### PR TITLE
Fix shared library loading for testing.

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -869,6 +869,11 @@ extern "C"
     struct ISlangSharedLibraryLoader: public ISlangUnknown
     {
         public:
+            /** Load a shared library. In typical usage the library name should *not* contain any platform
+            specific elements. For example on windows a dll name should *not* be passed with a '.dll' extension,
+            and similarly on linux a shared library should *not* be passed with the 'lib' prefix and '.so' extension
+            @path path The unadorned filename and/or path for the shared library
+            @ param sharedLibraryOut Holds the shared library if successfully loaded */
         virtual SLANG_NO_THROW SlangResult SLANG_MCALL loadSharedLibrary(
             const char*     path,
             ISlangSharedLibrary** sharedLibraryOut) = 0;

--- a/source/core/slang-platform.h
+++ b/source/core/slang-platform.h
@@ -15,7 +15,12 @@ namespace Slang
         
         typedef void(*FuncPtr)(void);
 
-            /// Load via an unadorned filename
+            /// Load via an unadorned filename.
+            ///
+            /// The unadorned filename here means without any platform specific filename elements. This typically means no extension and no prefix.
+            /// On windows this means without the '.dll' extension.
+            /// On linux this means without the 'lib' prefix and '.so' extension.
+            /// To load with a platform specific filename use the 'loadWithPlatformFilename' API
             /// 
             /// @param the unadorned filename
             /// @return Returns a non null handle for the shared library on success. nullptr indicated failure
@@ -42,7 +47,7 @@ namespace Slang
             /// The input name should be unadorned with any 'lib' prefix or extension
         static void appendPlatformFileName(const UnownedStringSlice& name, StringBuilder& dst);
 
-            /// Calculate the shared library 
+            /// Given a path, calculate that path with the filename replaced with the platform filename (using appendPlatformFilename)
         static String calcPlatformPath(const UnownedStringSlice& path);
 
         private:

--- a/source/core/slang-render-api-util.cpp
+++ b/source/core/slang-render-api-util.cpp
@@ -262,10 +262,10 @@ static bool _canLoadSharedLibrary(const char* libName)
 #if SLANG_WINDOWS_FAMILY
     switch (type)
     {
-        case RenderApiType::OpenGl:    return _canLoadSharedLibrary("opengl32.dll");
-        case RenderApiType::Vulkan:    return _canLoadSharedLibrary("vulkan-1.dll");
-        case RenderApiType::D3D11:     return _canLoadSharedLibrary("d3d11.dll"); 
-        case RenderApiType::D3D12:     return _canLoadSharedLibrary("d3d12.dll"); 
+        case RenderApiType::OpenGl:    return _canLoadSharedLibrary("opengl32");
+        case RenderApiType::Vulkan:    return _canLoadSharedLibrary("vulkan-1");
+        case RenderApiType::D3D11:     return _canLoadSharedLibrary("d3d11"); 
+        case RenderApiType::D3D12:     return _canLoadSharedLibrary("d3d12"); 
         default: break; 
     }
 #elif SLANG_UNIX_FAMILY


### PR DESCRIPTION
A previous PR changed the behavior of calculating shared library filenames. The change meant that on windows shared libraries when their name was calculated the '.dll' was added. This was necessary because other code now wanted to delete the dlls before creating them. Before it was not a problem because in windows if the .dll extension is left off the file is still correctly found and loaded.

Unfortunately in code that used the SharedLibrary slang module, when it new it was only used on windows, the file shared library was loaded with the .dll extension as part of the filename. That the SharedLibrary because it works across platforms, should not include the extension when loading (unless being loaded with the 'Platform' API methods). 

The fix just removes the .dll extension which was leading to the dll not being loaded. 

We may want to use the SharedLibrary API across the code base more because it will allow for example invoking of dxc from linux if we had a linux dxc binary.