### PR TITLE
Fix issues found during testing of v0.4.0 with Falcor

### DIFF
--- a/source/core/exception.h
+++ b/source/core/exception.h
@@ -110,6 +110,13 @@ namespace Slang
 		{
 		}
 	};
+
+    #define SLANG_UNEXPECTED(reason) \
+        throw Slang::Exception("unexpected: " reason)
+
+    #define SLANG_UNIMPLEMENTED_X(what) \
+        throw Slang::NotImplementedException("unimplemented: " what)
+
 }
 
 #endif

--- a/source/core/int-set.h
+++ b/source/core/int-set.h
@@ -46,7 +46,7 @@ namespace Slang
 		{
 			SetMax(maxVal);
 		}
-		int Size() const
+		UInt Size() const
 		{
 			return buffer.Count()*32;
 		}
@@ -57,40 +57,40 @@ namespace Slang
 		}
 		void SetAll()
 		{
-			for (int i = 0; i<buffer.Count(); i++)
+			for (UInt i = 0; i<buffer.Count(); i++)
 				buffer[i] = 0xFFFFFFFF;
 		}
-		void Resize(int size)
+		void Resize(UInt size)
 		{
-			int oldBufferSize = buffer.Count();
+			UInt oldBufferSize = buffer.Count();
 			buffer.SetSize((size+31)>>5);
 			if (buffer.Count() > oldBufferSize)
 				memset(buffer.Buffer()+oldBufferSize, 0, (buffer.Count()-oldBufferSize) * sizeof(int));
 		}
 		void Clear()
 		{
-			for (int i = 0; i<buffer.Count(); i++)
+			for (UInt i = 0; i<buffer.Count(); i++)
 				buffer[i] = 0;
 		}
-		void Add(int val)
+		void Add(UInt val)
 		{
-			int id = val>>5;
+			UInt id = val>>5;
 			if (id < buffer.Count())
 				buffer[id] |= (1<<(val&31));
 			else
 			{
-				int oldSize = buffer.Count();
+				UInt oldSize = buffer.Count();
 				buffer.SetSize(id+1);
 				memset(buffer.Buffer() + oldSize, 0, (buffer.Count()-oldSize)*sizeof(int));
 				buffer[id] |= (1<<(val&31));
 			}
 		}
-		void Remove(int val)
+		void Remove(UInt val)
 		{
 			if ((val>>5) < buffer.Count())
 				buffer[(val>>5)] &= ~(1<<(val&31));
 		}
