### PR TITLE
Improvements around Surface type

### DIFF
--- a/tools/render-test/main.cpp
+++ b/tools/render-test/main.cpp
@@ -430,7 +430,11 @@ SlangResult innerMain(int argc, char** argv)
 			return SLANG_FAIL;
 	}
 
-	SLANG_RETURN_ON_FAIL(renderer->initialize(windowHandle));
+    Renderer::Desc desc;
+    desc.width = gWindowWidth;
+    desc.height = gWindowHeight;
+
+	SLANG_RETURN_ON_FAIL(renderer->initialize(desc, windowHandle));
 
 	auto shaderCompiler = renderer->getShaderCompiler();
 	switch (gOptions.inputLanguageID)
@@ -500,7 +504,12 @@ SlangResult innerMain(int argc, char** argv)
                     }
 					else
                     {
-						SLANG_RETURN_ON_FAIL(renderer->captureScreenShot(gOptions.outputPath));
+						Result res = renderer->captureScreenShot(gOptions.outputPath);
+                        if (SLANG_FAILED(res))
+                        {
+                            fprintf(stderr, "ERROR: failed to write screen capture to file\n");
+                            return res;   
+                        }
                     }
 					return SLANG_OK;
 				}

--- a/tools/render-test/options.h
+++ b/tools/render-test/options.h
@@ -51,10 +51,6 @@ struct Options
 
 extern Options gOptions;
 
-extern int gWindowWidth;
-extern int gWindowHeight;
-
-
 SlangResult parseOptions(int* argc, char** argv);
 
 } // renderer_test

--- a/tools/render-test/png-serialize-util.cpp
+++ b/tools/render-test/png-serialize-util.cpp
@@ -1,0 +1,38 @@
+// png-serialize-util.cpp
+#define _CRT_SECURE_NO_WARNINGS
+
+#include "png-serialize-util.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "external/stb/stb_image_write.h"
+
+namespace renderer_test {
+using namespace Slang;
+
+/* static */Slang::Result PngSerializeUtil::write(const char* filename, const Surface& surface)
+{
+    int numComps = 0;
+    switch (surface.m_format)
+    {
+        case Format::RGBA_Unorm_UInt8:
+        {
+            numComps = 4;
+            break;
+        }
+        default: break;
+    }
+
+    if (numComps <= 0)
+    {
+        return SLANG_FAIL;
+    }
+
+    int stbResult = stbi_write_png(filename, surface.m_width, surface.m_height, numComps, surface.m_data, surface.m_rowStrideInBytes);
+
+    return stbResult ? SLANG_OK : SLANG_FAIL;
+}
+
+} // renderer_test

--- a/tools/render-test/png-serialize-util.h
+++ b/tools/render-test/png-serialize-util.h
@@ -1,0 +1,14 @@
+// png-serialize-util.h
+#pragma once
+
+#include "surface.h"
+    
+namespace renderer_test {
+
+struct PngSerializeUtil 
+{
+    static Slang::Result write(const char* filename, const Surface& surface);
+
+};
+
+} // renderer_test

--- a/tools/render-test/render-test.vcxproj
+++ b/tools/render-test/render-test.vcxproj
@@ -171,6 +171,7 @@
     <ClCompile Include="descriptor-heap-d3d12.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="options.cpp" />
+    <ClCompile Include="png-serialize-util.cpp" />
     <ClCompile Include="render-d3d11.cpp" />
     <ClCompile Include="render-d3d12.cpp" />
     <ClCompile Include="render-gl.cpp" />
@@ -180,6 +181,7 @@
     <ClCompile Include="shader-input-layout.cpp" />
     <ClCompile Include="shader-renderer-util.cpp" />
     <ClCompile Include="slang-support.cpp" />
+    <ClCompile Include="surface.cpp" />
     <ClCompile Include="vk-api.cpp" />
     <ClCompile Include="vk-device-queue.cpp" />
     <ClCompile Include="vk-module.cpp" />
@@ -191,6 +193,7 @@
     <ClInclude Include="d3d-util.h" />
     <ClInclude Include="descriptor-heap-d3d12.h" />
     <ClInclude Include="options.h" />
