### PR TITLE
Fix a 64-bit issue in our Windows UI code

### DIFF
--- a/tools/gfx/window.cpp
+++ b/tools/gfx/window.cpp
@@ -173,7 +173,7 @@ static LRESULT CALLBACK windowProc(
             window = (Window*) createInfo->lpCreateParams;
             window->handle = windowHandle;
 
-            SetWindowLongPtrW(windowHandle, GWLP_USERDATA, (LONG)size_t(window));
+            SetWindowLongPtrW(windowHandle, GWLP_USERDATA, (LONG_PTR) window);
         }
         break;
 


### PR DESCRIPTION
Fixes issue #874

The problem here was that a pointer was being cast to `LONG` so that it could be used with the `SetWindowLongPtr` API, but that API actually expects a `LONG_PTR`. Since `LONG` is a 32-bit type on 64-bit Windows, the pointer we stored was getting truncated, leading to crashes.

I'm kind of surprised this wasn't biting more of our applications (e.g., the render tests).