### PR TITLE
Change uses of "spire" to "slang"

### DIFF
--- a/examples/hello/README.md
+++ b/examples/hello/README.md
@@ -1,9 +1,9 @@
-Spire "Hello World" Example
+Slang "Hello World" Example
 ===========================
 
-The goal of this example is to demonstrate an almost minimal application that uses Spire for shading, and D3D11 for rendering.
+The goal of this example is to demonstrate an almost minimal application that uses Slang for shading, and D3D11 for rendering.
 
-The `hello.spire` file contains a simple declaration of a Spire *shader module*, along with a *pipeline declaration* that will be used for mapping shader code to the capabilities of the "engine" (in this case, just vertex and fragment shaders).
-The `hello.cpp` file contains the C++ application code, showing how to use the Spire C API to load and compile the shader code, and construct a (trivial) executable shader from Spire modules.
+The `hello.slang` file contains simple vertex and fragment shader entry points.
+The `hello.cpp` file contains the C++ application code, showing how to use the Slang C API to load and compile the shader code to DirectX shader bytecode (DXBC).
 
-Note that this example is not intended to demonstrate good practices for integrating Spire into a production engine; the goal is merely to use the minimum amount of code possible to demonstrate a complete applicaiton that uses Spire.
+Note that this example is not intended to demonstrate good practices for integrating Slang into a production engine; the goal is merely to use the minimum amount of code possible to demonstrate a complete applicaiton that uses Slang.

--- a/examples/hello/hello.slang
+++ b/examples/hello/hello.slang
@@ -1,4 +1,4 @@
-// shaders.spire
+// hello.slang
 
 cbuffer Uniforms
 {

--- a/examples/hello/hello.vcxproj
+++ b/examples/hello/hello.vcxproj
@@ -157,7 +157,7 @@
     <ClCompile Include="hello.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="hello.spire" />
+    <None Include="hello.slang" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/examples/hello/hello.vcxproj.filters
+++ b/examples/hello/hello.vcxproj.filters
@@ -4,6 +4,6 @@
     <ClCompile Include="hello.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="hello.spire" />
+    <None Include="hello.slang" />
   </ItemGroup>
 </Project>

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DB00DA62-0533-4AFD-B59F-A67D5B3A0808}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>SpireCore</RootNamespace>
+    <RootNamespace>slang</RootNamespace>
     <ProjectName>slang</ProjectName>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>

--- a/source/slangc/slangc.vcxproj
+++ b/source/slangc/slangc.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D56CBCEB-1EB5-4CA8-AEC4-48EA35ED61C7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>SpireCompiler</RootNamespace>
+    <RootNamespace>slangc</RootNamespace>
     <ProjectName>slangc</ProjectName>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
@@ -92,7 +92,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <AdditionalIncludeDirectories>../;../SpireLib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
@@ -109,7 +109,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <AdditionalIncludeDirectories>../;../SpireLib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
@@ -128,7 +128,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <AdditionalIncludeDirectories>../;../SpireLib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
@@ -149,7 +149,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <AdditionalIncludeDirectories>../;../SpireLib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>

--- a/tests/bindings/README.md
+++ b/tests/bindings/README.md
@@ -21,9 +21,9 @@ The resulting code guarantees that `tb` will always be assigned to the same loca
 Methodology
 -----------
 
-These tests currently rely on the ability to run the same HLSL code through the Spire compiler driver and execute either Spire, or HLSL. We write an example like the above by wrapping explicit `register` semantics in a macro:
+These tests currently rely on the ability to run the same HLSL code through the Slang compiler driver and execute either Slang, or HLSL. We write an example like the above by wrapping explicit `register` semantics in a macro:
 
     Texture2D ta R(: register(t0));
     Texture2D tb R(: register(t1));
 
-In the HLSL case, these annotations will manually place things where we want them, while in the Spire case, we define the macro to have an empty expansion, so that the annotations express our expectation for what the compiler will auto-generate.
+In the HLSL case, these annotations will manually place things where we want them, while in the Slang case, we define the macro to have an empty expansion, so that the annotations express our expectation for what the compiler will auto-generate.

