### PR TITLE
More work on IR-based lowering and cross-compilation

### DIFF
--- a/examples/hello/hello.vcxproj
+++ b/examples/hello/hello.vcxproj
@@ -96,6 +96,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -109,6 +110,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -124,6 +126,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -141,6 +144,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/slang.h
+++ b/slang.h
@@ -1016,6 +1016,7 @@ namespace slang
 #include "source/slang/emit.cpp"
 #include "source/slang/ir.cpp"
 #include "source/slang/lexer.cpp"
+#include "source/slang/mangle.cpp"
 #include "source/slang/name.cpp"
 #include "source/slang/options.cpp"
 #include "source/slang/parameter-binding.cpp"

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -94,7 +94,7 @@ sb << "    typedef T Element;\n";
 
 // Declare initializer taking a single scalar of the elemnt type
 sb << "    __implicit_conversion(" << kConversionCost_ScalarToVector << ")\n";
-sb << "    __intrinsic_op(" << kIROp_constructorVectorFromScalar << ")\n";
+sb << "    __intrinsic_op(" << kIROp_constructVectorFromScalar << ")\n";
 sb << "    __init(T value);\n";
 
 sb << "};\n";

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -94,6 +94,7 @@ sb << "    typedef T Element;\n";
 
 // Declare initializer taking a single scalar of the elemnt type
 sb << "    __implicit_conversion(" << kConversionCost_ScalarToVector << ")\n";
+sb << "    __intrinsic_op(" << kIROp_constructorVectorFromScalar << ")\n";
 sb << "    __init(T value);\n";
 
 sb << "};\n";
@@ -424,7 +425,12 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
 
                     sb << ")\")\n";
-                    sb << "__intrinsic_op\n";
+
+
+					// TIM: Making `GetDimensions` *not* be marked as
+					// an intrinsic, just so we can see how defining
+					// things as `extern` functions would work.
+//                    sb << "__intrinsic_op\n";
 
                 }
 

--- a/source/slang/core.meta.slang.cpp
+++ b/source/slang/core.meta.slang.cpp
@@ -95,6 +95,7 @@ sb << "    typedef T Element;\n";
 
 // Declare initializer taking a single scalar of the elemnt type
 sb << "    __implicit_conversion(" << kConversionCost_ScalarToVector << ")\n";
+sb << "    __intrinsic_op(" << kIROp_constructVectorFromScalar << ")\n";
 sb << "    __init(T value);\n";
 
 sb << "};\n";
@@ -426,7 +427,12 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
 
                     sb << ")\")\n";
-                    sb << "__intrinsic_op\n";
+
+
+					// TIM: Making `GetDimensions` *not* be marked as
+					// an intrinsic, just so we can see how defining
+					// things as `extern` functions would work.
+//                    sb << "__intrinsic_op\n";
 
                 }
 

--- a/source/slang/ir-inst-defs.h
+++ b/source/slang/ir-inst-defs.h
@@ -21,10 +21,54 @@ INST(MatrixType, Mat, 3, 0)
 INST(arrayType, Array, 2, 0)
 
 INST(BoolType, Bool, 0, 0)
-INST(Float32Type, Float32, 0, 0)
-INST(Int32Type, Int32, 0, 0)
-INST(UInt32Type, UInt32, 0, 0)
+
+INST(Float16Type,   Float16,    0, 0)
+INST(Float32Type,   Float32,    0, 0)
+INST(Float64Type,   Float64,    0, 0)
+
+// Signed integer types.
+// Note that `IntPtr` represents a pointer-sized integer type,
+// and will end up being equivalent to either `Int32` or `Int64`
+// when it comes time to actually generate code.
+//
+INST(Int8Type,      Int8,       0, 0)
+INST(Int16Type,     Int16,      0, 0)
+INST(Int32Type,     Int32,      0, 0)
+INST(IntPtrType,    IntPtr,     0, 0)
+INST(Int64Type,     Int64,      0, 0)
+
+// Unlike a lot of other IRs, we retain a distinction between
+// signed and unsigned integer types, simply because many of
+// the target languages we need to generate code for also
+// keep this distinction, and it will help us generate variable
+// declarations that will be friendly to debuggers.
+//
+// TODO: We may want to reconsider this choice simply because
+// some targets (e.g., those based on C++) may have undefined
+// behavior around operations on signed integers that are
+// well-defined (two's complement) on unsigned integers. In
+// those cases we either want to default to unsigned integers,
+// and then cast around the few ops that care about the difference,
+// or else we want to keep using the orignal types, but need
+// to cast around any ordinary math operations on signed types.
+//
+INST(UInt8Type,     Int8,       0, 0)
+INST(UInt16Type,    Int16,      0, 0)
+INST(UInt32Type,    Int32,      0, 0)
+INST(UIntPtrType,   IntPtr,     0, 0)
+INST(UInt64Type,    Int64,      0, 0)
+
+// A user-defined structure declaration at the IR level.
+// Unlike in the AST where there is a distinction between
+// a `StructDecl` and a `DeclRefType` that refers to it,
+// at the IR level the struct declaration and the type
+// are the same IR instruction.
+//
+// This is a parent instruction that holds zero or more
+// `field` instructions.
+//
 INST(StructType, Struct, 0, PARENT)
