### PR TITLE
Add back a notion of IR global constants

### DIFF
--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -743,6 +743,7 @@ bool CLikeSourceEmitter::shouldFoldInstIntoUseSites(IRInst* inst)
     //
     case kIROp_Var:
     case kIROp_GlobalVar:
+    case kIROp_GlobalConstant:
     case kIROp_GlobalParam:
     case kIROp_Param:
     case kIROp_Func:
@@ -1958,6 +1959,10 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
             emitOperand(inst->getOperand(0), getInfo(EmitOp::General));
             m_writer->emit(")");
         }
+        break;
+
+    case kIROp_GlobalConstant:
+        emitOperand(inst->getOperand(0), outerPrec);
         break;
 
     default:

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -271,6 +271,15 @@ String emitEntryPoint(
         // un-specialized IR.
         dumpIRIfEnabled(compileRequest, irModule);
 
+        // Replace any global constants with their values.
+        //
+        replaceGlobalConstants(irModule);
+#if 0
+        dumpIRIfEnabled(compileRequest, irModule, "GLOBAL CONSTANTS REPLACED");
+#endif
+        validateIRModuleIfEnabled(compileRequest, irModule);
+
+
         // When there are top-level existential-type parameters
         // to the shader, we need to take the side-band information
         // on how the existential "slots" were bound to concrete

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -182,6 +182,7 @@ INST_RANGE(Type, VoidType, InterfaceType)
 INST_RANGE(GlobalValueWithCode, Func, GlobalVar)
 
 INST(GlobalParam, global_param, 0, 0)
+INST(GlobalConstant, globalConstant, 0, 0)
 
 INST(StructKey, key, 0, 0)
 INST(GlobalGenericParam, global_generic_param, 0, 0)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -579,6 +579,25 @@ struct IRGlobalParam : IRInst
     IR_LEAF_ISA(GlobalParam)
 };
 
+/// @brief A global constnat.
+///
+/// Represents a global constant that may have a name and linkage.
+/// If it has an operand, then this operand is the value of
+/// the constants. If there is no operand, then the instruction
+/// represents an "extern" constant that will be defined in another
+/// module, and which is thus expected to have linkage.
+///
+struct IRGlobalConstant : IRInst
+{
+    IR_LEAF_ISA(GlobalConstant);
+
+    /// Get the value of this global constant, or null if the value is not known.
+    IRInst* getValue()
+    {
+        return getOperandCount() != 0 ? getOperand(0) : nullptr;
+    }
+
+};
 
 // An entry in a witness table (see below)
 struct IRWitnessTableEntry : IRInst
@@ -1174,6 +1193,13 @@ struct IRBuilder
         IRInst* tag);
 
     IRInst* emitBitCast(
+        IRType* type,
+        IRInst* val);
+
+    IRGlobalConstant* emitGlobalConstant(
+        IRType* type);
+
+    IRGlobalConstant* emitGlobalConstant(
         IRType* type,
         IRInst* val);
 

--- a/source/slang/slang-ir-link.h
+++ b/source/slang/slang-ir-link.h
@@ -24,4 +24,13 @@ namespace Slang
         ProgramLayout*          programLayout,
         CodeGenTarget           target,
         TargetRequest*          targetReq);
+
+    // Replace any global constants in the IR module with their
+    // definitions, if possible.
+    //
+    // This pass should always be run shortly after linking the
+    // IR, to ensure that constants with identical values are
+    // treated as identical for the purposes of specialization.
+    //
+    void replaceGlobalConstants(IRModule* module);
 }

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -2955,6 +2955,30 @@ namespace Slang
         return inst;
     }
 
+    IRGlobalConstant* IRBuilder::emitGlobalConstant(
+        IRType* type)
+    {
+        auto inst = createInst<IRGlobalConstant>(
+            this,
+            kIROp_GlobalConstant,
+            type);
+        addInst(inst);
+        return inst;
+    }
+
+    IRGlobalConstant* IRBuilder::emitGlobalConstant(
+        IRType* type,
+        IRInst* val)
+    {
+        auto inst = createInst<IRGlobalConstant>(
+            this,
+            kIROp_GlobalConstant,
+            type,
+            val);
+        addInst(inst);
+        return inst;
+    }
+
     //
     // Decorations
     //
@@ -4284,7 +4308,8 @@ namespace Slang
         case kIROp_StructField:
         case kIROp_Func:
         case kIROp_Generic:
-        case kIROp_GlobalVar:
+        case kIROp_GlobalVar: // Note: the IRGlobalVar represents the *address*, so only a load/store would have side effects
+        case kIROp_GlobalConstant:
         case kIROp_GlobalParam:
         case kIROp_StructKey:
         case kIROp_GlobalGenericParam:
@@ -4458,6 +4483,9 @@ namespace Slang
         case kIROp_Func:
         case kIROp_Generic:
             return val->getFirstChild() != nullptr;
+
+        case kIROp_GlobalConstant:
+            return cast<IRGlobalConstant>(val)->getValue() != nullptr;
 
         case kIROp_StructType:
         case kIROp_GlobalVar:


### PR DESCRIPTION
This change adds back a little bit of explicit support for global constants in the IR, after a previous change completely removed the existing `IRGlobalConstant` node type.

The new `IRGlobalConstant` is *not* a parent instruction, and doesn't function at all like the old one.
Instead it is effectively a simple instruction that takes zero or one operands:

* The zero-operand case represents a constant with unknown value. This would usually come from another module, and thus would have an `[import(...)]` linkage decoration, so that after linking it resolves to a constant with a known value.

* In the one-operand case, the single operand represents the value of the constant, so that the operation semantically behaves like an identity function. It exists just to give decorations something to "attach" to, so that a global constant with a value can have, e.g., an `[export(...)]` decoration to establish linkage.

The IR lowering pass was updated to create the new node type to wrap any global constants. For now we do this both for global `static const` variables and function-scope `static const`, although the latter doesn't really need the extra indirection.

The IR linking logic was extended to handle linking of global constants akin to how other global instructions are handled. The new logic is mostly boilerplate, and it is likely that a refactor of the linking logic would eliminate the need for this kind of per-instruction-opcode handling of IR instructions that can have linkage.

A custom pass was added that is intended to be run right after linking (it could arguably be folded into `linkIR()`, but I thought it was safer to keep each pass as small as possible). This pass replaces any `IRGlobalConstant` that has a value (operand) with that value, so that global constants should be eliminated after the linking step. This ensures that downstream optimization/transformation passes don't have to deal with the possibility of global constants.

Almost all the existing passes would Just Work if global constants were left in the IR. The two big exceptions are:

* Anything that relies on testing `IRInst*` identity as a way to test for things having the same value would break, since a global constant is a distinct `IRInst*` from its value.

* The type legalization pass doesn't handle `IRGlobalConstant` instructions with non-simple types. This could be added if we ever wanted it, but it seemed silly to write this code now if it would always be dead (and thus untested).

I went ahead and updated the emit logic to handle an `IRGlobalConstant`s that still existing in the IR module at emit time, since the amount of code required was small so that being robust to that case seemed safest (e.g., in case we ever want to have a path that emits code directly while skipping some/all of our IR transformation passes).

There should be no visible changes to the functionality of the compiler with this change, but it should help make IR dumps from the front-end more clear/explicit (since each constant will be a distinct instruction with its own name), and paves the way for supporting proper cross-module linkage of constants.