### PR TITLE
Remap IROp value ranges

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -461,7 +461,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
             sb << "__generic<T = float4> ";
 
             sb << "__magic_type(TextureSampler," << int(flavor) << ")\n";
-            sb << "__intrinsic_type(" << (kIROp_FirstTextureSamplerType + flavor) << ")\n";
+            sb << "__intrinsic_type(" << (kIROp_TextureSamplerType + (int(flavor) << kIROp_Mask_Shift)) << ")\n";
             sb << "struct Sampler";
             sb << kBaseTextureAccessLevels[accessLevel].name;
             sb << name;
@@ -519,7 +519,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
             sb << "__generic<T = float4> ";
 
             sb << "__magic_type(Texture," << int(flavor) << ")\n";
-            sb << "__intrinsic_type(" << (kIROp_FirstTextureType + flavor) << ")\n";
+            sb << "__intrinsic_type(" << (kIROp_TextureType + (int(flavor) << kIROp_Mask_Shift)) << ")\n";
             sb << "struct ";
             sb << kBaseTextureAccessLevels[accessLevel].name;
             sb << name;

--- a/source/slang/core.meta.slang.h
+++ b/source/slang/core.meta.slang.h
@@ -476,7 +476,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
             sb << "__generic<T = float4> ";
 
             sb << "__magic_type(TextureSampler," << int(flavor) << ")\n";
-            sb << "__intrinsic_type(" << (kIROp_FirstTextureSamplerType + flavor) << ")\n";
+            sb << "__intrinsic_type(" << (kIROp_TextureSamplerType + (int(flavor) << kIROp_Mask_Shift)) << ")\n";
             sb << "struct Sampler";
             sb << kBaseTextureAccessLevels[accessLevel].name;
             sb << name;
@@ -534,7 +534,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
             sb << "__generic<T = float4> ";
 
             sb << "__magic_type(Texture," << int(flavor) << ")\n";
-            sb << "__intrinsic_type(" << (kIROp_FirstTextureType + flavor) << ")\n";
+            sb << "__intrinsic_type(" << (kIROp_TextureType + (int(flavor) << kIROp_Mask_Shift)) << ")\n";
             sb << "struct ";
             sb << kBaseTextureAccessLevels[accessLevel].name;
             sb << name;

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -1180,7 +1180,7 @@ for (int aa = 0; aa < kBaseBufferAccessLevelCount; ++aa)
     auto flavor = TextureFlavor::create(TextureFlavor::Shape::ShapeBuffer, kBaseBufferAccessLevels[aa].access).flavor;
     sb << "__generic<T>\n";
     sb << "__magic_type(Texture," << int(flavor) << ")\n";
-    sb << "__intrinsic_type(" << (kIROp_FirstTextureType + flavor) << ")\n";
+    sb << "__intrinsic_type(" << (kIROp_TextureType + (int(flavor) << kIROp_Mask_Shift)) << ")\n";
     sb << "struct ";
     sb << kBaseBufferAccessLevels[aa].name;
     sb << "Buffer {\n";

--- a/source/slang/hlsl.meta.slang.h
+++ b/source/slang/hlsl.meta.slang.h
@@ -1225,7 +1225,7 @@ for (int aa = 0; aa < kBaseBufferAccessLevelCount; ++aa)
     auto flavor = TextureFlavor::create(TextureFlavor::Shape::ShapeBuffer, kBaseBufferAccessLevels[aa].access).flavor;
     sb << "__generic<T>\n";
     sb << "__magic_type(Texture," << int(flavor) << ")\n";
-    sb << "__intrinsic_type(" << (kIROp_FirstTextureType + flavor) << ")\n";
+    sb << "__intrinsic_type(" << (kIROp_TextureType + (int(flavor) << kIROp_Mask_Shift)) << ")\n";
     sb << "struct ";
     sb << kBaseBufferAccessLevels[aa].name;
     sb << "Buffer {\n";

--- a/source/slang/ir-inst-defs.h
+++ b/source/slang/ir-inst-defs.h
@@ -8,10 +8,6 @@
 #define INST_RANGE(BASE, FIRST, LAST) /* empty */
 #endif
 
-#ifndef MANUAL_INST_RANGE
-#define MANUAL_INST_RANGE(NAME, START, COUNT) /* empty */
-#endif
-
 #ifndef PSEUDO_INST
 #define PSEUDO_INST(ID) /* empty */
 #endif
@@ -82,15 +78,17 @@ INST(Nop, nop, 0, 0)
     /* ResourceTypeBase */
         /* ResourceType */
             /* TextureTypeBase */
+                // NOTE! TextureFlavor::Flavor is stored in 'other' bits for these types.
                 /* TextureType */
-                MANUAL_INST_RANGE(TextureType, 0x10000, TextureFlavor::Count)
+                INST(TextureType, TextureType, 0, 0)
                 /* TextureSamplerType */
-                MANUAL_INST_RANGE(TextureSamplerType, 0x20000, TextureFlavor::Count)
+                INST(TextureSamplerType, TextureSamplerType, 0, 0)
                 /* GLSLImageType */
-                MANUAL_INST_RANGE(GLSLImageType, 0x30000, TextureFlavor::Count)
-            INST_RANGE(TextureTypeBase, FirstTextureType, LastGLSLImageType)
-        INST_RANGE(ResourceType, FirstTextureType, LastGLSLImageType)
-    INST_RANGE(ResourceTypeBase, FirstTextureType, LastGLSLImageType)
+                INST(GLSLImageType, GLSLImageType, 0, 0) 
+            INST_RANGE(TextureTypeBase, TextureType, GLSLImageType)
+        INST_RANGE(ResourceType, TextureType, GLSLImageType)
+    INST_RANGE(ResourceTypeBase, TextureType, GLSLImageType)
+
 
     /* UntypedBufferResourceType */
         INST(HLSLByteAddressBufferType,                     ByteAddressBuffer,   0, 0)
@@ -382,7 +380,6 @@ PSEUDO_INST(Or)
 
 #undef PSEUDO_INST
 #undef PARENT
-#undef MANUAL_INST_RANGE
 #undef INST_RANGE
 #undef INST
 

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -623,7 +623,7 @@ LoweredValInfo emitCallToDeclRef(
     {
         auto op = getIntrinsicOp(funcDecl, intrinsicOpModifier);
 
-        if (Int(op) < 0)
+        if (isPseudoOp(op))
         {
             switch (op)
             {


### PR DESCRIPTION
* Change the layout of IROp such that 'main' IROps are 0-x.
* Removed MANUAL_RANGE instruction types, as no longer needed.

