### PR TITLE
Major naming overhaul:

### DIFF
--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -162,7 +162,7 @@ namespace Slang
         SlangCompileFlags compileFlags = 0;
 
         // The parsed syntax for the translation unit
-        RefPtr<ProgramSyntaxNode>   SyntaxNode;
+        RefPtr<ModuleDecl>   SyntaxNode;
 
         // The resulting output for the translation unit
         //
@@ -241,13 +241,13 @@ namespace Slang
         // Modules that have been dynamically loaded via `import`
         //
         // This is a list of unique modules loaded, in the order they were encountered.
-        List<RefPtr<ProgramSyntaxNode> > loadedModulesList;
+        List<RefPtr<ModuleDecl> > loadedModulesList;
 
         // Map from the logical name of a module to its definition
-        Dictionary<String, RefPtr<ProgramSyntaxNode>> mapPathToLoadedModule;
+        Dictionary<String, RefPtr<ModuleDecl>> mapPathToLoadedModule;
 
         // Map from the path of a module file to its definition
-        Dictionary<String, RefPtr<ProgramSyntaxNode>> mapNameToLoadedModules;
+        Dictionary<String, RefPtr<ModuleDecl>> mapNameToLoadedModules;
 
 
         CompileRequest(Session* session)
@@ -281,7 +281,7 @@ namespace Slang
             String const&           name,
             Profile                 profile);
 
-        RefPtr<ProgramSyntaxNode> loadModule(
+        RefPtr<ModuleDecl> loadModule(
             String const&       name,
             String const&       path,
             String const&       source,
@@ -291,7 +291,7 @@ namespace Slang
             String const&       path,
             TokenList const&    tokens);
 
-        RefPtr<ProgramSyntaxNode> findOrImportModule(
+        RefPtr<ModuleDecl> findOrImportModule(
             String const&       name,
             CodePosition const& loc);
     };
@@ -322,7 +322,7 @@ namespace Slang
         RefPtr<Scope>   slangLanguageScope;
         RefPtr<Scope>   glslLanguageScope;
 
-        List<RefPtr<ProgramSyntaxNode>> loadedModuleCode;
+        List<RefPtr<ModuleDecl>> loadedModuleCode;
 
 
         //
@@ -340,27 +340,27 @@ namespace Slang
         String getGLSLLibraryCode();
 
         // Basic types that we don't want to re-create all the time
-        RefPtr<ExpressionType> errorType;
-        RefPtr<ExpressionType> initializerListType;
-        RefPtr<ExpressionType> overloadedType;
+        RefPtr<Type> errorType;
+        RefPtr<Type> initializerListType;
+        RefPtr<Type> overloadedType;
 
-        Dictionary<int, RefPtr<ExpressionType>> builtinTypes;
+        Dictionary<int, RefPtr<Type>> builtinTypes;
         Dictionary<String, Decl*> magicDecls;
-        List<RefPtr<ExpressionType>> canonicalTypes;
+        List<RefPtr<Type>> canonicalTypes;
 
         void initializeTypes();
 
-        ExpressionType* getBoolType();
-        ExpressionType* getFloatType();
-        ExpressionType* getDoubleType();
-        ExpressionType* getIntType();
-        ExpressionType* getUIntType();
-        ExpressionType* getVoidType();
-        ExpressionType* getBuiltinType(BaseType flavor);
+        Type* getBoolType();
+        Type* getFloatType();
+        Type* getDoubleType();
+        Type* getIntType();
+        Type* getUIntType();
+        Type* getVoidType();
+        Type* getBuiltinType(BaseType flavor);
 
-        ExpressionType* getInitializerListType();
-        ExpressionType* getOverloadedType();
-        ExpressionType* getErrorType();
+        Type* getInitializerListType();
+        Type* getOverloadedType();
+        Type* getErrorType();
 
         //
 

--- a/source/slang/decl-defs.h
+++ b/source/slang/decl-defs.h
@@ -36,15 +36,15 @@ END_SYNTAX_CLASS()
 // Base class for all variable-like declarations
 ABSTRACT_SYNTAX_CLASS(VarDeclBase, Decl)
 
-    // Type of the variable
-    SYNTAX_FIELD(TypeExp, Type)
+    // type of the variable
+    SYNTAX_FIELD(TypeExp, type)
 
     RAW(
-    ExpressionType* getType() { return Type.type.Ptr(); }
+    Type* getType() { return type.type.Ptr(); }
     )
 
     // Initializer expression (optional)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, Expr)
+    SYNTAX_FIELD(RefPtr<Expr>, initExpr)
 END_SYNTAX_CLASS()
 
 
@@ -103,9 +103,9 @@ RAW(
     )
 END_SYNTAX_CLASS()
 
-SIMPLE_SYNTAX_CLASS(StructSyntaxNode, AggTypeDecl)
+SIMPLE_SYNTAX_CLASS(StructDecl, AggTypeDecl)
 
-SIMPLE_SYNTAX_CLASS(ClassSyntaxNode, AggTypeDecl)
+SIMPLE_SYNTAX_CLASS(ClassDecl, AggTypeDecl)
 
 // An interface which other types can conform to
 SIMPLE_SYNTAX_CLASS(InterfaceDecl, AggTypeDecl)
@@ -130,20 +130,20 @@ END_SYNTAX_CLASS()
 
 // A `typedef` declaration
 SYNTAX_CLASS(TypeDefDecl, SimpleTypeDecl)
-    SYNTAX_FIELD(TypeExp, Type)
+    SYNTAX_FIELD(TypeExp, type)
 END_SYNTAX_CLASS()
 
 // A scope for local declarations (e.g., as part of a statement)
 SIMPLE_SYNTAX_CLASS(ScopeDecl, ContainerDecl)
 
-SIMPLE_SYNTAX_CLASS(ParameterSyntaxNode, VarDeclBase)
+SIMPLE_SYNTAX_CLASS(ParamDecl, VarDeclBase)
 
 // Base class for things that have parameter lists and can thus be applied to arguments ("called")
 ABSTRACT_SYNTAX_CLASS(CallableDecl, ContainerDecl)
     RAW(
-    FilteredMemberList<ParameterSyntaxNode> GetParameters()
+    FilteredMemberList<ParamDecl> GetParameters()
     {
-        return getMembersOfType<ParameterSyntaxNode>();
+        return getMembersOfType<ParamDecl>();
     })
 
     SYNTAX_FIELD(TypeExp, ReturnType)
@@ -151,7 +151,7 @@ END_SYNTAX_CLASS()
 
 // Base class for callable things that may also have a body that is evaluated to produce their result
 ABSTRACT_SYNTAX_CLASS(FunctionDeclBase, CallableDecl)
-    SYNTAX_FIELD(RefPtr<StatementSyntaxNode>, Body)
+    SYNTAX_FIELD(RefPtr<Stmt>, Body)
 END_SYNTAX_CLASS()
 
 // A constructor/initializer to create instances of a type
@@ -166,13 +166,13 @@ SIMPLE_SYNTAX_CLASS(AccessorDecl, FunctionDeclBase)
 SIMPLE_SYNTAX_CLASS(GetterDecl, AccessorDecl)
 SIMPLE_SYNTAX_CLASS(SetterDecl, AccessorDecl)
 
-SIMPLE_SYNTAX_CLASS(FunctionSyntaxNode, FunctionDeclBase)
+SIMPLE_SYNTAX_CLASS(FuncDecl, FunctionDeclBase)
 
 SIMPLE_SYNTAX_CLASS(Variable, VarDeclBase);
 
 // A "module" of code (essentiately, a single translation unit)
 // that provides a scope for some number of declarations.
-SIMPLE_SYNTAX_CLASS(ProgramSyntaxNode, ContainerDecl)
+SIMPLE_SYNTAX_CLASS(ModuleDecl, ContainerDecl)
 
 SYNTAX_CLASS(ImportDecl, Decl)
     // The name of the module we are trying to import
@@ -182,7 +182,7 @@ SYNTAX_CLASS(ImportDecl, Decl)
     FIELD(RefPtr<Scope>, scope)
 
     // The module that actually got imported
-    DECL_FIELD(RefPtr<ProgramSyntaxNode>, importedModuleDecl)
+    DECL_FIELD(RefPtr<ModuleDecl>, importedModuleDecl)
 END_SYNTAX_CLASS()
 
 // A generic declaration, parameterized on types/values

--- a/source/slang/diagnostics.cpp
+++ b/source/slang/diagnostics.cpp
@@ -42,7 +42,7 @@ void printDiagnosticArg(StringBuilder& sb, Decl* decl)
     sb << decl->Name.Content;
 }
 
-void printDiagnosticArg(StringBuilder& sb, ExpressionType* type)
+void printDiagnosticArg(StringBuilder& sb, Type* type)
 {
     sb << type->ToString();
 }

--- a/source/slang/diagnostics.h
+++ b/source/slang/diagnostics.h
@@ -68,8 +68,8 @@ namespace Slang
     };
 
     class Decl;
+    class type;
     class Type;
-    class ExpressionType;
     class ILType;
     class StageAttribute;
     struct TypeExp;
@@ -80,8 +80,8 @@ namespace Slang
     void printDiagnosticArg(StringBuilder& sb, UInt val);
     void printDiagnosticArg(StringBuilder& sb, Slang::String const& str);
     void printDiagnosticArg(StringBuilder& sb, Decl* decl);
+    void printDiagnosticArg(StringBuilder& sb, type* type);
     void printDiagnosticArg(StringBuilder& sb, Type* type);
-    void printDiagnosticArg(StringBuilder& sb, ExpressionType* type);
     void printDiagnosticArg(StringBuilder& sb, TypeExp const& type);
     void printDiagnosticArg(StringBuilder& sb, QualType const& type);
     void printDiagnosticArg(StringBuilder& sb, TokenType tokenType);

--- a/source/slang/expr-defs.h
+++ b/source/slang/expr-defs.h
@@ -4,7 +4,7 @@
 
 
 // Base class for expressions that will reference declarations
-ABSTRACT_SYNTAX_CLASS(DeclRefExpr, ExpressionSyntaxNode)
+ABSTRACT_SYNTAX_CLASS(DeclRefExpr, Expr)
 
 // The scope in which to perform lookup
     FIELD(RefPtr<Scope>, scope)
@@ -16,21 +16,21 @@ ABSTRACT_SYNTAX_CLASS(DeclRefExpr, ExpressionSyntaxNode)
     FIELD(String, name)
 END_SYNTAX_CLASS()
 
-SIMPLE_SYNTAX_CLASS(VarExpressionSyntaxNode, DeclRefExpr)
+SIMPLE_SYNTAX_CLASS(VarExpr, DeclRefExpr)
 
 // An expression that references an overloaded set of declarations
 // having the same name.
-SYNTAX_CLASS(OverloadedExpr, ExpressionSyntaxNode)
+SYNTAX_CLASS(OverloadedExpr, Expr)
 
     // Optional: the base expression is this overloaded result
     // arose from a member-reference expression.
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, base)
+    SYNTAX_FIELD(RefPtr<Expr>, base)
 
     // The lookup result that was ambiguous
     FIELD(LookupResult, lookupResult2)
 END_SYNTAX_CLASS()
 
