### PR TITLE
Get rid of the `-slang-ir-asm` target

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -90,7 +90,6 @@ extern "C"
         SLANG_DXBC,
         SLANG_DXBC_ASM,
         SLANG_IR,
-        SLANG_IR_ASM,
     };
 
     typedef int SlangPassThrough;

--- a/source/slang/compiler.cpp
+++ b/source/slang/compiler.cpp
@@ -559,6 +559,7 @@ namespace Slang
             }
             break;
 
+#if 0
         case CodeGenTarget::SlangIRAssembly:
             {
                 String code = emitSlangIRAssemblyForEntryPoint(entryPoint);
@@ -566,6 +567,7 @@ namespace Slang
                 result = CompileResult(code);
             }
             break;
+#endif
 
         case CodeGenTarget::None:
             // The user requested no output
@@ -818,6 +820,10 @@ namespace Slang
         // If we are in command-line mode, we might be expected to actually
         // write output to one or more files here.
 
+        // But don't write any output if we were told to skip it.
+        if (compileRequest->shouldSkipCodegen)
+            return;
+
         if (compileRequest->isCommandLineCompile)
         {
             for( auto entryPoint : compileRequest->entryPoints )
@@ -910,9 +916,11 @@ namespace Slang
             dumpIntermediateText(compileRequest, data, size, ".spv.asm");
             break;
 
+#if 0
         case CodeGenTarget::SlangIRAssembly:
             dumpIntermediateText(compileRequest, data, size, ".slang-ir.asm");
             break;
+#endif
 
         case CodeGenTarget::SPIRV:
             dumpIntermediateBinary(compileRequest, data, size, ".spv");

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -48,7 +48,6 @@ namespace Slang
         DXBytecode          = SLANG_DXBC,
         DXBytecodeAssembly  = SLANG_DXBC_ASM,
         SlangIR             = SLANG_IR,
-        SlangIRAssembly     = SLANG_IR_ASM,
     };
 
     enum class LineDirectiveMode : SlangLineDirectiveMode
@@ -210,6 +209,9 @@ namespace Slang
 
         // Should we dump intermediate results along the way, for debugging?
         bool shouldDumpIntermediates = false;
+
+        bool shouldDumpIR = false;
+        bool shouldSkipCodegen = false;
 
         // How should `#line` directives be emitted (if at all)?
         LineDirectiveMode lineDirectiveMode = LineDirectiveMode::Default;
@@ -390,6 +392,8 @@ namespace Slang
 
         // Construct pointer types on-demand
         RefPtr<PtrType> getPtrType(RefPtr<Type> valueType);
+
+        RefPtr<GroupSharedType> getGroupSharedType(RefPtr<Type> valueType);
 
         SyntaxClass<RefObject> findSyntaxClass(Name* name);
 

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -1224,6 +1224,12 @@ struct EmitVisitor
         emitTypeImpl(arrayType->baseType, &arrayDeclarator);
     }
 
+    void visitGroupSharedType(GroupSharedType* type, TypeEmitArg const& arg)
+    {
+        Emit("groupshared ");
+        emitTypeImpl(type->valueType, arg.declarator);
+    }
+
     void EmitType(
         RefPtr<Type>        type,
         SourceLoc const&    typeLoc,
@@ -4492,6 +4498,9 @@ emitDeclImpl(decl, nullptr);
         if(!type)
             return;
 
+        if (type->Equals(getSession()->getVoidType()))
+            return;
+
         emitIRType(context, type, getIRName(inst));
         emit(" = ");
     }
