### PR TITLE
Fix GLSL translation of several Texture* operations

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -703,7 +703,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 if (isMultisample)
                 {
                     sb << "__glsl_extension(GL_EXT_samplerless_texture_functions)";
-                    sb << "__target_intrinsic(glsl, \"texelFetch($0, $1, $3)\")\n";
+                    sb << "__target_intrinsic(glsl, \"texelFetch($0, $1, $3)$z\")\n";
                 }
                 else
                 {
@@ -717,7 +717,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                     {
                         sb << "$1, 0";
                     }
-                    sb << ")\")\n";
+                    sb << ")$z\")\n";
                 }
                 sb << "T Load(";
                 sb << "int" << loadCoordCount << " location";
@@ -730,7 +730,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 if (isMultisample)
                 {
                     sb << "__glsl_extension(GL_EXT_samplerless_texture_functions)";
-                    sb << "__target_intrinsic(glsl, \"texelFetchOffset($0, $0, $1, $2)\")\n";
+                    sb << "__target_intrinsic(glsl, \"texelFetchOffset($0, $0, $1, $2)$z\")\n";
                 }
                 else
                 {
@@ -744,7 +744,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                     {
                         sb << "$1, 0";
                     }
-                    sb << ", $2)\")\n";
+                    sb << ", $2)$z\")\n";
                 }
                 sb << "T Load(";
                 sb << "int" << loadCoordCount << " location";
@@ -834,17 +834,13 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
             {
                 // `Sample()`
 
-                sb << "__target_intrinsic(glsl, \"texture($p, $2)\")\n";
-
-                // TODO: only enable if IR is being used?
-//                sb << "__intrinsic_op(sample)\n";
-
+                sb << "__target_intrinsic(glsl, \"texture($p, $2)$z\")\n";
                 sb << "T Sample(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location);\n";
 
                 if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
-                    sb << "__target_intrinsic(glsl, \"textureOffset($p, $2, $3)\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureOffset($p, $2, $3)$z\")\n";
                     sb << "T Sample(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                     sb << "constexpr int" << kBaseTextureTypes[tt].coordCount << " offset);\n";
@@ -868,13 +864,13 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
 
                 // `SampleBias()`
-                sb << "__target_intrinsic(glsl, \"texture($p, $2, $3)\")\n";
+                sb << "__target_intrinsic(glsl, \"texture($p, $2, $3)$z\")\n";
                 sb << "T SampleBias(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, float bias);\n";
 
                 if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
-                    sb << "__target_intrinsic(glsl, \"textureOffset($p, $2, $3, $4)\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureOffset($p, $2, $3, $4)$z\")\n";
                     sb << "T SampleBias(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, float bias, ";
                     sb << "constexpr int" << kBaseTextureTypes[tt].coordCount << " offset);\n";
@@ -904,7 +900,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                     }
                     sb << "$3)";
 
-                    sb << ", 0.0)\")\n";
+                    sb << ", 0.0)$z\")\n";
                 }
                 else if(arrCoordCount <= 3)
                 {
@@ -925,7 +921,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                     // Construct gradients
                     sb << ", vec" << baseCoordCount << "(0.0)";
                     sb << ", vec" << baseCoordCount << "(0.0)";
-                    sb << ")\")\n";
+                    sb << ")$z\")\n";
                 }
                 sb << "float SampleCmpLevelZero(SamplerComparisonState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
@@ -953,7 +949,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 }
 
 
-                sb << "__target_intrinsic(glsl, \"textureGrad($p, $2, $3, $4)\")\n";
+                sb << "__target_intrinsic(glsl, \"textureGrad($p, $2, $3, $4)$z\")\n";
 //                sb << "__intrinsic_op(sampleGrad)\n";
                 sb << "T SampleGrad(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
