### PR TITLE
Sample rate reflection

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -514,6 +514,16 @@ extern "C"
 
     // Entry Point Reflection
 
+    SLANG_API char const* spReflectionEntryPoint_getName(
+        SlangReflectionEntryPoint* entryPoint);
+
+    SLANG_API unsigned spReflectionEntryPoint_getParameterCount(
+        SlangReflectionEntryPoint* entryPoint);
+
+    SLANG_API SlangReflectionVariableLayout* spReflectionEntryPoint_getParameterByIndex(
+        SlangReflectionEntryPoint*  entryPoint,
+        unsigned                    index);
+
     SLANG_API SlangStage spReflectionEntryPoint_getStage(SlangReflectionEntryPoint* entryPoint);
 
     SLANG_API void spReflectionEntryPoint_getComputeThreadGroupSize(
@@ -857,6 +867,21 @@ namespace slang
 
     struct EntryPointReflection
     {
+        char const* getName()
+        {
+            return spReflectionEntryPoint_getName((SlangReflectionEntryPoint*) this);
+        }
+
+        unsigned getParameterCount()
+        {
+            return spReflectionEntryPoint_getParameterCount((SlangReflectionEntryPoint*) this);
+        }
+
+        VariableLayoutReflection* getParameterByIndex(unsigned index)
+        {
+            return (VariableLayoutReflection*) spReflectionEntryPoint_getParameterByIndex((SlangReflectionEntryPoint*) this, index);
+        }
+
         SlangStage getStage()
         {
             return spReflectionEntryPoint_getStage((SlangReflectionEntryPoint*) this);

--- a/slang.h
+++ b/slang.h
@@ -531,6 +531,9 @@ extern "C"
         SlangUInt                   axisCount,
         SlangUInt*                  outSizeAlongAxis);
 
+    SLANG_API int spReflectionEntryPoint_usesAnySampleRateInput(
+        SlangReflectionEntryPoint* entryPoint);
+
     // Shader Reflection
 
     SLANG_API unsigned spReflection_GetParameterCount(SlangReflection* reflection);
@@ -892,6 +895,11 @@ namespace slang
             SlangUInt*  outSizeAlongAxis)
         {
             return spReflectionEntryPoint_getComputeThreadGroupSize((SlangReflectionEntryPoint*) this, axisCount, outSizeAlongAxis);
+        }
+
+        bool usesAnySampleRateInput()
+        {
+            return 0 != spReflectionEntryPoint_usesAnySampleRateInput((SlangReflectionEntryPoint*) this);
         }
     };
 

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -2833,7 +2833,10 @@ struct EmitVisitor
 
     // Emit a single `regsiter` semantic, as appropriate for a given resource-type-specific layout info
     void emitHLSLRegisterSemantic(
-        VarLayout::ResourceInfo const&  info)
+        VarLayout::ResourceInfo const&  info,
+
+        // Keyword to use in the uniform case (`register` for globals, `packoffset` inside a `cbuffer`)
+        char const* uniformSemanticSpelling = "register")
     {
         if( info.kind == LayoutResourceKind::Uniform )
         {
@@ -2845,7 +2848,9 @@ struct EmitVisitor
             // units, and then a "component" within that register, based on 4-byte
             // offsets from there. We cannot support more fine-grained offsets than that.
 
-            Emit(": packoffset(c");
+            Emit(": ");
+            Emit(uniformSemanticSpelling);
+            Emit("(c");
 
             // Size of a logical `c` register in bytes
             auto registerSize = 16;
@@ -2907,7 +2912,8 @@ struct EmitVisitor
 
     // Emit all the `register` semantics that are appropriate for a particular variable layout
     void emitHLSLRegisterSemantics(
-        RefPtr<VarLayout>   layout)
+        RefPtr<VarLayout>   layout,
+        char const*         uniformSemanticSpelling = "register")
     {
         if (!layout) return;
 
@@ -2922,7 +2928,7 @@ struct EmitVisitor
 
         for( auto rr : layout->resourceInfos )
         {
-            emitHLSLRegisterSemantic(rr);
+            emitHLSLRegisterSemantic(rr, uniformSemanticSpelling);
         }
     }
 
@@ -3026,7 +3032,7 @@ struct EmitVisitor
                         offsetResource.space += cbufferResource->space;
                     }
 
-                    emitHLSLRegisterSemantic(offsetResource);
+                    emitHLSLRegisterSemantic(offsetResource, "packoffset");
                 }
 
                 Emit(";\n");

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -751,6 +751,18 @@ SLANG_API void spReflectionEntryPoint_getComputeThreadGroupSize(
     }
 }
 
