### PR TITLE
C/C++ integration into Slang 

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -514,6 +514,8 @@ extern "C"
         SLANG_DXIL_ASM,
         SLANG_C_SOURCE,             ///< The C language
         SLANG_CPP_SOURCE,           ///< The C++ language
+        SLANG_EXECUTABLE,           ///< Executable (for hosting CPU/OS)
+        SLANG_SHARED_LIBRARY,       ///< A shared library/Dll (for hosting CPU/OS)
     };
 
     /* A "container format" describes the way that the outputs
@@ -537,6 +539,10 @@ extern "C"
         SLANG_PASS_THROUGH_FXC,
         SLANG_PASS_THROUGH_DXC,
         SLANG_PASS_THROUGH_GLSLANG,
+        SLANG_PASS_THROUGH_CLANG,                   ///< Clang C/C++ compiler 
+        SLANG_PASS_THROUGH_VISUAL_STUDIO,           ///< Visual studio C/C++ compiler
+        SLANG_PASS_THROUGH_GCC,                     ///< GCC C/C++ compiler
+        SLANG_PASS_THROUGH_GENERIC_C_CPP,           ///< Generic C or C++ compiler, which is decided by the source type
     };
 
     /*!
@@ -601,6 +607,8 @@ extern "C"
         SLANG_SOURCE_LANGUAGE_SLANG,
         SLANG_SOURCE_LANGUAGE_HLSL,
         SLANG_SOURCE_LANGUAGE_GLSL,
+        SLANG_SOURCE_LANGUAGE_C,
+        SLANG_SOURCE_LANGUAGE_CPP,
     };
 
     typedef unsigned int SlangProfileID;

--- a/slang.h
+++ b/slang.h
@@ -543,6 +543,7 @@ extern "C"
         SLANG_PASS_THROUGH_VISUAL_STUDIO,           ///< Visual studio C/C++ compiler
         SLANG_PASS_THROUGH_GCC,                     ///< GCC C/C++ compiler
         SLANG_PASS_THROUGH_GENERIC_C_CPP,           ///< Generic C or C++ compiler, which is decided by the source type
+        SLANG_PASS_THROUGH_COUNT_OF,
     };
 
     /*!

--- a/slang.h
+++ b/slang.h
@@ -868,7 +868,7 @@ extern "C"
 
     typedef void(*SlangFuncPtr)(void);
 
-    /** An interface that can be used to encapsulate access to a shared library. An implementaion 
+    /** An interface that can be used to encapsulate access to a shared library. An implementation 
     does not have to implement the library as a shared library. 
     */
     struct ISlangSharedLibrary: public ISlangUnknown

--- a/source/core/core.vcxproj
+++ b/source/core/core.vcxproj
@@ -182,6 +182,7 @@
     <ClInclude Include="slang-free-list.h" />
     <ClInclude Include="slang-gcc-compiler-util.h" />
     <ClInclude Include="slang-hash.h" />
+    <ClInclude Include="slang-hex-dump-util.h" />
     <ClInclude Include="slang-io.h" />
     <ClInclude Include="slang-list.h" />
     <ClInclude Include="slang-math.h" />
@@ -213,6 +214,7 @@
     <ClCompile Include="slang-cpp-compiler.cpp" />
     <ClCompile Include="slang-free-list.cpp" />
     <ClCompile Include="slang-gcc-compiler-util.cpp" />
+    <ClCompile Include="slang-hex-dump-util.cpp" />
     <ClCompile Include="slang-io.cpp" />
     <ClCompile Include="slang-memory-arena.cpp" />
     <ClCompile Include="slang-object-scope-manager.cpp" />

--- a/source/core/core.vcxproj.filters
+++ b/source/core/core.vcxproj.filters
@@ -45,6 +45,9 @@
     <ClInclude Include="slang-hash.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="slang-hex-dump-util.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="slang-io.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -132,6 +135,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="slang-gcc-compiler-util.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="slang-hex-dump-util.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="slang-io.cpp">

--- a/source/core/slang-cpp-compiler.cpp
+++ b/source/core/slang-cpp-compiler.cpp
@@ -167,6 +167,11 @@ SlangResult GenericCPPCompiler::compile(const CompileOptions& options, Output& o
     return m_parseOutputFunc(exeRes, outOutput);
 }
 
+SlangResult GenericCPPCompiler::calcModuleFilePath(const CompileOptions& options, StringBuilder& outPath)
+{
+    return m_calcModuleFilePathFunc(options, outPath);
+}
+
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! CPPCompilerUtil !!!!!!!!!!!!!!!!!!!!!!*/
 
 static CPPCompiler::Desc _calcCompiledWithDesc()
@@ -308,7 +313,7 @@ static void _addGCCFamilyCompiler(const String& exeName, CPPCompilerSet* compile
     CPPCompiler::Desc desc;
     if (SLANG_SUCCEEDED(GCCCompilerUtil::calcVersion(exeName, desc)))
     {
-        RefPtr<CPPCompiler> compiler(new GenericCPPCompiler(desc, exeName, &GCCCompilerUtil::calcArgs, &GCCCompilerUtil::parseOutput));
+        RefPtr<CPPCompiler> compiler(new GenericCPPCompiler(desc, exeName, &GCCCompilerUtil::calcArgs, &GCCCompilerUtil::parseOutput, GCCCompilerUtil::calcModuleFilePath));
         compilerSet->addCompiler(compiler);
     }
 }

--- a/source/core/slang-cpp-compiler.cpp
+++ b/source/core/slang-cpp-compiler.cpp
@@ -377,6 +377,19 @@ void CPPCompilerSet::getCompilers(List<CPPCompiler*>& outCompilers) const
     outCompilers.addRange((CPPCompiler*const*)m_compilers.begin(), m_compilers.getCount());
 }
 
