### PR TITLE
Fixup for missing code in #896

### DIFF
--- a/source/slang/ir-legalize-types.cpp
+++ b/source/slang/ir-legalize-types.cpp
@@ -604,6 +604,7 @@ static LegalType getPointedToType(
                 TuplePseudoType::Element resultElement;
                 resultElement.key = ee.key;
                 resultElement.type = getPointedToType(context, ee.type);
+                resultTuple->elements.Add(resultElement);
             }
             return LegalType::tuple(resultTuple);
         }


### PR DESCRIPTION
The `tuple` case in `getPointedToType` was failing to add the elements it computed to the output tuple type.
This isn't triggered in any of our test cases, but was caught by some work I was doing in another branch.