### PR TITLE
Fix issue with atomics-groupshared.slang failing on Dx12

### DIFF
--- a/tests/compute/atomics-groupshared.slang
+++ b/tests/compute/atomics-groupshared.slang
@@ -13,17 +13,17 @@ uint test(uint val)
 {
     uint originalValue;
 
-    outputBuffer[val] = 0;
+    shared[val] = 0;
 
     GroupMemoryBarrierWithGroupSync();
 
-	InterlockedAdd(outputBuffer[val], 		val, 		originalValue);
-	InterlockedAdd(outputBuffer[val ^ 1], 	val*16, 	originalValue);
-	InterlockedAdd(outputBuffer[val ^ 2], 	val*16*16, 	originalValue);
-
+	InterlockedAdd(shared[val], 		val, 		originalValue);
+	InterlockedAdd(shared[val ^ 1], 	val*16, 	originalValue);
+	InterlockedAdd(shared[val ^ 2], 	val*16*16, 	originalValue);
+	
     GroupMemoryBarrierWithGroupSync();
 
-    return outputBuffer[val];
+    return shared[val];
 }
 
 [numthreads(4, 1, 1)]


### PR DESCRIPTION
GroupMemoryBarrierWithGroupSync only works on groupshared memory - it doesn't block on global memory accesses. The fix is to copy the values to be processed by InterlockedAdd into a groupshared array. The previous test ran successfully on Dx11, but broke on Dx12/GTX 670.