### PR TITLE
Store integer literals at high precision in AST

### DIFF
--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -1155,9 +1155,9 @@ namespace Slang
                     hlslNumThreadsAttribute->Position   = hlslUncheckedAttribute->Position;
                     hlslNumThreadsAttribute->nameToken  = hlslUncheckedAttribute->nameToken;
                     hlslNumThreadsAttribute->args       = hlslUncheckedAttribute->args;
-                    hlslNumThreadsAttribute->x          = xVal->value;
-                    hlslNumThreadsAttribute->y          = yVal->value;
-                    hlslNumThreadsAttribute->z          = zVal->value;
+                    hlslNumThreadsAttribute->x          = (int32_t) xVal->value;
+                    hlslNumThreadsAttribute->y          = (int32_t) yVal->value;
+                    hlslNumThreadsAttribute->z          = (int32_t) zVal->value;
 
                     return hlslNumThreadsAttribute;
                 }
@@ -1683,7 +1683,7 @@ namespace Slang
             return stmt;
         }
 
-        int GetMinBound(RefPtr<IntVal> val)
+        IntegerLiteralValue GetMinBound(RefPtr<IntVal> val)
         {
             if (auto constantVal = val.As<ConstantIntVal>())
                 return constantVal->value;
@@ -1913,7 +1913,7 @@ namespace Slang
         IntVal* GetIntVal(ConstantExpressionSyntaxNode* expr)
         {
             // TODO(tfoley): don't keep allocating here!
-            return new ConstantIntVal(expr->IntValue);
+            return new ConstantIntVal(expr->integerValue);
         }
 
         RefPtr<IntVal> TryConstantFoldExpr(
@@ -1939,7 +1939,7 @@ namespace Slang
 
             // Before checking the operation name, let's look at the arguments
             RefPtr<IntVal> argVals[kMaxArgs];
-            int constArgVals[kMaxArgs];
+            IntegerLiteralValue constArgVals[kMaxArgs];
             int argCount = 0;
             bool allConst = true;
             for (auto argExpr : invokeExpr->Arguments)
@@ -1977,7 +1977,7 @@ namespace Slang
             }
 
             // At this point, all the operands had simple integer values, so we are golden.
-            int resultValue = 0;
+            IntegerLiteralValue resultValue = 0;
             auto opName = funcDeclRef.GetName();
 
             // handle binary operators
@@ -4674,15 +4674,15 @@ namespace Slang
         }
 
         RefPtr<ExpressionSyntaxNode> CheckSwizzleExpr(
-            MemberExpressionSyntaxNode*	memberRefExpr,
-            RefPtr<ExpressionType>		baseElementType,
-            int							baseElementCount)
+            MemberExpressionSyntaxNode* memberRefExpr,
+            RefPtr<ExpressionType>      baseElementType,
+            IntegerLiteralValue         baseElementCount)
         {
             RefPtr<SwizzleExpr> swizExpr = new SwizzleExpr();
             swizExpr->Position = memberRefExpr->Position;
             swizExpr->base = memberRefExpr->BaseExpression;
 
-            int limitElement = baseElementCount;
+            IntegerLiteralValue limitElement = baseElementCount;
 
             int elementIndices[4];
             int elementCount = 0;

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -197,6 +197,14 @@ static void emitName(EmitContext* context, String const& name)
     emitName(context, name, CodePosition());
 }
 
