### PR TITLE
Revisions to "new" Slang API based on use in Falcor

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -2820,9 +2820,10 @@ namespace slang
             It is an error to create a composite component type that recursively
             aggregates the a single module more than once.
             */
-        virtual SLANG_NO_THROW IComponentType* SLANG_MCALL createCompositeComponentType(
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL createCompositeComponentType(
             IComponentType* const*  componentTypes,
             SlangInt                componentTypeCount,
+            IComponentType**        outCompositeComponentType,
             ISlangBlob**            outDiagnostics = nullptr) = 0;
 
             /** Specialize a type based on type arguments.
@@ -2965,13 +2966,12 @@ namespace slang
             The `specializationArgs` array must have `specializationArgCount` entries, and
             this must match the number of specialization parameters on this component type.
 
-            If the specialization arguments are not valid, then the function will return null.
-
             If any diagnostics (error or warnings) are produced, they will be written to `outDiagnostics`.
             */
-        virtual SLANG_NO_THROW IComponentType* SLANG_MCALL specialize(
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL specialize(
             SpecializationArg const*    specializationArgs,
             SlangInt                    specializationArgCount,
+            IComponentType**            outSpecializedComponentType,
             ISlangBlob**                outDiagnostics = nullptr) = 0;
     };
     #define SLANG_UUID_IComponentType { 0x5bc42be8, 0x5c50, 0x4929, { 0x9e, 0x5e, 0xd1, 0x5e, 0x7c, 0x24, 0x1, 0x5f } };
@@ -2998,7 +2998,6 @@ namespace slang
     };
     
     #define SLANG_UUID_IModule { 0xc720e64, 0x8722, 0x4d31, { 0x89, 0x90, 0x63, 0x8a, 0x98, 0xb1, 0xc2, 0x79 } }
-
 
         /** Argument used for specialization to types/values.
         */
@@ -3040,6 +3039,11 @@ namespace slang
 SLANG_API SlangResult spCompileRequest_getProgram(
     SlangCompileRequest*    request,
     slang::IComponentType** outProgram);
+
+SLANG_API SlangResult spCompileRequest_getEntryPoint(
+    SlangCompileRequest*    request,
+    SlangInt                entryPointIndex,
+    slang::IComponentType**    outEntryPoint);
 
 #endif
 

--- a/source/slang/slang-check.cpp
+++ b/source/slang/slang-check.cpp
@@ -10840,7 +10840,8 @@ static bool doesParameterMatch(
         /// account any specialization arguments the user might have supplied.
         ///
     RefPtr<ComponentType> createUnspecializedGlobalAndEntryPointsComponentType(
-        FrontEndCompileRequest* compileRequest)
+        FrontEndCompileRequest*         compileRequest,
+        List<RefPtr<ComponentType>>&    outUnspecializedEntryPoints)
     {
         auto linkage = compileRequest->getLinkage();
         auto sink = compileRequest->getSink();
@@ -10880,6 +10881,7 @@ static bool doesParameterMatch(
                     //
                     entryPointReq->getTranslationUnit()->entryPoints.add(entryPoint);
 
+                    outUnspecializedEntryPoints.add(entryPoint);
                     allComponentTypes.add(entryPoint);
                 }
             }
@@ -10958,6 +10960,7 @@ static bool doesParameterMatch(
                     //
                     translationUnit->entryPoints.add(entryPoint);
 
+                    outUnspecializedEntryPoints.add(entryPoint);
                     allComponentTypes.add(entryPoint);
                 }
             }