+bool CPPCompilerSet::hasCompiler(CPPCompiler::CompilerType compilerType) const
+{
+    for (CPPCompiler* compiler : m_compilers)
+    {
+        const auto& desc = compiler->getDesc();
+        if (desc.type == compilerType)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 void CPPCompilerSet::addCompiler(CPPCompiler* compiler)
 {
     const Index index = _findIndex(compiler->getDesc());

--- a/source/core/slang-cpp-compiler.h
+++ b/source/core/slang-cpp-compiler.h
@@ -56,13 +56,20 @@ public:
         Maximal,        ///< Include optimizations that may take a very long time, or may involve severe space-vs-speed tradeoffs 
     };
 
-    enum DebugInfoType
+    enum class DebugInfoType
     {
         None,       ///< Don't emit debug information at all. 
         Minimal,    ///< Emit as little debug information as possible, while still supporting stack traces. 
         Standard,   ///< Emit whatever is the standard level of debug information for each target. 
         Maximal,    ///< Emit as much debug information as possible for each target. 
     };
+    enum class FloatingPointMode
+    {
+        Default, 
+        Fast,
+        Precise,
+    };
+
     enum TargetType
     {
         Executable,         ///< Produce an executable
@@ -91,6 +98,7 @@ public:
         DebugInfoType debugInfoType = DebugInfoType::Standard;
         TargetType targetType = TargetType::Executable;
         SourceType sourceType = SourceType::CPP;
+        FloatingPointMode floatingPointMode = FloatingPointMode::Default;
 
         Flags flags = Flag::EnableExceptionHandling;
 

--- a/source/core/slang-cpp-compiler.h
+++ b/source/core/slang-cpp-compiler.h
@@ -225,6 +225,9 @@ public:
         /// Set the default compiler
     void setDefaultCompiler(CPPCompiler* compiler) { m_defaultCompiler = compiler;  }
 
+        /// True if has a compiler of the specified type
+    bool hasCompiler(CPPCompiler::CompilerType compilerType) const;
+
 protected:
 
     Index _findIndex(const CPPCompiler::Desc& desc) const;

--- a/source/core/slang-cpp-compiler.h
+++ b/source/core/slang-cpp-compiler.h
@@ -163,6 +163,8 @@ public:
     const Desc& getDesc() const { return m_desc;  }
         /// Compile using the specified options. The result is in resOut
     virtual SlangResult compile(const CompileOptions& options, Output& outOutput) = 0;
+        /// Given the compilation options and the module name, determines the actual file name used for output
+    virtual SlangResult calcModuleFilePath(const CompileOptions& options, StringBuilder& outPath) = 0;
 
 protected:
 
@@ -180,26 +182,31 @@ public:
 
     typedef void(*CalcArgsFunc)(const CPPCompiler::CompileOptions& options, CommandLine& cmdLine);
     typedef SlangResult(*ParseOutputFunc)(const ExecuteResult& exeResult, Output& output);
+    typedef SlangResult(*CalcModuleFilePathFunc)(const CPPCompiler::CompileOptions& options, StringBuilder& outPath);
 
     virtual SlangResult compile(const CompileOptions& options, Output& outOutput) SLANG_OVERRIDE;
+    virtual SlangResult calcModuleFilePath(const CompileOptions& options, StringBuilder& outPath) SLANG_OVERRIDE;
 
-    GenericCPPCompiler(const Desc& desc, const String& exeName, CalcArgsFunc calcArgsFunc, ParseOutputFunc parseOutputFunc) :
+    GenericCPPCompiler(const Desc& desc, const String& exeName, CalcArgsFunc calcArgsFunc, ParseOutputFunc parseOutputFunc, CalcModuleFilePathFunc calcModuleFilePathFunc) :
         Super(desc),
         m_calcArgsFunc(calcArgsFunc),
-        m_parseOutputFunc(parseOutputFunc)
+        m_parseOutputFunc(parseOutputFunc),
+        m_calcModuleFilePathFunc(calcModuleFilePathFunc)
     {
         m_cmdLine.setExecutableFilename(exeName);
     }
 
-    GenericCPPCompiler(const Desc& desc, const CommandLine& cmdLine, CalcArgsFunc calcArgsFunc, ParseOutputFunc parseOutputFunc) :
+    GenericCPPCompiler(const Desc& desc, const CommandLine& cmdLine, CalcArgsFunc calcArgsFunc, ParseOutputFunc parseOutputFunc, CalcModuleFilePathFunc calcModuleFilePathFunc) :
         Super(desc),
         m_cmdLine(cmdLine),
         m_calcArgsFunc(calcArgsFunc),
-        m_parseOutputFunc(parseOutputFunc)
+        m_parseOutputFunc(parseOutputFunc),
+        m_calcModuleFilePathFunc(calcModuleFilePathFunc)
     {}
 
     CalcArgsFunc m_calcArgsFunc;
     ParseOutputFunc m_parseOutputFunc;
+    CalcModuleFilePathFunc m_calcModuleFilePathFunc;
     CommandLine m_cmdLine;
 };
 

--- a/source/core/slang-cpp-compiler.h
+++ b/source/core/slang-cpp-compiler.h
@@ -50,15 +50,18 @@ public:
 
     enum class OptimizationLevel
     {
-        Normal,             ///< Normal optimization
-        Debug,              ///< General has no optimizations
+        None,           ///< Don't optimize at all. 
+        Default,        ///< Default optimization level: balance code quality and compilation time. 
+        High,           ///< Optimize aggressively. 
+        Maximal,        ///< Include optimizations that may take a very long time, or may involve severe space-vs-speed tradeoffs 
     };
 
     enum DebugInfoType
     {
-        None,               ///< Binary has no debug information
-        Maximum,            ///< Has maximum debug information
-        Normal,             ///< Has normal debug information
+        None,       ///< Don't emit debug information at all. 
+        Minimal,    ///< Emit as little debug information as possible, while still supporting stack traces. 
+        Standard,   ///< Emit whatever is the standard level of debug information for each target. 
+        Maximal,    ///< Emit as much debug information as possible for each target. 
     };
     enum TargetType
     {
@@ -84,8 +87,8 @@ public:
             };
         };
 
-        OptimizationLevel optimizationLevel = OptimizationLevel::Debug;
-        DebugInfoType debugInfoType = DebugInfoType::Normal;
+        OptimizationLevel optimizationLevel = OptimizationLevel::Default;
+        DebugInfoType debugInfoType = DebugInfoType::Standard;
         TargetType targetType = TargetType::Executable;
         SourceType sourceType = SourceType::CPP;
 

--- a/source/core/slang-gcc-compiler-util.cpp
+++ b/source/core/slang-gcc-compiler-util.cpp
@@ -377,15 +377,25 @@ static SlangResult _parseGCCFamilyLine(const UnownedStringSlice& line, LineParse
 
     switch (options.optimizationLevel)
     {
-        case OptimizationLevel::Debug:
+        case OptimizationLevel::None:
         {
             // No optimization
             cmdLine.addArg("-O0");
             break;
         }
-        case OptimizationLevel::Normal:
+        case OptimizationLevel::Default:
         {
             cmdLine.addArg("-Os");
+            break;
+        }
+        case OptimizationLevel::High:
+        {
+            cmdLine.addArg("-O2");
+            break;
+        }
+        case OptimizationLevel::Maximal:
+        {
+            cmdLine.addArg("-O4");
             break;
         }
         default: break;
@@ -395,7 +405,6 @@ static SlangResult _parseGCCFamilyLine(const UnownedStringSlice& line, LineParse
     {
         cmdLine.addArg("-g");
     }
-
 
     StringBuilder moduleFilePath;
     calcModuleFilePath(options, moduleFilePath);

--- a/source/core/slang-gcc-compiler-util.cpp
+++ b/source/core/slang-gcc-compiler-util.cpp
@@ -406,6 +406,23 @@ static SlangResult _parseGCCFamilyLine(const UnownedStringSlice& line, LineParse
         cmdLine.addArg("-g");
     }
 
+    switch (options.floatingPointMode)
+    {
+        case FloatingPointMode::Default: break;
+        case FloatingPointMode::Precise:
+        {
+            //cmdLine.addArg("-fno-unsafe-math-optimizations");
+            break;
+        }
+        case FloatingPointMode::Fast:
+        {
+            // We could enable SSE with -mfpmath=sse
+            // But that would only make sense on a x64/x86 type processor and only if that feature is present (it is on all x64)
+            cmdLine.addArg("-ffast-math");
+            break;
+        }
+    }
+
     StringBuilder moduleFilePath;
     calcModuleFilePath(options, moduleFilePath);
 

--- a/source/core/slang-gcc-compiler-util.h
+++ b/source/core/slang-gcc-compiler-util.h
@@ -26,6 +26,10 @@ struct GCCCompilerUtil
 
         /// Parse ExecuteResult into Output
     static SlangResult parseOutput(const ExecuteResult& exeRes, CPPCompiler::Output& outOutput);
+
+        /// Calculate the output module filename 
+    static SlangResult calcModuleFilePath(const CompileOptions& options, StringBuilder& outPath);
+
 };
 
 }

--- a/source/core/slang-gcc-compiler-util.h
+++ b/source/core/slang-gcc-compiler-util.h
@@ -14,6 +14,7 @@ struct GCCCompilerUtil
     typedef CPPCompiler::TargetType TargetType;
     typedef CPPCompiler::DebugInfoType DebugInfoType;
     typedef CPPCompiler::SourceType SourceType;
+    typedef CPPCompiler::FloatingPointMode FloatingPointMode;
 
         /// Extracts version number into desc from text (assumes gcc/clang -v layout with a line with version)
     static SlangResult parseVersion(const UnownedStringSlice& text, const UnownedStringSlice& prefix, CPPCompiler::Desc& outDesc);

--- a/source/core/slang-hex-dump-util.cpp
+++ b/source/core/slang-hex-dump-util.cpp
@@ -2,9 +2,29 @@
 #include "slang-hex-dump-util.h"
 
 #include "slang-common.h"
+#include "slang-string-util.h"
+#include "slang-writer.h"
+
+#include "../../slang-com-helper.h"
 
 namespace Slang
 {
+
+static const UnownedStringSlice s_start = UnownedStringSlice::fromLiteral("--START--");
+static const UnownedStringSlice s_end = UnownedStringSlice::fromLiteral("--END--");
+
+/* static */SlangResult HexDumpUtil::dumpWithMarkers(const List<uint8_t>& data, int maxBytesPerLine, ISlangWriter* writer)
+{
+    WriterHelper helper(writer);
+    SLANG_RETURN_ON_FAIL(helper.write(s_start.begin(), s_start.size()));
+    SLANG_RETURN_ON_FAIL(helper.print(" (%zu)\n", size_t(data.getCount())));
+
+    SLANG_RETURN_ON_FAIL(dump(data, maxBytesPerLine, writer));
+
+    SLANG_RETURN_ON_FAIL(helper.write(s_end.begin(), s_end.size()));
+    SLANG_RETURN_ON_FAIL(helper.put("\n"));
+    return SLANG_OK;
+}
 
 /* static */SlangResult HexDumpUtil::dump(const List<uint8_t>& data, int maxBytesPerLine, ISlangWriter* writer)
 {
@@ -52,12 +72,112 @@ namespace Slang
         *dst++ = '\n';
         SLANG_ASSERT(dst <= startDst + maxCharsPerLine);
 
-        writer->endAppendBuffer(startDst, size_t(dst - startDst));
+        SLANG_RETURN_ON_FAIL(writer->endAppendBuffer(startDst, size_t(dst - startDst)));
 
         cur += count;
     }
+
+    return SLANG_OK;
 }
 
+static int _parseHexDigit(char c)
+{
+    if (c >= '0' && c <= '9')
+    {
+        return c -'0';
+    }
+    else if (c >= 'a' && c <= 'f')
+    {
+        return c - 'a' + 10;
+    }
+    else if (c >= 'A' && c <= 'F')
+    {
+        return c - 'A' + 10;
+    }
+    return -1;
+}
 
+/* static */SlangResult HexDumpUtil::parse(const UnownedStringSlice& lines, List<uint8_t>& outBytes)
+{
+    outBytes.clear();
+
+    bool inHex = false;
+
+    LineParser lineParser(lines);
+    for (const auto& line : lineParser)
+    {
+        if (!inHex)
+        {
+            if (line.startsWith(s_start))
+            {
+                inHex = true;
+                continue;
+            }
+        }
+        else
+        {
+            if (line.startsWith(s_end))
+            {
+                break;
+            }
+        }
+
+        const char* cur = line.begin();
+        const char* end = line.end();
+
+        while(cur + 2 <= end)
+        {
+            const char c = cur[0];
+            if (c == ' ' || c== '\n' || c == '\r' || c == '\t')
+            {
+                // Skip to next line
+                break;
+            }
+
+            const int hi = _parseHexDigit(c);
+            const int lo = _parseHexDigit(cur[1]);
+            cur += 2;
+
+            if (hi < 0 || lo < 0)
+            {
+                return SLANG_FAIL;
+            }
+            outBytes.add(uint8_t((hi << 4) | lo));
+        }
+    }
+
+    return SLANG_OK;
+}
+
+/* static */SlangResult HexDumpUtil::parseWithMarkers(const UnownedStringSlice& lines, List<uint8_t>& outBytes)
+{
+    UnownedStringSlice remaining(lines), line;
+
+    while(StringUtil::extractLine(remaining, line))
+    {
+        if (line.startsWith(s_start))
+        {
+            // Extract next line
+            if (!StringUtil::extractLine(remaining, line))
+            {
+                return SLANG_FAIL;
+            }
+            // It's the start line
+            UnownedStringSlice startLine = line;
+
+            // Look for the ending line
+            do 
+            {
+                if (line.startsWith(s_end))
+                {
+                    return parse(UnownedStringSlice(startLine.begin(), line.begin()), outBytes);
+                }
+            }
+            while ( StringUtil::extractLine(remaining, line));
+        }
+    }
+
+    return SLANG_FAIL;
+}
 
 }

--- a/source/core/slang-hex-dump-util.cpp
+++ b/source/core/slang-hex-dump-util.cpp
@@ -1,0 +1,63 @@
+// slang-hex-dump-util.cpp
+#include "slang-hex-dump-util.h"
+
+#include "slang-common.h"
+
+namespace Slang
+{
+
+/* static */SlangResult HexDumpUtil::dump(const List<uint8_t>& data, int maxBytesPerLine, ISlangWriter* writer)
+{
+    int maxCharsPerLine = 2 * maxBytesPerLine + 1 + maxBytesPerLine + 1;
+
+    const uint8_t* cur = data.begin();
+    const uint8_t* end = data.end();
+
+    static char s_hex[] = "0123456789abcdef";
+
+    while (cur < end)
+    {
+        size_t count = size_t(end - cur);
+        count = (count > maxBytesPerLine) ? maxBytesPerLine : count;
+
+        char* startDst = writer->beginAppendBuffer(maxCharsPerLine);
+        char* dst = startDst;
+
+        for (size_t i = 0; i < count; ++i)
+        {
+            uint8_t byte = cur[i];
+            *dst++ = s_hex[byte >> 4];
+            *dst++ = s_hex[byte & 0xf];
+        }
+
+        *dst++ = ' ';
+
+        for (size_t i = 0; i < count; ++i)
+        {
+            char c = char(cur[i]);
+
+            if ((c >= '0' && c <= '9') ||
+                (c >= 'a' && c <= 'z') ||
+                (c >= 'A' && c <= 'Z') ||
+                (c >= 32 && (c & 0x80) == 0))
+            {
+            }
+            else
+            {
+                c = '.';
+            }
+            *dst++ = c;
+        }
+
+        *dst++ = '\n';
+        SLANG_ASSERT(dst <= startDst + maxCharsPerLine);
+
+        writer->endAppendBuffer(startDst, size_t(dst - startDst));
+
+        cur += count;
+    }
+}
+
+
+
+}

--- a/source/core/slang-hex-dump-util.h
+++ b/source/core/slang-hex-dump-util.h
@@ -1,0 +1,21 @@
+#ifndef SLANG_HEX_DUMP_UTIL_H
+#define SLANG_HEX_DUMP_UTIL_H
+
+#include "slang-common.h"
+#include "slang-string.h"
+
+#include "slang-list.h"
+#include "../../slang.h"
+
+namespace Slang
+{
+
+struct HexDumpUtil
+{
+    static SlangResult dump(const List<uint8_t>& data, int numBytesPerLine, ISlangWriter* writer);
+
+};
+
+}
+
+#endif

--- a/source/core/slang-hex-dump-util.h
+++ b/source/core/slang-hex-dump-util.h
@@ -12,8 +12,15 @@ namespace Slang
 
 struct HexDumpUtil
 {
+        /// Dump data to writer, with lines starting with hex data
     static SlangResult dump(const List<uint8_t>& data, int numBytesPerLine, ISlangWriter* writer);
 
+    static SlangResult dumpWithMarkers(const List<uint8_t>& data, int numBytesPerLine, ISlangWriter* writer);
+
+        /// Parses lines formatted by dump, back into bytes
+    static SlangResult parse(const UnownedStringSlice& lines, List<uint8_t>& outBytes);
+
+    static SlangResult parseWithMarkers(const UnownedStringSlice& lines, List<uint8_t>& outBytes);
 };
 
 }

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -665,5 +665,6 @@ namespace Slang
 		writer.Write(text);
 	}
 
