### PR TITLE
Disable Dx12 half tests. 

### DIFF
--- a/tests/compute/half-calc.slang
+++ b/tests/compute/half-calc.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:-dx12 -compute -use-dxil -profile cs_6_2 -render-features half
-//TEST(compute):COMPARE_COMPUTE:-vk -compute -use-dxil -profile cs_6_2 -render-features half
+//DISABLE_TEST(compute):COMPARE_COMPUTE:-dx12 -compute -use-dxil -profile cs_6_2 -render-features half
+//TEST(compute):COMPARE_COMPUTE:-vk -compute -profile cs_6_2 -render-features half
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
 
 // Test for doing a calculation using half


### PR DESCRIPTION
The half-calc test runs, but is not actually doing any half maths. If the code is changed such that it is, the device fails when the shader is used. This can be seen by looking at dxil-asm - the test as currently constructed does not use half, but if vector half2 ops are used, it does and then the test fails. 