### PR TITLE
Path simplification/hash mode, plus bug fixes

### DIFF
--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -174,6 +174,21 @@ namespace Slang
         }
     }
 
+    /* static */bool Path::IsRelative(const UnownedStringSlice& path)
+    {
+        List<UnownedStringSlice> split;
+        Split(path, split);
+
+        for (const auto& cur : split)
+        {
+            if (cur == "." || cur == "..")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /* static */String Path::Simplify(const UnownedStringSlice& path)
     {
         List<UnownedStringSlice> split;
@@ -208,7 +223,7 @@ namespace Slang
         {
             split.Add(UnownedStringSlice::fromLiteral("."));
         }
-
+   
         // Reconstruct the string
         StringBuilder builder;
         for (int i = 0; i < int(split.Count()); i++)
@@ -219,6 +234,7 @@ namespace Slang
             }
             builder.Append(split[i]);
         }
+
         return builder;
     }
 

--- a/source/core/slang-io.h
+++ b/source/core/slang-io.h
@@ -43,6 +43,10 @@ namespace Slang
         static String Simplify(const UnownedStringSlice& path);
         static String Simplify(const String& path) { return Simplify(path.getUnownedSlice()); }
 
+            /// Returns true if a path contains a . or ..
+        static bool IsRelative(const UnownedStringSlice& path);
+        static bool IsRelative(const String& path) { return IsRelative(path.getUnownedSlice()); }
+
         static SlangResult GetPathType(const String & path, SlangPathType* pathTypeOut);
 
         static SlangResult GetCanonical(const String & path, String& canonicalPathOut);

--- a/source/core/slang-std-writers.cpp
+++ b/source/core/slang-std-writers.cpp
@@ -6,29 +6,28 @@ namespace Slang
 
 /* static */StdWriters* StdWriters::s_singleton = nullptr;
 
-/* static */StdWriters* StdWriters::getDefault()
+/* static */RefPtr<StdWriters> StdWriters::createDefault()
 {
-    static StdWriters* s_context = nullptr;
+    RefPtr<StdWriters> stdWriters(new StdWriters);
 
-    if (!s_context)
-    {
-        static FileWriter s_stdError(stderr, WriterFlag::IsStatic | WriterFlag::IsUnowned | WriterFlag::AutoFlush);
-        static FileWriter s_stdOut(stdout, WriterFlag::IsStatic | WriterFlag::IsUnowned | WriterFlag::AutoFlush);
+    RefPtr<FileWriter> stdError(new FileWriter(stderr, WriterFlag::AutoFlush));
+    RefPtr<FileWriter> stdOut(new FileWriter(stdout, WriterFlag::AutoFlush));
 
-        static StdWriters s_contextVar;
-        s_context = &s_contextVar;
-
-        s_context->setWriter(SLANG_WRITER_CHANNEL_STD_ERROR, &s_stdError);
-        s_context->setWriter(SLANG_WRITER_CHANNEL_STD_OUTPUT, &s_stdOut);
-    }
-    return s_context;
+    stdWriters->setWriter(SLANG_WRITER_CHANNEL_STD_ERROR, stdError);
+    stdWriters->setWriter(SLANG_WRITER_CHANNEL_STD_OUTPUT, stdOut);
+    
+    return stdWriters;
 }
 
-/* static */StdWriters* StdWriters::initDefault()
+/* static */RefPtr<StdWriters> StdWriters::initDefaultSingleton()
 {
-    StdWriters* context = getDefault();
-    setSingleton(context);
-    return context;
+    if (s_singleton)
+    {
+        return s_singleton;
+    }
+    auto defaults = createDefault();
+    setSingleton(defaults);
+    return defaults;
 }
 
 void StdWriters::setRequestWriters(SlangCompileRequest* request)

