### PR TITLE
Support __target_intrinsic modifiers in IR codegen

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -461,7 +461,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                     sb << "__glsl_version(450)\n";
                     sb << "__target_intrinsic(glsl, \"(";
 
-                    int aa = 0;
+                    int aa = 1;
                     String lodStr = "0";
                     if (includeMipInfo)
                     {
@@ -582,11 +582,11 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 if (isMultisample)
                 {
-                    sb << "__target_intrinsic(glsl, \"texelFetch($$P, $0, $1)\")\n";
+                    sb << "__target_intrinsic(glsl, \"texelFetch($$P, $1, $3)\")\n";
                 }
                 else
                 {
-                    sb << "__target_intrinsic(glsl, \"texelFetch($$P, ($0)." << kGLSLLoadCoordsSwizzle[loadCoordCount] << ", ($0)." << kGLSLLoadLODSwizzle[loadCoordCount] << ")\")\n";
+                    sb << "__target_intrinsic(glsl, \"texelFetch($$P, ($1)." << kGLSLLoadCoordsSwizzle[loadCoordCount] << ", ($1)." << kGLSLLoadLODSwizzle[loadCoordCount] << ")\")\n";
                 }
                 sb << "T Load(";
                 sb << "int" << loadCoordCount << " location";
@@ -602,7 +602,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 }
                 else
                 {
-                    sb << "__target_intrinsic(glsl, \"texelFetch($$P, ($0)." << kGLSLLoadCoordsSwizzle[loadCoordCount] << ", ($0)." << kGLSLLoadLODSwizzle[loadCoordCount] << ", $1)\")\n";
+                    sb << "__target_intrinsic(glsl, \"texelFetch($$P, ($1)." << kGLSLLoadCoordsSwizzle[loadCoordCount] << ", ($1)." << kGLSLLoadLODSwizzle[loadCoordCount] << ", $2)\")\n";
                 }
                 sb << "T Load(";
                 sb << "int" << loadCoordCount << " location";
@@ -643,7 +643,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
             {
                 // `Sample()`
 
-//                sb << "__target_intrinsic(glsl, \"texture($$p, $1)\")\n";
+                sb << "__target_intrinsic(glsl, \"texture($$p, $2)\")\n";
 
                 // TODO: only enable if IR is being used?
 //                sb << "__intrinsic_op(sample)\n";
@@ -651,21 +651,9 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 sb << "T Sample(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location);\n";
 
-                // Specialized definition for GLSL
-                sb << "__specialized_for_target(glsl)\n";
-                sb << "T Sample(SamplerState s, ";
-                sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location) {\n";
-                sb << "    return texture<T>(Sampler";
-				sb << kBaseTextureAccessLevels[accessLevel].name;
-				sb << name;
-				if (isMultisample) sb << "MS";
-				if (isArray) sb << "Array";
-				sb << "<T>(this, s), location);\n";
-                sb << "}\n";
-
                 if( baseShape != TextureType::ShapeCube )
                 {
-                    sb << "__target_intrinsic(glsl, \"textureOffset($$p, $1, $2)\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureOffset($$p, $2, $3)\")\n";
                     sb << "T Sample(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                     sb << "int" << kBaseTextureTypes[tt].coordCount << " offset);\n";
@@ -689,13 +677,13 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
 
                 // `SampleBias()`
-                sb << "__target_intrinsic(glsl, \"texture($$p, $1, $2)\")\n";
+                sb << "__target_intrinsic(glsl, \"texture($$p, $2, $3)\")\n";
                 sb << "T SampleBias(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, float bias);\n";
 
                 if( baseShape != TextureType::ShapeCube )
                 {
-                    sb << "__target_intrinsic(glsl, \"textureOffset($$p, $1, $2, $3)\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureOffset($$p, $2, $3, $4)\")\n";
                     sb << "T SampleBias(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, float bias, ";
                     sb << "int" << kBaseTextureTypes[tt].coordCount << " offset);\n";
@@ -718,12 +706,12 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                     sb << "__target_intrinsic(glsl, \"textureLod($$p, ";
 
-                    sb << "vec" << extCoordCount << "($1,";
+                    sb << "vec" << extCoordCount << "($2,";
                     for (int ii = arrCoordCount; ii < extCoordCount - 1; ++ii)
                     {
                         sb << " 0.0,";
                     }
-                    sb << "$2)";
+                    sb << "$3)";
 
                     sb << ", 0.0)\")\n";
                 }
@@ -736,12 +724,12 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                     sb << "__target_intrinsic(glsl, \"textureGrad($$p, ";
 
-                    sb << "vec" << extCoordCount << "($1,";
+                    sb << "vec" << extCoordCount << "($2,";
                     for (int ii = arrCoordCount; ii < extCoordCount - 1; ++ii)
                     {
                         sb << " 0.0,";
                     }
-                    sb << "$2)";
+                    sb << "$3)";
 
                     // Construct gradients
                     sb << ", vec" << baseCoordCount << "(0.0)";
@@ -774,7 +762,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 }
 
 
-                sb << "__target_intrinsic(glsl, \"textureGrad($$p, $1, $2, $3)\")\n";
+                sb << "__target_intrinsic(glsl, \"textureGrad($$p, $2, $3, $4)\")\n";
 //                sb << "__intrinsic_op(sampleGrad)\n";
                 sb << "T SampleGrad(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