@@ -963,7 +959,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
-                    sb << "__target_intrinsic(glsl, \"textureGradOffset($p, $2, $3, $4, $5)\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureGradOffset($p, $2, $3, $4, $5)$z\")\n";
 //                    sb << "__intrinsic_op(sampleGrad)\n";
                     sb << "T SampleGrad(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
@@ -981,7 +977,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
-                    sb << "__target_intrinsic(glsl, \"textureLodOffset($p, $2, $3, $4)\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureLodOffset($p, $2, $3, $4)$z\")\n";
                     sb << "T SampleLevel(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                     sb << "float level, ";

--- a/source/slang/core.meta.slang.h
+++ b/source/slang/core.meta.slang.h
@@ -718,7 +718,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 if (isMultisample)
                 {
                     sb << "__glsl_extension(GL_EXT_samplerless_texture_functions)";
-                    sb << "__target_intrinsic(glsl, \"texelFetch($0, $1, $3)\")\n";
+                    sb << "__target_intrinsic(glsl, \"texelFetch($0, $1, $3)$z\")\n";
                 }
                 else
                 {
@@ -732,7 +732,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                     {
                         sb << "$1, 0";
                     }
-                    sb << ")\")\n";
+                    sb << ")$z\")\n";
                 }
                 sb << "T Load(";
                 sb << "int" << loadCoordCount << " location";
@@ -745,7 +745,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 if (isMultisample)
                 {
                     sb << "__glsl_extension(GL_EXT_samplerless_texture_functions)";
-                    sb << "__target_intrinsic(glsl, \"texelFetchOffset($0, $0, $1, $2)\")\n";
+                    sb << "__target_intrinsic(glsl, \"texelFetchOffset($0, $0, $1, $2)$z\")\n";
                 }
                 else
                 {
@@ -759,7 +759,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                     {
                         sb << "$1, 0";
                     }
-                    sb << ", $2)\")\n";
+                    sb << ", $2)$z\")\n";
                 }
                 sb << "T Load(";
                 sb << "int" << loadCoordCount << " location";
@@ -849,17 +849,13 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
             {
                 // `Sample()`
 
-                sb << "__target_intrinsic(glsl, \"texture($p, $2)\")\n";
-
-                // TODO: only enable if IR is being used?
-//                sb << "__intrinsic_op(sample)\n";
-
+                sb << "__target_intrinsic(glsl, \"texture($p, $2)$z\")\n";
                 sb << "T Sample(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location);\n";
 
                 if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
-                    sb << "__target_intrinsic(glsl, \"textureOffset($p, $2, $3)\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureOffset($p, $2, $3)$z\")\n";
                     sb << "T Sample(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                     sb << "constexpr int" << kBaseTextureTypes[tt].coordCount << " offset);\n";
@@ -883,13 +879,13 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
 
                 // `SampleBias()`
-                sb << "__target_intrinsic(glsl, \"texture($p, $2, $3)\")\n";
+                sb << "__target_intrinsic(glsl, \"texture($p, $2, $3)$z\")\n";
                 sb << "T SampleBias(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, float bias);\n";
 
                 if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
-                    sb << "__target_intrinsic(glsl, \"textureOffset($p, $2, $3, $4)\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureOffset($p, $2, $3, $4)$z\")\n";
                     sb << "T SampleBias(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, float bias, ";
                     sb << "constexpr int" << kBaseTextureTypes[tt].coordCount << " offset);\n";
@@ -919,7 +915,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                     }
                     sb << "$3)";
 
-                    sb << ", 0.0)\")\n";
+                    sb << ", 0.0)$z\")\n";
                 }
                 else if(arrCoordCount <= 3)
                 {
@@ -940,7 +936,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                     // Construct gradients
                     sb << ", vec" << baseCoordCount << "(0.0)";
                     sb << ", vec" << baseCoordCount << "(0.0)";
-                    sb << ")\")\n";
+                    sb << ")$z\")\n";
                 }
                 sb << "float SampleCmpLevelZero(SamplerComparisonState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
