### PR TITLE
IR types for subset of Attributes

### DIFF
--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -274,7 +274,7 @@ DIAGNOSTIC(31006, Error, attributeFunctionNotFound, "Could not find function '$0
 DIAGNOSTIC(31100, Error, unknownStageName, "unknown stage name '$0'")
 DIAGNOSTIC(31101, Error, unknownImageFormatName, "unknown image format '$0'")
 DIAGNOSTIC(31101, Error, unknownDiagnosticName, "unknown diagnostic '$0'")
-DIAGNOSTIC(31102, Error, nonPositiveNumThreads, "numThreads attribute or local_size_x,y,z layout must be positive integers '$0'")
+DIAGNOSTIC(31102, Error, nonPositiveNumThreads, "expected a positive integer in 'numthreads' attribute, got '$0'")
 
 DIAGNOSTIC(31120, Error, invalidAttributeTarget, "invalid syntax target for user defined attribute")
 

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -274,6 +274,7 @@ DIAGNOSTIC(31006, Error, attributeFunctionNotFound, "Could not find function '$0
 DIAGNOSTIC(31100, Error, unknownStageName, "unknown stage name '$0'")
 DIAGNOSTIC(31101, Error, unknownImageFormatName, "unknown image format '$0'")
 DIAGNOSTIC(31101, Error, unknownDiagnosticName, "unknown diagnostic '$0'")
+DIAGNOSTIC(31102, Error, nonPositiveNumThreads, "numThreads attribute or local_size_x,y,z layout must be positive integers '$0'")
 
 DIAGNOSTIC(31120, Error, invalidAttributeTarget, "invalid syntax target for user defined attribute")
 

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -209,7 +209,7 @@ void CLikeSourceEmitter::emitSimpleType(IRType* type)
     IRNumThreadsDecoration* decor = func->findDecoration<IRNumThreadsDecoration>();
     for (int i = 0; i < 3; ++i)
     {
-        outNumThreads[i] = decor ? GetIntVal(decor->getOperand(i)) : 1;
+        outNumThreads[i] = decor ? Int(GetIntVal(decor->getOperand(i))) : 1;
     }
     return decor;
 }

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -203,6 +203,17 @@ void CLikeSourceEmitter::emitSimpleType(IRType* type)
     }
 }
 
+
+/* static */IRNumThreadsDecoration* CLikeSourceEmitter::getComputeThreadGroupSize(IRFunc* func, Int outNumThreads[kThreadGroupAxisCount])
+{
+    IRNumThreadsDecoration* decor = func->findDecoration<IRNumThreadsDecoration>();
+    for (int i = 0; i < 3; ++i)
+    {
+        outNumThreads[i] = decor ? GetIntVal(decor->getOperand(i)) : 1;
+    }
+    return decor;
+}
+
 void CLikeSourceEmitter::_emitArrayType(IRArrayType* arrayType, EDeclarator* declarator)
 {
     EDeclarator arrayDeclarator;

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -43,6 +43,11 @@ public:
             // explicitly in the layout data.
         StructTypeLayout* globalStructLayout = nullptr;
     };
+
+    enum
+    {
+        kThreadGroupAxisCount = 3,
+    };
     
         /// To simplify cases 
     enum class SourceStyle
@@ -317,6 +322,9 @@ public:
         /// Gets the default type name for built in scalar types. Different impls may require something different.
         /// Returns an empty slice if not a built in type
     static UnownedStringSlice getDefaultBuiltinTypeName(IROp op);
+
+        /// Finds the IRNumThreadsDecoration and gets the size from that or sets all dimensions to 1
+    static IRNumThreadsDecoration* getComputeThreadGroupSize(IRFunc* func, Int outNumThreads[kThreadGroupAxisCount]);
 
     protected:
 

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -271,15 +271,15 @@ protected:
 
     void _emitEntryPointDefinitionStart(IRFunc* func, IRGlobalParam* entryPointGlobalParams, const String& funcName, const UnownedStringSlice& varyingTypeName);
     void _emitEntryPointDefinitionEnd(IRFunc* func);
-    void _emitEntryPointGroup(const UInt sizeAlongAxis[3], const String& funcName);
-    void _emitEntryPointGroupRange(const UInt sizeAlongAxis[3], const String& funcName);
+    void _emitEntryPointGroup(const Int sizeAlongAxis[kThreadGroupAxisCount], const String& funcName);
+    void _emitEntryPointGroupRange(const Int sizeAlongAxis[kThreadGroupAxisCount], const String& funcName);
 
-    void _emitInitAxisValues(const UInt sizeAlongAxis[3], const UnownedStringSlice& mulName, const UnownedStringSlice& addName);
+    void _emitInitAxisValues(const Int sizeAlongAxis[kThreadGroupAxisCount], const UnownedStringSlice& mulName, const UnownedStringSlice& addName);
 
     Dictionary<SpecializedIntrinsic, StringSlicePool::Handle> m_intrinsicNameMap;
     Dictionary<IRType*, StringSlicePool::Handle> m_typeNameMap;
 
