### PR TITLE
Add basic support for `interface` declarations

### DIFF
--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -270,7 +270,7 @@ DIAGNOSTIC(39999, Error, expectedAGeneric, "expected a generic when using '<...>
 DIAGNOSTIC(39999, Error, genericArgumentInferenceFailed, "could not specialize generic for arguments of type $0")
 DIAGNOSTIC(39999, Note, genericSignatureTried, "see declaration of $0")
 
-DIAGNOSTIC(39999, Error, expectedATraitGot, "expected a trait, got '$0'")
+DIAGNOSTIC(39999, Error, expectedAnInterfaceGot, "expected an interface, got '$0'")
 
 DIAGNOSTIC(39999, Error, ambiguousReference, "amiguous reference to '$0'");
 

--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -239,22 +239,22 @@ __generic<T> __magic_type(HLSLLineStreamType) struct TriangleStream {};
 // Note(tfoley): Trying to systematically add all the HLSL builtins
 
 // A type that can be used as an operand for builtins
-__trait __BuiltinType {}
+interface __BuiltinType {}
 
 // A type that can be used for arithmetic operations
-__trait __BuiltinArithmeticType : __BuiltinType {}
+interface __BuiltinArithmeticType : __BuiltinType {}
 
 // A type that logically has a sign (positive/negative/zero)
-__trait __BuiltinSignedArithmeticType : __BuiltinArithmeticType {}
+interface __BuiltinSignedArithmeticType : __BuiltinArithmeticType {}
 
 // A type that can represent integers
-__trait __BuiltinIntegerType : __BuiltinArithmeticType {}
+interface __BuiltinIntegerType : __BuiltinArithmeticType {}
 
 // A type that can represent non-integers
-__trait __BuiltinRealType : __BuiltinArithmeticType {}
+interface __BuiltinRealType : __BuiltinArithmeticType {}
 
 // A type that uses a floating-point representation
-__trait __BuiltinFloatingPointType : __BuiltinRealType, __BuiltinSignedType {}
+interface __BuiltinFloatingPointType : __BuiltinRealType, __BuiltinSignedArithmeticType {}
 
 // Try to terminate the current draw or dispatch call (HLSL SM 4.0)
 __intrinsic void abort();
@@ -1088,32 +1088,35 @@ namespace Slang
             for (int tt = 0; tt < kBaseTypeCount; ++tt)
             {
                 EMIT_LINE_DIRECTIVE();
-                sb << "__builtin_type(" << int(kBaseTypes[tt].tag) << ") struct " << kBaseTypes[tt].name << "\n{\n";
+                sb << "__builtin_type(" << int(kBaseTypes[tt].tag) << ") struct " << kBaseTypes[tt].name;
 
-                // Declare trait conformances for this type
+                // Declare interface conformances for this type
 
-                sb << "__conforms __BuiltinType;\n";
+                sb << "\n    : __BuiltinType\n";
 
                 switch( kBaseTypes[tt].tag )
                 {
                 case BaseType::Float:
-                    sb << "__conforms __BuiltinFloatingPointType;\n";
-                    sb << "__conforms __BuiltinRealType;\n";
+                    sb << "\n    , __BuiltinFloatingPointType\n";
+                    sb << "\n    ,  __BuiltinRealType\n";
                     // fall through to:
                 case BaseType::Int:
-                    sb << "__conforms __BuiltinSignedArithmeticType;\n";
+                    sb << "\n    ,  __BuiltinSignedArithmeticType\n";
                     // fall through to:
                 case BaseType::UInt:
                 case BaseType::UInt64:
-                    sb << "__conforms __BuiltinArithmeticType;\n";
+                    sb << "\n    ,  __BuiltinArithmeticType\n";
                     // fall through to:
                 case BaseType::Bool:
-                    sb << "__conforms __BuiltinType;\n";
+                    sb << "\n    ,  __BuiltinType\n";
                     break;
 
                 default:
                     break;
                 }
+
+                sb << "\n{\n";
+
 
                 // Declare initializers to convert from various other types
                 for( int ss = 0; ss < kBaseTypeCount; ++ss )

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -1311,19 +1311,19 @@ namespace Slang
             return visitor->VisitDefaultStmt(this);
         }
 
-        // TraitDecl
+        // InterfaceDecl
 
-        RefPtr<SyntaxNode> TraitDecl::Accept(SyntaxVisitor * visitor)
+        RefPtr<SyntaxNode> InterfaceDecl::Accept(SyntaxVisitor * visitor)
         {
-            visitor->VisitTraitDecl(this);
+            visitor->visitInterfaceDecl(this);
             return this;
         }
 
-        // TraitConformanceDecl
+        // InheritanceDecl
 
-        RefPtr<SyntaxNode> TraitConformanceDecl::Accept(SyntaxVisitor * visitor)
+        RefPtr<SyntaxNode> InheritanceDecl::Accept(SyntaxVisitor * visitor)
         {
-            visitor->VisitTraitConformanceDecl(this);
+            visitor->visitInheritanceDecl(this);
             return this;
         }
 

--- a/tests/front-end/interface.slang
+++ b/tests/front-end/interface.slang
@@ -1,0 +1,65 @@
+//TEST:SIMPLE:
+
+// Confirm that basic `interface` syntax stuff type-checks.
+
+// The example here is adapted from examples in Matt Pharr's
+// chapter in GPU Gems: "An Introduction to Shader Interaces"
+
+struct LightSample
+{
+	float3 C; // radiance
+	float3 L; // direction	
+};
+
+interface Light
+{
+	LightSample illuminate(float3 P_world);
+}
+
+struct PointLight : Light
+{
+	float3 Plight_world;
+	float3 C;
+
+	LightSample illuminate(float3 P_world)
+	{
+		float3 delta = Plight_world - P_world;
+		float3 L = normalize(delta);
+		float distance = length(delta);
+
+		LightSample result;
+		result.L = L;
+		result.C = C * (1 / (distance*distance));
+		return result;
+	}	
+};
+
+// using the concrete type directly
+float3 A( float3 P_world, PointLight light )
+{
+	return light.illuminate(P_world).L;
+}
+
+// using the abstract interface type
+float3 B( float3 P_world, Light light )
+{
+	return light.illuminate(P_world).L;
+}
+
+//
+float3 Test(float3 P_world, PointLight pointLight, Light light)
+{
+	// dconcrete type expected, concrete type provided
+	float3 a = A(P_world, pointLight);
+
+	// abstract type expected, abstract type provided
+	float3 b = B(P_world, light);
+
+	// abstract type expected, concrete type provided
+	float3 c = B(P_world, pointLight);
+
+	// The remaining case (passing `Light` where `PointLight` is expected)
+	// should be an error, so we want a distinct test for that.
+
+	return a + b + c;
+}


### PR DESCRIPTION
- Add a test case for `interface` declarations and the exected implicit type conversion rules around them

- Rename exising "trait" declaration kind to "interface"
  - There was already basic syntax for `__trait` declarations, and a bunch of related machinery.
  - Not all of it worked as needed, but it was clearly a start at solving the problem

- Change `InterfaceConformanceDecl` to a more general `InheritanceDecl` that covers inheritance from any type expression (leave it to other code to validate the cases that should be allowed)

- Instead of keeping a raw `bases` array on interface/trait declarations, turn all inheritance clauses into `IheritanceDecl` members

- Add support for inheritance clause on `struct` types

- Remove the `__conforms` syntax only used in the stdlib, in favor of conentional `: Base` style syntax already in place for aggregate types

- Make sure that the parser pushes a new scope around he member declarations of an aggregate type, so that lookup in member functions will correctly find members of the enclosing type

- In `TryCoerceImpl`, allow a type that conforms to an interface to be implicitly conveted to the corresponding interface type.

This leaves out a lot of major functionality:

- There is no validation that a type provides all the members it is supposed to as part of fulfilling a claimed interface conformance

- The lookup process needs to deal with inherited members at some point.
  - We can avoid this for now if we don't allow inheritance for concrete types
  - When it comes time to handle it, it *might* be possible to implement by considering an `InheritanceDecl` to be, conceptually, a member of the inherited type, with a `__transparent` modifier

- The lookup rules member functions do *not* deal with a lot of stuff:
  - There is no `this` expression right now
  - The semantic checker does not rewrite `foo` to `this.foo`, so downstream stages aren't going to get things in a clean format
  - There is no handling of mutability currently
    - The right answer there is probably to make member functions on `struct` types non-mutating by default, and add a qualifier to opt in to mutability. I believe this is actually what the OOP syntax in HLSL did way back when.
  - There is no handling of `static` members, and thus no checking to make sure that non-static members aren't referenced in static functions

- None of this affects down-stream code generation right now, so it probably won't actually produce anything valid.
  - This is where we start needing a suitable IR to use for lowering, to manage the complexity.