### PR TITLE
Don't use specialized field names when legalizing types

### DIFF
--- a/source/slang/legalize-types.cpp
+++ b/source/slang/legalize-types.cpp
@@ -1016,7 +1016,7 @@ RefPtr<VarLayout> getFieldLayout(
     {
         for(auto ff : structTypeLayout->fields)
         {
-            if(mangledFieldName == getMangledName(ff->varDecl) )
+            if(mangledFieldName == getMangledName(ff->varDecl.getDecl()) )
             {
                 return ff;
             }


### PR DESCRIPTION
The type legalization logic currently looks up layout information for the fields of an aggregate type using the mangled name of the field (since this should be consistent even when legalization changes the number of  fields). The problem at present is that type layouts for specialized generic types were storing the mangled names of *specialized* field decl-refs, while the lookup was using the mangled names of the unspecialized declarations. The latter (unspecialized names) is what we want for simplicity, so this change fixes the comparison.