### PR TITLE
Add basic support for #pragma once

### DIFF
--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -1876,7 +1876,7 @@ namespace Slang
             }
             return true;
         }
-        
+
         bool validateAttribute(RefPtr<Attribute> attr)
         {
                 if(auto numThreadsAttr = attr.As<NumThreadsAttribute>())
@@ -1939,7 +1939,7 @@ namespace Slang
 
                     entryPointAttr->stage = stage;
                 }
-                else if ((attr.As<DomainAttribute>()) || 
+                else if ((attr.As<DomainAttribute>()) ||
                          (attr.As<MaxTessFactorAttribute>()) ||
                          (attr.As<OutputTopologyAttribute>()) ||
                          (attr.As<PartitioningAttribute>()) ||
@@ -1964,7 +1964,7 @@ namespace Slang
                     // Has no args
                     SLANG_ASSERT(attr->args.Count() == 0);
                 }
-                else 
+                else
                 {
                     if(attr->args.Count() == 0)
                     {
@@ -3639,8 +3639,9 @@ namespace Slang
                 auto prevResultType = GetResultType(prevFuncDeclRef);
                 if (!resultType->Equals(prevResultType))
                 {
-                    // Bad dedeclaration
-                    getSink()->diagnose(funcDecl, Diagnostics::unimplemented, "redeclaration has a different return type");
+                    // Bad redeclaration
+                    getSink()->diagnose(funcDecl, Diagnostics::functionRedeclarationWithDifferentReturnType, funcDecl->getName(), resultType, prevResultType);
+                    getSink()->diagnose(prevFuncDecl, Diagnostics::seePreviousDeclarationOf, funcDecl->getName());
 
                     // Don't bother emitting other errors at this point
                     break;
@@ -3671,7 +3672,8 @@ namespace Slang
                 if (funcDecl->Body && prevFuncDecl->Body)
                 {
                     // Redefinition
-                    getSink()->diagnose(funcDecl, Diagnostics::unimplemented, "function redefinition");
+                    getSink()->diagnose(funcDecl, Diagnostics::functionRedefinition, funcDecl->getName());
+                    getSink()->diagnose(prevFuncDecl, Diagnostics::seePreviousDefinitionOf, funcDecl->getName());
 
                     // Don't bother emitting other errors
                     break;
@@ -8379,7 +8381,7 @@ namespace Slang
         // TODO: We currently do minimal checking here, but this is the
         // right place to perform the following validation checks:
         //
-        
+
         // * Are the function input/output parameters and result type
         //   all valid for the chosen stage? (e.g., there shouldn't be
         //   an `OutputStream<X>` type in a vertex shader signature)

--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -42,6 +42,7 @@ DIAGNOSTIC(-1, Note, doYouForgetToMakeComponentAccessible, "do you forget to mak
 
 DIAGNOSTIC(-1, Note, seeDeclarationOf, "see declaration of '$0'")
 DIAGNOSTIC(-1, Note, seeOtherDeclarationOf, "see other declaration of '$0'")
+DIAGNOSTIC(-1, Note, seePreviousDeclarationOf, "see previous declaration of '$0'")
 
 //
 // 0xxxx -  Command line and interaction with host platform APIs.
@@ -67,7 +68,7 @@ DIAGNOSTIC(    12, Error, cannotDeduceSourceLanguage, "can't deduce language for
 DIAGNOSTIC(    13, Error, unknownCodeGenerationTarget, "unknown code generation target '$0'");
 DIAGNOSTIC(    14, Error, unknownProfile, "unknown profile '$0'");
 DIAGNOSTIC(    15, Error, unknownStage, "unknown stage '$0'");
-DIAGNOSTIC(    16, Error, unknownPassThroughTarget, "unknown pass-through target '$0'");    
+DIAGNOSTIC(    16, Error, unknownPassThroughTarget, "unknown pass-through target '$0'");
 DIAGNOSTIC(    17, Error, unknownCommandLineOption, "unknown command-line option '$0'");
 DIAGNOSTIC(    18, Error, noProfileSpecified, "no profile specified; use the '-profile <profile name>' option");
 DIAGNOSTIC(    19, Error, multipleEntryPointsNeedMulitpleProfiles, "when multiple entry points are specified, each must have a profile given (with '-profile') before the '-entry' option");
@@ -160,7 +161,6 @@ DIAGNOSTIC(20011, Error, unexpectedColon, "unexpected ':'.")
 // 3xxxx - Semantic analysis
 //
 
-DIAGNOSTIC(30001, Error, functionRedefinitionWithArgList, "'$0$1': function redefinition.")
 DIAGNOSTIC(30002, Error, parameterAlreadyDefined, "parameter '$0' already defined.")
 DIAGNOSTIC(30003, Error, breakOutsideLoop, "'break' must appear inside loop constructs.")
 DIAGNOSTIC(30004, Error, continueOutsideLoop, "'continue' must appear inside loop constructs.")
@@ -203,8 +203,14 @@ DIAGNOSTIC(30052, Error, invalidSwizzleExpr, "invalid swizzle pattern '$0' on ty
 
 DIAGNOSTIC(30100, Error, staticRefToNonStaticMember, "type '$0' cannot be used to refer to non-static member '$1'")
 
+DIAGNOSTIC(30201, Error, functionRedefinition, "function '$0' already has a body")
+DIAGNOSTIC(30202, Error, functionRedeclarationWithDifferentReturnType, "function '$0' declared to return '$1' was previously declared to return '$2'")
+
+
 DIAGNOSTIC(33070, Error, expectedFunction, "expression preceding parenthesis of apparent call must have function type.")
 DIAGNOSTIC(33071, Error, expectedAStringLiteral, "expected a string literal")
+
+
 
 // Attributes
 DIAGNOSTIC(31000, Error, unknownAttributeName, "unknown attribute '$0'")

--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -131,6 +131,10 @@ DIAGNOSTIC(15403, Error, expectedTokenInMacroParameters, "expected '$0' in macro
 DIAGNOSTIC(15500, Warning, expectedTokenInMacroArguments, "expected '$0' in macro invocation")
 DIAGNOSTIC(15501, Error, wrongNumberOfArgumentsToMacro, "wrong number of arguments to macro (expected $0, got $1)")
 
+// 156xx - pragmas
+DIAGNOSTIC(15600, Error, expectedPragmaDirectiveName, "expected a name after '#pragma'")
+DIAGNOSTIC(15601, Warning, unknownPragmaDirectiveIgnored, "ignoring unknown directive '#pragma $0'")
+
 // 159xx - user-defined error/warning
 DIAGNOSTIC(15900, Error,    userDefinedError,   "#error: $0")
 DIAGNOSTIC(15901, Warning,  userDefinedWarning, "#warning: $0")

--- a/tests/preprocessor/pragma-once-a.h
+++ b/tests/preprocessor/pragma-once-a.h
@@ -1,0 +1,6 @@
+// pragma-once-a.h
+#pragma once
+
+// Used by the `pragma-once.slang` test
+
+float foo(float x) { return x; }

--- a/tests/preprocessor/pragma-once-b.h
+++ b/tests/preprocessor/pragma-once-b.h
@@ -1,0 +1,5 @@
+// pragma-once-b.h
+
+// Used by the `pragma-once.slang` test
+
+#define BAR foo

--- a/tests/preprocessor/pragma-once.slang
+++ b/tests/preprocessor/pragma-once.slang
@@ -1,0 +1,42 @@
+//TEST(smoke):SIMPLE:
+
+// Test support for `#pragma once`
+
+// We will include two header files:
+// one that uses `#pragma once`, and
+// one that doesn't.
+//
+// The first file defines a function `foo()`,
+// and the second defines a macro `BAR`
+//
+#include "pragma-once-a.h"
+#include "pragma-once-b.h"
+
+// We will include the files again, and
+// before we do so we need to undefine
+// the macro from the second file so
+// that it doesn't get a redefinition diagnostic.
+//
+#undef BAR
+//
+// We don't do anything about the function
+// in the first file, because we expect
+// the `#pragma once` to cause it to be
+// ignored on this second time.
+//
+#include "pragma-once-a.h"
+#include "pragma-once-b.h"
+
+// Now let's use both the function and the
+// macro, to confirm that they are both
+// defined as expected.
+//
+// Note: if we accidentally include file
+// `a.h` more than once, we'd expect to
+// get an error here, because the two
+// function definitions conflict.
+//
+float test(float x)
+{
+	return foo(x) + BAR(x);
+}


### PR DESCRIPTION
This work is broken into three changes just to keep it clean:

1. Add a better error message for function redefinition. My test case for `#pragma once` started out giving an internal compiler error for a simple issue, so I cleaned up the code.

2. Add basic support for recognizing `#pragma` directives. The existing code was just blindly ignoring all of them, so I added support for dispatching on the "sub-directive" token. This also added a warning for unknown `#pragma` sub-directives.

3. Actually add `#pragma once` in the simplest way possible.

There's plenty of work that could still be done on this, as discussed in the commit message for the third change. Still, this is hopefully enough that many users can muddle through.