--- a/source/core/slang-std-writers.h
+++ b/source/core/slang-std-writers.h
@@ -8,9 +8,10 @@ namespace Slang
 {
 
 /* Holds standard writers for the channels */
-class StdWriters
+class StdWriters: public RefObject
 {
 public:
+
     ISlangWriter * getWriter(SlangWriterChannel chan) const { return m_writers[chan]; }
     void setWriter(SlangWriterChannel chan, ISlangWriter* writer) { m_writers[chan] = writer; }
 
@@ -21,9 +22,8 @@ public:
     StdWriters() {}
 
         /// Initialize a default context
-    static StdWriters* initDefault();
-
-    static StdWriters* getDefault();
+    static RefPtr<StdWriters> createDefault();
+    static RefPtr<StdWriters> initDefaultSingleton();
 
     static StdWriters* getSingleton() { return s_singleton; }
     static void setSingleton(StdWriters* context) { s_singleton = context;  }

--- a/source/core/slang-string-util.cpp
+++ b/source/core/slang-string-util.cpp
@@ -59,7 +59,7 @@ static const Guid IID_ISlangBlob = SLANG_UUID_ISlangBlob;
 
 /* static */void StringUtil::append(const char* format, va_list args, StringBuilder& buf)
 {
-    // Calculate the size 
+    // Calculate the size required (not including terminating 0)
     size_t numChars;
     {
         // Create a copy of args, as will be consumed by calcFormattedSize
@@ -69,6 +69,7 @@ static const Guid IID_ISlangBlob = SLANG_UUID_ISlangBlob;
         va_end(argsCopy);
     }
 
+    // Requires + 1 , because calcFormatted appends a terminating 0
     char* dst = buf.prepareForAppend(numChars + 1);
     calcFormatted(format, args, numChars, dst);
     buf.appendInPlace(dst, numChars);

--- a/source/core/slang-string-util.cpp
+++ b/source/core/slang-string-util.cpp
@@ -119,4 +119,34 @@ ComPtr<ISlangBlob> StringUtil::createStringBlob(const String& string)
     return ComPtr<ISlangBlob>(new StringBlob(string));
 }
 
+/* static */String StringUtil::calcCharReplaced(const UnownedStringSlice& slice, char fromChar, char toChar)
+{
+    if (fromChar == toChar)
+    {
+        return slice;
+    }
+
+    const UInt numChars = slice.size();
+    const char* srcChars = slice.begin();
+
+    StringBuilder builder;
+    char* dstChars = builder.prepareForAppend(numChars);
+
+    for (UInt i = 0; i < numChars; ++i)
+    {
+        char c = srcChars[i];
+        dstChars[i] = (c == fromChar) ? toChar : c;
+    }
+
+    builder.appendInPlace(dstChars, numChars);
+    return builder;
+}
+
+/* static */String StringUtil::calcCharReplaced(const String& string, char fromChar, char toChar)
+{
+    return (fromChar == toChar || string.IndexOf(fromChar) == UInt(-1)) ? string : calcCharReplaced(string.getUnownedSlice(), fromChar, toChar);
+}
+
+
+
 } // namespace Slang

--- a/source/core/slang-string-util.h
+++ b/source/core/slang-string-util.h
@@ -63,6 +63,10 @@ struct StringUtil
         /// Returns an empty string if blob is nullptr 
     static String getString(ISlangBlob* blob);
 
+        /// Given a string or slice, replaces all instances of fromChar with toChar
+    static String calcCharReplaced(const UnownedStringSlice& slice, char fromChar, char toChar);
+    static String calcCharReplaced(const String& string, char fromChar, char toChar);
+    
         /// Create a blob from a string
     static ComPtr<ISlangBlob> createStringBlob(const String& string);
 };

--- a/source/core/slang-writer.cpp
+++ b/source/core/slang-writer.cpp
@@ -28,6 +28,7 @@ SlangResult WriterHelper::print(const char* format, ...)
 
     SlangResult res = SLANG_OK;
 
