### PR TITLE
#include not using search paths

### DIFF
--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -790,6 +790,13 @@ namespace Slang
         UInt getEntryPointReqCount() { return m_entryPointReqs.Count(); }
         FrontEndEntryPointRequest* getEntryPointReq(UInt index) { return m_entryPointReqs[index]; }
 
+        // Directories to search for `#include` files or `import`ed modules
+        // NOTE! That for now these search directories are not settable via the API
+        // so the search directories on Linkage is used for #include as well as for modules.
+        SearchDirectoryList searchDirectories;
+
+        SearchDirectoryList const& getSearchDirectories() { return searchDirectories; }
+
         // Definitions to provide during preprocessing
         Dictionary<String, String> preprocessorDefinitions;
 

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -790,11 +790,6 @@ namespace Slang
         UInt getEntryPointReqCount() { return m_entryPointReqs.Count(); }
         FrontEndEntryPointRequest* getEntryPointReq(UInt index) { return m_entryPointReqs[index]; }
 
-        // Directories to search for `#include` files or `import`ed modules
-        SearchDirectoryList searchDirectories;
-
-        SearchDirectoryList const& getSearchDirectories() { return searchDirectories; }
-
         // Definitions to provide during preprocessing
         Dictionary<String, String> preprocessorDefinitions;
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -587,8 +587,11 @@ void FrontEndCompileRequest::parseTranslationUnit(
     TranslationUnitRequest* translationUnit)
 {
     IncludeHandlerImpl includeHandler;
-    includeHandler.linkage = getLinkage();
-    includeHandler.searchDirectories = &searchDirectories;
+
+    auto linkage = getLinkage();
+
+    includeHandler.linkage = linkage;
+    includeHandler.searchDirectories = &linkage->searchDirectories;
 
     RefPtr<Scope> languageScope;
     switch (translationUnit->sourceLanguage)

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -590,6 +590,13 @@ void FrontEndCompileRequest::parseTranslationUnit(
 
     auto linkage = getLinkage();
 
+    // TODO(JS): NOTE! Here we are using the searchDirectories on the linkage. This is because
+    // currently the API only allows the setting search paths on linkage.
+    // 
+    // Here we should probably be using the searchDirectories on the FrontEndCompileRequest.
+    // If searchDirectories.parent pointed to the one in the Linkage would mean linkage paths
+    // would be checked too (after those on the FrontEndCompileRequest). 
+
     includeHandler.linkage = linkage;
     includeHandler.searchDirectories = &linkage->searchDirectories;
 

--- a/tests/preprocessor/include-search-path.slang
+++ b/tests/preprocessor/include-search-path.slang
@@ -1,0 +1,13 @@
+//TEST:SIMPLE: -Itests/preprocessor/include
+// #include support
+
+int foo() { return 0; }
+
+#include "pragma-once-c.h"
+
+// If include worked this will be defined
+#ifndef ONLY_DEFINED_ONCE_C
+// And so hitting this indicates and error (and will fail as bar isn't defined)
+int baz() { return bar(); }
+#endif
+

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -105,16 +105,16 @@ RefPtr<ShaderProgram> ShaderCompiler::compileProgram(
     for (auto typeName : request.entryPointGenericTypeArguments)
         rawEntryPointTypeNames.Add(typeName.Buffer());
 
-    UInt globalExistentialTypeCount = request.globalExistentialTypeArguments.Count();
-    for( UInt ii = 0; ii < globalExistentialTypeCount; ++ii )
+    const int globalExistentialTypeCount = int(request.globalExistentialTypeArguments.Count());
+    for(int ii = 0; ii < globalExistentialTypeCount; ++ii )
     {
         spSetTypeNameForGlobalExistentialSlot(slangRequest, ii, request.globalExistentialTypeArguments[ii].Buffer());
     }
 
-    UInt entryPointExistentialTypeCount = request.entryPointExistentialTypeArguments.Count();
+    const int entryPointExistentialTypeCount = int(request.entryPointExistentialTypeArguments.Count());
     auto setEntryPointExistentialTypeArgs = [&](int entryPoint)
     {
-        for( UInt ii = 0; ii < entryPointExistentialTypeCount; ++ii )
+        for( int ii = 0; ii < entryPointExistentialTypeCount; ++ii )
         {
             spSetTypeNameForEntryPointExistentialSlot(slangRequest, entryPoint, ii, request.entryPointExistentialTypeArguments[ii].Buffer());
         }


### PR DESCRIPTION
Search paths set using spSearchPath were not being used for #include. This is because there are now two sets of search paths one on the FrontEndCompileRequest and one on linkage. That the slang API only set the paths on Linkage. 

This meant that import (and the test for that) worked- because it used these search paths set on the linkage, but #include did not because it was empty. 

The fix for now was to make the #include use searchPaths on the Linkage. That a full fix probably needs to add/alter method to the slang API to set paths for the separate purposes.  