### PR TITLE
Pass through original names for most declarations

### DIFF
--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -121,6 +121,17 @@ struct IRInterpolationModeDecoration : IRDecoration
     IRInterpolationMode mode;
 };
 
+/// A decoration that provides a desired name to be used
+/// in conjunction with the given instruction. Back-end
+/// code generation may use this to help derive symbol
+/// names, emit debug information, etc.
+struct IRNameHintDecoration : IRDecoration
+{
+    enum { kDecorationOp = kIRDecorationOp_NameHint };
+
+    Name* name;
+};
+
 //
 
 // An IR node to represent a reference to an AST-level

--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -4713,6 +4713,14 @@ namespace Slang
                 }
                 break;
 
+            case kIRDecorationOp_NameHint:
+                {
+                    auto originalDecoration = (IRNameHintDecoration*)dd;
+                    auto newDecoration = context->builder->addDecoration<IRNameHintDecoration>(clonedValue);
+                    newDecoration->name = originalDecoration->name;
+                }
+                break;
+
             default:
                 // Don't clone any decorations we don't understand.
                 break;

--- a/source/slang/ir.h
+++ b/source/slang/ir.h
@@ -125,6 +125,7 @@ enum IRDecorationOp : uint16_t
     kIRDecorationOp_GLSLOuterArray,
     kIRDecorationOp_Semantic,
     kIRDecorationOp_InterpolationMode,
+    kIRDecorationOp_NameHint,
 };
 
 // represents an object allocated in an IR memory pool

--- a/source/slang/legalize-types.cpp
+++ b/source/slang/legalize-types.cpp
@@ -341,6 +341,11 @@ struct TupleTypeBuilder
             ordinaryStructType->sourceLoc = originalStructType->sourceLoc;
             ordinaryStructType->mangledName = originalStructType->mangledName;
 
+            if(auto nameHintDecoration = originalStructType->findDecoration<IRNameHintDecoration>())
+            {
+                builder->addDecoration<IRNameHintDecoration>(ordinaryStructType)->name = nameHintDecoration->name;
+            }
+
             // The new struct type will appear right after the original in the IR,
             // so that we can be sure any instruction that could reference the
             // original can also reference the new one.

--- a/tests/bindings/array-of-struct-of-resource.hlsl
+++ b/tests/bindings/array-of-struct-of-resource.hlsl
@@ -27,9 +27,9 @@ float4 main() : SV_Target
 
 #else
 
-#define a _SV04testL0
-#define b _SV04testL1
-#define s _SV01s
+#define a test_a_0
+#define b test_b_0
+#define s s_0
 
 Texture2D a[2];
 Texture2D b[2];

--- a/tests/bindings/binding0.hlsl
+++ b/tests/bindings/binding0.hlsl
@@ -9,10 +9,10 @@
 #else
 #define R(X) X
 
-#define C _SV022SLANG_parameterGroup_C
-#define t _SV01t
-#define s _SV01s
-#define c _SV022SLANG_ParameterGroup_C1c
+#define C C_0
+#define t t_0
+#define s s_0
+#define c c_0
 
 #endif
 

--- a/tests/bindings/binding1.hlsl
+++ b/tests/bindings/binding1.hlsl
@@ -16,11 +16,11 @@
 #else
 #define R(X) X
 
-#define tB _SV02tB
-#define sB _SV02sB
+#define tB tB_0
+#define sB sB_0
 
-#define C1 _SV023SLANG_parameterGroup_C1
-#define c1 _SV023SLANG_ParameterGroup_C12c1
+#define C1 C1_0
+#define c1 c1_0
 
 #endif
 

--- a/tests/bindings/explicit-binding.hlsl
+++ b/tests/bindings/explicit-binding.hlsl
@@ -8,22 +8,22 @@
 #else
 #define R(X) X
 
-#define CA _SV023SLANG_parameterGroup_CA
-#define ca _SV023SLANG_ParameterGroup_CA2ca
+#define CA CA_0
+#define ca ca_0
 