-SYNTAX_CLASS(ConstantExpressionSyntaxNode, ExpressionSyntaxNode)
+SYNTAX_CLASS(ConstantExpr, Expr)
     FIELD(Token, token)
 
     RAW(
@@ -52,13 +52,13 @@ SYNTAX_CLASS(ConstantExpressionSyntaxNode, ExpressionSyntaxNode)
 END_SYNTAX_CLASS()
 
 // An initializer list, e.g. `{ 1, 2, 3 }`
-SYNTAX_CLASS(InitializerListExpr, ExpressionSyntaxNode)
-    SYNTAX_FIELD(List<RefPtr<ExpressionSyntaxNode>>, args)
+SYNTAX_CLASS(InitializerListExpr, Expr)
+    SYNTAX_FIELD(List<RefPtr<Expr>>, args)
 END_SYNTAX_CLASS()
 
 // A base class for expressions with arguments
-ABSTRACT_SYNTAX_CLASS(ExprWithArgsBase, ExpressionSyntaxNode)
-    SYNTAX_FIELD(List<RefPtr<ExpressionSyntaxNode>>, Arguments)
+ABSTRACT_SYNTAX_CLASS(ExprWithArgsBase, Expr)
+    SYNTAX_FIELD(List<RefPtr<Expr>>, Arguments)
 END_SYNTAX_CLASS()
 
 // An aggregate type constructor
@@ -70,49 +70,49 @@ END_SYNTAX_CLASS()
 // A base expression being applied to arguments: covers
 // both ordinary `()` function calls and `<>` generic application
 ABSTRACT_SYNTAX_CLASS(AppExprBase, ExprWithArgsBase)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, FunctionExpr)
+    SYNTAX_FIELD(RefPtr<Expr>, FunctionExpr)
 END_SYNTAX_CLASS()
 
-SIMPLE_SYNTAX_CLASS(InvokeExpressionSyntaxNode, AppExprBase)
+SIMPLE_SYNTAX_CLASS(InvokeExpr, AppExprBase)
 
-SIMPLE_SYNTAX_CLASS(OperatorExpressionSyntaxNode, InvokeExpressionSyntaxNode)
+SIMPLE_SYNTAX_CLASS(OperatorExpr, InvokeExpr)
 
-SIMPLE_SYNTAX_CLASS(InfixExpr  , OperatorExpressionSyntaxNode)
-SIMPLE_SYNTAX_CLASS(PrefixExpr , OperatorExpressionSyntaxNode)
-SIMPLE_SYNTAX_CLASS(PostfixExpr, OperatorExpressionSyntaxNode)
+SIMPLE_SYNTAX_CLASS(InfixExpr  , OperatorExpr)
+SIMPLE_SYNTAX_CLASS(PrefixExpr , OperatorExpr)
+SIMPLE_SYNTAX_CLASS(PostfixExpr, OperatorExpr)
 
-SYNTAX_CLASS(IndexExpressionSyntaxNode, ExpressionSyntaxNode)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, BaseExpression)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, IndexExpression)
+SYNTAX_CLASS(IndexExpr, Expr)
+    SYNTAX_FIELD(RefPtr<Expr>, BaseExpression)
+    SYNTAX_FIELD(RefPtr<Expr>, IndexExpression)
 END_SYNTAX_CLASS()
 
-SYNTAX_CLASS(MemberExpressionSyntaxNode, DeclRefExpr)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, BaseExpression)
+SYNTAX_CLASS(MemberExpr, DeclRefExpr)
+    SYNTAX_FIELD(RefPtr<Expr>, BaseExpression)
 END_SYNTAX_CLASS()
 
-SYNTAX_CLASS(SwizzleExpr, ExpressionSyntaxNode)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, base)
+SYNTAX_CLASS(SwizzleExpr, Expr)
+    SYNTAX_FIELD(RefPtr<Expr>, base)
     FIELD(int, elementCount)
     FIELD(int, elementIndices[4])
 END_SYNTAX_CLASS()
 
 // A dereference of a pointer or pointer-like type
-SYNTAX_CLASS(DerefExpr, ExpressionSyntaxNode)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, base)
+SYNTAX_CLASS(DerefExpr, Expr)
+    SYNTAX_FIELD(RefPtr<Expr>, base)
 END_SYNTAX_CLASS()
 
 // Any operation that performs type-casting
-SYNTAX_CLASS(TypeCastExpressionSyntaxNode, ExpressionSyntaxNode)
+SYNTAX_CLASS(TypeCastExpr, Expr)
     SYNTAX_FIELD(TypeExp, TargetType)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, Expression)
+    SYNTAX_FIELD(RefPtr<Expr>, Expression)
 END_SYNTAX_CLASS()
 
-// An explicit type-cast that appear in the user's code with `(Type) expr` syntax
-SYNTAX_CLASS(ExplicitCastExpr, TypeCastExpressionSyntaxNode)
+// An explicit type-cast that appear in the user's code with `(type) expr` syntax
+SYNTAX_CLASS(ExplicitCastExpr, TypeCastExpr)
 END_SYNTAX_CLASS()
 
 // An implicit type-cast inserted during semantic checking
-SYNTAX_CLASS(ImplicitCastExpr, TypeCastExpressionSyntaxNode)
+SYNTAX_CLASS(ImplicitCastExpr, TypeCastExpr)
 END_SYNTAX_CLASS()
 
 // An implicit type-cast that should also be hidden on output,
@@ -120,26 +120,26 @@ END_SYNTAX_CLASS()
 SYNTAX_CLASS(HiddenImplicitCastExpr, ImplicitCastExpr)
 END_SYNTAX_CLASS()
 
-SIMPLE_SYNTAX_CLASS(SelectExpressionSyntaxNode, OperatorExpressionSyntaxNode)
+SIMPLE_SYNTAX_CLASS(SelectExpr, OperatorExpr)
 
 SIMPLE_SYNTAX_CLASS(GenericAppExpr, AppExprBase)
 
 // An expression representing re-use of the syntax for a type in more
 // than once conceptually-distinct declaration
-SYNTAX_CLASS(SharedTypeExpr, ExpressionSyntaxNode)
+SYNTAX_CLASS(SharedTypeExpr, Expr)
     // The underlying type expression that we want to share
     SYNTAX_FIELD(TypeExp, base)
 END_SYNTAX_CLASS()
 
-SYNTAX_CLASS(AssignExpr, ExpressionSyntaxNode)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, left);
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, right);
+SYNTAX_CLASS(AssignExpr, Expr)
+    SYNTAX_FIELD(RefPtr<Expr>, left);
+    SYNTAX_FIELD(RefPtr<Expr>, right);
 END_SYNTAX_CLASS()
 
 // Just an expression inside parentheses `(exp)`
 //
 // We keep this around explicitly to be sure we don't lose any structure
 // when we do rewriter stuff.
-SYNTAX_CLASS(ParenExpr, ExpressionSyntaxNode)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, base);
+SYNTAX_CLASS(ParenExpr, Expr)
+    SYNTAX_FIELD(RefPtr<Expr>, base);
 END_SYNTAX_CLASS()

--- a/source/slang/lexer.cpp
+++ b/source/slang/lexer.cpp
@@ -18,7 +18,7 @@ namespace Slang
     Token* TokenList::end() const
     {
         SLANG_ASSERT(mTokens.Count());
-        SLANG_ASSERT(mTokens[mTokens.Count()-1].Type == TokenType::EndOfFile);
+        SLANG_ASSERT(mTokens[mTokens.Count()-1].type == TokenType::EndOfFile);
         return &mTokens[mTokens.Count() - 1];
     }
 
@@ -40,7 +40,7 @@ namespace Slang
 
         Token token = *mCursor;
         if (mCursor == mEnd)
-            token.Type = TokenType::EndOfFile;
+            token.type = TokenType::EndOfFile;
         return token;
     }
 
@@ -49,7 +49,7 @@ namespace Slang
         if (mCursor == mEnd)
             return TokenType::EndOfFile;
         SLANG_ASSERT(mCursor);
-        return mCursor->Type;
+        return mCursor->type;
     }
 
     CodePosition TokenReader::PeekLoc() const
@@ -67,7 +67,7 @@ namespace Slang
 
         Token token = *mCursor;
         if (mCursor == mEnd)
-            token.Type = TokenType::EndOfFile;
+            token.type = TokenType::EndOfFile;
         else
             mCursor++;
         return token;
@@ -774,8 +774,8 @@ namespace Slang
 
     String getStringLiteralTokenValue(Token const& token)
     {
-        SLANG_ASSERT(token.Type == TokenType::StringLiteral
-            || token.Type == TokenType::CharLiteral);
+        SLANG_ASSERT(token.type == TokenType::StringLiteral
+            || token.type == TokenType::CharLiteral);
 
         char const* cursor = token.Content.begin();
         char const* end = token.Content.end();
@@ -1244,7 +1244,7 @@ namespace Slang
                 break;
             }
 
-            token.Type =  tokenType;
+            token.type =  tokenType;
 
             char const* textEnd = cursor;
 
@@ -1303,7 +1303,7 @@ namespace Slang
             Token token = lexToken();
             tokenList.mTokens.Add(token);
 
-            if(token.Type == TokenType::EndOfFile)
+            if(token.type == TokenType::EndOfFile)
                 return tokenList;
         }
     }

--- a/source/slang/lookup.cpp
+++ b/source/slang/lookup.cpp
@@ -8,7 +8,7 @@ namespace Slang {
 DeclRef<ExtensionDecl> ApplyExtensionToType(
     SemanticsVisitor*       semantics,
     ExtensionDecl*          extDecl,
-    RefPtr<ExpressionType>  type);
+    RefPtr<Type>  type);
 
 //
 
@@ -74,11 +74,11 @@ bool DeclPassesLookupMask(Decl* decl, LookupMask mask)
     // type declarations
     if(auto aggTypeDecl = dynamic_cast<AggTypeDecl*>(decl))
     {
-        return int(mask) & int(LookupMask::Type);
+        return int(mask) & int(LookupMask::type);
     }
     else if(auto simpleTypeDecl = dynamic_cast<SimpleTypeDecl*>(decl))
     {
-        return int(mask) & int(LookupMask::Type);
+        return int(mask) & int(LookupMask::type);
     }
     // function declarations
     else if(auto funcDecl = dynamic_cast<FunctionDeclBase*>(decl))
