### PR TITLE
Add support for more RasterizerOrdered types

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -1101,10 +1101,11 @@ struct EmitVisitor
             {
                 switch (type->op)
                 {
-                case kIROp_HLSLStructuredBufferType:        Emit("StructuredBuffer");           break;
-                case kIROp_HLSLRWStructuredBufferType:      Emit("RWStructuredBuffer");         break;
-                case kIROp_HLSLAppendStructuredBufferType:  Emit("AppendStructuredBuffer");     break;
-                case kIROp_HLSLConsumeStructuredBufferType: Emit("ConsumeStructuredBuffer");    break;
+                case kIROp_HLSLStructuredBufferType:                    Emit("StructuredBuffer");                   break;
+                case kIROp_HLSLRWStructuredBufferType:                  Emit("RWStructuredBuffer");                 break;
+                case kIROp_HLSLRasterizerOrderedStructuredBufferType:   Emit("RasterizerOrderedStructuredBuffer");  break;
+                case kIROp_HLSLAppendStructuredBufferType:              Emit("AppendStructuredBuffer");             break;
+                case kIROp_HLSLConsumeStructuredBufferType:             Emit("ConsumeStructuredBuffer");            break;
 
                 default:
                     SLANG_DIAGNOSE_UNEXPECTED(getSink(), SourceLoc(), "unhandled structured buffer type");
@@ -1139,9 +1140,10 @@ struct EmitVisitor
             {
                 switch (type->op)
                 {
-                case kIROp_HLSLByteAddressBufferType:           Emit("ByteAddressBuffer");                  break;
-                case kIROp_HLSLRWByteAddressBufferType:         Emit("RWByteAddressBuffer");                break;
-                case kIROp_RaytracingAccelerationStructureType: Emit("RaytracingAccelerationStructure");    break;
+                case kIROp_HLSLByteAddressBufferType:                   Emit("ByteAddressBuffer");                  break;
+                case kIROp_HLSLRWByteAddressBufferType:                 Emit("RWByteAddressBuffer");                break;
+                case kIROp_HLSLRasterizerOrderedByteAddressBufferType:  Emit("RasterizerOrderedByteAddressBuffer"); break;
+                case kIROp_RaytracingAccelerationStructureType:         Emit("RaytracingAccelerationStructure");    break;
 
                 default:
                     SLANG_DIAGNOSE_UNEXPECTED(getSink(), SourceLoc(), "unhandled buffer type");
@@ -1152,11 +1154,13 @@ struct EmitVisitor
 
         case CodeGenTarget::GLSL:
             {
+                // TODO: This "translation" is obviously wrong for GLSL.
                 switch (type->op)
                 {
-                case kIROp_HLSLByteAddressBufferType:           Emit("ByteAddressBuffer");                  break;
-                case kIROp_HLSLRWByteAddressBufferType:         Emit("RWByteAddressBuffer");                break;
-                case kIROp_RaytracingAccelerationStructureType: Emit("RaytracingAccelerationStructure");    break;
+                case kIROp_HLSLByteAddressBufferType:                   Emit("ByteAddressBuffer");                  break;
+                case kIROp_HLSLRWByteAddressBufferType:                 Emit("RWByteAddressBuffer");                break;
+                case kIROp_HLSLRasterizerOrderedByteAddressBufferType:  Emit("RasterizerOrderedByteAddressBuffer"); break;
+                case kIROp_RaytracingAccelerationStructureType:         Emit("RaytracingAccelerationStructure");    break;
 
                 default:
                     SLANG_DIAGNOSE_UNEXPECTED(getSink(), SourceLoc(), "unhandled buffer type");

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -77,9 +77,21 @@ struct OutputPatch
     __subscript(uint index) -> T;
 };
 
-__magic_type(HLSLRWByteAddressBufferType)
-__intrinsic_type($(kIROp_HLSLRWByteAddressBufferType))
-struct RWByteAddressBuffer
+${{{{
+static const struct {
+    IROp op;
+    char const* name;
+} kMutableByteAddressBufferCases[] =
+{
+    { kIROp_HLSLRWByteAddressBufferType,                "RWByteAddressBuffer" },
+    { kIROp_HLSLRasterizerOrderedByteAddressBufferType, "RasterizerOrderedByteAddressBuffer" },
+};
+for(auto item : kMutableByteAddressBufferCases) {
+}}}}
+
+__magic_type(HLSL$(item.name)Type)
+__intrinsic_type($(item.op))
+struct $(item.name)
 {
     // Note(tfoley): supports alll operations from `ByteAddressBuffer`
     // TODO(tfoley): can this be made a sub-type?
@@ -192,10 +204,27 @@ struct RWByteAddressBuffer
         uint4 value);
 };
 
+${{{{
+}
+}}}}
+
+${{{{
+static const struct {
+    IROp op;
+    char const* name;
+} kMutableStructuredBufferCases[] =
+{
+    { kIROp_HLSLRWStructuredBufferType,                "RWStructuredBuffer" },
+    { kIROp_HLSLRasterizerOrderedStructuredBufferType, "RasterizerOrderedStructuredBuffer" },
+};
+for(auto item : kMutableStructuredBufferCases) {
+}}}}
+
+
 __generic<T>
-__magic_type(HLSLRWStructuredBufferType)
-__intrinsic_type($(kIROp_HLSLRWStructuredBufferType))
-struct RWStructuredBuffer
+__magic_type(HLSL$(item.name)Type)
+__intrinsic_type($(item.op))
+struct $(item.name)
 {
     uint DecrementCounter();
 
@@ -214,6 +243,10 @@ struct RWStructuredBuffer
         ref;
 	}
 };
+
+${{{{
+}
+}}}}
 
 __generic<T>
 __magic_type(HLSLPointStreamType)

--- a/source/slang/hlsl.meta.slang.h
+++ b/source/slang/hlsl.meta.slang.h
@@ -95,12 +95,30 @@ SLANG_RAW("{\n")
 SLANG_RAW("    __subscript(uint index) -> T;\n")
 SLANG_RAW("};\n")
 SLANG_RAW("\n")
-SLANG_RAW("__magic_type(HLSLRWByteAddressBufferType)\n")
+
+static const struct {
+    IROp op;
+    char const* name;
+} kMutableByteAddressBufferCases[] =
+{
+    { kIROp_HLSLRWByteAddressBufferType,                "RWByteAddressBuffer" },
+    { kIROp_HLSLRasterizerOrderedByteAddressBufferType, "RasterizerOrderedByteAddressBuffer" },
+};
+for(auto item : kMutableByteAddressBufferCases) {
+SLANG_RAW("\n")
+SLANG_RAW("\n")
+SLANG_RAW("__magic_type(HLSL")
+SLANG_SPLICE(item.name
+)
+SLANG_RAW("Type)\n")
 SLANG_RAW("__intrinsic_type(")
-SLANG_SPLICE(kIROp_HLSLRWByteAddressBufferType
+SLANG_SPLICE(item.op
 )
 SLANG_RAW(")\n")
-SLANG_RAW("struct RWByteAddressBuffer\n")
+SLANG_RAW("struct ")
+SLANG_SPLICE(item.name
+)
+SLANG_RAW("\n")
 SLANG_RAW("{\n")
 SLANG_RAW("    // Note(tfoley): supports alll operations from `ByteAddressBuffer`\n")
 SLANG_RAW("    // TODO(tfoley): can this be made a sub-type?\n")
@@ -213,13 +231,36 @@ SLANG_RAW("        uint address,\n")
 SLANG_RAW("        uint4 value);\n")
 SLANG_RAW("};\n")
 SLANG_RAW("\n")
+
+}
+SLANG_RAW("\n")
+SLANG_RAW("\n")
+
+static const struct {
+    IROp op;
+    char const* name;
+} kMutableStructuredBufferCases[] =
+{
+    { kIROp_HLSLRWStructuredBufferType,                "RWStructuredBuffer" },
+    { kIROp_HLSLRasterizerOrderedStructuredBufferType, "RasterizerOrderedStructuredBuffer" },
+};
+for(auto item : kMutableStructuredBufferCases) {
+SLANG_RAW("\n")
+SLANG_RAW("\n")
+SLANG_RAW("\n")
 SLANG_RAW("__generic<T>\n")
-SLANG_RAW("__magic_type(HLSLRWStructuredBufferType)\n")
+SLANG_RAW("__magic_type(HLSL")
+SLANG_SPLICE(item.name
+)
+SLANG_RAW("Type)\n")
 SLANG_RAW("__intrinsic_type(")
-SLANG_SPLICE(kIROp_HLSLRWStructuredBufferType
+SLANG_SPLICE(item.op
 )
 SLANG_RAW(")\n")
-SLANG_RAW("struct RWStructuredBuffer\n")
+SLANG_RAW("struct ")
+SLANG_SPLICE(item.name
+)
+SLANG_RAW("\n")
 SLANG_RAW("{\n")
 SLANG_RAW("    uint DecrementCounter();\n")
 SLANG_RAW("\n")
@@ -238,6 +279,10 @@ SLANG_RAW("        __intrinsic_op(bufferElementRef)\n")
 SLANG_RAW("        ref;\n")
 SLANG_RAW("\t}\n")
 SLANG_RAW("};\n")
+SLANG_RAW("\n")
+
+}
+SLANG_RAW("\n")
 SLANG_RAW("\n")
 SLANG_RAW("__generic<T>\n")
 SLANG_RAW("__magic_type(HLSLPointStreamType)\n")

--- a/source/slang/ir-inst-defs.h
+++ b/source/slang/ir-inst-defs.h
@@ -93,8 +93,9 @@ INST(Nop, nop, 0, 0)
     INST_RANGE(ResourceTypeBase, FirstTextureType, LastGLSLImageType)
 
     /* UntypedBufferResourceType */
-        INST(HLSLByteAddressBufferType,      ByteAddressBuffer,   0, 0)
-        INST(HLSLRWByteAddressBufferType,    RWByteAddressBuffer, 0, 0)
+        INST(HLSLByteAddressBufferType,                     ByteAddressBuffer,   0, 0)
+        INST(HLSLRWByteAddressBufferType,                   RWByteAddressBuffer, 0, 0)
+        INST(HLSLRasterizerOrderedByteAddressBufferType,    RasterizerOrderedByteAddressBuffer, 0, 0)
         INST(RaytracingAccelerationStructureType, RaytracingAccelerationStructure, 0, 0)
     INST_RANGE(UntypedBufferResourceType, HLSLByteAddressBufferType, RaytracingAccelerationStructureType)
 
@@ -113,10 +114,11 @@ INST(Nop, nop, 0, 0)
         INST_RANGE(HLSLStreamOutputType, HLSLPointStreamType, HLSLTriangleStreamType)
 
         /* HLSLStructuredBufferTypeBase */
-            INST(HLSLStructuredBufferType,          StructuredBuffer,           0, 0)
-            INST(HLSLRWStructuredBufferType,        RWStructuredBuffer,         0, 0)
-            INST(HLSLAppendStructuredBufferType,    AppendStructuredBuffer,     0, 0)
-            INST(HLSLConsumeStructuredBufferType,   ConsumeStructuredBuffer,    0, 0)
+            INST(HLSLStructuredBufferType,                  StructuredBuffer,                   0, 0)
+            INST(HLSLRWStructuredBufferType,                RWStructuredBuffer,                 0, 0)
+            INST(HLSLRasterizerOrderedStructuredBufferType, RasterizerOrderedStructuredBuffer,  0, 0)
+            INST(HLSLAppendStructuredBufferType,            AppendStructuredBuffer,             0, 0)
+            INST(HLSLConsumeStructuredBufferType,           ConsumeStructuredBuffer,            0, 0)
         INST_RANGE(HLSLStructuredBufferTypeBase, HLSLStructuredBufferType, HLSLConsumeStructuredBufferType)
 
         /* PointerLikeType */

--- a/source/slang/ir.h
+++ b/source/slang/ir.h
@@ -709,11 +709,12 @@ SIMPLE_IR_PARENT_TYPE(PointerLikeType, BuiltinGenericType);
 SIMPLE_IR_PARENT_TYPE(HLSLStructuredBufferTypeBase, BuiltinGenericType)
 SIMPLE_IR_TYPE(HLSLStructuredBufferType, HLSLStructuredBufferTypeBase)
 SIMPLE_IR_TYPE(HLSLRWStructuredBufferType, HLSLStructuredBufferTypeBase)
-// TODO: need raster-ordered case here
+SIMPLE_IR_TYPE(HLSLRasterizerOrderedStructuredBufferType, HLSLStructuredBufferTypeBase)
 
 SIMPLE_IR_PARENT_TYPE(UntypedBufferResourceType, Type)
 SIMPLE_IR_TYPE(HLSLByteAddressBufferType, UntypedBufferResourceType)
 SIMPLE_IR_TYPE(HLSLRWByteAddressBufferType, UntypedBufferResourceType)
+SIMPLE_IR_TYPE(HLSLRasterizerOrderedByteAddressBufferType, UntypedBufferResourceType)
 
 SIMPLE_IR_TYPE(HLSLAppendStructuredBufferType, HLSLStructuredBufferTypeBase)
 SIMPLE_IR_TYPE(HLSLConsumeStructuredBufferType, HLSLStructuredBufferTypeBase)

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -143,10 +143,12 @@ SLANG_API SlangTypeKind spReflectionType_GetKind(SlangReflectionType* inType)
 
     CASE(HLSLStructuredBufferType);
     CASE(HLSLRWStructuredBufferType);
+    CASE(HLSLRasterizerOrderedStructuredBufferType);
     CASE(HLSLAppendStructuredBufferType);
     CASE(HLSLConsumeStructuredBufferType);
     CASE(HLSLByteAddressBufferType);
     CASE(HLSLRWByteAddressBufferType);
+    CASE(HLSLRasterizerOrderedByteAddressBufferType);
     CASE(UntypedBufferResourceType);
 #undef CASE
 
@@ -364,13 +366,15 @@ SLANG_API SlangResourceShape spReflectionType_GetResourceShape(SlangReflectionTy
         return SHAPE;               \
     } while(0)
 
-    CASE(HLSLStructuredBufferType,          SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_READ);
-    CASE(HLSLRWStructuredBufferType,        SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_READ_WRITE);
-    CASE(HLSLAppendStructuredBufferType,    SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_APPEND);
-    CASE(HLSLConsumeStructuredBufferType,   SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_CONSUME);
-    CASE(HLSLByteAddressBufferType,         SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_READ);
-    CASE(HLSLRWByteAddressBufferType,       SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_READ_WRITE);
-    CASE(UntypedBufferResourceType,         SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_READ);
+    CASE(HLSLStructuredBufferType,                      SLANG_STRUCTURED_BUFFER,    SLANG_RESOURCE_ACCESS_READ);
+    CASE(HLSLRWStructuredBufferType,                    SLANG_STRUCTURED_BUFFER,    SLANG_RESOURCE_ACCESS_READ_WRITE);
+    CASE(HLSLRasterizerOrderedStructuredBufferType,     SLANG_STRUCTURED_BUFFER,    SLANG_RESOURCE_ACCESS_RASTER_ORDERED);
+    CASE(HLSLAppendStructuredBufferType,                SLANG_STRUCTURED_BUFFER,    SLANG_RESOURCE_ACCESS_APPEND);
+    CASE(HLSLConsumeStructuredBufferType,               SLANG_STRUCTURED_BUFFER,    SLANG_RESOURCE_ACCESS_CONSUME);
+    CASE(HLSLByteAddressBufferType,                     SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_READ);
+    CASE(HLSLRWByteAddressBufferType,                   SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_READ_WRITE);
+    CASE(HLSLRasterizerOrderedByteAddressBufferType,    SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_RASTER_ORDERED);
+    CASE(UntypedBufferResourceType,                     SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_READ);
 #undef CASE
 
     return SLANG_RESOURCE_NONE;
@@ -397,16 +401,18 @@ SLANG_API SlangResourceAccess spReflectionType_GetResourceAccess(SlangReflection
         return ACCESS;              \
     } while(0)
 
-    CASE(HLSLStructuredBufferType,          SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_READ);
-    CASE(HLSLRWStructuredBufferType,        SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_READ_WRITE);
-    CASE(HLSLAppendStructuredBufferType,    SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_APPEND);
-    CASE(HLSLConsumeStructuredBufferType,   SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_CONSUME);
-    CASE(HLSLByteAddressBufferType,         SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_READ);
-    CASE(HLSLRWByteAddressBufferType,       SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_READ_WRITE);
-    CASE(UntypedBufferResourceType,         SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_READ);
+    CASE(HLSLStructuredBufferType,                      SLANG_STRUCTURED_BUFFER,    SLANG_RESOURCE_ACCESS_READ);
+    CASE(HLSLRWStructuredBufferType,                    SLANG_STRUCTURED_BUFFER,    SLANG_RESOURCE_ACCESS_READ_WRITE);
+    CASE(HLSLRasterizerOrderedStructuredBufferType,     SLANG_STRUCTURED_BUFFER,    SLANG_RESOURCE_ACCESS_RASTER_ORDERED);
+    CASE(HLSLAppendStructuredBufferType,                SLANG_STRUCTURED_BUFFER,    SLANG_RESOURCE_ACCESS_APPEND);
+    CASE(HLSLConsumeStructuredBufferType,               SLANG_STRUCTURED_BUFFER,    SLANG_RESOURCE_ACCESS_CONSUME);
+    CASE(HLSLByteAddressBufferType,                     SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_READ);
+    CASE(HLSLRWByteAddressBufferType,                   SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_READ_WRITE);
+    CASE(HLSLRasterizerOrderedByteAddressBufferType,    SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_RASTER_ORDERED);
+    CASE(UntypedBufferResourceType,                     SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_READ);
 
     // This isn't entirely accurate, but I can live with it for now
-    CASE(GLSLShaderStorageBufferType,       SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_READ_WRITE);
+    CASE(GLSLShaderStorageBufferType, SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_READ_WRITE);
 #undef CASE
 
     return SLANG_RESOURCE_ACCESS_NONE;
@@ -480,10 +486,11 @@ SLANG_API SlangReflectionType* spReflectionType_GetResourceResultType(SlangRefle
 
     // TODO: structured buffer needs to expose type layout!
 
-    CASE(HLSLStructuredBufferType,          SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_READ);
-    CASE(HLSLRWStructuredBufferType,        SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_READ_WRITE);
-    CASE(HLSLAppendStructuredBufferType,    SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_APPEND);
-    CASE(HLSLConsumeStructuredBufferType,   SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_CONSUME);
+    CASE(HLSLStructuredBufferType,                  SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_READ);
+    CASE(HLSLRWStructuredBufferType,                SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_READ_WRITE);
+    CASE(HLSLRasterizerOrderedStructuredBufferType, SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_RASTER_ORDERED);
+    CASE(HLSLAppendStructuredBufferType,            SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_APPEND);
+    CASE(HLSLConsumeStructuredBufferType,           SLANG_STRUCTURED_BUFFER, SLANG_RESOURCE_ACCESS_CONSUME);
 #undef CASE
 
     return nullptr;

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -873,6 +873,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
             CASE(HLSLStructuredBufferType, HLSLStructuredBufferType)
             CASE(HLSLRWStructuredBufferType, HLSLRWStructuredBufferType)
+            CASE(HLSLRasterizerOrderedStructuredBufferType, HLSLRasterizerOrderedStructuredBufferType)
             CASE(HLSLAppendStructuredBufferType, HLSLAppendStructuredBufferType)
             CASE(HLSLConsumeStructuredBufferType, HLSLConsumeStructuredBufferType)
 
@@ -893,6 +894,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
             CASE(HLSLByteAddressBufferType, HLSLByteAddressBufferType)
             CASE(HLSLRWByteAddressBufferType, HLSLRWByteAddressBufferType)
+            CASE(HLSLRasterizerOrderedByteAddressBufferType, HLSLRasterizerOrderedByteAddressBufferType)
             CASE(UntypedBufferResourceType, UntypedBufferResourceType)
 
             CASE(GLSLInputAttachmentType, GLSLInputAttachmentType)

--- a/source/slang/type-defs.h
+++ b/source/slang/type-defs.h
@@ -195,11 +195,12 @@ SIMPLE_SYNTAX_CLASS(PointerLikeType, BuiltinGenericType)
 SIMPLE_SYNTAX_CLASS(HLSLStructuredBufferTypeBase, BuiltinGenericType)
 SIMPLE_SYNTAX_CLASS(HLSLStructuredBufferType, HLSLStructuredBufferTypeBase)
 SIMPLE_SYNTAX_CLASS(HLSLRWStructuredBufferType, HLSLStructuredBufferTypeBase)
-// TODO: need raster-ordered case here
+SIMPLE_SYNTAX_CLASS(HLSLRasterizerOrderedStructuredBufferType, HLSLStructuredBufferTypeBase)
 
 SIMPLE_SYNTAX_CLASS(UntypedBufferResourceType, BuiltinType)
 SIMPLE_SYNTAX_CLASS(HLSLByteAddressBufferType, UntypedBufferResourceType)
 SIMPLE_SYNTAX_CLASS(HLSLRWByteAddressBufferType, UntypedBufferResourceType)
+SIMPLE_SYNTAX_CLASS(HLSLRasterizerOrderedByteAddressBufferType, UntypedBufferResourceType)
 SIMPLE_SYNTAX_CLASS(RaytracingAccelerationStructureType, UntypedBufferResourceType)
 
 SIMPLE_SYNTAX_CLASS(HLSLAppendStructuredBufferType, HLSLStructuredBufferTypeBase)

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -1659,10 +1659,11 @@ SimpleLayoutInfo GetLayoutImpl(
         return info;                                                    \
     } while(0)
 
-    CASE(HLSLStructuredBufferType,          StructuredBuffer);
-    CASE(HLSLRWStructuredBufferType,        MutableStructuredBuffer);
-    CASE(HLSLAppendStructuredBufferType,    MutableStructuredBuffer);
-    CASE(HLSLConsumeStructuredBufferType,   MutableStructuredBuffer);
+    CASE(HLSLStructuredBufferType,                  StructuredBuffer);
+    CASE(HLSLRWStructuredBufferType,                MutableStructuredBuffer);
+    CASE(HLSLRasterizerOrderedStructuredBufferType, MutableStructuredBuffer);
+    CASE(HLSLAppendStructuredBufferType,            MutableStructuredBuffer);
+    CASE(HLSLConsumeStructuredBufferType,           MutableStructuredBuffer);
 
 #undef CASE
 
@@ -1675,8 +1676,9 @@ SimpleLayoutInfo GetLayoutImpl(
             type, rules, outTypeLayout);                        \
     } while(0)
 
-    CASE(HLSLByteAddressBufferType,         RawBuffer);
-    CASE(HLSLRWByteAddressBufferType,       MutableRawBuffer);
+    CASE(HLSLByteAddressBufferType,                     RawBuffer);
+    CASE(HLSLRWByteAddressBufferType,                   MutableRawBuffer);
+    CASE(HLSLRasterizerOrderedByteAddressBufferType,    MutableRawBuffer);
 
     CASE(GLSLInputAttachmentType,           InputRenderTarget);
 

--- a/tests/front-end/rasterizer-ordered-uav.slang
+++ b/tests/front-end/rasterizer-ordered-uav.slang
@@ -1,0 +1,20 @@
+// rasterizer-ordered-uav.slang
+//TEST:SIMPLE:
+
+// Confirm that the `RasterizerOrdered*` types are supported
+
+struct S { float4 a; }
+
+RasterizerOrderedBuffer<float4> 		b0;
+RasterizerOrderedByteAddressBuffer 		b1;
+RasterizerOrderedStructuredBuffer<S>	b2;
+RasterizerOrderedTexture1D<float4>		b3;
+RasterizerOrderedTexture1DArray			b4;
+RasterizerOrderedTexture2D 				b5;
+RasterizerOrderedTexture2DArray<float4>	b6;
+RasterizerOrderedTexture3D<int>			b7;
+
+
+float4 test(uint4 coord, float4 value)
+{
+}


### PR DESCRIPTION
Fixes #627

The front-end has support for `RasterizerOrderedBuffer` and `RasterizerOrderedTexture*`, but left out support for:

* `RasterizerOrderedByteAddressBuffer`
* `RasterizerOrderedStructuredBuffer`

[Nitpick: these tyeps are all amazingly annoying to type. It is easy to want to write `RasterOrdered` instead of the bulkier `RasterizerOrdered`, and almost everybody does in casual speech. There's already the issue of wanting to type `StructureBuffer` (a buffer of structures) instead of `StructuredBuffer` (a buffer that is... structured?). Then you have `ByteAddressBuffer` which is just adding to the confusion because it is nominally a "byte addressable" buffer (so that `ByteAddressedBuffer` would actually make sense), but then actually *isn't* byte addressable in practice.]

There were a few `TODO` comments related to this already, and this change was mostly a matter of doing a find-in-files for `RWByteAddressBuffer` and `RWStructuredBuffer` and adding matching `RasterizerOrdered` cases.

The test I added just checks that these types make it through the front-end, and doesn't do any actual confirmation that they work as intended. It is worth noting that the handling of ordering in GLSL/VK is different from in HLSL ("pixel shader interlock" instead of "rasterizer ordered views"), so coming up with a cross-compilation story would need to be a later step.