### PR TITLE
Rename existing ParameterBlock to ParameterGroup

### DIFF
--- a/source/slang/bytecode.cpp
+++ b/source/slang/bytecode.cpp
@@ -651,7 +651,7 @@ BytecodeGenerationPtr<char> tryGenerateNameForSymbol(
     if (auto highLevelDeclDecoration = inst->findDecoration<IRHighLevelDeclDecoration>())
     {
         auto decl = highLevelDeclDecoration->decl;
-        if (auto reflectionNameMod = decl->FindModifier<ParameterBlockReflectionName>())
+        if (auto reflectionNameMod = decl->FindModifier<ParameterGroupReflectionName>())
         {
             return allocateString(context, reflectionNameMod->name);
         }

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -150,8 +150,8 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
     }
 }
 
-sb << "__generic<T> __magic_type(GLSLInputParameterBlockType) struct __GLSLInputParameterBlock {};\n";
-sb << "__generic<T> __magic_type(GLSLOutputParameterBlockType) struct __GLSLOutputParameterBlock {};\n";
+sb << "__generic<T> __magic_type(GLSLInputParameterGroupType) struct __GLSLInputParameterGroup {};\n";
+sb << "__generic<T> __magic_type(GLSLOutputParameterGroupType) struct __GLSLOutputParameterGroup {};\n";
 sb << "__generic<T> __magic_type(GLSLShaderStorageBufferType) struct __GLSLShaderStorageBuffer {};\n";
 
 sb << "__magic_type(SamplerState," << int(SamplerStateType::Flavor::SamplerState) << ") struct sampler {};";

--- a/source/slang/glsl.meta.slang.h
+++ b/source/slang/glsl.meta.slang.h
@@ -151,8 +151,8 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
     }
 }
 
-sb << "__generic<T> __magic_type(GLSLInputParameterBlockType) struct __GLSLInputParameterBlock {};\n";
-sb << "__generic<T> __magic_type(GLSLOutputParameterBlockType) struct __GLSLOutputParameterBlock {};\n";
+sb << "__generic<T> __magic_type(GLSLInputParameterGroupType) struct __GLSLInputParameterGroup {};\n";
+sb << "__generic<T> __magic_type(GLSLOutputParameterGroupType) struct __GLSLOutputParameterGroup {};\n";
 sb << "__generic<T> __magic_type(GLSLShaderStorageBufferType) struct __GLSLShaderStorageBuffer {};\n";
 
 sb << "__magic_type(SamplerState," << int(SamplerStateType::Flavor::SamplerState) << ") struct sampler {};";

--- a/source/slang/lower.cpp
+++ b/source/slang/lower.cpp
@@ -3336,9 +3336,9 @@ struct LoweringVisitor
         if (!typeLayout)
             return nullptr;
 
-        while (auto parameterBlockTypeLayout = typeLayout.As<ParameterBlockTypeLayout>())
+        while (auto parameterGroupTypeLayout = typeLayout.As<ParameterGroupTypeLayout>())
         {
-            typeLayout = parameterBlockTypeLayout->elementTypeLayout;
+            typeLayout = parameterGroupTypeLayout->elementTypeLayout;
         }
 
         while (auto arrayTypeLayout = typeLayout.As<ArrayTypeLayout>())
@@ -3414,7 +3414,7 @@ struct LoweringVisitor
             shared->loweredDecls.Add(decl, tupleDecl);
             return tupleDecl;
         }
