### PR TITLE
Decorations are instructions

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -6188,12 +6188,9 @@ struct EmitVisitor
             ensureInstOperand(ctx, inst->getOperand(ii));
         }
 
-        if(auto parentInst = as<IRParentInst>(inst))
+        for(auto child : inst->getChildren())
         {
-            for(auto child : parentInst->getChildren())
-            {
-                ensureInstOperandsRec(ctx, child);
-            }
+            ensureInstOperandsRec(ctx, child);
         }
     }
 

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -1419,7 +1419,7 @@ struct EmitVisitor
     bool isTargetIntrinsicModifierApplicable(
         IRTargetIntrinsicDecoration*    decoration)
     {
-        auto targetName = String(decoration->targetName);
+        auto targetName = String(decoration->getTargetName());
 
         // If no target name was specified, then the modifier implicitly
         // applies to all targets.
@@ -2170,7 +2170,7 @@ struct EmitVisitor
         // then use that name instead.
         if(auto intrinsicDecoration = findTargetIntrinsicDecoration(context, inst))
         {
-            return String(intrinsicDecoration->definition);
+            return String(intrinsicDecoration->getDefinition());
         }
 
         // If we have a name hint on the instruction, then we will try to use that
@@ -2200,7 +2200,7 @@ struct EmitVisitor
             // name hint already ends with one.
             //
 
-            String nameHint = nameHintDecoration->name->text;
+            String nameHint = nameHintDecoration->getName();
             nameHint = scrubName(nameHint);
 
             StringBuilder sb;
@@ -2928,9 +2928,9 @@ struct EmitVisitor
         EmitContext*    /* ctx */,
         IRInst*         inst)
     {
-        for (auto dd = inst->firstDecoration; dd; dd = dd->next)
+        for(auto dd : inst->getDecorations())
         {
-            if (dd->op != kIRDecorationOp_TargetIntrinsic)
+            if (dd->op != kIROp_TargetIntrinsicDecoration)
                 continue;
 
             auto targetIntrinsic = (IRTargetIntrinsicDecoration*)dd;
@@ -2978,7 +2978,7 @@ struct EmitVisitor
         args++;
         argCount--;
 
-        auto name = String(targetIntrinsic->definition);
+        auto name = String(targetIntrinsic->getDefinition());
 
 
         if(isOrdinaryName(name))
@@ -3512,19 +3512,19 @@ struct EmitVisitor
                 decoratedValue = getSpecializedValue(specInst);
             }
 
-            for( auto decoration = decoratedValue->firstDecoration; decoration; decoration = decoration->next )
+            for( auto decoration : decoratedValue->getDecorations() )
             {
                 switch(decoration->op)
                 {
                 default:
                     break;
 
-                case kIRDecorationOp_RequireGLSLExtension:
-                    requireGLSLExtension(String(((IRRequireGLSLExtensionDecoration*)decoration)->extensionName));
+                case kIROp_RequireGLSLExtensionDecoration:
+                    requireGLSLExtension(String(((IRRequireGLSLExtensionDecoration*)decoration)->getExtensionName()));
                     break;
 
-                case kIRDecorationOp_RequireGLSLVersion:
-                    requireGLSLVersion(int(((IRRequireGLSLVersionDecoration*)decoration)->languageVersion));
+                case kIROp_RequireGLSLVersionDecoration:
+                    requireGLSLVersion(int(((IRRequireGLSLVersionDecoration*)decoration)->getLanguageVersion()));
                     break;
                 }
             }
@@ -3800,7 +3800,7 @@ struct EmitVisitor
                 auto prec = kEOp_Postfix;
                 needClose = maybeEmitParens(outerPrec, prec);
 
-                emit(decoration->outerArrayName);
+                emit(decoration->getOuterArrayName());
                 emit("[");
                 emitIROperand(ctx, inst->getOperand(1), mode, kEOp_General);
                 emit("].");
@@ -3968,12 +3968,6 @@ struct EmitVisitor
             }
             break;
 
