### PR TITLE
A more convoluted #pragma once file identity test, using relative paths.

### DIFF
--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -69,6 +69,8 @@ DIAGNOSTIC(    14, Error, unknownProfile, "unknown profile '$0'");
 DIAGNOSTIC(    15, Error, unknownStage, "unknown stage '$0'");
 DIAGNOSTIC(    16, Error, unknownPassThroughTarget, "unknown pass-through target '$0'");
 DIAGNOSTIC(    17, Error, unknownCommandLineOption, "unknown command-line option '$0'");
+DIAGNOSTIC(    18, Error, unknownFileSystemOption, "unknown file-system option '$0'");
+
 DIAGNOSTIC(    20, Error, entryPointsNeedToBeAssociatedWithTranslationUnits, "when using multiple source files, entry points must be specified after their corresponding source file(s)");
 DIAGNOSTIC(    21, Error, expectedArgumentForOption, "expected an argument for command-line option '$0'");
 

--- a/source/slang/slang-file-system.cpp
+++ b/source/slang/slang-file-system.cpp
@@ -36,6 +36,13 @@ static SlangResult _calcCombinedPath(SlangPathType fromPathType, const char* fro
     return SLANG_OK;
 }
 
+/* !!!!!!!!!!!!!!!!!!!!!!!!!! LoadOnlyFileSystem !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!*/
+
+ISlangUnknown* LoadFileFileSystem::getInterface(const Guid& guid)
+{
+    return (guid == IID_ISlangUnknown || guid == IID_ISlangFileSystem ) ? static_cast<ISlangFileSystem*>(this) : nullptr;
+}
+
 /* !!!!!!!!!!!!!!!!!!!!!!!!!! IncludeFileSystem !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!*/
 
 /* static */OSFileSystem OSFileSystem::s_singleton; 

--- a/source/slang/slang-file-system.cpp
+++ b/source/slang/slang-file-system.cpp
@@ -36,16 +36,18 @@ static SlangResult _calcCombinedPath(SlangPathType fromPathType, const char* fro
     return SLANG_OK;
 }
 
-/* !!!!!!!!!!!!!!!!!!!!!!!!!! LoadOnlyFileSystem !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!*/
+/* !!!!!!!!!!!!!!!!!!!!!!!!!!!!! OSFileSystem !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!*/
 
-ISlangUnknown* LoadFileFileSystem::getInterface(const Guid& guid)
+/* static */OSFileSystem OSFileSystem::s_singleton;
+
+ISlangUnknown* OSFileSystem::getInterface(const Guid& guid)
 {
     return (guid == IID_ISlangUnknown || guid == IID_ISlangFileSystem ) ? static_cast<ISlangFileSystem*>(this) : nullptr;
 }
 
-/* !!!!!!!!!!!!!!!!!!!!!!!!!! IncludeFileSystem !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!*/
+/* !!!!!!!!!!!!!!!!!!!!!!!!!! OSFileSystemExt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!*/
 
-/* static */OSFileSystem OSFileSystem::s_singleton; 
+/* static */OSFileSystemExt OSFileSystemExt::s_singleton; 
 
 template <typename T>
 static ISlangFileSystemExt* _getInterface(T* ptr, const Guid& guid)
@@ -53,7 +55,7 @@ static ISlangFileSystemExt* _getInterface(T* ptr, const Guid& guid)
     return (guid == IID_ISlangUnknown || guid == IID_ISlangFileSystem || guid == IID_ISlangFileSystemExt) ? static_cast<ISlangFileSystemExt*>(ptr) : nullptr;
 }
 
-ISlangUnknown* OSFileSystem::getInterface(const Guid& guid)
+ISlangUnknown* OSFileSystemExt::getInterface(const Guid& guid)
 {
     return _getInterface(this, guid); 
 }
@@ -69,13 +71,13 @@ static String _fixPathDelimiters(const char* pathIn)
 #endif
 }
 
-SlangResult OSFileSystem::getFileUniqueIdentity(const char* pathIn, ISlangBlob** outUniqueIdentity)
+SlangResult OSFileSystemExt::getFileUniqueIdentity(const char* pathIn, ISlangBlob** outUniqueIdentity)
 {
     // By default we use the canonical path to uniquely identify a file
     return getCanonicalPath(pathIn, outUniqueIdentity);
 }
 
