### PR TITLE
Pass AST interpolation modifiers through to codegen.

### DIFF
--- a/source/slang/modifier-defs.h
+++ b/source/slang/modifier-defs.h
@@ -258,6 +258,9 @@ END_SYNTAX_CLASS()
 // HLSL `nointerpolation` modifier
 SIMPLE_SYNTAX_CLASS(HLSLNoInterpolationModifier, InterpolationModeModifier)
 
+// HLSL `noperspective` modifier
+SIMPLE_SYNTAX_CLASS(HLSLNoPerspectiveModifier, InterpolationModeModifier)
+
 // HLSL `linear` modifier
 SIMPLE_SYNTAX_CLASS(HLSLLinearModifier, InterpolationModeModifier)
 

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -4358,6 +4358,7 @@ namespace Slang
         MODIFIER(column_major,  HLSLColumnMajorLayoutModifier);
 
         MODIFIER(nointerpolation,   HLSLNoInterpolationModifier);
+        MODIFIER(noperspective,     HLSLNoPerspectiveModifier);
         MODIFIER(linear,            HLSLLinearModifier);
         MODIFIER(sample,            HLSLSampleModifier);
         MODIFIER(centroid,          HLSLCentroidModifier);

--- a/tests/render/nointerpolation.hlsl
+++ b/tests/render/nointerpolation.hlsl
@@ -1,0 +1,77 @@
+//TEST(smoke):COMPARE_HLSL_RENDER:
+
+// Confirm that the `nointerpolation` modifier
+// makes it through Slang codegen with the
+// same effect as for HLSL.
+
+cbuffer Uniforms
+{
+	float4x4 modelViewProjection;
+}
+
+struct AssembledVertex
+{
+	float3	position;
+	float3	color;
+};
+
+struct CoarseVertex
+{
+	nointerpolation float3	color;
+};
+
+struct Fragment
+{
+	float4 color;
+};
+
+
+// Vertex  Shader
+
+struct VertexStageInput
+{
+	AssembledVertex assembledVertex	: A;
+};
+
+struct VertexStageOutput
+{
+	CoarseVertex	coarseVertex	: CoarseVertex;
+	float4			sv_position		: SV_Position;
+};
+
+VertexStageOutput vertexMain(VertexStageInput input)
+{
+	VertexStageOutput output;
+
+	float3 position = input.assembledVertex.position;
+	float3 color	= input.assembledVertex.color;
+
+	output.coarseVertex.color = color;
+	output.sv_position = mul(modelViewProjection, float4(position, 1.0));
+
+	return output;
+}
+
+// Fragment Shader
+
+struct FragmentStageInput
+{
+	CoarseVertex	coarseVertex	: CoarseVertex;
+};
+
+struct FragmentStageOutput
+{
+	Fragment fragment	: SV_Target;
+};
+
+FragmentStageOutput fragmentMain(FragmentStageInput input)
+{
+	FragmentStageOutput output;
+
+	float3 color = input.coarseVertex.color;
+
+	output.fragment.color = float4(color, 1.0);
+
+	return output;
+}
+


### PR DESCRIPTION
This is a short-term fix, because we (1) don't have an IR-level representation of interpolation qualifiers, and (2) can't introduce one until *after* the IR-level type system is introduced (to be able to handle `struct` fields).

The approach here is to find the AST-level declaration, either from layout information (in the case of an ordinary variable or function parameter), or from struct field information (because structs are being output from the AST form anyway).

I've included a single end-to-end rendering test to confirm that we handle the `nointerpolation` modifier the same as HLSL.

I also added the `noperspective` modifier, which seemed to be missing from our implementation.