+static void Emit(EmitContext* context, IntegerLiteralValue value)
+{
+    char buffer[32];
+    sprintf(buffer, "%lld", value);
+    Emit(context, buffer);
+}
+
+
 static void Emit(EmitContext* context, UInt value)
 {
     char buffer[32];
@@ -923,7 +931,7 @@ static void EmitExprWithPrecedence(EmitContext* context, RefPtr<ExpressionSyntax
             {
                 assert(!"unimplemented");
             }
-            Emit(context, litExpr->IntValue);
+            Emit(context, litExpr->integerValue);
             Emit(context, suffix);
             break;
 
@@ -945,12 +953,12 @@ static void EmitExprWithPrecedence(EmitContext* context, RefPtr<ExpressionSyntax
             {
                 assert(!"unimplemented");
             }
-            Emit(context, litExpr->FloatValue);
+            Emit(context, litExpr->floatingPointValue);
             Emit(context, suffix);
             break;
 
         case ConstantExpressionSyntaxNode::ConstantType::Bool:
-            Emit(context, litExpr->IntValue ? "true" : "false");
+            Emit(context, litExpr->integerValue ? "true" : "false");
             break;
         case ConstantExpressionSyntaxNode::ConstantType::String:
             emitStringLiteral(context, litExpr->stringValue);

--- a/source/slang/lexer.h
+++ b/source/slang/lexer.h
@@ -92,7 +92,7 @@ namespace Slang
     String getStringLiteralTokenValue(Token const& token);
     String getFileNameTokenValue(Token const& token);
 
-    typedef unsigned long long IntegerLiteralValue;
+    typedef long long IntegerLiteralValue;
     typedef double FloatingPointLiteralValue;
 
     IntegerLiteralValue getIntegerLiteralValue(Token const& token, String* outSuffix = 0);

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -895,7 +895,7 @@ static void processEntryPointParameter(
     else if( auto matrixType = type->As<MatrixExpressionType>() )
     {
         auto rowCount = GetIntVal(matrixType->getRowCount());
-        processSimpleEntryPointParameter(context, basicType, state, rowCount);
+        processSimpleEntryPointParameter(context, basicType, state, (int) rowCount);
     }
     else if( auto arrayType = type->As<ArrayExpressionType>() )
     {

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -3276,7 +3276,7 @@ namespace Slang
                 }
 
                 constExpr->ConstType = ConstantExpressionSyntaxNode::ConstantType::Int;
-                constExpr->IntValue = value;
+                constExpr->integerValue = value;
                 constExpr->Type = suffixType;
 
                 return constExpr;
@@ -3345,7 +3345,7 @@ namespace Slang
                 }
 
                 constExpr->ConstType = ConstantExpressionSyntaxNode::ConstantType::Float;
-                constExpr->FloatValue = value;
+                constExpr->floatingPointValue = value;
                 constExpr->Type = suffixType;
 
                 return constExpr;
@@ -3391,7 +3391,7 @@ namespace Slang
                     constExpr->token = token;
                     parser->FillPosition(constExpr.Ptr());
                     constExpr->ConstType = ConstantExpressionSyntaxNode::ConstantType::Bool;
-                    constExpr->IntValue = token.Content == "true" ? 1 : 0;
+                    constExpr->integerValue = token.Content == "true" ? 1 : 0;
 
                     return constExpr;
                 }

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -233,7 +233,7 @@ SLANG_API unsigned int spReflectionType_GetRowCount(SlangReflectionType* inType)
 
     if(auto matrixType = dynamic_cast<MatrixExpressionType*>(type))
     {
-        return GetIntVal(matrixType->getRowCount());
+        return (unsigned int) GetIntVal(matrixType->getRowCount());
     }
     else if(auto vectorType = dynamic_cast<VectorExpressionType*>(type))
     {
@@ -254,11 +254,11 @@ SLANG_API unsigned int spReflectionType_GetColumnCount(SlangReflectionType* inTy
 
     if(auto matrixType = dynamic_cast<MatrixExpressionType*>(type))
     {
-        return GetIntVal(matrixType->getColumnCount());
+        return (unsigned int) GetIntVal(matrixType->getColumnCount());
     }
     else if(auto vectorType = dynamic_cast<VectorExpressionType*>(type))
     {
-        return GetIntVal(vectorType->elementCount);
+        return (unsigned int) GetIntVal(vectorType->elementCount);
     }
     else if( auto basicType = dynamic_cast<BasicExpressionType*>(type) )
     {

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -1268,7 +1268,7 @@ namespace Slang
 
     // IntVal
 
-    int GetIntVal(RefPtr<IntVal> val)
+    IntegerLiteralValue GetIntVal(RefPtr<IntVal> val)
     {
         if (auto constantVal = val.As<ConstantIntVal>())
         {
@@ -1294,7 +1294,7 @@ namespace Slang
 
     int ConstantIntVal::GetHashCode()
     {
-        return value;
+        return (int) value;
     }
 
     // SwitchStmt

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -437,15 +437,15 @@ namespace Slang
 
     // Try to extract a simple integer value from an `IntVal`.
     // This fill assert-fail if the object doesn't represent a literal value.
-    int GetIntVal(RefPtr<IntVal> val);
+    IntegerLiteralValue GetIntVal(RefPtr<IntVal> val);
 
     // Trivial case of a value that is just a constant integer
     class ConstantIntVal : public IntVal
     {
     public:
-        int value;
+        IntegerLiteralValue value;
 
-        ConstantIntVal(int value)
+        ConstantIntVal(IntegerLiteralValue value)
             : value(value)
         {}
 
@@ -1188,7 +1188,7 @@ namespace Slang
     {
         auto constantVal = vecType->elementCount.As<ConstantIntVal>();
         if (constantVal)
-            return constantVal->value;
+            return (int) constantVal->value;
         // TODO: what to do in this case?
         return 0;
     }
@@ -1913,8 +1913,6 @@ namespace Slang
         virtual RefPtr<SyntaxNode> Accept(SyntaxVisitor * visitor) override;
     };
 
-    typedef double FloatingPointLiteralValue;
-
     class ConstantExpressionSyntaxNode : public ExpressionSyntaxNode
     {
     public:
@@ -1930,8 +1928,8 @@ namespace Slang
         ConstantType ConstType;
         union
         {
-            int IntValue;
-            FloatingPointLiteralValue FloatValue;
+            IntegerLiteralValue         integerValue;
+            FloatingPointLiteralValue   floatingPointValue;
         };
         String stringValue;
         virtual RefPtr<SyntaxNode> Accept(SyntaxVisitor * visitor) override;

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -544,7 +544,7 @@ static int GetElementCount(RefPtr<IntVal> val)
 {
     if (auto constantVal = val.As<ConstantIntVal>())
     {
-        return constantVal->value;
+        return (int) constantVal->value;
     }
     else if( auto varRefVal = val.As<GenericParamIntVal>() )
     {


### PR DESCRIPTION
The lexer was creating an `unsigned long long` value, and then the AST was storing it in an `int`.
This change makes both use a `long long`.

This is obviously still a stopgap until I can get arbitrary precisions in here.