### PR TITLE
Allow entry points to have explicit generic parameters

### DIFF
--- a/source/slang/compiler.cpp
+++ b/source/slang/compiler.cpp
@@ -127,6 +127,17 @@ namespace Slang
         return compileRequest->translationUnits[translationUnitIndex].Ptr();
     }
 
+    DeclRef<FuncDecl> EntryPointRequest::getFuncDeclRef()
+    {
+        return funcDeclRef;
+    }
+
+    RefPtr<FuncDecl> EntryPointRequest::getFuncDecl()
+    {
+        return getFuncDeclRef().getDecl();
+    }
+
+
     //
 
     Profile Profile::LookUp(char const* name)

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -152,7 +152,11 @@ namespace Slang
         // This will be filled in as part of semantic analysis;
         // it should not be assumed to be available in cases
         // where any errors were diagnosed.
-        RefPtr<FuncDecl> decl;
+        //
+        DeclRef<FuncDecl> funcDeclRef;
+
+        DeclRef<FuncDecl> getFuncDeclRef();
+        RefPtr<FuncDecl> getFuncDecl();
 
         RefPtr<Substitutions> globalGenericSubst;
 

--- a/source/slang/ir-link.cpp
+++ b/source/slang/ir-link.cpp
@@ -659,13 +659,29 @@ void cloneFunctionCommon(
     }
 }
 
+// We will forward-declare the subroutine for eagerly specializing
+// an IR-level generic to argument values, because `specializeIRForEntryPoint`
+// needs to perform this operation even though it is logically part of
+// the later generic specialization pass.
+//
+IRInst* specializeGeneric(
+    IRSpecialize*   specializeInst);
+
 IRFunc* specializeIRForEntryPoint(
     IRSpecContext*  context,
     EntryPointRequest*  entryPointRequest,
     EntryPointLayout*   entryPointLayout)
 {
-    // Look up the IR symbol by name
-    auto mangledName = getMangledName(entryPointRequest->decl);
+    // We start by looking up the IR symbol that
+    // matches the mangled name given to the
+    // function we want to emit.
+    //
+    // Note: the function decl-ref may refer to
+    // a specialization of a generic function,
+    // so that the mangled name of the decl-ref is
+    // not the same as the mangled name of the decl.
+    //
+    auto mangledName = getMangledName(entryPointRequest->getFuncDeclRef());
     RefPtr<IRSpecSymbol> sym;
     if (!context->getSymbols().TryGetValue(mangledName, sym))
     {
@@ -674,40 +690,63 @@ IRFunc* specializeIRForEntryPoint(
     }
 
     // TODO: deal with the case where we might
-    // have multiple versions...
+    // have multiple (profile-overloaded) versions...
+    //
+    auto originalVal = sym->irGlobalValue;
 
-    auto globalValue = sym->irGlobalValue;
-    if (globalValue->op != kIROp_Func)
+    // We will start by cloning the entry point reference
+    // like any other global value.
+    //
+    auto clonedVal = cloneGlobalValue(context, originalVal);
+
+    // In the case where the user is requesting a specialization
+    // of a generic entry point, we have a bit of a problem.
+    //
+    // This function is expected to return an `IRFunc` and
+    // subsequent passes expect to find, e.g., layout information
+    // attached to the parameters of such a func.
+    //
+    // In the generic case, the `clonedValue` won't be an
+    // `IRFunc`, but instead an `IRSpecialize`.
+    //
+    if(auto clonedSpec = as<IRSpecialize>(clonedVal))
     {
-        SLANG_UNEXPECTED("expected an IR function");
+        // The Right Thing to do here is to perform some
+        // amount of generic specialization, at least
+        // until we get back an `IRFunc`.
+        //
+        // The dangerous thing is that the generic specialization
+        // pass can, in principle, change the signature of
+        // functions, so that attaching parameter layout
+        // information *after* specialization might not work.
+        //
+        // The compromise we make here is to directly
+        // invoke the logic for specializing a generic.
+        //
+        // In theory this isn't valid, because there is no
+        // way we can register the specialized function we
+        // create so that it would be re-used by other instantiations
+        // with the same arguments (because we cannot be
+        // sure the generic arguments are themselves fully specialized)
+        //
+        // In practice this isn't really a problem, because
+        // we don't want to share the definition between
+        // an entry point and an ordinary function anyway.
+        //
+        clonedVal = specializeGeneric(clonedSpec);
+    }
+
+    auto clonedFunc = as<IRFunc>(clonedVal);
+    if(!clonedFunc)
+    {
+        SLANG_UNEXPECTED("expected entry point to be a function");
         return nullptr;
     }
-    auto originalFunc = (IRFunc*)globalValue;
-
-    // Create a clone for the IR function
-    auto clonedFunc = context->builder->createFunc();
-
-    // Note: we do *not* register this cloned declaration
-    // as the cloned value for the original symbol.
-    // This is kind of a kludge, but it ensures that
-    // in the unlikely case that the function is both
-    // used as an entry point and a callable function
-    // (yes, this would imply recursion...) we actually
-    // have two copies, which lets us arbitrarily
-    // transform the entry point to meet target requirements.
-    //
-    // TODO: The above statement is kind of bunk, though,
-    // because both versions of the function would have
-    // the same mangled name... :(
-
-    // We need to clone all the properties of the original
-    // function, including any blocks, their parameters,
-    // and their instructions.
-    cloneFunctionCommon(context, clonedFunc, originalFunc);
 
     // We need to attach the layout information for
     // the entry point to this declaration, so that
     // we can use it to inform downstream code emit.
+    //
     context->builder->addLayoutDecoration(
         clonedFunc,
         entryPointLayout);
@@ -1166,13 +1205,14 @@ struct IRSpecializationState
     }
 };
 