-#define CB _SV023SLANG_parameterGroup_CB
-#define cb _SV023SLANG_ParameterGroup_CB2cb
+#define CB CB_0
+#define cb cb_0
 
-#define CC _SV023SLANG_parameterGroup_CC
-#define cc _SV023SLANG_ParameterGroup_CC2cc
+#define CC CC_0
+#define cc cc_0
 
-#define sa _SV02sa
-#define sb _SV02sb
-#define sc _SV02sc
+#define sa sa_0
+#define sb sb_0
+#define sc sc_0
 
-#define ta _SV02ta
-#define tb _SV02tb
-#define tc _SV02tc
+#define ta ta_0
+#define tb tb_0
+#define tc tc_0
 
 #endif
 

--- a/tests/bindings/glsl-parameter-blocks.slang.glsl
+++ b/tests/bindings/glsl-parameter-blocks.slang.glsl
@@ -1,12 +1,12 @@
 //TEST_IGNORE_FILE:
 #version 450 core
 
-#define Test _ST04Test
-#define a _SV04Test1a
+#define Test Test_0
+#define a a_0
 
-#define gTest _SV05gTestL0
-#define gTest_t _SV05gTestL1
-#define gTest_s _SV05gTestL2
+#define gTest gTest_0
+#define gTest_t gTest_t_0
+#define gTest_s gTest_s_0
 
 #define ParameterBlock_gTest _S1
 

--- a/tests/bindings/multi-file-extra.hlsl
+++ b/tests/bindings/multi-file-extra.hlsl
@@ -10,34 +10,34 @@
 #else
 #define R(X) X
 
-#define sharedC     _SV028SLANG_parameterGroup_sharedC
-#define sharedCA    _SV028SLANG_ParameterGroup_sharedC8sharedCA
-#define sharedCB    _SV028SLANG_ParameterGroup_sharedC8sharedCB
-#define sharedCC    _SV028SLANG_ParameterGroup_sharedC8sharedCC
-#define sharedCD    _SV028SLANG_ParameterGroup_sharedC8sharedCD
+#define sharedC     sharedC_0
+#define sharedCA    sharedCA_0
+#define sharedCB    sharedCB_0
+#define sharedCC    sharedCC_0
+#define sharedCD    sharedCD_0
 
-#define vertexC     _SV028SLANG_parameterGroup_vertexC
-#define vertexCA    _SV028SLANG_ParameterGroup_vertexC8vertexCA
-#define vertexCB    _SV028SLANG_ParameterGroup_vertexC8vertexCB
-#define vertexCC    _SV028SLANG_ParameterGroup_vertexC8vertexCC
-#define vertexCD    _SV028SLANG_ParameterGroup_vertexC8vertexCD
+#define vertexC     vertexC_0
+#define vertexCA    vertexCA_0
+#define vertexCB    vertexCB_0
+#define vertexCC    vertexCC_0
+#define vertexCD    vertexCD_0
 
-#define fragmentC   _SV030SLANG_parameterGroup_fragmentC
-#define fragmentCA  _SV030SLANG_ParameterGroup_fragmentC10fragmentCA
-#define fragmentCB  _SV030SLANG_ParameterGroup_fragmentC10fragmentCB
-#define fragmentCC  _SV030SLANG_ParameterGroup_fragmentC10fragmentCC
-#define fragmentCD  _SV030SLANG_ParameterGroup_fragmentC10fragmentCD
+#define fragmentC   fragmentC_0
+#define fragmentCA  fragmentCA_0
+#define fragmentCB  fragmentCB_0
+#define fragmentCC  fragmentCC_0
+#define fragmentCD  fragmentCD_0
 