-        case kIROp_NotePatchConstantFunc:
-        {
-            // No-op
-            break;
-        }
-
         case kIROp_Var:
             {
                 auto ptrType = cast<IRPtrType>(inst->getDataType());
@@ -4108,13 +4102,13 @@ struct EmitVisitor
         if (auto semanticDecoration = inst->findDecoration<IRSemanticDecoration>())
         {
             Emit(" : ");
-            emit(semanticDecoration->semanticName);
+            emit(semanticDecoration->getSemanticName());
             return;
         }
 
         if(auto layoutDecoration = inst->findDecoration<IRLayoutDecoration>())
         {
-            auto layout = layoutDecoration->layout;
+            auto layout = layoutDecoration->getLayout();
             if(auto varLayout = layout->dynamicCast<VarLayout>())
             {
                 emitIRSemantics(ctx, varLayout);
@@ -4137,7 +4131,7 @@ struct EmitVisitor
         if (!decoration)
             return nullptr;
 
-        return (VarLayout*) decoration->layout;
+        return (VarLayout*) decoration->getLayout();
     }
 
     void emitIRLayoutSemantics(
@@ -4354,7 +4348,7 @@ struct EmitVisitor
                     //
                     if (auto loopControlDecoration = loopInst->findDecoration<IRLoopControlDecoration>())
                     {
-                        switch (loopControlDecoration->mode)
+                        switch (loopControlDecoration->getMode())
                         {
                         case kIRLoopControl_Unroll:
                             // Note: loop unrolling control is only available in HLSL, not GLSL
@@ -4468,23 +4462,6 @@ struct EmitVisitor
         }
     }
 
-
-
-    IRInst* findFirstInst(IRFunc* irFunc, IROp op)
-    {
-        for (auto block : irFunc->getBlocks())
-        {
-            for (auto inst : block->getChildren())
-            {
-                if (inst->op == op)
-                {
-                    return inst;
-                }
-            }
-        }
-        return nullptr;
-    }
-
     void emitAttributeSingleString(const char* name, FuncDecl* entryPoint, Attribute* attrib)
     {
         assert(attrib);
@@ -4543,11 +4520,11 @@ struct EmitVisitor
     {
         SLANG_UNUSED(attrib);
 
-        auto irPatchFunc = static_cast<IRNotePatchConstantFunc*>(findFirstInst(irFunc, kIROp_NotePatchConstantFunc));
+        auto irPatchFunc = irFunc->findDecoration<IRPatchConstantFuncDecoration>();
         assert(irPatchFunc);
         if (!irPatchFunc)
         {
-            SLANG_DIAGNOSE_UNEXPECTED(getSink(), entryPoint->loc, "Unable to find NotePatchConstantFunc instruction");
+            SLANG_DIAGNOSE_UNEXPECTED(getSink(), entryPoint->loc, "Unable to find [patchConstantFunc(...)] decoration");
             return;
         }
 
@@ -4897,7 +4874,7 @@ struct EmitVisitor
             {
                 if (auto layoutDecor = pp->findDecoration<IRLayoutDecoration>())
                 {
-                    Layout* layout = layoutDecor->layout;
+                    Layout* layout = layoutDecor->getLayout();
                     VarLayout* varLayout = dynamic_cast<VarLayout*>(layout);
 
                     if (varLayout)
@@ -5053,7 +5030,7 @@ struct EmitVisitor
     {
         if( auto layoutDecoration = func->findDecoration<IRLayoutDecoration>() )
         {
-            return layoutDecoration->layout->dynamicCast<EntryPointLayout>();
+            return layoutDecoration->getLayout()->dynamicCast<EntryPointLayout>();
         }
         return nullptr;
     }
@@ -5062,7 +5039,7 @@ struct EmitVisitor
     {
         if (auto layoutDecoration = func->findDecoration<IRLayoutDecoration>())
         {
-            if (auto entryPointLayout = layoutDecoration->layout->dynamicCast<EntryPointLayout>())
+            if (auto entryPointLayout = layoutDecoration->getLayout()->dynamicCast<EntryPointLayout>())
             {
                 return entryPointLayout;
             }
@@ -5268,13 +5245,13 @@ struct EmitVisitor
         bool isGLSL = (ctx->shared->target == CodeGenTarget::GLSL);
         bool anyModifiers = false;
 
-        for(auto dd = varInst->firstDecoration; dd; dd = dd->next)
+        for(auto dd : varInst->getDecorations())
         {
-            if(dd->op != kIRDecorationOp_InterpolationMode)
+            if(dd->op != kIROp_InterpolationModeDecoration)
                 continue;
 
             auto decoration = (IRInterpolationModeDecoration*)dd;
-            auto mode = decoration->mode;
+            auto mode = decoration->getMode();
 
             switch(mode)
             {
@@ -6055,7 +6032,7 @@ struct EmitVisitor
 
         // We expect the terminator to be a `return`
         // instruction with a value.
-        auto returnInst = (IRReturnVal*) block->getLastInst();
+        auto returnInst = (IRReturnVal*) block->getLastDecorationOrChild();
         SLANG_RELEASE_ASSERT(returnInst->op == kIROp_ReturnVal);
 
         // We will emit the value in the `GlobalConstant` mode, which
@@ -6188,7 +6165,7 @@ struct EmitVisitor
             ensureInstOperand(ctx, inst->getOperand(ii));
         }
 
-        for(auto child : inst->getChildren())
+        for(auto child : inst->getDecorationsAndChildren())
         {
             ensureInstOperandsRec(ctx, child);
         }

--- a/source/slang/ir-inst-defs.h
+++ b/source/slang/ir-inst-defs.h
@@ -149,40 +149,31 @@ INST(Nop, nop, 0, 0)
 // This is a parent instruction that holds zero or more
 // `field` instructions.
 //
-// Note: we are being a bit slippery here, because a `struct`
-// instruction is really an `IRParentInst`, but we want it
-// to also be caught in any dynamic cast to `IRType`, so we
-// ensure that it comes at the *end* of the range for `IRType`,
-// and the start of the range for `IRParentInst` (and `IRGlobalValue`)
 INST(StructType, struct, 0, PARENT)
 
 INST_RANGE(Type, VoidType, StructType)
 
-/*IRParentInst*/
+/*IRGlobalValue*/
 
-    /*IRGlobalValue*/
+    /*IRGlobalValueWithCode*/
+        /* IRGlobalValueWIthParams*/
+            INST(Func, func, 0, PARENT)
+            INST(Generic, generic, 0, PARENT)
+        INST_RANGE(GlobalValueWithParams, Func, Generic)
 
-        /*IRGlobalValueWithCode*/
-            /* IRGlobalValueWIthParams*/
-                INST(Func, func, 0, PARENT)
-                INST(Generic, generic, 0, PARENT)
-            INST_RANGE(GlobalValueWithParams, Func, Generic)
+        INST(GlobalVar, global_var, 0, 0)
+        INST(GlobalConstant, global_constant, 0, 0)
+    INST_RANGE(GlobalValueWithCode, Func, GlobalConstant)
 
-            INST(GlobalVar, global_var, 0, 0)
-            INST(GlobalConstant, global_constant, 0, 0)
-        INST_RANGE(GlobalValueWithCode, Func, GlobalConstant)
+    INST(StructKey, key, 0, 0)
+    INST(GlobalGenericParam, global_generic_param, 0, 0)
+    INST(WitnessTable, witness_table, 0, 0)
 
-        INST(StructKey, key, 0, 0)
-        INST(GlobalGenericParam, global_generic_param, 0, 0)
-        INST(WitnessTable, witness_table, 0, 0)
+INST_RANGE(GlobalValue, StructType, WitnessTable)
 
-    INST_RANGE(GlobalValue, StructType, WitnessTable)
+INST(Module, module, 0, PARENT)
 
-    INST(Module, module, 0, PARENT)
-
-    INST(Block, block, 0, PARENT)
-
-INST_RANGE(ParentInst, StructType, Block)
+INST(Block, block, 0, PARENT)
 
 /* IRConstant */
     INST(BoolLit, boolConst, 0, 0)

--- a/source/slang/ir-inst-defs.h
+++ b/source/slang/ir-inst-defs.h
@@ -179,6 +179,7 @@ INST(Block, block, 0, PARENT)
     INST(BoolLit, boolConst, 0, 0)
     INST(IntLit, integer_constant, 0, 0)
     INST(FloatLit, float_constant, 0, 0)
+    INST(PtrLit, ptr_constant, 0, 0)
     INST(StringLit, string_constant, 0, 0)
 INST_RANGE(Constant, BoolLit, StringLit)
 
@@ -354,7 +355,40 @@ INST(SampleGrad, sampleGrad, 4, 0)
 
 INST(GroupMemoryBarrierWithGroupSync, GroupMemoryBarrierWithGroupSync, 0, 0)
 
-INST(NotePatchConstantFunc, notePatchConstantFunc, 1, 0)
+/* Decoration */
+
+INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
+    INST(LayoutDecoration,                  layout,                 1, 0)
+    INST(LoopControlDecoration,             loopControl,            1, 0)
+    /* TargetSpecificDecoration */
+        INST(TargetDecoration,              target,                 1, 0)
+        INST(TargetIntrinsicDecoration,     targetIntrinsic,        2, 0)
+    INST_RANGE(TargetSpecificDecoration, TargetDecoration, TargetIntrinsicDecoration)
+    INST(GLSLOuterArrayDecoration,          glslOuterArray,         1, 0)
+    INST(SemanticDecoration,                semantic,               1, 0)
+    INST(InterpolationModeDecoration,       interpolationMode,      1, 0)
+    INST(NameHintDecoration,                nameHint,               1, 0)
+
+    /**  The decorated _instruction_ is transitory. Such a decoration should NEVER be found on an output instruction a module. 
+        Typically used mark an instruction so can be specially handled - say when creating a IRConstant literal, and the payload of 
+        needs to be special cased for lookup. */
+    INST(TransitoryDecoration,              transitory,             0, 0)
+
+    INST(VulkanRayPayloadDecoration,        vulkanRayPayload,       0, 0)
+    INST(VulkanHitAttributesDecoration,     vulkanHitAttributes,    0, 0)
+    INST(RequireGLSLVersionDecoration,      requireGLSLVersion,     1, 0)
+    INST(RequireGLSLExtensionDecoration,    requireGLSLExtension,   1, 0)
+    INST(ReadNoneDecoration,                readNone,               0, 0)
+    INST(VulkanCallablePayloadDecoration,   vulkanCallablePayload,  0, 0)
+    INST(EarlyDepthStencilDecoration,       earlyDepthStencil,      0, 0)
+    INST(GloballyCoherentDecoration,        globallyCoherent,       0, 0)
+    INST(PatchConstantFuncDecoration,       patchConstantFunc,      1, 0)
+
+INST_RANGE(Decoration, HighLevelDeclDecoration, PatchConstantFuncDecoration)
+
+
+//
+
 
 PSEUDO_INST(Pos)
 PSEUDO_INST(PreInc)

--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -982,7 +982,7 @@ struct IRBuilder
     template<typename T>
     void addSimpleDecoration(IRInst* value)
     {
-        addDecoration(value, IROp(T::kOp), nullptr, 0);
+        addDecoration(value, IROp(T::kOp), (IRInst* const*) nullptr, 0);
     }
 
     void addHighLevelDeclDecoration(IRInst* value, Decl* decl);

--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -573,7 +573,7 @@ struct IRBuilder
     // The current parent being inserted into (this might
     // be the global scope, a function, a block inside
     // a function, etc.)
-    IRParentInst*   insertIntoParent = nullptr;
+    IRInst*   insertIntoParent = nullptr;
     //
     // An instruction in the current parent that we should insert before
     IRInst*         insertBeforeInst = nullptr;
@@ -585,7 +585,7 @@ struct IRBuilder
     // that we are inserting into (if any).
     IRGlobalValueWithCode*  getFunc();
 
-    void setInsertInto(IRParentInst* insertInto);
+    void setInsertInto(IRInst* insertInto);
     void setInsertBefore(IRInst* insertBefore);
 
     IRBuilderSourceLocRAII* sourceLocInfo = nullptr;

--- a/source/slang/ir-legalize-types.cpp
+++ b/source/slang/ir-legalize-types.cpp
@@ -1096,7 +1096,7 @@ static void addParamType(List<IRType*>& ioParamTypes, LegalType t)
 
 static void legalizeInstsInParent(
     IRTypeLegalizationContext*  context,
-    IRParentInst*               parent)
+    IRInst*                     parent)
 {
     IRInst* nextChild = nullptr;
     for(auto child = parent->getFirstChild(); child; child = nextChild)

--- a/source/slang/ir-missing-return.cpp
+++ b/source/slang/ir-missing-return.cpp
@@ -26,7 +26,7 @@ void checkForMissingReturnsRec(
         }
     }
 
-    for( auto childInst : inst->getChildren() )
+    for( auto childInst : inst->getDecorationsAndChildren() )
     {
         checkForMissingReturnsRec(childInst, sink);
     }

--- a/source/slang/ir-missing-return.cpp
+++ b/source/slang/ir-missing-return.cpp
@@ -26,12 +26,9 @@ void checkForMissingReturnsRec(
         }
     }
 
-    if( auto parentInst = as<IRParentInst>(inst) )
+    for( auto childInst : inst->getChildren() )
     {
-        for( auto childInst : parentInst->getChildren() )
-        {
-            checkForMissingReturnsRec(childInst, sink);
-        }
+        checkForMissingReturnsRec(childInst, sink);
     }
 }
 

--- a/source/slang/ir-restructure-scoping.cpp
+++ b/source/slang/ir-restructure-scoping.cpp
@@ -424,7 +424,7 @@ void fixValueScoping(RegionTree* regionTree)
         if(!parentRegion)
             continue;
 
-        for(auto inst : block->getChildren())
+        for(auto inst : block->getDecorationsAndChildren())
         {
             fixValueScopingForInst(inst, parentRegion, regionTree);
         }

--- a/source/slang/ir-sccp.cpp
+++ b/source/slang/ir-sccp.cpp
@@ -929,14 +929,10 @@ static void applySparseConditionalConstantPropagationRec(
         }
     }
 
-    if( auto parentInst = as<IRParentInst>(inst) )
+    for( auto childInst : inst->getChildren() )
     {
-        for( auto childInst : parentInst->getChildren() )
-        {
-            applySparseConditionalConstantPropagationRec(shared, childInst);
-        }
+        applySparseConditionalConstantPropagationRec(shared, childInst);
     }
-
 }
 
 void applySparseConditionalConstantPropagation(

--- a/source/slang/ir-sccp.cpp
+++ b/source/slang/ir-sccp.cpp
@@ -633,7 +633,7 @@ struct SCCPContext
                     // may in turn add other blocks/instructions to
                     // the work lists.
                     //
-                    for( auto inst : block->getChildren() )
+                    for( auto inst : block->getDecorationsAndChildren() )
                     {
                         updateValueForInst(inst);
                     }
@@ -702,7 +702,7 @@ struct SCCPContext
         List<IRInst*> instsToRemove;
         for( auto block : code->getBlocks() )
         {
-            for( auto inst : block->getChildren() )
+            for( auto inst : block->getDecorationsAndChildren() )
             {
                 // We look for instructions that have a constnat value on
                 // the lattice.
@@ -869,7 +869,7 @@ struct SCCPContext
             // err on the side of allowing unreachable code without
             // a warning.
             //
-            block->removeAndDeallocateAllChildren();
+            block->removeAndDeallocateAllDecorationsAndChildren();
         }
         //
         // At this point every one of our unreachable blocks is empty,
@@ -929,7 +929,7 @@ static void applySparseConditionalConstantPropagationRec(
         }
     }
 
-    for( auto childInst : inst->getChildren() )
+    for( auto childInst : inst->getDecorationsAndChildren() )
     {
         applySparseConditionalConstantPropagationRec(shared, childInst);
     }

--- a/source/slang/ir-serialize.cpp
+++ b/source/slang/ir-serialize.cpp
@@ -264,7 +264,6 @@ size_t IRSerialData::calcSizeInBytes() const
     return 
         _calcArraySize(m_insts) + 
         _calcArraySize(m_childRuns) + 
-        _calcArraySize(m_decorationRuns) + 
         _calcArraySize(m_externalOperands) + 
         _calcArraySize(m_stringTable) + 
         /* Raw source locs */
@@ -284,7 +283,6 @@ void IRSerialData::clear()
     memset(&m_insts[0], 0, sizeof(Inst));
 
     m_childRuns.Clear();
-    m_decorationRuns.Clear();
     m_externalOperands.Clear();
     m_rawSourceLocs.Clear();
 
@@ -298,8 +296,6 @@ void IRSerialData::clear()
     m_stringTable.SetSize(2);
     m_stringTable[int(kNullStringIndex)] = 0;
     m_stringTable[int(kEmptyStringIndex)] = 0;
-
-    m_decorationBaseIndex = 0;
 }
 
 template <typename T>
@@ -335,10 +331,8 @@ static bool _isEqual(const List<T>& aIn, const List<T>& bIn)
 bool IRSerialData::operator==(const ThisType& rhs) const
 {
     return (this == &rhs) || 
-        (m_decorationBaseIndex == rhs.m_decorationBaseIndex &&
-        _isEqual(m_insts, rhs.m_insts) &&
+        (_isEqual(m_insts, rhs.m_insts) &&
         _isEqual(m_childRuns, rhs.m_childRuns) &&
-        _isEqual(m_decorationRuns, rhs.m_decorationRuns) &&
         _isEqual(m_externalOperands, rhs.m_externalOperands) &&
         _isEqual(m_rawSourceLocs, rhs.m_rawSourceLocs) &&
         _isEqual(m_stringTable, rhs.m_stringTable));
@@ -354,33 +348,6 @@ void IRSerialWriter::_addInstruction(IRInst* inst)
     // Add to the map
     m_instMap.Add(inst, Ser::InstIndex(m_insts.Count()));
     m_insts.Add(inst);
-
-    // Add all the decorations, to the list. 
-    // We don't add to the decoration map, as we only want to do this once all the instructions have been hit
-    if (inst->firstDecoration)
-    {
-        m_instWithFirstDecoration.Add(inst);
-
-        IRDecoration* decor = inst->firstDecoration;
-  
-        const int initialNumDecor = int(m_decorations.Count());
-        while (decor)
-        {
-            m_decorations.Add(decor);
-            decor = decor->next;
-        }
-        
-        const Ser::SizeType numDecor = Ser::SizeType(int(m_decorations.Count()) - initialNumDecor);
-        
-        Ser::InstRun run;
-        run.m_parentIndex = m_instMap[inst];
-
-        // NOTE! This isn't quite correct, as we need to correct for when all the instructions are added, this is done at the end
-        run.m_startInstIndex = Ser::InstIndex(initialNumDecor);
-        run.m_numChildren = numDecor;
-
-        m_serialData->m_decorationRuns.Add(run);
-    }
 }
 
 // Find a view index that matches the view by file (and perhaps other characteristics in the future)
@@ -444,7 +411,7 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
         // cos we want breadth first so the order of children is the same as their index order, meaning we don't need to store explicit indices
         const Ser::InstIndex startChildInstIndex = Ser::InstIndex(m_insts.Count());
         
-        IRInstListBase childrenList = parentInst->getChildren();
+        IRInstListBase childrenList = parentInst->getDecorationsAndChildren();
         for (IRInst* child : childrenList)
         {
             // This instruction can't be in the map...
@@ -467,32 +434,10 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
         }
     }
 
-    // Now fix the decorations 
-    {
-        const int decorationBaseIndex = int(m_insts.Count());
-        m_serialData->m_decorationBaseIndex = decorationBaseIndex;
-        const int numDecorRuns = int(m_serialData->m_decorationRuns.Count());
-
-        // Work out the total num of decoration
-        int totalNumDecorations = 0;
-        if (numDecorRuns)
-        {
-            const auto& lastDecorInfo = m_serialData->m_decorationRuns.Last();
-            totalNumDecorations = int(lastDecorInfo.m_startInstIndex) + lastDecorInfo.m_numChildren;
-        }
-
-        // Fix the indices
-        for (int i = 0; i < numDecorRuns; ++i)
-        {
-            Ser::InstRun& info = m_serialData->m_decorationRuns[i];
-            info.m_startInstIndex = Ser::InstIndex(decorationBaseIndex + int(info.m_startInstIndex));
-        }
-
-        // Set to the right size
-        m_serialData->m_insts.SetSize(decorationBaseIndex + totalNumDecorations);
-        // Clear all instructions
-        memset(m_serialData->m_insts.begin(), 0, sizeof(Ser::Inst) * m_serialData->m_insts.Count());
-    }
+    // Set to the right size
+    m_serialData->m_insts.SetSize(m_insts.Count());
+    // Clear all instructions
+    memset(m_serialData->m_insts.begin(), 0, sizeof(Ser::Inst) * m_serialData->m_insts.Count());
 
     // Need to set up the actual instructions
     {
@@ -528,6 +473,12 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
                     {
                         dstInst.m_payloadType = PayloadType::Int64;
                         dstInst.m_payload.m_int64 = irConst->value.intVal;
+                        break;
+                    }
+                    case kIROp_PtrLit:
+                    {
+                        dstInst.m_payloadType = PayloadType::Int64;
+                        dstInst.m_payload.m_int64 = (intptr_t) irConst->value.ptrVal;
                         break;
                     }
                     case kIROp_FloatLit:
@@ -599,128 +550,6 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
             {
                 const Ser::InstIndex dstInstIndex = getInstIndex(srcInst->getOperand(j));
                 dstOperands[j] = dstInstIndex;
-            }
-        }
-    }
-
-    // Now need to do the decorations
-
-    {
-        const int decorationBaseIndex = m_serialData->m_decorationBaseIndex;
-        const int numDecor = int(m_decorations.Count());
-        SLANG_ASSERT(decorationBaseIndex + numDecor == int(m_serialData->m_insts.Count()));
-
-        // Have to be able to store in a byte!
-        SLANG_COMPILE_TIME_ASSERT(kIROpCount + kIRDecorationOp_CountOf < 0x100);
-
-        for (int i = 0; i < numDecor; ++i)
-        {
-            IRDecoration* srcDecor = m_decorations[i];
-            Ser::Inst& dstInst = m_serialData->m_insts[decorationBaseIndex + i];
-
-            dstInst.m_op = uint8_t(kIROpCount + srcDecor->op);
-
-            switch (srcDecor->op)
-            {
-                case kIRDecorationOp_HighLevelDecl:
-                {
-                    // TODO!
-                    // Decl* decl;
-                    break;
-                }
-                case kIRDecorationOp_Layout:
-                {
-                    // TODO!
-                    // Layout* layout;
-                    break;
-                }
-                case kIRDecorationOp_LoopControl:
-                {
-                    auto loopDecor = static_cast<IRLoopControlDecoration*>(srcDecor);
-
-                    dstInst.m_payloadType = PayloadType::UInt32;
-                    dstInst.m_payload.m_uint32 = uint32_t(loopDecor->mode);
-                    break;
-                }
-                case kIRDecorationOp_Target:
-                {
-                    auto targetDecor = static_cast<IRTargetDecoration*>(srcDecor);
-
-                    dstInst.m_payloadType = PayloadType::String_1;
-                    dstInst.m_payload.m_stringIndices[0] = getStringIndex(targetDecor->targetName);
-                    break;
-                }
-                case kIRDecorationOp_TargetIntrinsic:
-                {
-                    auto targetDecor = static_cast<IRTargetIntrinsicDecoration*>(srcDecor);
-                    dstInst.m_payloadType = PayloadType::String_2;
-
-                    dstInst.m_payload.m_stringIndices[0] = getStringIndex(targetDecor->targetName);
-                    dstInst.m_payload.m_stringIndices[1] = getStringIndex(targetDecor->definition);
-                    break;
-                }
-                case kIRDecorationOp_GLSLOuterArray:
-                {
-                    auto arrayDecor = static_cast<IRGLSLOuterArrayDecoration*>(srcDecor);
-                    dstInst.m_payloadType = PayloadType::String_1;
-
-                    dstInst.m_payload.m_stringIndices[0] = getStringIndex(arrayDecor->outerArrayName);
-                    break;
-                }
-                case kIRDecorationOp_Semantic:
-                {
-                    auto semanticDecor = static_cast<IRSemanticDecoration*>(srcDecor);
-
-                    dstInst.m_payloadType = PayloadType::String_1;
-                    dstInst.m_payload.m_stringIndices[0] = getStringIndex(semanticDecor->semanticName);
-                    break;
-                }
-                case kIRDecorationOp_InterpolationMode:
-                {
-                    auto semanticDecor = static_cast<IRInterpolationModeDecoration*>(srcDecor);
-                    dstInst.m_payloadType = PayloadType::UInt32;
-                    dstInst.m_payload.m_uint32 = uint32_t(semanticDecor->mode);
-                    break;
-                }
-                case kIRDecorationOp_NameHint:
-                {
-                    auto nameDecor = static_cast<IRNameHintDecoration*>(srcDecor);
-
-                    dstInst.m_payloadType = PayloadType::String_1;
-                    dstInst.m_payload.m_stringIndices[0] = getStringIndex(nameDecor->name);
-                    break;
-                }
-                case kIRDecorationOp_VulkanRayPayload:
-                case kIRDecorationOp_VulkanCallablePayload:
-                case kIRDecorationOp_VulkanHitAttributes:
-                case kIRDecorationOp_EarlyDepthStencil:
-                case kIRDecorationOp_ReadNone:
-                case kIRDecorationOp_GloballyCoherent:
-                {
-                    dstInst.m_payloadType = PayloadType::Empty;
-                    break;
-                }
-                case kIRDecorationOp_RequireGLSLExtension:
-                {
-                    auto extDecor = static_cast<IRRequireGLSLExtensionDecoration*>(srcDecor);
-
-                    dstInst.m_payloadType = PayloadType::String_1;
-                    dstInst.m_payload.m_stringIndices[0] = getStringIndex(extDecor->extensionName);
-                    break;
-                }
-                case kIRDecorationOp_RequireGLSLVersion:
-                {
-                    auto verDecor = static_cast<IRRequireGLSLVersionDecoration*>(srcDecor);
-
-                    dstInst.m_payloadType = PayloadType::UInt32;
-                    dstInst.m_payload.m_uint32 = uint32_t(verDecor->languageVersion);
-                    break;
-                }
-                default:
-                {
-                    SLANG_ASSERT(!"Unhandled decoration type");
-                    return SLANG_FAIL;
-                }
             }
         }
     }
@@ -1070,7 +899,6 @@ static size_t _calcInstChunkSize(IRSerialBinary::CompressionType compressionType
     totalSize += sizeof(Bin::SlangHeader) + 
         _calcInstChunkSize(compressionType, data.m_insts) +
         _calcChunkSize(compressionType, data.m_childRuns) +
-        _calcChunkSize(compressionType, data.m_decorationRuns) +
         _calcChunkSize(compressionType, data.m_externalOperands) +
         _calcChunkSize(Bin::CompressionType::None, data.m_stringTable) + 
         _calcChunkSize(Bin::CompressionType::None, data.m_rawSourceLocs);
@@ -1086,7 +914,6 @@ static size_t _calcInstChunkSize(IRSerialBinary::CompressionType compressionType
         Bin::SlangHeader slangHeader;
         slangHeader.m_chunk.m_type = Bin::kSlangFourCc;
         slangHeader.m_chunk.m_size = uint32_t(sizeof(slangHeader) - sizeof(Bin::Chunk));
-        slangHeader.m_decorationBase = uint32_t(data.m_decorationBaseIndex);
         slangHeader.m_compressionType = uint32_t(Bin::CompressionType::VariableByteLite);
 
         stream->Write(&slangHeader, sizeof(slangHeader));
@@ -1094,7 +921,6 @@ static size_t _calcInstChunkSize(IRSerialBinary::CompressionType compressionType
 
     SLANG_RETURN_ON_FAIL(_writeInstArrayChunk(compressionType, Bin::kInstFourCc, data.m_insts, stream));
     SLANG_RETURN_ON_FAIL(_writeArrayChunk(compressionType, Bin::kChildRunFourCc, data.m_childRuns, stream));
-    SLANG_RETURN_ON_FAIL(_writeArrayChunk(compressionType, Bin::kDecoratorRunFourCc, data.m_decorationRuns, stream));
     SLANG_RETURN_ON_FAIL(_writeArrayChunk(compressionType, Bin::kExternalOperandsFourCc, data.m_externalOperands, stream));
     SLANG_RETURN_ON_FAIL(_writeArrayChunk(Bin::CompressionType::None, Bin::kStringFourCc, data.m_stringTable, stream));
 
@@ -1417,7 +1243,6 @@ int64_t _calcChunkTotalSize(const IRSerialBinary::Chunk& chunk)
 
                 stream->Read(&slangHeader.m_chunk + 1, sizeof(slangHeader) - sizeof(chunk));
 
-                dataOut->m_decorationBaseIndex = slangHeader.m_decorationBase;
                 remainingBytes -= _calcChunkTotalSize(chunk);
                 break;
             }
@@ -1427,13 +1252,6 @@ int64_t _calcChunkTotalSize(const IRSerialBinary::Chunk& chunk)
                 SLANG_RETURN_ON_FAIL(_readInstArrayChunk(slangHeader, chunk, stream, &bytesRead, dataOut->m_insts));
                 remainingBytes -= _calcChunkTotalSize(chunk);
                 break;    
-            }
-            case SLANG_MAKE_COMPRESSED_FOUR_CC(Bin::kDecoratorRunFourCc):
-            case Bin::kDecoratorRunFourCc:
-            {
-                SLANG_RETURN_ON_FAIL(_readArrayChunk(slangHeader, chunk, stream, &bytesRead, dataOut->m_decorationRuns));
-                remainingBytes -= _calcChunkTotalSize(chunk);
-                break;
             }
             case SLANG_MAKE_COMPRESSED_FOUR_CC(Bin::kChildRunFourCc):
             case Bin::kChildRunFourCc:
@@ -1473,135 +1291,6 @@ int64_t _calcChunkTotalSize(const IRSerialBinary::Chunk& chunk)
     return SLANG_OK;
 }
 
-IRDecoration* IRSerialReader::_createDecoration(const Ser::Inst& srcInst)
-{
-    typedef Ser::Inst::PayloadType PayloadType;
-
-    IRDecorationOp decorOp = IRDecorationOp(srcInst.m_op - kIROpCount);
-    SLANG_ASSERT(decorOp < kIRDecorationOp_CountOf);
-
-    switch (decorOp)
-    {
-        case kIRDecorationOp_HighLevelDecl:
-        {
-            // TODO!
-            // Decl* decl;
-            return createEmptyDecoration<IRHighLevelDeclDecoration>(m_module);
-        }
-        case kIRDecorationOp_Layout:
-        {
-            // TODO!
-            // Layout* layout;
-            return createEmptyDecoration<IRLayoutDecoration>(m_module);
-        }
-        case kIRDecorationOp_LoopControl:
-        {
-            auto decor = createEmptyDecoration<IRLoopControlDecoration>(m_module);
-            SLANG_ASSERT(srcInst.m_payloadType == PayloadType::UInt32);
-            decor->mode = IRLoopControl(srcInst.m_payload.m_uint32);
-            return decor;
-        }
-        case kIRDecorationOp_Target:
-        {
-            auto decor = createEmptyDecoration<IRTargetDecoration>(m_module);
-            SLANG_ASSERT(srcInst.m_payloadType == PayloadType::String_1);
-            decor->targetName = m_stringRepresentationCache.getStringRepresentation(StringHandle(srcInst.m_payload.m_stringIndices[0]));
-            return decor;
-        }
-        case kIRDecorationOp_TargetIntrinsic:
-        {
-            auto decor = createEmptyDecoration<IRTargetIntrinsicDecoration>(m_module);
-            SLANG_ASSERT(srcInst.m_payloadType == PayloadType::String_2);
-            decor->targetName = m_stringRepresentationCache.getStringRepresentation(StringHandle(srcInst.m_payload.m_stringIndices[0]));
-            decor->definition = m_stringRepresentationCache.getStringRepresentation(StringHandle(srcInst.m_payload.m_stringIndices[1]));
-            return decor;
-        }
-        case kIRDecorationOp_GLSLOuterArray:
-        {
-            auto decor = createEmptyDecoration<IRGLSLOuterArrayDecoration>(m_module);
-            SLANG_ASSERT(srcInst.m_payloadType == PayloadType::String_1);
-            decor->outerArrayName = m_stringRepresentationCache.getCStr(StringHandle(srcInst.m_payload.m_stringIndices[0]));
-            return decor;
-        }
-        case kIRDecorationOp_Semantic:
-        {
-            auto decor = createEmptyDecoration<IRSemanticDecoration>(m_module);
-            SLANG_ASSERT(srcInst.m_payloadType == PayloadType::String_1);
-            decor->semanticName = m_stringRepresentationCache.getName(StringHandle(srcInst.m_payload.m_stringIndices[0]));
-            return decor;
-        }
-        case kIRDecorationOp_InterpolationMode:
-        {
-            auto decor = createEmptyDecoration<IRInterpolationModeDecoration>(m_module);
-            SLANG_ASSERT(srcInst.m_payloadType == Ser::Inst::PayloadType::UInt32);
-            decor->mode = IRInterpolationMode(srcInst.m_payload.m_uint32);
-            return decor;
-        }
-        case kIRDecorationOp_NameHint:
-        {
-            auto decor = createEmptyDecoration<IRNameHintDecoration>(m_module);
-            SLANG_ASSERT(srcInst.m_payloadType == PayloadType::String_1);
-            decor->name = m_stringRepresentationCache.getName(StringHandle(srcInst.m_payload.m_stringIndices[0]));
-            return decor;
-        }
-        case kIRDecorationOp_VulkanRayPayload:
-        {
-            auto decor = createEmptyDecoration<IRVulkanRayPayloadDecoration>(m_module);
-            SLANG_ASSERT(srcInst.m_payloadType == PayloadType::Empty);
-            return decor;
-        }
-        case kIRDecorationOp_VulkanCallablePayload:
-        {
-            auto decor = createEmptyDecoration<IRVulkanCallablePayloadDecoration>(m_module);
-            SLANG_ASSERT(srcInst.m_payloadType == PayloadType::Empty);
-            return decor;
-        }
-        case kIRDecorationOp_EarlyDepthStencil:
-        {
-            auto decor = createEmptyDecoration<IREarlyDepthStencilDecoration>(m_module);
-            SLANG_ASSERT(srcInst.m_payloadType == PayloadType::Empty);
-            return decor;
-        }
-        case kIRDecorationOp_GloballyCoherent:
-        {
-            auto decor = createEmptyDecoration<IRGloballyCoherentDecoration>(m_module);
-            SLANG_ASSERT(srcInst.m_payloadType == PayloadType::Empty);
-            return decor;
-        }
-        case kIRDecorationOp_VulkanHitAttributes:
-        {
-            auto decor = createEmptyDecoration<IRVulkanHitAttributesDecoration>(m_module);
-            SLANG_ASSERT(srcInst.m_payloadType == PayloadType::Empty);
-            return decor;
-        }
-        case kIRDecorationOp_RequireGLSLExtension:
-        {
-            auto decor = createEmptyDecoration<IRRequireGLSLExtensionDecoration>(m_module);
-            SLANG_ASSERT(srcInst.m_payloadType == PayloadType::String_1);
-            decor->extensionName = m_stringRepresentationCache.getStringRepresentation(StringHandle(srcInst.m_payload.m_stringIndices[0]));
-            return decor;
-        }
-        case kIRDecorationOp_RequireGLSLVersion:
-        {
-            auto decor = createEmptyDecoration<IRRequireGLSLVersionDecoration>(m_module);
-            SLANG_ASSERT(srcInst.m_payloadType == Ser::Inst::PayloadType::UInt32);
-            decor->languageVersion = Int(srcInst.m_payload.m_uint32);
-            return decor;
-        }
-        case kIRDecorationOp_ReadNone:
-        {
-            auto decor = createEmptyDecoration<IRReadNoneDecoration>(m_module);
-            SLANG_ASSERT(srcInst.m_payloadType == PayloadType::Empty);
-            return decor;
-        }
-        default:
-        {
-            SLANG_ASSERT(!"Unhandled decoration type");
-            return nullptr;
-        }
-    }
-}
-
 /* static */Result IRSerialReader::read(const IRSerialData& data, Session* session, RefPtr<IRModule>& moduleOut)
 {
     typedef Ser::Inst::PayloadType PayloadType;
@@ -1620,17 +1309,13 @@ IRDecoration* IRSerialReader::_createDecoration(const Ser::Inst& srcInst)
     // Add all the instructions
 
     List<IRInst*> insts;
-    List<IRDecoration*> decorations;
 
-    const int numInsts = data.m_decorationBaseIndex;
-    const int numDecorations = int(data.m_insts.Count() - numInsts);
+    const int numInsts = int(data.m_insts.Count());
 
     SLANG_ASSERT(numInsts > 0);
 
     insts.SetSize(numInsts);
     insts[0] = nullptr;
-
-    decorations.SetSize(numDecorations);
 
     // 0 holds null
     // 1 holds the IRModuleInst
@@ -1690,6 +1375,13 @@ IRDecoration* IRSerialReader::_createDecoration(const Ser::Inst& srcInst)
                         SLANG_ASSERT(srcInst.m_payloadType == PayloadType::Int64);
                         irConst = static_cast<IRConstant*>(createEmptyInstWithSize(module, op, prefixSize + sizeof(IRIntegerValue)));
                         irConst->value.intVal = srcInst.m_payload.m_int64; 
+                        break;
+                    }
+                    case kIROp_PtrLit:
+                    {
+                        SLANG_ASSERT(srcInst.m_payloadType == PayloadType::Int64);
+                        irConst = static_cast<IRConstant*>(createEmptyInstWithSize(module, op, prefixSize + sizeof(void*)));
+                        irConst->value.ptrVal = (void*) (intptr_t) srcInst.m_payload.m_int64; 
                         break;
                     }
                     case kIROp_FloatLit:
@@ -1792,47 +1484,6 @@ IRDecoration* IRSerialReader::_createDecoration(const Ser::Inst& srcInst)
                 IRInst* child = insts[j + int(run.m_startInstIndex)];
                 SLANG_ASSERT(child->parent == nullptr);
                 child->insertAtEnd(inst);
-            }
-        }
-    }
-
-    // Create the decorations
-    for (int i = 0; i < numDecorations; ++i)
-    {
-        IRDecoration* decor = _createDecoration(data.m_insts[i + numInsts]);
-        if (!decor)
-        {
-            return SLANG_FAIL;
-        }
-        decorations[i] = decor;
-    }
-
-    // Associate the decorations with the instructions
-
-    {
-        const int decorationBaseIndex = m_serialData->m_decorationBaseIndex;
-
-        const int numRuns = int(m_serialData->m_decorationRuns.Count());
-        for (int i = 0; i < numRuns; ++i)
-        {
-            const Ser::InstRun& run = m_serialData->m_decorationRuns[i];
-
-            // Decorations must be associated with instructions
-            SLANG_ASSERT(int(run.m_parentIndex) < decorationBaseIndex);
-
-            IRInst* inst = insts[int(run.m_parentIndex)];
-            SLANG_ASSERT(int(run.m_startInstIndex) >= decorationBaseIndex && int(run.m_startInstIndex) + run.m_numChildren <= m_serialData->m_insts.Count());
-
-            // Calculate the offset in the decoration list, which index 0, is decorationBaseIndex in instruction indices
-            const int decorStartIndex = int(run.m_startInstIndex) - decorationBaseIndex;
-
-            // Go in reverse order so that linked list is in same order as original
-            for (int j = int(run.m_numChildren) - 1; j >= 0; --j)
-            {
-                IRDecoration* decor = decorations[decorStartIndex + j]; 
-                // And to the linked list on the 
-                decor->next = inst->firstDecoration;
-                inst->firstDecoration = decor;
             }
         }
     }

--- a/source/slang/ir-serialize.h
+++ b/source/slang/ir-serialize.h
@@ -212,14 +212,12 @@ struct IRSerialData
     size_t calcSizeInBytes() const;
 
     /// Ctor
-    IRSerialData() :
-        m_decorationBaseIndex(0)
+    IRSerialData()
     {}
 
     List<Inst> m_insts;                         ///< The instructions
 
     List<InstRun> m_childRuns;                  ///< Holds the information about children that belong to an instruction
-    List<InstRun> m_decorationRuns;             ///< Holds instruction decorations    
 
     List<InstIndex> m_externalOperands;         ///< Holds external operands (for instructions with more than kNumOperands)
 
@@ -234,8 +232,6 @@ struct IRSerialData
     List<char> m_debugStrings;                  ///< All of the debug strings
 
     static const PayloadInfo s_payloadInfos[int(Inst::PayloadType::CountOf)];
-    
-    int m_decorationBaseIndex;                  ///< All decorations insts are at indices >= to this value
 };
 
 // --------------------------------------------------------------------------
