### PR TITLE
Work around glslang issue 988

### DIFF
--- a/tests/rewriter/glslang-bug-988-workaround.frag
+++ b/tests/rewriter/glslang-bug-988-workaround.frag
@@ -1,0 +1,58 @@
+#version 450
+//TEST:COMPARE_GLSL:
+
+// Test workaround for glslang issue #988
+// (https://github.com/KhronosGroup/glslang/issues/988)
+
+
+#if defined(__SLANG__)
+
+
+__import glslang_bug_988_workaround;
+
+uniform U
+{
+	Foo foo;	
+};
+
+vec4 doIt(Foo foo)
+{
+	return foo.bar;
+}
+
+layout(location = 0)
+out vec4 result;
+
+void main()
+{
+	result = doIt(foo);
+}
+
+#else
+
+struct Foo
+{
+	vec4 bar;
+};
+
+layout(binding = 0)
+uniform U
+{
+	Foo foo;	
+};
+
+vec4 doIt(Foo foo)
+{
+	return foo.bar;
+}
+
+layout(location = 0)
+out vec4 result;
+
+void main()
+{
+	Foo SLANG_tmp_0 = foo;
+	result = doIt(SLANG_tmp_0);
+}
+
+#endif

--- a/tests/rewriter/glslang-bug-988-workaround.slang
+++ b/tests/rewriter/glslang-bug-988-workaround.slang
@@ -1,0 +1,6 @@
+//TEST_IGNORE_FILE:
+
+struct Foo
+{
+	float4 bar;
+};

--- a/tests/rewriter/resources-in-structs.glsl
+++ b/tests/rewriter/resources-in-structs.glsl
@@ -55,8 +55,9 @@ out vec4 color;
 
 void main()
 {
+	Material SLANG_tmp_0 = m;
 	color = evaluateMaterial(
-		m,
+		SLANG_tmp_0,
 		SLANG_parameterBlock_U_m_t,
 		SLANG_parameterBlock_U_m_s, uv);
 }


### PR DESCRIPTION
The basic bug there is that if you have a member of `struct` type in a `uniform` block and then pass a reference to that member directly to a call:

```
struct Foo { vec4 bar; };
uniform U { Foo foo; };

void main() { doSomething(foo); }
```

then glslang generates invalid SPIR-V which seems to cause an issue for some drivers.

This change works around the problem by detecting cases where an argument to a function call is a reference to `uniform` block member (of `struct` type) and then rewrites the code to move that value to a temporary before the call.