-#define sharedS     _SV07sharedS
-#define sharedT     _SV07sharedT
-#define sharedTV    _SV08sharedTV
-#define sharedTF    _SV08sharedTF
+#define sharedS     sharedS_0
+#define sharedT     sharedT_0
+#define sharedTV    sharedTV_0
+#define sharedTF    sharedTF_0
 
-#define vertexS     _SV07vertexS
-#define vertexT     _SV07vertexT
+#define vertexS     vertexS_0
+#define vertexT     vertexT_0
 
-#define fragmentS     _SV09fragmentS
-#define fragmentT     _SV09fragmentT
+#define fragmentS     fragmentS_0
+#define fragmentT     fragmentT_0
 
 #endif
 

--- a/tests/bindings/multi-file.hlsl
+++ b/tests/bindings/multi-file.hlsl
@@ -11,34 +11,34 @@
 #else
 #define R(X) X
 
-#define sharedC     _SV028SLANG_parameterGroup_sharedC
-#define sharedCA    _SV028SLANG_ParameterGroup_sharedC8sharedCA
-#define sharedCB    _SV028SLANG_ParameterGroup_sharedC8sharedCB
-#define sharedCC    _SV028SLANG_ParameterGroup_sharedC8sharedCC
-#define sharedCD    _SV028SLANG_ParameterGroup_sharedC8sharedCD
+#define sharedC     sharedC_0
+#define sharedCA    sharedCA_0
+#define sharedCB    sharedCB_0
+#define sharedCC    sharedCC_0
+#define sharedCD    sharedCD_0
 
-#define vertexC     _SV028SLANG_parameterGroup_vertexC
-#define vertexCA    _SV028SLANG_ParameterGroup_vertexC8vertexCA
-#define vertexCB    _SV028SLANG_ParameterGroup_vertexC8vertexCB
-#define vertexCC    _SV028SLANG_ParameterGroup_vertexC8vertexCC
-#define vertexCD    _SV028SLANG_ParameterGroup_vertexC8vertexCD
+#define vertexC     vertexC_0
+#define vertexCA    vertexCA_0
+#define vertexCB    vertexCB_0
+#define vertexCC    vertexCC_0
+#define vertexCD    vertexCD_0
 
-#define fragmentC   _SV030SLANG_parameterGroup_fragmentC
-#define fragmentCA  _SV030SLANG_ParameterGroup_fragmentC10fragmentCA
-#define fragmentCB  _SV030SLANG_ParameterGroup_fragmentC10fragmentCB
-#define fragmentCC  _SV030SLANG_ParameterGroup_fragmentC10fragmentCC
-#define fragmentCD  _SV030SLANG_ParameterGroup_fragmentC10fragmentCD
+#define fragmentC   fragmentC_0
+#define fragmentCA  fragmentCA_0
+#define fragmentCB  fragmentCB_0
+#define fragmentCC  fragmentCC_0
+#define fragmentCD  fragmentCD_0
 
-#define sharedS     _SV07sharedS
-#define sharedT     _SV07sharedT
-#define sharedTV    _SV08sharedTV
-#define sharedTF    _SV08sharedTF
+#define sharedS     sharedS_0
+#define sharedT     sharedT_0
+#define sharedTV    sharedTV_0
+#define sharedTF    sharedTF_0
 
-#define vertexS     _SV07vertexS
-#define vertexT     _SV07vertexT
+#define vertexS     vertexS_0
+#define vertexT     vertexT_0
 
-#define fragmentS     _SV09fragmentS
-#define fragmentT     _SV09fragmentT
+#define fragmentS     fragmentS_0
+#define fragmentT     fragmentT_0
 
 #endif
 

--- a/tests/bindings/multiple-parameter-blocks.slang
+++ b/tests/bindings/multiple-parameter-blocks.slang
@@ -29,20 +29,20 @@ float4 main(float v : V) : SV_Target
 
 #else
 
