### PR TITLE
 Refactor IR type system, step 0

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -1263,7 +1263,7 @@ namespace slang
 #include "source/slang/reflection.cpp"
 #include "source/slang/slang.cpp"
 #include "source/slang/vm.cpp"
-
+#include "source/slang/type-system-shared.cpp"
 #endif
 
 #endif

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -316,24 +316,24 @@ for( int C = 2; C <= 4; ++C )
 
 
 
-sb << "__magic_type(SamplerState," << int(SamplerStateType::Flavor::SamplerState) << ")\n";
-sb << "__intrinsic_type(" << kIROp_SamplerType << ", " << int(SamplerStateType::Flavor::SamplerState) << ")\n";
+sb << "__magic_type(SamplerState," << int(SamplerStateFlavor::SamplerState) << ")\n";
+sb << "__intrinsic_type(" << kIROp_SamplerType << ", " << int(SamplerStateFlavor::SamplerState) << ")\n";
 sb << "struct SamplerState {};";
         
-sb << "__magic_type(SamplerState," << int(SamplerStateType::Flavor::SamplerComparisonState) << ")\n";
-sb << "__intrinsic_type(" << kIROp_SamplerType << ", " << int(SamplerStateType::Flavor::SamplerComparisonState) << ")\n";
+sb << "__magic_type(SamplerState," << int(SamplerStateFlavor::SamplerComparisonState) << ")\n";
+sb << "__intrinsic_type(" << kIROp_SamplerType << ", " << int(SamplerStateFlavor::SamplerComparisonState) << ")\n";
 sb << "struct SamplerComparisonState {};";
 
 // TODO(tfoley): Need to handle `RW*` variants of texture types as well...
 static const struct {
-    char const*			name;
-    TextureType::Shape	baseShape;
-    int					coordCount;
+    char const*			    name;
+    TextureFlavor::Shape	baseShape;
+    int					    coordCount;
 } kBaseTextureTypes[] = {
-    { "Texture1D",		TextureType::Shape1D,	1 },
-    { "Texture2D",		TextureType::Shape2D,	2 },
-    { "Texture3D",		TextureType::Shape3D,	3 },
-    { "TextureCube",	TextureType::ShapeCube,	3 },
+    { "Texture1D",		TextureFlavor::Shape::Shape1D,	1 },
+    { "Texture2D",		TextureFlavor::Shape::Shape2D,	2 },
+    { "Texture3D",		TextureFlavor::Shape::Shape3D,	3 },
+    { "TextureCube",	TextureFlavor::Shape::ShapeCube,	3 },
 };
 static const int kBaseTextureTypeCount = sizeof(kBaseTextureTypes) / sizeof(kBaseTextureTypes[0]);
 
