### PR TITLE
Fix implementation of >= in preprocessor conditionals

### DIFF
--- a/source/slang/preprocessor.cpp
+++ b/source/slang/preprocessor.cpp
@@ -1320,7 +1320,7 @@ static PreprocessorExpressionValue EvaluateInfixOp(
     case TokenType::OpLess:     return left <  right ? 1 : 0;
     case TokenType::OpGreater:  return left >  right ? 1 : 0;
     case TokenType::OpLeq:      return left <= right ? 1 : 0;
-    case TokenType::OpGeq:      return left <= right ? 1 : 0;
+    case TokenType::OpGeq:      return left >= right ? 1 : 0;
     case TokenType::OpEql:      return left == right ? 1 : 0;
     case TokenType::OpNeq:      return left != right ? 1 : 0;
     case TokenType::OpBitAnd:   return left & right;


### PR DESCRIPTION
By a copy-paste error, `>=` in a preprocessor condition was behaving as `<=`.