### PR TITLE
Make the "hack" sampler explicit for now

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -3848,7 +3848,10 @@ String emitEntryPoint(
 
     if (sharedContext.needHackSamplerForTexelFetch)
     {
-        finalResultBuilder << "layout(set = 0, binding = 0) uniform sampler SLANG_hack_samplerForTexelFetch;\n";
+        finalResultBuilder
+            << "layout(set = 0, binding = "
+            << programLayout->bindingForHackSampler
+            << ") uniform sampler SLANG_hack_samplerForTexelFetch;\n";
     }
 
     finalResultBuilder << code;

--- a/source/slang/type-layout.h
+++ b/source/slang/type-layout.h
@@ -383,6 +383,11 @@ public:
     // and any entry-point-specific parameter data
     // will (eventually) belong there...
     List<RefPtr<EntryPointLayout>> entryPoints;
+
+    // HACK: binding to use when we have to create
+    // a dummy sampler just to appease glslang
+    int bindingForHackSampler = 0;
+    RefPtr<VarDeclBase> hackSamplerVar;
 };
 
 struct LayoutRulesFamilyImpl;

--- a/tests/reflection/cross-compile.slang.expected
+++ b/tests/reflection/cross-compile.slang.expected
@@ -42,6 +42,13 @@ standard output = {
                     ]
                 }
             }
+        },
+        {
+            "name": "SLANG_hack_samplerForTexelFetch",
+            "binding": {"kind": "descriptorTableSlot", "index": 3},
+            "type": {
+                "kind": "samplerState"
+            }
         }
     ]
 }


### PR DESCRIPTION
- We use this to work around the fact that, e.g., `Texture2D.Load` doesn't take a sampler, but the equivalent GLSL operation `texelFetch` requires one

- Previously we tried to hide the sampler from the user, hoping that glslang would drop it and we could just ignore it, but that doesn't work

- For now we'll go ahead and explicitly show the sampler in the reflection info so that an app can react appropriately

- We also generate a unique binding for the sampler, instead of the old behavior that fixed it with `binding = 0`
  - We still fix it with `set = 0`, so it might still surprise users