### PR TITLE
Speedup type checking using cached overload resolution results.

### DIFF
--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -445,6 +445,7 @@ namespace Slang
         char const*     text,
         CodeGenTarget   target);
 
+    struct TypeCheckingCache;
     //
 
     class Session
@@ -535,6 +536,10 @@ namespace Slang
 
         Dictionary<Name*, SyntaxClass<RefObject> > mapNameToSyntaxClass;
 
+        // cache used by type checking, implemented in check.cpp
+        TypeCheckingCache* typeCheckingCache = nullptr;
+        TypeCheckingCache* getTypeCheckingCache();
+        void destroyTypeCheckingCache();
         //
 
         Session();

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -823,6 +823,8 @@ Session::~Session()
     irBasicBlockType = nullptr;
     constExprRate = nullptr;
 
+    destroyTypeCheckingCache();
+    
     builtinTypes = decltype(builtinTypes)();
     // destroy modules next
     loadedModuleCode = decltype(loadedModuleCode)();

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -77,6 +77,9 @@ namespace Slang
         // a vector (this will be added to the cost, if any, of converting
         // the element type of the vector)
         kConversionCost_ScalarToVector = 1,
+
+        // Conversion is impossible
+        kConversionCost_Impossible = 0xFFFFFFFF,
     };
 
     // TODO(tfoley): We should ditch this enumeration


### PR DESCRIPTION
This change adds caches to built-in operator overload resolution and type coersion to avoid running these time-consuming operations every time.

- Adds `TypeCheckingCache` type, which is defined in check.cpp, that contains two dictionaries for the cached results of `ResolveInvoke` and `CanCoerce` calls.
- Add `destroyTypeCheckingCache` and `getTypeCheckingCache` methods to `Session` class to reuse these cached results over the entire session.

Addressing #538.