### PR TITLE
Try to improve handling of failures during compilation

### DIFF
--- a/source/core/common.h
+++ b/source/core/common.h
@@ -34,6 +34,35 @@ namespace Slang
 		v0 = _Move(v1);
 		v1 = _Move(tmp);
 	}
+
+#ifdef _MSC_VER
+#define SLANG_RETURN_NEVER __declspec(noreturn)
+#else
+#efine SLANG_RETURN_NEVER /* empty */
+#endif
+
+    SLANG_RETURN_NEVER void signalUnexpectedError(char const* message);
 }
+
+#define SLANG_UNEXPECTED(reason) \
+    Slang::signalUnexpectedError("unexpected: " reason)
+
+#define SLANG_UNIMPLEMENTED_X(what) \
+    Slang::signalUnexpectedError("unimplemented: " what)
+
+#define SLANG_UNREACHABLE(msg) \
+    Slang::signalUnexpectedError("unreachable code executed: " msg)
+
+#ifdef _DEBUG
+#define SLANG_EXPECT(VALUE, MSG) if(VALUE) {} else Slang::signalUnexpectedError("assertion failed: '" MSG "'")
+#define SLANG_ASSERT(VALUE) SLANG_EXPECT(VALUE, #VALUE)
+#else
+#define SLANG_EXPECT(VALUE, MSG) do {} while(0)
+#define SLANG_ASSERT(VALUE) do {} while(0)
+#endif
+
+#define SLANG_RELEASE_ASSERT(VALUE) if(VALUE) {} else Slang::signalUnexpectedError("assertion failed")
+#define SLANG_RELEASE_EXPECT(VALUE, WHAT) if(VALUE) {} else SLANG_UNEXPECTED(WHAT)
+
 
 #endif

--- a/source/core/exception.h
+++ b/source/core/exception.h
@@ -111,12 +111,16 @@ namespace Slang
 		}
 	};
 
-    #define SLANG_UNEXPECTED(reason) \
-        throw Slang::Exception("unexpected: " reason)
-
-    #define SLANG_UNIMPLEMENTED_X(what) \
-        throw Slang::NotImplementedException("unimplemented: " what)
-
+	class InternalError : public Exception
+	{
+	public:
+		InternalError()
+		{}
+		InternalError(const String & message)
+			: Exception(message)
+		{
+		}
+	};
 }
 
 #endif

