### PR TITLE
Small bug fixes to get latest refactored Falcor shader library to work

### DIFF
--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -2549,6 +2549,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
         // (and that control flow will fall through to otherwise).
         // This is the block that subsequent code will go into.
         insertBlock(breakLabel);
+        context->shared->breakLabels.Remove(stmt);
     }
 };
 

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -2492,14 +2492,14 @@ RefPtr<ProgramLayout> specializeProgramLayout(
         for (UInt i = 0; i < varLayout->resourceInfos.Count(); i++)
         {
             auto resInfo = varLayout->resourceInfos[i];
-            auto tresInfo = varLayout->typeLayout->resourceInfos[i];
-            SLANG_ASSERT(resInfo.kind == tresInfo.kind);
+            auto tresInfo = varLayout->typeLayout->FindResourceInfo(resInfo.kind);
+            SLANG_ASSERT(tresInfo);
             auto usedRangeSet = findUsedRangeSetForSpace(&context, resInfo.space);
             markSpaceUsed(&context, resInfo.space);
             usedRangeSet->usedResourceRanges[(int)resInfo.kind].Add(
                 nullptr, // we don't need to track parameter info here
                 resInfo.index,
-                resInfo.index + tresInfo.count);
+                resInfo.index + tresInfo->count);
         }
         structLayout->fields[varId] = varLayout;
         varLayoutMapping[varLayout] = varLayout;


### PR DESCRIPTION
This commit contains two small bug fixes:

1. In `specializeProgramLayout`, we cannot assume the resourceInfo entries in a varLayout and its corresponding type layout has the same order. Should use `FindResourceLayout`.

2. When generating ir for a switch statement, make sure to remove the breakLabel from the shared context when done. For some reason if a switch statement is being lowered twice, the Dictionary::Add method will complain the statement key already exists.