### PR TITLE
Use WARP for D3D rendering tests.

### DIFF
--- a/tests/render/render0.hlsl
+++ b/tests/render/render0.hlsl
@@ -1,4 +1,4 @@
-//TEST(smoke,render):COMPARE_HLSL_RENDER:
+//TEST(smoke):COMPARE_HLSL_RENDER:
 // Starting with a basic test for the ability to render stuff...
 
 cbuffer Uniforms


### PR DESCRIPTION
This should in principle allow for the D3D-only tests to run on AppVeyor so that we can validate running things for CI purposes (and is probably a whole lot easier than trying to plug the VM up to the rendering tests).

I've switched up one of the tests so that it should run even on AppVeyor, so fingers crossed that it will actually run.