### PR TITLE
Feature/decor entry point name

### DIFF
--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -600,6 +600,20 @@ String CLikeSourceEmitter::generateName(IRInst* inst)
         return String(intrinsicDecoration->getDefinition());
     }
 
+    auto entryPointDecor = inst->findDecoration<IREntryPointDecoration>();
+    if (entryPointDecor && getSourceStyle() == SourceStyle::GLSL)
+    {
+        // GLSL will always need to use `main` as the
+        // name for an entry-point function, but other
+        // targets should try to use the original name.
+        //
+        // TODO: always use the original name, and
+        // use the appropriate options for glslang to
+        // make it support a non-`main` name.
+        //
+        return "main";
+    }
+
     // If we have a name hint on the instruction, then we will try to use that
     // to provide the actual name in the output code.
     //
@@ -618,6 +632,13 @@ String CLikeSourceEmitter::generateName(IRInst* inst)
     //
     if(auto nameHintDecoration = inst->findDecoration<IRNameHintDecoration>())
     {
+        // We need to special case entry points to use the name as given.
+        if (entryPointDecor)
+        {
+            // Just use the name as given
+            return nameHintDecoration->getName();
+        }
+
         // The name we output will basically be:
         //
         //      <nameHint>_<uniqueID>
@@ -2448,34 +2469,6 @@ bool CLikeSourceEmitter::isDefinition(IRFunc* func)
     return func->getFirstBlock() != nullptr;
 }
 
-String CLikeSourceEmitter::getFuncName(IRFunc* func)
-{
-    if (auto entryPointLayout = asEntryPoint(func))
-    {
-        // GLSL will always need to use `main` as the
-        // name for an entry-point function, but other
-        // targets should try to use the original name.
-        //
-        // TODO: always use the original name, and
-        // use the appropriate options for glslang to
-        // make it support a non-`main` name.
-        //
-        if (getSourceStyle() != SourceStyle::GLSL)
-        {
-            return getText(entryPointLayout->getFuncDecl()->getName());
-        }
-
-        //
-
-        return "main";
-    }
-    else
-    {
-        return getName(func);
-    }
-}
-
-
 void CLikeSourceEmitter::emitEntryPointAttributes(IRFunc* irFunc, IREntryPointDecoration* entryPointDecor)
 {
     emitEntryPointAttributesImpl(irFunc, entryPointDecor);
@@ -2549,7 +2542,7 @@ void CLikeSourceEmitter::emitSimpleFuncImpl(IRFunc* func)
         emitEntryPointAttributes(func, entryPointDecor);
     }
 
-    auto name = getFuncName(func);
+    auto name = getName(func);
 
     emitType(resultType, name);
 
@@ -2657,7 +2650,7 @@ void CLikeSourceEmitter::emitFuncDecl(IRFunc* func)
     auto funcType = func->getDataType();
     auto resultType = func->getResultType();
 
-    auto name = getFuncName(func);
+    auto name = getName(func);
 
     emitType(resultType, name);
 

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -601,17 +601,22 @@ String CLikeSourceEmitter::generateName(IRInst* inst)
     }
 
     auto entryPointDecor = inst->findDecoration<IREntryPointDecoration>();
-    if (entryPointDecor && getSourceStyle() == SourceStyle::GLSL)
+    if (entryPointDecor)
     {
-        // GLSL will always need to use `main` as the
-        // name for an entry-point function, but other
-        // targets should try to use the original name.
-        //
-        // TODO: always use the original name, and
-        // use the appropriate options for glslang to
-        // make it support a non-`main` name.
-        //
-        return "main";
+        if (getSourceStyle() == SourceStyle::GLSL)
+        {
+            // GLSL will always need to use `main` as the
+            // name for an entry-point function, but other
+            // targets should try to use the original name.
+            //
+            // TODO: always use the original name, and
+            // use the appropriate options for glslang to
+            // make it support a non-`main` name.
+            //
+            return "main";
+        }
+
+        return entryPointDecor->getName()->getStringSlice();
     }
 
     // If we have a name hint on the instruction, then we will try to use that
