### PR TITLE
Fix emission of `static` for HLSL

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -2628,7 +2628,7 @@ struct EmitVisitor
                 switch(context->shared->target)
                 {
                 default:
-                    Emit("static");
+                    Emit("static ");
                     break;
 
                 case CodeGenTarget::GLSL:


### PR DESCRIPTION
I forgot to include a trailing space.