### PR TITLE
String/List closer to conventions, and use Index type

### DIFF
--- a/source/core/allocator.h
+++ b/source/core/allocator.h
@@ -8,7 +8,7 @@
 
 namespace Slang
 {
-	inline void* AlignedAlloc(size_t size, size_t alignment)
+	inline void* alignedAllocate(size_t size, size_t alignment)
 	{
 #ifdef _MSC_VER
 		return _aligned_malloc(size, alignment);
@@ -23,7 +23,7 @@ namespace Slang
 #endif
 	}
 
-	inline void AlignedFree(void* ptr)
+	inline void alignedDeallocate(void* ptr)
 	{
 #ifdef _MSC_VER
 		_aligned_free(ptr);
@@ -36,27 +36,27 @@ namespace Slang
 	{
 	public:
 		// not really called
-		void* Alloc(size_t size)
+		void* allocate(size_t size)
 		{
-			return malloc(size);
+			return ::malloc(size);
 		}
-		void Free(void * ptr)
+		void deallocate(void * ptr)
 		{
-			return free(ptr);
+			return ::free(ptr);
 		}
 	};
 
-	template<int alignment>
+	template<int ALIGNMENT>
 	class AlignedAllocator
 	{
 	public:
-		void* Alloc(size_t size)
+		void* allocate(size_t size)
 		{
-			return AlignedAlloc(size, alignment);
+			return alignedAllocate(size, ALIGNMENT);
 		}
-		void Free(void * ptr)
+		void deallocate(void * ptr)
 		{
-			return AlignedFree(ptr);
+			return alignedDeallocate(ptr);
 		}
 	};
 }

--- a/source/core/allocator.h
+++ b/source/core/allocator.h
@@ -8,7 +8,7 @@
 
 namespace Slang
 {
-	inline void * AlignedAlloc(size_t size, size_t alignment)
+	inline void* AlignedAlloc(size_t size, size_t alignment)
 	{
 #ifdef _MSC_VER
 		return _aligned_malloc(size, alignment);
@@ -23,7 +23,7 @@ namespace Slang
 #endif
 	}
 
-	inline void AlignedFree(void * ptr)
+	inline void AlignedFree(void* ptr)
 	{
 #ifdef _MSC_VER
 		_aligned_free(ptr);
@@ -36,7 +36,7 @@ namespace Slang
 	{
 	public:
 		// not really called
-		void * Alloc(size_t size)
+		void* Alloc(size_t size)
 		{
 			return malloc(size);
 		}
@@ -50,7 +50,7 @@ namespace Slang
 	class AlignedAllocator
 	{
 	public:
-		void * Alloc(size_t size)
+		void* Alloc(size_t size)
 		{
 			return AlignedAlloc(size, alignment);
 		}

--- a/source/core/array-view.h
+++ b/source/core/array-view.h
@@ -1,7 +1,7 @@
 #ifndef CORE_LIB_ARRAY_VIEW_H
 #define CORE_LIB_ARRAY_VIEW_H
 
-#include "exception.h"
+#include "common.h"
 
 namespace Slang
 {
@@ -9,104 +9,90 @@ namespace Slang
 	class ArrayView
 	{
 	private:
-		T * _buffer;
-		int _count;
-		int stride;
+		T* m_buffer;
+		int m_size;
 	public:
-		T* begin() const
-		{
-			return _buffer;
-		}
-		T* end() const
-		{
-			return (T*)((char*)_buffer + _count*stride);
-		}
+        const T* begin() const { return m_buffer; }
+        T* begin() { return m_buffer; }
+
+        const T* end() const { return m_buffer + m_size; }
+        T* end() { return m_buffer + m_size; }
+        
 	public:
-		ArrayView()
-		{
-			_buffer = 0;
-			_count = 0;
+		ArrayView():
+			m_buffer(nullptr),
+			m_size(0)
+        {
 		}
-		ArrayView(const T & singleObj)
-		{
-			SetData((T*)&singleObj, 1, sizeof(T));
+		ArrayView(T& singleObj):
+            m_buffer(&singleObj),
+            m_size(1)
+        {
 		}
-		ArrayView(T * buffer, int count)
+		ArrayView(T* buffer, int size):
+            m_buffer(buffer),
+            m_size(size)
 		{
-			SetData(buffer, count, sizeof(T));
 		}
-		ArrayView(void * buffer, int count, int _stride)
+		
+		inline int getSize() const
 		{
-			SetData(buffer, count, _stride);
-		}
-		void SetData(void * buffer, int count, int _stride)
-		{
-			this->_buffer = (T*)buffer;
-			this->_count = count;
-			this->stride = _stride;
-		}
-		inline int GetCapacity() const
-		{
-			return _count;
-		}
-		inline int Count() const
-		{
-			return _count;
+			return m_size;
 		}
 
-		inline T & operator [](int id) const
+		inline const T& operator [](int idx) const
 		{
-#if _DEBUG
-			if (id >= _count || id < 0)
-				throw IndexOutofRangeException("Operator[]: Index out of Range.");
-#endif
-			return *(T*)((char*)_buffer+id*stride);
+            SLANG_ASSERT(idx >= 0 && idx <= m_size);
+            return m_buffer[idx];
 		}
+        inline T& operator [](int idx)
+        {
+            SLANG_ASSERT(idx >= 0 && idx <= m_size);
+            return m_buffer[idx];
+        }
 
-		inline T* Buffer() const
-		{
-			return _buffer;
-		}
+        inline const T* Buffer() const {return m_buffer; }
+        inline T* Buffer() { return m_buffer; }
 
 		template<typename T2>
-		int IndexOf(const T2 & val) const
+		int indexOf(const T2 & val) const
 		{
-			for (int i = 0; i < _count; i++)
+			for (int i = 0; i < m_size; i++)
 			{
-				if (*(T*)((char*)_buffer + i*stride) == val)
+				if (m_buffer[i] == val)
 					return i;
 			}
 			return -1;
 		}
 
 		template<typename T2>
-		int LastIndexOf(const T2 & val) const
+		int lastIndexOf(const T2 & val) const
 		{
-			for (int i = _count - 1; i >= 0; i--)
+			for (int i = m_size - 1; i >= 0; i--)
 			{
-				if (*(T*)((char*)_buffer + i*stride) == val)
+				if (m_buffer[i] == val)
 					return i;
 			}
 			return -1;
 		}
 
 		template<typename Func>
-		int FindFirst(const Func & predicate) const
+		int findFirstIndex(const Func& predicate) const
 		{
-			for (int i = 0; i < _count; i++)
+			for (int i = 0; i < m_size; i++)
 			{
-				if (predicate(_buffer[i]))
+				if (predicate(m_buffer[i]))
 					return i;
 			}
 			return -1;
 		}
 
 		template<typename Func>
-		int FindLast(const Func & predicate) const
+		int findLastIndex(const Func& predicate) const
 		{
-			for (int i = _count - 1; i >= 0; i--)
+			for (int i = m_size - 1; i >= 0; i--)
 			{
-				if (predicate(_buffer[i]))
+				if (predicate(m_buffer[i]))
 					return i;
 			}
 			return -1;
@@ -114,13 +100,13 @@ namespace Slang
 	};
 
 	template<typename T>
-	ArrayView<T> MakeArrayView(const T & obj)
+	ArrayView<T> MakeArrayView(T& obj)
 	{
 		return ArrayView<T>(obj);
 	}
 		
 	template<typename T>
-	ArrayView<T> MakeArrayView(T * buffer, int count)
+	ArrayView<T> MakeArrayView(T* buffer, int count)
 	{
 		return ArrayView<T>(buffer, count);
 	}

--- a/source/core/array-view.h
+++ b/source/core/array-view.h
@@ -10,54 +10,51 @@ namespace Slang
 	{
 	private:
 		T* m_buffer;
-		int m_size;
+		int m_count;
 	public:
         const T* begin() const { return m_buffer; }
         T* begin() { return m_buffer; }
 
-        const T* end() const { return m_buffer + m_size; }
-        T* end() { return m_buffer + m_size; }
+        const T* end() const { return m_buffer + m_count; }
+        T* end() { return m_buffer + m_count; }
         
 	public:
 		ArrayView():
 			m_buffer(nullptr),
-			m_size(0)
+			m_count(0)
         {
 		}
 		ArrayView(T& singleObj):
             m_buffer(&singleObj),
-            m_size(1)
+            m_count(1)
         {
 		}
 		ArrayView(T* buffer, int size):
             m_buffer(buffer),
-            m_size(size)
+            m_count(size)
 		{
 		}
 		
-		inline int getSize() const
-		{
-			return m_size;
-		}
+		inline int getCount() const { return m_count; }
 
 		inline const T& operator [](int idx) const
 		{
-            SLANG_ASSERT(idx >= 0 && idx <= m_size);
+            SLANG_ASSERT(idx >= 0 && idx <= m_count);
             return m_buffer[idx];
 		}
         inline T& operator [](int idx)
         {
-            SLANG_ASSERT(idx >= 0 && idx <= m_size);
+            SLANG_ASSERT(idx >= 0 && idx <= m_count);
             return m_buffer[idx];
         }
 
-        inline const T* Buffer() const {return m_buffer; }
-        inline T* Buffer() { return m_buffer; }
+        inline const T* getBuffer() const { return m_buffer; }
+        inline T* getBuffer() { return m_buffer; }
 
 		template<typename T2>
 		int indexOf(const T2 & val) const
 		{
-			for (int i = 0; i < m_size; i++)
+			for (int i = 0; i < m_count; i++)
 			{
 				if (m_buffer[i] == val)
 					return i;
@@ -68,7 +65,7 @@ namespace Slang
 		template<typename T2>
 		int lastIndexOf(const T2 & val) const
 		{
-			for (int i = m_size - 1; i >= 0; i--)
+			for (int i = m_count - 1; i >= 0; i--)
 			{
 				if (m_buffer[i] == val)
 					return i;
@@ -79,7 +76,7 @@ namespace Slang
 		template<typename Func>
 		int findFirstIndex(const Func& predicate) const
 		{
-			for (int i = 0; i < m_size; i++)
+			for (int i = 0; i < m_count; i++)
 			{
 				if (predicate(m_buffer[i]))
 					return i;
@@ -90,7 +87,7 @@ namespace Slang
 		template<typename Func>
 		int findLastIndex(const Func& predicate) const
 		{
-			for (int i = m_size - 1; i >= 0; i--)
+			for (int i = m_count - 1; i >= 0; i--)
 			{
 				if (predicate(m_buffer[i]))
 					return i;
@@ -100,13 +97,13 @@ namespace Slang
 	};
 
 	template<typename T>
-	ArrayView<T> MakeArrayView(T& obj)
+	ArrayView<T> makeArrayView(T& obj)
 	{
 		return ArrayView<T>(obj);
 	}
 		
 	template<typename T>
-	ArrayView<T> MakeArrayView(T* buffer, int count)
+	ArrayView<T> makeArrayView(T* buffer, int count)
 	{
 		return ArrayView<T>(buffer, count);
 	}

--- a/source/core/array.h
+++ b/source/core/array.h
@@ -6,136 +6,128 @@
 
 namespace Slang
 {
-	template<typename T, int size>
+	template<typename T, int COUNT>
 	class Array
 	{
 	private:
-		T _buffer[size];
-		int _count = 0;
+		T m_buffer[COUNT];
+		int m_count = 0;
 	public:
-		T* begin() const
-		{
-			return (T*)_buffer;
-		}
-		T* end() const
-		{
-			return (T*)_buffer + _count;
-		}
+        T* begin() { return m_buffer; }
+        const T* begin() const { return m_buffer; }
+
+        const T* end() const { return m_buffer + m_count; }
+        T* end() { return m_buffer + m_count; }
+
 	public:
-		inline int GetCapacity() const
+		inline int getCapacity() const { return COUNT; }
+		inline int getCount() const { return m_count; }
+		inline const T& getFirst() const
 		{
-			return size;
+            SLANG_ASSERT(m_count > 0);
+			return m_buffer[0];
 		}
-		inline int Count() const
+        inline T& getFirst()
+        {
+            SLANG_ASSERT(m_count > 0);
+            return m_buffer[0];
+        }
+		inline const T& getLast() const
 		{
-			return _count;
+            SLANG_ASSERT(m_count > 0);
+			return m_buffer[m_count - 1];
 		}
-		inline T & First() const
+        inline T& getLast()
+        {
+            SLANG_ASSERT(m_count > 0);
+            return m_buffer[m_count - 1];
+        }
+		inline void setCount(int newCount)
 		{
-			return const_cast<T&>(_buffer[0]);
+            SLANG_ASSERT(newCount >= 0 && newCount <= COUNT);
+			m_count = newCount;
 		}
-		inline T & Last() const
+		inline void add(const T & item)
 		{
-			return const_cast<T&>(_buffer[_count - 1]);
+            SLANG_ASSERT(m_count < COUNT);
+			m_buffer[m_count++] = item;
 		}
-		inline void SetSize(int newSize)
+		inline void add(T && item)
 		{
-#ifdef _DEBUG
-			if (newSize > size)
-				throw IndexOutofRangeException("size too large.");
-#endif
-			_count = newSize;
-		}
-		inline void Add(const T & item)
-		{
-#ifdef _DEBUG
-			if (_count == size)
-				throw IndexOutofRangeException("out of range access to static array.");
-#endif
-			_buffer[_count++] = item;
-		}
-		inline void Add(T && item)
-		{
-#ifdef _DEBUG
-			if (_count == size)
-				throw IndexOutofRangeException("out of range access to static array.");
-#endif
-			_buffer[_count++] = _Move(item);
+            SLANG_ASSERT(m_count < COUNT);
+			m_buffer[m_count++] = _Move(item);
 		}
 
-		inline T & operator [](int id) const
+		inline const T& operator [](int idx) const
 		{
-#if _DEBUG
-			if (id >= _count || id < 0)
-				throw IndexOutofRangeException("Operator[]: Index out of Range.");
-#endif
-			return ((T*)_buffer)[id];
+            SLANG_ASSERT(idx >= 0 && idx < m_count);
+			return m_buffer[idx];
 		}
+        inline T& operator [](int idx)
+        {
+            SLANG_ASSERT(idx >= 0 && idx < m_count);
+            return m_buffer[idx];
+        }
 
-		inline T* Buffer() const
-		{
-			return (T*)_buffer;
-		}
+		inline const T* getBuffer() const { return m_buffer; }
+        inline T* getBuffer() { return m_buffer; }
 
-		inline void Clear()
-		{
-			_count = 0;
-		}
+		inline void clear() { m_count = 0; }
 
 		template<typename T2>
-		int IndexOf(const T2 & val) const
+		int indexOf(const T2& val) const
 		{
-			for (int i = 0; i < _count; i++)
+			for (int i = 0; i < m_count; i++)
 			{
-				if (_buffer[i] == val)
+				if (m_buffer[i] == val)
 					return i;
 			}
 			return -1;
 		}
 
 		template<typename T2>
-		int LastIndexOf(const T2 & val) const
+		int lastIndexOf(const T2& val) const
 		{
-			for (int i = _count - 1; i >= 0; i--)
+			for (int i = m_count - 1; i >= 0; i--)
 			{
-				if (_buffer[i] == val)
+				if (m_buffer[i] == val)
 					return i;
 			}
 			return -1;
 		}
 
-		inline ArrayView<T> GetArrayView() const
+		inline ArrayView<T> getArrayView() const
 		{
-			return ArrayView<T>((T*)_buffer, _count);
+			return ArrayView<T>((T*)m_buffer, m_count);
 		}
-		inline ArrayView<T> GetArrayView(int start, int count) const
+		inline ArrayView<T> getArrayView(int start, int count) const
 		{
-			return ArrayView<T>((T*)_buffer + start, count);
+			return ArrayView<T>((T*)m_buffer + start, count);
 		}
 	};
 
 	template<typename T, typename ...TArgs>
 	struct FirstType
 	{
-		typedef T type;
+		typedef T Type;
 	};
 
 
-	template<typename T, int size>
-	void InsertArray(Array<T, size> &) {}
+	template<typename T, int SIZE>
+	void insertArray(Array<T, SIZE>&) {}
 
-	template<typename T, typename ...TArgs, int size>
-	void InsertArray(Array<T, size> & arr, const T & val, TArgs... args)
+	template<typename T, typename ...TArgs, int SIZE>
+	void insertArray(Array<T, SIZE>& arr, const T& val, TArgs... args)
 	{
-		arr.Add(val);
-		InsertArray(arr, args...);
+		arr.add(val);
+		insertArray(arr, args...);
 	}
 
 	template<typename ...TArgs>
-	auto MakeArray(TArgs ...args) -> Array<typename FirstType<TArgs...>::type, sizeof...(args)>
+	auto makeArray(TArgs ...args) -> Array<typename FirstType<TArgs...>::Type, sizeof...(args)>
 	{
-		Array<typename FirstType<TArgs...>::type, sizeof...(args)> rs;
-		InsertArray(rs, args...);
+		Array<typename FirstType<TArgs...>::Type, sizeof...(args)> rs;
+		insertArray(rs, args...);
 		return rs;
 	}
 }

--- a/source/core/common.h
+++ b/source/core/common.h
@@ -31,6 +31,9 @@ namespace Slang
 
 	typedef intptr_t PtrInt;
 
+    // Type used for indexing, in arrays/views etc
+    typedef UInt Index;
+
 	template <typename T>
 	inline T&& _Move(T & obj)
 	{

--- a/source/core/common.h
+++ b/source/core/common.h
@@ -3,6 +3,8 @@
 
 #include "../../slang.h"
 
+#include <assert.h>
+
 #include <cstdint>
 
 #ifdef __GNUC__

--- a/source/core/common.h
+++ b/source/core/common.h
@@ -32,7 +32,7 @@ namespace Slang
 	typedef intptr_t PtrInt;
 
     // Type used for indexing, in arrays/views etc
-    typedef UInt Index;
+    typedef Int Index;
 
 	template <typename T>
 	inline T&& _Move(T & obj)

--- a/source/core/dictionary.h
+++ b/source/core/dictionary.h
@@ -91,25 +91,25 @@ namespace Slang
 		}
 		inline bool IsDeleted(int pos) const
 		{
-			return marks.Contains((pos << 1) + 1);
+			return marks.contains((pos << 1) + 1);
 		}
 		inline bool IsEmpty(int pos) const
 		{
-			return !marks.Contains((pos << 1));
+			return !marks.contains((pos << 1));
 		}
 		inline void SetDeleted(int pos, bool val)
 		{
 			if (val)
-				marks.Add((pos << 1) + 1);
+				marks.add((pos << 1) + 1);
 			else
-				marks.Remove((pos << 1) + 1);
+				marks.remove((pos << 1) + 1);
 		}
 		inline void SetEmpty(int pos, bool val)
 		{
 			if (val)
-				marks.Remove((pos << 1));
+				marks.remove((pos << 1));
 			else
-				marks.Add((pos << 1));
+				marks.add((pos << 1));
 		}
 		struct FindPositionResult
 		{
@@ -180,7 +180,7 @@ namespace Slang
 				Dictionary<TKey, TValue> newDict;
 				newDict.bucketSizeMinusOne = newSize - 1;
 				newDict.hashMap = new KeyValuePair<TKey, TValue>[newSize];
-				newDict.marks.SetMax(newSize * 2);
+				newDict.marks.setMax(newSize * 2);
 				if (hashMap)
 				{
 					for (auto & kvPair : *this)
@@ -326,7 +326,7 @@ namespace Slang
 		{
 			_count = 0;
 
-			marks.Clear();
+			marks.clear();
 		}
 
         TValue* TryGetValueOrAdd(const TKey& key, const TValue& value)

--- a/source/core/int-set.h
+++ b/source/core/int-set.h
@@ -48,7 +48,7 @@ namespace Slang
 		}
 		UInt Size() const
 		{
-			return buffer.getSize()*32;
+			return buffer.getCount()*32;
 		}
 		void SetMax(int val)
 		{
@@ -57,59 +57,59 @@ namespace Slang
 		}
 		void SetAll()
 		{
-			for (UInt i = 0; i<buffer.getSize(); i++)
+			for (UInt i = 0; i<buffer.getCount(); i++)
 				buffer[i] = 0xFFFFFFFF;
 		}
 		void Resize(UInt size)
 		{
-			UInt oldBufferSize = buffer.getSize();
-			buffer.setSize((size+31)>>5);
-			if (buffer.getSize() > oldBufferSize)
-				memset(buffer.Buffer()+oldBufferSize, 0, (buffer.getSize()-oldBufferSize) * sizeof(int));
+			UInt oldBufferSize = buffer.getCount();
+			buffer.setCount((size+31)>>5);
+			if (buffer.getCount() > oldBufferSize)
+				memset(buffer.getBuffer()+oldBufferSize, 0, (buffer.getCount()-oldBufferSize) * sizeof(int));
 		}
 		void Clear()
 		{
-			for (UInt i = 0; i<buffer.getSize(); i++)
+			for (UInt i = 0; i<buffer.getCount(); i++)
 				buffer[i] = 0;
 		}
 		void Add(UInt val)
 		{
 			UInt id = val>>5;
-			if (id < buffer.getSize())
+			if (id < buffer.getCount())
 				buffer[id] |= (1<<(val&31));
 			else
 			{
-				UInt oldSize = buffer.getSize();
-				buffer.setSize(id+1);
-				memset(buffer.Buffer() + oldSize, 0, (buffer.getSize()-oldSize)*sizeof(int));
+				UInt oldSize = buffer.getCount();
+				buffer.setCount(id+1);
+				memset(buffer.getBuffer() + oldSize, 0, (buffer.getCount()-oldSize)*sizeof(int));
 				buffer[id] |= (1<<(val&31));
 			}
 		}
 		void Remove(UInt val)
 		{
-			if ((val>>5) < buffer.getSize())
+			if ((val>>5) < buffer.getCount())
 				buffer[(val>>5)] &= ~(1<<(val&31));
 		}
 		bool Contains(UInt val) const
 		{
-			if ((val>>5) >= buffer.getSize())
+			if ((val>>5) >= buffer.getCount())
 				return false;
 			return (buffer[(val>>5)] & (1<<(val&31))) != 0;
 		}
 		void UnionWith(const IntSet & set)
 		{
-			for (UInt i = 0; i<Math::Min(set.buffer.getSize(), buffer.getSize()); i++)
+			for (UInt i = 0; i<Math::Min(set.buffer.getCount(), buffer.getCount()); i++)
 			{
 				buffer[i] |= set.buffer[i];
 			}
-			if (set.buffer.getSize() > buffer.getSize())
-				buffer.addRange(set.buffer.Buffer()+buffer.getSize(), set.buffer.getSize()-buffer.getSize());
+			if (set.buffer.getCount() > buffer.getCount())
+				buffer.addRange(set.buffer.getBuffer()+buffer.getCount(), set.buffer.getCount()-buffer.getCount());
 		}
 		bool operator == (const IntSet & set)
 		{
-			if (buffer.getSize() != set.buffer.getSize())
+			if (buffer.getCount() != set.buffer.getCount())
 				return false;
-			for (UInt i = 0; i<buffer.getSize(); i++)
+			for (UInt i = 0; i<buffer.getCount(); i++)
 				if (buffer[i] != set.buffer[i])
 					return false;
 			return true;
@@ -120,37 +120,37 @@ namespace Slang
 		}
 		void IntersectWith(const IntSet & set)
 		{
-			if (set.buffer.getSize() < buffer.getSize())
-				memset(buffer.Buffer() + set.buffer.getSize(), 0, (buffer.getSize()-set.buffer.getSize())*sizeof(int));
-			for (UInt i = 0; i<Math::Min(set.buffer.getSize(), buffer.getSize()); i++)
+			if (set.buffer.getCount() < buffer.getCount())
+				memset(buffer.getBuffer() + set.buffer.getCount(), 0, (buffer.getCount()-set.buffer.getCount())*sizeof(int));
+			for (UInt i = 0; i<Math::Min(set.buffer.getCount(), buffer.getCount()); i++)
 			{
 				buffer[i] &= set.buffer[i];
 			}
 		}
 		static void Union(IntSet & rs, const IntSet & set1, const IntSet & set2)
 		{
-			rs.buffer.setSize(Math::Max(set1.buffer.getSize(), set2.buffer.getSize()));
+			rs.buffer.setCount(Math::Max(set1.buffer.getCount(), set2.buffer.getCount()));
 			rs.Clear();
-			for (UInt i = 0; i<set1.buffer.getSize(); i++)
+			for (UInt i = 0; i<set1.buffer.getCount(); i++)
 				rs.buffer[i] |= set1.buffer[i];
-			for (UInt i = 0; i<set2.buffer.getSize(); i++)
+			for (UInt i = 0; i<set2.buffer.getCount(); i++)
 				rs.buffer[i] |= set2.buffer[i];
 		}
 		static void Intersect(IntSet & rs, const IntSet & set1, const IntSet & set2)
 		{
-			rs.buffer.setSize(Math::Min(set1.buffer.getSize(), set2.buffer.getSize()));
-			for (UInt i = 0; i<rs.buffer.getSize(); i++)
+			rs.buffer.setCount(Math::Min(set1.buffer.getCount(), set2.buffer.getCount()));
+			for (UInt i = 0; i<rs.buffer.getCount(); i++)
 				rs.buffer[i] = set1.buffer[i] & set2.buffer[i];
 		}
 		static void Subtract(IntSet & rs, const IntSet & set1, const IntSet & set2)
 		{
-			rs.buffer.setSize(set1.buffer.getSize());
-			for (UInt i = 0; i<Math::Min(set1.buffer.getSize(), set2.buffer.getSize()); i++)
+			rs.buffer.setCount(set1.buffer.getCount());
+			for (UInt i = 0; i<Math::Min(set1.buffer.getCount(), set2.buffer.getCount()); i++)
 				rs.buffer[i] = set1.buffer[i] & (~set2.buffer[i]);
 		}
 		static bool HasIntersection(const IntSet & set1, const IntSet & set2)
 		{
-			for (UInt i = 0; i<Math::Min(set1.buffer.getSize(), set2.buffer.getSize()); i++)
+			for (UInt i = 0; i<Math::Min(set1.buffer.getCount(), set2.buffer.getCount()); i++)
 			{
 				if (set1.buffer[i] & set2.buffer[i])
 					return true;

--- a/source/core/int-set.h
+++ b/source/core/int-set.h
@@ -103,7 +103,7 @@ namespace Slang
 				buffer[i] |= set.buffer[i];
 			}
 			if (set.buffer.getSize() > buffer.getSize())
-				buffer.AddRange(set.buffer.Buffer()+buffer.getSize(), set.buffer.getSize()-buffer.getSize());
+				buffer.addRange(set.buffer.Buffer()+buffer.getSize(), set.buffer.getSize()-buffer.getSize());
 		}
 		bool operator == (const IntSet & set)
 		{

--- a/source/core/int-set.h
+++ b/source/core/int-set.h
@@ -48,7 +48,7 @@ namespace Slang
 		}
 		UInt Size() const
 		{
-			return buffer.Count()*32;
+			return buffer.getSize()*32;
 		}
 		void SetMax(int val)
 		{
@@ -57,59 +57,59 @@ namespace Slang
 		}
 		void SetAll()
 		{
-			for (UInt i = 0; i<buffer.Count(); i++)
+			for (UInt i = 0; i<buffer.getSize(); i++)
 				buffer[i] = 0xFFFFFFFF;
 		}
 		void Resize(UInt size)
 		{
-			UInt oldBufferSize = buffer.Count();
+			UInt oldBufferSize = buffer.getSize();
 			buffer.SetSize((size+31)>>5);
-			if (buffer.Count() > oldBufferSize)
-				memset(buffer.Buffer()+oldBufferSize, 0, (buffer.Count()-oldBufferSize) * sizeof(int));
+			if (buffer.getSize() > oldBufferSize)
+				memset(buffer.Buffer()+oldBufferSize, 0, (buffer.getSize()-oldBufferSize) * sizeof(int));
 		}
 		void Clear()
 		{
-			for (UInt i = 0; i<buffer.Count(); i++)
+			for (UInt i = 0; i<buffer.getSize(); i++)
 				buffer[i] = 0;
 		}
 		void Add(UInt val)
 		{
 			UInt id = val>>5;
-			if (id < buffer.Count())
+			if (id < buffer.getSize())
 				buffer[id] |= (1<<(val&31));
 			else
 			{
-				UInt oldSize = buffer.Count();
+				UInt oldSize = buffer.getSize();
 				buffer.SetSize(id+1);
-				memset(buffer.Buffer() + oldSize, 0, (buffer.Count()-oldSize)*sizeof(int));
+				memset(buffer.Buffer() + oldSize, 0, (buffer.getSize()-oldSize)*sizeof(int));
 				buffer[id] |= (1<<(val&31));
 			}
 		}
 		void Remove(UInt val)
 		{
-			if ((val>>5) < buffer.Count())
+			if ((val>>5) < buffer.getSize())
 				buffer[(val>>5)] &= ~(1<<(val&31));
 		}
 		bool Contains(UInt val) const
 		{
-			if ((val>>5) >= buffer.Count())
+			if ((val>>5) >= buffer.getSize())
 				return false;
 			return (buffer[(val>>5)] & (1<<(val&31))) != 0;
 		}
 		void UnionWith(const IntSet & set)
 		{
-			for (UInt i = 0; i<Math::Min(set.buffer.Count(), buffer.Count()); i++)
+			for (UInt i = 0; i<Math::Min(set.buffer.getSize(), buffer.getSize()); i++)
 			{
 				buffer[i] |= set.buffer[i];
 			}
-			if (set.buffer.Count() > buffer.Count())
-				buffer.AddRange(set.buffer.Buffer()+buffer.Count(), set.buffer.Count()-buffer.Count());
+			if (set.buffer.getSize() > buffer.getSize())
+				buffer.AddRange(set.buffer.Buffer()+buffer.getSize(), set.buffer.getSize()-buffer.getSize());
 		}
 		bool operator == (const IntSet & set)
 		{
-			if (buffer.Count() != set.buffer.Count())
+			if (buffer.getSize() != set.buffer.getSize())
 				return false;
-			for (UInt i = 0; i<buffer.Count(); i++)
+			for (UInt i = 0; i<buffer.getSize(); i++)
 				if (buffer[i] != set.buffer[i])
 					return false;
 			return true;
@@ -120,37 +120,37 @@ namespace Slang
 		}
 		void IntersectWith(const IntSet & set)
 		{
-			if (set.buffer.Count() < buffer.Count())
-				memset(buffer.Buffer() + set.buffer.Count(), 0, (buffer.Count()-set.buffer.Count())*sizeof(int));
-			for (UInt i = 0; i<Math::Min(set.buffer.Count(), buffer.Count()); i++)
+			if (set.buffer.getSize() < buffer.getSize())
+				memset(buffer.Buffer() + set.buffer.getSize(), 0, (buffer.getSize()-set.buffer.getSize())*sizeof(int));
+			for (UInt i = 0; i<Math::Min(set.buffer.getSize(), buffer.getSize()); i++)
 			{
 				buffer[i] &= set.buffer[i];
 			}
 		}
 		static void Union(IntSet & rs, const IntSet & set1, const IntSet & set2)
 		{
-			rs.buffer.SetSize(Math::Max(set1.buffer.Count(), set2.buffer.Count()));
+			rs.buffer.SetSize(Math::Max(set1.buffer.getSize(), set2.buffer.getSize()));
 			rs.Clear();
-			for (UInt i = 0; i<set1.buffer.Count(); i++)
+			for (UInt i = 0; i<set1.buffer.getSize(); i++)
 				rs.buffer[i] |= set1.buffer[i];
-			for (UInt i = 0; i<set2.buffer.Count(); i++)
+			for (UInt i = 0; i<set2.buffer.getSize(); i++)
 				rs.buffer[i] |= set2.buffer[i];
 		}
 		static void Intersect(IntSet & rs, const IntSet & set1, const IntSet & set2)
 		{
-			rs.buffer.SetSize(Math::Min(set1.buffer.Count(), set2.buffer.Count()));
-			for (UInt i = 0; i<rs.buffer.Count(); i++)
+			rs.buffer.SetSize(Math::Min(set1.buffer.getSize(), set2.buffer.getSize()));
+			for (UInt i = 0; i<rs.buffer.getSize(); i++)
 				rs.buffer[i] = set1.buffer[i] & set2.buffer[i];
 		}
 		static void Subtract(IntSet & rs, const IntSet & set1, const IntSet & set2)
 		{
-			rs.buffer.SetSize(set1.buffer.Count());
-			for (UInt i = 0; i<Math::Min(set1.buffer.Count(), set2.buffer.Count()); i++)
+			rs.buffer.SetSize(set1.buffer.getSize());
+			for (UInt i = 0; i<Math::Min(set1.buffer.getSize(), set2.buffer.getSize()); i++)
 				rs.buffer[i] = set1.buffer[i] & (~set2.buffer[i]);
 		}
 		static bool HasIntersection(const IntSet & set1, const IntSet & set2)
 		{
-			for (UInt i = 0; i<Math::Min(set1.buffer.Count(), set2.buffer.Count()); i++)
+			for (UInt i = 0; i<Math::Min(set1.buffer.getSize(), set2.buffer.getSize()); i++)
 			{
 				if (set1.buffer[i] & set2.buffer[i])
 					return true;

--- a/source/core/int-set.h
+++ b/source/core/int-set.h
@@ -63,7 +63,7 @@ namespace Slang
 		void Resize(UInt size)
 		{
 			UInt oldBufferSize = buffer.getSize();
-			buffer.SetSize((size+31)>>5);
+			buffer.setSize((size+31)>>5);
 			if (buffer.getSize() > oldBufferSize)
 				memset(buffer.Buffer()+oldBufferSize, 0, (buffer.getSize()-oldBufferSize) * sizeof(int));
 		}
@@ -80,7 +80,7 @@ namespace Slang
 			else
 			{
 				UInt oldSize = buffer.getSize();
-				buffer.SetSize(id+1);
+				buffer.setSize(id+1);
 				memset(buffer.Buffer() + oldSize, 0, (buffer.getSize()-oldSize)*sizeof(int));
 				buffer[id] |= (1<<(val&31));
 			}
@@ -129,7 +129,7 @@ namespace Slang
 		}
 		static void Union(IntSet & rs, const IntSet & set1, const IntSet & set2)
 		{
-			rs.buffer.SetSize(Math::Max(set1.buffer.getSize(), set2.buffer.getSize()));
+			rs.buffer.setSize(Math::Max(set1.buffer.getSize(), set2.buffer.getSize()));
 			rs.Clear();
 			for (UInt i = 0; i<set1.buffer.getSize(); i++)
 				rs.buffer[i] |= set1.buffer[i];
@@ -138,13 +138,13 @@ namespace Slang
 		}
 		static void Intersect(IntSet & rs, const IntSet & set1, const IntSet & set2)
 		{
-			rs.buffer.SetSize(Math::Min(set1.buffer.getSize(), set2.buffer.getSize()));
+			rs.buffer.setSize(Math::Min(set1.buffer.getSize(), set2.buffer.getSize()));
 			for (UInt i = 0; i<rs.buffer.getSize(); i++)
 				rs.buffer[i] = set1.buffer[i] & set2.buffer[i];
 		}
 		static void Subtract(IntSet & rs, const IntSet & set1, const IntSet & set2)
 		{
-			rs.buffer.SetSize(set1.buffer.getSize());
+			rs.buffer.setSize(set1.buffer.getSize());
 			for (UInt i = 0; i<Math::Min(set1.buffer.getSize(), set2.buffer.getSize()); i++)
 				rs.buffer[i] = set1.buffer[i] & (~set2.buffer[i]);
 		}

--- a/source/core/list.h
+++ b/source/core/list.h
@@ -145,7 +145,7 @@ namespace Slang
 		static List<T> Create(const T& val, int count)
 		{
 			List<T> rs;
-			rs.SetSize(count);
+			rs.setSize(count);
 			for (int i = 0; i < count; i++)
 				rs[i] = val;
 			return rs;
@@ -253,7 +253,7 @@ namespace Slang
 				if (m_capacity)
 					newBufferSize = (m_capacity << 1);
 
-				Reserve(newBufferSize);
+				reserve(newBufferSize);
 			}
 			m_buffer[m_size++] = static_cast<T&&>(obj);
 		}
@@ -266,7 +266,7 @@ namespace Slang
 				if (m_capacity)
 					newBufferSize = (m_capacity << 1);
 
-				Reserve(newBufferSize);
+				reserve(newBufferSize);
 			}
 			m_buffer[m_size++] = obj;
 
@@ -421,7 +421,7 @@ namespace Slang
             m_size = m_capacity = 0;
         }
 
-		void Reserve(UInt size)
+		void reserve(UInt size)
 		{
 			if(size > m_capacity)
 			{
@@ -448,19 +448,19 @@ namespace Slang
 			}
 		}
 
-		void GrowToSize(UInt size)
+		void growToSize(UInt size)
 		{
 			UInt newBufferSize = UInt(1) << Math::Log2Ceil(size);
 			if (m_capacity < newBufferSize)
 			{
-				Reserve(newBufferSize);
+				reserve(newBufferSize);
 			}
 			m_size = size;
 		}
 
-		void SetSize(UInt size)
+		void setSize(UInt size)
 		{
-			Reserve(size);
+			reserve(size);
 			m_size = size;
 		}
 

--- a/source/core/list.h
+++ b/source/core/list.h
@@ -124,7 +124,7 @@ namespace Slang
 		template<typename... Args>
 		void Init(const T& val, Args... args)
 		{
-			Add(val);
+			add(val);
 			Init(args...);
 		}
 	public:
@@ -180,19 +180,31 @@ namespace Slang
 			return *this;
 		}
 
-		T& First() const
+		const T& getFirst() const
 		{
             SLANG_ASSERT(m_size > 0);
 			return m_buffer[0];
 		}
 
-		T& Last() const
+		const T& getLast() const
 		{
             SLANG_ASSERT(m_size > 0);
 			return m_buffer[m_size-1];
 		}
 
-        void RemoveLast()
+        T& getFirst()
+        {
+            SLANG_ASSERT(m_size > 0);
+            return m_buffer[0];
+        }
+
+        T& getLast() 
+        {
+            SLANG_ASSERT(m_size > 0);
+            return m_buffer[m_size - 1];
+        }
+
+        void removeLast()
         {
             SLANG_ASSERT(m_size > 0);
             m_size--;
@@ -217,7 +229,7 @@ namespace Slang
 			other.m_allocator = _Move(tmpAlloc);
 		}
 
-		T* ReleaseBuffer()
+		T* detachBuffer()
 		{
 			T* rs = m_buffer;
 			m_buffer = nullptr;
@@ -226,18 +238,18 @@ namespace Slang
 			return rs;
 		}
 
-		inline ArrayView<T> GetArrayView() const
+		inline ArrayView<T> getArrayView() const
 		{
 			return ArrayView<T>(m_buffer, m_size);
 		}
 
-		inline ArrayView<T> GetArrayView(int start, int count) const
+		inline ArrayView<T> getArrayView(int start, int count) const
 		{
             SLANG_ASSERT(start >= 0 && count >= 0 && start + count <= m_size);
 			return ArrayView<T>(m_buffer + start, count);
 		}
 
-		void Add(T&& obj)
+		void add(T&& obj)
 		{
 			if (m_capacity < m_size + 1)
 			{
@@ -250,7 +262,7 @@ namespace Slang
 			m_buffer[m_size++] = static_cast<T&&>(obj);
 		}
 
-		void Add(const T& obj)
+		void add(const T& obj)
 		{
 			if (m_capacity < m_size + 1)
 			{
@@ -643,7 +655,7 @@ namespace Slang
 	template<typename T>
 	T Min(const List<T>& list)
 	{
-		T minVal = list.First();
+		T minVal = list.getFirst();
 		for (int i = 1; i < list.getSize(); i++)
 			if (list[i] < minVal)
 				minVal = list[i];
@@ -653,7 +665,7 @@ namespace Slang
 	template<typename T>
 	T Max(const List<T>& list)
 	{
-		T maxVal = list.First();
+		T maxVal = list.getFirst();
 		for (int i = 1; i< list.getSize(); i++)
 			if (list[i] > maxVal)
 				maxVal = list[i];

--- a/source/core/list.h
+++ b/source/core/list.h
@@ -162,7 +162,7 @@ namespace Slang
 		List<T>& operator=(const List<T>& list)
 		{
 			Free();
-			AddRange(list);
+			addRange(list);
 
 			return *this;
 		}
@@ -286,17 +286,17 @@ namespace Slang
 			return m_buffer;
 		}
 
-		UInt Capacity() const
+		UInt getCapacity() const
 		{
 			return m_capacity;
 		}
 
-		void Insert(UInt id, const T& val)
+		void insert(UInt id, const T& val)
 		{
-			InsertRange(id, &val, 1);
+			insertRange(id, &val, 1);
 		}
 
-		void InsertRange(UInt id, const T* vals, UInt n)
+		void insertRange(UInt id, const T* vals, UInt n)
 		{
 			if (m_capacity < m_size + n)
 			{
@@ -349,27 +349,27 @@ namespace Slang
 		//	InsertRange(_count, &val, 1);
 		//}
 
-		void InsertRange(int id, const List<T>& list)
+		void insertRange(int id, const List<T>& list)
 		{
-			InsertRange(id, list.m_buffer, list.m_size);
+			insertRange(id, list.m_buffer, list.m_size);
 		}
 
-		void AddRange(ArrayView<T> list)
+		void addRange(ArrayView<T> list)
 		{
-			InsertRange(m_size, list.Buffer(), list.Count());
+			insertRange(m_size, list.Buffer(), list.Count());
 		}
 
-		void AddRange(const T* vals, UInt n)
+		void addRange(const T* vals, UInt n)
 		{
-			InsertRange(m_size, vals, n);
+			insertRange(m_size, vals, n);
 		}
 
-		void AddRange(const List<T>& list)
+		void addRange(const List<T>& list)
 		{
-			InsertRange(m_size, list.m_buffer, list.m_size);
+			insertRange(m_size, list.m_buffer, list.m_size);
 		}
 
-		void RemoveRange(UInt idx, UInt count)
+		void removeRange(UInt idx, UInt count)
 		{
             SLANG_ASSERT(idx >= 0 && idx <= m_size);
 
@@ -379,19 +379,19 @@ namespace Slang
 			m_size -= actualDeleteCount;
 		}
 
-		void RemoveAt(UInt id)
+		void removeAt(UInt id)
 		{
-			RemoveRange(id, 1);
+			removeRange(id, 1);
 		}
 
-		void Remove(const T& val)
+		void remove(const T& val)
 		{
 			int idx = IndexOf(val);
 			if (idx != -1)
-				RemoveAt(idx);
+				removeAt(idx);
 		}
 
-		void Reverse()
+		void reverse()
 		{
 			for (UInt i = 0; i < (m_size >> 1); i++)
 			{
@@ -399,13 +399,13 @@ namespace Slang
 			}
 		}
 
-		void FastRemove(const T& val)
+		void fastRemove(const T& val)
 		{
 			int idx = IndexOf(val);
-			FastRemoveAt(idx);
+			fastRemoveAt(idx);
 		}
 
-		void FastRemoveAt(UInt idx)
+		void fastRemoveAt(UInt idx)
 		{
 			if (idx != -1 && m_size - 1 != idx)
 			{
@@ -414,7 +414,7 @@ namespace Slang
 			m_size--;
 		}
 
-		void Clear()
+		void clear()
 		{
 			m_size = 0;
 		}

--- a/source/core/list.h
+++ b/source/core/list.h
@@ -464,12 +464,12 @@ namespace Slang
 			m_size = size;
 		}
 
-		void UnsafeShrinkToSize(UInt size)
+		void unsafeShrinkToSize(UInt size)
 		{
 			m_size = size;
 		}
 
-		void Compress()
+		void compress()
 		{
 			if (m_capacity > m_size && m_size > 0)
 			{
@@ -490,7 +490,7 @@ namespace Slang
 		}
 
 		template<typename Func>
-		UInt FindFirst(const Func& predicate) const
+		UInt findFirstIndex(const Func& predicate) const
 		{
 			for (UInt i = 0; i < m_size; i++)
 			{
@@ -501,7 +501,7 @@ namespace Slang
 		}
 
 		template<typename Func>
-		UInt FindLast(const Func& predicate) const
+		UInt findLastIndex(const Func& predicate) const
 		{
 			for (UInt i = m_size; i > 0; i--)
 			{
@@ -538,12 +538,9 @@ namespace Slang
 			Sort([](const T& t1, const T& t2){return t1 < t2;});
 		}
 
-		bool Contains(const T& val)
+		bool Contains(const T& val) const
 		{
-			for (UInt i = 0; i< m_size; i++)
-				if (m_buffer[i] == val)
-					return true;
-			return false;
+            return IndexOf(val) != UInt(-1);
 		}
 
 		template<typename Comparer>

--- a/source/core/list.h
+++ b/source/core/list.h
@@ -92,7 +92,6 @@ namespace Slang
 		}
 	private:
 		static const Int kInitialSize = 16;
-		TAllocator m_allocator;
 	private:
 		T*      m_buffer;           ///< A new T[N] allocated buffer. NOTE! All elements up to capacity are in some valid form for T.
         UInt    m_capacity;         ///< The total capacity of elements
@@ -219,10 +218,6 @@ namespace Slang
 			auto count = m_size;
 			m_size = other.m_size;
 			other.m_size = count;
-
-			TAllocator tmpAlloc = _Move(m_allocator);
-			m_allocator = _Move(other.m_allocator);
-			other.m_allocator = _Move(tmpAlloc);
 		}
 
 		T* detachBuffer()
@@ -391,7 +386,7 @@ namespace Slang
 		{
 			for (UInt i = 0; i < (m_size >> 1); i++)
 			{
-				Swap(m_buffer, i, m_size - i - 1);
+				swapElements(m_buffer, i, m_size - i - 1);
 			}
 		}
 
@@ -533,18 +528,18 @@ namespace Slang
 			return (UInt)-1;
 		}
 
-		void Sort()
+		void sort()
 		{
-			Sort([](const T& t1, const T& t2){return t1 < t2;});
+			sort([](const T& t1, const T& t2){return t1 < t2;});
 		}
 
-		bool Contains(const T& val) const
+		bool contains(const T& val) const
 		{
             return IndexOf(val) != UInt(-1);
 		}
 
 		template<typename Comparer>
-		void Sort(Comparer compare)
+		void sort(Comparer compare)
 		{
 			//InsertionSort(buffer, 0, _count - 1);
 			//QuickSort(buffer, 0, _count - 1, compare);
@@ -552,48 +547,48 @@ namespace Slang
 		}
 
 		template <typename IterateFunc>
-		void ForEach(IterateFunc f) const
+		void forEach(IterateFunc f) const
 		{
 			for (int i = 0; i< m_size; i++)
 				f(m_buffer[i]);
 		}
 
 		template<typename Comparer>
-		void QuickSort(T* vals, int startIndex, int endIndex, Comparer comparer)
+		void quickSort(T* vals, int startIndex, int endIndex, Comparer comparer)
 		{
 			if(startIndex < endIndex)
 			{
 				if (endIndex - startIndex < MIN_QSORT_SIZE)
-					InsertionSort(vals, startIndex, endIndex, comparer);
+					insertionSort(vals, startIndex, endIndex, comparer);
 				else
 				{
 					int pivotIndex = (startIndex + endIndex) >> 1;
-					int pivotNewIndex = Partition(vals, startIndex, endIndex, pivotIndex, comparer);
-					QuickSort(vals, startIndex, pivotNewIndex - 1, comparer);
-					QuickSort(vals, pivotNewIndex + 1, endIndex, comparer);
+					int pivotNewIndex = partition(vals, startIndex, endIndex, pivotIndex, comparer);
+					quickSort(vals, startIndex, pivotNewIndex - 1, comparer);
+					quickSort(vals, pivotNewIndex + 1, endIndex, comparer);
 				}
 			}
 
 		}
 		template<typename Comparer>
-		int Partition(T* vals, int left, int right, int pivotIndex, Comparer comparer)
+		int partition(T* vals, int left, int right, int pivotIndex, Comparer comparer)
 		{
 			T pivotValue = vals[pivotIndex];
-			Swap(vals, right, pivotIndex);
+			swapElements(vals, right, pivotIndex);
 			int storeIndex = left;
 			for (int i = left; i < right; i++)
 			{
 				if (comparer(vals[i], pivotValue))
 				{
-					Swap(vals, i, storeIndex);
+					swapElements(vals, i, storeIndex);
 					storeIndex++;
 				}
 			}
-			Swap(vals, storeIndex, right);
+			swapElements(vals, storeIndex, right);
 			return storeIndex;
 		}
 		template<typename Comparer>
-		void InsertionSort(T* vals, int startIndex, int endIndex, Comparer comparer)
+		void insertionSort(T* vals, int startIndex, int endIndex, Comparer comparer)
 		{
 			for (int i = startIndex  + 1; i <= endIndex; i++)
 			{
@@ -608,7 +603,7 @@ namespace Slang
 			}
 		}
 
-		inline void Swap(T* vals, int index1, int index2)
+		inline void swapElements(T* vals, int index1, int index2)
 		{
 			if (index1 != index2)
 			{
@@ -619,7 +614,7 @@ namespace Slang
 		}
 
 		template<typename T2, typename Comparer>
-		int BinarySearch(const T2& obj, Comparer comparer)
+		int binarySearch(const T2& obj, Comparer comparer)
 		{
 			int imin = 0, imax = m_size - 1;
 			while (imax >= imin)
@@ -637,9 +632,9 @@ namespace Slang
 		}
 
 		template<typename T2>
-		int BinarySearch(const T2& obj)
+		int binarySearch(const T2& obj)
 		{
-			return BinarySearch(obj, 
+			return binarySearch(obj, 
 				[](T & curObj, const T2 & thatObj)->int
 				{
 					if (curObj < thatObj)
@@ -653,7 +648,7 @@ namespace Slang
 	};
 
 	template<typename T>
-	T Min(const List<T>& list)
+	T calcMin(const List<T>& list)
 	{
 		T minVal = list.getFirst();
 		for (int i = 1; i < list.getSize(); i++)
@@ -663,7 +658,7 @@ namespace Slang
 	}
 
 	template<typename T>
-	T Max(const List<T>& list)
+	T calcMax(const List<T>& list)
 	{
 		T maxVal = list.getFirst();
 		for (int i = 1; i< list.getSize(); i++)

--- a/source/core/platform.cpp
+++ b/source/core/platform.cpp
@@ -52,7 +52,7 @@ SLANG_COMPILE_TIME_ASSERT(E_OUTOFMEMORY == SLANG_E_OUT_OF_MEMORY);
         {
             builderOut << " ";
             // Convert to string
-            builderOut.Append(String::FromWString(buffer));
+            builderOut.Append(String::fromWString(buffer));
             LocalFree(buffer);
             return SLANG_OK;
         }

--- a/source/core/slang-byte-encode-util.cpp
+++ b/source/core/slang-byte-encode-util.cpp
@@ -100,7 +100,7 @@ namespace Slang {
 /* static */void ByteEncodeUtil::encodeLiteUInt32(const uint32_t* in, size_t num, List<uint8_t>& encodeArrayOut)
 {
     // Make sure there is at least enough space for all bytes
-    encodeArrayOut.setSize(num);
+    encodeArrayOut.setCount(num);
 
     uint8_t* encodeOut = encodeArrayOut.begin();
     uint8_t* encodeOutEnd = encodeArrayOut.end();
@@ -118,7 +118,7 @@ namespace Slang {
             encodeArrayOut.reserve(oldCapacity + (oldCapacity >> 1) + kMaxLiteEncodeUInt32);
             // Make the size the capacity
             const UInt capacity = encodeArrayOut.getCapacity();
-            encodeArrayOut.setSize(capacity);
+            encodeArrayOut.setCount(capacity);
 
             encodeOut = encodeArrayOut.begin() + offset;
             encodeOutEnd = encodeArrayOut.end();
@@ -152,7 +152,7 @@ namespace Slang {
         }
     }
 
-    encodeArrayOut.setSize(UInt(encodeOut - encodeArrayOut.begin()));
+    encodeArrayOut.setCount(UInt(encodeOut - encodeArrayOut.begin()));
     encodeArrayOut.compress();
 }
 

--- a/source/core/slang-byte-encode-util.cpp
+++ b/source/core/slang-byte-encode-util.cpp
@@ -100,7 +100,7 @@ namespace Slang {
 /* static */void ByteEncodeUtil::encodeLiteUInt32(const uint32_t* in, size_t num, List<uint8_t>& encodeArrayOut)
 {
     // Make sure there is at least enough space for all bytes
-    encodeArrayOut.SetSize(num);
+    encodeArrayOut.setSize(num);
 
     uint8_t* encodeOut = encodeArrayOut.begin();
     uint8_t* encodeOutEnd = encodeArrayOut.end();
@@ -115,10 +115,10 @@ namespace Slang {
             const UInt oldCapacity = encodeArrayOut.getCapacity();
            
             // Make some more space
-            encodeArrayOut.Reserve(oldCapacity + (oldCapacity >> 1) + kMaxLiteEncodeUInt32);
+            encodeArrayOut.reserve(oldCapacity + (oldCapacity >> 1) + kMaxLiteEncodeUInt32);
             // Make the size the capacity
             const UInt capacity = encodeArrayOut.getCapacity();
-            encodeArrayOut.SetSize(capacity);
+            encodeArrayOut.setSize(capacity);
 
             encodeOut = encodeArrayOut.begin() + offset;
             encodeOutEnd = encodeArrayOut.end();
@@ -152,7 +152,7 @@ namespace Slang {
         }
     }
 
-    encodeArrayOut.SetSize(UInt(encodeOut - encodeArrayOut.begin()));
+    encodeArrayOut.setSize(UInt(encodeOut - encodeArrayOut.begin()));
     encodeArrayOut.Compress();
 }
 

--- a/source/core/slang-byte-encode-util.cpp
+++ b/source/core/slang-byte-encode-util.cpp
@@ -112,12 +112,12 @@ namespace Slang {
         {
             const size_t offset = size_t(encodeOut - encodeArrayOut.begin());
 
-            const UInt oldCapacity = encodeArrayOut.Capacity();
+            const UInt oldCapacity = encodeArrayOut.getCapacity();
            
             // Make some more space
             encodeArrayOut.Reserve(oldCapacity + (oldCapacity >> 1) + kMaxLiteEncodeUInt32);
             // Make the size the capacity
-            const UInt capacity = encodeArrayOut.Capacity();
+            const UInt capacity = encodeArrayOut.getCapacity();
             encodeArrayOut.SetSize(capacity);
 
             encodeOut = encodeArrayOut.begin() + offset;

--- a/source/core/slang-byte-encode-util.cpp
+++ b/source/core/slang-byte-encode-util.cpp
@@ -153,7 +153,7 @@ namespace Slang {
     }
 
     encodeArrayOut.setSize(UInt(encodeOut - encodeArrayOut.begin()));
-    encodeArrayOut.Compress();
+    encodeArrayOut.compress();
 }
 
 /* static */int ByteEncodeUtil::encodeLiteUInt32(uint32_t in, uint8_t out[kMaxLiteEncodeUInt32])

--- a/source/core/slang-free-list.h
+++ b/source/core/slang-free-list.h
@@ -1,9 +1,9 @@
-﻿#ifndef SLANG_FREE_LIST_H
+#ifndef SLANG_FREE_LIST_H
 #define SLANG_FREE_LIST_H
 
 #include "../../slang.h"
 
-#include <assert.h>
+#include "common.h"
 
 #include <stdlib.h>
 #include <string.h>

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -241,7 +241,7 @@ namespace Slang
         split(path, splitPath);
 
         // Strictly speaking we could do something about case on platforms like window, but here we won't worry about that
-        for (int i = 0; i < int(splitPath.getCount()); i++)
+        for (Index i = 0; i < splitPath.getCount(); i++)
         {
             const UnownedStringSlice& cur = splitPath[i];
             if (cur == "." && splitPath.getCount() > 1)
@@ -272,7 +272,7 @@ namespace Slang
    
         // Reconstruct the string
         StringBuilder builder;
-        for (int i = 0; i < int(splitPath.getCount()); i++)
+        for (Index i = 0; i < splitPath.getCount(); i++)
         {
             if (i > 0)
             {
@@ -480,7 +480,7 @@ namespace Slang
 
         while (true)
         {
-            const size_t size = buffer.getCount();
+            const size_t size = size_t(buffer.getCount());
             size_t bufferSize = size;
             SlangResult res = _calcExectuablePath(buffer.getBuffer(), &bufferSize);
 
@@ -497,7 +497,7 @@ namespace Slang
 
             // If bufferSize changed it should be the exact fit size, else we just make the buffer bigger by a guess (50% bigger)
             bufferSize = (bufferSize > size) ? bufferSize : (bufferSize + bufferSize / 2);
-            buffer.setCount(bufferSize);
+            buffer.setCount(Index(bufferSize));
         }
     }
 

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -209,9 +209,9 @@ namespace Slang
         }
 
         // Okay if the end is empty. And we aren't with a spec like // or c:/ , then drop the final slash 
-        if (splitOut.Count() > 1 && splitOut.Last().size() == 0)
+        if (splitOut.getSize() > 1 && splitOut.Last().size() == 0)
         {
-            if (splitOut.Count() == 2 && isDriveSpecification(splitOut[0]))
+            if (splitOut.getSize() == 2 && isDriveSpecification(splitOut[0]))
             {
                 return;
             }
@@ -241,10 +241,10 @@ namespace Slang
         split(path, splitPath);
 
         // Strictly speaking we could do something about case on platforms like window, but here we won't worry about that
-        for (int i = 0; i < int(splitPath.Count()); i++)
+        for (int i = 0; i < int(splitPath.getSize()); i++)
         {
             const UnownedStringSlice& cur = splitPath[i];
-            if (cur == "." && splitPath.Count() > 1)
+            if (cur == "." && splitPath.getSize() > 1)
             {
                 // Just remove it 
                 splitPath.RemoveAt(i);
@@ -265,14 +265,14 @@ namespace Slang
         }
 
         // If its empty it must be .
-        if (splitPath.Count() == 0)
+        if (splitPath.getSize() == 0)
         {
             splitPath.Add(UnownedStringSlice::fromLiteral("."));
         }
    
         // Reconstruct the string
         StringBuilder builder;
-        for (int i = 0; i < int(splitPath.Count()); i++)
+        for (int i = 0; i < int(splitPath.getSize()); i++)
         {
             if (i > 0)
             {
@@ -480,7 +480,7 @@ namespace Slang
 
         while (true)
         {
-            const size_t size = buffer.Count();
+            const size_t size = buffer.getSize();
             size_t bufferSize = size;
             SlangResult res = _calcExectuablePath(buffer.Buffer(), &bufferSize);
 

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -191,7 +191,7 @@ namespace Slang
 
     /* static */void Path::split(const UnownedStringSlice& path, List<UnownedStringSlice>& splitOut)
     {
-        splitOut.Clear();
+        splitOut.clear();
 
         const char* start = path.begin();
         const char* end = path.end();
@@ -247,7 +247,7 @@ namespace Slang
             if (cur == "." && splitPath.getSize() > 1)
             {
                 // Just remove it 
-                splitPath.RemoveAt(i);
+                splitPath.removeAt(i);
                 i--;
             }
             else if (cur == ".." && i > 0)
@@ -259,7 +259,7 @@ namespace Slang
                     // Can't do it
                     continue;
                 }
-                splitPath.RemoveRange(i - 1, 2);
+                splitPath.removeRange(i - 1, 2);
                 i -= 2;
             }
         }

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -209,9 +209,9 @@ namespace Slang
         }
 
         // Okay if the end is empty. And we aren't with a spec like // or c:/ , then drop the final slash 
-        if (splitOut.getSize() > 1 && splitOut.getLast().size() == 0)
+        if (splitOut.getCount() > 1 && splitOut.getLast().size() == 0)
         {
-            if (splitOut.getSize() == 2 && isDriveSpecification(splitOut[0]))
+            if (splitOut.getCount() == 2 && isDriveSpecification(splitOut[0]))
             {
                 return;
             }
@@ -241,10 +241,10 @@ namespace Slang
         split(path, splitPath);
 
         // Strictly speaking we could do something about case on platforms like window, but here we won't worry about that
-        for (int i = 0; i < int(splitPath.getSize()); i++)
+        for (int i = 0; i < int(splitPath.getCount()); i++)
         {
             const UnownedStringSlice& cur = splitPath[i];
-            if (cur == "." && splitPath.getSize() > 1)
+            if (cur == "." && splitPath.getCount() > 1)
             {
                 // Just remove it 
                 splitPath.removeAt(i);
@@ -265,14 +265,14 @@ namespace Slang
         }
 
         // If its empty it must be .
-        if (splitPath.getSize() == 0)
+        if (splitPath.getCount() == 0)
         {
             splitPath.add(UnownedStringSlice::fromLiteral("."));
         }
    
         // Reconstruct the string
         StringBuilder builder;
-        for (int i = 0; i < int(splitPath.getSize()); i++)
+        for (int i = 0; i < int(splitPath.getCount()); i++)
         {
             if (i > 0)
             {
@@ -476,17 +476,17 @@ namespace Slang
     {
         List<char> buffer;
         // Guess an initial buffer size
-        buffer.setSize(1024);
+        buffer.setCount(1024);
 
         while (true)
         {
-            const size_t size = buffer.getSize();
+            const size_t size = buffer.getCount();
             size_t bufferSize = size;
-            SlangResult res = _calcExectuablePath(buffer.Buffer(), &bufferSize);
+            SlangResult res = _calcExectuablePath(buffer.getBuffer(), &bufferSize);
 
             if (SLANG_SUCCEEDED(res))
             {
-                return String(buffer.Buffer());
+                return String(buffer.getBuffer());
             }
 
             if (res != SLANG_E_BUFFER_TOO_SMALL)
@@ -497,7 +497,7 @@ namespace Slang
 
             // If bufferSize changed it should be the exact fit size, else we just make the buffer bigger by a guess (50% bigger)
             bufferSize = (bufferSize > size) ? bufferSize : (bufferSize + bufferSize / 2);
-            buffer.setSize(bufferSize);
+            buffer.setCount(bufferSize);
         }
     }
 

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -202,21 +202,21 @@ namespace Slang
             // Find the split
             while (cur < end && !isDelimiter(*cur)) cur++;
 
-            splitOut.Add(UnownedStringSlice(start, cur));
+            splitOut.add(UnownedStringSlice(start, cur));
            
             // Next
             start = cur + 1;
         }
 
         // Okay if the end is empty. And we aren't with a spec like // or c:/ , then drop the final slash 
-        if (splitOut.getSize() > 1 && splitOut.Last().size() == 0)
+        if (splitOut.getSize() > 1 && splitOut.getLast().size() == 0)
         {
             if (splitOut.getSize() == 2 && isDriveSpecification(splitOut[0]))
             {
                 return;
             }
             // Remove the last 
-            splitOut.RemoveLast();
+            splitOut.removeLast();
         }
     }
 
@@ -267,7 +267,7 @@ namespace Slang
         // If its empty it must be .
         if (splitPath.getSize() == 0)
         {
-            splitPath.Add(UnownedStringSlice::fromLiteral("."));
+            splitPath.add(UnownedStringSlice::fromLiteral("."));
         }
    
         // Reconstruct the string
@@ -522,7 +522,7 @@ namespace Slang
 			unsigned char ch;
 			int read = (int)fs->Read(&ch, 1);
 			if (read)
-				buffer.Add(ch);
+				buffer.add(ch);
 			else
 				break;
 		}

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -476,7 +476,7 @@ namespace Slang
     {
         List<char> buffer;
         // Guess an initial buffer size
-        buffer.SetSize(1024);
+        buffer.setSize(1024);
 
         while (true)
         {
@@ -497,7 +497,7 @@ namespace Slang
 
             // If bufferSize changed it should be the exact fit size, else we just make the buffer bigger by a guess (50% bigger)
             bufferSize = (bufferSize > size) ? bufferSize : (bufferSize + bufferSize / 2);
-            buffer.SetSize(bufferSize);
+            buffer.setSize(bufferSize);
         }
     }
 

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -35,10 +35,10 @@ namespace Slang
 	{
 #ifdef _WIN32
 		struct _stat32 statVar;
-		return ::_wstat32(((String)fileName).ToWString(), &statVar) != -1;
+		return ::_wstat32(((String)fileName).toWString(), &statVar) != -1;
 #else
 		struct stat statVar;
-		return ::stat(fileName.Buffer(), &statVar) == 0;
+		return ::stat(fileName.getBuffer(), &statVar) == 0;
 #endif
 	}
 
@@ -56,7 +56,7 @@ namespace Slang
 		UInt dotPos = path.lastIndexOf('.');
 		if (dotPos == -1)
 			dotPos = path.getLength();
-		sb.Append(path.Buffer(), dotPos);
+		sb.Append(path.getBuffer(), dotPos);
 		sb.Append('.');
 		sb.Append(newExt);
 		return sb.ProduceString();
@@ -287,9 +287,9 @@ namespace Slang
 	bool Path::createDirectory(const String& path)
 	{
 #if defined(_WIN32)
-		return _wmkdir(path.ToWString()) == 0;
+		return _wmkdir(path.toWString()) == 0;
 #else 
-		return mkdir(path.Buffer(), 0777) == 0;
+		return mkdir(path.getBuffer(), 0777) == 0;
 #endif
 	}
 
@@ -298,7 +298,7 @@ namespace Slang
 #ifdef _WIN32
         // https://msdn.microsoft.com/en-us/library/14h5k7ff.aspx
         struct _stat32 statVar;
-        if (::_wstat32(String(path).ToWString(), &statVar) == 0)
+        if (::_wstat32(String(path).toWString(), &statVar) == 0)
         {
             if (statVar.st_mode & _S_IFDIR)
             {
@@ -316,7 +316,7 @@ namespace Slang
         return SLANG_E_NOT_FOUND;
 #else
         struct stat statVar;
-        if (::stat(path.Buffer(), &statVar) == 0)
+        if (::stat(path.getBuffer(), &statVar) == 0)
         {
             if (S_ISDIR(statVar.st_mode))
             {
@@ -340,7 +340,7 @@ namespace Slang
     {
 #if defined(_WIN32)
         // https://msdn.microsoft.com/en-us/library/506720ff.aspx
-        wchar_t* absPath = ::_wfullpath(nullptr, path.ToWString(), 0);
+        wchar_t* absPath = ::_wfullpath(nullptr, path.toWString(), 0);
         if (!absPath)
         {
             return SLANG_FAIL;

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -44,18 +44,18 @@ namespace Slang
 
 	String Path::truncateExt(const String& path)
 	{
-		UInt dotPos = path.LastIndexOf('.');
+		UInt dotPos = path.lastIndexOf('.');
 		if (dotPos != -1)
-			return path.SubString(0, dotPos);
+			return path.subString(0, dotPos);
 		else
 			return path;
 	}
 	String Path::replaceExt(const String& path, const char* newExt)
 	{
-		StringBuilder sb(path.Length()+10);
-		UInt dotPos = path.LastIndexOf('.');
+		StringBuilder sb(path.getLength()+10);
+		UInt dotPos = path.lastIndexOf('.');
 		if (dotPos == -1)
-			dotPos = path.Length();
+			dotPos = path.getLength();
 		sb.Append(path.Buffer(), dotPos);
 		sb.Append('.');
 		sb.Append(newExt);
@@ -64,8 +64,8 @@ namespace Slang
 
     static UInt findLastSeparator(String const& path)
     {
-		UInt slashPos = path.LastIndexOf('/');
-        UInt backslashPos = path.LastIndexOf('\\');
+		UInt slashPos = path.lastIndexOf('/');
+        UInt backslashPos = path.lastIndexOf('\\');
 
         if (slashPos == -1) return backslashPos;
         if (backslashPos == -1) return slashPos;
@@ -83,7 +83,7 @@ namespace Slang
         if (pos != -1)
         {
             pos = pos + 1;
-            return path.SubString(pos, path.Length() - pos);
+            return path.subString(pos, path.getLength() - pos);
         }
         else
         {
@@ -93,16 +93,16 @@ namespace Slang
 	String Path::getFileNameWithoutExt(const String& path)
 	{
         String fileName = getFileName(path);
-		UInt dotPos = fileName.LastIndexOf('.');
+		UInt dotPos = fileName.lastIndexOf('.');
 		if (dotPos == -1)
             return fileName;
-		return fileName.SubString(0, dotPos);
+		return fileName.subString(0, dotPos);
 	}
 	String Path::getFileExt(const String& path)
 	{
-		UInt dotPos = path.LastIndexOf('.');
+		UInt dotPos = path.lastIndexOf('.');
 		if (dotPos != -1)
-			return path.SubString(dotPos+1, path.Length()-dotPos-1);
+			return path.subString(dotPos+1, path.getLength()-dotPos-1);
 		else
 			return "";
 	}
@@ -110,28 +110,28 @@ namespace Slang
 	{
         UInt pos = findLastSeparator(path);
 		if (pos != -1)
-			return path.SubString(0, pos);
+			return path.subString(0, pos);
 		else
 			return "";
 	}
 	String Path::combine(const String& path1, const String& path2)
 	{
-		if (path1.Length() == 0) return path2;
-		StringBuilder sb(path1.Length()+path2.Length()+2);
+		if (path1.getLength() == 0) return path2;
+		StringBuilder sb(path1.getLength()+path2.getLength()+2);
 		sb.Append(path1);
-		if (!path1.EndsWith('\\') && !path1.EndsWith('/'))
+		if (!path1.endsWith('\\') && !path1.endsWith('/'))
 			sb.Append(kPathDelimiter);
 		sb.Append(path2);
 		return sb.ProduceString();
 	}
 	String Path::combine(const String& path1, const String& path2, const String& path3)
 	{
-		StringBuilder sb(path1.Length()+path2.Length()+path3.Length()+3);
+		StringBuilder sb(path1.getLength()+path2.getLength()+path3.getLength()+3);
 		sb.Append(path1);
-		if (!path1.EndsWith('\\') && !path1.EndsWith('/'))
+		if (!path1.endsWith('\\') && !path1.endsWith('/'))
 			sb.Append(kPathDelimiter);
 		sb.Append(path2);
-		if (!path2.EndsWith('\\') && !path2.EndsWith('/'))
+		if (!path2.endsWith('\\') && !path2.endsWith('/'))
 			sb.Append(kPathDelimiter);
 		sb.Append(path3);
 		return sb.ProduceString();
@@ -346,7 +346,7 @@ namespace Slang
             return SLANG_FAIL;
         }  
 
-        canonicalPathOut =  String::FromWString(absPath);
+        canonicalPathOut =  String::fromWString(absPath);
         ::free(absPath);
         return SLANG_OK;
 #else
@@ -432,15 +432,15 @@ namespace Slang
         return SLANG_OK;
 #   else        
         String text = Slang::File::readAllText("/proc/self/maps");
-        Index startIndex = text.IndexOf('/');
+        Index startIndex = text.indexOf('/');
         if (startIndex == Index(-1))
         {
             return SLANG_FAIL;
         }
-        Index endIndex = text.IndexOf("\n", startIndex);
-        endIndex = (endIndex == Index(-1)) ? text.Length() : endIndex;
+        Index endIndex = text.indexOf("\n", startIndex);
+        endIndex = (endIndex == Index(-1)) ? text.getLength() : endIndex;
 
-        auto path = text.SubString(startIndex, endIndex - startIndex);
+        auto path = text.subString(startIndex, endIndex - startIndex);
 
         if (path.getLength() < bufferSize)
         {

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -432,13 +432,13 @@ namespace Slang
         return SLANG_OK;
 #   else        
         String text = Slang::File::readAllText("/proc/self/maps");
-        UInt startIndex = text.IndexOf('/');
-        if (startIndex == UInt(-1))
+        Index startIndex = text.IndexOf('/');
+        if (startIndex == Index(-1))
         {
             return SLANG_FAIL;
         }
-        UInt endIndex = text.IndexOf("\n", startIndex);
-        endIndex = (endIndex == UInt(-1)) ? text.Length() : endIndex;
+        Index endIndex = text.IndexOf("\n", startIndex);
+        endIndex = (endIndex == Index(-1)) ? text.Length() : endIndex;
 
         auto path = text.SubString(startIndex, endIndex - startIndex);
 

--- a/source/core/slang-memory-arena.h
+++ b/source/core/slang-memory-arena.h
@@ -3,8 +3,6 @@
 
 #include "../../slang.h"
 
-#include <assert.h>
-
 #include <stdlib.h>
 #include <string.h>
 

--- a/source/core/slang-object-scope-manager.cpp
+++ b/source/core/slang-object-scope-manager.cpp
@@ -5,8 +5,8 @@ namespace Slang {
 void ObjectScopeManager::_releaseAll()
 {
     RefObject*const* objs = m_objs.begin();
-    const int numObjs = int(m_objs.getCount());
-    for (int i = 0; i < numObjs; ++i)
+    const Index numObjs = m_objs.getCount();
+    for (Index i = 0; i < numObjs; ++i)
     {
         objs[i]->decreaseReference();
     }

--- a/source/core/slang-object-scope-manager.cpp
+++ b/source/core/slang-object-scope-manager.cpp
@@ -5,7 +5,7 @@ namespace Slang {
 void ObjectScopeManager::_releaseAll()
 {
     RefObject*const* objs = m_objs.begin();
-    const int numObjs = int(m_objs.getSize());
+    const int numObjs = int(m_objs.getCount());
     for (int i = 0; i < numObjs; ++i)
     {
         objs[i]->decreaseReference();

--- a/source/core/slang-object-scope-manager.cpp
+++ b/source/core/slang-object-scope-manager.cpp
@@ -5,7 +5,7 @@ namespace Slang {
 void ObjectScopeManager::_releaseAll()
 {
     RefObject*const* objs = m_objs.begin();
-    const int numObjs = int(m_objs.Count());
+    const int numObjs = int(m_objs.getSize());
     for (int i = 0; i < numObjs; ++i)
     {
         objs[i]->decreaseReference();

--- a/source/core/slang-object-scope-manager.h
+++ b/source/core/slang-object-scope-manager.h
@@ -1,4 +1,4 @@
-﻿#ifndef SLANG_OBJECT_SCOPE_MANAGER_H
+#ifndef SLANG_OBJECT_SCOPE_MANAGER_H
 #define SLANG_OBJECT_SCOPE_MANAGER_H
 
 #include "smart-pointer.h"
@@ -48,7 +48,7 @@ RefObject* ObjectScopeManager::addMaybeNull(RefObject* obj)
     if (obj)
     {
         obj->addReference();
-        m_objs.Add(obj);
+        m_objs.add(obj);
     }
     return obj;
 }
@@ -58,7 +58,7 @@ RefObject* ObjectScopeManager::add(RefObject* obj)
 {
     SLANG_ASSERT(obj);
     obj->addReference();
-    m_objs.Add(obj);
+    m_objs.add(obj);
     return obj;
 }
 

--- a/source/core/slang-random-generator.h
+++ b/source/core/slang-random-generator.h
@@ -3,8 +3,6 @@
 
 #include "../../slang.h"
 
-#include <assert.h>
-
 #include <stdlib.h>
 #include <string.h>
 

--- a/source/core/slang-render-api-util.cpp
+++ b/source/core/slang-render-api-util.cpp
@@ -62,7 +62,7 @@ UnownedStringSlice RenderApiUtil::getApiName(RenderApiType type)
         if (names.indexOf(',') >= 0)
         {
             StringUtil::split(names, ',', namesList);
-            if (namesList.IndexOf(name) != UInt(-1))
+            if (namesList.indexOf(name) != UInt(-1))
             {
                 return apiInfo.type;
             }

--- a/source/core/slang-render-api-util.cpp
+++ b/source/core/slang-render-api-util.cpp
@@ -62,7 +62,7 @@ UnownedStringSlice RenderApiUtil::getApiName(RenderApiType type)
         if (names.indexOf(',') >= 0)
         {
             StringUtil::split(names, ',', namesList);
-            if (namesList.indexOf(name) != UInt(-1))
+            if (namesList.indexOf(name) != Index(-1))
             {
                 return apiInfo.type;
             }

--- a/source/core/slang-string-slice-pool.cpp
+++ b/source/core/slang-string-slice-pool.cpp
@@ -40,7 +40,7 @@ StringSlicePool::Handle StringSlicePool::add(const Slice& slice)
 
     const int index = int(m_slices.getSize());
 
-    m_slices.Add(scopePath);
+    m_slices.add(scopePath);
     m_map.Add(scopePath, Handle(index));
     return Handle(index);
 }

--- a/source/core/slang-string-slice-pool.cpp
+++ b/source/core/slang-string-slice-pool.cpp
@@ -38,7 +38,7 @@ StringSlicePool::Handle StringSlicePool::add(const Slice& slice)
     // Create a scoped copy
     UnownedStringSlice scopePath(m_arena.allocateString(slice.begin(), slice.size()), slice.size());
 
-    const int index = int(m_slices.Count());
+    const int index = int(m_slices.getSize());
 
     m_slices.Add(scopePath);
     m_map.Add(scopePath, Handle(index));

--- a/source/core/slang-string-slice-pool.cpp
+++ b/source/core/slang-string-slice-pool.cpp
@@ -16,7 +16,7 @@ StringSlicePool::StringSlicePool() :
 
 void StringSlicePool::clear()
 {
-    m_slices.setSize(2);
+    m_slices.setCount(2);
 
     m_slices[0] = UnownedStringSlice((const char*)nullptr, (const char*)nullptr);
     m_slices[1] = UnownedStringSlice::fromLiteral("");
@@ -38,7 +38,7 @@ StringSlicePool::Handle StringSlicePool::add(const Slice& slice)
     // Create a scoped copy
     UnownedStringSlice scopePath(m_arena.allocateString(slice.begin(), slice.size()), slice.size());
 
-    const int index = int(m_slices.getSize());
+    const int index = int(m_slices.getCount());
 
     m_slices.add(scopePath);
     m_map.Add(scopePath, Handle(index));

--- a/source/core/slang-string-slice-pool.cpp
+++ b/source/core/slang-string-slice-pool.cpp
@@ -16,7 +16,7 @@ StringSlicePool::StringSlicePool() :
 
 void StringSlicePool::clear()
 {
-    m_slices.SetSize(2);
+    m_slices.setSize(2);
 
     m_slices[0] = UnownedStringSlice((const char*)nullptr, (const char*)nullptr);
     m_slices[1] = UnownedStringSlice::fromLiteral("");

--- a/source/core/slang-string-slice-pool.cpp
+++ b/source/core/slang-string-slice-pool.cpp
@@ -38,7 +38,7 @@ StringSlicePool::Handle StringSlicePool::add(const Slice& slice)
     // Create a scoped copy
     UnownedStringSlice scopePath(m_arena.allocateString(slice.begin(), slice.size()), slice.size());
 
-    const int index = int(m_slices.getCount());
+    const auto index = m_slices.getCount();
 
     m_slices.add(scopePath);
     m_map.Add(scopePath, Handle(index));

--- a/source/core/slang-string-slice-pool.h
+++ b/source/core/slang-string-slice-pool.h
@@ -46,7 +46,7 @@ public:
     const List<UnownedStringSlice>& getSlices() const { return m_slices; }
 
         /// Get the number of slices
-    int getNumSlices() const { return int(m_slices.Count()); }
+    int getNumSlices() const { return int(m_slices.getSize()); }
 
         /// Convert a handle to and index. (A handle is just an index!) 
     static int asIndex(Handle handle) { return int(handle); }

--- a/source/core/slang-string-slice-pool.h
+++ b/source/core/slang-string-slice-pool.h
@@ -46,7 +46,7 @@ public:
     const List<UnownedStringSlice>& getSlices() const { return m_slices; }
 
         /// Get the number of slices
-    int getNumSlices() const { return int(m_slices.getSize()); }
+    int getNumSlices() const { return int(m_slices.getCount()); }
 
         /// Convert a handle to and index. (A handle is just an index!) 
     static int asIndex(Handle handle) { return int(handle); }

--- a/source/core/slang-string-util.cpp
+++ b/source/core/slang-string-util.cpp
@@ -196,7 +196,7 @@ ComPtr<ISlangBlob> StringUtil::createStringBlob(const String& string)
 
 /* static */String StringUtil::calcCharReplaced(const String& string, char fromChar, char toChar)
 {
-    return (fromChar == toChar || string.IndexOf(fromChar) == UInt(-1)) ? string : calcCharReplaced(string.getUnownedSlice(), fromChar, toChar);
+    return (fromChar == toChar || string.IndexOf(fromChar) == Index(-1)) ? string : calcCharReplaced(string.getUnownedSlice(), fromChar, toChar);
 }
 
 

--- a/source/core/slang-string-util.cpp
+++ b/source/core/slang-string-util.cpp
@@ -17,7 +17,7 @@ static const Guid IID_ISlangBlob = SLANG_UUID_ISlangBlob;
 
 /* static */void StringUtil::split(const UnownedStringSlice& in, char splitChar, List<UnownedStringSlice>& slicesOut)
 {
-    slicesOut.Clear();
+    slicesOut.clear();
 
     const char* start = in.begin();
     const char* end = in.end();

--- a/source/core/slang-string-util.cpp
+++ b/source/core/slang-string-util.cpp
@@ -32,7 +32,7 @@ static const Guid IID_ISlangBlob = SLANG_UUID_ISlangBlob;
         }
 
         // Add to output
-        slicesOut.Add(UnownedStringSlice(start, cur));
+        slicesOut.add(UnownedStringSlice(start, cur));
 
         // Skip the split character, if at end we are okay anyway
         start = cur + 1;

--- a/source/core/slang-string-util.cpp
+++ b/source/core/slang-string-util.cpp
@@ -178,13 +178,13 @@ ComPtr<ISlangBlob> StringUtil::createStringBlob(const String& string)
         return slice;
     }
 
-    const UInt numChars = slice.size();
+    const Index numChars = slice.size();
     const char* srcChars = slice.begin();
 
     StringBuilder builder;
     char* dstChars = builder.prepareForAppend(numChars);
 
-    for (UInt i = 0; i < numChars; ++i)
+    for (Index i = 0; i < numChars; ++i)
     {
         char c = srcChars[i];
         dstChars[i] = (c == fromChar) ? toChar : c;

--- a/source/core/slang-string-util.cpp
+++ b/source/core/slang-string-util.cpp
@@ -196,7 +196,7 @@ ComPtr<ISlangBlob> StringUtil::createStringBlob(const String& string)
 
 /* static */String StringUtil::calcCharReplaced(const String& string, char fromChar, char toChar)
 {
-    return (fromChar == toChar || string.IndexOf(fromChar) == Index(-1)) ? string : calcCharReplaced(string.getUnownedSlice(), fromChar, toChar);
+    return (fromChar == toChar || string.indexOf(fromChar) == Index(-1)) ? string : calcCharReplaced(string.getUnownedSlice(), fromChar, toChar);
 }
 
 

--- a/source/core/slang-string-util.h
+++ b/source/core/slang-string-util.h
@@ -21,7 +21,7 @@ public:
 
         // ISlangBlob
     SLANG_NO_THROW void const* SLANG_MCALL getBufferPointer() SLANG_OVERRIDE { return m_string.Buffer(); }
-    SLANG_NO_THROW size_t SLANG_MCALL getBufferSize() SLANG_OVERRIDE { return m_string.Length(); }
+    SLANG_NO_THROW size_t SLANG_MCALL getBufferSize() SLANG_OVERRIDE { return m_string.getLength(); }
 
         /// Get the contained string
     SLANG_FORCE_INLINE const String& getString() const { return m_string; }

--- a/source/core/slang-string-util.h
+++ b/source/core/slang-string-util.h
@@ -20,7 +20,7 @@ public:
     SLANG_REF_OBJECT_IUNKNOWN_ALL
 
         // ISlangBlob
-    SLANG_NO_THROW void const* SLANG_MCALL getBufferPointer() SLANG_OVERRIDE { return m_string.Buffer(); }
+    SLANG_NO_THROW void const* SLANG_MCALL getBufferPointer() SLANG_OVERRIDE { return m_string.getBuffer(); }
     SLANG_NO_THROW size_t SLANG_MCALL getBufferSize() SLANG_OVERRIDE { return m_string.getLength(); }
 
         /// Get the contained string

--- a/source/core/slang-string.cpp
+++ b/source/core/slang-string.cpp
@@ -91,7 +91,7 @@ namespace Slang
     StringSlice::StringSlice(String const& str)
         : representation(str.m_buffer)
         , beginIndex(0)
-        , endIndex(str.Length())
+        , endIndex(str.getLength())
     {}
 
     StringSlice::StringSlice(String const& str, UInt beginIndex, UInt endIndex)
@@ -128,14 +128,14 @@ namespace Slang
 
 	int StringToInt(const String & str, int radix)
 	{
-		if (str.StartsWith("0x"))
+		if (str.startsWith("0x"))
 			return (int)strtoll(str.Buffer(), NULL, 16);
 		else
 			return (int)strtoll(str.Buffer(), NULL, radix);
 	}
 	unsigned int StringToUInt(const String & str, int radix)
 	{
-		if (str.StartsWith("0x"))
+		if (str.startsWith("0x"))
 			return (unsigned int)strtoull(str.Buffer(), NULL, 16);
 		else
 			return (unsigned int)strtoull(str.Buffer(), NULL, radix);
@@ -165,7 +165,7 @@ namespace Slang
 	}
 #endif
 
-	String String::FromWString(const wchar_t * wstr)
+	String String::fromWString(const wchar_t * wstr)
 	{
 #ifdef _WIN32
 		return Slang::Encoding::UTF16->ToString((const char*)wstr, (int)(wcslen(wstr) * sizeof(wchar_t)));
@@ -174,7 +174,7 @@ namespace Slang
 #endif
 	}
 
-	String String::FromWString(const wchar_t * wstr, const wchar_t * wend)
+	String String::fromWString(const wchar_t * wstr, const wchar_t * wend)
 	{
 #ifdef _WIN32
 		return Slang::Encoding::UTF16->ToString((const char*)wstr, (int)((wend - wstr) * sizeof(wchar_t)));
@@ -183,7 +183,7 @@ namespace Slang
 #endif
 	}
 
-	String String::FromWChar(const wchar_t ch)
+	String String::fromWChar(const wchar_t ch)
 	{
 #ifdef _WIN32
 		return Slang::Encoding::UTF16->ToString((const char*)&ch, (int)(sizeof(wchar_t)));
@@ -192,7 +192,7 @@ namespace Slang
 #endif
 	}
 
-	String String::FromUnicodePoint(unsigned int codePoint)
+	String String::fromUnicodePoint(unsigned int codePoint)
 	{
 		char buf[6];
 		int len = Slang::EncodeUnicodePointToUTF8(buf, (int)codePoint);

--- a/source/core/slang-string.cpp
+++ b/source/core/slang-string.cpp
@@ -223,14 +223,14 @@ namespace Slang
                 break;
             }
 
-            auto length = buf.getSize() / sizeof(wchar_t);
+            auto length = buf.getCount() / sizeof(wchar_t);
 			if (outLength)
 				*outLength = length;
 
             for(int ii = 0; ii < sizeof(wchar_t); ++ii)
     			buf.add(0);
 
-            wchar_t* beginData = (wchar_t*)buf.Buffer();
+            wchar_t* beginData = (wchar_t*)buf.getBuffer();
             wchar_t* endData = beginData + length;
 
 			buf.detachBuffer();

--- a/source/core/slang-string.cpp
+++ b/source/core/slang-string.cpp
@@ -129,24 +129,24 @@ namespace Slang
 	int StringToInt(const String & str, int radix)
 	{
 		if (str.startsWith("0x"))
-			return (int)strtoll(str.Buffer(), NULL, 16);
+			return (int)strtoll(str.getBuffer(), NULL, 16);
 		else
-			return (int)strtoll(str.Buffer(), NULL, radix);
+			return (int)strtoll(str.getBuffer(), NULL, radix);
 	}
 	unsigned int StringToUInt(const String & str, int radix)
 	{
 		if (str.startsWith("0x"))
-			return (unsigned int)strtoull(str.Buffer(), NULL, 16);
+			return (unsigned int)strtoull(str.getBuffer(), NULL, 16);
 		else
-			return (unsigned int)strtoull(str.Buffer(), NULL, radix);
+			return (unsigned int)strtoull(str.getBuffer(), NULL, radix);
 	}
 	double StringToDouble(const String & str)
 	{
-		return (double)strtod(str.Buffer(), NULL);
+		return (double)strtod(str.getBuffer(), NULL);
 	}
 	float StringToFloat(const String & str)
 	{
-		return strtof(str.Buffer(), NULL);
+		return strtof(str.getBuffer(), NULL);
 	}
 
 #if 0
@@ -200,7 +200,7 @@ namespace Slang
 		return String(buf);
 	}
 
-	OSString String::ToWString(Index* outLength) const
+	OSString String::toWString(Index* outLength) const
 	{
 		if (!m_buffer)
 		{

--- a/source/core/slang-string.cpp
+++ b/source/core/slang-string.cpp
@@ -228,12 +228,12 @@ namespace Slang
 				*outLength = length;
 
             for(int ii = 0; ii < sizeof(wchar_t); ++ii)
-    			buf.Add(0);
+    			buf.add(0);
 
             wchar_t* beginData = (wchar_t*)buf.Buffer();
             wchar_t* endData = beginData + length;
 
-			buf.ReleaseBuffer();
+			buf.detachBuffer();
 
             return OSString(beginData, endData);
 		}

--- a/source/core/slang-string.cpp
+++ b/source/core/slang-string.cpp
@@ -14,20 +14,20 @@ namespace Slang
     // OSString
 
     OSString::OSString()
-        : beginData(0)
-        , endData(0)
+        : m_begin(0)
+        , m_end(0)
     {}
 
     OSString::OSString(wchar_t* begin, wchar_t* end)
-        : beginData(begin)
-        , endData(end)
+        : m_begin(begin)
+        , m_end(end)
     {}
 
     OSString::~OSString()
     {
-        if (beginData)
+        if (m_begin)
         {
-            delete[] beginData;
+            delete[] m_begin;
         }
     }
 
@@ -35,12 +35,12 @@ namespace Slang
 
     wchar_t const* OSString::begin() const
     {
-        return beginData ? beginData : kEmptyOSString;
+        return m_begin ? m_begin : kEmptyOSString;
     }
 
     wchar_t const* OSString::end() const
     {
-        return endData ? endData : kEmptyOSString;
+        return m_end ? m_end : kEmptyOSString;
     }
 
     // UnownedStringSlice
@@ -89,13 +89,13 @@ namespace Slang
     {}
 
     StringSlice::StringSlice(String const& str)
-        : representation(str.buffer)
+        : representation(str.m_buffer)
         , beginIndex(0)
         , endIndex(str.Length())
     {}
 
     StringSlice::StringSlice(String const& str, UInt beginIndex, UInt endIndex)
-        : representation(str.buffer)
+        : representation(str.m_buffer)
         , beginIndex(beginIndex)
         , endIndex(endIndex)
     {}
@@ -200,9 +200,9 @@ namespace Slang
 		return String(buf);
 	}
 
-	OSString String::ToWString(UInt* outLength) const
+	OSString String::ToWString(Index* outLength) const
 	{
-		if (!buffer)
+		if (!m_buffer)
 		{
             return OSString();
 		}
@@ -223,7 +223,7 @@ namespace Slang
                 break;
             }
 
-            auto length = buf.getCount() / sizeof(wchar_t);
+            auto length = Index(buf.getCount() / sizeof(wchar_t));
 			if (outLength)
 				*outLength = length;
 
@@ -241,55 +241,55 @@ namespace Slang
 
     //
 
-    void String::ensureUniqueStorageWithCapacity(UInt requiredCapacity)
+    void String::ensureUniqueStorageWithCapacity(Index requiredCapacity)
     {
-        if (buffer && buffer->isUniquelyReferenced() && buffer->capacity >= requiredCapacity)
+        if (m_buffer && m_buffer->isUniquelyReferenced() && m_buffer->capacity >= requiredCapacity)
             return;
 
-        UInt newCapacity = buffer ? 2*buffer->capacity : 16;
+        Index newCapacity = m_buffer ? 2 * m_buffer->capacity : 16;
         if (newCapacity < requiredCapacity)
         {
             newCapacity = requiredCapacity;
         }
 
-        UInt length = getLength();
+        Index length = getLength();
         StringRepresentation* newRepresentation = StringRepresentation::createWithCapacityAndLength(newCapacity, length);
 
-        if (buffer)
+        if (m_buffer)
         {
-            memcpy(newRepresentation->getData(), buffer->getData(), length + 1);
+            memcpy(newRepresentation->getData(), m_buffer->getData(), length + 1);
         }
 
-        buffer = newRepresentation;
+        m_buffer = newRepresentation;
     }
 
-    char* String::prepareForAppend(UInt count)
+    char* String::prepareForAppend(Index count)
     {
         auto oldLength = getLength();
         auto newLength = oldLength + count;
         ensureUniqueStorageWithCapacity(newLength);
         return getData() + oldLength;
     }
-    void String::appendInPlace(const char* chars, UInt count)
+    void String::appendInPlace(const char* chars, Index count)
     {
         SLANG_UNUSED(chars);
 
         if (count > 0)
         {
-            SLANG_ASSERT(buffer && buffer->isUniquelyReferenced());
+            SLANG_ASSERT(m_buffer && m_buffer->isUniquelyReferenced());
 
             auto oldLength = getLength();
             auto newLength = oldLength + count;
 
-            char* dst = buffer->getData();
+            char* dst = m_buffer->getData();
 
             // Make sure the input buffer is the same one returned from prepareForAppend
             SLANG_ASSERT(chars == dst + oldLength);
             // It has to fit within the capacity
-            SLANG_ASSERT(newLength <= buffer->capacity);
+            SLANG_ASSERT(newLength <= m_buffer->capacity);
 
             // We just need to modify the length
-            buffer->length = newLength;
+            m_buffer->length = newLength;
 
             // And mark with a terminating 0
             dst[newLength] = 0;
@@ -307,7 +307,7 @@ namespace Slang
 
         memcpy(getData() + oldLength, textBegin, textLength);
         getData()[newLength] = 0;
-        buffer->length = newLength;
+        m_buffer->length = newLength;
     }
 
     void String::append(char const* str)
@@ -325,9 +325,9 @@ namespace Slang
 
     void String::append(String const& str)
     {
-        if (!buffer)
+        if (!m_buffer)
         {
-            buffer = str.buffer;
+            m_buffer = str.m_buffer;
             return;
         }
 
@@ -350,7 +350,7 @@ namespace Slang
         char* data = prepareForAppend(kCount);
         auto count = IntToAscii(data, value, radix);
         ReverseInternalAscii(data, count);
-        buffer->length += count;
+        m_buffer->length += count;
     }
 
     void String::append(uint32_t value, int radix)
@@ -359,7 +359,7 @@ namespace Slang
         char* data = prepareForAppend(kCount);
         auto count = IntToAscii(data, value, radix);
         ReverseInternalAscii(data, count);
-        buffer->length += count;
+        m_buffer->length += count;
     }
 
     void String::append(int64_t value, int radix)
@@ -368,7 +368,7 @@ namespace Slang
         char* data = prepareForAppend(kCount);
         auto count = IntToAscii(data, value, radix);
         ReverseInternalAscii(data, count);
-        buffer->length += count;
+        m_buffer->length += count;
     }
 
     void String::append(uint64_t value, int radix)
@@ -377,7 +377,7 @@ namespace Slang
         char* data = prepareForAppend(kCount);
         auto count = IntToAscii(data, value, radix);
         ReverseInternalAscii(data, count);
-        buffer->length += count;
+        m_buffer->length += count;
     }
 
     void String::append(float val, const char * format)
@@ -385,7 +385,7 @@ namespace Slang
         enum { kCount = 128 };
         char* data = prepareForAppend(kCount);
         sprintf_s(data, kCount, format, val);
-        buffer->length += strnlen_s(data, kCount);
+        m_buffer->length += strnlen_s(data, kCount);
     }
 
     void String::append(double val, const char * format)
@@ -393,6 +393,6 @@ namespace Slang
         enum { kCount = 128 };
         char* data = prepareForAppend(kCount);
         sprintf_s(data, kCount, format, val);
-        buffer->length += strnlen_s(data, kCount);
+        m_buffer->length += strnlen_s(data, kCount);
     }
 }

--- a/source/core/slang-string.cpp
+++ b/source/core/slang-string.cpp
@@ -223,7 +223,7 @@ namespace Slang
                 break;
             }
 
-            auto length = buf.Count() / sizeof(wchar_t);
+            auto length = buf.getSize() / sizeof(wchar_t);
 			if (outLength)
 				*outLength = length;
 

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -490,8 +490,9 @@ namespace Slang
 			if (!m_buffer)
 				return StringSlice();
 			Index startIndex = 0;
+            const char*const data = getData();
 			while (startIndex < getLength() &&
-				(getData()[startIndex] == ' ' || getData()[startIndex] == '\t' || getData()[startIndex] == '\r' || getData()[startIndex] == '\n'))
+				(data[startIndex] == ' ' || data[startIndex] == '\t' || data[startIndex] == '\r' || data[startIndex] == '\n'))
 				startIndex++;
             return StringSlice(m_buffer, startIndex, getLength());
 		}
@@ -502,8 +503,9 @@ namespace Slang
 				return StringSlice();
 
 			Index endIndex = getLength();
+            const char*const data = getData();
 			while (endIndex > 0 &&
-				(getData()[endIndex-1] == ' ' || getData()[endIndex-1] == '\t' || getData()[endIndex-1] == '\r' || getData()[endIndex-1] == '\n'))
+				(data[endIndex-1] == ' ' || data[endIndex-1] == '\t' || data[endIndex-1] == '\r' || data[endIndex-1] == '\n'))
 				endIndex--;
 
             return StringSlice(m_buffer, 0, endIndex);
@@ -515,12 +517,13 @@ namespace Slang
 				return StringSlice();
 
 			Index startIndex = 0;
+            const char*const data = getData();
 			while (startIndex < getLength() &&
-				(getData()[startIndex] == ' ' || getData()[startIndex] == '\t'))
+				(data[startIndex] == ' ' || data[startIndex] == '\t'))
 				startIndex++;
             Index endIndex = getLength();
 			while (endIndex > startIndex &&
-				(getData()[endIndex-1] == ' ' || getData()[endIndex-1] == '\t'))
+				(data[endIndex-1] == ' ' || data[endIndex-1] == '\t'))
 				endIndex--;
 
             return StringSlice(m_buffer, startIndex, endIndex);
@@ -549,7 +552,7 @@ namespace Slang
 
         OSString toWString(Index* len = 0) const;
 
-		bool Equals(const String & str, bool caseSensitive = true)
+		bool equals(const String & str, bool caseSensitive = true)
 		{
 			if (caseSensitive)
 				return (strcmp(begin(), str.begin()) == 0);
@@ -623,7 +626,7 @@ namespace Slang
 			if (id >= getLength())
 				return Index(-1);
 			auto findRs = strstr(begin() + id, str);
-			UInt res = findRs ? findRs - begin() : -1;
+			Index res = findRs ? findRs - begin() : Index(-1);
 			return res;
 		}
 
@@ -682,7 +685,8 @@ namespace Slang
             Index strLen = Index(::strlen(str));
 			if (strLen > getLength())
 				return false;
-            const char* data = getData();
+
+            const char*const data = getData();
 
 			for (Index i = 0; i < strLen; i++)
 				if (str[i] != data[i])
@@ -699,12 +703,15 @@ namespace Slang
 		{
 			if (!m_buffer)
 				return false;
-			Index strLen = Index(::strlen(str));
-			if (strLen > getLength())
+
+			const Index strLen = Index(::strlen(str));
+            const Index len = getLength();
+
+			if (strLen > len)
 				return false;
             const char* data = getData();
 			for (Index i = strLen; i > 0; i--)
-				if (str[i-1] != data[getLength() - strLen + i-1])
+				if (str[i-1] != data[len - strLen + i-1])
 					return false;
 			return true;
 		}

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -542,12 +542,12 @@ namespace Slang
             return StringSlice(m_buffer, id, id + len);
 		}
 
-		char const* Buffer() const
+		char const* getBuffer() const
 		{
             return getData();
 		}
 
-        OSString ToWString(Index* len = 0) const;
+        OSString toWString(Index* len = 0) const;
 
 		bool Equals(const String & str, bool caseSensitive = true)
 		{
@@ -851,7 +851,7 @@ namespace Slang
 		}
 		void Append(const String & str)
 		{
-			Append(str.Buffer(), str.getLength());
+			Append(str.getBuffer(), str.getLength());
 		}
 		void Append(const char * str)
 		{

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -66,44 +66,44 @@ namespace Slang
     {
     public:
         UnownedStringSlice()
-            : beginData(nullptr)
-            , endData(nullptr)
+            : m_begin(nullptr)
+            , m_end(nullptr)
         {}
 
         explicit UnownedStringSlice(char const* a) :
-            beginData(a),
-            endData(a + strlen(a))
+            m_begin(a),
+            m_end(a + strlen(a))
         {}
         UnownedStringSlice(char const* b, char const* e)
-            : beginData(b)
-            , endData(e)
+            : m_begin(b)
+            , m_end(e)
         {}
         UnownedStringSlice(char const* b, size_t len)
-            : beginData(b)
-            , endData(b + len)
+            : m_begin(b)
+            , m_end(b + len)
         {}
 
         char const* begin() const
         {
-            return beginData;
+            return m_begin;
         }
 
         char const* end() const
         {
-            return endData;
+            return m_end;
         }
 
-        UInt size() const
+        Index size() const
         {
-            return endData - beginData;
+            return Index(m_end - m_begin);
         }
 
         int indexOf(char c) const
         {
-            const int size = int(endData - beginData);
+            const int size = int(m_end - m_begin);
             for (int i = 0; i < size; ++i)
             {
-                if (beginData[i] == c)
+                if (m_begin[i] == c)
                 {
                     return i;
                 }
@@ -111,10 +111,10 @@ namespace Slang
             return -1;
         }
 
-        const char& operator[](UInt i) const
+        const char& operator[](Index i) const
         {
-            assert(i < UInt(endData - beginData));
-            return beginData[i];
+            assert(i >= 0 && i < Index(m_end - m_begin));
+            return m_begin[i];
         }
 
         bool operator==(UnownedStringSlice const& other) const
@@ -125,7 +125,7 @@ namespace Slang
 
         bool operator==(char const* str) const
         {
-            return (*this) == UnownedStringSlice(str, str + strlen(str));
+            return (*this) == UnownedStringSlice(str, str + ::strlen(str));
         }
 
         bool operator!=(UnownedStringSlice const& other) const
@@ -141,15 +141,15 @@ namespace Slang
 
         int GetHashCode() const
         {
-            return Slang::GetHashCode(beginData, size_t(endData - beginData)); 
+            return Slang::GetHashCode(m_begin, size_t(m_end - m_begin)); 
         }
 
         template <size_t SIZE> 
         SLANG_FORCE_INLINE static UnownedStringSlice fromLiteral(const char (&in)[SIZE]) { return UnownedStringSlice(in, SIZE - 1); }
 
     private:
-        char const* beginData;
-        char const* endData;
+        char const* m_begin;
+        char const* m_end;
     };
 
     // A `StringRepresentation` provides the backing storage for
@@ -157,10 +157,10 @@ namespace Slang
     class StringRepresentation : public RefObject
     {
     public:
-        UInt length;
-        UInt capacity;
+        Index length;
+        Index capacity;
 
-        SLANG_FORCE_INLINE UInt getLength() const
+        SLANG_FORCE_INLINE Index getLength() const
         {
             return length;
         }
@@ -189,7 +189,7 @@ namespace Slang
             return (a == b) || asSlice(a) == asSlice(b);
         }
 
-        static StringRepresentation* createWithCapacityAndLength(UInt capacity, UInt length)
+        static StringRepresentation* createWithCapacityAndLength(Index capacity, Index length)
         {
             SLANG_ASSERT(capacity >= length);
             void* allocation = operator new(sizeof(StringRepresentation) + capacity + 1);
@@ -200,17 +200,17 @@ namespace Slang
             return obj;
         }
 
-        static StringRepresentation* createWithCapacity(UInt capacity)
+        static StringRepresentation* createWithCapacity(Index capacity)
         {
             return createWithCapacityAndLength(capacity, 0);
         }
 
-        static StringRepresentation* createWithLength(UInt length)
+        static StringRepresentation* createWithLength(Index length)
         {
             return createWithCapacityAndLength(length, length);
         }
 
-        StringRepresentation* cloneWithCapacity(UInt newCapacity)
+        StringRepresentation* cloneWithCapacity(Index newCapacity)
         {
             StringRepresentation* newObj = createWithCapacityAndLength(newCapacity, length);
             memcpy(getData(), newObj->getData(), length + 1);
@@ -222,11 +222,11 @@ namespace Slang
             return cloneWithCapacity(length);
         }
 
-        StringRepresentation* ensureCapacity(UInt required)
+        StringRepresentation* ensureCapacity(Index required)
         {
             if (capacity >= required) return this;
 
-            UInt newCapacity = capacity;
+            Index newCapacity = capacity;
             if (!newCapacity) newCapacity = 16; // TODO: figure out good value for minimum capacity
 
             while (newCapacity < required)
@@ -305,8 +305,8 @@ namespace Slang
         wchar_t const* end() const;
 
     private:
-        wchar_t* beginData;
-        wchar_t* endData;
+        wchar_t* m_begin;
+        wchar_t* m_end;
     };
 
 	/*!
@@ -322,22 +322,22 @@ namespace Slang
 
         char* getData() const
         {
-            return buffer ? buffer->getData() : (char*)"";
+            return m_buffer ? m_buffer->getData() : (char*)"";
         }
 
-        UInt getLength() const
+        Index getLength() const
         {
-            return buffer ? buffer->getLength() : 0;
+            return m_buffer ? m_buffer->getLength() : 0;
         }
 
-        void ensureUniqueStorageWithCapacity(UInt capacity);
+        void ensureUniqueStorageWithCapacity(Index capacity);
      
-        RefPtr<StringRepresentation> buffer;
+        RefPtr<StringRepresentation> m_buffer;
 
     public:
 
         explicit String(StringRepresentation* buffer)
-            : buffer(buffer)
+            : m_buffer(buffer)
         {}
 
 		static String FromWString(const wchar_t * wstr);
@@ -349,11 +349,11 @@ namespace Slang
 		}
 
             /// Returns a buffer which can hold at least count chars
-        char* prepareForAppend(UInt count);
+        char* prepareForAppend(Index count);
             /// Append data written to buffer output via 'prepareForAppend' directly written 'inplace'
-        void appendInPlace(const char* chars, UInt count);
+        void appendInPlace(const char* chars, Index count);
 
-        SLANG_FORCE_INLINE StringRepresentation* getStringRepresentation() const { return buffer; }
+        SLANG_FORCE_INLINE StringRepresentation* getStringRepresentation() const { return m_buffer; }
 
 		const char * begin() const
 		{
@@ -439,14 +439,14 @@ namespace Slang
 		}
 		String(String const& str)
 		{
-            buffer = str.buffer;
+            m_buffer = str.m_buffer;
 #if 0
 			this->operator=(str);
 #endif
 		}
 		String(String&& other)
 		{
-            buffer = _Move(other.buffer);
+            m_buffer = _Move(other.m_buffer);
 		}
 
         String(StringSlice const& slice)
@@ -461,25 +461,22 @@ namespace Slang
 
 		~String()
 		{
-            buffer = 0;
+            m_buffer = 0;
 		}
 
 		String & operator=(const String & str)
 		{
-            buffer = str.buffer;
+            m_buffer = str.m_buffer;
 			return *this;
 		}
 		String & operator=(String&& other)
 		{
-            buffer = _Move(other.buffer);
+            m_buffer = _Move(other.m_buffer);
             return *this;
 		}
-		char operator[](UInt id) const
+		char operator[](Index id) const
 		{
-#if _DEBUG
-			if (id < 0 || id >= getLength())
-				throw "Operator[]: index out of range.";
-#endif
+            SLANG_ASSERT(id >= 0 && id < getLength());
 			return begin()[id];
 		}
 
@@ -489,46 +486,46 @@ namespace Slang
 
 		StringSlice TrimStart() const
 		{
-			if (!buffer)
+			if (!m_buffer)
 				return StringSlice();
-			UInt startIndex = 0;
+			Index startIndex = 0;
 			while (startIndex < getLength() &&
 				(getData()[startIndex] == ' ' || getData()[startIndex] == '\t' || getData()[startIndex] == '\r' || getData()[startIndex] == '\n'))
 				startIndex++;
-            return StringSlice(buffer, startIndex, getLength());
+            return StringSlice(m_buffer, startIndex, getLength());
 		}
 
 		StringSlice TrimEnd() const
 		{
-			if (!buffer)
+			if (!m_buffer)
 				return StringSlice();
 
-			UInt endIndex = getLength();
+			Index endIndex = getLength();
 			while (endIndex > 0 &&
 				(getData()[endIndex-1] == ' ' || getData()[endIndex-1] == '\t' || getData()[endIndex-1] == '\r' || getData()[endIndex-1] == '\n'))
 				endIndex--;
 
-            return StringSlice(buffer, 0, endIndex);
+            return StringSlice(m_buffer, 0, endIndex);
 		}
 
 		StringSlice Trim() const
 		{
-			if (!buffer)
+			if (!m_buffer)
 				return StringSlice();
 
-			UInt startIndex = 0;
+			Index startIndex = 0;
 			while (startIndex < getLength() &&
 				(getData()[startIndex] == ' ' || getData()[startIndex] == '\t'))
 				startIndex++;
-			UInt endIndex = getLength();
+            Index endIndex = getLength();
 			while (endIndex > startIndex &&
 				(getData()[endIndex-1] == ' ' || getData()[endIndex-1] == '\t'))
 				endIndex--;
 
-            return StringSlice(buffer, startIndex, endIndex);
+            return StringSlice(m_buffer, startIndex, endIndex);
 		}
 
-		StringSlice SubString(UInt id, UInt len) const
+		StringSlice SubString(Index id, Index len) const
 		{
 			if (len == 0)
 				return StringSlice();
@@ -541,7 +538,7 @@ namespace Slang
 			if (len < 0)
 				throw "SubString: length less than zero.";
 #endif
-            return StringSlice(buffer, id, id + len);
+            return StringSlice(m_buffer, id, id + len);
 		}
 
 		char const* Buffer() const
@@ -549,7 +546,7 @@ namespace Slang
             return getData();
 		}
 
-        OSString ToWString(UInt* len = 0) const;
+        OSString ToWString(Index* len = 0) const;
 
 		bool Equals(const String & str, bool caseSensitive = true)
 		{
@@ -620,89 +617,98 @@ namespace Slang
             return result;
 		}
 
-		UInt Length() const
+		Index Length() const
 		{
 			return getLength();
 		}
 
-		UInt IndexOf(const char * str, UInt id) const // String str
+        Index IndexOf(const char * str, Index id) const // String str
 		{
 			if (id >= getLength())
-				return UInt(-1);
+				return Index(-1);
 			auto findRs = strstr(begin() + id, str);
 			UInt res = findRs ? findRs - begin() : -1;
 			return res;
 		}
 
-		UInt IndexOf(const String & str, UInt id) const
+        Index IndexOf(const String & str, Index id) const
 		{
 			return IndexOf(str.begin(), id);
 		}
 
-		UInt IndexOf(const char * str) const
+        Index IndexOf(const char * str) const
 		{
 			return IndexOf(str, 0);
 		}
 
-		UInt IndexOf(const String & str) const
+        Index IndexOf(const String & str) const
 		{
 			return IndexOf(str.begin(), 0);
 		}
 
-		UInt IndexOf(char ch, UInt id) const
+        Index IndexOf(char ch, UInt id) const
 		{
-#if _DEBUG
-			if (id < 0 || id >= getLength())
-				throw "SubString: index out of range.";
-#endif
-			if (!buffer)
-				return UInt(-1);
-			for (UInt i = id; i < getLength(); i++)
-				if (getData()[i] == ch)
+            const Index length = getLength();
+            SLANG_ASSERT(id >= 0 && id <= length);
+
+			if (!m_buffer)
+				return Index(-1);
+
+            const char* data = getData();
+			for (Index i = id; i < length; i++)
+				if (data[i] == ch)
 					return i;
-			return UInt(-1);
+			return Index(-1);
 		}
 
-		UInt IndexOf(char ch) const
+        Index IndexOf(char ch) const
 		{
 			return IndexOf(ch, 0);
 		}
 
-		UInt LastIndexOf(char ch) const
-		{
-			for (UInt i = getLength(); i > 0; i--)
-				if (getData()[i-1] == ch)
-					return i-1;
-			return UInt(-1);
+        Index LastIndexOf(char ch) const
+		{            
+            const Index length = getLength();
+            const char* data = getData();
+
+            // TODO(JS): If we know Index is signed we can do this a bit more simply
+
+            for (Index i = length; i > 0; i--)
+				if (data[i - 1] == ch)
+					return i - 1;
+			return Index(-1);
 		}
 
 		bool StartsWith(const char * str) const // String str
 		{
-			if (!buffer)
+			if (!m_buffer)
 				return false;
-			UInt strLen = strlen(str);
+            Index strLen = Index(::strlen(str));
 			if (strLen > getLength())
 				return false;
-			for (UInt i = 0; i < strLen; i++)
-				if (str[i] != getData()[i])
+            const char* data = getData();
+
+			for (Index i = 0; i < strLen; i++)
+				if (str[i] != data[i])
 					return false;
 			return true;
 		}
 
-		bool StartsWith(const String & str) const
+		bool StartsWith(const String& str) const
 		{
 			return StartsWith(str.begin());
 		}
 
 		bool EndsWith(char const * str)  const // String str
 		{
-			if (!buffer)
+			if (!m_buffer)
 				return false;
-			UInt strLen = strlen(str);
+			Index strLen = Index(::strlen(str));
 			if (strLen > getLength())
 				return false;
-			for (UInt i = strLen; i > 0; i--)
-				if (str[i-1] != getData()[getLength() - strLen + i-1])
+            const char* data = getData();
+			for (Index i = strLen; i > 0; i--)
+				if (str[i-1] != data[getLength() - strLen + i-1])
 					return false;
 			return true;
 		}
@@ -714,9 +720,9 @@ namespace Slang
 
 		bool Contains(const char * str) const // String str
 		{
-			if (!buffer)
+			if (!m_buffer)
 				return false;
-			return (IndexOf(str) != UInt(-1)) ? true : false;
+			return (IndexOf(str) != Index(-1)) ? true : false;
 		}
 
 		bool Contains(const String & str) const
@@ -731,7 +737,7 @@ namespace Slang
 
         UnownedStringSlice getUnownedSlice() const
         {
-            return StringRepresentation::asSlice(buffer);
+            return StringRepresentation::asSlice(m_buffer);
         }
 	};
 
@@ -919,7 +925,7 @@ namespace Slang
 
 		void Clear()
 		{
-            buffer = 0;
+            m_buffer = 0;
 		}
 	};
 

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -325,11 +325,7 @@ namespace Slang
             return m_buffer ? m_buffer->getData() : (char*)"";
         }
 
-        Index getLength() const
-        {
-            return m_buffer ? m_buffer->getLength() : 0;
-        }
-
+     
         void ensureUniqueStorageWithCapacity(Index capacity);
      
         RefPtr<StringRepresentation> m_buffer;
@@ -340,10 +336,10 @@ namespace Slang
             : m_buffer(buffer)
         {}
 
-		static String FromWString(const wchar_t * wstr);
-		static String FromWString(const wchar_t * wstr, const wchar_t * wend);
-		static String FromWChar(const wchar_t ch);
-		static String FromUnicodePoint(unsigned int codePoint);
+		static String fromWString(const wchar_t * wstr);
+		static String fromWString(const wchar_t * wstr, const wchar_t * wend);
+		static String fromWChar(const wchar_t ch);
+		static String fromUnicodePoint(unsigned int codePoint);
 		String()
 		{
 		}
@@ -480,11 +476,16 @@ namespace Slang
 			return begin()[id];
 		}
 
+        Index getLength() const
+        {
+            return m_buffer ? m_buffer->getLength() : 0;
+        }
+
 		friend String operator+(const char*op1, const String & op2);
 		friend String operator+(const String & op1, const char * op2);
 		friend String operator+(const String & op1, const String & op2);
 
-		StringSlice TrimStart() const
+		StringSlice trimStart() const
 		{
 			if (!m_buffer)
 				return StringSlice();
@@ -495,7 +496,7 @@ namespace Slang
             return StringSlice(m_buffer, startIndex, getLength());
 		}
 
-		StringSlice TrimEnd() const
+		StringSlice trimEnd() const
 		{
 			if (!m_buffer)
 				return StringSlice();
@@ -508,7 +509,7 @@ namespace Slang
             return StringSlice(m_buffer, 0, endIndex);
 		}
 
-		StringSlice Trim() const
+		StringSlice trim() const
 		{
 			if (!m_buffer)
 				return StringSlice();
@@ -525,7 +526,7 @@ namespace Slang
             return StringSlice(m_buffer, startIndex, endIndex);
 		}
 
-		StringSlice SubString(Index id, Index len) const
+		StringSlice subString(Index id, Index len) const
 		{
 			if (len == 0)
 				return StringSlice();
@@ -595,7 +596,7 @@ namespace Slang
 			return (strcmp(begin(), str.begin()) <= 0);
 		}
 
-		String ToUpper() const
+		String toUpper() const
 		{
             String result;
             for (auto c : *this)
@@ -606,7 +607,7 @@ namespace Slang
             return result;
 		}
 
-		String ToLower() const
+		String toLower() const
 		{
             String result;
             for (auto c : *this)
@@ -617,12 +618,7 @@ namespace Slang
             return result;
 		}
 
-		Index Length() const
-		{
-			return getLength();
-		}
-
-        Index IndexOf(const char * str, Index id) const // String str
+        Index indexOf(const char * str, Index id) const // String str
 		{
 			if (id >= getLength())
 				return Index(-1);
@@ -631,22 +627,22 @@ namespace Slang
 			return res;
 		}
 
-        Index IndexOf(const String & str, Index id) const
+        Index indexOf(const String & str, Index id) const
 		{
-			return IndexOf(str.begin(), id);
+			return indexOf(str.begin(), id);
 		}
 
-        Index IndexOf(const char * str) const
+        Index indexOf(const char * str) const
 		{
-			return IndexOf(str, 0);
+			return indexOf(str, 0);
 		}
 
-        Index IndexOf(const String & str) const
+        Index indexOf(const String & str) const
 		{
-			return IndexOf(str.begin(), 0);
+			return indexOf(str.begin(), 0);
 		}
 
-        Index IndexOf(char ch, UInt id) const
+        Index indexOf(char ch, Index id) const
 		{
             const Index length = getLength();
             SLANG_ASSERT(id >= 0 && id <= length);
@@ -661,12 +657,12 @@ namespace Slang
 			return Index(-1);
 		}
 
-        Index IndexOf(char ch) const
+        Index indexOf(char ch) const
 		{
-			return IndexOf(ch, 0);
+			return indexOf(ch, 0);
 		}
 
-        Index LastIndexOf(char ch) const
+        Index lastIndexOf(char ch) const
 		{            
             const Index length = getLength();
             const char* data = getData();
@@ -679,7 +675,7 @@ namespace Slang
 			return Index(-1);
 		}
 
-		bool StartsWith(const char * str) const // String str
+		bool startsWith(const char * str) const // String str
 		{
 			if (!m_buffer)
 				return false;
@@ -694,12 +690,12 @@ namespace Slang
 			return true;
 		}
 
-		bool StartsWith(const String& str) const
+		bool startsWith(const String& str) const
 		{
-			return StartsWith(str.begin());
+			return startsWith(str.begin());
 		}
 
-		bool EndsWith(char const * str)  const // String str
+		bool endsWith(char const * str)  const // String str
 		{
 			if (!m_buffer)
 				return false;
@@ -713,21 +709,19 @@ namespace Slang
 			return true;
 		}
 
-		bool EndsWith(const String & str) const
+		bool endsWith(const String & str) const
 		{
-			return EndsWith(str.begin());
+			return endsWith(str.begin());
 		}
 
-		bool Contains(const char * str) const // String str
+		bool contains(const char * str) const // String str
 		{
-			if (!m_buffer)
-				return false;
-			return (IndexOf(str) != Index(-1)) ? true : false;
+			return m_buffer && indexOf(str) != Index(-1); 
 		}
 
-		bool Contains(const String & str) const
+		bool contains(const String & str) const
 		{
-			return Contains(str.begin());
+			return contains(str.begin());
 		}
 
 		int GetHashCode() const
@@ -857,7 +851,7 @@ namespace Slang
 		}
 		void Append(const String & str)
 		{
-			Append(str.Buffer(), str.Length());
+			Append(str.Buffer(), str.getLength());
 		}
 		void Append(const char * str)
 		{

--- a/source/core/slang-writer.cpp
+++ b/source/core/slang-writer.cpp
@@ -66,13 +66,13 @@ ISlangUnknown* BaseWriter::getInterface(const Guid& guid)
 
 SLANG_NO_THROW char* SLANG_MCALL AppendBufferWriter::beginAppendBuffer(size_t maxNumChars)
 {
-    m_appendBuffer.setSize(maxNumChars);
-    return m_appendBuffer.Buffer();
+    m_appendBuffer.setCount(maxNumChars);
+    return m_appendBuffer.getBuffer();
 }
 
 SLANG_NO_THROW SlangResult SLANG_MCALL AppendBufferWriter::endAppendBuffer(char* buffer, size_t numChars)
 {
-    SLANG_ASSERT(m_appendBuffer.Buffer() == buffer && buffer + numChars <= m_appendBuffer.end());
+    SLANG_ASSERT(m_appendBuffer.getBuffer() == buffer && buffer + numChars <= m_appendBuffer.end());
     // Do the actual write
     SlangResult res = write(buffer, numChars);
     // Clear so that buffer can't be written from again without assert
@@ -85,17 +85,17 @@ SLANG_NO_THROW SlangResult SLANG_MCALL AppendBufferWriter::endAppendBuffer(char*
 SLANG_NO_THROW char* SLANG_MCALL CallbackWriter::beginAppendBuffer(size_t maxNumChars)
 {
     // Add one so there is always space for end termination, we need for the callback.
-    m_appendBuffer.setSize(maxNumChars + 1);
-    return m_appendBuffer.Buffer();
+    m_appendBuffer.setCount(maxNumChars + 1);
+    return m_appendBuffer.getBuffer();
 }
 
 SlangResult CallbackWriter::write(const char* chars, size_t numChars)
 {
     if (numChars > 0)
     {
-        char* appendBuffer = m_appendBuffer.Buffer();
+        char* appendBuffer = m_appendBuffer.getBuffer();
         // See if it's from an append buffer
-        if (chars >= appendBuffer && (chars + numChars) < (appendBuffer + m_appendBuffer.getSize()))
+        if (chars >= appendBuffer && (chars + numChars) < (appendBuffer + m_appendBuffer.getCount()))
         {
             // Set terminating 0
             appendBuffer[(chars + numChars) - appendBuffer] = 0;
@@ -105,11 +105,11 @@ SlangResult CallbackWriter::write(const char* chars, size_t numChars)
         else
         {
             // Use the append buffer to add the terminating 0
-            m_appendBuffer.setSize(numChars + 1);
-            ::memcpy(m_appendBuffer.Buffer(), chars, numChars);
+            m_appendBuffer.setCount(numChars + 1);
+            ::memcpy(m_appendBuffer.getBuffer(), chars, numChars);
             m_appendBuffer[numChars] = 0;
 
-            m_callback(m_appendBuffer.Buffer(), (void*)m_data);
+            m_callback(m_appendBuffer.getBuffer(), (void*)m_data);
         }
     }
 

--- a/source/core/slang-writer.cpp
+++ b/source/core/slang-writer.cpp
@@ -76,7 +76,7 @@ SLANG_NO_THROW SlangResult SLANG_MCALL AppendBufferWriter::endAppendBuffer(char*
     // Do the actual write
     SlangResult res = write(buffer, numChars);
     // Clear so that buffer can't be written from again without assert
-    m_appendBuffer.Clear();
+    m_appendBuffer.clear();
     return res;
 }
 

--- a/source/core/slang-writer.cpp
+++ b/source/core/slang-writer.cpp
@@ -66,7 +66,7 @@ ISlangUnknown* BaseWriter::getInterface(const Guid& guid)
 
 SLANG_NO_THROW char* SLANG_MCALL AppendBufferWriter::beginAppendBuffer(size_t maxNumChars)
 {
-    m_appendBuffer.SetSize(maxNumChars);
+    m_appendBuffer.setSize(maxNumChars);
     return m_appendBuffer.Buffer();
 }
 
@@ -85,7 +85,7 @@ SLANG_NO_THROW SlangResult SLANG_MCALL AppendBufferWriter::endAppendBuffer(char*
 SLANG_NO_THROW char* SLANG_MCALL CallbackWriter::beginAppendBuffer(size_t maxNumChars)
 {
     // Add one so there is always space for end termination, we need for the callback.
-    m_appendBuffer.SetSize(maxNumChars + 1);
+    m_appendBuffer.setSize(maxNumChars + 1);
     return m_appendBuffer.Buffer();
 }
 
@@ -105,7 +105,7 @@ SlangResult CallbackWriter::write(const char* chars, size_t numChars)
         else
         {
             // Use the append buffer to add the terminating 0
-            m_appendBuffer.SetSize(numChars + 1);
+            m_appendBuffer.setSize(numChars + 1);
             ::memcpy(m_appendBuffer.Buffer(), chars, numChars);
             m_appendBuffer[numChars] = 0;
 

--- a/source/core/slang-writer.cpp
+++ b/source/core/slang-writer.cpp
@@ -95,7 +95,7 @@ SlangResult CallbackWriter::write(const char* chars, size_t numChars)
     {
         char* appendBuffer = m_appendBuffer.Buffer();
         // See if it's from an append buffer
-        if (chars >= appendBuffer && (chars + numChars) < (appendBuffer + m_appendBuffer.Count()))
+        if (chars >= appendBuffer && (chars + numChars) < (appendBuffer + m_appendBuffer.getSize()))
         {
             // Set terminating 0
             appendBuffer[(chars + numChars) - appendBuffer] = 0;

--- a/source/core/smart-pointer.h
+++ b/source/core/smart-pointer.h
@@ -5,8 +5,6 @@
 #include "hash.h"
 #include "type-traits.h"
 
-#include <assert.h>
-
 #include "../../slang.h"
 
 namespace Slang

--- a/source/core/stream.cpp
+++ b/source/core/stream.cpp
@@ -113,11 +113,11 @@ namespace Slang
 		}
         if (share == Slang::FileShare::None)
 #pragma warning(suppress:4996)
-            handle = _wfopen(fileName.ToWString(), mode);
+            handle = _wfopen(fileName.toWString(), mode);
         else
-			handle = _wfsopen(fileName.ToWString(), mode, shFlag);
+			handle = _wfsopen(fileName.toWString(), mode, shFlag);
 #else
-		handle = fopen(fileName.Buffer(), modeMBCS);
+		handle = fopen(fileName.getBuffer(), modeMBCS);
 #endif
 		if (!handle)
 		{

--- a/source/core/stream.cpp
+++ b/source/core/stream.cpp
@@ -278,11 +278,11 @@ namespace Slang
 
         if (m_position == m_contents.getSize())
         {
-            m_contents.AddRange((const uint8_t*)buffer, UInt(length));
+            m_contents.addRange((const uint8_t*)buffer, UInt(length));
         }
         else
         {
-            m_contents.InsertRange(m_position, (const uint8_t*)buffer, UInt(length));
+            m_contents.insertRange(m_position, (const uint8_t*)buffer, UInt(length));
         }
 
         m_atEnd = false;

--- a/source/core/stream.cpp
+++ b/source/core/stream.cpp
@@ -228,7 +228,7 @@ namespace Slang
             pos = offset;
             break;
         case Slang::SeekOrigin::End:
-            pos = Int64(m_contents.getSize()) + offset;
+            pos = Int64(m_contents.getCount()) + offset;
             break;
         case Slang::SeekOrigin::Current:
             pos = Int64(m_position) + offset;
@@ -242,7 +242,7 @@ namespace Slang
 
         // Clamp to the valid range
         pos = (pos < 0) ? 0 : pos;
-        pos = (pos > Int64(m_contents.getSize())) ? Int64(m_contents.getSize()) : pos;
+        pos = (pos > Int64(m_contents.getCount())) ? Int64(m_contents.getCount()) : pos;
 
         m_position = UInt(pos);
     }
@@ -254,7 +254,7 @@ namespace Slang
             throw IOException("Cannot read this stream.");
         }
 
-        const Int64 maxRead = Int64(m_contents.getSize() - m_position);
+        const Int64 maxRead = Int64(m_contents.getCount() - m_position);
         
         if (maxRead == 0 && length > 0)
         {
@@ -276,7 +276,7 @@ namespace Slang
             throw IOException("Cannot write this stream.");
         }
 
-        if (m_position == m_contents.getSize())
+        if (m_position == m_contents.getCount())
         {
             m_contents.addRange((const uint8_t*)buffer, UInt(length));
         }

--- a/source/core/stream.cpp
+++ b/source/core/stream.cpp
@@ -228,7 +228,7 @@ namespace Slang
             pos = offset;
             break;
         case Slang::SeekOrigin::End:
-            pos = Int64(m_contents.Count()) + offset;
+            pos = Int64(m_contents.getSize()) + offset;
             break;
         case Slang::SeekOrigin::Current:
             pos = Int64(m_position) + offset;
@@ -242,7 +242,7 @@ namespace Slang
 
         // Clamp to the valid range
         pos = (pos < 0) ? 0 : pos;
-        pos = (pos > Int64(m_contents.Count())) ? Int64(m_contents.Count()) : pos;
+        pos = (pos > Int64(m_contents.getSize())) ? Int64(m_contents.getSize()) : pos;
 
         m_position = UInt(pos);
     }
@@ -254,7 +254,7 @@ namespace Slang
             throw IOException("Cannot read this stream.");
         }
 
-        const Int64 maxRead = Int64(m_contents.Count() - m_position);
+        const Int64 maxRead = Int64(m_contents.getSize() - m_position);
         
         if (maxRead == 0 && length > 0)
         {
@@ -276,7 +276,7 @@ namespace Slang
             throw IOException("Cannot write this stream.");
         }
 
-        if (m_position == m_contents.Count())
+        if (m_position == m_contents.getSize())
         {
             m_contents.AddRange((const uint8_t*)buffer, UInt(length));
         }

--- a/source/core/stream.h
+++ b/source/core/stream.h
@@ -79,7 +79,7 @@ namespace Slang
             m_atEnd(false)
         {}
 
-        UInt m_position;
+        Index m_position;
 
         bool m_atEnd;           ///< Happens when a read is done and nothing can be returned because already at end
 

--- a/source/core/text-io.cpp
+++ b/source/core/text-io.cpp
@@ -235,10 +235,10 @@ namespace Slang
 		
 	void StreamReader::ReadBuffer()
 	{
-		buffer.SetSize(4096);
+		buffer.setSize(4096);
         memset(buffer.Buffer(), 0, buffer.getSize() * sizeof(buffer[0]));
 		auto len = stream->Read(buffer.Buffer(), buffer.getSize());
-		buffer.SetSize((int)len);
+		buffer.setSize((int)len);
 		ptr = 0;
 	}
 

--- a/source/core/text-io.cpp
+++ b/source/core/text-io.cpp
@@ -15,7 +15,7 @@ namespace Slang
 	public:
 		virtual void GetBytes(List<char> & result, const String & str) override
 		{
-			result.AddRange(str.Buffer(), str.Length());
+			result.addRange(str.Buffer(), str.Length());
 		}
 		virtual String ToString(const char * bytes, int /*length*/) override
 		{
@@ -38,7 +38,7 @@ namespace Slang
 					else
 						return '\0';
 				});
-				result.AddRange((char*)&codePoint, 4);
+				result.addRange((char*)&codePoint, 4);
 			}
 		}
 		virtual String ToString(const char * bytes, int length) override
@@ -82,7 +82,7 @@ namespace Slang
 					count = EncodeUnicodePointToUTF16(buffer, codePoint);
 				else
 					count = EncodeUnicodePointToUTF16Reversed(buffer, codePoint);
-				result.AddRange((char*)buffer, count * 2);
+				result.addRange((char*)buffer, count * 2);
 			}
 		}
 		virtual String ToString(const char * bytes, int length) override
@@ -148,7 +148,7 @@ namespace Slang
 	}
 	void StreamWriter::Write(const String & str)
 	{
-		encodingBuffer.Clear();
+		encodingBuffer.clear();
 		StringBuilder sb;
 		String newLine;
 #ifdef _WIN32

--- a/source/core/text-io.cpp
+++ b/source/core/text-io.cpp
@@ -15,7 +15,7 @@ namespace Slang
 	public:
 		virtual void GetBytes(List<char> & result, const String & str) override
 		{
-			result.addRange(str.Buffer(), str.Length());
+			result.addRange(str.Buffer(), str.getLength());
 		}
 		virtual String ToString(const char * bytes, int /*length*/) override
 		{
@@ -29,11 +29,11 @@ namespace Slang
 		virtual void GetBytes(List<char> & result, const String & str) override
 		{
 			Index ptr = 0;
-			while (ptr < str.Length())
+			while (ptr < str.getLength())
 			{
 				int codePoint = GetUnicodePointFromUTF8([&](int)
 				{
-					if (ptr < str.Length())
+					if (ptr < str.getLength())
 						return str[ptr++];
 					else
 						return '\0';
@@ -67,11 +67,11 @@ namespace Slang
 		virtual void GetBytes(List<char> & result, const String & str) override
 		{
 			Index ptr = 0;
-			while (ptr < str.Length())
+			while (ptr < str.getLength())
 			{
 				int codePoint = GetUnicodePointFromUTF8([&](int)
 				{
-					if (ptr < str.Length())
+					if (ptr < str.getLength())
 						return str[ptr++];
 					else
 						return '\0';
@@ -156,7 +156,7 @@ namespace Slang
 #else
 		newLine = "\n";
 #endif
-		for (Index i = 0; i < str.Length(); i++)
+		for (Index i = 0; i < str.getLength(); i++)
 		{
 			if (str[i] == '\r')
 				sb << newLine;

--- a/source/core/text-io.cpp
+++ b/source/core/text-io.cpp
@@ -169,7 +169,7 @@ namespace Slang
 				sb << str[i];
 		}
 		encoding->GetBytes(encodingBuffer, sb.ProduceString());
-		stream->Write(encodingBuffer.Buffer(), encodingBuffer.getSize());
+		stream->Write(encodingBuffer.getBuffer(), encodingBuffer.getCount());
 	}
 	void StreamWriter::Write(const char * str)
 	{
@@ -207,17 +207,17 @@ namespace Slang
 
 	Encoding * StreamReader::DetermineEncoding()
 	{
-		if (buffer.getSize() >= 3 && (unsigned char)(buffer[0]) == 0xEF && (unsigned char)(buffer[1]) == 0xBB && (unsigned char)(buffer[2]) == 0xBF)
+		if (buffer.getCount() >= 3 && (unsigned char)(buffer[0]) == 0xEF && (unsigned char)(buffer[1]) == 0xBB && (unsigned char)(buffer[2]) == 0xBF)
 		{
 			ptr += 3;
 			return Encoding::UTF8;
 		}
-		else if (*((unsigned short*)(buffer.Buffer())) == 0xFEFF)
+		else if (*((unsigned short*)(buffer.getBuffer())) == 0xFEFF)
 		{
 			ptr += 2;
 			return Encoding::UTF16;
 		}
-		else if (*((unsigned short*)(buffer.Buffer())) == 0xFFFE)
+		else if (*((unsigned short*)(buffer.getBuffer())) == 0xFFFE)
 		{
 			ptr += 2;
 			return Encoding::UTF16Reversed;
@@ -225,7 +225,7 @@ namespace Slang
 		else
 		{
             // find null bytes
-            if (HasNullBytes(buffer.Buffer(), (int)buffer.getSize()))
+            if (HasNullBytes(buffer.getBuffer(), (int)buffer.getCount()))
             {
                 return Encoding::UTF16;
             }
@@ -235,22 +235,22 @@ namespace Slang
 		
 	void StreamReader::ReadBuffer()
 	{
-		buffer.setSize(4096);
-        memset(buffer.Buffer(), 0, buffer.getSize() * sizeof(buffer[0]));
-		auto len = stream->Read(buffer.Buffer(), buffer.getSize());
-		buffer.setSize((int)len);
+		buffer.setCount(4096);
+        memset(buffer.getBuffer(), 0, buffer.getCount() * sizeof(buffer[0]));
+		auto len = stream->Read(buffer.getBuffer(), buffer.getCount());
+		buffer.setCount((int)len);
 		ptr = 0;
 	}
 
 	char StreamReader::ReadBufferChar()
 	{
-		if (ptr<buffer.getSize())
+		if (ptr<buffer.getCount())
 		{
 			return buffer[ptr++];
 		}
 		if (!stream->IsEnd())
 			ReadBuffer();
-		if (ptr<buffer.getSize())
+		if (ptr<buffer.getCount())
 		{
 			return buffer[ptr++];
 		}

--- a/source/core/text-io.cpp
+++ b/source/core/text-io.cpp
@@ -169,7 +169,7 @@ namespace Slang
 				sb << str[i];
 		}
 		encoding->GetBytes(encodingBuffer, sb.ProduceString());
-		stream->Write(encodingBuffer.Buffer(), encodingBuffer.Count());
+		stream->Write(encodingBuffer.Buffer(), encodingBuffer.getSize());
 	}
 	void StreamWriter::Write(const char * str)
 	{
@@ -207,7 +207,7 @@ namespace Slang
 
 	Encoding * StreamReader::DetermineEncoding()
 	{
-		if (buffer.Count() >= 3 && (unsigned char)(buffer[0]) == 0xEF && (unsigned char)(buffer[1]) == 0xBB && (unsigned char)(buffer[2]) == 0xBF)
+		if (buffer.getSize() >= 3 && (unsigned char)(buffer[0]) == 0xEF && (unsigned char)(buffer[1]) == 0xBB && (unsigned char)(buffer[2]) == 0xBF)
 		{
 			ptr += 3;
 			return Encoding::UTF8;
@@ -225,7 +225,7 @@ namespace Slang
 		else
 		{
             // find null bytes
-            if (HasNullBytes(buffer.Buffer(), (int)buffer.Count()))
+            if (HasNullBytes(buffer.Buffer(), (int)buffer.getSize()))
             {
                 return Encoding::UTF16;
             }
@@ -236,21 +236,21 @@ namespace Slang
 	void StreamReader::ReadBuffer()
 	{
 		buffer.SetSize(4096);
-        memset(buffer.Buffer(), 0, buffer.Count() * sizeof(buffer[0]));
-		auto len = stream->Read(buffer.Buffer(), buffer.Count());
+        memset(buffer.Buffer(), 0, buffer.getSize() * sizeof(buffer[0]));
+		auto len = stream->Read(buffer.Buffer(), buffer.getSize());
 		buffer.SetSize((int)len);
 		ptr = 0;
 	}
 
 	char StreamReader::ReadBufferChar()
 	{
-		if (ptr<buffer.Count())
+		if (ptr<buffer.getSize())
 		{
 			return buffer[ptr++];
 		}
 		if (!stream->IsEnd())
 			ReadBuffer();
-		if (ptr<buffer.Count())
+		if (ptr<buffer.getSize())
 		{
 			return buffer[ptr++];
 		}

--- a/source/core/text-io.cpp
+++ b/source/core/text-io.cpp
@@ -15,7 +15,7 @@ namespace Slang
 	public:
 		virtual void GetBytes(List<char> & result, const String & str) override
 		{
-			result.addRange(str.Buffer(), str.getLength());
+			result.addRange(str.getBuffer(), str.getLength());
 		}
 		virtual String ToString(const char * bytes, int /*length*/) override
 		{

--- a/source/core/text-io.cpp
+++ b/source/core/text-io.cpp
@@ -28,7 +28,7 @@ namespace Slang
 	public:
 		virtual void GetBytes(List<char> & result, const String & str) override
 		{
-			UInt ptr = 0;
+			Index ptr = 0;
 			while (ptr < str.Length())
 			{
 				int codePoint = GetUnicodePointFromUTF8([&](int)
@@ -66,7 +66,7 @@ namespace Slang
 		{}
 		virtual void GetBytes(List<char> & result, const String & str) override
 		{
-			UInt ptr = 0;
+			Index ptr = 0;
 			while (ptr < str.Length())
 			{
 				int codePoint = GetUnicodePointFromUTF8([&](int)
@@ -156,7 +156,7 @@ namespace Slang
 #else
 		newLine = "\n";
 #endif
-		for (UInt i = 0; i < str.Length(); i++)
+		for (Index i = 0; i < str.Length(); i++)
 		{
 			if (str[i] == '\r')
 				sb << newLine;

--- a/source/core/text-io.h
+++ b/source/core/text-io.h
@@ -300,7 +300,7 @@ namespace Slang
 		virtual String ReadToEnd();
 		virtual bool IsEnd()
 		{
-			return ptr == buffer.getSize() && stream->IsEnd();
+			return ptr == buffer.getCount() && stream->IsEnd();
 		}
 		virtual void Close()
 		{

--- a/source/core/text-io.h
+++ b/source/core/text-io.h
@@ -273,7 +273,7 @@ namespace Slang
 		RefPtr<Stream> stream;
 		List<char> buffer;
 		Encoding * encoding;
-		UInt ptr;
+		Index ptr;
 		char ReadBufferChar();
 		void ReadBuffer();
 			

--- a/source/core/text-io.h
+++ b/source/core/text-io.h
@@ -300,7 +300,7 @@ namespace Slang
 		virtual String ReadToEnd();
 		virtual bool IsEnd()
 		{
-			return ptr == buffer.Count() && stream->IsEnd();
+			return ptr == buffer.getSize() && stream->IsEnd();
 		}
 		virtual void Close()
 		{

--- a/source/core/token-reader.cpp
+++ b/source/core/token-reader.cpp
@@ -675,7 +675,7 @@ namespace Slang
         StringBuilder sb;
         sb << "\"";
         const Index length = str.getLength();
-        const char*const data = str.Buffer();
+        const char*const data = str.getBuffer();
         for (Index i = 0; i < length; i++)
         {
             switch (data[i])
@@ -717,7 +717,7 @@ namespace Slang
     {
         StringBuilder sb;
         const Index length = str.getLength();
-        const char*const data = str.Buffer();
+        const char*const data = str.getBuffer();
         for (Index i = 0; i < length; i++)
         {
             if (data[i] == '\\' && i < length - 1)

--- a/source/core/token-reader.cpp
+++ b/source/core/token-reader.cpp
@@ -44,15 +44,15 @@ namespace Slang
 
     void ParseOperators(const String & str, List<Token> & tokens, TokenFlags& tokenFlags, int line, int col, int startPos, String fileName)
     {
-        int pos = 0;
-        while (pos < (int)str.Length())
+        Index pos = 0;
+        while (pos < str.getLength())
         {
             wchar_t curChar = str[pos];
-            wchar_t nextChar = (pos < (int)str.Length() - 1) ? str[pos + 1] : '\0';
-            wchar_t nextNextChar = (pos < (int)str.Length() - 2) ? str[pos + 2] : '\0';
+            wchar_t nextChar = (pos < str.getLength() - 1) ? str[pos + 1] : '\0';
+            wchar_t nextNextChar = (pos < str.getLength() - 2) ? str[pos + 2] : '\0';
             auto InsertToken = [&](TokenType type, const String & ct)
             {
-                tokens.add(Token(type, ct, line, col + pos, pos + startPos, fileName, tokenFlags));
+                tokens.add(Token(type, ct, line, int(col + pos), int(pos + startPos), fileName, tokenFlags));
                 tokenFlags = 0;
             };
             switch (curChar)
@@ -323,7 +323,7 @@ namespace Slang
 
     List<Token> TokenizeText(const String & fileName, const String & text)
     {
-        int lastPos = 0, pos = 0;
+        Index lastPos = 0, pos = 0;
         int line = 1, col = 0;
         String file = fileName;
         State state = State::Start;
@@ -335,7 +335,7 @@ namespace Slang
         auto InsertToken = [&](TokenType type)
         {
             derivative = LexDerivative::None;
-            tokenList.add(Token(type, tokenBuilder.ToString(), tokenLine, tokenCol, pos, file, tokenFlags));
+            tokenList.add(Token(type, tokenBuilder.ToString(), tokenLine, tokenCol, int(pos), file, tokenFlags));
             tokenFlags = 0;
             tokenBuilder.Clear();
         };
@@ -365,10 +365,10 @@ namespace Slang
                 break;
             }
         };
-        while (pos <= (int)text.Length())
+        while (pos <= text.getLength())
         {
-            char curChar = (pos < (int)text.Length() ? text[pos] : ' ');
-            char nextChar = (pos < (int)text.Length() - 1) ? text[pos + 1] : '\0';
+            char curChar = (pos < text.getLength() ? text[pos] : ' ');
+            char nextChar = (pos < text.getLength() - 1) ? text[pos + 1] : '\0';
             if (lastPos != pos)
             {
                 if (curChar == '\n')
@@ -490,7 +490,7 @@ namespace Slang
                 else
                 {
                     //do token analyze
-                    ParseOperators(tokenBuilder.ToString(), tokenList, tokenFlags, tokenLine, tokenCol, (int)(pos - tokenBuilder.Length()), file);
+                    ParseOperators(tokenBuilder.ToString(), tokenList, tokenFlags, tokenLine, tokenCol, (int)(pos - tokenBuilder.getLength()), file);
                     tokenBuilder.Clear();
                     state = State::Start;
                 }
@@ -674,9 +674,11 @@ namespace Slang
     {
         StringBuilder sb;
         sb << "\"";
-        for (int i = 0; i < (int)str.Length(); i++)
+        const Index length = str.getLength();
+        const char*const data = str.Buffer();
+        for (Index i = 0; i < length; i++)
         {
-            switch (str[i])
+            switch (data[i])
             {
             case ' ':
                 sb << "\\s";
@@ -703,7 +705,7 @@ namespace Slang
                 sb << "\\\\";
                 break;
             default:
-                sb << str[i];
+                sb << data[i];
                 break;
             }
         }
@@ -714,11 +716,13 @@ namespace Slang
     String UnescapeStringLiteral(String str)
     {
         StringBuilder sb;
-        for (int i = 0; i < (int)str.Length(); i++)
+        const Index length = str.getLength();
+        const char*const data = str.Buffer();
+        for (Index i = 0; i < length; i++)
         {
-            if (str[i] == '\\' && i < (int)str.Length() - 1)
+            if (data[i] == '\\' && i < length - 1)
             {
-                switch (str[i + 1])
+                switch (data[i + 1])
                 {
                 case 's':
                     sb << " ";
@@ -746,12 +750,12 @@ namespace Slang
                     break;
                 default:
                     i = i - 1;
-                    sb << str[i];
+                    sb << data[i];
                 }
                 i++;
             }
             else
-                sb << str[i];
+                sb << data[i];
         }
         return sb.ProduceString();
     }

--- a/source/core/token-reader.cpp
+++ b/source/core/token-reader.cpp
@@ -52,7 +52,7 @@ namespace Slang
             wchar_t nextNextChar = (pos < (int)str.Length() - 2) ? str[pos + 2] : '\0';
             auto InsertToken = [&](TokenType type, const String & ct)
             {
-                tokens.Add(Token(type, ct, line, col + pos, pos + startPos, fileName, tokenFlags));
+                tokens.add(Token(type, ct, line, col + pos, pos + startPos, fileName, tokenFlags));
                 tokenFlags = 0;
             };
             switch (curChar)
@@ -335,7 +335,7 @@ namespace Slang
         auto InsertToken = [&](TokenType type)
         {
             derivative = LexDerivative::None;
-            tokenList.Add(Token(type, tokenBuilder.ToString(), tokenLine, tokenCol, pos, file, tokenFlags));
+            tokenList.add(Token(type, tokenBuilder.ToString(), tokenLine, tokenCol, pos, file, tokenFlags));
             tokenFlags = 0;
             tokenBuilder.Clear();
         };

--- a/source/core/token-reader.h
+++ b/source/core/token-reader.h
@@ -189,7 +189,7 @@ namespace Slang
         }
         Token ReadToken()
         {
-            if (tokenPtr < (int)tokens.getSize())
+            if (tokenPtr < (int)tokens.getCount())
             {
                 auto &rs = tokens[tokenPtr];
                 tokenPtr++;
@@ -199,7 +199,7 @@ namespace Slang
         }
         Token NextToken(int offset = 0)
         {
-            if (tokenPtr + offset < (int)tokens.getSize())
+            if (tokenPtr + offset < (int)tokens.getCount())
                 return tokens[tokenPtr + offset];
             else
             {
@@ -210,7 +210,7 @@ namespace Slang
         }
         bool LookAhead(String token)
         {
-            if (tokenPtr < (int)tokens.getSize())
+            if (tokenPtr < (int)tokens.getCount())
             {
                 auto next = NextToken();
                 return next.Content == token;
@@ -222,7 +222,7 @@ namespace Slang
         }
         bool IsEnd()
         {
-            return tokenPtr == (int)tokens.getSize();
+            return tokenPtr == (int)tokens.getCount();
         }
     public:
         bool IsLegalText()

--- a/source/core/token-reader.h
+++ b/source/core/token-reader.h
@@ -189,7 +189,7 @@ namespace Slang
         }
         Token ReadToken()
         {
-            if (tokenPtr < (int)tokens.Count())
+            if (tokenPtr < (int)tokens.getSize())
             {
                 auto &rs = tokens[tokenPtr];
                 tokenPtr++;
@@ -199,7 +199,7 @@ namespace Slang
         }
         Token NextToken(int offset = 0)
         {
-            if (tokenPtr + offset < (int)tokens.Count())
+            if (tokenPtr + offset < (int)tokens.getSize())
                 return tokens[tokenPtr + offset];
             else
             {
@@ -210,7 +210,7 @@ namespace Slang
         }
         bool LookAhead(String token)
         {
-            if (tokenPtr < (int)tokens.Count())
+            if (tokenPtr < (int)tokens.getSize())
             {
                 auto next = NextToken();
                 return next.Content == token;
@@ -222,7 +222,7 @@ namespace Slang
         }
         bool IsEnd()
         {
-            return tokenPtr == (int)tokens.Count();
+            return tokenPtr == (int)tokens.getSize();
         }
     public:
         bool IsLegalText()

--- a/source/core/token-reader.h
+++ b/source/core/token-reader.h
@@ -235,12 +235,12 @@ namespace Slang
     {
         List<String> result;
         StringBuilder sb;
-        for (int i = 0; i < (int)text.Length(); i++)
+        for (Index i = 0; i < text.getLength(); i++)
         {
             if (text[i] == c)
             {
                 auto str = sb.ToString();
-                if (str.Length() != 0)
+                if (str.getLength() != 0)
                     result.add(str);
                 sb.Clear();
             }
@@ -248,7 +248,7 @@ namespace Slang
                 sb << text[i];
         }
         auto lastStr = sb.ToString();
-        if (lastStr.Length())
+        if (lastStr.getLength())
             result.add(lastStr);
         return result;
     }

--- a/source/core/token-reader.h
+++ b/source/core/token-reader.h
@@ -241,7 +241,7 @@ namespace Slang
             {
                 auto str = sb.ToString();
                 if (str.Length() != 0)
-                    result.Add(str);
+                    result.add(str);
                 sb.Clear();
             }
             else
@@ -249,7 +249,7 @@ namespace Slang
         }
         auto lastStr = sb.ToString();
         if (lastStr.Length())
-            result.Add(lastStr);
+            result.add(lastStr);
         return result;
     }
 }

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -8945,7 +8945,7 @@ namespace Slang
 
             auto swizzleText = getText(memberRefExpr->name);
 
-            for (Index i = 0; i < swizzleText.Length(); i++)
+            for (Index i = 0; i < swizzleText.getLength(); i++)
             {
                 auto ch = swizzleText[i];
                 int elementIndex = -1;
@@ -9764,7 +9764,7 @@ namespace Slang
                 {
                     const auto& semanticToken = semantic->name;
 
-                    String lowerName = String(semanticToken.Content).ToLower();
+                    String lowerName = String(semanticToken.Content).toLower();
 
                     if(lowerName == "sv_dispatchthreadid")
                     {
@@ -10847,11 +10847,11 @@ static bool doesParameterMatch(
         //
         // We will punt on this for now, and just check each constraint in isolation.
         //
-        UInt argCounter = 0;
+        Index argCounter = 0;
         for(auto& globalGenericParam : globalGenericParams)
         {
             // Get the argument that matches this parameter.
-            UInt argIndex = argCounter++;
+            Index argIndex = argCounter++;
             SLANG_ASSERT(argIndex < globalGenericArgs.getCount());
             auto globalGenericArg = checkProperType(linkage, TypeExp(globalGenericArgs[argIndex]), sink);
             if (!globalGenericArg)

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -2869,7 +2869,7 @@ namespace Slang
                 else if (auto userDefAttr = as<UserDefinedAttribute>(attr))
                 {
                     // check arguments against attribute parameters defined in attribClassDecl
-                    uint32_t paramIndex = 0;
+                    Index paramIndex = 0;
                     auto params = attribClassDecl->getMembersOfType<ParamDecl>();
                     for (auto paramDecl : params)
                     {
@@ -6875,7 +6875,7 @@ namespace Slang
             candidate.subst = genSubst;
             auto& checkedArgs = genSubst->args;
 
-            uint32_t aa = 0;
+            Index aa = 0;
             for (auto memberRef : getMembers(genericDeclRef))
             {
                 if (auto typeParamRef = memberRef.as<GenericTypeParamDecl>())

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -2896,13 +2896,13 @@ namespace Slang
                         }
                         paramIndex++;
                     }
-                    if (params.Count() < attr->args.getCount())
+                    if (params.getCount() < attr->args.getCount())
                     {
-                        getSink()->diagnose(attr, Diagnostics::tooManyArguments, attr->args.getCount(), params.Count());
+                        getSink()->diagnose(attr, Diagnostics::tooManyArguments, attr->args.getCount(), params.getCount());
                     }
-                    else if (params.Count() > attr->args.getCount())
+                    else if (params.getCount() > attr->args.getCount())
                     {
-                        getSink()->diagnose(attr, Diagnostics::notEnoughArguments, attr->args.getCount(), params.Count());
+                        getSink()->diagnose(attr, Diagnostics::notEnoughArguments, attr->args.getCount(), params.getCount());
                     }
                 }
                 else if (auto formatAttr = as<FormatAttribute>(attr))
@@ -3319,7 +3319,7 @@ namespace Slang
         {
             if (genDecl.getDecl()->Members.getCount() != requirementGenDecl.getDecl()->Members.getCount())
                 return false;
-            for (UInt i = 0; i < genDecl.getDecl()->Members.getCount(); i++)
+            for (Index i = 0; i < genDecl.getDecl()->Members.getCount(); i++)
             {
                 auto genMbr = genDecl.getDecl()->Members[i];
                 auto requiredGenMbr = genDecl.getDecl()->Members[i];
@@ -4358,12 +4358,12 @@ namespace Slang
 
             // For there to be any hope of a match, the
             // two need to have the same number of parameters.
-            UInt paramCount = fstParams.getCount();
+            Index paramCount = fstParams.getCount();
             if (paramCount != sndParams.getCount())
                 return false;
 
             // Now we'll walk through the parameters.
-            for (UInt pp = 0; pp < paramCount; ++pp)
+            for (Index pp = 0; pp < paramCount; ++pp)
             {
                 Decl* fstParam = fstParams[pp];
                 Decl* sndParam = sndParams[pp];
@@ -4416,11 +4416,11 @@ namespace Slang
             //
             // For now I'm going to assume/require that all declarations must
             // declare the signature in a way that matches exactly.
-            UInt constraintCount = fstConstraints.getCount();
+            Index constraintCount = fstConstraints.getCount();
             if(constraintCount != sndConstraints.getCount())
                 return false;
 
-            for (UInt cc = 0; cc < constraintCount; ++cc)
+            for (Index cc = 0; cc < constraintCount; ++cc)
             {
                 //auto fstConstraint = fstConstraints[cc];
                 //auto sndConstraint = sndConstraints[cc];
@@ -4453,7 +4453,7 @@ namespace Slang
             if (fstParamCount != sndParamCount)
                 return false;
 
-            for (UInt ii = 0; ii < fstParamCount; ++ii)
+            for (Index ii = 0; ii < fstParamCount; ++ii)
             {
                 auto fstParam = fstParams[ii];
                 auto sndParam = sndParams[ii];
@@ -5602,9 +5602,9 @@ namespace Slang
 
         bool MatchArguments(FuncDecl * functionNode, List <RefPtr<Expr>> &args)
         {
-            if (functionNode->GetParameters().Count() != args.getCount())
+            if (functionNode->GetParameters().getCount() != args.getCount())
                 return false;
-            int i = 0;
+            Index i = 0;
             for (auto param : functionNode->GetParameters())
             {
                 if (!param->type.Equals(args[i]->type.Ptr()))
@@ -6933,7 +6933,7 @@ namespace Slang
             OverloadResolveContext&	context,
             OverloadCandidate&		candidate)
         {
-            UInt argCount = context.getArgCount();
+            Index argCount = context.getArgCount();
 
             List<DeclRef<ParamDecl>> params;
             switch (candidate.flavor)
@@ -6954,7 +6954,7 @@ namespace Slang
             // case where one or more parameters had defaults.
             SLANG_RELEASE_ASSERT(argCount <= params.getCount());
 
-            for (UInt ii = 0; ii < argCount; ++ii)
+            for (Index ii = 0; ii < argCount; ++ii)
             {
                 auto& arg = context.getArg(ii);
                 auto argType = context.getArgType(ii);
@@ -7296,7 +7296,7 @@ namespace Slang
                 bool anyFiltered = false;
                 // Note that we are querying the list length on every iteration,
                 // because we might remove things.
-                for (UInt cc = 0; cc < context.bestCandidates.getCount(); ++cc)
+                for (Index cc = 0; cc < context.bestCandidates.getCount(); ++cc)
                 {
                     int cmp = CompareOverloadCandidates(&candidate, &context.bestCandidates[cc]);
                     if (cmp < 0)
@@ -8735,8 +8735,8 @@ namespace Slang
                 // if this is still an invoke expression, test arguments passed to inout/out parameter are LValues
                 if(auto funcType = as<FuncType>(invoke->FunctionExpr->type))
                 {
-                    UInt paramCount = funcType->getParamCount();
-                    for (UInt pp = 0; pp < paramCount; ++pp)
+                    Index paramCount = funcType->getParamCount();
+                    for (Index pp = 0; pp < paramCount; ++pp)
                     {
                         auto paramType = funcType->getParamType(pp);
                         if (as<OutTypeBase>(paramType) || as<RefType>(paramType))
@@ -8945,7 +8945,7 @@ namespace Slang
 
             auto swizzleText = getText(memberRefExpr->name);
 
-            for (UInt i = 0; i < swizzleText.Length(); i++)
+            for (Index i = 0; i < swizzleText.Length(); i++)
             {
                 auto ch = swizzleText[i];
                 int elementIndex = -1;
@@ -10112,14 +10112,14 @@ static bool validateGenericSubstitutionsMatch(
 
 
 
-    UInt argCount = left->args.getCount();
+    Index argCount = left->args.getCount();
     if( argCount != right->args.getCount() )
     {
         diagnoseTypeMismatch(sink, stack);
         return false;
     }
 
-    for( UInt aa = 0; aa < argCount; ++aa )
+    for( Index aa = 0; aa < argCount; ++aa )
     {
         auto leftArg = left->args[aa];
         auto rightArg = right->args[aa];

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -230,10 +230,10 @@ namespace Slang
             // that we can encode in our space of keys.
             args[0].aggVal = 0;
             args[1].aggVal = 0;
-            if (opExpr->Arguments.getSize() > 2)
+            if (opExpr->Arguments.getCount() > 2)
                 return false;
 
-            for (UInt i = 0; i < opExpr->Arguments.getSize(); i++)
+            for (UInt i = 0; i < opExpr->Arguments.getCount(); i++)
             {
                 if (!args[i].fromType(opExpr->Arguments[i]->type.Ptr()))
                     return false;
@@ -1487,7 +1487,7 @@ namespace Slang
             // First, we will check if we have run out of arguments
             // on the initializer list.
             //
-            UInt initArgCount = fromInitializerListExpr->args.getSize();
+            UInt initArgCount = fromInitializerListExpr->args.getCount();
             if(ioInitArgIndex >= initArgCount)
             {
                 // If we are at the end of the initializer list,
@@ -1567,7 +1567,7 @@ namespace Slang
             UInt                       &ioArgIndex)
         {
             auto toType = inToType;
-            UInt argCount = fromInitializerListExpr->args.getSize();
+            UInt argCount = fromInitializerListExpr->args.getCount();
 
             // In the case where we need to build a result expression,
             // we will collect the new arguments here
@@ -1862,7 +1862,7 @@ namespace Slang
             RefPtr<Expr>*               outToExpr,
             RefPtr<InitializerListExpr> fromInitializerListExpr)
         {
-            UInt argCount = fromInitializerListExpr->args.getSize();
+            UInt argCount = fromInitializerListExpr->args.getCount();
             UInt argIndex = 0;
 
             // TODO: we should handle the special case of `{0}` as an initializer
@@ -2062,7 +2062,7 @@ namespace Slang
             // to the context and processed, we need to see whether
             // there was one best overload or not.
             //
-            if(overloadContext.bestCandidates.getSize() != 0)
+            if(overloadContext.bestCandidates.getCount() != 0)
             {
                 // In this case there were multiple equally-good candidates to call.
                 //
@@ -2676,7 +2676,7 @@ namespace Slang
 
         bool hasIntArgs(Attribute* attr, int numArgs)
         {
-            if (int(attr->args.getSize()) != numArgs)
+            if (int(attr->args.getCount()) != numArgs)
             {
                 return false;
             }
@@ -2692,7 +2692,7 @@ namespace Slang
 
         bool hasStringArgs(Attribute* attr, int numArgs)
         {
-            if (int(attr->args.getSize()) != numArgs)
+            if (int(attr->args.getCount()) != numArgs)
             {
                 return false;
             }
@@ -2730,7 +2730,7 @@ namespace Slang
         {
                 if(auto numThreadsAttr = as<NumThreadsAttribute>(attr))
                 {
-                    SLANG_ASSERT(attr->args.getSize() == 3);
+                    SLANG_ASSERT(attr->args.getCount() == 3);
                     auto xVal = checkConstantIntVal(attr->args[0]);
                     auto yVal = checkConstantIntVal(attr->args[1]);
                     auto zVal = checkConstantIntVal(attr->args[2]);
@@ -2748,7 +2748,7 @@ namespace Slang
                     // This must be vk::binding or gl::binding (as specified in core.meta.slang under vk_binding/gl_binding)
                     // Must have 2 int parameters. Ideally this would all be checked from the specification
                     // in core.meta.slang, but that's not completely implemented. So for now we check here.
-                    if (attr->args.getSize() != 2)
+                    if (attr->args.getCount() != 2)
                     {
                         return false;
                     }
@@ -2768,7 +2768,7 @@ namespace Slang
                 }
                 else if (auto maxVertexCountAttr = as<MaxVertexCountAttribute>(attr))
                 {
-                    SLANG_ASSERT(attr->args.getSize() == 1);
+                    SLANG_ASSERT(attr->args.getCount() == 1);
                     auto val = checkConstantIntVal(attr->args[0]);
 
                     if(!val) return false;
@@ -2777,7 +2777,7 @@ namespace Slang
                 }
                 else if(auto instanceAttr = as<InstanceAttribute>(attr))
                 {
-                    SLANG_ASSERT(attr->args.getSize() == 1);
+                    SLANG_ASSERT(attr->args.getCount() == 1);
                     auto val = checkConstantIntVal(attr->args[0]);
 
                     if(!val) return false;
@@ -2786,7 +2786,7 @@ namespace Slang
                 }
                 else if(auto entryPointAttr = as<EntryPointAttribute>(attr))
                 {
-                    SLANG_ASSERT(attr->args.getSize() == 1);
+                    SLANG_ASSERT(attr->args.getCount() == 1);
 
                     String stageName;
                     if(!checkLiteralStringVal(attr->args[0], &stageName))
@@ -2825,22 +2825,22 @@ namespace Slang
                 else if (as<PushConstantAttribute>(attr))
                 {
                     // Has no args
-                    SLANG_ASSERT(attr->args.getSize() == 0);
+                    SLANG_ASSERT(attr->args.getCount() == 0);
                 }
                 else if (as<ShaderRecordAttribute>(attr))
                 {
                     // Has no args
-                    SLANG_ASSERT(attr->args.getSize() == 0);
+                    SLANG_ASSERT(attr->args.getCount() == 0);
                 }
                 else if (as<EarlyDepthStencilAttribute>(attr))
                 {
                     // Has no args
-                    SLANG_ASSERT(attr->args.getSize() == 0);
+                    SLANG_ASSERT(attr->args.getCount() == 0);
                 }
                 else if (auto attrUsageAttr = as<AttributeUsageAttribute>(attr))
                 {
                     uint32_t targetClassId = (uint32_t)UserDefinedAttributeTargets::None;
-                    if (attr->args.getSize() == 1)
+                    if (attr->args.getCount() == 1)
                     {
                         RefPtr<IntVal> outIntVal;
                         if (auto cInt = checkConstantEnumVal(attr->args[0]))
@@ -2864,7 +2864,7 @@ namespace Slang
                     // Check has an argument. We need this because default behavior is to give an error
                     // if an attribute has arguments, but not handled explicitly (and the default param will come through
                     // as 1 arg if nothing is specified)
-                    SLANG_ASSERT(attr->args.getSize() == 1);
+                    SLANG_ASSERT(attr->args.getCount() == 1);
                 }
                 else if (auto userDefAttr = as<UserDefinedAttribute>(attr))
                 {
@@ -2873,7 +2873,7 @@ namespace Slang
                     auto params = attribClassDecl->getMembersOfType<ParamDecl>();
                     for (auto paramDecl : params)
                     {
-                        if (paramIndex < attr->args.getSize())
+                        if (paramIndex < attr->args.getCount())
                         {
                             auto & arg = attr->args[paramIndex];
                             bool typeChecked = false;
@@ -2896,18 +2896,18 @@ namespace Slang
                         }
                         paramIndex++;
                     }
-                    if (params.Count() < attr->args.getSize())
+                    if (params.Count() < attr->args.getCount())
                     {
-                        getSink()->diagnose(attr, Diagnostics::tooManyArguments, attr->args.getSize(), params.Count());
+                        getSink()->diagnose(attr, Diagnostics::tooManyArguments, attr->args.getCount(), params.Count());
                     }
-                    else if (params.Count() > attr->args.getSize())
+                    else if (params.Count() > attr->args.getCount())
                     {
-                        getSink()->diagnose(attr, Diagnostics::notEnoughArguments, attr->args.getSize(), params.Count());
+                        getSink()->diagnose(attr, Diagnostics::notEnoughArguments, attr->args.getCount(), params.Count());
                     }
                 }
                 else if (auto formatAttr = as<FormatAttribute>(attr))
                 {
-                    SLANG_ASSERT(attr->args.getSize() == 1);
+                    SLANG_ASSERT(attr->args.getCount() == 1);
 
                     String formatName;
                     if(!checkLiteralStringVal(attr->args[0], &formatName))
@@ -2925,7 +2925,7 @@ namespace Slang
                 }
                 else
                 {
-                    if(attr->args.getSize() == 0)
+                    if(attr->args.getCount() == 0)
                     {
                         // If the attribute took no arguments, then we will
                         // assume it is valid as written.
@@ -2984,7 +2984,7 @@ namespace Slang
             // us to look at the attribute declaration itself.
             //
             // Start by doing argument/parameter matching
-            UInt argCount = attr->args.getSize();
+            UInt argCount = attr->args.getCount();
             UInt paramCounter = 0;
             bool mismatch = false;
             for(auto paramDecl : attrDecl->getMembersOfType<ParamDecl>())
@@ -3317,9 +3317,9 @@ namespace Slang
             DeclRef<GenericDecl>        requirementGenDecl,
             RefPtr<WitnessTable>        witnessTable)
         {
-            if (genDecl.getDecl()->Members.getSize() != requirementGenDecl.getDecl()->Members.getSize())
+            if (genDecl.getDecl()->Members.getCount() != requirementGenDecl.getDecl()->Members.getCount())
                 return false;
-            for (UInt i = 0; i < genDecl.getDecl()->Members.getSize(); i++)
+            for (UInt i = 0; i < genDecl.getDecl()->Members.getCount(); i++)
             {
                 auto genMbr = genDecl.getDecl()->Members[i];
                 auto requiredGenMbr = genDecl.getDecl()->Members[i];
@@ -4358,8 +4358,8 @@ namespace Slang
 
             // For there to be any hope of a match, the
             // two need to have the same number of parameters.
-            UInt paramCount = fstParams.getSize();
-            if (paramCount != sndParams.getSize())
+            UInt paramCount = fstParams.getCount();
+            if (paramCount != sndParams.getCount())
                 return false;
 
             // Now we'll walk through the parameters.
@@ -4416,8 +4416,8 @@ namespace Slang
             //
             // For now I'm going to assume/require that all declarations must
             // declare the signature in a way that matches exactly.
-            UInt constraintCount = fstConstraints.getSize();
-            if(constraintCount != sndConstraints.getSize())
+            UInt constraintCount = fstConstraints.getCount();
+            if(constraintCount != sndConstraints.getCount())
                 return false;
 
             for (UInt cc = 0; cc < constraintCount; ++cc)
@@ -4448,8 +4448,8 @@ namespace Slang
 
             // If the functions have different numbers of parameters, then
             // their signatures trivially don't match.
-            auto fstParamCount = fstParams.getSize();
-            auto sndParamCount = sndParams.getSize();
+            auto fstParamCount = fstParams.getCount();
+            auto sndParamCount = sndParams.getCount();
             if (fstParamCount != sndParamCount)
                 return false;
 
@@ -4845,7 +4845,7 @@ namespace Slang
         template<typename T>
         T* FindOuterStmt()
         {
-            UInt outerStmtCount = outerStmts.getSize();
+            UInt outerStmtCount = outerStmts.getCount();
             for (UInt ii = outerStmtCount; ii > 0; --ii)
             {
                 auto outerStmt = outerStmts[ii-1];
@@ -4882,7 +4882,7 @@ namespace Slang
 
         void PopOuterStmt(Stmt* /*stmt*/)
         {
-            outerStmts.removeAt(outerStmts.getSize() - 1);
+            outerStmts.removeAt(outerStmts.getCount() - 1);
         }
 
         RefPtr<Expr> checkPredicateExpr(Expr* expr)
@@ -5220,7 +5220,7 @@ namespace Slang
 
             // Let's not constant-fold operations with more than a certain number of arguments, for simplicity
             static const int kMaxArgs = 8;
-            if (invokeExpr->Arguments.getSize() > kMaxArgs)
+            if (invokeExpr->Arguments.getCount() > kMaxArgs)
                 return nullptr;
 
             // Before checking the operation name, let's look at the arguments
@@ -5602,7 +5602,7 @@ namespace Slang
 
         bool MatchArguments(FuncDecl * functionNode, List <RefPtr<Expr>> &args)
         {
-            if (functionNode->GetParameters().Count() != args.getSize())
+            if (functionNode->GetParameters().Count() != args.getCount())
                 return false;
             int i = 0;
             for (auto param : functionNode->GetParameters())
@@ -6952,7 +6952,7 @@ namespace Slang
 
             // Note(tfoley): We might have fewer arguments than parameters in the
             // case where one or more parameters had defaults.
-            SLANG_RELEASE_ASSERT(argCount <= params.getSize());
+            SLANG_RELEASE_ASSERT(argCount <= params.getCount());
 
             for (UInt ii = 0; ii < argCount; ++ii)
             {
@@ -7290,13 +7290,13 @@ namespace Slang
 
             bool keepThisCandidate = true; // should this candidate be kept?
 
-            if (context.bestCandidates.getSize() != 0)
+            if (context.bestCandidates.getCount() != 0)
             {
                 // We have multiple candidates right now, so filter them.
                 bool anyFiltered = false;
                 // Note that we are querying the list length on every iteration,
                 // because we might remove things.
-                for (UInt cc = 0; cc < context.bestCandidates.getSize(); ++cc)
+                for (UInt cc = 0; cc < context.bestCandidates.getCount(); ++cc)
                 {
                     int cmp = CompareOverloadCandidates(&candidate, &context.bestCandidates[cc]);
                     if (cmp < 0)
@@ -7344,7 +7344,7 @@ namespace Slang
                 return;
 
             // Otherwise we want to keep the candidate
-            if (context.bestCandidates.getSize() > 0)
+            if (context.bestCandidates.getCount() > 0)
             {
                 // There were already multiple candidates, and we are adding one more
                 context.bestCandidates.add(candidate);
@@ -7581,8 +7581,8 @@ namespace Slang
                 return false;
 
             // Their arguments must unify
-            SLANG_RELEASE_ASSERT(fstGen->args.getSize() == sndGen->args.getSize());
-            UInt argCount = fstGen->args.getSize();
+            SLANG_RELEASE_ASSERT(fstGen->args.getCount() == sndGen->args.getCount());
+            UInt argCount = fstGen->args.getCount();
             bool okay = true;
             for (UInt aa = 0; aa < argCount; ++aa)
             {
@@ -7926,7 +7926,7 @@ namespace Slang
                 auto params = GetParameters(funcDeclRef).ToArray();
 
                 UInt argCount = context.getArgCount();
-                UInt paramCount = params.getSize();
+                UInt paramCount = params.getCount();
 
                 // Bail out on mismatch.
                 // TODO(tfoley): need more nuance here
@@ -8418,8 +8418,8 @@ namespace Slang
             context.originalExpr = expr;
             context.funcLoc = funcExpr->loc;
 
-            context.argCount = expr->Arguments.getSize();
-            context.args = expr->Arguments.Buffer();
+            context.argCount = expr->Arguments.getCount();
+            context.args = expr->Arguments.getBuffer();
             context.loc = expr->loc;
 
             if (auto funcMemberExpr = as<MemberExpr>(funcExpr))
@@ -8440,7 +8440,7 @@ namespace Slang
                 AddOverloadCandidates(funcExpr, context);
             }
 
-            if (context.bestCandidates.getSize() > 0)
+            if (context.bestCandidates.getCount() > 0)
             {
                 // Things were ambiguous.
 
@@ -8495,7 +8495,7 @@ namespace Slang
                 }
 
                 {
-                    UInt candidateCount = context.bestCandidates.getSize();
+                    UInt candidateCount = context.bestCandidates.getCount();
                     UInt maxCandidatesToPrint = 10; // don't show too many candidates at once...
                     UInt candidateIndex = 0;
                     for (auto candidate : context.bestCandidates)
@@ -8634,15 +8634,15 @@ namespace Slang
             OverloadResolveContext context;
             context.originalExpr = genericAppExpr;
             context.funcLoc = baseExpr->loc;
-            context.argCount = args.getSize();
-            context.args = args.Buffer();
+            context.argCount = args.getCount();
+            context.args = args.getBuffer();
             context.loc = genericAppExpr->loc;
 
             context.baseExpr = GetBaseExpr(baseExpr);
 
             AddGenericOverloadCandidates(baseExpr, context);
 
-            if (context.bestCandidates.getSize() > 0)
+            if (context.bestCandidates.getCount() > 0)
             {
                 // Things were ambiguous.
                 if (context.bestCandidates[0].status != OverloadCandidate::Status::Applicable)
@@ -8748,7 +8748,7 @@ namespace Slang
                             // for an `inout` parameter to be converted in both
                             // directions.
                             //
-                            if( pp < expr->Arguments.getSize() )
+                            if( pp < expr->Arguments.getCount() )
                             {
                                 auto argExpr = expr->Arguments[pp];
                                 if( !argExpr->type.IsLeftValue )
@@ -9135,7 +9135,7 @@ namespace Slang
                     {
                         // If we had some static items, then that's okay,
                         // we just want to use our newly-filtered list.
-                        if (staticItems.getSize())
+                        if (staticItems.getCount())
                         {
                             lookupResult.items = staticItems;
                         }
@@ -9621,9 +9621,9 @@ namespace Slang
         ExistentialTypeSlots&       ioSlots,
         DeclRef<VarDeclBase>    paramDeclRef)
     {
-        UInt startSlot = ioSlots.paramTypes.getSize();
+        UInt startSlot = ioSlots.paramTypes.getCount();
         _collectExistentialTypeParamsRec(ioSlots, paramDeclRef);
-        UInt endSlot = ioSlots.paramTypes.getSize();
+        UInt endSlot = ioSlots.paramTypes.getCount();
         UInt slotCount = endSlot - startSlot;
 
         ioParamInfo.firstExistentialTypeSlot = startSlot;
@@ -9714,7 +9714,7 @@ namespace Slang
 
             if (attr)
             {
-                if (attr->args.getSize() != 1)
+                if (attr->args.getCount() != 1)
                 {
                     sink->diagnose(attr, Diagnostics::badlyDefinedPatchConstantFunc, entryPointName);
                     return;
@@ -10112,8 +10112,8 @@ static bool validateGenericSubstitutionsMatch(
 
 
 
-    UInt argCount = left->args.getSize();
-    if( argCount != right->args.getSize() )
+    UInt argCount = left->args.getCount();
+    if( argCount != right->args.getCount() )
     {
         diagnoseTypeMismatch(sink, stack);
         return false;
@@ -10256,8 +10256,8 @@ static bool validateTypesMatch(
                         collectFields(leftStructDeclRef, leftFields);
                         collectFields(rightStructDeclRef, rightFields);
 
-                        UInt leftFieldCount = leftFields.getSize();
-                        UInt rightFieldCount = rightFields.getSize();
+                        UInt leftFieldCount = leftFields.getCount();
+                        UInt rightFieldCount = rightFields.getCount();
 
                         if( leftFieldCount != rightFieldCount )
                         {
@@ -10405,7 +10405,7 @@ static bool doesParameterMatch(
                     }
                 }
 
-                Int newParamIndex = Int(m_shaderParams.getSize());
+                Int newParamIndex = Int(m_shaderParams.getCount());
                 mapNameToParamIndex.Add(paramName, newParamIndex);
 
                 GlobalShaderParamInfo shaderParamInfo;
@@ -10501,7 +10501,7 @@ static bool doesParameterMatch(
             // For now we'll start with an extremely basic approach that
             // should work for typical HLSL code.
             //
-            UInt translationUnitCount = compileRequest->translationUnits.getSize();
+            UInt translationUnitCount = compileRequest->translationUnits.getCount();
             for(UInt tt = 0; tt < translationUnitCount; ++tt)
             {
                 auto translationUnit = compileRequest->translationUnits[tt];
@@ -10558,8 +10558,8 @@ static bool doesParameterMatch(
         List<RefPtr<Expr>> const&   args,
         DiagnosticSink*             sink)
     {
-        UInt slotCount = ioSlots.paramTypes.getSize();
-        UInt argCount = args.getSize();
+        UInt slotCount = ioSlots.paramTypes.getCount();
+        UInt argCount = args.getCount();
 
         if( slotCount != argCount )
         {
@@ -10811,11 +10811,11 @@ static bool doesParameterMatch(
         // An easy early-out case will be if the number of
         // arguments isn't correct.
         //
-        if (globalGenericParams.getSize() != globalGenericArgs.getSize())
+        if (globalGenericParams.getCount() != globalGenericArgs.getCount())
         {
             sink->diagnose(SourceLoc(), Diagnostics::mismatchGlobalGenericArguments,
-                globalGenericParams.getSize(),
-                globalGenericArgs.getSize());
+                globalGenericParams.getCount(),
+                globalGenericArgs.getCount());
             return nullptr;
         }
 
@@ -10852,7 +10852,7 @@ static bool doesParameterMatch(
         {
             // Get the argument that matches this parameter.
             UInt argIndex = argCounter++;
-            SLANG_ASSERT(argIndex < globalGenericArgs.getSize());
+            SLANG_ASSERT(argIndex < globalGenericArgs.getCount());
             auto globalGenericArg = checkProperType(linkage, TypeExp(globalGenericArgs[argIndex]), sink);
             if (!globalGenericArg)
             {
@@ -11049,11 +11049,11 @@ static bool doesParameterMatch(
         // ahead and consider all the entry points that were found
         // by the front-end.
         //
-        UInt entryPointCount = endToEndReq->entryPoints.getSize();
+        UInt entryPointCount = endToEndReq->entryPoints.getCount();
         if( entryPointCount == 0 )
         {
             entryPointCount = unspecializedProgram->getEntryPointCount();
-            endToEndReq->entryPoints.setSize(entryPointCount);
+            endToEndReq->entryPoints.setCount(entryPointCount);
         }
 
         for( UInt ii = 0; ii < entryPointCount; ++ii )

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -2916,7 +2916,7 @@ namespace Slang
                     }
 
                     ImageFormat format = ImageFormat::unknown;
-                    if(!findImageFormatByName(formatName.Buffer(), &format))
+                    if(!findImageFormatByName(formatName.getBuffer(), &format))
                     {
                         getSink()->diagnose(attr->args[0], Diagnostics::unknownImageFormatName, formatName);
                     }

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -2181,7 +2181,7 @@ namespace Slang
                     // because we don't allow nested implicit conversions,
                     // but I'd rather play it safe.
                     //
-                    castExpr->Arguments.Clear();
+                    castExpr->Arguments.clear();
                     castExpr->Arguments.add(fromExpr);
                 }
 
@@ -4882,7 +4882,7 @@ namespace Slang
 
         void PopOuterStmt(Stmt* /*stmt*/)
         {
-            outerStmts.RemoveAt(outerStmts.getSize() - 1);
+            outerStmts.removeAt(outerStmts.getSize() - 1);
         }
 
         RefPtr<Expr> checkPredicateExpr(Expr* expr)
@@ -7304,7 +7304,7 @@ namespace Slang
                         // our new candidate is better!
 
                         // remove it from the list (by swapping in a later one)
-                        context.bestCandidates.FastRemoveAt(cc);
+                        context.bestCandidates.fastRemoveAt(cc);
                         // and then reduce our index so that we re-visit the same index
                         --cc;
 

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -6249,7 +6249,7 @@ namespace Slang
                     RefPtr<TaggedUnionSubtypeWitness> taggedUnionWitness = new TaggedUnionSubtypeWitness();
                     taggedUnionWitness->sub = taggedUnionType;
                     taggedUnionWitness->sup = DeclRefType::Create(getSession(), interfaceDeclRef);
-                    taggedUnionWitness->caseWitnesses.SwapWith(caseWitnesses);
+                    taggedUnionWitness->caseWitnesses.swapWith(caseWitnesses);
 
                     *outWitness = taggedUnionWitness;
                 }

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -233,7 +233,7 @@ namespace Slang
             if (opExpr->Arguments.getCount() > 2)
                 return false;
 
-            for (UInt i = 0; i < opExpr->Arguments.getCount(); i++)
+            for (Index i = 0; i < opExpr->Arguments.getCount(); i++)
             {
                 if (!args[i].fromType(opExpr->Arguments[i]->type.Ptr()))
                     return false;

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -4845,8 +4845,8 @@ namespace Slang
         template<typename T>
         T* FindOuterStmt()
         {
-            UInt outerStmtCount = outerStmts.getCount();
-            for (UInt ii = outerStmtCount; ii > 0; --ii)
+            const Index outerStmtCount = outerStmts.getCount();
+            for (Index ii = outerStmtCount; ii > 0; --ii)
             {
                 auto outerStmt = outerStmts[ii-1];
                 auto found = as<T>(outerStmt);
@@ -6690,13 +6690,13 @@ namespace Slang
             SourceLoc       funcLoc;
 
             // The original arguments to the call
-            UInt argCount = 0;
+            Index argCount = 0;
             RefPtr<Expr>* args = nullptr;
             RefPtr<Type>* argTypes = nullptr;
 
-            UInt getArgCount() { return argCount; }
-            RefPtr<Expr>& getArg(UInt index) { return args[index]; }
-            RefPtr<Type>& getArgType(UInt index)
+            Index getArgCount() { return argCount; }
+            RefPtr<Expr>& getArg(Index index) { return args[index]; }
+            RefPtr<Type>& getArgType(Index index)
             {
                 if(argTypes)
                     return argTypes[index];
@@ -7206,7 +7206,7 @@ namespace Slang
                             callExpr = new InvokeExpr();
                             callExpr->loc = context.loc;
 
-                            for(UInt aa = 0; aa < context.argCount; ++aa)
+                            for(Index aa = 0; aa < context.argCount; ++aa)
                                 callExpr->Arguments.add(context.getArg(aa));
                         }
 
@@ -7582,9 +7582,9 @@ namespace Slang
 
             // Their arguments must unify
             SLANG_RELEASE_ASSERT(fstGen->args.getCount() == sndGen->args.getCount());
-            UInt argCount = fstGen->args.getCount();
+            Index argCount = fstGen->args.getCount();
             bool okay = true;
-            for (UInt aa = 0; aa < argCount; ++aa)
+            for (Index aa = 0; aa < argCount; ++aa)
             {
                 if (!TryUnifyVals(constraints, fstGen->args[aa], sndGen->args[aa]))
                 {
@@ -7925,8 +7925,8 @@ namespace Slang
             {
                 auto params = GetParameters(funcDeclRef).ToArray();
 
-                UInt argCount = context.getArgCount();
-                UInt paramCount = params.getCount();
+                Index argCount = context.getArgCount();
+                Index paramCount = params.getCount();
 
                 // Bail out on mismatch.
                 // TODO(tfoley): need more nuance here
@@ -7935,7 +7935,7 @@ namespace Slang
                     return DeclRef<Decl>(nullptr, nullptr);
                 }
 
-                for (UInt aa = 0; aa < argCount; ++aa)
+                for (Index aa = 0; aa < argCount; ++aa)
                 {
 #if 0
                     if (!TryUnifyArgAndParamTypes(constraints, args[aa], params[aa]))
@@ -8495,9 +8495,9 @@ namespace Slang
                 }
 
                 {
-                    UInt candidateCount = context.bestCandidates.getCount();
-                    UInt maxCandidatesToPrint = 10; // don't show too many candidates at once...
-                    UInt candidateIndex = 0;
+                    Index candidateCount = context.bestCandidates.getCount();
+                    Index maxCandidatesToPrint = 10; // don't show too many candidates at once...
+                    Index candidateIndex = 0;
                     for (auto candidate : context.bestCandidates)
                     {
                         String declString = getDeclSignatureString(candidate.item);
@@ -9621,13 +9621,12 @@ namespace Slang
         ExistentialTypeSlots&       ioSlots,
         DeclRef<VarDeclBase>    paramDeclRef)
     {
-        UInt startSlot = ioSlots.paramTypes.getCount();
+        Index startSlot = ioSlots.paramTypes.getCount();
         _collectExistentialTypeParamsRec(ioSlots, paramDeclRef);
-        UInt endSlot = ioSlots.paramTypes.getCount();
-        UInt slotCount = endSlot - startSlot;
-
-        ioParamInfo.firstExistentialTypeSlot = startSlot;
-        ioParamInfo.existentialTypeSlotCount = slotCount;
+        Index endSlot = ioSlots.paramTypes.getCount();
+        
+        ioParamInfo.firstExistentialTypeSlot = UInt(startSlot);
+        ioParamInfo.existentialTypeSlotCount = UInt(endSlot - startSlot);;
     }
 
         /// Enumerate the existential-type parameters of an `EntryPoint`.
@@ -10256,8 +10255,8 @@ static bool validateTypesMatch(
                         collectFields(leftStructDeclRef, leftFields);
                         collectFields(rightStructDeclRef, rightFields);
 
-                        UInt leftFieldCount = leftFields.getCount();
-                        UInt rightFieldCount = rightFields.getCount();
+                        Index leftFieldCount = leftFields.getCount();
+                        Index rightFieldCount = rightFields.getCount();
 
                         if( leftFieldCount != rightFieldCount )
                         {
@@ -10265,7 +10264,7 @@ static bool validateTypesMatch(
                             return false;
                         }
 
-                        for( UInt ii = 0; ii < leftFieldCount; ++ii )
+                        for( Index ii = 0; ii < leftFieldCount; ++ii )
                         {
                             auto leftField = leftFields[ii];
                             auto rightField = rightFields[ii];
@@ -10501,8 +10500,8 @@ static bool doesParameterMatch(
             // For now we'll start with an extremely basic approach that
             // should work for typical HLSL code.
             //
-            UInt translationUnitCount = compileRequest->translationUnits.getCount();
-            for(UInt tt = 0; tt < translationUnitCount; ++tt)
+            Index translationUnitCount = compileRequest->translationUnits.getCount();
+            for(Index tt = 0; tt < translationUnitCount; ++tt)
             {
                 auto translationUnit = compileRequest->translationUnits[tt];
                 for( auto globalDecl : translationUnit->getModuleDecl()->Members )
@@ -10558,8 +10557,8 @@ static bool doesParameterMatch(
         List<RefPtr<Expr>> const&   args,
         DiagnosticSink*             sink)
     {
-        UInt slotCount = ioSlots.paramTypes.getCount();
-        UInt argCount = args.getCount();
+        Index slotCount = ioSlots.paramTypes.getCount();
+        Index argCount = args.getCount();
 
         if( slotCount != argCount )
         {
@@ -10569,7 +10568,7 @@ static bool doesParameterMatch(
 
         SemanticsVisitor visitor(linkage, sink);
 
-        for( UInt ii = 0; ii < slotCount; ++ii )
+        for( Index ii = 0; ii < slotCount; ++ii )
         {
             auto slotType = ioSlots.paramTypes[ii];
             auto argExpr = args[ii];
@@ -11049,14 +11048,14 @@ static bool doesParameterMatch(
         // ahead and consider all the entry points that were found
         // by the front-end.
         //
-        UInt entryPointCount = endToEndReq->entryPoints.getCount();
+        Index entryPointCount = endToEndReq->entryPoints.getCount();
         if( entryPointCount == 0 )
         {
             entryPointCount = unspecializedProgram->getEntryPointCount();
             endToEndReq->entryPoints.setCount(entryPointCount);
         }
 
-        for( UInt ii = 0; ii < entryPointCount; ++ii )
+        for( Index ii = 0; ii < entryPointCount; ++ii )
         {
             auto unspecializedEntryPoint = unspecializedProgram->getEntryPoint(ii);
             auto& entryPointInfo = endToEndReq->entryPoints[ii];

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -230,10 +230,10 @@ namespace Slang
             // that we can encode in our space of keys.
             args[0].aggVal = 0;
             args[1].aggVal = 0;
-            if (opExpr->Arguments.Count() > 2)
+            if (opExpr->Arguments.getSize() > 2)
                 return false;
 
-            for (UInt i = 0; i < opExpr->Arguments.Count(); i++)
+            for (UInt i = 0; i < opExpr->Arguments.getSize(); i++)
             {
                 if (!args[i].fromType(opExpr->Arguments[i]->type.Ptr()))
                     return false;
@@ -1487,7 +1487,7 @@ namespace Slang
             // First, we will check if we have run out of arguments
             // on the initializer list.
             //
-            UInt initArgCount = fromInitializerListExpr->args.Count();
+            UInt initArgCount = fromInitializerListExpr->args.getSize();
             if(ioInitArgIndex >= initArgCount)
             {
                 // If we are at the end of the initializer list,
@@ -1567,7 +1567,7 @@ namespace Slang
             UInt                       &ioArgIndex)
         {
             auto toType = inToType;
-            UInt argCount = fromInitializerListExpr->args.Count();
+            UInt argCount = fromInitializerListExpr->args.getSize();
 
             // In the case where we need to build a result expression,
             // we will collect the new arguments here
@@ -1862,7 +1862,7 @@ namespace Slang
             RefPtr<Expr>*               outToExpr,
             RefPtr<InitializerListExpr> fromInitializerListExpr)
         {
-            UInt argCount = fromInitializerListExpr->args.Count();
+            UInt argCount = fromInitializerListExpr->args.getSize();
             UInt argIndex = 0;
 
             // TODO: we should handle the special case of `{0}` as an initializer
@@ -2062,7 +2062,7 @@ namespace Slang
             // to the context and processed, we need to see whether
             // there was one best overload or not.
             //
-            if(overloadContext.bestCandidates.Count() != 0)
+            if(overloadContext.bestCandidates.getSize() != 0)
             {
                 // In this case there were multiple equally-good candidates to call.
                 //
@@ -2676,7 +2676,7 @@ namespace Slang
 
         bool hasIntArgs(Attribute* attr, int numArgs)
         {
-            if (int(attr->args.Count()) != numArgs)
+            if (int(attr->args.getSize()) != numArgs)
             {
                 return false;
             }
@@ -2692,7 +2692,7 @@ namespace Slang
 
         bool hasStringArgs(Attribute* attr, int numArgs)
         {
-            if (int(attr->args.Count()) != numArgs)
+            if (int(attr->args.getSize()) != numArgs)
             {
                 return false;
             }
@@ -2730,7 +2730,7 @@ namespace Slang
         {
                 if(auto numThreadsAttr = as<NumThreadsAttribute>(attr))
                 {
-                    SLANG_ASSERT(attr->args.Count() == 3);
+                    SLANG_ASSERT(attr->args.getSize() == 3);
                     auto xVal = checkConstantIntVal(attr->args[0]);
                     auto yVal = checkConstantIntVal(attr->args[1]);
                     auto zVal = checkConstantIntVal(attr->args[2]);
@@ -2748,7 +2748,7 @@ namespace Slang
                     // This must be vk::binding or gl::binding (as specified in core.meta.slang under vk_binding/gl_binding)
                     // Must have 2 int parameters. Ideally this would all be checked from the specification
                     // in core.meta.slang, but that's not completely implemented. So for now we check here.
-                    if (attr->args.Count() != 2)
+                    if (attr->args.getSize() != 2)
                     {
                         return false;
                     }
@@ -2768,7 +2768,7 @@ namespace Slang
                 }
                 else if (auto maxVertexCountAttr = as<MaxVertexCountAttribute>(attr))
                 {
-                    SLANG_ASSERT(attr->args.Count() == 1);
+                    SLANG_ASSERT(attr->args.getSize() == 1);
                     auto val = checkConstantIntVal(attr->args[0]);
 
                     if(!val) return false;
@@ -2777,7 +2777,7 @@ namespace Slang
                 }
                 else if(auto instanceAttr = as<InstanceAttribute>(attr))
                 {
-                    SLANG_ASSERT(attr->args.Count() == 1);
+                    SLANG_ASSERT(attr->args.getSize() == 1);
                     auto val = checkConstantIntVal(attr->args[0]);
 
                     if(!val) return false;
@@ -2786,7 +2786,7 @@ namespace Slang
                 }
                 else if(auto entryPointAttr = as<EntryPointAttribute>(attr))
                 {
-                    SLANG_ASSERT(attr->args.Count() == 1);
+                    SLANG_ASSERT(attr->args.getSize() == 1);
 
                     String stageName;
                     if(!checkLiteralStringVal(attr->args[0], &stageName))
@@ -2825,22 +2825,22 @@ namespace Slang
                 else if (as<PushConstantAttribute>(attr))
                 {
                     // Has no args
-                    SLANG_ASSERT(attr->args.Count() == 0);
+                    SLANG_ASSERT(attr->args.getSize() == 0);
                 }
                 else if (as<ShaderRecordAttribute>(attr))
                 {
                     // Has no args
-                    SLANG_ASSERT(attr->args.Count() == 0);
+                    SLANG_ASSERT(attr->args.getSize() == 0);
                 }
                 else if (as<EarlyDepthStencilAttribute>(attr))
                 {
                     // Has no args
-                    SLANG_ASSERT(attr->args.Count() == 0);
+                    SLANG_ASSERT(attr->args.getSize() == 0);
                 }
                 else if (auto attrUsageAttr = as<AttributeUsageAttribute>(attr))
                 {
                     uint32_t targetClassId = (uint32_t)UserDefinedAttributeTargets::None;
-                    if (attr->args.Count() == 1)
+                    if (attr->args.getSize() == 1)
                     {
                         RefPtr<IntVal> outIntVal;
                         if (auto cInt = checkConstantEnumVal(attr->args[0]))
@@ -2864,7 +2864,7 @@ namespace Slang
                     // Check has an argument. We need this because default behavior is to give an error
                     // if an attribute has arguments, but not handled explicitly (and the default param will come through
                     // as 1 arg if nothing is specified)
-                    SLANG_ASSERT(attr->args.Count() == 1);
+                    SLANG_ASSERT(attr->args.getSize() == 1);
                 }
                 else if (auto userDefAttr = as<UserDefinedAttribute>(attr))
                 {
@@ -2873,7 +2873,7 @@ namespace Slang
                     auto params = attribClassDecl->getMembersOfType<ParamDecl>();
                     for (auto paramDecl : params)
                     {
-                        if (paramIndex < attr->args.Count())
+                        if (paramIndex < attr->args.getSize())
                         {
                             auto & arg = attr->args[paramIndex];
                             bool typeChecked = false;
@@ -2896,18 +2896,18 @@ namespace Slang
                         }
                         paramIndex++;
                     }
-                    if (params.Count() < attr->args.Count())
+                    if (params.Count() < attr->args.getSize())
                     {
-                        getSink()->diagnose(attr, Diagnostics::tooManyArguments, attr->args.Count(), params.Count());
+                        getSink()->diagnose(attr, Diagnostics::tooManyArguments, attr->args.getSize(), params.Count());
                     }
-                    else if (params.Count() > attr->args.Count())
+                    else if (params.Count() > attr->args.getSize())
                     {
-                        getSink()->diagnose(attr, Diagnostics::notEnoughArguments, attr->args.Count(), params.Count());
+                        getSink()->diagnose(attr, Diagnostics::notEnoughArguments, attr->args.getSize(), params.Count());
                     }
                 }
                 else if (auto formatAttr = as<FormatAttribute>(attr))
                 {
-                    SLANG_ASSERT(attr->args.Count() == 1);
+                    SLANG_ASSERT(attr->args.getSize() == 1);
 
                     String formatName;
                     if(!checkLiteralStringVal(attr->args[0], &formatName))
@@ -2925,7 +2925,7 @@ namespace Slang
                 }
                 else
                 {
-                    if(attr->args.Count() == 0)
+                    if(attr->args.getSize() == 0)
                     {
                         // If the attribute took no arguments, then we will
                         // assume it is valid as written.
@@ -2984,7 +2984,7 @@ namespace Slang
             // us to look at the attribute declaration itself.
             //
             // Start by doing argument/parameter matching
-            UInt argCount = attr->args.Count();
+            UInt argCount = attr->args.getSize();
             UInt paramCounter = 0;
             bool mismatch = false;
             for(auto paramDecl : attrDecl->getMembersOfType<ParamDecl>())
@@ -3317,9 +3317,9 @@ namespace Slang
             DeclRef<GenericDecl>        requirementGenDecl,
             RefPtr<WitnessTable>        witnessTable)
         {
-            if (genDecl.getDecl()->Members.Count() != requirementGenDecl.getDecl()->Members.Count())
+            if (genDecl.getDecl()->Members.getSize() != requirementGenDecl.getDecl()->Members.getSize())
                 return false;
-            for (UInt i = 0; i < genDecl.getDecl()->Members.Count(); i++)
+            for (UInt i = 0; i < genDecl.getDecl()->Members.getSize(); i++)
             {
                 auto genMbr = genDecl.getDecl()->Members[i];
                 auto requiredGenMbr = genDecl.getDecl()->Members[i];
@@ -4358,8 +4358,8 @@ namespace Slang
 
             // For there to be any hope of a match, the
             // two need to have the same number of parameters.
-            UInt paramCount = fstParams.Count();
-            if (paramCount != sndParams.Count())
+            UInt paramCount = fstParams.getSize();
+            if (paramCount != sndParams.getSize())
                 return false;
 
             // Now we'll walk through the parameters.
@@ -4416,8 +4416,8 @@ namespace Slang
             //
             // For now I'm going to assume/require that all declarations must
             // declare the signature in a way that matches exactly.
-            UInt constraintCount = fstConstraints.Count();
-            if(constraintCount != sndConstraints.Count())
+            UInt constraintCount = fstConstraints.getSize();
+            if(constraintCount != sndConstraints.getSize())
                 return false;
 
             for (UInt cc = 0; cc < constraintCount; ++cc)
@@ -4448,8 +4448,8 @@ namespace Slang
 
             // If the functions have different numbers of parameters, then
             // their signatures trivially don't match.
-            auto fstParamCount = fstParams.Count();
-            auto sndParamCount = sndParams.Count();
+            auto fstParamCount = fstParams.getSize();
+            auto sndParamCount = sndParams.getSize();
             if (fstParamCount != sndParamCount)
                 return false;
 
@@ -4845,7 +4845,7 @@ namespace Slang
         template<typename T>
         T* FindOuterStmt()
         {
-            UInt outerStmtCount = outerStmts.Count();
+            UInt outerStmtCount = outerStmts.getSize();
             for (UInt ii = outerStmtCount; ii > 0; --ii)
             {
                 auto outerStmt = outerStmts[ii-1];
@@ -4882,7 +4882,7 @@ namespace Slang
 
         void PopOuterStmt(Stmt* /*stmt*/)
         {
-            outerStmts.RemoveAt(outerStmts.Count() - 1);
+            outerStmts.RemoveAt(outerStmts.getSize() - 1);
         }
 
         RefPtr<Expr> checkPredicateExpr(Expr* expr)
@@ -5220,7 +5220,7 @@ namespace Slang
 
             // Let's not constant-fold operations with more than a certain number of arguments, for simplicity
             static const int kMaxArgs = 8;
-            if (invokeExpr->Arguments.Count() > kMaxArgs)
+            if (invokeExpr->Arguments.getSize() > kMaxArgs)
                 return nullptr;
 
             // Before checking the operation name, let's look at the arguments
@@ -5602,7 +5602,7 @@ namespace Slang
 
         bool MatchArguments(FuncDecl * functionNode, List <RefPtr<Expr>> &args)
         {
-            if (functionNode->GetParameters().Count() != args.Count())
+            if (functionNode->GetParameters().Count() != args.getSize())
                 return false;
             int i = 0;
             for (auto param : functionNode->GetParameters())
@@ -6952,7 +6952,7 @@ namespace Slang
 
             // Note(tfoley): We might have fewer arguments than parameters in the
             // case where one or more parameters had defaults.
-            SLANG_RELEASE_ASSERT(argCount <= params.Count());
+            SLANG_RELEASE_ASSERT(argCount <= params.getSize());
 
             for (UInt ii = 0; ii < argCount; ++ii)
             {
@@ -7290,13 +7290,13 @@ namespace Slang
 
             bool keepThisCandidate = true; // should this candidate be kept?
 
-            if (context.bestCandidates.Count() != 0)
+            if (context.bestCandidates.getSize() != 0)
             {
                 // We have multiple candidates right now, so filter them.
                 bool anyFiltered = false;
                 // Note that we are querying the list length on every iteration,
                 // because we might remove things.
-                for (UInt cc = 0; cc < context.bestCandidates.Count(); ++cc)
+                for (UInt cc = 0; cc < context.bestCandidates.getSize(); ++cc)
                 {
                     int cmp = CompareOverloadCandidates(&candidate, &context.bestCandidates[cc]);
                     if (cmp < 0)
@@ -7344,7 +7344,7 @@ namespace Slang
                 return;
 
             // Otherwise we want to keep the candidate
-            if (context.bestCandidates.Count() > 0)
+            if (context.bestCandidates.getSize() > 0)
             {
                 // There were already multiple candidates, and we are adding one more
                 context.bestCandidates.Add(candidate);
@@ -7581,8 +7581,8 @@ namespace Slang
                 return false;
 
             // Their arguments must unify
-            SLANG_RELEASE_ASSERT(fstGen->args.Count() == sndGen->args.Count());
-            UInt argCount = fstGen->args.Count();
+            SLANG_RELEASE_ASSERT(fstGen->args.getSize() == sndGen->args.getSize());
+            UInt argCount = fstGen->args.getSize();
             bool okay = true;
             for (UInt aa = 0; aa < argCount; ++aa)
             {
@@ -7926,7 +7926,7 @@ namespace Slang
                 auto params = GetParameters(funcDeclRef).ToArray();
 
                 UInt argCount = context.getArgCount();
-                UInt paramCount = params.Count();
+                UInt paramCount = params.getSize();
 
                 // Bail out on mismatch.
                 // TODO(tfoley): need more nuance here
@@ -8418,7 +8418,7 @@ namespace Slang
             context.originalExpr = expr;
             context.funcLoc = funcExpr->loc;
 
-            context.argCount = expr->Arguments.Count();
+            context.argCount = expr->Arguments.getSize();
             context.args = expr->Arguments.Buffer();
             context.loc = expr->loc;
 
@@ -8440,7 +8440,7 @@ namespace Slang
                 AddOverloadCandidates(funcExpr, context);
             }
 
-            if (context.bestCandidates.Count() > 0)
+            if (context.bestCandidates.getSize() > 0)
             {
                 // Things were ambiguous.
 
@@ -8495,7 +8495,7 @@ namespace Slang
                 }
 
                 {
-                    UInt candidateCount = context.bestCandidates.Count();
+                    UInt candidateCount = context.bestCandidates.getSize();
                     UInt maxCandidatesToPrint = 10; // don't show too many candidates at once...
                     UInt candidateIndex = 0;
                     for (auto candidate : context.bestCandidates)
@@ -8634,7 +8634,7 @@ namespace Slang
             OverloadResolveContext context;
             context.originalExpr = genericAppExpr;
             context.funcLoc = baseExpr->loc;
-            context.argCount = args.Count();
+            context.argCount = args.getSize();
             context.args = args.Buffer();
             context.loc = genericAppExpr->loc;
 
@@ -8642,7 +8642,7 @@ namespace Slang
 
             AddGenericOverloadCandidates(baseExpr, context);
 
-            if (context.bestCandidates.Count() > 0)
+            if (context.bestCandidates.getSize() > 0)
             {
                 // Things were ambiguous.
                 if (context.bestCandidates[0].status != OverloadCandidate::Status::Applicable)
@@ -8748,7 +8748,7 @@ namespace Slang
                             // for an `inout` parameter to be converted in both
                             // directions.
                             //
-                            if( pp < expr->Arguments.Count() )
+                            if( pp < expr->Arguments.getSize() )
                             {
                                 auto argExpr = expr->Arguments[pp];
                                 if( !argExpr->type.IsLeftValue )
@@ -9135,7 +9135,7 @@ namespace Slang
                     {
                         // If we had some static items, then that's okay,
                         // we just want to use our newly-filtered list.
-                        if (staticItems.Count())
+                        if (staticItems.getSize())
                         {
                             lookupResult.items = staticItems;
                         }
@@ -9621,9 +9621,9 @@ namespace Slang
         ExistentialTypeSlots&       ioSlots,
         DeclRef<VarDeclBase>    paramDeclRef)
     {
-        UInt startSlot = ioSlots.paramTypes.Count();
+        UInt startSlot = ioSlots.paramTypes.getSize();
         _collectExistentialTypeParamsRec(ioSlots, paramDeclRef);
-        UInt endSlot = ioSlots.paramTypes.Count();
+        UInt endSlot = ioSlots.paramTypes.getSize();
         UInt slotCount = endSlot - startSlot;
 
         ioParamInfo.firstExistentialTypeSlot = startSlot;
@@ -9714,7 +9714,7 @@ namespace Slang
 
             if (attr)
             {
-                if (attr->args.Count() != 1)
+                if (attr->args.getSize() != 1)
                 {
                     sink->diagnose(attr, Diagnostics::badlyDefinedPatchConstantFunc, entryPointName);
                     return;
@@ -10112,8 +10112,8 @@ static bool validateGenericSubstitutionsMatch(
 
 
 
-    UInt argCount = left->args.Count();
-    if( argCount != right->args.Count() )
+    UInt argCount = left->args.getSize();
+    if( argCount != right->args.getSize() )
     {
         diagnoseTypeMismatch(sink, stack);
         return false;
@@ -10256,8 +10256,8 @@ static bool validateTypesMatch(
                         collectFields(leftStructDeclRef, leftFields);
                         collectFields(rightStructDeclRef, rightFields);
 
-                        UInt leftFieldCount = leftFields.Count();
-                        UInt rightFieldCount = rightFields.Count();
+                        UInt leftFieldCount = leftFields.getSize();
+                        UInt rightFieldCount = rightFields.getSize();
 
                         if( leftFieldCount != rightFieldCount )
                         {
@@ -10405,7 +10405,7 @@ static bool doesParameterMatch(
                     }
                 }
 
-                Int newParamIndex = Int(m_shaderParams.Count());
+                Int newParamIndex = Int(m_shaderParams.getSize());
                 mapNameToParamIndex.Add(paramName, newParamIndex);
 
                 GlobalShaderParamInfo shaderParamInfo;
@@ -10501,7 +10501,7 @@ static bool doesParameterMatch(
             // For now we'll start with an extremely basic approach that
             // should work for typical HLSL code.
             //
-            UInt translationUnitCount = compileRequest->translationUnits.Count();
+            UInt translationUnitCount = compileRequest->translationUnits.getSize();
             for(UInt tt = 0; tt < translationUnitCount; ++tt)
             {
                 auto translationUnit = compileRequest->translationUnits[tt];
@@ -10558,8 +10558,8 @@ static bool doesParameterMatch(
         List<RefPtr<Expr>> const&   args,
         DiagnosticSink*             sink)
     {
-        UInt slotCount = ioSlots.paramTypes.Count();
-        UInt argCount = args.Count();
+        UInt slotCount = ioSlots.paramTypes.getSize();
+        UInt argCount = args.getSize();
 
         if( slotCount != argCount )
         {
@@ -10811,11 +10811,11 @@ static bool doesParameterMatch(
         // An easy early-out case will be if the number of
         // arguments isn't correct.
         //
-        if (globalGenericParams.Count() != globalGenericArgs.Count())
+        if (globalGenericParams.getSize() != globalGenericArgs.getSize())
         {
             sink->diagnose(SourceLoc(), Diagnostics::mismatchGlobalGenericArguments,
-                globalGenericParams.Count(),
-                globalGenericArgs.Count());
+                globalGenericParams.getSize(),
+                globalGenericArgs.getSize());
             return nullptr;
         }
 
@@ -10852,7 +10852,7 @@ static bool doesParameterMatch(
         {
             // Get the argument that matches this parameter.
             UInt argIndex = argCounter++;
-            SLANG_ASSERT(argIndex < globalGenericArgs.Count());
+            SLANG_ASSERT(argIndex < globalGenericArgs.getSize());
             auto globalGenericArg = checkProperType(linkage, TypeExp(globalGenericArgs[argIndex]), sink);
             if (!globalGenericArg)
             {
@@ -11049,7 +11049,7 @@ static bool doesParameterMatch(
         // ahead and consider all the entry points that were found
         // by the front-end.
         //
-        UInt entryPointCount = endToEndReq->entryPoints.Count();
+        UInt entryPointCount = endToEndReq->entryPoints.getSize();
         if( entryPointCount == 0 )
         {
             entryPointCount = unspecializedProgram->getEntryPointCount();

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -1023,7 +1023,7 @@ namespace Slang
 
             for (auto argExpr : args)
             {
-                subst->args.Add(ExtractGenericArgVal(argExpr));
+                subst->args.add(ExtractGenericArgVal(argExpr));
             }
 
             DeclRef<Decl> innerDeclRef;
@@ -1219,7 +1219,7 @@ namespace Slang
 
                         // TODO: this is one place where syntax should get cloned!
                         if (outProperType)
-                            args.Add(typeParam->initType.exp);
+                            args.add(typeParam->initType.exp);
                     }
                     else if (auto valParam = as<GenericValueParamDecl>(member))
                     {
@@ -1235,7 +1235,7 @@ namespace Slang
 
                         // TODO: this is one place where syntax should get cloned!
                         if (outProperType)
-                            args.Add(valParam->initExpr);
+                            args.add(valParam->initExpr);
                     }
                     else
                     {
@@ -1637,7 +1637,7 @@ namespace Slang
 
                     if( coercedArg )
                     {
-                        coercedArgs.Add(coercedArg);
+                        coercedArgs.add(coercedArg);
                     }
                 }
             }
@@ -1685,7 +1685,7 @@ namespace Slang
 
                         if( coercedArg )
                         {
-                            coercedArgs.Add(coercedArg);
+                            coercedArgs.add(coercedArg);
                         }
                     }
                 }
@@ -1713,7 +1713,7 @@ namespace Slang
 
                         if( coercedArg )
                         {
-                            coercedArgs.Add(coercedArg);
+                            coercedArgs.add(coercedArg);
                         }
                     }
 
@@ -1775,7 +1775,7 @@ namespace Slang
 
                     if( coercedArg )
                     {
-                        coercedArgs.Add(coercedArg);
+                        coercedArgs.add(coercedArg);
                     }
                 }
             }
@@ -1803,7 +1803,7 @@ namespace Slang
 
                         if( coercedArg )
                         {
-                            coercedArgs.Add(coercedArg);
+                            coercedArgs.add(coercedArg);
                         }
                     }
                 }
@@ -2159,7 +2159,7 @@ namespace Slang
                     //
                     auto castExpr = createImplicitCastExpr();
                     castExpr->loc = fromExpr->loc;
-                    castExpr->Arguments.Add(fromExpr);
+                    castExpr->Arguments.add(fromExpr);
                     //
                     // Next we need to set our cast expression as the "original"
                     // expression and then complete the overload process.
@@ -2182,7 +2182,7 @@ namespace Slang
                     // but I'd rather play it safe.
                     //
                     castExpr->Arguments.Clear();
-                    castExpr->Arguments.Add(fromExpr);
+                    castExpr->Arguments.add(fromExpr);
                 }
 
                 return true;
@@ -2275,7 +2275,7 @@ namespace Slang
             castExpr->loc = fromExpr->loc;
             castExpr->FunctionExpr = typeExpr;
             castExpr->type = QualType(toType);
-            castExpr->Arguments.Add(fromExpr);
+            castExpr->Arguments.add(fromExpr);
             return castExpr;
         }
 
@@ -2663,11 +2663,11 @@ namespace Slang
                     param->nameAndLoc = member->nameAndLoc;
                     param->type = varMember->type;
                     param->loc = member->loc;
-                    attribDecl->Members.Add(param);
+                    attribDecl->Members.add(param);
                 }
             }
             // add the attribute class definition to the syntax tree, so it can be found
-            structAttribDef->ParentDecl->Members.Add(attribDecl.Ptr());
+            structAttribDef->ParentDecl->Members.add(attribDecl.Ptr());
             structAttribDef->ParentDecl->memberDictionaryIsValid = false;
             // do necessary checks on this newly constructed node
             checkDecl(attribDecl.Ptr());
@@ -3008,7 +3008,7 @@ namespace Slang
                         // default arguments as needed.
                         // For now just copy the expression over.
 
-                        attr->args.Add(paramDecl->initExpr);
+                        attr->args.add(paramDecl->initExpr);
                     }
                     else
                     {
@@ -4049,7 +4049,7 @@ namespace Slang
                     enumConformanceDecl->ParentDecl = decl;
                     enumConformanceDecl->loc = decl->loc;
                     enumConformanceDecl->base.type = getSession()->getEnumTypeType();
-                    decl->Members.Add(enumConformanceDecl);
+                    decl->Members.add(enumConformanceDecl);
 
                     // The `__EnumType` interface has one required member, the `__Tag` type.
                     // We need to satisfy this requirement automatically, rather than require
@@ -4329,11 +4329,11 @@ namespace Slang
                     continue;
 
                 if (auto typeParamDecl = as<GenericTypeParamDecl>(dd))
-                    outParams.Add(typeParamDecl);
+                    outParams.add(typeParamDecl);
                 else if (auto valueParamDecl = as<GenericValueParamDecl>(dd))
-                    outParams.Add(valueParamDecl);
+                    outParams.add(valueParamDecl);
                 else if (auto constraintDecl = as<GenericTypeConstraintDecl>(dd))
-                    outConstraints.Add(constraintDecl);
+                    outConstraints.add(constraintDecl);
             }
         }
 
@@ -4495,13 +4495,13 @@ namespace Slang
                 {
                     auto type = DeclRefType::Create(getSession(),
                         makeDeclRef(typeParam));
-                    subst->args.Add(type);
+                    subst->args.add(type);
                 }
                 else if (auto valueParam = as<GenericValueParamDecl>(dd))
                 {
                     auto val = new GenericParamIntVal(
                         makeDeclRef(valueParam));
-                    subst->args.Add(val);
+                    subst->args.add(val);
                 }
                 // TODO: need to handle constraints here?
             }
@@ -4877,7 +4877,7 @@ namespace Slang
 
         void PushOuterStmt(Stmt* stmt)
         {
-            outerStmts.Add(stmt);
+            outerStmts.add(stmt);
         }
 
         void PopOuterStmt(Stmt* /*stmt*/)
@@ -5483,8 +5483,8 @@ namespace Slang
 
             auto substitutions = new GenericSubstitution();
             substitutions->genericDecl = vectorGenericDecl.Ptr();
-            substitutions->args.Add(elementType);
-            substitutions->args.Add(elementCount);
+            substitutions->args.add(elementType);
+            substitutions->args.add(elementCount);
 
             auto declRef = DeclRef<Decl>(vectorTypeDecl.Ptr(), substitutions);
 
@@ -5588,7 +5588,7 @@ namespace Slang
                 subscriptCallExpr->FunctionExpr = subscriptFuncExpr;
 
                 // TODO(tfoley): This path can support multiple arguments easily
-                subscriptCallExpr->Arguments.Add(subscriptExpr->IndexExpression);
+                subscriptCallExpr->Arguments.add(subscriptExpr->IndexExpression);
 
                 return CheckInvokeExprWithCheckedOperands(subscriptCallExpr.Ptr());
             }
@@ -5832,7 +5832,7 @@ namespace Slang
                 getterDecl->loc = decl->loc;
 
                 getterDecl->ParentDecl = decl;
-                decl->Members.Add(getterDecl);
+                decl->Members.add(getterDecl);
             }
 
             for(auto mm : decl->Members)
@@ -6221,7 +6221,7 @@ namespace Slang
 
                     if(outWitness)
                     {
-                        caseWitnesses.Add(caseWitness);
+                        caseWitnesses.add(caseWitness);
                     }
                 }
 
@@ -6556,7 +6556,7 @@ namespace Slang
                         // failure!
                         return SubstitutionSet();
                     }
-                    args.Add(type);
+                    args.add(type);
                 }
                 else if (auto valParam = m.as<GenericValueParamDecl>())
                 {
@@ -6593,7 +6593,7 @@ namespace Slang
                         // failure!
                         return SubstitutionSet();
                     }
-                    args.Add(val);
+                    args.add(val);
                 }
                 else
                 {
@@ -6638,7 +6638,7 @@ namespace Slang
                 if(subTypeWitness)
                 {
                     // We found a witness, so it will become an (implicit) argument.
-                    solvedSubst->args.Add(subTypeWitness);
+                    solvedSubst->args.add(subTypeWitness);
                 }
                 else
                 {
@@ -6899,7 +6899,7 @@ namespace Slang
                     {
                         typeExp = CoerceToProperType(TypeExp(arg));
                     }
-                    checkedArgs.Add(typeExp.type);
+                    checkedArgs.add(typeExp.type);
                 }
                 else if (auto valParamRef = memberRef.as<GenericValueParamDecl>())
                 {
@@ -6917,7 +6917,7 @@ namespace Slang
 
                     arg = coerce(GetType(valParamRef), arg);
                     auto val = ExtractGenericArgInteger(arg);
-                    checkedArgs.Add(val);
+                    checkedArgs.add(val);
                 }
                 else
                 {
@@ -7072,7 +7072,7 @@ namespace Slang
                 auto subTypeWitness = tryGetSubtypeWitness(sub, sup);
                 if(subTypeWitness)
                 {
-                    subst->args.Add(subTypeWitness);
+                    subst->args.add(subTypeWitness);
                 }
                 else
                 {
@@ -7207,7 +7207,7 @@ namespace Slang
                             callExpr->loc = context.loc;
 
                             for(UInt aa = 0; aa < context.argCount; ++aa)
-                                callExpr->Arguments.Add(context.getArg(aa));
+                                callExpr->Arguments.add(context.getArg(aa));
                         }
 
 
@@ -7347,13 +7347,13 @@ namespace Slang
             if (context.bestCandidates.getSize() > 0)
             {
                 // There were already multiple candidates, and we are adding one more
-                context.bestCandidates.Add(candidate);
+                context.bestCandidates.add(candidate);
             }
             else if (context.bestCandidate)
             {
                 // There was a unique best candidate, but now we are ambiguous
-                context.bestCandidates.Add(*context.bestCandidate);
-                context.bestCandidates.Add(candidate);
+                context.bestCandidates.add(*context.bestCandidate);
+                context.bestCandidates.add(candidate);
                 context.bestCandidate = nullptr;
             }
             else
@@ -7612,7 +7612,7 @@ namespace Slang
             constraint.decl = typeParamDecl.Ptr();
             constraint.val = type;
 
-            constraints.constraints.Add(constraint);
+            constraints.constraints.add(constraint);
 
             return true;
         }
@@ -7635,7 +7635,7 @@ namespace Slang
             constraint.decl = paramDecl.Ptr();
             constraint.val = val;
 
-            constraints.constraints.Add(constraint);
+            constraints.constraints.add(constraint);
 
             return true;
         }
@@ -8666,7 +8666,7 @@ namespace Slang
                     for (auto candidate : context.bestCandidates)
                     {
                         auto candidateExpr = CompleteOverloadCandidate(context, candidate);
-                        overloadedExpr->candidiateExprs.Add(candidateExpr);
+                        overloadedExpr->candidiateExprs.add(candidateExpr);
                     }
                     return overloadedExpr;
                 }
@@ -8708,7 +8708,7 @@ namespace Slang
             for( auto& caseTypeExpr : expr->caseTypes )
             {
                 caseTypeExpr = CheckProperType(caseTypeExpr);
-                type->caseTypes.Add(caseTypeExpr.type);
+                type->caseTypes.add(caseTypeExpr.type);
             }
 
             return expr;
@@ -9121,7 +9121,7 @@ namespace Slang
                         if (isUsableAsStaticMember(item))
                         {
                             // If yes, then it will be part of the output.
-                            staticItems.Add(item);
+                            staticItems.add(item);
                         }
                         else
                         {
@@ -9585,7 +9585,7 @@ namespace Slang
             {
                 // Each leaf parameter of interface type adds one slot.
                 //
-                ioSlots.paramTypes.Add(type);
+                ioSlots.paramTypes.add(type);
             }
             else if( auto structDeclRef = typeDeclRef.as<StructDecl>() )
             {
@@ -9652,7 +9652,7 @@ namespace Slang
                     m_existentialSlots,
                     paramDeclRef);
 
-                m_shaderParams.Add(shaderParamInfo);
+                m_shaderParams.add(shaderParamInfo);
             }
         }
     }
@@ -10033,7 +10033,7 @@ static void collectFields(
         if(fieldDeclRef.getDecl()->HasModifier<HLSLStaticModifier>())
             continue;
 
-        outFields.Add(fieldDeclRef);
+        outFields.add(fieldDeclRef);
     }
 }
 
@@ -10399,7 +10399,7 @@ static bool doesParameterMatch(
                         // consider the new variable to be a redclaration of
                         // the existing one.
 
-                        existingParam.additionalParamDeclRefs.Add(
+                        existingParam.additionalParamDeclRefs.add(
                             makeDeclRef(globalVar.Ptr()));
                         continue;
                     }
@@ -10416,7 +10416,7 @@ static bool doesParameterMatch(
                     m_globalExistentialSlots,
                     makeDeclRef(globalVar.Ptr()));
 
-                m_shaderParams.Add(shaderParamInfo);
+                m_shaderParams.add(shaderParamInfo);
             }
         }
     }
@@ -10476,7 +10476,7 @@ static bool doesParameterMatch(
                 if( entryPoint )
                 {
                     program->addEntryPoint(entryPoint);
-                    entryPointReq->getTranslationUnit()->entryPoints.Add(entryPoint);
+                    entryPointReq->getTranslationUnit()->entryPoints.add(entryPoint);
                 }
             }
 
@@ -10542,7 +10542,7 @@ static bool doesParameterMatch(
                     validateEntryPoint(entryPoint, sink);
 
                     program->addEntryPoint(entryPoint);
-                    translationUnit->entryPoints.Add(entryPoint);
+                    translationUnit->entryPoints.add(entryPoint);
                 }
             }
         }
@@ -10597,7 +10597,7 @@ static bool doesParameterMatch(
             ExistentialTypeSlots::Arg arg;
             arg.type = argType;
             arg.witness = witness;
-            ioSlots.args.Add(arg);
+            ioSlots.args.add(arg);
         }
     }
 
@@ -10722,7 +10722,7 @@ static bool doesParameterMatch(
         //
         List<RefPtr<Scope>> scopesToTry;
         for( auto module : unspecialiedProgram->getModuleDependencies() )
-            scopesToTry.Add(module->getModuleDecl()->scope);
+            scopesToTry.add(module->getModuleDecl()->scope);
 
         // We are going to do some semantic checking, so we need to
         // set up a `SemanticsVistitor` that we can use.
@@ -10753,7 +10753,7 @@ static bool doesParameterMatch(
                 }
             }
 
-            outGenericArgs.Add(argExpr);
+            outGenericArgs.add(argExpr);
         }
     }
 
@@ -10802,7 +10802,7 @@ static bool doesParameterMatch(
         for(auto module : unspecializedProgram->getModuleDependencies())
         {
             for(auto param : module->getModuleDecl()->getMembersOfType<GlobalGenericParamDecl>())
-                globalGenericParams.Add(param);
+                globalGenericParams.add(param);
         }
 
         // Next, we will check whether the supplied arguments can
@@ -10919,7 +10919,7 @@ static bool doesParameterMatch(
                 GlobalGenericParamSubstitution::ConstraintArg constraintArg;
                 constraintArg.decl = constraint;
                 constraintArg.val = witness;
-                subst->constraintArgs.Add(constraintArg);
+                subst->constraintArgs.add(constraintArg);
             }
 
             // Add the substitution for this parameter to the global substitution
@@ -11228,11 +11228,11 @@ static bool doesParameterMatch(
         {
             if( auto genericTypeParamDecl = as<GenericTypeParamDecl>(mm) )
             {
-                genericSubst->args.Add(DeclRefType::Create(session, DeclRef<Decl>(genericTypeParamDecl, outerSubst)));
+                genericSubst->args.add(DeclRefType::Create(session, DeclRef<Decl>(genericTypeParamDecl, outerSubst)));
             }
             else if( auto genericValueParamDecl = as<GenericValueParamDecl>(mm) )
             {
-                genericSubst->args.Add(new GenericParamIntVal(DeclRef<GenericValueParamDecl>(genericValueParamDecl, outerSubst)));
+                genericSubst->args.add(new GenericParamIntVal(DeclRef<GenericValueParamDecl>(genericValueParamDecl, outerSubst)));
             }
         }
 
@@ -11245,7 +11245,7 @@ static bool doesParameterMatch(
                 witness->declRef = DeclRef<Decl>(genericTypeConstraintDecl, outerSubst);
                 witness->sub = genericTypeConstraintDecl->sub.type;
                 witness->sup = genericTypeConstraintDecl->sup.type;
-                genericSubst->args.Add(witness);
+                genericSubst->args.add(witness);
             }
         }
 

--- a/source/slang/check.cpp
+++ b/source/slang/check.cpp
@@ -11053,7 +11053,7 @@ static bool doesParameterMatch(
         if( entryPointCount == 0 )
         {
             entryPointCount = unspecializedProgram->getEntryPointCount();
-            endToEndReq->entryPoints.SetSize(entryPointCount);
+            endToEndReq->entryPoints.setSize(entryPointCount);
         }
 
         for( UInt ii = 0; ii < entryPointCount; ++ii )

--- a/source/slang/compiler.cpp
+++ b/source/slang/compiler.cpp
@@ -221,7 +221,7 @@ namespace Slang
                 {
                     if( auto taggedUnionType = as<TaggedUnionType>(arg) )
                     {
-                        m_taggedUnionTypes.Add(taggedUnionType);
+                        m_taggedUnionTypes.add(taggedUnionType);
                     }
                 }
             }
@@ -706,17 +706,17 @@ namespace Slang
                 D3D_SHADER_MACRO dxMacro;
                 dxMacro.Name = define.Key.Buffer();
                 dxMacro.Definition = define.Value.Buffer();
-                dxMacrosStorage.Add(dxMacro);
+                dxMacrosStorage.add(dxMacro);
             }
             for( auto& define : translationUnit->preprocessorDefinitions )
             {
                 D3D_SHADER_MACRO dxMacro;
                 dxMacro.Name = define.Key.Buffer();
                 dxMacro.Definition = define.Value.Buffer();
-                dxMacrosStorage.Add(dxMacro);
+                dxMacrosStorage.add(dxMacro);
             }
             D3D_SHADER_MACRO nullTerminator = { 0, 0 };
-            dxMacrosStorage.Add(nullTerminator);
+            dxMacrosStorage.add(nullTerminator);
 
             dxMacros = dxMacrosStorage.Buffer();
         }

--- a/source/slang/compiler.cpp
+++ b/source/slang/compiler.cpp
@@ -94,7 +94,7 @@ namespace Slang
         }
         else if (appendTo == ResultFormat::Binary)
         {
-            outputBinary.addRange(result.outputBinary.Buffer(), result.outputBinary.getSize());
+            outputBinary.addRange(result.outputBinary.getBuffer(), result.outputBinary.getCount());
         }
     }
 
@@ -113,7 +113,7 @@ namespace Slang
                 break;
 
             case ResultFormat::Binary:
-                blob = createRawBlob(outputBinary.Buffer(), outputBinary.getSize());
+                blob = createRawBlob(outputBinary.getBuffer(), outputBinary.getCount());
                 break;
             }
         }
@@ -634,7 +634,7 @@ namespace Slang
 
         const auto& sourceFiles = translationUnitRequest->getSourceFiles();
 
-        const int numSourceFiles = int(sourceFiles.getSize());
+        const int numSourceFiles = int(sourceFiles.getCount());
 
         switch (numSourceFiles)
         {
@@ -718,7 +718,7 @@ namespace Slang
             D3D_SHADER_MACRO nullTerminator = { 0, 0 };
             dxMacrosStorage.add(nullTerminator);
 
-            dxMacros = dxMacrosStorage.Buffer();
+            dxMacros = dxMacrosStorage.getBuffer();
         }
 
         DWORD flags = 0;
@@ -853,11 +853,11 @@ namespace Slang
             targetReq,
             endToEndReq,
             dxbc));
-        if (!dxbc.getSize())
+        if (!dxbc.getCount())
         {
             return SLANG_FAIL;
         }
-        return dissassembleDXBC(compileRequest, dxbc.Buffer(), dxbc.getSize(), assemOut);
+        return dissassembleDXBC(compileRequest, dxbc.getBuffer(), dxbc.getCount(), assemOut);
     }
 #endif
 
@@ -1004,10 +1004,10 @@ SlangResult dissassembleDXILUsingDXC(
             endToEndReq,
             spirv));
 
-        if (spirv.getSize() == 0)
+        if (spirv.getCount() == 0)
             return SLANG_FAIL;
 
-        return dissassembleSPIRV(slangRequest, spirv.begin(), spirv.getSize(), assemblyOut);
+        return dissassembleSPIRV(slangRequest, spirv.begin(), spirv.getCount(), assemblyOut);
     }
 #endif
 
@@ -1063,7 +1063,7 @@ SlangResult dissassembleDXILUsingDXC(
                     endToEndReq,
                     code)))
                 {
-                    maybeDumpIntermediate(compileRequest, code.Buffer(), code.getSize(), target);
+                    maybeDumpIntermediate(compileRequest, code.getBuffer(), code.getCount(), target);
                     result = CompileResult(code);
                 }
             }
@@ -1099,7 +1099,7 @@ SlangResult dissassembleDXILUsingDXC(
                     endToEndReq,
                     code)))
                 {
-                    maybeDumpIntermediate(compileRequest, code.Buffer(), code.getSize(), target);
+                    maybeDumpIntermediate(compileRequest, code.getBuffer(), code.getCount(), target);
                     result = CompileResult(code);
                 }
             }
@@ -1119,8 +1119,8 @@ SlangResult dissassembleDXILUsingDXC(
                     String assembly; 
                     dissassembleDXILUsingDXC(
                         compileRequest,
-                        code.Buffer(),
-                        code.getSize(), 
+                        code.getBuffer(),
+                        code.getCount(), 
                         assembly);
 
                     maybeDumpIntermediate(compileRequest, assembly.Buffer(), target);
@@ -1142,7 +1142,7 @@ SlangResult dissassembleDXILUsingDXC(
                     endToEndReq,
                     code)))
                 {
-                    maybeDumpIntermediate(compileRequest, code.Buffer(), code.getSize(), target);
+                    maybeDumpIntermediate(compileRequest, code.getBuffer(), code.getCount(), target);
                     result = CompileResult(code);
                 }
             }

--- a/source/slang/compiler.cpp
+++ b/source/slang/compiler.cpp
@@ -634,7 +634,7 @@ namespace Slang
 
         const auto& sourceFiles = translationUnitRequest->getSourceFiles();
 
-        const int numSourceFiles = int(sourceFiles.getCount());
+        const Index numSourceFiles = sourceFiles.getCount();
 
         switch (numSourceFiles)
         {
@@ -1425,7 +1425,7 @@ SlangResult dissassembleDXILUsingDXC(
         // Generate target code any entry points that
         // have been requested for compilation.
         auto entryPointCount = program->getEntryPointCount();
-        for(UInt ii = 0; ii < entryPointCount; ++ii)
+        for(Index ii = 0; ii < entryPointCount; ++ii)
         {
             auto entryPoint = program->getEntryPoint(ii);
             CompileResult entryPointResult = emitEntryPoint(
@@ -1472,8 +1472,8 @@ SlangResult dissassembleDXILUsingDXC(
             auto program = compileRequest->getSpecializedProgram();
             for (auto targetReq : linkage->targets)
             {
-                UInt entryPointCount = program->getEntryPointCount();
-                for (UInt ee = 0; ee < entryPointCount; ++ee)
+                Index entryPointCount = program->getEntryPointCount();
+                for (Index ee = 0; ee < entryPointCount; ++ee)
                 {
                     writeEntryPointResult(
                         compileRequest,

--- a/source/slang/compiler.cpp
+++ b/source/slang/compiler.cpp
@@ -774,7 +774,7 @@ namespace Slang
         ComPtr<ID3DBlob> diagnosticsBlob;
         HRESULT hr = compileFunc(
             hlslCode.begin(),
-            hlslCode.Length(),
+            hlslCode.getLength(),
             sourcePath.Buffer(),
             dxMacros,
             nullptr,
@@ -1287,7 +1287,7 @@ SlangResult dissassembleDXILUsingDXC(
         ISlangWriter* writer,
         String const&   text)
     {
-        writer->write(text.Buffer(), text.Length());
+        writer->write(text.Buffer(), text.getLength());
     }
 
     static void writeEntryPointResultToStandardOutput(
@@ -1578,7 +1578,7 @@ SlangResult dissassembleDXILUsingDXC(
             {
                 String spirvAssembly;
                 dissassembleSPIRV(compileRequest, data, size, spirvAssembly);
-                dumpIntermediateText(compileRequest, spirvAssembly.begin(), spirvAssembly.Length(), ".spv.asm");
+                dumpIntermediateText(compileRequest, spirvAssembly.begin(), spirvAssembly.getLength(), ".spv.asm");
             }
             break;
 
@@ -1592,7 +1592,7 @@ SlangResult dissassembleDXILUsingDXC(
             {
                 String dxbcAssembly;
                 dissassembleDXBC(compileRequest, data, size, dxbcAssembly);
-                dumpIntermediateText(compileRequest, dxbcAssembly.begin(), dxbcAssembly.Length(), ".dxbc.asm");
+                dumpIntermediateText(compileRequest, dxbcAssembly.begin(), dxbcAssembly.getLength(), ".dxbc.asm");
             }
             break;
     #endif
@@ -1607,7 +1607,7 @@ SlangResult dissassembleDXILUsingDXC(
             {
                 String dxilAssembly;
                 dissassembleDXILUsingDXC(compileRequest, data, size, dxilAssembly);
-                dumpIntermediateText(compileRequest, dxilAssembly.begin(), dxilAssembly.Length(), ".dxil.asm");
+                dumpIntermediateText(compileRequest, dxilAssembly.begin(), dxilAssembly.getLength(), ".dxil.asm");
             }
             break;
     #endif

--- a/source/slang/compiler.cpp
+++ b/source/slang/compiler.cpp
@@ -90,7 +90,7 @@ namespace Slang
 
         if (appendTo == ResultFormat::Text)
         {
-            outputString.append(result.outputString.Buffer());
+            outputString.append(result.outputString.getBuffer());
         }
         else if (appendTo == ResultFormat::Binary)
         {
@@ -687,7 +687,7 @@ namespace Slang
         }
 
         auto hlslCode = emitHLSLForEntryPoint(compileRequest, entryPoint, entryPointIndex, targetReq, endToEndReq);
-        maybeDumpIntermediate(compileRequest, hlslCode.Buffer(), CodeGenTarget::HLSL);
+        maybeDumpIntermediate(compileRequest, hlslCode.getBuffer(), CodeGenTarget::HLSL);
 
         auto profile = getEffectiveProfile(entryPoint, targetReq);
 
@@ -704,15 +704,15 @@ namespace Slang
             for( auto& define :  translationUnit->compileRequest->preprocessorDefinitions )
             {
                 D3D_SHADER_MACRO dxMacro;
-                dxMacro.Name = define.Key.Buffer();
-                dxMacro.Definition = define.Value.Buffer();
+                dxMacro.Name = define.Key.getBuffer();
+                dxMacro.Definition = define.Value.getBuffer();
                 dxMacrosStorage.add(dxMacro);
             }
             for( auto& define : translationUnit->preprocessorDefinitions )
             {
                 D3D_SHADER_MACRO dxMacro;
-                dxMacro.Name = define.Key.Buffer();
-                dxMacro.Definition = define.Value.Buffer();
+                dxMacro.Name = define.Key.getBuffer();
+                dxMacro.Definition = define.Value.getBuffer();
                 dxMacrosStorage.add(dxMacro);
             }
             D3D_SHADER_MACRO nullTerminator = { 0, 0 };
@@ -775,11 +775,11 @@ namespace Slang
         HRESULT hr = compileFunc(
             hlslCode.begin(),
             hlslCode.getLength(),
-            sourcePath.Buffer(),
+            sourcePath.getBuffer(),
             dxMacros,
             nullptr,
             getText(entryPoint->getName()).begin(),
-            GetHLSLProfileName(profile).Buffer(),
+            GetHLSLProfileName(profile).getBuffer(),
             flags,
             0, // unused: effect flags
             codeBlob.writeRef(),
@@ -963,7 +963,7 @@ SlangResult dissassembleDXILUsingDXC(
             entryPointIndex,
             targetReq,
             endToEndReq);
-        maybeDumpIntermediate(slangRequest, rawGLSL.Buffer(), CodeGenTarget::GLSL);
+        maybeDumpIntermediate(slangRequest, rawGLSL.getBuffer(), CodeGenTarget::GLSL);
 
         auto outputFunc = [](void const* data, size_t size, void* userData)
         {
@@ -974,7 +974,7 @@ SlangResult dissassembleDXILUsingDXC(
 
         glslang_CompileRequest request;
         request.action = GLSLANG_ACTION_COMPILE_GLSL_TO_SPIRV;
-        request.sourcePath = sourcePath.Buffer();
+        request.sourcePath = sourcePath.getBuffer();
         request.slangStage = (SlangStage)entryPoint->getStage();
 
         request.inputBegin  = rawGLSL.begin();
@@ -1033,7 +1033,7 @@ SlangResult dissassembleDXILUsingDXC(
                     entryPointIndex,
                     targetReq,
                     endToEndReq);
-                maybeDumpIntermediate(compileRequest, code.Buffer(), target);
+                maybeDumpIntermediate(compileRequest, code.getBuffer(), target);
                 result = CompileResult(code);
             }
             break;
@@ -1046,7 +1046,7 @@ SlangResult dissassembleDXILUsingDXC(
                     entryPointIndex,
                     targetReq,
                     endToEndReq);
-                maybeDumpIntermediate(compileRequest, code.Buffer(), target);
+                maybeDumpIntermediate(compileRequest, code.getBuffer(), target);
                 result = CompileResult(code);
             }
             break;
@@ -1080,7 +1080,7 @@ SlangResult dissassembleDXILUsingDXC(
                     endToEndReq,
                     code)))
                 {
-                    maybeDumpIntermediate(compileRequest, code.Buffer(), target);
+                    maybeDumpIntermediate(compileRequest, code.getBuffer(), target);
                     result = CompileResult(code);
                 }
             }
@@ -1123,7 +1123,7 @@ SlangResult dissassembleDXILUsingDXC(
                         code.getCount(), 
                         assembly);
 
-                    maybeDumpIntermediate(compileRequest, assembly.Buffer(), target);
+                    maybeDumpIntermediate(compileRequest, assembly.getBuffer(), target);
 
                     result = CompileResult(assembly);
                 }
@@ -1159,7 +1159,7 @@ SlangResult dissassembleDXILUsingDXC(
                     endToEndReq,
                     code)))
                 {
-                    maybeDumpIntermediate(compileRequest, code.Buffer(), target);
+                    maybeDumpIntermediate(compileRequest, code.getBuffer(), target);
                     result = CompileResult(code);
                 }
             }
@@ -1229,7 +1229,7 @@ SlangResult dissassembleDXILUsingDXC(
         OutputFileKind          kind)
     {
         FILE* file = fopen(
-            path.Buffer(),
+            path.getBuffer(),
             kind == OutputFileKind::Binary ? "wb" : "w");
         if (!file)
         {
@@ -1287,7 +1287,7 @@ SlangResult dissassembleDXILUsingDXC(
         ISlangWriter* writer,
         String const&   text)
     {
-        writer->write(text.Buffer(), text.getLength());
+        writer->write(text.getBuffer(), text.getLength());
     }
 
     static void writeEntryPointResultToStandardOutput(
@@ -1516,7 +1516,7 @@ SlangResult dissassembleDXILUsingDXC(
         path.append(id);
         path.append(ext);
 
-        FILE* file = fopen(path.Buffer(), isBinary ? "wb" : "w");
+        FILE* file = fopen(path.getBuffer(), isBinary ? "wb" : "w");
         if (!file) return;
 
         fwrite(data, size, 1, file);

--- a/source/slang/compiler.cpp
+++ b/source/slang/compiler.cpp
@@ -94,7 +94,7 @@ namespace Slang
         }
         else if (appendTo == ResultFormat::Binary)
         {
-            outputBinary.AddRange(result.outputBinary.Buffer(), result.outputBinary.Count());
+            outputBinary.AddRange(result.outputBinary.Buffer(), result.outputBinary.getSize());
         }
     }
 
@@ -113,7 +113,7 @@ namespace Slang
                 break;
 
             case ResultFormat::Binary:
-                blob = createRawBlob(outputBinary.Buffer(), outputBinary.Count());
+                blob = createRawBlob(outputBinary.Buffer(), outputBinary.getSize());
                 break;
             }
         }
@@ -634,7 +634,7 @@ namespace Slang
 
         const auto& sourceFiles = translationUnitRequest->getSourceFiles();
 
-        const int numSourceFiles = int(sourceFiles.Count());
+        const int numSourceFiles = int(sourceFiles.getSize());
 
         switch (numSourceFiles)
         {
@@ -853,11 +853,11 @@ namespace Slang
             targetReq,
             endToEndReq,
             dxbc));
-        if (!dxbc.Count())
+        if (!dxbc.getSize())
         {
             return SLANG_FAIL;
         }
-        return dissassembleDXBC(compileRequest, dxbc.Buffer(), dxbc.Count(), assemOut);
+        return dissassembleDXBC(compileRequest, dxbc.Buffer(), dxbc.getSize(), assemOut);
     }
 #endif
 
@@ -1004,10 +1004,10 @@ SlangResult dissassembleDXILUsingDXC(
             endToEndReq,
             spirv));
 
-        if (spirv.Count() == 0)
+        if (spirv.getSize() == 0)
             return SLANG_FAIL;
 
-        return dissassembleSPIRV(slangRequest, spirv.begin(), spirv.Count(), assemblyOut);
+        return dissassembleSPIRV(slangRequest, spirv.begin(), spirv.getSize(), assemblyOut);
     }
 #endif
 
@@ -1063,7 +1063,7 @@ SlangResult dissassembleDXILUsingDXC(
                     endToEndReq,
                     code)))
                 {
-                    maybeDumpIntermediate(compileRequest, code.Buffer(), code.Count(), target);
+                    maybeDumpIntermediate(compileRequest, code.Buffer(), code.getSize(), target);
                     result = CompileResult(code);
                 }
             }
@@ -1099,7 +1099,7 @@ SlangResult dissassembleDXILUsingDXC(
                     endToEndReq,
                     code)))
                 {
-                    maybeDumpIntermediate(compileRequest, code.Buffer(), code.Count(), target);
+                    maybeDumpIntermediate(compileRequest, code.Buffer(), code.getSize(), target);
                     result = CompileResult(code);
                 }
             }
@@ -1120,7 +1120,7 @@ SlangResult dissassembleDXILUsingDXC(
                     dissassembleDXILUsingDXC(
                         compileRequest,
                         code.Buffer(),
-                        code.Count(), 
+                        code.getSize(), 
                         assembly);
 
                     maybeDumpIntermediate(compileRequest, assembly.Buffer(), target);
@@ -1142,7 +1142,7 @@ SlangResult dissassembleDXILUsingDXC(
                     endToEndReq,
                     code)))
                 {
-                    maybeDumpIntermediate(compileRequest, code.Buffer(), code.Count(), target);
+                    maybeDumpIntermediate(compileRequest, code.Buffer(), code.getSize(), target);
                     result = CompileResult(code);
                 }
             }

--- a/source/slang/compiler.cpp
+++ b/source/slang/compiler.cpp
@@ -94,7 +94,7 @@ namespace Slang
         }
         else if (appendTo == ResultFormat::Binary)
         {
-            outputBinary.AddRange(result.outputBinary.Buffer(), result.outputBinary.getSize());
+            outputBinary.addRange(result.outputBinary.Buffer(), result.outputBinary.getSize());
         }
     }
 
@@ -675,7 +675,7 @@ namespace Slang
         EndToEndCompileRequest* endToEndReq,
         List<uint8_t>&          byteCodeOut)
     {
-        byteCodeOut.Clear();
+        byteCodeOut.clear();
 
         auto session = compileRequest->getSession();
         auto sink = compileRequest->getSink();
@@ -787,7 +787,7 @@ namespace Slang
 
         if (codeBlob && SLANG_SUCCEEDED(hr))
         {
-            byteCodeOut.AddRange((uint8_t const*)codeBlob->GetBufferPointer(), (int)codeBlob->GetBufferSize());
+            byteCodeOut.addRange((uint8_t const*)codeBlob->GetBufferPointer(), (int)codeBlob->GetBufferSize());
         }
 
         if (FAILED(hr))
@@ -955,7 +955,7 @@ SlangResult dissassembleDXILUsingDXC(
         EndToEndCompileRequest* endToEndReq,
         List<uint8_t>&          spirvOut)
     {
-        spirvOut.Clear();
+        spirvOut.clear();
 
         String rawGLSL = emitGLSLForEntryPoint(
             slangRequest,
@@ -967,7 +967,7 @@ SlangResult dissassembleDXILUsingDXC(
 
         auto outputFunc = [](void const* data, size_t size, void* userData)
         {
-            ((List<uint8_t>*)userData)->AddRange((uint8_t*)data, size);
+            ((List<uint8_t>*)userData)->addRange((uint8_t*)data, size);
         };
 
         const String sourcePath = calcSourcePathForEntryPoint(endToEndReq, entryPointIndex);

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -321,19 +321,19 @@ namespace Slang
             Profile     profile);
 
             /// Get the number of existential type parameters for the entry point.
-        UInt getExistentialTypeParamCount() { return m_existentialSlots.paramTypes.getCount(); }
+        Index getExistentialTypeParamCount() { return m_existentialSlots.paramTypes.getCount(); }
 
             /// Get the existential type parameter at `index`.
-        Type* getExistentialTypeParam(UInt index) { return m_existentialSlots.paramTypes[index]; }
+        Type* getExistentialTypeParam(Index index) { return m_existentialSlots.paramTypes[index]; }
 
             /// Get the number of arguments supplied for existential type parameters.
             ///
             /// Note that the number of arguments may not match the number of parameters.
             /// In particular, an unspecialized entry point may have many parameters, but zero arguments.
-        UInt getExistentialTypeArgCount() { return m_existentialSlots.args.getCount(); }
+        Index getExistentialTypeArgCount() { return m_existentialSlots.args.getCount(); }
 
             /// Get the existential type argument (type and witness table) at `index`.
-        ExistentialTypeSlots::Arg getExistentialTypeArg(UInt index) { return m_existentialSlots.args[index]; }
+        ExistentialTypeSlots::Arg getExistentialTypeArg(Index index) { return m_existentialSlots.args[index]; }
 
             /// Get an array of all existential type arguments.
         ExistentialTypeSlots::Arg const* getExistentialTypeArgs() { return m_existentialSlots.args.getBuffer(); }
@@ -913,10 +913,10 @@ namespace Slang
         Linkage* getLinkage() { return m_linkage; }
 
             /// Get the number of entry points added to the program
-        UInt getEntryPointCount() { return m_entryPoints.getCount(); }
+        Index getEntryPointCount() { return m_entryPoints.getCount(); }
 
             /// Get the entry point at the given `index`.
-        RefPtr<EntryPoint> getEntryPoint(UInt index) { return m_entryPoints[index]; }
+        RefPtr<EntryPoint> getEntryPoint(Index index) { return m_entryPoints[index]; }
 
             /// Get the full ist of entry points on the program.
         List<RefPtr<EntryPoint>> const& getEntryPoints() { return m_entryPoints; }
@@ -980,19 +980,19 @@ namespace Slang
         RefPtr<IRModule> getOrCreateIRModule(DiagnosticSink* sink);
 
             /// Get the number of existential type parameters for the program.
-        UInt getExistentialTypeParamCount() { return m_globalExistentialSlots.paramTypes.getCount(); }
+        Index getExistentialTypeParamCount() { return m_globalExistentialSlots.paramTypes.getCount(); }
 
             /// Get the existential type parameter at `index`.
-        Type* getExistentialTypeParam(UInt index) { return m_globalExistentialSlots.paramTypes[index]; }
+        Type* getExistentialTypeParam(Index index) { return m_globalExistentialSlots.paramTypes[index]; }
 
             /// Get the number of arguments supplied for existential type parameters.
             ///
             /// Note that the number of arguments may not match the number of parameters.
             /// In particular, an unspecialized program may have many parameters, but zero arguments.
-        UInt getExistentialTypeArgCount() { return m_globalExistentialSlots.args.getCount(); }
+        Index getExistentialTypeArgCount() { return m_globalExistentialSlots.args.getCount(); }
 
             /// Get the existential type argument (type and witness table) at `index`.
-        ExistentialTypeSlots::Arg getExistentialTypeArg(UInt index) { return m_globalExistentialSlots.args[index]; }
+        ExistentialTypeSlots::Arg getExistentialTypeArg(Index index) { return m_globalExistentialSlots.args[index]; }
 
             /// Get an array of all existential type arguments.
         ExistentialTypeSlots::Arg const* getExistentialTypeArgs() { return m_globalExistentialSlots.args.getBuffer(); }

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -321,7 +321,7 @@ namespace Slang
             Profile     profile);
 
             /// Get the number of existential type parameters for the entry point.
-        UInt getExistentialTypeParamCount() { return m_existentialSlots.paramTypes.getSize(); }
+        UInt getExistentialTypeParamCount() { return m_existentialSlots.paramTypes.getCount(); }
 
             /// Get the existential type parameter at `index`.
         Type* getExistentialTypeParam(UInt index) { return m_existentialSlots.paramTypes[index]; }
@@ -330,13 +330,13 @@ namespace Slang
             ///
             /// Note that the number of arguments may not match the number of parameters.
             /// In particular, an unspecialized entry point may have many parameters, but zero arguments.
-        UInt getExistentialTypeArgCount() { return m_existentialSlots.args.getSize(); }
+        UInt getExistentialTypeArgCount() { return m_existentialSlots.args.getCount(); }
 
             /// Get the existential type argument (type and witness table) at `index`.
         ExistentialTypeSlots::Arg getExistentialTypeArg(UInt index) { return m_existentialSlots.args[index]; }
 
             /// Get an array of all existential type arguments.
-        ExistentialTypeSlots::Arg const* getExistentialTypeArgs() { return m_existentialSlots.args.Buffer(); }
+        ExistentialTypeSlots::Arg const* getExistentialTypeArgs() { return m_existentialSlots.args.getBuffer(); }
 
             /// Get an array of all entry-point shader parameters.
         List<ShaderParamInfo> const& getShaderParams() { return m_shaderParams; }
@@ -827,7 +827,7 @@ namespace Slang
         List<RefPtr<FrontEndEntryPointRequest>> m_entryPointReqs;
 
         List<RefPtr<FrontEndEntryPointRequest>> const& getEntryPointReqs() { return m_entryPointReqs; }
-        UInt getEntryPointReqCount() { return m_entryPointReqs.getSize(); }
+        UInt getEntryPointReqCount() { return m_entryPointReqs.getCount(); }
         FrontEndEntryPointRequest* getEntryPointReq(UInt index) { return m_entryPointReqs[index]; }
 
         // Directories to search for `#include` files or `import`ed modules
@@ -913,7 +913,7 @@ namespace Slang
         Linkage* getLinkage() { return m_linkage; }
 
             /// Get the number of entry points added to the program
-        UInt getEntryPointCount() { return m_entryPoints.getSize(); }
+        UInt getEntryPointCount() { return m_entryPoints.getCount(); }
 
             /// Get the entry point at the given `index`.
         RefPtr<EntryPoint> getEntryPoint(UInt index) { return m_entryPoints[index]; }
@@ -980,7 +980,7 @@ namespace Slang
         RefPtr<IRModule> getOrCreateIRModule(DiagnosticSink* sink);
 
             /// Get the number of existential type parameters for the program.
-        UInt getExistentialTypeParamCount() { return m_globalExistentialSlots.paramTypes.getSize(); }
+        UInt getExistentialTypeParamCount() { return m_globalExistentialSlots.paramTypes.getCount(); }
 
             /// Get the existential type parameter at `index`.
         Type* getExistentialTypeParam(UInt index) { return m_globalExistentialSlots.paramTypes[index]; }
@@ -989,13 +989,13 @@ namespace Slang
             ///
             /// Note that the number of arguments may not match the number of parameters.
             /// In particular, an unspecialized program may have many parameters, but zero arguments.
-        UInt getExistentialTypeArgCount() { return m_globalExistentialSlots.args.getSize(); }
+        UInt getExistentialTypeArgCount() { return m_globalExistentialSlots.args.getCount(); }
 
             /// Get the existential type argument (type and witness table) at `index`.
         ExistentialTypeSlots::Arg getExistentialTypeArg(UInt index) { return m_globalExistentialSlots.args[index]; }
 
             /// Get an array of all existential type arguments.
-        ExistentialTypeSlots::Arg const* getExistentialTypeArgs() { return m_globalExistentialSlots.args.Buffer(); }
+        ExistentialTypeSlots::Arg const* getExistentialTypeArgs() { return m_globalExistentialSlots.args.getBuffer(); }
 
             /// Get an array of all global shader parameters.
         List<GlobalShaderParamInfo> const& getShaderParams() { return m_shaderParams; }

--- a/source/slang/compiler.h
+++ b/source/slang/compiler.h
@@ -321,7 +321,7 @@ namespace Slang
             Profile     profile);
 
             /// Get the number of existential type parameters for the entry point.
-        UInt getExistentialTypeParamCount() { return m_existentialSlots.paramTypes.Count(); }
+        UInt getExistentialTypeParamCount() { return m_existentialSlots.paramTypes.getSize(); }
 
             /// Get the existential type parameter at `index`.
         Type* getExistentialTypeParam(UInt index) { return m_existentialSlots.paramTypes[index]; }
@@ -330,7 +330,7 @@ namespace Slang
             ///
             /// Note that the number of arguments may not match the number of parameters.
             /// In particular, an unspecialized entry point may have many parameters, but zero arguments.
-        UInt getExistentialTypeArgCount() { return m_existentialSlots.args.Count(); }
+        UInt getExistentialTypeArgCount() { return m_existentialSlots.args.getSize(); }
 
             /// Get the existential type argument (type and witness table) at `index`.
         ExistentialTypeSlots::Arg getExistentialTypeArg(UInt index) { return m_existentialSlots.args[index]; }
@@ -827,7 +827,7 @@ namespace Slang
         List<RefPtr<FrontEndEntryPointRequest>> m_entryPointReqs;
 
         List<RefPtr<FrontEndEntryPointRequest>> const& getEntryPointReqs() { return m_entryPointReqs; }
-        UInt getEntryPointReqCount() { return m_entryPointReqs.Count(); }
+        UInt getEntryPointReqCount() { return m_entryPointReqs.getSize(); }
         FrontEndEntryPointRequest* getEntryPointReq(UInt index) { return m_entryPointReqs[index]; }
 
         // Directories to search for `#include` files or `import`ed modules
@@ -913,7 +913,7 @@ namespace Slang
         Linkage* getLinkage() { return m_linkage; }
 
             /// Get the number of entry points added to the program
-        UInt getEntryPointCount() { return m_entryPoints.Count(); }
+        UInt getEntryPointCount() { return m_entryPoints.getSize(); }
 
             /// Get the entry point at the given `index`.
         RefPtr<EntryPoint> getEntryPoint(UInt index) { return m_entryPoints[index]; }
@@ -980,7 +980,7 @@ namespace Slang
         RefPtr<IRModule> getOrCreateIRModule(DiagnosticSink* sink);
 
             /// Get the number of existential type parameters for the program.
-        UInt getExistentialTypeParamCount() { return m_globalExistentialSlots.paramTypes.Count(); }
+        UInt getExistentialTypeParamCount() { return m_globalExistentialSlots.paramTypes.getSize(); }
 
             /// Get the existential type parameter at `index`.
         Type* getExistentialTypeParam(UInt index) { return m_globalExistentialSlots.paramTypes[index]; }
@@ -989,7 +989,7 @@ namespace Slang
             ///
             /// Note that the number of arguments may not match the number of parameters.
             /// In particular, an unspecialized program may have many parameters, but zero arguments.
-        UInt getExistentialTypeArgCount() { return m_globalExistentialSlots.args.Count(); }
+        UInt getExistentialTypeArgCount() { return m_globalExistentialSlots.args.getSize(); }
 
             /// Get the existential type argument (type and witness table) at `index`.
         ExistentialTypeSlots::Arg getExistentialTypeArg(UInt index) { return m_globalExistentialSlots.args[index]; }

--- a/source/slang/diagnostics.cpp
+++ b/source/slang/diagnostics.cpp
@@ -23,15 +23,24 @@ void printDiagnosticArg(StringBuilder& sb, char const* str)
     sb << str;
 }
 
-void printDiagnosticArg(StringBuilder& sb, int str)
+void printDiagnosticArg(StringBuilder& sb, int32_t val)
 {
-    sb << str;
+    sb << val;
 }
 
-void printDiagnosticArg(StringBuilder& sb, UInt val)
+void printDiagnosticArg(StringBuilder& sb, uint32_t val)
 {
-    // TODO: make this robust
-    sb << (int) val;
+    sb << val;
+}
+
+void printDiagnosticArg(StringBuilder& sb, int64_t val)
+{
+    sb << val;
+}
+
+void printDiagnosticArg(StringBuilder& sb, uint64_t val)
+{
+    sb << val;
 }
 
 void printDiagnosticArg(StringBuilder& sb, Slang::String const& str)

--- a/source/slang/diagnostics.cpp
+++ b/source/slang/diagnostics.cpp
@@ -287,7 +287,7 @@ void DiagnosticSink::diagnoseImpl(SourceLoc const& pos, DiagnosticInfo const& in
         StringBuilder messageBuilder;
         formatDiagnostic(this, diagnostic, messageBuilder);
 
-        writer->write(messageBuilder.Buffer(), messageBuilder.Length());
+        writer->write(messageBuilder.Buffer(), messageBuilder.getLength());
     }
     else
     {

--- a/source/slang/diagnostics.cpp
+++ b/source/slang/diagnostics.cpp
@@ -287,7 +287,7 @@ void DiagnosticSink::diagnoseImpl(SourceLoc const& pos, DiagnosticInfo const& in
         StringBuilder messageBuilder;
         formatDiagnostic(this, diagnostic, messageBuilder);
 
-        writer->write(messageBuilder.Buffer(), messageBuilder.getLength());
+        writer->write(messageBuilder.getBuffer(), messageBuilder.getLength());
     }
     else
     {

--- a/source/slang/diagnostics.h
+++ b/source/slang/diagnostics.h
@@ -80,8 +80,13 @@ namespace Slang
     enum class ProfileVersion;
 
     void printDiagnosticArg(StringBuilder& sb, char const* str);
-    void printDiagnosticArg(StringBuilder& sb, int val);
-    void printDiagnosticArg(StringBuilder& sb, UInt val);
+
+    void printDiagnosticArg(StringBuilder& sb, int32_t val);
+    void printDiagnosticArg(StringBuilder& sb, uint32_t val);
+
+    void printDiagnosticArg(StringBuilder& sb, int64_t val);
+    void printDiagnosticArg(StringBuilder& sb, uint64_t val);
+
     void printDiagnosticArg(StringBuilder& sb, Slang::String const& str);
     void printDiagnosticArg(StringBuilder& sb, Slang::UnownedStringSlice const& str);
     void printDiagnosticArg(StringBuilder& sb, Name* name);

--- a/source/slang/dxc-support.cpp
+++ b/source/slang/dxc-support.cpp
@@ -107,7 +107,7 @@ namespace Slang
         ComPtr<IDxcBlobEncoding> dxcSourceBlob;
         SLANG_RETURN_ON_FAIL(dxcLibrary->CreateBlobWithEncodingFromPinned(
             (LPBYTE)hlslCode.Buffer(),
-            (UINT32)hlslCode.Length(),
+            (UINT32)hlslCode.getLength(),
             0,
             dxcSourceBlob.writeRef()));
 

--- a/source/slang/dxc-support.cpp
+++ b/source/slang/dxc-support.cpp
@@ -248,7 +248,7 @@ namespace Slang
         ComPtr<IDxcBlob> dxcResultBlob;
         SLANG_RETURN_ON_FAIL(dxcResult->GetResult(dxcResultBlob.writeRef()));
         
-        outCode.AddRange(
+        outCode.addRange(
             (uint8_t const*)dxcResultBlob->GetBufferPointer(),
             (int)           dxcResultBlob->GetBufferSize());
 

--- a/source/slang/dxc-support.cpp
+++ b/source/slang/dxc-support.cpp
@@ -99,14 +99,14 @@ namespace Slang
             entryPointIndex,
             targetReq,
             endToEndReq);
-        maybeDumpIntermediate(compileRequest, hlslCode.Buffer(), CodeGenTarget::HLSL);
+        maybeDumpIntermediate(compileRequest, hlslCode.getBuffer(), CodeGenTarget::HLSL);
 
         // Wrap the 
 
         // Create blob from the string
         ComPtr<IDxcBlobEncoding> dxcSourceBlob;
         SLANG_RETURN_ON_FAIL(dxcLibrary->CreateBlobWithEncodingFromPinned(
-            (LPBYTE)hlslCode.Buffer(),
+            (LPBYTE)hlslCode.getBuffer(),
             (UINT32)hlslCode.getLength(),
             0,
             dxcSourceBlob.writeRef()));
@@ -181,11 +181,11 @@ namespace Slang
         args[argCount++] = L"-no-warnings";
 
         String entryPointName = getText(entryPoint->getName());
-        OSString wideEntryPointName = entryPointName.ToWString();
+        OSString wideEntryPointName = entryPointName.toWString();
 
         auto profile = getEffectiveProfile(entryPoint, targetReq);
         String profileName = GetHLSLProfileName(profile);
-        OSString wideProfileName = profileName.ToWString();
+        OSString wideProfileName = profileName.toWString();
 
         // We will enable the flag to generate proper code for 16-bit types
         // by default, as long as the user is requesting a sufficiently
@@ -207,7 +207,7 @@ namespace Slang
 
         ComPtr<IDxcOperationResult> dxcResult;
         SLANG_RETURN_ON_FAIL(dxcCompiler->Compile(dxcSourceBlob,
-            sourcePath.ToWString().begin(),
+            sourcePath.toWString().begin(),
             profile.GetStage() == Stage::Unknown ? L"" : wideEntryPointName.begin(),
             wideProfileName.begin(),
             args,

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -3027,7 +3027,7 @@ struct EmitVisitor
         auto outerPrec = inOuterPrec;
 
         IRUse* args = inst->getOperands();
-        UInt argCount = inst->getOperandCount();
+        Index argCount = inst->getOperandCount();
 
         // First operand was the function to be called
         args++;
@@ -3043,7 +3043,7 @@ struct EmitVisitor
 
             emit(name);
             Emit("(");
-            for (UInt aa = 0; aa < argCount; ++aa)
+            for (Index aa = 0; aa < argCount; ++aa)
             {
                 if (aa != 0) Emit(", ");
                 emitIROperand(ctx, args[aa].get(), mode, kEOp_General);
@@ -3090,7 +3090,7 @@ struct EmitVisitor
                 case '5': case '6': case '7': case '8': case '9':
                     {
                         // Simple case: emit one of the direct arguments to the call
-                        UInt argIndex = d - '0';
+                        Index argIndex = d - '0';
                         SLANG_RELEASE_ASSERT((0 <= argIndex) && (argIndex < argCount));
                         Emit("(");
                         emitIROperand(ctx, args[argIndex].get(), mode, kEOp_General);
@@ -3213,7 +3213,7 @@ struct EmitVisitor
                         // we can use it in the constructed expression.
 
                         SLANG_RELEASE_ASSERT(*cursor >= '0' && *cursor <= '9');
-                        UInt argIndex = (*cursor++) - '0';
+                        Index argIndex = (*cursor++) - '0';
                         SLANG_RELEASE_ASSERT(argCount > argIndex);
 
                         auto vectorArg = args[argIndex].get();
@@ -3236,7 +3236,7 @@ struct EmitVisitor
                         // (this is the inverse of `$z`).
                         //
                         SLANG_RELEASE_ASSERT(*cursor >= '0' && *cursor <= '9');
-                        UInt argIndex = (*cursor++) - '0';
+                        Index argIndex = (*cursor++) - '0';
                         SLANG_RELEASE_ASSERT(argCount > argIndex);
 
                         auto arg = args[argIndex].get();
@@ -3293,7 +3293,7 @@ struct EmitVisitor
                         // with the front-end picking the right overload
                         // based on the "address space" of the argument.
 
-                        UInt argIndex = 0;
+                        Index argIndex = 0;
                         SLANG_RELEASE_ASSERT(argCount > argIndex);
 
                         auto arg = args[argIndex].get();
@@ -3318,7 +3318,7 @@ struct EmitVisitor
                         // to the `imageAtomic*` function.
                         //
 
-                        UInt argIndex = 0;
+                        Index argIndex = 0;
                         SLANG_RELEASE_ASSERT(argCount > argIndex);
 
                         auto arg = args[argIndex].get();
@@ -3401,7 +3401,7 @@ struct EmitVisitor
                                 // used as the argument ray payload at a
                                 // trace call site.
 
-                                UInt argIndex = 0;
+                                Index argIndex = 0;
                                 SLANG_RELEASE_ASSERT(argCount > argIndex);
                                 auto arg = args[argIndex].get();
                                 auto argLoad = as<IRLoad>(arg);
@@ -3418,7 +3418,7 @@ struct EmitVisitor
                                 // used as the argument callable payload at a
                                 // call site.
 
-                                UInt argIndex = 0;
+                            Index argIndex = 0;
                                 SLANG_RELEASE_ASSERT(argCount > argIndex);
                                 auto arg = args[argIndex].get();
                                 auto argLoad = as<IRLoad>(arg);
@@ -4095,8 +4095,8 @@ struct EmitVisitor
                 auto ii = (IRSwizzle*)inst;
                 emitIROperand(ctx, ii->getBase(), mode, leftSide(outerPrec, prec));
                 emit(".");
-                UInt elementCount = ii->getElementCount();
-                for (UInt ee = 0; ee < elementCount; ++ee)
+                const Index elementCount = Index(ii->getElementCount());
+                for (Index ee = 0; ee < elementCount; ++ee)
                 {
                     IRInst* irElementIndex = ii->getElementIndex(ee);
                     SLANG_RELEASE_ASSERT(irElementIndex->op == kIROp_IntLit);

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -6769,7 +6769,7 @@ struct EmitVisitor
         }
 
         ctx->mapInstToLevel[inst] = requiredLevel;
-        ctx->actions->Add(action);
+        ctx->actions->add(action);
     }
 
     void computeIREmitActions(

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -1490,7 +1490,7 @@ struct EmitVisitor
 
         // If no target name was specified, then the modifier implicitly
         // applies to all targets.
-        if(targetName.Length() == 0)
+        if(targetName.getLength() == 0)
             return true;
 
         return isTargetIntrinsicModifierApplicable(targetName);
@@ -2105,7 +2105,7 @@ struct EmitVisitor
         char const* dummyChar = "U";
 
         // Special case a name that is the empty string, just in case.
-        if(name.Length() == 0)
+        if(name.getLength() == 0)
             return dummyChar;
 
         // Otherwise, we are going to walk over the name byte by byte
@@ -2117,7 +2117,7 @@ struct EmitVisitor
             // GLSL reserverse all names that start with `gl_`,
             // so if we are in danger of collision, then make
             // our name start with a dummy character instead.
-            if(name.StartsWith("gl_"))
+            if(name.startsWith("gl_"))
             {
                 sb.append(dummyChar);
             }
@@ -2126,7 +2126,7 @@ struct EmitVisitor
         // We will also detect user-defined names that
         // might overlap with our convention for mangled names,
         // to avoid an possible collision.
-        if(name.StartsWith("_S"))
+        if(name.startsWith("_S"))
         {
             sb.Append(dummyChar);
         }
@@ -2259,7 +2259,7 @@ struct EmitVisitor
             sb.append(nameHint);
 
             // Avoid introducing a double underscore
-            if(!nameHint.EndsWith("_"))
+            if(!nameHint.endsWith("_"))
             {
                 sb.append("_");
             }

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -4806,8 +4806,8 @@ struct EmitVisitor
     {
         assert(attrib);
 
-        attrib->args.getSize();
-        if (attrib->args.getSize() != 1)
+        attrib->args.getCount();
+        if (attrib->args.getCount() != 1)
         {
             SLANG_DIAGNOSE_UNEXPECTED(getSink(), entryPoint->loc, "Attribute expects single parameter");
             return;
@@ -4833,8 +4833,8 @@ struct EmitVisitor
     {
         assert(attrib);
 
-        attrib->args.getSize();
-        if (attrib->args.getSize() != 1)
+        attrib->args.getCount();
+        if (attrib->args.getCount() != 1)
         {
             SLANG_DIAGNOSE_UNEXPECTED(getSink(), entryPoint->loc, "Attribute expects single parameter");
             return;

--- a/source/slang/emit.cpp
+++ b/source/slang/emit.cpp
@@ -4806,8 +4806,8 @@ struct EmitVisitor
     {
         assert(attrib);
 
-        attrib->args.Count();
-        if (attrib->args.Count() != 1)
+        attrib->args.getSize();
+        if (attrib->args.getSize() != 1)
         {
             SLANG_DIAGNOSE_UNEXPECTED(getSink(), entryPoint->loc, "Attribute expects single parameter");
             return;
@@ -4833,8 +4833,8 @@ struct EmitVisitor
     {
         assert(attrib);
 
-        attrib->args.Count();
-        if (attrib->args.Count() != 1)
+        attrib->args.getSize();
+        if (attrib->args.getSize() != 1)
         {
             SLANG_DIAGNOSE_UNEXPECTED(getSink(), entryPoint->loc, "Attribute expects single parameter");
             return;

--- a/source/slang/ir-bind-existentials.cpp
+++ b/source/slang/ir-bind-existentials.cpp
@@ -285,7 +285,7 @@ struct BindExistentialSlots
         UInt slotOperandCount = slotCount*2;
         List<IRInst*> slotOperands;
         for(UInt ii = 0; ii < slotOperandCount; ++ii)
-            slotOperands.Add(slotArgs[ii].get());
+            slotOperands.add(slotArgs[ii].get());
 
         // We are going to create a proxy type that represents
         // the results of plugging all the information
@@ -315,7 +315,7 @@ struct BindExistentialSlots
         //
         List<IRUse*> usesToReplace;
         for(auto use = inst->firstUse; use; use = use->nextUse )
-            usesToReplace.Add(use);
+            usesToReplace.add(use);
 
         // Now we can loop over our list of uses and replace each.
         //

--- a/source/slang/ir-bind-existentials.cpp
+++ b/source/slang/ir-bind-existentials.cpp
@@ -294,7 +294,7 @@ struct BindExistentialSlots
         auto newType = builder.getBindExistentialsType(
             fullType,
             slotOperandCount,
-            slotOperands.Buffer());
+            slotOperands.getBuffer());
 
         // We will replace the type of the original parameter
         // with the new proxy type.
@@ -329,7 +329,7 @@ struct BindExistentialSlots
                 fullType,
                 inst,
                 slotOperandCount,
-                slotOperands.Buffer());
+                slotOperands.getBuffer());
 
             // Second we make the use site point at the new
             // value instead.

--- a/source/slang/ir-clone.cpp
+++ b/source/slang/ir-clone.cpp
@@ -260,8 +260,8 @@ void cloneDecoration(
 
 bool IRSimpleSpecializationKey::operator==(IRSimpleSpecializationKey const& other) const
 {
-    auto valCount = vals.Count();
-    if(valCount != other.vals.Count()) return false;
+    auto valCount = vals.getSize();
+    if(valCount != other.vals.getSize()) return false;
     for( UInt ii = 0; ii < valCount; ++ii )
     {
         if(vals[ii] != other.vals[ii]) return false;
@@ -271,7 +271,7 @@ bool IRSimpleSpecializationKey::operator==(IRSimpleSpecializationKey const& othe
 
 int IRSimpleSpecializationKey::GetHashCode() const
 {
-    auto valCount = vals.Count();
+    auto valCount = vals.getSize();
     int hash = Slang::GetHashCode(valCount);
     for( UInt ii = 0; ii < valCount; ++ii )
     {

--- a/source/slang/ir-clone.cpp
+++ b/source/slang/ir-clone.cpp
@@ -262,7 +262,7 @@ bool IRSimpleSpecializationKey::operator==(IRSimpleSpecializationKey const& othe
 {
     auto valCount = vals.getCount();
     if(valCount != other.vals.getCount()) return false;
-    for( UInt ii = 0; ii < valCount; ++ii )
+    for( Index ii = 0; ii < valCount; ++ii )
     {
         if(vals[ii] != other.vals[ii]) return false;
     }
@@ -273,7 +273,7 @@ int IRSimpleSpecializationKey::GetHashCode() const
 {
     auto valCount = vals.getCount();
     int hash = Slang::GetHashCode(valCount);
-    for( UInt ii = 0; ii < valCount; ++ii )
+    for( Index ii = 0; ii < valCount; ++ii )
     {
         hash = combineHash(hash, Slang::GetHashCode(vals[ii]));
     }

--- a/source/slang/ir-clone.cpp
+++ b/source/slang/ir-clone.cpp
@@ -260,8 +260,8 @@ void cloneDecoration(
 
 bool IRSimpleSpecializationKey::operator==(IRSimpleSpecializationKey const& other) const
 {
-    auto valCount = vals.getSize();
-    if(valCount != other.vals.getSize()) return false;
+    auto valCount = vals.getCount();
+    if(valCount != other.vals.getCount()) return false;
     for( UInt ii = 0; ii < valCount; ++ii )
     {
         if(vals[ii] != other.vals[ii]) return false;
@@ -271,7 +271,7 @@ bool IRSimpleSpecializationKey::operator==(IRSimpleSpecializationKey const& othe
 
 int IRSimpleSpecializationKey::GetHashCode() const
 {
-    auto valCount = vals.getSize();
+    auto valCount = vals.getCount();
     int hash = Slang::GetHashCode(valCount);
     for( UInt ii = 0; ii < valCount; ++ii )
     {

--- a/source/slang/ir-clone.cpp
+++ b/source/slang/ir-clone.cpp
@@ -176,7 +176,7 @@ static void _cloneInstDecorationsAndChildren(
             IRCloningOldNewPair pair;
             pair.oldInst = oldChild;
             pair.newInst = newChild;
-            pairs.Add(pair);
+            pairs.add(pair);
         }
     }
 

--- a/source/slang/ir-constexpr.cpp
+++ b/source/slang/ir-constexpr.cpp
@@ -492,7 +492,7 @@ void propagateConstExpr(
     while( context.workList.getSize() )
     {
         auto gv = context.workList[0];
-        context.workList.FastRemoveAt(0);
+        context.workList.fastRemoveAt(0);
         context.onWorkList.Remove(gv);
 
         switch( gv->op )

--- a/source/slang/ir-constexpr.cpp
+++ b/source/slang/ir-constexpr.cpp
@@ -489,7 +489,7 @@ void propagateConstExpr(
 
     // We will iterate applying propagation to one global value at a time
     // until we run out.
-    while( context.workList.Count() )
+    while( context.workList.getSize() )
     {
         auto gv = context.workList[0];
         context.workList.FastRemoveAt(0);

--- a/source/slang/ir-constexpr.cpp
+++ b/source/slang/ir-constexpr.cpp
@@ -489,7 +489,7 @@ void propagateConstExpr(
 
     // We will iterate applying propagation to one global value at a time
     // until we run out.
-    while( context.workList.getSize() )
+    while( context.workList.getCount() )
     {
         auto gv = context.workList[0];
         context.workList.fastRemoveAt(0);

--- a/source/slang/ir-constexpr.cpp
+++ b/source/slang/ir-constexpr.cpp
@@ -162,7 +162,7 @@ void maybeAddToWorkList(
 {
     if( !context->onWorkList.Contains(gv) )
     {
-        context->workList.Add(gv);
+        context->workList.add(gv);
         context->onWorkList.Add(gv);
     }
 }

--- a/source/slang/ir-dce.cpp
+++ b/source/slang/ir-dce.cpp
@@ -95,7 +95,7 @@ struct DeadCodeEliminationContext
         // processing entries off of our work list
         // until it goes dry.
         //
-        while( workList.Count() )
+        while( workList.getSize() )
         {
             auto inst = workList.Last();
             workList.RemoveLast();

--- a/source/slang/ir-dce.cpp
+++ b/source/slang/ir-dce.cpp
@@ -95,7 +95,7 @@ struct DeadCodeEliminationContext
         // processing entries off of our work list
         // until it goes dry.
         //
-        while( workList.getSize() )
+        while( workList.getCount() )
         {
             auto inst = workList.getLast();
             workList.removeLast();

--- a/source/slang/ir-dce.cpp
+++ b/source/slang/ir-dce.cpp
@@ -74,7 +74,7 @@ struct DeadCodeEliminationContext
         if(liveInsts.Contains(inst))
             return;
         liveInsts.Add(inst);
-        workList.Add(inst);
+        workList.add(inst);
     }
 
     // Given the basic infrastructrure above, let's
@@ -97,8 +97,8 @@ struct DeadCodeEliminationContext
         //
         while( workList.getSize() )
         {
-            auto inst = workList.Last();
-            workList.RemoveLast();
+            auto inst = workList.getLast();
+            workList.removeLast();
 
             // At this point we know that `inst` is live,
             // and we want to start considering which other

--- a/source/slang/ir-dominators.cpp
+++ b/source/slang/ir-dominators.cpp
@@ -314,7 +314,7 @@ struct DominatorTreeComputationContext
 
         // We will initialize our map from the block objects to their "name"
         // (index in the traversal order), before moving on.
-        BlockName blockCount = BlockName(postorder.getSize());
+        BlockName blockCount = BlockName(postorder.getCount());
         for(BlockName bb = 0; bb < blockCount; ++bb)
         {
             mapBlockToName[postorder[bb]] = bb;
@@ -322,7 +322,7 @@ struct DominatorTreeComputationContext
 
         // Next we initialize the `doms` array that we will iteratively turn
         // into an encoding of the dominator tree.
-        doms.setSize(blockCount);
+        doms.setCount(blockCount);
         for(BlockName bb = 0; bb < blockCount; ++bb)
         {
             doms[bb] = kUndefined;
@@ -524,7 +524,7 @@ struct DominatorTreeComputationContext
 
         // We will build some intermediate information on each
         // block to help us fill out the tree.
-        BlockName blockCount = BlockName(doms.getSize());
+        BlockName blockCount = BlockName(doms.getCount());
         List<BlockInfo> blockInfos;
         for(BlockName bb = 0; bb < blockCount; ++bb)
         {
@@ -626,7 +626,7 @@ struct DominatorTreeComputationContext
         //
         RefPtr<IRDominatorTree> dominatorTree = new IRDominatorTree();
         dominatorTree->code = code;
-        dominatorTree->nodes.setSize(blockCount);
+        dominatorTree->nodes.setCount(blockCount);
 
         // We will iterate over all of the blocks, and fill in the corresponding
         // dominator tree node for each.

--- a/source/slang/ir-dominators.cpp
+++ b/source/slang/ir-dominators.cpp
@@ -314,7 +314,7 @@ struct DominatorTreeComputationContext
 
         // We will initialize our map from the block objects to their "name"
         // (index in the traversal order), before moving on.
-        BlockName blockCount = BlockName(postorder.Count());
+        BlockName blockCount = BlockName(postorder.getSize());
         for(BlockName bb = 0; bb < blockCount; ++bb)
         {
             mapBlockToName[postorder[bb]] = bb;
@@ -524,7 +524,7 @@ struct DominatorTreeComputationContext
 
         // We will build some intermediate information on each
         // block to help us fill out the tree.
-        BlockName blockCount = BlockName(doms.Count());
+        BlockName blockCount = BlockName(doms.getSize());
         List<BlockInfo> blockInfos;
         for(BlockName bb = 0; bb < blockCount; ++bb)
         {

--- a/source/slang/ir-dominators.cpp
+++ b/source/slang/ir-dominators.cpp
@@ -322,7 +322,7 @@ struct DominatorTreeComputationContext
 
         // Next we initialize the `doms` array that we will iteratively turn
         // into an encoding of the dominator tree.
-        doms.SetSize(blockCount);
+        doms.setSize(blockCount);
         for(BlockName bb = 0; bb < blockCount; ++bb)
         {
             doms[bb] = kUndefined;
@@ -626,7 +626,7 @@ struct DominatorTreeComputationContext
         //
         RefPtr<IRDominatorTree> dominatorTree = new IRDominatorTree();
         dominatorTree->code = code;
-        dominatorTree->nodes.SetSize(blockCount);
+        dominatorTree->nodes.setSize(blockCount);
 
         // We will iterate over all of the blocks, and fill in the corresponding
         // dominator tree node for each.

--- a/source/slang/ir-dominators.cpp
+++ b/source/slang/ir-dominators.cpp
@@ -245,7 +245,7 @@ struct PostorderComputationContext : public DepthFirstSearchContext
 
     virtual void postVisit(IRBlock* block) SLANG_OVERRIDE
     {
-        order->Add(block);
+        order->add(block);
     }
 };
 
@@ -528,7 +528,7 @@ struct DominatorTreeComputationContext
         List<BlockInfo> blockInfos;
         for(BlockName bb = 0; bb < blockCount; ++bb)
         {
-            blockInfos.Add(BlockInfo());
+            blockInfos.add(BlockInfo());
         }
 
         // We will propagate layout information in two passes over the tree.

--- a/source/slang/ir-entry-point-uniforms.cpp
+++ b/source/slang/ir-entry-point-uniforms.cpp
@@ -373,7 +373,7 @@ struct MoveEntryPointUniformParametersToGlobalScope
         // Note: an empty `struct` parameter would also show up the same way, but
         // we should eliminate any such parameters later on during type legalization.
         //
-        if(layout->resourceInfos.getSize() == 0)
+        if(layout->resourceInfos.getCount() == 0)
             return true;
 
         // if none of the above tests determined that the

--- a/source/slang/ir-entry-point-uniforms.cpp
+++ b/source/slang/ir-entry-point-uniforms.cpp
@@ -373,7 +373,7 @@ struct MoveEntryPointUniformParametersToGlobalScope
         // Note: an empty `struct` parameter would also show up the same way, but
         // we should eliminate any such parameters later on during type legalization.
         //
-        if(layout->resourceInfos.Count() == 0)
+        if(layout->resourceInfos.getSize() == 0)
             return true;
 
         // if none of the above tests determined that the

--- a/source/slang/ir-glsl-legalize.cpp
+++ b/source/slang/ir-glsl-legalize.cpp
@@ -835,7 +835,7 @@ void assign(
                 // that is not a tuple. We will perform assignment
                 // element-by-element.
                 auto rightTupleVal = as<ScalarizedTupleValImpl>(right.impl);
-                UInt elementCount = rightTupleVal->elements.Count();
+                UInt elementCount = rightTupleVal->elements.getSize();
 
                 for( UInt ee = 0; ee < elementCount; ++ee )
                 {
@@ -861,7 +861,7 @@ void assign(
             // We have a tuple, so we are going to need to try and assign
             // to each of its constituent fields.
             auto leftTupleVal = as<ScalarizedTupleValImpl>(left.impl);
-            UInt elementCount = leftTupleVal->elements.Count();
+            UInt elementCount = leftTupleVal->elements.getSize();
 
             for( UInt ee = 0; ee < elementCount; ++ee )
             {
@@ -923,7 +923,7 @@ ScalarizedVal getSubscriptVal(
             RefPtr<ScalarizedTupleValImpl> resultTuple = new ScalarizedTupleValImpl();
             resultTuple->type = elementType;
 
-            UInt elementCount = inputTuple->elements.Count();
+            UInt elementCount = inputTuple->elements.getSize();
             UInt elementCounter = 0;
 
             auto structType = as<IRStructType>(elementType);
@@ -983,7 +983,7 @@ IRInst* materializeTupleValue(
     auto tupleVal = val.impl.as<ScalarizedTupleValImpl>();
     SLANG_ASSERT(tupleVal);
 
-    UInt elementCount = tupleVal->elements.Count();
+    UInt elementCount = tupleVal->elements.getSize();
     auto type = tupleVal->type;
 
     if( auto arrayType = as<IRArrayType>(type))
@@ -1014,7 +1014,7 @@ IRInst* materializeTupleValue(
 
         return builder->emitMakeArray(
             arrayType,
-            arrayElementVals.Count(),
+            arrayElementVals.getSize(),
             arrayElementVals.Buffer());
     }
     else
@@ -1034,7 +1034,7 @@ IRInst* materializeTupleValue(
 
         return builder->emitConstructorInst(
             tupleVal->type,
-            elementVals.Count(),
+            elementVals.getSize(),
             elementVals.Buffer());
     }
 }

--- a/source/slang/ir-glsl-legalize.cpp
+++ b/source/slang/ir-glsl-legalize.cpp
@@ -698,7 +698,7 @@ ScalarizedVal createGLSLGlobalVaryingsImpl(
                 element.val = fieldVal;
                 element.key = field->getKey();
 
-                tupleValImpl->elements.Add(element);
+                tupleValImpl->elements.add(element);
             }
         }
 
@@ -944,7 +944,7 @@ ScalarizedVal getSubscriptVal(
                     inputElement.val,
                     indexVal);
 
-                resultTuple->elements.Add(resultElement);
+                resultTuple->elements.add(resultElement);
             }
             SLANG_RELEASE_ASSERT(elementCounter == elementCount);
 
@@ -1009,7 +1009,7 @@ IRInst* materializeTupleValue(
                 builder,
                 arrayElementPseudoVal);
 
-            arrayElementVals.Add(arrayElementVal);
+            arrayElementVals.add(arrayElementVal);
         }
 
         return builder->emitMakeArray(
@@ -1029,7 +1029,7 @@ IRInst* materializeTupleValue(
         for( UInt ee = 0; ee < elementCount; ++ee )
         {
             auto elementVal = materializeValue(builder, tupleVal->elements[ee].val);
-            elementVals.Add(elementVal);
+            elementVals.add(elementVal);
         }
 
         return builder->emitConstructorInst(

--- a/source/slang/ir-glsl-legalize.cpp
+++ b/source/slang/ir-glsl-legalize.cpp
@@ -835,7 +835,7 @@ void assign(
                 // that is not a tuple. We will perform assignment
                 // element-by-element.
                 auto rightTupleVal = as<ScalarizedTupleValImpl>(right.impl);
-                UInt elementCount = rightTupleVal->elements.getSize();
+                UInt elementCount = rightTupleVal->elements.getCount();
 
                 for( UInt ee = 0; ee < elementCount; ++ee )
                 {
@@ -861,7 +861,7 @@ void assign(
             // We have a tuple, so we are going to need to try and assign
             // to each of its constituent fields.
             auto leftTupleVal = as<ScalarizedTupleValImpl>(left.impl);
-            UInt elementCount = leftTupleVal->elements.getSize();
+            UInt elementCount = leftTupleVal->elements.getCount();
 
             for( UInt ee = 0; ee < elementCount; ++ee )
             {
@@ -923,7 +923,7 @@ ScalarizedVal getSubscriptVal(
             RefPtr<ScalarizedTupleValImpl> resultTuple = new ScalarizedTupleValImpl();
             resultTuple->type = elementType;
 
-            UInt elementCount = inputTuple->elements.getSize();
+            UInt elementCount = inputTuple->elements.getCount();
             UInt elementCounter = 0;
 
             auto structType = as<IRStructType>(elementType);
@@ -983,7 +983,7 @@ IRInst* materializeTupleValue(
     auto tupleVal = val.impl.as<ScalarizedTupleValImpl>();
     SLANG_ASSERT(tupleVal);
 
-    UInt elementCount = tupleVal->elements.getSize();
+    UInt elementCount = tupleVal->elements.getCount();
     auto type = tupleVal->type;
 
     if( auto arrayType = as<IRArrayType>(type))
@@ -1014,8 +1014,8 @@ IRInst* materializeTupleValue(
 
         return builder->emitMakeArray(
             arrayType,
-            arrayElementVals.getSize(),
-            arrayElementVals.Buffer());
+            arrayElementVals.getCount(),
+            arrayElementVals.getBuffer());
     }
     else
     {
@@ -1034,8 +1034,8 @@ IRInst* materializeTupleValue(
 
         return builder->emitConstructorInst(
             tupleVal->type,
-            elementVals.getSize(),
-            elementVals.Buffer());
+            elementVals.getCount(),
+            elementVals.getBuffer());
     }
 }
 

--- a/source/slang/ir-glsl-legalize.cpp
+++ b/source/slang/ir-glsl-legalize.cpp
@@ -835,9 +835,9 @@ void assign(
                 // that is not a tuple. We will perform assignment
                 // element-by-element.
                 auto rightTupleVal = as<ScalarizedTupleValImpl>(right.impl);
-                UInt elementCount = rightTupleVal->elements.getCount();
+                Index elementCount = rightTupleVal->elements.getCount();
 
-                for( UInt ee = 0; ee < elementCount; ++ee )
+                for( Index ee = 0; ee < elementCount; ++ee )
                 {
                     auto rightElement = rightTupleVal->elements[ee];
                     auto leftElementVal = extractField(
@@ -861,9 +861,9 @@ void assign(
             // We have a tuple, so we are going to need to try and assign
             // to each of its constituent fields.
             auto leftTupleVal = as<ScalarizedTupleValImpl>(left.impl);
-            UInt elementCount = leftTupleVal->elements.getCount();
+            Index elementCount = leftTupleVal->elements.getCount();
 
-            for( UInt ee = 0; ee < elementCount; ++ee )
+            for( Index ee = 0; ee < elementCount; ++ee )
             {
                 auto rightElementVal = extractField(
                     builder,
@@ -923,15 +923,15 @@ ScalarizedVal getSubscriptVal(
             RefPtr<ScalarizedTupleValImpl> resultTuple = new ScalarizedTupleValImpl();
             resultTuple->type = elementType;
 
-            UInt elementCount = inputTuple->elements.getCount();
-            UInt elementCounter = 0;
+            Index elementCount = inputTuple->elements.getCount();
+            Index elementCounter = 0;
 
             auto structType = as<IRStructType>(elementType);
             for(auto field : structType->getFields())
             {
                 auto tupleElementType = field->getFieldType();
 
-                UInt elementIndex = elementCounter++;
+                Index elementIndex = elementCounter++;
 
                 SLANG_RELEASE_ASSERT(elementIndex < elementCount);
                 auto inputElement = inputTuple->elements[elementIndex];
@@ -983,7 +983,7 @@ IRInst* materializeTupleValue(
     auto tupleVal = val.impl.as<ScalarizedTupleValImpl>();
     SLANG_ASSERT(tupleVal);
 
-    UInt elementCount = tupleVal->elements.getCount();
+    Index elementCount = tupleVal->elements.getCount();
     auto type = tupleVal->type;
 
     if( auto arrayType = as<IRArrayType>(type))
@@ -1026,7 +1026,7 @@ IRInst* materializeTupleValue(
         // TODO: this should be using a `makeStruct` instruction.
 
         List<IRInst*> elementVals;
-        for( UInt ee = 0; ee < elementCount; ++ee )
+        for( Index ee = 0; ee < elementCount; ++ee )
         {
             auto elementVal = materializeValue(builder, tupleVal->elements[ee].val);
             elementVals.add(elementVal);

--- a/source/slang/ir-glsl-legalize.cpp
+++ b/source/slang/ir-glsl-legalize.cpp
@@ -224,10 +224,10 @@ GLSLSystemValueInfo* getGLSLSystemValueInfo(
     char const* outerArrayName = nullptr;
 
     auto semanticNameSpelling = varLayout->systemValueSemantic;
-    if(semanticNameSpelling.Length() == 0)
+    if(semanticNameSpelling.getLength() == 0)
         return nullptr;
 
-    auto semanticName = semanticNameSpelling.ToLower();
+    auto semanticName = semanticNameSpelling.toLower();
 
     IRType* requiredType = nullptr;
 

--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -781,7 +781,7 @@ struct IRBuilder
         List<IRType*> const&    paramTypes,
         IRType*                 resultType)
     {
-        return getFuncType(paramTypes.Count(), paramTypes.Buffer(), resultType);
+        return getFuncType(paramTypes.getSize(), paramTypes.Buffer(), resultType);
     }
 
     IRConstantBufferType* getConstantBufferType(
@@ -801,7 +801,7 @@ struct IRBuilder
     IRType* getTaggedUnionType(
         List<IRType*> const& caseTypes)
     {
-        return getTaggedUnionType(caseTypes.Count(), caseTypes.Buffer());
+        return getTaggedUnionType(caseTypes.getSize(), caseTypes.Buffer());
     }
 
     IRType* getBindExistentialsType(
@@ -853,7 +853,7 @@ struct IRBuilder
         IRInst*                 func,
         List<IRInst*> const&    args)
     {
-        return emitCallInst(type, func, args.Count(), args.Buffer());
+        return emitCallInst(type, func, args.getSize(), args.Buffer());
     }
 
     IRInst* createIntrinsicInst(
@@ -882,7 +882,7 @@ struct IRBuilder
         IRType*                 type,
         List<IRInst*> const&    args)
     {
-        return emitMakeVector(type, args.Count(), args.Buffer());
+        return emitMakeVector(type, args.getSize(), args.Buffer());
     }
 
     IRInst* emitMakeMatrix(
@@ -904,7 +904,7 @@ struct IRBuilder
         IRType*                 type,
         List<IRInst*> const&    args)
     {
-        return emitMakeStruct(type, args.Count(), args.Buffer());
+        return emitMakeStruct(type, args.getSize(), args.Buffer());
     }
 
     IRInst* emitMakeExistential(

--- a/source/slang/ir-insts.h
+++ b/source/slang/ir-insts.h
@@ -781,7 +781,7 @@ struct IRBuilder
         List<IRType*> const&    paramTypes,
         IRType*                 resultType)
     {
-        return getFuncType(paramTypes.getSize(), paramTypes.Buffer(), resultType);
+        return getFuncType(paramTypes.getCount(), paramTypes.getBuffer(), resultType);
     }
 
     IRConstantBufferType* getConstantBufferType(
@@ -801,7 +801,7 @@ struct IRBuilder
     IRType* getTaggedUnionType(
         List<IRType*> const& caseTypes)
     {
-        return getTaggedUnionType(caseTypes.getSize(), caseTypes.Buffer());
+        return getTaggedUnionType(caseTypes.getCount(), caseTypes.getBuffer());
     }
 
     IRType* getBindExistentialsType(
@@ -853,7 +853,7 @@ struct IRBuilder
         IRInst*                 func,
         List<IRInst*> const&    args)
     {
-        return emitCallInst(type, func, args.getSize(), args.Buffer());
+        return emitCallInst(type, func, args.getCount(), args.getBuffer());
     }
 
     IRInst* createIntrinsicInst(
@@ -882,7 +882,7 @@ struct IRBuilder
         IRType*                 type,
         List<IRInst*> const&    args)
     {
-        return emitMakeVector(type, args.getSize(), args.Buffer());
+        return emitMakeVector(type, args.getCount(), args.getBuffer());
     }
 
     IRInst* emitMakeMatrix(
@@ -904,7 +904,7 @@ struct IRBuilder
         IRType*                 type,
         List<IRInst*> const&    args)
     {
-        return emitMakeStruct(type, args.getSize(), args.Buffer());
+        return emitMakeStruct(type, args.getCount(), args.getBuffer());
     }
 
     IRInst* emitMakeExistential(

--- a/source/slang/ir-legalize-types.cpp
+++ b/source/slang/ir-legalize-types.cpp
@@ -384,7 +384,7 @@ static LegalVal legalizeStore(
             auto valTuple = legalVal.getTuple();
             SLANG_ASSERT(destTuple->elements.getCount() == valTuple->elements.getCount());
 
-            for (UInt i = 0; i < valTuple->elements.getCount(); i++)
+            for (Index i = 0; i < valTuple->elements.getCount(); i++)
             {
                 legalizeStore(context, destTuple->elements[i].val, valTuple->elements[i].val);
             }
@@ -892,7 +892,7 @@ static LegalVal legalizeGetElement(
             auto elemCount = ptrTupleInfo->elements.getCount();
             SLANG_ASSERT(elemCount == tupleType->elements.getCount());
 
-            for(UInt ee = 0; ee < elemCount; ++ee)
+            for(Index ee = 0; ee < elemCount; ++ee)
             {
                 auto ptrElem = ptrTupleInfo->elements[ee];
                 auto elemType = tupleType->elements[ee].type;
@@ -1003,7 +1003,7 @@ static LegalVal legalizeGetElementPtr(
             auto elemCount = ptrTupleInfo->elements.getCount();
             SLANG_ASSERT(elemCount == tupleType->elements.getCount());
 
-            for(UInt ee = 0; ee < elemCount; ++ee)
+            for(Index ee = 0; ee < elemCount; ++ee)
             {
                 auto ptrElem = ptrTupleInfo->elements[ee];
                 auto elemType = tupleType->elements[ee].type;

--- a/source/slang/ir-legalize-types.cpp
+++ b/source/slang/ir-legalize-types.cpp
@@ -22,7 +22,7 @@ namespace Slang
 
 LegalVal LegalVal::tuple(RefPtr<TuplePseudoVal> tupleVal)
 {
-    SLANG_ASSERT(tupleVal->elements.getSize());
+    SLANG_ASSERT(tupleVal->elements.getCount());
 
     LegalVal result;
     result.flavor = LegalVal::Flavor::tuple;
@@ -259,8 +259,8 @@ static LegalVal legalizeCall(
     return LegalVal::simple(context->builder->emitCallInst(
         retIRType,
         callInst->getCallee(),
-        instArgs.getSize(),
-        instArgs.Buffer()));
+        instArgs.getCount(),
+        instArgs.getBuffer()));
 }
 
 static LegalVal legalizeRetVal(IRTypeLegalizationContext*    context,
@@ -382,9 +382,9 @@ static LegalVal legalizeStore(
             // the tuple.
             auto destTuple = legalPtrVal.getTuple();
             auto valTuple = legalVal.getTuple();
-            SLANG_ASSERT(destTuple->elements.getSize() == valTuple->elements.getSize());
+            SLANG_ASSERT(destTuple->elements.getCount() == valTuple->elements.getCount());
 
-            for (UInt i = 0; i < valTuple->elements.getSize(); i++)
+            for (UInt i = 0; i < valTuple->elements.getCount(); i++)
             {
                 legalizeStore(context, destTuple->elements[i].val, valTuple->elements[i].val);
             }
@@ -889,8 +889,8 @@ static LegalVal legalizeGetElement(
             auto tupleType = type.getTuple();
             SLANG_ASSERT(tupleType);
 
-            auto elemCount = ptrTupleInfo->elements.getSize();
-            SLANG_ASSERT(elemCount == tupleType->elements.getSize());
+            auto elemCount = ptrTupleInfo->elements.getCount();
+            SLANG_ASSERT(elemCount == tupleType->elements.getCount());
 
             for(UInt ee = 0; ee < elemCount; ++ee)
             {
@@ -1000,8 +1000,8 @@ static LegalVal legalizeGetElementPtr(
             auto tupleType = type.getTuple();
             SLANG_ASSERT(tupleType);
 
-            auto elemCount = ptrTupleInfo->elements.getSize();
-            SLANG_ASSERT(elemCount == tupleType->elements.getSize());
+            auto elemCount = ptrTupleInfo->elements.getCount();
+            SLANG_ASSERT(elemCount == tupleType->elements.getCount());
 
             for(UInt ee = 0; ee < elemCount; ++ee)
             {
@@ -1096,7 +1096,7 @@ static LegalVal legalizeMakeStruct(
                 builder->emitMakeStruct(
                     legalType.getSimple(),
                     argCount,
-                    args.Buffer()));
+                    args.getBuffer()));
         }
 
     case LegalType::Flavor::pair:
@@ -1136,14 +1136,14 @@ static LegalVal legalizeMakeStruct(
             LegalVal ordinaryVal = legalizeMakeStruct(
                 context,
                 ordinaryType,
-                ordinaryArgs.Buffer(),
-                ordinaryArgs.getSize());
+                ordinaryArgs.getBuffer(),
+                ordinaryArgs.getCount());
 
             LegalVal specialVal = legalizeMakeStruct(
                 context,
                 specialType,
-                specialArgs.Buffer(),
-                specialArgs.getSize());
+                specialArgs.getBuffer(),
+                specialArgs.getCount());
 
             return LegalVal::pair(ordinaryVal, specialVal, pairInfo);
         }
@@ -1466,7 +1466,7 @@ static LegalVal legalizeInst(
         context,
         inst,
         legalType,
-        legalArgs.Buffer());
+        legalArgs.getBuffer());
 
     // After we are done, we will eliminate the
     // original instruction by removing it from
@@ -1571,8 +1571,8 @@ static LegalVal legalizeFunc(
     }
 
     auto newFuncType = context->builder->getFuncType(
-        newParamTypes.getSize(),
-        newParamTypes.Buffer(),
+        newParamTypes.getCount(),
+        newParamTypes.getBuffer(),
         newResultType);
 
     context->builder->setDataType(irFunc, newFuncType);

--- a/source/slang/ir-legalize-types.cpp
+++ b/source/slang/ir-legalize-types.cpp
@@ -22,7 +22,7 @@ namespace Slang
 
 LegalVal LegalVal::tuple(RefPtr<TuplePseudoVal> tupleVal)
 {
-    SLANG_ASSERT(tupleVal->elements.Count());
+    SLANG_ASSERT(tupleVal->elements.getSize());
 
     LegalVal result;
     result.flavor = LegalVal::Flavor::tuple;
@@ -259,7 +259,7 @@ static LegalVal legalizeCall(
     return LegalVal::simple(context->builder->emitCallInst(
         retIRType,
         callInst->getCallee(),
-        instArgs.Count(),
+        instArgs.getSize(),
         instArgs.Buffer()));
 }
 
@@ -382,9 +382,9 @@ static LegalVal legalizeStore(
             // the tuple.
             auto destTuple = legalPtrVal.getTuple();
             auto valTuple = legalVal.getTuple();
-            SLANG_ASSERT(destTuple->elements.Count() == valTuple->elements.Count());
+            SLANG_ASSERT(destTuple->elements.getSize() == valTuple->elements.getSize());
 
-            for (UInt i = 0; i < valTuple->elements.Count(); i++)
+            for (UInt i = 0; i < valTuple->elements.getSize(); i++)
             {
                 legalizeStore(context, destTuple->elements[i].val, valTuple->elements[i].val);
             }
@@ -889,8 +889,8 @@ static LegalVal legalizeGetElement(
             auto tupleType = type.getTuple();
             SLANG_ASSERT(tupleType);
 
-            auto elemCount = ptrTupleInfo->elements.Count();
-            SLANG_ASSERT(elemCount == tupleType->elements.Count());
+            auto elemCount = ptrTupleInfo->elements.getSize();
+            SLANG_ASSERT(elemCount == tupleType->elements.getSize());
 
             for(UInt ee = 0; ee < elemCount; ++ee)
             {
@@ -1000,8 +1000,8 @@ static LegalVal legalizeGetElementPtr(
             auto tupleType = type.getTuple();
             SLANG_ASSERT(tupleType);
 
-            auto elemCount = ptrTupleInfo->elements.Count();
-            SLANG_ASSERT(elemCount == tupleType->elements.Count());
+            auto elemCount = ptrTupleInfo->elements.getSize();
+            SLANG_ASSERT(elemCount == tupleType->elements.getSize());
 
             for(UInt ee = 0; ee < elemCount; ++ee)
             {
@@ -1137,13 +1137,13 @@ static LegalVal legalizeMakeStruct(
                 context,
                 ordinaryType,
                 ordinaryArgs.Buffer(),
-                ordinaryArgs.Count());
+                ordinaryArgs.getSize());
 
             LegalVal specialVal = legalizeMakeStruct(
                 context,
                 specialType,
                 specialArgs.Buffer(),
-                specialArgs.Count());
+                specialArgs.getSize());
 
             return LegalVal::pair(ordinaryVal, specialVal, pairInfo);
         }
@@ -1571,7 +1571,7 @@ static LegalVal legalizeFunc(
     }
 
     auto newFuncType = context->builder->getFuncType(
-        newParamTypes.Count(),
+        newParamTypes.getSize(),
         newParamTypes.Buffer(),
         newResultType);
 

--- a/source/slang/ir-legalize-types.cpp
+++ b/source/slang/ir-legalize-types.cpp
@@ -202,7 +202,7 @@ static void getArgumentValues(
         break;
 
     case LegalVal::Flavor::simple:
-        instArgs.Add(val.getSimple());
+        instArgs.add(val.getSimple());
         break;
 
     case LegalVal::Flavor::implicitDeref:
@@ -322,7 +322,7 @@ static LegalVal legalizeLoad(
                 element.key = ee.key;
                 element.val = legalizeLoad(context, ee.val);
 
-                tupleVal->elements.Add(element);
+                tupleVal->elements.add(element);
             }
             return LegalVal::tuple(tupleVal);
         }
@@ -615,7 +615,7 @@ static LegalVal unwrapBufferValue(
                     context,
                     legalPtrOperand,
                     ee.field);
-                obj->elements.Add(element);
+                obj->elements.add(element);
             }
 
             return LegalVal::tuple(obj);
@@ -667,7 +667,7 @@ static LegalType getPointedToType(
                 TuplePseudoType::Element resultElement;
                 resultElement.key = ee.key;
                 resultElement.type = getPointedToType(context, ee.type);
-                resultTuple->elements.Add(resultElement);
+                resultTuple->elements.add(resultElement);
             }
             return LegalType::tuple(resultTuple);
         }
@@ -905,7 +905,7 @@ static LegalVal legalizeGetElement(
                     ptrElem.val,
                     indexOperand);
 
-                resTupleInfo->elements.Add(resElem);
+                resTupleInfo->elements.add(resElem);
             }
 
             return LegalVal::tuple(resTupleInfo);
@@ -1016,7 +1016,7 @@ static LegalVal legalizeGetElementPtr(
                     ptrElem.val,
                     indexOperand);
 
-                resTupleInfo->elements.Add(resElem);
+                resTupleInfo->elements.add(resElem);
             }
 
             return LegalVal::tuple(resTupleInfo);
@@ -1090,7 +1090,7 @@ static LegalVal legalizeMakeStruct(
                 // the `struct` type with them as fields
                 // would not be simple...
                 //
-                args.Add(legalArgs[aa].getSimple());
+                args.add(legalArgs[aa].getSimple());
             }
             return LegalVal::simple(
                 builder->emitMakeStruct(
@@ -1120,16 +1120,16 @@ static LegalVal legalizeMakeStruct(
                 {
                     // The argument is itself a pair
                     auto argPair = arg.getPair();
-                    ordinaryArgs.Add(argPair->ordinaryVal);
-                    specialArgs.Add(argPair->specialVal);
+                    ordinaryArgs.add(argPair->ordinaryVal);
+                    specialArgs.add(argPair->specialVal);
                 }
                 else if(ee.flags & Slang::PairInfo::kFlag_hasOrdinary)
                 {
-                    ordinaryArgs.Add(arg);
+                    ordinaryArgs.add(arg);
                 }
                 else if(ee.flags & Slang::PairInfo::kFlag_hasSpecial)
                 {
-                    specialArgs.Add(arg);
+                    specialArgs.add(arg);
                 }
             }
 
@@ -1172,7 +1172,7 @@ static LegalVal legalizeMakeStruct(
                 resElem.key = elemKey;
                 resElem.val = argVal;
 
-                resTupleInfo->elements.Add(resElem);
+                resTupleInfo->elements.add(resElem);
             }
             return LegalVal::tuple(resTupleInfo);
         }
@@ -1316,7 +1316,7 @@ static LegalVal legalizeLocalVar(
         // Remove the old local var.
         irLocalVar->removeFromParent();
         // add old local var to list
-        context->replacedInstructions.Add(irLocalVar);
+        context->replacedInstructions.add(irLocalVar);
         return newVal;
     }
     break;
@@ -1348,7 +1348,7 @@ static LegalVal legalizeParam(
         auto newVal = declareVars(context, kIROp_Param, legalParamType, nullptr, LegalVarChain(), nameHint, originalParam, nullptr);
 
         originalParam->removeFromParent();
-        context->replacedInstructions.Add(originalParam);
+        context->replacedInstructions.add(originalParam);
         return newVal;
     }
 }
@@ -1422,7 +1422,7 @@ static LegalVal legalizeInst(
     {
         auto oldArg = inst->getOperand(aa);
         auto legalArg = legalizeOperand(context, oldArg);
-        legalArgs.Add(legalArg);
+        legalArgs.add(legalArg);
 
         if (legalArg.flavor != LegalVal::Flavor::simple)
             anyComplex = true;
@@ -1473,7 +1473,7 @@ static LegalVal legalizeInst(
     // the IR.
     //
     inst->removeFromParent();
-    context->replacedInstructions.Add(inst);
+    context->replacedInstructions.add(inst);
 
     // The value to be used when referencing
     // the original instruction will now be
@@ -1489,7 +1489,7 @@ static void addParamType(List<IRType*>& ioParamTypes, LegalType t)
         break;
 
     case LegalType::Flavor::simple:
-        ioParamTypes.Add(t.getSimple());
+        ioParamTypes.add(t.getSimple());
         break;
 
     case LegalType::Flavor::implicitDeref:
@@ -1799,7 +1799,7 @@ static void _addFieldsToWrappedBufferElementTypeLayout(
             // information so that we can find the field layout
             // based on the IR key for the struct field.
             //
-            newTypeLayout->fields.Add(newFieldLayout);
+            newTypeLayout->fields.add(newFieldLayout);
             newTypeLayout->mapKeyToLayout.Add(simpleInfo->key, newFieldLayout);
         }
         break;
@@ -2310,7 +2310,7 @@ static LegalVal declareVars(
                 TuplePseudoVal::Element element;
                 element.key = ee.key;
                 element.val = fieldVal;
-                tupleVal->elements.Add(element);
+                tupleVal->elements.add(element);
             }
 
             return LegalVal::tuple(tupleVal);
@@ -2380,7 +2380,7 @@ static LegalVal legalizeGlobalVar(
 
             // Remove the old global from the module.
             irGlobalVar->removeFromParent();
-            context->replacedInstructions.Add(irGlobalVar);
+            context->replacedInstructions.add(irGlobalVar);
 
             return newVal;
         }
@@ -2424,7 +2424,7 @@ static LegalVal legalizeGlobalConstant(
 
             // Remove the old global from the module.
             irGlobalConstant->removeFromParent();
-            context->replacedInstructions.Add(irGlobalConstant);
+            context->replacedInstructions.add(irGlobalConstant);
 
             return newVal;
         }
@@ -2473,7 +2473,7 @@ static LegalVal legalizeGlobalParam(
 
             // Remove the old global from the module.
             irGlobalParam->removeFromParent();
-            context->replacedInstructions.Add(irGlobalParam);
+            context->replacedInstructions.add(irGlobalParam);
 
             return newVal;
         }

--- a/source/slang/ir-link.cpp
+++ b/source/slang/ir-link.cpp
@@ -775,7 +775,7 @@ IRFunc* specializeIRForEntryPoint(
     if( auto firstBlock = clonedFunc->getFirstBlock() )
     {
         auto paramsStructLayout = getScopeStructLayout(entryPointLayout);
-        UInt paramLayoutCount = paramsStructLayout->fields.Count();
+        UInt paramLayoutCount = paramsStructLayout->fields.getSize();
         UInt paramCounter = 0;
         for( auto pp = firstBlock->getFirstParam(); pp; pp = pp->getNextParam() )
         {

--- a/source/slang/ir-link.cpp
+++ b/source/slang/ir-link.cpp
@@ -775,11 +775,11 @@ IRFunc* specializeIRForEntryPoint(
     if( auto firstBlock = clonedFunc->getFirstBlock() )
     {
         auto paramsStructLayout = getScopeStructLayout(entryPointLayout);
-        UInt paramLayoutCount = paramsStructLayout->fields.getCount();
-        UInt paramCounter = 0;
+        Index paramLayoutCount = paramsStructLayout->fields.getCount();
+        Index paramCounter = 0;
         for( auto pp = firstBlock->getFirstParam(); pp; pp = pp->getNextParam() )
         {
-            UInt paramIndex = paramCounter++;
+            Index paramIndex = paramCounter++;
             if( paramIndex < paramLayoutCount )
             {
                 auto paramLayout = paramsStructLayout->fields[paramIndex];

--- a/source/slang/ir-link.cpp
+++ b/source/slang/ir-link.cpp
@@ -775,7 +775,7 @@ IRFunc* specializeIRForEntryPoint(
     if( auto firstBlock = clonedFunc->getFirstBlock() )
     {
         auto paramsStructLayout = getScopeStructLayout(entryPointLayout);
-        UInt paramLayoutCount = paramsStructLayout->fields.getSize();
+        UInt paramLayoutCount = paramsStructLayout->fields.getCount();
         UInt paramCounter = 0;
         for( auto pp = firstBlock->getFirstParam(); pp; pp = pp->getNextParam() )
         {

--- a/source/slang/ir-restructure.cpp
+++ b/source/slang/ir-restructure.cpp
@@ -514,14 +514,14 @@ namespace Slang
                         caseIndex++;
 
                         RefPtr<SwitchRegion::Case> currentCase = new SwitchRegion::Case();
-                        switchRegion->cases.Add(currentCase);
+                        switchRegion->cases.add(currentCase);
 
                         // Add the case value for this case, and any
                         // others that share the same label
                         //
                         for(;;)
                         {
-                            currentCase->values.Add(caseVal);
+                            currentCase->values.add(caseVal);
 
                             // Are there any more `case`s left?
                             //
@@ -586,7 +586,7 @@ namespace Slang
                     if(!defaultLabelHandled)
                     {
                         RefPtr<SwitchRegion::Case> defaultCase = new SwitchRegion::Case();
-                        switchRegion->cases.Add(defaultCase);
+                        switchRegion->cases.add(defaultCase);
 
                         // Note: we use `null` instead of `breakLabel` as the end block
                         // here, to ensure that the `default` region will end with an

--- a/source/slang/ir-sccp.cpp
+++ b/source/slang/ir-sccp.cpp
@@ -357,7 +357,7 @@ struct SCCPContext
                 // executed. We do this by adding the target to our CFG work list.
                 //
                 auto target = unconditionalBranch->getTargetBlock();
-                cfgWorkList.Add(target);
+                cfgWorkList.add(target);
 
                 // Besides transferring control to another block, the other
                 // thing our unconditional branch instructions do is provide
@@ -408,7 +408,7 @@ struct SCCPContext
                         setLatticeVal(param, newVal);
                         for( auto use = param->firstUse; use; use = use->nextUse )
                         {
-                            ssaWorkList.Add(use->getUser());
+                            ssaWorkList.add(use->getUser());
                         }
                     }
                 }
@@ -448,7 +448,7 @@ struct SCCPContext
                         // bail out now.
                         //
                         auto target = boolConst->getValue() ? conditionalBranch->getTrueBlock() : conditionalBranch->getFalseBlock();
-                        cfgWorkList.Add(target);
+                        cfgWorkList.add(target);
                         return;
                     }
                 }
@@ -459,8 +459,8 @@ struct SCCPContext
                 // taken, so that both of the target blocks are
                 // potentially executed.
                 //
-                cfgWorkList.Add(conditionalBranch->getTrueBlock());
-                cfgWorkList.Add(conditionalBranch->getFalseBlock());
+                cfgWorkList.add(conditionalBranch->getTrueBlock());
+                cfgWorkList.add(conditionalBranch->getFalseBlock());
             }
             else if( auto switchInst = as<IRSwitch>(inst) )
             {
@@ -497,7 +497,7 @@ struct SCCPContext
                         // Whatever single block we decided will get executed,
                         // we need to make sure it gets processed and then bail.
                         //
-                        cfgWorkList.Add(target);
+                        cfgWorkList.add(target);
                         return;
                     }
                 }
@@ -507,9 +507,9 @@ struct SCCPContext
                 //
                 for( UInt cc = 0; cc < caseCount; ++cc )
                 {
-                    cfgWorkList.Add(switchInst->getCaseLabel(cc));
+                    cfgWorkList.add(switchInst->getCaseLabel(cc));
                 }
-                cfgWorkList.Add(switchInst->getDefaultLabel());
+                cfgWorkList.add(switchInst->getDefaultLabel());
             }
 
             // There are other cases of terminator instructions not handled
@@ -563,7 +563,7 @@ struct SCCPContext
         //
         for( auto use = inst->firstUse; use; use = use->nextUse )
         {
-            ssaWorkList.Add(use->getUser());
+            ssaWorkList.add(use->getUser());
         }
     }
 
@@ -584,7 +584,7 @@ struct SCCPContext
         // The entry block is always going to be executed when the
         // function gets called, so we will process it right away.
         //
-        cfgWorkList.Add(firstBlock);
+        cfgWorkList.add(firstBlock);
 
         // The parameters of the first block are our function parameters,
         // and we want to operate on the assumption that they could have
@@ -728,7 +728,7 @@ struct SCCPContext
                 inst->replaceUsesWith(constantVal);
                 if( !inst->mightHaveSideEffects() )
                 {
-                    instsToRemove.Add(inst);
+                    instsToRemove.add(inst);
                 }
             }
         }
@@ -817,7 +817,7 @@ struct SCCPContext
         {
             if( !isMarkedAsExecuted(block) )
             {
-                unreachableBlocks.Add(block);
+                unreachableBlocks.add(block);
             }
         }
         //

--- a/source/slang/ir-sccp.cpp
+++ b/source/slang/ir-sccp.cpp
@@ -597,7 +597,7 @@ struct SCCPContext
 
         // Now we will iterate until both of our work lists go dry.
         //
-        while(cfgWorkList.getSize() || ssaWorkList.getSize())
+        while(cfgWorkList.getCount() || ssaWorkList.getCount())
         {
             // Note: there is a design choice to be had here
             // around whether we do `if if` or `while while`
@@ -607,7 +607,7 @@ struct SCCPContext
             // We will start by processing any blocks that we
             // have determined are potentially reachable.
             //
-            while( cfgWorkList.getSize() )
+            while( cfgWorkList.getCount() )
             {
                 // We pop one block off of the work list.
                 //
@@ -644,7 +644,7 @@ struct SCCPContext
             // will start looking at individual instructions that
             // need to be updated.
             //
-            while( ssaWorkList.getSize() )
+            while( ssaWorkList.getCount() )
             {
                 // We pop one instruction that needs an update.
                 //

--- a/source/slang/ir-sccp.cpp
+++ b/source/slang/ir-sccp.cpp
@@ -612,7 +612,7 @@ struct SCCPContext
                 // We pop one block off of the work list.
                 //
                 auto block = cfgWorkList[0];
-                cfgWorkList.FastRemoveAt(0);
+                cfgWorkList.fastRemoveAt(0);
 
                 // We only want to process blocks that haven't
                 // already been marked as executed, so that we
@@ -649,7 +649,7 @@ struct SCCPContext
                 // We pop one instruction that needs an update.
                 //
                 auto inst = ssaWorkList[0];
-                ssaWorkList.FastRemoveAt(0);
+                ssaWorkList.fastRemoveAt(0);
 
                 // Before updating the instruction, we will check if
                 // the parent block of the instructin is marked as

--- a/source/slang/ir-sccp.cpp
+++ b/source/slang/ir-sccp.cpp
@@ -597,7 +597,7 @@ struct SCCPContext
 
         // Now we will iterate until both of our work lists go dry.
         //
-        while(cfgWorkList.Count() || ssaWorkList.Count())
+        while(cfgWorkList.getSize() || ssaWorkList.getSize())
         {
             // Note: there is a design choice to be had here
             // around whether we do `if if` or `while while`
@@ -607,7 +607,7 @@ struct SCCPContext
             // We will start by processing any blocks that we
             // have determined are potentially reachable.
             //
-            while( cfgWorkList.Count() )
+            while( cfgWorkList.getSize() )
             {
                 // We pop one block off of the work list.
                 //
@@ -644,7 +644,7 @@ struct SCCPContext
             // will start looking at individual instructions that
             // need to be updated.
             //
-            while( ssaWorkList.Count() )
+            while( ssaWorkList.getSize() )
             {
                 // We pop one instruction that needs an update.
                 //

--- a/source/slang/ir-serialize.cpp
+++ b/source/slang/ir-serialize.cpp
@@ -112,7 +112,7 @@ void StringRepresentationCache::init(const List<char>* stringTable, NamePool* na
             entry.m_numChars = len;
             entry.m_object = nullptr;
 
-            m_entries.Add(entry);
+            m_entries.add(entry);
 
             cur = reader.m_pos + len;
         }
@@ -239,7 +239,7 @@ char* StringRepresentationCache::getCStr(Handle handle)
     {
         CharReader reader(cur);
         const int len = GetUnicodePointFromUTF8(reader);
-        slicesOut.Add(UnownedStringSlice(reader.m_pos, len));
+        slicesOut.add(UnownedStringSlice(reader.m_pos, len));
         cur = reader.m_pos + len;
     }
 }
@@ -377,7 +377,7 @@ void IRSerialWriter::_addInstruction(IRInst* inst)
 
     // Add to the map
     m_instMap.Add(inst, Ser::InstIndex(m_insts.getSize()));
-    m_insts.Add(inst);
+    m_insts.add(inst);
 }
 
 #if 0
@@ -444,7 +444,7 @@ void IRSerialWriter::_addDebugSourceLocRun(SourceLoc sourceLoc, uint32_t startIn
         int entryIndex = sourceView->findEntryIndex(sourceLoc);
         if (entryIndex < 0)
         {
-            debugSourceFile->m_lineInfos.Add(lineInfo);
+            debugSourceFile->m_lineInfos.add(lineInfo);
         }
         else
         {
@@ -463,7 +463,7 @@ void IRSerialWriter::_addDebugSourceLocRun(SourceLoc sourceLoc, uint32_t startIn
 
             adjustedLineInfo.m_adjustedLineIndex = lineIndex + entry.m_lineAdjust;
 
-            debugSourceFile->m_adjustedLineInfos.Add(adjustedLineInfo);
+            debugSourceFile->m_adjustedLineInfos.add(adjustedLineInfo);
         }
 
         debugSourceFile->setHasLineIndex(lineIndex);
@@ -475,7 +475,7 @@ void IRSerialWriter::_addDebugSourceLocRun(SourceLoc sourceLoc, uint32_t startIn
     sourceLocRun.m_startInstIndex = IRSerialData::InstIndex(startInstIndex);
     sourceLocRun.m_sourceLoc = uint32_t(debugSourceFile->m_baseSourceLoc + offset);
 
-    m_serialData->m_debugSourceLocRuns.Add(sourceLocRun);
+    m_serialData->m_debugSourceLocRuns.add(sourceLocRun);
 }
 
 Result IRSerialWriter::_calcDebugInfo()
@@ -508,7 +508,7 @@ Result IRSerialWriter::_calcDebugInfo()
         InstLoc instLoc;
         instLoc.instIndex = uint32_t(i);
         instLoc.sourceLoc = uint32_t(srcInst->sourceLoc.getRaw());
-        instLocs.Add(instLoc);
+        instLocs.add(instLoc);
     }
 
     // Sort them
@@ -567,7 +567,7 @@ Result IRSerialWriter::_calcDebugInfo()
         m_serialData->m_debugAdjustedLineInfos.AddRange(debugSourceFile->m_adjustedLineInfos.begin(), debugSourceFile->m_adjustedLineInfos.getSize());
 
         // Add the source info
-        m_serialData->m_debugSourceInfos.Add(sourceInfo);
+        m_serialData->m_debugSourceInfos.add(sourceInfo);
     }
 
     // Convert the string pool
@@ -587,7 +587,7 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
 
     // We reserve 0 for null
     m_insts.Clear();
-    m_insts.Add(nullptr);
+    m_insts.add(nullptr);
 
     // Reset
     m_instMap.Clear();
@@ -597,7 +597,7 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
     List<IRInst*> parentInstStack;
   
     IRModuleInst* moduleInst = module->getModuleInst();
-    parentInstStack.Add(moduleInst);
+    parentInstStack.add(moduleInst);
 
     // Add to the map
     _addInstruction(moduleInst);
@@ -606,8 +606,8 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
     while (parentInstStack.getSize())
     {
         // If it's in the stack it is assumed it is already in the inst map
-        IRInst* parentInst = parentInstStack.Last();
-        parentInstStack.RemoveLast();
+        IRInst* parentInst = parentInstStack.getLast();
+        parentInstStack.removeLast();
         SLANG_ASSERT(m_instMap.ContainsKey(parentInst));
 
         // Okay we go through each of the children in order. If they are IRInstParent derived, we add to stack to process later 
@@ -622,7 +622,7 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
 
             _addInstruction(child);
             
-            parentInstStack.Add(child);
+            parentInstStack.add(child);
         }
 
         // If it had any children, then store the information about it
@@ -633,7 +633,7 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
             run.m_startInstIndex = startChildInstIndex;
             run.m_numChildren = Ser::SizeType(m_insts.getSize() - int(startChildInstIndex));
 
-            m_serialData->m_childRuns.Add(run);
+            m_serialData->m_childRuns.add(run);
         }
     }
 
@@ -1949,23 +1949,23 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
     List<IRInst*> parentInstStack;
 
     IRModuleInst* moduleInst = module->getModuleInst();
-    parentInstStack.Add(moduleInst);
+    parentInstStack.add(moduleInst);
 
     // Add to list
-    instsOut.Add(moduleInst);
+    instsOut.add(moduleInst);
 
     // Traverse all of the instructions
     while (parentInstStack.getSize())
     {
         // If it's in the stack it is assumed it is already in the inst map
-        IRInst* parentInst = parentInstStack.Last();
-        parentInstStack.RemoveLast();
+        IRInst* parentInst = parentInstStack.getLast();
+        parentInstStack.removeLast();
 
         IRInstListBase childrenList = parentInst->getDecorationsAndChildren();
         for (IRInst* child : childrenList)
         {
-            instsOut.Add(child);
-            parentInstStack.Add(child);
+            instsOut.add(child);
+            parentInstStack.add(child);
         }
     }
 }

--- a/source/slang/ir-serialize.cpp
+++ b/source/slang/ir-serialize.cpp
@@ -118,7 +118,7 @@ void StringRepresentationCache::init(const List<char>* stringTable, NamePool* na
         }
     }
 
-    m_entries.Compress();
+    m_entries.compress();
 }
 
 Name* StringRepresentationCache::getName(Handle handle)

--- a/source/slang/ir-serialize.cpp
+++ b/source/slang/ir-serialize.cpp
@@ -2025,7 +2025,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
     {
         SLANG_ASSERT(readInsts[0] == originalInsts[0]);
         // All the source locs should be identical
-        for (UInt i = 1; i < readInsts.getCount(); ++i)
+        for (Index i = 1; i < readInsts.getCount(); ++i)
         {
             IRInst* origInst = originalInsts[i];
             IRInst* readInst = readInsts[i];
@@ -2040,7 +2040,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
     else if (optionFlags & IRSerialWriter::OptionFlag::DebugInfo)
     {
         // They should be on the same line nos
-        for (UInt i = 1; i < readInsts.getCount(); ++i)
+        for (Index i = 1; i < readInsts.getCount(); ++i)
         {
             IRInst* origInst = originalInsts[i];
             IRInst* readInst = readInsts[i];

--- a/source/slang/ir-serialize.cpp
+++ b/source/slang/ir-serialize.cpp
@@ -209,7 +209,7 @@ char* StringRepresentationCache::getCStr(Handle handle)
     
 /* static */void SerialStringTableUtil::encodeStringTable(const UnownedStringSlice* slices, size_t numSlices, List<char>& stringTable)
 {
-    stringTable.Clear();
+    stringTable.clear();
     for (size_t i = 0; i < numSlices; ++i)
     {
         const UnownedStringSlice slice = slices[i];
@@ -309,18 +309,18 @@ void IRSerialData::clear()
     m_insts.SetSize(1);
     memset(&m_insts[0], 0, sizeof(Inst));
 
-    m_childRuns.Clear();
-    m_externalOperands.Clear();
-    m_rawSourceLocs.Clear();
+    m_childRuns.clear();
+    m_externalOperands.clear();
+    m_rawSourceLocs.clear();
 
-    m_stringTable.Clear();
+    m_stringTable.clear();
     
     // Debug data
-    m_debugLineInfos.Clear();
-    m_debugAdjustedLineInfos.Clear();
-    m_debugSourceInfos.Clear();
-    m_debugSourceLocRuns.Clear();
-    m_debugStringTable.Clear();
+    m_debugLineInfos.clear();
+    m_debugAdjustedLineInfos.clear();
+    m_debugSourceInfos.clear();
+    m_debugSourceLocRuns.clear();
+    m_debugStringTable.clear();
 }
 
 template <typename T>
@@ -563,8 +563,8 @@ Result IRSerialWriter::_calcDebugInfo()
         sourceInfo.m_numAdjustedLineInfos = uint32_t(debugSourceFile->m_adjustedLineInfos.getSize());
 
         // Add the line infos
-        m_serialData->m_debugLineInfos.AddRange(debugSourceFile->m_lineInfos.begin(), debugSourceFile->m_lineInfos.getSize());
-        m_serialData->m_debugAdjustedLineInfos.AddRange(debugSourceFile->m_adjustedLineInfos.begin(), debugSourceFile->m_adjustedLineInfos.getSize());
+        m_serialData->m_debugLineInfos.addRange(debugSourceFile->m_lineInfos.begin(), debugSourceFile->m_lineInfos.getSize());
+        m_serialData->m_debugAdjustedLineInfos.addRange(debugSourceFile->m_adjustedLineInfos.begin(), debugSourceFile->m_adjustedLineInfos.getSize());
 
         // Add the source info
         m_serialData->m_debugSourceInfos.add(sourceInfo);
@@ -586,12 +586,12 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
     serialData->clear();
 
     // We reserve 0 for null
-    m_insts.Clear();
+    m_insts.clear();
     m_insts.add(nullptr);
 
     // Reset
     m_instMap.Clear();
-    m_decorations.Clear();
+    m_decorations.clear();
     
     // Stack for parentInst
     List<IRInst*> parentInstStack;
@@ -905,7 +905,7 @@ Result _encodeInsts(IRSerialBinary::CompressionType compressionType, const List<
     {
         return SLANG_FAIL;
     }
-    encodeArrayOut.Clear();
+    encodeArrayOut.clear();
     
     const size_t numInsts = size_t(instsIn.getSize());
     const IRSerialData::Inst* insts = instsIn.begin();
@@ -927,10 +927,10 @@ Result _encodeInsts(IRSerialBinary::CompressionType compressionType, const List<
         {
             const size_t offset = size_t(encodeOut - encodeArrayOut.begin());
             
-            const UInt oldCapacity = encodeArrayOut.Capacity();
+            const UInt oldCapacity = encodeArrayOut.getCapacity();
 
             encodeArrayOut.Reserve(oldCapacity + (oldCapacity >> 1) + maxInstSize);
-            const UInt capacity = encodeArrayOut.Capacity();
+            const UInt capacity = encodeArrayOut.getCapacity();
             encodeArrayOut.SetSize(capacity);
 
             encodeOut = encodeArrayOut.begin() + offset;
@@ -1816,7 +1816,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
                 }
             }
             // Add regular lines
-            lineInfos.AddRange(m_serialData->m_debugLineInfos.Buffer() + srcSourceInfo.m_lineInfosStartIndex, srcSourceInfo.m_numLineInfos);
+            lineInfos.addRange(m_serialData->m_debugLineInfos.Buffer() + srcSourceInfo.m_lineInfosStartIndex, srcSourceInfo.m_numLineInfos);
             // Put in sourceloc order
             lineInfos.Sort();
 
@@ -1865,7 +1865,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
 
                 int numEntries = int(srcSourceInfo.m_numAdjustedLineInfos);
 
-                adjustedLineInfos.AddRange(m_serialData->m_debugAdjustedLineInfos.Buffer() + srcSourceInfo.m_adjustedLineInfosStartIndex, numEntries);
+                adjustedLineInfos.addRange(m_serialData->m_debugAdjustedLineInfos.Buffer() + srcSourceInfo.m_adjustedLineInfosStartIndex, numEntries);
                 adjustedLineInfos.Sort();
 
                 // Work out the views adjustments, and place in dstEntries

--- a/source/slang/ir-serialize.cpp
+++ b/source/slang/ir-serialize.cpp
@@ -81,7 +81,7 @@ void StringRepresentationCache::init(const List<char>* stringTable, NamePool* na
     m_scopeManager = scopeManager;
 
     // Decode the table
-    m_entries.setSize(StringSlicePool::kNumDefaultHandles);
+    m_entries.setCount(StringSlicePool::kNumDefaultHandles);
     SLANG_COMPILE_TIME_ASSERT(StringSlicePool::kNumDefaultHandles == 2);
 
     {
@@ -218,9 +218,9 @@ char* StringRepresentationCache::getCStr(Handle handle)
         // We need to write into the the string array
         char prefixBytes[6];
         const int numPrefixBytes = EncodeUnicodePointToUTF8(prefixBytes, len);
-        const int baseIndex = int(stringTable.getSize());
+        const int baseIndex = int(stringTable.getCount());
 
-        stringTable.setSize(baseIndex + numPrefixBytes + len);
+        stringTable.setCount(baseIndex + numPrefixBytes + len);
 
         char* dst = stringTable.begin() + baseIndex;
 
@@ -246,7 +246,7 @@ char* StringRepresentationCache::getCStr(Handle handle)
 
 /* static */void SerialStringTableUtil::decodeStringTable(const List<char>& stringTable, List<UnownedStringSlice>& slicesOut)
 {
-    slicesOut.setSize(2);
+    slicesOut.setCount(2);
     slicesOut[0] = UnownedStringSlice(nullptr, size_t(0));
     slicesOut[1] = UnownedStringSlice("", size_t(0));
 
@@ -255,18 +255,18 @@ char* StringRepresentationCache::getCStr(Handle handle)
 
 /* static */void SerialStringTableUtil::calcStringSlicePoolMap(const List<UnownedStringSlice>& slices, StringSlicePool& pool, List<StringSlicePool::Handle>& indexMapOut)
 {
-    SLANG_ASSERT(slices.getSize() >= StringSlicePool::kNumDefaultHandles);
+    SLANG_ASSERT(slices.getCount() >= StringSlicePool::kNumDefaultHandles);
     SLANG_ASSERT(slices[int(StringSlicePool::kNullHandle)] == "" && slices[int(StringSlicePool::kNullHandle)].begin() == nullptr);
     SLANG_ASSERT(slices[int(StringSlicePool::kEmptyHandle)] == "");
 
-    indexMapOut.setSize(slices.getSize());
+    indexMapOut.setCount(slices.getCount());
     // Set up all of the defaults
     for (int i = 0; i < StringSlicePool::kNumDefaultHandles; ++i)
     {
         indexMapOut[i] = StringSlicePool::Handle(i);
     }
 
-    const int numSlices = int(slices.getSize());
+    const int numSlices = int(slices.getCount());
     for (int i = StringSlicePool::kNumDefaultHandles; i < numSlices ; ++i)
     {
         indexMapOut[i] = pool.add(slices[i]);
@@ -278,7 +278,7 @@ char* StringRepresentationCache::getCStr(Handle handle)
 template<typename T>
 static size_t _calcArraySize(const List<T>& list)
 {
-    return list.getSize() * sizeof(T);
+    return list.getCount() * sizeof(T);
 }
 
 size_t IRSerialData::calcSizeInBytes() const
@@ -306,7 +306,7 @@ IRSerialData::IRSerialData()
 void IRSerialData::clear()
 {
     // First Instruction is null
-    m_insts.setSize(1);
+    m_insts.setCount(1);
     memset(&m_insts[0], 0, sizeof(Inst));
 
     m_childRuns.clear();
@@ -326,12 +326,12 @@ void IRSerialData::clear()
 template <typename T>
 static bool _isEqual(const List<T>& aIn, const List<T>& bIn)
 {
-    if (aIn.getSize() != bIn.getSize())
+    if (aIn.getCount() != bIn.getCount())
     {
         return false;
     }
 
-    size_t size = size_t(aIn.getSize());
+    size_t size = size_t(aIn.getCount());
 
     const T* a = aIn.begin();
     const T* b = bIn.begin();
@@ -376,7 +376,7 @@ void IRSerialWriter::_addInstruction(IRInst* inst)
     SLANG_ASSERT(!m_instMap.ContainsKey(inst));
 
     // Add to the map
-    m_instMap.Add(inst, Ser::InstIndex(m_insts.getSize()));
+    m_instMap.Add(inst, Ser::InstIndex(m_insts.getCount()));
     m_insts.add(inst);
 }
 
@@ -497,7 +497,7 @@ Result IRSerialWriter::_calcDebugInfo()
 
     // Find all of the source locations and their associated instructions
     List<InstLoc> instLocs;
-    const int numInsts = int(m_insts.getSize());
+    const int numInsts = int(m_insts.getCount());
     for (int i = 1; i < numInsts; i++)
     {
         IRInst* srcInst = m_insts[i];
@@ -549,22 +549,22 @@ Result IRSerialWriter::_calcDebugInfo()
 
         IRSerialData::DebugSourceInfo sourceInfo;
 
-        sourceInfo.m_numLines = uint32_t(debugSourceFile->m_sourceFile->getLineBreakOffsets().getSize());
+        sourceInfo.m_numLines = uint32_t(debugSourceFile->m_sourceFile->getLineBreakOffsets().getCount());
 
         sourceInfo.m_startSourceLoc = uint32_t(debugSourceFile->m_baseSourceLoc);
         sourceInfo.m_endSourceLoc = uint32_t(debugSourceFile->m_baseSourceLoc + sourceFile->getContentSize());
 
         sourceInfo.m_pathIndex = Ser::StringIndex(m_debugStringSlicePool.add(sourceFile->getPathInfo().foundPath));
 
-        sourceInfo.m_lineInfosStartIndex = uint32_t(m_serialData->m_debugLineInfos.getSize());
-        sourceInfo.m_adjustedLineInfosStartIndex = uint32_t(m_serialData->m_debugAdjustedLineInfos.getSize());
+        sourceInfo.m_lineInfosStartIndex = uint32_t(m_serialData->m_debugLineInfos.getCount());
+        sourceInfo.m_adjustedLineInfosStartIndex = uint32_t(m_serialData->m_debugAdjustedLineInfos.getCount());
 
-        sourceInfo.m_numLineInfos = uint32_t(debugSourceFile->m_lineInfos.getSize());
-        sourceInfo.m_numAdjustedLineInfos = uint32_t(debugSourceFile->m_adjustedLineInfos.getSize());
+        sourceInfo.m_numLineInfos = uint32_t(debugSourceFile->m_lineInfos.getCount());
+        sourceInfo.m_numAdjustedLineInfos = uint32_t(debugSourceFile->m_adjustedLineInfos.getCount());
 
         // Add the line infos
-        m_serialData->m_debugLineInfos.addRange(debugSourceFile->m_lineInfos.begin(), debugSourceFile->m_lineInfos.getSize());
-        m_serialData->m_debugAdjustedLineInfos.addRange(debugSourceFile->m_adjustedLineInfos.begin(), debugSourceFile->m_adjustedLineInfos.getSize());
+        m_serialData->m_debugLineInfos.addRange(debugSourceFile->m_lineInfos.begin(), debugSourceFile->m_lineInfos.getCount());
+        m_serialData->m_debugAdjustedLineInfos.addRange(debugSourceFile->m_adjustedLineInfos.begin(), debugSourceFile->m_adjustedLineInfos.getCount());
 
         // Add the source info
         m_serialData->m_debugSourceInfos.add(sourceInfo);
@@ -603,7 +603,7 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
     _addInstruction(moduleInst);
 
     // Traverse all of the instructions
-    while (parentInstStack.getSize())
+    while (parentInstStack.getCount())
     {
         // If it's in the stack it is assumed it is already in the inst map
         IRInst* parentInst = parentInstStack.getLast();
@@ -612,7 +612,7 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
 
         // Okay we go through each of the children in order. If they are IRInstParent derived, we add to stack to process later 
         // cos we want breadth first so the order of children is the same as their index order, meaning we don't need to store explicit indices
-        const Ser::InstIndex startChildInstIndex = Ser::InstIndex(m_insts.getSize());
+        const Ser::InstIndex startChildInstIndex = Ser::InstIndex(m_insts.getCount());
         
         IRInstListBase childrenList = parentInst->getDecorationsAndChildren();
         for (IRInst* child : childrenList)
@@ -626,12 +626,12 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
         }
 
         // If it had any children, then store the information about it
-        if (Ser::InstIndex(m_insts.getSize()) != startChildInstIndex)
+        if (Ser::InstIndex(m_insts.getCount()) != startChildInstIndex)
         {
             Ser::InstRun run;
             run.m_parentIndex = m_instMap[parentInst];
             run.m_startInstIndex = startChildInstIndex;
-            run.m_numChildren = Ser::SizeType(m_insts.getSize() - int(startChildInstIndex));
+            run.m_numChildren = Ser::SizeType(m_insts.getCount() - int(startChildInstIndex));
 
             m_serialData->m_childRuns.add(run);
         }
@@ -650,13 +650,13 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
 #endif
 
     // Set to the right size
-    m_serialData->m_insts.setSize(m_insts.getSize());
+    m_serialData->m_insts.setCount(m_insts.getCount());
     // Clear all instructions
-    memset(m_serialData->m_insts.begin(), 0, sizeof(Ser::Inst) * m_serialData->m_insts.getSize());
+    memset(m_serialData->m_insts.begin(), 0, sizeof(Ser::Inst) * m_serialData->m_insts.getCount());
 
     // Need to set up the actual instructions
     {
-        const int numInsts = int(m_insts.getSize());
+        const int numInsts = int(m_insts.getCount());
 
         for (int i = 1; i < numInsts; ++i)
         {
@@ -744,8 +744,8 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
             {
                 dstInst.m_payloadType = PayloadType::OperandExternal;
 
-                int operandArrayBaseIndex = int(m_serialData->m_externalOperands.getSize());
-                m_serialData->m_externalOperands.setSize(operandArrayBaseIndex + numOperands);
+                int operandArrayBaseIndex = int(m_serialData->m_externalOperands.getCount());
+                m_serialData->m_externalOperands.setCount(operandArrayBaseIndex + numOperands);
 
                 dstOperands = m_serialData->m_externalOperands.begin() + operandArrayBaseIndex; 
 
@@ -770,8 +770,8 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
     // If the option to use RawSourceLocations is enabled, serialize out as is
     if (options & OptionFlag::RawSourceLocation)
     {
-        const int numInsts = int(m_insts.getSize());
-        serialData->m_rawSourceLocs.setSize(numInsts);
+        const int numInsts = int(m_insts.getCount());
+        serialData->m_rawSourceLocs.setCount(numInsts);
 
         Ser::RawSourceLoc* dstLocs =  serialData->m_rawSourceLocs.begin();
         // 0 is null, just mark as no location
@@ -797,18 +797,18 @@ static size_t _calcChunkSize(IRSerialBinary::CompressionType compressionType, co
 {
     typedef IRSerialBinary Bin;
 
-    if (array.getSize())
+    if (array.getCount())
     {
         switch (compressionType)
         {
             case Bin::CompressionType::None:
             {
-                const size_t size = sizeof(Bin::ArrayHeader) + sizeof(T) * array.getSize();
+                const size_t size = sizeof(Bin::ArrayHeader) + sizeof(T) * array.getCount();
                 return (size + 3) & ~size_t(3);
             }
             case Bin::CompressionType::VariableByteLite:
             {
-                const size_t payloadSize = ByteEncodeUtil::calcEncodeLiteSizeUInt32((const uint32_t*)array.begin(), (array.getSize() * sizeof(T)) / sizeof(uint32_t));
+                const size_t payloadSize = ByteEncodeUtil::calcEncodeLiteSizeUInt32((const uint32_t*)array.begin(), (array.getCount() * sizeof(T)) / sizeof(uint32_t));
                 const size_t size = sizeof(Bin::CompressedArrayHeader) + payloadSize;
                 return (size + 3) & ~size_t(3);
             }
@@ -860,7 +860,7 @@ static Result _writeArrayChunk(IRSerialBinary::CompressionType compressionType, 
 
             ByteEncodeUtil::encodeLiteUInt32((const uint32_t*)data, numCompressedEntries, compressedPayload);
 
-            payloadSize = sizeof(Bin::CompressedArrayHeader) - sizeof(Bin::Chunk) + compressedPayload.getSize();
+            payloadSize = sizeof(Bin::CompressedArrayHeader) - sizeof(Bin::Chunk) + compressedPayload.getCount();
 
             Bin::CompressedArrayHeader header;
             header.m_chunk.m_type = SLANG_MAKE_COMPRESSED_FOUR_CC(chunkId);
@@ -870,7 +870,7 @@ static Result _writeArrayChunk(IRSerialBinary::CompressionType compressionType, 
 
             stream->Write(&header, sizeof(header));
 
-            stream->Write(compressedPayload.begin(), compressedPayload.getSize());
+            stream->Write(compressedPayload.begin(), compressedPayload.getCount());
             break;
         }
         default:
@@ -893,7 +893,7 @@ static Result _writeArrayChunk(IRSerialBinary::CompressionType compressionType, 
 template <typename T>
 Result _writeArrayChunk(IRSerialBinary::CompressionType compressionType, uint32_t chunkId, const List<T>& array, Stream* stream)
 {
-    return _writeArrayChunk(compressionType, chunkId, array.begin(), size_t(array.getSize()), sizeof(T), stream);
+    return _writeArrayChunk(compressionType, chunkId, array.begin(), size_t(array.getCount()), sizeof(T), stream);
 }
 
 Result _encodeInsts(IRSerialBinary::CompressionType compressionType, const List<IRSerialData::Inst>& instsIn, List<uint8_t>& encodeArrayOut)
@@ -907,7 +907,7 @@ Result _encodeInsts(IRSerialBinary::CompressionType compressionType, const List<
     }
     encodeArrayOut.clear();
     
-    const size_t numInsts = size_t(instsIn.getSize());
+    const size_t numInsts = size_t(instsIn.getCount());
     const IRSerialData::Inst* insts = instsIn.begin();
         
     uint8_t* encodeOut = encodeArrayOut.begin();
@@ -931,7 +931,7 @@ Result _encodeInsts(IRSerialBinary::CompressionType compressionType, const List<
 
             encodeArrayOut.reserve(oldCapacity + (oldCapacity >> 1) + maxInstSize);
             const UInt capacity = encodeArrayOut.getCapacity();
-            encodeArrayOut.setSize(capacity);
+            encodeArrayOut.setCount(capacity);
 
             encodeOut = encodeArrayOut.begin() + offset;
             encodeEnd = encodeArrayOut.end();
@@ -982,14 +982,14 @@ Result _encodeInsts(IRSerialBinary::CompressionType compressionType, const List<
     }
 
     // Fix the size 
-    encodeArrayOut.setSize(UInt(encodeOut - encodeArrayOut.begin()));
+    encodeArrayOut.setCount(UInt(encodeOut - encodeArrayOut.begin()));
     return SLANG_OK;
 }
 
 Result _writeInstArrayChunk(IRSerialBinary::CompressionType compressionType, uint32_t chunkId, const List<IRSerialData::Inst>& array, Stream* stream)
 {
     typedef IRSerialBinary Bin;
-    if (array.getSize() == 0)
+    if (array.getCount() == 0)
     {
         return SLANG_OK;
     }
@@ -1005,16 +1005,16 @@ Result _writeInstArrayChunk(IRSerialBinary::CompressionType compressionType, uin
             List<uint8_t> compressedPayload;
             SLANG_RETURN_ON_FAIL(_encodeInsts(compressionType, array, compressedPayload));
             
-            size_t payloadSize = sizeof(Bin::CompressedArrayHeader) - sizeof(Bin::Chunk) + compressedPayload.getSize();
+            size_t payloadSize = sizeof(Bin::CompressedArrayHeader) - sizeof(Bin::Chunk) + compressedPayload.getCount();
 
             Bin::CompressedArrayHeader header;
             header.m_chunk.m_type = SLANG_MAKE_COMPRESSED_FOUR_CC(chunkId);
             header.m_chunk.m_size = uint32_t(payloadSize);
-            header.m_numEntries = uint32_t(array.getSize());
+            header.m_numEntries = uint32_t(array.getCount());
             header.m_numCompressedEntries = 0;          
 
             stream->Write(&header, sizeof(header));
-            stream->Write(compressedPayload.begin(), compressedPayload.getSize());
+            stream->Write(compressedPayload.begin(), compressedPayload.getCount());
     
             // All chunks have sizes rounded to dword size
             if (payloadSize & 3)
@@ -1046,7 +1046,7 @@ static size_t _calcInstChunkSize(IRSerialBinary::CompressionType compressionType
         {
             size_t size = sizeof(Bin::CompressedArrayHeader);
 
-            size_t numInsts = size_t(instsIn.getSize());
+            size_t numInsts = size_t(instsIn.getCount());
             size += numInsts * 2;           // op and payload
 
             IRSerialData::Inst* insts = instsIn.begin();
@@ -1114,7 +1114,7 @@ static size_t _calcInstChunkSize(IRSerialBinary::CompressionType compressionType
         _calcChunkSize(Bin::CompressionType::None, data.m_stringTable) +
         _calcChunkSize(Bin::CompressionType::None, data.m_rawSourceLocs);
 
-    if (data.m_debugSourceInfos.getSize())
+    if (data.m_debugSourceInfos.getCount())
     {
         totalSize += _calcChunkSize(Bin::CompressionType::None, data.m_debugStringTable) +
             _calcChunkSize(Bin::CompressionType::None, data.m_debugLineInfos) +
@@ -1146,7 +1146,7 @@ static size_t _calcInstChunkSize(IRSerialBinary::CompressionType compressionType
 
     SLANG_RETURN_ON_FAIL(_writeArrayChunk(Bin::CompressionType::None, Bin::kUInt32SourceLocFourCc, data.m_rawSourceLocs, stream));
 
-    if (data.m_debugSourceInfos.getSize())
+    if (data.m_debugSourceInfos.getCount())
     {
         _writeArrayChunk(Bin::CompressionType::None, Bin::kDebugStringFourCc, data.m_debugStringTable, stream);
         _writeArrayChunk(Bin::CompressionType::None, Bin::kDebugLineInfoFourCc, data.m_debugLineInfos, stream);
@@ -1184,7 +1184,7 @@ class ListResizerForType: public ListResizer
     
     virtual void* setSize(size_t newSize) SLANG_OVERRIDE
     {
-        m_list.setSize(UInt(newSize));
+        m_list.setCount(UInt(newSize));
         return (void*)m_list.begin();
     }
 
@@ -1215,7 +1215,7 @@ static Result _readArrayChunk(IRSerialBinary::CompressionType compressionType, c
             size_t payloadSize = header.m_chunk.m_size - (sizeof(header) - sizeof(Bin::Chunk));
 
             List<uint8_t> compressedPayload;
-            compressedPayload.setSize(payloadSize);
+            compressedPayload.setCount(payloadSize);
 
             stream->Read(compressedPayload.begin(), payloadSize);
             *numReadInOut += payloadSize;
@@ -1294,7 +1294,7 @@ static Result _decodeInsts(IRSerialBinary::CompressionType compressionType, cons
         return SLANG_FAIL;
     }
 
-    const size_t numInsts = size_t(instsOut.getSize());
+    const size_t numInsts = size_t(instsOut.getCount());
     IRSerialData::Inst* insts = instsOut.begin();
 
     const uint8_t* encodeCur = encodeIn.begin();
@@ -1381,12 +1381,12 @@ Result _readInstArrayChunk(const IRSerialBinary::SlangHeader& slangHeader, const
             size_t payloadSize = header.m_chunk.m_size - (sizeof(header) - sizeof(Bin::Chunk));
 
             List<uint8_t> compressedPayload;
-            compressedPayload.setSize(payloadSize);
+            compressedPayload.setCount(payloadSize);
 
             stream->Read(compressedPayload.begin(), payloadSize);
             *numReadInOut += payloadSize;
 
-            arrayOut.setSize(header.m_numEntries);
+            arrayOut.setCount(header.m_numEntries);
 
             SLANG_RETURN_ON_FAIL(_decodeInsts(compressionType, compressedPayload, arrayOut));
             break;
@@ -1561,7 +1561,7 @@ static SourceRange _toSourceRange(const IRSerialData::DebugSourceInfo& info)
 
 static int _findIndex(const List<IRSerialData::DebugSourceInfo>& infos, SourceLoc sourceLoc)
 {
-    const int numInfos = int(infos.getSize());
+    const int numInfos = int(infos.getCount());
     for (int i = 0; i < numInfos; ++i)
     {
         if (_toSourceRange(infos[i]).contains(sourceLoc))
@@ -1598,11 +1598,11 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
 
     List<IRInst*> insts;
 
-    const int numInsts = int(data.m_insts.getSize());
+    const int numInsts = int(data.m_insts.getCount());
 
     SLANG_ASSERT(numInsts > 0);
 
-    insts.setSize(numInsts);
+    insts.setCount(numInsts);
     insts[0] = nullptr;
 
     // 0 holds null
@@ -1746,7 +1746,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
     
     // Patch up the children
     {
-        const int numChildRuns = int(data.m_childRuns.getSize());
+        const int numChildRuns = int(data.m_childRuns.getCount());
         for (int i = 0; i < numChildRuns; i++)
         {
             const auto& run = data.m_childRuns[i];
@@ -1763,7 +1763,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
     }
 
     // Re-add source locations, if they are defined
-    if (int(m_serialData->m_rawSourceLocs.getSize()) == numInsts)
+    if (int(m_serialData->m_rawSourceLocs.getCount()) == numInsts)
     {
         const Ser::RawSourceLoc* srcLocs = m_serialData->m_rawSourceLocs.begin();
         for (int i = 1; i < numInsts; ++i)
@@ -1774,7 +1774,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
         }
     }
 
-    if (sourceManager && m_serialData->m_debugSourceInfos.getSize())
+    if (sourceManager && m_serialData->m_debugSourceInfos.getCount())
     {
         List<UnownedStringSlice> debugStringSlices;
         SerialStringTableUtil::decodeStringTable(m_serialData->m_debugStringTable, debugStringSlices);
@@ -1786,11 +1786,11 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
         const List<IRSerialData::DebugSourceInfo>& sourceInfos = m_serialData->m_debugSourceInfos;
 
         // Construct the source files
-        int numSourceFiles = int(sourceInfos.getSize());
+        int numSourceFiles = int(sourceInfos.getCount());
 
         // These hold the views (and SourceFile as there is only one SourceFile per view) in the same order as the sourceInfos
         List<SourceView*> sourceViews;
-        sourceViews.setSize(numSourceFiles);
+        sourceViews.setCount(numSourceFiles);
 
         for (int i = 0; i < numSourceFiles; ++i)
         {
@@ -1807,8 +1807,8 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
             List<IRSerialData::DebugLineInfo> lineInfos;
             // Add the adjusted lines
             {
-                lineInfos.setSize(srcSourceInfo.m_numAdjustedLineInfos);
-                IRSerialData::DebugAdjustedLineInfo* srcAdjustedLineInfos = m_serialData->m_debugAdjustedLineInfos.Buffer() + srcSourceInfo.m_adjustedLineInfosStartIndex;
+                lineInfos.setCount(srcSourceInfo.m_numAdjustedLineInfos);
+                const IRSerialData::DebugAdjustedLineInfo* srcAdjustedLineInfos = m_serialData->m_debugAdjustedLineInfos.getBuffer() + srcSourceInfo.m_adjustedLineInfosStartIndex;
                 const int numAdjustedLines = int(srcSourceInfo.m_numAdjustedLineInfos);
                 for (int j = 0; j < numAdjustedLines; ++j)
                 {
@@ -1816,7 +1816,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
                 }
             }
             // Add regular lines
-            lineInfos.addRange(m_serialData->m_debugLineInfos.Buffer() + srcSourceInfo.m_lineInfosStartIndex, srcSourceInfo.m_numLineInfos);
+            lineInfos.addRange(m_serialData->m_debugLineInfos.getBuffer() + srcSourceInfo.m_lineInfosStartIndex, srcSourceInfo.m_numLineInfos);
             // Put in sourceloc order
             lineInfos.sort();
 
@@ -1824,10 +1824,10 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
 
             // We can now set up the line breaks array
             const int numLines = int(srcSourceInfo.m_numLines);
-            lineBreakOffsets.setSize(numLines);
+            lineBreakOffsets.setCount(numLines);
 
             {
-                const int numLineInfos = int(lineInfos.getSize());
+                const int numLineInfos = int(lineInfos.getCount());
                 int lineIndex = 0;
                 
                 // Every line up and including should hold the same offset
@@ -1857,7 +1857,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
                 }
             }
 
-            sourceFile->setLineBreakOffsets(lineBreakOffsets.Buffer(), lineBreakOffsets.getSize());
+            sourceFile->setLineBreakOffsets(lineBreakOffsets.getBuffer(), lineBreakOffsets.getCount());
 
             if (srcSourceInfo.m_numAdjustedLineInfos)
             {
@@ -1865,12 +1865,12 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
 
                 int numEntries = int(srcSourceInfo.m_numAdjustedLineInfos);
 
-                adjustedLineInfos.addRange(m_serialData->m_debugAdjustedLineInfos.Buffer() + srcSourceInfo.m_adjustedLineInfosStartIndex, numEntries);
+                adjustedLineInfos.addRange(m_serialData->m_debugAdjustedLineInfos.getBuffer() + srcSourceInfo.m_adjustedLineInfosStartIndex, numEntries);
                 adjustedLineInfos.sort();
 
                 // Work out the views adjustments, and place in dstEntries
                 List<SourceView::Entry> dstEntries;
-                dstEntries.setSize(numEntries);
+                dstEntries.setCount(numEntries);
 
                 const uint32_t sourceLocOffset = uint32_t(sourceView->getRange().begin.getRaw());
 
@@ -1885,7 +1885,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
                 }
 
                 // Set the adjustments on the view
-                sourceView->setEntries(dstEntries.Buffer(), dstEntries.getSize());
+                sourceView->setEntries(dstEntries.getBuffer(), dstEntries.getCount());
             }
 
             sourceViews[i] = sourceView;
@@ -1901,7 +1901,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
             SourceRange range;
             int fixSourceLoc = _calcFixSourceLoc(sourceInfos[0], sourceViews[0], range);
 
-            const int numRuns = int(sourceRuns.getSize());
+            const int numRuns = int(sourceRuns.getCount());
             for (int i = 0; i < numRuns; ++i)
             {
                 const auto& run = sourceRuns[i];
@@ -1922,8 +1922,8 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
                 // Work out the fixed source location
                 SourceLoc sourceLoc = SourceLoc::fromRaw(int(run.m_sourceLoc) + fixSourceLoc); 
 
-                SLANG_ASSERT(uint32_t(run.m_startInstIndex) + run.m_numInst <= insts.getSize());
-                IRInst** dstInsts = insts.Buffer() + int(run.m_startInstIndex);
+                SLANG_ASSERT(uint32_t(run.m_startInstIndex) + run.m_numInst <= insts.getCount());
+                IRInst** dstInsts = insts.getBuffer() + int(run.m_startInstIndex);
 
                 const int runSize = int(run.m_numInst);
                 for (int j = 0; j < runSize; ++j)
@@ -1942,7 +1942,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
 /* static */void IRSerialUtil::calcInstructionList(IRModule* module, List<IRInst*>& instsOut)
 {
     // We reserve 0 for null
-    instsOut.setSize(1);
+    instsOut.setCount(1);
     instsOut[0] = nullptr;
 
     // Stack for parentInst
@@ -1955,7 +1955,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
     instsOut.add(moduleInst);
 
     // Traverse all of the instructions
-    while (parentInstStack.getSize())
+    while (parentInstStack.getCount())
     {
         // If it's in the stack it is assumed it is already in the inst map
         IRInst* parentInst = parentInstStack.getLast();
@@ -2015,7 +2015,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
     List<IRInst*> readInsts;
     calcInstructionList(irReadModule, readInsts);
 
-    if (readInsts.getSize() != originalInsts.getSize())
+    if (readInsts.getCount() != originalInsts.getCount())
     {
         SLANG_ASSERT(!"Instruction counts don't match");
         return SLANG_FAIL;
@@ -2025,7 +2025,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
     {
         SLANG_ASSERT(readInsts[0] == originalInsts[0]);
         // All the source locs should be identical
-        for (UInt i = 1; i < readInsts.getSize(); ++i)
+        for (UInt i = 1; i < readInsts.getCount(); ++i)
         {
             IRInst* origInst = originalInsts[i];
             IRInst* readInst = readInsts[i];
@@ -2040,7 +2040,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
     else if (optionFlags & IRSerialWriter::OptionFlag::DebugInfo)
     {
         // They should be on the same line nos
-        for (UInt i = 1; i < readInsts.getSize(); ++i)
+        for (UInt i = 1; i < readInsts.getCount(); ++i)
         {
             IRInst* origInst = originalInsts[i];
             IRInst* readInst = readInsts[i];

--- a/source/slang/ir-serialize.cpp
+++ b/source/slang/ir-serialize.cpp
@@ -81,7 +81,7 @@ void StringRepresentationCache::init(const List<char>* stringTable, NamePool* na
     m_scopeManager = scopeManager;
 
     // Decode the table
-    m_entries.SetSize(StringSlicePool::kNumDefaultHandles);
+    m_entries.setSize(StringSlicePool::kNumDefaultHandles);
     SLANG_COMPILE_TIME_ASSERT(StringSlicePool::kNumDefaultHandles == 2);
 
     {
@@ -220,7 +220,7 @@ char* StringRepresentationCache::getCStr(Handle handle)
         const int numPrefixBytes = EncodeUnicodePointToUTF8(prefixBytes, len);
         const int baseIndex = int(stringTable.getSize());
 
-        stringTable.SetSize(baseIndex + numPrefixBytes + len);
+        stringTable.setSize(baseIndex + numPrefixBytes + len);
 
         char* dst = stringTable.begin() + baseIndex;
 
@@ -246,7 +246,7 @@ char* StringRepresentationCache::getCStr(Handle handle)
 
 /* static */void SerialStringTableUtil::decodeStringTable(const List<char>& stringTable, List<UnownedStringSlice>& slicesOut)
 {
-    slicesOut.SetSize(2);
+    slicesOut.setSize(2);
     slicesOut[0] = UnownedStringSlice(nullptr, size_t(0));
     slicesOut[1] = UnownedStringSlice("", size_t(0));
 
@@ -259,7 +259,7 @@ char* StringRepresentationCache::getCStr(Handle handle)
     SLANG_ASSERT(slices[int(StringSlicePool::kNullHandle)] == "" && slices[int(StringSlicePool::kNullHandle)].begin() == nullptr);
     SLANG_ASSERT(slices[int(StringSlicePool::kEmptyHandle)] == "");
 
-    indexMapOut.SetSize(slices.getSize());
+    indexMapOut.setSize(slices.getSize());
     // Set up all of the defaults
     for (int i = 0; i < StringSlicePool::kNumDefaultHandles; ++i)
     {
@@ -306,7 +306,7 @@ IRSerialData::IRSerialData()
 void IRSerialData::clear()
 {
     // First Instruction is null
-    m_insts.SetSize(1);
+    m_insts.setSize(1);
     memset(&m_insts[0], 0, sizeof(Inst));
 
     m_childRuns.clear();
@@ -650,7 +650,7 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
 #endif
 
     // Set to the right size
-    m_serialData->m_insts.SetSize(m_insts.getSize());
+    m_serialData->m_insts.setSize(m_insts.getSize());
     // Clear all instructions
     memset(m_serialData->m_insts.begin(), 0, sizeof(Ser::Inst) * m_serialData->m_insts.getSize());
 
@@ -745,7 +745,7 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
                 dstInst.m_payloadType = PayloadType::OperandExternal;
 
                 int operandArrayBaseIndex = int(m_serialData->m_externalOperands.getSize());
-                m_serialData->m_externalOperands.SetSize(operandArrayBaseIndex + numOperands);
+                m_serialData->m_externalOperands.setSize(operandArrayBaseIndex + numOperands);
 
                 dstOperands = m_serialData->m_externalOperands.begin() + operandArrayBaseIndex; 
 
@@ -771,7 +771,7 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
     if (options & OptionFlag::RawSourceLocation)
     {
         const int numInsts = int(m_insts.getSize());
-        serialData->m_rawSourceLocs.SetSize(numInsts);
+        serialData->m_rawSourceLocs.setSize(numInsts);
 
         Ser::RawSourceLoc* dstLocs =  serialData->m_rawSourceLocs.begin();
         // 0 is null, just mark as no location
@@ -929,9 +929,9 @@ Result _encodeInsts(IRSerialBinary::CompressionType compressionType, const List<
             
             const UInt oldCapacity = encodeArrayOut.getCapacity();
 
-            encodeArrayOut.Reserve(oldCapacity + (oldCapacity >> 1) + maxInstSize);
+            encodeArrayOut.reserve(oldCapacity + (oldCapacity >> 1) + maxInstSize);
             const UInt capacity = encodeArrayOut.getCapacity();
-            encodeArrayOut.SetSize(capacity);
+            encodeArrayOut.setSize(capacity);
 
             encodeOut = encodeArrayOut.begin() + offset;
             encodeEnd = encodeArrayOut.end();
@@ -982,7 +982,7 @@ Result _encodeInsts(IRSerialBinary::CompressionType compressionType, const List<
     }
 
     // Fix the size 
-    encodeArrayOut.SetSize(UInt(encodeOut - encodeArrayOut.begin()));
+    encodeArrayOut.setSize(UInt(encodeOut - encodeArrayOut.begin()));
     return SLANG_OK;
 }
 
@@ -1184,7 +1184,7 @@ class ListResizerForType: public ListResizer
     
     virtual void* setSize(size_t newSize) SLANG_OVERRIDE
     {
-        m_list.SetSize(UInt(newSize));
+        m_list.setSize(UInt(newSize));
         return (void*)m_list.begin();
     }
 
@@ -1215,7 +1215,7 @@ static Result _readArrayChunk(IRSerialBinary::CompressionType compressionType, c
             size_t payloadSize = header.m_chunk.m_size - (sizeof(header) - sizeof(Bin::Chunk));
 
             List<uint8_t> compressedPayload;
-            compressedPayload.SetSize(payloadSize);
+            compressedPayload.setSize(payloadSize);
 
             stream->Read(compressedPayload.begin(), payloadSize);
             *numReadInOut += payloadSize;
@@ -1381,12 +1381,12 @@ Result _readInstArrayChunk(const IRSerialBinary::SlangHeader& slangHeader, const
             size_t payloadSize = header.m_chunk.m_size - (sizeof(header) - sizeof(Bin::Chunk));
 
             List<uint8_t> compressedPayload;
-            compressedPayload.SetSize(payloadSize);
+            compressedPayload.setSize(payloadSize);
 
             stream->Read(compressedPayload.begin(), payloadSize);
             *numReadInOut += payloadSize;
 
-            arrayOut.SetSize(header.m_numEntries);
+            arrayOut.setSize(header.m_numEntries);
 
             SLANG_RETURN_ON_FAIL(_decodeInsts(compressionType, compressedPayload, arrayOut));
             break;
@@ -1602,7 +1602,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
 
     SLANG_ASSERT(numInsts > 0);
 
-    insts.SetSize(numInsts);
+    insts.setSize(numInsts);
     insts[0] = nullptr;
 
     // 0 holds null
@@ -1790,7 +1790,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
 
         // These hold the views (and SourceFile as there is only one SourceFile per view) in the same order as the sourceInfos
         List<SourceView*> sourceViews;
-        sourceViews.SetSize(numSourceFiles);
+        sourceViews.setSize(numSourceFiles);
 
         for (int i = 0; i < numSourceFiles; ++i)
         {
@@ -1807,7 +1807,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
             List<IRSerialData::DebugLineInfo> lineInfos;
             // Add the adjusted lines
             {
-                lineInfos.SetSize(srcSourceInfo.m_numAdjustedLineInfos);
+                lineInfos.setSize(srcSourceInfo.m_numAdjustedLineInfos);
                 IRSerialData::DebugAdjustedLineInfo* srcAdjustedLineInfos = m_serialData->m_debugAdjustedLineInfos.Buffer() + srcSourceInfo.m_adjustedLineInfosStartIndex;
                 const int numAdjustedLines = int(srcSourceInfo.m_numAdjustedLineInfos);
                 for (int j = 0; j < numAdjustedLines; ++j)
@@ -1824,7 +1824,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
 
             // We can now set up the line breaks array
             const int numLines = int(srcSourceInfo.m_numLines);
-            lineBreakOffsets.SetSize(numLines);
+            lineBreakOffsets.setSize(numLines);
 
             {
                 const int numLineInfos = int(lineInfos.getSize());
@@ -1870,7 +1870,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
 
                 // Work out the views adjustments, and place in dstEntries
                 List<SourceView::Entry> dstEntries;
-                dstEntries.SetSize(numEntries);
+                dstEntries.setSize(numEntries);
 
                 const uint32_t sourceLocOffset = uint32_t(sourceView->getRange().begin.getRaw());
 
@@ -1942,7 +1942,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
 /* static */void IRSerialUtil::calcInstructionList(IRModule* module, List<IRInst*>& instsOut)
 {
     // We reserve 0 for null
-    instsOut.SetSize(1);
+    instsOut.setSize(1);
     instsOut[0] = nullptr;
 
     // Stack for parentInst

--- a/source/slang/ir-serialize.cpp
+++ b/source/slang/ir-serialize.cpp
@@ -512,7 +512,7 @@ Result IRSerialWriter::_calcDebugInfo()
     }
 
     // Sort them
-    instLocs.Sort();
+    instLocs.sort();
     m_debugFreeSourceLoc = 1;
 
     // Look for runs
@@ -1818,7 +1818,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
             // Add regular lines
             lineInfos.addRange(m_serialData->m_debugLineInfos.Buffer() + srcSourceInfo.m_lineInfosStartIndex, srcSourceInfo.m_numLineInfos);
             // Put in sourceloc order
-            lineInfos.Sort();
+            lineInfos.sort();
 
             List<uint32_t> lineBreakOffsets;
 
@@ -1866,7 +1866,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
                 int numEntries = int(srcSourceInfo.m_numAdjustedLineInfos);
 
                 adjustedLineInfos.addRange(m_serialData->m_debugAdjustedLineInfos.Buffer() + srcSourceInfo.m_adjustedLineInfosStartIndex, numEntries);
-                adjustedLineInfos.Sort();
+                adjustedLineInfos.sort();
 
                 // Work out the views adjustments, and place in dstEntries
                 List<SourceView::Entry> dstEntries;
@@ -1895,7 +1895,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
         {
             List<IRSerialData::SourceLocRun> sourceRuns(m_serialData->m_debugSourceLocRuns);
             // They are now in source location order
-            sourceRuns.Sort();
+            sourceRuns.sort();
 
             // Just guess initially 0 for the source file that contains the initial run
             SourceRange range;

--- a/source/slang/ir-serialize.cpp
+++ b/source/slang/ir-serialize.cpp
@@ -1922,7 +1922,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
                 // Work out the fixed source location
                 SourceLoc sourceLoc = SourceLoc::fromRaw(int(run.m_sourceLoc) + fixSourceLoc); 
 
-                SLANG_ASSERT(uint32_t(run.m_startInstIndex) + run.m_numInst <= insts.getCount());
+                SLANG_ASSERT(Index(uint32_t(run.m_startInstIndex) + run.m_numInst) <= insts.getCount());
                 IRInst** dstInsts = insts.getBuffer() + int(run.m_startInstIndex);
 
                 const int runSize = int(run.m_numInst);

--- a/source/slang/ir-serialize.cpp
+++ b/source/slang/ir-serialize.cpp
@@ -218,7 +218,7 @@ char* StringRepresentationCache::getCStr(Handle handle)
         // We need to write into the the string array
         char prefixBytes[6];
         const int numPrefixBytes = EncodeUnicodePointToUTF8(prefixBytes, len);
-        const int baseIndex = int(stringTable.getCount());
+        const Index baseIndex = stringTable.getCount();
 
         stringTable.setCount(baseIndex + numPrefixBytes + len);
 
@@ -266,8 +266,8 @@ char* StringRepresentationCache::getCStr(Handle handle)
         indexMapOut[i] = StringSlicePool::Handle(i);
     }
 
-    const int numSlices = int(slices.getCount());
-    for (int i = StringSlicePool::kNumDefaultHandles; i < numSlices ; ++i)
+    const Index numSlices = slices.getCount();
+    for (Index i = StringSlicePool::kNumDefaultHandles; i < numSlices ; ++i)
     {
         indexMapOut[i] = pool.add(slices[i]);
     }
@@ -497,8 +497,8 @@ Result IRSerialWriter::_calcDebugInfo()
 
     // Find all of the source locations and their associated instructions
     List<InstLoc> instLocs;
-    const int numInsts = int(m_insts.getCount());
-    for (int i = 1; i < numInsts; i++)
+    const Index numInsts = m_insts.getCount();
+    for (Index i = 1; i < numInsts; i++)
     {
         IRInst* srcInst = m_insts[i];
         if (!srcInst->sourceLoc.isValid())
@@ -656,9 +656,9 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
 
     // Need to set up the actual instructions
     {
-        const int numInsts = int(m_insts.getCount());
+        const Index numInsts = m_insts.getCount();
 
-        for (int i = 1; i < numInsts; ++i)
+        for (Index i = 1; i < numInsts; ++i)
         {
             IRInst* srcInst = m_insts[i];
             Ser::Inst& dstInst = m_serialData->m_insts[i];
@@ -770,13 +770,13 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
     // If the option to use RawSourceLocations is enabled, serialize out as is
     if (options & OptionFlag::RawSourceLocation)
     {
-        const int numInsts = int(m_insts.getCount());
+        const Index numInsts = m_insts.getCount();
         serialData->m_rawSourceLocs.setCount(numInsts);
 
         Ser::RawSourceLoc* dstLocs =  serialData->m_rawSourceLocs.begin();
         // 0 is null, just mark as no location
         dstLocs[0] = Ser::RawSourceLoc(0);
-        for (int i = 1; i < numInsts; ++i)
+        for (Index i = 1; i < numInsts; ++i)
         {
             IRInst* srcInst = m_insts[i];
             dstLocs[i] = Ser::RawSourceLoc(srcInst->sourceLoc.getRaw());
@@ -1598,7 +1598,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
 
     List<IRInst*> insts;
 
-    const int numInsts = int(data.m_insts.getCount());
+    const Index numInsts = data.m_insts.getCount();
 
     SLANG_ASSERT(numInsts > 0);
 
@@ -1622,7 +1622,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
         insts[1] = moduleInst; 
     }
 
-    for (int i = 2; i < numInsts; ++i)
+    for (Index i = 2; i < numInsts; ++i)
     {
         const Ser::Inst& srcInst = data.m_insts[i];
 
@@ -1714,7 +1714,7 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
     }
 
     // Patch up the operands
-    for (int i = 1; i < numInsts; ++i)
+    for (Index i = 1; i < numInsts; ++i)
     {
         const Ser::Inst& srcInst = data.m_insts[i];
         const IROp op((IROp)srcInst.m_op);
@@ -1746,8 +1746,8 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
     
     // Patch up the children
     {
-        const int numChildRuns = int(data.m_childRuns.getCount());
-        for (int i = 0; i < numChildRuns; i++)
+        const Index numChildRuns = data.m_childRuns.getCount();
+        for (Index i = 0; i < numChildRuns; i++)
         {
             const auto& run = data.m_childRuns[i];
 
@@ -1763,10 +1763,10 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
     }
 
     // Re-add source locations, if they are defined
-    if (int(m_serialData->m_rawSourceLocs.getCount()) == numInsts)
+    if (m_serialData->m_rawSourceLocs.getCount() == numInsts)
     {
         const Ser::RawSourceLoc* srcLocs = m_serialData->m_rawSourceLocs.begin();
-        for (int i = 1; i < numInsts; ++i)
+        for (Index i = 1; i < numInsts; ++i)
         {
             IRInst* dstInst = insts[i];
             
@@ -1786,13 +1786,13 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
         const List<IRSerialData::DebugSourceInfo>& sourceInfos = m_serialData->m_debugSourceInfos;
 
         // Construct the source files
-        int numSourceFiles = int(sourceInfos.getCount());
+        Index numSourceFiles = sourceInfos.getCount();
 
         // These hold the views (and SourceFile as there is only one SourceFile per view) in the same order as the sourceInfos
         List<SourceView*> sourceViews;
         sourceViews.setCount(numSourceFiles);
 
-        for (int i = 0; i < numSourceFiles; ++i)
+        for (Index i = 0; i < numSourceFiles; ++i)
         {
             const IRSerialData::DebugSourceInfo& srcSourceInfo = sourceInfos[i];
 
@@ -1827,11 +1827,11 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
             lineBreakOffsets.setCount(numLines);
 
             {
-                const int numLineInfos = int(lineInfos.getCount());
-                int lineIndex = 0;
+                const Index numLineInfos = lineInfos.getCount();
+                Index lineIndex = 0;
                 
                 // Every line up and including should hold the same offset
-                for (int lineInfoIndex = 0; lineInfoIndex < numLineInfos; ++lineInfoIndex)
+                for (Index lineInfoIndex = 0; lineInfoIndex < numLineInfos; ++lineInfoIndex)
                 {
                     const auto& lineInfo = lineInfos[lineInfoIndex];
 
@@ -1901,8 +1901,8 @@ static int _calcFixSourceLoc(const IRSerialData::DebugSourceInfo& info, SourceVi
             SourceRange range;
             int fixSourceLoc = _calcFixSourceLoc(sourceInfos[0], sourceViews[0], range);
 
-            const int numRuns = int(sourceRuns.getCount());
-            for (int i = 0; i < numRuns; ++i)
+            const Index numRuns = sourceRuns.getCount();
+            for (Index i = 0; i < numRuns; ++i)
             {
                 const auto& run = sourceRuns[i];
                 const SourceLoc srcSourceLoc = SourceLoc::fromRaw(run.m_sourceLoc);

--- a/source/slang/ir-serialize.h
+++ b/source/slang/ir-serialize.h
@@ -461,7 +461,7 @@ protected:
             // Need to know how many lines there are
             const List<uint32_t>& lineOffsets = sourceFile->getLineBreakOffsets();
 
-            const auto numLineIndices = lineOffsets.Count();
+            const auto numLineIndices = lineOffsets.getSize();
 
             // Set none as being used initially
             m_lineIndexUsed.SetSize(numLineIndices);

--- a/source/slang/ir-serialize.h
+++ b/source/slang/ir-serialize.h
@@ -464,7 +464,7 @@ protected:
             const auto numLineIndices = lineOffsets.getSize();
 
             // Set none as being used initially
-            m_lineIndexUsed.SetSize(numLineIndices);
+            m_lineIndexUsed.setSize(numLineIndices);
             ::memset(m_lineIndexUsed.begin(), 0, numLineIndices * sizeof(uint8_t));
         }
             /// True if we have information on that line index

--- a/source/slang/ir-serialize.h
+++ b/source/slang/ir-serialize.h
@@ -461,10 +461,10 @@ protected:
             // Need to know how many lines there are
             const List<uint32_t>& lineOffsets = sourceFile->getLineBreakOffsets();
 
-            const auto numLineIndices = lineOffsets.getSize();
+            const auto numLineIndices = lineOffsets.getCount();
 
             // Set none as being used initially
-            m_lineIndexUsed.setSize(numLineIndices);
+            m_lineIndexUsed.setCount(numLineIndices);
             ::memset(m_lineIndexUsed.begin(), 0, numLineIndices * sizeof(uint8_t));
         }
             /// True if we have information on that line index

--- a/source/slang/ir-specialize-resources.cpp
+++ b/source/slang/ir-specialize-resources.cpp
@@ -57,7 +57,7 @@ struct ResourceParameterSpecializationContext
         // We will process the work list until it goes dry,
         // treating it like a stack of work items.
         //
-        while( workList.getSize() )
+        while( workList.getCount() )
         {
             auto call = workList.getLast();
             workList.removeLast();
@@ -395,8 +395,8 @@ struct ResourceParameterSpecializationContext
         auto newCall = getBuilder()->emitCallInst(
             oldCall->getFullType(),
             newFunc,
-            callInfo.newArgs.getSize(),
-            callInfo.newArgs.Buffer());
+            callInfo.newArgs.getCount(),
+            callInfo.newArgs.getBuffer());
 
         newCall->insertBefore(oldCall);
         oldCall->replaceUsesWith(newCall);
@@ -778,8 +778,8 @@ struct ResourceParameterSpecializationContext
 
         auto builder = getBuilder();
         IRType* funcType = builder->getFuncType(
-            paramTypes.getSize(),
-            paramTypes.Buffer(),
+            paramTypes.getCount(),
+            paramTypes.getBuffer(),
             oldFunc->getResultType());
 
         IRFunc* newFunc = builder->createFunc();

--- a/source/slang/ir-specialize-resources.cpp
+++ b/source/slang/ir-specialize-resources.cpp
@@ -59,8 +59,8 @@ struct ResourceParameterSpecializationContext
         //
         while( workList.getSize() )
         {
-            auto call = workList.Last();
-            workList.RemoveLast();
+            auto call = workList.getLast();
+            workList.removeLast();
 
             // At each call site we first check whether it
             // is something we can (and should) specialize,
@@ -84,7 +84,7 @@ struct ResourceParameterSpecializationContext
         //
         if( auto call = as<IRCall>(inst) )
         {
-            workList.Add(call);
+            workList.add(call);
         }
 
         // Recursively walk through any children, to
@@ -477,7 +477,7 @@ struct ResourceParameterSpecializationContext
         // the original function, since different functions
         // will always yield different specializations.
         //
-        callInfo.key.vals.Add(oldFunc);
+        callInfo.key.vals.add(oldFunc);
 
         // The rest of the information is gathered by looking
         // at parameter and argument pairs.
@@ -507,7 +507,7 @@ struct ResourceParameterSpecializationContext
             // to add any information to distinguish the
             // specialized callee based on this paramter.
             //
-            ioInfo.newArgs.Add(oldArg);
+            ioInfo.newArgs.add(oldArg);
         }
         else
         {
@@ -537,7 +537,7 @@ struct ResourceParameterSpecializationContext
             // callee reflects that we are specializing
             // to the chosen parameter.
             //
-            ioInfo.key.vals.Add(oldGlobalParam);
+            ioInfo.key.vals.add(oldGlobalParam);
         }
         else if( oldArg->op == kIROp_getElement )
         {
@@ -563,7 +563,7 @@ struct ResourceParameterSpecializationContext
             // the arguments at the new call site, and
             // don't add anything to the specialization key.
             //
-            ioInfo.newArgs.Add(oldIndex);
+            ioInfo.newArgs.add(oldIndex);
         }
         else
         {
@@ -601,7 +601,7 @@ struct ResourceParameterSpecializationContext
             // We will collect the replacement value to use
             // for each of the original parameters in an array.
             //
-            funcInfo.replacementsForOldParameters.Add(newVal);
+            funcInfo.replacementsForOldParameters.add(newVal);
         }
     }
 
@@ -620,7 +620,7 @@ struct ResourceParameterSpecializationContext
             // create it here.
             //
             auto newParam = getBuilder()->createParam(oldParam->getFullType());
-            ioInfo.newParams.Add(newParam);
+            ioInfo.newParams.add(newParam);
 
             // The new parameter will be used as the replacement
             // for the old one in the specialized function.
@@ -683,7 +683,7 @@ struct ResourceParameterSpecializationContext
             //
             auto builder = getBuilder();
             auto newIndex = builder->createParam(oldIndex->getFullType());
-            ioInfo.newParams.Add(newIndex);
+            ioInfo.newParams.add(newIndex);
 
             // Finally, we need to compute a value that
             // can stand in for `oldArg` (which was
@@ -714,7 +714,7 @@ struct ResourceParameterSpecializationContext
             // that should be inserted into the body of
             // the specialized callee.
             //
-            ioInfo.newBodyInsts.Add(newVal);
+            ioInfo.newBodyInsts.add(newVal);
 
             return newVal;
         }
@@ -773,7 +773,7 @@ struct ResourceParameterSpecializationContext
         List<IRType*> paramTypes;
         for( auto param : funcInfo.newParams )
         {
-            paramTypes.Add(param->getFullType());
+            paramTypes.add(param->getFullType());
         }
 
         auto builder = getBuilder();

--- a/source/slang/ir-specialize-resources.cpp
+++ b/source/slang/ir-specialize-resources.cpp
@@ -57,7 +57,7 @@ struct ResourceParameterSpecializationContext
         // We will process the work list until it goes dry,
         // treating it like a stack of work items.
         //
-        while( workList.Count() )
+        while( workList.getSize() )
         {
             auto call = workList.Last();
             workList.RemoveLast();
@@ -395,7 +395,7 @@ struct ResourceParameterSpecializationContext
         auto newCall = getBuilder()->emitCallInst(
             oldCall->getFullType(),
             newFunc,
-            callInfo.newArgs.Count(),
+            callInfo.newArgs.getSize(),
             callInfo.newArgs.Buffer());
 
         newCall->insertBefore(oldCall);
@@ -778,7 +778,7 @@ struct ResourceParameterSpecializationContext
 
         auto builder = getBuilder();
         IRType* funcType = builder->getFuncType(
-            paramTypes.Count(),
+            paramTypes.getSize(),
             paramTypes.Buffer(),
             oldFunc->getResultType());
 

--- a/source/slang/ir-specialize.cpp
+++ b/source/slang/ir-specialize.cpp
@@ -112,7 +112,7 @@ struct SpecializationContext
                 return;
         }
 
-        workList.Add(inst);
+        workList.add(inst);
     }
 
     // When a transformation makes a change to an instruction,
@@ -192,11 +192,11 @@ struct SpecializationContext
         // the array `[g, a, b, c]`.
         //
         Key key;
-        key.vals.Add(specializeInst->getBase());
+        key.vals.add(specializeInst->getBase());
         UInt argCount = specializeInst->getArgCount();
         for( UInt ii = 0; ii < argCount; ++ii )
         {
-            key.vals.Add(specializeInst->getArg(ii));
+            key.vals.add(specializeInst->getArg(ii));
         }
 
         {
@@ -570,8 +570,8 @@ struct SpecializationContext
         //
         while(workList.getSize() != 0)
         {
-            IRInst* inst = workList.Last();
-            workList.RemoveLast();
+            IRInst* inst = workList.getLast();
+            workList.removeLast();
 
             // For each instruction we process, we want to perform
             // a few steps.
@@ -677,7 +677,7 @@ struct SpecializationContext
         // The specialized callee will always depend on the unspecialized
         // function from which it is generated, so we add that to our key.
         //
-        key.vals.Add(calleeFunc);
+        key.vals.add(calleeFunc);
 
         // Also, for any parameter that has an existential type, the
         // specialized function will depend on the concrete type of the
@@ -700,7 +700,7 @@ struct SpecializationContext
                 //
                 auto val = makeExistential->getWrappedValue();
                 auto valType = val->getFullType();
-                key.vals.Add(valType);
+                key.vals.add(valType);
 
                 // We are also including the witness table in the key.
                 // This isn't required with our current language model,
@@ -717,7 +717,7 @@ struct SpecializationContext
                 // table even if it is redundant.
                 //
                 auto witnessTable = makeExistential->getWitnessTable();
-                key.vals.Add(witnessTable);
+                key.vals.add(witnessTable);
             }
             else
             {
@@ -757,7 +757,7 @@ struct SpecializationContext
                 // If the parameter doesn't have an existential type, then we
                 // don't want to change up the argument we pass at all.
                 //
-                newArgs.Add(arg);
+                newArgs.add(arg);
             }
             else
             {
@@ -768,7 +768,7 @@ struct SpecializationContext
                 if( auto makeExistential = as<IRMakeExistential>(arg) )
                 {
                     auto val = makeExistential->getWrappedValue();
-                    newArgs.Add(val);
+                    newArgs.add(val);
                 }
                 else
                 {
@@ -912,7 +912,7 @@ struct SpecializationContext
                 // and we'll use that instead of the original parameter.
                 //
                 auto newParam = builder->createParam(oldParam->getFullType());
-                newParams.Add(newParam);
+                newParams.add(newParam);
                 replacementVal = newParam;
             }
             else
@@ -936,7 +936,7 @@ struct SpecializationContext
                     //
                     auto valType = val->getFullType();
                     auto newParam = builder->createParam(valType);
-                    newParams.Add(newParam);
+                    newParams.add(newParam);
 
                     // Within the body of the function we cannot just use `val`
                     // directly, because the existing code expects an existential
@@ -948,7 +948,7 @@ struct SpecializationContext
                     // correct existential type, and stores the right witness table).
                     //
                     auto newMakeExistential = builder->emitMakeExistential(oldParam->getFullType(), newParam, witnessTable);
-                    newBodyInsts.Add(newMakeExistential);
+                    newBodyInsts.add(newMakeExistential);
                     replacementVal = newMakeExistential;
                 }
                 else
@@ -972,7 +972,7 @@ struct SpecializationContext
         List<IRType*> newParamTypes;
         for( auto newParam : newParams )
         {
-            newParamTypes.Add(newParam->getFullType());
+            newParamTypes.add(newParam->getFullType());
         }
         IRType* newFuncType = builder->getFuncType(
             newParamTypes.getSize(),
@@ -1190,7 +1190,7 @@ struct SpecializationContext
             UInt slotOperandCount = wrapInst->getSlotOperandCount();
             for( UInt ii = 0; ii < slotOperandCount; ++ii )
             {
-                slotOperands.Add(wrapInst->getSlotOperand(ii));
+                slotOperands.add(wrapInst->getSlotOperand(ii));
             }
 
             auto newLoadInst = builder.emitLoad(elementType, val);

--- a/source/slang/ir-specialize.cpp
+++ b/source/slang/ir-specialize.cpp
@@ -568,7 +568,7 @@ struct SpecializationContext
 
         // We will then iterate until our work list goes dry.
         //
-        while(workList.getSize() != 0)
+        while(workList.getCount() != 0)
         {
             IRInst* inst = workList.getLast();
             workList.removeLast();
@@ -975,8 +975,8 @@ struct SpecializationContext
             newParamTypes.add(newParam->getFullType());
         }
         IRType* newFuncType = builder->getFuncType(
-            newParamTypes.getSize(),
-            newParamTypes.Buffer(),
+            newParamTypes.getCount(),
+            newParamTypes.getBuffer(),
             oldFunc->getResultType());
         IRFunc* newFunc = builder->createFunc();
         newFunc->setFullType(newFuncType);
@@ -1198,7 +1198,7 @@ struct SpecializationContext
                 resultType,
                 newLoadInst,
                 slotOperandCount,
-                slotOperands.Buffer());
+                slotOperands.getBuffer());
 
             addUsersToWorkList(inst);
 

--- a/source/slang/ir-specialize.cpp
+++ b/source/slang/ir-specialize.cpp
@@ -568,7 +568,7 @@ struct SpecializationContext
 
         // We will then iterate until our work list goes dry.
         //
-        while(workList.Count() != 0)
+        while(workList.getSize() != 0)
         {
             IRInst* inst = workList.Last();
             workList.RemoveLast();
@@ -975,7 +975,7 @@ struct SpecializationContext
             newParamTypes.Add(newParam->getFullType());
         }
         IRType* newFuncType = builder->getFuncType(
-            newParamTypes.Count(),
+            newParamTypes.getSize(),
             newParamTypes.Buffer(),
             oldFunc->getResultType());
         IRFunc* newFunc = builder->createFunc();

--- a/source/slang/ir-ssa.cpp
+++ b/source/slang/ir-ssa.cpp
@@ -261,7 +261,7 @@ IRVar* asPromotableVar(
         return nullptr;
 
     IRVar* var = (IRVar*)value;
-    if (!context->promotableVars.Contains(var))
+    if (!context->promotableVars.contains(var))
         return nullptr;
 
     return var;
@@ -311,7 +311,7 @@ IRInst* applyAccessChain(
 
     case kIROp_FieldAddress:
         {
-            SLANG_ASSERT(context->instsToRemove.Contains(accessChain));
+            SLANG_ASSERT(context->instsToRemove.contains(accessChain));
 
             auto baseChain = accessChain->getOperand(0);
             auto fieldKey = accessChain->getOperand(1);
@@ -325,7 +325,7 @@ IRInst* applyAccessChain(
 
     case kIROp_getElementPtr:
         {
-            SLANG_ASSERT(context->instsToRemove.Contains(accessChain));
+            SLANG_ASSERT(context->instsToRemove.contains(accessChain));
 
             auto baseChain = accessChain->getOperand(0);
             auto index = accessChain->getOperand(1);

--- a/source/slang/ir-ssa.cpp
+++ b/source/slang/ir-ssa.cpp
@@ -518,7 +518,7 @@ IRInst* addPhiOperands(
     // required invariant.
 
     UInt operandCount = operandValues.getSize();
-    phiInfo->operands.SetSize(operandCount);
+    phiInfo->operands.setSize(operandCount);
     for(UInt ii = 0; ii < operandCount; ++ii)
     {
         phiInfo->operands[ii].init(phiInfo->phi, operandValues[ii]);

--- a/source/slang/ir-ssa.cpp
+++ b/source/slang/ir-ssa.cpp
@@ -517,7 +517,7 @@ IRInst* addPhiOperands(
     // list with its final size so that we can preserve the
     // required invariant.
 
-    UInt operandCount = operandValues.Count();
+    UInt operandCount = operandValues.getSize();
     phiInfo->operands.SetSize(operandCount);
     for(UInt ii = 0; ii < operandCount; ++ii)
     {
@@ -561,7 +561,7 @@ void maybeSealBlock(
     // Note that we are doing the "inefficient" loop where we compute
     // the count on each iteration to account for the possibility that
     // new incomplete phis will get added while we are working.
-    for (UInt ii = 0; ii < blockInfo->phis.Count(); ++ii)
+    for (UInt ii = 0; ii < blockInfo->phis.getSize(); ++ii)
     {
         auto incompletePhi = blockInfo->phis[ii];
         addPhiOperands(context, blockInfo, incompletePhi);
@@ -968,7 +968,7 @@ void constructSSA(ConstructSSAContext* context)
 
     // If none of the variables are promote-able,
     // then we can exit without making any changes
-    if (context->promotableVars.Count() == 0)
+    if (context->promotableVars.getSize() == 0)
         return;
 
     // We are going to walk the blocks in order,
@@ -1037,7 +1037,7 @@ void constructSSA(ConstructSSAContext* context)
 
         // Don't do any work for blocks that don't need to pass along
         // values to the sucessor block.
-        auto addedArgCount = blockInfo->successorArgs.Count();
+        auto addedArgCount = blockInfo->successorArgs.getSize();
         if (addedArgCount == 0)
             continue;
 

--- a/source/slang/ir-ssa.cpp
+++ b/source/slang/ir-ssa.cpp
@@ -517,8 +517,8 @@ IRInst* addPhiOperands(
     // list with its final size so that we can preserve the
     // required invariant.
 
-    UInt operandCount = operandValues.getSize();
-    phiInfo->operands.setSize(operandCount);
+    UInt operandCount = operandValues.getCount();
+    phiInfo->operands.setCount(operandCount);
     for(UInt ii = 0; ii < operandCount; ++ii)
     {
         phiInfo->operands[ii].init(phiInfo->phi, operandValues[ii]);
@@ -561,7 +561,7 @@ void maybeSealBlock(
     // Note that we are doing the "inefficient" loop where we compute
     // the count on each iteration to account for the possibility that
     // new incomplete phis will get added while we are working.
-    for (UInt ii = 0; ii < blockInfo->phis.getSize(); ++ii)
+    for (UInt ii = 0; ii < blockInfo->phis.getCount(); ++ii)
     {
         auto incompletePhi = blockInfo->phis[ii];
         addPhiOperands(context, blockInfo, incompletePhi);
@@ -968,7 +968,7 @@ void constructSSA(ConstructSSAContext* context)
 
     // If none of the variables are promote-able,
     // then we can exit without making any changes
-    if (context->promotableVars.getSize() == 0)
+    if (context->promotableVars.getCount() == 0)
         return;
 
     // We are going to walk the blocks in order,
@@ -1037,7 +1037,7 @@ void constructSSA(ConstructSSAContext* context)
 
         // Don't do any work for blocks that don't need to pass along
         // values to the sucessor block.
-        auto addedArgCount = blockInfo->successorArgs.getSize();
+        auto addedArgCount = blockInfo->successorArgs.getCount();
         if (addedArgCount == 0)
             continue;
 
@@ -1066,7 +1066,7 @@ void constructSSA(ConstructSSAContext* context)
             oldTerminator->getFullType(),
             oldTerminator->op,
             newArgCount,
-            newArgs.Buffer());
+            newArgs.getBuffer());
 
         // Transfer decorations (a terminator should have no children) over to the new instruction.
         //

--- a/source/slang/ir-ssa.cpp
+++ b/source/slang/ir-ssa.cpp
@@ -561,7 +561,7 @@ void maybeSealBlock(
     // Note that we are doing the "inefficient" loop where we compute
     // the count on each iteration to account for the possibility that
     // new incomplete phis will get added while we are working.
-    for (UInt ii = 0; ii < blockInfo->phis.getCount(); ++ii)
+    for (Index ii = 0; ii < blockInfo->phis.getCount(); ++ii)
     {
         auto incompletePhi = blockInfo->phis[ii];
         addPhiOperands(context, blockInfo, incompletePhi);
@@ -1057,7 +1057,7 @@ void constructSSA(ConstructSSAContext* context)
         {
             newArgs.add(oldTerminator->getOperand(aa));
         }
-        for (UInt aa = 0; aa < addedArgCount; ++aa)
+        for (Index aa = 0; aa < addedArgCount; ++aa)
         {
             newArgs.add(blockInfo->successorArgs[aa]);
         }

--- a/source/slang/ir-ssa.cpp
+++ b/source/slang/ir-ssa.cpp
@@ -246,7 +246,7 @@ void identifyPromotableVars(
 
             if (isPromotableVar(context, var))
             {
-                context->promotableVars.Add(var);
+                context->promotableVars.add(var);
             }
         }
     }
@@ -391,7 +391,7 @@ PhiInfo* addPhi(
     phiInfo->phi = phi;
     phiInfo->var = var;
 
-    blockInfo->phis.Add(phiInfo);
+    blockInfo->phis.add(phiInfo);
 
     return phiInfo;
 }
@@ -458,7 +458,7 @@ IRInst* tryRemoveTrivialPhi(
             auto maybeOtherPhi = (IRParam*) user;
             if( auto otherPhiInfo = context->getPhiInfo(maybeOtherPhi) )
             {
-                otherPhis.Add(otherPhiInfo);
+                otherPhis.add(otherPhiInfo);
             }
         }
     }
@@ -509,7 +509,7 @@ IRInst* addPhiOperands(
 
         auto phiOperand = readVar(context, predInfo, var);
 
-        operandValues.Add(phiOperand);
+        operandValues.add(phiOperand);
     }
 
     // The `IRUse`  type needs to stay at a stable location
@@ -829,7 +829,7 @@ void processBlock(
                 auto  ptrArg = ii->getOperand(0);
                 if (auto var = asPromotableVarAccessChain(context, ptrArg))
                 {
-                    context->instsToRemove.Add(ii);
+                    context->instsToRemove.add(ii);
                 }
             }
             break;
@@ -913,7 +913,7 @@ static void breakCriticalEdges(
             // Furthermore, the `IRUse` embedded in `succIter` represents
             // that edge directly.
             auto edgeUse = succIter.use;
-            criticalEdges.Add(edgeUse);
+            criticalEdges.add(edgeUse);
         }
     }
 
@@ -1020,7 +1020,7 @@ void constructSSA(ConstructSSAContext* context)
 
                 phiInfo->operands[predIndex].clear();
 
-                predInfo->successorArgs.Add(operandVal);
+                predInfo->successorArgs.add(operandVal);
             }
         }
     }
@@ -1055,11 +1055,11 @@ void constructSSA(ConstructSSAContext* context)
         List<IRInst*> newArgs;
         for (UInt aa = 0; aa < oldArgCount; ++aa)
         {
-            newArgs.Add(oldTerminator->getOperand(aa));
+            newArgs.add(oldTerminator->getOperand(aa));
         }
         for (UInt aa = 0; aa < addedArgCount; ++aa)
         {
-            newArgs.Add(blockInfo->successorArgs[aa]);
+            newArgs.add(blockInfo->successorArgs[aa]);
         }
 
         IRTerminatorInst* newTerminator = (IRTerminatorInst*)blockInfo->builder.emitIntrinsicInst(

--- a/source/slang/ir-union.cpp
+++ b/source/slang/ir-union.cpp
@@ -269,7 +269,7 @@ struct DesugarUnionTypesContext
                 // for fields, etc.).
                 //
                 auto taggedUnionTypeLayout = taggedUnionInfo->taggedUnionTypeLayout;
-                SLANG_ASSERT(caseTagIndex < taggedUnionTypeLayout->caseTypeLayouts.Count());
+                SLANG_ASSERT(caseTagIndex < taggedUnionTypeLayout->caseTypeLayouts.getSize());
                 auto caseTypeLayout = taggedUnionTypeLayout->caseTypeLayouts[caseTagIndex];
 
                 // At this point we know the type we are trying to extract, as well

--- a/source/slang/ir-union.cpp
+++ b/source/slang/ir-union.cpp
@@ -269,7 +269,7 @@ struct DesugarUnionTypesContext
                 // for fields, etc.).
                 //
                 auto taggedUnionTypeLayout = taggedUnionInfo->taggedUnionTypeLayout;
-                SLANG_ASSERT(caseTagIndex < taggedUnionTypeLayout->caseTypeLayouts.getCount());
+                SLANG_ASSERT(caseTagIndex < UInt(taggedUnionTypeLayout->caseTypeLayouts.getCount()));
                 auto caseTypeLayout = taggedUnionTypeLayout->caseTypeLayouts[caseTagIndex];
 
                 // At this point we know the type we are trying to extract, as well

--- a/source/slang/ir-union.cpp
+++ b/source/slang/ir-union.cpp
@@ -269,7 +269,7 @@ struct DesugarUnionTypesContext
                 // for fields, etc.).
                 //
                 auto taggedUnionTypeLayout = taggedUnionInfo->taggedUnionTypeLayout;
-                SLANG_ASSERT(caseTagIndex < taggedUnionTypeLayout->caseTypeLayouts.getSize());
+                SLANG_ASSERT(caseTagIndex < taggedUnionTypeLayout->caseTypeLayouts.getCount());
                 auto caseTypeLayout = taggedUnionTypeLayout->caseTypeLayouts[caseTagIndex];
 
                 // At this point we know the type we are trying to extract, as well

--- a/source/slang/ir-union.cpp
+++ b/source/slang/ir-union.cpp
@@ -230,7 +230,7 @@ struct DesugarUnionTypesContext
                 // list for later removal.
                 //
                 inst->replaceUsesWith(replacement);
-                instsToRemove.Add(inst);
+                instsToRemove.add(inst);
             }
             break;
 
@@ -321,7 +321,7 @@ struct DesugarUnionTypesContext
                 // this instruction, and schedule the original instruction for removal.
                 //
                 inst->replaceUsesWith(payloadVal);
-                instsToRemove.Add(inst);
+                instsToRemove.add(inst);
             }
             break;
         }
@@ -403,7 +403,7 @@ struct DesugarUnionTypesContext
                     fieldType,
                     fieldTypeLayout,
                     fieldOffset);
-                fieldVals.Add(fieldVal);
+                fieldVals.add(fieldVal);
             }
 
             // The final value is then just a new struct constructed from
@@ -447,7 +447,7 @@ struct DesugarUnionTypesContext
                     elementType,
                     elementTypeLayout,
                     payloadOffset + ii*elementSize);
-                elementVals.Add(elementVal);
+                elementVals.add(elementVal);
             }
             return builder->emitMakeVector(vecType, elementVals);
         }
@@ -625,7 +625,7 @@ struct DesugarUnionTypesContext
         //
         auto info = createTaggedUnionInfo(type);
         mapIRTypeToTaggedUnionInfo.Add(type, info.Ptr());
-        taggedUnionInfos.Add(info);
+        taggedUnionInfos.add(info);
 
         return info;
     }

--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -3766,7 +3766,7 @@ namespace Slang
 
         dumpInst(&context, globalVal);
 
-        writer->write(sb.Buffer(), sb.getLength());
+        writer->write(sb.getBuffer(), sb.getLength());
         writer->flush();
     }
 
@@ -3780,7 +3780,7 @@ namespace Slang
     void dumpIR(IRModule* module, ISlangWriter* writer, IRDumpMode mode)
     {
         String ir = getSlangIRAssembly(module, mode);
-        writer->write(ir.Buffer(), ir.getLength());
+        writer->write(ir.getBuffer(), ir.getLength());
         writer->flush();
     }
 

--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -275,7 +275,7 @@ namespace Slang
                 List<IRInst*> existentialArgs;
                 for( UInt ii = 0; ii < existentialArgCount; ++ii )
                 {
-                    existentialArgs.Add(bindExistentials->getExistentialArg(ii));
+                    existentialArgs.add(bindExistentials->getExistentialArg(ii));
                 }
                 return builder->getBindExistentialsType(
                     baseElementType,
@@ -1862,7 +1862,7 @@ namespace Slang
         List<IRInst*> slotArgs;
         for( UInt ii = 0; ii < slotArgCount; ++ii )
         {
-            slotArgs.Add(slotArgUses[ii].get());
+            slotArgs.add(slotArgUses[ii].get());
         }
         return getBindExistentialsType(
             baseType,

--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -280,7 +280,7 @@ namespace Slang
                 return builder->getBindExistentialsType(
                     baseElementType,
                     existentialArgCount,
-                    existentialArgs.Buffer());
+                    existentialArgs.getBuffer());
             }
         }
 
@@ -1867,7 +1867,7 @@ namespace Slang
         return getBindExistentialsType(
             baseType,
             slotArgCount,
-            slotArgs.Buffer());
+            slotArgs.getBuffer());
     }
 
 

--- a/source/slang/ir.cpp
+++ b/source/slang/ir.cpp
@@ -3069,7 +3069,7 @@ namespace Slang
 
         // Allow an empty nam
         // Special case a name that is the empty string, just in case.
-        if(name.Length() == 0)
+        if(name.getLength() == 0)
         {
             sb.append('_');
         }
@@ -3766,7 +3766,7 @@ namespace Slang
 
         dumpInst(&context, globalVal);
 
-        writer->write(sb.Buffer(), sb.Length());
+        writer->write(sb.Buffer(), sb.getLength());
         writer->flush();
     }
 
@@ -3780,7 +3780,7 @@ namespace Slang
     void dumpIR(IRModule* module, ISlangWriter* writer, IRDumpMode mode)
     {
         String ir = getSlangIRAssembly(module, mode);
-        writer->write(ir.Buffer(), ir.Length());
+        writer->write(ir.Buffer(), ir.getLength());
         writer->flush();
     }
 

--- a/source/slang/legalize-types.cpp
+++ b/source/slang/legalize-types.cpp
@@ -22,7 +22,7 @@ LegalType LegalType::implicitDeref(
 LegalType LegalType::tuple(
     RefPtr<TuplePseudoType>   tupleType)
 {
-    SLANG_ASSERT(tupleType->elements.getSize());
+    SLANG_ASSERT(tupleType->elements.getCount());
 
     LegalType result;
     result.flavor = Flavor::tuple;

--- a/source/slang/legalize-types.cpp
+++ b/source/slang/legalize-types.cpp
@@ -363,7 +363,7 @@ struct TupleTypeBuilder
                 SLANG_UNEXPECTED("unexpected ordinary field type");
             }
         }
-        ordinaryElements.Add(ordinaryElement);
+        ordinaryElements.add(ordinaryElement);
 
         if (specialType.flavor != LegalType::Flavor::none)
         {
@@ -374,11 +374,11 @@ struct TupleTypeBuilder
             TuplePseudoType::Element specialElement;
             specialElement.key = fieldKey;
             specialElement.type = specialType;
-            specialElements.Add(specialElement);
+            specialElements.add(specialElement);
         }
 
         pairElement.type = LegalType::pair(ordinaryType, specialType, elementPairInfo);
-        pairElements.Add(pairElement);
+        pairElements.add(pairElement);
     }
 
     // Add a field to the (pseudo-)type we are building
@@ -452,7 +452,7 @@ struct TupleTypeBuilder
             // collide.
             //
             // (Also, the original type wasn't legal - that was the whole point...)
-            context->replacedInstructions.Add(originalStructType);
+            context->replacedInstructions.add(originalStructType);
 
             for(auto ee : ordinaryElements)
             {
@@ -681,7 +681,7 @@ LegalType createLegalUniformBufferTypeForResources(
                 newElement.key = ee.key;
                 newElement.type = LegalType::implicitDeref(ee.type);
 
-                bufferPseudoTupleType->elements.Add(newElement);
+                bufferPseudoTupleType->elements.add(newElement);
             }
 
             return LegalType::tuple(bufferPseudoTupleType);
@@ -808,7 +808,7 @@ LegalElementWrapping declareStructFields(
                 TupleLegalElementWrappingObj::Element element;
                 element.key = ee.key;
                 element.field = declareStructFields(context, structType, ee.type);
-                obj->elements.Add(element);
+                obj->elements.add(element);
             }
             return LegalElementWrapping::makeTuple(obj);
         }
@@ -952,7 +952,7 @@ static LegalType createLegalPtrType(
                     op,
                     ee.type);
 
-                ptrPseudoTupleType->elements.Add(newElement);
+                ptrPseudoTupleType->elements.add(newElement);
             }
 
             return LegalType::tuple(ptrPseudoTupleType);
@@ -1072,7 +1072,7 @@ static LegalType wrapLegalType(
                     ordinaryWrapper,
                     specialWrapper);
 
-                resultTupleType->elements.Add(element);
+                resultTupleType->elements.add(element);
             }
 
             return LegalType::tuple(resultTupleType);

--- a/source/slang/legalize-types.cpp
+++ b/source/slang/legalize-types.cpp
@@ -22,7 +22,7 @@ LegalType LegalType::implicitDeref(
 LegalType LegalType::tuple(
     RefPtr<TuplePseudoType>   tupleType)
 {
-    SLANG_ASSERT(tupleType->elements.Count());
+    SLANG_ASSERT(tupleType->elements.getSize());
 
     LegalType result;
     result.flavor = Flavor::tuple;

--- a/source/slang/lexer.cpp
+++ b/source/slang/lexer.cpp
@@ -19,15 +19,15 @@ namespace Slang
 
     Token* TokenList::begin() const
     {
-        SLANG_ASSERT(mTokens.Count());
+        SLANG_ASSERT(mTokens.getSize());
         return &mTokens[0];
     }
 
     Token* TokenList::end() const
     {
-        SLANG_ASSERT(mTokens.Count());
-        SLANG_ASSERT(mTokens[mTokens.Count()-1].type == TokenType::EndOfFile);
-        return &mTokens[mTokens.Count() - 1];
+        SLANG_ASSERT(mTokens.getSize());
+        SLANG_ASSERT(mTokens[mTokens.getSize()-1].type == TokenType::EndOfFile);
+        return &mTokens[mTokens.getSize() - 1];
     }
 
     TokenSpan::TokenSpan()

--- a/source/slang/lexer.cpp
+++ b/source/slang/lexer.cpp
@@ -19,15 +19,15 @@ namespace Slang
 
     Token* TokenList::begin() const
     {
-        SLANG_ASSERT(mTokens.getSize());
+        SLANG_ASSERT(mTokens.getCount());
         return &mTokens[0];
     }
 
     Token* TokenList::end() const
     {
-        SLANG_ASSERT(mTokens.getSize());
-        SLANG_ASSERT(mTokens[mTokens.getSize()-1].type == TokenType::EndOfFile);
-        return &mTokens[mTokens.getSize() - 1];
+        SLANG_ASSERT(mTokens.getCount());
+        SLANG_ASSERT(mTokens[mTokens.getCount()-1].type == TokenType::EndOfFile);
+        return &mTokens[mTokens.getCount() - 1];
     }
 
     TokenSpan::TokenSpan()

--- a/source/slang/lexer.cpp
+++ b/source/slang/lexer.cpp
@@ -1325,7 +1325,7 @@ namespace Slang
         for(;;)
         {
             Token token = lexToken();
-            tokenList.mTokens.Add(token);
+            tokenList.mTokens.add(token);
 
             if(token.type == TokenType::EndOfFile)
                 return tokenList;

--- a/source/slang/lookup.cpp
+++ b/source/slang/lookup.cpp
@@ -56,7 +56,7 @@ void buildMemberDictionary(ContainerDecl* decl)
         {
             TransparentMemberInfo info;
             info.decl = m.Ptr();
-            decl->transparentMembers.Add(info);
+            decl->transparentMembers.add(info);
         }
 
         // Ignore members with no name
@@ -121,13 +121,13 @@ void AddToLookupResult(
     else if (!result.isOverloaded())
     {
         // We are about to make this overloaded
-        result.items.Add(result.item);
-        result.items.Add(item);
+        result.items.add(result.item);
+        result.items.add(item);
     }
     else
     {
         // The result was already overloaded, so we pile on
-        result.items.Add(item);
+        result.items.add(item);
     }
 }
 

--- a/source/slang/lookup.cpp
+++ b/source/slang/lookup.cpp
@@ -42,7 +42,7 @@ void buildMemberDictionary(ContainerDecl* decl)
         return;
 
     decl->memberDictionary.Clear();
-    decl->transparentMembers.Clear();
+    decl->transparentMembers.clear();
 
     // are we a generic?
     GenericDecl* genericDecl = as<GenericDecl>(decl);

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -679,7 +679,7 @@ LoweredValInfo emitCallToDeclRef(
             boundSubscript->type = type;
             boundSubscript->args.AddRange(args, argCount);
 
-            context->shared->extValues.Add(boundSubscript);
+            context->shared->extValues.add(boundSubscript);
 
             return LoweredValInfo::boundSubscript(boundSubscript);
         }
@@ -769,7 +769,7 @@ LoweredValInfo emitCallToDeclRef(
         List<IRType*> argTypes;
         for(UInt ii = 0; ii < argCount; ++ii)
         {
-            argTypes.Add(args[ii]->getDataType());
+            argTypes.add(args[ii]->getDataType());
         }
         funcType = builder->getFuncType(argCount, argTypes.Buffer(), type);
     }
@@ -826,7 +826,7 @@ LoweredValInfo extractField(
             boundMemberInfo->base = base;
             boundMemberInfo->declRef = field;
 
-            context->shared->extValues.Add(boundMemberInfo);
+            context->shared->extValues.add(boundMemberInfo);
             return LoweredValInfo::boundMember(boundMemberInfo);
         }
         break;
@@ -1161,7 +1161,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
         for( auto caseWitness : val->caseWitnesses )
         {
             auto caseWitnessTable = lowerSimpleVal(context, caseWitness);
-            caseWitnessTables.Add(caseWitnessTable);
+            caseWitnessTables.add(caseWitnessTable);
         }
 
         // Now we need to synthesize a witness table for the tagged union
@@ -1244,7 +1244,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
                 auto irThisParam = subBuilder->emitParam(irThisType);
 
                 List<IRType*> irParamTypes;
-                irParamTypes.Add(irThisType);
+                irParamTypes.add(irThisType);
 
                 // Create the remaining parameters of the callable,
                 // using a decl-ref specialized to the tagged union
@@ -1262,8 +1262,8 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
                     auto irParamType = lowerType(context, GetType(paramDeclRef));
                     auto irParam = subBuilder->emitParam(irParamType);
 
-                    irParams.Add(irParam);
-                    irParamTypes.Add(irParamType);
+                    irParams.add(irParam);
+                    irParamTypes.add(irParamType);
                 }
 
                 auto irResultType = lowerType(context, GetResultType(callableDeclRef));
@@ -1296,8 +1296,8 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
                     if(!defaultLabel)
                         defaultLabel = caseLabel;
 
-                    switchCaseOperands.Add(caseTag);
-                    switchCaseOperands.Add(caseLabel);
+                    switchCaseOperands.add(caseTag);
+                    switchCaseOperands.add(caseLabel);
 
                     subBuilder->setInsertInto(caseLabel);
 
@@ -1332,7 +1332,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
                     auto caseThisArg = subBuilder->emitExtractTaggedUnionPayload(
                         caseThisType,
                         irThisParam, caseTag);
-                    caseArgs.Add(caseThisArg);
+                    caseArgs.add(caseThisArg);
 
                     // The remaining arguments to the call will just be forwarded from
                     // the parameters of the wrapper function.
@@ -1343,7 +1343,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
                     //
                     for( auto param : irParams )
                     {
-                        caseArgs.Add(param);
+                        caseArgs.add(param);
                     }
 
                     auto caseCall = subBuilder->emitCallInst(caseResultType, caseFunc, caseArgs);
@@ -1410,7 +1410,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
         List<IRType*> paramTypes;
         for (UInt pp = 0; pp < paramCount; ++pp)
         {
-            paramTypes.Add(lowerType(context, type->getParamType(pp)));
+            paramTypes.add(lowerType(context, type->getParamType(pp)));
         }
         return getBuilder()->getFuncType(
             paramCount,
@@ -1592,7 +1592,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
         for(auto caseType : type->caseTypes)
         {
             auto irCaseType = lowerType(context, caseType);
-            irCaseTypes.Add(irCaseType);
+            irCaseTypes.add(irCaseType);
         }
 
         auto irType = getBuilder()->getTaggedUnionType(irCaseTypes);
@@ -1842,7 +1842,7 @@ void addArgs(
     case LoweredValInfo::Flavor::SwizzledLValue:
     case LoweredValInfo::Flavor::BoundSubscript:
     case LoweredValInfo::Flavor::BoundMember:
-        args.Add(getSimpleVal(context, argInfo));
+        args.add(getSimpleVal(context, argInfo));
         break;
 
     default:
@@ -2066,7 +2066,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             List<IRInst*> args;
             for(UInt ee = 0; ee < elementCount; ++ee)
             {
-                args.Add(irDefaultValue);
+                args.add(irDefaultValue);
             }
             return LoweredValInfo::simple(
                 getBuilder()->emitMakeVector(irType, args.getSize(), args.Buffer()));
@@ -2082,7 +2082,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             List<IRInst*> args;
             for(UInt rr = 0; rr < rowCount; ++rr)
             {
-                args.Add(irDefaultValue);
+                args.add(irDefaultValue);
             }
             return LoweredValInfo::simple(
                 getBuilder()->emitMakeMatrix(irType, args.getSize(), args.Buffer()));
@@ -2096,7 +2096,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             List<IRInst*> args;
             for(UInt ee = 0; ee < elementCount; ++ee)
             {
-                args.Add(irDefaultElement);
+                args.add(irDefaultElement);
             }
 
             return LoweredValInfo::simple(
@@ -2114,7 +2114,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
                         continue;
 
                     auto irFieldVal = getSimpleVal(context, getDefaultVal(ff));
-                    args.Add(irFieldVal);
+                    args.add(irFieldVal);
                 }
 
                 return LoweredValInfo::simple(
@@ -2166,14 +2166,14 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             {
                 auto argExpr = expr->args[ee];
                 LoweredValInfo argVal = lowerRValueExpr(context, argExpr);
-                args.Add(getSimpleVal(context, argVal));
+                args.add(getSimpleVal(context, argVal));
             }
             if(elementCount > argCount)
             {
                 auto irDefaultValue = getSimpleVal(context, getDefaultVal(arrayType->baseType));
                 for(UInt ee = argCount; ee < elementCount; ++ee)
                 {
-                    args.Add(irDefaultValue);
+                    args.add(irDefaultValue);
                 }
             }
 
@@ -2188,14 +2188,14 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             {
                 auto argExpr = expr->args[ee];
                 LoweredValInfo argVal = lowerRValueExpr(context, argExpr);
-                args.Add(getSimpleVal(context, argVal));
+                args.add(getSimpleVal(context, argVal));
             }
             if(elementCount > argCount)
             {
                 auto irDefaultValue = getSimpleVal(context, getDefaultVal(vectorType->elementType));
                 for(UInt ee = argCount; ee < elementCount; ++ee)
                 {
-                    args.Add(irDefaultValue);
+                    args.add(irDefaultValue);
                 }
             }
 
@@ -2210,7 +2210,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             {
                 auto argExpr = expr->args[rr];
                 LoweredValInfo argVal = lowerRValueExpr(context, argExpr);
-                args.Add(getSimpleVal(context, argVal));
+                args.add(getSimpleVal(context, argVal));
             }
             if(rowCount > argCount)
             {
@@ -2219,7 +2219,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
 
                 for(UInt rr = argCount; rr < rowCount; ++rr)
                 {
-                    args.Add(irDefaultValue);
+                    args.add(irDefaultValue);
                 }
             }
 
@@ -2242,12 +2242,12 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
                     {
                         auto argExpr = expr->args[argIndex];
                         LoweredValInfo argVal = lowerRValueExpr(context, argExpr);
-                        args.Add(getSimpleVal(context, argVal));
+                        args.add(getSimpleVal(context, argVal));
                     }
                     else
                     {
                         auto irDefaultValue = getSimpleVal(context, getDefaultVal(ff));
-                        args.Add(irDefaultValue);
+                        args.add(irDefaultValue);
                     }
                 }
 
@@ -2366,7 +2366,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
                 // pass in the actual pointer.
                 //
                 IRInst* argPtr = getAddress(context, loweredArg, argExpr->loc);
-                (*ioArgs).Add(argPtr);
+                (*ioArgs).add(argPtr);
             }
             else if (paramDecl->HasModifier<OutModifier>()
                 || paramDecl->HasModifier<InOutModifier>())
@@ -2410,7 +2410,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
                 // Now we can pass the address of the temporary variable
                 // to the callee as the actual argument for the `in out`
                 SLANG_ASSERT(tempVar.flavor == LoweredValInfo::Flavor::Ptr);
-                (*ioArgs).Add(tempVar.val);
+                (*ioArgs).add(tempVar.val);
 
                 // Finally, after the call we will need
                 // to copy in the other direction: from our
@@ -2419,7 +2419,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
                 fixup.src = tempVar;
                 fixup.dst = loweredArg;
 
-                (*ioFixups).Add(fixup);
+                (*ioFixups).add(fixup);
 
             }
             else
@@ -2819,7 +2819,7 @@ struct LValueExprLoweringVisitor : ExprLoweringVisitorBase<LValueExprLoweringVis
             }
         }
 
-        context->shared->extValues.Add(swizzledLValue);
+        context->shared->extValues.add(swizzledLValue);
         return LoweredValInfo::swizzledLValue(swizzledLValue);
     }
 };
@@ -3513,8 +3513,8 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
             auto label = getLabelForCase(info);
 
             // Add this `case` to the list for the enclosing `switch`.
-            info->cases.Add(caseVal);
-            info->cases.Add(label);
+            info->cases.add(caseVal);
+            info->cases.add(label);
         }
         else if(auto defaultStmt = as<DefaultStmt>(stmt))
         {
@@ -3791,7 +3791,7 @@ LoweredValInfo tryGetAddress(
 
             auto newBase = tryGetAddress(context, originalBase, TryGetAddressMode::Aggressive);
             RefPtr<SwizzledLValueInfo> newSwizzleInfo = new SwizzledLValueInfo();
-            context->shared->extValues.Add(newSwizzleInfo);
+            context->shared->extValues.add(newSwizzleInfo);
 
             newSwizzleInfo->base = newBase;
             newSwizzleInfo->type = originalSwizzleInfo->type;
@@ -4557,11 +4557,11 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         {
             if (auto typeParamDecl = as<GenericTypeParamDecl>(member))
             {
-                genericArgs.Add(getSimpleVal(context, ensureDecl(context, typeParamDecl)));
+                genericArgs.add(getSimpleVal(context, ensureDecl(context, typeParamDecl)));
             }
             else if (auto valDecl = as<GenericValueParamDecl>(member))
             {
-                genericArgs.Add(getSimpleVal(context, ensureDecl(context, valDecl)));
+                genericArgs.add(getSimpleVal(context, ensureDecl(context, valDecl)));
             }
         }
         // Then we emit constraint parameters, again in
@@ -4570,7 +4570,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         {
             if (auto constraintDecl = as<GenericTypeConstraintDecl>(member))
             {
-                genericArgs.Add(getSimpleVal(context, ensureDecl(context, constraintDecl)));
+                genericArgs.add(getSimpleVal(context, ensureDecl(context, constraintDecl)));
             }
         }
 
@@ -5235,7 +5235,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         info.direction = direction;
         info.isThisParam = true;
 
-        ioParameterLists->params.Add(info);
+        ioParameterLists->params.add(info);
     }
     void addThisParameter(
         ParameterDirection  direction,
@@ -5317,7 +5317,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             {
                 for( auto paramDecl : callableDecl->GetParameters() )
                 {
-                    ioParameterLists->params.Add(getParameterInfo(paramDecl));
+                    ioParameterLists->params.add(getParameterInfo(paramDecl));
                 }
             }
         }
@@ -5584,7 +5584,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                 irParamType = maybeGetConstExprType(irParamType, paramInfo.decl);
             }
 
-            paramTypes.Add(irParamType);
+            paramTypes.add(irParamType);
         }
 
         auto irResultType = lowerType(subContext, declForReturnType->ReturnType);
@@ -5597,7 +5597,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             // it as a parameter.
             //
             IRType* irParamType = irResultType;
-            paramTypes.Add(irParamType);
+            paramTypes.add(irParamType);
 
             // Instead, a setter always returns `void`
             //
@@ -6086,7 +6086,7 @@ LoweredValInfo emitDeclRef(
         {
             auto irArgVal = lowerSimpleVal(context, argVal);
             SLANG_ASSERT(irArgVal);
-            irArgs.Add(irArgVal);
+            irArgs.add(irArgVal);
         }
 
         // Once we have both the generic and its arguments,
@@ -6229,8 +6229,8 @@ static void lowerProgramEntryPointToIR(
             auto irArgType = lowerType(context, arg.type);
             auto irWitnessTable = lowerSimpleVal(context, arg.witness);
 
-            existentialSlotArgs.Add(irArgType);
-            existentialSlotArgs.Add(irWitnessTable);
+            existentialSlotArgs.add(irArgType);
+            existentialSlotArgs.add(irWitnessTable);
         }
 
         builder->addBindExistentialSlotsDecoration(loweredEntryPointFunc, existentialSlotArgs.getSize(), existentialSlotArgs.Buffer());
@@ -6459,8 +6459,8 @@ RefPtr<IRModule> generateIRForProgram(
             auto irArgType = lowerType(context, arg.type);
             auto irWitnessTable = lowerSimpleVal(context, arg.witness);
 
-            existentialSlotArgs.Add(irArgType);
-            existentialSlotArgs.Add(irWitnessTable);
+            existentialSlotArgs.add(irArgType);
+            existentialSlotArgs.add(irWitnessTable);
         }
 
         builder->emitBindGlobalExistentialSlots(existentialSlotArgs.getSize(), existentialSlotArgs.Buffer());

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -1724,7 +1724,7 @@ static String getNameForNameHint(
     // or with an empty name
     if(!leafName)
         return String();
-    if(leafName->text.Length() == 0)
+    if(leafName->text.getLength() == 0)
         return String();
 
 
@@ -1769,7 +1769,7 @@ static String getNameForNameHint(
     }
 
     auto parentName = getNameForNameHint(context, parentDecl);
-    if(parentName.Length() == 0)
+    if(parentName.getLength() == 0)
     {
         return leafName->text;
     }
@@ -1793,7 +1793,7 @@ static void addNameHint(
     Decl*           decl)
 {
     String name = getNameForNameHint(context, decl);
-    if(name.Length() == 0)
+    if(name.getLength() == 0)
         return;
     context->irBuilder->addNameHintDecoration(inst, name.getUnownedSlice());
 }

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -1286,7 +1286,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
 
                 IRBlock* defaultLabel = nullptr;
 
-                for( UInt ii = 0; ii < caseCount; ++ii )
+                for( Index ii = 0; ii < caseCount; ++ii )
                 {
                     auto caseTag = subBuilder->getIntValue(irTagVal->getDataType(), ii);
 

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -677,7 +677,7 @@ LoweredValInfo emitCallToDeclRef(
             RefPtr<BoundSubscriptInfo> boundSubscript = new BoundSubscriptInfo();
             boundSubscript->declRef = subscriptDeclRef;
             boundSubscript->type = type;
-            boundSubscript->args.AddRange(args, argCount);
+            boundSubscript->args.addRange(args, argCount);
 
             context->shared->extValues.add(boundSubscript);
 

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -771,7 +771,7 @@ LoweredValInfo emitCallToDeclRef(
         {
             argTypes.add(args[ii]->getDataType());
         }
-        funcType = builder->getFuncType(argCount, argTypes.Buffer(), type);
+        funcType = builder->getFuncType(argCount, argTypes.getBuffer(), type);
     }
     LoweredValInfo funcVal = emitDeclRef(context, funcDeclRef, funcType);
     return emitCallToVal(context, type, funcVal, argCount, args);
@@ -784,7 +784,7 @@ LoweredValInfo emitCallToDeclRef(
     IRType*                 funcType,
     List<IRInst*> const&    args)
 {
-    return emitCallToDeclRef(context, type, funcDeclRef, funcType, args.getSize(), args.Buffer());
+    return emitCallToDeclRef(context, type, funcDeclRef, funcType, args.getCount(), args.getBuffer());
 }
 
 IRInst* getFieldKey(
@@ -1156,7 +1156,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
         // We can turn each of those per-case witnesses into a witness
         // table value:
         //
-        auto caseCount = val->caseWitnesses.getSize();
+        auto caseCount = val->caseWitnesses.getCount();
         List<IRInst*> caseWitnessTables;
         for( auto caseWitness : val->caseWitnesses )
         {
@@ -1375,8 +1375,8 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
                     irTagVal,       // value to `switch` on
                     invalidLabel,   // `break` label (block after the `switch` statement ends)
                     defaultLabel,   // `default` label (where to go if no `case` matches)
-                    switchCaseOperands.getSize(),
-                    switchCaseOperands.Buffer());
+                    switchCaseOperands.getCount(),
+                    switchCaseOperands.getBuffer());
             }
             else
             {
@@ -1414,7 +1414,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
         }
         return getBuilder()->getFuncType(
             paramCount,
-            paramTypes.Buffer(),
+            paramTypes.getBuffer(),
             resultType);
     }
 
@@ -2069,7 +2069,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
                 args.add(irDefaultValue);
             }
             return LoweredValInfo::simple(
-                getBuilder()->emitMakeVector(irType, args.getSize(), args.Buffer()));
+                getBuilder()->emitMakeVector(irType, args.getCount(), args.getBuffer()));
         }
         else if (auto matrixType = as<MatrixExpressionType>(type))
         {
@@ -2085,7 +2085,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
                 args.add(irDefaultValue);
             }
             return LoweredValInfo::simple(
-                getBuilder()->emitMakeMatrix(irType, args.getSize(), args.Buffer()));
+                getBuilder()->emitMakeMatrix(irType, args.getCount(), args.getBuffer()));
         }
         else if (auto arrayType = as<ArrayExpressionType>(type))
         {
@@ -2100,7 +2100,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             }
 
             return LoweredValInfo::simple(
-                getBuilder()->emitMakeArray(irType, args.getSize(), args.Buffer()));
+                getBuilder()->emitMakeArray(irType, args.getCount(), args.getBuffer()));
         }
         else if (auto declRefType = as<DeclRefType>(type))
         {
@@ -2118,7 +2118,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
                 }
 
                 return LoweredValInfo::simple(
-                    getBuilder()->emitMakeStruct(irType, args.getSize(), args.Buffer()));
+                    getBuilder()->emitMakeStruct(irType, args.getCount(), args.getBuffer()));
             }
         }
 
@@ -2145,7 +2145,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         IRType* irType = lowerType(context, type);
         List<IRInst*> args;
 
-        UInt argCount = expr->args.getSize();
+        UInt argCount = expr->args.getCount();
 
         // If the initializer list was empty, then the user was
         // asking for default initialization, which should apply
@@ -2178,7 +2178,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             }
 
             return LoweredValInfo::simple(
-                getBuilder()->emitMakeArray(irType, args.getSize(), args.Buffer()));
+                getBuilder()->emitMakeArray(irType, args.getCount(), args.getBuffer()));
         }
         else if (auto vectorType = as<VectorExpressionType>(type))
         {
@@ -2200,7 +2200,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             }
 
             return LoweredValInfo::simple(
-                getBuilder()->emitMakeVector(irType, args.getSize(), args.Buffer()));
+                getBuilder()->emitMakeVector(irType, args.getCount(), args.getBuffer()));
         }
         else if (auto matrixType = as<MatrixExpressionType>(type))
         {
@@ -2224,7 +2224,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             }
 
             return LoweredValInfo::simple(
-                getBuilder()->emitMakeMatrix(irType, args.getSize(), args.Buffer()));
+                getBuilder()->emitMakeMatrix(irType, args.getCount(), args.getBuffer()));
         }
         else if (auto declRefType = as<DeclRefType>(type))
         {
@@ -2252,7 +2252,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
                 }
 
                 return LoweredValInfo::simple(
-                    getBuilder()->emitMakeStruct(irType, args.getSize(), args.Buffer()));
+                    getBuilder()->emitMakeStruct(irType, args.getCount(), args.getBuffer()));
             }
         }
 
@@ -2311,7 +2311,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         List<IRInst*>*         ioArgs,
         List<OutArgumentFixup>* ioFixups)
     {
-        UInt argCount = expr->Arguments.getSize();
+        UInt argCount = expr->Arguments.getCount();
         UInt argCounter = 0;
         for (auto paramDeclRef : getMembersOfType<ParamDecl>(funcDeclRef))
         {
@@ -3651,8 +3651,8 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
             conditionVal,
             breakLabel,
             defaultLabel,
-            info.cases.getSize(),
-            info.cases.Buffer());
+            info.cases.getCount(),
+            info.cases.getBuffer());
 
         // Finally we insert the label that a `break` will jump to
         // (and that control flow will fall through to otherwise).
@@ -4574,7 +4574,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             }
         }
 
-        return builder->emitSpecializeInst(type, specialiedOuterVal, genericArgs.getSize(), genericArgs.Buffer());
+        return builder->emitSpecializeInst(type, specialiedOuterVal, genericArgs.getCount(), genericArgs.getBuffer());
     }
 
     IRInst* defaultSpecializeOuterGenerics(
@@ -5612,8 +5612,8 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         }
 
         auto irFuncType = subBuilder->getFuncType(
-            paramTypes.getSize(),
-            paramTypes.Buffer(),
+            paramTypes.getCount(),
+            paramTypes.getBuffer(),
             irResultType);
         irFunc->setFullType(irFuncType);
 
@@ -6095,8 +6095,8 @@ LoweredValInfo emitDeclRef(
         auto irSpecializedVal = context->irBuilder->emitSpecializeInst(
             type,
             irGenericVal,
-            irArgs.getSize(),
-            irArgs.Buffer());
+            irArgs.getCount(),
+            irArgs.getBuffer());
 
         return LoweredValInfo::simple(irSpecializedVal);
     }
@@ -6233,7 +6233,7 @@ static void lowerProgramEntryPointToIR(
             existentialSlotArgs.add(irWitnessTable);
         }
 
-        builder->addBindExistentialSlotsDecoration(loweredEntryPointFunc, existentialSlotArgs.getSize(), existentialSlotArgs.Buffer());
+        builder->addBindExistentialSlotsDecoration(loweredEntryPointFunc, existentialSlotArgs.getCount(), existentialSlotArgs.getBuffer());
     }
 
 
@@ -6463,7 +6463,7 @@ RefPtr<IRModule> generateIRForProgram(
             existentialSlotArgs.add(irWitnessTable);
         }
 
-        builder->emitBindGlobalExistentialSlots(existentialSlotArgs.getSize(), existentialSlotArgs.Buffer());
+        builder->emitBindGlobalExistentialSlots(existentialSlotArgs.getCount(), existentialSlotArgs.getBuffer());
     }
 
 

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -784,7 +784,7 @@ LoweredValInfo emitCallToDeclRef(
     IRType*                 funcType,
     List<IRInst*> const&    args)
 {
-    return emitCallToDeclRef(context, type, funcDeclRef, funcType, args.Count(), args.Buffer());
+    return emitCallToDeclRef(context, type, funcDeclRef, funcType, args.getSize(), args.Buffer());
 }
 
 IRInst* getFieldKey(
@@ -1156,7 +1156,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
         // We can turn each of those per-case witnesses into a witness
         // table value:
         //
-        auto caseCount = val->caseWitnesses.Count();
+        auto caseCount = val->caseWitnesses.getSize();
         List<IRInst*> caseWitnessTables;
         for( auto caseWitness : val->caseWitnesses )
         {
@@ -1375,7 +1375,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
                     irTagVal,       // value to `switch` on
                     invalidLabel,   // `break` label (block after the `switch` statement ends)
                     defaultLabel,   // `default` label (where to go if no `case` matches)
-                    switchCaseOperands.Count(),
+                    switchCaseOperands.getSize(),
                     switchCaseOperands.Buffer());
             }
             else
@@ -2069,7 +2069,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
                 args.Add(irDefaultValue);
             }
             return LoweredValInfo::simple(
-                getBuilder()->emitMakeVector(irType, args.Count(), args.Buffer()));
+                getBuilder()->emitMakeVector(irType, args.getSize(), args.Buffer()));
         }
         else if (auto matrixType = as<MatrixExpressionType>(type))
         {
@@ -2085,7 +2085,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
                 args.Add(irDefaultValue);
             }
             return LoweredValInfo::simple(
-                getBuilder()->emitMakeMatrix(irType, args.Count(), args.Buffer()));
+                getBuilder()->emitMakeMatrix(irType, args.getSize(), args.Buffer()));
         }
         else if (auto arrayType = as<ArrayExpressionType>(type))
         {
@@ -2100,7 +2100,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             }
 
             return LoweredValInfo::simple(
-                getBuilder()->emitMakeArray(irType, args.Count(), args.Buffer()));
+                getBuilder()->emitMakeArray(irType, args.getSize(), args.Buffer()));
         }
         else if (auto declRefType = as<DeclRefType>(type))
         {
@@ -2118,7 +2118,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
                 }
 
                 return LoweredValInfo::simple(
-                    getBuilder()->emitMakeStruct(irType, args.Count(), args.Buffer()));
+                    getBuilder()->emitMakeStruct(irType, args.getSize(), args.Buffer()));
             }
         }
 
@@ -2145,7 +2145,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         IRType* irType = lowerType(context, type);
         List<IRInst*> args;
 
-        UInt argCount = expr->args.Count();
+        UInt argCount = expr->args.getSize();
 
         // If the initializer list was empty, then the user was
         // asking for default initialization, which should apply
@@ -2178,7 +2178,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             }
 
             return LoweredValInfo::simple(
-                getBuilder()->emitMakeArray(irType, args.Count(), args.Buffer()));
+                getBuilder()->emitMakeArray(irType, args.getSize(), args.Buffer()));
         }
         else if (auto vectorType = as<VectorExpressionType>(type))
         {
@@ -2200,7 +2200,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             }
 
             return LoweredValInfo::simple(
-                getBuilder()->emitMakeVector(irType, args.Count(), args.Buffer()));
+                getBuilder()->emitMakeVector(irType, args.getSize(), args.Buffer()));
         }
         else if (auto matrixType = as<MatrixExpressionType>(type))
         {
@@ -2224,7 +2224,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             }
 
             return LoweredValInfo::simple(
-                getBuilder()->emitMakeMatrix(irType, args.Count(), args.Buffer()));
+                getBuilder()->emitMakeMatrix(irType, args.getSize(), args.Buffer()));
         }
         else if (auto declRefType = as<DeclRefType>(type))
         {
@@ -2252,7 +2252,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
                 }
 
                 return LoweredValInfo::simple(
-                    getBuilder()->emitMakeStruct(irType, args.Count(), args.Buffer()));
+                    getBuilder()->emitMakeStruct(irType, args.getSize(), args.Buffer()));
             }
         }
 
@@ -2311,7 +2311,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         List<IRInst*>*         ioArgs,
         List<OutArgumentFixup>* ioFixups)
     {
-        UInt argCount = expr->Arguments.Count();
+        UInt argCount = expr->Arguments.getSize();
         UInt argCounter = 0;
         for (auto paramDeclRef : getMembersOfType<ParamDecl>(funcDeclRef))
         {
@@ -3651,7 +3651,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
             conditionVal,
             breakLabel,
             defaultLabel,
-            info.cases.Count(),
+            info.cases.getSize(),
             info.cases.Buffer());
 
         // Finally we insert the label that a `break` will jump to
@@ -4574,7 +4574,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             }
         }
 
-        return builder->emitSpecializeInst(type, specialiedOuterVal, genericArgs.Count(), genericArgs.Buffer());
+        return builder->emitSpecializeInst(type, specialiedOuterVal, genericArgs.getSize(), genericArgs.Buffer());
     }
 
     IRInst* defaultSpecializeOuterGenerics(
@@ -5612,7 +5612,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         }
 
         auto irFuncType = subBuilder->getFuncType(
-            paramTypes.Count(),
+            paramTypes.getSize(),
             paramTypes.Buffer(),
             irResultType);
         irFunc->setFullType(irFuncType);
@@ -6095,7 +6095,7 @@ LoweredValInfo emitDeclRef(
         auto irSpecializedVal = context->irBuilder->emitSpecializeInst(
             type,
             irGenericVal,
-            irArgs.Count(),
+            irArgs.getSize(),
             irArgs.Buffer());
 
         return LoweredValInfo::simple(irSpecializedVal);
@@ -6233,7 +6233,7 @@ static void lowerProgramEntryPointToIR(
             existentialSlotArgs.Add(irWitnessTable);
         }
 
-        builder->addBindExistentialSlotsDecoration(loweredEntryPointFunc, existentialSlotArgs.Count(), existentialSlotArgs.Buffer());
+        builder->addBindExistentialSlotsDecoration(loweredEntryPointFunc, existentialSlotArgs.getSize(), existentialSlotArgs.Buffer());
     }
 
 
@@ -6463,7 +6463,7 @@ RefPtr<IRModule> generateIRForProgram(
             existentialSlotArgs.Add(irWitnessTable);
         }
 
-        builder->emitBindGlobalExistentialSlots(existentialSlotArgs.Count(), existentialSlotArgs.Buffer());
+        builder->emitBindGlobalExistentialSlots(existentialSlotArgs.getSize(), existentialSlotArgs.Buffer());
     }
 
 

--- a/source/slang/lower-to-ir.cpp
+++ b/source/slang/lower-to-ir.cpp
@@ -6222,7 +6222,7 @@ static void lowerProgramEntryPointToIR(
     if( existentialTypeArgCount )
     {
         List<IRInst*> existentialSlotArgs;
-        for( UInt ii = 0; ii < existentialTypeArgCount; ++ii )
+        for( Index ii = 0; ii < existentialTypeArgCount; ++ii )
         {
             auto arg = entryPoint->getExistentialTypeArg(ii);
 
@@ -6452,7 +6452,7 @@ RefPtr<IRModule> generateIRForProgram(
     if( existentialTypeArgCount )
     {
         List<IRInst*> existentialSlotArgs;
-        for( UInt ii = 0; ii < existentialTypeArgCount; ++ii )
+        for( Index ii = 0; ii < existentialTypeArgCount; ++ii )
         {
             auto arg = program->getExistentialTypeArg(ii);
 

--- a/source/slang/mangle.cpp
+++ b/source/slang/mangle.cpp
@@ -279,7 +279,7 @@ namespace Slang
             {
                 // This is the case where we *do* have substitutions.
                 emitRaw(context, "G");
-                UInt genericArgCount = subst->args.getSize();
+                UInt genericArgCount = subst->args.getCount();
                 emit(context, genericArgCount);
                 for( auto aa : subst->args )
                 {

--- a/source/slang/mangle.cpp
+++ b/source/slang/mangle.cpp
@@ -46,7 +46,7 @@ namespace Slang
 
         // We prefix the string with its byte length, so that
         // decoding doesn't have to worry about finding a terminator.
-        UInt length = str.Length();
+        Index length = str.getLength();
         emit(context, length);
         context->sb.append(str);
     }

--- a/source/slang/mangle.cpp
+++ b/source/slang/mangle.cpp
@@ -279,7 +279,7 @@ namespace Slang
             {
                 // This is the case where we *do* have substitutions.
                 emitRaw(context, "G");
-                UInt genericArgCount = subst->args.Count();
+                UInt genericArgCount = subst->args.getSize();
                 emit(context, genericArgCount);
                 for( auto aa : subst->args )
                 {

--- a/source/slang/options.cpp
+++ b/source/slang/options.cpp
@@ -181,7 +181,7 @@ struct OptionsParser
         // be broken if we decide to support a mix of translation units specified
         // via API, and ones specified via command-line arguments.
         //
-        SLANG_RELEASE_ASSERT(UInt(translationUnitID) == translationUnitIndex);
+        SLANG_RELEASE_ASSERT(Index(translationUnitID) == translationUnitIndex);
 
         RawTranslationUnit rawTranslationUnit;
         rawTranslationUnit.sourceLanguage = language;

--- a/source/slang/options.cpp
+++ b/source/slang/options.cpp
@@ -247,7 +247,7 @@ struct OptionsParser
         for (int i = 0; i < SLANG_COUNT_OF(entries); ++i)
         {
             const Entry& entry = entries[i];
-            if (path.EndsWith(entry.ext))
+            if (path.endsWith(entry.ext))
             {
                 return entry.profileId;
             }
@@ -283,7 +283,7 @@ struct OptionsParser
         for (int i = 0; i < SLANG_COUNT_OF(entries); ++i)
         {
             const Entry& entry = entries[i];
-            if (path.EndsWith(entry.ext))
+            if (path.endsWith(entry.ext))
             {
                 outImpliedStage = Stage(entry.impliedStage);
                 return entry.sourceLanguage;
@@ -301,7 +301,7 @@ struct OptionsParser
         // how we should handle it.
         String path = String(inPath);
 
-        if( path.EndsWith(".slang") )
+        if( path.endsWith(".slang") )
         {
             // Plain old slang code
             addInputSlangPath(path);
@@ -338,7 +338,7 @@ struct OptionsParser
 
         if (!inPath) {}
 #define CASE(EXT, TARGET)   \
-        else if(path.EndsWith(EXT)) do { addOutputPath(path, CodeGenTarget(SLANG_##TARGET)); } while(0)
+        else if(path.endsWith(EXT)) do { addOutputPath(path, CodeGenTarget(SLANG_##TARGET)); } while(0)
 
         CASE(".hlsl", HLSL);
         CASE(".fx",   HLSL);
@@ -362,7 +362,7 @@ struct OptionsParser
 
 #undef CASE
 
-        else if (path.EndsWith(".slang-module"))
+        else if (path.endsWith(".slang-module"))
         {
             spSetOutputContainerFormat(compileRequest, SLANG_CONTAINER_FORMAT_SLANG_MODULE);
             requestImpl->containerOutputPath = path;

--- a/source/slang/options.cpp
+++ b/source/slang/options.cpp
@@ -173,7 +173,7 @@ struct OptionsParser
         SlangSourceLanguage language,
         Stage               impliedStage)
     {
-        auto translationUnitIndex = rawTranslationUnits.Count();
+        auto translationUnitIndex = rawTranslationUnits.getSize();
         auto translationUnitID = spAddTranslationUnit(compileRequest, language, nullptr);
 
         // As a sanity check: the API should be returning the same translation
@@ -377,7 +377,7 @@ struct OptionsParser
 
     RawEntryPoint* getCurrentEntryPoint()
     {
-        auto rawEntryPointCount = rawEntryPoints.Count();
+        auto rawEntryPointCount = rawEntryPoints.getSize();
         return rawEntryPointCount ? &rawEntryPoints[rawEntryPointCount-1] : &defaultEntryPoint;
     }
 
@@ -396,7 +396,7 @@ struct OptionsParser
 
     RawTarget* getCurrentTarget()
     {
-        auto rawTargetCount = rawTargets.Count();
+        auto rawTargetCount = rawTargets.getSize();
         return rawTargetCount ? &rawTargets[rawTargetCount-1] : &defaultTarget;
     }
 
@@ -808,8 +808,8 @@ struct OptionsParser
         // of the translation unit, then we assume they wanted to compile a single
         // entry point named `main`.
         //
-        if(rawEntryPoints.Count() == 0
-           && rawTranslationUnits.Count() == 1
+        if(rawEntryPoints.getSize() == 0
+           && rawTranslationUnits.getSize() == 1
            && (defaultEntryPoint.stage != Stage::Unknown
                 || rawTranslationUnits[0].impliedStage != Stage::Unknown))
         {
@@ -825,7 +825,7 @@ struct OptionsParser
         // to the "default" entry point, we should copy it over to the
         // explicit one.
         //
-        if( rawEntryPoints.Count() == 1 )
+        if( rawEntryPoints.getSize() == 1 )
         {
             if(defaultEntryPoint.stage != Stage::Unknown)
             {
@@ -848,7 +848,7 @@ struct OptionsParser
             //
             if( defaultEntryPoint.stage != Stage::Unknown )
             {
-                if( rawEntryPoints.Count() == 0 )
+                if( rawEntryPoints.getSize() == 0 )
                 {
                     sink->diagnose(SourceLoc(), Diagnostics::stageSpecificationIgnoredBecauseNoEntryPoints);
                 }
@@ -988,7 +988,7 @@ struct OptionsParser
         // If there was no explicit `-target` specified, then we will look
         // at the `-o` options to see what we can infer.
         //
-        if(rawTargets.Count() == 0)
+        if(rawTargets.getSize() == 0)
         {
             for(auto& rawOutput : rawOutputs)
             {
@@ -1000,7 +1000,7 @@ struct OptionsParser
                 int targetIndex = 0;
                 if( !mapFormatToTargetIndex.TryGetValue(impliedFormat, targetIndex) )
                 {
-                    targetIndex = (int) rawTargets.Count();
+                    targetIndex = (int) rawTargets.getSize();
 
                     RawTarget rawTarget;
                     rawTarget.format = impliedFormat;
@@ -1019,7 +1019,7 @@ struct OptionsParser
             // is specified more than once (just because of the ambiguities
             // it will create).
             //
-            int targetCount = (int) rawTargets.Count();
+            int targetCount = (int) rawTargets.getSize();
             for(int targetIndex = 0; targetIndex < targetCount; ++targetIndex)
             {
                 auto format = rawTargets[targetIndex].format;
@@ -1039,7 +1039,7 @@ struct OptionsParser
         // because there were no output paths), but there was a profile specified,
         // then we can try to infer a target from the profile.
         //
-        if( rawTargets.Count() == 0
+        if( rawTargets.getSize() == 0
             && defaultTarget.profileVersion != ProfileVersion::Unknown
             && !defaultTarget.conflictingProfilesSet)
         {
@@ -1092,7 +1092,7 @@ struct OptionsParser
         // Similar to the case for entry points, if there is a single target,
         // then we allow some of its options to come from the "default"
         // target state.
-        if(rawTargets.Count() == 1)
+        if(rawTargets.getSize() == 1)
         {
             if(defaultTarget.profileVersion != ProfileVersion::Unknown)
             {
@@ -1114,7 +1114,7 @@ struct OptionsParser
             //
             if( defaultTarget.profileVersion != ProfileVersion::Unknown )
             {
-                if( rawTargets.Count() == 0 )
+                if( rawTargets.getSize() == 0 )
                 {
                     // This should only happen if there were multiple `-profile` options,
                     // so we didn't try to infer a target, or if the `-profile` option
@@ -1130,7 +1130,7 @@ struct OptionsParser
 
             if( defaultTarget.targetFlags )
             {
-                if( rawTargets.Count() == 0 )
+                if( rawTargets.getSize() == 0 )
                 {
                     sink->diagnose(SourceLoc(), Diagnostics::targetFlagsIgnoredBecauseNoTargets);
                 }
@@ -1142,7 +1142,7 @@ struct OptionsParser
 
             if( defaultTarget.floatingPointMode != FloatingPointMode::Default )
             {
-                if( rawTargets.Count() == 0 )
+                if( rawTargets.getSize() == 0 )
                 {
                     sink->diagnose(SourceLoc(), Diagnostics::targetFlagsIgnoredBecauseNoTargets);
                 }
@@ -1204,7 +1204,7 @@ struct OptionsParser
         // If there is only a single entry point, then that is automatically
         // the entry point that should be associated with all outputs.
         //
-        if( rawEntryPoints.Count() == 1 )
+        if( rawEntryPoints.getSize() == 1 )
         {
             for( auto& rawOutput : rawOutputs )
             {
@@ -1215,7 +1215,7 @@ struct OptionsParser
         // Similarly, if there is only one target, then all outputs must
         // implicitly appertain to that target.
         //
-        if( rawTargets.Count() == 1 )
+        if( rawTargets.getSize() == 1 )
         {
             for( auto& rawOutput : rawOutputs )
             {

--- a/source/slang/options.cpp
+++ b/source/slang/options.cpp
@@ -173,7 +173,7 @@ struct OptionsParser
         SlangSourceLanguage language,
         Stage               impliedStage)
     {
-        auto translationUnitIndex = rawTranslationUnits.getSize();
+        auto translationUnitIndex = rawTranslationUnits.getCount();
         auto translationUnitID = spAddTranslationUnit(compileRequest, language, nullptr);
 
         // As a sanity check: the API should be returning the same translation
@@ -377,7 +377,7 @@ struct OptionsParser
 
     RawEntryPoint* getCurrentEntryPoint()
     {
-        auto rawEntryPointCount = rawEntryPoints.getSize();
+        auto rawEntryPointCount = rawEntryPoints.getCount();
         return rawEntryPointCount ? &rawEntryPoints[rawEntryPointCount-1] : &defaultEntryPoint;
     }
 
@@ -396,7 +396,7 @@ struct OptionsParser
 
     RawTarget* getCurrentTarget()
     {
-        auto rawTargetCount = rawTargets.getSize();
+        auto rawTargetCount = rawTargets.getCount();
         return rawTargetCount ? &rawTargets[rawTargetCount-1] : &defaultTarget;
     }
 
@@ -808,8 +808,8 @@ struct OptionsParser
         // of the translation unit, then we assume they wanted to compile a single
         // entry point named `main`.
         //
-        if(rawEntryPoints.getSize() == 0
-           && rawTranslationUnits.getSize() == 1
+        if(rawEntryPoints.getCount() == 0
+           && rawTranslationUnits.getCount() == 1
            && (defaultEntryPoint.stage != Stage::Unknown
                 || rawTranslationUnits[0].impliedStage != Stage::Unknown))
         {
@@ -825,7 +825,7 @@ struct OptionsParser
         // to the "default" entry point, we should copy it over to the
         // explicit one.
         //
-        if( rawEntryPoints.getSize() == 1 )
+        if( rawEntryPoints.getCount() == 1 )
         {
             if(defaultEntryPoint.stage != Stage::Unknown)
             {
@@ -848,7 +848,7 @@ struct OptionsParser
             //
             if( defaultEntryPoint.stage != Stage::Unknown )
             {
-                if( rawEntryPoints.getSize() == 0 )
+                if( rawEntryPoints.getCount() == 0 )
                 {
                     sink->diagnose(SourceLoc(), Diagnostics::stageSpecificationIgnoredBecauseNoEntryPoints);
                 }
@@ -988,7 +988,7 @@ struct OptionsParser
         // If there was no explicit `-target` specified, then we will look
         // at the `-o` options to see what we can infer.
         //
-        if(rawTargets.getSize() == 0)
+        if(rawTargets.getCount() == 0)
         {
             for(auto& rawOutput : rawOutputs)
             {
@@ -1000,7 +1000,7 @@ struct OptionsParser
                 int targetIndex = 0;
                 if( !mapFormatToTargetIndex.TryGetValue(impliedFormat, targetIndex) )
                 {
-                    targetIndex = (int) rawTargets.getSize();
+                    targetIndex = (int) rawTargets.getCount();
 
                     RawTarget rawTarget;
                     rawTarget.format = impliedFormat;
@@ -1019,7 +1019,7 @@ struct OptionsParser
             // is specified more than once (just because of the ambiguities
             // it will create).
             //
-            int targetCount = (int) rawTargets.getSize();
+            int targetCount = (int) rawTargets.getCount();
             for(int targetIndex = 0; targetIndex < targetCount; ++targetIndex)
             {
                 auto format = rawTargets[targetIndex].format;
@@ -1039,7 +1039,7 @@ struct OptionsParser
         // because there were no output paths), but there was a profile specified,
         // then we can try to infer a target from the profile.
         //
-        if( rawTargets.getSize() == 0
+        if( rawTargets.getCount() == 0
             && defaultTarget.profileVersion != ProfileVersion::Unknown
             && !defaultTarget.conflictingProfilesSet)
         {
@@ -1092,7 +1092,7 @@ struct OptionsParser
         // Similar to the case for entry points, if there is a single target,
         // then we allow some of its options to come from the "default"
         // target state.
-        if(rawTargets.getSize() == 1)
+        if(rawTargets.getCount() == 1)
         {
             if(defaultTarget.profileVersion != ProfileVersion::Unknown)
             {
@@ -1114,7 +1114,7 @@ struct OptionsParser
             //
             if( defaultTarget.profileVersion != ProfileVersion::Unknown )
             {
-                if( rawTargets.getSize() == 0 )
+                if( rawTargets.getCount() == 0 )
                 {
                     // This should only happen if there were multiple `-profile` options,
                     // so we didn't try to infer a target, or if the `-profile` option
@@ -1130,7 +1130,7 @@ struct OptionsParser
 
             if( defaultTarget.targetFlags )
             {
-                if( rawTargets.getSize() == 0 )
+                if( rawTargets.getCount() == 0 )
                 {
                     sink->diagnose(SourceLoc(), Diagnostics::targetFlagsIgnoredBecauseNoTargets);
                 }
@@ -1142,7 +1142,7 @@ struct OptionsParser
 
             if( defaultTarget.floatingPointMode != FloatingPointMode::Default )
             {
-                if( rawTargets.getSize() == 0 )
+                if( rawTargets.getCount() == 0 )
                 {
                     sink->diagnose(SourceLoc(), Diagnostics::targetFlagsIgnoredBecauseNoTargets);
                 }
@@ -1204,7 +1204,7 @@ struct OptionsParser
         // If there is only a single entry point, then that is automatically
         // the entry point that should be associated with all outputs.
         //
-        if( rawEntryPoints.getSize() == 1 )
+        if( rawEntryPoints.getCount() == 1 )
         {
             for( auto& rawOutput : rawOutputs )
             {
@@ -1215,7 +1215,7 @@ struct OptionsParser
         // Similarly, if there is only one target, then all outputs must
         // implicitly appertain to that target.
         //
-        if( rawTargets.getSize() == 1 )
+        if( rawTargets.getCount() == 1 )
         {
             for( auto& rawOutput : rawOutputs )
             {

--- a/source/slang/options.cpp
+++ b/source/slang/options.cpp
@@ -188,7 +188,7 @@ struct OptionsParser
         rawTranslationUnit.translationUnitID = translationUnitID;
         rawTranslationUnit.impliedStage = impliedStage;
 
-        rawTranslationUnits.Add(rawTranslationUnit);
+        rawTranslationUnits.add(rawTranslationUnit);
 
         return int(translationUnitIndex);
     }
@@ -329,7 +329,7 @@ struct OptionsParser
         RawOutput rawOutput;
         rawOutput.path = path;
         rawOutput.impliedFormat = impliedFormat;
-        rawOutputs.Add(rawOutput);
+        rawOutputs.add(rawOutput);
     }
 
     void addOutputPath(char const* inPath)
@@ -510,7 +510,7 @@ struct OptionsParser
                     RawTarget rawTarget;
                     rawTarget.format = CodeGenTarget(format);
 
-                    rawTargets.Add(rawTarget);
+                    rawTargets.add(rawTarget);
                 }
                 // A "profile" can specify both a general capability level for
                 // a target, and also (as a legacy/compatibility feature) a
@@ -566,7 +566,7 @@ struct OptionsParser
                     rawEntryPoint.name = name;
                     rawEntryPoint.translationUnitIndex = currentTranslationUnitIndex;
 
-                    rawEntryPoints.Add(rawEntryPoint);
+                    rawEntryPoints.add(rawEntryPoint);
                 }
                 else if (argStr == "-pass-through")
                 {
@@ -816,7 +816,7 @@ struct OptionsParser
             RawEntryPoint entry;
             entry.name = "main";
             entry.translationUnitIndex = 0;
-            rawEntryPoints.Add(entry);
+            rawEntryPoints.add(entry);
         }
 
         // If the user (manually or implicitly) specified only a single entry point,
@@ -1004,7 +1004,7 @@ struct OptionsParser
 
                     RawTarget rawTarget;
                     rawTarget.format = impliedFormat;
-                    rawTargets.Add(rawTarget);
+                    rawTargets.add(rawTarget);
 
                     mapFormatToTargetIndex[impliedFormat] = targetIndex;
                 }
@@ -1085,7 +1085,7 @@ struct OptionsParser
             {
                 RawTarget rawTarget;
                 rawTarget.format = inferredFormat;
-                rawTargets.Add(rawTarget);
+                rawTargets.add(rawTarget);
             }
         }
 

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -1342,7 +1342,7 @@ SimpleSemanticInfo decomposeSimpleSemantic(
         // The name is everything before the digits
         String stringComposedName(composedName);
 
-        info.name = stringComposedName.SubString(0, indexLoc);
+        info.name = stringComposedName.subString(0, indexLoc);
         info.index = strtol(stringComposedName.begin() + indexLoc, nullptr, 10);
     }
     return info;
@@ -1362,11 +1362,11 @@ static RefPtr<TypeLayout> processSimpleEntryPointParameter(
     auto semanticIndex      = *state.ioSemanticIndex;
 
     String semanticName = optSemanticName ? *optSemanticName : "";
-    String sn = semanticName.ToLower();
+    String sn = semanticName.toLower();
 
     RefPtr<TypeLayout> typeLayout;
-    if (sn.StartsWith("sv_")
-        || sn.StartsWith("nv_"))
+    if (sn.startsWith("sv_")
+        || sn.startsWith("nv_"))
     {
         // System-value semantic.
 
@@ -1626,7 +1626,7 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
         // supposed to be case-insensitive and
         // upper-case is the dominant convention.
         String semanticName = *optSemanticName;
-        String sn = semanticName.ToUpper();
+        String sn = semanticName.toUpper();
 
         auto semanticIndex      = *state.ioSemanticIndex;
 

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -99,7 +99,7 @@ struct UsedRanges
         // using indices, because we may actually modify
         // the array as we go.
         //
-        Int rangeCount = ranges.getSize();
+        Int rangeCount = ranges.getCount();
         for(Int rr = 0; rr < rangeCount; ++rr)
         {
             auto existingRange = ranges[rr];
@@ -250,7 +250,7 @@ struct UsedRanges
     {
         UInt begin = 0;
 
-        UInt rangeCount = ranges.getSize();
+        UInt rangeCount = ranges.getCount();
         for (UInt rr = 0; rr < rangeCount; ++rr)
         {
             // try to fit in before this range...
@@ -671,7 +671,7 @@ static void collectGlobalGenericParameter(
 {
     RefPtr<GenericParamLayout> layout = new GenericParamLayout();
     layout->decl = paramDecl;
-    layout->index = (int)context->shared->programLayout->globalGenericParams.getSize();
+    layout->index = (int)context->shared->programLayout->globalGenericParams.getCount();
     context->shared->programLayout->globalGenericParams.add(layout);
     context->shared->programLayout->globalGenericParamsMap[layout->decl->getName()->text] = layout.Ptr();
 }
@@ -1002,7 +1002,7 @@ void generateParameterBindings(
     RefPtr<ParameterInfo>       parameterInfo)
 {
     // There must be at least one declaration for the parameter.
-    SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getSize() != 0);
+    SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getCount() != 0);
 
     // Iterate over all declarations looking for explicit binding information.
     for( auto& varLayout : parameterInfo->varLayouts )
@@ -1246,7 +1246,7 @@ static void completeBindingsForParameter(
     // that earlier code has validated that the declarations
     // "match".
 
-    SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getSize() != 0);
+    SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getCount() != 0);
     auto firstVarLayout = parameterInfo->varLayouts.getFirst();
 
     completeBindingsForParameterImpl(
@@ -1934,7 +1934,7 @@ struct ScopeLayoutBuilder
     void addParameter(
         ParameterInfo* parameterInfo)
     {
-        SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getSize() != 0);
+        SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getCount() != 0);
         auto firstVarLayout = parameterInfo->varLayouts.getFirst();
 
         _addParameter(firstVarLayout, parameterInfo);
@@ -2337,7 +2337,7 @@ RefPtr<ProgramLayout> generateParameterBindings(
     bool needDefaultConstantBuffer = false;
     for( auto& parameterInfo : sharedContext.parameters )
     {
-        SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getSize() != 0);
+        SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getCount() != 0);
         auto firstVarLayout = parameterInfo->varLayouts.getFirst();
 
         // Does the field have any uniform data?
@@ -2366,7 +2366,7 @@ RefPtr<ProgramLayout> generateParameterBindings(
         //
         for (auto& parameterInfo : sharedContext.parameters)
         {
-            SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getSize() != 0);
+            SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getCount() != 0);
             auto firstVarLayout = parameterInfo->varLayouts.getFirst();
 
             // For each parameter, we will look at each resource it consumes.

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -202,7 +202,7 @@ struct UsedRanges
         // be in the proper sorted order, so we'll need to
         // sort the array to restore our global invariant.
         //
-        ranges.Sort();
+        ranges.sort();
 
         // We end by returning an overlapping parameter that
         // we found along the way, if any.

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -584,7 +584,7 @@ static bool findLayoutArg(
     {
         if( modifier )
         {
-            *outVal = (UInt) strtoull(String(modifier->valToken.Content).Buffer(), nullptr, 10);
+            *outVal = (UInt) strtoull(String(modifier->valToken.Content).getBuffer(), nullptr, 10);
             return true;
         }
     }

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -161,7 +161,7 @@ struct UsedRanges
                 prefix.begin = range.begin;
                 prefix.end = existingRange.begin;
                 prefix.parameter = range.parameter;
-                ranges.Add(prefix);
+                ranges.add(prefix);
             }
             //
             // Now we know that the interval `[range.begin, existingRange.begin)`
@@ -195,7 +195,7 @@ struct UsedRanges
         //
         if(range.begin < range.end)
         {
-            ranges.Add(range);
+            ranges.add(range);
         }
 
         // Any ranges that got added along the way might not
@@ -672,7 +672,7 @@ static void collectGlobalGenericParameter(
     RefPtr<GenericParamLayout> layout = new GenericParamLayout();
     layout->decl = paramDecl;
     layout->index = (int)context->shared->programLayout->globalGenericParams.getSize();
-    context->shared->programLayout->globalGenericParams.Add(layout);
+    context->shared->programLayout->globalGenericParams.add(layout);
     context->shared->programLayout->globalGenericParamsMap[layout->decl->getName()->text] = layout.Ptr();
 }
 
@@ -716,10 +716,10 @@ static void collectGlobalScopeParameter(
     // TODO: `ParameterInfo` should probably become `LayoutParamInfo`.
     //
     ParameterInfo* parameterInfo = new ParameterInfo();
-    context->shared->parameters.Add(parameterInfo);
+    context->shared->parameters.add(parameterInfo);
 
     // Add the first variable declaration to the list of declarations for the parameter
-    parameterInfo->varLayouts.Add(varLayout);
+    parameterInfo->varLayouts.add(varLayout);
 
     // Add any additional variables to the list of declarations
     for( auto additionalVarDeclRef : shaderParamInfo.additionalParamDeclRefs )
@@ -739,7 +739,7 @@ static void collectGlobalScopeParameter(
         additionalVarLayout->typeLayout = typeLayout;
         additionalVarLayout->varDecl = additionalVarDeclRef;
 
-        parameterInfo->varLayouts.Add(additionalVarLayout);
+        parameterInfo->varLayouts.add(additionalVarLayout);
     }
 }
 
@@ -1247,7 +1247,7 @@ static void completeBindingsForParameter(
     // "match".
 
     SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getSize() != 0);
-    auto firstVarLayout = parameterInfo->varLayouts.First();
+    auto firstVarLayout = parameterInfo->varLayouts.getFirst();
 
     completeBindingsForParameterImpl(
         context,
@@ -1720,7 +1720,7 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
                     }
                 }
 
-                structLayout->fields.Add(fieldVarLayout);
+                structLayout->fields.add(fieldVarLayout);
                 structLayout->mapVarToLayout.Add(field.getDecl(), fieldVarLayout);
             }
 
@@ -1883,7 +1883,7 @@ struct ScopeLayoutBuilder
             }
         }
 
-        m_structLayout->fields.Add(firstVarLayout);
+        m_structLayout->fields.add(firstVarLayout);
 
         if( parameterInfo )
         {
@@ -1935,7 +1935,7 @@ struct ScopeLayoutBuilder
         ParameterInfo* parameterInfo)
     {
         SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getSize() != 0);
-        auto firstVarLayout = parameterInfo->varLayouts.First();
+        auto firstVarLayout = parameterInfo->varLayouts.getFirst();
 
         _addParameter(firstVarLayout, parameterInfo);
     }
@@ -2024,7 +2024,7 @@ static void collectEntryPointParameters(
     // The entry point layout must be added to the output
     // program layout so that it can be accessed by reflection.
     //
-    context->shared->programLayout->entryPoints.Add(entryPointLayout);
+    context->shared->programLayout->entryPoints.add(entryPointLayout);
 
     // For the duration of our parameter collection work we will
     // establish this entry point as the current one in the context.
@@ -2041,7 +2041,7 @@ static void collectEntryPointParameters(
         SLANG_ASSERT(taggedUnionType);
         auto substType = taggedUnionType->Substitute(typeSubst).as<Type>();
         auto typeLayout = createTypeLayout(context->layoutContext, substType);
-        entryPointLayout->taggedUnionTypeLayouts.Add(typeLayout);
+        entryPointLayout->taggedUnionTypeLayouts.add(typeLayout);
     }
 
     // We are going to iterate over the entry-point parameters,
@@ -2338,7 +2338,7 @@ RefPtr<ProgramLayout> generateParameterBindings(
     for( auto& parameterInfo : sharedContext.parameters )
     {
         SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getSize() != 0);
-        auto firstVarLayout = parameterInfo->varLayouts.First();
+        auto firstVarLayout = parameterInfo->varLayouts.getFirst();
 
         // Does the field have any uniform data?
         if( firstVarLayout->typeLayout->FindResourceInfo(LayoutResourceKind::Uniform) )
@@ -2367,7 +2367,7 @@ RefPtr<ProgramLayout> generateParameterBindings(
         for (auto& parameterInfo : sharedContext.parameters)
         {
             SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getSize() != 0);
-            auto firstVarLayout = parameterInfo->varLayouts.First();
+            auto firstVarLayout = parameterInfo->varLayouts.getFirst();
 
             // For each parameter, we will look at each resource it consumes.
             //

--- a/source/slang/parameter-binding.cpp
+++ b/source/slang/parameter-binding.cpp
@@ -99,7 +99,7 @@ struct UsedRanges
         // using indices, because we may actually modify
         // the array as we go.
         //
-        Int rangeCount = ranges.Count();
+        Int rangeCount = ranges.getSize();
         for(Int rr = 0; rr < rangeCount; ++rr)
         {
             auto existingRange = ranges[rr];
@@ -250,7 +250,7 @@ struct UsedRanges
     {
         UInt begin = 0;
 
-        UInt rangeCount = ranges.Count();
+        UInt rangeCount = ranges.getSize();
         for (UInt rr = 0; rr < rangeCount; ++rr)
         {
             // try to fit in before this range...
@@ -671,7 +671,7 @@ static void collectGlobalGenericParameter(
 {
     RefPtr<GenericParamLayout> layout = new GenericParamLayout();
     layout->decl = paramDecl;
-    layout->index = (int)context->shared->programLayout->globalGenericParams.Count();
+    layout->index = (int)context->shared->programLayout->globalGenericParams.getSize();
     context->shared->programLayout->globalGenericParams.Add(layout);
     context->shared->programLayout->globalGenericParamsMap[layout->decl->getName()->text] = layout.Ptr();
 }
@@ -1002,7 +1002,7 @@ void generateParameterBindings(
     RefPtr<ParameterInfo>       parameterInfo)
 {
     // There must be at least one declaration for the parameter.
-    SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.Count() != 0);
+    SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getSize() != 0);
 
     // Iterate over all declarations looking for explicit binding information.
     for( auto& varLayout : parameterInfo->varLayouts )
@@ -1246,7 +1246,7 @@ static void completeBindingsForParameter(
     // that earlier code has validated that the declarations
     // "match".
 
-    SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.Count() != 0);
+    SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getSize() != 0);
     auto firstVarLayout = parameterInfo->varLayouts.First();
 
     completeBindingsForParameterImpl(
@@ -1934,7 +1934,7 @@ struct ScopeLayoutBuilder
     void addParameter(
         ParameterInfo* parameterInfo)
     {
-        SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.Count() != 0);
+        SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getSize() != 0);
         auto firstVarLayout = parameterInfo->varLayouts.First();
 
         _addParameter(firstVarLayout, parameterInfo);
@@ -2337,7 +2337,7 @@ RefPtr<ProgramLayout> generateParameterBindings(
     bool needDefaultConstantBuffer = false;
     for( auto& parameterInfo : sharedContext.parameters )
     {
-        SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.Count() != 0);
+        SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getSize() != 0);
         auto firstVarLayout = parameterInfo->varLayouts.First();
 
         // Does the field have any uniform data?
@@ -2366,7 +2366,7 @@ RefPtr<ProgramLayout> generateParameterBindings(
         //
         for (auto& parameterInfo : sharedContext.parameters)
         {
-            SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.Count() != 0);
+            SLANG_RELEASE_ASSERT(parameterInfo->varLayouts.getSize() != 0);
             auto firstVarLayout = parameterInfo->varLayouts.First();
 
             // For each parameter, we will look at each resource it consumes.

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -2943,7 +2943,7 @@ namespace Slang
         }
         else if( auto declGroup = as<DeclGroup>(declBase) )
         {
-            if( declGroup->decls.Count() == 1 )
+            if( declGroup->decls.getSize() == 1 )
             {
                 return declGroup->decls[0];
             }

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -735,7 +735,7 @@ namespace Slang
                     auto arg = parser->ParseArgExpr();
                     if (arg)
                     {
-                        modifier->args.Add(arg);
+                        modifier->args.add(arg);
                     }
 
                     if (AdvanceIfMatch(parser, TokenType::RParent))
@@ -1075,7 +1075,7 @@ namespace Slang
         if (container)
         {
             member->ParentDecl = container.Ptr();
-            container->Members.Add(member);
+            container->Members.add(member);
 
             container->memberDictionaryIsValid = false;
         }
@@ -1597,13 +1597,13 @@ namespace Slang
             {
                 group = new DeclGroup();
                 group->loc = startPosition;
-                group->decls.Add(decl);
+                group->decls.add(decl);
                 decl = nullptr;
             }
 
             if( group )
             {
-                group->decls.Add(newDecl);
+                group->decls.add(newDecl);
             }
             else
             {
@@ -1662,10 +1662,10 @@ namespace Slang
         parser->ReadToken(TokenType::OpLess);
         parser->genericDepth++;
         // For now assume all generics have at least one argument
-        genericApp->Arguments.Add(ParseGenericArg(parser));
+        genericApp->Arguments.add(ParseGenericArg(parser));
         while (AdvanceIf(parser, TokenType::Comma))
         {
-            genericApp->Arguments.Add(ParseGenericArg(parser));
+            genericApp->Arguments.add(ParseGenericArg(parser));
         }
         parser->genericDepth--;
 
@@ -1778,7 +1778,7 @@ namespace Slang
         while(!AdvanceIfMatch(parser, TokenType::RParent))
         {
             auto caseType = parser->ParseTypeExp();
-            taggedUnionType->caseTypes.Add(caseType);
+            taggedUnionType->caseTypes.add(caseType);
 
             if(AdvanceIf(parser, TokenType::RParent))
                 break;
@@ -2258,7 +2258,7 @@ namespace Slang
         bufferDataTypeExpr->name = bufferDataTypeDecl->nameAndLoc.name;
         bufferDataTypeExpr->scope = parser->currentScope.Ptr();
 
-        // Construct a type exrpession to reference the type constructor
+        // Construct a type expression to reference the type constructor
         auto bufferWrapperTypeExpr = new VarExpr();
         bufferWrapperTypeExpr->loc = bufferWrapperTypeNamePos;
         bufferWrapperTypeExpr->name = getName(parser, bufferWrapperTypeName);
@@ -2272,11 +2272,11 @@ namespace Slang
         auto bufferVarTypeExpr = new GenericAppExpr();
         bufferVarTypeExpr->loc = bufferVarDecl->loc;
         bufferVarTypeExpr->FunctionExpr = bufferWrapperTypeExpr;
-        bufferVarTypeExpr->Arguments.Add(bufferDataTypeExpr);
+        bufferVarTypeExpr->Arguments.add(bufferDataTypeExpr);
 
         bufferVarDecl->type.exp = bufferVarTypeExpr;
 
-        // Any semantics applied to the bufer declaration are taken as applying
+        // Any semantics applied to the buffer declaration are taken as applying
         // to the variable instead.
         ParseOptSemantics(parser, bufferVarDecl.Ptr());
 
@@ -3340,14 +3340,14 @@ namespace Slang
                 }
                 else if (auto seqStmt = as<SeqStmt>(body))
                 {
-                    seqStmt->stmts.Add(stmt);
+                    seqStmt->stmts.add(stmt);
                 }
                 else
                 {
                     RefPtr<SeqStmt> newBody = new SeqStmt();
                     newBody->loc = blockStatement->loc;
-                    newBody->stmts.Add(body);
-                    newBody->stmts.Add(stmt);
+                    newBody->stmts.add(body);
+                    newBody->stmts.add(stmt);
 
                     body = newBody;
                 }
@@ -3668,8 +3668,8 @@ namespace Slang
         RefPtr<InfixExpr> expr = new InfixExpr();
         expr->loc = op->loc;
         expr->FunctionExpr = op;
-        expr->Arguments.Add(left);
-        expr->Arguments.Add(right);
+        expr->Arguments.add(left);
+        expr->Arguments.add(right);
         return expr;
     }
 
@@ -3696,11 +3696,11 @@ namespace Slang
                 select->loc = op->loc;
                 select->FunctionExpr = op;
 
-                select->Arguments.Add(expr);
+                select->Arguments.add(expr);
 
-                select->Arguments.Add(parser->ParseExpression(opPrec));
+                select->Arguments.add(parser->ParseExpression(opPrec));
                 parser->ReadToken(TokenType::Colon);
-                select->Arguments.Add(parser->ParseExpression(opPrec));
+                select->Arguments.add(parser->ParseExpression(opPrec));
 
                 expr = select;
                 continue;
@@ -3855,7 +3855,7 @@ namespace Slang
         //
         // Proper disambiguation requires mixing up parsing
         // and semantic checking (which we should do eventually)
-        // but for now we will follow some hueristics.
+        // but for now we will follow some heuristics.
         case TokenType::LParent:
             {
                 Token openParen = parser->ReadToken(TokenType::LParent);
@@ -3868,7 +3868,7 @@ namespace Slang
                     parser->ReadToken(TokenType::RParent);
 
                     auto arg = parsePrefixExpr(parser);
-                    tcexpr->Arguments.Add(arg);
+                    tcexpr->Arguments.add(arg);
 
                     return tcexpr;
                 }
@@ -3903,7 +3903,7 @@ namespace Slang
                     auto expr = parser->ParseArgExpr();
                     if( expr )
                     {
-                        initExpr->args.Add(expr);
+                        initExpr->args.add(expr);
                     }
 
                     if(AdvanceIfMatch(parser, TokenType::RBrace))
@@ -4150,7 +4150,7 @@ namespace Slang
                     RefPtr<OperatorExpr> postfixExpr = new PostfixExpr();
                     parser->FillPosition(postfixExpr.Ptr());
                     postfixExpr->FunctionExpr = parseOperator(parser);
-                    postfixExpr->Arguments.Add(expr);
+                    postfixExpr->Arguments.add(expr);
 
                     expr = postfixExpr;
                 }
@@ -4184,7 +4184,7 @@ namespace Slang
                     while (!parser->tokenReader.IsAtEnd())
                     {
                         if (!parser->LookAheadToken(TokenType::RParent))
-                            invokeExpr->Arguments.Add(parser->ParseArgExpr());
+                            invokeExpr->Arguments.add(parser->ParseArgExpr());
                         else
                         {
                             break;
@@ -4259,7 +4259,7 @@ namespace Slang
                 RefPtr<PrefixExpr> prefixExpr = new PrefixExpr();
                 parser->FillPosition(prefixExpr.Ptr());
                 prefixExpr->FunctionExpr = parseOperator(parser);
-                prefixExpr->Arguments.Add(parsePrefixExpr(parser));
+                prefixExpr->Arguments.add(parsePrefixExpr(parser));
                 return prefixExpr;
             }
             break;
@@ -4566,7 +4566,7 @@ namespace Slang
         while( AdvanceIf(parser, TokenType::Comma) )
         {
             auto operand = uint32_t(StringToInt(parser->ReadToken(TokenType::IntegerLiteral).Content));
-            modifier->irOperands.Add(operand);
+            modifier->irOperands.add(operand);
         }
         parser->ReadToken(TokenType::RParent);
 

--- a/source/slang/parser.cpp
+++ b/source/slang/parser.cpp
@@ -2943,7 +2943,7 @@ namespace Slang
         }
         else if( auto declGroup = as<DeclGroup>(declBase) )
         {
-            if( declGroup->decls.getSize() == 1 )
+            if( declGroup->decls.getCount() == 1 )
             {
                 return declGroup->decls[0];
             }

--- a/source/slang/preprocessor.cpp
+++ b/source/slang/preprocessor.cpp
@@ -564,7 +564,7 @@ static void AddEndOfStreamToken(
 {
     Token token = PeekRawToken(preprocessor);
     token.type = TokenType::EndOfFile;
-    macro->tokens.mTokens.Add(token);
+    macro->tokens.mTokens.add(token);
 }
 
 static SimpleTokenInputStream* createSimpleInputStream(
@@ -574,13 +574,13 @@ static SimpleTokenInputStream* createSimpleInputStream(
     SimpleTokenInputStream* inputStream = new SimpleTokenInputStream();
     initializeInputStream(preprocessor, inputStream);
 
-    inputStream->lexedTokens.mTokens.Add(token);
+    inputStream->lexedTokens.mTokens.add(token);
 
     Token eofToken;
     eofToken.type = TokenType::EndOfFile;
     eofToken.loc = token.loc;
     eofToken.flags = TokenFlag::AfterWhitespace | TokenFlag::AtStartOfLine;
-    inputStream->lexedTokens.mTokens.Add(eofToken);
+    inputStream->lexedTokens.mTokens.add(eofToken);
 
     inputStream->tokenReader = TokenReader(inputStream->lexedTokens);
 
@@ -740,7 +740,7 @@ static void MaybeBeginMacroExpansion(
                         }
 
                         // Add the token and continue parsing.
-                        arg->tokens.mTokens.Add(AdvanceRawToken(preprocessor));
+                        arg->tokens.mTokens.add(AdvanceRawToken(preprocessor));
                     }
                 doneWithArgument: {}
                     // We've parsed an argument and should move onto
@@ -1732,7 +1732,7 @@ static void HandleDefineDirective(PreprocessorDirectiveContext* context)
                     // are not allowed to be used as macros or parameters).
 
                     // Add the parameter to the macro being deifned
-                    macro->params.Add(paramToken);
+                    macro->params.add(paramToken);
 
                     // If we see `)` then we are done with arguments
                     if (PeekRawTokenType(context) == TokenType::RParent)
@@ -1755,12 +1755,12 @@ static void HandleDefineDirective(PreprocessorDirectiveContext* context)
             // Last token on line will be turned into a conceptual end-of-file
             // token for the sub-stream that the macro expands into.
             token.type = TokenType::EndOfFile;
-            macro->tokens.mTokens.Add(token);
+            macro->tokens.mTokens.add(token);
             break;
         }
 
         // In the ordinary case, we just add the token to the definition
-        macro->tokens.mTokens.Add(token);
+        macro->tokens.mTokens.add(token);
     }
 }
 
@@ -2236,7 +2236,7 @@ static TokenList ReadAllTokens(
     {
         Token token = ReadToken(preprocessor);
 
-        tokens.mTokens.Add(token);
+        tokens.mTokens.add(token);
 
         // Note: we include the EOF token in the list,
         // since that is expected by the `TokenList` type.

--- a/source/slang/preprocessor.cpp
+++ b/source/slang/preprocessor.cpp
@@ -659,7 +659,7 @@ static void MaybeBeginMacroExpansion(
             expansion->environment = &expansion->argumentEnvironment;
 
             // Try to read any arguments present.
-            UInt paramCount = macro->params.getSize();
+            UInt paramCount = macro->params.getCount();
             UInt argIndex = 0;
 
             switch (PeekRawTokenType(preprocessor))

--- a/source/slang/preprocessor.cpp
+++ b/source/slang/preprocessor.cpp
@@ -1586,7 +1586,7 @@ static SlangResult readFile(
     //
     auto linkage = context->preprocessor->linkage;
     auto fileSystemExt = linkage->getFileSystemExt();
-    SLANG_RETURN_ON_FAIL(fileSystemExt->loadFile(path.Buffer(), outBlob));
+    SLANG_RETURN_ON_FAIL(fileSystemExt->loadFile(path.getBuffer(), outBlob));
 
     // If we are running the preprocessor as part of compiling a
     // specific module, then we must keep track of the file we've
@@ -1939,7 +1939,7 @@ static const PragmaDirective kUnknownPragmaDirective = {
 // Look up the `#pragma` directive with the given name.
 static PragmaDirective const* findPragmaDirective(String const& name)
 {
-    char const* nameStr = name.Buffer();
+    char const* nameStr = name.getBuffer();
     for (int ii = 0; kPragmaDirectives[ii].name; ++ii)
     {
         if (strcmp(kPragmaDirectives[ii].name, nameStr) != 0)
@@ -2037,7 +2037,7 @@ static const PreprocessorDirective kInvalidDirective = {
 // Look up the directive with the given name.
 static PreprocessorDirective const* FindDirective(String const& name)
 {
-    char const* nameStr = name.Buffer();
+    char const* nameStr = name.getBuffer();
     for (int ii = 0; kDirectives[ii].name; ++ii)
     {
         if (strcmp(kDirectives[ii].name, nameStr) != 0)

--- a/source/slang/preprocessor.cpp
+++ b/source/slang/preprocessor.cpp
@@ -659,7 +659,7 @@ static void MaybeBeginMacroExpansion(
             expansion->environment = &expansion->argumentEnvironment;
 
             // Try to read any arguments present.
-            UInt paramCount = macro->params.Count();
+            UInt paramCount = macro->params.getSize();
             UInt argIndex = 0;
 
             switch (PeekRawTokenType(preprocessor))

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -143,7 +143,7 @@ SLANG_API unsigned int spReflectionUserAttribute_GetArgumentCount(SlangReflectio
 {
     auto userAttr = convert(attrib);
     if (!userAttr) return 0;
-    return (unsigned int)userAttr->args.getSize();
+    return (unsigned int)userAttr->args.getCount();
 }
 SlangReflectionType* spReflectionUserAttribute_GetArgumentType(SlangReflectionUserAttribute* attrib, unsigned int index)
 {
@@ -155,7 +155,7 @@ SLANG_API SlangResult spReflectionUserAttribute_GetArgumentValueInt(SlangReflect
 {
     auto userAttr = convert(attrib);
     if (!userAttr) return SLANG_ERROR_INVALID_PARAMETER;
-    if (index >= userAttr->args.getSize()) return SLANG_ERROR_INVALID_PARAMETER;
+    if (index >= userAttr->args.getCount()) return SLANG_ERROR_INVALID_PARAMETER;
     RefPtr<RefObject> val;
     if (userAttr->intArgVals.TryGetValue(index, val))
     {
@@ -168,7 +168,7 @@ SLANG_API SlangResult spReflectionUserAttribute_GetArgumentValueFloat(SlangRefle
 {
     auto userAttr = convert(attrib);
     if (!userAttr) return SLANG_ERROR_INVALID_PARAMETER;
-    if (index >= userAttr->args.getSize()) return SLANG_ERROR_INVALID_PARAMETER;
+    if (index >= userAttr->args.getCount()) return SLANG_ERROR_INVALID_PARAMETER;
     if (auto cexpr = as<FloatingPointLiteralExpr>(userAttr->args[index]))
     {
         *rs = (float)cexpr->value;
@@ -180,7 +180,7 @@ SLANG_API const char* spReflectionUserAttribute_GetArgumentValueString(SlangRefl
 {
     auto userAttr = convert(attrib);
     if (!userAttr) return nullptr;
-    if (index >= userAttr->args.getSize()) return nullptr;
+    if (index >= userAttr->args.getCount()) return nullptr;
     if (auto cexpr = as<StringLiteralExpr>(userAttr->args[index]))
     {
         if (bufLen)
@@ -772,7 +772,7 @@ static SlangParameterCategory getParameterCategory(
 static SlangParameterCategory getParameterCategory(
     TypeLayout*  typeLayout)
 {
-    auto resourceInfoCount = typeLayout->resourceInfos.getSize();
+    auto resourceInfoCount = typeLayout->resourceInfos.getCount();
     if(resourceInfoCount == 1)
     {
         return getParameterCategory(typeLayout->resourceInfos[0].kind);
@@ -790,7 +790,7 @@ static TypeLayout* maybeGetContainerLayout(TypeLayout* typeLayout)
     if (auto parameterGroupTypeLayout = as<ParameterGroupTypeLayout>(typeLayout))
     {
         auto containerTypeLayout = parameterGroupTypeLayout->containerVarLayout->typeLayout;
-        if (containerTypeLayout->resourceInfos.getSize() != 0)
+        if (containerTypeLayout->resourceInfos.getCount() != 0)
         {
             return containerTypeLayout;
         }
@@ -816,7 +816,7 @@ SLANG_API unsigned spReflectionTypeLayout_GetCategoryCount(SlangReflectionTypeLa
 
     typeLayout = maybeGetContainerLayout(typeLayout);
 
-    return (unsigned) typeLayout->resourceInfos.getSize();
+    return (unsigned) typeLayout->resourceInfos.getCount();
 }
 
 SLANG_API SlangParameterCategory spReflectionTypeLayout_GetCategoryByIndex(SlangReflectionTypeLayout* inTypeLayout, unsigned index)
@@ -1124,7 +1124,7 @@ namespace Slang
 
         if(auto structLayout = as<StructTypeLayout>(typeLayout))
         {
-            return (unsigned) structLayout->fields.getSize();
+            return (unsigned) structLayout->fields.getCount();
         }
 
         return 0;
@@ -1293,7 +1293,7 @@ SLANG_API unsigned spReflection_GetParameterCount(SlangReflection* inProgram)
     if (!globalStructLayout)
         return 0;
 
-    return (unsigned) globalStructLayout->fields.getSize();
+    return (unsigned) globalStructLayout->fields.getCount();
 }
 
 SLANG_API SlangReflectionParameter* spReflection_GetParameterByIndex(SlangReflection* inProgram, unsigned index)
@@ -1311,7 +1311,7 @@ SLANG_API SlangReflectionParameter* spReflection_GetParameterByIndex(SlangReflec
 SLANG_API unsigned int spReflection_GetTypeParameterCount(SlangReflection * reflection)
 {
     auto program = convert(reflection);
-    return (unsigned int)program->globalGenericParams.getSize();
+    return (unsigned int)program->globalGenericParams.getCount();
 }
 
 SLANG_API SlangReflectionTypeParameter* spReflection_GetTypeParameterByIndex(SlangReflection * reflection, unsigned int index)
@@ -1334,7 +1334,7 @@ SLANG_API SlangUInt spReflection_getEntryPointCount(SlangReflection* inProgram)
     auto program = convert(inProgram);
     if(!program) return 0;
 
-    return SlangUInt(program->entryPoints.getSize());
+    return SlangUInt(program->entryPoints.getCount());
 }
 
 SLANG_API SlangReflectionEntryPoint* spReflection_getEntryPointByIndex(SlangReflection* inProgram, SlangUInt index)

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -137,7 +137,7 @@ SLANG_API char const* spReflectionUserAttribute_GetName(SlangReflectionUserAttri
 {
     auto userAttr = convert(attrib);
     if (!userAttr) return nullptr;
-    return userAttr->getName()->text.Buffer();
+    return userAttr->getName()->text.getBuffer();
 }
 SLANG_API unsigned int spReflectionUserAttribute_GetArgumentCount(SlangReflectionUserAttribute* attrib)
 {
@@ -871,9 +871,9 @@ SLANG_API char const* spReflectionVariable_GetName(SlangReflectionVariable* inVa
     // If the variable is one that has an "external" name that is supposed
     // to be exposed for reflection, then report it here
     if(auto reflectionNameMod = var->FindModifier<ParameterGroupReflectionName>())
-        return getText(reflectionNameMod->nameAndLoc.name).Buffer();
+        return getText(reflectionNameMod->nameAndLoc.name).getBuffer();
 
-    return getText(var->getName()).Buffer();
+    return getText(var->getName()).getBuffer();
 }
 
 SLANG_API SlangReflectionType* spReflectionVariable_GetType(SlangReflectionVariable* inVar)
@@ -1046,7 +1046,7 @@ SLANG_API char const* spReflectionVariableLayout_GetSemanticName(SlangReflection
     if (!(varLayout->flags & Slang::VarLayoutFlag::HasSemantic))
         return 0;
 
-    return varLayout->semanticName.Buffer();
+    return varLayout->semanticName.getBuffer();
 }
 
 SLANG_API size_t spReflectionVariableLayout_GetSemanticIndex(SlangReflectionVariableLayout* inVarLayout)
@@ -1259,7 +1259,7 @@ SLANG_API int spReflectionEntryPoint_usesAnySampleRateInput(
 SLANG_API char const* spReflectionTypeParameter_GetName(SlangReflectionTypeParameter * inTypeParam)
 {
     auto typeParam = convert(inTypeParam);
-    return typeParam->decl->getName()->text.Buffer();
+    return typeParam->decl->getName()->text.getBuffer();
 }
 
 SLANG_API unsigned spReflectionTypeParameter_GetIndex(SlangReflectionTypeParameter * inTypeParam)

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -1272,14 +1272,14 @@ SLANG_API unsigned int spReflectionTypeParameter_GetConstraintCount(SlangReflect
 {
     auto typeParam = convert(inTypeParam);
     auto constraints = typeParam->decl->getMembersOfType<GenericTypeConstraintDecl>();
-    return (unsigned int)constraints.Count();
+    return (unsigned int)constraints.getCount();
 }
 
 SLANG_API SlangReflectionType* spReflectionTypeParameter_GetConstraintByIndex(SlangReflectionTypeParameter * inTypeParam, unsigned index)
 {
     auto typeParam = convert(inTypeParam);
     auto constraints = typeParam->decl->getMembersOfType<GenericTypeConstraintDecl>();
-    return (SlangReflectionType*)constraints.ToArray()[index]->sup.Ptr();
+    return (SlangReflectionType*)constraints.toArray()[index]->sup.Ptr();
 }
 
 // Shader Reflection

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -155,7 +155,7 @@ SLANG_API SlangResult spReflectionUserAttribute_GetArgumentValueInt(SlangReflect
 {
     auto userAttr = convert(attrib);
     if (!userAttr) return SLANG_ERROR_INVALID_PARAMETER;
-    if (index >= userAttr->args.getCount()) return SLANG_ERROR_INVALID_PARAMETER;
+    if (index >= (unsigned int)userAttr->args.getCount()) return SLANG_ERROR_INVALID_PARAMETER;
     RefPtr<RefObject> val;
     if (userAttr->intArgVals.TryGetValue(index, val))
     {
@@ -168,7 +168,7 @@ SLANG_API SlangResult spReflectionUserAttribute_GetArgumentValueFloat(SlangRefle
 {
     auto userAttr = convert(attrib);
     if (!userAttr) return SLANG_ERROR_INVALID_PARAMETER;
-    if (index >= userAttr->args.getCount()) return SLANG_ERROR_INVALID_PARAMETER;
+    if (index >= (unsigned int)userAttr->args.getCount()) return SLANG_ERROR_INVALID_PARAMETER;
     if (auto cexpr = as<FloatingPointLiteralExpr>(userAttr->args[index]))
     {
         *rs = (float)cexpr->value;
@@ -180,7 +180,7 @@ SLANG_API const char* spReflectionUserAttribute_GetArgumentValueString(SlangRefl
 {
     auto userAttr = convert(attrib);
     if (!userAttr) return nullptr;
-    if (index >= userAttr->args.getCount()) return nullptr;
+    if (index >= (unsigned int)userAttr->args.getCount()) return nullptr;
     if (auto cexpr = as<StringLiteralExpr>(userAttr->args[index]))
     {
         if (bufLen)

--- a/source/slang/reflection.cpp
+++ b/source/slang/reflection.cpp
@@ -143,7 +143,7 @@ SLANG_API unsigned int spReflectionUserAttribute_GetArgumentCount(SlangReflectio
 {
     auto userAttr = convert(attrib);
     if (!userAttr) return 0;
-    return (unsigned int)userAttr->args.Count();
+    return (unsigned int)userAttr->args.getSize();
 }
 SlangReflectionType* spReflectionUserAttribute_GetArgumentType(SlangReflectionUserAttribute* attrib, unsigned int index)
 {
@@ -155,7 +155,7 @@ SLANG_API SlangResult spReflectionUserAttribute_GetArgumentValueInt(SlangReflect
 {
     auto userAttr = convert(attrib);
     if (!userAttr) return SLANG_ERROR_INVALID_PARAMETER;
-    if (index >= userAttr->args.Count()) return SLANG_ERROR_INVALID_PARAMETER;
+    if (index >= userAttr->args.getSize()) return SLANG_ERROR_INVALID_PARAMETER;
     RefPtr<RefObject> val;
     if (userAttr->intArgVals.TryGetValue(index, val))
     {
@@ -168,7 +168,7 @@ SLANG_API SlangResult spReflectionUserAttribute_GetArgumentValueFloat(SlangRefle
 {
     auto userAttr = convert(attrib);
     if (!userAttr) return SLANG_ERROR_INVALID_PARAMETER;
-    if (index >= userAttr->args.Count()) return SLANG_ERROR_INVALID_PARAMETER;
+    if (index >= userAttr->args.getSize()) return SLANG_ERROR_INVALID_PARAMETER;
     if (auto cexpr = as<FloatingPointLiteralExpr>(userAttr->args[index]))
     {
         *rs = (float)cexpr->value;
@@ -180,7 +180,7 @@ SLANG_API const char* spReflectionUserAttribute_GetArgumentValueString(SlangRefl
 {
     auto userAttr = convert(attrib);
     if (!userAttr) return nullptr;
-    if (index >= userAttr->args.Count()) return nullptr;
+    if (index >= userAttr->args.getSize()) return nullptr;
     if (auto cexpr = as<StringLiteralExpr>(userAttr->args[index]))
     {
         if (bufLen)
@@ -772,7 +772,7 @@ static SlangParameterCategory getParameterCategory(
 static SlangParameterCategory getParameterCategory(
     TypeLayout*  typeLayout)
 {
-    auto resourceInfoCount = typeLayout->resourceInfos.Count();
+    auto resourceInfoCount = typeLayout->resourceInfos.getSize();
     if(resourceInfoCount == 1)
     {
         return getParameterCategory(typeLayout->resourceInfos[0].kind);
@@ -790,7 +790,7 @@ static TypeLayout* maybeGetContainerLayout(TypeLayout* typeLayout)
     if (auto parameterGroupTypeLayout = as<ParameterGroupTypeLayout>(typeLayout))
     {
         auto containerTypeLayout = parameterGroupTypeLayout->containerVarLayout->typeLayout;
-        if (containerTypeLayout->resourceInfos.Count() != 0)
+        if (containerTypeLayout->resourceInfos.getSize() != 0)
         {
             return containerTypeLayout;
         }
@@ -816,7 +816,7 @@ SLANG_API unsigned spReflectionTypeLayout_GetCategoryCount(SlangReflectionTypeLa
 
     typeLayout = maybeGetContainerLayout(typeLayout);
 
-    return (unsigned) typeLayout->resourceInfos.Count();
+    return (unsigned) typeLayout->resourceInfos.getSize();
 }
 
 SLANG_API SlangParameterCategory spReflectionTypeLayout_GetCategoryByIndex(SlangReflectionTypeLayout* inTypeLayout, unsigned index)
@@ -1124,7 +1124,7 @@ namespace Slang
 
         if(auto structLayout = as<StructTypeLayout>(typeLayout))
         {
-            return (unsigned) structLayout->fields.Count();
+            return (unsigned) structLayout->fields.getSize();
         }
 
         return 0;
@@ -1293,7 +1293,7 @@ SLANG_API unsigned spReflection_GetParameterCount(SlangReflection* inProgram)
     if (!globalStructLayout)
         return 0;
 
-    return (unsigned) globalStructLayout->fields.Count();
+    return (unsigned) globalStructLayout->fields.getSize();
 }
 
 SLANG_API SlangReflectionParameter* spReflection_GetParameterByIndex(SlangReflection* inProgram, unsigned index)
@@ -1311,7 +1311,7 @@ SLANG_API SlangReflectionParameter* spReflection_GetParameterByIndex(SlangReflec
 SLANG_API unsigned int spReflection_GetTypeParameterCount(SlangReflection * reflection)
 {
     auto program = convert(reflection);
-    return (unsigned int)program->globalGenericParams.Count();
+    return (unsigned int)program->globalGenericParams.getSize();
 }
 
 SLANG_API SlangReflectionTypeParameter* spReflection_GetTypeParameterByIndex(SlangReflection * reflection, unsigned int index)
@@ -1334,7 +1334,7 @@ SLANG_API SlangUInt spReflection_getEntryPointCount(SlangReflection* inProgram)
     auto program = convert(inProgram);
     if(!program) return 0;
 
-    return SlangUInt(program->entryPoints.Count());
+    return SlangUInt(program->entryPoints.getSize());
 }
 
 SLANG_API SlangReflectionEntryPoint* spReflection_getEntryPointByIndex(SlangReflection* inProgram, SlangUInt index)

--- a/source/slang/slang-file-system.cpp
+++ b/source/slang/slang-file-system.cpp
@@ -235,7 +235,7 @@ SlangResult CacheFileSystem::_calcUniqueIdentity(const String& path, String& out
         {
             // Try getting the uniqueIdentity by asking underlying file system
             ComPtr<ISlangBlob> uniqueIdentity;
-            SLANG_RETURN_ON_FAIL(m_fileSystemExt->getFileUniqueIdentity(path.Buffer(), uniqueIdentity.writeRef()));
+            SLANG_RETURN_ON_FAIL(m_fileSystemExt->getFileUniqueIdentity(path.getBuffer(), uniqueIdentity.writeRef()));
             // Get the path as a string
             outUniqueIdentity = StringUtil::getString(uniqueIdentity);
             return SLANG_OK;
@@ -255,7 +255,7 @@ SlangResult CacheFileSystem::_calcUniqueIdentity(const String& path, String& out
         case UniqueIdentityMode::Hash:
         {
             // I can only see if this is the same file as already loaded by loading the file and doing a hash
-            Result res = m_fileSystem->loadFile(path.Buffer(), outFileContents.writeRef());
+            Result res = m_fileSystem->loadFile(path.getBuffer(), outFileContents.writeRef());
             if (SLANG_FAILED(res) || outFileContents == nullptr)
             {
                 return SLANG_FAIL;
@@ -362,7 +362,7 @@ SlangResult CacheFileSystem::loadFile(char const* pathIn, ISlangBlob** blobOut)
     
     if (info->m_loadFileResult == CompressedResult::Uninitialized)
     {
-        info->m_loadFileResult = toCompressedResult(m_fileSystem->loadFile(path.Buffer(), info->m_fileBlob.writeRef()));
+        info->m_loadFileResult = toCompressedResult(m_fileSystem->loadFile(path.getBuffer(), info->m_fileBlob.writeRef()));
     }
 
     *blobOut = info->m_fileBlob;
@@ -419,7 +419,7 @@ SlangResult CacheFileSystem::getPathType(const char* pathIn, SlangPathType* path
             // Okay try to load the file
             if (info->m_loadFileResult == CompressedResult::Uninitialized)
             {
-                info->m_loadFileResult = toCompressedResult(m_fileSystem->loadFile(path.Buffer(), info->m_fileBlob.writeRef()));
+                info->m_loadFileResult = toCompressedResult(m_fileSystem->loadFile(path.getBuffer(), info->m_fileBlob.writeRef()));
             }
 
             // Make the getPathResult the same as the load result

--- a/source/slang/slang-file-system.cpp
+++ b/source/slang/slang-file-system.cpp
@@ -265,7 +265,7 @@ SlangResult CacheFileSystem::_calcUniqueIdentity(const String& path, String& out
             const uint64_t hash = GetHashCode64((const char*)outFileContents->getBufferPointer(), outFileContents->getBufferSize());
 
             String hashString = Path::getFileName(path);
-            hashString = hashString.ToLower();
+            hashString = hashString.toLower();
 
             hashString.append(':');
 
@@ -482,7 +482,7 @@ SlangResult CacheFileSystem::getCanonicalPath(const char* path, ISlangBlob** out
         {
             // Get the path as a string
             String canonicalPath = StringUtil::getString(canonicalPathBlob);
-            if (canonicalPath.Length() > 0)
+            if (canonicalPath.getLength() > 0)
             {
                 info->m_canonicalPath = new StringBlob(canonicalPath);
             }

--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -12,7 +12,7 @@ namespace Slang
 {
     String Session::getStdlibPath()
     {
-        if(stdlibPath.Length() != 0)
+        if(stdlibPath.getLength() != 0)
             return stdlibPath;
 
         StringBuilder pathBuilder;
@@ -244,7 +244,7 @@ namespace Slang
 
     String Session::getCoreLibraryCode()
     {
-        if (coreLibraryCode.Length() > 0)
+        if (coreLibraryCode.getLength() > 0)
             return coreLibraryCode;
 
         StringBuilder sb;
@@ -264,7 +264,7 @@ namespace Slang
 
     String Session::getHLSLLibraryCode()
     {
-        if (hlslLibraryCode.Length() > 0)
+        if (hlslLibraryCode.getLength() > 0)
             return hlslLibraryCode;
 
         StringBuilder sb;

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -839,7 +839,7 @@ SlangResult EndToEndCompileRequest::executeActionsInner()
     // TODO: This logic should be moved into `options.cpp` or somewhere else
     // specific to the command-line tool.
     //
-    if (getLinkage()->targets.getSize() == 0)
+    if (getLinkage()->targets.getCount() == 0)
     {
         auto language = inferSourceLanguage(getFrontEndReq());
         switch (language)
@@ -938,7 +938,7 @@ SlangResult EndToEndCompileRequest::executeActions()
 
 int FrontEndCompileRequest::addTranslationUnit(SourceLanguage language, Name* moduleName)
 {
-    UInt result = translationUnits.getSize();
+    UInt result = translationUnits.getCount();
 
     RefPtr<TranslationUnitRequest> translationUnit = new TranslationUnitRequest(this);
     translationUnit->compileRequest = this;
@@ -959,7 +959,7 @@ int FrontEndCompileRequest::addTranslationUnit(SourceLanguage language)
     // even when they are being compiled together.
     //
     String generatedName = "tu";
-    generatedName.append(translationUnits.getSize());
+    generatedName.append(translationUnits.getCount());
     return addTranslationUnit(language,  getNamePool()->getName(generatedName));
 }
 
@@ -1029,7 +1029,7 @@ int FrontEndCompileRequest::addEntryPoint(
 {
     auto translationUnitReq = translationUnits[translationUnitIndex];
 
-    UInt result = m_entryPointReqs.getSize();
+    UInt result = m_entryPointReqs.getCount();
 
     RefPtr<FrontEndEntryPointRequest> entryPointReq = new FrontEndEntryPointRequest(
         this,
@@ -1055,7 +1055,7 @@ int EndToEndCompileRequest::addEntryPoint(
     for (auto typeName : genericTypeNames)
         entryPointInfo.genericArgStrings.add(typeName);
 
-    UInt result = entryPoints.getSize();
+    UInt result = entryPoints.getCount();
     entryPoints.add(_Move(entryPointInfo));
     return (int) result;
 }
@@ -1067,7 +1067,7 @@ UInt Linkage::addTarget(
     targetReq->linkage = this;
     targetReq->target = target;
 
-    UInt result = targets.getSize();
+    UInt result = targets.getCount();
     targets.add(targetReq);
     return (int) result;
 }
@@ -1423,7 +1423,7 @@ TargetProgram::TargetProgram(
     : m_program(program)
     , m_targetReq(targetReq)
 {
-    m_entryPointResults.setSize(program->getEntryPoints().getSize());
+    m_entryPointResults.setCount(program->getEntryPoints().getCount());
 }
 
 //
@@ -1990,7 +1990,7 @@ SLANG_API void spAddTranslationUnitSourceFile(
     auto frontEndReq = req->getFrontEndReq();
     if(!path) return;
     if(translationUnitIndex < 0) return;
-    if(Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getSize()) return;
+    if(Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getCount()) return;
 
     frontEndReq->addTranslationUnitSourceFile(
         translationUnitIndex,
@@ -2024,7 +2024,7 @@ SLANG_API void spAddTranslationUnitSourceStringSpan(
     auto frontEndReq = req->getFrontEndReq();
     if(!sourceBegin) return;
     if(translationUnitIndex < 0) return;
-    if(Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getSize()) return;
+    if(Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getCount()) return;
 
     if(!path) path = "";
 
@@ -2045,7 +2045,7 @@ SLANG_API void spAddTranslationUnitSourceBlob(
     auto frontEndReq = req->getFrontEndReq();
     if(!sourceBlob) return;
     if(translationUnitIndex < 0) return;
-    if(Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getSize()) return;
+    if(Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getCount()) return;
 
     if(!path) path = "";
 
@@ -2095,7 +2095,7 @@ SLANG_API int spAddEntryPointEx(
     auto frontEndReq = req->getFrontEndReq();
     if (!name) return -1;
     if (translationUnitIndex < 0) return -1;
-    if (Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getSize()) return -1;
+    if (Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getCount()) return -1;
     Slang::List<Slang::String> typeNames;
     for (int i = 0; i < genericParamTypeNameCount; i++)
         typeNames.add(genericParamTypeNames[i]);
@@ -2133,8 +2133,8 @@ SLANG_API SlangResult spSetTypeNameForGlobalExistentialTypeParam(
 
     auto req = convert(request);
     auto& typeArgStrings = req->globalExistentialSlotArgStrings;
-    if(Slang::UInt(slotIndex) >= typeArgStrings.getSize())
-        typeArgStrings.setSize(slotIndex+1);
+    if(Slang::UInt(slotIndex) >= typeArgStrings.getCount())
+        typeArgStrings.setCount(slotIndex+1);
     typeArgStrings[slotIndex] = Slang::String(typeName);
     return SLANG_OK;
 }
@@ -2151,13 +2151,13 @@ SLANG_API SlangResult spSetTypeNameForEntryPointExistentialTypeParam(
     if(!typeName)           return SLANG_FAIL;
 
     auto req = convert(request);
-    if(Slang::UInt(entryPointIndex) >= req->entryPoints.getSize())
+    if(Slang::UInt(entryPointIndex) >= req->entryPoints.getCount())
         return SLANG_FAIL;
 
     auto& entryPointInfo = req->entryPoints[entryPointIndex];
     auto& typeArgStrings = entryPointInfo.existentialArgStrings;
-    if(Slang::UInt(slotIndex) >= typeArgStrings.getSize())
-        typeArgStrings.setSize(slotIndex+1);
+    if(Slang::UInt(slotIndex) >= typeArgStrings.getCount())
+        typeArgStrings.setCount(slotIndex+1);
     typeArgStrings[slotIndex] = Slang::String(typeName);
     return SLANG_OK;
 }
@@ -2224,7 +2224,7 @@ spGetDependencyFileCount(
     auto req = convert(request);
     auto frontEndReq = req->getFrontEndReq();
     auto program = frontEndReq->getProgram();
-    return (int) program->getFilePathDependencies().getSize();
+    return (int) program->getFilePathDependencies().getCount();
 }
 
 /** Get the path to a file this compilation dependend on.
@@ -2247,7 +2247,7 @@ spGetTranslationUnitCount(
 {
     auto req = convert(request);
     auto frontEndReq = req->getFrontEndReq();
-    return (int) frontEndReq->translationUnits.getSize();
+    return (int) frontEndReq->translationUnits.getCount();
 }
 
 // Get the output code associated with a specific translation unit
@@ -2270,14 +2270,14 @@ SLANG_API void const* spGetEntryPointCode(
 
     // TODO: We should really accept a target index in this API
     Slang::UInt targetIndex = 0;
-    auto targetCount = linkage->targets.getSize();
+    auto targetCount = linkage->targets.getCount();
     if (targetIndex >= targetCount)
         return nullptr;
     auto targetReq = linkage->targets[targetIndex];
 
 
     if(entryPointIndex < 0) return nullptr;
-    if(Slang::UInt(entryPointIndex) >= req->entryPoints.getSize()) return nullptr;
+    if(Slang::UInt(entryPointIndex) >= req->entryPoints.getCount()) return nullptr;
     auto entryPoint = program->getEntryPoint(entryPointIndex);
 
     auto targetProgram = program->getTargetProgram(targetReq);
@@ -2295,8 +2295,8 @@ SLANG_API void const* spGetEntryPointCode(
         break;
 
     case Slang::ResultFormat::Binary:
-        data = result.outputBinary.Buffer();
-        size = result.outputBinary.getSize();
+        data = result.outputBinary.getBuffer();
+        size = result.outputBinary.getCount();
         break;
 
     case Slang::ResultFormat::Text:
@@ -2322,14 +2322,14 @@ SLANG_API SlangResult spGetEntryPointCodeBlob(
     auto linkage = req->getLinkage();
     auto program = req->getSpecializedProgram();
 
-    int targetCount = (int) linkage->targets.getSize();
+    int targetCount = (int) linkage->targets.getCount();
     if((targetIndex < 0) || (targetIndex >= targetCount))
     {
         return SLANG_ERROR_INVALID_PARAMETER;
     }
     auto targetReq = linkage->targets[targetIndex];
 
-    int entryPointCount = (int) req->entryPoints.getSize();
+    int entryPointCount = (int) req->entryPoints.getCount();
     if((entryPointIndex < 0) || (entryPointIndex >= entryPointCount))
     {
         return SLANG_ERROR_INVALID_PARAMETER;
@@ -2382,7 +2382,7 @@ SLANG_API SlangReflection* spGetReflection(
     // `spGetReflection()` is shorthand for `targetIndex == 0`.
     //
     Slang::UInt targetIndex = 0;
-    auto targetCount = linkage->targets.getSize();
+    auto targetCount = linkage->targets.getCount();
     if (targetIndex >= targetCount)
         return nullptr;
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -1423,7 +1423,7 @@ TargetProgram::TargetProgram(
     : m_program(program)
     , m_targetReq(targetReq)
 {
-    m_entryPointResults.SetSize(program->getEntryPoints().getSize());
+    m_entryPointResults.setSize(program->getEntryPoints().getSize());
 }
 
 //
@@ -2134,7 +2134,7 @@ SLANG_API SlangResult spSetTypeNameForGlobalExistentialTypeParam(
     auto req = convert(request);
     auto& typeArgStrings = req->globalExistentialSlotArgStrings;
     if(Slang::UInt(slotIndex) >= typeArgStrings.getSize())
-        typeArgStrings.SetSize(slotIndex+1);
+        typeArgStrings.setSize(slotIndex+1);
     typeArgStrings[slotIndex] = Slang::String(typeName);
     return SLANG_OK;
 }
@@ -2157,7 +2157,7 @@ SLANG_API SlangResult spSetTypeNameForEntryPointExistentialTypeParam(
     auto& entryPointInfo = req->entryPoints[entryPointIndex];
     auto& typeArgStrings = entryPointInfo.existentialArgStrings;
     if(Slang::UInt(slotIndex) >= typeArgStrings.getSize())
-        typeArgStrings.SetSize(slotIndex+1);
+        typeArgStrings.setSize(slotIndex+1);
     typeArgStrings[slotIndex] = Slang::String(typeName);
     return SLANG_OK;
 }

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -938,7 +938,7 @@ SlangResult EndToEndCompileRequest::executeActions()
 
 int FrontEndCompileRequest::addTranslationUnit(SourceLanguage language, Name* moduleName)
 {
-    UInt result = translationUnits.getCount();
+    Index result = translationUnits.getCount();
 
     RefPtr<TranslationUnitRequest> translationUnit = new TranslationUnitRequest(this);
     translationUnit->compileRequest = this;
@@ -1029,7 +1029,7 @@ int FrontEndCompileRequest::addEntryPoint(
 {
     auto translationUnitReq = translationUnits[translationUnitIndex];
 
-    UInt result = m_entryPointReqs.getCount();
+    Index result = m_entryPointReqs.getCount();
 
     RefPtr<FrontEndEntryPointRequest> entryPointReq = new FrontEndEntryPointRequest(
         this,
@@ -1055,7 +1055,7 @@ int EndToEndCompileRequest::addEntryPoint(
     for (auto typeName : genericTypeNames)
         entryPointInfo.genericArgStrings.add(typeName);
 
-    UInt result = entryPoints.getCount();
+    Index result = entryPoints.getCount();
     entryPoints.add(_Move(entryPointInfo));
     return (int) result;
 }
@@ -1067,7 +1067,7 @@ UInt Linkage::addTarget(
     targetReq->linkage = this;
     targetReq->target = target;
 
-    UInt result = targets.getCount();
+    Index result = targets.getCount();
     targets.add(targetReq);
     return (int) result;
 }

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -1990,7 +1990,7 @@ SLANG_API void spAddTranslationUnitSourceFile(
     auto frontEndReq = req->getFrontEndReq();
     if(!path) return;
     if(translationUnitIndex < 0) return;
-    if(Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getCount()) return;
+    if(Slang::Index(translationUnitIndex) >= frontEndReq->translationUnits.getCount()) return;
 
     frontEndReq->addTranslationUnitSourceFile(
         translationUnitIndex,
@@ -2019,19 +2019,20 @@ SLANG_API void spAddTranslationUnitSourceStringSpan(
     char const*             sourceBegin,
     char const*             sourceEnd)
 {
+    using namespace Slang;
     if(!request) return;
     auto req = convert(request);
     auto frontEndReq = req->getFrontEndReq();
     if(!sourceBegin) return;
     if(translationUnitIndex < 0) return;
-    if(Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getCount()) return;
+    if(Index(translationUnitIndex) >= frontEndReq->translationUnits.getCount()) return;
 
     if(!path) path = "";
 
     frontEndReq->addTranslationUnitSourceString(
         translationUnitIndex,
         path,
-        Slang::UnownedStringSlice(sourceBegin, sourceEnd));
+        UnownedStringSlice(sourceBegin, sourceEnd));
 }
 
 SLANG_API void spAddTranslationUnitSourceBlob(
@@ -2045,7 +2046,7 @@ SLANG_API void spAddTranslationUnitSourceBlob(
     auto frontEndReq = req->getFrontEndReq();
     if(!sourceBlob) return;
     if(translationUnitIndex < 0) return;
-    if(Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getCount()) return;
+    if(Slang::Index(translationUnitIndex) >= frontEndReq->translationUnits.getCount()) return;
 
     if(!path) path = "";
 
@@ -2090,19 +2091,20 @@ SLANG_API int spAddEntryPointEx(
     int                     genericParamTypeNameCount,
     char const **           genericParamTypeNames)
 {
+    using namespace Slang;
     if (!request) return -1;
     auto req = convert(request);
     auto frontEndReq = req->getFrontEndReq();
     if (!name) return -1;
     if (translationUnitIndex < 0) return -1;
-    if (Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getCount()) return -1;
-    Slang::List<Slang::String> typeNames;
+    if (Index(translationUnitIndex) >= frontEndReq->translationUnits.getCount()) return -1;
+    List<String> typeNames;
     for (int i = 0; i < genericParamTypeNameCount; i++)
         typeNames.add(genericParamTypeNames[i]);
     return req->addEntryPoint(
         translationUnitIndex,
         name,
-        Slang::Profile(Slang::Stage(stage)),
+        Profile(Stage(stage)),
         typeNames);
 }
 
@@ -2127,15 +2129,16 @@ SLANG_API SlangResult spSetTypeNameForGlobalExistentialTypeParam(
     int                     slotIndex,
     char const*             typeName)
 {
+    using namespace Slang;
     if(!request)        return SLANG_FAIL;
     if(slotIndex < 0)   return SLANG_FAIL;
     if(!typeName)       return SLANG_FAIL;
 
     auto req = convert(request);
     auto& typeArgStrings = req->globalExistentialSlotArgStrings;
-    if(Slang::UInt(slotIndex) >= typeArgStrings.getCount())
+    if(Index(slotIndex) >= typeArgStrings.getCount())
         typeArgStrings.setCount(slotIndex+1);
-    typeArgStrings[slotIndex] = Slang::String(typeName);
+    typeArgStrings[slotIndex] = String(typeName);
     return SLANG_OK;
 }
 
@@ -2145,20 +2148,21 @@ SLANG_API SlangResult spSetTypeNameForEntryPointExistentialTypeParam(
     int                     slotIndex,
     char const*             typeName)
 {
+    using namespace Slang;
     if(!request)            return SLANG_FAIL;
     if(entryPointIndex < 0) return SLANG_FAIL;
     if(slotIndex < 0)       return SLANG_FAIL;
     if(!typeName)           return SLANG_FAIL;
 
     auto req = convert(request);
-    if(Slang::UInt(entryPointIndex) >= req->entryPoints.getCount())
+    if(Index(entryPointIndex) >= req->entryPoints.getCount())
         return SLANG_FAIL;
 
     auto& entryPointInfo = req->entryPoints[entryPointIndex];
     auto& typeArgStrings = entryPointInfo.existentialArgStrings;
-    if(Slang::UInt(slotIndex) >= typeArgStrings.getCount())
+    if(Index(slotIndex) >= typeArgStrings.getCount())
         typeArgStrings.setCount(slotIndex+1);
-    typeArgStrings[slotIndex] = Slang::String(typeName);
+    typeArgStrings[slotIndex] = String(typeName);
     return SLANG_OK;
 }
 
@@ -2264,12 +2268,13 @@ SLANG_API void const* spGetEntryPointCode(
     int                     entryPointIndex,
     size_t*                 outSize)
 {
+    using namespace Slang;
     auto req = convert(request);
     auto linkage = req->getLinkage();
     auto program = req->getSpecializedProgram();
 
     // TODO: We should really accept a target index in this API
-    Slang::UInt targetIndex = 0;
+    Index targetIndex = 0;
     auto targetCount = linkage->targets.getCount();
     if (targetIndex >= targetCount)
         return nullptr;
@@ -2277,29 +2282,29 @@ SLANG_API void const* spGetEntryPointCode(
 
 
     if(entryPointIndex < 0) return nullptr;
-    if(Slang::UInt(entryPointIndex) >= req->entryPoints.getCount()) return nullptr;
+    if(Index(entryPointIndex) >= req->entryPoints.getCount()) return nullptr;
     auto entryPoint = program->getEntryPoint(entryPointIndex);
 
     auto targetProgram = program->getTargetProgram(targetReq);
     if(!targetProgram)
         return nullptr;
-    Slang::CompileResult& result = targetProgram->getExistingEntryPointResult(entryPointIndex);
+    CompileResult& result = targetProgram->getExistingEntryPointResult(entryPointIndex);
 
     void const* data = nullptr;
     size_t size = 0;
 
     switch (result.format)
     {
-    case Slang::ResultFormat::None:
+    case ResultFormat::None:
     default:
         break;
 
-    case Slang::ResultFormat::Binary:
+    case ResultFormat::Binary:
         data = result.outputBinary.getBuffer();
         size = result.outputBinary.getCount();
         break;
 
-    case Slang::ResultFormat::Text:
+    case ResultFormat::Text:
         data = result.outputString.Buffer();
         size = result.outputString.Length();
         break;
@@ -2315,6 +2320,7 @@ SLANG_API SlangResult spGetEntryPointCodeBlob(
         int                     targetIndex,
         ISlangBlob**            outBlob)
 {
+    using namespace Slang;
     if(!request) return SLANG_ERROR_INVALID_PARAMETER;
     if(!outBlob) return SLANG_ERROR_INVALID_PARAMETER;
 
@@ -2322,14 +2328,14 @@ SLANG_API SlangResult spGetEntryPointCodeBlob(
     auto linkage = req->getLinkage();
     auto program = req->getSpecializedProgram();
 
-    int targetCount = (int) linkage->targets.getCount();
+    Index targetCount = linkage->targets.getCount();
     if((targetIndex < 0) || (targetIndex >= targetCount))
     {
         return SLANG_ERROR_INVALID_PARAMETER;
     }
     auto targetReq = linkage->targets[targetIndex];
 
-    int entryPointCount = (int) req->entryPoints.getCount();
+    Index entryPointCount = req->entryPoints.getCount();
     if((entryPointIndex < 0) || (entryPointIndex >= entryPointCount))
     {
         return SLANG_ERROR_INVALID_PARAMETER;
@@ -2381,7 +2387,7 @@ SLANG_API SlangReflection* spGetReflection(
     // so that we can do this better, and make it clear that
     // `spGetReflection()` is shorthand for `targetIndex == 0`.
     //
-    Slang::UInt targetIndex = 0;
+    Slang::Index targetIndex = 0;
     auto targetCount = linkage->targets.getCount();
     if (targetIndex >= targetCount)
         return nullptr;

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -108,7 +108,7 @@ struct IncludeHandlerImpl : IncludeHandler
         ComPtr<ISlangBlob> combinedPathBlob;
         SLANG_RETURN_ON_FAIL(fileSystemExt->calcCombinedPath(fromPathType, fromPath.begin(), path.begin(), combinedPathBlob.writeRef()));
         String combinedPath(StringUtil::getString(combinedPathBlob));
-        if (combinedPath.Length() <= 0)
+        if (combinedPath.getLength() <= 0)
         {
             return SLANG_FAIL;
         }
@@ -126,7 +126,7 @@ struct IncludeHandlerImpl : IncludeHandler
 
         // If the rel path exists -> a uniqueIdentity MUST exists too
         String uniqueIdentity(StringUtil::getString(uniqueIdentityBlob));
-        if (uniqueIdentity.Length() <= 0)
+        if (uniqueIdentity.getLength() <= 0)
         {   
             // Unique identity can't be empty
             return SLANG_FAIL;
@@ -1085,7 +1085,7 @@ void Linkage::loadParsedModule(
 
     // Get a path
     String mostUniqueIdentity = pathInfo.getMostUniqueIdentity();
-    SLANG_ASSERT(mostUniqueIdentity.Length() > 0);
+    SLANG_ASSERT(mostUniqueIdentity.getLength() > 0);
 
     mapPathToLoadedModule.Add(mostUniqueIdentity, loadedModule);
     mapNameToLoadedModules.Add(name, loadedModule);
@@ -2306,7 +2306,7 @@ SLANG_API void const* spGetEntryPointCode(
 
     case ResultFormat::Text:
         data = result.outputString.Buffer();
-        size = result.outputString.Length();
+        size = result.outputString.getLength();
         break;
     }
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -188,7 +188,7 @@ struct IncludeHandlerImpl : IncludeHandler
     {
         ISlangFileSystemExt* fileSystemExt = _getFileSystemExt();
         ComPtr<ISlangBlob> simplifiedPath;
-        if (SLANG_FAILED(fileSystemExt->getSimplifiedPath(path.Buffer(), simplifiedPath.writeRef())))
+        if (SLANG_FAILED(fileSystemExt->getSimplifiedPath(path.getBuffer(), simplifiedPath.writeRef())))
         {
             return path;
         }
@@ -472,7 +472,7 @@ void EndToEndCompileRequest::setWriter(WriterChannel chan, ISlangWriter* writer)
 
 SlangResult Linkage::loadFile(String const& path, ISlangBlob** outBlob)
 {
-    return fileSystemExt->loadFile(path.Buffer(), outBlob);
+    return fileSystemExt->loadFile(path.getBuffer(), outBlob);
 }
 
 RefPtr<Expr> Linkage::parseTypeString(String typeStr, RefPtr<Scope> scope)
@@ -1263,7 +1263,7 @@ RefPtr<Module> Linkage::findOrImportModule(
 
     // Try to load it
     ComPtr<ISlangBlob> fileContents;
-    if(SLANG_FAILED(getFileSystemExt()->loadFile(filePathInfo.foundPath.Buffer(), fileContents.writeRef())))
+    if(SLANG_FAILED(getFileSystemExt()->loadFile(filePathInfo.foundPath.getBuffer(), fileContents.writeRef())))
     {
         sink->diagnose(loc, Diagnostics::cannotOpenFile, fileName);
         mapNameToLoadedModules[name] = nullptr;
@@ -1516,7 +1516,7 @@ void Session::addBuiltinSource(
     SlangResult res = compileRequest->executeActionsInner();
     if (SLANG_FAILED(res))
     {
-        char const* diagnostics = sink.outputBuffer.Buffer();
+        char const* diagnostics = sink.outputBuffer.getBuffer();
         fprintf(stderr, "%s", diagnostics);
 
 #ifdef _WIN32
@@ -2305,7 +2305,7 @@ SLANG_API void const* spGetEntryPointCode(
         break;
 
     case ResultFormat::Text:
-        data = result.outputString.Buffer();
+        data = result.outputString.getBuffer();
         size = result.outputString.getLength();
         break;
     }

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -75,7 +75,7 @@ Session::Session()
     auto baseModuleDecl = populateBaseLanguageModule(
         this,
         baseLanguageScope);
-    loadedModuleCode.Add(baseModuleDecl);
+    loadedModuleCode.add(baseModuleDecl);
 
     coreLanguageScope = new Scope();
     coreLanguageScope->nextSibling = baseLanguageScope;
@@ -422,7 +422,7 @@ SourceManager* TranslationUnitRequest::getSourceManager()
 
 void TranslationUnitRequest::addSourceFile(SourceFile* sourceFile)
 {
-    m_sourceFiles.Add(sourceFile);
+    m_sourceFiles.add(sourceFile);
 
     // We want to record that the compiled module has a dependency
     // on the path of the source file, but we also need to account
@@ -549,7 +549,7 @@ Type* Program::getTypeFromString(String typeStr, DiagnosticSink* sink)
     //
     List<RefPtr<Scope>> scopesToTry;
     for(auto module : getModuleDependencies())
-        scopesToTry.Add(module->getModuleDecl()->scope);
+        scopesToTry.add(module->getModuleDecl()->scope);
 
     auto linkage = getLinkage();
     for(auto& s : scopesToTry)
@@ -946,7 +946,7 @@ int FrontEndCompileRequest::addTranslationUnit(SourceLanguage language, Name* mo
 
     translationUnit->moduleName = moduleName;
 
-    translationUnits.Add(translationUnit);
+    translationUnits.add(translationUnit);
 
     return (int) result;
 }
@@ -1037,7 +1037,7 @@ int FrontEndCompileRequest::addEntryPoint(
         getNamePool()->getName(name),
         entryPointProfile);
 
-    m_entryPointReqs.Add(entryPointReq);
+    m_entryPointReqs.add(entryPointReq);
 //    translationUnitReq->entryPoints.Add(entryPointReq);
 
     return int(result);
@@ -1053,10 +1053,10 @@ int EndToEndCompileRequest::addEntryPoint(
 
     EntryPointInfo entryPointInfo;
     for (auto typeName : genericTypeNames)
-        entryPointInfo.genericArgStrings.Add(typeName);
+        entryPointInfo.genericArgStrings.add(typeName);
 
     UInt result = entryPoints.getSize();
-    entryPoints.Add(_Move(entryPointInfo));
+    entryPoints.add(_Move(entryPointInfo));
     return (int) result;
 }
 
@@ -1068,7 +1068,7 @@ UInt Linkage::addTarget(
     targetReq->target = target;
 
     UInt result = targets.getSize();
-    targets.Add(targetReq);
+    targets.add(targetReq);
     return (int) result;
 }
 
@@ -1107,7 +1107,7 @@ void Linkage::loadParsedModule(
         SLANG_ASSERT(errorCountAfter == 0);
         loadedModule->setIRModule(generateIRForTranslationUnit(translationUnit));
     }
-    loadedModulesList.Add(loadedModule);
+    loadedModulesList.add(loadedModule);
 }
 
 Module* Linkage::loadModule(String const& name)
@@ -1314,7 +1314,7 @@ void ModuleDependencyList::_addDependency(Module* module)
     if(m_moduleSet.Contains(module))
         return;
 
-    m_moduleList.Add(module);
+    m_moduleList.add(module);
     m_moduleSet.Add(module);
 }
 
@@ -1327,7 +1327,7 @@ void FilePathDependencyList::addDependency(String const& path)
     if(m_filePathSet.Contains(path))
         return;
 
-    m_filePathList.Add(path);
+    m_filePathList.add(path);
     m_filePathSet.Add(path);
 }
 
@@ -1381,7 +1381,7 @@ void Program::addReferencedLeafModule(Module* module)
 
 void Program::addEntryPoint(EntryPoint* entryPoint)
 {
-    m_entryPoints.Add(entryPoint);
+    m_entryPoints.add(entryPoint);
 
     for(auto module : entryPoint->getModuleDependencies())
     {
@@ -1556,7 +1556,7 @@ void Session::addBuiltinSource(
 
     // We need to retain this AST so that we can use it in other code
     // (Note that the `Scope` type does not retain the AST it points to)
-    loadedModuleCode.Add(syntax);
+    loadedModuleCode.add(syntax);
 }
 
 Session::~Session()
@@ -1912,7 +1912,7 @@ SLANG_API void spAddSearchPath(
 {
     auto req = convert(request);
     auto linkage = req->getLinkage();
-    linkage->searchDirectories.searchDirectories.Add(Slang::SearchDirectory(path));
+    linkage->searchDirectories.searchDirectories.add(Slang::SearchDirectory(path));
 }
 
 SLANG_API void spAddPreprocessorDefine(
@@ -2098,7 +2098,7 @@ SLANG_API int spAddEntryPointEx(
     if (Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getSize()) return -1;
     Slang::List<Slang::String> typeNames;
     for (int i = 0; i < genericParamTypeNameCount; i++)
-        typeNames.Add(genericParamTypeNames[i]);
+        typeNames.add(genericParamTypeNames[i]);
     return req->addEntryPoint(
         translationUnitIndex,
         name,
@@ -2117,7 +2117,7 @@ SLANG_API SlangResult spSetGlobalGenericArgs(
     auto& genericArgStrings = req->globalGenericArgStrings;
     genericArgStrings.Clear();
     for (int i = 0; i < genericArgCount; i++)
-        genericArgStrings.Add(genericArgs[i]);
+        genericArgStrings.add(genericArgs[i]);
 
     return SLANG_OK;
 }

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -839,7 +839,7 @@ SlangResult EndToEndCompileRequest::executeActionsInner()
     // TODO: This logic should be moved into `options.cpp` or somewhere else
     // specific to the command-line tool.
     //
-    if (getLinkage()->targets.Count() == 0)
+    if (getLinkage()->targets.getSize() == 0)
     {
         auto language = inferSourceLanguage(getFrontEndReq());
         switch (language)
@@ -938,7 +938,7 @@ SlangResult EndToEndCompileRequest::executeActions()
 
 int FrontEndCompileRequest::addTranslationUnit(SourceLanguage language, Name* moduleName)
 {
-    UInt result = translationUnits.Count();
+    UInt result = translationUnits.getSize();
 
     RefPtr<TranslationUnitRequest> translationUnit = new TranslationUnitRequest(this);
     translationUnit->compileRequest = this;
@@ -959,7 +959,7 @@ int FrontEndCompileRequest::addTranslationUnit(SourceLanguage language)
     // even when they are being compiled together.
     //
     String generatedName = "tu";
-    generatedName.append(translationUnits.Count());
+    generatedName.append(translationUnits.getSize());
     return addTranslationUnit(language,  getNamePool()->getName(generatedName));
 }
 
@@ -1029,7 +1029,7 @@ int FrontEndCompileRequest::addEntryPoint(
 {
     auto translationUnitReq = translationUnits[translationUnitIndex];
 
-    UInt result = m_entryPointReqs.Count();
+    UInt result = m_entryPointReqs.getSize();
 
     RefPtr<FrontEndEntryPointRequest> entryPointReq = new FrontEndEntryPointRequest(
         this,
@@ -1055,7 +1055,7 @@ int EndToEndCompileRequest::addEntryPoint(
     for (auto typeName : genericTypeNames)
         entryPointInfo.genericArgStrings.Add(typeName);
 
-    UInt result = entryPoints.Count();
+    UInt result = entryPoints.getSize();
     entryPoints.Add(_Move(entryPointInfo));
     return (int) result;
 }
@@ -1067,7 +1067,7 @@ UInt Linkage::addTarget(
     targetReq->linkage = this;
     targetReq->target = target;
 
-    UInt result = targets.Count();
+    UInt result = targets.getSize();
     targets.Add(targetReq);
     return (int) result;
 }
@@ -1423,7 +1423,7 @@ TargetProgram::TargetProgram(
     : m_program(program)
     , m_targetReq(targetReq)
 {
-    m_entryPointResults.SetSize(program->getEntryPoints().Count());
+    m_entryPointResults.SetSize(program->getEntryPoints().getSize());
 }
 
 //
@@ -1990,7 +1990,7 @@ SLANG_API void spAddTranslationUnitSourceFile(
     auto frontEndReq = req->getFrontEndReq();
     if(!path) return;
     if(translationUnitIndex < 0) return;
-    if(Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.Count()) return;
+    if(Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getSize()) return;
 
     frontEndReq->addTranslationUnitSourceFile(
         translationUnitIndex,
@@ -2024,7 +2024,7 @@ SLANG_API void spAddTranslationUnitSourceStringSpan(
     auto frontEndReq = req->getFrontEndReq();
     if(!sourceBegin) return;
     if(translationUnitIndex < 0) return;
-    if(Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.Count()) return;
+    if(Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getSize()) return;
 
     if(!path) path = "";
 
@@ -2045,7 +2045,7 @@ SLANG_API void spAddTranslationUnitSourceBlob(
     auto frontEndReq = req->getFrontEndReq();
     if(!sourceBlob) return;
     if(translationUnitIndex < 0) return;
-    if(Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.Count()) return;
+    if(Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getSize()) return;
 
     if(!path) path = "";
 
@@ -2095,7 +2095,7 @@ SLANG_API int spAddEntryPointEx(
     auto frontEndReq = req->getFrontEndReq();
     if (!name) return -1;
     if (translationUnitIndex < 0) return -1;
-    if (Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.Count()) return -1;
+    if (Slang::UInt(translationUnitIndex) >= frontEndReq->translationUnits.getSize()) return -1;
     Slang::List<Slang::String> typeNames;
     for (int i = 0; i < genericParamTypeNameCount; i++)
         typeNames.Add(genericParamTypeNames[i]);
@@ -2133,7 +2133,7 @@ SLANG_API SlangResult spSetTypeNameForGlobalExistentialTypeParam(
 
     auto req = convert(request);
     auto& typeArgStrings = req->globalExistentialSlotArgStrings;
-    if(Slang::UInt(slotIndex) >= typeArgStrings.Count())
+    if(Slang::UInt(slotIndex) >= typeArgStrings.getSize())
         typeArgStrings.SetSize(slotIndex+1);
     typeArgStrings[slotIndex] = Slang::String(typeName);
     return SLANG_OK;
@@ -2151,12 +2151,12 @@ SLANG_API SlangResult spSetTypeNameForEntryPointExistentialTypeParam(
     if(!typeName)           return SLANG_FAIL;
 
     auto req = convert(request);
-    if(Slang::UInt(entryPointIndex) >= req->entryPoints.Count())
+    if(Slang::UInt(entryPointIndex) >= req->entryPoints.getSize())
         return SLANG_FAIL;
 
     auto& entryPointInfo = req->entryPoints[entryPointIndex];
     auto& typeArgStrings = entryPointInfo.existentialArgStrings;
-    if(Slang::UInt(slotIndex) >= typeArgStrings.Count())
+    if(Slang::UInt(slotIndex) >= typeArgStrings.getSize())
         typeArgStrings.SetSize(slotIndex+1);
     typeArgStrings[slotIndex] = Slang::String(typeName);
     return SLANG_OK;
@@ -2224,7 +2224,7 @@ spGetDependencyFileCount(
     auto req = convert(request);
     auto frontEndReq = req->getFrontEndReq();
     auto program = frontEndReq->getProgram();
-    return (int) program->getFilePathDependencies().Count();
+    return (int) program->getFilePathDependencies().getSize();
 }
 
 /** Get the path to a file this compilation dependend on.
@@ -2247,7 +2247,7 @@ spGetTranslationUnitCount(
 {
     auto req = convert(request);
     auto frontEndReq = req->getFrontEndReq();
-    return (int) frontEndReq->translationUnits.Count();
+    return (int) frontEndReq->translationUnits.getSize();
 }
 
 // Get the output code associated with a specific translation unit
@@ -2270,14 +2270,14 @@ SLANG_API void const* spGetEntryPointCode(
 
     // TODO: We should really accept a target index in this API
     Slang::UInt targetIndex = 0;
-    auto targetCount = linkage->targets.Count();
+    auto targetCount = linkage->targets.getSize();
     if (targetIndex >= targetCount)
         return nullptr;
     auto targetReq = linkage->targets[targetIndex];
 
 
     if(entryPointIndex < 0) return nullptr;
-    if(Slang::UInt(entryPointIndex) >= req->entryPoints.Count()) return nullptr;
+    if(Slang::UInt(entryPointIndex) >= req->entryPoints.getSize()) return nullptr;
     auto entryPoint = program->getEntryPoint(entryPointIndex);
 
     auto targetProgram = program->getTargetProgram(targetReq);
@@ -2296,7 +2296,7 @@ SLANG_API void const* spGetEntryPointCode(
 
     case Slang::ResultFormat::Binary:
         data = result.outputBinary.Buffer();
-        size = result.outputBinary.Count();
+        size = result.outputBinary.getSize();
         break;
 
     case Slang::ResultFormat::Text:
@@ -2322,14 +2322,14 @@ SLANG_API SlangResult spGetEntryPointCodeBlob(
     auto linkage = req->getLinkage();
     auto program = req->getSpecializedProgram();
 
-    int targetCount = (int) linkage->targets.Count();
+    int targetCount = (int) linkage->targets.getSize();
     if((targetIndex < 0) || (targetIndex >= targetCount))
     {
         return SLANG_ERROR_INVALID_PARAMETER;
     }
     auto targetReq = linkage->targets[targetIndex];
 
-    int entryPointCount = (int) req->entryPoints.Count();
+    int entryPointCount = (int) req->entryPoints.getSize();
     if((entryPointIndex < 0) || (entryPointIndex >= entryPointCount))
     {
         return SLANG_ERROR_INVALID_PARAMETER;
@@ -2382,7 +2382,7 @@ SLANG_API SlangReflection* spGetReflection(
     // `spGetReflection()` is shorthand for `targetIndex == 0`.
     //
     Slang::UInt targetIndex = 0;
-    auto targetCount = linkage->targets.Count();
+    auto targetCount = linkage->targets.getSize();
     if (targetIndex >= targetCount)
         return nullptr;
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -1770,7 +1770,7 @@ SLANG_API void spSetCodeGenTarget(
 {
     auto req = convert(request);
     auto linkage = req->getLinkage();
-    linkage->targets.Clear();
+    linkage->targets.clear();
     linkage->addTarget(Slang::CodeGenTarget(target));
 }
 
@@ -2115,7 +2115,7 @@ SLANG_API SlangResult spSetGlobalGenericArgs(
     auto req = convert(request);
 
     auto& genericArgStrings = req->globalGenericArgStrings;
-    genericArgStrings.Clear();
+    genericArgStrings.clear();
     for (int i = 0; i < genericArgCount; i++)
         genericArgStrings.add(genericArgs[i]);
 

--- a/source/slang/source-loc.cpp
+++ b/source/slang/source-loc.cpp
@@ -34,7 +34,7 @@ int SourceView::findEntryIndex(SourceLoc sourceLoc) const
 
     const auto rawValue = sourceLoc.getRaw();
 
-    int hi = int(m_entries.getSize());    
+    int hi = int(m_entries.getCount());    
     // If there are no entries, or it is in front of the first entry, then there is no associated entry
     if (hi == 0 || 
         m_entries[0].m_startLoc.getRaw() > sourceLoc.getRaw())
@@ -69,7 +69,7 @@ void SourceView::addLineDirective(SourceLoc directiveLoc, StringSlicePool::Handl
     SLANG_ASSERT(m_range.contains(directiveLoc));
 
     // Check that the directiveLoc values are always increasing
-    SLANG_ASSERT(m_entries.getSize() == 0 || (m_entries.getLast().m_startLoc.getRaw() < directiveLoc.getRaw()));
+    SLANG_ASSERT(m_entries.getCount() == 0 || (m_entries.getLast().m_startLoc.getRaw() < directiveLoc.getRaw()));
 
     // Calculate the offset
     const int offset = m_range.getOffset(directiveLoc);
@@ -101,10 +101,10 @@ void SourceView::addDefaultLineDirective(SourceLoc directiveLoc)
 {
     SLANG_ASSERT(m_range.contains(directiveLoc));
     // Check that the directiveLoc values are always increasing
-    SLANG_ASSERT(m_entries.getSize() == 0 || (m_entries.getLast().m_startLoc.getRaw() < directiveLoc.getRaw()));
+    SLANG_ASSERT(m_entries.getCount() == 0 || (m_entries.getLast().m_startLoc.getRaw() < directiveLoc.getRaw()));
 
     // Well if there are no entries, or the last one puts it in default case, then we don't need to add anything
-    if (m_entries.getSize() == 0 || (m_entries.getSize() && m_entries.getLast().isDefault()))
+    if (m_entries.getCount() == 0 || (m_entries.getCount() && m_entries.getLast().isDefault()))
     {
         return;
     }
@@ -209,7 +209,7 @@ const List<uint32_t>& SourceFile::getLineBreakOffsets()
     // We now have a raw input file that we can search for line breaks.
     // We obviously don't want to do a linear scan over and over, so we will
     // cache an array of line break locations in the file.
-    if (m_lineBreakOffsets.getSize() == 0)
+    if (m_lineBreakOffsets.getCount() == 0)
     {
         UnownedStringSlice content = getContent();
 
@@ -266,7 +266,7 @@ int SourceFile::calcLineIndexFromOffset(int offset)
     // We will use a binary search to find the line index that contains our
     // chosen offset.
     int lo = 0;
-    int hi = int(lineBreakOffsets.getSize());
+    int hi = int(lineBreakOffsets.getCount());
 
     while (lo + 1 < hi)
     {
@@ -458,7 +458,7 @@ SourceView* SourceManager::createSourceView(SourceFile* sourceFile, const PathIn
 
 SourceView* SourceManager::findSourceView(SourceLoc loc) const
 {
-    int hi = int(m_sourceViews.getSize());
+    int hi = int(m_sourceViews.getCount());
     // It must be in the range of this manager and have associated views for it to possibly be a hit
     if (!getSourceRange().contains(loc) || hi == 0)
     {

--- a/source/slang/source-loc.cpp
+++ b/source/slang/source-loc.cpp
@@ -34,7 +34,7 @@ int SourceView::findEntryIndex(SourceLoc sourceLoc) const
 
     const auto rawValue = sourceLoc.getRaw();
 
-    int hi = int(m_entries.Count());    
+    int hi = int(m_entries.getSize());    
     // If there are no entries, or it is in front of the first entry, then there is no associated entry
     if (hi == 0 || 
         m_entries[0].m_startLoc.getRaw() > sourceLoc.getRaw())
@@ -69,7 +69,7 @@ void SourceView::addLineDirective(SourceLoc directiveLoc, StringSlicePool::Handl
     SLANG_ASSERT(m_range.contains(directiveLoc));
 
     // Check that the directiveLoc values are always increasing
-    SLANG_ASSERT(m_entries.Count() == 0 || (m_entries.Last().m_startLoc.getRaw() < directiveLoc.getRaw()));
+    SLANG_ASSERT(m_entries.getSize() == 0 || (m_entries.Last().m_startLoc.getRaw() < directiveLoc.getRaw()));
 
     // Calculate the offset
     const int offset = m_range.getOffset(directiveLoc);
@@ -101,10 +101,10 @@ void SourceView::addDefaultLineDirective(SourceLoc directiveLoc)
 {
     SLANG_ASSERT(m_range.contains(directiveLoc));
     // Check that the directiveLoc values are always increasing
-    SLANG_ASSERT(m_entries.Count() == 0 || (m_entries.Last().m_startLoc.getRaw() < directiveLoc.getRaw()));
+    SLANG_ASSERT(m_entries.getSize() == 0 || (m_entries.Last().m_startLoc.getRaw() < directiveLoc.getRaw()));
 
     // Well if there are no entries, or the last one puts it in default case, then we don't need to add anything
-    if (m_entries.Count() == 0 || (m_entries.Count() && m_entries.Last().isDefault()))
+    if (m_entries.getSize() == 0 || (m_entries.getSize() && m_entries.Last().isDefault()))
     {
         return;
     }
@@ -209,7 +209,7 @@ const List<uint32_t>& SourceFile::getLineBreakOffsets()
     // We now have a raw input file that we can search for line breaks.
     // We obviously don't want to do a linear scan over and over, so we will
     // cache an array of line break locations in the file.
-    if (m_lineBreakOffsets.Count() == 0)
+    if (m_lineBreakOffsets.getSize() == 0)
     {
         UnownedStringSlice content = getContent();
 
@@ -266,7 +266,7 @@ int SourceFile::calcLineIndexFromOffset(int offset)
     // We will use a binary search to find the line index that contains our
     // chosen offset.
     int lo = 0;
-    int hi = int(lineBreakOffsets.Count());
+    int hi = int(lineBreakOffsets.getSize());
 
     while (lo + 1 < hi)
     {
@@ -458,7 +458,7 @@ SourceView* SourceManager::createSourceView(SourceFile* sourceFile, const PathIn
 
 SourceView* SourceManager::findSourceView(SourceLoc loc) const
 {
-    int hi = int(m_sourceViews.Count());
+    int hi = int(m_sourceViews.getSize());
     // It must be in the range of this manager and have associated views for it to possibly be a hit
     if (!getSourceRange().contains(loc) || hi == 0)
     {

--- a/source/slang/source-loc.cpp
+++ b/source/slang/source-loc.cpp
@@ -69,7 +69,7 @@ void SourceView::addLineDirective(SourceLoc directiveLoc, StringSlicePool::Handl
     SLANG_ASSERT(m_range.contains(directiveLoc));
 
     // Check that the directiveLoc values are always increasing
-    SLANG_ASSERT(m_entries.getSize() == 0 || (m_entries.Last().m_startLoc.getRaw() < directiveLoc.getRaw()));
+    SLANG_ASSERT(m_entries.getSize() == 0 || (m_entries.getLast().m_startLoc.getRaw() < directiveLoc.getRaw()));
 
     // Calculate the offset
     const int offset = m_range.getOffset(directiveLoc);
@@ -88,7 +88,7 @@ void SourceView::addLineDirective(SourceLoc directiveLoc, StringSlicePool::Handl
     // Taking both into account means +2 is correct 'fix'
     entry.m_lineAdjust = line - (lineIndex + 2);
 
-    m_entries.Add(entry);
+    m_entries.add(entry);
 }
 
 void SourceView::addLineDirective(SourceLoc directiveLoc, const String& path, int line)
@@ -101,10 +101,10 @@ void SourceView::addDefaultLineDirective(SourceLoc directiveLoc)
 {
     SLANG_ASSERT(m_range.contains(directiveLoc));
     // Check that the directiveLoc values are always increasing
-    SLANG_ASSERT(m_entries.getSize() == 0 || (m_entries.Last().m_startLoc.getRaw() < directiveLoc.getRaw()));
+    SLANG_ASSERT(m_entries.getSize() == 0 || (m_entries.getLast().m_startLoc.getRaw() < directiveLoc.getRaw()));
 
     // Well if there are no entries, or the last one puts it in default case, then we don't need to add anything
-    if (m_entries.getSize() == 0 || (m_entries.getSize() && m_entries.Last().isDefault()))
+    if (m_entries.getSize() == 0 || (m_entries.getSize() && m_entries.getLast().isDefault()))
     {
         return;
     }
@@ -116,7 +116,7 @@ void SourceView::addDefaultLineDirective(SourceLoc directiveLoc)
 
     SLANG_ASSERT(entry.isDefault());
 
-    m_entries.Add(entry);
+    m_entries.add(entry);
 }
 
 HumaneSourceLoc SourceView::getHumaneLoc(SourceLoc loc, SourceLocType type)
@@ -219,7 +219,7 @@ const List<uint32_t>& SourceFile::getLineBreakOffsets()
         char const* cursor = begin;
 
         // Treat the beginning of the file as a line break
-        m_lineBreakOffsets.Add(0);
+        m_lineBreakOffsets.add(0);
 
         while (cursor != end)
         {
@@ -238,7 +238,7 @@ const List<uint32_t>& SourceFile::getLineBreakOffsets()
                     if ((c^d) == ('\r' ^ '\n'))
                         cursor++;
 
-                    m_lineBreakOffsets.Add(uint32_t(cursor - begin));
+                    m_lineBreakOffsets.add(uint32_t(cursor - begin));
                     break;
                 }
                 default:
@@ -416,14 +416,14 @@ SourceRange SourceManager::allocateSourceRange(UInt size)
 SourceFile* SourceManager::createSourceFileWithSize(const PathInfo& pathInfo, size_t contentSize)
 {
     SourceFile* sourceFile = new SourceFile(this, pathInfo, contentSize);
-    m_sourceFiles.Add(sourceFile);
+    m_sourceFiles.add(sourceFile);
     return sourceFile;
 }
 
 SourceFile* SourceManager::createSourceFileWithString(const PathInfo& pathInfo, const String& contents)
 {
     SourceFile* sourceFile = new SourceFile(this, pathInfo, contents.Length());
-    m_sourceFiles.Add(sourceFile);
+    m_sourceFiles.add(sourceFile);
     sourceFile->setContents(contents);
     return sourceFile;
 }
@@ -431,7 +431,7 @@ SourceFile* SourceManager::createSourceFileWithString(const PathInfo& pathInfo, 
 SourceFile* SourceManager::createSourceFileWithBlob(const PathInfo& pathInfo, ISlangBlob* blob)
 {
     SourceFile* sourceFile = new SourceFile(this, pathInfo, blob->getBufferSize());
-    m_sourceFiles.Add(sourceFile);
+    m_sourceFiles.add(sourceFile);
     sourceFile->setContents(blob);
     return sourceFile;
 }
@@ -451,7 +451,7 @@ SourceView* SourceManager::createSourceView(SourceFile* sourceFile, const PathIn
         sourceView = new SourceView(sourceFile, range, nullptr);
     }
 
-    m_sourceViews.Add(sourceView);
+    m_sourceViews.add(sourceView);
 
     return sourceView;
 }

--- a/source/slang/source-loc.cpp
+++ b/source/slang/source-loc.cpp
@@ -34,7 +34,7 @@ int SourceView::findEntryIndex(SourceLoc sourceLoc) const
 
     const auto rawValue = sourceLoc.getRaw();
 
-    int hi = int(m_entries.getCount());    
+    Index hi = m_entries.getCount();    
     // If there are no entries, or it is in front of the first entry, then there is no associated entry
     if (hi == 0 || 
         m_entries[0].m_startLoc.getRaw() > sourceLoc.getRaw())
@@ -42,10 +42,10 @@ int SourceView::findEntryIndex(SourceLoc sourceLoc) const
         return -1;
     }
 
-    int lo = 0;
+    Index lo = 0;
     while (lo + 1 < hi)
     {
-        const int mid = (hi + lo) >> 1;
+        const Index mid = (hi + lo) >> 1;
         const Entry& midEntry = m_entries[mid];
         SourceLoc::RawValue midValue = midEntry.m_startLoc.getRaw();
         if (midValue <= rawValue)
@@ -60,7 +60,7 @@ int SourceView::findEntryIndex(SourceLoc sourceLoc) const
         }
     }
 
-    return lo;
+    return int(lo);
 }
 
 void SourceView::addLineDirective(SourceLoc directiveLoc, StringSlicePool::Handle pathHandle, int line)
@@ -265,12 +265,12 @@ int SourceFile::calcLineIndexFromOffset(int offset)
     // At this point we can assume the `lineBreakOffsets` array has been filled in.
     // We will use a binary search to find the line index that contains our
     // chosen offset.
-    int lo = 0;
-    int hi = int(lineBreakOffsets.getCount());
+    Index lo = 0;
+    Index hi = lineBreakOffsets.getCount();
 
     while (lo + 1 < hi)
     {
-        const int mid = (hi + lo) >> 1; 
+        const Index mid = (hi + lo) >> 1; 
         const uint32_t midOffset = lineBreakOffsets[mid];
         if (midOffset <= uint32_t(offset))
         {
@@ -282,7 +282,7 @@ int SourceFile::calcLineIndexFromOffset(int offset)
         }
     }
 
-    return lo;
+    return int(lo);
 }
 
 int SourceFile::calcColumnIndex(int lineIndex, int offset)
@@ -458,7 +458,7 @@ SourceView* SourceManager::createSourceView(SourceFile* sourceFile, const PathIn
 
 SourceView* SourceManager::findSourceView(SourceLoc loc) const
 {
-    int hi = int(m_sourceViews.getCount());
+    Index hi = m_sourceViews.getCount();
     // It must be in the range of this manager and have associated views for it to possibly be a hit
     if (!getSourceRange().contains(loc) || hi == 0)
     {
@@ -482,10 +482,10 @@ SourceView* SourceManager::findSourceView(SourceLoc loc) const
     const SourceLoc::RawValue rawLoc = loc.getRaw();
 
     // Binary chop to see if we can find the associated SourceUnit
-    int lo = 0;
+    Index lo = 0;
     while (lo + 1 < hi)
     {
-        int mid = (hi + lo) >> 1;
+        Index mid = (hi + lo) >> 1;
 
         SourceView* midView = m_sourceViews[mid];
         if (midView->getRange().contains(loc))

--- a/source/slang/source-loc.cpp
+++ b/source/slang/source-loc.cpp
@@ -331,7 +331,7 @@ String SourceFile::calcVerbosePath() const
     {
         String canonicalPath;
         ComPtr<ISlangBlob> canonicalPathBlob;
-        if (SLANG_SUCCEEDED(fileSystemExt->getCanonicalPath(m_pathInfo.foundPath.Buffer(), canonicalPathBlob.writeRef())))
+        if (SLANG_SUCCEEDED(fileSystemExt->getCanonicalPath(m_pathInfo.foundPath.getBuffer(), canonicalPathBlob.writeRef())))
         {
             canonicalPath = StringUtil::getString(canonicalPathBlob);
         }

--- a/source/slang/source-loc.cpp
+++ b/source/slang/source-loc.cpp
@@ -200,8 +200,8 @@ PathInfo SourceView::getPathInfo(SourceLoc loc, SourceLocType type)
 
 void SourceFile::setLineBreakOffsets(const uint32_t* offsets, UInt numOffsets)
 {
-    m_lineBreakOffsets.Clear();
-    m_lineBreakOffsets.AddRange(offsets, numOffsets);
+    m_lineBreakOffsets.clear();
+    m_lineBreakOffsets.addRange(offsets, numOffsets);
 }
 
 const List<uint32_t>& SourceFile::getLineBreakOffsets()

--- a/source/slang/source-loc.cpp
+++ b/source/slang/source-loc.cpp
@@ -160,7 +160,7 @@ HumaneSourceLoc SourceView::getHumaneLoc(SourceLoc loc, SourceLocType type)
 
 PathInfo SourceView::_getPathInfo() const
 {
-    if (m_viewPath.Length())
+    if (m_viewPath.getLength())
     {
         PathInfo pathInfo(m_sourceFile->getPathInfo());
         pathInfo.foundPath = m_viewPath;
@@ -335,7 +335,7 @@ String SourceFile::calcVerbosePath() const
         {
             canonicalPath = StringUtil::getString(canonicalPathBlob);
         }
-        if (canonicalPath.Length() > 0)
+        if (canonicalPath.getLength() > 0)
         {
             return canonicalPath;
         }
@@ -422,7 +422,7 @@ SourceFile* SourceManager::createSourceFileWithSize(const PathInfo& pathInfo, si
 
 SourceFile* SourceManager::createSourceFileWithString(const PathInfo& pathInfo, const String& contents)
 {
-    SourceFile* sourceFile = new SourceFile(this, pathInfo, contents.Length());
+    SourceFile* sourceFile = new SourceFile(this, pathInfo, contents.getLength());
     m_sourceFiles.add(sourceFile);
     sourceFile->setContents(contents);
     return sourceFile;
@@ -442,7 +442,7 @@ SourceView* SourceManager::createSourceView(SourceFile* sourceFile, const PathIn
 
     SourceView* sourceView = nullptr;
     if (pathInfo &&
-        (pathInfo->foundPath.Length() && sourceFile->getPathInfo().foundPath != pathInfo->foundPath))
+        (pathInfo->foundPath.getLength() && sourceFile->getPathInfo().foundPath != pathInfo->foundPath))
     {
         sourceView = new SourceView(sourceFile, range, &pathInfo->foundPath);
     }

--- a/source/slang/source-loc.h
+++ b/source/slang/source-loc.h
@@ -264,7 +264,7 @@ class SourceView
         /// Get the entries
     const List<Entry>& getEntries() const { return m_entries; }
         /// Set the entries list
-    void setEntries(const Entry* entries, UInt numEntries) { m_entries.Clear(); m_entries.AddRange(entries, numEntries); }
+    void setEntries(const Entry* entries, UInt numEntries) { m_entries.clear(); m_entries.addRange(entries, numEntries); }
 
         /// Get the source file holds the contents this view 
     SourceFile* getSourceFile() const { return m_sourceFile; }

--- a/source/slang/source-loc.h
+++ b/source/slang/source-loc.h
@@ -53,11 +53,11 @@ struct PathInfo
     };
 
         /// True if has a canonical path
-    SLANG_FORCE_INLINE bool hasUniqueIdentity() const { return type == Type::Normal && uniqueIdentity.Length() > 0; }
+    SLANG_FORCE_INLINE bool hasUniqueIdentity() const { return type == Type::Normal && uniqueIdentity.getLength() > 0; }
         /// True if has a regular found path
-    SLANG_FORCE_INLINE bool hasFoundPath() const { return type == Type::Normal || type == Type::FoundPath || (type == Type::FromString && foundPath.Length() > 0); }
+    SLANG_FORCE_INLINE bool hasFoundPath() const { return type == Type::Normal || type == Type::FoundPath || (type == Type::FromString && foundPath.getLength() > 0); }
         /// True if has a found path that has originated from a file (as opposed to string or some other origin)
-    SLANG_FORCE_INLINE bool hasFileFoundPath() const { return (type == Type::Normal || type == Type::FoundPath) && foundPath.Length() > 0; }
+    SLANG_FORCE_INLINE bool hasFileFoundPath() const { return (type == Type::Normal || type == Type::FoundPath) && foundPath.getLength() > 0; }
 
         /// Returns the 'most unique' identity for the path. If has a 'uniqueIdentity' returns that, else the foundPath, else "".
     const String getMostUniqueIdentity() const;
@@ -65,8 +65,8 @@ struct PathInfo
     // So simplify construction. In normal usage it's safer to use make methods over constructing directly.
     static PathInfo makeUnknown() { return PathInfo { Type::Unknown, "unknown", String() }; }
     static PathInfo makeTokenPaste() { return PathInfo{ Type::TokenPaste, "token paste", String()}; }
-    static PathInfo makeNormal(const String& foundPathIn, const String& uniqueIdentity) { SLANG_ASSERT(uniqueIdentity.Length() > 0 && foundPathIn.Length() > 0); return PathInfo { Type::Normal, foundPathIn, uniqueIdentity }; }
-    static PathInfo makePath(const String& pathIn) { SLANG_ASSERT(pathIn.Length() > 0); return PathInfo { Type::FoundPath, pathIn, String()}; }
+    static PathInfo makeNormal(const String& foundPathIn, const String& uniqueIdentity) { SLANG_ASSERT(uniqueIdentity.getLength() > 0 && foundPathIn.getLength() > 0); return PathInfo { Type::Normal, foundPathIn, uniqueIdentity }; }
+    static PathInfo makePath(const String& pathIn) { SLANG_ASSERT(pathIn.getLength() > 0); return PathInfo { Type::FoundPath, pathIn, String()}; }
     static PathInfo makeTypeParse() { return PathInfo { Type::TypeParse, "type string", String() }; }
     static PathInfo makeCommandLine() { return PathInfo { Type::CommandLine, "command line", String() }; }
     static PathInfo makeFromString(const String& userPath) { return PathInfo{ Type::FromString, userPath, String() }; }

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -2635,7 +2635,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
         RefPtr<TaggedUnionType> substType = new TaggedUnionType();
         substType->setSession(getSession());
-        substType->caseTypes.SwapWith(substCaseTypes);
+        substType->caseTypes.swapWith(substCaseTypes);
         return substType;
     }
 
@@ -2709,7 +2709,7 @@ RefPtr<Val> TaggedUnionSubtypeWitness::SubstituteImpl(SubstitutionSet subst, int
     RefPtr<TaggedUnionSubtypeWitness> substWitness = new TaggedUnionSubtypeWitness();
     substWitness->sub = substSub;
     substWitness->sup = substSup;
-    substWitness->caseWitnesses.SwapWith(substCaseWitnesses);
+    substWitness->caseWitnesses.swapWith(substCaseWitnesses);
     return substWitness;
 }
 

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -299,7 +299,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
         auto substitutions = new GenericSubstitution();
         substitutions->genericDecl = genericDecl;
-        substitutions->args.Add(valueType);
+        substitutions->args.add(valueType);
 
         auto declRef = DeclRef<Decl>(typeDecl.Ptr(), substitutions);
         auto rsType = DeclRefType::Create(
@@ -1074,7 +1074,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
         List<RefPtr<Type>> substParamTypes;
         for( auto pp : paramTypes )
         {
-            substParamTypes.Add(pp->SubstituteImpl(subst, &diff).as<Type>());
+            substParamTypes.add(pp->SubstituteImpl(subst, &diff).as<Type>());
         }
 
         // early exit for no change...
@@ -1098,7 +1098,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
         List<RefPtr<Type>> canParamTypes;
         for( auto pp : paramTypes )
         {
-            canParamTypes.Add(pp->GetCanonicalType());
+            canParamTypes.add(pp->GetCanonicalType());
         }
 
         RefPtr<FuncType> canType = new FuncType();
@@ -1256,8 +1256,8 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
         auto substitutions = new GenericSubstitution();
         substitutions->genericDecl = vectorGenericDecl.Ptr();
-        substitutions->args.Add(elementType);
-        substitutions->args.Add(elementCount);
+        substitutions->args.add(elementType);
+        substitutions->args.add(elementCount);
 
         auto declRef = DeclRef<Decl>(vectorTypeDecl.Ptr(), substitutions);
 
@@ -1348,7 +1348,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
         List<RefPtr<Val>> substArgs;
         for (auto a : args)
         {
-            substArgs.Add(a->SubstituteImpl(substSet, &diff));
+            substArgs.add(a->SubstituteImpl(substSet, &diff));
         }
 
         if (!diff) return this;
@@ -1447,7 +1447,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             substConstraintArg.decl = constraintArg.decl;
             substConstraintArg.val = constraintArg.val->SubstituteImpl(substSet, &diff);
 
-            substConstraintArgs.Add(substConstraintArg);
+            substConstraintArgs.add(substConstraintArg);
         }
 
         if(!diff)
@@ -2139,7 +2139,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
                     paramType = session->getOutType(paramType);
                 }
             }
-            funcType->paramTypes.Add(paramType);
+            funcType->paramTypes.add(paramType);
         }
 
         return funcType;
@@ -2613,7 +2613,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
         for( auto caseType : caseTypes )
         {
             auto canCaseType = caseType->GetCanonicalType();
-            canType->caseTypes.Add(canCaseType);
+            canType->caseTypes.add(canCaseType);
         }
 
         return canType;
@@ -2626,7 +2626,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
         List<RefPtr<Type>> substCaseTypes;
         for( auto caseType : caseTypes )
         {
-            substCaseTypes.Add(caseType->SubstituteImpl(subst, &diff).as<Type>());
+            substCaseTypes.add(caseType->SubstituteImpl(subst, &diff).as<Type>());
         }
         if(!diff)
             return this;
@@ -2698,7 +2698,7 @@ RefPtr<Val> TaggedUnionSubtypeWitness::SubstituteImpl(SubstitutionSet subst, int
     List<RefPtr<Val>> substCaseWitnesses;
     for( auto caseWitness : caseWitnesses )
     {
-        substCaseWitnesses.Add(caseWitness->SubstituteImpl(subst, &diff));
+        substCaseWitnesses.add(caseWitness->SubstituteImpl(subst, &diff));
     }
 
     if(!diff)

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -1375,9 +1375,9 @@ void Type::accept(IValVisitor* visitor, void* extra)
         if (genericDecl != genericSubst->genericDecl)
             return false;
 
-        UInt argCount = args.getCount();
+        Index argCount = args.getCount();
         SLANG_RELEASE_ASSERT(args.getCount() == genericSubst->args.getCount());
-        for (UInt aa = 0; aa < argCount; ++aa)
+        for (Index aa = 0; aa < argCount; ++aa)
         {
             if (!args[aa]->EqualsVal(genericSubst->args[aa].Ptr()))
                 return false;

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -2238,7 +2238,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
                         continue;
 
                     bool found = false;
-                    UInt index = 0;
+                    Index index = 0;
                     for (auto m : genericDecl->Members)
                     {
                         if (auto constraintParam = as<GenericTypeConstraintDecl>(m))

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -766,7 +766,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             }
             else if (magicMod->name == "Vector")
             {
-                SLANG_ASSERT(subst && subst->args.getSize() == 2);
+                SLANG_ASSERT(subst && subst->args.getCount() == 2);
                 auto vecType = new VectorExpressionType();
                 vecType->setSession(session);
                 vecType->declRef = declRef;
@@ -776,7 +776,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             }
             else if (magicMod->name == "Matrix")
             {
-                SLANG_ASSERT(subst && subst->args.getSize() == 3);
+                SLANG_ASSERT(subst && subst->args.getCount() == 3);
                 auto matType = new MatrixExpressionType();
                 matType->setSession(session);
                 matType->declRef = declRef;
@@ -784,7 +784,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             }
             else if (magicMod->name == "Texture")
             {
-                SLANG_ASSERT(subst && subst->args.getSize() >= 1);
+                SLANG_ASSERT(subst && subst->args.getCount() >= 1);
                 auto textureType = new TextureType(
                     TextureFlavor(magicMod->tag),
                     ExtractGenericArgType(subst->args[0]));
@@ -794,7 +794,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             }
             else if (magicMod->name == "TextureSampler")
             {
-                SLANG_ASSERT(subst && subst->args.getSize() >= 1);
+                SLANG_ASSERT(subst && subst->args.getCount() >= 1);
                 auto textureType = new TextureSamplerType(
                     TextureFlavor(magicMod->tag),
                     ExtractGenericArgType(subst->args[0]));
@@ -804,7 +804,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             }
             else if (magicMod->name == "GLSLImageType")
             {
-                SLANG_ASSERT(subst && subst->args.getSize() >= 1);
+                SLANG_ASSERT(subst && subst->args.getCount() >= 1);
                 auto textureType = new GLSLImageType(
                     TextureFlavor(magicMod->tag),
                     ExtractGenericArgType(subst->args[0]));
@@ -832,7 +832,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
             #define CASE(n,T)													\
                 else if(magicMod->name == #n) {									\
-                    SLANG_ASSERT(subst && subst->args.getSize() == 1);			\
+                    SLANG_ASSERT(subst && subst->args.getCount() == 1);			\
                     auto type = new T();									    \
                     type->setSession(session);                                  \
                     type->elementType = ExtractGenericArgType(subst->args[0]);	\
@@ -1375,8 +1375,8 @@ void Type::accept(IValVisitor* visitor, void* extra)
         if (genericDecl != genericSubst->genericDecl)
             return false;
 
-        UInt argCount = args.getSize();
-        SLANG_RELEASE_ASSERT(args.getSize() == genericSubst->args.getSize());
+        UInt argCount = args.getCount();
+        SLANG_RELEASE_ASSERT(args.getCount() == genericSubst->args.getCount());
         for (UInt aa = 0; aa < argCount; ++aa)
         {
             if (!args[aa]->EqualsVal(genericSubst->args[aa].Ptr()))
@@ -1476,9 +1476,9 @@ void Type::accept(IValVisitor* visitor, void* extra)
                 return false;
             if (!actualType->EqualsVal(genSubst->actualType))
                 return false;
-            if (constraintArgs.getSize() != genSubst->constraintArgs.getSize())
+            if (constraintArgs.getCount() != genSubst->constraintArgs.getCount())
                 return false;
-            for (UInt i = 0; i < constraintArgs.getSize(); i++)
+            for (UInt i = 0; i < constraintArgs.getCount(); i++)
             {
                 if (!constraintArgs[i].val->EqualsVal(genSubst->constraintArgs[i].val))
                     return false;
@@ -2256,7 +2256,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
                         (*ioDiff)++;
                         auto ordinaryParamCount = genericDecl->getMembersOfType<GenericTypeParamDecl>().Count() +
                             genericDecl->getMembersOfType<GenericValueParamDecl>().Count();
-                        SLANG_ASSERT(index + ordinaryParamCount < genericSubst->args.getSize());
+                        SLANG_ASSERT(index + ordinaryParamCount < genericSubst->args.getCount());
                         return genericSubst->args[index + ordinaryParamCount];
                     }
                 }
@@ -2583,8 +2583,8 @@ void Type::accept(IValVisitor* visitor, void* extra)
         if(!taggedUnion)
             return false;
 
-        auto caseCount = caseTypes.getSize();
-        if(caseCount != taggedUnion->caseTypes.getSize())
+        auto caseCount = caseTypes.getCount();
+        if(caseCount != taggedUnion->caseTypes.getCount())
             return false;
 
         for( UInt ii = 0; ii < caseCount; ++ii )
@@ -2650,8 +2650,8 @@ bool TaggedUnionSubtypeWitness::EqualsVal(Val* val)
     if(!taggedUnionWitness)
         return false;
 
-    auto caseCount = caseWitnesses.getSize();
-    if(caseCount != taggedUnionWitness->caseWitnesses.getSize())
+    auto caseCount = caseWitnesses.getCount();
+    if(caseCount != taggedUnionWitness->caseWitnesses.getCount())
         return false;
 
     for(UInt ii = 0; ii < caseCount; ++ii)

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -766,7 +766,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             }
             else if (magicMod->name == "Vector")
             {
-                SLANG_ASSERT(subst && subst->args.Count() == 2);
+                SLANG_ASSERT(subst && subst->args.getSize() == 2);
                 auto vecType = new VectorExpressionType();
                 vecType->setSession(session);
                 vecType->declRef = declRef;
@@ -776,7 +776,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             }
             else if (magicMod->name == "Matrix")
             {
-                SLANG_ASSERT(subst && subst->args.Count() == 3);
+                SLANG_ASSERT(subst && subst->args.getSize() == 3);
                 auto matType = new MatrixExpressionType();
                 matType->setSession(session);
                 matType->declRef = declRef;
@@ -784,7 +784,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             }
             else if (magicMod->name == "Texture")
             {
-                SLANG_ASSERT(subst && subst->args.Count() >= 1);
+                SLANG_ASSERT(subst && subst->args.getSize() >= 1);
                 auto textureType = new TextureType(
                     TextureFlavor(magicMod->tag),
                     ExtractGenericArgType(subst->args[0]));
@@ -794,7 +794,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             }
             else if (magicMod->name == "TextureSampler")
             {
-                SLANG_ASSERT(subst && subst->args.Count() >= 1);
+                SLANG_ASSERT(subst && subst->args.getSize() >= 1);
                 auto textureType = new TextureSamplerType(
                     TextureFlavor(magicMod->tag),
                     ExtractGenericArgType(subst->args[0]));
@@ -804,7 +804,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
             }
             else if (magicMod->name == "GLSLImageType")
             {
-                SLANG_ASSERT(subst && subst->args.Count() >= 1);
+                SLANG_ASSERT(subst && subst->args.getSize() >= 1);
                 auto textureType = new GLSLImageType(
                     TextureFlavor(magicMod->tag),
                     ExtractGenericArgType(subst->args[0]));
@@ -832,7 +832,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
 
             #define CASE(n,T)													\
                 else if(magicMod->name == #n) {									\
-                    SLANG_ASSERT(subst && subst->args.Count() == 1);			\
+                    SLANG_ASSERT(subst && subst->args.getSize() == 1);			\
                     auto type = new T();									    \
                     type->setSession(session);                                  \
                     type->elementType = ExtractGenericArgType(subst->args[0]);	\
@@ -1375,8 +1375,8 @@ void Type::accept(IValVisitor* visitor, void* extra)
         if (genericDecl != genericSubst->genericDecl)
             return false;
 
-        UInt argCount = args.Count();
-        SLANG_RELEASE_ASSERT(args.Count() == genericSubst->args.Count());
+        UInt argCount = args.getSize();
+        SLANG_RELEASE_ASSERT(args.getSize() == genericSubst->args.getSize());
         for (UInt aa = 0; aa < argCount; ++aa)
         {
             if (!args[aa]->EqualsVal(genericSubst->args[aa].Ptr()))
@@ -1476,9 +1476,9 @@ void Type::accept(IValVisitor* visitor, void* extra)
                 return false;
             if (!actualType->EqualsVal(genSubst->actualType))
                 return false;
-            if (constraintArgs.Count() != genSubst->constraintArgs.Count())
+            if (constraintArgs.getSize() != genSubst->constraintArgs.getSize())
                 return false;
-            for (UInt i = 0; i < constraintArgs.Count(); i++)
+            for (UInt i = 0; i < constraintArgs.getSize(); i++)
             {
                 if (!constraintArgs[i].val->EqualsVal(genSubst->constraintArgs[i].val))
                     return false;
@@ -2256,7 +2256,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
                         (*ioDiff)++;
                         auto ordinaryParamCount = genericDecl->getMembersOfType<GenericTypeParamDecl>().Count() +
                             genericDecl->getMembersOfType<GenericValueParamDecl>().Count();
-                        SLANG_ASSERT(index + ordinaryParamCount < genericSubst->args.Count());
+                        SLANG_ASSERT(index + ordinaryParamCount < genericSubst->args.getSize());
                         return genericSubst->args[index + ordinaryParamCount];
                     }
                 }
@@ -2583,8 +2583,8 @@ void Type::accept(IValVisitor* visitor, void* extra)
         if(!taggedUnion)
             return false;
 
-        auto caseCount = caseTypes.Count();
-        if(caseCount != taggedUnion->caseTypes.Count())
+        auto caseCount = caseTypes.getSize();
+        if(caseCount != taggedUnion->caseTypes.getSize())
             return false;
 
         for( UInt ii = 0; ii < caseCount; ++ii )
@@ -2650,8 +2650,8 @@ bool TaggedUnionSubtypeWitness::EqualsVal(Val* val)
     if(!taggedUnionWitness)
         return false;
 
-    auto caseCount = caseWitnesses.Count();
-    if(caseCount != taggedUnionWitness->caseWitnesses.Count())
+    auto caseCount = caseWitnesses.getSize();
+    if(caseCount != taggedUnionWitness->caseWitnesses.getSize())
         return false;
 
     for(UInt ii = 0; ii < caseCount; ++ii)

--- a/source/slang/syntax.cpp
+++ b/source/slang/syntax.cpp
@@ -1478,7 +1478,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
                 return false;
             if (constraintArgs.getCount() != genSubst->constraintArgs.getCount())
                 return false;
-            for (UInt i = 0; i < constraintArgs.getCount(); i++)
+            for (Index i = 0; i < constraintArgs.getCount(); i++)
             {
                 if (!constraintArgs[i].val->EqualsVal(genSubst->constraintArgs[i].val))
                     return false;
@@ -2254,8 +2254,8 @@ void Type::accept(IValVisitor* visitor, void* extra)
                     if (found)
                     {
                         (*ioDiff)++;
-                        auto ordinaryParamCount = genericDecl->getMembersOfType<GenericTypeParamDecl>().Count() +
-                            genericDecl->getMembersOfType<GenericValueParamDecl>().Count();
+                        auto ordinaryParamCount = genericDecl->getMembersOfType<GenericTypeParamDecl>().getCount() +
+                            genericDecl->getMembersOfType<GenericValueParamDecl>().getCount();
                         SLANG_ASSERT(index + ordinaryParamCount < genericSubst->args.getCount());
                         return genericSubst->args[index + ordinaryParamCount];
                     }
@@ -2587,7 +2587,7 @@ void Type::accept(IValVisitor* visitor, void* extra)
         if(caseCount != taggedUnion->caseTypes.getCount())
             return false;
 
-        for( UInt ii = 0; ii < caseCount; ++ii )
+        for( Index ii = 0; ii < caseCount; ++ii )
         {
             if(!caseTypes[ii]->Equals(taggedUnion->caseTypes[ii]))
                 return false;
@@ -2654,7 +2654,7 @@ bool TaggedUnionSubtypeWitness::EqualsVal(Val* val)
     if(caseCount != taggedUnionWitness->caseWitnesses.getCount())
         return false;
 
-    for(UInt ii = 0; ii < caseCount; ++ii)
+    for(Index ii = 0; ii < caseCount; ++ii)
     {
         if(!caseWitnesses[ii]->EqualsVal(taggedUnionWitness->caseWitnesses[ii]))
             return false;

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -589,50 +589,50 @@ namespace Slang
         typedef RefPtr<Decl> Element;
 
         FilteredMemberList()
-            : mBegin(NULL)
-            , mEnd(NULL)
+            : m_begin(nullptr)
+            , m_end(nullptr)
         {}
 
         explicit FilteredMemberList(
             List<Element> const& list)
-            : mBegin(Adjust(list.begin(), list.end()))
-            , mEnd(list.end())
+            : m_begin(adjust(list.begin(), list.end()))
+            , m_end(list.end())
         {}
 
         struct Iterator
         {
-            Element* mCursor;
-            Element* mEnd;
+            Element* m_cursor;
+            Element* m_end;
 
             bool operator!=(Iterator const& other)
             {
-                return mCursor != other.mCursor;
+                return m_cursor != other.m_cursor;
             }
 
             void operator++()
             {
-                mCursor = Adjust(mCursor + 1, mEnd);
+                m_cursor = adjust(m_cursor + 1, m_end);
             }
 
             RefPtr<T>& operator*()
             {
-                return *(RefPtr<T>*)mCursor;
+                return *(RefPtr<T>*)m_cursor;
             }
         };
 
         Iterator begin()
         {
-            Iterator iter = { mBegin, mEnd };
+            Iterator iter = { m_begin, m_end };
             return iter;
         }
 
         Iterator end()
         {
-            Iterator iter = { mEnd, mEnd };
+            Iterator iter = { m_end, m_end };
             return iter;
         }
 
-        static Element* Adjust(Element* cursor, Element* end)
+        static Element* adjust(Element* cursor, Element* end)
         {
             while (cursor != end)
             {
@@ -645,10 +645,10 @@ namespace Slang
 
         // TODO(tfoley): It is ugly to have these.
         // We should probably fix the call sites instead.
-        RefPtr<T>& First() { return *begin(); }
-        UInt Count()
+        RefPtr<T>& getFirst() { return *begin(); }
+        Index getCount()
         {
-            UInt count = 0;
+            Index count = 0;
             for (auto iter : (*this))
             {
                 (void)iter;
@@ -657,7 +657,7 @@ namespace Slang
             return count;
         }
 
-        List<RefPtr<T>> ToArray()
+        List<RefPtr<T>> toArray()
         {
             List<RefPtr<T>> result;
             for (auto element : (*this))
@@ -667,8 +667,8 @@ namespace Slang
             return result;
         }
 
-        Element* mBegin;
-        Element* mEnd;
+        Element* m_begin;
+        Element* m_end;
     };
 
     struct TransparentMemberInfo

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -998,11 +998,11 @@ namespace Slang
         // Was at least one result found?
         bool isValid() const { return item.declRef.getDecl() != nullptr; }
 
-        bool isOverloaded() const { return items.getSize() > 1; }
+        bool isOverloaded() const { return items.getCount() > 1; }
 
         Name* getName() const
         {
-            return items.getSize() > 1 ? items[0].declRef.GetName() : item.declRef.GetName();
+            return items.getCount() > 1 ? items[0].declRef.GetName() : item.declRef.GetName();
         }
         LookupResultItem* begin()
         {

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -998,11 +998,11 @@ namespace Slang
         // Was at least one result found?
         bool isValid() const { return item.declRef.getDecl() != nullptr; }
 
-        bool isOverloaded() const { return items.Count() > 1; }
+        bool isOverloaded() const { return items.getSize() > 1; }
 
         Name* getName() const
         {
-            return items.Count() > 1 ? items[0].declRef.GetName() : item.declRef.GetName();
+            return items.getSize() > 1 ? items[0].declRef.GetName() : item.declRef.GetName();
         }
         LookupResultItem* begin()
         {

--- a/source/slang/syntax.h
+++ b/source/slang/syntax.h
@@ -662,7 +662,7 @@ namespace Slang
             List<RefPtr<T>> result;
             for (auto element : (*this))
             {
-                result.Add(element);
+                result.add(element);
             }
             return result;
         }
@@ -702,7 +702,7 @@ namespace Slang
         {
             List<DeclRef<T>> result;
             for (auto d : *this)
-                result.Add(d);
+                result.add(d);
             return result;
         }
 
@@ -1217,14 +1217,14 @@ namespace Slang
     {
         List<DeclRef<T>> rs;
         for (auto d : getMembersOfType<T>(declRef))
-            rs.Add(d);
+            rs.add(d);
         if (auto aggDeclRef = declRef.as<AggTypeDecl>())
         {
             for (auto ext = GetCandidateExtensions(aggDeclRef); ext; ext = ext->nextCandidateExtension)
             {
                 auto extMembers = getMembersOfType<T>(DeclRef<ContainerDecl>(ext, declRef.substitutions));
                 for (auto mbr : extMembers)
-                    rs.Add(mbr);
+                    rs.add(mbr);
             }
         }
         return rs;

--- a/source/slang/type-defs.h
+++ b/source/slang/type-defs.h
@@ -406,7 +406,7 @@ RAW(
     FuncType()
     {}
 
-    UInt getParamCount() { return paramTypes.Count(); }
+    UInt getParamCount() { return paramTypes.getSize(); }
     Type* getParamType(UInt index) { return paramTypes[index]; }
     Type* getResultType() { return resultType; }
 

--- a/source/slang/type-defs.h
+++ b/source/slang/type-defs.h
@@ -406,7 +406,7 @@ RAW(
     FuncType()
     {}
 
-    UInt getParamCount() { return paramTypes.getSize(); }
+    UInt getParamCount() { return paramTypes.getCount(); }
     Type* getParamType(UInt index) { return paramTypes[index]; }
     Type* getResultType() { return resultType; }
 

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -1119,7 +1119,7 @@ RefPtr<TypeLayout> applyOffsetToTypeLayout(
                 }
             }
 
-            newStructTypeLayout->fields.Add(newField);
+            newStructTypeLayout->fields.add(newField);
 
             mapOldFieldToNew.Add(oldField.Ptr(), newField.Ptr());
         }
@@ -2072,7 +2072,7 @@ static RefPtr<TypeLayout> maybeAdjustLayoutForArrayElementType(
                 }
             }
 
-            adjustedStructTypeLayout->fields.Add(adjustedField);
+            adjustedStructTypeLayout->fields.add(adjustedField);
 
             mapOriginalFieldToAdjusted.Add(originalField, adjustedField);
         }
@@ -2209,7 +2209,7 @@ RefPtr<VarLayout> StructTypeLayoutBuilder::addField(
     RefPtr<VarLayout> fieldLayout = new VarLayout();
     fieldLayout->varDecl = field;
     fieldLayout->typeLayout = fieldTypeLayout;
-    m_typeLayout->fields.Add(fieldLayout);
+    m_typeLayout->fields.add(fieldLayout);
     m_typeLayout->mapVarToLayout.Add(field.getDecl(), fieldLayout);
 
     // Set up uniform offset information, if there is any uniform data in the field
@@ -2906,7 +2906,7 @@ static TypeLayoutResult _createTypeLayout(
             // We need to remember the layout of the case type
             // on the final `TaggedUnionTypeLayout`.
             //
-            taggedUnionLayout->caseTypeLayouts.Add(caseTypeLayout);
+            taggedUnionLayout->caseTypeLayouts.add(caseTypeLayout);
 
             // We also need to consider contributions for other
             // resource kinds beyond uniform data.

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -1843,7 +1843,7 @@ static TypeLayoutResult _createTypeLayout(
 
 int findGenericParam(List<RefPtr<GenericParamLayout>> & genericParameters, GlobalGenericParamDecl * decl)
 {
-    return (int)genericParameters.FindFirst([=](RefPtr<GenericParamLayout> & x) {return x->decl.Ptr() == decl; });
+    return (int)genericParameters.findFirstIndex([=](RefPtr<GenericParamLayout> & x) {return x->decl.Ptr() == decl; });
 }
 
 // When constructing a new var layout from an existing one,

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -1999,7 +1999,7 @@ static RefPtr<TypeLayout> maybeAdjustLayoutForArrayElementType(
     }
     else if(auto originalStructTypeLayout = originalTypeLayout.as<StructTypeLayout>() )
     {
-        UInt fieldCount = originalStructTypeLayout->fields.Count();
+        UInt fieldCount = originalStructTypeLayout->fields.getSize();
 
         // Empty struct? Bail out.
         if(fieldCount == 0)
@@ -2119,7 +2119,7 @@ TypeLayoutResult makeTypeLayoutResult(RefPtr<TypeLayout> typeLayout)
     // If the type only consumes a single kind of non-uniform resource,
     // we can fill in the `info` field directly.
     //
-    if( typeLayout->resourceInfos.Count() == 1 )
+    if( typeLayout->resourceInfos.getSize() == 1 )
     {
         auto resInfo = typeLayout->resourceInfos[0];
         if( resInfo.kind != LayoutResourceKind::Uniform )

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -1999,7 +1999,7 @@ static RefPtr<TypeLayout> maybeAdjustLayoutForArrayElementType(
     }
     else if(auto originalStructTypeLayout = originalTypeLayout.as<StructTypeLayout>() )
     {
-        UInt fieldCount = originalStructTypeLayout->fields.getCount();
+        Index fieldCount = originalStructTypeLayout->fields.getCount();
 
         // Empty struct? Bail out.
         if(fieldCount == 0)

--- a/source/slang/type-layout.cpp
+++ b/source/slang/type-layout.cpp
@@ -1999,7 +1999,7 @@ static RefPtr<TypeLayout> maybeAdjustLayoutForArrayElementType(
     }
     else if(auto originalStructTypeLayout = originalTypeLayout.as<StructTypeLayout>() )
     {
-        UInt fieldCount = originalStructTypeLayout->fields.getSize();
+        UInt fieldCount = originalStructTypeLayout->fields.getCount();
 
         // Empty struct? Bail out.
         if(fieldCount == 0)
@@ -2119,7 +2119,7 @@ TypeLayoutResult makeTypeLayoutResult(RefPtr<TypeLayout> typeLayout)
     // If the type only consumes a single kind of non-uniform resource,
     // we can fill in the `info` field directly.
     //
-    if( typeLayout->resourceInfos.getSize() == 1 )
+    if( typeLayout->resourceInfos.getCount() == 1 )
     {
         auto resInfo = typeLayout->resourceInfos[0];
         if( resInfo.kind != LayoutResourceKind::Uniform )

--- a/source/slang/type-layout.h
+++ b/source/slang/type-layout.h
@@ -358,8 +358,8 @@ public:
         ResourceInfo info;
         info.kind = kind;
         info.count = 0;
-        resourceInfos.Add(info);
-        return &resourceInfos.Last();
+        resourceInfos.add(info);
+        return &resourceInfos.getLast();
     }
 
     void addResourceUsage(ResourceInfo info)
@@ -460,8 +460,8 @@ public:
         info.space = 0;
         info.index = 0;
 
-        resourceInfos.Add(info);
-        return &resourceInfos.Last();
+        resourceInfos.add(info);
+        return &resourceInfos.getLast();
     }
 
     ResourceInfo* findOrAddResourceInfo(LayoutResourceKind kind)

--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -102,12 +102,12 @@ int wmain(int argc, wchar_t** argv)
         List<String> args;
         for(int ii = 0; ii < argc; ++ii)
         {
-            args.Add(String::FromWString(argv[ii]));
+            args.add(String::FromWString(argv[ii]));
         }
         List<char const*> argBuffers;
         for(int ii = 0; ii < argc; ++ii)
         {
-            argBuffers.Add(args[ii].Buffer());
+            argBuffers.add(args[ii].Buffer());
         }
 
         result = MAIN(argc, (char**) &argBuffers[0]);

--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -102,7 +102,7 @@ int wmain(int argc, wchar_t** argv)
         List<String> args;
         for(int ii = 0; ii < argc; ++ii)
         {
-            args.add(String::FromWString(argv[ii]));
+            args.add(String::fromWString(argv[ii]));
         }
         List<char const*> argBuffers;
         for(int ii = 0; ii < argc; ++ii)

--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -66,7 +66,7 @@ SLANG_TEST_TOOL_API SlangResult innerMain(StdWriters* stdWriters, SlangSession* 
 #ifndef _DEBUG
     catch (Exception & e)
     {
-        StdWriters::getOut().print("internal compiler error: %S\n", e.Message.ToWString().begin());
+        StdWriters::getOut().print("internal compiler error: %S\n", e.Message.toWString().begin());
         res = SLANG_FAIL;
     }
 #endif
@@ -107,7 +107,7 @@ int wmain(int argc, wchar_t** argv)
         List<char const*> argBuffers;
         for(int ii = 0; ii < argc; ++ii)
         {
-            argBuffers.add(args[ii].Buffer());
+            argBuffers.add(args[ii].getBuffer());
         }
 
         result = MAIN(argc, (char**) &argBuffers[0]);

--- a/tools/gfx/circular-resource-heap-d3d12.cpp
+++ b/tools/gfx/circular-resource-heap-d3d12.cpp
@@ -65,13 +65,13 @@ void D3D12CircularResourceHeap::updateCompleted()
 	const uint64_t completedValue = m_fence->getCompletedValue();
 
 #if 0
-	while (m_pendingQueue.Count() != 0)
+	while (m_pendingQueue.getCount() != 0)
 	{
 		const PendingEntry& entry = m_pendingQueue[0];
 		if (entry.m_completedValue <= completedValue)
 		{
 			m_back = entry.m_cursor;
-			m_pendingQueue.RemoveAt(0);
+			m_pendingQueue.removeAt(0);
 		}
 		else
 		{
@@ -80,8 +80,8 @@ void D3D12CircularResourceHeap::updateCompleted()
 	}
 #else
 	// A more efficient implementation is m_pendingQueue is implemented as a vector like type
-	const int size = int(m_pendingQueue.getCount());
-	int end = 0;
+	const Index size = m_pendingQueue.getCount();
+	Index end = 0;
 	while (end < size && m_pendingQueue[end].m_completedValue <= completedValue)
 	{
 		end++;

--- a/tools/gfx/circular-resource-heap-d3d12.cpp
+++ b/tools/gfx/circular-resource-heap-d3d12.cpp
@@ -93,11 +93,11 @@ void D3D12CircularResourceHeap::updateCompleted()
 		m_back = m_pendingQueue[end - 1].m_cursor;
 		if (end == size)
 		{
-			m_pendingQueue.Clear();
+			m_pendingQueue.clear();
 		}
 		else
 		{
-			m_pendingQueue.RemoveRange(0, size);
+			m_pendingQueue.removeRange(0, size);
 		}
 	}
 #endif

--- a/tools/gfx/circular-resource-heap-d3d12.cpp
+++ b/tools/gfx/circular-resource-heap-d3d12.cpp
@@ -80,7 +80,7 @@ void D3D12CircularResourceHeap::updateCompleted()
 	}
 #else
 	// A more efficient implementation is m_pendingQueue is implemented as a vector like type
-	const int size = int(m_pendingQueue.getSize());
+	const int size = int(m_pendingQueue.getCount());
 	int end = 0;
 	while (end < size && m_pendingQueue[end].m_completedValue <= completedValue)
 	{

--- a/tools/gfx/circular-resource-heap-d3d12.cpp
+++ b/tools/gfx/circular-resource-heap-d3d12.cpp
@@ -57,7 +57,7 @@ void D3D12CircularResourceHeap::addSync(uint64_t signalValue)
 	PendingEntry entry;
 	entry.m_completedValue = signalValue;
 	entry.m_cursor = m_front;
-	m_pendingQueue.Add(entry);
+	m_pendingQueue.add(entry);
 }
 
 void D3D12CircularResourceHeap::updateCompleted()

--- a/tools/gfx/circular-resource-heap-d3d12.cpp
+++ b/tools/gfx/circular-resource-heap-d3d12.cpp
@@ -80,7 +80,7 @@ void D3D12CircularResourceHeap::updateCompleted()
 	}
 #else
 	// A more efficient implementation is m_pendingQueue is implemented as a vector like type
-	const int size = int(m_pendingQueue.Count());
+	const int size = int(m_pendingQueue.getSize());
 	int end = 0;
 	while (end < size && m_pendingQueue[end].m_completedValue <= completedValue)
 	{

--- a/tools/gfx/d3d-util.cpp
+++ b/tools/gfx/d3d-util.cpp
@@ -378,7 +378,7 @@ static bool _isMatch(IDXGIAdapter* adapter, const Slang::UnownedStringSlice& low
 
     String descName = String::FromWString(desc.Description).ToLower();
 
-    return descName.IndexOf(lowerAdapaterName) != UInt(-1);
+    return descName.IndexOf(lowerAdapaterName) != Index(-1);
 }
 
 /* static */bool D3DUtil::isWarp(IDXGIFactory* dxgiFactory, IDXGIAdapter* adapterIn)

--- a/tools/gfx/d3d-util.cpp
+++ b/tools/gfx/d3d-util.cpp
@@ -295,7 +295,7 @@ bool D3DUtil::isTypeless(DXGI_FORMAT format)
     if (outSize > 0)
     {
         const UInt prevSize = out.getSize();
-        out.SetSize(prevSize + len + 1);
+        out.setSize(prevSize + len + 1);
 
         WCHAR* dst = out.Buffer() + prevSize;
         ::MultiByteToWideChar(CP_UTF8, dwFlags, in, int(len), dst, outSize);

--- a/tools/gfx/d3d-util.cpp
+++ b/tools/gfx/d3d-util.cpp
@@ -376,9 +376,9 @@ static bool _isMatch(IDXGIAdapter* adapter, const Slang::UnownedStringSlice& low
     DXGI_ADAPTER_DESC desc;
     adapter->GetDesc(&desc);
 
-    String descName = String::FromWString(desc.Description).ToLower();
+    String descName = String::fromWString(desc.Description).toLower();
 
-    return descName.IndexOf(lowerAdapaterName) != Index(-1);
+    return descName.indexOf(lowerAdapaterName) != Index(-1);
 }
 
 /* static */bool D3DUtil::isWarp(IDXGIFactory* dxgiFactory, IDXGIAdapter* adapterIn)
@@ -397,7 +397,7 @@ static bool _isMatch(IDXGIAdapter* adapter, const Slang::UnownedStringSlice& low
 
 /* static */SlangResult D3DUtil::findAdapters(DeviceCheckFlags flags, const UnownedStringSlice& adapterName, IDXGIFactory* dxgiFactory, List<ComPtr<IDXGIAdapter>>& outDxgiAdapters)
 {
-    String lowerAdapterName = String(adapterName).ToLower();
+    String lowerAdapterName = String(adapterName).toLower();
 
     outDxgiAdapters.clear();
 

--- a/tools/gfx/d3d-util.cpp
+++ b/tools/gfx/d3d-util.cpp
@@ -302,7 +302,7 @@ bool D3DUtil::isTypeless(DXGI_FORMAT format)
         // Make null terminated
         dst[outSize] = 0;
         // Remove terminating 0 from array
-        out.UnsafeShrinkToSize(prevSize + outSize);
+        out.unsafeShrinkToSize(prevSize + outSize);
     }
 }
 

--- a/tools/gfx/d3d-util.cpp
+++ b/tools/gfx/d3d-util.cpp
@@ -294,15 +294,15 @@ bool D3DUtil::isTypeless(DXGI_FORMAT format)
 
     if (outSize > 0)
     {
-        const UInt prevSize = out.getSize();
-        out.setSize(prevSize + len + 1);
+        const UInt prevSize = out.getCount();
+        out.setCount(prevSize + len + 1);
 
-        WCHAR* dst = out.Buffer() + prevSize;
+        WCHAR* dst = out.getBuffer() + prevSize;
         ::MultiByteToWideChar(CP_UTF8, dwFlags, in, int(len), dst, outSize);
         // Make null terminated
         dst[outSize] = 0;
         // Remove terminating 0 from array
-        out.unsafeShrinkToSize(prevSize + outSize);
+        out.unsafeShrinkToCount(prevSize + outSize);
     }
 }
 

--- a/tools/gfx/d3d-util.cpp
+++ b/tools/gfx/d3d-util.cpp
@@ -399,7 +399,7 @@ static bool _isMatch(IDXGIAdapter* adapter, const Slang::UnownedStringSlice& low
 {
     String lowerAdapterName = String(adapterName).ToLower();
 
-    outDxgiAdapters.Clear();
+    outDxgiAdapters.clear();
 
     ComPtr<IDXGIAdapter> warpAdapter;
     if ((flags & DeviceCheckFlag::UseHardwareDevice) == 0)

--- a/tools/gfx/d3d-util.cpp
+++ b/tools/gfx/d3d-util.cpp
@@ -294,7 +294,7 @@ bool D3DUtil::isTypeless(DXGI_FORMAT format)
 
     if (outSize > 0)
     {
-        const UInt prevSize = out.getCount();
+        const Index prevSize = out.getCount();
         out.setCount(prevSize + len + 1);
 
         WCHAR* dst = out.getBuffer() + prevSize;

--- a/tools/gfx/d3d-util.cpp
+++ b/tools/gfx/d3d-util.cpp
@@ -1,4 +1,4 @@
-﻿// d3d-util.cpp
+// d3d-util.cpp
 #include "d3d-util.h"
 
 #include <d3dcompiler.h>
@@ -294,7 +294,7 @@ bool D3DUtil::isTypeless(DXGI_FORMAT format)
 
     if (outSize > 0)
     {
-        const UInt prevSize = out.Count();
+        const UInt prevSize = out.getSize();
         out.SetSize(prevSize + len + 1);
 
         WCHAR* dst = out.Buffer() + prevSize;

--- a/tools/gfx/d3d-util.cpp
+++ b/tools/gfx/d3d-util.cpp
@@ -410,7 +410,7 @@ static bool _isMatch(IDXGIAdapter* adapter, const Slang::UnownedStringSlice& low
             dxgiFactory4->EnumWarpAdapter(IID_PPV_ARGS(warpAdapter.writeRef()));
             if (_isMatch(warpAdapter, lowerAdapterName.getUnownedSlice()))
             {
-                outDxgiAdapters.Add(warpAdapter);
+                outDxgiAdapters.add(warpAdapter);
             }
         }
     }
@@ -444,7 +444,7 @@ static bool _isMatch(IDXGIAdapter* adapter, const Slang::UnownedStringSlice& low
         // If the right type then add it
         if ((deviceFlags & DXGI_ADAPTER_FLAG_SOFTWARE) == 0 && (flags & DeviceCheckFlag::UseHardwareDevice) != 0)
         {
-            outDxgiAdapters.Add(dxgiAdapter);
+            outDxgiAdapters.add(dxgiAdapter);
         }
     }
 

--- a/tools/gfx/descriptor-heap-d3d12.h
+++ b/tools/gfx/descriptor-heap-d3d12.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 
 #include <dxgi.h>
@@ -108,7 +108,7 @@ public:
     {
         // TODO: this allocator would take some work to make thread-safe
 
-        if(m_freeList.Count() > 0)
+        if(m_freeList.getSize() > 0)
         {
             auto descriptor = m_freeList[0];
             m_freeList.FastRemoveAt(0);

--- a/tools/gfx/descriptor-heap-d3d12.h
+++ b/tools/gfx/descriptor-heap-d3d12.h
@@ -111,7 +111,7 @@ public:
         if(m_freeList.getSize() > 0)
         {
             auto descriptor = m_freeList[0];
-            m_freeList.FastRemoveAt(0);
+            m_freeList.fastRemoveAt(0);
 
             *outDescriptor = descriptor;
             return SLANG_OK;

--- a/tools/gfx/descriptor-heap-d3d12.h
+++ b/tools/gfx/descriptor-heap-d3d12.h
@@ -121,7 +121,7 @@ public:
         if(index < 0)
         {
             // Allocate a new heap and try again.
-            m_heaps.Add(m_heap);
+            m_heaps.add(m_heap);
             SLANG_RETURN_ON_FAIL(m_heap.init(m_device, m_chunkSize, m_type, D3D12_DESCRIPTOR_HEAP_FLAG_NONE));
 
             int index = m_heap.allocate();
@@ -141,7 +141,7 @@ public:
 
     void free(D3D12HostVisibleDescriptor descriptor)
     {
-        m_freeList.Add(descriptor);
+        m_freeList.add(descriptor);
     }
 };
 

--- a/tools/gfx/descriptor-heap-d3d12.h
+++ b/tools/gfx/descriptor-heap-d3d12.h
@@ -108,7 +108,7 @@ public:
     {
         // TODO: this allocator would take some work to make thread-safe
 
-        if(m_freeList.getSize() > 0)
+        if(m_freeList.getCount() > 0)
         {
             auto descriptor = m_freeList[0];
             m_freeList.fastRemoveAt(0);

--- a/tools/gfx/flag-combiner.cpp
+++ b/tools/gfx/flag-combiner.cpp
@@ -24,7 +24,7 @@ void FlagCombiner::add(uint32_t flags, ChangeType type)
 void FlagCombiner::calcCombinations(List<uint32_t>& outCombinations) const
 {
     const int numCombinations = getNumCombinations();
-    outCombinations.SetSize(numCombinations);
+    outCombinations.setSize(numCombinations);
     uint32_t* dstCombinations = outCombinations.Buffer();
     for (int i = 0; i < numCombinations; ++i)
     {

--- a/tools/gfx/flag-combiner.cpp
+++ b/tools/gfx/flag-combiner.cpp
@@ -24,8 +24,8 @@ void FlagCombiner::add(uint32_t flags, ChangeType type)
 void FlagCombiner::calcCombinations(List<uint32_t>& outCombinations) const
 {
     const int numCombinations = getNumCombinations();
-    outCombinations.setSize(numCombinations);
-    uint32_t* dstCombinations = outCombinations.Buffer();
+    outCombinations.setCount(numCombinations);
+    uint32_t* dstCombinations = outCombinations.getBuffer();
     for (int i = 0; i < numCombinations; ++i)
     {
         dstCombinations[i] = getCombination(i);

--- a/tools/gfx/gui.cpp
+++ b/tools/gfx/gui.cpp
@@ -166,8 +166,8 @@ GUI::GUI(Window* window, Renderer* inRenderer)
     descriptorSetRanges.add(DescriptorSetLayout::SlotRangeDesc(DescriptorSlotType::Sampler));
 
     DescriptorSetLayout::Desc descriptorSetLayoutDesc;
-    descriptorSetLayoutDesc.slotRangeCount = descriptorSetRanges.getSize();
-    descriptorSetLayoutDesc.slotRanges = descriptorSetRanges.Buffer();
+    descriptorSetLayoutDesc.slotRangeCount = descriptorSetRanges.getCount();
+    descriptorSetLayoutDesc.slotRanges = descriptorSetRanges.getBuffer();
 
     descriptorSetLayout = renderer->createDescriptorSetLayout(descriptorSetLayoutDesc);
 
@@ -175,8 +175,8 @@ GUI::GUI(Window* window, Renderer* inRenderer)
     pipelineDescriptorSets.add(PipelineLayout::DescriptorSetDesc(descriptorSetLayout));
 
     PipelineLayout::Desc pipelineLayoutDesc;
-    pipelineLayoutDesc.descriptorSetCount = pipelineDescriptorSets.getSize();
-    pipelineLayoutDesc.descriptorSets = pipelineDescriptorSets.Buffer();
+    pipelineLayoutDesc.descriptorSetCount = pipelineDescriptorSets.getCount();
+    pipelineLayoutDesc.descriptorSets = pipelineDescriptorSets.getBuffer();
     pipelineLayoutDesc.renderTargetCount = 1;
 
     pipelineLayout = renderer->createPipelineLayout(pipelineLayoutDesc);

--- a/tools/gfx/gui.cpp
+++ b/tools/gfx/gui.cpp
@@ -161,9 +161,9 @@ GUI::GUI(Window* window, Renderer* inRenderer)
     //
 
     List<DescriptorSetLayout::SlotRangeDesc> descriptorSetRanges;
-    descriptorSetRanges.Add(DescriptorSetLayout::SlotRangeDesc(DescriptorSlotType::UniformBuffer));
-    descriptorSetRanges.Add(DescriptorSetLayout::SlotRangeDesc(DescriptorSlotType::SampledImage));
-    descriptorSetRanges.Add(DescriptorSetLayout::SlotRangeDesc(DescriptorSlotType::Sampler));
+    descriptorSetRanges.add(DescriptorSetLayout::SlotRangeDesc(DescriptorSlotType::UniformBuffer));
+    descriptorSetRanges.add(DescriptorSetLayout::SlotRangeDesc(DescriptorSlotType::SampledImage));
+    descriptorSetRanges.add(DescriptorSetLayout::SlotRangeDesc(DescriptorSlotType::Sampler));
 
     DescriptorSetLayout::Desc descriptorSetLayoutDesc;
     descriptorSetLayoutDesc.slotRangeCount = descriptorSetRanges.getSize();
@@ -172,7 +172,7 @@ GUI::GUI(Window* window, Renderer* inRenderer)
     descriptorSetLayout = renderer->createDescriptorSetLayout(descriptorSetLayoutDesc);
 
     List<PipelineLayout::DescriptorSetDesc> pipelineDescriptorSets;
-    pipelineDescriptorSets.Add(PipelineLayout::DescriptorSetDesc(descriptorSetLayout));
+    pipelineDescriptorSets.add(PipelineLayout::DescriptorSetDesc(descriptorSetLayout));
 
     PipelineLayout::Desc pipelineLayoutDesc;
     pipelineLayoutDesc.descriptorSetCount = pipelineDescriptorSets.getSize();

--- a/tools/gfx/gui.cpp
+++ b/tools/gfx/gui.cpp
@@ -166,7 +166,7 @@ GUI::GUI(Window* window, Renderer* inRenderer)
     descriptorSetRanges.Add(DescriptorSetLayout::SlotRangeDesc(DescriptorSlotType::Sampler));
 
     DescriptorSetLayout::Desc descriptorSetLayoutDesc;
-    descriptorSetLayoutDesc.slotRangeCount = descriptorSetRanges.Count();
+    descriptorSetLayoutDesc.slotRangeCount = descriptorSetRanges.getSize();
     descriptorSetLayoutDesc.slotRanges = descriptorSetRanges.Buffer();
 
     descriptorSetLayout = renderer->createDescriptorSetLayout(descriptorSetLayoutDesc);
@@ -175,7 +175,7 @@ GUI::GUI(Window* window, Renderer* inRenderer)
     pipelineDescriptorSets.Add(PipelineLayout::DescriptorSetDesc(descriptorSetLayout));
 
     PipelineLayout::Desc pipelineLayoutDesc;
-    pipelineLayoutDesc.descriptorSetCount = pipelineDescriptorSets.Count();
+    pipelineLayoutDesc.descriptorSetCount = pipelineDescriptorSets.getSize();
     pipelineLayoutDesc.descriptorSets = pipelineDescriptorSets.Buffer();
     pipelineLayoutDesc.renderTargetCount = 1;
 

--- a/tools/gfx/render-d3d11.cpp
+++ b/tools/gfx/render-d3d11.cpp
@@ -1813,7 +1813,7 @@ Result D3D11Renderer::createDescriptorSetLayout(const DescriptorSetLayout::Desc&
             rangeInfo.arrayIndex = counts[typeIndex];
             counts[typeIndex] += rangeDesc.count;
         }
-        descriptorSetLayoutImpl->m_ranges.Add(rangeInfo);
+        descriptorSetLayoutImpl->m_ranges.add(rangeInfo);
     }
 
     for(int ii = 0; ii < int(D3D11DescriptorSlotType::CountOf); ++ii)
@@ -1845,7 +1845,7 @@ Result D3D11Renderer::createPipelineLayout(const PipelineLayout::Desc& desc, Pip
             counts[jj] += setInfo.layout->m_counts[jj];
         }
 
-        pipelineLayoutImpl->m_descriptorSets.Add(setInfo);
+        pipelineLayoutImpl->m_descriptorSets.add(setInfo);
     }
 
     pipelineLayoutImpl->m_uavCount = UINT(counts[int(D3D11DescriptorSlotType::UnorderedAccessView)]);

--- a/tools/gfx/render-d3d11.cpp
+++ b/tools/gfx/render-d3d11.cpp
@@ -695,7 +695,7 @@ Result D3D11Renderer::createTextureResource(Resource::Usage initialUsage, const 
     D3D11_SUBRESOURCE_DATA* subResourcesPtr = nullptr;
     if(initData)
     {
-        subRes.SetSize(srcDesc.numMipLevels * effectiveArraySize);
+        subRes.setSize(srcDesc.numMipLevels * effectiveArraySize);
         {
             int subResourceIndex = 0;
             for (int i = 0; i < effectiveArraySize; i++)
@@ -816,7 +816,7 @@ Result D3D11Renderer::createBufferResource(Resource::Usage initialUsage, const B
     List<uint8_t> initDataBuffer;
     if (initData && alignedSizeInBytes > srcDesc.sizeInBytes)
     {
-        initDataBuffer.SetSize(alignedSizeInBytes);
+        initDataBuffer.setSize(alignedSizeInBytes);
         ::memcpy(initDataBuffer.Buffer(), initData, srcDesc.sizeInBytes);
         initData = initDataBuffer.Buffer();
     }
@@ -1861,10 +1861,10 @@ Result D3D11Renderer::createDescriptorSet(DescriptorSetLayout* layout, Descripto
     RefPtr<DescriptorSetImpl> descriptorSetImpl = new DescriptorSetImpl();
 
     descriptorSetImpl->m_layout = layoutImpl;
-    descriptorSetImpl->m_cbs     .SetSize(layoutImpl->m_counts[int(D3D11DescriptorSlotType::ConstantBuffer)]);
-    descriptorSetImpl->m_srvs    .SetSize(layoutImpl->m_counts[int(D3D11DescriptorSlotType::ShaderResourceView)]);
-    descriptorSetImpl->m_uavs    .SetSize(layoutImpl->m_counts[int(D3D11DescriptorSlotType::UnorderedAccessView)]);
-    descriptorSetImpl->m_samplers.SetSize(layoutImpl->m_counts[int(D3D11DescriptorSlotType::Sampler)]);
+    descriptorSetImpl->m_cbs     .setSize(layoutImpl->m_counts[int(D3D11DescriptorSlotType::ConstantBuffer)]);
+    descriptorSetImpl->m_srvs    .setSize(layoutImpl->m_counts[int(D3D11DescriptorSlotType::ShaderResourceView)]);
+    descriptorSetImpl->m_uavs    .setSize(layoutImpl->m_counts[int(D3D11DescriptorSlotType::UnorderedAccessView)]);
+    descriptorSetImpl->m_samplers.setSize(layoutImpl->m_counts[int(D3D11DescriptorSlotType::Sampler)]);
 
     *outDescriptorSet = descriptorSetImpl.detach();
     return SLANG_OK;

--- a/tools/gfx/render-d3d11.cpp
+++ b/tools/gfx/render-d3d11.cpp
@@ -479,7 +479,7 @@ SlangResult D3D11Renderer::initialize(const Desc& desc, void* inWindowHandle)
             {
                 List<ComPtr<IDXGIAdapter>> dxgiAdapters;
                 D3DUtil::findAdapters(deviceCheckFlags, desc.adapter.getUnownedSlice(), dxgiAdapters);
-                if (dxgiAdapters.Count() == 0)
+                if (dxgiAdapters.getSize() == 0)
                 {
                     continue;
                 }

--- a/tools/gfx/render-d3d11.cpp
+++ b/tools/gfx/render-d3d11.cpp
@@ -475,7 +475,7 @@ SlangResult D3D11Renderer::initialize(const Desc& desc, void* inWindowHandle)
 
             // If we have an adapter set on the desc, look it up. We only need to do so for hardware
             ComPtr<IDXGIAdapter> adapter;
-            if (desc.adapter.Length() &&  (deviceCheckFlags & DeviceCheckFlag::UseHardwareDevice))
+            if (desc.adapter.getLength() &&  (deviceCheckFlags & DeviceCheckFlag::UseHardwareDevice))
             {
                 List<ComPtr<IDXGIAdapter>> dxgiAdapters;
                 D3DUtil::findAdapters(deviceCheckFlags, desc.adapter.getUnownedSlice(), dxgiAdapters);

--- a/tools/gfx/render-d3d11.cpp
+++ b/tools/gfx/render-d3d11.cpp
@@ -479,7 +479,7 @@ SlangResult D3D11Renderer::initialize(const Desc& desc, void* inWindowHandle)
             {
                 List<ComPtr<IDXGIAdapter>> dxgiAdapters;
                 D3DUtil::findAdapters(deviceCheckFlags, desc.adapter.getUnownedSlice(), dxgiAdapters);
-                if (dxgiAdapters.getSize() == 0)
+                if (dxgiAdapters.getCount() == 0)
                 {
                     continue;
                 }
@@ -695,7 +695,7 @@ Result D3D11Renderer::createTextureResource(Resource::Usage initialUsage, const 
     D3D11_SUBRESOURCE_DATA* subResourcesPtr = nullptr;
     if(initData)
     {
-        subRes.setSize(srcDesc.numMipLevels * effectiveArraySize);
+        subRes.setCount(srcDesc.numMipLevels * effectiveArraySize);
         {
             int subResourceIndex = 0;
             for (int i = 0; i < effectiveArraySize; i++)
@@ -715,7 +715,7 @@ Result D3D11Renderer::createTextureResource(Resource::Usage initialUsage, const 
                 }
             }
         }
-        subResourcesPtr = subRes.Buffer();
+        subResourcesPtr = subRes.getBuffer();
     }
 
     const int accessFlags = _calcResourceAccessFlags(srcDesc.cpuAccessFlags);
@@ -816,9 +816,9 @@ Result D3D11Renderer::createBufferResource(Resource::Usage initialUsage, const B
     List<uint8_t> initDataBuffer;
     if (initData && alignedSizeInBytes > srcDesc.sizeInBytes)
     {
-        initDataBuffer.setSize(alignedSizeInBytes);
-        ::memcpy(initDataBuffer.Buffer(), initData, srcDesc.sizeInBytes);
-        initData = initDataBuffer.Buffer();
+        initDataBuffer.setCount(alignedSizeInBytes);
+        ::memcpy(initDataBuffer.getBuffer(), initData, srcDesc.sizeInBytes);
+        initData = initDataBuffer.getBuffer();
     }
 
     D3D11_BUFFER_DESC bufferDesc = { 0 };
@@ -1861,10 +1861,10 @@ Result D3D11Renderer::createDescriptorSet(DescriptorSetLayout* layout, Descripto
     RefPtr<DescriptorSetImpl> descriptorSetImpl = new DescriptorSetImpl();
 
     descriptorSetImpl->m_layout = layoutImpl;
-    descriptorSetImpl->m_cbs     .setSize(layoutImpl->m_counts[int(D3D11DescriptorSlotType::ConstantBuffer)]);
-    descriptorSetImpl->m_srvs    .setSize(layoutImpl->m_counts[int(D3D11DescriptorSlotType::ShaderResourceView)]);
-    descriptorSetImpl->m_uavs    .setSize(layoutImpl->m_counts[int(D3D11DescriptorSlotType::UnorderedAccessView)]);
-    descriptorSetImpl->m_samplers.setSize(layoutImpl->m_counts[int(D3D11DescriptorSlotType::Sampler)]);
+    descriptorSetImpl->m_cbs     .setCount(layoutImpl->m_counts[int(D3D11DescriptorSlotType::ConstantBuffer)]);
+    descriptorSetImpl->m_srvs    .setCount(layoutImpl->m_counts[int(D3D11DescriptorSlotType::ShaderResourceView)]);
+    descriptorSetImpl->m_uavs    .setCount(layoutImpl->m_counts[int(D3D11DescriptorSlotType::UnorderedAccessView)]);
+    descriptorSetImpl->m_samplers.setCount(layoutImpl->m_counts[int(D3D11DescriptorSlotType::Sampler)]);
 
     *outDescriptorSet = descriptorSetImpl.detach();
     return SLANG_OK;

--- a/tools/gfx/render-d3d11.cpp
+++ b/tools/gfx/render-d3d11.cpp
@@ -2097,7 +2097,7 @@ void D3D11Renderer::_applyBindingState(bool isCompute)
                     else
                         context->OMSetRenderTargetsAndUnorderedAccessViews(
                             m_currentBindings->getDesc().m_numRenderTargets,
-                            m_renderTargetViews.Buffer()->readRef(),
+                            m_renderTargetViews.getBuffer()->readRef(),
                             m_depthStencilView,
                             bindingIndex,
                             1,

--- a/tools/gfx/render-d3d12.cpp
+++ b/tools/gfx/render-d3d12.cpp
@@ -3116,15 +3116,15 @@ Result D3D12Renderer::createProgram(const ShaderProgram::Desc& desc, ShaderProgr
     if (desc.pipelineType == PipelineType::Compute)
     {
         auto computeKernel = desc.findKernel(StageType::Compute);
-        program->m_computeShader.InsertRange(0, (const uint8_t*) computeKernel->codeBegin, computeKernel->getCodeSize());
+        program->m_computeShader.insertRange(0, (const uint8_t*) computeKernel->codeBegin, computeKernel->getCodeSize());
     }
     else
     {
         auto vertexKernel = desc.findKernel(StageType::Vertex);
         auto fragmentKernel = desc.findKernel(StageType::Fragment);
 
-        program->m_vertexShader.InsertRange(0, (const uint8_t*) vertexKernel->codeBegin, vertexKernel->getCodeSize());
-        program->m_pixelShader.InsertRange(0, (const uint8_t*) fragmentKernel->codeBegin, fragmentKernel->getCodeSize());
+        program->m_vertexShader.insertRange(0, (const uint8_t*) vertexKernel->codeBegin, vertexKernel->getCodeSize());
+        program->m_pixelShader.insertRange(0, (const uint8_t*) fragmentKernel->codeBegin, fragmentKernel->getCodeSize());
     }
 
     *outProgram = program.detach();

--- a/tools/gfx/render-d3d12.cpp
+++ b/tools/gfx/render-d3d12.cpp
@@ -3611,8 +3611,8 @@ Result D3D12Renderer::createGraphicsPipelineState(const GraphicsPipelineStateDes
 
     psoDesc.pRootSignature = pipelineLayoutImpl->m_rootSignature;
 
-    psoDesc.VS = { programImpl->m_vertexShader.getBuffer(), programImpl->m_vertexShader.getCount() };
-    psoDesc.PS = { programImpl->m_pixelShader .getBuffer(), programImpl->m_pixelShader .getCount() };
+    psoDesc.VS = { programImpl->m_vertexShader.getBuffer(), SIZE_T(programImpl->m_vertexShader.getCount()) };
+    psoDesc.PS = { programImpl->m_pixelShader .getBuffer(), SIZE_T(programImpl->m_pixelShader .getCount()) };
 
     psoDesc.InputLayout = { inputLayoutImpl->m_elements.getBuffer(), UINT(inputLayoutImpl->m_elements.getCount()) };
     psoDesc.PrimitiveTopologyType = m_primitiveTopologyType;
@@ -3706,7 +3706,7 @@ Result D3D12Renderer::createComputePipelineState(const ComputePipelineStateDesc&
     // Describe and create the compute pipeline state object
     D3D12_COMPUTE_PIPELINE_STATE_DESC computeDesc = {};
     computeDesc.pRootSignature = pipelineLayoutImpl->m_rootSignature;
-    computeDesc.CS = { programImpl->m_computeShader.getBuffer(), programImpl->m_computeShader.getCount() };
+    computeDesc.CS = { programImpl->m_computeShader.getBuffer(), SIZE_T(programImpl->m_computeShader.getCount()) };
 
     ComPtr<ID3D12PipelineState> pipelineState;
     SLANG_RETURN_ON_FAIL(m_device->CreateComputePipelineState(&computeDesc, IID_PPV_ARGS(pipelineState.writeRef())));

--- a/tools/gfx/render-d3d12.cpp
+++ b/tools/gfx/render-d3d12.cpp
@@ -1324,7 +1324,7 @@ Result D3D12Renderer::_createDevice(DeviceCheckFlags deviceCheckFlags, const Uno
     ComPtr<ID3D12Device> device;
     ComPtr<IDXGIAdapter> adapter;
 
-    for (int i = 0; i < int(dxgiAdapters.getCount()); ++i)
+    for (Index i = 0; i < dxgiAdapters.getCount(); ++i)
     {
         IDXGIAdapter* dxgiAdapter = dxgiAdapters[i];
         if (SLANG_SUCCEEDED(m_D3D12CreateDevice(dxgiAdapter, featureLevel, IID_PPV_ARGS(device.writeRef()))))
@@ -2739,7 +2739,7 @@ void D3D12Renderer::draw(UInt vertexCount, UInt startVertex)
     {
         int numVertexViews = 0;
         D3D12_VERTEX_BUFFER_VIEW vertexViews[16];
-        for (int i = 0; i < int(m_boundVertexBuffers.getCount()); i++)
+        for (Index i = 0; i < m_boundVertexBuffers.getCount(); i++)
         {
             const BoundVertexBuffer& boundVertexBuffer = m_boundVertexBuffers[i];
             BufferResourceImpl* buffer = boundVertexBuffer.m_buffer;

--- a/tools/gfx/render-d3d12.cpp
+++ b/tools/gfx/render-d3d12.cpp
@@ -1965,11 +1965,11 @@ Result D3D12Renderer::createTextureResource(Resource::Usage initialUsage, const 
 
     // Calculate the layout
     List<D3D12_PLACED_SUBRESOURCE_FOOTPRINT> layouts;
-    layouts.SetSize(numMipMaps);
+    layouts.setSize(numMipMaps);
     List<UInt64> mipRowSizeInBytes;
-    mipRowSizeInBytes.SetSize(numMipMaps);
+    mipRowSizeInBytes.setSize(numMipMaps);
     List<UInt32> mipNumRows;
-    mipNumRows.SetSize(numMipMaps);
+    mipNumRows.setSize(numMipMaps);
 
     // Since textures are effectively immutable currently initData must be set
     assert(initData);
@@ -2119,7 +2119,7 @@ Result D3D12Renderer::createBufferResource(Resource::Usage initialUsage, const B
         {
             // Assume the constant buffer will change every frame. We'll just keep a copy of the contents
             // in regular memory until it needed
-            buffer->m_memory.SetSize(UInt(alignedSizeInBytes));
+            buffer->m_memory.setSize(UInt(alignedSizeInBytes));
             // Initialize
             if (initData)
             {
@@ -2424,12 +2424,12 @@ Result D3D12Renderer::createInputLayout(const InputElementDesc* inputElements, U
         const char* text = inputElements[i].semanticName;
         textSize += text ? (::strlen(text) + 1) : 0;
     }
-    layout->m_text.SetSize(textSize);
+    layout->m_text.setSize(textSize);
     char* textPos = layout->m_text.Buffer();
 
     //
     List<D3D12_INPUT_ELEMENT_DESC>& elements = layout->m_elements;
-    elements.SetSize(inputElementCount);
+    elements.setSize(inputElementCount);
 
 
     for (UInt i = 0; i < inputElementCount; ++i)
@@ -2537,7 +2537,7 @@ void* D3D12Renderer::map(BufferResource* bufferIn, MapFlavor flavor)
                         SLANG_RETURN_NULL_ON_FAIL(stageBuf.getResource()->Map(0, &readRange, reinterpret_cast<void**>(&data)));
 
                         // Copy to memory buffer
-                        buffer->m_memory.SetSize(bufferSize);
+                        buffer->m_memory.setSize(bufferSize);
                         ::memcpy(buffer->m_memory.Buffer(), data, bufferSize);
 
                         stageBuf.getResource()->Unmap(0, nullptr);
@@ -2639,7 +2639,7 @@ void D3D12Renderer::setVertexBuffers(UInt startSlot, UInt slotCount, BufferResou
         const UInt num = startSlot + slotCount;
         if (num > m_boundVertexBuffers.getSize())
         {
-            m_boundVertexBuffers.SetSize(num);
+            m_boundVertexBuffers.setSize(num);
         }
     }
 
@@ -3221,7 +3221,7 @@ Result D3D12Renderer::createDescriptorSetLayout(const DescriptorSetLayout::Desc&
     // again based on totals that we can compute easily:
     //
     Int totalRangeCount = totalResourceRangeCount + totalSamplerRangeCount;
-    descriptorSetLayoutImpl->m_dxRanges.SetSize(totalRangeCount);
+    descriptorSetLayoutImpl->m_dxRanges.setSize(totalRangeCount);
 
     // Now we will walk through the ranges in  the order they were
     // specified, so that we can fill in the "range info" required for
@@ -3584,7 +3584,7 @@ Result D3D12Renderer::createDescriptorSet(DescriptorSetLayout* layout, Descripto
         auto resourceHeap = &m_cpuViewHeap;
         descriptorSetImpl->m_resourceHeap = resourceHeap;
         descriptorSetImpl->m_resourceTable = resourceHeap->allocate(int(resourceCount));
-        descriptorSetImpl->m_resourceObjects.SetSize(resourceCount);
+        descriptorSetImpl->m_resourceObjects.setSize(resourceCount);
     }
 
     Int samplerCount = layoutImpl->m_samplerCount;
@@ -3593,7 +3593,7 @@ Result D3D12Renderer::createDescriptorSet(DescriptorSetLayout* layout, Descripto
         auto samplerHeap = &m_cpuSamplerHeap;
         descriptorSetImpl->m_samplerHeap = samplerHeap;
         descriptorSetImpl->m_samplerTable = samplerHeap->allocate(int(samplerCount));
-        descriptorSetImpl->m_samplerObjects.SetSize(samplerCount);
+        descriptorSetImpl->m_samplerObjects.setSize(samplerCount);
     }
 
     *outDescriptorSet = descriptorSetImpl.detach();

--- a/tools/gfx/render-d3d12.cpp
+++ b/tools/gfx/render-d3d12.cpp
@@ -2636,7 +2636,7 @@ void D3D12Renderer::setPrimitiveTopology(PrimitiveTopology topology)
 void D3D12Renderer::setVertexBuffers(UInt startSlot, UInt slotCount, BufferResource*const* buffers, const UInt* strides, const UInt* offsets)
 {
     {
-        const UInt num = startSlot + slotCount;
+        const Index num = startSlot + slotCount;
         if (num > m_boundVertexBuffers.getCount())
         {
             m_boundVertexBuffers.setCount(num);

--- a/tools/gfx/render-d3d12.cpp
+++ b/tools/gfx/render-d3d12.cpp
@@ -1000,7 +1000,7 @@ Result D3D12Renderer::calcComputePipelineState(ComPtr<ID3D12RootSignature>& sign
         // Describe and create the compute pipeline state object
         D3D12_COMPUTE_PIPELINE_STATE_DESC computeDesc = {};
         computeDesc.pRootSignature = rootSignature;
-        computeDesc.CS = { m_boundShaderProgram->m_computeShader.Buffer(), m_boundShaderProgram->m_computeShader.Count() };
+        computeDesc.CS = { m_boundShaderProgram->m_computeShader.getBuffer(), m_boundShaderProgram->m_computeShader.Count() };
         SLANG_RETURN_ON_FAIL(m_device->CreateComputePipelineState(&computeDesc, IID_PPV_ARGS(pipelineState.writeRef())));
     }
 
@@ -2052,7 +2052,7 @@ Result D3D12Renderer::createTextureResource(Resource::Usage initialUsage, const 
                     }
                 }
 
-                //assert(srcRow == (const uint8_t*)(srcMip.Buffer() + srcMip.Count()));
+                //assert(srcRow == (const uint8_t*)(srcMip.getBuffer() + srcMip.getCount()));
             }
             uploadResource->Unmap(0, nullptr);
 

--- a/tools/gfx/render-d3d12.cpp
+++ b/tools/gfx/render-d3d12.cpp
@@ -1501,7 +1501,7 @@ Result D3D12Renderer::initialize(const Desc& desc, void* inWindowHandle)
                 featureShaderModel.HighestShaderModel >= 0x62)
             {
                 // With sm_6_2 we have half
-                m_features.Add("half");
+                m_features.add("half");
             }
         }
         // Check what min precision support we have
@@ -3207,14 +3207,14 @@ Result D3D12Renderer::createDescriptorSetLayout(const DescriptorSetLayout::Desc&
         D3D12_ROOT_PARAMETER dxRootParameter = {};
         dxRootParameter.ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
         dxRootParameter.DescriptorTable.NumDescriptorRanges = UINT(totalResourceRangeCount);
-        descriptorSetLayoutImpl->m_dxRootParameters.Add(dxRootParameter);
+        descriptorSetLayoutImpl->m_dxRootParameters.add(dxRootParameter);
     }
     if( totalSamplerRangeCount )
     {
         D3D12_ROOT_PARAMETER dxRootParameter = {};
         dxRootParameter.ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
         dxRootParameter.DescriptorTable.NumDescriptorRanges = UINT(totalSamplerRangeCount);
-        descriptorSetLayoutImpl->m_dxRootParameters.Add(dxRootParameter);
+        descriptorSetLayoutImpl->m_dxRootParameters.add(dxRootParameter);
     }
 
     // Next we can allocate space for all the D3D register ranges we need,
@@ -3272,7 +3272,7 @@ Result D3D12Renderer::createDescriptorSetLayout(const DescriptorSetLayout::Desc&
                 break;
             }
 
-            descriptorSetLayoutImpl->m_ranges.Add(rangeInfo);
+            descriptorSetLayoutImpl->m_ranges.add(rangeInfo);
         }
     }
 

--- a/tools/gfx/render-d3d12.cpp
+++ b/tools/gfx/render-d3d12.cpp
@@ -175,7 +175,7 @@ protected:
             {
                 case BackingStyle::MemoryBacked:
                 {
-                    const size_t bufferSize = m_memory.Count();
+                    const size_t bufferSize = m_memory.getSize();
                     D3D12CircularResourceHeap::Cursor cursor = circularHeap.allocateConstantBuffer(bufferSize);
                     ::memcpy(cursor.m_position, m_memory.Buffer(), bufferSize);
                     // Set the constant buffer
@@ -1324,7 +1324,7 @@ Result D3D12Renderer::_createDevice(DeviceCheckFlags deviceCheckFlags, const Uno
     ComPtr<ID3D12Device> device;
     ComPtr<IDXGIAdapter> adapter;
 
-    for (int i = 0; i < int(dxgiAdapters.Count()); ++i)
+    for (int i = 0; i < int(dxgiAdapters.getSize()); ++i)
     {
         IDXGIAdapter* dxgiAdapter = dxgiAdapters[i];
         if (SLANG_SUCCEEDED(m_D3D12CreateDevice(dxgiAdapter, featureLevel, IID_PPV_ARGS(device.writeRef()))))
@@ -2637,7 +2637,7 @@ void D3D12Renderer::setVertexBuffers(UInt startSlot, UInt slotCount, BufferResou
 {
     {
         const UInt num = startSlot + slotCount;
-        if (num > m_boundVertexBuffers.Count())
+        if (num > m_boundVertexBuffers.getSize())
         {
             m_boundVertexBuffers.SetSize(num);
         }
@@ -2739,7 +2739,7 @@ void D3D12Renderer::draw(UInt vertexCount, UInt startVertex)
     {
         int numVertexViews = 0;
         D3D12_VERTEX_BUFFER_VIEW vertexViews[16];
-        for (int i = 0; i < int(m_boundVertexBuffers.Count()); i++)
+        for (int i = 0; i < int(m_boundVertexBuffers.getSize()); i++)
         {
             const BoundVertexBuffer& boundVertexBuffer = m_boundVertexBuffers[i];
             BufferResourceImpl* buffer = boundVertexBuffer.m_buffer;
@@ -3611,10 +3611,10 @@ Result D3D12Renderer::createGraphicsPipelineState(const GraphicsPipelineStateDes
 
     psoDesc.pRootSignature = pipelineLayoutImpl->m_rootSignature;
 
-    psoDesc.VS = { programImpl->m_vertexShader.Buffer(), programImpl->m_vertexShader.Count() };
-    psoDesc.PS = { programImpl->m_pixelShader .Buffer(), programImpl->m_pixelShader .Count() };
+    psoDesc.VS = { programImpl->m_vertexShader.Buffer(), programImpl->m_vertexShader.getSize() };
+    psoDesc.PS = { programImpl->m_pixelShader .Buffer(), programImpl->m_pixelShader .getSize() };
 
-    psoDesc.InputLayout = { inputLayoutImpl->m_elements.Buffer(), UINT(inputLayoutImpl->m_elements.Count()) };
+    psoDesc.InputLayout = { inputLayoutImpl->m_elements.Buffer(), UINT(inputLayoutImpl->m_elements.getSize()) };
     psoDesc.PrimitiveTopologyType = m_primitiveTopologyType;
 
     {
@@ -3706,7 +3706,7 @@ Result D3D12Renderer::createComputePipelineState(const ComputePipelineStateDesc&
     // Describe and create the compute pipeline state object
     D3D12_COMPUTE_PIPELINE_STATE_DESC computeDesc = {};
     computeDesc.pRootSignature = pipelineLayoutImpl->m_rootSignature;
-    computeDesc.CS = { programImpl->m_computeShader.Buffer(), programImpl->m_computeShader.Count() };
+    computeDesc.CS = { programImpl->m_computeShader.Buffer(), programImpl->m_computeShader.getSize() };
 
     ComPtr<ID3D12PipelineState> pipelineState;
     SLANG_RETURN_ON_FAIL(m_device->CreateComputePipelineState(&computeDesc, IID_PPV_ARGS(pipelineState.writeRef())));

--- a/tools/gfx/render-gl.cpp
+++ b/tools/gfx/render-gl.cpp
@@ -473,7 +473,7 @@ void GLRenderer::flushStateForDraw()
     // Next bind the descriptor sets as required by the layout
     auto pipelineLayout = m_currentPipelineState->m_pipelineLayout;
     auto descriptorSetCount = pipelineLayout->m_sets.getCount();
-    for(UInt ii = 0; ii < descriptorSetCount; ++ii)
+    for(Index ii = 0; ii < descriptorSetCount; ++ii)
     {
         auto descriptorSet = m_boundDescriptorSets[ii];
         auto descriptorSetInfo = pipelineLayout->m_sets[ii];
@@ -683,7 +683,7 @@ SlangResult GLRenderer::initialize(const Desc& desc, void* inWindowHandle)
         String lowerRenderer = String((const char*)renderer).ToLower();
 
         // The adapter is not available
-        if (lowerRenderer.IndexOf(lowerAdapter) == UInt(-1))
+        if (lowerRenderer.IndexOf(lowerAdapter) == Index(-1))
         {
             return SLANG_E_NOT_AVAILABLE;
         }

--- a/tools/gfx/render-gl.cpp
+++ b/tools/gfx/render-gl.cpp
@@ -4,7 +4,6 @@
 //WORKING:#include "options.h"
 #include "render.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "core/basic.h"

--- a/tools/gfx/render-gl.cpp
+++ b/tools/gfx/render-gl.cpp
@@ -473,7 +473,7 @@ void GLRenderer::flushStateForDraw()
 
     // Next bind the descriptor sets as required by the layout
     auto pipelineLayout = m_currentPipelineState->m_pipelineLayout;
-    auto descriptorSetCount = pipelineLayout->m_sets.Count();
+    auto descriptorSetCount = pipelineLayout->m_sets.getSize();
     for(UInt ii = 0; ii < descriptorSetCount; ++ii)
     {
         auto descriptorSet = m_boundDescriptorSets[ii];

--- a/tools/gfx/render-gl.cpp
+++ b/tools/gfx/render-gl.cpp
@@ -472,7 +472,7 @@ void GLRenderer::flushStateForDraw()
 
     // Next bind the descriptor sets as required by the layout
     auto pipelineLayout = m_currentPipelineState->m_pipelineLayout;
-    auto descriptorSetCount = pipelineLayout->m_sets.getSize();
+    auto descriptorSetCount = pipelineLayout->m_sets.getCount();
     for(UInt ii = 0; ii < descriptorSetCount; ++ii)
     {
         auto descriptorSet = m_boundDescriptorSets[ii];
@@ -1383,15 +1383,15 @@ Result GLRenderer::createDescriptorSet(DescriptorSetLayout* layout, DescriptorSe
     {
         auto slotTypeIndex = int(GLDescriptorSlotType::ConstantBuffer);
         auto slotCount = layoutImpl->m_counts[slotTypeIndex];
-        descriptorSetImpl->m_constantBuffers.setSize(slotCount);
+        descriptorSetImpl->m_constantBuffers.setCount(slotCount);
     }
 
     {
         auto slotTypeIndex = int(GLDescriptorSlotType::CombinedTextureSampler);
         auto slotCount = layoutImpl->m_counts[slotTypeIndex];
 
-        descriptorSetImpl->m_textures.setSize(slotCount);
-        descriptorSetImpl->m_samplers.setSize(slotCount);
+        descriptorSetImpl->m_textures.setCount(slotCount);
+        descriptorSetImpl->m_samplers.setCount(slotCount);
     }
 
     *outDescriptorSet = descriptorSetImpl.detach();

--- a/tools/gfx/render-gl.cpp
+++ b/tools/gfx/render-gl.cpp
@@ -446,8 +446,8 @@ void GLRenderer::bindBufferImpl(int target, UInt startSlot, UInt slotCount, Buff
 void GLRenderer::flushStateForDraw()
 {
     auto inputLayout = m_currentPipelineState->m_inputLayout.Ptr();
-    auto attrCount = inputLayout->m_attributeCount;
-    for (UInt ii = 0; ii < attrCount; ++ii)
+    auto attrCount = Index(inputLayout->m_attributeCount);
+    for (Index ii = 0; ii < attrCount; ++ii)
     {
         auto& attr = inputLayout->m_attributes[ii];
 
@@ -465,7 +465,7 @@ void GLRenderer::flushStateForDraw()
 
         glEnableVertexAttribArray((GLuint)ii);
     }
-    for (UInt ii = attrCount; ii < kMaxVertexStreams; ++ii)
+    for (Index ii = attrCount; ii < kMaxVertexStreams; ++ii)
     {
         glDisableVertexAttribArray((GLuint)ii);
     }

--- a/tools/gfx/render-gl.cpp
+++ b/tools/gfx/render-gl.cpp
@@ -1384,15 +1384,15 @@ Result GLRenderer::createDescriptorSet(DescriptorSetLayout* layout, DescriptorSe
     {
         auto slotTypeIndex = int(GLDescriptorSlotType::ConstantBuffer);
         auto slotCount = layoutImpl->m_counts[slotTypeIndex];
-        descriptorSetImpl->m_constantBuffers.SetSize(slotCount);
+        descriptorSetImpl->m_constantBuffers.setSize(slotCount);
     }
 
     {
         auto slotTypeIndex = int(GLDescriptorSlotType::CombinedTextureSampler);
         auto slotCount = layoutImpl->m_counts[slotTypeIndex];
 
-        descriptorSetImpl->m_textures.SetSize(slotCount);
-        descriptorSetImpl->m_samplers.SetSize(slotCount);
+        descriptorSetImpl->m_textures.setSize(slotCount);
+        descriptorSetImpl->m_samplers.setSize(slotCount);
     }
 
     *outDescriptorSet = descriptorSetImpl.detach();

--- a/tools/gfx/render-gl.cpp
+++ b/tools/gfx/render-gl.cpp
@@ -677,13 +677,13 @@ SlangResult GLRenderer::initialize(const Desc& desc, void* inWindowHandle)
 
     auto renderer = glGetString(GL_RENDERER);
 
-    if (renderer && desc.adapter.Length() > 0)
+    if (renderer && desc.adapter.getLength() > 0)
     {
-        String lowerAdapter = desc.adapter.ToLower();
-        String lowerRenderer = String((const char*)renderer).ToLower();
+        String lowerAdapter = desc.adapter.toLower();
+        String lowerRenderer = String((const char*)renderer).toLower();
 
         // The adapter is not available
-        if (lowerRenderer.IndexOf(lowerAdapter) == Index(-1))
+        if (lowerRenderer.indexOf(lowerAdapter) == Index(-1))
         {
             return SLANG_E_NOT_AVAILABLE;
         }

--- a/tools/gfx/render-gl.cpp
+++ b/tools/gfx/render-gl.cpp
@@ -1329,7 +1329,7 @@ Result GLRenderer::createDescriptorSetLayout(const DescriptorSetLayout::Desc& de
         rangeInfo.arrayIndex = counts[int(glSlotType)];
         counts[int(glSlotType)] += rangeDesc.count;
 
-        layoutImpl->m_ranges.Add(rangeInfo);
+        layoutImpl->m_ranges.add(rangeInfo);
     }
 
     for( Int ii = 0; ii < int(GLDescriptorSlotType::CountOf); ++ii )
@@ -1362,7 +1362,7 @@ Result GLRenderer::createPipelineLayout(const PipelineLayout::Desc& desc, Pipeli
             counts[ii] += setLayout->m_counts[ii];
         }
 
-        layoutImpl->m_sets.Add(setInfo);
+        layoutImpl->m_sets.add(setInfo);
     }
 
     *outLayout = layoutImpl.detach();

--- a/tools/gfx/render-vk.cpp
+++ b/tools/gfx/render-vk.cpp
@@ -956,7 +956,7 @@ SlangResult VKRenderer::initialize(const Desc& desc, void* inWindowHandle)
 
         String lowerAdapter = desc.adapter.ToLower();
 
-        for (int i = 0; i < int(physicalDevices.Count()); ++i)
+        for (int i = 0; i < int(physicalDevices.getSize()); ++i)
         {
             auto physicalDevice = physicalDevices[i];
 
@@ -1056,7 +1056,7 @@ SlangResult VKRenderer::initialize(const Desc& desc, void* inWindowHandle)
 
     deviceCreateInfo.pQueueCreateInfos = &queueCreateInfo;
 
-    deviceCreateInfo.enabledExtensionCount = uint32_t(deviceExtensions.Count());
+    deviceCreateInfo.enabledExtensionCount = uint32_t(deviceExtensions.getSize());
     deviceCreateInfo.ppEnabledExtensionNames = deviceExtensions.Buffer();
 
     SLANG_VK_RETURN_ON_FAIL(m_api.vkCreateDevice(m_api.m_physicalDevice, &deviceCreateInfo, nullptr, &m_device));
@@ -1491,7 +1491,7 @@ Result VKRenderer::createTextureResource(Resource::Usage initialUsage, const Tex
         Buffer uploadBuffer;
         SLANG_RETURN_ON_FAIL(uploadBuffer.init(m_api, bufferSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT));
 
-        assert(mipSizes.Count() == numMipMaps);
+        assert(mipSizes.getSize() == numMipMaps);
 
         // Copy into upload buffer
         {
@@ -1502,7 +1502,7 @@ Result VKRenderer::createTextureResource(Resource::Usage initialUsage, const Tex
 
             for (int i = 0; i < arraySize; ++i)
             {
-                for (int j = 0; j < int(mipSizes.Count()); ++j)
+                for (int j = 0; j < int(mipSizes.getSize()); ++j)
                 {
                     const auto& mipSize = mipSizes[j];
 
@@ -1536,7 +1536,7 @@ Result VKRenderer::createTextureResource(Resource::Usage initialUsage, const Tex
             size_t srcOffset = 0;
             for (int i = 0; i < arraySize; ++i)
             {
-                for (int j = 0; j < int(mipSizes.Count()); ++j)
+                for (int j = 0; j < int(mipSizes.getSize()); ++j)
                 {
                     const auto& mipSize = mipSizes[j];
 
@@ -1960,7 +1960,7 @@ void VKRenderer::setVertexBuffers(UInt startSlot, UInt slotCount, BufferResource
 {
     {
         const UInt num = startSlot + slotCount;
-        if (num > m_boundVertexBuffers.Count())
+        if (num > m_boundVertexBuffers.getSize())
         {
             m_boundVertexBuffers.SetSize(num);
         }
@@ -2061,7 +2061,7 @@ void VKRenderer::draw(UInt vertexCount, UInt startVertex = 0)
         0, nullptr);
 
     // Bind the vertex buffer
-    if (m_boundVertexBuffers.Count() > 0 && m_boundVertexBuffers[0].m_buffer)
+    if (m_boundVertexBuffers.getSize() > 0 && m_boundVertexBuffers[0].m_buffer)
     {
         const BoundVertexBuffer& boundVertexBuffer = m_boundVertexBuffers[0];
 
@@ -2322,7 +2322,7 @@ Result VKRenderer::createDescriptorSetLayout(const DescriptorSetLayout::Desc& de
     }
 
     VkDescriptorSetLayoutCreateInfo descriptorSetLayoutInfo = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
-    descriptorSetLayoutInfo.bindingCount = uint32_t(dstBindings.Count());
+    descriptorSetLayoutInfo.bindingCount = uint32_t(dstBindings.getSize());
     descriptorSetLayoutInfo.pBindings = dstBindings.Buffer();
 
     VkDescriptorSetLayout descriptorSetLayout = VK_NULL_HANDLE;
@@ -2428,7 +2428,7 @@ void VKRenderer::DescriptorSetImpl::_setBinding(Binding::Type type, UInt range, 
 {
     SLANG_ASSERT(ptr == nullptr || _getBindingType(ptr) == type);
 
-    const int numBindings = int(m_bindings.Count());
+    const int numBindings = int(m_bindings.getSize());
     for (int i = 0; i < numBindings; ++i)
     {
         Binding& binding = m_bindings[i];
@@ -2654,7 +2654,7 @@ Result VKRenderer::createGraphicsPipelineState(const GraphicsPipelineStateDesc& 
         vertexInputInfo.vertexBindingDescriptionCount = 1;
         vertexInputInfo.pVertexBindingDescriptions = &vertexInputBindingDescription;
 
-        vertexInputInfo.vertexAttributeDescriptionCount = static_cast<uint32_t>(srcAttributeDescs.Count());
+        vertexInputInfo.vertexAttributeDescriptionCount = static_cast<uint32_t>(srcAttributeDescs.getSize());
         vertexInputInfo.pVertexAttributeDescriptions = srcAttributeDescs.Buffer();
     }
 

--- a/tools/gfx/render-vk.cpp
+++ b/tools/gfx/render-vk.cpp
@@ -862,7 +862,7 @@ VkPipelineShaderStageCreateInfo VKRenderer::compileEntryPoint(
     // will free the memory after a compile request is closed.
     size_t codeSize = dataEnd - dataBegin;
 
-	bufferOut.InsertRange(0, dataBegin, codeSize);
+	bufferOut.insertRange(0, dataBegin, codeSize);
 
     char* codeBegin = bufferOut.Buffer();
 
@@ -2441,7 +2441,7 @@ void VKRenderer::DescriptorSetImpl::_setBinding(Binding::Type type, UInt range, 
             }
             else
             {
-                m_bindings.RemoveAt(i);
+                m_bindings.removeAt(i);
             }
 
             return;

--- a/tools/gfx/render-vk.cpp
+++ b/tools/gfx/render-vk.cpp
@@ -965,7 +965,7 @@ SlangResult VKRenderer::initialize(const Desc& desc, void* inWindowHandle)
 
             String lowerName = String(basicProps.deviceName).ToLower();
 
-            if (lowerName.IndexOf(lowerAdapter) != UInt(-1))
+            if (lowerName.IndexOf(lowerAdapter) != Index(-1))
             {
                 selectedDeviceIndex = i;
                 break;
@@ -1959,14 +1959,14 @@ void VKRenderer::setPrimitiveTopology(PrimitiveTopology topology)
 void VKRenderer::setVertexBuffers(UInt startSlot, UInt slotCount, BufferResource*const* buffers, const UInt* strides, const UInt* offsets)
 {
     {
-        const UInt num = startSlot + slotCount;
+        const Index num = Index(startSlot + slotCount);
         if (num > m_boundVertexBuffers.getCount())
         {
             m_boundVertexBuffers.setCount(num);
         }
     }
 
-    for (UInt i = 0; i < slotCount; i++)
+    for (Index i = 0; i < Index(slotCount); i++)
     {
         BufferResourceImpl* buffer = static_cast<BufferResourceImpl*>(buffers[i]);
         if (buffer)

--- a/tools/gfx/render-vk.cpp
+++ b/tools/gfx/render-vk.cpp
@@ -950,11 +950,11 @@ SlangResult VKRenderer::initialize(const Desc& desc, void* inWindowHandle)
 
     int32_t selectedDeviceIndex = 0;
 
-    if (desc.adapter.Length())
+    if (desc.adapter.getLength())
     {
         selectedDeviceIndex = -1;
 
-        String lowerAdapter = desc.adapter.ToLower();
+        String lowerAdapter = desc.adapter.toLower();
 
         for (int i = 0; i < int(physicalDevices.getCount()); ++i)
         {
@@ -963,9 +963,9 @@ SlangResult VKRenderer::initialize(const Desc& desc, void* inWindowHandle)
             VkPhysicalDeviceProperties basicProps = {};
             m_api.vkGetPhysicalDeviceProperties(physicalDevice, &basicProps);
 
-            String lowerName = String(basicProps.deviceName).ToLower();
+            String lowerName = String(basicProps.deviceName).toLower();
 
-            if (lowerName.IndexOf(lowerAdapter) != Index(-1))
+            if (lowerName.indexOf(lowerAdapter) != Index(-1))
             {
                 selectedDeviceIndex = i;
                 break;

--- a/tools/gfx/render-vk.cpp
+++ b/tools/gfx/render-vk.cpp
@@ -825,7 +825,7 @@ VkBool32 VKRenderer::handleDebugMessage(VkDebugReportFlagsEXT flags, VkDebugRepo
     // Use a dynamic buffer to store
     size_t bufferSize = strlen(pMsg) + 1 + 1024;
     List<char> bufferArray;
-    bufferArray.SetSize(bufferSize);
+    bufferArray.setSize(bufferSize);
     char* buffer = bufferArray.Buffer();
 
     sprintf_s(buffer,
@@ -945,7 +945,7 @@ SlangResult VKRenderer::initialize(const Desc& desc, void* inWindowHandle)
     SLANG_VK_RETURN_ON_FAIL(m_api.vkEnumeratePhysicalDevices(instance, &numPhysicalDevices, nullptr));
 
     List<VkPhysicalDevice> physicalDevices;
-    physicalDevices.SetSize(numPhysicalDevices);
+    physicalDevices.setSize(numPhysicalDevices);
     SLANG_VK_RETURN_ON_FAIL(m_api.vkEnumeratePhysicalDevices(instance, &numPhysicalDevices, physicalDevices.Buffer()));
 
     int32_t selectedDeviceIndex = 0;
@@ -1829,7 +1829,7 @@ Result VKRenderer::createInputLayout(const InputElementDesc* elements, UInt numE
     List<VkVertexInputAttributeDescription>& dstVertexDescs = layout->m_vertexDescs;
 
     size_t vertexSize = 0;
-    dstVertexDescs.SetSize(numElements);
+    dstVertexDescs.setSize(numElements);
 
     for (UInt i = 0; i <  numElements; ++i)
     {
@@ -1887,7 +1887,7 @@ void* VKRenderer::map(BufferResource* bufferIn, MapFlavor flavor)
         case MapFlavor::HostRead:
         {
             // Make sure there is space in the read buffer
-            buffer->m_readBuffer.SetSize(bufferSize);
+            buffer->m_readBuffer.setSize(bufferSize);
 
             // create staging buffer
             Buffer staging;
@@ -1962,7 +1962,7 @@ void VKRenderer::setVertexBuffers(UInt startSlot, UInt slotCount, BufferResource
         const UInt num = startSlot + slotCount;
         if (num > m_boundVertexBuffers.getSize())
         {
-            m_boundVertexBuffers.SetSize(num);
+            m_boundVertexBuffers.setSize(num);
         }
     }
 

--- a/tools/gfx/render-vk.cpp
+++ b/tools/gfx/render-vk.cpp
@@ -825,8 +825,8 @@ VkBool32 VKRenderer::handleDebugMessage(VkDebugReportFlagsEXT flags, VkDebugRepo
     // Use a dynamic buffer to store
     size_t bufferSize = strlen(pMsg) + 1 + 1024;
     List<char> bufferArray;
-    bufferArray.setSize(bufferSize);
-    char* buffer = bufferArray.Buffer();
+    bufferArray.setCount(bufferSize);
+    char* buffer = bufferArray.getBuffer();
 
     sprintf_s(buffer,
         bufferSize,
@@ -864,7 +864,7 @@ VkPipelineShaderStageCreateInfo VKRenderer::compileEntryPoint(
 
 	bufferOut.insertRange(0, dataBegin, codeSize);
 
-    char* codeBegin = bufferOut.Buffer();
+    char* codeBegin = bufferOut.getBuffer();
 
     VkShaderModuleCreateInfo moduleCreateInfo = { VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO };
     moduleCreateInfo.pCode = (uint32_t*)codeBegin;
@@ -945,8 +945,8 @@ SlangResult VKRenderer::initialize(const Desc& desc, void* inWindowHandle)
     SLANG_VK_RETURN_ON_FAIL(m_api.vkEnumeratePhysicalDevices(instance, &numPhysicalDevices, nullptr));
 
     List<VkPhysicalDevice> physicalDevices;
-    physicalDevices.setSize(numPhysicalDevices);
-    SLANG_VK_RETURN_ON_FAIL(m_api.vkEnumeratePhysicalDevices(instance, &numPhysicalDevices, physicalDevices.Buffer()));
+    physicalDevices.setCount(numPhysicalDevices);
+    SLANG_VK_RETURN_ON_FAIL(m_api.vkEnumeratePhysicalDevices(instance, &numPhysicalDevices, physicalDevices.getBuffer()));
 
     int32_t selectedDeviceIndex = 0;
 
@@ -956,7 +956,7 @@ SlangResult VKRenderer::initialize(const Desc& desc, void* inWindowHandle)
 
         String lowerAdapter = desc.adapter.ToLower();
 
-        for (int i = 0; i < int(physicalDevices.getSize()); ++i)
+        for (int i = 0; i < int(physicalDevices.getCount()); ++i)
         {
             auto physicalDevice = physicalDevices[i];
 
@@ -1056,8 +1056,8 @@ SlangResult VKRenderer::initialize(const Desc& desc, void* inWindowHandle)
 
     deviceCreateInfo.pQueueCreateInfos = &queueCreateInfo;
 
-    deviceCreateInfo.enabledExtensionCount = uint32_t(deviceExtensions.getSize());
-    deviceCreateInfo.ppEnabledExtensionNames = deviceExtensions.Buffer();
+    deviceCreateInfo.enabledExtensionCount = uint32_t(deviceExtensions.getCount());
+    deviceCreateInfo.ppEnabledExtensionNames = deviceExtensions.getBuffer();
 
     SLANG_VK_RETURN_ON_FAIL(m_api.vkCreateDevice(m_api.m_physicalDevice, &deviceCreateInfo, nullptr, &m_device));
     SLANG_RETURN_ON_FAIL(m_api.initDeviceProcs(m_device));
@@ -1491,7 +1491,7 @@ Result VKRenderer::createTextureResource(Resource::Usage initialUsage, const Tex
         Buffer uploadBuffer;
         SLANG_RETURN_ON_FAIL(uploadBuffer.init(m_api, bufferSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT));
 
-        assert(mipSizes.getSize() == numMipMaps);
+        assert(mipSizes.getCount() == numMipMaps);
 
         // Copy into upload buffer
         {
@@ -1502,7 +1502,7 @@ Result VKRenderer::createTextureResource(Resource::Usage initialUsage, const Tex
 
             for (int i = 0; i < arraySize; ++i)
             {
-                for (int j = 0; j < int(mipSizes.getSize()); ++j)
+                for (int j = 0; j < int(mipSizes.getCount()); ++j)
                 {
                     const auto& mipSize = mipSizes[j];
 
@@ -1536,7 +1536,7 @@ Result VKRenderer::createTextureResource(Resource::Usage initialUsage, const Tex
             size_t srcOffset = 0;
             for (int i = 0; i < arraySize; ++i)
             {
-                for (int j = 0; j < int(mipSizes.getSize()); ++j)
+                for (int j = 0; j < int(mipSizes.getCount()); ++j)
                 {
                     const auto& mipSize = mipSizes[j];
 
@@ -1829,7 +1829,7 @@ Result VKRenderer::createInputLayout(const InputElementDesc* elements, UInt numE
     List<VkVertexInputAttributeDescription>& dstVertexDescs = layout->m_vertexDescs;
 
     size_t vertexSize = 0;
-    dstVertexDescs.setSize(numElements);
+    dstVertexDescs.setCount(numElements);
 
     for (UInt i = 0; i <  numElements; ++i)
     {
@@ -1887,7 +1887,7 @@ void* VKRenderer::map(BufferResource* bufferIn, MapFlavor flavor)
         case MapFlavor::HostRead:
         {
             // Make sure there is space in the read buffer
-            buffer->m_readBuffer.setSize(bufferSize);
+            buffer->m_readBuffer.setCount(bufferSize);
 
             // create staging buffer
             Buffer staging;
@@ -1907,12 +1907,12 @@ void* VKRenderer::map(BufferResource* bufferIn, MapFlavor flavor)
             void* mappedData = nullptr;
             SLANG_VK_CHECK(m_api.vkMapMemory(m_device, staging.m_memory, 0, bufferSize, 0, &mappedData));
 
-            ::memcpy(buffer->m_readBuffer.Buffer(), mappedData, bufferSize);
+            ::memcpy(buffer->m_readBuffer.getBuffer(), mappedData, bufferSize);
             m_api.vkUnmapMemory(m_device, staging.m_memory);
 
             buffer->m_mapFlavor = flavor;
 
-            return buffer->m_readBuffer.Buffer();
+            return buffer->m_readBuffer.getBuffer();
         }
         default:
             return nullptr;
@@ -1960,9 +1960,9 @@ void VKRenderer::setVertexBuffers(UInt startSlot, UInt slotCount, BufferResource
 {
     {
         const UInt num = startSlot + slotCount;
-        if (num > m_boundVertexBuffers.getSize())
+        if (num > m_boundVertexBuffers.getCount())
         {
-            m_boundVertexBuffers.setSize(num);
+            m_boundVertexBuffers.setCount(num);
         }
     }
 
@@ -2061,7 +2061,7 @@ void VKRenderer::draw(UInt vertexCount, UInt startVertex = 0)
         0, nullptr);
 
     // Bind the vertex buffer
-    if (m_boundVertexBuffers.getSize() > 0 && m_boundVertexBuffers[0].m_buffer)
+    if (m_boundVertexBuffers.getCount() > 0 && m_boundVertexBuffers[0].m_buffer)
     {
         const BoundVertexBuffer& boundVertexBuffer = m_boundVertexBuffers[0];
 
@@ -2322,8 +2322,8 @@ Result VKRenderer::createDescriptorSetLayout(const DescriptorSetLayout::Desc& de
     }
 
     VkDescriptorSetLayoutCreateInfo descriptorSetLayoutInfo = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
-    descriptorSetLayoutInfo.bindingCount = uint32_t(dstBindings.getSize());
-    descriptorSetLayoutInfo.pBindings = dstBindings.Buffer();
+    descriptorSetLayoutInfo.bindingCount = uint32_t(dstBindings.getCount());
+    descriptorSetLayoutInfo.pBindings = dstBindings.getBuffer();
 
     VkDescriptorSetLayout descriptorSetLayout = VK_NULL_HANDLE;
     SLANG_VK_CHECK(m_api.vkCreateDescriptorSetLayout(m_device, &descriptorSetLayoutInfo, nullptr, &descriptorSetLayout));
@@ -2428,7 +2428,7 @@ void VKRenderer::DescriptorSetImpl::_setBinding(Binding::Type type, UInt range, 
 {
     SLANG_ASSERT(ptr == nullptr || _getBindingType(ptr) == type);
 
-    const int numBindings = int(m_bindings.getSize());
+    const int numBindings = int(m_bindings.getCount());
     for (int i = 0; i < numBindings; ++i)
     {
         Binding& binding = m_bindings[i];
@@ -2654,8 +2654,8 @@ Result VKRenderer::createGraphicsPipelineState(const GraphicsPipelineStateDesc& 
         vertexInputInfo.vertexBindingDescriptionCount = 1;
         vertexInputInfo.pVertexBindingDescriptions = &vertexInputBindingDescription;
 
-        vertexInputInfo.vertexAttributeDescriptionCount = static_cast<uint32_t>(srcAttributeDescs.getSize());
-        vertexInputInfo.pVertexAttributeDescriptions = srcAttributeDescs.Buffer();
+        vertexInputInfo.vertexAttributeDescriptionCount = static_cast<uint32_t>(srcAttributeDescs.getCount());
+        vertexInputInfo.pVertexAttributeDescriptions = srcAttributeDescs.getBuffer();
     }
 
     VkPipelineInputAssemblyStateCreateInfo inputAssembly = {};

--- a/tools/gfx/render-vk.cpp
+++ b/tools/gfx/render-vk.cpp
@@ -981,7 +981,7 @@ SlangResult VKRenderer::initialize(const Desc& desc, void* inWindowHandle)
     SLANG_RETURN_ON_FAIL(m_api.initPhysicalDevice(physicalDevices[selectedDeviceIndex]));
 
     List<const char*> deviceExtensions;
-    deviceExtensions.Add(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+    deviceExtensions.add(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
 
     VkDeviceCreateInfo deviceCreateInfo = { VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };
     deviceCreateInfo.queueCreateInfoCount = 1;
@@ -1038,10 +1038,10 @@ SlangResult VKRenderer::initialize(const Desc& desc, void* inWindowHandle)
             deviceCreateInfo.pNext = &float16Features;
 
             // Add the Float16 extension
-            deviceExtensions.Add(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
+            deviceExtensions.add(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
 
             // We have half support
-            m_features.Add("half");
+            m_features.add("half");
         }   
     }
 
@@ -1479,7 +1479,7 @@ Result VKRenderer::createTextureResource(Resource::Usage initialUsage, const Tex
             const int rowSizeInBytes = Surface::calcRowSize(desc.format, mipSize.width);
             const int numRows =  Surface::calcNumRows(desc.format, mipSize.height);
 
-            mipSizes.Add(mipSize);
+            mipSizes.add(mipSize);
 
             bufferSize += (rowSizeInBytes * numRows) * mipSize.depth;
         }
@@ -2314,11 +2314,11 @@ Result VKRenderer::createDescriptorSetLayout(const DescriptorSetLayout::Desc& de
 
         descriptorCountForTypes[dstDescriptorType] += uint32_t(srcRange.count);
 
-        dstBindings.Add(dstBinding);
+        dstBindings.add(dstBinding);
 
         DescriptorSetLayoutImpl::RangeInfo rangeInfo;
         rangeInfo.descriptorType = dstDescriptorType;
-        descriptorSetLayoutImpl->m_ranges.Add(rangeInfo);
+        descriptorSetLayoutImpl->m_ranges.add(rangeInfo);
     }
 
     VkDescriptorSetLayoutCreateInfo descriptorSetLayoutInfo = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
@@ -2457,7 +2457,7 @@ void VKRenderer::DescriptorSetImpl::_setBinding(Binding::Type type, UInt range, 
         binding.index = uint32_t(index);
         binding.obj = ptr;
 
-        m_bindings.Add(binding);
+        m_bindings.add(binding);
     }
 }
 

--- a/tools/gfx/render-vk.cpp
+++ b/tools/gfx/render-vk.cpp
@@ -619,7 +619,7 @@ Slang::Result VKRenderer::_createPipeline(RefPtr<Pipeline>& pipelineOut)
             vertexInputInfo.pVertexBindingDescriptions = &vertexInputBindingDescription;
 
             vertexInputInfo.vertexAttributeDescriptionCount = static_cast<uint32_t>(srcAttributeDescs.Count());
-            vertexInputInfo.pVertexAttributeDescriptions = srcAttributeDescs.Buffer();
+            vertexInputInfo.pVertexAttributeDescriptions = srcAttributeDescs.getBuffer();
         }
 
         //

--- a/tools/gfx/render-vk.cpp
+++ b/tools/gfx/render-vk.cpp
@@ -948,7 +948,7 @@ SlangResult VKRenderer::initialize(const Desc& desc, void* inWindowHandle)
     physicalDevices.setCount(numPhysicalDevices);
     SLANG_VK_RETURN_ON_FAIL(m_api.vkEnumeratePhysicalDevices(instance, &numPhysicalDevices, physicalDevices.getBuffer()));
 
-    int32_t selectedDeviceIndex = 0;
+    Index selectedDeviceIndex = 0;
 
     if (desc.adapter.getLength())
     {
@@ -956,7 +956,7 @@ SlangResult VKRenderer::initialize(const Desc& desc, void* inWindowHandle)
 
         String lowerAdapter = desc.adapter.toLower();
 
-        for (int i = 0; i < int(physicalDevices.getCount()); ++i)
+        for (Index i = 0; i < physicalDevices.getCount(); ++i)
         {
             auto physicalDevice = physicalDevices[i];
 
@@ -1502,7 +1502,7 @@ Result VKRenderer::createTextureResource(Resource::Usage initialUsage, const Tex
 
             for (int i = 0; i < arraySize; ++i)
             {
-                for (int j = 0; j < int(mipSizes.getCount()); ++j)
+                for (Index j = 0; j < mipSizes.getCount(); ++j)
                 {
                     const auto& mipSize = mipSizes[j];
 
@@ -1536,7 +1536,7 @@ Result VKRenderer::createTextureResource(Resource::Usage initialUsage, const Tex
             size_t srcOffset = 0;
             for (int i = 0; i < arraySize; ++i)
             {
-                for (int j = 0; j < int(mipSizes.getCount()); ++j)
+                for (Index j = 0; j < mipSizes.getCount(); ++j)
                 {
                     const auto& mipSize = mipSizes[j];
 
@@ -1555,7 +1555,7 @@ Result VKRenderer::createTextureResource(Resource::Usage initialUsage, const Tex
                     region.bufferImageHeight = 0;
 
                     region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-                    region.imageSubresource.mipLevel = j;
+                    region.imageSubresource.mipLevel = uint32_t(j);
                     region.imageSubresource.baseArrayLayer = i;
                     region.imageSubresource.layerCount = 1;
                     region.imageOffset = { 0, 0, 0 };
@@ -2428,8 +2428,8 @@ void VKRenderer::DescriptorSetImpl::_setBinding(Binding::Type type, UInt range, 
 {
     SLANG_ASSERT(ptr == nullptr || _getBindingType(ptr) == type);
 
-    const int numBindings = int(m_bindings.getCount());
-    for (int i = 0; i < numBindings; ++i)
+    const Index numBindings = m_bindings.getCount();
+    for (Index i = 0; i < numBindings; ++i)
     {
         Binding& binding = m_bindings[i];
 

--- a/tools/gfx/render.h
+++ b/tools/gfx/render.h
@@ -788,7 +788,7 @@ public:
 
     virtual SlangResult initialize(const Desc& desc, void* inWindowHandle) = 0;
 
-    bool hasFeature(const Slang::UnownedStringSlice& feature) { return getFeatures().IndexOf(Slang::String(feature)) != UInt(-1); }
+    bool hasFeature(const Slang::UnownedStringSlice& feature) { return getFeatures().indexOf(Slang::String(feature)) != UInt(-1); }
     virtual const Slang::List<Slang::String>& getFeatures() = 0;
 
     virtual void setClearColor(const float color[4]) = 0;

--- a/tools/gfx/render.h
+++ b/tools/gfx/render.h
@@ -788,7 +788,7 @@ public:
 
     virtual SlangResult initialize(const Desc& desc, void* inWindowHandle) = 0;
 
-    bool hasFeature(const Slang::UnownedStringSlice& feature) { return getFeatures().indexOf(Slang::String(feature)) != UInt(-1); }
+    bool hasFeature(const Slang::UnownedStringSlice& feature) { return getFeatures().indexOf(Slang::String(feature)) != Slang::Index(-1); }
     virtual const Slang::List<Slang::String>& getFeatures() = 0;
 
     virtual void setClearColor(const float color[4]) = 0;

--- a/tools/gfx/resource-d3d12.cpp
+++ b/tools/gfx/resource-d3d12.cpp
@@ -1,4 +1,4 @@
-﻿// resource-d3d12.cpp
+// resource-d3d12.cpp
 #include "resource-d3d12.h"
 
 namespace gfx {
@@ -135,7 +135,7 @@ void D3D12CounterFence::nextSignalAndWait(ID3D12CommandQueue* commandQueue)
 	{
 		size_t len = ::strlen(name);
 		List<wchar_t> buf;
-		buf.SetSize(len + 1);
+		buf.setSize(len + 1);
 
 		D3DUtil::appendWideChars(name, buf);
 		resource->SetName(buf.begin());

--- a/tools/gfx/resource-d3d12.cpp
+++ b/tools/gfx/resource-d3d12.cpp
@@ -135,7 +135,7 @@ void D3D12CounterFence::nextSignalAndWait(ID3D12CommandQueue* commandQueue)
 	{
 		size_t len = ::strlen(name);
 		List<wchar_t> buf;
-		buf.setSize(len + 1);
+		buf.setCount(len + 1);
 
 		D3DUtil::appendWideChars(name, buf);
 		resource->SetName(buf.begin());

--- a/tools/gfx/surface.cpp
+++ b/tools/gfx/surface.cpp
@@ -174,8 +174,8 @@ void Surface::flipInplaceVertically()
     uint8_t* bottom = m_data + (m_numRows - 1) * m_rowStrideInBytes;
 
     List<uint8_t> bufferList;
-    bufferList.setSize(rowSizeInBytes);
-    uint8_t* buffer = bufferList.Buffer();
+    bufferList.setCount(rowSizeInBytes);
+    uint8_t* buffer = bufferList.getBuffer();
 
     const int stride = m_rowStrideInBytes;
 

--- a/tools/gfx/surface.cpp
+++ b/tools/gfx/surface.cpp
@@ -1,4 +1,4 @@
-﻿// surface.cpp
+// surface.cpp
 #include "surface.h"
 
 #include <stdlib.h>
@@ -174,7 +174,7 @@ void Surface::flipInplaceVertically()
     uint8_t* bottom = m_data + (m_numRows - 1) * m_rowStrideInBytes;
 
     List<uint8_t> bufferList;
-    bufferList.SetSize(rowSizeInBytes);
+    bufferList.setSize(rowSizeInBytes);
     uint8_t* buffer = bufferList.Buffer();
 
     const int stride = m_rowStrideInBytes;

--- a/tools/gfx/vk-api.cpp
+++ b/tools/gfx/vk-api.cpp
@@ -121,8 +121,8 @@ int VulkanApi::findQueue(VkQueueFlags reqFlags) const
     vkGetPhysicalDeviceQueueFamilyProperties(m_physicalDevice, &numQueueFamilies, nullptr);
 
     Slang::List<VkQueueFamilyProperties> queueFamilies;
-    queueFamilies.setSize(numQueueFamilies);
-    vkGetPhysicalDeviceQueueFamilyProperties(m_physicalDevice, &numQueueFamilies, queueFamilies.Buffer());
+    queueFamilies.setCount(numQueueFamilies);
+    vkGetPhysicalDeviceQueueFamilyProperties(m_physicalDevice, &numQueueFamilies, queueFamilies.getBuffer());
 
     // Find a queue that can service our needs
     //VkQueueFlags reqQueueFlags = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT;

--- a/tools/gfx/vk-api.cpp
+++ b/tools/gfx/vk-api.cpp
@@ -121,7 +121,7 @@ int VulkanApi::findQueue(VkQueueFlags reqFlags) const
     vkGetPhysicalDeviceQueueFamilyProperties(m_physicalDevice, &numQueueFamilies, nullptr);
 
     Slang::List<VkQueueFamilyProperties> queueFamilies;
-    queueFamilies.SetSize(numQueueFamilies);
+    queueFamilies.setSize(numQueueFamilies);
     vkGetPhysicalDeviceQueueFamilyProperties(m_physicalDevice, &numQueueFamilies, queueFamilies.Buffer());
 
     // Find a queue that can service our needs

--- a/tools/gfx/vk-swap-chain.cpp
+++ b/tools/gfx/vk-swap-chain.cpp
@@ -13,10 +13,10 @@ using namespace Slang;
 
 static int _indexOf(List<VkSurfaceFormatKHR>& formatsIn, VkFormat format)
 {
-    const int numFormats = int(formatsIn.getCount());
+    const Index numFormats = formatsIn.getCount();
     const VkSurfaceFormatKHR* formats = formatsIn.getBuffer();
 
-    for (int i = 0; i < numFormats; ++i)
+    for (Index i = 0; i < numFormats; ++i)
     {
         if (formats[i].format == format)
         {
@@ -78,7 +78,7 @@ SlangResult VulkanSwapChain::init(VulkanDeviceQueue* deviceQueue, const Desc& de
         formats.add(VK_FORMAT_B8G8R8A8_UNORM);
     }
 
-    for(int i = 0; i < int(formats.getCount()); ++i)
+    for(Index i = 0; i < formats.getCount(); ++i)
     {
         VkFormat format = formats[i];
         if (_indexOf(surfaceFormats, format) >= 0)
@@ -125,7 +125,7 @@ SlangResult VulkanSwapChain::_createFrameBuffers(VkRenderPass renderPass)
 {
     assert(renderPass != VK_NULL_HANDLE);
 
-    for (int i = 0; i < int(m_images.getCount()); ++i)
+    for (Index i = 0; i < m_images.getCount(); ++i)
     {
         Image& image = m_images[i];
         VkImageView attachments[] =
@@ -150,7 +150,7 @@ SlangResult VulkanSwapChain::_createFrameBuffers(VkRenderPass renderPass)
 
 void VulkanSwapChain::_destroyFrameBuffers()
 {
-    for (int i = 0; i < int(m_images.getCount()); ++i)
+    for (Index i = 0; i < m_images.getCount(); ++i)
     {
         Image& image = m_images[i];
         if (image.m_frameBuffer != VK_NULL_HANDLE)
@@ -328,7 +328,7 @@ void VulkanSwapChain::_destroySwapChain()
         _destroyFrameBuffers();
     }
 
-    for (int i = 0; i < int(m_images.getCount()); ++i)
+    for (Index i = 0; i < m_images.getCount(); ++i)
     {
         Image& image = m_images[i];
 

--- a/tools/gfx/vk-swap-chain.cpp
+++ b/tools/gfx/vk-swap-chain.cpp
@@ -71,11 +71,11 @@ SlangResult VulkanSwapChain::init(VulkanDeviceQueue* deviceQueue, const Desc& de
 
     // Look for a suitable format
     List<VkFormat> formats;
-    formats.Add(VulkanUtil::getVkFormat(desc.m_format));
+    formats.add(VulkanUtil::getVkFormat(desc.m_format));
     // HACK! To check for a different format if couldn't be found
     if (descIn.m_format == Format::RGBA_Unorm_UInt8)
     {
-        formats.Add(VK_FORMAT_B8G8R8A8_UNORM);
+        formats.add(VK_FORMAT_B8G8R8A8_UNORM);
     }
 
     for(int i = 0; i < int(formats.getSize()); ++i)

--- a/tools/gfx/vk-swap-chain.cpp
+++ b/tools/gfx/vk-swap-chain.cpp
@@ -345,7 +345,7 @@ void VulkanSwapChain::_destroySwapChain()
     }
 
     // Mark that it is no longer used
-    m_images.Clear();
+    m_images.clear();
 }
 
 VulkanSwapChain::~VulkanSwapChain()

--- a/tools/gfx/vk-swap-chain.cpp
+++ b/tools/gfx/vk-swap-chain.cpp
@@ -13,8 +13,8 @@ using namespace Slang;
 
 static int _indexOf(List<VkSurfaceFormatKHR>& formatsIn, VkFormat format)
 {
-    const int numFormats = int(formatsIn.getSize());
-    const VkSurfaceFormatKHR* formats = formatsIn.Buffer();
+    const int numFormats = int(formatsIn.getCount());
+    const VkSurfaceFormatKHR* formats = formatsIn.getBuffer();
 
     for (int i = 0; i < numFormats; ++i)
     {
@@ -66,8 +66,8 @@ SlangResult VulkanSwapChain::init(VulkanDeviceQueue* deviceQueue, const Desc& de
     uint32_t numSurfaceFormats = 0;
     List<VkSurfaceFormatKHR> surfaceFormats;
     m_api->vkGetPhysicalDeviceSurfaceFormatsKHR(m_api->m_physicalDevice, m_surface, &numSurfaceFormats, nullptr);
-    surfaceFormats.setSize(int(numSurfaceFormats));
-    m_api->vkGetPhysicalDeviceSurfaceFormatsKHR(m_api->m_physicalDevice, m_surface, &numSurfaceFormats, surfaceFormats.Buffer());
+    surfaceFormats.setCount(int(numSurfaceFormats));
+    m_api->vkGetPhysicalDeviceSurfaceFormatsKHR(m_api->m_physicalDevice, m_surface, &numSurfaceFormats, surfaceFormats.getBuffer());
 
     // Look for a suitable format
     List<VkFormat> formats;
@@ -78,7 +78,7 @@ SlangResult VulkanSwapChain::init(VulkanDeviceQueue* deviceQueue, const Desc& de
         formats.add(VK_FORMAT_B8G8R8A8_UNORM);
     }
 
-    for(int i = 0; i < int(formats.getSize()); ++i)
+    for(int i = 0; i < int(formats.getCount()); ++i)
     {
         VkFormat format = formats[i];
         if (_indexOf(surfaceFormats, format) >= 0)
@@ -125,7 +125,7 @@ SlangResult VulkanSwapChain::_createFrameBuffers(VkRenderPass renderPass)
 {
     assert(renderPass != VK_NULL_HANDLE);
 
-    for (int i = 0; i < int(m_images.getSize()); ++i)
+    for (int i = 0; i < int(m_images.getCount()); ++i)
     {
         Image& image = m_images[i];
         VkImageView attachments[] =
@@ -150,7 +150,7 @@ SlangResult VulkanSwapChain::_createFrameBuffers(VkRenderPass renderPass)
 
 void VulkanSwapChain::_destroyFrameBuffers()
 {
-    for (int i = 0; i < int(m_images.getSize()); ++i)
+    for (int i = 0; i < int(m_images.getCount()); ++i)
     {
         Image& image = m_images[i];
         if (image.m_frameBuffer != VK_NULL_HANDLE)
@@ -209,8 +209,8 @@ SlangResult VulkanSwapChain::_createSwapChain()
     List<VkPresentModeKHR> presentModes;
     uint32_t numPresentModes = 0;
     m_api->vkGetPhysicalDeviceSurfacePresentModesKHR(m_api->m_physicalDevice, m_surface, &numPresentModes, nullptr);
-    presentModes.setSize(numPresentModes);
-    m_api->vkGetPhysicalDeviceSurfacePresentModesKHR(m_api->m_physicalDevice, m_surface, &numPresentModes, presentModes.Buffer());
+    presentModes.setCount(numPresentModes);
+    m_api->vkGetPhysicalDeviceSurfacePresentModesKHR(m_api->m_physicalDevice, m_surface, &numPresentModes, presentModes.getBuffer());
 
     {
         int numCheckPresentOptions = 3;
@@ -265,11 +265,11 @@ SlangResult VulkanSwapChain::_createSwapChain()
 
     {
         List<VkImage> images;
-        images.setSize(numSwapChainImages);
+        images.setCount(numSwapChainImages);
 
-        m_api->vkGetSwapchainImagesKHR(m_api->m_device, m_swapChain, &numSwapChainImages, images.Buffer());
+        m_api->vkGetSwapchainImagesKHR(m_api->m_device, m_swapChain, &numSwapChainImages, images.getBuffer());
 
-        m_images.setSize(numSwapChainImages);
+        m_images.setCount(numSwapChainImages);
         for (int i = 0; i < int(numSwapChainImages); ++i)
         {
             Image& dstImage = m_images[i];
@@ -328,7 +328,7 @@ void VulkanSwapChain::_destroySwapChain()
         _destroyFrameBuffers();
     }
 
-    for (int i = 0; i < int(m_images.getSize()); ++i)
+    for (int i = 0; i < int(m_images.getCount()); ++i)
     {
         Image& image = m_images[i];
 

--- a/tools/gfx/vk-swap-chain.cpp
+++ b/tools/gfx/vk-swap-chain.cpp
@@ -227,7 +227,7 @@ SlangResult VulkanSwapChain::_createSwapChain()
         // Find the first option that's available on the device
         for (int j = 0; j < numCheckPresentOptions; j++)
         {
-            if (presentModes.IndexOf(presentOptions[j]) != UInt(-1))
+            if (presentModes.indexOf(presentOptions[j]) != UInt(-1))
             {
                 m_presentMode = presentOptions[j];
                 break;

--- a/tools/gfx/vk-swap-chain.cpp
+++ b/tools/gfx/vk-swap-chain.cpp
@@ -227,7 +227,7 @@ SlangResult VulkanSwapChain::_createSwapChain()
         // Find the first option that's available on the device
         for (int j = 0; j < numCheckPresentOptions; j++)
         {
-            if (presentModes.indexOf(presentOptions[j]) != UInt(-1))
+            if (presentModes.indexOf(presentOptions[j]) != Index(-1))
             {
                 m_presentMode = presentOptions[j];
                 break;

--- a/tools/gfx/vk-swap-chain.cpp
+++ b/tools/gfx/vk-swap-chain.cpp
@@ -13,7 +13,7 @@ using namespace Slang;
 
 static int _indexOf(List<VkSurfaceFormatKHR>& formatsIn, VkFormat format)
 {
-    const int numFormats = int(formatsIn.Count());
+    const int numFormats = int(formatsIn.getSize());
     const VkSurfaceFormatKHR* formats = formatsIn.Buffer();
 
     for (int i = 0; i < numFormats; ++i)
@@ -78,7 +78,7 @@ SlangResult VulkanSwapChain::init(VulkanDeviceQueue* deviceQueue, const Desc& de
         formats.Add(VK_FORMAT_B8G8R8A8_UNORM);
     }
 
-    for(int i = 0; i < int(formats.Count()); ++i)
+    for(int i = 0; i < int(formats.getSize()); ++i)
     {
         VkFormat format = formats[i];
         if (_indexOf(surfaceFormats, format) >= 0)
@@ -125,7 +125,7 @@ SlangResult VulkanSwapChain::_createFrameBuffers(VkRenderPass renderPass)
 {
     assert(renderPass != VK_NULL_HANDLE);
 
-    for (int i = 0; i < int(m_images.Count()); ++i)
+    for (int i = 0; i < int(m_images.getSize()); ++i)
     {
         Image& image = m_images[i];
         VkImageView attachments[] =
@@ -150,7 +150,7 @@ SlangResult VulkanSwapChain::_createFrameBuffers(VkRenderPass renderPass)
 
 void VulkanSwapChain::_destroyFrameBuffers()
 {
-    for (int i = 0; i < int(m_images.Count()); ++i)
+    for (int i = 0; i < int(m_images.getSize()); ++i)
     {
         Image& image = m_images[i];
         if (image.m_frameBuffer != VK_NULL_HANDLE)
@@ -328,7 +328,7 @@ void VulkanSwapChain::_destroySwapChain()
         _destroyFrameBuffers();
     }
 
-    for (int i = 0; i < int(m_images.Count()); ++i)
+    for (int i = 0; i < int(m_images.getSize()); ++i)
     {
         Image& image = m_images[i];
 

--- a/tools/gfx/vk-swap-chain.cpp
+++ b/tools/gfx/vk-swap-chain.cpp
@@ -66,7 +66,7 @@ SlangResult VulkanSwapChain::init(VulkanDeviceQueue* deviceQueue, const Desc& de
     uint32_t numSurfaceFormats = 0;
     List<VkSurfaceFormatKHR> surfaceFormats;
     m_api->vkGetPhysicalDeviceSurfaceFormatsKHR(m_api->m_physicalDevice, m_surface, &numSurfaceFormats, nullptr);
-    surfaceFormats.SetSize(int(numSurfaceFormats));
+    surfaceFormats.setSize(int(numSurfaceFormats));
     m_api->vkGetPhysicalDeviceSurfaceFormatsKHR(m_api->m_physicalDevice, m_surface, &numSurfaceFormats, surfaceFormats.Buffer());
 
     // Look for a suitable format
@@ -209,7 +209,7 @@ SlangResult VulkanSwapChain::_createSwapChain()
     List<VkPresentModeKHR> presentModes;
     uint32_t numPresentModes = 0;
     m_api->vkGetPhysicalDeviceSurfacePresentModesKHR(m_api->m_physicalDevice, m_surface, &numPresentModes, nullptr);
-    presentModes.SetSize(numPresentModes);
+    presentModes.setSize(numPresentModes);
     m_api->vkGetPhysicalDeviceSurfacePresentModesKHR(m_api->m_physicalDevice, m_surface, &numPresentModes, presentModes.Buffer());
 
     {
@@ -265,11 +265,11 @@ SlangResult VulkanSwapChain::_createSwapChain()
 
     {
         List<VkImage> images;
-        images.SetSize(numSwapChainImages);
+        images.setSize(numSwapChainImages);
 
         m_api->vkGetSwapchainImagesKHR(m_api->m_device, m_swapChain, &numSwapChainImages, images.Buffer());
 
-        m_images.SetSize(numSwapChainImages);
+        m_images.setSize(numSwapChainImages);
         for (int i = 0; i < int(numSwapChainImages); ++i)
         {
             Image& dstImage = m_images[i];

--- a/tools/gfx/vk-swap-chain.h
+++ b/tools/gfx/vk-swap-chain.h
@@ -72,7 +72,7 @@ struct VulkanSwapChain
     const Desc& getDesc() const { return m_desc; }
 
         /// True if the swap chain is available
-    bool hasValidSwapChain() const { return m_images.Count() > 0; }
+    bool hasValidSwapChain() const { return m_images.getSize() > 0; }
 
         /// Present to the display
     void present(bool vsync);

--- a/tools/gfx/vk-swap-chain.h
+++ b/tools/gfx/vk-swap-chain.h
@@ -105,7 +105,7 @@ struct VulkanSwapChain
     {
         const PlatformDesc* check = &desc;
         int size = (sizeof(T) + sizeof(void*) - 1) / sizeof(void*);
-        m_platformDescBuffer.SetSize(size);
+        m_platformDescBuffer.setSize(size);
         *(T*)m_platformDescBuffer.Buffer() = desc;
     }
     template <typename T>

--- a/tools/gfx/vk-swap-chain.h
+++ b/tools/gfx/vk-swap-chain.h
@@ -72,7 +72,7 @@ struct VulkanSwapChain
     const Desc& getDesc() const { return m_desc; }
 
         /// True if the swap chain is available
-    bool hasValidSwapChain() const { return m_images.getSize() > 0; }
+    bool hasValidSwapChain() const { return m_images.getCount() > 0; }
 
         /// Present to the display
     void present(bool vsync);
@@ -105,11 +105,11 @@ struct VulkanSwapChain
     {
         const PlatformDesc* check = &desc;
         int size = (sizeof(T) + sizeof(void*) - 1) / sizeof(void*);
-        m_platformDescBuffer.setSize(size);
-        *(T*)m_platformDescBuffer.Buffer() = desc;
+        m_platformDescBuffer.setCount(size);
+        *(T*)m_platformDescBuffer.getBuffer() = desc;
     }
     template <typename T>
-    const T* _getPlatformDesc() const { return static_cast<const T*>((const PlatformDesc*)m_platformDescBuffer.Buffer()); }
+    const T* _getPlatformDesc() const { return static_cast<const T*>((const PlatformDesc*)m_platformDescBuffer.getBuffer()); }
     SlangResult _createSwapChain();
     void _destroySwapChain();
     SlangResult _createFrameBuffers(VkRenderPass renderPass);

--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -200,14 +200,14 @@ SlangResult parseOptions(int argc, const char*const* argv, Slang::WriterHelper s
     gOptions.rendererType = (gOptions.rendererType == RendererType::Unknown) ? gOptions.targetLanguageRendererType : gOptions.rendererType;
 
     // first positional argument is source shader path
-    if(positionalArgs.Count())
+    if(positionalArgs.getSize())
     {
         gOptions.sourcePath = positionalArgs[0];
         positionalArgs.RemoveAt(0);
     }
 
     // any remaining arguments represent an error
-    if(positionalArgs.Count() != 0)
+    if(positionalArgs.getSize() != 0)
     {
         stdError.print("unexpected arguments\n");
         return SLANG_FAIL;

--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -200,14 +200,14 @@ SlangResult parseOptions(int argc, const char*const* argv, Slang::WriterHelper s
     gOptions.rendererType = (gOptions.rendererType == RendererType::Unknown) ? gOptions.targetLanguageRendererType : gOptions.rendererType;
 
     // first positional argument is source shader path
-    if(positionalArgs.getSize())
+    if(positionalArgs.getCount())
     {
         gOptions.sourcePath = positionalArgs[0];
         positionalArgs.removeAt(0);
     }
 
     // any remaining arguments represent an error
-    if(positionalArgs.getSize() != 0)
+    if(positionalArgs.getCount() != 0)
     {
         stdError.print("unexpected arguments\n");
         return SLANG_FAIL;

--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -203,7 +203,7 @@ SlangResult parseOptions(int argc, const char*const* argv, Slang::WriterHelper s
     if(positionalArgs.getSize())
     {
         gOptions.sourcePath = positionalArgs[0];
-        positionalArgs.RemoveAt(0);
+        positionalArgs.removeAt(0);
     }
 
     // any remaining arguments represent an error

--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -72,7 +72,7 @@ SlangResult parseOptions(int argc, const char*const* argv, Slang::WriterHelper s
         char const* arg = *argCursor++;
         if( arg[0] != '-' )
         {
-            positionalArgs.Add(arg);
+            positionalArgs.add(arg);
             continue;
         }
 
@@ -80,7 +80,7 @@ SlangResult parseOptions(int argc, const char*const* argv, Slang::WriterHelper s
         {
             while(argCursor != argEnd)
             {
-                positionalArgs.Add(*argCursor++);
+                positionalArgs.add(*argCursor++);
             }
             break;
         }
@@ -116,7 +116,7 @@ SlangResult parseOptions(int argc, const char*const* argv, Slang::WriterHelper s
 
             for (const auto& value : values)
             {
-                gOptions.renderFeatures.Add(value);
+                gOptions.renderFeatures.add(value);
             }
         }
         else if( strcmp(arg, "-xslang") == 0 )

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -568,7 +568,7 @@ SLANG_TEST_TOOL_API SlangResult innerMain(Slang::StdWriters* stdWriters, SlangSe
     {
         if (!gOptions.onlyStartup)
         {
-            fprintf(stderr, "Unable to create renderer %s\n", rendererName.Buffer());
+            fprintf(stderr, "Unable to create renderer %s\n", rendererName.getBuffer());
         }
         return SLANG_FAIL;
     }
@@ -584,7 +584,7 @@ SLANG_TEST_TOOL_API SlangResult innerMain(Slang::StdWriters* stdWriters, SlangSe
         {
             if (!gOptions.onlyStartup)
             {
-                fprintf(stderr, "Unable to initialize renderer %s\n", rendererName.Buffer());
+                fprintf(stderr, "Unable to initialize renderer %s\n", rendererName.getBuffer());
             }
             return res;
         }

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -351,7 +351,7 @@ Result RenderTestApp::initializeShaders(ShaderCompiler* shaderCompiler)
 	fseek(sourceFile, 0, SEEK_SET);
 
     List<char> sourceText;
-    sourceText.SetSize(sourceSize + 1);
+    sourceText.setSize(sourceSize + 1);
 	fread(sourceText.Buffer(), sourceSize, 1, sourceFile);
 	fclose(sourceFile);
 	sourceText[sourceSize] = 0;

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -558,7 +558,7 @@ SLANG_TEST_TOOL_API SlangResult innerMain(Slang::StdWriters* stdWriters, SlangSe
     
     StringBuilder rendererName;
     rendererName << "[" << RendererUtil::toText(gOptions.rendererType) << "] ";
-    if (gOptions.adapter.Length())
+    if (gOptions.adapter.getLength())
     {
         rendererName << "'" << gOptions.adapter << "'";
     }

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -351,8 +351,8 @@ Result RenderTestApp::initializeShaders(ShaderCompiler* shaderCompiler)
 	fseek(sourceFile, 0, SEEK_SET);
 
     List<char> sourceText;
-    sourceText.setSize(sourceSize + 1);
-	fread(sourceText.Buffer(), sourceSize, 1, sourceFile);
+    sourceText.setCount(sourceSize + 1);
+	fread(sourceText.getBuffer(), sourceSize, 1, sourceFile);
 	fclose(sourceFile);
 	sourceText[sourceSize] = 0;
 
@@ -366,12 +366,12 @@ Result RenderTestApp::initializeShaders(ShaderCompiler* shaderCompiler)
         m_shaderInputLayout.numRenderTargets = 0;
         break;
     }
-	m_shaderInputLayout.Parse(sourceText.Buffer());
+	m_shaderInputLayout.Parse(sourceText.getBuffer());
 
 	ShaderCompileRequest::SourceInfo sourceInfo;
 	sourceInfo.path = sourcePath;
-	sourceInfo.dataBegin = sourceText.Buffer();
-	sourceInfo.dataEnd = sourceText.Buffer() + sourceSize;
+	sourceInfo.dataBegin = sourceText.getBuffer();
+	sourceInfo.dataEnd = sourceText.getBuffer() + sourceSize;
 
 	ShaderCompileRequest compileRequest;
 	compileRequest.source = sourceInfo;

--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -302,12 +302,12 @@ namespace renderer_test
 
                 List<List<unsigned int>>& dstBuffer = output.dataBuffer;
 
-                int numMips = int(work.dataBuffer.Count());
+                int numMips = int(work.dataBuffer.getSize());
                 dstBuffer.SetSize(numMips);
 
                 for (int i = 0; i < numMips; ++i)
                 {
-                    const int numPixels = int(work.dataBuffer[i].Count());
+                    const int numPixels = int(work.dataBuffer[i].getSize());
                     const unsigned int* srcPixels = work.dataBuffer[i].Buffer();
 
                     dstBuffer[i].SetSize(numPixels);

--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -28,7 +28,7 @@ namespace renderer_test
                         StringBuilder typeExp;
                         while (!parser.IsEnd())
                             typeExp << parser.ReadToken().Content;
-                        entryPointGenericTypeArguments.Add(typeExp);
+                        entryPointGenericTypeArguments.add(typeExp);
                     }
                     else if (parser.LookAhead("global_type"))
                     {
@@ -36,7 +36,7 @@ namespace renderer_test
                         StringBuilder typeExp;
                         while (!parser.IsEnd())
                             typeExp << parser.ReadToken().Content;
-                        globalGenericTypeArguments.Add(typeExp);
+                        globalGenericTypeArguments.add(typeExp);
                     }
                     else if (parser.LookAhead("globalExistentialType"))
                     {
@@ -44,7 +44,7 @@ namespace renderer_test
                         StringBuilder typeExp;
                         while (!parser.IsEnd())
                             typeExp << parser.ReadToken().Content;
-                        globalExistentialTypeArguments.Add(typeExp);
+                        globalExistentialTypeArguments.add(typeExp);
                     }
                     else if (parser.LookAhead("entryPointExistentialType"))
                     {
@@ -52,7 +52,7 @@ namespace renderer_test
                         StringBuilder typeExp;
                         while (!parser.IsEnd())
                             typeExp << parser.ReadToken().Content;
-                        entryPointExistentialTypeArguments.Add(typeExp);
+                        entryPointExistentialTypeArguments.add(typeExp);
                     }
                     else
                     {
@@ -183,12 +183,12 @@ namespace renderer_test
                                     {
                                         if (parser.NextToken().Type == TokenType::IntLiteral)
                                         {
-                                            entry.bufferData.Add(parser.ReadUInt());
+                                            entry.bufferData.add(parser.ReadUInt());
                                         }
                                         else
                                         {
                                             auto floatNum = parser.ReadFloat();
-                                            entry.bufferData.Add(*(unsigned int*)&floatNum);
+                                            entry.bufferData.add(*(unsigned int*)&floatNum);
                                         }
                                     }
                                     parser.Read("]");
@@ -254,7 +254,7 @@ namespace renderer_test
                                     parser.Read("(");
                                     while (!parser.IsEnd() && !parser.LookAhead(")"))
                                     {
-                                        entry.glslBinding.Add(parser.ReadInt());
+                                        entry.glslBinding.add(parser.ReadInt());
                                         if (parser.LookAhead(","))
                                             parser.Read(",");
                                         else
@@ -271,7 +271,7 @@ namespace renderer_test
                                     parser.Read(",");
                             }
                         }
-                        entries.Add(entry);
+                        entries.add(entry);
                     }
                 }
                 catch (TextFormatException)

--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -16,9 +16,9 @@ namespace renderer_test
         auto lines = Split(source, '\n');
         for (auto & line : lines)
         {
-            if (line.StartsWith("//TEST_INPUT:"))
+            if (line.startsWith("//TEST_INPUT:"))
             {
-                auto lineContent = line.SubString(13, line.Length() - 13);
+                auto lineContent = line.subString(13, line.getLength() - 13);
                 TokenReader parser(lineContent);
                 try
                 {

--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -8,11 +8,11 @@ namespace renderer_test
     using namespace Slang;
     void ShaderInputLayout::Parse(const char * source)
     {
-        entries.Clear();
-        globalGenericTypeArguments.Clear();
-        entryPointGenericTypeArguments.Clear();
-        globalExistentialTypeArguments.Clear();
-        entryPointExistentialTypeArguments.Clear();
+        entries.clear();
+        globalGenericTypeArguments.clear();
+        entryPointGenericTypeArguments.clear();
+        globalExistentialTypeArguments.clear();
+        entryPointExistentialTypeArguments.clear();
         auto lines = Split(source, '\n');
         for (auto & line : lines)
         {

--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -302,19 +302,19 @@ namespace renderer_test
 
                 List<List<unsigned int>>& dstBuffer = output.dataBuffer;
 
-                int numMips = int(work.dataBuffer.getCount());
+                Index numMips = work.dataBuffer.getCount();
                 dstBuffer.setCount(numMips);
 
                 for (int i = 0; i < numMips; ++i)
                 {
-                    const int numPixels = int(work.dataBuffer[i].getCount());
+                    const Index numPixels = work.dataBuffer[i].getCount();
                     const unsigned int* srcPixels = work.dataBuffer[i].getBuffer();
 
                     dstBuffer[i].setCount(numPixels);
 
                     float* dstPixels = (float*)dstBuffer[i].getBuffer();
 
-                    for (int j = 0; j < numPixels; ++j)
+                    for (Index j = 0; j < numPixels; ++j)
                     {
                         // Copy out red
                         const unsigned int srcPixel = srcPixels[j];

--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -302,17 +302,17 @@ namespace renderer_test
 
                 List<List<unsigned int>>& dstBuffer = output.dataBuffer;
 
-                int numMips = int(work.dataBuffer.getSize());
-                dstBuffer.setSize(numMips);
+                int numMips = int(work.dataBuffer.getCount());
+                dstBuffer.setCount(numMips);
 
                 for (int i = 0; i < numMips; ++i)
                 {
-                    const int numPixels = int(work.dataBuffer[i].getSize());
-                    const unsigned int* srcPixels = work.dataBuffer[i].Buffer();
+                    const int numPixels = int(work.dataBuffer[i].getCount());
+                    const unsigned int* srcPixels = work.dataBuffer[i].getBuffer();
 
-                    dstBuffer[i].setSize(numPixels);
+                    dstBuffer[i].setCount(numPixels);
 
-                    float* dstPixels = (float*)dstBuffer[i].Buffer();
+                    float* dstPixels = (float*)dstBuffer[i].getBuffer();
 
                     for (int j = 0; j < numPixels; ++j)
                     {
@@ -344,7 +344,7 @@ namespace renderer_test
         output.arraySize = arraySize;
         output.textureSize = inputDesc.size;
         output.mipLevels = Math::Log2Floor(output.textureSize) + 1;
-        output.dataBuffer.setSize(output.mipLevels * output.arraySize);
+        output.dataBuffer.setCount(output.mipLevels * output.arraySize);
         auto iteratePixels = [&](int dimension, int size, unsigned int * buffer, auto f)
         {
             if (dimension == 1)
@@ -372,9 +372,9 @@ namespace renderer_test
                     bufferLen *= size;
                 else if (inputDesc.dimension == 3)
                     bufferLen *= size*size;
-                dataBuffer[slice].setSize(bufferLen);
+                dataBuffer[slice].setCount(bufferLen);
 
-                iteratePixels(inputDesc.dimension, size, dataBuffer[slice].Buffer(), [&](int x, int y, int z) -> unsigned int
+                iteratePixels(inputDesc.dimension, size, dataBuffer[slice].getBuffer(), [&](int x, int y, int z) -> unsigned int
                 {
                     if (inputDesc.content == InputTextureContent::Zero)
                     {

--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -303,14 +303,14 @@ namespace renderer_test
                 List<List<unsigned int>>& dstBuffer = output.dataBuffer;
 
                 int numMips = int(work.dataBuffer.getSize());
-                dstBuffer.SetSize(numMips);
+                dstBuffer.setSize(numMips);
 
                 for (int i = 0; i < numMips; ++i)
                 {
                     const int numPixels = int(work.dataBuffer[i].getSize());
                     const unsigned int* srcPixels = work.dataBuffer[i].Buffer();
 
-                    dstBuffer[i].SetSize(numPixels);
+                    dstBuffer[i].setSize(numPixels);
 
                     float* dstPixels = (float*)dstBuffer[i].Buffer();
 
@@ -344,7 +344,7 @@ namespace renderer_test
         output.arraySize = arraySize;
         output.textureSize = inputDesc.size;
         output.mipLevels = Math::Log2Floor(output.textureSize) + 1;
-        output.dataBuffer.SetSize(output.mipLevels * output.arraySize);
+        output.dataBuffer.setSize(output.mipLevels * output.arraySize);
         auto iteratePixels = [&](int dimension, int size, unsigned int * buffer, auto f)
         {
             if (dimension == 1)
@@ -372,7 +372,7 @@ namespace renderer_test
                     bufferLen *= size;
                 else if (inputDesc.dimension == 3)
                     bufferLen *= size*size;
-                dataBuffer[slice].SetSize(bufferLen);
+                dataBuffer[slice].setSize(bufferLen);
 
                 iteratePixels(inputDesc.dimension, size, dataBuffer[slice].Buffer(), [&](int x, int y, int z) -> unsigned int
                 {

--- a/tools/render-test/shader-renderer-util.cpp
+++ b/tools/render-test/shader-renderer-util.cpp
@@ -66,9 +66,9 @@ void BindingStateImpl::apply(Renderer* renderer, PipelineType pipelineType)
     TextureResource::Data initData;
 
     List<ptrdiff_t> mipRowStrides;
-    mipRowStrides.SetSize(textureResourceDesc.numMipLevels);
+    mipRowStrides.setSize(textureResourceDesc.numMipLevels);
     List<const void*> subResources;
-    subResources.SetSize(numSubResources);
+    subResources.setSize(numSubResources);
 
     // Set up the src row strides
     for (int i = 0; i < textureResourceDesc.numMipLevels; i++)

--- a/tools/render-test/shader-renderer-util.cpp
+++ b/tools/render-test/shader-renderer-util.cpp
@@ -80,7 +80,7 @@ void BindingStateImpl::apply(Renderer* renderer, PipelineType pipelineType)
     // Set up pointers the the data
     {
         int subResourceIndex = 0;
-        const int numGen = int(texData.dataBuffer.Count());
+        const int numGen = int(texData.dataBuffer.getSize());
         for (int i = 0; i < numSubResources; i++)
         {
             subResources[i] = texData.dataBuffer[subResourceIndex].Buffer();
@@ -175,7 +175,7 @@ static RefPtr<SamplerState> _createSamplerState(
         }
         case BindingStyle::OpenGl:
         {
-            const int count = int(entry.glslBinding.Count());
+            const int count = int(entry.glslBinding.getSize());
 
             if (count <= 0)
             {
@@ -184,7 +184,7 @@ static RefPtr<SamplerState> _createSamplerState(
 
             int baseIndex = entry.glslBinding[0];
             // Make sure they are contiguous
-            for (int i = 1; i < int(entry.glslBinding.Count()); ++i)
+            for (int i = 1; i < int(entry.glslBinding.getSize()); ++i)
             {
                 if (baseIndex + i != entry.glslBinding[i])
                 {
@@ -206,7 +206,7 @@ static RefPtr<SamplerState> _createSamplerState(
 /* static */Result ShaderRendererUtil::createBindingState(const ShaderInputLayout& layout, Renderer* renderer, BufferResource* addedConstantBuffer, BindingStateImpl** outBindingState)
 {
     auto srcEntries = layout.entries.Buffer();
-    auto numEntries = int(layout.entries.Count());
+    auto numEntries = int(layout.entries.getSize());
 
     const int textureBindFlags = Resource::BindFlag::NonPixelShaderResource | Resource::BindFlag::PixelShaderResource;
 
@@ -283,7 +283,7 @@ static RefPtr<SamplerState> _createSamplerState(
     }
 
     DescriptorSetLayout::Desc descriptorSetLayoutDesc;
-    descriptorSetLayoutDesc.slotRangeCount = slotRangeDescs.Count();
+    descriptorSetLayoutDesc.slotRangeCount = slotRangeDescs.getSize();
     descriptorSetLayoutDesc.slotRanges = slotRangeDescs.Buffer();
 
     auto descriptorSetLayout = renderer->createDescriptorSetLayout(descriptorSetLayoutDesc);
@@ -294,7 +294,7 @@ static RefPtr<SamplerState> _createSamplerState(
 
     PipelineLayout::Desc pipelineLayoutDesc;
     pipelineLayoutDesc.renderTargetCount = layout.numRenderTargets;
-    pipelineLayoutDesc.descriptorSetCount = pipelineDescriptorSets.Count();
+    pipelineLayoutDesc.descriptorSetCount = pipelineDescriptorSets.getSize();
     pipelineLayoutDesc.descriptorSets = pipelineDescriptorSets.Buffer();
 
     auto pipelineLayout = renderer->createPipelineLayout(pipelineLayoutDesc);
@@ -320,7 +320,7 @@ static RefPtr<SamplerState> _createSamplerState(
             case ShaderInputType::Buffer:
                 {
                     const InputBufferDesc& srcBuffer = srcEntry.bufferDesc;
-                    const size_t bufferSize = srcEntry.bufferData.Count() * sizeof(uint32_t);
+                    const size_t bufferSize = srcEntry.bufferData.getSize() * sizeof(uint32_t);
 
                     RefPtr<BufferResource> bufferResource;
                     SLANG_RETURN_ON_FAIL(createBufferResource(srcEntry.bufferDesc, srcEntry.isOutput, bufferSize, srcEntry.bufferData.Buffer(), renderer, bufferResource));

--- a/tools/render-test/shader-renderer-util.cpp
+++ b/tools/render-test/shader-renderer-util.cpp
@@ -66,9 +66,9 @@ void BindingStateImpl::apply(Renderer* renderer, PipelineType pipelineType)
     TextureResource::Data initData;
 
     List<ptrdiff_t> mipRowStrides;
-    mipRowStrides.setSize(textureResourceDesc.numMipLevels);
+    mipRowStrides.setCount(textureResourceDesc.numMipLevels);
     List<const void*> subResources;
-    subResources.setSize(numSubResources);
+    subResources.setCount(numSubResources);
 
     // Set up the src row strides
     for (int i = 0; i < textureResourceDesc.numMipLevels; i++)
@@ -80,19 +80,19 @@ void BindingStateImpl::apply(Renderer* renderer, PipelineType pipelineType)
     // Set up pointers the the data
     {
         int subResourceIndex = 0;
-        const int numGen = int(texData.dataBuffer.getSize());
+        const int numGen = int(texData.dataBuffer.getCount());
         for (int i = 0; i < numSubResources; i++)
         {
-            subResources[i] = texData.dataBuffer[subResourceIndex].Buffer();
+            subResources[i] = texData.dataBuffer[subResourceIndex].getBuffer();
             // Wrap around
             subResourceIndex = (subResourceIndex + 1 >= numGen) ? 0 : (subResourceIndex + 1);
         }
     }
 
-    initData.mipRowStrides = mipRowStrides.Buffer();
+    initData.mipRowStrides = mipRowStrides.getBuffer();
     initData.numMips = textureResourceDesc.numMipLevels;
     initData.numSubResources = numSubResources;
-    initData.subResources = subResources.Buffer();
+    initData.subResources = subResources.getBuffer();
 
     textureOut = renderer->createTextureResource(Resource::Usage::GenericRead, textureResourceDesc, &initData);
 
@@ -175,7 +175,7 @@ static RefPtr<SamplerState> _createSamplerState(
         }
         case BindingStyle::OpenGl:
         {
-            const int count = int(entry.glslBinding.getSize());
+            const int count = int(entry.glslBinding.getCount());
 
             if (count <= 0)
             {
@@ -184,7 +184,7 @@ static RefPtr<SamplerState> _createSamplerState(
 
             int baseIndex = entry.glslBinding[0];
             // Make sure they are contiguous
-            for (int i = 1; i < int(entry.glslBinding.getSize()); ++i)
+            for (int i = 1; i < int(entry.glslBinding.getCount()); ++i)
             {
                 if (baseIndex + i != entry.glslBinding[i])
                 {
@@ -205,8 +205,8 @@ static RefPtr<SamplerState> _createSamplerState(
 
 /* static */Result ShaderRendererUtil::createBindingState(const ShaderInputLayout& layout, Renderer* renderer, BufferResource* addedConstantBuffer, BindingStateImpl** outBindingState)
 {
-    auto srcEntries = layout.entries.Buffer();
-    auto numEntries = int(layout.entries.getSize());
+    auto srcEntries = layout.entries.getBuffer();
+    auto numEntries = int(layout.entries.getCount());
 
     const int textureBindFlags = Resource::BindFlag::NonPixelShaderResource | Resource::BindFlag::PixelShaderResource;
 
@@ -283,8 +283,8 @@ static RefPtr<SamplerState> _createSamplerState(
     }
 
     DescriptorSetLayout::Desc descriptorSetLayoutDesc;
-    descriptorSetLayoutDesc.slotRangeCount = slotRangeDescs.getSize();
-    descriptorSetLayoutDesc.slotRanges = slotRangeDescs.Buffer();
+    descriptorSetLayoutDesc.slotRangeCount = slotRangeDescs.getCount();
+    descriptorSetLayoutDesc.slotRanges = slotRangeDescs.getBuffer();
 
     auto descriptorSetLayout = renderer->createDescriptorSetLayout(descriptorSetLayoutDesc);
     if(!descriptorSetLayout) return SLANG_FAIL;
@@ -294,8 +294,8 @@ static RefPtr<SamplerState> _createSamplerState(
 
     PipelineLayout::Desc pipelineLayoutDesc;
     pipelineLayoutDesc.renderTargetCount = layout.numRenderTargets;
-    pipelineLayoutDesc.descriptorSetCount = pipelineDescriptorSets.getSize();
-    pipelineLayoutDesc.descriptorSets = pipelineDescriptorSets.Buffer();
+    pipelineLayoutDesc.descriptorSetCount = pipelineDescriptorSets.getCount();
+    pipelineLayoutDesc.descriptorSets = pipelineDescriptorSets.getBuffer();
 
     auto pipelineLayout = renderer->createPipelineLayout(pipelineLayoutDesc);
     if(!pipelineLayout) return SLANG_FAIL;
@@ -320,10 +320,10 @@ static RefPtr<SamplerState> _createSamplerState(
             case ShaderInputType::Buffer:
                 {
                     const InputBufferDesc& srcBuffer = srcEntry.bufferDesc;
-                    const size_t bufferSize = srcEntry.bufferData.getSize() * sizeof(uint32_t);
+                    const size_t bufferSize = srcEntry.bufferData.getCount() * sizeof(uint32_t);
 
                     RefPtr<BufferResource> bufferResource;
-                    SLANG_RETURN_ON_FAIL(createBufferResource(srcEntry.bufferDesc, srcEntry.isOutput, bufferSize, srcEntry.bufferData.Buffer(), renderer, bufferResource));
+                    SLANG_RETURN_ON_FAIL(createBufferResource(srcEntry.bufferDesc, srcEntry.isOutput, bufferSize, srcEntry.bufferData.getBuffer(), renderer, bufferResource));
 
                     switch(srcBuffer.type)
                     {

--- a/tools/render-test/shader-renderer-util.cpp
+++ b/tools/render-test/shader-renderer-util.cpp
@@ -184,7 +184,7 @@ static RefPtr<SamplerState> _createSamplerState(
 
             int baseIndex = entry.glslBinding[0];
             // Make sure they are contiguous
-            for (int i = 1; i < int(entry.glslBinding.getCount()); ++i)
+            for (Index i = 1; i < int(entry.glslBinding.getCount()); ++i)
             {
                 if (baseIndex + i != entry.glslBinding[i])
                 {
@@ -206,7 +206,7 @@ static RefPtr<SamplerState> _createSamplerState(
 /* static */Result ShaderRendererUtil::createBindingState(const ShaderInputLayout& layout, Renderer* renderer, BufferResource* addedConstantBuffer, BindingStateImpl** outBindingState)
 {
     auto srcEntries = layout.entries.getBuffer();
-    auto numEntries = int(layout.entries.getCount());
+    auto numEntries = layout.entries.getCount();
 
     const int textureBindFlags = Resource::BindFlag::NonPixelShaderResource | Resource::BindFlag::PixelShaderResource;
 
@@ -220,7 +220,7 @@ static RefPtr<SamplerState> _createSamplerState(
         slotRangeDescs.add(slotRangeDesc);
     }
 
-    for (int i = 0; i < numEntries; i++)
+    for (Index i = 0; i < numEntries; i++)
     {
         const ShaderInputLayoutEntry& srcEntry = srcEntries[i];
 

--- a/tools/render-test/shader-renderer-util.cpp
+++ b/tools/render-test/shader-renderer-util.cpp
@@ -217,7 +217,7 @@ static RefPtr<SamplerState> _createSamplerState(
         DescriptorSetLayout::SlotRangeDesc slotRangeDesc;
         slotRangeDesc.type = DescriptorSlotType::UniformBuffer;
 
-        slotRangeDescs.Add(slotRangeDesc);
+        slotRangeDescs.add(slotRangeDesc);
     }
 
     for (int i = 0; i < numEntries; i++)
@@ -279,7 +279,7 @@ static RefPtr<SamplerState> _createSamplerState(
                 assert(!"Unhandled type");
                 return SLANG_FAIL;
         }
-        slotRangeDescs.Add(slotRangeDesc);
+        slotRangeDescs.add(slotRangeDesc);
     }
 
     DescriptorSetLayout::Desc descriptorSetLayoutDesc;
@@ -290,7 +290,7 @@ static RefPtr<SamplerState> _createSamplerState(
     if(!descriptorSetLayout) return SLANG_FAIL;
 
     List<PipelineLayout::DescriptorSetDesc> pipelineDescriptorSets;
-    pipelineDescriptorSets.Add(PipelineLayout::DescriptorSetDesc(descriptorSetLayout));
+    pipelineDescriptorSets.add(PipelineLayout::DescriptorSetDesc(descriptorSetLayout));
 
     PipelineLayout::Desc pipelineLayoutDesc;
     pipelineLayoutDesc.renderTargetCount = layout.numRenderTargets;
@@ -349,7 +349,7 @@ static RefPtr<SamplerState> _createSamplerState(
                         BindingStateImpl::OutputBinding binding;
                         binding.entryIndex = i;
                         binding.resource = bufferResource;
-                        outputBindings.Add(binding);
+                        outputBindings.add(binding);
                     }
                 }
                 break;
@@ -374,7 +374,7 @@ static RefPtr<SamplerState> _createSamplerState(
                         BindingStateImpl::OutputBinding binding;
                         binding.entryIndex = i;
                         binding.resource = texture;
-                        outputBindings.Add(binding);
+                        outputBindings.add(binding);
                     }
                 }
                 break;
@@ -404,7 +404,7 @@ static RefPtr<SamplerState> _createSamplerState(
                         BindingStateImpl::OutputBinding binding;
                         binding.entryIndex = i;
                         binding.resource = texture;
-                        outputBindings.Add(binding);
+                        outputBindings.add(binding);
                     }
                 }
                 break;

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -98,20 +98,20 @@ RefPtr<ShaderProgram> ShaderCompiler::compileProgram(
         rawGlobalTypeNames.add(typeName.Buffer());
     spSetGlobalGenericArgs(
         slangRequest,
-        (int)rawGlobalTypeNames.getSize(),
-        rawGlobalTypeNames.Buffer());
+        (int)rawGlobalTypeNames.getCount(),
+        rawGlobalTypeNames.getBuffer());
 
     Slang::List<const char*> rawEntryPointTypeNames;
     for (auto typeName : request.entryPointGenericTypeArguments)
         rawEntryPointTypeNames.add(typeName.Buffer());
 
-    const int globalExistentialTypeCount = int(request.globalExistentialTypeArguments.getSize());
+    const int globalExistentialTypeCount = int(request.globalExistentialTypeArguments.getCount());
     for(int ii = 0; ii < globalExistentialTypeCount; ++ii )
     {
         spSetTypeNameForGlobalExistentialTypeParam(slangRequest, ii, request.globalExistentialTypeArguments[ii].Buffer());
     }
 
-    const int entryPointExistentialTypeCount = int(request.entryPointExistentialTypeArguments.getSize());
+    const int entryPointExistentialTypeCount = int(request.entryPointExistentialTypeArguments.getCount());
     auto setEntryPointExistentialTypeArgs = [&](int entryPoint)
     {
         for( int ii = 0; ii < entryPointExistentialTypeCount; ++ii )
@@ -125,8 +125,8 @@ RefPtr<ShaderProgram> ShaderCompiler::compileProgram(
         int computeEntryPoint = spAddEntryPointEx(slangRequest, computeTranslationUnit, 
             computeEntryPointName,
             SLANG_STAGE_COMPUTE,
-            (int)rawEntryPointTypeNames.getSize(),
-            rawEntryPointTypeNames.Buffer());
+            (int)rawEntryPointTypeNames.getCount(),
+            rawEntryPointTypeNames.getBuffer());
 
         setEntryPointExistentialTypeArgs(computeEntryPoint);
 
@@ -156,8 +156,8 @@ RefPtr<ShaderProgram> ShaderCompiler::compileProgram(
     }
     else
     {
-        int vertexEntryPoint = spAddEntryPointEx(slangRequest, vertexTranslationUnit, vertexEntryPointName, SLANG_STAGE_VERTEX, (int)rawEntryPointTypeNames.getSize(), rawEntryPointTypeNames.Buffer());
-        int fragmentEntryPoint = spAddEntryPointEx(slangRequest, fragmentTranslationUnit, fragmentEntryPointName, SLANG_STAGE_FRAGMENT, (int)rawEntryPointTypeNames.getSize(), rawEntryPointTypeNames.Buffer());
+        int vertexEntryPoint = spAddEntryPointEx(slangRequest, vertexTranslationUnit, vertexEntryPointName, SLANG_STAGE_VERTEX, (int)rawEntryPointTypeNames.getCount(), rawEntryPointTypeNames.getBuffer());
+        int fragmentEntryPoint = spAddEntryPointEx(slangRequest, fragmentTranslationUnit, fragmentEntryPointName, SLANG_STAGE_FRAGMENT, (int)rawEntryPointTypeNames.getCount(), rawEntryPointTypeNames.getBuffer());
 
         setEntryPointExistentialTypeArgs(vertexEntryPoint);
         setEntryPointExistentialTypeArgs(fragmentEntryPoint);

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -95,7 +95,7 @@ RefPtr<ShaderProgram> ShaderCompiler::compileProgram(
 
     Slang::List<const char*> rawGlobalTypeNames;
     for (auto typeName : request.globalGenericTypeArguments)
-        rawGlobalTypeNames.Add(typeName.Buffer());
+        rawGlobalTypeNames.add(typeName.Buffer());
     spSetGlobalGenericArgs(
         slangRequest,
         (int)rawGlobalTypeNames.getSize(),
@@ -103,7 +103,7 @@ RefPtr<ShaderProgram> ShaderCompiler::compileProgram(
 
     Slang::List<const char*> rawEntryPointTypeNames;
     for (auto typeName : request.entryPointGenericTypeArguments)
-        rawEntryPointTypeNames.Add(typeName.Buffer());
+        rawEntryPointTypeNames.add(typeName.Buffer());
 
     const int globalExistentialTypeCount = int(request.globalExistentialTypeArguments.getSize());
     for(int ii = 0; ii < globalExistentialTypeCount; ++ii )

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -95,7 +95,7 @@ RefPtr<ShaderProgram> ShaderCompiler::compileProgram(
 
     Slang::List<const char*> rawGlobalTypeNames;
     for (auto typeName : request.globalGenericTypeArguments)
-        rawGlobalTypeNames.add(typeName.Buffer());
+        rawGlobalTypeNames.add(typeName.getBuffer());
     spSetGlobalGenericArgs(
         slangRequest,
         (int)rawGlobalTypeNames.getCount(),
@@ -103,12 +103,12 @@ RefPtr<ShaderProgram> ShaderCompiler::compileProgram(
 
     Slang::List<const char*> rawEntryPointTypeNames;
     for (auto typeName : request.entryPointGenericTypeArguments)
-        rawEntryPointTypeNames.add(typeName.Buffer());
+        rawEntryPointTypeNames.add(typeName.getBuffer());
 
     const int globalExistentialTypeCount = int(request.globalExistentialTypeArguments.getCount());
     for(int ii = 0; ii < globalExistentialTypeCount; ++ii )
     {
-        spSetTypeNameForGlobalExistentialTypeParam(slangRequest, ii, request.globalExistentialTypeArguments[ii].Buffer());
+        spSetTypeNameForGlobalExistentialTypeParam(slangRequest, ii, request.globalExistentialTypeArguments[ii].getBuffer());
     }
 
     const int entryPointExistentialTypeCount = int(request.entryPointExistentialTypeArguments.getCount());
@@ -116,7 +116,7 @@ RefPtr<ShaderProgram> ShaderCompiler::compileProgram(
     {
         for( int ii = 0; ii < entryPointExistentialTypeCount; ++ii )
         {
-            spSetTypeNameForEntryPointExistentialTypeParam(slangRequest, entryPoint, ii, request.entryPointExistentialTypeArguments[ii].Buffer());
+            spSetTypeNameForEntryPointExistentialTypeParam(slangRequest, entryPoint, ii, request.entryPointExistentialTypeArguments[ii].getBuffer());
         }
     };
 

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -98,20 +98,20 @@ RefPtr<ShaderProgram> ShaderCompiler::compileProgram(
         rawGlobalTypeNames.Add(typeName.Buffer());
     spSetGlobalGenericArgs(
         slangRequest,
-        (int)rawGlobalTypeNames.Count(),
+        (int)rawGlobalTypeNames.getSize(),
         rawGlobalTypeNames.Buffer());
 
     Slang::List<const char*> rawEntryPointTypeNames;
     for (auto typeName : request.entryPointGenericTypeArguments)
         rawEntryPointTypeNames.Add(typeName.Buffer());
 
-    const int globalExistentialTypeCount = int(request.globalExistentialTypeArguments.Count());
+    const int globalExistentialTypeCount = int(request.globalExistentialTypeArguments.getSize());
     for(int ii = 0; ii < globalExistentialTypeCount; ++ii )
     {
         spSetTypeNameForGlobalExistentialTypeParam(slangRequest, ii, request.globalExistentialTypeArguments[ii].Buffer());
     }
 
-    const int entryPointExistentialTypeCount = int(request.entryPointExistentialTypeArguments.Count());
+    const int entryPointExistentialTypeCount = int(request.entryPointExistentialTypeArguments.getSize());
     auto setEntryPointExistentialTypeArgs = [&](int entryPoint)
     {
         for( int ii = 0; ii < entryPointExistentialTypeCount; ++ii )
@@ -125,7 +125,7 @@ RefPtr<ShaderProgram> ShaderCompiler::compileProgram(
         int computeEntryPoint = spAddEntryPointEx(slangRequest, computeTranslationUnit, 
             computeEntryPointName,
             SLANG_STAGE_COMPUTE,
-            (int)rawEntryPointTypeNames.Count(),
+            (int)rawEntryPointTypeNames.getSize(),
             rawEntryPointTypeNames.Buffer());
 
         setEntryPointExistentialTypeArgs(computeEntryPoint);
@@ -156,8 +156,8 @@ RefPtr<ShaderProgram> ShaderCompiler::compileProgram(
     }
     else
     {
-        int vertexEntryPoint = spAddEntryPointEx(slangRequest, vertexTranslationUnit, vertexEntryPointName, SLANG_STAGE_VERTEX, (int)rawEntryPointTypeNames.Count(), rawEntryPointTypeNames.Buffer());
-        int fragmentEntryPoint = spAddEntryPointEx(slangRequest, fragmentTranslationUnit, fragmentEntryPointName, SLANG_STAGE_FRAGMENT, (int)rawEntryPointTypeNames.Count(), rawEntryPointTypeNames.Buffer());
+        int vertexEntryPoint = spAddEntryPointEx(slangRequest, vertexTranslationUnit, vertexEntryPointName, SLANG_STAGE_VERTEX, (int)rawEntryPointTypeNames.getSize(), rawEntryPointTypeNames.Buffer());
+        int fragmentEntryPoint = spAddEntryPointEx(slangRequest, fragmentTranslationUnit, fragmentEntryPointName, SLANG_STAGE_FRAGMENT, (int)rawEntryPointTypeNames.getSize(), rawEntryPointTypeNames.Buffer());
 
         setEntryPointExistentialTypeArgs(vertexEntryPoint);
         setEntryPointExistentialTypeArgs(fragmentEntryPoint);

--- a/tools/slang-generate/main.cpp
+++ b/tools/slang-generate/main.cpp
@@ -610,7 +610,7 @@ static int _findLineIndex(const List<const char*>& lineBreaks, const char* locat
 
     // Use a binary chop to find the associated line
     int lo = 0;
-    int hi = int(lineBreaks.getSize());
+    int hi = int(lineBreaks.getCount());
 
     while (lo + 1 < hi)
     {
@@ -867,7 +867,7 @@ int main(
         }
     }
 
-    if(inputPaths.getSize() == 0)
+    if(inputPaths.getCount() == 0)
     {
         usage(appName);
         exit(1);

--- a/tools/slang-generate/main.cpp
+++ b/tools/slang-generate/main.cpp
@@ -601,7 +601,7 @@ void emitCodeNodes(
 }
 
 // Given line starts and a location, find the line number. Returns -1 if not found
-static int _findLineIndex(const List<const char*>& lineBreaks, const char* location)
+static Index _findLineIndex(const List<const char*>& lineBreaks, const char* location)
 {
     if (location == nullptr)
     {
@@ -609,12 +609,12 @@ static int _findLineIndex(const List<const char*>& lineBreaks, const char* locat
     }
 
     // Use a binary chop to find the associated line
-    int lo = 0;
-    int hi = int(lineBreaks.getCount());
+    Index lo = 0;
+    Index hi = lineBreaks.getCount();
 
     while (lo + 1 < hi)
     {
-        const int mid = (hi + lo) >> 1;
+        const auto mid = (hi + lo) >> 1;
         const auto midOffset = lineBreaks[mid];
         if (midOffset <= location)
         {
@@ -682,7 +682,7 @@ void emitTemplateNodes(
         if (enable && prev && prev->flavor == Node::Flavor::escape && nn->flavor == Node::Flavor::text)
         {
             // Find the line
-            int lineIndex = _findLineIndex(lineBreaks, nn->span.begin());
+            Index lineIndex = _findLineIndex(lineBreaks, nn->span.begin());
             // If found, output the directive
             if (lineIndex >= 0)
             {

--- a/tools/slang-generate/main.cpp
+++ b/tools/slang-generate/main.cpp
@@ -896,7 +896,7 @@ int main(
         outputPath << inputPath << ".temp.h";
 
         FILE* outputStream;
-        fopen_s(&outputStream, outputPath.Buffer(), "w");
+        fopen_s(&outputStream, outputPath.getBuffer(), "w");
 
         emitTemplateNodes(sourceFile, outputStream, node);
 
@@ -907,13 +907,13 @@ int main(
         outputPathFinal << inputPath << ".h";
 
         String allTextOld, allTextNew;
-        readAllText(outputPathFinal.Buffer(), allTextOld);
-        readAllText(outputPath.Buffer(), allTextNew);
+        readAllText(outputPathFinal.getBuffer(), allTextOld);
+        readAllText(outputPath.getBuffer(), allTextNew);
         if (allTextOld != allTextNew)
         {
-            writeAllText(inputPath, outputPathFinal.Buffer(), allTextNew.Buffer());
+            writeAllText(inputPath, outputPathFinal.getBuffer(), allTextNew.getBuffer());
         }
-        remove(outputPath.Buffer());
+        remove(outputPath.getBuffer());
     }
 
     return 0;

--- a/tools/slang-generate/main.cpp
+++ b/tools/slang-generate/main.cpp
@@ -611,7 +611,7 @@ static int _findLineIndex(const List<const char*>& lineBreaks, const char* locat
 
     // Use a binary chop to find the associated line
     int lo = 0;
-    int hi = int(lineBreaks.Count());
+    int hi = int(lineBreaks.getSize());
 
     while (lo + 1 < hi)
     {
@@ -868,7 +868,7 @@ int main(
         }
     }
 
-    if(inputPaths.Count() == 0)
+    if(inputPaths.getSize() == 0)
     {
         usage(appName);
         exit(1);

--- a/tools/slang-generate/main.cpp
+++ b/tools/slang-generate/main.cpp
@@ -1,6 +1,5 @@
 // main.cpp
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tools/slang-generate/main.cpp
+++ b/tools/slang-generate/main.cpp
@@ -638,7 +638,7 @@ static void _calcLineBreaks(const UnownedStringSlice& content, List<const char*>
     char const* cursor = begin;
 
     // Treat the beginning of the file as a line break
-    outLineStarts.Add(cursor);
+    outLineStarts.add(cursor);
 
     while (cursor != end)
     {
@@ -657,7 +657,7 @@ static void _calcLineBreaks(const UnownedStringSlice& content, List<const char*>
             if ((c^d) == ('\r' ^ '\n'))
                 cursor++;
 
-            outLineStarts.Add(cursor);
+            outLineStarts.add(cursor);
             break;
         }
         default:
@@ -864,7 +864,7 @@ int main(
         // Copy the input paths
         for (; argCursor != argEnd; ++argCursor)
         {
-            inputPaths.Add(*argCursor);
+            inputPaths.add(*argCursor);
         }
     }
 
@@ -881,7 +881,7 @@ int main(
         SourceFile* sourceFile = parseSourceFile(inputPath);
         if (sourceFile)
         {
-            gSourceFiles.Add(sourceFile);
+            gSourceFiles.add(sourceFile);
         }
     }
 

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -36,7 +36,7 @@ TestCategory* TestCategorySet::findOrError(String const& name)
     TestCategory* category = find(name);
     if (!category)
     {
-        StdWriters::getError().print("error: unknown test category name '%s'\n", name.Buffer());
+        StdWriters::getError().print("error: unknown test category name '%s'\n", name.getBuffer());
     }
     return category;
 }

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -290,11 +290,11 @@ static bool _isSubCommand(const char* arg)
         return SLANG_FAIL;
     }
 
-    if (optionsOut->binDir.Length() == 0)
+    if (optionsOut->binDir.getLength() == 0)
     {
         // If the binDir isn't set try using the path to the executable
         String exePath = Path::getExecutablePath();
-        if (exePath.Length())
+        if (exePath.getLength())
         {
             optionsOut->binDir = Path::getParentDirectory(exePath);
         }

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -277,14 +277,14 @@ static bool _isSubCommand(const char* arg)
 
 
     // first positional argument is source shader path
-    if (positionalArgs.getSize())
+    if (positionalArgs.getCount())
     {
         optionsOut->testPrefix = positionalArgs[0];
         positionalArgs.removeAt(0);
     }
 
     // any remaining arguments represent an error
-    if (positionalArgs.getSize() != 0)
+    if (positionalArgs.getCount() != 0)
     {
         stdError.print("unexpected arguments\n");
         return SLANG_FAIL;

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -281,7 +281,7 @@ static bool _isSubCommand(const char* arg)
     if (positionalArgs.getSize())
     {
         optionsOut->testPrefix = positionalArgs[0];
-        positionalArgs.RemoveAt(0);
+        positionalArgs.removeAt(0);
     }
 
     // any remaining arguments represent an error

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -278,14 +278,14 @@ static bool _isSubCommand(const char* arg)
 
 
     // first positional argument is source shader path
-    if (positionalArgs.Count())
+    if (positionalArgs.getSize())
     {
         optionsOut->testPrefix = positionalArgs[0];
         positionalArgs.RemoveAt(0);
     }
 
     // any remaining arguments represent an error
-    if (positionalArgs.Count() != 0)
+    if (positionalArgs.getSize() != 0)
     {
         stdError.print("unexpected arguments\n");
         return SLANG_FAIL;

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -92,18 +92,18 @@ static bool _isSubCommand(const char* arg)
             {
                 optionsOut->subCommand = arg;
                 // Make the first arg the command name
-                optionsOut->subCommandArgs.Add(optionsOut->subCommand);
+                optionsOut->subCommandArgs.add(optionsOut->subCommand);
 
                 // Add all the remaining commands to subCommands
                 for (; argCursor != argEnd; ++argCursor)
                 {
-                    optionsOut->subCommandArgs.Add(*argCursor);
+                    optionsOut->subCommandArgs.add(*argCursor);
                 }
                 // Done
                 return SLANG_OK;
             }
 
-            positionalArgs.Add(arg);
+            positionalArgs.add(arg);
             continue;
         }
 
@@ -112,7 +112,7 @@ static bool _isSubCommand(const char* arg)
             // Add all positional args at the end
             while (argCursor != argEnd)
             {
-                positionalArgs.Add(*argCursor++);
+                positionalArgs.add(*argCursor++);
             }
             break;
         }

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -4,7 +4,6 @@
 #include "os.h"
 #include "../../source/core/slang-string-util.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/tools/slang-test/os.cpp
+++ b/tools/slang-test/os.cpp
@@ -404,7 +404,7 @@ static bool checkValidResult(OSFindFilesResult& result)
     String path = result.directoryPath_
         + String(result.entry_->d_name);
 
-//    fprintf(stderr, "stat(%s)\n", path.Buffer());
+//    fprintf(stderr, "stat(%s)\n", path.getBuffer());
     struct stat fileInfo;
     if(stat(path.getBuffer(), &fileInfo) != 0)
         return false;
@@ -442,7 +442,7 @@ OSFindFilesResult osFindFilesInDirectory(
 {
     OSFindFilesResult result;
 
-//    fprintf(stderr, "osFindFilesInDirectory(%s)\n", directoryPath.Buffer());
+//    fprintf(stderr, "osFindFilesInDirectory(%s)\n", directoryPath.getBuffer());
 
     result.directory_ = opendir(directoryPath.getBuffer());
     if(!result.directory_)
@@ -518,7 +518,7 @@ OSError OSProcessSpawner::spawnAndWaitForCompletion()
     List<char const*> argPtrs;
     for(auto arg : arguments_)
     {
-        argPtrs.add(arg.Buffer());
+        argPtrs.add(arg.getBuffer());
     }
     argPtrs.add(NULL);
 

--- a/tools/slang-test/os.cpp
+++ b/tools/slang-test/os.cpp
@@ -33,7 +33,7 @@ static bool adjustToValidResult(OSFindFilesResult& result)
         if (wcscmp(result.fileData_.cFileName, L"..") == 0)
             goto skip;
 
-        result.filePath_ = result.directoryPath_ + String::FromWString(result.fileData_.cFileName);
+        result.filePath_ = result.directoryPath_ + String::fromWString(result.fileData_.cFileName);
         if (result.fileData_.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
             result.filePath_ = result.filePath_ + "/";
 

--- a/tools/slang-test/os.cpp
+++ b/tools/slang-test/os.cpp
@@ -223,7 +223,7 @@ void OSProcessSpawner::pushArgument(
     commandLine_.Append(" ");
     commandLine_.Append(argument);
 
-    argumentList_.Add(argument);
+    argumentList_.add(argument);
 }
 
 Slang::String OSProcessSpawner::getCommandLine()
@@ -482,7 +482,7 @@ void OSProcessSpawner::pushExecutableName(
     Slang::String executableName)
 {
     executableName_ = executableName;
-    arguments_.Add(executableName);
+    arguments_.add(executableName);
     isExecutablePath_ = false;
 }
 
@@ -490,15 +490,15 @@ void OSProcessSpawner::pushExecutablePath(
     Slang::String executablePath)
 {
     executableName_ = executablePath;
-    arguments_.Add(executablePath);
+    arguments_.add(executablePath);
     isExecutablePath_ = true;
 }
 
 void OSProcessSpawner::pushArgument(
     Slang::String argument)
 {
-    arguments_.Add(argument);
-    argumentList_.Add(argument);
+    arguments_.add(argument);
+    argumentList_.add(argument);
 }
 
 Slang::String OSProcessSpawner::getCommandLine()
@@ -519,9 +519,9 @@ OSError OSProcessSpawner::spawnAndWaitForCompletion()
     List<char const*> argPtrs;
     for(auto arg : arguments_)
     {
-        argPtrs.Add(arg.Buffer());
+        argPtrs.add(arg.Buffer());
     }
-    argPtrs.Add(NULL);
+    argPtrs.add(NULL);
 
     int stdoutPipe[2];
     int stderrPipe[2];

--- a/tools/slang-test/os.cpp
+++ b/tools/slang-test/os.cpp
@@ -502,7 +502,7 @@ void OSProcessSpawner::pushArgument(
 
 Slang::String OSProcessSpawner::getCommandLine()
 {
-    Slang::UInt argCount = arguments_.getSize();
+    Slang::UInt argCount = arguments_.getCount();
 
     Slang::StringBuilder sb;
     for(Slang::UInt ii = 0; ii < argCount;  ++ii)

--- a/tools/slang-test/os.cpp
+++ b/tools/slang-test/os.cpp
@@ -1,7 +1,6 @@
 // os.cpp
 #include "os.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/tools/slang-test/os.cpp
+++ b/tools/slang-test/os.cpp
@@ -62,7 +62,7 @@ OSFindFilesResult osFindFilesInDirectoryMatchingPattern(
 
     OSFindFilesResult result;
     HANDLE findHandle = FindFirstFileW(
-        searchPath.ToWString(),
+        searchPath.toWString(),
         &result.fileData_);
 
     result.directoryPath_ = directoryPath;
@@ -100,7 +100,7 @@ OSFindFilesResult osFindChildDirectories(
 
     OSFindFilesResult result;
     HANDLE findHandle = FindFirstFileW(
-        searchPath.ToWString(),
+        searchPath.toWString(),
         &result.fileData_);
 
     result.directoryPath_ = directoryPath;
@@ -320,8 +320,8 @@ OSError OSProcessSpawner::spawnAndWaitForCompletion()
 
     // `CreateProcess` requires write access to this, for some reason...
     BOOL success = CreateProcessW(
-        isExecutablePath_ ? executableName_.ToWString().begin() : nullptr,
-        (LPWSTR)commandLine_.ToString().ToWString().begin(),
+        isExecutablePath_ ? executableName_.toWString().begin() : nullptr,
+        (LPWSTR)commandLine_.ToString().toWString().begin(),
         nullptr,
         nullptr,
         true,
@@ -406,7 +406,7 @@ static bool checkValidResult(OSFindFilesResult& result)
 
 //    fprintf(stderr, "stat(%s)\n", path.Buffer());
     struct stat fileInfo;
-    if(stat(path.Buffer(), &fileInfo) != 0)
+    if(stat(path.getBuffer(), &fileInfo) != 0)
         return false;
 
     if(S_ISDIR(fileInfo.st_mode))
@@ -444,7 +444,7 @@ OSFindFilesResult osFindFilesInDirectory(
 
 //    fprintf(stderr, "osFindFilesInDirectory(%s)\n", directoryPath.Buffer());
 
-    result.directory_ = opendir(directoryPath.Buffer());
+    result.directory_ = opendir(directoryPath.getBuffer());
     if(!result.directory_)
     {
         result.entry_ = NULL;
@@ -461,7 +461,7 @@ OSFindFilesResult osFindChildDirectories(
 {
     OSFindFilesResult result;
 
-    result.directory_ = opendir(directoryPath.Buffer());
+    result.directory_ = opendir(directoryPath.getBuffer());
     if(!result.directory_)
     {
         result.entry_ = NULL;

--- a/tools/slang-test/os.cpp
+++ b/tools/slang-test/os.cpp
@@ -503,7 +503,7 @@ void OSProcessSpawner::pushArgument(
 
 Slang::String OSProcessSpawner::getCommandLine()
 {
-    Slang::UInt argCount = arguments_.Count();
+    Slang::UInt argCount = arguments_.getSize();
 
     Slang::StringBuilder sb;
     for(Slang::UInt ii = 0; ii < argCount;  ++ii)

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -240,7 +240,7 @@ static TestResult _gatherTestOptions(
     }
 
     // If no categories were specified, then add the default category
-    if(outOptions.categories.Count() == 0)
+    if(outOptions.categories.getSize() == 0)
     {
         outOptions.categories.Add(categorySet->defaultCategory);
     }
@@ -422,7 +422,7 @@ OSError spawnAndWaitSharedLibrary(TestContext* context, const String& testPath, 
 
         // TODO(js): Potentially this should handle escaping parameters for the command line if need be
         const auto& argList = spawner.argumentList_;
-        for (UInt i = 0; i < argList.Count(); ++i)
+        for (UInt i = 0; i < argList.getSize(); ++i)
         {
             builder << " " << argList[i];
         }
@@ -453,12 +453,12 @@ OSError spawnAndWaitSharedLibrary(TestContext* context, const String& testPath, 
 
         List<const char*> args;
         args.Add(exeName.Buffer());
-        for (int i = 0; i < int(spawner.argumentList_.Count()); ++i)
+        for (int i = 0; i < int(spawner.argumentList_.getSize()); ++i)
         {
             args.Add(spawner.argumentList_[i].Buffer());
         }
 
-        SlangResult res = func(&stdWriters, context->getSession(), int(args.Count()), args.begin());
+        SlangResult res = func(&stdWriters, context->getSession(), int(args.getSize()), args.begin());
 
         StdWriters::setSingleton(prevStdWriters);
 
@@ -478,7 +478,7 @@ static SlangResult _extractArg(const List<String>& args, const String& argName, 
 {
     SLANG_ASSERT(argName.Length() > 0 && argName[0] == '-');
 
-    const UInt count = args.Count();
+    const UInt count = args.getSize();
     for (UInt i = 0; i < count - 1; ++i)
     {
         if (args[i] == argName)
@@ -1106,7 +1106,7 @@ TestResult runCrossCompilerTest(TestContext* context, TestInput& input)
     const auto& args = input.testOptions->args;
 
     const UInt targetIndex = args.IndexOf("-target");
-    if (targetIndex != UInt(-1) && targetIndex + 1 < args.Count())
+    if (targetIndex != UInt(-1) && targetIndex + 1 < args.getSize())
     {
         SlangCompileTarget target = _getCompileTarget(args[targetIndex + 1].getUnownedSlice());
 
@@ -1539,12 +1539,12 @@ TestResult runComputeComparisonImpl(TestContext* context, TestInput& input, cons
     {
         context->reporter->messageFormat(TestMessageType::TestFailure, "output mismatch! actual output: {\n%s\n}, \n%s\n", actualOutputContent.Buffer(), actualOutput.Buffer());
     };
-    if (actualProgramOutput.Count() < referenceProgramOutput.Count())
+    if (actualProgramOutput.getSize() < referenceProgramOutput.getSize())
     {
         printOutput();
 		return TestResult::Fail;
     }
-	for (int i = 0; i < (int)referenceProgramOutput.Count(); i++)
+	for (int i = 0; i < (int)referenceProgramOutput.getSize(); i++)
 	{
 		auto reference = String(referenceProgramOutput[i].Trim());
 		auto actual = String(actualProgramOutput[i].Trim());
@@ -2056,7 +2056,7 @@ void runTestsOnFile(
     }
 
     // Note cases where a test file exists, but we found nothing to run
-    if( testList.tests.Count() == 0 )
+    if( testList.tests.getSize() == 0 )
     {
         context->reporter->addTest(filePath, TestResult::Ignored);
         return;
@@ -2094,7 +2094,7 @@ void runTestsOnFile(
         // What render options do we want to synthesize
         RenderApiFlags missingApis = (~apiUsedFlags) & (context->options.synthesizedTestApis & availableRenderApiFlags);
 
-        const UInt numInitialTests = testList.tests.Count();
+        const UInt numInitialTests = testList.tests.getSize();
 
         while (missingApis)
         {
@@ -2351,13 +2351,13 @@ SlangResult innerMain(int argc, char** argv)
         // Copy args to a char* list
         const auto& srcArgs = options.subCommandArgs;
         List<const char*> args;
-        args.SetSize(srcArgs.Count());
-        for (UInt i = 0; i < srcArgs.Count(); ++i)
+        args.SetSize(srcArgs.getSize());
+        for (UInt i = 0; i < srcArgs.getSize(); ++i)
         {
             args[i] = srcArgs[i].Buffer();
         }
 
-        return func(StdWriters::getSingleton(), context.getSession(), int(args.Count()), args.Buffer());
+        return func(StdWriters::getSingleton(), context.getSession(), int(args.getSize()), args.Buffer());
     }
 
     if( options.includeCategories.Count() == 0 )

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -2351,7 +2351,7 @@ SlangResult innerMain(int argc, char** argv)
         // Copy args to a char* list
         const auto& srcArgs = options.subCommandArgs;
         List<const char*> args;
-        args.SetSize(srcArgs.getSize());
+        args.setSize(srcArgs.getSize());
         for (UInt i = 0; i < srcArgs.getSize(); ++i)
         {
             args[i] = srcArgs[i].Buffer();

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -421,7 +421,7 @@ OSError spawnAndWaitSharedLibrary(TestContext* context, const String& testPath, 
 
         // TODO(js): Potentially this should handle escaping parameters for the command line if need be
         const auto& argList = spawner.argumentList_;
-        for (UInt i = 0; i < argList.getCount(); ++i)
+        for (Index i = 0; i < argList.getCount(); ++i)
         {
             builder << " " << argList[i];
         }
@@ -491,7 +491,7 @@ static SlangResult _extractArg(const List<String>& args, const String& argName, 
 
 static bool _hasOption(const List<String>& args, const String& argName)
 {
-    return args.indexOf(argName) != UInt(-1);
+    return args.indexOf(argName) != Index(-1);
 }
 
 static BackendType _toBackendType(const UnownedStringSlice& slice)
@@ -1104,8 +1104,8 @@ TestResult runCrossCompilerTest(TestContext* context, TestInput& input)
 
     const auto& args = input.testOptions->args;
 
-    const UInt targetIndex = args.indexOf("-target");
-    if (targetIndex != UInt(-1) && targetIndex + 1 < args.getCount())
+    const Index targetIndex = args.indexOf("-target");
+    if (targetIndex != Index(-1) && targetIndex + 1 < args.getCount())
     {
         SlangCompileTarget target = _getCompileTarget(args[targetIndex + 1].getUnownedSlice());
 
@@ -2001,8 +2001,8 @@ static void _calcSynthesizedTests(TestContext* context, RenderApiType synthRende
         // If the target is vulkan remove the -hlsl option
         if (synthRenderApiType == RenderApiType::Vulkan)
         {
-            UInt index = synthOptions.args.indexOf("-hlsl");
-            if (index != UInt(-1))
+            Index index = synthOptions.args.indexOf("-hlsl");
+            if (index != Index(-1))
             {
                 synthOptions.args.removeAt(index);
             }
@@ -2351,7 +2351,7 @@ SlangResult innerMain(int argc, char** argv)
         const auto& srcArgs = options.subCommandArgs;
         List<const char*> args;
         args.setCount(srcArgs.getCount());
-        for (UInt i = 0; i < srcArgs.getCount(); ++i)
+        for (Index i = 0; i < srcArgs.getCount(); ++i)
         {
             args[i] = srcArgs[i].Buffer();
         }

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -239,7 +239,7 @@ static TestResult _gatherTestOptions(
     }
 
     // If no categories were specified, then add the default category
-    if(outOptions.categories.getSize() == 0)
+    if(outOptions.categories.getCount() == 0)
     {
         outOptions.categories.add(categorySet->defaultCategory);
     }
@@ -421,7 +421,7 @@ OSError spawnAndWaitSharedLibrary(TestContext* context, const String& testPath, 
 
         // TODO(js): Potentially this should handle escaping parameters for the command line if need be
         const auto& argList = spawner.argumentList_;
-        for (UInt i = 0; i < argList.getSize(); ++i)
+        for (UInt i = 0; i < argList.getCount(); ++i)
         {
             builder << " " << argList[i];
         }
@@ -452,12 +452,12 @@ OSError spawnAndWaitSharedLibrary(TestContext* context, const String& testPath, 
 
         List<const char*> args;
         args.add(exeName.Buffer());
-        for (int i = 0; i < int(spawner.argumentList_.getSize()); ++i)
+        for (int i = 0; i < int(spawner.argumentList_.getCount()); ++i)
         {
             args.add(spawner.argumentList_[i].Buffer());
         }
 
-        SlangResult res = func(&stdWriters, context->getSession(), int(args.getSize()), args.begin());
+        SlangResult res = func(&stdWriters, context->getSession(), int(args.getCount()), args.begin());
 
         StdWriters::setSingleton(prevStdWriters);
 
@@ -477,7 +477,7 @@ static SlangResult _extractArg(const List<String>& args, const String& argName, 
 {
     SLANG_ASSERT(argName.Length() > 0 && argName[0] == '-');
 
-    const UInt count = args.getSize();
+    const UInt count = args.getCount();
     for (UInt i = 0; i < count - 1; ++i)
     {
         if (args[i] == argName)
@@ -1105,7 +1105,7 @@ TestResult runCrossCompilerTest(TestContext* context, TestInput& input)
     const auto& args = input.testOptions->args;
 
     const UInt targetIndex = args.indexOf("-target");
-    if (targetIndex != UInt(-1) && targetIndex + 1 < args.getSize())
+    if (targetIndex != UInt(-1) && targetIndex + 1 < args.getCount())
     {
         SlangCompileTarget target = _getCompileTarget(args[targetIndex + 1].getUnownedSlice());
 
@@ -1538,12 +1538,12 @@ TestResult runComputeComparisonImpl(TestContext* context, TestInput& input, cons
     {
         context->reporter->messageFormat(TestMessageType::TestFailure, "output mismatch! actual output: {\n%s\n}, \n%s\n", actualOutputContent.Buffer(), actualOutput.Buffer());
     };
-    if (actualProgramOutput.getSize() < referenceProgramOutput.getSize())
+    if (actualProgramOutput.getCount() < referenceProgramOutput.getCount())
     {
         printOutput();
 		return TestResult::Fail;
     }
-	for (int i = 0; i < (int)referenceProgramOutput.getSize(); i++)
+	for (int i = 0; i < (int)referenceProgramOutput.getCount(); i++)
 	{
 		auto reference = String(referenceProgramOutput[i].Trim());
 		auto actual = String(actualProgramOutput[i].Trim());
@@ -2055,7 +2055,7 @@ void runTestsOnFile(
     }
 
     // Note cases where a test file exists, but we found nothing to run
-    if( testList.tests.getSize() == 0 )
+    if( testList.tests.getCount() == 0 )
     {
         context->reporter->addTest(filePath, TestResult::Ignored);
         return;
@@ -2093,7 +2093,7 @@ void runTestsOnFile(
         // What render options do we want to synthesize
         RenderApiFlags missingApis = (~apiUsedFlags) & (context->options.synthesizedTestApis & availableRenderApiFlags);
 
-        const UInt numInitialTests = testList.tests.getSize();
+        const UInt numInitialTests = testList.tests.getCount();
 
         while (missingApis)
         {
@@ -2350,13 +2350,13 @@ SlangResult innerMain(int argc, char** argv)
         // Copy args to a char* list
         const auto& srcArgs = options.subCommandArgs;
         List<const char*> args;
-        args.setSize(srcArgs.getSize());
-        for (UInt i = 0; i < srcArgs.getSize(); ++i)
+        args.setCount(srcArgs.getCount());
+        for (UInt i = 0; i < srcArgs.getCount(); ++i)
         {
             args[i] = srcArgs[i].Buffer();
         }
 
-        return func(StdWriters::getSingleton(), context.getSession(), int(args.getSize()), args.Buffer());
+        return func(StdWriters::getSingleton(), context.getSession(), int(args.getCount()), args.getBuffer());
     }
 
     if( options.includeCategories.Count() == 0 )

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -396,7 +396,7 @@ OSError spawnAndWaitExe(TestContext* context, const String& testPath, OSProcessS
     if (err != kOSError_None)
     {
         //        fprintf(stderr, "failed to run test '%S'\n", testPath.ToWString());
-        context->reporter->messageFormat(TestMessageType::RunError, "failed to run test '%S'", testPath.ToWString().begin());
+        context->reporter->messageFormat(TestMessageType::RunError, "failed to run test '%S'", testPath.toWString().begin());
     }
     return err;
 }
@@ -451,10 +451,10 @@ OSError spawnAndWaitSharedLibrary(TestContext* context, const String& testPath, 
         }
 
         List<const char*> args;
-        args.add(exeName.Buffer());
+        args.add(exeName.getBuffer());
         for (int i = 0; i < int(spawner.argumentList_.getCount()); ++i)
         {
-            args.add(spawner.argumentList_[i].Buffer());
+            args.add(spawner.argumentList_[i].getBuffer());
         }
 
         SlangResult res = func(&stdWriters, context->getSession(), int(args.getCount()), args.begin());
@@ -887,7 +887,7 @@ String findExpectedPath(const TestInput& input, const char* postFix)
     }
 
     // Couldn't find either 
-    printf("referenceOutput '%s' or '%s' not found.\n", defaultBuf.Buffer(), specializedBuf.Buffer());
+    printf("referenceOutput '%s' or '%s' not found.\n", defaultBuf.getBuffer(), specializedBuf.getBuffer());
 
     return "";
 }
@@ -1523,12 +1523,12 @@ TestResult runComputeComparisonImpl(TestContext* context, TestInput& input, cons
     if (!File::exists(actualOutputFile))
     {
         printf("render-test not producing expected outputs.\n");
-        printf("render-test output:\n%s\n", actualOutput.Buffer());
+        printf("render-test output:\n%s\n", actualOutput.getBuffer());
 		return TestResult::Fail;
     }
     if (!File::exists(referenceOutput))
     {
-        printf("referenceOutput %s not found.\n", referenceOutput.Buffer());
+        printf("referenceOutput %s not found.\n", referenceOutput.getBuffer());
 		return TestResult::Fail;
     }
     auto actualOutputContent = File::readAllText(actualOutputFile);
@@ -1536,7 +1536,7 @@ TestResult runComputeComparisonImpl(TestContext* context, TestInput& input, cons
 	auto referenceProgramOutput = Split(File::readAllText(referenceOutput), '\n');
     auto printOutput = [&]()
     {
-        context->reporter->messageFormat(TestMessageType::TestFailure, "output mismatch! actual output: {\n%s\n}, \n%s\n", actualOutputContent.Buffer(), actualOutput.Buffer());
+        context->reporter->messageFormat(TestMessageType::TestFailure, "output mismatch! actual output: {\n%s\n}, \n%s\n", actualOutputContent.getBuffer(), actualOutput.getBuffer());
     };
     if (actualProgramOutput.getCount() < referenceProgramOutput.getCount())
     {
@@ -1709,22 +1709,22 @@ TestResult doImageComparison(TestContext* context, String const& filePath)
     String actualPath = filePath + ".actual.png";
 
     STBImage expectedImage;
-    if (SLANG_FAILED(expectedImage.read(expectedPath.Buffer())))
+    if (SLANG_FAILED(expectedImage.read(expectedPath.getBuffer())))
     {
-        reporter->messageFormat(TestMessageType::RunError, "Unable to load image ;%s'", expectedPath.Buffer());
+        reporter->messageFormat(TestMessageType::RunError, "Unable to load image ;%s'", expectedPath.getBuffer());
         return TestResult::Fail;
     }
 
     STBImage actualImage;
-    if (SLANG_FAILED(actualImage.read(actualPath.Buffer())))
+    if (SLANG_FAILED(actualImage.read(actualPath.getBuffer())))
     {
-        reporter->messageFormat(TestMessageType::RunError, "Unable to load image ;%s'", actualPath.Buffer());
+        reporter->messageFormat(TestMessageType::RunError, "Unable to load image ;%s'", actualPath.getBuffer());
         return TestResult::Fail;
     }
 
     if (!expectedImage.isComparable(actualImage))
     {
-        reporter->messageFormat(TestMessageType::TestFailure, "Images are different sizes '%s' '%s'", actualPath.Buffer(), expectedPath.Buffer());
+        reporter->messageFormat(TestMessageType::TestFailure, "Images are different sizes '%s' '%s'", actualPath.getBuffer(), expectedPath.getBuffer());
         return TestResult::Fail;
     }
 
@@ -2343,7 +2343,7 @@ SlangResult innerMain(int argc, char** argv)
         auto func = context.getInnerMainFunc(options.binDir, options.subCommand);
         if (!func)
         {
-            StdWriters::getError().print("error: Unable to launch tool '%s'\n", options.subCommand.Buffer());
+            StdWriters::getError().print("error: Unable to launch tool '%s'\n", options.subCommand.getBuffer());
             return SLANG_FAIL;
         }
 
@@ -2353,7 +2353,7 @@ SlangResult innerMain(int argc, char** argv)
         args.setCount(srcArgs.getCount());
         for (Index i = 0; i < srcArgs.getCount(); ++i)
         {
-            args[i] = srcArgs[i].Buffer();
+            args[i] = srcArgs[i].getBuffer();
         }
 
         return func(StdWriters::getSingleton(), context.getSession(), int(args.getCount()), args.getBuffer());

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -412,7 +412,7 @@ OSError spawnAndWaitSharedLibrary(TestContext* context, const String& testPath, 
 
         builder << "slang-test";
 
-        if (options.binDir.Length())
+        if (options.binDir.getLength())
         {
             builder << " -bindir " << options.binDir;
         }
@@ -475,7 +475,7 @@ OSError spawnAndWaitSharedLibrary(TestContext* context, const String& testPath, 
 
 static SlangResult _extractArg(const List<String>& args, const String& argName, String& outValue)
 {
-    SLANG_ASSERT(argName.Length() > 0 && argName[0] == '-');
+    SLANG_ASSERT(argName.getLength() > 0 && argName[0] == '-');
 
     const UInt count = args.getCount();
     for (UInt i = 0; i < count - 1; ++i)
@@ -959,7 +959,7 @@ TestResult runSimpleTest(TestContext* context, TestInput& input)
 
     // If no expected output file was found, then we
     // expect everything to be empty
-    if (expectedOutput.Length() == 0)
+    if (expectedOutput.getLength() == 0)
     {
         expectedOutput = "result code = 0\nstandard error = {\n}\nstandard output = {\n}\n";
     }
@@ -1035,7 +1035,7 @@ TestResult runReflectionTest(TestContext* context, TestInput& input)
 
     // If no expected output file was found, then we
     // expect everything to be empty
-    if (expectedOutput.Length() == 0)
+    if (expectedOutput.getLength() == 0)
     {
         expectedOutput = "result code = 0\nstandard error = {\n}\nstandard output = {\n}\n";
     }
@@ -1076,7 +1076,7 @@ String getExpectedOutput(String const& outputStem)
 
     // If no expected output file was found, then we
     // expect everything to be empty
-    if (expectedOutput.Length() == 0)
+    if (expectedOutput.getLength() == 0)
     {
         expectedOutput = "result code = 0\nstandard error = {\n}\nstandard output = {\n}\n";
     }
@@ -1314,11 +1314,11 @@ TestResult runHLSLComparisonTest(TestContext* context, TestInput& input)
 
     // If no expected output file was found, then we
     // expect everything to be empty
-    if (expectedOutput.Length() == 0)
+    if (expectedOutput.getLength() == 0)
     {
         if (resultCode != 0)				result = TestResult::Fail;
-        if (standardError.Length() != 0)	result = TestResult::Fail;
-        if (standardOutput.Length() != 0)	result = TestResult::Fail;
+        if (standardError.getLength() != 0)	result = TestResult::Fail;
+        if (standardOutput.getLength() != 0)	result = TestResult::Fail;
     }
     // Otherwise we compare to the expected output
     else if (actualOutput != expectedOutput)
@@ -1455,7 +1455,7 @@ TestResult runGLSLComparisonTest(TestContext* context, TestInput& input)
 
 static void _addRenderTestOptions(const Options& options, OSProcessSpawner& spawner)
 {
-    if (options.adapter.Length())
+    if (options.adapter.getLength())
     {
         spawner.pushArgument("-adapter");
         spawner.pushArgument(options.adapter);
@@ -1502,7 +1502,7 @@ TestResult runComputeComparisonImpl(TestContext* context, TestInput& input, cons
     }
 
     const String referenceOutput = findExpectedPath(input, ".expected.txt");
-    if (referenceOutput.Length() <= 0)
+    if (referenceOutput.getLength() <= 0)
     {
         return TestResult::Fail;
     }
@@ -1545,8 +1545,8 @@ TestResult runComputeComparisonImpl(TestContext* context, TestInput& input, cons
     }
 	for (int i = 0; i < (int)referenceProgramOutput.getCount(); i++)
 	{
-		auto reference = String(referenceProgramOutput[i].Trim());
-		auto actual = String(actualProgramOutput[i].Trim());
+		auto reference = String(referenceProgramOutput[i].trim());
+		auto actual = String(actualProgramOutput[i].trim());
         if (actual != reference)
         {
             printOutput();
@@ -2215,7 +2215,7 @@ static bool endsWithAllowedExtension(
 
     for( auto ii = allowedExtensions; *ii; ++ii )
     {
-        if(filePath.EndsWith(*ii))
+        if(filePath.endsWith(*ii))
             return true;
     }
 
@@ -2337,7 +2337,7 @@ SlangResult innerMain(int argc, char** argv)
     
     Options& options = context.options;
 
-    if (options.subCommand.Length())
+    if (options.subCommand.getLength())
     {
         // Get the function from the tool
         auto func = context.getInnerMainFunc(options.binDir, options.subCommand);

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -2005,7 +2005,7 @@ static void _calcSynthesizedTests(TestContext* context, RenderApiType synthRende
             UInt index = synthOptions.args.IndexOf("-hlsl");
             if (index != UInt(-1))
             {
-                synthOptions.args.RemoveAt(index);
+                synthOptions.args.removeAt(index);
             }
         }
 
@@ -2110,7 +2110,7 @@ void runTestsOnFile(
         }
 
         // Add all the synthesized tests
-        testList.tests.AddRange(synthesizedTests);
+        testList.tests.addRange(synthesizedTests);
     }
 
     // We have found a test to run!

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -492,7 +492,7 @@ static SlangResult _extractArg(const List<String>& args, const String& argName, 
 
 static bool _hasOption(const List<String>& args, const String& argName)
 {
-    return args.IndexOf(argName) != UInt(-1);
+    return args.indexOf(argName) != UInt(-1);
 }
 
 static BackendType _toBackendType(const UnownedStringSlice& slice)
@@ -1105,7 +1105,7 @@ TestResult runCrossCompilerTest(TestContext* context, TestInput& input)
 
     const auto& args = input.testOptions->args;
 
-    const UInt targetIndex = args.IndexOf("-target");
+    const UInt targetIndex = args.indexOf("-target");
     if (targetIndex != UInt(-1) && targetIndex + 1 < args.getSize())
     {
         SlangCompileTarget target = _getCompileTarget(args[targetIndex + 1].getUnownedSlice());
@@ -2002,7 +2002,7 @@ static void _calcSynthesizedTests(TestContext* context, RenderApiType synthRende
         // If the target is vulkan remove the -hlsl option
         if (synthRenderApiType == RenderApiType::Vulkan)
         {
-            UInt index = synthOptions.args.IndexOf("-hlsl");
+            UInt index = synthOptions.args.indexOf("-hlsl");
             if (index != UInt(-1))
             {
                 synthOptions.args.removeAt(index);

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -21,7 +21,6 @@ using namespace Slang;
 #define STB_IMAGE_IMPLEMENTATION
 #include "external/stb/stb_image.h"
 
-#include <assert.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -2248,7 +2248,7 @@ void runTestsInDirectory(
     {
         if( shouldRunTest(context, file) )
         {
-//            fprintf(stderr, "slang-test: found '%s'\n", file.Buffer());
+//            fprintf(stderr, "slang-test: found '%s'\n", file.getBuffer());
             runTestsOnFile(context, file);
         }
     }

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -452,7 +452,7 @@ OSError spawnAndWaitSharedLibrary(TestContext* context, const String& testPath, 
 
         List<const char*> args;
         args.add(exeName.getBuffer());
-        for (int i = 0; i < int(spawner.argumentList_.getCount()); ++i)
+        for (Index i = 0; i < spawner.argumentList_.getCount(); ++i)
         {
             args.add(spawner.argumentList_[i].getBuffer());
         }
@@ -477,8 +477,8 @@ static SlangResult _extractArg(const List<String>& args, const String& argName, 
 {
     SLANG_ASSERT(argName.getLength() > 0 && argName[0] == '-');
 
-    const UInt count = args.getCount();
-    for (UInt i = 0; i < count - 1; ++i)
+    const Index count = args.getCount();
+    for (Index i = 0; i < count - 1; ++i)
     {
         if (args[i] == argName)
         {
@@ -1543,7 +1543,7 @@ TestResult runComputeComparisonImpl(TestContext* context, TestInput& input, cons
         printOutput();
 		return TestResult::Fail;
     }
-	for (int i = 0; i < (int)referenceProgramOutput.getCount(); i++)
+	for (Index i = 0; i < referenceProgramOutput.getCount(); i++)
 	{
 		auto reference = String(referenceProgramOutput[i].trim());
 		auto actual = String(actualProgramOutput[i].trim());
@@ -2093,7 +2093,7 @@ void runTestsOnFile(
         // What render options do we want to synthesize
         RenderApiFlags missingApis = (~apiUsedFlags) & (context->options.synthesizedTestApis & availableRenderApiFlags);
 
-        const UInt numInitialTests = testList.tests.getCount();
+        //const Index numInitialTests = testList.tests.getCount();
 
         while (missingApis)
         {

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -220,7 +220,7 @@ static TestResult _gatherTestOptions(
                     }
                     
 
-                    outOptions.categories.Add(category);
+                    outOptions.categories.add(category);
 
                     if( *categoryEnd == ',' )
                     {
@@ -242,7 +242,7 @@ static TestResult _gatherTestOptions(
     // If no categories were specified, then add the default category
     if(outOptions.categories.getSize() == 0)
     {
-        outOptions.categories.Add(categorySet->defaultCategory);
+        outOptions.categories.add(categorySet->defaultCategory);
     }
 
     if(*cursor == ':')
@@ -319,7 +319,7 @@ static TestResult _gatherTestOptions(
         char const* argEnd = cursor;
         assert(argBegin != argEnd);
 
-        outOptions.args.Add(getString(argBegin, argEnd));
+        outOptions.args.add(getString(argBegin, argEnd));
     }
 }
 
@@ -361,7 +361,7 @@ TestResult gatherTestsForFile(
             if(_gatherTestOptions(categorySet, &cursor, testDetails.options) != TestResult::Pass)
                 return TestResult::Fail;
 
-            testList->tests.Add(testDetails);
+            testList->tests.add(testDetails);
         }
         else if (match(&cursor, "//DIAGNOSTIC_TEST"))
         {
@@ -372,7 +372,7 @@ TestResult gatherTestsForFile(
 
             // Mark that it is a diagnostic test
             testDetails.options.type = TestOptions::Type::Diagnostic;
-            testList->tests.Add(testDetails);
+            testList->tests.add(testDetails);
         }
         else
         {
@@ -452,10 +452,10 @@ OSError spawnAndWaitSharedLibrary(TestContext* context, const String& testPath, 
         }
 
         List<const char*> args;
-        args.Add(exeName.Buffer());
+        args.add(exeName.Buffer());
         for (int i = 0; i < int(spawner.argumentList_.getSize()); ++i)
         {
-            args.Add(spawner.argumentList_[i].Buffer());
+            args.add(spawner.argumentList_[i].Buffer());
         }
 
         SlangResult res = func(&stdWriters, context->getSession(), int(args.getSize()), args.begin());
@@ -1997,7 +1997,7 @@ static void _calcSynthesizedTests(TestContext* context, RenderApiType synthRende
         builder << "-";
         builder << RenderApiUtil::getApiName(synthRenderApiType);
 
-        synthOptions.args.Add(builder);
+        synthOptions.args.add(builder);
 
         // If the target is vulkan remove the -hlsl option
         if (synthRenderApiType == RenderApiType::Vulkan)
@@ -2017,7 +2017,7 @@ static void _calcSynthesizedTests(TestContext* context, RenderApiType synthRende
         // It does set the explicit render target
         SLANG_ASSERT(synthTestDetails.requirements.explicitRenderApi == synthRenderApiType);
         // Add to the tests
-        ioSynthTests.Add(synthTestDetails);
+        ioSynthTests.add(synthTestDetails);
     }
 }
 
@@ -2406,7 +2406,7 @@ SlangResult innerMain(int argc, char** argv)
                 filePath << "unit-tests/" << cur->m_name << ".internal";
 
                 TestOptions testOptions;
-                testOptions.categories.Add(unitTestCatagory);
+                testOptions.categories.add(unitTestCatagory);
                 testOptions.command = filePath;
 
                 if (shouldRunTest(&context, testOptions.command))

--- a/tools/slang-test/slangc-tool.cpp
+++ b/tools/slang-test/slangc-tool.cpp
@@ -1,6 +1,8 @@
 // test-context.cpp
 #include "slangc-tool.h"
 
+#include "../../source/core/exception.h"
+
 using namespace Slang;
 
 SLANG_API void spSetCommandLineCompilerMode(SlangCompileRequest* request);

--- a/tools/slang-test/slangc-tool.cpp
+++ b/tools/slang-test/slangc-tool.cpp
@@ -47,7 +47,7 @@ SlangResult SlangCTool::innerMain(StdWriters* stdWriters, SlangSession* session,
 #ifndef _DEBUG
     catch (Exception & e)
     {
-        StdWriters::getOut().print("internal compiler error: %S\n", e.Message.ToWString().begin());
+        StdWriters::getOut().print("internal compiler error: %S\n", e.Message.toWString().begin());
         res = SLANG_FAIL;
     }
 #endif

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -4,7 +4,6 @@
 #include "os.h"
 #include "../../source/core/slang-string-util.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/tools/slang-test/test-reporter.cpp
+++ b/tools/slang-test/test-reporter.cpp
@@ -109,7 +109,7 @@ bool TestReporter::canWriteStdError() const
 void TestReporter::startTest(const String& testName)
 {
     // Must be in a suite
-    assert(m_suiteStack.getSize());
+    assert(m_suiteStack.getCount());
     assert(!m_inTest);
 
     m_inTest = true;
@@ -124,7 +124,7 @@ void TestReporter::startTest(const String& testName)
 
 void TestReporter::endTest()
 {
-    assert(m_suiteStack.getSize());
+    assert(m_suiteStack.getCount());
     assert(m_inTest);
 
     m_currentInfo.message = m_currentMessage;
@@ -594,7 +594,7 @@ void TestReporter::startSuite(const String& name)
 
 void TestReporter::endSuite()
 {
-    assert(m_suiteStack.getSize());
+    assert(m_suiteStack.getCount());
 
     switch (m_outputMode)
     {

--- a/tools/slang-test/test-reporter.cpp
+++ b/tools/slang-test/test-reporter.cpp
@@ -42,7 +42,7 @@ static bool isXmlEncodeChar(char c)
 static void appendXmlEncode(const String& in, StringBuilder& out)
 {
     const char* cur = in.Buffer();
-    const char* end = cur + in.Length();
+    const char* end = cur + in.getLength();
 
     while (cur < end)
     {
@@ -308,7 +308,7 @@ void TestReporter::_addResult(const TestInfo& info)
             {
                 case TestResult::Fail:      
                 {
-                    if (info.message.Length())
+                    if (info.message.getLength())
                     {
                         StringBuilder escapedMessage;
                         _appendEncodedTeamCityString(info.message.getUnownedSlice(), escapedMessage);            
@@ -322,7 +322,7 @@ void TestReporter::_addResult(const TestInfo& info)
                 }
                 case TestResult::Pass:     
                 {
-                    if (info.message.Length())
+                    if (info.message.getLength())
                     {
                         StringBuilder escapedMessage;
                         _appendEncodedTeamCityString(info.message.getUnownedSlice(), escapedMessage);
@@ -332,7 +332,7 @@ void TestReporter::_addResult(const TestInfo& info)
                 }
                 case TestResult::Ignored:  
                 {
-                    if (info.message.Length())
+                    if (info.message.getLength())
                     {
                         StringBuilder escapedMessage;
                         _appendEncodedTeamCityString(info.message.getUnownedSlice(), escapedMessage);
@@ -442,7 +442,7 @@ void TestReporter::message(TestMessageType type, const String& message)
         }
     }
 
-    if (m_currentMessage.Length() > 0)
+    if (m_currentMessage.getLength() > 0)
     {
         m_currentMessage << "\n";
     }

--- a/tools/slang-test/test-reporter.cpp
+++ b/tools/slang-test/test-reporter.cpp
@@ -110,7 +110,7 @@ bool TestReporter::canWriteStdError() const
 void TestReporter::startTest(const String& testName)
 {
     // Must be in a suite
-    assert(m_suiteStack.Count());
+    assert(m_suiteStack.getSize());
     assert(!m_inTest);
 
     m_inTest = true;
@@ -125,7 +125,7 @@ void TestReporter::startTest(const String& testName)
 
 void TestReporter::endTest()
 {
-    assert(m_suiteStack.Count());
+    assert(m_suiteStack.getSize());
     assert(m_inTest);
 
     m_currentInfo.message = m_currentMessage;
@@ -595,7 +595,7 @@ void TestReporter::startSuite(const String& name)
 
 void TestReporter::endSuite()
 {
-    assert(m_suiteStack.Count());
+    assert(m_suiteStack.getSize());
 
     switch (m_outputMode)
     {

--- a/tools/slang-test/test-reporter.cpp
+++ b/tools/slang-test/test-reporter.cpp
@@ -41,7 +41,7 @@ static bool isXmlEncodeChar(char c)
 
 static void appendXmlEncode(const String& in, StringBuilder& out)
 {
-    const char* cur = in.Buffer();
+    const char* cur = in.getBuffer();
     const char* end = cur + in.getLength();
 
     while (cur < end)
@@ -195,13 +195,13 @@ void TestReporter::dumpOutputDifference(const String& expectedOutput, const Stri
         "ERROR:\n"
         "EXPECTED{{{\n%s}}}\n"
         "ACTUAL{{{\n%s}}}\n",
-        expectedOutput.Buffer(),
-        actualOutput.Buffer());
+        expectedOutput.getBuffer(),
+        actualOutput.getBuffer());
 
 
     if (m_dumpOutputOnFailure && canWriteStdError())
     {
-        fprintf(stderr, "%s", builder.Buffer());
+        fprintf(stderr, "%s", builder.getBuffer());
         fflush(stderr);
     }
 
@@ -294,7 +294,7 @@ void TestReporter::_addResult(const TestInfo& info)
                     assert(!"unexpected");
                     break;
             }
-            printf("%s test: '%S'\n", resultString, info.name.ToWString().begin());
+            printf("%s test: '%S'\n", resultString, info.name.toWString().begin());
             break;
         }
         case TestOutputMode::TeamCity:
@@ -389,7 +389,7 @@ void TestReporter::_addResult(const TestInfo& info)
 
             if (err != kOSError_None)
             {
-                messageFormat(TestMessageType::Info, "failed to add appveyor test results for '%S'\n", info.name.ToWString().begin());
+                messageFormat(TestMessageType::Info, "failed to add appveyor test results for '%S'\n", info.name.toWString().begin());
 
 #if 0
                 fprintf(stderr, "[%d] TEST RESULT: %s {%d} {%s} {%s}\n", err, spawner.commandLine_.Buffer(),
@@ -421,7 +421,7 @@ void TestReporter::message(TestMessageType type, const String& message)
     {
         if (m_isVerbose && canWriteStdError())
         {
-            fputs(message.Buffer(), stderr);
+            fputs(message.getBuffer(), stderr);
         }
 
         // Just dump out if can dump out
@@ -433,12 +433,12 @@ void TestReporter::message(TestMessageType type, const String& message)
         if (type == TestMessageType::RunError || type == TestMessageType::TestFailure)
         {
             fprintf(stderr, "error: ");
-            fputs(message.Buffer(), stderr);
+            fputs(message.getBuffer(), stderr);
             fprintf(stderr, "\n");
         }
         else
         {
-            fputs(message.Buffer(), stderr);
+            fputs(message.getBuffer(), stderr);
         }
     }
 
@@ -505,7 +505,7 @@ void TestReporter::outputSummary()
                 {
                     if (testInfo.testResult == TestResult::Fail)
                     {
-                        printf("%s\n", testInfo.name.Buffer());
+                        printf("%s\n", testInfo.name.getBuffer());
                     }
                 }
                 printf("---\n");
@@ -529,11 +529,11 @@ void TestReporter::outputSummary()
 
                 if (testInfo.testResult == TestResult::Pass)
                 {
-                    printf("    <testcase name=\"%s\" status=\"run\"/>\n", testInfo.name.Buffer());
+                    printf("    <testcase name=\"%s\" status=\"run\"/>\n", testInfo.name.getBuffer());
                 }
                 else
                 {
-                    printf("    <testcase name=\"%s\" status=\"run\">\n", testInfo.name.Buffer());
+                    printf("    <testcase name=\"%s\" status=\"run\">\n", testInfo.name.getBuffer());
                     switch (testInfo.testResult)
                     {
                         case TestResult::Fail:
@@ -542,7 +542,7 @@ void TestReporter::outputSummary()
                             appendXmlEncode(testInfo.message, buf);
 
                             printf("      <error>\n");
-                            printf("%s", buf.Buffer());
+                            printf("%s", buf.getBuffer());
                             printf("      </error>\n");
                             break;
                         }

--- a/tools/slang-test/test-reporter.cpp
+++ b/tools/slang-test/test-reporter.cpp
@@ -278,7 +278,7 @@ void TestReporter::_addResult(const TestInfo& info)
             break;
     }
 
-    m_testInfos.Add(info);
+    m_testInfos.add(info);
 
     //    printf("OUTPUT_MODE: %d\n", options.outputMode);
     switch (m_outputMode)
@@ -578,7 +578,7 @@ void TestReporter::outputSummary()
 
 void TestReporter::startSuite(const String& name)
 {
-    m_suiteStack.Add(name);
+    m_suiteStack.add(name);
 
     switch (m_outputMode)
     {
@@ -601,7 +601,7 @@ void TestReporter::endSuite()
     {
         case TestOutputMode::TeamCity:
         {
-            const String& name = m_suiteStack.Last();
+            const String& name = m_suiteStack.getLast();
             StringBuilder escapedSuiteName;
             _appendEncodedTeamCityString(name.getUnownedSlice(), escapedSuiteName);
             printf("##teamcity[testSuiteFinished name='%s']\n", escapedSuiteName.begin());
@@ -610,5 +610,5 @@ void TestReporter::endSuite()
         default: break;
     }
     
-    m_suiteStack.RemoveLast();
+    m_suiteStack.removeLast();
 }

--- a/tools/slang-test/test-reporter.cpp
+++ b/tools/slang-test/test-reporter.cpp
@@ -392,7 +392,7 @@ void TestReporter::_addResult(const TestInfo& info)
                 messageFormat(TestMessageType::Info, "failed to add appveyor test results for '%S'\n", info.name.toWString().begin());
 
 #if 0
-                fprintf(stderr, "[%d] TEST RESULT: %s {%d} {%s} {%s}\n", err, spawner.commandLine_.Buffer(),
+                fprintf(stderr, "[%d] TEST RESULT: %s {%d} {%s} {%s}\n", err, spawner.commandLine_.getBuffer(),
                     spawner.getResultCode(),
                     spawner.getStandardOutput().begin(),
                     spawner.getStandardError().begin());

--- a/tools/slang-test/test-reporter.cpp
+++ b/tools/slang-test/test-reporter.cpp
@@ -4,7 +4,6 @@
 #include "os.h"
 #include "../../source/core/slang-string-util.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/tools/slang-test/unit-test-byte-encode.cpp
+++ b/tools/slang-test/unit-test-byte-encode.cpp
@@ -79,12 +79,12 @@ static void byteEncodeUnitTest()
         const int blockSize = 1024;
 
         List<uint8_t> encodedBuffer;
-        encodedBuffer.SetSize(ByteEncodeUtil::kMaxLiteEncodeUInt32 * blockSize);
+        encodedBuffer.setSize(ByteEncodeUtil::kMaxLiteEncodeUInt32 * blockSize);
 
         List<uint32_t> initialBuffer;
-        initialBuffer.SetSize(blockSize);
+        initialBuffer.setSize(blockSize);
         List<uint32_t> decodeBuffer;
-        decodeBuffer.SetSize(blockSize);
+        decodeBuffer.setSize(blockSize);
         // Put in cache?
         memset(decodeBuffer.begin(), 0, blockSize * sizeof(uint32_t));
 

--- a/tools/slang-test/unit-test-byte-encode.cpp
+++ b/tools/slang-test/unit-test-byte-encode.cpp
@@ -2,7 +2,6 @@
 
 #include "../../source/core/slang-byte-encode-util.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/tools/slang-test/unit-test-byte-encode.cpp
+++ b/tools/slang-test/unit-test-byte-encode.cpp
@@ -78,12 +78,12 @@ static void byteEncodeUnitTest()
         const int blockSize = 1024;
 
         List<uint8_t> encodedBuffer;
-        encodedBuffer.setSize(ByteEncodeUtil::kMaxLiteEncodeUInt32 * blockSize);
+        encodedBuffer.setCount(ByteEncodeUtil::kMaxLiteEncodeUInt32 * blockSize);
 
         List<uint32_t> initialBuffer;
-        initialBuffer.setSize(blockSize);
+        initialBuffer.setCount(blockSize);
         List<uint32_t> decodeBuffer;
-        decodeBuffer.setSize(blockSize);
+        decodeBuffer.setCount(blockSize);
         // Put in cache?
         memset(decodeBuffer.begin(), 0, blockSize * sizeof(uint32_t));
 

--- a/tools/slang-test/unit-test-free-list.cpp
+++ b/tools/slang-test/unit-test-free-list.cpp
@@ -33,11 +33,11 @@ static void freeListUnitTest()
         }
 
         int numDealloc = randGen.nextInt32UpTo(19);
-        numDealloc = int(allocs.getSize()) < numDealloc ? int(allocs.getSize()) : numDealloc;
+        numDealloc = int(allocs.getCount()) < numDealloc ? int(allocs.getCount()) : numDealloc;
 
         for (int j = 0; j < numDealloc; j++)
         {
-            const int index = randGen.nextInt32UpTo(int(allocs.getSize()));
+            const int index = randGen.nextInt32UpTo(int(allocs.getCount()));
 
             int* alloc = allocs[index];
 

--- a/tools/slang-test/unit-test-free-list.cpp
+++ b/tools/slang-test/unit-test-free-list.cpp
@@ -47,7 +47,7 @@ static void freeListUnitTest()
 
             freeList.deallocate(alloc);
 
-            allocs.FastRemoveAt(index);
+            allocs.fastRemoveAt(index);
         }
     }
 }

--- a/tools/slang-test/unit-test-free-list.cpp
+++ b/tools/slang-test/unit-test-free-list.cpp
@@ -2,7 +2,6 @@
 
 #include "../../source/core/slang-free-list.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/tools/slang-test/unit-test-free-list.cpp
+++ b/tools/slang-test/unit-test-free-list.cpp
@@ -34,11 +34,11 @@ static void freeListUnitTest()
         }
 
         int numDealloc = randGen.nextInt32UpTo(19);
-        numDealloc = int(allocs.Count()) < numDealloc ? int(allocs.Count()) : numDealloc;
+        numDealloc = int(allocs.getSize()) < numDealloc ? int(allocs.getSize()) : numDealloc;
 
         for (int j = 0; j < numDealloc; j++)
         {
-            const int index = randGen.nextInt32UpTo(int(allocs.Count()));
+            const int index = randGen.nextInt32UpTo(int(allocs.getSize()));
 
             int* alloc = allocs[index];
 

--- a/tools/slang-test/unit-test-free-list.cpp
+++ b/tools/slang-test/unit-test-free-list.cpp
@@ -30,7 +30,7 @@ static void freeListUnitTest()
         {
             int* ptr = (int*)freeList.allocate();
             *ptr = i;
-            allocs.Add(ptr);
+            allocs.add(ptr);
         }
 
         int numDealloc = randGen.nextInt32UpTo(19);

--- a/tools/slang-test/unit-test-memory-arena.cpp
+++ b/tools/slang-test/unit-test-memory-arena.cpp
@@ -156,7 +156,7 @@ static void memoryArenaUnitTest()
                 count++;
 
                 const int var = randGen.nextInt32() & 0x3ff;
-                if (var < 3 && blocks.Count() > 0)
+                if (var < 3 && blocks.getSize() > 0)
                 {
                     if (var == 1)
                     {
@@ -177,7 +177,7 @@ static void memoryArenaUnitTest()
                     else if (var == 4)
                     {
                         // Rewind to a random position
-                        int rewindIndex = randGen.nextInt32UpTo(int32_t(blocks.Count()));
+                        int rewindIndex = randGen.nextInt32UpTo(int32_t(blocks.getSize()));
                         // rewind to this block
                         arena.rewindToCursor(blocks[rewindIndex].m_data);
                         // All the blocks (includign this one) and now deallocated
@@ -252,7 +252,7 @@ static void memoryArenaUnitTest()
                 }
 
                 // Check the blocks
-                for (int j = 0; j < int(blocks.Count()); ++j)
+                for (int j = 0; j < int(blocks.getSize()); ++j)
                 {
                     const Block& block = blocks[j];
 

--- a/tools/slang-test/unit-test-memory-arena.cpp
+++ b/tools/slang-test/unit-test-memory-arena.cpp
@@ -2,7 +2,6 @@
 
 #include "../../source/core/slang-memory-arena.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/tools/slang-test/unit-test-memory-arena.cpp
+++ b/tools/slang-test/unit-test-memory-arena.cpp
@@ -251,7 +251,7 @@ static void memoryArenaUnitTest()
                 }
 
                 // Check the blocks
-                for (int j = 0; j < int(blocks.getCount()); ++j)
+                for (Index j = 0; j < blocks.getCount(); ++j)
                 {
                     const Block& block = blocks[j];
 

--- a/tools/slang-test/unit-test-memory-arena.cpp
+++ b/tools/slang-test/unit-test-memory-arena.cpp
@@ -181,7 +181,7 @@ static void memoryArenaUnitTest()
                         // rewind to this block
                         arena.rewindToCursor(blocks[rewindIndex].m_data);
                         // All the blocks (includign this one) and now deallocated
-                        blocks.SetSize(rewindIndex);
+                        blocks.setSize(rewindIndex);
 
                     }
                     else

--- a/tools/slang-test/unit-test-memory-arena.cpp
+++ b/tools/slang-test/unit-test-memory-arena.cpp
@@ -162,17 +162,17 @@ static void memoryArenaUnitTest()
                     {
                         // Deallocate everything
                         arena.deallocateAll();
-                        blocks.Clear();
+                        blocks.clear();
                     }   
                     else if (var == 2)
                     {
                         arena.reset();
-                        blocks.Clear();
+                        blocks.clear();
                     }
                     else if (var == 3)
                     {
                         arena.rewindToCursor(nullptr);
-                        blocks.Clear();
+                        blocks.clear();
                     }
                     else if (var == 4)
                     {

--- a/tools/slang-test/unit-test-memory-arena.cpp
+++ b/tools/slang-test/unit-test-memory-arena.cpp
@@ -117,15 +117,15 @@ static void memoryArenaUnitTest()
 
         List<void*> blocks;
 
-        blocks.Add(arena.allocate(100));
-        blocks.Add(arena.allocate(blockSize * 2));
-        blocks.Add(arena.allocate(100));
-        blocks.Add(arena.allocate(blockSize * 2));
-        blocks.Add(arena.allocate(100));
+        blocks.add(arena.allocate(100));
+        blocks.add(arena.allocate(blockSize * 2));
+        blocks.add(arena.allocate(100));
+        blocks.add(arena.allocate(blockSize * 2));
+        blocks.add(arena.allocate(100));
 
         arena.deallocateAll();
-        blocks.Add(arena.allocate(100));
-        blocks.Add(arena.allocate(blockSize * 2));
+        blocks.add(arena.allocate(100));
+        blocks.add(arena.allocate(blockSize * 2));
 
         arena.reset();
 
@@ -248,7 +248,7 @@ static void memoryArenaUnitTest()
                     block.m_size = sizeInBytes;
                     block.m_value = value;
 
-                    blocks.Add(block);
+                    blocks.add(block);
                 }
 
                 // Check the blocks

--- a/tools/slang-test/unit-test-memory-arena.cpp
+++ b/tools/slang-test/unit-test-memory-arena.cpp
@@ -155,7 +155,7 @@ static void memoryArenaUnitTest()
                 count++;
 
                 const int var = randGen.nextInt32() & 0x3ff;
-                if (var < 3 && blocks.getSize() > 0)
+                if (var < 3 && blocks.getCount() > 0)
                 {
                     if (var == 1)
                     {
@@ -176,11 +176,11 @@ static void memoryArenaUnitTest()
                     else if (var == 4)
                     {
                         // Rewind to a random position
-                        int rewindIndex = randGen.nextInt32UpTo(int32_t(blocks.getSize()));
+                        int rewindIndex = randGen.nextInt32UpTo(int32_t(blocks.getCount()));
                         // rewind to this block
                         arena.rewindToCursor(blocks[rewindIndex].m_data);
                         // All the blocks (includign this one) and now deallocated
-                        blocks.setSize(rewindIndex);
+                        blocks.setCount(rewindIndex);
 
                     }
                     else
@@ -251,7 +251,7 @@ static void memoryArenaUnitTest()
                 }
 
                 // Check the blocks
-                for (int j = 0; j < int(blocks.getSize()); ++j)
+                for (int j = 0; j < int(blocks.getCount()); ++j)
                 {
                     const Block& block = blocks[j];
 


### PR DESCRIPTION
* Use lowerCamel method names on
** String, List, FilteredList, 
* Use m_ where appropriate
* Use Index where could be simply determined
** It could be used elsewhere
** If it is known that Index is signed, can use < 0 for indexOf 
* For some methods prefix with get (Buffer->getBuffer, Count -> getCount, Length -> getLength)
* Use Count more consistently (setSize -> setCount etc)
* Removed stride from ArrayView. It wasn't used - and allows future refactor improvements
* Improved IntSet, fixed bug around ==

NOTE!

* Some methods still return int - did not change until *confirmed* that Index is signed
* List<T> getBuffer is NOT const safe. Some other classes rely on this
* Future work required to use Index more appropriately across code base
