### PR TITLE
Fix bug around arrays of structs of resources

### DIFF
--- a/source/slang/type-layout.h
+++ b/source/slang/type-layout.h
@@ -340,7 +340,12 @@ public:
 class ArrayTypeLayout : public TypeLayout
 {
 public:
-    // The layout used for the element type
+    // The original type layout for the array elements,
+    // which doesn't include any adjustments based on
+    // resource type splitting.
+    RefPtr<TypeLayout> originalElementTypeLayout;
+
+    // The *adjusted* layout used for the element type
     RefPtr<TypeLayout>  elementTypeLayout;
 
     // the stride between elements when used in
@@ -380,6 +385,9 @@ public:
     // one will appear in `fields`, while all of
     // them will be reflected in `mapVarToLayout`.
     //
+    // TODO: This should map from a declaration to the *index*
+    // in the array above, rather than to the actual pointer,
+    // so that we 
     Dictionary<Decl*, RefPtr<VarLayout>> mapVarToLayout;
 };
 

--- a/tests/bindings/array-of-struct-of-resource.hlsl
+++ b/tests/bindings/array-of-struct-of-resource.hlsl
@@ -1,0 +1,42 @@
+//TEST:COMPARE_HLSL:-no-mangle -target dxbc-assembly -profile ps_5_1 -entry main
+
+// Let's first confirm that Spire can reproduce what the
+// HLSL compiler would already do in the simple case (when
+// all shader parameters are actually used).
+
+float4 use(Texture2D t, SamplerState s) { return t.Sample(s, 0.0); }
+
+#ifdef __SLANG__
+
+struct Test
+{
+	Texture2D a;
+	Texture2D b;
+};
+
+Test test[2];
+SamplerState s;
+
+float4 main() : SV_Target
+{
+	return use(test[0].a,s)
+		 + use(test[0].b,s)
+		 + use(test[1].a,s)
+		 + use(test[1].b,s);
+}
+
+#else
+
+Texture2D test_a[2];
+Texture2D test_b[2];
+SamplerState s;
+
+float4 main() : SV_Target
+{
+	return use(test_a[0],s)
+		 + use(test_b[0],s)
+		 + use(test_a[1],s)
+		 + use(test_b[1],s);
+}
+
+#endif


### PR DESCRIPTION
Should fix #351

The basic problem is that the type layout logic in Slang isn't taking into account the way that resource-type fields in aggregate types get split. When you just have a bare aggregate, this oversight doesn't cause a problem, but once you put those aggregates into an array, the problems become clear.

Given:

```hlsl
struct Test
{
	Texture2D a;
	Texture2D b;
};
Test test[8];
```

The default type-layout algorithm gives `Test::a` an offset of zero, and `Test::b` an offset of one.

However, after splitting, we have something like:

```hlsl
Texture2D test_a[8];
Texture2D test_b[8];
```

It is clear in this case that `test_b` can't start at an offset of one relative to `test_a` - it needs to start at `register(t8)`.

This change handles things by adjusting the layout of an array type to account for this detail as soon as it is created. The alternative would have been to not change layout rules at all, but to instead try to adjust things at the point where types get split (and the layout for the un-split case gets applied to the split variable). The reason for doing it the way it is in this change is that the reflection API will hopefully provide accurate information.

Related to reflection information, one thing that is missing here is proper computation of the "stride" for an array like this. We'll see if that needs to be addressed in a follow-up.