### PR TITLE
Fix emitting of loop attributes for HLSL pass-through

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -2708,18 +2708,12 @@ struct EmitVisitor
 
         for(auto attr : decl->GetModifiersOfType<HLSLUncheckedAttribute>())
         {
-            if(getText(attr->getName()) == "loop")
-            {
-                Emit("[loop]");
-            }
-            else if(getText(attr->getName()) == "unroll")
-            {
-                Emit("[unroll]");
-            }
-            else if(getText(attr->getName()) == "allow_uav_condition")
-            {
-                Emit("[allow_uav_condition]");
-            }
+            // Emit whatever attributes the user might have attached,
+            // whether or not we think they make semantic sense.
+            //
+            Emit("[");
+            emit(attr->getName());
+            Emit("]");
         }
     }
 

--- a/tests/bugs/gh-295.hlsl
+++ b/tests/bugs/gh-295.hlsl
@@ -1,0 +1,40 @@
+//TEST:COMPARE_HLSL: -profile vs_4_0 -target dxbc-assembly -no-checking
+
+// Confirm that we pass through `[fastopt]` attributes
+//
+// This shader does indexing into the elements of
+// a vector, fetched from a `cbuffer`, based on
+// a loop counter (or a loop with a small trip
+// count), so `fxc` seems to want to unroll the
+// loop. The `[fastopt]` attribute changes this
+// behavior and results in a `loop` instruction
+// in the DX bytecode, so we can use this to
+// test whether Slang is passing through the
+// attribute or not.
+
+// Import Slang code so that we aren't just in
+// the 100% pass-through mode.
+#ifdef __SLANG__
+__import empty;
+#endif
+
+cbuffer C
+{
+	float4 b[4];
+}
+float test(float x, float c)
+{
+	[fastopt]
+	for(int ii = 0; ii < 2; ++ii)
+	{
+		x = x*x + c + b[ii][ii];
+	}
+	return x;
+}
+
+float4 main(float4 a : A) : SV_Position
+{
+	a.x = test(a.x, a.y);
+
+	return a;
+}


### PR DESCRIPTION
Fixes #295.

The code previously had a white list of attributes that it passed through, implemented in `emit.cpp` in an ad hoc fashion. The fix here is to just pass through whatever attributes the user wrote, and then let the downstream compiler diagnose if any of them are errorneous.