### PR TITLE
Small improvements on include refactor

### DIFF
--- a/slang-com-helper.h
+++ b/slang-com-helper.h
@@ -98,7 +98,7 @@ SLANG_NO_THROW uint32_t SLANG_MCALL release() \
         return 0; \
     } \
     return m_refCount; \
-} \
+} 
 
 #define SLANG_IUNKNOWN_ALL \
     SLANG_IUNKNOWN_QUERY_INTERFACE \

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -175,13 +175,13 @@
     <ClInclude Include="compiler.h" />
     <ClInclude Include="core.meta.slang.h" />
     <ClInclude Include="decl-defs.h" />
+    <ClInclude Include="default-file-system.h" />
     <ClInclude Include="diagnostic-defs.h" />
     <ClInclude Include="diagnostics.h" />
     <ClInclude Include="emit.h" />
     <ClInclude Include="expr-defs.h" />
     <ClInclude Include="glsl.meta.slang.h" />
     <ClInclude Include="hlsl.meta.slang.h" />
-    <ClInclude Include="include-file-system.h" />
     <ClInclude Include="ir-constexpr.h" />
     <ClInclude Include="ir-dominators.h" />
     <ClInclude Include="ir-inst-defs.h" />
@@ -228,10 +228,10 @@
     <ClCompile Include="bytecode.cpp" />
     <ClCompile Include="check.cpp" />
     <ClCompile Include="compiler.cpp" />
+    <ClCompile Include="default-file-system.cpp" />
     <ClCompile Include="diagnostics.cpp" />
     <ClCompile Include="dxc-support.cpp" />
     <ClCompile Include="emit.cpp" />
-    <ClCompile Include="include-file-system.cpp" />
     <ClCompile Include="ir-constexpr.cpp" />
     <ClCompile Include="ir-dominators.cpp" />
     <ClCompile Include="ir-legalize-types.cpp" />

--- a/source/slang/slang.vcxproj.filters
+++ b/source/slang/slang.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClInclude Include="decl-defs.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="default-file-system.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="diagnostic-defs.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -40,9 +43,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="hlsl.meta.slang.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="include-file-system.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="ir-constexpr.h">
@@ -179,6 +179,9 @@
     <ClCompile Include="compiler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="default-file-system.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="diagnostics.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -186,9 +189,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="emit.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="include-file-system.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="ir-constexpr.cpp">


### PR DESCRIPTION
* IncludeFileSystem -> DefaultFileSystem
* Improvements in 'singleton'ness of DefaultFileSystem
* Made WrapFileSystem a stand alone type - to remove 'odd' aspects of deriving from DefaultFileSystem  (such as inheriting getSingleton method/fixing ref counting)
* Simplified CompileRequest::loadFile - becauce fileSystemExt is always available.