### PR TITLE
Perform some transformations on IR to legalize for GLSL

### DIFF
--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -134,6 +134,15 @@ namespace Slang
     struct UnownedStringSlice
     {
     public:
+        UnownedStringSlice()
+            : beginData(0)
+            , endData(0)
+        {}
+
+        UnownedStringSlice(char const* b, char const* e)
+            : beginData(b)
+            , endData(e)
+        {}
 
         char const* begin() const
         {

--- a/source/slang/bytecode.cpp
+++ b/source/slang/bytecode.cpp
@@ -956,7 +956,7 @@ BytecodeGenerationPtr<BCModule> generateBytecodeForModule(
     // for the module, where the registers represent the
     // values being computed at the global scope.
     UInt symbolCount = 0;
-    for( auto gv : irModule->globalValues )
+    for( auto gv = irModule->getFirstGlobalValue(); gv; gv = gv->getNextValue() )
     {
         Int globalID = Int(symbolCount++);
 
@@ -975,7 +975,7 @@ BytecodeGenerationPtr<BCModule> generateBytecodeForModule(
     bcModule->symbolCount = symbolCount;
     bcModule->symbols = bcSymbols;
 
-    for( auto gv : irModule->globalValues )
+    for( auto gv = irModule->getFirstGlobalValue(); gv; gv = gv->getNextValue() )
     {
         UInt symbolIndex = *context->mapInstToLocalID.TryGetValue(gv);
 

--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -11,6 +11,7 @@
 #include "compiler.h"
 #include "ir.h"
 #include "syntax.h"
+#include "type-layout.h"
 
 namespace Slang {
 
@@ -40,6 +41,7 @@ struct IREntryPointDecoration : IRDecoration
     enum { kDecorationOp = kIRDecorationOp_EntryPoint };
 
     Profile profile;
+    EntryPointLayout* layout;
 };
 
 // Associates a compute-shader entry point function

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -2117,8 +2117,6 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             // TODO: need to handle global with initializer!
         }
 
-        getBuilder()->getModule()->globalValues.Add(irGlobal);
-
         return globalVal;
     }
 
@@ -2837,7 +2835,11 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         getBuilder()->addHighLevelDeclDecoration(irFunc, decl);
 
-        getBuilder()->getModule()->globalValues.Add(irFunc);
+        // For convenience, ensure that any additional global
+        // values that were emitted while outputting the function
+        // body appear before the function itself in the list
+        // of global values.
+        irFunc->moveToEnd();
 
         return LoweredValInfo::simple(irFunc);
     }
@@ -2939,6 +2941,7 @@ static void lowerEntryPointToIR(
 
     auto entryPointDecoration = builder->addDecoration<IREntryPointDecoration>(irFunc);
     entryPointDecoration->profile = profile;
+    entryPointDecoration->layout = entryPointLayout;
 
     // Attach layout information here.
     builder->addLayoutDecoration(irFunc, entryPointLayout);

--- a/tests/render/render0.hlsl
+++ b/tests/render/render0.hlsl
@@ -1,4 +1,4 @@
-//TEST(smoke):COMPARE_HLSL_RENDER:
+//TEST(smoke):COMPARE_HLSL_RENDER:-xslang -use-ir
 // Starting with a basic test for the ability to render stuff...
 
 cbuffer Uniforms

--- a/tools/slang-test/main.cpp
+++ b/tools/slang-test/main.cpp
@@ -54,7 +54,7 @@ struct Options
     // Dump expected/actual output on failures, for debugging.
     // This is especially intended for use in continuous
     // integration builds.
-    bool dumpOutputOnFailure = true;
+    bool dumpOutputOnFailure = false;
 
     // kind of output to generate
     OutputMode outputMode = kOutputMode_Default;


### PR DESCRIPTION
When outputting GLSL from a Slang or HLSL entry point, we need to translate any parameters or results of an entry-point function into global declarations of `in` or `out` parameters, as needed by GLSL.
This change adds these transformations at the IR level, so that they don't need to complicate the emit logic.

More detailed changes:

- Make `render0` test use IR. It passes out of the box.

- Fix test runner to not always dump diffs on failures

  I accidentally initialized an option to `true` instead of `false` when working on debugging the Travis CI failures.

- Special-case output for component-wise multiplication to handle GLSL `matrixCompMul()`

- Handle GLSL vs. HLSL output for calls to `mul()`

- Output proper `layout(std140)` on GLSL constant buffer declarations

- Require appropriate GLSL extension when emitting explicit `layout(offset = ...)` on constant buffer members
  - TODO: Need to avoid requiring this extension in cases where the offsets are what would be computed anyway.
    Realistically, should probably be emitting code with explicit padding, etc. to guarantee layouts.

- Add an IR-based pass to translate entry point functions by eliminating their input/output parameters and replacing them with global variables.

- Demangle names when calling target intrinsics

  The lowering to the IR will turn a call like `sin(foo)` into a call to a function declaration with a   mangled name like `_S3sin...`. This works fine when the user is calling their own functions, since the   name mangling will apply to both the definition and use sites, but for builtin functions it obviously   isn't what we want.

  This change makes it so that we demangle the name of an instrinsic function just enough so that we can   extract the original simple name, and make a call using that.

These changes do nor provide 100% of what we need when translating to GLSL, so the `cross-compile-entry-point` test *still* hasn't been flipped over to use the IR (even though that is the test case I've been using to develop these changes).