### PR TITLE
Add basic support for "Dear IMGUI"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "external/glm"]
 	path = external/glm
 	url = https://github.com/g-truc/glm.git
+[submodule "external/imgui"]
+	path = external/imgui
+	url = https://github.com/ocornut/imgui.git

--- a/examples/model-viewer/main.cpp
+++ b/examples/model-viewer/main.cpp
@@ -21,6 +21,7 @@
 #include "gfx/render-d3d11.h"
 #include "gfx/vector-math.h"
 #include "gfx/window.h"
+#include "gfx/gui.h"
 using namespace gfx;
 
 // We will use a few utilities from the C++ standard library,
@@ -1273,6 +1274,7 @@ RefPtr<ParameterBlockLayout> gPerViewParameterBlockLayout;
 RefPtr<ParameterBlockLayout> gPerModelParameterBlockLayout;
 
 RefPtr<ShaderCache> shaderCache;
+RefPtr<GUI>         gui;
 
 // Most of the application state is stored in the list of loaded models.
 //
@@ -1421,7 +1423,11 @@ Result initialize()
     // Support for loading more interesting/complex models will be added
     // to this example over time (although model loading is *not* the focus).
     //
-    loadAndAddModel("cube.obj");
+    loadAndAddModel("cube.obj", ModelLoader::LoadFlag::FlipWinding);
+
+    // We will do some GUI rendering in this app, using "Dear, IMGUI",
+    // so we need to do the appropriate initialization work here.
+    gui = new GUI(gWindow, gRenderer);
 
     showWindow(gWindow);
 
@@ -1434,6 +1440,8 @@ Result initialize()
 //
 void renderFrame()
 {
+    gui->beginFrame();
+
     // In order to see that things are rendering properly we need some
     // kind of animation, so we will compute a crude delta-time value here.
     //
@@ -1454,7 +1462,10 @@ void renderFrame()
         1000.0f);
 
     glm::mat4x4 view = identity;
-    view = translate(view, glm::vec3(0, 0, -5));
+    view = glm::lookAt(
+        glm::vec3(4, 5, -5),
+        glm::vec3(0),
+        glm::vec3(0, 1, 0));
 
     glm::mat4x4 viewProjection = projection * view;
 
@@ -1584,6 +1595,18 @@ void renderFrame()
         }
     }
 
+#if 0
+    ImGui::Begin("Model Viewer");
+    ImGui::Text("Average %.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
+    if (ImGui::Button("Load Model"))
+    {
+        // need to do a file open box, and then try to open the resulting file
+
+    }
+    ImGui::End();
+#endif
+
+    gui->endFrame();
     gRenderer->presentFrame();
 }
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -394,7 +394,7 @@ tool "gfx"
     -- rather than a stand-alone executable.
     kind "StaticLib"
 
-    includedirs { ".", "external", "source" }
+    includedirs { ".", "external", "source", "external/imgui" }
 
     filter { "system:windows" }
 

--- a/source/core/smart-pointer.h
+++ b/source/core/smart-pointer.h
@@ -199,6 +199,13 @@ namespace Slang
             return pointer;
         }
 
