### PR TITLE
SPIR-V Support

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -322,15 +322,6 @@ extern "C"
         SlangCompileRequest*    request,
         int                     translationUnitIndex);
 
-    /** Get the output bytecode associated with a specific translation unit.
-
-    The lifetime of the output pointer is the same as `request`.
-    */
-    SLANG_API void const* spGetTranslationUnitCode(
-        SlangCompileRequest*    request,
-        int                     translationUnitIndex,
-        size_t*                 outSize);
-
     /** Get the output source code associated with a specific entry point.
 
     The lifetime of the output pointer is the same as `request`.

--- a/slang.h
+++ b/slang.h
@@ -314,7 +314,7 @@ extern "C"
     spGetTranslationUnitCount(
         SlangCompileRequest*    request);
 
-    /** Get the output code associated with a specific translation unit
+    /** Get the output code associated with a specific translation unit.
 
     The lifetime of the output pointer is the same as `request`.
     */
@@ -322,13 +322,31 @@ extern "C"
         SlangCompileRequest*    request,
         int                     translationUnitIndex);
 
-    /** Get the output code associated with a specific entry point.
+    /** Get the output bytecode associated with a specific translation unit.
+
+    The lifetime of the output pointer is the same as `request`.
+    */
+    SLANG_API void const* spGetTranslationUnitCode(
+        SlangCompileRequest*    request,
+        int                     translationUnitIndex,
+        size_t*                 outSize);
+
+    /** Get the output source code associated with a specific entry point.
 
     The lifetime of the output pointer is the same as `request`.
     */
     SLANG_API char const* spGetEntryPointSource(
         SlangCompileRequest*    request,
         int                     entryPointIndex);
