### PR TITLE
Feature/test tool interface

### DIFF
--- a/source/core/slang-std-writers.cpp
+++ b/source/core/slang-std-writers.cpp
@@ -4,7 +4,7 @@
 namespace Slang
 {
 
-/* static */StdWriters* StdWriters::s_singleton = nullptr;
+/* static */StdWriters* GlobalWriters::s_singleton = nullptr;
 
 /* static */RefPtr<StdWriters> StdWriters::createDefault()
 {
@@ -19,13 +19,25 @@ namespace Slang
     return stdWriters;
 }
 
-/* static */RefPtr<StdWriters> StdWriters::initDefaultSingleton()
+/* static */RefPtr<StdWriters> StdWriters::createNull()
+{
+    RefPtr<StdWriters> stdWriters(new StdWriters);
+    ComPtr<ISlangWriter> writer(new NullWriter(WriterFlag::AutoFlush));
+
+    stdWriters->setWriter(SLANG_WRITER_CHANNEL_STD_ERROR, writer);
+    stdWriters->setWriter(SLANG_WRITER_CHANNEL_STD_OUTPUT, writer);
+    stdWriters->setWriter(SLANG_WRITER_CHANNEL_DIAGNOSTIC, writer);
+
+    return stdWriters;
+}
+
+/* static */RefPtr<StdWriters> GlobalWriters::initDefaultSingleton()
 {
     if (s_singleton)
     {
         return s_singleton;
     }
-    auto defaults = createDefault();
+    auto defaults = StdWriters::createDefault();
     setSingleton(defaults);
     return defaults;
 }

--- a/source/core/slang-std-writers.h
+++ b/source/core/slang-std-writers.h
@@ -12,30 +12,43 @@ class StdWriters: public RefObject
 {
 public:
 
-    ISlangWriter * getWriter(SlangWriterChannel chan) const { return m_writers[chan]; }
+    ISlangWriter* getWriter(SlangWriterChannel chan) const { return m_writers[chan]; }
     void setWriter(SlangWriterChannel chan, ISlangWriter* writer) { m_writers[chan] = writer; }
+
+    WriterHelper getError() { return getWriter(SLANG_WRITER_CHANNEL_STD_ERROR); }
+    WriterHelper getOut() { return getWriter(SLANG_WRITER_CHANNEL_STD_OUTPUT); }
+    WriterHelper getDiagnostic() { return getWriter(SLANG_WRITER_CHANNEL_DIAGNOSTIC); }
 
         /// Set the writers on the SlangCompileRequest
     void setRequestWriters(SlangCompileRequest* request);
+        /// Create default std writers
+    static RefPtr<StdWriters> createDefault();
+
+        /// All throw away
+    static RefPtr<StdWriters> createNull();
 
         /// Ctor
     StdWriters() {}
 
-        /// Initialize a default context
-    static RefPtr<StdWriters> createDefault();
-    static RefPtr<StdWriters> initDefaultSingleton();
-
-    static StdWriters* getSingleton() { return s_singleton; }
-    static void setSingleton(StdWriters* context) { s_singleton = context;  }
-
-    static WriterHelper getError() { return getSingleton()->getWriter(SLANG_WRITER_CHANNEL_STD_ERROR); }
-    static WriterHelper getOut() { return getSingleton()->getWriter(SLANG_WRITER_CHANNEL_STD_OUTPUT); }
-    static WriterHelper getDiagnostic() { return getSingleton()->getWriter(SLANG_WRITER_CHANNEL_DIAGNOSTIC); }
-
 protected:
 
     ComPtr<ISlangWriter> m_writers[SLANG_WRITER_CHANNEL_COUNT_OF]; 
-    
+};
+
+class GlobalWriters
+{
+public:
+    /// Initialize a default context
+    static RefPtr<StdWriters> initDefaultSingleton();
+
+    static WriterHelper getError() { return getSingleton()->getError(); }
+    static WriterHelper getOut() { return getSingleton()->getOut(); }
+    static WriterHelper getDiagnostic() { return getSingleton()->getDiagnostic(); }
+
+    static StdWriters* getSingleton() { return s_singleton; }
+    static void setSingleton(StdWriters* context) { s_singleton = context; }
+
+private:
     static StdWriters* s_singleton;
 };
 

--- a/source/core/slang-test-tool-util.cpp
+++ b/source/core/slang-test-tool-util.cpp
@@ -32,6 +32,113 @@ namespace Slang
     }
 }
 
