### PR TITLE
Allow writes to UAV textures

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -566,16 +566,22 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
             if(baseShape != TextureType::ShapeCube)
             {
-				// TODO: In the case where `access` includes writeability,
-				// this should have both `get` and `set` accessors.
-
                 // subscript operator
                 sb << "__subscript(uint";
 				if(kBaseTextureTypes[tt].coordCount + isArray > 1)
 				{
 					sb << kBaseTextureTypes[tt].coordCount + isArray;
 				}
-				sb << " location) -> T;\n";
+				sb << " location) -> T";
+
+				if (access != SLANG_RESOURCE_ACCESS_READ)
+				{
+					sb << " { get; set; }\n";
+				}
+				else
+				{
+					sb << ";\n";
+				}
             }
 
             if( !isMultisample )

--- a/source/slang/core.meta.slang.h
+++ b/source/slang/core.meta.slang.h
@@ -569,16 +569,22 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
             if(baseShape != TextureType::ShapeCube)
             {
-				// TODO: In the case where `access` includes writeability,
-				// this should have both `get` and `set` accessors.
-
                 // subscript operator
                 sb << "__subscript(uint";
 				if(kBaseTextureTypes[tt].coordCount + isArray > 1)
 				{
 					sb << kBaseTextureTypes[tt].coordCount + isArray;
 				}
-				sb << " location) -> T;\n";
+				sb << " location) -> T";
+
+				if (access != SLANG_RESOURCE_ACCESS_READ)
+				{
+					sb << " { get; set; }\n";
+				}
+				else
+				{
+					sb << ";\n";
+				}
             }
 
             if( !isMultisample )

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -63,7 +63,7 @@ __generic<T, let N : int> __magic_type(HLSLInputPatchType) struct InputPatch
 
 __generic<T, let N : int> __magic_type(HLSLOutputPatchType) struct OutputPatch
 {
-    __subscript(uint index) -> T { set; }
+    __subscript(uint index) -> T;
 };
 
 __magic_type(HLSLRWByteAddressBufferType) struct RWByteAddressBuffer

--- a/source/slang/hlsl.meta.slang.h
+++ b/source/slang/hlsl.meta.slang.h
@@ -64,7 +64,7 @@ sb << "};\n";
 sb << "\n";
 sb << "__generic<T, let N : int> __magic_type(HLSLOutputPatchType) struct OutputPatch\n";
 sb << "{\n";
-sb << "    __subscript(uint index) -> T { set; }\n";
+sb << "    __subscript(uint index) -> T;\n";
 sb << "};\n";
 sb << "\n";
 sb << "__magic_type(HLSLRWByteAddressBufferType) struct RWByteAddressBuffer\n";

--- a/tests/front-end/uav-write.slang
+++ b/tests/front-end/uav-write.slang
@@ -1,0 +1,20 @@
+// uav-write.slang
+//TEST:SIMPLE:
+
+// Just confirming that code that writes to a UAV will type-check.
+
+RWTexture2D<float4> gOutput;
+
+float4 test(uint2 coord, float4 value)
+{
+	// read
+    value = value + gOutput[coord];
+
+    // write
+    gOutput[coord] = value;
+
+    // read-modify-write
+    gOutput[coord] += value;
+	
+	return value;
+}


### PR DESCRIPTION
Work on #415

This issue is already fixed in the `v0.10.*` line, but I'm back-porting the fix to `v0.9.*`.
The issue here was that the stdlib declarations for texture types were only including the `get` accessor for subscript operations, even if the texture was write-able.

I've also included the fixes for other subscript accessors in the stdlib (notably that `OutputPatch<T>` is readable, but not writable, despite what the name seems to imply).