### PR TITLE
Change extractLine signature based on review of LineParser

### DIFF
--- a/source/core/slang-string-util.cpp
+++ b/source/core/slang-string-util.cpp
@@ -199,7 +199,7 @@ ComPtr<ISlangBlob> StringUtil::createStringBlob(const String& string)
     return (fromChar == toChar || string.indexOf(fromChar) == Index(-1)) ? string : calcCharReplaced(string.getUnownedSlice(), fromChar, toChar);
 }
 
-/* static */UnownedStringSlice StringUtil::extractLine(UnownedStringSlice& ioText)
+/* static */bool StringUtil::extractLine(UnownedStringSlice& ioText, UnownedStringSlice& outLine)
 {
     char const*const begin = ioText.begin();
     char const*const end = ioText.end();
@@ -207,7 +207,8 @@ ComPtr<ISlangBlob> StringUtil::createStringBlob(const String& string)
     // If we have hit the end then return the 'special' terminator
     if (begin == nullptr)
     {
-        return UnownedStringSlice(nullptr, nullptr);
+        outLine = UnownedStringSlice(nullptr, nullptr);
+        return false;
     }
 
     char const* cursor = begin;
@@ -234,7 +235,8 @@ ComPtr<ISlangBlob> StringUtil::createStringBlob(const String& string)
                 }
 
                 ioText = UnownedStringSlice(cursor, end);
-                return UnownedStringSlice(begin, lineEnd);
+                outLine = UnownedStringSlice(begin, lineEnd);
+                return true;
             }
             default:
                 break;
@@ -247,39 +249,32 @@ ComPtr<ISlangBlob> StringUtil::createStringBlob(const String& string)
     // Could be empty, or the remaining line (without line end terminators of)
     SLANG_ASSERT(begin <= cursor);
 
