### PR TITLE
More fixups for parameter block binding generation

### DIFF
--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -574,15 +574,26 @@ static SlangParameterCategory getParameterCategory(
     return SLANG_PARAMETER_CATEGORY_MIXED;
 }
 
+static TypeLayout* maybeGetContainerLayout(TypeLayout* typeLayout)
+{
+    if (auto parameterGroupTypeLayout = dynamic_cast<ParameterGroupTypeLayout*>(typeLayout))
+    {
+        auto containerTypeLayout = parameterGroupTypeLayout->containerVarLayout->typeLayout;
+        if (containerTypeLayout->resourceInfos.Count() != 0)
+        {
+            return containerTypeLayout;
+        }
+    }
+
+    return typeLayout;
+}
+
 SLANG_API SlangParameterCategory spReflectionTypeLayout_GetParameterCategory(SlangReflectionTypeLayout* inTypeLayout)
 {
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return SLANG_PARAMETER_CATEGORY_NONE;
 
-    if (auto parameterGroupTypeLayout = dynamic_cast<ParameterGroupTypeLayout*>(typeLayout))
-    {
-        typeLayout = parameterGroupTypeLayout->containerVarLayout->typeLayout;
-    }
+    typeLayout = maybeGetContainerLayout(typeLayout);
 
     return getParameterCategory(typeLayout);
 }
@@ -592,10 +603,7 @@ SLANG_API unsigned spReflectionTypeLayout_GetCategoryCount(SlangReflectionTypeLa
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return 0;
 
-    if (auto parameterGroupTypeLayout = dynamic_cast<ParameterGroupTypeLayout*>(typeLayout))
-    {
-        typeLayout = parameterGroupTypeLayout->containerVarLayout->typeLayout;
-    }
+    typeLayout = maybeGetContainerLayout(typeLayout);
 
     return (unsigned) typeLayout->resourceInfos.Count();
 }
@@ -605,10 +613,7 @@ SLANG_API SlangParameterCategory spReflectionTypeLayout_GetCategoryByIndex(Slang
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return SLANG_PARAMETER_CATEGORY_NONE;
 
-    if (auto parameterGroupTypeLayout = dynamic_cast<ParameterGroupTypeLayout*>(typeLayout))
-    {
-        typeLayout = parameterGroupTypeLayout->containerVarLayout->typeLayout;
-    }
+    typeLayout = maybeGetContainerLayout(typeLayout);
 
     return typeLayout->resourceInfos[index].kind;
 }

--- a/tests/bindings/glsl-parameter-blocks.slang.glsl
+++ b/tests/bindings/glsl-parameter-blocks.slang.glsl
@@ -6,16 +6,16 @@ struct Test
     vec4 a;
 };
 
-layout(binding = 0)
+layout(binding = 0, set = 1)
 uniform gTest_S1
 {
     Test gTest;
 };
 
-layout(binding = 1)
+layout(binding = 1, set = 1)
 uniform texture2D gTest_t;
 
-layout(binding = 2)
+layout(binding = 2, set = 1)
 uniform sampler gTest_s;
 
 vec4 main_(vec2 uv)

--- a/tests/reflection/parameter-block.slang
+++ b/tests/reflection/parameter-block.slang
@@ -1,0 +1,19 @@
+//TEST:REFLECTION:-profile glsl_fragment -target glsl
+
+// Confirm that we do parameter binding correctly
+// when we have both a parameter block *and* user-defined
+// resource parameters that both need automatic
+// binding allocation.
+
+struct Helper
+{
+	Texture2D t;
+	SamplerState s;	
+};
+
+ParameterBlock<Helper> a;
+
+Texture2D b;
+
+float4 main() : SV_target
+{ return 0.0; }

--- a/tests/reflection/parameter-block.slang.expected
+++ b/tests/reflection/parameter-block.slang.expected
@@ -1,0 +1,52 @@
+result code = 0
+standard error = {
+}
+standard output = {
+{
+    "parameters": [
+        {
+            "name": "a",
+            "binding": {"kind": "registerSpace", "index": 1},
+            "type": {
+                "kind": "parameterBlock",
+                "elementType": {
+                    "kind": "struct",
+                    "name": "Helper",
+                    "fields": [
+                        {
+                            "name": "t",
+                            "type": {
+                                "kind": "resource",
+                                "baseShape": "texture2D"
+                            },
+                            "binding": {"kind": "descriptorTableSlot", "index": 0}
+                        },
+                        {
+                            "name": "s",
+                            "type": {
+                                "kind": "samplerState"
+                            },
+                            "binding": {"kind": "descriptorTableSlot", "index": 1}
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "b",
+            "binding": {"kind": "descriptorTableSlot", "index": 0},
+            "type": {
+                "kind": "resource",
+                "baseShape": "texture2D"
+            }
+        },
+        {
+            "name": "SLANG_hack_samplerForTexelFetch",
+            "binding": {"kind": "descriptorTableSlot", "index": 1},
+            "type": {
+                "kind": "samplerState"
+            }
+        }
+    ]
+}
+}

--- a/tests/reflection/thread-group-size.comp.expected
+++ b/tests/reflection/thread-group-size.comp.expected
@@ -21,10 +21,7 @@ standard output = {
                                     "kind": "scalar",
                                     "scalarType": "float32"
                                 }
-                            },
-                            "bindings": [
-
-                            ]
+                            }
                         }
                     ]
                 }

