### PR TITLE
Expose HLSL `shared` modifier through reflection.

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -500,6 +500,7 @@ extern "C"
 
     typedef struct SlangReflection                  SlangReflection;
     typedef struct SlangReflectionEntryPoint        SlangReflectionEntryPoint;
+    typedef struct SlangReflectionModifier          SlangReflectionModifier;
     typedef struct SlangReflectionType              SlangReflectionType;
     typedef struct SlangReflectionTypeLayout        SlangReflectionTypeLayout;
     typedef struct SlangReflectionVariable          SlangReflectionVariable;
@@ -639,6 +640,12 @@ extern "C"
         SLANG_LAYOUT_RULES_DEFAULT,
     };
 
+    typedef SlangUInt32 SlangModifierID;
+    enum
+    {
+        SLANG_MODIFIER_SHARED,
+    };
+
     // Type Reflection
 
     SLANG_API SlangTypeKind spReflectionType_GetKind(SlangReflectionType* type);
@@ -678,6 +685,8 @@ extern "C"
 
     SLANG_API char const* spReflectionVariable_GetName(SlangReflectionVariable* var);
     SLANG_API SlangReflectionType* spReflectionVariable_GetType(SlangReflectionVariable* var);
+
+    SLANG_API SlangReflectionModifier* spReflectionVariable_FindModifier(SlangReflectionVariable* var, SlangModifierID modifierID);
 
     // Variable Layout Reflection
 
@@ -1030,6 +1039,14 @@ namespace slang
         }
     };
 
+    struct Modifier
+    {
+        enum ID : SlangModifierID
+        {
+            Shared = SLANG_MODIFIER_SHARED,
+        };
+    };
+
     struct VariableReflection
     {
         char const* getName()
@@ -1040,6 +1057,11 @@ namespace slang
         TypeReflection* getType()
         {
             return (TypeReflection*) spReflectionVariable_GetType((SlangReflectionVariable*) this);
+        }
+
+        Modifier* findModifier(Modifier::ID id)
+        {
+            return (Modifier*) spReflectionVariable_FindModifier((SlangReflectionVariable*) this, (SlangModifierID) id);
         }
     };
 
@@ -1053,6 +1075,11 @@ namespace slang
         char const* getName()
         {
             return getVariable()->getName();
+        }
+
+        Modifier* findModifier(Modifier::ID id)
+        {
+            return getVariable()->findModifier(id);
         }
 
         TypeLayoutReflection* getTypeLayout()

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -677,6 +677,26 @@ SLANG_API SlangReflectionType* spReflectionVariable_GetType(SlangReflectionVaria
     return  convert(var->getType());
 }
 
+SLANG_API SlangReflectionModifier* spReflectionVariable_FindModifier(SlangReflectionVariable* inVar, SlangModifierID modifierID)
+{
+    auto var = convert(inVar);
+    if(!var) return nullptr;
+
+    Modifier* modifier = nullptr;
+    switch( modifierID )
+    {
+    case SLANG_MODIFIER_SHARED:
+        modifier = var->FindModifier<HLSLEffectSharedModifier>();
+        break;
+
+    default:
+        return nullptr;
+    }
+
+    return (SlangReflectionModifier*) modifier;
+}
+
+
 // Variable Layout Reflection
 
 SLANG_API SlangReflectionVariable* spReflectionVariableLayout_GetVariable(SlangReflectionVariableLayout* inVarLayout)

--- a/tests/reflection/shared-modifier.hlsl
+++ b/tests/reflection/shared-modifier.hlsl
@@ -1,0 +1,12 @@
+// shared-modifier.hlsl
+//TEST:REFLECTION:-profile ps_5_0 -target hlsl
+
+// Confirm that we expose the `shared` modifier in reflection data.
+
+Texture2D t;
+shared SamplerState s;
+
+float4 main(float2 uv : UV) : SV_Target
+{
+	return t.Sample(s, uv);
+}

--- a/tests/reflection/shared-modifier.hlsl.expected
+++ b/tests/reflection/shared-modifier.hlsl.expected
@@ -1,0 +1,47 @@
+result code = 0
+standard error = {
+}
+standard output = {
+{
+    "parameters": [
+        {
+            "name": "t",
+            "binding": {"kind": "shaderResource", "index": 0},
+            "type": {
+                "kind": "resource",
+                "baseShape": "texture2D"
+            }
+        },
+        {
+            "name": "s",
+            "shared": true,
+            "binding": {"kind": "samplerState", "index": 0},
+            "type": {
+                "kind": "samplerState"
+            }
+        }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "fragment",
+            "parameters": [
+                {
+                    "name": "uv",
+                    "stage": "fragment",
+                    "binding": {"kind": "varyingInput", "index": 0},
+                    "semanticName": "UV",
+                    "type": {
+                        "kind": "vector",
+                        "elementCount": 2,
+                        "elementType": {
+                            "kind": "scalar",
+                            "scalarType": "float32"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}
+}

--- a/tools/slang-reflection-test/main.cpp
+++ b/tools/slang-reflection-test/main.cpp
@@ -239,6 +239,16 @@ static void emitReflectionNameInfoJSON(
     write(writer, "\"");
 }
 
+static void emitReflectionModifierInfoJSON(
+    PrettyWriter&               writer,
+    slang::VariableReflection*  var)
+{
+    if( var->findModifier(slang::Modifier::Shared) )
+    {
+        write(writer, ",\n\"shared\": true");
+    }
+}
+
 static void emitReflectionVarLayoutJSON(
     PrettyWriter&                       writer,
     slang::VariableLayoutReflection*    var)
@@ -251,6 +261,8 @@ static void emitReflectionVarLayoutJSON(
 
     write(writer, "\"type\": ");
     emitReflectionTypeLayoutJSON(writer, var->getTypeLayout());
+
+    emitReflectionModifierInfoJSON(writer, var->getVariable());
 
     emitReflectionVarBindingInfoJSON(writer, var);
 
@@ -607,8 +619,10 @@ static void emitReflectionVarInfoJSON(
     slang::VariableReflection*  var)
 {
     emitReflectionNameInfoJSON(writer, var->getName());
-    write(writer, ",\n");
 
+    emitReflectionModifierInfoJSON(writer, var);
+
+    write(writer, ",\n");
     write(writer, "\"type\": ");
     emitReflectionTypeJSON(writer, var->getType());
 }
@@ -621,6 +635,8 @@ static void emitReflectionParamJSON(
     indent(writer);
 
     emitReflectionNameInfoJSON(writer, param->getName());
+
+    emitReflectionModifierInfoJSON(writer, param->getVariable());
 
     emitReflectionVarBindingInfoJSON(writer, param);
     write(writer, ",\n");


### PR DESCRIPTION
This is a request from Falcor, because the `shared` modifier can be used as a hint to optimize the grouping of parameters for binding. The intention is that `shared` marks shader parameters (including parameter blocks) that will us the same values across many draw calls (e.g., per-frame data, as opposed to per-model or per-instance).

The mechanism I'm using here is to provide a general reflection API for exposing the `Modifier`s already attached to declarations. While the only modifier exposed is `shared`, and the only modifier information being exposed is presence/absence, this interface could be extended down the line.