-    /* This is used so as to try and use slangs type system to uniquely identify types and specializations on intrinsice.
+    /* This is used so as to try and use slangs type system to uniquely identify types and specializations on intrinsic.
     That we want to have a pointer to a type be unique, and slang supports this through the m_sharedIRBuilder. BUT for this to
     work all work on the module must use the same sharedIRBuilder, and that appears to not be the case in terms
     of other passes.

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -661,20 +661,12 @@ void GLSLSourceEmitter::emitEntryPointAttributesImpl(IRFunc* irFunc, EntryPointL
     {
         case Stage::Compute:
         {
-            static const UInt kAxisCount = 3;
-            UInt sizeAlongAxis[kAxisCount];
-
-            // TODO: this is kind of gross because we are using a public
-            // reflection API function, rather than some kind of internal
-            // utility it forwards to...
-            spReflectionEntryPoint_getComputeThreadGroupSize(
-                (SlangReflectionEntryPoint*)entryPointLayout,
-                kAxisCount,
-                &sizeAlongAxis[0]);
+            Int sizeAlongAxis[kThreadGroupAxisCount];
+            getComputeThreadGroupSize(irFunc, sizeAlongAxis);
 
             m_writer->emit("layout(");
             char const* axes[] = { "x", "y", "z" };
-            for (int ii = 0; ii < 3; ++ii)
+            for (int ii = 0; ii < kThreadGroupAxisCount; ++ii)
             {
                 if (ii != 0) m_writer->emit(", ");
                 m_writer->emit("local_size_");

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -694,10 +694,12 @@ void GLSLSourceEmitter::emitEntryPointAttributesImpl(IRFunc* irFunc, EntryPointL
                 m_writer->emit(Int(count));
                 m_writer->emit(") out;\n");
             }
-            if (auto attrib = entryPointLayout->getFuncDecl()->FindModifier<InstanceAttribute>())
+
+            if (auto decor = irFunc->findDecoration<IRInstanceDecoration>())
             {
+                auto count = GetIntVal(decor->getCount());
                 m_writer->emit("layout(invocations = ");
-                m_writer->emit(attrib->value);
+                m_writer->emit(Int(count));
                 m_writer->emit(") in;\n");
             }
 

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -687,10 +687,11 @@ void GLSLSourceEmitter::emitEntryPointAttributesImpl(IRFunc* irFunc, EntryPointL
         break;
         case Stage::Geometry:
         {
-            if (auto attrib = entryPointLayout->getFuncDecl()->FindModifier<MaxVertexCountAttribute>())
+            if (auto decor = irFunc->findDecoration<IRMaxVertexCountDecoration>())
             {
+                auto count = GetIntVal(decor->getCount());
                 m_writer->emit("layout(max_vertices = ");
-                m_writer->emit(attrib->value);
+                m_writer->emit(Int(count));
                 m_writer->emit(") out;\n");
             }
             if (auto attrib = entryPointLayout->getFuncDecl()->FindModifier<InstanceAttribute>())

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -353,11 +353,11 @@ void HLSLSourceEmitter::_emitHLSLEntryPointAttributes(IRFunc* irFunc, EntryPoint
             FuncDecl* entryPoint = entryPointLayout->entryPoint;
 
             /* [domain("isoline")] */
-            if (auto attrib = entryPoint->FindModifier<DomainAttribute>())
+            if (auto decor = irFunc->findDecoration<IRDomainDecoration>())
             {
-                _emitHLSLAttributeSingleString("domain", entryPoint, attrib);
+                _emitHLSLDecorationSingleString("domain", irFunc, decor->getDomain());
             }
