### PR TITLE
Fix IR memory leaks.

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -1237,6 +1237,7 @@ namespace slang
 #include "source/slang/dxc-support.cpp"
 #include "source/slang/emit.cpp"
 #include "source/slang/ir.cpp"
+#include "source/slang/memory_pool.cpp"
 #include "source/slang/ir-legalize-types.cpp"
 #include "source/slang/ir-ssa.cpp"
 #include "source/slang/legalize-types.cpp"

--- a/source/core/smart-pointer.h
+++ b/source/core/smart-pointer.h
@@ -35,6 +35,11 @@ namespace Slang
             referenceCount++;
         }
 
+        void decreaseReference()
+        {
+            --referenceCount;
+        }
+
         void releaseReference()
         {
             SLANG_ASSERT(referenceCount != 0);
@@ -190,6 +195,15 @@ namespace Slang
         operator T*() const
         {
             return pointer;
+        }
+
+        T* detach()
+        {
+            if (pointer)
+                dynamic_cast<RefObject*>(pointer)->decreaseReference();
+            auto rs = pointer;
+            pointer = nullptr;
+            return rs;
         }
 
     private:

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -179,7 +179,7 @@ namespace Slang
         // This will only be valid/non-null after semantic
         // checking and IR generation are complete, so it
         // is not safe to use this field without testing for NULL.
-        IRModule* irModule;
+        RefPtr<IRModule> irModule;
     };
 
     // A request to generate output in some target format
@@ -225,7 +225,7 @@ namespace Slang
         RefPtr<ModuleDecl>  moduleDecl;
 
         // The IR for the module
-        IRModule* irModule = nullptr;
+        RefPtr<IRModule> irModule = nullptr;
     };
 
     class Session;

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -450,7 +450,6 @@ namespace Slang
 
         Dictionary<int, RefPtr<Type>> builtinTypes;
         Dictionary<String, Decl*> magicDecls;
-        List<RefPtr<Type>> canonicalTypes;
 
         void initializeTypes();
 
@@ -505,6 +504,7 @@ namespace Slang
             RefPtr<Scope> const&    scope,
             String const&           path,
             String const&           source);
+        ~Session();
     };
 
 }

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -313,6 +313,8 @@ namespace Slang
         // Map from the logical name of a module to its definition
         Dictionary<Name*, RefPtr<LoadedModule>> mapNameToLoadedModules;
 
+        // The resulting specialized IR module for each entry point request
+        List<RefPtr<IRModule>> compiledModules;
 
         CompileRequest(Session* session);
 

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -8158,6 +8158,7 @@ String emitEntryPoint(
         // TODO: do we want to emit directly from IR, or translate the
         // IR back into AST for emission?
         visitor.emitIRModule(&context, irModule);
+        destroyIRSpecializationState(irSpecializationState);
     }
 
     String code = sharedContext.sb.ProduceString();
@@ -8189,7 +8190,7 @@ String emitEntryPoint(
     finalResultBuilder << code;
 
     String finalResult = finalResultBuilder.ProduceString();
-
+    
     return finalResult;
 }
 

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -8158,6 +8158,10 @@ String emitEntryPoint(
         // TODO: do we want to emit directly from IR, or translate the
         // IR back into AST for emission?
         visitor.emitIRModule(&context, irModule);
+        
+        // retain the specialized ir module, because the current
+        // GlobalGenericParamSubstitution implementation may reference ir objects 
+        targetRequest->compileRequest->compiledModules.Add(irModule);
     }
     destroyIRSpecializationState(irSpecializationState);
 
