### PR TITLE
Fix `spReflection_FindTypeByName`

### DIFF
--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -592,7 +592,8 @@ SLANG_API SlangReflectionType * spReflection_FindTypeByName(SlangReflection * re
     // when type lookup fails.
     //
     Slang::DiagnosticSink sink;
-
+    
+    sink.sourceManager = programLayout->getTargetReq()->getLinkage()->getSourceManager();;
     RefPtr<Type> result = program->getTypeFromString(name, &sink);
     return (SlangReflectionType*)result.Ptr();
 }

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -557,7 +557,7 @@ Type* Program::getTypeFromString(String typeStr, DiagnosticSink* sink)
         RefPtr<Expr> typeExpr = linkage->parseTypeString(
             typeStr, s);
         type = checkProperType(linkage, TypeExp(typeExpr), sink);
-        if(type)
+        if (type && !type.as<ErrorType>())
             break;
     }
     if( type )


### PR DESCRIPTION
`FindTypeByName` is broken by some recent changes. This PR fixes the issue.

The existing implementation works by trying to type check user's string by placing the newly constructed `Expr` under the scope of each loaded `Module`. If the `Expr` failed to type check, the diagnostic message will be written to a temp `DiagnosticSink`. This `DiagnosticSink` must be initialized with `sourceManager`, or the compiler will crash.

The new `checkProperType` function will no longer return `nullptr` when it fails, instead it will now return `ErrorType`, so `Program::getTypeFromString` must change accordingly.