### PR TITLE
Fix GS stream types

### DIFF
--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -827,8 +827,8 @@ void Type::accept(IValVisitor* visitor, void* extra)
             CASE(HLSLConsumeStructuredBufferType, HLSLConsumeStructuredBufferType)
 
             CASE(HLSLPointStreamType, HLSLPointStreamType)
-            CASE(HLSLLineStreamType, HLSLPointStreamType)
-            CASE(HLSLTriangleStreamType, HLSLPointStreamType)
+            CASE(HLSLLineStreamType, HLSLLineStreamType)
+            CASE(HLSLTriangleStreamType, HLSLTriangleStreamType)
 
             #undef CASE
 


### PR DESCRIPTION
The code in `DeclRefType::Create` was treating all of the point/line/triangle output stream types as `HLSLPointStreamType`, which meant we always output GLSL geometry shaders with `layout(points) out;`.