### PR TITLE
Various IR fixes for Falcor

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -4743,7 +4743,13 @@ emitDeclImpl(decl, nullptr);
             switch(peek())
             {
             case 'T':
+            case 'C':
                 get();
+                break;
+
+            case 'v':
+                get();
+                readType();
                 break;
 
             default:
@@ -4862,7 +4868,9 @@ emitDeclImpl(decl, nullptr);
         UInt readParamCount()
         {
             expect("p");
-            return readCount();
+            UInt count = readCount();
+            expect("p");
+            return count;
         }
     };
 
@@ -5436,6 +5444,9 @@ emitDeclImpl(decl, nullptr);
             {
             default:
                 SLANG_UNEXPECTED("terminator inst");
+                return;
+
+            case kIROp_unreachable:
                 return;
 
             case kIROp_ReturnVal:

--- a/source/slang/ir-inst-defs.h
+++ b/source/slang/ir-inst-defs.h
@@ -184,6 +184,7 @@ INST(loopTest, loopTest, 3, 0)
 INST(switch, switch, 3, 0)
 
 INST(discard, discard, 0, 0)
+INST(unreachable, unreachable, 0, 0)
 
 INST(Add, add, 2, 0)
 INST(Sub, sub, 2, 0)

--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -138,6 +138,13 @@ struct IRReturnVoid : IRReturn
 struct IRDiscard : IRTerminatorInst
 {};
 
+// Signals that this point in the code should be unreachable.
+// We can/should emit a dataflow error if we can ever determine
+// that a block ending in one of these can actually be
+// executed.
+struct IRUnreachable : IRTerminatorInst
+{};
+
 struct IRBlock;
 
 struct IRUnconditionalBranch : IRTerminatorInst
@@ -486,6 +493,8 @@ struct IRBuilder
     IRInst* emitReturn();
 
     IRInst* emitDiscard();
+
+    IRInst* emitUnreachable();
 
     IRInst* emitBranch(
         IRBlock*    block);

--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -168,6 +168,7 @@ namespace Slang
         case kIROp_loopTest:
         case kIROp_discard:
         case kIROp_switch:
+        case kIROp_unreachable:
             return true;
         }
     }
@@ -1147,6 +1148,16 @@ namespace Slang
         auto inst = createInst<IRReturnVoid>(
             this,
             kIROp_ReturnVoid,
+            nullptr);
+        addInst(inst);
+        return inst;
+    }
+
+    IRInst* IRBuilder::emitUnreachable()
+    {
+        auto inst = createInst<IRUnreachable>(
+            this,
+            kIROp_unreachable,
             nullptr);
         addInst(inst);
         return inst;
@@ -3457,6 +3468,14 @@ namespace Slang
         return clonedFunc;
     }
 
+    IRFunc* cloneSimpleFuncWithoutRegistering(IRSpecContextBase* context, IRFunc* originalFunc)
+    {
+        auto clonedFunc = context->builder->createFunc();
+        cloneFunctionCommon(context, clonedFunc, originalFunc);
+        return clonedFunc;
+    }
+
+
     IRFunc* cloneSimpleFunc(IRSpecContextBase* context, IRFunc* originalFunc)
     {
         auto clonedFunc = context->builder->createFunc();
@@ -4017,7 +4036,7 @@ namespace Slang
 
         // TODO: other initialization is needed here...
 
-        auto specFunc = cloneSimpleFunc(&context, genericFunc);
+        auto specFunc = cloneSimpleFuncWithoutRegistering(&context, genericFunc);
 
         // Set up the clone to recognize that it is no longer generic
         specFunc->mangledName = specMangledName;

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -3242,8 +3242,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                     // this by putting an `unreachable` terminator here,
                     // and then emit a dataflow error if this block
                     // can't be eliminated.
-                    SLANG_UNEXPECTED("Needed a return here");
-                    UNREACHABLE(subContext->irBuilder->emitReturn());
+                    subContext->irBuilder->emitUnreachable();
                 }
             }
         }

