### PR TITLE
Allow for re-export of an `import` declaration

### DIFF
--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -619,6 +619,9 @@ namespace Slang
             CASE(__prefix,   PrefixModifier);
             CASE(__postfix,  PostfixModifier);
 
+            // Modifier to apply to `import` that should be re-exported
+            CASE(__exported,  ExportedModifier);
+
             #undef CASE
 
             else if (AdvanceIf(parser, "__intrinsic_op"))

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -57,6 +57,7 @@ namespace Slang
     SIMPLE_MODIFIER(FromStdLib);
     SIMPLE_MODIFIER(Prefix);
     SIMPLE_MODIFIER(Postfix);
+    SIMPLE_MODIFIER(Exported);
 
 #undef SIMPLE_MODIFIER
 

--- a/tests/front-end/import-exported-a.slang
+++ b/tests/front-end/import-exported-a.slang
@@ -1,0 +1,5 @@
+//TEST_IGNORE_FILE:
+
+// This file imports other code, and re-exports it to clients of this module.
+
+__exported __import import_exported_b;

--- a/tests/front-end/import-exported-b.slang
+++ b/tests/front-end/import-exported-b.slang
@@ -1,0 +1,5 @@
+//TEST_IGNORE_FILE:
+
+// This file defines the code that will be (transitively) imported into `import-exported.slang`
+
+float foo(float x) { return x; }

--- a/tests/front-end/import-exported.slang
+++ b/tests/front-end/import-exported.slang
@@ -1,0 +1,8 @@
+//TEST:SIMPLE:
+
+// Confirming that we can use a re-exported function
+
+// `a` imports `b` (which defines `foo`) and re-exports it
+__import import_exported_a;
+
+float bar(float x) { return foo(x); }


### PR DESCRIPTION
If module `A.slang` contains `__exported __import B;` then any declarations from `B.slang` will be visible to any client code that does `__import A;`.
This allows a user to make a single "umbrella" file that encompases a bunch of code files.

Note that this really only affects scoping during Slang compilation/checking; at code generation time everything always gets emitted as raw HLSL/GLSL so that names will be visible whether we want them to be or not.