### PR TITLE
Allow parameter blocks to be explicitly bound to spaces

### DIFF
--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -241,6 +241,12 @@ namespace Slang
         MatrixLayoutMode getDefaultMatrixLayoutMode();
     };
 
+        /// Are we generating code for a D3D API?
+    bool isD3DTarget(TargetRequest* targetReq);
+
+        /// Are we generating code for a Khronos API (OpenGL or Vulkan)?
+    bool isKhronosTarget(TargetRequest* targetReq);
+
     // Compute the "effective" profile to use when outputting the given entry point
     // for the chosen code-generation target.
     //

--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -369,6 +369,8 @@ DIAGNOSTIC(39010, Error, expectedSpaceIndex, "expected a register space index af
 DIAGNOSTIC(39011, Error, componentMaskNotSupported, "explicit register component masks are not yet supported in Slang")
 DIAGNOSTIC(39012, Error, packOffsetNotSupported, "explicit 'packoffset' bindings are not yet supported in Slang")
 DIAGNOSTIC(39013, Warning, registerModifierButNoVulkanLayout, "shader parameter '$0' has a 'register' specified for D3D, but no '[[vk::binding(...)]]` specified for Vulkan")
+DIAGNOSTIC(39014, Error, unexpectedSpecifierAfterSpace, "unexpected specifier after register space: '$0'")
+DIAGNOSTIC(39015, Error, wholeSpaceParameterRequiresZeroBinding, "shader parameter '$0' consumes whole descriptor sets, so the binding must be in the form '[[vk::binding(0, ...)]]'; the non-zero binding '$1' is not allowed")
 
 DIAGNOSTIC(39013, Error, dontExpectOutParametersForStage, "the '$0' stage does not support `out` or `inout` entry point parameters")
 DIAGNOSTIC(39014, Error, dontExpectInParametersForStage, "the '$0' stage does not support `in` entry point parameters")

--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -368,6 +368,7 @@ DIAGNOSTIC(39009, Error, expectedSpace, "expected 'space', got '$0'")
 DIAGNOSTIC(39010, Error, expectedSpaceIndex, "expected a register space index after 'space'")
 DIAGNOSTIC(39011, Error, componentMaskNotSupported, "explicit register component masks are not yet supported in Slang")
 DIAGNOSTIC(39012, Error, packOffsetNotSupported, "explicit 'packoffset' bindings are not yet supported in Slang")
+DIAGNOSTIC(39013, Warning, registerModifierButNoVulkanLayout, "shader parameter '$0' has a 'register' specified for D3D, but no '[[vk::binding(...)]]` specified for Vulkan")
 
 DIAGNOSTIC(39013, Error, dontExpectOutParametersForStage, "the '$0' stage does not support `out` or `inout` entry point parameters")
 DIAGNOSTIC(39014, Error, dontExpectInParametersForStage, "the '$0' stage does not support `in` entry point parameters")

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -823,7 +823,7 @@ static bool isOpenGLTarget(TargetRequest*)
     return false;
 }
 
-static bool isD3DTarget(TargetRequest* targetReq)
+bool isD3DTarget(TargetRequest* targetReq)
 {
     switch( targetReq->target )
     {
@@ -836,6 +836,20 @@ static bool isD3DTarget(TargetRequest* targetReq)
 
     default:
         return false;
+    }
+}
+
+bool isKhronosTarget(TargetRequest* targetReq)
+{
+    switch( targetReq->target )
+    {
+    default:
+        return false;
+
+    case CodeGenTarget::GLSL:
+    case CodeGenTarget::SPIRV:
+    case CodeGenTarget::SPIRVAssembly:
+        return true;
     }
 }
 
