### PR TITLE
Workaround for cases where we emit illegal-but-unused types

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -5701,6 +5701,12 @@ struct EmitVisitor
 
         for(auto inst : module->getGlobalInsts())
         {
+            if( as<IRType>(inst) )
+            {
+                // Don't emit a type unless it is actually used.
+                continue;
+            }
+
             ensureGlobalInst(&ctx, inst, EmitAction::Level::Definition);
         }
     }


### PR DESCRIPTION
This is a quick workaround to deal with cases where we try to emit an unreferenced IR type that contains references to pre-legalization types (which might have been removed from the IR even thought they are still referenced). The basic fix is to *not* add types to our global order of instructions to emit by default, and only add them on demand as they are referenced by other instructions.

This is not a real fix for the underlying issue, which is that type legalization is only being applied to a subset of global instructions instead of all of them. A more detailed fix for that problem will need to be devised next.

This fix also doesn't address the question of why an unreferenced `struct` type came to be present in the IR code passed to the back-end in the first place. It would be good to understand how this scenario is arising.