### PR TITLE
Diagnose attempts to write to fields in methods

### DIFF
--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -193,6 +193,7 @@ DIAGNOSTIC(30035, Error, componentOverloadTypeMismatch, "'$0': type of overloade
 DIAGNOSTIC(30041, Error, bitOperationNonIntegral, "bit operation: operand must be integral type.")
 DIAGNOSTIC(30047, Error, argumentExpectedLValue, "argument passed to parameter '$0' must be l-value.")
 DIAGNOSTIC(30048, Note,  implicitCastUsedAsLValue, "argument was implicitly cast from '$0' to '$1', and Slang does not support using an implicit cast as an l-value")
+DIAGNOSTIC(30049, Note,  thisIsImmutableByDefault, "a 'this' parameter is currently immutable in Slang")
 
 DIAGNOSTIC(30051, Error, invalidValueForArgument, "invalid value for argument '$0'")
 DIAGNOSTIC(30052, Error, invalidSwizzleExpr, "invalid swizzle pattern '$0' on type '$1'")

--- a/tests/diagnostics/setter-method.slang
+++ b/tests/diagnostics/setter-method.slang
@@ -16,7 +16,7 @@ struct Sphere
         center = value;
     }
 
-    void setRadisu(float value)
+    void setRadius(float value)
     {
         this.radius = value;
     }

--- a/tests/diagnostics/setter-method.slang
+++ b/tests/diagnostics/setter-method.slang
@@ -1,0 +1,23 @@
+// setter-method.slang
+
+//TEST:SIMPLE:
+
+// Make sure we provide a user a diagnostic if they
+// try to declare a setter method without `mutating`
+// (even if we don't support `mutating` yet).
+
+struct Sphere
+{
+    float3 center;
+    float radius;
+
+    void setCenter(float3 value)
+    {
+        center = value;
+    }
+
+    void setRadisu(float value)
+    {
+        this.radius = value;
+    }
+};

--- a/tests/diagnostics/setter-method.slang.expected
+++ b/tests/diagnostics/setter-method.slang.expected
@@ -1,0 +1,9 @@
+result code = -1
+standard error = {
+tests/diagnostics/setter-method.slang(16): error 30011: left of '=' is not an l-value.
+tests/diagnostics/setter-method.slang(16): note 30049: a 'this' parameter is currently immutable in Slang
+tests/diagnostics/setter-method.slang(21): error 30011: left of '=' is not an l-value.
+tests/diagnostics/setter-method.slang(21): note 30049: a 'this' parameter is currently immutable in Slang
+}
+standard output = {
+}


### PR DESCRIPTION
Work on #529

This helps to avoid the case where a Slang user writes a struct with helpful `setter` methods, and finds that it doesn't work as expected because the `this` parameter is currently handled like an `in` parameter (passed by value, but mutable in the callee).

Fixing this issue actually involved making a more broad fix to how l-value-ness is propagated. The existing checking logic was assuming that l-value-ness is just a property of a particular member declaration (e.g., a field is either mutable or not), and didn't take into account whether the "base expression" was mutable. This change fixes that oversight, which might lead to additional errors being issued if we aren't correctly making things mutable when we should.

A `ThisExpr` was already immutable by default, so that part didn't actually need to change. Just propagating its immutability through was enough.

As an additional assistance to users, I have added an extra diagnostic that triggers when a "destination of assignment is not an l-value" error occurs and the left-hand-side expression seems to be based on `this` (whether implicitly or explicitly). This will ideally help users to understand that the "setter" idiom is not yet supported.