+SLANG_API int spReflectionEntryPoint_usesAnySampleRateInput(
+    SlangReflectionEntryPoint* inEntryPoint)
+{
+    auto entryPointLayout = convert(inEntryPoint);
+    if(!entryPointLayout)
+        return 0;
+
+    if (entryPointLayout->profile.GetStage() != Stage::Fragment)
+        return 0;
+
+    return (entryPointLayout->flags & EntryPointLayout::Flag::usesAnySampleRateInput) != 0;
+}
 
 // Shader Reflection
 
@@ -1495,6 +1507,11 @@ static void emitReflectionEntryPointJSON(
 
         dedent(writer);
         write(writer, "\n]");
+    }
+
+    if (entryPoint->usesAnySampleRateInput())
+    {
+        write(writer, ",\n\"usesAnySampleRateInput\": true");
     }
 
     dedent(writer);

--- a/source/slang/type-layout.h
+++ b/source/slang/type-layout.h
@@ -352,6 +352,12 @@ public:
 
     // Layout for any results of the entry point
     RefPtr<VarLayout> resultLayout;
+
+    enum Flag : unsigned
+    {
+        usesAnySampleRateInput = 0x1,
+    };
+    unsigned flags = 0;
 };
 
 // Layout information for the global scope of a program

--- a/tests/reflection/arrays.hlsl.expected
+++ b/tests/reflection/arrays.hlsl.expected
@@ -98,6 +98,12 @@ standard output = {
                 "kind": "samplerState"
             }
         }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "fragment"
+        }
     ]
 }
 }

--- a/tests/reflection/gh-55.glsl.expected
+++ b/tests/reflection/gh-55.glsl.expected
@@ -40,6 +40,12 @@ standard output = {
                 }
             }
         }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "fragment"
+        }
     ]
 }
 }

--- a/tests/reflection/global-uniforms.hlsl.expected
+++ b/tests/reflection/global-uniforms.hlsl.expected
@@ -67,6 +67,12 @@ standard output = {
                 }
             }
         }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "fragment"
+        }
     ]
 }
 }

--- a/tests/reflection/image-types.glsl
+++ b/tests/reflection/image-types.glsl
@@ -2,9 +2,11 @@
 
 // Confirm that we expose GLSL `image` types through reflection
 
-uniform imageBuffer iBuffer;
+layout(rgba32f)
+uniform writeonly imageBuffer iBuffer;
 
-uniform image2D i2D;
+layout(rgba32f)
+uniform writeonly image2D i2D;
 
 void main()
 {}

--- a/tests/reflection/image-types.glsl.expected
+++ b/tests/reflection/image-types.glsl.expected
@@ -22,6 +22,12 @@ standard output = {
                 "access": "readWrite"
             }
         }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "fragment"
+        }
     ]
 }
 }

--- a/tests/reflection/multi-file-extra.hlsl
+++ b/tests/reflection/multi-file-extra.hlsl
@@ -18,7 +18,7 @@ float4 use(float  val) { return val; };
 float4 use(float2 val) { return float4(val,0.0,0.0); };
 float4 use(float3 val) { return float4(val,0.0); };
 float4 use(float4 val) { return val; };
-float4 use(Texture2D t, SamplerState s) { return t.Sample(s, 0.0); }
+float4 use(Texture2D t, SamplerState s) { return t.SampleLevel(s, 0.0, 0.0); }
 
 // Start with some parameters that will appear in both shaders
 Texture2D sharedT;
@@ -51,7 +51,7 @@ Texture2D sharedTV;
 Texture2D sharedTF;
 
 
-float4 main() : SV_Target
+float4 mainVS() : SV_Position
 {
 	// Go ahead and use everything here, just to make sure things got placed correctly
 	return use(sharedT, sharedS)

--- a/tests/reflection/multi-file.hlsl
+++ b/tests/reflection/multi-file.hlsl
@@ -1,4 +1,4 @@
-//TEST:SIMPLE:-profile ps_4_0 -target reflection-json Tests/bindings/multi-file-extra.hlsl
+//TEST:SIMPLE:-profile ps_4_0 -entry mainFS -target reflection-json tests/reflection/multi-file-extra.hlsl -profile vs_4_0 -entry mainVS
 
 // Here we are testing the case where multiple translation units are provided
 // at once, so that we want combined reflection information for the resulting
@@ -44,7 +44,7 @@ Texture2D sharedTV;
 Texture2D sharedTF;
 
 
-float4 main() : SV_Position
+float4 mainFS() : SV_Target
 {
 	// Go ahead and use everything here, just to make sure things got placed correctly
 	return use(sharedT, sharedS)

--- a/tests/reflection/multi-file.hlsl.expected
+++ b/tests/reflection/multi-file.hlsl.expected
@@ -233,6 +233,16 @@ standard output = {
                 }
             }
         }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "fragment"
