### PR TITLE
Parser: fix precedence of cast expressions

### DIFF
--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -3321,6 +3321,8 @@ namespace Slang
         return parseGenericApp(parser, base);
     }
 
+    static RefPtr<Expr> parsePrefixExpr(Parser* parser);
+
     static RefPtr<Expr> parseAtomicExpr(Parser* parser)
     {
         switch( peekTokenType(parser) )
@@ -3348,7 +3350,7 @@ namespace Slang
                     tcexpr->FunctionExpr = parser->ParseType();
                     parser->ReadToken(TokenType::RParent);
 
-                    auto arg = parser->ParseExpression(Precedence::Multiplicative); // Note(tfoley): need to double-check this
+                    auto arg = parsePrefixExpr(parser);
                     tcexpr->Arguments.Add(arg);
 
                     return tcexpr;

--- a/tests/parser/cast-precedence.hlsl
+++ b/tests/parser/cast-precedence.hlsl
@@ -1,0 +1,15 @@
+//TEST:COMPARE_HLSL: -profile vs_5_0
+
+// Confirm that type-cast expressions parse with
+// the appropriate precedence.
+
+cbuffer C : register(b0)
+{
+	float a;
+	float b;
+};
+
+float4 main() : SV_Position
+{
+	return (uint) a / b;
+}


### PR DESCRIPTION
We were accidentally parsing this:

    (uint) a / b

as this:

    (uint) ( a / b )

when it should be:

    ((uint) a) / b

This is a bug that seems to have been inherited from a long time ago. It has taken a while to bite anybody because the only class of expressions it would hit are multiplicative ones, and in many cases the difference in the cast order won't be noticed for values in a limited range.