### PR TITLE
Feature/as refactor review

### DIFF
--- a/docs/design/casting.md
+++ b/docs/design/casting.md
@@ -7,7 +7,7 @@ C++'s built in mechanisms for casting (principally dynamic_cast) is problematic 
 
 * There are types which we want to 'dynamic_cast' that do not have, and we do not want to have a Vtbl (for example Slang::IRInst). 
 * There are types which a 'dynamic_cast' doesn't do quite what we want (for example casting on Type* derived types typically wants to work on their canonical type)
-* We may want to replace use of dynamic_cast in the future for speed/space or other reasons in the future
+* We may want to replace use of dynamic_cast in the future for speed/space or other reasons
 * It is common in the code base when using a 'smart pointer' type to cast it, but still return a smart pointer 
 
 To deal with these issues we need casting within Slang to follow it's own methodology. In summary it is as follows...

--- a/docs/design/decl-refs.md
+++ b/docs/design/decl-refs.md
@@ -69,7 +69,7 @@ If we then want to query the type of this field, we can first look up the type s
 Cell::T [Cell::T => int]
 ```
 
-Of course, we can then simplify the reference by applying the substutions, to get:
+Of course, we can then simplify the reference by applying the substitutions, to get:
 
 ```
 int
@@ -89,7 +89,7 @@ Each ancestor of a declaration can introduce an expected substitution along the 
 
 * A surrounding `interface` declaration usually requires a `ThisTypeSubstitution` that identifies the specific type on which an interface member has been looked up.
 
