### PR TITLE
Add some dummy logic to print IR to HLSL

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -3827,6 +3827,11 @@ emitDeclImpl(decl, nullptr);
 
     String getName(IRInst* inst)
     {
+        if(auto decoration = inst->findDecoration<IRHighLevelDeclDecoration>())
+        {
+            return getText(decoration->decl->getName());
+        }
+
         StringBuilder sb;
         sb << "_S";
         sb << inst->id;
@@ -4038,6 +4043,17 @@ emitDeclImpl(decl, nullptr);
         }
     }
 
+    void emitIRSemantics(
+        EmitContext*    context,
+        IRInst*         inst)
+    {
+        auto decoration = inst->findDecoration<IRHighLevelDeclDecoration>();
+        if( decoration )
+        {
+            EmitSemantics(decoration->decl);
+        }
+    }
+
     void emitIRFunc(
         EmitContext*    context,
         IRFunc*         func)
@@ -4060,6 +4076,9 @@ emitDeclImpl(decl, nullptr);
             emitIRType(context, pp->getType(), paramName);
         }
         emit(")");
+
+
+        emitIRSemantics(context, func);
 
         // TODO: encode declaration vs. definition
         bool isDefinition = true;
@@ -4097,6 +4116,9 @@ emitDeclImpl(decl, nullptr);
         {
             auto fieldType = ff->getFieldType();
             emitIRType(context, fieldType, getName(ff));
+
+            emitIRSemantics(context, ff);
+
             emit(";\n");
         }
         emit("};\n");