@@ -11570,7 +11573,8 @@ static bool doesParameterMatch(
         /// compilation (e.g., from the command line).
         ///
     RefPtr<ComponentType> createSpecializedGlobalAndEntryPointsComponentType(
-        EndToEndCompileRequest* endToEndReq)
+        EndToEndCompileRequest*         endToEndReq,
+        List<RefPtr<ComponentType>>&    outSpecializedEntryPoints)
     {
         auto specializedGlobalComponentType = endToEndReq->getSpecializedGlobalComponentType();
 
@@ -11587,6 +11591,8 @@ static bool doesParameterMatch(
 
             auto specializedEntryPoint = createSpecializedEntryPoint(endToEndReq, unspecializedEntryPoint, entryPointInfo);
             allComponentTypes.add(specializedEntryPoint);
+
+            outSpecializedEntryPoints.add(specializedEntryPoint);
         }
 
         RefPtr<ComponentType> composed = CompositeComponentType::create(endToEndReq->getLinkage(), allComponentTypes);

--- a/source/slang/slang-reflection.cpp
+++ b/source/slang/slang-reflection.cpp
@@ -1522,4 +1522,3 @@ SLANG_API  SlangReflectionType* spReflection_specializeType(
 
     return convert(specializedType);
 }
-

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -497,16 +497,20 @@ SLANG_NO_THROW slang::IModule* SLANG_MCALL Linkage::loadModule(
     return asExternal(module);
 }
 
-SLANG_NO_THROW slang::IComponentType* SLANG_MCALL Linkage::createCompositeComponentType(
-    slang::IComponentType* const*  componentTypes,
-    SlangInt                componentTypeCount,
-    ISlangBlob**            outDiagnostics)
+SLANG_NO_THROW SlangResult SLANG_MCALL Linkage::createCompositeComponentType(
+    slang::IComponentType* const*   componentTypes,
+    SlangInt                        componentTypeCount,
+    slang::IComponentType**         outCompositeComponentType,
+    ISlangBlob**                    outDiagnostics)
 {
     // Attempting to create a "composite" of just one component type should
     // just return the component type itself, to avoid redundant work.
     //
     if( componentTypeCount == 1)
-        return componentTypes[0];
+    {
+        *outCompositeComponentType = componentTypes[0];
+        return SLANG_OK;
+    }
 
     DiagnosticSink sink(getSourceManager());
 
@@ -521,7 +525,9 @@ SLANG_NO_THROW slang::IComponentType* SLANG_MCALL Linkage::createCompositeCompon
         childComponents);
 
     sink.getBlobIfNeeded(outDiagnostics);
-    return asExternal(composite.detach());
+
+    *outCompositeComponentType = asExternal(composite.detach());
+    return SLANG_OK;
 }
 
 SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL Linkage::specializeType(
@@ -953,13 +959,15 @@ RefPtr<ComponentType> createUnspecializedGlobalComponentType(
         FrontEndCompileRequest* compileRequest);
 
 RefPtr<ComponentType> createUnspecializedGlobalAndEntryPointsComponentType(
-        FrontEndCompileRequest* compileRequest);
+        FrontEndCompileRequest*         compileRequest,
+        List<RefPtr<ComponentType>>&    outUnspecializedEntryPoints);
 
 RefPtr<ComponentType> createSpecializedGlobalComponentType(
     EndToEndCompileRequest* endToEndReq);
 
 RefPtr<ComponentType> createSpecializedGlobalAndEntryPointsComponentType(
-    EndToEndCompileRequest* endToEndReq);
+    EndToEndCompileRequest*         endToEndReq,
+    List<RefPtr<ComponentType>>&    outSpecializedEntryPoints);
 
 void FrontEndCompileRequest::checkAllTranslationUnits()
 {
@@ -1092,7 +1100,9 @@ SlangResult FrontEndCompileRequest::executeActionsInner()
     if (getSink()->GetErrorCount() != 0)
         return SLANG_FAIL;
 
-    m_globalAndEntryPointsComponentType = createUnspecializedGlobalAndEntryPointsComponentType(this);
+    m_globalAndEntryPointsComponentType = createUnspecializedGlobalAndEntryPointsComponentType(
+        this,
+        m_unspecializedEntryPoints);
     if (getSink()->GetErrorCount() != 0)
         return SLANG_FAIL;
 
@@ -1208,6 +1218,7 @@ SlangResult EndToEndCompileRequest::executeActionsInner()
         //
         m_specializedGlobalComponentType = getUnspecializedGlobalComponentType();
         m_specializedGlobalAndEntryPointsComponentType = getUnspecializedGlobalAndEntryPointsComponentType();
+        m_specializedEntryPoints = getFrontEndReq()->getUnspecializedEntryPoints();
 
         return SLANG_OK;
     }
@@ -1221,7 +1232,9 @@ SlangResult EndToEndCompileRequest::executeActionsInner()
         if (getSink()->GetErrorCount() != 0)
             return SLANG_FAIL;
 
-        m_specializedGlobalAndEntryPointsComponentType = createSpecializedGlobalAndEntryPointsComponentType(this);
+        m_specializedGlobalAndEntryPointsComponentType = createSpecializedGlobalAndEntryPointsComponentType(
+            this,
+            m_specializedEntryPoints);
         if (getSink()->GetErrorCount() != 0)
             return SLANG_FAIL;
 
@@ -1260,6 +1273,7 @@ SlangResult EndToEndCompileRequest::executeActionsInner()
 
         m_specializedGlobalComponentType = getUnspecializedGlobalComponentType();
         m_specializedGlobalAndEntryPointsComponentType = composedProgram;
+        m_specializedEntryPoints = getFrontEndReq()->getUnspecializedEntryPoints();
     }
 
     // Generate output code, in whatever format was requested
