### PR TITLE
Fix diagnostic output for command-line slangc

### DIFF
--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -39,9 +39,6 @@ SLANG_TEST_TOOL_API SlangResult innerMain(StdWriters* stdWriters, SlangSession* 
 
     spSetCommandLineCompilerMode(compileRequest);
 
-    // Do any app specific configuration
-    stdWriters->setRequestWriters(compileRequest);
-
     char const* appName = "slangc";
     if (argc > 0) appName = argv[0];
 


### PR DESCRIPTION
Somehow the work to support output redirection when running things in `slang-test` ended up interfering with the API-specified diagnostic callback in the `slangc` code.

This change doesn't include fixes to the testing infrastructure to prevent a regression like this happening again.