### PR TITLE
Make parser recovering more robust to avoid infinite loops

### DIFF
--- a/tests/bugs/gh-75.hlsl
+++ b/tests/bugs/gh-75.hlsl
@@ -1,0 +1,24 @@
+//TEST:SIMPLE:-profile cs_5_0
+
+// Missing opening `{` sends parser into infinite loop
+
+struct LightCB
+{
+    float3 vec3Val; // We're using 2 values. [0]: worldDir [1]: intensity
+};
+
+StructuredBuffer<LightCB> gLightIn;
+AppendStructuredBuffer<LightCB> gLightOut;
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    uint numLights = 0;
+    uint stride;
+    gLightIn.GetDimensions(numLights, stride);
+    
+    for (uint i = 0; i < numLights; i++)
+    
+        gLightOut.Append(gLightIn[i]);
+    }
+}

--- a/tests/bugs/gh-75.hlsl.expected
+++ b/tests/bugs/gh-75.hlsl.expected
@@ -1,0 +1,6 @@
+result code = -1
+standard error = {
+tests/bugs/gh-75.hlsl(24): error 20001: unexpected '}', expected identifier
+}
+standard output = {
+}


### PR DESCRIPTION
Fixes #75

In order to avoid cascaded errors, I went ahead and made the parser refuse to skip past a `}` in recovery mode. The problem with this is that we fail to make forward progress if we are stuck on a `}` (this happens if you have an extra `}` at the global scope.