### PR TITLE
Feature/vulkan first render

### DIFF
--- a/tools/render-test/d3d-util.cpp
+++ b/tools/render-test/d3d-util.cpp
@@ -26,6 +26,7 @@ using namespace Slang;
 {
     switch (format)
     {
+        case Format::RGBA_Float32:          return DXGI_FORMAT_R32G32B32A32_FLOAT;
         case Format::RGB_Float32:           return DXGI_FORMAT_R32G32B32_FLOAT;
         case Format::RG_Float32:            return DXGI_FORMAT_R32G32_FLOAT;
         case Format::R_Float32:             return DXGI_FORMAT_R32_FLOAT;

--- a/tools/render-test/d3d-util.cpp
+++ b/tools/render-test/d3d-util.cpp
@@ -31,6 +31,10 @@ using namespace Slang;
         case Format::RG_Float32:            return DXGI_FORMAT_R32G32_FLOAT;
         case Format::R_Float32:             return DXGI_FORMAT_R32_FLOAT;
         case Format::RGBA_Unorm_UInt8:      return DXGI_FORMAT_R8G8B8A8_UNORM;
+
+        case Format::D_Float32:             return DXGI_FORMAT_D32_FLOAT;
+        case Format::D_Unorm24_S8:          return DXGI_FORMAT_D24_UNORM_S8_UINT;
+
         default:                            return DXGI_FORMAT_UNKNOWN;
     }
 }

--- a/tools/render-test/main.cpp
+++ b/tools/render-test/main.cpp
@@ -177,7 +177,7 @@ Result RenderTestApp::initializeShaders(ShaderCompiler* shaderCompiler)
 
 	ShaderCompileRequest compileRequest;
 	compileRequest.source = sourceInfo;