-Texture2D _SV01pL0 : register(t0, space0);
-Texture2D _SV01pL1[4] : register(t1, space0);
-SamplerState _SV01pL2 : register(s0, space0);
+Texture2D p_t_0 : register(t0, space0);
+Texture2D p_ta_0[4] : register(t1, space0);
+SamplerState p_s_0 : register(s0, space0);
 
-Texture2D _SV02p1L0 : register(t0, space1);
-Texture2D _SV02p1L1[4] : register(t1, space1);
-SamplerState _SV02p1L2 : register(s0, space1);
+Texture2D p1_t_0 : register(t0, space1);
+Texture2D p1_ta_0[4] : register(t1, space1);
+SamplerState p1_s_0 : register(s0, space1);
 
 float4 main(float v : V) : SV_TARGET
 {
-	return use(_SV01pL0,          _SV01pL2)
-		 + use(_SV01pL1[int(v)],  _SV01pL2)
-		 + use(_SV02p1L0,         _SV02p1L2)
-		 + use(_SV02p1L1[int(v)], _SV02p1L2);
+	return use(p_t_0,         	p_s_0)
+		 + use(p_ta_0[int(v)],  p_s_0)
+		 + use(p1_t_0,         	p1_s_0)
+		 + use(p1_ta_0[int(v)], p1_s_0);
 }
 
 #endif

--- a/tests/bindings/packoffset.hlsl
+++ b/tests/bindings/packoffset.hlsl
@@ -8,15 +8,15 @@
 #else
 #define R(X) X
 
-#define CA _SV023SLANG_parameterGroup_CAL0
-#define ca _SV023SLANG_ParameterGroup_CA2ca
-#define cb _SV023SLANG_ParameterGroup_CA2cb
-#define cc _SV023SLANG_ParameterGroup_CA2cc
-#define cd _SV023SLANG_ParameterGroup_CA2cd
-#define ce _SV023SLANG_ParameterGroup_CA2ce
+#define CA CA_0
+#define ca ca_0
+#define cb cb_0
+#define cc cc_0
+#define cd cd_0
+#define ce ce_0
 
-#define ta _SV023SLANG_parameterGroup_CAL1
-#define sa _SV023SLANG_parameterGroup_CAL2
+#define ta CA_ta_0
+#define sa CA_sa_0
 
 #endif
 

--- a/tests/bindings/parameter-blocks.slang
+++ b/tests/bindings/parameter-blocks.slang
@@ -26,9 +26,9 @@ float4 main(float v : V) : SV_Target
 
 #else
 
-#define t _SV01pL0
-#define ta _SV01pL1
-#define s _SV01pL2
+#define t p_t_0
+#define ta p_ta_0
+#define s p_s_0
 
 Texture2D t : register(t0, space0);
 Texture2D ta[4] : register(t1, space0);

--- a/tests/bindings/resources-in-cbuffer.hlsl
+++ b/tests/bindings/resources-in-cbuffer.hlsl
@@ -9,34 +9,34 @@
 #else
 #define R(X) X
 
-#define CA _SV023SLANG_parameterGroup_CAL0
-#define caa _SV023SLANG_ParameterGroup_CA3caa
-#define cab _SV023SLANG_ParameterGroup_CA3cab
-#define cac _SV023SLANG_ParameterGroup_CA3cac
-#define cad _SV023SLANG_ParameterGroup_CA3cad
-#define cae _SV023SLANG_ParameterGroup_CA3cae
-#define ta 	_SV023SLANG_parameterGroup_CAL1
-#define sa 	_SV023SLANG_parameterGroup_CAL2
+#define CA CA_0
+#define caa caa_0
+#define cab cab_0
+#define cac cac_0
+#define cad cad_0
+#define cae cae_0
+#define ta 	CA_ta_0
+#define sa 	CA_sa_0
 
