### PR TITLE
Feature/casting tidyup

### DIFF
--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -6783,7 +6783,7 @@ namespace Slang
             // We should have the existing arguments to the generic
             // handy, so that we can construct a substitution list.
 
-            RefPtr<GenericSubstitution> subst = candidate.subst.as<GenericSubstitution>();
+            auto subst = candidate.subst.as<GenericSubstitution>();
             SLANG_ASSERT(subst);
 
             subst->genericDecl = genericDeclRef.getDecl();
@@ -9744,16 +9744,16 @@ namespace Slang
                 isLValue = false;
 
             // Variables declared with `let` are always immutable.
-            if(as<LetDecl>(varDeclRef.getDecl()))
+            if(varDeclRef.is<LetDecl>())
                 isLValue = false;
 
             // Generic value parameters are always immutable
-            if(as<GenericValueParamDecl>(varDeclRef.getDecl()))
+            if(varDeclRef.is<GenericValueParamDecl>())
                 isLValue = false;
 
             // Function parameters declared in the "modern" style
             // are immutable unless they have an `out` or `inout` modifier.
-            if(as<ModernParamDecl>(varDeclRef.getDecl()) )
+            if(varDeclRef.is<ModernParamDecl>())
             {
                 // Note: the `inout` modifier AST class inherits from
                 // the class for the `out` modifier so that we can

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -35,9 +35,9 @@ namespace Slang
         // so (Java is an exception here, perhaps due to some
         // influence from the Scandanavian OOP tradition of Beta/gbeta).
         //
-        if(dynamicCast<AggTypeDecl>(decl))
+        if(as<AggTypeDecl>(decl))
             return true;
-        if(dynamicCast<SimpleTypeDecl>(decl))
+        if(as<SimpleTypeDecl>(decl))
             return true;
 
         // Things nested inside functions may have dependencies
@@ -45,7 +45,7 @@ namespace Slang
         // be dealt with via "capture" so they are also effectively
         // `static`
         //
-        if(dynamicCast<FunctionDeclBase>(parentDecl))
+        if(as<FunctionDeclBase>(parentDecl))
             return true;
 
         // Type constraint declarations are used in member-reference
@@ -85,7 +85,7 @@ namespace Slang
     {
         // A global shader parameter must be declared at global (module) scope.
         //
-        if(!dynamicCast<ModuleDecl>(decl->ParentDecl)) return false;
+        if(!as<ModuleDecl>(decl->ParentDecl)) return false;
 
         // A global variable marked `static` indicates a traditional
         // global variable (albeit one that is implicitly local to
@@ -138,9 +138,9 @@ namespace Slang
             }
             else if (auto matrixType = as<MatrixExpressionType>(typeIn))
             {
-                if (auto elemCount1 = dynamicCast<ConstantIntVal>(matrixType->getRowCount()))
+                if (auto elemCount1 = as<ConstantIntVal>(matrixType->getRowCount()))
                 {
-                    if (auto elemCount2 = dynamicCast<ConstantIntVal>(matrixType->getColumnCount()))
+                    if (auto elemCount2 = as<ConstantIntVal>(matrixType->getColumnCount()))
                     {
                         auto elemBasicType = as<BasicExpressionType>(matrixType->getElementType());
                         data.type = (unsigned char)elemBasicType->baseType;
@@ -1638,7 +1638,7 @@ namespace Slang
                     toMatrixType->getElementType(),
                     toMatrixType->getColumnCount());
 
-                if (auto constRowCount = dynamicCast<ConstantIntVal>(toMatrixType->getRowCount()))
+                if (auto constRowCount = as<ConstantIntVal>(toMatrixType->getRowCount()))
                 {
                     rowCount = (UInt) constRowCount->value;
                 }
@@ -2400,7 +2400,7 @@ namespace Slang
             if (lookupResult.isValid())
             {
                 auto decl = lookupResult.item.declRef.getDecl();
-                if (auto attributeDecl = dynamicCast<AttributeDecl>(decl))
+                if (auto attributeDecl = as<AttributeDecl>(decl))
                 {
                     return attributeDecl;
                 }
@@ -3577,12 +3577,12 @@ namespace Slang
             // confirm that the type actually provides whatever
             // those clauses require.
 
-            if (auto interfaceDecl = dynamicCast<InterfaceDecl>(decl))
+            if (auto interfaceDecl = as<InterfaceDecl>(decl))
             {
                 // Don't check that an interface conforms to the
                 // things it inherits from.
             }
-            else if (auto assocTypeDecl = dynamicCast<AssocTypeDecl>(decl))
+            else if (auto assocTypeDecl = as<AssocTypeDecl>(decl))
             {
                 // Don't check that an associated type decl conforms to the
                 // things it inherits from.
@@ -4083,9 +4083,9 @@ namespace Slang
                 Decl* fstParam = fstParams[pp];
                 Decl* sndParam = sndParams[pp];
 
-                if (auto fstTypeParam = dynamicCast<GenericTypeParamDecl>(fstParam))
+                if (auto fstTypeParam = as<GenericTypeParamDecl>(fstParam))
                 {
-                    if (auto sndTypeParam = dynamicCast<GenericTypeParamDecl>(sndParam))
+                    if (auto sndTypeParam = as<GenericTypeParamDecl>(sndParam))
                     {
                         // TODO: is there any validation that needs to be performed here?
                     }
@@ -4095,9 +4095,9 @@ namespace Slang
                         return false;
                     }
                 }
-                else if (auto fstValueParam = dynamicCast<GenericValueParamDecl>(fstParam))
+                else if (auto fstValueParam = as<GenericValueParamDecl>(fstParam))
                 {
-                    if (auto sndValueParam = dynamicCast<GenericValueParamDecl>(sndParam))
+                    if (auto sndValueParam = as<GenericValueParamDecl>(sndParam))
                     {
                         // Need to check that the parameters have the same type.
                         //
@@ -4234,7 +4234,7 @@ namespace Slang
             // If this is a generic function (that is, its parent
             // declaration is a generic), then we need to look
             // for sibling declarations of the parent.
-            auto genericDecl = dynamicCast<GenericDecl>(parentDecl);
+            auto genericDecl = as<GenericDecl>(parentDecl);
             if (genericDecl)
             {
                 parentDecl = genericDecl->ParentDecl;
@@ -4257,14 +4257,14 @@ namespace Slang
                 auto prevDecl = pp;
 
                 // Look through generics to the declaration underneath
-                auto prevGenericDecl = dynamicCast<GenericDecl>(prevDecl);
+                auto prevGenericDecl = as<GenericDecl>(prevDecl);
                 if (prevGenericDecl)
                     prevDecl = prevGenericDecl->inner.Ptr();
 
                 // We only care about previously-declared functions
                 // Note(tfoley): although we should really error out if the
                 // name is already in use for something else, like a variable...
-                auto prevFuncDecl = dynamicCast<FuncDecl>(prevDecl);
+                auto prevFuncDecl = as<FuncDecl>(prevDecl);
                 if (!prevFuncDecl)
                     continue;
 
@@ -4548,7 +4548,7 @@ namespace Slang
             for (UInt ii = outerStmtCount; ii > 0; --ii)
             {
                 auto outerStmt = outerStmts[ii-1];
-                auto found = dynamicCast<T>(outerStmt);
+                auto found = as<T>(outerStmt);
                 if (found)
                     return found;
             }
@@ -5013,19 +5013,19 @@ namespace Slang
             Expr* expr)
         {
             // Unwrap any "identity" expressions
-            while (auto parenExpr = dynamicCast<ParenExpr>(expr))
+            while (auto parenExpr = as<ParenExpr>(expr))
             {
                 expr = parenExpr->base;
             }
 
             // TODO(tfoley): more serious constant folding here
-            if (auto intLitExpr = dynamicCast<IntegerLiteralExpr>(expr))
+            if (auto intLitExpr = as<IntegerLiteralExpr>(expr))
             {
                 return GetIntVal(intLitExpr);
             }
 
             // it is possible that we are referring to a generic value param
-            if (auto declRefExpr = dynamicCast<DeclRefExpr>(expr))
+            if (auto declRefExpr = as<DeclRefExpr>(expr))
             {
                 auto declRef = declRefExpr->declRef;
 
@@ -5104,13 +5104,13 @@ namespace Slang
                 }
             }
 
-            if(auto castExpr = dynamicCast<TypeCastExpr>(expr))
+            if(auto castExpr = as<TypeCastExpr>(expr))
             {
                 auto val = TryConstantFoldExpr(castExpr->Arguments[0].Ptr());
                 if(val)
                     return val;
             }
-            else if (auto invokeExpr = dynamicCast<InvokeExpr>(expr))
+            else if (auto invokeExpr = as<InvokeExpr>(expr))
             {
                 auto val = TryConstantFoldExpr(invokeExpr);
                 if (val)
@@ -5476,14 +5476,14 @@ namespace Slang
             // the grandparent.
             //
             auto parent = decl->ParentDecl;
-            auto genericParent = dynamicCast<GenericDecl>(parent);
+            auto genericParent = as<GenericDecl>(parent);
             if (genericParent)
             {
                 parent = genericParent->ParentDecl;
             }
 
             // Now look at the type of the parent (or grandparent).
-            if (auto aggTypeDecl = dynamicCast<AggTypeDecl>(parent))
+            if (auto aggTypeDecl = as<AggTypeDecl>(parent))
             {
                 // We are nested in an aggregate type declaration,
                 // so the result type of the initializer will just
@@ -5492,7 +5492,7 @@ namespace Slang
                     getSession(),
                     makeDeclRef(aggTypeDecl));
             }
-            else if (auto extDecl = dynamicCast<ExtensionDecl>(parent))
+            else if (auto extDecl = as<ExtensionDecl>(parent))
             {
                 // We are nested inside an extension, so the result
                 // type needs to be the type being extended.
@@ -5582,7 +5582,7 @@ namespace Slang
                 // its return type from the outer declaration, so we handle both
                 // of these checks at the same place.
                 auto parent = decl->ParentDecl;
-                if (auto parentSubscript = dynamicCast<SubscriptDecl>(parent))
+                if (auto parentSubscript = as<SubscriptDecl>(parent))
                 {
                     decl->ReturnType = parentSubscript->ReturnType;
                 }
@@ -7200,7 +7200,7 @@ namespace Slang
         {
             auto parentDecl = decl->ParentDecl;
             if (!parentDecl) return nullptr;
-            auto parentGeneric = dynamicCast<GenericDecl>(parentDecl);
+            auto parentGeneric = as<GenericDecl>(parentDecl);
             return parentGeneric;
         }
 
@@ -7394,14 +7394,14 @@ namespace Slang
             {
                 auto fstDeclRef = fstDeclRefType->declRef;
 
-                if (auto typeParamDecl = dynamicCast<GenericTypeParamDecl>(fstDeclRef.getDecl()))
+                if (auto typeParamDecl = as<GenericTypeParamDecl>(fstDeclRef.getDecl()))
                     return TryUnifyTypeParam(constraints, typeParamDecl, snd);
 
                 if (auto sndDeclRefType = as<DeclRefType>(snd))
                 {
                     auto sndDeclRef = sndDeclRefType->declRef;
 
-                    if (auto typeParamDecl = dynamicCast<GenericTypeParamDecl>(sndDeclRef.getDecl()))
+                    if (auto typeParamDecl = as<GenericTypeParamDecl>(sndDeclRef.getDecl()))
                         return TryUnifyTypeParam(constraints, typeParamDecl, fst);
 
                     // can't be unified if they refer to different declarations.
@@ -7447,7 +7447,7 @@ namespace Slang
             {
                 auto fstDeclRef = fstDeclRefType->declRef;
 
-                if (auto typeParamDecl = dynamicCast<GenericTypeParamDecl>(fstDeclRef.getDecl()))
+                if (auto typeParamDecl = as<GenericTypeParamDecl>(fstDeclRef.getDecl()))
                 {
                     if(typeParamDecl->ParentDecl == constraints.genericDecl )
                         return TryUnifyTypeParam(constraints, typeParamDecl, snd);
@@ -7458,7 +7458,7 @@ namespace Slang
             {
                 auto sndDeclRef = sndDeclRefType->declRef;
 
-                if (auto typeParamDecl = dynamicCast<GenericTypeParamDecl>(sndDeclRef.getDecl()))
+                if (auto typeParamDecl = as<GenericTypeParamDecl>(sndDeclRef.getDecl()))
                 {
                     if(typeParamDecl->ParentDecl == constraints.genericDecl )
                         return TryUnifyTypeParam(constraints, typeParamDecl, fst);
@@ -8236,7 +8236,7 @@ namespace Slang
 
 #if 0
                         // Debugging: ensure that we don't consider multiple declarations of the same operation
-                        if (auto decl = dynamicCast<CallableDecl>(candidate.item.declRef.decl))
+                        if (auto decl = as<CallableDecl>(candidate.item.declRef.decl))
                         {
                             char buffer[1024];
                             sprintf_s(buffer, sizeof(buffer), "[this:%p, primary:%p, next:%p]",
@@ -8451,7 +8451,7 @@ namespace Slang
         RefPtr<Expr> CheckInvokeExprWithCheckedOperands(InvokeExpr *expr)
         {
             auto rs = ResolveInvoke(expr);
-            if (auto invoke = dynamicCast<InvokeExpr>(rs.Ptr()))
+            if (auto invoke = as<InvokeExpr>(rs.Ptr()))
             {
                 // if this is still an invoke expression, test arguments passed to inout/out parameter are LValues
                 if(auto funcType = as<FuncType>(invoke->FunctionExpr->type))
@@ -9145,7 +9145,7 @@ namespace Slang
         for (auto ee = firstDeclWithName; ee; ee = ee->nextInContainerWithSameName)
         {
             // Is this declaration a function?
-            if (auto funcDecl = dynamicCast<FuncDecl>(ee))
+            if (auto funcDecl = as<FuncDecl>(ee))
             {
                 // Skip non-primary declarations, so that
                 // we don't give an error when an entry
@@ -9171,7 +9171,7 @@ namespace Slang
                     // List all of the declarations that the user *might* mean
                     for (auto ff = firstDeclWithName; ff; ff = ff->nextInContainerWithSameName)
                     {
-                        if (auto candidate = dynamicCast<FuncDecl>(ff))
+                        if (auto candidate = as<FuncDecl>(ff))
                         {
                             sink->diagnose(candidate, Diagnostics::entryPointCandidate, candidate->getName());
                         }
@@ -9304,7 +9304,7 @@ namespace Slang
         for(auto ee = firstDeclWithName; ee; ee = ee->nextInContainerWithSameName)
         {
             // Is this declaration a function?
-            if (auto funcDecl = dynamicCast<FuncDecl>(ee))
+            if (auto funcDecl = as<FuncDecl>(ee))
             {
                 // Skip non-primary declarations, so that
                 // we don't give an error when an entry
@@ -9330,7 +9330,7 @@ namespace Slang
                     // List all of the declarations that the user *might* mean
                     for (auto ff = firstDeclWithName; ff; ff = ff->nextInContainerWithSameName)
                     {
-                        if (auto candidate = dynamicCast<FuncDecl>(ff))
+                        if (auto candidate = as<FuncDecl>(ff))
                         {
                             sink->diagnose(candidate, Diagnostics::entryPointCandidate, candidate->getName());
                         }
@@ -9885,7 +9885,7 @@ namespace Slang
         SubstitutionSet outerSubstSet)
     {
         auto dd = decl->ParentDecl;
-        if( auto genericDecl = dynamicCast<GenericDecl>(dd) )
+        if( auto genericDecl = as<GenericDecl>(dd) )
         {
             // We don't want to specialize references to anything
             // other than the "inner" declaration itself.

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -35,9 +35,9 @@ namespace Slang
         // so (Java is an exception here, perhaps due to some
         // influence from the Scandanavian OOP tradition of Beta/gbeta).
         //
-        if(dynamic_cast<AggTypeDecl*>(decl))
+        if(dynamicCast<AggTypeDecl>(decl))
             return true;
-        if(dynamic_cast<SimpleTypeDecl*>(decl))
+        if(dynamicCast<SimpleTypeDecl>(decl))
             return true;
 
         // Things nested inside functions may have dependencies
@@ -45,7 +45,7 @@ namespace Slang
         // be dealt with via "capture" so they are also effectively
         // `static`
         //
-        if(dynamic_cast<FunctionDeclBase*>(parentDecl))
+        if(dynamicCast<FunctionDeclBase>(parentDecl))
             return true;
 
         // Type constraint declarations are used in member-reference
@@ -85,7 +85,7 @@ namespace Slang
     {
         // A global shader parameter must be declared at global (module) scope.
         //
-        if(!dynamic_cast<ModuleDecl*>(decl->ParentDecl)) return false;
+        if(!dynamicCast<ModuleDecl>(decl->ParentDecl)) return false;
 
         // A global variable marked `static` indicates a traditional
         // global variable (albeit one that is implicitly local to
@@ -138,9 +138,9 @@ namespace Slang
             }
             else if (auto matrixType = as<MatrixExpressionType>(typeIn))
             {
-                if (auto elemCount1 = dynamic_cast<ConstantIntVal*>(matrixType->getRowCount()))
+                if (auto elemCount1 = dynamicCast<ConstantIntVal>(matrixType->getRowCount()))
                 {
-                    if (auto elemCount2 = dynamic_cast<ConstantIntVal*>(matrixType->getColumnCount()))
+                    if (auto elemCount2 = dynamicCast<ConstantIntVal>(matrixType->getColumnCount()))
                     {
                         auto elemBasicType = as<BasicExpressionType>(matrixType->getElementType());
                         data.type = (unsigned char)elemBasicType->baseType;
@@ -1638,7 +1638,7 @@ namespace Slang
                     toMatrixType->getElementType(),
                     toMatrixType->getColumnCount());
 
-                if (auto constRowCount = dynamic_cast<ConstantIntVal*>(toMatrixType->getRowCount()))
+                if (auto constRowCount = dynamicCast<ConstantIntVal>(toMatrixType->getRowCount()))
                 {
                     rowCount = (UInt) constRowCount->value;
                 }
@@ -2400,7 +2400,7 @@ namespace Slang
             if (lookupResult.isValid())
             {
                 auto decl = lookupResult.item.declRef.getDecl();
-                if (auto attributeDecl = dynamic_cast<AttributeDecl*>(decl))
+                if (auto attributeDecl = dynamicCast<AttributeDecl>(decl))
                 {
                     return attributeDecl;
                 }
@@ -3577,12 +3577,12 @@ namespace Slang
             // confirm that the type actually provides whatever
             // those clauses require.
 
-            if (auto interfaceDecl = dynamic_cast<InterfaceDecl*>(decl))
+            if (auto interfaceDecl = dynamicCast<InterfaceDecl>(decl))
             {
                 // Don't check that an interface conforms to the
                 // things it inherits from.
             }
-            else if (auto assocTypeDecl = dynamic_cast<AssocTypeDecl*>(decl))
+            else if (auto assocTypeDecl = dynamicCast<AssocTypeDecl>(decl))
             {
                 // Don't check that an associated type decl conforms to the
                 // things it inherits from.
@@ -4083,11 +4083,11 @@ namespace Slang
                 Decl* fstParam = fstParams[pp];
                 Decl* sndParam = sndParams[pp];
 
-                if (auto fstTypeParam = dynamic_cast<GenericTypeParamDecl*>(fstParam))
+                if (auto fstTypeParam = dynamicCast<GenericTypeParamDecl>(fstParam))
                 {
-                    if (auto sndTypeParam = dynamic_cast<GenericTypeParamDecl*>(sndParam))
+                    if (auto sndTypeParam = dynamicCast<GenericTypeParamDecl>(sndParam))
                     {
-                        // TODO: is there any validation that needs to be peformed here?
+                        // TODO: is there any validation that needs to be performed here?
                     }
                     else
                     {
@@ -4095,9 +4095,9 @@ namespace Slang
                         return false;
                     }
                 }
-                else if (auto fstValueParam = dynamic_cast<GenericValueParamDecl*>(fstParam))
+                else if (auto fstValueParam = dynamicCast<GenericValueParamDecl>(fstParam))
                 {
-                    if (auto sndValueParam = dynamic_cast<GenericValueParamDecl*>(sndParam))
+                    if (auto sndValueParam = dynamicCast<GenericValueParamDecl>(sndParam))
                     {
                         // Need to check that the parameters have the same type.
                         //
@@ -4234,7 +4234,7 @@ namespace Slang
             // If this is a generic function (that is, its parent
             // declaration is a generic), then we need to look
             // for sibling declarations of the parent.
-            auto genericDecl = dynamic_cast<GenericDecl*>(parentDecl);
+            auto genericDecl = dynamicCast<GenericDecl>(parentDecl);
             if (genericDecl)
             {
                 parentDecl = genericDecl->ParentDecl;
@@ -4257,20 +4257,20 @@ namespace Slang
                 auto prevDecl = pp;
 
                 // Look through generics to the declaration underneath
-                auto prevGenericDecl = dynamic_cast<GenericDecl*>(prevDecl);
+                auto prevGenericDecl = dynamicCast<GenericDecl>(prevDecl);
                 if (prevGenericDecl)
                     prevDecl = prevGenericDecl->inner.Ptr();
 
                 // We only care about previously-declared functions
                 // Note(tfoley): although we should really error out if the
                 // name is already in use for something else, like a variable...
-                auto prevFuncDecl = dynamic_cast<FuncDecl*>(prevDecl);
+                auto prevFuncDecl = dynamicCast<FuncDecl>(prevDecl);
                 if (!prevFuncDecl)
                     continue;
 
                 // If one declaration is a prefix/postfix operator, and the
                 // other is not a matching operator, then don't consider these
-                // to be redeclarations.
+                // to be re-declarations.
                 //
                 // Note(tfoley): Any attempt to call such an operator using
                 // ordinary function-call syntax (if we decided to allow it)
@@ -4548,7 +4548,7 @@ namespace Slang
             for (UInt ii = outerStmtCount; ii > 0; --ii)
             {
                 auto outerStmt = outerStmts[ii-1];
-                auto found = dynamic_cast<T*>(outerStmt);
+                auto found = dynamicCast<T>(outerStmt);
                 if (found)
                     return found;
             }
@@ -5013,19 +5013,19 @@ namespace Slang
             Expr* expr)
         {
             // Unwrap any "identity" expressions
-            while (auto parenExpr = dynamic_cast<ParenExpr*>(expr))
+            while (auto parenExpr = dynamicCast<ParenExpr>(expr))
             {
                 expr = parenExpr->base;
             }
 
             // TODO(tfoley): more serious constant folding here
-            if (auto intLitExpr = dynamic_cast<IntegerLiteralExpr*>(expr))
+            if (auto intLitExpr = dynamicCast<IntegerLiteralExpr>(expr))
             {
                 return GetIntVal(intLitExpr);
             }
 
             // it is possible that we are referring to a generic value param
-            if (auto declRefExpr = dynamic_cast<DeclRefExpr*>(expr))
+            if (auto declRefExpr = dynamicCast<DeclRefExpr>(expr))
             {
                 auto declRef = declRefExpr->declRef;
 
@@ -5104,13 +5104,13 @@ namespace Slang
                 }
             }
 
-            if(auto castExpr = dynamic_cast<TypeCastExpr*>(expr))
+            if(auto castExpr = dynamicCast<TypeCastExpr>(expr))
             {
                 auto val = TryConstantFoldExpr(castExpr->Arguments[0].Ptr());
                 if(val)
                     return val;
             }
-            else if (auto invokeExpr = dynamic_cast<InvokeExpr*>(expr))
+            else if (auto invokeExpr = dynamicCast<InvokeExpr>(expr))
             {
                 auto val = TryConstantFoldExpr(invokeExpr);
                 if (val)
@@ -5476,14 +5476,14 @@ namespace Slang
             // the grandparent.
             //
             auto parent = decl->ParentDecl;
-            auto genericParent = dynamic_cast<GenericDecl*>(parent);
+            auto genericParent = dynamicCast<GenericDecl>(parent);
             if (genericParent)
             {
                 parent = genericParent->ParentDecl;
             }
 
             // Now look at the type of the parent (or grandparent).
-            if (auto aggTypeDecl = dynamic_cast<AggTypeDecl*>(parent))
+            if (auto aggTypeDecl = dynamicCast<AggTypeDecl>(parent))
             {
                 // We are nested in an aggregate type declaration,
                 // so the result type of the initializer will just
@@ -5492,7 +5492,7 @@ namespace Slang
                     getSession(),
                     makeDeclRef(aggTypeDecl));
             }
-            else if (auto extDecl = dynamic_cast<ExtensionDecl*>(parent))
+            else if (auto extDecl = dynamicCast<ExtensionDecl>(parent))
             {
                 // We are nested inside an extension, so the result
                 // type needs to be the type being extended.
@@ -5582,7 +5582,7 @@ namespace Slang
                 // its return type from the outer declaration, so we handle both
                 // of these checks at the same place.
                 auto parent = decl->ParentDecl;
-                if (auto parentSubscript = dynamic_cast<SubscriptDecl*>(parent))
+                if (auto parentSubscript = dynamicCast<SubscriptDecl>(parent))
                 {
                     decl->ReturnType = parentSubscript->ReturnType;
                 }
@@ -7200,7 +7200,7 @@ namespace Slang
         {
             auto parentDecl = decl->ParentDecl;
             if (!parentDecl) return nullptr;
-            auto parentGeneric = dynamic_cast<GenericDecl*>(parentDecl);
+            auto parentGeneric = dynamicCast<GenericDecl>(parentDecl);
             return parentGeneric;
         }
 
@@ -7394,14 +7394,14 @@ namespace Slang
             {
                 auto fstDeclRef = fstDeclRefType->declRef;
 
-                if (auto typeParamDecl = dynamic_cast<GenericTypeParamDecl*>(fstDeclRef.getDecl()))
+                if (auto typeParamDecl = dynamicCast<GenericTypeParamDecl>(fstDeclRef.getDecl()))
                     return TryUnifyTypeParam(constraints, typeParamDecl, snd);
 
                 if (auto sndDeclRefType = as<DeclRefType>(snd))
                 {
                     auto sndDeclRef = sndDeclRefType->declRef;
 
-                    if (auto typeParamDecl = dynamic_cast<GenericTypeParamDecl*>(sndDeclRef.getDecl()))
+                    if (auto typeParamDecl = dynamicCast<GenericTypeParamDecl>(sndDeclRef.getDecl()))
                         return TryUnifyTypeParam(constraints, typeParamDecl, fst);
 
                     // can't be unified if they refer to different declarations.
@@ -7447,7 +7447,7 @@ namespace Slang
             {
                 auto fstDeclRef = fstDeclRefType->declRef;
 
-                if (auto typeParamDecl = dynamic_cast<GenericTypeParamDecl*>(fstDeclRef.getDecl()))
+                if (auto typeParamDecl = dynamicCast<GenericTypeParamDecl>(fstDeclRef.getDecl()))
                 {
                     if(typeParamDecl->ParentDecl == constraints.genericDecl )
                         return TryUnifyTypeParam(constraints, typeParamDecl, snd);
@@ -7458,7 +7458,7 @@ namespace Slang
             {
                 auto sndDeclRef = sndDeclRefType->declRef;
 
-                if (auto typeParamDecl = dynamic_cast<GenericTypeParamDecl*>(sndDeclRef.getDecl()))
+                if (auto typeParamDecl = dynamicCast<GenericTypeParamDecl>(sndDeclRef.getDecl()))
                 {
                     if(typeParamDecl->ParentDecl == constraints.genericDecl )
                         return TryUnifyTypeParam(constraints, typeParamDecl, fst);
@@ -8236,7 +8236,7 @@ namespace Slang
 
 #if 0
                         // Debugging: ensure that we don't consider multiple declarations of the same operation
-                        if (auto decl = dynamic_cast<CallableDecl*>(candidate.item.declRef.decl))
+                        if (auto decl = dynamicCast<CallableDecl>(candidate.item.declRef.decl))
                         {
                             char buffer[1024];
                             sprintf_s(buffer, sizeof(buffer), "[this:%p, primary:%p, next:%p]",
@@ -8451,7 +8451,7 @@ namespace Slang
         RefPtr<Expr> CheckInvokeExprWithCheckedOperands(InvokeExpr *expr)
         {
             auto rs = ResolveInvoke(expr);
-            if (auto invoke = dynamic_cast<InvokeExpr*>(rs.Ptr()))
+            if (auto invoke = dynamicCast<InvokeExpr>(rs.Ptr()))
             {
                 // if this is still an invoke expression, test arguments passed to inout/out parameter are LValues
                 if(auto funcType = as<FuncType>(invoke->FunctionExpr->type))
@@ -9145,7 +9145,7 @@ namespace Slang
         for (auto ee = firstDeclWithName; ee; ee = ee->nextInContainerWithSameName)
         {
             // Is this declaration a function?
-            if (auto funcDecl = dynamic_cast<FuncDecl*>(ee))
+            if (auto funcDecl = dynamicCast<FuncDecl>(ee))
             {
                 // Skip non-primary declarations, so that
                 // we don't give an error when an entry
@@ -9171,7 +9171,7 @@ namespace Slang
                     // List all of the declarations that the user *might* mean
                     for (auto ff = firstDeclWithName; ff; ff = ff->nextInContainerWithSameName)
                     {
-                        if (auto candidate = dynamic_cast<FuncDecl*>(ff))
+                        if (auto candidate = dynamicCast<FuncDecl>(ff))
                         {
                             sink->diagnose(candidate, Diagnostics::entryPointCandidate, candidate->getName());
                         }
@@ -9304,7 +9304,7 @@ namespace Slang
         for(auto ee = firstDeclWithName; ee; ee = ee->nextInContainerWithSameName)
         {
             // Is this declaration a function?
-            if (auto funcDecl = dynamic_cast<FuncDecl*>(ee))
+            if (auto funcDecl = dynamicCast<FuncDecl>(ee))
             {
                 // Skip non-primary declarations, so that
                 // we don't give an error when an entry
@@ -9330,7 +9330,7 @@ namespace Slang
                     // List all of the declarations that the user *might* mean
                     for (auto ff = firstDeclWithName; ff; ff = ff->nextInContainerWithSameName)
                     {
-                        if (auto candidate = dynamic_cast<FuncDecl*>(ff))
+                        if (auto candidate = dynamicCast<FuncDecl>(ff))
                         {
                             sink->diagnose(candidate, Diagnostics::entryPointCandidate, candidate->getName());
                         }
@@ -9885,7 +9885,7 @@ namespace Slang
         SubstitutionSet outerSubstSet)
     {
         auto dd = decl->ParentDecl;
-        if( auto genericDecl = dynamic_cast<GenericDecl*>(dd) )
+        if( auto genericDecl = dynamicCast<GenericDecl>(dd) )
         {
             // We don't want to specialize references to anything
             // other than the "inner" declaration itself.

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -5004,7 +5004,7 @@ struct EmitVisitor
                 if (auto layoutDecor = pp->findDecoration<IRLayoutDecoration>())
                 {
                     Layout* layout = layoutDecor->getLayout();
-                    VarLayout* varLayout = dynamic_cast<VarLayout*>(layout);
+                    VarLayout* varLayout = dynamicCast<VarLayout>(layout);
 
                     if (varLayout)
                     {
@@ -5012,15 +5012,15 @@ struct EmitVisitor
 
                         if (auto primTypeModifier = var->FindModifier<HLSLGeometryShaderInputPrimitiveTypeModifier>())
                         {
-                            if (dynamic_cast<HLSLTriangleModifier*>(primTypeModifier))
+                            if (dynamicCast<HLSLTriangleModifier>(primTypeModifier))
                                 emit("triangle ");
-                            else if (dynamic_cast<HLSLPointModifier*>(primTypeModifier))
+                            else if (dynamicCast<HLSLPointModifier>(primTypeModifier))
                                 emit("point ");
-                            else if (dynamic_cast<HLSLLineModifier*>(primTypeModifier))
+                            else if (dynamicCast<HLSLLineModifier>(primTypeModifier))
                                 emit("line ");
-                            else if (dynamic_cast<HLSLLineAdjModifier*>(primTypeModifier))
+                            else if (dynamicCast<HLSLLineAdjModifier>(primTypeModifier))
                                 emit("lineadj ");
-                            else if (dynamic_cast<HLSLTriangleAdjModifier*>(primTypeModifier))
+                            else if (dynamicCast<HLSLTriangleAdjModifier>(primTypeModifier))
                                 emit("triangleadj ");
                         }
                     }

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -5004,7 +5004,7 @@ struct EmitVisitor
                 if (auto layoutDecor = pp->findDecoration<IRLayoutDecoration>())
                 {
                     Layout* layout = layoutDecor->getLayout();
-                    VarLayout* varLayout = dynamicCast<VarLayout>(layout);
+                    VarLayout* varLayout = as<VarLayout>(layout);
 
                     if (varLayout)
                     {
@@ -5012,15 +5012,15 @@ struct EmitVisitor
 
                         if (auto primTypeModifier = var->FindModifier<HLSLGeometryShaderInputPrimitiveTypeModifier>())
                         {
-                            if (dynamicCast<HLSLTriangleModifier>(primTypeModifier))
+                            if (as<HLSLTriangleModifier>(primTypeModifier))
                                 emit("triangle ");
-                            else if (dynamicCast<HLSLPointModifier>(primTypeModifier))
+                            else if (as<HLSLPointModifier>(primTypeModifier))
                                 emit("point ");
-                            else if (dynamicCast<HLSLLineModifier>(primTypeModifier))
+                            else if (as<HLSLLineModifier>(primTypeModifier))
                                 emit("line ");
-                            else if (dynamicCast<HLSLLineAdjModifier>(primTypeModifier))
+                            else if (as<HLSLLineAdjModifier>(primTypeModifier))
                                 emit("lineadj ");
-                            else if (dynamicCast<HLSLTriangleAdjModifier>(primTypeModifier))
+                            else if (as<HLSLTriangleAdjModifier>(primTypeModifier))
                                 emit("triangleadj ");
                         }
                     }

--- a/source/slang/ir-entry-point-uniforms.cpp
+++ b/source/slang/ir-entry-point-uniforms.cpp
@@ -149,7 +149,7 @@ struct MoveEntryPointUniformParametersToGlobalScope
         if(!funcLayoutDecoration)
             return;
 
-        auto entryPointLayout = dynamic_cast<EntryPointLayout*>(funcLayoutDecoration->getLayout());
+        auto entryPointLayout = dynamicCast<EntryPointLayout>(funcLayoutDecoration->getLayout());
         SLANG_ASSERT(entryPointLayout);
         if(!entryPointLayout)
             return;
@@ -202,7 +202,7 @@ struct MoveEntryPointUniformParametersToGlobalScope
             SLANG_ASSERT(layoutDecoration);
             if(!layoutDecoration)
                 continue;
-            auto paramLayout = dynamic_cast<VarLayout*>(layoutDecoration->getLayout());
+            auto paramLayout = dynamicCast<VarLayout>(layoutDecoration->getLayout());
             SLANG_ASSERT(paramLayout);
             if(!paramLayout)
                 continue;

--- a/source/slang/ir-entry-point-uniforms.cpp
+++ b/source/slang/ir-entry-point-uniforms.cpp
@@ -149,7 +149,7 @@ struct MoveEntryPointUniformParametersToGlobalScope
         if(!funcLayoutDecoration)
             return;
 
-        auto entryPointLayout = dynamicCast<EntryPointLayout>(funcLayoutDecoration->getLayout());
+        auto entryPointLayout = as<EntryPointLayout>(funcLayoutDecoration->getLayout());
         SLANG_ASSERT(entryPointLayout);
         if(!entryPointLayout)
             return;
@@ -202,7 +202,7 @@ struct MoveEntryPointUniformParametersToGlobalScope
             SLANG_ASSERT(layoutDecoration);
             if(!layoutDecoration)
                 continue;
-            auto paramLayout = dynamicCast<VarLayout>(layoutDecoration->getLayout());
+            auto paramLayout = as<VarLayout>(layoutDecoration->getLayout());
             SLANG_ASSERT(paramLayout);
             if(!paramLayout)
                 continue;

--- a/source/slang/ir-glsl-legalize.cpp
+++ b/source/slang/ir-glsl-legalize.cpp
@@ -596,7 +596,7 @@ ScalarizedVal createGLSLGlobalVaryingsImpl(
 
         auto elementType = arrayType->getElementType();
         auto elementCount = arrayType->getElementCount();
-        auto arrayLayout = dynamicCast<ArrayTypeLayout>(typeLayout);
+        auto arrayLayout = as<ArrayTypeLayout>(typeLayout);
         SLANG_ASSERT(arrayLayout);
         auto elementTypeLayout = arrayLayout->elementTypeLayout;
 
@@ -619,7 +619,7 @@ ScalarizedVal createGLSLGlobalVaryingsImpl(
     else if( auto streamType = as<IRHLSLStreamOutputType>(type))
     {
         auto elementType = streamType->getElementType();
-        auto streamLayout = dynamicCast<StreamOutputTypeLayout>(typeLayout);
+        auto streamLayout = as<StreamOutputTypeLayout>(typeLayout);
         SLANG_ASSERT(streamLayout);
         auto elementTypeLayout = streamLayout->elementTypeLayout;
 
@@ -639,7 +639,7 @@ ScalarizedVal createGLSLGlobalVaryingsImpl(
         // We need to recurse down into the individual fields,
         // and generate a variable for each of them.
 
-        auto structTypeLayout = dynamicCast<StructTypeLayout>(typeLayout);
+        auto structTypeLayout = as<StructTypeLayout>(typeLayout);
         SLANG_ASSERT(structTypeLayout);
         RefPtr<ScalarizedTupleValImpl> tupleValImpl = new ScalarizedTupleValImpl();
 
@@ -1398,7 +1398,7 @@ void legalizeEntryPointForGLSL(
     auto layoutDecoration = func->findDecoration<IRLayoutDecoration>();
     SLANG_ASSERT(layoutDecoration);
 
-    auto entryPointLayout = dynamicCast<EntryPointLayout>(layoutDecoration->getLayout());
+    auto entryPointLayout = as<EntryPointLayout>(layoutDecoration->getLayout());
     SLANG_ASSERT(entryPointLayout);
 
     GLSLLegalizationContext context;
@@ -1524,7 +1524,7 @@ void legalizeEntryPointForGLSL(
             //
             auto paramLayoutDecoration = pp->findDecoration<IRLayoutDecoration>();
             SLANG_ASSERT(paramLayoutDecoration);
-            auto paramLayout = dynamicCast<VarLayout>(paramLayoutDecoration->getLayout());
+            auto paramLayout = as<VarLayout>(paramLayoutDecoration->getLayout());
             SLANG_ASSERT(paramLayout);
 
             legalizeEntryPointParameterForGLSL(

--- a/source/slang/ir-glsl-legalize.cpp
+++ b/source/slang/ir-glsl-legalize.cpp
@@ -596,7 +596,7 @@ ScalarizedVal createGLSLGlobalVaryingsImpl(
 
         auto elementType = arrayType->getElementType();
         auto elementCount = arrayType->getElementCount();
-        auto arrayLayout = dynamic_cast<ArrayTypeLayout*>(typeLayout);
+        auto arrayLayout = dynamicCast<ArrayTypeLayout>(typeLayout);
         SLANG_ASSERT(arrayLayout);
         auto elementTypeLayout = arrayLayout->elementTypeLayout;
 
@@ -619,7 +619,7 @@ ScalarizedVal createGLSLGlobalVaryingsImpl(
     else if( auto streamType = as<IRHLSLStreamOutputType>(type))
     {
         auto elementType = streamType->getElementType();
-        auto streamLayout = dynamic_cast<StreamOutputTypeLayout*>(typeLayout);
+        auto streamLayout = dynamicCast<StreamOutputTypeLayout>(typeLayout);
         SLANG_ASSERT(streamLayout);
         auto elementTypeLayout = streamLayout->elementTypeLayout;
 
@@ -639,7 +639,7 @@ ScalarizedVal createGLSLGlobalVaryingsImpl(
         // We need to recurse down into the individual fields,
         // and generate a variable for each of them.
 
-        auto structTypeLayout = dynamic_cast<StructTypeLayout*>(typeLayout);
+        auto structTypeLayout = dynamicCast<StructTypeLayout>(typeLayout);
         SLANG_ASSERT(structTypeLayout);
         RefPtr<ScalarizedTupleValImpl> tupleValImpl = new ScalarizedTupleValImpl();
 
@@ -1398,7 +1398,7 @@ void legalizeEntryPointForGLSL(
     auto layoutDecoration = func->findDecoration<IRLayoutDecoration>();
     SLANG_ASSERT(layoutDecoration);
 
-    auto entryPointLayout = dynamic_cast<EntryPointLayout*>(layoutDecoration->getLayout());
+    auto entryPointLayout = dynamicCast<EntryPointLayout>(layoutDecoration->getLayout());
     SLANG_ASSERT(entryPointLayout);
 
     GLSLLegalizationContext context;
@@ -1524,7 +1524,7 @@ void legalizeEntryPointForGLSL(
             //
             auto paramLayoutDecoration = pp->findDecoration<IRLayoutDecoration>();
             SLANG_ASSERT(paramLayoutDecoration);
-            auto paramLayout = dynamic_cast<VarLayout*>(paramLayoutDecoration->getLayout());
+            auto paramLayout = dynamicCast<VarLayout>(paramLayoutDecoration->getLayout());
             SLANG_ASSERT(paramLayout);
 
             legalizeEntryPointParameterForGLSL(

--- a/source/slang/ir-serialize.cpp
+++ b/source/slang/ir-serialize.cpp
@@ -131,7 +131,7 @@ Name* StringRepresentationCache::getName(Handle handle)
     Entry& entry = m_entries[int(handle)];
     if (entry.m_object)
     {
-        Name* name = dynamic_cast<Name*>(entry.m_object);
+        Name* name = dynamicCast<Name>(entry.m_object);
         if (name)
         {
             return name;
@@ -171,7 +171,7 @@ StringRepresentation* StringRepresentationCache::getStringRepresentation(Handle 
     Entry& entry = m_entries[int(handle)];
     if (entry.m_object)
     {
-        Name* name = dynamic_cast<Name*>(entry.m_object);
+        Name* name = dynamicCast<Name>(entry.m_object);
         if (name)
         {
             return name->text.getStringRepresentation();

--- a/source/slang/ir-union.cpp
+++ b/source/slang/ir-union.cpp
@@ -366,7 +366,7 @@ struct DesugarUnionTypesContext
             // there to be complete type layout information for the
             // types involved.
             //
-            auto structTypeLayout = dynamic_cast<StructTypeLayout*>(payloadTypeLayout);
+            auto structTypeLayout = dynamicCast<StructTypeLayout>(payloadTypeLayout);
             SLANG_ASSERT(structTypeLayout);
 
             // We are going to emit code to extract each of the fields
@@ -672,7 +672,7 @@ struct DesugarUnionTypesContext
         SLANG_ASSERT(layoutDecoration);
         auto layout = layoutDecoration->getLayout();
         SLANG_ASSERT(layout);
-        auto taggedUnionTypeLayout = dynamic_cast<TaggedUnionTypeLayout*>(layout);
+        auto taggedUnionTypeLayout = dynamicCast<TaggedUnionTypeLayout>(layout);
         SLANG_ASSERT(taggedUnionTypeLayout);
 
         info->taggedUnionTypeLayout = taggedUnionTypeLayout;

--- a/source/slang/ir-union.cpp
+++ b/source/slang/ir-union.cpp
@@ -366,7 +366,7 @@ struct DesugarUnionTypesContext
             // there to be complete type layout information for the
             // types involved.
             //
-            auto structTypeLayout = dynamicCast<StructTypeLayout>(payloadTypeLayout);
+            auto structTypeLayout = as<StructTypeLayout>(payloadTypeLayout);
             SLANG_ASSERT(structTypeLayout);
 
             // We are going to emit code to extract each of the fields
@@ -665,14 +665,14 @@ struct DesugarUnionTypesContext
         info->replacementInst = structType;
 
         // We require/expect the earlier code generation steps to have
-        // assocaited a layout with every tagged union that appears in
+        // associated a layout with every tagged union that appears in
         // the code.
         //
         auto layoutDecoration = type->findDecoration<IRLayoutDecoration>();
         SLANG_ASSERT(layoutDecoration);
         auto layout = layoutDecoration->getLayout();
         SLANG_ASSERT(layout);
-        auto taggedUnionTypeLayout = dynamicCast<TaggedUnionTypeLayout>(layout);
+        auto taggedUnionTypeLayout = as<TaggedUnionTypeLayout>(layout);
         SLANG_ASSERT(taggedUnionTypeLayout);
 
         info->taggedUnionTypeLayout = taggedUnionTypeLayout;

--- a/source/slang/legalize-types.cpp
+++ b/source/slang/legalize-types.cpp
@@ -109,7 +109,7 @@ ModuleDecl* findModuleForDecl(
 {
     for (auto dd = decl; dd; dd = dd->ParentDecl)
     {
-        if (auto moduleDecl = dynamicCast<ModuleDecl>(dd))
+        if (auto moduleDecl = as<ModuleDecl>(dd))
             return moduleDecl;
     }
     return nullptr;
@@ -945,7 +945,7 @@ RefPtr<TypeLayout> getDerefTypeLayout(
     if (!typeLayout)
         return nullptr;
 
-    if (auto parameterGroupTypeLayout = dynamicCast<ParameterGroupTypeLayout>(typeLayout))
+    if (auto parameterGroupTypeLayout = as<ParameterGroupTypeLayout>(typeLayout))
     {
         return parameterGroupTypeLayout->offsetElementTypeLayout;
     }
@@ -962,11 +962,11 @@ RefPtr<VarLayout> getFieldLayout(
 
     for(;;)
     {
-        if(auto arrayTypeLayout = dynamicCast<ArrayTypeLayout>(typeLayout))
+        if(auto arrayTypeLayout = as<ArrayTypeLayout>(typeLayout))
         {
             typeLayout = arrayTypeLayout->elementTypeLayout;
         }
-        else if(auto parameterGroupTypeLayout = dynamicCast<ParameterGroupTypeLayout>(typeLayout))
+        else if(auto parameterGroupTypeLayout = as<ParameterGroupTypeLayout>(typeLayout))
         {
             typeLayout = parameterGroupTypeLayout->offsetElementTypeLayout;
         }
@@ -977,7 +977,7 @@ RefPtr<VarLayout> getFieldLayout(
     }
 
 
-    if (auto structTypeLayout = dynamicCast<StructTypeLayout>(typeLayout))
+    if (auto structTypeLayout = as<StructTypeLayout>(typeLayout))
     {
         for(auto ff : structTypeLayout->fields)
         {

--- a/source/slang/legalize-types.cpp
+++ b/source/slang/legalize-types.cpp
@@ -109,7 +109,7 @@ ModuleDecl* findModuleForDecl(
 {
     for (auto dd = decl; dd; dd = dd->ParentDecl)
     {
-        if (auto moduleDecl = dynamic_cast<ModuleDecl*>(dd))
+        if (auto moduleDecl = dynamicCast<ModuleDecl>(dd))
             return moduleDecl;
     }
     return nullptr;
@@ -945,7 +945,7 @@ RefPtr<TypeLayout> getDerefTypeLayout(
     if (!typeLayout)
         return nullptr;
 
-    if (auto parameterGroupTypeLayout = dynamic_cast<ParameterGroupTypeLayout*>(typeLayout))
+    if (auto parameterGroupTypeLayout = dynamicCast<ParameterGroupTypeLayout>(typeLayout))
     {
         return parameterGroupTypeLayout->offsetElementTypeLayout;
     }
@@ -962,13 +962,13 @@ RefPtr<VarLayout> getFieldLayout(
 
     for(;;)
     {
-        if(auto arrayTypeLayout = dynamic_cast<ArrayTypeLayout*>(typeLayout))
+        if(auto arrayTypeLayout = dynamicCast<ArrayTypeLayout>(typeLayout))
         {
             typeLayout = arrayTypeLayout->elementTypeLayout;
         }
-        else if(auto parameterGroupTypeLayotu = dynamic_cast<ParameterGroupTypeLayout*>(typeLayout))
+        else if(auto parameterGroupTypeLayout = dynamicCast<ParameterGroupTypeLayout>(typeLayout))
         {
-            typeLayout = parameterGroupTypeLayotu->offsetElementTypeLayout;
+            typeLayout = parameterGroupTypeLayout->offsetElementTypeLayout;
         }
         else
         {
@@ -977,7 +977,7 @@ RefPtr<VarLayout> getFieldLayout(
     }
 
 
-    if (auto structTypeLayout = dynamic_cast<StructTypeLayout*>(typeLayout))
+    if (auto structTypeLayout = dynamicCast<StructTypeLayout>(typeLayout))
     {
         for(auto ff : structTypeLayout->fields)
         {

--- a/source/slang/lookup.cpp
+++ b/source/slang/lookup.cpp
@@ -45,7 +45,7 @@ void buildMemberDictionary(ContainerDecl* decl)
     decl->transparentMembers.Clear();
 
     // are we a generic?
-    GenericDecl* genericDecl = dynamicCast<GenericDecl>(decl);
+    GenericDecl* genericDecl = as<GenericDecl>(decl);
 
     for (auto m : decl->Members)
     {
@@ -84,21 +84,21 @@ void buildMemberDictionary(ContainerDecl* decl)
 bool DeclPassesLookupMask(Decl* decl, LookupMask mask)
 {
     // type declarations
-    if(auto aggTypeDecl = dynamicCast<AggTypeDecl>(decl))
+    if(auto aggTypeDecl = as<AggTypeDecl>(decl))
     {
         return int(mask) & int(LookupMask::type);
     }
-    else if(auto simpleTypeDecl = dynamicCast<SimpleTypeDecl>(decl))
+    else if(auto simpleTypeDecl = as<SimpleTypeDecl>(decl))
     {
         return int(mask) & int(LookupMask::type);
     }
     // function declarations
-    else if(auto funcDecl = dynamicCast<FunctionDeclBase>(decl))
+    else if(auto funcDecl = as<FunctionDeclBase>(decl))
     {
         return (int(mask) & int(LookupMask::Function)) != 0;
     }
     // attribute declaration
-    else if( auto attrDecl = dynamicCast<AttributeDecl>(decl) )
+    else if( auto attrDecl = as<AttributeDecl>(decl) )
     {
         return (int(mask) & int(LookupMask::Attribute)) != 0;
     }

--- a/source/slang/lookup.cpp
+++ b/source/slang/lookup.cpp
@@ -45,7 +45,7 @@ void buildMemberDictionary(ContainerDecl* decl)
     decl->transparentMembers.Clear();
 
     // are we a generic?
-    GenericDecl* genericDecl = dynamic_cast<GenericDecl*>(decl);
+    GenericDecl* genericDecl = dynamicCast<GenericDecl>(decl);
 
     for (auto m : decl->Members)
     {
@@ -84,21 +84,21 @@ void buildMemberDictionary(ContainerDecl* decl)
 bool DeclPassesLookupMask(Decl* decl, LookupMask mask)
 {
     // type declarations
-    if(auto aggTypeDecl = dynamic_cast<AggTypeDecl*>(decl))
+    if(auto aggTypeDecl = dynamicCast<AggTypeDecl>(decl))
     {
         return int(mask) & int(LookupMask::type);
     }
-    else if(auto simpleTypeDecl = dynamic_cast<SimpleTypeDecl*>(decl))
+    else if(auto simpleTypeDecl = dynamicCast<SimpleTypeDecl>(decl))
     {
         return int(mask) & int(LookupMask::type);
     }
     // function declarations
-    else if(auto funcDecl = dynamic_cast<FunctionDeclBase*>(decl))
+    else if(auto funcDecl = dynamicCast<FunctionDeclBase>(decl))
     {
         return (int(mask) & int(LookupMask::Function)) != 0;
     }
     // attribute declaration
-    else if( auto attrDecl = dynamic_cast<AttributeDecl*>(decl) )
+    else if( auto attrDecl = dynamicCast<AttributeDecl>(decl) )
     {
         return (int(mask) & int(LookupMask::Attribute)) != 0;
     }

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -389,7 +389,7 @@ ModuleDecl* findModuleDecl(Decl* decl)
 {
     for (auto dd = decl; dd; dd = dd->ParentDecl)
     {
-        if (auto moduleDecl = dynamicCast<ModuleDecl>(dd))
+        if (auto moduleDecl = as<ModuleDecl>(dd))
             return moduleDecl;
     }
     return nullptr;
@@ -1704,7 +1704,7 @@ static String getNameForNameHint(
         return String();
 
 
-    if(auto varDecl = dynamicCast<VarDeclBase>(decl))
+    if(auto varDecl = as<VarDeclBase>(decl))
     {
         // For an ordinary local variable, global variable,
         // parameter, or field, we will just use the name
@@ -1722,7 +1722,7 @@ static String getNameForNameHint(
     auto parentDecl = decl->ParentDecl;
 
     // Skip past a generic parent, if we are a declaration nested in a generic.
-    if(auto genericParentDecl = dynamicCast<GenericDecl>(parentDecl))
+    if(auto genericParentDecl = as<GenericDecl>(parentDecl))
         parentDecl = genericParentDecl->ParentDecl;
 
     auto parentName = getNameForNameHint(context, parentDecl);
@@ -2423,7 +2423,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         // In such a case we should be careful to not statically
         // resolve things.
         //
-        if(auto callableDecl = dynamicCast<CallableDecl>(declRefExpr->declRef.getDecl()))
+        if(auto callableDecl = as<CallableDecl>(declRefExpr->declRef.getDecl()))
         {
             // Okay, the declaration is directly callable, so we can continue.
         }
@@ -3387,13 +3387,13 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
 
         // Unwrap any surrounding `{ ... }` so we can look
         // at the statement inside.
-        while(auto blockStmt = dynamicCast<BlockStmt>(stmt))
+        while(auto blockStmt = as<BlockStmt>(stmt))
         {
             stmt = blockStmt->body;
             continue;
         }
 
-        if(auto seqStmt = dynamicCast<SeqStmt>(stmt))
+        if(auto seqStmt = as<SeqStmt>(stmt))
         {
             // Walk through teh children and process each.
             for(auto childStmt : seqStmt->stmts)
@@ -3401,7 +3401,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
                 lowerSwitchCases(childStmt, info);
             }
         }
-        else if(auto caseStmt = dynamicCast<CaseStmt>(stmt))
+        else if(auto caseStmt = as<CaseStmt>(stmt))
         {
             // A full `case` statement has a value we need
             // to test against. It is expected to be a
@@ -3429,7 +3429,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
             info->cases.Add(caseVal);
             info->cases.Add(label);
         }
-        else if(auto defaultStmt = dynamicCast<DefaultStmt>(stmt))
+        else if(auto defaultStmt = as<DefaultStmt>(stmt))
         {
             auto label = getLabelForCase(info);
 
@@ -3438,7 +3438,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
 
             info->defaultLabel = label;
         }
-        else if(auto emptyStmt = dynamicCast<EmptyStmt>(stmt))
+        else if(auto emptyStmt = as<EmptyStmt>(stmt))
         {
             // Special-case empty statements so they don't
             // mess up our "trivial fall-through" optimization.
@@ -4217,7 +4217,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // then we need to identify the type being extended.
         //
         RefPtr<Type> subType;
-        if (auto extParentDecl = dynamicCast<ExtensionDecl>(parentDecl))
+        if (auto extParentDecl = as<ExtensionDecl>(parentDecl))
         {
             subType = extParentDecl->targetType.type;
         }
@@ -4324,12 +4324,12 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
     bool isGlobalVarDecl(VarDecl* decl)
     {
         auto parent = decl->ParentDecl;
-        if (dynamicCast<ModuleDecl>(parent))
+        if (as<ModuleDecl>(parent))
         {
             // Variable declared at global scope? -> Global.
             return true;
         }
-        else if(dynamicCast<AggTypeDeclBase>(parent))
+        else if(as<AggTypeDeclBase>(parent))
         {
             if(decl->HasModifier<HLSLStaticModifier>())
             {
@@ -4344,7 +4344,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
     bool isMemberVarDecl(VarDecl* decl)
     {
         auto parent = decl->ParentDecl;
-        if (dynamicCast<AggTypeDecl>(parent))
+        if (as<AggTypeDecl>(parent))
         {
             // A variable declared inside of an aggregate type declaration is a member.
             return true;
@@ -4466,7 +4466,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // set correctly, so we can't just scan up and look
         // for a function in the parent chain...
         auto parent = decl->ParentDecl;
-        if( dynamicCast<ScopeDecl>(parent) )
+        if( as<ScopeDecl>(parent) )
         {
             return true;
         }
@@ -4538,7 +4538,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         for(auto pp = decl->ParentDecl; pp; pp = pp->ParentDecl)
         {
-            if(auto genericAncestor = dynamicCast<GenericDecl>(pp))
+            if(auto genericAncestor = as<GenericDecl>(pp))
             {
                 return defaultSpecializeOuterGeneric(parentVal, type, genericAncestor);
             }
@@ -5235,11 +5235,11 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                     direction = kParameterDirection_InOut;
                 }
 
-                if( auto aggTypeDecl = dynamicCast<AggTypeDecl>(parentDecl) )
+                if( auto aggTypeDecl = as<AggTypeDecl>(parentDecl) )
                 {
                     addThisParameter(direction, aggTypeDecl, ioParameterLists);
                 }
-                else if( auto extensionDecl = dynamicCast<ExtensionDecl>(parentDecl) )
+                else if( auto extensionDecl = as<ExtensionDecl>(parentDecl) )
                 {
                     addThisParameter(direction, extensionDecl->targetType, ioParameterLists);
                 }
@@ -5249,7 +5249,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // Once we've added any parameters based on parent declarations,
         // we can see if this declaration itself introduces parameters.
         //
-        if( auto callableDecl = dynamicCast<CallableDecl>(decl) )
+        if( auto callableDecl = as<CallableDecl>(decl) )
         {
             // Don't collect parameters from the outer scope if
             // we are in a `static` context.
@@ -5360,7 +5360,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
     {
         for(auto pp = decl->ParentDecl; pp; pp = pp->ParentDecl)
         {
-            if(auto genericAncestor = dynamicCast<GenericDecl>(pp))
+            if(auto genericAncestor = as<GenericDecl>(pp))
             {
                 return emitOuterGeneric(subContext, genericAncestor, leafDecl);
             }
@@ -5467,13 +5467,13 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         //
         // We compute a declaration to use for looking up the return type here:
         CallableDecl* declForReturnType = decl;
-        if (auto accessorDecl = dynamicCast<AccessorDecl>(decl))
+        if (auto accessorDecl = as<AccessorDecl>(decl))
         {
             // We are some kind of accessor, so the parent declaration should
             // know the correct return type to expose.
             //
             auto parentDecl = accessorDecl->ParentDecl;
-            if (auto subscriptDecl = dynamicCast<SubscriptDecl>(parentDecl))
+            if (auto subscriptDecl = as<SubscriptDecl>(parentDecl))
             {
                 declForReturnType = subscriptDecl;
             }
@@ -5529,7 +5529,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         auto irResultType = lowerType(subContext, declForReturnType->ReturnType);
 
-        if (auto setterDecl = dynamicCast<SetterDecl>(decl))
+        if (auto setterDecl = as<SetterDecl>(decl))
         {
             // We are lowering a "setter" accessor inside a subscript
             // declaration, which means we don't want to *return* the
@@ -5544,7 +5544,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             irResultType = subBuilder->getVoidType();
         }
 
-        if( auto refAccessorDecl = dynamicCast<RefAccessorDecl>(decl) )
+        if( auto refAccessorDecl = as<RefAccessorDecl>(decl) )
         {
             // A `ref` accessor needs to return a *pointer* to the value
             // being accessed, rather than a simple value.
@@ -5678,7 +5678,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                 }
             }
 
-            if (auto setterDecl = dynamicCast<SetterDecl>(decl))
+            if (auto setterDecl = as<SetterDecl>(decl))
             {
                 // Add the IR parameter for the new value
                 IRType* irParamType = irResultType;
@@ -5836,12 +5836,12 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // TODO: Need to be careful about how this is approached,
         // to avoid emitting a bunch of extra definitions in the IR.
 
-        auto primaryFuncDecl = dynamicCast<FunctionDeclBase>(primaryDecl);
+        auto primaryFuncDecl = as<FunctionDeclBase>(primaryDecl);
         SLANG_ASSERT(primaryFuncDecl);
         LoweredValInfo result = lowerFuncDecl(primaryFuncDecl);
         for (auto dd = primaryDecl->nextDecl; dd; dd = dd->nextDecl)
         {
-            auto funcDecl = dynamicCast<FunctionDeclBase>(dd);
+            auto funcDecl = as<FunctionDeclBase>(dd);
             SLANG_ASSERT(funcDecl);
             lowerFuncDecl(funcDecl);
         }
@@ -5919,7 +5919,7 @@ IRInst* lowerSubstitutionArg(
     {
         return lowerType(context, type);
     }
-    else if (auto declaredSubtypeWitness = dynamicCast<DeclaredSubtypeWitness>(val))
+    else if (auto declaredSubtypeWitness = as<DeclaredSubtypeWitness>(val))
     {
         // We need to look up the IR-level representation of the witness (which will be a witness table).
         auto irWitnessTable = getSimpleVal(
@@ -6161,7 +6161,7 @@ static void ensureAllDeclsRec(
     // Aggregate types are the main case where we can emit an outer declaration
     // and not the stuff nested inside of it.
     //
-    if(auto containerDecl = dynamicCast<AggTypeDecl>(decl))
+    if(auto containerDecl = as<AggTypeDecl>(decl))
     {
         for (auto memberDecl : containerDecl->Members)
         {

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -389,7 +389,7 @@ ModuleDecl* findModuleDecl(Decl* decl)
 {
     for (auto dd = decl; dd; dd = dd->ParentDecl)
     {
-        if (auto moduleDecl = dynamic_cast<ModuleDecl*>(dd))
+        if (auto moduleDecl = dynamicCast<ModuleDecl>(dd))
             return moduleDecl;
     }
     return nullptr;
@@ -1704,7 +1704,7 @@ static String getNameForNameHint(
         return String();
 
 
-    if(auto varDecl = dynamic_cast<VarDeclBase*>(decl))
+    if(auto varDecl = dynamicCast<VarDeclBase>(decl))
     {
         // For an ordinary local variable, global variable,
         // parameter, or field, we will just use the name
@@ -1722,7 +1722,7 @@ static String getNameForNameHint(
     auto parentDecl = decl->ParentDecl;
 
     // Skip past a generic parent, if we are a declaration nested in a generic.
-    if(auto genericParentDecl = dynamic_cast<GenericDecl*>(parentDecl))
+    if(auto genericParentDecl = dynamicCast<GenericDecl>(parentDecl))
         parentDecl = genericParentDecl->ParentDecl;
 
     auto parentName = getNameForNameHint(context, parentDecl);
@@ -2423,7 +2423,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         // In such a case we should be careful to not statically
         // resolve things.
         //
-        if(auto callableDecl = dynamic_cast<CallableDecl*>(declRefExpr->declRef.getDecl()))
+        if(auto callableDecl = dynamicCast<CallableDecl>(declRefExpr->declRef.getDecl()))
         {
             // Okay, the declaration is directly callable, so we can continue.
         }
@@ -3380,20 +3380,20 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
         // enclosing `switch`.
         //
         // For now we will assume that any `case` and `default`
-        // statements need to be direclty nested under the `switch`,
+        // statements need to be directly nested under the `switch`,
         // and so we can find them with a simpler walk.
 
         Stmt* stmt = inStmt;
 
         // Unwrap any surrounding `{ ... }` so we can look
         // at the statement inside.
-        while(auto blockStmt = dynamic_cast<BlockStmt*>(stmt))
+        while(auto blockStmt = dynamicCast<BlockStmt>(stmt))
         {
             stmt = blockStmt->body;
             continue;
         }
 
-        if(auto seqStmt = dynamic_cast<SeqStmt*>(stmt))
+        if(auto seqStmt = dynamicCast<SeqStmt>(stmt))
         {
             // Walk through teh children and process each.
             for(auto childStmt : seqStmt->stmts)
@@ -3401,7 +3401,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
                 lowerSwitchCases(childStmt, info);
             }
         }
-        else if(auto caseStmt = dynamic_cast<CaseStmt*>(stmt))
+        else if(auto caseStmt = dynamicCast<CaseStmt>(stmt))
         {
             // A full `case` statement has a value we need
             // to test against. It is expected to be a
@@ -3429,7 +3429,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
             info->cases.Add(caseVal);
             info->cases.Add(label);
         }
-        else if(auto defaultStmt = dynamic_cast<DefaultStmt*>(stmt))
+        else if(auto defaultStmt = dynamicCast<DefaultStmt>(stmt))
         {
             auto label = getLabelForCase(info);
 
@@ -3438,7 +3438,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
 
             info->defaultLabel = label;
         }
-        else if(auto emptyStmt = dynamic_cast<EmptyStmt*>(stmt))
+        else if(auto emptyStmt = dynamicCast<EmptyStmt>(stmt))
         {
             // Special-case empty statements so they don't
             // mess up our "trivial fall-through" optimization.
@@ -3446,7 +3446,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
         else
         {
             // We have an ordinary statement, that needs to get
-            // emitted to the currrent case block.
+            // emitted to the current case block.
             if(!info->currentCaseLabel)
             {
                 // It possible in full C/C++ to have statements
@@ -4217,7 +4217,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // then we need to identify the type being extended.
         //
         RefPtr<Type> subType;
-        if (auto extParentDecl = dynamic_cast<ExtensionDecl*>(parentDecl))
+        if (auto extParentDecl = dynamicCast<ExtensionDecl>(parentDecl))
         {
             subType = extParentDecl->targetType.type;
         }
@@ -4324,12 +4324,12 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
     bool isGlobalVarDecl(VarDecl* decl)
     {
         auto parent = decl->ParentDecl;
-        if (dynamic_cast<ModuleDecl*>(parent))
+        if (dynamicCast<ModuleDecl>(parent))
         {
             // Variable declared at global scope? -> Global.
             return true;
         }
-        else if(dynamic_cast<AggTypeDeclBase*>(parent))
+        else if(dynamicCast<AggTypeDeclBase>(parent))
         {
             if(decl->HasModifier<HLSLStaticModifier>())
             {
@@ -4344,7 +4344,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
     bool isMemberVarDecl(VarDecl* decl)
     {
         auto parent = decl->ParentDecl;
-        if (dynamic_cast<AggTypeDecl*>(parent))
+        if (dynamicCast<AggTypeDecl>(parent))
         {
             // A variable declared inside of an aggregate type declaration is a member.
             return true;
@@ -4466,7 +4466,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // set correctly, so we can't just scan up and look
         // for a function in the parent chain...
         auto parent = decl->ParentDecl;
-        if( dynamic_cast<ScopeDecl*>(parent) )
+        if( dynamicCast<ScopeDecl>(parent) )
         {
             return true;
         }
@@ -4538,7 +4538,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         for(auto pp = decl->ParentDecl; pp; pp = pp->ParentDecl)
         {
-            if(auto genericAncestor = dynamic_cast<GenericDecl*>(pp))
+            if(auto genericAncestor = dynamicCast<GenericDecl>(pp))
             {
                 return defaultSpecializeOuterGeneric(parentVal, type, genericAncestor);
             }
@@ -5235,11 +5235,11 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                     direction = kParameterDirection_InOut;
                 }
 
-                if( auto aggTypeDecl = dynamic_cast<AggTypeDecl*>(parentDecl) )
+                if( auto aggTypeDecl = dynamicCast<AggTypeDecl>(parentDecl) )
                 {
                     addThisParameter(direction, aggTypeDecl, ioParameterLists);
                 }
-                else if( auto extensionDecl = dynamic_cast<ExtensionDecl*>(parentDecl) )
+                else if( auto extensionDecl = dynamicCast<ExtensionDecl>(parentDecl) )
                 {
                     addThisParameter(direction, extensionDecl->targetType, ioParameterLists);
                 }
@@ -5249,7 +5249,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // Once we've added any parameters based on parent declarations,
         // we can see if this declaration itself introduces parameters.
         //
-        if( auto callableDecl = dynamic_cast<CallableDecl*>(decl) )
+        if( auto callableDecl = dynamicCast<CallableDecl>(decl) )
         {
             // Don't collect parameters from the outer scope if
             // we are in a `static` context.
@@ -5360,7 +5360,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
     {
         for(auto pp = decl->ParentDecl; pp; pp = pp->ParentDecl)
         {
-            if(auto genericAncestor = dynamic_cast<GenericDecl*>(pp))
+            if(auto genericAncestor = dynamicCast<GenericDecl>(pp))
             {
                 return emitOuterGeneric(subContext, genericAncestor, leafDecl);
             }
@@ -5467,13 +5467,13 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         //
         // We compute a declaration to use for looking up the return type here:
         CallableDecl* declForReturnType = decl;
-        if (auto accessorDecl = dynamic_cast<AccessorDecl*>(decl))
+        if (auto accessorDecl = dynamicCast<AccessorDecl>(decl))
         {
             // We are some kind of accessor, so the parent declaration should
             // know the correct return type to expose.
             //
             auto parentDecl = accessorDecl->ParentDecl;
-            if (auto subscriptDecl = dynamic_cast<SubscriptDecl*>(parentDecl))
+            if (auto subscriptDecl = dynamicCast<SubscriptDecl>(parentDecl))
             {
                 declForReturnType = subscriptDecl;
             }
@@ -5529,7 +5529,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         auto irResultType = lowerType(subContext, declForReturnType->ReturnType);
 
-        if (auto setterDecl = dynamic_cast<SetterDecl*>(decl))
+        if (auto setterDecl = dynamicCast<SetterDecl>(decl))
         {
             // We are lowering a "setter" accessor inside a subscript
             // declaration, which means we don't want to *return* the
@@ -5544,7 +5544,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             irResultType = subBuilder->getVoidType();
         }
 
-        if( auto refAccessorDecl = dynamic_cast<RefAccessorDecl*>(decl) )
+        if( auto refAccessorDecl = dynamicCast<RefAccessorDecl>(decl) )
         {
             // A `ref` accessor needs to return a *pointer* to the value
             // being accessed, rather than a simple value.
@@ -5678,7 +5678,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                 }
             }
 
-            if (auto setterDecl = dynamic_cast<SetterDecl*>(decl))
+            if (auto setterDecl = dynamicCast<SetterDecl>(decl))
             {
                 // Add the IR parameter for the new value
                 IRType* irParamType = irResultType;
@@ -5836,12 +5836,12 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // TODO: Need to be careful about how this is approached,
         // to avoid emitting a bunch of extra definitions in the IR.
 
-        auto primaryFuncDecl = dynamic_cast<FunctionDeclBase*>(primaryDecl);
+        auto primaryFuncDecl = dynamicCast<FunctionDeclBase>(primaryDecl);
         SLANG_ASSERT(primaryFuncDecl);
         LoweredValInfo result = lowerFuncDecl(primaryFuncDecl);
         for (auto dd = primaryDecl->nextDecl; dd; dd = dd->nextDecl)
         {
-            auto funcDecl = dynamic_cast<FunctionDeclBase*>(dd);
+            auto funcDecl = dynamicCast<FunctionDeclBase>(dd);
             SLANG_ASSERT(funcDecl);
             lowerFuncDecl(funcDecl);
         }
@@ -5915,11 +5915,11 @@ IRInst* lowerSubstitutionArg(
     IRGenContext*   context,
     Val*            val)
 {
-    if (auto type = dynamic_cast<Type*>(val))
+    if (auto type = dynamicCast<Type>(val))
     {
         return lowerType(context, type);
     }
-    else if (auto declaredSubtypeWitness = dynamic_cast<DeclaredSubtypeWitness*>(val))
+    else if (auto declaredSubtypeWitness = dynamicCast<DeclaredSubtypeWitness>(val))
     {
         // We need to look up the IR-level representation of the witness (which will be a witness table).
         auto irWitnessTable = getSimpleVal(
@@ -6161,7 +6161,7 @@ static void ensureAllDeclsRec(
     // Aggregate types are the main case where we can emit an outer declaration
     // and not the stuff nested inside of it.
     //
-    if(auto containerDecl = dynamic_cast<AggTypeDecl*>(decl))
+    if(auto containerDecl = dynamicCast<AggTypeDecl>(decl))
     {
         for (auto memberDecl : containerDecl->Members)
         {

--- a/source/slang/mangle.cpp
+++ b/source/slang/mangle.cpp
@@ -65,7 +65,7 @@ namespace Slang
         ManglingContext*    context,
         Val*                val)
     {
-        if( auto constVal = dynamic_cast<ConstantIntVal*>(val) )
+        if( auto constVal = dynamicCast<ConstantIntVal>(val) )
         {
             auto cVal = constVal->value;
             if(cVal >= 0 && cVal <= 9 )
@@ -112,17 +112,17 @@ namespace Slang
     {
         // TODO: actually implement this bit...
 
-        if( auto basicType = dynamic_cast<BasicExpressionType*>(type) )
+        if( auto basicType = dynamicCast<BasicExpressionType>(type) )
         {
             emitBaseType(context, basicType->baseType);
         }
-        else if( auto vecType = dynamic_cast<VectorExpressionType*>(type) )
+        else if( auto vecType = dynamicCast<VectorExpressionType>(type) )
         {
             emitRaw(context, "v");
             emitSimpleIntVal(context, vecType->elementCount);
             emitType(context, vecType->elementType);
         }
-        else if( auto matType = dynamic_cast<MatrixExpressionType*>(type) )
+        else if( auto matType = dynamicCast<MatrixExpressionType>(type) )
         {
             emitRaw(context, "m");
             emitSimpleIntVal(context, matType->getRowCount());
@@ -130,21 +130,21 @@ namespace Slang
             emitSimpleIntVal(context, matType->getColumnCount());
             emitType(context, matType->getElementType());
         }
-        else if( auto namedType = dynamic_cast<NamedExpressionType*>(type) )
+        else if( auto namedType = dynamicCast<NamedExpressionType>(type) )
         {
             emitType(context, GetType(namedType->declRef));
         }
-        else if( auto declRefType = dynamic_cast<DeclRefType*>(type) )
+        else if( auto declRefType = dynamicCast<DeclRefType>(type) )
         {
             emitQualifiedName(context, declRefType->declRef);
         }
-        else if (auto arrType = dynamic_cast<ArrayExpressionType*>(type))
+        else if (auto arrType = dynamicCast<ArrayExpressionType>(type))
         {
             emitRaw(context, "a");
             emitSimpleIntVal(context, arrType->ArrayLength);
             emitType(context, arrType->baseType);
         }
-        else if( auto taggedUnionType = dynamic_cast<TaggedUnionType*>(type) )
+        else if( auto taggedUnionType = dynamicCast<TaggedUnionType>(type) )
         {
             emitRaw(context, "u");
             for( auto caseType : taggedUnionType->caseTypes )
@@ -163,11 +163,11 @@ namespace Slang
         ManglingContext*    context,
         Val*                val)
     {
-        if( auto type = dynamic_cast<Type*>(val) )
+        if( auto type = dynamicCast<Type>(val) )
         {
             emitType(context, type);
         }
-        else if( auto witness = dynamic_cast<Witness*>(val) )
+        else if( auto witness = dynamicCast<Witness>(val) )
         {
             // We don't emit witnesses as part of a mangled
             // name, because the way that the front-end
@@ -182,7 +182,7 @@ namespace Slang
             // to mangle in the constraints even when
             // the whole thing is specialized...
         }
-        else if( auto genericParamIntVal = dynamic_cast<GenericParamIntVal*>(val) )
+        else if( auto genericParamIntVal = dynamicCast<GenericParamIntVal>(val) )
         {
             // TODO: we shouldn't be including the names of generic parameters
             // anywhere in mangled names, since changing parameter names
@@ -195,7 +195,7 @@ namespace Slang
             emitRaw(context, "K");
             emitName(context, genericParamIntVal->declRef.GetName());
         }
-        else if( auto constantIntVal = dynamic_cast<ConstantIntVal*>(val) )
+        else if( auto constantIntVal = dynamicCast<ConstantIntVal>(val) )
         {
             // TODO: need to figure out what prefix/suffix is needed
             // to allow demangling later.
@@ -386,18 +386,18 @@ namespace Slang
         //
         // Functions will get no prefix, since we assume
         // they are a common case:
-        if(dynamic_cast<FuncDecl*>(decl))
+        if(dynamicCast<FuncDecl>(decl))
         {}
         // Types will get a `T` prefix:
-        else if(dynamic_cast<AggTypeDecl*>(decl))
+        else if(dynamicCast<AggTypeDecl>(decl))
             emitRaw(context, "T");
-        else if(dynamic_cast<TypeDefDecl*>(decl))
+        else if(dynamicCast<TypeDefDecl>(decl))
             emitRaw(context, "T");
         // Variables will get a `V` prefix:
         //
         // TODO: probably need to pull constant-buffer
         // declarations out of this...
-        else if(dynamic_cast<VarDeclBase*>(decl))
+        else if(dynamicCast<VarDeclBase>(decl))
             emitRaw(context, "V");
         else
         {

--- a/source/slang/mangle.cpp
+++ b/source/slang/mangle.cpp
@@ -65,7 +65,7 @@ namespace Slang
         ManglingContext*    context,
         Val*                val)
     {
-        if( auto constVal = dynamicCast<ConstantIntVal>(val) )
+        if( auto constVal = as<ConstantIntVal>(val) )
         {
             auto cVal = constVal->value;
             if(cVal >= 0 && cVal <= 9 )
@@ -386,18 +386,18 @@ namespace Slang
         //
         // Functions will get no prefix, since we assume
         // they are a common case:
-        if(dynamicCast<FuncDecl>(decl))
+        if(as<FuncDecl>(decl))
         {}
         // Types will get a `T` prefix:
-        else if(dynamicCast<AggTypeDecl>(decl))
+        else if(as<AggTypeDecl>(decl))
             emitRaw(context, "T");
-        else if(dynamicCast<TypeDefDecl>(decl))
+        else if(as<TypeDefDecl>(decl))
             emitRaw(context, "T");
         // Variables will get a `V` prefix:
         //
         // TODO: probably need to pull constant-buffer
         // declarations out of this...
-        else if(dynamicCast<VarDeclBase>(decl))
+        else if(as<VarDeclBase>(decl))
             emitRaw(context, "V");
         else
         {

--- a/source/slang/mangle.cpp
+++ b/source/slang/mangle.cpp
@@ -296,15 +296,15 @@ namespace Slang
                 UInt genericParameterCount = 0;
                 for( auto mm : getMembers(parentGenericDeclRef) )
                 {
-                    if(as<GenericTypeParamDecl>(mm))
+                    if(mm.is<GenericTypeParamDecl>())
                     {
                         genericParameterCount++;
                     }
-                    else if(as<GenericValueParamDecl>(mm))
+                    else if(mm.is<GenericValueParamDecl>())
                     {
                         genericParameterCount++;
                     }
-                    else if(as<GenericTypeConstraintDecl>(mm))
+                    else if(mm.is<GenericTypeConstraintDecl>())
                     {
                         genericParameterCount++;
                     }

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -523,7 +523,7 @@ LayoutSemanticInfo ExtractLayoutSemanticInfo(
 
 
     UInt space = 0;
-    if( auto registerSemantic = dynamic_cast<HLSLRegisterSemantic*>(semantic) )
+    if( auto registerSemantic = dynamicCast<HLSLRegisterSemantic>(semantic) )
     {
         auto const& spaceName = registerSemantic->spaceName.Content;
         if(spaceName.size() != 0)
@@ -698,25 +698,25 @@ static bool validateValuesMatch(
     Val*                        right,
     StructuralTypeMatchStack*   stack)
 {
-    if( auto leftType = dynamic_cast<Type*>(left) )
+    if( auto leftType = dynamicCast<Type>(left) )
     {
-        if( auto rightType = dynamic_cast<Type*>(right) )
+        if( auto rightType = dynamicCast<Type>(right) )
         {
             return validateTypesMatch(context, leftType, rightType, stack);
         }
     }
 
-    if( auto leftInt = dynamic_cast<IntVal*>(left) )
+    if( auto leftInt = dynamicCast<IntVal>(left) )
     {
-        if( auto rightInt = dynamic_cast<IntVal*>(right) )
+        if( auto rightInt = dynamicCast<IntVal>(right) )
         {
             return validateIntValuesMatch(context, leftInt, rightInt, stack);
         }
     }
 
-    if( auto leftWitness = dynamic_cast<SubtypeWitness*>(left) )
+    if( auto leftWitness = dynamicCast<SubtypeWitness>(left) )
     {
-        if( auto rightWitness = dynamic_cast<SubtypeWitness*>(right) )
+        if( auto rightWitness = dynamicCast<SubtypeWitness>(right) )
         {
             return true;
         }

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -523,7 +523,7 @@ LayoutSemanticInfo ExtractLayoutSemanticInfo(
 
 
     UInt space = 0;
-    if( auto registerSemantic = dynamicCast<HLSLRegisterSemantic>(semantic) )
+    if( auto registerSemantic = as<HLSLRegisterSemantic>(semantic) )
     {
         auto const& spaceName = registerSemantic->spaceName.Content;
         if(spaceName.size() != 0)

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -795,7 +795,7 @@ namespace Slang
             return nullptr;
 
         auto decl = lookupResult.item.declRef.getDecl();
-        if( auto syntaxDecl = dynamic_cast<SyntaxDecl*>(decl) )
+        if( auto syntaxDecl = dynamicCast<SyntaxDecl>(decl) )
         {
             return syntaxDecl;
         }
@@ -1323,7 +1323,7 @@ namespace Slang
     static RefPtr<VarDeclBase> CreateVarDeclForContext(
         ContainerDecl*  containerDecl )
     {
-        if (dynamic_cast<CallableDecl*>(containerDecl))
+        if (dynamicCast<CallableDecl>(containerDecl))
         {
             // Function parameters always use their dedicated syntax class.
             //
@@ -1685,15 +1685,7 @@ namespace Slang
         if (!lookupResult.isValid() || lookupResult.isOverloaded())
             return false;
 
-        auto decl = lookupResult.item.declRef.getDecl();
-        if (auto genericDecl = dynamic_cast<GenericDecl*>(decl))
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
+        return lookupResult.item.declRef.is<GenericDecl>();
     }
 
     static RefPtr<Expr> tryParseGenericApp(
@@ -3321,11 +3313,11 @@ namespace Slang
             return false;
 
         auto decl = lookupResult.item.declRef.getDecl();
-        if( auto typeDecl = dynamic_cast<AggTypeDecl*>(decl) )
+        if( auto typeDecl = dynamicCast<AggTypeDecl>(decl) )
         {
             return true;
         }
-        else if( auto typeVarDecl = dynamic_cast<SimpleTypeDecl*>(decl) )
+        else if( auto typeVarDecl = dynamicCast<SimpleTypeDecl>(decl) )
         {
             return true;
         }

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -795,7 +795,7 @@ namespace Slang
             return nullptr;
 
         auto decl = lookupResult.item.declRef.getDecl();
-        if( auto syntaxDecl = dynamicCast<SyntaxDecl>(decl) )
+        if( auto syntaxDecl = as<SyntaxDecl>(decl) )
         {
             return syntaxDecl;
         }
@@ -1323,7 +1323,7 @@ namespace Slang
     static RefPtr<VarDeclBase> CreateVarDeclForContext(
         ContainerDecl*  containerDecl )
     {
-        if (dynamicCast<CallableDecl>(containerDecl))
+        if (as<CallableDecl>(containerDecl))
         {
             // Function parameters always use their dedicated syntax class.
             //
@@ -3313,11 +3313,11 @@ namespace Slang
             return false;
 
         auto decl = lookupResult.item.declRef.getDecl();
-        if( auto typeDecl = dynamicCast<AggTypeDecl>(decl) )
+        if( auto typeDecl = as<AggTypeDecl>(decl) )
         {
             return true;
         }
-        else if( auto typeVarDecl = dynamicCast<SimpleTypeDecl>(decl) )
+        else if( auto typeVarDecl = as<SimpleTypeDecl>(decl) )
         {
             return true;
         }

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -678,7 +678,7 @@ SLANG_API SlangReflectionVariableLayout* spReflectionTypeLayout_GetFieldByIndex(
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return nullptr;
 
-    if(auto structTypeLayout = dynamicCast<StructTypeLayout>(typeLayout))
+    if(auto structTypeLayout = as<StructTypeLayout>(typeLayout))
     {
         return (SlangReflectionVariableLayout*) structTypeLayout->fields[index].Ptr();
     }
@@ -691,7 +691,7 @@ SLANG_API size_t spReflectionTypeLayout_GetElementStride(SlangReflectionTypeLayo
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return 0;
 
-    if( auto arrayTypeLayout = dynamicCast<ArrayTypeLayout>(typeLayout))
+    if( auto arrayTypeLayout = as<ArrayTypeLayout>(typeLayout))
     {
         switch (category)
         {
@@ -726,15 +726,15 @@ SLANG_API SlangReflectionTypeLayout* spReflectionTypeLayout_GetElementTypeLayout
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return nullptr;
 
-    if( auto arrayTypeLayout = dynamicCast<ArrayTypeLayout>(typeLayout))
+    if( auto arrayTypeLayout = as<ArrayTypeLayout>(typeLayout))
     {
         return (SlangReflectionTypeLayout*) arrayTypeLayout->elementTypeLayout.Ptr();
     }
-    else if( auto constantBufferTypeLayout = dynamicCast<ParameterGroupTypeLayout>(typeLayout))
+    else if( auto constantBufferTypeLayout = as<ParameterGroupTypeLayout>(typeLayout))
     {
         return convert(constantBufferTypeLayout->offsetElementTypeLayout.Ptr());
     }
-    else if( auto structuredBufferTypeLayout = dynamicCast<StructuredBufferTypeLayout>(typeLayout))
+    else if( auto structuredBufferTypeLayout = as<StructuredBufferTypeLayout>(typeLayout))
     {
         return convert(structuredBufferTypeLayout->elementTypeLayout.Ptr());
     }
@@ -747,7 +747,7 @@ SLANG_API SlangReflectionVariableLayout* spReflectionTypeLayout_GetElementVarLay
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return nullptr;
 
-    if( auto constantBufferTypeLayout = dynamicCast<ParameterGroupTypeLayout>(typeLayout))
+    if( auto constantBufferTypeLayout = as<ParameterGroupTypeLayout>(typeLayout))
     {
         return convert(constantBufferTypeLayout->elementVarLayout.Ptr());
     }
@@ -779,7 +779,7 @@ static SlangParameterCategory getParameterCategory(
 
 static TypeLayout* maybeGetContainerLayout(TypeLayout* typeLayout)
 {
-    if (auto parameterGroupTypeLayout = dynamicCast<ParameterGroupTypeLayout>(typeLayout))
+    if (auto parameterGroupTypeLayout = as<ParameterGroupTypeLayout>(typeLayout))
     {
         auto containerTypeLayout = parameterGroupTypeLayout->containerVarLayout->typeLayout;
         if (containerTypeLayout->resourceInfos.Count() != 0)
@@ -826,7 +826,7 @@ SLANG_API SlangMatrixLayoutMode spReflectionTypeLayout_GetMatrixLayoutMode(Slang
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return SLANG_MATRIX_LAYOUT_MODE_UNKNOWN;
 
-    if( auto matrixLayout = dynamicCast<MatrixTypeLayout>(typeLayout) )
+    if( auto matrixLayout = as<MatrixTypeLayout>(typeLayout) )
     {
         return matrixLayout->mode;
     }
@@ -842,7 +842,7 @@ SLANG_API int spReflectionTypeLayout_getGenericParamIndex(SlangReflectionTypeLay
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return -1;
 
-    if(auto genericParamTypeLayout = dynamicCast<GenericParamTypeLayout>(typeLayout))
+    if(auto genericParamTypeLayout = as<GenericParamTypeLayout>(typeLayout))
     {
         return genericParamTypeLayout->paramIndex;
     }
@@ -1204,19 +1204,19 @@ SLANG_API void spReflectionEntryPoint_getComputeThreadGroupSize(
     else
     {
         // Fall back to the GLSL case, which requires a search over global-scope declarations
-        // to look for anything with the `local_size_*` qualifier
-        auto module = dynamicCast<ModuleDecl>(entryPointFunc->ParentDecl);
+        // to look for as with the `local_size_*` qualifier
+        auto module = as<ModuleDecl>(entryPointFunc->ParentDecl);
         if (module)
         {
             for (auto dd : module->Members)
             {
                 for (auto mod : dd->GetModifiersOfType<GLSLLocalSizeLayoutModifier>())
                 {
-                    if (auto xMod = dynamicCast<GLSLLocalSizeXLayoutModifier>(mod))
+                    if (auto xMod = as<GLSLLocalSizeXLayoutModifier>(mod))
                         sizeAlongAxis[0] = (SlangUInt) getIntegerLiteralValue(xMod->valToken);
-                    else if (auto yMod = dynamicCast<GLSLLocalSizeYLayoutModifier>(mod))
+                    else if (auto yMod = as<GLSLLocalSizeYLayoutModifier>(mod))
                         sizeAlongAxis[1] = (SlangUInt) getIntegerLiteralValue(yMod->valToken);
-                    else if (auto zMod = dynamicCast<GLSLLocalSizeZLayoutModifier>(mod))
+                    else if (auto zMod = as<GLSLLocalSizeZLayoutModifier>(mod))
                         sizeAlongAxis[2] = (SlangUInt) getIntegerLiteralValue(zMod->valToken);
                 }
             }

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -678,7 +678,7 @@ SLANG_API SlangReflectionVariableLayout* spReflectionTypeLayout_GetFieldByIndex(
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return nullptr;
 
-    if(auto structTypeLayout = dynamic_cast<StructTypeLayout*>(typeLayout))
+    if(auto structTypeLayout = dynamicCast<StructTypeLayout>(typeLayout))
     {
         return (SlangReflectionVariableLayout*) structTypeLayout->fields[index].Ptr();
     }
@@ -691,7 +691,7 @@ SLANG_API size_t spReflectionTypeLayout_GetElementStride(SlangReflectionTypeLayo
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return 0;
 
-    if( auto arrayTypeLayout = dynamic_cast<ArrayTypeLayout*>(typeLayout))
+    if( auto arrayTypeLayout = dynamicCast<ArrayTypeLayout>(typeLayout))
     {
         switch (category)
         {
@@ -726,15 +726,15 @@ SLANG_API SlangReflectionTypeLayout* spReflectionTypeLayout_GetElementTypeLayout
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return nullptr;
 
-    if( auto arrayTypeLayout = dynamic_cast<ArrayTypeLayout*>(typeLayout))
+    if( auto arrayTypeLayout = dynamicCast<ArrayTypeLayout>(typeLayout))
     {
         return (SlangReflectionTypeLayout*) arrayTypeLayout->elementTypeLayout.Ptr();
     }
-    else if( auto constantBufferTypeLayout = dynamic_cast<ParameterGroupTypeLayout*>(typeLayout))
+    else if( auto constantBufferTypeLayout = dynamicCast<ParameterGroupTypeLayout>(typeLayout))
     {
         return convert(constantBufferTypeLayout->offsetElementTypeLayout.Ptr());
     }
-    else if( auto structuredBufferTypeLayout = dynamic_cast<StructuredBufferTypeLayout*>(typeLayout))
+    else if( auto structuredBufferTypeLayout = dynamicCast<StructuredBufferTypeLayout>(typeLayout))
     {
         return convert(structuredBufferTypeLayout->elementTypeLayout.Ptr());
     }
@@ -747,7 +747,7 @@ SLANG_API SlangReflectionVariableLayout* spReflectionTypeLayout_GetElementVarLay
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return nullptr;
 
-    if( auto constantBufferTypeLayout = dynamic_cast<ParameterGroupTypeLayout*>(typeLayout))
+    if( auto constantBufferTypeLayout = dynamicCast<ParameterGroupTypeLayout>(typeLayout))
     {
         return convert(constantBufferTypeLayout->elementVarLayout.Ptr());
     }
@@ -779,7 +779,7 @@ static SlangParameterCategory getParameterCategory(
 
 static TypeLayout* maybeGetContainerLayout(TypeLayout* typeLayout)
 {
-    if (auto parameterGroupTypeLayout = dynamic_cast<ParameterGroupTypeLayout*>(typeLayout))
+    if (auto parameterGroupTypeLayout = dynamicCast<ParameterGroupTypeLayout>(typeLayout))
     {
         auto containerTypeLayout = parameterGroupTypeLayout->containerVarLayout->typeLayout;
         if (containerTypeLayout->resourceInfos.Count() != 0)
@@ -826,7 +826,7 @@ SLANG_API SlangMatrixLayoutMode spReflectionTypeLayout_GetMatrixLayoutMode(Slang
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return SLANG_MATRIX_LAYOUT_MODE_UNKNOWN;
 
-    if( auto matrixLayout = dynamic_cast<MatrixTypeLayout*>(typeLayout) )
+    if( auto matrixLayout = dynamicCast<MatrixTypeLayout>(typeLayout) )
     {
         return matrixLayout->mode;
     }
@@ -842,7 +842,7 @@ SLANG_API int spReflectionTypeLayout_getGenericParamIndex(SlangReflectionTypeLay
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return -1;
 
-    if(auto genericParamTypeLayout = dynamic_cast<GenericParamTypeLayout*>(typeLayout))
+    if(auto genericParamTypeLayout = dynamicCast<GenericParamTypeLayout>(typeLayout))
     {
         return genericParamTypeLayout->paramIndex;
     }
@@ -1205,18 +1205,18 @@ SLANG_API void spReflectionEntryPoint_getComputeThreadGroupSize(
     {
         // Fall back to the GLSL case, which requires a search over global-scope declarations
         // to look for anything with the `local_size_*` qualifier
-        auto module = dynamic_cast<ModuleDecl*>(entryPointFunc->ParentDecl);
+        auto module = dynamicCast<ModuleDecl>(entryPointFunc->ParentDecl);
         if (module)
         {
             for (auto dd : module->Members)
             {
                 for (auto mod : dd->GetModifiersOfType<GLSLLocalSizeLayoutModifier>())
                 {
-                    if (auto xMod = dynamic_cast<GLSLLocalSizeXLayoutModifier*>(mod))
+                    if (auto xMod = dynamicCast<GLSLLocalSizeXLayoutModifier>(mod))
                         sizeAlongAxis[0] = (SlangUInt) getIntegerLiteralValue(xMod->valToken);
-                    else if (auto yMod = dynamic_cast<GLSLLocalSizeYLayoutModifier*>(mod))
+                    else if (auto yMod = dynamicCast<GLSLLocalSizeYLayoutModifier>(mod))
                         sizeAlongAxis[1] = (SlangUInt) getIntegerLiteralValue(yMod->valToken);
-                    else if (auto zMod = dynamic_cast<GLSLLocalSizeZLayoutModifier*>(mod))
+                    else if (auto zMod = dynamicCast<GLSLLocalSizeZLayoutModifier>(mod))
                         sizeAlongAxis[2] = (SlangUInt) getIntegerLiteralValue(zMod->valToken);
                 }
             }

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -12,10 +12,8 @@ namespace Slang
 
     bool BasicExpressionType::EqualsImpl(Type * type)
     {
-        auto basicType = dynamic_cast<const BasicExpressionType*>(type);
-        if (basicType == nullptr)
-            return false;
-        return basicType->baseType == this->baseType;
+        auto basicType = dynamicCast<const BasicExpressionType>(type);
+        return basicType && basicType->baseType == this->baseType;
     }
 
     RefPtr<Type> BasicExpressionType::CreateCanonicalType()
@@ -130,7 +128,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     bool Type::EqualsVal(Val* val)
     {
-        if (auto type = dynamic_cast<Type*>(val))
+        if (auto type = dynamicCast<Type>(val))
             return const_cast<Type*>(this)->Equals(type);
         return false;
     }
@@ -455,7 +453,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
         SubtypeWitness* subtypeWitness,
         Decl*           requirementKey)
     {
-        if(auto declaredSubtypeWitness = dynamic_cast<DeclaredSubtypeWitness*>(subtypeWitness))
+        if(auto declaredSubtypeWitness = dynamicCast<DeclaredSubtypeWitness>(subtypeWitness))
         {
             if(auto inheritanceDeclRef = declaredSubtypeWitness->declRef.as<InheritanceDecl>())
             {
@@ -529,7 +527,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
         // the case we especially care about is when this type references a declaration
         // of a generic parameter, since that is what we might be substituting...
-        if (auto genericTypeParamDecl = dynamic_cast<GenericTypeParamDecl*>(declRef.getDecl()))
+        if (auto genericTypeParamDecl = dynamicCast<GenericTypeParamDecl>(declRef.getDecl()))
         {
             // search for a substitution that might apply to us
             for(auto s = subst.substitutions; s; s = s->outer)
@@ -567,7 +565,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
                 }
             }
         }
-        else if (auto globalGenParam = dynamic_cast<GlobalGenericParamDecl*>(declRef.getDecl()))
+        else if (auto globalGenParam = dynamicCast<GlobalGenericParamDecl>(declRef.getDecl()))
         {
             // search for a substitution that might apply to us
             for(auto s = subst.substitutions; s; s = s->outer)
@@ -1275,7 +1273,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     bool GenericParamIntVal::EqualsVal(Val* val)
     {
-        if (auto genericParamVal = dynamic_cast<GenericParamIntVal*>(val))
+        if (auto genericParamVal = dynamicCast<GenericParamIntVal>(val))
         {
             return declRef.Equals(genericParamVal->declRef);
         }
@@ -1365,7 +1363,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
         // both must be NULL, or non-NULL
         if (!this || !subst)
             return !this && !subst;
-        auto genericSubst = dynamic_cast<GenericSubstitution*>(subst);
+        auto genericSubst = dynamicCast<GenericSubstitution>(subst);
         if (!genericSubst)
             return false;
         if (genericDecl != genericSubst->genericDecl)
@@ -1415,7 +1413,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
         if (!subst)
             return false;
 
-        if (auto thisTypeSubst = dynamic_cast<ThisTypeSubstitution*>(subst))
+        if (auto thisTypeSubst = dynamicCast<ThisTypeSubstitution>(subst))
         {
             return witness->EqualsVal(thisTypeSubst->witness);
         }
@@ -1464,7 +1462,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
     {
         if (!subst)
             return false;
-        if (auto genSubst = dynamic_cast<GlobalGenericParamSubstitution*>(subst))
+        if (auto genSubst = dynamicCast<GlobalGenericParamSubstitution>(subst))
         {
             if (paramDecl != genSubst->paramDecl)
                 return false;
@@ -1900,7 +1898,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
         // to the parent declaration as were applied to the child.
         RefPtr<Substitutions> substToApply = substitutions.substitutions;
 
-        if(auto interfaceDecl = dynamic_cast<InterfaceDecl*>(decl))
+        if(auto interfaceDecl = dynamicCast<InterfaceDecl>(decl))
         {
             // The declaration being referenced is an `interface` declaration,
             // and there might be a this-type substitution in place.
@@ -1916,7 +1914,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             }
         }
 
-        if (auto parentGenericDecl = dynamic_cast<GenericDecl*>(parentDecl))
+        if (auto parentGenericDecl = dynamicCast<GenericDecl>(parentDecl))
         {
             // The parent of this declaration is a generic, which means
             // that the decl-ref to the current declaration might include
@@ -2152,7 +2150,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     bool TypeEqualityWitness::EqualsVal(Val* val)
     {
-        auto otherWitness = dynamic_cast<TypeEqualityWitness*>(val);
+        auto otherWitness = dynamicCast<TypeEqualityWitness>(val);
         if (!otherWitness)
             return false;
         return sub->Equals(otherWitness->sub);
@@ -2178,7 +2176,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     bool DeclaredSubtypeWitness::EqualsVal(Val* val)
     {
-        auto otherWitness = dynamic_cast<DeclaredSubtypeWitness*>(val);
+        auto otherWitness = dynamicCast<DeclaredSubtypeWitness>(val);
         if(!otherWitness)
             return false;
 
@@ -2347,7 +2345,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     bool TransitiveSubtypeWitness::EqualsVal(Val* val)
     {
-        auto otherWitness = dynamic_cast<TransitiveSubtypeWitness*>(val);
+        auto otherWitness = dynamicCast<TransitiveSubtypeWitness>(val);
         if(!otherWitness)
             return false;
 

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -453,7 +453,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
         SubtypeWitness* subtypeWitness,
         Decl*           requirementKey)
     {
-        if(auto declaredSubtypeWitness = dynamicCast<DeclaredSubtypeWitness>(subtypeWitness))
+        if(auto declaredSubtypeWitness = as<DeclaredSubtypeWitness>(subtypeWitness))
         {
             if(auto inheritanceDeclRef = declaredSubtypeWitness->declRef.as<InheritanceDecl>())
             {
@@ -527,7 +527,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
         // the case we especially care about is when this type references a declaration
         // of a generic parameter, since that is what we might be substituting...
-        if (auto genericTypeParamDecl = dynamicCast<GenericTypeParamDecl>(declRef.getDecl()))
+        if (auto genericTypeParamDecl = as<GenericTypeParamDecl>(declRef.getDecl()))
         {
             // search for a substitution that might apply to us
             for(auto s = subst.substitutions; s; s = s->outer)
@@ -565,7 +565,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
                 }
             }
         }
-        else if (auto globalGenParam = dynamicCast<GlobalGenericParamDecl>(declRef.getDecl()))
+        else if (auto globalGenParam = as<GlobalGenericParamDecl>(declRef.getDecl()))
         {
             // search for a substitution that might apply to us
             for(auto s = subst.substitutions; s; s = s->outer)
@@ -1273,7 +1273,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     bool GenericParamIntVal::EqualsVal(Val* val)
     {
-        if (auto genericParamVal = dynamicCast<GenericParamIntVal>(val))
+        if (auto genericParamVal = as<GenericParamIntVal>(val))
         {
             return declRef.Equals(genericParamVal->declRef);
         }
@@ -1363,7 +1363,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
         // both must be NULL, or non-NULL
         if (!this || !subst)
             return !this && !subst;
-        auto genericSubst = dynamicCast<GenericSubstitution>(subst);
+        auto genericSubst = as<GenericSubstitution>(subst);
         if (!genericSubst)
             return false;
         if (genericDecl != genericSubst->genericDecl)
@@ -1413,7 +1413,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
         if (!subst)
             return false;
 
-        if (auto thisTypeSubst = dynamicCast<ThisTypeSubstitution>(subst))
+        if (auto thisTypeSubst = as<ThisTypeSubstitution>(subst))
         {
             return witness->EqualsVal(thisTypeSubst->witness);
         }
@@ -1462,7 +1462,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
     {
         if (!subst)
             return false;
-        if (auto genSubst = dynamicCast<GlobalGenericParamSubstitution>(subst))
+        if (auto genSubst = as<GlobalGenericParamSubstitution>(subst))
         {
             if (paramDecl != genSubst->paramDecl)
                 return false;
@@ -1898,7 +1898,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
         // to the parent declaration as were applied to the child.
         RefPtr<Substitutions> substToApply = substitutions.substitutions;
 
-        if(auto interfaceDecl = dynamicCast<InterfaceDecl>(decl))
+        if(auto interfaceDecl = as<InterfaceDecl>(decl))
         {
             // The declaration being referenced is an `interface` declaration,
             // and there might be a this-type substitution in place.
@@ -1914,7 +1914,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             }
         }
 
-        if (auto parentGenericDecl = dynamicCast<GenericDecl>(parentDecl))
+        if (auto parentGenericDecl = as<GenericDecl>(parentDecl))
         {
             // The parent of this declaration is a generic, which means
             // that the decl-ref to the current declaration might include
@@ -2150,7 +2150,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     bool TypeEqualityWitness::EqualsVal(Val* val)
     {
-        auto otherWitness = dynamicCast<TypeEqualityWitness>(val);
+        auto otherWitness = as<TypeEqualityWitness>(val);
         if (!otherWitness)
             return false;
         return sub->Equals(otherWitness->sub);
@@ -2176,7 +2176,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     bool DeclaredSubtypeWitness::EqualsVal(Val* val)
     {
-        auto otherWitness = dynamicCast<DeclaredSubtypeWitness>(val);
+        auto otherWitness = as<DeclaredSubtypeWitness>(val);
         if(!otherWitness)
             return false;
 
@@ -2345,7 +2345,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     bool TransitiveSubtypeWitness::EqualsVal(Val* val)
     {
-        auto otherWitness = dynamicCast<TransitiveSubtypeWitness>(val);
+        auto otherWitness = as<TransitiveSubtypeWitness>(val);
         if(!otherWitness)
             return false;
 

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -226,7 +226,7 @@ namespace Slang
             for (;;)
             {
                 if (!m) return m;
-                if (dynamic_cast<T*>(m)) return m;
+                if (dynamicCast<T>(m)) return m;
                 m = m->next.Ptr();
             }
         }
@@ -1322,7 +1322,10 @@ namespace Slang
         for (;;)
         {
             if (!m) return m;
-            if (dynamic_cast<T*>(m)) return m;
+            if (dynamicCast<T>(m))
+            {
+                return m;
+            }
             m = m->next.Ptr();
         }        
     }

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -734,7 +734,7 @@ namespace Slang
         {
             for (; ptr != end; ptr++)
             {
-                if (as<T>(*ptr))
+                if (ptr->is<T>())
                 {
                     return ptr;
                 }

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -625,7 +625,7 @@ namespace Slang
         {
             while (cursor != end)
             {
-                if (dynamicCast<T>(*cursor))
+                if (as<T>(*cursor))
                     return cursor;
                 cursor++;
             }
@@ -1322,7 +1322,7 @@ namespace Slang
         for (;;)
         {
             if (!m) return m;
-            if (dynamicCast<T>(m))
+            if (as<T>(m))
             {
                 return m;
             }

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -2483,7 +2483,7 @@ RefPtr<TypeLayout> TypeLayout::unwrapArray()
 {
     TypeLayout* typeLayout = this;
 
-    while(auto arrayTypeLayout = dynamicCast<ArrayTypeLayout>(typeLayout))
+    while(auto arrayTypeLayout = as<ArrayTypeLayout>(typeLayout))
         typeLayout = arrayTypeLayout->elementTypeLayout;
 
     return typeLayout;

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -2483,7 +2483,7 @@ RefPtr<TypeLayout> TypeLayout::unwrapArray()
 {
     TypeLayout* typeLayout = this;
 
-    while(auto arrayTypeLayout = dynamic_cast<ArrayTypeLayout*>(typeLayout))
+    while(auto arrayTypeLayout = dynamicCast<ArrayTypeLayout>(typeLayout))
         typeLayout = arrayTypeLayout->elementTypeLayout;
 
     return typeLayout;


### PR DESCRIPTION
* Replace uses of dynamic_cast with dynamicCast (in slang)
* Replace uses of dynamicCast with as if no change in behavior and not ambiguous
* Use 'is' over dynamicCast/as where more suitable