### PR TITLE
Replace `DeclRef` approach

### DIFF
--- a/source/slang/lookup.h
+++ b/source/slang/lookup.h
@@ -19,8 +19,7 @@ LookupResult LookUp(String const& name, RefPtr<Scope> scope);
 
 // perform lookup within the context of a particular container declaration,
 // and do *not* look further up the chain
-LookupResult LookUpLocal(String const& name, ContainerDeclRef containerDeclRef);
-LookupResult LookUpLocal(String const& name, ContainerDecl* containerDecl);
+LookupResult LookUpLocal(String const& name, DeclRef<ContainerDecl> containerDeclRef);
 
 // TODO: this belongs somewhere else
 
@@ -28,11 +27,11 @@ class SemanticsVisitor;
 QualType getTypeForDeclRef(
     SemanticsVisitor*       sema,
     DiagnosticSink*         sink,
-    DeclRef                 declRef,
+    DeclRef<Decl>                 declRef,
     RefPtr<ExpressionType>* outTypeResult);
 
 QualType getTypeForDeclRef(
-    DeclRef                 declRef);
+    DeclRef<Decl>                 declRef);
 
 
 }

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -262,10 +262,10 @@ static bool findLayoutArg(
 
 template<typename T>
 static bool findLayoutArg(
-    DeclRef declRef,
+    DeclRef<Decl> declRef,
     int*    outVal)
 {
-    return findLayoutArg<T>(declRef.GetDecl(), outVal);
+    return findLayoutArg<T>(declRef.getDecl(), outVal);
 }
 
 //
@@ -437,7 +437,7 @@ static void collectGlobalScopeParameter(
     // Now create a variable layout that we can use
     RefPtr<VarLayout> varLayout = new VarLayout();
     varLayout->typeLayout = typeLayout;
-    varLayout->varDecl = DeclRef(varDecl.Ptr(), nullptr).As<VarDeclBaseRef>();
+    varLayout->varDecl = DeclRef<Decl>(varDecl.Ptr(), nullptr).As<VarDeclBase>();
 
     // This declaration may represent the same logical parameter
     // as a declaration that came from a different translation unit.
@@ -528,7 +528,7 @@ static void addExplicitParameterBindings_HLSL(
     // here is where we want to extract and apply them...
 
     // Look for HLSL `register` or `packoffset` semantics.
-    for (auto semantic : varDecl.GetDecl()->GetModifiersOfType<HLSLLayoutSemantic>())
+    for (auto semantic : varDecl.getDecl()->GetModifiersOfType<HLSLLayoutSemantic>())
     {
         // Need to extract the information encoded in the semantic
         LayoutSemanticInfo semanticInfo = ExtractLayoutSemanticInfo(context, semantic);
@@ -916,15 +916,15 @@ static void processEntryPointParameter(
     {
         auto declRef = declRefType->declRef;
 
-        if (auto structDeclRef = declRef.As<StructDeclRef>())
+        if (auto structDeclRef = declRef.As<StructSyntaxNode>())
         {
             // Need to recursively walk the fields of the structure now...
-            for( auto field : structDeclRef.GetFields() )
+            for( auto field : GetFields(structDeclRef) )
             {
                 processEntryPointParameterWithPossibleSemantic(
                     context,
-                    field.GetDecl(),
-                    field.GetType(),
+                    field.getDecl(),
+                    GetType(field),
                     state);
             }
         }
@@ -1223,7 +1223,7 @@ void GenerateParameterBindings(
 
         for( auto& varLayout : parameterInfo->varLayouts )
         {
-            globalScopeStructLayout->mapVarToLayout.Add(varLayout->varDecl.GetDecl(), varLayout);
+            globalScopeStructLayout->mapVarToLayout.Add(varLayout->varDecl.getDecl(), varLayout);
         }
     }
     globalScopeRules->EndStructLayout(&structLayoutInfo);

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -754,7 +754,7 @@ namespace Slang
                     if( lookupResult.isValid() && !lookupResult.isOverloaded() )
                     {
                         auto& item = lookupResult.item;
-                        auto decl = item.declRef.GetDecl();
+                        auto decl = item.declRef.getDecl();
 
                         if( auto modifierDecl = dynamic_cast<ModifierDecl*>(decl) )
                         {
@@ -1910,7 +1910,7 @@ namespace Slang
                 auto paramConstraint = new GenericTypeConstraintDecl();
                 parser->FillPosition(paramConstraint);
 
-                auto paramType = DeclRefType::Create(DeclRef(paramDecl, nullptr));
+                auto paramType = DeclRefType::Create(DeclRef<Decl>(paramDecl, nullptr));
 
                 auto paramTypeExpr = new SharedTypeExpr();
                 paramTypeExpr->Position = paramDecl->Position;
@@ -2365,7 +2365,7 @@ parser->ReadToken(TokenType::Comma);
         if(!lookupResult.isValid() || lookupResult.isOverloaded())
             return false;
 
-        auto decl = lookupResult.item.declRef.GetDecl();
+        auto decl = lookupResult.item.declRef.getDecl();
         if( auto typeDecl = dynamic_cast<AggTypeDecl*>(decl) )
         {
             return true;

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -135,7 +135,7 @@ SLANG_API SlangTypeKind spReflectionType_GetKind(SlangReflectionType* inType)
     else if( auto declRefType = type->As<DeclRefType>() )
     {
         auto declRef = declRefType->declRef;
-        if( auto structDeclRef = declRef.As<StructDeclRef>() )
+        if( auto structDeclRef = declRef.As<StructSyntaxNode>() )
         {
             return SLANG_TYPE_KIND_STRUCT;
         }
@@ -155,9 +155,9 @@ SLANG_API unsigned int spReflectionType_GetFieldCount(SlangReflectionType* inTyp
     if(auto declRefType = dynamic_cast<DeclRefType*>(type))
     {
         auto declRef = declRefType->declRef;
-        if( auto structDeclRef = declRef.As<StructDeclRef>())
+        if( auto structDeclRef = declRef.As<StructSyntaxNode>())
         {
-            return structDeclRef.GetFields().Count();
+            return GetFields(structDeclRef).Count();
         }
     }
 
@@ -174,10 +174,10 @@ SLANG_API SlangReflectionVariable* spReflectionType_GetFieldByIndex(SlangReflect
     if(auto declRefType = dynamic_cast<DeclRefType*>(type))
     {
         auto declRef = declRefType->declRef;
-        if( auto structDeclRef = declRef.As<StructDeclRef>())
+        if( auto structDeclRef = declRef.As<StructSyntaxNode>())
         {
-            auto fieldDeclRef = structDeclRef.GetFields().ToArray()[index];
-            return (SlangReflectionVariable*) fieldDeclRef.GetDecl();
+            auto fieldDeclRef = GetFields(structDeclRef).ToArray()[index];
+            return (SlangReflectionVariable*) fieldDeclRef.getDecl();
         }
     }
 
@@ -573,7 +573,7 @@ SLANG_API SlangReflectionVariable* spReflectionVariableLayout_GetVariable(SlangR
     auto varLayout = convert(inVarLayout);
     if(!varLayout) return nullptr;
 
-    return convert(varLayout->varDecl.GetDecl());
+    return convert(varLayout->varDecl.getDecl());
 }
 
 SLANG_API SlangReflectionTypeLayout* spReflectionVariableLayout_GetTypeLayout(SlangReflectionVariableLayout* inVarLayout)

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -1009,7 +1009,7 @@ SimpleLayoutInfo GetLayoutImpl(
     {
         auto declRef = declRefType->declRef;
 
-        if (auto structDeclRef = declRef.As<StructDeclRef>())
+        if (auto structDeclRef = declRef.As<StructSyntaxNode>())
         {
             RefPtr<StructTypeLayout> typeLayout;
             if (outTypeLayout)
@@ -1022,11 +1022,11 @@ SimpleLayoutInfo GetLayoutImpl(
 
             UniformLayoutInfo info = rules->BeginStructLayout();
 
-            for (auto field : structDeclRef.GetFields())
+            for (auto field : GetFields(structDeclRef))
             {
                 RefPtr<TypeLayout> fieldTypeLayout;
                 UniformLayoutInfo fieldInfo = GetLayoutImpl(
-                    field.GetType().Ptr(),
+                    GetType(field).Ptr(),
                     rules,
                     outTypeLayout ? &fieldTypeLayout : nullptr).getUniformLayout();
 
@@ -1053,7 +1053,7 @@ SimpleLayoutInfo GetLayoutImpl(
                     fieldLayout->varDecl = field;
                     fieldLayout->typeLayout = fieldTypeLayout;
                     typeLayout->fields.Add(fieldLayout);
-                    typeLayout->mapVarToLayout.Add(field.GetDecl(), fieldLayout);
+                    typeLayout->mapVarToLayout.Add(field.getDecl(), fieldLayout);
 
                     // Set up uniform offset information, if there is any uniform data in the field
                     if( fieldTypeLayout->FindResourceInfo(LayoutResourceKind::Uniform) )

--- a/source/slang/type-layout.h
+++ b/source/slang/type-layout.h
@@ -219,8 +219,8 @@ class VarLayout : public RefObject
 {
 public:
     // The variable we are laying out
-    VarDeclBaseRef          varDecl;
-    VarDeclBase* getVariable() { return varDecl.GetDecl(); }
+    DeclRef<VarDeclBase>          varDecl;
+    VarDeclBase* getVariable() { return varDecl.getDecl(); }
 
     String const& getName() { return getVariable()->getName(); }
 


### PR DESCRIPTION
For context: a `DeclRef` is supposed to capture both a pointer to a particualr declaration, and also any information needed to specialize that declaration for a context (e.g., generic parameter substitutions).

The existing approach had a hiearchy of specialized decl-ref types that mirrored the AST hierarchy, but that led to a lot of boilerplate where you had to recapitulate the exact same hierarchy.

The new appraoch basically treats `DeclRef<T>` as a sort of "smart pointer" in that it wraps a pointer to a `T` (the declaration), plus a side field for the specialization info, and then allows it to be cast as needed to other types (where the pointer cast would be allowed), while carrying along the side info.

To enable this, all the things that used to be member functions of declaration-reference types are now free functions that take a `DeclRef<T>` for some specific `T` as a parameter.