### PR TITLE
Add support for a "strict" floating-point mode

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -451,6 +451,17 @@ extern "C"
     };
 
     /*!
+    @brief Options to control floating-point precision guarantees for a target.
+    */
+    typedef unsigned int SlangFloatingPointMode;
+    enum
+    {
+        SLANG_FLOATING_POINT_MODE_DEFAULT = 0,
+        SLANG_FLOATING_POINT_MODE_FAST,
+        SLANG_FLOATING_POINT_MODE_PRECISE,
+    };
+
+    /*!
     @brief Options to control emission of `#line` directives
     */
     typedef unsigned int SlangLineDirectiveMode;
@@ -876,6 +887,14 @@ extern "C"
         SlangCompileRequest*    request,
         int                     targetIndex,
         SlangTargetFlags        flags);
+
+    /*!
+    @brief Set the floating point mode (e.g., precise or fast) to use a target.
+    */
+    SLANG_API void spSetTargetFloatingPointMode(
+        SlangCompileRequest*    request,
+        int                     targetIndex,
+        SlangFloatingPointMode  mode);
 
     /* DEPRECATED: use `spSetMatrixLayoutMode` instead. */
     SLANG_API void spSetTargetMatrixLayoutMode(

--- a/source/slang/compiler.cpp
+++ b/source/slang/compiler.cpp
@@ -428,6 +428,18 @@ namespace Slang
             dxMacros = dxMacrosStorage.Buffer();
         }
 
+        DWORD flags = 0;
+
+        switch( targetReq->floatingPointMode )
+        {
+        default:
+            break;
+
+        case FloatingPointMode::Precise:
+            flags |= D3DCOMPILE_IEEE_STRICTNESS;
+            break;
+        }
+
         ID3DBlob* codeBlob;
         ID3DBlob* diagnosticsBlob;
         HRESULT hr = D3DCompile_(
@@ -438,8 +450,8 @@ namespace Slang
             nullptr,
             getText(entryPoint->name).begin(),
             GetHLSLProfileName(profile).Buffer(),
-            0,
-            0,
+            flags,
+            0, // unused: effect flags
             &codeBlob,
             &diagnosticsBlob);
 

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -203,6 +203,13 @@ namespace Slang
         RefPtr<IRModule> irModule;
     };
 
+    enum class FloatingPointMode : SlangFloatingPointMode
+    {
+        Default = SLANG_FLOATING_POINT_MODE_DEFAULT,
+        Fast = SLANG_FLOATING_POINT_MODE_FAST,
+        Precise = SLANG_FLOATING_POINT_MODE_PRECISE,
+    };
+
     // A request to generate output in some target format
     class TargetRequest : public RefObject
     {
@@ -211,6 +218,7 @@ namespace Slang
         CodeGenTarget       target;
         SlangTargetFlags    targetFlags = 0;
         Slang::Profile      targetProfile = Slang::Profile();
+        FloatingPointMode   floatingPointMode = FloatingPointMode::Default;
 
         // Requested output paths for each entry point.
         // An empty string indices no output desired for

--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -73,6 +73,7 @@ DIAGNOSTIC(    20, Error, entryPointsNeedToBeAssociatedWithTranslationUnits, "wh
 DIAGNOSTIC(    21, Error, expectedArgumentForOption, "expected an argument for command-line option '$0'");
 
 DIAGNOSTIC(    24, Error, unknownLineDirectiveMode, "unknown '#line' directive mode '$0'");
+DIAGNOSTIC(    25, Error, unknownFloatingPointMode, "unknown floating-point mode '$0'");
 
 DIAGNOSTIC(    30, Error, sameStageSpecifiedMoreThanOnce, "the stage '$0' was specified more than once for entry point '$1'")
 DIAGNOSTIC(    31, Error, conflictingStagesForEntryPoint, "conflicting stages have been specified for entry point '$0'")

--- a/source/slang/dxc-support.cpp
+++ b/source/slang/dxc-support.cpp
@@ -132,6 +132,16 @@ namespace Slang
             break;
         }
 
+        switch( targetReq->floatingPointMode )
+        {
+        default:
+            break;
+
+        case FloatingPointMode::Precise:
+            args[argCount++] = L"-Gis"; // "force IEEE strictness"
+            break;
+        }
+
         String entryPointName = getText(entryPoint->name);
         OSString wideEntryPointName = entryPointName.ToWString();
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -1229,6 +1229,15 @@ SLANG_API void spSetTargetFlags(
     req->targets[targetIndex]->targetFlags = flags;
 }
 
+SLANG_API void spSetTargetFloatingPointMode(
+    SlangCompileRequest*    request,
+    int                     targetIndex,
+    SlangFloatingPointMode  mode)
+{
+    auto req = REQ(request);
+    req->targets[targetIndex]->floatingPointMode = Slang::FloatingPointMode(mode);
+}
+
 SLANG_API void spSetMatrixLayoutMode(
     SlangCompileRequest*    request,
     SlangMatrixLayoutMode   mode)


### PR DESCRIPTION
This change adds an API function and command line options for controlling the default floating-point behavior for a target, with options for "fast" and "precise" computation.
The "precise" option gets mapped to the "IEEE strictness" mode in `fxc` and `dxc` (there is currently no equivalent option for glslang that I could find).