### PR TITLE
Hotfix/device check review

### DIFF
--- a/source/slang/compiler.cpp
+++ b/source/slang/compiler.cpp
@@ -843,7 +843,7 @@ namespace Slang
 
 // Implementations in `dxc-support.cpp`
 
-int emitDXILForEntryPointUsingDXC(
+SlangResult emitDXILForEntryPointUsingDXC(
     BackEndCompileRequest*  compileRequest,
     EntryPoint*             entryPoint,
     Int                     entryPointIndex,

--- a/tools/gfx/flag-combiner.cpp
+++ b/tools/gfx/flag-combiner.cpp
@@ -38,7 +38,7 @@ uint32_t FlagCombiner::getCombination(int index) const
 
     uint32_t combination = 0;
     uint32_t bit = 1;
-    for (int i = 0; i < m_numChangingBits; ++i, bit += bit)
+    for (int i = m_numChangingBits - 1; i >= 0; --i, bit += bit)
     {
         combination |= ((bit & index) ? m_changingBits[i] : 0);
     }

--- a/tools/gfx/flag-combiner.h
+++ b/tools/gfx/flag-combiner.h
@@ -27,8 +27,16 @@ enum class ChangeType
 };
 
 /* Calculates all the combinations of flags as controlled by the change types.
-The earlier a flag/changeType is added increases the frequency the flag will change. This can be used to control the
-'importance' of a change, earlier added items will iterate through their combinations first.
+
+The order of adding flags can be considered to be like a nested loop
+for (first added) {
+    for (second added)
+    {
+        ///..
+    }
+}
+
+So the last added flags will have the highest frequency. 
 */
 class FlagCombiner
 {

--- a/tools/gfx/render-d3d11.cpp
+++ b/tools/gfx/render-d3d11.cpp
@@ -452,9 +452,6 @@ SlangResult D3D11Renderer::initialize(const Desc& desc, void* inWindowHandle)
         // with 11_1 and then back off to 11_0 if that fails.
 
         FlagCombiner combiner;
-        combiner.add(DeviceCheckFlag::UseFullFeatureLevel, ChangeType::OnOff);      ///< First try fully featured, then degrade features
-        combiner.add(DeviceCheckFlag::UseHardwareDevice, ChangeType::OnOff);        ///< First try hardware, then reference
-
         // TODO: we should probably provide a command-line option
         // to override UseDebug of default rather than leave it
         // up to each back-end to specify.
@@ -464,6 +461,8 @@ SlangResult D3D11Renderer::initialize(const Desc& desc, void* inWindowHandle)
 #else
         combiner.add(DeviceCheckFlag::UseDebug, ChangeType::Off);                   ///< Don't bother with debug
 #endif
+        combiner.add(DeviceCheckFlag::UseHardwareDevice, ChangeType::OnOff);        ///< First try hardware, then reference
+        combiner.add(DeviceCheckFlag::UseFullFeatureLevel, ChangeType::OnOff);      ///< First try fully featured, then degrade features
 
         const int numCombinations = combiner.getNumCombinations();
         Result res = SLANG_FAIL;

--- a/tools/gfx/render-d3d12.cpp
+++ b/tools/gfx/render-d3d12.cpp
@@ -1297,7 +1297,7 @@ Result D3D12Renderer::_createAdaptor(DeviceCheckFlags deviceCheckFlags, ComPtr<I
     ComPtr<IDXGIFactory4> dxgiFactory;
     SLANG_RETURN_ON_FAIL(m_CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(dxgiFactory.writeRef())));
     
-    D3D_FEATURE_LEVEL featureLevel = DeviceCheckFlag::UseFullFeatureLevel ? D3D_FEATURE_LEVEL_11_1 : D3D_FEATURE_LEVEL_11_0;
+    const D3D_FEATURE_LEVEL featureLevel = D3D_FEATURE_LEVEL_11_0;
 
     // Search for an adapter that meets our requirements
     ComPtr<IDXGIAdapter> adapter;
@@ -1361,7 +1361,7 @@ Result D3D12Renderer::initialize(const Desc& desc, void* inWindowHandle)
         return SLANG_FAIL;
     }
 
-    HMODULE dxgiModule = LoadLibraryA("Dxgi.dll");
+    HMODULE dxgiModule = LoadLibraryA("dxgi.dll");
     if (!dxgiModule)
     {
         fprintf(stderr, "error: failed load 'dxgi.dll'\n");
@@ -1398,19 +1398,16 @@ Result D3D12Renderer::initialize(const Desc& desc, void* inWindowHandle)
     }
 
     FlagCombiner combiner;
-    combiner.add(DeviceCheckFlag::UseFullFeatureLevel, ChangeType::OnOff);      ///< First try fully featured, then degrade features
-    combiner.add(DeviceCheckFlag::UseHardwareDevice, ChangeType::OnOff);        ///< First try hardware, then reference
-
     // TODO: we should probably provide a command-line option
     // to override UseDebug of default rather than leave it
     // up to each back-end to specify.
-
 #if ENABLE_DEBUG_LAYER
     combiner.add(DeviceCheckFlag::UseDebug, ChangeType::OnOff);                 ///< First try debug then non debug
 #else
     combiner.add(DeviceCheckFlag::UseDebug, ChangeType::Off);                   ///< Don't bother with debug
 #endif
-
+    combiner.add(DeviceCheckFlag::UseHardwareDevice, ChangeType::OnOff);        ///< First try hardware, then reference
+    
     ComPtr<IDXGIFactory4> dxgiFactory;
     ComPtr<IDXGIAdapter> adapter;
     const int numCombinations = combiner.getNumCombinations();


### PR DESCRIPTION
 * Inverted order of FlagCombiner (to make more 'nested for' like)
* On Dx12 just use D3D_FEATURE_LEVEL_11_0
* Fix typo on dll name
* Typo fix