### PR TITLE
Fix output for type cast when checking fails

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -1563,6 +1563,20 @@ struct EmitVisitor
         Emit(")");
     }
 
+    void emitTypeOrExpr(
+        Type*   type,
+        Expr*   expr)
+    {
+        if (type && !type->As<ErrorType>())
+        {
+            EmitType(type);
+        }
+        else
+        {
+            emitTypeBasedOnExpr(expr, nullptr);
+        }
+    }
+
     void emitSimpleConstructorCallExpr(
         RefPtr<InvokeExpr>  callExpr,
         EOpInfo             outerPrec)
@@ -1576,7 +1590,7 @@ struct EmitVisitor
                 bool needClose = MaybeEmitParens(outerPrec, prec);
 
                 Emit("(");
-                EmitType(callExpr->type);
+                emitTypeOrExpr(callExpr->type.type, callExpr->FunctionExpr);
                 Emit(") ");
 
                 EmitExprWithPrecedence(callExpr->Arguments[0], rightSide(outerPrec, prec));
@@ -1592,7 +1606,7 @@ struct EmitVisitor
         auto prec = kEOp_Postfix;
         bool needClose = MaybeEmitParens(outerPrec, prec);
 
-        EmitType(callExpr->type);
+        emitTypeOrExpr(callExpr->type.type, callExpr->FunctionExpr);
 
         emitSimpleCallArgs(callExpr);
 


### PR DESCRIPTION
Fixes #237

There were some cases where we would try to emit an `ErrorType` to the output HLSL, which obviously isn't allowed. This change tries to avoid emitting error types, and instead use the original expression when it is available.

I tried adding a test case for the change, but I can't convince Slang to output matching line numbers for the error message; it seems like more work is needed on that front.