### PR TITLE
Handling of duplicate global shader parameter declarations

### DIFF
--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -241,6 +241,18 @@ DIAGNOSTIC(39999, Error, invalidFloatingPOintLiteralSuffix, "invalid suffix '$0'
 DIAGNOSTIC(39999, Error, conflictingExplicitBindingsForParameter, "conflicting explicit bindings for parameter '$0'")
 DIAGNOSTIC(39999, Warning, parameterBindingsOverlap, "explicit binding for parameter '$0' overlaps with parameter '$1'")
 
+
+DIAGNOSTIC(39999, Error, shaderParameterDeclarationsDontMatch, "declarations of shader parameter '$0' in different translation units don't match")
+
+DIAGNOSTIC(39999, Note, shaderParameterTypeMismatch, "type is declared as '$0' in one translation unit, and '$0' in another")
+DIAGNOSTIC(39999, Note, fieldTypeMisMatch, "type of field '$0' is declared as '$1' in one translation unit, and '$2' in another")
+DIAGNOSTIC(39999, Note, fieldDeclarationsDontMatch, "type '$0' is declared with different fields in each translation unit")
+DIAGNOSTIC(39999, Note, usedInDeclarationOf, "used in declaration of '$0'")
+
+
+
+
+
 DIAGNOSTIC(38000, Error, entryPointFunctionNotFound, "no function found matching entry point name '$0'")
 DIAGNOSTIC(38001, Error, ambiguousEntryPoint, "more than one function matches entry point name '$0'")
 DIAGNOSTIC(38002, Note, entryPointCandidate, "see candidate declaration for entry point '$0'")

--- a/source/slang/legalize-types.h
+++ b/source/slang/legalize-types.h
@@ -138,7 +138,7 @@ struct TuplePseudoType : LegalTypeImpl
     struct Element
     {
         // The field that this element replaces
-        DeclRef<VarDeclBase>    fieldDeclRef;
+        String mangledName;
 
         // The legalized type of the element
         LegalType               type;
@@ -161,7 +161,7 @@ struct PairInfo : RefObject
     struct Element
     {
         // The original field the element represents
-        DeclRef<Decl> fieldDeclRef;
+        String mangledName;
 
         // The conceptual type of the field.
         // If both the `hasOrdinary` and
@@ -192,11 +192,11 @@ struct PairInfo : RefObject
     // which fields are on which side(s).
     List<Element> elements;
 
-    Element* findElement(DeclRef<Decl> const& fieldDeclRef)
+    Element* findElement(String const& mangledName)
     {
         for (auto& ee : elements)
         {
-            if(ee.fieldDeclRef.Equals(fieldDeclRef))
+            if(ee.mangledName == mangledName)
                 return &ee;
         }
         return nullptr;
@@ -227,8 +227,8 @@ RefPtr<TypeLayout> getDerefTypeLayout(
     TypeLayout* typeLayout);
 
 RefPtr<VarLayout> getFieldLayout(
-    TypeLayout*             typeLayout,
-    DeclRef<VarDeclBase>    fieldDeclRef);
+    TypeLayout*     typeLayout,
+    String const&   mangledFieldName);
 
 // Represents the "chain" of declarations that
 // were followed to get to a variable that we
@@ -321,8 +321,8 @@ struct TuplePseudoVal : LegalValImpl
 {
     struct Element
     {
-        DeclRef<VarDeclBase>            fieldDeclRef;
-        LegalVal                        val;
+        String      mangledName;
+        LegalVal    val;
     };
 
     List<Element>   elements;


### PR DESCRIPTION
The changes in this PR both relate to cases where the user feeds the Slang compiler two distinct translation units (e.g., distinct files for their vertex and fragment shader), which share declarations of some global shader parameters (either by duplicating declarations, or by `#include`ing a common file).

The first change deals with the case where such parameters have the same name, but their types are somehow inconsistent between the declarations. The place where this check should be made was already present in the parameter binding logic, and just wasn't implemented.

The second change tries to make the IR code generator (type legalization in particular) robust in these cases. Previously we would end up dropping type layout information in cases where a shader parameter's layout was based on the type of a distinct declaration of the "same" parameter (since the field decl-refs embedded in it would be for the wrong `struct` declaration). I "fixed" this in a slightly heavy-handed fashion (just using mangled names instead of decl-refs), but that seems reasonable for our purposes.

The obvious alternative to this PR is to drop support for multiple translation units per compile request. I actually think that is the right answer in the long term, but for now it is easier to add this functionality than it is to port all of Falcor to conform to a new constraint like that.