-            
+
             /* [domain("partitioning")] */
             if (auto decor = irFunc->findDecoration<IRPartitioningDecoration>())
             {

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -357,12 +357,13 @@ void HLSLSourceEmitter::_emitHLSLEntryPointAttributes(IRFunc* irFunc, EntryPoint
             {
                 _emitHLSLAttributeSingleString("domain", entryPoint, attrib);
             }
-            /* [domain("partitioning")] */
-            if (auto attrib = entryPoint->FindModifier<PartitioningAttribute>())
-            {
-                _emitHLSLAttributeSingleString("partitioning", entryPoint, attrib);
-            }
             
+            /* [domain("partitioning")] */
+            if (auto decor = irFunc->findDecoration<IRPartitioningDecoration>())
+            {
+                _emitHLSLDecorationSingleString("partitioning", irFunc, decor->getPartitioning());
+            }
+
             /* [outputtopology("line")] */
             if (auto decor = irFunc->findDecoration<IROutputTopologyDecoration>())
             {

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -65,6 +65,18 @@ void HLSLSourceEmitter::_emitHLSLAttributeSingleInt(const char* name, FuncDecl* 
     m_writer->emit(")]\n");
 }
 
+void HLSLSourceEmitter::_emitHLSLDecorationSingleString(const char* name, IRFunc* entryPoint, IRStringLit* val)
+{
+    SLANG_UNUSED(entryPoint);
+    assert(val);
+
+    m_writer->emit("[");
+    m_writer->emit(name);
+    m_writer->emit("(\"");
+    m_writer->emit(val->getStringSlice());
+    m_writer->emit("\")]\n");
+}
+
 void HLSLSourceEmitter::_emitHLSLDecorationSingleInt(const char* name, IRFunc* entryPoint, IRIntLit* val)
 {
     SLANG_UNUSED(entryPoint);
@@ -350,12 +362,13 @@ void HLSLSourceEmitter::_emitHLSLEntryPointAttributes(IRFunc* irFunc, EntryPoint
             {
                 _emitHLSLAttributeSingleString("partitioning", entryPoint, attrib);
             }
-            /* [outputtopology("line")] */
-            if (auto attrib = entryPoint->FindModifier<OutputTopologyAttribute>())
-            {
-                _emitHLSLAttributeSingleString("outputtopology", entryPoint, attrib);
-            }
             
+            /* [outputtopology("line")] */
+            if (auto decor = irFunc->findDecoration<IROutputTopologyDecoration>())
+            {
+                _emitHLSLDecorationSingleString("outputtopology", irFunc, decor->getTopology());
+            }
+
             /* [outputcontrolpoints(4)] */
             if (auto decor = irFunc->findDecoration<IROutputControlPointsDecoration>())
             {

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -320,12 +320,14 @@ void HLSLSourceEmitter::_emitHLSLEntryPointAttributes(IRFunc* irFunc, EntryPoint
         break;
         case Stage::Geometry:
         {
-            if (auto attrib = entryPointLayout->getFuncDecl()->FindModifier<MaxVertexCountAttribute>())
+            if (auto decor = irFunc->findDecoration<IRMaxVertexCountDecoration>())
             {
+                auto count = GetIntVal(decor->getCount());
                 m_writer->emit("[maxvertexcount(");
-                m_writer->emit(attrib->value);
+                m_writer->emit(Int(count));
                 m_writer->emit(")]\n");
             }
+
             if (auto attrib = entryPointLayout->getFuncDecl()->FindModifier<InstanceAttribute>())
             {
                 m_writer->emit("[instance(");
@@ -336,13 +338,11 @@ void HLSLSourceEmitter::_emitHLSLEntryPointAttributes(IRFunc* irFunc, EntryPoint
         }
         case Stage::Domain:
         {
-            FuncDecl* entryPoint = entryPointLayout->entryPoint;
             /* [domain("isoline")] */
-            if (auto attrib = entryPoint->FindModifier<DomainAttribute>())
+            if (auto decor = irFunc->findDecoration<IRDomainDecoration>())
             {
-                _emitHLSLAttributeSingleString("domain", entryPoint, attrib);
+                _emitHLSLDecorationSingleString("domain", irFunc, decor->getDomain());
             }
-
             break;
         }
         case Stage::Hull:

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -350,8 +350,6 @@ void HLSLSourceEmitter::_emitHLSLEntryPointAttributes(IRFunc* irFunc, EntryPoint
             // Lists these are only attributes for hull shader
             // https://docs.microsoft.com/en-us/windows/desktop/direct3d11/direct3d-11-advanced-stages-hull-shader-design
 
-            FuncDecl* entryPoint = entryPointLayout->entryPoint;
-
             /* [domain("isoline")] */
             if (auto decor = irFunc->findDecoration<IRDomainDecoration>())
             {
@@ -377,9 +375,13 @@ void HLSLSourceEmitter::_emitHLSLEntryPointAttributes(IRFunc* irFunc, EntryPoint
             }
 
             /* [patchconstantfunc("HSConst")] */
-            if (auto attrib = entryPoint->FindModifier<PatchConstantFuncAttribute>())
+            if (auto decor = irFunc->findDecoration<IRPatchConstantFuncDecoration>())
             {
-                _emitHLSLFuncDeclPatchConstantFuncAttribute(irFunc, entryPoint, attrib);
+                const String irName = getName(decor->getFunc());
+
+                m_writer->emit("[patchconstantfunc(\"");
+                m_writer->emit(irName);
+                m_writer->emit("\")]\n");
             }
 
             break;
@@ -450,25 +452,6 @@ void HLSLSourceEmitter::_emitHLSLTextureType(IRTextureTypeBase* texType)
     m_writer->emit("<");
     emitType(texType->getElementType());
     m_writer->emit(" >");
-}
-
-void HLSLSourceEmitter::_emitHLSLFuncDeclPatchConstantFuncAttribute(IRFunc* irFunc, FuncDecl* entryPoint, PatchConstantFuncAttribute* attrib)
-{
-    SLANG_UNUSED(attrib);
-
-    auto irPatchFunc = irFunc->findDecoration<IRPatchConstantFuncDecoration>();
-    assert(irPatchFunc);
-    if (!irPatchFunc)
-    {
-        SLANG_DIAGNOSE_UNEXPECTED(getSink(), entryPoint->loc, "Unable to find [patchConstantFunc(...)] decoration");
-        return;
-    }
-
-    const String irName = getName(irPatchFunc->getFunc());
-
-    m_writer->emit("[patchconstantfunc(\"");
-    m_writer->emit(irName);
-    m_writer->emit("\")]\n");
 }
 
 void HLSLSourceEmitter::emitLayoutSemanticsImpl(IRInst* inst, char const* uniformSemanticSpelling)

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -328,10 +328,11 @@ void HLSLSourceEmitter::_emitHLSLEntryPointAttributes(IRFunc* irFunc, EntryPoint
                 m_writer->emit(")]\n");
             }
 
-            if (auto attrib = entryPointLayout->getFuncDecl()->FindModifier<InstanceAttribute>())
+            if (auto decor = irFunc->findDecoration<IRInstanceDecoration>())
             {
+                auto count = GetIntVal(decor->getCount());
                 m_writer->emit("[instance(");
-                m_writer->emit(attrib->value);
+                m_writer->emit(Int(count));
                 m_writer->emit(")]\n");
             }
             break;

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -243,19 +243,11 @@ void HLSLSourceEmitter::_emitHLSLEntryPointAttributes(IRFunc* irFunc, EntryPoint
     {
         case Stage::Compute:
         {
-            static const UInt kAxisCount = 3;
-            UInt sizeAlongAxis[kAxisCount];
-
-            // TODO: this is kind of gross because we are using a public
-            // reflection API function, rather than some kind of internal
-            // utility it forwards to...
-            spReflectionEntryPoint_getComputeThreadGroupSize(
-                (SlangReflectionEntryPoint*)entryPointLayout,
-                kAxisCount,
-                &sizeAlongAxis[0]);
+            Int sizeAlongAxis[kThreadGroupAxisCount];
+            getComputeThreadGroupSize(irFunc, sizeAlongAxis);
 
             m_writer->emit("[numthreads(");
-            for (int ii = 0; ii < 3; ++ii)
+            for (int ii = 0; ii < kThreadGroupAxisCount; ++ii)
             {
                 if (ii != 0) m_writer->emit(", ");
                 m_writer->emit(sizeAlongAxis[ii]);

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -65,6 +65,20 @@ void HLSLSourceEmitter::_emitHLSLAttributeSingleInt(const char* name, FuncDecl* 
     m_writer->emit(")]\n");
 }
 
+void HLSLSourceEmitter::_emitHLSLDecorationSingleInt(const char* name, IRFunc* entryPoint, IRIntLit* val)
+{
+    SLANG_UNUSED(entryPoint);
+    SLANG_ASSERT(val);
+
+    auto intVal = GetIntVal(val);
+
+    m_writer->emit("[");
+    m_writer->emit(name);
+    m_writer->emit("(");
+    m_writer->emit(intVal);
+    m_writer->emit(")]\n");
+}
+
 void HLSLSourceEmitter::_emitHLSLRegisterSemantic(LayoutResourceKind kind, EmitVarChain* chain, char const* uniformSemanticSpelling)
 {
     if (!chain)
@@ -341,11 +355,13 @@ void HLSLSourceEmitter::_emitHLSLEntryPointAttributes(IRFunc* irFunc, EntryPoint
             {
                 _emitHLSLAttributeSingleString("outputtopology", entryPoint, attrib);
             }
+            
             /* [outputcontrolpoints(4)] */
-            if (auto attrib = entryPoint->FindModifier<OutputControlPointsAttribute>())
+            if (auto decor = irFunc->findDecoration<IROutputControlPointsDecoration>())
             {
-                _emitHLSLAttributeSingleInt("outputcontrolpoints", entryPoint, attrib);
+                _emitHLSLDecorationSingleInt("outputcontrolpoints", irFunc, decor->getControlPointCount());
             }
+
             /* [patchconstantfunc("HSConst")] */
             if (auto attrib = entryPoint->FindModifier<PatchConstantFuncAttribute>())
             {

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -10,61 +10,6 @@
 
 namespace Slang {
 
-
-void HLSLSourceEmitter::_emitHLSLAttributeSingleString(const char* name, FuncDecl* entryPoint, Attribute* attrib)
-{
-    assert(attrib);
-
-    attrib->args.getCount();
-    if (attrib->args.getCount() != 1)
-    {
-        SLANG_DIAGNOSE_UNEXPECTED(getSink(), entryPoint->loc, "Attribute expects single parameter");
-        return;
-    }
-
-    Expr* expr = attrib->args[0];
-
-    auto stringLitExpr = as<StringLiteralExpr>(expr);
-    if (!stringLitExpr)
-    {
-        SLANG_DIAGNOSE_UNEXPECTED(getSink(), entryPoint->loc, "Attribute parameter expecting to be a string ");
-        return;
-    }
-
-    m_writer->emit("[");
-    m_writer->emit(name);
-    m_writer->emit("(\"");
-    m_writer->emit(stringLitExpr->value);
-    m_writer->emit("\")]\n");
-}
-
-void HLSLSourceEmitter::_emitHLSLAttributeSingleInt(const char* name, FuncDecl* entryPoint, Attribute* attrib)
-{
-    assert(attrib);
-
-    attrib->args.getCount();
-    if (attrib->args.getCount() != 1)
-    {
-        SLANG_DIAGNOSE_UNEXPECTED(getSink(), entryPoint->loc, "Attribute expects single parameter");
-        return;
-    }
-
-    Expr* expr = attrib->args[0];
-
-    auto intLitExpr = as<IntegerLiteralExpr>(expr);
-    if (!intLitExpr)
-    {
-        SLANG_DIAGNOSE_UNEXPECTED(getSink(), entryPoint->loc, "Attribute expects an int");
-        return;
-    }
-
-    m_writer->emit("[");
-    m_writer->emit(name);
-    m_writer->emit("(");
-    m_writer->emit(intLitExpr->value);
-    m_writer->emit(")]\n");
-}
-
 void HLSLSourceEmitter::_emitHLSLDecorationSingleString(const char* name, IRFunc* entryPoint, IRStringLit* val)
 {
     SLANG_UNUSED(entryPoint);

--- a/source/slang/slang-emit-hlsl.h
+++ b/source/slang/slang-emit-hlsl.h
@@ -50,10 +50,6 @@ protected:
 
     void _emitHLSLTextureType(IRTextureTypeBase* texType);
 
-    void _emitHLSLAttributeSingleString(const char* name, FuncDecl* entryPoint, Attribute* attrib);
-
-    void _emitHLSLAttributeSingleInt(const char* name, FuncDecl* entryPoint, Attribute* attrib);
-
     void _emitHLSLDecorationSingleString(const char* name, IRFunc* entryPoint, IRStringLit* val);
     void _emitHLSLDecorationSingleInt(const char* name, IRFunc* entryPoint, IRIntLit* val);
     

--- a/source/slang/slang-emit-hlsl.h
+++ b/source/slang/slang-emit-hlsl.h
@@ -56,7 +56,7 @@ protected:
 
     void _emitHLSLAttributeSingleInt(const char* name, FuncDecl* entryPoint, Attribute* attrib);
 
-
+    void _emitHLSLDecorationSingleString(const char* name, IRFunc* entryPoint, IRStringLit* val);
     void _emitHLSLDecorationSingleInt(const char* name, IRFunc* entryPoint, IRIntLit* val);
     
 };

--- a/source/slang/slang-emit-hlsl.h
+++ b/source/slang/slang-emit-hlsl.h
@@ -50,8 +50,6 @@ protected:
 
     void _emitHLSLTextureType(IRTextureTypeBase* texType);
 
-    void _emitHLSLFuncDeclPatchConstantFuncAttribute(IRFunc* irFunc, FuncDecl* entryPoint, PatchConstantFuncAttribute* attrib);
-
     void _emitHLSLAttributeSingleString(const char* name, FuncDecl* entryPoint, Attribute* attrib);
 
     void _emitHLSLAttributeSingleInt(const char* name, FuncDecl* entryPoint, Attribute* attrib);

--- a/source/slang/slang-emit-hlsl.h
+++ b/source/slang/slang-emit-hlsl.h
@@ -56,6 +56,9 @@ protected:
 
     void _emitHLSLAttributeSingleInt(const char* name, FuncDecl* entryPoint, Attribute* attrib);
 
+
+    void _emitHLSLDecorationSingleInt(const char* name, IRFunc* entryPoint, IRIntLit* val);
+    
 };
 
 }

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -415,6 +415,7 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     INST(PatchConstantFuncDecoration,       patchConstantFunc,      1, 0)
 
     INST(OutputControlPointsDecoration,     outputControlPoints,    1, 0)
+    INST(OutputTopologyDecoration,          outputTopology,         1, 0)
 
         /// An `[entryPoint]` decoration marks a function that represents a shader entry point.
         /// Also used in some scenarios mark parameters that are moved from entry point parameters to global params as coming from the entry point.

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -418,6 +418,7 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     INST(OutputTopologyDecoration,          outputTopology,         1, 0)
     INST(PartitioningDecoration,            partioning,             1, 0)
     INST(DomainDecoration,                  domain,                 1, 0)
+    INST(MaxVertexCountDecoration,          maxVertexCount,         1, 0)
 
         /// An `[entryPoint]` decoration marks a function that represents a shader entry point.
         /// Also used in some scenarios mark parameters that are moved from entry point parameters to global params as coming from the entry point.

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -416,6 +416,7 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
 
     INST(OutputControlPointsDecoration,     outputControlPoints,    1, 0)
     INST(OutputTopologyDecoration,          outputTopology,         1, 0)
+    INST(PartitioningDecoration,            partioning,             1, 0)
 
         /// An `[entryPoint]` decoration marks a function that represents a shader entry point.
         /// Also used in some scenarios mark parameters that are moved from entry point parameters to global params as coming from the entry point.

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -419,6 +419,7 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     INST(PartitioningDecoration,            partioning,             1, 0)
     INST(DomainDecoration,                  domain,                 1, 0)
     INST(MaxVertexCountDecoration,          maxVertexCount,         1, 0)
+    INST(InstanceDecoration,                instance,               1, 0)
 
         /// An `[entryPoint]` decoration marks a function that represents a shader entry point.
         /// Also used in some scenarios mark parameters that are moved from entry point parameters to global params as coming from the entry point.

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -417,6 +417,7 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     INST(OutputControlPointsDecoration,     outputControlPoints,    1, 0)
     INST(OutputTopologyDecoration,          outputTopology,         1, 0)
     INST(PartitioningDecoration,            partioning,             1, 0)
+    INST(DomainDecoration,                  domain,                 1, 0)
 
         /// An `[entryPoint]` decoration marks a function that represents a shader entry point.
         /// Also used in some scenarios mark parameters that are moved from entry point parameters to global params as coming from the entry point.

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -420,6 +420,7 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     INST(DomainDecoration,                  domain,                 1, 0)
     INST(MaxVertexCountDecoration,          maxVertexCount,         1, 0)
     INST(InstanceDecoration,                instance,               1, 0)
+    INST(NumThreadsDecoration,              numThreads,             3, 0)
 
         /// An `[entryPoint]` decoration marks a function that represents a shader entry point.
         /// Also used in some scenarios mark parameters that are moved from entry point parameters to global params as coming from the entry point.

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -414,6 +414,8 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     INST(PreciseDecoration,                 precise,       0, 0)
     INST(PatchConstantFuncDecoration,       patchConstantFunc,      1, 0)
 
+    INST(OutputControlPointsDecoration,     outputControlPoints,    1, 0)
+
         /// An `[entryPoint]` decoration marks a function that represents a shader entry point.
         /// Also used in some scenarios mark parameters that are moved from entry point parameters to global params as coming from the entry point.
     INST(EntryPointDecoration,              entryPoint,             0, 0)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -253,6 +253,14 @@ struct IRPartitioningDecoration : IRDecoration
     IRStringLit* getPartitioning() { return cast<IRStringLit>(getOperand(0)); }
 };
 
+struct IRDomainDecoration : IRDecoration
+{
+    enum { kOp = kIROp_DomainDecoration };
+    IR_LEAF_ISA(DomainDecoration)
+
+    IRStringLit* getDomain() { return cast<IRStringLit>(getOperand(0)); }
+};
+
     /// A decoration that marks a value as having linkage.
     ///
     /// A value with linkage is either exported from its module,

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -277,6 +277,16 @@ struct IRInstanceDecoration : IRDecoration
     IRIntLit* getCount() { return cast<IRIntLit>(getOperand(0)); }
 };
 
+struct IRNumThreadsDecoration : IRDecoration
+{
+    enum { kOp = kIROp_NumThreadsDecoration };
+    IR_LEAF_ISA(NumThreadsDecoration)
+
+    IRIntLit* getX() { return cast<IRIntLit>(getOperand(0)); }
+    IRIntLit* getY() { return cast<IRIntLit>(getOperand(1)); }
+    IRIntLit* getZ() { return cast<IRIntLit>(getOperand(2)); }
+};
+
     /// A decoration that marks a value as having linkage.
     ///
     /// A value with linkage is either exported from its module,

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -269,6 +269,14 @@ struct IRMaxVertexCountDecoration : IRDecoration
     IRIntLit* getCount() { return cast<IRIntLit>(getOperand(0)); }
 };
 
+struct IRInstanceDecoration : IRDecoration
+{
+    enum { kOp = kIROp_InstanceDecoration };
+    IR_LEAF_ISA(InstanceDecoration)
+
+    IRIntLit* getCount() { return cast<IRIntLit>(getOperand(0)); }
+};
+
     /// A decoration that marks a value as having linkage.
     ///
     /// A value with linkage is either exported from its module,

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -237,6 +237,14 @@ struct IROutputControlPointsDecoration : IRDecoration
     IRIntLit* getControlPointCount() { return cast<IRIntLit>(getOperand(0)); }
 };
 
+struct IROutputTopologyDecoration : IRDecoration
+{
+    enum { kOp = kIROp_OutputTopologyDecoration };
+    IR_LEAF_ISA(OutputTopologyDecoration)
+
+    IRStringLit* getTopology() { return cast<IRStringLit>(getOperand(0)); }
+};
+
     /// A decoration that marks a value as having linkage.
     ///
     /// A value with linkage is either exported from its module,

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -245,6 +245,14 @@ struct IROutputTopologyDecoration : IRDecoration
     IRStringLit* getTopology() { return cast<IRStringLit>(getOperand(0)); }
 };
 
+struct IRPartitioningDecoration : IRDecoration
+{
+    enum { kOp = kIROp_PartitioningDecoration };
+    IR_LEAF_ISA(PartitioningDecoration)
+
+    IRStringLit* getPartitioning() { return cast<IRStringLit>(getOperand(0)); }
+};
+
     /// A decoration that marks a value as having linkage.
     ///
     /// A value with linkage is either exported from its module,

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -261,6 +261,14 @@ struct IRDomainDecoration : IRDecoration
     IRStringLit* getDomain() { return cast<IRStringLit>(getOperand(0)); }
 };
 
+struct IRMaxVertexCountDecoration : IRDecoration
+{
+    enum { kOp = kIROp_MaxVertexCountDecoration };
+    IR_LEAF_ISA(MaxVertexCountDecoration)
+
+    IRIntLit* getCount() { return cast<IRIntLit>(getOperand(0)); }
+};
+
     /// A decoration that marks a value as having linkage.
     ///
     /// A value with linkage is either exported from its module,

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -228,6 +228,15 @@ IR_SIMPLE_DECORATION(EarlyDepthStencilDecoration)
 IR_SIMPLE_DECORATION(GloballyCoherentDecoration)
 IR_SIMPLE_DECORATION(PreciseDecoration)
 
+
+struct IROutputControlPointsDecoration : IRDecoration
+{
+    enum { kOp = kIROp_OutputControlPointsDecoration };
+    IR_LEAF_ISA(OutputControlPointsDecoration)
+
+    IRIntLit* getControlPointCount() { return cast<IRIntLit>(getOperand(0)); }
+};
+
     /// A decoration that marks a value as having linkage.
     ///
     /// A value with linkage is either exported from its module,

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -5947,6 +5947,20 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             getBuilder()->addDecoration(irFunc, kIROp_MaxVertexCountDecoration, intLit);
         }
 
+        if(auto attr = decl->FindModifier<NumThreadsAttribute>())
+        {
+            auto builder = getBuilder();
+            IRType* intType = builder->getIntType();
+
+            IRInst* operands[3] = {
+                builder->getIntValue(intType, attr->x),
+                builder->getIntValue(intType, attr->y),
+                builder->getIntValue(intType, attr->z)
+            };
+
+           builder->addDecoration(irFunc, kIROp_NumThreadsDecoration, operands, 3);
+        }
+
         if(decl->FindModifier<ReadNoneAttribute>())
         {
             getBuilder()->addSimpleDecoration<IRReadNoneDecoration>(irFunc);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -5935,6 +5935,12 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             getBuilder()->addRequireGLSLVersionDecoration(irFunc, Int(getIntegerLiteralValue(versionMod->versionNumberToken)));
         }
 
+        if (auto attr = decl->FindModifier<InstanceAttribute>())
+        {
+            IRIntLit* intLit = _getIntLitFromAttribute(getBuilder(), attr);
+            getBuilder()->addDecoration(irFunc, kIROp_InstanceDecoration, intLit);
+        }
+
         if(auto attr = decl->FindModifier<MaxVertexCountAttribute>())
         {
             IRIntLit* intLit = _getIntLitFromAttribute(getBuilder(), attr);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -5945,6 +5945,12 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             getBuilder()->addSimpleDecoration<IREarlyDepthStencilDecoration>(irFunc);
         }
 
+        if (auto attr = decl->FindModifier<DomainAttribute>())
+        {
+            IRStringLit* stringLit = _getStringLitFromAttribute(getBuilder(), attr);
+            getBuilder()->addDecoration(irFunc, kIROp_DomainDecoration, stringLit);
+        }
+
         if (auto attr = decl->FindModifier<PartitioningAttribute>())
         {
             IRStringLit* stringLit = _getStringLitFromAttribute(getBuilder(), attr);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -5945,6 +5945,12 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             getBuilder()->addSimpleDecoration<IREarlyDepthStencilDecoration>(irFunc);
         }
 
+        if (auto attr = decl->FindModifier<PartitioningAttribute>())
+        {
+            IRStringLit* stringLit = _getStringLitFromAttribute(getBuilder(), attr);
+            getBuilder()->addDecoration(irFunc, kIROp_PartitioningDecoration, stringLit);
+        }
+
         if (auto attr = decl->FindModifier<OutputTopologyAttribute>())
         {
             IRStringLit* stringLit = _getStringLitFromAttribute(getBuilder(), attr);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -5935,6 +5935,12 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             getBuilder()->addRequireGLSLVersionDecoration(irFunc, Int(getIntegerLiteralValue(versionMod->versionNumberToken)));
         }
 
+        if(auto attr = decl->FindModifier<MaxVertexCountAttribute>())
+        {
+            IRIntLit* intLit = _getIntLitFromAttribute(getBuilder(), attr);
+            getBuilder()->addDecoration(irFunc, kIROp_MaxVertexCountDecoration, intLit);
+        }
+
         if(decl->FindModifier<ReadNoneAttribute>())
         {
             getBuilder()->addSimpleDecoration<IRReadNoneDecoration>(irFunc);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -5585,6 +5585,17 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         return as<IRIntLit>(builder->getIntValue(builder->getIntType(), intLitExpr->value));
     }
 
+    IRStringLit* _getStringLitFromAttribute(IRBuilder* builder, Attribute* attrib)
+    {
+        attrib->args.getCount();
+        SLANG_ASSERT(attrib->args.getCount() == 1);
+        Expr* expr = attrib->args[0];
+
+        auto stringLitExpr = as<StringLiteralExpr>(expr);
+        SLANG_ASSERT(stringLitExpr);
+        return as<IRStringLit>(builder->getStringValue(stringLitExpr->value.getUnownedSlice()));
+    }
+
     LoweredValInfo lowerFuncDecl(FunctionDeclBase* decl)
     {
         // We are going to use a nested builder, because we will
@@ -5932,6 +5943,12 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         if (decl->FindModifier<EarlyDepthStencilAttribute>())
         {
             getBuilder()->addSimpleDecoration<IREarlyDepthStencilDecoration>(irFunc);
+        }
+
+        if (auto attr = decl->FindModifier<OutputTopologyAttribute>())
+        {
+            IRStringLit* stringLit = _getStringLitFromAttribute(getBuilder(), attr);
+            getBuilder()->addDecoration(irFunc, kIROp_OutputTopologyDecoration, stringLit);
         }
 
         if (auto attr = decl->FindModifier<OutputControlPointsAttribute>())

--- a/source/slang/slang-modifier-defs.h
+++ b/source/slang/slang-modifier-defs.h
@@ -131,11 +131,6 @@ SIMPLE_SYNTAX_CLASS(GLSLUnparsedLayoutModifier   , GLSLLayoutModifier)
 SIMPLE_SYNTAX_CLASS(GLSLConstantIDLayoutModifier , GLSLParsedLayoutModifier)
 SIMPLE_SYNTAX_CLASS(GLSLLocationLayoutModifier   , GLSLParsedLayoutModifier)
 
-SIMPLE_SYNTAX_CLASS(GLSLLocalSizeLayoutModifier,    GLSLUnparsedLayoutModifier)
-SIMPLE_SYNTAX_CLASS(GLSLLocalSizeXLayoutModifier,    GLSLLocalSizeLayoutModifier)
-SIMPLE_SYNTAX_CLASS(GLSLLocalSizeYLayoutModifier,    GLSLLocalSizeLayoutModifier)
-SIMPLE_SYNTAX_CLASS(GLSLLocalSizeZLayoutModifier,    GLSLLocalSizeLayoutModifier)
-
 // A catch-all for single-keyword modifiers
 SIMPLE_SYNTAX_CLASS(SimpleModifier, Modifier)
 

--- a/source/slang/slang-reflection.cpp
+++ b/source/slang/slang-reflection.cpp
@@ -1267,27 +1267,6 @@ SLANG_API void spReflectionEntryPoint_getComputeThreadGroupSize(
         sizeAlongAxis[1] = numThreadsAttribute->y;
         sizeAlongAxis[2] = numThreadsAttribute->z;
     }
-    else
-    {
-        // Fall back to the GLSL case, which requires a search over global-scope declarations
-        // to look for as with the `local_size_*` qualifier
-        auto module = as<ModuleDecl>(entryPointFunc.getDecl()->ParentDecl);
-        if (module)
-        {
-            for (auto dd : module->Members)
-            {
-                for (auto mod : dd->GetModifiersOfType<GLSLLocalSizeLayoutModifier>())
-                {
-                    if (auto xMod = as<GLSLLocalSizeXLayoutModifier>(mod))
-                        sizeAlongAxis[0] = (SlangUInt) getIntegerLiteralValue(xMod->valToken);
-                    else if (auto yMod = as<GLSLLocalSizeYLayoutModifier>(mod))
-                        sizeAlongAxis[1] = (SlangUInt) getIntegerLiteralValue(yMod->valToken);
-                    else if (auto zMod = as<GLSLLocalSizeZLayoutModifier>(mod))
-                        sizeAlongAxis[2] = (SlangUInt) getIntegerLiteralValue(zMod->valToken);
-                }
-            }
-        }
-    }
 
     //
 

--- a/tests/ir/string-literal.slang.expected
+++ b/tests/ir/string-literal.slang.expected
@@ -1,6 +1,7 @@
 result code = 0
 standard error = {
 [entryPoint]
+[numThreads(1, 1, 1)]
 [export("_S3tu04mainp1puV")]
 [nameHint("main")]
 func %main	: Func(Void, UInt)


### PR DESCRIPTION
Added decorations for

IROutputControlPointsDecoration
IROutputTopologyDecoration
IRPartitioningDecoration
IRDomainDecoration
IRMaxVertexCountDecoration
IRInstanceDecoration 
IRNumThreadsDecoration

These are then used where appropriate in emitting instead of Attribute types which cannot be serialized. 