@@ -8166,8 +8170,6 @@ String emitEntryPoint(
 
     // Now that we've emitted the code for all the declaratiosn in the file,
     // it is time to stich together the final output.
-
-
 
     // There may be global-scope modifiers that we should emit now
     visitor.emitGLSLPreprocessorDirectives(translationUnitSyntax);

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -8084,17 +8084,17 @@ String emitEntryPoint(
 
     EmitVisitor visitor(&context);
 
+    // We are going to create a fresh IR module that we will use to
+    // clone any code needed by the user's entry point.
+    IRSpecializationState* irSpecializationState = createIRSpecializationState(
+        entryPoint,
+        programLayout,
+        target,
+        targetRequest);
     {
         TypeLegalizationContext typeLegalizationContext;
         typeLegalizationContext.session = entryPoint->compileRequest->mSession;
 
-        // We are going to create a fresh IR module that we will use to
-        // clone any code needed by the user's entry point.
-        IRSpecializationState* irSpecializationState = createIRSpecializationState(
-            entryPoint,
-            programLayout,
-            target,
-            targetRequest);
         IRModule* irModule = getIRModule(irSpecializationState);
 
         typeLegalizationContext.irModule = irModule;
@@ -8158,8 +8158,8 @@ String emitEntryPoint(
         // TODO: do we want to emit directly from IR, or translate the
         // IR back into AST for emission?
         visitor.emitIRModule(&context, irModule);
-        destroyIRSpecializationState(irSpecializationState);
     }
+    destroyIRSpecializationState(irSpecializationState);
 
     String code = sharedContext.sb.ProduceString();
     sharedContext.sb.Clear();

--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -33,6 +33,11 @@ struct IRLayoutDecoration : IRDecoration
     enum { kDecorationOp = kIRDecorationOp_Layout };
 
     RefPtr<Layout>  layout;
+    virtual void dispose() override
+    {
+        IRDecoration::dispose();
+        layout = nullptr;
+    }
 };
 
 enum IRLoopControl
@@ -52,6 +57,11 @@ struct IRTargetSpecificDecoration : IRDecoration
 {
     // TODO: have a more structured representation of target specifiers
     String targetName;
+    virtual void dispose()override
+    {
+        IRDecoration::dispose();
+        targetName = String();
+    }
 };
 
 struct IRTargetDecoration : IRTargetSpecificDecoration
@@ -64,6 +74,11 @@ struct IRTargetIntrinsicDecoration : IRTargetSpecificDecoration
     enum { kDecorationOp = kIRDecorationOp_TargetIntrinsic };
 
     String definition;
+    virtual void dispose()override
+    {
+        IRTargetSpecificDecoration::dispose();
+        definition = String();
+    }
 };
 
 //
@@ -73,6 +88,11 @@ struct IRTargetIntrinsicDecoration : IRTargetSpecificDecoration
 struct IRDeclRef : IRValue
 {
     DeclRef<Decl> declRef;
+    virtual void dispose() override
+    {
+        IRValue::dispose();
+        declRef = decltype(declRef)();
+    }
 };
 
 // An instruction that specializes another IR value
@@ -333,6 +353,13 @@ struct IRWitnessTable : IRGlobalValue
     RefPtr<GenericDecl> genericDecl;
     DeclRef<Decl> subTypeDeclRef, supTypeDeclRef;
     IRValueList<IRWitnessTableEntry> entries;
+    virtual void dispose() override
+    {
+        IRGlobalValue::dispose();
+        genericDecl = decltype(genericDecl)();
+        subTypeDeclRef = decltype(subTypeDeclRef)();
+        supTypeDeclRef = decltype(supTypeDeclRef)();
+    }
 };
 
 // An instruction that yields an undefined value.

--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -2648,6 +2648,12 @@ namespace Slang
 #endif
     }
 
+    void IRValue::dispose()
+    {
+        IRObject::dispose();
+        type = decltype(type)();
+    }
+
     // Insert this instruction into the same basic block
     // as `other`, right before it.
     void IRInst::insertBefore(IRInst* other)
@@ -4739,9 +4745,9 @@ namespace Slang
         if( !module )
         {
             module = builder->createModule();
-            sharedBuilder->module = module;
         }
 
+        sharedBuilder->module = module;
         sharedContext->module = module;
         sharedContext->originalModule = originalModule;
         sharedContext->target = target;
@@ -4777,6 +4783,12 @@ namespace Slang
 
         IRSharedSpecContext* getSharedContext() { return &sharedContextStorage; }
         IRSpecContext* getContext() { return &contextStorage; }
