### PR TITLE
Make `IRGlobalValue::mangledName` a `Name*`

### DIFF
--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -429,7 +429,7 @@ namespace Slang
 
         RootNamePool* getRootNamePool() { return &rootNamePool; }
         NamePool* getNamePool() { return &namePool; }
-
+        Name* getNameObj(String name) { return namePool.getName(name); }
         //
 
         // Generated code for stdlib, etc.

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -4584,8 +4584,8 @@ emitDeclImpl(decl, nullptr);
         case kIROp_Func:
             {
                 auto& mangledName = ((IRGlobalValue*)inst)->mangledName;
-                if(mangledName.Length() != 0)
-                    return mangledName;
+                if(getText(mangledName).Length() != 0)
+                    return getText(mangledName);
             }
             break;
 
@@ -5582,7 +5582,7 @@ emitDeclImpl(decl, nullptr);
         // be better strategies (including just stuffing
         // a pointer to the original decl onto the callee).
 
-        UnmangleContext um(func->mangledName);
+        UnmangleContext um(getText(func->mangledName));
         um.startUnmangling();
 
         // We'll read through the qualified name of the
@@ -7679,7 +7679,7 @@ emitDeclImpl(decl, nullptr);
             // actually *require* redeclaration...).
             //
             // TODO: can we detect this more robustly?
-            if(varDecl->mangledName.StartsWith("gl_"))
+            if(getText(varDecl->mangledName).StartsWith("gl_"))
             {
                 // The variable represents an OpenGL system value,
                 // so we will assume that it doesn't need to be declared.

--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -406,7 +406,7 @@ struct SharedIRBuilder
 
     Dictionary<IRInstKey,       IRInst*>    globalValueNumberingMap;
     Dictionary<IRConstantKey,   IRConstant*>    constantMap;
-    Dictionary<String, IRWitnessTable*> witnessTableMap;
+    Dictionary<Name*, IRWitnessTable*> witnessTableMap;
 };
 
 struct IRBuilderSourceLocRAII;
@@ -523,7 +523,7 @@ struct IRBuilder
         IRWitnessTable* witnessTable,
         IRValue*        requirementKey,
         IRValue*        satisfyingVal);
-    IRWitnessTable* lookupWitnessTable(String mangledName);
+    IRWitnessTable* lookupWitnessTable(Name* mangledName);
     void registerWitnessTable(IRWitnessTable* table);
     IRBlock* createBlock();
     IRBlock* emitBlock();

--- a/source/slang/ir-legalize-types.cpp
+++ b/source/slang/ir-legalize-types.cpp
@@ -14,6 +14,7 @@
 #include "ir-insts.h"
 #include "legalize-types.h"
 #include "mangle.h"
