### PR TITLE
Improved command line control for apis and synthesized tests

### DIFF
--- a/tools/slang-test/README.md
+++ b/tools/slang-test/README.md
@@ -21,9 +21,12 @@ The command line can control which tests are run with a couple of switches
 * -api - Overall controls over which apis will be tested against 
 * -synthesizedTestApi - Controls which apis will have tests synthesized for them from other apis. Tests can be synthesized for dx12 and vulkan.
 
-The parameter afterwards indicates which apis will or wont be used. This is described in a simple kind of expression, probably best conveyed with some examples
+The parameter afterwards is a simple 'language' to control which apis will or wont be used. The basis is this is like a mathematical expression with only + and - operations. If the first operation is + or - it will be applied to whatever the default is, otherwise the defaults are ignored.
 
-* all - for all apis
+* vk - just for vulkan
+* +vk - Whatever the defaults are including vulkan
+* -dx12 - Whatever the defaults are excluding vulkan
+* all - for all apis, none - for no apis
 * all-vk - all apis but not vulkan (vk)
 * all-vk-dx12 - all apis but not vulkan (vk) or directx12 (dx12)
 * gl+dx11 - just on opengl (gl) and directx11 (dx11)

--- a/tools/slang-test/README.md
+++ b/tools/slang-test/README.md
@@ -16,6 +16,28 @@ slang-test -bindir E:\slang\bin\windows-x64\Debug\\ -category full tests/compute
 * The -category full means that all tests can be run.
 * The final 'free parameter' is 'tests/compute/array-param' and means only tests starting with this string will run.
 
+The command line can control which tests are run with a couple of switches
+
+* -api - Overall controls over which apis will be tested against 
+* -synthesizedTestApi - Controls which apis will have tests synthesized for them from other apis. Tests can be synthesized for dx12 and vulkan.
+
+The parameter afterwards indicates which apis will or wont be used. This is described in a simple kind of expression, probably best conveyed with some examples
+
+* all - for all apis
+* all-vk - all apis but not vulkan (vk)
+* all-vk-dx12 - all apis but not vulkan (vk) or directx12 (dx12)
+* gl+dx11 - just on opengl (gl) and directx11 (dx11)
+
+So if you wanted to test for all apis, except opengl you'd put on the command line '-api all-gl'
+
+The different APIs are 
+
+* OpenGL - gl,ogl,opengl
+* Vulkan - vk,vulkan
+* DirectD3D12 - dx12,d3d12
+* DirectD3D11 -dx11,d3d11
+
+
 It may also be necessary to have the working directory the root directory of the slang distribution - in the example above this would be "E:\slang\". 
 
 ## Test Categories

--- a/tools/slang-test/README.md
+++ b/tools/slang-test/README.md
@@ -21,7 +21,7 @@ The command line can control which tests are run with a couple of switches
 * -api - Overall controls over which apis will be tested against 
 * -synthesizedTestApi - Controls which apis will have tests synthesized for them from other apis. Tests can be synthesized for dx12 and vulkan.
 
-The parameter afterwards is a simple 'language' to control which apis will or wont be used. The basis is this is like a mathematical expression with only + and - operations. If the first operation is + or - it will be applied to whatever the default is, otherwise the defaults are ignored.
+The parameter afterwards is an 'api expression' used to control which apis will or wont be used. This is somewhat like a mathematical expression with only + and - operations and api names. If the first operation is + or - it will be applied to whatever the default is, otherwise the defaults are ignored.
 
 * vk - just for vulkan
 * +vk - Whatever the defaults are including vulkan
@@ -30,6 +30,7 @@ The parameter afterwards is a simple 'language' to control which apis will or wo
 * all-vk - all apis but not vulkan (vk)
 * all-vk-dx12 - all apis but not vulkan (vk) or directx12 (dx12)
 * gl+dx11 - just on opengl (gl) and directx11 (dx11)
+* +none - same as defaults 
 
 So if you wanted to test for all apis, except opengl you'd put on the command line '-api all-gl'
 

--- a/tools/slang-test/main.cpp
+++ b/tools/slang-test/main.cpp
@@ -199,7 +199,11 @@ struct Options
     Dictionary<TestCategory*, TestCategory*> excludeCategories;
 
     // By default we can test against all apis
