### PR TITLE
Properly initialize m_modulesBeingImported otherwize it will segfault

### DIFF
--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -710,7 +710,7 @@ namespace Slang
         };
 
         // Any modules currently being imported will be listed here
-        ModuleBeingImportedRAII* m_modulesBeingImported;
+        ModuleBeingImportedRAII* m_modulesBeingImported = nullptr;
 
             /// Is the given module in the middle of being imported?
         bool isBeingImported(Module* module);


### PR DESCRIPTION
If this pointer is non-zero, Linkage::isBeingImported triggers a crash when the function accesses this pointer.