+
 }
 

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -138,7 +138,7 @@ namespace Slang
         // As long as file extension is executable, it can be executed
         return SLANG_OK;
 #else
-        const int ret = ::chmod(fileName.getbuffer(), S_IXUSR);
+        const int ret = ::chmod(fileName.getBuffer(), S_IXUSR);
         return (ret == 0) ? SLANG_OK : SLANG_FAIL;
 #endif
     }

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -131,6 +131,19 @@ namespace Slang
     }
 #endif
 
+    /* static */SlangResult File::makeExecutable(const String& fileName)
+    {
+#ifdef _WIN32
+        SLANG_UNUSED(fileName);
+        // As long as file extension is executable, it can be executed
+        return SLANG_OK;
+#else
+        const int ret = ::chmod(fileName.getbuffer(), S_IXUSR);
+        return (ret == 0) ? SLANG_OK : SLANG_FAIL;
+#endif
+    }
+
+
 	bool File::exists(const String& fileName)
 	{
 #ifdef _WIN32

--- a/source/core/slang-io.h
+++ b/source/core/slang-io.h
@@ -17,6 +17,8 @@ namespace Slang
 		static void writeAllText(const Slang::String& fileName, const Slang::String& text);
         static SlangResult remove(const String& fileName);
 
+        static SlangResult makeExecutable(const String& fileName);
+
         static SlangResult generateTemporary(const UnownedStringSlice& prefix, Slang::String& outFileName);
 	};
 