-SlangResult OSFileSystem::getCanonicalPath(const char* path, ISlangBlob** outCanonicalPath)
+SlangResult OSFileSystemExt::getCanonicalPath(const char* path, ISlangBlob** outCanonicalPath)
 {
     String canonicalPath;
     SLANG_RETURN_ON_FAIL(Path::getCanonical(_fixPathDelimiters(path), canonicalPath));
@@ -83,25 +85,25 @@ SlangResult OSFileSystem::getCanonicalPath(const char* path, ISlangBlob** outCan
     return SLANG_OK;
 }
 
-SlangResult OSFileSystem::getSimplifiedPath(const char* pathIn, ISlangBlob** outSimplifiedPath)
+SlangResult OSFileSystemExt::getSimplifiedPath(const char* pathIn, ISlangBlob** outSimplifiedPath)
 {
     String simplifiedPath = Path::simplify(_fixPathDelimiters(pathIn));
     *outSimplifiedPath = StringUtil::createStringBlob(simplifiedPath).detach();
     return SLANG_OK;
 }
 
-SlangResult OSFileSystem::calcCombinedPath(SlangPathType fromPathType, const char* fromPath, const char* path, ISlangBlob** pathOut)
+SlangResult OSFileSystemExt::calcCombinedPath(SlangPathType fromPathType, const char* fromPath, const char* path, ISlangBlob** pathOut)
 {
     // Don't need to fix delimiters - because combine path handles both path delimiter types
     return _calcCombinedPath(fromPathType, fromPath, path, pathOut);
 }
 
-SlangResult SLANG_MCALL OSFileSystem::getPathType(const char* pathIn, SlangPathType* pathTypeOut)
+SlangResult SLANG_MCALL OSFileSystemExt::getPathType(const char* pathIn, SlangPathType* pathTypeOut)
 {
     return Path::getPathType(_fixPathDelimiters(pathIn), pathTypeOut);
 }
 
-SlangResult OSFileSystem::loadFile(char const* pathIn, ISlangBlob** outBlob)
+SlangResult OSFileSystemExt::loadFile(char const* pathIn, ISlangBlob** outBlob)
 {
     // Default implementation that uses the `core` libraries facilities for talking to the OS filesystem.
     //

--- a/source/slang/slang-file-system.h
+++ b/source/slang/slang-file-system.h
@@ -11,7 +11,8 @@
 namespace Slang
 {
 
-class OSFileSystem : public ISlangFileSystemExt
+// Implementation of ISlangFileSystemExt for the OS
+class OSFileSystemExt : public ISlangFileSystemExt
 {
 public:
     // ISlangUnknown 
@@ -55,34 +56,41 @@ public:
 
 private:
         /// Make so not constructible
-    OSFileSystem() {}
-    virtual ~OSFileSystem() {}
+    OSFileSystemExt() {}
+    virtual ~OSFileSystemExt() {}
 
     ISlangUnknown* getInterface(const Guid& guid);
 
-    static OSFileSystem s_singleton;
+    static OSFileSystemExt s_singleton;
 };
 
-// A class that turns a files-ystem into a 'loadFile' style that only implements ISlangFileSystem interface
-class LoadFileFileSystem : public ISlangFileSystem, RefObject 
+// Implementation of ISlangFileSystem for the OS (ie only has simplified interface of just loadFile)
+class OSFileSystem : public ISlangFileSystem
 {
 public:
-    // ISlangUnknown 
-    SLANG_REF_OBJECT_IUNKNOWN_ALL
+        // ISlangUnknown 
+    SLANG_IUNKNOWN_QUERY_INTERFACE
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE { return 1; }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE { return 1; }
 
     // ISlangFileSystem
     virtual SLANG_NO_THROW SlangResult SLANG_MCALL loadFile(
         char const*     path,
         ISlangBlob**    outBlob) SLANG_OVERRIDE
     {
-        return m_fileSystem->loadFile(path, outBlob);
+        // Can just use OsFileSystemExt impl
+        return OSFileSystemExt::getSingleton()->loadFile(path, outBlob);
     }
 
-    LoadFileFileSystem(ISlangFileSystem* fileSystem):m_fileSystem(fileSystem) {}
-    virtual ~LoadFileFileSystem() {}
-    ISlangUnknown* getInterface(const Guid& guid);
+     static ISlangFileSystem* getSingleton() { return &s_singleton; }
 
-    ComPtr<ISlangFileSystem> m_fileSystem;
+private:
+    /// Make so not constructible
+        OSFileSystem() {}
+    virtual ~OSFileSystem() {}
+
+    ISlangUnknown* getInterface(const Guid& guid);
+    static OSFileSystem s_singleton;
 };
 
 /* Wraps an underlying ISlangFileSystem or ISlangFileSystemExt and provides caching, 

--- a/source/slang/slang-file-system.h
+++ b/source/slang/slang-file-system.h
@@ -63,6 +63,28 @@ private:
     static OSFileSystem s_singleton;
 };
 
+// A class that turns a files-ystem into a 'loadFile' style that only implements ISlangFileSystem interface
+class LoadFileFileSystem : public ISlangFileSystem, RefObject 
+{
+public:
+    // ISlangUnknown 
+    SLANG_REF_OBJECT_IUNKNOWN_ALL
+
+    // ISlangFileSystem
+    virtual SLANG_NO_THROW SlangResult SLANG_MCALL loadFile(
+        char const*     path,
+        ISlangBlob**    outBlob) SLANG_OVERRIDE
+    {
+        return m_fileSystem->loadFile(path, outBlob);
+    }
+
+    LoadFileFileSystem(ISlangFileSystem* fileSystem):m_fileSystem(fileSystem) {}
+    virtual ~LoadFileFileSystem() {}
+    ISlangUnknown* getInterface(const Guid& guid);
+
+    ComPtr<ISlangFileSystem> m_fileSystem;
+};
+
 /* Wraps an underlying ISlangFileSystem or ISlangFileSystemExt and provides caching, 
 as well as emulation of methods if only has ISlangFileSystem interface. Will query capabilities
 of the interface on the constructor.

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -816,8 +816,7 @@ struct OptionsParser
                     }
                     else if (name == "load-file")
                     {
-                        ComPtr<ISlangFileSystem> fileSystem(new LoadFileFileSystem(OSFileSystem::getSingleton()));
-                        spSetFileSystem(compileRequest, fileSystem);
+                        spSetFileSystem(compileRequest, OSFileSystem::getSingleton());
                     }
                     else
                     {

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -8,6 +8,8 @@
 #include "slang-compiler.h"
 #include "slang-profile.h"
 
+#include "slang-file-system.h"
+
 #include <assert.h>
 
 namespace Slang {
@@ -632,7 +634,7 @@ struct OptionsParser
                     SLANG_RETURN_ON_FAIL(tryReadCommandLineArgument(sink, arg, &argCursor, argEnd, name));
                     addSharedLibraryPath(SharedLibraryType::Fxc, name);
                 }
-                else if (argStr[1] == 'D')
+                else if (argStr.getLength() >= 2 && argStr[1] == 'D')
                 {
                     // The value to be defined might be part of the same option, as in:
                     //     -DFOO
@@ -677,7 +679,7 @@ struct OptionsParser
                             "");
                     }
                 }
-                else if (argStr[1] == 'I')
+                else if (argStr.getLength() >= 2 && argStr[1] == 'I')
                 {
                     // The value to be defined might be part of the same option, as in:
                     //     -IFOO
@@ -802,6 +804,26 @@ struct OptionsParser
                 else if( argStr == "-default-image-format-unknown" )
                 {
                     requestImpl->getBackEndReq()->useUnknownImageFormatAsDefault = true;
+                }
+                else if (argStr == "-file-system")
+                {
+                    String name;
+                    SLANG_RETURN_ON_FAIL(tryReadCommandLineArgument(sink, arg, &argCursor, argEnd, name));
+
+                    if (name == "default")
+                    {
+                        spSetFileSystem(compileRequest, nullptr);
+                    }
+                    else if (name == "load-file")
+                    {
+                        ComPtr<ISlangFileSystem> fileSystem(new LoadFileFileSystem(OSFileSystem::getSingleton()));
+                        spSetFileSystem(compileRequest, fileSystem);
+                    }
+                    else
+                    {
+                        sink->diagnose(SourceLoc(), Diagnostics::unknownFileSystemOption, name);
+                        return SLANG_FAIL;
+                    }
                 }
                 else if (argStr == "--")
                 {

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -2365,17 +2365,17 @@ void Linkage::setFileSystem(ISlangFileSystem* inFileSystem)
     // Set the fileSystem
     fileSystem = inFileSystem;
 
-    // Set up fileSystemExt appropriately
+    // If nullptr passed in set up default 
     if (inFileSystem == nullptr)
     {
-        fileSystemExt = new Slang::CacheFileSystem(Slang::OSFileSystem::getSingleton());
+        fileSystemExt = new Slang::CacheFileSystem(Slang::OSFileSystemExt::getSingleton());
     }
     else
     {
-        // See if we have the interface 
+        // See if we have the full ISlangFileSystemExt interface, if we do just use it
         inFileSystem->queryInterface(IID_ISlangFileSystemExt, (void**)fileSystemExt.writeRef());
 
-        // If not wrap with WrapFileSytem that keeps the old behavior
+        // If not wrap with CacheFileSystem that emulates ISlangFileSystemExt from the ISlangFileSystem interface
         if (!fileSystemExt)
         {
             // Construct a wrapper to emulate the extended interface behavior

--- a/tests/preprocessor/file-identity/b.h
+++ b/tests/preprocessor/file-identity/b.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "c.h"
+
+#ifdef B_H
+#   error "Shouldn't be included twice"
+#endif
+
+#define B_H
+
+float foo(float x) { return x; }

--- a/tests/preprocessor/file-identity/c.h
+++ b/tests/preprocessor/file-identity/c.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "b.h"
+
+#ifdef C_H
+#   error "c.h shouldn't be included twice"
+#endif
+
+#define C_H
+
+float bar(float x) { return x; }

--- a/tests/preprocessor/file-identity/sub-folder/file-identity.slang
+++ b/tests/preprocessor/file-identity/sub-folder/file-identity.slang
@@ -1,4 +1,6 @@
 //TEST(smoke):SIMPLE:
+//TEST(smoke):SIMPLE: -file-system load-file
+
 
 #include "../b.h"
 #include "../c.h"

--- a/tests/preprocessor/file-identity/sub-folder/file-identity.slang
+++ b/tests/preprocessor/file-identity/sub-folder/file-identity.slang
@@ -1,0 +1,11 @@
+//TEST(smoke):SIMPLE:
+
+#include "../b.h"
+#include "../c.h"
+
+#include "./../b.h"
+
+float test(float x)
+{
+	return foo(x) + bar(x);
+}

--- a/tests/preprocessor/pragma-once.slang
+++ b/tests/preprocessor/pragma-once.slang
@@ -1,4 +1,5 @@
 //TEST(smoke):SIMPLE:
+//TEST(smoke):SIMPLE: -file-system load-file
 
 // Test support for `#pragma once`
 


### PR DESCRIPTION
This adds a new test file-identity-test.slang that aims to explore #pragma once file identity. In part it is different in that files are relative by being in parent directories. 

There is another issue that the changed tests address. That by default slang handles includes (unless the include handler is replaced) with the OSFileSystem (now OSFileSystemExt). That this implements the ISlangFileSystemExt interface - so it owns the responsibility for uniquely identifying files, and that implementation uses canonical paths.

Clients may not want to implement the ISlangFileSystemExt interface - and that's fine and they can just implement ISlangFileSystem. If they do this, internally slang will wrap CachedFileSystem around it which *does* implement the ISlangFileSystemExt interface. 

The emulation of ISlangFileSystemExt on top of a user supplied ISlangFileSystem was not tested in the test harness. So the other change is to add the -file-system command line option to slangc. It only has two options 'default' and 'file-only'. Default uses the default behavior. 'load-file' makes it use an implementation of the ISlangFileSystem interface, and so uses ISlangFileSystemExt emulation. 

The pragma once tests now also include a test using 'load-file'.

Finally it was found if you execute `slangc -` you get a seg fault. The problem here was that some of the options parsing assuming that there are > 1 characters which isn't necessarily the case. 
