### PR TITLE
When emitting from IR, skip structured types with `__builtin` modifier

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -7889,6 +7889,15 @@ emitDeclImpl(decl, nullptr);
             emitIRUsedType(ctx, fieldType);
         }
 
+        // Don't emit declarations for types that should be built-in on the target.
+        //
+        // TODO: This should really be checking if the type is a target intrinsic
+        // for the chosen target, and not just whether it is globally declared
+        // as a builtin (so that we can have types that are builtin in some cases,
+        // but not others).
+        if(declRef.getDecl()->HasModifier<BuiltinModifier>())
+            return;
+
         Emit("struct ");
         EmitDeclRef(declRef);
         Emit("\n{\n");


### PR DESCRIPTION
This allows users who call `spAddBuiltins` to specify `struct` types that are provided for a target, and that should not be part of the generated HLSL/GLSL from Slang.

The existing emit logic already skips emitting any basic, vector, matrix, or resource types, so this case really only triggers when the standard library needs to declare a completely ordinary `struct`.

No provision is made right now for a `struct` type that might be builtin on one target, but need to be declared on another. That is a clear next step for this feature.