### PR TITLE
Fix 'unreachable code' stopping compilation on VS2017.

### DIFF
--- a/source/slang/object-meta-begin.h
+++ b/source/slang/object-meta-begin.h
@@ -34,3 +34,10 @@
 
 #define SIMPLE_SYNTAX_CLASS(NAME, BASE) SYNTAX_CLASS(NAME, BASE) END_SYNTAX_CLASS()
 
+// Hack to remove 'warning C4702: unreachable code' on VS2017, blocking compilation
+// Note! This is matched in object-meta-end.h 
+#if _MSC_VER >= 1910
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
+

--- a/source/slang/object-meta-end.h
+++ b/source/slang/object-meta-end.h
@@ -9,3 +9,9 @@
 #undef DECL_FIELD
 #undef RAW
 #undef SIMPLE_SYNTAX_CLASS
+
+// Hack to remove 'warning C4702: unreachable code' on VS2017, blocking compilation
+// Note! This is matched in object-meta-begin.h 
+#if _MSC_VER >= 1910
+#pragma warning(pop)
+#endif


### PR DESCRIPTION
When building with VS2017, compilation failed for slang because of an 'unreachable code' warning is produced for code generated using macros - such as with expr-defs.h. The reason for warning couldn't be determined by visual inspection. To fix the warning is disabled when the macros are used via the 'object-meta-begin.h' and 'object-meta-end.h' include. 

It may worth looking into more in the future why VS2017 thinks there is a problem, and perhaps doing so will allow for a less heavy handed solution.