### PR TITLE
Fix handling of GLSL sign function

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -3488,7 +3488,23 @@ struct EmitVisitor
             emit(".");
             operandIndex++;
         }
-
+        // fixing issue #602 for GLSL sign function: https://github.com/shader-slang/slang/issues/602
+        bool glslSignFix = ctx->shared->target == CodeGenTarget::GLSL && name == "sign";
+        if (glslSignFix)
+        {
+            if (auto vectorType = as<IRVectorType>(inst->getDataType()))
+            {
+                emit("ivec");
+                emit(as<IRConstant>(vectorType->getElementCount())->value.intVal);
+                emit("(");
+            }
+            else if (auto scalarType = as<IRBasicType>(inst->getDataType()))
+            {
+                emit("int(");
+            }
+            else
+                glslSignFix = false;
+        }
         emit(name);
         emit("(");
         bool first = true;
@@ -3499,7 +3515,8 @@ struct EmitVisitor
             first = false;
         }
         emit(")");
-
+        if (glslSignFix)
+            emit(")");
         maybeCloseParens(needClose);
     }
 

--- a/tests/cross-compile/sign.slang
+++ b/tests/cross-compile/sign.slang
@@ -1,0 +1,13 @@
+// sign.slang
+
+//TEST:CROSS_COMPILE:-target spirv-assembly -entry main -stage fragment
+//TEST:CROSS_COMPILE:-target dxil-assembly  -entry main -stage fragment -profile sm_6_0
+
+// Test cross compilation of the sign function
+
+float4 main() : SV_Target
+{
+    float4 s = sign(float4(1.5, 1.0, -1.5, -1.0));
+    return s;
+}
+

--- a/tests/cross-compile/sign.slang.glsl
+++ b/tests/cross-compile/sign.slang.glsl
@@ -1,0 +1,17 @@
+//TEST_IGNORE_FILE:
+#version 450
+layout(row_major) uniform;
+layout(row_major) buffer;
+
+#line 8 0
+layout(location = 0)
+out vec4 _S1;
+
+
+#line 8
+void main()
+{
+    ivec4 _S2 = ivec4(sign(vec4(1.50000000000000000000, 1.00000000000000000000, -1.50000000000000000000, -1.00000000000000000000)));
+    _S1 = vec4(_S2);
+    return;
+}

--- a/tests/cross-compile/sign.slang.hlsl
+++ b/tests/cross-compile/sign.slang.hlsl
@@ -1,0 +1,6 @@
+//TEST_IGNORE_FILE:
+float4 main() : SV_Target
+{
+    float4 s = sign(float4(1.5, 1.0, -1.5, -1.0));
+    return s;
+}


### PR DESCRIPTION
Quick fix to issue #602.

The issue is due to `sign` function returns the same type as the argument in GLSL, but returns `int` in HLSL.
This results that Slang always output GLSL like
```
ivec2 signrs = sign(vec2_arg);
```
Which fails to compile because the result of the `sign` call is actually a `vec2`, and assigning a `vec2` to a `ivec2`  variable triggers type error in GLSLang.

This fix simply adds a check right before emitting the `sign` intrinsic function, and insert a type-cast if it is emitting GLSL. This makes the code messier, but if this is the only case it is probably not worth the trouble for now to pursue a more systematic solution.