-#define CB _SV023SLANG_parameterGroup_CBL0
-#define cba _SV023SLANG_ParameterGroup_CB3cba
-#define cbb _SV023SLANG_ParameterGroup_CB3cbb
-#define cbc _SV023SLANG_ParameterGroup_CB3cbc
-#define cbd _SV023SLANG_ParameterGroup_CB3cbd
-#define cbe _SV023SLANG_ParameterGroup_CB3cbe
-#define tbx	_SV023SLANG_parameterGroup_CBL1
-#define tby	_SV023SLANG_parameterGroup_CBL2
-#define sb 	_SV023SLANG_parameterGroup_CBL3
+#define CB CB_0
+#define cba cba_0
+#define cbb cbb_0
+#define cbc cbc_0
+#define cbd cbd_0
+#define cbe cbe_0
+#define tbx	CB_tbx_0
+#define tby	CB_tby_0
+#define sb 	CB_sb_0
 
-#define CC _SV023SLANG_parameterGroup_CCL0
-#define cca _SV023SLANG_ParameterGroup_CC3cca
-#define ccb _SV023SLANG_ParameterGroup_CC3ccb
-#define ccc _SV023SLANG_ParameterGroup_CC3ccc
-#define ccd _SV023SLANG_ParameterGroup_CC3ccd
-#define cce _SV023SLANG_ParameterGroup_CC3cce
-#define tc 	_SV023SLANG_parameterGroup_CCL1
-#define scx	_SV023SLANG_parameterGroup_CCL2
-#define scy	_SV023SLANG_parameterGroup_CCL3
+#define CC CC_0
+#define cca cca_0
+#define ccb ccb_0
+#define ccc ccc_0
+#define ccd ccd_0
+#define cce cce_0
+#define tc 	CC_tc_0
+#define scx	CC_scx_0
+#define scy	CC_scy_0
 
 #endif
 

--- a/tests/bindings/targets-and-uavs-structure.hlsl
+++ b/tests/bindings/targets-and-uavs-structure.hlsl
@@ -8,9 +8,9 @@
 #else
 #define R(X) X
 
-#define Foo _ST03Foo
-#define v _SV03Foo1v
-#define fooBuffer _SV09fooBuffer
+#define Foo Foo_0
+#define v v_0
+#define fooBuffer fooBuffer_0
 
 #endif
 

--- a/tests/bindings/targets-and-uavs.hlsl
+++ b/tests/bindings/targets-and-uavs.hlsl
@@ -10,9 +10,9 @@
 #else
 #define R(X) X
 
-#define Foo _ST03Foo
-#define v _SV03Foo1v
-#define fooBuffer _SV09fooBuffer
+#define Foo Foo_0
+#define v v_0
+#define fooBuffer fooBuffer_0
 
 #endif
 

--- a/tests/bugs/gh-103.slang
+++ b/tests/bugs/gh-103.slang
@@ -3,9 +3,9 @@
 // Ensure that matrix-times-scalar works
 
 #ifndef __SLANG__
-#define C _SV022SLANG_parameterGroup_C
-#define a _SV022SLANG_ParameterGroup_C1a
-#define b _SV022SLANG_ParameterGroup_C1b
+#define C C_0
+#define a a_0
+#define b b_0
 #endif
 
 float4x4 doIt(float4x4 a, float b)

--- a/tests/bugs/gh-333.slang
+++ b/tests/bugs/gh-333.slang
@@ -3,13 +3,13 @@
 // Ensure declaration order in output is correct
 
 #ifndef __SLANG__
-#define A _ST01A
-#define x _SV01A1x
-#define B _ST01B
-#define y _SV01B1y
-#define C _SV022SLANG_parameterGroup_CL0
-#define a _SV022SLANG_ParameterGroup_C1a
-#define b _SV022SLANG_ParameterGroup_C1b
+#define A A_0
+#define x x_0
+#define B B_0
+#define y y_0
+#define C C_0
+#define a a_0
+#define b b_0
 #endif
 
 struct A

--- a/tests/bugs/split-nested-types.hlsl
+++ b/tests/bugs/split-nested-types.hlsl
@@ -4,18 +4,18 @@
 import split_nested_types;
 #else
 
