### PR TITLE
Warn when undefined identifier used in preprocessor conditional

### DIFF
--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -114,6 +114,7 @@ DIAGNOSTIC(15201, Error, syntaxErrorInPreprocessorExpression, "syntax error in p
 DIAGNOSTIC(15202, Error, divideByZeroInPreprocessorExpression, "division by zero in preprocessor expression");
 DIAGNOSTIC(15203, Error, expectedTokenInDefinedExpression, "expected '$0' in 'defined' expression");
 DIAGNOSTIC(15204, Warning, directiveExpectsExpression, "'$0' directive requires an expression");
+DIAGNOSTIC(15205, Warning, undefinedIdentifierInPreprocessorExpression, "undefined idenfier '$0' in preprocessor expression will evaluate to zero")
 
 DIAGNOSTIC(-1, Note, seeOpeningToken, "see opening '$0'")
 

--- a/source/slang/preprocessor.cpp
+++ b/source/slang/preprocessor.cpp
@@ -1213,6 +1213,7 @@ static PreprocessorExpressionValue ParseAndEvaluateUnaryExpression(PreprocessorD
             // An identifier here means it was not defined as a macro (or
             // it is defined, but as a function-like macro. These should
             // just evaluate to zero (possibly with a warning)
+            GetSink(context)->diagnose(token.loc, Diagnostics::undefinedIdentifierInPreprocessorExpression, token.getName());
             return 0;
         }
 

--- a/tests/diagnostics/undefined-in-preprocessor-conditional.slang
+++ b/tests/diagnostics/undefined-in-preprocessor-conditional.slang
@@ -1,0 +1,10 @@
+//TEST(smoke):SIMPLE:
+
+// Use an undefined identifier in a preprocessor conditional
+
+#define FOO  1
+#define BORT 1
+
+#if FOO && BART
+#error Should not get here
+#endif

--- a/tests/diagnostics/undefined-in-preprocessor-conditional.slang.expected
+++ b/tests/diagnostics/undefined-in-preprocessor-conditional.slang.expected
@@ -1,0 +1,6 @@
+result code = 0
+standard error = {
+tests/diagnostics/undefined-in-preprocessor-conditional.slang(8): warning 15205: undefined idenfier 'BART' in preprocessor expression will evaluate to zero
+}
+standard output = {
+}


### PR DESCRIPTION
This can mask an error when the user either typos a macro name when writing a conditional, or (as was the case for the user who pointed out this issue) they mistakenly assume that a `#define` in an `import`ed file has been made visible to them.

This change just adds the warning in the obvious place, with a test code to ensure it triggers.