@@ -1788,6 +1802,11 @@ RefPtr<ComponentType> ComponentType::specialize(
     SlangInt                    specializationArgCount,
     DiagnosticSink*             sink)
 {
+    if(specializationArgCount == 0)
+    {
+        return this;
+    }
+
     List<SpecializationArg> specializationArgs;
     specializationArgs.addRange(
         inSpecializationArgs,
@@ -1810,9 +1829,10 @@ RefPtr<ComponentType> ComponentType::specialize(
         sink);
 }
 
-SLANG_NO_THROW slang::IComponentType* SLANG_MCALL ComponentType::specialize(
+SLANG_NO_THROW SlangResult SLANG_MCALL ComponentType::specialize(
     slang::SpecializationArg const* specializationArgs,
     SlangInt                        specializationArgCount,
+    slang::IComponentType**         outSpecializedComponentType,
     ISlangBlob**                    outDiagnostics)
 {
     DiagnosticSink sink(getLinkage()->getSourceManager());
@@ -1825,7 +1845,7 @@ SLANG_NO_THROW slang::IComponentType* SLANG_MCALL ComponentType::specialize(
     {
         // TODO: diagnose
         sink.getBlobIfNeeded(outDiagnostics);
-        return nullptr;
+        return SLANG_FAIL;
     }
 
     List<SpecializationArg> expandedArgs;
@@ -1842,7 +1862,7 @@ SLANG_NO_THROW slang::IComponentType* SLANG_MCALL ComponentType::specialize(
 
         default:
             sink.getBlobIfNeeded(outDiagnostics);
-            return nullptr;
+            return SLANG_FAIL;
         }
         expandedArgs.add(expandedArg);
     }
@@ -1854,7 +1874,9 @@ SLANG_NO_THROW slang::IComponentType* SLANG_MCALL ComponentType::specialize(
 
     sink.getBlobIfNeeded(outDiagnostics);
 
-    return specializedComponentType;
+    *outSpecializedComponentType = specializedComponentType.detach();
+
+    return SLANG_OK;
 }
 
     /// Visitor used by `ComponentType::enumerateModules`
@@ -3305,11 +3327,26 @@ SLANG_API SlangResult spCompileRequest_getProgram(
 {
     if( !request ) return SLANG_ERROR_INVALID_PARAMETER;
     auto req = Slang::asInternal(request);
-    auto program = req->getSpecializedGlobalAndEntryPointsComponentType();
+    auto program = req->getSpecializedGlobalComponentType();
 
     *outProgram = Slang::ComPtr<slang::IComponentType>(program).detach();
     return SLANG_OK;
 }
+
+SLANG_API SlangResult spCompileRequest_getEntryPoint(
+    SlangCompileRequest*    request,
+    SlangInt                entryPointIndex,
+    slang::IComponentType** outEntryPoint)
+{
+    if( !request ) return SLANG_ERROR_INVALID_PARAMETER;
+    auto req = Slang::asInternal(request);
+
+    auto entryPoint = req->getSpecializedEntryPointComponentType(entryPointIndex);
+
+    *outEntryPoint = Slang::ComPtr<slang::IComponentType>(entryPoint).detach();
+    return SLANG_OK;
+}
+
 
 SLANG_API SlangReflection* spGetReflection(
     SlangCompileRequest*    request)

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -508,7 +508,9 @@ SLANG_NO_THROW SlangResult SLANG_MCALL Linkage::createCompositeComponentType(
     //
     if( componentTypeCount == 1)
     {
-        *outCompositeComponentType = componentTypes[0];
+        auto componentType = componentTypes[0];
+        componentType->addRef();
+        *outCompositeComponentType = componentType;
         return SLANG_OK;
     }
 


### PR DESCRIPTION
As I've been integrating the new/revised Slang API (using the "COM-lite" interfaces) I've run into some cases where the API was either missing features or didn't really work as originally implemented. This change fixes the gaps/problems that came up.

There are two main things here:

1. Some of the routines that returned an `IComponentType*` as a function result weren't actually doing anythign to retain the object they returned (e.g., putting it into a cache). Leaving aside the question of whether we need to add that caching layer, it made sense to instead have the return be through an output argument. Discussion after the initial iteration of the COM-lite API came around to the point that properly reference-counting objects that get returned would be useful if we ever decide we don't like having ever-expanding memory usage for caches of specialized/composed component types.

2. There was no way with the existing API to get at an `IComponentType` that represents an entry point produced during compilation, so that a user could include it in their own composition. This change alters `spCompileRequest_getProgram` to return the global program *without* the entry points, and adds a separate `spCompileRequest_getEntryPoint`. This design lets an application compose whatever combination/layout they want, rather than being stuck with a pre-designed composition baked into the compiler.