### PR TITLE
Support shifts and a few other ops in front-end constant folding

### DIFF
--- a/source/slang/slang-check.cpp
+++ b/source/slang/slang-check.cpp
@@ -5359,6 +5359,11 @@ namespace Slang
 
             CASE(+); // TODO: this can also be unary...
             CASE(*);
+            CASE(<<);
+            CASE(>>);
+            CASE(&);
+            CASE(|);
+            CASE(^);
 #undef CASE
 
             // binary operators with chance of divide-by-zero

--- a/tests/compute/enum.slang
+++ b/tests/compute/enum.slang
@@ -7,7 +7,7 @@
 enum Color
 {
     Red,
-    Green = 2,
+    Green = (1 << 1),
     Blue,
 }
 


### PR DESCRIPTION
The set of supported operations in front-end constant folding was very limited: `+`, `-`, `*`, `/`, and `%`.
This meant that enum declarations like:

```
enum MyBits
{
    A = 1 << 0,
    B = 1 << 1,
    C = A | C,
}
```

would fail to compile, with a claim that the expressions like `1 << 0` aren't compile-time constants.

This change adds `<<`, `>>`, `&`, `|`, and `^` to the list of integer operations we will cosntant-fold in the front-end. It also changes one of the declarations in the existing test case for `enum`s to use the added functionality.

Note that this change does *not* address the more deep-seated problems with our approach to constant-folding in the front-end. It does not change the constant folding to rely on IR machinery, or to allow for more general `constexpr` functions, and it does not address the fact that constant-folding is currently applied without paying attention to the type (and thus precision) of the original expression.