### PR TITLE
Feature/remove entry point layout flags

### DIFF
--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -389,21 +389,6 @@ void CLikeSourceEmitter::emitStringLiteral(String const& value)
     m_writer->emit("\"");
 }
 
-void CLikeSourceEmitter::setSampleRateFlag()
-{
-    m_entryPointLayout->flags |= EntryPointLayout::Flag::usesAnySampleRateInput;
-}
-
-void CLikeSourceEmitter::doSampleRateInputCheck(Name* name)
-{
-    // TODO(JS): This doesn't appear to be called from anywhere!!
-    auto text = getText(name);
-    if (text == "gl_SampleID")
-    {
-        setSampleRateFlag();
-    }
-}
-
 void CLikeSourceEmitter::emitVal(IRInst* val, EmitOpInfo const& outerPrec)
 {
     if(auto type = as<IRType>(val))

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -152,10 +152,6 @@ public:
 
     void emitStringLiteral(const String& value);
 
-    void setSampleRateFlag();
-
-    void doSampleRateInputCheck(Name* name);
-
     void emitVal(IRInst* val, const EmitOpInfo& outerPrec);
 
     UInt getBindingOffset(EmitVarChain* chain, LayoutResourceKind kind);

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -2343,7 +2343,7 @@ void CPPSourceEmitter::emitOperandImpl(IRInst* inst, EmitOpInfo const&  outerPre
         {            
             String name = getName(inst);
 
-            if (inst->findDecorationImpl(kIROp_EntryPointDecoration))
+            if (inst->findDecorationImpl(kIROp_EntryPointParamDecoration))
             {
                 // It's an entry point parameter
                 // The parameter is held in a struct so always deref
@@ -2695,7 +2695,7 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
             {
                 auto inst = action.inst;
 
-                if (inst->findDecorationImpl(kIROp_EntryPointDecoration))
+                if (inst->findDecorationImpl(kIROp_EntryPointParamDecoration))
                 {
                     // Should only be one instruction marked this way
                     SLANG_ASSERT(entryPointGlobalParams == nullptr);

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -706,16 +706,13 @@ void GLSLSourceEmitter::emitEntryPointAttributesImpl(IRFunc* irFunc, EntryPointL
             // The actual parameters have become potentially multiple global parameters.
             if (auto decor = irFunc->findDecoration<IRGeometryPrimitiveTypeDecoration>())
             {
-                typedef IRGeometryPrimitiveTypeDecoration::PrimitiveType PrimitiveType;
-
-                PrimitiveType primType = decor->getPrimitiveType();
-                switch (primType)
+                switch (decor->op)
                 {
-                    case PrimitiveType::Triangle:       m_writer->emit("layout(triangles) in;\n"); break;
-                    case PrimitiveType::Line:           m_writer->emit("layout(lines) in;\n"); break;
-                    case PrimitiveType::LineAdj:        m_writer->emit("layout(lines_adjacency) in;\n"); break;
-                    case PrimitiveType::Point:          m_writer->emit("layout(points) in;\n"); break;
-                    case PrimitiveType::TriangleAdj:    m_writer->emit("layout(triangles_adjacency) in;\n"); break;
+                    case kIROp_TrianglePrimitiveTypeDecoration:       m_writer->emit("layout(triangles) in;\n"); break;
+                    case kIROp_LinePrimitiveTypeDecoration:           m_writer->emit("layout(lines) in;\n"); break;
+                    case kIROp_LineAdjPrimitiveTypeDecoration:        m_writer->emit("layout(lines_adjacency) in;\n"); break;
+                    case kIROp_PointPrimitiveTypeDecoration:          m_writer->emit("layout(points) in;\n"); break;
+                    case kIROp_TriangleAdjPrimitiveTypeDecoration:    m_writer->emit("layout(triangles_adjacency) in;\n"); break;
                     default:
                     {
                         SLANG_ASSERT(!"Unknown primitive type");

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -730,6 +730,7 @@ void GLSLSourceEmitter::emitEntryPointAttributesImpl(IRFunc* irFunc, EntryPointL
                 }
             }
 
+#if 0
             if (auto decor = irFunc->findDecoration<IRStreamOutputTypeDecoration>())
             {
                 IRType* type = decor->getStreamType();
@@ -743,6 +744,7 @@ void GLSLSourceEmitter::emitEntryPointAttributesImpl(IRFunc* irFunc, EntryPointL
                 else
                     SLANG_ASSERT(!"Unknown stream out type");
             }
+#endif
 
 #if 0
             for (auto pp : entryPointLayout->getFuncDecl()->GetParameters())
@@ -1578,6 +1580,27 @@ void GLSLSourceEmitter::emitInterpolationModifiersImpl(IRInst* varInst, IRType* 
 
 void GLSLSourceEmitter::emitVarDecorationsImpl(IRInst* varDecl)
 {
+    {
+        IRType* type = varDecl->getFullType();
+        // Strip out type 
+        if (auto outType = as<IROutTypeBase>(type))
+        {
+            type = outType->getValueType();
+        }
+
+        if (auto streamType = as<IRHLSLStreamOutputType>(type))
+        {
+            if (as<IRHLSLPointStreamType>(type))
+                m_writer->emit("layout(points) out;\n");
+            else if (as<IRHLSLLineStreamType>(type))
+                m_writer->emit("layout(line_strip) out;\n");
+            else if (as<IRHLSLTriangleStreamType>(type))
+                m_writer->emit("layout(triangle_strip) out;\n");
+            else
+                SLANG_ASSERT(!"Unknown stream out type");
+        }
+    }
+
     // Deal with Vulkan raytracing layout stuff *before* we
     // do the check for whether `layout` is null, because
     // the payload won't automatically get a layout applied

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -1525,27 +1525,6 @@ void GLSLSourceEmitter::emitInterpolationModifiersImpl(IRInst* varInst, IRType* 
 
 void GLSLSourceEmitter::emitVarDecorationsImpl(IRInst* varDecl)
 {
-    {
-        IRType* type = varDecl->getFullType();
-        // Strip out type 
-        if (auto outType = as<IROutTypeBase>(type))
-        {
-            type = outType->getValueType();
-        }
-
-        if (auto streamType = as<IRHLSLStreamOutputType>(type))
-        {
-            if (as<IRHLSLPointStreamType>(type))
-                m_writer->emit("layout(points) out;\n");
-            else if (as<IRHLSLLineStreamType>(type))
-                m_writer->emit("layout(line_strip) out;\n");
-            else if (as<IRHLSLTriangleStreamType>(type))
-                m_writer->emit("layout(triangle_strip) out;\n");
-            else
-                SLANG_ASSERT(!"Unknown stream out type");
-        }
-    }
-
     // Deal with Vulkan raytracing layout stuff *before* we
     // do the check for whether `layout` is null, because
     // the payload won't automatically get a layout applied

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -222,8 +222,14 @@ void HLSLSourceEmitter::_emitHLSLParameterGroup(IRGlobalParam* varDecl, IRUnifor
 
 void HLSLSourceEmitter::_emitHLSLEntryPointAttributes(IRFunc* irFunc, EntryPointLayout* entryPointLayout)
 {
+    SLANG_UNUSED(entryPointLayout);
+
+    IREntryPointDecoration* entryPointDecor = irFunc->findDecoration<IREntryPointDecoration>();
+    SLANG_ASSERT(entryPointDecor);
+
     auto profile = m_effectiveProfile;
-    auto stage = entryPointLayout->profile.GetStage();
+    //auto stage = entryPointLayout->profile.GetStage();
+    auto stage = entryPointDecor->getProfile().GetStage();
 
     if (profile.getFamily() == ProfileFamily::DX)
     {
@@ -668,6 +674,22 @@ void HLSLSourceEmitter::emitSemanticsImpl(IRInst* inst)
 
 void HLSLSourceEmitter::emitSimpleFuncParamImpl(IRParam* param)
 {
+    if (auto decor = param->findDecoration<IRGeometryPrimitiveTypeDecoration>())
+    {
+        typedef IRGeometryPrimitiveTypeDecoration::PrimitiveType Type;
+
+        switch (decor->getPrimitiveType())
+        {
+            case Type::Triangle:             m_writer->emit("triangle "); break;
+            case Type::Point:                m_writer->emit("point "); break;
+            case Type::Line:                 m_writer->emit("line "); break;
+            case Type::LineAdj:              m_writer->emit("lineadj "); break;
+            case Type::TriangleAdj:          m_writer->emit("triangleadj "); break;
+            default: SLANG_ASSERT(!"Unknown primitive type"); break;
+        }
+    }
+
+#if 0
     if (auto layoutDecor = param->findDecoration<IRLayoutDecoration>())
     {
         Layout* layout = layoutDecor->getLayout();
@@ -692,6 +714,7 @@ void HLSLSourceEmitter::emitSimpleFuncParamImpl(IRParam* param)
             }
         }
     }
+#endif
 
     Super::emitSimpleFuncParamImpl(param);
 }

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -675,15 +675,13 @@ void HLSLSourceEmitter::emitSimpleFuncParamImpl(IRParam* param)
 {
     if (auto decor = param->findDecoration<IRGeometryPrimitiveTypeDecoration>())
     {
-        typedef IRGeometryPrimitiveTypeDecoration::PrimitiveType Type;
-
-        switch (decor->getPrimitiveType())
+        switch (decor->op)
         {
-            case Type::Triangle:             m_writer->emit("triangle "); break;
-            case Type::Point:                m_writer->emit("point "); break;
-            case Type::Line:                 m_writer->emit("line "); break;
-            case Type::LineAdj:              m_writer->emit("lineadj "); break;
-            case Type::TriangleAdj:          m_writer->emit("triangleadj "); break;
+            case kIROp_TrianglePrimitiveTypeDecoration:             m_writer->emit("triangle "); break;
+            case kIROp_PointPrimitiveTypeDecoration:                m_writer->emit("point "); break;
+            case kIROp_LinePrimitiveTypeDecoration:                 m_writer->emit("line "); break;
+            case kIROp_LineAdjPrimitiveTypeDecoration:              m_writer->emit("lineadj "); break;
+            case kIROp_TriangleAdjPrimitiveTypeDecoration:          m_writer->emit("triangleadj "); break;
             default: SLANG_ASSERT(!"Unknown primitive type"); break;
         }
     }

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -228,7 +228,6 @@ void HLSLSourceEmitter::_emitHLSLEntryPointAttributes(IRFunc* irFunc, EntryPoint
     SLANG_ASSERT(entryPointDecor);
 
     auto profile = m_effectiveProfile;
-    //auto stage = entryPointLayout->profile.GetStage();
     auto stage = entryPointDecor->getProfile().GetStage();
 
     if (profile.getFamily() == ProfileFamily::DX)
@@ -688,33 +687,6 @@ void HLSLSourceEmitter::emitSimpleFuncParamImpl(IRParam* param)
             default: SLANG_ASSERT(!"Unknown primitive type"); break;
         }
     }
-
-#if 0
-    if (auto layoutDecor = param->findDecoration<IRLayoutDecoration>())
-    {
-        Layout* layout = layoutDecor->getLayout();
-        VarLayout* varLayout = as<VarLayout>(layout);
-
-        if (varLayout)
-        {
-            auto var = varLayout->getVariable();
-
-            if (auto primTypeModifier = var->FindModifier<HLSLGeometryShaderInputPrimitiveTypeModifier>())
-            {
-                if (as<HLSLTriangleModifier>(primTypeModifier))
-                    m_writer->emit("triangle ");
-                else if (as<HLSLPointModifier>(primTypeModifier))
-                    m_writer->emit("point ");
-                else if (as<HLSLLineModifier>(primTypeModifier))
-                    m_writer->emit("line ");
-                else if (as<HLSLLineAdjModifier>(primTypeModifier))
-                    m_writer->emit("lineadj ");
-                else if (as<HLSLTriangleAdjModifier>(primTypeModifier))
-                    m_writer->emit("triangleadj ");
-            }
-        }
-    }
-#endif
 
     Super::emitSimpleFuncParamImpl(param);
 }

--- a/source/slang/slang-ir-entry-point-uniforms.cpp
+++ b/source/slang/slang-ir-entry-point-uniforms.cpp
@@ -250,7 +250,7 @@ struct MoveEntryPointUniformParametersToGlobalScope
                     globalParam = builder->createGlobalParam(paramStructType);
 
                     // Mark that this global comes from the entry point
-                    builder->addEntryPointDecoration(globalParam);
+                    builder->addDecoration(globalParam, kIROp_EntryPointParamDecoration);
                 }
 
                 // No matter what, the global shader parameter should have the layout

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -1269,6 +1269,12 @@ void legalizeEntryPointParameterForGLSL(
         auto valueType = paramPtrType->getValueType();
         if( auto gsStreamType = as<IRHLSLStreamOutputType>(valueType) )
         {
+            // Add it to the entry point
+            if (!func->findDecoration<IRStreamOutputTypeDecoration>())
+            {
+                builder->addDecoration(func, kIROp_StreamOutputTypeDecoration, gsStreamType);
+            }
+
             // An output stream type like `TriangleStream<Foo>` should
             // more or less translate into `out Foo` (plus scalarization).
 

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -1269,12 +1269,6 @@ void legalizeEntryPointParameterForGLSL(
         auto valueType = paramPtrType->getValueType();
         if( auto gsStreamType = as<IRHLSLStreamOutputType>(valueType) )
         {
-            // Add it to the entry point
-            if (!func->findDecoration<IRStreamOutputTypeDecoration>())
-            {
-                builder->addDecoration(func, kIROp_StreamOutputTypeDecoration, gsStreamType);
-            }
-
             // An output stream type like `TriangleStream<Foo>` should
             // more or less translate into `out Foo` (plus scalarization).
 

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -1257,7 +1257,7 @@ void legalizeEntryPointParameterForGLSL(
     {
         if (!func->findDecoration<IRGeometryPrimitiveTypeDecoration>())
         {
-            builder->addDecoration(func, kIROp_GeometryPrimitiveTypeDecoration, geomDecor->getPrimitiveTypeInst());
+            builder->addDecoration(func, geomDecor->op);
         }
         else
         {

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -1246,6 +1246,48 @@ void legalizeEntryPointParameterForGLSL(
     auto builder = context->getBuilder();
     auto stage = context->getStage();
 
+    // (JS): In the legalization process parameters are moved from the entry point.
+    // So when we get to emit we have a problem in that we can't use parameters to find important decorations
+    // And in the future we will not have front end 'Layout' available. To work around this, we take the
+    // decorations that need special handling from parameters and put them on the IRFunc.
+    //
+    // This is only appropriate of course if there is only one of each for all parameters...
+    // which is what current emit code assumes, but may not be more generally applicable.
+    if (auto geomDecor = pp->findDecoration<IRGeometryPrimitiveTypeDecoration>())
+    {
+        if (!func->findDecoration<IRGeometryPrimitiveTypeDecoration>())
+        {
+            builder->addDecoration(func, kIROp_GeometryPrimitiveTypeDecoration, geomDecor->getPrimitiveTypeInst());
+        }
+        else
+        {
+            SLANG_UNEXPECTED("Only expected a single parameter to have IRGeometryPrimitiveTypeDecoration decoration");
+        }
+    }
+
+    // There *can* be multiple streamout parameters, to an entry point (points if nothing else)
+    {
+        IRType* type = pp->getFullType();
+        // Strip out type 
+        if (auto outType = as<IROutTypeBase>(type))
+        {
+            type = outType->getValueType();
+        }
+
+        if (auto streamType = as<IRHLSLStreamOutputType>(type))
+        {
+            if (auto decor = func->findDecoration<IRStreamOutputTypeDecoration>())
+            {
+                // If it has the same stream out type, we *may* be ok (might not work for all types of streams)
+                SLANG_ASSERT(decor->getStreamType()->op == streamType->op);
+            }
+            else
+            {
+                builder->addDecoration(func, kIROp_StreamOutputTypeDecoration, streamType);
+            }
+        }
+    }
+
     // We need to create a global variable that will replace the parameter.
     // It seems superficially obvious that the variable should have
     // the same type as the parameter.
@@ -1288,8 +1330,6 @@ void legalizeEntryPointParameterForGLSL(
             //
             // For now we will just try to deal with `Append` calls
             // directly in this function.
-
-
 
             for( auto bb = func->getFirstBlock(); bb; bb = bb->getNextBlock() )
             {

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -424,7 +424,6 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
 
         // Added to IRParam parameters to an entry point
     INST(GeometryPrimitiveTypeDecoration,  geometryPrimitiveTypeDecoration, 1, 0)
-    INST(StreamOutputTypeDecoration,       streamOutputTypeDecoration,    1, 0)
 
         /// An `[entryPoint]` decoration marks a function that represents a shader entry point
     INST(EntryPointDecoration,              entryPoint,             1, 0)

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -422,9 +422,11 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     INST(InstanceDecoration,                instance,               1, 0)
     INST(NumThreadsDecoration,              numThreads,             3, 0)
 
-        /// An `[entryPoint]` decoration marks a function that represents a shader entry point.
-        /// Also used in some scenarios mark parameters that are moved from entry point parameters to global params as coming from the entry point.
+        /// An `[entryPoint]` decoration marks a function that represents a shader entry point
     INST(EntryPointDecoration,              entryPoint,             0, 0)
+
+        /// Used to mark parameters that are moved from entry point parameters to global params as coming from the entry point.
+    INST(EntryPointParamDecoration,         entryPointParam,        0, 0)
 
         /// A `[dependsOn(x)]` decoration indicates that the parent instruction depends on `x`
         /// even if it does not otherwise reference it.

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -422,6 +422,10 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     INST(InstanceDecoration,                instance,               1, 0)
     INST(NumThreadsDecoration,              numThreads,             3, 0)
 
+        // Added to IRParam parameters to an entry point
+    INST(GeometryPrimitiveTypeDecoration,  geometryPrimitiveTypeDecoration, 1, 0)
+    INST(StreamOutputTypeDecoration,       streamOutputTypeDecoration,    1, 0)
+
         /// An `[entryPoint]` decoration marks a function that represents a shader entry point
     INST(EntryPointDecoration,              entryPoint,             1, 0)
 

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -424,6 +424,15 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
 
         // Added to IRParam parameters to an entry point
     INST(GeometryPrimitiveTypeDecoration,  geometryPrimitiveTypeDecoration, 1, 0)
+
+    /* GeometryPrimitiveTypeDecoration */
+        INST(PointPrimitiveTypeDecoration,  pointPrimitiveType,     0, 0)
+        INST(LinePrimitiveTypeDecoration,   linePrimitiveType,      0, 0)
+        INST(TrianglePrimitiveTypeDecoration, trianglePrimitiveType, 0, 0)
+        INST(LineAdjPrimitiveTypeDecoration,  lineAdjPrimitiveType,  0, 0)
+        INST(TriangleAdjPrimitiveTypeDecoration, triangleAdjPrimitiveType, 0, 0)
+    INST_RANGE(GeometryPrimitiveTypeDecoration, PointPrimitiveTypeDecoration, TriangleAdjPrimitiveTypeDecoration)
+
     INST(StreamOutputTypeDecoration,       streamOutputTypeDecoration,    1, 0)
 
         /// An `[entryPoint]` decoration marks a function that represents a shader entry point

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -424,6 +424,7 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
 
         // Added to IRParam parameters to an entry point
     INST(GeometryPrimitiveTypeDecoration,  geometryPrimitiveTypeDecoration, 1, 0)
+    INST(StreamOutputTypeDecoration,       streamOutputTypeDecoration,    1, 0)
 
         /// An `[entryPoint]` decoration marks a function that represents a shader entry point
     INST(EntryPointDecoration,              entryPoint,             1, 0)

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -423,7 +423,7 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     INST(NumThreadsDecoration,              numThreads,             3, 0)
 
         /// An `[entryPoint]` decoration marks a function that represents a shader entry point
-    INST(EntryPointDecoration,              entryPoint,             0, 0)
+    INST(EntryPointDecoration,              entryPoint,             1, 0)
 
         /// Used to mark parameters that are moved from entry point parameters to global params as coming from the entry point.
     INST(EntryPointParamDecoration,         entryPointParam,        0, 0)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -292,7 +292,44 @@ struct IREntryPointDecoration : IRDecoration
     enum { kOp = kIROp_EntryPointDecoration };
     IR_LEAF_ISA(EntryPointDecoration)
 
-    IRIntLit* getProfile() { return cast<IRIntLit>(getOperand(0)); }
+    IRIntLit* getProfileInst() { return cast<IRIntLit>(getOperand(0)); }
+    Profile getProfile() { return Profile(Profile::RawVal(GetIntVal(getProfileInst()))); }
+};
+
+struct IRGeometryPrimitiveTypeDecoration : IRDecoration
+{
+    enum { kOp = kIROp_GeometryPrimitiveTypeDecoration };
+    IR_LEAF_ISA(GeometryPrimitiveTypeDecoration)
+
+    enum class PrimitiveType
+    {
+        Unknown,
+        Triangle,
+        Point,
+        Line,
+        LineAdj,
+        TriangleAdj,
+    };
+
+    IRIntLit* getPrimitiveTypeInst() { return cast<IRIntLit>(getOperand(0)); }
+    PrimitiveType getPrimitiveType()
+    {
+        auto inst = getPrimitiveTypeInst();
+        return PrimitiveType(GetIntVal(inst));
+    }
+};
+
+    /// This is a bit of a hack. The problem is that when GLSL legalization takes place
+    /// any entry point parameters which are StreamOut are found they are removed and made
+    /// global. Meaning when doing entryPoint emitting it's kind of hard to know if there
+    /// are stream out parameters. To work around this we add this decoration to the entry
+    /// point that holds the stream out type.
+struct IRStreamOutputTypeDecoration : IRDecoration
+{
+    enum { kOp = kIROp_StreamOutputTypeDecoration };
+    IR_LEAF_ISA(StreamOutputTypeDecoration)
+
+    IRHLSLStreamOutputType* getStreamType() { return cast<IRHLSLStreamOutputType>(getOperand(0)); }
 };
 
     /// A decoration that marks a value as having linkage.

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -319,19 +319,6 @@ struct IRGeometryPrimitiveTypeDecoration : IRDecoration
     }
 };
 
-    /// This is a bit of a hack. The problem is that when GLSL legalization takes place
-    /// any entry point parameters which are StreamOut are found they are removed and made
-    /// global. Meaning when doing entryPoint emitting it's kind of hard to know if there
-    /// are stream out parameters. To work around this we add this decoration to the entry
-    /// point that holds the stream out type.
-struct IRStreamOutputTypeDecoration : IRDecoration
-{
-    enum { kOp = kIROp_StreamOutputTypeDecoration };
-    IR_LEAF_ISA(StreamOutputTypeDecoration)
-
-    IRHLSLStreamOutputType* getStreamType() { return cast<IRHLSLStreamOutputType>(getOperand(0)); }
-};
-
     /// A decoration that marks a value as having linkage.
     ///
     /// A value with linkage is either exported from its module,

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -319,13 +319,22 @@ struct IRGeometryPrimitiveTypeDecoration : IRDecoration
     }
 };
 
+    /// This is a bit of a hack. The problem is that when GLSL legalization takes place
     /// A decoration that marks a value as having linkage.
     ///
     /// A value with linkage is either exported from its module,
     /// or will have a definition imported from another module.
     /// In either case, it requires a mangled name to use when
     /// matching imports and exports.
-    ///
+struct IRStreamOutputTypeDecoration : IRDecoration
+{
+    enum { kOp = kIROp_StreamOutputTypeDecoration };
+    IR_LEAF_ISA(StreamOutputTypeDecoration)
+
+    IRHLSLStreamOutputType* getStreamType() { return cast<IRHLSLStreamOutputType>(getOperand(0)); }
+};
+
+
 struct IRLinkageDecoration : IRDecoration
 {
     IR_PARENT_ISA(LinkageDecoration)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -287,6 +287,14 @@ struct IRNumThreadsDecoration : IRDecoration
     IRIntLit* getZ() { return cast<IRIntLit>(getOperand(2)); }
 };
 
+struct IREntryPointDecoration : IRDecoration
+{
+    enum { kOp = kIROp_EntryPointDecoration };
+    IR_LEAF_ISA(EntryPointDecoration)
+
+    IRIntLit* getProfile() { return cast<IRIntLit>(getOperand(0)); }
+};
+
     /// A decoration that marks a value as having linkage.
     ///
     /// A value with linkage is either exported from its module,
@@ -1368,9 +1376,9 @@ struct IRBuilder
         addDecoration(value, kIROp_ExportDecoration, getStringValue(mangledName));
     }
 
-    void addEntryPointDecoration(IRInst* value)
+    void addEntryPointDecoration(IRInst* value, Profile profile)
     {
-        addDecoration(value, kIROp_EntryPointDecoration);
+        addDecoration(value, kIROp_EntryPointDecoration, getIntValue(getIntType(), profile.raw));
     }
 
     void addKeepAliveDecoration(IRInst* value)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -296,28 +296,17 @@ struct IREntryPointDecoration : IRDecoration
     Profile getProfile() { return Profile(Profile::RawVal(GetIntVal(getProfileInst()))); }
 };
 
-struct IRGeometryPrimitiveTypeDecoration : IRDecoration
+struct IRGeometryPrimitiveTypeDecoration: IRDecoration
 {
     enum { kOp = kIROp_GeometryPrimitiveTypeDecoration };
-    IR_LEAF_ISA(GeometryPrimitiveTypeDecoration)
-
-    enum class PrimitiveType
-    {
-        Unknown,
-        Triangle,
-        Point,
-        Line,
-        LineAdj,
-        TriangleAdj,
-    };
-
-    IRIntLit* getPrimitiveTypeInst() { return cast<IRIntLit>(getOperand(0)); }
-    PrimitiveType getPrimitiveType()
-    {
-        auto inst = getPrimitiveTypeInst();
-        return PrimitiveType(GetIntVal(inst));
-    }
+    IR_PARENT_ISA(GeometryPrimitiveTypeDecoration)
 };
+
+IR_SIMPLE_DECORATION(PointPrimitiveTypeDecoration)
+IR_SIMPLE_DECORATION(LinePrimitiveTypeDecoration)
+IR_SIMPLE_DECORATION(TrianglePrimitiveTypeDecoration)
+IR_SIMPLE_DECORATION(LineAdjPrimitiveTypeDecoration)
+IR_SIMPLE_DECORATION(TriangleAdjPrimitiveTypeDecoration)
 
     /// This is a bit of a hack. The problem is that when GLSL legalization takes place
     /// A decoration that marks a value as having linkage.

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -6338,7 +6338,7 @@ static void lowerFrontEndEntryPointToIR(
     {
         instToDecorate = findGenericReturnVal(irGeneric);
     }
-    builder->addEntryPointDecoration(instToDecorate);
+    builder->addEntryPointDecoration(instToDecorate, entryPoint->getProfile());
 }
 
 static void lowerProgramEntryPointToIR(

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -15,9 +15,6 @@
 #include "slang-type-layout.h"
 #include "slang-visitor.h"
 
-#include "slang-syntax.h"
-#include "slang-legalize-types.h"
-
 namespace Slang
 {
 
@@ -6343,7 +6340,7 @@ static void lowerFrontEndEntryPointToIR(
     }
     builder->addEntryPointDecoration(instToDecorate, entryPoint->getProfile());
 
-    // lets see if we can get get the layout
+    // Go through the entry point parameters creating decorations from layout as appropriate
     {
         FilteredMemberList<ParamDecl> params = entryPointFuncDecl->GetParameters();
 

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -6353,23 +6353,22 @@ static void lowerFrontEndEntryPointToIR(
             {
                 if (auto modifier = param->FindModifier<HLSLGeometryShaderInputPrimitiveTypeModifier>())
                 {
-                    typedef IRGeometryPrimitiveTypeDecoration::PrimitiveType PrimitiveType;
-                    PrimitiveType primType = PrimitiveType::Unknown;
+                    IROp op = kIROp_Invalid;
 
                     if (as<HLSLTriangleModifier>(modifier))
-                        primType = PrimitiveType::Triangle;
+                        op = kIROp_TrianglePrimitiveTypeDecoration;
                     else if (as<HLSLPointModifier>(modifier))
-                        primType = PrimitiveType::Point;
+                        op = kIROp_PointPrimitiveTypeDecoration;
                     else if (as<HLSLLineModifier>(modifier))
-                        primType = PrimitiveType::Line; 
+                        op = kIROp_LinePrimitiveTypeDecoration; 
                     else if (as<HLSLLineAdjModifier>(modifier))
-                        primType = PrimitiveType::LineAdj;
+                        op = kIROp_LineAdjPrimitiveTypeDecoration;
                     else if (as<HLSLTriangleAdjModifier>(modifier))
-                        primType = PrimitiveType::TriangleAdj;
+                        op = kIROp_TriangleAdjPrimitiveTypeDecoration;
 
-                    if (primType != PrimitiveType::Unknown)
+                    if (op != kIROp_Invalid)
                     {
-                        builder->addDecoration(irParam, kIROp_GeometryPrimitiveTypeDecoration, builder->getIntValue(builder->getIntType(), int(primType)));
+                        builder->addDecoration(irParam, op);
                     }
                     else
                     {

--- a/tests/ir/string-literal.slang.expected
+++ b/tests/ir/string-literal.slang.expected
@@ -1,6 +1,6 @@
 result code = 0
 standard error = {
-[entryPoint]
+[entryPoint(6)]
 [numThreads(1, 1, 1)]
 [export("_S3tu04mainp1puV")]
 [nameHint("main")]


### PR DESCRIPTION
This is on top of #1068, and just removes two functions

setSampleRateFlag & doSampleRateInputCheck

That were in CLikeSourceEmitter as no longer used. 

