### PR TITLE
Adapter selection for Renderer

### DIFF
--- a/tools/gfx/d3d-util.cpp
+++ b/tools/gfx/d3d-util.cpp
@@ -381,6 +381,20 @@ static bool _isMatch(IDXGIAdapter* adapter, const Slang::UnownedStringSlice& low
     return descName.IndexOf(lowerAdapaterName) != UInt(-1);
 }
 
+/* static */bool D3DUtil::isWarp(IDXGIFactory* dxgiFactory, IDXGIAdapter* adapterIn)
+{
+    ComPtr<IDXGIFactory4> dxgiFactory4;
+    if (SLANG_SUCCEEDED(dxgiFactory->QueryInterface(IID_PPV_ARGS(dxgiFactory4.writeRef()))))
+    {
+        ComPtr<IDXGIAdapter> warpAdapter;
+        dxgiFactory4->EnumWarpAdapter(IID_PPV_ARGS(warpAdapter.writeRef()));
+
+        return adapterIn == warpAdapter;
+    }
+
+    return false;
+}
+
 /* static */SlangResult D3DUtil::findAdapters(DeviceCheckFlags flags, const UnownedStringSlice& adapterName, IDXGIFactory* dxgiFactory, List<ComPtr<IDXGIAdapter>>& outDxgiAdapters)
 {
     String lowerAdapterName = String(adapterName).ToLower();

--- a/tools/gfx/d3d-util.cpp
+++ b/tools/gfx/d3d-util.cpp
@@ -3,6 +3,8 @@
 
 #include <d3dcompiler.h>
 
+#include <dxgi1_4.h>
+
 // We will use the C standard library just for printing error messages.
 #include <stdio.h>
 
@@ -302,6 +304,137 @@ bool D3DUtil::isTypeless(DXGI_FORMAT format)
         // Remove terminating 0 from array
         out.UnsafeShrinkToSize(prevSize + outSize);
     }