+        ~IRSpecializationState()
+        {
+            newProgramLayout = nullptr;
+            contextStorage = IRSpecContext();
+            sharedContextStorage = IRSharedSpecContext();
+        }
     };
 
     IRSpecializationState* createIRSpecializationState(
@@ -4816,7 +4828,6 @@ namespace Slang
         auto context = state->getContext();
         context->shared = sharedContext;
         context->builder = &sharedContext->builderStorage;
-
         // Create the GlobalGenericParamSubstitution for substituting global generic types
         // into user-provided type arguments
         auto globalParamSubst = createGlobalGenericParamSubstitution(entryPointRequest, programLayout, context, originalIRModule);

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -2870,6 +2870,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         if (parentDecl->ParentDecl)
             witnessTable->genericDecl = dynamic_cast<GenericDecl*>(parentDecl->ParentDecl);
         witnessTable->subTypeDeclRef = makeDeclRef(parentDecl);
+        witnessTable->subTypeDeclRef.substitutions = createDefaultSubstitutions(context->getSession(), parentDecl);
         witnessTable->supTypeDeclRef = inheritanceDecl->base.type->AsDeclRefType()->declRef;
 
         // Register the value now, rather than later, to avoid

--- a/source/slang/memory_pool.cpp
+++ b/source/slang/memory_pool.cpp
@@ -1,0 +1,52 @@
+#include "memory_pool.h"
+
+namespace Slang
+{
+    const size_t kPoolSegmentSize = 4 << 20; // use 4MB segments
+
+    struct MemoryPoolSegment
+    {
+        unsigned char* data = nullptr;
+        size_t allocPtr = 0;
+        MemoryPoolSegment* nextSegment = nullptr;
+    };
+
+    MemoryPool::~MemoryPool()
+    {
+        while (curSegment)
+        {
+            auto nxtSegment = curSegment->nextSegment;
+            free(curSegment->data);
+            delete curSegment;
+            curSegment = nxtSegment;
+        }
+    }
+
+    void newSegment(MemoryPool* pool)
+    {
+        auto seg = new MemoryPoolSegment();
+        seg->nextSegment = pool->curSegment;
+        seg->data = (unsigned char*)malloc(kPoolSegmentSize);
+        pool->curSegment = seg;
+    }
+
+    void * MemoryPool::alloc(size_t size)
+    {
+        assert(size < kPoolSegmentSize);
+        // ensure there is a segment available
+        if (!curSegment)
+            newSegment(this);
+        if (curSegment->allocPtr + size > kPoolSegmentSize)
+            newSegment(this);
+        // alloc memory from current segment
+        void* rs = curSegment->data + curSegment->allocPtr;
+        curSegment->allocPtr += size;
+        return rs;
+    }
+    void * MemoryPool::allocZero(size_t size)
+    {
+        auto rs = alloc(size);
+        memset(rs, 0, size);
+        return rs;
+    }
+}

--- a/source/slang/memory_pool.h
+++ b/source/slang/memory_pool.h
@@ -1,0 +1,19 @@
+#ifndef SLANG_MEMORY_POOL_H
+#define SLANG_MEMORY_POOL_H
+
+#include "../core/basic.h"
+
+namespace Slang
+{
+    struct MemoryPoolSegment;
+
+    struct MemoryPool : public RefObject
+    {
+        MemoryPoolSegment* curSegment = nullptr;
+        ~MemoryPool();
+        void* alloc(size_t size);
+        void* allocZero(size_t size);
+    };
+}
+
+#endif

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -123,7 +123,13 @@ CompileRequest::CompileRequest(Session* session)
 }
 
 CompileRequest::~CompileRequest()
