### PR TITLE
Handle sv_groupthread_id & sv_groupid with different vec size on glsl

### DIFF
--- a/source/slang/ir-glsl-legalize.cpp
+++ b/source/slang/ir-glsl-legalize.cpp
@@ -315,6 +315,9 @@ GLSLSystemValueInfo* getGLSLSystemValueInfo(
     else if(semanticName == "sv_groupid")
     {
         name = "gl_WorkGroupID";
+
+        auto builder = context->getBuilder();
+        requiredType = builder->getVectorType(builder->getBasicType(BaseType::UInt), builder->getIntValue(builder->getIntType(), 3));
     }
     else if(semanticName == "sv_groupindex")
     {
@@ -323,6 +326,9 @@ GLSLSystemValueInfo* getGLSLSystemValueInfo(
     else if(semanticName == "sv_groupthreadid")
     {
         name = "gl_LocalInvocationID";
+
+        auto builder = context->getBuilder();
+        requiredType = builder->getVectorType(builder->getBasicType(BaseType::UInt), builder->getIntValue(builder->getIntType(), 3));
     }
     else if(semanticName == "sv_gsinstanceid")
     {


### PR DESCRIPTION
* Set the underlying type for sv_groupthread_id and sv_groupid for glsl, so if smaller type is used conversion is performed