### PR TITLE
Don't add `flat` qualifier to integer fragment output

### DIFF
--- a/source/slang/lower.cpp
+++ b/source/slang/lower.cpp
@@ -3582,9 +3582,14 @@ struct LoweringVisitor
             else if (isIntegralType(varType))
             {
                 if (info.direction == VaryingParameterDirection::Input
-                    && shared->entryPointRequest->profile.GetStage() == Stage::Vertex)
+                    && shared->entryPointRequest->profile.GetStage() != Stage::Fragment)
                 {
-                    // Don't add extra qualification to VS inputs
+                    // Don't add extra qualification to vertex shader inputs
+                }
+                else if (info.direction == VaryingParameterDirection::Output
+                    && shared->entryPointRequest->profile.GetStage() == Stage::Fragment)
+                {
+                    // Don't add extra qualification to fragment shader outputs
                 }
                 else
                 {

--- a/tests/bugs/gh-133.slang
+++ b/tests/bugs/gh-133.slang
@@ -1,0 +1,21 @@
+//TEST:CROSS_COMPILE: -profile ps_5_0 -entry main -target spirv-assembly
+
+// Ensure that an integer output from
+// a fragment shader doesn't get a `flat` qualifier
+
+struct Fragment
+{
+	uint foo;
+};
+
+cbuffer U
+{
+	uint bar;
+}
+
+Fragment main() : SV_Target
+{
+	Fragment result;
+	result.foo = bar;
+	return result;
+}

--- a/tests/bugs/gh-133.slang.glsl
+++ b/tests/bugs/gh-133.slang.glsl
@@ -1,0 +1,28 @@
+#version 420
+//TEST_IGNORE_FILE:
+
+struct Fragment
+{
+	uint foo;
+};
+
+uniform U
+{
+	uint bar;
+};
+
+Fragment main_()
+{
+	Fragment result;
+	result.foo = bar;
+	return result;
+}
+
+layout(location = 0)
+out uint SLANG_out_main_result_foo;
+
+void main()
+{
+	Fragment main_result = main_();
+	SLANG_out_main_result_foo = main_result.foo;
+}


### PR DESCRIPTION
Fixes #133

We already had logic to skip adding `flat` to a vertex input, and this just extends it to not adding `flat` to a fragment output.

Note that explicit qualifiers in the input HLSL/Slang will still be carried through to the output, so it is still possible for a Slang user to shoot themself in the foot with interpolation qualifiers.