### PR TITLE
Fix translation of RWTexture subscript operations for Vulkan

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -704,17 +704,33 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 // subscript operator
                 sb << "__subscript(" << uintN << " location) -> T {\n";
 
-                sb << "__target_intrinsic(glsl, \"texelFetch($P, " << ivecN << "($1)";
+                // GLSL/SPIR-V distinguished sampled vs. non-sampled images
+                switch( access )
+                {
+                case SLANG_RESOURCE_ACCESS_NONE:
+                case SLANG_RESOURCE_ACCESS_READ:
+                    sb << "__target_intrinsic(glsl, \"texelFetch($P, " << ivecN << "($1)";
+                    if( !isMultisample )
+                    {
+                        sb << ", 0";
+                    }
+                    else
+                    {
+                        // TODO: how to handle passing through sample index?
+                        sb << ", 0";
+                    }
+                    break;
 
-                if( !isMultisample )
-                {
-                    sb << ", 0";
+                default:
+                    sb << "__target_intrinsic(glsl, \"imageLoad($0, " << ivecN << "($1)";
+                    if( isMultisample )
+                    {
+                        // TODO: how to handle passing through sample index?
+                        sb << ", 0";
+                    }
+                    break;
                 }
-                else
-                {
-                    // TODO: how to handle this...
-                    sb << ", 0";
-                }
+
 
                 sb << ")$z\") get;\n";
 
@@ -730,10 +746,11 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 default:
                     sb << "__target_intrinsic(glsl, \"imageStore($0, " << ivecN << "($1), $2)\") set;\n";
 
-                    // TODO: really need a way to map access through `ref` accessor (e.g., when
-                    // used with an atomic operation) over to GLSL equivalent.
+                    // Note: HLSL doesn't support component-granularity access into typed UAVs,
+                    // and also doesn't support atomic operations on them. As such, there should
+                    // be no reason why a `ref` accessor is required here.
                     //
-                    sb << "ref;\n";
+                    // sb << "ref;\n";
                     break;
                 }
 

--- a/source/slang/core.meta.slang.h
+++ b/source/slang/core.meta.slang.h
@@ -719,17 +719,33 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 // subscript operator
                 sb << "__subscript(" << uintN << " location) -> T {\n";
 
-                sb << "__target_intrinsic(glsl, \"texelFetch($P, " << ivecN << "($1)";
+                // GLSL/SPIR-V distinguished sampled vs. non-sampled images
+                switch( access )
+                {
+                case SLANG_RESOURCE_ACCESS_NONE:
+                case SLANG_RESOURCE_ACCESS_READ:
+                    sb << "__target_intrinsic(glsl, \"texelFetch($P, " << ivecN << "($1)";
+                    if( !isMultisample )
+                    {
+                        sb << ", 0";
+                    }
+                    else
+                    {
+                        // TODO: how to handle passing through sample index?
+                        sb << ", 0";
+                    }
+                    break;
 
-                if( !isMultisample )
-                {
-                    sb << ", 0";
+                default:
+                    sb << "__target_intrinsic(glsl, \"imageLoad($0, " << ivecN << "($1)";
+                    if( isMultisample )
+                    {
+                        // TODO: how to handle passing through sample index?
+                        sb << ", 0";
+                    }
+                    break;
                 }
-                else
-                {
-                    // TODO: how to handle this...
-                    sb << ", 0";
-                }
+
 
                 sb << ")$z\") get;\n";
 
@@ -745,10 +761,11 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 default:
                     sb << "__target_intrinsic(glsl, \"imageStore($0, " << ivecN << "($1), $2)\") set;\n";
 
-                    // TODO: really need a way to map access through `ref` accessor (e.g., when
-                    // used with an atomic operation) over to GLSL equivalent.
+                    // Note: HLSL doesn't support component-granularity access into typed UAVs,
+                    // and also doesn't support atomic operations on them. As such, there should
+                    // be no reason why a `ref` accessor is required here.
                     //
-                    sb << "ref;\n";
+                    // sb << "ref;\n";
                     break;
                 }
 

--- a/source/slang/mangle.cpp
+++ b/source/slang/mangle.cpp
@@ -325,6 +325,12 @@ namespace Slang
 
         emitName(context, declRef.GetName());
 
+        // Special case: accessors need some way to distinguish themselves
+        // so that a getter/setter/ref-er don't all compile to the same name.
+        if(declRef.As<GetterDecl>())        emitRaw(context, "Ag");
+        if(declRef.As<SetterDecl>())        emitRaw(context, "As");
+        if(declRef.As<RefAccessorDecl>())   emitRaw(context, "Ar");
+
         // Are we the "inner" declaration beneath a generic decl?
         if(parentGenericDeclRef && (parentGenericDeclRef.getDecl()->inner.Ptr() == declRef.getDecl()))
         {


### PR DESCRIPTION
Partially fixes #615

There's kind of a mess going on here, and it is difficult to be sure which of the changes here are strictly necessary.
Also, our testing isn't setup to run tests that use `RWTexture2D`, so the only testing I can really run is manual tests using Falcor.

The most basic issue here is that in an earlier change I added `ref` accessors for the subscript operation on various `RW*` types in the standard library, and that included `RWTexture2D` (and the other `RWTexture*` types). The compiler ended up favoring a `ref` accessor over a `set` accessor even when the `set` would suffice, but only the `set` accessor could be lowerd to GLSL/SPIR-V.

This change ends up implementing two different fixes for the same problem:

* Logic has been added to try and favor a `set` accessor over a `ref` accessor in the cases where either could be used (but still require a `ref` accessor to be used when it is really needed)

* The `ref` accessor for `RWTexture*` has been removed, since it turns out that the operations that might have benefited from it (atomics, and component-granularity stores) aren't actually allowed on typed UAVs anyway.

There is a deeper issue here that somebody needs to go through and rationalize our representation and handling of accessors like this, but I'm not going to be able to do that in the time I can put into this PR.