### PR TITLE
Fix some resources-in-structs bugs

### DIFF
--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -572,7 +572,17 @@ namespace Slang
 
         // Splice the modifier into the linked list
 
-        modifier->next = *modifierLink;
+        // We need to deal with the case where the modifeir to
+        // be spliced in might actually be a modifier *list*,
+        // so that we actually want to splice in at the
+        // end of the new list...
+        auto spliceLink = &modifier->next;
+        while(*spliceLink)
+            spliceLink = &(*spliceLink)->next;
+
+        // Do the splice.
+        *spliceLink = *modifierLink;
+
         *modifierLink = modifier;
         modifierLink = &modifier->next;
     }

--- a/tests/bugs/gh-171.slang
+++ b/tests/bugs/gh-171.slang
@@ -17,10 +17,6 @@ float4 main(float2 uv: UV) : SV_Target
 
 #else
 
-cbuffer C : register(b0)
-{
-};
-
 Texture2D SLANG_parameterBlock_C_t : register(t0);
 SamplerState SLANG_parameterBlock_C_s : register(s0);
 

--- a/tests/bugs/gh-171.slang
+++ b/tests/bugs/gh-171.slang
@@ -1,0 +1,34 @@
+//TEST:COMPARE_HLSL: -profile ps_5_0 -entry main -target dxbc-assembly -split-mixed-types
+// Make sure we don't crash when desugaring resources
+// in structs when a `cbuffer` only contains resources.
+
+#ifdef __SLANG__
+
+cbuffer C
+{
+	Texture2D t;
+	SamplerState s;
+};
+
+float4 main(float2 uv: UV) : SV_Target
+{
+	return t.Sample(s, uv);
+}
+
+#else
+
+cbuffer C : register(b0)
+{
+};
+
+Texture2D SLANG_parameterBlock_C_t : register(t0);
+SamplerState SLANG_parameterBlock_C_s : register(s0);
+
+float4 main(float2 uv: UV) : SV_Target
+{
+	return SLANG_parameterBlock_C_t.Sample(SLANG_parameterBlock_C_s, uv);
+}
+
+#endif
+
+

--- a/tests/bugs/gh-172.slang
+++ b/tests/bugs/gh-172.slang
@@ -1,0 +1,41 @@
+//TEST:COMPARE_HLSL: -profile ps_5_0 -entry main -target dxbc-assembly -split-mixed-types
+
+// Make sure we don't crash when desugaring resource in structs,
+// when the user also declares multiple variables with a
+// single declaration.
+
+#ifdef __SLANG__
+
+cbuffer C
+{
+	Texture2D t0, t1;
+	SamplerState s;
+	float2 uv;
+};
+
+float4 main() : SV_Target
+{
+	return t0.Sample(s, uv)
+         + t1.Sample(s, uv);
+}
+
+#else
+
+cbuffer C : register(b0)
+{
+	float2 uv;
+};
+
+Texture2D SLANG_parameterBlock_C_t0 : register(t0);
+Texture2D SLANG_parameterBlock_C_t1 : register(t1);
+SamplerState SLANG_parameterBlock_C_s : register(s0);
+
+float4 main() : SV_Target
+{
+	return SLANG_parameterBlock_C_t0.Sample(SLANG_parameterBlock_C_s, uv)
+	     + SLANG_parameterBlock_C_t1.Sample(SLANG_parameterBlock_C_s, uv);
+}
+
+#endif
+
+

--- a/tools/slang-test/main.cpp
+++ b/tools/slang-test/main.cpp
@@ -873,6 +873,16 @@ TestResult runHLSLComparisonTest(TestInput& input)
     {
         String actualOutputPath = outputStem + ".actual";
         Slang::File::WriteAllText(actualOutputPath, actualOutput);
+
+        if (options.outputMode == kOutputMode_AppVeyor)
+        {
+            fprintf(stderr, "ERROR:\n"
+                "EXPECTED{{{\n%s}}}\n"
+                "ACTUAL{{{\n%s}}}\n",
+                expectedOutput.Buffer(),
+                actualOutput.Buffer());
+            fflush(stderr);
+        }
     }
 
     return result;


### PR DESCRIPTION
Fixes #171
Fixes #172

These two bugs related to bad logic in handling of splitting resource-containing `cbuffer` declarations.

- Issue #171 was the case where a `cbuffer` *only* had resource fields, in which case we crashed whenever referencing any field (some code was assuming there had to be non-resource fields)

- Issue #172 was a case where two fields were declared with a single declaration (`Texture2D a, b;`), and the logic we had for tracking resource-type fields was accidentally tagging *both* fields with a single modifier so that field `b` would get confused for `a` in some contexts, and attempts to access `b` would crash.

Both issues are now fixed, and regression tests have been added.