@@ -323,12 +319,10 @@ struct IRSerialBinary
     static const uint32_t kSlangFourCc = SLANG_FOUR_CC('S', 'L', 'N', 'G');             ///< Holds all the slang specific chunks
 
     static const uint32_t kInstFourCc = SLANG_FOUR_CC('S', 'L', 'i', 'n');
-    static const uint32_t kDecoratorRunFourCc = SLANG_FOUR_CC('S', 'L', 'd', 'r');
     static const uint32_t kChildRunFourCc = SLANG_FOUR_CC('S', 'L', 'c', 'r');
     static const uint32_t kExternalOperandsFourCc = SLANG_FOUR_CC('S', 'L', 'e', 'o');
 
     static const uint32_t kCompressedInstFourCc = SLANG_MAKE_COMPRESSED_FOUR_CC(kInstFourCc);
-    static const uint32_t kCompressedDecoratorRunFourCc = SLANG_MAKE_COMPRESSED_FOUR_CC(kDecoratorRunFourCc);
     static const uint32_t kCompressedChildRunFourCc = SLANG_MAKE_COMPRESSED_FOUR_CC(kChildRunFourCc);
     static const uint32_t kCompressedExternalOperandsFourCc = SLANG_MAKE_COMPRESSED_FOUR_CC(kExternalOperandsFourCc);
 