+    <ClInclude Include="png-serialize-util.h" />
     <ClInclude Include="render-d3d11.h" />
     <ClInclude Include="render-d3d12.h" />
     <ClInclude Include="render-gl.h" />
@@ -200,6 +203,7 @@
     <ClInclude Include="shader-input-layout.h" />
     <ClInclude Include="shader-renderer-util.h" />
     <ClInclude Include="slang-support.h" />
+    <ClInclude Include="surface.h" />
     <ClInclude Include="vk-api.h" />
     <ClInclude Include="vk-device-queue.h" />
     <ClInclude Include="vk-module.h" />

--- a/tools/render-test/render-test.vcxproj.filters
+++ b/tools/render-test/render-test.vcxproj.filters
@@ -72,6 +72,12 @@
     <ClCompile Include="vk-util.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="surface.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="png-serialize-util.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="options.h">
@@ -129,6 +135,12 @@
       <Filter>Source Files</Filter>
     </ClInclude>
     <ClInclude Include="vk-util.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="surface.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="png-serialize-util.h">
       <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/tools/render-test/render-vk.cpp
+++ b/tools/render-test/render-vk.cpp
@@ -33,7 +33,7 @@ public:
     enum { kMaxRenderTargets = 8, kMaxAttachments = kMaxRenderTargets + 1 };
     
     // Renderer    implementation
-    virtual SlangResult initialize(void* inWindowHandle) override;
+    virtual SlangResult initialize(const Desc& desc, void* inWindowHandle) override;
     virtual void setClearColor(const float color[4]) override;
     virtual void clearFrame() override;
     virtual void presentFrame() override;
@@ -254,6 +254,8 @@ public:
     int m_swapChainImageIndex = -1;
 
     float m_clearColor[4] = { 0, 0, 0, 0 };
