### PR TITLE
Make sure that semantic checks always apply to Slang files

### DIFF
--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -47,6 +47,7 @@ namespace Slang
         ProgramSyntaxNode * program = nullptr;
         FunctionSyntaxNode * function = nullptr;
         CompileOptions const* options = nullptr;
+        TranslationUnitOptions const* translationUnitOptions = nullptr;
         CompileRequest* request = nullptr;
 
         // lexical outer statements
@@ -55,14 +56,17 @@ namespace Slang
         SemanticsVisitor(
             DiagnosticSink * pErr,
             CompileOptions const& options,
+            TranslationUnitOptions const& translationUnitOptions,
             CompileRequest* request)
             : SyntaxVisitor(pErr)
             , options(&options)
+            , translationUnitOptions(&translationUnitOptions)
             , request(request)
         {
         }
 
         CompileOptions const& getOptions() { return *options; }
+        TranslationUnitOptions const& getTranslationUnitOptions() { return *translationUnitOptions; }
 
     public:
         // Translate Types
@@ -965,7 +969,7 @@ namespace Slang
             // expressions without a type, and we need to ignore them.
             if( !fromExpr->Type.type )
             {
-                if(getOptions().flags & SLANG_COMPILE_FLAG_NO_CHECKING )
+                if(getTranslationUnitOptions().compileFlags & SLANG_COMPILE_FLAG_NO_CHECKING )
                     return fromExpr;
             }
 
@@ -977,7 +981,7 @@ namespace Slang
                 fromExpr.Ptr(),
                 nullptr))
             {
-                if(!(getOptions().flags & SLANG_COMPILE_FLAG_NO_CHECKING))
+                if(!(getTranslationUnitOptions().compileFlags & SLANG_COMPILE_FLAG_NO_CHECKING))
                 {
                     getSink()->diagnose(fromExpr->Position, Diagnostics::typeMismatch, toType, fromExpr->Type);
                 }
@@ -4963,11 +4967,12 @@ namespace Slang
     };
 
     SyntaxVisitor* CreateSemanticsVisitor(
-        DiagnosticSink*         err,
-        CompileOptions const&   options,
-        CompileRequest*         request)
+        DiagnosticSink*                 err,
+        CompileOptions const&           options,
+        TranslationUnitOptions const&   translationUnitOptions,
+        CompileRequest*                 request)
     {
-        return new SemanticsVisitor(err, options, request);
+        return new SemanticsVisitor(err, options, translationUnitOptions, request);
     }
 
     //

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -89,6 +89,9 @@ namespace Slang
         // Preprocessor definitions to use for this translation unit only
         // (whereas the ones on `CompileOptions` will be shared)
         Dictionary<String, String> preprocessorDefinitions;
+
+        // Compile flags for this translation unit
+        SlangCompileFlags compileFlags = 0;
     };
 
 
@@ -132,8 +135,8 @@ namespace Slang
         // Should we just pass the input to another compiler?
         PassThroughMode passThrough = PassThroughMode::None;
 
-        // Flags supplied through the API
-        SlangCompileFlags flags = 0;
+        // Compile flags to be shared by all translation units
+        SlangCompileFlags compileFlags = 0;
     };
 
     // This is the representation of a given translation unit

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 
+#include "compiler.h"
 #include "lookup.h"
 
 namespace Slang
@@ -31,7 +32,9 @@ namespace Slang
     class Parser
     {
     public:
-        CompileOptions& options;
+        CompileOptions const&           options;
+        TranslationUnitOptions const&   translationUnitOptions;
+
         int anonymousCounter = 0;
 
         RefPtr<Scope> outerScope;
@@ -64,12 +67,14 @@ namespace Slang
             currentScope = currentScope->parent;
         }
         Parser(
-            CompileOptions& options,
+            CompileOptions const& options,
+            TranslationUnitOptions const& translationUnitOptions,
             TokenSpan const& _tokens,
             DiagnosticSink * sink,
             String _fileName,
             RefPtr<Scope> const& outerScope)
             : options(options)
+            , translationUnitOptions(translationUnitOptions)
             , tokenReader(_tokens)
             , sink(sink)
             , fileName(_fileName)