--- a/source/core/slang-io.h
+++ b/source/core/slang-io.h
@@ -87,6 +87,26 @@ namespace Slang
             /// @return The first element of the path, or empty 
         static UnownedStringSlice getFirstElement(const UnownedStringSlice& path);
 	};
+
+    // Helper class to clean up temporary files on dtor
+    struct TemporaryFileSet
+    {
+        void add(const String& path)
+        {
+            if (m_paths.indexOf(path) < 0)
+            {
+                m_paths.add(path);
+            }
+        }
+        ~TemporaryFileSet()
+        {
+            for (const auto& path : m_paths)
+            {
+                File::remove(path);
+            }
+        }
+        List<String> m_paths;
+    };
 }
 
 #endif

--- a/source/core/slang-io.h
+++ b/source/core/slang-io.h
@@ -16,6 +16,8 @@ namespace Slang
 		static Slang::List<unsigned char> readAllBytes(const Slang::String& fileName);
 		static void writeAllText(const Slang::String& fileName, const Slang::String& text);
         static SlangResult remove(const String& fileName);
+
+        static SlangResult generateTemporary(const UnownedStringSlice& prefix, Slang::String& outFileName);
 	};
 
 	class Path

--- a/source/core/slang-string.cpp
+++ b/source/core/slang-string.cpp
@@ -361,6 +361,12 @@ namespace Slang
         append(&chr, &chr + 1);
     }
 
+
+    void String::appendChar(char chr)
+    {
+        append(&chr, &chr + 1);
+    }
+
     void String::append(String const& str)
     {
         if (!m_buffer)

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -443,6 +443,9 @@ namespace Slang
         void append(StringSlice const& slice);
         void append(UnownedStringSlice const& slice);
 
+            /// Append a character (to remove ambiguity with other integral types)
+        void appendChar(char chr);
+
 		String(int32_t val, int radix = 10)
 		{
             append(val, radix);

--- a/source/core/slang-visual-studio-compiler-util.cpp
+++ b/source/core/slang-visual-studio-compiler-util.cpp
@@ -98,12 +98,33 @@ namespace Slang
         }
         case OptimizationLevel::Maximal:
         {
-            cmdLine.addArg("/O4");
+            cmdLine.addArg("/Ox");
             break;
         }
         default: break;
     }
-    
+
+    switch (options.floatingPointMode)
+    {
+        case FloatingPointMode::Default: break;
+        case FloatingPointMode::Precise:
+        {
+            // precise is default behavior, VS also has 'strict'
+            //
+            // ```/fp:strict has behavior similar to /fp:precise, that is, the compiler preserves the source ordering and rounding properties of floating-point code when
+            // it generates and optimizes object code for the target machine, and observes the standard when handling special values. In addition, the program may safely
+            // access or modify the floating-point environment at runtime.```
+
+            cmdLine.addArg("/fp:precise");
+            break;
+        }
+        case FloatingPointMode::Fast:
+        {
+            cmdLine.addArg("/fp:fast");
+            break;
+        }
+    }
+
     switch (options.targetType)
     {
         case TargetType::SharedLibrary:

--- a/source/core/slang-visual-studio-compiler-util.cpp
+++ b/source/core/slang-visual-studio-compiler-util.cpp
@@ -57,24 +57,20 @@ namespace Slang
         }
     }
 
-    switch (options.optimizationLevel)
+    switch (options.debugInfoType)
     {
-        case OptimizationLevel::Debug:
+        default:
         {
-            // No optimization
-            cmdLine.addArg("/Od");
-
-            cmdLine.addArg("/MDd");
-            break;
-        }
-        case OptimizationLevel::Normal:
-        {
-            cmdLine.addArg("/O2");
-            // Multithreaded DLL
+            // Multithreaded statically linked runtime library
             cmdLine.addArg("/MD");
             break;
         }
-        default: break;
+        case DebugInfoType::Maximal:
+        {
+            // Multithreaded statically linked *debug* runtime library
+            cmdLine.addArg("/MDd");
+            break;
+        }
     }
 
     // /Fd - followed by name of the pdb file
@@ -83,12 +79,37 @@ namespace Slang
         cmdLine.addPrefixPathArg("/Fd", options.modulePath, ".pdb");
     }
 
