### PR TITLE
Make source location lightweight

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -984,6 +984,7 @@ namespace slang
 #include "source/slang/check.cpp"
 #include "source/slang/compiler.cpp"
 #include "source/slang/slang-stdlib.cpp"
+#include "source/slang/source-loc.cpp"
 #include "source/slang/syntax.cpp"
 #include "source/slang/token.cpp"
 #include "source/slang/type-layout.cpp"

--- a/source/core/slang-string.cpp
+++ b/source/core/slang-string.cpp
@@ -51,6 +51,12 @@ namespace Slang
         , endIndex(0)
     {}
 
+    StringSlice::StringSlice(String const& str)
+        : representation(str.buffer)
+        , beginIndex(0)
+        , endIndex(str.Length())
+    {}
+
     StringSlice::StringSlice(String const& str, UInt beginIndex, UInt endIndex)
         : representation(str.buffer)
         , beginIndex(beginIndex)

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -155,6 +155,8 @@ namespace Slang
     public:
         StringSlice();
 
+        StringSlice(String const& str);
+
         StringSlice(String const& str, UInt beginIndex, UInt endIndex);
 
         UInt getLength() const

--- a/source/slang/compiler.cpp
+++ b/source/slang/compiler.cpp
@@ -196,7 +196,7 @@ namespace Slang
         HMODULE d3dCompiler =  LoadLibraryA(libraryName);
         if (!d3dCompiler)
         {
-            request->mSink.diagnose(CodePosition(), Diagnostics::failedToLoadDynamicLibrary, libraryName);
+            request->mSink.diagnose(SourceLoc(), Diagnostics::failedToLoadDynamicLibrary, libraryName);
         }
         return d3dCompiler;
     }
@@ -373,7 +373,7 @@ namespace Slang
         HMODULE glslCompiler =  LoadLibraryA(libraryName);
         if (!glslCompiler)
         {
-            request->mSink.diagnose(CodePosition(), Diagnostics::failedToLoadDynamicLibrary, libraryName);
+            request->mSink.diagnose(SourceLoc(), Diagnostics::failedToLoadDynamicLibrary, libraryName);
         }
         return glslCompiler;
     }
@@ -611,7 +611,7 @@ namespace Slang
         if (count != 1)
         {
             compileRequest->mSink.diagnose(
-                CodePosition(),
+                SourceLoc(),
                 Diagnostics::cannotWriteOutputFile,
                 path);
         }