@@ -784,7 +772,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 if( baseShape != TextureType::ShapeCube )
                 {
-                    sb << "__target_intrinsic(glsl, \"textureGradOffset($$p, $1, $2, $3, $4)\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureGradOffset($$p, $2, $3, $4, $5)\")\n";
 //                    sb << "__intrinsic_op(sampleGrad)\n";
                     sb << "T SampleGrad(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
@@ -795,14 +783,14 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 // `SampleLevel`
 
-                sb << "__target_intrinsic(glsl, \"textureLod($$p, $1, $2)\")\n";
+                sb << "__target_intrinsic(glsl, \"textureLod($$p, $2, $3)\")\n";
                 sb << "T SampleLevel(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                 sb << "float level);\n";
 
                 if( baseShape != TextureType::ShapeCube )
                 {
-                    sb << "__target_intrinsic(glsl, \"textureLodOffset($$p, $1, $2, $3)\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureLodOffset($$p, $2, $3, $4)\")\n";
                     sb << "T SampleLevel(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                     sb << "float level, ";
@@ -869,12 +857,12 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                     EMIT_LINE_DIRECTIVE();
                             
-                    sb << "__target_intrinsic(glsl, \"textureGather($$p, $1, " << componentIndex << ")\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureGather($$p, $2, " << componentIndex << ")\")\n";
                     sb << "vector<T, 4> Gather" << componentName << "(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount << " location);\n";
 
                     EMIT_LINE_DIRECTIVE();
-                    sb << "__target_intrinsic(glsl, \"textureGatherOffset($$p, $1, $2, " << componentIndex << ")\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureGatherOffset($$p, $2, $3, " << componentIndex << ")\")\n";
                     sb << "vector<T, 4> Gather" << componentName << "(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount << " location, ";
                     sb << "int" << kBaseTextureTypes[tt].coordCount << " offset);\n";
@@ -886,7 +874,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                     sb << "out uint status);\n";
 
                     EMIT_LINE_DIRECTIVE();
-                    sb << "__target_intrinsic(glsl, \"textureGatherOffsets($$p, $1, int" << kBaseTextureTypes[tt].coordCount << "[]($2, $3, $4, $5), " << componentIndex << ")\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureGatherOffsets($$p, $2, int" << kBaseTextureTypes[tt].coordCount << "[]($3, $4, $5, $6), " << componentIndex << ")\")\n";
                     sb << "vector<T, 4> Gather" << componentName << "(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount << " location, ";
                     sb << "int" << kBaseTextureTypes[tt].coordCount << " offset1, ";

