### PR TITLE
Better diagnostics when compilation is aborted

### DIFF
--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -455,6 +455,51 @@ namespace Slang
                 innerDeclRef);
         }
 
+        // This routine is a bottleneck for all declaration checking,
+        // so that we can add some quality-of-life features for users
+        // in cases where the compiler crashes
+        void dispatchDecl(DeclBase* decl)
+        {
+            try
+            {
+                DeclVisitor::dispatch(decl);
+            }
+            // Don't emit any context message for an explicit `AbortCompilationException`
+            // because it should only happen when an error is already emitted.
+            catch(AbortCompilationException&) { throw; }
+            catch(...)
+            {
+                getCompileRequest()->noteInternalErrorLoc(decl->loc);
+                throw;
+            }
+        }
+        void dispatchStmt(Stmt* stmt)
+        {
+            try
+            {
+                StmtVisitor::dispatch(stmt);
+            }
+            catch(AbortCompilationException&) { throw; }
+            catch(...)
+            {
+                getCompileRequest()->noteInternalErrorLoc(stmt->loc);
+                throw;
+            }
+        }
+        void dispatchExpr(Expr* expr)
+        {
+            try
+            {
+                ExprVisitor::dispatch(expr);
+            }
+            catch(AbortCompilationException&) { throw; }
+            catch(...)
+            {
+                getCompileRequest()->noteInternalErrorLoc(expr->loc);
+                throw;
+            }
+        }
+
         // Make sure a declaration has been checked, so we can refer to it.
         // Note that this may lead to us recursively invoking checking,
         // so this may not be the best way to handle things.
@@ -499,7 +544,7 @@ namespace Slang
             }
 
             // Use visitor pattern to dispatch to correct case
-            DeclVisitor::dispatch(decl);
+            dispatchDecl(decl);
 
             if(state > decl->checkState)
             {
@@ -2492,7 +2537,7 @@ namespace Slang
         {
             for (auto decl : declGroup->decls)
             {
-                DeclVisitor::dispatch(decl);
+                dispatchDecl(decl);
             }
         }
 
@@ -2549,7 +2594,7 @@ namespace Slang
         void checkStmt(Stmt* stmt)
         {
             if (!stmt) return;
-            StmtVisitor::dispatch(stmt);
+            dispatchStmt(stmt);
             checkModifiers(stmt);
         }
 
@@ -3052,7 +3097,7 @@ namespace Slang
             // 2. `EnsureDecl()` is specialized for `Decl*` instead of `DeclBase*`
             // and trying to special case `DeclGroup*` here feels silly.
             //
-            DeclVisitor::dispatch(stmt->decl);
+            dispatchDecl(stmt->decl);
         }
 
         void visitBlockStmt(BlockStmt* stmt)

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -423,6 +423,12 @@ namespace Slang
             sourceManager = sm;
             mSink.sourceManager = sm;
         }
+
+            /// During propagation of an exception for an internal
+            /// error, note that this source location was involved
+        void noteInternalErrorLoc(SourceLoc const& loc);
+
+        int internalErrorLocsNoted = 0;
     };
 
     void generateOutput(

--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -339,9 +339,10 @@ DIAGNOSTIC(51092, Error, stageDoesntHaveInputWorld, "'$0' doesn't appear to have
 
 // 99999 - Internal compiler errors, and not-yet-classified diagnostics.
 
-DIAGNOSTIC(99999, Internal, unimplemented, "unimplemented: $0")
-DIAGNOSTIC(99999, Internal, unexpected, "unexpected: $0")
-DIAGNOSTIC(99999, Internal, internalCompilerError, "internal compiler error")
-DIAGNOSTIC(99999, Error, compilationAborted, "compilation aborted due to internal error");
+DIAGNOSTIC(99999, Internal, unimplemented, "unimplemented feature in Slang compiler: $0")
+DIAGNOSTIC(99999, Internal, unexpected, "unexpected condition encountered in Slang compiler: $0")
+DIAGNOSTIC(99999, Internal, internalCompilerError, "Slang internal compiler error")
+DIAGNOSTIC(99999, Error, compilationAborted, "Slang compilation aborted due to internal error");
+DIAGNOSTIC(99999, Error, compilationAbortedDueToException, "Slang compilation aborted due to an exception of $0: $1");
 
 #undef DIAGNOSTIC

--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -344,5 +344,6 @@ DIAGNOSTIC(99999, Internal, unexpected, "unexpected condition encountered in Sla
 DIAGNOSTIC(99999, Internal, internalCompilerError, "Slang internal compiler error")
 DIAGNOSTIC(99999, Error, compilationAborted, "Slang compilation aborted due to internal error");
 DIAGNOSTIC(99999, Error, compilationAbortedDueToException, "Slang compilation aborted due to an exception of $0: $1");
+DIAGNOSTIC(99999, Note, noteLocationOfInternalError, "the Slang compiler threw an exception while working on code near this location");
 
 #undef DIAGNOSTIC

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -727,6 +727,23 @@ Decl * CompileRequest::lookupGlobalDecl(Name * name)
     return resultDecl;
 }
 
+void CompileRequest::noteInternalErrorLoc(SourceLoc const& loc)
+{
+    // Don't consider invalid source locations.
+    if(!loc.isValid())
+        return;
+
+    // If this is the first source location being noted,
+    // then emit a message to help the user isolate what
+    // code might have confused the compiler.
+    if(internalErrorLocsNoted == 0)
+    {
+        mSink.diagnose(loc, Diagnostics::noteLocationOfInternalError);
+    }
+    internalErrorLocsNoted++;
+}
+
+
 RefPtr<ModuleDecl> findOrImportModule(
     CompileRequest*     request,
     Name*               name,


### PR DESCRIPTION
These are two changes that try to improve the user experience when Slang hits an internal error. Yes, it is important to fix those errors, but for now it is important to give users as much context as possible into why a failure occurred, in case that helps them find a workaround.