### PR TITLE
Disable compilers optimizing away tests for this against null

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ SHARED_LIB_SUFFIX := .so
 BIN_SUFFIX :=
 # Note: we set `visibility=hidden` to avoid exporting more symbols than
 # we really need.
-CFLAGS := -std=c++11 -fvisibility=hidden
+CFLAGS := -std=c++11 -fvisibility=hidden -fno-delete-null-pointer-checks
 CFLAGS += -I.
 LDFLAGS := -L$(OUTPUTDIR)
 SHARED_LIB_LDFLAGS := -shared

--- a/premake5.lua
+++ b/premake5.lua
@@ -111,7 +111,7 @@ workspace "slang"
         architecture "ARM"
 
     filter { "toolset:clang or gcc*" }
-        buildoptions { "-Wno-unused-parameter", "-Wno-type-limits", "-Wno-sign-compare", "-Wno-unused-variable", "-Wno-reorder", "-Wno-switch", "-Wno-return-type", "-Wno-unused-local-typedefs", "-Wno-parentheses",  "-std=c++11", "-fvisibility=hidden", "-std=gnu++11" } 
+        buildoptions { "-Wno-unused-parameter", "-Wno-type-limits", "-Wno-sign-compare", "-Wno-unused-variable", "-Wno-reorder", "-Wno-switch", "-Wno-return-type", "-Wno-unused-local-typedefs", "-Wno-parentheses",  "-std=c++11", "-fvisibility=hidden",  "-fno-delete-null-pointer-checks" } 
     	
 	filter { "toolset:gcc*"}
 		buildoptions { "-Wno-nonnull-compare", "-Wno-unused-but-set-variable", "-Wno-implicit-fallthrough" }


### PR DESCRIPTION
Newer versions of gcc, optimize away tests for this being null, because this being null is defined as undefined behavior in the standard. This is a workaround that disables that optimization for now.