### PR TITLE
Entry point attribute

### DIFF
--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -7292,7 +7292,7 @@ namespace Slang
                     // We manually fill in the entry point request object.
                     RefPtr<EntryPointRequest> entryPointReq = new EntryPointRequest();
                     entryPointReq->compileRequest = compileRequest;
-                    entryPointReq->translationUnitIndex = tt;
+                    entryPointReq->translationUnitIndex = int(tt);
                     entryPointReq->decl = funcDecl;
                     entryPointReq->name = funcDecl->getName();
                     entryPointReq->profile = profile;

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -468,6 +468,7 @@ namespace Slang
         Type* getInitializerListType();
         Type* getOverloadedType();
         Type* getErrorType();
+        Type* getStringType();
 
         Type* getConstExprRate();
         RefPtr<RateQualifiedType> getRateQualifiedType(

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -107,9 +107,19 @@ namespace Slang
         List<String> genericParameterTypeNames;
 
         // The profile that the entry point will be compiled for
-        // (this is a combination of the target state, and also
+        // (this is a combination of the target stage, and also
         // a feature level that sets capabilities)
+        //
+        // Note: the profile-version part of this should probably
+        // be moving towards deprecation, in favor of the version
+        // information (e.g., "Shader Model 5.1") always coming
+        // from the target, while the stage part is all that is
+        // intrinsic to the entry point.
+        //
         Profile profile;
+
+        // Get the stage that the entry point is being compiled for.
+        Stage getStage() { return profile.GetStage(); }
 
         // The index of the translation unit (within the parent
         // compile request) that the entry point function is
@@ -118,6 +128,19 @@ namespace Slang
 
         // The output path requested for this entry point.
         // (only used when compiling from the command line)
+        //
+        // TODO: This should get dropped. When compiling from the
+        // command line, the user should be either:
+        //
+        // * Compiling a single entry point for a single target, so
+        //   that only a single output path is needed for the whole request.
+        //
+        // * Compiling for a target that supports multiple entry points directly
+        //   (e.g., a recent DXIL version), so that only one output file is needed.
+        //
+        // * Compiling to a slang module container, so that as many entry
+        //   points and targets as needed can be specified.
+        //
         String outputPath;
 
         // The translation unit that this entry point came from
@@ -202,6 +225,21 @@ namespace Slang
         // TypeLayouts created on the fly by reflection API
         Dictionary<Type*, RefPtr<TypeLayout>> typeLayouts;
     };
+
+    // Compute the "effective" profile to use when outputting the given entry point
+    // for the chosen code-generation target.
+    //
+    // The stage of the effective profile will always come from the entry point, while
+    // the profile version (aka "shader model") will be computed as follows:
+    //
+    // - If the entry point and target belong to the same profile family, then take
+    //   the latest version between the two (e.g., if the entry point specified `ps_5_1`
+    //   and the target specifies `sm_5_0` then use `sm_5_1` as the version).
+    //
+    // - If the entry point and target disagree on the profile family, always use the
+    //   profile family and version from the target.
+    //
+    Profile getEffectiveProfile(EntryPointRequest* entryPoint, TargetRequest* target);
 
     // A directory to be searched when looking for files (e.g., `#include`)
     struct SearchDirectory

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -114,6 +114,10 @@ __magic_type(InOutType)
 struct InOut
 {};
 
