### PR TITLE
Hotfix/remove null this work around

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -115,13 +115,13 @@ workspace "slang"
         architecture "ARM"
 
     filter { "toolset:clang or gcc*" }
-        buildoptions { "-Wno-unused-parameter", "-Wno-type-limits", "-Wno-sign-compare", "-Wno-unused-variable", "-Wno-reorder", "-Wno-switch", "-Wno-return-type", "-Wno-unused-local-typedefs", "-Wno-parentheses",  "-std=c++11", "-fvisibility=hidden" , "-fno-delete-null-pointer-checks", "-Wno-ignored-optimization-argument", "-Wno-unknown-warning-option"} 
+        buildoptions { "-Wno-unused-parameter", "-Wno-type-limits", "-Wno-sign-compare", "-Wno-unused-variable", "-Wno-reorder", "-Wno-switch", "-Wno-return-type", "-Wno-unused-local-typedefs", "-Wno-parentheses",  "-std=c++11", "-fvisibility=hidden" , "-Wno-ignored-optimization-argument", "-Wno-unknown-warning-option"} 
     	
 	filter { "toolset:gcc*"}
-		buildoptions { "-Wno-nonnull-compare", "-Wno-unused-but-set-variable", "-Wno-implicit-fallthrough"  }
+		buildoptions { "-Wno-unused-but-set-variable", "-Wno-implicit-fallthrough"  }
 		
     filter { "toolset:clang" }
-         buildoptions { "-Wno-deprecated-register", "-Wno-tautological-compare", "-Wno-missing-braces", "-Wno-undefined-var-template", "-Wno-unused-function", "-Wno-undefined-bool-conversion"}
+         buildoptions { "-Wno-deprecated-register", "-Wno-tautological-compare", "-Wno-missing-braces", "-Wno-undefined-var-template", "-Wno-unused-function"}
 		
     -- When compiling the debug configuration, we want to turn
     -- optimization off, make sure debug symbols are output,

--- a/source/slang/syntax-base-defs.h
+++ b/source/slang/syntax-base-defs.h
@@ -118,14 +118,13 @@ ABSTRACT_SYNTAX_CLASS(Substitutions, RefObject)
 
     // Check if these are equivalent substitutiosn to another set
     virtual bool Equals(Substitutions* subst) = 0;
-    virtual bool operator == (const Substitutions & subst) = 0;
     virtual int GetHashCode() const = 0;
     )
 END_SYNTAX_CLASS()
 
 SYNTAX_CLASS(GenericSubstitution, Substitutions)
     // The generic declaration that defines the
-    // parametesr we are binding to arguments
+    // parameters we are binding to arguments
     DECL_FIELD(GenericDecl*, genericDecl)
 
     // The actual values of the arguments
@@ -137,10 +136,7 @@ SYNTAX_CLASS(GenericSubstitution, Substitutions)
 
     // Check if these are equivalent substitutiosn to another set
     virtual bool Equals(Substitutions* subst) override;
-    virtual bool operator == (const Substitutions & subst) override
-    {
-        return Equals(const_cast<Substitutions*>(&subst));
-    }
+
     virtual int GetHashCode() const override
     {
         int rs = 0;
@@ -169,10 +165,7 @@ SYNTAX_CLASS(ThisTypeSubstitution, Substitutions)
 
     // Check if these are equivalent substitutiosn to another set
     virtual bool Equals(Substitutions* subst) override;
-    virtual bool operator == (const Substitutions & subst) override
-    {
-        return Equals(const_cast<Substitutions*>(&subst));
-    }
+
     virtual int GetHashCode() const override;
     )
 END_SYNTAX_CLASS()
@@ -201,10 +194,7 @@ RAW(
 
     // Check if these are equivalent substitutiosn to another set
     virtual bool Equals(Substitutions* subst) override;
-    virtual bool operator == (const Substitutions & subst) override
-    {
-        return Equals(const_cast<Substitutions*>(&subst));
-    }
+
     virtual int GetHashCode() const override
     {
         int rs = actualType->GetHashCode();
@@ -242,7 +232,7 @@ ABSTRACT_SYNTAX_CLASS(Modifier, SyntaxNode)
     )
 END_SYNTAX_CLASS()
 
-// A syntax node which can have modifiers appled
+// A syntax node which can have modifiers applied
 ABSTRACT_SYNTAX_CLASS(ModifiableSyntaxNode, SyntaxNode)
 
     SYNTAX_FIELD(Modifiers, modifiers)

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -330,7 +330,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
 
 
-    bool ArrayExpressionType::EqualsImpl(Type * type)
+    bool ArrayExpressionType::EqualsImpl(Type* type)
     {
         auto arrType = as<ArrayExpressionType>(type);
         if (!arrType)
@@ -1361,8 +1361,11 @@ void Type::accept(IValVisitor* visitor, void* extra)
     bool GenericSubstitution::Equals(Substitutions* subst)
     {
         // both must be NULL, or non-NULL
-        if (!this || !subst)
-            return !this && !subst;
+        if (subst == nullptr)
+            return false;
+        if (this == subst)
+            return true;
+
         auto genericSubst = as<GenericSubstitution>(subst);
         if (!genericSubst)
             return false;
@@ -1409,9 +1412,10 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
     bool ThisTypeSubstitution::Equals(Substitutions* subst)
     {
-        SLANG_ASSERT(this);
         if (!subst)
             return false;
+        if (subst == this)
+            return true;
 
         if (auto thisTypeSubst = as<ThisTypeSubstitution>(subst))
         {
@@ -1462,6 +1466,9 @@ void Type::accept(IValVisitor* visitor, void* extra)
     {
         if (!subst)
             return false;
+        if (subst == this)
+            return true;
+
         if (auto genSubst = as<GlobalGenericParamSubstitution>(subst))
         {
             if (paramDecl != genSubst->paramDecl)
@@ -2437,11 +2444,16 @@ void Type::accept(IValVisitor* visitor, void* extra)
         return name->text;
     }
 
-    bool SubstitutionSet::Equals(SubstitutionSet substSet) const
+    bool SubstitutionSet::Equals(const SubstitutionSet& substSet) const
     {
-        if(!substitutions || !substSet.substitutions)
-            return substitutions == substSet.substitutions;
-
+        if (substitutions == substSet.substitutions)
+        {
+            return true;
+        }
+        if (substitutions == nullptr || substSet.substitutions == nullptr)
+        {
+            return false;
+        }
         return substitutions->Equals(substSet.substitutions);
     }
 

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -417,7 +417,7 @@ namespace Slang
             : substitutions(subst)
         {
         }
-        bool Equals(SubstitutionSet substSet) const;
+        bool Equals(const SubstitutionSet& substSet) const;
         int GetHashCode() const;
     };
 


### PR DESCRIPTION
* Re-enable warnings around null this, previously disabled 
* Remove any remaining code that relies on tests for this