### PR TITLE
Fix parameter block binding for Vulkan

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -656,6 +656,7 @@ extern "C"
 
     SLANG_API size_t spReflectionTypeLayout_GetElementStride(SlangReflectionTypeLayout* type, SlangParameterCategory category);
     SLANG_API SlangReflectionTypeLayout* spReflectionTypeLayout_GetElementTypeLayout(SlangReflectionTypeLayout* type);
+    SLANG_API SlangReflectionVariableLayout* spReflectionTypeLayout_GetElementVarLayout(SlangReflectionTypeLayout* type);
 
     SLANG_API SlangParameterCategory spReflectionTypeLayout_GetParameterCategory(SlangReflectionTypeLayout* type);
 
@@ -945,6 +946,11 @@ namespace slang
         TypeLayoutReflection* getElementTypeLayout()
         {
             return (TypeLayoutReflection*) spReflectionTypeLayout_GetElementTypeLayout((SlangReflectionTypeLayout*) this);
+        }
+
+        VariableLayoutReflection* getElementVarLayout()
+        {
+            return (VariableLayoutReflection*)spReflectionTypeLayout_GetElementVarLayout((SlangReflectionTypeLayout*) this);
         }
 
         // How is this type supposed to be bound?

--- a/source/slang/ast-legalize.cpp
+++ b/source/slang/ast-legalize.cpp
@@ -3129,7 +3129,7 @@ struct LoweringVisitor
 
         while (auto parameterGroupTypeLayout = typeLayout.As<ParameterGroupTypeLayout>())
         {
-            typeLayout = parameterGroupTypeLayout->elementTypeLayout;
+            typeLayout = parameterGroupTypeLayout->offsetElementTypeLayout;
         }
 
         while (auto arrayTypeLayout = typeLayout.As<ArrayTypeLayout>())

--- a/source/slang/type-layout.h
+++ b/source/slang/type-layout.h
@@ -307,7 +307,24 @@ public:
 class ParameterGroupTypeLayout : public TypeLayout
 {
 public:
-    RefPtr<TypeLayout> elementTypeLayout;
+    // The layout of the "container" type itself.
+    // E.g., for a constant buffer, this would reflect
+    // the resource usage of the container, without
+    // the element type factored in.
+    RefPtr<TypeLayout>  containerTypeLayout;
+
+    // A variable layout for the element of the container.
+    // The offsets of the variable layout will reflect
+    // the offsets that need to applied to get past the
+    // container types resource usage, while the actual
+    // type layout won't have offsets applied (unlike
+    // `offsetElementTypeLayout` below).
+    RefPtr<VarLayout>   elementVarLayout;
+
+    // The layout of the element type, with offsets applied
+    // so that any fields (if the element type is a `struct`)
+    // will be offset by the resource usage of the container.
+    RefPtr<TypeLayout>  offsetElementTypeLayout;
 };
 
 // type layout for a variable that has a constant-buffer type

--- a/tests/reflection/resource-in-cbuffer.hlsl.expected
+++ b/tests/reflection/resource-in-cbuffer.hlsl.expected
@@ -6,11 +6,7 @@ standard output = {
     "parameters": [
         {
             "name": "MyConstantBuffer",
-            "bindings": [
-                {"kind": "constantBuffer", "index": 0},
-                {"kind": "shaderResource", "index": 0},
-                {"kind": "samplerState", "index": 0}
-            ],
+            "binding": {"kind": "constantBuffer", "index": 0},
             "type": {
                 "kind": "constantBuffer",
                 "elementType": {


### PR DESCRIPTION
Fixes #307

This ends up being a major overhaul over how type layout computation is structured and exposed.
The big problems all arise around cases where both the "container" for a parameter block or CB, and the "element" type both use the same kind of resource.
E.g., if you define a CB with a texture in it, then in Vulkan both the CB and the texture use the same kind of resource, and so if you query the CB's resource usage it will just tell you it uses two descriptor-table slots, but nothing more than that.

Similar confusion still arises in the HLSL case, when a CB with a texture in it reports its parameter category as "mixed" so that a user might query for a category they didn't mean to. There were also cases in the existing code where a parameter block might expose *both* a register-space usage and another concrete resource type, which isn't right.

The most important changes here are:

- A `ParameterGroupTypeLayout` now has a more refined internal structure, consisting of:
  - A `containerTypeLayout`, which represents the resource usage of the buffer/block itself (e.g., if a constant buffer had to be allocated)
  - An `elementVarLayout` which stores the offsets that need to be applied to get from the `VarLayout` for an instance of this parameter-group type to the offsets of its elements. The `TypeLayout` for this variable layout should be the "raw" type of the block/CB element.
  - The `offsetElementTypeLayout` (formerly just `elementTypeLayout`) which represents the element type, but in the case of a `struct` element type, will have fields offset similar to the `elementVarLayout`. This is what all the old code used to use, so we need to keep it for compatibility.

- When doing reflection on a `ParameterGroupTypeLayout`, we now only report the resource usage of the `containerTypeLayout`. This is technically a potentially breaking change in the public API, but I don't think Falcor will mind, since they actually want something closer to this behavior.

- Add a new public API for querying the element variable layout of a parameter block of constant buffer. This could be used by savvy applications to fold the handling of CB element offsetting into some notion of a "reflection path." This would be required for applications that want to handle CBs or parameter blocks where the element type is *not* a `struct` type.

- Remove old logic for applying an offset when creating a type layout for constant buffer element, and instead perform offsetting more uniformly later, by constructing the `offsetElementTypeLayout` from the `rawElementTypeLayout`. This is useful both because we want to keep both (the "raw" type layout becomes the type layout of the `elementVarLayout`), and also because we can decide later whether we even want to allocate a CB register for a buffer, based on whether it actually contains any uniform data.

- Fix cases where we might end up with a parameter block type reporting both that it uses a whole register space (and thus should not expose the resource usage of the container/element type) *and* a constant-buffer register/slot. The latter should be hidden inside the regsiter space.

- Clean up the `spReflectionParameter_GetBinding{Index,Space}` functions to just route to `spReflectionVariableLayout_Get{Offset,Space}`, using the "default" category of the parameter

- Try to make the `GetSpace` query take into account cases where a variable also has an explicit `RegisterSpace` allocation.
  - This probably still needs some cleanup, since ideally we'd just move things into the `space` field on the `ReosurceInfo` and have an invariant that a variable *either* has a `RegisterSpace` allocation, or it has other resource infos, but never both...

- Add some ad-hoc logic so that if the user queries for a binding index/space using a parameter category that doesn't actually apply (e.g., they query for a D3D `t` register when using Vulkan), we can optionally remap it to the resource type they "probably" meant. This is a mess of Do What I Mean code, but it is also what our users want right now.

- Fix various bits of emit logic so that if a parameter block has a register space/set allocated to it, we properly output that as part of the binding information for it.
  - This is another thing that might be cleaned up if we rationale the way that things get split during legalization.

- Add a GLSL case for emitting a parameter block variable as a `cbuffer`.