-    return UnownedStringSlice(begin, cursor);
+    outLine = UnownedStringSlice(begin, cursor);
+    return true;
 }
 
 /* static */void StringUtil::calcLines(const UnownedStringSlice& textIn, List<UnownedStringSlice>& outLines)
 {
     outLines.clear();
-
-    UnownedStringSlice text(textIn);
-    while (true)
+    UnownedStringSlice text(textIn), line;
+    while (extractLine(text, line))
     {
-        UnownedStringSlice line = extractLine(text);
-        if (line.begin() == nullptr)
-        {
-            return;
-        }
         outLines.add(line);
     }
 }
 
 /* static */bool StringUtil::areLinesEqual(const UnownedStringSlice& inA, const UnownedStringSlice& inB)
 {
-    UnownedStringSlice a(inA);
-    UnownedStringSlice b(inB);
-
+    UnownedStringSlice a(inA), b(inB), lineA, lineB;
+    
     while (true)
     {
-        const UnownedStringSlice lineA = extractLine(a);
-        const UnownedStringSlice lineB = extractLine(b);
+        const auto hasLineA = extractLine(a, lineA);
+        const auto hasLineB = extractLine(b, lineB);
 
-        // If either has ended, they both must have ended
-        if (lineA.begin() == nullptr || lineB.begin() == nullptr)
+        if (!(hasLineA && hasLineB))
         {
-            return lineA.begin() == lineB.begin();
+            return hasLineA == hasLineB;
         }
 
         // The lines must be equal

--- a/source/core/slang-string-util.h
+++ b/source/core/slang-string-util.h
@@ -78,15 +78,16 @@ struct StringUtil
         /// Create a blob from a string
     static ComPtr<ISlangBlob> createStringBlob(const String& string);
 
-        /// Returns a line extracted from the start of ioText.
+        /// Extracts a line and stores the remaining text in ioText, and the line in outLine. Returns true if has a line. 
         /// 
-        /// At the end of all the text a 'special' null UnownedStringSlice with a null 'begin' pointer is returned.
-        /// The slice passed in will be modified on output to contain the remaining text, starting at the beginning of the next line.
-        /// As en empty final line is still a line, the special null UnownedStringSlice is the last value ioText after the last valid line is returned.
+        /// As well as indicating end of text with the return value, at the end of all the text a 'special' null UnownedStringSlice with a null 'begin'
+        /// pointer is also returned as the outLine.
+        /// ioText will be modified to contain the remaining text, starting at the beginning of the next line.
+        /// As an empty final line is still a line, the special null UnownedStringSlice is the last value ioText after the last valid line is returned.
         /// 
         /// NOTE! That behavior is as if line terminators (like \n) act as separators. Thus input of "\n" will return *two* lines - an empty line
         /// before and then after the \n. 
-    static UnownedStringSlice extractLine(UnownedStringSlice& ioText);
+    static bool extractLine(UnownedStringSlice& ioText, UnownedStringSlice& outLine);
     
         /// Given text, splits into lines stored in outLines. NOTE! That lines is only valid as long as textIn remains valid
     static void calcLines(const UnownedStringSlice& textIn, List<UnownedStringSlice>& lines);
@@ -105,7 +106,7 @@ public:
         const UnownedStringSlice* operator->() const { return &m_line; }
         Iterator& operator++()
         {
-            m_line = StringUtil::extractLine(m_remaining);
+            StringUtil::extractLine(m_remaining, m_line);
             return *this;
         }
         Iterator operator++(int) { Iterator rs = *this; operator++(); return rs; }
@@ -122,7 +123,7 @@ public:
         UnownedStringSlice m_remaining;
     };
 
-    Iterator begin() const { UnownedStringSlice remaining(m_text);  UnownedStringSlice line = StringUtil::extractLine(remaining); return Iterator(line, remaining);  }
+    Iterator begin() const { UnownedStringSlice remaining(m_text), line;  StringUtil::extractLine(remaining, line); return Iterator(line, remaining);  }
     Iterator end() const { UnownedStringSlice term(nullptr, nullptr); return Iterator(term, term); }
 
         /// Ctor

--- a/source/slang/slang-source-loc.cpp
+++ b/source/slang/slang-source-loc.cpp
@@ -211,16 +211,10 @@ const List<uint32_t>& SourceFile::getLineBreakOffsets()
     // cache an array of line break locations in the file.
     if (m_lineBreakOffsets.getCount() == 0)
     {
-        UnownedStringSlice content = getContent();
+        UnownedStringSlice content(getContent()), line;
         char const* contentBegin = content.begin();
-      
-        while (true)
+        while (StringUtil::extractLine(content, line))
         {
-            auto line = StringUtil::extractLine(content);
-            if (line.begin() == nullptr)
-            {
-                break;
-            }
             m_lineBreakOffsets.add(uint32_t(line.begin() - contentBegin));
         }
         // Note that we do *not* treat the end of the file as a line

--- a/tools/slang-generate/main.cpp
+++ b/tools/slang-generate/main.cpp
@@ -554,15 +554,9 @@ void emitSimpleText(
     FILE*               stream,
     StringSpan const&   span)
 {
-    UnownedStringSlice content = span;
-    while (true)
+    UnownedStringSlice content(span), line;
+    while (StringUtil::extractLine(content, line))
     {
-        const auto line = StringUtil::extractLine(content);
-        if (line.begin() == nullptr)
-        {
-            break;
-        }
-
         // Write the line
         fwrite(line.begin(), 1, line.size(), stream);
 

--- a/tools/slang-test/unit-test-string.cpp
+++ b/tools/slang-test/unit-test-string.cpp
@@ -26,36 +26,21 @@ static bool _areEqual(const List<UnownedStringSlice>& lines, const UnownedString
 static bool _checkLines(const UnownedStringSlice& input, const UnownedStringSlice* checkLines, Int checkLinesCount)
 {
     List<UnownedStringSlice> lines;
-    UnownedStringSlice text(input);
-    while (true)
-    {
-        UnownedStringSlice line = StringUtil::extractLine(text);
-        if (line.begin() == nullptr)
-        {
-            return _areEqual(lines, checkLines, checkLinesCount);
-        }
-        lines.add(line);
-    }
+    StringUtil::calcLines(input, lines);
+    return _areEqual(lines, checkLines, checkLinesCount);
 }
 
 static bool _checkLineParser(const UnownedStringSlice& input)
 {
-    UnownedStringSlice remaining(input);
-    for (const auto line : LineParser(input))
+    UnownedStringSlice remaining(input), line;
+    for (const auto parserLine : LineParser(input))
     {
-        UnownedStringSlice extractLine = StringUtil::extractLine(remaining);
-        if (line != extractLine)
+        if (!StringUtil::extractLine(remaining, line) || line != parserLine)
         {
             return false;
         }
-        // Handle hitting the end
-        if (line.begin() == nullptr || extractLine.begin() == nullptr)
-        {
-            return line.begin() == extractLine.begin();
-        }
     }
-
-    return remaining.begin() == nullptr;
+    return StringUtil::extractLine(remaining, line) == false;
 }
 
 static void stringUnitTest()


### PR DESCRIPTION
* Make extractLine return a bool.
* Kept the special UnownedStringSlice for the end of text string (and for the ioText) - as works well with LineParser. 