+    switch (options.optimizationLevel)
+    {
+        case OptimizationLevel::None:
+        {
+            // No optimization
+            cmdLine.addArg("/Od");   
+            break;
+        }
+        case OptimizationLevel::Default:
+        {
+            break;
+        }
+        case OptimizationLevel::High:
+        {
+            cmdLine.addArg("/O2");
+            break;
+        }
+        case OptimizationLevel::Maximal:
+        {
+            cmdLine.addArg("/O4");
+            break;
+        }
+        default: break;
+    }
+    
     switch (options.targetType)
     {
         case TargetType::SharedLibrary:
         {
             // Create dynamic link library
-            if (options.optimizationLevel == OptimizationLevel::Debug)
+            if (options.debugInfoType == DebugInfoType::None)
             {
                 cmdLine.addArg("/LDd");
             }

--- a/source/core/slang-visual-studio-compiler-util.cpp
+++ b/source/core/slang-visual-studio-compiler-util.cpp
@@ -10,6 +10,33 @@
 namespace Slang
 {
 
+/* static */ SlangResult VisualStudioCompilerUtil::calcModuleFilePath(const CompileOptions& options, StringBuilder& outPath)
+{
+    outPath.Clear();
+
+    switch (options.targetType)
+    {
+        case TargetType::SharedLibrary:
+        {
+            outPath << options.modulePath << ".dll";
+            return SLANG_OK;
+        }
+        case TargetType::Executable:
+        {
+            outPath << options.modulePath << ".exe";
+            return SLANG_OK;
+        }
+        case TargetType::Object:
+        {
+            outPath << options.modulePath << ".obj";
+            return SLANG_OK;
+        }
+        default: break;
+    }
+
+    return SLANG_FAIL;
+}
+
 /* static */void VisualStudioCompilerUtil::calcArgs(const CompileOptions& options, CommandLine& cmdLine)
 {
     // https://docs.microsoft.com/en-us/cpp/build/reference/compiler-options-listed-alphabetically?view=vs-2019

--- a/source/core/slang-visual-studio-compiler-util.h
+++ b/source/core/slang-visual-studio-compiler-util.h
@@ -19,6 +19,9 @@ struct VisualStudioCompilerUtil
     static void calcArgs(const CompileOptions& options, CommandLine& cmdLine);
         /// Parse Visual Studio exeRes into CPPCompiler::Output
     static SlangResult parseOutput(const ExecuteResult& exeRes, CPPCompiler::Output& outOutput);
+
+    static SlangResult calcModuleFilePath(const CompileOptions& options, StringBuilder& outPath);
+
 };
 
 }

--- a/source/core/slang-visual-studio-compiler-util.h
+++ b/source/core/slang-visual-studio-compiler-util.h
@@ -14,6 +14,7 @@ struct VisualStudioCompilerUtil
     typedef CPPCompiler::DebugInfoType DebugInfoType;
     typedef CPPCompiler::SourceType SourceType;
     typedef CPPCompiler::OutputMessage OutputMessage;
+    typedef CPPCompiler::FloatingPointMode FloatingPointMode;
 
         /// Calculate Visual Studio family compilers cmdLine arguments from options
     static void calcArgs(const CompileOptions& options, CommandLine& cmdLine);

--- a/source/core/slang-writer.cpp
+++ b/source/core/slang-writer.cpp
@@ -1,3 +1,5 @@
+#define  _CRT_SECURE_NO_WARNINGS
+
 #include "slang-writer.h"
 
 #include "slang-platform.h"
@@ -165,6 +167,21 @@ SlangResult FileWriter::setMode(SlangWriterMode mode)
     }
     return SLANG_FAIL;
 }
+
+/* static */SlangResult FileWriter::create(const char* filePath, const char* writeOptions, WriterFlags flags, ComPtr<ISlangWriter>& outWriter)
+{
+    flags &= ~WriterFlag::IsUnowned;
+
+    FILE* file = fopen(filePath, writeOptions);
+    if (!file)
+    {
+        return SLANG_E_CANNOT_OPEN;
+    }
+
+    outWriter = new FileWriter(file, flags);
+    return SLANG_OK;
+}
+
 
 /* !!!!!!!!!!!!!!!!!!!!!!!!! StringWriter !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!*/
 

--- a/source/core/slang-writer.h
+++ b/source/core/slang-writer.h
@@ -4,6 +4,8 @@
 #include "slang-string.h"
 
 #include "../../slang-com-helper.h"
+#include "../../slang-com-ptr.h"
+
 #include "slang-list.h"
 
 namespace Slang
@@ -117,6 +119,12 @@ public:
         Parent(flags | getDefaultFlags(file)),
         m_file(file)
     {}
+
+        /// 
+    static SlangResult create(const char* filePath, const char* writeOptions, WriterFlags flags, ComPtr<ISlangWriter>& outWriter);
+
+    static SlangResult createBinary(const char* filePath, WriterFlags flags, ComPtr<ISlangWriter>& outWriter) { return create(filePath, "wb", flags, outWriter); }
+    static SlangResult createText(const char* filePath, WriterFlags flags, ComPtr<ISlangWriter>& outWriter) { return create(filePath, "w", flags, outWriter); }
 
         /// Dtor
     ~FileWriter();

--- a/source/core/windows/slang-win-visual-studio-util.cpp
+++ b/source/core/windows/slang-win-visual-studio-util.cpp
@@ -293,7 +293,7 @@ static SlangResult _find(int versionIndex, WinVisualStudioUtil::VersionPath& out
             CommandLine cmdLine;
             calcExecuteCompilerArgs(versionPath, cmdLine);
             
-            RefPtr<GenericCPPCompiler> compiler = new GenericCPPCompiler(desc, cmdLine, &VisualStudioCompilerUtil::calcArgs, &VisualStudioCompilerUtil::parseOutput);
+            RefPtr<GenericCPPCompiler> compiler = new GenericCPPCompiler(desc, cmdLine, &VisualStudioCompilerUtil::calcArgs, &VisualStudioCompilerUtil::parseOutput, &VisualStudioCompilerUtil::calcModuleFilePath);
             set->addCompiler(compiler);
         }
     }

--- a/source/slang/slang-check.cpp
+++ b/source/slang/slang-check.cpp
@@ -381,6 +381,17 @@ namespace Slang
         return func;
     }
 