+
+    Desc m_desc;
 };
 
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! VkRenderer::Buffer !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
@@ -774,10 +776,12 @@ VkPipelineShaderStageCreateInfo VKRenderer::compileEntryPoint(const ShaderCompil
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!! Renderer interface !!!!!!!!!!!!!!!!!!!!!!!!!!
 
-SlangResult VKRenderer::initialize(void* inWindowHandle)
+SlangResult VKRenderer::initialize(const Desc& desc, void* inWindowHandle)
 {
     SLANG_RETURN_ON_FAIL(m_module.init());
     SLANG_RETURN_ON_FAIL(m_api.initGlobalProcs(m_module));
+
+    m_desc = desc;
 
     VkApplicationInfo applicationInfo = { VK_STRUCTURE_TYPE_APPLICATION_INFO };
     applicationInfo.pApplicationName = "slang-render-test";

--- a/tools/render-test/render.h
+++ b/tools/render-test/render.h
@@ -532,12 +532,13 @@ class Renderer: public Slang::RefObject
 {
 public:
     
-    struct Info
+    struct Desc
     {
-        ProjectionStyle m_projectionStyle;
+        int width;          ///< Width in pixels
+        int height;         ///< height in pixels
     };
 
-    virtual SlangResult initialize(void* inWindowHandle) = 0;
+    virtual SlangResult initialize(const Desc& desc, void* inWindowHandle) = 0;
 
     virtual void setClearColor(const float color[4]) = 0;
     virtual void clearFrame() = 0;

--- a/tools/render-test/surface.cpp
+++ b/tools/render-test/surface.cpp
@@ -1,0 +1,191 @@
+// surface.cpp
+#include "surface.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "../../source/core/list.h"
+
+namespace renderer_test {
+using namespace Slang;
+
+class MallocSurfaceAllocator: public SurfaceAllocator
+{
+    public:
+
+    virtual Slang::Result allocate(int width, int height, Format format, int alignment, Surface& surface) override;
+    virtual void deallocate(Surface& surface) override;
+};
+
+static MallocSurfaceAllocator s_mallocSurfaceAllocator;
+
+/// Get the malloc allocator
+/* static */SurfaceAllocator* SurfaceAllocator::getMallocAllocator()
+{
+    return &s_mallocSurfaceAllocator;
+}
+
+Slang::Result MallocSurfaceAllocator::allocate(int width, int height, Format format, int alignment, Surface& surface)
+{
+    assert(surface.m_data == nullptr);
+
+    // Calculate row size
+
+    const int rowSizeInBytes = Surface::calcRowSize(format, width);
+    const int numRows = Surface::calcNumRows(format, height);
+
+    alignment = (alignment <= 0) ? int(sizeof(void*)) : alignment;
+    // It must be a power of 2
+    assert( ((alignment - 1)  & alignment) == 0);
+
+    // Align rowSize
+    const int alignedRowSizeInBytes = (rowSizeInBytes + alignment - 1) & -alignment;
+
+    size_t totalSize = numRows * alignedRowSizeInBytes;
+
+    uint8_t* data = (uint8_t*)::malloc(totalSize);
+    if (!data)
+    {
+        return SLANG_E_MEM_OUT_OF_MEMORY;
+    }
+
+    surface.m_data = data;
+    surface.m_width = width;
+    surface.m_height = height;
+    surface.m_format = format;
+    surface.m_numRows = numRows;
+    surface.m_rowStrideInBytes = alignedRowSizeInBytes;
+
+    surface.m_allocator = this;
+    return SLANG_OK;
+}
+
+void MallocSurfaceAllocator::deallocate(Surface& surface)
+{
+    assert(surface.m_data);
+    // Make sure it's not an inverted, cos otherwise m_data is not the start address
+    assert(surface.m_rowStrideInBytes > 0);
+    ::free(surface.m_data);
+}
+
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Surface !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+/* static */int Surface::calcRowSize(Format format, int width)
+{
+    size_t pixelSize = RendererUtil::getFormatSize(format);
+    if (pixelSize == 0)
+    {
+        return 0;
+    }
+    return int(pixelSize * width);
+}
+
+/* static */int Surface::calcNumRows(Format format, int height) 
+{ 
+    // Don't have any compressed types, so number of rows is same as the height
+    return height; 
+}
+
+void Surface::init()
+{
+    m_width = 0;
+    m_height = 0;
+    m_format = Format::Unknown;
+    m_data = nullptr;
+    m_numRows = 0;
+    m_rowStrideInBytes = 0;
+    // NOTE! does not clear the allocator. 
+    // If called with an allocation memory will leak!
+}
+
+Surface::~Surface()
+{
+    if (m_data && m_allocator)
+    {
+        m_allocator->deallocate(*this);
+    }
+}
+
+void Surface::deallocate()
+{
+    if (m_data && m_allocator)
+    {
+        m_allocator->deallocate(*this);
+        init();
+    }
+}
+
+Result Surface::allocate(int width, int height, Format format, int alignment, SurfaceAllocator* allocator)
+{
+    deallocate();
+    allocator = allocator ? allocator : m_allocator;
+    if (!allocator)
+    {
+        // An allocator needs to be set on the surface, or one passed in.
+        return SLANG_FAIL;
+    }
+    return allocator->allocate(width, height, format, alignment, *this);
+}
+
+void Surface::setUnowned(int width, int height, Format format, int strideInBytes, void* data)
+{
+    deallocate();
+
+    // This is unowned
+    m_allocator = nullptr;
+
+    m_width = width;
+    m_height = height;
+    m_format = format;
+    m_rowStrideInBytes = strideInBytes;
+    m_data = (uint8_t*)data;
+
+    m_numRows = Surface::calcNumRows(format, height);
+ 
+    const int rowSizeInBytes = Surface::calcRowSize(format, width);
+    assert((strideInBytes > 0 && rowSizeInBytes <= strideInBytes) || (strideInBytes < 0 && rowSizeInBytes <= -strideInBytes));
+}
+
+void Surface::zeroContents()
+{
+    const int rowSizeInBytes = Surface::calcRowSize(m_format, m_width);
+
+    const int stride = m_rowStrideInBytes;
+    uint8_t* dst = m_data;
+
+    for (int i = 0; i < m_numRows; i++, dst += stride)
+    {
+        ::memset(dst, 0, rowSizeInBytes);
+    }
+}
+
+void Surface::flipInplaceVertically()
+{
+    // Can only flip when m_height matches number of rows
+    assert(m_numRows == m_height);
+
+    const int rowSizeInBytes = Surface::calcRowSize(m_format, m_width);
+    if (rowSizeInBytes <= 0 || m_numRows <= 1)
+    {
+        return;
+    }
+
+    uint8_t* top = m_data;
+    uint8_t* bottom = m_data + (m_numRows - 1) * m_rowStrideInBytes;
+
+    List<uint8_t> bufferList;
+    bufferList.SetSize(rowSizeInBytes);
+    uint8_t* buffer = bufferList.Buffer();
+
+    const int stride = m_rowStrideInBytes;
+
+    const int num = m_height >> 1;
+    for (int i = 0; i < num; ++i, top += stride, bottom -= stride)
+    {
+        ::memcpy(buffer, top, rowSizeInBytes);
+        ::memcpy(top, bottom, rowSizeInBytes);
+        ::memcpy(bottom, buffer, rowSizeInBytes);
+    }
+}
+
+} // renderer_test

--- a/tools/render-test/surface.h
+++ b/tools/render-test/surface.h
@@ -1,0 +1,83 @@
+// surface.h
+#pragma once
+
+#include "render.h"
+    
+namespace renderer_test {
+
+class Surface;
+
+class SurfaceAllocator
+{
+    public:
+    virtual Slang::Result allocate(int width, int height, Format format, int alignment, Surface& surface) = 0;
+    virtual void deallocate(Surface& surface) = 0;
+
+        /// Get the malloc allocator
+    static SurfaceAllocator* getMallocAllocator();
+};
+
+class Surface
+{
+    public:
+
+    enum 
+    {
+        kDefaultAlignment = sizeof(void*)
+    };
+
+        /// Allocate
+    Slang::Result allocate(int width, int height, Format format, int alignment = kDefaultAlignment, SurfaceAllocator* allocator = nullptr);
+
+        /// Deallocate contents
+    void deallocate();
+        /// Initialize contents (zero sized, no data). Note that the allocator pointer is left as is
+    void init();
+
+        /// Set unowned
+    void setUnowned(int width, int height, Format format, int strideInBytes, void* data); 
+
+    template <typename T>
+    T* calcNextRow(T* ptr) const { return (T*)calcNextRow((void*)ptr); }
+    template <typename T>
+    const T* calcNextRow(const T* ptr) const { return (const T*)calcNextRow((const void*)ptr); }
+
+    void* calcNextRow(void* ptr) const { return (void*)(((uint8_t*)ptr) + m_rowStrideInBytes); }
+    const void* calcNextRow(const void* ptr) const { return (const void*)(((const uint8_t*)ptr) + m_rowStrideInBytes); }
+
+        /// Writes zero to all of the contents
+    void zeroContents();
+
+        /// Flips the contents vertically in place
+    void flipInplaceVertically();
+    
+        /// True if has some contents
+    bool hasContents() const { return m_data != nullptr; }
+
+        /// Ctor
+    Surface() :
+        m_allocator(nullptr)
+    {
+        init();
+    }
+        /// Dtor
+    ~Surface();
+    
+        /// Get the size of the row in bytes
+    static int calcRowSize(Format format, int width);
+        /// Calculates the number of rows
+    static int calcNumRows(Format format, int height);
+
+    int m_width;
+    int m_height;
+    Format m_format;                
+    
+    uint8_t* m_data;                    /// The data that makes up the image. If nullptr, has no data. Pointer to first 'row' of the image.
+
+    int m_numRows;                      ///< Total amount of rows (typically same as height, but in compressed formats may be less)
+    int m_rowStrideInBytes;             ///< The number of bytes between rows
+
+    SurfaceAllocator* m_allocator;      ///< Can be null if so contents is 'unowned', if set
+};
+
+} // renderer_test


### PR DESCRIPTION
* Added Surface type - as a simple value type to hold a 2d collection of pixels.
* Added PngSerializeUtil allows currently for just writing Surface of RGBA format 
* Removes dependency on stbi_image except for in PngSerializeUtil.
* Removed use of gWindowWidth/Height globals - instead pass the size in Desc to initialize on Renderer.