@@ -6266,7 +6275,10 @@ String emitEntryPoint(
         auto lowered = lowerEntryPointToIR(entryPoint, programLayout, target);
 
         // debugging:
-//        dumpIR(lowered);
+        if (translationUnit->compileRequest->shouldDumpIR)
+        {
+            dumpIR(lowered);
+        }
 
         // TODO: depending on the target we are trying to generate code for,
         // we may need to apply certain transformations, and we may also

--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -76,38 +76,6 @@ struct IRDeclRef : IRValue
 
 //
 
-// TODO(tfoley): the IR-level representation of
-// pointers had an "address space" field that the
-// current AST level lacks. This capability was
-// used to represent `groupshared` allocation,
-// so we probably need to find an alternative.
-
-// Address spaces for IR pointers
-enum IRAddressSpace : UInt
-{
-    // A default address space for things like local variables
-    kIRAddressSpace_Default,
-
-    // Address space for HLSL `groupshared` allocations
-    kIRAddressSpace_GroupShared,
-};
-
-#if 0
-struct IRPtrType : IRType
-{
-    IRUse valueType;
-    IRUse addressSpace;
-
-    IRType* getValueType() { return (IRType*) valueType.usedValue; }
-
-    IRAddressSpace getAddressSpace()
-    {
-        return IRAddressSpace(
-            ((IRConstant*)addressSpace.usedValue)->u.intVal);
-    }
-};
-#endif
-
 struct IRCall : IRInst
 {
     IRUse func;
@@ -382,10 +350,6 @@ struct IRBuilder
 
     IRParam* emitParam(
         IRType* type);
-
-    IRVar* emitVar(
-        IRType*         type,
-        IRAddressSpace  addressSpace);
 
     IRVar* emitVar(
         IRType* type);

--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -805,8 +805,7 @@ namespace Slang
     }
 
     IRVar* IRBuilder::emitVar(
-        IRType*         type,
-        IRAddressSpace  addressSpace)
+        IRType*         type)
     {
         auto allocatedType = getSession()->getPtrType(type);
         auto inst = createInst<IRVar>(
@@ -815,13 +814,6 @@ namespace Slang
             allocatedType);
         addInst(inst);
         return inst;
-    }
-
-
-    IRVar* IRBuilder::emitVar(
-        IRType* type)
-    {
-        return emitVar(type, kIRAddressSpace_Default);
     }
 
     IRInst* IRBuilder::emitLoad(
@@ -1450,6 +1442,11 @@ namespace Slang
         else if(auto declRefType = type->As<DeclRefType>())
         {
             dumpDeclRef(context, declRefType->declRef);
+        }
+        else if(auto groupSharedType = type->As<GroupSharedType>())
+        {
+            dump(context, "@ThreadGroup ");
+            dumpType(context, groupSharedType->valueType);
         }
         else
         {

--- a/source/slang/lower.cpp
+++ b/source/slang/lower.cpp
@@ -785,6 +785,12 @@ struct LoweringVisitor
         return loweredType;
     }
 
+    RefPtr<Type> visitGroupSharedType(GroupSharedType* type)
+    {
+        return getSession()->getGroupSharedType(
+            lowerType(type->valueType));
+    }
+
     RefPtr<Type> transformSyntaxField(Type* type)
     {
         return lowerType(type);

--- a/source/slang/options.cpp
+++ b/source/slang/options.cpp
@@ -266,6 +266,14 @@ struct OptionsParser
                 {
                     flags |= SLANG_COMPILE_FLAG_NO_MANGLING;
                 }
+                else if(argStr == "-dump-ir" )
+                {
+                    requestImpl->shouldDumpIR = true;
+                }
+                else if(argStr == "-skip-codegen" )
+                {
+                    requestImpl->shouldSkipCodegen = true;
+                }
                 else if (argStr == "-backend" || argStr == "-target")
                 {
                     String name = tryReadCommandLineArgument(arg, &argCursor, argEnd);
@@ -304,8 +312,6 @@ struct OptionsParser
 
                     CASE(spirv, SPIRV);
                     CASE(spirv-assembly, SPIRV_ASM);
-                    CASE(slang-ir, IR);
-                    CASE(slang-ir-assembly, IR_ASM);
                     CASE(none, TARGET_NONE);
 
                 #undef CASE

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -301,6 +301,11 @@ int CompileRequest::executeActionsInner()
         if (mSink.GetErrorCount() != 0)
             return 1;
     }
+    
+    // If command line specifies to skip codegen, we exit here.
+    // Note: this is a debugging option.
+//    if (shouldSkipCodegen)
+//        return 0;
 
     // Generate output code, in whatever format was requested
     generateOutput(this);

--- a/source/slang/type-defs.h
+++ b/source/slang/type-defs.h
@@ -308,7 +308,27 @@ protected:
     virtual bool EqualsImpl(Type * type) override;
     virtual Type* CreateCanonicalType() override;
     virtual int GetHashCode() override;
-)
+    )
+END_SYNTAX_CLASS()
+
+// The effective type of a variable declared with `groupshared` storage qualifier.
+SYNTAX_CLASS(GroupSharedType, Type)
+    SYNTAX_FIELD(RefPtr<Type>, valueType);
+
+RAW(
+    virtual ~GroupSharedType()
+    {
+    int f = 0;
+    }
+
+    virtual Slang::String ToString() override;
+
+protected:
+    virtual bool EqualsImpl(Type * type) override;
+    virtual Type* CreateCanonicalType() override;
+    virtual int GetHashCode() override;
+    )
+
 END_SYNTAX_CLASS()
 
 // The "type" of an expression that resolves to a type.

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -622,7 +622,6 @@ LayoutRulesFamilyImpl* GetLayoutRulesFamilyImpl(CodeGenTarget target)
     case CodeGenTarget::DXBytecode:
     case CodeGenTarget::DXBytecodeAssembly:
     case CodeGenTarget::SlangIR:
