### PR TITLE
Hotfix/crash invalid vk binding

### DIFF
--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -2603,17 +2603,22 @@ namespace Slang
                 }
                 else if (auto bindingAttr = as<GLSLBindingAttribute>(attr))
                 {
-                    SLANG_ASSERT(attr->args.Count() == 2);
+                    // This must be vk::binding or gl::binding (as specified in core.meta.slang under vk_binding/gl_binding)
+                    // Must have 2 int parameters. Ideally this would all be checked from the specification
+                    // in core.meta.slang, but that's not completely unimplemented. So for now we check here.
+                    if (attr->args.Count() != 2)
+                    {
+                        return false;
+                    }
 
                     auto binding = checkConstantIntVal(attr->args[0]);
                     auto set = checkConstantIntVal(attr->args[1]);
 
-                    if (!binding || !set)
+                    if (binding == nullptr || set == nullptr)
                     {
-                        getSink()->diagnose(attr, Diagnostics::attributeExpectsTwoIntArgs, attr->name);
                         return false;
                     }
-
+                    
                     bindingAttr->binding = int32_t(binding->value);
                     bindingAttr->set = int32_t(set->value);
                 }
@@ -2709,6 +2714,11 @@ namespace Slang
                         getSink()->diagnose(attr, Diagnostics::invalidAttributeTarget);
                         return false;
                     }
