### PR TITLE
Preprocessor: fix `undef` and redefinition

### DIFF
--- a/source/slang/preprocessor.cpp
+++ b/source/slang/preprocessor.cpp
@@ -1619,7 +1619,7 @@ static void HandleIncludeDirective(PreprocessorDirectiveContext* context)
 static void HandleDefineDirective(PreprocessorDirectiveContext* context)
 {
     Token nameToken;
-    if (!Expect(context, TokenType::Identifier, Diagnostics::expectedTokenInPreprocessorDirective, &nameToken))
+    if (!ExpectRaw(context, TokenType::Identifier, Diagnostics::expectedTokenInPreprocessorDirective, &nameToken))
         return;
     Name* name = nameToken.getName();
 
@@ -1701,7 +1701,7 @@ static void HandleDefineDirective(PreprocessorDirectiveContext* context)
 static void HandleUndefDirective(PreprocessorDirectiveContext* context)
 {
     Token nameToken;
-    if (!Expect(context, TokenType::Identifier, Diagnostics::expectedTokenInPreprocessorDirective, &nameToken))
+    if (!ExpectRaw(context, TokenType::Identifier, Diagnostics::expectedTokenInPreprocessorDirective, &nameToken))
         return;
     Name* name = nameToken.getName();
 

--- a/tests/preprocessor/define-redefine.slang
+++ b/tests/preprocessor/define-redefine.slang
@@ -1,0 +1,10 @@
+//TEST:SIMPLE:
+
+// Confirm that we handle redefinition
+// of an existing define (with a diagnostic)
+
+#define FOO 1.0f
+
+float foo() { return FOO + 2.0; }
+
+#define FOO 2.0f

--- a/tests/preprocessor/define-redefine.slang.expected
+++ b/tests/preprocessor/define-redefine.slang.expected
@@ -1,0 +1,7 @@
+result code = 0
+standard error = {
+tests/preprocessor/define-redefine.slang(10): warning 15400: redefinition of macro 'FOO'
+tests/preprocessor/define-redefine.slang(6): note: see previous definition of 'FOO'
+}
+standard output = {
+}

--- a/tests/preprocessor/undef.slang
+++ b/tests/preprocessor/undef.slang
@@ -1,0 +1,32 @@
+//TEST:SIMPLE:
+// #undef support
+
+// warning: undef of something not defined
+#undef FOO
+
+#define BAR 1.0f
+
+float foo() { return BAR + 2.0; }
+
+#ifdef BAR
+// okay
+#else
+#error not okay
+#endif
+
+#undef BAR
+
+typedef float BAR;
+
+BAR bar() { return 2.0; }
+
+#if !defined(BAR)
+// okay
+#else
+#error not okay
+#endif
+
+
+#define FOO
+
+#undef FOO

--- a/tests/preprocessor/undef.slang.expected
+++ b/tests/preprocessor/undef.slang.expected
@@ -1,0 +1,6 @@
+result code = 0
+standard error = {
+tests/preprocessor/undef.slang(5): warning 15401: macro 'FOO' is not defined
+}
+standard output = {
+}


### PR DESCRIPTION
The logic for `undef` directives was failing to suppress macro expansion when reading the name to un-define, and so it wasn't actually working at all. We didn't notice this because we didn't have a test case, and users hadn't tried it.

The logic for `define` had a similar bug, which meant that any attempt to define an already-defined macro would fail with a cryptic error, rather than raising the intended warning.

Test cases have been added for both issues, along with the fixes.