### PR TITLE
Bring Path class more inline with stated codebase conventions

### DIFF
--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -29,7 +29,7 @@
 
 namespace Slang
 {
-	bool File::Exists(const String & fileName)
+	bool File::exists(const String& fileName)
 	{
 #ifdef _WIN32
 		struct _stat32 statVar;
@@ -40,7 +40,7 @@ namespace Slang
 #endif
 	}
 
-	String Path::TruncateExt(const String & path)
+	String Path::truncateExt(const String& path)
 	{
 		UInt dotPos = path.LastIndexOf('.');
 		if (dotPos != -1)
@@ -48,7 +48,7 @@ namespace Slang
 		else
 			return path;
 	}
-	String Path::ReplaceExt(const String & path, const char * newExt)
+	String Path::replaceExt(const String& path, const char* newExt)
 	{
 		StringBuilder sb(path.Length()+10);
 		UInt dotPos = path.LastIndexOf('.');
@@ -75,7 +75,7 @@ namespace Slang
         return pos;
     }
 
-	String Path::GetFileName(const String & path)
+	String Path::getFileName(const String& path)
 	{
         UInt pos = findLastSeparator(path);
         if (pos != -1)
@@ -88,15 +88,15 @@ namespace Slang
             return path;
         }
 	}
-	String Path::GetFileNameWithoutEXT(const String & path)
+	String Path::getFileNameWithoutExt(const String& path)
 	{
-        String fileName = GetFileName(path);
+        String fileName = getFileName(path);
 		UInt dotPos = fileName.LastIndexOf('.');
 		if (dotPos == -1)
             return fileName;
 		return fileName.SubString(0, dotPos);
 	}
-	String Path::GetFileExt(const String & path)
+	String Path::getFileExt(const String& path)
 	{
 		UInt dotPos = path.LastIndexOf('.');
 		if (dotPos != -1)
@@ -104,7 +104,7 @@ namespace Slang
 		else
 			return "";
 	}
-	String Path::GetDirectoryName(const String & path)
+	String Path::getParentDirectory(const String& path)
 	{
         UInt pos = findLastSeparator(path);
 		if (pos != -1)
@@ -112,30 +112,30 @@ namespace Slang
 		else
 			return "";
 	}
-	String Path::Combine(const String & path1, const String & path2)
+	String Path::combine(const String& path1, const String& path2)
 	{
 		if (path1.Length() == 0) return path2;
 		StringBuilder sb(path1.Length()+path2.Length()+2);
 		sb.Append(path1);
 		if (!path1.EndsWith('\\') && !path1.EndsWith('/'))
-			sb.Append(PathDelimiter);
+			sb.Append(kPathDelimiter);
 		sb.Append(path2);
 		return sb.ProduceString();
 	}
-	String Path::Combine(const String & path1, const String & path2, const String & path3)
+	String Path::combine(const String& path1, const String& path2, const String& path3)
 	{
 		StringBuilder sb(path1.Length()+path2.Length()+path3.Length()+3);
 		sb.Append(path1);
 		if (!path1.EndsWith('\\') && !path1.EndsWith('/'))
-			sb.Append(PathDelimiter);
+			sb.Append(kPathDelimiter);
 		sb.Append(path2);
 		if (!path2.EndsWith('\\') && !path2.EndsWith('/'))
-			sb.Append(PathDelimiter);
+			sb.Append(kPathDelimiter);
 		sb.Append(path3);
 		return sb.ProduceString();
 	}
 