@@ -339,7 +333,6 @@ struct IRSerialBinary
     struct SlangHeader
     {
         Chunk m_chunk;
-        uint32_t m_decorationBase;
         uint32_t m_compressionType;         ///< Holds the compression type used (if used at all)
     };
     struct ArrayHeader

--- a/source/slang/ir-validate.cpp
+++ b/source/slang/ir-validate.cpp
@@ -38,7 +38,7 @@ namespace Slang
         IRInst*             parent)
     {
         IRInst* prevChild = nullptr;
-        for (auto child = parent->getFirstChild(); child; child = child->getNextInst())
+        for(auto child : parent->getDecorationsAndChildren() )
         {
             // We need to check the integrity of the parent/next/prev links of
             // all of our instructions
@@ -53,7 +53,7 @@ namespace Slang
             // * The last instruction of a block should always be a terminator
             // * No other instruction should be a terminator
             //
-            if(as<IRBlock>(parent) && (child == parent->getLastChild()))
+            if(as<IRBlock>(parent) && (child == parent->getLastDecorationOrChild()))
             {
                 validate(context, as<IRTerminatorInst>(child) != nullptr, child, "last instruction in block must be terminator");
             }

--- a/source/slang/ir-validate.cpp
+++ b/source/slang/ir-validate.cpp
@@ -35,7 +35,7 @@ namespace Slang
 
     void validateIRInstChildren(
         IRValidateContext*  context,
-        IRParentInst*       parent)
+        IRInst*             parent)
     {
         IRInst* prevChild = nullptr;
         for (auto child = parent->getFirstChild(); child; child = child->getNextInst())
@@ -174,10 +174,7 @@ namespace Slang
 
         // If `inst` is itself a parent instruction, then we need to recursively
         // validate its children.
-        if (auto parent = as<IRParentInst>(inst))
-        {
-            validateIRInstChildren(context, parent);
-        }
+        validateIRInstChildren(context, inst);
     }
 
     void validateIRModule(IRModule* module, DiagnosticSink* sink)

--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -193,9 +193,9 @@ namespace Slang
         return (IRUse*)(this + 1);
     }
 