-IRSpecializationState* createIRSpecializationState(
+LinkedIR linkIR(
     EntryPointRequest*  entryPointRequest,
     ProgramLayout*      programLayout,
     CodeGenTarget       target,
     TargetRequest*      targetReq)
 {
-    IRSpecializationState* state = new IRSpecializationState();
+    IRSpecializationState stateStorage;
+    auto state = &stateStorage;
 
     state->programLayout = programLayout;
     state->target = target;
@@ -1232,6 +1272,8 @@ IRSpecializationState* createIRSpecializationState(
         context->globalVarLayouts.AddIfNotExists(mangledName, globalVarLayout);
     }
 
+    context->builder->setInsertInto(context->getModule()->getModuleInst());
+
     // for now, clone all unreferenced witness tables
     //
     // TODO: This step should *not* be needed with the current IR
@@ -1242,38 +1284,8 @@ IRSpecializationState* createIRSpecializationState(
         if (sym.Value->irGlobalValue->op == kIROp_WitnessTable)
             cloneGlobalValue(context, (IRWitnessTable*)sym.Value->irGlobalValue);
     }
-    return state;
-}
-
-void destroyIRSpecializationState(IRSpecializationState* state)
-{
-    delete state;
-}
-
-IRModule* getIRModule(IRSpecializationState* state)
-{
-    return state->irModule;
-}
-
-IRFunc* specializeIRForEntryPoint(
-    IRSpecializationState*  state,
-    EntryPointRequest*  entryPointRequest)
-{
-    auto translationUnit = entryPointRequest->getTranslationUnit();
-    auto originalIRModule = translationUnit->irModule;
-    if (!originalIRModule)
-    {
-        // We should already have emitted IR for the original
-        // translation unit, and it we don't have it, then
-        // we are now in trouble.
-        return nullptr;
-    }
-
-    auto context = state->getContext();
-    auto newProgramLayout = state->newProgramLayout;
 
     auto entryPointLayout = findEntryPointLayout(newProgramLayout, entryPointRequest);
-
 
     // Next, we make sure to clone the global value for
     // the entry point function itself, and rely on
@@ -1317,13 +1329,19 @@ IRFunc* specializeIRForEntryPoint(
         context->builder->addLayoutDecoration(clonedType, taggedUnionTypeLayout);
     }
 
-
-
     // TODO: *technically* we should consider the case where
     // we have global variables with initializers, since
     // these should get run whether or not the entry point
     // references them.
-    return irEntryPoint;
+
+    // Now that we've cloned the entry point and everything
+    // it refers to, we can package up the data we return
+    // to the caller.
+    //
+    LinkedIR linkedIR;
+    linkedIR.module = state->irModule;
+    linkedIR.entryPoint = irEntryPoint;
+    return linkedIR;
 }
 
 

--- a/source/slang/ir-link.h
+++ b/source/slang/ir-link.h
@@ -5,29 +5,22 @@
 
 namespace Slang
 {
-    // Interface to IR specialization for use when cloning target-specific
-    // IR as part of compiling an entry point.
+    struct LinkedIR
+    {
+        RefPtr<IRModule>    module;
+        IRFunc*             entryPoint;
+    };
 
-    // `IRSpecializationState` is used as an opaque type to wrap up all
-    // the data needed to perform IR specialization, without exposing
-    // implementation details.
-    struct IRSpecializationState;
-    IRSpecializationState* createIRSpecializationState(
-        EntryPointRequest*  entryPointRequest,
-        ProgramLayout*      programLayout,
-        CodeGenTarget       target,
-        TargetRequest*      targetReq);
-    void destroyIRSpecializationState(IRSpecializationState* state);
-    IRModule* getIRModule(IRSpecializationState* state);
-
-    struct ExtensionUsageTracker;
 
     // Clone the IR values reachable from the given entry point
     // into the IR module associated with the specialization state.
     // When multiple definitions of a symbol are found, the one
     // that is best specialized for the given `targetReq` will be
     // used.
-    IRFunc* specializeIRForEntryPoint(
-        IRSpecializationState*  state,
-        EntryPointRequest*  entryPointRequest);
+    //
+    LinkedIR linkIR(
+        EntryPointRequest*  entryPointRequest,
+        ProgramLayout*      programLayout,
+        CodeGenTarget       target,
+        TargetRequest*      targetReq);
 }

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -6103,25 +6103,38 @@ static void lowerEntryPointToIR(
     EntryPointRequest*  entryPointRequest)
 {
     // First, lower the entry point like an ordinary function
-    auto entryPointFuncDecl = entryPointRequest->decl;
-    if (!entryPointFuncDecl)
-    {
-        // Something must have gone wrong earlier, if we
-        // weren't able to associate a declaration with
-        // the entry point request.
-        return;
-    }
-    auto loweredEntryPointFunc = ensureDecl(context, entryPointFuncDecl);
+
+    auto session = context->getSession();
+    auto entryPointFuncDeclRef = entryPointRequest->getFuncDeclRef();
+    auto entryPointFuncType = lowerType(context, getFuncType(session, entryPointFuncDeclRef));
+
+    auto builder = context->irBuilder;
+    builder->setInsertInto(builder->getModule()->getModuleInst());
+
+    auto loweredEntryPointFunc = getSimpleVal(context,
+        emitDeclRef(context, entryPointFuncDeclRef, entryPointFuncType));
 
     // Attach a marker decoration so that we recognize
     // this as an entry point.
-    auto builder = context->irBuilder;
-    builder->addEntryPointDecoration(getSimpleVal(context, loweredEntryPointFunc));
+    //
+    // Note: We use `getResolvedInstForDecoration` here in
+    // case `loweredEntryPointFunc` refers to a `specialize`
+    // instruction that specialized a generic entry point
+    // (in which case we want to decorate the `IRFunc`
+    // that the generic returns).
+    //
+    builder->addEntryPointDecoration(
+        getResolvedInstForDecorations(loweredEntryPointFunc));
+
+    //
+    if(!loweredEntryPointFunc->findDecoration<IRLinkageDecoration>())
+    {
+        builder->addExportDecoration(loweredEntryPointFunc, getMangledName(entryPointFuncDeclRef).getUnownedSlice());
+    }
 
     // Now lower all the arguments supplied for global generic
     // type parameters.
     //
-    builder->setInsertInto(builder->getModule()->getModuleInst());
     for (RefPtr<Substitutions> subst = entryPointRequest->globalGenericSubst; subst; subst = subst->outer)
     {
         auto gSubst = subst.as<GlobalGenericParamSubstitution>();

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -2255,13 +2255,13 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
 static RefPtr<TypeLayout> computeEntryPointParameterTypeLayout(
     ParameterBindingContext*        context,
     SubstitutionSet                 typeSubst,
-    RefPtr<ParamDecl>               paramDecl,
+    DeclRef<ParamDecl>              paramDeclRef,
     RefPtr<VarLayout>               paramVarLayout,
     EntryPointParameterState&       state)
 {
-    auto paramType = paramDecl->type.type->Substitute(typeSubst).as<Type>();
+    auto paramType = GetType(paramDeclRef)->Substitute(typeSubst).as<Type>();
 
-    if( paramDecl->HasModifier<HLSLUniformModifier>() )
+    if( paramDeclRef.getDecl()->HasModifier<HLSLUniformModifier>() )
     {
         // An entry-point parameter that is explicitly marked `uniform` represents
         // a uniform shader parameter passed via the implicitly-defined
@@ -2283,21 +2283,24 @@ static RefPtr<TypeLayout> computeEntryPointParameterTypeLayout(
         state.directionMask = 0;
 
         // If it appears to be an input, process it as such.
-        if( paramDecl->HasModifier<InModifier>() || paramDecl->HasModifier<InOutModifier>() || !paramDecl->HasModifier<OutModifier>() )
+        if( paramDeclRef.getDecl()->HasModifier<InModifier>()
+            || paramDeclRef.getDecl()->HasModifier<InOutModifier>()
+            || !paramDeclRef.getDecl()->HasModifier<OutModifier>() )
         {
             state.directionMask |= kEntryPointParameterDirection_Input;
         }
 
         // If it appears to be an output, process it as such.
-        if(paramDecl->HasModifier<OutModifier>() || paramDecl->HasModifier<InOutModifier>())
+        if(paramDeclRef.getDecl()->HasModifier<OutModifier>()
+            || paramDeclRef.getDecl()->HasModifier<InOutModifier>())
         {
             state.directionMask |= kEntryPointParameterDirection_Output;
         }
 
         return processEntryPointVaryingParameterDecl(
             context,
-            paramDecl.Ptr(),
-            paramDecl->type.type->Substitute(typeSubst).as<Type>(),
+            paramDeclRef.getDecl(),
+            paramType,
             state,
             paramVarLayout);
     }
@@ -2460,22 +2463,14 @@ static void collectEntryPointParameters(
     EntryPointRequest*              entryPoint,
     SubstitutionSet                 typeSubst)
 {
-    FuncDecl* entryPointFuncDecl = entryPoint->decl;
-    if (!entryPointFuncDecl)
-    {
-        // Something must have failed earlier, so that
-        // we didn't find a declaration to match this
-        // entry point request.
-        //
-        return;
-    }
+    DeclRef<FuncDecl> entryPointFuncDeclRef = entryPoint->getFuncDeclRef();
 
     // We will take responsibility for creating and filling in
     // the `EntryPointLayout` object here.
     //
     RefPtr<EntryPointLayout> entryPointLayout = new EntryPointLayout();
     entryPointLayout->profile = entryPoint->profile;
-    entryPointLayout->entryPoint = entryPointFuncDecl;
+    entryPointLayout->entryPoint = entryPointFuncDeclRef.getDecl();
 
     // The entry point layout must be added to the output
     // program layout so that it can be accessed by reflection.
@@ -2522,12 +2517,12 @@ static void collectEntryPointParameters(
     scopeBuilder.beginLayout(context);
     auto paramsStructLayout = scopeBuilder.m_structLayout;
 
-    for( auto paramDecl : entryPointFuncDecl->getMembersOfType<ParamDecl>() )
+    for( auto paramDeclRef : getMembersOfType<ParamDecl>(entryPointFuncDeclRef) )
     {
         // Any error messages we emit during the process should
         // refer to the location of this parameter.
         //
-        state.loc = paramDecl->loc;
+        state.loc = paramDeclRef.getLoc();
 
         // We are going to construct the variable layout for this
         // parameter *before* computing the type layout, because
@@ -2536,13 +2531,13 @@ static void collectEntryPointParameters(
         // back onto the `VarLayout`.
         //
         RefPtr<VarLayout> paramVarLayout = new VarLayout();
-        paramVarLayout->varDecl = makeDeclRef(paramDecl.Ptr());
+        paramVarLayout->varDecl = paramDeclRef;
         paramVarLayout->stage = state.stage;
 
         auto paramTypeLayout = computeEntryPointParameterTypeLayout(
             context,
             typeSubst,
-            paramDecl,
+            paramDeclRef,
             paramVarLayout,
             state);
         paramVarLayout->typeLayout = paramTypeLayout;
@@ -2598,10 +2593,10 @@ static void collectEntryPointParameters(
     // TODO: Ideally we should make the layout process more robust to empty/void
     // types and apply this logic unconditionally.
     //
-    auto resultType = entryPointFuncDecl->ReturnType.type;
+    auto resultType = GetResultType(entryPointFuncDeclRef)->Substitute(typeSubst).as<Type>();
     if( !resultType->Equals(resultType->getSession()->getVoidType()) )
     {
-        state.loc = entryPointFuncDecl->loc;
+        state.loc = entryPointFuncDeclRef.getLoc();
         state.directionMask = kEntryPointParameterDirection_Output;
 
         RefPtr<VarLayout> resultLayout = new VarLayout();
@@ -2609,7 +2604,7 @@ static void collectEntryPointParameters(
 
         auto resultTypeLayout = processEntryPointVaryingParameterDecl(
             context,
-            entryPointFuncDecl,
+            entryPointFuncDeclRef.getDecl(),
             resultType->Substitute(typeSubst).as<Type>(),
             state,
             resultLayout);

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -1884,6 +1884,11 @@ void Type::accept(IValVisitor* visitor, void* extra)
         return decl->nameAndLoc.name;
     }
 
+    SourceLoc DeclRefBase::getLoc() const
+    {
+        return decl->loc;
+    }
+
     DeclRefBase DeclRefBase::GetParent() const
     {
         // Want access to the free function (the 'as' method by default gets priority)

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -482,6 +482,7 @@ namespace Slang
 
         // Convenience accessors for common properties of declarations
         Name* GetName() const;
+        SourceLoc getLoc() const;
         DeclRefBase GetParent() const;
 
         int GetHashCode() const;

--- a/tests/compute/global-type-param.slang
+++ b/tests/compute/global-type-param.slang
@@ -26,10 +26,8 @@ struct Impl : IBase
     }
 };
 
-__generic_param TImpl : IBase;
-
 [numthreads(1, 1, 1)]
-void computeMain(
+void computeMain<TImpl:IBase>(
     uniform TImpl impl,
     uint3 dispatchThreadID : SV_DispatchThreadID)
 {


### PR DESCRIPTION
Prior to this change, the Slang implementation required users to use global `type_param` declarations in order to specialize a full shader. For example:

```hlsl
type_param L : ILight;
ParameterBlock<L> gLight;

[shader("fragment")]
float4 fs(...)
{ ... gLight.doSomething() ... }
```

With this change we can rewrite code like the above using explicit generics, plus the ability to have `uniform` entry-point parameters:

```hlsl
[shader("fragment")]
float4 fs<L : ILight>(
    uniform ParameterBlock<L> light,
    ...)
{ ... light.doSomething() ... }
```

Having this support in place should make it possible for us to eliminate global generic type parameters and the complications they cause (both at a conceptual and implementation level).

The most central and visible piece of the change is that `EntryPointRequest` now holds a `DeclRef<FuncDecl>` instead of just ` RefPtr<FuncDecl>`, which allows it to refer to a specialization of a generic function.
Various places in the code that refer to the `EntryPointRequest::decl` member now use a `getFuncDecl()` or `getFuncDeclRef()` method as appropriate (see `compiler.h`).

In order to fill in the new data, the `findAndValidateEntryPoint` function has been greaterly overhauled.
The changes to its operation include:

* The by-name lookup step for the entry point function has been adapted to accept either a function or a generic function.

* The generic argument strings provided by API or command line are no longer parsed all the way to `Type`s, but instead just to `Expr`s in the first pass.

* There are now two cases for checking the global generic arguments against their matching parameters. The first case is the new one, where we plug the generic argument `Expr`s into the explicit generic parameters of an entry point (that case re-uses existing semantic checking logic).  The second case is the pre-existing code for dealing with global generic type arguments.

The `lower-to-ir.cpp` logic for hadling entry points then had to be extended. Making it deal with a full `DeclRef` instead of just a `Decl` was the easy part (just call `emitDeclRef` instead of `ensureDecl`).
The more interesting bits were:

* We need to carefully add the `IREntryPointDecoration` to the nested function and not the generic in the case where we have a generic entry point. There is a handy `getResolvedInstForDecorations` that can extract the return value for an IR generic so that we can decorate the right hting.

* We need to make sure that in the case where we emit a `specialize` instruction (which normally wouldn't get a linkage decoration), we attach an `[export(...)]` decoration to it with the mangled name of the decl-ref, so that it can be found during the linking step.

The IR linking step is then slightly more complicated because the mangled entry point name could either refer directly to an `IRFunc` or to a `specialize` instruction for a generic entry point. The logic was refactored to first clone the entry point symbol without concern for which case it is (the old code was specific to functions), and then *if* the result is a `specialize` instruction, we attempt to run generic specialization on-demand.

That on-demand specialization is a bit of a kludge, but it deals with the fact that all the downstream passing only expect to see an `IRFunc`. A future cleanup might try to split out that specialization step into its own pass, which ends up being a limited form of the specialization pass.

Since I was already having to touch a lot of the code around IR linking, I went ahead and refactored the signature of the operations. I eliminated the need for the caller to create, pass in, and then destroy an `IRSpecializationState` (really an IR *linking* state), and replaced it with a structure local to the pass (that data structure was a remnant of an older approach in the compiler), and then also renamed the main operation to `linkIR` to reflect what it is doing in our conceptual flow.

Smaller changes made along the way include:

* Refactored `visitGenericAppExpr` to create a subroutine `checkGenericAppWithCheckedArgs` so that it can be used by the entry-point validation logic described above).

* Refactored the declarations around the IR passes in `emitEntryPoint()` (`emit.cpp`), to show that things are more self-contained than they used to be (e.g., that the `TypeLegalizationContext` is now only needed by one pass).

* Refactored the generic specialization code so that there is a stand-along free function that can perform specialization on a `specialize` instruction without all the other context being required. This is only to support the limited specialization that needs to be done as part of linking.

* Updated the `global-type-param.slang` test to actually test entry-point generic parameters. In a later pass we can/should rework all the tests/examples for global type parameters over to use explicit entry-point generic parameters (at which point we should rename the tests as well). For now I am leaving thigns with just one test case, with the expectation that bugs will be found and ironed out as we expand to more tests.