### PR TITLE
Small improvements around C/C++ testing

### DIFF
--- a/docs/cpu-target.md
+++ b/docs/cpu-target.md
@@ -15,10 +15,9 @@ Slang has preliminary support for producing CPU source and binaries.
 
 These limitations apply to Slang source, with C/C++ the limitations are whatever the compiler requires
 
-* Only supports 64 bit targets (specifically it assumes all pointers are 64 bit)
 * Barriers are not supported (making these work would require an ABI change)
 * Atomics are not supported
-* Complex resource types (such as say Texture2d) are work in progress
+* Complex resource types (such as Texture2d) are work in progress
 * Out of bounds access to resources has undefined behavior 
 * ParameterBlocks are not currently supported
 
@@ -37,7 +36,9 @@ SLANG_PASS_THROUGH_GENERIC_C_CPP,           ///< Generic C or C++ compiler, whic
 
 Sometimes it is not important which C/C++ compiler is used, and this can be specified via the 'Generic C/C++' option. This will aim to use the compiler that is most likely binary compatible with the compiler that was used to build the slang binary being used. 
 
-To make it possible for slang to produce CPU code, we now need a mechanism to convert slang code into C/C++. The first iteration only supports C++ generation. If source is desired instead of a binary this can be specified via the SlangCompileTarget. These can be specified on the slangc command line as `-target c` or `-target cpp`
+To make it possible for slang to produce CPU code, we now need a mechanism to convert slang code into C/C++. The first iteration only supports C++ generation. If source is desired instead of a binary this can be specified via the SlangCompileTarget. These can be specified on the slangc command line as `-target c` or `-target cpp`.
+
+Note that when using the 'pass through' mode for a CPU based target it is currently necessary to set an entry point, even though it's basically ignored. 
 
 In the API the `SlangCompileTarget`s are 
 
@@ -65,7 +66,7 @@ Under the covers when slang is used to generate a binary via a C/C++ compiler, i
 Executing CPU Code
 ==================
 
-In typically slang operation when code is compiled it produces either source or a binary that can then be loaded by another API such as a rendering API. With CPU code the binary produced could be saved to a file and then executed as an exe or a shared library/dll. In practice though it is not uncommon to want to be able to execute compiled code immediately. Having to save off to a file and then load again can be awkward. It is also not necessarily the case that code needs to be saved to a file to be executed. 
+In typical slang operation when code is compiled it produces either source or a binary that can then be loaded by another API such as a rendering API. With CPU code the binary produced could be saved to a file and then executed as an exe or a shared library/dll. In practice though it is not uncommon to want to be able to execute compiled code immediately. Having to save off to a file and then load again can be awkward. It is also not necessarily the case that code needs to be saved to a file to be executed. 
 
 To handle being able call code directly, code can be compiled using the SLANG_HOST_CALLABLE code target type. To access the code that has been produced use the function
 

--- a/source/core/slang-gcc-compiler-util.cpp
+++ b/source/core/slang-gcc-compiler-util.cpp
@@ -184,6 +184,16 @@ static SlangResult _parseGCCFamilyLine(const UnownedStringSlice& line, LineParse
             outLineParseResult = LineParseResult::Start;
             return SLANG_OK;
         }
+
+        if (SLANG_SUCCEEDED(_parseErrorType(split0, outMsg.type)))
+        {
+            // Command line errors can be just contain 'error:' etc. Can be seen on apple/clang
+            outMsg.stage = OutputMessage::Stage::Compile;
+            outMsg.text = split[1].trim();
+            outLineParseResult = LineParseResult::Single;
+            return SLANG_OK;
+        }
+
         outLineParseResult = LineParseResult::Ignore;
         return SLANG_OK;
     }