-#define A _ST01A
-#define x _SV01A1x
+#define A A_0
+#define x x_0
 
-#define B _ST01B
-#define y _SV01B1y
+#define B B_0
+#define y y_0
 
-#define M _ST01M
-#define a _SV01M1a
-#define b _SV01M1b
+#define M M_0
+#define a a_0
+#define b b_0
 
-#define C _SV022SLANG_parameterGroup_CL0
-#define m _SV022SLANG_ParameterGroup_C1m
+#define C C_0
+#define m m_0
 
 struct A { int x; };
 

--- a/tests/bugs/vec-init-list.hlsl
+++ b/tests/bugs/vec-init-list.hlsl
@@ -4,8 +4,8 @@
 
 #ifndef __SLANG__
 
-#define C _SV022SLANG_parameterGroup_C
-#define a _SV022SLANG_ParameterGroup_C1a
+#define C C_0
+#define a a_0
 #define SV_Position SV_POSITION
 
 #endif

--- a/tests/hlsl/dxsdk/AdaptiveTessellationCS40/Render.hlsl
+++ b/tests/hlsl/dxsdk/AdaptiveTessellationCS40/Render.hlsl
@@ -1,8 +1,8 @@
 //TEST(smoke):COMPARE_HLSL:-no-mangle -profile vs_4_0 -entry RenderBaseVS -profile ps_4_0 -entry RenderPS -target dxbc-assembly
 
 #ifndef __SLANG__
-#define cbPerObject _SV032SLANG_parameterGroup_cbPerObject
-#define g_mWorldViewProjection _SV032SLANG_ParameterGroup_cbPerObject22g_mWorldViewProjection
+#define cbPerObject cbPerObject_0
+#define g_mWorldViewProjection g_mWorldViewProjection_0
 #endif
 
 

--- a/tests/hlsl/dxsdk/BasicHLSL11/BasicHLSL11_PS.hlsl
+++ b/tests/hlsl/dxsdk/BasicHLSL11/BasicHLSL11_PS.hlsl
@@ -1,11 +1,11 @@
 //TEST:COMPARE_HLSL:-no-mangle -target dxbc-assembly -profile ps_4_0 -entry PSMain
 
 #ifndef __SLANG__
-#define cbPerFrame _SV031SLANG_parameterGroup_cbPerFrame
-#define g_vLightDir _SV031SLANG_ParameterGroup_cbPerFrame11g_vLightDir
-#define g_fAmbient _SV031SLANG_ParameterGroup_cbPerFrame10g_fAmbient
-#define g_samLinear _SV011g_samLinear
-#define g_txDiffuse _SV011g_txDiffuse
+#define cbPerFrame cbPerFrame_0
+#define g_vLightDir g_vLightDir_0
+#define g_fAmbient g_fAmbient_0
+#define g_samLinear g_samLinear_0
+#define g_txDiffuse g_txDiffuse_0
 #endif
 
 //--------------------------------------------------------------------------------------

--- a/tests/hlsl/dxsdk/BasicHLSL11/BasicHLSL11_VS.hlsl
+++ b/tests/hlsl/dxsdk/BasicHLSL11/BasicHLSL11_VS.hlsl
@@ -1,9 +1,9 @@
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VSMain
 
 #ifndef __SLANG__
-#define cbPerObject _SV032SLANG_parameterGroup_cbPerObject
-#define g_mWorldViewProjection _SV032SLANG_ParameterGroup_cbPerObject22g_mWorldViewProjection
-#define g_mWorld _SV032SLANG_ParameterGroup_cbPerObject8g_mWorld
+#define cbPerObject cbPerObject_0
+#define g_mWorldViewProjection g_mWorldViewProjection_0
+#define g_mWorld g_mWorld_0
 #endif
 
 //--------------------------------------------------------------------------------------

