### PR TITLE
Fixes related to handling of empty types

### DIFF
--- a/source/slang/ir-legalize-types.cpp
+++ b/source/slang/ir-legalize-types.cpp
@@ -21,6 +21,8 @@ namespace Slang
 
 LegalVal LegalVal::tuple(RefPtr<TuplePseudoVal> tupleVal)
 {
+    SLANG_ASSERT(tupleVal->elements.Count());
+
     LegalVal result;
     result.flavor = LegalVal::Flavor::tuple;
     result.obj = tupleVal;
@@ -343,6 +345,9 @@ static LegalVal legalizeFieldAddress(
 
     switch (legalPtrOperand.flavor)
     {
+    case LegalVal::Flavor::none:
+        return LegalVal();
+
     case LegalVal::Flavor::simple:
         return LegalVal::simple(
             builder->emitFieldAddress(
@@ -457,6 +462,9 @@ static LegalVal legalizeFieldExtract(
 
     switch (legalStructOperand.flavor)
     {
+    case LegalVal::Flavor::none:
+        return LegalVal();
+
     case LegalVal::Flavor::simple:
         return LegalVal::simple(
             builder->emitFieldExtract(
@@ -571,6 +579,9 @@ static LegalVal legalizeGetElementPtr(
 
     switch (legalPtrOperand.flavor)
     {
+    case LegalVal::Flavor::none:
+        return LegalVal();
+
     case LegalVal::Flavor::simple:
         return LegalVal::simple(
             builder->emitElementAddress(
@@ -679,6 +690,9 @@ static LegalVal legalizeMakeStruct(
 
     switch(legalType.flavor)
     {
+    case LegalType::Flavor::none:
+        return LegalVal();
+
     case LegalType::Flavor::simple:
         {
             List<IRInst*> args;

--- a/source/slang/legalize-types.cpp
+++ b/source/slang/legalize-types.cpp
@@ -22,6 +22,8 @@ LegalType LegalType::implicitDeref(
 LegalType LegalType::tuple(
     RefPtr<TuplePseudoType>   tupleType)
 {
+    SLANG_ASSERT(tupleType->elements.Count());
+
     LegalType result;
     result.flavor = Flavor::tuple;
     result.obj = tupleType;
@@ -173,6 +175,10 @@ struct TupleTypeBuilder
             }
             break;
 
+        case LegalType::Flavor::none:
+            anyComplex = true;
+            break;
+
         case LegalType::Flavor::implicitDeref:
             {
                 // TODO: we may want to say that any use
@@ -305,7 +311,7 @@ struct TupleTypeBuilder
         // This helps get rid of emtpy structs that often trips up the 
         // downstream compiler
         if (!anyOrdinary && !anySpecial && !anyComplex)
-            return LegalType::tuple(new TuplePseudoType());
+            return LegalType();
 
         // If we didn't see anything "special"
         // then we can use the type as-is.
@@ -437,6 +443,9 @@ static LegalType createLegalUniformBufferType(
 {
     switch (legalElementType.flavor)
     {
+    case LegalType::Flavor::none:
+        return LegalType();
+
     case LegalType::Flavor::simple:
         {
             // Easy case: we just have a simple element type,
@@ -540,6 +549,9 @@ static LegalType createLegalPtrType(
 {
     switch (legalValueType.flavor)
     {
+    case LegalType::Flavor::none:
+        return LegalType();
+
     case LegalType::Flavor::simple:
         {
             // Easy case: we just have a simple element type,
@@ -675,6 +687,9 @@ static LegalType wrapLegalType(
 {
     switch (legalType.flavor)
     {
+    case LegalType::Flavor::none:
+        return LegalType();
+
     case LegalType::Flavor::simple:
         {
             return ordinaryWrapper->wrap(context, legalType.getSimple());


### PR DESCRIPTION
PR #577 tries to eliminate empty `struct` types by replacing them with a `LegalType::tuple` with zero elements, but this seems to run into problems in some cases, where we end up trying to match up `::none` values with empty `::tuple`s.

An alternative way to handle this is to never create empty `LegalType::tuple`s (and the same for `LegalVal::tuple`), and instead create `LegalType::none` and `LegalVal::none`. PR #577 avoided this because there were various cases in the legalization logic that didn't robustly handle `LegalType::Flavor::none`.

This PR thus includes two main changes:

1. Construct a `::none` type when we have an empty `struct` type.

2. Survery all places that handle the `::tuple` case and extend them to handle the `::none` case if it was missing.

This fixes an issue filed in Falcor's internal GitLab as number 424.