--- a/source/slang/core.meta.slang.h
+++ b/source/slang/core.meta.slang.h
@@ -464,7 +464,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                     sb << "__glsl_version(450)\n";
                     sb << "__target_intrinsic(glsl, \"(";
 
-                    int aa = 0;
+                    int aa = 1;
                     String lodStr = "0";
                     if (includeMipInfo)
                     {
@@ -585,11 +585,11 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 if (isMultisample)
                 {
-                    sb << "__target_intrinsic(glsl, \"texelFetch($P, $0, $1)\")\n";
+                    sb << "__target_intrinsic(glsl, \"texelFetch($P, $1, $3)\")\n";
                 }
                 else
                 {
-                    sb << "__target_intrinsic(glsl, \"texelFetch($P, ($0)." << kGLSLLoadCoordsSwizzle[loadCoordCount] << ", ($0)." << kGLSLLoadLODSwizzle[loadCoordCount] << ")\")\n";
+                    sb << "__target_intrinsic(glsl, \"texelFetch($P, ($1)." << kGLSLLoadCoordsSwizzle[loadCoordCount] << ", ($1)." << kGLSLLoadLODSwizzle[loadCoordCount] << ")\")\n";
                 }
                 sb << "T Load(";
                 sb << "int" << loadCoordCount << " location";
@@ -605,7 +605,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 }
                 else
                 {
-                    sb << "__target_intrinsic(glsl, \"texelFetch($P, ($0)." << kGLSLLoadCoordsSwizzle[loadCoordCount] << ", ($0)." << kGLSLLoadLODSwizzle[loadCoordCount] << ", $1)\")\n";
+                    sb << "__target_intrinsic(glsl, \"texelFetch($P, ($1)." << kGLSLLoadCoordsSwizzle[loadCoordCount] << ", ($1)." << kGLSLLoadLODSwizzle[loadCoordCount] << ", $2)\")\n";
                 }
                 sb << "T Load(";
                 sb << "int" << loadCoordCount << " location";
@@ -646,7 +646,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
             {
                 // `Sample()`
 
-//                sb << "__target_intrinsic(glsl, \"texture($p, $1)\")\n";
+                sb << "__target_intrinsic(glsl, \"texture($p, $2)\")\n";
 
                 // TODO: only enable if IR is being used?
 //                sb << "__intrinsic_op(sample)\n";
@@ -654,21 +654,9 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 sb << "T Sample(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location);\n";
 
-                // Specialized definition for GLSL
-                sb << "__specialized_for_target(glsl)\n";
-                sb << "T Sample(SamplerState s, ";
-                sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location) {\n";
-                sb << "    return texture<T>(Sampler";
-				sb << kBaseTextureAccessLevels[accessLevel].name;
-				sb << name;
-				if (isMultisample) sb << "MS";
-				if (isArray) sb << "Array";
-				sb << "<T>(this, s), location);\n";
-                sb << "}\n";
-
                 if( baseShape != TextureType::ShapeCube )
                 {
-                    sb << "__target_intrinsic(glsl, \"textureOffset($p, $1, $2)\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureOffset($p, $2, $3)\")\n";
                     sb << "T Sample(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                     sb << "int" << kBaseTextureTypes[tt].coordCount << " offset);\n";
@@ -692,13 +680,13 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
 
                 // `SampleBias()`
-                sb << "__target_intrinsic(glsl, \"texture($p, $1, $2)\")\n";
+                sb << "__target_intrinsic(glsl, \"texture($p, $2, $3)\")\n";
                 sb << "T SampleBias(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, float bias);\n";
 
                 if( baseShape != TextureType::ShapeCube )
                 {
-                    sb << "__target_intrinsic(glsl, \"textureOffset($p, $1, $2, $3)\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureOffset($p, $2, $3, $4)\")\n";
                     sb << "T SampleBias(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, float bias, ";
                     sb << "int" << kBaseTextureTypes[tt].coordCount << " offset);\n";
@@ -721,12 +709,12 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                     sb << "__target_intrinsic(glsl, \"textureLod($p, ";
 
-                    sb << "vec" << extCoordCount << "($1,";
+                    sb << "vec" << extCoordCount << "($2,";
                     for (int ii = arrCoordCount; ii < extCoordCount - 1; ++ii)
                     {
                         sb << " 0.0,";
                     }
-                    sb << "$2)";
+                    sb << "$3)";
 
                     sb << ", 0.0)\")\n";
                 }
@@ -739,12 +727,12 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                     sb << "__target_intrinsic(glsl, \"textureGrad($p, ";
 
-                    sb << "vec" << extCoordCount << "($1,";
+                    sb << "vec" << extCoordCount << "($2,";
                     for (int ii = arrCoordCount; ii < extCoordCount - 1; ++ii)
                     {
                         sb << " 0.0,";
                     }
-                    sb << "$2)";
+                    sb << "$3)";
 
                     // Construct gradients
                     sb << ", vec" << baseCoordCount << "(0.0)";
@@ -777,7 +765,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 }
 
 
-                sb << "__target_intrinsic(glsl, \"textureGrad($p, $1, $2, $3)\")\n";
+                sb << "__target_intrinsic(glsl, \"textureGrad($p, $2, $3, $4)\")\n";
 //                sb << "__intrinsic_op(sampleGrad)\n";
                 sb << "T SampleGrad(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