--- a/source/core/slang-string.cpp
+++ b/source/core/slang-string.cpp
@@ -3,6 +3,14 @@
 
 namespace Slang
 {
+    // TODO: this belongs in a different file:
+
+    SLANG_RETURN_NEVER void signalUnexpectedError(char const* message)
+    {
+        throw InternalError(message);
+    }
+
+
     // OSString
 
     OSString::OSString()

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -1,8 +1,10 @@
 #ifndef FUNDAMENTAL_LIB_STRING_H
 #define FUNDAMENTAL_LIB_STRING_H
+
 #include <string.h>
 #include <cstdlib>
 #include <stdio.h>
+
 #include "smart-pointer.h"
 #include "common.h"
 #include "hash.h"
@@ -80,7 +82,7 @@ namespace Slang
 
         static StringRepresentation* createWithCapacityAndLength(UInt capacity, UInt length)
         {
-            assert(capacity >= length);
+            SLANG_ASSERT(capacity >= length);
             void* allocation = operator new(sizeof(StringRepresentation) + capacity + 1);
             StringRepresentation* obj = new(allocation) StringRepresentation();
             obj->capacity = capacity;

--- a/source/core/smart-pointer.h
+++ b/source/core/smart-pointer.h
@@ -1,6 +1,7 @@
 #ifndef FUNDAMENTAL_LIB_SMART_POINTER_H
 #define FUNDAMENTAL_LIB_SMART_POINTER_H
 
+#include "common.h"
 #include "type-traits.h"
 
 #include <assert.h>
@@ -36,7 +37,7 @@ namespace Slang
 
         void releaseReference()
         {
-            assert(referenceCount != 0);
+            SLANG_ASSERT(referenceCount != 0);
             if(--referenceCount == 0)
             {
                 delete this;
@@ -45,7 +46,7 @@ namespace Slang
 
         bool isUniquelyReferenced()
         {
-            assert(referenceCount != 0);
+            SLANG_ASSERT(referenceCount != 0);
             return referenceCount == 1;
         }
     };

--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -47,6 +47,7 @@ DIAGNOSTIC(    1, Error, cannotOpenFile, "cannot open file '$0'.")
 DIAGNOSTIC(    2, Error, cannotFindFile, "cannot find file '$0'.")
 DIAGNOSTIC(    2, Error, unsupportedCompilerMode, "unsupported compiler mode.")
 DIAGNOSTIC(    4, Error, cannotWriteOutputFile, "cannot write output file '$0'.")
+DIAGNOSTIC(    5, Error, failedToLoadDynamicLibrary, "failed to load dynamic library '$0'")
 
 //
 // 1xxxx - Lexical anaylsis
@@ -102,6 +103,7 @@ DIAGNOSTIC(15403, Error, expectedTokenInMacroParameters, "expected '$0' in macro
 
 // 155xx - macro expansion
 DIAGNOSTIC(15500, Warning, expectedTokenInMacroArguments, "expected '$0' in macro invocation")
+DIAGNOSTIC(15501, Error, wrongNumberOfArgumentsToMacro, "wrong number of arguments to macro (expected $0, got $1)")
 
 // 159xx - user-defined error/warning
 DIAGNOSTIC(15900, Error,    userDefinedError,   "#error: $0")
@@ -298,6 +300,10 @@ DIAGNOSTIC(40002, Error, invalidBindingValue, "binding location '$0' is out of v
 DIAGNOSTIC(40003, Error, bindingExceedsLimit, "binding location '$0' assigned to component '$1' exceeds maximum limit.")
 DIAGNOSTIC(40004, Error, bindingAlreadyOccupiedByModule, "DescriptorSet ID '$0' is already occupied by module instance '$1'.")
 DIAGNOSTIC(40005, Error, topLevelModuleUsedWithoutSpecifyingBinding, "top level module '$0' is being used without specifying binding location. Use [Binding: \"index\"] attribute to provide a binding location.")
+
+
+DIAGNOSTIC(49999, Error, unknownSystemValueSemantic, "unknown system-value semantic '$0'")
+
 //
 // 5xxxx - Target code generation.
 //
@@ -339,7 +345,9 @@ DIAGNOSTIC(51092, Error, stageDoesntHaveInputWorld, "'$0' doesn't appear to have
 
 // 99999 - Internal compiler errors, and not-yet-classified diagnostics.
 
+DIAGNOSTIC(99999, Internal, unimplemented, "unimplemented: $0")
+DIAGNOSTIC(99999, Internal, unexpected, "uuexpected: $0")
 DIAGNOSTIC(99999, Internal, internalCompilerError, "internal compiler error")
-DIAGNOSTIC(99999, Internal, unimplemented, "unimplemented feature: $0")
+DIAGNOSTIC(99999, Error, compilationAborted, "compilation aborted due to internal error");
 
 #undef DIAGNOSTIC

--- a/source/slang/diagnostics.cpp
+++ b/source/slang/diagnostics.cpp
@@ -100,7 +100,7 @@ static void formatDiagnosticMessage(StringBuilder& sb, char const* format, int a
         if (!*spanEnd)
             return;
 
-        assert(*spanEnd == '$');
+        SLANG_API(*spanEnd == '$');
         spanEnd++;
         int d = *spanEnd++;
         switch (d)

--- a/source/slang/diagnostics.h
+++ b/source/slang/diagnostics.h
@@ -206,15 +206,15 @@ namespace Slang
 #define SLANG_UNIMPLEMENTED(sink, pos, what) \
     (sink)->diagnose(Slang::CodePosition(__LINE__, 0, 0, __FILE__), Slang::Diagnostics::unimplemented, what)
 
-#define SLANG_UNREACHABLE(msg) do { assert(!"ureachable code:" msg); throw 0; } while(0)
 #else
 #define SLANG_INTERNAL_ERROR(sink, pos) \
     (sink)->diagnose(pos, Slang::Diagnostics::internalCompilerError)
 #define SLANG_UNIMPLEMENTED(sink, pos, what) \
     (sink)->diagnose(pos, Slang::Diagnostics::unimplemented, what)
 
-// TODO: find something that will perform better
-#define SLANG_UNREACHABLE(msg) exit(1)
 #endif
+
+#define SLANG_DIAGNOSE_UNEXPECTED(sink, pos, message) \
+    (sink)->diagnose(pos, Slang::Diagnostics::unexpected, message)
 
 #endif

--- a/source/slang/lexer.cpp
+++ b/source/slang/lexer.cpp
@@ -11,14 +11,14 @@ namespace Slang
 
     Token* TokenList::begin() const
     {
-        assert(mTokens.Count());
+        SLANG_ASSERT(mTokens.Count());
         return &mTokens[0];
     }
 
     Token* TokenList::end() const
     {
-        assert(mTokens.Count());
-        assert(mTokens[mTokens.Count()-1].Type == TokenType::EndOfFile);
+        SLANG_ASSERT(mTokens.Count());
+        SLANG_ASSERT(mTokens[mTokens.Count()-1].Type == TokenType::EndOfFile);
         return &mTokens[mTokens.Count() - 1];
     }
 
@@ -48,7 +48,7 @@ namespace Slang
     {
         if (mCursor == mEnd)
             return TokenType::EndOfFile;
-        assert(mCursor);
+        SLANG_ASSERT(mCursor);
         return mCursor->Type;
     }
 
@@ -56,7 +56,7 @@ namespace Slang
     {
         if (!mCursor)
             return CodePosition();
-        assert(mCursor);
+        SLANG_ASSERT(mCursor);
         return mCursor->Position;
     }
 
@@ -135,7 +135,7 @@ namespace Slang
     //
     static void handleNewLineInner(Lexer* lexer, int c)
     {
-        assert(c == '\n' || c == '\r');
+        SLANG_ASSERT(c == '\n' || c == '\r');
 
         int d = peekRaw(lexer);
         if( (c ^ d) == ('\n' ^ '\r') )
@@ -774,26 +774,26 @@ namespace Slang
 
     String getStringLiteralTokenValue(Token const& token)
     {
-        assert(token.Type == TokenType::StringLiteral
+        SLANG_ASSERT(token.Type == TokenType::StringLiteral
             || token.Type == TokenType::CharLiteral);
 
         char const* cursor = token.Content.begin();
         char const* end = token.Content.end();
 
         auto quote = *cursor++;
-        assert(quote == '\'' || quote == '"');
+        SLANG_ASSERT(quote == '\'' || quote == '"');
 
         StringBuilder valueBuilder;
         for(;;)
         {
-            assert(cursor != end);
+            SLANG_ASSERT(cursor != end);
 
             auto c = *cursor++;
 
             // If we see a closing quote, then we are at the end of the string literal
             if(c == quote)
             {
-                assert(cursor == end);
+                SLANG_ASSERT(cursor == end);
                 return valueBuilder.ProduceString();
             }
 

--- a/source/slang/options.cpp
+++ b/source/slang/options.cpp
@@ -81,7 +81,7 @@ struct OptionsParser
     {
         auto translationUnitIndex = spAddTranslationUnit(compileRequest, language, nullptr);
 
-        assert(UInt(translationUnitIndex) == rawTranslationUnits.Count());
+        SLANG_RELEASE_ASSERT(UInt(translationUnitIndex) == rawTranslationUnits.Count());
 
         RawTranslationUnit rawTranslationUnit;
         rawTranslationUnit.sourceLanguage = language;

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -7,8 +7,6 @@
 
 #include "../../slang.h"
 
-#define SLANG_EXHAUSTIVE_SWITCH() default: assert(!"unexpected"); break;
-
 namespace Slang {
 
 struct ParameterInfo;
@@ -34,8 +32,8 @@ bool operator<(UsedRange left, UsedRange right)
 
 static bool rangesOverlap(UsedRange const& x, UsedRange const& y)
 {
-    assert(x.begin <= x.end);
-    assert(y.begin <= y.end);
+    SLANG_ASSERT(x.begin <= x.end);
+    SLANG_ASSERT(y.begin <= y.end);
 
     // If they don't overlap, then one must be earlier than the other,
     // and that one must therefore *end* before the other *begins*
@@ -503,14 +501,14 @@ getTypeLayoutForGlobalShaderParameter_GLSL(
     if (auto effectiveVaryingInputType = tryGetEffectiveTypeForGLSLVaryingInput(context, varDecl))
     {
         // We expect to handle these elsewhere
-        assert(!"unexpected");
+        SLANG_DIAGNOSE_UNEXPECTED(getSink(context), varDecl, "GLSL varying input");
         return CreateTypeLayout(effectiveVaryingInputType, rules->getVaryingInputRules());
     }
 
     if (auto effectiveVaryingOutputType = tryGetEffectiveTypeForGLSLVaryingOutput(context, varDecl))
     {
         // We expect to handle these elsewhere
-        assert(!"unexpected");
+        SLANG_DIAGNOSE_UNEXPECTED(getSink(context), varDecl, "GLSL varying output");
         return CreateTypeLayout(effectiveVaryingOutputType, rules->getVaryingOutputRules());
     }
 
@@ -568,7 +566,7 @@ getTypeLayoutForGlobalShaderParameter(
         return getTypeLayoutForGlobalShaderParameter_GLSL(context, varDecl);
 
     default:
-        assert(false);
+        SLANG_UNEXPECTED("unhandled source language");
         return nullptr;
     }
 }
@@ -900,7 +898,7 @@ void generateParameterBindings(
     RefPtr<ParameterInfo>       parameterInfo)
 {
     // There must be at least one declaration for the parameter.
-    assert(parameterInfo->varLayouts.Count() != 0);
+    SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.Count() != 0);
 
     // Iterate over all declarations looking for explicit binding information.
     for( auto& varLayout : parameterInfo->varLayouts )
@@ -928,7 +926,7 @@ static void completeBindingsForParameter(
     // that earlier code has validated that the declarations
     // "match".
 
-    assert(parameterInfo->varLayouts.Count() != 0);
+    SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.Count() != 0);
     auto firstVarLayout = parameterInfo->varLayouts.First();
     auto firstTypeLayout = firstVarLayout->typeLayout;
 
@@ -1258,7 +1256,7 @@ static RefPtr<TypeLayout> processEntryPointParameter(
 
                 for (auto rr : fieldTypeLayout->resourceInfos)
                 {
-                    assert(rr.count != 0);
+                    SLANG_RELEASE_ASSERT(rr.count != 0);
 
                     auto structRes = structLayout->findOrAddResourceInfo(rr.kind);
                     fieldVarLayout->findOrAddResourceInfo(rr.kind)->index = structRes->count;
@@ -1273,7 +1271,7 @@ static RefPtr<TypeLayout> processEntryPointParameter(
         }
         else
         {
-            assert(!"unimplemented");
+            SLANG_UNEXPECTED("unhandled type kind");
         }
     }
     // If we ran into an error in checking the user's code, then skip this parameter
@@ -1281,12 +1279,8 @@ static RefPtr<TypeLayout> processEntryPointParameter(
     {
         return nullptr;
     }
-    else
-    {
-        assert(!"unimplemented");
-    }
 
-    assert(!"unexpected");
+    SLANG_UNEXPECTED("unhandled type kind");
     return nullptr;
 }
 
@@ -1545,7 +1539,7 @@ void generateParameterBindings(
     bool anyGlobalUniforms = false;
     for( auto& parameterInfo : sharedContext.parameters )
     {
-        assert(parameterInfo->varLayouts.Count() != 0);
+        SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.Count() != 0);
         auto firstVarLayout = parameterInfo->varLayouts.First();
 
         // Does the field have any uniform data?
@@ -1606,7 +1600,7 @@ void generateParameterBindings(
     UniformLayoutInfo structLayoutInfo = globalScopeRules->BeginStructLayout();
     for( auto& parameterInfo : sharedContext.parameters )
     {
-        assert(parameterInfo->varLayouts.Count() != 0);
+        SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.Count() != 0);
         auto firstVarLayout = parameterInfo->varLayouts.First();
 
         // Does the field have any uniform data?

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -848,8 +848,9 @@ namespace Slang
                             }
                             else
                             {
+                                SLANG_DIAGNOSE_UNEXPECTED(parser->sink, parser->tokenReader.PeekLoc(), "needed a modifier");
+
                                 parser->ReadToken(TokenType::Identifier);
-                                assert(!"unexpected");
                             }
                         }
                     }
@@ -1377,7 +1378,7 @@ namespace Slang
         void addDecl(
             RefPtr<Decl>    newDecl)
         {
-            assert(newDecl);
+            SLANG_ASSERT(newDecl);
             
             if( decl )
             {
@@ -1715,7 +1716,7 @@ namespace Slang
 
         RefPtr<Modifier> result;
         RefPtr<Modifier>* link = &result;
-        assert(!*link);
+        SLANG_ASSERT(!*link);
 
         for (;;)
         {
@@ -2440,7 +2441,7 @@ namespace Slang
         ParseDeclBody(this, program, TokenType::EndOfFile);
         PopScope();
 
-        assert(currentScope == outerScope);
+        SLANG_RELEASE_ASSERT(currentScope == outerScope);
         currentScope = nullptr;
     }
 

--- a/source/slang/preprocessor.cpp
+++ b/source/slang/preprocessor.cpp
@@ -705,8 +705,7 @@ static void MaybeBeginMacroExpansion(
             UInt argCount = argIndex;
             if (argCount != paramCount)
             {
-                // TODO: diagnose
-                throw 99;
+                GetSink(preprocessor)->diagnose(PeekLoc(preprocessor), Diagnostics::wrongNumberOfArgumentsToMacro, paramCount, argCount);
             }
 
             // We are ready to expand.
@@ -1006,7 +1005,7 @@ static void beginConditional(
     bool                            enable)
 {
     Preprocessor* preprocessor = context->preprocessor;
-    assert(inputStream);
+    SLANG_ASSERT(inputStream);
 
     PreprocessorConditional* conditional = CreateConditional(preprocessor);
 
@@ -1346,7 +1345,7 @@ static void HandleIfNDefDirective(PreprocessorDirectiveContext* context)
 static void HandleElseDirective(PreprocessorDirectiveContext* context)
 {
     PreprocessorInputStream* inputStream = context->preprocessor->inputStream;
-    assert(inputStream);
+    SLANG_ASSERT(inputStream);
 
     // if we aren't inside a conditional, then error
     PreprocessorConditional* conditional = inputStream->conditional;
@@ -1386,7 +1385,7 @@ static void HandleElifDirective(PreprocessorDirectiveContext* context)
     // Need to grab current input stream *before* we try to parse
     // the conditional expression.
     PreprocessorInputStream* inputStream = context->preprocessor->inputStream;
-    assert(inputStream);
+    SLANG_ASSERT(inputStream);
 
     // HACK(tfoley): handle an empty `elif` like an `else` directive
     //
@@ -1438,7 +1437,7 @@ static void HandleElifDirective(PreprocessorDirectiveContext* context)
 static void HandleEndIfDirective(PreprocessorDirectiveContext* context)
 {
     PreprocessorInputStream* inputStream = context->preprocessor->inputStream;
-    assert(inputStream);
+    SLANG_ASSERT(inputStream);
 
     // if we aren't inside a conditional, then error
     PreprocessorConditional* conditional = inputStream->conditional;

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -6,6 +6,12 @@
 
 #include <assert.h>
 
+// Don't signal errors for stuff we don't implement here,
+// and instead just try to return things defensively
+//
+// Slang developers can switch this when debugging.
+#define SLANG_REFLECTION_UNEXPECTED() do {} while(0)
+
 // Implementation to back public-facing reflection API
 
 using namespace Slang;
@@ -150,7 +156,7 @@ SLANG_API SlangTypeKind spReflectionType_GetKind(SlangReflectionType* inType)
         return SLANG_TYPE_KIND_NONE;
     }
 
-    assert(!"unexpected");
+    SLANG_REFLECTION_UNEXPECTED();
     return SLANG_TYPE_KIND_NONE;
 }
 
@@ -308,7 +314,7 @@ SLANG_API SlangScalarType spReflectionType_GetScalarType(SlangReflectionType* in
 #undef CASE
 
         default:
-            assert(!"unexpected");
+            SLANG_REFLECTION_UNEXPECTED();
             return SLANG_SCALAR_TYPE_NONE;
             break;
         }
@@ -967,7 +973,7 @@ static void emitReflectionVarBindingInfoJSON(
 
         default:
             write(writer, "unknown");
-            assert(!"unexpected");
+            SLANG_UNEXPECTED("unhandled case");
             break;
         }
         write(writer, "\"");
@@ -1071,7 +1077,7 @@ static void emitReflectionScalarTypeInfoJSON(
     {
     default:
         write(writer, "unknown");
-        assert(!"unexpected");
+        SLANG_UNEXPECTED("unhandled case");
         break;
 #define CASE(TAG, ID) case slang::TypeReflection::ScalarType::TAG: write(writer, #ID); break
         CASE(Void, void);
@@ -1109,7 +1115,7 @@ static void emitReflectionTypeInfoJSON(
             {
             default:
                 write(writer, "unknown");
-                assert(!"unexpected");
+                SLANG_UNEXPECTED("unhandled case");
                 break;
 
 #define CASE(SHAPE, NAME) case SLANG_##SHAPE: write(writer, #NAME); break
@@ -1141,7 +1147,7 @@ static void emitReflectionTypeInfoJSON(
                 {
                 default:
                     write(writer, "unknown");
-                    assert(!"unexpected");
+                    SLANG_UNEXPECTED("unhandled case");
                     break;
 
                 case SLANG_RESOURCE_ACCESS_READ:
@@ -1253,7 +1259,7 @@ static void emitReflectionTypeInfoJSON(
         break;
 
     default:
-        assert(!"unimplemented");
+        SLANG_UNEXPECTED("unhandled case");
         break;
     }
 }
@@ -1373,58 +1379,6 @@ static void emitReflectionVarInfoJSON(
     write(writer, "\"type\": ");
     emitReflectionTypeJSON(writer, var->getType());
 }
-
-#if 0
-static void emitReflectionBindingInfoJSON(
-    PrettyWriter& writer,
-    
-    ReflectionParameterNode* param)
-{
-    auto info = &param->binding;
-
-    if( info->category == SLANG_PARAMETER_CATEGORY_MIXED )
-    {
-        write(writer,"\"bindings\": [\n");
-        indent(writer);
-
-        ReflectionSize bindingCount = info->bindingCount;
-        assert(bindingCount);
-        ReflectionParameterBindingInfo* bindings = info->bindings;
-        for( ReflectionSize bb = 0; bb < bindingCount; ++bb )
-        {
-            if (bb != 0) write(writer, ",\n");
-
-            write(writer,"{");
-            auto& binding = bindings[bb];
-            emitReflectionVarBindingInfoJSON(
-                writer,
-                binding.category,
-                binding.index,
-                (ReflectionSize) param->GetTypeLayout()->GetSize(binding.category),
-                binding.space);
-
-            write(writer,"}");
-        }
-        dedent(writer);
-        write(writer,"\n]");
-    }
-    else
-    {
-        write(writer,"\"binding\": {");
-        indent(writer);
-
-        emitReflectionVarBindingInfoJSON(
-            writer,
-            info->category,
-            info->index,
-            (ReflectionSize) param->GetTypeLayout()->GetSize(info->category),
-            info->space);
-
-        dedent(writer);
-        write(writer,"}");
-    }
-}
-#endif
 
 static void emitReflectionParamJSON(
     PrettyWriter&                       writer,

--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -1289,7 +1289,7 @@ namespace Slang
             for(int M = 2; M <= (N-2); ++M)
             {
                 int K = N - M;
-                assert(K >= 2);
+                SLANG_ASSERT(K >= 2);
 
                 sb << "__init(vector<T," << M << "> " << kVectorNames[M];
                 sb << ", vector<T," << K << "> ";
@@ -1453,7 +1453,7 @@ namespace Slang
                                 break;
 
                             default:
-                                assert(!"unexpected");
+                                SLANG_UNEXPECTED("unhandled resource shape");
                                 break;
                             }
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -571,7 +571,7 @@ void Session::addBuiltinSource(
         OutputDebugStringA(compileRequest->mDiagnosticOutput.Buffer());
 #endif
 
-        assert(!"error in stdlib");
+        SLANG_UNEXPECTED("error in Slang standard library");
     }
 
     // Extract the AST for the code we just parsed
@@ -831,8 +831,16 @@ SLANG_API int spCompile(
 {
     auto req = REQ(request);
 
-    int anyErrors = req->executeActions();
-    return anyErrors;
+    try
+    {
+        int anyErrors = req->executeActions();
+        return anyErrors;
+    }
+    catch (...)
+    {
+        req->mSink.diagnose(Slang::CodePosition(), Slang::Diagnostics::compilationAborted);
+        return 1;
+    }
 }
 
 SLANG_API int

--- a/source/slang/syntax-base-defs.h
+++ b/source/slang/syntax-base-defs.h
@@ -238,7 +238,7 @@ ABSTRACT_SYNTAX_CLASS(Decl, DeclBase)
     bool IsChecked(DeclCheckState state) { return checkState >= state; }
     void SetCheckState(DeclCheckState state)
     {
-        assert(state >= checkState);
+        SLANG_RELEASE_ASSERT(state >= checkState);
         checkState = state;
     }
     )

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -147,7 +147,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         {
             // TODO(tfoley): worry about thread safety here?
             et->canonicalType = et->CreateCanonicalType();
-            assert(et->canonicalType);
+            SLANG_ASSERT(et->canonicalType);
         }
         return et->canonicalType;
     }
@@ -314,14 +314,14 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
     static RefPtr<ExpressionType> ExtractGenericArgType(RefPtr<Val> val)
     {
         auto type = val.As<ExpressionType>();
-        assert(type.Ptr());
+        SLANG_RELEASE_ASSERT(type.Ptr());
         return type;
     }
 
     static RefPtr<IntVal> ExtractGenericArgInteger(RefPtr<Val> val)
     {
         auto intVal = val.As<IntVal>();
-        assert(intVal.Ptr());
+        SLANG_RELEASE_ASSERT(intVal.Ptr());
         return intVal;
     }
 
@@ -348,7 +348,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
             }
             else if (magicMod->name == "Vector")
             {
-                assert(subst && subst->args.Count() == 2);
+                SLANG_ASSERT(subst && subst->args.Count() == 2);
                 auto vecType = new VectorExpressionType();
                 vecType->declRef = declRef;
                 vecType->elementType = ExtractGenericArgType(subst->args[0]);
@@ -357,14 +357,14 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
             }
             else if (magicMod->name == "Matrix")
             {
-                assert(subst && subst->args.Count() == 3);
+                SLANG_ASSERT(subst && subst->args.Count() == 3);
                 auto matType = new MatrixExpressionType();
                 matType->declRef = declRef;
                 return matType;
             }
             else if (magicMod->name == "Texture")
             {
-                assert(subst && subst->args.Count() >= 1);
+                SLANG_ASSERT(subst && subst->args.Count() >= 1);
                 auto textureType = new TextureType(
                     TextureType::Flavor(magicMod->tag),
                     ExtractGenericArgType(subst->args[0]));
@@ -373,7 +373,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
             }
             else if (magicMod->name == "TextureSampler")
             {
-                assert(subst && subst->args.Count() >= 1);
+                SLANG_ASSERT(subst && subst->args.Count() >= 1);
                 auto textureType = new TextureSamplerType(
                     TextureType::Flavor(magicMod->tag),
                     ExtractGenericArgType(subst->args[0]));
@@ -382,7 +382,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
             }
             else if (magicMod->name == "GLSLImageType")
             {
-                assert(subst && subst->args.Count() >= 1);
+                SLANG_ASSERT(subst && subst->args.Count() >= 1);
                 auto textureType = new GLSLImageType(
                     TextureType::Flavor(magicMod->tag),
                     ExtractGenericArgType(subst->args[0]));
@@ -408,7 +408,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
 
             #define CASE(n,T)													\
                 else if(magicMod->name == #n) {									\
-                    assert(subst && subst->args.Count() == 1);					\
+                    SLANG_ASSERT(subst && subst->args.Count() == 1);			\
                     auto type = new T();										\
                     type->elementType = ExtractGenericArgType(subst->args[0]);	\
                     type->declRef = declRef;									\
@@ -450,7 +450,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
 
             else
             {
-                throw "unimplemented";
+                SLANG_UNEXPECTED("unhandled type");
             }
         }
         else
@@ -537,7 +537,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
 
     bool NamedExpressionType::EqualsImpl(ExpressionType * /*type*/)
     {
-        assert(!"unreachable");
+        SLANG_UNEXPECTED("unreachable");
         return false;
     }
 
@@ -548,7 +548,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
 
     int NamedExpressionType::GetHashCode()
     {
-        assert(!"unreachable");
+        SLANG_UNEXPECTED("unreachable");
         return 0;
     }
 
@@ -609,7 +609,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
 
     int TypeType::GetHashCode()
     {
-        assert(!"unreachable");
+        SLANG_UNEXPECTED("unreachable");
         return 0;
     }
 
@@ -778,7 +778,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
             return false;
 
         UInt argCount = args.Count();
-        assert(args.Count() == subst->args.Count());
+        SLANG_RELEASE_ASSERT(args.Count() == subst->args.Count());
         for (UInt aa = 0; aa < argCount; ++aa)
         {
             if (!args[aa]->EqualsVal(subst->args[aa].Ptr()))
@@ -821,7 +821,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         if (!substitutions)
             return expr;
 
-        assert(!"unimplemented");
+        SLANG_UNIMPLEMENTED_X("generic substitution into expressions");
 
         return expr;
     }
@@ -928,7 +928,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         {
             return constantVal->value;
         }
-        assert(!"unexpected");
+        SLANG_UNEXPECTED("needed a known integer value");
         return 0;
     }
 
@@ -1032,7 +1032,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
     #undef CASE
         else
         {
-            assert(!"unexpected");
+            SLANG_UNEXPECTED("unhandled syntax class name");
             return nullptr;
         }
     }

--- a/source/slang/token.cpp
+++ b/source/slang/token.cpp
@@ -10,7 +10,7 @@ char const* TokenTypeToString(TokenType type)
     switch( type )
     {
     default:
-        assert(!"unexpected");
+        SLANG_ASSERT(!"unexpected");
         return "<uknown>";
 
 #define TOKEN(NAME, DESC) case TokenType::NAME: return DESC;

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -38,8 +38,11 @@ struct DefaultLayoutRulesImpl : SimpleLayoutRulesImpl
         case BaseType::Bool:
             return SimpleLayoutInfo( LayoutResourceKind::Uniform, 4, 4 );
 
+        case BaseType::Double:
+            return SimpleLayoutInfo( LayoutResourceKind::Uniform, 8, 8 );
+
         default:
-            assert(!"unimplemented");
+            SLANG_UNEXPECTED("uhandled scalar type");
             return SimpleLayoutInfo( LayoutResourceKind::Uniform, 0, 1 );
         }
     }
@@ -64,7 +67,7 @@ struct DefaultLayoutRulesImpl : SimpleLayoutRulesImpl
         case slang::TypeReflection::ScalarType::Float64:    return SimpleLayoutInfo( LayoutResourceKind::Uniform, 8,8);
 
         default:
-            assert(!"unimplemented");
+            SLANG_UNEXPECTED("unhandled scalar type");
             return SimpleLayoutInfo();
         }
     }
@@ -164,7 +167,7 @@ struct GLSLConstantBufferLayoutRulesImpl : DefaultConstantBufferLayoutRulesImpl
 static SimpleLayoutInfo getGLSLVectorLayout(
     SimpleLayoutInfo elementInfo, size_t elementCount)
 {
-    assert(elementInfo.kind == LayoutResourceKind::Uniform);
+    SLANG_RELEASE_ASSERT(elementInfo.kind == LayoutResourceKind::Uniform);
     auto size = elementInfo.size * elementCount;
     SimpleLayoutInfo vectorInfo(
         LayoutResourceKind::Uniform,
@@ -380,7 +383,7 @@ struct HLSLObjectLayoutRulesImpl : ObjectLayoutRulesImpl
         case ShaderParameterKind::InputRenderTarget:
             // TODO: how to handle these?
         default:
-            assert(!"unimplemented");
+            SLANG_UNEXPECTED("unhandled shader parameter kind");
             return SimpleLayoutInfo();
         }
     }
@@ -601,7 +604,7 @@ static int GetElementCount(RefPtr<IntVal> val)
         // TODO(tfoley): do something sensible in this case
         return 0;
     }
-    assert(!"unexpected");
+    SLANG_UNEXPECTED("unhandled integer literal kind");
     return 0;
 }
 
@@ -670,7 +673,7 @@ static SimpleLayoutInfo getParameterBlockLayoutInfo(
     }
     else
     {
-        assert(!"unexpected");
+        SLANG_UNEXPECTED("unhandled parameter block type");
         return SimpleLayoutInfo();
     }
 }
@@ -696,8 +699,8 @@ createParameterBlockTypeLayout(
     // and hence no uniform data).
     // 
     typeLayout->uniformAlignment = parameterBlockInfo.alignment;
-    assert(!typeLayout->FindResourceInfo(LayoutResourceKind::Uniform));
-    assert(typeLayout->uniformAlignment == 1);
+    SLANG_RELEASE_ASSERT(!typeLayout->FindResourceInfo(LayoutResourceKind::Uniform));
+    SLANG_RELEASE_ASSERT(typeLayout->uniformAlignment == 1);
 
     // TODO(tfoley): There is a subtle question here of whether
     // a constant buffer declaration that then contains zero
@@ -801,7 +804,7 @@ LayoutRulesImpl* getParameterBufferElementTypeLayoutRules(
     }
     else
     {
-        assert(!"unexpected");
+        SLANG_UNEXPECTED("uhandled parameter block type");
         return nullptr;
     }
 }
@@ -843,8 +846,8 @@ createStructuredBufferTypeLayout(
     typeLayout->elementTypeLayout = elementTypeLayout;
 
     typeLayout->uniformAlignment = info.alignment;
-    assert(!typeLayout->FindResourceInfo(LayoutResourceKind::Uniform));
-    assert(typeLayout->uniformAlignment == 1);
+    SLANG_RELEASE_ASSERT(!typeLayout->FindResourceInfo(LayoutResourceKind::Uniform));
+    SLANG_RELEASE_ASSERT(typeLayout->uniformAlignment == 1);
 
     if( info.size != 0 )
     {
@@ -1211,7 +1214,7 @@ SimpleLayoutInfo GetLayoutImpl(
                             continue;
 
                         // We should not have already processed this resource type
-                        assert(!fieldLayout->FindResourceInfo(fieldTypeResourceInfo.kind));
+                        SLANG_RELEASE_ASSERT(!fieldLayout->FindResourceInfo(fieldTypeResourceInfo.kind));
 
                         // The field will need offset information for this kind
                         auto fieldResourceInfo = fieldLayout->AddResourceInfo(fieldTypeResourceInfo.kind);
@@ -1258,7 +1261,7 @@ SimpleLayoutInfo GetLayoutImpl(
     }
 
     // catch-all case in case nothing matched
-    assert(!"unimplemented");
+    SLANG_ASSERT(!"unimplemented");
     SimpleLayoutInfo info;
     return GetSimpleLayoutImpl(
         info,


### PR DESCRIPTION
The change is mostly about trying to make sure the compiler "fails safe" when it encounters an internal assumption that isn't met.
Most internal errors will now throw exceptions (yes, exceptions are evil, but this will work for now), and these get caught in `spCompile` so that they don't propagate to the user (they just see a message that compilation aborted due to an internal error).

Subsequent changes are going to need to work on diagnosing as many of these situations as possible, so that users can at least know what construct in their code was unexpected or unhandled by the compiler.