### PR TITLE
Pick correct GLSL version when `gl_Layer` used

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -3604,6 +3604,13 @@ String emitEntryPoint(
 
     auto translationUnitSyntax = translationUnit->SyntaxNode.Ptr();
 
+    // We perform lowering of the program before emitting *anything*,
+    // because the lowering process might change how we emit some
+    // boilerplate at the start of the ouput for GLSL (e.g., what
+    // version we require).
+    auto lowered = lowerEntryPoint(entryPoint, programLayout, target);
+    sharedContext.program = lowered.program;
+
 
     // There may be global-scope modifiers that we should emit now
     visitor.emitGLSLPreprocessorDirectives(translationUnitSyntax);
@@ -3624,9 +3631,6 @@ String emitEntryPoint(
         break;
     }
 
-    auto lowered = lowerEntryPoint(entryPoint, programLayout, target);
-
-    sharedContext.program = lowered.program;
 
     visitor.EmitDeclsInContainer(lowered.program.Ptr());
 

--- a/source/slang/profile.h
+++ b/source/slang/profile.h
@@ -70,6 +70,11 @@ namespace Slang
         ProfileVersion GetVersion() const { return ProfileVersion(uint32_t(raw) & 0xFFFF); }
         ProfileFamily getFamily() const { return getProfileFamily(GetVersion()); }
 
+        void setVersion(ProfileVersion version)
+        {
+            raw = (raw & ~0xFFFF) | uint32_t(version);
+        }
+
         static Profile LookUp(char const* name);
 
         RawVal raw = Unknown;

--- a/tests/cross-compile/gl-layer-pick-version.slang
+++ b/tests/cross-compile/gl-layer-pick-version.slang
@@ -1,0 +1,11 @@
+//TEST:CROSS_COMPILE: -profile ps_5_0 -entry main -target spirv-assembly
+
+struct VS_OUT
+{
+	nointerpolation uint layerID : SV_RenderTargetArrayIndex;	
+};
+
+float4 main(VS_OUT vsOut) : SV_Target
+{
+	return float4(float(vsOut.layerID));
+}

--- a/tests/cross-compile/gl-layer-pick-version.slang.glsl
+++ b/tests/cross-compile/gl-layer-pick-version.slang.glsl
@@ -1,0 +1,25 @@
+//TEST_IGNORE_FILE:
+#version 430
+
+struct VS_OUT
+{
+	uint layerID;
+};
+
+vec4 main_(VS_OUT vsOut) : SV_Target
+{
+	return vec4(float(vsOut.layerID));
+}
+
+out vec4 SLANG_out_main_result;
+
+void main()
+{
+	VS_OUT vsOut;
+	vsOut.layerID = gl_Layer;
+
+	vec4 main_result;
+	main_result = main_(vsOut);
+
+	SLANG_out_main_result = main_result;
+}


### PR DESCRIPTION
`gl_Layer` as a fragment input requires at least version 4.30 of GLSL, so we try to track that information when we see the name used.

Note that this does *not* override a user-specified `#version` line.

This required re-ordering when lowering happens relative to emitting the `#version` directive, since this code works by actually modifying the chosen profile for the entry point.
Yes, that is kind of gross and we should do something cleaner in the long term.