### PR TITLE
Refactor substitution representation in DeclRefBase

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -3054,7 +3054,7 @@ struct EmitVisitor
                 return;
             }
 
-            GenericSubstitution* subst = declRef.substitutions.As<GenericSubstitution>().Ptr();
+            GenericSubstitution* subst = declRef.substitutions.genericSubstitutions;
             if (!subst)
                 return;
 

--- a/source/slang/legalize-types.cpp
+++ b/source/slang/legalize-types.cpp
@@ -450,8 +450,7 @@ static RefPtr<Type> createBuiltinGenericType(
     // TODO: we should have library code to make
     // manipulations like this way easier.
 
-    RefPtr<GenericSubstitution> oldGenericSubst = getGenericSubstitution(
-        typeDeclRef.substitutions);
+    RefPtr<GenericSubstitution> oldGenericSubst = typeDeclRef.substitutions.genericSubstitutions;
     SLANG_ASSERT(oldGenericSubst);
 
     RefPtr<GenericSubstitution> newGenericSubst = new GenericSubstitution();

--- a/source/slang/mangle.h
+++ b/source/slang/mangle.h
@@ -12,7 +12,7 @@ namespace Slang
     String getMangledName(DeclRef<Decl> const & declRef);
     String getMangledName(DeclRefBase const & declRef);
 
-    String mangleSpecializedFuncName(String baseName, RefPtr<Substitutions> subst);
+    String mangleSpecializedFuncName(String baseName, SubstitutionSet subst);
     String getMangledNameForConformanceWitness(
         Type* sub,
         Type* sup);

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -1529,7 +1529,7 @@ static RefPtr<TypeLayout> processEntryPointParameter(
 static void collectEntryPointParameters(
     ParameterBindingContext*        context,
     EntryPointRequest*              entryPoint,
-    Substitutions*                  typeSubst)
+    SubstitutionSet                 typeSubst)
 {
     FuncDecl* entryPointFuncDecl = entryPoint->decl;
     if (!entryPointFuncDecl)
@@ -1722,7 +1722,7 @@ static void collectParameters(
         for( auto& entryPoint : translationUnit->entryPoints )
         {
             context->stage = entryPoint->profile.GetStage();
-            collectEntryPointParameters(context, entryPoint.Ptr(), nullptr);
+            collectEntryPointParameters(context, entryPoint.Ptr(), SubstitutionSet());
         }
         context->entryPointLayout = nullptr;
     }
@@ -2059,7 +2059,7 @@ StructTypeLayout* getGlobalStructLayout(
 RefPtr<ProgramLayout> specializeProgramLayout(
     TargetRequest * targetReq,
     ProgramLayout* programLayout, 
-    Substitutions * typeSubst)
+    SubstitutionSet typeSubst)
 {
     RefPtr<ProgramLayout> newProgramLayout;
     newProgramLayout = new ProgramLayout();

--- a/source/slang/type-defs.h
+++ b/source/slang/type-defs.h
@@ -61,7 +61,7 @@ SYNTAX_CLASS(DeclRefType, Type)
 
 RAW(
     virtual String ToString() override;
-    virtual RefPtr<Val> SubstituteImpl(Substitutions* subst, int* ioDiff) override;
+    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
 
     static DeclRefType* Create(
         Session*        session,
@@ -310,7 +310,7 @@ RAW(
 protected:
     virtual bool EqualsImpl(Type * type) override;
     virtual Type* CreateCanonicalType() override;
-    virtual RefPtr<Val> SubstituteImpl(Substitutions* subst, int* ioDiff) override;
+    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
     virtual int GetHashCode() override;
     )
 END_SYNTAX_CLASS()
@@ -464,7 +464,7 @@ RAW(
 
     virtual String ToString() override;
 protected:
-    virtual RefPtr<Val> SubstituteImpl(Substitutions* subst, int* ioDiff) override;
+    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
     virtual bool EqualsImpl(Type * type) override;
     virtual Type* CreateCanonicalType() override;
     virtual int GetHashCode() override;

--- a/source/slang/val-defs.h
+++ b/source/slang/val-defs.h
@@ -37,7 +37,7 @@ SYNTAX_CLASS(GenericParamIntVal, IntVal)
     virtual bool EqualsVal(Val* val) override;
     virtual String ToString() override;
     virtual int GetHashCode() override;
-    virtual RefPtr<Val> SubstituteImpl(Substitutions* subst, int* ioDiff) override;
+    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
 )
 END_SYNTAX_CLASS()
 
@@ -98,7 +98,7 @@ RAW(
     virtual bool EqualsVal(Val* val) override;
     virtual String ToString() override;
     virtual int GetHashCode() override;
-    virtual RefPtr<Val> SubstituteImpl(Substitutions * subst, int * ioDiff) override;
+    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int * ioDiff) override;
     virtual DeclRef<Decl> getLastStepDeclRef() override
     {
         return declRef;
@@ -117,7 +117,7 @@ RAW(
     virtual bool EqualsVal(Val* val) override;
     virtual String ToString() override;
     virtual int GetHashCode() override;
-    virtual RefPtr<Val> SubstituteImpl(Substitutions * subst, int * ioDiff) override;
+    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int * ioDiff) override;
     virtual DeclRef<Decl> getLastStepDeclRef() override
     {
         return midToSup->getLastStepDeclRef();


### PR DESCRIPTION
This commit changes the type of `DeclRefBase::substitutions` from `RefPtr<Substitutions>` to `SubstitutionSet`, which is a new type defined as following:
```
struct SubstitutionSet
{
    RefPtr<GenericSubstitution> genericSubstitutions;
    RefPtr<ThisTypeSubstitution> thisTypeSubstitution;
    RefPtr<GlobalGenericParamSubstitution> globalGenParamSubstitutions;
}
```
This change get rid of most helper functions to retreive the substitution of a certain type, as well as surgery operations to insert a `ThisTypeSubstitution` or `GlobalGenericTypeSubstittuion` at top or bottom of the substitution chain. It also simplies type comparison when certain type of substitution should not be considered as part of type definition.