--- a/tests/reflection/thread-group-size.hlsl.expected
+++ b/tests/reflection/thread-group-size.hlsl.expected
@@ -21,9 +21,6 @@ standard output = {
             "parameters": [
                 {
                     "name": "tid",
-                    "bindings": [
-
-                    ],
                     "semanticName": "SV_DISPATCHTHREADID",
                     "type": {
                         "kind": "vector",

--- a/tools/slang-reflection-test/main.cpp
+++ b/tools/slang-reflection-test/main.cpp
@@ -150,6 +150,7 @@ static void emitReflectionVarBindingInfoJSON(
     auto stage = var->getStage();
     if (stage != SLANG_STAGE_NONE)
     {
+        write(writer, ",\n");
         char const* stageName = "UNKNOWN";
         switch (stage)
         {
@@ -166,7 +167,7 @@ static void emitReflectionVarBindingInfoJSON(
 
         write(writer, "\"stage\": \"");
         write(writer, stageName);
-        write(writer, "\",\n");
+        write(writer, "\"");
     }
 
     auto typeLayout = var->getTypeLayout();
@@ -174,6 +175,7 @@ static void emitReflectionVarBindingInfoJSON(
 
     if (categoryCount)
     {
+        write(writer, ",\n");
         if( categoryCount != 1 )
         {
             write(writer,"\"bindings\": [\n");
@@ -248,7 +250,6 @@ static void emitReflectionVarLayoutJSON(
 
     write(writer, "\"type\": ");
     emitReflectionTypeLayoutJSON(writer, var->getTypeLayout());
-    write(writer, ",\n");
 
     emitReflectionVarBindingInfoJSON(writer, var);
 
@@ -600,7 +601,6 @@ static void emitReflectionParamJSON(
     indent(writer);
 
     emitReflectionNameInfoJSON(writer, param->getName());
-    write(writer, ",\n");
 
     emitReflectionVarBindingInfoJSON(writer, param);
     write(writer, ",\n");

--- a/tools/slang-reflection-test/main.cpp
+++ b/tools/slang-reflection-test/main.cpp
@@ -116,6 +116,7 @@ static void emitReflectionVarBindingInfoJSON(
     CASE(DESCRIPTOR_TABLE_SLOT, descriptorTableSlot);
     CASE(SPECIALIZATION_CONSTANT, specializationConstant);
     CASE(MIXED, mixed);
+    CASE(REGISTER_SPACE, registerSpace);
     #undef CASE
 
         default:
@@ -124,7 +125,7 @@ static void emitReflectionVarBindingInfoJSON(
             break;
         }
         write(writer, "\"");
-        if( space )
+        if( space && category != SLANG_PARAMETER_CATEGORY_REGISTER_SPACE)
         {
             write(writer, ", ");
             write(writer, "\"space\": ");
@@ -171,39 +172,42 @@ static void emitReflectionVarBindingInfoJSON(
     auto typeLayout = var->getTypeLayout();
     auto categoryCount = var->getCategoryCount();
 
-    if( categoryCount != 1 )
+    if (categoryCount)
     {
-        write(writer,"\"bindings\": [\n");
-    }
-    else
-    {
-        write(writer,"\"binding\": ");
-    }
-    indent(writer);
+        if( categoryCount != 1 )
+        {
+            write(writer,"\"bindings\": [\n");
+        }
+        else
+        {
+            write(writer,"\"binding\": ");
+        }
+        indent(writer);
 
-    for(uint32_t cc = 0; cc < categoryCount; ++cc )
-    {
-        auto category = var->getCategoryByIndex(cc);
-        auto index = var->getOffset(category);
-        auto space = var->getBindingSpace(category);
-        auto count = typeLayout->getSize(category);
+        for(uint32_t cc = 0; cc < categoryCount; ++cc )
+        {
+            auto category = var->getCategoryByIndex(cc);
+            auto index = var->getOffset(category);
+            auto space = var->getBindingSpace(category);
+            auto count = typeLayout->getSize(category);
 
-        if (cc != 0) write(writer, ",\n");
+            if (cc != 0) write(writer, ",\n");
 
-        write(writer,"{");
-        emitReflectionVarBindingInfoJSON(
-            writer,
-            category,
-            index,
-            count,
-            space);
-        write(writer,"}");
-    }
+            write(writer,"{");
+            emitReflectionVarBindingInfoJSON(
+                writer,
+                category,
+                index,
+                count,
+                space);
+            write(writer,"}");
+        }
 
-    dedent(writer);
-    if( categoryCount != 1 )
-    {
-        write(writer,"\n]");
+        dedent(writer);
+        if( categoryCount != 1 )
+        {
+            write(writer,"\n]");
+        }
     }
 
     if (auto semanticName = var->getSemanticName())


### PR DESCRIPTION
The bug in this case arises when there is both a parameter block and global-scope resources, all of which are relying on automatic binding assignment. If the parameter block is the first global-scope parameter that gets encountered, then it is possible for it to allocate regsiter space/set zero for itself, which confuses the logic for handling other global-scope parameters (which assumes that *they* get space/set zero).

I've also made some fixup to the reflection test harness and reflection API code:

- Have the hardness handle register-space allocations when printing, and be sure to only show their `index` and not their `space` (since that would be redundant)

- Have the reflection API only auto-redirect queries on a parameter group type layout to its container type layout *if* the container type layout has a non-zero number of resource allocations. The problem that arises here is a `ParameterBlock<X>` where `X` doesn't contain any uniforms, so that no container is needed. In that case the container ends up with no resource allocation(s).