-{}
+{
+    // delete things that may reference IR objects first
+    targets = decltype(targets)();
+    translationUnits = decltype(translationUnits)();
+    entryPoints = decltype(entryPoints)();
+    types = decltype(types)();
+}
 
 
 RefPtr<Expr> CompileRequest::parseTypeString(TranslationUnitRequest * translationUnit, String typeStr, RefPtr<Scope> scope)

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -751,6 +751,9 @@ SLANG_API void spDestroySession(
 {
     if(!session) return;
     delete SESSION(session);
+#ifdef _MSC_VER
+    _CrtDumpMemoryLeaks();
+#endif
 }
 
 SLANG_API void spAddBuiltins(

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -734,6 +734,19 @@ void Session::addBuiltinSource(
     loadedModuleCode.Add(syntax);
 }
 
+Session::~Session()
+{
+    // free all built-in types first
+    errorType = nullptr;
+    initializerListType = nullptr;
+    overloadedType = nullptr;
+    irBasicBlockType = nullptr;
+
+    builtinTypes = decltype(builtinTypes)();
+    // destroy modules next
+    loadedModuleCode = decltype(loadedModuleCode)();
+}
+
 }
 
 // implementation of C interface

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -186,6 +186,7 @@
     <ClInclude Include="lookup.h" />
     <ClInclude Include="lower-to-ir.h" />
     <ClInclude Include="mangle.h" />
+    <ClInclude Include="memory_pool.h" />
     <ClInclude Include="modifier-defs.h" />
     <ClInclude Include="name.h" />
     <ClInclude Include="object-meta-begin.h" />
@@ -225,6 +226,7 @@
     <ClCompile Include="lookup.cpp" />
     <ClCompile Include="lower-to-ir.cpp" />
     <ClCompile Include="mangle.cpp" />
+    <ClCompile Include="memory_pool.cpp" />
     <ClCompile Include="name.cpp" />
     <ClCompile Include="options.cpp" />
     <ClCompile Include="parameter-binding.cpp" />

--- a/source/slang/slang.vcxproj.filters
+++ b/source/slang/slang.vcxproj.filters
@@ -45,6 +45,7 @@
     <ClInclude Include="mangle.h" />
     <ClInclude Include="legalize-types.h" />
     <ClInclude Include="ir-ssa.h" />
+    <ClInclude Include="memory_pool.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="check.cpp" />
@@ -75,6 +76,7 @@
     <ClCompile Include="ir-legalize-types.cpp" />
     <ClCompile Include="legalize-types.cpp" />
     <ClCompile Include="ir-ssa.cpp" />
+    <ClCompile Include="memory_pool.cpp" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="core.meta.slang" />

--- a/source/slang/syntax-base-defs.h
+++ b/source/slang/syntax-base-defs.h
@@ -119,7 +119,7 @@ public:
 protected:
     virtual bool EqualsImpl(Type * type) = 0;
 
-    virtual Type* CreateCanonicalType() = 0;
+    virtual RefPtr<Type> CreateCanonicalType() = 0;
     Type* canonicalType = nullptr;
     RefPtr<Type> canonicalTypeRefPtr;
 
@@ -227,7 +227,7 @@ RAW(
         return rs;
     }
     typedef List<KeyValuePair<RefPtr<Type>, RefPtr<Val>>> WitnessTableLookupTable;
-)
+    )
     // The witness tables for each interface this actual type implements
     SYNTAX_FIELD(WitnessTableLookupTable, witnessTables)
 END_SYNTAX_CLASS()

--- a/source/slang/type-defs.h
+++ b/source/slang/type-defs.h
@@ -10,7 +10,7 @@ public:
 
 protected:
     virtual bool EqualsImpl(Type * type) override;
-    virtual Type* CreateCanonicalType() override;
+    virtual RefPtr<Type> CreateCanonicalType() override;
     virtual int GetHashCode() override;
 )
 END_SYNTAX_CLASS()
@@ -23,7 +23,7 @@ RAW(
 
 protected:
     virtual bool EqualsImpl(Type * type) override;
-    virtual Type* CreateCanonicalType() override;
+    virtual RefPtr<Type> CreateCanonicalType() override;
     virtual int GetHashCode() override;
 )
 END_SYNTAX_CLASS()
@@ -37,7 +37,7 @@ public:
 protected:
     virtual bool EqualsImpl(Type * type) override;
     virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
-    virtual Type* CreateCanonicalType() override;
+    virtual RefPtr<Type> CreateCanonicalType() override;
     virtual int GetHashCode() override;
 )
 END_SYNTAX_CLASS()
@@ -51,7 +51,7 @@ public:
 
 protected:
     virtual bool EqualsImpl(Type * type) override;
-    virtual Type* CreateCanonicalType() override;
+    virtual RefPtr<Type> CreateCanonicalType() override;
     virtual int GetHashCode() override;
 )
 END_SYNTAX_CLASS()
