### PR TITLE
Add API for querying TypeLayout from a Type

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -633,6 +633,12 @@ extern "C"
         SLANG_STAGE_PIXEL = SLANG_STAGE_FRAGMENT,
     };
 
+    typedef SlangUInt32 SlangLayoutRules;
+    enum
+    {
+        SLANG_LAYOUT_RULES_DEFAULT,
+    };
+
     // Type Reflection
 
     SLANG_API SlangTypeKind spReflectionType_GetKind(SlangReflectionType* type);
@@ -738,6 +744,9 @@ extern "C"
     SLANG_API unsigned int spReflection_GetTypeParameterCount(SlangReflection* reflection);
     SLANG_API SlangReflectionTypeParameter* spReflection_GetTypeParameterByIndex(SlangReflection* reflection, unsigned int index);
     SLANG_API SlangReflectionTypeParameter* spReflection_FindTypeParameter(SlangReflection* reflection, char const* name);
+
+    SLANG_API SlangReflectionType* spReflection_FindTypeByName(SlangReflection* reflection, char const* name);
+    SLANG_API SlangReflectionTypeLayout* spReflection_GetTypeLayout(SlangReflection* reflection, SlangReflectionType* reflectionType, SlangLayoutRules rules);
 
     SLANG_API SlangUInt spReflection_getEntryPointCount(SlangReflection* reflection);
 

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -6777,7 +6777,8 @@ namespace Slang
         // Lookup generic parameter types in global scope
         for (auto name : entryPoint->genericParameterTypeNames)
         {
-            if (!translationUnitSyntax->memberDictionary.TryGetValue(name, firstDeclWithName))
+            firstDeclWithName = entryPoint->compileRequest->lookupGlobalDecl(name);
+            if (!firstDeclWithName)
             {
                 // If there doesn't appear to be any such declaration, then
                 // we need to diagnose it as an error, and then bail out.

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -5348,6 +5348,8 @@ namespace Slang
             DeclRef<GenericDecl>			genericDeclRef,
             OverloadResolveContext&	context)
         {
+            EnsureDecl(genericDeclRef.getDecl());
+
             ConstraintSystem constraints;
             constraints.genericDecl = genericDeclRef.getDecl();
 

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -16,6 +16,7 @@ namespace Slang
     class CompileRequest;
     class ProgramLayout;
     class PtrType;
+    class TypeLayout;
 
     enum class CompilerMode
     {
@@ -197,6 +198,9 @@ namespace Slang
         // in the parent compile request (indexing matches
         // the order they are given in the compile request)
         List<CompileResult> entryPointResults;
+
+        // TypeLayouts created on the fly by reflection API
+        Dictionary<Type*, RefPtr<TypeLayout>> typeLayouts;
     };
 
     // A directory to be searched when looking for files (e.g., `#include`)
@@ -254,6 +258,9 @@ namespace Slang
         // Entry points we've been asked to compile (each
         // assocaited with a translation unit).
         List<RefPtr<EntryPointRequest> > entryPoints;
+
+        // Types constructed by reflection API
+        Dictionary<String, RefPtr<Type>> types;
 
         // The code generation profile we've been asked to use.
         Profile profile;

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -373,6 +373,8 @@ namespace Slang
             Name*               name,
             SourceLoc const&    loc);
 
+        Decl* lookupGlobalDecl(Name* name);
+
         SourceManager* getSourceManager()
         {
             return sourceManager;

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -1786,6 +1786,8 @@ void generateParameterBindings(
         return;
 
     RefPtr<ProgramLayout> programLayout = new ProgramLayout();
+    programLayout->targetRequest = targetReq;
+
     targetReq->layout = programLayout;
 
     // Create a context to hold shared state during the process
@@ -2061,6 +2063,7 @@ RefPtr<ProgramLayout> specializeProgramLayout(
 {
     RefPtr<ProgramLayout> newProgramLayout;
     newProgramLayout = new ProgramLayout();
+    newProgramLayout->targetRequest = targetReq;
     newProgramLayout->bindingForHackSampler = programLayout->bindingForHackSampler;
     newProgramLayout->hackSamplerVar = programLayout->hackSamplerVar;
     newProgramLayout->globalGenericParams = programLayout->globalGenericParams;

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -428,6 +428,47 @@ SLANG_API char const* spReflectionType_GetName(SlangReflectionType* inType)
     return nullptr;
 }
 
+SLANG_API SlangReflectionType * spReflection_FindTypeByName(SlangReflection * reflection, char const * name)
+{
+    auto context = convert(reflection);
+    auto compileRequest = context->targetRequest->compileRequest;
+
+    RefPtr<Type> result;
+    if (compileRequest->types.TryGetValue(name, result))
+        return (SlangReflectionType*)result.Ptr();
+
+    Decl* resultDecl = nullptr;
+    for (auto module : compileRequest->loadedModulesList)
+    {
+        auto nameObj = compileRequest->getNamePool()->getName(name);
+        if (module->moduleDecl->memberDictionary.TryGetValue(nameObj, resultDecl))
+            break;
+    }
+    if (resultDecl)
+    {
+        RefPtr<DeclRefType> declRefType = new DeclRefType();
+        declRefType->declRef.decl = resultDecl;
+        compileRequest->types[name] = declRefType;
+        return (SlangReflectionType*)declRefType.Ptr();
+    }
+    return nullptr;
+}
+
+SLANG_API SlangReflectionTypeLayout* spReflection_GetTypeLayout(
+    SlangReflection* reflection,
+    SlangReflectionType* inType, 
+    SlangLayoutRules /*rules*/)
+{
+    auto context = convert(reflection);
+    auto type = convert(inType);
+    auto layoutContext = getInitialLayoutContextForTarget(context->targetRequest);
+    RefPtr<TypeLayout> result;
+    if (context->targetRequest->typeLayouts.TryGetValue(type, result))
+        return (SlangReflectionTypeLayout*)result.Ptr();
+    result = CreateTypeLayout(layoutContext, type);
+    context->targetRequest->typeLayouts[type] = result;
+    return (SlangReflectionTypeLayout*)result.Ptr();
+}
 
 SLANG_API SlangReflectionType* spReflectionType_GetResourceResultType(SlangReflectionType* inType)
 {

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -438,10 +438,15 @@ SLANG_API SlangReflectionType * spReflection_FindTypeByName(SlangReflection * re
         return (SlangReflectionType*)result.Ptr();
 
     Decl* resultDecl = nullptr;
+    auto nameObj = compileRequest->getNamePool()->getName(name);
     for (auto module : compileRequest->loadedModulesList)
     {
-        auto nameObj = compileRequest->getNamePool()->getName(name);
         if (module->moduleDecl->memberDictionary.TryGetValue(nameObj, resultDecl))
+            break;
+    }
+    for (auto transUnit : compileRequest->translationUnits)
+    {
+        if (transUnit->SyntaxNode->memberDictionary.TryGetValue(nameObj, resultDecl))
             break;
     }
     if (resultDecl)

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -437,18 +437,8 @@ SLANG_API SlangReflectionType * spReflection_FindTypeByName(SlangReflection * re
     if (compileRequest->types.TryGetValue(name, result))
         return (SlangReflectionType*)result.Ptr();
 
-    Decl* resultDecl = nullptr;
     auto nameObj = compileRequest->getNamePool()->getName(name);
-    for (auto module : compileRequest->loadedModulesList)
-    {
-        if (module->moduleDecl->memberDictionary.TryGetValue(nameObj, resultDecl))
-            break;
-    }
-    for (auto transUnit : compileRequest->translationUnits)
-    {
-        if (transUnit->SyntaxNode->memberDictionary.TryGetValue(nameObj, resultDecl))
-            break;
-    }
+    Decl* resultDecl = compileRequest->lookupGlobalDecl(nameObj);
     if (resultDecl)
     {
         RefPtr<DeclRefType> declRefType = new DeclRefType();

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -590,6 +590,22 @@ RefPtr<ModuleDecl> CompileRequest::findOrImportModule(
         loc);
 }
 
+Decl * CompileRequest::lookupGlobalDecl(Name * name)
+{
+    Decl* resultDecl = nullptr;
+    for (auto module : loadedModulesList)
+    {
+        if (module->moduleDecl->memberDictionary.TryGetValue(name, resultDecl))
+            break;
+    }
+    for (auto transUnit : translationUnits)
+    {
+        if (transUnit->SyntaxNode->memberDictionary.TryGetValue(name, resultDecl))
+            break;
+    }
+    return resultDecl;
+}
+
 RefPtr<ModuleDecl> findOrImportModule(
     CompileRequest*     request,
     Name*               name,

--- a/source/slang/type-layout.h
+++ b/source/slang/type-layout.h
@@ -456,6 +456,8 @@ public:
     // a dummy sampler just to appease glslang
     int bindingForHackSampler = 0;
     RefPtr<VarDeclBase> hackSamplerVar;
+
+    TargetRequest* targetRequest = nullptr;
 };
 
 struct LayoutRulesFamilyImpl;


### PR DESCRIPTION
Added two API functions:
1. `spReflection_FindTypeByName`, which returns a DeclRefType to the struct type with the given name. The function finds from all loaded modules in a `CompileRequest` for a decl with the given name, construct a `Type` object and cache it in `CompileRequest::types` dictionary. The subsequent calls to `spReflection_FindTypeByName` with the same name will simply returned the cached Type objects.
2. `spReflection_GetTypeLayout`, which returns a `TypeLayout` for a given `Type`. This function creates and caches the `TypeLayout` in the `TargetRequest` object that is used to create the `ProgramLayout`.