### PR TITLE
Add support for explicit register space bindings

### DIFF
--- a/source/core/slang-string.cpp
+++ b/source/core/slang-string.cpp
@@ -298,6 +298,11 @@ namespace Slang
         append(slice.begin(), slice.end());
     }
 
+    void String::append(UnownedStringSlice const& slice)
+    {
+        append(slice.begin(), slice.end());
+    }
+
     void String::append(int32_t value, int radix)
     {
         enum { kCount = 33 };

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -193,6 +193,12 @@ namespace Slang
             return (*this) == UnownedStringSlice(str, str + strlen(str));
         }
 
+        bool operator!=(UnownedStringSlice const& other) const
+        {
+            return !(*this == other);
+        }
+
+
         bool endsWith(UnownedStringSlice const& other) const;
         bool endsWith(char const* str) const;
 
@@ -328,6 +334,7 @@ namespace Slang
         void append(char chr);
         void append(String const& str);
         void append(StringSlice const& slice);
+        void append(UnownedStringSlice const& slice);
 
 		String(int32_t val, int radix = 10)
 		{

--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -253,18 +253,6 @@ DIAGNOSTIC(39999, Error, tooManyArguments, "too many arguments to call (got $0, 
 DIAGNOSTIC(39999, Error, invalidIntegerLiteralSuffix, "invalid suffix '$0' on integer literal")
 DIAGNOSTIC(39999, Error, invalidFloatingPOintLiteralSuffix, "invalid suffix '$0' on floating-point literal")
 
-DIAGNOSTIC(39999, Error, conflictingExplicitBindingsForParameter, "conflicting explicit bindings for parameter '$0'")
-DIAGNOSTIC(39999, Warning, parameterBindingsOverlap, "explicit binding for parameter '$0' overlaps with parameter '$1'")
-
-
-DIAGNOSTIC(39999, Error, shaderParameterDeclarationsDontMatch, "declarations of shader parameter '$0' in different translation units don't match")
-
-DIAGNOSTIC(39999, Note, shaderParameterTypeMismatch, "type is declared as '$0' in one translation unit, and '$0' in another")
-DIAGNOSTIC(39999, Note, fieldTypeMisMatch, "type of field '$0' is declared as '$1' in one translation unit, and '$2' in another")
-DIAGNOSTIC(39999, Note, fieldDeclarationsDontMatch, "type '$0' is declared with different fields in each translation unit")
-DIAGNOSTIC(39999, Note, usedInDeclarationOf, "used in declaration of '$0'")
-
-
 
 
 
@@ -286,6 +274,26 @@ DIAGNOSTIC(38021, Error, typeArgumentDoesNotConformToInterface, "type argument `
 
 DIAGNOSTIC(38200, Error, recursiveModuleImport, "module `$0` recursively imports itself")
 DIAGNOSTIC(39999, Fatal, errorInImportedModule, "error in imported module, compilation ceased.")
+
+// 39xxx - Type layout and parameter binding.
+
+DIAGNOSTIC(39000, Error, conflictingExplicitBindingsForParameter, "conflicting explicit bindings for parameter '$0'")
+DIAGNOSTIC(39001, Warning, parameterBindingsOverlap, "explicit binding for parameter '$0' overlaps with parameter '$1'")
+
+
+DIAGNOSTIC(39002, Error, shaderParameterDeclarationsDontMatch, "declarations of shader parameter '$0' in different translation units don't match")
+
+DIAGNOSTIC(39003, Note, shaderParameterTypeMismatch, "type is declared as '$0' in one translation unit, and '$0' in another")
+DIAGNOSTIC(39004, Note, fieldTypeMisMatch, "type of field '$0' is declared as '$1' in one translation unit, and '$2' in another")
+DIAGNOSTIC(39005, Note, fieldDeclarationsDontMatch, "type '$0' is declared with different fields in each translation unit")
+DIAGNOSTIC(39006, Note, usedInDeclarationOf, "used in declaration of '$0'")
+
+DIAGNOSTIC(39007, Error, unknownRegisterClass, "unknown register class: '$0'")
+DIAGNOSTIC(39008, Error, expectedARegisterIndex, "expected a register index after '$0'")
+DIAGNOSTIC(39009, Error, expectedSpace, "expected 'space', got '$0'")
+DIAGNOSTIC(39010, Error, expectedSpaceIndex, "expected a register space index after 'space'")
+DIAGNOSTIC(39011, Error, componentMaskNotSupported, "explicit register component masks are not yet supported in Slang")
+DIAGNOSTIC(39012, Error, packOffsetNotSupported, "explicit 'packoffset' bindings are not yet supported in Slang")
 
 //
 // 4xxxx - IL code generation.

--- a/source/slang/diagnostics.cpp
+++ b/source/slang/diagnostics.cpp
@@ -39,6 +39,12 @@ void printDiagnosticArg(StringBuilder& sb, Slang::String const& str)
     sb << str;
 }
 
+void printDiagnosticArg(StringBuilder& sb, Slang::UnownedStringSlice const& str)
+{
+    sb.append(str);
+}
+
+
 void printDiagnosticArg(StringBuilder& sb, Name* name)
 {
     sb << getText(name);

--- a/source/slang/diagnostics.h
+++ b/source/slang/diagnostics.h
@@ -77,6 +77,7 @@ namespace Slang
     void printDiagnosticArg(StringBuilder& sb, int val);
     void printDiagnosticArg(StringBuilder& sb, UInt val);
     void printDiagnosticArg(StringBuilder& sb, Slang::String const& str);
+    void printDiagnosticArg(StringBuilder& sb, Slang::UnownedStringSlice const& str);
     void printDiagnosticArg(StringBuilder& sb, Name* name);
     void printDiagnosticArg(StringBuilder& sb, Decl* decl);
     void printDiagnosticArg(StringBuilder& sb, Type* type);

--- a/source/slang/modifier-defs.h
+++ b/source/slang/modifier-defs.h
@@ -164,7 +164,9 @@ SYNTAX_CLASS(HLSLLayoutSemantic, HLSLSemantic)
 END_SYNTAX_CLASS()
 
 // An HLSL `register` semantic
-SIMPLE_SYNTAX_CLASS(HLSLRegisterSemantic, HLSLLayoutSemantic)
+SYNTAX_CLASS(HLSLRegisterSemantic, HLSLLayoutSemantic)
+    FIELD(Token, spaceName)
+END_SYNTAX_CLASS()
 
 // TODO(tfoley): `packoffset`
 SIMPLE_SYNTAX_CLASS(HLSLPackOffsetSemantic, HLSLLayoutSemantic)

--- a/tests/diagnostics/gh-38-vs.hlsl.expected
+++ b/tests/diagnostics/gh-38-vs.hlsl.expected
@@ -1,8 +1,8 @@
 result code = -1
 standard error = {
-tests/diagnostics/gh-38-fs.hlsl(7): error 39999: conflicting explicit bindings for parameter 'conflicting'
+tests/diagnostics/gh-38-fs.hlsl(7): error 39000: conflicting explicit bindings for parameter 'conflicting'
 tests/diagnostics/gh-38-vs.hlsl(7): note: see other declaration of 'conflicting'
-tests/diagnostics/gh-38-fs.hlsl(5): warning 39999: explicit binding for parameter 'overlappingB' overlaps with parameter 'overlappingA'
+tests/diagnostics/gh-38-fs.hlsl(5): warning 39001: explicit binding for parameter 'overlappingB' overlaps with parameter 'overlappingA'
 tests/diagnostics/gh-38-vs.hlsl(5): note: see declaration of 'overlappingA'
 }
 standard output = {

--- a/tests/diagnostics/packoffset.slang
+++ b/tests/diagnostics/packoffset.slang
@@ -1,0 +1,11 @@
+// packoffset.slang
+//TEST:SIMPLE:-target hlsl
+
+// use of `packoffset` (not supported):
+cbuffer B
+{
+	float4 x : packoffset(c0);
+}
+
+void main()
+{}

--- a/tests/diagnostics/packoffset.slang.expected
+++ b/tests/diagnostics/packoffset.slang.expected
@@ -1,0 +1,6 @@
+result code = -1
+standard error = {
+tests/diagnostics/packoffset.slang(7): error 39012: explicit 'packoffset' bindings are not yet supported in Slang
+}
+standard output = {
+}

--- a/tests/diagnostics/register-bindings.slang
+++ b/tests/diagnostics/register-bindings.slang
@@ -1,0 +1,22 @@
+// register-bindings.slang
+//TEST:SIMPLE:-target hlsl
+
+// Various bad forms for register bindings
+
+// Not a valid register class:
+Texture2D	a : register(DOESNT_EXIST);
+
+// No register index given:
+TextureCube b : register(t);
+
+// Unexpected name in place of `space`:
+SamplerState c : register(s0, s1);
+
+// No space index given after `space`:
+SamplerState d : register(s2, space);
+
+// use of a component mask (not supported):
+Texture2D e : register(t3.x);
+
+void main()
+{}

--- a/tests/diagnostics/register-bindings.slang.expected
+++ b/tests/diagnostics/register-bindings.slang.expected
@@ -1,0 +1,10 @@
+result code = -1
+standard error = {
+tests/diagnostics/register-bindings.slang(7): error 39007: unknown register class: 'DOESNT_EXIST'
+tests/diagnostics/register-bindings.slang(10): error 39008: expected a register index after 't'
+tests/diagnostics/register-bindings.slang(13): error 39009: expected 'space', got 's'
+tests/diagnostics/register-bindings.slang(16): error 39010: expected a register space index after 'space'
+tests/diagnostics/register-bindings.slang(19): error 39011: explicit register component masks are not yet supported in Slang
+}
+standard output = {
+}

--- a/tests/hlsl/dxsdk/AdaptiveTessellationCS40/Render.hlsl
+++ b/tests/hlsl/dxsdk/AdaptiveTessellationCS40/Render.hlsl
@@ -15,7 +15,7 @@
 //--------------------------------------------------------------------------------------
 cbuffer cbPerObject : register( b0 )
 {
-    row_major matrix    g_mWorldViewProjection    : packoffset( c0 );
+    row_major matrix    g_mWorldViewProjection    ;//SLANG: : packoffset( c0 );
 }
 
 // The tessellated vertex structure

--- a/tests/hlsl/dxsdk/BasicHLSL11/BasicHLSL11_PS.hlsl
+++ b/tests/hlsl/dxsdk/BasicHLSL11/BasicHLSL11_PS.hlsl
@@ -21,13 +21,13 @@
 //--------------------------------------------------------------------------------------
 cbuffer cbPerObject : register( b0 )
 {
-	float4		g_vObjectColor			: packoffset( c0 );
+	float4		g_vObjectColor			;//SLANG: : packoffset( c0 );
 };
 
 cbuffer cbPerFrame : register( b1 )
 {
-	float3		g_vLightDir				: packoffset( c0 );
-	float		g_fAmbient				: packoffset( c0.w );
+	float3		g_vLightDir				;//SLANG: : packoffset( c0 );
+	float		g_fAmbient				;//SLANG: : packoffset( c0.w );
 };
 
 //--------------------------------------------------------------------------------------

--- a/tests/hlsl/dxsdk/BasicHLSL11/BasicHLSL11_VS.hlsl
+++ b/tests/hlsl/dxsdk/BasicHLSL11/BasicHLSL11_VS.hlsl
@@ -19,8 +19,8 @@
 //--------------------------------------------------------------------------------------
 cbuffer cbPerObject : register( b0 )
 {
-	matrix		g_mWorldViewProjection	: packoffset( c0 );
-	matrix		g_mWorld				: packoffset( c4 );
+	matrix		g_mWorldViewProjection	;//SLANG: : packoffset( c0 );
+	matrix		g_mWorld				;//SLANG: : packoffset( c4 );
 };
 
 //--------------------------------------------------------------------------------------

--- a/tests/hlsl/dxsdk/CascadedShadowMaps11/RenderCascadeShadow.hlsl
+++ b/tests/hlsl/dxsdk/CascadedShadowMaps11/RenderCascadeShadow.hlsl
@@ -19,7 +19,7 @@
 //--------------------------------------------------------------------------------------
 cbuffer cbPerObject : register( b0 )
 {
-    matrix        g_mWorldViewProjection    : packoffset( c0 );
+    matrix        g_mWorldViewProjection    ;//SLANG: : packoffset( c0 );
 };
 
 //--------------------------------------------------------------------------------------

--- a/tests/hlsl/dxsdk/DynamicShaderLinkage11/DynamicShaderLinkage11_VS.hlsl
+++ b/tests/hlsl/dxsdk/DynamicShaderLinkage11/DynamicShaderLinkage11_VS.hlsl
@@ -19,8 +19,8 @@
 //--------------------------------------------------------------------------------------
 cbuffer cbPerObject : register( b0 )
 {
-	float4x4		g_mWorldViewProjection	: packoffset( c0 );
-	float4x4		g_mWorld				: packoffset( c4 );
+	float4x4		g_mWorldViewProjection	;//SLANG: : packoffset( c0 );
+	float4x4		g_mWorld				;//SLANG: : packoffset( c4 );
 };
 
 //--------------------------------------------------------------------------------------

--- a/tests/hlsl/dxsdk/MultithreadedRendering11/MultithreadedRendering11_VS.hlsl
+++ b/tests/hlsl/dxsdk/MultithreadedRendering11/MultithreadedRendering11_VS.hlsl
@@ -23,11 +23,11 @@
 //--------------------------------------------------------------------------------------
 cbuffer cbPerObject : register( b0 )
 {
-	matrix		g_mWorld	: packoffset( c0 );
+	matrix		g_mWorld	;//SLANG: : packoffset( c0 );
 };
 cbuffer cbPerScene : register( b1 )
 {
-	matrix		g_mViewProj	: packoffset( c0 );
+	matrix		g_mViewProj	;//SLANG: : packoffset( c0 );
 };
 
 //--------------------------------------------------------------------------------------

--- a/tests/hlsl/dxsdk/OIT11/SceneVS.hlsl
+++ b/tests/hlsl/dxsdk/OIT11/SceneVS.hlsl
@@ -16,7 +16,7 @@
 
 cbuffer cbPerObject : register( b0 )
 {
-    row_major matrix    g_mWorldViewProjection	: packoffset( c0 );
+    row_major matrix    g_mWorldViewProjection	;//SLANG: : packoffset( c0 );
 }
 
 struct SceneVS_Input

--- a/tests/hlsl/dxsdk/VarianceShadows11/RenderVarianceShadow.hlsl
+++ b/tests/hlsl/dxsdk/VarianceShadows11/RenderVarianceShadow.hlsl
@@ -10,7 +10,7 @@
 //--------------------------------------------------------------------------------------
 cbuffer cbPerObject : register( b0 )
 {
-	matrix		g_mWorldViewProjection	: packoffset( c0 );
+	matrix		g_mWorldViewProjection	;//SLANG: : packoffset( c0 );
 };
 
 //--------------------------------------------------------------------------------------

--- a/tests/reflection/explicit-register-space.slang
+++ b/tests/reflection/explicit-register-space.slang
@@ -1,0 +1,12 @@
+// explicit-register-space.slang
+//TEST:REFLECTION:-profile ps_5_1 -target hlsl
+
+// Confirm that we handle explicit register spaces
+// on global shader parameters.
+
+Texture2D tx : register(t1, space2);
+
+float4 main() : SV_Target
+{
+	return 0.0;
+}

--- a/tests/reflection/explicit-register-space.slang.expected
+++ b/tests/reflection/explicit-register-space.slang.expected
@@ -1,0 +1,17 @@
+result code = 0
+standard error = {
+}
+standard output = {
+{
+    "parameters": [
+        {
+            "name": "tx",
+            "binding": {"kind": "shaderResource", "space": 2, "index": 1},
+            "type": {
+                "kind": "resource",
+                "baseShape": "texture2D"
+            }
+        }
+    ]
+}
+}


### PR DESCRIPTION
This change adds support for specifying explicit register spaces, like:

```hlsl
// Bind to texture register #2 in space #1
Texture2D t : register(t2, space1);
```

I added a test case to confirm that the register space is properly propagated through the Slang reflection API.

This change also adds proper error messages for some error/unsupported cases that weren't being diagnosed:

* Specifying a completely bogus register "class" (e.g., `register(bad99)`)
* Failing to specify a register index (`register(u)`)
* Specifying a component mask (`register(t0.x)`)
* Using `packoffset` bindings

I added test cases to cover all of these, as well as the new errors around support for register `space` bindings.

In order to get the existing tests to pass, I had to remove explicit `packoffset` bindings from some DXSDK test shaders.
None of these `packoffset` bindings were semantically significant (they matched what the compiler would do anyway, for both Slang and the standard HLSL compiler). Removing them is required for Slang now that we give an explicit error about our lack of `packoffset` support.
In a future change we might add logic to either detect semantically insignificant `packoffset`s, or to just go ahead and support them properly (as a general feature on `struct` types).