### PR TITLE
IR: next phase of "everything is an instruction"

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -1241,6 +1241,7 @@ namespace slang
 #include "source/slang/ir-constexpr.cpp"
 #include "source/slang/ir-legalize-types.cpp"
 #include "source/slang/ir-ssa.cpp"
+#include "source/slang/ir-validate.cpp"
 #include "source/slang/legalize-types.cpp"
 #include "source/slang/lexer.cpp"
 #include "source/slang/mangle.cpp"

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -275,6 +275,7 @@ namespace Slang
         bool shouldDumpIntermediates = false;
 
         bool shouldDumpIR = false;
+        bool shouldValidateIR = false;
         bool shouldSkipCodegen = false;
 
         // How should `#line` directives be emitted (if at all)?

--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -286,7 +286,9 @@ DIAGNOSTIC(40005, Error, topLevelModuleUsedWithoutSpecifyingBinding, "top level 
 
 DIAGNOSTIC(49999, Error, unknownSystemValueSemantic, "unknown system-value semantic '$0'")
 
-DIAGNOSTIC(40006, Error, needCompileTimeConstant, "expected a compile-time constant");
+DIAGNOSTIC(40006, Error, needCompileTimeConstant, "expected a compile-time constant")
+
+DIAGNOSTIC(40007, Internal, irValidationFailed, "IR validation failed: $0")
 
 //
 // 5xxxx - Target code generation.

--- a/source/slang/diagnostics.cpp
+++ b/source/slang/diagnostics.cpp
@@ -93,6 +93,12 @@ SourceLoc const& getDiagnosticPos(TypeExp const& typeExp)
     return typeExp.exp->loc;
 }
 
