### PR TITLE
IR: handle control flow constructs

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -76,6 +76,8 @@ extern "C"
         SLANG_DXBC,
         SLANG_DXBC_ASM,
         SLANG_REFLECTION_JSON,
+        SLANG_IR,
+        SLANG_IR_ASM,
     };
 
     typedef int SlangPassThrough;

--- a/source/core/slang-string.cpp
+++ b/source/core/slang-string.cpp
@@ -266,7 +266,7 @@ namespace Slang
         append(slice.begin(), slice.end());
     }
 
-    void String::append(int value, int radix)
+    void String::append(int32_t value, int radix)
     {
         enum { kCount = 33 };
         char* data = prepareForAppend(kCount);
@@ -275,7 +275,7 @@ namespace Slang
         buffer->length += count;
     }
 
-    void String::append(unsigned int value, int radix)
+    void String::append(uint32_t value, int radix)
     {
         enum { kCount = 33 };
         char* data = prepareForAppend(kCount);
@@ -284,7 +284,7 @@ namespace Slang
         buffer->length += count;
     }
 
-    void String::append(long long value, int radix)
+    void String::append(int64_t value, int radix)
     {
         enum { kCount = 65 };
         char* data = prepareForAppend(kCount);
@@ -293,6 +293,14 @@ namespace Slang
         buffer->length += count;
     }
 
+    void String::append(uint64_t value, int radix)
+    {
+        enum { kCount = 65 };
+        char* data = prepareForAppend(kCount);
+        auto count = IntToAscii(data, value, radix);
+        ReverseInternalAscii(data, count);
+        buffer->length += count;
+    }
 
     void String::append(float val, const char * format)
     {

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -257,9 +257,10 @@ namespace Slang
 			return getData() + getLength();
 		}
 
-        void append(int value, int radix = 10);
-        void append(unsigned int value, int radix = 10);
-        void append(long long value, int radix = 10);
+        void append(int32_t value, int radix = 10);
+        void append(uint32_t value, int radix = 10);
+        void append(int64_t value, int radix = 10);
+        void append(uint64_t value, int radix = 10);
         void append(float val, const char * format = "%g");
         void append(double val, const char * format = "%g");
 

--- a/source/slang/compiler.cpp
+++ b/source/slang/compiler.cpp
@@ -499,25 +499,14 @@ namespace Slang
     }
 #endif
 
-#if 0
-    String emitSPIRVAssembly(
-        ExtraContext&				context)
+    List<uint8_t> emitSlangIRForEntryPoint(
+        EntryPointRequest*  entryPoint)
     {
-        if(context.getTranslationUnitOptions().entryPoints.Count() == 0)
-        {
-            // TODO(tfoley): need to write diagnostics into this whole thing...
-            fprintf(stderr, "no entry point specified\n");
-            return "";
-        }
-
-        StringBuilder sb;
-        for (auto entryPoint : context.getTranslationUnitOptions().entryPoints)
-        {
-            sb << emitSPIRVAssemblyForEntryPoint(context, entryPoint);
-        }
-        return sb.ProduceString();
+        SLANG_UNIMPLEMENTED_X("Slang IR Binary Generation");
     }
