### PR TITLE
Add sample-rate-input detection for HLSL.

### DIFF
--- a/tests/reflection/sample-index-input.hlsl
+++ b/tests/reflection/sample-index-input.hlsl
@@ -1,0 +1,15 @@
+//TEST:REFLECTION:-profile ps_5_0 -target hlsl
+
+// Confirm that we register a shader as sample-rate when
+// it declares `SV_SampleIndex` as an input.
+
+struct PSInput
+{
+	float4 color : COLOR;
+	uint sampleIndex : SV_SampleIndex;	
+};
+
+float4 main(PSInput input) : SV_Target
+{
+	return input.color;
+}

--- a/tests/reflection/sample-index-input.hlsl.expected
+++ b/tests/reflection/sample-index-input.hlsl.expected
@@ -1,0 +1,52 @@
+result code = 0
+standard error = {
+}
+standard output = {
+{
+    "parameters": [
+
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "fragment",
+            "parameters": [
+                {
+                    "name": "input",
+                    "stage": "fragment",
+                    "binding": {"kind": "varyingInput", "index": 0},
+                    "type": {
+                        "kind": "struct",
+                        "name": "PSInput",
+                        "fields": [
+                            {
+                                "name": "color",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 4,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "stage": "fragment",
+                                "binding": {"kind": "varyingInput", "index": 0},
+                                "semanticName": "COLOR"
+                            },
+                            {
+                                "name": "sampleIndex",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "uint32"
+                                },
+                                "semanticName": "SV_SAMPLEINDEX"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "usesAnySampleRateInput": true
+        }
+    ]
+}
+}

--- a/tests/reflection/sample-rate-input.hlsl
+++ b/tests/reflection/sample-rate-input.hlsl
@@ -1,0 +1,15 @@
+//TEST:REFLECTION:-profile ps_5_0 -target hlsl
+
+// Confirm that we register a shader as sample-rate when
+// it declares (not necessarly *uses*) a `sample` qualified input
+
+struct PSInput
+{
+    float4 extra : EXTRA;
+	sample float4 color : COLOR;
+};
+
+float4 main(PSInput input) : SV_Target
+{
+	return input.extra + input.color;
+}

--- a/tests/reflection/sample-rate-input.hlsl.expected
+++ b/tests/reflection/sample-rate-input.hlsl.expected
@@ -1,0 +1,58 @@
+result code = 0
+standard error = {
+}
+standard output = {
+{
+    "parameters": [
+
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "fragment",
+            "parameters": [
+                {
+                    "name": "input",
+                    "stage": "fragment",
+                    "binding": {"kind": "varyingInput", "index": 0, "count": 2},
+                    "type": {
+                        "kind": "struct",
+                        "name": "PSInput",
+                        "fields": [
+                            {
+                                "name": "extra",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 4,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "stage": "fragment",
+                                "binding": {"kind": "varyingInput", "index": 0},
+                                "semanticName": "EXTRA"
+                            },
+                            {
+                                "name": "color",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 4,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "stage": "fragment",
+                                "binding": {"kind": "varyingInput", "index": 1},
+                                "semanticName": "COLOR"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "usesAnySampleRateInput": true
+        }
+    ]
+}
+}


### PR DESCRIPTION
In the HLSL case, it is possible to do this detection entirely based on declared signatures (it doesn't have a dependency on code generation like the GLSL case does). I've added test cases for the two main ways that a shader can become sample rate:

1. Qualify a fragment input with `sample`
2. Accept an input with the `SV_SampleIndex` semantic

In each case I nested the input inside a `struct` to try to match common HLSL idiom, and to make sure that we handle the nested case.

This code is *not* robust against shaders that declare such an input and then never use it, but that is to be expected given the goals for Slang.