+        void attach(T* p)
+        {
+            T* old = pointer;
+            pointer = p;
+            releaseReference(old);
+        }
+
         T* detach()
         {
             auto rs = pointer;

--- a/tools/gfx/d3d-util.cpp
+++ b/tools/gfx/d3d-util.cpp
@@ -31,6 +31,7 @@ using namespace Slang;
         case Format::RG_Float32:            return DXGI_FORMAT_R32G32_FLOAT;
         case Format::R_Float32:             return DXGI_FORMAT_R32_FLOAT;
         case Format::RGBA_Unorm_UInt8:      return DXGI_FORMAT_R8G8B8A8_UNORM;
+        case Format::R_UInt16:              return DXGI_FORMAT_R16_UINT;
         case Format::R_UInt32:              return DXGI_FORMAT_R32_UINT;
 
         case Format::D_Float32:             return DXGI_FORMAT_D32_FLOAT;

--- a/tools/gfx/gfx.vcxproj
+++ b/tools/gfx/gfx.vcxproj
@@ -95,7 +95,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..;..\..\external;..\..\source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..;..\..\external;..\..\source;..\..\external\imgui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -113,7 +113,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..;..\..\external;..\..\source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..;..\..\external;..\..\source;..\..\external\imgui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -131,7 +131,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..;..\..\external;..\..\source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..;..\..\external;..\..\source;..\..\external\imgui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -153,7 +153,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..;..\..\external;..\..\source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..;..\..\external;..\..\source;..\..\external\imgui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -174,6 +174,7 @@
     <ClInclude Include="circular-resource-heap-d3d12.h" />
     <ClInclude Include="d3d-util.h" />
     <ClInclude Include="descriptor-heap-d3d12.h" />
+    <ClInclude Include="gui.h" />
     <ClInclude Include="model.h" />
     <ClInclude Include="render-d3d11.h" />
     <ClInclude Include="render-d3d12.h" />
@@ -194,6 +195,7 @@
     <ClCompile Include="circular-resource-heap-d3d12.cpp" />
     <ClCompile Include="d3d-util.cpp" />
     <ClCompile Include="descriptor-heap-d3d12.cpp" />
+    <ClCompile Include="gui.cpp" />
     <ClCompile Include="model.cpp" />
     <ClCompile Include="render-d3d11.cpp" />
     <ClCompile Include="render-d3d12.cpp" />

--- a/tools/gfx/gfx.vcxproj.filters
+++ b/tools/gfx/gfx.vcxproj.filters
@@ -18,6 +18,9 @@
     <ClInclude Include="descriptor-heap-d3d12.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="gui.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="model.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -72,6 +75,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="descriptor-heap-d3d12.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="gui.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="model.cpp">

--- a/tools/gfx/gui.cpp
+++ b/tools/gfx/gui.cpp
@@ -1,0 +1,398 @@
+// gui.cpp
+#include "gui.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#include "external/imgui/examples/imgui_impl_win32.h"
+IMGUI_IMPL_API LRESULT  ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+#endif
+
+
+namespace gfx {
+
+#ifdef _WIN32
+LRESULT CALLBACK guiWindowProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    return ImGui_ImplWin32_WndProcHandler(hWnd, msg, wParam, lParam);
+}
+void setNativeWindowHook(Window* window, WNDPROC proc);
+#endif
+
+
+GUI::GUI(Window* window, Renderer* inRenderer)
+    : renderer(inRenderer)
+{
+     ImGui::CreateContext();
+     ImGuiIO& io = ImGui::GetIO();
+
+#ifdef _WIN32
+     ImGui_ImplWin32_Init(getPlatformWindowHandle(window));
+
+     setNativeWindowHook(window, &guiWindowProc);
+#endif
+
+    // Let's do the initialization work required for our graphics API
+    // abstraction layer, so that we can pipe all IMGUI rendering
+    // through the same interface as other work.
+    //
+
+    static const char* shaderCode =
+    "cbuffer U { float4x4 mvp; };           \
+    Texture2D t;                            \
+    SamplerState s;                         \
+    struct AssembledVertex {                \
+        float2 pos;                         \
+        float2 uv;                          \
+        float4 col;                         \
+    };                                      \
+    struct CoarseVertex {                   \
+        float4 col;                         \
+        float2 uv;                          \
+    };                                      \
+    struct VSOutput {                       \
+        CoarseVertex cv : U;                \
+        float4 pos : SV_Position;           \
+    };                                      \
+    void vertexMain(                        \
+        AssembledVertex i : U,              \
+        out VSOutput    o)                  \
+    {                                       \
+        o.cv.col = i.col;                   \
+        o.cv.uv = i.uv;                     \
+        o.pos = mul(mvp,                    \
+            float4(i.pos.xy, 0.f, 1.f));    \
+    }                                       \
+    float4 fragmentMain(                    \
+        CoarseVertex     i : U)             \
+        : SV_target                         \
+    {                                       \
+        return i.col * t.Sample(s, i.uv);   \
+    }                                       \
+    ";
+
+    SlangSession* slangSession = spCreateSession(nullptr);
+    SlangCompileRequest* slangRequest = spCreateCompileRequest(slangSession);
+
+    // TODO: These two lines need to change based on what the target graphics API
+    // is, so we need a way for a `Renderer` to pass back its prefeerred code
+    // format and profile name...
+    //
+    int targetIndex = spAddCodeGenTarget(slangRequest, SLANG_DXBC);
+    spSetTargetProfile(slangRequest, targetIndex, spFindProfile(slangSession, "sm_4_0"));
+
+    int translationUnitIndex = spAddTranslationUnit(slangRequest, SLANG_SOURCE_LANGUAGE_SLANG, nullptr);
+    spAddTranslationUnitSourceString(slangRequest, translationUnitIndex, "gui.cpp.slang", shaderCode);
+
+    char const* vertexEntryPointName    = "vertexMain";
+    char const* fragmentEntryPointName  = "fragmentMain";
+    int vertexIndex   = spAddEntryPoint(slangRequest, translationUnitIndex, vertexEntryPointName,   SLANG_STAGE_VERTEX);
+    int fragmentIndex = spAddEntryPoint(slangRequest, translationUnitIndex, fragmentEntryPointName, SLANG_STAGE_FRAGMENT);
+
+    const SlangResult compileRes = spCompile(slangRequest);
+    if(auto diagnostics = spGetDiagnosticOutput(slangRequest))
+    {
+        reportError("%s", diagnostics);
+    }
+    if(SLANG_FAILED(compileRes))
+    {
+        spDestroyCompileRequest(slangRequest);
+        spDestroySession(slangSession);
+        assert(!"unexpected");
+        return;
+    }
+
+    ISlangBlob* vertexShaderBlob = nullptr;
+    spGetEntryPointCodeBlob(slangRequest, vertexIndex, 0, &vertexShaderBlob);
+
+    ISlangBlob* fragmentShaderBlob = nullptr;
+    spGetEntryPointCodeBlob(slangRequest, fragmentIndex, 0, &fragmentShaderBlob);
+
+    char const* vertexCode = (char const*) vertexShaderBlob->getBufferPointer();
+    char const* vertexCodeEnd = vertexCode + vertexShaderBlob->getBufferSize();
+
+    char const* fragmentCode = (char const*) fragmentShaderBlob->getBufferPointer();
+    char const* fragmentCodeEnd = fragmentCode + fragmentShaderBlob->getBufferSize();
+
+    spDestroyCompileRequest(slangRequest);
+    spDestroySession(slangSession);
+
+    gfx::ShaderProgram::KernelDesc kernelDescs[] =
+    {
+        { gfx::StageType::Vertex,    vertexCode,     vertexCodeEnd },
+        { gfx::StageType::Fragment,  fragmentCode,   fragmentCodeEnd },
+    };
+
+    gfx::ShaderProgram::Desc programDesc;
+    programDesc.pipelineType = gfx::PipelineType::Graphics;
+    programDesc.kernels = &kernelDescs[0];
+    programDesc.kernelCount = 2;
+
+    auto program = renderer->createProgram(programDesc);
+
+    vertexShaderBlob->release();
+    fragmentShaderBlob->release();
+
+    InputElementDesc inputElements[] = {
+        {"U", 0, Format::RG_Float32,        offsetof(ImDrawVert, pos) },
+        {"U", 1, Format::RG_Float32,        offsetof(ImDrawVert, uv) },
+        {"U", 2, Format::RGBA_Unorm_UInt8,  offsetof(ImDrawVert, col) },
+    };
+    auto inputLayout = renderer->createInputLayout(
+        &inputElements[0],
+        SLANG_COUNT_OF(inputElements));
+
+    //
+
+    List<DescriptorSetLayout::SlotRangeDesc> descriptorSetRanges;
+    descriptorSetRanges.Add(DescriptorSetLayout::SlotRangeDesc(DescriptorSlotType::UniformBuffer));
+    descriptorSetRanges.Add(DescriptorSetLayout::SlotRangeDesc(DescriptorSlotType::SampledImage));
+    descriptorSetRanges.Add(DescriptorSetLayout::SlotRangeDesc(DescriptorSlotType::Sampler));
+
+    DescriptorSetLayout::Desc descriptorSetLayoutDesc;
+    descriptorSetLayoutDesc.slotRangeCount = descriptorSetRanges.Count();
+    descriptorSetLayoutDesc.slotRanges = descriptorSetRanges.Buffer();
+
+    descriptorSetLayout = renderer->createDescriptorSetLayout(descriptorSetLayoutDesc);
+
+    List<PipelineLayout::DescriptorSetDesc> pipelineDescriptorSets;
+    pipelineDescriptorSets.Add(PipelineLayout::DescriptorSetDesc(descriptorSetLayout));
+
+    PipelineLayout::Desc pipelineLayoutDesc;
+    pipelineLayoutDesc.descriptorSetCount = pipelineDescriptorSets.Count();
+    pipelineLayoutDesc.descriptorSets = pipelineDescriptorSets.Buffer();
+    pipelineLayoutDesc.renderTargetCount = 1;
+
+    pipelineLayout = renderer->createPipelineLayout(pipelineLayoutDesc);
+
+    TargetBlendDesc targetBlendDesc;
+    targetBlendDesc.color.srcFactor = BlendFactor::SrcAlpha;
+    targetBlendDesc.color.dstFactor = BlendFactor::InvSrcAlpha;
+    targetBlendDesc.alpha.srcFactor = BlendFactor::InvSrcAlpha;
+    targetBlendDesc.alpha.dstFactor = BlendFactor::Zero;
+
+    GraphicsPipelineStateDesc pipelineDesc;
+    pipelineDesc.renderTargetCount = 1;
+    pipelineDesc.program = program;
+    pipelineDesc.pipelineLayout = pipelineLayout;
+    pipelineDesc.inputLayout = inputLayout;
+    pipelineDesc.blend.targets = &targetBlendDesc;
+    pipelineDesc.blend.targetCount = 1;
+    pipelineDesc.rasterizer.cullMode = CullMode::None;
+
+    // Set up the pieces of fixed-function state that we care about
+    pipelineDesc.depthStencil.depthTestEnable = false;
+
+    // TODO: need to set up blending state...
+
+    pipelineState = renderer->createGraphicsPipelineState(pipelineDesc);
+
+    // Initialize the texture atlas
+    unsigned char* pixels;
+    int width, height;
+    io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+
+    {
+        gfx::TextureResource::Desc desc;
+        desc.init2D(Resource::Type::Texture2D, Format::RGBA_Unorm_UInt8, width, height, 1);
+        desc.setDefaults(Resource::Usage::PixelShaderResource);
+
+
+        ptrdiff_t mipRowStrides[] = { ptrdiff_t(width * 4 * sizeof(unsigned char)) };
+        void* subResourceData[] = { pixels };
+        TextureResource::Data initData;
+        initData.mipRowStrides = mipRowStrides;
+        initData.numMips = 1;
+        initData.numSubResources = 1;
+        initData.subResources = subResourceData;
+
+        auto texture = renderer->createTextureResource(Resource::Usage::PixelShaderResource, desc, &initData);
+
+        gfx::ResourceView::Desc viewDesc;
+        viewDesc.format = desc.format;
+        viewDesc.type = ResourceView::Type::ShaderResource;
+        auto textureView = renderer->createTextureView(texture, viewDesc);
+
+        io.Fonts->TexID = (void*) textureView.detach();
+    }
+
+    {
+        SamplerState::Desc desc;
+        samplerState = renderer->createSamplerState(desc);
+    }
+}
+
+
+
+void GUI::beginFrame()
+{
+#ifdef _WIN32
+    ImGui_ImplWin32_NewFrame();
+#endif
+    ImGui::NewFrame();
+}
+
+void GUI::endFrame()
+{
+    ImGui::Render();
+
+    ImDrawData* draw_data = ImGui::GetDrawData();
+    auto vertexCount = draw_data->TotalVtxCount;
+    auto indexCount = draw_data->TotalIdxCount;
+    int commandListCount = draw_data->CmdListsCount;
+
+    if(!vertexCount)        return;
+    if(!indexCount)         return;
+    if(!commandListCount)   return;
+
+    // Allocate transient vertex/index buffers to hold the data for this frame.
+
+    gfx::BufferResource::Desc vertexBufferDesc;
+    vertexBufferDesc.init(vertexCount * sizeof(ImDrawVert));
+    vertexBufferDesc.setDefaults(Resource::Usage::VertexBuffer);
+    vertexBufferDesc.cpuAccessFlags = Resource::AccessFlag::Write;
+    auto vertexBuffer = renderer->createBufferResource(
+        Resource::Usage::VertexBuffer,
+        vertexBufferDesc);
+
+    gfx::BufferResource::Desc indexBufferDesc;
+    indexBufferDesc.init(indexCount * sizeof(ImDrawIdx));
+    indexBufferDesc.setDefaults(Resource::Usage::IndexBuffer);
+    indexBufferDesc.cpuAccessFlags = Resource::AccessFlag::Write;
+    auto indexBuffer = renderer->createBufferResource(
+        Resource::Usage::IndexBuffer,
+        indexBufferDesc);
+
+    {
+        ImDrawVert* dstVertex = (ImDrawVert*) renderer->map(vertexBuffer, MapFlavor::WriteDiscard);
+        ImDrawIdx* dstIndex = (ImDrawIdx*) renderer->map(indexBuffer, MapFlavor::WriteDiscard);
+
+        for(int ii = 0; ii < commandListCount; ++ii)
+        {
+            const ImDrawList* commandList = draw_data->CmdLists[ii];
+            memcpy(dstVertex, commandList->VtxBuffer.Data, commandList->VtxBuffer.Size * sizeof(ImDrawVert));
+            memcpy(dstIndex, commandList->IdxBuffer.Data, commandList->IdxBuffer.Size * sizeof(ImDrawIdx));
+            dstVertex += commandList->VtxBuffer.Size;
+            dstIndex += commandList->IdxBuffer.Size;
+        }
+
+        renderer->unmap(vertexBuffer);
+        renderer->unmap(indexBuffer);
+    }
+
+    // Allocate a transient constant buffer for projection matrix
+    gfx::BufferResource::Desc constantBufferDesc;
+    constantBufferDesc.init(sizeof(glm::mat4x4));
+    constantBufferDesc.setDefaults(Resource::Usage::ConstantBuffer);
+    constantBufferDesc.cpuAccessFlags = Resource::AccessFlag::Write;
+    auto constantBuffer = renderer->createBufferResource(
+        Resource::Usage::ConstantBuffer,
+        constantBufferDesc);
+
+    {
+        glm::mat4x4* dstMVP = (glm::mat4x4*) renderer->map(constantBuffer, MapFlavor::WriteDiscard);
+
+        float L = draw_data->DisplayPos.x;
+        float R = draw_data->DisplayPos.x + draw_data->DisplaySize.x;
+        float T = draw_data->DisplayPos.y;
+        float B = draw_data->DisplayPos.y + draw_data->DisplaySize.y;
+        float mvp[4][4] =
+        {
+            { 2.0f/(R-L),   0.0f,           0.0f,       0.0f },
+            { 0.0f,         2.0f/(T-B),     0.0f,       0.0f },
+            { 0.0f,         0.0f,           0.5f,       0.0f },
+            { (R+L)/(L-R),  (T+B)/(B-T),    0.5f,       1.0f },
+        };
+        memcpy(dstMVP, mvp, sizeof(mvp));
+
+        renderer->unmap(constantBuffer);
+    }
+
+    gfx::Viewport viewport;
+    viewport.originX = 0;
+    viewport.originY = 0;
+    viewport.extentY = draw_data->DisplaySize.y;
+    viewport.extentX = draw_data->DisplaySize.x;
+    viewport.extentY = draw_data->DisplaySize.y;
+    viewport.minZ = 0;
+    viewport.maxZ = 0;
+
+    renderer->setViewport(viewport);
+
+    auto pipelineType = PipelineType::Graphics;
+    renderer->setPipelineState(pipelineType, pipelineState);
+
+    renderer->setVertexBuffer(0, vertexBuffer, sizeof(ImDrawVert));
+    renderer->setIndexBuffer(indexBuffer, sizeof(ImDrawIdx) == 2 ? Format::R_UInt16 : Format::R_UInt32);
+    renderer->setPrimitiveTopology(PrimitiveTopology::TriangleList);
+
+    UInt vertexOffset = 0;
+    UInt indexOffset = 0;
+    ImVec2 pos = draw_data->DisplayPos;
+    for(int ii = 0; ii < commandListCount; ++ii)
+    {
+        auto commandList = draw_data->CmdLists[ii];
+        auto commandCount = commandList->CmdBuffer.Size;
+        for(int jj = 0; jj < commandCount; jj++)
+        {
+            auto command = &commandList->CmdBuffer[jj];
+            if(auto userCallback = command->UserCallback)
+            {
+                userCallback(commandList, command);
+            }
+            else
+            {
+                ScissorRect rect =
+                {
+                    (Int)(command->ClipRect.x - pos.x),
+                    (Int)(command->ClipRect.y - pos.y),
+                    (Int)(command->ClipRect.z - pos.x),
+                    (Int)(command->ClipRect.w - pos.y)
+                };
+                renderer->setScissorRect(rect);
+
+                // TODO: This should be a dynamic/transient descriptor set...
+                auto descriptorSet = renderer->createDescriptorSet(descriptorSetLayout);
+                descriptorSet->setConstantBuffer(0, 0, constantBuffer);
+                descriptorSet->setResource(1, 0,
+                    (gfx::ResourceView*) command->TextureId);
+                descriptorSet->setSampler(2, 0,
+                    samplerState);
+
+                renderer->setDescriptorSet(
+                    pipelineType,
+                    pipelineLayout,
+                    0,
+                    descriptorSet);
+
+                renderer->drawIndexed(command->ElemCount, indexOffset, vertexOffset);
+            }
+            indexOffset += command->ElemCount;
+        }
+        vertexOffset += commandList->VtxBuffer.Size;
+    }
+}
+
+GUI::~GUI()
+{
+    auto& io = ImGui::GetIO();
+
+    {
+        RefPtr<ResourceView> textureView;
+        textureView.attach((ResourceView*) io.Fonts->TexID);
+        textureView = nullptr;
+    }
+
+#ifdef _WIN32
+     ImGui_ImplWin32_Shutdown();
+#endif
+
+     ImGui::DestroyContext();
+}
+
+} // gfx
+
+#include "external/imgui/imgui.cpp"
+#include "external/imgui/imgui_draw.cpp"
+#ifdef _WIN32
+#include "external/imgui/examples/imgui_impl_win32.cpp"
+#endif