@@ -193,8 +203,9 @@ static SlangResult _parseGCCFamilyLine(const UnownedStringSlice& line, LineParse
         const auto split1 = split[1].trim();
         const auto text = split[2].trim();
 
-        // Check for special handling for clang
-        if (split0.startsWith(UnownedStringSlice::fromLiteral("clang")))
+        // Check for special handling for clang (Can be Clang or clang apparently)
+        if (split0.startsWith(UnownedStringSlice::fromLiteral("clang")) ||
+            split0.startsWith(UnownedStringSlice::fromLiteral("Clang")) )
         {
             // Extract the type
             SLANG_RETURN_ON_FAIL(_parseErrorType(split[1].trim(), outMsg.type));
@@ -387,11 +398,11 @@ static SlangResult _parseGCCFamilyLine(const UnownedStringSlice& line, LineParse
 /* static */SlangResult GCCCompilerUtil::calcArgs(const CompileOptions& options, CommandLine& cmdLine)
 {
     PlatformKind platformKind = (options.platform == PlatformKind::Unknown) ? PlatformUtil::getPlatformKind() : options.platform;
-    
-    cmdLine.addArg("-fvisibility=hidden");
-
+        
     if (options.sourceType == SourceType::CPP)
     {
+        cmdLine.addArg("-fvisibility=hidden");
+
         // Need C++14 for partial specialization
         cmdLine.addArg("-std=c++14");
     }

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -1345,6 +1345,9 @@ SlangResult dissassembleDXILUsingDXC(
         String modulePath;
         SLANG_RETURN_ON_FAIL(File::generateTemporary(UnownedStringSlice::fromLiteral("slang-generated"), modulePath));
 
+        // Remove the temporary path/file when done
+        temporaryFileSet.add(modulePath);
+
         options.modulePath = modulePath;
         options.sourceFiles.add(compileSourcePath);
 

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -768,7 +768,7 @@ namespace Slang
         return result;
     }
 
-    void reportExternalCompileError(const char* compilerName, SlangResult res, const UnownedStringSlice& diagnostic, DiagnosticSink* sink)
+    void reportExternalCompileError(const char* compilerName, Severity severity, SlangResult res, const UnownedStringSlice& diagnostic, DiagnosticSink* sink)
     {
         StringBuilder builder;
         if (compilerName)
@@ -792,10 +792,15 @@ namespace Slang
             PlatformUtil::appendResult(res, builder);
         }
 
+        sink->diagnoseRaw(severity, builder.getUnownedSlice());
+    }
+
+    void reportExternalCompileError(const char* compilerName, SlangResult res, const UnownedStringSlice& diagnostic, DiagnosticSink* sink)
+    {
         // TODO(tfoley): need a better policy for how we translate diagnostics
         // back into the Slang world (although we should always try to generate
         // HLSL that doesn't produce any diagnostics...)
-        sink->diagnoseRaw(SLANG_FAILED(res) ? Severity::Error : Severity::Warning, builder.getUnownedSlice());
+        reportExternalCompileError(compilerName, SLANG_FAILED(res) ? Severity::Error : Severity::Warning, res, diagnostic, sink);
     }
 
     static String _getDisplayPath(DiagnosticSink* sink, SourceFile* sourceFile)
@@ -1486,17 +1491,36 @@ SlangResult dissassembleDXILUsingDXC(
                     builder << "link ";
                 }
 
+                // 
+                Severity severity = Severity::Error;
+                
                 switch (msg.type)
                 {
-                    case OutputMessage::Type::Error:    builder << "error"; break;
-                    case OutputMessage::Type::Unknown:  builder << "warning"; break;
-                    case OutputMessage::Type::Info:     builder << "info"; break;
+                    case OutputMessage::Type::Unknown:
+                    case OutputMessage::Type::Error:
+                    {
+                        severity = Severity::Error;
+                        builder << "error";
+                        break;
+                    }
+                    case OutputMessage::Type::Warning:
+                    {
+                        severity = Severity::Warning;
+                        builder << "warning";
+                        break;
+                    }
+                    case OutputMessage::Type::Info:
+                    {
+                        severity = Severity::Note;
+                        builder << "info";
+                        break;
+                    }
                     default: break;
                 }
 
                 builder << " " << msg.code << ": " << msg.text;
 
-                reportExternalCompileError(compilerText.getBuffer(), SLANG_OK, builder.getUnownedSlice(), sink);
+                reportExternalCompileError(compilerText.getBuffer(), severity, SLANG_OK, builder.getUnownedSlice(), sink);
             }
         }
 

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -1346,6 +1346,9 @@ SlangResult dissassembleDXILUsingDXC(
 
         CPPCompiler::CompileOptions options;
 
+        // Set the source type
+        options.sourceType = (rawSourceLanguage == SourceLanguage::C) ? CPPCompiler::SourceType::C : CPPCompiler::SourceType::CPP;
+
         // Generate a path a temporary filename for output module
         String modulePath;
         SLANG_RETURN_ON_FAIL(File::generateTemporary(UnownedStringSlice::fromLiteral("slang-generated"), modulePath));

--- a/tests/cpp-compiler/c-compile-pass-through-shared-library.c
+++ b/tests/cpp-compiler/c-compile-pass-through-shared-library.c
@@ -6,9 +6,8 @@
    
 #if defined(_MSC_VER)
 #   define DLL_EXPORT __declspec(dllexport)
-#else 
-//#   define DLL_EXPORT 
-#   define DLL_EXPORT __attribute__ ((dllexport)) __attribute__((__visibility__("default")))
+#else  
+#   define DLL_EXPORT  __attribute__((__visibility__("default")))
 #endif    
 
 #ifdef __cplusplus    

--- a/tests/cpp-compiler/c-compile-pass-through-shared-library.c
+++ b/tests/cpp-compiler/c-compile-pass-through-shared-library.c
@@ -1,0 +1,25 @@
+//TEST(smoke,shared-library):CPP_COMPILER_COMPILE: -pass-through c -entry test -target callable
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>   
+   
+#if defined(_MSC_VER)
+#   define DLL_EXPORT __declspec(dllexport)
+#else 
+//#   define DLL_EXPORT 
+#   define DLL_EXPORT __attribute__ ((dllexport)) __attribute__((__visibility__("default")))
+#endif    
+
+#ifdef __cplusplus    
+#define EXTERN_C extern "C"
+#else
+#define EXTERN_C 
+#endif    
+    
+EXTERN_C DLL_EXPORT int test(int intValue, const char* textValue, char* outTextValue)
+{
+    strcpy(outTextValue, textValue);
+    return intValue;
+}
+   

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1368,6 +1368,14 @@ static TestResult runCPPCompilerCompile(TestContext* context, TestInput& input)
         return TestResult::Fail;
     }
 
+    // Check for any errors
+    if (exeRes.standardError.indexOf("error") >= 0 || exeRes.standardOutput.indexOf("error") >= 0)
+    {
+        String actualOutputPath = outputStem + ".actual";
+        Slang::File::writeAllText(actualOutputPath, getOutput(exeRes));
+        return TestResult::Fail;
+    }
+
     String actualOutput = exeRes.standardOutput;
  
     String modulePath = _calcModulePath(input);

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1363,26 +1363,21 @@ static TestResult runCPPCompilerCompile(TestContext* context, TestInput& input)
         return TestResult::Pass;
     }
 