+__magic_type(StringType)
+struct String
+{};
+
 ${{{{
 // Declare vector and matrix types
 

--- a/source/slang/core.meta.slang.h
+++ b/source/slang/core.meta.slang.h
@@ -114,6 +114,10 @@ SLANG_RAW("__magic_type(InOutType)\n")
 SLANG_RAW("struct InOut\n")
 SLANG_RAW("{};\n")
 SLANG_RAW("\n")
+SLANG_RAW("__magic_type(StringType)\n")
+SLANG_RAW("struct String\n")
+SLANG_RAW("{};\n")
+SLANG_RAW("\n")
 
 // Declare vector and matrix types
 

--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -337,7 +337,7 @@ DIAGNOSTIC(51092, Error, stageDoesntHaveInputWorld, "'$0' doesn't appear to have
 // 99999 - Internal compiler errors, and not-yet-classified diagnostics.
 
 DIAGNOSTIC(99999, Internal, unimplemented, "unimplemented: $0")
-DIAGNOSTIC(99999, Internal, unexpected, "uuexpected: $0")
+DIAGNOSTIC(99999, Internal, unexpected, "unexpected: $0")
 DIAGNOSTIC(99999, Internal, internalCompilerError, "internal compiler error")
 DIAGNOSTIC(99999, Error, compilationAborted, "compilation aborted due to internal error");
 

--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -197,10 +197,15 @@ DIAGNOSTIC(30051, Error, invalidValueForArgument, "invalid value for argument '$
 DIAGNOSTIC(30052, Error, invalidSwizzleExpr, "invalid swizzle pattern '$0' on type '$1'")
 DIAGNOSTIC(33070, Error, expectedFunction, "expression preceding parenthesis of apparent call must have function type.")
 
+DIAGNOSTIC(33071, Error, expectedAStringLiteral, "expected a string literal")
+
 // Attributes
 DIAGNOSTIC(31000, Error, unknownAttributeName, "unknown attribute '$0'")
 DIAGNOSTIC(31001, Error, attributeArgumentCountMismatch, "attribute '$0' expects $1 arguments ($2 provided)")
 DIAGNOSTIC(31001, Error, attributeNotApplicable, "attribute '$0' is not valid here")
+
+DIAGNOSTIC(31100, Error, unknownStageName,  "unknown stage name '$0'")
+
 
 // 303xx: interfaces and associated types
 DIAGNOSTIC(30300, Error, assocTypeInInterfaceOnly, "'associatedtype' can only be defined in an 'interface'.")
@@ -299,7 +304,6 @@ DIAGNOSTIC(40007, Internal, irValidationFailed, "IR validation failed: $0")
 //
 // 5xxxx - Target code generation.
 //
-DIAGNOSTIC(50020, Error, unknownStageType,              "Unknown stage type '$0'.")
 DIAGNOSTIC(50020, Error, invalidTessCoordType,          "TessCoord must have vec2 or vec3 type.")
 DIAGNOSTIC(50020, Error, invalidFragCoordType,          "FragCoord must be a vec4.")
 DIAGNOSTIC(50020, Error, invalidInvocationIdType,       "InvocationId must have int type.")

--- a/source/slang/dxc-support.cpp
+++ b/source/slang/dxc-support.cpp
@@ -125,7 +125,8 @@ namespace Slang
         String entryPointName = getText(entryPoint->name);
         OSString wideEntryPointName = entryPointName.ToWString();
 
-        String profileName = GetHLSLProfileName(entryPoint->profile);
+        auto profile = getEffectiveProfile(entryPoint, targetReq);
+        String profileName = GetHLSLProfileName(profile);
         OSString wideProfileName = profileName.ToWString();
 
 

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -6752,6 +6752,32 @@ emitDeclImpl(decl, nullptr);
         auto profile = entryPointLayout->profile;
         auto stage = profile.GetStage();
 
+        if(profile.getFamily() == ProfileFamily::DX)
+        {
+            if(profile.GetVersion() >= ProfileVersion::DX_6_1 )
+            {
+                char const* stageName = nullptr;
+                switch(stage)
+                {
+                case Stage::Compute:    stageName = "compute";
+                case Stage::Vertex:     stageName = "vertex";
+                case Stage::Hull:       stageName = "hull";
+                case Stage::Domain:     stageName = "domain";
+                case Stage::Geometry:   stageName = "geometry";
+                case Stage::Fragment:   stageName = "pixel";
+                default:
+                    break;
+                }
+
+                if(stageName)
+                {
+                    emit("[shader(\"");
+                    emit(stageName);
+                    emit("\")]");
+                }
+            }
+        }
+
         switch (stage)
         {
         case Stage::Compute:

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -2673,8 +2673,15 @@ struct EmitVisitor
         ExprVisitorWithArg::dispatch(derefExpr->base, arg);
     }
 
-    void visitConstantExpr(ConstantExpr* litExpr, ExprEmitArg const& arg)
+    void visitLiteralExpr(LiteralExpr*, ExprEmitArg const&)
     {
+        // Disabling because we no longer use the AST-based emit path.
+        //
+        // Note: I'm keeping this code around for a while just in case
+        // we want to borrow any of the logic here for how to apply
+        // suffixes to numeric literals we emit.
+        //
+#if 0
         auto outerPrec = arg.outerPrec;
         bool needClose = MaybeEmitParens(outerPrec, kEOp_Atomic);
 
@@ -2736,6 +2743,7 @@ struct EmitVisitor
             break;
         }
         if(needClose) Emit(")");
+#endif
     }
 
     void visitTypeCastExpr(TypeCastExpr* castExpr, ExprEmitArg const& arg)

--- a/source/slang/expr-defs.h
+++ b/source/slang/expr-defs.h
@@ -42,25 +42,32 @@ SYNTAX_CLASS(OverloadedExpr2, Expr)
     FIELD(List<RefPtr<Expr>>, candidiateExprs)
 END_SYNTAX_CLASS()
 
-SYNTAX_CLASS(ConstantExpr, Expr)
+ABSTRACT_SYNTAX_CLASS(LiteralExpr, Expr)
+    // The token that was used to express the literal. This can be
+    // used to get the raw text of the literal, including any suffix.
     FIELD(Token, token)
+END_SYNTAX_CLASS()
 
-    RAW(
-    enum class ConstantType
-    {
-        Int,
-        Bool,
-        Float,
-        String,
-    };
-    ConstantType ConstType;
-    union
-    {
-        IntegerLiteralValue         integerValue;
-        FloatingPointLiteralValue   floatingPointValue;
-    };
-    String stringValue;
-    )
+SYNTAX_CLASS(IntegerLiteralExpr, LiteralExpr)
+    FIELD(IntegerLiteralValue, value)
+END_SYNTAX_CLASS()
+
+SYNTAX_CLASS(FloatingPointLiteralExpr, LiteralExpr)
+    FIELD(FloatingPointLiteralValue, value)
+END_SYNTAX_CLASS()
+
+SYNTAX_CLASS(BoolLiteralExpr, LiteralExpr)
+    FIELD(bool, value)
+END_SYNTAX_CLASS()
+
+SYNTAX_CLASS(StringLiteralExpr, LiteralExpr)
+    // TODO: consider storing the "segments" of the string
+    // literal, in the case where multiple literals were
+    //lined up at the lexer level, e.g.:
+    //
+    //      "first" "second" "third"
+    //
+    FIELD(String, value)
 END_SYNTAX_CLASS()
 
 // An initializer list, e.g. `{ 1, 2, 3 }`

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -1390,23 +1390,26 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         UNREACHABLE_RETURN(LoweredValInfo());
     }
 
-    LoweredValInfo visitConstantExpr(ConstantExpr* expr)
+    LoweredValInfo visitBoolLiteralExpr(BoolLiteralExpr* expr)
+    {
+        return LoweredValInfo::simple(context->irBuilder->getBoolValue(expr->value));
+    }
+
+    LoweredValInfo visitIntegerLiteralExpr(IntegerLiteralExpr* expr)
     {
         auto type = lowerSimpleType(context, expr->type);
+        return LoweredValInfo::simple(context->irBuilder->getIntValue(type, expr->value));
+    }
 
-        switch( expr->ConstType )
-        {
-        case ConstantExpr::ConstantType::Bool:
-            return LoweredValInfo::simple(context->irBuilder->getBoolValue(expr->integerValue != 0));
-        case ConstantExpr::ConstantType::Int:
-            return LoweredValInfo::simple(context->irBuilder->getIntValue(type, expr->integerValue));
-        case ConstantExpr::ConstantType::Float:
-            return LoweredValInfo::simple(context->irBuilder->getFloatValue(type, expr->floatingPointValue));
-        case ConstantExpr::ConstantType::String:
-            break;
-        }
+    LoweredValInfo visitFloatingPointLiteralExpr(FloatingPointLiteralExpr* expr)
+    {
+        auto type = lowerSimpleType(context, expr->type);
+        return LoweredValInfo::simple(context->irBuilder->getFloatValue(type, expr->value));
+    }
 
-        SLANG_UNEXPECTED("unexpected constant type");
+    LoweredValInfo visitStringLiteralExpr(StringLiteralExpr*)
+    {
+        SLANG_UNEXPECTED("string literal encountered during code emit");
     }
 
     LoweredValInfo visitAggTypeCtorExpr(AggTypeCtorExpr* /*expr*/)

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -1922,7 +1922,7 @@ static void collectEntryPointParameters(
     state.ioSemanticIndex = &defaultSemanticIndex;
     state.optSemanticName = nullptr;
     state.semanticSlotCount = 0;
-    state.stage = entryPoint->profile.GetStage();
+    state.stage = entryPoint->getStage();
 
     for( auto m : entryPointFuncDecl->Members )
     {
@@ -2020,12 +2020,14 @@ inferStageForTranslationUnit(
     // and have only a single entry point, use the stage
     // of the entry point.
     //
-    // TODO: can we generalize this at all?
+    // TODO: now that we've dropped official GLSL support,
+    // we probably should drop this as well.
+    //
     if( translationUnit->sourceLanguage == SourceLanguage::GLSL )
     {
         if( translationUnit->entryPoints.Count() == 1 )
         {
-            return translationUnit->entryPoints[0]->profile.GetStage();
+            return translationUnit->entryPoints[0]->getStage();
         }
     }
 
@@ -2080,7 +2082,7 @@ static void collectParameters(
         // Next consider parameters for entry points
         for( auto& entryPoint : translationUnit->entryPoints )
         {
-            context->stage = entryPoint->profile.GetStage();
+            context->stage = entryPoint->getStage();
             collectEntryPointParameters(context, entryPoint.Ptr(), SubstitutionSet());
         }
         context->entryPointLayout = nullptr;

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -3603,10 +3603,9 @@ namespace Slang
 
     static RefPtr<Expr> parseBoolLitExpr(Parser* /*parser*/, bool value)
     {
-        RefPtr<ConstantExpr> constExpr = new ConstantExpr();
-        constExpr->ConstType = ConstantExpr::ConstantType::Bool;
-        constExpr->integerValue = value ? 1 : 0;
-        return constExpr;
+        RefPtr<BoolLiteralExpr> expr = new BoolLiteralExpr();
+        expr->value = value;
+        return expr;
     }
 
     static RefPtr<RefObject> parseTrueExpr(Parser* parser, void* /*userData*/)
@@ -3696,7 +3695,7 @@ namespace Slang
 
         case TokenType::IntegerLiteral:
             {
-                RefPtr<ConstantExpr> constExpr = new ConstantExpr();
+                RefPtr<IntegerLiteralExpr> constExpr = new IntegerLiteralExpr();
                 parser->FillPosition(constExpr.Ptr());
 
                 auto token = parser->tokenReader.AdvanceToken();
@@ -3756,8 +3755,7 @@ namespace Slang
                     }
                 }
 
-                constExpr->ConstType = ConstantExpr::ConstantType::Int;
-                constExpr->integerValue = value;
+                constExpr->value = value;
                 constExpr->type = QualType(suffixType);
 
                 return constExpr;
@@ -3766,7 +3764,7 @@ namespace Slang
 
         case TokenType::FloatingPointLiteral:
             {
-                RefPtr<ConstantExpr> constExpr = new ConstantExpr();
+                RefPtr<FloatingPointLiteralExpr> constExpr = new FloatingPointLiteralExpr();
                 parser->FillPosition(constExpr.Ptr());
 
                 auto token = parser->tokenReader.AdvanceToken();
@@ -3825,8 +3823,7 @@ namespace Slang
                     }
                 }
 
-                constExpr->ConstType = ConstantExpr::ConstantType::Float;
-                constExpr->floatingPointValue = value;
+                constExpr->value = value;
                 constExpr->type = QualType(suffixType);
 
                 return constExpr;
@@ -3834,16 +3831,15 @@ namespace Slang
 
         case TokenType::StringLiteral:
             {
-                RefPtr<ConstantExpr> constExpr = new ConstantExpr();
+                RefPtr<StringLiteralExpr> constExpr = new StringLiteralExpr();
                 auto token = parser->tokenReader.AdvanceToken();
                 constExpr->token = token;
                 parser->FillPosition(constExpr.Ptr());
-                constExpr->ConstType = ConstantExpr::ConstantType::String;
 
                 if (!parser->LookAheadToken(TokenType::StringLiteral))
                 {
                     // Easy/common case: a single string
-                    constExpr->stringValue = getStringLiteralTokenValue(token);
+                    constExpr->value = getStringLiteralTokenValue(token);
                 }
                 else
                 {
@@ -3854,7 +3850,7 @@ namespace Slang
                         token = parser->tokenReader.AdvanceToken();
                         sb << getStringLiteralTokenValue(token);
                     }
-                    constExpr->stringValue = sb.ProduceString();
+                    constExpr->value = sb.ProduceString();
                 }
 
                 return constExpr;

--- a/source/slang/profile.h
+++ b/source/slang/profile.h
@@ -67,13 +67,18 @@ namespace Slang
         bool operator!=(Profile const& other) const { return raw != other.raw; }
 
         Stage GetStage() const { return Stage((uint32_t(raw) >> 16) & 0xFFFF); }
-        ProfileVersion GetVersion() const { return ProfileVersion(uint32_t(raw) & 0xFFFF); }
-        ProfileFamily getFamily() const { return getProfileFamily(GetVersion()); }
+        void setStage(Stage stage)
+        {
+            raw = (raw & 0x0000FFFF) | (uint32_t(stage) << 16);
+        }
 
+        ProfileVersion GetVersion() const { return ProfileVersion(uint32_t(raw) & 0xFFFF); }
         void setVersion(ProfileVersion version)
         {
             raw = (raw & ~0xFFFF) | uint32_t(version);
         }
+
+        ProfileFamily getFamily() const { return getProfileFamily(GetVersion()); }
 
         static Profile LookUp(char const* name);
 

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -296,6 +296,12 @@ void Type::accept(IValVisitor* visitor, void* extra)
         return constExprRate;
     }
 
+    Type* Session::getStringType()
+    {
+        auto stringTypeDecl = findMagicDecl(this, "StringType");
+        return DeclRefType::Create(this, makeDeclRef<Decl>(stringTypeDecl));
+    }
+
     RefPtr<RateQualifiedType> Session::getRateQualifiedType(
         Type*   rate,
         Type*   valueType)

--- a/source/slang/type-defs.h
+++ b/source/slang/type-defs.h
@@ -388,6 +388,9 @@ protected:
 )
 END_SYNTAX_CLASS()
 
+// The built-in `String` type
+SIMPLE_SYNTAX_CLASS(StringType, DeclRefType)
+
 // Base class for types that map down to
 // simple pointers as part of code generation.
 SYNTAX_CLASS(PtrTypeBase, DeclRefType)


### PR DESCRIPTION
These are changes working toward supporting the `[shader("...")]` attribute on input as an alternative to `-entry ...` options on the command line, and then also outputting the attribute so that it can be recognized by dxc when generating DXIL libraries.

The support here isn't really finished, but it should be at a good state to check in. The next step would be to fundamentally break up the "profile" concept in the compiler implementation so that we more completely decouple stages and "profile versions."