@@ -4250,7 +4272,7 @@ String emitEntryPoint(
     //
     // We'll try to detect the cases here:
     //
-#if 1
+#if 0
     if(!(translationUnit->compileFlags & SLANG_COMPILE_FLAG_NO_CHECKING ))
     {
         // This seems to be case (3), because the user is asking for full

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -4016,8 +4016,8 @@ emitDeclImpl(decl, nullptr);
 
                 emitIRInstResultDecl(context, inst);
                 emitIROperand(context, fieldExtract->getBase());
-                emit(".field");
-                emit(fieldExtract->fieldIndex);
+                emit(".");
+                emit(getName(fieldExtract->getField()));
                 emit(";\n");
             }
             break;
@@ -4087,20 +4087,16 @@ emitDeclImpl(decl, nullptr);
 
     void emitIRStruct(
         EmitContext*    context,
-        IRStructType*   structType)
+        IRStructDecl*   structType)
     {
         emit("struct ");
         emit(getName(structType));
         emit("\n{\n");
-        auto fieldCount = structType->getFieldCount();
-        for( UInt ff = 0; ff < fieldCount; ++ff )
+
+        for(auto ff = structType->getFirstField(); ff; ff = ff->getNextField())
         {
-            auto fieldType = structType->getFieldType(ff);
-
-            String fieldName = "field";
-            fieldName.append(ff);
-
-            emitIRType(context, fieldType, fieldName);
+            auto fieldType = ff->getFieldType();
+            emitIRType(context, fieldType, getName(ff));
             emit(";\n");
         }
         emit("};\n");
@@ -4119,7 +4115,7 @@ emitDeclImpl(decl, nullptr);
             break;
 
         case kIROp_StructType:
-            emitIRStruct(context, (IRStructType*) inst);
+            emitIRStruct(context, (IRStructDecl*) inst);
             break;
 
         default:
@@ -4254,7 +4250,7 @@ String emitEntryPoint(
     //
     // We'll try to detect the cases here:
     //
-#if 0
+#if 1
     if(!(translationUnit->compileFlags & SLANG_COMPILE_FLAG_NO_CHECKING ))
     {
         // This seems to be case (3), because the user is asking for full

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -3822,8 +3822,328 @@ emitDeclImpl(decl, nullptr);
             SLANG_UNEXPECTED("unhandled declaration kind");
         }
     }
+
+    // IR-level emit logc
+
+    String getName(IRInst* inst)
+    {
+        StringBuilder sb;
+        sb << "_S";
+        sb << inst->id;
+        return sb.ProduceString();
+    }
+
+    struct IRDeclaratorInfo
+    {
+        enum class Flavor
+        {
+            Simple,
+        };
+
+        Flavor flavor;
+        String const* name;
+    };
+
+    void emitDeclarator(
+        EmitContext*    context,
+        IRDeclaratorInfo*   declarator)
+    {
+        if(!declarator)
+            return;
+
+        switch( declarator->flavor )
+        {
+        case IRDeclaratorInfo::Flavor::Simple:
+            emit(" ");
+            emit(*declarator->name);
+            break;
+        }
+    }
+
+    void emitIRSimpleType(
+        EmitContext*    context,
+        IRType*         type)
+    {
+        switch(type->op)
+        {
+    #define CASE(ID, NAME) \
+        case kIROp_##ID: emit(#NAME); break
+
+        CASE(Float32Type,   float);
+        CASE(Int32Type,     int);
+        CASE(UInt32Type,    uint);
+
+    #undef CASE
+
+        default:
+            SLANG_UNIMPLEMENTED_X("type case for emit");
+            break;
+        }
+
+    }
+
+    void emitIRSimpleValue(
+        EmitContext*    context,
+        IRInst*         inst)
+    {
+        switch(inst->op)
+        {
+        case kIROp_IntLit:
+            emit(((IRConstant*) inst)->u.intVal);
+            break;
+
+        case kIROp_FloatLit:
+            emit(((IRConstant*) inst)->u.floatVal);
+            break;
+
+        default:
+            SLANG_UNIMPLEMENTED_X("val case for emit");
+            break;
+        }
+
+    }
+
+
+    void emitIRVectorType(
+        EmitContext*    context,
+        IRVectorType*   type)
+    {
+        // TODO: this is a GLSL-vs-HLSL decision point
+
+        emitIRSimpleType(context, type->getElementType());
+        emitIRSimpleValue(context, type->getElementCount());
+    }
+
+    void emitIRType(
+        EmitContext*        context,
+        IRType*             type,
+        IRDeclaratorInfo*   declarator)
+    {
+        switch( type->op )
+        {
+        case kIROp_VectorType:
+            emitIRVectorType(context, (IRVectorType*) type);
+            emitDeclarator(context, declarator);
+            break;
+
+        case kIROp_StructType:
+            emit(getName(type));
+            emitDeclarator(context, declarator);
+            break;
+
+        default:
+            emitIRSimpleType(context, type);
+            emitDeclarator(context, declarator);
+            break;
+        }
+    }
+
+    void emitIRType(
+        EmitContext*    context,
+        IRType*         type,
+        String const&   name)
+    {
+        IRDeclaratorInfo declarator;
+        declarator.flavor = IRDeclaratorInfo::Flavor::Simple;
+        declarator.name = &name;
+
+        emitIRType(context, type, &declarator);
+    }
+
+    void emitIRType(
+        EmitContext*    context,
+        IRType*         type)
+    {
+        emitIRType(context, type, (IRDeclaratorInfo*) nullptr);
+    }
+
+    void emitIROperand(
+        EmitContext*    context,
+        IRInst*         inst)
+    {
+        emit(getName(inst));
+    }
+
+    void emitIRArgs(
+        EmitContext*    context,
+        IRInst*         inst)
+    {
+        UInt argCount = inst->argCount - 1;
+        IRUse* args = inst->getArgs() + 1;
+
+        emit("(");
+        for(UInt aa = 0; aa < argCount; ++aa)
+        {
+            if(aa != 0) emit(", ");
+            emitIROperand(context, args[aa].usedValue);
+        }
+        emit(")");
+    }
+
+    void emitIRInstResultDecl(
+        EmitContext*    context,
+        IRInst*         inst)
+    {
+        emitIRType(context, inst->getType(), getName(inst));
+        emit(" = ");
+    }
+
+    void emitIRInst(
+        EmitContext*    context,
+        IRInst*         inst)
+    {
+        // TODO: need to be able to `switch` on the IR opcode here,
+        // so there is some work to be done.
+        switch(inst->op)
+        {
+        case kIROp_Param:
+            // Don't emit parameters, since they are declared as part of the function.
+            break;
+
+        case kIROp_Construct:
+            // Simple constructor call
+            emitIRInstResultDecl(context, inst);
+            emitIRType(context, inst->getType());
+            emitIRArgs(context, inst);
+            emit(";\n");
+            break;
+
+        case kIROp_FieldExtract:
+            {
+                // Extract field from aggregate
+
+                IRFieldExtract* fieldExtract = (IRFieldExtract*) inst;
+
+                emitIRInstResultDecl(context, inst);
+                emitIROperand(context, fieldExtract->getBase());
+                emit(".field");
+                emit(fieldExtract->fieldIndex);
+                emit(";\n");
+            }
+            break;
+
+        case kIROp_ReturnVoid:
+            emit("return;\n");
+            break;
+
+        case kIROp_ReturnVal:
+            emit("return ");
+            emitIROperand(context, ((IRReturnVal*) inst)->getVal());
+            emit(";\n");
+            break;
+
+        default:
+            emit("// uhandled\n");
+            break;
+        }
+    }
+
+    void emitIRFunc(
+        EmitContext*    context,
+        IRFunc*         func)
+    {
+        auto funcType = func->getType();
+        auto resultType = func->getResultType();
+
+        auto name = getName(func);
+
+        emitIRType(context, resultType, name);
+
+        emit("(");
+        auto firstParam = func->getFirstParam();
+        for( auto pp = firstParam; pp; pp = pp->getNextParam() )
+        {
+            if(pp != firstParam)
+                emit(", ");
+
+            auto paramName = getName(pp);
+            emitIRType(context, pp->getType(), paramName);
+        }
+        emit(")");
+
+        // TODO: encode declaration vs. definition
+        bool isDefinition = true;
+        if(isDefinition)
+        {
+            emit("\n{\n");
+
+            // Need to emit the operations in the blocks of the function
+            for( auto bb = func->getFirstBlock(); bb; bb = bb->getNextBlock() )
+            {
+                // TODO: need to handle control flow and so forth...
+                for( auto ii = bb->firstChild; ii; ii = ii->nextInst )
+                {
+                    emitIRInst(context, ii);
+                }
+            }
+
+            emit("}\n");
+        }
+        else
+        {
+            emit(";\n");
+        }
+    }
+
+    void emitIRStruct(
+        EmitContext*    context,
+        IRStructType*   structType)
+    {
+        emit("struct ");
+        emit(getName(structType));
+        emit("\n{\n");
+        auto fieldCount = structType->getFieldCount();
+        for( UInt ff = 0; ff < fieldCount; ++ff )
+        {
+            auto fieldType = structType->getFieldType(ff);
+
+            String fieldName = "field";
+            fieldName.append(ff);
+
+            emitIRType(context, fieldType, fieldName);
+            emit(";\n");
+        }
+        emit("};\n");
+    }
+
+    void emitIRGlobalInst(
+        EmitContext*    context,
+        IRInst*         inst)
+    {
+        // TODO: need to be able to `switch` on the IR opcode here,
+        // so there is some work to be done.
+        switch(inst->op)
+        {
+        case kIROp_Func:
+            emitIRFunc(context, (IRFunc*) inst);
+            break;
+
+        case kIROp_StructType:
+            emitIRStruct(context, (IRStructType*) inst);
+            break;
+
+        default:
+            break;
+        }
+    }
+
+    void emitIRModule(
+        EmitContext*    context,
+        IRModule*       module)
+    {
+        for(auto ii = module->firstChild; ii; ii = ii->nextInst )
+        {
+            emitIRGlobalInst(context, ii);
+        }
+    }
+
+
 };
 
