### PR TITLE
Fix some issues around cloned modifiers.

### DIFF
--- a/source/core/smart-pointer.h
+++ b/source/core/smart-pointer.h
@@ -49,6 +49,11 @@ namespace Slang
             SLANG_ASSERT(referenceCount != 0);
             return referenceCount == 1;
         }
+
+        UInt debugGetReferenceCount()
+        {
+            return referenceCount;
+        }
     };
 
     inline void addReference(RefObject* obj)

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -859,6 +859,16 @@ SLANG_API int spCompile(
 {
     auto req = REQ(request);
 
+#if 1
+    // By default we'd like to catch as many internal errors as possible,
+    // and report them to the user nicely (rather than just crash their
+    // application). Internally Slang currently uses exceptions for this.
+    //
+    // TODO: Consider using `setjmp()`-style escape so that we can work
+    // with applications that disable exceptions.
+    //
+    // TODO: Consider supporting Windows "Structured Exception Handling"
+    // so that we can also recover from a wider class of crashes.
     try
     {
         int anyErrors = req->executeActions();
@@ -869,6 +879,14 @@ SLANG_API int spCompile(
         req->mSink.diagnose(Slang::SourceLoc(), Slang::Diagnostics::compilationAborted);
         return 1;
     }
+#else
+    // When debugging, we probably don't want to filter out any errors, since
+    // we are probably trying to root-cause and *fix* those errors.
+    {
+        int anyErrors = req->executeActions();
+        return anyErrors;
+    }
+#endif
 }
 
 SLANG_API int


### PR DESCRIPTION
The root of the problem here is that:

- We do a shallow copy of modifiers when "lowering" declarations/statements, by just copying over the head pointer of the linked list of modifiers

- During lowering we sometimes add additional modifiers (only used during lowering), and these can thus accidentally get added to the end of the list of modifiers for the original declaration (rather than just the lowered decl)

- If the same declaration is used by multiple entry points to be output, then a modifier added by the first entry point (which could reference entry-point-specific storage) will be earlier in the modifier list and might be picked up by a later entry point, so that we dereference already released memory

The simple fix for right now is the use the support for a "shared" modifier node to ensure that each lowered declaration/statement gets a unique modifier list.

A better long-term fix is:

1. Don't use modifiers to store general side-band information, and instead use proper lookup tables that own their contents.

2. Don't use a linked list to store modifiers (this was done to make splicing easy, but now we have a whole class of bugs related to bad splices), and be willing to clone them as needed.