### PR TITLE
Feature/hash for source identity

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -798,7 +798,7 @@ extern "C"
             const char* path,
             ISlangBlob** canonicalPathOut) = 0;
 
-        /** Get a path relative to a 'from' path.
+        /** Calculate a path combining the 'fromPath' with 'path'
 
         The client must ensure the blob be released when no longer used, otherwise memory will leak.
 
@@ -808,7 +808,7 @@ extern "C"
         @param pathOut Holds the string which is the relative path. The string is held in the blob zero terminated.  
         @returns A `SlangResult` to indicate success or failure in loading the file.
         */
-        virtual SLANG_NO_THROW SlangResult SLANG_MCALL calcRelativePath(
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL calcCombinedPath(
             SlangPathType fromPathType,
             const char* fromPath,
             const char* path,

--- a/source/core/hash.h
+++ b/source/core/hash.h
@@ -43,7 +43,18 @@ namespace Slang
         }
         return hash;
     }
-    
+
+    inline uint64_t GetHashCode64(const char * buffer, size_t numChars)
+    {
+        // Use uints because hash requires wrap around behavior and int is undefined on over/underflows
+        uint64_t hash = 0;
+        for (size_t i = 0; i < numChars; ++i)
+        {
+            hash = uint64_t(int64_t(buffer[i])) + (hash << 6) + (hash << 16) - hash;
+        }
+        return hash;
+    }
+
 	template<int IsInt>
 	class Hash
 	{

--- a/source/slang/slang-file-system.cpp
+++ b/source/slang/slang-file-system.cpp
@@ -14,8 +14,8 @@ static const Guid IID_ISlangUnknown = SLANG_UUID_ISlangUnknown;
 static const Guid IID_ISlangFileSystem = SLANG_UUID_ISlangFileSystem;
 static const Guid IID_ISlangFileSystemExt = SLANG_UUID_ISlangFileSystemExt;
 
-// Cacluate a relative path, just using Path:: string processing
-static SlangResult _calcRelativePath(SlangPathType fromPathType, const char* fromPath, const char* path, ISlangBlob** pathOut)
+// Cacluate a combined path, just using Path:: string processing
+static SlangResult _calcCombinedPath(SlangPathType fromPathType, const char* fromPath, const char* path, ISlangBlob** pathOut)
 {
     String relPath;
     switch (fromPathType)
@@ -60,9 +60,9 @@ SlangResult DefaultFileSystem::getCanoncialPath(const char* path, ISlangBlob** c
     return SLANG_OK;
 }
 
-SlangResult DefaultFileSystem::calcRelativePath(SlangPathType fromPathType, const char* fromPath, const char* path, ISlangBlob** pathOut)
+SlangResult DefaultFileSystem::calcCombinedPath(SlangPathType fromPathType, const char* fromPath, const char* path, ISlangBlob** pathOut)
 {
-    return _calcRelativePath(fromPathType, fromPath, path, pathOut);
+    return _calcCombinedPath(fromPathType, fromPath, path, pathOut);
 }
 
 SlangResult SLANG_MCALL DefaultFileSystem::getPathType(
@@ -224,17 +224,17 @@ SlangResult CacheFileSystem::getCanoncialPath(const char* path, ISlangBlob** can
     return SLANG_OK;
 }
 
-SlangResult CacheFileSystem::calcRelativePath(SlangPathType fromPathType, const char* fromPath, const char* path, ISlangBlob** pathOut)
+SlangResult CacheFileSystem::calcCombinedPath(SlangPathType fromPathType, const char* fromPath, const char* path, ISlangBlob** pathOut)
 {
     // Just defer to contained implementation
     if (m_fileSystemExt)
     {
-        return m_fileSystemExt->calcRelativePath(fromPathType, fromPath, path, pathOut);
+        return m_fileSystemExt->calcCombinedPath(fromPathType, fromPath, path, pathOut);
     }
     else
     {
         // Just use the default implementation
-        return _calcRelativePath(fromPathType, fromPath, path, pathOut);
+        return _calcCombinedPath(fromPathType, fromPath, path, pathOut);
     }
 }
 

--- a/source/slang/slang-file-system.cpp
+++ b/source/slang/slang-file-system.cpp
@@ -127,12 +127,25 @@ ISlangUnknown* CacheFileSystem::getInterface(const Guid& guid)
     return _getInterface(this, guid);
 }
 
-CacheFileSystem::CacheFileSystem(ISlangFileSystem* fileSystem, bool useSimplifyForCanonicalPath) :
+CacheFileSystem::CacheFileSystem(ISlangFileSystem* fileSystem, CanonicalMode canonicalMode) :
     m_fileSystem(fileSystem),
-    m_useSimplifyForCanonicalPath(useSimplifyForCanonicalPath)
+    m_canonicalMode(canonicalMode)
 {
     // Try to get the more sophisticated interface
     fileSystem->queryInterface(IID_ISlangFileSystemExt, (void**)m_fileSystemExt.writeRef());
+
+    switch (canonicalMode)
+    {
+        case CanonicalMode::Default:
+        case CanonicalMode::FileSystemExt:
+        {
+            m_canonicalMode = m_fileSystemExt ? CanonicalMode::FileSystemExt : CanonicalMode::Hash;
+            break;
+        }
+        default: break;
+    }
+    // It can't be default
+    SLANG_ASSERT(m_canonicalMode != CanonicalMode::Default);
 }
 
 CacheFileSystem::~CacheFileSystem()
@@ -140,6 +153,23 @@ CacheFileSystem::~CacheFileSystem()
     for (const auto& pair : m_canonicalMap)
     {
         delete pair.Value;
+    }
+}
+
+CacheFileSystem::PathInfo* CacheFileSystem::_getPathInfoFromCanonical(const String& canonicalPath)
+{
+    // First see if we have it.. if not add it
+    PathInfo** infoPtr = m_canonicalMap.TryGetValue(canonicalPath);
+    if (infoPtr)
+    {
+        return *infoPtr;
+    }
+    else
+    {
+        // Create and add to canonical path
+        PathInfo* pathInfo  = new PathInfo(canonicalPath);
+        m_canonicalMap.Add(canonicalPath, pathInfo);
+        return pathInfo;
     }
 }
 
@@ -151,37 +181,70 @@ CacheFileSystem::PathInfo* CacheFileSystem::_getPathInfo(const String& relPath)
         return *infoPtr;
     }
 