+
 INST(FuncType, Func, 0, 0)
 INST(PtrType, Ptr, 1, 0)
 INST(TextureType, Texture, 2, 0)
@@ -34,6 +78,18 @@ INST(TextureBufferType, TextureBuffer, 1, 0)
 
 INST(structuredBufferType, StructuredBuffer, 1, 0)
 INST(readWriteStructuredBufferType, RWStructuredBuffer, 1, 0)
+
+// A type use to represent an earlier generic parameter in
+// a signature. For example, given an AST declaration like:
+//
+//     func Foo<T, U>(int a, T b) -> U;
+//
+// The lowered function type would be something like:
+//
+//      T     U     a      b
+//     (Type, Type, Int32, GenericParameterType<0>) -> GenericParameterType<1>
+//
+INST(GenericParameterType, GenericParameterType, 1, 0)
 
 INST(boolConst, boolConst, 0, 0)
 INST(IntLit, integer_constant, 0, 0)
@@ -61,6 +117,18 @@ INST(FieldAddress, get_field_addr, 2, 0)
 
 INST(getElement, getElement, 2, 0)
 INST(getElementPtr, getElementPtr, 2, 0)
+
+// Construct a vector from a scalar
+//
+// %dst = constructVectorFromScalar %T %N %val
+//
+// where
+// - `T` is a `Type`
+// - `N` is a (compile-time) `Int`
+// - `val` is a `T`
+// - dst is a `Vec<T,N>`
+//
+INST(constructVectorFromScalar, constructVectorFromScalar, 3, 0)
 
 // A swizzle of a vector:
 //

--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -62,6 +62,13 @@ struct IRLoopControlDecoration : IRDecoration
     IRLoopControl mode;
 };
 
+struct IRMangledNameDecoration : IRDecoration
+{
+    enum { kDecorationOp = kIRDecorationOp_MangledName };
+
+    String mangledName;
+};
+
 // Types
 
 struct IRVectorType : IRType
@@ -93,6 +100,10 @@ struct IRArrayType : IRType
     IRInst* getElementCount() { return elementCount.usedValue; }
 };
 
+struct IRGenericParameterType : IRType
+{
+    IRUse   index;
+};
 
 
 struct IRFuncType : IRType
@@ -387,6 +398,7 @@ struct IRBuilder
         IRValue* columnCount);
     IRType* getArrayType(IRType* elementType, IRValue* elementCount);
     IRType* getArrayType(IRType* elementType);
+    IRType* getGenericParameterType(UInt index);
 
     IRType* getTypeType();
     IRType* getVoidType();

--- a/source/slang/ir.h
+++ b/source/slang/ir.h
@@ -148,6 +148,7 @@ enum IRDecorationOp : uint16_t
     kIRDecorationOp_EntryPoint,
     kIRDecorationOp_ComputeThreadGroupSize,
     kIRDecorationOp_LoopControl,
+    kIRDecorationOp_MangledName,
 };
 
 // A "decoration" that gets applied to an instruction.
@@ -269,6 +270,13 @@ struct IRParentInst : IRInst
     IRInst* lastChild;
 };
 
+// A function parameter is represented by an instruction
+// in the entry block of a function.
+struct IRParam : IRInst
+{
+    IRParam* getNextParam();
+};
+
 // A basic block is a parent instruction that adds the constraint
 // that all the children need to be "ordinary" instructions (so
 // no function declarations, or nested blocks). We also expect
