### PR TITLE
Avoid SPIR-V validation error by removing readonly flag from shaderRecordNV buffer

### DIFF
--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -6052,9 +6052,9 @@ struct EmitVisitor
 
         if( isShaderRecord )
         {
-            // TODO: A shader record in vk can be potentially read write. Currently slang does't support write access
-            // so for now we will assume readonly
-            emit("readonly buffer ");
+            // TODO: A shader record in vk can be potentially read-write. Currently slang doesn't support write access
+            // and readonly buffer generates SPIRV validation error.
+            emit("buffer ");
         }
         else if(as<IRGLSLShaderStorageBufferType>(type))
         {

--- a/tests/vkray/closesthit.slang.glsl
+++ b/tests/vkray/closesthit.slang.glsl
@@ -21,7 +21,7 @@ struct SLANG_ParameterGroup_ShaderRecord_0
 };
 
 layout(shaderRecordNV)
-readonly buffer tmp_shaderrecord
+buffer tmp_shaderrecord
 {
     SLANG_ParameterGroup_ShaderRecord_0 _data;
 } ShaderRecord_0;


### PR DESCRIPTION
Having `readonly buffer` on a shaderRecordNV storage buffer produces the following validation error in Vulkan. Removing it resolved the error.
```
 [ UNASSIGNED-CoreValidation-Shader-InconsistentSpirv ] Object: VK_NULL_HANDLE (Type = 0) | 
SPIR-V module not valid: Target of NonWritable member decoration is invalid:
must be the struct type of a uniform block or storage buffer
  %_S1 = OpTypeStruct %MyConstants_0_0
```