### PR TITLE
Add an EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,37 @@
+# This file sets up basic text editor behavior
+# using EditorConfig: http://EditorConfig.org.
+#
+# Some editors will import and use the settings from
+# this file automatically, while others need a plugin.
+
+# Editors are supposed to search upwards from a source
+# file to find configuration settings until they see
+# a "root" file. This file should be a root:
+#
+root = true
+
+# Shared configuration for all C/C++ and Slang code
+#
+[*.{c,cpp,h,slang}]
+
+# Use UTF-8 encoding
+#
+charset = utf-8
+
+# Indent using 4 spaces.
+#
+indent_style = space
+indent_size = 4
+
+# Insert a newline at the end of the file
+# if one is missing (this used to be officially
+# required by C, but it is also just a tidyness thing)
+#
+insert_final_newline = true
+
+# Remove any extra whitespace characters at the
+# end of a line. This is just for tidyness, to
+# minimize the chances of introducing whitspace
+# diffs that are hard to spot.
+#
+trim_trailing_whitespace = true


### PR DESCRIPTION
Developers may need to install an appropriate plugin for their text editor.
For example, Visual Studio 2015 users can install the plugin from `Tools -> Extensions and Updates...`.
Visual Studio 2017 supports EditorConfig directly.

The main goal of this PR is to allow VS users to more easily toggle between projects that default to spaces or tabs for indentation without having to change their VS options.

One side effect, however, is that EditorConfig might get overzealous and replace tabs with spaces in any file that is edited, so that PRs may contain spurious changes for a bit. The best fix for this would be to check in some project-wide fixup changes for formatting.