### PR TITLE
Data-driven parsing of modifiers

### DIFF
--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -1202,11 +1202,6 @@ namespace Slang
             // These are only used in the stdlib, so no checking is needed
         }
 
-        void visitModifierDecl(ModifierDecl*)
-        {
-            // These are only used in the stdlib, so no checking is needed
-        }
-
         void visitGenericTypeParamDecl(GenericTypeParamDecl*)
         {
             // These are only used in the stdlib, so no checking is needed for now

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -372,6 +372,10 @@ namespace Slang
         Type* getOverloadedType();
         Type* getErrorType();
 
+        SyntaxClass<RefObject> findSyntaxClass(String const& name);
+
+        Dictionary<String, SyntaxClass<RefObject> > mapNameToSyntaxClass;
+
         //
 
         Session();

--- a/source/slang/decl-defs.h
+++ b/source/slang/decl-defs.h
@@ -212,14 +212,6 @@ END_SYNTAX_CLASS()
 
 SIMPLE_SYNTAX_CLASS(GenericValueParamDecl, VarDeclBase)
 
-// Declaration of a user-defined modifier
-SYNTAX_CLASS(ModifierDecl, Decl)
-    // The name of the C++ class to instantiate
-    // (this is a reference to a class in the compiler source code,
-    // and not the user's source code)
-    FIELD(Token, classNameToken)
-END_SYNTAX_CLASS()
-
 // An empty declaration (which might still have modifiers attached).
 //
 // An empty declaration is uncommon in HLSL, but
@@ -236,8 +228,9 @@ SIMPLE_SYNTAX_CLASS(EmptyDecl, Decl)
 //
 SYNTAX_CLASS(SyntaxDecl, Decl)
     // What type of syntax node will be produced when parsing with this keyword?
-    FIELD(SyntaxClass<SyntaxNode>, syntaxClass)
+    FIELD(SyntaxClass<RefObject>, syntaxClass)
 
     // Callback to invoke in order to parse syntax with this keyword.
-    FIELD(SyntaxParseCallback, parserCallback)
+    FIELD(SyntaxParseCallback,  parseCallback)
+    FIELD(void*,                parseUserData)
 END_SYNTAX_CLASS()

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -2746,7 +2746,6 @@ struct EmitVisitor
     void visit##NAME(NAME*, DeclEmitArg const&) {}
 
     // Only used by stdlib
-    IGNORED(ModifierDecl)
     IGNORED(SyntaxDecl)
 
     // Don't emit generic decls directly; we will only

--- a/source/slang/lower.cpp
+++ b/source/slang/lower.cpp
@@ -2638,12 +2638,6 @@ struct LoweringVisitor
         return LoweredDecl();
     }
 
