### PR TITLE
Fix bug with HostCallable not returning SharedLibrary correctly

### DIFF
--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -1546,6 +1546,8 @@ SlangResult dissassembleDXILUsingDXC(
             RefPtr<TemporarySharedLibrary> sharedLib(new TemporarySharedLibrary(handle, moduleFilePath));
             sharedLib->m_temporaryFileSet = productFileSet;
             productFileSet.clear();
+
+            outSharedLib = sharedLib;
         }
         else
         {


### PR DESCRIPTION
Fix bug where in emitCPUBinaryForEntryPoint for HostCallable doesn't correctly return the created SharedLibrary.