### PR TITLE
Propagate diagnostics when imported module has errors

### DIFF
--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -1120,6 +1120,10 @@ SLANG_API int spCompile(
     {
         // This should only be thrown if we already emitted a fatal error
         // message, so there is no reason to print something else.
+        //
+        // We still need to copy the diagnostic output into the variable
+        // that the user will query via the API.
+        req->mDiagnosticOutput = req->mSink.outputBuffer.ProduceString();
         return 1;
     }
     catch (...)


### PR DESCRIPTION
A previous fix avoided crashes when an `import`ed module has errors by making the "failed to import" error a fatal one.
Unfortunately, the code path that handles fatal errors was failing to copy diagnostic output from the sink over to the member variable on the `CompileRequest` that exposes the output through the API.
This meant that API users lost all context on error messages in `import`ed code.

This change fixes the immediate issue by plumbing through the error output, but doesn't fix the more fundamental issue: the front-end should not crash when an `import` fails, by any means.