+#include "name.h"
 
 namespace Slang
 {
@@ -111,14 +112,13 @@ static void maybeRegisterLegalizedGlobal(
     // Check the mangled name of the symbol and don't register
     // symbols that don't have an external name (currently
     // indicated by them having an empty name string).
-    String mangledName = irGlobalVar->mangledName;
-    if (mangledName.Length() == 0)
+    if (getText(irGlobalVar->mangledName).Length() == 0)
         return;
 
     // Otherwise, register the legalized value for this symbol
     // under its mangled name, so that other code can still
     // find the right value(s) to use after legalization.
-    context->typeLegalizationContext->mapMangledNameToLegalIRValue.AddIfNotExists(mangledName, legalVal);
+    context->typeLegalizationContext->mapMangledNameToLegalIRValue.AddIfNotExists(irGlobalVar->mangledName, legalVal);
 }
 
 struct IRGlobalNameInfo
@@ -893,12 +893,12 @@ static LegalVal declareSimpleVar(
             // a counter to each leaf variable generated from the original
             if (globalNameInfo)
             {
-                String mangledName = globalNameInfo->globalVar->mangledName;
-                if (mangledName.Length() != 0)
+                String mangledNameStr = getText(globalNameInfo->globalVar->mangledName);
+                if (mangledNameStr.Length() != 0)
                 {
-                    mangledName.append("L");
-                    mangledName.append(globalNameInfo->counter++);
-                    globalVar->mangledName = mangledName;
+                    mangledNameStr.append("L");
+                    mangledNameStr.append(globalNameInfo->counter++);
+                    globalVar->mangledName = context->session->getNameObj(mangledNameStr);
                 }
             }
             

--- a/source/slang/ir.h
+++ b/source/slang/ir.h
@@ -20,7 +20,7 @@ class   FuncType;
 class   Layout;
 class   Type;
 class   Session;
-
+class   Name;
 struct  IRFunc;
 struct  IRGlobalValueWithCode;
 struct  IRInst;
@@ -480,7 +480,7 @@ struct IRGlobalValue : IRValue
 
     // The mangled name, for a symbol that should have linkage,
     // or which might have multiple declarations.
-    String mangledName;
+    Name* mangledName = nullptr;
 
 
     IRGlobalValue*  nextGlobalValue;
@@ -500,11 +500,6 @@ struct IRGlobalValue : IRValue
     void removeFromParent();
 
     void moveToEnd();
-    virtual void dispose() override
-    {
-        IRValue::dispose();
-        mangledName = String();
-    }
 };
 
 /// @brief A global value that potentially holds executable code.

--- a/source/slang/legalize-types.h
+++ b/source/slang/legalize-types.h
@@ -26,6 +26,7 @@
 #include "../core/basic.h"
 #include "syntax.h"
 #include "type-layout.h"
+#include "name.h"
 
 namespace Slang
 {
@@ -382,7 +383,7 @@ struct TypeLegalizationContext
     Dictionary<DeclRef<Decl>, LegalType> mapDeclRefToLegalType;
 
     //
-    Dictionary<String, LegalVal> mapMangledNameToLegalIRValue;
+    Dictionary<Name*, LegalVal> mapMangledNameToLegalIRValue;
 };
 
 

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -2812,7 +2812,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         {
             for (auto subInheritanceDeclRef : getMembersOfType<InheritanceDecl>(baseInterfaceDeclRef))
             {
-                auto cpyMangledName = getMangledNameForConformanceWitness(subType, subInheritanceDeclRef.getDecl()->getSup().type);
+                auto cpyMangledName = context->getSession()->getNameObj(getMangledNameForConformanceWitness(subType, subInheritanceDeclRef.getDecl()->getSup().type));
                 if (!witnessTablesDictionary.ContainsKey(cpyMangledName))
                 {
                     auto cpyTable = context->irBuilder->createWitnessTable();
@@ -2820,14 +2820,14 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                     context->irBuilder->createWitnessTableEntry(witnessTable,
                         context->irBuilder->getDeclRefVal(subInheritanceDeclRef), cpyTable);
                     cpyTable->entries = witnessTable->entries;
-                    witnessTablesDictionary.Add(cpyMangledName, cpyTable);
+                    witnessTablesDictionary.Add(cpyTable->mangledName, cpyTable);
                     walkInheritanceHierarchyAndCreateWitnessTableCopies(witnessTable, subType, subInheritanceDeclRef.getDecl());
                 }
             }
         }
     }
 
-    Dictionary<String, IRWitnessTable*> witnessTablesDictionary;
+    Dictionary<Name*, IRWitnessTable*> witnessTablesDictionary;
 
     LoweredValInfo visitInheritanceDecl(InheritanceDecl* inheritanceDecl)
     {
@@ -2859,7 +2859,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         // Construct the mangled name for the witness table, which depends
         // on the type that is conforming, and the type that it conforms to.
-        String mangledName = getMangledNameForConformanceWitness(type, superType);
+        auto mangledName = context->getSession()->getNameObj(getMangledNameForConformanceWitness(type, superType));
 
         // Build an IR level witness table, which will represent the
         // conformance of the type to its super-type.
@@ -2999,7 +2999,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             irGlobal = builder->createGlobalVar(varType);
             globalVal = LoweredValInfo::ptr(irGlobal);
         }
-        irGlobal->mangledName = getMangledName(decl);
+        irGlobal->mangledName = context->getSession()->getNameObj(getMangledName(decl));
 
         if (decl)
         {
@@ -3458,7 +3458,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         String mangledName = getMangledName(decl);
 
-        irFunc->mangledName = mangledName;
+        irFunc->mangledName = context->getSession()->getNameObj(mangledName);
     }
 
     ModuleDecl* findModuleDecl(Decl* decl)


### PR DESCRIPTION
This allows us to get rid of `IRGlobalValue::dispose()`.