### PR TITLE
Fix bug in handling of `h` literal suffix.

### DIFF
--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -4044,7 +4044,7 @@ namespace Slang
                         suffixType = parser->getSession()->getErrorType();
                     }
                     // `f` suffix -> `float`
-                    if(fCount == 1 && !lCount)
+                    if(fCount == 1 && !lCount && !hCount)
                     {
                         suffixType = parser->getSession()->getFloatType();
                     }
@@ -4054,7 +4054,7 @@ namespace Slang
                         suffixType = parser->getSession()->getDoubleType();
                     }
                     // `h` or `hf` suffix on floating-point literal -> `half`
-                    else if(lCount == 1 && (fCount <= 1))
+                    else if(hCount == 1 && (fCount <= 1))
                     {
                         suffixType = parser->getSession()->getHalfType();
                     }


### PR DESCRIPTION
A literal like:

    2.0h

is supposed to default to `half` precision, but there was a typo in our logic that meant that the `half` case was mistakenly checking for `l` and not `h` and so it would never trigger (because the `double` case right before it was checking for `l` first), and certainly wouldn't trigger on an `h`.

There was also a bug that a literal with `hf`:

    2.0hf

would go into the path for the `f` suffix without considering the `h`.

These changes really ought to have some tests for them, but this was also just a quick issue I noticed while working on something else.