### PR TITLE
Fix sampler-less texture functions

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -3365,9 +3365,38 @@ struct EmitVisitor
         IRCall*         inst,
         IREmitMode      mode)
     {
+        auto funcValue = inst->getOperand(0);
+
+        // Does this function declare any requirements on GLSL version or
+        // extensions, which should affect our output?
+        if(getTarget(ctx) == CodeGenTarget::GLSL)
+        {
+            auto decoratedValue = funcValue;
+            while (auto specInst = as<IRSpecialize>(decoratedValue))
+            {
+                decoratedValue = getSpecializedValue(specInst);
+            }
+
+            for( auto decoration = decoratedValue->firstDecoration; decoration; decoration = decoration->next )
+            {
+                switch(decoration->op)
+                {
+                default:
+                    break;
+
+                case kIRDecorationOp_RequireGLSLExtension:
+                    requireGLSLExtension(String(((IRRequireGLSLExtensionDecoration*)decoration)->extensionName));
+                    break;
+
+                case kIRDecorationOp_RequireGLSLVersion:
+                    requireGLSLVersion(int(((IRRequireGLSLVersionDecoration*)decoration)->languageVersion));
+                    break;
+                }
+            }
+        }
+
         // We want to detect any call to an intrinsic operation,
         // that we can emit it directly without mangling, etc.
-        auto funcValue = inst->getOperand(0);
         if(auto irFunc = asTargetIntrinsic(ctx, funcValue))
         {
             emitIntrinsicCallExpr(ctx, inst, irFunc, mode);

--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -117,6 +117,20 @@ struct IRNameHintDecoration : IRDecoration
     Name* name;
 };
 
+struct IRRequireGLSLVersionDecoration : IRDecoration
+{
+    enum { kDecorationOp = kIRDecorationOp_RequireGLSLVersion };
+
+    Int languageVersion;
+};
+
+struct IRRequireGLSLExtensionDecoration : IRDecoration
+{
+    enum { kDecorationOp = kIRDecorationOp_RequireGLSLExtension };
+
+    StringRepresentation* extensionName;
+};
+
 // An instruction that specializes another IR value
 // (representing a generic) to a particular set of generic arguments 
 // (instructions representing types, witness tables, etc.)

--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -5065,6 +5065,22 @@ namespace Slang
                 }
                 break;
 
+            case kIRDecorationOp_RequireGLSLExtension:
+                {
+                    auto originalDecoration = (IRRequireGLSLExtensionDecoration*)dd;
+                    auto newDecoration = context->builder->addDecoration<IRRequireGLSLExtensionDecoration>(clonedValue);
+                    newDecoration->extensionName = originalDecoration->extensionName;
+                }
+                break;
+
+            case kIRDecorationOp_RequireGLSLVersion:
+                {
+                    auto originalDecoration = (IRRequireGLSLVersionDecoration*)dd;
+                    auto newDecoration = context->builder->addDecoration<IRRequireGLSLVersionDecoration>(clonedValue);
+                    newDecoration->languageVersion = originalDecoration->languageVersion;
+                }
+                break;
+
             default:
                 // Don't clone any decorations we don't understand.
                 break;

--- a/source/slang/ir.h
+++ b/source/slang/ir.h
@@ -145,6 +145,9 @@ enum IRDecorationOp : uint16_t
         Typically used mark an instruction so can be specially handled - say when creating a IRConstant literal, and the payload of 
         needs to be special cased for lookup. */ 
     kIRDecorationOp_Transitory,             
+
+    kIRDecorationOp_RequireGLSLVersion,
+    kIRDecorationOp_RequireGLSLExtension,
 };
 
 // represents an object allocated in an IR memory arena

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -4923,7 +4923,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         for(auto versionMod : decl->GetModifiersOfType<RequiredGLSLVersionModifier>())
         {
             auto decoration = getBuilder()->addDecoration<IRRequireGLSLVersionDecoration>(irFunc);
-            decoration->languageVersion = getIntegerLiteralValue(versionMod->versionNumberToken);
+            decoration->languageVersion = Int(getIntegerLiteralValue(versionMod->versionNumberToken));
         }
 
         // For convenience, ensure that any additional global

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -4909,6 +4909,23 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // for a particular target, then handle that here.
         addTargetIntrinsicDecorations(irFunc, decl);
 
+        // If this declaration requires certain GLSL extension (or a particular GLSL version)
+        // for it to be usable, then declare that here.
+        //
+        // TODO: We should wrap this an `SpecializedForTargetModifier` together into a single
+        // case for enumerating the "capabilities" that a declaration requires.
+        //
+        for(auto extensionMod : decl->GetModifiersOfType<RequiredGLSLExtensionModifier>())
+        {
+            auto decoration = getBuilder()->addDecoration<IRRequireGLSLExtensionDecoration>(irFunc);
+            decoration->extensionName = getBuilder()->addStringToFree(extensionMod->extensionNameToken.Content);
+        }
+        for(auto versionMod : decl->GetModifiersOfType<RequiredGLSLVersionModifier>())
+        {
+            auto decoration = getBuilder()->addDecoration<IRRequireGLSLVersionDecoration>(irFunc);
+            decoration->languageVersion = getIntegerLiteralValue(versionMod->versionNumberToken);
+        }
+
         // For convenience, ensure that any additional global
         // values that were emitted while outputting the function
         // body appear before the function itself in the list


### PR DESCRIPTION
I'm honestly not sure how the original work on this feature in #648 worked at all (probably insufficient testing).

We have these front-end modifiers to indicate that a particular function definition requires a certain GLSL version, or a GLSL extension in order to be used, and they are supposed to be automatically employed by the logic in `emit.cpp` to output `#extension` lines in the output GLSL. However, it turns out that nothing is actually wired up right now, so that adding the modifiers to a declaration is a placebo.

This change propagates the modifiers through as decorations, and then uses them during GLSL code emit, which allows the functions that require `EXT_samplerless_texture_functions` to work.