### PR TITLE
Unify all generic parameters, even if some mismatch

### DIFF
--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -5419,17 +5419,22 @@ namespace Slang
             // Their arguments must unify
             SLANG_RELEASE_ASSERT(fstGen->args.Count() == sndGen->args.Count());
             UInt argCount = fstGen->args.Count();
+            bool okay = true;
             for (UInt aa = 0; aa < argCount; ++aa)
             {
                 if (!TryUnifyVals(constraints, fstGen->args[aa], sndGen->args[aa]))
-                    return false;
+                {
+                    okay = false;
+                }
             }
 
             // Their "base" specializations must unify
             if (!TryUnifySubstitutions(constraints, fstGen->outer, sndGen->outer))
-                return false;
+            {
+                okay = false;
+            }
 
-            return true;
+            return okay;
         }
 
         bool TryUnifyTypeParam(

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -2011,10 +2011,13 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     String DeclRefBase::toString() const
     {
-        StringBuilder sb;
-        sb << this->getDecl()->getName()->text;
+        if (!decl) return "";
+
+        auto name = decl->getName();
+        if (!name) return "";
+
         // TODO: need to print out substitutions too!
-        return sb.ProduceString();
+        return name->text;
     }
     
     RefPtr<ThisTypeSubstitution> getThisTypeSubst(DeclRefBase & declRef, bool insertSubstEntry)

--- a/tests/bugs/gh-449.slang
+++ b/tests/bugs/gh-449.slang
@@ -1,0 +1,25 @@
+// gh-449.slang
+//TEST:SIMPLE:
+
+// Issue when dealing with binary operations that
+// mix scalars with vectors that have a different
+// element type.
+
+struct S { int dummy; };
+
+void foo(S s);
+
+void main()
+{
+    // This works fine right now. The `uint` gets converted to a
+    // `float`, and then we do the addition.
+    float2 a = float2(1, 2);
+    uint   b = 3;
+    foo(a + b);
+
+    // This used to get confused, with the `f` getting converted
+    // to a `uint` before the addition.
+    uint2 u = uint2(1, 2);
+    float f = 3.0;
+    foo(u + f);
+}

--- a/tests/bugs/gh-449.slang.expected
+++ b/tests/bugs/gh-449.slang.expected
@@ -1,0 +1,7 @@
+result code = -1
+standard error = {
+tests/bugs/gh-449.slang(18): error 30019: expected an expression of type 'S', got 'vector<float,2>'
+tests/bugs/gh-449.slang(24): error 30019: expected an expression of type 'S', got 'vector<float,2>'
+}
+standard output = {
+}


### PR DESCRIPTION
Most of the description is in the second commit message below. This is a fix for bug #449.