### PR TITLE
Fix a bug in import handling

### DIFF
--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -575,7 +575,10 @@ RefPtr<ModuleDecl> CompileRequest::findOrImportModule(
         {
             // We seem to be in the middle of loading this module
             mSink.diagnose(loc, Diagnostics::recursiveModuleImport, name);
+            return nullptr;
         }
+
+        return loadedModule->moduleDecl;
     }
 
     // Derive a file name for the module, by taking the given


### PR DESCRIPTION
The recent change that removed `#import` accidentally introduced a regression that made *any* code that imports the same module in more than one place fail.

I'm just fixing the bug for now to unblock users, but this should really get a regression test.