### PR TITLE
Use Surface for screen capture in Renderer interface

### DIFF
--- a/tools/render-test/main.cpp
+++ b/tools/render-test/main.cpp
@@ -8,6 +8,8 @@
 #include "render-vk.h"
 
 #include "slang-support.h"
+#include "surface.h"
+#include "png-serialize-util.h"
 
 #include "shader-renderer-util.h"
 
@@ -68,6 +70,8 @@ class RenderTestApp
 
     Result writeBindingOutput(const char* fileName);
     
+    Result writeScreen(const char* filename);
+
 	protected:
 		/// Called in initialize
 	Result initializeShaders(ShaderCompiler* shaderCompiler);
@@ -312,6 +316,14 @@ Result RenderTestApp::writeBindingOutput(const char* fileName)
     return SLANG_OK;
 }
 
+
+Result RenderTestApp::writeScreen(const char* filename)
+{
+    Surface surface;
+    SLANG_RETURN_ON_FAIL(m_renderer->captureScreenSurface(surface));
+    return PngSerializeUtil::write(filename, surface);
+}
+
 //
 // We use a bare-minimum window procedure to get things up and running.
 //
@@ -504,7 +516,8 @@ SlangResult innerMain(int argc, char** argv)
                     }
 					else
                     {
-						Result res = renderer->captureScreenShot(gOptions.outputPath);
+						Result res = app.writeScreen(gOptions.outputPath);
+                        
                         if (SLANG_FAILED(res))
                         {
                             fprintf(stderr, "ERROR: failed to write screen capture to file\n");

--- a/tools/render-test/render-gl.cpp
+++ b/tools/render-test/render-gl.cpp
@@ -12,7 +12,6 @@
 #include "external/stb/stb_image_write.h"
 
 #include "surface.h"
-#include "png-serialize-util.h"
 
 // TODO(tfoley): eventually we should be able to run these
 // tests on non-Windows targets to confirm that cross-compilation
@@ -87,7 +86,7 @@ public:
     virtual void presentFrame() override;
     virtual TextureResource* createTextureResource(Resource::Type type, Resource::Usage initialUsage, const TextureResource::Desc& desc, const TextureResource::Data* initData) override;
     virtual BufferResource* createBufferResource(Resource::Usage initialUsage, const BufferResource::Desc& descIn, const void* initData) override;
-    virtual SlangResult captureScreenShot(char const* outputPath) override;
+    virtual SlangResult captureScreenSurface(Surface& surfaceOut) override;
     virtual InputLayout* createInputLayout(const InputElementDesc* inputElements, UInt inputElementCount) override;
     virtual BindingState* createBindingState(const BindingState::Desc& bindingStateDesc) override;
     virtual ShaderCompiler* getShaderCompiler() override;
@@ -586,13 +585,12 @@ void GLRenderer::presentFrame()
     ::SwapBuffers(m_hdc);
 }
 
-SlangResult GLRenderer::captureScreenShot(const char* outputPath)
+SlangResult GLRenderer::captureScreenSurface(Surface& surfaceOut)
 {
-    Surface surface;
-    surface.allocate(m_desc.width, m_desc.height, Format::RGBA_Unorm_UInt8, 1, SurfaceAllocator::getMallocAllocator());
-    glReadPixels(0, 0, m_desc.width, m_desc.height, GL_RGBA, GL_UNSIGNED_BYTE, surface.m_data);
-    surface.flipInplaceVertically();
-    return PngSerializeUtil::write(outputPath, surface);
+    SLANG_RETURN_ON_FAIL(surfaceOut.allocate(m_desc.width, m_desc.height, Format::RGBA_Unorm_UInt8, 1, SurfaceAllocator::getMallocAllocator()));
+    glReadPixels(0, 0, m_desc.width, m_desc.height, GL_RGBA, GL_UNSIGNED_BYTE, surfaceOut.m_data);
+    surfaceOut.flipInplaceVertically();
+    return SLANG_OK;
 }
 
 ShaderCompiler* GLRenderer::getShaderCompiler()

--- a/tools/render-test/render-vk.cpp
+++ b/tools/render-test/render-vk.cpp
@@ -39,7 +39,7 @@ public:
     virtual void presentFrame() override;
     virtual TextureResource* createTextureResource(Resource::Type type, Resource::Usage initialUsage, const TextureResource::Desc& desc, const TextureResource::Data* initData) override;
     virtual BufferResource* createBufferResource(Resource::Usage initialUsage, const BufferResource::Desc& bufferDesc, const void* initData) override;
-    virtual SlangResult captureScreenShot(const char* outputPath) override;
+    virtual SlangResult captureScreenSurface(Surface& surface) override;
     virtual InputLayout* createInputLayout(const InputElementDesc* inputElements, UInt inputElementCount) override;
     virtual BindingState* createBindingState(const BindingState::Desc& bindingStateDesc) override;
     virtual ShaderCompiler* getShaderCompiler() override;
@@ -1010,7 +1010,7 @@ void VKRenderer::presentFrame()
     _beginRender();
 }
 