-		bool Contains(int val) const
+		bool Contains(UInt val) const
 		{
 			if ((val>>5) >= buffer.Count())
 				return false;
@@ -98,7 +98,7 @@ namespace Slang
 		}
 		void UnionWith(const IntSet & set)
 		{
-			for (int i = 0; i<Math::Min(set.buffer.Count(), buffer.Count()); i++)
+			for (UInt i = 0; i<Math::Min(set.buffer.Count(), buffer.Count()); i++)
 			{
 				buffer[i] |= set.buffer[i];
 			}
@@ -109,7 +109,7 @@ namespace Slang
 		{
 			if (buffer.Count() != set.buffer.Count())
 				return false;
-			for (int i = 0; i<buffer.Count(); i++)
+			for (UInt i = 0; i<buffer.Count(); i++)
 				if (buffer[i] != set.buffer[i])
 					return false;
 			return true;
@@ -122,7 +122,7 @@ namespace Slang
 		{
 			if (set.buffer.Count() < buffer.Count())
 				memset(buffer.Buffer() + set.buffer.Count(), 0, (buffer.Count()-set.buffer.Count())*sizeof(int));
-			for (int i = 0; i<Math::Min(set.buffer.Count(), buffer.Count()); i++)
+			for (UInt i = 0; i<Math::Min(set.buffer.Count(), buffer.Count()); i++)
 			{
 				buffer[i] &= set.buffer[i];
 			}
@@ -131,26 +131,26 @@ namespace Slang
 		{
 			rs.buffer.SetSize(Math::Max(set1.buffer.Count(), set2.buffer.Count()));
 			rs.Clear();
-			for (int i = 0; i<set1.buffer.Count(); i++)
+			for (UInt i = 0; i<set1.buffer.Count(); i++)
 				rs.buffer[i] |= set1.buffer[i];
-			for (int i = 0; i<set2.buffer.Count(); i++)
+			for (UInt i = 0; i<set2.buffer.Count(); i++)
 				rs.buffer[i] |= set2.buffer[i];
 		}
 		static void Intersect(IntSet & rs, const IntSet & set1, const IntSet & set2)
 		{
 			rs.buffer.SetSize(Math::Min(set1.buffer.Count(), set2.buffer.Count()));
-			for (int i = 0; i<rs.buffer.Count(); i++)
+			for (UInt i = 0; i<rs.buffer.Count(); i++)
 				rs.buffer[i] = set1.buffer[i] & set2.buffer[i];
 		}
 		static void Subtract(IntSet & rs, const IntSet & set1, const IntSet & set2)
 		{
 			rs.buffer.SetSize(set1.buffer.Count());
-			for (int i = 0; i<Math::Min(set1.buffer.Count(), set2.buffer.Count()); i++)
+			for (UInt i = 0; i<Math::Min(set1.buffer.Count(), set2.buffer.Count()); i++)
 				rs.buffer[i] = set1.buffer[i] & (~set2.buffer[i]);
 		}
 		static bool HasIntersection(const IntSet & set1, const IntSet & set2)
 		{
-			for (int i = 0; i<Math::Min(set1.buffer.Count(), set2.buffer.Count()); i++)
+			for (UInt i = 0; i<Math::Min(set1.buffer.Count(), set2.buffer.Count()); i++)
 			{
 				if (set1.buffer[i] & set2.buffer[i])
 					return true;

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -23,7 +23,7 @@ namespace Slang
 
 	String Path::TruncateExt(const String & path)
 	{
-		int dotPos = path.LastIndexOf('.');
+		UInt dotPos = path.LastIndexOf('.');
 		if (dotPos != -1)
 			return path.SubString(0, dotPos);
 		else
@@ -32,7 +32,7 @@ namespace Slang
 	String Path::ReplaceExt(const String & path, const char * newExt)
 	{
 		StringBuilder sb(path.Length()+10);
-		int dotPos = path.LastIndexOf('.');
+		UInt dotPos = path.LastIndexOf('.');
 		if (dotPos == -1)
 			dotPos = path.Length();
 		sb.Append(path.Buffer(), dotPos);
@@ -72,7 +72,7 @@ namespace Slang
 	String Path::GetFileNameWithoutEXT(const String & path)
 	{
         String fileName = GetFileName(path);
-		int dotPos = fileName.LastIndexOf('.');
+		UInt dotPos = fileName.LastIndexOf('.');
 		if (dotPos == -1)
             return fileName;
 		return fileName.SubString(0, dotPos);

--- a/source/core/slang-string.cpp
+++ b/source/core/slang-string.cpp
@@ -149,7 +149,7 @@ namespace Slang
 		return String(buf);
 	}
 
-	OSString String::ToWString(int* outLength) const
+	OSString String::ToWString(UInt* outLength) const
 	{
 		if (!buffer)
 		{

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -506,7 +506,7 @@ namespace Slang
             String result;
             for (auto c : *this)
             {
-                int d = (c >= 'a' && c <= 'z') ? (c - ('a' - 'A')) : c;
+                char d = (c >= 'a' && c <= 'z') ? (c - ('a' - 'A')) : c;
                 result.append(d);
             }
             return result;
@@ -517,7 +517,7 @@ namespace Slang
             String result;
             for (auto c : *this)
             {
-                int d = (c >= 'A' && c <= 'Z') ? (c - ('A' - 'a')) : c;
+                char d = (c >= 'A' && c <= 'Z') ? (c - ('A' - 'a')) : c;
                 result.append(d);
             }
             return result;

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -452,7 +452,7 @@ namespace Slang
             return getData();
 		}
 
-        OSString ToWString(int* len = 0) const;
+        OSString ToWString(UInt* len = 0) const;
 
 		bool Equals(const String & str, bool caseSensitive = true)
 		{
@@ -636,13 +636,13 @@ namespace Slang
 	class StringBuilder : public String
 	{
 	private:
-		static const int InitialSize = 1024;
+        enum { InitialSize = 1024 };
 	public:
-		explicit StringBuilder(int bufferSize = InitialSize)
+		explicit StringBuilder(UInt bufferSize = InitialSize)
 		{
             ensureUniqueStorageWithCapacity(bufferSize);
 		}
-		void EnsureCapacity(int size)
+		void EnsureCapacity(UInt size)
 		{
             ensureUniqueStorageWithCapacity(size);
 		}
@@ -678,7 +678,7 @@ namespace Slang
 		}
 		StringBuilder & operator << (const char * str)
 		{
-			Append(str, (int)strlen(str));
+			Append(str, strlen(str));
 			return *this;
 		}
 		StringBuilder & operator << (const String & str)
@@ -736,9 +736,9 @@ namespace Slang
 		}
 		void Append(const char * str)
 		{
-			Append(str, (int)strlen(str));
+			Append(str, strlen(str));
 		}
-		void Append(const char * str, int strLen)
+		void Append(const char * str, UInt strLen)
 		{
             append(str, str + strLen);
 		}

--- a/source/core/smart-pointer.h
+++ b/source/core/smart-pointer.h
@@ -9,6 +9,7 @@ namespace Slang
 {
     // TODO: Need to centralize these typedefs
     typedef uintptr_t UInt;
+    typedef intptr_t Int;
 
     // Base class for all reference-counted objects
     class RefObject

--- a/source/core/text-io.cpp
+++ b/source/core/text-io.cpp
@@ -215,7 +215,7 @@ namespace Slang
 		{
 #ifdef _WIN32
 			int flag = IS_TEXT_UNICODE_SIGNATURE | IS_TEXT_UNICODE_REVERSE_SIGNATURE | IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_ASCII16;
-			int rs = IsTextUnicode(buffer.Buffer(), buffer.Count(), &flag);
+			int rs = IsTextUnicode(buffer.Buffer(), (int) buffer.Count(), &flag);
 			if (rs)
 			{
 				if (flag & (IS_TEXT_UNICODE_SIGNATURE | IS_TEXT_UNICODE_STATISTICS))

--- a/source/core/text-io.h
+++ b/source/core/text-io.h
@@ -273,7 +273,7 @@ namespace Slang
 		RefPtr<Stream> stream;
 		List<char> buffer;
 		Encoding * encoding;
-		int ptr;
+		UInt ptr;
 		char ReadBufferChar();
 		void ReadBuffer();
 			

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -717,7 +717,7 @@ namespace Slang
                         // up with initializer arguments.
 
 
-                        int argIndex = 0;
+                        UInt argIndex = 0;
                         for(auto fieldDeclRef : getMembersOfType<StructField>(toStructDeclRef))
                         {
                             if(argIndex >= argCount)
@@ -1144,27 +1144,27 @@ namespace Slang
             return constIntVal;
         }
 
-        void visit(ModifierDecl* decl)
+        void visit(ModifierDecl*)
         {
             // These are only used in the stdlib, so no checking is needed
         }
 
-        void visit(GenericTypeParamDecl* decl)
+        void visit(GenericTypeParamDecl*)
         {
             // These are only used in the stdlib, so no checking is needed for now
         }
 
-        void visit(GenericValueParamDecl* decl)
+        void visit(GenericValueParamDecl*)
         {
             // These are only used in the stdlib, so no checking is needed for now
         }
 
-        void visit(GenericTypeConstraintDecl* decl)
+        void visit(GenericTypeConstraintDecl*)
         {
             // These are only used in the stdlib, so no checking is needed for now
         }
 
-        void visit(Modifier* modifier)
+        void visit(Modifier*)
         {
             // Do nothing with modifiers for now
         }
@@ -1442,7 +1442,7 @@ namespace Slang
             if (fstParamCount != sndParamCount)
                 return false;
 
-            for (int ii = 0; ii < fstParamCount; ++ii)
+            for (UInt ii = 0; ii < fstParamCount; ++ii)
             {
                 auto fstParam = fstParams[ii];
                 auto sndParam = sndParams[ii];
@@ -1597,10 +1597,10 @@ namespace Slang
         template<typename T>
         T* FindOuterStmt()
         {
-            int outerStmtCount = outerStmts.Count();
-            for (int ii = outerStmtCount - 1; ii >= 0; --ii)
+            UInt outerStmtCount = outerStmts.Count();
+            for (UInt ii = outerStmtCount; ii > 0; --ii)
             {
-                auto outerStmt = outerStmts[ii];
+                auto outerStmt = outerStmts[ii-1];
                 auto found = dynamic_cast<T*>(outerStmt);
                 if (found)
                     return found;
@@ -2988,8 +2988,8 @@ namespace Slang
 
         struct ParamCounts
         {
-            int required;
-            int allowed;
+            UInt required;
+            UInt allowed;
         };
 
         // count the number of parameters required/allowed for a callable
@@ -3048,7 +3048,7 @@ namespace Slang
             OverloadResolveContext&		context,
             OverloadCandidate const&	candidate)
         {
-            int argCount = context.appExpr->Arguments.Count();
+            UInt argCount = context.appExpr->Arguments.Count();
             ParamCounts paramCounts = { 0, 0 };
             switch (candidate.flavor)
             {
@@ -3187,7 +3187,7 @@ namespace Slang
             OverloadCandidate&		candidate)
         {
             auto& args = context.appExpr->Arguments;
-            int argCount = args.Count();
+            UInt argCount = args.Count();
 
             List<DeclRef<ParameterSyntaxNode>> params;
             switch (candidate.flavor)
@@ -3208,7 +3208,7 @@ namespace Slang
             // case where one or more parameters had defaults.
             assert(argCount <= params.Count());
 
-            for (int ii = 0; ii < argCount; ++ii)
+            for (UInt ii = 0; ii < argCount; ++ii)
             {
                 auto& arg = args[ii];
                 auto param = params[ii];
@@ -3410,7 +3410,7 @@ namespace Slang
                 bool anyFiltered = false;
                 // Note that we are querying the list length on every iteration,
                 // because we might remove things.
-                for (int cc = 0; cc < context.bestCandidates.Count(); ++cc)
+                for (UInt cc = 0; cc < context.bestCandidates.Count(); ++cc)
                 {
                     int cmp = CompareOverloadCandidates(&candidate, &context.bestCandidates[cc]);
                     if (cmp < 0)
@@ -3624,8 +3624,8 @@ namespace Slang
 
             // Their arguments must unify
             assert(fst->args.Count() == snd->args.Count());
-            int argCount = fst->args.Count();
-            for (int aa = 0; aa < argCount; ++aa)
+            UInt argCount = fst->args.Count();
+            for (UInt aa = 0; aa < argCount; ++aa)
             {
                 if (!TryUnifyVals(constraints, fst->args[aa], snd->args[aa]))
                     return false;
@@ -3865,8 +3865,8 @@ namespace Slang
                 auto& args = context.appExpr->Arguments;
                 auto params = GetParameters(funcDeclRef).ToArray();
 
-                int argCount = args.Count();
-                int paramCount = params.Count();
+                UInt argCount = args.Count();
+                UInt paramCount = params.Count();
 
                 // Bail out on mismatch.
                 // TODO(tfoley): need more nuance here
@@ -3875,7 +3875,7 @@ namespace Slang
                     return DeclRef<Decl>(nullptr, nullptr);
                 }
 
-                for (int aa = 0; aa < argCount; ++aa)
+                for (UInt aa = 0; aa < argCount; ++aa)
                 {
 #if 0
                     if (!TryUnifyArgAndParamTypes(constraints, args[aa], params[aa]))
@@ -4289,9 +4289,9 @@ namespace Slang
                     }
                 }
 
-                int candidateCount = context.bestCandidates.Count();
-                int maxCandidatesToPrint = 10; // don't show too many candidates at once...
-                int candidateIndex = 0;
+                UInt candidateCount = context.bestCandidates.Count();
+                UInt maxCandidatesToPrint = 10; // don't show too many candidates at once...
+                UInt candidateIndex = 0;
                 for (auto candidate : context.bestCandidates)
                 {
                     String declString = getDeclSignatureString(candidate.item);
@@ -4561,7 +4561,7 @@ namespace Slang
                     }
                     if (params)
                     {
-                        for (int i = 0; i < (*params).Count(); i++)
+                        for (UInt i = 0; i < (*params).Count(); i++)
                         {
                             if ((*params)[i]->HasModifier<OutModifier>())
                             {

--- a/source/slang/diagnostics.cpp
+++ b/source/slang/diagnostics.cpp
@@ -26,6 +26,12 @@ void printDiagnosticArg(StringBuilder& sb, int str)
     sb << str;
 }
 
+void printDiagnosticArg(StringBuilder& sb, UInt val)
+{
+    // TODO: make this robust
+    sb << (int) val;
+}
+
 void printDiagnosticArg(StringBuilder& sb, Slang::String const& str)
 {
     sb << str;

--- a/source/slang/diagnostics.h
+++ b/source/slang/diagnostics.h
@@ -77,6 +77,7 @@ namespace Slang
 
     void printDiagnosticArg(StringBuilder& sb, char const* str);
     void printDiagnosticArg(StringBuilder& sb, int val);
+    void printDiagnosticArg(StringBuilder& sb, UInt val);
     void printDiagnosticArg(StringBuilder& sb, Slang::String const& str);
     void printDiagnosticArg(StringBuilder& sb, Decl* decl);
     void printDiagnosticArg(StringBuilder& sb, Type* type);

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -1491,12 +1491,15 @@ static void EmitType(EmitContext* context, RefPtr<ExpressionType> type)
 static void EmitType(EmitContext* context, TypeExp const& typeExp, Token const& nameToken)
 {
     EmitType(context, typeExp.type,
-        typeExp.exp ? typeExp.exp->Position : CodePosition(), nameToken.Content, nameToken.Position);
+        typeExp.exp ? typeExp.exp->Position : CodePosition(),
+        nameToken.Content, nameToken.Position);
 }
 
 static void EmitType(EmitContext* context, TypeExp const& typeExp, String const& name)
 {
-    EmitType(context, typeExp.type, typeExp.exp->Position, name, CodePosition());
+    EmitType(context, typeExp.type,
+        typeExp.exp ? typeExp.exp->Position : CodePosition(),
+        name, CodePosition());
 }
 
 // Statements

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -549,8 +549,8 @@ static void emitSimpleCallExpr(
     }
 
     Emit(context, "(");
-    int argCount = callExpr->Arguments.Count();
-    for (int aa = 0; aa < argCount; ++aa)
+    UInt argCount = callExpr->Arguments.Count();
+    for (UInt aa = 0; aa < argCount; ++aa)
     {
         if (aa != 0) Emit(context, ", ");
         EmitExpr(context, callExpr->Arguments[aa]);
@@ -721,8 +721,8 @@ static void emitCallExpr(
 
                     emit(context, name);
                     Emit(context, "(");
-                    int argCount = callExpr->Arguments.Count();
-                    for (int aa = 0; aa < argCount; ++aa)
+                    UInt argCount = callExpr->Arguments.Count();
+                    for (UInt aa = 0; aa < argCount; ++aa)
                     {
                         if (aa != 0) Emit(context, ", ");
                         EmitExpr(context, callExpr->Arguments[aa]);
@@ -734,7 +734,7 @@ static void emitCallExpr(
                 {
                     // General case: we are going to emit some more complex text.
 
-                    int argCount = callExpr->Arguments.Count();
+                    UInt argCount = callExpr->Arguments.Count();
 
                     Emit(context, "(");
 
@@ -782,8 +782,8 @@ static void emitCallExpr(
                     Emit(context, "(");
                     EmitExpr(context, memberExpr->BaseExpression);
                     Emit(context, ")[");
-                    int argCount = callExpr->Arguments.Count();
-                    for (int aa = 0; aa < argCount; ++aa)
+                    UInt argCount = callExpr->Arguments.Count();
+                    for (UInt aa = 0; aa < argCount; ++aa)
                     {
                         if (aa != 0) Emit(context, ", ");
                         EmitExpr(context, callExpr->Arguments[aa]);
@@ -1483,12 +1483,6 @@ static void EmitType(EmitContext* context, RefPtr<ExpressionType> type, Token co
     EmitType(context, type, CodePosition(), nameToken.Content, nameToken.Position);
 }
 
-
-static void EmitType(EmitContext* context, RefPtr<ExpressionType> type, String const& name)
-{
-    EmitType(context, type, CodePosition(), name, CodePosition());
-}
-
 static void EmitType(EmitContext* context, RefPtr<ExpressionType> type)
 {
     EmitType(context, type, nullptr);
@@ -1504,13 +1498,6 @@ static void EmitType(EmitContext* context, TypeExp const& typeExp, String const&
 {
     EmitType(context, typeExp.type, typeExp.exp->Position, name, CodePosition());
 }
-
-static void EmitType(EmitContext* context, TypeExp const& typeExp)
-{
-    advanceToSourceLocation(context, typeExp.exp->Position);
-    EmitType(context, typeExp.type, nullptr);
-}
-
 
 // Statements
 
@@ -1974,8 +1961,8 @@ static void EmitDeclRef(EmitContext* context, DeclRef<Decl> declRef)
 
         Substitutions* subst = declRef.substitutions.Ptr();
         Emit(context, "<");
-        int argCount = subst->args.Count();
-        for (int aa = 0; aa < argCount; ++aa)
+        UInt argCount = subst->args.Count();
+        for (UInt aa = 0; aa < argCount; ++aa)
         {
             if (aa != 0) Emit(context, ",");
             EmitVal(context, subst->args[aa]);
@@ -2064,7 +2051,7 @@ static void EmitModifiers(EmitContext* context, RefPtr<Decl> decl)
             if (argCount != 0)
             {
                 Emit(context, "(");
-                for (int aa = 0; aa < argCount; ++aa)
+                for (UInt aa = 0; aa < argCount; ++aa)
                 {
                     if (aa != 0) Emit(context, ", ");
                     EmitExpr(context, args[aa]);
@@ -3025,9 +3012,9 @@ String emitEntryPoint(
     // where there were global-scope uniforms.
     auto globalScopeLayout = programLayout->globalScopeLayout;
     StructTypeLayout* globalStructLayout = nullptr;
-    if( auto globalStructLayout = globalScopeLayout.As<StructTypeLayout>() )
+    if( auto gs = globalScopeLayout.As<StructTypeLayout>() )
     {
-        globalStructLayout = globalStructLayout.Ptr();
+        globalStructLayout = gs.Ptr();
     }
     else if(auto globalConstantBufferLayout = globalScopeLayout.As<ParameterBlockTypeLayout>())
     {

--- a/source/slang/lower.cpp
+++ b/source/slang/lower.cpp
@@ -80,7 +80,7 @@ struct StructuralTransformStmtVisitor
     : StructuralTransformVisitorBase<V>
     , StmtVisitor<StructuralTransformStmtVisitor<V>, RefPtr<StatementSyntaxNode>>
 {
-    void transformFields(StatementSyntaxNode* result, StatementSyntaxNode* obj)
+    void transformFields(StatementSyntaxNode*, StatementSyntaxNode*)
     {
     }
 
@@ -457,7 +457,7 @@ struct LoweringVisitor
     //
 
     StatementSyntaxNode* translateStmtRef(
-        StatementSyntaxNode*    stmt)
+        StatementSyntaxNode*)
     {
         throw "unimplemented";
     }
@@ -666,13 +666,13 @@ struct LoweringVisitor
     }
 
     RefPtr<Substitutions> translateSubstitutions(
-        Substitutions*  substitutions)
+        Substitutions*  inSubstitutions)
     {
-        if (!substitutions) return nullptr;
+        if (!inSubstitutions) return nullptr;
 
         RefPtr<Substitutions> result = new Substitutions();
-        result->genericDecl = translateDeclRef(substitutions->genericDecl).As<GenericDecl>();
-        for (auto arg : substitutions->args)
+        result->genericDecl = translateDeclRef(inSubstitutions->genericDecl).As<GenericDecl>();
+        for (auto arg : inSubstitutions->args)
         {
             result->args.Add(translateVal(arg));
         }
@@ -740,9 +740,8 @@ struct LoweringVisitor
         }
         else
         {
-            DeclVisitor::dispatch(declBase);
+            return DeclVisitor::dispatch(declBase);
         }
-
     }
 
     RefPtr<Decl> lowerDecl(
@@ -922,8 +921,8 @@ struct LoweringVisitor
         //
         // If this is a global variable (program scope), then add it
         // to the global scope.
-        RefPtr<ContainerDecl> parentDecl = decl->ParentDecl;
-        if (auto parentModuleDecl = parentDecl.As<ProgramSyntaxNode>())
+        RefPtr<ContainerDecl> pp = decl->ParentDecl;
+        if (auto parentModuleDecl = pp.As<ProgramSyntaxNode>())
         {
             addMember(
                 translateDeclRef(parentModuleDecl),
@@ -1138,10 +1137,6 @@ struct LoweringVisitor
             subscriptExpr->Position = varExpr->Position;
             subscriptExpr->BaseExpression = varExpr;
 
-            // TODO: we need to construct syntax for a loop to initialize
-            // the array here...
-            throw "unimplemented";
-
             // Note that we use the original `varLayout` that was passed in,
             // since that is the layout that will ultimately need to be
             // used on the array elements.
@@ -1154,6 +1149,9 @@ struct LoweringVisitor
                 varLayout,
                 subscriptExpr);
 
+            // TODO: we need to construct syntax for a loop to initialize
+            // the array here...
+            throw "unimplemented";
         }
         else if (auto declRefType = varType->As<DeclRefType>())
         {

--- a/source/slang/lower.cpp
+++ b/source/slang/lower.cpp
@@ -826,11 +826,68 @@ struct LoweringVisitor
     }
 
     // Catch-all
-    RefPtr<Decl> visit(
-        Decl* decl)
+
+    RefPtr<Decl> visit(ModifierDecl*)
     {
-        assert(!"unimplemented");
-        return decl;
+        // should not occur in user code
+        SLANG_UNEXPECTED("modifiers shouldn't occur in user code");
+    }
+
+    RefPtr<Decl> visit(GenericValueParamDecl*)
+    {
+        SLANG_UNEXPECTED("generics should be lowered to specialized decls");
+    }
+
+    RefPtr<Decl> visit(GenericTypeParamDecl*)
+    {
+        SLANG_UNEXPECTED("generics should be lowered to specialized decls");
+    }
+
+    RefPtr<Decl> visit(GenericTypeConstraintDecl*)
+    {
+        SLANG_UNEXPECTED("generics should be lowered to specialized decls");
+    }
+
+    RefPtr<Decl> visit(GenericDecl*)
+    {
+        SLANG_UNEXPECTED("generics should be lowered to specialized decls");
+    }
+
+    RefPtr<Decl> visit(ProgramSyntaxNode*)
+    {
+        SLANG_UNEXPECTED("module decls should be lowered explicitly");
+    }
+
+    RefPtr<Decl> visit(SubscriptDecl*)
+    {
+        // We don't expect to find direct references to a subscript
+        // declaration, but rather to the underlying accessors
+        return nullptr;
+    }
+
+    RefPtr<Decl> visit(InheritanceDecl*)
+    {
+        // We should deal with these explicitly, as part of lowering
+        // the type that contains them.
+        return nullptr;
+    }
+
+    RefPtr<Decl> visit(ExtensionDecl*)
+    {
+        // Extensions won't exist in the lowered code: their members
+        // will turn into ordinary functions that get called explicitly
+        return nullptr;
+    }
+
+    RefPtr<Decl> visit(TypeDefDecl* decl)
+    {
+        RefPtr<TypeDefDecl> loweredDecl = new TypeDefDecl();
+        lowerDeclCommon(loweredDecl, decl);
+
+        loweredDecl->Type = lowerType(decl->Type);
+
+        addMember(shared->loweredProgram, loweredDecl);
+        return loweredDecl;
     }
 
     RefPtr<ImportDecl> visit(ImportDecl* decl)

--- a/source/slang/options.cpp
+++ b/source/slang/options.cpp
@@ -80,7 +80,7 @@ struct OptionsParser
     {
         auto translationUnitIndex = spAddTranslationUnit(compileRequest, language, nullptr);
 
-        assert(translationUnitIndex == rawTranslationUnits.Count());
+        assert(UInt(translationUnitIndex) == rawTranslationUnits.Count());
 
         RawTranslationUnit rawTranslationUnit;
         rawTranslationUnit.sourceLanguage = language;

--- a/source/slang/preprocessor.cpp
+++ b/source/slang/preprocessor.cpp
@@ -600,8 +600,8 @@ static void MaybeBeginMacroExpansion(
             expansion->environment = &expansion->argumentEnvironment;
 
             // Try to read any arguments present.
-            int paramCount = macro->params.Count();
-            int argIndex = 0;
+            UInt paramCount = macro->params.Count();
+            UInt argIndex = 0;
 
             switch (PeekRawTokenType(preprocessor))
             {
@@ -702,7 +702,7 @@ static void MaybeBeginMacroExpansion(
                 GetSink(preprocessor)->diagnose(PeekLoc(preprocessor), Diagnostics::expectedTokenInMacroArguments, TokenType::RParent, PeekRawTokenType(preprocessor));
             }
 
-            int argCount = argIndex;
+            UInt argCount = argIndex;
             if (argCount != paramCount)
             {
                 // TODO: diagnose

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -191,11 +191,11 @@ SLANG_API size_t spReflectionType_GetElementCount(SlangReflectionType* inType)
 
     if(auto arrayType = dynamic_cast<ArrayExpressionType*>(type))
     {
-        return GetIntVal(arrayType->ArrayLength);
+        return (size_t) GetIntVal(arrayType->ArrayLength);
     }
     else if( auto vectorType = dynamic_cast<VectorExpressionType*>(type))
     {
-        return GetIntVal(vectorType->elementCount);
+        return (size_t) GetIntVal(vectorType->elementCount);
     }
 
     return 0;
@@ -688,7 +688,7 @@ SLANG_API unsigned spReflection_GetParameterCount(SlangReflection* inProgram)
 
     if(auto globalStructLayout = globalLayout.As<StructTypeLayout>())
     {
-        return globalStructLayout->fields.Count();
+        return (unsigned) globalStructLayout->fields.Count();
     }
 
     return 0;

--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -1598,10 +1598,9 @@ namespace Slang
                             { 3, "Alpha" },
                         };
 
-                        for(auto cc : kGatherComponets)
+                        for(auto kk : kGatherComponets)
                         {
-                            auto componentIndex = cc.componentIndex;
-                            auto componentName = cc.componentName;
+                            auto componentName = kk.componentName;
 
                             EMIT_LINE_DIRECTIVE();
                             sb << "vector<T, 4> Gather" << componentName << "(SamplerState s, ";

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -19,17 +19,6 @@
 
 namespace Slang {
 
-static void stdlibDiagnosticCallback(
-    char const* message,
-    void*       userData)
-{
-    fputs(message, stderr);
-    fflush(stderr);
-#ifdef WIN32
-    OutputDebugStringA(message);
-#endif
-}
-
 class Session
 {
 public:
@@ -281,9 +270,9 @@ int CompileRequest::executeActions()
     return err;
 }
 
-int CompileRequest::addTranslationUnit(SourceLanguage language, String const& name)
+int CompileRequest::addTranslationUnit(SourceLanguage language, String const&)
 {
-    int result = translationUnits.Count();
+    UInt result = translationUnits.Count();
 
     RefPtr<TranslationUnitRequest> translationUnit = new TranslationUnitRequest();
     translationUnit->compileRequest = this;
@@ -291,7 +280,7 @@ int CompileRequest::addTranslationUnit(SourceLanguage language, String const& na
 
     translationUnits.Add(translationUnit);
 
-    return result;
+    return (int) result;
 }
 
 void CompileRequest::addTranslationUnitSourceString(
@@ -336,27 +325,27 @@ void CompileRequest::addTranslationUnitSourceFile(
 int CompileRequest::addEntryPoint(
     int                     translationUnitIndex,
     String const&           name,
-    Profile                 profile)
+    Profile                 entryPointProfile)
 {
     RefPtr<EntryPointRequest> entryPoint = new EntryPointRequest();
     entryPoint->compileRequest = this;
     entryPoint->name = name;
-    entryPoint->profile = profile;
+    entryPoint->profile = entryPointProfile;
     entryPoint->translationUnitIndex = translationUnitIndex;
 
     auto translationUnit = translationUnits[translationUnitIndex].Ptr();
     translationUnit->entryPoints.Add(entryPoint);
 
-    int result = entryPoints.Count();
+    UInt result = entryPoints.Count();
     entryPoints.Add(entryPoint);
-    return result;
+    return (int) result;
 }
 
 RefPtr<ProgramSyntaxNode> CompileRequest::loadModule(
     String const&       name,
     String const&       path,
     String const&       source,
-    CodePosition const& loc)
+    CodePosition const&)
 {
     RefPtr<TranslationUnitRequest> translationUnit = new TranslationUnitRequest();
     translationUnit->compileRequest = this;
@@ -714,7 +703,7 @@ SLANG_API void spAddTranslationUnitSourceFile(
     auto req = REQ(request);
     if(!path) return;
     if(translationUnitIndex < 0) return;
-    if(translationUnitIndex >= req->translationUnits.Count()) return;
+    if(Slang::UInt(translationUnitIndex) >= req->translationUnits.Count()) return;
 
     req->addTranslationUnitSourceFile(
         translationUnitIndex,
@@ -732,7 +721,7 @@ SLANG_API void spAddTranslationUnitSourceString(
     auto req = REQ(request);
     if(!source) return;
     if(translationUnitIndex < 0) return;
-    if(translationUnitIndex >= req->translationUnits.Count()) return;
+    if(Slang::UInt(translationUnitIndex) >= req->translationUnits.Count()) return;
 
     if(!path) path = "";
 
@@ -744,7 +733,7 @@ SLANG_API void spAddTranslationUnitSourceString(
 }
 
 SLANG_API SlangProfileID spFindProfile(
-    SlangSession*   session,
+    SlangSession*,
     char const*     name)
 {
     return Slang::Profile::LookUp(name).raw;
@@ -760,7 +749,7 @@ SLANG_API int spAddEntryPoint(
     auto req = REQ(request);
     if(!name) return -1;
     if(translationUnitIndex < 0) return -1;
-    if(translationUnitIndex >= req->translationUnits.Count()) return -1;
+    if(Slang::UInt(translationUnitIndex) >= req->translationUnits.Count()) return -1;
 
     return req->addEntryPoint(
         translationUnitIndex,
@@ -785,7 +774,7 @@ spGetDependencyFileCount(
 {
     if(!request) return 0;
     auto req = REQ(request);
-    return req->mDependencyFilePaths.Count();
+    return (int) req->mDependencyFilePaths.Count();
 }
 
 /** Get the path to a file this compilation dependend on.
@@ -805,7 +794,7 @@ spGetTranslationUnitCount(
     SlangCompileRequest*    request)
 {
     auto req = REQ(request);
-    return req->translationUnits.Count();
+    return (int) req->translationUnits.Count();
 }
 
 // Get the output code associated with a specific translation unit

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -782,9 +782,9 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         if (genericDecl != subst->genericDecl)
             return false;
 
-        int argCount = args.Count();
+        UInt argCount = args.Count();
         assert(args.Count() == subst->args.Count());
-        for (int aa = 0; aa < argCount; ++aa)
+        for (UInt aa = 0; aa < argCount; ++aa)
         {
             if (!args[aa]->EqualsVal(subst->args[aa].Ptr()))
                 return false;

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -420,9 +420,9 @@ namespace Slang
         // TODO(tfoley): It is ugly to have these.
         // We should probably fix the call sites instead.
         RefPtr<T>& First() { return *begin(); }
-        int Count()
+        UInt Count()
         {
-            int count = 0;
+            UInt count = 0;
             for (auto iter : (*this))
             {
                 (void)iter;

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -225,7 +225,7 @@ struct DefaultVaryingLayoutRulesImpl : DefaultLayoutRulesImpl
         return kind;
     }
 
-    SimpleLayoutInfo GetScalarLayout(BaseType baseType) override
+    SimpleLayoutInfo GetScalarLayout(BaseType) override
     {
         // Assume that all scalars take up one "slot"
         return SimpleLayoutInfo(
@@ -233,7 +233,7 @@ struct DefaultVaryingLayoutRulesImpl : DefaultLayoutRulesImpl
             1);
     }
 
-    virtual SimpleLayoutInfo GetScalarLayout(slang::TypeReflection::ScalarType scalarType)
+    virtual SimpleLayoutInfo GetScalarLayout(slang::TypeReflection::ScalarType)
     {
         // Assume that all scalars take up one "slot"
         return SimpleLayoutInfo(
@@ -241,7 +241,7 @@ struct DefaultVaryingLayoutRulesImpl : DefaultLayoutRulesImpl
             1);
     }
 
-    SimpleLayoutInfo GetVectorLayout(SimpleLayoutInfo elementInfo, size_t elementCount) override
+    SimpleLayoutInfo GetVectorLayout(SimpleLayoutInfo, size_t) override
     {
         // Vectors take up one slot by default
         //
@@ -276,7 +276,7 @@ struct GLSLSpecializationConstantLayoutRulesImpl : DefaultLayoutRulesImpl
         return LayoutResourceKind::SpecializationConstant;
     }
 
-    SimpleLayoutInfo GetScalarLayout(BaseType baseType) override
+    SimpleLayoutInfo GetScalarLayout(BaseType) override
     {
         // Assume that all scalars take up one "slot"
         return SimpleLayoutInfo(
@@ -284,7 +284,7 @@ struct GLSLSpecializationConstantLayoutRulesImpl : DefaultLayoutRulesImpl
             1);
     }
 
-    virtual SimpleLayoutInfo GetScalarLayout(slang::TypeReflection::ScalarType scalarType)
+    virtual SimpleLayoutInfo GetScalarLayout(slang::TypeReflection::ScalarType)
     {
         // Assume that all scalars take up one "slot"
         return SimpleLayoutInfo(
@@ -292,7 +292,7 @@ struct GLSLSpecializationConstantLayoutRulesImpl : DefaultLayoutRulesImpl
             1);
     }
 
-    SimpleLayoutInfo GetVectorLayout(SimpleLayoutInfo elementInfo, size_t elementCount) override
+    SimpleLayoutInfo GetVectorLayout(SimpleLayoutInfo, size_t elementCount) override
     {
         // GLSL doesn't support vectors of specialization constants,
         // but we will assume that, if supported, they would use one slot per element.
@@ -308,7 +308,7 @@ GLSLSpecializationConstantLayoutRulesImpl kGLSLSpecializationConstantLayoutRules
 
 struct GLSLObjectLayoutRulesImpl : ObjectLayoutRulesImpl
 {
-    virtual SimpleLayoutInfo GetObjectLayout(ShaderParameterKind kind) override
+    virtual SimpleLayoutInfo GetObjectLayout(ShaderParameterKind) override
     {
         // In Vulkan GLSL, pretty much every object is just a descriptor-table slot.
         // We can refine this method once we support a case where this isn't true.
@@ -954,7 +954,7 @@ SimpleLayoutInfo GetLayoutImpl(
         return GetSimpleLayoutImpl(
             rules->GetVectorLayout(
                 GetLayout(vecType->elementType.Ptr(), rules),
-                GetIntVal(vecType->elementCount)),
+                (size_t) GetIntVal(vecType->elementCount)),
             type,
             rules,
             outTypeLayout);
@@ -964,8 +964,8 @@ SimpleLayoutInfo GetLayoutImpl(
         return GetSimpleLayoutImpl(
             rules->GetMatrixLayout(
                 GetLayout(matType->getElementType(), rules),
-                GetIntVal(matType->getRowCount()),
-                GetIntVal(matType->getColumnCount())),
+                (size_t) GetIntVal(matType->getRowCount()),
+                (size_t) GetIntVal(matType->getColumnCount())),
             type,
             rules,
             outTypeLayout);

--- a/tools/render-test/main.cpp
+++ b/tools/render-test/main.cpp
@@ -15,6 +15,10 @@
 #undef WIN32_LEAN_AND_MEAN
 #undef NOMINMAX
 
+#ifdef _MSC_VER
+#pragma warning(disable: 4996)
+#endif
+
 namespace renderer_test {
 
 //

--- a/tools/render-test/render-d3d11.cpp
+++ b/tools/render-test/render-d3d11.cpp
@@ -8,6 +8,9 @@
 
 #include <Slang.h>
 
+#ifdef _MSC_VER
+#pragma warning(disable: 4996)
+#endif
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "external/stb/stb_image_write.h"
 
@@ -660,7 +663,7 @@ public:
     virtual Buffer* createBuffer(BufferDesc const& desc) override
     {
         D3D11_BUFFER_DESC dxBufferDesc = { 0 };
-        dxBufferDesc.ByteWidth = desc.size;
+        dxBufferDesc.ByteWidth = (UINT) desc.size;
 
         switch( desc.flavor )
         {
@@ -715,10 +718,10 @@ public:
         for( UInt ii = 0; ii < inputElementCount; ++ii )
         {
             dxInputElements[ii].SemanticName            = inputElements[ii].semanticName;
-            dxInputElements[ii].SemanticIndex           = inputElements[ii].semanticIndex;
+            dxInputElements[ii].SemanticIndex           = (UINT) inputElements[ii].semanticIndex;
             dxInputElements[ii].Format                  = mapFormat(inputElements[ii].format);
             dxInputElements[ii].InputSlot               = 0;
-            dxInputElements[ii].AlignedByteOffset       = inputElements[ii].offset;
+            dxInputElements[ii].AlignedByteOffset       = (UINT) inputElements[ii].offset;
             dxInputElements[ii].InputSlotClass          = D3D11_INPUT_PER_VERTEX_DATA;
             dxInputElements[ii].InstanceDataStepRate    = 0;
 
@@ -738,9 +741,11 @@ public:
                 return nullptr;
             }
 
-            hlslCursor+= sprintf(hlslCursor, "%s a%d : %s%d", typeName, ii,
+            hlslCursor+= sprintf(hlslCursor, "%s a%d : %s%d",
+                typeName,
+                (int) ii,
                 inputElements[ii].semanticName,
-                inputElements[ii].semanticIndex);
+                (int) inputElements[ii].semanticIndex);
         }
 
         hlslCursor += sprintf(hlslCursor, "\n) : SV_Position { return 0; }");
@@ -752,7 +757,7 @@ public:
         ID3D11InputLayout* dxInputLayout = nullptr;
         HRESULT hr = dxDevice->CreateInputLayout(
             &dxInputElements[0],
-            inputElementCount,
+            (UINT) inputElementCount,
             dxVertexShaderBlob->GetBufferPointer(),
             dxVertexShaderBlob->GetBufferSize(),
             &dxInputLayout);
@@ -839,13 +844,15 @@ public:
 
         for( UInt ii = 0; ii < slotCount; ++ii )
         {
-            dxVertexStrides[ii] = strides[ii];
-            dxVertexOffsets[ii] = offsets[ii];
+            dxVertexStrides[ii] = (UINT) strides[ii];
+            dxVertexOffsets[ii] = (UINT) offsets[ii];
         }
 
         auto dxVertexBuffers = (ID3D11Buffer* const*) buffers;
 
-        dxContext->IASetVertexBuffers(startSlot, slotCount, &dxVertexBuffers[0], &dxVertexStrides[0], &dxVertexOffsets[0]);
+        dxContext->IASetVertexBuffers(
+            (UINT) startSlot,
+            (UINT) slotCount, &dxVertexBuffers[0], &dxVertexStrides[0], &dxVertexOffsets[0]);
     }
 
     virtual void setShaderProgram(ShaderProgram* inProgram) override
@@ -866,8 +873,10 @@ public:
 
         auto dxConstantBuffers = (ID3D11Buffer* const*) buffers;
 
-        dxContext->VSSetConstantBuffers(startSlot, slotCount, &dxConstantBuffers[0]);
-        dxContext->VSSetConstantBuffers(startSlot, slotCount, &dxConstantBuffers[0]);
+        dxContext->VSSetConstantBuffers(
+            (UINT) startSlot, (UINT) slotCount, &dxConstantBuffers[0]);
+        dxContext->VSSetConstantBuffers(
+            (UINT) startSlot, (UINT) slotCount, &dxConstantBuffers[0]);
     }
 
 
@@ -875,7 +884,7 @@ public:
     {
         auto dxContext = dxImmediateContext;
 
-        dxContext->Draw(vertexCount, startVertex);
+        dxContext->Draw((UINT) vertexCount, (UINT) startVertex);
     }
 
 

--- a/tools/render-test/render-gl.cpp
+++ b/tools/render-test/render-gl.cpp
@@ -297,7 +297,7 @@ public:
 
             glAttr.streamIndex = 0;
             glAttr.format = getVertexAttributeFormat(inputAttr.format);
-            glAttr.offset = inputAttr.offset;
+            glAttr.offset = (GLsizei) inputAttr.offset;
         }
 
         return (InputLayout*)inputLayout;
@@ -388,7 +388,7 @@ public:
 
             assert(!offsets || !offsets[ii]);
 
-            glBindBufferBase(GL_UNIFORM_BUFFER, slot, bufferID);
+            glBindBufferBase(GL_UNIFORM_BUFFER, (GLuint) slot, bufferID);
         }
     }
 
@@ -405,18 +405,18 @@ public:
             glBindBuffer(GL_ARRAY_BUFFER, boundVertexStreamBuffers[streamIndex]);
 
             glVertexAttribPointer(
-                ii,
-                attr.format.componentCount,
+                (GLuint) ii,
+                 attr.format.componentCount,
                 attr.format.componentType,
                 attr.format.normalized,
-                boundVertexStreamStrides[streamIndex],
+                (GLsizei) boundVertexStreamStrides[streamIndex],
                 (GLvoid*)(attr.offset + boundVertexStreamOffsets[streamIndex]));
 
-            glEnableVertexAttribArray(ii);
+            glEnableVertexAttribArray((GLuint)ii);
         }
         for (UInt ii = attrCount; ii < kMaxVertexStreams; ++ii)
         {
-            glDisableVertexAttribArray(ii);
+            glDisableVertexAttribArray((GLuint)ii);
         }
     }
 
@@ -424,7 +424,7 @@ public:
     {
         flushStateForDraw();
 
-        glDrawArrays(boundPrimitiveTopology, startVertex, vertexCount);
+        glDrawArrays(boundPrimitiveTopology, (GLint) startVertex, (GLsizei) vertexCount);
     }
 
     // ShaderCompiler interface


### PR DESCRIPTION
The code should now compile cleanly with warnings as errors for VS2015 with `W3`.
Most of the changes had to do with propagating a real pointer-sized integer type through code that had been using `int`.