### PR TITLE
Fix for Dx12 to stop crash when dxil cannot be handled by driver

### DIFF
--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -332,7 +332,8 @@ SlangResult RenderTestApp::initialize(Renderer* renderer, ShaderCompiler* shader
         }
     }
 
-    return SLANG_OK;
+    // If success must have a pipeline state
+    return m_pipelineState ? SLANG_OK : SLANG_FAIL;
 }
 
 Result RenderTestApp::initializeShaders(ShaderCompiler* shaderCompiler)

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -389,12 +389,8 @@ Result RenderTestApp::initializeShaders(ShaderCompiler* shaderCompiler)
 	}
 	compileRequest.entryPointTypeArguments = m_shaderInputLayout.globalTypeArguments;
 	m_shaderProgram = shaderCompiler->compileProgram(compileRequest);
-	if (!m_shaderProgram)
-	{
-		return SLANG_FAIL;
-	}
 
-	return SLANG_OK;
+    return m_shaderProgram ? SLANG_OK : SLANG_FAIL;
 }
 
 void RenderTestApp::renderFrame()


### PR DESCRIPTION
* Added test such that if m_pipelineState is not constructed an error is returned