### PR TITLE
Hot fix: Remove getExecutablePath reported memory leak

### DIFF
--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -550,8 +550,7 @@ namespace Slang
 
     /* static */String Path::getExecutablePath()
     {
-        static String executablePath = _getExecutablePath();
-        return executablePath;
+        return _getExecutablePath();
     }
 
 	Slang::String File::readAllText(const Slang::String& fileName)

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -549,6 +549,11 @@ namespace Slang
 
     /* static */String Path::getExecutablePath()
     {
+        // TODO(JS): It would be better if we lazily evaluated this, and then returned the same string on subsequent calls, because it has to do
+        // a fair amount of work depending on target.
+        // This was how previous code worked, with a static variable. Unfortunately this led to a memory leak being reported - because reporting
+        // is done before a global variable is released.
+        // It would be good to have a mechanism that allows 'core' library source free memory in some controlled manner.
         return _getExecutablePath();
     }
 


### PR DESCRIPTION
Remove the memory leak that is being reported on Visual Studio, due to getExecutablePath having a static local variable that is not freed before leaks are dumped. The solution is sort of clumsy, in so far as it just removes the cache. Would be nice to have a better way to handle such situations.