### PR TITLE
Fixup: re-enable exception guard

### DIFF
--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -859,7 +859,7 @@ SLANG_API int spCompile(
 {
     auto req = REQ(request);
 
-#if 0
+#if 1
     // By default we'd like to catch as many internal errors as possible,
     // and report them to the user nicely (rather than just crash their
     // application). Internally Slang currently uses exceptions for this.


### PR DESCRIPTION
This is intended to produce a better experience for end users when they encounter internal compiler errors.