@@ -968,7 +964,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 }
 
 
-                sb << "__target_intrinsic(glsl, \"textureGrad($p, $2, $3, $4)\")\n";
+                sb << "__target_intrinsic(glsl, \"textureGrad($p, $2, $3, $4)$z\")\n";
 //                sb << "__intrinsic_op(sampleGrad)\n";
                 sb << "T SampleGrad(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
@@ -978,7 +974,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
-                    sb << "__target_intrinsic(glsl, \"textureGradOffset($p, $2, $3, $4, $5)\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureGradOffset($p, $2, $3, $4, $5)$z\")\n";
 //                    sb << "__intrinsic_op(sampleGrad)\n";
                     sb << "T SampleGrad(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
@@ -996,7 +992,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
-                    sb << "__target_intrinsic(glsl, \"textureLodOffset($p, $2, $3, $4)\")\n";
+                    sb << "__target_intrinsic(glsl, \"textureLodOffset($p, $2, $3, $4)$z\")\n";
                     sb << "T SampleLevel(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                     sb << "float level, ";

--- a/tests/cross-compile/texture-load.slang
+++ b/tests/cross-compile/texture-load.slang
@@ -1,0 +1,21 @@
+// texture-load.slang
+
+// Confirm that texture `Load` operations yield the
+// expected type when compiled to SPIR-V.
+
+//TEST:CROSS_COMPILE:-target spirv-assembly -entry main -stage compute
+
+Texture2D<float2>   inputTexture;
+RWTexture2D<float2> outputTexture;
+
+cbuffer C
+{
+	int2 pos;
+}
+
+[numthreads(16, 16, 1)]
+void main(uint2 pixelIndex : SV_DispatchThreadID)
+{
+	float2 tmp = inputTexture.Load(int3(pos,0));
+    outputTexture[pos] = tmp;
+}

--- a/tests/cross-compile/texture-load.slang.glsl
+++ b/tests/cross-compile/texture-load.slang.glsl
@@ -1,0 +1,44 @@
+// texture-load.slang.glsl
+//TEST_IGNORE_FILE:
+
+#version 450
+
+layout(row_major) uniform;
+layout(row_major) buffer;
+
+#extension GL_EXT_samplerless_texture_functions : require
+
+struct SLANG_ParameterGroup_C_0
+{
+    ivec2 pos_0;
+};
+
+layout(binding = 2)
+layout(std140)
+uniform _S1
+{
+    SLANG_ParameterGroup_C_0 _data;
+} C_0;
+
+layout(binding = 0)
+uniform texture2D inputTexture_0;
+
+layout(rg32f)
+layout(binding = 1)
+uniform image2D outputTexture_0;
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+void main()
+{
+    vec2 tmp_0 = texelFetch(
+    	inputTexture_0,
+    	ivec3(C_0._data.pos_0, 0).xy,
+    	ivec3(C_0._data.pos_0, 0).z).xy;
+
+    imageStore(
+    	outputTexture_0,
+    	ivec2(uvec2(C_0._data.pos_0)),
+    	vec4(tmp_0, float(0), float(0)));
+
+    return;
+}


### PR DESCRIPTION
A user found that the `Texture2D<float2>.Load(...)` operation was not being compiled to GLSL properly, such that it returned a `vec4` instead of the expected `vec2`.

The GLSL texture-related functions always return (and take) 4-component vectors, and we already have infrastructure in `emit.cpp` for recognizing a `$z` operator in the GLSL intrinsic definition to stand in for an appropriate swizzle based on teh number of components in the texture result type.

This change just adds that `$z` operator to the GLSL code for several more texture operations (including `Load()`) that are defined on a `Texture*<T>` and that return `T`.

This change doesn't try to add additional GLSL translations for texture-related operations (e.g., additional variations like `SampleCmp` that we have defined in the stdlib but not given GLSL translations for). That work still needs to be done.