### PR TITLE
Allow "dotted" import paths

### DIFF
--- a/tests/front-end/import-subdir.slang
+++ b/tests/front-end/import-subdir.slang
@@ -1,0 +1,7 @@
+//TEST:SIMPLE:
+
+// Confirming that we can use "dot notation" to import via a subdirectory
+
+__import subdir.import_subdir_a;
+
+float bar(float x) { return foo(x); }

--- a/tests/front-end/subdir/import-subdir-a.slang
+++ b/tests/front-end/subdir/import-subdir-a.slang
@@ -1,0 +1,5 @@
+//TEST_IGNORE_FILE:
+
+// This is the imported code.
+
+float foo(float x) { return x; }


### PR DESCRIPTION
The code:

    __import foo.bar;

will try to import from a file matching "foo/bar.slang".

I also went ahead and allowed a raw string literal in and import:

    __import "foo/bar";

(In the latter case, an explicit `/` must be used instead of `.`)