@@ -886,21 +900,9 @@ static bool isSM5_1OrLater(TargetRequest* targetReq)
 
 static bool isVulkanTarget(TargetRequest* targetReq)
 {
-    switch( targetReq->target )
-    {
-    default:
-        return false;
-
-    case CodeGenTarget::GLSL:
-    case CodeGenTarget::SPIRV:
-    case CodeGenTarget::SPIRVAssembly:
-        break;
-    }
-
-    // For right now, any GLSL-related target is assumed
+    // For right now, any Khronos-related target is assumed
     // to be a Vulkan target.
-
-    return true;
+    return isKhronosTarget(targetReq);
 }
 
 static bool shouldAllocateRegisterSpaceForParameterBlock(

--- a/tests/diagnostics/vk-bindings.slang
+++ b/tests/diagnostics/vk-bindings.slang
@@ -1,0 +1,16 @@
+// vk-bindings.slang
+
+//TEST:SIMPLE:-target spirv
+
+// D3D `register` without VK binding
+Texture2D t : register(t0);
+
+struct S { float4 a; };
+
+// Parameter block with non-zero binding:
+[[vk::binding(2,1)]]
+ParameterBlock<S> b;
+
+[shader("compute")]
+void main()
+{}

--- a/tests/diagnostics/vk-bindings.slang.expected
+++ b/tests/diagnostics/vk-bindings.slang.expected
@@ -1,0 +1,7 @@
+result code = -1
+standard error = {
+tests/diagnostics/vk-bindings.slang(6): warning 39013: shader parameter 't' has a 'register' specified for D3D, but no '[[vk::binding(...)]]` specified for Vulkan
+tests/diagnostics/vk-bindings.slang(11): error 39015: shader parameter 'b' consumes whole descriptor sets, so the binding must be in the form '[[vk::binding(0, ...)]]'; the non-zero binding '2' is not allowed
+}
+standard output = {
+}

--- a/tests/reflection/parameter-block-explicit-space.slang
+++ b/tests/reflection/parameter-block-explicit-space.slang
@@ -1,0 +1,104 @@
+// parameter-block-explicit-space.slang
+
+//TEST:REFLECTION:-D__SLANG__ -stage fragment -entry main -profile sm_5_1 -target hlsl
+//TEST:COMPARE_HLSL:-stage fragment -entry main -profile sm_5_1
+
+#ifdef __SLANG__
+struct A
+{
+    float4          au;
+    Texture2D       at1;
+    Texture2D       at2;
+    SamplerState    as;
+}
+
+struct X
+{
+    float4 xu;    
+}
+
+struct B
+{
+    float4              bu;
+    Texture2D           bt;
+    SamplerState        bs;
+
+    // TODO: This line leads to a crash
+//    ConstantBuffer<X>   bx;
+}
+
+
+
+[[vk::binding(0,2)]]
+ParameterBlock<A> a : register(space2);
+
+[[vk::binding(0,3)]]
+ParameterBlock<B> b : register(space3);
+
+float4 use(float4 val) { return val; }
+float4 use(Texture2D t, SamplerState s)
+{
+    return t.Sample(s, 0.0);
+}
+
+float4 main() : SV_Target
+{
+    return use(a.au)
+        + use(a.at1, a.as)
+        + use(a.at2, a.as)
+        + use(b.bu)
+        + use(b.bt, b.bs)
+        // + use(b.bx.xu)
+        ;
+}
+
+#else
+
+#define A A_0
+#define a a_0
+#define au au_0
+#define at1 a_at1_0
+#define at2 a_at2_0
+#define as a_as_0
+
+#define B B_0
+#define b b_0
+#define bu bu_0
+#define bt b_bt_0
+#define bs b_bs_0
+
+struct A
+{
+    float4 au;
+};
+cbuffer _S1         : register(b0, space2)
+{ A a; }
+Texture2D       at1  : register(t0, space2);
+Texture2D       at2  : register(t1, space2);
+SamplerState    as  : register(s0, space2);
+
+struct B
+{
+    float4      bu;
+};
+cbuffer _S3         : register(b0, space3)
+{ B b; }
+Texture2D       bt  : register(t0, space3);
+SamplerState    bs  : register(s0, space3);
+
+float4 use(float4 val) { return val; }
+float4 use(Texture2D t, SamplerState s)
+{
+    return t.Sample(s, 0.0);
+}
+
+float4 main() : SV_TARGET
+{
+    return use(a.au)
+        + use(at1, as)
+        + use(at2, as)
+        + use(b.bu)
+        + use(bt, bs);
+}
+
+#endif

--- a/tests/reflection/parameter-block-explicit-space.slang.expected
+++ b/tests/reflection/parameter-block-explicit-space.slang.expected
@@ -1,0 +1,103 @@
+result code = 0
+standard error = {
+}
+standard output = {
+{
+    "parameters": [
+        {
+            "name": "a",
+            "binding": {"kind": "constantBuffer", "space": 2, "index": 0, "count": 0},
+            "type": {
+                "kind": "parameterBlock",
+                "elementType": {
+                    "kind": "struct",
+                    "name": "A",
+                    "fields": [
+                        {
+                            "name": "au",
+                            "type": {
+                                "kind": "vector",
+                                "elementCount": 4,
+                                "elementType": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                }
+                            },
+                            "binding": {"kind": "uniform", "offset": 0, "size": 16}
+                        },
+                        {
+                            "name": "at1",
+                            "type": {
+                                "kind": "resource",
+                                "baseShape": "texture2D"
+                            },
+                            "binding": {"kind": "shaderResource", "index": 0}
+                        },
+                        {
+                            "name": "at2",
+                            "type": {
+                                "kind": "resource",
+                                "baseShape": "texture2D"
+                            },
+                            "binding": {"kind": "shaderResource", "index": 1}
+                        },
+                        {
+                            "name": "as",
+                            "type": {
+                                "kind": "samplerState"
+                            },
+                            "binding": {"kind": "samplerState", "index": 0}
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "b",
+            "binding": {"kind": "constantBuffer", "space": 3, "index": 0, "count": 0},
+            "type": {
+                "kind": "parameterBlock",
+                "elementType": {
+                    "kind": "struct",
+                    "name": "B",
+                    "fields": [
+                        {
+                            "name": "bu",
+                            "type": {
+                                "kind": "vector",
+                                "elementCount": 4,
+                                "elementType": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                }
+                            },
+                            "binding": {"kind": "uniform", "offset": 0, "size": 16}
+                        },
+                        {
+                            "name": "bt",
+                            "type": {
+                                "kind": "resource",
+                                "baseShape": "texture2D"
+                            },
+                            "binding": {"kind": "shaderResource", "index": 0}
+                        },
+                        {
+                            "name": "bs",
+                            "type": {
+                                "kind": "samplerState"
+                            },
+                            "binding": {"kind": "samplerState", "index": 0}
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "fragment"
+        }
+    ]
+}
+}


### PR DESCRIPTION
This PR pulls together two changes.

The first one is a bit of infrastructure work to make sure that we ignore Vulkan-directed binding syntax (e.g., `[[vk::binding(...)]]`) when targeting D3D and vice versa for D3D `register` bindings on Vulkan. That change also adds a warning message if you are compiling a shader with explicit `register` bindings for Vulkan, if you forgot to also include `[[vk::binding(...)]]`. That whole change is really just here to avoid some subtle bugs it could create for the next bit.

The second change allows the user to specify something like `register(space1234)` on a `ParameterBlock` declaration to indicate that it should use space `1234`, and similarly to use `[[vk::binding(0,1234)]]` (where the `0` binding is required) for Vulkan.

As with all explicit binding constructs, this is not something I *want* to support, but it is something that users are requesting, so here we are.