### PR TITLE
Add a case to `TryUnifyVals` to cover `SubtypeWitness` vals

### DIFF
--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -5149,6 +5149,20 @@ namespace Slang
                 }
             }
 
+            if (auto fstWit = fst.As<DeclaredSubtypeWitness>())
+            {
+                if (auto sndWit = snd.As<DeclaredSubtypeWitness>())
+                {
+                    auto constraintDecl1 = fstWit->declRef.As<TypeConstraintDecl>();
+                    auto constraintDecl2 = sndWit->declRef.As<TypeConstraintDecl>();
+                    assert(constraintDecl1);
+                    assert(constraintDecl2);
+                    return TryUnifyTypes(constraints, 
+                        constraintDecl1.getDecl()->getSup().type,
+                        constraintDecl2.getDecl()->getSup().type);
+                }
+            }
+
             throw "unimplemented";
 
             // default: fail


### PR DESCRIPTION
This is trigered when compiling the following code
```
interface ILight
{
    ShadingResult evalLighting<TBxDF:IBxDF>(ShadingPoint<TBxDF> p, float shadowFactor);
}

ShadingResult evalMaterial<TBxDF : IBxDF, TLight : ILight>(ShadingPoint<TBxDF> p, TLight light, float shadowFactor)
{
    return light.evalLighting(p, shadowFactor); // trigered when trying to resolve overload here.
}
```