### PR TITLE
Command line option to set profile on render-test

### DIFF
--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -89,6 +89,15 @@ SlangResult parseOptions(int argc, const char*const* argv, Slang::WriterHelper s
             }
             gOptions.outputPath = *argCursor++;
         }
+        else if (strcmp(arg, "-profile") == 0)
+        {
+            if (argCursor == argEnd)
+            {
+                stdError.print("expected argument for '%s' option\n", arg);
+                return SLANG_FAIL;
+            }
+            gOptions.profileName = *argCursor++;
+        }
         else if( strcmp(arg, "-xslang") == 0 )
         {
             // This is an option that we want to pass along to Slang

--- a/tools/render-test/options.h
+++ b/tools/render-test/options.h
@@ -48,6 +48,9 @@ struct Options
     RendererType rendererType = RendererType::Unknown;
     InputLanguageID inputLanguageID = InputLanguageID::Slang;
 
+        /// Can be used for overriding the profile
+    const char* profileName = nullptr;
+
     char const* slangArgs[kMaxSlangArgs];
     int slangArgCount = 0;
 

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -574,6 +574,9 @@ SLANG_TEST_TOOL_API SlangResult innerMain(Slang::StdWriters* stdWriters, SlangSe
         }
     }
 
+    // Use the profilename set on options if set
+    profileName = gOptions.profileName ? gOptions.profileName : profileName;
+
     ShaderCompiler shaderCompiler;
     shaderCompiler.renderer = renderer;
     shaderCompiler.target = slangTarget;


### PR DESCRIPTION
* Optionally use -profile to set profile on render-test
* If not set will use the same mechanism as before that implies the profile