--- a/tests/bindings/binding0.hlsl
+++ b/tests/bindings/binding0.hlsl
@@ -1,10 +1,10 @@
 //TEST:COMPARE_HLSL:-no-mangle -target dxbc-assembly -profile ps_4_0 -entry main
 
-// Let's first confirm that Spire can reproduce what the
+// Let's first confirm that Slang can reproduce what the
 // HLSL compiler would already do in the simple case (when
 // all shader parameters are actually used).
 
-#ifdef __SPIRE__
+#ifdef __SLANG__
 #define R(X) /**/
 #else
 #define R(X) X

--- a/tests/bindings/binding1.hlsl
+++ b/tests/bindings/binding1.hlsl
@@ -1,6 +1,6 @@
 //TEST:COMPARE_HLSL:-no-mangle -target dxbc-assembly -profile ps_4_0 -entry main
 
-// We want to make sure that the registers that Spire generates
+// We want to make sure that the registers Slang generates
 // are used, even if there are "dead" parameter earlier in the program.
 //
 // In this case, we declare two each of textures, samplers, and constant
@@ -8,10 +8,10 @@
 // Left to its own devices, the HLSL compiler would usually shift the
 // object that was used up to binding slot zero, and eliminate the one
 // that wasn't used.
-// We expect Spire to generate explicit annotations that stop this from
+// We expect Slang to generate explicit annotations that stop this from
 // happening.
 
-#ifdef __SPIRE__
+#ifdef __SLANG__
 #define R(X) /**/
 #else
 #define R(X) X

--- a/tests/bindings/explicit-binding.hlsl
+++ b/tests/bindings/explicit-binding.hlsl
@@ -3,7 +3,7 @@
 // We need to allow the user to add explicit bindings to their parameters,
 // and we can't go and auto-assign anything to use the same locations.
 
-#ifdef __SPIRE__
+#ifdef __SLANG__
 #define R(X) /**/
 #else
 #define R(X) X

--- a/tests/bindings/multi-file-extra.hlsl
+++ b/tests/bindings/multi-file-extra.hlsl
@@ -5,7 +5,7 @@
 
 // This file provides the fragment shader, and is only meant to be tested in combination with `multi-file.hlsl`
 
-#ifdef __SPIRE__
+#ifdef __SLANG__
 #define R(X) /**/
 #else
 #define R(X) X

--- a/tests/bindings/multi-file.hlsl
+++ b/tests/bindings/multi-file.hlsl
@@ -6,7 +6,7 @@
 // This file provides the vertex shader, while the fragment shader resides in
 // the file `multi-file-extra.hlsl`
 
-#ifdef __SPIRE__
+#ifdef __SLANG__
 #define R(X) /**/
 #else
 #define R(X) X

--- a/tests/bindings/packoffset.hlsl
+++ b/tests/bindings/packoffset.hlsl
@@ -3,7 +3,7 @@
 // Let's make sure we generate correct output in cases
 // where there are non-trivial `packoffset`s needed
 
-#ifdef __SPIRE__
+#ifdef __SLANG__
 #define R(X) /**/
 #else
 #define R(X) X

--- a/tests/bindings/resources-in-cbuffer.hlsl
+++ b/tests/bindings/resources-in-cbuffer.hlsl
@@ -4,7 +4,7 @@
 // including the case where there are *multiple* constant buffers
 // with reosurces.
 
-#ifdef __SPIRE__
+#ifdef __SLANG__
 #define R(X) /**/
 #else
 #define R(X) X

--- a/tests/bindings/resources-in-structs.hlsl.disabled
+++ b/tests/bindings/resources-in-structs.hlsl.disabled
@@ -1,8 +1,8 @@
-//SPIRE_TEST_OPTS:-target dxbc-assembly -profile ps_5_0 -entry main
+//SLANG_TEST_OPTS:-target dxbc-assembly -profile ps_5_0 -entry main
 
 // Confirm that resources inside `struct` types work reasonably well,
 