-        if (auto bufferType = loweredType->As<UniformParameterBlockType>())
+        if (auto bufferType = loweredType->As<UniformParameterGroupType>())
         {
             auto varLayout = tryToFindLayout(decl).As<VarLayout>();
 

--- a/source/slang/modifier-defs.h
+++ b/source/slang/modifier-defs.h
@@ -144,11 +144,11 @@ SIMPLE_SYNTAX_CLASS(GLSLPatchModifier    , SimpleModifier)
 
 // Indicates that this is a variable declaration that corresponds to
 // a parameter block declaration in the source program.
-SIMPLE_SYNTAX_CLASS(ImplicitParameterBlockVariableModifier   , Modifier)
+SIMPLE_SYNTAX_CLASS(ImplicitParameterGroupVariableModifier   , Modifier)
 
 // Indicates that this is a type that corresponds to the element
 // type of a parameter block declaration in the source program.
-SIMPLE_SYNTAX_CLASS(ImplicitParameterBlockElementTypeModifier, Modifier)
+SIMPLE_SYNTAX_CLASS(ImplicitParameterGroupElementTypeModifier, Modifier)
 
 // An HLSL semantic
 ABSTRACT_SYNTAX_CLASS(HLSLSemantic, Modifier)
@@ -197,7 +197,7 @@ SYNTAX_CLASS(GLSLExtensionDirective, GLSLPreprocessorDirective)
     FIELD(Token, dispositionToken)
 END_SYNTAX_CLASS()
 
-SYNTAX_CLASS(ParameterBlockReflectionName, Modifier)
+SYNTAX_CLASS(ParameterGroupReflectionName, Modifier)
     FIELD(NameLoc, nameAndLoc)
 END_SYNTAX_CLASS()
 

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -379,7 +379,7 @@ static bool findLayoutArg(
 
 static Name* getReflectionName(VarDeclBase* varDecl)
 {
-    if (auto reflectionNameModifier = varDecl->FindModifier<ParameterBlockReflectionName>())
+    if (auto reflectionNameModifier = varDecl->FindModifier<ParameterGroupReflectionName>())
         return reflectionNameModifier->nameAndLoc.name;
 
     return varDecl->getName();
@@ -398,7 +398,7 @@ RefPtr<Type> tryGetEffectiveTypeForGLSLVaryingInput(
         return nullptr;
 
     auto type = varDecl->getType();
-    if( varDecl->HasModifier<InModifier>() || type->As<GLSLInputParameterBlockType>())
+    if( varDecl->HasModifier<InModifier>() || type->As<GLSLInputParameterGroupType>())
     {
         // Special case to handle "arrayed" shader inputs, as used
         // for Geometry and Hull input
@@ -436,7 +436,7 @@ RefPtr<Type> tryGetEffectiveTypeForGLSLVaryingOutput(
         return nullptr;
 
     auto type = varDecl->getType();
-    if( varDecl->HasModifier<OutModifier>() || type->As<GLSLOutputParameterBlockType>())
+    if( varDecl->HasModifier<OutModifier>() || type->As<GLSLOutputParameterGroupType>())
     {
         // Special case to handle "arrayed" shader outputs, as used
         // for Hull Shader output
@@ -1699,7 +1699,7 @@ void generateParameterBindings(
     // up a global constant buffer type layout to hold them
     if( anyGlobalUniforms )
     {
-        auto globalConstantBufferLayout = createParameterBlockTypeLayout(
+        auto globalConstantBufferLayout = createParameterGroupTypeLayout(
             nullptr,
             globalScopeRules,
             globalScopeRules->GetObjectLayout(ShaderParameterKind::ConstantBuffer),

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -1718,16 +1718,16 @@ namespace Slang
         auto reflectionNameToken = parser->ReadToken(TokenType::Identifier);
 
         // Attach the reflection name to the block so we can use it
-        auto reflectionNameModifier = new ParameterBlockReflectionName();
+        auto reflectionNameModifier = new ParameterGroupReflectionName();
         reflectionNameModifier->nameAndLoc = NameLoc(reflectionNameToken);
         addModifier(bufferVarDecl, reflectionNameModifier);
 
         // Both the buffer variable and its type need to have names generated
-        bufferVarDecl->nameAndLoc.name = generateName(parser, "parameterBlock_" + reflectionNameToken.Content);
-        bufferDataTypeDecl->nameAndLoc.name = generateName(parser, "ParameterBlock_" + reflectionNameToken.Content);
+        bufferVarDecl->nameAndLoc.name = generateName(parser, "parameterGroup_" + reflectionNameToken.Content);
+        bufferDataTypeDecl->nameAndLoc.name = generateName(parser, "ParameterGroup_" + reflectionNameToken.Content);
 
-        addModifier(bufferDataTypeDecl, new ImplicitParameterBlockElementTypeModifier());
-        addModifier(bufferVarDecl, new ImplicitParameterBlockVariableModifier());
+        addModifier(bufferDataTypeDecl, new ImplicitParameterGroupElementTypeModifier());
+        addModifier(bufferVarDecl, new ImplicitParameterGroupVariableModifier());
 
         // TODO(tfoley): We end up constructing unchecked syntax here that
         // is expected to type check into the right form, but it might be
@@ -1855,12 +1855,12 @@ namespace Slang
         else if( auto inMod = modifiers.findModifier<InModifier>() )
         {
             removeModifier(modifiers, inMod);
-            blockWrapperTypeName = "__GLSLInputParameterBlock";
+            blockWrapperTypeName = "__GLSLInputParameterGroup";
         }
         else if( auto outMod = modifiers.findModifier<OutModifier>() )
         {
             removeModifier(modifiers, outMod);
-            blockWrapperTypeName = "__GLSLOutputParameterBlock";
+            blockWrapperTypeName = "__GLSLOutputParameterGroup";
         }
         else if( auto bufferMod = modifiers.findModifier<GLSLBufferModifier>() )
         {
@@ -1879,11 +1879,11 @@ namespace Slang
         RefPtr<StructDecl> blockDataTypeDecl = new StructDecl();
         RefPtr<Variable> blockVarDecl = new Variable();
 
-        addModifier(blockDataTypeDecl, new ImplicitParameterBlockElementTypeModifier());
-        addModifier(blockVarDecl, new ImplicitParameterBlockVariableModifier());
+        addModifier(blockDataTypeDecl, new ImplicitParameterGroupElementTypeModifier());
+        addModifier(blockVarDecl, new ImplicitParameterGroupVariableModifier());
 
         // Attach the reflection name to the block so we can use it
-        auto reflectionNameModifier = new ParameterBlockReflectionName();
+        auto reflectionNameModifier = new ParameterGroupReflectionName();
         reflectionNameModifier->nameAndLoc = NameLoc(reflectionNameToken);
         addModifier(blockVarDecl, reflectionNameModifier);
 
@@ -1892,7 +1892,7 @@ namespace Slang
         parser->FillPosition(blockVarDecl.Ptr());
 
         // Generate a unique name for the data type
-        blockDataTypeDecl->nameAndLoc.name = generateName(parser, "ParameterBlock_" + reflectionNameToken.Content);
+        blockDataTypeDecl->nameAndLoc.name = generateName(parser, "ParameterGroup_" + reflectionNameToken.Content);
 
         // TODO(tfoley): We end up constructing unchecked syntax here that
         // is expected to type check into the right form, but it might be
@@ -1937,7 +1937,7 @@ namespace Slang
         else
         {
             // synthesize a dummy name
-            blockVarDecl->nameAndLoc.name = generateName(parser, "parameterBlock_" + reflectionNameToken.Content);
+            blockVarDecl->nameAndLoc.name = generateName(parser, "parameterGroup_" + reflectionNameToken.Content);
 
             // Otherwise we have a transparent declaration, similar
             // to an HLSL `cbuffer`

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -502,7 +502,7 @@ SLANG_API SlangReflectionTypeLayout* spReflectionTypeLayout_GetElementTypeLayout
     {
         return (SlangReflectionTypeLayout*) arrayTypeLayout->elementTypeLayout.Ptr();
     }
-    else if( auto constantBufferTypeLayout = dynamic_cast<ParameterBlockTypeLayout*>(typeLayout))
+    else if( auto constantBufferTypeLayout = dynamic_cast<ParameterGroupTypeLayout*>(typeLayout))
     {
         return convert(constantBufferTypeLayout->elementTypeLayout.Ptr());
     }
@@ -569,7 +569,7 @@ SLANG_API char const* spReflectionVariable_GetName(SlangReflectionVariable* inVa
 
     // If the variable is one that has an "external" name that is supposed
     // to be exposed for reflection, then report it here
-    if(auto reflectionNameMod = var->FindModifier<ParameterBlockReflectionName>())
+    if(auto reflectionNameMod = var->FindModifier<ParameterGroupReflectionName>())
         return getText(reflectionNameMod->nameAndLoc.name).Buffer();
 
     return getText(var->getName()).Buffer();
@@ -680,9 +680,9 @@ namespace Slang
 {
     static unsigned getParameterCount(RefPtr<TypeLayout> typeLayout)
     {
-        if(auto parameterBlockLayout = typeLayout.As<ParameterBlockTypeLayout>())
+        if(auto parameterGroupLayout = typeLayout.As<ParameterGroupTypeLayout>())
         {
-            typeLayout = parameterBlockLayout->elementTypeLayout;
+            typeLayout = parameterGroupLayout->elementTypeLayout;
         }
 
         if(auto structLayout = typeLayout.As<StructTypeLayout>())
@@ -695,9 +695,9 @@ namespace Slang
 
     static VarLayout* getParameterByIndex(RefPtr<TypeLayout> typeLayout, unsigned index)
     {
-        if(auto parameterBlockLayout = typeLayout.As<ParameterBlockTypeLayout>())
+        if(auto parameterGroupLayout = typeLayout.As<ParameterGroupTypeLayout>())
         {
-            typeLayout = parameterBlockLayout->elementTypeLayout;
+            typeLayout = parameterGroupLayout->elementTypeLayout;
         }
 
         if(auto structLayout = typeLayout.As<StructTypeLayout>())

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -595,8 +595,8 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
             CASE(ConstantBuffer, ConstantBufferType)
             CASE(TextureBuffer, TextureBufferType)
-            CASE(GLSLInputParameterBlockType, GLSLInputParameterBlockType)
-            CASE(GLSLOutputParameterBlockType, GLSLOutputParameterBlockType)
+            CASE(GLSLInputParameterGroupType, GLSLInputParameterGroupType)
+            CASE(GLSLOutputParameterGroupType, GLSLOutputParameterGroupType)
             CASE(GLSLShaderStorageBufferType, GLSLShaderStorageBufferType)
 
             CASE(HLSLStructuredBufferType, HLSLStructuredBufferType)

--- a/source/slang/type-defs.h
+++ b/source/slang/type-defs.h
@@ -278,24 +278,24 @@ SIMPLE_SYNTAX_CLASS(GLSLInputAttachmentType, DeclRefType)
 
 // Base class for types used when desugaring parameter block
 // declarations, includeing HLSL `cbuffer` or GLSL `uniform` blocks.
-SIMPLE_SYNTAX_CLASS(ParameterBlockType, PointerLikeType)
+SIMPLE_SYNTAX_CLASS(ParameterGroupType, PointerLikeType)
 
-SIMPLE_SYNTAX_CLASS(UniformParameterBlockType, ParameterBlockType)
-SIMPLE_SYNTAX_CLASS(VaryingParameterBlockType, ParameterBlockType)
+SIMPLE_SYNTAX_CLASS(UniformParameterGroupType, ParameterGroupType)
+SIMPLE_SYNTAX_CLASS(VaryingParameterGroupType, ParameterGroupType)
 
 // type for HLSL `cbuffer` declarations, and `ConstantBuffer<T>`
 // ALso used for GLSL `uniform` blocks.
-SIMPLE_SYNTAX_CLASS(ConstantBufferType, UniformParameterBlockType)
+SIMPLE_SYNTAX_CLASS(ConstantBufferType, UniformParameterGroupType)
 
 // type for HLSL `tbuffer` declarations, and `TextureBuffer<T>`
-SIMPLE_SYNTAX_CLASS(TextureBufferType, UniformParameterBlockType)
+SIMPLE_SYNTAX_CLASS(TextureBufferType, UniformParameterGroupType)
 
 // type for GLSL `in` and `out` blocks
-SIMPLE_SYNTAX_CLASS(GLSLInputParameterBlockType, VaryingParameterBlockType)
-SIMPLE_SYNTAX_CLASS(GLSLOutputParameterBlockType, VaryingParameterBlockType)
+SIMPLE_SYNTAX_CLASS(GLSLInputParameterGroupType, VaryingParameterGroupType)
+SIMPLE_SYNTAX_CLASS(GLSLOutputParameterGroupType, VaryingParameterGroupType)
 
 // type for GLLSL `buffer` blocks
-SIMPLE_SYNTAX_CLASS(GLSLShaderStorageBufferType, UniformParameterBlockType)
+SIMPLE_SYNTAX_CLASS(GLSLShaderStorageBufferType, UniformParameterGroupType)
 
 SYNTAX_CLASS(ArrayExpressionType, Type)
     SYNTAX_FIELD(RefPtr<Type>, baseType)

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -687,8 +687,8 @@ SimpleLayoutInfo GetSimpleLayoutImpl(
     return info;
 }
 
-static SimpleLayoutInfo getParameterBlockLayoutInfo(
-    RefPtr<ParameterBlockType>  type,
+static SimpleLayoutInfo getParameterGroupLayoutInfo(
+    RefPtr<ParameterGroupType>  type,
     LayoutRulesImpl*            rules)
 {
     if( type->As<ConstantBufferType>() )
@@ -706,11 +706,11 @@ static SimpleLayoutInfo getParameterBlockLayoutInfo(
     // TODO: the vertex-input and fragment-output cases should
     // only actually apply when we are at the appropriate stage in
     // the pipeline...
-    else if( type->As<GLSLInputParameterBlockType>() )
+    else if( type->As<GLSLInputParameterGroupType>() )
     {
         return SimpleLayoutInfo(LayoutResourceKind::VertexInput, 0);
     }
-    else if( type->As<GLSLOutputParameterBlockType>() )
+    else if( type->As<GLSLOutputParameterGroupType>() )
     {
         return SimpleLayoutInfo(LayoutResourceKind::FragmentOutput, 0);
     }
@@ -738,19 +738,19 @@ RefPtr<TypeLayout> createTypeLayout(
     Type*               type,
     SimpleLayoutInfo    offset);
 
-RefPtr<ParameterBlockTypeLayout>
-createParameterBlockTypeLayout(
+RefPtr<ParameterGroupTypeLayout>
+createParameterGroupTypeLayout(
     TypeLayoutContext*          context,
-    RefPtr<ParameterBlockType>  parameterBlockType,
-    SimpleLayoutInfo            parameterBlockInfo,
+    RefPtr<ParameterGroupType>  parameterGroupType,
+    SimpleLayoutInfo            parameterGroupInfo,
     RefPtr<TypeLayout>          elementTypeLayout)
 {
-    auto parameterBlockRules = context->rules;
+    auto parameterGroupRules = context->rules;
 
-    auto typeLayout = new ParameterBlockTypeLayout();
+    auto typeLayout = new ParameterGroupTypeLayout();
 
-    typeLayout->type = parameterBlockType;
-    typeLayout->rules = parameterBlockRules;
+    typeLayout->type = parameterGroupType;
+    typeLayout->rules = parameterGroupRules;
 
     typeLayout->elementTypeLayout = elementTypeLayout;
 
@@ -759,7 +759,7 @@ createParameterBlockTypeLayout(
     // originally (which should be a single binding "slot"
     // and hence no uniform data).
     // 
-    typeLayout->uniformAlignment = parameterBlockInfo.alignment;
+    typeLayout->uniformAlignment = parameterGroupInfo.alignment;
     SLANG_RELEASE_ASSERT(!typeLayout->FindResourceInfo(LayoutResourceKind::Uniform));
     SLANG_RELEASE_ASSERT(typeLayout->uniformAlignment == 1);
 
@@ -773,11 +773,11 @@ createParameterBlockTypeLayout(
 
     // Make sure that we allocate resource usage for the
     // parameter block itself.
-    if( parameterBlockInfo.size )
+    if( parameterGroupInfo.size )
     {
         typeLayout->addResourceUsage(
-            parameterBlockInfo.kind,
-            parameterBlockInfo.size);
+            parameterGroupInfo.kind,
+            parameterGroupInfo.size);
     }
 
     // Now, if the element type itself had any resources, then
@@ -797,49 +797,49 @@ createParameterBlockTypeLayout(
     return typeLayout;
 }
 
-RefPtr<ParameterBlockTypeLayout>
-createParameterBlockTypeLayout(
-    RefPtr<ParameterBlockType>  parameterBlockType,
-    LayoutRulesImpl*            parameterBlockRules,
-    SimpleLayoutInfo            parameterBlockInfo,
+RefPtr<ParameterGroupTypeLayout>
+createParameterGroupTypeLayout(
+    RefPtr<ParameterGroupType>  parameterGroupType,
+    LayoutRulesImpl*            parameterGroupRules,
+    SimpleLayoutInfo            parameterGroupInfo,
     RefPtr<TypeLayout>          elementTypeLayout)
 {
     TypeLayoutContext context;
-    context.rules = parameterBlockRules;
-    context.matrixLayoutMode = parameterBlockRules->getDefaultMatrixLayoutMode();
+    context.rules = parameterGroupRules;
+    context.matrixLayoutMode = parameterGroupRules->getDefaultMatrixLayoutMode();
 
-    return createParameterBlockTypeLayout(
+    return createParameterGroupTypeLayout(
         &context,
-        parameterBlockType,
-        parameterBlockInfo,
+        parameterGroupType,
+        parameterGroupInfo,
         elementTypeLayout);
 }
 
-RefPtr<ParameterBlockTypeLayout>
-createParameterBlockTypeLayout(
+RefPtr<ParameterGroupTypeLayout>
+createParameterGroupTypeLayout(
     TypeLayoutContext*          context,
-    RefPtr<ParameterBlockType>  parameterBlockType,
+    RefPtr<ParameterGroupType>  parameterGroupType,
     RefPtr<Type>                elementType,
     LayoutRulesImpl*            elementTypeRules)
 {
-    auto parameterBlockRules = context->rules;
+    auto parameterGroupRules = context->rules;
 
     // First compute resource usage of the block itself.
     // For now we assume that the layout of the block can
     // always be described in a `SimpleLayoutInfo` (only
     // a single resource kind consumed).
     SimpleLayoutInfo info;
-    if (parameterBlockType)
+    if (parameterGroupType)
     {
-        info = getParameterBlockLayoutInfo(
-            parameterBlockType,
-            parameterBlockRules);
+        info = getParameterGroupLayoutInfo(
+            parameterGroupType,
+            parameterGroupRules);
     }
     else
     {
         // If there is no concrete type, then it seems like we are
         // being asked to compute layout for the global scope
-        info = parameterBlockRules->GetObjectLayout(ShaderParameterKind::ConstantBuffer);
+        info = parameterGroupRules->GetObjectLayout(ShaderParameterKind::ConstantBuffer);
     }
 
     // Now compute a layout for the elements of the parameter block.
@@ -854,34 +854,34 @@ createParameterBlockTypeLayout(
         elementType,
         info);
 
-    return createParameterBlockTypeLayout(
+    return createParameterGroupTypeLayout(
         context,
-        parameterBlockType,
+        parameterGroupType,
         info,
         elementTypeLayout);
 }
 
 LayoutRulesImpl* getParameterBufferElementTypeLayoutRules(
-    RefPtr<ParameterBlockType>  parameterBlockType,
+    RefPtr<ParameterGroupType>  parameterGroupType,
     LayoutRulesImpl*            rules)
 {
-    if( parameterBlockType->As<ConstantBufferType>() )
+    if( parameterGroupType->As<ConstantBufferType>() )
     {
         return rules->getLayoutRulesFamily()->getConstantBufferRules();
     }
-    else if( parameterBlockType->As<TextureBufferType>() )
+    else if( parameterGroupType->As<TextureBufferType>() )
     {
         return rules->getLayoutRulesFamily()->getTextureBufferRules();
     }
-    else if( parameterBlockType->As<GLSLInputParameterBlockType>() )
+    else if( parameterGroupType->As<GLSLInputParameterGroupType>() )
     {
         return rules->getLayoutRulesFamily()->getVaryingInputRules();
     }
-    else if( parameterBlockType->As<GLSLOutputParameterBlockType>() )
+    else if( parameterGroupType->As<GLSLOutputParameterGroupType>() )
     {
         return rules->getLayoutRulesFamily()->getVaryingOutputRules();
     }
-    else if( parameterBlockType->As<GLSLShaderStorageBufferType>() )
+    else if( parameterGroupType->As<GLSLShaderStorageBufferType>() )
     {
         return rules->getLayoutRulesFamily()->getShaderStorageBufferRules();
     }
@@ -892,23 +892,23 @@ LayoutRulesImpl* getParameterBufferElementTypeLayoutRules(
     }
 }
 
-RefPtr<ParameterBlockTypeLayout>
-createParameterBlockTypeLayout(
+RefPtr<ParameterGroupTypeLayout>
+createParameterGroupTypeLayout(
     TypeLayoutContext*          context,
-    RefPtr<ParameterBlockType>  parameterBlockType)
+    RefPtr<ParameterGroupType>  parameterGroupType)
 {
-    auto parameterBlockRules = context->rules;
+    auto parameterGroupRules = context->rules;
 
     // Determine the layout rules to use for the contents of the block
     auto elementTypeRules = getParameterBufferElementTypeLayoutRules(
-        parameterBlockType,
-        parameterBlockRules);
+        parameterGroupType,
+        parameterGroupRules);
 
-    auto elementType = parameterBlockType->elementType;
+    auto elementType = parameterGroupType->elementType;
 
-    return createParameterBlockTypeLayout(
+    return createParameterGroupTypeLayout(
         context,
-        parameterBlockType,
+        parameterGroupType,
         elementType,
         elementTypeRules);
 }
@@ -1017,14 +1017,14 @@ SimpleLayoutInfo GetLayoutImpl(
 {
     auto rules = context->rules;
 
-    if (auto parameterBlockType = type->As<ParameterBlockType>())
+    if (auto parameterGroupType = type->As<ParameterGroupType>())
     {
         // If the user is just interested in uniform layout info,
         // then this is easy: a `ConstantBuffer<T>` is really no
         // different from a `Texture2D<U>` in terms of how it
         // should be handled as a member of a container.
         //
-        auto info = getParameterBlockLayoutInfo(parameterBlockType, rules);
+        auto info = getParameterGroupLayoutInfo(parameterGroupType, rules);
 
         // The more interesting case, though, is when the user
         // is requesting us to actually create a `TypeLayout`,
@@ -1039,9 +1039,9 @@ SimpleLayoutInfo GetLayoutImpl(
         //
         if (outTypeLayout)
         {
-            *outTypeLayout = createParameterBlockTypeLayout(
+            *outTypeLayout = createParameterGroupTypeLayout(
                 context,
-                parameterBlockType);
+                parameterGroupType);
         }
 
         return info;

--- a/source/slang/type-layout.h
+++ b/source/slang/type-layout.h
@@ -296,7 +296,7 @@ public:
 };
 
 // type layout for a variable that has a constant-buffer type
-class ParameterBlockTypeLayout : public TypeLayout
+class ParameterGroupTypeLayout : public TypeLayout
 {
 public:
     RefPtr<TypeLayout> elementTypeLayout;
@@ -391,7 +391,7 @@ public:
     // We store a layout for the declarations at the global
     // scope. Note that this will *either* be a single
     // `StructTypeLayout` with the fields stored directly,
-    // or it will be a single `ParameterBlockTypeLayout`,
+    // or it will be a single `ParameterGroupTypeLayout`,
     // where the global-scope fields are the members of
     // that constant buffer.
     //
@@ -571,30 +571,30 @@ RefPtr<TypeLayout> CreateTypeLayout(Type* type, LayoutRulesImpl* rules, SimpleLa
 struct TypeLayoutContext;
 
 // Create a type layout for a parameter block type.
-RefPtr<ParameterBlockTypeLayout>
-createParameterBlockTypeLayout(
+RefPtr<ParameterGroupTypeLayout>
+createParameterGroupTypeLayout(
     TypeLayoutContext*          context,
-    RefPtr<ParameterBlockType>  parameterBlockType);
+    RefPtr<ParameterGroupType>  parameterGroupType);
 
-RefPtr<ParameterBlockTypeLayout>
-createParameterBlockTypeLayout(
+RefPtr<ParameterGroupTypeLayout>
+createParameterGroupTypeLayout(
     TypeLayoutContext*          context,
-    RefPtr<ParameterBlockType>  parameterBlockType,
+    RefPtr<ParameterGroupType>  parameterGroupType,
     RefPtr<Type>                elementType,
     LayoutRulesImpl*            elementTypeRules);
 
-RefPtr<ParameterBlockTypeLayout>
-createParameterBlockTypeLayout(
+RefPtr<ParameterGroupTypeLayout>
+createParameterGroupTypeLayout(
     TypeLayoutContext*          context,
-    RefPtr<ParameterBlockType>  parameterBlockType,
-    SimpleLayoutInfo            parameterBlockInfo,
+    RefPtr<ParameterGroupType>  parameterGroupType,
+    SimpleLayoutInfo            parameterGroupInfo,
     RefPtr<TypeLayout>          elementTypeLayout);
 
-RefPtr<ParameterBlockTypeLayout>
-createParameterBlockTypeLayout(
-    RefPtr<ParameterBlockType>  parameterBlockType,
-    LayoutRulesImpl*            parameterBlockRules,
-    SimpleLayoutInfo            parameterBlockInfo,
+RefPtr<ParameterGroupTypeLayout>
+createParameterGroupTypeLayout(
+    RefPtr<ParameterGroupType>  parameterGroupType,
+    LayoutRulesImpl*            parameterGroupRules,
+    SimpleLayoutInfo            parameterGroupInfo,
     RefPtr<TypeLayout>          elementTypeLayout);
 
 // Create a type layout for a structured buffer type.

--- a/tests/bugs/gh-171.slang
+++ b/tests/bugs/gh-171.slang
@@ -17,12 +17,12 @@ float4 main(float2 uv: UV) : SV_Target
 
 #else
 
-Texture2D SLANG_parameterBlock_C_t : register(t0);
-SamplerState SLANG_parameterBlock_C_s : register(s0);
+Texture2D SLANG_parameterGroup_C_t : register(t0);
+SamplerState SLANG_parameterGroup_C_s : register(s0);
 
 float4 main(float2 uv: UV) : SV_Target
 {
-	return SLANG_parameterBlock_C_t.Sample(SLANG_parameterBlock_C_s, uv);
+	return SLANG_parameterGroup_C_t.Sample(SLANG_parameterGroup_C_s, uv);
 }
 
 #endif

--- a/tests/bugs/gh-172.slang
+++ b/tests/bugs/gh-172.slang
@@ -26,14 +26,14 @@ cbuffer C : register(b0)
 	float2 uv;
 };
 
-Texture2D SLANG_parameterBlock_C_t0 : register(t0);
-Texture2D SLANG_parameterBlock_C_t1 : register(t1);
-SamplerState SLANG_parameterBlock_C_s : register(s0);
+Texture2D SLANG_parameterGroup_C_t0 : register(t0);
+Texture2D SLANG_parameterGroup_C_t1 : register(t1);
+SamplerState SLANG_parameterGroup_C_s : register(s0);
 
 float4 main() : SV_Target
 {
-	return SLANG_parameterBlock_C_t0.Sample(SLANG_parameterBlock_C_s, uv)
-	     + SLANG_parameterBlock_C_t1.Sample(SLANG_parameterBlock_C_s, uv);
+	return SLANG_parameterGroup_C_t0.Sample(SLANG_parameterGroup_C_s, uv)
+	     + SLANG_parameterGroup_C_t1.Sample(SLANG_parameterGroup_C_s, uv);
 }
 
 #endif

--- a/tests/rewriter/resources-in-structs.glsl
+++ b/tests/rewriter/resources-in-structs.glsl
@@ -42,10 +42,10 @@ uniform U
 };
 
 layout(binding = 1)
-uniform texture2D SLANG_parameterBlock_U_m_t;
+uniform texture2D SLANG_parameterGroup_U_m_t;
 
 layout(binding = 2)
-uniform sampler SLANG_parameterBlock_U_m_s;
+uniform sampler SLANG_parameterGroup_U_m_s;
 
 layout(location = 0)
 in vec2 uv;
@@ -58,8 +58,8 @@ void main()
 	Material SLANG_tmp_0 = m;
 	color = evaluateMaterial(
 		SLANG_tmp_0,
-		SLANG_parameterBlock_U_m_t,
-		SLANG_parameterBlock_U_m_s, uv);
+		SLANG_parameterGroup_U_m_t,
+		SLANG_parameterGroup_U_m_s, uv);
 }
 
 #endif

--- a/tests/rewriter/type-splitting.hlsl
+++ b/tests/rewriter/type-splitting.hlsl
@@ -47,12 +47,12 @@ cbuffer C
 	Foo foo;
 }
 
-Texture2D    SLANG_parameterBlock_C_foo_t;
-SamplerState SLANG_parameterBlock_C_foo_s;
+Texture2D    SLANG_parameterGroup_C_foo_t;
+SamplerState SLANG_parameterGroup_C_foo_s;
 
 float4 main() : SV_Target
 {
-	return SLANG_parameterBlock_C_foo_t.Sample(SLANG_parameterBlock_C_foo_s, foo.u);	
+	return SLANG_parameterGroup_C_foo_t.Sample(SLANG_parameterGroup_C_foo_s, foo.u);	
 }
 
 #endif


### PR DESCRIPTION
We are planning to add a new `ParameterBlock<T>` type, which maps to the notion of a "parameter block" as used in the Spire research work.
Unfortunately, the compiler codebase already uses the term `ParameterBlock` as catch-all to encompass all of HLSL `cbuffer`/`tbuffer` and GLSL `uniform`/`buffer`/`in`/`out` blocks (all of which are lexical `{}`-enclosed blocks that define parameters...).

This change instead renames all of the existing concepts over to `ParameterGroup`, which isn't an ideal name, but at least doesn't directly overlap the new terminology or any existing terminology.

The new `ParameterBlockType` case will probably be a subclass of `ParameterGroupType`, since it is a logical extension of the underlying concept.