### PR TITLE
Require extension when using `gl_Layer` in VS

### DIFF
--- a/source/slang/lower.cpp
+++ b/source/slang/lower.cpp
@@ -3458,10 +3458,22 @@ struct LoweringVisitor
             }
             else if (ns == "sv_rendertargetarrayindex")
             {
-                if (info.direction == VaryingParameterDirection::Input)
+                switch (shared->entryPointRequest->profile.GetStage())
                 {
+                case Stage::Geometry:
+                    requireGLSLVersion(ProfileVersion::GLSL_150);
+                    break;
+
+                case Stage::Fragment:
                     requireGLSLVersion(ProfileVersion::GLSL_430);
+                    break;
+
+                default:
+                    requireGLSLVersion(ProfileVersion::GLSL_450);
+                    requireGLSLExtension(shared->extensionUsageTracker, "GL_ARB_shader_viewport_layer_array");
+                    break;
                 }
+
                 globalVarExpr = createGLSLBuiltinRef("gl_Layer", getIntType());
             }
             else if (ns == "sv_sampleindex")


### PR DESCRIPTION
The requirements for using `gl_Layer` differ by stage, and so we need to pick an appropriate GL version based on the target stage, and then also require a specific extension for anything other than geometry or fragment.