+}
+
+/* static */HMODULE D3DUtil::getDxgiModule()
+{
+    static HMODULE s_dxgiModule = LoadLibraryA("dxgi.dll");
+    if (!s_dxgiModule)
+    {
+        fprintf(stderr, "error: failed load 'dxgi.dll'\n");
+        return nullptr;
+    }
+
+    return s_dxgiModule;
+}
+
+/* static */SlangResult D3DUtil::createFactory(DeviceCheckFlags flags, ComPtr<IDXGIFactory>& outFactory)
+{
+    auto dxgiModule =  getDxgiModule();
+    if (!dxgiModule)
+    {
+        return SLANG_FAIL;
+    }
+
+    typedef HRESULT(WINAPI *PFN_DXGI_CREATE_FACTORY)(REFIID riid, void   **ppFactory);
+    typedef HRESULT(WINAPI *PFN_DXGI_CREATE_FACTORY_2)(UINT Flags, REFIID riid, _COM_Outptr_ void **ppFactory);
+
+    {
+        auto createFactory2 = (PFN_DXGI_CREATE_FACTORY_2)::GetProcAddress(dxgiModule, "CreateDXGIFactory2");
+        if (createFactory2)
+        {
+            UINT dxgiFlags = 0;
+
+            if (flags & DeviceCheckFlag::UseDebug)
+            {
+                dxgiFlags |= DXGI_CREATE_FACTORY_DEBUG;
+            }
+
+            ComPtr<IDXGIFactory4> factory;
+            SLANG_RETURN_ON_FAIL(createFactory2(dxgiFlags, IID_PPV_ARGS(factory.writeRef())));
+
+            outFactory = factory;
+            return SLANG_OK;
+        }
+    }
+
+    {
+        auto createFactory = (PFN_DXGI_CREATE_FACTORY)::GetProcAddress(dxgiModule, "CreateDXGIFactory");
+        if (!createFactory)
+        {
+            fprintf(stderr, "error: failed load symbol '%s'\n", "CreateDXGIFactory");
+            return SLANG_FAIL;
+        }
+        return createFactory(IID_PPV_ARGS(outFactory.writeRef()));
+    }
+}
+
+/* static */SlangResult D3DUtil::findAdapters(DeviceCheckFlags flags, const Slang::UnownedStringSlice& adapaterName, List<ComPtr<IDXGIAdapter>>& outDxgiAdapters)
+{
+    ComPtr<IDXGIFactory> factory;
+    SLANG_RETURN_ON_FAIL(createFactory(flags, factory));
+    return findAdapters(flags, adapaterName, factory, outDxgiAdapters);
+}
+
+static bool _nameMatch(IDXGIAdapter* adapter, const Slang::UnownedStringSlice& lowerAdapaterName)
+{
+    if (lowerAdapaterName.size() == 0)
+    {
+        return true;
+    }
+
+    DXGI_ADAPTER_DESC desc;
+    adapter->GetDesc(&desc);
+
+    String descName = String::FromWString(desc.Description).ToLower();
+
+    return descName.IndexOf(lowerAdapaterName) != UInt(-1);
+}
+
+/* static */SlangResult D3DUtil::findAdapters(DeviceCheckFlags flags, const UnownedStringSlice& adapterName, IDXGIFactory* dxgiFactory, List<ComPtr<IDXGIAdapter>>& outDxgiAdapters)
+{
+    String lowerAdapterName = String(adapterName).ToLower();
+
+    outDxgiAdapters.Clear();
+
+    ComPtr<IDXGIAdapter> warpAdapter;
+    if ((flags & DeviceCheckFlag::UseHardwareDevice) == 0)
+    {
+        ComPtr<IDXGIFactory4> dxgiFactory4;
+        if (SLANG_SUCCEEDED(dxgiFactory->QueryInterface(IID_PPV_ARGS(dxgiFactory4.writeRef()))))
+        {
+            dxgiFactory4->EnumWarpAdapter(IID_PPV_ARGS(warpAdapter.writeRef()));
+            if (_nameMatch(warpAdapter, lowerAdapterName.getUnownedSlice()))
+            {
+                outDxgiAdapters.Add(warpAdapter);
+            }
+        }
+    }
+
+    for (UINT adapterIndex = 0; true; adapterIndex++)
+    {
+        ComPtr<IDXGIAdapter> dxgiAdapter;
+        if (dxgiFactory->EnumAdapters(adapterIndex, dxgiAdapter.writeRef()) == DXGI_ERROR_NOT_FOUND)
+            break;
+
+        // Skip if warp (as we will have already added it)
+        if (dxgiAdapter == warpAdapter)
+        {
+            continue;
+        }
+        if (!_nameMatch(dxgiAdapter, lowerAdapterName.getUnownedSlice()))
+        {
+            continue;
+        }
+
+        // Get if it's software
+        UINT deviceFlags = 0;
+        ComPtr<IDXGIAdapter1> dxgiAdapter1;
+        if (SLANG_SUCCEEDED(dxgiAdapter->QueryInterface(IID_PPV_ARGS(dxgiAdapter1.writeRef()))))
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            dxgiAdapter1->GetDesc1(&desc);
+            deviceFlags = desc.Flags;
+        }
+
+        // If the right type then add it
+        if ((deviceFlags & DXGI_ADAPTER_FLAG_SOFTWARE) == 0 && (flags & DeviceCheckFlag::UseHardwareDevice) != 0)
+        {
+            outDxgiAdapters.Add(dxgiAdapter);
+        }
+    }
+
+    return SLANG_OK;
 }
 
 } // renderer_test

--- a/tools/gfx/d3d-util.cpp
+++ b/tools/gfx/d3d-util.cpp
@@ -366,7 +366,7 @@ bool D3DUtil::isTypeless(DXGI_FORMAT format)
     return findAdapters(flags, adapaterName, factory, outDxgiAdapters);
 }
 
