### PR TITLE
Fix types for `InputPatch` and `OutputPatch`

### DIFF
--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -78,12 +78,12 @@ __generic<T> __magic_type(HLSLConsumeStructuredBufferType) struct ConsumeStructu
         out uint stride);
 };
 
-__generic<T> __magic_type(HLSLInputPatchType) struct InputPatch
+__generic<T, let N : int> __magic_type(HLSLInputPatchType) struct InputPatch
 {
     __intrinsic __subscript(uint index) -> T;
 };
 
-__generic<T> __magic_type(HLSLOutputPatchType) struct OutputPatch
+__generic<T, let N : int> __magic_type(HLSLOutputPatchType) struct OutputPatch
 {
     __intrinsic __subscript(uint index) -> T { set; }
 };

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -525,6 +525,22 @@ namespace Slang
                 return textureType;
             }
 
+            // TODO: eventually everything should follow this pattern,
+            // and we can drive the dispatch with a table instead
+            // of this ridiculously slow `if` cascade.
+
+        #define CASE(n,T)													\
+            else if(magicMod->name == #n) {									\
+                auto type = new T();										\
+                type->declRef = declRef;									\
+                return type;												\
+            }
+
+            CASE(HLSLInputPatchType, HLSLInputPatchType)
+            CASE(HLSLOutputPatchType, HLSLOutputPatchType)
+
+        #undef CASE
+
             #define CASE(n,T)													\
                 else if(magicMod->name == #n) {									\
                     assert(subst && subst->args.Count() == 1);					\
@@ -550,8 +566,6 @@ namespace Slang
             CASE(HLSLRWStructuredBufferType, HLSLRWStructuredBufferType)
             CASE(HLSLAppendStructuredBufferType, HLSLAppendStructuredBufferType)
             CASE(HLSLConsumeStructuredBufferType, HLSLConsumeStructuredBufferType)
-            CASE(HLSLInputPatchType, HLSLInputPatchType)
-            CASE(HLSLOutputPatchType, HLSLOutputPatchType)
 
             CASE(HLSLPointStreamType, HLSLPointStreamType)
             CASE(HLSLLineStreamType, HLSLPointStreamType)
@@ -1470,4 +1484,17 @@ namespace Slang
         return IntrinsicOp::Unknown;
     }
 
+    //
+
+    // HLSLPatchType
+
+    ExpressionType* HLSLPatchType::getElementType()
+    {
+        return this->declRef.substitutions->args[0].As<ExpressionType>().Ptr();
+    }
+
+    IntVal* HLSLPatchType::getElementCount()
+    {
+        return this->declRef.substitutions->args[1].As<IntVal>().Ptr();
+    }
 }

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -1044,8 +1044,15 @@ namespace Slang
     class HLSLAppendStructuredBufferType : public BuiltinGenericType {};
     class HLSLConsumeStructuredBufferType : public BuiltinGenericType {};
 
-    class HLSLInputPatchType : public BuiltinGenericType {};
-    class HLSLOutputPatchType : public BuiltinGenericType {};
+    class HLSLPatchType : public DeclRefType
+    {
+    public:
+        ExpressionType* getElementType();
+        IntVal*         getElementCount();
+    };
+
+    class HLSLInputPatchType : public HLSLPatchType {};
+    class HLSLOutputPatchType : public HLSLPatchType {};
 
     // HLSL geometry shader output stream types
 

--- a/tests/bugs/gh-34.hlsl
+++ b/tests/bugs/gh-34.hlsl
@@ -1,0 +1,16 @@
+//TEST:COMPARE_HLSL: -profile gs_5_0 -target dxbc-assembly -no-checking
+
+struct VS_OUT { float3 p : POSITION; };
+
+[maxvertexcount(3)]
+void main(InputPatch<VS_OUT, 3> input, inout TriangleStream<VS_OUT> outStream)
+{
+    VS_OUT output;
+    for (uint i = 0; i < 3; i += 1)
+    {
+        output = input[i];
+        outStream.Append(output);
+    }
+
+    outStream.RestartStrip();
+}


### PR DESCRIPTION
Fixes #34.

I'd declared these as if they were `InputPatch<T>`, but they are really `InputPatch<T,N>`.
This change fixes the declarations, and makes these types no longer inherit from the contrived `BuiltinGenericType`.
Instead they are more-or-less ordinary `DeclRefType`s using the same approach that `MatrixExpressionType` uses.