### PR TITLE
Fixes for how parameter block names are set up.

### DIFF
--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -1126,15 +1126,15 @@ namespace Slang
     }
 
 
-    static String GenerateName(Parser* /*parser*/, String const& base)
+    static String generateName(Parser* /*parser*/, String const& base)
     {
         // TODO: somehow mangle the name to avoid clashes
-        return base;
+        return "SLANG_" + base;
     }
 
-    static String GenerateName(Parser* parser)
+    static String generateName(Parser* parser)
     {
-        return GenerateName(parser, "_anonymous_" + String(parser->anonymousCounter++));
+        return generateName(parser, "anonymous_" + String(parser->anonymousCounter++));
     }
 
 
@@ -1149,7 +1149,7 @@ namespace Slang
         if( declaratorInfo.nameToken.Type == TokenType::Unknown )
         {
             // HACK(tfoley): we always give a name, even if the declarator didn't include one... :(
-            decl->Name.Content = GenerateName(parser);
+            decl->Name.Content = generateName(parser);
         }
         else
         {
@@ -1791,8 +1791,8 @@ namespace Slang
         addModifier(bufferVarDecl, reflectionNameModifier);
 
         // Both the buffer variable and its type need to have names generated
-        bufferVarDecl->Name.Content = GenerateName(parser, "SLANG_constantBuffer_" + reflectionNameToken.Content);
-        bufferDataTypeDecl->Name.Content = GenerateName(parser, "SLANG_ConstantBuffer_" + reflectionNameToken.Content);
+        bufferVarDecl->Name.Content = generateName(parser, "parameterBlock_" + reflectionNameToken.Content);
+        bufferDataTypeDecl->Name.Content = generateName(parser, "ParameterBlock_" + reflectionNameToken.Content);
 
         addModifier(bufferDataTypeDecl, new ImplicitParameterBlockElementTypeModifier());
         addModifier(bufferVarDecl, new ImplicitParameterBlockVariableModifier());
@@ -1948,7 +1948,7 @@ namespace Slang
         parser->FillPosition(blockVarDecl.Ptr());
 
         // Generate a unique name for the data type
-        blockDataTypeDecl->Name.Content = GenerateName(parser, "SLANG_ParameterBlock_" + reflectionNameToken.Content);
+        blockDataTypeDecl->Name.Content = generateName(parser, "ParameterBlock_" + reflectionNameToken.Content);
 
         // TODO(tfoley): We end up constructing unchecked syntax here that
         // is expected to type check into the right form, but it might be
@@ -1993,7 +1993,7 @@ namespace Slang
         else
         {
             // synthesize a dummy name
-            blockVarDecl->Name.Content = GenerateName(parser, "SLANG_parameterBlock_" + reflectionNameToken.Content);
+            blockVarDecl->Name.Content = generateName(parser, "parameterBlock_" + reflectionNameToken.Content);
 
             // Otherwise we have a transparent declaration, similar
             // to an HLSL `cbuffer`


### PR DESCRIPTION
We generate implicit names for global-scope parameter blocks (including HLSL `cbuffer`s, since the "name" the user sees is really just for reflection purposes), but this had a few problems:

- We used the generated names for parameter-binding purposes
  - Except for a GLSL block with an explicit name, in which case we'd use the internal name and not the reflection name for matching

- The generated named didn't match between GLSL and HLSL/Slang declarations

This change tries to fix both of these issues. I changed the name generation to try to make it identical between HLSL and GLSL (to the extent we can control it), just in case. But then I also went and changed the parameter-binding-generation logic to use the *reflection* name instead of the internal name when deciding if things are the "same" parameter.