@@ -355,12 +355,12 @@ static const int kBaseTextureAccessLevelCount = sizeof(kBaseTextureAccessLevels)
 for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 {
     char const* name = kBaseTextureTypes[tt].name;
-    TextureType::Shape baseShape = kBaseTextureTypes[tt].baseShape;
+    TextureFlavor::Shape baseShape = kBaseTextureTypes[tt].baseShape;
 
     for (int isArray = 0; isArray < 2; ++isArray)
     {
         // Arrays of 3D textures aren't allowed
-        if (isArray && baseShape == TextureType::Shape3D) continue;
+        if (isArray && baseShape == TextureFlavor::Shape::Shape3D) continue;
 
         for (int isMultisample = 0; isMultisample < 2; ++isMultisample)
         for (int accessLevel = 0; accessLevel < kBaseTextureAccessLevelCount; ++accessLevel)
@@ -370,9 +370,9 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
             // TODO: any constraints to enforce on what gets to be multisampled?
 
             unsigned flavor = baseShape;
-            if (isArray)		flavor |= TextureType::ArrayFlag;
-            if (isMultisample)	flavor |= TextureType::MultisampleFlag;
-//                        if (isShadow)		flavor |= TextureType::ShadowFlag;
+            if (isArray)		flavor |= TextureFlavor::ArrayFlag;
+            if (isMultisample)	flavor |= TextureFlavor::MultisampleFlag;
+//                        if (isShadow)		flavor |= TextureFlavor::ShadowFlag;
 
             flavor |= (access << 8);
 
@@ -412,12 +412,12 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 {
     char const* name = kBaseTextureTypes[tt].name;
-    TextureType::Shape baseShape = kBaseTextureTypes[tt].baseShape;
+    TextureFlavor::Shape baseShape = kBaseTextureTypes[tt].baseShape;
 
     for (int isArray = 0; isArray < 2; ++isArray)
     {
         // Arrays of 3D textures aren't allowed
-        if (isArray && baseShape == TextureType::Shape3D) continue;
+        if (isArray && baseShape == TextureFlavor::Shape::Shape3D) continue;
 
         for (int isMultisample = 0; isMultisample < 2; ++isMultisample)
         for (int accessLevel = 0; accessLevel < kBaseTextureAccessLevelCount; ++accessLevel)
@@ -427,9 +427,9 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
             // TODO: any constraints to enforce on what gets to be multisampled?
 
             unsigned flavor = baseShape;
-            if (isArray)		flavor |= TextureType::ArrayFlag;
-            if (isMultisample)	flavor |= TextureType::MultisampleFlag;
-//                        if (isShadow)		flavor |= TextureType::ShadowFlag;
+            if (isArray)		flavor |= TextureFlavor::ArrayFlag;
+            if (isMultisample)	flavor |= TextureFlavor::MultisampleFlag;
+//                        if (isShadow)		flavor |= TextureFlavor::ShadowFlag;
 
             flavor |= (access << 8);
 
@@ -491,19 +491,19 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                     int cc = 0;
                     switch(baseShape)
                     {
-                    case TextureType::Shape1D:
+                    case TextureFlavor::Shape::Shape1D:
                         sb << "($" << aa++ << opStr << "))";
                         cc = 1;
                         break;
 
-                    case TextureType::Shape2D:
-                    case TextureType::ShapeCube:
+                    case TextureFlavor::Shape::Shape2D:
+                    case TextureFlavor::Shape::ShapeCube:
                         sb << "($" << aa++ << opStr << ").x)";
                         sb << ", ($" << aa++ << opStr << ").y)";
                         cc = 2;
                         break;
 
-                    case TextureType::Shape3D:
+                    case TextureFlavor::Shape::Shape3D:
                         sb << "($" << aa++ << opStr << ").x)";
                         sb << ", ($" << aa++ << opStr << ").y)";
                         sb << ", ($" << aa++ << opStr << ").z)";
@@ -542,17 +542,17 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 switch(baseShape)
                 {
-                case TextureType::Shape1D:
+                case TextureFlavor::Shape::Shape1D:
                     sb << t << "width";
                     break;
 
-                case TextureType::Shape2D:
-                case TextureType::ShapeCube:
+                case TextureFlavor::Shape::Shape2D:
+                case TextureFlavor::Shape::ShapeCube:
                     sb << t << "width,";
                     sb << t << "height";
                     break;
 
-                case TextureType::Shape3D:
+                case TextureFlavor::Shape::Shape3D:
                     sb << t << "width,";
                     sb << t << "height,";
                     sb << t << "depth";
@@ -642,7 +642,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 sb << ");\n";
             }
 
-            if(baseShape != TextureType::ShapeCube)
+            if(baseShape != TextureFlavor::Shape::ShapeCube)
             {
                 int N = kBaseTextureTypes[tt].coordCount + isArray;
 
@@ -698,7 +698,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 sb << "T Sample(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location);\n";
 
-                if( baseShape != TextureType::ShapeCube )
+                if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     sb << "__target_intrinsic(glsl, \"textureOffset($$p, $2, $3)\")\n";
                     sb << "T Sample(SamplerState s, ";
@@ -708,7 +708,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 sb << "T Sample(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
-                if( baseShape != TextureType::ShapeCube )
+                if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     sb << "constexpr int" << kBaseTextureTypes[tt].coordCount << " offset, ";
                 }
@@ -716,7 +716,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 sb << "T Sample(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
-                if( baseShape != TextureType::ShapeCube )
+                if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     sb << "constexpr int" << kBaseTextureTypes[tt].coordCount << " offset, ";
                 }
@@ -728,7 +728,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 sb << "T SampleBias(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, float bias);\n";
 
-                if( baseShape != TextureType::ShapeCube )
+                if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     sb << "__target_intrinsic(glsl, \"textureOffset($$p, $2, $3, $4)\")\n";
                     sb << "T SampleBias(SamplerState s, ";
@@ -788,7 +788,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 sb << "float compareValue";
                 sb << ");\n";
 
-                if( baseShape != TextureType::ShapeCube )
+                if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     // Note(tfoley): MSDN seems confused, and claims that the `offset`
                     // parameter for `SampleCmp` is available for everything but 3D
@@ -817,7 +817,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 sb << "float" << kBaseTextureTypes[tt].coordCount << " gradY";
                 sb << ");\n";
 
-                if( baseShape != TextureType::ShapeCube )
+                if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     sb << "__target_intrinsic(glsl, \"textureGradOffset($$p, $2, $3, $4, $5)\")\n";
 //                    sb << "__intrinsic_op(sampleGrad)\n";
@@ -835,7 +835,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                 sb << "float level);\n";
 
-                if( baseShape != TextureType::ShapeCube )
+                if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     sb << "__target_intrinsic(glsl, \"textureLodOffset($$p, $2, $3, $4)\")\n";
                     sb << "T SampleLevel(SamplerState s, ";

--- a/source/slang/core.meta.slang.h
+++ b/source/slang/core.meta.slang.h
@@ -319,24 +319,24 @@ for( int C = 2; C <= 4; ++C )
 
 
 
-sb << "__magic_type(SamplerState," << int(SamplerStateType::Flavor::SamplerState) << ")\n";
-sb << "__intrinsic_type(" << kIROp_SamplerType << ", " << int(SamplerStateType::Flavor::SamplerState) << ")\n";
+sb << "__magic_type(SamplerState," << int(SamplerStateFlavor::SamplerState) << ")\n";
+sb << "__intrinsic_type(" << kIROp_SamplerType << ", " << int(SamplerStateFlavor::SamplerState) << ")\n";
 sb << "struct SamplerState {};";
         
-sb << "__magic_type(SamplerState," << int(SamplerStateType::Flavor::SamplerComparisonState) << ")\n";
-sb << "__intrinsic_type(" << kIROp_SamplerType << ", " << int(SamplerStateType::Flavor::SamplerComparisonState) << ")\n";
+sb << "__magic_type(SamplerState," << int(SamplerStateFlavor::SamplerComparisonState) << ")\n";
+sb << "__intrinsic_type(" << kIROp_SamplerType << ", " << int(SamplerStateFlavor::SamplerComparisonState) << ")\n";
 sb << "struct SamplerComparisonState {};";
 
 // TODO(tfoley): Need to handle `RW*` variants of texture types as well...
 static const struct {
-    char const*			name;
-    TextureType::Shape	baseShape;
-    int					coordCount;
+    char const*			    name;
+    TextureFlavor::Shape	baseShape;
+    int					    coordCount;
 } kBaseTextureTypes[] = {
-    { "Texture1D",		TextureType::Shape1D,	1 },
-    { "Texture2D",		TextureType::Shape2D,	2 },
-    { "Texture3D",		TextureType::Shape3D,	3 },
-    { "TextureCube",	TextureType::ShapeCube,	3 },
+    { "Texture1D",		TextureFlavor::Shape::Shape1D,	1 },
+    { "Texture2D",		TextureFlavor::Shape::Shape2D,	2 },
+    { "Texture3D",		TextureFlavor::Shape::Shape3D,	3 },
+    { "TextureCube",	TextureFlavor::Shape::ShapeCube,	3 },
 };
 static const int kBaseTextureTypeCount = sizeof(kBaseTextureTypes) / sizeof(kBaseTextureTypes[0]);
 
@@ -358,12 +358,12 @@ static const int kBaseTextureAccessLevelCount = sizeof(kBaseTextureAccessLevels)
 for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 {
     char const* name = kBaseTextureTypes[tt].name;
-    TextureType::Shape baseShape = kBaseTextureTypes[tt].baseShape;
+    TextureFlavor::Shape baseShape = kBaseTextureTypes[tt].baseShape;
 
     for (int isArray = 0; isArray < 2; ++isArray)
     {
         // Arrays of 3D textures aren't allowed
-        if (isArray && baseShape == TextureType::Shape3D) continue;
+        if (isArray && baseShape == TextureFlavor::Shape::Shape3D) continue;
 
         for (int isMultisample = 0; isMultisample < 2; ++isMultisample)
         for (int accessLevel = 0; accessLevel < kBaseTextureAccessLevelCount; ++accessLevel)
@@ -373,9 +373,9 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
             // TODO: any constraints to enforce on what gets to be multisampled?
 
             unsigned flavor = baseShape;
-            if (isArray)		flavor |= TextureType::ArrayFlag;
-            if (isMultisample)	flavor |= TextureType::MultisampleFlag;
-//                        if (isShadow)		flavor |= TextureType::ShadowFlag;
+            if (isArray)		flavor |= TextureFlavor::ArrayFlag;
+            if (isMultisample)	flavor |= TextureFlavor::MultisampleFlag;
+//                        if (isShadow)		flavor |= TextureFlavor::ShadowFlag;
 
             flavor |= (access << 8);
 
@@ -415,12 +415,12 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 {
     char const* name = kBaseTextureTypes[tt].name;
-    TextureType::Shape baseShape = kBaseTextureTypes[tt].baseShape;
+    TextureFlavor::Shape baseShape = kBaseTextureTypes[tt].baseShape;
 
     for (int isArray = 0; isArray < 2; ++isArray)
     {
         // Arrays of 3D textures aren't allowed
-        if (isArray && baseShape == TextureType::Shape3D) continue;
+        if (isArray && baseShape == TextureFlavor::Shape::Shape3D) continue;
 
         for (int isMultisample = 0; isMultisample < 2; ++isMultisample)
         for (int accessLevel = 0; accessLevel < kBaseTextureAccessLevelCount; ++accessLevel)
@@ -430,9 +430,9 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
             // TODO: any constraints to enforce on what gets to be multisampled?
 
             unsigned flavor = baseShape;
-            if (isArray)		flavor |= TextureType::ArrayFlag;
-            if (isMultisample)	flavor |= TextureType::MultisampleFlag;
-//                        if (isShadow)		flavor |= TextureType::ShadowFlag;
+            if (isArray)		flavor |= TextureFlavor::ArrayFlag;
+            if (isMultisample)	flavor |= TextureFlavor::MultisampleFlag;
+//                        if (isShadow)		flavor |= TextureFlavor::ShadowFlag;
 
             flavor |= (access << 8);
 
@@ -494,19 +494,19 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                     int cc = 0;
                     switch(baseShape)
                     {
-                    case TextureType::Shape1D:
+                    case TextureFlavor::Shape::Shape1D:
                         sb << "($" << aa++ << opStr << "))";
                         cc = 1;
                         break;
 
-                    case TextureType::Shape2D:
-                    case TextureType::ShapeCube:
+                    case TextureFlavor::Shape::Shape2D:
+                    case TextureFlavor::Shape::ShapeCube:
                         sb << "($" << aa++ << opStr << ").x)";
                         sb << ", ($" << aa++ << opStr << ").y)";
                         cc = 2;
                         break;
 
-                    case TextureType::Shape3D:
+                    case TextureFlavor::Shape::Shape3D:
                         sb << "($" << aa++ << opStr << ").x)";
                         sb << ", ($" << aa++ << opStr << ").y)";
                         sb << ", ($" << aa++ << opStr << ").z)";
@@ -545,17 +545,17 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 switch(baseShape)
                 {
-                case TextureType::Shape1D:
+                case TextureFlavor::Shape::Shape1D:
                     sb << t << "width";
                     break;
 
-                case TextureType::Shape2D:
-                case TextureType::ShapeCube:
+                case TextureFlavor::Shape::Shape2D:
+                case TextureFlavor::Shape::ShapeCube:
                     sb << t << "width,";
                     sb << t << "height";
                     break;
 
-                case TextureType::Shape3D:
+                case TextureFlavor::Shape::Shape3D:
                     sb << t << "width,";
                     sb << t << "height,";
                     sb << t << "depth";
@@ -645,7 +645,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 sb << ");\n";
             }
 
-            if(baseShape != TextureType::ShapeCube)
+            if(baseShape != TextureFlavor::Shape::ShapeCube)
             {
                 int N = kBaseTextureTypes[tt].coordCount + isArray;
 
@@ -701,7 +701,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 sb << "T Sample(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location);\n";
 
-                if( baseShape != TextureType::ShapeCube )
+                if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     sb << "__target_intrinsic(glsl, \"textureOffset($p, $2, $3)\")\n";
                     sb << "T Sample(SamplerState s, ";
@@ -711,7 +711,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 sb << "T Sample(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
-                if( baseShape != TextureType::ShapeCube )
+                if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     sb << "constexpr int" << kBaseTextureTypes[tt].coordCount << " offset, ";
                 }
@@ -719,7 +719,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 sb << "T Sample(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
-                if( baseShape != TextureType::ShapeCube )
+                if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     sb << "constexpr int" << kBaseTextureTypes[tt].coordCount << " offset, ";
                 }
@@ -731,7 +731,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 sb << "T SampleBias(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, float bias);\n";
 
-                if( baseShape != TextureType::ShapeCube )
+                if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     sb << "__target_intrinsic(glsl, \"textureOffset($p, $2, $3, $4)\")\n";
                     sb << "T SampleBias(SamplerState s, ";
@@ -791,7 +791,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 sb << "float compareValue";
                 sb << ");\n";
 
-                if( baseShape != TextureType::ShapeCube )
+                if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     // Note(tfoley): MSDN seems confused, and claims that the `offset`
                     // parameter for `SampleCmp` is available for everything but 3D
@@ -820,7 +820,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 sb << "float" << kBaseTextureTypes[tt].coordCount << " gradY";
                 sb << ");\n";
 
-                if( baseShape != TextureType::ShapeCube )
+                if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     sb << "__target_intrinsic(glsl, \"textureGradOffset($p, $2, $3, $4, $5)\")\n";
 //                    sb << "__intrinsic_op(sampleGrad)\n";
@@ -838,7 +838,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                 sb << "float level);\n";
 
-                if( baseShape != TextureType::ShapeCube )
+                if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     sb << "__target_intrinsic(glsl, \"textureLodOffset($p, $2, $3, $4)\")\n";
                     sb << "T SampleLevel(SamplerState s, ";

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -960,11 +960,11 @@ struct EmitVisitor
 
         switch (texType->GetBaseShape())
         {
-        case TextureType::Shape1D:		Emit("Texture1D");		break;
-        case TextureType::Shape2D:		Emit("Texture2D");		break;
-        case TextureType::Shape3D:		Emit("Texture3D");		break;
-        case TextureType::ShapeCube:	Emit("TextureCube");	break;
-        case TextureType::ShapeBuffer:  Emit("Buffer");         break;
+        case TextureFlavor::Shape::Shape1D:		Emit("Texture1D");		break;
+        case TextureFlavor::Shape::Shape2D:		Emit("Texture2D");		break;
+        case TextureFlavor::Shape::Shape3D:		Emit("Texture3D");		break;
+        case TextureFlavor::Shape::ShapeCube:	Emit("TextureCube");	break;
+        case TextureFlavor::Shape::ShapeBuffer:  Emit("Buffer");         break;
         default:
             SLANG_DIAGNOSE_UNEXPECTED(getSink(), SourceLoc(), "unhandled resource shape");
             break;
@@ -992,11 +992,11 @@ struct EmitVisitor
         Emit(baseName);
         switch (type->GetBaseShape())
         {
-        case TextureType::Shape1D:		Emit("1D");		break;
-        case TextureType::Shape2D:		Emit("2D");		break;
-        case TextureType::Shape3D:		Emit("3D");		break;
-        case TextureType::ShapeCube:	Emit("Cube");	break;
-        case TextureType::ShapeBuffer:	Emit("Buffer");	break;
+        case TextureFlavor::Shape::Shape1D:		Emit("1D");		break;
+        case TextureFlavor::Shape::Shape2D:		Emit("2D");		break;
+        case TextureFlavor::Shape::Shape3D:		Emit("3D");		break;
+        case TextureFlavor::Shape::ShapeCube:	Emit("Cube");	break;
+        case TextureFlavor::Shape::ShapeBuffer:	Emit("Buffer");	break;
         default:
             SLANG_DIAGNOSE_UNEXPECTED(getSink(), SourceLoc(), "unhandled resource shape");
             break;
@@ -1245,8 +1245,8 @@ struct EmitVisitor
         default:
             switch (samplerStateType->flavor)
             {
-            case SamplerStateType::Flavor::SamplerState:			Emit("SamplerState");			break;
-            case SamplerStateType::Flavor::SamplerComparisonState:	Emit("SamplerComparisonState");	break;
+            case SamplerStateFlavor::SamplerState:			Emit("SamplerState");			break;
+            case SamplerStateFlavor::SamplerComparisonState:	Emit("SamplerComparisonState");	break;
             default:
                 SLANG_DIAGNOSE_UNEXPECTED(getSink(), SourceLoc(), "unhandled sampler state flavor");
                 break;
@@ -1256,8 +1256,8 @@ struct EmitVisitor
         case CodeGenTarget::GLSL:
             switch (samplerStateType->flavor)
             {
-            case SamplerStateType::Flavor::SamplerState:			Emit("sampler");		break;
-            case SamplerStateType::Flavor::SamplerComparisonState:	Emit("samplerShadow");	break;
+            case SamplerStateFlavor::SamplerState:			Emit("sampler");		break;
+            case SamplerStateFlavor::SamplerComparisonState:	Emit("samplerShadow");	break;
             default:
                 SLANG_DIAGNOSE_UNEXPECTED(getSink(), SourceLoc(), "unhandled sampler state flavor");
                 break;
@@ -2179,7 +2179,7 @@ struct EmitVisitor
 
                                         if (auto samplerType = callExpr->Arguments[0]->type.type->As<SamplerStateType>())
                                         {
-                                            if (samplerType->flavor == SamplerStateType::Flavor::SamplerComparisonState)
+                                            if (samplerType->flavor == SamplerStateFlavor::SamplerComparisonState)
                                             {
                                                 Emit("Shadow");
                                             }
@@ -5447,7 +5447,7 @@ emitDeclImpl(decl, nullptr);
 
                             if (auto samplerType = samplerArg->type->As<SamplerStateType>())
                             {
-                                if (samplerType->flavor == SamplerStateType::Flavor::SamplerComparisonState)
+                                if (samplerType->flavor == SamplerStateFlavor::SamplerComparisonState)
                                 {
                                     Emit("Shadow");
                                 }

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -58,14 +58,14 @@ sb << "__generic<T : __BuiltinArithmeticType, let R : int, let N : int, let C : 
 // TODO(tfoley): Need to handle `RW*` variants of texture types as well...
 static const struct {
     char const*			name;
-    TextureType::Shape	baseShape;
+    TextureFlavor::Shape	baseShape;
     int					coordCount;
 } kBaseTextureTypes[] = {
-    { "1D",		TextureType::Shape1D,	1 },
-    { "2D",		TextureType::Shape2D,	2 },
-    { "3D",		TextureType::Shape3D,	3 },
-    { "Cube",	TextureType::ShapeCube,	3 },
-    { "Buffer", TextureType::ShapeBuffer,   1 },
+    { "1D",		TextureFlavor::Shape::Shape1D,	1 },
+    { "2D",		TextureFlavor::Shape::Shape2D,	2 },
+    { "3D",		TextureFlavor::Shape::Shape3D,	3 },
+    { "Cube",	TextureFlavor::Shape::ShapeCube,	3 },
+    { "Buffer", TextureFlavor::Shape::ShapeBuffer,   1 },
 };
 static const int kBaseTextureTypeCount = sizeof(kBaseTextureTypes) / sizeof(kBaseTextureTypes[0]);
 
@@ -83,12 +83,12 @@ static const int kBaseTextureAccessLevelCount = sizeof(kBaseTextureAccessLevels)
 for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 {
     char const* shapeName = kBaseTextureTypes[tt].name;
-    TextureType::Shape baseShape = kBaseTextureTypes[tt].baseShape;
+    TextureFlavor::Shape baseShape = kBaseTextureTypes[tt].baseShape;
 
     for (int isArray = 0; isArray < 2; ++isArray)
     {
         // Arrays of 3D textures aren't allowed
-        if (isArray && baseShape == TextureType::Shape3D) continue;
+        if (isArray && baseShape == TextureFlavor::Shape::Shape3D) continue;
 
         for (int isMultisample = 0; isMultisample < 2; ++isMultisample)
         {
@@ -99,9 +99,9 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                         
             unsigned flavor = baseShape;
-            if (isArray)		flavor |= TextureType::ArrayFlag;
-            if (isMultisample)	flavor |= TextureType::MultisampleFlag;
-//                        if (isShadow)		flavor |= TextureType::ShadowFlag;
+            if (isArray)		flavor |= TextureFlavor::ArrayFlag;
+            if (isMultisample)	flavor |= TextureFlavor::MultisampleFlag;
+//                        if (isShadow)		flavor |= TextureFlavor::ShadowFlag;
 
 
 
@@ -154,7 +154,7 @@ sb << "__generic<T> __magic_type(GLSLInputParameterGroupType) struct __GLSLInput
 sb << "__generic<T> __magic_type(GLSLOutputParameterGroupType) struct __GLSLOutputParameterGroup {};\n";
 sb << "__generic<T> __magic_type(GLSLShaderStorageBufferType) struct __GLSLShaderStorageBuffer {};\n";
 
-sb << "__magic_type(SamplerState," << int(SamplerStateType::Flavor::SamplerState) << ") struct sampler {};";
+sb << "__magic_type(SamplerState," << int(SamplerStateFlavor::SamplerState) << ") struct sampler {};";
 
 sb << "__magic_type(GLSLInputAttachmentType) struct subpassInput {};";
 

--- a/source/slang/glsl.meta.slang.h
+++ b/source/slang/glsl.meta.slang.h
@@ -59,14 +59,14 @@ sb << "__generic<T : __BuiltinArithmeticType, let R : int, let N : int, let C : 
 // TODO(tfoley): Need to handle `RW*` variants of texture types as well...
 static const struct {
     char const*			name;
-    TextureType::Shape	baseShape;
+    TextureFlavor::Shape	baseShape;
     int					coordCount;
 } kBaseTextureTypes[] = {
-    { "1D",		TextureType::Shape1D,	1 },
-    { "2D",		TextureType::Shape2D,	2 },
-    { "3D",		TextureType::Shape3D,	3 },
-    { "Cube",	TextureType::ShapeCube,	3 },
-    { "Buffer", TextureType::ShapeBuffer,   1 },
+    { "1D",		TextureFlavor::Shape::Shape1D,	1 },
+    { "2D",		TextureFlavor::Shape::Shape2D,	2 },
+    { "3D",		TextureFlavor::Shape::Shape3D,	3 },
+    { "Cube",	TextureFlavor::Shape::ShapeCube,	3 },
+    { "Buffer", TextureFlavor::Shape::ShapeBuffer,   1 },
 };
 static const int kBaseTextureTypeCount = sizeof(kBaseTextureTypes) / sizeof(kBaseTextureTypes[0]);
 
@@ -84,12 +84,12 @@ static const int kBaseTextureAccessLevelCount = sizeof(kBaseTextureAccessLevels)
 for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 {
     char const* shapeName = kBaseTextureTypes[tt].name;
-    TextureType::Shape baseShape = kBaseTextureTypes[tt].baseShape;
+    TextureFlavor::Shape baseShape = kBaseTextureTypes[tt].baseShape;
 
     for (int isArray = 0; isArray < 2; ++isArray)
     {
         // Arrays of 3D textures aren't allowed
-        if (isArray && baseShape == TextureType::Shape3D) continue;
+        if (isArray && baseShape == TextureFlavor::Shape::Shape3D) continue;
 
         for (int isMultisample = 0; isMultisample < 2; ++isMultisample)
         {
@@ -100,9 +100,9 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                         
             unsigned flavor = baseShape;
-            if (isArray)		flavor |= TextureType::ArrayFlag;
-            if (isMultisample)	flavor |= TextureType::MultisampleFlag;
-//                        if (isShadow)		flavor |= TextureType::ShadowFlag;
+            if (isArray)		flavor |= TextureFlavor::ArrayFlag;
+            if (isMultisample)	flavor |= TextureFlavor::MultisampleFlag;
+//                        if (isShadow)		flavor |= TextureFlavor::ShadowFlag;
 
 
 
@@ -155,7 +155,7 @@ sb << "__generic<T> __magic_type(GLSLInputParameterGroupType) struct __GLSLInput
 sb << "__generic<T> __magic_type(GLSLOutputParameterGroupType) struct __GLSLOutputParameterGroup {};\n";
 sb << "__generic<T> __magic_type(GLSLShaderStorageBufferType) struct __GLSLShaderStorageBuffer {};\n";
 
-sb << "__magic_type(SamplerState," << int(SamplerStateType::Flavor::SamplerState) << ") struct sampler {};";
+sb << "__magic_type(SamplerState," << int(SamplerStateFlavor::SamplerState) << ") struct sampler {};";
 
 sb << "__magic_type(GLSLInputAttachmentType) struct subpassInput {};";
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -1086,7 +1086,7 @@ for (int aa = 0; aa < kBaseBufferAccessLevelCount; ++aa)
 {
 
     sb << "__generic<T> __magic_type(Texture, ";
-    sb << ResourceType::makeFlavor(ResourceType::Shape::ShapeBuffer, kBaseBufferAccessLevels[aa].access);
+    sb << TextureFlavor::create(TextureFlavor::Shape::ShapeBuffer, kBaseBufferAccessLevels[aa].access).flavor;
     sb << ") struct ";
     sb << kBaseBufferAccessLevels[aa].name;
     sb << "Buffer {\n";

--- a/source/slang/hlsl.meta.slang.h
+++ b/source/slang/hlsl.meta.slang.h
@@ -1090,7 +1090,7 @@ for (int aa = 0; aa < kBaseBufferAccessLevelCount; ++aa)
 {
 
     sb << "__generic<T> __magic_type(Texture, ";
-    sb << ResourceType::makeFlavor(ResourceType::Shape::ShapeBuffer, kBaseBufferAccessLevels[aa].access);
+    sb << TextureFlavor::create(TextureFlavor::Shape::ShapeBuffer, kBaseBufferAccessLevels[aa].access).flavor;
     sb << ") struct ";
     sb << kBaseBufferAccessLevels[aa].name;
     sb << "Buffer {\n";

--- a/source/slang/ir-type-defs.h
+++ b/source/slang/ir-type-defs.h
@@ -1,0 +1,3 @@
+#ifndef TYPE
+#error Must #define `TYPE` before including `ir-type-defs.h`
+#endif

--- a/source/slang/ir-types.h
+++ b/source/slang/ir-types.h
@@ -1,0 +1,109 @@
+#ifndef SLANG_IR_TYPES_H
+#define SLANG_IR_TYPES_H
+
+#include "ir.h"
+#include "type-system-shared.h"
+
+namespace Slang
+{
+    struct IRBasicType : public IRType
+    {
+        BaseType type;
+    };
+    struct IRBuiltinGenericType : public IRType
+    {
+        IRUse elementType;
+    };
+    struct IRVectorType : public IRBuiltinGenericType
+    {
+        int vectorSize;
+    };
+    struct IRMatrixType : public IRBuiltinGenericType
+    {
+        int rows, cols;
+    };
+    struct IRArrayType : public IRBuiltinGenericType
+    {
+        IRUse size;
+    };
+    struct IRFuncType : public IRType
+    {
+        IRUse returnType;
+        IRType* getParameterType(uint32_t i);
+        int getParameterCount();
+    };
+    
+    struct IRTextureBaseType : public IRBuiltinGenericType
+    {
+    public:
+        TextureFlavor flavor;
+    };
+    struct IRTextureType : public IRTextureBaseType
+    {};
+    struct IRTextureSamplerType : public IRBuiltinGenericType
+    {};
+    struct IRSamplerStateType : public IRType
+    {};
+    struct IRGLSLImageType : public IRTextureBaseType
+    {};
+    struct IRPointerType : public IRBuiltinGenericType
+    {};
+    struct IROutBaseType : public IRPointerType
+    {};
+    struct IROutType : public IROutBaseType
+    {};
+    struct IRInOutType : public IROutBaseType
+    {};
+    struct IRHLSLStructuredBufferBaseType : public IRBuiltinGenericType
+    {};
+    struct IRHLSLStructuredBufferType : public IRHLSLStructuredBufferBaseType
+    {};
+    struct IRHLSLRWStructuredBufferType : public IRHLSLStructuredBufferBaseType
+    {};
+    struct IRHLSLAppendStructuredBufferType : public IRHLSLStructuredBufferBaseType
+    {};
+    struct IRHLSLConsumeStructuredBufferType : public IRHLSLStructuredBufferBaseType
+    {};
+    struct IRUntypedBufferResourceType : public IRType
+    {};
+    struct IRHLSLByteAddressBufferType : public IRUntypedBufferResourceType
+    {};
+    struct IRHLSLRWByteAddressBufferType : public IRUntypedBufferResourceType
+    {};
+    struct IRHLSLPatchType : public IRBuiltinGenericType
+    {};
+    struct IRHLSLInputPatchType : public IRHLSLPatchType
+    {};
+    struct IRHLSLOutputPatchType : public IRHLSLPatchType
+    {};
+    struct IRHLSLStreamOutputType : public IRBuiltinGenericType
+    {};
+    struct IRHLSLPointStreamType : public IRHLSLStreamOutputType
+    {};
+    struct IRHLSLLineStreamType : public IRHLSLStreamOutputType
+    {};
+    struct IRHLSLTriangleStreamType : public IRHLSLStreamOutputType
+    {};
+    struct IRGLSLInputAttachmentType : public IRType
+    {};
+    struct IRParameterGroupType : public IRPointerType
+    {};
+    struct IRUniformParameterGroupType : public IRParameterGroupType
+    {};
+    struct IRVaryingParameterGroupType : public IRParameterGroupType
+    {};
+    struct IRConstantBufferType : public IRParameterGroupType
+    {};
+    struct IRTextureBufferType : public IRParameterGroupType
+    {};
+    struct IRGLSLInputParameterGroupType : public IRVaryingParameterGroupType
+    {};
+    struct IRGLSLOutputParameterGroupType : public IRVaryingParameterGroupType
+    {};
+    struct IRGLSLShaderStorageBufferType : public IRUniformParameterGroupType
+    {};
+    struct IRParameterBlockType : public IRUniformParameterGroupType
+    {};
+};
+
+#endif

--- a/source/slang/ir.h
+++ b/source/slang/ir.h
@@ -57,6 +57,9 @@ enum IROp : int16_t
 
 #include "ir-inst-defs.h"
 
+#define TYPE(ID) kIRType_##ID,
+#include "ir-type-defs.h"
+
     kIROp_Invalid = -1,
 
 };

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -181,6 +181,8 @@
     <ClInclude Include="ir-inst-defs.h" />
     <ClInclude Include="ir-insts.h" />
     <ClInclude Include="ir-ssa.h" />
+    <ClInclude Include="ir-type-defs.h" />
+    <ClInclude Include="ir-types.h" />
     <ClInclude Include="ir.h" />
     <ClInclude Include="legalize-types.h" />
     <ClInclude Include="lexer.h" />
@@ -208,6 +210,7 @@
     <ClInclude Include="token.h" />
     <ClInclude Include="type-defs.h" />
     <ClInclude Include="type-layout.h" />
+    <ClInclude Include="type-system-shared.h" />
     <ClInclude Include="val-defs.h" />
     <ClInclude Include="visitor.h" />
     <ClInclude Include="vm.h" />
@@ -242,6 +245,7 @@
     <ClCompile Include="syntax.cpp" />
     <ClCompile Include="token.cpp" />
     <ClCompile Include="type-layout.cpp" />
+    <ClCompile Include="type-system-shared.cpp" />
     <ClCompile Include="vm.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/source/slang/slang.vcxproj.filters
+++ b/source/slang/slang.vcxproj.filters
@@ -47,6 +47,9 @@
     <ClInclude Include="ir-ssa.h" />
     <ClInclude Include="memory_pool.h" />
     <ClInclude Include="ir-constexpr.h" />
+    <ClInclude Include="ir-types.h" />
+    <ClInclude Include="ir-type-defs.h" />
+    <ClInclude Include="type-system-shared.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="check.cpp" />
@@ -79,6 +82,7 @@
     <ClCompile Include="ir-ssa.cpp" />
     <ClCompile Include="memory_pool.cpp" />
     <ClCompile Include="ir-constexpr.cpp" />
+    <ClCompile Include="type-system-shared.cpp" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="core.meta.slang" />

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -735,7 +735,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
                 auto type = new SamplerStateType();
                 type->setSession(session);
                 type->declRef = declRef;
-                type->flavor = SamplerStateType::Flavor(magicMod->tag);
+                type->flavor = SamplerStateFlavor(magicMod->tag);
                 return type;
             }
             else if (magicMod->name == "Vector")
@@ -760,7 +760,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             {
                 SLANG_ASSERT(subst && subst->args.Count() >= 1);
                 auto textureType = new TextureType(
-                    TextureType::Flavor(magicMod->tag),
+                    TextureFlavor(magicMod->tag),
                     ExtractGenericArgType(subst->args[0]));
                 textureType->setSession(session);
                 textureType->declRef = declRef;
@@ -770,7 +770,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             {
                 SLANG_ASSERT(subst && subst->args.Count() >= 1);
                 auto textureType = new TextureSamplerType(
-                    TextureType::Flavor(magicMod->tag),
+                    TextureFlavor(magicMod->tag),
                     ExtractGenericArgType(subst->args[0]));
                 textureType->setSession(session);
                 textureType->declRef = declRef;
@@ -780,7 +780,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             {
                 SLANG_ASSERT(subst && subst->args.Count() >= 1);
                 auto textureType = new GLSLImageType(
-                    TextureType::Flavor(magicMod->tag),
+                    TextureFlavor(magicMod->tag),
                     ExtractGenericArgType(subst->args[0]));
                 textureType->setSession(session);
                 textureType->declRef = declRef;

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -5,7 +5,7 @@
 #include "ir.h"
 #include "lexer.h"
 #include "profile.h"
-
+#include "type-system-shared.h"
 #include "../../slang.h"
 
 #include <assert.h>
@@ -88,19 +88,6 @@ namespace Slang
     // We either need to keep that restriction, or
     // look up promotion rank by some other means.
     //
-    enum class BaseType
-    {
-        // Note(tfoley): These are ordered in terms of promotion rank, so be vareful when messing with this
-
-        Void = 0,
-        Bool,
-        Int,
-        UInt,
-        UInt64,
-        Half,
-        Float,
-        Double,
-    };
 
     class Decl;
     class Val;

--- a/source/slang/type-defs.h
+++ b/source/slang/type-defs.h
@@ -109,56 +109,18 @@ END_SYNTAX_CLASS()
 
 // Base type for things we think of as "resources"
 ABSTRACT_SYNTAX_CLASS(ResourceTypeBase, DeclRefType)
-RAW(
-    enum
-    {
-        // Mask for the overall "shape" of the texture
-        ShapeMask		= SLANG_RESOURCE_BASE_SHAPE_MASK,
+    FIELD(TextureFlavor, flavor)
+    RAW(
+        TextureFlavor::Shape GetBaseShape()
+        {
+            return flavor.GetBaseShape();
+        }
+        bool isMultisample() { return flavor.isMultisample(); }
+        bool isArray() { return flavor.isArray(); }
+        SlangResourceShape getShape() const { return flavor.getShape(); }
+        SlangResourceAccess getAccess() { return flavor.getAccess(); }
 
-        // Flag for whether the shape has "array-ness"
-        ArrayFlag		= SLANG_TEXTURE_ARRAY_FLAG,
-
-        // Whether or not the texture stores multiple samples per pixel
-        MultisampleFlag	= SLANG_TEXTURE_MULTISAMPLE_FLAG,
-
-        // Whether or not this is a shadow texture
-        //
-        // TODO(tfoley): is this even meaningful/used?
-        // ShadowFlag		= 0x80, 
-    };
-
-    enum Shape : uint8_t
-    {
-        Shape1D			= SLANG_TEXTURE_1D,
-        Shape2D			= SLANG_TEXTURE_2D,
-        Shape3D			= SLANG_TEXTURE_3D,
-        ShapeCube		= SLANG_TEXTURE_CUBE,
-        ShapeBuffer     = SLANG_TEXTURE_BUFFER,
-
-        Shape1DArray	= Shape1D | ArrayFlag,
-        Shape2DArray	= Shape2D | ArrayFlag,
-        // No Shape3DArray
-        ShapeCubeArray	= ShapeCube | ArrayFlag,
-    };
-
-    Shape GetBaseShape() const { return Shape(flavor & ShapeMask); }
-    bool isArray() const { return (flavor & ArrayFlag) != 0; }
-    bool isMultisample() const { return (flavor & MultisampleFlag) != 0; }
-//            bool isShadow() const { return (flavor & ShadowFlag) != 0; }
-
-    SlangResourceShape getShape() const { return flavor & 0xFF; }
-    SlangResourceAccess getAccess() const { return (flavor >> 8) & 0xFF; }
-
-    // Bits representing the kind of resource we are looking at
-    // (e.g., `Texture2DMS` vs. `TextureCubeArray`)
-    typedef uint16_t Flavor;
-
-    static Flavor makeFlavor(SlangResourceShape shape, SlangResourceAccess access)
-    {
-        return Flavor(shape | (access << 8));
-    }
-)
-    FIELD(Flavor, flavor)
+    )
 END_SYNTAX_CLASS()
 
 // Resources that contain "elements" that can be fetched
@@ -172,7 +134,7 @@ RAW(
     TextureTypeBase()
     {}
     TextureTypeBase(
-        Flavor flavor,
+        TextureFlavor flavor,
         RefPtr<Type> elementType)
     {
         this->elementType = elementType;
@@ -186,7 +148,7 @@ RAW(
     TextureType()
     {}
     TextureType(
-        Flavor flavor,
+        TextureFlavor flavor,
         RefPtr<Type> elementType)
         : TextureTypeBase(flavor, elementType)
     {}
@@ -200,7 +162,7 @@ RAW(
     TextureSamplerType()
     {}
     TextureSamplerType(
-        Flavor flavor,
+        TextureFlavor flavor,
         RefPtr<Type> elementType)
         : TextureTypeBase(flavor, elementType)
     {}
@@ -213,7 +175,7 @@ RAW(
     GLSLImageType()
     {}
     GLSLImageType(
-        Flavor flavor,
+        TextureFlavor flavor,
         RefPtr<Type> elementType)
         : TextureTypeBase(flavor, elementType)
     {}
@@ -221,16 +183,8 @@ RAW(
 END_SYNTAX_CLASS()
 
 SYNTAX_CLASS(SamplerStateType, DeclRefType)
-
     // What flavor of sampler state is this
-    RAW(enum class Flavor : uint8_t
-    {
-        SamplerState,
-        SamplerComparisonState,
-    };
-
-    )
-    FIELD(Flavor, flavor)
+    FIELD(SamplerStateFlavor, flavor)
 END_SYNTAX_CLASS()
 
 // Other cases of generic types known to the compiler

--- a/source/slang/type-system-shared.cpp
+++ b/source/slang/type-system-shared.cpp
@@ -1,0 +1,11 @@
+#include "type-system-shared.h"
+
+namespace Slang
+{
+    TextureFlavor TextureFlavor::create(SlangResourceShape shape, SlangResourceAccess access)
+    {
+        TextureFlavor rs;
+        rs.flavor = uint16_t(shape | (access << 8));
+        return rs;
+    }
+}

--- a/source/slang/type-system-shared.h
+++ b/source/slang/type-system-shared.h
@@ -1,0 +1,77 @@
+#ifndef SLANG_TYPE_SYSTEM_SHARED_H
+#define SLANG_TYPE_SYSTEM_SHARED_H
+
+#include "../../slang.h"
+
+namespace Slang
+{
+    enum class BaseType
+    {
+        Void = 0,
+        Bool,
+        Int,
+        UInt,
+        UInt64,
+        Half,
+        Float,
+        Double,
+    };
+
+    struct TextureFlavor
+    {
+        enum
+        {
+            // Mask for the overall "shape" of the texture
+            ShapeMask = SLANG_RESOURCE_BASE_SHAPE_MASK,
+
+            // Flag for whether the shape has "array-ness"
+            ArrayFlag = SLANG_TEXTURE_ARRAY_FLAG,
+
+            // Whether or not the texture stores multiple samples per pixel
+            MultisampleFlag = SLANG_TEXTURE_MULTISAMPLE_FLAG,
+
+            // Whether or not this is a shadow texture
+            //
+            // TODO(tfoley): is this even meaningful/used?
+            // ShadowFlag		= 0x80, 
+        };
+
+        enum Shape : uint8_t
+        {
+            Shape1D = SLANG_TEXTURE_1D,
+            Shape2D = SLANG_TEXTURE_2D,
+            Shape3D = SLANG_TEXTURE_3D,
+            ShapeCube = SLANG_TEXTURE_CUBE,
+            ShapeBuffer = SLANG_TEXTURE_BUFFER,
+
+            Shape1DArray = Shape1D | ArrayFlag,
+            Shape2DArray = Shape2D | ArrayFlag,
+            // No Shape3DArray
+            ShapeCubeArray = ShapeCube | ArrayFlag,
+        };
+
+        uint16_t flavor;
+
+        Shape GetBaseShape() const { return Shape(flavor & ShapeMask); }
+        bool isArray() const { return (flavor & ArrayFlag) != 0; }
+        bool isMultisample() const { return (flavor & MultisampleFlag) != 0; }
+        //            bool isShadow() const { return (flavor & ShadowFlag) != 0; }
+
+        SlangResourceShape getShape() const { return flavor & 0xFF; }
+        SlangResourceAccess getAccess() const { return (flavor >> 8) & 0xFF; }
+
+        TextureFlavor() = default;
+        TextureFlavor(uint32_t tag) { flavor = (uint16_t)tag; }
+
+        static TextureFlavor create(SlangResourceShape shape, SlangResourceAccess access);
+    };
+
+    enum class SamplerStateFlavor : uint8_t
+    {
+        SamplerState,
+        SamplerComparisonState,
+    };
+
+}
+
+#endif


### PR DESCRIPTION
Pull BaseType, TextureFlavor and SamplerStateFlavor enums and helper functions into a shared file "type-system-shared.h", so that they can be shared by both front-end and IR type systems.