### PR TITLE
Continue work on IR-based codegen

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -98,6 +98,9 @@ extern "C"
 
         /* Split apart types that contain a mix of resource and non-resource data */
         SLANG_COMPILE_FLAG_SPLIT_MIXED_TYPES    = 1 << 1,
+
+        /* Use new IR-based code generation path (unstable pre-release feature)*/
+        SLANG_COMPILE_FLAG_USE_IR               = 1 << 2,
     };
 
     /*!

--- a/source/slang/intrinsic-defs.h
+++ b/source/slang/intrinsic-defs.h
@@ -68,6 +68,10 @@ INTRINSIC(InnerProduct_Vector_Matrix)
 INTRINSIC(InnerProduct_Matrix_Vector)
 INTRINSIC(InnerProduct_Matrix_Matrix)
 
+// Texture sampling operation of the form `t.Sample(s,u)`
+INTRINSIC(sample_t_s_u)
+
+
 
 
 

--- a/source/slang/ir-inst-defs.h
+++ b/source/slang/ir-inst-defs.h
@@ -16,11 +16,17 @@ INST(Int32Type,   type.i32,       0, 0)
 INST(UInt32Type,  type.u32,       0, 0)
 INST(StructType,  type.struct,    0, PARENT)
 INST(FuncType,    func_type,      0, 0)
+INST(PtrType,       ptr_type,       1, 0)
+INST(TextureType,   texture_type,   2, 0)
+INST(SamplerType,   sampler_type,   1, 0)
+INST(ConstantBufferType,    constant_buffer_type,   1, 0)
+INST(TextureBufferType,     texture_buffer_type,   1, 0)
 
 INST(IntLit,      integer_constant,   0, 0)
 INST(FloatLit,    float_constant,     0, 0)
 
-INST(Construct,   construct,         0, 0)
+INST(Construct,   construct,        0, 0)
+INST(Call,          call,             1, 0)
 
 INST(Module,      module, 0, PARENT)
 INST(Func,        func,   0, PARENT)
@@ -28,8 +34,14 @@ INST(Block,       block,  0, PARENT)
 
 INST(Param,         param,  0, 0)
 INST(StructField,   field,  0, 0)
+INST(Var,           var,    0, 0)
 
-INST(FieldExtract,    get_field,      2, 0)
+INST(Load,          load,   1, 0)
+INST(Store,         store,  2, 0)
+
+INST(FieldExtract,    get_field,        2, 0)
+INST(FieldAddress,    get_field_addr,   2, 0)
+
 INST(ReturnVal,       return_val,     1, 0)
 INST(ReturnVoid, return_void, 1, 0)
 

--- a/source/slang/modifier-defs.h
+++ b/source/slang/modifier-defs.h
@@ -209,6 +209,20 @@ SYNTAX_CLASS(MagicTypeModifier, Modifier)
     FIELD(uint32_t, tag)
 END_SYNTAX_CLASS()
 
+// A modifier applied to declarations of builtin types to indicate how they
+// should be lowered to the IR.
+//
+// TODO: This should really subsume `BuiltinTypeModifier` and
+// `MagicTypeModifier` so that we don't have to apply all of them.
+SYNTAX_CLASS(IntrinsicTypeModifier, Modifier)
+    // The IR opcode to use when constructing a type
+    FIELD(uint32_t, irOp)
+
+    // Additional literal opreands to provide when creating instances.
+    // (e.g., for a texture type this passes in shape/mutability info)
+    FIELD(List<uint32_t>, irOperands)
+END_SYNTAX_CLASS()
+
 // Modifiers that affect the storage layout for matrices
 SIMPLE_SYNTAX_CLASS(MatrixLayoutModifier, Modifier)
 

--- a/source/slang/options.cpp
+++ b/source/slang/options.cpp
@@ -258,6 +258,10 @@ struct OptionsParser
                 {
                     flags |= SLANG_COMPILE_FLAG_SPLIT_MIXED_TYPES;
                 }
+                else if(argStr == "-use-ir" )
+                {
+                    flags |= SLANG_COMPILE_FLAG_USE_IR;
+                }
                 else if (argStr == "-backend" || argStr == "-target")
                 {
                     String name = tryReadCommandLineArgument(arg, &argCursor, argEnd);

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -3916,6 +3916,20 @@ namespace Slang
         return modifier;
     }
 
+    static RefPtr<RefObject> parseIntrinsicTypeModifier(Parser* parser, void* /*userData*/)
+    {
+        RefPtr<IntrinsicTypeModifier> modifier = new IntrinsicTypeModifier();
+        parser->ReadToken(TokenType::LParent);
+        modifier->irOp = uint32_t(StringToInt(parser->ReadToken(TokenType::IntegerLiteral).Content));
+        while( AdvanceIf(parser, TokenType::Comma) )
+        {
+            auto operand = uint32_t(StringToInt(parser->ReadToken(TokenType::IntegerLiteral).Content));
+            modifier->irOperands.Add(operand);
+        }
+        parser->ReadToken(TokenType::RParent);
+
+        return modifier;
+    }
     static RefPtr<RefObject> parseImplicitConversionModifier(Parser* parser, void* /*userData*/)
     {
         RefPtr<ImplicitConversionModifier> modifier = new ImplicitConversionModifier();
@@ -4020,6 +4034,7 @@ namespace Slang
 
         MODIFIER(__builtin_type,    parseBuiltinTypeModifier);
         MODIFIER(__magic_type,      parseMagicTypeModifier);
+        MODIFIER(__intrinsic_type,    parseIntrinsicTypeModifier);
         MODIFIER(__implicit_conversion,     parseImplicitConversionModifier);
 
 #undef MODIFIER

--- a/tests/bindings/binding0.hlsl
+++ b/tests/bindings/binding0.hlsl
@@ -1,4 +1,4 @@
-//TEST:COMPARE_HLSL: -target dxbc-assembly -profile ps_4_0 -entry main
+//TEST:COMPARE_HLSL: -use-ir -target dxbc-assembly -profile ps_4_0 -entry main
 
 // Let's first confirm that Spire can reproduce what the
 // HLSL compiler would already do in the simple case (when


### PR DESCRIPTION
This gets us far enough that we can convert a single test case to use the IR, under the new `-use-ir` flag.
Getting this merged into mainline will at least ensure that we keep the IR path working in a minimal fashion, even when we have to add functionality the existing AST-based path

There is definitely some clutter here from keeping both IR-based and AST-based translation around, but I don't want to have a long-lived branch for the IR that gets further and further away from the `master` branch that is actually getting used and tested.

Summary of changes:

- Add pointer types and basic `load` operation to be able to handle variable declarations

- Add basic `call` instruction type

- Add simple address math for field reference in l-value

- Always add IR for referenced decls to global scope

- Add notion of "intrinsic" type modifier, which maps a type declaration directly to an IR opcode (plus optional literal operands to handle things like texture/sampler flavor)

- Improve printing of IR instructions, types, operands

- Add constant-buffer type to IR

- Allow any instruction to be detected as "should be folded into use sites" and use this to tag things of constant-buffer type

- Also add logic for implicit base on member expressions, to handle references to `cbuffer` members

- Add connection back to original decl to IR variables (including global shader parameters...)

- Use reflection name instead of true name when emitting HLSL from IR (so that we can match HLSL output)

- Make IR include decorations for type layout

- Re-use existing emit logic for HLSL semantics to output `register` semantics for IR-based code

- Make IR-based codegen be an option we can enable from the command line
  - It still isn't on by default (it can barely manage a trivial shader), but it seems better to enable it always instead of putting it under an `#ifdef`

- Fix up how we check for intrinsic operations during AST-based cross compilation so that adding new intrinsic ops for the IR won't break codegen.