### PR TITLE
Cleanup of "support generic interface method".

### DIFF
--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -1609,6 +1609,15 @@ namespace Slang
                     else
                         return false;
                 }
+                else if (auto genValMbr = genMbr.As<GenericValueParamDecl>())
+                {
+                    if (auto requiredGenValMbr = requiredGenMbr.As<GenericValueParamDecl>())
+                    {
+                        return genValMbr->type->Equals(requiredGenValMbr->type);
+                    }
+                    else
+                        return false;
+                }
                 else if (auto genTypeConstraintMbr = genMbr.As<GenericTypeConstraintDecl>())
                 {
                     if (auto requiredTypeConstraintMbr = requiredGenMbr.As<GenericTypeConstraintDecl>())

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -1579,7 +1579,11 @@ void Type::accept(IValVisitor* visitor, void* extra)
                 }
             }
         }
-        return this;
+        RefPtr<DeclaredSubtypeWitness> rs = new DeclaredSubtypeWitness();
+        rs->sub = sub->SubstituteImpl(subst, ioDiff).As<Type>();
+        rs->sup = sup->SubstituteImpl(subst, ioDiff).As<Type>();
+        rs->declRef = declRef.SubstituteImpl(subst, ioDiff);
+        return rs;
     }
 
     String DeclaredSubtypeWitness::ToString()


### PR DESCRIPTION
Add a `GenericValueParamDecl` case in `doesGenericSignatureMatchRequirement()`

Return a substituted `DeclaredSubtypeWitness` in `DeclaredSubtypeWitness::SubstituteImpl()` instead of return this.

Need more work in `DeclaredSubtypeWitness::SubstituteImpl` to properly implement substitution of the `DeclaredSubTypeWitness` val into an actual` IRWitnessTable` argument value that comes from a GenericSubstitution.