### PR TITLE
Fix up declaration checking order for enums

### DIFF
--- a/tests/bugs/enum-init-cast.slang
+++ b/tests/bugs/enum-init-cast.slang
@@ -1,0 +1,15 @@
+// enum-init-cast.slang
+//TEST:SIMPLE:
+
+// Regression test for a bug around declaration checking order
+// for `enum` types, which manifests when an `enum` case
+// has an initializer that requires an implicit cast.
+
+enum class AAA
+{
+	// These cases use a `uint` literal for initialization,
+	// but the `enum` type will use `int` for its tags.
+
+    BBB 	= 0u,
+    CCC  	= 1u,
+};


### PR DESCRIPTION
The logic in `check.cpp` for declaration checking is very messy and needs to be re-written, but in the interim we need to be careful to avoid any cases where a declaration, or some piece of it, gets redundantly checked multiple times.

The way the logic had been working, the different "cases" in an `enum` type were being checked twice, and that meant that any initialization expression for a case would be type-checked the first time (potentially leading to a new AST) and then the checked AST would be checked again. This created a problem if the first round of checking introduced any AST nodes that the checking logic would not expect to see (because the parser cannot possibly produce them).

The fix here is to follow the style of the other declaration checking cases, where checking is separated into two distinct phases (the "header" phase makes the declaration usable by others, while the "body" phase checks its implementation details for internal consistency).

This change includes a test case that produced an internal compiler error before, and compiles without error now.