### PR TITLE
Fix emit logic for `cbuffer` member with initializer

### DIFF
--- a/tests/bugs/cbuffer-member-init.hlsl
+++ b/tests/bugs/cbuffer-member-init.hlsl
@@ -1,0 +1,13 @@
+//TEST:COMPARE_HLSL: -profile vs_5_0 -target dxbc-assembly -no-checking
+
+// Allow (but ignore) initializer on `cbuffer` member
+
+cbuffer C : register(b0)
+{
+	int a = -1;
+};
+
+float4 main() : SV_Position
+{
+	return a;
+}


### PR DESCRIPTION
Given an input declaration like:

    cbuffer C
    {
        int a = -1;
    }

Slang was automatically generating a `packoffset` semantic to place the member manually, but was emitting it *after* the initializer of the original declaration:

    cbuffer C : register(b)
    {
        int a = -1 : packoffset(c0);
    }

That syntax is invalid, of course, and we actually want:

    cbuffer C : register(b)
    {
        int a : packoffset(c0) = -1;
    }

This wasn't spotted earlier because putting initializers on a `cbuffer` member is not commonly done, since it requires reading those values via the reflection API. Slang's reflection API currently provides no way to access default values like this, so they aren't of much use yet. Still, it is better to emit correct syntax even in cases like this one.