@@ -787,7 +775,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 if( baseShape != TextureType::ShapeCube )
                 {
-                    sb << "__target_intrinsic(glsl, \"textureGradOffset($p, $1, $2, $3, $4)\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureGradOffset($p, $2, $3, $4, $5)\")\n";
 //                    sb << "__intrinsic_op(sampleGrad)\n";
                     sb << "T SampleGrad(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
@@ -798,14 +786,14 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 // `SampleLevel`
 
-                sb << "__target_intrinsic(glsl, \"textureLod($p, $1, $2)\")\n";
+                sb << "__target_intrinsic(glsl, \"textureLod($p, $2, $3)\")\n";
                 sb << "T SampleLevel(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                 sb << "float level);\n";
 
                 if( baseShape != TextureType::ShapeCube )
                 {
-                    sb << "__target_intrinsic(glsl, \"textureLodOffset($p, $1, $2, $3)\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureLodOffset($p, $2, $3, $4)\")\n";
                     sb << "T SampleLevel(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                     sb << "float level, ";
@@ -872,12 +860,12 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                     EMIT_LINE_DIRECTIVE();
                             
-                    sb << "__target_intrinsic(glsl, \"textureGather($p, $1, " << componentIndex << ")\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureGather($p, $2, " << componentIndex << ")\")\n";
                     sb << "vector<T, 4> Gather" << componentName << "(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount << " location);\n";
 
                     EMIT_LINE_DIRECTIVE();
-                    sb << "__target_intrinsic(glsl, \"textureGatherOffset($p, $1, $2, " << componentIndex << ")\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureGatherOffset($p, $2, $3, " << componentIndex << ")\")\n";
                     sb << "vector<T, 4> Gather" << componentName << "(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount << " location, ";
                     sb << "int" << kBaseTextureTypes[tt].coordCount << " offset);\n";
@@ -889,7 +877,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                     sb << "out uint status);\n";
 
                     EMIT_LINE_DIRECTIVE();
-                    sb << "__target_intrinsic(glsl, \"textureGatherOffsets($p, $1, int" << kBaseTextureTypes[tt].coordCount << "[]($2, $3, $4, $5), " << componentIndex << ")\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureGatherOffsets($p, $2, int" << kBaseTextureTypes[tt].coordCount << "[]($3, $4, $5, $6), " << componentIndex << ")\")\n";
                     sb << "vector<T, 4> Gather" << componentName << "(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount << " location, ";
                     sb << "int" << kBaseTextureTypes[tt].coordCount << " offset1, ";

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -1072,12 +1072,12 @@ for (int aa = 0; aa < kBaseBufferAccessLevelCount; ++aa)
 
     sb << "void GetDimensions(out uint dim);\n";
 
