### PR TITLE
Fix substitution mechanism to remove special cases for global params

### DIFF
--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -3109,24 +3109,7 @@ namespace Slang
 
     RefPtr<Type> IRSpecContext::maybeCloneType(Type* originalType)
     {
-        auto rsType = originalType->GetCanonicalType()->Substitute(subst).As<Type>();
-        if (auto declRefType = rsType.As<DeclRefType>())
-        {
-            if (subst)
-            {
-                auto newSubst = cloneSubstitutions(this, subst);
-                insertSubstAtBottom(declRefType->declRef.substitutions, newSubst);
-            }
-        }
-        else if (auto funcType = rsType.As<FuncType>())
-        {
-            RefPtr<FuncType> newFuncType = new FuncType();
-            newFuncType->setSession(funcType->getSession());
-            newFuncType->resultType = maybeCloneType(funcType->resultType);
-            for (auto paramType : funcType->paramTypes)
-                newFuncType->paramTypes.Add(maybeCloneType(paramType));
-        }
-        return rsType;
+        return originalType->Substitute(subst).As<Type>();
     }
 
     IRValue* IRSpecContext::maybeCloneValue(IRValue* originalValue)

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -1162,6 +1162,23 @@ namespace Slang
     void removeSubstitution(DeclRefBase & declRef, RefPtr<Substitutions> subst);
     bool hasGenericSubstitutions(RefPtr<Substitutions> subst);
     RefPtr<GenericSubstitution> getGenericSubstitution(RefPtr<Substitutions> subst);
+
+    // This function substitutes the type arguments referenced in a linked list of substitutions 
+    // which head is at `substHead` using the substitutions specified by `subst`. If the linked
+    // list `substHead` does not contain `GlobalGenericParamSubstitution` entries, they will be 
+    // added to the bottom(outter most) of the linked list.
+    // Note that this function should be called when `substHead` is known to be the head of 
+    // substitution linked list because the existance of `GlobalGenericPaaramSubstitution` is 
+    // detected assuming the linked lists starts at `substHead`. If a substitution that is not 
+    // the head of a substitution linked list is passed in, duplicate 
+    // `GlobalGenericParamSubstitution`s could be appended to the linked list.
+    // This means that this function should * not* be called in places like 
+    // `GenericSubstitution::SubstitutionImpl()` for its outer substitutions, because `outer` is 
+    // obviously not the head of the linked list. Instead, use this function to substitution the 
+    // substitution lists of `DeclRef` etc. to replace the call of 
+    // `declRef.substitutions->SubstituteImpl()`, because the head to the linked list is known as a 
+    // member of that class there.
+    RefPtr<Substitutions> substituteSubstitutions(RefPtr<Substitutions> oldSubst, Substitutions * subst, int * ioDiff);
 } // namespace Slang
 
 #endif


### PR DESCRIPTION
This PR fixes the ad-hoc handling of global-generic-type substitutions introduced in #293.

# Changes
1. Add a new function:

`substituteSubstitutions(Substitutions * substHead, Substitutions subst, int * ioDiff)`
This function substitutes the type arguments referenced in a linked list of substitutions headed at `substHead` using the substitutions specified by `subst`. If the linked list `substHead` does not contain `GlobalGenericParamSubstitution` entries, they will be added to the bottom (outter most) of the linked list.

Note that this function should be called when `substHead` is known to be the head of substitution linked list because the existance of `GlobalGenericPaaramSubstitution` is detected assuming the linked lists starts at `substHead`. If a substitution that is not the head of a substitution linked list is passed in, duplicate `GlobalGenericParamSubstitution`s could be appended to the linked list.

This means that this function should *not* be called in places like `GenericSubstitution::SubstitutionImpl()` for its outer substitutions, because `outer` is obviously not the head of the linked list. Instead, use this function to substitution the substitution lists of `DeclRef` etc. instead of calling `declRef.substitutions->SubstituteImpl()` where the head to the linked list is known as a member of that class.

2. With this function, IRSpecContext::maybeCloneType() is simplified down to `originalType->Substitute(subst)`

3. Updates `DeclRefBase::SubstituteImpl` and `DeclRefType::SubstituteImpl` to call `substituteSubstitutions` instead of making direct `substitutions->SubstituteImpl` call.

4. Providing actual implementation of `GlobalGenericParamSubstitution::SubstituteImpl` instead of just returning `this` to deal with potential situations where a true substitution is needed.