--- a/tools/gfx/gui.h
+++ b/tools/gfx/gui.h
@@ -1,0 +1,28 @@
+// gui.h
+#pragma once
+
+#include "render.h"
+#include "vector-math.h"
+#include "window.h"
+
+#include "external/imgui/imgui.h"
+
+namespace gfx {
+
+struct GUI : RefObject
+{
+    GUI(Window* window, Renderer* renderer);
+    ~GUI();
+
+    void beginFrame();
+    void endFrame();
+
+private:
+    RefPtr<Renderer>            renderer;
+    RefPtr<PipelineState>       pipelineState;
+    RefPtr<DescriptorSetLayout> descriptorSetLayout;
+    RefPtr<PipelineLayout>      pipelineLayout;
+    RefPtr<SamplerState>        samplerState;
+};
+
+} // gfx

--- a/tools/gfx/render-d3d12.cpp
+++ b/tools/gfx/render-d3d12.cpp
@@ -88,6 +88,8 @@ public:
     virtual void setVertexBuffers(UInt startSlot, UInt slotCount, BufferResource*const* buffers, const UInt* strides, const UInt* offsets) override;
     virtual void setIndexBuffer(BufferResource* buffer, Format indexFormat, UInt offset) override;
     virtual void setDepthStencilTarget(ResourceView* depthStencilView) override;
