### PR TITLE
[Update language-guide.md] Error on the associated types example

### DIFF
--- a/docs/language-guide.md
+++ b/docs/language-guide.md
@@ -202,7 +202,7 @@ interface IMaterial
 struct MyCoolMaterial : IMaterial
 {
 	typedef DisneyBRDF B;
-	DisneyBRDF evalPattern(float3 position, float2 uv)
+	B evalPattern(float3 position, float2 uv)
 	{ ... }
 }
 ```


### PR DESCRIPTION
I found this while I was reading the guide, I think this is what was intended to be there from the start.