### PR TITLE
Fix Vulkan codegen for image atomics

### DIFF
--- a/tests/bugs/vk-image-atomics.slang
+++ b/tests/bugs/vk-image-atomics.slang
@@ -1,0 +1,12 @@
+//TEST:CROSS_COMPILE: -profile ps_5_0 -entry main -target spirv-assembly
+
+// Ensure that we can lower to `imageAtomicAdd` correctly.
+
+RWTexture2D<uint> t;
+
+float4 main() : SV_Target
+{
+	uint u;
+	InterlockedAdd(t[uint2(0)], 1, u);
+	return u;
+}

--- a/tests/bugs/vk-image-atomics.slang.glsl
+++ b/tests/bugs/vk-image-atomics.slang.glsl
@@ -1,0 +1,18 @@
+#version 450
+
+layout(r32ui)
+layout(binding = 0)
+uniform uimage2D t_0;
+
+layout(location = 0)
+out vec4 _S1;
+
+void main()
+{
+    const uint _S2 = uint(1);
+
+    uint _S3;
+    _S3 = imageAtomicAdd(t_0, ivec2(uvec2(0)), _S2);
+    _S1 = vec4(_S3);
+    return;
+}


### PR DESCRIPTION
The basic problem was that the front-end was generating code that used a `uint` vector for the coordinates, while GLSL requires an `int` vector.
Without support for implicit type conversions, this leads to GLSL compilation failure.

The fix here is to insert the type conversion as late as possible (during GLSL emit). This isn't a pretty solution, but it is the easiest one to implement in the current compiler.
A more forward-looking approach would be to support "force inline" functions in the stdlib, so that we can implement the conversion logic in a stdlib implementation specialized for the Vulkan/GLSL target.

At the moment, everything to do with image atomics is all sleight of hand anyway, so making it incrementally messier isn't a bit hit.