--- a/source/slang/mangle.cpp
+++ b/source/slang/mangle.cpp
@@ -164,6 +164,13 @@ namespace Slang
             // parameter are they at the specified depth).
             emitName(context, genericParamIntVal->declRef.GetName());
         }
+        else if( auto constantIntVal = dynamic_cast<ConstantIntVal*>(val) )
+        {
+            // TODO: need to figure out what prefix/suffix is needed
+            // to allow demangling later.
+            emitRaw(context, "k");
+            emit(context, (UInt) constantIntVal->value);
+        }
         else
         {
             SLANG_UNEXPECTED("unimplemented case in mangling");
@@ -277,11 +284,13 @@ namespace Slang
         //
         if( auto callableDeclRef = declRef.As<CallableDecl>())
         {
-            emitRaw(context, "p");
-
             auto parameters = GetParameters(callableDeclRef);
             UInt parameterCount = parameters.Count();
+
+            emitRaw(context, "p");
             emit(context, parameterCount);
+            emitRaw(context, "p");
+
             for(auto paramDeclRef : parameters)
             {
                 emitType(context, GetType(paramDeclRef));

--- a/tests/ir/loop.slang.expected
+++ b/tests/ir/loop.slang.expected
@@ -5,11 +5,11 @@ ir_global_var @_SV01s	: Ptr<@ThreadGroup vector<float,4>[64]>;
 
 ir_global_var @_SV05input	: Ptr<StructuredBuffer<vector<float,4>>>;
 
-ir_func @_S031GroupMemoryBarrierWithGroupSyncp0V	: () -> void;
+ir_func @_S031GroupMemoryBarrierWithGroupSyncp0pV	: () -> void;
 
 ir_global_var @_SV06output	: Ptr<RWStructuredBuffer<vector<float,4>>>;
 
-ir_func @_S04mainp3uuuV	: (uint, uint, uint) -> void
+ir_func @_S04mainp3puuuV	: (uint, uint, uint) -> void
 {
 block %1(
 		param %2	: uint,
@@ -39,7 +39,7 @@ block %15:
 	loopTest(%20, %21, %16)
 
 block %21:
-	call(@_S031GroupMemoryBarrierWithGroupSyncp0V)
+	call(@_S031GroupMemoryBarrierWithGroupSyncp0pV)
 	let  %22	: uint	= load(%6)
 	let  %23	: Ptr<vector<float,4>>	= getElementPtr(@_SV01s, %22)
 	let  %24	: Ptr<vector<float,4>>	= var()
@@ -70,7 +70,7 @@ block %17:
 	unconditionalBranch(%15)
 
 block %16:
-	call(@_S031GroupMemoryBarrierWithGroupSyncp0V)
+	call(@_S031GroupMemoryBarrierWithGroupSyncp0pV)
 	let  %40	: RWStructuredBuffer<vector<float,4>>	= load(@_SV06output)
 	let  %41	: uint	= load(%5)
 	let  %42	: Ptr<vector<float,4>>	= getElementPtr(@_SV01s, 0)


### PR DESCRIPTION
- Change function mangling so we use `p<parameterCount>p` instead of just `p<parameterCount>` to avoid the parameter count running into digits at the start of a mangled type name and tripping up the un-mangling logic.
  - We really need to step back at some point and define our mangling scheme a bit more carefully, especially if we are going to keep going down this road where un-mangling things is important for generating HLSL output.

- Also allow the unmangling logic to unmangle a few more cases of generic parameters, so that it can skip over them to get to the parameter count of the underlying function.

- Add a notion of an `unreachable` instruction to the IR, and emit it as the terminator (if needed) at the end of the last block for a function with a non-void return type.
  - This does *not* implement any logic to emit a diagnostic if the `unreachable` turns out to be potentially reachable

- Fix a bug in IR specialization of generics where we can't create two different specializations of the same function, because both get registered in the same hash map

With all these fixes, testing in Falcor modified to use the full Slang compiler and IR for all HLSL/Slang:

- The UI and text rendering shaders yield HLSL that compiles without error; no idea if they actually *work*

- The ModelViewer shaders yield HLSL, but there are some issues (looks like type legalization isn't applying to stuff inside constant buffers)