### PR TITLE
Represent global shader parameters explicitly in the IR

### DIFF
--- a/source/slang/check.h
+++ b/source/slang/check.h
@@ -1,0 +1,7 @@
+// check.h
+#pragma once
+
+namespace Slang
+{
+    bool isGlobalShaderParameter(VarDeclBase* decl);
+}

--- a/source/slang/ir-inst-defs.h
+++ b/source/slang/ir-inst-defs.h
@@ -163,6 +163,8 @@ INST_RANGE(Type, VoidType, StructType)
     INST(GlobalConstant, global_constant, 0, 0)
 INST_RANGE(GlobalValueWithCode, Func, GlobalConstant)
 
+INST(GlobalParam, global_param, 0, 0)
+
 INST(StructKey, key, 0, 0)
 INST(GlobalGenericParam, global_generic_param, 0, 0)
 INST(WitnessTable, witness_table, 0, 0)

--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -558,6 +558,12 @@ struct IRGlobalConstant : IRGlobalValueWithCode
     IR_LEAF_ISA(GlobalConstant)
 };
 
+struct IRGlobalParam : IRInst
+{
+    IR_LEAF_ISA(GlobalParam)
+};
+
+
 // An entry in a witness table (see below)
 struct IRWitnessTableEntry : IRInst
 {
@@ -797,6 +803,8 @@ struct IRBuilder
     IRGlobalVar* createGlobalVar(
         IRType* valueType);
     IRGlobalConstant* createGlobalConstant(
+        IRType* valueType);
+    IRGlobalParam* createGlobalParam(
         IRType* valueType);
     IRWitnessTable* createWitnessTable();
     IRWitnessTableEntry* createWitnessTableEntry(

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -171,6 +171,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\..\slang.h" />
+    <ClInclude Include="check.h" />
     <ClInclude Include="compiler.h" />
     <ClInclude Include="core.meta.slang.h" />
     <ClInclude Include="decl-defs.h" />

--- a/source/slang/slang.vcxproj.filters
+++ b/source/slang/slang.vcxproj.filters
@@ -162,6 +162,9 @@
     <ClInclude Include="visitor.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="check.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="check.cpp">

--- a/tests/bindings/array-of-struct-of-resource.hlsl
+++ b/tests/bindings/array-of-struct-of-resource.hlsl
@@ -4,7 +4,7 @@
 // HLSL compiler would already do in the simple case (when
 // all shader parameters are actually used).
 
-float4 use(Texture2D t, SamplerState s) { return t.Sample(s, 0.0); }
+float4 use(Texture2D t, SamplerState samp) { return t.Sample(samp, 0.0); }
 
 #ifdef __SLANG__
 

--- a/tests/bindings/binding0.hlsl
+++ b/tests/bindings/binding0.hlsl
@@ -24,7 +24,7 @@
 #endif
 
 float4 use(float4 val) { return val; };
-float4 use(Texture2D t, SamplerState s) { return t.Sample(s, 0.0); }
+float4 use(Texture2D tex, SamplerState samp) { return tex.Sample(samp, 0.0); }
 
 Texture2D 		t R(: register(t0));
 SamplerState 	s R(: register(s0));

--- a/tests/cross-compile/non-uniform-indexing.slang.glsl
+++ b/tests/cross-compile/non-uniform-indexing.slang.glsl
@@ -17,12 +17,10 @@ in vec3 _S2;
 
 void main()
 {
-    vec3 _S3 = _S2;
+    int _S3 = nonuniformEXT(int(_S2.z));
 
-    int _S4 = nonuniformEXT(int(_S3.z));
+    vec4 _S4 = texture(sampler2D(t_0[_S3],s_0), _S2.xy);
 
-    vec4 _S5 = texture(sampler2D(t_0[_S4],s_0), _S3.xy);
-
-    _S1 = _S5;
+    _S1 = _S4;
     return;
 }

--- a/tests/vkray/anyhit.slang.glsl
+++ b/tests/vkray/anyhit.slang.glsl
@@ -33,13 +33,11 @@ rayPayloadInNV ShadowRay_0 _S3;
 
 void main()
 {
-    SphereHitAttributes_0 _S4 = _S2;
-
     if(bool(gParams_0._data.mode_0))
     {
         float val_0 = textureLod(
             sampler2D(gParams_alphaMap_0, gParams_sampler_0),
-            _S4.normal_0.xy,
+            _S2.normal_0.xy,
             float(0)).x;
 
 

--- a/tests/vkray/closesthit.slang.glsl
+++ b/tests/vkray/closesthit.slang.glsl
@@ -6,15 +6,14 @@
 #define tmp_colors          _S2
 #define tmp_hitattrs        _S3
 #define tmp_payload         _S4
-#define tmp_localattrs      _S5
-#define tmp_customidx       _S6
-#define tmp_instanceid      _S7
-#define tmp_add_0           _S8
-#define tmp_primid          _S9
-#define tmp_add_1           _S10
-#define tmp_hitkind         _S11
-#define tmp_hitt            _S12
-#define tmp_tmin            _S13
+#define tmp_customidx       _S5
+#define tmp_instanceid      _S6
+#define tmp_add_0           _S7
+#define tmp_primid          _S8
+#define tmp_add_1           _S9
+#define tmp_hitkind         _S10
+#define tmp_hitt            _S11
+#define tmp_tmin            _S12
 
 struct SLANG_ParameterGroup_ShaderRecord_0
 {
@@ -49,8 +48,6 @@ rayPayloadInNV ReflectionRay_0 tmp_payload;
 
 void main()
 {
-    BuiltInTriangleIntersectionAttributes_0 tmp_localattrs = tmp_hitattrs;
-
     uint tmp_customidx = gl_InstanceCustomIndexNV;
     uint tmp_instanceid = gl_InstanceID;
 


### PR DESCRIPTION
Before this change, global shader parameters were represented in the IR as just being ordinary global variables.
The only indication that a particular global represented a parameter was when it got a layotu attached to it (as part of back-end processing), and we've had a number of bugs related to layouts being dropped so that what should have been a shader parameter turned into an ordinary global variable in the output.

This change is more strongly motivated by the fact that making shader parameters look like globals means that we cannot easily reason about their value when doing IR transformations.
If we see two `load`s from the same global variable can we assume they yield the same value?
In the general case we cannot, and this means that any transformation that wants to rely on the fact that an input `Texture2D` shader parameter can't actually change over the life of the program needs to do extra work.

The fix here is to introduce a new kind of IR instruction that represents a global shader parameter directly (not a pointer to it as a global would), at which point there isn't even such a notion as a "load" from the parameter, since it represents the value directly.

In several cases logic that used to apply to global variables in case they were shader parameters (by looking for a layout) is now moved to apply to these global parameters.

The biggest source of issues in this change was that switching from pointers to plain values to represent these shader parameters stresses different cases in type legalization. I also had to deal with the case of legalization for GLSL where we actually *do* need global shader parameters that are writable (since varying output goes in the global scope), but in that case I borrowed the use of pointer-like `Out<...>` and `InOut<...>` types to represent that intent, which we were already using for function parameters representing outputs.

A few tests started failing because the changes lead to a slightly different order of code emission, which in some HLSL tests resulted in a function parameter named `s` getting emitted before a global parameter named `s`, leading to the latter getting the name `s_1` instead of `s_0`.

A few SPIR-V tests started failing because the new approach means that we no longer end up performing a load from all varying input parameters at the start of `main` and instead reference the varying inputs directly. The resulting code is more idomatic, but it differed from the baselines for those tests.