### PR TITLE
Get IR working for `AdaptiveTessellationCS40/Render` test

### DIFF
--- a/source/slang/type-layout.h
+++ b/source/slang/type-layout.h
@@ -313,6 +313,22 @@ public:
     size_t              uniformStride;
 };
 
+// When storing the layout for a matrix-type
+// value, we need to know whether it has been
+// laid ot with row-major or column-major
+// storage.
+//
+enum MatrixLayoutMode
+{
+    kMatrixLayoutMode_RowMajor,
+    kMatrixLayoutMode_ColumnMajor,
+};
+class MatrixTypeLayout : public TypeLayout
+{
+public:
+    MatrixLayoutMode    mode;
+};
+
 // Specific case of type layout for a struct
 class StructTypeLayout : public TypeLayout
 {
@@ -515,6 +531,8 @@ struct LayoutRulesImpl
     //
 
     LayoutRulesFamilyImpl* getLayoutRulesFamily() { return family; }
+
+    MatrixLayoutMode getDefaultMatrixLayoutMode();
 };
 
 struct LayoutRulesFamilyImpl
@@ -526,6 +544,7 @@ struct LayoutRulesFamilyImpl
     virtual LayoutRulesImpl* getVaryingOutputRules()        = 0;
     virtual LayoutRulesImpl* getSpecializationConstantRules()   = 0;
     virtual LayoutRulesImpl* getShaderStorageBufferRules()      = 0;
+    virtual MatrixLayoutMode getDefaultMatrixLayoutMode() = 0;
 };
 
 LayoutRulesImpl* GetLayoutRulesImpl(LayoutRule rule);
@@ -541,18 +560,27 @@ RefPtr<TypeLayout> CreateTypeLayout(Type* type, LayoutRulesImpl* rules, SimpleLa
 
 //
 
+struct TypeLayoutContext;
+
 // Create a type layout for a parameter block type.
 RefPtr<ParameterBlockTypeLayout>
 createParameterBlockTypeLayout(
-    RefPtr<ParameterBlockType>  parameterBlockType,
-    LayoutRulesImpl*            rules);
+    TypeLayoutContext*          context,
+    RefPtr<ParameterBlockType>  parameterBlockType);
 
 RefPtr<ParameterBlockTypeLayout>
 createParameterBlockTypeLayout(
+    TypeLayoutContext*          context,
     RefPtr<ParameterBlockType>  parameterBlockType,
-    LayoutRulesImpl*            parameterBlockRules,
-    RefPtr<Type>      elementType,
+    RefPtr<Type>                elementType,
     LayoutRulesImpl*            elementTypeRules);
+
+RefPtr<ParameterBlockTypeLayout>
+createParameterBlockTypeLayout(
+    TypeLayoutContext*          context,
+    RefPtr<ParameterBlockType>  parameterBlockType,
+    SimpleLayoutInfo            parameterBlockInfo,
+    RefPtr<TypeLayout>          elementTypeLayout);
 
 RefPtr<ParameterBlockTypeLayout>
 createParameterBlockTypeLayout(

--- a/tests/hlsl/dxsdk/AdaptiveTessellationCS40/Render.hlsl
+++ b/tests/hlsl/dxsdk/AdaptiveTessellationCS40/Render.hlsl
@@ -1,4 +1,4 @@
-//TEST(smoke):COMPARE_HLSL: -profile vs_4_0 -entry RenderBaseVS -profile ps_4_0 -entry RenderPS -target dxbc-assembly
+//TEST(smoke):COMPARE_HLSL: -use-ir -profile vs_4_0 -entry RenderBaseVS -profile ps_4_0 -entry RenderPS -target dxbc-assembly
 //--------------------------------------------------------------------------------------
 // File: Render.hlsl
 //


### PR DESCRIPTION
I had expected this to be the first case where control-flow instructions were needed, but it turns out that we aren't testing that entry point right now.

The real work/fix here ended up being handling of the `row_major` layout qualifier on a matrix inside a `cbuffer`. The existing AST-based code was passing it through easily (although I don't believe it was handling the layout rules right).
Getting it working in the IR involved beefing up the type-layout behavior so that it can handle explicit layout qualifiers (at least for matrix layout) which should also improve the layout computation for non-square matrices with nonstandard layout in the AST-based path.

There are still some annoying things left to do:

- The `row_major` and `column_major` layout qualifiers in HLSL/GLSL mean different things (well, they mean the reverse of one another) so I need to validate that the GLSL case is working remotely correctly.

- The layout logic isn't handling other explicit-layout cases as supported by GLSL (but of course GLSL is a far lower priority than HLSL/Slang)

- There is currently no way to pass in an explicit matrix layout flag to Slang to control the default behavior.
  - Any client who was using Slang for HLSL pass-through and then applying a non-default flag on their HLSL->* compilation will get nasty unexpected behavior when the IR goes live - and they are already dealing with nasty behavior around non-square matrices not matching layout between Slang and the downstream.

- The logic that gleans layout modes from a variable declaration is currently only being applied for fields of structure types (which applies to `cbuffer` declarations as well), and not to global-scope uniform variables.

- We need test cases for all of this.