-#ifdef __SPIRE__
+#ifdef __SLANG__
 #define R(X) /**/
 #else
 #define R(X) X

--- a/tests/bindings/targets-and-uavs-structure.hlsl
+++ b/tests/bindings/targets-and-uavs-structure.hlsl
@@ -3,7 +3,7 @@
 // Handle the case where the fragment shader output is
 // defined a structure, and the semantics are on the sub-fields
 
-#ifdef __SPIRE__
+#ifdef __SLANG__
 #define R(X) /**/
 #else
 #define R(X) X

--- a/tests/bindings/targets-and-uavs.hlsl
+++ b/tests/bindings/targets-and-uavs.hlsl
@@ -5,7 +5,7 @@
 // make sure that any `u` registers we allocate don't
 // interfere with render targets.
 
-#ifdef __SPIRE__
+#ifdef __SLANG__
 #define R(X) /**/
 #else
 #define R(X) X

--- a/tests/front-end/parser-using-file-a.slang.h
+++ b/tests/front-end/parser-using-file-a.slang.h
@@ -1,3 +1,3 @@
-// this file exists to be included by "parser-using-file.spire"
+// this file exists to be included by "parser-using-file.slang"
 
 float a(float x) { return x * x; }

--- a/tests/hlsl/dxsdk/AdaptiveTessellationCS40/TessellatorCS40_EdgeFactorCS.hlsl
+++ b/tests/hlsl/dxsdk/AdaptiveTessellationCS40/TessellatorCS40_EdgeFactorCS.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile cs_4_0 -entry CSEdgeFactor
 //--------------------------------------------------------------------------------------
 // File: TessellatorCS40_EdgeFactorCS.hlsl

--- a/tests/hlsl/dxsdk/AdaptiveTessellationCS40/TessellatorCS40_NumVerticesIndicesCS.hlsl
+++ b/tests/hlsl/dxsdk/AdaptiveTessellationCS40/TessellatorCS40_NumVerticesIndicesCS.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile cs_4_0 -entry CSNumVerticesIndices
 //--------------------------------------------------------------------------------------
 // File: TessellatorCS40_NumVerticesIndicesCS.hlsl

--- a/tests/hlsl/dxsdk/AdaptiveTessellationCS40/TessellatorCS40_TessellateIndicesCS.hlsl
+++ b/tests/hlsl/dxsdk/AdaptiveTessellationCS40/TessellatorCS40_TessellateIndicesCS.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile cs_4_0 -entry CSTessellationIndices
 //--------------------------------------------------------------------------------------
 // File: TessellatorCS40_TessellateIndicesCS.hlsl

--- a/tests/hlsl/dxsdk/AdaptiveTessellationCS40/TessellatorCS40_TessellateVerticesCS.hlsl
+++ b/tests/hlsl/dxsdk/AdaptiveTessellationCS40/TessellatorCS40_TessellateVerticesCS.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile cs_4_0 -entry CSTessellationVertices
 //--------------------------------------------------------------------------------------
 // File: TessellatorCS40_TessellateVerticesCS.hlsl

--- a/tests/hlsl/dxsdk/BasicCompute11/BasicCompute11.hlsl
+++ b/tests/hlsl/dxsdk/BasicCompute11/BasicCompute11.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile cs_4_0 -entry CSMain
 //--------------------------------------------------------------------------------------
 // File: BasicCompute11.hlsl

--- a/tests/hlsl/dxsdk/CascadedShadowMaps11/RenderCascadeScene.hlsl
+++ b/tests/hlsl/dxsdk/CascadedShadowMaps11/RenderCascadeScene.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VSMain -profile ps_4_0 -entry PSMain
 //--------------------------------------------------------------------------------------
 // File: RenderCascadeScene.hlsl

