### PR TITLE
Use AppVeyor to deploy to GitHub Releases

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,18 @@
 # Our solution file is currently set up for VS2015
 image: Visual Studio 2015
 
+init:
+  # Construct a version number suitable for using as a release name
+  - ps: >-
+      if ($env:APPVEYOR_REPO_TAG -eq "true")
+      {
+        $env:SLANG_VERSION = "$($env:APPVEYOR_REPO_TAG_NAME.TrimStart("v"))"
+      }
+      else
+      {
+        $env:SLANG_VERSION = "dev-$($env:APPVEYOR_REPO_COMMIT.Substring(0, 7))"
+      }
+
 # The project uses a submodule for the "glslang" dependency,
 # so we need to make sure to pull that before building.
 install:
@@ -8,9 +20,11 @@ install:
 
 # We want to build the full matrix of platforms and configurations
 # that we support on Windows.
+#
+# Put Release|x64 first since that is the target which runs the most tests.
 platform:
-  - Win32
   - x64
+  - Win32
 
 configuration:
   - Release
@@ -54,6 +68,49 @@ test_script:
       }
       .\test.bat -platform %PLATFORM% -configuration %CONFIGURATION% -appveyor -category $testCategory
 
-# TODO: need to figure out what we want to package for deployment
+# Package up the stuff we want to deploy into a single .zip file
 
-# TODO: on a successful build of a tag, push to GitHub releases
+after_build:
+  - ps: |
+      if ($env:PLATFORM -eq "x64")
+      {
+        $env:SLANG_DEPLOY_PLATFORM = "win64"
+      }
+      else
+      {
+        $env:SLANG_DEPLOY_PLATFORM = "win32"
+      }
+      $env:SLANG_BINARY_ARCHIVE = "slang-$($env:SLANG_VERSION)-$($env:SLANG_DEPLOY_PLATFORM).zip"
+      $env:SLANG_SOURCE_ARCHIVE = "slang-$($env:SLANG_VERSION)-source.zip"
+      7z a "$env:SLANG_BINARY_ARCHIVE" slang.h
+      7z a "$env:SLANG_BINARY_ARCHIVE" bin\*\*\slang.dll
+      7z a "$env:SLANG_BINARY_ARCHIVE" bin\*\*\slang.lib
+      7z a "$env:SLANG_BINARY_ARCHIVE" bin\*\*\slang-glslang.dll
+      7z a "$env:SLANG_BINARY_ARCHIVE" bin\*\*\slangc.exe
+      7z a "$env:SLANG_SOURCE_ARCHIVE" slang.h
+      7z a "$env:SLANG_SOURCE_ARCHIVE" source\*\*.h
+      7z a "$env:SLANG_SOURCE_ARCHIVE" source\*\*.cpp
+
+# Register the created .zip file as an artifact with AppVeyor
+
+artifacts:
+  - path: $(SLANG_BINARY_ARCHIVE)
+    name: binary_archive
+  - path: $(SLANG_SOURCE_ARCHIVE)
+    name: source_archive
+
+# On a successful build of a tag, push archices to GitHub releases
+
+deploy:
+  release: v$(SLANG_VERSION)
+  description: 'Slang $(SLANG_VERSION)'
+  provider: GitHub
+  auth_token:
+    secure: +FukP7TA9F+fofZRZnu2FSqPcrQ1u4r8r4pl+/83owiY6M1R4ykg+8RcSzXi2f63
+  artifact: 'binary_archive,source_archive'
+  draft: false
+  prerelease: false
+  force_update: true # TODO: consider if we can avoid this
+  on:
+    configuration: Release
+    appveyor_repo_tag: true        # deploy on tag push only

--- a/build/slang-build.props
+++ b/build/slang-build.props
@@ -3,8 +3,8 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <OutDir>$(SolutionDir)bin\$(PlatformShortName)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)intermediate\$(PlatformShortName)\$(Configuration)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)bin\windows-$(PlatformShortName)\$(Configuration.ToLower())\</OutDir>
+    <IntDir>$(SolutionDir)intermediate\windows-$(PlatformShortName)\$(Configuration.ToLower())\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup />
   <ItemGroup />

--- a/test.bat
+++ b/test.bat
@@ -31,6 +31,9 @@ if "%1"=="-configuration" (
 
 :: When done with arguments, we'll just fall through here
 
+
+
+
 :: Set root directory to the directory where `test.bat` resides
 :: (which should be the root of the source tree)
 SET "SLANG_TEST_ROOT=%~dp0"
@@ -45,7 +48,7 @@ IF "%SLANG_TEST_CONFIG%" == "" ( SET "SLANG_TEST_CONFIG=Debug" )
 IF "%SLANG_TEST_PLATFORM%"=="Win32" ( Set "SLANG_TEST_PLATFORM=x86" )
 
 :: Establish the directory where the binaries to be tested reside
-set "SLANG_TEST_BIN_DIR=%SLANG_TEST_ROOT%bin\%SLANG_TEST_PLATFORM%\%SLANG_TEST_CONFIG%\"
+set "SLANG_TEST_BIN_DIR=%SLANG_TEST_ROOT%bin\windows-%SLANG_TEST_PLATFORM%\%SLANG_TEST_CONFIG%\"
 
 :: ensure that any built tools are visible
 SET "PATH=%PATH%;%SLANG_TEST_BIN_DIR%"


### PR DESCRIPTION
- Change naming convention for output directory
  - `windows-x86` and `windows-x64`
  - Lower-case for `debug`, `release`
  - Test script needed to be patched up for this

- Add packaging and deployment logic to AppVeyor CI script
  - Trigger deployment on new tag
  - Compute a release version based on Git tag name (`vX.Y.Z` becomes `X.Y.Z`)
    - Fallback to hash in case tag isn't available (it should always be)
  - Bundle files into a few artifacts (binary package + source package)
  - Set up to push those files into existing GitHub tag/release