### PR TITLE
Allow multiple threads to call glslang

### DIFF
--- a/source/slang-glslang/slang-glslang.cpp
+++ b/source/slang-glslang/slang-glslang.cpp
@@ -228,8 +228,6 @@ public:
     bool m_isInitialized = false;
 };
 
-static ProcessInitializer s_processInitializer;
-
 extern "C"
 #ifdef _MSC_VER
 _declspec(dllexport)
@@ -238,7 +236,8 @@ __attribute__((__visibility__("default")))
 #endif
 int glslang_compile(glslang_CompileRequest* request)
 {
-    if (!s_processInitializer.init())
+    static ProcessInitializer g_processInitializer;
+    if (!g_processInitializer.init())
     {
         // Failed
         return 1;

--- a/source/slang-glslang/slang-glslang.cpp
+++ b/source/slang-glslang/slang-glslang.cpp
@@ -12,7 +12,7 @@
 #include "SPIRV/doc.h"
 #include "SPIRV/disassemble.h"
 
-#include "OGLCompilersDll/InitializeDll.h"
+#include "OGLCompilersDLL/InitializeDll.h"
 
 #include "../../slang.h"
 

--- a/source/slang-glslang/slang-glslang.cpp
+++ b/source/slang-glslang/slang-glslang.cpp
@@ -12,6 +12,8 @@
 #include "SPIRV/doc.h"
 #include "SPIRV/disassemble.h"
 
+#include "OGLCompilersDll/InitializeDll.h"
+
 #include "../../slang.h"
 
 #if 0
@@ -190,6 +192,44 @@ static int glslang_dissassembleSPIRV(glslang_CompileRequest* request)
     return 0;
 }
 
+// We need a per process initialization
+class ProcessInitializer
+{
+public:
+    ProcessInitializer()
+    {
+        m_isInitialized = false;
+    }
+
+    bool init()
+    {
+        std::lock_guard<std::mutex> guard(m_mutex);
+        if (!m_isInitialized)
+        {
+            if (!glslang::InitializeProcess())
+            {
+                return false;
+            }
+            m_isInitialized = true;
+        }
+        return true;
+    }
+
+    ~ProcessInitializer()
+    {
+        // We *assume* will only be called once dll is detatched and that will be on a single thread
+        if (m_isInitialized)
+        {
+            glslang::FinalizeProcess();
+        }
+    }
+
+    std::mutex m_mutex;
+    bool m_isInitialized = false;
+};
+
+static ProcessInitializer s_processInitializer;
+
 extern "C"
 #ifdef _MSC_VER
 _declspec(dllexport)
@@ -198,7 +238,16 @@ __attribute__((__visibility__("default")))
 #endif
 int glslang_compile(glslang_CompileRequest* request)
 {
-    glslang::InitializeProcess();
+    if (!s_processInitializer.init())
+    {
+        // Failed
+        return 1;
+    }
+    if (!glslang::InitThread())
+    {
+        // Failed
+        return 1;
+    }
 
     int result = 0;
     switch(request->action)
@@ -215,8 +264,6 @@ int glslang_compile(glslang_CompileRequest* request)
         result = glslang_dissassembleSPIRV(request);
         break;
     }
-
-    glslang::FinalizeProcess();
 
     return result;
 }


### PR DESCRIPTION
In our 'multi-thread' story if client code wants to execute multiple parallel compilations via slang, the advice is to make multiple SlangSessions one per thread. It probably also makes sense to have a pool of such sessions and have worker threads, reuse them. The reason for this is that there is a significant cost associated with creating a session as doing so compiles the slang stdlib. 

As it turns out though, if the target was spir-v slang would use glslang in order to compile the output glsl. Unfortunately it appears that doing so was not thread safe and would cause a crash. To fix this...

* Have a single call to glslang::InitializeProcess() 
* Explicitly call glslang::InitThread

In the glslang api it says that glslang::InitializeProcess()  should be called once per *process*. We were not doing this, and it was being called multiple times and potentially from multiple threads. This in turn would call int ShInitialize(). In here we have the comment 

```//
// ShInitialize() should be called exactly once per process, not per thread.
//
int ShInitialize()
{
    glslang::InitGlobalLock();

    if (! InitProcess())
        return 0;

    glslang::GetGlobalLock();
    ++NumberOfClients;
    glslang::ReleaseGlobalLock();

    if (PerProcessGPA == nullptr)
        PerProcessGPA = new TPoolAllocator();

    glslang::TScanContext::fillInKeywordMap();
#ifdef ENABLE_HLSL
    glslang::HlslScanContext::fillInKeywordMap();
#endif

    return 1;
}
```

At a minimum would create a race on PerProcessGPA and void TScanContext::fillInKeywordMap().

The call to `glslang::InitThread` sets up a thread local pool (using the global thread local index allocated from `glslang::InitializeProcess()`. Looking at the documentation around InitThread, also points out it's fine if the Thread is not explicitly released. 

The fix works (in terms of being per process), because the dll is loaded *once* per process and so with appropriate guarding `glslang::InitializeProcess` can be called once - even if many independent clients are using the same dll independently.  