+    // numChars is the amount of characters needed *not* including terminating 0
     size_t numChars;
     {
         // Create a copy of args, as will be consumed by calcFormattedSize
@@ -39,7 +40,8 @@ SlangResult WriterHelper::print(const char* format, ...)
 
     if (numChars > 0)
     {
-        char* appendBuffer = m_writer->beginAppendBuffer(numChars);
+        // We need to add 1 here, because calcFormatted, *requires* space for terminating 0
+        char* appendBuffer = m_writer->beginAppendBuffer(numChars + 1);
         StringUtil::calcFormatted(format, args, numChars, appendBuffer);
         res = m_writer->endAppendBuffer(appendBuffer, numChars);
     }

--- a/source/slang/slang-file-system.h
+++ b/source/slang/slang-file-system.h
@@ -149,18 +149,16 @@ protected:
         SlangPathType m_pathType;
         ComPtr<ISlangBlob> m_fileBlob;
     };
-
-        /// For a given path gets a PathInfo. Can return nullptr, if it is not possible to create the PathInfo for some reason
-    PathInfo* _getOrCreatePathInfo(const String& path);
         /// Given a path works out a canonical path, based on the canonicalMode. outFileContents will be set if file had to be read to produce the canonicalPath (ie with Hash)
     SlangResult _calcCanonicalPath(const String& path, String& outCanonicalPath, ComPtr<ISlangBlob>& outFileContents);
 
+
+        /// For a given path gets a PathInfo. Can return nullptr, if it is not possible to create the PathInfo for some reason
+    PathInfo* _getOrCreatePathCacheInfo(const String& path);
         /// Turns the path into a canonical path, and then tries to look up in the canonicalPathMap.
