### PR TITLE
Handle function name properly for unchecked call

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -1598,7 +1598,7 @@ struct EmitVisitor
             auto funcDecl = funcDeclRef.getDecl();
             if(!funcDecl)
             {
-                emitUncheckedCallExpr(callExpr, funcDeclRef.GetName(), arg);
+                emitUncheckedCallExpr(callExpr, funcDeclRefExpr->name, arg);
                 return;
             }
             else if (auto intrinsicOpModifier = funcDecl->FindModifier<IntrinsicOpModifier>())


### PR DESCRIPTION
The emit logic was checking for a missing decl, and then asking that same (missing) declaration for its name.