-	if (gOptions.shaderType == ShaderProgramType::Graphics || gOptions.shaderType == ShaderProgramType::GraphicsCompute)
+	if (gOptions.shaderType == Options::ShaderProgramType::Graphics || gOptions.shaderType == Options::ShaderProgramType::GraphicsCompute)
 	{
 		compileRequest.vertexShader.source = sourceInfo;
 		compileRequest.vertexShader.name = vertexEntryPointName;
@@ -391,25 +391,25 @@ SlangResult innerMain(int argc, char** argv)
 	SlangCompileTarget slangTarget = SLANG_TARGET_NONE;
 	switch (gOptions.rendererID)
 	{
-		case RendererID::D3D11:
+		case Options::RendererID::D3D11:
 			renderer = createD3D11Renderer();
 			slangTarget = SLANG_HLSL;
 			nativeLanguage = SLANG_SOURCE_LANGUAGE_HLSL;
 			break;
 
-		case RendererID::D3D12:
+		case Options::RendererID::D3D12:
 			renderer = createD3D12Renderer();
 			slangTarget = SLANG_HLSL;
 			nativeLanguage = SLANG_SOURCE_LANGUAGE_HLSL;
 			break;
 
-		case RendererID::GL:
+		case Options::RendererID::GL:
 			renderer = createGLRenderer();
 			slangTarget = SLANG_GLSL;
 			nativeLanguage = SLANG_SOURCE_LANGUAGE_GLSL;
 			break;
 
-		case RendererID::VK:
+		case Options::RendererID::VK:
 			renderer = createVKRenderer();
 			slangTarget = SLANG_SPIRV;
 			nativeLanguage = SLANG_SOURCE_LANGUAGE_GLSL;
@@ -425,11 +425,11 @@ SlangResult innerMain(int argc, char** argv)
 	auto shaderCompiler = renderer->getShaderCompiler();
 	switch (gOptions.inputLanguageID)
 	{
-		case InputLanguageID::Slang:
+		case Options::InputLanguageID::Slang:
 			shaderCompiler = createSlangShaderCompiler(shaderCompiler, SLANG_SOURCE_LANGUAGE_SLANG, slangTarget);
 			break;
 
-		case InputLanguageID::NativeRewrite:
+		case Options::InputLanguageID::NativeRewrite:
 			shaderCompiler = createSlangShaderCompiler(shaderCompiler, nativeLanguage, slangTarget);
 			break;
 
@@ -464,7 +464,7 @@ SlangResult innerMain(int argc, char** argv)
 			else
 			{
 				// Whenever we don't have Windows events to process, we render a frame.
-				if (gOptions.shaderType == ShaderProgramType::Compute)
+				if (gOptions.shaderType == Options::ShaderProgramType::Compute)
 				{
 					app.runCompute();
 				}
@@ -484,7 +484,7 @@ SlangResult innerMain(int argc, char** argv)
                     // Wait until everything is complete
                     renderer->waitForGpu();
 
-					if (gOptions.shaderType == ShaderProgramType::Compute || gOptions.shaderType == ShaderProgramType::GraphicsCompute)
+					if (gOptions.shaderType == Options::ShaderProgramType::Compute || gOptions.shaderType == Options::ShaderProgramType::GraphicsCompute)
                     {
                         SLANG_RETURN_ON_FAIL(app.writeBindingOutput(gOptions.outputPath));
                     }

--- a/tools/render-test/main.cpp
+++ b/tools/render-test/main.cpp
@@ -222,13 +222,9 @@ void RenderTestApp::renderFrame()
     auto mappedData = m_renderer->map(m_constantBuffer, MapFlavor::WriteDiscard);
     if(mappedData)
     {
-        static const float kIdentity[] =
-        { 1, 0, 0, 0,
-          0, 1, 0, 0,
-          0, 0, 1, 0,
-          0, 0, 0, 1 };
-        memcpy(mappedData, kIdentity, sizeof(kIdentity));
-
+        const ProjectionStyle projectionStyle = RendererUtil::getProjectionStyle(m_renderer->getRendererType());
+        RendererUtil::getIdentityProjection(projectionStyle, (float*)mappedData);
+        
 		m_renderer->unmap(m_constantBuffer);
     }
 
@@ -403,27 +399,27 @@ SlangResult innerMain(int argc, char** argv)
 
 	SlangSourceLanguage nativeLanguage = SLANG_SOURCE_LANGUAGE_UNKNOWN;
 	SlangCompileTarget slangTarget = SLANG_TARGET_NONE;
-	switch (gOptions.rendererID)
+	switch (gOptions.rendererType)
 	{
-		case Options::RendererID::D3D11:
+		case RendererType::DirectX11:
 			renderer = createD3D11Renderer();
 			slangTarget = SLANG_HLSL;
 			nativeLanguage = SLANG_SOURCE_LANGUAGE_HLSL;
 			break;
 
-		case Options::RendererID::D3D12:
+		case RendererType::DirectX12:
 			renderer = createD3D12Renderer();
 			slangTarget = SLANG_HLSL;
 			nativeLanguage = SLANG_SOURCE_LANGUAGE_HLSL;
 			break;
 
-		case Options::RendererID::GL:
+		case RendererType::OpenGl:
 			renderer = createGLRenderer();
 			slangTarget = SLANG_GLSL;
 			nativeLanguage = SLANG_SOURCE_LANGUAGE_GLSL;
 			break;
 
-		case Options::RendererID::VK:
+		case RendererType::Vulkan:
 			renderer = createVKRenderer();
 			slangTarget = SLANG_SPIRV;
 			nativeLanguage = SLANG_SOURCE_LANGUAGE_GLSL;

--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -11,14 +11,13 @@ namespace renderer_test {
 Options gOptions;
 
 // Only set it, if the 
-void setDefaultRendererID(Options::RendererID id)
+void setDefaultRendererType(RendererType type)
 {
-    gOptions.rendererID = (gOptions.rendererID == Options::RendererID::NONE) ? id : gOptions.rendererID;
+    gOptions.rendererType = (gOptions.rendererType == RendererType::Unknown) ? type : gOptions.rendererType;
 }
 
 SlangResult parseOptions(int* argc, char** argv)
 {
-    typedef Options::RendererID RendererID;
     typedef Options::ShaderProgramType ShaderProgramType;
     typedef Options::InputLanguageID InputLanguageID;
 
@@ -65,32 +64,32 @@ SlangResult parseOptions(int* argc, char** argv)
         }
         else if( strcmp(arg, "-hlsl") == 0 )
         {
-            setDefaultRendererID( RendererID::D3D11);
+            setDefaultRendererType( RendererType::DirectX11);
             gOptions.inputLanguageID = InputLanguageID::Native;
         }
         else if( strcmp(arg, "-glsl") == 0 )
         {
-            setDefaultRendererID(RendererID::GL);
+            setDefaultRendererType( RendererType::OpenGl);
             gOptions.inputLanguageID = InputLanguageID::Native;
         }
         else if( strcmp(arg, "-hlsl-rewrite") == 0 )
         {
-            setDefaultRendererID(RendererID::D3D11);
+            setDefaultRendererType( RendererType::DirectX11);
             gOptions.inputLanguageID = InputLanguageID::NativeRewrite;
         }
         else if( strcmp(arg, "-glsl-rewrite") == 0 )
         {
-            setDefaultRendererID(RendererID::GL);
+            setDefaultRendererType(RendererType::OpenGl);
             gOptions.inputLanguageID = InputLanguageID::NativeRewrite;
         }
         else if( strcmp(arg, "-slang") == 0 )
         {
-            setDefaultRendererID(RendererID::D3D11);
+            setDefaultRendererType( RendererType::DirectX11);
             gOptions.inputLanguageID = InputLanguageID::Slang;
         }
         else if( strcmp(arg, "-glsl-cross") == 0 )
         {
-            setDefaultRendererID(RendererID::GL);
+            setDefaultRendererType(RendererType::OpenGl);
             gOptions.inputLanguageID = InputLanguageID::Slang;
         }
         else if( strcmp(arg, "-xslang") == 0 )
@@ -124,21 +123,21 @@ SlangResult parseOptions(int* argc, char** argv)
         else if (strcmp(arg, "-vk") == 0
             || strcmp(arg, "-vulkan") == 0)
         {
-            gOptions.rendererID = RendererID::VK;
+            gOptions.rendererType = RendererType::Vulkan;
         }
         else if (strcmp(arg, "-d3d12") == 0
             || strcmp(arg, "-dx12") == 0)
         {
-            gOptions.rendererID = RendererID::D3D12;
+            gOptions.rendererType = RendererType::DirectX12;
         }
         else if(strcmp(arg, "-gl") == 0)
         {
-            gOptions.rendererID = RendererID::GL;
+            gOptions.rendererType = RendererType::OpenGl;
         }
         else if (strcmp(arg, "-d3d11") == 0 
             || strcmp(arg, "-dx11") == 0)
         {
-            gOptions.rendererID = RendererID::D3D11;
+            gOptions.rendererType = RendererType::DirectX11;
         }
         else
         {

--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -11,13 +11,18 @@ namespace renderer_test {
 Options gOptions;
 
 // Only set it, if the 
-void setDefaultRendererID(RendererID id)
+void setDefaultRendererID(Options::RendererID id)
 {
-    gOptions.rendererID = (gOptions.rendererID == RendererID::NONE) ? id : gOptions.rendererID;
+    gOptions.rendererID = (gOptions.rendererID == Options::RendererID::NONE) ? id : gOptions.rendererID;
 }
 
 SlangResult parseOptions(int* argc, char** argv)
 {
+    typedef Options::RendererID RendererID;
+    typedef Options::ShaderProgramType ShaderProgramType;
+    typedef Options::InputLanguageID InputLanguageID;
+
+
     int argCount = *argc;
     char const* const* argCursor = argv;
     char const* const* argEnd = argCursor + argCount;
@@ -97,9 +102,9 @@ SlangResult parseOptions(int* argc, char** argv)
                 fprintf(stderr, "expected argument for '%s' option\n", arg);
                 return SLANG_FAIL;
             }
-            if( gOptions.slangArgCount == kMaxSlangArgs )
+            if( gOptions.slangArgCount == Options::kMaxSlangArgs )
             {
-                fprintf(stderr, "maximum number of '%s' options exceeded (%d)\n", arg, kMaxSlangArgs);
+                fprintf(stderr, "maximum number of '%s' options exceeded (%d)\n", arg, Options::kMaxSlangArgs);
                 return SLANG_FAIL;
             }
             gOptions.slangArgs[gOptions.slangArgCount++] = *argCursor++;

--- a/tools/render-test/options.h
+++ b/tools/render-test/options.h
@@ -5,10 +5,9 @@
 
 #include "../../source/core/slang-result.h"
 
-namespace renderer_test {
+#include "render.h"
 
-typedef intptr_t Int;
-typedef uintptr_t UInt;
+namespace renderer_test {
 
 struct Options
 {
@@ -29,14 +28,7 @@ struct Options
         // Raw HLSL or GLSL input, passed through the Slang rewriter
         NativeRewrite
     };
-    enum class RendererID
-    {
-        NONE,
-        D3D11,
-        D3D12,
-        GL,
-        VK,
-    };
+   
 
     enum class ShaderProgramType
     {
@@ -50,7 +42,7 @@ struct Options
     char const* outputPath = nullptr;
 	ShaderProgramType shaderType = ShaderProgramType::Graphics;
 
-    RendererID rendererID = RendererID::NONE;
+    RendererType rendererType = RendererType::Unknown;
     InputLanguageID inputLanguageID = InputLanguageID::Slang;
 
     char const* slangArgs[kMaxSlangArgs];

--- a/tools/render-test/options.h
+++ b/tools/render-test/options.h
@@ -10,42 +10,41 @@ namespace renderer_test {
 typedef intptr_t Int;
 typedef uintptr_t UInt;
 
-enum class RendererID
-{
-    NONE,          
-    D3D11,
-    D3D12,
-    GL,
-    VK,
-};
-
-enum class InputLanguageID
-{
-    // Slang being used as an HLSL-ish compiler
-    Slang,
-
-    // Raw HLSL or GLSL input, bypassing Slang
-    Native,
-
-    // Raw HLSL or GLSL input, passed through the Slang rewriter
-    NativeRewrite
-};
-
-enum
-{
-    // maximum number of command-line arguments to pass along to slang
-    kMaxSlangArgs = 16,
-};
-
-enum class ShaderProgramType
-{
-	Graphics,
-	Compute,
-    GraphicsCompute
-};
-
 struct Options
 {
+    enum
+    {
+        // maximum number of command-line arguments to pass along to slang
+        kMaxSlangArgs = 16,
+    };
+
+    enum class InputLanguageID
+    {
+        // Slang being used as an HLSL-ish compiler
+        Slang,
+
+        // Raw HLSL or GLSL input, bypassing Slang
+        Native,
+
+        // Raw HLSL or GLSL input, passed through the Slang rewriter
+        NativeRewrite
+    };
+    enum class RendererID
+    {
+        NONE,
+        D3D11,
+        D3D12,
+        GL,
+        VK,
+    };
+
+    enum class ShaderProgramType
+    {
+        Graphics,
+        Compute,
+        GraphicsCompute
+    };
+
     char const* appName = "render-test";
     char const* sourcePath = nullptr;
     char const* outputPath = nullptr;

--- a/tools/render-test/render-d3d11.cpp
+++ b/tools/render-test/render-d3d11.cpp
@@ -68,6 +68,7 @@ public:
     virtual void dispatchCompute(int x, int y, int z) override;
     virtual void submitGpuWork() override {}
     virtual void waitForGpu() override {}
+    virtual RendererType getRendererType() const override { return RendererType::DirectX11; }
 
     // ShaderCompiler implementation
     virtual ShaderProgram* compileProgram(ShaderCompileRequest const& request) override;

--- a/tools/render-test/render-d3d11.cpp
+++ b/tools/render-test/render-d3d11.cpp
@@ -669,6 +669,9 @@ InputLayout* D3D11Renderer::createInputLayout(const InputElementDesc* inputEleme
         char const* typeName = "Unknown";
         switch (inputElementsIn[ii].format)
         {
+            case Format::RGBA_Float32:  
+                typeName = "float4";
+                break;
             case Format::RGB_Float32:
                 typeName = "float3";
                 break;

--- a/tools/render-test/render-d3d12.cpp
+++ b/tools/render-test/render-d3d12.cpp
@@ -77,6 +77,7 @@ public:
     virtual void dispatchCompute(int x, int y, int z) override;
     virtual void submitGpuWork() override;
     virtual void waitForGpu() override;
+    virtual RendererType getRendererType() const override { return RendererType::DirectX12; }
 
     // ShaderCompiler implementation
     virtual ShaderProgram* compileProgram(const ShaderCompileRequest& request) override;

--- a/tools/render-test/render-gl.cpp
+++ b/tools/render-test/render-gl.cpp
@@ -99,6 +99,7 @@ public:
     virtual void dispatchCompute(int x, int y, int z) override;
     virtual void submitGpuWork() override {}
     virtual void waitForGpu() override {}
+    virtual RendererType getRendererType() const override { return RendererType::OpenGl; }
 
     // ShaderCompiler implementation
     virtual ShaderProgram* compileProgram(const ShaderCompileRequest& request) override;

--- a/tools/render-test/render-gl.cpp
+++ b/tools/render-test/render-gl.cpp
@@ -95,7 +95,6 @@ public:
     virtual void setBindingState(BindingState* state);
     virtual void setVertexBuffers(UInt startSlot, UInt slotCount, BufferResource*const* buffers, const UInt* strides, const UInt* offsets) override;
     virtual void setShaderProgram(ShaderProgram* inProgram) override;
-    virtual void setConstantBuffers(UInt startSlot, UInt slotCount, BufferResource*const* buffers, const UInt* offsets) override;
     virtual void draw(UInt vertexCount, UInt startVertex) override;
     virtual void dispatchCompute(int x, int y, int z) override;
     virtual void submitGpuWork() override {}
@@ -280,7 +279,7 @@ public:
     MAP_GL_EXTENSION_FUNCS(DECLARE_GL_EXTENSION_FUNC)
 #undef DECLARE_GL_EXTENSION_FUNC
 
-        static const GlPixelFormatInfo s_pixelFormatInfos[int(GlPixelFormat::CountOf)];
+    static const GlPixelFormatInfo s_pixelFormatInfos[int(GlPixelFormat::CountOf)];
 };
 
 /* static */GLRenderer::GlPixelFormat GLRenderer::_getGlPixelFormat(Format format)
@@ -894,11 +893,6 @@ void GLRenderer::setShaderProgram(ShaderProgram* programIn)
 	m_boundShaderProgram = program;
     GLuint programID = program ? program->m_id : 0;
 	glUseProgram(programID);
-}
-
-void GLRenderer::setConstantBuffers(UInt startSlot, UInt slotCount, BufferResource*const* buffers, const UInt* offsets) 
-{
-    bindBufferImpl(GL_UNIFORM_BUFFER, startSlot, slotCount, buffers, offsets);
 }
 
 void GLRenderer::draw(UInt vertexCount, UInt startVertex = 0) 

--- a/tools/render-test/render-gl.cpp
+++ b/tools/render-test/render-gl.cpp
@@ -333,6 +333,7 @@ void GLRenderer::debugCallback(GLenum source, GLenum type, GLuint id, GLenum sev
 #define CASE(NAME, COUNT, TYPE, NORMALIZED) \
         case Format::NAME: do { VertexAttributeFormat result = {COUNT, TYPE, NORMALIZED}; return result; } while (0)
 
+        CASE(RGBA_Float32, 4, GL_FLOAT, GL_FALSE);
         CASE(RGB_Float32, 3, GL_FLOAT, GL_FALSE);
         CASE(RG_Float32, 2, GL_FLOAT, GL_FALSE);
         CASE(R_Float32, 1, GL_FLOAT, GL_FALSE);

--- a/tools/render-test/render-test.vcxproj
+++ b/tools/render-test/render-test.vcxproj
@@ -184,6 +184,7 @@
     <ClCompile Include="vk-device-queue.cpp" />
     <ClCompile Include="vk-module.cpp" />
     <ClCompile Include="vk-swap-chain.cpp" />
+    <ClCompile Include="vk-util.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="circular-resource-heap-d3d12.h" />
@@ -203,6 +204,7 @@
     <ClInclude Include="vk-device-queue.h" />
     <ClInclude Include="vk-module.h" />
     <ClInclude Include="vk-swap-chain.h" />
+    <ClInclude Include="vk-util.h" />
     <ClInclude Include="window.h" />
   </ItemGroup>
   <ItemGroup>

--- a/tools/render-test/render-test.vcxproj
+++ b/tools/render-test/render-test.vcxproj
@@ -180,6 +180,8 @@
     <ClCompile Include="shader-input-layout.cpp" />
     <ClCompile Include="shader-renderer-util.cpp" />
     <ClCompile Include="slang-support.cpp" />
+    <ClCompile Include="vk-api.cpp" />
+    <ClCompile Include="vk-module.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="circular-resource-heap-d3d12.h" />
@@ -195,6 +197,8 @@
     <ClInclude Include="shader-input-layout.h" />
     <ClInclude Include="shader-renderer-util.h" />
     <ClInclude Include="slang-support.h" />
+    <ClInclude Include="vk-api.h" />
+    <ClInclude Include="vk-module.h" />
     <ClInclude Include="window.h" />
   </ItemGroup>
   <ItemGroup>

--- a/tools/render-test/render-test.vcxproj
+++ b/tools/render-test/render-test.vcxproj
@@ -181,7 +181,9 @@
     <ClCompile Include="shader-renderer-util.cpp" />
     <ClCompile Include="slang-support.cpp" />
     <ClCompile Include="vk-api.cpp" />
+    <ClCompile Include="vk-device-queue.cpp" />
     <ClCompile Include="vk-module.cpp" />
+    <ClCompile Include="vk-swap-chain.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="circular-resource-heap-d3d12.h" />
@@ -198,7 +200,9 @@
     <ClInclude Include="shader-renderer-util.h" />
     <ClInclude Include="slang-support.h" />
     <ClInclude Include="vk-api.h" />
+    <ClInclude Include="vk-device-queue.h" />
     <ClInclude Include="vk-module.h" />
+    <ClInclude Include="vk-swap-chain.h" />
     <ClInclude Include="window.h" />
   </ItemGroup>
   <ItemGroup>

--- a/tools/render-test/render-test.vcxproj.filters
+++ b/tools/render-test/render-test.vcxproj.filters
@@ -69,6 +69,9 @@
     <ClCompile Include="vk-device-queue.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="vk-util.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="options.h">
@@ -123,6 +126,9 @@
       <Filter>Source Files</Filter>
     </ClInclude>
     <ClInclude Include="vk-device-queue.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="vk-util.h">
       <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/tools/render-test/render-test.vcxproj.filters
+++ b/tools/render-test/render-test.vcxproj.filters
@@ -57,6 +57,12 @@
     <ClCompile Include="shader-renderer-util.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="vk-api.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="vk-module.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="options.h">
@@ -99,6 +105,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="shader-renderer-util.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="vk-api.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="vk-module.h">
       <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/tools/render-test/render-test.vcxproj.filters
+++ b/tools/render-test/render-test.vcxproj.filters
@@ -63,6 +63,12 @@
     <ClCompile Include="vk-module.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="vk-swap-chain.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="vk-device-queue.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="options.h">
@@ -111,6 +117,12 @@
       <Filter>Source Files</Filter>
     </ClInclude>
     <ClInclude Include="vk-module.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="vk-swap-chain.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="vk-device-queue.h">
       <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/tools/render-test/render-vk.cpp
+++ b/tools/render-test/render-vk.cpp
@@ -694,7 +694,7 @@ void VKRenderer::_beginRender()
 
 void VKRenderer::_endRender()
 {
-    m_deviceQueue.flushStep();
+    m_deviceQueue.flush();
 }
 
 Renderer* createVKRenderer()
@@ -925,7 +925,7 @@ SlangResult VKRenderer::initialize(void* inWindowHandle)
             VkAttachmentDescription& dst = attachmentDesc[numAttachments++];
 
             dst.flags = 0;
-            dst.format = VulkanUtil::calcVkFormat(depthFormat);
+            dst.format = VulkanUtil::getVkFormat(depthFormat);
             dst.samples = VK_SAMPLE_COUNT_1_BIT;
             dst.loadOp = shouldClearDepth ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD;
             dst.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
@@ -978,7 +978,7 @@ SlangResult VKRenderer::initialize(void* inWindowHandle)
 
 void VKRenderer::submitGpuWork()
 {
-    m_deviceQueue.flushStep();
+    m_deviceQueue.flush();
 }
 
 void VKRenderer::waitForGpu()
@@ -1137,7 +1137,7 @@ InputLayout* VKRenderer::createInputLayout(const InputElementDesc* elements, UIn
 
         dstDesc.location = uint32_t(i);
         dstDesc.binding = 0;
-        dstDesc.format = VulkanUtil::calcVkFormat(srcDesc.format);
+        dstDesc.format = VulkanUtil::getVkFormat(srcDesc.format);
         if (dstDesc.format == VK_FORMAT_UNDEFINED)
         {
             return nullptr;
@@ -1256,7 +1256,7 @@ void VKRenderer::setInputLayout(InputLayout* inputLayout)
 
 void VKRenderer::setPrimitiveTopology(PrimitiveTopology topology)
 {
-    m_primitiveTopology = VulkanUtil::calcVkPrimitiveTopology(topology);
+    m_primitiveTopology = VulkanUtil::getVkPrimitiveTopology(topology);
 }
 
 void VKRenderer::setVertexBuffers(UInt startSlot, UInt slotCount, BufferResource*const* buffers, const UInt* strides, const UInt* offsets)

--- a/tools/render-test/render-vk.cpp
+++ b/tools/render-test/render-vk.cpp
@@ -1122,11 +1122,6 @@ void VKRenderer::dispatchCompute(int x, int y, int z)
         0, 1, &pipeline->m_descriptorSet, 0, nullptr);
 
     m_api.vkCmdDispatch(commandBuffer, x, y, z);
-
-    m_deviceQueue.flushAndWait();
-    
-
-    // TODO: need to free up the other resources too...
 }
 
 // ShaderCompiler interface

--- a/tools/render-test/render-vk.cpp
+++ b/tools/render-test/render-vk.cpp
@@ -460,7 +460,7 @@ SlangResult VKRenderer::initialize(void* inWindowHandle)
 
     RETURN_ON_VK_FAIL(m_api.vkCreateDevice(m_physicalDevice, &deviceCreateInfo, nullptr, &m_device));
 
-    SLANG_RETURN_ON_FAIL(m_api.initDeviceProcs(m_device));
+    SLANG_RETURN_ON_FAIL(m_api.initDeviceProcs(m_physicalDevice, m_device));
 
     // Create a command pool
 

--- a/tools/render-test/render-vk.cpp
+++ b/tools/render-test/render-vk.cpp
@@ -290,8 +290,6 @@ void VKRenderer::flushCommandBuffer(VkCommandBuffer commandBuffer)
     m_api.vkFreeCommandBuffers(m_device, m_commandPool, 1, &commandBuffer);
 }
 
-
-
 VkPipelineShaderStageCreateInfo VKRenderer::compileEntryPoint(const ShaderCompileRequest::EntryPoint& entryPointRequest, VkShaderStageFlagBits stage, List<char>& bufferOut)
 {
     char const* dataBegin = entryPointRequest.source.dataBegin;

--- a/tools/render-test/render-vk.cpp
+++ b/tools/render-test/render-vk.cpp
@@ -47,7 +47,6 @@ public:
     virtual void setBindingState(BindingState* state);
     virtual void setVertexBuffers(UInt startSlot, UInt slotCount, BufferResource*const* buffers, const UInt* strides, const UInt* offsets) override;
     virtual void setShaderProgram(ShaderProgram* inProgram) override;
-    virtual void setConstantBuffers(UInt startSlot, UInt slotCount, BufferResource*const* buffers,  const UInt* offsets) override;
     virtual void draw(UInt vertexCount, UInt startVertex) override;
     virtual void dispatchCompute(int x, int y, int z) override;
     virtual void submitGpuWork() override;
@@ -234,8 +233,7 @@ public:
     Pipeline* m_currentPipeline = nullptr;
 
     List<BoundVertexBuffer> m_boundVertexBuffers;
-    List<RefPtr<BufferResourceImpl> > m_boundConstantBuffers;
-
+    
     VkPrimitiveTopology m_primitiveTopology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 
     VkDevice m_device = VK_NULL_HANDLE;
@@ -451,7 +449,7 @@ Slang::Result VKRenderer::_createPipeline(RefPtr<Pipeline>& pipelineOut)
 
                 writeInfo.dstSet = pipeline->m_descriptorSet;
                 writeInfo.dstBinding = srcDetail.m_binding;
-                writeInfo.dstArrayElement = elementIndex++;
+                writeInfo.dstArrayElement = 0; 
                 writeInfo.pBufferInfo = &bufferInfo;
 
                 m_api.vkUpdateDescriptorSets(m_device, 1, &writeInfo, 0, nullptr);
@@ -1287,27 +1285,6 @@ void VKRenderer::setVertexBuffers(UInt startSlot, UInt slotCount, BufferResource
 void VKRenderer::setShaderProgram(ShaderProgram* program)
 {
     m_currentProgram = (ShaderProgramImpl*)program;
-}
-
-void VKRenderer::setConstantBuffers(UInt startSlot, UInt slotCount, BufferResource*const* buffers, const UInt* offsets) 
-{
-    {
-        const UInt num = startSlot + slotCount;
-        if (num > m_boundConstantBuffers.Count())
-        {
-            m_boundConstantBuffers.SetSize(num);
-        }
-    }
-
-    for (UInt i = 0; i < slotCount; i++)
-    {
-        BufferResourceImpl* buffer = static_cast<BufferResourceImpl*>(buffers[i]);
-        if (buffer)
-        {
-            assert(buffer->m_initialUsage == Resource::Usage::ConstantBuffer);
-        }
-        m_boundConstantBuffers[startSlot + i] = buffer;
-    }
 }
 
 void VKRenderer::draw(UInt vertexCount, UInt startVertex = 0)

--- a/tools/render-test/render-vk.cpp
+++ b/tools/render-test/render-vk.cpp
@@ -7,6 +7,7 @@
 #include "../../source/core/smart-pointer.h"
 
 #include "vk-api.h"
+#include "vk-util.h"
 
 #define ENABLE_VALIDATION_LAYER 1
 
@@ -622,19 +623,6 @@ BufferResource* VKRenderer::createBufferResource(Resource::Usage initialUsage, c
     return buffer.detach();
 }
 
-static VkFormat _getVkFormat(Format format)
-{
-    switch (format)
-    {
-        case Format::RGBA_Float32:      return VK_FORMAT_R32G32B32A32_SFLOAT;
-        case Format::RGB_Float32:       return VK_FORMAT_R32G32B32_SFLOAT;
-        case Format::RG_Float32:        return VK_FORMAT_R32G32_SFLOAT;
-        case Format::R_Float32:         return VK_FORMAT_R32_SFLOAT;
-        case Format::RGBA_Unorm_UInt8:  return VK_FORMAT_R8G8B8A8_UNORM;
-        default:                        return VK_FORMAT_UNDEFINED;
-    }
-}
-
 InputLayout* VKRenderer::createInputLayout(const InputElementDesc* elements, UInt numElements) 
 {
     RefPtr<InputLayoutImpl> layout(new InputLayoutImpl);
@@ -650,7 +638,7 @@ InputLayout* VKRenderer::createInputLayout(const InputElementDesc* elements, UIn
 
         dstDesc.location = uint32_t(i);
         dstDesc.binding = 0;
-        dstDesc.format = _getVkFormat(srcDesc.format);
+        dstDesc.format = VulkanUtil::calcVkFormat(srcDesc.format);
         if (dstDesc.format == VK_FORMAT_UNDEFINED)
         {
             return nullptr;

--- a/tools/render-test/render.cpp
+++ b/tools/render-test/render.cpp
@@ -166,6 +166,26 @@ BindingState::BindIndexSlice BindingState::Desc::asSlice(ShaderStyle style, cons
 }
 
 
+int BindingState::Desc::findBindingIndex(Resource::BindFlag::Enum bindFlag, ShaderStyleFlags shaderStyleFlags, BindIndex index) const
+{
+    const int numBindings = int(m_bindings.Count());
+    for (int i = 0; i < numBindings; ++i)
+    {
+        const Binding& binding = m_bindings[i];
+        if (binding.resource && (binding.resource->getDescBase().bindFlags & bindFlag) != 0)
+        {
+            for (int j = 0; j < int(ShaderStyle::CountOf); ++j)
+            {
+                if (indexOf(binding.shaderBindSet.shaderSlices[j], index) >= 0)
+                {
+                    return i;
+                }
+            }
+        }
+    }
+
+    return -1;
+}
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!! TextureResource::Size !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
 
 int TextureResource::Size::calcMaxDimension(Type type) const

--- a/tools/render-test/render.cpp
+++ b/tools/render-test/render.cpp
@@ -48,6 +48,9 @@ const Resource::DescBase& Resource::getDescBase() const
     uint8_t(sizeof(float) * 1),      // R_Float32,
 
     uint8_t(sizeof(uint32_t)),       // RGBA_Unorm_UInt8,
+
+    uint8_t(sizeof(float)),          // D_Float32,
+    uint8_t(sizeof(uint32_t)),       // D_Unorm24_S8,
 };
 
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!! BindingState::Desc !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */

--- a/tools/render-test/render.cpp
+++ b/tools/render-test/render.cpp
@@ -365,4 +365,62 @@ void TextureResource::Desc::init3D(Format formatIn, int widthIn, int heightIn, i
     this->cpuAccessFlags = 0;
 }
 
+/* !!!!!!!!!!!!!!!!!!!!!!!!! RennderUtil !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
+
+ProjectionStyle RendererUtil::getProjectionStyle(RendererType type)
+{
+    switch (type)
+    {
+        case RendererType::DirectX11:
+        case RendererType::DirectX12:
+        {
+            return ProjectionStyle::DirectX;
+        }
+        case RendererType::OpenGl:              return ProjectionStyle::OpenGl;
+        case RendererType::Vulkan:              return ProjectionStyle::Vulkan;
+        case RendererType::Unknown:             return ProjectionStyle::Unknown;
+        default:
+        {
+            assert(!"Unhandled type");
+            return ProjectionStyle::Unknown;
+        }
+    }
+}
+
+/* static */void RendererUtil::getIdentityProjection(ProjectionStyle style, float projMatrix[16])
+{
+    switch (style)
+    {
+        case ProjectionStyle::DirectX:
+        case ProjectionStyle::OpenGl:
+        {
+            static const float kIdentity[] =
+            { 
+                1, 0, 0, 0,
+                0, 1, 0, 0,
+                0, 0, 1, 0,
+                0, 0, 0, 1
+            };
+            ::memcpy(projMatrix, kIdentity, sizeof(kIdentity));
+            break;
+        }
+        case ProjectionStyle::Vulkan:
+        {
+            static const float kIdentity[] =
+            {
+                1, 0, 0, 0,
+                0, -1, 0, 0,
+                0, 0, 1, 0,
+                0, 0, 0, 1
+            };
+            ::memcpy(projMatrix, kIdentity, sizeof(kIdentity));
+            break;
+        }
+        default: 
+        {
+            assert(!"Not handled");
+        }
+    }
+}
+
 } // renderer_test

--- a/tools/render-test/render.cpp
+++ b/tools/render-test/render.cpp
@@ -36,6 +36,20 @@ const Resource::DescBase& Resource::getDescBase() const
     return s_emptyDescBase;
 }
 
+/* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! RendererUtil !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
+
+/* static */const uint8_t RendererUtil::s_formatSize[int(Format::CountOf)] = 
+{
+    0,                               // Unknown,
+
+    uint8_t(sizeof(float) * 4),      // RGBA_Float32,
+    uint8_t(sizeof(float) * 3),      // RGB_Float32,
+    uint8_t(sizeof(float) * 2),      // RG_Float32,
+    uint8_t(sizeof(float) * 1),      // R_Float32,
+
+    uint8_t(sizeof(uint32_t)),       // RGBA_Unorm_UInt8,
+};
+
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!! BindingState::Desc !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
 
 void BindingState::Desc::addSampler(const SamplerDesc& desc, const ShaderBindSet& shaderBindSet)

--- a/tools/render-test/render.h
+++ b/tools/render-test/render.h
@@ -62,9 +62,13 @@ public:
     virtual ShaderProgram* compileProgram(ShaderCompileRequest const& request) = 0;
 };
 
+/// Different formats of things like pixels or elements of vertices
+/// NOTE! Any change to this type (adding, removing, changing order) - must also be reflected in changes to RendererUtil 
 enum class Format
 {
     Unknown,
+
+    RGBA_Float32,
     RGB_Float32,
     RG_Float32,
     R_Float32,
@@ -512,5 +516,14 @@ inline void Renderer::setConstantBuffer(UInt slot, BufferResource* buffer, UInt 
     setConstantBuffers(slot, 1, &buffer, &offset);
 }
 
+/// Functions that are around Renderer and it's types
+struct RendererUtil
+{
+        /// Gets the size in bytes of a Format type. Returns 0 if a size is not defined/invalid
+    SLANG_FORCE_INLINE static size_t getFormatSize(Format format) { return s_formatSize[int(format)]; }
+
+    private:
+    static const uint8_t s_formatSize[int(Format::CountOf)];
+};
 
 } // renderer_test

--- a/tools/render-test/render.h
+++ b/tools/render-test/render.h
@@ -74,6 +74,10 @@ enum class Format
     R_Float32,
 
     RGBA_Unorm_UInt8,
+
+    D_Float32, 
+    D_Unorm24_S8,
+
     CountOf, 
 };
 

--- a/tools/render-test/render.h
+++ b/tools/render-test/render.h
@@ -173,6 +173,9 @@ class Resource: public Slang::RefObject
         /// Base class for Descs
     struct DescBase
     {
+        bool canBind(BindFlag::Enum bindFlag) const { return (bindFlags & bindFlag) != 0; }
+        bool hasCpuAccessFlag(AccessFlag::Enum accessFlag) { return (cpuAccessFlags & accessFlag) != 0; }
+
         int bindFlags = 0;          ///< Combination of Resource::BindFlag or 0 (and will use initialUsage to set)
         int cpuAccessFlags = 0;     ///< Combination of Resource::AccessFlag 
     };
@@ -187,7 +190,7 @@ class Resource: public Slang::RefObject
         /// Get the descBase
     const DescBase& getDescBase() const;
         /// Returns true if can bind with flag
-    bool canBind(BindFlag::Enum bindFlag) const { return (getDescBase().bindFlags & bindFlag) != 0; }
+    bool canBind(BindFlag::Enum bindFlag) const { return getDescBase().canBind(bindFlag); }
 
         /// For a usage gives the required binding flags
     static const BindFlag::Enum s_requiredBinding[int(Usage::CountOf)]; 

--- a/tools/render-test/render.h
+++ b/tools/render-test/render.h
@@ -19,12 +19,18 @@ class InputLayout: public Slang::RefObject
 	public:
 };
 
+enum class PipelineType
+{
+    Unknown,
+    Graphics,
+    Compute,
+    CountOf,
+};
+
 class ShaderProgram: public Slang::RefObject
 {
 	public:
 };
-
-
 
 struct ShaderCompileRequest
 {

--- a/tools/render-test/render.h
+++ b/tools/render-test/render.h
@@ -1,7 +1,6 @@
 // render.h
 #pragma once
 
-#include "options.h"
 #include "window.h"
 
 //#include "shader-input-layout.h"
@@ -12,6 +11,9 @@
 
 namespace renderer_test {
 
+// Had to move here, because Options needs types defined here
+typedef intptr_t Int;
+typedef uintptr_t UInt;
 
 // Declare opaque type
 class InputLayout: public Slang::RefObject
@@ -24,6 +26,25 @@ enum class PipelineType
     Unknown,
     Graphics,
     Compute,
+    CountOf,
+};
+
+enum class RendererType
+{
+    Unknown,
+    DirectX11,
+    DirectX12,
+    OpenGl,
+    Vulkan,
+    CountOf,
+};
+
+enum class ProjectionStyle
+{
+    Unknown,
+    OpenGl,
+    DirectX,
+    Vulkan, 
     CountOf,
 };
 
@@ -510,6 +531,12 @@ public:
 class Renderer: public Slang::RefObject
 {
 public:
+    
+    struct Info
+    {
+        ProjectionStyle m_projectionStyle;
+    };
+
     virtual SlangResult initialize(void* inWindowHandle) = 0;
 
     virtual void setClearColor(const float color[4]) = 0;
@@ -548,6 +575,9 @@ public:
     virtual void submitGpuWork() = 0;
         /// Blocks until Gpu work is complete
     virtual void waitForGpu() = 0;
+
+        /// Get the type of this renderer
+    virtual RendererType getRendererType() const = 0;
 };
 
 // ----------------------------------------------------------------------------------------
@@ -561,6 +591,11 @@ struct RendererUtil
 {
         /// Gets the size in bytes of a Format type. Returns 0 if a size is not defined/invalid
     SLANG_FORCE_INLINE static size_t getFormatSize(Format format) { return s_formatSize[int(format)]; }
+        /// Given a renderer type, gets a projection style
+    static ProjectionStyle getProjectionStyle(RendererType type);
+
+        /// Given the projection style returns an 'identity' matrix, which ensures x,y mapping to pixels is the same on all targets
+    static void getIdentityProjection(ProjectionStyle style, float projMatrix[16]);
 
     private:
     static const uint8_t s_formatSize[int(Format::CountOf)];

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -4,6 +4,8 @@
 
 #include "slang-support.h"
 
+#include "options.h"
+
 #include <assert.h>
 #include <stdio.h>
 

--- a/tools/render-test/vk-api.cpp
+++ b/tools/render-test/vk-api.cpp
@@ -74,4 +74,7 @@ Slang::Result VulkanApi::initDeviceProcs(VkPhysicalDevice physicalDevice, VkDevi
     return SLANG_OK;
 }
 
+
+
+
 } // renderer_test

--- a/tools/render-test/vk-api.cpp
+++ b/tools/render-test/vk-api.cpp
@@ -1,0 +1,76 @@
+// vk-api.cpp
+#include "vk-api.h"
+
+namespace renderer_test {
+using namespace Slang;
+
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! VulkanApi !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+#define VK_API_CHECK_FUNCTION(x) && (x != nullptr) 
+#define  VK_API_CHECK_FUNCTIONS(FUNCTION_LIST) true FUNCTION_LIST(VK_API_CHECK_FUNCTION) 
+
+bool VulkanApi::areDefined(ProcType type) const
+{
+    switch (type)
+    {
+        case ProcType::Global:          return VK_API_CHECK_FUNCTIONS(VK_API_ALL_GLOBAL_PROCS);
+        case ProcType::Instance:        return VK_API_CHECK_FUNCTIONS(VK_API_ALL_INSTANCE_PROCS);
+        case ProcType::Device:          return VK_API_CHECK_FUNCTIONS(VK_API_ALL_DEVICE_PROCS);
+        default:
+        {
+            assert(!"Unhandled type");
+            return false;
+        }
+    }
+}
+
+Slang::Result VulkanApi::initGlobalProcs(const VulkanModule& module)
+{
+#define VK_API_GET_GLOBAL_PROC(x) x = (PFN_##x)module.getFunction(#x);
+
+    // Initialize all the global functions
+    VK_API_ALL_GLOBAL_PROCS(VK_API_GET_GLOBAL_PROC)
+
+    if (!areDefined(ProcType::Global))
+    {
+        return SLANG_FAIL;
+    }
+    m_module = &module;
+    return SLANG_OK;
+}
+
+Slang::Result VulkanApi::initInstanceProcs(VkInstance instance)
+{
+    assert(instance && vkGetInstanceProcAddr != nullptr);
+
+#define VK_API_GET_INSTANCE_PROC(x) x = (PFN_##x)vkGetInstanceProcAddr(instance, #x);
+
+    VK_API_ALL_INSTANCE_PROCS(VK_API_GET_INSTANCE_PROC)
+
+    if (!areDefined(ProcType::Instance))
+    {
+        return SLANG_FAIL;
+    }
+
+    m_instance = instance;
+    return SLANG_OK;
+}
+
+Slang::Result VulkanApi::initDeviceProcs(VkDevice device)
+{
+    assert(m_instance && device && vkGetDeviceProcAddr != nullptr);
+
+#define VK_API_GET_DEVICE_PROC(x) x = (PFN_##x)vkGetDeviceProcAddr(device, #x);
+
+    VK_API_ALL_DEVICE_PROCS(VK_API_GET_DEVICE_PROC)
+
+    if (!areDefined(ProcType::Device))
+    {
+        return SLANG_FAIL;
+    }
+
+    m_device = device;
+    return SLANG_OK;
+}
+
+} // renderer_test

--- a/tools/render-test/vk-api.cpp
+++ b/tools/render-test/vk-api.cpp
@@ -56,7 +56,7 @@ Slang::Result VulkanApi::initInstanceProcs(VkInstance instance)
     return SLANG_OK;
 }
 
-Slang::Result VulkanApi::initDeviceProcs(VkDevice device)
+Slang::Result VulkanApi::initDeviceProcs(VkPhysicalDevice physicalDevice, VkDevice device)
 {
     assert(m_instance && device && vkGetDeviceProcAddr != nullptr);
 
@@ -70,6 +70,7 @@ Slang::Result VulkanApi::initDeviceProcs(VkDevice device)
     }
 
     m_device = device;
+    m_physicalDevice = physicalDevice;
     return SLANG_OK;
 }
 

--- a/tools/render-test/vk-api.h
+++ b/tools/render-test/vk-api.h
@@ -49,6 +49,8 @@ namespace renderer_test {
     x(vkDestroyPipeline)                \
     x(vkCreateShaderModule)             \
     x(vkDestroyShaderModule)            \
+    x(vkCreateFramebuffer) \
+    x(vkDestroyFramebuffer) \
     \
     x(vkCmdBindPipeline)                \
     x(vkCmdBindDescriptorSets)          \

--- a/tools/render-test/vk-api.h
+++ b/tools/render-test/vk-api.h
@@ -71,6 +71,9 @@ namespace renderer_test {
     x(vkBeginCommandBuffer)             \
     x(vkEndCommandBuffer)               \
     x(vkResetCommandBuffer) \
+    \
+    x(vkCreateImageView) \
+    x(vkDestroyImageView) \
     /* */
 
 #if SLANG_WINDOWS_FAMILY

--- a/tools/render-test/vk-api.h
+++ b/tools/render-test/vk-api.h
@@ -26,6 +26,7 @@ namespace renderer_test {
 
 #define VK_API_DEVICE_PROCS(x)          \
     x(vkCreateDescriptorPool)           \
+    x(vkDestroyDescriptorPool)          \
     x(vkGetDeviceQueue)                 \
     x(vkQueueSubmit)                    \
     x(vkQueueWaitIdle)                  \
@@ -39,15 +40,19 @@ namespace renderer_test {
     x(vkDestroyBuffer)                  \
     x(vkFreeMemory)                     \
     x(vkCreateDescriptorSetLayout)      \
+    x(vkDestroyDescriptorSetLayout)     \
     x(vkAllocateDescriptorSets)         \
     x(vkUpdateDescriptorSets)           \
     x(vkCreatePipelineLayout)           \
+    x(vkDestroyPipelineLayout)          \
     x(vkCreateComputePipelines)         \
+    x(vkDestroyPipeline)                \
+    x(vkCreateShaderModule)             \
+    x(vkDestroyShaderModule)            \
+    \
     x(vkCmdBindPipeline)                \
     x(vkCmdBindDescriptorSets)          \
     x(vkCmdDispatch)                    \
-    x(vkDestroyPipeline)                \
-    x(vkCreateShaderModule)             \
     \
     x(vkCreateFence) \
     x(vkDestroyFence) \

--- a/tools/render-test/vk-api.h
+++ b/tools/render-test/vk-api.h
@@ -74,6 +74,9 @@ namespace renderer_test {
     \
     x(vkCreateImageView) \
     x(vkDestroyImageView) \
+    \
+    x(vkCreateRenderPass) \
+    x(vkDestroyRenderPass) \
     /* */
 
 #if SLANG_WINDOWS_FAMILY

--- a/tools/render-test/vk-api.h
+++ b/tools/render-test/vk-api.h
@@ -57,6 +57,12 @@ namespace renderer_test {
     x(vkCmdBindDescriptorSets)          \
     x(vkCmdDispatch)                    \
     x(vkCmdDraw) \
+    x(vkCmdSetScissor) \
+    x(vkCmdSetViewport) \
+    x(vkCmdBindVertexBuffers) \
+    x(vkCmdBindIndexBuffer) \
+    x(vkCmdBeginRenderPass) \
+    x(vkCmdEndRenderPass) \
     \
     x(vkCreateFence) \
     x(vkDestroyFence) \
@@ -87,9 +93,6 @@ namespace renderer_test {
     \
     x(vkCreateRenderPass) \
     x(vkDestroyRenderPass) \
-    \
-    x(vkCmdBindVertexBuffers) \
-    x(vkCmdBindIndexBuffer) \
     /* */
 
 #if SLANG_WINDOWS_FAMILY

--- a/tools/render-test/vk-api.h
+++ b/tools/render-test/vk-api.h
@@ -132,13 +132,29 @@ struct VulkanApi
     Slang::Result initGlobalProcs(const VulkanModule& module);
         /// Initialize the instance functions
     Slang::Result initInstanceProcs(VkInstance instance);
+
+        /// Called before initDevice
+    Slang::Result initPhysicalDevice(VkPhysicalDevice physicalDevice);
+
         /// Initialize the device functions
-    Slang::Result initDeviceProcs(VkPhysicalDevice physicalDevice, VkDevice device);
+    Slang::Result initDeviceProcs(VkDevice device);
+
+        /// Type bits control which indices are tested against bit 0 for testing at index 0
+        /// properties - a memory type must have all the bits set as passed in
+        /// Returns -1 if couldn't find an appropriate memory type index
+    int findMemoryTypeIndex(uint32_t typeBits, VkMemoryPropertyFlags properties) const;
+
+        /// Given queue required flags, finds a queue
+    int findQueue(VkQueueFlags reqFlags) const;
 
     const VulkanModule* m_module = nullptr;               ///< Module this was all loaded from
     VkInstance m_instance = VK_NULL_HANDLE;
     VkDevice m_device = VK_NULL_HANDLE;
     VkPhysicalDevice m_physicalDevice = VK_NULL_HANDLE;
+
+    VkPhysicalDeviceProperties          m_deviceProperties;
+    VkPhysicalDeviceFeatures            m_deviceFeatures;
+    VkPhysicalDeviceMemoryProperties    m_deviceMemoryProperties;
 };
 
 } // renderer_test

--- a/tools/render-test/vk-api.h
+++ b/tools/render-test/vk-api.h
@@ -52,8 +52,22 @@ namespace renderer_test {
     x(vkCmdDispatch)                    \
     x(vkDestroyPipeline)                \
     x(vkCreateShaderModule)             \
+    \
+    x(vkCreateFence) \
+    x(vkDestroyFence) \
+    x(vkResetFences) \
+    x(vkGetFenceStatus) \
+    x(vkWaitForFences) \
+    x(vkCreateSemaphore) \
+    x(vkDestroySemaphore) \
+    x(vkCreateEvent) \
+    x(vkDestroyEvent) \
+    x(vkGetEventStatus) \
+    x(vkSetEvent) \
+    x(vkResetEvent) \
+    \
+    x(vkResetCommandBuffer) \
     /* */
-
 
 #if SLANG_WINDOWS_FAMILY
 #   define VK_API_INSTANCE_PLATFORM_KHR_PROCS(x)          \
@@ -119,11 +133,12 @@ struct VulkanApi
         /// Initialize the instance functions
     Slang::Result initInstanceProcs(VkInstance instance);
         /// Initialize the device functions
-    Slang::Result initDeviceProcs(VkDevice device);
+    Slang::Result initDeviceProcs(VkPhysicalDevice physicalDevice, VkDevice device);
 
     const VulkanModule* m_module = nullptr;               ///< Module this was all loaded from
     VkInstance m_instance = VK_NULL_HANDLE;
     VkDevice m_device = VK_NULL_HANDLE;
+    VkPhysicalDevice m_physicalDevice = VK_NULL_HANDLE;
 };
 
 } // renderer_test

--- a/tools/render-test/vk-api.h
+++ b/tools/render-test/vk-api.h
@@ -20,6 +20,7 @@ namespace renderer_test {
     x(vkGetPhysicalDeviceFeatures)              \
     x(vkGetPhysicalDeviceMemoryProperties)      \
     x(vkGetPhysicalDeviceQueueFamilyProperties) \
+    x(vkGetPhysicalDeviceFormatProperties) \
     x(vkGetDeviceProcAddr)                      \
     /* */
 
@@ -94,6 +95,7 @@ namespace renderer_test {
     x(vkGetPhysicalDeviceSurfaceSupportKHR) \
     x(vkGetPhysicalDeviceSurfaceFormatsKHR) \
     x(vkGetPhysicalDeviceSurfacePresentModesKHR) \
+    x(vkGetPhysicalDeviceSurfaceCapabilitiesKHR) \
     x(vkDestroySurfaceKHR) \
     /* */
 

--- a/tools/render-test/vk-api.h
+++ b/tools/render-test/vk-api.h
@@ -1,0 +1,129 @@
+// vk-api.h
+#pragma once
+
+#include "vk-module.h"
+
+namespace renderer_test {
+
+#define VK_API_GLOBAL_PROCS(x)          \
+    x(vkGetInstanceProcAddr)            \
+    x(vkCreateInstance)                 \
+    /* */
+
+#define VK_API_INSTANCE_PROCS(x)                \
+    x(vkCreateDevice)                           \
+    x(vkCreateDebugReportCallbackEXT)           \
+    x(vkDestroyDebugReportCallbackEXT)          \
+    x(vkDebugReportMessageEXT)                  \
+    x(vkEnumeratePhysicalDevices)               \
+    x(vkGetPhysicalDeviceProperties)            \
+    x(vkGetPhysicalDeviceFeatures)              \
+    x(vkGetPhysicalDeviceMemoryProperties)      \
+    x(vkGetPhysicalDeviceQueueFamilyProperties) \
+    x(vkGetDeviceProcAddr)                      \
+    /* */
+
+#define VK_API_DEVICE_PROCS(x)          \
+    x(vkCreateDescriptorPool)           \
+    x(vkCreateCommandPool)              \
+    x(vkGetDeviceQueue)                 \
+    x(vkAllocateCommandBuffers)         \
+    x(vkBeginCommandBuffer)             \
+    x(vkEndCommandBuffer)               \
+    x(vkQueueSubmit)                    \
+    x(vkQueueWaitIdle)                  \
+    x(vkFreeCommandBuffers)             \
+    x(vkCreateBuffer)                   \
+    x(vkGetBufferMemoryRequirements)    \
+    x(vkAllocateMemory)                 \
+    x(vkBindBufferMemory)               \
+    x(vkMapMemory)                      \
+    x(vkUnmapMemory)                    \
+    x(vkCmdCopyBuffer)                  \
+    x(vkDestroyBuffer)                  \
+    x(vkFreeMemory)                     \
+    x(vkCreateDescriptorSetLayout)      \
+    x(vkAllocateDescriptorSets)         \
+    x(vkUpdateDescriptorSets)           \
+    x(vkCreatePipelineLayout)           \
+    x(vkCreateComputePipelines)         \
+    x(vkCmdBindPipeline)                \
+    x(vkCmdBindDescriptorSets)          \
+    x(vkCmdDispatch)                    \
+    x(vkDestroyPipeline)                \
+    x(vkCreateShaderModule)             \
+    /* */
+
+
+#if SLANG_WINDOWS_FAMILY
+#   define VK_API_INSTANCE_PLATFORM_KHR_PROCS(x)          \
+    x(vkCreateWin32SurfaceKHR) \
+    /* */
+#else
+#   define VK_API_INSTANCE_PLATFORM_KHR_PROCS(x)          \
+    x(vkCreateXlibSurfaceKHR) \
+    /* */
+#endif
+
+#define VK_API_INSTANCE_KHR_PROCS(x)          \
+    VK_API_INSTANCE_PLATFORM_KHR_PROCS(x) \
+    x(vkGetPhysicalDeviceSurfaceSupportKHR) \
+    x(vkGetPhysicalDeviceSurfaceFormatsKHR) \
+    x(vkGetPhysicalDeviceSurfacePresentModesKHR) \
+    x(vkDestroySurfaceKHR) \
+    /* */
+
+#define VK_API_DEVICE_KHR_PROCS(x) \
+    x(vkQueuePresentKHR) \
+    x(vkCreateSwapchainKHR) \
+    x(vkGetSwapchainImagesKHR) \
+    x(vkDestroySwapchainKHR) \
+    x(vkAcquireNextImageKHR) \
+    /* */
+
+#define VK_API_ALL_GLOBAL_PROCS(x) \
+    VK_API_GLOBAL_PROCS(x)
+
+#define VK_API_ALL_INSTANCE_PROCS(x) \
+    VK_API_INSTANCE_PROCS(x) \
+    VK_API_INSTANCE_KHR_PROCS(x)
+
+#define VK_API_ALL_DEVICE_PROCS(x) \
+    VK_API_DEVICE_PROCS(x) \
+    VK_API_DEVICE_KHR_PROCS(x)
+
+#define VK_API_ALL_PROCS(x) \
+    VK_API_ALL_GLOBAL_PROCS(x) \
+    VK_API_ALL_INSTANCE_PROCS(x) \
+    VK_API_ALL_DEVICE_PROCS(x) \
+    /* */
+
+#define VK_API_DECLARE_PROC(NAME) PFN_##NAME NAME = nullptr;
+
+struct VulkanApi
+{
+    VK_API_ALL_PROCS(VK_API_DECLARE_PROC)
+
+    enum class ProcType 
+    {
+        Global,
+        Instance, 
+        Device,
+    };
+
+        /// Returns true if all the functions in the class are defined 
+    bool areDefined(ProcType type) const;
+
+        /// Sets up global parameters 
+    Slang::Result initGlobalProcs(const VulkanModule& module);
+        /// Initialize the instance functions
+    Slang::Result initInstanceProcs(VkInstance instance);
+        /// Initialize the device functions
+    Slang::Result initDeviceProcs(VkDevice device);
+
+    const VulkanModule* m_module = nullptr;               ///< Module this was all loaded from
+    VkInstance m_instance = VK_NULL_HANDLE;
+    VkDevice m_device = VK_NULL_HANDLE;
+};
+
+} // renderer_test

--- a/tools/render-test/vk-api.h
+++ b/tools/render-test/vk-api.h
@@ -46,6 +46,7 @@ namespace renderer_test {
     x(vkCreatePipelineLayout)           \
     x(vkDestroyPipelineLayout)          \
     x(vkCreateComputePipelines)         \
+    x(vkCreateGraphicsPipelines)        \
     x(vkDestroyPipeline)                \
     x(vkCreateShaderModule)             \
     x(vkDestroyShaderModule)            \
@@ -55,6 +56,7 @@ namespace renderer_test {
     x(vkCmdBindPipeline)                \
     x(vkCmdBindDescriptorSets)          \
     x(vkCmdDispatch)                    \
+    x(vkCmdDraw) \
     \
     x(vkCreateFence) \
     x(vkDestroyFence) \
@@ -85,6 +87,9 @@ namespace renderer_test {
     \
     x(vkCreateRenderPass) \
     x(vkDestroyRenderPass) \
+    \
+    x(vkCmdBindVertexBuffers) \
+    x(vkCmdBindIndexBuffer) \
     /* */
 
 #if SLANG_WINDOWS_FAMILY

--- a/tools/render-test/vk-api.h
+++ b/tools/render-test/vk-api.h
@@ -25,14 +25,9 @@ namespace renderer_test {
 
 #define VK_API_DEVICE_PROCS(x)          \
     x(vkCreateDescriptorPool)           \
-    x(vkCreateCommandPool)              \
     x(vkGetDeviceQueue)                 \
-    x(vkAllocateCommandBuffers)         \
-    x(vkBeginCommandBuffer)             \
-    x(vkEndCommandBuffer)               \
     x(vkQueueSubmit)                    \
     x(vkQueueWaitIdle)                  \
-    x(vkFreeCommandBuffers)             \
     x(vkCreateBuffer)                   \
     x(vkGetBufferMemoryRequirements)    \
     x(vkAllocateMemory)                 \
@@ -58,14 +53,23 @@ namespace renderer_test {
     x(vkResetFences) \
     x(vkGetFenceStatus) \
     x(vkWaitForFences) \
+    \
     x(vkCreateSemaphore) \
     x(vkDestroySemaphore) \
+    \
     x(vkCreateEvent) \
     x(vkDestroyEvent) \
     x(vkGetEventStatus) \
     x(vkSetEvent) \
     x(vkResetEvent) \
     \
+    x(vkCreateCommandPool)              \
+    x(vkDestroyCommandPool) \
+    \
+    x(vkFreeCommandBuffers)             \
+    x(vkAllocateCommandBuffers)         \
+    x(vkBeginCommandBuffer)             \
+    x(vkEndCommandBuffer)               \
     x(vkResetCommandBuffer) \
     /* */
 

--- a/tools/render-test/vk-device-queue.cpp
+++ b/tools/render-test/vk-device-queue.cpp
@@ -1,0 +1,169 @@
+// vk-device-queue.cpp
+#include "vk-device-queue.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+namespace renderer_test {
+using namespace Slang;
+
+SlangResult VulkanDeviceQueue::init(const VulkanApi& api, VkQueue graphicsQueue, int graphicsQueueIndex)
+{
+    assert(m_api == nullptr);
+
+    m_numCommandBuffers = kMaxCommandBuffers;
+    m_graphicsQueueIndex = graphicsQueueIndex;
+
+    //NvFlowDeviceQueue_init(&ptr->deviceQueue, objectHandle, desc);
+
+    m_graphicsQueue = graphicsQueue;
+    
+    VkCommandPoolCreateInfo poolCreateInfo = {};
+    poolCreateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    poolCreateInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+
+    poolCreateInfo.queueFamilyIndex = graphicsQueueIndex;
+
+    api.vkCreateCommandPool(api.m_device, &poolCreateInfo, nullptr, &m_commandPool);
+
+    VkCommandBufferAllocateInfo commandInfo = {};
+    commandInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    commandInfo.commandPool = m_commandPool;
+    commandInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    commandInfo.commandBufferCount = 1;
+
+    VkFenceCreateInfo fenceCreateInfo = {};
+    fenceCreateInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    fenceCreateInfo.flags = 0; // VK_FENCE_CREATE_SIGNALED_BIT;
+
+    for (int i = 0; i < m_numCommandBuffers; i++)
+    {
+        Fence& fence = m_fences[i];
+
+        api.vkAllocateCommandBuffers(api.m_device, &commandInfo, &m_commandBuffers[i]);
+
+        api.vkCreateFence(api.m_device, &fenceCreateInfo, nullptr, &fence.fence);
+        fence.active = false;
+        fence.value = 0;
+    }
+
+    VkSemaphoreCreateInfo semaphoreCreateInfo = {};
+    semaphoreCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+
+    api.vkCreateSemaphore(api.m_device, &semaphoreCreateInfo, nullptr, &m_beginFrameSemaphore);
+    api.vkCreateSemaphore(api.m_device, &semaphoreCreateInfo, nullptr, &m_endFrameSemaphore);
+
+    // Second step of flush to prime command buffer
+    flushStepB();
+
+#if 0
+    NvFlowContextDescVulkan contextDesc = {};
+    contextDesc.vkGetInstanceProcAddr = ptr->device->loader.vkGetInstanceProcAddr;
+    contextDesc.vkGetDeviceProcAddr = ptr->device->loader.vkGetDeviceProcAddr;
+    contextDesc.instance = ptr->device->vulkanInstance;
+    contextDesc.physicalDevice = ptr->device->physicalDevice;
+    contextDesc.device = ptr->vulkanDevice;
+    contextDesc.queue = ptr->graphicsQueue;
+    contextDesc.commandBuffer = ptr->commandBuffer;
+    contextDesc.lastFenceCompleted = ptr->lastFenceCompleted;
+    contextDesc.nextFenceValue = ptr->nextFenceValue;
+
+    ptr->internalContext = NvFlowCreateContextVulkan(NV_FLOW_VERSION, &contextDesc);
+#endif
+
+    m_api = &api;
+    return SLANG_OK;
+}
+
+void VulkanDeviceQueue::flushStepA()
+{
+    //NvFlowContextEndRenderPass(ptr->internalContext);
+
+    m_api->vkEndCommandBuffer(m_commandBuffer);
+
+    VkPipelineStageFlags stageFlags = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+
+    VkSubmitInfo submitInfo = {};
+    submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    if (m_currentBeginFrameSemaphore)
+    {
+        submitInfo.waitSemaphoreCount = 1;
+        submitInfo.pWaitSemaphores = &m_currentBeginFrameSemaphore;
+    }
+    submitInfo.pWaitDstStageMask = &stageFlags;
+    submitInfo.commandBufferCount = 1;
+    submitInfo.pCommandBuffers = &m_commandBuffer;
+    if (m_currentEndFrameSemaphore)
+    {
+        submitInfo.signalSemaphoreCount = 1;
+        submitInfo.pSignalSemaphores = &m_currentEndFrameSemaphore;
+    }
+
+    Fence& fence = m_fences[m_commandBufferIndex];
+
+    m_api->vkQueueSubmit(m_graphicsQueue, 1, &submitInfo, fence.fence);
+
+    // mark signaled fence value
+    fence.value = m_nextFenceValue;
+    fence.active = true;
+    
+    // increment fence value
+    m_nextFenceValue++;
+
+    m_currentBeginFrameSemaphore = VK_NULL_HANDLE;
+}
+
+void VulkanDeviceQueue::fenceUpdate( int fenceIndex, bool blocking)
+{
+    Fence& fence = m_fences[fenceIndex];
+
+    if (fence.active)
+    {
+        uint64_t timeout = blocking ? ~uint64_t(0) : 0;
+
+        if (VK_SUCCESS == m_api->vkWaitForFences(m_api->m_device, 1, &fence.fence, VK_TRUE, timeout))
+        {
+            m_api->vkResetFences(m_api->m_device, 1, &fence.fence);
+
+            fence.active = false;
+
+            if (fence.value > m_lastFenceCompleted)
+            {
+                m_lastFenceCompleted = fence.value;
+            }
+        }
+    }
+}
+
+void VulkanDeviceQueue::flushStepB()
+{
+    VkCommandBufferBeginInfo beginInfo = {};
+    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+
+    m_commandBufferIndex = (m_commandBufferIndex + 1) % m_numCommandBuffers;
+    m_commandBuffer = m_commandBuffers[m_commandBufferIndex];
+    
+    // non-blocking update of fence values
+    for (int i = 0; i < m_numCommandBuffers; ++i)
+    {
+        fenceUpdate(i, false);
+    }
+
+    // blocking update of fence values
+    fenceUpdate(m_commandBufferIndex, true);
+    
+    m_api->vkResetCommandBuffer(m_commandBuffer, 0);
+
+    //m_api.vkResetCommandPool(m_api->m_device, m_commandPool, 0);
+
+    m_api->vkBeginCommandBuffer(m_commandBuffer, &beginInfo);
+}
+
+void VulkanDeviceQueue::flushStep()
+{
+    flushStepA();
+    flushStepB();
+}
+
+} // renderer_test

--- a/tools/render-test/vk-device-queue.cpp
+++ b/tools/render-test/vk-device-queue.cpp
@@ -83,8 +83,6 @@ SlangResult VulkanDeviceQueue::init(const VulkanApi& api, VkQueue queue, int que
 
 void VulkanDeviceQueue::flushStepA()
 {
-    //NvFlowContextEndRenderPass(ptr->internalContext);
-
     m_api->vkEndCommandBuffer(m_commandBuffer);
 
     VkPipelineStageFlags stageFlags = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;

--- a/tools/render-test/vk-device-queue.h
+++ b/tools/render-test/vk-device-queue.h
@@ -12,19 +12,41 @@ struct VulkanDeviceQueue
         kMaxCommandBuffers = 8,
     };
 
+    enum class EventType
+    {
+        BeginFrame,
+        EndFrame,
+        CountOf,
+    };
+
     SlangResult init(const VulkanApi& api, VkQueue graphicsQueue, int graphicsQueueIndex);
 
     void flushStep();
-
-    void flushStepA();
-    void flushStepB();
 
     void fenceUpdate(int fenceIndex, bool blocking);
 
     void waitForIdle() { m_api->vkQueueWaitIdle(m_graphicsQueue); }
 
-    //NvFlowDeviceQueue deviceQueue;
-    //NvFlowDeviceVulkan* device;
+        /// Set the graphics queue index (as set on init)
+    int getGraphicsQueueIndex() const { return m_graphicsQueueIndex; }
+
+    VkSemaphore makeCurrent(EventType eventType);
+
+    void makeCompleted(EventType eventType);
+
+        /// Get the graphics queu
+    VkQueue getGraphicsQueue() const { return m_graphicsQueue; }
+
+        /// Get the API
+    const VulkanApi* getApi() const { return m_api; }
+
+    void flushStepA();
+    void flushStepB();
+
+        /// Dtor
+    ~VulkanDeviceQueue();
+
+    protected:
 
     VkQueue m_graphicsQueue = nullptr;
 
@@ -38,22 +60,20 @@ struct VulkanDeviceQueue
     VkCommandPool m_commandPool = VK_NULL_HANDLE;
     int m_numCommandBuffers = 0;
     int m_commandBufferIndex = 0;
+    // There are the same amount of command buffers as fences
     VkCommandBuffer m_commandBuffers[kMaxCommandBuffers] = { nullptr };
+
     Fence m_fences[kMaxCommandBuffers] = { {VK_NULL_HANDLE, 0, 0u} };
+    
     VkCommandBuffer m_commandBuffer = nullptr;
 
-    VkSemaphore m_beginFrameSemaphore = VK_NULL_HANDLE;
-    VkSemaphore m_endFrameSemaphore = VK_NULL_HANDLE;
-
-    VkSemaphore m_currentBeginFrameSemaphore = VK_NULL_HANDLE;
-    VkSemaphore m_currentEndFrameSemaphore = VK_NULL_HANDLE;
+    VkSemaphore m_semaphores[int(EventType::CountOf)];
+    VkSemaphore m_currentSemaphores[int(EventType::CountOf)];
 
     uint64_t m_lastFenceCompleted = 1;
     uint64_t m_nextFenceValue = 2;
 
     int m_graphicsQueueIndex = 0;
-
-    //NvFlowContext* internalContext = nullptr;
 
     const VulkanApi* m_api = nullptr;
 };

--- a/tools/render-test/vk-device-queue.h
+++ b/tools/render-test/vk-device-queue.h
@@ -19,37 +19,43 @@ struct VulkanDeviceQueue
         CountOf,
     };
 
-    SlangResult init(const VulkanApi& api, VkQueue graphicsQueue, int graphicsQueueIndex);
+        /// Initialize - must be called before anything else can be done
+    SlangResult init(const VulkanApi& api, VkQueue queue, int queueIndex);
 
+        /// Flushes the current command list, and steps to next (ie combination of step A then B)
     void flushStep();
 
-    void fenceUpdate(int fenceIndex, bool blocking);
-
-    void waitForIdle() { m_api->vkQueueWaitIdle(m_graphicsQueue); }
+        /// Blocks until all work submitted to GPU has completed
+    void waitForIdle() { m_api->vkQueueWaitIdle(m_queue); }
 
         /// Set the graphics queue index (as set on init)
-    int getGraphicsQueueIndex() const { return m_graphicsQueueIndex; }
+    int getQueueIndex() const { return m_queueIndex; }
 
     VkSemaphore makeCurrent(EventType eventType);
 
     void makeCompleted(EventType eventType);
 
-        /// Get the graphics queu
-    VkQueue getGraphicsQueue() const { return m_graphicsQueue; }
+        /// Get the command buffer
+    VkCommandBuffer getCommandBuffer() const { return m_commandBuffer; }
+
+        /// Get the queue
+    VkQueue getQueue() const { return m_queue; }
 
         /// Get the API
     const VulkanApi* getApi() const { return m_api; }
 
+        /// Flushes the current command list 
     void flushStepA();
+        /// Steps to next command buffer and opens. May block if command buffer is still in use
     void flushStepB();
+
+    void flushAndWait();
 
         /// Dtor
     ~VulkanDeviceQueue();
 
     protected:
-
-    VkQueue m_graphicsQueue = nullptr;
-
+        
     struct Fence
     {
         VkFence fence;
@@ -57,15 +63,19 @@ struct VulkanDeviceQueue
         uint64_t value;
     };
 
+    void fenceUpdate(int fenceIndex, bool blocking);
+
+    VkQueue m_queue = VK_NULL_HANDLE;
+
     VkCommandPool m_commandPool = VK_NULL_HANDLE;
     int m_numCommandBuffers = 0;
     int m_commandBufferIndex = 0;
     // There are the same amount of command buffers as fences
-    VkCommandBuffer m_commandBuffers[kMaxCommandBuffers] = { nullptr };
+    VkCommandBuffer m_commandBuffers[kMaxCommandBuffers] = { VK_NULL_HANDLE };
 
     Fence m_fences[kMaxCommandBuffers] = { {VK_NULL_HANDLE, 0, 0u} };
     
-    VkCommandBuffer m_commandBuffer = nullptr;
+    VkCommandBuffer m_commandBuffer = VK_NULL_HANDLE;
 
     VkSemaphore m_semaphores[int(EventType::CountOf)];
     VkSemaphore m_currentSemaphores[int(EventType::CountOf)];
@@ -73,7 +83,7 @@ struct VulkanDeviceQueue
     uint64_t m_lastFenceCompleted = 1;
     uint64_t m_nextFenceValue = 2;
 
-    int m_graphicsQueueIndex = 0;
+    int m_queueIndex = 0;
 
     const VulkanApi* m_api = nullptr;
 };

--- a/tools/render-test/vk-device-queue.h
+++ b/tools/render-test/vk-device-queue.h
@@ -1,0 +1,61 @@
+// vk-swap-chain.h
+#pragma once
+
+#include "vk-api.h"
+
+namespace renderer_test {
+
+struct VulkanDeviceQueue
+{
+    enum 
+    {
+        kMaxCommandBuffers = 8,
+    };
+
+    SlangResult init(const VulkanApi& api, VkQueue graphicsQueue, int graphicsQueueIndex);
+
+    void flushStep();
+
+    void flushStepA();
+    void flushStepB();
+
+    void fenceUpdate(int fenceIndex, bool blocking);
+
+    void waitForIdle() { m_api->vkQueueWaitIdle(m_graphicsQueue); }
+
+    //NvFlowDeviceQueue deviceQueue;
+    //NvFlowDeviceVulkan* device;
+
+    VkQueue m_graphicsQueue = nullptr;
+
+    struct Fence
+    {
+        VkFence fence;
+        bool  active;
+        uint64_t value;
+    };
+
+    VkCommandPool m_commandPool = VK_NULL_HANDLE;
+    int m_numCommandBuffers = 0;
+    int m_commandBufferIndex = 0;
+    VkCommandBuffer m_commandBuffers[kMaxCommandBuffers] = { nullptr };
+    Fence m_fences[kMaxCommandBuffers] = { {VK_NULL_HANDLE, 0, 0u} };
+    VkCommandBuffer m_commandBuffer = nullptr;
+
+    VkSemaphore m_beginFrameSemaphore = VK_NULL_HANDLE;
+    VkSemaphore m_endFrameSemaphore = VK_NULL_HANDLE;
+
+    VkSemaphore m_currentBeginFrameSemaphore = VK_NULL_HANDLE;
+    VkSemaphore m_currentEndFrameSemaphore = VK_NULL_HANDLE;
+
+    uint64_t m_lastFenceCompleted = 1;
+    uint64_t m_nextFenceValue = 2;
+
+    int m_graphicsQueueIndex = 0;
+
+    //NvFlowContext* internalContext = nullptr;
+
+    const VulkanApi* m_api = nullptr;
+};
+
+} // renderer_test

--- a/tools/render-test/vk-module.cpp
+++ b/tools/render-test/vk-module.cpp
@@ -1,0 +1,75 @@
+// module.cpp
+#include "vk-module.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#if SLANG_WINDOWS_FAMILY 
+#   include <windows.h>
+#else
+#   include <dlfcn.h>
+#endif
+
+namespace renderer_test {
+using namespace Slang;
+
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! VulkanModule !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+Slang::Result VulkanModule::init()
+{
+    if (isInitialized())
+    {
+        destroy();
+        return SLANG_OK;
+    }
+
+    const char* dynamicLibraryName = "Unknown";
+
+#if SLANG_WINDOWS_FAMILY
+    dynamicLibraryName = "vulkan-1.dll";
+    HMODULE module = ::LoadLibraryA(dynamicLibraryName);    
+    m_module = (void*)module;    
+#else
+    dynamicLibraryName = "libvulkan.so.1";
+    m_module = dlopen(dynamicLibraryName, RTLD_NOW);
+#endif
+
+    if (!m_module)
+    {
+        fprintf(stderr, "error: failed load '%s'\n", dynamicLibraryName);
+        return SLANG_FAIL;
+    }
+
+    return SLANG_OK;
+}
+
+PFN_vkVoidFunction VulkanModule::getFunction(const char* name) const
+{
+    assert(m_module);
+    if (!m_module)
+    {
+        return nullptr;
+    }
+#if SLANG_WINDOWS_FAMILY
+    return (PFN_vkVoidFunction)::GetProcAddress((HMODULE)m_module, name);
+#else 
+    return (PFN_vkVoidFunction)dlsym(m_module, name);
+#endif
+}
+
+void VulkanModule::destroy()
+{
+    if (!isInitialized())
+    {
+        return;
+    }
+
+#if SLANG_WINDOWS_FAMILY 
+    ::FreeLibrary((HMODULE)m_module); 
+#else
+    dlclose(m_module);
+#endif
+    m_module = nullptr;
+}
+
+} // renderer_test

--- a/tools/render-test/vk-module.h
+++ b/tools/render-test/vk-module.h
@@ -1,0 +1,38 @@
+// vk-module.h
+#pragma once
+
+#include "../../source/core/slang-defines.h"
+#include "../../source/core/slang-result.h"
+
+#if SLANG_WINDOWS_FAMILY
+#   define VK_USE_PLATFORM_WIN32_KHR 1
+#else
+#   define VK_USE_PLATFORM_XLIB_KHR 1
+#endif
+
+#define VK_NO_PROTOTYPES
+#include <vulkan/vulkan.h>
+
+namespace renderer_test {
+
+struct VulkanModule
+{
+        /// true if has been initialized
+    SLANG_FORCE_INLINE bool isInitialized() const { return m_module != nullptr; }
+
+        /// Get a function by name
+    PFN_vkVoidFunction getFunction(const char* name) const;
+
+        /// Initialize
+    Slang::Result init();
+        /// Destroy
+    void destroy();    
+
+        /// Dtor
+    ~VulkanModule() { destroy(); }
+
+    protected:
+    void* m_module = nullptr;
+};
+
+} // renderer_test

--- a/tools/render-test/vk-swap-chain.cpp
+++ b/tools/render-test/vk-swap-chain.cpp
@@ -398,11 +398,14 @@ VulkanSwapChain::~VulkanSwapChain()
     }
 }
 
-TextureResource* VulkanSwapChain::getFrontRenderTarget()
+int VulkanSwapChain::nextFrontImageIndex()
 {
     if (!hasValidSwapChain())
     {
-        SLANG_RETURN_NULL_ON_FAIL(_createSwapChain());
+        if (SLANG_FAILED(_createSwapChain()))
+        {
+            return -1;
+        }
     }
 
     VkSemaphore beginFrameSemaphore = m_deviceQueue->makeCurrent(VulkanDeviceQueue::EventType::BeginFrame);
@@ -413,10 +416,10 @@ TextureResource* VulkanSwapChain::getFrontRenderTarget()
     if (result != VK_SUCCESS)
     {
         _destroySwapChain();
-        return nullptr;
+        return -1;
     }
     m_currentSwapChainIndex = int(swapChainIndex);
-    return nullptr;
+    return swapChainIndex;
 }
 
 void VulkanSwapChain::present(bool vsync)

--- a/tools/render-test/vk-swap-chain.cpp
+++ b/tools/render-test/vk-swap-chain.cpp
@@ -240,7 +240,7 @@ SlangResult VulkanSwapChain::_createSwapChain()
         }
     }
 
-    VkSwapchainKHR oldSwapchain = nullptr;
+    VkSwapchainKHR oldSwapchain = VK_NULL_HANDLE;
 
     VkSwapchainCreateInfoKHR swapchainDesc = {};
     swapchainDesc.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;

--- a/tools/render-test/vk-swap-chain.cpp
+++ b/tools/render-test/vk-swap-chain.cpp
@@ -41,7 +41,7 @@ SlangResult VulkanSwapChain::init(VulkanDeviceQueue* deviceQueue, const Desc& de
 #endif
 
     VkBool32 supported = false;
-    m_api->vkGetPhysicalDeviceSurfaceSupportKHR(m_api->m_physicalDevice, deviceQueue->getGraphicsQueueIndex(), m_surface, &supported);
+    m_api->vkGetPhysicalDeviceSurfaceSupportKHR(m_api->m_physicalDevice, deviceQueue->getQueueIndex(), m_surface, &supported);
 
     uint32_t numSurfaceFormats = 0;
     List<VkSurfaceFormatKHR> surfaceFormats;
@@ -292,7 +292,7 @@ void VulkanSwapChain::present(bool vsync)
     presentInfo.waitSemaphoreCount = 1;
     presentInfo.pWaitSemaphores = &endFrameSemaphore;
 
-    VkResult result = m_api->vkQueuePresentKHR(m_deviceQueue->getGraphicsQueue(), &presentInfo);
+    VkResult result = m_api->vkQueuePresentKHR(m_deviceQueue->getQueue(), &presentInfo);
 
     m_deviceQueue->makeCompleted(VulkanDeviceQueue::EventType::EndFrame);
     

--- a/tools/render-test/vk-swap-chain.cpp
+++ b/tools/render-test/vk-swap-chain.cpp
@@ -69,6 +69,7 @@ SlangResult VulkanSwapChain::init(VulkanDeviceQueue* deviceQueue, const Desc& de
     surfaceFormats.SetSize(int(numSurfaceFormats));
     m_api->vkGetPhysicalDeviceSurfaceFormatsKHR(m_api->m_physicalDevice, m_surface, &numSurfaceFormats, surfaceFormats.Buffer());
 
+    // Look for a suitable format
     List<VkFormat> formats;
     formats.Add(VulkanUtil::calcVkFormat(desc.m_format));
     // HACK! To check for a different format if couldn't be found
@@ -93,32 +94,6 @@ SlangResult VulkanSwapChain::init(VulkanDeviceQueue* deviceQueue, const Desc& de
 
     // Save the desc
     m_desc = desc;
-
-    /*
-    // try to find BGR, fall back to RGB
-    bool formatFound = false;
-    for (uint32_t i = 0; i < surfaceCount; i++)
-    {
-    if (surfaceFormats[i].format == VK_FORMAT_B8G8R8A8_UNORM)
-    {
-    ptr->swapchainFormat = surfaceFormats[i].format;
-    formatFound = true;
-    break;
-    }
-    }
-    if (!formatFound)
-    {
-    for (uint32_t i = 0; i < surfaceCount; i++)
-    {
-    if (surfaceFormats[i].format == VK_FORMAT_R8G8B8A8_UNORM)
-    {
-    ptr->swapchainFormat = surfaceFormats[i].format;
-    formatFound = true;
-    break;
-    }
-    }
-    }
-    */
 
     SLANG_RETURN_ON_FAIL(_createSwapChain());
 
@@ -441,8 +416,6 @@ TextureResource* VulkanSwapChain::getFrontRenderTarget()
         return nullptr;
     }
     m_currentSwapChainIndex = int(swapChainIndex);
-
-    //return m_renderTargets[m_currentSwapChainIndex];
     return nullptr;
 }
 

--- a/tools/render-test/vk-swap-chain.cpp
+++ b/tools/render-test/vk-swap-chain.cpp
@@ -1,0 +1,307 @@
+// vk-swap-chain.cpp
+#include "vk-swap-chain.h"
+
+#include "../../source/core/list.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+namespace renderer_test {
+using namespace Slang;
+
+SlangResult VulkanSwapChain::init(VulkanDeviceQueue* deviceQueue, const Desc& desc, const PlatformDesc* platformDescIn)
+{
+    assert(platformDescIn);
+
+    m_deviceQueue = deviceQueue;
+    m_api = deviceQueue->m_api;
+    
+#if SLANG_WINDOWS_FAMILY
+    const WinPlatformDesc* platformDesc = static_cast<const WinPlatformDesc*>(platformDescIn);
+    _setPlatformDesc(*platformDesc);
+
+    VkWin32SurfaceCreateInfoKHR surfaceCreateInfo = {};
+    surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
+    surfaceCreateInfo.hinstance = platformDesc->m_hinstance;
+    surfaceCreateInfo.hwnd = platformDesc->m_hwnd;
+
+    m_api->vkCreateWin32SurfaceKHR(m_api->m_instance, &surfaceCreateInfo, nullptr, &m_surface);
+#else
+    const XPlatformDesc* platformDesc = static_cast<const XPlatformDesc*>(platformDescIn);
+    _setPlatformDesc(*platformDesc);
+
+    VkXlibSurfaceCreateInfoKHR surfaceCreateInfo = {};
+    surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
+    surfaceCreateInfo.dpy = platformDesc->m_display; 
+    surfaceCreateInfo.window = platformDesc->m_window;
+    
+    m_api->vkCreateXlibSurfaceKHR(m_api->m_instance, &surfaceCreateInfo, nullptr, &m_surface);
+#endif
+
+    VkBool32 supported = false;
+    m_api->vkGetPhysicalDeviceSurfaceSupportKHR(m_api->m_physicalDevice, deviceQueue->m_graphicsQueueIndex, m_surface, &supported);
+
+    uint32_t numSurfaceFormats = 0;
+    List<VkSurfaceFormatKHR> surfaceFormats;
+    m_api->vkGetPhysicalDeviceSurfaceFormatsKHR(m_api->m_physicalDevice, m_surface, &numSurfaceFormats, nullptr);
+    surfaceFormats.SetSize(int(numSurfaceFormats));
+    m_api->vkGetPhysicalDeviceSurfaceFormatsKHR(m_api->m_physicalDevice, m_surface, &numSurfaceFormats, surfaceFormats.Buffer());
+
+    //m_swapchainFormat = NvFlowVulkan_convertToVulkan(ptr->swapchain.desc.format);
+
+    /*
+    // try to find BGR, fall back to RGB
+    bool formatFound = false;
+    for (uint32_t i = 0; i < surfaceCount; i++)
+    {
+    if (surfaceFormats[i].format == VK_FORMAT_B8G8R8A8_UNORM)
+    {
+    ptr->swapchainFormat = surfaceFormats[i].format;
+    formatFound = true;
+    break;
+    }
+    }
+    if (!formatFound)
+    {
+    for (uint32_t i = 0; i < surfaceCount; i++)
+    {
+    if (surfaceFormats[i].format == VK_FORMAT_R8G8B8A8_UNORM)
+    {
+    ptr->swapchainFormat = surfaceFormats[i].format;
+    formatFound = true;
+    break;
+    }
+    }
+    }
+    */
+
+    return initSwapchain();
+}
+
+void VulkanSwapChain::getWindowSize(int* widthOut, int* heightOut) const
+{
+#if SLANG_WINDOWS_FAMILY
+    auto platformDesc = _getPlatformDesc<WinPlatformDesc>();
+
+    RECT rc;
+    ::GetClientRect(platformDesc->m_hwnd, &rc);
+    *widthOut = rc.right - rc.left;
+    *heightOut = rc.bottom - rc.top;
+#else
+    auto platformDesc = _getPlatformDesc<XPlatformDesc>();
+
+    XWindowAttributes winAttr = {}; 
+    XGetWindowAttributes(platformDesc->m_display, platformDesc->m_window, &winAttr);
+
+    *widthOut = winAttr.width;
+    *heightOut = winAttr.height;
+#endif
+}
+
+SlangResult VulkanSwapChain::initSwapchain()
+{
+    int width, height; 
+    getWindowSize(&width, &height);
+
+    VkExtent2D imageExtent = {};
+    imageExtent.width = width;
+    imageExtent.height = height;
+
+    m_width = width;
+    m_height = height;
+
+    // catch this before throwing error
+    if (m_width == 0 || m_height == 0)
+    {
+        return SLANG_FAIL;
+    }
+
+    List<VkPresentModeKHR> presentModes;
+    uint32_t numPresentModes = 0;
+    m_api->vkGetPhysicalDeviceSurfacePresentModesKHR(m_api->m_physicalDevice, m_surface, &numPresentModes, nullptr);
+    presentModes.SetSize(numPresentModes);
+    m_api->vkGetPhysicalDeviceSurfacePresentModesKHR(m_api->m_physicalDevice, m_surface, &numPresentModes, presentModes.Buffer());
+
+    VkPresentModeKHR presentOptions[] = { VK_PRESENT_MODE_IMMEDIATE_KHR, VK_PRESENT_MODE_MAILBOX_KHR, VK_PRESENT_MODE_FIFO_KHR };
+    if (m_vsync)
+    {
+        presentOptions[0] = VK_PRESENT_MODE_FIFO_KHR;
+        presentOptions[1] = VK_PRESENT_MODE_IMMEDIATE_KHR;
+        presentOptions[2] = VK_PRESENT_MODE_MAILBOX_KHR;
+    }
+
+    for (int j = 0; j < 3; j++)
+    {
+        for (uint32_t i = 0; i < numPresentModes; i++)
+        {
+            if (presentModes[i] == presentOptions[j])
+            {
+                m_presentMode = presentOptions[j];
+                j = 3;
+                break;
+            }
+        }
+    }
+
+    VkSwapchainKHR oldSwapchain = nullptr;
+
+    VkSwapchainCreateInfoKHR swapchainDesc = {};
+    swapchainDesc.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+    swapchainDesc.surface = m_surface;
+    swapchainDesc.minImageCount = 3;
+    swapchainDesc.imageFormat = m_swapchainFormat;
+    swapchainDesc.imageColorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+    swapchainDesc.imageExtent = imageExtent;
+    swapchainDesc.imageArrayLayers = 1;
+    swapchainDesc.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    swapchainDesc.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    swapchainDesc.preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+    swapchainDesc.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+    swapchainDesc.presentMode = m_presentMode;
+    swapchainDesc.clipped = VK_TRUE;
+    swapchainDesc.oldSwapchain = oldSwapchain;
+
+    VkResult result = m_api->vkCreateSwapchainKHR(m_api->m_device, &swapchainDesc, nullptr, &m_swapChain);
+
+    if (result != VK_SUCCESS)
+    {
+        return SLANG_FAIL;
+    }
+
+    uint32_t numSwapChainImages = 0;
+    m_api->vkGetSwapchainImagesKHR(m_api->m_device, m_swapChain, &numSwapChainImages, nullptr);
+    if (numSwapChainImages > kMaxImages)
+    {
+        numSwapChainImages = kMaxImages;
+    }
+
+    m_api->vkGetSwapchainImagesKHR(m_api->m_device, m_swapChain, &numSwapChainImages, m_images);
+    m_numImages = int(numSwapChainImages);
+
+#if 0
+    for (NvFlowUint idx = 0; idx < ptr->numSwapchainImages; idx++)
+    {
+        NvFlowRenderTargetDescVulkan renderTargetDesc = {};
+        renderTargetDesc.texture = ptr->swapchainImages[idx];
+        renderTargetDesc.format = ptr->swapchainFormat;
+        renderTargetDesc.width = imageExtent.width;
+        renderTargetDesc.height = imageExtent.height;
+
+        ptr->renderTargets[idx] = NvFlowCreateRenderTargetExternalVulkan(ptr->deviceQueue->internalContext, &renderTargetDesc);
+    }
+
+    if (ptr->swapchain.desc.enableDepth)
+    {
+        NvFlowDepthBufferDesc depthBufferDesc = {};
+        depthBufferDesc.format_typeless = ptr->swapchain.desc.depthFormat_typeless;
+        depthBufferDesc.format_depth = ptr->swapchain.desc.depthFormat_depth;
+        depthBufferDesc.format_texture = ptr->swapchain.desc.depthFormat_texture;
+        depthBufferDesc.width = ptr->width;
+        depthBufferDesc.height = ptr->height;
+
+        ptr->depthBuffer = NvFlowCreateDepthBuffer(ptr->deviceQueue->internalContext, &depthBufferDesc);
+    }
+#endif
+
+    return SLANG_OK;
+}
+
+void VulkanSwapChain::destroySwapchain()
+{
+    m_deviceQueue->waitForIdle();
+
+#if 0
+    if (m_depthBuffer)
+    {
+        NvFlowDestroyDepthBuffer(ptr->deviceQueue->internalContext, ptr->depthBuffer);
+        ptr->depthBuffer = nullptr;
+    }
+
+    for (NvFlowUint idx = 0; idx < ptr->numSwapchainImages; idx++)
+    {
+        NvFlowDestroyRenderTarget(ptr->deviceQueue->internalContext, ptr->renderTargets[idx]);
+        ptr->renderTargets[idx] = VK_NULL_HANDLE;
+    }
+#endif
+
+    if (m_swapChain != VK_NULL_HANDLE)
+    {
+        m_api->vkDestroySwapchainKHR(m_api->m_device, m_swapChain, nullptr);
+        m_swapChain = VK_NULL_HANDLE;
+    }
+}
+
+VulkanSwapChain::~VulkanSwapChain()
+{
+    destroySwapchain();
+   
+    if (m_surface)
+    {
+        m_api->vkDestroySurfaceKHR(m_api->m_instance, m_surface, nullptr);
+        m_surface = VK_NULL_HANDLE;
+    }
+}
+
+TextureResource* VulkanSwapChain::getFrontRenderTargetVulkan()
+{
+    m_deviceQueue->m_currentBeginFrameSemaphore = m_deviceQueue->m_beginFrameSemaphore;
+
+    uint32_t swapChainIndex = 0;
+    VkResult result = m_api->vkAcquireNextImageKHR(m_api->m_device, m_swapChain, UINT64_MAX, m_deviceQueue->m_currentBeginFrameSemaphore, VK_NULL_HANDLE, &swapChainIndex);
+
+    if (result != VK_SUCCESS)
+    {
+        destroySwapchain();
+
+        //ptr->valid = NV_FLOW_FALSE;
+        return nullptr;
+    }
+    m_currentSwapChainIndex = int(swapChainIndex);
+
+    //return ptr->renderTargets[ptr->currentSwapchainIdx];
+    return nullptr;
+}
+
+void VulkanSwapChain::present(bool vsync)
+{
+#if 0
+    if (ptr->valid == NV_FLOW_FALSE)
+    {
+        NvFlowDeviceQueueFlush(&ptr->deviceQueue->deviceQueue);
+        return;
+    }
+#endif
+
+    m_deviceQueue->m_currentEndFrameSemaphore = m_deviceQueue->m_endFrameSemaphore;
+
+    m_deviceQueue->flushStepA();
+    
+    uint32_t swapChainIndices[] = { uint32_t(m_currentSwapChainIndex) };
+
+    VkPresentInfoKHR presentInfo = {};
+    presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+    presentInfo.swapchainCount = 1;
+    presentInfo.pSwapchains = &m_swapChain; 
+    presentInfo.pImageIndices = swapChainIndices;
+    presentInfo.waitSemaphoreCount = 1;
+    presentInfo.pWaitSemaphores = &m_deviceQueue->m_currentEndFrameSemaphore;
+
+    VkResult result = m_api->vkQueuePresentKHR(m_deviceQueue->m_graphicsQueue, &presentInfo);
+
+    m_deviceQueue->m_currentEndFrameSemaphore = VK_NULL_HANDLE;
+
+    m_deviceQueue->flushStepB();
+    
+#if 0
+    if (result != VK_SUCCESS || m_vsync != vsync)
+    {
+        m_vsync = vsync;
+        destroySwapchain();
+        ptr->valid = NV_FLOW_FALSE;
+    }
+#endif
+}
+
+
+
+} // renderer_test

--- a/tools/render-test/vk-swap-chain.cpp
+++ b/tools/render-test/vk-swap-chain.cpp
@@ -27,7 +27,7 @@ SlangResult VulkanSwapChain::init(VulkanDeviceQueue* deviceQueue, const Desc& de
     surfaceCreateInfo.hinstance = platformDesc->m_hinstance;
     surfaceCreateInfo.hwnd = platformDesc->m_hwnd;
 
-    m_api->vkCreateWin32SurfaceKHR(m_api->m_instance, &surfaceCreateInfo, nullptr, &m_surface);
+    SLANG_VK_RETURN_ON_FAIL(m_api->vkCreateWin32SurfaceKHR(m_api->m_instance, &surfaceCreateInfo, nullptr, &m_surface));
 #else
     const XPlatformDesc* platformDesc = static_cast<const XPlatformDesc*>(platformDescIn);
     _setPlatformDesc(*platformDesc);
@@ -37,7 +37,7 @@ SlangResult VulkanSwapChain::init(VulkanDeviceQueue* deviceQueue, const Desc& de
     surfaceCreateInfo.dpy = platformDesc->m_display; 
     surfaceCreateInfo.window = platformDesc->m_window;
     
-    m_api->vkCreateXlibSurfaceKHR(m_api->m_instance, &surfaceCreateInfo, nullptr, &m_surface);
+    SLANG_VK_RETURN_ON_FAIL(m_api->vkCreateXlibSurfaceKHR(m_api->m_instance, &surfaceCreateInfo, nullptr, &m_surface));
 #endif
 
     VkBool32 supported = false;
@@ -167,12 +167,7 @@ SlangResult VulkanSwapChain::initSwapchain()
     swapchainDesc.clipped = VK_TRUE;
     swapchainDesc.oldSwapchain = oldSwapchain;
 
-    VkResult result = m_api->vkCreateSwapchainKHR(m_api->m_device, &swapchainDesc, nullptr, &m_swapChain);
-
-    if (result != VK_SUCCESS)
-    {
-        return SLANG_FAIL;
-    }
+    SLANG_VK_RETURN_ON_FAIL(m_api->vkCreateSwapchainKHR(m_api->m_device, &swapchainDesc, nullptr, &m_swapChain));
 
     uint32_t numSwapChainImages = 0;
     m_api->vkGetSwapchainImagesKHR(m_api->m_device, m_swapChain, &numSwapChainImages, nullptr);

--- a/tools/render-test/vk-swap-chain.cpp
+++ b/tools/render-test/vk-swap-chain.cpp
@@ -71,7 +71,7 @@ SlangResult VulkanSwapChain::init(VulkanDeviceQueue* deviceQueue, const Desc& de
 
     // Look for a suitable format
     List<VkFormat> formats;
-    formats.Add(VulkanUtil::calcVkFormat(desc.m_format));
+    formats.Add(VulkanUtil::getVkFormat(desc.m_format));
     // HACK! To check for a different format if couldn't be found
     if (descIn.m_format == Format::RGBA_Unorm_UInt8)
     {
@@ -305,30 +305,6 @@ SlangResult VulkanSwapChain::_createSwapChain()
             SLANG_VK_RETURN_ON_FAIL(m_api->vkCreateImageView(m_api->m_device, &createInfo, nullptr, &image.m_imageView));
         }
     }
-#if 0
-    for (int i = 0; i < int(m_images.Count()); ++i)
-    {
-        RenderTargetDescVulkan renderTargetDesc = {};
-        renderTargetDesc.texture = ptr->swapchainImages[idx];
-        renderTargetDesc.format = ptr->swapchainFormat;
-        renderTargetDesc.width = imageExtent.width;
-        renderTargetDesc.height = imageExtent.height;
-
-        ptr->renderTargets[idx] = CreateRenderTargetExternalVulkan(ptr->deviceQueue->internalContext, &renderTargetDesc);
-    }
-
-    if (ptr->swapchain.desc.enableDepth)
-    {
-        DepthBufferDesc depthBufferDesc = {};
-        depthBufferDesc.format_typeless = ptr->swapchain.desc.depthFormat_typeless;
-        depthBufferDesc.format_depth = ptr->swapchain.desc.depthFormat_depth;
-        depthBufferDesc.format_texture = ptr->swapchain.desc.depthFormat_texture;
-        depthBufferDesc.width = ptr->width;
-        depthBufferDesc.height = ptr->height;
-
-        ptr->depthBuffer = CreateDepthBuffer(ptr->deviceQueue->internalContext, &depthBufferDesc);
-    }
-#endif
 
     if (m_renderPass != VK_NULL_HANDLE)
     {
@@ -362,27 +338,12 @@ void VulkanSwapChain::_destroySwapChain()
         }
     }
 
-#if 0
-    if (m_depthBuffer)
-    {
-        NvFlowDestroyDepthBuffer(ptr->deviceQueue->internalContext, ptr->depthBuffer);
-        ptr->depthBuffer = nullptr;
-    }
-
-    for (NvFlowUint idx = 0; idx < ptr->numSwapchainImages; idx++)
-    {
-        NvFlowDestroyRenderTarget(ptr->deviceQueue->internalContext, ptr->renderTargets[idx]);
-        ptr->renderTargets[idx] = VK_NULL_HANDLE;
-    }
-#endif
-
     if (m_swapChain != VK_NULL_HANDLE)
     {
         m_api->vkDestroySwapchainKHR(m_api->m_device, m_swapChain, nullptr);
         m_swapChain = VK_NULL_HANDLE;
     }
 
-    
     // Mark that it is no longer used
     m_images.Clear();
 }
@@ -426,7 +387,7 @@ void VulkanSwapChain::present(bool vsync)
 {
     if (!hasValidSwapChain())
     {
-        m_deviceQueue->flushStep();
+        m_deviceQueue->flush();
         return;
     }
 

--- a/tools/render-test/vk-swap-chain.cpp
+++ b/tools/render-test/vk-swap-chain.cpp
@@ -1,6 +1,8 @@
 // vk-swap-chain.cpp
 #include "vk-swap-chain.h"
 
+#include "vk-util.h"
+
 #include "../../source/core/list.h"
 
 #include <stdlib.h>
@@ -47,7 +49,11 @@ SlangResult VulkanSwapChain::init(VulkanDeviceQueue* deviceQueue, const Desc& de
     surfaceFormats.SetSize(int(numSurfaceFormats));
     m_api->vkGetPhysicalDeviceSurfaceFormatsKHR(m_api->m_physicalDevice, m_surface, &numSurfaceFormats, surfaceFormats.Buffer());
 
-    //m_swapchainFormat = NvFlowVulkan_convertToVulkan(ptr->swapchain.desc.format);
+    m_swapchainFormat = VulkanUtil::calcVkFormat(desc.m_format);
+    if (m_swapchainFormat == VK_FORMAT_UNDEFINED)
+    {
+        return SLANG_FAIL;
+    }
 
     /*
     // try to find BGR, fall back to RGB

--- a/tools/render-test/vk-swap-chain.h
+++ b/tools/render-test/vk-swap-chain.h
@@ -53,6 +53,14 @@ struct VulkanSwapChain
         Format m_textureDepthFormat;
     };
 
+    struct Image
+    {
+        VkImage m_image = VK_NULL_HANDLE;
+        VkImageView m_imageView = VK_NULL_HANDLE;
+        VkFramebuffer m_frameBuffer = VK_NULL_HANDLE;
+    };
+
+
         /// Must be called before the swap chain can be used
     SlangResult init(VulkanDeviceQueue* deviceQueue, const Desc& desc, const PlatformDesc* platformDesc);
 
@@ -80,20 +88,18 @@ struct VulkanSwapChain
         /// Get the height of the back buffer
     int getHeight() const { return m_height; }
 
-    TextureResource* getFrontRenderTarget();
+        /// Get the detail about the images
+    const Slang::List<Image>& getImages() const { return m_images; }
+
+        /// Get the next front render image index. Returns -1, if image couldn't be found
+    int nextFrontImageIndex();
 
         /// Dtor
     ~VulkanSwapChain();
 
     protected:
 
-    struct Image
-    {
-        VkImage m_image = VK_NULL_HANDLE;
-        VkImageView m_imageView = VK_NULL_HANDLE;
-        VkFramebuffer m_frameBuffer = VK_NULL_HANDLE;
-    };
-
+    
     template <typename T>
     void _setPlatformDesc(const T& desc)
     {

--- a/tools/render-test/vk-swap-chain.h
+++ b/tools/render-test/vk-swap-chain.h
@@ -17,6 +17,7 @@ struct VulkanSwapChain
         kMaxImages = 8,
     };
 
+        /// Base class for platform specific information
     struct PlatformDesc
     {
     };

--- a/tools/render-test/vk-swap-chain.h
+++ b/tools/render-test/vk-swap-chain.h
@@ -56,6 +56,9 @@ struct VulkanSwapChain
         /// Must be called before the swap chain can be used
     SlangResult init(VulkanDeviceQueue* deviceQueue, const Desc& desc, const PlatformDesc* platformDesc);
 
+        /// 
+    SlangResult createFrameBuffers(VkRenderPass renderPass);
+
         /// Returned the desc used to construct the swap chain. 
         /// Is invalid if init hasn't returned with successful result.
     const Desc& getDesc() const { return m_desc; }
@@ -69,6 +72,9 @@ struct VulkanSwapChain
         /// Get the current size of the window (in pixels written to widthOut, heightOut)
     void getWindowSize(int* widthOut, int* heightOut) const;
 
+        /// Get the VkFormat for the back buffer
+    VkFormat getVkFormat() const { return m_format; }
+
     TextureResource* getFrontRenderTarget();
 
         /// Dtor
@@ -80,6 +86,7 @@ struct VulkanSwapChain
     {
         VkImage m_image = VK_NULL_HANDLE;
         VkImageView m_imageView = VK_NULL_HANDLE;
+        VkFramebuffer m_frameBuffer = VK_NULL_HANDLE;
     };
 
     template <typename T>
@@ -94,6 +101,8 @@ struct VulkanSwapChain
     const T* _getPlatformDesc() const { return static_cast<const T*>((const PlatformDesc*)m_platformDescBuffer.Buffer()); }
     SlangResult _createSwapChain();
     void _destroySwapChain();
+    SlangResult _createFrameBuffers(VkRenderPass renderPass);
+    void _destroyFrameBuffers();
 
     bool m_vsync = true;
     int m_width = 0;
@@ -104,6 +113,8 @@ struct VulkanSwapChain
 
     VkSurfaceKHR m_surface = VK_NULL_HANDLE;
     VkSwapchainKHR m_swapChain = VK_NULL_HANDLE;
+
+    VkRenderPass m_renderPass = VK_NULL_HANDLE;             //< Not owned
 
     int m_currentSwapChainIndex = 0;
 

--- a/tools/render-test/vk-swap-chain.h
+++ b/tools/render-test/vk-swap-chain.h
@@ -56,7 +56,7 @@ struct VulkanSwapChain
         /// Must be called before the swap chain can be used
     SlangResult init(VulkanDeviceQueue* deviceQueue, const Desc& desc, const PlatformDesc* platformDesc);
 
-        /// 
+        /// Create the frame buffers (they must be compatible with the supplied renderPass)
     SlangResult createFrameBuffers(VkRenderPass renderPass);
 
         /// Returned the desc used to construct the swap chain. 
@@ -74,6 +74,11 @@ struct VulkanSwapChain
 
         /// Get the VkFormat for the back buffer
     VkFormat getVkFormat() const { return m_format; }
+
+        /// Get width of the back buffers
+    int getWidth() const { return m_width; }
+        /// Get the height of the back buffer
+    int getHeight() const { return m_height; }
 
     TextureResource* getFrontRenderTarget();
 
@@ -109,7 +114,7 @@ struct VulkanSwapChain
     int m_height = 0;
 
     VkPresentModeKHR m_presentMode = VK_PRESENT_MODE_IMMEDIATE_KHR;
-    VkFormat m_format = VK_FORMAT_B8G8R8A8_UNORM;
+    VkFormat m_format = VK_FORMAT_UNDEFINED;                ///< The format used for backbuffer. Valid after successful init.
 
     VkSurfaceKHR m_surface = VK_NULL_HANDLE;
     VkSwapchainKHR m_swapChain = VK_NULL_HANDLE;
@@ -119,9 +124,6 @@ struct VulkanSwapChain
     int m_currentSwapChainIndex = 0;
 
     Slang::List<Image> m_images;              
-
-    //RenderTarget*	m_renderTargets[kMaxImages] = {};
-    //DepthBuffer* m_depthBuffer = nullptr;
 
     VulkanDeviceQueue* m_deviceQueue = nullptr;
     const VulkanApi* m_api = nullptr;

--- a/tools/render-test/vk-swap-chain.h
+++ b/tools/render-test/vk-swap-chain.h
@@ -38,8 +38,16 @@ struct VulkanSwapChain
 
     struct Desc
     {
+        void init()
+        {
+            m_format = Format::Unknown;
+            m_depthFormatTypeless = Format::Unknown;
+            m_depthFormat = Format::Unknown;
+            m_textureDepthFormat = Format::Unknown;
+        }
+
         Format m_format;
-        bool m_enableFormat;
+        //bool m_enableFormat;
         Format m_depthFormatTypeless;
         Format m_depthFormat;
         Format m_textureDepthFormat;

--- a/tools/render-test/vk-swap-chain.h
+++ b/tools/render-test/vk-swap-chain.h
@@ -12,10 +12,10 @@ namespace renderer_test {
 
 struct VulkanSwapChain
 {
-    enum 
+    /* enum 
     {
         kMaxImages = 8,
-    };
+    }; */
 
         /// Base class for platform specific information
     struct PlatformDesc
@@ -53,21 +53,35 @@ struct VulkanSwapChain
         Format m_textureDepthFormat;
     };
 
+        /// Must be called before the swap chain can be used
     SlangResult init(VulkanDeviceQueue* deviceQueue, const Desc& desc, const PlatformDesc* platformDesc);
 
-    SlangResult initSwapchain();
+        /// Returned the desc used to construct the swap chain. 
+        /// Is invalid if init hasn't returned with successful result.
+    const Desc& getDesc() const { return m_desc; }
 
+        /// True if the swap chain is available
+    bool hasValidSwapChain() const { return m_images.Count() > 0; }
+
+        /// Present to the display
     void present(bool vsync);
 
-    void destroySwapchain();
-
+        /// Get the current size of the window (in pixels written to widthOut, heightOut)
     void getWindowSize(int* widthOut, int* heightOut) const;
 
-    TextureResource* getFrontRenderTargetVulkan();
+    TextureResource* getFrontRenderTarget();
 
+        /// Dtor
     ~VulkanSwapChain();
 
     protected:
+
+    struct Image
+    {
+        VkImage m_image = VK_NULL_HANDLE;
+        VkImageView m_imageView = VK_NULL_HANDLE;
+    };
+
     template <typename T>
     void _setPlatformDesc(const T& desc)
     {
@@ -78,28 +92,31 @@ struct VulkanSwapChain
     }
     template <typename T>
     const T* _getPlatformDesc() const { return static_cast<const T*>((const PlatformDesc*)m_platformDescBuffer.Buffer()); }
+    SlangResult _createSwapChain();
+    void _destroySwapChain();
 
     bool m_vsync = true;
     int m_width = 0;
     int m_height = 0;
 
     VkPresentModeKHR m_presentMode = VK_PRESENT_MODE_IMMEDIATE_KHR;
-    VkFormat m_swapchainFormat = VK_FORMAT_B8G8R8A8_UNORM;
+    VkFormat m_format = VK_FORMAT_B8G8R8A8_UNORM;
 
     VkSurfaceKHR m_surface = VK_NULL_HANDLE;
     VkSwapchainKHR m_swapChain = VK_NULL_HANDLE;
 
-    int m_numImages = 0;
-    VkImage m_images[kMaxImages] = { VK_NULL_HANDLE };
     int m_currentSwapChainIndex = 0;
 
-    //NvFlowRenderTarget*	m_renderTargets[kMaxImages] = {};
-    //NvFlowDepthBuffer* m_depthBuffer = nullptr;
+    Slang::List<Image> m_images;              
+
+    //RenderTarget*	m_renderTargets[kMaxImages] = {};
+    //DepthBuffer* m_depthBuffer = nullptr;
 
     VulkanDeviceQueue* m_deviceQueue = nullptr;
     const VulkanApi* m_api = nullptr;
 
-    Slang::List<void*> m_platformDescBuffer;
+    Desc m_desc;                                            ///< The desc used to init this swap chain
+    Slang::List<void*> m_platformDescBuffer;                ///< Buffer to hold the platform specific description parameters (as passed in platformDesc)
 };
 
 } // renderer_test

--- a/tools/render-test/vk-util.cpp
+++ b/tools/render-test/vk-util.cpp
@@ -15,6 +15,10 @@ namespace renderer_test {
         case Format::RG_Float32:        return VK_FORMAT_R32G32_SFLOAT;
         case Format::R_Float32:         return VK_FORMAT_R32_SFLOAT;
         case Format::RGBA_Unorm_UInt8:  return VK_FORMAT_R8G8B8A8_UNORM;
+
+        case Format::D_Float32:         return VK_FORMAT_D32_SFLOAT;
+        case Format::D_Unorm24_S8:      return VK_FORMAT_D24_UNORM_S8_UINT;
+
         default:                        return VK_FORMAT_UNDEFINED;
     }
 }

--- a/tools/render-test/vk-util.cpp
+++ b/tools/render-test/vk-util.cpp
@@ -1,0 +1,22 @@
+// vk-util.cpp
+#include "vk-util.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+namespace renderer_test {
+
+/* static */VkFormat VulkanUtil::calcVkFormat(Format format)
+{
+    switch (format)
+    {
+        case Format::RGBA_Float32:      return VK_FORMAT_R32G32B32A32_SFLOAT;
+        case Format::RGB_Float32:       return VK_FORMAT_R32G32B32_SFLOAT;
+        case Format::RG_Float32:        return VK_FORMAT_R32G32_SFLOAT;
+        case Format::R_Float32:         return VK_FORMAT_R32_SFLOAT;
+        case Format::RGBA_Unorm_UInt8:  return VK_FORMAT_R8G8B8A8_UNORM;
+        default:                        return VK_FORMAT_UNDEFINED;
+    }
+}
+
+} // renderer_test

--- a/tools/render-test/vk-util.cpp
+++ b/tools/render-test/vk-util.cpp
@@ -41,6 +41,18 @@ namespace renderer_test {
 {
     assert(res != VK_SUCCESS);
     assert(!"Vulkan check failed");
+
+}
+
+/* static */VkPrimitiveTopology VulkanUtil::calcVkPrimitiveTopology(PrimitiveTopology topology)
+{
+    switch (topology)
+    {
+        case PrimitiveTopology::TriangleList:       return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+        default: break;
+    }
+    assert(!"Unknown topology");
+    return VK_PRIMITIVE_TOPOLOGY_MAX_ENUM;
 }
 
 } // renderer_test

--- a/tools/render-test/vk-util.cpp
+++ b/tools/render-test/vk-util.cpp
@@ -6,7 +6,7 @@
 
 namespace renderer_test {
 
-/* static */VkFormat VulkanUtil::calcVkFormat(Format format)
+/* static */VkFormat VulkanUtil::getVkFormat(Format format)
 {
     switch (format)
     {
@@ -44,7 +44,7 @@ namespace renderer_test {
 
 }
 
-/* static */VkPrimitiveTopology VulkanUtil::calcVkPrimitiveTopology(PrimitiveTopology topology)
+/* static */VkPrimitiveTopology VulkanUtil::getVkPrimitiveTopology(PrimitiveTopology topology)
 {
     switch (topology)
     {

--- a/tools/render-test/vk-util.cpp
+++ b/tools/render-test/vk-util.cpp
@@ -19,4 +19,24 @@ namespace renderer_test {
     }
 }
 
+/* static */SlangResult VulkanUtil::toSlangResult(VkResult res)
+{
+    return (res == VK_SUCCESS) ? SLANG_OK : SLANG_FAIL;
+}
+
+/* static */Slang::Result VulkanUtil::handleFail(VkResult res)
+{
+    if (res != VK_SUCCESS)
+    {
+        assert(!"Vulkan returned a failure");
+    }
+    return toSlangResult(res);
+}
+
+/* static */void VulkanUtil::checkFail(VkResult res)
+{
+    assert(res != VK_SUCCESS);
+    assert(!"Vulkan check failed");
+}
+
 } // renderer_test

--- a/tools/render-test/vk-util.h
+++ b/tools/render-test/vk-util.h
@@ -4,8 +4,13 @@
 #include "vk-api.h"
 #include "render.h"
 
+// Macros to make testing vulkan return codes simpler
+
+/// SLANG_VK_RETURN_ON_FAIL can be used in a similar way to SLANG_RETURN_ON_FAIL macro, except it will turn a vulkan failure into Slang::Result in the process
+/// Calls handleFail which on debug builds asserts
 #define SLANG_VK_RETURN_ON_FAIL(x) { VkResult _res = x; if (_res != VK_SUCCESS) { return VulkanUtil::handleFail(_res); }  }
 
+/// Is similar to SLANG_VK_RETURN_ON_FAIL, but does not return. Will call checkFail on failure - which asserts on debug builds. 
 #define SLANG_VK_CHECK(x) {  VkResult _res = x; if (_res != VK_SUCCESS) { VulkanUtil::checkFail(_res); }  } 
     
 namespace renderer_test {
@@ -13,17 +18,21 @@ namespace renderer_test {
 // Utility functions for Vulkan
 struct VulkanUtil
 {
-        /// Calculate the VkFormat from the renderer format
-    static VkFormat calcVkFormat(Format format);
-        /// Handles a failure
+        /// Get the equivalent VkFormat from the format
+        /// Returns VK_FORMAT_UNDEFINED if a match is not found
+    static VkFormat getVkFormat(Format format);
+
+        /// Called by SLANG_VK_RETURN_FAIL if a res is a failure. 
+        /// On debug builds this will cause an assertion on failure.
     static Slang::Result handleFail(VkResult res);
-
-    static VkPrimitiveTopology calcVkPrimitiveTopology(PrimitiveTopology topology);
-
-        /// Called when a failure has occured with SLANG_VK_CHECK - will typically assert.
+        /// Called when a failure has occurred with SLANG_VK_CHECK - will typically assert.
     static void checkFail(VkResult res);
 
-        /// Returns a vulkan result into a Slang::Result
+        /// Get the VkPrimitiveTopology for the given topology. 
+        /// Returns VK_PRIMITIVE_TOPOLOGY_MAX_ENUM on failure
+    static VkPrimitiveTopology getVkPrimitiveTopology(PrimitiveTopology topology);
+
+        /// Returns Slang::Result equivalent of a VkResult 
     static Slang::Result toSlangResult(VkResult res);
 };
 

--- a/tools/render-test/vk-util.h
+++ b/tools/render-test/vk-util.h
@@ -4,6 +4,10 @@
 #include "vk-api.h"
 #include "render.h"
 
+#define SLANG_VK_RETURN_ON_FAIL(x) { VkResult _res = x; if (_res != VK_SUCCESS) { return VulkanUtil::handleFail(_res); }  }
+
+#define SLANG_VK_CHECK(x) {  VkResult _res = x; if (_res != VK_SUCCESS) { VulkanUtil::checkFail(_res); }  } 
+    
 namespace renderer_test {
 
 // Utility functions for Vulkan
@@ -11,6 +15,13 @@ struct VulkanUtil
 {
         /// Calculate the VkFormat from the renderer format
     static VkFormat calcVkFormat(Format format);
+        /// Handles a failure
+    static Slang::Result handleFail(VkResult res);
+
+    static void checkFail(VkResult res);
+
+        /// Returns a vulkan result into a Slang::Result
+    static Slang::Result toSlangResult(VkResult res);
 };
 
 } // renderer_test

--- a/tools/render-test/vk-util.h
+++ b/tools/render-test/vk-util.h
@@ -18,6 +18,7 @@ struct VulkanUtil
         /// Handles a failure
     static Slang::Result handleFail(VkResult res);
 
+        /// Called when a failure has occured with SLANG_VK_CHECK - will typically assert.
     static void checkFail(VkResult res);
 
         /// Returns a vulkan result into a Slang::Result

--- a/tools/render-test/vk-util.h
+++ b/tools/render-test/vk-util.h
@@ -18,6 +18,8 @@ struct VulkanUtil
         /// Handles a failure
     static Slang::Result handleFail(VkResult res);
 
+    static VkPrimitiveTopology calcVkPrimitiveTopology(PrimitiveTopology topology);
+
         /// Called when a failure has occured with SLANG_VK_CHECK - will typically assert.
     static void checkFail(VkResult res);
 

--- a/tools/render-test/vk-util.h
+++ b/tools/render-test/vk-util.h
@@ -1,0 +1,16 @@
+// vk-util.h
+#pragma once
+
+#include "vk-api.h"
+#include "render.h"
+
+namespace renderer_test {
+
+// Utility functions for Vulkan
+struct VulkanUtil
+{
+        /// Calculate the VkFormat from the renderer format
+    static VkFormat calcVkFormat(Format format);
+};
+
+} // renderer_test


### PR DESCRIPTION
First pass at getting Vulkan Renderer rendering to work. With this check in - the render0 test works and renders a triangle. Currently does not support textures, or screen capture. Pipeline construction/binding is semi combined, and needs better separation.

* VulkanApi - encapsulates getting function pointers (and common state - device etc), and separates dependency from VKRenderer
* VulkanSwapChain - encapsulates and manages a swap chain
* VulkanDeviceQueue - encapsulates management/sync of work  
* Removed binding of constant buffers, as can be done through the BindingState (removes previous binding ambiguity)
* Simple calculation of 'identity' projection so that all renderers match

