### PR TITLE
Fixes for shader cross-compilation

### DIFF
--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -2540,7 +2540,11 @@ namespace Slang
 
             if (!type.IsLeftValue)
             {
-                if (!isRewriteMode())
+                if (type->As<ErrorType>())
+                {
+                    // Don't report an l-value issue on an errorneous expression
+                }
+                else if (!isRewriteMode())
                 {
                     getSink()->diagnose(expr, Diagnostics::assignNonLValue);
                 }

--- a/source/slang/compiler.cpp
+++ b/source/slang/compiler.cpp
@@ -236,15 +236,14 @@ namespace Slang
             // TODO(tfoley): need a better policy for how we translate diagnostics
             // back into the Slang world (although we should always try to generate
             // HLSL that doesn't produce any diagnostics...)
-            String diagnostics = (char const*) diagnosticsBlob->GetBufferPointer();
-            fprintf(stderr, "%s", diagnostics.begin());
-            OutputDebugStringA(diagnostics.begin());
+            entryPoint->compileRequest->mSink.diagnoseRaw(
+                FAILED(hr) ? Severity::Error : Severity::Warning,
+                (char const*) diagnosticsBlob->GetBufferPointer());
             diagnosticsBlob->Release();
         }
         if (FAILED(hr))
         {
-            // TODO(tfoley): What to do on failure?
-            exit(1);
+            return List<uint8_t>();
         }
         return data;
     }
@@ -376,9 +375,10 @@ namespace Slang
 
         if (err)
         {
-            OutputDebugStringA(diagnosticOutput.Buffer());
-            fprintf(stderr, "%s", diagnosticOutput.Buffer());
-            exit(1);
+            entryPoint->compileRequest->mSink.diagnoseRaw(
+                Severity::Error,
+                diagnosticOutput.begin());
+            return err;
         }
 
         return 0;

--- a/source/slang/diagnostics.cpp
+++ b/source/slang/diagnostics.cpp
@@ -194,6 +194,36 @@ void DiagnosticSink::diagnoseImpl(CodePosition const& pos, DiagnosticInfo const&
     }
 }
 
+void DiagnosticSink::diagnoseRaw(
+    Severity    severity,
+    char const* message)
+{
+    if (severity >= Severity::Error)
+    {
+        errorCount++;
+    }
+
+    // Did the client supply a callback for us to use?
+    if( callback )
+    {
+        // If so, pass the error string along to them
+        callback(message, callbackUserData);
+    }
+    else
+    {
+        // If the user doesn't have a callback, then just
+        // collect our diagnostic messages into a buffer
+        outputBuffer.append(message);
+    }
+
+    if (severity >= Severity::Fatal)
+    {
+        // TODO: figure out a better policy for aborting compilation
+        throw InvalidOperationException();
+    }
+}
+
+
 namespace Diagnostics
 {
 #define DIAGNOSTIC(id, severity, name, messageFormat) const DiagnosticInfo name = { id, Severity::severity, messageFormat };

--- a/source/slang/diagnostics.h
+++ b/source/slang/diagnostics.h
@@ -185,6 +185,12 @@ namespace Slang
         }
 
         void diagnoseImpl(CodePosition const& pos, DiagnosticInfo const& info, int argCount, DiagnosticArg const* const* args);
+
+        // Add a diagnostic with raw text
+        // (used when we get errors from a downstream compiler)
+        void diagnoseRaw(
+            Severity    severity,
+            char const* message);
     };
 
     namespace Diagnostics

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -450,7 +450,17 @@ struct EmitVisitor
 
         emitRawText(" ");
 
-        if(context->shared->target == CodeGenTarget::GLSL)
+        bool shouldUseGLSLStyleLineDirective = false;
+
+        // Let's not do this
+#if 0
+        if (context->shared->target == CodeGenTarget::GLSL)
+        {
+            shouldUseGLSLStyleLineDirective = true;
+        }
+#endif
+
+        if(shouldUseGLSLStyleLineDirective)
         {
             auto path = sourceLocation.FileName;
 

--- a/source/slang/modifier-defs.h
+++ b/source/slang/modifier-defs.h
@@ -208,17 +208,20 @@ SIMPLE_SYNTAX_CLASS(GLSLColumnMajorLayoutModifier, RowMajorLayoutModifier)
 
 // More HLSL Keyword
 
+ABSTRACT_SYNTAX_CLASS(InterpolationModeModifier, Modifier)
+END_SYNTAX_CLASS()
+
 // HLSL `nointerpolation` modifier
-SIMPLE_SYNTAX_CLASS(HLSLNoInterpolationModifier, Modifier)
+SIMPLE_SYNTAX_CLASS(HLSLNoInterpolationModifier, InterpolationModeModifier)
 
 // HLSL `linear` modifier
-SIMPLE_SYNTAX_CLASS(HLSLLinearModifier, Modifier)
+SIMPLE_SYNTAX_CLASS(HLSLLinearModifier, InterpolationModeModifier)
 
 // HLSL `sample` modifier
-SIMPLE_SYNTAX_CLASS(HLSLSampleModifier, Modifier)
+SIMPLE_SYNTAX_CLASS(HLSLSampleModifier, InterpolationModeModifier)
 
 // HLSL `centroid` modifier
-SIMPLE_SYNTAX_CLASS(HLSLCentroidModifier, Modifier)
+SIMPLE_SYNTAX_CLASS(HLSLCentroidModifier, InterpolationModeModifier)
 
 // HLSL `precise` modifier
 SIMPLE_SYNTAX_CLASS(HLSLPreciseModifier, Modifier)

--- a/source/slang/modifier-defs.h
+++ b/source/slang/modifier-defs.h
@@ -53,6 +53,12 @@ SYNTAX_CLASS(TargetIntrinsicModifier, IntrinsicModifierBase)
     FIELD(Token, definitionToken)
 END_SYNTAX_CLASS()
 
+// A modifier to tag something as an intrinsic that requires
+// a certain GLSL extension to be enabled when used
+SYNTAX_CLASS(RequiredGLSLExtensionModifier, Modifier)
+    FIELD(Token, extensionNameToken)
+END_SYNTAX_CLASS()
+
 SIMPLE_SYNTAX_CLASS(InOutModifier, OutModifier)
 
 // This is a special sentinel modifier that gets added

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -717,6 +717,17 @@ namespace Slang
                 AddModifier(&modifierLink, modifier);
             }
 
