### PR TITLE
Fix #248

### DIFF
--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -318,6 +318,7 @@ DIAGNOSTIC(38003, Error, entryPointSymbolNotAFunction, "entry point '$0' must be
 
 DIAGNOSTIC(38100, Error, typeDoesntImplementInterfaceRequirement, "type '$0' does not provide required interface member '$1'")
 DIAGNOSTIC(38101, Error, thisExpressionOutsideOfTypeDecl, "'this' expression can only be used in members of an aggregate type")
+DIAGNOSTIC(38102, Error, initializerNotInsideType, "an 'init' declaration is only allowed inside a type or 'extension' declaration")
 
 //
 // 4xxxx - IL code generation.

--- a/source/slang/mangle.cpp
+++ b/source/slang/mangle.cpp
@@ -275,7 +275,12 @@ namespace Slang
                 emitType(context, GetType(paramDeclRef));
             }
 
-            emitType(context, GetResultType(callableDeclRef));
+            // Don't print result type for an initializer/constructor,
+            // since it is implicit in the qualified name.
+            if (!callableDeclRef.As<ConstructorDecl>())
+            {
+                emitType(context, GetResultType(callableDeclRef));
+            }
         }
     }
 

--- a/tools/slang-test/main.cpp
+++ b/tools/slang-test/main.cpp
@@ -674,6 +674,7 @@ TestResult runSimpleTest(TestInput& input)
     // Otherwise we compare to the expected output
     if (actualOutput != expectedOutput)
     {
+        maybeDumpOutput(expectedOutput, actualOutput);
         result = kTestResult_Fail;
     }
 
@@ -1147,6 +1148,14 @@ TestResult runComputeComparisonImpl(TestInput& input, const char * langOption, S
 	}
 
     auto actualOutput = getOutput(spawner);
+    auto expectedOutput = getExpectedOutput(outputStem);
+    if (actualOutput != expectedOutput)
+    {
+        String actualOutputPath = outputStem + ".actual";
+        Slang::File::WriteAllText(actualOutputPath, actualOutput);
+
+        return kTestResult_Fail;
+    }
 
 	// check against reference output
     if (!File::Exists(actualOutputFile))


### PR DESCRIPTION
The main fix here is to actually compute result types for constructor/initializer decls, but I also added some work on the test runner to make it a bit more usable when debugging these kinds of issues.