-    /* static */ bool Path::IsDriveSpecification(const UnownedStringSlice& element)
+    /* static */ bool Path::isDriveSpecification(const UnownedStringSlice& element)
     {
         switch (element.size())
         {
@@ -155,7 +155,7 @@ namespace Slang
         
     }
 
-    /* static */void Path::Split(const UnownedStringSlice& path, List<UnownedStringSlice>& splitOut)
+    /* static */void Path::split(const UnownedStringSlice& path, List<UnownedStringSlice>& splitOut)
     {
         splitOut.Clear();
 
@@ -166,7 +166,7 @@ namespace Slang
         {
             const char* cur = start;
             // Find the split
-            while (cur < end && !IsDelimiter(*cur)) cur++;
+            while (cur < end && !isDelimiter(*cur)) cur++;
 
             splitOut.Add(UnownedStringSlice(start, cur));
            
@@ -177,7 +177,7 @@ namespace Slang
         // Okay if the end is empty. And we aren't with a spec like // or c:/ , then drop the final slash 
         if (splitOut.Count() > 1 && splitOut.Last().size() == 0)
         {
-            if (splitOut.Count() == 2 && IsDriveSpecification(splitOut[0]))
+            if (splitOut.Count() == 2 && isDriveSpecification(splitOut[0]))
             {
                 return;
             }
@@ -186,12 +186,12 @@ namespace Slang
         }
     }
 
-    /* static */bool Path::IsRelative(const UnownedStringSlice& path)
+    /* static */bool Path::isRelative(const UnownedStringSlice& path)
     {
-        List<UnownedStringSlice> split;
-        Split(path, split);
+        List<UnownedStringSlice> splitPath;
+        split(path, splitPath);
 
-        for (const auto& cur : split)
+        for (const auto& cur : splitPath)
         {
             if (cur == "." || cur == "..")
             {
@@ -201,56 +201,56 @@ namespace Slang
         return false;
     }
 
-    /* static */String Path::Simplify(const UnownedStringSlice& path)
+    /* static */String Path::simplify(const UnownedStringSlice& path)
     {
-        List<UnownedStringSlice> split;
-        Split(path, split);
+        List<UnownedStringSlice> splitPath;
+        split(path, splitPath);
 
         // Strictly speaking we could do something about case on platforms like window, but here we won't worry about that
-        for (int i = 0; i < int(split.Count()); i++)
+        for (int i = 0; i < int(splitPath.Count()); i++)
         {
-            const UnownedStringSlice& cur = split[i];
-            if (cur == "." && split.Count() > 1)
+            const UnownedStringSlice& cur = splitPath[i];
+            if (cur == "." && splitPath.Count() > 1)
             {
                 // Just remove it 
-                split.RemoveAt(i);
+                splitPath.RemoveAt(i);
                 i--;
             }
             else if (cur == ".." && i > 0)
             {
                 // Can we remove this and the one before ?
-                UnownedStringSlice& before = split[i - 1];
-                if (before == ".." || (i == 1 && IsDriveSpecification(before)))
+                UnownedStringSlice& before = splitPath[i - 1];
+                if (before == ".." || (i == 1 && isDriveSpecification(before)))
                 {
                     // Can't do it
                     continue;
                 }
-                split.RemoveRange(i - 1, 2);
+                splitPath.RemoveRange(i - 1, 2);
                 i -= 2;
             }
         }
 
         // If its empty it must be .
-        if (split.Count() == 0)
+        if (splitPath.Count() == 0)
         {
-            split.Add(UnownedStringSlice::fromLiteral("."));
+            splitPath.Add(UnownedStringSlice::fromLiteral("."));
         }
    
         // Reconstruct the string
         StringBuilder builder;
-        for (int i = 0; i < int(split.Count()); i++)
+        for (int i = 0; i < int(splitPath.Count()); i++)
         {
             if (i > 0)
             {
-                builder.Append(PathDelimiter);
+                builder.Append(kPathDelimiter);
             }
-            builder.Append(split[i]);
+            builder.Append(splitPath[i]);
         }
 
         return builder;
     }
 
-	bool Path::CreateDir(const String & path)
+	bool Path::createDirectory(const String& path)
 	{
 #if defined(_WIN32)
 		return _wmkdir(path.ToWString()) == 0;
@@ -259,7 +259,7 @@ namespace Slang
 #endif
 	}
 
-    /* static */SlangResult Path::GetPathType(const String & path, SlangPathType* pathTypeOut)
+    /* static */SlangResult Path::getPathType(const String& path, SlangPathType* pathTypeOut)
     {
 #ifdef _WIN32
         // https://msdn.microsoft.com/en-us/library/14h5k7ff.aspx
@@ -302,7 +302,7 @@ namespace Slang
     }
 
 
-    /* static */SlangResult Path::GetCanonical(const String & path, String & canonicalPathOut)
+    /* static */SlangResult Path::getCanonical(const String& path, String& canonicalPathOut)
     {
 #if defined(_WIN32)
         // https://msdn.microsoft.com/en-us/library/506720ff.aspx
@@ -367,7 +367,7 @@ namespace Slang
         outPath[resSize - 1] = 0;
         return SLANG_OK;
 #   else        
-        String text = Slang::File::ReadAllText("/proc/self/maps");
+        String text = Slang::File::readAllText("/proc/self/maps");
         UInt startIndex = text.IndexOf('/');
         if (startIndex == UInt(-1))
         {
@@ -437,19 +437,19 @@ namespace Slang
         }
     }
 
-    /* static */String Path::GetExecutablePath()
+    /* static */String Path::getExecutablePath()
     {
         static String executablePath = _getExecutablePath();
         return executablePath;
     }
 
-	Slang::String File::ReadAllText(const Slang::String & fileName)
+	Slang::String File::readAllText(const Slang::String& fileName)
 	{
 		StreamReader reader(new FileStream(fileName, FileMode::Open, FileAccess::Read, FileShare::ReadWrite));
 		return reader.ReadToEnd();
 	}
 
-	Slang::List<unsigned char> File::ReadAllBytes(const Slang::String & fileName)
+	Slang::List<unsigned char> File::readAllBytes(const Slang::String& fileName)
 	{
 		RefPtr<FileStream> fs = new FileStream(fileName, FileMode::Open, FileAccess::Read, FileShare::ReadWrite);
 		List<unsigned char> buffer;
@@ -465,12 +465,11 @@ namespace Slang
 		return _Move(buffer);
 	}
 
-	void File::WriteAllText(const Slang::String & fileName, const Slang::String & text)
+	void File::writeAllText(const Slang::String& fileName, const Slang::String& text)
 	{
 		StreamWriter writer(new FileStream(fileName, FileMode::Create));
 		writer.Write(text);
 	}
-
 
 }
 

--- a/source/core/slang-io.h
+++ b/source/core/slang-io.h
@@ -11,49 +11,60 @@ namespace Slang
 	class File
 	{
 	public:
-		static bool Exists(const Slang::String & fileName);
-		static Slang::String ReadAllText(const Slang::String & fileName);
-		static Slang::List<unsigned char> ReadAllBytes(const Slang::String & fileName);
-		static void WriteAllText(const Slang::String & fileName, const Slang::String & text);
+		static bool exists(const Slang::String& fileName);
+		static Slang::String readAllText(const Slang::String& fileName);
+		static Slang::List<unsigned char> readAllBytes(const Slang::String& fileName);
+		static void writeAllText(const Slang::String& fileName, const Slang::String& text);
 	};
 
 	class Path
 	{
 	public:
-		static const char PathDelimiter = '/';
+		static const char kPathDelimiter = '/';
 
-		static String TruncateExt(const String & path);
-		static String ReplaceExt(const String & path, const char * newExt);
-		static String GetFileName(const String & path);
-		static String GetFileNameWithoutEXT(const String & path);
-		static String GetFileExt(const String & path);
-		static String GetDirectoryName(const String & path);
-		static String Combine(const String & path1, const String & path2);
-		static String Combine(const String & path1, const String & path2, const String & path3);
-		static bool CreateDir(const String & path);
+		static String truncateExt(const String& path);
+		static String replaceExt(const String& path, const char* newExt);
+		static String getFileName(const String& path);
+		static String getFileNameWithoutExt(const String& path);
+		static String getFileExt(const String& path);
+		static String getParentDirectory(const String& path);
+		static String combine(const String& path1, const String& path2);
+		static String combine(const String& path1, const String& path2, const String& path3);
+		static bool createDirectory(const String& path);
 
             /// Accept either style of delimiter
-        SLANG_FORCE_INLINE static bool IsDelimiter(char c) { return c == '/' || c == '\\'; }
+        SLANG_FORCE_INLINE static bool isDelimiter(char c) { return c == '/' || c == '\\'; }
 
-        static bool IsDriveSpecification(const UnownedStringSlice& element);
+            /// True if the element appears to be a drive specification (where element is the prefix to a path that isn't a directory)
+            /// @param pathPrefix The path prefix to test if it's a drive specification
+        static bool isDriveSpecification(const UnownedStringSlice& pathPrefix);
 
             /// Splits the path into it's individual bits
-        static void Split(const UnownedStringSlice& path, List<UnownedStringSlice>& splitOut);
+        static void split(const UnownedStringSlice& path, List<UnownedStringSlice>& splitOut);
             /// Strips .. and . as much as it can 
-        static String Simplify(const UnownedStringSlice& path);
-        static String Simplify(const String& path) { return Simplify(path.getUnownedSlice()); }
+        static String simplify(const UnownedStringSlice& path);
+        static String simplify(const String& path) { return simplify(path.getUnownedSlice()); }
 
             /// Returns true if a path contains a . or ..
-        static bool IsRelative(const UnownedStringSlice& path);
-        static bool IsRelative(const String& path) { return IsRelative(path.getUnownedSlice()); }
+        static bool isRelative(const UnownedStringSlice& path);
+        static bool isRelative(const String& path) { return isRelative(path.getUnownedSlice()); }
 
-        static SlangResult GetPathType(const String & path, SlangPathType* pathTypeOut);
+            /// Determines the type of file at the path
+            /// @param path The path to test
+            /// @param outPathType Holds the object type at the path on success
+            /// @return SLANG_OK on success
+        static SlangResult getPathType(const String& path, SlangPathType* outPathType);
 
-        static SlangResult GetCanonical(const String & path, String& canonicalPathOut);
+            /// Determines the canonical equivalent path to path.
+            /// The path returned should reference the identical object - and two different references to the same path should return the same canonical path
+            /// @param path Path to get the canonical path for
+            /// @param outCanonicalPath The canonical path for 'path' is call is successful
+            /// @return SLANG_OK on success
+        static SlangResult getCanonical(const String& path, String& outCanonicalPath);
 
             /// Returns the executable path
             /// @return The path in platform native format. Returns empty string if failed.
-        static String GetExecutablePath();
+        static String getExecutablePath();
 
 	};
 }

--- a/source/core/slang-shared-library.cpp
+++ b/source/core/slang-shared-library.cpp
@@ -106,7 +106,7 @@ SlangResult ConfigurableSharedLibraryLoader::loadSharedLibrary(const char* path,
     // Okay we need to reconstruct the name and insert the path
     StringBuilder builder;
     SharedLibrary::appendPlatformFileName(UnownedStringSlice(pathIn), builder);
-    String path = Path::Combine(entryString, builder);
+    String path = Path::combine(entryString, builder);
 
     return SharedLibrary::loadWithPlatformFilename(path.begin(), handleOut);
 }

--- a/source/core/stream.cpp
+++ b/source/core/stream.cpp
@@ -57,7 +57,7 @@ namespace Slang
 			}
 			break;
 		case Slang::FileMode::CreateNew:
-			if (File::Exists(fileName))
+			if (File::exists(fileName))
 			{
 				throw IOException("Failed opening '" + fileName + "', file already exists.");
 			}

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -294,10 +294,10 @@ static bool _isSubCommand(const char* arg)
     if (optionsOut->binDir.Length() == 0)
     {
         // If the binDir isn't set try using the path to the executable
-        String exePath = Path::GetExecutablePath();
+        String exePath = Path::getExecutablePath();
         if (exePath.Length())
         {
-            optionsOut->binDir = Path::GetDirectoryName(exePath);
+            optionsOut->binDir = Path::getParentDirectory(exePath);
         }
     }
 

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -332,7 +332,7 @@ TestResult gatherTestsForFile(
     String fileContents;
     try
     {
-        fileContents = Slang::File::ReadAllText(filePath);
+        fileContents = Slang::File::readAllText(filePath);
     }
     catch (Slang::IOException)
     {
@@ -405,7 +405,7 @@ OSError spawnAndWaitExe(TestContext* context, const String& testPath, OSProcessS
 OSError spawnAndWaitSharedLibrary(TestContext* context, const String& testPath, OSProcessSpawner& spawner)
 {
     const auto& options = context->options;
-    String exeName = Path::GetFileNameWithoutEXT(spawner.executableName_);
+    String exeName = Path::getFileNameWithoutExt(spawner.executableName_);
 
     if (options.shouldBeVerbose)
     {
@@ -728,7 +728,7 @@ static SlangResult _extractReflectionTestRequirements(OSProcessSpawner& spawner,
 
 static SlangResult _extractTestRequirements(OSProcessSpawner& spawner, TestRequirements* ioInfo)
 {
-    String exeName = Path::GetFileNameWithoutEXT(spawner.executableName_);
+    String exeName = Path::getFileNameWithoutExt(spawner.executableName_);
 
     if (exeName == "render-test")
     {
@@ -765,7 +765,7 @@ static RenderApiFlags _getAvailableRenderApiFlags(TestContext* context)
             {
                 // Try starting up the device
                 OSProcessSpawner spawner;
-                spawner.pushExecutablePath(Path::Combine(context->options.binDir,  String("render-test") + osGetExecutableSuffix()));
+                spawner.pushExecutablePath(Path::combine(context->options.binDir,  String("render-test") + osGetExecutableSuffix()));
                 _addRenderTestOptions(context->options, spawner);
                 // We just want to see if the device can be started up
                 spawner.pushArgument("-only-startup");
@@ -867,7 +867,7 @@ String findExpectedPath(const TestInput& input, const char* postFix)
     {
         specializedBuf << postFix;
     }
-    if (File::Exists(specializedBuf))
+    if (File::exists(specializedBuf))
     {
         return specializedBuf;
     }
@@ -882,7 +882,7 @@ String findExpectedPath(const TestInput& input, const char* postFix)
         defaultBuf << postFix;
     }
 
-    if (File::Exists(defaultBuf))
+    if (File::exists(defaultBuf))
     {
         return defaultBuf;
     }
@@ -895,7 +895,7 @@ String findExpectedPath(const TestInput& input, const char* postFix)
 
 static void _initSlangCompiler(TestContext* context, OSProcessSpawner& spawnerOut)
 {
-    spawnerOut.pushExecutablePath(Path::Combine(context->options.binDir, String("slangc") + osGetExecutableSuffix()));
+    spawnerOut.pushExecutablePath(Path::combine(context->options.binDir, String("slangc") + osGetExecutableSuffix()));
 
     if (context->options.verbosePaths)
     {
@@ -952,7 +952,7 @@ TestResult runSimpleTest(TestContext* context, TestInput& input)
     String expectedOutput;
     try
     {
-        expectedOutput = Slang::File::ReadAllText(expectedOutputPath);
+        expectedOutput = Slang::File::readAllText(expectedOutputPath);
     }
     catch (Slang::IOException)
     {
@@ -980,7 +980,7 @@ TestResult runSimpleTest(TestContext* context, TestInput& input)
     if (result == TestResult::Fail)
     {
         String actualOutputPath = outputStem + ".actual";
-        Slang::File::WriteAllText(actualOutputPath, actualOutput);
+        Slang::File::writeAllText(actualOutputPath, actualOutput);
 
         context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
     }
@@ -1007,7 +1007,7 @@ TestResult runReflectionTest(TestContext* context, TestInput& input)
 
     OSProcessSpawner spawner;
 
-    spawner.pushExecutablePath(Path::Combine(options.binDir, String("slang-reflection-test") + osGetExecutableSuffix()));
+    spawner.pushExecutablePath(Path::combine(options.binDir, String("slang-reflection-test") + osGetExecutableSuffix()));
     spawner.pushArgument(filePath);
 
     for( auto arg : input.testOptions->args )
@@ -1028,7 +1028,7 @@ TestResult runReflectionTest(TestContext* context, TestInput& input)
     String expectedOutput;
     try
     {
-        expectedOutput = Slang::File::ReadAllText(expectedOutputPath);
+        expectedOutput = Slang::File::readAllText(expectedOutputPath);
     }
     catch (Slang::IOException)
     {
@@ -1055,7 +1055,7 @@ TestResult runReflectionTest(TestContext* context, TestInput& input)
     if (result == TestResult::Fail)
     {
         String actualOutputPath = outputStem + ".actual";
-        Slang::File::WriteAllText(actualOutputPath, actualOutput);
+        Slang::File::writeAllText(actualOutputPath, actualOutput);
 
         context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
     }
@@ -1069,7 +1069,7 @@ String getExpectedOutput(String const& outputStem)
     String expectedOutput;
     try
     {
-        expectedOutput = Slang::File::ReadAllText(expectedOutputPath);
+        expectedOutput = Slang::File::readAllText(expectedOutputPath);
     }
     catch (Slang::IOException)
     {
@@ -1157,7 +1157,7 @@ TestResult runCrossCompilerTest(TestContext* context, TestInput& input)
         String expectedOutputPath = outputStem + ".expected";
         try
         {
-            Slang::File::WriteAllText(expectedOutputPath, expectedOutput);
+            Slang::File::writeAllText(expectedOutputPath, expectedOutput);
         }
         catch (Slang::IOException)
         {
@@ -1197,7 +1197,7 @@ TestResult runCrossCompilerTest(TestContext* context, TestInput& input)
     if (result == TestResult::Fail)
     {
         String actualOutputPath = outputStem + ".actual";
-        Slang::File::WriteAllText(actualOutputPath, actualOutput);
+        Slang::File::writeAllText(actualOutputPath, actualOutput);
 
         context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
     }
@@ -1236,7 +1236,7 @@ TestResult generateHLSLBaseline(TestContext* context, TestInput& input)
     String expectedOutputPath = outputStem + ".expected";
     try
     {
-        Slang::File::WriteAllText(expectedOutputPath, expectedOutput);
+        Slang::File::writeAllText(expectedOutputPath, expectedOutput);
     }
     catch (Slang::IOException)
     {
@@ -1305,7 +1305,7 @@ TestResult runHLSLComparisonTest(TestContext* context, TestInput& input)
     String expectedOutput;
     try
     {
-        expectedOutput = Slang::File::ReadAllText(expectedOutputPath);
+        expectedOutput = Slang::File::readAllText(expectedOutputPath);
     }
     catch (Slang::IOException)
     {
@@ -1342,7 +1342,7 @@ TestResult runHLSLComparisonTest(TestContext* context, TestInput& input)
     if (result == TestResult::Fail)
     {
         String actualOutputPath = outputStem + ".actual";
-        Slang::File::WriteAllText(actualOutputPath, actualOutput);
+        Slang::File::writeAllText(actualOutputPath, actualOutput);
 
         context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
     }
@@ -1438,8 +1438,8 @@ TestResult runGLSLComparisonTest(TestContext* context, TestInput& input)
         return TestResult::Ignored;
     }
 
-    Slang::File::WriteAllText(outputStem + ".expected", expectedOutput);
-    Slang::File::WriteAllText(outputStem + ".actual",   actualOutput);
+    Slang::File::writeAllText(outputStem + ".expected", expectedOutput);
+    Slang::File::writeAllText(outputStem + ".actual",   actualOutput);
 
     if( hlslResult  == TestResult::Fail )   return TestResult::Fail;
     if( slangResult == TestResult::Fail )   return TestResult::Fail;
@@ -1471,7 +1471,7 @@ TestResult runComputeComparisonImpl(TestContext* context, TestInput& input, cons
 
 	OSProcessSpawner spawner;
 
-	spawner.pushExecutablePath(Path::Combine(context->options.binDir, String("render-test") + osGetExecutableSuffix()));
+	spawner.pushExecutablePath(Path::combine(context->options.binDir, String("render-test") + osGetExecutableSuffix()));
 	spawner.pushArgument(filePath999);
 
     _addRenderTestOptions(context->options, spawner);
@@ -1492,7 +1492,7 @@ TestResult runComputeComparisonImpl(TestContext* context, TestInput& input, cons
     if (context->isExecuting())
     {
         // clear the stale actual output file first. This will allow us to detect error if render-test fails and outputs nothing.
-        File::WriteAllText(actualOutputFile, "");
+        File::writeAllText(actualOutputFile, "");
     }
 
 	TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, spawner));
@@ -1515,26 +1515,26 @@ TestResult runComputeComparisonImpl(TestContext* context, TestInput& input, cons
         context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
 
         String actualOutputPath = outputStem + ".actual";
-        Slang::File::WriteAllText(actualOutputPath, actualOutput);
+        Slang::File::writeAllText(actualOutputPath, actualOutput);
 
         return TestResult::Fail;
     }
 
 	// check against reference output
-    if (!File::Exists(actualOutputFile))
+    if (!File::exists(actualOutputFile))
     {
         printf("render-test not producing expected outputs.\n");
         printf("render-test output:\n%s\n", actualOutput.Buffer());
 		return TestResult::Fail;
     }
-    if (!File::Exists(referenceOutput))
+    if (!File::exists(referenceOutput))
     {
         printf("referenceOutput %s not found.\n", referenceOutput.Buffer());
 		return TestResult::Fail;
     }
-    auto actualOutputContent = File::ReadAllText(actualOutputFile);
+    auto actualOutputContent = File::readAllText(actualOutputFile);
 	auto actualProgramOutput = Split(actualOutputContent, '\n');
-	auto referenceProgramOutput = Split(File::ReadAllText(referenceOutput), '\n');
+	auto referenceProgramOutput = Split(File::readAllText(referenceOutput), '\n');
     auto printOutput = [&]()
     {
         context->reporter->messageFormat(TestMessageType::TestFailure, "output mismatch! actual output: {\n%s\n}, \n%s\n", actualOutputContent.Buffer(), actualOutput.Buffer());
@@ -1589,7 +1589,7 @@ TestResult doRenderComparisonTestRun(TestContext* context, TestInput& input, cha
 
     OSProcessSpawner spawner;
 
-    spawner.pushExecutablePath(Path::Combine(context->options.binDir, String("render-test") + osGetExecutableSuffix()));
+    spawner.pushExecutablePath(Path::combine(context->options.binDir, String("render-test") + osGetExecutableSuffix()));
     spawner.pushArgument(filePath);
 
     _addRenderTestOptions(context->options, spawner);
@@ -1820,8 +1820,8 @@ TestResult runHLSLRenderComparisonTestImpl(
         return TestResult::Pass;
     }
 
-    Slang::File::WriteAllText(outputStem + ".expected", expectedOutput);
-    Slang::File::WriteAllText(outputStem + ".actual",   actualOutput);
+    Slang::File::writeAllText(outputStem + ".expected", expectedOutput);
+    Slang::File::writeAllText(outputStem + ".actual",   actualOutput);
 
     if( hlslResult  == TestResult::Fail )   return TestResult::Fail;
     if( slangResult == TestResult::Fail )   return TestResult::Fail;

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -58,7 +58,7 @@ TestContext::InnerMainFunc TestContext::getInnerMainFunc(const String& dirPath, 
 
     StringBuilder builder;
     SharedLibrary::appendPlatformFileName(sharedLibToolBuilder.getUnownedSlice(), builder);
-    String path = Path::Combine(dirPath, builder);
+    String path = Path::combine(dirPath, builder);
 
     SharedLibraryTool tool = {};
 

--- a/tools/slang-test/unit-test-path.cpp
+++ b/tools/slang-test/unit-test-path.cpp
@@ -11,48 +11,48 @@ static void pathUnitTest()
 {
     {
         String path;
-        SlangResult res = Path::GetCanonical(".", path);
+        SlangResult res = Path::getCanonical(".", path);
         SLANG_CHECK(SLANG_SUCCEEDED(res));
 
         String parentPath;
-        res = Path::GetCanonical("..", parentPath);
+        res = Path::getCanonical("..", parentPath);
         SLANG_CHECK(SLANG_SUCCEEDED(res));
 
-        String parentPath2 = Path::GetDirectoryName(path);
+        String parentPath2 = Path::getParentDirectory(path);
         SLANG_CHECK(parentPath == parentPath2);
     }
     // Test the paths
     {
-        SLANG_CHECK(Path::Simplify(".") == ".");
-        SLANG_CHECK(Path::Simplify("..") == "..");
-        SLANG_CHECK(Path::Simplify("blah/..") == ".");
+        SLANG_CHECK(Path::simplify(".") == ".");
+        SLANG_CHECK(Path::simplify("..") == "..");
+        SLANG_CHECK(Path::simplify("blah/..") == ".");
 
-        SLANG_CHECK(Path::Simplify("blah/.././a") == "a");
+        SLANG_CHECK(Path::simplify("blah/.././a") == "a");
 
-        SLANG_CHECK(Path::Simplify("a:/what/.././../is/./../this/.") == "a:/../this");
+        SLANG_CHECK(Path::simplify("a:/what/.././../is/./../this/.") == "a:/../this");
 
-        SLANG_CHECK(Path::Simplify("a:/what/.././../is/./../this/./") == "a:/../this");
+        SLANG_CHECK(Path::simplify("a:/what/.././../is/./../this/./") == "a:/../this");
 
-        SLANG_CHECK(Path::Simplify("a:\\what\\..\\.\\..\\is\\.\\..\\this\\.\\") == "a:/../this");
+        SLANG_CHECK(Path::simplify("a:\\what\\..\\.\\..\\is\\.\\..\\this\\.\\") == "a:/../this");
 
-        SLANG_CHECK(Path::Simplify("tests/preprocessor/.\\pragma-once-a.h") == "tests/preprocessor/pragma-once-a.h");
-
-
-        SLANG_CHECK(Path::IsRelative("."));
-        SLANG_CHECK(Path::IsRelative(".."));
-        SLANG_CHECK(Path::IsRelative("blah/.."));
-
-        SLANG_CHECK(Path::IsRelative("blah/.././a"));
-        SLANG_CHECK(Path::IsRelative("a") == false);
-        SLANG_CHECK(Path::IsRelative("blah/a") == false);
-        SLANG_CHECK(Path::IsRelative("a:\\blah/a") == false);
+        SLANG_CHECK(Path::simplify("tests/preprocessor/.\\pragma-once-a.h") == "tests/preprocessor/pragma-once-a.h");
 
 
-        SLANG_CHECK(Path::IsRelative("a:/what/.././../is/./../this/."));
+        SLANG_CHECK(Path::isRelative("."));
+        SLANG_CHECK(Path::isRelative(".."));
+        SLANG_CHECK(Path::isRelative("blah/.."));
 
-        SLANG_CHECK(Path::IsRelative("a:/what/.././../is/./../this/./"));
+        SLANG_CHECK(Path::isRelative("blah/.././a"));
+        SLANG_CHECK(Path::isRelative("a") == false);
+        SLANG_CHECK(Path::isRelative("blah/a") == false);
+        SLANG_CHECK(Path::isRelative("a:\\blah/a") == false);
 
-        SLANG_CHECK(Path::IsRelative("a:\\what\\..\\.\\..\\is\\.\\..\\this\\.\\"));
+
+        SLANG_CHECK(Path::isRelative("a:/what/.././../is/./../this/."));
+
+        SLANG_CHECK(Path::isRelative("a:/what/.././../is/./../this/./"));
+
+        SLANG_CHECK(Path::isRelative("a:\\what\\..\\.\\..\\is\\.\\..\\this\\.\\"));
 
 
     }


### PR DESCRIPTION
* Make Path:: use lowerCamel method names as per coding standard
* Small improvements to make closer to standard
* GetDirectoryName -> getParentDirectory - previous method name's action was somewhat unclear, hopefully this is better