### PR TITLE
Fix problem with __import not working 

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -685,7 +685,7 @@ extern "C"
     typedef unsigned int SlangPathType;
     enum
     {
-        SLANG_PATH_TYPE_DIRECTORY,     /**< Path specified specifies a directory. */
+        SLANG_PATH_TYPE_DIRECTORY,      /**< Path specified specifies a directory. */
         SLANG_PATH_TYPE_FILE,           /**< Path specified is to a file. */
     };
 
@@ -734,7 +734,16 @@ extern "C"
             SlangPathType fromPathType,
             const char* fromPath,
             const char* path,
-            ISlangBlob** pathOut) = 0;            
+            ISlangBlob** pathOut) = 0;          
+            
+        /** Gets the type of path that path is on the file system. 
+        @param path
+        @param pathTypeOut
+        @returns SLANG_OK if located and type is known, else an error. SLANG_E_NOT_FOUND if not found.
+        */
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL getPathType(
+            const char* path, 
+            SlangPathType* pathTypeOut) = 0;  
     };
 
     #define SLANG_UUID_ISlangFileSystemExt { 0x5fb632d2, 0x979d, 0x4481, { 0x9f, 0xee, 0x66, 0x3c, 0x3f, 0x14, 0x49, 0xe1 } }

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -132,6 +132,49 @@ namespace Slang
 #endif
 	}
 
+    /* static */SlangResult Path::GetPathType(const String & path, SlangPathType* pathTypeOut)
+    {
+#ifdef _WIN32
+        // https://msdn.microsoft.com/en-us/library/14h5k7ff.aspx
+        struct _stat32 statVar;
+        if (::_wstat32(String(path).ToWString(), &statVar) == 0)
+        {
+            if (statVar.st_mode & _S_IFDIR)
+            {
+                *pathTypeOut = SLANG_PATH_TYPE_DIRECTORY;
+                return SLANG_OK;
+            }
+            else if (statVar.st_mode & _S_IFREG)
+            {
+                *pathTypeOut = SLANG_PATH_TYPE_FILE;
+                return SLANG_OK;
+            }
+            return SLANG_FAIL;
+        }
+
+        return SLANG_E_NOT_FOUND;
+#else
+        struct stat statVar;
+        if (::stat(path.Buffer(), &statVar) == 0)
+        {
+            if (S_ISDIR(statVar.st_mode))
+            {
+                *pathTypeOut = SLANG_PATH_TYPE_DIRECTORY;
+                return SLANG_OK;
+            }
+            if (S_ISREG(statVar.st_mode))
+            {
+                *pathTypeOut = SLANG_PATH_TYPE_FILE;
+                return SLANG_OK;
+            }
+            return SLANG_FAIL;
+        }
+
+        return SLANG_E_NOT_FOUND;
+#endif
+    }
+
+
     /* static */SlangResult Path::GetCanonical(const String & path, String & canonicalPathOut)
     {
 #if defined(_WIN32)

--- a/source/core/slang-io.h
+++ b/source/core/slang-io.h
@@ -32,6 +32,8 @@ namespace Slang
 		static String Combine(const String & path1, const String & path2, const String & path3);
 		static bool CreateDir(const String & path);
 
+        static SlangResult GetPathType(const String & path, SlangPathType* pathTypeOut);
+
         static SlangResult GetCanonical(const String & path, String& canonicalPathOut);
 	};
 }

--- a/source/slang/default-file-system.cpp
+++ b/source/slang/default-file-system.cpp
@@ -51,6 +51,13 @@ SlangResult DefaultFileSystem::calcRelativePath(SlangPathType fromPathType, cons
     return SLANG_OK;
 }
 
