### PR TITLE
Implement IR-level translation of system values for GLSL

### DIFF
--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -682,6 +682,8 @@ IRGlobalValue* getSpecializedGlobalValueForDeclRef(
     IRSpecializationState*  state,
     DeclRef<Decl> const&    declRef);
 
+struct ExtensionUsageTracker;
+
 // Clone the IR values reachable from the given entry point
 // into the IR module assocaited with the specialization state.
 // When multiple definitions of a symbol are found, the one
@@ -689,7 +691,8 @@ IRGlobalValue* getSpecializedGlobalValueForDeclRef(
 // used.
 void specializeIRForEntryPoint(
     IRSpecializationState*  state,
-    EntryPointRequest*  entryPointRequest);
+    EntryPointRequest*  entryPointRequest,
+    ExtensionUsageTracker*  extensionUsageTracker);
 
 // Find suitable uses of the `specialize` instruction that
 // can be replaced with references to specialized functions.


### PR DESCRIPTION
The approach here isn't ideal. We already have a pass that transforms HLSL varying input/output types into GLSL global variables. This change makes it so that when those inputs/outputs have system-value semantics, we generate a global variable declaration with the appropriate `gl_*` name (leaving the type the same for now). Later, when emitting code, we just skip emitting declarations for declarations with mangled names that start with `gl_*`.

A more complete implementation will be needed later on, which handles cases where the translation requires types to be changed (so that conversion code needs to be inserted).