### PR TITLE
On GLSL targets emit 3 component texture layouts as 4 component

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -5612,9 +5612,20 @@ struct EmitVisitor
                             {
                             default: Emit("rgba");  break;
 
-                            // TODO: GLSL doesn't actually seem to support 3-component formats
-                            // universally, so this might cause problems.
-                            case 3:  Emit("rgb");   break;
+                            case 3:
+                            {
+                                // TODO: GLSL doesn't actually seem to support 3-component formats
+                                // universally so for now we are going to default to rgba
+                                //
+                                // It seems that SPIR-V can support such formats, so with direct SPIR-V
+                                // path, and/or with support glslang could support in the future.
+                                //
+                                // Should this emit a warning? That it requires something different bound
+                                // than specified in source, and that could be pretty confusing.
+                                Emit("rgba");
+                                //Emit("rgb");                                
+                                break;
+                            }
 
                             case 2:  Emit("rg");    break;
                             case 1:  Emit("r");     break;

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -5614,14 +5614,23 @@ struct EmitVisitor
 
                             case 3:
                             {
-                                // TODO: GLSL doesn't actually seem to support 3-component formats
-                                // universally so for now we are going to default to rgba
+                                // TODO: GLSL doesn't support 3-component formats so for now we are going to
+                                // default to rgba
                                 //
-                                // It seems that SPIR-V can support such formats, so with direct SPIR-V
-                                // path, and/or with support glslang could support in the future.
+                                // The SPIR-V spec (https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.pdf)
+                                // section 3.11 on Image Formats it does not list rgbf32.
                                 //
-                                // Should this emit a warning? That it requires something different bound
-                                // than specified in source, and that could be pretty confusing.
+                                // It seems SPIR-V can support having an image with an unknown-at-compile-time
+                                // format, so long as the underlying API supports it. Ideally this would mean that we can
+                                // just drop all these qualifiers when emitting GLSL for Vulkan targets.
+                                //
+                                // This raises the question of what to do more long term. For Vulkan hopefully we can just
+                                // drop the layout. For OpenGL targets it would seem reasonable to have well-defined rules
+                                // for inferring the format (and just document that 3-component formats map to 4-component formats,
+                                // but that shouldn't matter because the API wouldn't let the user allocate those 3-component formats anyway),
+                                // and add an attribute for specifying the format manually if you really want to override our
+                                // inference (e.g., to specify r11fg11fb10f).
+
                                 Emit("rgba");
                                 //Emit("rgb");                                
                                 break;


### PR DESCRIPTION
* On GLSL targets, output texture layouts that are 3 component as 4 component, because 4 component style is not supported by glslang currently