### PR TITLE
Added -serial-ir command line option

### DIFF
--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -342,6 +342,10 @@ namespace Slang
         bool shouldValidateIR = false;
         bool shouldSkipCodegen = false;
 
+        // If true then generateIR will serialize out IR, and serialize back in again. Making 
+        // serialization a bottleneck or firewall between the front end and the backend
+        bool useSerialIRBottleneck = false; 
+
         // How should `#line` directives be emitted (if at all)?
         LineDirectiveMode lineDirectiveMode = LineDirectiveMode::Default;
 

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -320,7 +320,7 @@ namespace Slang
         List<RefPtr<TranslationUnitRequest> > translationUnits;
 
         // Entry points we've been asked to compile (each
-        // assocaited with a translation unit).
+        // associated with a translation unit).
         List<RefPtr<EntryPointRequest> > entryPoints;
 
         // Types constructed by reflection API

--- a/source/slang/options.cpp
+++ b/source/slang/options.cpp
@@ -320,6 +320,10 @@ struct OptionsParser
                 {
                     requestImpl->shouldDumpIR = true;
                 }
+                else if (argStr == "-serial-ir")
+                {
+                    requestImpl->useSerialIRBottleneck = true;
+                }
                 else if(argStr == "-validate-ir" )
                 {
                     requestImpl->shouldValidateIR = true;

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -487,12 +487,12 @@ void CompileRequest::generateIR()
     for( auto& translationUnit : translationUnits )
     {
         if (useSerialIRBottleneck)
-        {   
-            /// Generate IR for translation unit
-            RefPtr<IRModule> irModule(generateIRForTranslationUnit(translationUnit));
-
+        {              
             IRSerialData serialData;
             {
+                /// Generate IR for translation unit
+                RefPtr<IRModule> irModule(generateIRForTranslationUnit(translationUnit));
+
                 // Write IR out to serialData - copying over SourceLoc information directly
                 IRSerialWriter writer;
                 writer.write(irModule, sourceManager, IRSerialWriter::OptionFlag::RawSourceLocation, &serialData);

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -9,6 +9,8 @@
 #include "syntax-visitors.h"
 #include "../slang/type-layout.h"
 
+#include "ir-serialize.h"
+
 // Used to print exception type names in internal-compiler-error messages
 #include <typeinfo>
 
@@ -484,7 +486,31 @@ void CompileRequest::generateIR()
     // in isolation.
     for( auto& translationUnit : translationUnits )
     {
-        translationUnit->irModule = generateIRForTranslationUnit(translationUnit);
+        if (useSerialIRBottleneck)
+        {   
+            /// Generate IR for translation unit
+            RefPtr<IRModule> irModule(generateIRForTranslationUnit(translationUnit));
+
+            IRSerialData serialData;
+            {
+                // Write IR out to serialData - copying over SourceLoc information directly
+                IRSerialWriter writer;
+                writer.write(irModule, sourceManager, IRSerialWriter::OptionFlag::RawSourceLocation, &serialData);
+            }
+            RefPtr<IRModule> irReadModule;
+            {
+                // Read IR back from serialData
+                IRSerialReader reader;
+                reader.read(serialData, mSession, irReadModule);
+            }
+
+            // Use the serialized irModule
+            translationUnit->irModule = irReadModule;
+        }
+        else
+        {
+            translationUnit->irModule = generateIRForTranslationUnit(translationUnit);
+        }
     }
 }
 


### PR DESCRIPTION
Added -serial-ir option, to make generateIR always serialize out and in before further processing. This tests the serialization path, and adding a kind of 'firewall' between compiler front end and backend.