+/* static */SlangResult TestToolUtil::extractArg(const char*const* args, int argsCount, const char* argName, const char** outValue)
+{
+    SLANG_ASSERT(strlen(argName) > 0 && argName[0] == '-');
+    for (int i = 0; i < argsCount - 1; ++i)
+    {
+        if (strcmp(args[i], argName) == 0)
+        {
+            *outValue = args[i + 1];
+            return SLANG_OK;
+        }
+    }
+    return SLANG_FAIL;
+}
+
+/* static */bool TestToolUtil::hasOption(const char*const* args, int argsCount, const char* argName)
+{
+    for (int i = 0; i < argsCount; ++i)
+    {
+        if (strcmp(args[i], argName) == 0)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* static */BackendType TestToolUtil::toBackendType(const UnownedStringSlice& slice)
+{
+    if (slice == "dxc")
+    {
+        return BackendType::Dxc;
+    }
+    else if (slice == "fxc")
+    {
+        return BackendType::Fxc;
+    }
+    else if (slice == "glslang")
+    {
+        return BackendType::Glslang;
+    }
+    return BackendType::Unknown;
+}
+
+/* static */BackendFlags TestToolUtil::getBackendFlagsForTarget(SlangCompileTarget target)
+{
+    switch (target)
+    {
+        case SLANG_TARGET_UNKNOWN:
+        case SLANG_HLSL:
+        case SLANG_GLSL:
+        {
+            return 0;
+        }
+        case SLANG_DXBC:
+        case SLANG_DXBC_ASM:
+        {
+            return BackendFlag::Fxc;
+        }
+        case SLANG_SPIRV:
+        case SLANG_SPIRV_ASM:
+        {
+            return BackendFlag::Glslang;
+        }
+        case SLANG_DXIL:
+        case SLANG_DXIL_ASM:
+        {
+            return BackendFlag::Dxc;
+        }
+        default:
+        {
+            SLANG_ASSERT(!"Unknown type");
+            return 0;
+        }
+    }
+}
+
+/* static */BackendType TestToolUtil::toBackendTypeFromPassThroughType(SlangPassThrough passThru)
+{
+    switch (passThru)
+    {
+        case SLANG_PASS_THROUGH_DXC: return BackendType::Dxc;
+        case SLANG_PASS_THROUGH_FXC: return BackendType::Fxc;
+        case SLANG_PASS_THROUGH_GLSLANG: return BackendType::Glslang;
+        default:                     return BackendType::Unknown;
+    }
+}
+
+/* static */SlangCompileTarget TestToolUtil::toCompileTarget(const UnownedStringSlice& name)
+{
+#define CASE(NAME, TARGET)  if(name == NAME) return SLANG_##TARGET;
+
+    CASE("hlsl", HLSL)
+        CASE("glsl", GLSL)
+        CASE("dxbc", DXBC)
+        CASE("dxbc-assembly", DXBC_ASM)
+        CASE("dxbc-asm", DXBC_ASM)
+        CASE("spirv", SPIRV)
+        CASE("spirv-assembly", SPIRV_ASM)
+        CASE("spirv-asm", SPIRV_ASM)
+        CASE("dxil", DXIL)
+        CASE("dxil-assembly", DXIL_ASM)
+        CASE("dxil-asm", DXIL_ASM)
+#undef CASE
+
+        return SLANG_TARGET_UNKNOWN;
+}
+
 
 }
 

--- a/source/core/slang-test-tool-util.h
+++ b/source/core/slang-test-tool-util.h
@@ -3,6 +3,8 @@
 
 #include "slang-std-writers.h"
 
+#include "slang-render-api-util.h"
+
 namespace Slang {
 
 #ifdef SLANG_SHARED_LIBRARY_TOOL
@@ -11,6 +13,89 @@ namespace Slang {
 #   define SLANG_TEST_TOOL_API
 #endif
 
+/* Enumeration of the different kinds of compiler backends slang needs. */
+enum class BackendType
+{
+    Unknown = -1,
+    Dxc,
+    Fxc,
+    Glslang,
+    CountOf,
+};
+
+typedef uint32_t BackendFlags;
+struct BackendFlag
+{
+    enum Enum : uint32_t
+    {
+        Dxc = 1 << int(BackendType::Dxc),
+        Fxc = 1 << int(BackendType::Fxc),
+        Glslang = 1 << int(BackendType::Glslang),
+    };
+};
+
+/// Structure that describes requirements needs to run - such as rendering APIs or
+/// back-end availability 
+struct TestRequirements
+{
+    TestRequirements& addUsed(BackendType type)
+    {
+        if (type != BackendType::Unknown)
+        {
+            usedBackendFlags |= BackendFlags(1) << int(type);
+        }
+        return *this;
+    }
+    TestRequirements& addUsed(Slang::RenderApiType type)
+    {
+        using namespace Slang;
+        if (type != RenderApiType::Unknown)
+        {
+            usedRenderApiFlags |= RenderApiFlags(1) << int(type);
+        }
+        return *this;
+    }
+    TestRequirements& addUsedBackends(BackendFlags flags)
+    {
+        usedBackendFlags |= flags;
+        return *this;
+    }
+    TestRequirements& addUsedRenderApis(Slang::RenderApiFlags flags)
+    {
+        usedRenderApiFlags |= flags;
+        return *this;
+    }
+    /// True if has this render api as used
+    bool isUsed(Slang::RenderApiType apiType) const
+    {
+        return (apiType != Slang::RenderApiType::Unknown) && ((usedRenderApiFlags & (Slang::RenderApiFlags(1) << int(apiType))) != 0);
+    }
+
+    Slang::RenderApiType explicitRenderApi = Slang::RenderApiType::Unknown;     ///< The render api explicitly specified 
+    BackendFlags usedBackendFlags = 0;                                          ///< Used backends
+    Slang::RenderApiFlags usedRenderApiFlags = 0;                               ///< Used render api flags (some might be implied)
+};
+
+/* An interface to communicate between a test tool and the test runner */
+struct ITestTool : public ISlangUnknown
+{
+public:
+        /** Run the test using the session and the specified args.
+        @param stdWriters Writes used for output
+        @param session A slang session
+        @param argc The number of arguments
+        @param argv The arguments */
+    virtual SLANG_NO_THROW SlangResult SLANG_MCALL run(Slang::StdWriters* stdWriters, SlangSession* session, int argc, const char*const* argv) = 0;
+        /** Parse the specified command line parameters.
+        @param stdWriters Writers used for output
+        @param argc The number of arguments
+        @param argv The arguments
+        @param outRequirements The requirements of this test */
+    virtual SLANG_NO_THROW SlangResult SLANG_MCALL calcTestRequirements(Slang::StdWriters* stdWriters, SlangSession* session, int argc, const char*const* argv, TestRequirements* ioRequirements ) = 0;
+};
+
+#define SLANG_UUID_Slang_ITestTool { 0x1023b36c, 0xda3f, 0x40fb, { 0xa0, 0xb1, 0xb5, 0xcd, 0xc9, 0x61, 0x96, 0xd1 } };
+    
 /* When a tool is run as an executable the return code is the code returned from
 the last return of main. On unix this can be up to 8 bits. 
 By normal command line tool conventions returning 0 means success. */
@@ -36,10 +121,28 @@ enum class ToolReturnCodeSpan
 /* Utility functions for 'test tools' */
 struct TestToolUtil
 {
-    typedef SlangResult(*InnerMainFunc)(Slang::StdWriters* stdWriters, SlangSession* session, int argc, const char*const* argv);
+    typedef SlangResult(*getTestToolFunc)(const Guid& intf, ISlangUnknown** toolOut);
 
         /// If the test failed to run or was ignored then we are done
     static bool isDone(ToolReturnCode code) { return int(code) >= int(ToolReturnCodeSpan::FirstIsDone) && int(code) <= int(ToolReturnCodeSpan::LastIsDone); }
+
+        /// Given a list of args extracts an args value specified by name. Arg name must have - prefix, and the result is the next arg.
+    static SlangResult extractArg(const char*const* args, int argsCount, const char* argName, const char** outValue);
+
+        /// Returns true if the option, specified as argName, is found in the list of args
+    static bool hasOption(const char*const* args, int argsCount, const char* argName);
+
+        /// Given a string returns BackendType or BackendType::Unknown if not found
+    static BackendType toBackendType(const UnownedStringSlice& slice);
+
+        /// Given a compilation target returns what backends are required as flags
+    static BackendFlags getBackendFlagsForTarget(SlangCompileTarget target);
+
+        /// For given pass through type returns the associated backend type
+    static BackendType toBackendTypeFromPassThroughType(SlangPassThrough passThru);
+
+        /// Given a string returns as the associated SlangCompileTarget or Unknown if not found
+    static SlangCompileTarget toCompileTarget(const UnownedStringSlice& name);
 
         /// Convert from an int
     static ToolReturnCode getReturnCodeFromInt(int code);

--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -15,7 +15,7 @@ static void diagnosticCallback(
     char const* message,
     void*       /*userData*/)
 {
-    auto stdError = StdWriters::getError();
+    auto stdError = GlobalWriters::getError();
     stdError.put(message);
     stdError.flush();
 }
@@ -28,7 +28,7 @@ static void diagnosticCallback(
 
 SLANG_TEST_TOOL_API SlangResult innerMain(StdWriters* stdWriters, SlangSession* session, int argc, const char*const* argv)
 {
-    StdWriters::setSingleton(stdWriters);
+    GlobalWriters::setSingleton(stdWriters);
 
     SlangCompileRequest* compileRequest = spCreateCompileRequest(session);
 
@@ -66,7 +66,7 @@ SLANG_TEST_TOOL_API SlangResult innerMain(StdWriters* stdWriters, SlangSession* 
 #ifndef _DEBUG
     catch (Exception & e)
     {
-        StdWriters::getOut().print("internal compiler error: %S\n", e.Message.ToWString().begin());
+        GlobalWriters::getOut().print("internal compiler error: %S\n", e.Message.ToWString().begin());
         res = SLANG_FAIL;
     }
 #endif
@@ -82,7 +82,7 @@ int MAIN(int argc, char** argv)
     {
         SlangSession* session = spCreateSession(nullptr);
 
-        auto stdWriters = StdWriters::initDefaultSingleton();
+        auto stdWriters = GlobalWriters::initDefaultSingleton();
         
         res = innerMain(stdWriters, session, argc, argv);
         spDestroySession(session);

--- a/tools/gfx/render-d3d11.cpp
+++ b/tools/gfx/render-d3d11.cpp
@@ -96,7 +96,7 @@ public:
     virtual void dispatchCompute(int x, int y, int z) override;
     virtual void submitGpuWork() override {}
     virtual void waitForGpu() override {}
-    virtual RendererType getRendererType() const override { return RendererType::DirectX11; }
+    virtual RenderApiType getRendererType() const override { return RenderApiType::D3D11; }
 
     ~D3D11Renderer() {}
 

--- a/tools/gfx/render-d3d12.cpp
+++ b/tools/gfx/render-d3d12.cpp
@@ -98,7 +98,7 @@ public:
     virtual void dispatchCompute(int x, int y, int z) override;
     virtual void submitGpuWork() override;
     virtual void waitForGpu() override;
-    virtual RendererType getRendererType() const override { return RendererType::DirectX12; }
+    virtual RenderApiType getRendererType() const override { return RenderApiType::D3D12; }
 
     ~D3D12Renderer();
 

--- a/tools/gfx/render-gl.cpp
+++ b/tools/gfx/render-gl.cpp
@@ -123,7 +123,7 @@ public:
     virtual void dispatchCompute(int x, int y, int z) override;
     virtual void submitGpuWork() override {}
     virtual void waitForGpu() override {}
-    virtual RendererType getRendererType() const override { return RendererType::OpenGl; }
+    virtual RenderApiType getRendererType() const override { return RenderApiType::OpenGl; }
 
     protected:
     enum

--- a/tools/gfx/render-vk.cpp
+++ b/tools/gfx/render-vk.cpp
@@ -84,7 +84,7 @@ public:
     virtual void dispatchCompute(int x, int y, int z) override;
     virtual void submitGpuWork() override;
     virtual void waitForGpu() override;
-    virtual RendererType getRendererType() const override { return RendererType::Vulkan; }
+    virtual RenderApiType getRendererType() const override { return RenderApiType::Vulkan; }
 
         /// Dtor
     ~VKRenderer();

--- a/tools/gfx/render.cpp
+++ b/tools/gfx/render.cpp
@@ -62,19 +62,9 @@ const Resource::DescBase& Resource::getDescBase() const
     uint8_t(sizeof(uint32_t)),       // D_Unorm24_S8,
 };
 
-/* static */const BindingStyle RendererUtil::s_rendererTypeToBindingStyle[] =
-{
-    BindingStyle::Unknown,      // Unknown,
-    BindingStyle::DirectX,      // DirectX11,
-    BindingStyle::DirectX,      // DirectX12,
-    BindingStyle::OpenGl,       // OpenGl,
-    BindingStyle::Vulkan,       // Vulkan
-};
-
 /* static */void RendererUtil::compileTimeAsserts()
 {
     SLANG_COMPILE_TIME_ASSERT(SLANG_COUNT_OF(s_formatSize) == int(Format::CountOf));
-    SLANG_COMPILE_TIME_ASSERT(SLANG_COUNT_OF(s_rendererTypeToBindingStyle) == int(RendererType::CountOf));
 }
 
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!! BindingState::Desc !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
@@ -333,22 +323,42 @@ void TextureResource::Desc::init3D(Format formatIn, int widthIn, int heightIn, i
 
 /* !!!!!!!!!!!!!!!!!!!!!!!!! RennderUtil !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
 
-ProjectionStyle RendererUtil::getProjectionStyle(RendererType type)
+ProjectionStyle RendererUtil::getProjectionStyle(Slang::RenderApiType type)
 {
     switch (type)
     {
-        case RendererType::DirectX11:
-        case RendererType::DirectX12:
+        case RenderApiType::D3D11:
+        case RenderApiType::D3D12:
         {
             return ProjectionStyle::DirectX;
         }
-        case RendererType::OpenGl:              return ProjectionStyle::OpenGl;
-        case RendererType::Vulkan:              return ProjectionStyle::Vulkan;
-        case RendererType::Unknown:             return ProjectionStyle::Unknown;
+        case RenderApiType::OpenGl:              return ProjectionStyle::OpenGl;
+        case RenderApiType::Vulkan:              return ProjectionStyle::Vulkan;
+        case RenderApiType::Unknown:             return ProjectionStyle::Unknown;
         default:
         {
             assert(!"Unhandled type");
             return ProjectionStyle::Unknown;
+        }
+    }
+}
+
+/* static */BindingStyle RendererUtil::getBindingStyle(Slang::RenderApiType type)
+{
+    switch (type)
+    {
+        case RenderApiType::D3D11:
+        case RenderApiType::D3D12:
+        {
+            return BindingStyle::DirectX;
+        }
+        case RenderApiType::OpenGl:              return BindingStyle::OpenGl;
+        case RenderApiType::Vulkan:              return BindingStyle::Vulkan;
+        case RenderApiType::Unknown:             return BindingStyle::Unknown;
+        default:
+        {
+            assert(!"Unhandled type");
+            return BindingStyle::Unknown;
         }
     }
 }
@@ -389,15 +399,15 @@ ProjectionStyle RendererUtil::getProjectionStyle(RendererType type)
     }
 }
 
-/* static */UnownedStringSlice RendererUtil::toText(RendererType type)
+/* static */UnownedStringSlice RendererUtil::toText(RenderApiType type)
 {
     switch (type)
     {
-        case RendererType::DirectX11:       return UnownedStringSlice::fromLiteral("DirectX11");
-        case RendererType::DirectX12:       return UnownedStringSlice::fromLiteral("DirectX11");
-        case RendererType::OpenGl:          return UnownedStringSlice::fromLiteral("OpenGL");
-        case RendererType::Vulkan:          return UnownedStringSlice::fromLiteral("Vulkan");
-        case RendererType::Unknown:         return UnownedStringSlice::fromLiteral("Unknown");
+        case RenderApiType::D3D11:          return UnownedStringSlice::fromLiteral("DirectX11");
+        case RenderApiType::D3D12:          return UnownedStringSlice::fromLiteral("DirectX11");
+        case RenderApiType::OpenGl:         return UnownedStringSlice::fromLiteral("OpenGL");
+        case RenderApiType::Vulkan:         return UnownedStringSlice::fromLiteral("Vulkan");
+        case RenderApiType::Unknown:        return UnownedStringSlice::fromLiteral("Unknown");
         default:                            return UnownedStringSlice::fromLiteral("?!?");
     }
 }

--- a/tools/gfx/render.h
+++ b/tools/gfx/render.h
@@ -12,6 +12,7 @@
 #include "../../source/core/smart-pointer.h"
 #include "../../source/core/list.h"
 #include "../../source/core/dictionary.h"
+#include "../../source/core/slang-render-api-util.h"
 
 namespace gfx {
 
@@ -54,16 +55,6 @@ enum class StageType
     Geometry,
     Fragment,
     Compute,
-    CountOf,
-};
-
-enum class RendererType
-{
-    Unknown,
-    DirectX11,
-    DirectX12,
-    OpenGl,
-    Vulkan,
     CountOf,
 };
 
@@ -956,7 +947,7 @@ public:
     virtual void waitForGpu() = 0;
 
         /// Get the type of this renderer
-    virtual RendererType getRendererType() const = 0;
+    virtual Slang::RenderApiType getRendererType() const = 0;
 };
 
 // ----------------------------------------------------------------------------------------
@@ -971,21 +962,20 @@ struct RendererUtil
         /// Gets the size in bytes of a Format type. Returns 0 if a size is not defined/invalid
     SLANG_FORCE_INLINE static size_t getFormatSize(Format format) { return s_formatSize[int(format)]; }
         /// Given a renderer type, gets a projection style
-    static ProjectionStyle getProjectionStyle(RendererType type);
+    static ProjectionStyle getProjectionStyle(Slang::RenderApiType type);
 
         /// Given the projection style returns an 'identity' matrix, which ensures x,y mapping to pixels is the same on all targets
     static void getIdentityProjection(ProjectionStyle style, float projMatrix[16]);
 
         /// Get the binding style from the type
-    static BindingStyle getBindingStyle(RendererType type) { return s_rendererTypeToBindingStyle[int(type)]; }
-
+    static BindingStyle getBindingStyle(Slang::RenderApiType type);
+    
         /// Get as text
-    static Slang::UnownedStringSlice toText(RendererType type);
+    static Slang::UnownedStringSlice toText(Slang::RenderApiType type);
 
     private:
     static void compileTimeAsserts();
     static const uint8_t s_formatSize[]; // Maps Format::XXX to a size in bytes;
-    static const BindingStyle s_rendererTypeToBindingStyle[];           ///< Maps a RendererType to a BindingStyle
 };
 
 } // renderer_test

--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -19,22 +19,9 @@ static const Options gDefaultOptions;
 
 Options gOptions;
 
-static gfx::RendererType _toRenderType(Slang::RenderApiType apiType)
+static SlangResult _setRendererType(RenderApiType type, const char* arg, Slang::WriterHelper stdError)
 {
-    using namespace Slang;
-    switch (apiType)
-    {
-    case RenderApiType::D3D11: return gfx::RendererType::DirectX11;
-    case RenderApiType::D3D12: return gfx::RendererType::DirectX12;
-    case RenderApiType::OpenGl: return gfx::RendererType::OpenGl;
-    case RenderApiType::Vulkan: return gfx::RendererType::Vulkan;
-    default: return gfx::RendererType::Unknown;
-    }
-}
-
-static SlangResult _setRendererType(RendererType type, const char* arg, Slang::WriterHelper stdError)
-{
-    if (gOptions.rendererType != RendererType::Unknown)
+    if (gOptions.rendererType != RenderApiType::Unknown)
     {
         stdError.print("Already has renderer option set. Found '%s'\n", arg);
         return SLANG_FAIL;
@@ -173,17 +160,17 @@ SlangResult parseOptions(int argc, const char*const* argv, Slang::WriterHelper s
             {
                 // Look up the rendering API if set
                 UnownedStringSlice argName = UnownedStringSlice(argSlice.begin() + 1, argSlice.end());
-                RendererType rendererType = _toRenderType(RenderApiUtil::findApiTypeByName(argName));
+                RenderApiType rendererType = RenderApiUtil::findApiTypeByName(argName);
 
-                if (rendererType != RendererType::Unknown)
+                if (rendererType != RenderApiType::Unknown)
                 {
                     gOptions.rendererType = rendererType;
                     continue;
                 }
 
                 // Lookup the target language type
-                RendererType languageRenderType = _toRenderType(RenderApiUtil::findImplicitLanguageRenderApiType(argName));
-                if (languageRenderType != RendererType::Unknown)
+                RenderApiType languageRenderType = RenderApiUtil::findImplicitLanguageRenderApiType(argName);
+                if (languageRenderType != RenderApiType::Unknown)
                 {
                     gOptions.targetLanguageRendererType = languageRenderType;
                     gOptions.inputLanguageID = (argName == "hlsl" || argName == "glsl") ?  InputLanguageID::Native : InputLanguageID::Slang;
@@ -197,7 +184,7 @@ SlangResult parseOptions(int argc, const char*const* argv, Slang::WriterHelper s
     }
 
     // If a render option isn't set use defaultRenderType 
-    gOptions.rendererType = (gOptions.rendererType == RendererType::Unknown) ? gOptions.targetLanguageRendererType : gOptions.rendererType;
+    gOptions.rendererType = (gOptions.rendererType == RenderApiType::Unknown) ? gOptions.targetLanguageRendererType : gOptions.rendererType;
 
     // first positional argument is source shader path
     if(positionalArgs.Count())

--- a/tools/render-test/options.h
+++ b/tools/render-test/options.h
@@ -5,6 +5,7 @@
 
 #include "../../slang-com-helper.h"
 #include "../../source/core/slang-writer.h"
+#include "../../source/core/slang-render-api-util.h"
 
 #include "render.h"
 
@@ -43,9 +44,9 @@ struct Options
 	ShaderProgramType shaderType = ShaderProgramType::Graphics;
 
         /// The renderer type inferred from the target language type. Used if a rendererType is not explicitly set.
-    RendererType targetLanguageRendererType = RendererType::Unknown;
+    Slang::RenderApiType targetLanguageRendererType = Slang::RenderApiType::Unknown;
         /// The set render type
-    RendererType rendererType = RendererType::Unknown;
+    Slang::RenderApiType rendererType = Slang::RenderApiType::Unknown;
     InputLanguageID inputLanguageID = InputLanguageID::Slang;
 
         /// Can be used for overriding the profile

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -37,7 +37,7 @@ TestCategory* TestCategorySet::findOrError(String const& name)
     TestCategory* category = find(name);
     if (!category)
     {
-        StdWriters::getError().print("error: unknown test category name '%s'\n", name.Buffer());
+        GlobalWriters::getError().print("error: unknown test category name '%s'\n", name.Buffer());
     }
     return category;
 }

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1604,11 +1604,6 @@ TestResult runHLSLAndGLSLRenderComparisonTest(TestContext* context, TestInput& i
     return runHLSLRenderComparisonTestImpl(context, input, "-hlsl-rewrite", "-glsl-rewrite");
 }
 
-TestResult skipTest(TestContext* /* context */, TestInput& /*input*/)
-{
-    return TestResult::Ignored;
-}
-
 // based on command name, dispatch to an appropriate callback
 struct TestCommandInfo
 {
@@ -1768,7 +1763,8 @@ static void _calcSynthesizedTests(TestContext* context, RenderApiType synthRende
     }
 }
 
-static bool _canIgnore(TestContext* context,
+static bool _canIgnore(
+    TestContext* context,
     const TestRequirements& requirements)
 {
     // Work out what render api flags are available

--- a/tools/slang-test/slangc-tool.h
+++ b/tools/slang-test/slangc-tool.h
@@ -4,12 +4,13 @@
 #define SLANGC_TOOL_H_INCLUDED
 
 #include "../../source/core/slang-std-writers.h"
+#include "../../source/core/slang-test-tool-util.h"
 
 /* The slangc 'tool' interface, such that slangc like functionality is available directly without invoking slangc command line tool, or
 need for a dll/shared library. */
-struct SlangCTool
+struct SlangCTestToolUtil
 {
-    static SlangResult innerMain(Slang::StdWriters* stdWriters, SlangSession* session, int argc, const char*const* argv);
+    static Slang::ITestTool* getTestTool();
 };
 
 #endif // SLANGC_TOOL_H_INCLUDED

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -12,73 +12,9 @@
 
 #include "options.h"
 
-enum class BackendType
-{
-    Unknown = -1,
-    Dxc,
-    Fxc,
-    Glslang,
-    CountOf,
-};
-
-typedef uint32_t BackendFlags;
-struct BackendFlag
-{
-    enum Enum : uint32_t
-    {
-        Dxc = 1 << int(BackendType::Dxc),
-        Fxc = 1 << int(BackendType::Fxc),
-        Glslang = 1 << int(BackendType::Glslang),
-    };
-};
-
-/// Structure that describes requirements needs to run - such as rendering APIs or
-/// back-end availability 
-struct TestRequirements
-{
-    TestRequirements& addUsed(BackendType type)
-    {
-        if (type != BackendType::Unknown)
-        {
-            usedBackendFlags |= BackendFlags(1) << int(type);
-        }
-        return *this;
-    }
-    TestRequirements& addUsed(Slang::RenderApiType type)
-    {
-        using namespace Slang;
-        if (type != RenderApiType::Unknown)
-        {
-            usedRenderApiFlags |=RenderApiFlags(1) << int(type);
-        }
-        return *this;
-    }
-    TestRequirements& addUsedBackends(BackendFlags flags)
-    {
-        usedBackendFlags |= flags;
-        return *this;
-    }
-    TestRequirements& addUsedRenderApis(Slang::RenderApiFlags flags)
-    {
-        usedRenderApiFlags |= flags;
-        return *this;
-    }
-        /// True if has this render api as used
-    bool isUsed(Slang::RenderApiType apiType) const
-    {
-        return (apiType != Slang::RenderApiType::Unknown) && ((usedRenderApiFlags & (Slang::RenderApiFlags(1) << int(apiType))) != 0);
-    }
-
-    Slang::RenderApiType explicitRenderApi = Slang::RenderApiType::Unknown;     ///< The render api explicitly specified 
-    BackendFlags usedBackendFlags = 0;                                          ///< Used backends
-    Slang::RenderApiFlags usedRenderApiFlags = 0;                               ///< Used render api flags (some might be implied)
-};
-
 class TestContext
 {
     public:
-
-    typedef Slang::TestToolUtil::InnerMainFunc InnerMainFunc;
 
         /// Get the slang session
     SlangSession* getSession() const { return m_session;  }
@@ -86,9 +22,9 @@ class TestContext
     SlangResult init();
 
         /// Get the inner main function (from shared library)
-    InnerMainFunc getInnerMainFunc(const Slang::String& dirPath, const Slang::String& name);
+    Slang::ITestTool* getTestTool(const Slang::String& dirPath, const Slang::String& name);
         /// Set the function for the shared library
-    void setInnerMainFunc(const Slang::String& name, InnerMainFunc func);
+    void setTestTool(const Slang::String& name, Slang::ITestTool* tool);
 
         /// If true tests aren't being run just the information on testing is being accumulated
     bool isCollectingRequirements() const { return testRequirements != nullptr; }
@@ -105,9 +41,9 @@ class TestContext
     TestCategorySet categorySet;
 
         /// If set then tests are not run, but their requirements are set 
-    TestRequirements* testRequirements = nullptr;
+    Slang::TestRequirements* testRequirements = nullptr;
 
-    BackendFlags availableBackendFlags = 0;
+    Slang::BackendFlags availableBackendFlags = 0;
     Slang::RenderApiFlags availableRenderApiFlags = 0;
     bool isAvailableRenderApiFlagsValid = false;
 
@@ -115,7 +51,7 @@ protected:
     struct SharedLibraryTool
     {
         Slang::SharedLibrary::Handle m_sharedLibrary;
-        InnerMainFunc m_func;
+        Slang::ComPtr<Slang::ITestTool> m_testTool;
     };
 
     SlangSession* m_session;


### PR DESCRIPTION
* Added Slang::ITestTool interface
* Test runner can use this to run a test and/or to work out TestRequirements
* Removed command line parsing (for requirements) from slang-test
* Removed RendererType as it was doing the same thing as RenderApiType 
  * A future change might want to rename RenderApiType to RendererType
* StdWriters split to GlobalWriters/StdWriters
 
That the Global/StdWriters split is arguably something to fix in future PR. The problem was that StdWriters had global accessors called 'getOut' etc. But sometimes it was useful to get the StdWriters out. I think it would be better to just have StdWriters and getGlobalOut and setGlobal/getGlobal and use getXXX for the method. 
Using get/setGlobal is arguably better because it's not strictly a singleton, in that it is acceptable to have more than one instance of the object. 