### PR TITLE
Fix handling of DXR profiles

### DIFF
--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -246,15 +246,10 @@ Profile getEffectiveProfile(EntryPointRequest* entryPoint, TargetRequest* target
         case Stage::AnyHit:
         case Stage::Miss:
         case Stage::Callable:
-            stageMinVersion = ProfileVersion::DX_6_3;
-
-            // When compiling for DXR, we don't actually have distinct
-            // profiles for all of the DXR stages (e.g., there is no
-            // `raygeneration_6_3` profile), so we will clear out
-            // the stage part of the effective profile to avoid
-            // using a stage that isn't allowed downstream.
+            // The DirectX ray tracing stages implicitly
+            // require Shader Model 6.3 or later.
             //
-            effectiveProfile.setStage(Stage::Unknown);
+            stageMinVersion = ProfileVersion::DX_6_3;
             break;
 
         //  TODO: Add equivalent logic for geometry, tessellation, and compute stages.


### PR DESCRIPTION
The logic in `getEffectiveProfile()` function was mapping these to use `Stage::Unknown` in an early attempt to handle the way that dxc requires the `lib_*` profile for DXR shaders, instead of anything that mentions the stage name (in constrast to, e.g., `vs_5_1`). At the same time, the `GetHLSLProfileName()` function was updated to explicitly handle the DXR shaders and map anything it doesn't expect (including `Stage::Unknown`) to a profile named `unknown`, which dxc obviously doesn't like.

This change tries to fix both issues by:

* Having `getEffectiveProfile()` no longer clobber the stage part of a profile for DXR shaders.

* Having `GetHLSLProfileName()` map all unhandled cases to the `lib_*` profiles, since that seems likely to be how any future stages will need to be handled as well (based on the precedent with DXR)

Along the way, I also fixed a bug where invoking command-line `slangc` with no `-stage` options and then relying on `[shader(...)]` attributes to pick up the entry points would lead to a crash since the array of per-entry-point output paths on each target would not be sized appropriately.