### PR TITLE
Move implicit conversion operations to stdlib

### DIFF
--- a/source/slang/expr-defs.h
+++ b/source/slang/expr-defs.h
@@ -102,9 +102,9 @@ SYNTAX_CLASS(DerefExpr, Expr)
 END_SYNTAX_CLASS()
 
 // Any operation that performs type-casting
-SYNTAX_CLASS(TypeCastExpr, Expr)
-    SYNTAX_FIELD(TypeExp, TargetType)
-    SYNTAX_FIELD(RefPtr<Expr>, Expression)
+SYNTAX_CLASS(TypeCastExpr, InvokeExpr)
+//    SYNTAX_FIELD(TypeExp, TargetType)
+//    SYNTAX_FIELD(RefPtr<Expr>, Expression)
 END_SYNTAX_CLASS()
 
 // An explicit type-cast that appear in the user's code with `(type) expr` syntax

--- a/source/slang/modifier-defs.h
+++ b/source/slang/modifier-defs.h
@@ -315,3 +315,11 @@ END_SYNTAX_CLASS()
 SYNTAX_CLASS(TupleVarModifier, Modifier)
     FIELD_INIT(TupleFieldModifier*, tupleField, nullptr)
 END_SYNTAX_CLASS()
+
+// A modifier to indicate that a constructor/initializer can be used
+// to perform implicit type conversion, and to specify the cost of
+// the conversion, if applied.
+SYNTAX_CLASS(ImplicitConversionModifier, Modifier)
+    // The conversion cost, used to rank conversions
+    FIELD(ConversionCost, cost)
+END_SYNTAX_CLASS()

--- a/source/slang/syntax-base-defs.h
+++ b/source/slang/syntax-base-defs.h
@@ -4,10 +4,16 @@
 // AST nodes and related objects. For example, this is where the
 // basic `Decl`, `Stmt`, `Expr`, `type`, etc. definitions come from.
 
+ABSTRACT_SYNTAX_CLASS(NodeBase, RefObject)
+    // A helper to access the corresponding class on a concrete instance
+    RAW(
+    virtual SyntaxClass<NodeBase> getClass() = 0;
+    )
+END_SYNTAX_CLASS()
+
 // Base class for all nodes representing actual syntax
 // (thus having a location in the source code)
-ABSTRACT_SYNTAX_CLASS(SyntaxNodeBase, RefObject)
-
+ABSTRACT_SYNTAX_CLASS(SyntaxNodeBase, NodeBase)
     // The primary source location associated with this AST node
     FIELD(SourceLoc, loc)
 
@@ -26,7 +32,7 @@ END_SYNTAX_CLASS()
 // These are *not* syntax nodes, because they do not have
 // a unique location, and any two `Val`s representing
 // the same value should be conceptually equal.
