### PR TITLE
Fix bug when subscripting a type that must be split

### DIFF
--- a/source/slang/ast-legalize.cpp
+++ b/source/slang/ast-legalize.cpp
@@ -1533,6 +1533,7 @@ struct LoweringVisitor
                 auto basePair = baseExpr.getPair();
 
                 RefPtr<PairPseudoExpr> resultPair = new PairPseudoExpr();
+                resultPair->pairInfo = basePair->pairInfo;
                 resultPair->loc = basePair->loc;
 
                 resultPair->ordinary = createSubscriptExpr(basePair->ordinary, indexExpr);


### PR DESCRIPTION
The logic was creating a `PairPseudoExpr` as part of a subscript (`operator[]`) operation, but neglecting to fill in its `pairInfo` field, which led to a null-pointer crash further along.