--- a/tests/hlsl/dxsdk/CascadedShadowMaps11/RenderCascadeShadow.hlsl
+++ b/tests/hlsl/dxsdk/CascadedShadowMaps11/RenderCascadeShadow.hlsl
@@ -1,8 +1,8 @@
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VSMain -entry VSMainPancake
 
 #ifndef __SLANG__
-#define cbPerObject _SV032SLANG_parameterGroup_cbPerObject
-#define g_mWorldViewProjection _SV032SLANG_ParameterGroup_cbPerObject22g_mWorldViewProjection
+#define cbPerObject cbPerObject_0
+#define g_mWorldViewProjection g_mWorldViewProjection_0
 #endif
 
 //--------------------------------------------------------------------------------------

--- a/tests/hlsl/dxsdk/DynamicShaderLinkage11/DynamicShaderLinkage11_VS.hlsl
+++ b/tests/hlsl/dxsdk/DynamicShaderLinkage11/DynamicShaderLinkage11_VS.hlsl
@@ -1,9 +1,9 @@
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VSMain
 
 #ifndef __SLANG__
-#define cbPerObject _SV032SLANG_parameterGroup_cbPerObject
-#define g_mWorldViewProjection _SV032SLANG_ParameterGroup_cbPerObject22g_mWorldViewProjection
-#define g_mWorld _SV032SLANG_ParameterGroup_cbPerObject8g_mWorld
+#define cbPerObject cbPerObject_0
+#define g_mWorldViewProjection g_mWorldViewProjection_0
+#define g_mWorld g_mWorld_0
 #endif
 
 //--------------------------------------------------------------------------------------

--- a/tests/hlsl/dxsdk/MultithreadedRendering11/MultithreadedRendering11_VS.hlsl
+++ b/tests/hlsl/dxsdk/MultithreadedRendering11/MultithreadedRendering11_VS.hlsl
@@ -1,10 +1,10 @@
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VSMain
 
 #ifndef __SLANG__
-#define cbPerObject _SV032SLANG_parameterGroup_cbPerObject
-#define g_mWorld _SV032SLANG_ParameterGroup_cbPerObject8g_mWorld
-#define cbPerScene _SV031SLANG_parameterGroup_cbPerScene
-#define g_mViewProj _SV031SLANG_ParameterGroup_cbPerScene11g_mViewProj
+#define cbPerObject cbPerObject_0
+#define g_mWorld g_mWorld_0
+#define cbPerScene cbPerScene_0
+#define g_mViewProj g_mViewProj_0
 #endif
 
 //--------------------------------------------------------------------------------------

--- a/tests/hlsl/dxsdk/OIT11/SceneVS.hlsl
+++ b/tests/hlsl/dxsdk/OIT11/SceneVS.hlsl
@@ -1,8 +1,8 @@
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry SceneVS
 
 #ifndef __SLANG__
-#define cbPerObject _SV032SLANG_parameterGroup_cbPerObject
-#define g_mWorldViewProjection _SV032SLANG_ParameterGroup_cbPerObject22g_mWorldViewProjection
+#define cbPerObject cbPerObject_0
+#define g_mWorldViewProjection g_mWorldViewProjection_0
 #endif
 
 //-----------------------------------------------------------------------------

--- a/tests/hlsl/dxsdk/VarianceShadows11/RenderVarianceShadow.hlsl
+++ b/tests/hlsl/dxsdk/VarianceShadows11/RenderVarianceShadow.hlsl
@@ -1,8 +1,8 @@
 //TEST:COMPARE_HLSL: -target dxbc-assembly -profile vs_4_0 -entry VSMain -profile ps_4_0 -entry PSMain
 
 #ifndef __SLANG__
-#define cbPerObject _SV032SLANG_parameterGroup_cbPerObject
-#define g_mWorldViewProjection _SV032SLANG_ParameterGroup_cbPerObject22g_mWorldViewProjection
+#define cbPerObject cbPerObject_0
+#define g_mWorldViewProjection g_mWorldViewProjection_0
 #endif
 
 //--------------------------------------------------------------------------------------

