### PR TITLE
HotFix: Fix a random crash that can occur due to a buffer overun.

### DIFF
--- a/source/slang/source-loc.cpp
+++ b/source/slang/source-loc.cpp
@@ -234,9 +234,13 @@ const List<uint32_t>& SourceFile::getLineBreakOffsets()
                     // where a multi-byte sequence might encode
                     // the line break.
 
-                    int d = *cursor;
-                    if ((c^d) == ('\r' ^ '\n'))
-                        cursor++;
+                    // Check to make sure that the EOF hasn't been reached.
+                    if (cursor != end)
+                    {
+                        int d = *cursor;
+                        if ((c ^ d) == ('\r' ^ '\n'))
+                            cursor++;
+                    }
 
                     m_lineBreakOffsets.add(uint32_t(cursor - begin));
                     break;


### PR DESCRIPTION
Fix a buffer overrun that can occur when the last byte of the file is '\r' or '\n' and the byte adjacent to the last character in the file in memory is '\r' or '\n'.