@@ -2495,7 +2500,7 @@ parser->ReadToken(TokenType::Comma);
 
     RefPtr<StatementSyntaxNode> Parser::ParseBlockStatement()
     {
-        if( options.flags & SLANG_COMPILE_FLAG_NO_CHECKING )
+        if( translationUnitOptions.compileFlags & SLANG_COMPILE_FLAG_NO_CHECKING )
         {
             // We have been asked to parse the input, but not attempt to understand it.
 
@@ -3150,16 +3155,17 @@ parser->ReadToken(TokenType::Comma);
         return rs;
     }
 
-            // Parse a source file into an existing translation unit
+    // Parse a source file into an existing translation unit
     void parseSourceFile(
-        ProgramSyntaxNode*  translationUnitSyntax,
-        CompileOptions&     options,
-        TokenSpan const&    tokens,
-        DiagnosticSink*     sink,
-        String const&       fileName,
-        RefPtr<Scope> const&outerScope)
+        ProgramSyntaxNode*              translationUnitSyntax,
+        CompileOptions const&           options,
+        TranslationUnitOptions const&   translationUnitOptions,
+        TokenSpan const&                tokens,
+        DiagnosticSink*                 sink,
+        String const&                   fileName,
+        RefPtr<Scope> const&            outerScope)
     {
-        Parser parser(options, tokens, sink, fileName, outerScope);
+        Parser parser(options, translationUnitOptions, tokens, sink, fileName, outerScope);
         return parser.parseSourceFile(translationUnitSyntax);
     }
 }

--- a/source/slang/parser.h
+++ b/source/slang/parser.h
@@ -9,12 +9,14 @@ namespace Slang
 {
     // Parse a source file into an existing translation unit
     void parseSourceFile(
-        ProgramSyntaxNode*  translationUnitSyntax,
-        CompileOptions&     options,
-        TokenSpan const&    tokens,
-        DiagnosticSink*     sink,
-        String const&       fileName,
-        RefPtr<Scope> const&outerScope);
+        ProgramSyntaxNode*              translationUnitSyntax,
+        CompileOptions const&           options,
+        TranslationUnitOptions const&   translationUnitOptions,
+        TokenSpan const&                tokens,
+        DiagnosticSink*                 sink,
+        String const&                   fileName,
+        RefPtr<Scope> const&            outerScope);
+;
 }
 
 #endif

--- a/source/slang/profile.h
+++ b/source/slang/profile.h
@@ -13,9 +13,6 @@ namespace Slang
         Slang = SLANG_SOURCE_LANGUAGE_SLANG,
         HLSL = SLANG_SOURCE_LANGUAGE_HLSL,
         GLSL = SLANG_SOURCE_LANGUAGE_GLSL,
-
-        // A separate PACKAGE of Slang code that has been imported
-        ImportedSlangCode,
     };
 
     // TODO(tfoley): This should merge with the above...

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -164,6 +164,7 @@
     <Natvis Include="slang.natvis" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\slang.h" />
     <ClInclude Include="compiled-program.h" />
     <ClInclude Include="compiler.h" />
     <ClInclude Include="diagnostic-defs.h" />

--- a/source/slang/slang.vcxproj.filters
+++ b/source/slang/slang.vcxproj.filters
@@ -25,6 +25,7 @@
     <ClInclude Include="token.h" />
     <ClInclude Include="token-defs.h" />
     <ClInclude Include="type-layout.h" />
+    <ClInclude Include="..\..\slang.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="check.cpp" />

--- a/source/slang/syntax-visitors.h
+++ b/source/slang/syntax-visitors.h
@@ -12,11 +12,13 @@ namespace Slang
     class ShaderCompiler;
     class ShaderLinkInfo;
     class ShaderSymbol;
+    class TranslationUnitOptions;
 
     SyntaxVisitor* CreateSemanticsVisitor(
-        DiagnosticSink*         err,
-        CompileOptions const&   options,
-        CompileRequest*         request);
+        DiagnosticSink*                 err,
+        CompileOptions const&           options,
+        TranslationUnitOptions const&   translationUnitOptions,
+        CompileRequest*                 request);
 
     // Look for a module that matches the given name:
     // either one we've loaded already, or one we


### PR DESCRIPTION
That is, even if the user specified the `-no-checking` option (or the equivalent via API), we still want/need to apply full semantic checks to Slang code, so that cross-compilation will be possible.