@@ -632,13 +637,6 @@ String CLikeSourceEmitter::generateName(IRInst* inst)
     //
     if(auto nameHintDecoration = inst->findDecoration<IRNameHintDecoration>())
     {
-        // We need to special case entry points to use the name as given.
-        if (entryPointDecor)
-        {
-            // Just use the name as given
-            return nameHintDecoration->getName();
-        }
-
         // The name we output will basically be:
         //
         //      <nameHint>_<uniqueID>

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -239,8 +239,6 @@ public:
         // Is an IR function a definition? (otherwise it is a declaration)
     bool isDefinition(IRFunc* func);
 
-    String getFuncName(IRFunc* func);
-
     void emitEntryPointAttributes(IRFunc* irFunc, IREntryPointDecoration* entryPointDecor);
 
     void emitPhiVarDecls(IRFunc* func);

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -1939,15 +1939,14 @@ void CPPSourceEmitter::emitSimpleFuncImpl(IRFunc* func)
 {
     auto resultType = func->getResultType();
 
-    auto name = getFuncName(func);
+    auto name = getName(func);
 
     // Deal with decorations that need
     // to be emitted as attributes
 
     // We are going to ignore the parameters passed and just pass in the Context
 
-    auto entryPointLayout = asEntryPoint(func);
-    if (entryPointLayout)
+    if (IREntryPointDecoration* entryPointDecor = func->findDecoration<IREntryPointDecoration>())
     {
         StringBuilder prefixName;
         prefixName << "_" << name;
@@ -2809,8 +2808,9 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
         {
             IRFunc* func = as<IRFunc>(action.inst);
 
-            auto entryPointLayout = asEntryPoint(func);
-            if (entryPointLayout && entryPointLayout->profile.GetStage() == Stage::Compute)
+            IREntryPointDecoration* entryPointDecor = func->findDecoration<IREntryPointDecoration>();
+          
+            if (entryPointDecor && entryPointDecor->getProfile().GetStage() == Stage::Compute)
             {
                 // https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/sv-dispatchthreadid
                 // SV_DispatchThreadID is the sum of SV_GroupID * numthreads and GroupThreadID.
@@ -2818,7 +2818,7 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
                 Int groupThreadSize[kThreadGroupAxisCount];
                 getComputeThreadGroupSize(func, groupThreadSize);
                 
-                String funcName = getFuncName(func);
+                String funcName = getName(func);
 
                 {
                     StringBuilder builder;
@@ -2852,7 +2852,7 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
                 // Emit the group version which runs for all elements in *single* thread group
                 {
                     StringBuilder builder;
-                    builder << getFuncName(func);
+                    builder << getName(func);
                     builder << "_Group";
 
                     String groupFuncName = builder;

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -434,7 +434,7 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     INST(StreamOutputTypeDecoration,       streamOutputTypeDecoration,    1, 0)
 
         /// An `[entryPoint]` decoration marks a function that represents a shader entry point
-    INST(EntryPointDecoration,              entryPoint,             1, 0)
+    INST(EntryPointDecoration,              entryPoint,             2, 0)
 
         /// Used to mark parameters that are moved from entry point parameters to global params as coming from the entry point.
     INST(EntryPointParamDecoration,         entryPointParam,        0, 0)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -294,6 +294,8 @@ struct IREntryPointDecoration : IRDecoration
 
     IRIntLit* getProfileInst() { return cast<IRIntLit>(getOperand(0)); }
     Profile getProfile() { return Profile(Profile::RawVal(GetIntVal(getProfileInst()))); }
+
+    IRStringLit* getName()  { return cast<IRStringLit>(getOperand(1)); }
 };
 
 struct IRGeometryInputPrimitiveTypeDecoration: IRDecoration
@@ -1400,9 +1402,9 @@ struct IRBuilder
         addDecoration(value, kIROp_ExportDecoration, getStringValue(mangledName));
     }
 
-    void addEntryPointDecoration(IRInst* value, Profile profile)
+    void addEntryPointDecoration(IRInst* value, Profile profile, UnownedStringSlice const& name)
     {
-        addDecoration(value, kIROp_EntryPointDecoration, getIntValue(getIntType(), profile.raw));
+        addDecoration(value, kIROp_EntryPointDecoration, getIntValue(getIntType(), profile.raw), getStringValue(name));
     }
 
     void addKeepAliveDecoration(IRInst* value)

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -6338,7 +6338,11 @@ static void lowerFrontEndEntryPointToIR(
     {
         instToDecorate = findGenericReturnVal(irGeneric);
     }
-    builder->addEntryPointDecoration(instToDecorate, entryPoint->getProfile());
+
+    {
+        Name* entryPointName = entryPoint->getFuncDecl()->getName();
+        builder->addEntryPointDecoration(instToDecorate, entryPoint->getProfile(), entryPointName->text.getUnownedSlice());
+    }
 
     // Go through the entry point parameters creating decorations from layout as appropriate
     {

--- a/tests/ir/string-literal.slang.expected
+++ b/tests/ir/string-literal.slang.expected
@@ -1,6 +1,6 @@
 result code = 0
 standard error = {
-[entryPoint(6)]
+[entryPoint(6, "main")]
 [numThreads(1, 1, 1)]
 [export("_S3tu04mainp1puV")]
 [nameHint("main")]


### PR DESCRIPTION
* Added name to EntryPointDecoration
* Use entry point name for naming entry points - instead of layout

This may not last this way for too long - as may be better to use LinkageDecoration for getting the name. Trouble is at the moment not all IRFuncs that reach emit have LinkageDecoration. For a case in point `tests/bugs/gh-357.slang`

Once IRFunc have suitable linkage (or some way to get to the linkage) will update to that. 