-All of the expected substitutions should be in place in the gerneral case, even when we might not have additional information. E.g., within a generic declaration like this:
+All of the expected substitutions should be in place in the general case, even when we might not have additional information. E.g., within a generic declaration like this:
 
 ```hlsl
 struct Cell<T>

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -126,7 +126,7 @@ namespace Slang
             }
             else if (auto vectorType = as<VectorExpressionType>(typeIn))
             {
-                if (auto elemCount = vectorType->elementCount.as<ConstantIntVal>())
+                if (auto elemCount = as<ConstantIntVal>(vectorType->elementCount))
                 {
                     data.dim1 = elemCount->value - 1;
                     auto elementBasicType = as<BasicExpressionType>(vectorType->elementType);
@@ -885,16 +885,16 @@ namespace Slang
 
         RefPtr<Expr> ExpectATypeRepr(RefPtr<Expr> expr)
         {
-            if (auto overloadedExpr = expr.as<OverloadedExpr>())
+            if (auto overloadedExpr = as<OverloadedExpr>(expr))
             {
                 expr = ResolveOverloadedExpr(overloadedExpr, LookupMask::type);
             }
 
-            if (auto typeType = as<TypeType>(expr->type.type))
+            if (auto typeType = as<TypeType>(expr->type))
             {
                 return expr;
             }
-            else if (auto errorType = as<ErrorType>(expr->type.type))
+            else if (auto errorType = as<ErrorType>(expr->type))
             {
                 return expr;
             }
@@ -925,7 +925,7 @@ namespace Slang
 
         RefPtr<Val> ExtractGenericArgVal(RefPtr<Expr> exp)
         {
-            if (auto overloadedExpr = exp.as<OverloadedExpr>())
+            if (auto overloadedExpr = as<OverloadedExpr>(exp))
             {
                 // assume that if it is overloaded, we want a type
                 exp = ResolveOverloadedExpr(overloadedExpr, LookupMask::type);
@@ -1043,7 +1043,7 @@ namespace Slang
             // this is a quick fix that at least alerts the user to how we are
             // interpreting their code.
             //
-            if (auto varDecl = decl.as<VarDecl>())
+            if (auto varDecl = as<VarDecl>(decl))
             {
                 if (auto parenScope = as<ScopeDecl>(varDecl->ParentDecl))
                 {
@@ -1076,7 +1076,7 @@ namespace Slang
         void EnusreAllDeclsRec(RefPtr<Decl> decl)
         {
             checkDecl(decl);
-            if (auto containerDecl = decl.as<ContainerDecl>())
+            if (auto containerDecl = as<ContainerDecl>(decl))
             {
                 for (auto m : containerDecl->Members)
                 {
@@ -1141,7 +1141,7 @@ namespace Slang
                 List<RefPtr<Expr>> args;
                 for (RefPtr<Decl> member : genericDeclRef.getDecl()->Members)
                 {
-                    if (auto typeParam = member.as<GenericTypeParamDecl>())
+                    if (auto typeParam = as<GenericTypeParamDecl>(member))
                     {
                         if (!typeParam->initType.exp)
                         {
@@ -1157,7 +1157,7 @@ namespace Slang
                         if (outProperType)
                             args.Add(typeParam->initType.exp);
                     }
-                    else if (auto valParam = member.as<GenericValueParamDecl>())
+                    else if (auto valParam = as<GenericValueParamDecl>(member))
                     {
                         if (!valParam->initExpr)
                         {
@@ -1274,11 +1274,11 @@ namespace Slang
         // Capture the "base" expression in case this is a member reference
         RefPtr<Expr> GetBaseExpr(RefPtr<Expr> expr)
         {
-            if (auto memberExpr = expr.as<MemberExpr>())
+            if (auto memberExpr = as<MemberExpr>(expr))
             {
                 return memberExpr->BaseExpression;
             }
-            else if(auto overloadedExpr = expr.as<OverloadedExpr>())
+            else if(auto overloadedExpr = as<OverloadedExpr>(expr))
             {
                 return overloadedExpr->base;
             }
@@ -1293,17 +1293,17 @@ namespace Slang
         {
             if(left == right) return true;
 
-            if(auto leftConst = left.as<ConstantIntVal>())
+            if(auto leftConst = as<ConstantIntVal>(left))
             {
-                if(auto rightConst = right.as<ConstantIntVal>())
+                if(auto rightConst = as<ConstantIntVal>(right))
                 {
                     return leftConst->value == rightConst->value;
                 }
             }
 
-            if(auto leftVar = left.as<GenericParamIntVal>())
+            if(auto leftVar = as<GenericParamIntVal>(left))
             {
-                if(auto rightVar = right.as<GenericParamIntVal>())
+                if(auto rightVar = as<GenericParamIntVal>(right))
                 {
                     return leftVar->declRef.Equals(rightVar->declRef);
                 }
@@ -1352,7 +1352,7 @@ namespace Slang
 
             if(auto declRefType = as<DeclRefType>(type))
             {
-                if(declRefType->declRef.as<StructDecl>())
+                if(as<StructDecl>(declRefType->declRef))
                     return false;
             }
 
@@ -1500,7 +1500,7 @@ namespace Slang
                 auto toElementType = toVecType->elementType;
 
                 UInt elementCount = 0;
-                if (auto constElementCount = toElementCount.as<ConstantIntVal>())
+                if (auto constElementCount = as<ConstantIntVal>(toElementCount))
                 {
                     elementCount = (UInt) constElementCount->value;
                 }
@@ -3844,7 +3844,7 @@ namespace Slang
                         RefPtr<IntVal> explicitTagVal = TryConstantFoldExpr(explicitTagValExpr);
                         if(explicitTagVal)
                         {
-                            if(auto constIntVal = explicitTagVal.as<ConstantIntVal>())
+                            if(auto constIntVal = as<ConstantIntVal>(explicitTagVal))
                             {
                                 defaultTag = constIntVal->value;
                             }
@@ -6297,8 +6297,8 @@ namespace Slang
                         if (c.decl != valParam.getDecl())
                             continue;
 
-                        auto cVal = c.val.as<IntVal>();
-                        SLANG_RELEASE_ASSERT(cVal.Ptr());
+                        auto cVal = as<IntVal>(c.val);
+                        SLANG_RELEASE_ASSERT(cVal);
 
                         if (!val)
                         {
@@ -6306,7 +6306,7 @@ namespace Slang
                         }
                         else
                         {
-                            if(!val->EqualsVal(cVal.Ptr()))
+                            if(!val->EqualsVal(cVal))
                             {
                                 // failure!
                                 return SubstitutionSet();

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -7205,18 +7205,18 @@ namespace Slang
             RefPtr<Val>			snd)
         {
             // if both values are types, then unify types
-            if (auto fstType = dynamicCast<Type>(fst))
+            if (auto fstType = as<Type>(fst))
             {
-                if (auto sndType = dynamicCast<Type>(snd))
+                if (auto sndType = as<Type>(snd))
                 {
                     return TryUnifyTypes(constraints, fstType, sndType);
                 }
             }
 
             // if both values are constant integers, then compare them
-            if (auto fstIntVal = dynamicCast<ConstantIntVal>(fst))
+            if (auto fstIntVal = as<ConstantIntVal>(fst))
             {
-                if (auto sndIntVal = dynamicCast<ConstantIntVal>(snd))
+                if (auto sndIntVal = as<ConstantIntVal>(snd))
                 {
                     return fstIntVal->value == sndIntVal->value;
                 }

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -126,7 +126,7 @@ namespace Slang
             }
             else if (auto vectorType = as<VectorExpressionType>(typeIn))
             {
-                if (auto elemCount = vectorType->elementCount.dynamicCast<ConstantIntVal>())
+                if (auto elemCount = vectorType->elementCount.as<ConstantIntVal>())
                 {
                     data.dim1 = elemCount->value - 1;
                     auto elementBasicType = as<BasicExpressionType>(vectorType->elementType);
@@ -583,7 +583,7 @@ namespace Slang
                     // to the chosen interface decl must be the first substitution on
                     // the list (which is a linked list from the "inside" out).
                     //
-                    auto thisTypeSubst = interfaceDeclRef.substitutions.substitutions.dynamicCast<ThisTypeSubstitution>();
+                    auto thisTypeSubst = interfaceDeclRef.substitutions.substitutions.as<ThisTypeSubstitution>();
                     if(thisTypeSubst && thisTypeSubst->interfaceDecl == interfaceDeclRef.decl)
                     {
                         // This isn't really an existential type, because somebody
@@ -885,7 +885,7 @@ namespace Slang
 
         RefPtr<Expr> ExpectATypeRepr(RefPtr<Expr> expr)
         {
-            if (auto overloadedExpr = expr.dynamicCast<OverloadedExpr>())
+            if (auto overloadedExpr = expr.as<OverloadedExpr>())
             {
                 expr = ResolveOverloadedExpr(overloadedExpr, LookupMask::type);
             }
@@ -925,7 +925,7 @@ namespace Slang
 
         RefPtr<Val> ExtractGenericArgVal(RefPtr<Expr> exp)
         {
-            if (auto overloadedExpr = exp.dynamicCast<OverloadedExpr>())
+            if (auto overloadedExpr = exp.as<OverloadedExpr>())
             {
                 // assume that if it is overloaded, we want a type
                 exp = ResolveOverloadedExpr(overloadedExpr, LookupMask::type);
@@ -1043,7 +1043,7 @@ namespace Slang
             // this is a quick fix that at least alerts the user to how we are
             // interpreting their code.
             //
-            if (auto varDecl = decl.dynamicCast<VarDecl>())
+            if (auto varDecl = decl.as<VarDecl>())
             {
                 if (auto parenScope = as<ScopeDecl>(varDecl->ParentDecl))
                 {
@@ -1076,7 +1076,7 @@ namespace Slang
         void EnusreAllDeclsRec(RefPtr<Decl> decl)
         {
             checkDecl(decl);
-            if (auto containerDecl = decl.dynamicCast<ContainerDecl>())
+            if (auto containerDecl = decl.as<ContainerDecl>())
             {
                 for (auto m : containerDecl->Members)
                 {
@@ -1111,7 +1111,7 @@ namespace Slang
             Type* type = typeExp.type.Ptr();
             if(!type && typeExp.exp)
             {
-                if(auto typeType = typeExp.exp->type.type.dynamicCast<TypeType>())
+                if(auto typeType = as<TypeType>(typeExp.exp->type))
                 {
                     type = typeType->type;
                 }
@@ -1141,7 +1141,7 @@ namespace Slang
                 List<RefPtr<Expr>> args;
                 for (RefPtr<Decl> member : genericDeclRef.getDecl()->Members)
                 {
-                    if (auto typeParam = member.dynamicCast<GenericTypeParamDecl>())
+                    if (auto typeParam = member.as<GenericTypeParamDecl>())
                     {
                         if (!typeParam->initType.exp)
                         {
@@ -1157,7 +1157,7 @@ namespace Slang
                         if (outProperType)
                             args.Add(typeParam->initType.exp);
                     }
-                    else if (auto valParam = member.dynamicCast<GenericValueParamDecl>())
+                    else if (auto valParam = member.as<GenericValueParamDecl>())
                     {
                         if (!valParam->initExpr)
                         {
@@ -1274,11 +1274,11 @@ namespace Slang
         // Capture the "base" expression in case this is a member reference
         RefPtr<Expr> GetBaseExpr(RefPtr<Expr> expr)
         {
-            if (auto memberExpr = expr.dynamicCast<MemberExpr>())
+            if (auto memberExpr = expr.as<MemberExpr>())
             {
                 return memberExpr->BaseExpression;
             }
-            else if(auto overloadedExpr = expr.dynamicCast<OverloadedExpr>())
+            else if(auto overloadedExpr = expr.as<OverloadedExpr>())
             {
                 return overloadedExpr->base;
             }
@@ -1293,17 +1293,17 @@ namespace Slang
         {
             if(left == right) return true;
 
-            if(auto leftConst = left.dynamicCast<ConstantIntVal>())
+            if(auto leftConst = left.as<ConstantIntVal>())
             {
-                if(auto rightConst = right.dynamicCast<ConstantIntVal>())
+                if(auto rightConst = right.as<ConstantIntVal>())
                 {
                     return leftConst->value == rightConst->value;
                 }
             }
 
-            if(auto leftVar = left.dynamicCast<GenericParamIntVal>())
+            if(auto leftVar = left.as<GenericParamIntVal>())
             {
-                if(auto rightVar = right.dynamicCast<GenericParamIntVal>())
+                if(auto rightVar = right.as<GenericParamIntVal>())
                 {
                     return leftVar->declRef.Equals(rightVar->declRef);
                 }
@@ -1366,7 +1366,7 @@ namespace Slang
         {
             // A nested initializer list should always be used directly.
             //
-            if(fromExpr.dynamicCast<InitializerListExpr>())
+            if(as<InitializerListExpr>(fromExpr))
             {
                 return true;
             }
@@ -1500,7 +1500,7 @@ namespace Slang
                 auto toElementType = toVecType->elementType;
 
                 UInt elementCount = 0;
-                if (auto constElementCount = toElementCount.dynamicCast<ConstantIntVal>())
+                if (auto constElementCount = toElementCount.as<ConstantIntVal>())
                 {
                     elementCount = (UInt) constElementCount->value;
                 }
@@ -1548,7 +1548,7 @@ namespace Slang
                     // of elements being initialized matches what was declared.
                     //
                     UInt elementCount = 0;
-                    if (auto constElementCount = toElementCount.dynamicCast<ConstantIntVal>())
+                    if (auto constElementCount = as<ConstantIntVal>(toElementCount))
                     {
                         elementCount = (UInt) constElementCount->value;
                     }
@@ -1780,7 +1780,7 @@ namespace Slang
             }
 
             // Coercion from an initializer list is allowed for many types
-            if( auto fromInitializerListExpr = fromExpr.dynamicCast<InitializerListExpr>())
+            if( auto fromInitializerListExpr = as<InitializerListExpr>(fromExpr))
             {
                 if(!tryCoerceInitializerList(toType, outToExpr, fromInitializerListExpr))
                     return false;
@@ -2210,14 +2210,15 @@ namespace Slang
         }
 
         // Fill in default substitutions for the 'subtype' part of a type constraint decl
-        void CheckConstraintSubType(TypeExp & typeExp)
+        void CheckConstraintSubType(TypeExp& typeExp)
         {
-            if (auto sharedTypeExpr = typeExp.exp.dynamicCast<SharedTypeExpr>())
+            if (auto sharedTypeExpr = as<SharedTypeExpr>(typeExp.exp))
             {
                 if (auto declRefType = as<DeclRefType>(sharedTypeExpr->base))
                 {
                     declRefType->declRef.substitutions = createDefaultSubstitutions(getSession(), declRefType->declRef.getDecl());
-                    if (auto typetype = typeExp.exp->type.type.dynamicCast<TypeType>())
+
+                    if (auto typetype = as<TypeType>(typeExp.exp->type))
                         typetype->type = declRefType;
                 }
             }
@@ -2707,8 +2708,7 @@ namespace Slang
                 return uncheckedAttr;
             }
 
-            RefPtr<RefObject> attrObj = attrDecl->syntaxClass.createInstance();
-            auto attr = attrObj.dynamicCast<Attribute>();
+            RefPtr<Attribute> attr = as<Attribute>(attrDecl->syntaxClass.createInstance());
             if(!attr)
             {
                 SLANG_DIAGNOSE_UNEXPECTED(getSink(), attrDecl, "attribute class did not yield an attribute object");
@@ -2802,7 +2802,7 @@ namespace Slang
             RefPtr<Modifier>        m,
             ModifiableSyntaxNode*   syntaxNode)
         {
-            if(auto hlslUncheckedAttribute = m.dynamicCast<UncheckedAttribute>())
+            if(auto hlslUncheckedAttribute = as<UncheckedAttribute>(m))
             {
                 // We have an HLSL `[name(arg,...)]` attribute, and we'd like
                 // to check that it is provides all the expected arguments
@@ -3036,17 +3036,17 @@ namespace Slang
             {
                 auto genMbr = genDecl.getDecl()->Members[i];
                 auto requiredGenMbr = genDecl.getDecl()->Members[i];
-                if (auto genTypeMbr = genMbr.dynamicCast<GenericTypeParamDecl>())
+                if (auto genTypeMbr = as<GenericTypeParamDecl>(genMbr))
                 {
-                    if (auto requiredGenTypeMbr = requiredGenMbr.dynamicCast<GenericTypeParamDecl>())
+                    if (auto requiredGenTypeMbr = as<GenericTypeParamDecl>(requiredGenMbr))
                     {
                     }
                     else
                         return false;
                 }
-                else if (auto genValMbr = genMbr.dynamicCast<GenericValueParamDecl>())
+                else if (auto genValMbr = as<GenericValueParamDecl>(genMbr))
                 {
-                    if (auto requiredGenValMbr = requiredGenMbr.dynamicCast<GenericValueParamDecl>())
+                    if (auto requiredGenValMbr = as<GenericValueParamDecl>(requiredGenMbr))
                     {
                         if (!genValMbr->type->Equals(requiredGenValMbr->type))
                             return false;
@@ -3054,9 +3054,9 @@ namespace Slang
                     else
                         return false;
                 }
-                else if (auto genTypeConstraintMbr = genMbr.dynamicCast<GenericTypeConstraintDecl>())
+                else if (auto genTypeConstraintMbr = as<GenericTypeConstraintDecl>(genMbr))
                 {
-                    if (auto requiredTypeConstraintMbr = requiredGenMbr.dynamicCast<GenericTypeConstraintDecl>())
+                    if (auto requiredTypeConstraintMbr = as<GenericTypeConstraintDecl>(requiredGenMbr))
                     {
                         if (!genTypeConstraintMbr->sup->Equals(requiredTypeConstraintMbr->sup))
                         {
@@ -3844,7 +3844,7 @@ namespace Slang
                         RefPtr<IntVal> explicitTagVal = TryConstantFoldExpr(explicitTagValExpr);
                         if(explicitTagVal)
                         {
-                            if(auto constIntVal = explicitTagVal.dynamicCast<ConstantIntVal>())
+                            if(auto constIntVal = explicitTagVal.as<ConstantIntVal>())
                             {
                                 defaultTag = constIntVal->value;
                             }
@@ -4895,7 +4895,7 @@ namespace Slang
             //
             // For right now we will look for calls to intrinsic functions, and then inspect
             // their names (this is bad and slow).
-            auto funcDeclRefExpr = invokeExpr->FunctionExpr.dynamicCast<DeclRefExpr>();
+            auto funcDeclRefExpr = invokeExpr->FunctionExpr.as<DeclRefExpr>();
             if (!funcDeclRefExpr) return nullptr;
 
             auto funcDeclRef = funcDeclRefExpr->declRef;
@@ -5197,7 +5197,7 @@ namespace Slang
         {
             auto session = getSession();
             auto vectorGenericDecl = findMagicDecl(
-                session, "Vector").dynamicCast<GenericDecl>();
+                session, "Vector").as<GenericDecl>();
             auto vectorTypeDecl = vectorGenericDecl->inner;
 
             auto substitutions = new GenericSubstitution();
@@ -6258,7 +6258,7 @@ namespace Slang
                         if (c.decl != typeParam.getDecl())
                             continue;
 
-                        auto cType = c.val.dynamicCast<Type>();
+                        auto cType = c.val.as<Type>();
                         SLANG_RELEASE_ASSERT(cType.Ptr());
 
                         if (!type)
@@ -6297,7 +6297,7 @@ namespace Slang
                         if (c.decl != valParam.getDecl())
                             continue;
 
-                        auto cVal = c.val.dynamicCast<IntVal>();
+                        auto cVal = c.val.as<IntVal>();
                         SLANG_RELEASE_ASSERT(cVal.Ptr());
 
                         if (!val)
@@ -6777,7 +6777,7 @@ namespace Slang
             // We should have the existing arguments to the generic
             // handy, so that we can construct a substitution list.
 
-            RefPtr<GenericSubstitution> subst = candidate.subst.dynamicCast<GenericSubstitution>();
+            RefPtr<GenericSubstitution> subst = candidate.subst.as<GenericSubstitution>();
             SLANG_ASSERT(subst);
 
             subst->genericDecl = genericDeclRef.getDecl();
@@ -6847,7 +6847,7 @@ namespace Slang
             RefPtr<Expr>            originalExpr,
             RefPtr<GenericSubstitution>   subst)
         {
-            auto baseDeclRefExpr = baseExpr.dynamicCast<DeclRefExpr>();
+            auto baseDeclRefExpr = baseExpr.as<DeclRefExpr>();
             if (!baseDeclRefExpr)
             {
                 SLANG_DIAGNOSE_UNEXPECTED(getSink(), baseExpr, "expected a reference to a generic declaration");

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -6258,8 +6258,8 @@ namespace Slang
                         if (c.decl != typeParam.getDecl())
                             continue;
 
-                        auto cType = c.val.as<Type>();
-                        SLANG_RELEASE_ASSERT(cType.Ptr());
+                        auto cType = as<Type>(c.val);
+                        SLANG_RELEASE_ASSERT(cType);
 
                         if (!type)
                         {
@@ -6851,7 +6851,7 @@ namespace Slang
             RefPtr<Expr>            originalExpr,
             RefPtr<GenericSubstitution>   subst)
         {
-            auto baseDeclRefExpr = baseExpr.as<DeclRefExpr>();
+            auto baseDeclRefExpr = as<DeclRefExpr>(baseExpr);
             if (!baseDeclRefExpr)
             {
                 SLANG_DIAGNOSE_UNEXPECTED(getSink(), baseExpr, "expected a reference to a generic declaration");
@@ -6928,7 +6928,7 @@ namespace Slang
                 {
                 case OverloadCandidate::Flavor::Func:
                     {
-                        RefPtr<AppExprBase> callExpr = context.originalExpr.as<InvokeExpr>();
+                        RefPtr<AppExprBase> callExpr = as<InvokeExpr>(context.originalExpr);
                         if(!callExpr)
                         {
                             callExpr = new InvokeExpr();
@@ -7735,7 +7735,7 @@ namespace Slang
             //
             for (auto genericDeclRef : getMembersOfType<GenericDecl>(aggTypeDeclRef))
             {
-                if (auto ctorDecl = genericDeclRef.getDecl()->inner.as<ConstructorDecl>())
+                if (auto ctorDecl = as<ConstructorDecl>(genericDeclRef.getDecl()->inner))
                 {
                     DeclRef<Decl> innerRef = SpecializeGenericForOverload(genericDeclRef, context);
                     if (!innerRef)
@@ -9742,16 +9742,16 @@ namespace Slang
                 isLValue = false;
 
             // Variables declared with `let` are always immutable.
-            if(varDeclRef.as<LetDecl>())
+            if(as<LetDecl>(varDeclRef.getDecl()))
                 isLValue = false;
 
             // Generic value parameters are always immutable
-            if(varDeclRef.as<GenericValueParamDecl>())
+            if(as<GenericValueParamDecl>(varDeclRef.getDecl()))
                 isLValue = false;
 
             // Function parameters declared in the "modern" style
             // are immutable unless they have an `out` or `inout` modifier.
-            if( varDeclRef.as<ModernParamDecl>() )
+            if(as<ModernParamDecl>(varDeclRef.getDecl()) )
             {
                 // Note: the `inout` modifier AST class inherits from
                 // the class for the `out` modifier so that we can

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -4238,11 +4238,11 @@ struct EmitVisitor
         if(auto layoutDecoration = inst->findDecoration<IRLayoutDecoration>())
         {
             auto layout = layoutDecoration->getLayout();
-            if(auto varLayout = dynamicCast<VarLayout>(layout))
+            if(auto varLayout = as<VarLayout>(layout))
             {
                 emitIRSemantics(ctx, varLayout);
             }
-            else if (auto entryPointLayout = dynamicCast<EntryPointLayout>(layout))
+            else if (auto entryPointLayout = as<EntryPointLayout>(layout))
             {
                 if(auto resultLayout = entryPointLayout->resultLayout)
                 {
@@ -5159,7 +5159,7 @@ struct EmitVisitor
     {
         if( auto layoutDecoration = func->findDecoration<IRLayoutDecoration>() )
         {
-            return dynamicCast<EntryPointLayout>(layoutDecoration->getLayout());
+            return as<EntryPointLayout>(layoutDecoration->getLayout());
         }
         return nullptr;
     }
@@ -5168,7 +5168,7 @@ struct EmitVisitor
     {
         if (auto layoutDecoration = func->findDecoration<IRLayoutDecoration>())
         {
-            if (auto entryPointLayout = dynamicCast<EntryPointLayout>(layoutDecoration->getLayout()))
+            if (auto entryPointLayout = as<EntryPointLayout>(layoutDecoration->getLayout()))
             {
                 return entryPointLayout;
             }

--- a/source/slang/ir-entry-point-uniforms.cpp
+++ b/source/slang/ir-entry-point-uniforms.cpp
@@ -162,7 +162,7 @@ struct MoveEntryPointUniformParametersToGlobalScope
         // an explicit IR constant buffer for that wrapper, 
         //
         auto entryPointParamsLayout = entryPointLayout->parametersLayout;
-        bool needConstantBuffer = entryPointParamsLayout->typeLayout.as<ParameterGroupTypeLayout>() != nullptr;
+        bool needConstantBuffer = as<ParameterGroupTypeLayout>(entryPointParamsLayout->typeLayout) != nullptr;
 
         // We will set up an IR builder so that we are ready to generate code.
         //

--- a/source/slang/ir-legalize-types.cpp
+++ b/source/slang/ir-legalize-types.cpp
@@ -1017,7 +1017,7 @@ static LegalVal legalizeInst(
 RefPtr<VarLayout> findVarLayout(IRInst* value)
 {
     if (auto layoutDecoration = value->findDecoration<IRLayoutDecoration>())
-        return dynamicCast<VarLayout>(layoutDecoration->getLayout());
+        return as<VarLayout>(layoutDecoration->getLayout());
     return nullptr;
 }
 

--- a/source/slang/legalize-types.h
+++ b/source/slang/legalize-types.h
@@ -90,7 +90,7 @@ struct LegalType
     RefPtr<ImplicitDerefType> getImplicitDeref() const
     {
         SLANG_ASSERT(flavor == Flavor::implicitDeref);
-        return obj.dynamicCast<ImplicitDerefType>();
+        return obj.as<ImplicitDerefType>();
     }
 
     static LegalType tuple(
@@ -99,7 +99,7 @@ struct LegalType
     RefPtr<TuplePseudoType> getTuple() const
     {
         SLANG_ASSERT(flavor == Flavor::tuple);
-        return obj.dynamicCast<TuplePseudoType>();
+        return obj.as<TuplePseudoType>();
     }
 
     static LegalType pair(
@@ -113,7 +113,7 @@ struct LegalType
     RefPtr<PairPseudoType> getPair() const
     {
         SLANG_ASSERT(flavor == Flavor::pair);
-        return obj.dynamicCast<PairPseudoType>();
+        return obj.as<PairPseudoType>();
     }
 };
 

--- a/source/slang/lookup.cpp
+++ b/source/slang/lookup.cpp
@@ -404,7 +404,7 @@ void DoLocalLookupImpl(
         }
 
         // if we are looking inside an interface decl, try find in the interfaces it inherits from
-        bool isInterface = targetDeclRef.as<InterfaceDecl>() ? true : false;
+        bool isInterface = targetDeclRef.canAs<InterfaceDecl>(); 
         if (isInterface)
         {
             if(!targetDeclRefType)

--- a/source/slang/mangle.cpp
+++ b/source/slang/mangle.cpp
@@ -264,9 +264,12 @@ namespace Slang
 
         // Special case: accessors need some way to distinguish themselves
         // so that a getter/setter/ref-er don't all compile to the same name.
-        if(declRef.as<GetterDecl>())        emitRaw(context, "Ag");
-        if(declRef.as<SetterDecl>())        emitRaw(context, "As");
-        if(declRef.as<RefAccessorDecl>())   emitRaw(context, "Ar");
+        {
+            auto decl = declRef.getDecl();
+            if(as<GetterDecl>(decl))        emitRaw(context, "Ag");
+            if(as<SetterDecl>(decl))        emitRaw(context, "As");
+            if(as<RefAccessorDecl>(decl))   emitRaw(context, "Ar");
+        }
 
         // Are we the "inner" declaration beneath a generic decl?
         if(parentGenericDeclRef && (parentGenericDeclRef.getDecl()->inner.Ptr() == declRef.getDecl()))
@@ -294,15 +297,15 @@ namespace Slang
                 UInt genericParameterCount = 0;
                 for( auto mm : getMembers(parentGenericDeclRef) )
                 {
-                    if(mm.as<GenericTypeParamDecl>())
+                    if(as<GenericTypeParamDecl>(mm))
                     {
                         genericParameterCount++;
                     }
-                    else if(mm.as<GenericValueParamDecl>())
+                    else if(as<GenericValueParamDecl>(mm))
                     {
                         genericParameterCount++;
                     }
-                    else if(mm.as<GenericTypeConstraintDecl>())
+                    else if(as<GenericTypeConstraintDecl>(mm))
                     {
                         genericParameterCount++;
                     }

--- a/source/slang/mangle.cpp
+++ b/source/slang/mangle.cpp
@@ -265,10 +265,9 @@ namespace Slang
         // Special case: accessors need some way to distinguish themselves
         // so that a getter/setter/ref-er don't all compile to the same name.
         {
-            auto decl = declRef.getDecl();
-            if(as<GetterDecl>(decl))        emitRaw(context, "Ag");
-            if(as<SetterDecl>(decl))        emitRaw(context, "As");
-            if(as<RefAccessorDecl>(decl))   emitRaw(context, "Ar");
+            if (declRef.canAs<GetterDecl>())        emitRaw(context, "Ag");
+            if (declRef.canAs<SetterDecl>())        emitRaw(context, "As");
+            if (declRef.canAs<RefAccessorDecl>())   emitRaw(context, "Ar");
         }
 
         // Are we the "inner" declaration beneath a generic decl?
@@ -361,7 +360,7 @@ namespace Slang
 
             // Don't print result type for an initializer/constructor,
             // since it is implicit in the qualified name.
-            if (!callableDeclRef.as<ConstructorDecl>())
+            if (!callableDeclRef.canAs<ConstructorDecl>())
             {
                 emitType(context, GetResultType(callableDeclRef));
             }

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -785,12 +785,12 @@ static bool validateSpecializationsMatch(
     for(;;)
     {
         // Skip any global generic substitutions.
-        if(auto leftGlobalGeneric = ll.as<GlobalGenericParamSubstitution>())
+        if(auto leftGlobalGeneric = as<GlobalGenericParamSubstitution>(ll))
         {
             ll = leftGlobalGeneric->outer;
             continue;
         }
-        if(auto rightGlobalGeneric = rr.as<GlobalGenericParamSubstitution>())
+        if(auto rightGlobalGeneric = as<GlobalGenericParamSubstitution>(rr))
         {
             rr = rightGlobalGeneric->outer;
             continue;
@@ -806,7 +806,7 @@ static bool validateSpecializationsMatch(
         ll = ll->outer;
         rr = rr->outer;
 
-        if(auto leftGeneric = leftSubst.as<GenericSubstitution>())
+        if(auto leftGeneric = as<GenericSubstitution>(leftSubst))
         {
             if(auto rightGeneric = as<GenericSubstitution>(rightSubst))
             {
@@ -816,9 +816,9 @@ static bool validateSpecializationsMatch(
                 }
             }
         }
-        else if(auto leftThisType = leftSubst.as<ThisTypeSubstitution>())
+        else if(auto leftThisType = as<ThisTypeSubstitution>(leftSubst))
         {
-            if(auto rightThisType = rightSubst.as<ThisTypeSubstitution>())
+            if(auto rightThisType = as<ThisTypeSubstitution>(rightSubst))
             {
                 if(validateThisTypeSubstitutionsMatch(context, leftThisType, rightThisType, stack))
                 {

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -2494,7 +2494,7 @@ static void collectEntryPointParameters(
     //
     for( auto taggedUnionType : entryPoint->taggedUnionTypes )
     {
-        auto substType = taggedUnionType->Substitute(typeSubst).dynamicCast<Type>();
+        auto substType = taggedUnionType->Substitute(typeSubst).as<Type>();
         auto typeLayout = CreateTypeLayout(context->layoutContext, substType);
         entryPointLayout->taggedUnionTypeLayouts.Add(typeLayout);
     }
@@ -2610,7 +2610,7 @@ static void collectEntryPointParameters(
         auto resultTypeLayout = processEntryPointVaryingParameterDecl(
             context,
             entryPointFuncDecl,
-            resultType->Substitute(typeSubst).dynamicCast<Type>(),
+            resultType->Substitute(typeSubst).as<Type>(),
             state,
             resultLayout);
 

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -821,7 +821,7 @@ namespace Slang
         auto keywordToken = advanceToken(parser);
 
         RefPtr<RefObject> parsedObject = syntaxDecl->parseCallback(parser, syntaxDecl->parseUserData);
-        auto syntax = dynamicCast<T>(parsedObject);
+        auto syntax = as<T>(parsedObject);
 
         if (syntax)
         {

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -2997,7 +2997,7 @@ namespace Slang
         // then we really want the modifiers to apply to the inner declaration.
         //
         RefPtr<Decl> declToModify = decl;
-        if(auto genericDecl = decl.as<GenericDecl>())
+        if(auto genericDecl = as<GenericDecl>(decl))
             declToModify = genericDecl->inner;
         AddModifiers(declToModify.Ptr(), modifiers.first);
 

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -265,16 +265,16 @@ SLANG_API SlangTypeKind spReflectionType_GetKind(SlangReflectionType* inType)
     }
     else if( auto declRefType = as<DeclRefType>(type) )
     {
-        auto declRef = declRefType->declRef;
-        if( auto structDeclRef = declRef.as<StructDecl>() )
+        auto decl = declRefType->declRef.getDecl();
+        if( auto structDeclRef = as<StructDecl>(decl) )
         {
             return SLANG_TYPE_KIND_STRUCT;
         }
-        else if (auto genericParamType = declRef.as<GlobalGenericParamDecl>())
+        else if (auto genericParamType = as<GlobalGenericParamDecl>(decl))
         {
             return SLANG_TYPE_KIND_GENERIC_TYPE_PARAMETER;
         }
-        else if (auto interfaceType = declRef.as<InterfaceDecl>())
+        else if (auto interfaceType = as<InterfaceDecl>(decl))
         {
             return SLANG_TYPE_KIND_INTERFACE;
         }

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -265,16 +265,16 @@ SLANG_API SlangTypeKind spReflectionType_GetKind(SlangReflectionType* inType)
     }
     else if( auto declRefType = as<DeclRefType>(type) )
     {
-        auto decl = declRefType->declRef.getDecl();
-        if( auto structDeclRef = as<StructDecl>(decl) )
+        const auto& declRef = declRefType->declRef;
+        if(declRef.canAs<StructDecl>() )
         {
             return SLANG_TYPE_KIND_STRUCT;
         }
-        else if (auto genericParamType = as<GlobalGenericParamDecl>(decl))
+        else if (declRef.canAs<GlobalGenericParamDecl>())
         {
             return SLANG_TYPE_KIND_GENERIC_TYPE_PARAMETER;
         }
-        else if (auto interfaceType = as<InterfaceDecl>(decl))
+        else if (declRef.canAs<InterfaceDecl>())
         {
             return SLANG_TYPE_KIND_INTERFACE;
         }

--- a/source/slang/syntax-base-defs.h
+++ b/source/slang/syntax-base-defs.h
@@ -80,14 +80,8 @@ public:
     Session* getSession() { return this->session; }
     void setSession(Session* s) { this->session = s; }
 
-    bool Equals(Type * type);
+    bool Equals(Type* type);
     bool Equals(RefPtr<Type> type);
-
-    bool IsTextureOrSampler();
-    bool IsTexture() { return as<TextureType>(this) != nullptr; }
-    bool IsSampler() { return as<SamplerStateType>(this) != nullptr; }
-    bool IsStruct();
-    //bool IsClass();
 
     Type* GetCanonicalType();
 
@@ -95,7 +89,7 @@ public:
 
     virtual bool EqualsVal(Val* val) override;
 protected:
-    virtual bool EqualsImpl(Type * type) = 0;
+    virtual bool EqualsImpl(Type* type) = 0;
 
     virtual RefPtr<Type> CreateCanonicalType() = 0;
     Type* canonicalType = nullptr;

--- a/source/slang/syntax-base-defs.h
+++ b/source/slang/syntax-base-defs.h
@@ -81,20 +81,21 @@ public:
     void setSession(Session* s) { this->session = s; }
 
     bool Equals(Type* type);
-    bool Equals(RefPtr<Type> type);
-
+    
     Type* GetCanonicalType();
 
     virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
 
     virtual bool EqualsVal(Val* val) override;
+
+    ~Type();
+
 protected:
     virtual bool EqualsImpl(Type* type) = 0;
 
     virtual RefPtr<Type> CreateCanonicalType() = 0;
     Type* canonicalType = nullptr;
-    RefPtr<Type> canonicalTypeRefPtr;
-
+    
     Session* session = nullptr;
     )
 END_SYNTAX_CLASS()

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -165,20 +165,6 @@ void Type::accept(IValVisitor* visitor, void* extra)
         return et->canonicalType;
     }
 
-    bool Type::IsTextureOrSampler()
-    {
-        return IsTexture() || IsSampler();
-    }
-
-    bool Type::IsStruct()
-    {
-        auto declRefType = as<DeclRefType>(this);
-        if (!declRefType) return false;
-        auto structDeclRef = declRefType->declRef.as<StructDecl>();
-        if (!structDeclRef) return false;
-        return true;
-    }
-
     void Session::initializeTypes()
     {
         errorType = new ErrorType();

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -346,8 +346,8 @@ void Type::accept(IValVisitor* visitor, void* extra)
     RefPtr<Val> ArrayExpressionType::SubstituteImpl(SubstitutionSet subst, int* ioDiff)
     {
         int diff = 0;
-        auto elementType = baseType->SubstituteImpl(subst, &diff).dynamicCast<Type>();
-        auto arrlen = ArrayLength->SubstituteImpl(subst, &diff).dynamicCast<IntVal>();
+        auto elementType = baseType->SubstituteImpl(subst, &diff).as<Type>();
+        auto arrlen = ArrayLength->SubstituteImpl(subst, &diff).as<IntVal>();
         SLANG_ASSERT(arrlen);
         if (diff)
         {
@@ -428,7 +428,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
     RefPtr<WitnessTable> RequirementWitness::getWitnessTable()
     {
         SLANG_ASSERT(getFlavor() == Flavor::witnessTable);
-        return m_obj.dynamicCast<WitnessTable>();
+        return m_obj.as<WitnessTable>();
     }
 
 
@@ -537,7 +537,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             // search for a substitution that might apply to us
             for(auto s = subst.substitutions; s; s = s->outer)
             {
-                auto genericSubst = s.dynamicCast<GenericSubstitution>();
+                auto genericSubst = s.as<GenericSubstitution>();
                 if(!genericSubst)
                     continue;
 
@@ -640,7 +640,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     static RefPtr<Type> ExtractGenericArgType(RefPtr<Val> val)
     {
-        auto type = val.dynamicCast<Type>();
+        auto type = val.as<Type>();
         SLANG_RELEASE_ASSERT(type.Ptr());
         return type;
     }
@@ -1068,13 +1068,13 @@ void Type::accept(IValVisitor* visitor, void* extra)
         int diff = 0;
 
         // result type
-        RefPtr<Type> substResultType = resultType->SubstituteImpl(subst, &diff).dynamicCast<Type>();
+        RefPtr<Type> substResultType = resultType->SubstituteImpl(subst, &diff).as<Type>();
 
         // parameter types
         List<RefPtr<Type>> substParamTypes;
         for( auto pp : paramTypes )
         {
-            substParamTypes.Add(pp->SubstituteImpl(subst, &diff).dynamicCast<Type>());
+            substParamTypes.Add(pp->SubstituteImpl(subst, &diff).as<Type>());
         }
 
         // early exit for no change...
@@ -1438,7 +1438,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
         if(substOuter != outer) diff++;
 
-        auto substActualType = actualType->SubstituteImpl(substSet, &diff).dynamicCast<Type>();
+        auto substActualType = actualType->SubstituteImpl(substSet, &diff).as<Type>();
 
         List<ConstraintArg> substConstraintArgs;
         for(auto constraintArg : constraintArgs)
@@ -1497,7 +1497,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
         // Otherwise we need to recurse on the type structure
         // and apply substitutions where it makes sense
 
-        return type->Substitute(substitutions).dynamicCast<Type>();
+        return type->Substitute(substitutions).as<Type>();
     }
 
     DeclRefBase DeclRefBase::Substitute(DeclRefBase declRef) const
@@ -2160,8 +2160,8 @@ void Type::accept(IValVisitor* visitor, void* extra)
     RefPtr<Val> TypeEqualityWitness::SubstituteImpl(SubstitutionSet subst, int * ioDiff)
     {
         RefPtr<TypeEqualityWitness> rs = new TypeEqualityWitness();
-        rs->sub = sub->SubstituteImpl(subst, ioDiff).dynamicCast<Type>();
-        rs->sup = sup->SubstituteImpl(subst, ioDiff).dynamicCast<Type>();
+        rs->sub = sub->SubstituteImpl(subst, ioDiff).as<Type>();
+        rs->sup = sup->SubstituteImpl(subst, ioDiff).as<Type>();
         return rs;
     }
 
@@ -2192,7 +2192,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
     {
         for(RefPtr<Substitutions> s = substs; s; s = s->outer)
         {
-            auto thisTypeSubst = s.dynamicCast<ThisTypeSubstitution>();
+            auto thisTypeSubst = s.as<ThisTypeSubstitution>();
             if(!thisTypeSubst)
                 continue;
 
@@ -2226,7 +2226,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
                     UInt index = 0;
                     for (auto m : genericDecl->Members)
                     {
-                        if (auto constraintParam = m.dynamicCast<GenericTypeConstraintDecl>())
+                        if (auto constraintParam = m.as<GenericTypeConstraintDecl>())
                         {
                             if (constraintParam.Ptr() == declRef.getDecl())
                             {
@@ -2265,8 +2265,8 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
         // Perform substitution on the constituent elements.
         int diff = 0;
-        auto substSub = sub->SubstituteImpl(subst, &diff).dynamicCast<Type>();
-        auto substSup = sup->SubstituteImpl(subst, &diff).dynamicCast<Type>();
+        auto substSub = sub->SubstituteImpl(subst, &diff).as<Type>();
+        auto substSup = sup->SubstituteImpl(subst, &diff).as<Type>();
         auto substDeclRef = declRef.SubstituteImpl(subst, &diff);
         if (!diff)
             return this;
@@ -2360,9 +2360,9 @@ void Type::accept(IValVisitor* visitor, void* extra)
     {
         int diff = 0;
 
-        RefPtr<Type> substSub = sub->SubstituteImpl(subst, &diff).dynamicCast<Type>();
-        RefPtr<Type> substSup = sup->SubstituteImpl(subst, &diff).dynamicCast<Type>();
-        RefPtr<SubtypeWitness> substSubToMid = subToMid->SubstituteImpl(subst, &diff).dynamicCast<SubtypeWitness>();
+        RefPtr<Type> substSub = sub->SubstituteImpl(subst, &diff).as<Type>();
+        RefPtr<Type> substSup = sup->SubstituteImpl(subst, &diff).as<Type>();
+        RefPtr<SubtypeWitness> substSubToMid = subToMid->SubstituteImpl(subst, &diff).as<SubtypeWitness>();
         DeclRef<Decl> substMidToSup = midToSup.SubstituteImpl(subst, &diff);
 
         // If nothing changed, then we can bail out early.
@@ -2522,8 +2522,8 @@ void Type::accept(IValVisitor* visitor, void* extra)
         int diff = 0;
 
         auto substDeclRef = declRef.SubstituteImpl(subst, &diff);
-        auto substSub = sub->SubstituteImpl(subst, &diff).dynamicCast<Type>();
-        auto substSup = sup->SubstituteImpl(subst, &diff).dynamicCast<Type>();
+        auto substSub = sub->SubstituteImpl(subst, &diff).as<Type>();
+        auto substSup = sup->SubstituteImpl(subst, &diff).as<Type>();
 
         if(!diff)
             return this;
@@ -2606,7 +2606,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
         List<RefPtr<Type>> substCaseTypes;
         for( auto caseType : caseTypes )
         {
-            substCaseTypes.Add(caseType->SubstituteImpl(subst, &diff).dynamicCast<Type>());
+            substCaseTypes.Add(caseType->SubstituteImpl(subst, &diff).as<Type>());
         }
         if(!diff)
             return this;
@@ -2672,8 +2672,8 @@ RefPtr<Val> TaggedUnionSubtypeWitness::SubstituteImpl(SubstitutionSet subst, int
 {
     int diff = 0;
 
-    auto substSub = sub->SubstituteImpl(subst, &diff).dynamicCast<Type>();
-    auto substSup = sup->SubstituteImpl(subst, &diff).dynamicCast<Type>();
+    auto substSub = sub->SubstituteImpl(subst, &diff).as<Type>();
+    auto substSup = sup->SubstituteImpl(subst, &diff).as<Type>();
 
     List<RefPtr<Val>> substCaseWitnesses;
     for( auto caseWitness : caseWitnesses )

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -293,8 +293,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     RefPtr<PtrTypeBase> Session::getPtrType(RefPtr<Type> valueType, char const* ptrTypeName)
     {
-        auto genericDecl = findMagicDecl(
-            this, ptrTypeName).dynamicCast<GenericDecl>();
+        auto genericDecl = findMagicDecl(this, ptrTypeName).dynamicCast<GenericDecl>();
         return getPtrType(valueType, genericDecl);
     }
 
@@ -1224,17 +1223,17 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     Type* MatrixExpressionType::getElementType()
     {
-        return dynamicCast<Type>(findInnerMostGenericSubstitution(declRef.substitutions)->args[0]);
+        return as<Type>(findInnerMostGenericSubstitution(declRef.substitutions)->args[0]);
     }
 
     IntVal* MatrixExpressionType::getRowCount()
     {
-        return dynamicCast<IntVal>(findInnerMostGenericSubstitution(declRef.substitutions)->args[1]);
+        return as<IntVal>(findInnerMostGenericSubstitution(declRef.substitutions)->args[1]);
     }
 
     IntVal* MatrixExpressionType::getColumnCount()
     {
-        return dynamicCast<IntVal>(findInnerMostGenericSubstitution(declRef.substitutions)->args[2]);
+        return as<IntVal>(findInnerMostGenericSubstitution(declRef.substitutions)->args[2]);
     }
 
     RefPtr<Type> MatrixExpressionType::getRowType()
@@ -1271,7 +1270,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     Type* PtrTypeBase::getValueType()
     {
-        return dynamicCast<Type>(findInnerMostGenericSubstitution(declRef.substitutions)->args[0]);
+        return as<Type>(findInnerMostGenericSubstitution(declRef.substitutions)->args[0]);
     }
 
     // GenericParamIntVal
@@ -1973,7 +1972,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     bool ConstantIntVal::EqualsVal(Val* val)
     {
-        if (auto intVal = dynamicCast<ConstantIntVal>(val))
+        if (auto intVal = as<ConstantIntVal>(val))
             return value == intVal->value;
         return false;
     }
@@ -2045,12 +2044,12 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     Type* HLSLPatchType::getElementType()
     {
-        return dynamicCast<Type>(findInnerMostGenericSubstitution(declRef.substitutions)->args[0]);
+        return as<Type>(findInnerMostGenericSubstitution(declRef.substitutions)->args[0]);
     }
 
     IntVal* HLSLPatchType::getElementCount()
     {
-        return dynamicCast<IntVal>(findInnerMostGenericSubstitution(declRef.substitutions)->args[1]);
+        return as<IntVal>(findInnerMostGenericSubstitution(declRef.substitutions)->args[1]);
     }
 
     // Constructors for types
@@ -2496,7 +2495,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     bool ExtractExistentialSubtypeWitness::EqualsVal(Val* val)
     {
-        if( auto extractWitness = dynamicCast<ExtractExistentialSubtypeWitness>(val) )
+        if( auto extractWitness = as<ExtractExistentialSubtypeWitness>(val) )
         {
             return declRef.Equals(extractWitness->declRef);
         }
@@ -2626,7 +2625,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
 bool TaggedUnionSubtypeWitness::EqualsVal(Val* val)
 {
-    auto taggedUnionWitness = dynamicCast<TaggedUnionSubtypeWitness>(val);
+    auto taggedUnionWitness = as<TaggedUnionSubtypeWitness>(val);
     if(!taggedUnionWitness)
         return false;
 

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -1676,7 +1676,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             {
                 // The declaration is nested inside a generic.
                 // Does it already have a specialization for that generic?
-                if(auto specGenericSubst = substsToSpecialize.as<GenericSubstitution>())
+                if(auto specGenericSubst = as<GenericSubstitution>(substsToSpecialize))
                 {
                     if(specGenericSubst->genericDecl == ancestorGenericDecl)
                     {
@@ -1710,7 +1710,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
                 //
                 for(auto s = substsToApply; s; s = s->outer)
                 {
-                    auto appGenericSubst = s.as<GenericSubstitution>();
+                    auto appGenericSubst = as<GenericSubstitution>(s);
                     if(!appGenericSubst)
                         continue;
 
@@ -1746,7 +1746,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
                 // The declaration is nested inside a generic.
                 // Does it already have a specialization for that generic?
-                if(auto specThisTypeSubst = substsToSpecialize.as<ThisTypeSubstitution>())
+                if(auto specThisTypeSubst = as<ThisTypeSubstitution>(substsToSpecialize))
                 {
                     if(specThisTypeSubst->interfaceDecl == ancestorInterfaceDecl)
                     {
@@ -1895,7 +1895,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             // and there might be a this-type substitution in place.
             // A reference to the parent of the interface declaration
             // should not include that substitution.
-            if(auto thisTypeSubst = substToApply.as<ThisTypeSubstitution>())
+            if(auto thisTypeSubst = as<ThisTypeSubstitution>(substToApply))
             {
                 if(thisTypeSubst->interfaceDecl == interfaceDecl)
                 {
@@ -1913,7 +1913,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             // A decl-ref to the parent generic should *not* include
             // those substitutions.
             //
-            if(auto genericSubst = substToApply.as<GenericSubstitution>())
+            if(auto genericSubst = as<GenericSubstitution>(substToApply))
             {
                 if(genericSubst->genericDecl == parentGenericDecl)
                 {
@@ -2182,7 +2182,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
     {
         for(RefPtr<Substitutions> s = substs; s; s = s->outer)
         {
-            auto thisTypeSubst = s.as<ThisTypeSubstitution>();
+            auto thisTypeSubst = as<ThisTypeSubstitution>(s);
             if(!thisTypeSubst)
                 continue;
 
@@ -2204,7 +2204,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             // search for a substitution that might apply to us
             for(auto s = subst.substitutions; s; s = s->outer)
             {
-                if(auto genericSubst = s.as<GenericSubstitution>())
+                if(auto genericSubst = as<GenericSubstitution>(s))
                 {
                     // the generic decl associated with the substitution list must be
                     // the generic decl that declared this parameter
@@ -2216,9 +2216,9 @@ void Type::accept(IValVisitor* visitor, void* extra)
                     UInt index = 0;
                     for (auto m : genericDecl->Members)
                     {
-                        if (auto constraintParam = m.as<GenericTypeConstraintDecl>())
+                        if (auto constraintParam = as<GenericTypeConstraintDecl>(m))
                         {
-                            if (constraintParam.Ptr() == declRef.getDecl())
+                            if (constraintParam == declRef.getDecl())
                             {
                                 found = true;
                                 break;

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -1881,6 +1881,10 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     DeclRefBase DeclRefBase::GetParent() const
     {
+        // Want access to the free function (the 'as' method by default gets priority)
+        // Can access as method with this->as because it removes any ambiguity.
+        using Slang::as;
+
         auto parentDecl = decl->ParentDecl;
         if (!parentDecl)
             return DeclRefBase();

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -420,6 +420,10 @@ namespace Slang
         bool Equals(SubstitutionSet substSet) const;
         int GetHashCode() const;
     };
+
+    template<typename T>
+    struct DeclRef;
+
     // A reference to a declaration, which may include
     // substitutions for generic parameters.
     struct DeclRefBase
@@ -461,6 +465,13 @@ namespace Slang
         // Apply substitutions to this declaration reference
         DeclRefBase SubstituteImpl(SubstitutionSet subst, int* ioDiff);
 
+        // Returns true if 'as' will return a valid cast
+        template <typename T>
+        bool canAs() const { return Slang::as<T>(decl) != nullptr; }
+
+        // "dynamic cast" to a more specific declaration reference type
+        template<typename T>
+        DeclRef<T> as() const;
 
         // Check if this is an equivalent declaration reference to another
         bool Equals(DeclRefBase const& declRef) const;
@@ -500,16 +511,6 @@ namespace Slang
             typename EnableIf<IsConvertible<T*, U*>::Value, void>::type* = 0)
             : DeclRefBase(other.decl, other.substitutions)
         {
-        }
-
-        // "dynamic cast" to a more specific declaration reference type
-        template<typename U>
-        DeclRef<U> as() const
-        {
-            DeclRef<U> result;
-            result.decl = Slang::as<U>(decl);
-            result.substitutions = substitutions;
-            return result;
         }
 
         T* getDecl() const
@@ -556,7 +557,15 @@ namespace Slang
         }
     };
 
-    
+    template<typename T>
+    DeclRef<T> DeclRefBase::as() const
+    {
+        DeclRef<T> result;
+        result.decl = Slang::as<T>(decl);
+        result.substitutions = substitutions;
+        return result;
+    }
+
     template<typename T>
     inline DeclRef<T> makeDeclRef(T* decl)
     {

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -1165,7 +1165,7 @@ namespace Slang
 
     inline int GetVectorSize(VectorExpressionType* vecType)
     {
-        auto constantVal = vecType->elementCount.as<ConstantIntVal>();
+        auto constantVal = as<ConstantIntVal>(vecType->elementCount);
         if (constantVal)
             return (int) constantVal->value;
         // TODO: what to do in this case?

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -537,7 +537,7 @@ namespace Slang
             return DeclRefBase::Substitute(expr);
         }
 
-        // Apply substitutions to a type or ddeclaration
+        // Apply substitutions to a type or declaration
         template<typename U>
         DeclRef<U> Substitute(DeclRef<U> declRef) const
         {
@@ -723,12 +723,12 @@ namespace Slang
 
         RefPtr<Decl>* Adjust(RefPtr<Decl>* ptr, RefPtr<Decl>* end) const
         {
-            while (ptr != end)
+            for (; ptr != end; ptr++)
             {
-                DeclRef<Decl> declRef(ptr->Ptr(), substitutions);
-                if (declRef.as<T>())
+                if (as<T>(*ptr))
+                {
                     return ptr;
-                ptr++;
+                }
             }
             return end;
         }

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -1062,7 +1062,7 @@ namespace Slang
         RefPtr<Val> getVal()
         {
             SLANG_ASSERT(getFlavor() == Flavor::val);
-            return m_obj.dynamicCast<Val>();
+            return m_obj.as<Val>();
         }
 
         RefPtr<WitnessTable> getWitnessTable();
@@ -1165,7 +1165,7 @@ namespace Slang
 
     inline int GetVectorSize(VectorExpressionType* vecType)
     {
-        auto constantVal = vecType->elementCount.dynamicCast<ConstantIntVal>();
+        auto constantVal = vecType->elementCount.as<ConstantIntVal>();
         if (constantVal)
             return (int) constantVal->value;
         // TODO: what to do in this case?


### PR DESCRIPTION
* Remove IsXXX methods from Type
* Replace uses of dynamicCast with as, when can be determined no change in behavior
* Use free function's on RefPtr if can be determined no change in behavior
* Added canAs method to DeclRefBase, such that if the result isn't needed, just the cast-ability it can be tested
  * This was used over having a free function 'as' for DeclRefBase
* Moved 'as' from DeclRef to DeclRefBase - means only dependent on one template param (the target)
* Small typo fixes