### PR TITLE
SlangResult and small bug/typos fixes

### DIFF
--- a/docs/api-users-guide.md
+++ b/docs/api-users-guide.md
@@ -89,7 +89,7 @@ If you will be passing files with `#include` directives to Slang, you'll need to
 spAddSearchPath(request, "some/path/");
 ```
 
-Note that for now Slang does not support any kind of "virtual filesystem," although that is obviously a desirable feature to add.
+Note that for now Slang does not support any kind of "virtual file-system," although that is obviously a desirable feature to add.
 
 #### Preprocessor Definitions
 
@@ -127,7 +127,7 @@ The last argument is an optional name for the translation unit; Slang currently 
 
 The `spAddTranslationUnit` function returns the zero-based index of the translation unit you added.
 You don't need to use this return value, because it will be deterministic (the first translation unit gets `0`, the next gets `1`, etc.), but the API returns it in case it saves you from having to track it with your own counter.
-The translation unit index is used in subsequent API calls taht modify or query the translation unit.
+The translation unit index is used in subsequent API calls that modify or query the translation unit.
 
 #### Source Files/Strings
 
@@ -194,7 +194,7 @@ The diagnostic output will also contain any warnings produced, even if the compi
 Note that the returned pointer is guaranteed to live at least as long as the compile request, but no longer.
 If you need to retain the data for later use, then you must make your own copy.
 
-If any errors occured, you shouldn't expect to read any useful output (other than the diagnostics) from the request; you should destroy it and move on.
+If any errors occurred, you shouldn't expect to read any useful output (other than the diagnostics) from the request; you should destroy it and move on.
 
 ### Reading Output Code
 
@@ -308,12 +308,12 @@ for(unsigned cc = 0; cc < categoryCount; cc++)
 }
 ```
 
-A loop like this lets you enumerate all of the reosurce types consumed by a parameter, and get a starting offset (and space) for each category.
+A loop like this lets you enumerate all of the resource types consumed by a parameter, and get a starting offset (and space) for each category.
 
 #### Type Layouts
 
 Just knowing where a shader parameter *starts* is only part of the story, of course.
-We also need to know how many resources (e.g., registers, bytes of uniform data, ...) it consumes, how many elemnets it occupies (if it is an array), and what "sub-parameters" it might include.
+We also need to know how many resources (e.g., registers, bytes of uniform data, ...) it consumes, how many elements it occupies (if it is an array), and what "sub-parameters" it might include.
 
 For these kinds of queries, we need to look at the *type layout* of a parameter:
 
@@ -322,7 +322,7 @@ slang::TypeLayoutReflection* typeLayout = parameter->getTypeLayout();
 ```
 
 Just as with the distinction between a variable and a variable layout, a type layout represents a particular type in the source code that has been laid out according to API-specific rules.
-A single type like `float[10]` might be laid out differently in different contets (e.g., using GLSL `std140` vs. `std430` rules).
+A single type like `float[10]` might be laid out differently in different contexts (e.g., using GLSL `std140` vs. `std430` rules).
 
 The first thing we want to know about a type is its *kind*:
 
@@ -352,13 +352,13 @@ slang::TypeLayoutReflection* elementTypeLayout = typeLayout->getElementTypeLayou
 sie_t arrayElementStride = typeLayout->getElementStride(category);
 ```
 
-An array of unknoqn size will currently report zero elements.
+An array of unknown size will currently report zero elements.
 The "stride" of an array is the amount of resources (e.g., the number of bytes of uniform data) that need to be skipped between consecutive array elements.
 This need *not* be the same as `elementTypeLayout->getSize(category)`, and there are two notable cases to be aware of:
 
 - An array in a constant buffer may have a stride larger than the element size. E.g., a `float a[10]` in a D3D or `std140` constant buffer will have 4-byte elements, but a stride of 16.
 
-- An arrray of resources in Vulkan will have a stride of *zero* descriptor-table slots, because the entire array is allocated a single `binding`.
+- An array of resources in Vulkan will have a stride of *zero* descriptor-table slots, because the entire array is allocated a single `binding`.
 
 ##### Structures
 
@@ -378,7 +378,7 @@ Each field is represented as a full variable layout, so application code can rec
 An important caveat to be aware of when recursing into structure types like this, is that the layout information on a field is relative to the start of the parent type layout, and not absolute.
 This is perhaps not surprising in the case of `slang::ParameterCategory::Uniform`: if you ask a field in a `struct` type for its byte offset, it will return the offset from the start of the `struct`.
 
-Where this can trip up users is when a `struct` type containss fields of other categories (e.g., a structure with a `Texture2D` in it).
+Where this can trip up users is when a `struct` type contains fields of other categories (e.g., a structure with a `Texture2D` in it).
 In these cases, the "binding index" of a structure field in a relative offset from whatever binding index is given to the parent structure.
 
 The basic rule is that no matter what category of binding resource (bytes, registers, etc.) you are talking about, the index/offset of `a.b.c` must be computed by adding together the offsets of `a`, `b` and `c`.