+    // Dump out what happened
+    {
+        String actualOutputPath = outputStem + ".actual";
+        Slang::File::writeAllText(actualOutputPath, getOutput(exeRes));
+    }
+
     if (exeRes.resultCode != 0)
     {
         return TestResult::Fail;
     }
 
-    // Check for any errors
-    if (exeRes.standardError.indexOf("error") >= 0 || exeRes.standardOutput.indexOf("error") >= 0)
-    {
-        String actualOutputPath = outputStem + ".actual";
-        Slang::File::writeAllText(actualOutputPath, getOutput(exeRes));
-        return TestResult::Fail;
-    }
-
-    String actualOutput = exeRes.standardOutput;
- 
     String modulePath = _calcModulePath(input);
     
-    UnownedStringSlice targetExt = UnownedStringSlice::fromLiteral("c");
-
     // Find the target
+    UnownedStringSlice targetExt = UnownedStringSlice::fromLiteral("c");
     Index index = cmdLine.findArgIndex(UnownedStringSlice::fromLiteral("-target"));
     if (index >= 0 && index + 1 < cmdLine.getArgCount())
     {
@@ -1396,6 +1391,8 @@ static TestResult runCPPCompilerCompile(TestContext* context, TestInput& input)
         options.sourceType = (targetExt == "c") ? CPPCompiler::SourceType::C : CPPCompiler::SourceType::CPP;
 
         options.includePaths.add("tests/cross-compile");
+
+        String actualOutput = exeRes.standardOutput;
 
         // Create a filename to write this out to
         String cppSource = modulePath + "." + targetExt;
@@ -1427,6 +1424,7 @@ static TestResult runCPPCompilerCompile(TestContext* context, TestInput& input)
 
     return TestResult::Pass;
 }
+
 static TestResult runCPPCompilerSharedLibrary(TestContext* context, TestInput& input)
 {
     CPPCompiler* compiler = context->getDefaultCPPCompiler();

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -100,3 +100,10 @@ CPPCompilerSet* TestContext::getCPPCompilerSet()
     }
     return cppCompilerSet;
 }
+
+Slang::CPPCompiler* TestContext::getDefaultCPPCompiler()
+{
+    CPPCompilerSet* set = getCPPCompilerSet();
+    return set ? set->getDefaultCompiler() : nullptr;
+}
+

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -93,6 +93,7 @@ class TestContext
 
         /// Get compiler factory
     Slang::CPPCompilerSet* getCPPCompilerSet();
+    Slang::CPPCompiler* getDefaultCPPCompiler();
 
         /// Ctor
     TestContext();


### PR DESCRIPTION
* Simplify some of test code around CPPCompiler
* Test using 'callable' with pass-through
* Small cpu doc improvements
* Correctly set source code type for pass-thru
* Fix issue passing Clang output
* Handling 'severity for diagnostics for external tools 