### PR TITLE
Add a new type of test: smoke compile test

### DIFF
--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -1058,9 +1058,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
 
     IRType* visitNamedExpressionType(NamedExpressionType* type)
     {
-        return (IRType*) getSimpleVal(context,
-            emitDeclRef(context, type->declRef,
-                context->irBuilder->getTypeKind()));
+        return (IRType*)getSimpleVal(context, dispatchType(type->GetCanonicalType()));
     }
 
     IRType* visitBasicExpressionType(BasicExpressionType* type)


### PR DESCRIPTION
This type of test will simply use slang to generate hlsl entrypoints, and verify that the generated hlsl entrypoints can be successfully compiled by fxc. A smoke test fails If the slang crashes, outputs any error messages, or the generated hlsl cannot be compiled by fxc.

Following is an example smoke test:

```
//TEST(full):SMOKE:-slang
//TEST_SMOKE: entrypoint computeMain: cs_5_0   // one entrypoint per line
//TEST_SMOKE: entrypoint vertexMain: vs_5_0
//TEST_SMOKE: type LightPair<LightArray<PointLight,5>, AreaLight> // one type argument per line
//TEST_SMOKE: type StandardMaterial

// code:
type_param TLight;
type_param TMaterial;

[numthreads(4, 1, 1)]
void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
{
    ...
}
void vertexMain(){ ... }
```