### PR TITLE
Fix parsing of string literals.

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -765,6 +765,34 @@ static void emitCallExpr(
     emitSimpleCallExpr(context, callExpr, outerPrec);
 }
 
+static void emitStringLiteral(
+    EmitContext*    context,
+    String const&   value)
+{
+    emit(context, "\"");
+    for (auto c : value)
+    {
+        // TODO: This needs a more complete implementation,
+        // especially if we want to support Unicode.
+
+        char buffer[] = { c, 0 };
+        switch (c)
+        {
+        default:
+            emit(context, buffer);
+            break;
+
+        case '\"': emit(context, "\\\"");
+        case '\'': emit(context, "\\\'");
+        case '\\': emit(context, "\\\\");
+        case '\n': emit(context, "\\n");
+        case '\r': emit(context, "\\r");
+        case '\t': emit(context, "\\t");
+        }
+    }
+    emit(context, "\"");
+}
+
 static void EmitExprWithPrecedence(EmitContext* context, RefPtr<ExpressionSyntaxNode> expr, int outerPrec)
 {
     bool needClose = false;
@@ -873,6 +901,9 @@ static void EmitExprWithPrecedence(EmitContext* context, RefPtr<ExpressionSyntax
             break;
         case ConstantExpressionSyntaxNode::ConstantType::Bool:
             Emit(context, litExpr->IntValue ? "true" : "false");
+            break;
+        case ConstantExpressionSyntaxNode::ConstantType::String:
+            emitStringLiteral(context, litExpr->stringValue);
             break;
         default:
             assert(!"unreachable");

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -1917,7 +1917,10 @@ namespace Slang
     public:
         enum class ConstantType
         {
-            Int, Bool, Float
+            Int,
+            Bool,
+            Float,
+            String,
         };
         ConstantType ConstType;
         union
@@ -1925,6 +1928,7 @@ namespace Slang
             int IntValue;
             FloatingPointLiteralValue FloatValue;
         };
+        String stringValue;
         virtual RefPtr<SyntaxNode> Accept(SyntaxVisitor * visitor) override;
     };
 

--- a/tests/hlsl/dxsdk/SimpleBezier11/SimpleBezier11.hlsl
+++ b/tests/hlsl/dxsdk/SimpleBezier11/SimpleBezier11.hlsl
@@ -1,4 +1,3 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry BezierVS -profile hs_5_0 -entry BezierHS -profile ds_5_0 -entry BezierDS -profile ps_4_0 -entry BezierPS -entry SolidColorPS
 //--------------------------------------------------------------------------------------
 // File: SimpleBezier11.hlsl


### PR DESCRIPTION
String literals can be used as part of attributes, but we lacked an actual AST representation for them.
This change adds basic parsing for string literals, as well as emit logic for them.

I also included a fix for parsing of chained right-associative operators.

To test these fixes, I've re-enabled one of the HLSL tests I disabled a while back. It would be good to go through and see how many of those we can re-enable now.