### PR TITLE
Update to top-of-tree glslang (2018-04-02).

### DIFF
--- a/source/slang-glslang/slang-glslang.vcxproj
+++ b/source/slang-glslang/slang-glslang.vcxproj
@@ -96,7 +96,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>NV_EXTENSIONS;AMD_EXTENSIONS;WIN32;_DEBUG;_WINDOWS;_USRDLL;GLSLANG_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NV_EXTENSIONS;AMD_EXTENSIONS;ENABLE_OPT=0;WIN32;_DEBUG;_WINDOWS;_USRDLL;GLSLANG_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4819;4267</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -110,7 +110,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>NV_EXTENSIONS;AMD_EXTENSIONS;_DEBUG;_WINDOWS;_USRDLL;GLSLANG_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NV_EXTENSIONS;AMD_EXTENSIONS;ENABLE_OPT=0;_DEBUG;_WINDOWS;_USRDLL;GLSLANG_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4819;4267</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -126,7 +126,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NV_EXTENSIONS;AMD_EXTENSIONS;WIN32;NDEBUG;_WINDOWS;_USRDLL;GLSLANG_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NV_EXTENSIONS;AMD_EXTENSIONS;ENABLE_OPT=0;WIN32;NDEBUG;_WINDOWS;_USRDLL;GLSLANG_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4819;4267</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -144,7 +144,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NV_EXTENSIONS;AMD_EXTENSIONS;NDEBUG;_WINDOWS;_USRDLL;GLSLANG_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NV_EXTENSIONS;AMD_EXTENSIONS;ENABLE_OPT=0;NDEBUG;_WINDOWS;_USRDLL;GLSLANG_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4819;4267</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -157,6 +157,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\external\glslang\glslang\GenericCodeGen\CodeGen.cpp" />
     <ClCompile Include="..\..\external\glslang\glslang\GenericCodeGen\Link.cpp" />
+    <ClCompile Include="..\..\external\glslang\glslang\MachineIndependent\attribute.cpp" />
     <ClCompile Include="..\..\external\glslang\glslang\MachineIndependent\Constant.cpp" />
     <ClCompile Include="..\..\external\glslang\glslang\MachineIndependent\glslang_tab.cpp" />
     <ClCompile Include="..\..\external\glslang\glslang\MachineIndependent\InfoSink.cpp" />
@@ -197,6 +198,7 @@
     <ClCompile Include="slang-glslang.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\external\glslang\glslang\MachineIndependent\attribute.h" />
     <ClInclude Include="..\..\external\glslang\glslang\MachineIndependent\glslang_tab.cpp.h" />
     <ClInclude Include="..\..\external\glslang\glslang\MachineIndependent\gl_types.h" />
     <ClInclude Include="..\..\external\glslang\glslang\MachineIndependent\Initialize.h" />

--- a/source/slang-glslang/slang-glslang.vcxproj.filters
+++ b/source/slang-glslang/slang-glslang.vcxproj.filters
@@ -133,6 +133,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="slang-glslang.cpp" />
+    <ClCompile Include="..\..\external\glslang\glslang\MachineIndependent\attribute.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\external\glslang\glslang\MachineIndependent\gl_types.h">
@@ -241,6 +244,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="slang-glslang.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\external\glslang\glslang\MachineIndependent\attribute.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This is an attempt to alleviate some driver crashes caused by invalid SPIR-V. Because Slang drives `glslang` with GLSL source code, any invalid output is likely due to `glslang` bugs.

I chose top-of-tree for `glslang` because it wasn't clear what their release process is. Hopefully we can go another year without having to update this dependency.

The build setup we use for `glslang` had to change to account for one more `#define` that the code expects to have passed in externally.