### PR TITLE
Generate IR per-module for loaded modules

### DIFF
--- a/source/slang/ast-legalize.cpp
+++ b/source/slang/ast-legalize.cpp
@@ -3540,9 +3540,9 @@ struct LoweringVisitor
                 return translationUnit->sourceLanguage;
         }
 
-        for (auto loadedModuleDecl : shared->compileRequest->loadedModulesList)
+        for (auto loadedModule : shared->compileRequest->loadedModulesList)
         {
-            if (moduleDecl == loadedModuleDecl)
+            if (moduleDecl == loadedModule->moduleDecl)
                 return SourceLanguage::Slang;
         }
 
@@ -4696,7 +4696,7 @@ LoweredEntryPoint lowerEntryPoint(
     for (auto rr : entryPoint->compileRequest->loadedModulesList)
     {
         sharedContext.loweredDecls.Add(
-            rr,
+            rr->moduleDecl,
             LoweredDecl(loweredProgram));
     }
 

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -6648,8 +6648,9 @@ namespace Slang
                 globalGenericParams.Add(p);
         }
         // add imported modules
-        for (auto moduleDecl : entryPoint->compileRequest->loadedModulesList)
+        for (auto loadedModule : entryPoint->compileRequest->loadedModulesList)
         {
+            auto moduleDecl = loadedModule->moduleDecl;
             auto globalGenParams = moduleDecl->getMembersOfType<GlobalGenericParamDecl>();
             for (auto p : globalGenParams)
                 globalGenericParams.Add(p);

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -211,6 +211,19 @@ namespace Slang
         String  path;
     };
 
+    // Represents a module that has been loaded through the front-end
+    // (up through IR generation).
+    //
+    class LoadedModule : public RefObject
+    {
+    public:
+        // The AST for the module
+        RefPtr<ModuleDecl>  moduleDecl;
+
+        // The IR for the module
+        IRModule* irModule = nullptr;
+    };
+
     class Session;
 
     class CompileRequest : public RefObject
@@ -285,13 +298,13 @@ namespace Slang
         // Modules that have been dynamically loaded via `import`
         //
         // This is a list of unique modules loaded, in the order they were encountered.
-        List<RefPtr<ModuleDecl> > loadedModulesList;
+        List<RefPtr<LoadedModule> > loadedModulesList;
 
         // Map from the path of a module file to its definition
-        Dictionary<String, RefPtr<ModuleDecl>> mapPathToLoadedModule;
+        Dictionary<String, RefPtr<LoadedModule>> mapPathToLoadedModule;
 
         // Map from the logical name of a module to its definition
-        Dictionary<Name*, RefPtr<ModuleDecl>> mapNameToLoadedModules;
+        Dictionary<Name*, RefPtr<LoadedModule>> mapNameToLoadedModules;
 
 
         CompileRequest(Session* session);
@@ -343,6 +356,11 @@ namespace Slang
         void handlePoundImport(
             String const&       path,
             TokenList const&    tokens);
+
+        void loadParsedModule(
+            RefPtr<TranslationUnitRequest> const&   translationUnit,
+            Name*                                   name,
+            String const&                           path);
 
         RefPtr<ModuleDecl> findOrImportModule(
             Name*               name,

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -1648,9 +1648,9 @@ static void collectParameters(
     }
 
     // Now collect parameters from loaded modules
-    for (auto& module : request->loadedModulesList)
+    for (auto& loadedModule : request->loadedModulesList)
     {
-        collectModuleParameters(context, module.Ptr());
+        collectModuleParameters(context, loadedModule->moduleDecl.Ptr());
     }
 }
 


### PR DESCRIPTION
The basic idea here is that for each module that gets loaded via `import`, we should also generate the initial IR for the declarations in that module at the time it gets loaded.

Furthermore, when we generate initial IR for a module, we will only generate IR *declarations* (not *definitions*) for any functions/variables in modules it imports.
Later, when cloning IR to begin code generation for an entry point, we will effectively "link" all of the loadedm modules together, so that a given global value can get its definition from any of the IR modules present.

- Change the `loadedModulesList` and related data structures to hold a new `LoadedModule` type, instead of just the AST (and then have a `LoadedModule` own both the AST and the IR module)

- Share some logic between the `import` and `#import` cases, so that we always try to generate IR for modules we load.

- Make sure that IR generation always gets skipped if the command-line flags tell us not to use the IR.

- A few small fixups for cases that didn't arise in IR lowering so far, but come up when we try to actually generate IR for things like the stdlib.

There are some notable gaps in this work right now:

- The stdlib modules are exempted from this behavior; we always generate IR for stdlib functions in any user module that calls them. This is just a workaround for the fact that the stdlib modules don't show up in the list of imported modules right now.

- We don't currently have logic that does the "linking" step for global variables like we do for functions. We really need to look up the symbols with the same mangled name, and favor any one of them that has a definition (if there is one)

- Similarly, the handling of witness tables is incomplete. During initial IR generation, we should probably be generating empty witness tables for any conformances that were declared in other modules (but are being used locally in this module), and then the "linking" step should favor non-empty witness tables over empty ones.

Still, all the test cases pass with the code like this, and this seems like an important step in the right direction.