--- a/tests/hlsl/dxsdk/ComputeShaderSort11/ComputeShaderSort11.hlsl
+++ b/tests/hlsl/dxsdk/ComputeShaderSort11/ComputeShaderSort11.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile cs_4_0 -entry BitonicSort -entry MatrixTranspose
 //--------------------------------------------------------------------------------------
 // File: ComputeShaderSort11.hlsl

--- a/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial02/Tutorial02_PS.hlsl
+++ b/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial02/Tutorial02_PS.hlsl
@@ -1,3 +1,3 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile ps_4_0 -entry PS
 #include "Tutorial02.fx"

--- a/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial02/Tutorial02_VS.hlsl
+++ b/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial02/Tutorial02_VS.hlsl
@@ -1,3 +1,3 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VS
 #include "Tutorial02.fx"

--- a/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial03/Tutorial03_PS.hlsl
+++ b/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial03/Tutorial03_PS.hlsl
@@ -1,3 +1,3 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile ps_4_0 -entry PS
 #include "Tutorial03.fx"

--- a/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial03/Tutorial03_VS.hlsl
+++ b/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial03/Tutorial03_VS.hlsl
@@ -1,3 +1,3 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VS
 #include "Tutorial03.fx"

--- a/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial04/Tutorial04.fx
+++ b/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial04/Tutorial04.fx
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VS -profile ps_4_0 -entry PS
 //--------------------------------------------------------------------------------------
 // File: Tutorial04.fx

--- a/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial04/Tutorial04_PS.hlsl
+++ b/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial04/Tutorial04_PS.hlsl
@@ -1,3 +1,3 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile ps_4_0 -entry PS
 #include "Tutorial04.fx"

--- a/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial04/Tutorial04_VS.hlsl
+++ b/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial04/Tutorial04_VS.hlsl
@@ -1,3 +1,3 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VS
 #include "Tutorial04.fx"

--- a/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial05/Tutorial05.fx
+++ b/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial05/Tutorial05.fx
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VS -profile ps_4_0 -entry PS
 //--------------------------------------------------------------------------------------
 // File: Tutorial05.fx

--- a/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial05/Tutorial05_PS.hlsl
+++ b/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial05/Tutorial05_PS.hlsl
@@ -1,3 +1,3 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile ps_4_0 -entry PS
 #include "Tutorial05.fx"

--- a/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial05/Tutorial05_VS.hlsl
+++ b/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial05/Tutorial05_VS.hlsl
@@ -1,3 +1,3 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VS
 #include "Tutorial05.fx"

--- a/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial06/Tutorial06.fx
+++ b/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial06/Tutorial06.fx
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VS -profile ps_4_0 -entry PS -entry PSSolid
 //--------------------------------------------------------------------------------------
 // File: Tutorial06.fx

--- a/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial06/Tutorial06_PS.hlsl
+++ b/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial06/Tutorial06_PS.hlsl
@@ -1,3 +1,3 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile ps_4_0 -entry PS
 #include "Tutorial06.fx"

--- a/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial06/Tutorial06_VS.hlsl
+++ b/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial06/Tutorial06_VS.hlsl
@@ -1,3 +1,3 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VS
 #include "Tutorial06.fx"

--- a/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial07/Tutorial07.fx
+++ b/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial07/Tutorial07.fx
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VS -profile ps_4_0 -entry PS
 //--------------------------------------------------------------------------------------
 // File: Tutorial07.fx

--- a/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial07/Tutorial07_PS.hlsl
+++ b/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial07/Tutorial07_PS.hlsl
@@ -1,3 +1,3 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile ps_4_0 -entry PS
 #include "Tutorial07.fx"

--- a/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial07/Tutorial07_VS.hlsl
+++ b/tests/hlsl/dxsdk/Direct3D11Tutorials/Tutorial07/Tutorial07_VS.hlsl
@@ -1,3 +1,3 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VS
 #include "Tutorial07.fx"

