### PR TITLE
Add reflection support for GLSL thread-group-size modifier

### DIFF
--- a/source/slang/modifier-defs.h
+++ b/source/slang/modifier-defs.h
@@ -111,6 +111,11 @@ SIMPLE_SYNTAX_CLASS(GLSLSetLayoutModifier        , GLSLParsedLayoutModifier)
 SIMPLE_SYNTAX_CLASS(GLSLLocationLayoutModifier   , GLSLParsedLayoutModifier)
 SIMPLE_SYNTAX_CLASS(GLSLPushConstantLayoutModifier, GLSLParsedLayoutModifier)
 
+SIMPLE_SYNTAX_CLASS(GLSLLocalSizeLayoutModifier,    GLSLUnparsedLayoutModifier)
+SIMPLE_SYNTAX_CLASS(GLSLLocalSizeXLayoutModifier,    GLSLLocalSizeLayoutModifier)
+SIMPLE_SYNTAX_CLASS(GLSLLocalSizeYLayoutModifier,    GLSLLocalSizeLayoutModifier)
+SIMPLE_SYNTAX_CLASS(GLSLLocalSizeZLayoutModifier,    GLSLLocalSizeLayoutModifier)
+
 // A catch-all for single-keyword modifiers
 SIMPLE_SYNTAX_CLASS(SimpleModifier, Modifier)
 

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -748,6 +748,9 @@ namespace Slang
                     CASE(set,           GLSLSetLayoutModifier);
                     CASE(location,      GLSLLocationLayoutModifier);
                     CASE(push_constant, GLSLPushConstantLayoutModifier);
+                    CASE(local_size_x,  GLSLLocalSizeXLayoutModifier);
+                    CASE(local_size_y,  GLSLLocalSizeYLayoutModifier);
+                    CASE(local_size_z,  GLSLLocalSizeZLayoutModifier);
 
                 #undef CASE
                     else

--- a/tests/reflection/thread-group-size.comp
+++ b/tests/reflection/thread-group-size.comp
@@ -1,0 +1,18 @@
+//TEST:SIMPLE:-no-checking -target reflection-json
+
+// Confirm that we provide reflection data for the `local_size_*` attributes
+
+layout(local_size_x = 3) in;
+
+layout(local_size_y = 5, local_size_z = 7) in;
+
+buffer B
+{
+	float b[];	
+};
+
+void main()
+{
+	uint tid = gl_GlobalInvocationID.x;
+	b[tid] = b[tid + 1] + 1.0f;
+}

--- a/tests/reflection/thread-group-size.comp.expected
+++ b/tests/reflection/thread-group-size.comp.expected
@@ -1,0 +1,42 @@
+result code = 0
+standard error = {
+}
+standard output = {
+{
+    "parameters": [
+        {
+            "name": "B",
+            "binding": {"kind": "descriptorTableSlot", "index": 0},
+            "type": {
+                "kind": "shaderStorageBuffer",
+                "elementType": {
+                    "kind": "struct",
+                    "fields": [
+                        {
+                            "name": "b",
+                            "type": {
+                                "kind": "array",
+                                "elementCount": 0,
+                                "elementType": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                }
+                            },
+                            "bindings": [
+
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "compute",
+            "threadGroupSize": [3, 5, 7]
+        }
+    ]
+}
+}

--- a/tests/reflection/thread-group-size.hlsl
+++ b/tests/reflection/thread-group-size.hlsl
@@ -1,0 +1,11 @@
+//TEST:SIMPLE:-profile cs_5_0 -target reflection-json
+
+// Confirm that we provide reflection data for the `numthreads` attribute
+
+RWStructuredBuffer<float> b;
+
+[numthreads(3,5,7)]
+void main(uint3 tid : SV_DispatchThreadID)
+{
+	b[tid.x] = b[tid.x + 1] + 1.0f;
+}

--- a/tests/reflection/thread-group-size.hlsl.expected
+++ b/tests/reflection/thread-group-size.hlsl.expected
@@ -1,0 +1,39 @@
+result code = 0
+standard error = {
+}
+standard output = {
+{
+    "parameters": [
+        {
+            "name": "b",
+            "binding": {"kind": "unorderedAccess", "index": 0},
+            "type": {
+                "kind": "resource",
+                "baseShape": "structuredBuffer",
+                "access": "readWrite"
+            }
+        }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "compute",
+            "parameters": [
+                {
+                    "name": "tid",
+                    "binding": {"kind": "vertexInput", "index": 0},
+                    "type": {
+                        "kind": "vector",
+                        "elementCount": 3,
+                        "elementType": {
+                            "kind": "scalar",
+                            "scalarType": "uint32"
+                        }
+                    }
+                }
+            ],
+            "threadGroupSize": [3, 5, 7]
+        }
+    ]
+}
+}


### PR DESCRIPTION
Fixes #15

These are the modifiers like:

    layout(local_size_x = 16) in;

Unlike the HLSL case, these don't get attache to the entry point function itself, so there is a bit more work involed in looking them up.

Just to make sure I didn't mess up the HLSL case, I went ahead and added two tests for this capability: one for GLSL and one for HLSL.