+    void setViewports(UInt count, Viewport const* viewports) override;
+    void setScissorRects(UInt count, ScissorRect const* rects) override;
     virtual void setPipelineState(PipelineType pipelineType, PipelineState* state) override;
     virtual void draw(UInt vertexCount, UInt startVertex) override;
     virtual void drawIndexed(UInt indexCount, UInt startIndex, UInt baseVertex) override;
@@ -2543,6 +2545,48 @@ void D3D12Renderer::setIndexBuffer(BufferResource* buffer, Format indexFormat, U
 
 void D3D12Renderer::setDepthStencilTarget(ResourceView* depthStencilView)
 {
+}
+
+void D3D12Renderer::setViewports(UInt count, Viewport const* viewports)
+{
+    static const int kMaxViewports = D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE;
+    assert(count <= kMaxViewports);
+
+    D3D12_VIEWPORT dxViewports[kMaxViewports];
+    for(UInt ii = 0; ii < count; ++ii)
+    {
+        auto& inViewport = viewports[ii];
+        auto& dxViewport = dxViewports[ii];
+
+        dxViewport.TopLeftX = inViewport.originX;
+        dxViewport.TopLeftY = inViewport.originY;
+        dxViewport.Width    = inViewport.extentX;
+        dxViewport.Height   = inViewport.extentY;
+        dxViewport.MinDepth = inViewport.minZ;
+        dxViewport.MaxDepth = inViewport.maxZ;
+    }
+
+    m_commandList->RSSetViewports(count, dxViewports);
+}
+
+void D3D12Renderer::setScissorRects(UInt count, ScissorRect const* rects)
+{
+    static const int kMaxScissorRects = D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE;
+    assert(count <= kMaxScissorRects);
+
+    D3D12_RECT dxRects[kMaxScissorRects];
+    for(UInt ii = 0; ii < count; ++ii)
+    {
+        auto& inRect = rects[ii];
+        auto& dxRect = dxRects[ii];
+
+        dxRect.left     = inRect.minX;
+        dxRect.top      = inRect.minY;
+        dxRect.right    = inRect.maxX;
+        dxRect.bottom   = inRect.maxY;
+    }
+
+    m_commandList->RSSetScissorRects(count, dxRects);
 }
 
 void D3D12Renderer::setPipelineState(PipelineType pipelineType, PipelineState* state)

--- a/tools/gfx/render-gl.cpp
+++ b/tools/gfx/render-gl.cpp
@@ -114,6 +114,8 @@ public:
     virtual void setVertexBuffers(UInt startSlot, UInt slotCount, BufferResource*const* buffers, const UInt* strides, const UInt* offsets) override;
     virtual void setIndexBuffer(BufferResource* buffer, Format indexFormat, UInt offset) override;
     virtual void setDepthStencilTarget(ResourceView* depthStencilView) override;
+    void setViewports(UInt count, Viewport const* viewports) override;
+    void setScissorRects(UInt count, ScissorRect const* rects) override;
     virtual void setPipelineState(PipelineType pipelineType, PipelineState* state) override;
     virtual void draw(UInt vertexCount, UInt startVertex) override;
     virtual void drawIndexed(UInt indexCount, UInt startIndex, UInt baseVertex) override;
@@ -1028,6 +1030,46 @@ void GLRenderer::setIndexBuffer(BufferResource* buffer, Format indexFormat, UInt
 
 void GLRenderer::setDepthStencilTarget(ResourceView* depthStencilView)
 {
+}
+
+void GLRenderer::setViewports(UInt count, Viewport const* viewports)
+{
+    assert(count == 1);
+    auto viewport = viewports[0];
+    glViewport(
+        (GLint)     viewport.originX,
+        (GLint)     viewport.originY,
+        (GLsizei)   viewport.extentX,
+        (GLsizei)   viewport.extentY);
+    glDepthRange(viewport.minZ, viewport.maxZ);
+}
+
+void GLRenderer::setScissorRects(UInt count, ScissorRect const* rects)
+{
+    assert(count <= 1);
+    if( count )
+    {
+        // TODO: this isn't goign to be quite right because of the
+        // flipped coordinate system in GL.
+        //
+        // The best way around this is probably to *always* render
+        // things internally into textures with "flipped" conventions,
+        // and then only deal with the flipping as part of a final
+        // "present" step that copies to the primary back-buffer.
+        //
+        auto rect = rects[0];
+        glScissor(
+            rect.minX,
+            rect.minY,
+            rect.maxX - rect.minX,
+            rect.maxY - rect.minY);
+
+        glEnable(GL_SCISSOR_TEST);
+    }
+    else
+    {
+        glDisable(GL_SCISSOR_TEST);
+    }
 }
 
 void GLRenderer::setPipelineState(PipelineType pipelineType, PipelineState* state)

--- a/tools/gfx/render.cpp
+++ b/tools/gfx/render.cpp
@@ -55,6 +55,7 @@ const Resource::DescBase& Resource::getDescBase() const
 
     uint8_t(sizeof(uint32_t)),       // RGBA_Unorm_UInt8,
 
+    uint8_t(sizeof(uint16_t)),       // R_UInt16,
     uint8_t(sizeof(uint32_t)),       // R_UInt32,
 
     uint8_t(sizeof(float)),          // D_Float32,


### PR DESCRIPTION
This isn't being made visible just yet, but it will allow us to have a simple UI for loading models into the model-viewer example.

In order to support rendering with IMGUI I had to add the following to the `Renderer` layer:

* viewports
* scissor rects
* blend support

These are really only fully implemented for D3D11, but adding them to the other back-ends should be a reasonably small task.