### PR TITLE
WIP: slang to C++ code generation

### DIFF
--- a/source/core/slang-gcc-compiler-util.cpp
+++ b/source/core/slang-gcc-compiler-util.cpp
@@ -338,7 +338,11 @@ static SlangResult _parseGCCFamilyLine(const UnownedStringSlice& line, LineParse
 /* static */void GCCCompilerUtil::calcArgs(const CompileOptions& options, CommandLine& cmdLine)
 {
     cmdLine.addArg("-fvisibility=hidden");
-    cmdLine.addArg("-std=c++11");
+
+    if (options.sourceType == SourceType::CPP)
+    {
+        cmdLine.addArg("-std=c++11");
+    }
 
     // Use shared libraries
     //cmdLine.addArg("-shared");

--- a/source/core/slang-gcc-compiler-util.cpp
+++ b/source/core/slang-gcc-compiler-util.cpp
@@ -338,6 +338,8 @@ static SlangResult _parseGCCFamilyLine(const UnownedStringSlice& line, LineParse
 /* static */void GCCCompilerUtil::calcArgs(const CompileOptions& options, CommandLine& cmdLine)
 {
     cmdLine.addArg("-fvisibility=hidden");
+    cmdLine.addArg("-std=c++11");
+
     // Use shared libraries
     //cmdLine.addArg("-shared");
 
@@ -454,6 +456,8 @@ static SlangResult _parseGCCFamilyLine(const UnownedStringSlice& line, LineParse
     {
         // Make STD libs available
         cmdLine.addArg("-lstdc++");
+	// Make maths lib available
+        cmdLine.addArg("-lm");
     }
 }
 

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -280,7 +280,6 @@ void CLikeSourceEmitter::emitType(IRType* type, const String& name)
     emitType(type, SourceLoc(), &tempName, SourceLoc());
 }
 
-
 void CLikeSourceEmitter::emitType(IRType* type)
 {
     _emitType(type, nullptr);

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -1533,12 +1533,10 @@ void CLikeSourceEmitter::emitIntrinsicCallExpr(
     //
     auto linkageDecoration = valueForName->findDecoration<IRLinkageDecoration>();
     SLANG_ASSERT(linkageDecoration);
-    auto mangledName = String(linkageDecoration->getMangledName());
-
-
+    
     // We will use the `MangledLexer` to
     // help us split the original name into its pieces.
-    MangledLexer lexer(mangledName);
+    MangledLexer lexer(linkageDecoration->getMangledName());
     
     // We'll read through the qualified name of the
     // symbol (e.g., `Texture2D<T>.Sample`) and then

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -1653,7 +1653,7 @@ void CLikeSourceEmitter::emitCallExpr(IRCall* inst, IREmitMode mode, EmitOpInfo 
         maybeCloseParens(needClose);
     }
 }
-    
+
 void CLikeSourceEmitter::emitInstExpr(IRInst* inst, IREmitMode mode, const EmitOpInfo& inOuterPrec)
 {
     // Try target specific impl first
@@ -1661,7 +1661,11 @@ void CLikeSourceEmitter::emitInstExpr(IRInst* inst, IREmitMode mode, const EmitO
     {
         return;
     }
+    defaultEmitInstExpr(inst, mode, inOuterPrec);
+}
 
+void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, IREmitMode mode, const EmitOpInfo& inOuterPrec)
+{
     EmitOpInfo outerPrec = inOuterPrec;
     bool needClose = false;
     switch(inst->op)

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -226,7 +226,8 @@ public:
     void emitCallExpr(IRCall* inst, IREmitMode mode, EmitOpInfo outerPrec);
 
     void emitInstExpr(IRInst* inst, IREmitMode mode, EmitOpInfo const& inOuterPrec);
-    
+    void defaultEmitInstExpr(IRInst* inst, IREmitMode mode, EmitOpInfo const& inOuterPrec);
+
     BaseType extractBaseType(IRType* inType);
 
     void emitInst(IRInst* inst, IREmitMode mode);

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -133,14 +133,6 @@ public:
 
     void emitDeclarator(EDeclarator* declarator);
 
-    //void emitVectorTypeName(IRType* elementType, IRIntegerValue elementCount);
-    //void emitTextureType(IRTextureType* texType);
-    //void emitTextureSamplerType(IRTextureSamplerType* type);
-    //void emitImageType(IRGLSLImageType* type);
-    //void emitSamplerStateType(IRSamplerStateTypeBase* samplerStateType);
-    //void emitStructuredBufferType(IRHLSLStructuredBufferTypeBase* type);
-    //void emitUntypedBufferType(IRUntypedBufferResourceType* type);
-
     void emitType(IRType* type, const SourceLoc& typeLoc, Name* name, const SourceLoc& nameLoc);
     void emitType(IRType* type, Name* name);
     void emitType(IRType* type, String const& name);

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -133,7 +133,7 @@ public:
 
     void emitDeclarator(EDeclarator* declarator);
 
-    void emitType(IRType* type, const SourceLoc& typeLoc, Name* name, const SourceLoc& nameLoc);
+    void emitType(IRType* type, const StringSliceLoc* nameLoc) { emitTypeImpl(type, nameLoc); }
     void emitType(IRType* type, Name* name);
     void emitType(IRType* type, String const& name);
     void emitType(IRType* type);
@@ -346,6 +346,7 @@ public:
     virtual void emitSimpleTypeImpl(IRType* type) = 0;
     virtual void emitVarDecorationsImpl(IRInst* varDecl) { SLANG_UNUSED(varDecl);  }
     virtual void emitMatrixLayoutModifiersImpl(VarLayout* layout) { SLANG_UNUSED(layout);  }
+    virtual void emitTypeImpl(IRType* type, const StringSliceLoc* nameLoc);
 
         // Only needed for glsl output with $ prefix intrinsics - so perhaps removable in the future
     virtual void emitTextureOrTextureSamplerTypeImpl(IRTextureTypeBase*  type, char const* baseName) { SLANG_UNUSED(type); SLANG_UNUSED(baseName); }

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -1398,6 +1398,8 @@ void CPPSourceEmitter::emitEntryPointAttributesImpl(IRFunc* irFunc, EntryPointLa
         }
         default: break;
     }
+
+    m_writer->emit("SLANG_EXPORT\n");
 }
 
 void CPPSourceEmitter::emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount)

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -413,7 +413,7 @@ StringSlicePool::Handle CPPSourceEmitter::_calcTypeName(IRType* type)
             int elementCount = int(GetIntVal(arrayType->getElementCount()));
 
             StringBuilder builder;
-            builder << "Array<";
+            builder << "FixedArray<";
             builder << _getTypeName(elementType);
             builder << ", " << elementCount << ">";
 

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -1252,20 +1252,26 @@ void CPPEmitHandler::emitCall(const SpecializedOperation& specOp, IRInst* inst, 
         default:
         {
             const auto& info = getOperationInfo(specOp.op);
-            if (info.numOperands >= 0)
+            // Make sure that the return type is available
+            bool isOperator = _isOperator(info.funcName);
+
+            
+            UnownedStringSlice funcName = _getFuncName(specOp);
+
+            useType(specOp.returnType);
+            // add that we want a function
+            SLANG_ASSERT(numOperands == info.numOperands);
+
+            if (isOperator)
             {
-                SLANG_ASSERT(numOperands == info.numOperands);
-                // Make sure that the return type is available
-                useType(specOp.returnType);
-                // add that we want a function
-                _getFuncName(specOp);
                 // Just do the default output
                 emitter->defaultEmitInstExpr(inst, mode, inOuterPrec);
             }
             else
             {
-                UnownedStringSlice name = _getFuncName(specOp);
-                writer->emit(name);
+                
+
+                writer->emit(funcName);
                 writer->emitChar('(');
 
                 for (int i = 0; i < numOperands; ++i)

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -284,8 +284,18 @@ void CPPSourceEmitter::emitTypeDefinition(IRType* inType)
             m_typeEmittedMap.Add(type, true);
             break;
         }
+        case kIROp_PtrType:
+        case kIROp_RefType:
+        {
+            // We don't need to output a definition for these types
+            break;
+        }
+        case kIROp_ArrayType:
+        case kIROp_UnsizedArrayType:
         case kIROp_HLSLRWStructuredBufferType:
         {
+            // We don't need to output a definition for these with C++ templates
+            // For C we may need to (or do casting at point of usage)
             break;
         }
         default:
@@ -1385,6 +1395,18 @@ void CPPSourceEmitter::emitSimpleTypeImpl(IRType* inType)
             m_writer->emit(slice);
             break;
         }
+    }
+}
+
+void CPPSourceEmitter::emitTypeImpl(IRType* type, const StringSliceLoc* nameLoc)
+{
+    UnownedStringSlice slice = _getTypeName(type);
+    m_writer->emit(slice);
+
+    if (nameLoc)
+    {
+        m_writer->emit(" ");
+        m_writer->emitName(*nameLoc);
     }
 }
 

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -1255,7 +1255,6 @@ void CPPEmitHandler::emitCall(const SpecializedOperation& specOp, IRInst* inst, 
             // Make sure that the return type is available
             bool isOperator = _isOperator(info.funcName);
 
-            
             UnownedStringSlice funcName = _getFuncName(specOp);
 
             useType(specOp.returnType);
@@ -1269,8 +1268,6 @@ void CPPEmitHandler::emitCall(const SpecializedOperation& specOp, IRInst* inst, 
             }
             else
             {
-                
-
                 writer->emit(funcName);
                 writer->emitChar('(');
 

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -16,14 +16,15 @@ class CPPSourceEmitter;
         x(Invalid) \
         x(Init) \
         x(Broadcast) \
-        x(Splat) \
+        \
         x(Mul) \
         x(Div) \
         x(Add) \
         x(Sub) \
         \
-        x(Dot) \
+        x(Swizzle) \
         \
+        x(Dot) \
         x(VecMatMul)
 
 class CPPEmitHandler: public RefObject
@@ -67,7 +68,7 @@ public:
 
     virtual SpecializedOperation getSpecializedOperation(Operation op, IRType*const* argTypes, int argTypesCount, IRType* retType);
     virtual void useType(IRType* type);
-    virtual void emitCall(const SpecializedOperation& specOp, const IRUse* operands, int numOperands, CLikeSourceEmitter::IREmitMode mode, const EmitOpInfo& inOuterPrec, CPPSourceEmitter* emitter);
+    virtual void emitCall(const SpecializedOperation& specOp, IRInst* inst, const IRUse* operands, int numOperands, CLikeSourceEmitter::IREmitMode mode, const EmitOpInfo& inOuterPrec, CPPSourceEmitter* emitter);
     virtual void emitType(IRType* type, CPPSourceEmitter* emitter);
     virtual void emitTypeDefinition(IRType* type, CPPSourceEmitter* emitter);
     virtual void emitSpecializedOperationDefinition(const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
@@ -75,7 +76,7 @@ public:
 
     virtual void emitPreamble(CPPSourceEmitter* emitter);
 
-    void emitOperationCall(Operation op, IRUse* operands, int operandCount, IRType* retType, CLikeSourceEmitter::IREmitMode mode, const EmitOpInfo& inOuterPrec, CPPSourceEmitter* emitter);
+    void emitOperationCall(Operation op, IRInst* inst, IRUse* operands, int operandCount, IRType* retType, CLikeSourceEmitter::IREmitMode mode, const EmitOpInfo& inOuterPrec, CPPSourceEmitter* emitter);
 
     static UnownedStringSlice getBuiltinTypeName(IROp op);
     static UnownedStringSlice getName(Operation op);

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -180,7 +180,7 @@ protected:
     virtual void emitTypeImpl(IRType* type, const StringSliceLoc* nameLoc) SLANG_OVERRIDE;
     virtual void emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount) SLANG_OVERRIDE;
     virtual bool tryEmitInstExprImpl(IRInst* inst, IREmitMode mode, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;
-    virtual void emitPreprocessorDirectivesImpl();
+    virtual void emitPreprocessorDirectivesImpl() SLANG_OVERRIDE;
 
     void emitIntrinsicCallExpr(IRCall* inst, IRFunc* func, IREmitMode mode, EmitOpInfo const& inOuterPrec);
 

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -143,7 +143,7 @@ public:
         IRFuncType* signatureType;              // Same as funcType, but has return type of void
     };
 
-    struct Dimension
+    struct TypeDimension
     {
         bool isScalar() const { return rowCount <= 1 && colCount <= 1; }
 
@@ -201,8 +201,8 @@ protected:
 
     UnownedStringSlice _getAndEmitSpecializedOperationDefinition(Operation op, IRType*const* argTypes, Int argCount, IRType* retType);
 
-    static Dimension _getDimension(IRType* type, bool vecSwap);
-    static void _emitAccess(const UnownedStringSlice& name, const Dimension& dimension, int row, int col, SourceWriter* writer);
+    static TypeDimension _getTypeDimension(IRType* type, bool vecSwap);
+    static void _emitAccess(const UnownedStringSlice& name, const TypeDimension& dimension, int row, int col, SourceWriter* writer);
 
     IRType* _getVecType(IRType* elementType, int elementCount);
 

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -15,6 +15,47 @@ class CPPSourceEmitter: public CLikeSourceEmitter
 public:
     typedef CLikeSourceEmitter Super;
 
+    struct HLSLType
+    {
+        typedef HLSLType ThisType;
+
+        static ThisType makeVec(IROp inElementType, int inCount)
+        {
+            return ThisType{ uint8_t(kIROp_VectorType), uint8_t(inElementType), uint8_t(inCount), 0 };
+        }
+        static ThisType makeMatrix(IROp inElementType, int inRowsCount, int inColsCount)
+        {
+            return ThisType{ uint8_t(kIROp_MatrixType), uint8_t(inElementType), uint8_t(inColsCount), uint8_t(inRowsCount) };
+        }
+        static ThisType makeBasic(IROp inType)
+        {
+            return ThisType{ uint8_t(inType), 0, 0, 0 };
+        }
+
+        uint32_t getOrder() const
+        {
+            switch (op)
+            {
+                case kIROp_MatrixType:      return uint32_t(0x02000000) | (uint32_t(elementType) << 16) | (uint32_t(sizeOrColCount) << 8) | rowCount;
+                case kIROp_VectorType:      return uint32_t(0x01000000) | (uint32_t(elementType) << 16) | (uint32_t(sizeOrColCount) << 8);
+                default:                    return                        (uint32_t(op) << 16);
+            }
+        }
+            /// Just fit into a uint32_t
+        uint32_t getCompressed() const { return (uint32_t(op) << 24) | (uint32_t(elementType) << 16) | (uint32_t(sizeOrColCount) << 8) | uint32_t(rowCount); }
+
+            /// It's better than a hash in that one to one mapping between 'type' and hash
+        UInt GetHashCode() const { return getCompressed(); }
+
+        bool operator==(const ThisType& rhs) const { return getCompressed() == rhs.getCompressed(); }
+        bool operator!=(const ThisType& rhs) const { return getCompressed() != rhs.getCompressed(); }
+
+        uint8_t op;
+        uint8_t elementType;
+        uint8_t sizeOrColCount;
+        uint8_t rowCount;
+    };
+
     enum class BuiltInCOp
     {
         Splat,                  //< Splat a single value to all values of a vector or matrix type
@@ -22,6 +63,8 @@ public:
     };
 
     CPPSourceEmitter(const Desc& desc);
+
+    static UnownedStringSlice getBuiltinTypeName(IROp op);
 
 protected:
 
@@ -36,17 +79,12 @@ protected:
 
     virtual void emitPreprocessorDirectivesImpl();
 
-    UnownedStringSlice _getTypeName(IRType* type);
-    StringSlicePool::Handle _calcTypeName(IRType* type);
-    IRType* _getVectorType(IRType* elemType, int count);
-    
-    Dictionary<IRType*, StringSlicePool::Handle> m_typeNameMap;
+    UnownedStringSlice _getTypeName(const HLSLType& type);
+    StringSlicePool::Handle _calcTypeName(const HLSLType& type);
+
+    Dictionary<HLSLType, StringSlicePool::Handle> m_typeNameMap;
 
     StringSlicePool m_slicePool;
-
-    //RefPtr<IRModule> m_module;
-    //SharedIRBuilder m_sharedBuilder;
-    //IRBuilder m_builder;
 };
 
 }

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -176,6 +176,7 @@ protected:
     virtual void emitParameterGroupImpl(IRGlobalParam* varDecl, IRUniformParameterGroupType* type) SLANG_OVERRIDE;
     virtual void emitEntryPointAttributesImpl(IRFunc* irFunc, EntryPointLayout* entryPointLayout) SLANG_OVERRIDE;
     virtual void emitSimpleTypeImpl(IRType* type) SLANG_OVERRIDE;
+    virtual void emitTypeImpl(IRType* type, const StringSliceLoc* nameLoc) SLANG_OVERRIDE;
     virtual void emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount) SLANG_OVERRIDE;
 
     virtual bool tryEmitInstExprImpl(IRInst* inst, IREmitMode mode, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -42,10 +42,13 @@ class CPPSourceEmitter;
         x(Not, "!", 1) \
         x(BitNot, "~", 1) \
         \
+        x(Any, "any", 1) \
+        x(All, "all", 1) \
+        \
         x(Swizzle, "", -1) \
         \
-        x(Dot, "", -1) \
-        x(VecMatMul, "", -1)
+        x(Dot, "dot", -1) \
+        x(VecMatMul, "mul", -1) 
 
 class CPPEmitHandler: public RefObject
 {
@@ -128,6 +131,7 @@ protected:
     void _emitParameter(char charName, IRType* type, const Dimension& dim, CPPSourceEmitter* emitter);
     void _emitBinaryOp(const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
     void _emitUnaryOp(const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
+    void _emitAnyAll(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
 
     static Dimension _getDimension(IRType* type, bool vecSwap);
     static void _emitAccess(const UnownedStringSlice& name, const Dimension& dimension, int row, int col, SourceWriter* writer);
@@ -153,6 +157,9 @@ protected:
     Dictionary<IRInst*, IRInst*> m_cloneMap;
 
     Dictionary<IRType*, bool> m_typeEmittedMap;
+
+    // Maps from a name to an operation
+    List<Operation> m_operationMap;  
 
     StringSlicePool m_slicePool;
 };

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -47,11 +47,11 @@ class CPPSourceEmitter;
         \
         x(Swizzle, "", -1) \
         \
-        x(Dot, "dot", -1) \
-        x(VecMatMul, "mul", -1) \
+        x(Dot, "dot", 2) \
+        x(VecMatMul, "mul", 2) \
         \
-        x(Normalize, "normalize", -1) \
-        x(Length, "length", -1) \
+        x(Normalize, "normalize", 1) \
+        x(Length, "length", 1) \
         \
         x(Sin, "sin", 1) \
         x(Cos, "cos", 1) \

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -10,7 +10,7 @@
 namespace Slang
 {
 
-#define SLANG_CPP_OPERATION(x) \
+#define SLANG_CPP_INTRINSIC_OP(x) \
         x(Invalid, "", -1) \
         x(Init, "", -1) \
         \
@@ -101,10 +101,10 @@ class CPPSourceEmitter: public CLikeSourceEmitter
 public:
     typedef CLikeSourceEmitter Super;
 
-#define SLANG_CPP_OPERATION_ENUM(x, op, numOperands) x,
-    enum class Operation
+#define SLANG_CPP_INTRINSIC_OP_ENUM(x, op, numOperands) x,
+    enum class IntrinsicOp
     {
-        SLANG_CPP_OPERATION(SLANG_CPP_OPERATION_ENUM)
+        SLANG_CPP_INTRINSIC_OP(SLANG_CPP_INTRINSIC_OP_ENUM)
     };
 
     struct OperationInfo
@@ -114,9 +114,9 @@ public:
         int8_t numOperands;                     ///< -1 if can't be handled automatically via amount of params
     };
 
-    struct SpecializedOperation
+    struct SpecializedIntrinsic
     {
-        typedef SpecializedOperation ThisType;
+        typedef SpecializedIntrinsic ThisType;
 
         UInt GetHashCode() const { return combineHash(int(op), Slang::GetHashCode(signatureType)); }
 
@@ -138,7 +138,7 @@ public:
             return true;
         }
 
-        Operation op;
+        IntrinsicOp op;
         IRType* returnType;
         IRFuncType* signatureType;              // Same as funcType, but has return type of void
     };
@@ -151,55 +151,53 @@ public:
         int colCount;
     };
 
-    virtual SpecializedOperation getSpecializedOperation(Operation op, IRType*const* argTypes, int argTypesCount, IRType* retType);
+    virtual SpecializedIntrinsic getSpecializedOperation(IntrinsicOp op, IRType*const* argTypes, int argTypesCount, IRType* retType);
     virtual void useType(IRType* type);
-    virtual void emitCall(const SpecializedOperation& specOp, IRInst* inst, const IRUse* operands, int numOperands, CLikeSourceEmitter::IREmitMode mode, const EmitOpInfo& inOuterPrec);
+    virtual void emitCall(const SpecializedIntrinsic& specOp, IRInst* inst, const IRUse* operands, int numOperands, CLikeSourceEmitter::IREmitMode mode, const EmitOpInfo& inOuterPrec);
     virtual void emitTypeDefinition(IRType* type);
-    virtual void emitSpecializedOperationDefinition(const SpecializedOperation& specOp);
+    virtual void emitSpecializedOperationDefinition(const SpecializedIntrinsic& specOp);
     
-    void emitOperationCall(Operation op, IRInst* inst, IRUse* operands, int operandCount, IRType* retType, CLikeSourceEmitter::IREmitMode mode, const EmitOpInfo& inOuterPrec);
+    void emitOperationCall(IntrinsicOp op, IRInst* inst, IRUse* operands, int operandCount, IRType* retType, CLikeSourceEmitter::IREmitMode mode, const EmitOpInfo& inOuterPrec);
 
     static UnownedStringSlice getBuiltinTypeName(IROp op);
 
-    static const OperationInfo& getOperationInfo(Operation op);
+    static const OperationInfo& getOperationInfo(IntrinsicOp op);
 
-    static Operation getOperation(IROp op);
+    static IntrinsicOp getOperation(IROp op);
 
-    Operation getOperationByName(const UnownedStringSlice& slice);
+    IntrinsicOp getOperationByName(const UnownedStringSlice& slice);
 
     SourceWriter* getSourceWriter() const { return m_writer; }
 
     CPPSourceEmitter(const Desc& desc);
 
 protected:
-    
+
+    // Implement CLikeSourceEmitter interface
     virtual void emitParameterGroupImpl(IRGlobalParam* varDecl, IRUniformParameterGroupType* type) SLANG_OVERRIDE;
     virtual void emitEntryPointAttributesImpl(IRFunc* irFunc, EntryPointLayout* entryPointLayout) SLANG_OVERRIDE;
     virtual void emitSimpleTypeImpl(IRType* type) SLANG_OVERRIDE;
     virtual void emitTypeImpl(IRType* type, const StringSliceLoc* nameLoc) SLANG_OVERRIDE;
     virtual void emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount) SLANG_OVERRIDE;
-
     virtual bool tryEmitInstExprImpl(IRInst* inst, IREmitMode mode, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;
-
     virtual void emitPreprocessorDirectivesImpl();
 
     void emitIntrinsicCallExpr(IRCall* inst, IRFunc* func, IREmitMode mode, EmitOpInfo const& inOuterPrec);
 
+    void _emitVecMatMulDefinition(const UnownedStringSlice& funcName, const SpecializedIntrinsic& specOp);
 
-    void _emitVecMatMulDefinition(const UnownedStringSlice& funcName, const SpecializedOperation& specOp);
-
-    void _emitAryDefinition(const SpecializedOperation& specOp);
+    void _emitAryDefinition(const SpecializedIntrinsic& specOp);
 
     // Really we don't want any of these defined like they are here, they should be defined in slang stdlib 
-    void _emitAnyAllDefinition(const UnownedStringSlice& funcName, const SpecializedOperation& specOp);
-    void _emitCrossDefinition(const UnownedStringSlice& funcName, const SpecializedOperation& specOp);
-    void _emitLengthDefinition(const UnownedStringSlice& funcName, const SpecializedOperation& specOp);
-    void _emitNormalizeDefinition(const UnownedStringSlice& funcName, const SpecializedOperation& specOp);
-    void _emitReflectDefinition(const UnownedStringSlice& funcName, const SpecializedOperation& specOp);
+    void _emitAnyAllDefinition(const UnownedStringSlice& funcName, const SpecializedIntrinsic& specOp);
+    void _emitCrossDefinition(const UnownedStringSlice& funcName, const SpecializedIntrinsic& specOp);
+    void _emitLengthDefinition(const UnownedStringSlice& funcName, const SpecializedIntrinsic& specOp);
+    void _emitNormalizeDefinition(const UnownedStringSlice& funcName, const SpecializedIntrinsic& specOp);
+    void _emitReflectDefinition(const UnownedStringSlice& funcName, const SpecializedIntrinsic& specOp);
 
-    void _emitSignature(const UnownedStringSlice& funcName, const SpecializedOperation& specOp);
+    void _emitSignature(const UnownedStringSlice& funcName, const SpecializedIntrinsic& specOp);
 
-    UnownedStringSlice _getAndEmitSpecializedOperationDefinition(Operation op, IRType*const* argTypes, Int argCount, IRType* retType);
+    UnownedStringSlice _getAndEmitSpecializedOperationDefinition(IntrinsicOp op, IRType*const* argTypes, Int argCount, IRType* retType);
 
     static TypeDimension _getTypeDimension(IRType* type, bool vecSwap);
     static void _emitAccess(const UnownedStringSlice& name, const TypeDimension& dimension, int row, int col, SourceWriter* writer);
@@ -209,29 +207,47 @@ protected:
     IRInst* _clone(IRInst* inst);
     IRType* _cloneType(IRType* type) { return (IRType*)_clone((IRInst*)type); }
 
-    StringSlicePool::Handle _calcScalarFuncName(Operation op, IRBasicType* type);
-    UnownedStringSlice _getScalarFuncName(Operation operation, IRBasicType* scalarType);
+    StringSlicePool::Handle _calcScalarFuncName(IntrinsicOp op, IRBasicType* type);
+    UnownedStringSlice _getScalarFuncName(IntrinsicOp operation, IRBasicType* scalarType);
 
-    UnownedStringSlice _getFuncName(const SpecializedOperation& specOp);
-    StringSlicePool::Handle _calcFuncName(const SpecializedOperation& specOp);
+    UnownedStringSlice _getFuncName(const SpecializedIntrinsic& specOp);
+    StringSlicePool::Handle _calcFuncName(const SpecializedIntrinsic& specOp);
 
     UnownedStringSlice _getTypeName(IRType* type);
     StringSlicePool::Handle _calcTypeName(IRType* type);
 
-    Dictionary<SpecializedOperation, StringSlicePool::Handle> m_specializeOperationNameMap;
+    Dictionary<SpecializedIntrinsic, StringSlicePool::Handle> m_intrinsicNameMap;
     Dictionary<IRType*, StringSlicePool::Handle> m_typeNameMap;
 
-    RefPtr<IRModule> m_uniqueModule;            ///< Store types/function sigs etc for output
+    /* This is used so as to try and use slangs type system to uniquely identify types and specializations on intrinsice.
+    That we want to have a pointer to a type be unique, and slang supports this through the m_sharedIRBuilder. BUT for this to
+    work all work on the module must use the same sharedIRBuilder, and that appears to not be the case in terms
+    of other passes.
+    Even if it was the case when we may want to add types as part of emitting, we can't use the previously used
+    shared builder, so again we end up with pointers to the same things not being the same thing.
+
+    To work around this we clone types we want to use as keys into the 'unique module'.
+    This is not necessary for all types though - as we assume nominal types *must* have unique pointers (that is the
+    definition of nominal).
+
+    This could be handled in other ways (for example not testing equality on pointer equality). Anyway for now this
+    works, but probably needs to be handled in a better way. The better way may involve having guarantees about equality
+    enabled in other code generation and making de-duping possible in emit code.
+
+    Note that one pro for this approach is that it does not alter the source module. That as it stands it's not necessary
+    for the source module to be immutable, because it is created for emitting and then discarded. 
+     */
+    RefPtr<IRModule> m_uniqueModule;            
     SharedIRBuilder m_sharedIRBuilder;
     IRBuilder m_irBuilder;
 
     Dictionary<IRInst*, IRInst*> m_cloneMap;
 
     Dictionary<IRType*, bool> m_typeEmittedMap;
-    Dictionary<SpecializedOperation, bool> m_operationEmittedMap;
+    Dictionary<SpecializedIntrinsic, bool> m_intrinsicEmittedMap;
 
-    // Maps from a name to an operation
-    List<Operation> m_operationMap;
+    // Maps from a name (in the form of a handle/index from m_slicePool) to an operation
+    List<IntrinsicOp> m_intrinsicOpMap;
 
     StringSlicePool m_slicePool;
 };

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -174,23 +174,32 @@ public:
     CPPEmitHandler(const CLikeSourceEmitter::Desc& desc);
 
 protected:
-    void _emitVecMatMul(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
-    void _emitBinaryOp(const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
-    void _emitUnaryOp(const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
-    void _emitAnyAll(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
-    void _emitCross(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
+    void _emitVecMatMulDefinition(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
+
+    void _emitAryDefinition(const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
+
+    // Really we don't want any of these defined like they are here, they should be defined in slang stdlib 
+    void _emitAnyAllDefinition(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
+    void _emitCrossDefinition(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
+    void _emitLengthDefinition(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
+    void _emitNormalizeDefinition(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
+    void _emitReflectDefinition(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
 
     void _emitSignature(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
     
+    UnownedStringSlice _getAndEmitSpecializedOperationDefinition(Operation op, IRType*const* argTypes, Int argCount, IRType* retType, CPPSourceEmitter* emitter);
 
     static Dimension _getDimension(IRType* type, bool vecSwap);
     static void _emitAccess(const UnownedStringSlice& name, const Dimension& dimension, int row, int col, SourceWriter* writer);
-
+    
     IRType* _getVecType(IRType* elementType, int elementCount);
 
     IRInst* _clone(IRInst* inst);
     IRType* _cloneType(IRType* type) { return (IRType*)_clone((IRInst*)type); }
 
+    StringSlicePool::Handle _calcScalarFuncName(Operation op, IRBasicType* type);
+    UnownedStringSlice _getScalarFuncName(Operation operation, IRBasicType* scalarType);
+    
     UnownedStringSlice _getFuncName(const SpecializedOperation& specOp);
     StringSlicePool::Handle _calcFuncName(const SpecializedOperation& specOp);
 

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -15,64 +15,16 @@ class CPPSourceEmitter: public CLikeSourceEmitter
 public:
     typedef CLikeSourceEmitter Super;
 
-    struct HLSLType
-    {
-        typedef HLSLType ThisType;
-
-        static ThisType makeInvalid()
-        {
-            // I would use kIROp_Invalid, but it's bigger than 8 bits, so nop will do for now
-            return ThisType{ uint8_t(kIROp_Nop), 0, 0, 0};
-        }
-        static ThisType makeVec(IROp inElementType, int inCount)
-        {
-            return ThisType{ uint8_t(kIROp_VectorType), uint8_t(inElementType), uint8_t(inCount), 0 };
-        }
-        static ThisType makeMatrix(IROp inElementType, int inRowsCount, int inColsCount)
-        {
-            return ThisType{ uint8_t(kIROp_MatrixType), uint8_t(inElementType), uint8_t(inColsCount), uint8_t(inRowsCount) };
-        }
-        static ThisType makeBasic(IROp inType)
-        {
-            return ThisType{ uint8_t(inType), 0, 0, 0 };
-        }
-
-        uint32_t getOrder() const
-        {
-            switch (op)
-            {
-                case kIROp_MatrixType:      return uint32_t(0x02000000) | (uint32_t(elementType) << 16) | (uint32_t(sizeOrColCount) << 8) | rowCount;
-                case kIROp_VectorType:      return uint32_t(0x01000000) | (uint32_t(elementType) << 16) | (uint32_t(sizeOrColCount) << 8);
-                default:                    return                        (uint32_t(op) << 16);
-            }
-        }
-            /// Just fit into a uint32_t
-        uint32_t getCompressed() const { return (uint32_t(op) << 24) | (uint32_t(elementType) << 16) | (uint32_t(sizeOrColCount) << 8) | uint32_t(rowCount); }
-
-        bool isInvalid() const { return op == kIROp_Nop; }
-
-            /// It's better than a hash in that one to one mapping between 'type' and hash
-        UInt GetHashCode() const { return getCompressed(); }
-
-        bool operator==(const ThisType& rhs) const { return getCompressed() == rhs.getCompressed(); }
-        bool operator!=(const ThisType& rhs) const { return getCompressed() != rhs.getCompressed(); }
-
-        uint8_t op;
-        uint8_t elementType;
-        uint8_t sizeOrColCount;
-        uint8_t rowCount;
-    };
-
     struct HLSLFunction
     {
         typedef HLSLFunction ThisType;
 
         UInt GetHashCode() const
         {
-            auto hash = combineHash(combineHash(int(name), int(argsCount)), int(returnType.GetHashCode()));
+            auto hash = combineHash(combineHash(int(name), int(argsCount)), int(Slang::GetHashCode(returnType)));
             for (int i = 0; i < argsCount; ++i)
             {
-                hash = combineHash(hash, int(args[i].GetHashCode()));
+                hash = combineHash(hash, int(Slang::GetHashCode(args[i])));
             }
             return hash;
         }
@@ -95,8 +47,8 @@ public:
         bool operator!=(const ThisType& rhs) const { return !(*this == rhs); }
 
         StringSlicePool::Handle name;
-        HLSLType returnType;
-        HLSLType args[4];
+        IRType* returnType;
+        IRType* args[4];
         uint8_t argsCount;
     };
 
@@ -125,18 +77,29 @@ protected:
 
     void emitIntrinsicCallExpr(IRCall* inst, IRFunc* func, IREmitMode mode, EmitOpInfo const& inOuterPrec);
 
-        /// Convert a type into a HLSL built in type. 
-    HLSLType _getHLSLType(IRType* type);
+    IRInst* _clone(IRInst* inst);
+    IRType* _cloneType(IRType* type) { return (IRType*)_clone((IRInst*)type); }
+
     HLSLFunction _getHLSLFunc(const UnownedStringSlice& name, IRCall* inst, int operandIndex, int operandCount);
 
     UnownedStringSlice _getFuncName(const HLSLFunction& func);
     StringSlicePool::Handle _calcFuncName(const HLSLFunction& func);
 
-    UnownedStringSlice _getTypeName(const HLSLType& type);
-    StringSlicePool::Handle _calcTypeName(const HLSLType& type);
+    IRType* _getVecType(IRType* elementType, int count);
 
-    Dictionary<HLSLType, StringSlicePool::Handle> m_typeNameMap;
+    UnownedStringSlice _getTypeName(IRType* type);
+    StringSlicePool::Handle _calcTypeName(IRType* type);
+    
+    Dictionary<IRType*, StringSlicePool::Handle> m_typeNameMap;
     Dictionary<HLSLFunction, StringSlicePool::Handle> m_funcNameMap;
+
+    RefPtr<IRModule> m_uniqueModule;            ///< Store types/function sigs etc for output
+    SharedIRBuilder m_sharedIRBuilder;
+    IRBuilder m_irBuilder;
+
+    Dictionary<IRInst*, IRInst*> m_cloneMap;
+
+    IRCloneEnv m_cloneEnv;
 
     StringSlicePool m_slicePool;
 };

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -48,8 +48,55 @@ class CPPSourceEmitter;
         x(Swizzle, "", -1) \
         \
         x(Dot, "dot", -1) \
-        x(VecMatMul, "mul", -1) 
-
+        x(VecMatMul, "mul", -1) \
+        \
+        x(Normalize, "normalize", -1) \
+        x(Length, "length", -1) \
+        \
+        x(Sin, "sin", 1) \
+        x(Cos, "cos", 1) \
+        x(Tan, "tan", 1) \
+        \
+        x(ArcSin, "asin", 1) \
+        x(ArcCos, "acos", 1) \
+        x(ArcTan, "atan", 1) \
+        \
+        x(ArcTan2, "atan2", 2) \
+        x(SinCos, "sincos", 3) \
+        \
+        x(Rcp, "rcp", 1) \
+        x(Sign, "sign", 1) \
+        x(Saturate, "saturate", 1) \
+        x(Frac, "frac", 1) \
+        \
+        x(Ceil, "ceil", 1) \
+        x(Floor, "floor", 1) \
+        x(Trunc, "trunc", 1) \
+        \
+        x(Sqrt, "sqrt", 1) \
+        x(RecipSqrt, "rsqrt", 1) \
+        \
+        x(Exp2, "exp2", 1) \
+        x(Exp, "exp", 1) \
+        \
+        x(Abs, "abs", 1) \
+        \
+        x(Min, "min", 2) \
+        x(Max, "max", 2) \
+        x(Pow, "pow", 2) \
+        x(FMod, "fmod", 2) \
+        x(Cross, "cross", 2) \
+        x(Reflect, "reflect", 2) \
+        \
+        x(SmoothStep, "smoothstep", 3) \
+        x(Lerp, "lerp", 3) \
+        x(Clamp, "clamp", 3) \
+        x(Step, "step", 2) \
+        \
+        x(AsFloat, "asfloat", 1) \
+        x(AsInt, "asint", 1) \
+        x(AsUInt, "asuint", 1)
+        
 class CPPEmitHandler: public RefObject
 {
 public:
@@ -128,10 +175,13 @@ public:
 
 protected:
     void _emitVecMatMul(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
-    void _emitParameter(char charName, IRType* type, const Dimension& dim, CPPSourceEmitter* emitter);
     void _emitBinaryOp(const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
     void _emitUnaryOp(const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
     void _emitAnyAll(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
+    void _emitCross(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
+
+    void _emitSignature(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
+    
 
     static Dimension _getDimension(IRType* type, bool vecSwap);
     static void _emitAccess(const UnownedStringSlice& name, const Dimension& dimension, int row, int col, SourceWriter* writer);

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -22,6 +22,8 @@ class CPPSourceEmitter;
         x(Add) \
         x(Sub) \
         \
+        x(Dot) \
+        \
         x(VecMatMul)
 
 class CPPEmitHandler: public RefObject
@@ -83,6 +85,7 @@ public:
     CPPEmitHandler(const CLikeSourceEmitter::Desc& desc);
 
 protected:
+    void _emitVecMatMul(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
 
     IRType* _getVecType(IRType* elementType, int elementCount);
 

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -3,6 +3,9 @@
 #define SLANG_EMIT_CPP_H
 
 #include "slang-emit-c-like.h"
+#include "slang-ir-clone.h"
+
+#include "../core/slang-string-slice-pool.h"
 
 namespace Slang
 {
@@ -18,14 +21,10 @@ public:
         Init,                   //< Initialize with parameters (must match the type)
     };
 
-    CPPSourceEmitter(const Desc& desc) :
-        Super(desc)
-    {}
+    CPPSourceEmitter(const Desc& desc);
 
 protected:
 
-    void _emitCVecType(IROp op, Int size);
-    void _emitCMatType(IROp op, IRIntegerValue rowCount, IRIntegerValue colCount);
     void _emitCFunc(BuiltInCOp cop, IRType* type);
 
     virtual void emitParameterGroupImpl(IRGlobalParam* varDecl, IRUniformParameterGroupType* type) SLANG_OVERRIDE;
@@ -34,6 +33,20 @@ protected:
     virtual void emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount) SLANG_OVERRIDE;
 
     virtual bool tryEmitInstExprImpl(IRInst* inst, IREmitMode mode, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;
+
+    virtual void emitPreprocessorDirectivesImpl();
+
+    UnownedStringSlice _getTypeName(IRType* type);
+    StringSlicePool::Handle _calcTypeName(IRType* type);
+    IRType* _getVectorType(IRType* elemType, int count);
+    
+    Dictionary<IRType*, StringSlicePool::Handle> m_typeNameMap;
+
+    StringSlicePool m_slicePool;
+
+    //RefPtr<IRModule> m_module;
+    //SharedIRBuilder m_sharedBuilder;
+    //IRBuilder m_builder;
 };
 
 }

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -13,27 +13,44 @@ namespace Slang
 class CPPSourceEmitter;
 
 #define SLANG_CPP_OPERATION(x) \
-        x(Invalid, "") \
-        x(Init, "") \
-        x(Broadcast, "") \
+        x(Invalid, "", -1) \
+        x(Init, "", -1) \
         \
-        x(Mul, "*") \
-        x(Div, "/") \
-        x(Add, "+") \
-        x(Sub, "-") \
-        x(Lsh, "<<") \
-        x(Rsh, ">>") \
-        x(Mod, "%") \
+        x(Mul, "*", 2) \
+        x(Div, "/", 2) \
+        x(Add, "+", 2) \
+        x(Sub, "-", 2) \
+        x(Lsh, "<<", 2) \
+        x(Rsh, ">>", 2) \
+        x(Mod, "%", 2) \
         \
-        x(Swizzle, "") \
+        x(Eql, "==", 2) \
+        x(Neq, "!=", 2) \
+        x(Greater, ">", 2) \
+        x(Less, "<", 2) \
+        x(Geq, ">=", 2) \
+        x(Leq, "<=", 2) \
         \
-        x(Dot, "") \
-        x(VecMatMul, "")
+        x(BitAnd, "&", 2) \
+        x(BitXor, "^", 2) \
+        x(BitOr, "|" , 2) \
+        \
+        x(And, "&&", 2) \
+        x(Or, "||", 2) \
+        \
+        x(Neg, "-", 1) \
+        x(Not, "!", 1) \
+        x(BitNot, "~", 1) \
+        \
+        x(Swizzle, "", -1) \
+        \
+        x(Dot, "", -1) \
+        x(VecMatMul, "", -1)
 
 class CPPEmitHandler: public RefObject
 {
 public:
-#define SLANG_CPP_OPERATION_ENUM(x, op) x,
+#define SLANG_CPP_OPERATION_ENUM(x, op, numOperands) x,
 
     enum class Operation
     {
@@ -44,6 +61,7 @@ public:
     {
         UnownedStringSlice name;
         UnownedStringSlice funcName;
+        int8_t numOperands;                     ///< -1 if can't be handled automatically via amount of params
     };
 
     struct SpecializedOperation
@@ -109,6 +127,7 @@ protected:
     void _emitVecMatMul(const UnownedStringSlice& funcName, const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
     void _emitParameter(char charName, IRType* type, const Dimension& dim, CPPSourceEmitter* emitter);
     void _emitBinaryOp(const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
+    void _emitUnaryOp(const SpecializedOperation& specOp, CPPSourceEmitter* emitter);
 
     static Dimension _getDimension(IRType* type, bool vecSwap);
     static void _emitAccess(const UnownedStringSlice& name, const Dimension& dimension, int row, int col, SourceWriter* writer);

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -216,6 +216,7 @@ protected:
     Dictionary<IRInst*, IRInst*> m_cloneMap;
 
     Dictionary<IRType*, bool> m_typeEmittedMap;
+    Dictionary<SpecializedOperation, bool> m_operationEmittedMap;
 
     // Maps from a name to an operation
     List<Operation> m_operationMap;  

--- a/source/slang/slang-emit-source-writer.cpp
+++ b/source/slang/slang-emit-source-writer.cpp
@@ -156,6 +156,12 @@ void SourceWriter::emit(const NameLoc& nameAndLoc)
     emit(getText(nameAndLoc.name));
 }
 
+void SourceWriter::emit(const StringSliceLoc& nameAndLoc)
+{
+    advanceToSourceLocation(nameAndLoc.loc);
+    emit(nameAndLoc.name);
+}
+
 void SourceWriter::emitName(Name* name, const SourceLoc& locIn)
 {
     advanceToSourceLocation(locIn);
@@ -165,6 +171,11 @@ void SourceWriter::emitName(Name* name, const SourceLoc& locIn)
 void SourceWriter::emitName(const NameLoc& nameAndLoc)
 {
     emitName(nameAndLoc.name, nameAndLoc.loc);
+}
+
+void SourceWriter::emitName(const StringSliceLoc& nameAndLoc)
+{
+    emit(nameAndLoc);
 }
 
 void SourceWriter::emitName(Name* name)

--- a/source/slang/slang-emit-source-writer.h
+++ b/source/slang/slang-emit-source-writer.h
@@ -28,7 +28,8 @@ public:
     void emit(const String& text);
     void emit(const UnownedStringSlice& text);
     void emit(Name* name);
-    void emit(const NameLoc& nameAndLoc);    
+    void emit(const NameLoc& nameAndLoc);
+    void emit(const StringSliceLoc& nameAndLoc);
     void emit(IntegerLiteralValue value);
     void emit(UInt value);
     void emit(int value);
@@ -37,9 +38,11 @@ public:
     void emitChar(char c);
 
         /// Emit names (doing so can also advance to a new source location)
+    void emitName(const StringSliceLoc& nameAndLoc);
     void emitName(const NameLoc& nameAndLoc);
     void emitName(Name* name, const SourceLoc& loc);
     void emitName(Name* name);
+
 
         /// Indent the text
     void indent();

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -237,6 +237,9 @@ String emitEntryPoint(
         sink->diagnose(SourceLoc(), Diagnostics::unableToGenerateCodeForTarget, getCodeGenTargetName(target));
         return String();
     }
+
+    // Outside because we want to keep IR in scope whilst we are processing emits
+    LinkedIR linkedIR;
     {
         auto session = targetRequest->getSession();
 
@@ -248,7 +251,7 @@ String emitEntryPoint(
         // modules, and also select between the definitions of
         // any "profile-overloaded" symbols.
         //
-        auto linkedIR = linkIR(
+        linkedIR = linkIR(
             compileRequest,
             entryPoint,
             programLayout,

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -216,8 +216,7 @@ String emitEntryPoint(
     {
         case SourceStyle::CPP:
         {
-            RefPtr<CPPEmitHandler> handler(new CPPEmitHandler(desc));
-            sourceEmitter = new CPPSourceEmitter(desc, handler);
+            sourceEmitter = new CPPSourceEmitter(desc);
             break;
         }
         case SourceStyle::GLSL:

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -216,7 +216,8 @@ String emitEntryPoint(
     {
         case SourceStyle::CPP:
         {
-            sourceEmitter = new CPPSourceEmitter(desc);
+            RefPtr<CPPEmitHandler> handler(new CPPEmitHandler(desc));
+            sourceEmitter = new CPPSourceEmitter(desc, handler);
             break;
         }
         case SourceStyle::GLSL:

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -934,7 +934,23 @@ struct IRBuilder
 
     IRUndefined* emitUndefined(IRType* type);
 
-
+    IRInst* findOrEmitHoistableInst(
+        IRType*                 type,
+        IROp                    op,
+        UInt                    operandListCount,
+        UInt const*             listOperandCounts,
+        IRInst* const* const*   listOperands);
+    IRInst* findOrEmitHoistableInst(
+        IRType*         type,
+        IROp            op,
+        UInt            operandCount,
+        IRInst* const*  operands);
+    IRInst* findOrEmitHoistableInst(
+        IRType*         type,
+        IROp            op,
+        IRInst*         operand,
+        UInt            operandCount,
+        IRInst* const*  operands);
 
     IRModule* createModule();
 

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -1530,8 +1530,7 @@ namespace Slang
     }
 
  
-    IRInst* findOrEmitHoistableInst(
-        IRBuilder*              builder,
+    IRInst* IRBuilder::findOrEmitHoistableInst(
         IRType*                 type,
         IROp                    op,
         UInt                    operandListCount,
@@ -1544,7 +1543,7 @@ namespace Slang
             operandCount += listOperandCounts[ii];
         }
 
-        auto& memoryArena = builder->getModule()->memoryArena;
+        auto& memoryArena = getModule()->memoryArena;
         void* cursor = memoryArena.getCursor();
 
         // We are going to create a 'dummy' instruction on the memoryArena
@@ -1581,7 +1580,7 @@ namespace Slang
             IRInstKey key = { inst };
 
             // Ideally we would add if not found, else return if was found instead of testing & then adding.
-            IRInst** found = builder->sharedBuilder->globalValueNumberingMap.TryGetValueOrAdd(key, inst);
+            IRInst** found = sharedBuilder->globalValueNumberingMap.TryGetValueOrAdd(key, inst);
             SLANG_ASSERT(endCursor == memoryArena.getCursor());
             // If it's found, just return, and throw away the instruction
             if (found)
@@ -1600,7 +1599,7 @@ namespace Slang
                 inst->typeUse.init(inst, type);
             }
 
-            maybeSetSourceLoc(builder, inst);
+            maybeSetSourceLoc(this, inst);
 
             IRUse*const operands = inst->getOperands();
             for (UInt i = 0; i < operandCount; ++i)
@@ -1613,20 +1612,18 @@ namespace Slang
             }
         }
 
-        addHoistableInst(builder, inst);
+        addHoistableInst(this, inst);
 
         return inst;
     }
 
-    IRInst* findOrEmitHoistableInst(
-        IRBuilder*      builder,
+    IRInst* IRBuilder::findOrEmitHoistableInst(
         IRType*         type,
         IROp            op,
         UInt            operandCount,
         IRInst* const*  operands)
     {
         return findOrEmitHoistableInst(
-            builder,
             type,
             op,
             1,
@@ -1634,8 +1631,7 @@ namespace Slang
             &operands);
     }
 
-    IRInst* findOrEmitHoistableInst(
-        IRBuilder*      builder,
+    IRInst* IRBuilder::findOrEmitHoistableInst(
         IRType*         type,
         IROp            op,
         IRInst*         operand,
@@ -1646,7 +1642,6 @@ namespace Slang
         IRInst* const* lists[] = { &operand, operands };
 
         return findOrEmitHoistableInst(
-            builder,
             type,
             op,
             2,
@@ -1661,7 +1656,6 @@ namespace Slang
         IRInst* const*  operands)
     {
         return (IRType*) findOrEmitHoistableInst(
-            this,
             nullptr,
             op,
             operandCount,
@@ -1806,7 +1800,6 @@ namespace Slang
         IRType*         resultType)
     {
         return (IRFuncType*) findOrEmitHoistableInst(
-            this,
             nullptr,
             kIROp_FuncType,
             resultType,
@@ -1849,7 +1842,6 @@ namespace Slang
         IRType* const*  caseTypes)
     {
         return (IRType*) findOrEmitHoistableInst(
-            this,
             getTypeKind(),
             kIROp_TaggedUnionType,
             caseCount,
@@ -1882,7 +1874,6 @@ namespace Slang
         }
 
         return (IRType*) findOrEmitHoistableInst(
-            this,
             getTypeKind(),
             kIROp_BindExistentialsType,
             baseType,

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3844,7 +3844,7 @@ namespace Slang
         return true;
     }
 
-    static bool _isNominalOp(IROp op)
+    bool isNominalOp(IROp op)
     {
         // True if the op identity is 'nominal'
         switch (op)
@@ -3883,7 +3883,7 @@ namespace Slang
         }
 
         // If the type is nominal - it can only be the same if the pointer is the same.
-        if (_isNominalOp(opA))
+        if (isNominalOp(opA))
         {
             // The pointer isn't the same (as that was already tested), so cannot be equal
             return false;

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1197,6 +1197,10 @@ IRInst* createEmptyInstWithSize(
     IRModule*   module,
     IROp        op,
     size_t      totalSizeInBytes);
+
+    /// True if the op type can be handled 'nominally' meaning that pointer identity is applicable. 
+bool isNominalOp(IROp op);
+
 }
 
 #endif

--- a/source/slang/slang-mangled-lexer.h
+++ b/source/slang/slang-mangled-lexer.h
@@ -42,7 +42,7 @@ public:
     UInt readParamCount();
 
         /// Ctor
-    SLANG_FORCE_INLINE MangledLexer(String const& str);
+    SLANG_FORCE_INLINE MangledLexer(const UnownedStringSlice& slice);
 
 private:
 
@@ -71,10 +71,10 @@ private:
 };
 
 // -------------------------------------------------------------------------- -
-SLANG_FORCE_INLINE MangledLexer::MangledLexer(String const& str)
-    : m_cursor(str.begin())
-    , m_begin(str.begin())
-    , m_end(str.end())
+SLANG_FORCE_INLINE MangledLexer::MangledLexer(const UnownedStringSlice& slice)
+    : m_cursor(slice.begin())
+    , m_begin(slice.begin())
+    , m_end(slice.end())
 {
     _start();
 }

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -8,6 +8,8 @@
 #include "slang-type-system-shared.h"
 #include "../../slang.h"
 
+#include "slang-name.h"
+
 #include <assert.h>
 
 namespace Slang
@@ -120,20 +122,46 @@ namespace Slang
             : name(nullptr)
         {}
 
-        explicit NameLoc(Name* name)
-            : name(name)
+        explicit NameLoc(Name* inName)
+            : name(inName)
         {}
 
 
-        NameLoc(Name* name, SourceLoc loc)
-            : name(name)
-            , loc(loc)
+        NameLoc(Name* inName, SourceLoc inLoc)
+            : name(inName)
+            , loc(inLoc)
         {}
 
         NameLoc(Token const& token)
             : name(token.getNameOrNull())
             , loc(token.getLoc())
         {}
+    };
+
+    struct StringSliceLoc
+    {
+        UnownedStringSlice name;
+        SourceLoc loc;
+
+        StringSliceLoc()
+            : name(nullptr)
+        {}
+        explicit StringSliceLoc(const UnownedStringSlice& inName)
+            : name(inName)
+        {}
+        StringSliceLoc(const UnownedStringSlice& inName, SourceLoc inLoc)
+            : name(inName)
+            , loc(inLoc)
+        {}
+        StringSliceLoc(Token const& token)
+            : loc(token.getLoc())
+        {
+            Name* tokenName = token.getNameOrNull();
+            if (tokenName)
+            {
+                name = tokenName->text.getUnownedSlice();
+            }
+        }
     };
 
     // Helper class for iterating over a list of heap-allocated modifiers

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -64,7 +64,7 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     
     vector<bool, 3> z = vec2 > 0;
 
-    int val = int(tid) + z.x ? 1 : 0;
+    int val = int(tid) + any(z) ? 1 : 0;
     val = test(val);
 
     outputBuffer[tid] = val + int(dot(vec2, vec2));

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -60,7 +60,7 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 
     vector<float, 3> vec2 = mul(vec, mat);
 
-    vec2 += vec2.zyx;
+    vec2 += vec2.zyx * 2;
 
     int val = int(tid);
     val = test(val);

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -46,6 +46,16 @@ int test(int val)
     return (val << 4) + int(c);
 }
 
+float sum(float a[3])
+{
+    float total = a[0];
+    for (int i = 1; i < 3; ++i)
+    {
+        total += a[i];
+    }
+    return total;
+}
+
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
 RWStructuredBuffer<int> outputBuffer;
 
@@ -54,7 +64,9 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     uint tid = dispatchThreadID.x;
 
-    matrix<float, 2, 3> mat = { { 0, 1, 2 }, { 3, 4, 5} };
+    float array[3] = { 1, 2, 3};
+
+    matrix<float, 2, 3> mat = { { sum(array), 1, 2 }, { 3, 4, 5} };
     vector<float, 2> vec = { float(tid + 1), float(tid + 2) };
 
 

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -1,4 +1,4 @@
-//TEST(smoke):CPP_COMPILER_COMPILE: -profile cs_5_0 -entry computeMain -target cpp
+//TEST:CPP_COMPILER_COMPILE: -profile cs_5_0 -entry computeMain -target cpp
 
 enum Color
 {

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -70,6 +70,9 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     vector<bool, 3> z = vec2 > 0;
 
     int val = int(tid) + (any(z) ? 1 : 0) + (all(z) ? 2 : 0);
+    
+    val = asint(asfloat(asuint(asfloat(val))));
+    
     val = test(val);
 
     outputBuffer[tid] = val + int(dot(vec2, vec4));

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE: -profile cs_5_0 -entry computeMain -target cpp
+//TEST:CPP_COMPILER_COMPILE: -profile cs_5_0 -entry computeMain -target cpp
 
 enum Color
 {

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -59,7 +59,10 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 
 
     vector<float, 3> vec2 = max(sin(mul(vec, mat)), float3(1, 2, -1));
-
+    vector<float, 3> vec3 = mul(vec, mat);
+    
+    float3 vec4 = lerp(vec2, vec3, float3(tid * (1.0f / 4), 1, 1));
+    
     vec2 += (-vec2.zyx) * 2;
     
     vector<bool, 3> z = vec2 > 0;
@@ -67,5 +70,5 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     int val = int(tid) + any(z) ? 1 : 0;
     val = test(val);
 
-    outputBuffer[tid] = val + int(dot(vec2, vec2));
+    outputBuffer[tid] = val + int(dot(vec2, vec4));
 }

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -60,9 +60,11 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 
     vector<float, 3> vec2 = mul(vec, mat);
 
-    vec2 += vec2.zyx * 2;
+    vec2 += (-vec2.zyx) * 2;
+    
+    vector<bool, 3> z = vec2 > 0;
 
-    int val = int(tid);
+    int val = int(tid) + z.x ? 1 : 0;
     val = test(val);
 
     outputBuffer[tid] = val + int(dot(vec2, vec2));

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -58,7 +58,7 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     vector<float, 2> vec = { float(tid + 1), float(tid + 2) };
 
 
-    vector<float, 3> vec2 = mul(vec, mat);
+    vector<float, 3> vec2 = max(sin(mul(vec, mat)), float3(1, 2, -1));
 
     vec2 += (-vec2.zyx) * 2;
     

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -62,5 +62,5 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     int val = int(tid);
     val = test(val);
 
-    outputBuffer[tid] = val + int(vec2.x + vec2.y + vec2.z);
+    outputBuffer[tid] = val + int(dot(vec2, vec2));
 }

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -1,4 +1,4 @@
-//TEST:CPP_COMPILER_COMPILE: -profile cs_5_0 -entry computeMain -target cpp
+//TEST(smoke):CPP_COMPILER_COMPILE: -profile cs_5_0 -entry computeMain -target cpp
 
 enum Color
 {

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -56,6 +56,12 @@ float sum(float a[3])
     return total;
 }
 
+struct Thing
+{
+    int a;
+    float b;
+};
+
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
 RWStructuredBuffer<int> outputBuffer;
 
@@ -64,7 +70,13 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     uint tid = dispatchThreadID.x;
 
-    float array[3] = { 1, 2, 3};
+    Thing thing = { 10, -1.0 };
+
+    float array[3] = { thing.a, 2, 3};
+
+    float anotherArray[] = { 1, 2, 5 };
+
+    array[0] += anotherArray[1];
 
     matrix<float, 2, 3> mat = { { sum(array), 1, 2 }, { 3, 4, 5} };
     vector<float, 2> vec = { float(tid + 1), float(tid + 2) };

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -1,0 +1,66 @@
+//TEST:SIMPLE: -profile cs_5_0 -entry computeMain -target cpp
+
+enum Color
+{
+    Red,
+    Green = 2,
+    Blue,
+}
+
+int test(int val)
+{
+    Color c = Color.Red;
+
+    if(val > 1)
+    {
+        c = Color.Green;
+    }
+
+    if(c == Color.Red)
+    {
+        if(val & 1)
+        {
+            c = Color.Blue;
+        }
+    }
+
+    switch(c)
+    {
+    case Color.Red:
+        val = 1;
+        break;
+
+    case Color.Green:
+        val = 2;
+        break;
+
+    case Color.Blue:
+        val = 3;
+        break;
+
+    default:
+        val = -1;
+        break;
+    }
+
+    return (val << 4) + int(c);
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    uint tid = dispatchThreadID.x;
+
+    matrix<float, 2, 3> mat = { { 0, 1, 2 }, { 3, 4, 5} };
+    vector<float, 2> vec = { float(tid + 1), float(tid + 2) };
+
+    vector<float, 3> vec2 = mul(vec, mat);
+
+    int val = int(tid);
+    val = test(val);
+
+    outputBuffer[tid] = val + int(vec2.x + vec2.y + vec2.z);
+}

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -63,11 +63,13 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     
     float3 vec4 = lerp(vec2, vec3, float3(tid * (1.0f / 4), 1, 1));
     
-    vec2 += (-vec2.zyx) * 2;
+    float3 crossVec = normalize(cross(vec4, vec4));
+    
+    vec2 += (-vec2.zyx) * 2 + crossVec * length(crossVec) + reflect(vec4, normalize(crossVec));
     
     vector<bool, 3> z = vec2 > 0;
 
-    int val = int(tid) + any(z) ? 1 : 0;
+    int val = int(tid) + (any(z) ? 1 : 0) + (all(z) ? 2 : 0);
     val = test(val);
 
     outputBuffer[tid] = val + int(dot(vec2, vec4));

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -57,7 +57,10 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     matrix<float, 2, 3> mat = { { 0, 1, 2 }, { 3, 4, 5} };
     vector<float, 2> vec = { float(tid + 1), float(tid + 2) };
 
+
     vector<float, 3> vec2 = mul(vec, mat);
+
+    vec2 += vec2.zyx;
 
     int val = int(tid);
     val = test(val);

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -65,11 +65,15 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     
     float3 crossVec = normalize(cross(vec4, vec4));
     
+    vec2.x = fmod(crossVec.y, crossVec.x);
+    
+    vec2 = fmod(vec2, crossVec);
+    
     vec2 += (-vec2.zyx) * 2 + crossVec * length(crossVec) + reflect(vec4, normalize(crossVec));
     
     vector<bool, 3> z = vec2 > 0;
 
-    int val = int(tid) + (any(z) ? 1 : 0) + (all(z) ? 2 : 0);
+    int val = (int(tid) + (any(z) ? 1 : 0) + (all(z) ? 2 : 0)) % 100;
     
     val = asint(asfloat(asuint(asfloat(val))));
     

--- a/tests/cross-compile/slang-cpp-prelude.h
+++ b/tests/cross-compile/slang-cpp-prelude.h
@@ -3,6 +3,11 @@
 #include <math.h>
 #include <inttypes.h>
 #include <math.h>
+
+#ifndef M_PI
+#   define M_PI           3.14159265358979323846
+#endif
+
 template <typename T>
 struct RWStructuredBuffer
 {
@@ -12,6 +17,80 @@ struct RWStructuredBuffer
     size_t count;
 };
 
+// ----------------------------- F32 -----------------------------------------
 
+union Union32 
+{
+    uint32_t u;
+    int32_t i;
+    float f;
+};
 
+// Helpers
+float F32_calcSafeRadians(float radians)
+{
+	float a = radians * (1.0f /  M_PI);
+	a = (a < 0.0f) ? (::ceilf(a) - a) : (a - ::floorf(a));
+	return (a * M_PI);
+}
 
+// Unary 
+float F32_ceil(float f) { return ::ceilf(f); }
+float F32_floor(float f) { return ::floorf(f); }
+float F32_sin(float f) { return ::sinf(F32_calcSafeRadians(f)); }
+float F32_cos(float f) { return ::cosf(F32_calcSafeRadians(f)); }
+float F32_tan(float f) { return ::tanf(f); }
+float F32_asin(float f) { return ::asinf(f); }
+float F32_acos(float f) { return ::acosf(f); }
+float F32_atan(float f) { return ::atanf(f); }
+float F32_log2(float f) { return ::log2f(f); }
+float F32_exp2(float f) { return ::exp2f(f); }
+float F32_exp(float f) { return ::expf(f); }
+float F32_abs(float f) { return ::fabsf(f); }
+float F32_trunc(float f) { return ::truncf(f); }
+float F32_sqrt(float f) { return ::sqrtf(f); }
+float F32_rsqrt(float f) { return 1.0f / F32_sqrt(f); }
+float F32_rcp(float f) { return 1.0f / f; }
+float F32_sign(float f) { return ( f == 0.0f) ? f : (( f < 0.0f) ? -1.0f : 1.0f); } 
+float F32_saturate(float f) { return (f < 0.0f) ? 0.0f : (f > 1.0f) ? 1.0f : f; }
+float F32_frac(float f) { return f - F32_floor(f); }
+float F32_radians(float f) { return f * 0.01745329222f; }
+
+// Binary
+float F32_min(float a, float b) { return a < b ? a : b; }
+float F32_max(float a, float b) { return a > b ? a : b; }
+float F32_pow(float a, float b) { return ::powf(a, b); }
+float F32_fmod(float a, float b) { return ::fmodf(a, b); }
+float F32_step(float a, float b) { return float(a >= b); }
+float F32_atan2(float a, float b) { return float(atan2(a, b)); }
+
+// Ternary 
+float F32_smoothstep(float min, float max, float x) { return x < min ? min : ((x > max) ? max : x / (max - min)); }
+float F32_lerp(float x, float y, float s) { return x + s * (y - x); }
+float F32_clamp(float x, float min, float max) { return ( x < min) ? min : ((x > max) ? max : x); }
+void F32_sincos(float f, float& outSin, float& outCos) { outSin = F32_sin(f); outCos = F32_cos(f); }
+
+uint32_t F32_asuint(float f) { Union32 u; u.f = f; return u.u; }
+int32_t F32_asint(float f) { Union32 u; u.f = f; return u.i; }
+
+// ----------------------------- I32 -----------------------------------------
+
+int32_t I32_abs(int32_t f) { return (f < 0) ? -f : f; }
+
+int32_t I32_min(int32_t a, int32_t b) { return a < b ? a : b; }
+int32_t I32_max(int32_t a, int32_t b) { return a > b ? a : b; }
+
+int32_t I32_clamp(int32_t x, int32_t min, int32_t max) { return ( x < min) ? min : ((x > max) ? max : x); }
+
+float I32_asfloat(int32_t x) { Union32 u; u.i = x; return u.f; }
+
+// ----------------------------- U32 -----------------------------------------
+
+uint32_t U32_abs(uint32_t f) { return (f < 0) ? -f : f; }
+
+uint32_t U32_min(uint32_t a, uint32_t b) { return a < b ? a : b; }
+uint32_t U32_max(uint32_t a, uint32_t b) { return a > b ? a : b; }
+
+uint32_t U32_clamp(uint32_t x, uint32_t min, uint32_t max) { return ( x < min) ? min : ((x > max) ? max : x); }
+
+float U32_asfloat(uint32_t x) { Union32 u; u.u = x; return u.f; }

--- a/tests/cross-compile/slang-cpp-prelude.h
+++ b/tests/cross-compile/slang-cpp-prelude.h
@@ -10,7 +10,7 @@
 #endif
 
 template <typename T, size_t SIZE>
-struct Array
+struct FixedArray
 {
     const T& operator[](size_t index) const { assert(index < SIZE); return m_data[index]; }
     T& operator[](size_t index) { assert(index < SIZE); return m_data[index]; }

--- a/tests/cross-compile/slang-cpp-prelude.h
+++ b/tests/cross-compile/slang-cpp-prelude.h
@@ -4,6 +4,7 @@
 #include <inttypes.h>
 #include <math.h>
 #include <assert.h>
+#include <stdlib.h>
 
 #ifndef M_PI
 #   define M_PI           3.14159265358979323846
@@ -11,8 +12,9 @@
 
 #if defined(_MSC_VER)
 #   define SLANG_SHARED_LIB_EXPORT __declspec(dllexport)
-#else 
-#   define SLANG_SHARED_LIB_EXPORT __attribute__ ((dllexport)) __attribute__((__visibility__("default")))
+#else
+#   define SLANG_SHARED_LIB_EXPORT __attribute__((__visibility__("default")))
+//#   define SLANG_SHARED_LIB_EXPORT __attribute__ ((dllexport)) __attribute__((__visibility__("default")))
 #endif    
 
 #ifdef __cplusplus    
@@ -110,7 +112,7 @@ float I32_asfloat(int32_t x) { Union32 u; u.i = x; return u.f; }
 
 // ----------------------------- U32 -----------------------------------------
 
-uint32_t U32_abs(uint32_t f) { return (f < 0) ? -f : f; }
+uint32_t U32_abs(uint32_t f) { return f; }
 
 uint32_t U32_min(uint32_t a, uint32_t b) { return a < b ? a : b; }
 uint32_t U32_max(uint32_t a, uint32_t b) { return a > b ? a : b; }

--- a/tests/cross-compile/slang-cpp-prelude.h
+++ b/tests/cross-compile/slang-cpp-prelude.h
@@ -9,6 +9,20 @@
 #   define M_PI           3.14159265358979323846
 #endif
 
+#if defined(_MSC_VER)
+#   define SLANG_SHARED_LIB_EXPORT __declspec(dllexport)
+#else 
+#   define SLANG_SHARED_LIB_EXPORT __attribute__ ((dllexport)) __attribute__((__visibility__("default")))
+#endif    
+
+#ifdef __cplusplus    
+#   define SLANG_EXTERN_C extern "C"
+#else
+#   define SLANG_EXTERN_C 
+#endif    
+
+#define SLANG_EXPORT SLANG_EXTERN_C SLANG_SHARED_LIB_EXPORT
+
 template <typename T, size_t SIZE>
 struct FixedArray
 {

--- a/tests/cross-compile/slang-cpp-prelude.h
+++ b/tests/cross-compile/slang-cpp-prelude.h
@@ -1,0 +1,17 @@
+
+#include <inttypes.h>
+#include <math.h>
+#include <inttypes.h>
+#include <math.h>
+template <typename T>
+struct RWStructuredBuffer
+{
+    T& operator[](size_t index) const { return data[index]; }
+    
+    T* data;
+    size_t count;
+};
+
+
+
+

--- a/tests/cross-compile/slang-cpp-prelude.h
+++ b/tests/cross-compile/slang-cpp-prelude.h
@@ -3,10 +3,20 @@
 #include <math.h>
 #include <inttypes.h>
 #include <math.h>
+#include <assert.h>
 
 #ifndef M_PI
 #   define M_PI           3.14159265358979323846
 #endif
+
+template <typename T, size_t SIZE>
+struct Array
+{
+    const T& operator[](size_t index) const { assert(index < SIZE); return m_data[index]; }
+    T& operator[](size_t index) const { assert(index < SIZE); return m_data[index]; }
+    
+    T m_data[SIZE];
+};
 
 template <typename T>
 struct RWStructuredBuffer

--- a/tests/cross-compile/slang-cpp-prelude.h
+++ b/tests/cross-compile/slang-cpp-prelude.h
@@ -13,7 +13,7 @@ template <typename T, size_t SIZE>
 struct Array
 {
     const T& operator[](size_t index) const { assert(index < SIZE); return m_data[index]; }
-    T& operator[](size_t index) const { assert(index < SIZE); return m_data[index]; }
+    T& operator[](size_t index) { assert(index < SIZE); return m_data[index]; }
     
     T m_data[SIZE];
 };

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1167,9 +1167,15 @@ static TestResult runCPPCompilerCompile(TestContext* context, TestInput& input)
     // Compile this source
     options.sourceFiles.add(cppSource);
     options.modulePath = modulePath;
+    options.targetType = CPPCompiler::TargetType::SharedLibrary;
 
     CPPCompiler::Output output;
     if (SLANG_FAILED(compiler->compile(options, output)))
+    {
+        return TestResult::Fail;
+    }
+
+    if (output.getCountByType(CPPCompiler::OutputMessage::Type::Error) > 0)
     {
         return TestResult::Fail;
     }


### PR DESCRIPTION
* Preliminary support for outputting slang code as C++
* Handles most HLSL intrinsics
* Generates HLSL intrinsic functions on demand as needed
* Uses a 'c like' way to define vector and matrix types
* Uses a prelude file that defines scalar intrinsics 

One of the main things missing here is a ABI for communicating between the C++ code produced and client code. The code does test compiling slang code and C++, and that compilation doesn't produce any errors but does not execute that code. 

The generating of many of the intrinsics is fairly simple - but there are a few edge cases which are verbose and clumsy - such as with normalize, length, cross etc. That ideally we would define an implementation for these in the stdlib, and depending on the target it would choose a 'built in intrinsic' or use the implementation. Before this PR some work was put into trying to make this work, but it looks like will take some work to make things work this way - so for now the implementation uses the clunky code generation. 

There is also a question about the use of the C style structs, when templates could be used. That when the code was originally conceived it was thought doing this way would make outputting C easily. Outputting to C could have certain advantages - including typically more rapid compilation, which may be important for a more JIT like use case. For the moment there are a few sections in the code that assume C++ for the output - once we have the stdlib/intrinsic change described above, much of that will disappear, so so outputting C will require minimal changes - although such support is not an initial goal. 
  