-    sb << "__target_intrinsic(glsl, \"texelFetch($$P, $0)$$z\")\n";
+    sb << "__target_intrinsic(glsl, \"texelFetch($$P, $1)$$z\")\n";
     sb << "T Load(int location);\n";
 
     sb << "T Load(int location, out uint status);\n";
 
-    sb << "__target_intrinsic(glsl, \"texelFetch($$P, int($0))$$z\")\n";
+    sb << "__target_intrinsic(glsl, \"texelFetch($$P, int($1))$$z\")\n";
     sb << "__subscript(uint index) -> T";
 
     if (kBaseBufferAccessLevels[aa].access != SLANG_RESOURCE_ACCESS_READ)

--- a/source/slang/hlsl.meta.slang.h
+++ b/source/slang/hlsl.meta.slang.h
@@ -1075,12 +1075,12 @@ for (int aa = 0; aa < kBaseBufferAccessLevelCount; ++aa)
 
     sb << "void GetDimensions(out uint dim);\n";
 
-    sb << "__target_intrinsic(glsl, \"texelFetch($P, $0)$z\")\n";
+    sb << "__target_intrinsic(glsl, \"texelFetch($P, $1)$z\")\n";
     sb << "T Load(int location);\n";
 
     sb << "T Load(int location, out uint status);\n";
 
-    sb << "__target_intrinsic(glsl, \"texelFetch($P, int($0))$z\")\n";
+    sb << "__target_intrinsic(glsl, \"texelFetch($P, int($1))$z\")\n";
     sb << "__subscript(uint index) -> T";
 
     if (kBaseBufferAccessLevels[aa].access != SLANG_RESOURCE_ACCESS_READ)

--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -47,12 +47,23 @@ struct IRLoopControlDecoration : IRDecoration
     IRLoopControl mode;
 };
 
-struct IRTargetDecoration : IRDecoration
-{
-    enum { kDecorationOp = kIRDecorationOp_Target };
 
+struct IRTargetSpecificDecoration : IRDecoration
+{
     // TODO: have a more structured representation of target specifiers
     String targetName;
+};
+
+struct IRTargetDecoration : IRTargetSpecificDecoration
+{
+    enum { kDecorationOp = kIRDecorationOp_Target };
+};
+
+struct IRTargetIntrinsicDecoration : IRTargetSpecificDecoration
+{
+    enum { kDecorationOp = kIRDecorationOp_TargetIntrinsic };
+
+    String definition;
 };
 
 //

--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -3226,6 +3226,15 @@ namespace Slang
                 }
                 break;
 
+            case kIRDecorationOp_TargetIntrinsic:
+                {
+                    auto originalDecoration = (IRTargetIntrinsicDecoration*)dd;
+                    auto newDecoration = context->builder->addDecoration<IRTargetIntrinsicDecoration>(clonedValue);
+                    newDecoration->targetName = originalDecoration->targetName;
+                    newDecoration->definition = originalDecoration->definition;
+                }
+                break;
+
             default:
                 // Don't clone any decorations we don't understand.
                 break;

--- a/source/slang/ir.h
+++ b/source/slang/ir.h
@@ -106,6 +106,7 @@ enum IRDecorationOp : uint16_t
     kIRDecorationOp_Layout,
     kIRDecorationOp_LoopControl,
     kIRDecorationOp_Target,
+    kIRDecorationOp_TargetIntrinsic,
 };
 
 // A "decoration" that gets applied to an instruction.

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -3757,6 +3757,24 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             decoration->targetName = targetMod->targetToken.Content;
         }
 
