### PR TITLE
Clean up variable declaration class hierarchy

### DIFF
--- a/source/slang/expr-defs.h
+++ b/source/slang/expr-defs.h
@@ -183,7 +183,7 @@ END_SYNTAX_CLASS()
 // An expression that binds a temporary variable in a local expression context
 SYNTAX_CLASS(LetExpr, Expr)
 RAW(
-    RefPtr<VarDeclBase> decl;
+    RefPtr<VarDecl> decl;
     RefPtr<Expr> body;
 )
 END_SYNTAX_CLASS()

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -658,10 +658,10 @@ static void diagnoseTypeFieldsMismatch(
 }
 
 static void collectFields(
-    DeclRef<AggTypeDecl>        declRef,
-    List<DeclRef<StructField>>& outFields)
+    DeclRef<AggTypeDecl>    declRef,
+    List<DeclRef<VarDecl>>& outFields)
 {
-    for( auto fieldDeclRef : getMembersOfType<StructField>(declRef) )
+    for( auto fieldDeclRef : getMembersOfType<VarDecl>(declRef) )
     {
         if(fieldDeclRef.getDecl()->HasModifier<HLSLStaticModifier>())
             continue;
@@ -883,8 +883,8 @@ static bool validateTypesMatch(
                 {
                     if( auto rightStructDeclRef = rightDeclRef.As<AggTypeDecl>() )
                     {
-                        List<DeclRef<StructField>> leftFields;
-                        List<DeclRef<StructField>> rightFields;
+                        List<DeclRef<VarDecl>> leftFields;
+                        List<DeclRef<VarDecl>> rightFields;
 
                         collectFields(leftStructDeclRef, leftFields);
                         collectFields(rightStructDeclRef, rightFields);

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -1322,17 +1322,17 @@ namespace Slang
     static RefPtr<VarDeclBase> CreateVarDeclForContext(
         ContainerDecl*  containerDecl )
     {
-        if (dynamic_cast<StructDecl*>(containerDecl) || dynamic_cast<ClassDecl*>(containerDecl))
+        if (dynamic_cast<CallableDecl*>(containerDecl))
         {
-            return new StructField();
-        }
-        else if (dynamic_cast<CallableDecl*>(containerDecl))
-        {
+            // Function parameters always use their dedicated syntax class.
+            //
             return new ParamDecl();
         }
         else
         {
-            return new Variable();
+            // Globals, locals, and member variables all use the same syntax class.
+            //
+            return new VarDecl();
         }
     }
 
@@ -2227,7 +2227,7 @@ namespace Slang
         // The first is a type declaration that holds all the members, while
         // the second is a variable declaration that uses the buffer type.
         RefPtr<StructDecl> bufferDataTypeDecl = new StructDecl();
-        RefPtr<Variable> bufferVarDecl = new Variable();
+        RefPtr<VarDecl> bufferVarDecl = new VarDecl();
 
         // Both declarations will have a location that points to the name
         parser->FillPosition(bufferDataTypeDecl.Ptr());
@@ -2395,7 +2395,7 @@ namespace Slang
         // The first is a type declaration that holds all the members, while
         // the second is a variable declaration that uses the buffer type.
         RefPtr<StructDecl> blockDataTypeDecl = new StructDecl();
-        RefPtr<Variable> blockVarDecl = new Variable();
+        RefPtr<VarDecl> blockVarDecl = new VarDecl();
 
         addModifier(blockDataTypeDecl, new ImplicitParameterGroupElementTypeModifier());
         addModifier(blockVarDecl, new ImplicitParameterGroupVariableModifier());
@@ -3135,7 +3135,7 @@ namespace Slang
 
         if(AdvanceIf(parser, TokenType::OpAssign))
         {
-            decl->initExpr = parser->ParseArgExpr();
+            decl->tagExpr = parser->ParseArgExpr();
         }
 
         return decl;
@@ -3270,7 +3270,7 @@ namespace Slang
         parser->ReadToken(TokenType::LParent);
 
         NameLoc varNameAndLoc = expectIdentifier(parser);
-        RefPtr<Variable> varDecl = new Variable();
+        RefPtr<VarDecl> varDecl = new VarDecl();
         varDecl->nameAndLoc = varNameAndLoc;
         varDecl->loc = varNameAndLoc.loc;
 

--- a/source/slang/stmt-defs.h
+++ b/source/slang/stmt-defs.h
@@ -98,7 +98,7 @@ END_SYNTAX_CLASS()
 
 // A compile-time, range-based `for` loop, which will not appear in the output code
 SYNTAX_CLASS(CompileTimeForStmt, ScopeStmt)
-    SYNTAX_FIELD(RefPtr<Variable>, varDecl)
+    SYNTAX_FIELD(RefPtr<VarDecl>, varDecl)
     SYNTAX_FIELD(RefPtr<Expr>, rangeBeginExpr)
     SYNTAX_FIELD(RefPtr<Expr>, rangeEndExpr)
     SYNTAX_FIELD(RefPtr<Stmt>, body)

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -1223,14 +1223,24 @@ namespace Slang
         return declRef.Substitute(declRef.getDecl()->initExpr);
     }
 
+    inline RefPtr<Type> getType(DeclRef<EnumCaseDecl> const& declRef)
+    {
+        return declRef.Substitute(declRef.getDecl()->type.Ptr());
+    }
+
+    inline RefPtr<Expr> getTagExpr(DeclRef<EnumCaseDecl> const& declRef)
+    {
+        return declRef.Substitute(declRef.getDecl()->tagExpr);
+    }
+
     inline RefPtr<Type> GetTargetType(DeclRef<ExtensionDecl> const& declRef)
     {
         return declRef.Substitute(declRef.getDecl()->targetType.Ptr());
     }
     
-    inline FilteredMemberRefList<StructField> GetFields(DeclRef<StructDecl> const& declRef)
+    inline FilteredMemberRefList<VarDecl> GetFields(DeclRef<StructDecl> const& declRef)
     {
-        return getMembersOfType<StructField>(declRef);
+        return getMembersOfType<VarDecl>(declRef);
     }
 
     inline RefPtr<Type> getBaseType(DeclRef<InheritanceDecl> const& declRef)


### PR DESCRIPTION
The AST class hierarchy for variable declarations had a few messy bits.
First, there are more subclasses of `VarDeclBase` than seem strictly necessary; especially for stuff like `struct` member variable which use `StructField` even for `static` fields (which are effectively globals).
Second, the AST node type for the "cases" within an `enum` was made a subclass of `VarDeclBase` for expediency, but this isn't really semantically accurate (and doesn't seem to be paying off much in deduplication of code).

This change tries to address both of those problems.

First, we replace the existing `Variable` and `StructField` cases with a single `VarDecl` case that covers globals, locals, and member variables.
I haven't gone so far as to replace function parameters or generic value parameters, but that might be worth considering as a further clean-up.

Second, we change `EnumCaseDecl` to inherit directly from  `Decl` instead of `VarDeclBase` and add an explicit case for handling them where they were previously handled as if they were variable declarations (this was done by manually surveying all locations in the code that referenced `VarDeclBase`).