### PR TITLE
Build a dynamic library for Slang

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -2,7 +2,7 @@
 #define SLANG_H
 
 #ifdef _MSC_VER
-#ifdef SLANG_COMPILING_DLL
+#ifdef SLANG_DYNAMIC_EXPORT
 #define SLANG_API __declspec(dllexport)
 #else
 #ifdef SLANG_DYNAMIC

--- a/slang.sln
+++ b/slang.sln
@@ -13,12 +13,15 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "slang", "source\slang\slang.vcxproj", "{DB00DA62-0533-4AFD-B59F-A67D5B3A0808}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "slangc", "source\slangc\slangc.vcxproj", "{D56CBCEB-1EB5-4CA8-AEC4-48EA35ED61C7}"
+	ProjectSection(ProjectDependencies) = postProject
+		{C495878A-832C-485B-B347-0998A90CC936} = {C495878A-832C-485B-B347-0998A90CC936}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "slang-test", "tools\slang-test\slang-test.vcxproj", "{0C768A18-1D25-4000-9F37-DA5FE99E3B64}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "render-test", "tools\render-test\render-test.vcxproj", "{96610759-07B9-4EEB-A974-5C634A2E742B}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "glslang", "tools\glslang\glslang.vcxproj", "{C495878A-832C-485B-B347-0998A90CC936}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "slang-glslang", "source\slang-glslang\slang-glslang.vcxproj", "{C495878A-832C-485B-B347-0998A90CC936}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -92,6 +95,5 @@ Global
 		{E6385042-1649-4803-9EBD-168F8B7EF131} = {B625E3E2-3B0B-4A01-9D10-957F84092E10}
 		{0C768A18-1D25-4000-9F37-DA5FE99E3B64} = {74C5F0DC-93BB-4BF3-AC65-8C65491570F7}
 		{96610759-07B9-4EEB-A974-5C634A2E742B} = {74C5F0DC-93BB-4BF3-AC65-8C65491570F7}
-		{C495878A-832C-485B-B347-0998A90CC936} = {74C5F0DC-93BB-4BF3-AC65-8C65491570F7}
 	EndGlobalSection
 EndGlobal

--- a/source/slang-glslang/slang-glslang.cpp
+++ b/source/slang-glslang/slang-glslang.cpp
@@ -1,5 +1,5 @@
-// glslang.cpp
-#include "glslang.h"
+// slang-glslang.cpp
+#include "slang-glslang.h"
 
 
 #include "StandAlone/ResourceLimits.h"

--- a/source/slang-glslang/slang-glslang.h
+++ b/source/slang-glslang/slang-glslang.h
@@ -1,6 +1,6 @@
-// glslang.h
-#ifndef GLSLANG_H_INCLUDED
-#define GLSLANG_H_INCLUDED
+// slang-glslang.h
+#ifndef SLANG_GLSLANG_H_INCLUDED
+#define SLANG_GLSLANG_H_INCLUDED
 
 typedef void (*glslang_OutputFunc)(void const* data, size_t size, void* userData);
 

--- a/source/slang-glslang/slang-glslang.vcxproj
+++ b/source/slang-glslang/slang-glslang.vcxproj
@@ -21,8 +21,9 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C495878A-832C-485B-B347-0998A90CC936}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>glslang</RootNamespace>
+    <RootNamespace>slang_glslang</RootNamespace>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <ProjectName>slang-glslang</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -189,7 +190,7 @@
     <ClCompile Include="..\..\external\glslang\SPIRV\SPVRemapper.cpp" />
     <ClCompile Include="..\..\external\glslang\StandAlone\ResourceLimits.cpp" />
     <ClCompile Include="..\..\external\glslang\StandAlone\StandAlone.cpp" />
-    <ClCompile Include="glslang.cpp" />
+    <ClCompile Include="slang-glslang.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\external\glslang\glslang\MachineIndependent\glslang_tab.cpp.h" />
@@ -227,7 +228,7 @@
     <ClInclude Include="..\..\external\glslang\SPIRV\SPVRemapper.h" />
     <ClInclude Include="..\..\external\glslang\StandAlone\ResourceLimits.h" />
     <ClInclude Include="..\..\external\glslang\StandAlone\Worklist.h" />
-    <ClInclude Include="glslang.h" />
+    <ClInclude Include="slang-glslang.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/source/slang-glslang/slang-glslang.vcxproj.filters
+++ b/source/slang-glslang/slang-glslang.vcxproj.filters
@@ -132,7 +132,7 @@
     <ClCompile Include="..\..\external\glslang\SPIRV\SPVRemapper.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="glslang.cpp" />
+    <ClCompile Include="slang-glslang.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\external\glslang\glslang\MachineIndependent\gl_types.h">
@@ -240,7 +240,7 @@
     <ClInclude Include="..\..\external\glslang\SPIRV\SPVRemapper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="glslang.h">
+    <ClInclude Include="slang-glslang.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/source/slang/compiler.cpp
+++ b/source/slang/compiler.cpp
@@ -14,7 +14,7 @@
 #include "emit.h"
 
 // Utilities for pass-through modes
-#include "../../tools/glslang/glslang.h"
+#include "../slang-glslang/slang-glslang.h"
 
 
 #ifdef _WIN32
@@ -354,7 +354,7 @@ namespace Slang
     HMODULE getGLSLCompilerDLL()
     {
         // TODO(tfoley): let user specify version of glslang DLL to use.
-        static HMODULE glslCompiler =  LoadLibraryA("glslang");
+        static HMODULE glslCompiler =  LoadLibraryA("slang-glslang");
         // TODO(tfoley): handle case where we can't find it gracefully
         assert(glslCompiler);
         return glslCompiler;

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -27,26 +27,26 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -90,7 +90,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>SLANG_DYNAMIC;SLANG_DYNAMIC_EXPORT;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
@@ -106,7 +106,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>SLANG_DYNAMIC;SLANG_DYNAMIC_EXPORT;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <BrowseInformation>true</BrowseInformation>
@@ -128,7 +128,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>SLANG_DYNAMIC;SLANG_DYNAMIC_EXPORT;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
@@ -148,7 +148,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>SLANG_DYNAMIC;SLANG_DYNAMIC_EXPORT;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
@@ -217,6 +217,11 @@
     <ClCompile Include="syntax.cpp" />
     <ClCompile Include="token.cpp" />
     <ClCompile Include="type-layout.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\core\core.vcxproj">
+      <Project>{f9be7957-8399-899e-0c49-e714fddd4b65}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -1,5 +1,6 @@
 ﻿// main.cpp
 
+#define SLANG_DYNAMIC
 #include "../slang.h"
 
 #include "core/slang-io.h"


### PR DESCRIPTION
- Change the `slang` project from a static library to a dynamic one

- Add some details around `slang.h` to make sure DLL export stuff is working

- Make the `slangc` executable use the dynamic library

- Rename the `glslang` sub-project to `slang-glslang` and move it into the main source hierarchy
  - This reflects the fact that it isn't a stand-alone tool, and isn't in any way a standard binary of glslang, but rather just an artifact of how Slang uses glslang