+            else if (AdvanceIf(parser, "__glsl_extension"))
+            {
+                auto modifier = new RequiredGLSLExtensionModifier();
+                modifier->Position = loc;
+
+                parser->ReadToken(TokenType::LParent);
+                modifier->extensionNameToken = parser->ReadToken(TokenType::Identifier);
+                parser->ReadToken(TokenType::RParent);
+
+                AddModifier(&modifierLink, modifier);
+            }
 
             else if (AdvanceIf(parser, "layout"))
             {

--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -413,27 +413,33 @@ __intrinsic
 matrix<T,N,M> ddx(matrix<T,N,M> x);
 
 __generic<T : __BuiltinFloatingPointType>
+__glsl_extension(GL_ARB_derivative_control)
 __intrinsic(glsl, dFdxCoarse)
 __intrinsic
 T ddx_coarse(T x);
 __generic<T : __BuiltinFloatingPointType, let N : int>
+__glsl_extension(GL_ARB_derivative_control)
 __intrinsic(glsl, dFdxCoarse)
 __intrinsic
 vector<T,N> ddx_coarse(vector<T,N> x);
 __generic<T : __BuiltinFloatingPointType, let N : int, let M : int>
+__glsl_extension(GL_ARB_derivative_control)
 __intrinsic(glsl, dFdxCoarse)
 __intrinsic
 matrix<T,N,M> ddx_coarse(matrix<T,N,M> x);
 
 __generic<T : __BuiltinFloatingPointType>
+__glsl_extension(GL_ARB_derivative_control)
 __intrinsic(glsl, dFdxFine)
 __intrinsic
 T ddx_fine(T x);
 __generic<T : __BuiltinFloatingPointType, let N : int>
+__glsl_extension(GL_ARB_derivative_control)
 __intrinsic(glsl, dFdxFine)
 __intrinsic
 vector<T,N> ddx_fine(vector<T,N> x);
 __generic<T : __BuiltinFloatingPointType, let N : int, let M : int>
+__glsl_extension(GL_ARB_derivative_control)
 __intrinsic(glsl, dFdxFine)
 __intrinsic
 matrix<T,N,M> ddx_fine(matrix<T,N,M> x);
@@ -452,27 +458,33 @@ __intrinsic
  matrix<T,N,M> ddy(matrix<T,N,M> x);
 
 __generic<T : __BuiltinFloatingPointType>
+__glsl_extension(GL_ARB_derivative_control)
 __intrinsic(glsl, dFdyCoarse)
 __intrinsic
 T ddy_coarse(T x);
 __generic<T : __BuiltinFloatingPointType, let N : int>
+__glsl_extension(GL_ARB_derivative_control)
 __intrinsic(glsl, dFdyCoarse)
 __intrinsic
 vector<T,N> ddy_coarse(vector<T,N> x);
 __generic<T : __BuiltinFloatingPointType, let N : int, let M : int>
+__glsl_extension(GL_ARB_derivative_control)
 __intrinsic(glsl, dFdyCoarse)
 __intrinsic
 matrix<T,N,M> ddy_coarse(matrix<T,N,M> x);
 
 __generic<T : __BuiltinFloatingPointType>
+__glsl_extension(GL_ARB_derivative_control)
 __intrinsic(glsl, dFdyFine)
 __intrinsic
 T ddy_fine(T x);
 __generic<T : __BuiltinFloatingPointType, let N : int>
+__glsl_extension(GL_ARB_derivative_control)
 __intrinsic(glsl, dFdyFine)
 __intrinsic
 vector<T,N> ddy_fine(vector<T,N> x);
 __generic<T : __BuiltinFloatingPointType, let N : int, let M : int>
+__glsl_extension(GL_ARB_derivative_control)
 __intrinsic(glsl, dFdyFine)
 __intrinsic
 matrix<T,N,M> ddy_fine(matrix<T,N,M> x);


### PR DESCRIPTION
- When assigning tuples `(a0, ...) = (b0, ...)` generate a tuple of assignments `(a0 = b0, ...)`

- Given an expression statement on a tuple `(a0, ...);` generate a sequence of statements `a0; ...`