+                }
+                else if (auto unrollAttr = as<UnrollAttribute>(attr))
+                {
+                    // Check has an argument
+                    SLANG_ASSERT(attr->args.Count() == 1);
                 }
                 else if (auto userDefAttr = as<UserDefinedAttribute>(attr))
                 {
@@ -2820,7 +2830,6 @@ namespace Slang
                 {
                     // TODO: support checking the argument against the declared
                     // type for the parameter.
-                    
                 }
                 else
                 {
@@ -2833,6 +2842,9 @@ namespace Slang
                         //
                         // TODO: we need to figure out how to hook up
                         // default arguments as needed.
+                        // For now just copy the expression over.
+
+                        attr->args.Add(paramDecl->initExpr);
                     }
                     else
                     {

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -2604,8 +2604,15 @@ namespace Slang
                 else if (auto bindingAttr = as<GLSLBindingAttribute>(attr))
                 {
                     SLANG_ASSERT(attr->args.Count() == 2);
+
                     auto binding = checkConstantIntVal(attr->args[0]);
                     auto set = checkConstantIntVal(attr->args[1]);
+
+                    if (!binding || !set)
+                    {
+                        getSink()->diagnose(attr, Diagnostics::attributeExpectsTwoIntArgs, attr->name);
+                        return false;
+                    }
 
                     bindingAttr->binding = int32_t(binding->value);
                     bindingAttr->set = int32_t(set->value);

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -2605,12 +2605,14 @@ namespace Slang
                 {
                     // This must be vk::binding or gl::binding (as specified in core.meta.slang under vk_binding/gl_binding)
                     // Must have 2 int parameters. Ideally this would all be checked from the specification
-                    // in core.meta.slang, but that's not completely unimplemented. So for now we check here.
+                    // in core.meta.slang, but that's not completely implemented. So for now we check here.
                     if (attr->args.Count() != 2)
                     {
                         return false;
                     }
 
+                    // TODO(JS): Prior validation currently doesn't ensure both args are ints (as specified in core.meta.slang), so check here
+                    // to make sure they both are
                     auto binding = checkConstantIntVal(attr->args[0]);
                     auto set = checkConstantIntVal(attr->args[1]);
 
@@ -2717,7 +2719,9 @@ namespace Slang
                 }
                 else if (auto unrollAttr = as<UnrollAttribute>(attr))
                 {
-                    // Check has an argument
+                    // Check has an argument. We need this because default behavior is to give an error
+                    // if an attribute has arguments, but not handled explicitly (and the default param will come through
+                    // as 1 arg if nothing is specified)
                     SLANG_ASSERT(attr->args.Count() == 1);
                 }
                 else if (auto userDefAttr = as<UserDefinedAttribute>(attr))

--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -259,6 +259,7 @@ DIAGNOSTIC(31005, Error, expectedSingleStringArg, "attribute '$0' expects a sing
 
 DIAGNOSTIC(31006, Error, attributeFunctionNotFound, "Could not find function '$0' for attribute'$1'")
 
+DIAGNOSTIC(31007, Error, attributeExpectsTwoIntArgs, "attribute '$0' expects two int arguments")
 
 DIAGNOSTIC(31100, Error, unknownStageName, "unknown stage name '$0'")
 DIAGNOSTIC(31120, Error, invalidAttributeTarget, "invalid syntax target for user defined attribute")

--- a/source/slang/diagnostic-defs.h
+++ b/source/slang/diagnostic-defs.h
@@ -259,8 +259,6 @@ DIAGNOSTIC(31005, Error, expectedSingleStringArg, "attribute '$0' expects a sing
 
 DIAGNOSTIC(31006, Error, attributeFunctionNotFound, "Could not find function '$0' for attribute'$1'")
 
-DIAGNOSTIC(31007, Error, attributeExpectsTwoIntArgs, "attribute '$0' expects two int arguments")
-
 DIAGNOSTIC(31100, Error, unknownStageName, "unknown stage name '$0'")
 DIAGNOSTIC(31120, Error, invalidAttributeTarget, "invalid syntax target for user defined attribute")
 

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -91,7 +91,7 @@ namespace Slang
         RefPtr<Scope> currentScope;
 
         TokenReader tokenReader;
-        DiagnosticSink * sink;
+        DiagnosticSink* sink;
         int genericDepth = 0;
 
         // Have we seen any `import` declarations? If so, we need
@@ -819,8 +819,12 @@ namespace Slang
         auto keywordToken = advanceToken(parser);
 
         RefPtr<RefObject> parsedObject = syntaxDecl->parseCallback(parser, syntaxDecl->parseUserData);
-        auto syntax = as<T>(parsedObject);
+        if (!parsedObject)
+        {
+            return false;
+        }
 
+        auto syntax = as<T>(parsedObject);
         if (syntax)
         {
             if (!syntax->loc.isValid())
@@ -4440,7 +4444,14 @@ namespace Slang
 
                 parser->ReadToken(TokenType::OpAssign);
 
+                // If the token asked for is not returned found will put in recovering state, and return token found
                 Token valToken = parser->ReadToken(TokenType::IntegerLiteral);
+                // If wasn't the desired IntegerLiteral return that couldn't parse
+                if (valToken.type != TokenType::IntegerLiteral)
+                {
+                    return nullptr;
+                }
+
                 // Work out the value
                 auto value = getIntegerLiteralValue(valToken);
 

--- a/tests/bugs/glsl-layout-define.hlsl
+++ b/tests/bugs/glsl-layout-define.hlsl
@@ -1,0 +1,5 @@
+//TEST:SIMPLE: -profile vs_5_0
+
+[[vk::binding(UNDEFINED_VK_BINDING, UNDEFINED_VK_SET)]]
+Texture2DArray<float4> Float4Texture2DArrays[] : register(t0, space100);
+

--- a/tests/bugs/glsl-layout-define.hlsl.expected
+++ b/tests/bugs/glsl-layout-define.hlsl.expected
@@ -1,0 +1,8 @@
+result code = -1
+standard error = {
+tests/bugs/glsl-layout-define.hlsl(3): error 30015: undefined identifier 'UNDEFINED_VK_BINDING'.
+tests/bugs/glsl-layout-define.hlsl(3): error 30015: undefined identifier 'UNDEFINED_VK_SET'.
+tests/bugs/glsl-layout-define.hlsl(3): error 31007: attribute 'vk_binding' expects two int arguments
+}
+standard output = {
+}

--- a/tests/bugs/glsl-layout-define.hlsl.expected
+++ b/tests/bugs/glsl-layout-define.hlsl.expected
@@ -1,8 +1,7 @@
 result code = -1
 standard error = {
-tests/bugs/glsl-layout-define.hlsl(3): error 30015: undefined identifier 'UNDEFINED_VK_BINDING'.
-tests/bugs/glsl-layout-define.hlsl(3): error 30015: undefined identifier 'UNDEFINED_VK_SET'.
-tests/bugs/glsl-layout-define.hlsl(3): error 31007: attribute 'vk_binding' expects two int arguments
+tests/bugs/glsl-layout-define.hlsl(3): error 20001: unexpected identifier, expected integer literal
+tests/bugs/glsl-layout-define.hlsl(3): error 20001: unexpected ')', expected ';'
 }
 standard output = {
 }

--- a/tests/bugs/glsl-vk-binding-define.hlsl
+++ b/tests/bugs/glsl-vk-binding-define.hlsl
@@ -1,5 +1,5 @@
 //TEST:SIMPLE: -profile vs_5_0
 
-layout(binding = UNDEFINED_VK_BINDING, set = UNDEFINED_VK_SET) 
+[[vk::binding(UNDEFINED_VK_BINDING, UNDEFINED_VK_SET)]]
 Texture2DArray<float4> Float4Texture2DArrays[] : register(t0, space100);
 

--- a/tests/bugs/glsl-vk-binding-define.hlsl.expected
+++ b/tests/bugs/glsl-vk-binding-define.hlsl.expected
@@ -1,0 +1,7 @@
+result code = -1
+standard error = {
+tests/bugs/glsl-vk-binding-define.hlsl(3): error 30015: undefined identifier 'UNDEFINED_VK_BINDING'.
+tests/bugs/glsl-vk-binding-define.hlsl(3): error 30015: undefined identifier 'UNDEFINED_VK_SET'.
+}
+standard output = {
+}

--- a/tests/diagnostics/vk-bindings.slang
+++ b/tests/diagnostics/vk-bindings.slang
@@ -5,6 +5,9 @@
 // D3D `register` without VK binding
 Texture2D t : register(t0);
 
+[[vk::binding(3)]]
+Texture2D t1 : register(t3);
+
 struct S { float4 a; };
 
 // Parameter block with non-zero binding:

--- a/tests/diagnostics/vk-bindings.slang.expected
+++ b/tests/diagnostics/vk-bindings.slang.expected
@@ -1,7 +1,7 @@
 result code = -1
 standard error = {
 tests/diagnostics/vk-bindings.slang(6): warning 39013: shader parameter 't' has a 'register' specified for D3D, but no '[[vk::binding(...)]]` specified for Vulkan
-tests/diagnostics/vk-bindings.slang(11): error 39015: shader parameter 'b' consumes whole descriptor sets, so the binding must be in the form '[[vk::binding(0, ...)]]'; the non-zero binding '2' is not allowed
+tests/diagnostics/vk-bindings.slang(14): error 39015: shader parameter 'b' consumes whole descriptor sets, so the binding must be in the form '[[vk::binding(0, ...)]]'; the non-zero binding '2' is not allowed
 }
 standard output = {
 }


### PR DESCRIPTION
* Check that there are 2 int args on vk::binding + added diagnostic 
* Added test 