### PR TITLE
Initial work on a pass to scalarize GLSL varying input/output

### DIFF
--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -32,7 +32,7 @@ struct IRLayoutDecoration : IRDecoration
 {
     enum { kDecorationOp = kIRDecorationOp_Layout };
 
-    Layout* layout;
+    RefPtr<Layout>  layout;
 };
 
 enum IRLoopControl
@@ -304,10 +304,8 @@ struct IRBuilder
     IRFunc*     func = nullptr;
     IRBlock*    block = nullptr;
     //
-    // TODO: we eventually also want an `IRInst*` for
-    // an instruction to insert before, so that we
-    // can also use the builder to insert inside
-    // an existing block.
+    // An instruction in the current block that we should insert before
+    IRInst*     insertBeforeInst = nullptr;
 
     IRFunc*     getFunc() { return func; }
     IRBlock*    getBlock() { return block; }

--- a/tests/render/cross-compile-entry-point.slang
+++ b/tests/render/cross-compile-entry-point.slang
@@ -1,4 +1,4 @@
-//TEST(render):COMPARE_HLSL_CROSS_COMPILE_RENDER:
+//TEST(render):COMPARE_HLSL_CROSS_COMPILE_RENDER:-xslang -use-ir
 
 // This is a test to ensure that we can cross-compile a complete entry point.
 


### PR DESCRIPTION
There was already a pass in place that transformed parameters and results of an entry-point function into global variables for GLSL, but this pass would just turn a `struct`-type parameter into a `struct`-type global, which has two problems:

- The standard GLSL language doesn't seem to allow `struct` types as vertex shader inputs or fragment shader outputs.

- If there are any members in such a `struct` that represent "system value" inputs or outputs, then these would need to be transformed into the equivalent `gl_*` variables.

This change adds a more complete scalarization process that applies to inputs/outputs during the legalization pass. In order to support this there is a little bit of a data strcuture for abstracting over tuples of values (this same idiom is used in a few other places, so perhaps the implementation could be done once and shared?).

System values are current handled in a painfully ad hoc (and incomplete) fashion during code emit. We need to come up with a better solution for mapping HLSL `SV_*` semantics over to `gl_*` variables.
In some cases this mapping might introduce more code than we can easily deal with during emit time, so it probably needs to be handled back at the IR level.

This implementation has many gaps, but it appears to be enough to get teh `render/cross-compile-entry-point` test working with IR-based cross-compilation.