### PR TITLE
Added 'os' file-system testing

### DIFF
--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -816,7 +816,13 @@ struct OptionsParser
                     }
                     else if (name == "load-file")
                     {
+                        // OSFileSystem just implements loadFile interface, so will be wrapped with CacheFileSystem internally
                         spSetFileSystem(compileRequest, OSFileSystem::getSingleton());
+                    }
+                    else if (name == "os")
+                    {
+                        // OSFileSystemExt implements the ISlangFileSystemExt interface - and will be used directly
+                        spSetFileSystem(compileRequest, OSFileSystemExt::getSingleton());
                     }
                     else
                     {

--- a/tests/preprocessor/file-identity/sub-folder/file-identity.slang
+++ b/tests/preprocessor/file-identity/sub-folder/file-identity.slang
@@ -1,6 +1,6 @@
 //TEST(smoke):SIMPLE:
 //TEST(smoke):SIMPLE: -file-system load-file
-
+//TEST(smoke):SIMPLE: -file-system os
 
 #include "../b.h"
 #include "../c.h"

--- a/tests/preprocessor/pragma-once.slang
+++ b/tests/preprocessor/pragma-once.slang
@@ -1,5 +1,6 @@
 //TEST(smoke):SIMPLE:
 //TEST(smoke):SIMPLE: -file-system load-file
+//TEST(smoke):SIMPLE: -file-system os
 
 // Test support for `#pragma once`
 


### PR DESCRIPTION
Internally slang uses the ISlangFileSystemExt interface. In typical usage this either uses the default configuration or a user supplied ISlangFileSystem. 

In default configuration ISlangFileSystemExt is *actually* CachedFileSystem, wrapping a OsFileSystemExt. When a user supplied ISlangFileSystem is used it is again wrapped in CachedFileSystem (say with using the `-file-system read-file`. 

So to test the interface and use another implementation other than CachedFileSystem the option `-file-system os` is added and tested on some #pragma include tests.