### PR TITLE
Include imported code when generating reflection data

### DIFF
--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -211,7 +211,8 @@ namespace Slang
         RefPtr<ProgramLayout> layout;
 
         // Modules that have been dynamically loaded via `import`
-        Dictionary<String, RefPtr<ProgramSyntaxNode>> loadedModules;
+        Dictionary<String, RefPtr<ProgramSyntaxNode>> loadedModulesMap;
+        List<RefPtr<ProgramSyntaxNode> > loadedModulesList;
 
 
         CompileRequest(Session* session)

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -419,7 +419,8 @@ RefPtr<ProgramSyntaxNode> CompileRequest::loadModule(
 
     RefPtr<ProgramSyntaxNode> moduleDecl = translationUnit->SyntaxNode;
 
-    loadedModules.Add(name, moduleDecl);
+    loadedModulesMap.Add(name, moduleDecl);
+    loadedModulesList.Add(moduleDecl);
 
     return moduleDecl;
 
@@ -434,7 +435,7 @@ String CompileRequest::autoImportModule(
     String name = path;
 
     // Have we already loaded a module matching this name?
-    if (loadedModules.TryGetValue(name))
+    if (loadedModulesMap.TryGetValue(name))
         return name;
 
     loadModule(name, path, source, loc);
@@ -449,7 +450,7 @@ RefPtr<ProgramSyntaxNode> CompileRequest::findOrImportModule(
     // Have we already loaded a module matching this name?
     // If so, return it.
     RefPtr<ProgramSyntaxNode> moduleDecl;
-    if (loadedModules.TryGetValue(name, moduleDecl))
+    if (loadedModulesMap.TryGetValue(name, moduleDecl))
         return moduleDecl;
 
     // Derive a file name for the module, by taking the given
@@ -488,7 +489,7 @@ RefPtr<ProgramSyntaxNode> CompileRequest::findOrImportModule(
         {
             this->mSink.diagnose(loc, Diagnostics::cannotFindFile, fileName);
 
-            loadedModules[name] = nullptr;
+            loadedModulesMap[name] = nullptr;
             return nullptr;
         }
         break;

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -632,9 +632,20 @@ createParameterBlockTypeLayout(
     RefPtr<TypeLayout>          elementTypeLayout,
     LayoutRulesImpl*            rules)
 {
-    auto info = getParameterBlockLayoutInfo(
-        parameterBlockType,
-        rules);
+    SimpleLayoutInfo info;
+    if (parameterBlockType)
+    {
+        info = getParameterBlockLayoutInfo(
+            parameterBlockType,
+            rules);
+    }
+    else
+    {
+        // If there is no concrete type, then it seems like we are
+        // being asked to compute layout for the global scope
+        info = rules->GetObjectLayout(ShaderParameterKind::ConstantBuffer);
+    }
+ 
 
     auto typeLayout = new ParameterBlockTypeLayout();
 

--- a/tests/reflection/reflect-imported-code.hlsl
+++ b/tests/reflection/reflect-imported-code.hlsl
@@ -1,0 +1,21 @@
+//TEST:SIMPLE:-profile ps_4_0  -target reflection-json
+
+// Confirm that shader parameters in imported modules get reflected properly.
+
+__import reflect_imported_code;
+
+Texture2D 		t;
+SamplerState 	s;
+
+cbuffer C
+{
+	float c;
+}
+
+float4 main() : SV_Target
+{
+	return use(t,s_i)
+	     + use(c)
+	     + use(t_i, s)
+	     + use(c_i);
+}

--- a/tests/reflection/reflect-imported-code.slang
+++ b/tests/reflection/reflect-imported-code.slang
@@ -1,0 +1,14 @@
+//TEST_IGNORE_FILE:
+
+// Imported code used by `reflect-imported-code.hlsl`
+
+float4 use(float4 val) { return val; };
+float4 use(Texture2D t, SamplerState s) { return t.Sample(s, 0.0); }
+
+Texture2D 		t_i;
+SamplerState 	s_i;
+
+cbuffer C_i
+{
+	float c_i;
+}


### PR DESCRIPTION
- The basic idea is simple: be sure to enumerate code in `__import`ed modules when generating reflection info

- Note that we don't currently allow an entry point to appear in an imported module, so we only consider globlal-scope parameters

- Although there isn't currently a real implementation of namespacing, I went ahead and ensured that parameters in imported modules are treated as distinct from parameters in the user's code, even if they have the same name.