### PR TITLE
Use d3dcompiler_47.dll from slang-binaries on windows.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "external/imgui"]
 	path = external/imgui
 	url = https://github.com/ocornut/imgui.git
+[submodule "external/slang-binaries"]
+	path = external/slang-binaries
+	url = http://github.com/shader-slang/slang-binaries

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/ocornut/imgui.git
 [submodule "external/slang-binaries"]
 	path = external/slang-binaries
-	url = http://github.com/shader-slang/slang-binaries
+	url = https://github.com/shader-slang/slang-binaries

--- a/premake5.lua
+++ b/premake5.lua
@@ -513,7 +513,7 @@ if isTargetWindows then
         -- For Windows targets, we want to copy d3dcompiler_47.dll,
         -- dxcompiler.dll, and dxil.dll from the Windows SDK redistributable
         -- directory into the output directory.
-        postbuildcommands { '"$(SolutionDir)tools\\copy-hlsl-libs.bat" "$(WindowsSdkDir)Redist/D3D/%{cfg.platform:lower()}/" "%{cfg.targetdir}/"'}
+        postbuildcommands { '"$(SolutionDir)tools\\copy-hlsl-libs.bat" "$(WindowsSdkDir)Redist/D3D/%{cfg.platform:lower()}/" "%{cfg.targetdir}/" "windows-%{cfg.platform:lower()}"'}
        
 end
             

--- a/tools/copy-hlsl-libs.bat
+++ b/tools/copy-hlsl-libs.bat
@@ -3,8 +3,10 @@ setlocal
 
 set SOURCE_DIR=%~1
 set TARGET_DIR=%~2
+set PLATFORM=%~3
 
-robocopy "%SOURCE_DIR%" "%TARGET_DIR%" d3dcompiler_47.dll /r:0 >nul
+robocopy "../../external/slang-binaries/bin/%PLATFORM%" "%TARGET_DIR%" d3dcompiler_47.dll /r:0 >nul
+
 robocopy "%SOURCE_DIR%" "%TARGET_DIR%" dxcompiler.dll     /r:0 >nul
 robocopy "%SOURCE_DIR%" "%TARGET_DIR%" dxil.dll           /r:0 >nul
 

--- a/tools/render-test/render-test-tool.vcxproj
+++ b/tools/render-test/render-test-tool.vcxproj
@@ -110,7 +110,7 @@
       <ImportLibrary>..\..\bin\windows-x86\debug\render-test-tool.lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
-      <Command>"$(SolutionDir)tools\copy-hlsl-libs.bat" "$(WindowsSdkDir)Redist/D3D/x86/" "../../bin/windows-x86/debug/"</Command>
+      <Command>"$(SolutionDir)tools\copy-hlsl-libs.bat" "$(WindowsSdkDir)Redist/D3D/x86/" "../../bin/windows-x86/debug/" "windows-x86"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -129,7 +129,7 @@
       <ImportLibrary>..\..\bin\windows-x64\debug\render-test-tool.lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
-      <Command>"$(SolutionDir)tools\copy-hlsl-libs.bat" "$(WindowsSdkDir)Redist/D3D/x64/" "../../bin/windows-x64/debug/"</Command>
+      <Command>"$(SolutionDir)tools\copy-hlsl-libs.bat" "$(WindowsSdkDir)Redist/D3D/x64/" "../../bin/windows-x64/debug/" "windows-x64"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -152,7 +152,7 @@
       <ImportLibrary>..\..\bin\windows-x86\release\render-test-tool.lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
-      <Command>"$(SolutionDir)tools\copy-hlsl-libs.bat" "$(WindowsSdkDir)Redist/D3D/x86/" "../../bin/windows-x86/release/"</Command>
+      <Command>"$(SolutionDir)tools\copy-hlsl-libs.bat" "$(WindowsSdkDir)Redist/D3D/x86/" "../../bin/windows-x86/release/" "windows-x86"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -175,7 +175,7 @@
       <ImportLibrary>..\..\bin\windows-x64\release\render-test-tool.lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
-      <Command>"$(SolutionDir)tools\copy-hlsl-libs.bat" "$(WindowsSdkDir)Redist/D3D/x64/" "../../bin/windows-x64/release/"</Command>
+      <Command>"$(SolutionDir)tools\copy-hlsl-libs.bat" "$(WindowsSdkDir)Redist/D3D/x64/" "../../bin/windows-x64/release/" "windows-x64"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Problems were appearing on systems around fxc (d3dcompiler_47.dll). On CI systems as well as development systems testing would fail with fxc reporting incompatible flags being used. This was found to be due to `d3dcompiler_47.dll` copied as a build step from `$(WindowsSdkDir)Redist/D3D/` had changed to an earlier incompatible version. It is not clear how/why the change in the dll at this location happened, but because it was across multiple machines it may have been part of some update. 

For slang to work it assumes it has a version of fxc that supports the D3DCOMPILE_ENABLE_UNBOUNDED_DESCRIPTOR_TABLES flags. If an incompatible version is used, compilation will fail with fxc reporting it has been given 'incompatible flags'. 

To resolve the problem versions of `d3dcompiler_47.dll` which are compatible have been added to `slang-binaries` (https://github.com/shader-slang/slang-binaries). That `slang-binaries` has been added as a submodule to slang. That now for dxc it's dlls are copied from the slang-binary sub project not from WindowsSdkDir path.  

Note that for now dxcompiler.dll/dxil.dll (dxc) are still copied from  `$(WindowsSdkDir)Redist/D3D/`.