### PR TITLE
An array of resources in Vulkan only consumes one binding

### DIFF
--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -1053,10 +1053,30 @@ SimpleLayoutInfo GetLayoutImpl(
                 // The uniform case was already handled above
                 if( elementResourceInfo.kind == LayoutResourceKind::Uniform )
                     continue;
+
+                // In almost all cases, the resources consumed by an array
+                // will be its element count times the resources consumed
+                // by its element type. The one exception to this is
+                // arrays of resources in Vulkan GLSL, where an entire array
+                // only consumes a single descriptor-table slot.
+                //
+                // Note: We extend this logic to arbitrary arrays-of-structs,
+                // under the assumption that downstream legalization will
+                // turn those into scalarized structs-of-arrays and this
+                // logic will work out.
+                UInt arrayResourceCount = 0;
+                if (elementResourceInfo.kind == LayoutResourceKind::DescriptorTableSlot)
+                {
+                    arrayResourceCount = elementResourceInfo.count;
+                }
+                else
+                {
+                    arrayResourceCount = elementResourceInfo.count * elementCount;
+                }
             
                 typeLayout->addResourceUsage(
                     elementResourceInfo.kind,
-                    elementResourceInfo.count * elementCount);
+                    arrayResourceCount);
             }
         }
         return arrayUniformInfo;

--- a/tests/bindings/gh-84.frag
+++ b/tests/bindings/gh-84.frag
@@ -1,0 +1,35 @@
+#version 450
+//TEST:COMPARE_GLSL:
+
+// Confirm implementation of GitHub issue #84
+
+#if defined(__SLANG__)
+#define LAYOUT(X) /* empty */
+#else
+#define LAYOUT(X) layout(X)
+#endif
+
+// Array of resources: should only use up one binding
+LAYOUT(binding = 0)
+uniform texture2D t[8];
+
+// This should automatically get binding 1
+LAYOUT(binding = 1)
+uniform sampler s;
+
+LAYOUT(binding = 2)
+uniform U
+{
+	int i;
+};
+
+LAYOUT(location = 0)
+in vec2 uv;
+
+LAYOUT(location = 0)
+out vec4 color;
+
+void main()
+{
+	color = texture(sampler2D(t[i], s), uv);
+}


### PR DESCRIPTION
Fixes #84

- When computing resource usage for an array type, don't multiply the resource usage of the element type by the element count foor descriptor-table-slot resources.

- When reporting the "stride" of an array type through reflection, report the stride for descriptor table slots as zero, always.