+SourceLoc const& getDiagnosticPos(IRInst* inst)
+{
+    return inst->sourceLoc;
+}
+
+
 // Take the format string for a diagnostic message, along with its arguments, and turn it into a
 static void formatDiagnosticMessage(StringBuilder& sb, char const* format, int argCount, DiagnosticArg const* const* args)
 {

--- a/source/slang/diagnostics.h
+++ b/source/slang/diagnostics.h
@@ -94,10 +94,12 @@ namespace Slang
     inline SourceLoc const& getDiagnosticPos(SourceLoc const& pos) { return pos;  }
 
     class SyntaxNode;
-    class ShaderClosure;
     SourceLoc const& getDiagnosticPos(SyntaxNode const* syntax);
     SourceLoc const& getDiagnosticPos(Token const& token);
     SourceLoc const& getDiagnosticPos(TypeExp const& typeExp);
+
+    struct IRInst;
+    SourceLoc const& getDiagnosticPos(IRInst* inst);
 
     template<typename T>
     SourceLoc getDiagnosticPos(RefPtr<T> const& ptr)

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -3,6 +3,7 @@
 
 #include "ir-insts.h"
 #include "ir-ssa.h"
+#include "ir-validate.h"
 #include "legalize-types.h"
 #include "lower-to-ir.h"
 #include "mangle.h"
@@ -8200,6 +8201,7 @@ String emitEntryPoint(
         typeLegalizationContext.session = entryPoint->compileRequest->mSession;
 
         IRModule* irModule = getIRModule(irSpecializationState);
+        auto compileRequest = translationUnit->compileRequest;
 
         typeLegalizationContext.irModule = irModule;
 
@@ -8207,6 +8209,8 @@ String emitEntryPoint(
             irSpecializationState,
             entryPoint,
             &sharedContext.extensionUsageTracker);
+
+        validateIRModuleIfEnabled(compileRequest, irModule);
 
         // If the user specified the flag that they want us to dump
         // IR, then do it here, for the target-specific, but
@@ -8254,6 +8258,7 @@ String emitEntryPoint(
         // so that we can work with the individual fields).
         constructSSA(irModule);
 
+        validateIRModuleIfEnabled(compileRequest, irModule);
 
         // After all of the required optimization and legalization
         // passes have been performed, we can emit target code from

--- a/source/slang/ir-constexpr.cpp
+++ b/source/slang/ir-constexpr.cpp
@@ -234,8 +234,7 @@ bool propagateConstExprBackward(
 
     IRBuilder builder;
     builder.sharedBuilder = &sharedBuilder;
-    builder.curFunc = code;
-    builder.curBlock = nullptr;
+    builder.setInsertInto(code);
 
     bool anyChanges = false;
     for(;;)
@@ -432,9 +431,6 @@ void propagateConstExpr(
     context.sharedBuilder.module = module;
     context.sharedBuilder.session = session;
     context.builder.sharedBuilder = &context.sharedBuilder;
-    context.builder.curFunc = nullptr;
-    context.builder.curBlock = nullptr;
-
 
 
     // We need to propagate information both forward and backward.

--- a/source/slang/ir-inst-defs.h
+++ b/source/slang/ir-inst-defs.h
@@ -115,22 +115,25 @@ INST(makeStruct, makeStruct, 0, 0)
 
 INST(Call, call, 1, 0)
 
-INST(Module, module, 0, PARENT)
+/*IRParentInst*/
 
-INST(Block, block, 0, PARENT)
+    INST(Module, module, 0, PARENT)
 
-/*IRGlobalValue*/
+    INST(Block, block, 0, PARENT)
 
-    /*IRGlobalValueWithCode*/
-        INST(Func, func, 0, PARENT)
-        INST(global_var, global_var, 0, 0)
-        INST(global_constant, global_constant, 0, 0)
-    INST_RANGE(GlobalValueWithCode, Func, global_constant)
+    /*IRGlobalValue*/
 
-    INST(witness_table, witness_table, 0, 0)
+        /*IRGlobalValueWithCode*/
+            INST(Func, func, 0, PARENT)
+            INST(global_var, global_var, 0, 0)
+            INST(global_constant, global_constant, 0, 0)
+        INST_RANGE(GlobalValueWithCode, Func, global_constant)
+
+        INST(witness_table, witness_table, 0, 0)
 
     INST_RANGE(GlobalValue, Func, witness_table)
 
+INST_RANGE(ParentInst, Module, witness_table)
 
 INST(witness_table_entry, witness_table_entry, 2, 0)
 
@@ -241,36 +244,9 @@ INST(BitOr, or , 2, 0)
 INST(And, logicalAnd, 2, 0)
 INST(Or, logicalOr, 2, 0)
 
-#if 0
-INST(Assign, assign, 2, 0)
-INST(AddAssign, addAssign, 2, 0)
-INST(SubAssign, subAssign, 2, 0)
-INST(SubAssign, subAssign, 2, 0)
-
-INTRINSIC(SubAssign)
-INTRINSIC(MulAssign)
-INTRINSIC(DivAssign)
-INTRINSIC(ModAssign)
-INTRINSIC(LshAssign)
-INTRINSIC(RshAssign)
-INTRINSIC(OrAssign)
-INTRINSIC(AndAssign)
-INTRINSIC(XorAssign)
-INTRINSIC(Pos)
-#endif
-
 INST(Neg, neg, 1, 0)
 INST(Not, not, 1, 0)
 INST(BitNot, bitnot, 1, 0)
-
-#if 0
-INTRINSIC(PreInc)
-INTRINSIC(PreDec)
-INTRINSIC(PostInc)
-INTRINSIC(PostDec)
-
-INTRINSIC(Sequence)
-#endif
 
 INST(Select, select, 3, 0)
 
@@ -279,18 +255,6 @@ INST(Dot, dot, 2, 0)
 INST(Mul_Vector_Matrix, mulVectorMatrix, 2, 0)
 INST(Mul_Matrix_Vector, mulMatrixVector, 2, 0)
 INST(Mul_Matrix_Matrix, mulMatrixMatrix, 2, 0)
-
-#if 0
-INTRINSIC(Mul_Scalar_Scalar)
-INTRINSIC(Mul_Vector_Scalar)
-INTRINSIC(Mul_Scalar_Vector)
-INTRINSIC(Mul_Matrix_Scalar)
-INTRINSIC(Mul_Scalar_Matrix)
-INTRINSIC(InnerProduct_Vector_Vector)
-INTRINSIC(InnerProduct_Vector_Matrix)
-INTRINSIC(InnerProduct_Matrix_Vector)
-INTRINSIC(InnerProduct_Matrix_Matrix)
-#endif
 
 // Texture sampling operation of the form `t.Sample(s,u)`
 INST(Sample, sample, 3, 0)

--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -430,16 +430,23 @@ struct IRBuilder
 
     IRModule* getModule() { return sharedBuilder->module; }
 
-    // The current function and block being inserted into
-    // (or `null` if we aren't inserting).
-    IRGlobalValueWithCode*  curFunc = nullptr;
-    IRBlock*                curBlock = nullptr;
+    // The current parent being inserted into (this might
+    // be the global scope, a function, a block inside
+    // a function, etc.)
+    IRParentInst*   insertIntoParent = nullptr;
     //
-    // An instruction in the current block that we should insert before
-    IRInst*     insertBeforeInst = nullptr;
+    // An instruction in the current parent that we should insert before
+    IRInst*         insertBeforeInst = nullptr;
 
-    IRGlobalValueWithCode*  getFunc() { return curFunc; }
-    IRBlock*                getBlock() { return curBlock; }
+    // Get the current basic block we are inserting into (if any)
+    IRBlock*                getBlock();
+
+    // Get the current function (or other value with code)
+    // that we are inserting into (if any).
+    IRGlobalValueWithCode*  getFunc();
+
+    void setInsertInto(IRParentInst* insertInto);
+    void setInsertBefore(IRInst* insertBefore);
 
     IRBuilderSourceLocRAII* sourceLocInfo = nullptr;
 

--- a/source/slang/ir-legalize-types.cpp
+++ b/source/slang/ir-legalize-types.cpp
@@ -762,8 +762,7 @@ static LegalVal legalizeInst(
     // instructions generated will be placed after
     // the location of the original instruction.
     auto builder = context->builder;
-    builder->curBlock = as<IRBlock>(inst->getParent());
-    builder->insertBeforeInst = inst->getNextInst();
+    builder->setInsertBefore(inst->getNextInst());
 
     LegalVal legalVal = legalizeInst(
         context,

--- a/source/slang/ir-ssa.cpp
+++ b/source/slang/ir-ssa.cpp
@@ -563,7 +563,7 @@ void processBlock(
         // Any new instructions we create to represent
         // the new value will get inserted before whatever
         // instruction we are working with.
-        blockInfo->builder.insertBeforeInst = ii;
+        blockInfo->builder.setInsertBefore(ii);
 
         switch (ii->op)
         {
@@ -617,7 +617,7 @@ void processBlock(
         }
     }
 
-    blockInfo->builder.insertBeforeInst = block->getLastChild();
+    blockInfo->builder.setInsertBefore(block->getLastChild());
 
     // Once we are done with all of the instructions
     // in a block, we can mark it as "filled," which
@@ -709,8 +709,7 @@ static void breakCriticalEdges(
 
         IRBuilder builder;
         builder.sharedBuilder = &context->sharedBuilder;
-        builder.curFunc = globalVal;
-        builder.curBlock = pred;
+        builder.setInsertInto(pred);
 
         // Create a new block that will sit "along" the edge
         IRBlock* edgeBlock = builder.createBlock();
@@ -723,7 +722,7 @@ static void breakCriticalEdges(
 
         // The edge block should branch (unconditionally)
         // to the successor block.
-        builder.curBlock = edgeBlock;
+        builder.setInsertInto(edgeBlock);
         builder.emitBranch(succ);
 
         // Insert the new block into the block list
@@ -763,9 +762,7 @@ void constructSSA(ConstructSSAContext* context)
         blockInfo->block = bb;
 
         blockInfo->builder.sharedBuilder = &context->sharedBuilder;
-        blockInfo->builder.curBlock = bb;
-        blockInfo->builder.curFunc = globalVal;
-        blockInfo->builder.insertBeforeInst = bb->getLastInst();
+        blockInfo->builder.setInsertBefore(bb->getLastInst());
 
         context->blockInfos.Add(bb, blockInfo);
     }
@@ -830,7 +827,7 @@ void constructSSA(ConstructSSAContext* context)
         IRTerminatorInst* oldTerminator = bb->getTerminator();
         assert(oldTerminator);
 
-        blockInfo->builder.insertBeforeInst = nullptr;
+        blockInfo->builder.setInsertInto(bb);
 
         auto oldArgCount = oldTerminator->getOperandCount();
         auto newArgCount = oldArgCount + addedArgCount;

--- a/source/slang/ir-validate.cpp
+++ b/source/slang/ir-validate.cpp
@@ -1,0 +1,182 @@
+// ir-validate.cpp
+#include "ir-validate.h"
+
+#include "ir.h"
+#include "ir-insts.h"
+
+namespace Slang
+{
+    struct IRValidateContext
+    {
+        // The IR module we are validating.
+        IRModule*           module;
+
+        // A diagnostic sink to send errors to if anything is invalid.
+        DiagnosticSink*     sink;
+
+        DiagnosticSink* getSink() { return sink; }
+
+        // A set of instructions we've seen, to help confirm that
+        // values are defined before they are used in a given block.
+        HashSet<IRInst*>    seenInsts;
+    };
+
+    void validateIRInst(
+        IRValidateContext*  context,
+        IRInst*             inst);
+
+    void validate(IRValidateContext* context, bool condition, IRInst* inst, char const* message)
+    {
+        if (!condition)
+        {
+            context->getSink()->diagnose(inst, Diagnostics::irValidationFailed, message);
+        }
+    }
+
+    void validateIRInstChildren(
+        IRValidateContext*  context,
+        IRParentInst*       parent)
+    {
+        IRInst* prevChild = nullptr;
+        for (auto child = parent->getFirstChild(); child; child = child->getNextInst())
+        {
+            // We need to check the integrity of the parent/next/prev links of
+            // all of our instructions
+            validate(context, child->parent == parent,  child, "parent link");
+            validate(context, child->prev == prevChild, child, "next/prev link");
+
+            // Recursively validate the instruction itself.
+            validateIRInst(context, child);
+
+            prevChild = child;
+        }
+    }
+
+    void validateIRInstOperand(
+        IRValidateContext*  context,
+        IRInst*             inst,
+        IRUse*              operandUse)
+    {
+        // The `IRUse` for the operand had better have `inst` as its user.
+        validate(context, operandUse->getUser() == inst, inst, "operand user");
+
+        // The value we are using needs to fit into one of a few cases.
+        //
+        // * If the parent of `inst` and of `operand` is the same block, then
+        //   we require that `operand` is defined before `inst`
+        //
+        // * If the parents of `inst` and `operand` are both blocks in the
+        //   same functin, then the block defining `operand` must dominate
+        //   the block defining `inst`.
+        //
+        // * Otherwise, we simply require that the parent of `operand` be
+        //   an ancestor (transitive parent) of `inst`.
+
+        auto instParent = inst->getParent();
+
+        auto operandValue = operandUse->get();
+        auto operandParent = operandValue->getParent();
+
+        if (auto instParentBlock = as<IRBlock>(instParent))
+        {
+            if (auto operandParentBlock = as<IRBlock>(operandParent))
+            {
+                if (instParentBlock == operandParentBlock)
+                {
+                    // If `operandValue` precedes `inst`, then we should
+                    // have already seen it, because we scan parent instructions
+                    // in order.
+                    validate(context, context->seenInsts.Contains(operandValue),    inst, "def must come before use in same block");
+                    return;
+                }
+
+                auto instFunc = instParentBlock->getParent();
+                auto operandFunc = operandParentBlock->getParent();
+                if (instFunc == operandFunc)
+                {
+                    // The two instructions are defined in different blocks of
+                    // the same function (or another value with code). We need
+                    // to validate that `operandParentBlock` dominates `instParentBlock`.
+                    //
+                    // TODO: implement this validation once we compute dominator trees.
+                    //
+                    // validate(context, operandParentBlock->dominates(instParentBlock),    inst, "def must dominate use");
+                    return;
+                }
+            }
+        }
+
+        // If the special cases above did not trigger, then either the two values
+        // are nested in the same parent, but that parent isn't a block, or they
+        // are nested in distinct parents, and those parents aren't both children
+        // of a function.
+        //
+        // In either case, we need to enforce that the parent of `operand` needs
+        // to be an ancestor of `inst`.
+        //
+        for (auto pp = instParent; pp; pp = pp->getParent())
+        {
+            if (pp == operandParent)
+                return;
+        }
+        //
+        // We failed to find `operandParent` while walking the ancestors of `inst`,
+        // so something had gone wrong.
+        validate(context, false, inst, "def must be ancestor of use");
+    }
+
+    void validateIRInstOperands(
+        IRValidateContext*  context,
+        IRInst*             inst)
+    {
+        UInt operandCount = inst->getOperandCount();
+        for (UInt ii = 0; ii < operandCount; ++ii)
+        {
+            validateIRInstOperand(context, inst, inst->getOperands() + ii);
+        }
+    }
+
+    void validateIRInst(
+        IRValidateContext*  context,
+        IRInst*             inst)
+    {
+        // Validate that any operands of the instruction are used appropriately
+        validateIRInstOperands(context, inst);
+        context->seenInsts.Add(inst);
+
+        // If `inst` is itself a parent instruction, then we need to recursively
+        // validate its children.
+        if (auto parent = as<IRParentInst>(inst))
+        {
+            validateIRInstChildren(context, parent);
+        }
+    }
+
+    void validateIRModule(IRModule* module, DiagnosticSink* sink)
+    {
+        IRValidateContext contextStorage;
+        IRValidateContext* context = &contextStorage;
+        context->module = module;
+        context->sink = sink;
+
+        auto moduleInst = module->moduleInst;
+
+        validate(context, moduleInst != nullptr,            moduleInst, "module instruction");
+        validate(context, moduleInst->parent == nullptr,    moduleInst, "module instruction parent");
+        validate(context, moduleInst->prev == nullptr,      moduleInst, "module instruction prev");
+        validate(context, moduleInst->next == nullptr,      moduleInst, "module instruction next");
+
+        validateIRInst(context, module->moduleInst);
+    }
+
+    void validateIRModuleIfEnabled(
+        CompileRequest* compileRequest,
+        IRModule*       module)
+    {
+        if (!compileRequest->shouldValidateIR)
+            return;
+
+        auto sink = &compileRequest->mSink;
+        validateIRModule(module, sink);
+    }
+}

--- a/source/slang/ir-validate.h
+++ b/source/slang/ir-validate.h
@@ -1,0 +1,35 @@
+// ir-validate.h
+#pragma once
+
+namespace Slang
+{
+    class CompileRequest;
+    class DiagnosticSink;
+    struct IRModule;
+
+
+    // Validate that an IR module obeys the invariants we need to enforce.
+    // For example:
+    //
+    // * Confirm that linked lists for children and for use-def chains are consistent
+    //   (e.g., x.next.prev == x)
+    //
+    // * Confirm that parent/child relationships are correct (e.g., if is `x` is in
+    //   `y.children`, then `x.parent == y`
+    //
+    // * Confirm that every operand of an instruction is valid to reference (i.e., it
+    //   must either be defined earlier in the same block, in a different block that
+    //   dominates the current one, or in a parent instruction of the block.
+    //
+    // * Confirm that every block ends with a terminator, and there are no terminators
+    //   elsewhere in a block.
+    //
+    // * Confirm that all the parameters of a block come before any "ordinary" instructions.
+    void validateIRModule(IRModule* module, DiagnosticSink* sink);
+
+    // A wrapper that calls `validateIRModule` only when IR validation is enabled
+    // for the given compile request.
+    void validateIRModuleIfEnabled(
+        CompileRequest* compileRequest,
+        IRModule*       module);
+}

--- a/source/slang/ir.h
+++ b/source/slang/ir.h
@@ -431,6 +431,11 @@ struct IRParentInst : IRInst
     IRInst* getFirstChild() { return children.first; }
     IRInst* getLastChild()  { return children.last;  }
     IRInstListBase getChildren() { return children; }
+
+    static bool isaImpl(IROp op)
+    {
+        return (op >= kIROp_FirstParentInst) && (op <= kIROp_LastParentInst);
+    }
 };
 
 // A basic block is a parent instruction that adds the constraint
@@ -474,6 +479,16 @@ struct IRBlock : IRParentInst
     }
 
     void addParam(IRParam* param);
+
+    // The "ordinary" instructions come after the parameters
+    IRInst* getFirstOrdinaryInst();
+    IRInst* getLastOrdinaryInst();
+    IRInstList<IRInst> getOrdinaryInsts()
+    {
+        return IRInstList<IRInst>(
+            getFirstOrdinaryInst(),
+            getLastOrdinaryInst());
+    }
 
     // The parent of a basic block is assumed to be a
     // value with code (e.g., a function, global variable

--- a/source/slang/options.cpp
+++ b/source/slang/options.cpp
@@ -276,6 +276,10 @@ struct OptionsParser
                 {
                     requestImpl->shouldDumpIR = true;
                 }
+                else if(argStr == "-validate-ir" )
+                {
+                    requestImpl->shouldValidateIR = true;
+                }
                 else if(argStr == "-skip-codegen" )
                 {
                     requestImpl->shouldSkipCodegen = true;

--- a/source/slang/slang.natvis
+++ b/source/slang/slang.natvis
@@ -92,6 +92,7 @@
           </ArrayItems>
         </Expand>
       </Synthetic>
+      <Item Name="[parent]">parent</Item>
       <Synthetic Name="[uses]">
         <Expand>
           <LinkedListItems>
@@ -117,6 +118,7 @@
           </LinkedListItems>
         </Expand>
       </Synthetic>
+      <Item Name="[parent]">parent</Item>
       <Synthetic Name="[uses]">
         <Expand>
           <LinkedListItems>
@@ -142,6 +144,7 @@
           </LinkedListItems>
         </Expand>
       </Synthetic>
+      <Item Name="[parent]">parent</Item>
       <Synthetic Name="[uses]">
         <Expand>
           <LinkedListItems>
@@ -159,7 +162,8 @@
     <Expand>
       <Item Name="[op]">op</Item>
       <Item Name="[type]">type</Item>
-      <ExpandedItem>declRef</ExpandedItem>
+      <Item Name="[declRef]">declRef</Item>
+      <Item Name="[parent]">parent</Item>
     </Expand>
   </Type>
   <Type Name="Slang::IRUse">

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -183,6 +183,7 @@
     <ClInclude Include="ir-ssa.h" />
     <ClInclude Include="ir-type-defs.h" />
     <ClInclude Include="ir-types.h" />
+    <ClInclude Include="ir-validate.h" />
     <ClInclude Include="ir.h" />
     <ClInclude Include="legalize-types.h" />
     <ClInclude Include="lexer.h" />
@@ -225,6 +226,7 @@
     <ClCompile Include="ir-constexpr.cpp" />
     <ClCompile Include="ir-legalize-types.cpp" />
     <ClCompile Include="ir-ssa.cpp" />
+    <ClCompile Include="ir-validate.cpp" />
     <ClCompile Include="ir.cpp" />
     <ClCompile Include="legalize-types.cpp" />
     <ClCompile Include="lexer.cpp" />

--- a/source/slang/slang.vcxproj.filters
+++ b/source/slang/slang.vcxproj.filters
@@ -50,6 +50,7 @@
     <ClInclude Include="ir-types.h" />
     <ClInclude Include="ir-type-defs.h" />
     <ClInclude Include="type-system-shared.h" />
+    <ClInclude Include="ir-validate.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="check.cpp" />
@@ -83,6 +84,7 @@
     <ClCompile Include="memory_pool.cpp" />
     <ClCompile Include="ir-constexpr.cpp" />
     <ClCompile Include="type-system-shared.cpp" />
+    <ClCompile Include="ir-validate.cpp" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="core.meta.slang" />

--- a/tests/ir/loop.slang.expected
+++ b/tests/ir/loop.slang.expected
@@ -4,53 +4,56 @@ standard error = {
 ir_global_var @_SV01s	: Ptr<@ThreadGroup vector<float,4>[64]>;
 
 ir_global_var @_SV05input	: Ptr<StructuredBuffer<vector<float,4>>>;
+let  %1	: int	= integer_constant(1)
+let  %2	: int	= integer_constant(64)
 
 ir_func @_S031GroupMemoryBarrierWithGroupSyncp0pV	: () -> void;
 
 ir_global_var @_SV06output	: Ptr<RWStructuredBuffer<vector<float,4>>>;
+let  %3	: int	= integer_constant(0)
 
 ir_func @_S04mainp3puuuV	: (uint, uint, uint) -> void
 {
-block %1(
-		param %2	: uint,
-		param %3	: uint,
-		param %4	: uint):
-	let  %5	: Ptr<vector<float,4>>	= getElementPtr(@_SV01s, %3)
-	let  %6	: StructuredBuffer<vector<float,4>>	= load(@_SV05input)
-	let  %7	: vector<float,4>	= bufferLoad(%6, %2)
-	store(%5, %7)
-	let  %8	: @ConstExpr uint	= construct(1)
-	loop(%9, %10, %11, %8)
+block %4(
+		param %5	: uint,
+		param %6	: uint,
+		param %7	: uint):
+	let  %8	: Ptr<vector<float,4>>	= getElementPtr(@_SV01s, %6)
+	let  %9	: StructuredBuffer<vector<float,4>>	= load(@_SV05input)
+	let  %10	: vector<float,4>	= bufferLoad(%9, %5)
+	store(%8, %10)
+	let  %11	: @ConstExpr uint	= construct(1)
+	loop(%12, %13, %14, %11)
 
-block %9(
-		param %12	: uint):
-	let  %13	: @ConstExpr uint	= construct(64)
-	let  %14	: bool	= cmpLT(%12, %13)
-	ifElse(%14, %15, %10, %15)
+block %12(
+		param %15	: uint):
+	let  %16	: @ConstExpr uint	= construct(64)
+	let  %17	: bool	= cmpLT(%15, %16)
+	ifElse(%17, %18, %13, %18)
 
-block %15:
-	call(@_S031GroupMemoryBarrierWithGroupSyncp0pV)
-	let  %16	: Ptr<vector<float,4>>	= getElementPtr(@_SV01s, %3)
-	let  %17	: vector<float,4>	= load(%16)
-	let  %18	: uint	= sub(%3, %12)
-	let  %19	: Ptr<vector<float,4>>	= getElementPtr(@_SV01s, %18)
+block %18:
+	call @_S031GroupMemoryBarrierWithGroupSyncp0pV()
+	let  %19	: Ptr<vector<float,4>>	= getElementPtr(@_SV01s, %6)
 	let  %20	: vector<float,4>	= load(%19)
-	let  %21	: vector<float,4>	= add(%17, %20)
-	store(%16, %21)
-	unconditionalBranch(%11)
+	let  %21	: uint	= sub(%6, %15)
+	let  %22	: Ptr<vector<float,4>>	= getElementPtr(@_SV01s, %21)
+	let  %23	: vector<float,4>	= load(%22)
+	let  %24	: vector<float,4>	= add(%20, %23)
+	store(%19, %24)
+	unconditionalBranch(%14)
 
-block %11:
-	let  %22	: @ConstExpr uint	= construct(1)
-	let  %23	: uint	= shl(%12, %22)
-	unconditionalBranch(%9, %23)
+block %14:
+	let  %25	: @ConstExpr uint	= construct(1)
+	let  %26	: uint	= shl(%15, %25)
+	unconditionalBranch(%12, %26)
 
-block %10:
-	call(@_S031GroupMemoryBarrierWithGroupSyncp0pV)
-	let  %24	: RWStructuredBuffer<vector<float,4>>	= load(@_SV06output)
-	let  %25	: Ptr<vector<float,4>>	= bufferElementRef(%24, %2)
-	let  %26	: Ptr<vector<float,4>>	= getElementPtr(@_SV01s, 0)
-	let  %27	: vector<float,4>	= load(%26)
-	store(%25, %27)
+block %13:
+	call @_S031GroupMemoryBarrierWithGroupSyncp0pV()
+	let  %27	: RWStructuredBuffer<vector<float,4>>	= load(@_SV06output)
+	let  %28	: Ptr<vector<float,4>>	= bufferElementRef(%27, %5)
+	let  %29	: Ptr<vector<float,4>>	= getElementPtr(@_SV01s, 0)
+	let  %30	: vector<float,4>	= load(%29)
+	store(%28, %30)
 	return_void()
 }
 


### PR DESCRIPTION
The main practical change here is that things that used to be `IRValue`s, like literals, are now being expressed as instructions in the global scope.

In order to validate that things are actually being handled correctly, this change introduces an explicit "validation" pass that can be run on the IR to check for different invariants (although it doesn't check many of the important ones right now). I've left the validation pass turned off by default, but with a command-line flag to enable it. We may want to make it be on by default in debug builds, just to keep us honest. The main invariant for the moment is that when on IR instruction is used as an operand to another, it had better come from the same IR module.

Some of the existing passes were violating this rule, in particular when it came to cloning of witness tables related to global generic parameter substitution. Those features can in theory be handled better now by allowing `specialize` instructions at other scopes, but I didn't want to over-complicate this change, so I make just enough fixes to ensure that these steps always clone witness tables they get from the "symbols" on an IR specialization context. In order for this to work when recursively specializing, I had to ensure that the logic for generic specialization had a notion of a "parent" specialization context that it would fall back to to perform cloning when necessary.

This change keeps the logic that was caching and re-using the instructions for literal values within a module, but adds some logic that isn't really being tested right now for picking the right parent instruction to insert a constant instruction into. This logic doesn't trigger right now because all of the cases we are using it on have zero operands (and so they always get "hoisted" to the global scope), but eventually for things like types we want to be able to support instructions with operands (e.g., `vector<float, 4>`) and handle the case where some of those operands come from different scopes (e.g., when nested inside a generic).

The final change here is mostly cosmetic: the `IRBuilder` is now more abstract about where insertion occurs: it tracks a single `IRParentInst` to insert into, and then an optional `IRInst` to insert before. In the common case, that parent is an `IRBlock`, but it could conceivably also be the global scope, or a witness table, etc. Use sites where we used to change those fields directly now use distinct methods `setInsertInto(parent)` and `setInsertBefore(inst)` which capture the two cases we care about. Accessors are also defined to extract the current block (if the current parent is a block), and the current "function" (global value with code, if the current parent is a global value with code, or a block inside one).

With this work in place, it should be possible for a follow-on change to start putting `specialize` instructions at the global scope and thus clean up some of the on-the-fly specialization work. This work should also help with some of the requirements around a distinct IR-level type system and more explicit generics.