-    LoweredDecl visitModifierDecl(ModifierDecl*)
-    {
-        // should not occur in user code
-        SLANG_UNEXPECTED("modifiers shouldn't occur in user code");
-    }
-
     LoweredDecl visitGenericValueParamDecl(GenericValueParamDecl*)
     {
         SLANG_UNEXPECTED("generics should be lowered to specialized decls");

--- a/source/slang/modifier-defs.h
+++ b/source/slang/modifier-defs.h
@@ -35,34 +35,34 @@ END_SYNTAX_CLASS()
 // directly.
 SYNTAX_CLASS(IntrinsicOpModifier, IntrinsicModifierBase)
 
-    // token that names the intrinsic op
-    FIELD(Token, opToken)
+// token that names the intrinsic op
+FIELD(Token, opToken)
 
-    // The opcode for the intrinsic operation
-    FIELD_INIT(IntrinsicOp, op, IntrinsicOp::Unknown)
+// The opcode for the intrinsic operation
+FIELD_INIT(IntrinsicOp, op, IntrinsicOp::Unknown)
 END_SYNTAX_CLASS()
 
 // A modifier that marks something as an intrinsic function,
 // for some subset of targets.
 SYNTAX_CLASS(TargetIntrinsicModifier, IntrinsicModifierBase)
-    // Token that names the target that the operation
-    // is an intrisic for.
-    FIELD(Token, targetToken)
+// Token that names the target that the operation
+// is an intrisic for.
+FIELD(Token, targetToken)
 
-    // A custom definition for the operation
-    FIELD(Token, definitionToken)
+// A custom definition for the operation
+FIELD(Token, definitionToken)
 END_SYNTAX_CLASS()
 
 // A modifier to tag something as an intrinsic that requires
 // a certain GLSL extension to be enabled when used
 SYNTAX_CLASS(RequiredGLSLExtensionModifier, Modifier)
-    FIELD(Token, extensionNameToken)
+FIELD(Token, extensionNameToken)
 END_SYNTAX_CLASS()
 
 // A modifier to tag something as an intrinsic that requires
 // a certain GLSL version to be enabled when used
 SYNTAX_CLASS(RequiredGLSLVersionModifier, Modifier)
-    FIELD(Token, versionNumberToken)
+FIELD(Token, versionNumberToken)
 END_SYNTAX_CLASS()
 
 SIMPLE_SYNTAX_CLASS(InOutModifier, OutModifier)
@@ -95,12 +95,18 @@ SIMPLE_SYNTAX_CLASS(SharedModifiers, Modifier)
 // different constructs.
 ABSTRACT_SYNTAX_CLASS(GLSLLayoutModifier, Modifier)
 
-    // The token used to introduce the modifier is stored
-    // as the `nameToken` field.
+// The token used to introduce the modifier is stored
+// as the `nameToken` field.
 
-    // TODO: may want to accept a full expression here
-    FIELD(Token, valToken)
+// TODO: may want to accept a full expression here
+FIELD(Token, valToken)
 END_SYNTAX_CLASS()
+
+// AST nodes to represent the begin/end of a `layout` modifier group
+ABSTRACT_SYNTAX_CLASS(GLSLLayoutModifierGroupMarker, Modifier)
+END_SYNTAX_CLASS()
+SIMPLE_SYNTAX_CLASS(GLSLLayoutModifierGroupBegin, GLSLLayoutModifierGroupMarker)
+SIMPLE_SYNTAX_CLASS(GLSLLayoutModifierGroupEnd, GLSLLayoutModifierGroupMarker)
 
 // We divide GLSL `layout` modifiers into those we have parsed
 // (in the sense of having some notion of their semantics), and

--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -2232,19 +2232,19 @@ namespace Slang
 
         // Define additional keywords
 
-        sb << "__modifier(GLSLBufferModifier)       buffer;\n";
+        sb << "syntax buffer : GLSLBufferModifier;\n";
 
         // [GLSL 4.3] Storage Qualifiers
 
         // TODO: need to support `shared` here with its GLSL meaning
 
-        sb << "__modifier(GLSLPatchModifier)        patch;\n";
+        sb << "syntax patch : GLSLPatchModifier;\n";
         // `centroid` and `sample` handled centrally
 
         // [GLSL 4.5] Interpolation Qualifiers
-        sb << "__modifier(SimpleModifier)   smooth;\n";
-        sb << "__modifier(SimpleModifier)   flat;\n";
-        sb << "__modifier(SimpleModifier)   noperspective;\n";
+        sb << "syntax smooth : SimpleModifier;\n";
+        sb << "syntax flat : SimpleModifier;\n";
+        sb << "syntax noperspectie : SimpleModifier;\n";
 
 
         // [GLSL 4.3.2] Constant Qualifier
@@ -2253,24 +2253,24 @@ namespace Slang
         // since they mean such different things.
 
         // [GLSL 4.7.2] Precision Qualifiers
-        sb << "__modifier(SimpleModifier)   highp;\n";
-        sb << "__modifier(SimpleModifier)   mediump;\n";
-        sb << "__modifier(SimpleModifier)   lowp;\n";
+        sb << "syntax highp : SimpleModifier;\n";
+        sb << "syntax mediump : SimpleModifier;\n";
+        sb << "syntax lowp : SimpleModifier;\n";
 
         // [GLSL 4.8.1] The Invariant Qualifier
 
-        sb << "__modifier(GLSLWriteOnlyModifier)    invariant;\n";
+        sb << "syntax invariant : SimpleModifier;\n";
 
         // [GLSL 4.10] Memory Qualifiers
 
-        sb << "__modifier(SimpleModifier)           coherent;\n";
-        sb << "__modifier(SimpleModifier)           volatile;\n";
-        sb << "__modifier(SimpleModifier)           restrict;\n";
-        sb << "__modifier(GLSLReadOnlyModifier)     readonly;\n";
-        sb << "__modifier(GLSLWriteOnlyModifier)    writeonly;\n";
+        sb << "syntax coherent : SimpleModifier;\n";
+        sb << "syntax volatile : SimpleModifier;\n";
+        sb << "syntax restrict : SimpleModifier;\n";
+        sb << "syntax readonly : GLSLReadOnlyModifier;\n";
+        sb << "syntax writeonly : GLSLWriteOnlyModifier;\n";
 
-        // We will treat `subroutine` as a qualifier
-        sb << "__modifier(SimpleModifier)   subroutine;\n";
+        // We will treat `subroutine` as a qualifier for now
+        sb << "syntax subroutine : SimpleModifier;\n";
 
         glslLibraryCode = sb.ProduceString();
         return glslLibraryCode;

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -20,6 +20,20 @@ namespace Slang {
 
 Session::Session()
 {
+    // Initialize the lookup table of syntax classes:
+
+    #define SYNTAX_CLASS(NAME, BASE) mapNameToSyntaxClass.Add(#NAME, getClass<NAME>());
+
+#include "object-meta-begin.h"
+#include "syntax-base-defs.h"
+#include "expr-defs.h"
+#include "decl-defs.h"
+#include "modifier-defs.h"
+#include "stmt-defs.h"
+#include "type-defs.h"
+#include "val-defs.h"
+#include "object-meta-end.h"
+
     // Make sure our source manager is initialized
     builtinSourceManager.initialize(nullptr);
 

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -90,6 +90,8 @@ ABSTRACT_SYNTAX_CLASS(Type, Val);
 ABSTRACT_SYNTAX_CLASS(Modifier, SyntaxNodeBase);
 ABSTRACT_SYNTAX_CLASS(Expr, SyntaxNode);
 
+ABSTRACT_SYNTAX_CLASS(Substitutions, SyntaxNode);
+
 #include "object-meta-end.h"
 
 bool SyntaxClassBase::isSubClassOfImpl(SyntaxClassBase const& super) const
@@ -257,6 +259,16 @@ void Type::accept(IValVisitor* visitor, void* extra)
     {
         return errorType;
     }
+
+    SyntaxClass<RefObject> Session::findSyntaxClass(String const& name)
+    {
+        SyntaxClass<RefObject> syntaxClass;
+        if (mapNameToSyntaxClass.TryGetValue(name, syntaxClass))
+            return syntaxClass;
+
+        return SyntaxClass<RefObject>();
+    }
+
 
 
     bool ArrayExpressionType::EqualsImpl(Type * type)

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -26,7 +26,8 @@ namespace Slang
 
     class Parser;
     class SyntaxNode;
-    typedef RefPtr<SyntaxNode> (*SyntaxParseCallback)(Parser* parser);
+
+    typedef RefPtr<RefObject> (*SyntaxParseCallback)(Parser* parser, void* userData);
 
     // Forward-declare all syntax classes
 #define SYNTAX_CLASS(NAME, BASE, ...) class NAME;


### PR DESCRIPTION
Just like the previous change did for declaration keywords, this change uses the lexical environment to drive the lookup and dispatch of modifier parsing.
This allows us to easily add modifiers to Slang, even when they might conflict with identifiers used in user code (because the modifier names are no longer special keywords, but ordinary identifiers).

There was already some support for ideas like this with `__modifier` declarations (`ModifierDecl`) used to introduce some GLSL-specific keywords (so that they wouldn't pollute the namespace of HLSL files).
The new approach changes these to be actual `syntax` declarations (`SyntaxDecl`) with the same representation as those used to introduce declaration keywords.

Because many modifiers just introduce a single keyword that maps to a simple AST node (no further tokens/data), I modified the handling of syntax declarations so that they can take a user-data parameter, and this allows the common case ("just create an AST node of this type...") to be handled with minimal complications.

This also adds in a general-purpose string-based lookup path for AST node classes, that should support programmatic creation in more cases.

Statements are now the main case of keywords that need to be made table driven.