-#endif
+
+    String emitSlangIRAssemblyForEntryPoint(
+        EntryPointRequest*  entryPoint);
 
     // Do emit logic for a single entry point
     CompileResult emitEntryPoint(
@@ -573,6 +562,22 @@ namespace Slang
         case CodeGenTarget::SPIRVAssembly:
             {
                 String code = emitSPIRVAssemblyForEntryPoint(entryPoint);
+                maybeDumpIntermediate(compileRequest, code.Buffer(), target);
+                result = CompileResult(code);
+            }
+            break;
+
+        case CodeGenTarget::SlangIR:
+            {
+                List<uint8_t> code = emitSlangIRForEntryPoint(entryPoint);
+                maybeDumpIntermediate(compileRequest, code.Buffer(), code.Count(), target);
+                result = CompileResult(code);
+            }
+            break;
+
+        case CodeGenTarget::SlangIRAssembly:
+            {
+                String code = emitSlangIRAssemblyForEntryPoint(entryPoint);
                 maybeDumpIntermediate(compileRequest, code.Buffer(), target);
                 result = CompileResult(code);
             }
@@ -957,6 +962,10 @@ namespace Slang
             dumpIntermediateText(compileRequest, data, size, ".dxbc.asm");
             break;
 
+        case CodeGenTarget::SlangIRAssembly:
+            dumpIntermediateText(compileRequest, data, size, ".slang-ir.asm");
+            break;
+
         case CodeGenTarget::SPIRV:
             dumpIntermediateBinary(compileRequest, data, size, ".spv");
             {
@@ -970,6 +979,15 @@ namespace Slang
             {
                 String dxbcAssembly = dissassembleDXBC(compileRequest, data, size);
                 dumpIntermediateText(compileRequest, dxbcAssembly.begin(), dxbcAssembly.Length(), ".dxbc.asm");
+            }
+            break;
+
+        case CodeGenTarget::SlangIR:
+            dumpIntermediateBinary(compileRequest, data, size, ".slang-ir");
+            {
+                // TODO: need to support dissassembly from Slang IR binary
+//                String slangIRAssembly = dissassembleSlangIR(compileRequest, data, size);
+//                dumpIntermediateText(compileRequest, slangIRAssembly.begin(), slangIRAssembly.Length(), ".slang-ir.asm");
             }
             break;
         }

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -47,6 +47,8 @@ namespace Slang
         DXBytecode          = SLANG_DXBC,
         DXBytecodeAssembly  = SLANG_DXBC_ASM,
         ReflectionJSON      = SLANG_REFLECTION_JSON,
+        SlangIR             = SLANG_IR,
+        SlangIRAssembly     = SLANG_IR_ASM,
     };
 
     enum class LineDirectiveMode : SlangLineDirectiveMode

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -4503,6 +4503,7 @@ emitDeclImpl(decl, nullptr);
             emit(", ");
             emitIROperand(context, inst->getArg(2));
             emit(")");
+            break;
 
         case kIROp_swizzle:
             {

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -4906,7 +4906,7 @@ emitDeclImpl(decl, nullptr);
             for (int ii = 0; ii < 3; ++ii)
             {
                 if (ii != 0) emit(", ");
-                emit(threadGroupSizeDecoration->sizeAlongAxis[ii]);
+                Emit(threadGroupSizeDecoration->sizeAlongAxis[ii]);
             }
             emit(")]\n");
         }

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -29,7 +29,13 @@ __magic_type(HLSLByteAddressBufferType) struct ByteAddressBuffer
     __intrinsic_op uint4 Load4(int location, out uint status);
 };
 
