### PR TITLE
Add a flag to control type splitting

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -93,7 +93,11 @@ extern "C"
     typedef unsigned int SlangCompileFlags;
     enum
     {
-        SLANG_COMPILE_FLAG_NO_CHECKING = 1 << 0, /**< Disable semantic checking as much as possible. */
+         /** Disable semantic checking as much as possible. */
+        SLANG_COMPILE_FLAG_NO_CHECKING          = 1 << 0,
+
+        /* Split apart types that contain a mix of resource and non-resource data */
+        SLANG_COMPILE_FLAG_SPLIT_MIXED_TYPES    = 1 << 1,
     };
 
     /*!

--- a/source/slang/lower.cpp
+++ b/source/slang/lower.cpp
@@ -2833,6 +2833,17 @@ struct LoweringVisitor
             // due to, e.g., bindless textures.
             shouldDesugarTupleTypes = true;
         }
+        else if( shared->compileRequest->compileFlags & SLANG_COMPILE_FLAG_SPLIT_MIXED_TYPES )
+        {
+            // If the user is directly asking us to do this transformation,
+            // then obviously we need to do it.
+            //
+            // TODO: The way this is defined here means it will even apply to user
+            // HLSL code (not just code written in Slang). We may want to
+            // reconsider that choice, and only split things that originated in Slang.
+            //
+            shouldDesugarTupleTypes = true;
+        }
 
         bool isResultATupleType = false;
         bool hasAnyNonTupleFields = false;

--- a/source/slang/options.cpp
+++ b/source/slang/options.cpp
@@ -254,6 +254,10 @@ struct OptionsParser
                 //else
                 if (argStr == "-no-checking")
                     flags |= SLANG_COMPILE_FLAG_NO_CHECKING;
+                else if(argStr == "-split-mixed-types" )
+                {
+                    flags |= SLANG_COMPILE_FLAG_SPLIT_MIXED_TYPES;
+                }
                 else if (argStr == "-backend" || argStr == "-target")
                 {
                     String name = tryReadCommandLineArgument(arg, &argCursor, argEnd);

--- a/tests/rewriter/type-splitting.hlsl
+++ b/tests/rewriter/type-splitting.hlsl
@@ -1,0 +1,59 @@
+//TEST:COMPARE_HLSL: -split-mixed-types -no-checking -target dxbc-assembly -profile ps_4_0 -entry main
+
+// Confirm that the `-split-mixed-types` flag works.
+
+#ifdef __SLANG__
+
+// HLSL input:
+//
+// - Uses at least one `import` of Slang code
+// - Uses an aggregate type that mixes resource and non-resource types
+//
+
+__import type_splitting;
+
+struct Foo
+{
+	Texture2D 		t;
+	SamplerState 	s;
+	float2 			u;
+};
+
+cbuffer C
+{
+	Foo foo;
+}
+
+float4 main() : SV_Target
+{
+	return foo.t.Sample(foo.s, foo.u);	
+}
+
+#else
+
+// Equivalent raw HLSL:
+//
+// - Fields of resource type have been stripped from original type definition
+// - Fields of resource type get hoisted out of variable declarations
+//
+
+struct Foo
+{
+	float2 u;
+};
+
+cbuffer C
+{
+	Foo foo;
+}
+
+Texture2D    SLANG_parameterBlock_C_foo_t;
+SamplerState SLANG_parameterBlock_C_foo_s;
+
+float4 main() : SV_Target
+{
+	return SLANG_parameterBlock_C_foo_t.Sample(SLANG_parameterBlock_C_foo_s, foo.u);	
+}
+
+#endif
+

--- a/tests/rewriter/type-splitting.slang
+++ b/tests/rewriter/type-splitting.slang
@@ -1,0 +1,3 @@
+//TEST_IGNORE_FILE:
+
+// This file only exists so that `type-splitting.hlsl` officially appears to be using some Slang code.


### PR DESCRIPTION
The `-split-mixed-types` flag can be provided to command-line `slangc`, and the `SLANG_COMPILE_FLAG_SPLIT_MIXED_TYPE` flag can be passed to `spSetCompileFlags`.
Either of these turns on a mode where Slang will split types that included both resource and non-resource fields.
The declaration of such a type will just drop the resource fields, while a variable declare using such a type turns into multiple declararations: one for the non-resource fields, and then one for each resource field (recursively).

This behavior was already implemented for GLSL support, and this change just adds a flag so that the user can turn it on unconditionally.

Caveats:

- This does not apply in "full rewriter" mode, which is what happens if the user doesn't use any `import`s. I could try to fix that, but it seems like in that mode people are asking to bypass as much of the compiler as possible.

- When it *does* apply, it applies to user code as well as library/Slang code. So this will potentially rewrite the user's own HLSL in ways they wouldn't expect. I don't see a great way around it, though.