-    IRDecoration* IRInst::findDecorationImpl(IRDecorationOp decorationOp)
+    IRDecoration* IRInst::findDecorationImpl(IROp decorationOp)
     {
-        for( auto dd = firstDecoration; dd; dd = dd->next )
+        for(auto dd : getDecorations())
         {
             if(dd->op == decorationOp)
                 return dd;
@@ -252,14 +252,31 @@ namespace Slang
 
     void IRBlock::addParam(IRParam* param)
     {
-        auto lastParam = getLastParam();
-        if (lastParam)
+        // If there are any existing parameters,
+        // then insert after the last of them.
+        //
+        if (auto lastParam = getLastParam())
         {
             param->insertAfter(lastParam);
         }
+        //
+        // Otherwise, if there are any existing
+        // "ordinary" instructions, insert before
+        // the first of them.
+        //
+        else if(auto firstOrdinary = getFirstOrdinaryInst())
+        {
+            param->insertBefore(firstOrdinary);
+        }
+        //
+        // Otherwise the block currently has neither
+        // parameters nor orindary instructions,
+        // so we can safely insert at the end of
+        // the list of (raw) children.
+        //
         else
         {
-            param->insertAtStart(this);
+            param->insertAtEnd(this);
         }
     }
 
@@ -804,19 +821,6 @@ namespace Slang
         return inst;
     }
 
-
-    IRDecoration* createEmptyDecoration(
-        IRModule* module,
-        IRDecorationOp op,
-        size_t sizeInBytes)
-    {
-        SLANG_ASSERT(sizeInBytes >= sizeof(IRDecoration));
-        SLANG_ASSERT(module);
-        IRDecoration* decor = (IRDecoration*)module->memoryArena.allocateAndZero(sizeInBytes);
-        decor->op = op;
-        return decor;
-    }
-
     // Given an instruction that represents a constant, a type, etc.
     // Try to "hoist" it as far toward the global scope as possible
     // to insert it at a location where it will be maximally visible.
@@ -1190,13 +1194,14 @@ namespace Slang
         return code;
     }
 
-    UnownedStringSlice IRConstant::getStringSlice() const
+    UnownedStringSlice IRConstant::getStringSlice()
     {
         assert(op == kIROp_StringLit);
         // If the transitory decoration is set, then this is uses the transitoryStringVal for the text storage.
         // This is typically used when we are using a transitory IRInst held on the stack (such that it can be looked up in cached), 
         // that just points to a string elsewhere, and NOT the typical normal style, where the string is held after the instruction in memory.
-        if (firstDecoration && firstDecoration->op == kIRDecorationOp_Transitory)
+        //
+        if(findDecorationImpl(kIROp_TransitoryDecoration))
         {
             return UnownedStringSlice(value.transitoryStringVal.chars, value.transitoryStringVal.numChars);
         }
@@ -1230,6 +1235,10 @@ namespace Slang
                 // ... we can just compare as bits
                 return value.intVal == rhs.value.intVal;
             }
