### PR TITLE
Add support for dumping intermediates for debugging.

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -170,6 +170,13 @@ extern "C"
         SlangCompileFlags       flags);
 
     /*!
+    @brief Set whether to dump intermediate results (for debugging) or not.
+    */
+    SLANG_API void spSetDumpIntermediates(
+        SlangCompileRequest*    request,
+        int                     enable);
+
+    /*!
     @brief Sets the target for code generation.
     @param ctx The compilation context.
     @param target The code generation target. Possible values are:

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -207,6 +207,9 @@ namespace Slang
         // Compile flags to be shared by all translation units
         SlangCompileFlags compileFlags = 0;
 
+        // Should we dump intermediate results along the way, for debugging?
+        bool shouldDumpIntermediates = false;
+
         // Output stuff
         DiagnosticSink mSink;
         String mDiagnosticOutput;
@@ -277,6 +280,17 @@ namespace Slang
 
     void generateOutput(
         CompileRequest* compileRequest);
+
+    // Helper to dump intermediate output when debugging
+    void maybeDumpIntermediate(
+        CompileRequest* compileRequest,
+        void const*     data,
+        size_t          size,
+        CodeGenTarget   target);
+    void maybeDumpIntermediate(
+        CompileRequest* compileRequest,
+        char const*     text,
+        CodeGenTarget   target);
 }
 
 #endif

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -668,6 +668,14 @@ SLANG_API void spSetCompileFlags(
     REQ(request)->compileFlags = flags;
 }
 
+SLANG_API void spSetDumpIntermediates(
+    SlangCompileRequest*    request,
+    int                     enable)
+{
+    REQ(request)->shouldDumpIntermediates = enable != 0;
+}
+
+
 SLANG_API void spSetCodeGenTarget(
         SlangCompileRequest*    request,
         int target)

--- a/tools/glslang/glslang.h
+++ b/tools/glslang/glslang.h
@@ -4,10 +4,18 @@
 
 typedef void (*glslang_OutputFunc)(void const* data, size_t size, void* userData);
 
+enum
+{
+    GLSLANG_ACTION_COMPILE_GLSL_TO_SPIRV,
+    GLSLANG_ACTION_DISSASSEMBLE_SPIRV,
+};
+
 struct glslang_CompileRequest
 {
     char const*         sourcePath;
-    char const*         sourceText;
+
+    void const*         inputBegin;
+    void const*         inputEnd;
 
     glslang_OutputFunc  diagnosticFunc;
     void*               diagnosticUserData;
@@ -17,7 +25,7 @@ struct glslang_CompileRequest
 
     int                 slangStage;
 
-    bool                disassembleResult;
+    unsigned            action;
 };
 
 typedef int (*glslang_CompileFunc)(glslang_CompileRequest* request);


### PR DESCRIPTION
Calling:

    spSetDumpIntermedites(compileRequest, true);

will set up a mode where Slang tries to dump every intermediate HLSL, GLSL, DXBC, SPIR-V, etc. file it generates. If SPIR-V or DXBC is requested then we also dump assembly of those.

Right now the files are all named as `slang-<counter>.<ext>`, and get dropped in whatever the working directory is, but I'm open to ideas on how to improve that.

Note: this change introduces a new binary interface to `glslang`, so pulling it requires an updated `glslang.dll`.