-    int enabledApis = int(RenderApiFlag::AllOf);
+    RenderApiFlags enabledApis = RenderApiFlag::AllOf;
+
+    // By default we potentially synthesize test for all 
+    // TODO: Vulkan is disabled by default for now as the majority as vulkan synthesized tests fail  
+    RenderApiFlags synthesizedTestApis = RenderApiFlag::AllOf & ~RenderApiFlag::Vulkan;
 };
 
 // Globals
@@ -610,7 +614,23 @@ Result parseOptions(int* argc, char** argv)
             }
             const char* apiList = *argCursor++;
 
-            SlangResult res = RenderApiUtil::parseApiFlags(UnownedStringSlice(apiList), &g_options.enabledApis);
+            SlangResult res = RenderApiUtil::parseApiFlags(UnownedStringSlice(apiList), g_options.enabledApis, &g_options.enabledApis);
+            if (SLANG_FAILED(res))
+            {
+                fprintf(stderr, "error: unable to parse api list '%s'\n", apiList);
+                return res;
+            }
+        }
+        else if (strcmp(arg, "-synthesizedTestApi") == 0)
+        {
+            if (argCursor == argEnd)
+            {
+                fprintf(stderr, "error: expected comma separated list of apis '%s'\n", arg);
+                return SLANG_FAIL;
+            }
+            const char* apiList = *argCursor++;
+
+            SlangResult res = RenderApiUtil::parseApiFlags(UnownedStringSlice(apiList), g_options.synthesizedTestApis, &g_options.synthesizedTestApis);
             if (SLANG_FAILED(res))
             {
                 fprintf(stderr, "error: unable to parse api list '%s'\n", apiList);
@@ -629,6 +649,9 @@ Result parseOptions(int* argc, char** argv)
         const int availableApis = RenderApiUtil::getAvailableApis();
         // Only allow apis we know are available
         g_options.enabledApis &= availableApis;
+
+        // Can only synth for apis that are available
+        g_options.synthesizedTestApis &= g_options.enabledApis;
     }
 
     // any arguments left over were positional arguments
@@ -2066,7 +2089,7 @@ void runTestsOnFile(
     List<TestOptions> synthesizedTests;
 
     // If dx12 is available synthesize Dx12 test
-    if ((g_options.enabledApis & RenderApiFlag::D3D12) != 0)
+    if ((g_options.synthesizedTestApis & RenderApiFlag::D3D12) != 0)
     {
         // If doesn't have option generate dx12 options from dx11
         if (!hasRenderOption(RenderApiType::D3D12, testList))
@@ -2088,9 +2111,8 @@ void runTestsOnFile(
         }
     }
 
-#if 0
     // If Vulkan is available synthesize Vulkan test
-    if ((g_options.enabledApis & RenderApiFlag::Vulkan) != 0)
+    if ((g_options.synthesizedTestApis & RenderApiFlag::Vulkan) != 0)
     {
         // If doesn't have option generate dx12 options from dx11
         if (!hasRenderOption(RenderApiType::Vulkan, testList))
@@ -2102,7 +2124,7 @@ void runTestsOnFile(
                 // If it's a render test, and there is on d3d option, add one
                 if (isRenderTest(testOptions.command) && !isHLSLTest(testOptions.command) && !hasRenderOption(RenderApiType::Vulkan, testOptions))
                 {
-                    // Add with -dx12 option
+                    // Add with -vk option
                     TestOptions testOptionsCopy(testOptions);
                     testOptionsCopy.args.Add("-vk");
 
@@ -2112,13 +2134,11 @@ void runTestsOnFile(
                         testOptionsCopy.args.RemoveAt(index);
                     }
 
-
                     synthesizedTests.Add(testOptionsCopy);
                 }
             }
         }
     }
-#endif
 
     // Add any tests that were synthesized
     for (UInt i = 0; i < synthesizedTests.Count(); ++i)

--- a/tools/slang-test/main.cpp
+++ b/tools/slang-test/main.cpp
@@ -609,7 +609,7 @@ Result parseOptions(int* argc, char** argv)
         {
             if (argCursor == argEnd)
             {
-                fprintf(stderr, "error: expected comma separated list of apis '%s'\n", arg);
+                fprintf(stderr, "error: expecting an api expression (eg 'vk+dx12' or '+dx11') '%s'\n", arg);
                 return SLANG_FAIL;
             }
             const char* apiList = *argCursor++;
@@ -617,7 +617,7 @@ Result parseOptions(int* argc, char** argv)
             SlangResult res = RenderApiUtil::parseApiFlags(UnownedStringSlice(apiList), g_options.enabledApis, &g_options.enabledApis);
             if (SLANG_FAILED(res))
             {
-                fprintf(stderr, "error: unable to parse api list '%s'\n", apiList);
+                fprintf(stderr, "error: unable to parse api expression '%s'\n", apiList);
                 return res;
             }
         }
@@ -625,7 +625,7 @@ Result parseOptions(int* argc, char** argv)
         {
             if (argCursor == argEnd)
             {
-                fprintf(stderr, "error: expected comma separated list of apis '%s'\n", arg);
+                fprintf(stderr, "error: expected an api expression (eg 'vk+dx12' or '+dx11') '%s'\n", arg);
                 return SLANG_FAIL;
             }
             const char* apiList = *argCursor++;
@@ -633,7 +633,7 @@ Result parseOptions(int* argc, char** argv)
             SlangResult res = RenderApiUtil::parseApiFlags(UnownedStringSlice(apiList), g_options.synthesizedTestApis, &g_options.synthesizedTestApis);
             if (SLANG_FAILED(res))
             {
-                fprintf(stderr, "error: unable to parse api list '%s'\n", apiList);
+                fprintf(stderr, "error: unable to parse api expression '%s'\n", apiList);
                 return res;
             }
         }

--- a/tools/slang-test/render-api-util.h
+++ b/tools/slang-test/render-api-util.h
@@ -46,11 +46,11 @@ struct RenderApiUtil
         /// Returns -1 if unknown
     static RenderApiType findApiTypeByName(const Slang::UnownedStringSlice& name);
         /// Returns 0 if none found.
-    static int findApiFlagsByName(const Slang::UnownedStringSlice& name);
+    static RenderApiFlags findApiFlagsByName(const Slang::UnownedStringSlice& name);
 
         /// Parse api flags string (comma delimited list of api names, or 'all' for all)
         /// For example "all,-dx12" would be all apis, except dx12
-    static Slang::Result parseApiFlags(const Slang::UnownedStringSlice& text, int* apiBitsOut);
+    static Slang::Result parseApiFlags(const Slang::UnownedStringSlice& text, RenderApiFlags initialFlags, RenderApiFlags* apiBitsOut);
 
         /// Get information about a render API
     static const Info& getInfo(RenderApiType type) { return s_infos[int(type)]; }

--- a/tools/slang-test/render-api-util.h
+++ b/tools/slang-test/render-api-util.h
@@ -43,13 +43,15 @@ struct RenderApiUtil
         /// Returns a combination of RenderApiFlag bits which if set indicates that the API is available.
     static int getAvailableApis();
 
-        /// Returns -1 if unknown
+        /// Returns RenderApiType::Unknown if not found
     static RenderApiType findApiTypeByName(const Slang::UnownedStringSlice& name);
-        /// Returns 0 if none found.
-    static RenderApiFlags findApiFlagsByName(const Slang::UnownedStringSlice& name);
+        /// FlagsOut will have flag/flags specified by a name if returns with successful result code.
+    static Slang::Result findApiFlagsByName(const Slang::UnownedStringSlice& name, RenderApiFlags* flagsOut);
 
-        /// Parse api flags string (comma delimited list of api names, or 'all' for all)
-        /// For example "all,-dx12" would be all apis, except dx12
+        /// Parse api flags string, returning SLANG_OK on success.
+        /// If first character is + or - the flags will be applied to initialFlags, else initialFlags is ignored.
+        /// For example "all-dx12" would be all apis, except dx12
+        /// -vk would be whatever is in initial flags, but not vulkan.
     static Slang::Result parseApiFlags(const Slang::UnownedStringSlice& text, RenderApiFlags initialFlags, RenderApiFlags* apiBitsOut);
 
         /// Get information about a render API


### PR DESCRIPTION
* Parsing of control of api parameters no longer needs comma separator.
* Parsing of API list now can take an initial state.
* Document the command line option (in README.md)