### PR TITLE
Start exposing a new COM-lite API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.VC.db
 *.vcxproj.user
 *.sdf
+*.ilk
+*.obj
 bin/
 intermediate/
 build.*/

--- a/slang-com-helper.h
+++ b/slang-com-helper.h
@@ -70,7 +70,7 @@ For SLANG_IUNKNOWN_QUERY_INTERFACE to work - must have a method 'getInterface' t
 if not found. */
 
 #define SLANG_IUNKNOWN_QUERY_INTERFACE \
-SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const& uuid, void** outObject) \
+SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const& uuid, void** outObject) SLANG_OVERRIDE \
 { \
     ISlangUnknown* intf = getInterface(uuid); \
     if (intf) \

--- a/slang-com-helper.h
+++ b/slang-com-helper.h
@@ -108,7 +108,7 @@ SLANG_NO_THROW uint32_t SLANG_MCALL release() \
 // ------------------------ RefObject IUnknown -----------------------------
 
 #define SLANG_REF_OBJECT_IUNKNOWN_QUERY_INTERFACE \
-SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const& uuid, void** outObject) \
+SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const& uuid, void** outObject) SLANG_OVERRIDE \
 { \
     ISlangUnknown* intf = getInterface(uuid); \
     if (intf) \
@@ -120,8 +120,8 @@ SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const& uuid, voi
     return SLANG_E_NO_INTERFACE;\
 }
 
-#define SLANG_REF_OBJECT_IUNKNOWN_ADD_REF SLANG_NO_THROW uint32_t SLANG_MCALL addRef() { return (uint32_t)addReference(); }
-#define SLANG_REF_OBJECT_IUNKNOWN_RELEASE SLANG_NO_THROW uint32_t SLANG_MCALL release() { return (uint32_t)releaseReference(); }
+#define SLANG_REF_OBJECT_IUNKNOWN_ADD_REF SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE { return (uint32_t)addReference(); }
+#define SLANG_REF_OBJECT_IUNKNOWN_RELEASE SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE { return (uint32_t)releaseReference(); }
 
 #define SLANG_REF_OBJECT_IUNKNOWN_ALL \
     SLANG_REF_OBJECT_IUNKNOWN_QUERY_INTERFACE \

--- a/slang.h
+++ b/slang.h
@@ -2769,8 +2769,8 @@ namespace slang
             */
         virtual SLANG_NO_THROW TypeReflection* SLANG_MCALL specializeType(
             TypeReflection*             type,
-            SlangInt                    specializationArgCount,
             SpecializationArg const*    specializationArgs,
+            SlangInt                    specializationArgCount,
             ISlangBlob**                outDiagnostics = nullptr) = 0;
 
 
@@ -2786,24 +2786,6 @@ namespace slang
             */
         virtual SLANG_NO_THROW SlangResult SLANG_MCALL createCompileRequest(
             SlangCompileRequest**   outCompileRequest) = 0;
-
-#if 0
-            /** Add a path to use when searching for `#include`d or `import`ed files.
-            */
-        virtual SLANG_NO_THROW SlangResult SLANG_MCALL addSearchPath(
-            char const* path) = 0;
-
-            /** Add a global preprocessor definition to use for all compilation.
-            */
-        virtual SLANG_NO_THROW SlangResult SLANG_MCALL addPreprocessorDefine(
-            char const* name,
-            char const* value) = 0;
-
-            /** Set the default matrix layout mode to use for all compiles.
-            */
-        virtual SLANG_NO_THROW SlangResult SLANG_MCALL setMatrixLayoutMode(
-            SlangMatrixLayoutMode mode) = 0;
-#endif
     };
 
     #define SLANG_UUID_ISession { 0x67618701, 0xd116, 0x468f, { 0xab, 0x3b, 0x47, 0x4b, 0xed, 0xce, 0xe, 0x3d } }

--- a/slang.h
+++ b/slang.h
@@ -298,8 +298,15 @@ convention for interface methods.
 
 #ifdef __cplusplus
 // C++ specific macros
+// Clang
+#if SLANG_CLANG
+#    if (__clang_major__*10 + __clang_minor__) >= 330
+#       define SLANG_HAS_MOVE_SEMANTICS 1
+#       define SLANG_HAS_ENUM_CLASS 1
+#       define SLANG_OVERRIDE override
+#    endif
 // Gcc
-#	if SLANG_GCC_FAMILY
+#elif SLANG_GCC_FAMILY
 // Check for C++11
 #		if (__cplusplus >= 201103L)
 #			if (__GNUC__ * 100 + __GNUC_MINOR__) >= 405

--- a/slang.h
+++ b/slang.h
@@ -300,7 +300,7 @@ convention for interface methods.
 // C++ specific macros
 // Clang
 #if SLANG_CLANG
-#    if (__clang_major__*10 + __clang_minor__) >= 330
+#    if (__clang_major__*10 + __clang_minor__) >= 33
 #       define SLANG_HAS_MOVE_SEMANTICS 1
 #       define SLANG_HAS_ENUM_CLASS 1
 #       define SLANG_OVERRIDE override

--- a/source/core/core.vcxproj
+++ b/source/core/core.vcxproj
@@ -231,7 +231,9 @@
     <ClCompile Include="windows\slang-win-visual-studio-util.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="core.natvis" />
+    <Natvis Include="core.natvis">
+      <FileType>Document</FileType>
+    </Natvis>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/source/core/slang-writer.h
+++ b/source/core/slang-writer.h
@@ -45,7 +45,7 @@ public:
     // ISlangUnknown
     SLANG_REF_OBJECT_IUNKNOWN_QUERY_INTERFACE
     SLANG_REF_OBJECT_IUNKNOWN_ADD_REF
-    SLANG_NO_THROW uint32_t SLANG_MCALL release() { return (m_flags & WriterFlag::IsStatic) ? (uint32_t)decreaseReference() : (uint32_t)releaseReference(); }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE { return (m_flags & WriterFlag::IsStatic) ? (uint32_t)decreaseReference() : (uint32_t)releaseReference(); }
 
     // ISlangWriter - default impl
     SLANG_NO_THROW virtual void SLANG_MCALL flush() SLANG_OVERRIDE {}

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -653,8 +653,8 @@ namespace Slang
             ISlangBlob**                outDiagnostics = nullptr) override;
         SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL specializeType(
             slang::TypeReflection*          type,
-            SlangInt                        specializationArgCount,
             slang::SpecializationArg const* specializationArgs,
+            SlangInt                        specializationArgCount,
             ISlangBlob**                    outDiagnostics = nullptr) override;
         SLANG_NO_THROW slang::TypeLayoutReflection* SLANG_MCALL getTypeLayout(
             slang::TypeReflection* type,

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -366,6 +366,55 @@ namespace Slang
         ModuleDependencyList m_dependencyList;
     };
 