-    PathInfo* _getOrCreateCanonicalPathInfo(const String& path);
-
-
-    PathInfo* _createPathInfo(const String& path);
-
+    PathInfo* _getOrCreateCanonicalCacheInfo(const String& path);
+        /// Will simplify the path (if possible) to lookup on the pathCache else will create on canonicalCache
+    PathInfo* _getOrCreateSimplifiedPathCacheInfo(const String& path);
 
     /* TODO: This may be improved by mapping to a ISlangBlob. This makes output fast and easy, and if constructed 
     as a StringBlob, we can just static_cast to get as a string to use internally, instead of constantly converting. 

--- a/source/slang/slang-file-system.h
+++ b/source/slang/slang-file-system.h
@@ -150,14 +150,10 @@ protected:
         ComPtr<ISlangBlob> m_fileBlob;
     };
 
-        /// For a given relPath gets a PathInfo
-    PathInfo* _getPathInfo(const String& relPath);
-        /// Get path from a canonical path
-    PathInfo* _getPathInfoFromCanonical(const String& canonicalPath);
-        /// Given a path works out a canonical path, based on the canonicalMode
-    SlangResult _calcCanonicalPath(const String& path, String& outCanonicalPath);
-
-    PathInfo* _createPathInfo(const String& relPath);
+        /// For a given path gets a PathInfo. Can return nullptr, if it is not possible to create the PathInfo for some reason
+    PathInfo* _getOrCreatePathInfo(const String& path);
+        /// Given a path works out a canonical path, based on the canonicalMode. outFileContents will be set if file had to be read to produce the canonicalPath (ie with Hash)
+    SlangResult _calcCanonicalPath(const String& path, String& outCanonicalPath, ComPtr<ISlangBlob>& outFileContents);
     
     /* TODO: This may be improved by mapping to a ISlangBlob. This makes output fast and easy, and if constructed 
     as a StringBlob, we can just static_cast to get as a string to use internally, instead of constantly converting. 

--- a/source/slang/slang-file-system.h
+++ b/source/slang/slang-file-system.h
@@ -11,7 +11,7 @@
 namespace Slang
 {
 
-class DefaultFileSystem : public ISlangFileSystemExt
+class OSFileSystem : public ISlangFileSystemExt
 {
 public:
     // ISlangUnknown 
@@ -45,12 +45,12 @@ public:
 
 private:
         /// Make so not constructible
-    DefaultFileSystem() {}
-    virtual ~DefaultFileSystem() {}
+    OSFileSystem() {}
+    virtual ~OSFileSystem() {}
 
     ISlangUnknown* getInterface(const Guid& guid);
 
-    static DefaultFileSystem s_singleton;
+    static OSFileSystem s_singleton;
 };
 
 /* Wraps an underlying ISlangFileSystem or ISlangFileSystemExt and provides caching, 
@@ -154,7 +154,9 @@ protected:
     PathInfo* _getPathInfo(const String& relPath);
         /// Get path from a canonical path
     PathInfo* _getPathInfoFromCanonical(const String& canonicalPath);
-        
+        /// Given a path works out a canonical path, based on the canonicalMode
+    SlangResult _calcCanonicalPath(const String& path, String& outCanonicalPath);
+
     PathInfo* _createPathInfo(const String& relPath);
     
     /* TODO: This may be improved by mapping to a ISlangBlob. This makes output fast and easy, and if constructed 

--- a/source/slang/slang-file-system.h
+++ b/source/slang/slang-file-system.h
@@ -71,9 +71,10 @@ class CacheFileSystem: public ISlangFileSystemExt, public RefObject
     enum CanonicalMode
     {
         Default,                    ///< If passed, will default to the others depending on what kind of ISlangFileSystem is passed in
-        Path,                       ///< Just use the path as is
-        SimplifiedPath,             ///< Use the input path 'simplified' (ie removing . and .. aspects)
-        Hash,                       ///< Use hashing 
+        Path,                       ///< Just use the path as is (old style slang behavior)
+        SimplifyPath,               ///< Use the input path 'simplified' (ie removing . and .. aspects)
+        Hash,                       ///< Use hashing
+        SimplifyPathAndHash,        ///< Tries simplifying path first, and if that doesn't work it hashes
         FileSystemExt,              ///< Use the file system extended interface. 
     };
 
@@ -153,7 +154,9 @@ protected:
     PathInfo* _getPathInfo(const String& relPath);
         /// Get path from a canonical path
     PathInfo* _getPathInfoFromCanonical(const String& canonicalPath);
-
+        
+    PathInfo* _createPathInfo(const String& relPath);
+    
     /* TODO: This may be improved by mapping to a ISlangBlob. This makes output fast and easy, and if constructed 
     as a StringBlob, we can just static_cast to get as a string to use internally, instead of constantly converting. 
     It is probably the case we cannot do dynamic_cast on ISlangBlob if we don't know where constructed -> if outside of slang codebase 

--- a/source/slang/slang-file-system.h
+++ b/source/slang/slang-file-system.h
@@ -154,7 +154,14 @@ protected:
     PathInfo* _getOrCreatePathInfo(const String& path);
         /// Given a path works out a canonical path, based on the canonicalMode. outFileContents will be set if file had to be read to produce the canonicalPath (ie with Hash)
     SlangResult _calcCanonicalPath(const String& path, String& outCanonicalPath, ComPtr<ISlangBlob>& outFileContents);
-    
+
+        /// Turns the path into a canonical path, and then tries to look up in the canonicalPathMap.
+    PathInfo* _getOrCreateCanonicalPathInfo(const String& path);
+
+
+    PathInfo* _createPathInfo(const String& path);
+
+
     /* TODO: This may be improved by mapping to a ISlangBlob. This makes output fast and easy, and if constructed 
     as a StringBlob, we can just static_cast to get as a string to use internally, instead of constantly converting. 
     It is probably the case we cannot do dynamic_cast on ISlangBlob if we don't know where constructed -> if outside of slang codebase 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -316,7 +316,7 @@ CompileRequest::CompileRequest(Session* session)
 
     // Set up the default file system
     SLANG_ASSERT(fileSystem == nullptr);
-    fileSystemExt = new CacheFileSystem(DefaultFileSystem::getSingleton());
+    fileSystemExt = new CacheFileSystem(OSFileSystem::getSingleton());
 }
 
 // Allocate static const storage for the various interface IDs that the Slang API needs to expose
@@ -1251,7 +1251,7 @@ SLANG_API void spSetFileSystem(
     // Set up fileSystemExt appropriately
     if (fileSystem == nullptr)
     {
-        req->fileSystemExt = new Slang::CacheFileSystem(Slang::DefaultFileSystem::getSingleton());
+        req->fileSystemExt = new Slang::CacheFileSystem(Slang::OSFileSystem::getSingleton());
     }
     else
     {

--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -81,7 +81,10 @@ int MAIN(int argc, char** argv)
     SlangResult res;
     {
         SlangSession* session = spCreateSession(nullptr);
-        res = innerMain(StdWriters::initDefault(), session, argc, argv);
+
+        auto stdWriters = StdWriters::initDefaultSingleton();
+        
+        res = innerMain(stdWriters, session, argc, argv);
         spDestroySession(session);
     }
     return TestToolUtil::getReturnCode(res);

--- a/tests/preprocessor/include/pragma-once-c.h
+++ b/tests/preprocessor/include/pragma-once-c.h
@@ -1,0 +1,5 @@
+// pragma-once-c.h
+
+// Used by the `pragma-once.slang` test
+
+#define ONLY_DEFINED_ONCE

--- a/tests/preprocessor/include/pragma-once-c.h
+++ b/tests/preprocessor/include/pragma-once-c.h
@@ -2,4 +2,6 @@
 
 // Used by the `pragma-once.slang` test
 
-#define ONLY_DEFINED_ONCE
+#pragma once
+
+#define ONLY_DEFINED_ONCE_C

--- a/tests/preprocessor/pragma-once.slang
+++ b/tests/preprocessor/pragma-once.slang
@@ -39,6 +39,10 @@
 #include "include/pragma-once-c.h"
 #include "./include\pragma-once-c.h"
 
+#ifndef ONLY_DEFINED_ONCE_C
+#undef BAR
+#endif
+
 // Now let's use both the function and the
 // macro, to confirm that they are both
 // defined as expected.

--- a/tests/preprocessor/pragma-once.slang
+++ b/tests/preprocessor/pragma-once.slang
@@ -31,6 +31,11 @@
 #include "./pragma-once-a.h"
 #include "./pragma-once-a.h"
 
+#include ".\pragma-once-a.h"
+#include "./include\../pragma-once-a.h"
+
+#include "../preprocessor/./pragma-once-a.h"
+
 // Now let's use both the function and the
 // macro, to confirm that they are both
 // defined as expected.

--- a/tests/preprocessor/pragma-once.slang
+++ b/tests/preprocessor/pragma-once.slang
@@ -36,6 +36,9 @@
 
 #include "../preprocessor/./pragma-once-a.h"
 
+#include "include/pragma-once-c.h"
+#include "./include\pragma-once-c.h"
+
 // Now let's use both the function and the
 // macro, to confirm that they are both
 // defined as expected.

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -670,8 +670,12 @@ SLANG_TEST_TOOL_API SlangResult innerMain(Slang::StdWriters* stdWriters, SlangSe
 
 int main(int argc, char**  argv)
 {
+    using namespace Slang;
     SlangSession* session = spCreateSession(nullptr);
-    SlangResult res = innerMain(Slang::StdWriters::initDefault(), session, argc, argv);
+
+    auto stdWriters = StdWriters::initDefaultSingleton();
+    
+    SlangResult res = innerMain(stdWriters, session, argc, argv);
     spDestroySession(session);
 
 	return SLANG_FAILED(res) ? 1 : 0;

--- a/tools/slang-reflection-test/slang-reflection-test-main.cpp
+++ b/tools/slang-reflection-test/slang-reflection-test-main.cpp
@@ -963,8 +963,13 @@ int main(
     int argc,
     char** argv)
 {
+    using namespace Slang;
+
     SlangSession* session = spCreateSession(nullptr);
-    SlangResult res = innerMain(Slang::StdWriters::initDefault(), session, argc, argv);
+
+    auto stdWriters = StdWriters::initDefaultSingleton();
+    
+    SlangResult res = innerMain(stdWriters, session, argc, argv);
     spDestroySession(session);
 
     return SLANG_FAILED(res) ? 1 : 0;

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1818,7 +1818,7 @@ void runTestsInDirectory(
 
 SlangResult innerMain(int argc, char** argv)
 {
-    StdWriters::initDefault();
+    auto stdWriters = StdWriters::initDefaultSingleton();
 
     // The context holds useful things used during testing
     TestContext context;

--- a/tools/slang-test/unit-test-path.cpp
+++ b/tools/slang-test/unit-test-path.cpp
@@ -35,6 +35,26 @@ static void pathUnitTest()
 
         SLANG_CHECK(Path::Simplify("a:\\what\\..\\.\\..\\is\\.\\..\\this\\.\\") == "a:/../this");
 
+        SLANG_CHECK(Path::Simplify("tests/preprocessor/.\\pragma-once-a.h") == "tests/preprocessor/pragma-once-a.h");
+
+
+        SLANG_CHECK(Path::IsRelative("."));
+        SLANG_CHECK(Path::IsRelative(".."));
+        SLANG_CHECK(Path::IsRelative("blah/.."));
+
+        SLANG_CHECK(Path::IsRelative("blah/.././a"));
+        SLANG_CHECK(Path::IsRelative("a") == false);
+        SLANG_CHECK(Path::IsRelative("blah/a") == false);
+        SLANG_CHECK(Path::IsRelative("a:\\blah/a") == false);
+
+
+        SLANG_CHECK(Path::IsRelative("a:/what/.././../is/./../this/."));
+
+        SLANG_CHECK(Path::IsRelative("a:/what/.././../is/./../this/./"));
+
+        SLANG_CHECK(Path::IsRelative("a:\\what\\..\\.\\..\\is\\.\\..\\this\\.\\"));
+
+
     }
 }
 


### PR DESCRIPTION
* Fix memory bug around expanding va_args - needed buffer to have space for terminating 0
* Fix problem with FileWriter defaults being globals, as memory they allocate, will only be freed after return from main - work around by making StdWriters RefObject derived, and kept in scope such the writers are destroyed before checks for leaks is found
* Added SimplifyPathAndHash mode for CacheFileSystem - will simplify the path and see if simplified path is in cache before reading file (limiting amout of underlying file requests)

To explain a little more - there are actual 3 'modes' with the file system depending on what you set as your file system.

OSFileSystem is literally a wrapper on underlying file system. Calling loadFile will hit the file system. Calling getCanonicalPath will return a paths canonical path.

CacheFileSystem - can be used in several ways. It implements a cache for files loaded. It implements mechanism/s for handling how a file is identified as being 'the same'. Importantly it can turn an ISlangFileSystem into a ISlangFileSystemExt, by providing implementations to all the other methods. This is important because slang internally only knows how to talk ISlangFileSystemExt.

1) If you set nullptr (or set nothing) for the file system you will get CacheFileSystem wrapping OSFileSystem. Which means you get caching of results and file identity is via OS based canonical paths.
2) if you set a ISlangFileSystem (ie not Ext) you will get that wrapped by CacheFileSystem. This means you get 'same file identification' via SimplifyPathAndHash mechanism by default. It caches files and other results.
3) If you set ISlangFileSystemExt - you get just that and nothing else (ie there will be no caching etc from slang, you are on your own, and can implement your own caching / unique file identification) 

The SimplifyPathAndHash mechanism has the following steps

1) Look up the path as given to see if file can be found in 'path' cache. If found return it.
2) If not, simplify the path and try looking up that in the 'path' cache. If found return it.
3) If not load the file, calculate the hash (combination of lower case file name and 64 bit hash of file contents), and look up the hash in the 'canonical' cache. If not there add it. Then return it (storing the files contents so as not to need to read again).