### PR TITLE
Add an API option to control emission of `#line` directives

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -96,6 +96,18 @@ extern "C"
         SLANG_COMPILE_FLAG_NO_CHECKING = 1 << 0, /**< Disable semantic checking as much as possible. */
     };
 
+    /*!
+    @brief Options to control emission of `#line` directives
+    */
+    typedef unsigned int SlangLineDirectiveMode;
+    enum
+    {
+        SLANG_LINE_DIRECTIVE_MODE_DEFAULT = 0,  /**< Default behavior: pick behavior base on target. */
+        SLANG_LINE_DIRECTIVE_MODE_NONE,         /**< Don't emit line directives at all. */
+        SLANG_LINE_DIRECTIVE_MODE_STANDARD,     /**< Emit standard C-style `#line` directives. */
+        SLANG_LINE_DIRECTIVE_MODE_GLSL,         /**< Emit GLSL-style directives with file *number* instead of name */
+    };
+
     typedef int SlangSourceLanguage;
     enum
     {
@@ -175,6 +187,13 @@ extern "C"
     SLANG_API void spSetDumpIntermediates(
         SlangCompileRequest*    request,
         int                     enable);
+
+    /*!
+    @brief Set whether (and how) `#line` directives hsould be output.
+    */
+    SLANG_API void spSetLineDirectiveMode(
+        SlangCompileRequest*    request,
+        SlangLineDirectiveMode  mode);
 
     /*!
     @brief Sets the target for code generation.

--- a/source/slang/compiler.cpp
+++ b/source/slang/compiler.cpp
@@ -690,7 +690,7 @@ namespace Slang
         int id = counter++;
 
         String path;
-        path.append("slang-");
+        path.append("slang-dump-");
         path.append(id);
         path.append(ext);
 

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -48,6 +48,14 @@ namespace Slang
         ReflectionJSON      = SLANG_REFLECTION_JSON,
     };
 
+    enum class LineDirectiveMode : SlangLineDirectiveMode
+    {
+        Default     = SLANG_LINE_DIRECTIVE_MODE_DEFAULT,
+        None        = SLANG_LINE_DIRECTIVE_MODE_NONE,
+        Standard    = SLANG_LINE_DIRECTIVE_MODE_STANDARD,
+        GLSL        = SLANG_LINE_DIRECTIVE_MODE_GLSL,
+    };
+
     enum class ResultFormat
     {
         None,
@@ -209,6 +217,9 @@ namespace Slang
 
         // Should we dump intermediate results along the way, for debugging?
         bool shouldDumpIntermediates = false;
+
+        // How should `#line` directives be emitted (if at all)?
+        LineDirectiveMode lineDirectiveMode = LineDirectiveMode::Default;
 
         // Output stuff
         DiagnosticSink mSink;

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -675,6 +675,15 @@ SLANG_API void spSetDumpIntermediates(
     REQ(request)->shouldDumpIntermediates = enable != 0;
 }
 
+SLANG_API void spSetLineDirectiveMode(
+    SlangCompileRequest*    request,
+    SlangLineDirectiveMode  mode)
+{
+    // TODO: validation
+
+    REQ(request)->lineDirectiveMode = Slang::LineDirectiveMode(mode);
+}
+
 
 SLANG_API void spSetCodeGenTarget(
         SlangCompileRequest*    request,


### PR DESCRIPTION
- API users can use this to get "clean" output to aid with debugging Slang issues

- Also changes the prefix on intermediate files that Slang dumps, to make them easier to ignore with a regexp