### PR TITLE
Add support for "swizzled stores"

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -3317,6 +3317,31 @@ struct EmitVisitor
                 emit(";\n");
             }
             break;
+
+        case kIROp_SwizzledStore:
+            {
+                auto ii = cast<IRSwizzledStore>(inst);
+                emit("(");
+                emitIROperand(ctx, ii->getDest(), mode);
+                emit(").");
+                UInt elementCount = ii->getElementCount();
+                for (UInt ee = 0; ee < elementCount; ++ee)
+                {
+                    IRInst* irElementIndex = ii->getElementIndex(ee);
+                    assert(irElementIndex->op == kIROp_IntLit);
+                    IRConstant* irConst = (IRConstant*)irElementIndex;
+
+                    UInt elementIndex = (UInt)irConst->u.intVal;
+                    assert(elementIndex < 4);
+
+                    char const* kComponents[] = { "x", "y", "z", "w" };
+                    emit(kComponents[elementIndex]);
+                }
+                emit(" = ");
+                emitIROperand(ctx, ii->getSource(), mode);
+                emit(";\n");
+            }
+            break;
         }
     }
 

--- a/source/slang/ir-inst-defs.h
+++ b/source/slang/ir-inst-defs.h
@@ -265,6 +265,25 @@ INST(swizzle, swizzle, 1, 0)
 //
 INST(swizzleSet, swizzleSet, 2, 0)
 
+// Store to memory with a swizzle
+//
+// TODO: eventually this should be reduced to just
+// a write mask by moving the actual swizzle to the RHS.
+//
+// swizzleStore %dst %src %idx0 %idx1 ...
+//
+// where:
+// - `dst` is a vector<T,N>
+// - `src` is a vector<T,M>
+// - `idx0` through `idx[M-1]` are literal integers
+//
+// The semantics of the op is:
+//
+//     for(ii : 0 ... M-1 )
+//         dst[ii] = src[idx[ii]];
+//
+INST(SwizzledStore, swizzledStore, 2, 0)
+
 
 /* IRTerminatorInst */
 

--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -322,7 +322,7 @@ struct IRSwitch : IRTerminatorInst
     IRBlock* getCaseLabel(UInt index) { return (IRBlock*) getOperand(3 + index*2 + 1); }
 };
 
-struct IRSwizzle : IRReturn
+struct IRSwizzle : IRInst
 {
     IRUse base;
 
@@ -337,7 +337,7 @@ struct IRSwizzle : IRReturn
     }
 };
 
-struct IRSwizzleSet : IRReturn
+struct IRSwizzleSet : IRInst
 {
     IRUse base;
     IRUse source;
@@ -352,6 +352,22 @@ struct IRSwizzleSet : IRReturn
     {
         return getOperand(index + 2);
     }
+};
+
+struct IRSwizzledStore : IRInst
+{
+    IRInst* getDest() { return getOperand(0); }
+    IRInst* getSource() { return getOperand(1); }
+    UInt getElementCount()
+    {
+        return getOperandCount() - 2;
+    }
+    IRInst* getElementIndex(UInt index)
+    {
+        return getOperand(index + 2);
+    }
+
+    IR_LEAF_ISA(SwizzledStore)
 };
 
 // An IR `var` instruction conceptually represents
@@ -721,6 +737,20 @@ struct IRBuilder
         IRInst*        source,
         UInt            elementCount,
         UInt const*     elementIndices);
+
+    IRInst* emitSwizzledStore(
+        IRInst*         dest,
+        IRInst*         source,
+        UInt            elementCount,
+        IRInst* const*  elementIndices);
+
+    IRInst* emitSwizzledStore(
+        IRInst*         dest,
+        IRInst*         source,
+        UInt            elementCount,
+        UInt const*     elementIndices);
+
+
 
     IRInst* emitReturn(
         IRInst*    val);

--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -2033,6 +2033,45 @@ namespace Slang
         return emitSwizzleSet(type, base, source, elementCount, irElementIndices);
     }
 
+    IRInst* IRBuilder::emitSwizzledStore(
+        IRInst*         dest,
+        IRInst*         source,
+        UInt            elementCount,
+        IRInst* const*  elementIndices)
+    {
+        IRInst* fixedArgs[] = { dest, source };
+        UInt fixedArgCount = sizeof(fixedArgs) / sizeof(fixedArgs[0]);
+
+        auto inst = createInstImpl<IRSwizzledStore>(
+            this,
+            kIROp_SwizzledStore,
+            nullptr,
+            fixedArgCount,
+            fixedArgs,
+            elementCount,
+            elementIndices);
+
+        addInst(inst);
+        return inst;
+    }
+
+    IRInst* IRBuilder::emitSwizzledStore(
+        IRInst*         dest,
+        IRInst*         source,
+        UInt            elementCount,
+        UInt const*     elementIndices)
+    {
+        auto intType = getBasicType(BaseType::Int);
+
+        IRInst* irElementIndices[4];
+        for (UInt ii = 0; ii < elementCount; ++ii)
+        {
+            irElementIndices[ii] = getIntValue(intType, elementIndices[ii]);
+        }
+
+        return emitSwizzledStore(dest, source, elementCount, irElementIndices);
+    }
+
     IRInst* IRBuilder::emitReturn(
         IRInst*    val)
     {


### PR DESCRIPTION
This was a known issue in our IR representation, which was now biting a user. The basic problem is that in code like the following:

```hlsl
RWStructureBuffer<float4> buffer;
...
buffer[index].xz = value;
```

we ideally want to be able to reproduce the original HLSL code exactly, but that requires directly encoding the way that this code writes to two elements of a vector, but not the others.

The currently lowering strategy we had produced IR something like:

```hlsl
float4 tmp = buffer[index];
tmp.xz = value;
buffer[index] = tmp;
```

That transformation might seem valid, but it has some big problems:

* It generates UAV reads that are not needed, which could impact performance
* It performs read-modify-write operations on memory that the programmer didn't explicitly write, which could create data races

The fix here is somewhat obvious: if the "base" of a swizzle operation on a left-hand side resolves to a pointer in our IR, then we can output a "swizzled store" instead of the read-modify-write dance. We currently keep the read-modify-write around since it is potentially needed as a fallback in the general case.

Along the way I also tried to make sure that we handle the case where we have a swizzle of a swizzle on the left-hand side:

```hlsl
buffer[index].xz.y = value;
```

That code should behave the same as `buffer[index].z = value`. I am currently detecting and cleaning up this logic in the lowering path for `SwizzleExpr`, because that is the only place in the lowering logic that "swizzled l-values" currently get created.