### PR TITLE
Stop compilation when a imported module contains errors.

### DIFF
--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -273,6 +273,7 @@ DIAGNOSTIC(38020, Error, mismatchEntryPointTypeArgument, "expecting $0 entry-poi
 DIAGNOSTIC(38021, Error, typeArgumentDoesNotConformToInterface, "type argument `$1` for generic parameter `$0` does not conform to interface `$1`.")
 
 DIAGNOSTIC(38200, Error, recursiveModuleImport, "module `$0` recursively imports itself")
+DIAGNOSTIC(39999, Fatal, errorInImportedModule, "error in imported module, compilation ceased.")
 
 //
 // 4xxxx - IL code generation.

--- a/tests/bugs/import-with-error.slang.expected
+++ b/tests/bugs/import-with-error.slang.expected
@@ -1,6 +1,7 @@
 result code = -1
 standard error = {
 tests/bugs/import-with-error-extra.slang(10): error 30015: undefined identifier 'b'.
+tests/bugs/import-with-error.slang(6): fatal error 39999: error in imported module, compilation ceased.
 }
 standard output = {
 }

--- a/tests/diagnostics/recursive-import.slang.expected
+++ b/tests/diagnostics/recursive-import.slang.expected
@@ -1,6 +1,7 @@
 result code = -1
 standard error = {
 tests/diagnostics/recursive-import.slang(6): error 38200: module `recursive_import_extra` recursively imports itself
+tests/diagnostics/recursive-import-extra.slang(6): fatal error 39999: error in imported module, compilation ceased.
 }
 standard output = {
 }


### PR DESCRIPTION
This PR makes Slang generate a `Fatal` diagnostic when a imported module failed to parse or code gen. Currently we are still hitting compiler crashes when trying to access nullptr values from broken imported modules, this change should further prevent that from happening.