### PR TITLE
Add ability to obfuscate name when generating GLSL/HLSL source

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -560,6 +560,9 @@ extern "C"
         /* Skip code generation step, just check the code and generate layout */
         SLANG_COMPILE_FLAG_NO_CODEGEN           = 1 << 4,
 
+        /* Obfuscate shader names on release products */
+        SLANG_COMPILE_FLAG_OBFUSCATE = 1 << 5,
+
         /* Deprecated flags: kept around to allow existing applications to
         compile. Note that the relevant features will still be left in
         their default state. */

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1636,6 +1636,9 @@ namespace Slang
         //
         bool useUnknownImageFormatAsDefault = false;
 
+        // Remove name hints to help obfuscate code
+        //
+        bool obfuscateCode = false;
     private:
         RefPtr<ComponentType> m_program;
     };

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -637,7 +637,7 @@ String CLikeSourceEmitter::generateName(IRInst* inst)
     //
     if(auto nameHintDecoration = inst->findDecoration<IRNameHintDecoration>())
     {
-        // The name we output will basically be:
+        // The (non-obfuscated) name we output will basically be:
         //
         //      <nameHint>_<uniqueID>
         //
@@ -645,15 +645,28 @@ String CLikeSourceEmitter::generateName(IRInst* inst)
         // and we will omit the underscore if the (scrubbed)
         // name hint already ends with one.
         //
-
-        String nameHint = nameHintDecoration->getName();
-        nameHint = scrubName(nameHint);
+        // The obfuscated name we output will simply be:
+        //
+        //      _<uniqueID>
+        //
 
         StringBuilder sb;
-        sb.append(nameHint);
 
-        // Avoid introducing a double underscore
-        if(!nameHint.endsWith("_"))
+        if (!m_compileRequest->obfuscateCode)
+        {
+
+            String nameHint = nameHintDecoration->getName();
+            nameHint = scrubName(nameHint);
+
+            sb.append(nameHint);
+
+            // Avoid introducing a double underscore
+            if (!nameHint.endsWith("_"))
+            {
+                sb.append("_");
+            }
+        }
+        else
         {
             sb.append("_");
         }

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -775,6 +775,10 @@ struct OptionsParser
                 {
                     requestImpl->getBackEndReq()->useUnknownImageFormatAsDefault = true;
                 }
+                else if (argStr == "-obfuscate")
+                {
+                    requestImpl->getBackEndReq()->obfuscateCode = true;
+                }
                 else if (argStr == "-file-system")
                 {
                     String name;


### PR DESCRIPTION
This change adds a `-obfuscate` command-line option (and corresponding API flag) that can be used to turn off the use of original source name information in generated HLSL/GLSL. This option can be used when clients of the Slang compiler would like to produce DXIL or SPIR-V that doesn't include information about the original names in their source program, but don't want to deal with IR-specific tools for stripping such information.

Note that this change does not address things like `#line` directives, which can technically be controlled by other flags, but might want to also be covered by `-obfuscate`.