@@ -154,7 +154,7 @@ LookupResultItem CreateLookupResultItem(
 void DoMemberLookupImpl(
     Session*                session,
     String const&			name,
-    RefPtr<ExpressionType>	baseType,
+    RefPtr<Type>	baseType,
     LookupRequest const&    request,
     LookupResult&			ioResult,
     BreadcrumbInfo*			breadcrumbs)
@@ -270,7 +270,7 @@ void DoLocalLookupImpl(
     // Consider lookup via extension
     if( auto aggTypeDeclRef = containerDeclRef.As<AggTypeDecl>() )
     {
-        RefPtr<ExpressionType> type = DeclRefType::Create(
+        RefPtr<Type> type = DeclRefType::Create(
             session,
             aggTypeDeclRef);
 

--- a/source/slang/lookup.h
+++ b/source/slang/lookup.h
@@ -38,7 +38,7 @@ QualType getTypeForDeclRef(
     SemanticsVisitor*       sema,
     DiagnosticSink*         sink,
     DeclRef<Decl>           declRef,
-    RefPtr<ExpressionType>* outTypeResult);
+    RefPtr<Type>* outTypeResult);
 
 QualType getTypeForDeclRef(
     Session*        session,

--- a/source/slang/lower.h
+++ b/source/slang/lower.h
@@ -22,12 +22,12 @@ namespace Slang
     struct LoweredEntryPoint
     {
         // The actual lowered entry point
-        RefPtr<FunctionSyntaxNode>  entryPoint;
+        RefPtr<FuncDecl>  entryPoint;
 
         // The generated program AST that
         // contains the entry point and any
         // other declarations it uses
-        RefPtr<ProgramSyntaxNode>   program;
+        RefPtr<ModuleDecl>   program;
     };
 
     // Emit code for a single entry point, based on

--- a/source/slang/modifier-defs.h
+++ b/source/slang/modifier-defs.h
@@ -265,7 +265,7 @@ SIMPLE_SYNTAX_CLASS(HLSLVolatileModifier, Modifier)
 // An HLSL `[name(arg0, ...)]` style attribute.
 SYNTAX_CLASS(HLSLAttribute, Modifier)
     FIELD(Token, nameToken)
-    SYNTAX_FIELD(List<RefPtr<ExpressionSyntaxNode>>, args)
+    SYNTAX_FIELD(List<RefPtr<Expr>>, args)
 END_SYNTAX_CLASS()
 
 // An HLSL `[name(...)]` attribute that hasn't undergone

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -390,7 +390,7 @@ static bool isGLSLBuiltinName(VarDeclBase* varDecl)
     return getReflectionName(varDecl).StartsWith("gl_");
 }
 
-RefPtr<ExpressionType> tryGetEffectiveTypeForGLSLVaryingInput(
+RefPtr<Type> tryGetEffectiveTypeForGLSLVaryingInput(
     ParameterBindingContext*    context,
     VarDeclBase*                varDecl)
 {
@@ -428,7 +428,7 @@ RefPtr<ExpressionType> tryGetEffectiveTypeForGLSLVaryingInput(
     return nullptr;
 }
 
-RefPtr<ExpressionType> tryGetEffectiveTypeForGLSLVaryingOutput(
+RefPtr<Type> tryGetEffectiveTypeForGLSLVaryingOutput(
     ParameterBindingContext*    context,
     VarDeclBase*                varDecl)
 {
@@ -592,14 +592,14 @@ struct EntryPointParameterState
 
 static RefPtr<TypeLayout> processEntryPointParameter(
     ParameterBindingContext*        context,
-    RefPtr<ExpressionType>          type,
+    RefPtr<Type>          type,
     EntryPointParameterState const& state,
     RefPtr<VarLayout>               varLayout);
 
 static void collectGlobalScopeGLSLVaryingParameter(
     ParameterBindingContext*        context,
     RefPtr<VarDeclBase>             varDecl,
-    RefPtr<ExpressionType>          effectiveType,
+    RefPtr<Type>          effectiveType,
     EntryPointParameterDirection    direction)
 {
     int defaultSemanticIndex = 0;
@@ -994,7 +994,7 @@ static void completeBindingsForParameter(
 
 static void collectGlobalScopeParameters(
     ParameterBindingContext*    context,
-    ProgramSyntaxNode*          program)
+    ModuleDecl*          program)
 {
     // First enumerate parameters at global scope
     for( auto decl : program->Members )
@@ -1066,7 +1066,7 @@ SimpleSemanticInfo decomposeSimpleSemantic(
 
 static RefPtr<TypeLayout> processSimpleEntryPointParameter(
     ParameterBindingContext*        context,
-    RefPtr<ExpressionType>          type,
+    RefPtr<Type>          type,
     EntryPointParameterState const& inState,
     RefPtr<VarLayout>               varLayout,
     int                             semanticSlotCount = 1)
@@ -1147,7 +1147,7 @@ static RefPtr<TypeLayout> processSimpleEntryPointParameter(
 static RefPtr<TypeLayout> processEntryPointParameterWithPossibleSemantic(
     ParameterBindingContext*        context,
     Decl*                           declForSemantic,
-    RefPtr<ExpressionType>          type,
+    RefPtr<Type>          type,
     EntryPointParameterState const& state,
     RefPtr<VarLayout>               varLayout)
 {
@@ -1178,7 +1178,7 @@ static RefPtr<TypeLayout> processEntryPointParameterWithPossibleSemantic(
 
 static RefPtr<TypeLayout> processEntryPointParameter(
     ParameterBindingContext*        context,
-    RefPtr<ExpressionType>          type,
+    RefPtr<Type>          type,
     EntryPointParameterState const& state,
     RefPtr<VarLayout>               varLayout)
 {
@@ -1235,7 +1235,7 @@ static RefPtr<TypeLayout> processEntryPointParameter(
     {
         auto declRef = declRefType->declRef;
 
-        if (auto structDeclRef = declRef.As<StructSyntaxNode>())
+        if (auto structDeclRef = declRef.As<StructDecl>())
         {
             RefPtr<StructTypeLayout> structLayout = new StructTypeLayout();
             structLayout->type = type;
@@ -1288,7 +1288,7 @@ static RefPtr<TypeLayout> processEntryPointParameter(
 static void collectEntryPointParameters(
     ParameterBindingContext*        context,
     EntryPointRequest*              entryPoint,
-    ProgramSyntaxNode*              translationUnitSyntax)
+    ModuleDecl*              translationUnitSyntax)
 {
     // First, look for the entry point with the specified name
 
@@ -1307,7 +1307,7 @@ static void collectEntryPointParameters(
         return;
     }
 
-    FunctionSyntaxNode* entryPointFuncDecl = dynamic_cast<FunctionSyntaxNode*>(entryPointDecl);
+    FuncDecl* entryPointFuncDecl = dynamic_cast<FuncDecl*>(entryPointDecl);
     if( !entryPointFuncDecl )
     {
         // Not a function!
@@ -1368,7 +1368,7 @@ static void collectEntryPointParameters(
         auto paramTypeLayout = processEntryPointParameterWithPossibleSemantic(
             context,
             paramDecl.Ptr(),
-            paramDecl->Type.type,
+            paramDecl->type.type,
             state,
             paramVarLayout);
 
@@ -1443,7 +1443,7 @@ inferStageForTranslationUnit(
 
 static void collectModuleParameters(
     ParameterBindingContext*    inContext,
-    ProgramSyntaxNode*          module)
+    ModuleDecl*          module)
 {
     // Each loaded module provides a separate (logical) namespace for
     // parameters, so that two parameters with the same name, in
@@ -1689,10 +1689,10 @@ void generateParameterBindings(
 
         RefPtr<Variable> var = new Variable();
         var->Name.Content = "SLANG_hack_samplerForTexelFetch";
-        var->Type.type = getSamplerStateType(request->mSession);
+        var->type.type = getSamplerStateType(request->mSession);
 
         auto typeLayout = new TypeLayout();
-        typeLayout->type = var->Type.type;
+        typeLayout->type = var->type.type;
         typeLayout->addResourceUsage(LayoutResourceKind::DescriptorTableSlot, 1);
 
         auto varLayout = new VarLayout();

--- a/source/slang/preprocessor.cpp
+++ b/source/slang/preprocessor.cpp
@@ -175,7 +175,7 @@ struct Preprocessor
         return translationUnit;
     }
 
-    ProgramSyntaxNode* getSyntax()
+    ModuleDecl* getSyntax()
     {
         return getTranslationUnit()->SyntaxNode.Ptr();
     }
@@ -411,7 +411,7 @@ static CodePosition PeekLoc(Preprocessor* preprocessor)
 // Get the `TokenType` of the current (raw) token
 static TokenType PeekRawTokenType(Preprocessor* preprocessor)
 {
-    return PeekRawToken(preprocessor).Type;
+    return PeekRawToken(preprocessor).type;
 }
 
 //
@@ -546,7 +546,7 @@ static void AddEndOfStreamToken(
     PreprocessorMacro*  macro)
 {
     Token token = PeekRawToken(preprocessor);
-    token.Type = TokenType::EndOfFile;
+    token.type = TokenType::EndOfFile;
     macro->tokens.mTokens.Add(token);
 }
 
@@ -564,7 +564,7 @@ static void MaybeBeginMacroExpansion(
         Token const& token = PeekRawToken(preprocessor);
 
         // Not an identifier? Can't be a macro.
-        if (token.Type != TokenType::Identifier)
+        if (token.type != TokenType::Identifier)
             return;
 
         // Look for a macro with the given name.
@@ -795,7 +795,7 @@ static Token PeekToken(Preprocessor* preprocessor)
 // Peek the type of the next token, including macro expansion.
 static TokenType PeekTokenType(Preprocessor* preprocessor)
 {
-    return PeekToken(preprocessor).Type;
+    return PeekToken(preprocessor).type;
 }
 
 //
@@ -865,7 +865,7 @@ static PreprocessorMacro* LookupMacro(PreprocessorDirectiveContext* context, Str
 // Determine if we have read everthing on the directive's line.
 static bool IsEndOfLine(PreprocessorDirectiveContext* context)
 {
-    return PeekRawToken(context->preprocessor).Type == TokenType::EndOfDirective;
+    return PeekRawToken(context->preprocessor).type == TokenType::EndOfDirective;
 }
 
 // Peek one raw token in a directive, without going past the end of the line.
@@ -1108,7 +1108,7 @@ static PreprocessorExpressionValue ParseAndEvaluateUnaryExpression(PreprocessorD
                 String name = nameToken.Content;
 
                 // If we saw an opening `(`, then expect one to close
-                if (leftParen.Type != TokenType::Unknown)
+                if (leftParen.type != TokenType::Unknown)
                 {
                     if(!ExpectRaw(context, TokenType::RParent, Diagnostics::expectedTokenInDefinedExpression))
                     {
@@ -1143,7 +1143,7 @@ static int GetInfixOpPrecedence(Token const& opToken)
 
     // otherwise we look at the token type to figure
     // out what precednece it should be parse with
-    switch (opToken.Type)
+    switch (opToken.type)
     {
     default:
         // tokens that aren't infix operators should
@@ -1184,7 +1184,7 @@ static PreprocessorExpressionValue EvaluateInfixOp(
     PreprocessorExpressionValue     left,
     PreprocessorExpressionValue     right)
 {
-    switch (opToken.Type)
+    switch (opToken.type)
     {
     default:
 //        SLANG_INTERNAL_ERROR(getSink(preprocessor), opToken);
@@ -1356,7 +1356,7 @@ static void HandleElseDirective(PreprocessorDirectiveContext* context)
     }
 
     // if we've already seen a `#else`, then it is an error
-    if (conditional->elseToken.Type != TokenType::Unknown)
+    if (conditional->elseToken.type != TokenType::Unknown)
     {
         GetSink(context)->diagnose(GetDirectiveLoc(context), Diagnostics::directiveAfterElse, GetDirectiveName(context));
         GetSink(context)->diagnose(conditional->elseToken.Position, Diagnostics::seeDirective);
@@ -1410,7 +1410,7 @@ static void HandleElifDirective(PreprocessorDirectiveContext* context)
     }
 
     // if we've already seen a `#else`, then it is an error
-    if (conditional->elseToken.Type != TokenType::Unknown)
+    if (conditional->elseToken.type != TokenType::Unknown)
     {
         GetSink(context)->diagnose(GetDirectiveLoc(context), Diagnostics::directiveAfterElse, GetDirectiveName(context));
         GetSink(context)->diagnose(conditional->elseToken.Position, Diagnostics::seeDirective);
@@ -1597,11 +1597,11 @@ static void HandleDefineDirective(PreprocessorDirectiveContext* context)
     for(;;)
     {
         Token token = AdvanceRawToken(context);
-        if( token.Type == TokenType::EndOfDirective )
+        if( token.type == TokenType::EndOfDirective )
         {
             // Last token on line will be turned into a conceptual end-of-file
             // token for the sub-stream that the macro expands into.
-            token.Type = TokenType::EndOfFile;
+            token.type = TokenType::EndOfFile;
             macro->tokens.mTokens.Add(token);
             break;
         }
@@ -1876,7 +1876,7 @@ static void HandleDirective(PreprocessorDirectiveContext* context)
     // Try to read the directive name.
     context->directiveToken = PeekRawToken(context);
 
-    TokenType directiveTokenType = GetDirective(context).Type;
+    TokenType directiveTokenType = GetDirective(context).type;
 
     // An empty directive is allowed, and ignored.
     if (directiveTokenType == TokenType::EndOfDirective)
@@ -1920,12 +1920,12 @@ static Token ReadToken(Preprocessor* preprocessor)
     {
         // Look at the next raw token in the input.
         Token const& token = PeekRawToken(preprocessor);
-        if (token.Type == TokenType::EndOfFile)
+        if (token.type == TokenType::EndOfFile)
             return token;
 
 
         // If we have a directive (`#` at start of line) then handle it
-        if ((token.Type == TokenType::Pound) && (token.flags & TokenFlag::AtStartOfLine))
+        if ((token.type == TokenType::Pound) && (token.flags & TokenFlag::AtStartOfLine))
         {
             // Skip the `#`
             AdvanceRawToken(preprocessor);
@@ -1960,7 +1960,7 @@ static void InitializePreprocessor(
 {
     preprocessor->sink = sink;
     preprocessor->includeHandler = NULL;
-    preprocessor->endOfFileToken.Type = TokenType::EndOfFile;
+    preprocessor->endOfFileToken.type = TokenType::EndOfFile;
     preprocessor->endOfFileToken.flags = TokenFlag::AtStartOfLine;
 }
 
@@ -2032,7 +2032,7 @@ static TokenList ReadAllTokens(
 
         // Note: we include the EOF token in the list,
         // since that is expected by the `TokenList` type.
-        if (token.Type == TokenType::EndOfFile)
+        if (token.type == TokenType::EndOfFile)
             break;
     }
     return tokens;
@@ -2183,14 +2183,14 @@ static void HandleImportDirective(PreprocessorDirectiveContext* context)
     SourceTextInputStream* inputStream = new SourceTextInputStream();
  
     Token token;
-    token.Type = TokenType::PoundImport;
+    token.type = TokenType::PoundImport;
     token.Position = GetDirectiveLoc(context);
     token.flags = 0;
     token.Content = foundPath;
  
     inputStream->lexedTokens.mTokens.Add(token);
  
-    token.Type = TokenType::EndOfFile;
+    token.type = TokenType::EndOfFile;
     token.flags = TokenFlag::AfterWhitespace | TokenFlag::AtStartOfLine;
     inputStream->lexedTokens.mTokens.Add(token);
  

--- a/source/slang/preprocessor.h
+++ b/source/slang/preprocessor.h
@@ -8,7 +8,7 @@
 namespace Slang {
 
 class DiagnosticSink;
-class ProgramSyntaxNode;
+class ModuleDecl;
 class TranslationUnitRequest;
 
 enum class IncludeResult

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -19,12 +19,12 @@ using namespace Slang;
 
 // Conversion routines to help with strongly-typed reflection API
 
-static inline ExpressionType* convert(SlangReflectionType* type)
+static inline Type* convert(SlangReflectionType* type)
 {
-    return (ExpressionType*) type;
+    return (Type*) type;
 }
 
-static inline SlangReflectionType* convert(ExpressionType* type)
+static inline SlangReflectionType* convert(Type* type)
 {
     return (SlangReflectionType*) type;
 }
@@ -80,7 +80,7 @@ static inline SlangReflection* convert(ProgramLayout* program)
     return (SlangReflection*) program;
 }
 
-// Type Reflection
+// type Reflection
 
 
 SLANG_API SlangTypeKind spReflectionType_GetKind(SlangReflectionType* inType)
@@ -145,7 +145,7 @@ SLANG_API SlangTypeKind spReflectionType_GetKind(SlangReflectionType* inType)
     else if( auto declRefType = type->As<DeclRefType>() )
     {
         auto declRef = declRefType->declRef;
-        if( auto structDeclRef = declRef.As<StructSyntaxNode>() )
+        if( auto structDeclRef = declRef.As<StructDecl>() )
         {
             return SLANG_TYPE_KIND_STRUCT;
         }
@@ -170,7 +170,7 @@ SLANG_API unsigned int spReflectionType_GetFieldCount(SlangReflectionType* inTyp
     if(auto declRefType = dynamic_cast<DeclRefType*>(type))
     {
         auto declRef = declRefType->declRef;
-        if( auto structDeclRef = declRef.As<StructSyntaxNode>())
+        if( auto structDeclRef = declRef.As<StructDecl>())
         {
             return GetFields(structDeclRef).Count();
         }
@@ -189,7 +189,7 @@ SLANG_API SlangReflectionVariable* spReflectionType_GetFieldByIndex(SlangReflect
     if(auto declRefType = dynamic_cast<DeclRefType*>(type))
     {
         auto declRef = declRefType->declRef;
-        if( auto structDeclRef = declRef.As<StructSyntaxNode>())
+        if( auto structDeclRef = declRef.As<StructDecl>())
         {
             auto fieldDeclRef = GetFields(structDeclRef).ToArray()[index];
             return (SlangReflectionVariable*) fieldDeclRef.getDecl();
@@ -424,7 +424,7 @@ SLANG_API SlangReflectionType* spReflectionType_GetResourceResultType(SlangRefle
     return nullptr;
 }
 
-// Type Layout Reflection
+// type Layout Reflection
 
 SLANG_API SlangReflectionType* spReflectionTypeLayout_GetType(SlangReflectionTypeLayout* inTypeLayout)
 {
@@ -754,7 +754,7 @@ SLANG_API void spReflectionEntryPoint_getComputeThreadGroupSize(
     {
         // Fall back to the GLSL case, which requires a search over global-scope declarations
         // to look for anything with the `local_size_*` qualifier
-        auto module = dynamic_cast<ProgramSyntaxNode*>(entryPointFunc->ParentDecl);
+        auto module = dynamic_cast<ModuleDecl*>(entryPointFunc->ParentDecl);
         if (module)
         {
             for (auto dd : module->Members)

--- a/source/slang/reflection.h
+++ b/source/slang/reflection.h
@@ -24,12 +24,12 @@ String emitReflectionJSON(
 
 //
 
-SlangTypeKind getReflectionTypeKind(ExpressionType* type);
+SlangTypeKind getReflectionTypeKind(Type* type);
 
 SlangTypeKind getReflectionParameterCategory(TypeLayout* typeLayout);
 
-UInt getReflectionFieldCount(ExpressionType* type);
-UInt getReflectionFieldByIndex(ExpressionType* type, UInt index);
+UInt getReflectionFieldCount(Type* type);
+UInt getReflectionFieldByIndex(Type* type, UInt index);
 UInt getReflectionFieldByIndex(TypeLayout* typeLayout, UInt index);
 
 }

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -112,7 +112,7 @@ void CompileRequest::parseTranslationUnit(
     for(auto& def : translationUnit->preprocessorDefinitions)
         combinedPreprocessorDefinitions.Add(def.Key, def.Value);
 
-    RefPtr<ProgramSyntaxNode> translationUnitSyntax = new ProgramSyntaxNode();
+    RefPtr<ModuleDecl> translationUnitSyntax = new ModuleDecl();
     translationUnit->SyntaxNode = translationUnitSyntax;
 
     for (auto sourceFile : translationUnit->sourceFiles)
@@ -355,7 +355,7 @@ int CompileRequest::addEntryPoint(
     return (int) result;
 }
 
-RefPtr<ProgramSyntaxNode> CompileRequest::loadModule(
+RefPtr<ModuleDecl> CompileRequest::loadModule(
     String const&       name,
     String const&       path,
     String const&       source,
@@ -386,7 +386,7 @@ RefPtr<ProgramSyntaxNode> CompileRequest::loadModule(
 
     //
 
-    RefPtr<ProgramSyntaxNode> moduleDecl = translationUnit->SyntaxNode;
+    RefPtr<ModuleDecl> moduleDecl = translationUnit->SyntaxNode;
 
     mapPathToLoadedModule.Add(path, moduleDecl);
     mapNameToLoadedModules.Add(name, moduleDecl);
@@ -406,7 +406,7 @@ void CompileRequest::handlePoundImport(
     // Imported code is always native Slang code
     RefPtr<Scope> languageScope = mSession->slangLanguageScope;
 
-    RefPtr<ProgramSyntaxNode> translationUnitSyntax = new ProgramSyntaxNode();
+    RefPtr<ModuleDecl> translationUnitSyntax = new ModuleDecl();
     translationUnit->SyntaxNode = translationUnitSyntax;
 
     parseSourceFile(
@@ -424,7 +424,7 @@ void CompileRequest::handlePoundImport(
 
     //
 
-    RefPtr<ProgramSyntaxNode> moduleDecl = translationUnit->SyntaxNode;
+    RefPtr<ModuleDecl> moduleDecl = translationUnit->SyntaxNode;
 
     // TODO: It is a bit broken here that we use the module path,
     // as the "name" when registering things, but this saves
@@ -436,13 +436,13 @@ void CompileRequest::handlePoundImport(
     loadedModulesList.Add(moduleDecl);
 }
 
-RefPtr<ProgramSyntaxNode> CompileRequest::findOrImportModule(
+RefPtr<ModuleDecl> CompileRequest::findOrImportModule(
     String const&       name,
     CodePosition const& loc)
 {
     // Have we already loaded a module matching this name?
     // If so, return it.
-    RefPtr<ProgramSyntaxNode> moduleDecl;
+    RefPtr<ModuleDecl> moduleDecl;
     if (mapNameToLoadedModules.TryGetValue(name, moduleDecl))
         return moduleDecl;
 
@@ -505,7 +505,7 @@ RefPtr<ProgramSyntaxNode> CompileRequest::findOrImportModule(
         loc);
 }
 
-RefPtr<ProgramSyntaxNode> findOrImportModule(
+RefPtr<ModuleDecl> findOrImportModule(
     CompileRequest*     request,
     String const&       name,
     CodePosition const& loc)

--- a/source/slang/slang.natvis
+++ b/source/slang/slang.natvis
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?> 
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
-  <Type Name="Slang::CFGNode">
+  <type Name="Slang::CFGNode">
     <DisplayString>{{CFG Basic Block}}</DisplayString>
     <Expand>
       <LinkedListItems>
@@ -10,5 +10,5 @@
         <ValueNode>Value</ValueNode>
       </LinkedListItems>
     </Expand>
-  </Type>
+  </type>
 </AutoVisualizer>

--- a/source/slang/stmt-defs.h
+++ b/source/slang/stmt-defs.h
@@ -2,39 +2,39 @@
 
 // Syntax class definitions for statements.
 
-ABSTRACT_SYNTAX_CLASS(ScopeStmt, StatementSyntaxNode)
+ABSTRACT_SYNTAX_CLASS(ScopeStmt, Stmt)
     SYNTAX_FIELD(RefPtr<ScopeDecl>, scopeDecl)
 END_SYNTAX_CLASS()
 
 // A sequence of statements, treated as a single statement
-SYNTAX_CLASS(SeqStmt, StatementSyntaxNode)
-    SYNTAX_FIELD(List<RefPtr<StatementSyntaxNode>>, stmts)
+SYNTAX_CLASS(SeqStmt, Stmt)
+    SYNTAX_FIELD(List<RefPtr<Stmt>>, stmts)
 END_SYNTAX_CLASS()
 
 // The simplest kind of scope statement: just a `{...}` block
 SYNTAX_CLASS(BlockStmt, ScopeStmt)
-    SYNTAX_FIELD(RefPtr<StatementSyntaxNode>, body);
+    SYNTAX_FIELD(RefPtr<Stmt>, body);
 END_SYNTAX_CLASS()
 
 // A statement that we aren't going to parse or check, because
 // we want to let a downstream compiler handle any issues
-SYNTAX_CLASS(UnparsedStmt, StatementSyntaxNode)
+SYNTAX_CLASS(UnparsedStmt, Stmt)
     // The tokens that were contained between `{` and `}`
     FIELD(List<Token>, tokens)
 END_SYNTAX_CLASS()
 
-SIMPLE_SYNTAX_CLASS(EmptyStatementSyntaxNode, StatementSyntaxNode)
+SIMPLE_SYNTAX_CLASS(EmptyStmt, Stmt)
 
-SIMPLE_SYNTAX_CLASS(DiscardStatementSyntaxNode, StatementSyntaxNode)
+SIMPLE_SYNTAX_CLASS(DiscardStmt, Stmt)
 
-SYNTAX_CLASS(VarDeclrStatementSyntaxNode, StatementSyntaxNode)
+SYNTAX_CLASS(DeclStmt, Stmt)
     SYNTAX_FIELD(RefPtr<DeclBase>, decl)
 END_SYNTAX_CLASS()
 
-SYNTAX_CLASS(IfStatementSyntaxNode, StatementSyntaxNode)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, Predicate)
-    SYNTAX_FIELD(RefPtr<StatementSyntaxNode>, PositiveStatement)
-    SYNTAX_FIELD(RefPtr<StatementSyntaxNode>, NegativeStatement)
+SYNTAX_CLASS(IfStmt, Stmt)
+    SYNTAX_FIELD(RefPtr<Expr>, Predicate)
+    SYNTAX_FIELD(RefPtr<Stmt>, PositiveStatement)
+    SYNTAX_FIELD(RefPtr<Stmt>, NegativeStatement)
 END_SYNTAX_CLASS()
 
 // A statement that can be escaped with a `break`
@@ -42,15 +42,15 @@ ABSTRACT_SYNTAX_CLASS(BreakableStmt, ScopeStmt)
 END_SYNTAX_CLASS()
 
 SYNTAX_CLASS(SwitchStmt, BreakableStmt)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, condition)
-    SYNTAX_FIELD(RefPtr<StatementSyntaxNode>, body)
+    SYNTAX_FIELD(RefPtr<Expr>, condition)
+    SYNTAX_FIELD(RefPtr<Stmt>, body)
 END_SYNTAX_CLASS()
 
 // A statement that is expected to appear lexically nested inside
 // some other construct, and thus needs to keep track of the
 // outer statement that it is associated with...
-ABSTRACT_SYNTAX_CLASS(ChildStmt, StatementSyntaxNode)
-    DECL_FIELD(StatementSyntaxNode*, parentStmt RAW(= nullptr))
+ABSTRACT_SYNTAX_CLASS(ChildStmt, Stmt)
+    DECL_FIELD(Stmt*, parentStmt RAW(= nullptr))
 END_SYNTAX_CLASS()
 
 // a `case` or `default` statement inside a `switch`
@@ -63,7 +63,7 @@ END_SYNTAX_CLASS()
 
 // a `case` statement inside a `switch`
 SYNTAX_CLASS(CaseStmt, CaseStmtBase)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, expr)
+    SYNTAX_FIELD(RefPtr<Expr>, expr)
 END_SYNTAX_CLASS()
 
 // a `default` statement inside a `switch`
@@ -74,34 +74,34 @@ ABSTRACT_SYNTAX_CLASS(LoopStmt, BreakableStmt)
 END_SYNTAX_CLASS()
 
 // A `for` statement
-SYNTAX_CLASS(ForStatementSyntaxNode, LoopStmt)
-    SYNTAX_FIELD(RefPtr<StatementSyntaxNode>, InitialStatement)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, SideEffectExpression)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, PredicateExpression)
-    SYNTAX_FIELD(RefPtr<StatementSyntaxNode>, Statement)
+SYNTAX_CLASS(ForStmt, LoopStmt)
+    SYNTAX_FIELD(RefPtr<Stmt>, InitialStatement)
+    SYNTAX_FIELD(RefPtr<Expr>, SideEffectExpression)
+    SYNTAX_FIELD(RefPtr<Expr>, PredicateExpression)
+    SYNTAX_FIELD(RefPtr<Stmt>, Statement)
 END_SYNTAX_CLASS()
 
 // A `for` statement in a language that doesn't restrict the scope
 // of the loop variable to the body.
-SYNTAX_CLASS(UnscopedForStmt, ForStatementSyntaxNode);
+SYNTAX_CLASS(UnscopedForStmt, ForStmt);
 END_SYNTAX_CLASS()
 
-SYNTAX_CLASS(WhileStatementSyntaxNode, LoopStmt)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, Predicate)
-    SYNTAX_FIELD(RefPtr<StatementSyntaxNode>, Statement)
+SYNTAX_CLASS(WhileStmt, LoopStmt)
+    SYNTAX_FIELD(RefPtr<Expr>, Predicate)
+    SYNTAX_FIELD(RefPtr<Stmt>, Statement)
 END_SYNTAX_CLASS()
 
-SYNTAX_CLASS(DoWhileStatementSyntaxNode, LoopStmt)
-    SYNTAX_FIELD(RefPtr<StatementSyntaxNode>, Statement)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, Predicate)
+SYNTAX_CLASS(DoWhileStmt, LoopStmt)
+    SYNTAX_FIELD(RefPtr<Stmt>, Statement)
+    SYNTAX_FIELD(RefPtr<Expr>, Predicate)
 END_SYNTAX_CLASS()
 
 // A compile-time, range-based `for` loop, which will not appear in the output code
 SYNTAX_CLASS(CompileTimeForStmt, ScopeStmt)
     SYNTAX_FIELD(RefPtr<Variable>, varDecl)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, rangeBeginExpr)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, rangeEndExpr)
-    SYNTAX_FIELD(RefPtr<StatementSyntaxNode>, body)
+    SYNTAX_FIELD(RefPtr<Expr>, rangeBeginExpr)
+    SYNTAX_FIELD(RefPtr<Expr>, rangeEndExpr)
+    SYNTAX_FIELD(RefPtr<Stmt>, body)
     SYNTAX_FIELD(RefPtr<IntVal>, rangeBeginVal)
     SYNTAX_FIELD(RefPtr<IntVal>, rangeEndVal)
 END_SYNTAX_CLASS()
@@ -111,14 +111,14 @@ END_SYNTAX_CLASS()
 ABSTRACT_SYNTAX_CLASS(JumpStmt, ChildStmt)
 END_SYNTAX_CLASS()
 
-SIMPLE_SYNTAX_CLASS(BreakStatementSyntaxNode, JumpStmt)
+SIMPLE_SYNTAX_CLASS(BreakStmt, JumpStmt)
 
-SIMPLE_SYNTAX_CLASS(ContinueStatementSyntaxNode, JumpStmt)
+SIMPLE_SYNTAX_CLASS(ContinueStmt, JumpStmt)
 
-SYNTAX_CLASS(ReturnStatementSyntaxNode, StatementSyntaxNode)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, Expression)
+SYNTAX_CLASS(ReturnStmt, Stmt)
+    SYNTAX_FIELD(RefPtr<Expr>, Expression)
 END_SYNTAX_CLASS()
 
-SYNTAX_CLASS(ExpressionStatementSyntaxNode, StatementSyntaxNode)
-    SYNTAX_FIELD(RefPtr<ExpressionSyntaxNode>, Expression)
+SYNTAX_CLASS(ExpressionStmt, Stmt)
+    SYNTAX_FIELD(RefPtr<Expr>, Expression)
 END_SYNTAX_CLASS()

--- a/source/slang/syntax-base-defs.h
+++ b/source/slang/syntax-base-defs.h
@@ -2,7 +2,7 @@
 
 // This file defines the primary base classes for the hierarchy of
 // AST nodes and related objects. For example, this is where the
-// basic `Decl`, `Stmt`, `Expr`, `Type`, etc. definitions come from.
+// basic `Decl`, `Stmt`, `Expr`, `type`, etc. definitions come from.
 
 // Base class for all nodes representing actual syntax
 // (thus having a location in the source code)
@@ -64,7 +64,7 @@ END_SYNTAX_CLASS()
 // "canonical" type. The reprsentation caches a pointer to
 // a canonical type on every type, so we can easily
 // operate on the raw representation when needed.
-ABSTRACT_SYNTAX_CLASS(ExpressionType, Val)
+ABSTRACT_SYNTAX_CLASS(Type, Val)
     RAW(typedef ITypeVisitor Visitor;)
 
     RAW(virtual void accept(IValVisitor* visitor, void* extra) override;)
@@ -77,8 +77,8 @@ public:
 
     virtual String ToString() = 0;
 
-    bool Equals(ExpressionType * type);
-    bool Equals(RefPtr<ExpressionType> type);
+    bool Equals(Type * type);
+    bool Equals(RefPtr<Type> type);
 
     bool IsVectorType() { return As<VectorExpressionType>() != nullptr; }
     bool IsArray() { return As<ArrayExpressionType>() != nullptr; }
@@ -105,16 +105,16 @@ public:
     bool IsSampler() { return As<SamplerStateType>() != nullptr; }
     bool IsStruct();
     bool IsClass();
-    ExpressionType* GetCanonicalType();
+    Type* GetCanonicalType();
 
     virtual RefPtr<Val> SubstituteImpl(Substitutions* subst, int* ioDiff) override;
 
     virtual bool EqualsVal(Val* val) override;
 protected:
-    virtual bool EqualsImpl(ExpressionType * type) = 0;
+    virtual bool EqualsImpl(Type * type) = 0;
 
-    virtual ExpressionType* CreateCanonicalType() = 0;
-    ExpressionType* canonicalType = nullptr;
+    virtual Type* CreateCanonicalType() = 0;
+    Type* canonicalType = nullptr;
 
     Session* session = nullptr;
     )
@@ -234,16 +234,16 @@ ABSTRACT_SYNTAX_CLASS(Decl, DeclBase)
     )
 END_SYNTAX_CLASS()
 
-ABSTRACT_SYNTAX_CLASS(ExpressionSyntaxNode, SyntaxNode)
+ABSTRACT_SYNTAX_CLASS(Expr, SyntaxNode)
     RAW(typedef IExprVisitor Visitor;)
 
-    FIELD(QualType, Type)
+    FIELD(QualType, type)
 
     RAW(virtual void accept(IExprVisitor* visitor, void* extra) = 0;)
 
 END_SYNTAX_CLASS()
 
-ABSTRACT_SYNTAX_CLASS(StatementSyntaxNode, ModifiableSyntaxNode)
+ABSTRACT_SYNTAX_CLASS(Stmt, ModifiableSyntaxNode)
     RAW(typedef IStmtVisitor Visitor;)
 
     RAW(virtual void accept(IStmtVisitor* visitor, void* extra) = 0;)

--- a/source/slang/syntax-visitors.h
+++ b/source/slang/syntax-visitors.h
@@ -23,7 +23,7 @@ namespace Slang
     // Needed by import declaration checking.
     //
     // TODO: need a better location to declare this.
-    RefPtr<ProgramSyntaxNode> findOrImportModule(
+    RefPtr<ModuleDecl> findOrImportModule(
         CompileRequest*     request,
         String const&       name,
         CodePosition const& loc);

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -10,7 +10,7 @@ namespace Slang
 {
     // BasicExpressionType
 
-    bool BasicExpressionType::EqualsImpl(ExpressionType * type)
+    bool BasicExpressionType::EqualsImpl(Type * type)
     {
         auto basicType = dynamic_cast<const BasicExpressionType*>(type);
         if (basicType == nullptr)
@@ -18,7 +18,7 @@ namespace Slang
         return basicType->BaseType == BaseType;
     }
 
-    ExpressionType* BasicExpressionType::CreateCanonicalType()
+    Type* BasicExpressionType::CreateCanonicalType()
     {
         // A basic type is already canonical, in our setup
         return this;
@@ -76,19 +76,19 @@ namespace Slang
 
 #include "object-meta-end.h"
 
-void ExpressionType::accept(IValVisitor* visitor, void* extra)
+void Type::accept(IValVisitor* visitor, void* extra)
 {
     accept((ITypeVisitor*)visitor, extra);
 }
 
     // TypeExp
 
-    bool TypeExp::Equals(ExpressionType* other)
+    bool TypeExp::Equals(Type* other)
     {
         return type->Equals(other);
     }
 
-    bool TypeExp::Equals(RefPtr<ExpressionType> other)
+    bool TypeExp::Equals(RefPtr<Type> other)
     {
         return type->Equals(other.Ptr());
     }
@@ -102,29 +102,29 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
 
     //
 
-    bool ExpressionType::Equals(ExpressionType * type)
+    bool Type::Equals(Type * type)
     {
         return GetCanonicalType()->EqualsImpl(type->GetCanonicalType());
     }
 
-    bool ExpressionType::Equals(RefPtr<ExpressionType> type)
+    bool Type::Equals(RefPtr<Type> type)
     {
         return Equals(type.Ptr());
     }
 
-    bool ExpressionType::EqualsVal(Val* val)
+    bool Type::EqualsVal(Val* val)
     {
-        if (auto type = dynamic_cast<ExpressionType*>(val))
-            return const_cast<ExpressionType*>(this)->Equals(type);
+        if (auto type = dynamic_cast<Type*>(val))
+            return const_cast<Type*>(this)->Equals(type);
         return false;
     }
 
-    NamedExpressionType* ExpressionType::AsNamedType()
+    NamedExpressionType* Type::AsNamedType()
     {
         return dynamic_cast<NamedExpressionType*>(this);
     }
 
-    RefPtr<Val> ExpressionType::SubstituteImpl(Substitutions* subst, int* ioDiff)
+    RefPtr<Val> Type::SubstituteImpl(Substitutions* subst, int* ioDiff)
     {
         int diff = 0;
         auto canSubst = GetCanonicalType()->SubstituteImpl(subst, &diff);
@@ -140,10 +140,10 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
     }
 
 
-    ExpressionType* ExpressionType::GetCanonicalType()
+    Type* Type::GetCanonicalType()
     {
         if (!this) return nullptr;
-        ExpressionType* et = const_cast<ExpressionType*>(this);
+        Type* et = const_cast<Type*>(this);
         if (!et->canonicalType)
         {
             // TODO(tfoley): worry about thread safety here?
@@ -153,15 +153,15 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         return et->canonicalType;
     }
 
-    bool ExpressionType::IsTextureOrSampler()
+    bool Type::IsTextureOrSampler()
     {
         return IsTexture() || IsSampler();
     }
-    bool ExpressionType::IsStruct()
+    bool Type::IsStruct()
     {
         auto declRefType = AsDeclRefType();
         if (!declRefType) return false;
-        auto structDeclRef = declRefType->declRef.As<StructSyntaxNode>();
+        auto structDeclRef = declRefType->declRef.As<StructDecl>();
         if (!structDeclRef) return false;
         return true;
     }
@@ -178,65 +178,65 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         overloadedType->setSession(this);
     }
 
-    ExpressionType* Session::getBoolType()
+    Type* Session::getBoolType()
     {
         return getBuiltinType(BaseType::Bool);
     }
 
-    ExpressionType* Session::getFloatType()
+    Type* Session::getFloatType()
     {
         return getBuiltinType(BaseType::Float);
     }
 
-    ExpressionType* Session::getDoubleType()
+    Type* Session::getDoubleType()
     {
         return getBuiltinType(BaseType::Double);
     }
 
-    ExpressionType* Session::getIntType()
+    Type* Session::getIntType()
     {
         return getBuiltinType(BaseType::Int);
     }
 
-    ExpressionType* Session::getUIntType()
+    Type* Session::getUIntType()
     {
         return getBuiltinType(BaseType::UInt);
     }
 
-    ExpressionType* Session::getVoidType()
+    Type* Session::getVoidType()
     {
         return getBuiltinType(BaseType::Void);
     }
 
-    ExpressionType* Session::getBuiltinType(BaseType flavor)
+    Type* Session::getBuiltinType(BaseType flavor)
     {
-        return RefPtr<ExpressionType>(builtinTypes[(int)flavor]);
+        return RefPtr<Type>(builtinTypes[(int)flavor]);
     }
 
-    ExpressionType* Session::getInitializerListType()
+    Type* Session::getInitializerListType()
     {
         return initializerListType;
     }
 
-    ExpressionType* Session::getOverloadedType()
+    Type* Session::getOverloadedType()
     {
         return overloadedType;
     }
 
-    ExpressionType* Session::getErrorType()
+    Type* Session::getErrorType()
     {
         return errorType;
     }
 
 
-    bool ArrayExpressionType::EqualsImpl(ExpressionType * type)
+    bool ArrayExpressionType::EqualsImpl(Type * type)
     {
         auto arrType = type->AsArrayType();
         if (!arrType)
             return false;
         return (ArrayLength == arrType->ArrayLength && BaseType->Equals(arrType->BaseType.Ptr()));
     }
-    ExpressionType* ArrayExpressionType::CreateCanonicalType()
+    Type* ArrayExpressionType::CreateCanonicalType()
     {
         auto canonicalElementType = BaseType->GetCanonicalType();
         auto canonicalArrayType = getArrayType(
@@ -272,7 +272,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         return (declRef.GetHashCode() * 16777619) ^ (int)(typeid(this).hash_code());
     }
 
-    bool DeclRefType::EqualsImpl(ExpressionType * type)
+    bool DeclRefType::EqualsImpl(Type * type)
     {
         if (auto declRefType = type->AsDeclRefType())
         {
@@ -281,7 +281,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         return false;
     }
 
-    ExpressionType* DeclRefType::CreateCanonicalType()
+    Type* DeclRefType::CreateCanonicalType()
     {
         // A declaration reference is already canonical
         return this;
@@ -343,9 +343,9 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         return DeclRefType::Create(getSession(), substDeclRef);
     }
 
-    static RefPtr<ExpressionType> ExtractGenericArgType(RefPtr<Val> val)
+    static RefPtr<Type> ExtractGenericArgType(RefPtr<Val> val)
     {
-        auto type = val.As<ExpressionType>();
+        auto type = val.As<Type>();
         SLANG_RELEASE_ASSERT(type.Ptr());
         return type;
     }
@@ -512,12 +512,12 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         return "overload group";
     }
 
-    bool OverloadGroupType::EqualsImpl(ExpressionType * /*type*/)
+    bool OverloadGroupType::EqualsImpl(Type * /*type*/)
     {
         return false;
     }
 
-    ExpressionType* OverloadGroupType::CreateCanonicalType()
+    Type* OverloadGroupType::CreateCanonicalType()
     {
         return this;
     }
@@ -534,12 +534,12 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         return "initializer list";
     }
 
-    bool InitializerListType::EqualsImpl(ExpressionType * /*type*/)
+    bool InitializerListType::EqualsImpl(Type * /*type*/)
     {
         return false;
     }
 
-    ExpressionType* InitializerListType::CreateCanonicalType()
+    Type* InitializerListType::CreateCanonicalType()
     {
         return this;
     }
@@ -556,14 +556,14 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         return "error";
     }
 
-    bool ErrorType::EqualsImpl(ExpressionType* type)
+    bool ErrorType::EqualsImpl(Type* type)
     {
         if (auto errorType = type->As<ErrorType>())
             return true;
         return false;
     }
 
-    ExpressionType* ErrorType::CreateCanonicalType()
+    Type* ErrorType::CreateCanonicalType()
     {
         return  this;
     }
@@ -581,13 +581,13 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         return declRef.GetName();
     }
 
-    bool NamedExpressionType::EqualsImpl(ExpressionType * /*type*/)
+    bool NamedExpressionType::EqualsImpl(Type * /*type*/)
     {
         SLANG_UNEXPECTED("unreachable");
         return false;
     }
 
-    ExpressionType* NamedExpressionType::CreateCanonicalType()
+    Type* NamedExpressionType::CreateCanonicalType()
     {
         return GetType(declRef)->GetCanonicalType();
     }
@@ -609,7 +609,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
             return "/* unknown FuncType */";
     }
 
-    bool FuncType::EqualsImpl(ExpressionType * type)
+    bool FuncType::EqualsImpl(Type * type)
     {
         if (auto funcType = type->As<FuncType>())
         {
@@ -618,7 +618,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         return false;
     }
 
-    ExpressionType* FuncType::CreateCanonicalType()
+    Type* FuncType::CreateCanonicalType()
     {
         return this;
     }
@@ -637,7 +637,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         return sb.ProduceString();
     }
 
-    bool TypeType::EqualsImpl(ExpressionType * t)
+    bool TypeType::EqualsImpl(Type * t)
     {
         if (auto typeType = t->As<TypeType>())
         {
@@ -646,7 +646,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         return false;
     }
 
-    ExpressionType* TypeType::CreateCanonicalType()
+    Type* TypeType::CreateCanonicalType()
     {
         auto canType = getTypeType(type->GetCanonicalType());
         session->canonicalTypes.Add(canType);
@@ -667,7 +667,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         return "<DeclRef<GenericDecl>>";
     }
 
-    bool GenericDeclRefType::EqualsImpl(ExpressionType * type)
+    bool GenericDeclRefType::EqualsImpl(Type * type)
     {
         if (auto genericDeclRefType = type->As<GenericDeclRefType>())
         {
@@ -681,7 +681,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         return declRef.GetHashCode();
     }
 
-    ExpressionType* GenericDeclRefType::CreateCanonicalType()
+    Type* GenericDeclRefType::CreateCanonicalType()
     {
         return this;
     }
@@ -716,9 +716,9 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         return getElementType()->AsBasicType();
     }
 
-    ExpressionType* MatrixExpressionType::getElementType()
+    Type* MatrixExpressionType::getElementType()
     {
-        return this->declRef.substitutions->args[0].As<ExpressionType>().Ptr();
+        return this->declRef.substitutions->args[0].As<Type>().Ptr();
     }
 
     IntVal* MatrixExpressionType::getRowCount()
@@ -840,7 +840,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
 
     // DeclRefBase
 
-    RefPtr<ExpressionType> DeclRefBase::Substitute(RefPtr<ExpressionType> type) const
+    RefPtr<Type> DeclRefBase::Substitute(RefPtr<Type> type) const
     {
         // No substitutions? Easy.
         if (!substitutions)
@@ -849,7 +849,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         // Otherwise we need to recurse on the type structure
         // and apply substitutions where it makes sense
 
-        return type->Substitute(substitutions.Ptr()).As<ExpressionType>();
+        return type->Substitute(substitutions.Ptr()).As<Type>();
     }
 
     DeclRefBase DeclRefBase::Substitute(DeclRefBase declRef) const
@@ -861,7 +861,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
         return declRef.SubstituteImpl(substitutions.Ptr(), &diff);
     }
 
-    RefPtr<ExpressionSyntaxNode> DeclRefBase::Substitute(RefPtr<ExpressionSyntaxNode> expr) const
+    RefPtr<Expr> DeclRefBase::Substitute(RefPtr<Expr> expr) const
     {
         // No substitutions? Easy.
         if (!substitutions)
@@ -1063,9 +1063,9 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
 
     // HLSLPatchType
 
-    ExpressionType* HLSLPatchType::getElementType()
+    Type* HLSLPatchType::getElementType()
     {
-        return this->declRef.substitutions->args[0].As<ExpressionType>().Ptr();
+        return this->declRef.substitutions->args[0].As<Type>().Ptr();
     }
 
     IntVal* HLSLPatchType::getElementCount()
@@ -1076,7 +1076,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
     // Constructors for types
 
     RefPtr<ArrayExpressionType> getArrayType(
-        ExpressionType* elementType,
+        Type* elementType,
         IntVal*         elementCount)
     {
         auto session = elementType->getSession();
@@ -1088,7 +1088,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
     }
 
     RefPtr<ArrayExpressionType> getArrayType(
-        ExpressionType* elementType)
+        Type* elementType)
     {
         auto session = elementType->getSession();
         auto arrayType = new ArrayExpressionType();
@@ -1107,7 +1107,7 @@ void ExpressionType::accept(IValVisitor* visitor, void* extra)
     }
 
     RefPtr<TypeType> getTypeType(
-        ExpressionType* type)
+        Type* type)
     {
         auto session = type->getSession();
         auto typeType = new TypeType(type);

--- a/source/slang/token.h
+++ b/source/slang/token.h
@@ -26,7 +26,7 @@ typedef unsigned int TokenFlags;
 class Token
 {
 public:
-	TokenType Type = TokenType::Unknown;
+	TokenType type = TokenType::Unknown;
 	String Content;
 	CodePosition Position;
     TokenFlags flags = 0;
@@ -34,7 +34,7 @@ public:
 	Token(TokenType type, const String & content, int line, int col, int pos, String fileName, TokenFlags flags = 0)
         : flags(flags)
 	{
-		Type = type;
+		type = type;
 		Content = content;
 		Position = CodePosition(line, col, pos, fileName);
 	}

--- a/source/slang/type-defs.h
+++ b/source/slang/type-defs.h
@@ -3,46 +3,46 @@
 // Syntax class definitions for types.
 
 // The type of a reference to an overloaded name
-SYNTAX_CLASS(OverloadGroupType, ExpressionType)
+SYNTAX_CLASS(OverloadGroupType, Type)
 RAW(
 public:
     virtual String ToString() override;
 
 protected:
-    virtual bool EqualsImpl(ExpressionType * type) override;
-    virtual ExpressionType* CreateCanonicalType() override;
+    virtual bool EqualsImpl(Type * type) override;
+    virtual Type* CreateCanonicalType() override;
     virtual int GetHashCode() override;
 )
 END_SYNTAX_CLASS()
 
 // The type of an initializer-list expression (before it has
 // been coerced to some other type)
-SYNTAX_CLASS(InitializerListType, ExpressionType)
+SYNTAX_CLASS(InitializerListType, Type)
 RAW(
     virtual String ToString() override;
 
 protected:
-    virtual bool EqualsImpl(ExpressionType * type) override;
-    virtual ExpressionType* CreateCanonicalType() override;
+    virtual bool EqualsImpl(Type * type) override;
+    virtual Type* CreateCanonicalType() override;
     virtual int GetHashCode() override;
 )
 END_SYNTAX_CLASS()
 
 // The type of an expression that was erroneous
-SYNTAX_CLASS(ErrorType, ExpressionType)
+SYNTAX_CLASS(ErrorType, Type)
 RAW(
 public:
     virtual String ToString() override;
 
 protected:
-    virtual bool EqualsImpl(ExpressionType * type) override;
-    virtual ExpressionType* CreateCanonicalType() override;
+    virtual bool EqualsImpl(Type * type) override;
+    virtual Type* CreateCanonicalType() override;
     virtual int GetHashCode() override;
 )
 END_SYNTAX_CLASS()
 
 // A type that takes the form of a reference to some declaration
-SYNTAX_CLASS(DeclRefType, ExpressionType)
+SYNTAX_CLASS(DeclRefType, Type)
     DECL_FIELD(DeclRef<Decl>, declRef)
 
 RAW(
@@ -61,8 +61,8 @@ RAW(
     {}
 protected:
     virtual int GetHashCode() override;
-    virtual bool EqualsImpl(ExpressionType * type) override;
-    virtual ExpressionType* CreateCanonicalType() override;
+    virtual bool EqualsImpl(Type * type) override;
+    virtual Type* CreateCanonicalType() override;
 )
 END_SYNTAX_CLASS()
 
@@ -88,8 +88,8 @@ RAW(
     virtual Slang::String ToString() override;
 protected:
     virtual BasicExpressionType* GetScalarType() override;
-    virtual bool EqualsImpl(ExpressionType * type) override;
-    virtual ExpressionType* CreateCanonicalType() override;
+    virtual bool EqualsImpl(Type * type) override;
+    virtual Type* CreateCanonicalType() override;
 )
 END_SYNTAX_CLASS()
 
@@ -150,7 +150,7 @@ END_SYNTAX_CLASS()
 // Resources that contain "elements" that can be fetched
 ABSTRACT_SYNTAX_CLASS(ResourceType, ResourceTypeBase)
     // The type that results from fetching an element from this resource
-    SYNTAX_FIELD(RefPtr<ExpressionType>, elementType)
+    SYNTAX_FIELD(RefPtr<Type>, elementType)
 END_SYNTAX_CLASS()
 
 ABSTRACT_SYNTAX_CLASS(TextureTypeBase, ResourceType)
@@ -159,7 +159,7 @@ RAW(
     {}
     TextureTypeBase(
         Flavor flavor,
-        RefPtr<ExpressionType> elementType)
+        RefPtr<Type> elementType)
     {
         this->elementType = elementType;
         this->flavor = flavor;
@@ -173,7 +173,7 @@ RAW(
     {}
     TextureType(
         Flavor flavor,
-        RefPtr<ExpressionType> elementType)
+        RefPtr<Type> elementType)
         : TextureTypeBase(flavor, elementType)
     {}
 )
@@ -187,7 +187,7 @@ RAW(
     {}
     TextureSamplerType(
         Flavor flavor,
-        RefPtr<ExpressionType> elementType)
+        RefPtr<Type> elementType)
         : TextureTypeBase(flavor, elementType)
     {}
 )
@@ -200,7 +200,7 @@ RAW(
     {}
     GLSLImageType(
         Flavor flavor,
-        RefPtr<ExpressionType> elementType)
+        RefPtr<Type> elementType)
         : TextureTypeBase(flavor, elementType)
     {}
 )
@@ -221,7 +221,7 @@ END_SYNTAX_CLASS()
 
 // Other cases of generic types known to the compiler
 SYNTAX_CLASS(BuiltinGenericType, DeclRefType)
-    SYNTAX_FIELD(RefPtr<ExpressionType>, elementType)
+    SYNTAX_FIELD(RefPtr<Type>, elementType)
 END_SYNTAX_CLASS()
 
 // Types that behave like pointers, in that they can be
@@ -243,7 +243,7 @@ SIMPLE_SYNTAX_CLASS(HLSLConsumeStructuredBufferType, BuiltinGenericType)
 
 SYNTAX_CLASS(HLSLPatchType, DeclRefType)
 RAW(
-    ExpressionType* getElementType();
+    Type* getElementType();
     IntVal*         getElementCount();
 )
 END_SYNTAX_CLASS()
@@ -268,30 +268,30 @@ SIMPLE_SYNTAX_CLASS(ParameterBlockType, PointerLikeType)
 SIMPLE_SYNTAX_CLASS(UniformParameterBlockType, ParameterBlockType)
 SIMPLE_SYNTAX_CLASS(VaryingParameterBlockType, ParameterBlockType)
 
-// Type for HLSL `cbuffer` declarations, and `ConstantBuffer<T>`
+// type for HLSL `cbuffer` declarations, and `ConstantBuffer<T>`
 // ALso used for GLSL `uniform` blocks.
 SIMPLE_SYNTAX_CLASS(ConstantBufferType, UniformParameterBlockType)
 
-// Type for HLSL `tbuffer` declarations, and `TextureBuffer<T>`
+// type for HLSL `tbuffer` declarations, and `TextureBuffer<T>`
 SIMPLE_SYNTAX_CLASS(TextureBufferType, UniformParameterBlockType)
 
-// Type for GLSL `in` and `out` blocks
+// type for GLSL `in` and `out` blocks
 SIMPLE_SYNTAX_CLASS(GLSLInputParameterBlockType, VaryingParameterBlockType)
 SIMPLE_SYNTAX_CLASS(GLSLOutputParameterBlockType, VaryingParameterBlockType)
 
-// Type for GLLSL `buffer` blocks
+// type for GLLSL `buffer` blocks
 SIMPLE_SYNTAX_CLASS(GLSLShaderStorageBufferType, UniformParameterBlockType)
 
-SYNTAX_CLASS(ArrayExpressionType, ExpressionType)
-    SYNTAX_FIELD(RefPtr<ExpressionType>, BaseType)
+SYNTAX_CLASS(ArrayExpressionType, Type)
+    SYNTAX_FIELD(RefPtr<Type>, BaseType)
     SYNTAX_FIELD(RefPtr<IntVal>, ArrayLength)
 
 RAW(
     virtual Slang::String ToString() override;
 
 protected:
-    virtual bool EqualsImpl(ExpressionType * type) override;
-    virtual ExpressionType* CreateCanonicalType() override;
+    virtual bool EqualsImpl(Type * type) override;
+    virtual Type* CreateCanonicalType() override;
     virtual int GetHashCode() override;
 )
 END_SYNTAX_CLASS()
@@ -299,23 +299,23 @@ END_SYNTAX_CLASS()
 // The "type" of an expression that resolves to a type.
 // For example, in the expression `float(2)` the sub-expression,
 // `float` would have the type `TypeType(float)`.
-SYNTAX_CLASS(TypeType, ExpressionType)
+SYNTAX_CLASS(TypeType, Type)
     // The type that this is the type of...
-    SYNTAX_FIELD(RefPtr<ExpressionType>, type)
+    SYNTAX_FIELD(RefPtr<Type>, type)
 
 RAW(
 public:
     TypeType()
     {}
-    TypeType(RefPtr<ExpressionType> type)
+    TypeType(RefPtr<Type> type)
         : type(type)
     {}
 
     virtual String ToString() override;
 
 protected:
-    virtual bool EqualsImpl(ExpressionType * type) override;
-    virtual ExpressionType* CreateCanonicalType() override;
+    virtual bool EqualsImpl(Type * type) override;
+    virtual Type* CreateCanonicalType() override;
     virtual int GetHashCode() override;
 )
 END_SYNTAX_CLASS()
@@ -325,7 +325,7 @@ SYNTAX_CLASS(VectorExpressionType, ArithmeticExpressionType)
 
     // The type of vector elements.
     // As an invariant, this should be a basic type or an alias.
-    SYNTAX_FIELD(RefPtr<ExpressionType>, elementType)
+    SYNTAX_FIELD(RefPtr<Type>, elementType)
 
     // The number of elements
     SYNTAX_FIELD(RefPtr<IntVal>, elementCount)
@@ -342,7 +342,7 @@ END_SYNTAX_CLASS()
 SYNTAX_CLASS(MatrixExpressionType, ArithmeticExpressionType)
 RAW(
 
-    ExpressionType* getElementType();
+    Type* getElementType();
     IntVal*         getRowCount();
     IntVal*         getColumnCount();
 
@@ -355,7 +355,7 @@ protected:
 END_SYNTAX_CLASS()
 
 // A type alias of some kind (e.g., via `typedef`)
-SYNTAX_CLASS(NamedExpressionType, ExpressionType)
+SYNTAX_CLASS(NamedExpressionType, Type)
     DECL_FIELD(DeclRef<TypeDefDecl>, declRef)
 
 RAW(
@@ -370,8 +370,8 @@ RAW(
     virtual String ToString() override;
 
 protected:
-    virtual bool EqualsImpl(ExpressionType * type) override;
-    virtual ExpressionType* CreateCanonicalType() override;
+    virtual bool EqualsImpl(Type * type) override;
+    virtual Type* CreateCanonicalType() override;
     virtual int GetHashCode() override;
 )
 END_SYNTAX_CLASS()
@@ -380,7 +380,7 @@ END_SYNTAX_CLASS()
 // either ordinary functions, or "component functions."
 // We do not directly store a representation of the type, and instead
 // use a reference to the symbol to stand in for its logical type
-SYNTAX_CLASS(FuncType, ExpressionType)
+SYNTAX_CLASS(FuncType, Type)
     DECL_FIELD(DeclRef<CallableDecl>, declRef)
 
 RAW(
@@ -389,14 +389,14 @@ RAW(
 
     virtual String ToString() override;
 protected:
-    virtual bool EqualsImpl(ExpressionType * type) override;
-    virtual ExpressionType* CreateCanonicalType() override;
+    virtual bool EqualsImpl(Type * type) override;
+    virtual Type* CreateCanonicalType() override;
     virtual int GetHashCode() override;
 )
 END_SYNTAX_CLASS()
 
 // The "type" of an expression that names a generic declaration.
-SYNTAX_CLASS(GenericDeclRefType, ExpressionType)
+SYNTAX_CLASS(GenericDeclRefType, Type)
 
     DECL_FIELD(DeclRef<GenericDecl>, declRef)
 
@@ -414,9 +414,9 @@ SYNTAX_CLASS(GenericDeclRefType, ExpressionType)
     virtual String ToString() override;
 
 protected:
-    virtual bool EqualsImpl(ExpressionType * type) override;
+    virtual bool EqualsImpl(Type * type) override;
     virtual int GetHashCode() override;
-    virtual ExpressionType* CreateCanonicalType() override;
+    virtual Type* CreateCanonicalType() override;
 )
 END_SYNTAX_CLASS()
 

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -624,7 +624,7 @@ bool IsResourceKind(LayoutResourceKind kind)
 
 SimpleLayoutInfo GetSimpleLayoutImpl(
     SimpleLayoutInfo        info,
-    RefPtr<ExpressionType>  type,
+    RefPtr<Type>  type,
     LayoutRulesImpl*        rules,
     RefPtr<TypeLayout>*     outTypeLayout)
 {
@@ -740,7 +740,7 @@ RefPtr<ParameterBlockTypeLayout>
 createParameterBlockTypeLayout(
     RefPtr<ParameterBlockType>  parameterBlockType,
     LayoutRulesImpl*            parameterBlockRules,
-    RefPtr<ExpressionType>      elementType,
+    RefPtr<Type>      elementType,
     LayoutRulesImpl*            elementTypeRules)
 {
     // First compute resource usage of the block itself.
@@ -832,7 +832,7 @@ createParameterBlockTypeLayout(
 RefPtr<StructuredBufferTypeLayout>
 createStructuredBufferTypeLayout(
     ShaderParameterKind     kind,
-    RefPtr<ExpressionType>  structuredBufferType,
+    RefPtr<Type>  structuredBufferType,
     RefPtr<TypeLayout>      elementTypeLayout,
     LayoutRulesImpl*        rules)
 {
@@ -865,8 +865,8 @@ createStructuredBufferTypeLayout(
 RefPtr<StructuredBufferTypeLayout>
 createStructuredBufferTypeLayout(
     ShaderParameterKind     kind,
-    RefPtr<ExpressionType>  structuredBufferType,
-    RefPtr<ExpressionType>  elementType,
+    RefPtr<Type>  structuredBufferType,
+    RefPtr<Type>  elementType,
     LayoutRulesImpl*        rules)
 {
     // TODO(tfoley): need to compute the layout for the constant
@@ -888,13 +888,13 @@ createStructuredBufferTypeLayout(
 }
 
 SimpleLayoutInfo GetLayoutImpl(
-    ExpressionType*     type,
+    Type*     type,
     LayoutRulesImpl*    rules,
     RefPtr<TypeLayout>* outTypeLayout,
     SimpleLayoutInfo    offset);
 
 SimpleLayoutInfo GetLayoutImpl(
-    ExpressionType*     type,
+    Type*     type,
     LayoutRulesImpl*    rules,
     RefPtr<TypeLayout>* outTypeLayout)
 {
@@ -902,7 +902,7 @@ SimpleLayoutInfo GetLayoutImpl(
 }
 
 SimpleLayoutInfo GetLayoutImpl(
-    ExpressionType*     type,
+    Type*     type,
     LayoutRulesImpl*    rules,
     RefPtr<TypeLayout>* outTypeLayout,
     SimpleLayoutInfo    offset)
@@ -1154,7 +1154,7 @@ SimpleLayoutInfo GetLayoutImpl(
     {
         auto declRef = declRefType->declRef;
 
-        if (auto structDeclRef = declRef.As<StructSyntaxNode>())
+        if (auto structDeclRef = declRef.As<StructDecl>())
         {
             RefPtr<StructTypeLayout> typeLayout;
             if (outTypeLayout)
@@ -1270,24 +1270,24 @@ SimpleLayoutInfo GetLayoutImpl(
         outTypeLayout);
 }
 
-SimpleLayoutInfo GetLayout(ExpressionType* inType, LayoutRulesImpl* rules)
+SimpleLayoutInfo GetLayout(Type* inType, LayoutRulesImpl* rules)
 {
     return GetLayoutImpl(inType, rules, nullptr);
 }
 
-RefPtr<TypeLayout> CreateTypeLayout(ExpressionType* type, LayoutRulesImpl* rules, SimpleLayoutInfo offset)
+RefPtr<TypeLayout> CreateTypeLayout(Type* type, LayoutRulesImpl* rules, SimpleLayoutInfo offset)
 {
     RefPtr<TypeLayout> typeLayout;
     GetLayoutImpl(type, rules, &typeLayout, offset);
     return typeLayout;
 }
 
-RefPtr<TypeLayout> CreateTypeLayout(ExpressionType* type, LayoutRulesImpl* rules)
+RefPtr<TypeLayout> CreateTypeLayout(Type* type, LayoutRulesImpl* rules)
 {
     return CreateTypeLayout(type, rules, SimpleLayoutInfo());
 }
 
-SimpleLayoutInfo GetLayout(ExpressionType* type, LayoutRule rule)
+SimpleLayoutInfo GetLayout(Type* type, LayoutRule rule)
 {
     LayoutRulesImpl* rulesImpl = GetLayoutRulesImpl(rule);
     return GetLayout(type, rulesImpl);

--- a/source/slang/type-layout.h
+++ b/source/slang/type-layout.h
@@ -16,7 +16,7 @@ typedef uintptr_t UInt;
 // Forward declarations
 
 enum class BaseType;
-class ExpressionType;
+class Type;
 
 //
 
@@ -154,8 +154,8 @@ class TypeLayout : public Layout
 {
 public:
     // The type that was laid out
-    RefPtr<ExpressionType>  type;
-    ExpressionType* getType() { return type.Ptr(); }
+    RefPtr<Type>  type;
+    Type* getType() { return type.Ptr(); }
 
     // The layout rules that were used to produce this type
     LayoutRulesImpl*        rules;
@@ -287,14 +287,14 @@ public:
     }
 };
 
-// Type layout for a variable that has a constant-buffer type
+// type layout for a variable that has a constant-buffer type
 class ParameterBlockTypeLayout : public TypeLayout
 {
 public:
     RefPtr<TypeLayout> elementTypeLayout;
 };
 
-// Type layout for a variable that has a constant-buffer type
+// type layout for a variable that has a constant-buffer type
 class StructuredBufferTypeLayout : public TypeLayout
 {
 public:
@@ -345,7 +345,7 @@ class EntryPointLayout : public StructTypeLayout
 {
 public:
     // The corresponding function declaration
-    RefPtr<FunctionSyntaxNode> entryPoint;
+    RefPtr<FuncDecl> entryPoint;
 
     // The shader profile that was used to compile the entry point
     Profile profile;
@@ -532,12 +532,12 @@ LayoutRulesImpl* GetLayoutRulesImpl(LayoutRule rule);
 LayoutRulesFamilyImpl* GetLayoutRulesFamilyImpl(LayoutRulesFamily rule);
 LayoutRulesFamilyImpl* GetLayoutRulesFamilyImpl(CodeGenTarget target);
 
-SimpleLayoutInfo GetLayout(ExpressionType* type, LayoutRulesImpl* rules);
+SimpleLayoutInfo GetLayout(Type* type, LayoutRulesImpl* rules);
 
-SimpleLayoutInfo GetLayout(ExpressionType* type, LayoutRule rule = LayoutRule::Std430);
+SimpleLayoutInfo GetLayout(Type* type, LayoutRule rule = LayoutRule::Std430);
 
-RefPtr<TypeLayout> CreateTypeLayout(ExpressionType* type, LayoutRulesImpl* rules);
-RefPtr<TypeLayout> CreateTypeLayout(ExpressionType* type, LayoutRulesImpl* rules, SimpleLayoutInfo offset);
+RefPtr<TypeLayout> CreateTypeLayout(Type* type, LayoutRulesImpl* rules);
+RefPtr<TypeLayout> CreateTypeLayout(Type* type, LayoutRulesImpl* rules, SimpleLayoutInfo offset);
 
 //
 
@@ -551,7 +551,7 @@ RefPtr<ParameterBlockTypeLayout>
 createParameterBlockTypeLayout(
     RefPtr<ParameterBlockType>  parameterBlockType,
     LayoutRulesImpl*            parameterBlockRules,
-    RefPtr<ExpressionType>      elementType,
+    RefPtr<Type>      elementType,
     LayoutRulesImpl*            elementTypeRules);
 
 RefPtr<ParameterBlockTypeLayout>
@@ -565,8 +565,8 @@ createParameterBlockTypeLayout(
 RefPtr<StructuredBufferTypeLayout>
 createStructuredBufferTypeLayout(
     ShaderParameterKind     kind,
-    RefPtr<ExpressionType>  structuredBufferType,
-    RefPtr<ExpressionType>  elementType,
+    RefPtr<Type>  structuredBufferType,
+    RefPtr<Type>  elementType,
     LayoutRulesImpl*        rules);
 
 

--- a/source/slang/visitor.h
+++ b/source/slang/visitor.h
@@ -10,7 +10,7 @@
 namespace Slang {
 
 //
-// Type Visitors
+// type Visitors
 //
 
 struct ITypeVisitor
@@ -27,7 +27,7 @@ struct ITypeVisitor
 template<typename Derived, typename Result = void, typename Base = ITypeVisitor>
 struct TypeVisitor : Base
 {
-    Result dispatch(ExpressionType* type)
+    Result dispatch(Type* type)
     {
         Result result;
         type->accept(this, &result);
@@ -56,7 +56,7 @@ struct TypeVisitor : Base
 template<typename Derived, typename Base>
 struct TypeVisitor<Derived,void,Base> : Base
 {
-    void dispatch(ExpressionType* type)
+    void dispatch(Type* type)
     {
         type->accept(this, 0);
     }
@@ -83,7 +83,7 @@ struct TypeVisitor<Derived,void,Base> : Base
 template<typename Derived, typename Arg, typename Base = ITypeVisitor>
 struct TypeVisitorWithArg : Base
 {
-    void dispatch(ExpressionType* type, Arg const& arg)
+    void dispatch(Type* type, Arg const& arg)
     {
         type->accept(this, (void*)&arg);
     }
@@ -125,7 +125,7 @@ struct IExprVisitor
 template<typename Derived, typename Result = void>
 struct ExprVisitor : IExprVisitor
 {
-    Result dispatch(ExpressionSyntaxNode* expr)
+    Result dispatch(Expr* expr)
     {
         Result result;
         expr->accept(this, &result);
@@ -154,7 +154,7 @@ struct ExprVisitor : IExprVisitor
 template<typename Derived>
 struct ExprVisitor<Derived,void> : IExprVisitor
 {
-    void dispatch(ExpressionSyntaxNode* expr)
+    void dispatch(Expr* expr)
     {
         expr->accept(this, 0);
     }
@@ -181,7 +181,7 @@ struct ExprVisitor<Derived,void> : IExprVisitor
 template<typename Derived, typename Arg>
 struct ExprVisitorWithArg : IExprVisitor
 {
-    void dispatch(ExpressionSyntaxNode* obj, Arg const& arg)
+    void dispatch(Expr* obj, Arg const& arg)
     {
         obj->accept(this, (void*)&arg);
     }
@@ -223,7 +223,7 @@ struct IStmtVisitor
 template<typename Derived, typename Result = void>
 struct StmtVisitor : IStmtVisitor
 {
-    Result dispatch(StatementSyntaxNode* stmt)
+    Result dispatch(Stmt* stmt)
     {
         Result result;
         stmt->accept(this, &result);
@@ -252,7 +252,7 @@ struct StmtVisitor : IStmtVisitor
 template<typename Derived>
 struct StmtVisitor<Derived,void> : IStmtVisitor
 {
-    void dispatch(StatementSyntaxNode* stmt)
+    void dispatch(Stmt* stmt)
     {
         stmt->accept(this, 0);
     }


### PR DESCRIPTION
- `ExpressionSyntaxNode` becomes `Expr`
- `StatementSyntaxNode` becomes `Stmt`
- `StructSyntaxNode` becomes `StructDecl`
- `ProgramSyntaxNode` becomes `ModuleDecl`
- `ExpressionType` becomes `Type`
  - Existing fields names `Type` become `type`
  - There might be some collateral damage here if there were, e.g., `enum`s named `Type`, but I can live with that for now and fix those up as a I see them