### PR TITLE
More fixups for Vulkan parameter block bindings

### DIFF
--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -581,7 +581,7 @@ SLANG_API SlangParameterCategory spReflectionTypeLayout_GetParameterCategory(Sla
 
     if (auto parameterGroupTypeLayout = dynamic_cast<ParameterGroupTypeLayout*>(typeLayout))
     {
-        typeLayout = parameterGroupTypeLayout->containerTypeLayout;
+        typeLayout = parameterGroupTypeLayout->containerVarLayout->typeLayout;
     }
 
     return getParameterCategory(typeLayout);
@@ -594,7 +594,7 @@ SLANG_API unsigned spReflectionTypeLayout_GetCategoryCount(SlangReflectionTypeLa
 
     if (auto parameterGroupTypeLayout = dynamic_cast<ParameterGroupTypeLayout*>(typeLayout))
     {
-        typeLayout = parameterGroupTypeLayout->containerTypeLayout;
+        typeLayout = parameterGroupTypeLayout->containerVarLayout->typeLayout;
     }
 
     return (unsigned) typeLayout->resourceInfos.Count();
@@ -607,7 +607,7 @@ SLANG_API SlangParameterCategory spReflectionTypeLayout_GetCategoryByIndex(Slang
 
     if (auto parameterGroupTypeLayout = dynamic_cast<ParameterGroupTypeLayout*>(typeLayout))
     {
-        typeLayout = parameterGroupTypeLayout->containerTypeLayout;
+        typeLayout = parameterGroupTypeLayout->containerVarLayout->typeLayout;
     }
 
     return typeLayout->resourceInfos[index].kind;

--- a/source/slang/type-layout.h
+++ b/source/slang/type-layout.h
@@ -307,11 +307,13 @@ public:
 class ParameterGroupTypeLayout : public TypeLayout
 {
 public:
-    // The layout of the "container" type itself.
+    // The layout of the "container" part itself.
     // E.g., for a constant buffer, this would reflect
     // the resource usage of the container, without
-    // the element type factored in.
-    RefPtr<TypeLayout>  containerTypeLayout;
+    // the element type factored in. All of the offsets
+    // for this variable should be zero, but it is included
+    // for completeness.
+    RefPtr<VarLayout>  containerVarLayout;
 
     // A variable layout for the element of the container.
     // The offsets of the variable layout will reflect

--- a/tests/bindings/glsl-parameter-blocks.slang
+++ b/tests/bindings/glsl-parameter-blocks.slang
@@ -1,0 +1,16 @@
+#version 450 core
+//TEST:CROSS_COMPILE: -profile ps_5_0 -entry main -target spirv-assembly
+
+struct Test
+{
+    float4 a;
+	Texture2D t;
+	SamplerState s;
+};
+
+ParameterBlock<Test> gTest;
+
+float4 main(float2 uv : UV)
+{
+	return gTest.a + gTest.t.Sample(gTest.s, uv);
+}

--- a/tests/bindings/glsl-parameter-blocks.slang.glsl
+++ b/tests/bindings/glsl-parameter-blocks.slang.glsl
@@ -1,0 +1,37 @@
+//TEST_IGNORE_FILE:
+#version 450 core
+
+struct Test
+{
+    vec4 a;
+};
+
+layout(binding = 0)
+uniform gTest_S1
+{
+    Test gTest;
+};
+
+layout(binding = 1)
+uniform texture2D gTest_t;
+
+layout(binding = 2)
+uniform sampler gTest_s;
+
+vec4 main_(vec2 uv)
+{
+    return gTest.a + texture(sampler2D(gTest_t, gTest_s), uv);
+}
+
+layout(location = 0)
+in vec2 SLANG_in_uv;
+
+layout(location = 0)
+out vec4 SLANG_out_main_result;
+
+void main()
+{
+    vec2 uv = SLANG_in_uv;
+    vec4 main_result = main_(uv);
+    SLANG_out_main_result = main_result;
+}


### PR DESCRIPTION
I'm adding a small cross-compilation test to try to make sure that we are testing the binding generation for GLSL output. We probably still need a more complex test that uses multiple blocks, plus variables not in a block.

The big changes here are:

- Change the `containerTypeLayout` field to a `containerVarLayout` in the `ParameterGroupTypeLayout`, so that we can store the base offsets for the fields in a uniform fashion (even though these will all be zero).

- Switch the emit logic to carefully use either the container or element var layout depending on what they are emitting bindings for. This involved adding something akin to the "reflection path" notion that Falcor has to use, but only for the emit step.