+
+    /** Get the output bytecode associated with a specific entry point.
+
+    The lifetime of the output pointer is the same as `request`.
+    */
+    SLANG_API void const* spGetEntryPointCode(
+        SlangCompileRequest*    request,
+        int                     entryPointIndex,
+        size_t*                 outSize);
 
 
     /* Note(tfoley): working on new reflection interface...

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -48,13 +48,30 @@ namespace Slang
         ReflectionJSON      = SLANG_REFLECTION_JSON,
     };
 
+    enum class ResultFormat
+    {
+        None,
+        Text,
+        Binary
+    };
+
     class CompileRequest;
     class TranslationUnitRequest;
 
-    // Result of compiling an entry point
-    struct EntryPointResult
+    // Result of compiling an entry point.
+    // Should only ever be string OR binary.
+    class CompileResult
     {
-        List<uint8_t> outputSource;
+    public:
+        CompileResult() = default;
+        CompileResult(String const& str) : format(ResultFormat::Text), outputString(str) {}
+        CompileResult(List<uint8_t> const& buffer) : format(ResultFormat::Binary), outputBinary(buffer) {}
+
+        void append(CompileResult const& result);
+
+        ResultFormat format = ResultFormat::None;
+        String outputString;
+        List<uint8_t> outputBinary;
     };
 
     // Describes an entry point that we've been requested to compile
@@ -80,7 +97,7 @@ namespace Slang
         // The resulting output for the enry point
         //
         // TODO: low-level code generation should be a distinct step
-        EntryPointResult result;
+        CompileResult result;
 
         // The translation unit that this entry point came from
         TranslationUnitRequest* getTranslationUnit();
@@ -103,12 +120,6 @@ namespace Slang
 
         // The actual contents of the file
         String content;
-    };
-
-    // Result of compiling a translation unit
-    struct TranslationUnitResult
-    {
-        List<uint8_t> outputSource;
     };
 
     // A single translation unit requested to be compiled.
@@ -144,7 +155,7 @@ namespace Slang
         // The resulting output for the translation unit
         //
         // TODO: low-level code generation should be a distinct step
-        TranslationUnitResult result;
+        CompileResult result;
     };
 
     // A directory to be searched when looking for files (e.g., `#include`)

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -54,7 +54,7 @@ namespace Slang
     // Result of compiling an entry point
     struct EntryPointResult
     {
-        String outputSource;
+        List<uint8_t> outputSource;
     };
 
     // Describes an entry point that we've been requested to compile
@@ -108,7 +108,7 @@ namespace Slang
     // Result of compiling a translation unit
     struct TranslationUnitResult
     {
-        String outputSource;
+        List<uint8_t> outputSource;
     };
 
     // A single translation unit requested to be compiled.

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -862,18 +862,7 @@ SLANG_API char const* spGetTranslationUnitSource(
     int                     translationUnitIndex)
 {
     auto req = REQ(request);
-    return (char const*)req->translationUnits[translationUnitIndex]->result.outputSource.Buffer();
-}
-
-SLANG_API void const* spGetTranslationUnitCode(
-    SlangCompileRequest*    request,
-    int                     translationUnitIndex,
-    size_t*                 outSize)
-{
-    auto req = REQ(request);
-    Slang::TranslationUnitResult& result = req->translationUnits[translationUnitIndex]->result;
-    *outSize = (size_t)result.outputSource.Count();
-    return result.outputSource.Buffer();
+    return req->translationUnits[translationUnitIndex]->result.outputString.Buffer();
 }
 
 SLANG_API char const* spGetEntryPointSource(
@@ -881,8 +870,7 @@ SLANG_API char const* spGetEntryPointSource(
     int                     entryPointIndex)
 {
     auto req = REQ(request);
-    return (char const*)req->entryPoints[entryPointIndex]->result.outputSource.Buffer();
-
+    return req->entryPoints[entryPointIndex]->result.outputString.Buffer();
 }
 
 SLANG_API void const* spGetEntryPointCode(
@@ -891,9 +879,9 @@ SLANG_API void const* spGetEntryPointCode(
     size_t*                 outSize)
 {
     auto req = REQ(request);
-    Slang::EntryPointResult& result = req->entryPoints[entryPointIndex]->result;
-    *outSize = (size_t)result.outputSource.Count();
-    return result.outputSource.Buffer();
+    Slang::CompileResult& result = req->entryPoints[entryPointIndex]->result;
+    if(outSize) *outSize = result.outputBinary.Count();
+    return result.outputBinary.Buffer();
 }
 
 // Reflection API

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -862,7 +862,18 @@ SLANG_API char const* spGetTranslationUnitSource(
     int                     translationUnitIndex)
 {
     auto req = REQ(request);
-    return req->translationUnits[translationUnitIndex]->result.outputSource.Buffer();
+    return (char const*)req->translationUnits[translationUnitIndex]->result.outputSource.Buffer();
+}
+
+SLANG_API void const* spGetTranslationUnitCode(
+    SlangCompileRequest*    request,
+    int                     translationUnitIndex,
+    size_t*                 outSize)
+{
+    auto req = REQ(request);
+    Slang::TranslationUnitResult& result = req->translationUnits[translationUnitIndex]->result;
+    *outSize = (size_t)result.outputSource.Count();
+    return result.outputSource.Buffer();
 }
 
 SLANG_API char const* spGetEntryPointSource(
@@ -870,8 +881,19 @@ SLANG_API char const* spGetEntryPointSource(
     int                     entryPointIndex)
 {
     auto req = REQ(request);
-    return req->entryPoints[entryPointIndex]->result.outputSource.Buffer();
+    return (char const*)req->entryPoints[entryPointIndex]->result.outputSource.Buffer();
 
+}
+
+SLANG_API void const* spGetEntryPointCode(
+    SlangCompileRequest*    request,
+    int                     entryPointIndex,
+    size_t*                 outSize)
+{
+    auto req = REQ(request);
+    Slang::EntryPointResult& result = req->entryPoints[entryPointIndex]->result;
+    *outSize = (size_t)result.outputSource.Count();
+    return result.outputSource.Buffer();
 }
 
 // Reflection API
@@ -884,6 +906,5 @@ SLANG_API SlangReflection* spGetReflection(
     auto req = REQ(request);
     return (SlangReflection*) req->layout.Ptr();
 }
-
 
 // ... rest of reflection API implementation is in `Reflection.cpp`

--- a/tools/glslang/glslang.cpp
+++ b/tools/glslang/glslang.cpp
@@ -66,7 +66,8 @@ static void dump(
         fwrite(data, 1, size, fallbackStream);
 
         // also output it for debug purposes
-        OutputDebugStringA((char const*)data);
+        std::string str((char const*)data, size);
+        OutputDebugStringA(str.c_str());
     }
 }
 

--- a/tools/glslang/glslang.cpp
+++ b/tools/glslang/glslang.cpp
@@ -171,7 +171,7 @@ int glslang_compile(glslang_CompileRequest* request)
         }
         else
         {
-            dump(spirv.data(), spirv.size() * sizeof(spirv[0]), request->outputFunc, request->outputUserData, stdout);
+            dump(spirv.data(), spirv.size() * sizeof(unsigned int), request->outputFunc, request->outputUserData, stdout);
         }
     }
 

--- a/tools/glslang/glslang.h
+++ b/tools/glslang/glslang.h
@@ -2,7 +2,7 @@
 #ifndef GLSLANG_H_INCLUDED
 #define GLSLANG_H_INCLUDED
 
-typedef void (*glslang_OutputFunc)(char const* text, void* userData);
+typedef void (*glslang_OutputFunc)(void const* data, size_t size, void* userData);
 
 struct glslang_CompileRequest
 {
@@ -16,6 +16,8 @@ struct glslang_CompileRequest
     void*               outputUserData;
 
     int                 slangStage;
+
+    bool                disassembleResult;
 };
 
 typedef int (*glslang_CompileFunc)(glslang_CompileRequest* request);


### PR DESCRIPTION
- Refactored to allow Slang compiler to work with raw data instead of Strings.
- Added interface to get code as raw data.
- Added support for regular SPIR-V output in glslang wrapper.