### PR TITLE
Reorder ops so that normal op indices are confused by ranges.

### DIFF
--- a/source/slang/ir-inst-defs.h
+++ b/source/slang/ir-inst-defs.h
@@ -88,6 +88,10 @@ INST(Nop, nop, 0, 0)
                 MANUAL_INST_RANGE(TextureSamplerType, 0x20000, TextureFlavor::Count)
                 /* GLSLImageType */
                 MANUAL_INST_RANGE(GLSLImageType, 0x30000, TextureFlavor::Count)
+
+                // Define the manual range that type uses
+                MANUAL_INST_RANGE(TypeManualRange, 0x10000, 0x30000 + TextureFlavor::Count - 0x10000)
+
             INST_RANGE(TextureTypeBase, FirstTextureType, LastGLSLImageType)
         INST_RANGE(ResourceType, FirstTextureType, LastGLSLImageType)
     INST_RANGE(ResourceTypeBase, FirstTextureType, LastGLSLImageType)

--- a/source/slang/ir.h
+++ b/source/slang/ir.h
@@ -406,6 +406,8 @@ struct IRInstList : IRInstListBase
 #define IR_LEAF_ISA(NAME) static bool isaImpl(IROp op) { return op == kIROp_##NAME; }
 #define IR_PARENT_ISA(NAME) static bool isaImpl(IROp op) { return op >= kIROp_First##NAME && op <= kIROp_Last##NAME; }
 
+#define IR_PARENT_ISA_WITH_MANUAL_RANGE(NAME, MANUAL_RANGE) static bool isaImpl(IROp op) {  return (op >= kIROp_First##NAME && op <= kIROp_Last##NAME) || (op >= kIROp_First##MANUAL_RANGE && op <= kIROp_Last##MANUAL_RANGE); }
+
 #define SIMPLE_IR_TYPE(NAME, BASE) struct IR##NAME : IR##BASE { IR_LEAF_ISA(NAME) };
 #define SIMPLE_IR_PARENT_TYPE(NAME, BASE) struct IR##NAME : IR##BASE { IR_PARENT_ISA(NAME) };
 
@@ -416,7 +418,7 @@ struct IRType : IRInst
 {
     IRType* getCanonicalType() { return this; }
 
-    IR_PARENT_ISA(Type)
+    IR_PARENT_ISA_WITH_MANUAL_RANGE(Type, TypeManualRange)
 };
 
 struct IRBasicType : IRType

--- a/source/slang/ir.h
+++ b/source/slang/ir.h
@@ -40,31 +40,29 @@ enum : IROpFlags
 
 enum IROp : int32_t
 {
+    // Main instructions
 #define INST(ID, MNEMONIC, ARG_COUNT, FLAGS)  \
     kIROp_##ID,
-
-#define MANUAL_INST_RANGE(ID, START, COUNT) \
-    kIROp_First##ID = START, kIROp_Last##ID = kIROp_First##ID + ((COUNT) - 1),
-
 #include "ir-inst-defs.h"
+    kIROp_MainInstructionCount,
 
-    kIROpCount,
-
+    // Psuedo ops
     // We use the negative range of opcode values
     // to encode "pseudo" instructions that should
     // not appear in valid IR.
-
     kIRPseduoOp_FirstPseudo = -1000,
-
 #define INST(ID, MNEMONIC, ARG_COUNT, FLAGS) /* empty */
 #define PSEUDO_INST(ID) kIRPseudoOp_##ID,
-
 #include "ir-inst-defs.h"
 
+    // Ranges
 #define INST(ID, MNEMONIC, ARG_COUNT, FLAGS) /* empty */
+    // Ranges, manual and otherwise
 #define INST_RANGE(BASE, FIRST, LAST)       \
     kIROp_First##BASE   = kIROp_##FIRST,    \
     kIROp_Last##BASE    = kIROp_##LAST,
+#define MANUAL_INST_RANGE(ID, START, COUNT) \
+    kIROp_First##ID = START, kIROp_Last##ID = kIROp_First##ID + ((COUNT) - 1),
 
 #include "ir-inst-defs.h"
 


### PR DESCRIPTION
MANUAL_INST_RANGE introduces a problem, in that any instruction defined after a MANUAL_INST_RANGEs, would start their indices at +1 the last value of the last range. That would mean that lots of regular instructions would be large numbers. 

For example 

{op=kIROp_Dot (262238) info={name=0x00007ffac55e141c "dot" fixedArgCount=2 flags=0 } }

The change just moves the determining of all the ranges to the end of the declaration of the op codes - and in doing so it stops MANUAL_INST_RANGES from interfering with the sequence numbers of op codes.