### PR TITLE
IR generation cleanup work

### DIFF
--- a/source/core/hash.h
+++ b/source/core/hash.h
@@ -95,7 +95,10 @@ namespace Slang
 		return PointerHash<std::is_pointer<TKey>::value>::GetHashCode(key);
 	}
 
-		
+    inline int combineHash(int left, int right)
+    {
+        return (left * 16777619) ^ right;
+    }
 }
 
 #endif

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -3951,11 +3951,11 @@ String emitEntryPoint(
         throw 99;
 
     }
-    else if(translationUnit->compileRequest->loadedModulesList.Count() != 0)
+    else if(
 #else
-    if(!(translationUnit->compileFlags & SLANG_COMPILE_FLAG_NO_CHECKING )
-        || translationUnit->compileRequest->loadedModulesList.Count() != 0)
+    if(!(translationUnit->compileFlags & SLANG_COMPILE_FLAG_NO_CHECKING ) ||
 #endif
+        translationUnit->compileRequest->loadedModulesList.Count() != 0)
     {
         // The user has `import`ed some Slang modules, and so we are in case (2)
         //


### PR DESCRIPTION
- Make all instructions store their argument count for now, so we can iterate over them easily.
  - Longer term we might try to optimize for space because the common case is that the operand count is known, but keeping it simpler seems better for now

- Split apart the creation of an instruction from adding it to a parent

- Use the above capability to make sure that we add a function to its parent *after* all the parameter/result type emission has occured.

- Perform simple value numbering for types during IR creation
  - This logic also tries to pick a good parent for any type instructions, so that types don't get created local to a function unless they really need to

- Create all constants at global scope, and re-use when values are identical