+            case kIROp_PtrLit:
+            {
+                return value.ptrVal == rhs.value.ptrVal;
+            }
             case kIROp_StringLit:
             {
                 return getStringSlice() == rhs.getStringSlice();
@@ -1255,6 +1264,10 @@ namespace Slang
                 SLANG_COMPILE_TIME_ASSERT(sizeof(IRFloatingPointValue) == sizeof(IRIntegerValue));
                 // ... we can just compare as bits
                 return combineHash(code, Slang::GetHashCode(value.intVal));
+            }
+            case kIROp_PtrLit:
+            {
+                return combineHash(code, Slang::GetHashCode(value.ptrVal));
             }
             case kIROp_StringLit:
             {
@@ -1296,6 +1309,10 @@ namespace Slang
 
         switch (keyInst.op)
         {
+        default:
+            SLANG_UNEXPECTED("missing case for IR constant");
+            break;
+
             case kIROp_BoolLit:
             case kIROp_IntLit:
             {
@@ -1307,6 +1324,12 @@ namespace Slang
             {
                 irValue = static_cast<IRConstant*>(createInstWithSizeImpl(builder, keyInst.op, keyInst.getFullType(), prefixSize + sizeof(IRFloatingPointValue)));
                 irValue->value.floatVal = keyInst.value.floatVal;
+                break;
+            }
+            case kIROp_PtrLit:
+            {
+                irValue = static_cast<IRConstant*>(createInstWithSizeImpl(builder, keyInst.op, keyInst.getFullType(), prefixSize + sizeof(void*)));
+                irValue->value.ptrVal = keyInst.value.ptrVal;
                 break;
             }
             case kIROp_StringLit:
@@ -1376,8 +1399,10 @@ namespace Slang
         memset(&keyInst, 0, sizeof(keyInst));
         
         // Mark that this is on the stack...
-        static IRDecoration stackDecoration = IRDecoration::make(kIRDecorationOp_Transitory);
-        keyInst.firstDecoration = &stackDecoration;
+        IRDecoration stackDecoration;
+        memset(&stackDecoration, 0, sizeof(stackDecoration));
+        stackDecoration.op = kIROp_TransitoryDecoration;
+        stackDecoration.insertAtEnd(&keyInst);
             
         keyInst.op = kIROp_StringLit;
         keyInst.typeUse.usedValue = getStringType();
@@ -1388,6 +1413,19 @@ namespace Slang
 
         return static_cast<IRStringLit*>(findOrEmitConstant(this, keyInst));
     }
+
+    IRPtrLit* IRBuilder::getPtrValue(void* value)
+    {
+        IRType* type = getPtrType(getVoidType());
+
+        IRConstant keyInst;
+        memset(&keyInst, 0, sizeof(keyInst));
+        keyInst.op = kIROp_PtrLit;
+        keyInst.typeUse.usedValue = type;
+        keyInst.value.ptrVal = value;
+        return (IRPtrLit*) findOrEmitConstant(this, keyInst);
+    }
+
  
     IRInst* findOrEmitHoistableInst(
         IRBuilder*              builder,
@@ -2175,19 +2213,6 @@ namespace Slang
         return inst;
     }
 
-    IRNotePatchConstantFunc* IRBuilder::emitNotePatchConstantFunc(
-        IRInst* func)
-    {
-        auto inst = createInst<IRNotePatchConstantFunc>(
-            this,
-            kIROp_NotePatchConstantFunc,
-            nullptr,
-            func);
-
-        addInst(inst);
-        return inst;
-    }
-
     IRInst* IRBuilder::emitFieldExtract(
         IRType* type,
         IRInst* base,
@@ -2562,18 +2587,40 @@ namespace Slang
         return inst;
     }
 
-    IRHighLevelDeclDecoration* IRBuilder::addHighLevelDeclDecoration(IRInst* inst, Decl* decl)
+    IRDecoration* IRBuilder::addDecoration(IRInst* value, IROp op, IRInst* const* operands, Int operandCount)
     {
-        auto decoration = addDecoration<IRHighLevelDeclDecoration>(inst, kIRDecorationOp_HighLevelDecl);
-        decoration->decl = decl;
+        auto decoration = createInstWithTrailingArgs<IRDecoration>(
+            this,
+            op,
+            getVoidType(),
+            operandCount,
+            operands);
+
+        // Decoration order should not, in general, be semantically
+        // meaningful, so we will elect to insert a new decoration
+        // at the start of an instruction (constant time) rather
+        // than at the end of any existing list of deocrations
+        // (which would take time linear in the number of decorations).
+        //
+        // TODO: revisit this if maintaining decoration ordering
+        // from input source code is desirable.
+        //
+        decoration->insertAtStart(value);
+
         return decoration;
     }
 
-    IRLayoutDecoration* IRBuilder::addLayoutDecoration(IRInst* inst, Layout* layout)
+
+    void IRBuilder::addHighLevelDeclDecoration(IRInst* inst, Decl* decl)
     {
-        auto decoration = addDecoration<IRLayoutDecoration>(inst);
-        decoration->layout = addRefObjectToFree(layout);
-        return decoration;
+        auto ptrConst = getPtrValue(addRefObjectToFree(decl));
+        addDecoration(inst, kIROp_HighLevelDeclDecoration, ptrConst);
+    }
+
+    void IRBuilder::addLayoutDecoration(IRInst* inst, Layout* layout)
+    {
+        auto ptrConst = getPtrValue(addRefObjectToFree(layout));
+        addDecoration(inst, kIROp_LayoutDecoration, ptrConst);
     }
 
     //
@@ -2918,74 +2965,25 @@ namespace Slang
         for(; inst; inst = inst->getNextInst())
         {
             dumpInst(context, inst);
+            dump(context, "\n");
         }
     }
+
+    static void dumpInstBody(
+        IRDumpContext*  context,
+        IRInst*         inst);
 
     void dumpIRDecorations(
         IRDumpContext*  context,
         IRInst*         inst)
     {
-        for( auto dd = inst->firstDecoration; dd; dd = dd->next )
+        for(auto dd : inst->getDecorations())
         {
-            switch( dd->op )
-            {
-            case kIRDecorationOp_Target:
-                {
-                    auto decoration = (IRTargetDecoration*) dd;
+            dump(context, "[");
+            dumpInstBody(context, dd);
+            dump(context, "]\n");
 
-                    dump(context, "\n");
-                    dumpIndent(context);
-                    dump(context, "[target(");
-                    dump(context, StringRepresentation::getData(decoration->targetName));
-                    dump(context, ")]");
-                }
-                break;
-
-            case kIRDecorationOp_TargetIntrinsic:
-                {
-                    auto decoration = (IRTargetIntrinsicDecoration*) dd;
-
-                    dump(context, "\n");
-                    dumpIndent(context);
-                    dump(context, "[targetIntrinsic(");
-                    dump(context, StringRepresentation::getData(decoration->targetName));
-                    dump(context, ", ");
-                    dump(context, StringRepresentation::getData(decoration->definition));
-                    dump(context, ")]");
-                }
-                break;
-
-            case kIRDecorationOp_VulkanRayPayload:
-                {
-                    dump(context, "\n[__vulkanRayPayload]");
-                }
-                break;
-            case kIRDecorationOp_VulkanCallablePayload:
-                {
-                    dump(context, "\n[__vulkanCallPayload]");
-                }
-                break;
-            case kIRDecorationOp_VulkanHitAttributes:
-                {
-                    dump(context, "\n[__vulkanHitAttributes]");
-                }
-                break;
-            case kIRDecorationOp_ReadNone:
-                {
-                    dump(context, "\n[__readNone]");
-                }
-                break;
-            case kIRDecorationOp_EarlyDepthStencil:
-                {
-                    dump(context, "\n[earlydepthstencil]");
-                }
-                break;
-            case kIRDecorationOp_GloballyCoherent:
-                {
-                    dump(context, "\n[globallycoherent]");
-                }
-                break;
-            }
+            dumpIndent(context);
         }
     }
 
@@ -2995,7 +2993,6 @@ namespace Slang
     {
         auto opInfo = getIROpInfo(code->op);
 
-        dump(context, "\n");
         dumpIndent(context);
         dump(context, opInfo.name);
         dump(context, " ");
@@ -3055,7 +3052,6 @@ namespace Slang
     {
         auto opInfo = getIROpInfo(inst->op);
 
-        dump(context, "\n");
         dumpIndent(context);
         dump(context, opInfo.name);
         dump(context, " ");
@@ -3076,9 +3072,10 @@ namespace Slang
         dump(context, "{\n");
         context->indent++;
 
-        for (auto child = inst->getFirstChild(); child; child = child->getNextInst())
+        for(auto child : inst->getChildren())
         {
             dumpInst(context, child);
+            dump(context, "\n");
         }
 
         context->indent--;
@@ -3099,19 +3096,19 @@ namespace Slang
         for (auto ii : witnessTable->getChildren())
         {
             dumpInst(context, ii);
+            dump(context, "\n");
         }
 
         context->indent--;
         dump(context, "}\n");
     }
 
-    static void dumpInst(
+    static void dumpInstBody(
         IRDumpContext*  context,
         IRInst*         inst)
     {
         if (!inst)
         {
-            dumpIndent(context);
             dump(context, "<null>");
             return;
         }
@@ -3134,7 +3131,7 @@ namespace Slang
 
         case kIROp_WitnessTable:
         case kIROp_StructType:
-            dumpIRParentInst(context, (IRWitnessTable*)inst);
+            dumpIRParentInst(context, inst);
             return;
 
         case kIROp_WitnessTableEntry:
@@ -3146,8 +3143,6 @@ namespace Slang
         }
 
         // Okay, we have a seemingly "ordinary" op now
-        dumpIndent(context);
-
         auto opInfo = getIROpInfo(op);
         auto dataType = inst->getDataType();
         auto rate = inst->getRate();
@@ -3214,8 +3209,14 @@ namespace Slang
         }
 
         dump(context, ")");
+    }
 
-        dump(context, "\n");
+    static void dumpInst(
+        IRDumpContext*  context,
+        IRInst*         inst)
+    {
+        dumpIndent(context);
+        dumpInstBody(context, inst);
     }
 
     void dumpIRModule(
@@ -3225,6 +3226,7 @@ namespace Slang
         for(auto ii : module->getGlobalInsts())
         {
             dumpInst(context, ii);
+            dump(context, "\n");
         }
     }
 
@@ -3269,6 +3271,57 @@ namespace Slang
     //
     //
     //
+
+    IRDecoration* IRInst::getFirstDecoration()
+    {
+        return as<IRDecoration>(getFirstDecorationOrChild());
+    }
+
+    IRDecoration* IRInst::getLastDecoration()
+    {
+        IRDecoration* decoration = getFirstDecoration();
+        if (!decoration) return nullptr;
+
+        while (auto nextDecoration = decoration->getNextDecoration())
+            decoration = nextDecoration;
+
+        return decoration;
+    }
+
+    IRInstList<IRDecoration> IRInst::getDecorations()
+    {
+        return IRInstList<IRDecoration>(
+            getFirstDecoration(),
+            getLastDecoration());
+    }
+
+    IRInst* IRInst::getFirstChild()
+    {
+        // The children come after any decorations,
+        // so if there are any decorations, then the
+        // first child is right after the last decoration.
+        //
+        if(auto lastDecoration = getLastDecoration())
+            return lastDecoration->getNextInst();
+        //
+        // Otherwise, there must be no decorations, so
+        // that the first "child or decoration" is a child.
+        //
+        return getFirstDecorationOrChild();
+    }
+
+    IRInst* IRInst::getLastChild()
+    {
+        // The children come after any decorations, so
+        // that the last item in the list of children
+        // and decorations is the last child *unless*
+        // it is a decoration, in which case there are
+        // no children.
+        //
+        auto lastChild = getLastDecorationOrChild();
+        return as<IRDecoration>(lastChild) ? nullptr : lastChild;
+    }
+
 
     IRRate* IRInst::getRate()
     {
@@ -3358,13 +3411,13 @@ namespace Slang
     void IRInst::insertBefore(IRInst* other)
     {
         SLANG_ASSERT(other);
-        insertBefore(other, other->parent);
+        _insertAt(other->getPrevInst(), other, other->getParent());
     }
 
     void IRInst::insertAtStart(IRInst* newParent)
     {
         SLANG_ASSERT(newParent);
-        insertBefore(newParent->children.first, newParent);
+        _insertAt(nullptr, newParent->getFirstDecorationOrChild(), newParent);
     }
 
     void IRInst::moveToStart()
@@ -3374,52 +3427,49 @@ namespace Slang
         insertAtStart(p);
     }
 
-    void IRInst::insertBefore(IRInst* other, IRInst* newParent)
+    void IRInst::_insertAt(IRInst* inPrev, IRInst* inNext, IRInst* inParent)
     {
         // Make sure this instruction has been removed from any previous parent
         this->removeFromParent();
 
-        SLANG_ASSERT(other || newParent);
-        if (!other) other = newParent->children.first;
-        if (!newParent) newParent = other->parent;
-        SLANG_ASSERT(newParent);
+        SLANG_ASSERT(inParent);
+        SLANG_ASSERT(!inPrev || (inPrev->getNextInst() == inNext) && (inPrev->getParent() == inParent));
+        SLANG_ASSERT(!inNext || (inNext->getPrevInst() == inPrev) && (inNext->getParent() == inParent));
 
-        auto nn = other;
-        auto pp = other ? other->getPrevInst() : nullptr;
-
-        if( pp )
+        if( inPrev )
         {
-            pp->next = this;
+            inPrev->next = this;
         }
         else
         {
-            newParent->children.first = this;
+            inParent->m_decorationsAndChildren.first = this;
         }
 
-        if (nn)
+        if (inNext)
         {
-            nn->prev = this;
+            inNext->prev = this;
         }
         else
         {
-            newParent->children.last = this;
+            inParent->m_decorationsAndChildren.last = this;
         }
 
-        this->prev = pp;
-        this->next = nn;
-        this->parent = newParent;
+        this->prev = inPrev;
+        this->next = inNext;
+        this->parent = inParent;
     }
 
     void IRInst::insertAfter(IRInst* other)
     {
         SLANG_ASSERT(other);
-        insertAfter(other, other->parent);
+
+        _insertAt(other, other->getNextInst(), other->getParent());
     }
 
     void IRInst::insertAtEnd(IRInst* newParent)
     {
         SLANG_ASSERT(newParent);
-        insertAfter(newParent->children.last, newParent);
+        _insertAt(newParent->getLastDecorationOrChild(), nullptr, newParent);
     }
 
     void IRInst::moveToEnd()
@@ -3427,42 +3477,6 @@ namespace Slang
         auto p = parent;
         removeFromParent();
         insertAtEnd(p);
-    }
-
-    void IRInst::insertAfter(IRInst* other, IRInst* newParent)
-    {
-        // Make sure this instruction has been removed from any previous parent
-        this->removeFromParent();
-
-        SLANG_ASSERT(other || newParent);
-        if (!other) other = newParent->children.last;
-        if (!newParent) newParent = other->parent;
-        SLANG_ASSERT(newParent);
-
-        auto pp = other;
-        auto nn = other ? other->next : nullptr;
-
-        if (pp)
-        {
-            pp->next = this;
-        }
-        else
-        {
-            newParent->children.first = this;
-        }
-
-        if (nn)
-        {
-            nn->prev = this;
-        }
-        else
-        {
-            newParent->children.last = this;
-        }
-
-        this->prev = pp;
-        this->next = nn;
-        this->parent = newParent;
     }
 
     // Remove this instruction from its parent block,
