### PR TITLE
Fix infinite loop in semantic parsing

### DIFF
--- a/tests/diagnostics/missing-semicolon-after-semantic.slang
+++ b/tests/diagnostics/missing-semicolon-after-semantic.slang
@@ -1,0 +1,9 @@
+//TEST:SIMPLE:
+
+// Forgetting to put in the `;` after declaraing a variable/field
+// with a semantic used to put the compiler into an infinite loop.
+
+struct Test
+{
+	float4 pos : SV_POSITION
+};

--- a/tests/diagnostics/missing-semicolon-after-semantic.slang.expected
+++ b/tests/diagnostics/missing-semicolon-after-semantic.slang.expected
@@ -1,0 +1,6 @@
+result code = -1
+standard error = {
+tests/diagnostics/missing-semicolon-after-semantic.slang(9): error 20001: unexpected '}', expected ';'
+}
+standard output = {
+}


### PR DESCRIPTION
The code for parsing semantics was looking for a fixed set of tokens to terminate a semantic list, rather than assuming that whenever you don't see a `:` ahead, you probably are done with semantics. This meant that you could get into an infinite loop just with simple mistakes like leaving out a `;`.

This change fixes the parser to note infinite loop in this case, and adds a test case to verify the fix.