### PR TITLE
Improve reporting of GLSL `image*` types

### DIFF
--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -1941,7 +1941,8 @@ namespace Slang
 
                 for (int isMultisample = 0; isMultisample < 2; ++isMultisample)
                 {
-                    auto access = SLANG_RESOURCE_ACCESS_READ;
+                    auto readAccess = SLANG_RESOURCE_ACCESS_READ;
+                    auto readWriteAccess = SLANG_RESOURCE_ACCESS_READ_WRITE;
 
                     // TODO: any constraints to enforce on what gets to be multisampled?
 
@@ -1951,7 +1952,10 @@ namespace Slang
                     if (isMultisample)	flavor |= TextureType::MultisampleFlag;
 //                        if (isShadow)		flavor |= TextureType::ShadowFlag;
 
-                    flavor |= (access << 8);
+
+
+                    unsigned readFlavor = flavor | (readAccess << 8);
+                    unsigned readWriteFlavor = flavor | (readWriteAccess << 8);
 
                     StringBuilder nameBuilder;
                     nameBuilder << shapeName;
@@ -1960,17 +1964,17 @@ namespace Slang
                     auto name = nameBuilder.ProduceString();
 
                     sb << "__generic<T> ";
-                    sb << "__magic_type(TextureSampler," << int(flavor) << ") struct ";
+                    sb << "__magic_type(TextureSampler," << int(readFlavor) << ") struct ";
                     sb << "__sampler" << name;
                     sb << " {};\n";
 
                     sb << "__generic<T> ";
-                    sb << "__magic_type(Texture," << int(flavor) << ") struct ";
+                    sb << "__magic_type(Texture," << int(readFlavor) << ") struct ";
                     sb << "__texture" << name;
                     sb << " {};\n";
 
                     sb << "__generic<T> ";
-                    sb << "__magic_type(GLSLImageType," << int(flavor) << ") struct ";
+                    sb << "__magic_type(GLSLImageType," << int(readWriteFlavor) << ") struct ";
                     sb << "__image" << name;
                     sb << " {};\n";
 

--- a/tests/reflection/image-types.glsl
+++ b/tests/reflection/image-types.glsl
@@ -1,0 +1,10 @@
+//TEST(smoke):SIMPLE:-profile ps_4_0 -target reflection-json
+
+// Confirm that we expose GLSL `image` types through reflection
+
+uniform imageBuffer iBuffer;
+
+uniform image2D i2D;
+
+void main()
+{}

--- a/tests/reflection/image-types.glsl.expected
+++ b/tests/reflection/image-types.glsl.expected
@@ -1,0 +1,27 @@
+result code = 0
+standard error = {
+}
+standard output = {
+{
+    "parameters": [
+        {
+            "name": "iBuffer",
+            "binding": {"kind": "descriptorTableSlot", "index": 0},
+            "type": {
+                "kind": "resource",
+                "baseShape": "textureBuffer",
+                "access": "readWrite"
+            }
+        },
+        {
+            "name": "i2D",
+            "binding": {"kind": "descriptorTableSlot", "index": 1},
+            "type": {
+                "kind": "resource",
+                "baseShape": "texture2D",
+                "access": "readWrite"
+            }
+        }
+    ]
+}
+}


### PR DESCRIPTION
- Update stdlib so taht `image*` types have read-write access encoded in their type
  - TODO:  this isn't 100% right, since there are GLSL qualifiers that might override this

- Add a test case to verify  that the reflection API reports `image*` parameters