@@ -417,7 +417,7 @@ If you are implementing some kind of "hot reload" system for shaders, then you p
 Slang provides a simple API for enumerating these, on a successful compile:
 
 ```c++
-int depCount = spGetDepenencyFileCount(request);
+int depCount = spGetDependencyFileCount(request);
 for(int dep = 0; dep < depCount; dep++)
 {
 	char const* depPath = spGetDependencyFilePath(request, dep);

--- a/source/core/core.vcxproj
+++ b/source/core/core.vcxproj
@@ -32,6 +32,7 @@
     <ClInclude Include="secure-crt.h" />
     <ClInclude Include="slang-io.h" />
     <ClInclude Include="slang-math.h" />
+    <ClInclude Include="slang-result.h" />
     <ClInclude Include="slang-string.h" />
     <ClInclude Include="smart-pointer.h" />
     <ClInclude Include="stream.h" />

--- a/source/core/slang-result.h
+++ b/source/core/slang-result.h
@@ -1,0 +1,130 @@
+#ifndef SLANG_RESULT_H
+#define SLANG_RESULT_H
+
+#include <cstdint>
+#include <assert.h>
+
+/*! SlangResult is a type that represents the status result after a call to a function/method. It can represent if the call was successful or 
+not. It can also specify in an extensible manner what facility produced the result (as the integral 'facility') as well as what caused it (as an integral 'code').
+Under the covers SlangResult is represented as a int32_t. A negative value indicates an error, a positive (or 0) value indicates success. 
+
+SlangResult is designed to be compatible with COM HRESULT. 
+
+It's layout in bits is as follows
+
+Severity | Facility | Code
+---------|----------|-----
+31       |    30-16 | 15-0
+
+Severity - 1 fail, 0 is success.
+Facility is where the error originated from
+Code is the code specific to the facility.
+
+The layout is designed such that failure is a negative number, and success is positive due to Result
+being represented by an Int32.
+
+Result codes have the following style
+
+1. SLANG_name
+2. SLANG_s_f_name
+3. SLANG_s_name
+
+where s is severity as a single letter S - success, and E for error
+Style 1 is reserved for SLANG_OK and SLANG_FAIL as they are so common and not tied to a facility
+
+s is S for success, E for error 
+f is the short version of the facility name
+
+For the common used SLANG_OK and SLANG_FAIL, the name prefix is dropped.
+It is acceptable to expand 'f' to a longer name to differentiate a name
+ie for a facility 'DRIVER' it might make sense to have an error of the form SLANG_E_DRIVER_OUT_OF_MEMORY 
+*/
+
+typedef int32_t SlangResult;
+
+// Make just the identifier for the code
+#define SLANG_MAKE_RESULT_ID(fac, code) ((((int32_t)(fac))<<16) | ((int32_t)(code)))
+
+//! Make a result
+#define SLANG_MAKE_RESULT(sev, fac, code) ((((int32_t)(sev))<<31) | SLANG_MAKE_RESULT_ID(fac, code))
+
+//! Will be 0 - for ok, 1 for failure
+#define SLANG_GET_RESULT_SEVERITY(r)	((int32_t)(((uint32_t(r)) >> 31))
+//! Get the facility the result is associated with
+#define SLANG_GET_RESULT_FACILITY(r)	((int32_t)(((r) >> 16) & 0x7fff))
+//! Get the result code for the facility 
+#define SLANG_GET_RESULT_CODE(r)		((int32_t)((r) & 0xffff))
+
+#define SLANG_MAKE_ERROR(fac, code)		(SLANG_MAKE_RESULT_ID(SLANG_FACILITY_##fac, code) | 0x80000000)
+#define SLANG_MAKE_SUCCESS(fac, code)	SLANG_MAKE_RESULT_ID(SLANG_FACILITY_##fac, code)
+
+/*************************** Facilities ************************************/
+
+//! General - careful to make compatible with HRESULT
+#define SLANG_FACILITY_GENERAL      0
+
+//! Base facility -> so as to not clash with HRESULT values
+#define SLANG_FACILITY_BASE		 0x100				
+
+/*! Facilities numbers must be unique across a project to make the resulting result a unique number!
+It can be useful to have a consistent short name for a facility, as used in the name prefix */
+#define SLANG_FACILITY_DISK         (SLANG_FACILITY_BASE + 1)
+#define SLANG_FACILITY_INTERFACE    (SLANG_FACILITY_BASE + 2)
+#define SLANG_FACILITY_UNKNOWN      (SLANG_FACILITY_BASE + 3)
+#define SLANG_FACILITY_MEMORY		(SLANG_FACILITY_BASE + 4)
+#define SLANG_FACILITY_MISC			(SLANG_FACILITY_BASE + 5)
+
+/// Base for external facilities. Facilities should be unique across modules. 
+#define SLANG_FACILITY_EXTERNAL_BASE 0x210
+#define SLANG_FACILITY_CORE			(SLANG_FACILITY_EXTERNAL_BASE + 1)
+
+/* *************************** Codes **************************************/
+
+// Memory
+#define SLANG_E_MEM_OUT_OF_MEMORY            SLANG_MAKE_ERROR(MEMORY, 1)
+#define SLANG_E_MEM_BUFFER_TOO_SMALL         SLANG_MAKE_ERROR(MEMORY, 2)
+
+//! SLANG_OK indicates success, and is equivalent to SLANG_MAKE_RESULT(0, GENERAL, 0)
+#define SLANG_OK                          0
+//! SLANG_FAIL is the generic failure code - meaning a serious error occurred and the call couldn't complete
+#define SLANG_FAIL                        SLANG_MAKE_ERROR(GENERAL, 1)
+
+//! Used to identify a Result that has yet to be initialized.  
+//! It defaults to failure such that if used incorrectly will fail, as similar in concept to using an uninitialized variable. 
+#define SLANG_E_MISC_UNINITIALIZED			SLANG_MAKE_ERROR(MISC, 2)
+//! Returned from an async method meaning the output is invalid (thus an error), but a result for the request is pending, and will be returned on a subsequent call with the async handle. 			
+#define SLANG_E_MISC_PENDING				SLANG_MAKE_ERROR(MISC, 3)
+//! Indicates that a handle passed in as parameter to a method is invalid. 
+#define SLANG_E_MISC_INVALID_HANDLE			SLANG_MAKE_ERROR(MISC, 4)
+
+/*! Set SLANG_HANDLE_RESULT_FAIL(x) to code to be executed whenever an error occurs, and is detected by one of the macros */
+#ifndef SLANG_HANDLE_RESULT_FAIL
+#	define SLANG_HANDLE_RESULT_FAIL(x)
+#endif
+
+/* !!!!!!!!!!!!!!!!!!!!!!!!! Checking codes !!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
+
+//! Use to test if a result was failure. Never use result != SLANG_OK to test for failure, as there may be successful codes != SLANG_OK.
+#define SLANG_FAILED(status) ((status) < 0)
+//! Use to test if a result succeeded. Never use result == SLANG_OK to test for success, as will detect other successful codes as a failure.
+#define SLANG_SUCCEEDED(status) ((status) >= 0)
+
+//! Helper macro, that makes it easy to add result checking to calls in functions/methods that themselves return Result. 
+#define SLANG_RETURN_ON_FAIL(x) { SlangResult _res = (x); if (SLANG_FAILED(_res)) { SLANG_HANDLE_RESULT_FAIL(_res); return _res; } }
+//! Helper macro that can be used to test the return value from a call, and will return in a void method/function
+#define SLANG_RETURN_VOID_ON_FAIL(x) { SlangResult _res = (x); if (SLANG_FAILED(_res)) { SLANG_HANDLE_RESULT_FAIL(_res); return; } }
+//! Helper macro that will return false on failure.
+#define SLANG_RETURN_FALSE_ON_FAIL(x) { SlangResult _res = (x); if (SLANG_FAILED(_res)) { SLANG_HANDLE_RESULT_FAIL(_res); return false; } }
+
+//! Helper macro that will assert if the return code from a call is failure, also returns the failure.
+#define SLANG_ASSERT_ON_FAIL(x) { SlangResult _res = (x); if (SLANG_FAILED(_res)) { assert(false); return _res; } }
+//! Helper macro that will assert if the result from a call is a failure, also returns. 
+#define SLANG_ASSERT_VOID_ON_FAIL(x) { SlangResult _res = (x); if (SLANG_FAILED(_res)) { assert(false); return; } }
+
+#if defined(__cplusplus)
+namespace Slang {
+typedef SlangResult Result;
+} // namespace Slang
+#endif // defined(__cplusplus)
+
+#endif // SLANG_RESULT_H

--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -10,7 +10,7 @@ namespace renderer_test {
 
 Options gOptions;
 
-void parseOptions(int* argc, char** argv)
+SlangResult parseOptions(int* argc, char** argv)
 {
     int argCount = *argc;
     char const* const* argCursor = argv;
@@ -48,7 +48,7 @@ void parseOptions(int* argc, char** argv)
             if( argCursor == argEnd )
             {
                 fprintf(stderr, "expected argument for '%s' option\n", arg);
-                exit(1);
+                return SLANG_FAIL;
             }
             gOptions.outputPath = *argCursor++;
         }
@@ -89,12 +89,12 @@ void parseOptions(int* argc, char** argv)
             if( argCursor == argEnd )
             {
                 fprintf(stderr, "expected argument for '%s' option\n", arg);
-                exit(1);
+                return SLANG_FAIL;
             }
             if( gOptions.slangArgCount == kMaxSlangArgs )
             {
                 fprintf(stderr, "maximum number of '%s' options exceeded (%d)\n", arg, kMaxSlangArgs);
-                exit(1);
+                return SLANG_FAIL;
             }
             gOptions.slangArgs[gOptions.slangArgCount++] = *argCursor++;
         }
@@ -123,7 +123,7 @@ void parseOptions(int* argc, char** argv)
         else
         {
             fprintf(stderr, "unknown option '%s'\n", arg);
-            exit(1);
+            return SLANG_FAIL;
         }
     }
     
@@ -142,10 +142,11 @@ void parseOptions(int* argc, char** argv)
     if(argCursor != argEnd)
     {
         fprintf(stderr, "unexpected arguments\n");
-        exit(1);
+        return SLANG_FAIL;
     }
 
     *argc = 0;
+	return SLANG_OK;
 }
 
 } // renderer_test

--- a/tools/render-test/options.h
+++ b/tools/render-test/options.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#include "../../source/core/slang-result.h"
+
 namespace renderer_test {
 
 typedef intptr_t Int;
@@ -61,13 +63,6 @@ extern int gWindowWidth;
 extern int gWindowHeight;
 
 
-void parseOptions(int* argc, char** argv);
-
-enum class Error
-{
-    None = 0,
-    InvalidParam,
-    Unexpected,
-};
+SlangResult parseOptions(int* argc, char** argv);
 
 } // renderer_test

--- a/tools/render-test/render-d3d11.cpp
+++ b/tools/render-test/render-d3d11.cpp
@@ -294,19 +294,7 @@ public:
         UINT deviceFlags = 0;
         deviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
 
-        // We will ask for the highest feature level that can be supported.
-
-        D3D_FEATURE_LEVEL featureLevels[] = {
-            D3D_FEATURE_LEVEL_11_1,
-            D3D_FEATURE_LEVEL_11_0,
-            D3D_FEATURE_LEVEL_10_1,
-            D3D_FEATURE_LEVEL_10_0,
-            D3D_FEATURE_LEVEL_9_3,
-            D3D_FEATURE_LEVEL_9_2,
-            D3D_FEATURE_LEVEL_9_1,
-        };
-        D3D_FEATURE_LEVEL dxFeatureLevel = D3D_FEATURE_LEVEL_9_1;
-
+        
         // Our swap chain uses RGBA8 with sRGB, with double buffering.
 
         DXGI_SWAP_CHAIN_DESC dxSwapChainDesc = { 0 };
@@ -326,6 +314,19 @@ public:
         dxSwapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
         dxSwapChainDesc.Flags = 0;
 
+		// We will ask for the highest feature level that can be supported.
+		D3D_FEATURE_LEVEL featureLevels[] = {
+			D3D_FEATURE_LEVEL_11_1,
+			D3D_FEATURE_LEVEL_11_0,
+			D3D_FEATURE_LEVEL_10_1,
+			D3D_FEATURE_LEVEL_10_0,
+			D3D_FEATURE_LEVEL_9_3,
+			D3D_FEATURE_LEVEL_9_2,
+			D3D_FEATURE_LEVEL_9_1,
+		};
+		D3D_FEATURE_LEVEL dxFeatureLevel = D3D_FEATURE_LEVEL_9_1;
+		const int totalNumFeatureLevels = sizeof(featureLevels) / sizeof(featureLevels[0]);
+
         // On a machine that does not have an up-to-date version of D3D installed,
         // the `D3D11CreateDeviceAndSwapChain` call will fail with `E_INVALIDARG`
         // if you ask for featuer level 11_1. The workaround is to call
@@ -342,7 +343,7 @@ public:
                 NULL,                    // software
                 deviceFlags,
                 &featureLevels[ii],
-                (sizeof(featureLevels) / sizeof(featureLevels[0])) - 1,
+				totalNumFeatureLevels - ii,
                 D3D11_SDK_VERSION,
                 &dxSwapChainDesc,
                 &dxSwapChain,

--- a/tools/render-test/render-d3d11.cpp
+++ b/tools/render-test/render-d3d11.cpp
@@ -193,7 +193,7 @@ static HRESULT captureTextureToFile(
     D3D11_TEXTURE2D_DESC dxTextureDesc;
     dxTexture->GetDesc(&dxTextureDesc);
 
-    // Don't bother supporing MSAA for right now
+    // Don't bother supporting MSAA for right now
     if( dxTextureDesc.SampleDesc.Count > 1 )
     {
         fprintf(stderr, "ERROR: cannot capture multisample texture\n");
@@ -535,7 +535,7 @@ public:
                 hlslCursor+= sprintf(hlslCursor, ",\n");
             }
 
-            char const* typeName = "Uknown";
+            char const* typeName = "Unknown";
             switch(inputElements[ii].format)
             {
             case Format::RGB_Float32:

--- a/tools/render-test/render-d3d11.cpp
+++ b/tools/render-test/render-d3d11.cpp
@@ -350,12 +350,17 @@ public:
                 &dxFeatureLevel,
                 &dxImmediateContext);
 
-            // Failures with `E_INVALIDARG` might be due to feature level 11_1
-            // not being supported. Other failures are real, though.
-            if( hr != E_INVALIDARG )
+			// Failures with `E_INVALIDARG` might be due to feature level 11_1
+			// not being supported. 
+			if (hr == E_INVALIDARG)
 			{
-				SLANG_RETURN_ON_FAIL(hr);
+				continue;
 			}
+
+			// Other failures are real, though.
+			SLANG_RETURN_ON_FAIL(hr);
+			// We must have a swap chain
+			break;
         }
  
         // After we've created the swap chain, we can request a pointer to the

--- a/tools/render-test/render-gl.cpp
+++ b/tools/render-test/render-gl.cpp
@@ -86,7 +86,7 @@ public:
 
     // Renderer interface
 
-    virtual void initialize(void* inWindowHandle) override
+    virtual SlangResult initialize(void* inWindowHandle) override
     {
         auto windowHandle = (HWND) inWindowHandle;
 
@@ -127,6 +127,8 @@ public:
             glEnable(GL_DEBUG_OUTPUT);
             glDebugMessageCallback(staticDebugCallback, this);
         }
+
+		return SLANG_OK;
     }
 
     void debugCallback(
@@ -181,7 +183,7 @@ public:
         SwapBuffers(deviceContext);
     }
 
-    virtual void captureScreenShot(char const* outputPath) override
+    virtual SlangResult captureScreenShot(char const* outputPath) override
     {
         int width = gWindowWidth;
         int height = gWindowHeight;
@@ -189,7 +191,7 @@ public:
         int components = 4;
         int rowStride = width*components;
 
-        GLubyte* buffer = (GLubyte*)malloc(components * width * height);
+        GLubyte* buffer = (GLubyte*)::malloc(components * width * height);
 
         glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, buffer);
 
@@ -222,12 +224,16 @@ public:
             components,
             buffer,
             rowStride);
-        if( !stbResult )
+        
+		::free(buffer);
+
+		if( !stbResult )
         {
             assert(!"unexpected");
+			return SLANG_FAIL;
         }
 
-        delete(buffer);
+		return SLANG_OK;
     }
 
     virtual ShaderCompiler* getShaderCompiler() override
@@ -483,7 +489,7 @@ public:
             int maxSize = 0;
             glGetProgramiv(programID, GL_INFO_LOG_LENGTH, &maxSize);
 
-            auto infoBuffer = (char*) malloc(maxSize);
+            auto infoBuffer = (char*)::malloc(maxSize);
 
             int infoSize = 0;
             glGetProgramInfoLog(programID, maxSize, &infoSize, infoBuffer);
@@ -493,8 +499,10 @@ public:
                 OutputDebugStringA(infoBuffer);
             }
 
+			::free(infoBuffer);
+
             glDeleteProgram(programID);
-            return 0;
+            return nullptr;
         }
 
         return (ShaderProgram*) (uintptr_t) programID;

--- a/tools/render-test/render.h
+++ b/tools/render-test/render.h
@@ -5,6 +5,8 @@
 #include "window.h"
 #include "shader-input-layout.h"
 
+#include "../../source/core/slang-result.h"
+
 namespace renderer_test {
 
 typedef struct Buffer           Buffer;
@@ -90,14 +92,14 @@ enum class PrimitiveTopology
 class Renderer
 {
 public:
-    virtual void initialize(void* inWindowHandle) = 0;
+    virtual SlangResult initialize(void* inWindowHandle) = 0;
 
     virtual void setClearColor(float const* color) = 0;
     virtual void clearFrame() = 0;
 
     virtual void presentFrame() = 0;
 
-    virtual void captureScreenShot(char const* outputPath) = 0;
+    virtual SlangResult captureScreenShot(char const* outputPath) = 0;
     virtual void serializeOutput(BindingState * state, char const* outputPath) = 0;
     virtual Buffer* createBuffer(BufferDesc const& desc) = 0;
 

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -170,7 +170,6 @@ ShaderCompiler* createSlangShaderCompiler(
     result->target = target;
 
     return result;
-
 }
 
 

--- a/tools/slang-test/README.md
+++ b/tools/slang-test/README.md
@@ -1,0 +1,97 @@
+slang-test
+==========
+
+Slang test is a command line tool that is used to coordinate tests via other command line tools. It can be thought of as the 'hub' running multiple tests, and accumulating the results. In the distribution tests are held in the 'tests' directory. Inside this directory there are tests grouped together via other directories. Inside those directories are the actual tests themselves. The tests exist as .hlsl, .slang and .glsl and other files. The top line of each of these files describe what kind of test will be performed with a specialized comment. 
+
+Test Categories
+===============
+
+There are the following test categories
+
+* full
+* quick
+* smoke
+* render
+* compute
+* vulkan
+
+A test may be in one or more categories. The categories are specified in the test line, for example: 
+//TEST(smoke,compute):COMPARE_COMPUTE:
+
+Command line options
+====================
+
+** bindir ** 
+
+Specifies the directory where executables will be found. 
+
+"E:\git\slang-jsmall-nvidia\bin\windows-x64\Debug\\" 
+
+Eg -bindir "windows-x64\Debug\\"
+
+** -platform ** 
+
+The parameter after be x64, or x86.
+
+Eg. -platform x64
+
+** debug ** 
+
+A flag that if set means a debug executable/s will be used for testing.
+
+** release **
+
+A flag that if set means a release executables will be used for testing.
+
+** category ** 
+
+The parameter controls what kinds of tests will be run.
+
+* render
+* 
+
+** exclude **
+
+Used to specify categories to be excluded during a test.
+
+** appveyor **
+
+A flag that makes output suitable for the appveyor automated test suite.
+
+** travis **
+
+A flag that makes output suitable for the travis automated test suite.
+
+Test types
+==========
+
+Test types are controlled via a comment at the top of a test file, that starts with //TEST:
+This is then immediately followed by the test type which is one of the following
+
+* SIMPLE 
+	** Calls the slangc compiler with options after the comment 
+* REFLECTION
+	** Runs 'slang-reflection-test' passing in the options as given after the command
+* COMPARE_HLSL
+	** Runs the slangc compiler, forcing dxbc output and compares with file post fixed with '.expected'
+* COMPARE_HLSL_RENDER
+	** Runs 'render-test' rendering two images - one for hlsl (expected), and one for slang saving to .png files. The images must match for the test to pass. 
+* COMPARE_HLSL_CROSS_COMPILE_RENDER
+	** Runs 'render-test' rendering two images - one from slag, and the other -glsl-cross. The images must match for the test to pass.
+* COMPARE_HLSL_GLSL_RENDER
+	** Runs 'render-test' rendering two images - one with -hlsl-rewrite and the other -glsl-rewrite. The images must match for test to pass.
+* COMPARE_COMPUTE
+	** Runs 'render-test' producing a compute result written as a text file. Text file contents must be identical.
+* COMPARE_COMPUTE_EX
+	** Same as COMPARE_COMPUTE, but allows specific parameters to be specified.
+* HLSL_COMPUTE
+	** Runs 'render-test' with "-hlsl-rewrite -compute" options. Text files are compared. 
+* COMPARE_RENDER_COMPUTE
+	** Runs 'render-test' with "-slang -gcompute" options. Text files are compared. 
+* COMPARE_GLSL
+	** Runs the slangc compiler compiling through slang, and without and comparing output in spirv assembly.
+* CROSS_COMPILE
+	** Compiles as glsl pass through and then through slang and comparing output
+* EVAL
+	** Runs 'slang-eval-test' - which runs code on slang VM
+

--- a/tools/slang-test/README.md
+++ b/tools/slang-test/README.md
@@ -1,10 +1,10 @@
-slang-test
-==========
+# Slang Test
 
-Slang test is a command line tool that is used to coordinate tests via other command line tools. It can be thought of as the 'hub' running multiple tests, and accumulating the results. In the distribution tests are held in the 'tests' directory. Inside this directory there are tests grouped together via other directories. Inside those directories are the actual tests themselves. The tests exist as .hlsl, .slang and .glsl and other files. The top line of each of these files describe what kind of test will be performed with a specialized comment. 
+Slang Test is a command line tool that is used to coordinate tests via other command line tools. The actual executable is 'slang-test'. It is typically run from the test.bat script in the root directory of the project.
 
-Test Categories
-===============
+Slang Test can be thought of as the 'hub' running multiple tests and accumulating the results. In the distribution tests are held in the 'tests' directory. Inside this directory there are tests grouped together via other directories. Inside those directories are the actual tests themselves. The tests exist as .hlsl, .slang and .glsl and other file extensions. The top line of each of these files describe what kind of test will be performed with a specialized comment '//TEST'. 
+
+## Test Categories
 
 There are the following test categories
 
@@ -18,80 +18,67 @@ There are the following test categories
 A test may be in one or more categories. The categories are specified in the test line, for example: 
 //TEST(smoke,compute):COMPARE_COMPUTE:
 
-Command line options
-====================
+## Command line options
 
-** bindir ** 
+### bindir 
 
 Specifies the directory where executables will be found. 
 
-"E:\git\slang-jsmall-nvidia\bin\windows-x64\Debug\\" 
-
 Eg -bindir "windows-x64\Debug\\"
 
-** -platform ** 
+### category 
 
-The parameter after be x64, or x86.
+The parameter controls what kinds of tests will be run. Categories are listed at the 'test categories' section.
 
-Eg. -platform x64
-
-** debug ** 
-
-A flag that if set means a debug executable/s will be used for testing.
-
-** release **
-
-A flag that if set means a release executables will be used for testing.
-
-** category ** 
-
-The parameter controls what kinds of tests will be run.
-
-* render
-* 
-
-** exclude **
+### exclude 
 
 Used to specify categories to be excluded during a test.
 
-** appveyor **
+### appveyor
 
 A flag that makes output suitable for the appveyor automated test suite.
 
-** travis **
+### travis 
 
 A flag that makes output suitable for the travis automated test suite.
 
-Test types
-==========
+### Other Command Line Options
+
+The following flags/paramteres can be passed but will be ignored by the tool
+
+* debug (flag)
+* release (flag)
+* platform (parameter)
+
+## Test Types
 
 Test types are controlled via a comment at the top of a test file, that starts with //TEST:
 This is then immediately followed by the test type which is one of the following
 
 * SIMPLE 
-	** Calls the slangc compiler with options after the comment 
+	* Calls the slangc compiler with options after the comment 
 * REFLECTION
-	** Runs 'slang-reflection-test' passing in the options as given after the command
+	* Runs 'slang-reflection-test' passing in the options as given after the command
 * COMPARE_HLSL
-	** Runs the slangc compiler, forcing dxbc output and compares with file post fixed with '.expected'
+	* Runs the slangc compiler, forcing dxbc output and compares with file post fixed with '.expected'
 * COMPARE_HLSL_RENDER
-	** Runs 'render-test' rendering two images - one for hlsl (expected), and one for slang saving to .png files. The images must match for the test to pass. 
+	* Runs 'render-test' rendering two images - one for hlsl (expected), and one for slang saving to .png files. The images must match for the test to pass. 
 * COMPARE_HLSL_CROSS_COMPILE_RENDER
-	** Runs 'render-test' rendering two images - one from slag, and the other -glsl-cross. The images must match for the test to pass.
+	* Runs 'render-test' rendering two images - one from slag, and the other -glsl-cross. The images must match for the test to pass.
 * COMPARE_HLSL_GLSL_RENDER
-	** Runs 'render-test' rendering two images - one with -hlsl-rewrite and the other -glsl-rewrite. The images must match for test to pass.
+	* Runs 'render-test' rendering two images - one with -hlsl-rewrite and the other -glsl-rewrite. The images must match for test to pass.
 * COMPARE_COMPUTE
-	** Runs 'render-test' producing a compute result written as a text file. Text file contents must be identical.
+	* Runs 'render-test' producing a compute result written as a text file. Text file contents must be identical.
 * COMPARE_COMPUTE_EX
-	** Same as COMPARE_COMPUTE, but allows specific parameters to be specified.
+	* Same as COMPARE_COMPUTE, but allows specific parameters to be specified.
 * HLSL_COMPUTE
-	** Runs 'render-test' with "-hlsl-rewrite -compute" options. Text files are compared. 
+	* Runs 'render-test' with "-hlsl-rewrite -compute" options. Text files are compared. 
 * COMPARE_RENDER_COMPUTE
-	** Runs 'render-test' with "-slang -gcompute" options. Text files are compared. 
+	* Runs 'render-test' with "-slang -gcompute" options. Text files are compared. 
 * COMPARE_GLSL
-	** Runs the slangc compiler compiling through slang, and without and comparing output in spirv assembly.
+	* Runs the slangc compiler compiling through slang, and without and comparing output in spirv assembly.
 * CROSS_COMPILE
-	** Compiles as glsl pass through and then through slang and comparing output
+	* Compiles as glsl pass through and then through slang and comparing output
 * EVAL
-	** Runs 'slang-eval-test' - which runs code on slang VM
+	* Runs 'slang-eval-test' - which runs code on slang VM
 

--- a/tools/slang-test/main.cpp
+++ b/tools/slang-test/main.cpp
@@ -3,6 +3,8 @@
 #include "../../source/core/slang-io.h"
 #include "../../source/core/token-reader.h"
 
+#include "../../source/core/slang-result.h"
+
 using namespace Slang;
 
 #include "os.h"
@@ -71,7 +73,7 @@ struct Options
 };
 Options options;
 
-void parseOptions(int* argc, char** argv)
+Result parseOptions(int* argc, char** argv)
 {
     int argCount = *argc;
     char const* const* argCursor = argv;
@@ -110,7 +112,7 @@ void parseOptions(int* argc, char** argv)
             if( argCursor == argEnd )
             {
                 fprintf(stderr, "error: expected operand for '%s'\n", arg);
-                exit(1);
+                return SLANG_FAIL;
             }
             options.binDir = *argCursor++;
         }
@@ -135,7 +137,7 @@ void parseOptions(int* argc, char** argv)
             if( argCursor == argEnd )
             {
                 fprintf(stderr, "error: expected operand for '%s'\n", arg);
-                exit(1);
+				return SLANG_FAIL;
             }
             argCursor++;
             // Assumed to be handle by .bat file that called us
@@ -145,7 +147,7 @@ void parseOptions(int* argc, char** argv)
             if( argCursor == argEnd )
             {
                 fprintf(stderr, "error: expected operand for '%s'\n", arg);
-                exit(1);
+				return SLANG_FAIL;
             }
             argCursor++;
             // Assumed to be handle by .bat file that called us
@@ -165,7 +167,7 @@ void parseOptions(int* argc, char** argv)
             if( argCursor == argEnd )
             {
                 fprintf(stderr, "error: expected operand for '%s'\n", arg);
-                exit(1);
+                return SLANG_FAIL;
             }
             auto category = findTestCategory(*argCursor++);
             if(category)
@@ -178,7 +180,7 @@ void parseOptions(int* argc, char** argv)
             if( argCursor == argEnd )
             {
                 fprintf(stderr, "error: expected operand for '%s'\n", arg);
-                exit(1);
+                return SLANG_FAIL;
             }
             auto category = findTestCategory(*argCursor++);
             if(category)
@@ -189,7 +191,7 @@ void parseOptions(int* argc, char** argv)
         else
         {
             fprintf(stderr, "unknown option '%s'\n", arg);
-            exit(1);
+            return SLANG_FAIL;
         }
     }
     
@@ -208,10 +210,11 @@ void parseOptions(int* argc, char** argv)
     if(argCursor != argEnd)
     {
         fprintf(stderr, "unexpected arguments\n");
-        exit(1);
+        return SLANG_FAIL;
     }
 
     *argc = 0;
+	return SLANG_OK;
 }
 
 // Called for an error in the test-runner (not for an error involving
@@ -357,7 +360,7 @@ TestCategory* findTestCategory(String const& name)
     return category;
 }
 
-// Optiosn for a particular test
+// Options for a particular test
 struct TestOptions
 {
     String command;
@@ -1230,13 +1233,13 @@ TestResult doRenderComparisonTestRun(TestInput& input, char const* langOption, c
 {
     // TODO: delete any existing files at the output path(s) to avoid stale outputs leading to a false pass
 
-    auto filePath999 = input.filePath;
+    auto filePath = input.filePath;
     auto outputStem = input.outputStem;
 
     OSProcessSpawner spawner;
 
     spawner.pushExecutablePath(String(options.binDir) + "render-test" + osGetExecutableSuffix());
-    spawner.pushArgument(filePath999);
+    spawner.pushArgument(filePath);
 
     for( auto arg : input.testOptions->args )
     {
@@ -1280,7 +1283,7 @@ TestResult doImageComparison(String const& filePath)
     // Allow a difference in the low bits of the 8-bit result, just to play it safe
     static const int kAbsoluteDiffCutoff = 2;
 
-    // Allow a relatie 1% difference
+    // Allow a relative 1% difference
     static const float kRelativeDiffCutoff = 0.01f;
 
     String expectedPath = filePath + ".expected.png";
@@ -1288,7 +1291,6 @@ TestResult doImageComparison(String const& filePath)
 
     int expectedX,  expectedY,  expectedN;
     int actualX,    actualY,    actualN;
-
 
     unsigned char* expectedData = stbi_load(expectedPath.begin(), &expectedX, &expectedY, &expectedN, 0);
     unsigned char* actualData = stbi_load(actualPath.begin(), &actualX, &actualY, &actualN, 0);
@@ -1304,47 +1306,51 @@ TestResult doImageComparison(String const& filePath)
     unsigned char* actualCursor = actualData;
 
     for( int y = 0; y < actualY; ++y )
-    for( int x = 0; x < actualX; ++x )
-    for( int n = 0; n < actualN; ++n )
-    {
-        int expectedVal = *expectedCursor++;
-        int actualVal = *actualCursor++;
+	{
+		for( int x = 0; x < actualX; ++x )
+		{
+			for( int n = 0; n < actualN; ++n )
+			{
+				int expectedVal = *expectedCursor++;
+				int actualVal = *actualCursor++;
 
-        int absoluteDiff = actualVal - expectedVal;
-        if(absoluteDiff < 0) absoluteDiff = -absoluteDiff;
+				int absoluteDiff = actualVal - expectedVal;
+				if(absoluteDiff < 0) absoluteDiff = -absoluteDiff;
 
-        if( absoluteDiff < kAbsoluteDiffCutoff )
-        {
-            // There might be a difference, but we'll consider it to be inside tolerance
-            continue;
-        }
+				if( absoluteDiff < kAbsoluteDiffCutoff )
+				{
+					// There might be a difference, but we'll consider it to be inside tolerance
+					continue;
+				}
 
-        float relativeDiff = 0.0f;
-        if( expectedVal != 0 )
-        {
-            relativeDiff = fabsf(float(actualVal) - float(expectedVal)) / float(expectedVal);
+				float relativeDiff = 0.0f;
+				if( expectedVal != 0 )
+				{
+					relativeDiff = fabsf(float(actualVal) - float(expectedVal)) / float(expectedVal);
 
-            if( relativeDiff < kRelativeDiffCutoff )
-            {
-                // relative difference was small enough
-                continue;
-            }
-        }
+					if( relativeDiff < kRelativeDiffCutoff )
+					{
+						// relative difference was small enough
+						continue;
+					}
+				}
 
-        // TODO: may need to do some local search sorts of things, to deal with
-        // cases where vertex shader results lead to rendering that is off
-        // by one pixel...
+				// TODO: may need to do some local search sorts of things, to deal with
+				// cases where vertex shader results lead to rendering that is off
+				// by one pixel...
 
-        fprintf(stderr, "image compare failure at (%d,%d) channel %d. expected %d got %d (absolute error: %d, relative error: %f)\n",
-            x, y, n,
-            expectedVal,
-            actualVal,
-            absoluteDiff,
-            relativeDiff);
+				fprintf(stderr, "image compare failure at (%d,%d) channel %d. expected %d got %d (absolute error: %d, relative error: %f)\n",
+					x, y, n,
+					expectedVal,
+					actualVal,
+					absoluteDiff,
+					relativeDiff);
 
-        // There was a difference we couldn't excuse!
-        return kTestResult_Fail;
-    }
+				// There was a difference we couldn't excuse!
+				return kTestResult_Fail;
+			}
+		}
+	}
 
     return kTestResult_Pass;
 }
@@ -1354,7 +1360,7 @@ TestResult runHLSLRenderComparisonTestImpl(
     char const* expectedArg,
     char const* actualArg)
 {
-    auto filePath999 = input.filePath;
+    auto filePath = input.filePath;
     auto outputStem = input.outputStem;
 
     String expectedOutput;
@@ -1395,7 +1401,7 @@ TestResult runHLSLCrossCompileRenderComparisonTest(TestInput& input)
     return runHLSLRenderComparisonTestImpl(input, "-slang", "-glsl-cross");
 }
 
-TestResult runHLSLAndGLSLComparisonTest(TestInput& input)
+TestResult runHLSLAndGLSLRenderComparisonTest(TestInput& input)
 {
     return runHLSLRenderComparisonTestImpl(input, "-hlsl-rewrite", "-glsl-rewrite");
 }
@@ -1412,18 +1418,21 @@ TestResult runTest(
     FileTestList const& testList)
 {
     // based on command name, dispatch to an appropriate callback
-    static const struct TestCommands
+    struct TestCommands
     {
         char const*     name;
         TestCallback    callback;
-    } kTestCommands[] = {
+    };
+	
+	static const TestCommands kTestCommands[] = 
+	{
         { "SIMPLE", &runSimpleTest },
         { "REFLECTION", &runReflectionTest },
 #if SLANG_TEST_SUPPORT_HLSL
         { "COMPARE_HLSL", &runHLSLComparisonTest },
         { "COMPARE_HLSL_RENDER", &runHLSLRenderComparisonTest },
         { "COMPARE_HLSL_CROSS_COMPILE_RENDER", &runHLSLCrossCompileRenderComparisonTest},
-        { "COMPARE_HLSL_GLSL_RENDER", &runHLSLAndGLSLComparisonTest },
+        { "COMPARE_HLSL_GLSL_RENDER", &runHLSLAndGLSLRenderComparisonTest },
         { "COMPARE_COMPUTE", runSlangComputeComparisonTest},
         { "COMPARE_COMPUTE_EX", runSlangComputeComparisonTestEx},
         { "HLSL_COMPUTE", runHLSLComputeTest},
@@ -1748,8 +1757,11 @@ int main(
 
     //
 
-
-    parseOptions(&argc, argv);
+    if (SLANG_FAILED(parseOptions(&argc, argv)))
+	{
+		// Return exit code with error
+		return 1;
+	}
 
     if( options.includeCategories.Count() == 0 )
     {
@@ -1777,7 +1789,6 @@ int main(
         printf("no tests run\n");
         return 0;
     }
-
 
     auto passCount = context.passedTestCount;
     auto rawTotal = context.totalTestCount;

--- a/tools/slang-test/main.cpp
+++ b/tools/slang-test/main.cpp
@@ -28,7 +28,7 @@ enum OutputMode
     // Default mode is to write test results to the console
     kOutputMode_Default = 0,
 
-    // When running under AppVeyor contiuous integration, we
+    // When running under AppVeyor continuous integration, we
     // need to output test results in a way that the AppVeyor
     // environment can pick up and display.
     kOutputMode_AppVeyor,
@@ -68,7 +68,7 @@ struct Options
     // Only run tests that match one of the given categories
     Dictionary<TestCategory*, TestCategory*> includeCategories;
 
-    // Exclude test taht match one these categories
+    // Exclude test that match one these categories
     Dictionary<TestCategory*, TestCategory*> excludeCategories;
 };
 Options options;

--- a/tools/slang-test/main.cpp
+++ b/tools/slang-test/main.cpp
@@ -976,7 +976,7 @@ TestResult runHLSLComparisonTest(TestInput& input)
 
     OSProcessSpawner::ResultCode resultCode = spawner.getResultCode();
 
-    String standardOuptut = spawner.getStandardOutput();
+    String standardOuput = spawner.getStandardOutput();
     String standardError = spawner.getStandardError();
 
     // We construct a single output string that captures the results
@@ -986,7 +986,7 @@ TestResult runHLSLComparisonTest(TestInput& input)
     actualOutputBuilder.Append("\nstandard error = {\n");
     actualOutputBuilder.Append(standardError);
     actualOutputBuilder.Append("}\nstandard output = {\n");
-    actualOutputBuilder.Append(standardOuptut);
+    actualOutputBuilder.Append(standardOuput);
     actualOutputBuilder.Append("}\n");
 
     String actualOutput = actualOutputBuilder.ProduceString();
@@ -1008,7 +1008,7 @@ TestResult runHLSLComparisonTest(TestInput& input)
     {
         if (resultCode != 0)				result = kTestResult_Fail;
         if (standardError.Length() != 0)	result = kTestResult_Fail;
-        if (standardOuptut.Length() != 0)	result = kTestResult_Fail;
+        if (standardOuput.Length() != 0)	result = kTestResult_Fail;
     }
     // Otherwise we compare to the expected output
     else if (actualOutput != expectedOutput)

--- a/tools/slang-test/main.cpp
+++ b/tools/slang-test/main.cpp
@@ -979,7 +979,7 @@ TestResult runHLSLComparisonTest(TestInput& input)
 
     OSProcessSpawner::ResultCode resultCode = spawner.getResultCode();
 
-    String standardOuput = spawner.getStandardOutput();
+    String standardOutput = spawner.getStandardOutput();
     String standardError = spawner.getStandardError();
 
     // We construct a single output string that captures the results
@@ -989,7 +989,7 @@ TestResult runHLSLComparisonTest(TestInput& input)
     actualOutputBuilder.Append("\nstandard error = {\n");
     actualOutputBuilder.Append(standardError);
     actualOutputBuilder.Append("}\nstandard output = {\n");
-    actualOutputBuilder.Append(standardOuput);
+    actualOutputBuilder.Append(standardOutput);
     actualOutputBuilder.Append("}\n");
 
     String actualOutput = actualOutputBuilder.ProduceString();
@@ -1011,7 +1011,7 @@ TestResult runHLSLComparisonTest(TestInput& input)
     {
         if (resultCode != 0)				result = kTestResult_Fail;
         if (standardError.Length() != 0)	result = kTestResult_Fail;
-        if (standardOuput.Length() != 0)	result = kTestResult_Fail;
+        if (standardOutput.Length() != 0)	result = kTestResult_Fail;
     }
     // Otherwise we compare to the expected output
     else if (actualOutput != expectedOutput)
@@ -1339,16 +1339,16 @@ TestResult doImageComparison(String const& filePath)
 				// cases where vertex shader results lead to rendering that is off
 				// by one pixel...
 
-				fprintf(stderr, "image compare failure at (%d,%d) channel %d. expected %d got %d (absolute error: %d, relative error: %f)\n",
-					x, y, n,
-					expectedVal,
-					actualVal,
-					absoluteDiff,
-					relativeDiff);
-
-				// There was a difference we couldn't excuse!
-				return kTestResult_Fail;
-			}
+			    fprintf(stderr, "image compare failure at (%d,%d) channel %d. expected %d got %d (absolute error: %d, relative error: %f)\n",
+			    	x, y, n,
+			    	expectedVal,
+			    	actualVal,
+			    	absoluteDiff,
+			    	relativeDiff);
+                
+			    // There was a difference we couldn't excuse!
+			    return kTestResult_Fail;
+		    }
 		}
 	}
 
@@ -1758,10 +1758,10 @@ int main(
     //
 
     if (SLANG_FAILED(parseOptions(&argc, argv)))
-	{
-		// Return exit code with error
-		return 1;
-	}
+    {
+    	// Return exit code with error
+    	return 1;
+    }
 
     if( options.includeCategories.Count() == 0 )
     {
@@ -1799,7 +1799,7 @@ int main(
     printf("\n===\n%d%% of tests passed (%d/%d)", (passCount*100) / runTotal, passCount, runTotal);
     if(ignoredCount)
     {
-        printf(", %d tests ingored", ignoredCount);
+        printf(", %d tests ignored", ignoredCount);
     }
     printf("\n===\n\n");
 


### PR DESCRIPTION
The testing code, when an error occurred would often just call exit(1). Whilst this worked it made debugging more difficult - as program flow was terminated.

To work around the problem added the SlangResult (or Slang::Result) type, which is compatible with HRESULT. This is an integral type that can return success or failure - as well as identifying what specifically caused a failure. It is then used to propagate errors just as a return code. The Renderer interface is changed slightly such that it returns SlangResult on methods that can fail.  

Added a first pass README.md file for slang-test.