+        },
+        {
+            "name": "main",
+            "stage:": "fragment"
+        }
     ]
 }
 }

--- a/tests/reflection/multi-file.hlsl.expected
+++ b/tests/reflection/multi-file.hlsl.expected
@@ -236,12 +236,12 @@ standard output = {
     ],
     "entryPoints": [
         {
-            "name": "main",
+            "name": "mainFS",
             "stage:": "fragment"
         },
         {
-            "name": "main",
-            "stage:": "fragment"
+            "name": "mainVS",
+            "stage:": "vertex"
         }
     ]
 }

--- a/tests/reflection/reflect-imported-code.hlsl.expected
+++ b/tests/reflection/reflect-imported-code.hlsl.expected
@@ -74,6 +74,12 @@ standard output = {
                 }
             }
         }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "fragment"
+        }
     ]
 }
 }

--- a/tests/reflection/reflection0.hlsl.expected
+++ b/tests/reflection/reflection0.hlsl.expected
@@ -39,6 +39,12 @@ standard output = {
                 }
             }
         }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "fragment"
+        }
     ]
 }
 }

--- a/tests/reflection/resource-in-cbuffer.hlsl.expected
+++ b/tests/reflection/resource-in-cbuffer.hlsl.expected
@@ -55,6 +55,12 @@ standard output = {
                 }
             }
         }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "fragment"
+        }
     ]
 }
 }

--- a/tests/reflection/sample-rate-input.glsl
+++ b/tests/reflection/sample-rate-input.glsl
@@ -1,0 +1,15 @@
+//TEST(smoke):SIMPLE:-profile ps_4_0 -no-checking -target reflection-json
+
+// Check that we report sample-rate entry point input correctly
+
+uniform texture2D t;
+uniform sampler s;
+
+sample in vec2 uv;
+
+out vec4 c;
+
+void main()
+{
+    c = texture(sampler2D(t,s), uv);
+}

--- a/tests/reflection/sample-rate-input.glsl.expected
+++ b/tests/reflection/sample-rate-input.glsl.expected
@@ -1,0 +1,55 @@
+result code = 0
+standard error = {
+}
+standard output = {
+{
+    "parameters": [
+        {
+            "name": "t",
+            "binding": {"kind": "descriptorTableSlot", "index": 0},
+            "type": {
+                "kind": "resource",
+                "baseShape": "texture2D"
+            }
+        },
+        {
+            "name": "s",
+            "binding": {"kind": "descriptorTableSlot", "index": 1},
+            "type": {
+                "kind": "samplerState"
+            }
+        },
+        {
+            "name": "uv",
+            "binding": {"kind": "vertexInput", "index": 0},
+            "type": {
+                "kind": "vector",
+                "elementCount": 2,
+                "elementType": {
+                    "kind": "scalar",
+                    "scalarType": "float32"
+                }
+            }
+        },
+        {
+            "name": "c",
+            "binding": {"kind": "fragmentOutput", "index": 0},
+            "type": {
+                "kind": "vector",
+                "elementCount": 4,
+                "elementType": {
+                    "kind": "scalar",
+                    "scalarType": "float32"
+                }
+            }
+        }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "fragment",
+            "usesAnySampleRateInput": true
+        }
+    ]
+}
+}

--- a/tests/reflection/std430-layout.glsl
+++ b/tests/reflection/std430-layout.glsl
@@ -1,3 +1,4 @@
+#version 450
 //TEST(smoke):SIMPLE:-profile ps_4_0 -target reflection-json
 
 // Confirm fix for GitHub issue #55

--- a/tests/reflection/std430-layout.glsl.expected
+++ b/tests/reflection/std430-layout.glsl.expected
@@ -102,6 +102,12 @@ standard output = {
                 }
             }
         }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "fragment"
+        }
     ]
 }
 }


### PR DESCRIPTION
This adds an initial API query to check if an entry point needs to be evaluated at "sample rate." In the context of Vulkan/D3D12, this basically means "did the entry point reference any input with the `sample` qualifier, or the built-in variable that exposes sample index?"