-    case CodeGenTarget::SlangIRAssembly:
         return &kHLSLLayoutRulesFamilyImpl;
 
     case CodeGenTarget::GLSL:

--- a/tests/ir/loop.slang
+++ b/tests/ir/loop.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE:-target slang-ir-assembly -profile cs_4_0 -entry main
+//TEST:SIMPLE:-use-ir -dump-ir -skip-codegen -target dxbc -profile cs_5_0 -entry main
 
 #define GROUP_THREAD_COUNT 64
 
@@ -9,8 +9,8 @@ groupshared float4 s[GROUP_THREAD_COUNT];
 
 [numthreads(GROUP_THREAD_COUNT, 1, 1)]
 void main(
-    uint dispatchThreadID   : SV_DispatchThreadIndex,
-    uint groupThreadID      : SV_GroupThreadIndex,
+    uint dispatchThreadID   : SV_DispatchThreadID,
+    uint groupThreadID      : SV_GroupThreadID,
     uint groupID            : SV_GroupIndex )
 {
     // the actual algorithm being done here is bogus

--- a/tests/ir/loop.slang
+++ b/tests/ir/loop.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE:-use-ir -dump-ir -skip-codegen -target dxbc -profile cs_5_0 -entry main
+//TEST:SIMPLE:-use-ir -dump-ir -skip-codegen -target hlsl -profile cs_5_0 -entry main
 
 #define GROUP_THREAD_COUNT 64
 

--- a/tests/ir/loop.slang.expected
+++ b/tests/ir/loop.slang.expected
@@ -1,9 +1,7 @@
 result code = 0
 standard error = {
-}
-standard output = {
 
-ir_global_var %1	: Ptr<vector<float,4>[64]>;
+ir_global_var %1	: Ptr<@ThreadGroup vector<float,4>[64]>;
 
 ir_global_var %2	: Ptr<StructuredBuffer<vector<float,4>>>;
 
@@ -78,4 +76,7 @@ block %19:
 	bufferStore(%43, %44, %46)
 	return_void()
 }
+
+}
+standard output = {
 }


### PR DESCRIPTION
This is really only useful for debugging, so I've replaced the functionality with a `-dump-ir` command line option (which dump's the IR for an entry point before doing codegen).