### PR TITLE
Don't crash-fail on errors in entry point parameters

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -1495,14 +1495,28 @@ struct EmitVisitor
         outerPrec.rightPrecedence = rightPrec;
     }
 
+    void visitGenericAppExpr(GenericAppExpr* expr, ExprEmitArg const& arg)
+    {
+        auto prec = kEOp_Postfix;
+        auto outerPrec = arg.outerPrec;
+        bool needClose = MaybeEmitParens(outerPrec, prec);
 
-#define UNEXPECTED(NAME)                        \
-    void visit##NAME(NAME*, ExprEmitArg const&) \
-    { Emit(#NAME); }
+        EmitExprWithPrecedence(expr->FunctionExpr, leftSide(outerPrec, prec));
+        Emit("<");
+        bool first = true;
+        for(auto aa : expr->Arguments)
+        {
+            if(!first) Emit(", ");
+            EmitExpr(aa);
+            first = false;
+        }
+        Emit(" >");
 
-    UNEXPECTED(GenericAppExpr);
-
-#undef UNEXPECTED
+        if(needClose)
+        {
+            Emit(")");
+        }
+    }
 
     void visitSharedTypeExpr(SharedTypeExpr* expr, ExprEmitArg const&)
     {

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -994,6 +994,11 @@ static RefPtr<TypeLayout> processEntryPointParameter(
             assert(!"unimplemented");
         }
     }
+    // If we ran into an error in checking the user's code, then skip this parameter
+    else if( auto errorType = type->As<ErrorType>() )
+    {
+        return nullptr;
+    }
     else
     {
         assert(!"unimplemented");
@@ -1089,6 +1094,10 @@ static void collectEntryPointParameters(
             paramDecl->Type.type,
             state,
             paramVarLayout);
+
+        // Skip parameters for which we could not compute a layout
+        if(!paramTypeLayout)
+            continue;
 
         paramVarLayout->typeLayout = paramTypeLayout;
 

--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -264,7 +264,7 @@ __generic<T> __magic_type(HLSLLineStreamType) struct LineStream
     void RestartStrip();
 };
 
-__generic<T> __magic_type(HLSLLineStreamType) struct TriangleStream
+__generic<T> __magic_type(HLSLTriangleStreamType) struct TriangleStream
 {
     void Append(T value);
     void RestartStrip();


### PR DESCRIPTION
Fixes #105.

The root cause was an error in the shader code itself (it wasn't importing something it used), but the Slang compiler behavior around that error wasn't good (we crashed instead of letting the HLSL compiler report the issue). This change fixes up some of our behavior around bad input.