+    CPPCompilerSet* Session::requireCPPCompilerSet()
+    {
+        if (cppCompilerSet == nullptr)
+        {
+            cppCompilerSet = new CPPCompilerSet;
+            CPPCompilerUtil::initializeSet(cppCompilerSet);
+        }
+        SLANG_ASSERT(cppCompilerSet);
+        return cppCompilerSet;
+    }
+
 
     enum class CheckingPhase
     {

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -1299,6 +1299,31 @@ SlangResult dissassembleDXILUsingDXC(
         temporaryFileSet.add(moduleFilePath);
 
         // Need to configure for the compilation
+
+        {
+            auto linkage = targetReq->getLinkage();
+
+            switch (linkage->optimizationLevel)
+            {
+                case OptimizationLevel::None:       options.optimizationLevel = CPPCompiler::OptimizationLevel::None; break;
+                case OptimizationLevel::Default:    options.optimizationLevel = CPPCompiler::OptimizationLevel::Default;  break;
+                case OptimizationLevel::High:       options.optimizationLevel = CPPCompiler::OptimizationLevel::High;  break;
+                case OptimizationLevel::Maximal:    options.optimizationLevel = CPPCompiler::OptimizationLevel::Maximal;  break;
+                default: SLANG_ASSERT(!"Unhandled optimization level"); break;
+            }
+
+            switch (linkage->debugInfoLevel)
+            {
+                case DebugInfoLevel::None:          options.debugInfoType = CPPCompiler::DebugInfoType::None; break; 
+                case DebugInfoLevel::Minimal:       options.debugInfoType = CPPCompiler::DebugInfoType::Minimal; break; 
+                
+                case DebugInfoLevel::Standard:      options.debugInfoType = CPPCompiler::DebugInfoType::Standard; break; 
+                case DebugInfoLevel::Maximal:       options.debugInfoType = CPPCompiler::DebugInfoType::Maximal; break; 
+                default: SLANG_ASSERT(!"Unhanled debug level"); break;
+            }
+        }
+
+        // Compile
         CPPCompiler::Output output;
         SLANG_RETURN_ON_FAIL(compiler->compile(options, output ));
 

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -4,6 +4,7 @@
 #include "../core/slang-platform.h"
 #include "../core/slang-io.h"
 #include "../core/slang-string-util.h"
+#include "../core/slang-hex-dump-util.h"
 
 #include "slang-compiler.h"
 #include "slang-lexer.h"
@@ -1776,58 +1777,6 @@ SlangResult dissassembleDXILUsingDXC(
 
     }
 
-    static void _dumpHex(const List<uint8_t>& data, int maxBytesPerLine, ISlangWriter* writer)
-    {
-        int maxCharsPerLine = 2 * maxBytesPerLine + 1 + maxBytesPerLine + 1;
-
-        const uint8_t* cur = data.begin();
-        const uint8_t* end = data.end();
-
-        static char s_hex[] = "0123456789abcdef";
-
-        while (cur < end)
-        {
-            size_t count = size_t(end - cur);
-            count = (count > maxBytesPerLine) ? maxBytesPerLine : count;
-
-            char* startDst = writer->beginAppendBuffer(maxCharsPerLine);
-            char* dst = startDst; 
-
-            for (size_t i = 0; i < count; ++i)
-            {
-                uint8_t byte = cur[i];
-                *dst++ = s_hex[byte >> 4];
-                *dst++ = s_hex[byte & 0xf];
-            }
-
-            *dst++ = ' ';
-
-            for (size_t i = 0; i < count; ++i)
-            {
-                char c = char(cur[i]);
-
-                if ((c >= '0' && c <= '9') ||
-                    (c >= 'a' && c <= 'z') ||
-                    (c >= 'A' && c <= 'Z') ||
-                    (c >= 32 && (c & 0x80) == 0))
-                {
-                }
-                else
-                {
-                    c = '.';
-                }
-                *dst++ = c;
-            }
-
-            *dst++ = '\n';
-            SLANG_ASSERT(dst <= startDst + maxCharsPerLine);
-
-            writer->endAppendBuffer(startDst, size_t(dst - startDst));
-
-            cur += count;
-        }
-    }
-
     static void writeOutputToConsole(
         ISlangWriter* writer,
         String const&   text)
@@ -1899,7 +1848,7 @@ SlangResult dissassembleDXILUsingDXC(
 
                     case CodeGenTarget::SharedLibrary:
                     case CodeGenTarget::Executable:
-                        _dumpHex(data, 24, writer);
+                        HexDumpUtil::dump(data, 24, writer);
                         break;
 
                     default:

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -85,8 +85,8 @@ namespace Slang
     x("dxil-asm,dxil-assembly", DXILAssembly) \
     x("c", CSource) \
     x("cpp", CPPSource) \
-    x("sharedlib,sharedlibrary,dll", SharedLibrary) \
-    x("exe,executable", Executable) 
+    x("exe,executable", Executable) \
+    x("sharedlib,sharedlibrary,dll", SharedLibrary) 
 
 #define SLANG_CODE_GEN_INFO(names, e) \
     { CodeGenTarget::e, UnownedStringSlice::fromLiteral(names) },
@@ -1568,6 +1568,17 @@ SlangResult dissassembleDXILUsingDXC(
                                 data.begin(),
                                 data.end() - data.begin(), assembly);
                             writeOutputToConsole(writer, assembly);
+                        }
+                        break;
+
+                    case CodeGenTarget::SharedLibrary:
+                        {
+                            WriterHelper(writer).put("SharedLibrary\n");
+                        }
+                        break;
+                    case CodeGenTarget::Executable:
+                        {
+                            WriterHelper(writer).put("Executable\n");
                         }
                         break;
 

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -1776,6 +1776,58 @@ SlangResult dissassembleDXILUsingDXC(
 
     }
 
+    static void _dumpHex(const List<uint8_t>& data, int maxBytesPerLine, ISlangWriter* writer)
+    {
+        int maxCharsPerLine = 2 * maxBytesPerLine + 1 + maxBytesPerLine + 1;
+
+        const uint8_t* cur = data.begin();
+        const uint8_t* end = data.end();
+
+        static char s_hex[] = "0123456789abcdef";
+
+        while (cur < end)
+        {
+            size_t count = size_t(end - cur);
+            count = (count > maxBytesPerLine) ? maxBytesPerLine : count;
+
+            char* startDst = writer->beginAppendBuffer(maxCharsPerLine);
+            char* dst = startDst; 
+
+            for (size_t i = 0; i < count; ++i)
+            {
+                uint8_t byte = cur[i];
+                *dst++ = s_hex[byte >> 4];
+                *dst++ = s_hex[byte & 0xf];
+            }
+
+            *dst++ = ' ';
+
+            for (size_t i = 0; i < count; ++i)
+            {
+                char c = char(cur[i]);
+
+                if ((c >= '0' && c <= '9') ||
+                    (c >= 'a' && c <= 'z') ||
+                    (c >= 'A' && c <= 'Z') ||
+                    (c >= 32 && (c & 0x80) == 0))
+                {
+                }
+                else
+                {
+                    c = '.';
+                }
+                *dst++ = c;
+            }
+
+            *dst++ = '\n';
+            SLANG_ASSERT(dst <= startDst + maxCharsPerLine);
+
+            writer->endAppendBuffer(startDst, size_t(dst - startDst));
+
+            cur += count;
+        }
+    }
+
     static void writeOutputToConsole(
         ISlangWriter* writer,
         String const&   text)
@@ -1846,14 +1898,8 @@ SlangResult dissassembleDXILUsingDXC(
                         break;
 
                     case CodeGenTarget::SharedLibrary:
-                        {
-                            WriterHelper(writer).put("SharedLibrary\n");
-                        }
-                        break;
                     case CodeGenTarget::Executable:
-                        {
-                            WriterHelper(writer).put("Executable\n");
-                        }
+                        _dumpHex(data, 24, writer);
                         break;
 
                     default:
@@ -2165,6 +2211,22 @@ SlangResult dissassembleDXILUsingDXC(
             }
             break;
     #endif
+
+        case CodeGenTarget::CSource:
+            dumpIntermediateText(compileRequest, data, size, ".c");
+            break;
+        case CodeGenTarget::CPPSource:
+            dumpIntermediateText(compileRequest, data, size, ".cpp");
+            break;
+
+        case CodeGenTarget::Executable:
+            // What these should be called is target specific, but just use these exts to make clear for now
+            // for now
+            dumpIntermediateBinary(compileRequest, data, size, ".exe");
+            break;
+        case CodeGenTarget::SharedLibrary:
+            dumpIntermediateBinary(compileRequest, data, size, ".shared-lib");
+            break;
         }
     }
 

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -1132,7 +1132,7 @@ SlangResult dissassembleDXILUsingDXC(
 
         const String sourcePath = calcSourcePathForEntryPoint(endToEndReq, entryPointIndex);
 
-        // We will need to ouput a file that we will compile. We need temporary files for the
+        // We will need to output a file that we will compile. We need temporary files for the
         // source, and for the target file probly
 
         return SLANG_OK;

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -1103,25 +1103,6 @@ SlangResult dissassembleDXILUsingDXC(
         return SLANG_OK;
     }
 
-    struct TemporaryFileSet
-    {
-        void add(const String& path)
-        {
-            if (m_paths.indexOf(path) < 0)
-            {
-                m_paths.add(path);
-            }
-        }
-        ~TemporaryFileSet()
-        {
-            for (const auto& path : m_paths)
-            {
-                File::remove(path);
-            }
-        }
-        List<String> m_paths;
-    };
-
     SlangResult emitCPUBinaryForEntryPoint(
         BackEndCompileRequest*  slangRequest,
         EntryPoint*             entryPoint,
@@ -1848,7 +1829,7 @@ SlangResult dissassembleDXILUsingDXC(
 
                     case CodeGenTarget::SharedLibrary:
                     case CodeGenTarget::Executable:
-                        HexDumpUtil::dump(data, 24, writer);
+                        HexDumpUtil::dumpWithMarkers(data, 24, writer);
                         break;
 
                     default:

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -4,6 +4,8 @@
 #include "../core/slang-basic.h"
 #include "../core/slang-shared-library.h"
 
+#include "../core/slang-cpp-compiler.h"
+
 #include "../../slang-com-ptr.h"
 
 #include "slang-diagnostics.h"
@@ -57,6 +59,8 @@ namespace Slang
         DXILAssembly        = SLANG_DXIL_ASM,
         CSource             = SLANG_C_SOURCE,
         CPPSource           = SLANG_CPP_SOURCE,
+        Executable          = SLANG_EXECUTABLE,
+        SharedLibrary       = SLANG_SHARED_LIBRARY,
     };
 
     CodeGenTarget calcCodeGenTargetFromName(const UnownedStringSlice& name);
@@ -417,10 +421,14 @@ namespace Slang
 
     enum class PassThroughMode : SlangPassThrough
     {
-        None = SLANG_PASS_THROUGH_NONE,	// don't pass through: use Slang compiler
-        fxc = SLANG_PASS_THROUGH_FXC,	// pass through HLSL to `D3DCompile` API
-        dxc = SLANG_PASS_THROUGH_DXC,	// pass through HLSL to `IDxcCompiler` API
-        glslang = SLANG_PASS_THROUGH_GLSLANG,	// pass through GLSL to `glslang` library
+        None = SLANG_PASS_THROUGH_NONE,	                    ///< don't pass through: use Slang compiler
+        Fxc = SLANG_PASS_THROUGH_FXC,	                    ///< pass through HLSL to `D3DCompile` API
+        Dxc = SLANG_PASS_THROUGH_DXC,	                    ///< pass through HLSL to `IDxcCompiler` API
+        Glslang = SLANG_PASS_THROUGH_GLSLANG,	            ///< pass through GLSL to `glslang` library
+        Clang = SLANG_PASS_THROUGH_CLANG,                   ///< Pass through clang compiler
+        Gcc = SLANG_PASS_THROUGH_GCC,                       ///< Gcc compiler
+        VisualStudio = SLANG_PASS_THROUGH_VISUAL_STUDIO,    ///< Visual studio compiler
+        GenericCCpp = SLANG_PASS_THROUGH_GENERIC_C_CPP,     ///< Generic C/C++ compiler
     };
 
     class SourceFile;
@@ -1493,6 +1501,8 @@ namespace Slang
         RefPtr<Type> stringType;
         RefPtr<Type> enumTypeType;
 
+        RefPtr<CPPCompilerSet> cppCompilerSet;                                          ///< Information about available C/C++ compilers. null unless information is requested (because slow)
+
         ComPtr<ISlangSharedLibraryLoader> sharedLibraryLoader;                          ///< The shared library loader (never null)
         ComPtr<ISlangSharedLibrary> sharedLibraries[int(SharedLibraryType::CountOf)];   ///< The loaded shared libraries
         SlangFuncPtr sharedLibraryFunctions[int(SharedLibraryFuncType::CountOf)];
@@ -1566,6 +1576,9 @@ namespace Slang
         ISlangSharedLibrary* getSharedLibrary(SharedLibraryType type) const { return sharedLibraries[int(type)]; }
 
         SlangFuncPtr getSharedLibraryFunc(SharedLibraryFuncType type, DiagnosticSink* sink);
+
+            /// Finds out what compilers are present and caches the result
+        CPPCompilerSet* requireCPPCompilerSet();
 
         Session();
 

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -478,6 +478,8 @@ DIAGNOSTIC(52000, Error, multiLevelBreakUnsupported, "control flow appears to re
 
 DIAGNOSTIC(52001, Warning, dxilNotFound, "dxil shared library not found, so 'dxc' output cannot be signed! Shader code will not be runnable in non-development environments.");
 
+DIAGNOSTIC(52002, Error, passThroughCompilerNotFound, "Could not find a suitable pass-through compiler for '$0'.");
+
 // 99999 - Internal compiler errors, and not-yet-classified diagnostics.
 
 DIAGNOSTIC(99999, Internal, unimplemented, "unimplemented feature in Slang compiler: $0")

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -36,6 +36,26 @@ SlangResult tryReadCommandLineArgument(DiagnosticSink* sink, char const* option,
     return SLANG_OK;
 }
 
+#define SLANG_PASS_THROUGH_TYPES(x) \
+        x(none, NONE) \
+        x(fxc, FXC) \
+        x(dxc, DXC) \
+        x(glslang, GLSLANG) \
+        x(vs, VISUAL_STUDIO) \
+        x(visualstudio, VISUAL_STUDIO) \
+        x(clang, CLANG) \
+        x(gcc, GCC) \
+        x(c, GENERIC_C_CPP) \
+        x(cpp, GENERIC_C_CPP)
+
+static SlangResult _parsePassThrough(const UnownedStringSlice& name, SlangPassThrough& outPassThrough)
+{
+#define SLANG_PASS_THROUGH_TYPE_CHECK(x, y) \
+    if (name == #x) { outPassThrough = SLANG_PASS_THROUGH_##y; return SLANG_OK; }
+    SLANG_PASS_THROUGH_TYPES(SLANG_PASS_THROUGH_TYPE_CHECK)
+    return SLANG_FAIL;
+}
+
 struct OptionsParser
 {
     SlangSession*           session = nullptr;
@@ -278,6 +298,9 @@ struct OptionsParser
             { ".tesc", SLANG_SOURCE_LANGUAGE_GLSL,  SLANG_STAGE_HULL },
             { ".tese", SLANG_SOURCE_LANGUAGE_GLSL,  SLANG_STAGE_DOMAIN },
             { ".comp", SLANG_SOURCE_LANGUAGE_GLSL,  SLANG_STAGE_COMPUTE },
+
+            { ".c",    SLANG_SOURCE_LANGUAGE_C,     SLANG_STAGE_NONE },
+            { ".cpp",  SLANG_SOURCE_LANGUAGE_CPP,   SLANG_STAGE_NONE },
         };
 
         for (int i = 0; i < SLANG_COUNT_OF(entries); ++i)
@@ -360,8 +383,12 @@ struct OptionsParser
         CASE(".spv",        SPIRV);
         CASE(".spv.asm",    SPIRV_ASM);
 
-        CASE(".c",    C_SOURCE);
-        CASE(".cpp",   CPP_SOURCE);
+        CASE(".c",      C_SOURCE);
+        CASE(".cpp",    CPP_SOURCE);
+
+        CASE(".exe",    EXECUTABLE);
+        CASE(".dll",    SHARED_LIBRARY);
+        CASE(".so",     SHARED_LIBRARY);
 
 #undef CASE
 
@@ -561,18 +588,13 @@ struct OptionsParser
                     SLANG_RETURN_ON_FAIL(tryReadCommandLineArgument(sink, arg, &argCursor, argEnd, name));
 
                     SlangPassThrough passThrough = SLANG_PASS_THROUGH_NONE;
-                    if (name == "fxc") { passThrough = SLANG_PASS_THROUGH_FXC; }
-                    else if (name == "dxc") { passThrough = SLANG_PASS_THROUGH_DXC; }
-                    else if (name == "glslang") { passThrough = SLANG_PASS_THROUGH_GLSLANG; }
-                    else
+                    if (SLANG_FAILED(_parsePassThrough(name.getUnownedSlice(), passThrough)))
                     {
                         sink->diagnose(SourceLoc(), Diagnostics::unknownPassThroughTarget, name);
                         return SLANG_FAIL;
                     }
 
-                    spSetPassThrough(
-                        compileRequest,
-                        passThrough);
+                    spSetPassThrough(compileRequest, passThrough);
                 }
                 else if (argStr == "-dxc-path")
                 {

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -449,6 +449,23 @@ struct OptionsParser
         rawTarget->floatingPointMode = mode;
     }
 
+    static bool _passThroughRequiresStage(PassThroughMode passThrough)
+    {
+        switch (passThrough)
+        {
+            case PassThroughMode::Glslang:
+            case PassThroughMode::Dxc:
+            case PassThroughMode::Fxc:
+            {
+                return true;
+            }
+            default:
+            {
+                return false;
+            }
+        }
+    }
+
     SlangResult parse(
         int             argc,
         char const* const*  argv)
@@ -960,7 +977,7 @@ struct OptionsParser
         // because fxc/dxc/glslang don't have a facility for taking
         // a named entry point and pulling its stage from an attribute.
         //
-        if( requestImpl->passThrough != PassThroughMode::None )
+        if(_passThroughRequiresStage(requestImpl->passThrough) )
         {
             for( auto& rawEntryPoint : rawEntryPoints )
             {

--- a/source/slang/slang-profile-defs.h
+++ b/source/slang/slang-profile-defs.h
@@ -3,7 +3,7 @@
 // Define all the various language "profiles" we want to support.
 
 #ifndef LANGUAGE
-#define LANGUAGE(TAG, NAME) /* emptry */
+#define LANGUAGE(TAG, NAME) /* empty */
 #endif
 
 #ifndef LANGUAGE_ALIAS
@@ -47,6 +47,8 @@ LANGUAGE(GLSL_ES,			glsl_es)
 LANGUAGE(GLSL_VK,			glsl_vk)
 LANGUAGE(SPIRV,				spirv)
 LANGUAGE(SPIRV_GL,			spirv_gl)
+LANGUAGE(C,                 c)
+LANGUAGE(CPP,               cpp)
 
 LANGUAGE_ALIAS(GLSL,		glsl_gl)
 LANGUAGE_ALIAS(SPIRV,		spirv_vk)

--- a/source/slang/slang-profile.h
+++ b/source/slang/slang-profile.h
@@ -13,6 +13,8 @@ namespace Slang
         Slang = SLANG_SOURCE_LANGUAGE_SLANG,
         HLSL = SLANG_SOURCE_LANGUAGE_HLSL,
         GLSL = SLANG_SOURCE_LANGUAGE_GLSL,
+        C = SLANG_SOURCE_LANGUAGE_C,
+        CPP = SLANG_SOURCE_LANGUAGE_CPP,
     };
 
     // TODO(tfoley): This should merge with the above...

--- a/tests/cpp-compiler/simple-c-compile.c
+++ b/tests/cpp-compiler/simple-c-compile.c
@@ -1,0 +1,10 @@
+//TEST:SIMPLE: -entry main -target exe -pass-through c 
+
+#include <stdlib.h>
+#include <stdio.h>
+
+int main(int argc, char** argv)
+{
+    printf("Hello World!\n");
+	return 0;
+}

--- a/tests/cpp-compiler/simple-c-compile.c.expected
+++ b/tests/cpp-compiler/simple-c-compile.c.expected
@@ -1,0 +1,6 @@
+result code = 0
+standard error = {
+}
+standard output = {
+Hello World!
+}

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -571,6 +571,9 @@ static SlangCompileTarget _getCompileTarget(const UnownedStringSlice& name)
         CASE("dxil-asm", DXIL_ASM)
         CASE("c", C_SOURCE)
         CASE("cpp", CPP_SOURCE)
+        CASE("exe", EXECUTABLE)
+        CASE("sharedlib", SHARED_LIBRARY)
+        CASE("dll", SHARED_LIBRARY)
 #undef CASE
 
         return SLANG_TARGET_UNKNOWN;

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -961,6 +961,7 @@ static SlangResult _executeBinary(const UnownedStringSlice& hexDump, ExecuteResu
     }
 
     // Make executable... (for linux/unix like targets)
+    SLANG_RETURN_ON_FAIL(File::makeExecutable(fileName));
 
     // Execute it
     CommandLine cmdLine;

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -19,6 +19,7 @@ enum class BackendType
     Dxc,
     Fxc,
     Glslang,
+    CPPCompiler,
     CountOf,
 };
 
@@ -30,6 +31,7 @@ struct BackendFlag
         Dxc = 1 << int(BackendType::Dxc),
         Fxc = 1 << int(BackendType::Fxc),
         Glslang = 1 << int(BackendType::Glslang),
+        CPPCompiler = 1 << int(BackendType::CPPCompiler),
     };
 };
 

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -13,25 +13,18 @@
 
 #include "options.h"
 
-enum class BackendType
+typedef uint32_t PassThroughFlags;
+struct PassThroughFlag
 {
-    Unknown = -1,
-    Dxc,
-    Fxc,
-    Glslang,
-    CPPCompiler,
-    CountOf,
-};
-
-typedef uint32_t BackendFlags;
-struct BackendFlag
-{
-    enum Enum : uint32_t
+    enum Enum : PassThroughFlags
     {
-        Dxc = 1 << int(BackendType::Dxc),
-        Fxc = 1 << int(BackendType::Fxc),
-        Glslang = 1 << int(BackendType::Glslang),
-        CPPCompiler = 1 << int(BackendType::CPPCompiler),
+        Dxc = 1 << int(SLANG_PASS_THROUGH_DXC),
+        Fxc = 1 << int(SLANG_PASS_THROUGH_FXC),
+        Glslang = 1 << int(SLANG_PASS_THROUGH_GLSLANG),
+        VisualStudio = 1 << int(SLANG_PASS_THROUGH_VISUAL_STUDIO),
+        GCC = 1 << int(SLANG_PASS_THROUGH_GCC),
+        Clang = 1 << int(SLANG_PASS_THROUGH_CLANG),
+        Generic_C_CPP = 1 << int(SLANG_PASS_THROUGH_GENERIC_C_CPP),
     };
 };
 
@@ -39,11 +32,11 @@ struct BackendFlag
 /// back-end availability 
 struct TestRequirements
 {
-    TestRequirements& addUsed(BackendType type)
+    TestRequirements& addUsed(SlangPassThrough type)
     {
-        if (type != BackendType::Unknown)
+        if (type != SLANG_PASS_THROUGH_NONE)
         {
-            usedBackendFlags |= BackendFlags(1) << int(type);
+            usedBackendFlags |= PassThroughFlags(1) << int(type);
         }
         return *this;
     }
@@ -56,7 +49,7 @@ struct TestRequirements
         }
         return *this;
     }
-    TestRequirements& addUsedBackends(BackendFlags flags)
+    TestRequirements& addUsedBackends(PassThroughFlags flags)
     {
         usedBackendFlags |= flags;
         return *this;
@@ -73,7 +66,7 @@ struct TestRequirements
     }
 
     Slang::RenderApiType explicitRenderApi = Slang::RenderApiType::Unknown;     ///< The render api explicitly specified 
-    BackendFlags usedBackendFlags = 0;                                          ///< Used backends
+    PassThroughFlags usedBackendFlags = 0;                                          ///< Used backends
     Slang::RenderApiFlags usedRenderApiFlags = 0;                               ///< Used render api flags (some might be implied)
 };
 
@@ -113,7 +106,7 @@ class TestContext
         /// If set then tests are not run, but their requirements are set 
     TestRequirements* testRequirements = nullptr;
 
-    BackendFlags availableBackendFlags = 0;
+    PassThroughFlags availableBackendFlags = 0;
     Slang::RenderApiFlags availableRenderApiFlags = 0;
     bool isAvailableRenderApiFlagsValid = false;
 


### PR DESCRIPTION
* Pass through mechanism can target C/C++ compilers
* Target types now include shared library and executable
* Simple test has been extended such that if the output is an executable it tries to run it
* Make compile options for CPPCompiler similar to slangs 
* Convert slang compile options to CPPCompiler options
* Return result of C/C++ compilation as a array of bytes 
* Support for temporary files on linux/windows
* When compiling a binary - slang will output to terminal as a hexdump
  * Can parse the hex dump to get the code back again

Currently this has been tested on linux and windows. Using CygWin - the antivirus on machine detects the file and thinks it is a threat, so stops it being executed. 