--- a/tests/hlsl/dxsdk/Direct3D11TutorialsDXUT/Tutorial08/Tutorial08.fx
+++ b/tests/hlsl/dxsdk/Direct3D11TutorialsDXUT/Tutorial08/Tutorial08.fx
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VS -profile ps_4_0 -entry PS
 //--------------------------------------------------------------------------------------
 // File: Tutorial08.fx

--- a/tests/hlsl/dxsdk/Direct3D11TutorialsDXUT/Tutorial09/Tutorial09.fx
+++ b/tests/hlsl/dxsdk/Direct3D11TutorialsDXUT/Tutorial09/Tutorial09.fx
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VS -profile ps_4_0 -entry PS
 //--------------------------------------------------------------------------------------
 // File: Tutorial09.fx

--- a/tests/hlsl/dxsdk/Direct3D11TutorialsDXUT/Tutorial10/Tutorial10.fx
+++ b/tests/hlsl/dxsdk/Direct3D11TutorialsDXUT/Tutorial10/Tutorial10.fx
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VS -profile ps_4_0 -entry PS
 //--------------------------------------------------------------------------------------
 // File: Tutorial10.fx

--- a/tests/hlsl/dxsdk/DynamicShaderLinkage11/DynamicShaderLinkage11_PS.hlsl
+++ b/tests/hlsl/dxsdk/DynamicShaderLinkage11/DynamicShaderLinkage11_PS.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile ps_4_0 -entry PSMain
 //--------------------------------------------------------------------------------------
 // File: DynamicShaderLinkage11.psh

--- a/tests/hlsl/dxsdk/FluidCS11/ComputeShaderSort11.hlsl
+++ b/tests/hlsl/dxsdk/FluidCS11/ComputeShaderSort11.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile cs_4_0 -entry BitonicSort -entry MatrixTranspose
 //--------------------------------------------------------------------------------------
 // File: ComputeShaderSort11.hlsl

--- a/tests/hlsl/dxsdk/FluidCS11/FluidCS11.hlsl
+++ b/tests/hlsl/dxsdk/FluidCS11/FluidCS11.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile cs_4_0 -entry BuildGridCS -entry ClearGridIndicesCS -entry BuildGridIndicesCS -entry RearrangeParticlesCS -entry DensityCS_Simple -entry DensityCS_Shared -entry DensityCS_Grid -entry ForceCS_Simple -entry ForceCS_Shared -entry ForceCS_Grid -entry IntegrateCS
 //--------------------------------------------------------------------------------------
 // File: FluidCS11.hlsl

--- a/tests/hlsl/dxsdk/FluidCS11/FluidRender.hlsl
+++ b/tests/hlsl/dxsdk/FluidCS11/FluidRender.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry ParticleVS -profile gs_4_0 -entry ParticleGS -profile ps_4_0 -entry ParticlePS
 //--------------------------------------------------------------------------------------
 // File: FluidRender.hlsl

--- a/tests/hlsl/dxsdk/HDRToneMappingCS11/BrightPassAndHorizFilterCS.hlsl
+++ b/tests/hlsl/dxsdk/HDRToneMappingCS11/BrightPassAndHorizFilterCS.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile cs_4_0 -entry CSMain
 //--------------------------------------------------------------------------------------
 // File: BrightPassAndHorizFilterCS.hlsl

--- a/tests/hlsl/dxsdk/HDRToneMappingCS11/DumpToTexture.hlsl
+++ b/tests/hlsl/dxsdk/HDRToneMappingCS11/DumpToTexture.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile ps_4_0 -entry PSDump
 //--------------------------------------------------------------------------------------
 // File: DumpToTexture.hlsl

--- a/tests/hlsl/dxsdk/HDRToneMappingCS11/FilterCS.hlsl
+++ b/tests/hlsl/dxsdk/HDRToneMappingCS11/FilterCS.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile cs_4_0 -entry CSVerticalFilter -entry CSHorizFilter
 //--------------------------------------------------------------------------------------
 // File: FilterCS.hlsl