--- a/tests/hlsl/simple/allow-uav-conditional.hlsl
+++ b/tests/hlsl/simple/allow-uav-conditional.hlsl
@@ -3,7 +3,7 @@
 // Check output for `[allow_uav_conditional]`
 
 #ifndef __SLANG__
-#define gBuffer _SV07gBuffer
+#define gBuffer gBuffer_0
 #endif
 
 RWStructuredBuffer<uint> gBuffer : register(u0);

--- a/tests/hlsl/simple/compute-numthreads.hlsl
+++ b/tests/hlsl/simple/compute-numthreads.hlsl
@@ -3,7 +3,7 @@
 // Confirm that we properly pass along the `numthreads` attribute on an entry point.
 
 #ifndef __SLANG__
-#define b _SV01b
+#define b b_0
 #endif
 
 RWStructuredBuffer<float> b;

--- a/tests/hlsl/simple/literal-typing.hlsl
+++ b/tests/hlsl/simple/literal-typing.hlsl
@@ -18,7 +18,7 @@ Bad foo(int x) { Bad b; b.bad = x; return b; }
 // or ignore it and call the wrong one.
 
 #ifndef __SLANG__
-#define b _SV01b
+#define b b_0
 #endif
 
 RWStructuredBuffer<uint> b;

--- a/tests/parser/cast-precedence.hlsl
+++ b/tests/parser/cast-precedence.hlsl
@@ -4,9 +4,9 @@
 // the appropriate precedence.
 
 #ifndef __SLANG__
-#define C _SV022SLANG_parameterGroup_C
-#define a _SV022SLANG_ParameterGroup_C1a
-#define b _SV022SLANG_ParameterGroup_C1b
+#define C C_0
+#define a a_0
+#define b b_0
 #define SV_Position SV_POSITION
 #endif
 


### PR DESCRIPTION
The basic idea here is that when lowering to the IR, the front-end will attach a "name hint" to the IR instruction(s) that represent a given declaration, and then the passes that work on the IR will try to preserve and propagate those names, and then finally the emit logic will use them in place of mangled or unique names when available.

This change does *not* try to deal with the issues that arise when we try to use those variable names in the output without any modification (e.g., handling cases where they might clash with keywords or builtins in the target language). Instead, it tries to establish baseline behavior for propagating through names, so that a later change can concentrate on the issue of using those names exactly when it is legal to do so.

In order to avoid issues around the name "hints" causing problems we take two main steps:

1. We "scrub" each name to reduce it down to the allowed set of identifier characters in C-like languages, and then ensure that it doesn't do things that would be illegal in some downstream languages (e.g., consecutive underscores are not allowed in GLSL) or could clash with Slang's mangled names. This process isn't guaranteed to give distinct results for distinct inputs (it isn't a mangling scheme, after all).

2. We generate a unique ID for each occurence of a given name and always use that as a suffix. This means that even if a name happens to overlap with a keyword (if you somehow have a variable named `do`), we will still add a suffix that makes it not a problem (we'd output `do_0` which is fine).

The logic for generating these names is mostly straightforward. For simple variables, we use their given name directly, while for other declarations we try to form a name that includes their parent declaration (e.g. `SomeType.someMethod`).

Various IR passes need to propagate or preserve this information. The most interesting is type legalization, when we take a variable with an aggregate type and split some of the fields out into their own variables. In that case we generate "dotted" names like `someVar.someTexture` and rely on the emit logic to turn that into `someVar_someTexture`.

During SSA generation, if we are promoting a variable to SSA temporaries, we will try to propagate the name of the variable over to the temporaries (unless they already have a name from some other place). The same applies to block parameters ("phi nodes").

Many of the test changes need their expected output to be updated for this change. Luckily in most cases the output has gotten easier to understand.