+SlangResult SLANG_MCALL DefaultFileSystem::getPathType(
+    const char* path,
+    SlangPathType* pathTypeOut)
+{
+    return Path::GetPathType(path, pathTypeOut);   
+}
+
 SlangResult DefaultFileSystem::loadFile(char const* path, ISlangBlob** outBlob)
 {
     // Default implementation that uses the `core`
@@ -105,6 +112,11 @@ SlangResult WrapFileSystem::calcRelativePath(SlangPathType fromPathType, const c
 {
     // Just defer to the default implementation
     return DefaultFileSystem::getSingleton()->calcRelativePath(fromPathType, fromPath, path, pathOut);
+}
+
+SlangResult WrapFileSystem::getPathType(const char* path, SlangPathType* pathTypeOut)
+{
+    return DefaultFileSystem::getSingleton()->getPathType(path, pathTypeOut); 
 }
 
 } 

--- a/source/slang/default-file-system.cpp
+++ b/source/slang/default-file-system.cpp
@@ -60,8 +60,7 @@ SlangResult SLANG_MCALL DefaultFileSystem::getPathType(
 
 SlangResult DefaultFileSystem::loadFile(char const* path, ISlangBlob** outBlob)
 {
-    // Default implementation that uses the `core`
-    // libraries facilities for talking to the OS filesystem.
+    // Default implementation that uses the `core` libraries facilities for talking to the OS filesystem.
     //
     // TODO: we might want to conditionally compile these in, so that
     // a user could create a build of Slang that doesn't include any OS
@@ -100,7 +99,7 @@ SlangResult WrapFileSystem::loadFile(char const* path, ISlangBlob** outBlob)
 
 SlangResult WrapFileSystem::getCanoncialPath(const char* path, ISlangBlob** canonicalPathOut)
 {
-    // This isn't a very good 'canonical  path' because the same file might be referenced 
+    // This isn't a very good 'canonical path' because the same file might be referenced 
     // multiple ways - for example by using relative paths. 
     // But it's simple and matches slangs previous behavior. 
     String canonicalPath(path);
@@ -116,6 +115,12 @@ SlangResult WrapFileSystem::calcRelativePath(SlangPathType fromPathType, const c
 
 SlangResult WrapFileSystem::getPathType(const char* path, SlangPathType* pathTypeOut)
 {
+    // TODO:
+    // This might be undesirable in the longer term because it means that ISlangFileSystem will not be used 
+    // to test file existence - but the file system will be.
+    // 
+    // It would probably be better to use some kind of cache that uses 'loadFile' to load files, but also 
+    // to test for existence.
     return DefaultFileSystem::getSingleton()->getPathType(path, pathTypeOut); 
 }
 

--- a/source/slang/default-file-system.h
+++ b/source/slang/default-file-system.h
@@ -33,11 +33,15 @@ public:
         const char* path,
         ISlangBlob** pathOut) SLANG_OVERRIDE;
 
+    virtual SLANG_NO_THROW SlangResult SLANG_MCALL getPathType(
+        const char* path,
+        SlangPathType* pathTypeOut) SLANG_OVERRIDE;
+
         /// Get a default instance
     static ISlangFileSystemExt* getSingleton() { return &s_singleton; }
 
 private:
-        /// Make so not constructable
+        /// Make so not constructible
     DefaultFileSystem() {}
 
     ISlangUnknown* getInterface(const Guid& guid);
@@ -74,6 +78,10 @@ public:
         const char* fromPath,
         const char* path,
         ISlangBlob** pathOut) SLANG_OVERRIDE;
+
+    virtual SLANG_NO_THROW SlangResult SLANG_MCALL getPathType(
+        const char* path,
+        SlangPathType* pathTypeOut) SLANG_OVERRIDE;
 
         /// Ctor
     WrapFileSystem(ISlangFileSystem* fileSystem):

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -118,6 +118,13 @@ struct IncludeHandlerImpl : IncludeHandler
             return SLANG_FAIL;
         }
      
+        SlangPathType pathType;
+        SLANG_RETURN_ON_FAIL(fileSystemExt->getPathType(relPath.begin(), &pathType));
+        if (pathType != SLANG_PATH_TYPE_FILE)
+        {
+            return SLANG_E_NOT_FOUND;
+        }
+
         // Get the canonical path
         ComPtr<ISlangBlob> canonicalPathBlob;
         SLANG_RETURN_ON_FAIL(fileSystemExt->getCanoncialPath(relPath.begin(), canonicalPathBlob.writeRef()));

--- a/tests/front-end/import-subdir-search-path.slang
+++ b/tests/front-end/import-subdir-search-path.slang
@@ -1,0 +1,7 @@
+//TEST:SIMPLE: -Itests\front-end\subdir
+
+// Confirming import lookup via search paths work
+
+__import import_subdir_a;
+
+float bar(float x) { return foo(x); }

--- a/tests/front-end/import-subdir-search-path.slang
+++ b/tests/front-end/import-subdir-search-path.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE: -Itests\front-end\subdir
+//TEST:SIMPLE: -Itests/front-end/subdir
 
 // Confirming import lookup via search paths work
 


### PR DESCRIPTION
* Added getPathType to ISlangFileSystemExt.

There are couple of reasons for the change. On some platforms 'getCanonicalPath' only succeeds if the path exists - but this isn't so for all platforms. Also the thoughts on how getCanonicalPath 'really' was changed. To in the limit just returning the path passed in (and therefore no test). 

So the fix here was to add an explicit method to test for a paths existence (and type). Thus when doing a search it means the file doesn't have to be read. Doing this means that if an implementer implements just the ISlangFileSystem interface - we still use the Path::getFileType - that checks for existence via the file system.

This might not be what you want. So something closer to the original intent might try to read the file from the underlying file system and hold in a cache, and just test that. Thus the ISlangFileSystem would only be hit once - and the cache used for subsequent tests. 
