### PR TITLE
Disable half-structured-buffer.slang for D3D12

### DIFF
--- a/tests/compute/half-structured-buffer.slang
+++ b/tests/compute/half-structured-buffer.slang
@@ -1,6 +1,7 @@
 //TEST(compute):COMPARE_COMPUTE:-vk -compute -profile cs_6_2 -render-features half
 //Disable on Dx12 for now - because writing to structured buffer produces unexpected results
-//TEST(compute):COMPARE_COMPUTE:-dx12 -compute -use-dxil -profile cs_6_2 -render-features half
+//TEST_DISABLED(compute):COMPARE_COMPUTE:-dx12 -compute -use-dxil -profile cs_6_2 -render-features half
+
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=16):dxbinding(0),glbinding(0),out
 
 struct Thing


### PR DESCRIPTION
Disable D3D12 half-structured-buffer.slang test, as produces inconsistent results, confusing CI.