-SlangResult VKRenderer::captureScreenShot(char const* outputPath)
+SlangResult VKRenderer::captureScreenSurface(Surface& surfaceOut)
 {
     return SLANG_FAIL;
 }

--- a/tools/render-test/render.h
+++ b/tools/render-test/render.h
@@ -15,6 +15,9 @@ namespace renderer_test {
 typedef intptr_t Int;
 typedef uintptr_t UInt;
 
+// pre declare types
+class Surface;
+
 // Declare opaque type
 class InputLayout: public Slang::RefObject
 {
@@ -552,7 +555,8 @@ public:
         /// Create a buffer resource
     virtual BufferResource* createBufferResource(Resource::Usage initialUsage, const BufferResource::Desc& desc, const void* initData = nullptr) { return nullptr; } 
 
-    virtual SlangResult captureScreenShot(const char* outputPath) = 0;
+        /// Captures the back buffer and stores the result in surfaceOut. If the surface contains data, this will likely be freed in the process.
+    virtual SlangResult captureScreenSurface(Surface& surfaceOut) = 0;
 
     virtual InputLayout* createInputLayout(const InputElementDesc* inputElements, UInt inputElementCount) = 0;
     virtual BindingState* createBindingState(const BindingState::Desc& desc) { return nullptr; }

--- a/tools/render-test/render.h
+++ b/tools/render-test/render.h
@@ -555,7 +555,7 @@ public:
         /// Create a buffer resource
     virtual BufferResource* createBufferResource(Resource::Usage initialUsage, const BufferResource::Desc& desc, const void* initData = nullptr) { return nullptr; } 
 
-        /// Captures the back buffer and stores the result in surfaceOut. If the surface contains data, this will likely be freed in the process.
+        /// Captures the back buffer and stores the result in surfaceOut. If the surface contains data - it will either be overwritten (if same size and format), or freed and a re-allocated.
     virtual SlangResult captureScreenSurface(Surface& surfaceOut) = 0;
 
     virtual InputLayout* createInputLayout(const InputElementDesc* inputElements, UInt inputElementCount) = 0;

--- a/tools/render-test/surface.cpp
+++ b/tools/render-test/surface.cpp
@@ -188,4 +188,35 @@ void Surface::flipInplaceVertically()
     }
 }
 
+SlangResult Surface::set(int width, int height, Format format, int srcRowStride, const void* data, SurfaceAllocator* allocator)
+{
+    if (hasContents() && m_width == width && m_height == height && m_format == format)
+    {
+        // I can just overwrite the contents that is there
+    }
+    else
+    {
+        SLANG_RETURN_ON_FAIL(allocate(width, height, format, 0, allocator));
+    }
+
+    // Okay just need to set the contents
+
+    {
+        const size_t rowSize = calcRowSize(format, width);
+
+        const uint8_t* srcRow = (const uint8_t*)data;
+        uint8_t* dstRow = (uint8_t*)m_data;
+
+        for (int i = 0; i < m_numRows; i++)
+        {
+            ::memcpy(dstRow, srcRow, rowSize);    
+            
+            srcRow += srcRowStride;
+            dstRow += m_rowStrideInBytes;
+        }
+    }
+
+    return SLANG_OK;
+}
+
 } // renderer_test

--- a/tools/render-test/surface.h
+++ b/tools/render-test/surface.h
@@ -37,6 +37,9 @@ class Surface
         /// Set unowned
     void setUnowned(int width, int height, Format format, int strideInBytes, void* data); 
 
+        /// Set the contents - the memory will be owned by this surface (ie will be freed by the allocator when goes out of scope or is deallocated)
+    Slang::Result set(int width, int height, Format format, int strideInBytes, const void* data, SurfaceAllocator* allocator);
+    
     template <typename T>
     T* calcNextRow(T* ptr) const { return (T*)calcNextRow((void*)ptr); }
     template <typename T>


### PR DESCRIPTION
Screen capture now writes result into a Surface. This allows client code to decide what to do with the pixels.
 
It can still serialize the Surface out using PngSerializeUtil. In the future could also just directly compare captures between different renders without having to write to a file/png.  