@@ -284,13 +292,8 @@ struct IRBlock : IRParentInst
     IRBlock* getNextBlock() { return (IRBlock*) nextInst; }
 
     IRFunc* getParent() { return (IRFunc*)parent; }
-};
 
-// A function parameter is represented by an instruction
-// in the entry block of a function.
-struct IRParam : IRInst
-{
-    IRParam* getNextParam();
+    IRParam* getFirstParam();
 };
 
 struct IRFuncType;

--- a/source/slang/mangle.cpp
+++ b/source/slang/mangle.cpp
@@ -1,0 +1,190 @@
+#include "mangle.h"
+
+#include "name.h"
+#include "syntax.h"
+
+namespace Slang
+{
+    struct ManglingContext
+    {
+        StringBuilder sb;
+    };
+
+    void emitRaw(
+        ManglingContext*    context,
+        char const*         text)
+    {
+        context->sb.append(text);
+    }
+
+    void emit(
+        ManglingContext*    context,
+        UInt                value)
+    {
+        context->sb.append(value);
+    }
+
+    void emitName(
+        ManglingContext*    context,
+        Name*               name)
+    {
+        String str = getText(name);
+
+        // If the name consists of only traditional "identifer characters"
+        // (`[a-zA-Z_]`), then we wnat to emit it more or less directly.
+        //
+        // If it contains code points outside that range, we'll need to
+        // do something to encode them. I don't want to deal with
+        // that right now, so I'm going to ignore it.
+
+        // We prefix the string with its byte length, so that
+        // decoding doesn't have to worry about finding a terminator.
+        UInt length = str.Length();
+        emit(context, length);
+        context->sb.append(str);
+    }
+
+    void emitType(
+        ManglingContext*    context,
+        Type*               type)
+    {
+        // TODO: actually implement this bit...
+    }
+
+    void emitQualifiedName(
+        ManglingContext*    context,
+        Decl*               decl)
+    {
+        auto parentDecl = decl->ParentDecl;
+        if( parentDecl )
+        {
+            emitQualifiedName(context, parentDecl);
+        }
+
+        // A generic declaration is kind of a pseudo-declaration
+        // as far as the user is concerned; so we don't want
+        // to emit its name.
+        if( auto genericDecl = dynamic_cast<GenericDecl*>(decl) )
+        {
+            return;
+        }
+
+        emitName(context, decl->nameAndLoc.name);
+
+        if( auto parentGenericDecl = dynamic_cast<GenericDecl*>(parentDecl))
+        {
+            emitRaw(context, "g");
+            UInt genericParameterCount = 0;
+            for( auto mm : parentGenericDecl->Members )
+            {
+                if(mm.As<GenericTypeParamDecl>())
+                {
+                    genericParameterCount++;
+                }
+                else if(mm.As<GenericValueParamDecl>())
+                {
+                    genericParameterCount++;
+                }
+                else if(mm.As<GenericTypeConstraintDecl>())
+                {
+                    genericParameterCount++;
+                }
+                else
+                {
+                }
+            }
+
+            emit(context, genericParameterCount);
+            for( auto mm : parentGenericDecl->Members )
+            {
+                if(auto genericTypeParamDecl = mm.As<GenericTypeParamDecl>())
+                {
+                    emitRaw(context, "T");
+                }
+                else if(auto genericValueParamDecl = mm.As<GenericValueParamDecl>())
+                {
+                    emitRaw(context, "v");
+                    emitType(context, genericValueParamDecl->getType());
+                }
+                else if(mm.As<GenericTypeConstraintDecl>())
+                {
+                    emitRaw(context, "C");
+                    // TODO: actually emit info about the constraint
+                }
+                else
+                {
+                }
+            }
+        }
+
+        // If the declaration has parameters, then we need to emit
+        // those parameters to distinguish it from other declarations
+        // of the same name that might have different parameters.
+        //
+        // We'll also go ahead and emit the result type as well,
+        // just for completeness.
+        //
+        if( auto callableDecl = dynamic_cast<CallableDecl*>(decl) )
+        {
+            emitRaw(context, "p");
+            UInt parameterCount = callableDecl->GetParameters().Count();
+            emit(context, parameterCount);
+            for(auto pp : callableDecl->GetParameters())
+            {
+                emitType(context, pp->getType());
+            }
+
+            emitType(context, callableDecl->ReturnType);
+        }
+    }
+
+    void mangleName(
+        ManglingContext*    context,
+        Decl*               decl)
+    {
+        // TODO: catch cases where the declaration should
+        // forward to something else? E.g., what if we
+        // are asked to mangle the name of a `typedef`?
+
+        // We will start with a unique prefix to avoid
+        // clashes with user-defined symbols:
+        emitRaw(context, "_S");
+
+        // Next we will add a bit of info to register
+        // the *kind* of declaration we are dealing with.
+        //
+        // Functions will get no prefix, since we assume
+        // they are a common case:
+        if(dynamic_cast<FuncDecl*>(decl))
+        {}
+        // Types will get a `T` prefix:
+        else if(dynamic_cast<AggTypeDecl*>(decl))
+            emitRaw(context, "T");
+        else if(dynamic_cast<TypeDefDecl*>(decl))
+            emitRaw(context, "T");
+        // Variables will get a `V` prefix:
+        //
+        // TODO: probably need to pull constant-buffer
+        // declarations out of this...
+        else if(dynamic_cast<VarDeclBase*>(decl))
+            emitRaw(context, "V");
+        else
+        {
+            // TODO: handle other cases
+        }
+
+        // Now we encode the qualified name of the decl.
+        emitQualifiedName(context, decl);
+    }
+
+
+
+    String getMangledName(Decl* decl)
+    {
+        ManglingContext context;
+
+        mangleName(&context, decl);
+
+        return context.sb.ProduceString();
+    }
+}