-static bool _nameMatch(IDXGIAdapter* adapter, const Slang::UnownedStringSlice& lowerAdapaterName)
+static bool _isMatch(IDXGIAdapter* adapter, const Slang::UnownedStringSlice& lowerAdapaterName)
 {
     if (lowerAdapaterName.size() == 0)
     {
@@ -394,7 +394,7 @@ static bool _nameMatch(IDXGIAdapter* adapter, const Slang::UnownedStringSlice& l
         if (SLANG_SUCCEEDED(dxgiFactory->QueryInterface(IID_PPV_ARGS(dxgiFactory4.writeRef()))))
         {
             dxgiFactory4->EnumWarpAdapter(IID_PPV_ARGS(warpAdapter.writeRef()));
-            if (_nameMatch(warpAdapter, lowerAdapterName.getUnownedSlice()))
+            if (_isMatch(warpAdapter, lowerAdapterName.getUnownedSlice()))
             {
                 outDxgiAdapters.Add(warpAdapter);
             }
@@ -412,7 +412,7 @@ static bool _nameMatch(IDXGIAdapter* adapter, const Slang::UnownedStringSlice& l
         {
             continue;
         }
-        if (!_nameMatch(dxgiAdapter, lowerAdapterName.getUnownedSlice()))
+        if (!_isMatch(dxgiAdapter, lowerAdapterName.getUnownedSlice()))
         {
             continue;
         }

--- a/tools/gfx/d3d-util.h
+++ b/tools/gfx/d3d-util.h
@@ -70,6 +70,10 @@ class D3DUtil
     static SlangResult findAdapters(DeviceCheckFlags flags, const Slang::UnownedStringSlice& adapaterName, IDXGIFactory* dxgiFactory, Slang::List<Slang::ComPtr<IDXGIAdapter>>& dxgiAdapters);
         /// Find adapters
     static SlangResult findAdapters(DeviceCheckFlags flags, const Slang::UnownedStringSlice& adapaterName, Slang::List<Slang::ComPtr<IDXGIAdapter>>& dxgiAdapters);
+
+        /// True if the adapter is warp
+    static bool isWarp(IDXGIFactory* dxgiFactory, IDXGIAdapter* adapter);
+
 };
 
 } // renderer_test

--- a/tools/gfx/d3d-util.h
+++ b/tools/gfx/d3d-util.h
@@ -8,10 +8,13 @@
 #include "../../slang-com-ptr.h"
 #include "../../source/core/list.h"
 
+#include "flag-combiner.h"
+
 #include "render.h"
 
 #include <D3Dcommon.h>
 #include <DXGIFormat.h>
+#include <dxgi.h>
 
 namespace gfx {
 
@@ -56,6 +59,17 @@ class D3DUtil
 
         /// Append text in in, into wide char array
     static void appendWideChars(const char* in, Slang::List<wchar_t>& out);
+
+    
+    static SlangResult createFactory(DeviceCheckFlags flags, Slang::ComPtr<IDXGIFactory>& outFactory);
+
+        /// Get the dxgiModule
+    static HMODULE getDxgiModule();
+
+        /// Find adapters
+    static SlangResult findAdapters(DeviceCheckFlags flags, const Slang::UnownedStringSlice& adapaterName, IDXGIFactory* dxgiFactory, Slang::List<Slang::ComPtr<IDXGIAdapter>>& dxgiAdapters);
+        /// Find adapters
+    static SlangResult findAdapters(DeviceCheckFlags flags, const Slang::UnownedStringSlice& adapaterName, Slang::List<Slang::ComPtr<IDXGIAdapter>>& dxgiAdapters);
 };
 
 } // renderer_test

--- a/tools/gfx/render-d3d11.cpp
+++ b/tools/gfx/render-d3d11.cpp
@@ -486,6 +486,7 @@ SlangResult D3D11Renderer::initialize(const Desc& desc, void* inWindowHandle)
                 adapter = dxgiAdapters[0];
             }
 
+            // The adapter can be nullptr - that just means 'default', but when so we need to select the driver type
             D3D_DRIVER_TYPE driverType = D3D_DRIVER_TYPE_UNKNOWN;
             if (adapter == nullptr)
             {
@@ -497,7 +498,7 @@ SlangResult D3D11Renderer::initialize(const Desc& desc, void* inWindowHandle)
             const UINT deviceFlags = (deviceCheckFlags & DeviceCheckFlag::UseDebug) ? D3D11_CREATE_DEVICE_DEBUG : 0;
 
             res = D3D11CreateDeviceAndSwapChain_(
-                adapter,                    // adapter (use default)
+                adapter,                   
                 driverType,
                 nullptr,                    // software
                 deviceFlags,

--- a/tools/gfx/render-d3d12.cpp
+++ b/tools/gfx/render-d3d12.cpp
@@ -1330,6 +1330,7 @@ Result D3D12Renderer::_createDevice(DeviceCheckFlags deviceCheckFlags, const Uno
         if (SLANG_SUCCEEDED(m_D3D12CreateDevice(dxgiAdapter, featureLevel, IID_PPV_ARGS(device.writeRef()))))
         {
             adapter = dxgiAdapter;
+            break;
         }
     }
 

--- a/tools/gfx/render-d3d12.cpp
+++ b/tools/gfx/render-d3d12.cpp
@@ -542,7 +542,7 @@ protected:
 
     ComPtr<ID3D12Debug> m_dxDebug;
 
-    DeviceInfo m_adapterInfo;
+    DeviceInfo m_deviceInfo;
     ID3D12Device* m_device = nullptr;
 
     ComPtr<IDXGISwapChain3> m_swapChain;
@@ -1469,20 +1469,20 @@ Result D3D12Renderer::initialize(const Desc& desc, void* inWindowHandle)
     const int numCombinations = combiner.getNumCombinations();
     for (int i = 0; i < numCombinations; ++i)
     {
-        if (SLANG_SUCCEEDED(_createDevice(combiner.getCombination(i), desc.adapter.getUnownedSlice(), featureLevel, m_adapterInfo)))
+        if (SLANG_SUCCEEDED(_createDevice(combiner.getCombination(i), desc.adapter.getUnownedSlice(), featureLevel, m_deviceInfo)))
         {
             break;
         }
     }
 
-    if (!m_adapterInfo.m_adapter)
+    if (!m_deviceInfo.m_adapter)
     {
         // Couldn't find an adapter
         return SLANG_FAIL;
     }
 
     // Set the device
-    m_device = m_adapterInfo.m_device;
+    m_device = m_deviceInfo.m_device;
 
     // Find what features are supported
     {
@@ -1495,7 +1495,7 @@ Result D3D12Renderer::initialize(const Desc& desc, void* inWindowHandle)
 
             // TODO: Currently warp causes a crash when using half, so disable for now
             if (SLANG_SUCCEEDED(m_device->CheckFeatureSupport(D3D12_FEATURE_SHADER_MODEL, &featureShaderModel, sizeof(featureShaderModel))) &&
-                m_adapterInfo.m_isWarp == false &&
+                m_deviceInfo.m_isWarp == false &&
                 featureShaderModel.HighestShaderModel >= 0x62)
             {
                 // With sm_6_2 we have half
@@ -1566,7 +1566,7 @@ Result D3D12Renderer::initialize(const Desc& desc, void* inWindowHandle)
 
     // Swap chain needs the queue so that it can force a flush on it.
     ComPtr<IDXGISwapChain> swapChain;
-    SLANG_RETURN_ON_FAIL(m_adapterInfo.m_dxgiFactory->CreateSwapChain(m_commandQueue, &swapChainDesc, swapChain.writeRef()));
+    SLANG_RETURN_ON_FAIL(m_deviceInfo.m_dxgiFactory->CreateSwapChain(m_commandQueue, &swapChainDesc, swapChain.writeRef()));
     SLANG_RETURN_ON_FAIL(swapChain->QueryInterface(m_swapChain.writeRef()));
 
     if (!m_hasVsync)
@@ -1583,7 +1583,7 @@ Result D3D12Renderer::initialize(const Desc& desc, void* inWindowHandle)
     }
 
     // This sample does not support fullscreen transitions.
-    SLANG_RETURN_ON_FAIL(m_adapterInfo.m_dxgiFactory->MakeWindowAssociation(m_hwnd, DXGI_MWA_NO_ALT_ENTER));
+    SLANG_RETURN_ON_FAIL(m_deviceInfo.m_dxgiFactory->MakeWindowAssociation(m_hwnd, DXGI_MWA_NO_ALT_ENTER));
 
     m_renderTargetIndex = m_swapChain->GetCurrentBackBufferIndex();
 

--- a/tools/gfx/render-d3d12.cpp
+++ b/tools/gfx/render-d3d12.cpp
@@ -1399,6 +1399,7 @@ Result D3D12Renderer::_createDevice(DeviceCheckFlags deviceCheckFlags, const Uno
     outDeviceInfo.m_device = device;
     outDeviceInfo.m_dxgiFactory = dxgiFactory;
     outDeviceInfo.m_adapter = adapter;
+    outDeviceInfo.m_isWarp = D3DUtil::isWarp(dxgiFactory, adapter);
 
     return SLANG_OK;
 }

--- a/tools/gfx/render-gl.cpp
+++ b/tools/gfx/render-gl.cpp
@@ -677,6 +677,19 @@ SlangResult GLRenderer::initialize(const Desc& desc, void* inWindowHandle)
     wglMakeCurrent(m_hdc, m_glContext);
 
     auto renderer = glGetString(GL_RENDERER);
+
+    if (renderer && desc.adapter.Length() > 0)
+    {
+        String lowerAdapter = desc.adapter.ToLower();
+        String lowerRenderer = String((const char*)renderer).ToLower();
+
+        // The adapter is not available
+        if (lowerRenderer.IndexOf(lowerAdapter) == UInt(-1))
+        {
+            return SLANG_E_NOT_AVAILABLE;
+        }
+    }
+
     auto extensions = glGetString(GL_EXTENSIONS);
 
     // Load each of our extension functions by name

--- a/tools/gfx/render.cpp
+++ b/tools/gfx/render.cpp
@@ -389,4 +389,17 @@ ProjectionStyle RendererUtil::getProjectionStyle(RendererType type)
     }
 }
 
+/* static */UnownedStringSlice RendererUtil::toText(RendererType type)
+{
+    switch (type)
+    {
+        case RendererType::DirectX11:       return UnownedStringSlice::fromLiteral("DirectX11");
+        case RendererType::DirectX12:       return UnownedStringSlice::fromLiteral("DirectX11");
+        case RendererType::OpenGl:          return UnownedStringSlice::fromLiteral("OpenGL");
+        case RendererType::Vulkan:          return UnownedStringSlice::fromLiteral("Vulkan");
+        case RendererType::Unknown:         return UnownedStringSlice::fromLiteral("Unknown");
+        default:                            return UnownedStringSlice::fromLiteral("?!?");
+    }
+}
+
 } // renderer_test

--- a/tools/gfx/render.h
+++ b/tools/gfx/render.h
@@ -779,8 +779,9 @@ public:
 
     struct Desc
     {
-        int width;          ///< Width in pixels
-        int height;         ///< height in pixels
+        int width;                  ///< Width in pixels
+        int height;                 ///< height in pixels
+        Slang::String adapter;      ///< Name to identify the adapter to use
     };
 
     virtual SlangResult initialize(const Desc& desc, void* inWindowHandle) = 0;
@@ -977,6 +978,9 @@ struct RendererUtil
 
         /// Get the binding style from the type
     static BindingStyle getBindingStyle(RendererType type) { return s_rendererTypeToBindingStyle[int(type)]; }
+
+        /// Get as text
+    static Slang::UnownedStringSlice toText(RendererType type);
 
     private:
     static void compileTimeAsserts();

--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -151,6 +151,16 @@ SlangResult parseOptions(int argc, const char*const* argv, Slang::WriterHelper s
         {
             gOptions.useDXIL = true;
         }
+        else if (strcmp(arg, "-adapter") == 0)
+        {
+            if (argCursor == argEnd)
+            {
+                stdError.print("expected argument for '%s' option\n", arg);
+                return SLANG_FAIL;
+            }
+
+            gOptions.adapter = *argCursor++;
+        }
         else
         {
             // Lookup

--- a/tools/render-test/options.h
+++ b/tools/render-test/options.h
@@ -57,6 +57,8 @@ struct Options
     bool useDXIL = false;
 
     Slang::List<Slang::String> renderFeatures;          /// Required render features for this test to run
+
+    Slang::String adapter;                              ///< The adapter to use either name or index
 };
 
 extern Options gOptions;

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -555,21 +555,30 @@ SLANG_TEST_TOOL_API SlangResult innerMain(Slang::StdWriters* stdWriters, SlangSe
 			return SLANG_FAIL;
 	}
 
+    StringBuilder rendererName;
+    rendererName << "[" << RendererUtil::toText(gOptions.rendererType) << "] ";
+    if (gOptions.adapter.Length())
+    {
+        rendererName << "'" << gOptions.adapter << "'";
+    }
+
+
     if (!renderer)
     {
-        fprintf(stderr, "Unable to create renderer\n");
+        fprintf(stderr, "Unable to create renderer %s\n", rendererName.Buffer());
         return SLANG_FAIL;
     }
 
     Renderer::Desc desc;
     desc.width = gWindowWidth;
     desc.height = gWindowHeight;
+    desc.adapter = gOptions.adapter;
 
     {
         SlangResult res = renderer->initialize(desc, (HWND)window->getHandle());
         if (SLANG_FAILED(res))
         {
-            fprintf(stderr, "Unable to initialize renderer\n");
+            fprintf(stderr, "Unable to initialize renderer %s\n", rendererName.Buffer());
             return res;
         }
     }

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -170,6 +170,15 @@ static bool _isSubCommand(const char* arg)
             argCursor++;
             // Assumed to be handle by .bat file that called us
         }
+        else if (strcmp(arg, "-adapter") == 0)
+        {
+            if (argCursor == argEnd)
+            {
+                stdError.print("error: expected operand for '%s'\n", arg);
+                return SLANG_FAIL;
+            }
+            optionsOut->adapter = *argCursor++;
+        }
         else if (strcmp(arg, "-appveyor") == 0)
         {
             optionsOut->outputMode = TestOutputMode::AppVeyor;

--- a/tools/slang-test/options.h
+++ b/tools/slang-test/options.h
@@ -86,6 +86,9 @@ struct Options
     // OpenGL is disabled for now
     Slang::RenderApiFlags synthesizedTestApis = Slang::RenderApiFlag::AllOf & ~(Slang::RenderApiFlag::Vulkan | Slang::RenderApiFlag::OpenGl);
 
+    // The adapter to use. If empty will match first found adapter.
+    Slang::String adapter;
+
         /// Parse the args, report any errors into stdError, and write the results into optionsOut
     static SlangResult parse(int argc, char** argv, TestCategorySet* categorySet, Slang::WriterHelper stdError, Options* optionsOut);
 };


### PR DESCRIPTION
* Make adapter used selectable on the command line (-adapter)
  + If set the device string must contain the specified substring
* Added 'adapter' to Renderer::Desc with dx11, dx12, vk honoring it
* GL will check that the renderer matches, but cannot select a specific adapter
* Share functionality on dx adapter selection in D3DUtil

Note - that on tests that use OpenGL and the adapter doesn't match it will ignore the test (and display a message that the appropriate device couldn't be started)