### PR TITLE
Add SLANG_ACCELERATION_STRUCTURE resource shape for RaytracingAccelerationStructureType

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -1534,7 +1534,8 @@ extern "C"
 
         SLANG_STRUCTURED_BUFFER             = 0x06,
         SLANG_BYTE_ADDRESS_BUFFER           = 0x07,
-        SLANG_RESOURCE_UNKNOWN              = 0x08,
+        SLANG_ACCELERATION_STRUCTURE        = 0x08,
+        SLANG_RESOURCE_UNKNOWN              = 0x09,
 
         SLANG_RESOURCE_EXT_SHAPE_MASK       = 0xF0,
         SLANG_TEXTURE_ARRAY_FLAG            = 0x40,

--- a/slang.h
+++ b/slang.h
@@ -1534,8 +1534,8 @@ extern "C"
 
         SLANG_STRUCTURED_BUFFER             = 0x06,
         SLANG_BYTE_ADDRESS_BUFFER           = 0x07,
-        SLANG_ACCELERATION_STRUCTURE        = 0x08,
-        SLANG_RESOURCE_UNKNOWN              = 0x09,
+        SLANG_RESOURCE_UNKNOWN              = 0x08,
+        SLANG_ACCELERATION_STRUCTURE        = 0x09,
 
         SLANG_RESOURCE_EXT_SHAPE_MASK       = 0xF0,
         SLANG_TEXTURE_ARRAY_FLAG            = 0x40,

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -511,15 +511,16 @@ SLANG_API SlangResourceShape spReflectionType_GetResourceShape(SlangReflectionTy
         return SHAPE;               \
     } while(0)
 
-    CASE(HLSLStructuredBufferType,                      SLANG_STRUCTURED_BUFFER,    SLANG_RESOURCE_ACCESS_READ);
-    CASE(HLSLRWStructuredBufferType,                    SLANG_STRUCTURED_BUFFER,    SLANG_RESOURCE_ACCESS_READ_WRITE);
-    CASE(HLSLRasterizerOrderedStructuredBufferType,     SLANG_STRUCTURED_BUFFER,    SLANG_RESOURCE_ACCESS_RASTER_ORDERED);
-    CASE(HLSLAppendStructuredBufferType,                SLANG_STRUCTURED_BUFFER,    SLANG_RESOURCE_ACCESS_APPEND);
-    CASE(HLSLConsumeStructuredBufferType,               SLANG_STRUCTURED_BUFFER,    SLANG_RESOURCE_ACCESS_CONSUME);
-    CASE(HLSLByteAddressBufferType,                     SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_READ);
-    CASE(HLSLRWByteAddressBufferType,                   SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_READ_WRITE);
-    CASE(HLSLRasterizerOrderedByteAddressBufferType,    SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_RASTER_ORDERED);
-    CASE(UntypedBufferResourceType,                     SLANG_BYTE_ADDRESS_BUFFER,  SLANG_RESOURCE_ACCESS_READ);
+    CASE(HLSLStructuredBufferType,                      SLANG_STRUCTURED_BUFFER,        SLANG_RESOURCE_ACCESS_READ);
+    CASE(HLSLRWStructuredBufferType,                    SLANG_STRUCTURED_BUFFER,        SLANG_RESOURCE_ACCESS_READ_WRITE);
+    CASE(HLSLRasterizerOrderedStructuredBufferType,     SLANG_STRUCTURED_BUFFER,        SLANG_RESOURCE_ACCESS_RASTER_ORDERED);
+    CASE(HLSLAppendStructuredBufferType,                SLANG_STRUCTURED_BUFFER,        SLANG_RESOURCE_ACCESS_APPEND);
+    CASE(HLSLConsumeStructuredBufferType,               SLANG_STRUCTURED_BUFFER,        SLANG_RESOURCE_ACCESS_CONSUME);
+    CASE(HLSLByteAddressBufferType,                     SLANG_BYTE_ADDRESS_BUFFER,      SLANG_RESOURCE_ACCESS_READ);
+    CASE(HLSLRWByteAddressBufferType,                   SLANG_BYTE_ADDRESS_BUFFER,      SLANG_RESOURCE_ACCESS_READ_WRITE);
+    CASE(HLSLRasterizerOrderedByteAddressBufferType,    SLANG_BYTE_ADDRESS_BUFFER,      SLANG_RESOURCE_ACCESS_RASTER_ORDERED);
+    CASE(RaytracingAccelerationStructureType,           SLANG_ACCELERATION_STRUCTURE,   SLANG_RESOURCE_ACCESS_READ);
+    CASE(UntypedBufferResourceType,                     SLANG_BYTE_ADDRESS_BUFFER,      SLANG_RESOURCE_ACCESS_READ);
 #undef CASE
 
     return SLANG_RESOURCE_NONE;


### PR DESCRIPTION
Added a new `SLANG_ACCELERATION_STRUCTURE` enum in `SlangResourceShape`. Added handling for `RaytracingAccelerationStructureType ` to return this new value in `spReflectionType_GetResourceShape()`.

In `VK_NV_raytracing` extension, they introduced a new opaque type `accelerationStructureNV ` in GLSL for ray tracing acceleration structure, as well as a new descriptor type `VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV`. Slang needs to return a dedicated resource shape for this resource type in order for users to properly create descriptor set layout for the acceleration structure.

Original issue: https://github.com/shader-slang/slang/issues/894