--- a/source/slang/mangle.h
+++ b/source/slang/mangle.h
@@ -1,0 +1,15 @@
+#ifndef SLANG_MANGLE_H_INCLUDED
+#define SLANG_MANGLE_H_INCLUDED
+
+// This file implements the name mangling scheme for the Slang language.
+
+#include "../core/basic.h"
+
+namespace Slang
+{
+    struct Decl;
+
+    String getMangledName(Decl* decl);
+}
+
+#endif

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -178,6 +178,7 @@
     <ClInclude Include="lexer.h" />
     <ClInclude Include="lookup.h" />
     <ClInclude Include="lower-to-ir.h" />
+    <ClInclude Include="mangle.h" />
     <ClInclude Include="modifier-defs.h" />
     <ClInclude Include="name.h" />
     <ClInclude Include="object-meta-begin.h" />
@@ -214,6 +215,7 @@
     <ClCompile Include="lookup.cpp" />
     <ClCompile Include="lower-to-ir.cpp" />
     <ClCompile Include="lower.cpp" />
+    <ClCompile Include="mangle.cpp" />
     <ClCompile Include="name.cpp" />
     <ClCompile Include="options.cpp" />
     <ClCompile Include="parameter-binding.cpp" />

--- a/source/slang/slang.vcxproj.filters
+++ b/source/slang/slang.vcxproj.filters
@@ -42,6 +42,7 @@
     <ClInclude Include="ir-insts.h" />
     <ClInclude Include="bytecode.h" />
     <ClInclude Include="vm.h" />
+    <ClInclude Include="mangle.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="check.cpp" />
@@ -68,6 +69,7 @@
     <ClCompile Include="lower-to-ir.cpp" />
     <ClCompile Include="bytecode.cpp" />
     <ClCompile Include="vm.cpp" />
+    <ClCompile Include="mangle.cpp" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="core.meta.slang" />