--- a/tests/hlsl/dxsdk/HDRToneMappingCS11/FinalPass.hlsl
+++ b/tests/hlsl/dxsdk/HDRToneMappingCS11/FinalPass.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry QuadVS -profile ps_4_0 -entry PSFinalPass -entry PSFinalPassForCPUReduction
 //--------------------------------------------------------------------------------------
 // File: FinalPass.hlsl

--- a/tests/hlsl/dxsdk/HDRToneMappingCS11/PSApproach.hlsl
+++ b/tests/hlsl/dxsdk/HDRToneMappingCS11/PSApproach.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile ps_4_0 -entry DownScale2x2_Lum -entry DownScale3x3 -entry FinalPass -entry DownScale3x3_BrightPass -entry Bloom
 //--------------------------------------------------------------------------------------
 // File: PSApproach.hlsl

--- a/tests/hlsl/dxsdk/HDRToneMappingCS11/ReduceTo1DCS.hlsl
+++ b/tests/hlsl/dxsdk/HDRToneMappingCS11/ReduceTo1DCS.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile cs_4_0 -entry CSMain
 //-----------------------------------------------------------------------------
 // File: ReduceTo1DCS.hlsl

--- a/tests/hlsl/dxsdk/HDRToneMappingCS11/skybox11.hlsl
+++ b/tests/hlsl/dxsdk/HDRToneMappingCS11/skybox11.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry SkyboxVS -profile ps_4_0 -entry SkyboxPS
 //-----------------------------------------------------------------------------
 // File: SkyBox11.hlsl

--- a/tests/hlsl/dxsdk/MultithreadedRendering11/MultithreadedRendering11_PS.hlsl
+++ b/tests/hlsl/dxsdk/MultithreadedRendering11/MultithreadedRendering11_PS.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile ps_4_0 -entry PSMain
 //--------------------------------------------------------------------------------------
 // File: MultithreadedRendering11_PS.hlsl

--- a/tests/hlsl/dxsdk/NBodyGravityCS11/NBodyGravityCS11.hlsl
+++ b/tests/hlsl/dxsdk/NBodyGravityCS11/NBodyGravityCS11.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile cs_4_0 -entry CSMain
 //--------------------------------------------------------------------------------------
 // File: NBodyGravityCS11.hlsl

--- a/tests/hlsl/dxsdk/NBodyGravityCS11/ParticleDraw.hlsl
+++ b/tests/hlsl/dxsdk/NBodyGravityCS11/ParticleDraw.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VSParticleDraw -profile gs_4_0 -entry GSParticleDraw -profile ps_4_0 -entry PSParticleDraw
 //--------------------------------------------------------------------------------------
 // File: ParticleDraw.hlsl

--- a/tests/hlsl/dxsdk/OIT11/OIT_CS.hlsl
+++ b/tests/hlsl/dxsdk/OIT11/OIT_CS.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile cs_4_0 -entry VSParticleDraw -profile gs_4_0 -entry GSParticleDraw -profile ps_4_0 -entry PSParticleDraw
 //-----------------------------------------------------------------------------
 // File: OIT_CS.hlsl

--- a/tests/hlsl/dxsdk/OIT11/OIT_PS.hlsl
+++ b/tests/hlsl/dxsdk/OIT11/OIT_PS.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile ps_4_0 -entry FragmentCountPS -entry FillDeepBufferPS
 //-----------------------------------------------------------------------------
 // File: OITPS.hlsl

--- a/tests/hlsl/dxsdk/SimpleSample11/SimpleSample.hlsl
+++ b/tests/hlsl/dxsdk/SimpleSample11/SimpleSample.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry RenderSceneVS -profile ps_4_0 -entry RenderScenePS
 //--------------------------------------------------------------------------------------
 // File: SimpleSample.hlsl

