### PR TITLE
Fix some logic around legalization of sampler types

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -2076,7 +2076,7 @@ struct EmitVisitor
             {
                 return true;
             }
-            else if(as<IRSamplerStateType>(type))
+            else if(as<IRSamplerStateTypeBase>(type))
             {
                 return true;
             }

--- a/source/slang/legalize-types.cpp
+++ b/source/slang/legalize-types.cpp
@@ -88,7 +88,7 @@ static bool isResourceType(IRType* type)
     {
         return true;
     }
-    else if (auto samplerType = as<IRSamplerStateType>(type))
+    else if (auto samplerType = as<IRSamplerStateTypeBase>(type))
     {
         return true;
     }


### PR DESCRIPTION
The main error here was checking for `IRSamplerType` instead of `IRSamplerTypeBase`, which means the relevant logic only triggered for the `SamplerState` type and not the `SamplerComparisonState` type.

The two affected places were type legalization (so that comparison samplers in `struct` types weren't being hoisted out) and the emit logic when deciding whether to introduce local temporaries (so we were emitting temporaries for comparison samplers, leading to GLSL errors).