### PR TITLE
Fix declaration of scalar sincos() function.

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -1231,7 +1231,7 @@ __generic<T : __BuiltinFloatingPointType, let N : int> vector<T,N> sin(vector<T,
 __generic<T : __BuiltinFloatingPointType, let N : int, let M : int> matrix<T,N,M> sin(matrix<T,N,M> x);
 
 // Sine and cosine
-__generic<T : __BuiltinFloatingPointType, let N : int> void sincos(T x, out T s, out T c);
+__generic<T : __BuiltinFloatingPointType> void sincos(T x, out T s, out T c);
 __generic<T : __BuiltinFloatingPointType, let N : int> void sincos(vector<T,N> x, out vector<T,N> s, out vector<T,N> c);
 __generic<T : __BuiltinFloatingPointType, let N : int, let M : int> void sincos(matrix<T,N,M> x, out matrix<T,N,M> s, out matrix<T,N,M> c);
 

--- a/source/slang/hlsl.meta.slang.h
+++ b/source/slang/hlsl.meta.slang.h
@@ -1307,7 +1307,7 @@ SLANG_RAW("__generic<T : __BuiltinFloatingPointType, let N : int> vector<T,N> si
 SLANG_RAW("__generic<T : __BuiltinFloatingPointType, let N : int, let M : int> matrix<T,N,M> sin(matrix<T,N,M> x);\n")
 SLANG_RAW("\n")
 SLANG_RAW("// Sine and cosine\n")
-SLANG_RAW("__generic<T : __BuiltinFloatingPointType, let N : int> void sincos(T x, out T s, out T c);\n")
+SLANG_RAW("__generic<T : __BuiltinFloatingPointType> void sincos(T x, out T s, out T c);\n")
 SLANG_RAW("__generic<T : __BuiltinFloatingPointType, let N : int> void sincos(vector<T,N> x, out vector<T,N> s, out vector<T,N> c);\n")
 SLANG_RAW("__generic<T : __BuiltinFloatingPointType, let N : int, let M : int> void sincos(matrix<T,N,M> x, out matrix<T,N,M> s, out matrix<T,N,M> c);\n")
 SLANG_RAW("\n")

--- a/tests/front-end/sincos.slang
+++ b/tests/front-end/sincos.slang
@@ -1,0 +1,19 @@
+// sincos.slang
+//TEST:SIMPLE:
+
+// Just confirming that calls to the `sincos()` built
+// in work in the front-end.
+
+float test( float4x4 m, float4 v, float a )
+{
+    float4x4 mc, ms;
+    sincos(m, mc, ms);
+
+    float4 vc, vs;
+    sincos(v, vc, vs);
+
+    float c, s;
+    sincos(a, c, s);
+	
+	return c + s + vc[0] + vs[0] + mc[0][0] + ms[0][0];
+}


### PR DESCRIPTION
The function was accidentally defined with a generic `int` parameter copy-pasted  from the vector definition, but that made the scalar version impossible to call with inferred generic arguments, because there wasn't a way to infer `N` when it isn't used in the parameter list.

Includes a simple test case to confirm that the front-end no longer chokes on calls to scalar `sincos()`.