### PR TITLE
Fixup for the glslang bug workaround

### DIFF
--- a/source/slang/lower.cpp
+++ b/source/slang/lower.cpp
@@ -3006,8 +3006,16 @@ return loweredExpr;
         }
 
         RefPtr<VarDeclBase> loweredDecl = loweredDeclClass.createInstance();
+
+        // Note: we lower the declaration (including its initialization expression, if any)
+        // *before* we add the declaration to the current context (e.g., a statement being
+        // built), so that any operations inside the initialization expression that
+        // might need to inject statements/temporaries/whatever happen *before*
+        // the declaration of this variable.
+        auto result = lowerSimpleVarDeclCommon(loweredDecl, decl, loweredType);
         addDecl(loweredDecl);
-        return lowerSimpleVarDeclCommon(loweredDecl, decl, loweredType);
+
+        return result;
     }
 
     RefPtr<VarDeclBase> lowerVarDeclCommon(

--- a/tests/rewriter/glslang-bug-988-workaround.frag
+++ b/tests/rewriter/glslang-bug-988-workaround.frag
@@ -25,7 +25,8 @@ out vec4 result;
 
 void main()
 {
-	result = doIt(foo);
+	vec4 r = doIt(foo);
+	result = r;
 }
 
 #else
@@ -52,7 +53,8 @@ out vec4 result;
 void main()
 {
 	Foo SLANG_tmp_0 = foo;
-	result = doIt(SLANG_tmp_0);
+	vec4 r = doIt(SLANG_tmp_0);
+	result = r;
 }
 
 #endif


### PR DESCRIPTION
There was a bug where the intialization expression for a variable was being lowered after the declaration was added to the output code, so that any sub-expressions that get hoisted out actually get computed *after* the original variable. This obviously led to downstream compilation failure.

I've updated the test case to stress this scenario.