### PR TITLE
Make sure to treat imported modules as Slang

### DIFF
--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -1177,6 +1177,9 @@ static void collectModuleParameters(
 
     context->stage = Stage::Unknown;
 
+    // All imported modules are implicitly Slang code
+    context->sourceLanguage = SourceLanguage::Slang;
+
     // A loaded module cannot define entry points that
     // we'll expose (for now), so we just need to
     // consider global-scope parameters.


### PR DESCRIPTION
- When generating parameter binding/reflection info, treated imported modules as Slang code, instead of the source language of the outer translation unit

- This fixes an issue where global-scope shader parameters in a `.slang` file were getting ignored for binding-generation purposes when imported by a GLSL file