@@ -3486,7 +3500,7 @@ namespace Slang
         }
         else
         {
-            oldParent->children.first = nn;
+            oldParent->m_decorationsAndChildren.first = nn;
         }
 
         if(nn)
@@ -3496,7 +3510,7 @@ namespace Slang
         }
         else
         {
-            oldParent->children.last = pp;
+            oldParent->m_decorationsAndChildren.last = pp;
         }
 
         prev = nullptr;
@@ -3520,16 +3534,16 @@ namespace Slang
     {
         removeFromParent();
         removeArguments();
-        removeAndDeallocateAllChildren();
+        removeAndDeallocateAllDecorationsAndChildren();
 
         // Run destructor to be sure...
         this->~IRInst();
     }
 
-    void IRInst::removeAndDeallocateAllChildren()
+    void IRInst::removeAndDeallocateAllDecorationsAndChildren()
     {
         IRInst* nextChild = nullptr;
-        for( IRInst* child = getFirstChild(); child; child = nextChild )
+        for( IRInst* child = getFirstDecorationOrChild(); child; child = nextChild )
         {
             nextChild = child->getNextInst();
             child->removeAndDeallocate();
@@ -4159,8 +4173,7 @@ namespace Slang
 
             if(auto outerArrayName = systemValueInfo->outerArrayName)
             {
-                auto decoration = builder->addDecoration<IRGLSLOuterArrayDecoration>(globalVariable);
-                decoration->outerArrayName = outerArrayName;
+                builder->addGLSLOuterArrayDecoration(globalVariable, UnownedTerminatedStringSlice(outerArrayName));
             }
         }
 
@@ -4695,13 +4708,13 @@ namespace Slang
         IRInst*        val,
         String const&   targetName)
     {
-        for( auto dd = val->firstDecoration; dd; dd = dd->next )
+        for(auto dd : val->getDecorations())
         {
-            if(dd->op != kIRDecorationOp_TargetIntrinsic)
+            if(dd->op != kIROp_TargetIntrinsicDecoration)
                 continue;
 
             auto decoration = (IRTargetIntrinsicDecoration*) dd;
-            if(String(decoration->targetName) == targetName)
+            if(String(decoration->getTargetName()) == targetName)
                 return decoration;
         }
 
@@ -4870,7 +4883,7 @@ namespace Slang
                         if(!decoration)
                             continue;
 
-                        if(StringRepresentation::asSlice(decoration->definition) != UnownedStringSlice::fromLiteral("EmitVertex()"))
+                        if(decoration->getDefinition() != UnownedStringSlice::fromLiteral("EmitVertex()"))
                         {
                             continue;
                         }
@@ -5346,117 +5359,40 @@ namespace Slang
         }
     }
 
+    IRInst* cloneInst(
+        IRSpecContextBase*              context,
+        IRBuilder*                      builder,
+        IRInst*                         originalInst,
+        IROriginalValuesForClone const& originalValues);
+
+    IRInst* cloneInst(
+        IRSpecContextBase*  context,
+        IRBuilder*          builder,
+        IRInst*             originalInst)
+    {
+        return cloneInst(context, builder, originalInst, originalInst);
+    }
+
+        /// Clone any decorations from `originalValue` onto `clonedValue`
     void cloneDecorations(
         IRSpecContextBase*  context,
-        IRInst*        clonedValue,
-        IRInst*        originalValue)
+        IRInst*             clonedValue,
+        IRInst*             originalValue)
     {
-        for (auto dd = originalValue->firstDecoration; dd; dd = dd->next)
+        // TODO: In many cases we might be able to use this as a general-purpose
+        // place to do cloning of *all* the children of an instruction, and
+        // not just its decorations. We should look to refactor this code
+        // later.
+
+        IRBuilder builderStorage = *context->builder;
+        IRBuilder* builder = &builderStorage;
+        builder->setInsertInto(clonedValue);
+
+
+        SLANG_UNUSED(context);
+        for(auto originalDecoration : originalValue->getDecorations())
         {
-            switch (dd->op)
-            {
-            case kIRDecorationOp_HighLevelDecl:
-                {
-                    auto originalDecoration = (IRHighLevelDeclDecoration*)dd;
-
-                    context->builder->addHighLevelDeclDecoration(clonedValue, originalDecoration->decl);
-                }
-                break;
-
-            case kIRDecorationOp_LoopControl:
-                {
-                    auto originalDecoration = (IRLoopControlDecoration*)dd;
-                    auto newDecoration = context->builder->addDecoration<IRLoopControlDecoration>(clonedValue);
-                    newDecoration->mode = originalDecoration->mode;
-                }
-                break;
-
-            case kIRDecorationOp_TargetIntrinsic:
-                {
-                    auto originalDecoration = (IRTargetIntrinsicDecoration*)dd;
-                    auto newDecoration = context->builder->addDecoration<IRTargetIntrinsicDecoration>(clonedValue);
-                    newDecoration->targetName = originalDecoration->targetName;
-                    newDecoration->definition = originalDecoration->definition;
-                }
-                break;
-
-            case kIRDecorationOp_Semantic:
-                {
-                    auto originalDecoration = (IRSemanticDecoration*)dd;
-                    auto newDecoration = context->builder->addDecoration<IRSemanticDecoration>(clonedValue);
-                    newDecoration->semanticName = originalDecoration->semanticName;
-                }
-                break;
-
-            case kIRDecorationOp_InterpolationMode:
-                {
-                    auto originalDecoration = (IRInterpolationModeDecoration*)dd;
-                    auto newDecoration = context->builder->addDecoration<IRInterpolationModeDecoration>(clonedValue);
-                    newDecoration->mode = originalDecoration->mode;
-                }
-                break;
-
-            case kIRDecorationOp_NameHint:
-                {
-                    auto originalDecoration = (IRNameHintDecoration*)dd;
-                    auto newDecoration = context->builder->addDecoration<IRNameHintDecoration>(clonedValue);
-                    newDecoration->name = originalDecoration->name;
-                }
-                break;
-
-            case kIRDecorationOp_VulkanRayPayload:
-                {
-                    context->builder->addDecoration<IRVulkanRayPayloadDecoration>(clonedValue);
-                }
-                break;
-
-            case kIRDecorationOp_VulkanCallablePayload:
-                {
-                    context->builder->addDecoration<IRVulkanCallablePayloadDecoration>(clonedValue);
-                }
-                break;
-            case kIRDecorationOp_EarlyDepthStencil:
-                {
-                    context->builder->addDecoration<IREarlyDepthStencilDecoration>(clonedValue);
-                }
-                break;
-            case kIRDecorationOp_GloballyCoherent:
-                {
-                    context->builder->addDecoration<IRGloballyCoherentDecoration>(clonedValue);
-                }
-                break;
-            case kIRDecorationOp_VulkanHitAttributes:
-                {
-                    context->builder->addDecoration<IRVulkanHitAttributesDecoration>(clonedValue);
-                }
-                break;
-
-            case kIRDecorationOp_RequireGLSLExtension:
-                {
-                    auto originalDecoration = (IRRequireGLSLExtensionDecoration*)dd;
-                    auto newDecoration = context->builder->addDecoration<IRRequireGLSLExtensionDecoration>(clonedValue);
-                    newDecoration->extensionName = originalDecoration->extensionName;
-                }
-                break;
-
-            case kIRDecorationOp_RequireGLSLVersion:
-                {
-                    auto originalDecoration = (IRRequireGLSLVersionDecoration*)dd;
-                    auto newDecoration = context->builder->addDecoration<IRRequireGLSLVersionDecoration>(clonedValue);
-                    newDecoration->languageVersion = originalDecoration->languageVersion;
-                }
-                break;
-
-            case kIRDecorationOp_ReadNone:
-                {
-                    context->builder->addDecoration<IRReadNoneDecoration>(clonedValue);
-                }
-                break;
-
-            default:
-                // Don't clone any decorations we don't understand.
-                break;
-            }
+            cloneInst(context, builder, originalDecoration);
         }
 
         // We will also clone the location here, just because this is a convenient bottleneck
@@ -5513,6 +5449,20 @@ namespace Slang
             {
                 IRConstant* c = (IRConstant*)originalValue;
                 return builder->getFloatValue(cloneType(this, c->getDataType()), c->value.floatVal);
+            }
+            break;
+
+        case kIROp_StringLit:
+            {
+                IRConstant* c = (IRConstant*)originalValue;
+                return builder->getStringValue(c->getStringSlice());
+            }
+            break;
+
+        case kIROp_PtrLit:
+            {
+                IRConstant* c = (IRConstant*)originalValue;
+                return builder->getPtrValue(c->value.ptrVal);
             }
             break;
 
@@ -5602,20 +5552,6 @@ namespace Slang
         return cloneValue(context, originalValue);
     }
 