+    class EntryPointGroup : public RefObject
+    {
+    public:
+        static RefPtr<EntryPointGroup> create(
+            Linkage*                        linkage,
+            List<RefPtr<EntryPoint>> const& entryPoints,
+            DiagnosticSink*                 sink);
+
+        Linkage* getLinkageImpl() { return m_linkage; }
+
+            /// Get the number of entry points in the group
+        Index getEntryPointCount() { return m_entryPoints.getCount(); }
+
+            /// Get the entry point at the given `index`.
+        RefPtr<EntryPoint> getEntryPoint(Index index) { return m_entryPoints[index]; }
+
+            /// Get the full ist of entry points in the group.
+        List<RefPtr<EntryPoint>> const& getEntryPoints() { return m_entryPoints; }
+
+            /// Get a list of modules that this entry point group depends on.
+            ///
+            /// This will include the dependencies of all of the entry points in the group.
+            ///
+        List<RefPtr<Module>> getModuleDependencies() { return m_dependencyList.getModuleList(); }
+
+            /// Get an array of all entry-point-group shader parameters.
+        List<ShaderParamInfo> const& getShaderParams() { return m_shaderParams; }
+
+    private:
+        EntryPointGroup(Linkage* linkage)
+            : m_linkage(linkage)
+        {}
+
+        void _collectShaderParams(DiagnosticSink* sink);
+
+        Linkage* m_linkage;
+        List<RefPtr<EntryPoint>> m_entryPoints;
+
+            /// Information about shader parameters to be associated with the entry-point group itself.
+            ///
+            /// This list captures parameters that logically belong to the group itself, rather than
+            /// to any specific entry point in the group.
+            ///
+        List<ShaderParamInfo> m_shaderParams;
+
+            /// Modules the entry point group depends on.
+        ModuleDependencyList m_dependencyList;
+    };
+
     enum class PassThroughMode : SlangPassThrough
     {
         None = SLANG_PASS_THROUGH_NONE,	// don't pass through: use Slang compiler
@@ -382,9 +431,13 @@ namespace Slang
         /// may span multiple Slang source files), and provides access
         /// to both the AST and IR representations of that code.
         ///
-    class Module : public RefObject
+    class Module : public RefObject, public slang::IModule
     {
     public:
+        SLANG_REF_OBJECT_IUNKNOWN_ALL
+
+        ISlangUnknown* getInterface(const Guid& guid);
+
             /// Create a module (initially empty).
         Module(Linkage* linkage);
 
@@ -525,6 +578,8 @@ namespace Slang
         Dictionary<Type*, RefPtr<TypeLayout>> typeLayouts;
 
         Dictionary<Type*, RefPtr<TypeLayout>>& getTypeLayouts() { return typeLayouts; }
+
+        TypeLayout* getTypeLayout(Type* type);
     };
 
         /// Are we generating code for a D3D API?
@@ -576,14 +631,54 @@ namespace Slang
     ComPtr<ISlangBlob> createRawBlob(void const* data, size_t size);
 
         /// A context for loading and re-using code modules.
-    class Linkage : public RefObject
+    class Linkage : public RefObject, public slang::ISession
     {
     public:
+        SLANG_REF_OBJECT_IUNKNOWN_ALL
+
+        ISlangUnknown* getInterface(const Guid& guid);
+
+        SLANG_NO_THROW slang::IGlobalSession* SLANG_MCALL getGlobalSession() override;
+        SLANG_NO_THROW slang::IModule* SLANG_MCALL loadModule(
+            const char* moduleName,
+            slang::IBlob**     outDiagnostics = nullptr) override;
+        SLANG_NO_THROW SlangResult SLANG_MCALL createProgram(
+            slang::ProgramDesc const& desc,
+            slang::IProgram**         outProgram) override;
+        SLANG_NO_THROW SlangResult SLANG_MCALL specializeProgram(
+            slang::IProgram*                   program,
+            SlangInt                    specializationArgCount,
+            slang::SpecializationArg const*    specializationArgs,
+            slang::IProgram**                  outSpecializedProgram,
+            ISlangBlob**                outDiagnostics = nullptr) override;
+        SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL specializeType(
+            slang::TypeReflection*          type,
+            SlangInt                        specializationArgCount,
+            slang::SpecializationArg const* specializationArgs,
+            ISlangBlob**                    outDiagnostics = nullptr) override;
+        SLANG_NO_THROW slang::TypeLayoutReflection* SLANG_MCALL getTypeLayout(
+            slang::TypeReflection* type,
+            SlangInt               targetIndex = 0,
+            slang::LayoutRules     rules = slang::LayoutRules::Default,
+            ISlangBlob**    outDiagnostics = nullptr) override;
+        SLANG_NO_THROW SlangResult SLANG_MCALL createCompileRequest(
+            SlangCompileRequest**   outCompileRequest) override;
+
+        void addTarget(
+            slang::TargetDesc const& desc);
+        SlangResult addSearchPath(
+            char const* path);
+        SlangResult addPreprocessorDefine(
+            char const* name,
+            char const* value);
+        SlangResult setMatrixLayoutMode(
+            SlangMatrixLayoutMode mode);
+
             /// Create an initially-empty linkage
         Linkage(Session* session);
 
             /// Get the parent session for this linkage
-        Session* getSession() { return m_session; }
+        Session* getSessionImpl() { return m_session; }
 
         // Information on the targets we are being asked to
         // generate code for.
@@ -702,6 +797,8 @@ namespace Slang
         DebugInfoLevel debugInfoLevel = DebugInfoLevel::None;
 
         OptimizationLevel optimizationLevel = OptimizationLevel::Default;
+
+        bool m_useFalcorCustomSharedKeywordSemantics = false;
 
     private:
         Session* m_session = nullptr;
@@ -887,9 +984,25 @@ namespace Slang
         /// to be used togehter so that, e.g., layout can make sure to allocate
         /// space for the global shader parameters in all referenced modules.
         ///
-    class Program : public RefObject
+    class Program : public RefObject, public slang::IProgram
     {
     public:
+        SLANG_REF_OBJECT_IUNKNOWN_ALL;
+        ISlangUnknown* getInterface(Guid const& guid);
+
+        SLANG_NO_THROW slang::ISession* SLANG_MCALL getSession() override;
+
+        SLANG_NO_THROW slang::ProgramLayout* SLANG_MCALL getLayout(
+            SlangInt        targetIndex,
+            slang::IBlob**  outDiagnostics) override;
+
+        SLANG_NO_THROW SlangResult SLANG_MCALL getEntryPointCode(
+            SlangInt        entryPointIndex,
+            SlangInt        targetIndex,
+            slang::IBlob**  outCode,
+            slang::IBlob**  outDiagnostics) override;
+
+
             /// Create a new program, initially empty.
             ///
             /// All code loaded into the program must come
@@ -898,7 +1011,7 @@ namespace Slang
             Linkage* linkage);
 
             /// Get the linkage that this program uses.
-        Linkage* getLinkage() { return m_linkage; }
+        Linkage* getLinkageImpl() { return m_linkage; }
 
             /// Get the number of entry points added to the program
         Index getEntryPointCount() { return m_entryPoints.getCount(); }
@@ -908,6 +1021,12 @@ namespace Slang
 
             /// Get the full ist of entry points on the program.
         List<RefPtr<EntryPoint>> const& getEntryPoints() { return m_entryPoints; }
+
+
+        Index getEntryPointGroupCount() { return m_entryPointGroups.getCount(); }
+        RefPtr<EntryPointGroup> getEntryPointGroup(Index index) { return m_entryPointGroups[index]; }
+        List<RefPtr<EntryPointGroup>> const& getEntryPointGroups() { return m_entryPointGroups; }
+
 
             /// Get the substitution (if any) that represents how global generics are specialized.
         RefPtr<Substitutions> getGlobalGenericSubstitution() { return m_globalGenericSubst; }
@@ -936,7 +1055,13 @@ namespace Slang
             ///
             /// This also adds everything the entry point depends on to the list of references.
             ///
-        void addEntryPoint(EntryPoint* entryPoint);
+        void addEntryPoint(EntryPoint* entryPoint, DiagnosticSink* sink);
+
+            /// Add an entry point group to the program
+            ///
+            /// This also adds everything the entry point group depends on to the list of references.
+            ///
+        void addEntryPointGroup(EntryPointGroup* entryPointGroup);
 
             /// Set the global generic argument substitution to use.
         void setGlobalGenericSubsitution(RefPtr<Substitutions> subst)
@@ -1011,6 +1136,9 @@ namespace Slang
         // Entry points that are part of the program.
         List<RefPtr<EntryPoint> > m_entryPoints;
 
+        // Entry points that are part of the program.
+        List<RefPtr<EntryPointGroup> > m_entryPointGroups;
+
         // Specializations for global generic parameters (if any)
         RefPtr<Substitutions> m_globalGenericSubst;
 
@@ -1065,23 +1193,34 @@ namespace Slang
 
             /// Get the compiled code for an entry point on the target.
             ///
-            /// This routine assumes code generation has already been
-            /// performed and called `setEntryPointResult`.
+            /// If this is the first time that code generation has
+            /// been requested, report any errors that arise during
+            /// code generation to the given `sink`.
+            ///
+        CompileResult& getOrCreateEntryPointResult(Int entryPointIndex, DiagnosticSink* sink);
+
+            /// Get the compiled code for an entry point on the target.
+            ///
+            /// This routine assumes that `getOrCreateEntryPointResult`
+            /// has already been called previously.
             ///
         CompileResult& getExistingEntryPointResult(Int entryPointIndex)
         {
             return m_entryPointResults[entryPointIndex];
         }
 
-        // TODO: Need a lazy `getOrCreateEntryPointResult`
 
-            /// Set the compiled code for an entry point.
+            /// Internal helper for `getOrCreateEntryPointResult`.
             ///
-            /// Should only be called by code generation.
-        void setEntryPointResult(Int entryPointIndex, CompileResult const& result)
-        {
-            m_entryPointResults[entryPointIndex] = result;
-        }
+            /// This is used so that command-line and API-based
+            /// requests for code can bottleneck through the same place.
+            ///
+            /// Shouldn't be called directly by most code.
+            ///
+        CompileResult& _createEntryPointResult(
+            Int                     entryPointIndex,
+            BackEndCompileRequest*  backEndRequest,
+            EndToEndCompileRequest* endToEndRequest);
 
     private:
         // The program being compiled or laid out
@@ -1142,6 +1281,9 @@ namespace Slang
     public:
         EndToEndCompileRequest(
             Session* session);
+
+        EndToEndCompileRequest(
+            Linkage* linkage);
 
         // What container format are we being asked to generate?
         //
@@ -1224,6 +1366,8 @@ namespace Slang
         Program* getSpecializedProgram() { return m_specializedProgram; }
 
     private:
+        void init();
+
         Session*                        m_session = nullptr;
         RefPtr<Linkage>                 m_linkage;
         DiagnosticSink                  m_sink;
@@ -1277,9 +1421,24 @@ namespace Slang
     struct TypeCheckingCache;
     //
 
-    class Session
+    class Session : public RefObject, public slang::IGlobalSession
     {
     public:
+        SLANG_REF_OBJECT_IUNKNOWN_ALL
+
+        ISlangUnknown* getInterface(const Guid& guid);
+
+            /** Create a new linkage.
+            */
+        SLANG_NO_THROW SlangResult SLANG_MCALL createSession(
+            slang::SessionDesc const&  desc,
+            slang::ISession**          outSession) override;
+
+        SLANG_NO_THROW SlangProfileID SLANG_MCALL findProfile(
+            char const*     name) override;
+
+
+
         enum class SharedLibraryFuncType
         {
             Glslang_Compile,
@@ -1420,6 +1579,76 @@ namespace Slang
             /// Linkage used for all built-in (stdlib) code.
         RefPtr<Linkage> m_builtinLinkage;
     };
+
+
+//
+// The following functions are utilties to convert between
+// matching "external" (public API) and "internal" (implementation)
+// types. They are favored over explicit casts because they
+// help avoid making incorrect conversions (e.g., when using
+// `reinterpret_cast` or C-style casts), and because they
+// abstract over the conversion required for each pair of types.
+//
+
+inline slang::IGlobalSession* asExternal(Session* session)
+{
+    return static_cast<slang::IGlobalSession*>(session);
+}
+
+inline slang::ISession* asExternal(Linkage* linkage)
+{
+    return static_cast<slang::ISession*>(linkage);
+}
+
+inline Module* asInternal(slang::IModule* module)
+{
+    return static_cast<Module*>(module);
+}
+
+inline slang::IModule* asExternal(Module* module)
+{
+    return static_cast<slang::IModule*>(module);
+}
+
+inline Program* asInternal(slang::IProgram* module)
+{
+    return static_cast<Program*>(module);
+}
+
+inline slang::IProgram* asExternal(Program* module)
+{
+    return static_cast<slang::IProgram*>(module);
+}
+
+static inline slang::ProgramLayout* asExternal(ProgramLayout* programLayout)
+{
+    return (slang::ProgramLayout*) programLayout;
+}
+
+inline Type* asInternal(slang::TypeReflection* type)
+{
+    return reinterpret_cast<Type*>(type);
+}
+
+inline slang::TypeReflection* asExternal(Type* type)
+{
+    return reinterpret_cast<slang::TypeReflection*>(type);
+}
+
+inline TypeLayout* asInternal(slang::TypeLayoutReflection* type)
+{
+    return reinterpret_cast<TypeLayout*>(type);
+}
+
+inline slang::TypeLayoutReflection* asExternal(TypeLayout* type)
+{
+    return reinterpret_cast<slang::TypeLayoutReflection*>(type);
+}
+
+inline SlangCompileRequest* asExternal(EndToEndCompileRequest* request)
+{
+    return reinterpret_cast<SlangCompileRequest*>(request);
+}
 
 }
 

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -409,6 +409,8 @@ DIAGNOSTIC(39016, Error, globalUniformsNotSupported, "'$0' is implicitly a globa
 
 DIAGNOSTIC(39017, Error, tooManyShaderRecordConstantBuffers, "can have at most one 'shader record' attributed constant buffer; found $0.")
 
+DIAGNOSTIC(39018, Error, typeParametersNotAllowedOnEntryPointGlobal, "local-root-signature shader parameter '$0' at global scope must not include existential/interface types");
+
 //
 // 4xxxx - IL code generation.
 //

--- a/source/slang/slang-diagnostics.h
+++ b/source/slang/slang-diagnostics.h
@@ -143,7 +143,11 @@ namespace Slang
 
     class DiagnosticSink
     {
-    public:        
+    public:
+        DiagnosticSink(SourceManager* sourceManager)
+            : sourceManager(sourceManager)
+        {}
+
         struct Flag 
         {
             enum Enum: uint32_t

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -48,29 +48,37 @@ enum class BuiltInCOp
 //
 
 EntryPointLayout* findEntryPointLayout(
-    ProgramLayout*  programLayout,
-    EntryPoint*     entryPoint)
+    ProgramLayout*          programLayout,
+    EntryPoint*             entryPoint,
+    EntryPointGroupLayout** outEntryPointGroupLayout = nullptr)
 {
-    for( auto entryPointLayout : programLayout->entryPoints )
+    for( auto entryPointGroupLayout : programLayout->entryPointGroups )
     {
-        if(entryPointLayout->entryPoint->getName() != entryPoint->getName())
-            continue;
+        for( auto entryPointLayout : entryPointGroupLayout->entryPoints )
+        {
+            if(entryPointLayout->entryPoint->getName() != entryPoint->getName())
+                continue;
 
-        // TODO: We need to be careful about this check, since it relies on
-        // the profile information in the layout matching that in the request.
-        //
-        // What we really seem to want here is some dictionary mapping the
-        // `EntryPoint` directly to the `EntryPointLayout`, and maybe
-        // that is precisely what we should build...
-        //
-        if(entryPointLayout->profile != entryPoint->getProfile())
-            continue;
+            // TODO: We need to be careful about this check, since it relies on
+            // the profile information in the layout matching that in the request.
+            //
+            // What we really seem to want here is some dictionary mapping the
+            // `EntryPoint` directly to the `EntryPointLayout`, and maybe
+            // that is precisely what we should build...
+            //
+            if(entryPointLayout->profile != entryPoint->getProfile())
+                continue;
 
-        // TODO: can't easily filter on translation unit here...
-        // Ideally the `EntryPoint` should get filled in with a pointer
-        // the specific function declaration that represents the entry point.
+            // TODO: can't easily filter on translation unit here...
+            // Ideally the `EntryPoint` should get filled in with a pointer
+            // the specific function declaration that represents the entry point.
 
-        return entryPointLayout.Ptr();
+            if( outEntryPointGroupLayout )
+            {
+                *outEntryPointGroupLayout = entryPointGroupLayout;
+            }
+            return entryPointLayout;
+        }
     }
 
     return nullptr;

--- a/source/slang/slang-file-system.h
+++ b/source/slang/slang-file-system.h
@@ -48,7 +48,7 @@ public:
         const char* path,
         ISlangBlob** outCanonicalPath) SLANG_OVERRIDE;
 
-    virtual SLANG_NO_THROW void SLANG_MCALL clearCache() {}
+    virtual SLANG_NO_THROW void SLANG_MCALL clearCache() SLANG_OVERRIDE {}
 
         /// Get a default instance
     static ISlangFileSystemExt* getSingleton() { return &s_singleton; }
@@ -132,9 +132,9 @@ class CacheFileSystem: public ISlangFileSystemExt, public RefObject
 
     virtual SLANG_NO_THROW SlangResult SLANG_MCALL getCanonicalPath(
         const char* path,
-        ISlangBlob** outCanonicalPath);
+        ISlangBlob** outCanonicalPath) SLANG_OVERRIDE;
 
-    virtual SLANG_NO_THROW void SLANG_MCALL clearCache();
+    virtual SLANG_NO_THROW void SLANG_MCALL clearCache() SLANG_OVERRIDE;
 
         /// Ctor
     CacheFileSystem(ISlangFileSystem* fileSystem, UniqueIdentityMode uniqueIdentityMode = UniqueIdentityMode::Default, PathStyle pathStyle = PathStyle::Default);

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -588,7 +588,7 @@ static bool findLayoutArg(
         if( modifier )
         {
             *outVal = (UInt) strtoull(String(modifier->valToken.Content).getBuffer(), nullptr, 10);
-return true;
+            return true;
         }
     }
     return false;
@@ -2583,8 +2583,8 @@ RefPtr<ProgramLayout> generateParameterBindings(
     // anything pertaining to entry points. This is a crucial design choice to
     // get right, and we might want to revisit it based on experience.
 
-    // In some cases, a user will want o ensure that all the
-    // entry points they compile get non-overallping
+    // In some cases, a user will want to ensure that all the
+    // entry points they compile get non-overlapping
     // registers/bindings. E.g., if you have a vertex and fragment
     // shader being compiled together for Vulkan, you probably want distinct
     // bindings for their entry-point `uniform` parametres, so

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -1709,8 +1709,7 @@ namespace Slang
         TokenSpan tokenSpan;
         tokenSpan.mBegin = parser->tokenReader.mCursor;
         tokenSpan.mEnd = parser->tokenReader.mEnd;
-        DiagnosticSink newSink;
-        newSink.sourceManager = parser->sink->sourceManager;
+        DiagnosticSink newSink(parser->sink->sourceManager);
         Parser newParser(*parser);
         newParser.sink = &newSink;
         auto speculateParseRs = parseGenericApp(&newParser, base);

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -33,6 +33,12 @@
 
 namespace Slang {
 
+// Allocate static const storage for the various interface IDs that the Slang API needs to expose
+static const Guid IID_ISlangUnknown = SLANG_UUID_ISlangUnknown;
+static const Guid IID_ISlangBlob    = SLANG_UUID_ISlangBlob;
+static const Guid IID_ISession = SLANG_UUID_ISession;
+static const Guid IID_IGlobalSession = SLANG_UUID_IGlobalSession;
+static const Guid IID_IModule = SLANG_UUID_IModule;
 
 Session::Session()
 {
@@ -89,6 +95,55 @@ Session::Session()
 
     addBuiltinSource(coreLanguageScope, "core", getCoreLibraryCode());
     addBuiltinSource(hlslLanguageScope, "hlsl", getHLSLLibraryCode());
+}
+
+ISlangUnknown* Session::getInterface(const Guid& guid)
+{
+    if(guid == IID_ISlangUnknown || guid == IID_IGlobalSession)
+        return asExternal(this);
+    return nullptr;
+}
+
+SLANG_NO_THROW SlangResult SLANG_MCALL Session::createSession(
+    slang::SessionDesc const&  desc,
+    slang::ISession**          outSession)
+{
+    auto linkage = new Linkage(this);
+
+    Int targetCount = desc.targetCount;
+    for(Int ii = 0; ii < targetCount; ++ii)
+    {
+        linkage->addTarget(desc.targets[ii]);
+    }
+
+    if(desc.flags & slang::kSessionFlag_FalcorCustomSharedKeywordSemantics)
+    {
+        linkage->m_useFalcorCustomSharedKeywordSemantics = true;
+    }
+
+    linkage->setMatrixLayoutMode(desc.defaultMatrixLayoutMode);
+
+    Int searchPathCount = desc.searchPathCount;
+    for(Int ii = 0; ii < searchPathCount; ++ii)
+    {
+        linkage->addSearchPath(desc.searchPaths[ii]);
+    }
+
+    Int macroCount = desc.preprocessorMacroCount;
+    for(Int ii = 0; ii < macroCount; ++ii)
+    {
+        auto& macro = desc.preprocessorMacros[ii];
+        linkage->addPreprocessorDefine(macro.name, macro.value);
+    }
+
+    *outSession = ComPtr<slang::ISession>(asExternal(linkage)).detach();
+    return SLANG_OK;
+}
+
+SLANG_NO_THROW SlangProfileID SLANG_MCALL Session::findProfile(
+    char const*     name)
+{
+    return Slang::Profile::LookUp(name).raw;
 }
 
 struct IncludeHandlerImpl : IncludeHandler
@@ -330,9 +385,183 @@ Linkage::Linkage(Session* session)
     setFileSystem(nullptr);
 }
 
-// Allocate static const storage for the various interface IDs that the Slang API needs to expose
-static const Guid IID_ISlangUnknown = SLANG_UUID_ISlangUnknown;
-static const Guid IID_ISlangBlob    = SLANG_UUID_ISlangBlob;
+ISlangUnknown* Linkage::getInterface(const Guid& guid)
+{
+    if(guid == IID_ISlangUnknown || guid == IID_ISession)
+        return asExternal(this);
+
+    return nullptr;
+}
+
+SLANG_NO_THROW slang::IGlobalSession* SLANG_MCALL Linkage::getGlobalSession()
+{
+    return asExternal(getSessionImpl());
+}
+
+void Linkage::addTarget(
+    slang::TargetDesc const&  desc)
+{
+    auto targetIndex = addTarget(CodeGenTarget(desc.format));
+    auto target = targets[targetIndex];
+
+    target->floatingPointMode = FloatingPointMode(desc.floatingPointMode);
+    target->targetFlags = desc.flags;
+    target->targetProfile = Profile(desc.profile);
+}
+
+#if 0
+SLANG_NO_THROW SlangInt SLANG_MCALL Linkage::getTargetCount()
+{
+    return targets.getCount();
+}
+
+SLANG_NO_THROW slang::ITarget* SLANG_MCALL Linkage::getTargetByIndex(SlangInt index)
+{
+    if(index < 0) return nullptr;
+    if(index >= targets.getCount()) return nullptr;
+    return asExternal(targets[index]);
+}
+#endif
+
+SLANG_NO_THROW slang::IModule* SLANG_MCALL Linkage::loadModule(
+    const char*     moduleName,
+    slang::IBlob**  outDiagnostics)
+{
+    auto name = getNamePool()->getName(moduleName);
+
+    DiagnosticSink sink(getSourceManager());
+    auto module = findOrImportModule(name, SourceLoc(), &sink);
+    sink.getBlobIfNeeded(outDiagnostics);
+
+    return asExternal(module);
+}
+
+SLANG_NO_THROW SlangResult SLANG_MCALL Linkage::createProgram(
+    slang::ProgramDesc const& desc,
+    slang::IProgram**         outProgram)
+{
+    RefPtr<Program> program = new Program(this);
+
+    auto itemCount = desc.itemCount;
+    for(SlangInt ii = 0; ii < itemCount; ++ii)
+    {
+        auto& item = desc.items[ii];
+        switch(item.kind)
+        {
+        case slang::ProgramDesc::Item::Kind::Program:
+            {
+                Program* existingProgram = asInternal(item.program);
+                for(auto referencedModule : existingProgram->getModuleDependencies())
+                {
+                    program->addReferencedLeafModule(referencedModule);
+                }
+
+                // TODO: Need to decide whether to include the entry points as well...
+            }
+            break;
+
+        case slang::ProgramDesc::Item::Kind::Module:
+            {
+                Module* module = asInternal(item.module);
+                program->addReferencedModule(module);
+            }
+            break;
+
+        default:
+            return SLANG_E_INVALID_ARG;
+        }
+    }
+
+    *outProgram = ComPtr<slang::IProgram>(asExternal(program)).detach();
+    return SLANG_OK;
+}
+
+SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL Linkage::specializeType(
+    slang::TypeReflection*          inUnspecializedType,
+    SlangInt                        specializationArgCount,
+    slang::SpecializationArg const* specializationArgs,
+    ISlangBlob**                    outDiagnostics)
+{
+    auto unspecializedType = asInternal(inUnspecializedType);
+
+    List<Type*> typeArgs;
+
+    for(Int ii = 0; ii < specializationArgCount; ++ii)
+    {
+        auto& arg = specializationArgs[ii];
+        if(arg.kind != slang::SpecializationArg::Kind::Type)
+            return nullptr;
+
+        typeArgs.add(asInternal(arg.type));
+    }
+
+    DiagnosticSink sink(getSourceManager());
+    auto specializedType = specializeType(unspecializedType, typeArgs.getCount(), typeArgs.getBuffer(), &sink);
+    sink.getBlobIfNeeded(outDiagnostics);
+
+    return asExternal(specializedType);
+}
+
+SLANG_NO_THROW slang::TypeLayoutReflection* SLANG_MCALL Linkage::getTypeLayout(
+    slang::TypeReflection*  inType,
+    SlangInt                targetIndex,
+    slang::LayoutRules      rules,
+    ISlangBlob**            outDiagnostics)
+{
+    auto type = asInternal(inType);
+
+    if(targetIndex < 0 || targetIndex >= targets.getCount())
+        return nullptr;
+
+    auto target = targets[targetIndex];
+
+    // TODO: We need a way to pass through the layout rules
+    // that the user requested (e.g., constant buffers vs.
+    // structured buffer rules). Right now the API only
+    // exposes a single case, so this isn't a big deal.
+    //
+    SLANG_UNUSED(rules);
+
+    auto typeLayout = target->getTypeLayout(type);
+
+    // TODO: We currently don't have a path for capturing
+    // errors that occur during layout (e.g., types that
+    // are invalid because of target-specific layout constraints).
+    //
+    SLANG_UNUSED(outDiagnostics);
+
+    return asExternal(typeLayout);
+}
+
+SLANG_NO_THROW SlangResult SLANG_MCALL Linkage::createCompileRequest(
+    SlangCompileRequest**   outCompileRequest)
+{
+    auto compileRequest = new EndToEndCompileRequest(this);
+    *outCompileRequest = asExternal(compileRequest);
+    return SLANG_OK;
+}
+
+SlangResult Linkage::addSearchPath(
+    char const* path)
+{
+    searchDirectories.searchDirectories.add(Slang::SearchDirectory(path));
+    return SLANG_OK;
+}
+
+SlangResult Linkage::addPreprocessorDefine(
+    char const* name,
+    char const* value)
+{
+    preprocessorDefinitions[name] = value;
+    return SLANG_OK;
+}
+
+SlangResult Linkage::setMatrixLayoutMode(
+    SlangMatrixLayoutMode mode)
+{
+    defaultMatrixLayoutMode = MatrixLayoutMode(mode);
+    return SLANG_OK;
+}
 
 /** Base class for simple blobs.
 */
@@ -386,13 +615,36 @@ ComPtr<ISlangBlob> createRawBlob(void const* inData, size_t size)
 
 Session* TargetRequest::getSession()
 {
-    return linkage->getSession();
+    return linkage->getSessionImpl();
 }
 
 MatrixLayoutMode TargetRequest::getDefaultMatrixLayoutMode()
 {
     return linkage->getDefaultMatrixLayoutMode();
 }
+
+TypeLayout* TargetRequest::getTypeLayout(Type* type)
+{
+    // TODO: We are not passing in a `ProgramLayout` here, although one
+    // is nominally required to establish the global ordering of
+    // generic type parameters, which might be referenced from field types.
+    //
+    // The solution here is to make sure that the reflection data for
+    // uses of global generic/existential types does *not* include any
+    // kind of index in that global ordering, and just refers to the
+    // parameter instead (leaving the user to figure out how that
+    // maps to the ordering via some API on the program layout).
+    //
+    auto layoutContext = getInitialLayoutContextForTarget(this, nullptr);
+
+    RefPtr<TypeLayout> result;
+    if (getTypeLayouts().TryGetValue(type, result))
+        return result.Ptr();
+    result = createTypeLayout(layoutContext, type);
+    getTypeLayouts()[type] = result;
+    return result.Ptr();
+}
+
 
 //
 // TranslationUnitRequest
@@ -485,8 +737,7 @@ RefPtr<Expr> Linkage::parseTypeString(String typeStr, RefPtr<Scope> scope)
     Slang::SourceFile* srcFile = localSourceManager.createSourceFileWithString(PathInfo::makeTypeParse(), typeStr);
     
     // We'll use a temporary diagnostic sink  
-    DiagnosticSink sink;
-    sink.sourceManager = &localSourceManager;
+    DiagnosticSink sink(&localSourceManager);
 
     // RAII type to make make sure current SourceManager is restored after parse.
     // Use RAII - to make sure everything is reset even if an exception is thrown.
@@ -521,7 +772,7 @@ RefPtr<Expr> Linkage::parseTypeString(String typeStr, RefPtr<Scope> scope)
         nullptr);
 
     return parseTypeFromSourceFile(
-        getSession(),
+        getSessionImpl(),
         tokens, &sink, scope, getNamePool(), SourceLanguage::Slang);
 }
 
@@ -552,7 +803,7 @@ Type* Program::getTypeFromString(String typeStr, DiagnosticSink* sink)
     for(auto module : getModuleDependencies())
         scopesToTry.add(module->getModuleDecl()->scope);
 
-    auto linkage = getLinkage();
+    auto linkage = getLinkageImpl();
     for(auto& s : scopesToTry)
     {
         RefPtr<Expr> typeExpr = linkage->parseTypeString(
@@ -785,13 +1036,15 @@ SlangResult FrontEndCompileRequest::executeActionsInner()
     if (getSink()->GetErrorCount() != 0)
         return SLANG_FAIL;
 
-    if ((compileFlags & SLANG_COMPILE_FLAG_NO_CODEGEN) == 0)
-    {
-        // Generate initial IR for all the translation
-        // units, if we are in a mode where IR is called for.
-        generateIR();
-    }
-
+    // We always generate IR for all the translation units.
+    //
+    // TODO: We may eventually have a mode where we skip
+    // IR codegen and only produce an AST (e.g., for use when
+    // debugging problems in the parser or semantic checking),
+    // but for now there are no cases where not having IR
+    // makes sense.
+    //
+    generateIR();
     if (getSink()->GetErrorCount() != 0)
         return SLANG_FAIL;
 
@@ -819,9 +1072,23 @@ BackEndCompileRequest::BackEndCompileRequest(
 EndToEndCompileRequest::EndToEndCompileRequest(
     Session* session)
     : m_session(session)
+    , m_sink(nullptr)
 {
     m_linkage = new Linkage(session);
+    init();
+}
 
+EndToEndCompileRequest::EndToEndCompileRequest(
+    Linkage* linkage)
+    : m_session(linkage->getSessionImpl())
+    , m_linkage(linkage)
+    , m_sink(nullptr)
+{
+    init();
+}
+
+void EndToEndCompileRequest::init()
+{
     m_sink.sourceManager = m_linkage->getSourceManager();
 
     // Set all the default writers
@@ -919,7 +1186,7 @@ SlangResult EndToEndCompileRequest::executeActionsInner()
                 entryPointReq->getName(),
                 entryPointReq->getProfile());
 
-            specializedProgram->addEntryPoint(entryPoint);
+            specializedProgram->addEntryPoint(entryPoint, getSink());
         }
     }
 
@@ -1353,6 +1620,12 @@ Module::Module(Linkage* linkage)
     : m_linkage(linkage)
 {}
 
+ISlangUnknown* Module::getInterface(const Guid& guid)
+{
+    if(guid == IID_ISlangUnknown || guid == IID_IModule)
+        return asExternal(this);
+    return nullptr;
+}
 
 void Module::addModuleDependency(Module* module)
 {
@@ -1367,9 +1640,68 @@ void Module::addFilePathDependency(String const& path)
 
 // Program
 
+static const Guid IID_IProgram = SLANG_UUID_IProgram;
+
 Program::Program(Linkage* linkage)
     : m_linkage(linkage)
 {}
+
+ISlangUnknown* Program::getInterface(Guid const& guid)
+{
+    if(guid == IID_ISlangUnknown
+        || guid == IID_IProgram)
+    {
+        return static_cast<slang::IProgram*>(this);
+    }
+
+    return nullptr;
+}
+
+SLANG_NO_THROW slang::ISession* SLANG_MCALL Program::getSession()
+{
+    return m_linkage;
+}
+
+SLANG_NO_THROW slang::ProgramLayout* SLANG_MCALL Program::getLayout(
+    Int             targetIndex,
+    slang::IBlob**  outDiagnostics)
+{
+    auto linkage = getLinkageImpl();
+    if(targetIndex < 0 || targetIndex >= linkage->targets.getCount())
+        return nullptr;
+    auto target = linkage->targets[targetIndex];
+
+    DiagnosticSink sink(linkage->getSourceManager());
+    auto programLayout = getTargetProgram(target)->getOrCreateLayout(&sink);
+    sink.getBlobIfNeeded(outDiagnostics);
+
+    return asExternal(programLayout);
+}
+
+SLANG_NO_THROW SlangResult SLANG_MCALL Program::getEntryPointCode(
+    SlangInt        entryPointIndex,
+    Int             targetIndex,
+    slang::IBlob**  outCode,
+    slang::IBlob**  outDiagnostics)
+{
+    auto linkage = getLinkageImpl();
+    if(targetIndex < 0 || targetIndex >= linkage->targets.getCount())
+        return SLANG_E_INVALID_ARG;
+    auto target = linkage->targets[targetIndex];
+
+    auto targetProgram = getTargetProgram(target);
+
+    DiagnosticSink sink(linkage->getSourceManager());
+    auto& entryPointResult = targetProgram->getOrCreateEntryPointResult(entryPointIndex, &sink);
+    sink.getBlobIfNeeded(outDiagnostics);
+
+    if(entryPointResult.format == ResultFormat::None )
+        return SLANG_FAIL;
+
+    *outCode = entryPointResult.getBlob().detach();
+    return SLANG_OK;
+}
+
 
 void Program::addReferencedModule(Module* module)
 {
@@ -1383,13 +1715,27 @@ void Program::addReferencedLeafModule(Module* module)
     m_filePathDependencyList.addDependency(module);
 }
 
-void Program::addEntryPoint(EntryPoint* entryPoint)
+void Program::addEntryPoint(EntryPoint* entryPoint, DiagnosticSink* sink)
 {
-    m_entryPoints.add(entryPoint);
+    List<RefPtr<EntryPoint>> entryPoints;
+    entryPoints.add(entryPoint);
 
-    for(auto module : entryPoint->getModuleDependencies())
+    RefPtr<EntryPointGroup> entryPointGroup = EntryPointGroup::create(getLinkageImpl(), entryPoints, sink);
+
+    addEntryPointGroup(entryPointGroup);
+}
+
+void Program::addEntryPointGroup(EntryPointGroup* entryPointGroup)
+{
+    m_entryPointGroups.add(entryPointGroup);
+
+    for(auto entryPoint : entryPointGroup->getEntryPoints())
     {
-        addReferencedModule(module);
+        m_entryPoints.add(entryPoint);
+        for(auto module : entryPoint->getModuleDependencies())
+        {
+            addReferencedModule(module);
+        }
     }
 }
 
@@ -1398,7 +1744,7 @@ RefPtr<IRModule> Program::getOrCreateIRModule(DiagnosticSink* sink)
     if(!m_irModule)
     {
         m_irModule = generateIRForProgram(
-            m_linkage->getSession(),
+            m_linkage->getSessionImpl(),
             this,
             sink);
     }
@@ -1466,7 +1812,7 @@ SlangResult DiagnosticSink::getBlobIfNeeded(ISlangBlob** outBlob)
 
 Session* CompileRequestBase::getSession()
 {
-    return getLinkage()->getSession();
+    return getLinkage()->getSessionImpl();
 }
 
 static const Slang::Guid IID_ISlangFileSystemExt = SLANG_UUID_ISlangFileSystemExt;
@@ -1512,12 +1858,13 @@ void Session::addBuiltinSource(
     String const&           path,
     String const&           source)
 {
-    DiagnosticSink sink;
+    SourceManager* sourceManager = getBuiltinSourceManager();
+
+    DiagnosticSink sink(sourceManager);
     RefPtr<FrontEndCompileRequest> compileRequest = new FrontEndCompileRequest(
         m_builtinLinkage,
         &sink);
 
-    SourceManager* sourceManager = getBuiltinSourceManager();
 
     // Set the source manager on the sink
     sink.sourceManager = sourceManager;
@@ -1611,18 +1958,22 @@ static SlangCompileRequest* convert(Slang::EndToEndCompileRequest* request)
 static Slang::EndToEndCompileRequest* convert(SlangCompileRequest* request)
 { return reinterpret_cast<Slang::EndToEndCompileRequest*>(request); }
 
-static SlangLinkage* convert(Slang::Linkage* linkage)
-{ return reinterpret_cast<SlangLinkage*>(linkage); }
-
-static Slang::Linkage* convert(SlangLinkage* linkage)
-{ return reinterpret_cast<Slang::Linkage*>(linkage); }
-
-static SlangModule* convert(Slang::Module* module)
-{ return reinterpret_cast<SlangModule*>(module); }
-
 SLANG_API SlangSession* spCreateSession(const char*)
 {
     return convert(new Slang::Session());
+}
+
+SLANG_API SlangResult slang_createGlobalSession(
+    SlangInt                apiVersion,
+    slang::IGlobalSession** outGlobalSession)
+{
+    if(apiVersion != 0)
+        return SLANG_E_NOT_IMPLEMENTED;
+
+    Slang::Session* globalSession = new Slang::Session();
+    Slang::ComPtr<slang::IGlobalSession> result(Slang::asExternal(globalSession));
+    *outGlobalSession = result.detach();
+    return SLANG_OK;
 }
 
 SLANG_API void spDestroySession(
@@ -1697,35 +2048,6 @@ SLANG_API SlangResult spSessionCheckPassThroughSupport(
     auto s = convert(session);
     return Slang::checkExternalCompilerSupport(s, Slang::PassThroughMode(passThrough));
 }
-
-
-SLANG_API SlangLinkage* spCreateLinkage(
-    SlangSession* session)
-{
-    auto s = convert(session);
-    auto linkage = new Slang::Linkage(s);
-    return convert(linkage);
-}
-
-SLANG_API void spDestroyLinkage(
-    SlangLinkage* linkage)
-{
-    if(!linkage) return;
-    auto lnk = convert(linkage);
-    delete lnk;
-}
-
-SLANG_API SlangModule* spLoadModule(
-    SlangLinkage* linkage,
-    char const* moduleName)
-{
-    if(!linkage) return nullptr;
-    auto lnk = convert(linkage);
-
-    auto mod = lnk->loadModule(moduleName);
-    return convert(mod);
-}
-
 
 SLANG_API SlangCompileRequest* spCreateCompileRequest(
     SlangSession* session)
@@ -1839,7 +2161,7 @@ SLANG_API void spSetMatrixLayoutMode(
 {
     auto req = convert(request);
     auto linkage = req->getLinkage();
-    linkage->defaultMatrixLayoutMode = Slang::MatrixLayoutMode(mode);
+    linkage->setMatrixLayoutMode(mode);
 }
 
 SLANG_API void spSetTargetMatrixLayoutMode(
@@ -1932,7 +2254,7 @@ SLANG_API void spAddSearchPath(
 {
     auto req = convert(request);
     auto linkage = req->getLinkage();
-    linkage->searchDirectories.searchDirectories.add(Slang::SearchDirectory(path));
+    linkage->addSearchPath(path);
 }
 
 SLANG_API void spAddPreprocessorDefine(
@@ -1942,7 +2264,7 @@ SLANG_API void spAddPreprocessorDefine(
 {
     auto req = convert(request);
     auto linkage = req->getLinkage();
-    linkage->preprocessorDefinitions[key] = value;
+    linkage->addPreprocessorDefine(key, value);
 }
 
 SLANG_API char const* spGetDiagnosticOutput(
@@ -2390,6 +2712,18 @@ SLANG_API void const* spGetCompileRequestCode(
 }
 
 // Reflection API
+
+SLANG_API SlangResult spCompileRequest_getProgram(
+    SlangCompileRequest*    request,
+    slang::IProgram**         outProgram)
+{
+    if( !request ) return SLANG_ERROR_INVALID_PARAMETER;
+    auto req = convert(request);
+    auto program = req->getSpecializedProgram();
+
+    *outProgram = Slang::ComPtr<slang::IProgram>(program).detach();
+    return SLANG_OK;
+}
 
 SLANG_API SlangReflection* spGetReflection(
     SlangCompileRequest*    request)

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -108,7 +108,7 @@ SLANG_NO_THROW SlangResult SLANG_MCALL Session::createSession(
     slang::SessionDesc const&  desc,
     slang::ISession**          outSession)
 {
-    auto linkage = new Linkage(this);
+    RefPtr<Linkage> linkage = new Linkage(this);
 
     Int targetCount = desc.targetCount;
     for(Int ii = 0; ii < targetCount; ++ii)
@@ -136,7 +136,7 @@ SLANG_NO_THROW SlangResult SLANG_MCALL Session::createSession(
         linkage->addPreprocessorDefine(macro.name, macro.value);
     }
 
-    *outSession = ComPtr<slang::ISession>(asExternal(linkage)).detach();
+    *outSession = asExternal(linkage.detach());
     return SLANG_OK;
 }
 
@@ -472,14 +472,14 @@ SLANG_NO_THROW SlangResult SLANG_MCALL Linkage::createProgram(
         }
     }
 
-    *outProgram = ComPtr<slang::IProgram>(asExternal(program)).detach();
+    *outProgram = asExternal(program.detach());
     return SLANG_OK;
 }
 
 SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL Linkage::specializeType(
     slang::TypeReflection*          inUnspecializedType,
-    SlangInt                        specializationArgCount,
     slang::SpecializationArg const* specializationArgs,
+    SlangInt                        specializationArgCount,
     ISlangBlob**                    outDiagnostics)
 {
     auto unspecializedType = asInternal(inUnspecializedType);

--- a/source/slang/slang.natvis
+++ b/source/slang/slang.natvis
@@ -17,16 +17,10 @@
       <ExpandedItem>decl ? ($T1*)(decl) : ($T1*)0</ExpandedItem>
       <Item Name="[Substitutions]:">"========================="</Item>
       <LinkedListItems>
-        <HeadPointer>substitutions.genericSubstitutions.pointer</HeadPointer>
+        <HeadPointer>substitutions.substitutions.pointer</HeadPointer>
         <NextPointer>outer.pointer</NextPointer>
         <ValueNode>this</ValueNode>
       </LinkedListItems>
-        <LinkedListItems>
-            <HeadPointer>substitutions.globalGenParamSubstitutions.pointer</HeadPointer>
-            <NextPointer>outer.pointer</NextPointer>
-            <ValueNode>this</ValueNode>
-        </LinkedListItems>
-        <Item Name ="thisSubst">substitutions.thisTypeSubstitution</Item>
     </Expand>
   </Type>
     <Type Name="Slang::DeclRefBase">
@@ -66,10 +60,10 @@
         <DisplayString>FuncDecl {nameAndLoc}</DisplayString>
     </Type>
   <Type Name="Slang::Name">
-    <DisplayString>{{name={(char*)(text.buffer.pointer+1), s}}}</DisplayString>
+    <DisplayString>{{name={(char*)(text.m_buffer.pointer+1), s}}}</DisplayString>
   </Type>
   <Type Name="Slang::NameLoc">
-    <DisplayString>{{name={(char*)((*name).text.buffer.pointer+1), s} loc={loc.raw}}}</DisplayString>
+    <DisplayString>{{name={(char*)((*name).text.m_buffer.pointer+1), s} loc={loc.raw}}}</DisplayString>
   </Type>
   <Type Name="Slang::IRWitnessTableEntry">
     <Expand>

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -297,7 +297,10 @@
     <ClCompile Include="slang.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="slang.natvis" />
+    <Natvis Include="..\core\core.natvis" />
+    <Natvis Include="slang.natvis">
+      <FileType>Document</FileType>
+    </Natvis>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="core.meta.slang">

--- a/source/slang/slang.vcxproj.filters
+++ b/source/slang/slang.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Header Files">
@@ -393,5 +393,10 @@
     <CustomBuild Include="hlsl.meta.slang">
       <Filter>Source Files</Filter>
     </CustomBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="..\core\core.natvis">
+      <Filter>Source Files</Filter>
+    </Natvis>
   </ItemGroup>
 </Project>

--- a/tests/compute/interface-shader-param-in-struct.slang
+++ b/tests/compute/interface-shader-param-in-struct.slang
@@ -49,6 +49,9 @@ cbuffer C
    IRandomNumberGenerationStrategy gStrategy;
 }
 
+//TEST_INPUT: globalExistentialType MyStrategy
+//TEST_INPUT:ubuffer(data=[1 2 4 8], stride=4):dxbinding(1),glbinding(1)
+
 struct Stuff
 {
     IModifier modifier;
@@ -107,21 +110,5 @@ struct MyModifier : IModifier
     }
 }
 
-//TEST_INPUT: globalExistentialType MyStrategy
 //TEST_INPUT: entryPointExistentialType MyModifier
-
-// The concrete types we plug in for `gStrategy` and `modifier`
-// have buffer resources in them, so we need to assign them
-// data. The registers/bindings for these parameters will
-// always come after all other shader parameters, and their
-// relative order will match the relative order of their
-// declarations in the global order that Slang uses for
-// assigning bindings (all globals before all entry point parameters).
-//
-// Here's the data for `gStrategy`:
-//
-//TEST_INPUT:ubuffer(data=[1 2 4 8], stride=4):dxbinding(1),glbinding(1)
-//
-// Here's the data for `stuff.modifier`:
-//
 //TEST_INPUT:ubuffer(data=[16 32 64 128], stride=4):dxbinding(2),glbinding(3)

--- a/tests/compute/interface-shader-param3.slang
+++ b/tests/compute/interface-shader-param3.slang
@@ -45,16 +45,18 @@ int test(
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
 RWStructuredBuffer<int> gOutputBuffer;
 
-// Note: while we declare `gStrategy` here, there is no matching
-// line providing input data at this point. That is partly to
-// work around an apparent bug in the test runner, but it is also
-// to reflect the fact that this declaration does not cause a
-// constant buffer binding to be allocated, because just from
-// the declaration of `gStrategy` we cannot tell whether a
-// constant buffer binding is even needed (there might be no
-// uniform/ordinary data).
-//
 ConstantBuffer<IRandomNumberGenerationStrategy> gStrategy;
+
+// Note: The current strategy we use for laying out shader
+// parameters in the presence of existential/interface types
+// is to always put global-scope parameters before any
+// entry-point parameters. As a result we need to provide
+// the buffer for the specialized version of `gStrategy`
+// here, and we will go ahead and provide the concrete
+// type argument at the same time.
+//
+//TEST_INPUT: globalExistentialType MyStrategy
+//TEST_INPUT:cbuffer(data=[1 0 0 0], stride=4):dxbinding(0),glbinding(1)
 
 [numthreads(4, 1, 1)]
 void computeMain(
@@ -81,7 +83,7 @@ void computeMain(
 //
 // Here's the incantation to make the test runner fill in the constant buffer:
 //
-//TEST_INPUT:cbuffer(data=[256 0 0 0 16 0 0 0], stride=4):dxbinding(0),glbinding(1)
+//TEST_INPUT:cbuffer(data=[256 0 0 0 16 0 0 0], stride=4):dxbinding(1),glbinding(2)
 //
 // So, the value `256` will be used for `extra` and the value `16`
 // will be written to the first four bytes of the concrete value
@@ -134,16 +136,4 @@ struct MyModifier : IModifier
     }
 }
 
-//TEST_INPUT: globalExistentialType MyStrategy
 //TEST_INPUT: entryPointExistentialType MyModifier
-
-// Once the concrete types are plugged in, the compiler can
-// see that `gStrategy` needs a constant buffer register/binding.
-// It will alocate the location for `gStrategy` after all other
-// shader parameters, to ensure that different specializations
-// of the same shader will agree on the locations for all the
-// non-interface-type parameters.
-//
-//TEST_INPUT:cbuffer(data=[1 0 0 0], stride=4):dxbinding(1),glbinding(2)
-
-

--- a/tests/compute/interface-shader-param4.slang
+++ b/tests/compute/interface-shader-param4.slang
@@ -48,6 +48,18 @@ RWStructuredBuffer<int> gOutputBuffer;
 
 ConstantBuffer<IRandomNumberGenerationStrategy> gStrategy;
 
+// The concrete types we plug in for `gStrategy` and `modifier`
+// have buffer resources in them, so we need to assign them
+// data. The registers/bindings for these parameters will
+// always come after all other shader parameters in the same
+// scope (global or entry-point).
+//
+// Here's the data for `gStrategy`:
+//
+//TEST_INPUT: globalExistentialType MyStrategy
+//TEST_INPUT:ubuffer(data=[1 2 4 8], stride=4):dxbinding(1),glbinding(1)
+
+
 [numthreads(4, 1, 1)]
 void computeMain(
 
@@ -112,21 +124,7 @@ struct MyModifier : IModifier
     }
 }
 
-//TEST_INPUT: globalExistentialType MyStrategy
-//TEST_INPUT: entryPointExistentialType MyModifier
-
-// The concrete types we plug in for `gStrategy` and `modifier`
-// have buffer resources in them, so we need to assign them
-// data. The registers/bindings for these parameters will
-// always come after all other shader parameters, and their
-// relative order will match the relative order of their
-// declarations in the global order that Slang uses for
-// assigning bindings (all globals before all entry point parameters).
-//
-// Here's the data for `gStrategy`:
-//
-//TEST_INPUT:ubuffer(data=[1 2 4 8], stride=4):dxbinding(1),glbinding(1)
-//
 // Here's the data for `modifier`:
 //
+//TEST_INPUT: entryPointExistentialType MyModifier
 //TEST_INPUT:ubuffer(data=[16 32 64 128], stride=4):dxbinding(2),glbinding(3)

--- a/tests/reflection/parameter-block-explicit-space.slang.expected
+++ b/tests/reflection/parameter-block-explicit-space.slang.expected
@@ -7,7 +7,7 @@ standard output = {
         {
             "name": "a",
             "bindings": [
-                {"kind": "constantBuffer", "space": 2, "index": 0, "count": 0},
+                {"kind": "constantBuffer", "index": 0, "count": 0},
                 {"kind": "registerSpace", "index": 2}
             ],
             "type": {
@@ -58,7 +58,7 @@ standard output = {
         {
             "name": "b",
             "bindings": [
-                {"kind": "constantBuffer", "space": 3, "index": 0, "count": 0},
+                {"kind": "constantBuffer", "index": 0, "count": 0},
                 {"kind": "registerSpace", "index": 3}
             ],
             "type": {


### PR DESCRIPTION
This change is mostly about exposing a new API to the Slang compiler that allows more fine-grained control over the compilation flow. The basic concepts in the new API are:

* An `IGlobalSession` is the granularity at which we load/parse the Slang stdlib, and therefore gives applications a way to amortize startup cost for the library across multiple compiles. This is a concept that might be able to go away in a future version of Slang.

* An `ISession` owns all the code that gets loaded/compiled/generated. Any `import`ed modules are shared across everything in a session (we don't re-parse/-check the code when we see another `import` for the same module). Any generic- or interface-based code in the session can be specialized using types from the same session (but not necessarily across sessions).

* An `IModule` is the unit of code loading and scoping. It doesn't expose any API in this change, but would be the right scope for looking up types or entry points by name.

* An `IProgram` is a "linked" combination of modules and entry points from which code can be generated and reflection information queried.

This change re-uses the existing reflection API types, rather than introduce a new API that duplicates that functionality. That will probably change in a future revision.

There are two major pieces of functionality added here that aren't related to the new API:

* We now have an API concept of "entry point groups" which are one or more entry points that are intended to be used together so that they need to have non-overlapping parameters. For now this is being used to handle "hit groups" and local root signatures for ray tracing, but I'm not sure this is a concept we will keep in the long run.

* We have a very special-case (client-application-specific) flag that ascribes special meaning to the `shared` keyword, so that it can be attached to global parameters to indicate that they are actually to be part of the local root signature rather than the global one for DXR.

None of the API design (including naming) here is finalized; the only reason to check in the changes at this point to avoid having a long-running branch that leads to merge pain. Clients should *not* try to depend on the new API just yet, since it is still a work in progress.