--- a/tests/ir/loop.slang.expected
+++ b/tests/ir/loop.slang.expected
@@ -3,76 +3,76 @@ standard error = {
 }
 standard output = {
 let  %63	: Ptr<Array<Vec<Float32,4>,64>,1>	= var()
-let  %90	: Ptr<StructuredBuffer<Vec<Float32,4>>,0>	= var()
-let  %268	: Ptr<RWStructuredBuffer<Vec<Float32,4>>,0>	= var()
+let  %96	: Ptr<StructuredBuffer<Vec<Float32,4>>,0>	= var()
+let  %282	: Ptr<RWStructuredBuffer<Vec<Float32,4>>,0>	= var()
 
-func %1(
-	param %7	: UInt32,
-	param %18	: UInt32,
-	param %28	: UInt32)
+func @_S04mainp3	: (Int32, Int32, Int32) -> Void
 {
-block %4:
-	let  %13	: Ptr<UInt32,0>	= var()
-	store(%13, %7)
-	let  %23	: Ptr<UInt32,0>	= var()
-	store(%23, %18)
-	let  %33	: Ptr<UInt32,0>	= var()
-	store(%33, %28)
-	let  %64	: UInt32	= load(%23)
+block %14(	param %15	: Int32,
+	param %24	: Int32,
+	param %32	: Int32)
+:
+	let  %21	: Ptr<Int32,0>	= var()
+	store(%21, %15)
+	let  %29	: Ptr<Int32,0>	= var()
+	store(%29, %24)
+	let  %37	: Ptr<Int32,0>	= var()
+	store(%37, %32)
+	let  %64	: Int32	= load(%29)
 	let  %69	: Ptr<Vec<Float32,4>,0>	= getElementPtr(%63, %64)
-	let  %91	: StructuredBuffer<Vec<Float32,4>>	= load(%90)
-	let  %94	: UInt32	= load(%13)
-	let  %95	: Vec<Float32,4>	= bufferLoad(%91, %94)
-	store(%69, %95)
-	let  %104	: Ptr<UInt32,0>	= var()
-	let  %112	: UInt32	= construct(1)
-	store(%104, %112)
-	loop(%117, %123, %126)
-
-block %117:
-	let  %133	: UInt32	= load(%104)
-	let  %142	: UInt32	= construct(64)
-	let  %143	: Bool	= cmpLT(%133, %142)
-	loopTest(%143, %120, %123)
-
-block %120:
-	GroupMemoryBarrierWithGroupSync()
-	let  %166	: UInt32	= load(%23)
-	let  %171	: Ptr<Vec<Float32,4>,0>	= getElementPtr(%63, %166)
-	let  %176	: Ptr<Vec<Float32,4>,0>	= var()
-	let  %177	: Vec<Float32,4>	= load(%171)
-	store(%176, %177)
-	let  %196	: UInt32	= load(%23)
-	let  %199	: UInt32	= load(%104)
-	let  %200	: UInt32	= sub(%196, %199)
-	let  %205	: Ptr<Vec<Float32,4>,0>	= getElementPtr(%63, %200)
-	let  %206	: Vec<Float32,4>	= load(%205)
-	let  %207	: Vec<Float32,4>	= load(%176)
-	let  %208	: Vec<Float32,4>	= add(%207, %206)
-	store(%176, %208)
-	let  %211	: Vec<Float32,4>	= load(%176)
-	store(%171, %211)
-	unconditionalBranch(%126)
-
-block %126:
-	let  %224	: Ptr<UInt32,0>	= var()
-	let  %225	: UInt32	= load(%104)
-	store(%224, %225)
-	let  %236	: UInt32	= construct(1)
-	let  %237	: UInt32	= load(%224)
-	let  %238	: UInt32	= shl(%237, %236)
-	store(%224, %238)
-	let  %241	: UInt32	= load(%224)
-	store(%104, %241)
-	unconditionalBranch(%117)
+	let  %97	: StructuredBuffer<Vec<Float32,4>>	= load(%96)
+	let  %100	: Int32	= load(%21)
+	let  %101	: Vec<Float32,4>	= bufferLoad(%97, %100)
+	store(%69, %101)
+	let  %110	: Ptr<Int32,0>	= var()
+	let  %118	: Int32	= construct(1)
+	store(%110, %118)
+	loop(%123, %129, %132)
 
 block %123:
+	let  %139	: Int32	= load(%110)
+	let  %148	: Int32	= construct(64)
+	let  %149	: Bool	= cmpLT(%139, %148)
+	loopTest(%149, %126, %129)
+
+block %126:
 	GroupMemoryBarrierWithGroupSync()
-	let  %269	: RWStructuredBuffer<Vec<Float32,4>>	= load(%268)
-	let  %272	: UInt32	= load(%13)
-	let  %286	: Ptr<Vec<Float32,4>,0>	= getElementPtr(%63, 0)
-	let  %287	: Vec<Float32,4>	= load(%286)
-	bufferStore(%269, %272, %287)
+	let  %174	: Int32	= load(%29)
+	let  %179	: Ptr<Vec<Float32,4>,0>	= getElementPtr(%63, %174)
+	let  %184	: Ptr<Vec<Float32,4>,0>	= var()
+	let  %185	: Vec<Float32,4>	= load(%179)
+	store(%184, %185)
+	let  %204	: Int32	= load(%29)
+	let  %207	: Int32	= load(%110)
+	let  %208	: Int32	= sub(%204, %207)
+	let  %213	: Ptr<Vec<Float32,4>,0>	= getElementPtr(%63, %208)
+	let  %214	: Vec<Float32,4>	= load(%213)
+	let  %215	: Vec<Float32,4>	= load(%184)
+	let  %216	: Vec<Float32,4>	= add(%215, %214)
+	store(%184, %216)
+	let  %219	: Vec<Float32,4>	= load(%184)
+	store(%179, %219)
+	unconditionalBranch(%132)
+
+block %132:
+	let  %232	: Ptr<Int32,0>	= var()
+	let  %233	: Int32	= load(%110)
+	store(%232, %233)
+	let  %244	: Int32	= construct(1)
+	let  %245	: Int32	= load(%232)
+	let  %246	: Int32	= shl(%245, %244)
+	store(%232, %246)
+	let  %249	: Int32	= load(%232)
+	store(%110, %249)
+	unconditionalBranch(%123)
+
+block %129:
+	GroupMemoryBarrierWithGroupSync()
+	let  %283	: RWStructuredBuffer<Vec<Float32,4>>	= load(%282)
+	let  %286	: Int32	= load(%21)
+	let  %300	: Ptr<Vec<Float32,4>,0>	= getElementPtr(%63, 0)
+	let  %301	: Vec<Float32,4>	= load(%300)
+	bufferStore(%283, %286, %301)
 	return_void()
 }
 }