@@ -77,7 +77,7 @@ RAW(
 protected:
     virtual int GetHashCode() override;
     virtual bool EqualsImpl(Type * type) override;
-    virtual Type* CreateCanonicalType() override;
+    virtual RefPtr<Type> CreateCanonicalType() override;
 )
 END_SYNTAX_CLASS()
 
@@ -103,7 +103,7 @@ RAW(
 protected:
     virtual BasicExpressionType* GetScalarType() override;
     virtual bool EqualsImpl(Type * type) override;
-    virtual Type* CreateCanonicalType() override;
+    virtual RefPtr<Type> CreateCanonicalType() override;
 )
 END_SYNTAX_CLASS()
 
@@ -312,7 +312,7 @@ RAW(
 
 protected:
     virtual bool EqualsImpl(Type * type) override;
-    virtual Type* CreateCanonicalType() override;
+    virtual RefPtr<Type> CreateCanonicalType() override;
     virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
     virtual int GetHashCode() override;
     )
@@ -331,7 +331,7 @@ RAW(
 
 protected:
     virtual bool EqualsImpl(Type * type) override;
-    virtual Type* CreateCanonicalType() override;
+    virtual RefPtr<Type> CreateCanonicalType() override;
     virtual int GetHashCode() override;
     )
 
@@ -356,7 +356,7 @@ public:
 
 protected:
     virtual bool EqualsImpl(Type * type) override;
-    virtual Type* CreateCanonicalType() override;
+    virtual RefPtr<Type> CreateCanonicalType() override;
     virtual int GetHashCode() override;
 )
 END_SYNTAX_CLASS()
@@ -440,7 +440,7 @@ RAW(
 
 protected:
     virtual bool EqualsImpl(Type * type) override;
-    virtual Type* CreateCanonicalType() override;
+    virtual RefPtr<Type> CreateCanonicalType() override;
     virtual int GetHashCode() override;
 )
 END_SYNTAX_CLASS()
@@ -469,7 +469,7 @@ RAW(
 protected:
     virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
     virtual bool EqualsImpl(Type * type) override;
-    virtual Type* CreateCanonicalType() override;
+    virtual RefPtr<Type> CreateCanonicalType() override;
     virtual int GetHashCode() override;
 )
 END_SYNTAX_CLASS()
@@ -495,6 +495,6 @@ SYNTAX_CLASS(GenericDeclRefType, Type)
 protected:
     virtual bool EqualsImpl(Type * type) override;
     virtual int GetHashCode() override;
-    virtual Type* CreateCanonicalType() override;
+    virtual RefPtr<Type> CreateCanonicalType() override;
 )
 END_SYNTAX_CLASS()

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -99,8 +99,9 @@ struct SlangShaderCompilerWrapper : public ShaderCompiler
                 spFindProfile(slangSession, request.computeShader.profile),
                 (int)rawTypeNames.Count(),
                 rawTypeNames.Buffer());
-			int compileErr = spCompile(slangRequest);
+
             spSetLineDirectiveMode(slangRequest, SLANG_LINE_DIRECTIVE_MODE_NONE);
+			int compileErr = spCompile(slangRequest);
 			if (auto diagnostics = spGetDiagnosticOutput(slangRequest))
 			{
 				fprintf(stderr, "%s", diagnostics);


### PR DESCRIPTION
1. make IRModule class own a memory pool for all IR object allocations
2. For now, we allow IR objects to own other (externally) heap allocated objects, such as String, List and RefPtrs by tracking all IR objects that  has been allocated for the IRModule in a list named `IRModule::irObjectsToFree`. and call destructor for all these objects upon the destruction of the IRModule. In the long term, we should eliminate the use of all these externally allocated types in IR system and get rid of this tracking and explicit destructor calls.
3. remove non-generic `createValueImpl` functions and retain only generic versions in IRBulider so we can properly call the constructor of the IR types to set up virtual tables correctly for destructor dispatching.
4. add `MemoryPool` class for allocation of the IR objects.
5. Make sure we are disposing IRSpecContexts when we are done with the specialized IR module.
6. Add `_CrtDumpMemoryLeaks()` calls to check memory leaks upon destruction of a Slang session. If we are to support multiple sessions at a time, this call should probably be replaced with the more advanced MemoryState versions of the memory leak checker.