### PR TITLE
Always respect dependency order when lowering decls via AST

### DIFF
--- a/source/slang/ast-legalize.cpp
+++ b/source/slang/ast-legalize.cpp
@@ -4849,15 +4849,27 @@ LoweredEntryPoint lowerEntryPoint(
                 continue;
             visitor.translateDeclRef(dd);
         }
-#if 0
-        for (auto dd : translationUnit->SyntaxNode->Members)
-        {
-            visitor.translateDeclRef(dd);
-        }
-#endif
     }
     else
     {
+        // Emit everything we need other than the entry point first
+        for (auto dd : astDecls)
+        {
+            // Skip non-global decls
+            if (!dd->ParentDecl)
+                continue;
+            if (!dynamic_cast<ModuleDecl*>(dd->ParentDecl))
+                continue;
+
+            // Don't emit the entry point in this pass...
+            if(dd == entryPoint->decl)
+                continue;
+
+            visitor.translateDeclRef(dd);
+        }
+
+        // Now emit the entry point, after all its dependencies have
+        // been emitted.
         auto loweredEntryPoint = visitor.lowerEntryPoint(entryPoint);
         sharedContext.result.entryPoint = loweredEntryPoint;
     }

--- a/tests/bugs/gh-333.slang
+++ b/tests/bugs/gh-333.slang
@@ -1,0 +1,25 @@
+//TEST:COMPARE_HLSL:-profile ps_5_0 -entry main
+
+// Ensure declaration order in output is correct
+
+struct A
+{
+	float x;
+};
+
+struct B
+{
+	float y;
+	Texture2D t;
+};
+
+cbuffer C
+{
+	A a;
+	B b;
+};
+
+float4 main() : SV_Target
+{
+	return a.x;
+}


### PR DESCRIPTION
Fixes #333

The code in `ast-legalize` is passed an array of declarations that have been ordered by dependencies using a topological sort. Unfortunately, it was only using that list in the case where the request was considered to be a "rewrite" request, and would otherwise rely on the order in which things get forced during the recursive walk (which doesn't really work for our needs).