### PR TITLE
Produce a better error message on errors in inheritance clauses

### DIFF
--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -2310,6 +2310,11 @@ namespace Slang
                     return;
                 }
             }
+            else if(base.type.is<ErrorType>())
+            {
+                // If an error was already produced, don't emit a cascading error.
+                return;
+            }
 
             // If type expression didn't name an interface, we'll emit an error here
             // TODO: deal with the case of an error in the type expression (don't cascade)


### PR DESCRIPTION
If I write:

```
struct Foo : IDoesntExist
{}
```

Then currently Slang complains first that `IDoesntExist` is an undefined identifier, then it complains that it expected an interface type in the inheritance clause. The second ("cascading") error isn't really helpful, because of *course* if something isn't defined it isn't an interface.

This change detects the case where the type expression is erroneous so that we avoid the cascading error.