--- a/tools/render-test/render-test.vcxproj
+++ b/tools/render-test/render-test.vcxproj
@@ -164,6 +164,11 @@
     <ClInclude Include="slang-support.h" />
     <ClInclude Include="window.h" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\source\slang\slang.vcxproj">
+      <Project>{db00da62-0533-4afd-b59f-a67d5b3a0808}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -1,9 +1,8 @@
 // slang-support.cpp
 
-#define SLANG_INCLUDE_IMPLEMENTATION
-
 #include "slang-support.h"
 
+#include <assert.h>
 #include <stdio.h>
 
 namespace renderer_test {
@@ -133,11 +132,3 @@ ShaderCompiler* createSlangShaderCompiler(
 
 
 } // renderer_test
-
-//
-// In order to actually use Slang in our application, we need to link in its
-// implementation. The easiest way to accomplish this is by directly inlcuding
-// the (concatenated) Slang source code into our app.
-//
-
-#include <slang.h>


### PR DESCRIPTION
None of these changes are made "live" at the moment. I'm just trying to get them checked in to avoid divering too far from `master` at any point during development.

- Add basic emit logic to produce GLSL from the IR in a few cases (the existing IR emit logic was ad hoc and HLSL-specific)

- When lowering a function declaration, walk up its chain of parent declarations to collect additional parameters as needed

- When lowering a call, make sure to add generic arguments that come from the declaration reference being called

- Attach a "mangled name" to symbols when lowering, so that we can eventually use that name to resolve things for linkage.

- After the above work, I had to apply some fixups to make sure that generic arguments *don't* get added when the user is calling an `__intrinsic_op` function, since those should map 1-to-1 down to instructions with just their ordinary parameter list.

A big open question right now is whether I should continue to represent the generic arguments as just part of the ordinary argument list for a function, or split them out into separate `applyGeneric` and `apply` steps.
A strongly related question is whether a declaration with generic parameters should lower into a single declaration, or one declaration nested inside an outer generic declaration.

A good future step at this point would be to eliminate a lot of the `__intrinsic_op` stuff in favor of having the builtin functions include their own definitions, which might be in terms of a new expression-level construct for writing inline IR operations. This can't be done until the existing AST-to-AST path is no longer needed for cross-compilation purposes.

More immediate next steps here:

- We need a way to round-trip calls to external declaration that get handled by this mangled-name logic. Basically, if we are asked to output HLSL and we see a call to `_S...GetDimensions...(float4, t, a, ...)` we need to be able to walk the mangled name and get back to `t.getDimensions(a, ...)` without a whole lot of manual definitions to make things round-trip.

- In the other case, where a declaration isn't built-in for the chosen target, we need to be able to load a module of target-specific definitions (which will somehow map back to symbols with certain mangled names) and then look these up (by mangled name) and then load/link/inline them into the user's IR to satisfy requirements in their code.