-    String canonicalPath;
-    if (m_fileSystemExt)
+    PathInfo* pathInfo = nullptr;
+    switch (m_canonicalMode)
     {
-        // Try getting the canonical path
-        // Okay request from the underlying file system the canonical path
-        ComPtr<ISlangBlob> canonicalBlob;
-        if (SLANG_FAILED(m_fileSystemExt->getCanoncialPath(relPath.Buffer(), canonicalBlob.writeRef())))
+        case CanonicalMode::FileSystemExt:
         {
-            // Write in result as being null ptr so not tried again
-            m_pathMap.Add(relPath, nullptr);
-            return nullptr;
+            // Try getting the canonical path
+            // Okay request from the underlying file system the canonical path
+            ComPtr<ISlangBlob> canonicalBlob;
+            if (SLANG_FAILED(m_fileSystemExt->getCanoncialPath(relPath.Buffer(), canonicalBlob.writeRef())))
+            {
+                // Write in result as being null ptr so not tried again
+                m_pathMap.Add(relPath, nullptr);
+                return nullptr;
+            }
+            // Get the path as a string
+            String canonicalPath = StringUtil::getString(canonicalBlob);
+            pathInfo = _getPathInfoFromCanonical(canonicalPath);
+            break;
         }
-        // Get the path as a string
-        canonicalPath = StringUtil::getString(canonicalBlob);
-    }
-    else
-    {
-        canonicalPath = m_useSimplifyForCanonicalPath ? Path::Simplify(relPath.getUnownedSlice()) : relPath;
-    }
+        case CanonicalMode::Path:
+        {
+            pathInfo = _getPathInfoFromCanonical(relPath);
+            break;
+        }
+        case CanonicalMode::SimplifiedPath:
+        {
+            pathInfo = _getPathInfoFromCanonical(Path::Simplify(relPath.getUnownedSlice()));
+            break;
+        }
+        case CanonicalMode::Hash:
+        {
+            // I can only see if this is the same file as already loaded by loading the file and doing a hash
+            ComPtr<ISlangBlob> fileBlob;
+            Result res = m_fileSystem->loadFile(relPath.Buffer(), fileBlob.writeRef());
+            if (SLANG_FAILED(res) || fileBlob == nullptr)
+            {
+                // Write in result as being null ptr so not tried again
+                m_pathMap.Add(relPath, nullptr);
+                return nullptr;
+            }
 
-    PathInfo* pathInfo;
-    infoPtr = m_canonicalMap.TryGetValue(canonicalPath);
-    if (infoPtr)
-    {
-        pathInfo = *infoPtr;
-    }
-    else
-    {
-        // Create and add to canonical path
-        pathInfo = new PathInfo(canonicalPath);
-        m_canonicalMap.Add(canonicalPath, pathInfo);
+            // Calculate the hash on the contents
+            const uint64_t hash = GetHashCode64((const char*)fileBlob->getBufferPointer(), fileBlob->getBufferSize());
+
+            String hashString = Path::GetFileName(relPath);
+            hashString = hashString.ToLower();
+
+            hashString.append(':');
+
+            // The canonical name is.. combination of name and hash
+            hashString.append(hash, 16);
+            // We'll use the 'hashString' as the canonical path
+            pathInfo = _getPathInfoFromCanonical(hashString);
+
+            // We have the contents, so store it on the PathInfo, along with the result
+            if (pathInfo->m_loadFileResult == CompressedResult::Uninitialized)
+            {
+                // Save the contents of the saved file
+                pathInfo->m_loadFileResult = toCompressedResult(res);
+                pathInfo->m_fileBlob = fileBlob;
+            }
+
+            break;
+        }
     }
 
     // Add the relPath

