### PR TITLE
Add a `-o` option to command-line `slangc`

### DIFF
--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -102,6 +102,10 @@ namespace Slang
         // supposed to be defined in.
         int translationUnitIndex;
 
+        // The output path requested for this entry point.
+        // (only used when compiling from the command line)
+        String outputPath;
+
         // The resulting output for the enry point
         //
         // TODO: low-level code generation should be a distinct step
@@ -220,6 +224,9 @@ namespace Slang
 
         // How should `#line` directives be emitted (if at all)?
         LineDirectiveMode lineDirectiveMode = LineDirectiveMode::Default;
+
+        // Are we being driven by the command-line `slangc`, and should act accordingly?
+        bool isCommandLineCompile = false;
 
         // Output stuff
         DiagnosticSink mSink;

--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -49,6 +49,18 @@ DIAGNOSTIC(    2, Error, unsupportedCompilerMode, "unsupported compiler mode.")
 DIAGNOSTIC(    4, Error, cannotWriteOutputFile, "cannot write output file '$0'.")
 DIAGNOSTIC(    5, Error, failedToLoadDynamicLibrary, "failed to load dynamic library '$0'")
 
+DIAGNOSTIC(    6, Error, tooManyOutputPathsSpecified,
+    "$0 output paths specified, but only $1 entry points given")
+
+DIAGNOSTIC(    6, Error, noOutputPathSpecifiedForEntryPoint,
+    "no output path specified for entry point '$0' (the '-o' option for an entry point must precede the corresponding '-entry')")
+
+DIAGNOSTIC(    6, Error, outputPathsImplyDifferentFormats,
+    "the output paths '$0' and '$1' require different code-generation targets")
+
+DIAGNOSTIC(    6, Error, cannotDeduceOutputFormatFromPath,
+    "cannot deduce an output format from the output path '$0'")
+
 //
 // 1xxxx - Lexical anaylsis
 //

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -684,6 +684,12 @@ SLANG_API void spSetLineDirectiveMode(
     REQ(request)->lineDirectiveMode = Slang::LineDirectiveMode(mode);
 }
 
+SLANG_API void spSetCommandLineCompilerMode(
+    SlangCompileRequest* request)
+{
+    REQ(request)->isCommandLineCompile = true;
+
+}
 
 SLANG_API void spSetCodeGenTarget(
         SlangCompileRequest*    request,

--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -3,6 +3,8 @@
 #define SLANG_DYNAMIC
 #include "../slang.h"
 
+SLANG_API void spSetCommandLineCompilerMode(SlangCompileRequest* request);
+
 #include "core/slang-io.h"
 
 using namespace Slang;
@@ -31,6 +33,8 @@ int MAIN(int argc, char** argv)
 
     SlangSession* session = spCreateSession(nullptr);
     SlangCompileRequest* compileRequest = spCreateCompileRequest(session);
+
+    spSetCommandLineCompilerMode(compileRequest);
 
     char const* appName = "slangc";
     if(argc > 0) appName = argv[0];
@@ -62,6 +66,9 @@ int MAIN(int argc, char** argv)
             exit(-1);
         }
 
+#if 0
+        // Produce output as the command-line compiler driver should.
+
         // Now dump the output from the compilation to stdout.
         //
         // TODO: Need a way to control where output goes so that
@@ -76,6 +83,7 @@ int MAIN(int argc, char** argv)
             fputs(output, stdout);
         }
         fflush(stdout);
+#endif
 
         // Now that we are done, clean up after ourselves
 


### PR DESCRIPTION
Fixes #11

- This adds a `-o` command-line option for specifying an output file.

- The code tries to be a bit smart, to glean an output format from a file extension, and also to associate multiple `-o` options with multiple `-entry` options if needed.

- There is a restriction that all the output files need to agree on the code generation target. This is reasonable for now, but might be something to lift eventualy

- There is a restriction that only one output file is allowed per entry point
  - Together with the previous item this means you can't output both a `.spv` and a `.spv.asm` in one pass, even though both should be possible

- There is currently a restriction that output paths only apply to entry points
  - This means there is no way to output reflection JSON to a file with `-o` (but that is mostly just a debugging feature for now)
  - This also means we don't support any "container" formats that can encapsulate multiple compiled entry points