+        // If this declaration was marked as having a target-specific lowering
+        // for a particular target, then handle that here.
+        for (auto targetMod : decl->GetModifiersOfType<TargetIntrinsicModifier>())
+        {
+            auto decoration = getBuilder()->addDecoration<IRTargetIntrinsicDecoration>(irFunc);
+            decoration->targetName = targetMod->targetToken.Content;
+
+            auto definitionToken = targetMod->definitionToken;
+            if (definitionToken.type == TokenType::StringLiteral)
+            {
+                decoration->definition = getStringLiteralTokenValue(definitionToken);
+            }
+            else
+            {
+                decoration->definition = definitionToken.Content;
+            }
+        }
+
         // For convenience, ensure that any additional global
         // values that were emitted while outputting the function
         // body appear before the function itself in the list

--- a/tests/bindings/glsl-parameter-blocks.slang
+++ b/tests/bindings/glsl-parameter-blocks.slang
@@ -1,5 +1,5 @@
 #version 450 core
-//TEST_DISABLED:CROSS_COMPILE: -profile ps_5_0 -entry main -target spirv-assembly
+//TEST:CROSS_COMPILE: -profile ps_5_0 -entry main -target spirv-assembly
 
 // Note: disabled because the translation of `Texture2D.Sample()`
 // requires handling of local variables with resource types in the IR.

--- a/tests/bindings/glsl-parameter-blocks.slang.glsl
+++ b/tests/bindings/glsl-parameter-blocks.slang.glsl
@@ -1,37 +1,44 @@
 //TEST_IGNORE_FILE:
 #version 450 core
 
-struct Test
+struct _ST04Test
 {
     vec4 a;
 };
 
 layout(binding = 0, set = 1)
-uniform gTest_S1
+uniform _S1
 {
-    Test gTest;
+    _ST04Test _SV05gTestL0;
 };
 
 layout(binding = 1, set = 1)
-uniform texture2D gTest_t;
+uniform texture2D _SV05gTestL1;
 
 layout(binding = 2, set = 1)
-uniform sampler gTest_s;
-
-vec4 main_(vec2 uv)
-{
-    return gTest.a + texture(sampler2D(gTest_t, gTest_s), uv);
-}
+uniform sampler _SV05gTestL2;
 
 layout(location = 0)
-in vec2 SLANG_in_uv;
+in vec2 _S3;
 
 layout(location = 0)
-out vec4 SLANG_out_main_result;
+out vec4 _S2;
 
 void main()
 {
-    vec2 uv = SLANG_in_uv;
-    vec4 main_result = main_(uv);
-    SLANG_out_main_result = main_result;
+	vec2 _S4 = _S3;
+
+	vec2 _S5 = _S4;
+
+	vec4 _S6 = _SV05gTestL0.a;
+
+	vec2 _S7 = _S5;
+
+
+    vec4 _S8 = texture(sampler2D(_SV05gTestL1, _SV05gTestL2), _S7);
+
+    vec4 _S9 = _S6 + _S8;
+	_S2 = _S9;
+
+	return;
 }


### PR DESCRIPTION
The standard library already has a bunch of these decorations, since they were added to support Slang->Vulkan codegen on the AST-to-AST path. This change makes the IR code generator able to exploit the modifiers so that we pick up a bunch of Vulkan support "for free" in the short term.

The basic change is in `lower-to-ir.cpp` where we copy over any `TargetIntrinsicModifier`s to become `IRTargetIntrinsicDecoration`s with the same information. We then need a bit of logic in `ir.cpp` to make sure we clone them as needed.

The core work of using the modifiers is in `emit.cpp`, where I basically just copy-pasted the existing logic that applied in the AST path (all the AST-related code there is dead, and we should clean it up soon).

The big change that comes with this logic is that when dealing with a member function, the numbering of the argument used in the intrinsic definition string changes, so that `$0` refers to the base object (whereas before the base object was looked up via the base expression of a `MemberExpr` used for the function). This requires a bunch of the definitions in the library to be updated; hopefully I caught them all.

For kicks, I've re-enabled a cross-compilation test just to confirm that we are generating valid SPIR-V for code that performs texture-fetch operations. I don't expect us to keep that test enabled as-is in the long term, though, because it would be much better to instead use render-test to do the same thing. Alas, beefing up the Vulkan support in render-test is an outstanding work item, and I didn't want to pollute this change with more work along those lines.