+//
+
+
+//
 
 EntryPointLayout* findEntryPointLayout(
     ProgramLayout*      programLayout,
@@ -3947,6 +4267,11 @@ String emitEntryPoint(
         auto lowered = lowerEntryPointToIR(entryPoint, programLayout, target);
 
         dumpIR(lowered);
+
+        // TODO: do we want to emit directly from IR, or translate the
+        // IR back into AST for emission?
+
+        visitor.emitIRModule(&context, lowered);
 
         throw 99;
 

--- a/source/slang/ir-inst-defs.h
+++ b/source/slang/ir-inst-defs.h
@@ -14,7 +14,7 @@ INST(BoolType,    type.bool,      0, 0)
 INST(Float32Type, type.f32,       0, 0)
 INST(Int32Type,   type.i32,       0, 0)
 INST(UInt32Type,  type.u32,       0, 0)
-INST(StructType,  type.struct,    0, 0)
+INST(StructType,  type.struct,    0, PARENT)
 INST(FuncType,    func_type,      0, 0)
 
 INST(IntLit,      integer_constant,   0, 0)
@@ -26,9 +26,10 @@ INST(Module,      module, 0, PARENT)
 INST(Func,        func,   0, PARENT)
 INST(Block,       block,  0, PARENT)
 
-INST(Param,           param,  0, 0)
+INST(Param,         param,  0, 0)
+INST(StructField,   field,  0, 0)
 
-INST(FieldExtract,    get_field,      1, 0)
+INST(FieldExtract,    get_field,      2, 0)
 INST(ReturnVal,       return_val,     1, 0)
 INST(ReturnVoid, return_void, 1, 0)
 

--- a/source/slang/ir-inst-defs.h
+++ b/source/slang/ir-inst-defs.h
@@ -1,0 +1,41 @@
+// ir-inst-defs.h
+
+#ifndef INST
+#error Must #define `INST` before including `ir-inst-defs.h`
+#endif
+
+#define PARENT kIROpFlag_Parent
+
+INST(TypeType,    type.type,      0, 0)
+INST(VoidType,    type.void,      0, 0)
+INST(BlockType,   type.block,     0, 0)
+INST(VectorType,  type.vector,    2, 0)
+INST(BoolType,    type.bool,      0, 0)
+INST(Float32Type, type.f32,       0, 0)
+INST(Int32Type,   type.i32,       0, 0)
+INST(UInt32Type,  type.u32,       0, 0)
+INST(StructType,  type.struct,    0, 0)
+INST(FuncType,    func_type,      0, 0)
+
+INST(IntLit,      integer_constant,   0, 0)
+INST(FloatLit,    float_constant,     0, 0)
+
+INST(Construct,   construct,         0, 0)
+
+INST(Module,      module, 0, PARENT)
+INST(Func,        func,   0, PARENT)
+INST(Block,       block,  0, PARENT)
+
+INST(Param,           param,  0, 0)
+
+INST(FieldExtract,    get_field,      1, 0)
+INST(ReturnVal,       return_val,     1, 0)
+INST(ReturnVoid, return_void, 1, 0)
+
+#define INTRINSIC(NAME)                     \
+    INST(Intrinsic_##NAME, intrinsic.NAME, 0, 0)
+#include "intrinsic-defs.h"
+
+#undef PARENT
+#undef INST
+

--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -6,51 +6,19 @@
 namespace Slang
 {
 
-#define OP(ID, MNEMONIC, ARG_COUNT, FLAGS)  \
-    static const IROpInfo kIROpInfo_##ID {  \
-        #MNEMONIC, ARG_COUNT, FLAGS, }
-
-#define PARENT kIROpFlag_Parent
-
-    OP(TypeType,    type.type,      0, 0);
-    OP(VoidType,    type.void,      0, 0);
-    OP(BlockType,   type.block,     0, 0);
-    OP(VectorType,  type.vector,    2, 0);
-    OP(BoolType,    type.bool,      0, 0);
-    OP(Float32Type, type.f32,       0, 0);
-    OP(Int32Type,   type.i32,       0, 0);
-    OP(UInt32Type,  type.u32,       0, 0);
-    OP(StructType,  type.struct,    0, 0);
-
-    OP(IntLit,      integer_constant,   0, 0);
-    OP(FloatLit,    float_constant,     0, 0);
-
-    OP(Construct,   construct,         0, 0);
-
-    OP(Module,      module, 0, PARENT);
-    OP(Func,        func,   0, PARENT);
-    OP(Block,       block,  0, PARENT);
-
-    OP(Param,           param,  0, 0);
-
-    OP(FieldExtract,    get_field,      1, 0);
-    OP(ReturnVal,       return_val,     1, 0);
-    OP(ReturnVoid, return_void, 1, 0);
-
-#define INTRINSIC(NAME)                     \
-    static const IROpInfo kIROpInfo_Intrinsic_##NAME {  \
-        "intrinsic." #NAME, 0, 0, };
-#include "intrinsic-defs.h"
-
-#undef PARENT
-#undef OP
-
-
-    static IROpInfo const* const kIRIntrinsicOpInfos[] =
+    static const IROpInfo kIROpInfos[] =
     {
-        nullptr,
+#define INST(ID, MNEMONIC, ARG_COUNT, FLAGS)  \
+    { #MNEMONIC, ARG_COUNT, FLAGS, },
+#include "ir-inst-defs.h"
+    };
 
-#define INTRINSIC(NAME) &kIROpInfo_Intrinsic_##NAME,
+
+    static const IROp kIRIntrinsicOps[] =
+    {
+        (IROp) 0,
+
+#define INTRINSIC(NAME) kIROp_Intrinsic_##NAME,
 #include "intrinsic-defs.h"
 
     };
@@ -76,6 +44,33 @@ namespace Slang
     IRUse* IRInst::getArgs()
     {
         return &type;
+    }
+
+    //
+
+    IRParam* IRFunc::getFirstParam()
+    {
+        auto entryBlock = getFirstBlock();
+        if(!entryBlock) return nullptr;
+
+        auto firstInst = entryBlock->firstChild;
+        if(!firstInst) return nullptr;
+
+        if(firstInst->op != kIROp_Param)
+            return nullptr;
+
+        return (IRParam*) firstInst;
+    }
+
+    IRParam* IRParam::getNextParam()
+    {
+        auto next = nextInst;
+        if(!next) return nullptr;
+
+        if(next->op != kIROp_Param)
+            return nullptr;
+
+        return (IRParam*) next;
     }
 
     //
@@ -124,10 +119,12 @@ namespace Slang
     static IRValue* createInstImpl(
         IRBuilder*      builder,
         UInt            size,
-        IROpInfo const* op,
+        IROp            op,
         IRType*         type,
-        UInt            argCount,
-        IRValue* const* args)
+        UInt            fixedArgCount,
+        IRValue* const* fixedArgs,
+        UInt            varArgCount = 0,
+        IRValue* const* varArgs = nullptr)
     {
         IRValue* inst = (IRInst*) malloc(size);
         memset(inst, 0, size);
@@ -135,7 +132,7 @@ namespace Slang
         IRUse* instArgs = inst->getArgs();
 
         auto module = builder->getModule();
-        if (!module || (type && type->op == &kIROpInfo_VoidType))
+        if (!module || (type && type->op == kIROp_VoidType))
         {
             // Can't or shouldn't assign an ID to this op
         }
@@ -143,15 +140,25 @@ namespace Slang
         {
             inst->id = ++module->idCounter;
         }
-        inst->argCount = argCount + 1;
+        inst->argCount = fixedArgCount + varArgCount + 1;
 
         inst->op = op;
 
-        inst->type.init(inst, type);
+        auto operand = inst->getArgs();
 
-        for( UInt aa = 0; aa < argCount; ++aa )
+        operand->init(inst, type);
+        operand++;
+
+        for( UInt aa = 0; aa < fixedArgCount; ++aa )
         {
-            instArgs[aa+1].init(inst, args[aa]);
+            operand->init(inst, fixedArgs[aa]);
+            operand++;
+        }
+
+        for( UInt aa = 0; aa < varArgCount; ++aa )
+        {
+            operand->init(inst, varArgs[aa]);
+            operand++;
         }
 
         return inst;
@@ -165,7 +172,7 @@ namespace Slang
     static IRValue* createInstImpl(
         IRBuilder*      builder,
         UInt            size,
-        IROpInfo const* op,
+        IROp            op,
         UInt            argCount,
         IRValue* const* args)
     {
@@ -181,7 +188,7 @@ namespace Slang
     template<typename T>
     static T* createInst(
         IRBuilder*      builder,
-        IROpInfo const* op,
+        IROp            op,
         IRType*         type,
         UInt            argCount,
         IRValue* const* args)
@@ -198,7 +205,7 @@ namespace Slang
     template<typename T>
     static T* createInst(
         IRBuilder*      builder,
-        IROpInfo const* op,
+        IROp            op,
         IRType*         type)
     {
         return (T*)createInstImpl(
@@ -213,7 +220,7 @@ namespace Slang
     template<typename T>
     static T* createInst(
         IRBuilder*      builder,
-        IROpInfo const* op,
+        IROp            op,
         IRType*         type,
         IRValue*        arg)
     {
@@ -229,7 +236,7 @@ namespace Slang
     template<typename T>
     static T* createInst(
         IRBuilder*      builder,
-        IROpInfo const* op,
+        IROp            op,
         IRType*         type,
         IRValue*        arg1,
         IRValue*        arg2)
@@ -247,7 +254,7 @@ namespace Slang
     template<typename T>
     static T* createInstWithTrailingArgs(
         IRBuilder*      builder,
-        IROpInfo const* op,
+        IROp            op,
         IRType*         type,
         UInt            argCount,
         IRValue* const* args)
@@ -259,6 +266,27 @@ namespace Slang
             type,
             argCount,
             args);
+    }
+
+    template<typename T>
+    static T* createInstWithTrailingArgs(
+        IRBuilder*      builder,
+        IROp            op,
+        IRType*         type,
+        UInt            fixedArgCount,
+        IRValue* const* fixedArgs,
+        UInt            varArgCount,
+        IRValue* const* varArgs)
+    {
+        return (T*)createInstImpl(
+            builder,
+            sizeof(T) + varArgCount * sizeof(IRUse),
+            op,
+            type,
+            fixedArgCount,
+            fixedArgs,
+            varArgCount,
+            varArgs);
     }
 
     //
@@ -327,7 +355,7 @@ namespace Slang
     static IRInst* findOrEmitInstImpl(
         IRBuilder*      builder,
         UInt            size,
-        IROpInfo const* op,
+        IROp            op,
         IRType*         type,
         UInt            argCount,
         IRValue* const* args)
@@ -354,7 +382,7 @@ namespace Slang
             parent = builder->parentInst;
         }
 
-        if( parent->op == &kIROpInfo_Func )
+        if( parent->op == kIROp_Func )
         {
             // We are trying to insert into a function, and we should really
             // be inserting into its entry block.
@@ -398,7 +426,7 @@ namespace Slang
     template<typename T>
     static T* findOrEmitInst(
         IRBuilder*      builder,
-        IROpInfo const* op,
+        IROp            op,
         IRType*         type,
         UInt            argCount,
         IRValue* const* args)
@@ -415,7 +443,7 @@ namespace Slang
     template<typename T>
     static T* findOrEmitInst(
         IRBuilder*      builder,
-        IROpInfo const* op,
+        IROp            op,
         IRType*         type)
     {
         return (T*) findOrEmitInstImpl(
@@ -430,7 +458,7 @@ namespace Slang
     template<typename T>
     static T* findOrEmitInst(
         IRBuilder*      builder,
-        IROpInfo const* op,
+        IROp            op,
         IRType*         type,
         IRInst*         arg)
     {
@@ -446,7 +474,7 @@ namespace Slang
     template<typename T>
     static T* findOrEmitInst(
         IRBuilder*      builder,
-        IROpInfo const* op,
+        IROp            op,
         IRType*         type,
         IRInst*         arg1,
         IRInst*         arg2)
@@ -482,11 +510,11 @@ namespace Slang
     }
 
     static IRConstant* findOrEmitConstant(
-        IRBuilder*              builder,
-        IROpInfo const*         op,
-        IRType*                 type,
-        UInt                    valueSize,
-        void const*             value)
+        IRBuilder*      builder,
+        IROp            op,
+        IRType*         type,
+        UInt            valueSize,
+        void const*     value)
     {
         // First, we need to pick a good insertion point
         // for the instruction, which we do by looking
@@ -531,7 +559,7 @@ namespace Slang
 
     //
 
-    static IRType* getBaseTypeImpl(IRBuilder* builder, IROpInfo const* op)
+    static IRType* getBaseTypeImpl(IRBuilder* builder, IROp op)
     {
         auto inst = findOrEmitInst<IRType>(
             builder,
@@ -544,10 +572,10 @@ namespace Slang
     {
         switch( flavor )
         {
-        case BaseType::Bool:    return getBaseTypeImpl(this, &kIROpInfo_BoolType);
-        case BaseType::Float:   return getBaseTypeImpl(this, &kIROpInfo_Float32Type);
-        case BaseType::Int:     return getBaseTypeImpl(this, &kIROpInfo_Int32Type);
-        case BaseType::UInt:     return getBaseTypeImpl(this, &kIROpInfo_UInt32Type);
+        case BaseType::Bool:    return getBaseTypeImpl(this, kIROp_BoolType);
+        case BaseType::Float:   return getBaseTypeImpl(this, kIROp_Float32Type);
+        case BaseType::Int:     return getBaseTypeImpl(this, kIROp_Int32Type);
+        case BaseType::UInt:     return getBaseTypeImpl(this, kIROp_UInt32Type);
 
         default:
             SLANG_UNEXPECTED("unhandled base type");
@@ -564,7 +592,7 @@ namespace Slang
     {
         return findOrEmitInst<IRVectorType>(
             this,
-            &kIROpInfo_VectorType,
+            kIROp_VectorType,
             getTypeType(),
             elementType,
             elementCount);
@@ -574,7 +602,7 @@ namespace Slang
     {
         return findOrEmitInst<IRType>(
             this,
-            &kIROpInfo_TypeType,
+            kIROp_TypeType,
             nullptr);
     }
 
@@ -582,7 +610,7 @@ namespace Slang
     {
         return findOrEmitInst<IRType>(
             this,
-            &kIROpInfo_VoidType,
+            kIROp_VoidType,
             getTypeType());
     }
 
@@ -590,7 +618,7 @@ namespace Slang
     {
         return findOrEmitInst<IRType>(
             this,
-            &kIROpInfo_BlockType,
+            kIROp_BlockType,
             getTypeType());
     }
 
@@ -600,10 +628,27 @@ namespace Slang
     {
         auto inst = createInstWithTrailingArgs<IRStructType>(
             this,
-            &kIROpInfo_StructType,
+            kIROp_StructType,
             getTypeType(),
             fieldCount,
             (IRValue* const*)fieldTypes);
+        addInst(inst);
+        return inst;
+    }
+
+    IRType* IRBuilder::getFuncType(
+        UInt            paramCount,
+        IRType* const*  paramTypes,
+        IRType*         resultType)
+    {
+        auto inst = createInstWithTrailingArgs<IRFuncType>(
+            this,
+            kIROp_FuncType,
+            getTypeType(),
+            1,
+            (IRValue* const*) &resultType,
+            paramCount,
+            (IRValue* const*) paramTypes);
         addInst(inst);
         return inst;
     }
@@ -617,7 +662,7 @@ namespace Slang
     {
         return findOrEmitConstant(
             this,
-            &kIROpInfo_IntLit,
+            kIROp_IntLit,
             type,
             sizeof(value),
             &value);
@@ -627,7 +672,7 @@ namespace Slang
     {
         return findOrEmitConstant(
             this,
-            &kIROpInfo_FloatLit,
+            kIROp_FloatLit,
             type,
             sizeof(value),
             &value);
@@ -641,7 +686,7 @@ namespace Slang
     {
         auto inst = createInstWithTrailingArgs<IRInst>(
             this,
-            kIRIntrinsicOpInfos[(int)intrinsicOp],
+            kIRIntrinsicOps[(int)intrinsicOp],
             type,
             argCount,
             args);
@@ -656,7 +701,7 @@ namespace Slang
     {
         auto inst = createInstWithTrailingArgs<IRInst>(
             this,
-            &kIROpInfo_Construct,
+            kIROp_Construct,
             type,
             argCount,
             args);
@@ -668,7 +713,7 @@ namespace Slang
     {
         return createInst<IRModule>(
             this,
-            &kIROpInfo_Module,
+            kIROp_Module,
             nullptr);
     }
 
@@ -677,7 +722,7 @@ namespace Slang
     {
         return createInst<IRFunc>(
             this,
-            &kIROpInfo_Func,
+            kIROp_Func,
             nullptr);
     }
 
@@ -685,7 +730,7 @@ namespace Slang
     {
         return createInst<IRBlock>(
             this,
-            &kIROpInfo_Block,
+            kIROp_Block,
             getBlockType());
     }
 
@@ -701,7 +746,7 @@ namespace Slang
     {
         auto inst = createInst<IRParam>(
             this,
-            &kIROpInfo_Param,
+            kIROp_Param,
             type);
         addInst(inst);
         return inst;
@@ -714,7 +759,7 @@ namespace Slang
     {
         auto inst = createInst<IRFieldExtract>(
             this,
-            &kIROpInfo_FieldExtract,
+            kIROp_FieldExtract,
             type,
             base);
 
@@ -729,7 +774,7 @@ namespace Slang
     {
         auto inst = createInst<IRReturnVal>(
             this,
-            &kIROpInfo_ReturnVal,
+            kIROp_ReturnVal,
             getVoidType(),
             val);
         addInst(inst);
@@ -740,7 +785,7 @@ namespace Slang
     {
         auto inst = createInst<IRReturnVoid>(
             this,
-            &kIROpInfo_ReturnVoid,
+            kIROp_ReturnVoid,
             getVoidType());
         addInst(inst);
         return inst;
@@ -803,6 +848,7 @@ namespace Slang
         // TODO: need to display a name for the result...
 
         auto op = inst->op;
+        auto opInfo = &kIROpInfos[op];
 
         if (inst->id)
         {
@@ -810,7 +856,7 @@ namespace Slang
             dump(context, " = ");
         }
 
-        dump(context, op->name);
+        dump(context, opInfo->name);
 
         // TODO: dump operands
         uint32_t argCount = inst->argCount;
@@ -832,7 +878,7 @@ namespace Slang
 
         dump(context, "\n");
 
-        if (op->flags & kIROpFlag_Parent)
+        if (opInfo->flags & kIROpFlag_Parent)
         {
             dumpIndent(context);
             dump(context, "{\n");

--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -622,19 +622,22 @@ namespace Slang
             getTypeType());
     }
 
-    IRType* IRBuilder::getStructType(
-        UInt            fieldCount,
-        IRType* const*  fieldTypes)
+    IRStructDecl* IRBuilder::createStructType()
     {
-        auto inst = createInstWithTrailingArgs<IRStructType>(
+        return createInst<IRStructDecl>(
             this,
             kIROp_StructType,
-            getTypeType(),
-            fieldCount,
-            (IRValue* const*)fieldTypes);
-        addInst(inst);
-        return inst;
+            getTypeType());
     }
+
+    IRStructField* IRBuilder::createStructField(IRType* fieldType)
+    {
+        return createInst<IRStructField>(
+            this,
+            kIROp_StructField,
+            fieldType);
+    }
+
 
     IRType* IRBuilder::getFuncType(
         UInt            paramCount,
@@ -753,17 +756,16 @@ namespace Slang
     }
 
     IRInst* IRBuilder::emitFieldExtract(
-        IRType*     type,
-        IRValue*    base,
-        UInt        fieldIndex)
+        IRType*         type,
+        IRValue*        base,
+        IRStructField*  field)
     {
         auto inst = createInst<IRFieldExtract>(
             this,
             kIROp_FieldExtract,
             type,
-            base);
-
-        inst->fieldIndex = fieldIndex;
+            base,
+            field);
 
         addInst(inst);
         return inst;

--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -46,6 +46,16 @@ namespace Slang
         return &type;
     }
 
+    IRDecoration* IRInst::findDecorationImpl(IRDecorationOp decorationOp)
+    {
+        for( auto dd = firstDecoration; dd; dd = dd->next )
+        {
+            if(dd->op == decorationOp)
+                return dd;
+        }
+        return nullptr;
+    }
+
     //
 
     IRParam* IRFunc::getFirstParam()
@@ -128,8 +138,6 @@ namespace Slang
     {
         IRValue* inst = (IRInst*) malloc(size);
         memset(inst, 0, size);
-
-        IRUse* instArgs = inst->getArgs();
 
         auto module = builder->getModule();
         if (!module || (type && type->op == kIROp_VoidType))
@@ -792,6 +800,32 @@ namespace Slang
         addInst(inst);
         return inst;
     }
+
+    IRDecoration* IRBuilder::addDecorationImpl(
+        IRInst*         inst,
+        UInt            decorationSize,
+        IRDecorationOp  op)
+    {
+        auto decoration = (IRDecoration*) malloc(decorationSize);
+        memset(decoration, 0, decorationSize);
+
+        decoration->op = op;
+
+        decoration->next = inst->firstDecoration;
+        inst->firstDecoration = decoration;
+
+        return decoration;
+    }
+
+    IRHighLevelDeclDecoration* IRBuilder::addHighLevelDeclDecoration(IRInst* inst, Decl* decl)
+    {
+        auto decoration = addDecoration<IRHighLevelDeclDecoration>(inst, kIRDecorationOp_HighLevelDecl);
+        decoration->decl = decl;
+        return decoration;
+    }
+
+    //
+
 
     struct IRDumpContext
     {

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -562,6 +562,8 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                     auto irField = builder->createStructField(getSimpleType(fieldType));
                     builder->addInst(irStruct, irField);
 
+                    builder->addHighLevelDeclDecoration(irField, fieldDecl);
+
                     context->shared->declValues.Add(
                         DeclRef<StructField>(fieldDecl, nullptr),
                         LoweredValInfo::simple(irField));
@@ -573,6 +575,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             }
         }
 
+        builder->addHighLevelDeclDecoration(irStruct, decl);
 
         builder->addInst(irStruct);
 
@@ -623,6 +626,8 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         irFunc->type.init(irFunc, irFuncType);
 
         lowerStmt(subContext, decl->Body);
+
+        getBuilder()->addHighLevelDeclDecoration(irFunc, decl);
 
         getBuilder()->addInst(irFunc);
 

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -608,9 +608,13 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         // set up sub context for generating our new function
 
+        List<IRType*> paramTypes;
+
         for( auto paramDecl : decl->GetParameters() )
         {
             IRType* irParamType = lowerSimpleType(context, paramDecl->getType());
+            paramTypes.Add(irParamType);
+
             IRParam* irParam = subBuilder->emitParam(irParamType);
 
             DeclRef<ParamDecl> paramDeclRef = makeDeclRef(paramDecl.Ptr());
@@ -620,8 +624,13 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             subContext->shared->declValues.Add(paramDeclRef, irParamVal);
         }
 
-        auto irResultType = lowerType(context, decl->ReturnType);
+        auto irResultType = lowerSimpleType(context, decl->ReturnType);
 
+        auto irFuncType = getBuilder()->getFuncType(
+            paramTypes.Count(),
+            &paramTypes[0],
+            irResultType);
+        irFunc->type.init(irFunc, irFuncType);
 
         lowerStmt(subContext, decl->Body);
 

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -172,6 +172,7 @@
     <ClInclude Include="emit.h" />
     <ClInclude Include="expr-defs.h" />
     <ClInclude Include="intrinsic-defs.h" />
+    <ClInclude Include="ir-inst-defs.h" />
     <ClInclude Include="ir.h" />
     <ClInclude Include="lexer.h" />
     <ClInclude Include="lookup.h" />

--- a/source/slang/slang.vcxproj.filters
+++ b/source/slang/slang.vcxproj.filters
@@ -39,6 +39,7 @@
     <ClInclude Include="name.h" />
     <ClInclude Include="ir.h" />
     <ClInclude Include="lower-to-ir.h" />
+    <ClInclude Include="ir-inst-defs.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="check.cpp" />


### PR DESCRIPTION
- Change IR instructions to just hold an integer opcode instead of a pointer to the "info" structure

- Externalize definition of IR instructions to a header file, and use the "X macro" approach to allow generating different definitions

- Add notion of function types to the IR, so that we can easily query the result type of a function

- Add some convenience accesors to allow walking the IR in a strongly-typed manner (e.g., iterate over the parameters of a function)
  - TODO: these should really be changed to assert the type of things, as least in debug builds

- Add very basic logic to `emit.cpp` so  that it can walk the generated IR and start printing it back as HLSL
  - This isn't meant to be usable as-is, but it is a step toward where we need to go