-__generic<T> __magic_type(HLSLStructuredBufferType) struct StructuredBuffer
+__generic<T>
+__magic_type(HLSLStructuredBufferType)
+__intrinsic_type(${{
+	// TODO: we really need a simple way to write an "expression splice"
+	sb << kIROp_structuredBufferType;
+}})
+struct StructuredBuffer
 {
     __intrinsic_op void GetDimensions(
         out uint numStructs,

--- a/source/slang/hlsl.meta.slang.cpp
+++ b/source/slang/hlsl.meta.slang.cpp
@@ -29,7 +29,14 @@ sb << "    __intrinsic_op uint4 Load4(int location);\n";
 sb << "    __intrinsic_op uint4 Load4(int location, out uint status);\n";
 sb << "};\n";
 sb << "\n";
-sb << "__generic<T> __magic_type(HLSLStructuredBufferType) struct StructuredBuffer\n";
+sb << "__generic<T>\n";
+sb << "__magic_type(HLSLStructuredBufferType)\n";
+sb << "__intrinsic_type(";
+
+	// TODO: we really need a simple way to write an "expression splice"
+	sb << kIROp_structuredBufferType;
+sb << ")\n";
+sb << "struct StructuredBuffer\n";
 sb << "{\n";
 sb << "    __intrinsic_op void GetDimensions(\n";
 sb << "        out uint numStructs,\n";

--- a/source/slang/ir-inst-defs.h
+++ b/source/slang/ir-inst-defs.h
@@ -13,24 +13,29 @@
 // Invalid operation: should not appear in valid code
 INST(Nop, nop, 0, 0)
 
-INST(TypeType,    type.type,      0, 0)
-INST(VoidType,    type.void,      0, 0)
-INST(BlockType,   type.block,     0, 0)
-INST(VectorType,  type.vector,    2, 0)
-INST(MatrixType,  matrixType,     3, 0)
-INST(BoolType,    type.bool,      0, 0)
-INST(Float32Type, type.f32,       0, 0)
-INST(Int32Type,   type.i32,       0, 0)
-INST(UInt32Type,  type.u32,       0, 0)
-INST(StructType,  type.struct,    0, PARENT)
-INST(FuncType, func_type, 0, 0)
-INST(PtrType, ptr_type, 1, 0)
-INST(TextureType, texture_type, 2, 0)
-INST(SamplerType, sampler_type, 1, 0)
-INST(ConstantBufferType, constant_buffer_type, 1, 0)
-INST(TextureBufferType, texture_buffer_type, 1, 0)
-INST(readWriteStructuredBufferType, readWriteStructuredBufferType, 1, 0)
+INST(TypeType, Type, 0, 0)
+INST(VoidType, Void, 0, 0)
+INST(BlockType, Block, 0, 0)
+INST(VectorType, Vec, 2, 0)
+INST(MatrixType, Mat, 3, 0)
+INST(arrayType, Array, 2, 0)
 
+INST(BoolType, Bool, 0, 0)
+INST(Float32Type, Float32, 0, 0)
+INST(Int32Type, Int32, 0, 0)
+INST(UInt32Type, UInt32, 0, 0)
+INST(StructType, Struct, 0, PARENT)
+INST(FuncType, Func, 0, 0)
+INST(PtrType, Ptr, 1, 0)
+INST(TextureType, Texture, 2, 0)
+INST(SamplerType, SamplerState, 1, 0)
+INST(ConstantBufferType, ConstantBuffer, 1, 0)
+INST(TextureBufferType, TextureBuffer, 1, 0)
+
+INST(structuredBufferType, StructuredBuffer, 1, 0)
+INST(readWriteStructuredBufferType, RWStructuredBuffer, 1, 0)
+
+INST(boolConst, boolConst, 0, 0)
 INST(IntLit, integer_constant, 0, 0)
 INST(FloatLit, float_constant, 0, 0)
 
@@ -57,9 +62,48 @@ INST(FieldAddress, get_field_addr, 2, 0)
 INST(getElement, getElement, 2, 0)
 INST(getElementPtr, getElementPtr, 2, 0)
 
+// A swizzle of a vector:
+//
+// %dst = swizzle %src %idx0 %idx1 ...
+//
+// where:
+// - `src` is a vector<T,N>
+// - `dst` is a vector<T,M>
+// - `idx0` through `idx[M-1]` are literal integers
+//
+INST(swizzle, swizzle, 1, 0)
+
+// Setting a vector via swizzle
+//
+// %dst = swizzle %base %src %idx0 %idx1 ...
+//
+// where:
+// - `base` is a vector<T,N>
+// - `dst` is a vector<T,N>
+// - `src` is a vector<T,M>
+// - `idx0` through `idx[M-1]` are literal integers
+//
+// The semantics of the op is:
+//
+//     dst = base;
+//     for(ii : 0 ... M-1 )
+//         dst[ii] = src[idx[ii]];
+//
+INST(swizzleSet, swizzleSet, 2, 0)
+
+
 INST(ReturnVal, return_val, 1, 0)
 INST(ReturnVoid, return_void, 1, 0)
 
+INST(unconditionalBranch, unconditionalBranch, 1, 0)
+INST(break, break, 1, 0)
+INST(continue, continue, 1, 0)
+INST(loop, loop, 3, 0)
+
+INST(conditionalBranch, conditionalBranch, 1, 0)
+INST(if, if, 3, 0)
+INST(ifElse, ifElse, 4, 0)
+INST(loopTest, loopTest, 3, 0)
 
 INST(Add, add, 2, 0)
 INST(Sub, sub, 2, 0)
@@ -138,6 +182,8 @@ INTRINSIC(InnerProduct_Matrix_Matrix)
 INST(Sample, sample, 3, 0)
 
 INST(SampleGrad, sampleGrad, 4, 0)
+
+INST(GroupMemoryBarrierWithGroupSync, GroupMemoryBarrierWithGroupSync, 0, 0)
 
 PSEUDO_INST(Pos)
 PSEUDO_INST(PreInc)

--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -1,0 +1,569 @@
+// ir-insts.h
+#ifndef SLANG_IR_INSTS_H_INCLUDED
+#define SLANG_IR_INSTS_H_INCLUDED
+
+// This file extends the core definitions in `ir.h`
+// with a wider variety of concrete instructions,
+// and a "builder" abstraction.
+//
+// TODO: the builder probably needs its own file.
+
+#include "compiler.h"
+#include "ir.h"
+
+namespace Slang {
+
+class Decl;
+
+// Associates an IR-level decoration with a source declaration
+// in the high-level AST, that can be used to extract
+// additional information that informs code emission.
+struct IRHighLevelDeclDecoration : IRDecoration
+{
+    enum { kDecorationOp = kIRDecorationOp_HighLevelDecl };
+
+    Decl* decl;
+};
+
+// Associates an IR-level decoration with a source layout
+struct IRLayoutDecoration : IRDecoration
+{
+    enum { kDecorationOp = kIRDecorationOp_Layout };
+
+    Layout* layout;
+};
+
+// Identifies a function as an entry point for some stage
+struct IREntryPointDecoration : IRDecoration
+{
+    enum { kDecorationOp = kIRDecorationOp_EntryPoint };
+
+    Profile profile;
+};
+
+// Associates a compute-shader entry point function
+// with a thread-group size.
+struct IRComputeThreadGroupSizeDecoration : IRDecoration
+{
+    enum { kDecorationOp = kIRDecorationOp_ComputeThreadGroupSize };
+
+    UInt sizeAlongAxis[3];
+};
+
+enum IRLoopControl
+{
+    kIRLoopControl_Unroll,
+};
+
+struct IRLoopControlDecoration : IRDecoration
+{
+    enum { kDecorationOp = kIRDecorationOp_LoopControl };
+
+    IRLoopControl mode;
+};
+
+// Types
+
+struct IRVectorType : IRType
+{
+    IRUse   elementType;
+    IRUse   elementCount;
+
+    IRType* getElementType() { return (IRType*) elementType.usedValue; }
+    IRInst* getElementCount() { return elementCount.usedValue; }
+};
+
+struct IRMatrixType : IRType
+{
+    IRUse   elementType;
+    IRUse   rowCount;
+    IRUse   columnCount;
+
+    IRType* getElementType() { return (IRType*) elementType.usedValue; }
+    IRInst* getRowCount() { return rowCount.usedValue; }
+    IRInst* getColumnCount() { return columnCount.usedValue; }
+};
+
+struct IRArrayType : IRType
+{
+    IRUse   elementType;
+    IRUse   elementCount;
+
+    IRType* getElementType() { return (IRType*) elementType.usedValue; }
+    IRInst* getElementCount() { return elementCount.usedValue; }
+};
+
+
+
+struct IRFuncType : IRType
+{
+    IRUse resultType;
+    // parameter tyeps are varargs...
+
+    IRType* getResultType() { return (IRType*) resultType.usedValue; }
+    UInt getParamCount()
+    {
+        return getArgCount() - 2;
+    }
+    IRType* getParamType(UInt index)
+    {
+        return (IRType*) getArg(2 + index);
+    }
+};
+
+// Address spaces for IR pointers
+enum IRAddressSpace : UInt
+{
+    // A default address space for things like local variables
+    kIRAddressSpace_Default,
+
+    // Address space for HLSL `groupshared` allocations
+    kIRAddressSpace_GroupShared,
+};
+
+struct IRPtrType : IRType
+{
+    IRUse valueType;
+    IRUse addressSpace;
+
+    IRType* getValueType() { return (IRType*) valueType.usedValue; }
+
+    IRAddressSpace getAddressSpace()
+    {
+        return IRAddressSpace(
+            ((IRConstant*)addressSpace.usedValue)->u.intVal);
+    }
+};
+
+struct IRTextureType : IRType
+{
+    IRUse flavor;
+    IRUse elementType;
+
+    IRIntegerValue getFlavor() { return ((IRConstant*) flavor.usedValue)->u.intVal; }
+    IRType* getElementType() { return (IRType*) elementType.usedValue; }
+};
+
+struct IRBufferType : IRType
+{
+    IRUse elementType;
+    IRType* getElementType() { return (IRType*) elementType.usedValue; }
+};
+
+
+struct IRUniformBufferType : IRType
+{
+    IRUse elementType;
+    IRType* getElementType() { return (IRType*) elementType.usedValue; }
+};
+
+struct IRConstantBufferType : IRUniformBufferType {};
+struct IRTextureBufferType : IRUniformBufferType {};
+
+struct IRCall : IRInst
+{
+    IRUse func;
+};
+
+struct IRLoad : IRInst
+{
+    IRUse ptr;
+};
+
+struct IRStore : IRInst
+{
+    IRUse ptr;
+    IRUse val;
+};
+
+struct IRStructField;
+struct IRFieldExtract : IRInst
+{
+    IRUse   base;
+    IRUse   field;
+
+    IRInst* getBase() { return base.usedValue; }
+    IRStructField* getField() { return (IRStructField*) field.usedValue; }
+};
+
+struct IRFieldAddress : IRInst
+{
+    IRUse   base;
+    IRUse   field;
+
+    IRInst* getBase() { return base.usedValue; }
+    IRStructField* getField() { return (IRStructField*) field.usedValue; }
+};
+
+// Terminators
+
+struct IRReturn : IRTerminatorInst
+{};
+
+struct IRReturnVal : IRReturn
+{
+    IRUse val;
+
+    IRInst* getVal() { return val.usedValue; }
+};
+
+struct IRReturnVoid : IRReturn
+{};
+
+struct IRBlock;
+
+struct IRUnconditionalBranch : IRTerminatorInst
+{
+    IRUse block;
+
+    IRBlock* getTargetBlock() { return (IRBlock*)block.usedValue; }
+};
+
+// Special cases of unconditional branch, to handle
+// structured control flow:
+struct IRBreak : IRUnconditionalBranch {};
+struct IRContinue : IRUnconditionalBranch {};
+
+// The start of a loop is a special control-flow
+// instruction, that records relevant information
+// about the loop structure:
+struct IRLoop : IRUnconditionalBranch
+{
+    // The next block after the loop, which
+    // is where we expect control flow to
+    // re-converge, and also where a
+    // `break` will target.
+    IRUse breakBlock;
+
+    // The block where control flow will go
+    // on a `continue`.
+    IRUse continueBlock;
+
+    IRBlock* getBreakBlock() { return (IRBlock*)breakBlock.usedValue; }
+    IRBlock* getContinueBlock() { return (IRBlock*)continueBlock.usedValue; }
+};
+
+struct IRConditionalBranch : IRTerminatorInst
+{
+    IRUse condition;
+    IRUse trueBlock;
+    IRUse falseBlock;
+
+    IRInst* getCondition() { return condition.usedValue; }
+    IRBlock* getTrueBlock() { return (IRBlock*)trueBlock.usedValue; }
+    IRBlock* getFalseBlock() { return (IRBlock*)falseBlock.usedValue; }
+};
+
+// A conditional branch that represent the test inside a loop
+struct IRLoopTest : IRConditionalBranch
+{
+};
+
+// A conditional branch that represents a one-sided `if`:
+//
+//     if( <condition> ) { <trueBlock> }
+//     <falseBlock>
+struct IRIf : IRConditionalBranch
+{
+    IRBlock* getAfterBlock() { return getFalseBlock(); }
+};
+
+// A conditional branch that represents a two-sided `if`:
+//
+//     if( <condition> ) { <trueBlock> }
+//     else              { <falseBlock> }
+//     <afterBlock>
+//
+struct IRIfElse : IRConditionalBranch
+{
+    IRUse afterBlock;
+
+    IRBlock* getAfterBlock() { return (IRBlock*)afterBlock.usedValue; }
+};
+
+struct IRSwizzle : IRReturn
+{
+    IRUse base;
+
+    IRInst* getBase() { return base.usedValue; }
+    UInt getElementCount()
+    {
+        return getArgCount() - 2;
+    }
+    IRInst* getElementIndex(UInt index)
+    {
+        return getArg(index + 2);
+    }
+};
+
+struct IRSwizzleSet : IRReturn
+{
+    IRUse base;
+    IRUse source;
+
+    IRInst* getBase() { return base.usedValue; }
+    IRInst* getSource() { return source.usedValue; }
+    UInt getElementCount()
+    {
+        return getArgCount() - 3;
+    }
+    IRInst* getElementIndex(UInt index)
+    {
+        return getArg(index + 3);
+    }
+};
+
+// "Parent" Instructions (Declarations)
+
+struct IRStructField : IRInst
+{
+    IRType* getFieldType() { return (IRType*) type.usedValue; }
+
+    IRStructField* getNextField() { return (IRStructField*) nextInst; }
+};
+
+struct IRStructDecl : IRParentInst
+{
+    IRStructField* getFirstField() { return (IRStructField*) firstChild; }
+    IRStructField* getLastField() { return (IRStructField*) lastChild; }
+};
+
+
+struct IRVar : IRInst
+{
+    IRPtrType* getType()
+    {
+        return (IRPtrType*)type.usedValue;
+    }
+};
+
+
+// Description of an instruction to be used for global value numbering
+struct IRInstKey
+{
+    IRInst* inst;
+
+    int GetHashCode();
+};
+
+bool operator==(IRInstKey const& left, IRInstKey const& right);
+
+struct IRConstantKey
+{
+    IRConstant* inst;
+
+    int GetHashCode();
+};
+bool operator==(IRConstantKey const& left, IRConstantKey const& right);
+
+struct SharedIRBuilder
+{
+    // The module that will own all of the IR
+    IRModule*       module;
+
+    Dictionary<IRInstKey,       IRInst*>    globalValueNumberingMap;
+    Dictionary<IRConstantKey,   IRConstant*>    constantMap;
+};
+
+struct IRBuilder
+{
+    // Shared state for all IR builders working on the same module
+    SharedIRBuilder*    shared;
+
+    IRModule* getModule() { return shared->module; }
+
+    // The parent instruction to add children to.
+    IRParentInst*   parentInst;
+
+    void addInst(IRParentInst* parent, IRInst* inst);
+    void addInst(IRInst* inst);
+
+    IRType* getBaseType(BaseType flavor);
+    IRType* getBoolType();
+    IRType* getVectorType(IRType* elementType, IRValue* elementCount);
+    IRType* getMatrixType(
+        IRType* elementType,
+        IRValue* rowCount,
+        IRValue* columnCount);
+    IRType* getArrayType(IRType* elementType, IRValue* elementCount);
+    IRType* getArrayType(IRType* elementType);
+
+    IRType* getTypeType();
+    IRType* getVoidType();
+    IRType* getBlockType();
+
+    IRType* getIntrinsicType(
+        IROp op,
+        UInt argCount,
+        IRValue* const* args);
+
+    IRStructDecl* createStructType();
+    IRStructField* createStructField(IRType* fieldType);
+
+    IRType* getFuncType(
+        UInt            paramCount,
+        IRType* const*  paramTypes,
+        IRType*         resultType);
+
+    IRType* getPtrType(
+        IRType*         valueType,
+        IRAddressSpace  addressSpace);
+
+    IRType* getPtrType(
+        IRType* valueType);
+
+    IRValue* getBoolValue(bool value);
+    IRValue* getIntValue(IRType* type, IRIntegerValue value);
+    IRValue* getFloatValue(IRType* type, IRFloatingPointValue value);
+
+    IRInst* emitCallInst(
+        IRType*         type,
+        IRValue*        func,
+        UInt            argCount,
+        IRValue* const* args);
+
+    IRInst* emitIntrinsicInst(
+        IRType*         type,
+        IROp            op,
+        UInt            argCount,
+        IRValue* const* args);
+
+    IRInst* emitConstructorInst(
+        IRType*         type,
+        UInt            argCount,
+        IRValue* const* args);
+
+    IRModule* createModule();
+
+    IRFunc* createFunc();
+
+    IRBlock* createBlock();
+    IRBlock* emitBlock();
+
+    IRParam* emitParam(
+        IRType* type);
+
+    IRVar* emitVar(
+        IRType*         type,
+        IRAddressSpace  addressSpace);
+
+    IRVar* emitVar(
+        IRType* type);
+
+    IRInst* emitLoad(
+        IRValue*    ptr);
+
+    IRInst* emitStore(
+        IRValue*    dstPtr,
+        IRValue*    srcVal);
+
+    IRInst* emitFieldExtract(
+        IRType*         type,
+        IRValue*        base,
+        IRStructField*  field);
+
+    IRInst* emitFieldAddress(
+        IRType*         type,
+        IRValue*        basePtr,
+        IRStructField*  field);
+
+    IRInst* emitElementExtract(
+        IRType*     type,
+        IRValue*    base,
+        IRValue*    index);
+
+    IRInst* emitElementAddress(
+        IRType*     type,
+        IRValue*    basePtr,
+        IRValue*    index);
+
+    IRInst* emitSwizzle(
+        IRType*         type,
+        IRValue*        base,
+        UInt            elementCount,
+        IRValue* const* elementIndices);
+
+    IRInst* emitSwizzle(
+        IRType*         type,
+        IRValue*        base,
+        UInt            elementCount,
+        UInt const*     elementIndices);
+
+    IRInst* emitSwizzleSet(
+        IRType*         type,
+        IRValue*        base,
+        IRValue*        source,
+        UInt            elementCount,
+        IRValue* const* elementIndices);
+
+    IRInst* emitSwizzleSet(
+        IRType*         type,
+        IRValue*        base,
+        IRValue*        source,
+        UInt            elementCount,
+        UInt const*     elementIndices);
+
+    IRInst* emitReturn(
+        IRValue*    val);
+
+    IRInst* emitReturn();
+
+    IRInst* emitBranch(
+        IRBlock*    block);
+
+    IRInst* emitBreak(
+        IRBlock*    target);
+
+    IRInst* emitContinue(
+        IRBlock*    target);
+
+    IRInst* emitLoop(
+        IRBlock*    target,
+        IRBlock*    breakBlock,
+        IRBlock*    continueBlock);
+
+    IRInst* emitBranch(
+        IRValue*    val,
+        IRBlock*    trueBlock,
+        IRBlock*    falseBlock);
+
+    IRInst* emitIf(
+        IRValue*    val,
+        IRBlock*    trueBlock,
+        IRBlock*    afterBlock);
+
+    IRInst* emitIfElse(
+        IRValue*    val,
+        IRBlock*    trueBlock,
+        IRBlock*    falseBlock,
+        IRBlock*    afterBlock);
+
+    IRInst* emitLoopTest(
+        IRValue*    val,
+        IRBlock*    bodyBlock,
+        IRBlock*    breakBlock);
+
+    IRDecoration* addDecorationImpl(
+        IRInst*         inst,
+        UInt            decorationSize,
+        IRDecorationOp  op);
+
+    template<typename T>
+    T* addDecoration(IRInst* inst, IRDecorationOp op)
+    {
+        return (T*) addDecorationImpl(inst, sizeof(T), op);
+    }
+
+    template<typename T>
+    T* addDecoration(IRInst* inst)
+    {
+        return (T*) addDecorationImpl(inst, sizeof(T), IRDecorationOp(T::kDecorationOp));
+    }
+
+    IRHighLevelDeclDecoration* addHighLevelDeclDecoration(IRInst* inst, Decl* decl);
+    IRLayoutDecoration* addLayoutDecoration(IRInst* inst, Layout* layout);
+};
+
+}
+
+#endif

--- a/source/slang/options.cpp
+++ b/source/slang/options.cpp
@@ -300,6 +300,8 @@ struct OptionsParser
 
                     CASE(spirv, SPIRV);
                     CASE(spirv-assembly, SPIRV_ASM);
+                    CASE(slang-ir, IR);
+                    CASE(slang-ir-assembly, IR_ASM);
                     CASE(none, TARGET_NONE);
 
                 #undef CASE

--- a/source/slang/profile-defs.h
+++ b/source/slang/profile-defs.h
@@ -47,6 +47,8 @@ LANGUAGE(GLSL_ES,			glsl_es)
 LANGUAGE(GLSL_VK,			glsl_vk)
 LANGUAGE(SPIRV,				spirv)
 LANGUAGE(SPIRV_GL,			spirv_gl)
+LANGUAGE(SlangIR,           slang_ir)
+LANGUAGE(SlangIRAssembly,   slang_ir_assembly)
 
 LANGUAGE_ALIAS(GLSL,		glsl_gl)
 LANGUAGE_ALIAS(SPIRV,		spirv_vk)

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -172,6 +172,7 @@
     <ClInclude Include="emit.h" />
     <ClInclude Include="expr-defs.h" />
     <ClInclude Include="ir-inst-defs.h" />
+    <ClInclude Include="ir-insts.h" />
     <ClInclude Include="ir.h" />
     <ClInclude Include="lexer.h" />
     <ClInclude Include="lookup.h" />

--- a/source/slang/slang.vcxproj.filters
+++ b/source/slang/slang.vcxproj.filters
@@ -39,6 +39,7 @@
     <ClInclude Include="ir.h" />
     <ClInclude Include="lower-to-ir.h" />
     <ClInclude Include="ir-inst-defs.h" />
+    <ClInclude Include="ir-insts.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="check.cpp" />
@@ -65,8 +66,8 @@
     <ClCompile Include="lower-to-ir.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="core.meta.slang" />
-    <None Include="glsl.meta.slang" />
-    <None Include="hlsl.meta.slang" />
+    <CustomBuild Include="core.meta.slang" />
+    <CustomBuild Include="glsl.meta.slang" />
+    <CustomBuild Include="hlsl.meta.slang" />
   </ItemGroup>
 </Project>

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -621,6 +621,8 @@ LayoutRulesFamilyImpl* GetLayoutRulesFamilyImpl(CodeGenTarget target)
     case CodeGenTarget::HLSL:
     case CodeGenTarget::DXBytecode:
     case CodeGenTarget::DXBytecodeAssembly:
+    case CodeGenTarget::SlangIR:
+    case CodeGenTarget::SlangIRAssembly:
         return &kHLSLLayoutRulesFamilyImpl;
 
     case CodeGenTarget::GLSL:

--- a/tests/ir/loop.slang
+++ b/tests/ir/loop.slang
@@ -1,0 +1,33 @@
+//TEST:SIMPLE:-target slang-ir-assembly -profile cs_4_0 -entry main
+
+#define GROUP_THREAD_COUNT 64
+
+StructuredBuffer<float4> input;
+RWStructuredBuffer<float4> output;
+
+groupshared float4 s[GROUP_THREAD_COUNT];
+
+[numthreads(GROUP_THREAD_COUNT, 1, 1)]
+void main(
+    uint dispatchThreadID   : SV_DispatchThreadIndex,
+    uint groupThreadID      : SV_GroupThreadIndex,
+    uint groupID            : SV_GroupIndex )
+{
+    // the actual algorithm being done here is bogus
+
+    // load shared memory
+    s[groupThreadID] = input[dispatchThreadID];
+
+    // do some sum passes
+    for(uint stride = 1; stride < GROUP_THREAD_COUNT; stride <<= 1)
+    {
+        GroupMemoryBarrierWithGroupSync();
+
+        s[groupThreadID] += s[groupThreadID - stride];
+    }
+
+    GroupMemoryBarrierWithGroupSync();
+
+    output[dispatchThreadID] = s[0];
+}
+

--- a/tests/ir/loop.slang.expected
+++ b/tests/ir/loop.slang.expected
@@ -1,0 +1,67 @@
+result code = 0
+standard error = {
+}
+standard output = {
+let  %41	: Ptr<Array<Vec<Float32,4>,64>,1>	= var()
+let  %68	: Ptr<StructuredBuffer<Vec<Float32,4>>,0>	= var()
+let  %243	: Ptr<RWStructuredBuffer<Vec<Float32,4>>,0>	= var()
+
+func %1(
+	param %7	: UInt32,
+	param %10	: UInt32,
+	param %13	: UInt32)
+{
+block %4:
+	let  %47	: Ptr<Vec<Float32,4>,0>	= getElementPtr(%41, %10)
+	let  %69	: StructuredBuffer<Vec<Float32,4>>	= load(%68)
+	let  %72	: Vec<Float32,4>	= bufferLoad(%69, %7)
+	store(%47, %72)
+	let  %81	: Ptr<UInt32,0>	= var()
+	let  %89	: UInt32	= construct(1)
+	store(%81, %89)
+	loop(%94, %100, %103)
+
+block %94:
+	let  %110	: UInt32	= load(%81)
+	let  %119	: UInt32	= construct(64)
+	let  %120	: Bool	= cmpLT(%110, %119)
+	loopTest(%120, %97, %100)
+
+block %97:
+	GroupMemoryBarrierWithGroupSync()
+	let  %147	: Ptr<Vec<Float32,4>,0>	= getElementPtr(%41, %10)
+	let  %152	: Ptr<Vec<Float32,4>,0>	= var()
+	let  %153	: Vec<Float32,4>	= load(%147)
+	store(%152, %153)
+	let  %174	: UInt32	= load(%81)
+	let  %175	: UInt32	= sub(%10, %174)
+	let  %180	: Ptr<Vec<Float32,4>,0>	= getElementPtr(%41, %175)
+	let  %181	: Vec<Float32,4>	= load(%180)
+	let  %182	: Vec<Float32,4>	= load(%152)
+	let  %183	: Vec<Float32,4>	= add(%182, %181)
+	store(%152, %183)
+	let  %186	: Vec<Float32,4>	= load(%152)
+	store(%147, %186)
+	unconditionalBranch(%103)
+
+block %103:
+	let  %199	: Ptr<UInt32,0>	= var()
+	let  %200	: UInt32	= load(%81)
+	store(%199, %200)
+	let  %211	: UInt32	= construct(1)
+	let  %212	: UInt32	= load(%199)
+	let  %213	: UInt32	= shl(%212, %211)
+	store(%199, %213)
+	let  %216	: UInt32	= load(%199)
+	store(%81, %216)
+	unconditionalBranch(%94)
+
+block %100:
+	GroupMemoryBarrierWithGroupSync()
+	let  %244	: RWStructuredBuffer<Vec<Float32,4>>	= load(%243)
+	let  %260	: Ptr<Vec<Float32,4>,0>	= getElementPtr(%41, 0)
+	let  %261	: Vec<Float32,4>	= load(%260)
+	bufferStore(%244, %7, %261)
+	return_void()
+}
+}


### PR DESCRIPTION
This change includes a bunch of fixes and additions to the IR path:

- `slang-ir-assembly` is now a valid output target (so we can use it for testing)
  - This uses what used to be the IR "dumping" logic, revamped to support much prettier output.
  - A future change will need to add back support for less prettified output to use when actually debugging

- IR generation for `for` loops and `if` statements is supported

- HLSL output from the above control flow constructs is implemented

- Revamped the handling of l-values, and in particular work on compound ops like `+=`

- Add basic IR support for `groupshared` variables

- Add basic IR support for storing compute thread-group size

- Output semantics on entry point parameters
  - This uses the AST structures to find semantics, so its still needs work

- Pass through loop unroll flags
  - This is required to match `fxc` output, at least until we implement
    unrolling ourselves.