-    IRInst* cloneInst(
-        IRSpecContextBase*              context,
-        IRBuilder*                      builder,
-        IRInst*                         originalInst,
-        IROriginalValuesForClone const& originalValues);
-
-    IRInst* cloneInst(
-        IRSpecContextBase*  context,
-        IRBuilder*          builder,
-        IRInst*             originalInst)
-    {
-        return cloneInst(context, builder, originalInst, originalInst);
-    }
-
     void cloneGlobalValueWithCodeCommon(
         IRSpecContextBase*      context,
         IRGlobalValueWithCode*  clonedValue,
@@ -5658,8 +5594,6 @@ namespace Slang
         auto mangledName = originalVar->mangledName;
         clonedVar->mangledName = mangledName;
 
-        cloneDecorations(context, clonedVar, originalVar);
-
         VarLayout* layout = nullptr;
         if (context->globalVarLayouts.TryGetValue(mangledName, layout))
         {
@@ -5689,8 +5623,6 @@ namespace Slang
         auto mangledName = originalVal->mangledName;
         clonedVal->mangledName = mangledName;
 
-        cloneDecorations(context, clonedVal, originalVal);
-
         // Clone any code in the body of the constant, since this
         // represents the initializer.
         cloneGlobalValueWithCodeCommon(
@@ -5712,8 +5644,6 @@ namespace Slang
 
         auto mangledName = originalVal->mangledName;
         clonedVal->mangledName = mangledName;
-
-        cloneDecorations(context, clonedVal, originalVal);
 
         // Clone any code in the body of the generic, since this
         // computes its result value.
@@ -5738,15 +5668,13 @@ namespace Slang
         auto mangledName = originalInst->mangledName;
         clonedInst->mangledName = mangledName;
 
-        cloneDecorations(context, clonedInst, originalInst);
-
         // Set up an IR builder for inserting into the inst
         IRBuilder builderStorage = *context->builder;
         IRBuilder* builder = &builderStorage;
         builder->setInsertInto(clonedInst);
 
         // Clone any children of the instruction
-        for (auto child : originalInst->getChildren())
+        for (auto child : originalInst->getDecorationsAndChildren())
         {
             cloneInst(context, builder, child);
         }
@@ -5818,6 +5746,7 @@ namespace Slang
         IRBuilder* builder = &builderStorage;
         builder->setInsertInto(clonedValue);
 
+        cloneDecorations(context, clonedValue, originalValue);
 
         // We will walk through the blocks of the function, and clone each of them.
         //
@@ -5873,7 +5802,7 @@ namespace Slang
     void checkIRDuplicate(IRInst* inst, IRInst* moduleInst, Name* mangledName)
     {
 #ifdef _DEBUG
-        for (auto child : moduleInst->getChildren())
+        for (auto child : moduleInst->getDecorationsAndChildren())
         {
             if (child == inst)
                 continue;
@@ -5903,8 +5832,6 @@ namespace Slang
         // First clone all the simple properties.
         clonedFunc->mangledName = originalFunc->mangledName;
         clonedFunc->setFullType(cloneType(context, originalFunc->getFullType()));
-
-        cloneDecorations(context, clonedFunc, originalFunc);
 
         cloneGlobalValueWithCodeCommon(
             context,
@@ -6058,13 +5985,13 @@ namespace Slang
         }
 
         TargetSpecializationLevel result = TargetSpecializationLevel::notSpecialized;
-        for( auto dd = val->firstDecoration; dd; dd = dd->next )
+        for(auto dd : val->getDecorations())
         {
-            if(dd->op != kIRDecorationOp_Target)
+            if(dd->op != kIROp_TargetDecoration)
                 continue;
 
             auto decoration = (IRTargetDecoration*) dd;
-            if(String(decoration->targetName) == targetName)
+            if(String(decoration->getTargetName()) == targetName)
                 return TargetSpecializationLevel::specializedForTarget;
 
             result = TargetSpecializationLevel::specializedForOtherTarget;
@@ -6712,7 +6639,7 @@ namespace Slang
         }
         else
         {
-            for(auto child : inst->children)
+            for(auto child : inst->getChildren())
             {
                 addToSpecializationWorkListRec(sharedContext, child);
             }
@@ -6807,12 +6734,9 @@ namespace Slang
             // We expect a generic to only ever contain a single block.
             SLANG_ASSERT(bb == genericVal->getFirstBlock());
 
-            for (auto ii : bb->getChildren())
+            // Iterate over the non-parameter ("ordinary") instructions.
+            for (auto ii : bb->getOrdinaryInsts())
             {
-                // Skip parameters, since they were handled earlier.
-                if (auto param = as<IRParam>(ii))
-                    continue;
-
                 // The last block of the generic is expected to end with
                 // a `return` instruction for the specialized value that
                 // comes out of the abstraction.

--- a/source/slang/ir.h
+++ b/source/slang/ir.h
@@ -215,7 +215,7 @@ struct IRInstList : IRInstListBase
     };
 
     Iterator begin() { return Iterator(first); }
-    Iterator end() { return Iterator(last ? last->next : nullptr); }
+    Iterator end();
 };
 
 
@@ -422,6 +422,15 @@ T* cast(IRInst* inst, T* /* */ = nullptr)
 {
     SLANG_ASSERT(!inst || as<T>(inst));
     return (T*)inst;
+}
+
+// Now that `IRInst` is defined we can back-fill the `IRInstList<T>` members
+// that need to access it.
+
+template<typename T>
+typename IRInstList<T>::Iterator IRInstList<T>::end()
+{
+    return Iterator(last ? last->next : nullptr);
 }
 
 

--- a/source/slang/legalize-types.cpp
+++ b/source/slang/legalize-types.cpp
@@ -355,7 +355,7 @@ struct TupleTypeBuilder
 
             if(auto nameHintDecoration = originalStructType->findDecoration<IRNameHintDecoration>())
             {
-                builder->addDecoration<IRNameHintDecoration>(ordinaryStructType)->name = nameHintDecoration->name;
+                builder->addNameHintDecoration(ordinaryStructType, nameHintDecoration->getNameOperand());
             }
 
             // The new struct type will appear right after the original in the IR,

--- a/source/slang/slang.natvis
+++ b/source/slang/slang.natvis
@@ -93,10 +93,10 @@
         </Expand>
       </Synthetic>
       <Item Name="[parent]">parent</Item>
-      <Synthetic Name="[children]" Condition="(op &gt;= Slang::kIROp_FirstParentInst) &amp;&amp; (op &lt;= Slang::kIROp_LastParentInst)">
+      <Synthetic Name="[children]">
         <Expand>
           <LinkedListItems>
-            <HeadPointer>(*((Slang::IRParentInst*) this)).children.first</HeadPointer>
+            <HeadPointer>children.first</HeadPointer>
             <NextPointer>next</NextPointer>
             <ValueNode>this</ValueNode>
           </LinkedListItems>
@@ -112,32 +112,6 @@
         </Expand>
       </Synthetic>
   </Expand>
-  </Type>
-  <Type Name="Slang::IRParentInst">
-    <DisplayString>{{{op}}}</DisplayString>
-    <Expand>
-      <Item Name="[op]">op</Item>
-      <Item Name="[type]">typeUse.usedValue</Item>
-      <Synthetic Name="[children]">
-        <Expand>
-          <LinkedListItems>
-            <HeadPointer>children.first</HeadPointer>
-            <NextPointer>next</NextPointer>
-            <ValueNode>this</ValueNode>
-          </LinkedListItems>
-        </Expand>
-      </Synthetic>
-      <Item Name="[parent]">parent</Item>
-      <Synthetic Name="[uses]">
-        <Expand>
-          <LinkedListItems>
-            <HeadPointer>firstUse</HeadPointer>
-            <NextPointer>nextUse</NextPointer>
-            <ValueNode>user</ValueNode>
-          </LinkedListItems>
-        </Expand>
-      </Synthetic>
-    </Expand>
   </Type>
   <Type Name="Slang::IRGlobalValue">
     <DisplayString>{{{op} "{mangledName}"}}</DisplayString>

--- a/tests/compute/mutating-methods.slang
+++ b/tests/compute/mutating-methods.slang
@@ -1,7 +1,7 @@
 // mutating-methods.slang
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -xslang -serial-ir
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -xslang -serial-ir
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -xslang -serial-ir
 
 interface IAccumulator
 {

--- a/tests/ir/string-literal.slang.expected
+++ b/tests/ir/string-literal.slang.expected
@@ -1,19 +1,26 @@
 result code = 0
 standard error = {
-let  %1	: _	= UInt()
-let  %2	: _	= Void()
-let  %3	: _	= Func(%2, %1)
-let  %4	: _	= BasicBlock()
-Ptr(%1)
-let  %5	: _	= String()
-let  %6	: %5	= string_constant("Hello \t\n\0x083 World")
-
-func @_S04mainp1puV	: %3
+let  %1	: _	= String()
+let  %2	: %1	= string_constant("main")
+let  %3	: _	= Void()
+let  %4	: _	= UInt()
+let  %5	: _	= Func(%3, %4)
+let  %6	: _	= BasicBlock()
+let  %7	: _	= Ptr(%3)
+let  %8	: %7	= ptr_constant()
+let  %9	: %1	= string_constant("tid")
+Ptr(%4)
+let  %10	: %1	= string_constant("Hello \t\n\0x083 World")
+let  %11	: %7	= ptr_constant()
+[highLevelDecl(%11)]
+[nameHint("main")]
+func @_S04mainp1puV	: %5
 {
-block %7(
-		param %8	: %1):
+block %12(
+		param %13	: %4):
 	return_void()
 }
+
 
 }
 standard output = {


### PR DESCRIPTION
I tried to keep this as distinct commits to make the diffs easier, but the third one ended up being pretty big anyway. The commit message there explains most of what is going on, but the high order bit is that `IRDecoration` now inherits from `IRInst`, and an `IRInst` holds a single list of both decorations and children.