--- a/tests/hlsl/dxsdk/SubD11/SubD11.hlsl
+++ b/tests/hlsl/dxsdk/SubD11/SubD11.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry PatchSkinningVS -entry MeshSkinningVS -profile hs_5_0 -entry SubDToBezierHS -entry SubDToBezierHS4444 -profile ds_5_0 -entry BezierEvalDS -profile ps_4_0 -entry SmoothPS -entry SolidColorPS
 //--------------------------------------------------------------------------------------
 // File: SubD11.hlsl

--- a/tests/hlsl/dxsdk/VarianceShadows11/RenderVarianceScene.hlsl
+++ b/tests/hlsl/dxsdk/VarianceShadows11/RenderVarianceScene.hlsl
@@ -1,4 +1,4 @@
-//TEST_IGNORE_FILE: Currently failing due to Spire compiler issues.
+//TEST_IGNORE_FILE: Currently failing due to Slang compiler issues.
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VSMain -profile ps_4_0 -entry PSBlurX -entry PSBlurY
 //--------------------------------------------------------------------------------------
 // File: RenderCascadeScene.hlsl

--- a/tests/reflection/multi-file-extra.hlsl
+++ b/tests/reflection/multi-file-extra.hlsl
@@ -8,7 +8,7 @@
 // Let's make sure we generate correct output in cases
 // where there are non-trivial `packoffset`s needed
 
-#ifdef __SPIRE__
+#ifdef __SLANG__
 #define R(X) /**/
 #else
 #define R(X) X

--- a/tests/render/cross-compile0.hlsl
+++ b/tests/render/cross-compile0.hlsl
@@ -4,11 +4,11 @@
 //
 // We will define distinct HLSL and GLSL entry points,
 // but the two will share a dependency on a file of
-// pure Spire code that provides the actual shading logic.
+// pure Slang code that provides the actual shading logic.
 
 #if defined(__HLSL__)
 
-// Pull in Spire code depdendency using extended syntax:
+// Pull in Slang code depdendency using extended syntax:
 __import cross_compile0;
 
 cbuffer Uniforms

--- a/tests/render/imported-parameters.hlsl
+++ b/tests/render/imported-parameters.hlsl
@@ -6,7 +6,7 @@
 
 #if defined(__HLSL__)
 
-// Pull in Spire code depdendency using extended syntax:
+// Pull in Slang code depdendency using extended syntax:
 __import imported_parameters;
 
 struct AssembledVertex

--- a/tests/render/unused-discard.hlsl
+++ b/tests/render/unused-discard.hlsl
@@ -4,12 +4,12 @@
 //
 // We will define distinct HLSL and GLSL entry points,
 // but the two will share a dependency on a file of
-// pure Spire code that provides the actual shading logic.
+// pure Slang code that provides the actual shading logic.
 
 
 #if defined(__HLSL__)
 
-// Pull in Spire code depdendency using extended syntax:
+// Pull in Slang code depdendency using extended syntax:
 __import unused_discard;
 
 cbuffer Uniforms

--- a/tools/render-test/README.md
+++ b/tools/render-test/README.md
@@ -1,4 +1,4 @@
 Render Test
 ===========
 
-This is a simple tool for running end-to-end tests that render with Spire, so that we can validate that it generates correct code.
+This is a simple tool for running end-to-end tests that render with Slang, so that we can validate that it generates correct code.

--- a/tools/slang-test/slang-test.vcxproj
+++ b/tools/slang-test/slang-test.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0C768A18-1D25-4000-9F37-DA5FE99E3B64}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>SpireTestTool</RootNamespace>
+    <RootNamespace>slang_test</RootNamespace>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
Fixes #350

When the Slang project forked off from the Spire research effort, we renamed things as we went, but many cases seem to have slipped through the cracks.

The two biggest diffs here are:

- The `hello` example program was incorrectly talking about what was in the shader file (Slang no longer supports the "module" or "pipeline" constructs from Spire), and so it wasn't just a simple rename.

- The files under `tests/bindings` were mistakenly using `__SPIRE__` as a preprocessor guard, which means that they weren't actually testing what they meant to. Luckily, it looks like the relevant functionality didn't regress while these tests were unintentionally deactivated.