### PR TITLE
Handle `Buffer` types more like textures

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -771,6 +771,7 @@ struct EmitVisitor
         case TextureType::Shape2D:		Emit("Texture2D");		break;
         case TextureType::Shape3D:		Emit("Texture3D");		break;
         case TextureType::ShapeCube:	Emit("TextureCube");	break;
+        case TextureType::ShapeBuffer:  Emit("Buffer");         break;
         default:
             assert(!"unreachable");
             break;

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -123,10 +123,6 @@ SLANG_API SlangTypeKind spReflectionType_GetKind(SlangReflectionType* inType)
         return SLANG_TYPE_KIND_RESOURCE;    \
     } while(0)
 
-    CASE(HLSLBufferType);
-    CASE(HLSLRWBufferType);
-    CASE(HLSLBufferType);
-    CASE(HLSLRWBufferType);
     CASE(HLSLStructuredBufferType);
     CASE(HLSLRWStructuredBufferType);
     CASE(HLSLAppendStructuredBufferType);
@@ -342,10 +338,6 @@ SLANG_API SlangResourceShape spReflectionType_GetResourceShape(SlangReflectionTy
         return SHAPE;               \
     } while(0)
 
-    CASE(HLSLBufferType,                    SLANG_TEXTURE_BUFFER, SLANG_RESOURCE_ACCESS_READ);
-    CASE(HLSLRWBufferType,                  SLANG_TEXTURE_BUFFER, SLANG_RESOURCE_ACCESS_READ_WRITE);
-    CASE(HLSLBufferType,                    SLANG_TEXTURE_BUFFER, SLANG_RESOURCE_ACCESS_READ);
-    CASE(HLSLRWBufferType,                  SLANG_TEXTURE_BUFFER, SLANG_RESOURCE_ACCESS_READ_WRITE);
     CASE(HLSLStructuredBufferType,          SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_READ);
     CASE(HLSLRWStructuredBufferType,        SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_READ_WRITE);
     CASE(HLSLAppendStructuredBufferType,    SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_APPEND);
@@ -379,10 +371,6 @@ SLANG_API SlangResourceAccess spReflectionType_GetResourceAccess(SlangReflection
         return ACCESS;              \
     } while(0)
 
-    CASE(HLSLBufferType,                    SLANG_TEXTURE_BUFFER, SLANG_RESOURCE_ACCESS_READ);
-    CASE(HLSLRWBufferType,                  SLANG_TEXTURE_BUFFER, SLANG_RESOURCE_ACCESS_READ_WRITE);
-    CASE(HLSLBufferType,                    SLANG_TEXTURE_BUFFER, SLANG_RESOURCE_ACCESS_READ);
-    CASE(HLSLRWBufferType,                  SLANG_TEXTURE_BUFFER, SLANG_RESOURCE_ACCESS_READ_WRITE);
     CASE(HLSLStructuredBufferType,          SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_READ);
     CASE(HLSLRWStructuredBufferType,        SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_READ_WRITE);
     CASE(HLSLAppendStructuredBufferType,    SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_APPEND);
@@ -418,11 +406,6 @@ SLANG_API SlangReflectionType* spReflectionType_GetResourceResultType(SlangRefle
     else if(type->As<TYPE>()) do {                                                      \
         return convert(type->As<TYPE>()->elementType.Ptr());                            \
     } while(0)
-
-    CASE(HLSLBufferType,                    SLANG_TEXTURE_BUFFER, SLANG_RESOURCE_ACCESS_READ);
-    CASE(HLSLRWBufferType,                  SLANG_TEXTURE_BUFFER, SLANG_RESOURCE_ACCESS_READ_WRITE);
-    CASE(HLSLBufferType,                    SLANG_TEXTURE_BUFFER, SLANG_RESOURCE_ACCESS_READ);
-    CASE(HLSLRWBufferType,                  SLANG_TEXTURE_BUFFER, SLANG_RESOURCE_ACCESS_READ_WRITE);
 
     // TODO: structured buffer needs to expose type layout!
 

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -421,13 +421,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
             CASE(GLSLOutputParameterBlockType, GLSLOutputParameterBlockType)
             CASE(GLSLShaderStorageBufferType, GLSLShaderStorageBufferType)
 
-            CASE(PackedBuffer, PackedBufferType)
-            CASE(Uniform, UniformBufferType)
-            CASE(Patch, PatchType)
-
-            CASE(HLSLBufferType, HLSLBufferType)
             CASE(HLSLStructuredBufferType, HLSLStructuredBufferType)
-            CASE(HLSLRWBufferType, HLSLRWBufferType)
             CASE(HLSLRWStructuredBufferType, HLSLRWStructuredBufferType)
             CASE(HLSLAppendStructuredBufferType, HLSLAppendStructuredBufferType)
             CASE(HLSLConsumeStructuredBufferType, HLSLConsumeStructuredBufferType)

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -361,14 +361,12 @@ struct HLSLObjectLayoutRulesImpl : ObjectLayoutRulesImpl
 
         case ShaderParameterKind::TextureUniformBuffer:
         case ShaderParameterKind::StructuredBuffer:
-        case ShaderParameterKind::SampledBuffer:
         case ShaderParameterKind::RawBuffer:
         case ShaderParameterKind::Buffer:
         case ShaderParameterKind::Texture:
             return SimpleLayoutInfo(LayoutResourceKind::ShaderResource, 1);
 
         case ShaderParameterKind::MutableStructuredBuffer:
-        case ShaderParameterKind::MutableSampledBuffer:
         case ShaderParameterKind::MutableRawBuffer:
         case ShaderParameterKind::MutableBuffer:
         case ShaderParameterKind::MutableTexture:
@@ -1041,8 +1039,6 @@ SimpleLayoutInfo GetLayoutImpl(
             type, rules, outTypeLayout);                        \
     } while(0)
 
-    CASE(HLSLBufferType,                    SampledBuffer);
-    CASE(HLSLRWBufferType,                  MutableSampledBuffer);
     CASE(HLSLByteAddressBufferType,         RawBuffer);
     CASE(HLSLRWByteAddressBufferType,       MutableRawBuffer);
 

--- a/source/slang/type-layout.h
+++ b/source/slang/type-layout.h
@@ -403,9 +403,6 @@ enum class ShaderParameterKind
     StructuredBuffer,
     MutableStructuredBuffer,
 
-    SampledBuffer,
-    MutableSampledBuffer,
-
     RawBuffer,
     MutableRawBuffer,
 


### PR DESCRIPTION
Fixes #94

We'd been handling HLSL `Buffer` and `RWBuffer` in a one-off fashion, and that led to a lot of code duplication, and also to the issue that we weren't handling `RasterizerOrderedBuffer` at all.

This change basically folds `Buffer` in so that it is conceptually a texture type (just with a unique shape). Hopefully all the other logic still works.