### PR TITLE
Use register spaces by default for D3D12 targets

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -446,7 +446,10 @@ extern "C"
     enum
     {
         /* When compiling for a D3D Shader Model 5.1 or higher target, allocate
-           distinct register spaces for parameter blocks. */
+           distinct register spaces for parameter blocks.
+
+           @deprecated This behavior is now enabled unconditionally.
+        */
         SLANG_TARGET_FLAG_PARAMETER_BLOCKS_USE_REGISTER_SPACES = 1 << 4,
     };
 

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -868,6 +868,22 @@ static bool isSM5OrEarlier(TargetRequest* targetReq)
     return false;
 }
 
+static bool isSM5_1OrLater(TargetRequest* targetReq)
+{
+    if(!isD3DTarget(targetReq))
+        return false;
+
+    auto profile = targetReq->targetProfile;
+
+    if(profile.getFamily() == ProfileFamily::DX)
+    {
+        if(profile.GetVersion() >= ProfileVersion::DX_5_1)
+            return true;
+    }
+
+    return false;
+}
+
 static bool isVulkanTarget(TargetRequest* targetReq)
 {
     switch( targetReq->target )
@@ -907,10 +923,9 @@ static bool shouldAllocateRegisterSpaceForParameterBlock(
     // are generating code for D3D12, and using SM5.1 or later.
     // We will use a register space for parameter blocks *if*
     // the target options tell us to:
-    if( isD3D12Target(targetReq) )
+    if( isD3D12Target(targetReq) && isSM5_1OrLater(targetReq) )
     {
-        if(targetReq->targetFlags & SLANG_TARGET_FLAG_PARAMETER_BLOCKS_USE_REGISTER_SPACES)
-            return true;
+        return true;
     }
 
     return false;

--- a/tests/reflection/parameter-block.slang
+++ b/tests/reflection/parameter-block.slang
@@ -1,4 +1,6 @@
 //TEST:REFLECTION:-stage fragment -target glsl
+//TEST:REFLECTION:-stage fragment -target hlsl -profile sm_5_0
+//TEST:REFLECTION:-stage fragment -target hlsl -profile sm_5_1
 
 // Confirm that we do parameter binding correctly
 // when we have both a parameter block *and* user-defined

--- a/tests/reflection/parameter-block.slang.1.expected
+++ b/tests/reflection/parameter-block.slang.1.expected
@@ -1,0 +1,54 @@
+result code = 0
+standard error = {
+}
+standard output = {
+{
+    "parameters": [
+        {
+            "name": "a",
+            "bindings": [
+                {"kind": "shaderResource", "index": 0},
+                {"kind": "samplerState", "index": 0}
+            ],
+            "type": {
+                "kind": "parameterBlock",
+                "elementType": {
+                    "kind": "struct",
+                    "name": "Helper",
+                    "fields": [
+                        {
+                            "name": "t",
+                            "type": {
+                                "kind": "resource",
+                                "baseShape": "texture2D"
+                            },
+                            "binding": {"kind": "shaderResource", "index": 0}
+                        },
+                        {
+                            "name": "s",
+                            "type": {
+                                "kind": "samplerState"
+                            },
+                            "binding": {"kind": "samplerState", "index": 0}
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "b",
+            "binding": {"kind": "shaderResource", "index": 1},
+            "type": {
+                "kind": "resource",
+                "baseShape": "texture2D"
+            }
+        }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "fragment"
+        }
+    ]
+}
+}

--- a/tests/reflection/parameter-block.slang.2.expected
+++ b/tests/reflection/parameter-block.slang.2.expected
@@ -1,0 +1,51 @@
+result code = 0
+standard error = {
+}
+standard output = {
+{
+    "parameters": [
+        {
+            "name": "a",
+            "binding": {"kind": "registerSpace", "index": 1},
+            "type": {
+                "kind": "parameterBlock",
+                "elementType": {
+                    "kind": "struct",
+                    "name": "Helper",
+                    "fields": [
+                        {
+                            "name": "t",
+                            "type": {
+                                "kind": "resource",
+                                "baseShape": "texture2D"
+                            },
+                            "binding": {"kind": "shaderResource", "index": 0}
+                        },
+                        {
+                            "name": "s",
+                            "type": {
+                                "kind": "samplerState"
+                            },
+                            "binding": {"kind": "samplerState", "index": 0}
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "b",
+            "binding": {"kind": "shaderResource", "index": 0},
+            "type": {
+                "kind": "resource",
+                "baseShape": "texture2D"
+            }
+        }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "fragment"
+        }
+    ]
+}
+}


### PR DESCRIPTION
The change here is that the logic that used to be controlled by `-parameter-blocks-use-register-spaces` is now turned on unconditionally, meaning that a `ParameterBlock<X>` will get its own register `space` by default when targetting D3D Shader Model 5.1 and later.

I had originally made this feature optional because I wasn't sure whether Shader Model 5.1 should default to using register spaces or not, because D3D 11 doesn't support spaces at the API level and MSDN documetnation made it sound like SM5.1 was available for D3D11 as well. Subsequent reading has led me to understand that MSDN is wrong on this front, and SM5.1 and later are D3D12-only, so it is always safe to use spaces.

The new logic is now that we automatically use spaces for parameter blocks any time it is possible (SM5.1+ and any Vulkan target), and otherwise fall back to not using spaces (SM5.0 and earlier).

I updated a reflection test case that was covering parameter blocks to confirm the output differs between SM5.0 and 5.1.