### PR TITLE
Track stage for varying sub-fields

### DIFF
--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -2016,6 +2016,19 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
     EntryPointParameterState const& state,
     RefPtr<VarLayout>               varLayout)
 {
+    // Make sure to associate a stage with every
+    // varying parameter (including sub-fields of
+    // `struct`-type parameters), since downstream
+    // code generation will need to look at the
+    // stage (possibly on individual leaf fields) to
+    // decide when to emit things like the `flat`
+    // interpolation modifier.
+    //
+    if( varLayout )
+    {
+        varLayout->stage = state.stage;
+    }
+
     // The default handling of varying parameters should not apply
     // to geometry shader output streams; they have their own special rules.
     if( auto gsStreamType = as<HLSLStreamOutputType>(type) )

--- a/tests/bugs/gh-841.slang
+++ b/tests/bugs/gh-841.slang
@@ -1,0 +1,19 @@
+// gh-841.slang
+
+//TEST:CROSS_COMPILE: -profile ps_5_0 -entry main -target spirv-assembly
+
+// GitHub issue #841: failing to emit `flat` modifier in output GLSL when required
+
+struct RasterVertex
+{
+	float4 c : COLOR;
+	uint u : FLAGS;
+};
+
+float4 main(RasterVertex v) : SV_Target
+{
+	float4 result = v.c;
+	if(v.u & 1)
+	    result += 1.0;
+   return result;
+}

--- a/tests/bugs/gh-841.slang.glsl
+++ b/tests/bugs/gh-841.slang.glsl
@@ -1,0 +1,35 @@
+//TEST_IGNORE_FILE:
+#version 450
+
+layout(location = 0)
+out vec4 _S1;
+
+layout(location = 0)
+in vec4 _S2;
+
+flat layout(location = 1)
+in uint _S3;
+
+struct RasterVertex_0
+{
+    vec4 c_0;
+    uint u_0;
+};
+
+void main()
+{
+    vec4 result_0;
+    RasterVertex_0 _S4 = RasterVertex_0(_S2, _S3);
+    vec4 result_1 = _S4.c_0;
+
+    if(bool(_S4.u_0 & uint(1)))
+    {
+        result_0 = result_1 + 1.0;
+    }
+    else
+    {
+        result_0 = result_1;
+    }
+    _S1 = result_0;
+    return;
+}

--- a/tests/reflection/sample-index-input.hlsl.expected
+++ b/tests/reflection/sample-index-input.hlsl.expected
@@ -29,6 +29,7 @@ standard output = {
                                         "scalarType": "float32"
                                     }
                                 },
+                                "stage": "fragment",
                                 "binding": {"kind": "varyingInput", "index": 0},
                                 "semanticName": "COLOR"
                             },

--- a/tests/reflection/sample-rate-input.hlsl.expected
+++ b/tests/reflection/sample-rate-input.hlsl.expected
@@ -29,6 +29,7 @@ standard output = {
                                         "scalarType": "float32"
                                     }
                                 },
+                                "stage": "fragment",
                                 "binding": {"kind": "varyingInput", "index": 0},
                                 "semanticName": "EXTRA"
                             },
@@ -42,6 +43,7 @@ standard output = {
                                         "scalarType": "float32"
                                     }
                                 },
+                                "stage": "fragment",
                                 "binding": {"kind": "varyingInput", "index": 1},
                                 "semanticName": "COLOR"
                             }

--- a/tests/reflection/vertex-input-semantics.hlsl.expected
+++ b/tests/reflection/vertex-input-semantics.hlsl.expected
@@ -44,6 +44,7 @@ standard output = {
                                         "scalarType": "int32"
                                     }
                                 },
+                                "stage": "vertex",
                                 "binding": {"kind": "varyingInput", "index": 0},
                                 "semanticName": "B"
                             },
@@ -63,6 +64,7 @@ standard output = {
                                                     "scalarType": "float32"
                                                 }
                                             },
+                                            "stage": "vertex",
                                             "binding": {"kind": "varyingInput", "index": 0},
                                             "semanticName": "B",
                                             "semanticIndex": 1
@@ -77,12 +79,14 @@ standard output = {
                                                     "scalarType": "float32"
                                                 }
                                             },
+                                            "stage": "vertex",
                                             "binding": {"kind": "varyingInput", "index": 1},
                                             "semanticName": "B",
                                             "semanticIndex": 2
                                         }
                                     ]
                                 },
+                                "stage": "vertex",
                                 "binding": {"kind": "varyingInput", "index": 1, "count": 2},
                                 "semanticName": "B",
                                 "semanticIndex": 1
@@ -114,6 +118,7 @@ standard output = {
                                                     "scalarType": "float32"
                                                 }
                                             },
+                                            "stage": "vertex",
                                             "binding": {"kind": "varyingInput", "index": 0},
                                             "semanticName": "CX"
                                         },
@@ -127,12 +132,14 @@ standard output = {
                                                     "scalarType": "float32"
                                                 }
                                             },
+                                            "stage": "vertex",
                                             "binding": {"kind": "varyingInput", "index": 1},
                                             "semanticName": "CX",
                                             "semanticIndex": 1
                                         }
                                     ]
                                 },
+                                "stage": "vertex",
                                 "binding": {"kind": "varyingInput", "index": 0, "count": 2},
                                 "semanticName": "CX"
                             },
@@ -146,6 +153,7 @@ standard output = {
                                         "scalarType": "int32"
                                     }
                                 },
+                                "stage": "vertex",
                                 "binding": {"kind": "varyingInput", "index": 2},
                                 "semanticName": "CY"
                             }


### PR DESCRIPTION
Fixes #841

This reverts a small change made in #815 that seemed innocent at the time: we stopped tracking an explicit `Stage` to go with every `VarLayout` that is part of an entry-point varying parameter, and instead only associated the stage with the top-level parameter. That change ended up breaking the logic to emit the `flat` modifier automatically for integer type fragment-shader inputs for GLSL, but we didn't have a regression test to catch that case.

This change adds a regression test to cover this case, and adds the small number of lines that were removed from `parameter-binding.cpp`.
A few other test outputs had to be updated for the change (these are outputs that were changed in #815 for the same reason).