-ABSTRACT_SYNTAX_CLASS(Val, RefObject)
+ABSTRACT_SYNTAX_CLASS(Val, NodeBase)
     RAW(typedef IValVisitor Visitor;)
 
     RAW(virtual void accept(IValVisitor* visitor, void* extra) = 0;)

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -69,6 +69,7 @@ namespace Slang
     void NAME::accept(NAME::Visitor* visitor, void* extra)                  \
     { visitor->dispatch_##NAME(this, extra); }                              \
     void* SyntaxClassBase::Impl<NAME>::createFunc() { return new NAME(); }  \
+    SyntaxClass<NodeBase> NAME::getClass() { return Slang::getClass<NAME>(); }   \
     SyntaxClassBase::ClassInfo const SyntaxClassBase::Impl<NAME>::kClassInfo = { #NAME, &SyntaxClassBase::Impl<BASE>::kClassInfo, &SyntaxClassBase::Impl<NAME>::createFunc };
 #include "expr-defs.h"
 #include "decl-defs.h"
@@ -79,13 +80,14 @@ namespace Slang
 
 SyntaxClassBase::ClassInfo const SyntaxClassBase::Impl<RefObject>::kClassInfo = { "RefObject", nullptr, nullptr };
 
-ABSTRACT_SYNTAX_CLASS(SyntaxNodeBase, RefObject);
+ABSTRACT_SYNTAX_CLASS(NodeBase, RefObject);
+ABSTRACT_SYNTAX_CLASS(SyntaxNodeBase, NodeBase);
 ABSTRACT_SYNTAX_CLASS(SyntaxNode, SyntaxNodeBase);
 ABSTRACT_SYNTAX_CLASS(ModifiableSyntaxNode, SyntaxNode);
 ABSTRACT_SYNTAX_CLASS(DeclBase, ModifiableSyntaxNode);
 ABSTRACT_SYNTAX_CLASS(Decl, DeclBase);
 ABSTRACT_SYNTAX_CLASS(Stmt, ModifiableSyntaxNode);
-ABSTRACT_SYNTAX_CLASS(Val, RefObject);
+ABSTRACT_SYNTAX_CLASS(Val, NodeBase);
 ABSTRACT_SYNTAX_CLASS(Type, Val);
 ABSTRACT_SYNTAX_CLASS(Modifier, SyntaxNodeBase);
 ABSTRACT_SYNTAX_CLASS(Expr, SyntaxNode);

--- a/tests/hlsl/simple/implicit_conversion.hlsl
+++ b/tests/hlsl/simple/implicit_conversion.hlsl
@@ -1,0 +1,67 @@
+//TEST:COMPARE_HLSL: -target dxbc-assembly -profile cs_5_0 -entry main
+
+// Test various cases of implicit type conversion and preference
+// for overload resolution.
+
+cbuffer U
+{
+	int 	ii;
+	uint 	uu;
+	float 	ff;	
+};
+
+Buffer<int> ib;
+RWBuffer<int> ob;
+
+
+int pick(int   x) 	{ return 1; }
+int pick(uint  x)	{ return 2; }
+int pick(float x) 	{ return 3; }
+
+
+int test0(int x) { return x; }
+uint test0(uint x) { return x; }
+
+// Test: is integer-to-float conversion preferred
+// over scalar-to-vector conversion?
+int test1(uint3 v) { return 0; }
+float test1(float v) { return 0; }
+
+// Is rank of signed-int-to-float the same
+// as unsigned-init-to-float?
+int test2(float f, uint u) { return 0; }
+float test2(int i, float f) { return 0; }
+
+// Is just having "more" implicit conversions
+// enough to rank overloads?
+int test3(float f, uint u, uint u2) { return 0; }
+float test3(int i, float f, float f2) { return 0; }
+
+[numthreads(1,1,1)]
+void main(uint3 tid : SV_DispatchThreadID)
+{
+	uint idx = tid.x;
+
+	bool bb = (ii + uu) != 0;
+
+#define CASE(exp) ob[ib[idx++]] = pick(exp)
+
+	CASE(ii + uu);
+	CASE(uu + ii);
+	CASE(ii + ff);
+	CASE(uu + ff);
+
+	// Should be ambiguous, but currently isn't:
+//	CASE(test0(bb));
+
+	CASE(test1(uu));
+
+	// Ambiguous, and it should be
+//	CASE(test2(ii, uu));
+
+	// Prefer overload with lower overall converion cost
+	// (not necessarily one that is unambiguously "better"
+	// at every argument position).
+	//
+	CASE(test3(ii, uu, uu));
+}


### PR DESCRIPTION
- Previously, there were a variety of rules in `check.cpp` to pick the conversion cost for various cases involving scalar, vector, and matrix types.

- The main problem of the previous approach is that any lowering pass would need to convert an arbitrary "type cast" node into the right low-level operation(s).

- The new approach is that a type conversion (implicit or explicit) always resolves as a call to a constructor/initializer for the destination type. This means that the existing rules around marking operations as builtins should work for lowering.

- The support this, the checking logic needs to perform lookup of intializers/constructors when asked to perform conversion between types. It does this by re-using the existing logic for lookup and overload resolution if/when a type was applied in an ordinary context.

- Next, we define a modifier that can be attached to constructors/initializers to mark them as suitable for implicit conversion, and associate them with the correct cost to be used when doing overload comparisons.

- We add the modifier to all the scalar-to-scalar cases in the stdlib, using the logic that previously existed in semantic checking.

- Next we add cases for general vector-to-scalar conversions that also convert type, using the same cost computation as above.

- This probably misses various cases, but at this point they can hopefully be added just in the stdlib.

- One gotcha here is that in lowering, we need to make sure to lower any kind of call expression to another call expression of the same AST node class, so that we don't lose information on what casts were implicit/hidden in teh source-to-source case.

Two notes for potential longer-term changes:

1. There is still some duplication between the type conversion declarations here and the "join" logic for types used for generic arguments. Ideally we'd eventually clean up the "join" logic to be based on convertability, but that isn't a high priority right now, as long as joins continue to pick the right type.

2. It is a bit gross to have to declare all the N^2 conversions for vector/matrix types to duplicate the cases for scalars. For the simple scalar-to-vector case, we might try to support multiple conversion "steps" where both a scalar-to-scalar and a scalar-to-vector step can be allowed (this could be tagged on the modifiers already introduced). That simple option doesn't scale to vector-to-vector element type conversions, though, where you'd really want to make it a generic with a constraint like:

       vector<T,N> init<U>(vector<U,N> value) where T : ConvertibleFrom<U>;

   Here the `ConvertibleFrom<U>` interface expresses the fact that a conforming type has an initializer that takes a `U`. What doesn't appear in this context is any notion of conversion costs. We'd need some kind of system for computing the conversion cost of the vector conversion from the cost of the `T` to `U` converion.