### PR TITLE
bug fixes to get falcor example shader code to compile.

### DIFF
--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -4889,8 +4889,10 @@ namespace Slang
                         {
                             if (auto subDeclRefType = subtypeWitness->sub.As<DeclRefType>())
                             {
-                                auto genericWitnessTableName = getMangledNameForConformanceWitness(DeclRef<Decl>(subDeclRefType->declRef.getDecl(), nullptr), subtypeWitness->sup);
+                                auto defaultSubst = createDefaultSubstitutions(entryPointRequest->compileRequest->mSession, subDeclRefType->declRef.getDecl());
+                                auto genericWitnessTableName = getMangledNameForConformanceWitness(DeclRef<Decl>(subDeclRefType->declRef.getDecl(), defaultSubst), subtypeWitness->sup);
                                 table = findWitnessTableByName(genericWitnessTableName);
+                                SLANG_ASSERT(table);
                                 WitnessTableSpecializationWorkItem workItem;
                                 workItem.srcTable = (IRWitnessTable*)table;
                                 workItem.dstTable = context->builder->createWitnessTable();

--- a/source/slang/lookup.cpp
+++ b/source/slang/lookup.cpp
@@ -4,6 +4,8 @@
 
 namespace Slang {
 
+void checkDecl(SemanticsVisitor* visitor, Decl* decl);
+
 //
 
 DeclRef<ExtensionDecl> ApplyExtensionToType(
@@ -224,6 +226,10 @@ void DoLocalLookupImpl(
     LookupResult&		    result,
     BreadcrumbInfo*		    inBreadcrumbs)
 {
+    if (result.lookedupDecls.Contains(containerDeclRef))
+        return;
+    result.lookedupDecls.Add(containerDeclRef);
+
     ContainerDecl* containerDecl = containerDeclRef.getDecl();
 
     // Ensure that the lookup dictionary in the container is up to date
@@ -318,6 +324,7 @@ void DoLocalLookupImpl(
             auto baseInterfaces = getMembersOfType<InheritanceDecl>(containerDeclRef);
             for (auto inheritanceDeclRef : baseInterfaces)
             {
+                checkDecl(request.semantics, inheritanceDeclRef.decl);
                 auto baseType = inheritanceDeclRef.getDecl()->base.type.As<DeclRefType>();
                 SLANG_ASSERT(baseType);
                 int diff = 0;

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -1673,6 +1673,32 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     // TODO: should really have a `type.cpp` and a `witness.cpp`
 
+    bool TypeEqualityWitness::EqualsVal(Val* val)
+    {
+        auto otherWitness = dynamic_cast<TypeEqualityWitness*>(val);
+        if (!otherWitness)
+            return false;
+        return sub->Equals(otherWitness->sub);
+    }
+
+    RefPtr<Val> TypeEqualityWitness::SubstituteImpl(SubstitutionSet subst, int * ioDiff)
+    {
+        RefPtr<TypeEqualityWitness> rs = new TypeEqualityWitness();
+        rs->sub = sub->SubstituteImpl(subst, ioDiff).As<Type>();
+        rs->sup = sup->SubstituteImpl(subst, ioDiff).As<Type>();
+        return rs;
+    }
+
+    String TypeEqualityWitness::ToString()
+    {
+        return "TypeEqualityWitness(" + sub->ToString() + ")";
+    }
+
+    int TypeEqualityWitness::GetHashCode()
+    {
+        return sub->GetHashCode();
+    }
+
     bool DeclaredSubtypeWitness::EqualsVal(Val* val)
     {
         auto otherWitness = dynamic_cast<DeclaredSubtypeWitness*>(val);
@@ -1760,10 +1786,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     int DeclaredSubtypeWitness::GetHashCode()
     {
-        auto hash = sub->GetHashCode();
-        hash = combineHash(hash, sup->GetHashCode());
-        hash = combineHash(hash, declRef.GetHashCode());
-        return hash;
+        return declRef.GetHashCode();
     }
 
     // TransitiveSubtypeWitness

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -969,6 +969,8 @@ namespace Slang
         // used at all, to avoid allocation.
         List<LookupResultItem> items;
 
+        HashSet<DeclRef<ContainerDecl>>      lookedupDecls;
+
         // Was at least one result found?
         bool isValid() const { return item.declRef.getDecl() != nullptr; }
 
@@ -1009,7 +1011,6 @@ namespace Slang
     struct LookupRequest
     {
         SemanticsVisitor*   semantics   = nullptr;
-
         RefPtr<Scope>       scope       = nullptr;
         RefPtr<Scope>       endScope    = nullptr;
 

--- a/source/slang/val-defs.h
+++ b/source/slang/val-defs.h
@@ -90,6 +90,18 @@ ABSTRACT_SYNTAX_CLASS(SubtypeWitness, Witness)
     )
 END_SYNTAX_CLASS()
 
+SYNTAX_CLASS(TypeEqualityWitness, SubtypeWitness)
+RAW(
+    virtual bool EqualsVal(Val* val) override;
+    virtual String ToString() override;
+    virtual int GetHashCode() override;
+    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int * ioDiff) override;
+    virtual DeclRef<Decl> getLastStepDeclRef() override
+    {
+        return DeclRef<Decl>();
+    }
+)
+END_SYNTAX_CLASS()
 // A witness that one type is a subtype of another
 // because some in-scope declaration says so
 SYNTAX_CLASS(DeclaredSubtypeWitness, SubtypeWitness)


### PR DESCRIPTION
1. prevent cyclic lookups when an interface inherits transitively from itself.
2. in `createGlobalGenericParamSubstitution`, create a default substitution for the base type declref before using it to lookup the witness table.