### PR TITLE
Control unit tests being run with -category -exclude and using prefix.

### DIFF
--- a/test.bat
+++ b/test.bat
@@ -56,4 +56,3 @@ SET "PATH=%PATH%;%SLANG_TEST_BIN_DIR%"
 :: TODO: Maybe we should actually invoke `msbuild` to make sure all the code is up to date?
 
 "%SLANG_TEST_BIN_DIR%slang-test.exe" -bindir "%SLANG_TEST_BIN_DIR%\" %*
-"%SLANG_TEST_BIN_DIR%slang-test.exe" -bindir "%SLANG_TEST_BIN_DIR%\" -unitTests


### PR DESCRIPTION
* Unit tests appear in unit-test category
* Unit tests 'appear' (as there is no actual directory) in a directory unit-tests. 
* Removed the -unitTests command line option

Thus can run a specific unit test with 
`unit-tests/Free` will run any unit tests starting with Free (such as FreeList)
Or just for unit tests you can also use
`-category unit-test`