@@ -630,7 +630,7 @@ namespace Slang
         if (!file)
         {
             compileRequest->mSink.diagnose(
-                CodePosition(),
+                SourceLoc(),
                 Diagnostics::cannotWriteOutputFile,
                 path);
             return;

--- a/source/slang/lexer.h
+++ b/source/slang/lexer.h
@@ -47,7 +47,7 @@ namespace Slang
         bool IsAtEnd() const { return mCursor == mEnd; }
         Token PeekToken() const;
         TokenType PeekTokenType() const;
-        CodePosition PeekLoc() const;
+        SourceLoc PeekLoc() const;
 
         Token AdvanceToken();
 
@@ -66,9 +66,8 @@ namespace Slang
 
     struct Lexer
     {
-        Lexer(
-            String const&   path,
-            String const&   content,
+        void initialize(
+            SourceFile*     sourceFile,
             DiagnosticSink* sink);
 
         ~Lexer();
@@ -77,13 +76,30 @@ namespace Slang
 
         TokenList lexAllTokens();
 
-        String          path;
-        String          content;
+        // Begin overriding the reported locations of tokens,
+        // based on a `#line` directives
+        void startOverridingSourceLocations(SourceLoc loc);
+
+        // Stop overriding source locations, and go back
+        // to reporting source locations in the original file
+        void stopOverridingSourceLocations();
+
+        SourceFile*     sourceFile;
         DiagnosticSink* sink;
 
         char const*     cursor;
+
+        char const*     begin;
         char const*     end;
-        CodePosition    loc;
+
+        // The starting source location for the code as written,
+        // which cannot be overridden.
+        SourceLoc       spellingStartLoc;
+
+        // The nominal starting location for the file, taking
+        // any active `#line` directive into account.
+        SourceLoc       presumedStartLoc;
+
         TokenFlags      tokenFlags;
         LexerFlags      lexerFlags;
     };

--- a/source/slang/lower.cpp
+++ b/source/slang/lower.cpp
@@ -318,7 +318,7 @@ class PseudoVarDecl : public RefObject
 {
 public:
     Token Name;
-    CodePosition Position;
+    SourceLoc Position;
     TypeExp type;
 };
 
@@ -339,7 +339,7 @@ public:
 class PseudoExpr : public RefObject
 {
 public:
-    CodePosition Position;
+    SourceLoc Position;
     QualType type;
 };
 
@@ -384,7 +384,7 @@ public:
     List<Element>   elements;
 };
 
-static CodePosition getPosition(LoweredExpr const& expr)
+static SourceLoc getPosition(LoweredExpr const& expr)
 {
     switch (expr.getFlavor())
     {
@@ -393,7 +393,7 @@ static CodePosition getPosition(LoweredExpr const& expr)
     case LoweredExpr::Flavor::VaryingTuple: return expr.getVaryingTupleExpr()->Position;
     default:
         SLANG_UNREACHABLE("all cases handled");
-        return CodePosition();
+        return SourceLoc();
     }
 }
 
@@ -804,7 +804,7 @@ struct LoweringVisitor
     }
 
     RefPtr<Expr> createSimpleVarRef(
-        CodePosition const& loc,
+        SourceLoc const& loc,
         VarDeclBase*        decl)
     {
         RefPtr<VarExpr> result = new VarExpr();
@@ -816,7 +816,7 @@ struct LoweringVisitor
     }
 
     LoweredExpr createVarRef(
-        CodePosition const& loc,
+        SourceLoc const& loc,
         LoweredDecl const&  decl)
     {
         switch (decl.getFlavor())
@@ -838,7 +838,7 @@ struct LoweringVisitor
 
 
     LoweredExpr createTupleRef(
-        CodePosition const&     loc,
+        SourceLoc const&     loc,
         TupleVarDecl*           decl)
     {
         RefPtr<TupleExpr> result = new TupleExpr();
@@ -868,7 +868,7 @@ struct LoweringVisitor
     }
 
     LoweredExpr createVaryingTupleRef(
-        CodePosition const&     /*loc*/,
+        SourceLoc const&     /*loc*/,
         VaryingTupleVarDecl*    decl)
     {
         return decl->expr;

--- a/source/slang/options.cpp
+++ b/source/slang/options.cpp
@@ -596,7 +596,7 @@ struct OptionsParser
             else if (rawOutputPaths.Count() > rawEntryPoints.Count())
             {
                 requestImpl->mSink.diagnose(
-                    CodePosition(),
+                    SourceLoc(),
                     Diagnostics::tooManyOutputPathsSpecified,
                     rawOutputPaths.Count(),
                     rawEntryPoints.Count());
@@ -611,7 +611,7 @@ struct OptionsParser
                     if (entryPoint.outputPathIndex < 0)
                     {
                         requestImpl->mSink.diagnose(
-                            CodePosition(),
+                            SourceLoc(),
                             Diagnostics::noOutputPathSpecifiedForEntryPoint,
                             entryPoint.name);
 
@@ -639,7 +639,7 @@ struct OptionsParser
                             // This file didn't imply a target, and that
                             // needs to be an error:
                             requestImpl->mSink.diagnose(
-                                CodePosition(),
+                                SourceLoc(),
                                 Diagnostics::cannotDeduceOutputFormatFromPath,
                                 rawOutputPath.path);
 
@@ -669,7 +669,7 @@ struct OptionsParser
                                 // This file didn't imply a target, and that
                                 // needs to be an error:
                                 requestImpl->mSink.diagnose(
-                                    CodePosition(),
+                                    SourceLoc(),
                                     Diagnostics::outputPathsImplyDifferentFormats,
                                     rawOutputPaths[0].path,
                                     rawOutputPath.path);

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -41,7 +41,6 @@ namespace Slang
 
         TokenReader tokenReader;
         DiagnosticSink * sink;
-        String fileName;
         int genericDepth = 0;
 
         // Have we seen any `import` declarations? If so, we need
@@ -73,11 +72,9 @@ namespace Slang
         Parser(
             TokenSpan const& _tokens,
             DiagnosticSink * sink,
-            String _fileName,
             RefPtr<Scope> const& outerScope)
             : tokenReader(_tokens)
             , sink(sink)
-            , fileName(_fileName)
             , outerScope(outerScope)
         {}
 
@@ -614,7 +611,7 @@ namespace Slang
         RefPtr<Modifier>* modifierLink = &modifiers.first;
         for (;;)
         {
-            CodePosition loc = parser->tokenReader.PeekLoc();
+            SourceLoc loc = parser->tokenReader.PeekLoc();
 
             if (0) {}
 
@@ -1003,7 +1000,7 @@ namespace Slang
     struct PointerDeclarator : Declarator
     {
         // location of the `*` token
-        CodePosition starLoc;
+        SourceLoc starLoc;
 
         RefPtr<Declarator>				inner;
     };
@@ -1014,7 +1011,7 @@ namespace Slang
         RefPtr<Declarator>				inner;
 
         // location of the `[` token
-        CodePosition openBracketLoc;
+        SourceLoc openBracketLoc;
 
         // The expression that yields the element count, or NULL
         RefPtr<Expr>	elementCountExpr;
@@ -1377,7 +1374,7 @@ namespace Slang
     // Either a single declaration, or a group of them
     struct DeclGroupBuilder
     {
-        CodePosition        startPosition;
+        SourceLoc        startPosition;
         RefPtr<Decl>        decl;
         RefPtr<DeclGroup>   group;
 
@@ -1546,7 +1543,7 @@ namespace Slang
         Parser*         parser,
         ContainerDecl*  containerDecl)
     {
-        CodePosition startPosition = parser->tokenReader.PeekLoc();
+        SourceLoc startPosition = parser->tokenReader.PeekLoc();
 
         auto typeSpec = parseTypeSpec(parser);
 
@@ -1780,7 +1777,7 @@ namespace Slang
         // We first look at the declaration keywrod to determine
         // the type of buffer to declare:
         String bufferWrapperTypeName;
-        CodePosition bufferWrapperTypeNamePos = parser->tokenReader.PeekLoc();
+        SourceLoc bufferWrapperTypeNamePos = parser->tokenReader.PeekLoc();
         if (AdvanceIf(parser, "cbuffer"))
         {
             bufferWrapperTypeName = "ConstantBuffer";
@@ -1914,7 +1911,7 @@ namespace Slang
         // will see through it to the members inside.
 
 
-        CodePosition pos = parser->tokenReader.PeekLoc();
+        SourceLoc pos = parser->tokenReader.PeekLoc();
 
         // The initial name before the `{` is only supposed
         // to be made visible to reflection
@@ -2446,7 +2443,7 @@ namespace Slang
         }
 
         PushScope(program);
-        program->Position = CodePosition(0, 0, 0, fileName);
+        program->Position = tokenReader.PeekLoc();
         ParseDeclBody(this, program, TokenType::EndOfFile);
         PopScope();
 
@@ -3853,10 +3850,9 @@ namespace Slang
         TranslationUnitRequest*         translationUnit,
         TokenSpan const&                tokens,
         DiagnosticSink*                 sink,
-        String const&                   fileName,
         RefPtr<Scope> const&            outerScope)
     {
-        Parser parser(tokens, sink, fileName, outerScope);
+        Parser parser(tokens, sink, outerScope);
 
         parser.translationUnit = translationUnit;
 

--- a/source/slang/parser.h
+++ b/source/slang/parser.h
@@ -12,7 +12,6 @@ namespace Slang
         TranslationUnitRequest*         translationUnit,
         TokenSpan const&                tokens,
         DiagnosticSink*                 sink,
-        String const&                   fileName,
         RefPtr<Scope> const&            outerScope);
 ;
 }

--- a/source/slang/preprocessor.h
+++ b/source/slang/preprocessor.h
@@ -31,8 +31,7 @@ struct IncludeHandler
 
 // Take a string of source code and preprocess it into a list of tokens.
 TokenList preprocessSource(
-    String const&               source,
-    String const&               fileName,
+    SourceFile*                 file,
     DiagnosticSink*             sink,
     IncludeHandler*             includeHandler,
     Dictionary<String, String>  defines,

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -213,6 +213,7 @@
     <ClCompile Include="reflection.cpp" />
     <ClCompile Include="slang-stdlib.cpp" />
     <ClCompile Include="slang.cpp" />
+    <ClCompile Include="source-loc.cpp" />
     <ClCompile Include="syntax.cpp" />
     <ClCompile Include="token.cpp" />
     <ClCompile Include="type-layout.cpp" />

--- a/source/slang/slang.vcxproj.filters
+++ b/source/slang/slang.vcxproj.filters
@@ -56,5 +56,6 @@
     <ClCompile Include="type-layout.cpp" />
     <ClCompile Include="options.cpp" />
     <ClCompile Include="lower.cpp" />
+    <ClCompile Include="source-loc.cpp" />
   </ItemGroup>
 </Project>

--- a/source/slang/source-loc.cpp
+++ b/source/slang/source-loc.cpp
@@ -1,0 +1,332 @@
+// source-loc.cpp
+#include "source-loc.h"
+
+namespace Slang {
+
+String ExpandedSourceLoc::getPath() const
+{
+    if(!sourceManager)
+        return String();
+
+    return sourceManager->sourceFiles[entryIndex].path;
+}
+
+String ExpandedSourceLoc::getSpellingPath() const
+{
+    if(!sourceManager)
+        return String();
+
+    return sourceManager->sourceFiles[entryIndex].sourceFile->path;
+}
+
+SourceFile* ExpandedSourceLoc::getSourceFile() const
+{
+    if(!sourceManager)
+        return nullptr;
+
+    return sourceManager->sourceFiles[entryIndex].sourceFile;
+}
+
+void SourceManager::initialize(
+    SourceManager*  p)
+{
+    parent = p;
+
+    if( p )
+    {
+        // If we have a parent source manager, then we assume that all code at that level
+        // has already been loaded, and it is safe to start our own source locations
+        // right after those from the parent.
+        //
+        // TODO: more clever allocation in cases where that might not be reasonable
+        startLoc = p->nextLoc;
+    }
+    else
+    {
+        // Location zero is reserved for an invalid location,
+        // so we need to start reserving locations starting at 1.
+        startLoc = SourceLoc::fromRaw(1);
+    }
+
+    nextLoc = startLoc;
+}
+
+SourceRange SourceManager::allocateSourceRange(UInt size)
+{
+    // TODO: consider using atomics here
+
+
+    SourceLoc beginLoc  = nextLoc;
+    SourceLoc endLoc    = beginLoc + size;
+
+    // We need to be able to represent the location that is *at* the end of
+    // the input source, so the next available location for a new file
+    // must be placed one after the end of this one.
+
+    nextLoc = endLoc + 1;
+
+    return SourceRange(beginLoc, endLoc);
+}
+
+SourceFile* SourceManager::allocateSourceFile(
+    String const&   path,
+    String const&   content)
+{
+    UInt size = content.Length();
+
+    SourceRange sourceRange = allocateSourceRange(size);
+
+    SourceFile* sourceFile = new SourceFile();
+    sourceFile->path = path;
+    sourceFile->content = content;
+    sourceFile->sourceRange = sourceRange;
+
+    Entry entry;
+    entry.sourceFile = sourceFile;
+    entry.startLoc = sourceRange.begin;
+    entry.path = path;
+
+    sourceFiles.Add(entry);
+
+    return sourceFile;
+}
+
+SourceLoc SourceManager::allocateSourceFileForLineDirective(
+    SourceLoc const&    directiveLoc,
+    String const&       path,
+    UInt                line)
+{
+    // First, we need to find out what file we are being asked to remap
+    ExpandedSourceLoc expandedDirectiveLoc = expandSourceLoc(getSpellingLoc(directiveLoc));
+    HumaneSourceLoc humaneDirectiveLoc = getHumaneLoc(expandedDirectiveLoc);
+
+    SourceFile* sourceFile = expandedDirectiveLoc.getSourceFile();
+    if(!sourceFile)
+        return SourceLoc();
+
+    // We are going to be wasteful here and allocate a range of source locations
+    // that can cover the entire input file. This will lead to a problem with
+    // memory usage if we ever had a large input file that used many `#line` directives,
+    // since our usage of ranges would be quadratic!
+
+    // Count how many locations we'd need to reserve for a complete clone of the input
+    UInt size = sourceFile->sourceRange.end.getRaw() - sourceFile->sourceRange.begin.getRaw();
+
+    // Allocate a fresh range for our logically remapped file
+    SourceRange sourceRange = allocateSourceRange(size);
+
+    // Now fill in an entry that will point at the original source file,
+    // but use our new range.
+    Entry entry;
+    entry.sourceFile = sourceFile;
+    entry.startLoc = sourceRange.begin;
+    entry.path = path;
+
+    // We also need to make sure that any lookups for line numbers will
+    // get corrected based on this files location.
+    entry.lineAdjust = Int(line) - Int(humaneDirectiveLoc.line + 1);
+
+    sourceFiles.Add(entry);
+
+    return entry.startLoc;
+}
+
+static ExpandedSourceLoc expandSourceLoc(
+    SourceManager*      inSourceManager,
+    SourceLoc const&    loc)
+{
+    SourceManager* sourceManager = inSourceManager;
+
+    ExpandedSourceLoc expanded;
+
+    SourceLoc::RawValue rawValue = loc.getRaw();
+
+    // Invalid location? -> invalid expanded location
+    if(rawValue == 0)
+        return expanded;
+
+    // Past the end of what we can handle? -> invalid
+    if(rawValue >= sourceManager->nextLoc.getRaw())
+        return expanded;
+
+    // Maybe the location came from a parent source manager
+    while( rawValue < sourceManager->startLoc.getRaw()
+        && sourceManager->parent)
+    {
+        sourceManager = sourceManager->parent;
+    }
+
+    SLANG_ASSERT(sourceManager->sourceFiles.Count() > 0);
+
+    UInt lo = 0;
+    UInt hi = sourceManager->sourceFiles.Count();
+
+    while( lo+1 < hi )
+    {
+        UInt mid = lo + (hi - lo) / 2;
+
+        SourceManager::Entry const& midEntry = sourceManager->sourceFiles[mid];
+        SourceLoc::RawValue midValue = midEntry.startLoc.getRaw();
+
+        if( midValue <= rawValue )
+        {
+            // The location we seek is at or after this entry
+            lo = mid;
+        }
+        else
+        {
+            // The location we seek is before this entry
+            hi = mid;
+        }
+    }
+
+    // `lo` should now point at the entry we want
+    UInt entryIndex = lo;
+
+    expanded.setRaw(loc.getRaw());
+    expanded.sourceManager = sourceManager;
+    expanded.entryIndex = entryIndex;
+
+    return expanded;
+
+
+}
+
+ExpandedSourceLoc SourceManager::expandSourceLoc(SourceLoc const& loc)
+{
+    return Slang::expandSourceLoc(this, loc);
+}
+
+HumaneSourceLoc SourceManager::getHumaneLoc(ExpandedSourceLoc const& loc)
+{
+    // First check if this location maps to an actual file.
+    SourceFile* sourceFile = loc.getSourceFile();
+    if(!sourceFile)
+        return HumaneSourceLoc();
+
+    auto& entry = sourceFiles[loc.entryIndex];
+    UInt offset = loc.getRaw() - entry.startLoc.getRaw();
+
+    // We now have a raw input file that we can search for line breaks.
+    // We obviously don't want to do a linear scan over and over, so we will
+    // cache an array of line break locations in the file.
+    auto& lineBreakOffsets = sourceFile->lineBreakOffsets;
+    if( lineBreakOffsets.Count() == 0 )
+    {
+        char const* begin = sourceFile->content.begin();
+        char const* end = sourceFile->content.end();
+
+        char const* cursor = begin;
+
+        // Treat the beginning of the file as a line break
+        lineBreakOffsets.Add(0);
+
+        while( cursor != end )
+        {
+            int c = *cursor++;
+            switch( c )
+            {
+            case '\r': case '\n':
+                {
+                    // When we see a line-break character we need
+                    // to record the line break, but we also need
+                    // to deal with the annoying issue of encodings,
+                    // where a multi-byte sequence might encode
+                    // the line break.
+
+                    int d = *cursor;
+                    if( (c^d) == ('\r' ^ '\n'))
+                        cursor++;
+
+                    lineBreakOffsets.Add(cursor - begin);
+                }
+                break;
+
+            default:
+                break;
+            }
+        }
+
+        // Note taht we do *not* treat the end of the file as a line
+        // break, because otherwise we would report errors like
+        // "end of file inside string literal" with a line number
+        // that points at a line that doesn't exist.
+    }
+
+    // At this point we can assume the `lineBreakOffsets` array has been filled in.
+    // We will use a binary search to find the line index that contains our
+    // chosen offset.
+    UInt lo = 0;
+    UInt hi = lineBreakOffsets.Count();
+
+    while( lo+1 < hi )
+    {
+        UInt mid = lo + (hi - lo)/2;
+
+        UInt midOffset = lineBreakOffsets[mid];
+        if( midOffset <= offset )
+        {
+            lo = mid;
+        }
+        else
+        {
+            hi = mid;
+        }
+    }
+
+    UInt lineIndex = lo;
+    UInt byteIndexInLine = offset - lineBreakOffsets[lineIndex];
+
+    // Apply adjustment to the line number
+    lineIndex = lineIndex + entry.lineAdjust;
+
+    // TODO: we should really translate the byte index in the line
+    // to deal with:
+    //
+    // - Non-ASCII characters, while might consume multiple bytes
+    //
+    // - Tab characters, which should really adjust how we report
+    //   columns (although how are we supposed to know the setting
+    //   that an IDE expects us to use when reporting locations?)
+
+    HumaneSourceLoc humaneLoc;
+    humaneLoc.path = entry.path;
+    humaneLoc.line = lineIndex + 1;
+    humaneLoc.column = byteIndexInLine + 1;
+
+    return humaneLoc;
+}
+
+HumaneSourceLoc SourceManager::getHumaneLoc(SourceLoc const& loc)
+{
+    return getHumaneLoc(expandSourceLoc(loc));
+
+}
+
+SourceLoc SourceManager::getSpellingLoc(ExpandedSourceLoc const& loc)
+{
+    // First check if this location maps to some raw source file,
+    // so that a "spelling" is even possible
+    SourceFile* sourceFile = loc.getSourceFile();
+    if(!sourceFile)
+        return loc;
+
+    // If we mapped to a source file, then the location must represent
+    // some offset from an entry in our array.
+    auto& entry = sourceFiles[loc.entryIndex];
+
+    // We extract the offset of the location from the start of the entry
+    SourceLoc::RawValue offsetFromStart = loc.getRaw() - entry.startLoc.getRaw();
+
+    // And instead apply that offset to the spelling location of the file start
+    SourceLoc result = sourceFile->sourceRange.begin + offsetFromStart;
+
+    return result;
+}
+
+SourceLoc SourceManager::getSpellingLoc(SourceLoc const& loc)
+{
+    return getSpellingLoc(expandSourceLoc(loc));
+}
+
+} // namespace Slang

--- a/source/slang/source-loc.h
+++ b/source/slang/source-loc.h
@@ -6,36 +6,181 @@
 
 namespace Slang {
 
-class CodePosition
+class SourceLoc
 {
 public:
-	int Line = -1, Col = -1, Pos = -1;
-	String FileName;
-	String ToString()
-	{
-		StringBuilder sb(100);
-		sb << FileName;
-		if (Line != -1)
-			sb << "(" << Line << ")";
-		return sb.ProduceString();
-	}
-	CodePosition() = default;
-	CodePosition(int line, int col, int pos, String fileName)
-	{
-		Line = line;
-		Col = col;
-		Pos = pos;
-		this->FileName = fileName;
-	}
-	bool operator < (const CodePosition & pos) const
-	{
-		return FileName < pos.FileName || (FileName == pos.FileName && Line < pos.Line) ||
-			(FileName == pos.FileName && Line == pos.Line && Col < pos.Col);
-	}
-	bool operator == (const CodePosition & pos) const
-	{
-		return FileName == pos.FileName && Line == pos.Line && Col == pos.Col;
-	}
+    typedef UInt RawValue;
+
+private:
+    RawValue raw;
+
+public:
+    SourceLoc()
+        : raw(0)
+    {}
+
+    SourceLoc(
+        SourceLoc const& loc)
+        : raw(loc.raw)
+    {}
+
+    RawValue getRaw() const { return raw; }
+    void setRaw(RawValue value) { raw = value; }
+
+    static SourceLoc fromRaw(RawValue value)
+    {
+        SourceLoc result;
+        result.setRaw(value);
+        return result;
+    }
+
+    bool isValid() const
+    {
+        return raw != 0;
+    }
+};
+
+inline SourceLoc operator+(SourceLoc loc, Int offset)
+{
+    return SourceLoc::fromRaw(loc.getRaw() + UInt(offset));
+}
+
+// A range of locations in the input source
+struct SourceRange
+{
+    SourceRange()
+    {}
+
+    SourceRange(SourceLoc loc)
+        : begin(loc)
+        , end(loc)
+    {}
+
+    SourceRange(SourceLoc begin, SourceLoc end)
+        : begin(begin)
+        , end(end)
+    {}
+
+    SourceLoc begin;
+    SourceLoc end;
+};
+
+// A logical or phyiscal storage object for a range of input code
+// that has logically contiguous source locations.
+class SourceFile : public RefObject
+{
+public:
+    // The logical file path to report for locations inside this span.
+    String path;
+
+    // The actual contents of the file.
+    String content;
+
+    // The range of source locations that the span covers
+    SourceRange sourceRange;
+
+    // In order to speed up lookup of line number information,
+    // we will cache the starting offset of each line break in
+    // the input file:
+    List<UInt> lineBreakOffsets;
+};
+
+struct SourceManager;
+
+// A source location in a format a human might like to see
+struct HumaneSourceLoc
+{
+    String  path;
+    Int     line = 0;
+    Int     column = 0;
+
+    String const& getPath() const { return path; }
+    Int getLine() const { return line; }
+    Int getColumn() const { return column; }
+};
+
+// A source location that has been expanded with the info
+// needed to reconstruct a "humane" location if needed.
+struct ExpandedSourceLoc : public SourceLoc
+{
+    // The source manager that owns this location
+    SourceManager*  sourceManager = nullptr;
+
+    // The entry index that is used to understand the location
+    UInt            entryIndex = 0;
+
+    // Get the nominal path for this location
+    String getPath() const;
+
+    // Get the actual file path where this location appears
+    String getSpellingPath() const;
+
+    // Get the original source file that holds this location
+    SourceFile* getSourceFile() const;
+};
+
+
+
+struct SourceManager
+{
+    // Initialize a source manager, with an optional parent
+    void initialize(
+        SourceManager*  parent);
+
+    SourceRange allocateSourceRange(UInt size);
+
+    SourceFile* allocateSourceFile(
+        String const&   path,
+        String const&   content);
+
+    SourceLoc allocateSourceFileForLineDirective(
+        SourceLoc const&    directiveLoc,
+        String const&       path,
+        UInt                line);
+
+    // Expand a source location to include more explicit info
+    ExpandedSourceLoc expandSourceLoc(SourceLoc const& loc);
+
+    // Get a "humane" version of a source location
+    HumaneSourceLoc getHumaneLoc(ExpandedSourceLoc const& loc);
+    HumaneSourceLoc getHumaneLoc(SourceLoc const& loc);
+
+
+    // Get the source location that represents the spelling location corresponding to a location.
+    SourceLoc getSpellingLoc(ExpandedSourceLoc const& loc);
+    SourceLoc getSpellingLoc(SourceLoc const& loc);
+
+    // The first location available to this source manager
+    // (may not be the first location of all, because we might
+    // have a parent source manager)
+    SourceLoc startLoc;
+
+    // The "parent" source manager that owns locations ahead of `startLoc`
+    SourceManager* parent = nullptr;
+
+    // The location to be used by the next source file to be loaded
+    SourceLoc nextLoc;
+
+    // Each entry represents some contiguous span of locations that
+    // all map to the same logical file.
+    struct Entry
+    {
+        // Where does this entry begin?
+        SourceLoc        startLoc;
+
+        // The soure file that represents the actual data
+        RefPtr<SourceFile>  sourceFile;
+
+        // What is the presumed path for this entry
+        String path;
+
+        // Adjustment to apply to source line numbers when printing presumed locations
+        Int lineAdjust = 0;
+    };
+
+    // An array of soure files we have loaded, ordered by
+    // increasing starting location
+    List<Entry> sourceFiles;
 };
 
 

--- a/source/slang/syntax-base-defs.h
+++ b/source/slang/syntax-base-defs.h
@@ -9,7 +9,7 @@
 ABSTRACT_SYNTAX_CLASS(SyntaxNodeBase, RefObject)
 
     // The primary source location associated with this AST node
-    FIELD(CodePosition, Position)
+    FIELD(SourceLoc, Position)
 
     RAW(
     // Allow dynamic casting with a convenient syntax

--- a/source/slang/syntax-visitors.h
+++ b/source/slang/syntax-visitors.h
@@ -26,7 +26,7 @@ namespace Slang
     RefPtr<ModuleDecl> findOrImportModule(
         CompileRequest*     request,
         String const&       name,
-        CodePosition const& loc);
+        SourceLoc const& loc);
 }
 
 #endif

--- a/source/slang/token.h
+++ b/source/slang/token.h
@@ -18,8 +18,9 @@ char const* TokenTypeToString(TokenType type);
 
 enum TokenFlag : unsigned int
 {
-    AtStartOfLine   = 1 << 0,
-    AfterWhitespace = 1 << 1,
+    AtStartOfLine           = 1 << 0,
+    AfterWhitespace         = 1 << 1,
+    SuppressMacroExpansion  = 1 << 2,
 };
 typedef unsigned int TokenFlags;
 
@@ -28,15 +29,21 @@ class Token
 public:
 	TokenType type = TokenType::Unknown;
 	String Content;
-	CodePosition Position;
+	SourceLoc Position;
     TokenFlags flags = 0;
+
 	Token() = default;
-	Token(TokenType type, const String & content, int line, int col, int pos, String fileName, TokenFlags flags = 0)
+
+    Token(
+        TokenType type,
+        const String & content,
+        SourceLoc loc,
+        TokenFlags flags = 0)
         : flags(flags)
 	{
 		type = type;
 		Content = content;
-		Position = CodePosition(line, col, pos, fileName);
+        Position = loc;
 	}
 };
 

--- a/tests/preprocessor/line.slang
+++ b/tests/preprocessor/line.slang
@@ -1,0 +1,19 @@
+//TEST:SIMPLE:
+// #line support
+
+FooA a() { return 0; }
+
+#line 99 "b.slang"
+FooB b() { return 0; }
+
+#line default
+FooC c() { return 0; }
+
+#line 603 "d.slang"
+FooD d() { return 0; }
+
+#line 40
+FooE e() { return 0; }
+
+#line
+FooF f() { return 0; }

--- a/tests/preprocessor/line.slang.expected
+++ b/tests/preprocessor/line.slang.expected
@@ -1,0 +1,11 @@
+result code = -1
+standard error = {
+tests/preprocessor/line.slang(4): error 30015: undefined identifier 'FooA'.
+b.slang(99): error 30015: undefined identifier 'FooB'.
+tests/preprocessor/line.slang(10): error 30015: undefined identifier 'FooC'.
+d.slang(603): error 30015: undefined identifier 'FooD'.
+d.slang(40): error 30015: undefined identifier 'FooE'.
+tests/preprocessor/line.slang(19): error 30015: undefined identifier 'FooF'.
+}
+standard output = {
+}


### PR DESCRIPTION
Fixes #24

So far the code has used a representation for source locations that is heavy-weight, but typical of research or hobby compilers: a `struct` type containing a line number and a (heap-allocated) string.
This is actually very convenient for debugging, but it means that any data structure that might contain a source location needs careful memory management (because of those strings) and has a tendency to bloat.

The new represnetation is that a source location is just a pointer-sized integer.
In the simplest mental model, you can think of this as just counting every byte of source text that is passed in, and using those to name locations.

Finding the path and line number that corresponds to a location involves a lookup step, but we can arrange to store all the files in an array sorted by their start locations, and do a binary search.
Finding line numbers inside a file is similarly fast (one you pay a one-time cost to build an array of starting offsets for lines).

More advanced compilers like clang actually go further and create a unique range of source locations to represent a file each time it gets included, so that they can track the include stack and reproduce it in diagnostic messages.
I'm not doing anything that clever here.