### PR TITLE
Falcor work

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -776,6 +776,7 @@ struct EmitVisitor
         case TextureType::Shape2D:		Emit("2D");		break;
         case TextureType::Shape3D:		Emit("3D");		break;
         case TextureType::ShapeCube:	Emit("Cube");	break;
+        case TextureType::ShapeBuffer:	Emit("Buffer");	break;
         default:
             assert(!"unreachable");
             break;

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -1084,18 +1084,56 @@ struct EmitVisitor
         emitTypeImpl(type, nullptr);
     }
 
+    void emitTypeBasedOnExpr(ExpressionSyntaxNode* expr, EDeclarator* declarator)
+    {
+        if (auto subscriptExpr = dynamic_cast<IndexExpressionSyntaxNode*>(expr))
+        {
+            // Looks like an array
+            emitTypeBasedOnExpr(subscriptExpr->BaseExpression, declarator);
+            Emit("[");
+            if (auto indexExpr = subscriptExpr->IndexExpression)
+            {
+                EmitExpr(indexExpr);
+            }
+            Emit("]");
+        }
+        else
+        {
+            // Default case
+            EmitExpr(expr);
+            EmitDeclarator(declarator);
+        }
+    }
+
+    void EmitType(TypeExp const& typeExp, String const& name, CodePosition const& nameLoc)
+    {
+        if (!typeExp.type || typeExp.type->As<ErrorType>())
+        {
+            assert(typeExp.exp);
+
+            EDeclarator nameDeclarator;
+            nameDeclarator.flavor = EDeclarator::Flavor::Name;
+            nameDeclarator.name = name;
+            nameDeclarator.loc = nameLoc;
+
+            emitTypeBasedOnExpr(typeExp.exp, &nameDeclarator);
+        }
+        else
+        {
+            EmitType(typeExp.type,
+                typeExp.exp ? typeExp.exp->Position : CodePosition(),
+                name, nameLoc);
+        }
+    }
+
     void EmitType(TypeExp const& typeExp, Token const& nameToken)
     {
-        EmitType(typeExp.type,
-            typeExp.exp ? typeExp.exp->Position : CodePosition(),
-            nameToken.Content, nameToken.Position);
+        EmitType(typeExp, nameToken.Content, nameToken.Position);
     }
 
     void EmitType(TypeExp const& typeExp, String const& name)
     {
-        EmitType(typeExp.type,
-            typeExp.exp ? typeExp.exp->Position : CodePosition(),
-            name, CodePosition());
+        EmitType(typeExp, name, CodePosition());
     }
 
     void emitTypeExp(TypeExp const& typeExp)
@@ -2758,7 +2796,15 @@ struct EmitVisitor
     {
         EmitModifiers(declRef.getDecl());
 
-        EmitType(GetType(declRef), declRef.getDecl()->getNameToken());
+        auto type = GetType(declRef);
+        if (!type || type->As<ErrorType>())
+        {
+            EmitType(declRef.getDecl()->Type, declRef.getDecl()->getNameToken());
+        }
+        else
+        {
+            EmitType(GetType(declRef), declRef.getDecl()->getNameToken());
+        }
 
         EmitSemantics(declRef.getDecl());
 

--- a/source/slang/lower.cpp
+++ b/source/slang/lower.cpp
@@ -445,6 +445,7 @@ struct LoweringVisitor
     {
         TypeExp result;
         result.type = lowerType(typeExp.type);
+        result.exp = lowerExpr(typeExp.exp);
         return result;
     }
 

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -148,6 +148,11 @@ SLANG_API SlangTypeKind spReflectionType_GetKind(SlangReflectionType* inType)
             return SLANG_TYPE_KIND_STRUCT;
         }
     }
+    else if (auto errorType = type->As<ErrorType>())
+    {
+        // This means we saw a type we didn't understand in the user's code
+        return SLANG_TYPE_KIND_NONE;
+    }
 
     assert(!"unexpected");
     return SLANG_TYPE_KIND_NONE;

--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -1914,6 +1914,7 @@ namespace Slang
             { "2D",		TextureType::Shape2D,	2 },
             { "3D",		TextureType::Shape3D,	3 },
             { "Cube",	TextureType::ShapeCube,	3 },
+            { "Buffer", TextureType::ShapeBuffer,   1 },
         };
         static const int kBaseTextureTypeCount = sizeof(kBaseTextureTypes) / sizeof(kBaseTextureTypes[0]);
 

--- a/source/slang/type-defs.h
+++ b/source/slang/type-defs.h
@@ -125,6 +125,7 @@ RAW(
         Shape2D			= SLANG_TEXTURE_2D,
         Shape3D			= SLANG_TEXTURE_3D,
         ShapeCube		= SLANG_TEXTURE_CUBE,
+        ShapeBuffer     = SLANG_TEXTURE_BUFFER,
 
         Shape1DArray	= Shape1D | ArrayFlag,
         Shape2DArray	= Shape2D | ArrayFlag,

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -895,6 +895,28 @@ SimpleLayoutInfo GetLayoutImpl(
             rules,
             outTypeLayout);
     }
+    else if (auto imageType = type->As<GLSLImageType>())
+    {
+        // TODO: the logic here should really be defined by the rules,
+        // and not at this top level...
+        ShaderParameterKind kind;
+        switch( imageType->getAccess() )
+        {
+        default:
+            kind = ShaderParameterKind::MutableImage;
+            break;
+
+        case SLANG_RESOURCE_ACCESS_READ:
+            kind = ShaderParameterKind::Image;
+            break;
+        }
+
+        return GetSimpleLayoutImpl(
+            rules->GetObjectLayout(kind),
+            type,
+            rules,
+            outTypeLayout);
+    }
     else if (auto textureSamplerType = type->As<TextureSamplerType>())
     {
         // TODO: the logic here should really be defined by the rules,
@@ -1125,6 +1147,19 @@ SimpleLayoutInfo GetLayoutImpl(
 
             return info;
         }
+    }
+    else if (auto errorType = type->As<ErrorType>())
+    {
+        // An error type means that we encountered something we don't understand.
+        //
+        // We should probalby inform the user with an error message here.
+
+        SimpleLayoutInfo info;
+        return GetSimpleLayoutImpl(
+            info,
+            type,
+            rules,
+            outTypeLayout);
     }
 
     // catch-all case in case nothing matched

--- a/source/slang/type-layout.h
+++ b/source/slang/type-layout.h
@@ -415,6 +415,9 @@ enum class ShaderParameterKind
     InputRenderTarget,
 
     SamplerState,
+
+    Image,
+    MutableImage,
 };
 
 struct SimpleLayoutRulesImpl


### PR DESCRIPTION
This is mostly work to fix up the lack of `imageBuffer` as a type on the GLSL side.

The work to add the type was easy (3 lines), but I tried to make the new rewriter a bit more robust to the case where it doesn't understand a type in user code.

(I'm thinking, though, that maybe this class of error should not be suppressed, even in "rewriter" mode)