### PR TITLE
Delete what appears to be stray code in options validation

### DIFF
--- a/source/slang/options.cpp
+++ b/source/slang/options.cpp
@@ -1101,8 +1101,6 @@ struct OptionsParser
 
         for(auto& rawTarget : rawTargets)
         {
-            if(rawTarget.redundantProfileSet )
-
             if( rawTarget.conflictingProfilesSet )
             {
                 sink->diagnose(SourceLoc(), Diagnostics::conflictingProfilesSpecifiedForTarget, rawTarget.format);


### PR DESCRIPTION
The code for options validation had something like:

```c++
{
    if(rawTarget.redundantProfileSet)

    if(rawTarget.conflictingProfileSet)
    { ... }
    else if(rawTarget.redundantProfileSet)
    { ... }
}
```

The first `if` there seems to be stray code left over from some edit to this logic, since its case is handled later on.