### PR TITLE
Falcor shadow fixes

### DIFF
--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -4801,6 +4801,12 @@ namespace Slang
             return expr;
         }
 
+        RefPtr<ExpressionSyntaxNode> visitAggTypeCtorExpr(AggTypeCtorExpr* expr)
+        {
+            assert(!"unexpected");
+            return expr;
+        }
+
         //
         //
         //

--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -287,6 +287,9 @@ DIAGNOSTIC(39999, Error, tooManyArguments, "too many arguments to call (got $0, 
 DIAGNOSTIC(39999, Error, invalidIntegerLiteralSuffix, "invalid suffix '$0' on integer literal")
 DIAGNOSTIC(39999, Error, invalidFloatingPOintLiteralSuffix, "invalid suffix '$0' on floating-point literal")
 
+DIAGNOSTIC(39999, Error, conflictingExplicitBindingsForParameter, "conflicting explicit bindings for parameter '$0'")
+DIAGNOSTIC(39999, Error, parameterBindingsOverlap, "explicit parameter bindings overlap for parameters '$0' and '$1'")
+
 //
 // 4xxxx - IL code generation.
 //

--- a/source/slang/expr-defs.h
+++ b/source/slang/expr-defs.h
@@ -56,11 +56,21 @@ SYNTAX_CLASS(InitializerListExpr, ExpressionSyntaxNode)
     SYNTAX_FIELD(List<RefPtr<ExpressionSyntaxNode>>, args)
 END_SYNTAX_CLASS()
 
+// A base class for expressions with arguments
+ABSTRACT_SYNTAX_CLASS(ExprWithArgsBase, ExpressionSyntaxNode)
+    SYNTAX_FIELD(List<RefPtr<ExpressionSyntaxNode>>, Arguments)
+END_SYNTAX_CLASS()
+
+// An aggregate type constructor
+SYNTAX_CLASS(AggTypeCtorExpr, ExprWithArgsBase)
+    SYNTAX_FIELD(TypeExp, base);
+END_SYNTAX_CLASS()
+
+
 // A base expression being applied to arguments: covers
 // both ordinary `()` function calls and `<>` generic application
-ABSTRACT_SYNTAX_CLASS(AppExprBase, ExpressionSyntaxNode)
+ABSTRACT_SYNTAX_CLASS(AppExprBase, ExprWithArgsBase)
     SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, FunctionExpr)
-    SYNTAX_FIELD(List<RefPtr<ExpressionSyntaxNode>>, Arguments)
 END_SYNTAX_CLASS()
 
 SIMPLE_SYNTAX_CLASS(InvokeExpressionSyntaxNode, AppExprBase)

--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -1808,13 +1808,19 @@ namespace Slang
 
                         for(auto kk : kGatherComponets)
                         {
+                            auto componentIndex = kk.componentIndex;
                             auto componentName = kk.componentName;
 
                             EMIT_LINE_DIRECTIVE();
+                            
+                            sb << "__intrinsic(glsl, \"textureGather($p, $1, " << componentIndex << ")\")\n";
+                            sb << "__intrinsic\n";
                             sb << "vector<T, 4> Gather" << componentName << "(SamplerState s, ";
                             sb << "float" << kBaseTextureTypes[tt].coordCount << " location);\n";
 
                             EMIT_LINE_DIRECTIVE();
+                            sb << "__intrinsic(glsl, \"textureGatherOffset($p, $1, $2, " << componentIndex << ")\")\n";
+                            sb << "__intrinsic\n";
                             sb << "vector<T, 4> Gather" << componentName << "(SamplerState s, ";
                             sb << "float" << kBaseTextureTypes[tt].coordCount << " location, ";
                             sb << "int" << kBaseTextureTypes[tt].coordCount << " offset);\n";
@@ -1826,6 +1832,8 @@ namespace Slang
                             sb << "out uint status);\n";
 
                             EMIT_LINE_DIRECTIVE();
+                            sb << "__intrinsic(glsl, \"textureGatherOffsets($p, $1, int" << kBaseTextureTypes[tt].coordCount << "[]($2, $3, $4, $5), " << componentIndex << ")\")\n";
+                            sb << "__intrinsic\n";
                             sb << "vector<T, 4> Gather" << componentName << "(SamplerState s, ";
                             sb << "float" << kBaseTextureTypes[tt].coordCount << " location, ";
                             sb << "int" << kBaseTextureTypes[tt].coordCount << " offset1, ";

--- a/tests/reflection/thread-group-size.hlsl.expected
+++ b/tests/reflection/thread-group-size.hlsl.expected
@@ -21,7 +21,9 @@ standard output = {
             "parameters": [
                 {
                     "name": "tid",
-                    "binding": {"kind": "vertexInput", "index": 0},
+                    "bindings": [
+
+                    ],
                     "type": {
                         "kind": "vector",
                         "elementCount": 3,

--- a/tests/rewriter/varying-struct.slang
+++ b/tests/rewriter/varying-struct.slang
@@ -1,0 +1,21 @@
+//TEST_IGNORE_FILE:
+
+struct VS_IN
+{
+	float4 x : X;
+	float4 y : Y;	
+};
+
+struct VS_OUT
+{
+	float4 color : COLOR;
+	float4 posH : SV_Position;
+};
+
+VS_OUT doIt(VS_IN i)
+{
+	VS_OUT o;
+	o.color = i.x;
+	o.posH = i.y;
+	return o;
+}

--- a/tests/rewriter/varying-struct.vert
+++ b/tests/rewriter/varying-struct.vert
@@ -1,0 +1,54 @@
+#version 450 core
+//TEST:COMPARE_GLSL:
+
+#if defined(__SLANG__)
+
+__import varying_struct;
+
+in VS_IN foo;
+out VS_OUT bar;
+
+void main()
+{
+    bar = doIt(foo);
+}
+
+#else
+
+struct VS_IN
+{
+	vec4 x;
+	vec4 y;	
+};
+
+struct VS_OUT
+{
+	vec4 color;
+	vec4 posH;
+};
+
+VS_OUT doIt(VS_IN i)
+{
+	VS_OUT o;
+	o.color = i.x;
+	o.posH = i.y;
+	return o;
+}
+
+layout(location = 0)
+out vec4 SLANG_out_bar_color;
+
+layout(location = 0)
+in vec4 SLANG_in_foo_x;
+
+layout(location = 1)
+in vec4 SLANG_in_foo_y;
+
+void main()
+{
+	VS_OUT SLANG_tmp_0 = doIt(VS_IN(SLANG_in_foo_x, SLANG_in_foo_y));
+	SLANG_out_bar_color = SLANG_tmp_0.color;
+	gl_Position = SLANG_tmp_0.posH;
+}
+
+#endif


### PR DESCRIPTION
This is a bunch of fixes for issues I encountered while trying to run the Falcor VK "Shadows" sample.

The main interesting fix here is support for global-scope varying input/output with `struct` types that include system-value semantics on fields.