### PR TITLE
Fix GLSL emit logic for select expr

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -3959,14 +3959,29 @@ struct EmitVisitor
 
         case kIROp_Select:
             {
-                auto prec = kEOp_Conditional;
-                needClose = maybeEmitParens(outerPrec, prec);
+                if (getTarget(ctx) == CodeGenTarget::GLSL &&
+                    inst->getOperand(0)->getDataType()->op != kIROp_BoolType)
+                {
+                    // For GLSL, emit a call to `mix` if condition is a vector
+                    emit("mix(");
+                    emitIROperand(ctx, inst->getOperand(2), mode, leftSide(kEOp_General, kEOp_General));
+                    emit(", ");
+                    emitIROperand(ctx, inst->getOperand(1), mode, leftSide(kEOp_General, kEOp_General));
+                    emit(", ");
+                    emitIROperand(ctx, inst->getOperand(0), mode, leftSide(kEOp_General, kEOp_General));
+                    emit(")");
+                }
+                else
+                {
+                    auto prec = kEOp_Conditional;
+                    needClose = maybeEmitParens(outerPrec, prec);
 
-                emitIROperand(ctx, inst->getOperand(0), mode, leftSide(outerPrec, prec));
-                emit(" ? ");
-                emitIROperand(ctx, inst->getOperand(1), mode, prec);
-                emit(" : ");
-                emitIROperand(ctx, inst->getOperand(2), mode, rightSide(prec, outerPrec));
+                    emitIROperand(ctx, inst->getOperand(0), mode, leftSide(outerPrec, prec));
+                    emit(" ? ");
+                    emitIROperand(ctx, inst->getOperand(1), mode, prec);
+                    emit(" : ");
+                    emitIROperand(ctx, inst->getOperand(2), mode, rightSide(prec, outerPrec));
+                }
             }
             break;
 

--- a/tests/cross-compile/vector-comparison.slang
+++ b/tests/cross-compile/vector-comparison.slang
@@ -1,0 +1,24 @@
+// vector-comparison.slang
+
+//TEST:CROSS_COMPILE:-target spirv-assembly -entry main -stage fragment
+
+// This test ensures that we cross-compile vector comparison operators
+// correctly to GLSL
+
+struct Param
+{
+    float4 a, b;
+};
+ParameterBlock<Param> params;
+float4 main() : SV_Target
+{
+    float4 v0 = params.a;
+    float4 v1 = params.b;
+    float4 result = v0 == v1 ? float4(2.0f) : float4(3.0f);
+    result += v0 < v1 ? float4(2.0f) : float4(3.0f);
+    result += v0 > v1 ? float4(2.0f) : float4(3.0f);
+    result += v0 <= v1 ? float4(2.0f) : float4(3.0f);
+    result += v0 >= v1 ? float4(2.0f) : float4(3.0f);
+    result += v0 != v1 ? float4(2.0f) : float4(3.0f);
+    return result;
+}

--- a/tests/cross-compile/vector-comparison.slang.glsl
+++ b/tests/cross-compile/vector-comparison.slang.glsl
@@ -1,0 +1,26 @@
+//TEST_IGNORE_FILE
+#version 450
+layout(row_major) uniform;
+layout(row_major) buffer;
+
+struct Param_0
+{
+    vec4 a_0;
+    vec4 b_0;
+};
+
+layout(binding = 0)
+layout(std140) uniform _S1
+{
+    Param_0 _data;
+} params_0;
+layout(location = 0)
+out vec4 _S2;
+
+void main()
+{
+    vec4 v0_0 = params_0._data.a_0;
+    vec4 v1_0 = params_0._data.b_0;
+    _S2 = mix(vec4(3.00000000000000000000), vec4(2.00000000000000000000), equal(v0_0,v1_0)) + mix(vec4(3.00000000000000000000), vec4(2.00000000000000000000), lessThan(v0_0,v1_0)) + mix(vec4(3.00000000000000000000), vec4(2.00000000000000000000), greaterThan(v0_0,v1_0)) + mix(vec4(3.00000000000000000000), vec4(2.00000000000000000000), lessThanEqual(v0_0,v1_0)) + mix(vec4(3.00000000000000000000), vec4(2.00000000000000000000), greaterThanEqual(v0_0,v1_0)) + mix(vec4(3.00000000000000000000), vec4(2.00000000000000000000), notEqual(v0_0,v1_0));
+    return;
+}


### PR DESCRIPTION
Add special case emit logic for select expression (`x?y:z`) for GLSL when `x` is a `bool` vector. In this case, we should generate a call to `mix` instead of a select expression since GLSL does not support a vector-typed condition expression.

Fixes #892 