### PR TITLE
CPU uniform entry point params

### DIFF
--- a/docs/cpu-target.md
+++ b/docs/cpu-target.md
@@ -242,6 +242,7 @@ TODO
 * Complete support (in terms of interfaces) for 'complex' resource types - such as Texture
 * Parameter block support (the difficulty is around layout)
 * Output of header files 
+* Output multiple entry points
 
 # Internal Slang compiler features
 

--- a/docs/cpu-target.md
+++ b/docs/cpu-target.md
@@ -241,8 +241,6 @@ TODO
 
 * Complete support (in terms of interfaces) for 'complex' resource types - such as Texture
 * Parameter block support (the difficulty is around layout)
-* Split out entry point uniforms into a separate pointer passed to the entry point
-* Improve documentation
 * Output of header files 
 
 # Internal Slang compiler features

--- a/docs/cpu-target.md
+++ b/docs/cpu-target.md
@@ -94,6 +94,8 @@ struct Thing { int a; int b; }
 
 Texture2D<float> tex;
 SamplerState sampler;
+RWStructuredBuffer<int> outputBuffer;        
+ConstantBuffer<Thing> thing3;        
         
 [numthreads(4, 1, 1)]
 void computeMain(
@@ -108,13 +110,13 @@ void computeMain(
 When compiled into a shared library/dll - how is it invoked? The entry point is exported with a signiture 
 
 ```
-void computeMain(ComputeVaryingInput* varyingInput, UniformState* uniformState);
+void computeMain(ComputeVaryingInput* varyingInput, UniformEntryPointParams* uniformParams, UniformState* uniformState);
 ```
 
-The UniformState struct typically varies by shader, and holds all of the bindings. Where these are located can be determined by reflection. For example 
+The UniformState and UniformEntryPointParams struct typically vary by shader. UniformState holds 'normal' bindings, whereas UniformEntryPointParams hold the uniform entry point parameters. Where specific bindings or parameters are located can be determined by reflection. The structures for the example above would be something like the following... 
 
 ```
-struct _S1
+struct UniformEntryPointParams
 {
     Thing thing;
     Thing thing2;
@@ -122,15 +124,14 @@ struct _S1
 
 struct UniformState
 {
-    Thing* thing3;
-    RWStructuredBuffer<int32_t> outputBuffer;
     Texture2D<float > tex;
     SamplerState sampler;
-    _S1* _S2;
+    RWStructuredBuffer<int32_t> outputBuffer;
+    Thing* thing3;
 };   
 ```
 
-The code that sets up the prelude for the test infrastucture and command line usage can be found in ```TestToolUtil::setSessionDefaultPrelude```.
+Notice that of the entry point parameters `dispatchThreadID` is not part of UniformEntryPointParams and this is because it is not uniform.
 
 ConstantBuffers will become pointers to the type they hold (as `thing3` is in the above structure).
  
@@ -143,9 +144,7 @@ StructuredBuffer/RWStructuredBuffer/ByteAddressBuffer/RWByteAddressBuffer become
 
 Resource types become pointers to interfaces that implement their features. For example `Texture2D` become a pointer to a `ITexture2D` interface that has to be implemented in client side code. Similarly SamplerState and SamplerComparisonState become `ISamplerState` and `ISamplerComparisonState`.  
 
-The `_S1` struct in the example above (which may have different names) is actually a struct that holds all of the entry point uniforms if there are any, in this case
-
-Note that the this pointer is not directly reflected (although layout of uniform paramters in the struct are). Currently this pointer is just placed after all the other reflected bindings.  
+The code that sets up the prelude for the test infrastucture and command line usage can be found in ```TestToolUtil::setSessionDefaultPrelude```.
 
 ## Prelude
 

--- a/prelude/slang-cpp-types.h
+++ b/prelude/slang-cpp-types.h
@@ -232,8 +232,9 @@ struct ComputeVaryingInput
     uint3 groupThreadID;
 };
 
-/* Actual content of this type is dependent on the entry point parameters */
-struct EntryPointParams;
+/* Type that defines the uniform entry point params. The actual content of this type is dependent on the entry point parameters, and can be
+found via reflection or defined such that it matches the shader appropriately. */
+struct UniformEntryPointParams;
 
 #ifdef SLANG_PRELUDE_NAMESPACE
 }

