### PR TITLE
Fix glsl geometry shader problem setting gl_primitiveID

### DIFF
--- a/source/slang/ir-glsl-legalize.cpp
+++ b/source/slang/ir-glsl-legalize.cpp
@@ -353,6 +353,9 @@ GLSLSystemValueInfo* getGLSLSystemValueInfo(
     else if(semanticName == "sv_primitiveid")
     {
         name = "gl_PrimitiveID";
+
+        auto builder = context->getBuilder();
+        requiredType = builder->getBasicType(BaseType::Int);
     }
     else if (semanticName == "sv_rendertargetarrayindex")
     {


### PR DESCRIPTION
The gl_primitiveID built in type is int, but can be uint on HLSL. The change trys to cast for glsl targets to avoid glslang producing a type error.