--- a/source/slang/slang-file-system.h
+++ b/source/slang/slang-file-system.h
@@ -30,7 +30,7 @@ public:
             const char* path,
             ISlangBlob** canonicalPathOut) SLANG_OVERRIDE;
 
-    virtual SLANG_NO_THROW SlangResult SLANG_MCALL calcRelativePath(
+    virtual SLANG_NO_THROW SlangResult SLANG_MCALL calcCombinedPath(
         SlangPathType fromPathType,
         const char* fromPath,
         const char* path,
@@ -92,7 +92,7 @@ class CacheFileSystem: public ISlangFileSystemExt, public RefObject
         const char* path,
         ISlangBlob** canonicalPathOut) SLANG_OVERRIDE;
 
-    virtual SLANG_NO_THROW SlangResult SLANG_MCALL calcRelativePath(
+    virtual SLANG_NO_THROW SlangResult SLANG_MCALL calcCombinedPath(
         SlangPathType fromPathType,
         const char* fromPath,
         const char* path,

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -102,16 +102,16 @@ struct IncludeHandlerImpl : IncludeHandler
         ISlangFileSystemExt* fileSystemExt = _getFileSystemExt();
 
         // Get relative path
-        ComPtr<ISlangBlob> relPathBlob;
-        SLANG_RETURN_ON_FAIL(fileSystemExt->calcRelativePath(fromPathType, fromPath.begin(), path.begin(), relPathBlob.writeRef()));
-        String relPath(StringUtil::getString(relPathBlob));
-        if (relPath.Length() <= 0)
+        ComPtr<ISlangBlob> combinedPathBlob;
+        SLANG_RETURN_ON_FAIL(fileSystemExt->calcCombinedPath(fromPathType, fromPath.begin(), path.begin(), combinedPathBlob.writeRef()));
+        String combinedPath(StringUtil::getString(combinedPathBlob));
+        if (combinedPath.Length() <= 0)
         {
             return SLANG_FAIL;
         }
      
         SlangPathType pathType;
-        SLANG_RETURN_ON_FAIL(fileSystemExt->getPathType(relPath.begin(), &pathType));
+        SLANG_RETURN_ON_FAIL(fileSystemExt->getPathType(combinedPath.begin(), &pathType));
         if (pathType != SLANG_PATH_TYPE_FILE)
         {
             return SLANG_E_NOT_FOUND;
@@ -119,7 +119,7 @@ struct IncludeHandlerImpl : IncludeHandler
 
         // Get the canonical path
         ComPtr<ISlangBlob> canonicalPathBlob;
-        SLANG_RETURN_ON_FAIL(fileSystemExt->getCanoncialPath(relPath.begin(), canonicalPathBlob.writeRef()));
+        SLANG_RETURN_ON_FAIL(fileSystemExt->getCanoncialPath(combinedPath.begin(), canonicalPathBlob.writeRef()));
 
         // If the rel path exists -> the canonical path MUST exists too
         String canonicalPath(StringUtil::getString(canonicalPathBlob));
@@ -130,7 +130,7 @@ struct IncludeHandlerImpl : IncludeHandler
         }
         
         pathInfoOut.type = PathInfo::Type::Normal;
-        pathInfoOut.foundPath = relPath;
+        pathInfoOut.foundPath = combinedPath;
         pathInfoOut.canonicalPath = canonicalPath;
         return SLANG_OK;     
     }

--- a/tests/diagnostics/break-outside-loop.slang
+++ b/tests/diagnostics/break-outside-loop.slang
@@ -1,4 +1,6 @@
 //TEST:SIMPLE:
+//TEST:COMMAND_LINE_SIMPLE:
+
 // `break` where it isn't allowed
 
 void foo() { break; }

--- a/tests/diagnostics/break-outside-loop.slang.expected
+++ b/tests/diagnostics/break-outside-loop.slang.expected
@@ -1,6 +1,6 @@
 result code = -1
 standard error = {
-tests/diagnostics/break-outside-loop.slang(4): error 30003: 'break' must appear inside loop constructs.
+tests/diagnostics/break-outside-loop.slang(6): error 30003: 'break' must appear inside loop constructs.
 }
 standard output = {
 }

--- a/tests/diagnostics/global-uniform.slang
+++ b/tests/diagnostics/global-uniform.slang
@@ -1,6 +1,6 @@
 // global-uniform.slang
 //TEST:SIMPLE:-target hlsl
-
+//TEST:COMMAND_LINE_SIMPLE:-target hlsl
 
 // Any attempt to declare a global variable that actually declares a
 // global uniform should be diagnosed as unsupported.

--- a/tests/preprocessor/pragma-once.slang
+++ b/tests/preprocessor/pragma-once.slang
@@ -27,6 +27,10 @@
 #include "pragma-once-a.h"
 #include "pragma-once-b.h"
 
+// Make sure relative paths are handled
+#include "./pragma-once-a.h"
+#include "./pragma-once-a.h"
+
 // Now let's use both the function and the
 // macro, to confirm that they are both
 // defined as expected.


### PR DESCRIPTION
* calcRelativePath -> calcCombinedPath
* added 64 bit hashing function - for used with file hashes. 
  * We may want a higher quality non crypto hash (faster/less collisions) but this works for now.
* Added Hash mode to CacheFileSystem -> canonicalPaths hold lowercase filename + 64 bit hash
  * Defaults to Hash mode for ISlangFileSystem interfaces
  * Uses canonicalPath method of ISlangFileSystemExt otherwise