--- a/prelude/slang-cpp-types.h
+++ b/prelude/slang-cpp-types.h
@@ -232,6 +232,9 @@ struct ComputeVaryingInput
     uint3 groupThreadID;
 };
 
+/* Actual content of this type is dependent on the entry point parameters */
+struct EntryPointParams;
+
 #ifdef SLANG_PRELUDE_NAMESPACE
 }
 #endif

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -2607,7 +2607,7 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
                 emitEntryPointAttributes(func, entryPointLayout);
                 emitType(resultType, name);
 
-                m_writer->emit("(ComputeVaryingInput* varyingInput, EntryPointParams* params, UniformState* uniformState)\n{\n");
+                m_writer->emit("(ComputeVaryingInput* varyingInput, UniformEntryPointParams* params, UniformState* uniformState)\n{\n");
                 emitSemantics(func);
 
                 m_writer->indent();

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -2358,24 +2358,38 @@ void CPPSourceEmitter::emitOperandImpl(IRInst* inst, EmitOpInfo const&  outerPre
     {
         case 0: // nothing yet
         case kIROp_GlobalParam:
-        {
-            // It's in UniformState
+        {            
             String name = getName(inst);
-            m_writer->emit("(");
-            switch (inst->getDataType()->op)
+
+            if (inst->findDecorationImpl(kIROp_EntryPointDecoration))
             {
-                case kIROp_ParameterBlockType:
-                case kIROp_ConstantBufferType:
-                case kIROp_StructType:
-                {
-                    m_writer->emit("*");
-                    break;
-                }
-                default: break;
+                // It's an entry point parameter
+                // The parameter is held in a struct so always deref
+                m_writer->emit("(*");
+                m_writer->emit(name);
+                m_writer->emit(")");
             }
-            m_writer->emit("uniformState->");
-            m_writer->emit(name);
-            m_writer->emit(")");
+            else
+            {
+                // It's in UniformState
+                m_writer->emit("(");
+
+                switch (inst->getDataType()->op)
+                {
+                    case kIROp_ParameterBlockType:
+                    case kIROp_ConstantBufferType:
+                    case kIROp_StructType:
+                    {
+                        m_writer->emit("*");
+                        break;
+                    }
+                    default: break;
+                }
+
+                m_writer->emit("uniformState->");
+                m_writer->emit(name);
+                m_writer->emit(")");
+            }
             break;
         }
         case kIROp_Param:
@@ -2476,6 +2490,8 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
         }
     }
 
+    IRGlobalParam* entryPointGlobalParams = nullptr;
+
     // Output the global parameters in a 'UniformState' structure
     {
         m_writer->emit("struct UniformState\n{\n");
@@ -2487,6 +2503,16 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
         {
             if (action.level == EmitAction::Level::Definition && action.inst->op == kIROp_GlobalParam)
             {
+                auto inst = action.inst;
+
+                if (inst->findDecorationImpl(kIROp_EntryPointDecoration))
+                {
+                    // Should only be one instruction marked this way
+                    SLANG_ASSERT(entryPointGlobalParams == nullptr);
+                    entryPointGlobalParams = as<IRGlobalParam>(inst);
+                    continue;
+                }
+
                 VarLayout* varLayout = CLikeSourceEmitter::getVarLayout(action.inst);
                 SLANG_ASSERT(varLayout);
                 const VarLayout::ResourceInfo* varInfo = varLayout->FindResourceInfo(LayoutResourceKind::Uniform);
@@ -2536,6 +2562,11 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
         m_writer->emit("ComputeVaryingInput varyingInput;\n");
         m_writer->emit("uint3 dispatchThreadID;\n");
 
+        if (entryPointGlobalParams)
+        {
+            emitGlobalInst(entryPointGlobalParams);
+        }
+
         // Output all the thread locals 
         for (auto action : actions)
         {
@@ -2576,7 +2607,7 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
                 emitEntryPointAttributes(func, entryPointLayout);
                 emitType(resultType, name);
 
-                m_writer->emit("(ComputeVaryingInput* varyingInput, UniformState* uniformState)\n{\n");
+                m_writer->emit("(ComputeVaryingInput* varyingInput, EntryPointParams* params, UniformState* uniformState)\n{\n");
                 emitSemantics(func);
 
                 m_writer->indent();
@@ -2585,6 +2616,20 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
                 m_writer->emit("context.uniformState = uniformState;\n");
                 m_writer->emit("context.varyingInput = *varyingInput;\n");
 
+                if (entryPointGlobalParams)
+                {
+                    auto varDecl = entryPointGlobalParams;
+                    auto rawType = varDecl->getDataType();
+
+                    auto varType = rawType;
+
+                    m_writer->emit("context.");
+                    m_writer->emit(getName(varDecl));
+                    m_writer->emit(" =  (");
+                    emitType(varType);
+                    m_writer->emit("*)params; \n");
+                }
+                
                 // Emit dispatchThreadID
                 if (entryPointLayout->profile.GetStage() == Stage::Compute)
                 {

--- a/source/slang/slang-ir-entry-point-uniforms.cpp
+++ b/source/slang/slang-ir-entry-point-uniforms.cpp
@@ -248,6 +248,9 @@ struct MoveEntryPointUniformParametersToGlobalScope
                     // an instance of `paramStructType`.
                     //
                     globalParam = builder->createGlobalParam(paramStructType);
+
+                    // Mark that this global comes from the entry point
+                    builder->addEntryPointDecoration(globalParam);
                 }
 
                 // No matter what, the global shader parameter should have the layout

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -403,6 +403,7 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     INST(PatchConstantFuncDecoration,       patchConstantFunc,      1, 0)
 
         /// An `[entryPoint]` decoration marks a function that represents a shader entry point.
+        /// Also used in some scenarios mark parameters that are moved from entry point parameters to global params as coming from the entry point.
     INST(EntryPointDecoration,              entryPoint,             0, 0)
 
         /// A `[dependsOn(x)]` decoration indicates that the parent instruction depends on `x`

--- a/tests/compute/entry-point-uniform-params.slang
+++ b/tests/compute/entry-point-uniform-params.slang
@@ -3,6 +3,8 @@
 // Confirm that `uniform` parameters on
 // entry points are allowed, and work as expected.
 
+//DISABLE_TEST:CPU_REFLECTION: -profile cs_5_0 -entry computeMain -target cpp 
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
@@ -25,16 +27,17 @@ struct Things
 // A shader parameter at global scope should be assigned
 // a register/binding before any related to the entry point.
 
-//TEST_INPUT:cbuffer(data=[1 0 0 0]):dxbinding(0),glbinding(0)
+//TEST_INPUT:cbuffer(data=[1 0 0 0]):dxbinding(0),glbinding(0),name=signs
 ConstantBuffer<Signs> signs;
 
 [numthreads(4, 1, 1)]
 void computeMain(
-//TEST_INPUT:cbuffer(data=[2 0 0 0 3 0 0 0]):dxbinding(1),glbinding(1)
+//TEST_INPUT:cbuffer(data=[2 0 0 0 3 0 0 0]):dxbinding(1),glbinding(1),name=stuff
 	uniform Stuff  stuff,
+//TEST_INPUT:cbuffer(data=[3]):,isCPUOnly,name=things    
 	uniform Things things,
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(2),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(2),out,name=outputBuffer
 	uniform RWStructuredBuffer<int> outputBuffer,
 
 	uint3 dispatchThreadID : SV_DispatchThreadID)

--- a/tools/render-test/cpu-memory-binding.cpp
+++ b/tools/render-test/cpu-memory-binding.cpp
@@ -70,11 +70,12 @@ SlangResult CPUMemoryBinding::init(slang::ShaderReflection* reflection, int entr
         }
         SLANG_ASSERT(rootSizeInBytes == globalConstantBuffer);
 
-        // Allocate the root (0 is the root)
-        m_rootBuffer = _allocateBuffer(rootSizeInBytes);
-
-        // Create default empty constant buffers
+        if (rootSizeInBytes)
         {
+            // Allocate the 'root' buffer
+            m_rootBuffer = _allocateBuffer(rootSizeInBytes);
+
+            // Create default empty constant buffers
             uint8_t*const buffer = m_rootBuffer.m_data;
             for (int i = 0; i < parameterCount; ++i)
             {
@@ -119,9 +120,10 @@ SlangResult CPUMemoryBinding::init(slang::ShaderReflection* reflection, int entr
             entryPointParamsSizeInBytes = (endOffset > entryPointParamsSizeInBytes) ? endOffset : entryPointParamsSizeInBytes; 
         }
 
-        m_entryPointBuffer = _allocateBuffer(entryPointParamsSizeInBytes);
-
+        if (entryPointParamsSizeInBytes)
         {
+            m_entryPointBuffer = _allocateBuffer(entryPointParamsSizeInBytes);
+
             uint8_t*const buffer = m_entryPointBuffer.m_data;
             for (int i = 0; i < parameterCount; ++i)
             {

--- a/tools/render-test/cpu-memory-binding.cpp
+++ b/tools/render-test/cpu-memory-binding.cpp
@@ -42,46 +42,102 @@ CPUMemoryBinding::Buffer CPUMemoryBinding::_allocateBuffer(size_t size, const vo
     return buffer;
 }
 
-SlangResult CPUMemoryBinding::init(slang::ShaderReflection* reflection)
+SlangResult CPUMemoryBinding::init(slang::ShaderReflection* reflection, int entryPointIndex)
 {
     m_reflection = reflection;
     m_rootBuffer = Buffer();
 
     m_allBuffers.clear();
     m_arena.deallocateAll();
-
-    size_t globalConstantBuffer = reflection->getGlobalConstantBufferSize();
-
-    size_t rootSizeInBytes = 0;
-    const int parameterCount = reflection->getParameterCount();
-    for (int i = 0; i < parameterCount; ++i)
+    
     {
-        auto parameter = reflection->getParameterByIndex(i);
+        size_t globalConstantBuffer = reflection->getGlobalConstantBufferSize();
 
-        auto offset = parameter->getOffset();
-
-        auto typeLayout = parameter->getTypeLayout();
-        auto sizeInBytes = typeLayout->getSize();
-
-        size_t endOffset = offset + sizeInBytes;
-
-        rootSizeInBytes = (endOffset > rootSizeInBytes) ? endOffset : rootSizeInBytes;        
-    }
-    SLANG_ASSERT(rootSizeInBytes == globalConstantBuffer);
-
-    // Allocate the root (0 is the root)
-    m_rootBuffer = _allocateBuffer(rootSizeInBytes);
-
-    {
-        uint8_t*const buffer = m_rootBuffer.m_data;
+        size_t rootSizeInBytes = 0;
+        const int parameterCount = reflection->getParameterCount();
         for (int i = 0; i < parameterCount; ++i)
         {
             auto parameter = reflection->getParameterByIndex(i);
+
             auto offset = parameter->getOffset();
 
             auto typeLayout = parameter->getTypeLayout();
-            Buffer paramBuffer;
-            SLANG_RETURN_ON_FAIL(_add(parameter, typeLayout, buffer + offset, paramBuffer));
+            auto sizeInBytes = typeLayout->getSize();
+
+            size_t endOffset = offset + sizeInBytes;
+
+            rootSizeInBytes = (endOffset > rootSizeInBytes) ? endOffset : rootSizeInBytes;        
+        }
+        SLANG_ASSERT(rootSizeInBytes == globalConstantBuffer);
+
+        // Allocate the root (0 is the root)
+        m_rootBuffer = _allocateBuffer(rootSizeInBytes);
+
+        // Create default empty constant buffers
+        {
+            uint8_t*const buffer = m_rootBuffer.m_data;
+            for (int i = 0; i < parameterCount; ++i)
+            {
+                auto parameter = reflection->getParameterByIndex(i);
+                auto offset = parameter->getOffset();
+
+                auto typeLayout = parameter->getTypeLayout();
+                Buffer paramBuffer;
+                SLANG_RETURN_ON_FAIL(_add(parameter, typeLayout, buffer + offset, paramBuffer));
+            }
+        }
+    }
+
+    {
+        auto entryPointCount = reflection->getEntryPointCount();
+        if (entryPointIndex < 0 || entryPointIndex >= entryPointCount)
+        {
+            SLANG_ASSERT(!"Entry point index out of range");
+            return SLANG_FAIL;
+        }
+        
+        m_entryPoint = reflection->getEntryPointByIndex(entryPointIndex);
+        size_t entryPointParamsSizeInBytes = 0;
+
+        const int parameterCount = int(m_entryPoint->getParameterCount());
+        for (int i = 0 ; i < parameterCount; i++)
+        {
+            slang::VariableLayoutReflection* parameter = m_entryPoint->getParameterByIndex(i);
+
+            // If has a semantic, then isn't uniform parameter
+            if (auto semanticName = parameter->getSemanticName())
+            {
+                continue;
+            }
+
+            auto offset = parameter->getOffset();
+
+            auto typeLayout = parameter->getTypeLayout();
+            auto sizeInBytes = typeLayout->getSize();
+
+            size_t endOffset = offset + sizeInBytes;
+            entryPointParamsSizeInBytes = (endOffset > entryPointParamsSizeInBytes) ? endOffset : entryPointParamsSizeInBytes; 
+        }
+
+        m_entryPointBuffer = _allocateBuffer(entryPointParamsSizeInBytes);
+
+        {
+            uint8_t*const buffer = m_entryPointBuffer.m_data;
+            for (int i = 0; i < parameterCount; ++i)
+            {
+                auto parameter = m_entryPoint->getParameterByIndex(i);
+                // If has a semantic, then isn't uniform parameter
+                if (auto semanticName = parameter->getSemanticName())
+                {
+                    continue;
+                }
+
+                auto offset = parameter->getOffset();
+
+                auto typeLayout = parameter->getTypeLayout();
+                Buffer paramBuffer;
+                SLANG_RETURN_ON_FAIL(_add(parameter, typeLayout, buffer + offset, paramBuffer));
+            }
         }
     }
 
@@ -158,17 +214,42 @@ slang::VariableLayoutReflection* CPUMemoryBinding::getParameterByName(const char
             return parameter;
         }
     }
+    
     return nullptr;
+}
+
+slang::VariableLayoutReflection* CPUMemoryBinding::getEntryPointParameterByName(const char* name)
+{
+    const int parameterCount = int(m_entryPoint->getParameterCount());
+    for (int i = 0; i < parameterCount; ++i)
+    {
+        auto parameter = m_entryPoint->getParameterByIndex(i);
+        // If has a semantic we will ignore
+        if (parameter->getSemanticName())
+        {
+            continue;
+        }
+        if (strcmp(parameter->getName(), name) == 0)
+        {
+            return parameter;
+        }
+    }
+    return nullptr;   
 }
 
 CPUMemoryBinding::Location CPUMemoryBinding::find(const char* name)
 {
     auto varLayout = getParameterByName(name);
-    if (varLayout == nullptr)
+    if (varLayout)
     {
-        return Location();
+        return Location::make(varLayout->getTypeLayout(), m_rootBuffer.m_data + varLayout->getOffset());
     }
-    return Location::make(varLayout->getTypeLayout(), m_rootBuffer.m_data + varLayout->getOffset());
+    varLayout = getEntryPointParameterByName(name);
+    if (varLayout)
+    {
+        return Location::make(varLayout->getTypeLayout(), m_entryPointBuffer.m_data + varLayout->getOffset());
+    }
+    return Location();
 }
 
 CPUMemoryBinding::Location CPUMemoryBinding::Location::toField(const char* name) const

--- a/tools/render-test/cpu-memory-binding.h
+++ b/tools/render-test/cpu-memory-binding.h
@@ -43,6 +43,8 @@ struct CPUMemoryBinding
     };
     
     slang::VariableLayoutReflection* getParameterByName(const char* name);
+    slang::VariableLayoutReflection* getEntryPointParameterByName(const char* name);
+
 
     Location find(const char* name);
 
@@ -50,7 +52,7 @@ struct CPUMemoryBinding
     SlangResult setNewBuffer(const Location& location, const void* initialData, size_t sizeInBytes, Buffer& outBuffer);
     SlangResult setObject(const Location& location, void* object);
     SlangResult setInplace(const Location& location, const void* data, size_t sizeInBytes);
-    SlangResult init(slang::ShaderReflection* reflection);
+    SlangResult init(slang::ShaderReflection* reflection, int entryPointIndex);
     CPUMemoryBinding();
 
     Buffer _allocateBuffer(size_t size);
@@ -61,11 +63,15 @@ struct CPUMemoryBinding
     Slang::MemoryArena m_arena;    ///< Storage for buffers
 
     Buffer m_rootBuffer;
+    Buffer m_entryPointBuffer;
 
     slang::ShaderReflection* m_reflection;
     
     // All buffers
     Slang::List<Buffer> m_allBuffers;
+
+    slang::EntryPointReflection* m_entryPoint;
+    int m_entryPointIndex;
 };
 
 } // renderer_test

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -421,7 +421,7 @@ static SlangResult _doCPUCompute(SlangSession* session, const String& sourcePath
     auto request = output.compileOutput.request;
 
     struct UniformState;
-    typedef void(*Func)(CPPPrelude::ComputeVaryingInput* varyingInput, CPPPrelude::EntryPointParams* params, UniformState* uniformState);
+    typedef void(*Func)(CPPPrelude::ComputeVaryingInput* varyingInput, CPPPrelude::UniformEntryPointParams* params, UniformState* uniformState);
 
     auto reflection = (slang::ShaderReflection*) spGetReflection(request);
 
@@ -646,7 +646,7 @@ static SlangResult _doCPUCompute(SlangSession* session, const String& sourcePath
 
     {
         UniformState* uniformState = (UniformState*)binding.m_rootBuffer.m_data;
-        CPPPrelude::EntryPointParams* params = (CPPPrelude::EntryPointParams*)binding.m_entryPointBuffer.m_data;
+        CPPPrelude::UniformEntryPointParams* params = (CPPPrelude::UniformEntryPointParams*)binding.m_entryPointBuffer.m_data;
 
         CPPPrelude::ComputeVaryingInput varying;
         varying.groupID = {};

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -294,6 +294,7 @@ static SlangResult _compile(SlangSession* session, const String& sourcePath, Opt
 
     // Parse the layout
     layout.parse(sourceText.getBuffer());
+    layout.updateForTarget(input.target);
 
     // Setup SourceInfo
     ShaderCompileRequest::SourceInfo sourceInfo;
@@ -420,7 +421,7 @@ static SlangResult _doCPUCompute(SlangSession* session, const String& sourcePath
     auto request = output.compileOutput.request;
 
     struct UniformState;
-    typedef void(*Func)(CPPPrelude::ComputeVaryingInput* varyingInput, UniformState* uniformState);
+    typedef void(*Func)(CPPPrelude::ComputeVaryingInput* varyingInput, CPPPrelude::EntryPointParams* params, UniformState* uniformState);
 
     auto reflection = (slang::ShaderReflection*) spGetReflection(request);
 
@@ -442,7 +443,7 @@ static SlangResult _doCPUCompute(SlangSession* session, const String& sourcePath
     }
 
     CPUMemoryBinding binding;
-    binding.init(reflection);
+    SLANG_RETURN_ON_FAIL(binding.init(reflection, 0));
 
     List<CPUMemoryBinding::Buffer> buffers;
 
@@ -645,6 +646,7 @@ static SlangResult _doCPUCompute(SlangSession* session, const String& sourcePath
 
     {
         UniformState* uniformState = (UniformState*)binding.m_rootBuffer.m_data;
+        CPPPrelude::EntryPointParams* params = (CPPPrelude::EntryPointParams*)binding.m_entryPointBuffer.m_data;
 
         CPPPrelude::ComputeVaryingInput varying;
         varying.groupID = {};
@@ -659,7 +661,7 @@ static SlangResult _doCPUCompute(SlangSession* session, const String& sourcePath
                 {
                     varying.groupThreadID.x = x;
 
-                    func(&varying, uniformState);
+                    func(&varying, params, uniformState);
                 }
             }
         }

--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -22,6 +22,40 @@ namespace renderer_test
         return -1;
     }
 
+    static bool _isCPUTarget(SlangCompileTarget target)
+    {
+        switch (target)
+        {
+            case SLANG_C_SOURCE:
+            case SLANG_CPP_SOURCE:
+            case SLANG_EXECUTABLE:
+            case SLANG_SHARED_LIBRARY:
+            case SLANG_HOST_CALLABLE:
+            {
+                return true;
+            }
+            default: return false;
+        }
+    }
+
+    void ShaderInputLayout::updateForTarget(SlangCompileTarget target)
+    {
+        if (!_isCPUTarget(target))
+        {
+            int count = int(entries.getCount());
+            for (int i = 0; i < count; ++i)
+            {
+                auto& entry = entries[i];
+                if (entry.isCPUOnly)
+                {
+                    entries.removeAt(i);
+                    i--;
+                    count--;
+                }
+            }
+        }
+    }
+
     void ShaderInputLayout::parse(const char * source)
     {
         entries.clear();
@@ -257,7 +291,12 @@ namespace renderer_test
                             parser.Read(":");
                             while (!parser.IsEnd())
                             {
-                                if (parser.LookAhead("dxbinding"))
+                                if (parser.LookAhead("isCPUOnly"))
+                                {
+                                    entry.isCPUOnly = true;
+                                    parser.ReadToken();
+                                }
+                                else if (parser.LookAhead("dxbinding"))
                                 {
                                     parser.ReadToken();
                                     parser.Read("(");

--- a/tools/render-test/shader-input-layout.h
+++ b/tools/render-test/shader-input-layout.h
@@ -59,6 +59,7 @@ public:
     InputBufferDesc bufferDesc;
     InputSamplerDesc samplerDesc;
     bool isOutput = false;
+    bool isCPUOnly = false;
     int hlslBinding = -1;
     Slang::List<int> glslBinding;
 
@@ -85,7 +86,9 @@ public:
 
     Slang::Index findEntryIndexByName(const Slang::String& name) const;
 
-    void parse(const char * source);
+    void updateForTarget(SlangCompileTarget target);
+
+    void parse(const char* source);
 };
 
 void generateTextureDataRGB8(TextureData& output, const InputTextureDesc& desc);

--- a/tools/render-test/shader-renderer-util.cpp
+++ b/tools/render-test/shader-renderer-util.cpp
@@ -223,6 +223,7 @@ static RefPtr<SamplerState> _createSamplerState(
     for (Index i = 0; i < numEntries; i++)
     {
         const ShaderInputLayoutEntry& srcEntry = srcEntries[i];
+        SLANG_ASSERT(srcEntry.isCPUOnly == false);
 
         const BindingStateImpl::RegisterRange registerSet = calcRegisterRange(renderer, srcEntry);
         if (!registerSet.isValid())

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1162,7 +1162,7 @@ TestResult runCPUExecuteTest(TestContext* context, TestInput& input)
             CPPPrelude::RWStructuredBuffer<int> buffer;
         };
         
-        typedef void (*Func)(CPPPrelude::ComputeVaryingInput* varyingInput, UniformState* uniformState);
+        typedef void (*Func)(CPPPrelude::ComputeVaryingInput* varyingInput, CPPPrelude::EntryPointParams* params, UniformState* uniformState);
 
         Func runFunc = Func(func);
         int32_t data[4] = { 0, 0, 0, 0};
@@ -1175,7 +1175,7 @@ TestResult runCPUExecuteTest(TestContext* context, TestInput& input)
         for (Int i = 0; i < 4; ++i)
         {
             varyingInput.groupThreadID.x = uint32_t(i);
-            runFunc(&varyingInput, &state);
+            runFunc(&varyingInput, nullptr, &state);
         }
 
         SharedLibrary::unload(sharedLibrary);

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1162,7 +1162,7 @@ TestResult runCPUExecuteTest(TestContext* context, TestInput& input)
             CPPPrelude::RWStructuredBuffer<int> buffer;
         };
         
-        typedef void (*Func)(CPPPrelude::ComputeVaryingInput* varyingInput, CPPPrelude::EntryPointParams* params, UniformState* uniformState);
+        typedef void (*Func)(CPPPrelude::ComputeVaryingInput* varyingInput, CPPPrelude::UniformEntryPointParams* params, UniformState* uniformState);
 
         Func runFunc = Func(func);
         int32_t data[4] = { 0, 0, 0, 0};


### PR DESCRIPTION
* Uniform entry point params become separate parameter on CPU ABI
* Added isCPUOnly to binding information - explained below
* Update documentation to reflect ABI change
* entry-point-uniform-params.slang works

The main effort here was to make the CPU work more simply for uniform entry point params. This was achieved in part by making the uniform entry point params a separate parameter to the ABI function. This is also means that the reflection is more directly relevant, and there is no hidden knowledge that those parameters are just pointed to by a pointer at the end of the UnformState structure.

The change was achieved by marking global parameters that are created/moved from the entry point with the 'EntryPointDecoration'. Then in the c++ emit this information can be used to determine how to specially emit. 

One fly in the ointment of making this work is that the test infrastructure assumes that non resource entry point params are just all combined into a single 'constant buffer'. That resources and non resources can be combined into the structure. Moreover that the layout of that structure will be CPU like not GPU like. So for example 

``` 
struct A { int a; }
struct B { int b; }
//TEST_INPUT:cbuffer(data=[2 0 0 0 3 0 0 0]):dxbinding(1),glbinding(1)
	uniform A a,  
	uniform B b,
```

Is a problem - because the data assumes a and b are inserted into a constant buffer, and that b will start on the next 16 byte alignment. This isn't true on CPU, to work around this the 'isCPUOnly' parameter is added...

```
//TEST_INPUT:cbuffer(data=[2 0 0 0 3 0 0 0]):dxbinding(1),glbinding(1),name=a
	uniform A a,  
//TEST_INPUT:cbuffer(data=[3]):,isCPUOnly,name=b
	uniform B b,
```

That on GPU targets, the second binding is ignored. On CPU targets, the b binding will be found and set to the data.

Note that somewhat clumsily we have 3 defined twice, and both entries are listed as 'cbuffer' on CPU which they aren't and so perhaps a better mechanism should be used in the future. Also note that only 2 (not 0 0 0 3 etc) will be written into a, because on CPU targets the data is copied such that any extra stuff is ignored. 