### PR TITLE
Update glslang version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "external/glslang"]
 	path = external/glslang
-	url = https://github.com/KhronosGroup/glslang.git
+	url = https://github.com/shader-slang/glslang.git
 [submodule "external/tinyobjloader"]
 	path = external/tinyobjloader
 	url = https://github.com/syoyo/tinyobjloader

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -86,8 +86,7 @@ void requireGLSLHalfExtension(ExtensionUsageTracker* tracker)
         requireGLSLExtension(tracker, "GL_EXT_shader_16bit_storage");
 
         // https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GL_EXT_shader_explicit_arithmetic_types.txt
-        // Use GL_KHX_shader_explicit_arithmetic_types because that is what appears defined in glslang 
-        requireGLSLExtension(tracker, "GL_KHX_shader_explicit_arithmetic_types");
+        requireGLSLExtension(tracker, "GL_EXT_shader_explicit_arithmetic_types");
         
         tracker->hasHalfExtension = true;
     }

--- a/tests/compute/half-texture.slang.expected
+++ b/tests/compute/half-texture.slang.expected
@@ -15,8 +15,8 @@ standard output = {
                               ExecutionMode 4 LocalSize 4 4 1
                               Source GLSL 450
                               SourceExtension  "GL_EXT_shader_16bit_storage"
+                              SourceExtension  "GL_EXT_shader_explicit_arithmetic_types"
                               SourceExtension  "GL_GOOGLE_cpp_style_line_directive"
-                              SourceExtension  "GL_KHX_shader_explicit_arithmetic_types"
                               Name 4  "main"
                               Name 9  "pos_0"
                               Name 13  "gl_GlobalInvocationID"


### PR DESCRIPTION
This PR updates the version of glslang we depend on.

* This should pull in the fix for #937 that was made upstream.

* It also folds in our in-progress fix for KhronosGroup/glslang#1748, with the expectation that we will switch to a vanilla version of upstream glslang once a completed version of that PR is accepted.

* There was one extension that got renamed inside of the glslang compiler that required changes to how we emit GLSL code. It seems like the old name was effectively a bug (and our code has a comment about how it seemed weird), so this seems like a reasonable fix.