### PR TITLE
Fix struct decl order again

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -7122,6 +7122,7 @@ emitDeclImpl(decl, nullptr);
         case kIROp_global_var:
             {
                 auto irGlobal = (IRGlobalVar*) value;
+                emitIRUsedType(ctx, irGlobal->type);
                 emitIRUsedTypesForGlobalValueWithCode(ctx, irGlobal);
             }
             break;

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -165,6 +165,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <Natvis Include="..\core\core.natvis" />
     <Natvis Include="slang.natvis" />
   </ItemGroup>
   <ItemGroup>

--- a/source/slang/slang.vcxproj.filters
+++ b/source/slang/slang.vcxproj.filters
@@ -2,6 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Natvis Include="slang.natvis" />
+    <Natvis Include="..\core\core.natvis" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="compiler.h" />


### PR DESCRIPTION
This PR includes yet another fix to the output `struct` declaration order (this time in the IR + rewriter case, rather than the ordinary rewriter-only case), and then a small debugging fix to help make our lives easier.