### PR TITLE
User IR-based layout for all IR steps

### DIFF
--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -77,7 +77,7 @@ public:
     // A chain of variables to use for emitting semantic/layout info
     struct EmitVarChain
     {
-        VarLayout*      varLayout;
+        IRVarLayout*      varLayout;
         EmitVarChain*   next;
 
         EmitVarChain()
@@ -85,12 +85,12 @@ public:
             , next(nullptr)
         {}
 
-        EmitVarChain(VarLayout* varLayout)
+        EmitVarChain(IRVarLayout* varLayout)
             : varLayout(varLayout)
             , next(nullptr)
         {}
 
-        EmitVarChain(VarLayout* varLayout, EmitVarChain* next)
+        EmitVarChain(IRVarLayout* varLayout, EmitVarChain* next)
             : varLayout(varLayout)
             , next(next)
         {}
@@ -206,10 +206,17 @@ public:
 
     void emitInst(IRInst* inst);
 
-    void emitSemantics(VarLayout* varLayout);
+    // TODO: When this signature switched from `VarLayout` to `IRVarLayout`
+    // it became possible to get confused beetween this overload and the
+    // one that takes a base `IRInst`. We should probably be careful and
+    // rename one of the other of the `emitSemantics()` functions to avoid
+    // confusion.
+    //
+    void emitSemantics(IRVarLayout* varLayout);
+
     void emitSemantics(IRInst* inst);
 
-    static VarLayout* getVarLayout(IRInst* var);
+    static IRVarLayout* getVarLayout(IRInst* var);
 
     void emitLayoutSemantics(IRInst* inst, char const* uniformSemanticSpelling = "register");
 
@@ -244,9 +251,9 @@ public:
 
     void emitFuncDecl(IRFunc* func);
 
-    EntryPointLayout* getEntryPointLayout(IRFunc* func);
+    IREntryPointLayout* getEntryPointLayout(IRFunc* func);
 
-    EntryPointLayout* asEntryPoint(IRFunc* func);
+    IREntryPointLayout* asEntryPoint(IRFunc* func);
 
         // Detect if the given IR function represents a
         // declaration of an intrinsic/builtin for the
@@ -262,7 +269,7 @@ public:
 
     void emitStruct(IRStructType* structType);
 
-    void emitInterpolationModifiers(IRInst* varInst, IRType* valueType, VarLayout* layout);
+    void emitInterpolationModifiers(IRInst* varInst, IRType* valueType, IRVarLayout* layout);
 
     UInt getRayPayloadLocation(IRInst* inst);
 
@@ -271,7 +278,7 @@ public:
         /// Emit modifiers that should apply even for a declaration of an SSA temporary.
     void emitTempModifiers(IRInst* temp);
 
-    void emitVarModifiers(VarLayout* layout, IRInst* varDecl, IRType* varType);
+    void emitVarModifiers(IRVarLayout* layout, IRInst* varDecl, IRType* varType);
 
         /// Emit the array brackets that go on the end of a declaration of the given type.
     void emitArrayBrackets(IRType* inType);
@@ -317,16 +324,16 @@ public:
     virtual void emitEntryPointAttributesImpl(IRFunc* irFunc, IREntryPointDecoration* entryPointDecor) = 0;
 
     virtual void emitImageFormatModifierImpl(IRInst* varDecl, IRType* varType) { SLANG_UNUSED(varDecl); SLANG_UNUSED(varType); }
-    virtual void emitLayoutQualifiersImpl(VarLayout* layout) { SLANG_UNUSED(layout); }
+    virtual void emitLayoutQualifiersImpl(IRVarLayout* layout) { SLANG_UNUSED(layout); }
     virtual void emitPreprocessorDirectivesImpl() {}
     virtual void emitLayoutDirectivesImpl(TargetRequest* targetReq) { SLANG_UNUSED(targetReq); }
     virtual void emitRateQualifiersImpl(IRRate* rate) { SLANG_UNUSED(rate); }
     virtual void emitSemanticsImpl(IRInst* inst) { SLANG_UNUSED(inst);  }
     virtual void emitSimpleFuncParamImpl(IRParam* param);
-    virtual void emitInterpolationModifiersImpl(IRInst* varInst, IRType* valueType, VarLayout* layout) { SLANG_UNUSED(varInst); SLANG_UNUSED(valueType); SLANG_UNUSED(layout); }
+    virtual void emitInterpolationModifiersImpl(IRInst* varInst, IRType* valueType, IRVarLayout* layout) { SLANG_UNUSED(varInst); SLANG_UNUSED(valueType); SLANG_UNUSED(layout); }
     virtual void emitSimpleTypeImpl(IRType* type) = 0;
     virtual void emitVarDecorationsImpl(IRInst* varDecl) { SLANG_UNUSED(varDecl);  }
-    virtual void emitMatrixLayoutModifiersImpl(VarLayout* layout) { SLANG_UNUSED(layout);  }
+    virtual void emitMatrixLayoutModifiersImpl(IRVarLayout* layout) { SLANG_UNUSED(layout);  }
     virtual void emitTypeImpl(IRType* type, const StringSliceLoc* nameLoc);
     virtual void emitSimpleValueImpl(IRInst* inst);
     virtual void emitModuleImpl(IRModule* module);

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -2389,9 +2389,9 @@ void CPPSourceEmitter::emitOperandImpl(IRInst* inst, EmitOpInfo const&  outerPre
 
             if (varLayout)
             {
-                auto semanticNameSpelling = varLayout->systemValueSemantic;
-                if (semanticNameSpelling.getLength())
+                if(auto systemValueSemantic = varLayout->findSystemValueSemanticAttr())
                 {
+                    String semanticNameSpelling = systemValueSemantic->getName();
                     semanticNameSpelling = semanticNameSpelling.toLower();
 
                     if (semanticNameSpelling == "sv_dispatchthreadid")
@@ -2714,17 +2714,18 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
                     continue;
                 }
 
-                VarLayout* varLayout = CLikeSourceEmitter::getVarLayout(action.inst);
+                IRVarLayout* varLayout = CLikeSourceEmitter::getVarLayout(action.inst);
                 SLANG_ASSERT(varLayout);
-                const VarLayout::ResourceInfo* varInfo = varLayout->FindResourceInfo(LayoutResourceKind::Uniform);
-                TypeLayout* typeLayout = varLayout->getTypeLayout();
-                TypeLayout::ResourceInfo* typeInfo = typeLayout->FindResourceInfo(LayoutResourceKind::Uniform);
+
+                IRVarOffsetAttr* offsetAttr = varLayout->findOffsetAttr(LayoutResourceKind::Uniform);
+                IRTypeLayout* typeLayout = varLayout->getTypeLayout();
+                IRTypeSizeAttr* sizeAttr = typeLayout->findSizeAttr(LayoutResourceKind::Uniform);
 
                 GlobalParamInfo paramInfo;
                 paramInfo.inst = action.inst;
                 // Index is the byte offset for uniform
-                paramInfo.offset = varInfo ? varInfo->index : 0;
-                paramInfo.size = typeInfo ? typeInfo->count.raw : 0;
+                paramInfo.offset = offsetAttr ? offsetAttr->getOffset() : 0;
+                paramInfo.size = sizeAttr ? sizeAttr->getFiniteSize() : 0;
 
                 params.add(paramInfo);
             }

--- a/source/slang/slang-emit-glsl.h
+++ b/source/slang/slang-emit-glsl.h
@@ -22,18 +22,18 @@ protected:
     virtual void emitParameterGroupImpl(IRGlobalParam* varDecl, IRUniformParameterGroupType* type) SLANG_OVERRIDE;
     virtual void emitEntryPointAttributesImpl(IRFunc* irFunc, IREntryPointDecoration* entryPointDecor) SLANG_OVERRIDE;
     virtual void emitImageFormatModifierImpl(IRInst* varDecl, IRType* varType) SLANG_OVERRIDE;
-    virtual void emitLayoutQualifiersImpl(VarLayout* layout) SLANG_OVERRIDE;
+    virtual void emitLayoutQualifiersImpl(IRVarLayout* layout) SLANG_OVERRIDE;
     
     virtual void emitTextureOrTextureSamplerTypeImpl(IRTextureTypeBase*  type, char const* baseName) SLANG_OVERRIDE { _emitGLSLTextureOrTextureSamplerType(type, baseName); }
 
     virtual void emitPreprocessorDirectivesImpl() SLANG_OVERRIDE;
     virtual void emitLayoutDirectivesImpl(TargetRequest* targetReq) SLANG_OVERRIDE;
     virtual void emitRateQualifiersImpl(IRRate* rate) SLANG_OVERRIDE;
-    virtual void emitInterpolationModifiersImpl(IRInst* varInst, IRType* valueType, VarLayout* layout) SLANG_OVERRIDE;
+    virtual void emitInterpolationModifiersImpl(IRInst* varInst, IRType* valueType, IRVarLayout* layout) SLANG_OVERRIDE;
     virtual void emitSimpleTypeImpl(IRType* type) SLANG_OVERRIDE;
     virtual void emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount) SLANG_OVERRIDE;
     virtual void emitVarDecorationsImpl(IRInst* varDecl) SLANG_OVERRIDE;
-    virtual void emitMatrixLayoutModifiersImpl(VarLayout* layout) SLANG_OVERRIDE;
+    virtual void emitMatrixLayoutModifiersImpl(IRVarLayout* layout) SLANG_OVERRIDE;
 
     virtual void handleCallExprDecorationsImpl(IRInst* funcValue) SLANG_OVERRIDE;
 
@@ -48,7 +48,7 @@ protected:
 
     void _emitGLSLImageFormatModifier(IRInst* var, IRTextureType* resourceType);
 
-    void _emitGLSLLayoutQualifiers(RefPtr<VarLayout> layout, EmitVarChain* inChain, LayoutResourceKind filter = LayoutResourceKind::None);
+    void _emitGLSLLayoutQualifiers(IRVarLayout* layout, EmitVarChain* inChain, LayoutResourceKind filter = LayoutResourceKind::None);
     bool _emitGLSLLayoutQualifier(LayoutResourceKind kind, EmitVarChain* chain);
 
     void _emitGLSLTypePrefix(IRType* type, bool promoteHalfToFloat = false);

--- a/source/slang/slang-emit-hlsl.h
+++ b/source/slang/slang-emit-hlsl.h
@@ -25,11 +25,11 @@ protected:
     virtual void emitRateQualifiersImpl(IRRate* rate) SLANG_OVERRIDE;
     virtual void emitSemanticsImpl(IRInst* inst) SLANG_OVERRIDE;
     virtual void emitSimpleFuncParamImpl(IRParam* param) SLANG_OVERRIDE;
-    virtual void emitInterpolationModifiersImpl(IRInst* varInst, IRType* valueType, VarLayout* layout) SLANG_OVERRIDE;
+    virtual void emitInterpolationModifiersImpl(IRInst* varInst, IRType* valueType, IRVarLayout* layout) SLANG_OVERRIDE;
     virtual void emitSimpleTypeImpl(IRType* type) SLANG_OVERRIDE;
     virtual void emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount) SLANG_OVERRIDE;
     virtual void emitVarDecorationsImpl(IRInst* varDecl) SLANG_OVERRIDE;
-    virtual void emitMatrixLayoutModifiersImpl(VarLayout* layout) SLANG_OVERRIDE;
+    virtual void emitMatrixLayoutModifiersImpl(IRVarLayout* layout) SLANG_OVERRIDE;
 
     virtual bool tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;
 
@@ -39,10 +39,10 @@ protected:
 
         // Emit all the `register` semantics that are appropriate for a particular variable layout
     void _emitHLSLRegisterSemantics(EmitVarChain* chain, char const* uniformSemanticSpelling = "register");
-    void _emitHLSLRegisterSemantics(VarLayout* varLayout, char const* uniformSemanticSpelling = "register");
+    void _emitHLSLRegisterSemantics(IRVarLayout* varLayout, char const* uniformSemanticSpelling = "register");
 
     void _emitHLSLParameterGroupFieldLayoutSemantics(EmitVarChain* chain);
-    void _emitHLSLParameterGroupFieldLayoutSemantics(RefPtr<VarLayout> fieldLayout, EmitVarChain* inChain);
+    void _emitHLSLParameterGroupFieldLayoutSemantics(IRVarLayout* fieldLayout, EmitVarChain* inChain);
 
     void _emitHLSLParameterGroup(IRGlobalParam* varDecl, IRUniformParameterGroupType* type);
 

--- a/source/slang/slang-ir-bind-existentials.cpp
+++ b/source/slang/slang-ir-bind-existentials.cpp
@@ -196,14 +196,14 @@ struct BindExistentialSlots
         auto layoutDecoration = param->findDecoration<IRLayoutDecoration>();
         if(!layoutDecoration)
             return;
-        auto varLayout = as<VarLayout>(layoutDecoration->getASTLayout());
+        auto varLayout = as<IRVarLayout>(layoutDecoration->getLayout());
         if(!varLayout)
             return;
 
         // We only care about parameters that are associated
         // with one or more existential slots.
         //
-        auto resInfo = varLayout->FindResourceInfo(LayoutResourceKind::ExistentialTypeParam);
+        auto resInfo = varLayout->findOffsetAttr(LayoutResourceKind::ExistentialTypeParam);
         if(!resInfo)
             return;
 
@@ -212,8 +212,8 @@ struct BindExistentialSlots
         // the type to find out the number of slots.
         //
         UInt slotCount = 0;
-        if(auto typeResInfo = varLayout->getTypeLayout()->FindResourceInfo(LayoutResourceKind::ExistentialTypeParam))
-            slotCount = UInt(typeResInfo->count.getFiniteValue());
+        if(auto typeResInfo = varLayout->getTypeLayout()->findSizeAttr(LayoutResourceKind::ExistentialTypeParam))
+            slotCount = UInt(typeResInfo->getFiniteSize());
 
         // At this point we know that the parameter consumes
         // some number of slots, so it would be an error

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -456,18 +456,9 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
         INST(ExportDecoration, export, 1, 0)
     INST_RANGE(LinkageDecoration, ImportDecoration, ExportDecoration)
 
-    /* Layout decorations that do not use AST */
-    INST(StageLayoutDecoration, stageLayoutDecoration, 1, 0)
-    INST(ResourceInfoLayoutDecoration, resourceInfoLayoutDecoration, 3, 0)
+    INST(SemanticDecoration, semantic, 2, 0)
 
-    /* SemanticLayoutDecoration */
-        INST(SemanticDecoration, semantic, 2, 0)
-        INST(SystemSemanticDecoration, systemSemantic, 2, 0)
-    INST_RANGE(SemanticDecorationBase, SemanticDecoration, SystemSemanticDecoration)
-
-    INST(PendingVarLayoutDecoration, pendingVarLayoutDecoration, 1, 0)
-
-INST_RANGE(Decoration, HighLevelDeclDecoration, PendingVarLayoutDecoration)
+    INST_RANGE(Decoration, HighLevelDeclDecoration, SemanticDecoration)
 
 
 //
@@ -495,10 +486,35 @@ INST(ExtractTaggedUnionPayload,         extractTaggedUnionPayload,  1, 0)
 INST(BitCast,                           bitCast,                    1, 0)
 
 /* Layout */
-    INST(VarLayout, varLayout, 4, 0)
-    INST(TypeLayout, typeLayout, 1, 0)
+    INST(VarLayout, varLayout, 1, 0)
+
+    /* TypeLayout */
+        INST(TypeLayoutBase, typeLayout, 0, 0)
+        INST(ParameterGroupTypeLayout, parameterGroupTypeLayout, 2, 0)
+        INST(ArrayTypeLayout, arrayTypeLayout, 1, 0)
+        INST(StreamOutputTypeLayout, streamOutputTypeLayout, 1, 0)
+        INST(MatrixTypeLayout, matrixTypeLayout, 1, 0)
+        INST(TaggedUnionTypeLayout, taggedUnionTypeLayout, 0, 0)
+        INST(StructTypeLayout, structTypeLayout, 0, 0)
+    INST_RANGE(TypeLayout, TypeLayoutBase, StructTypeLayout)
+
     INST(EntryPointLayout, EntryPointLayout, 1, 0)
 INST_RANGE(Layout, VarLayout, EntryPointLayout)
+
+/* Attr */
+    INST(PendingLayoutAttr, pendingLayout, 1, 0)
+    INST(StageAttr, stage, 1, 0)
+    INST(StructFieldLayoutAttr, fieldLayout, 2, 0)
+    INST(CaseTypeLayoutAttr, caseLayout, 1, 0)
+    /* SemanticAttr */
+        INST(UserSemanticAttr, userSemantic, 2, 0)
+        INST(SystemValueSemanticAttr, systemValueSemantic, 2, 0)
+    INST_RANGE(SemanticAttr, UserSemanticAttr, SystemValueSemanticAttr)
+    /* LayoutResourceInfoAttr */
+        INST(TypeSizeAttr, size, 2, 0)
+        INST(VarOffsetAttr, offset, 2, 0)
+    INST_RANGE(LayoutResourceInfoAttr, TypeSizeAttr, VarOffsetAttr)
+INST_RANGE(Attr, PendingLayoutAttr, VarOffsetAttr)
 
 PSEUDO_INST(Pos)
 PSEUDO_INST(PreInc)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -370,129 +370,688 @@ struct IRLookupWitnessTable : IRInst
 
 // Layout decorations
 
-struct IRStageLayoutDecoration : public IRDecoration
+    /// A decoration that marks a field key as having been associated
+    /// with a particular simple semantic (e.g., `COLOR` or `SV_Position`,
+    /// but not a `register` semantic).
+    ///
+    /// This is currently needed so that we can round-trip HLSL `struct`
+    /// types that get used for varying input/output. This is an unfortunate
+    /// case where some amount of "layout" information can't just come
+    /// in via the `TypeLayout` part of things.
+    ///
+struct IRSemanticDecoration : public IRDecoration
 {
-    enum { kOp = kIROp_StageLayoutDecoration };
-    IR_LEAF_ISA(StageLayoutDecoration)
-
-    IRIntLit* getStageInst() { return cast<IRIntLit>(getOperand(0)); }
-    Stage getStage() { return Stage(GetIntVal(getStageInst())); }
-};
-
-struct IRSemanticDecorationBase : public IRDecoration
-{
-    IR_PARENT_ISA(SemanticDecorationBase)
+    IR_LEAF_ISA(SemanticDecoration)
 
     IRStringLit* getSemanticNameOperand() { return cast<IRStringLit>(getOperand(0)); }
     UnownedStringSlice getSemanticName() { return getSemanticNameOperand()->getStringSlice(); }
+
     IRIntLit* getSemanticIndexOperand() { return cast<IRIntLit>(getOperand(1)); }
     int getSemanticIndex() { return int(GetIntVal(getSemanticIndexOperand())); }
 };
 
-// A decoration that marks a field key as having been associated
-// with a particular simple semantic (e.g., `COLOR` or `SV_Position`,
-// but not a `register` semantic).
-//
-// This is currently needed so that we can round-trip HLSL `struct`
-// types that get used for varying input/output. This is an unfortunate
-// case where some amount of "layout" information can't just come
-// in via the `TypeLayout` part of things.
-//
-struct IRSemanticDecoration : IRSemanticDecorationBase
+    /// An attribute that can be attached to another instruction as an operand.
+    ///
+    /// Attributes serve a similar role to decorations, in that both are ways
+    /// to attach additional information to an instruction, where the operand
+    /// of the attribute/decoration identifies the purpose of the additional
+    /// information.
+    ///
+    /// The key difference between decorations and attributes is that decorations
+    /// are stored as children of an instruction (in terms of the ownership
+    /// hierarchy), while attributes are referenced as operands.
+    ///
+    /// The key benefit of having attributes be operands is that they must
+    /// be present at the time an instruction is created, which means that
+    /// they can affect the conceptual value/identity of an instruction
+    /// in cases where we deduplicate/hash instructions by value.
+    ///
+struct IRAttr : public IRInst
 {
-    enum { kOp = kIROp_SemanticDecoration };
-    IR_LEAF_ISA(SemanticDecoration)
+    IR_PARENT_ISA(Attr);
 };
 
-struct IRSystemSemanticDecoration : IRSemanticDecorationBase
+    /// An attribute that specifies layout information for a single resource kind.
+struct IRLayoutResourceInfoAttr : public IRAttr
 {
-    enum { kOp = kIROp_SystemSemanticDecoration };
-    IR_LEAF_ISA(SystemSemanticDecoration)
-};
+    IR_PARENT_ISA(LayoutResourceInfoAttr);
 
-/// Holds the resource usage. Typically bound to an IRVarLayout. Note that there can be multiple decorations,
-/// for each resource kind. That there should at most be one decoration connected to an instruction for a *kind*.
-struct IRResourceInfoLayoutDecoration : public IRDecoration
-{
-    enum { kOp = kIROp_ResourceInfoLayoutDecoration };
-    IR_LEAF_ISA(ResourceInfoLayoutDecoration)
-
-        // What kind of register was it?
     IRIntLit* getResourceKindInst() { return cast<IRIntLit>(getOperand(0)); }
-    LayoutResourceKind getResourceKind() { return (LayoutResourceKind)GetIntVal(getResourceKindInst()); }
+    LayoutResourceKind getResourceKind() { return LayoutResourceKind(GetIntVal(getResourceKindInst())); }
+};
 
-        // What binding space (HLSL) or set (Vulkan) are we placed in?
-    IRIntLit* getSpaceInst() { return cast<IRIntLit>(getOperand(1)); }
-    UInt getSpace() { return UInt(GetIntVal(getSpaceInst())); }
+    /// An attribute that specifies offset information for a single resource kind.
+    ///
+    /// This operation can appear as `varOffset(kind, offset)` or
+    /// `varOffset(kind, offset, space)`. The latter form is only
+    /// used when `space` is non-zero.
+    ///
+struct IRVarOffsetAttr : public IRLayoutResourceInfoAttr
+{
+    IR_LEAF_ISA(VarOffsetAttr);
 
-        // What is our starting register in that space?
-        //
-        // (In the case of uniform data, this is a byte offset)
-    IRIntLit* getIndexInst() { return cast<IRIntLit>(getOperand(2)); }
-    UInt getIndex() { return UInt(GetIntVal(getIndexInst())); }
+    IRIntLit* getOffsetInst() { return cast<IRIntLit>(getOperand(1)); }
+    UInt getOffset() { return UInt(GetIntVal(getOffsetInst())); }
+
+    IRIntLit* getSpaceInst()
+    {
+        if(getOperandCount() > 2)
+            return cast<IRIntLit>(getOperand(2));
+        return nullptr;
+    }
+
+    UInt getSpace()
+    {
+        if(auto spaceInst = getSpaceInst())
+            return UInt(GetIntVal(spaceInst));
+        return 0;
+    }
+};
+
+    /// An attribute that specifies size information for a single resource kind.
+struct IRTypeSizeAttr : public IRLayoutResourceInfoAttr
+{
+    IR_LEAF_ISA(TypeSizeAttr);
+
+    IRIntLit* getSizeInst() { return cast<IRIntLit>(getOperand(1)); }
+    LayoutSize getSize() { return LayoutSize::fromRaw(LayoutSize::RawValue(GetIntVal(getSizeInst()))); }
+    size_t getFiniteSize() { return getSize().getFiniteValue(); }
 };
 
 // Layout
 
+    /// Base type for instructions that represent layout information.
+    ///
+    /// Layout instructions are effectively just meta-data constants.
+    ///
 struct IRLayout : IRInst
 {
     IR_PARENT_ISA(Layout)
-
-        /// TODO(JS): Hold the pointer to the AST for now, whilst process of transitioning 
-        /// Over to using IR layout.
-    IRPtrLit* getASTLayoutOperand() { return cast<IRPtrLit>(getOperand(0)); }
-    Layout* getASTLayout() { return (VarLayout*)getASTLayoutOperand()->getValue(); }
 };
 
+struct IRVarLayout;
+
+    /// An attribute to specify that a layout has another layout attached for "pending" data.
+    ///
+    /// "Pending" data refers to the parts of a type or variable that
+    /// couldn't be laid out until the concrete types for existential
+    /// type slots were filled in. The layout of pending data may not
+    /// be contiguous with the layout of the original type/variable.
+    ///
+struct IRPendingLayoutAttr : IRAttr
+{
+    IR_LEAF_ISA(PendingLayoutAttr);
+
+    IRLayout* getLayout() { return cast<IRLayout>(getOperand(0)); }
+};
+
+    /// Layout information for a type.
+    ///
+    /// The most important thing this instruction provides is the
+    /// resource usage (aka "size") of the type for each of the
+    /// resource kinds it consumes.
+    ///
+    /// Subtypes of `IRTypeLayout` will include additional type-specific
+    /// operands or attributes. For example, a type layout for a
+    /// `struct` type will include offset information for its fields.
+    ///
 struct IRTypeLayout : IRLayout
 {
-    IR_LEAF_ISA(TypeLayout);
-    TypeLayout* getLayout() { return static_cast<TypeLayout*>(getASTLayout()); }
+    IR_PARENT_ISA(TypeLayout);
+
+        /// Find the attribute that stores offset information for `kind`.
+        ///
+        /// Returns null if no attribute is found, indicating that this
+        /// type does not consume any resources of `kind`.
+        ///
+    IRTypeSizeAttr* findSizeAttr(LayoutResourceKind kind);
+
+        /// Get all the attributes representing size information.
+    IROperandList<IRTypeSizeAttr> getSizeAttrs();
+
+        /// Unwrap any layers of array-ness and return the outer-most non-array type.
+    IRTypeLayout* unwrapArray();
+
+        /// Get the layout for pending data, if present.
+    IRTypeLayout* getPendingDataTypeLayout();
+
+        /// A builder for constructing `IRTypeLayout`s
+    struct Builder
+    {
+            /// Begin building.
+            ///
+            /// The `irBuilder` will be used to construct the
+            /// type layout and any additional instructions required.
+            ///
+        Builder(IRBuilder* irBuilder);
+
+            /// Add `size` units of resource `kind` to the resource usage of this type.
+        void addResourceUsage(
+            LayoutResourceKind  kind,
+            LayoutSize          size);
+
+            /// Add the resource usage specified by `sizeAttr`.
+        void addResourceUsage(IRTypeSizeAttr* sizeAttr);
+
+            /// Add all resource usage from `typeLayout`.
+        void addResourceUsageFrom(IRTypeLayout* typeLayout);
+
+            /// Set the (optional) layout for pending data.
+        void setPendingTypeLayout(
+            IRTypeLayout* typeLayout)
+        {
+            m_pendingTypeLayout = typeLayout;
+        }
+
+            /// Build a type layout according to the information specified so far.
+        IRTypeLayout* build();
+
+    protected:
+        // The following services are provided so that
+        // subtypes of `IRTypeLayout` can provide their
+        // own `Builder` subtypes that construct appropriate
+        // layouts.
+
+            /// Override to customize the opcode of the generated layout.
+        virtual IROp getOp() { return kIROp_TypeLayoutBase; }
+
+            /// Override to add additional operands to the generated layout.
+        virtual void addOperandsImpl(List<IRInst*>&) {}
+
+            /// Override to add additional attributes to the generated layout.
+        virtual void addAttrsImpl(List<IRInst*>&) {}
+
+            /// Use to access the underlying IR builder.
+        IRBuilder* getIRBuilder() { return m_irBuilder; };
+
+    private:
+        void addOperands(List<IRInst*>&);
+        void addAttrs(List<IRInst*>& ioOperands);
+
+        IRBuilder* m_irBuilder = nullptr;
+        IRTypeLayout* m_pendingTypeLayout = nullptr;
+
+        struct ResInfo
+        {
+            LayoutResourceKind  kind = LayoutResourceKind::None;
+            LayoutSize          size = 0;
+        };
+        ResInfo m_resInfos[SLANG_PARAMETER_CATEGORY_COUNT];
+    };
 };
 
+    /// Type layout for parameter groups (constant buffers and parameter blocks)
+struct IRParameterGroupTypeLayout : IRTypeLayout
+{
+private:
+    typedef IRTypeLayout Super;
+
+public:
+    IR_LEAF_ISA(ParameterGroupTypeLayout)
+
+    IRVarLayout* getContainerVarLayout()
+    {
+        return cast<IRVarLayout>(getOperand(0));
+    }
+
+    IRVarLayout* getElementVarLayout()
+    {
+        return cast<IRVarLayout>(getOperand(1));
+    }
+
+    // TODO: There shouldn't be a need for the IR to store an "offset" element type layout,
+    // but there are just enough places that currently use that information so that removing
+    // it would require some careful refactoring.
+    //
+    IRTypeLayout* getOffsetElementTypeLayout()
+    {
+        return cast<IRTypeLayout>(getOperand(2));
+    }
+
+        /// Specialized builder for parameter group type layouts.
+    struct Builder : Super::Builder
+    {
+    public:
+        Builder(IRBuilder* irBuilder)
+            : Super::Builder(irBuilder)
+        {}
+
+        void setContainerVarLayout(IRVarLayout* varLayout)
+        {
+            m_containerVarLayout = varLayout;
+        }
+
+        void setElementVarLayout(IRVarLayout* varLayout)
+        {
+            m_elementVarLayout = varLayout;
+        }
+
+        void setOffsetElementTypeLayout(IRTypeLayout* typeLayout)
+        {
+            m_offsetElementTypeLayout = typeLayout;
+        }
+
+        IRParameterGroupTypeLayout* build();
+
+    protected:
+        IROp getOp() SLANG_OVERRIDE { return kIROp_ParameterGroupTypeLayout; }
+        void addOperandsImpl(List<IRInst*>& ioOperands) SLANG_OVERRIDE;
+
+        IRVarLayout* m_containerVarLayout;
+        IRVarLayout* m_elementVarLayout;
+        IRTypeLayout* m_offsetElementTypeLayout;
+    };
+};
+
+    /// Specialized layout information for array types
+struct IRArrayTypeLayout : IRTypeLayout
+{
+    typedef IRTypeLayout Super;
+
+    IR_LEAF_ISA(ArrayTypeLayout)
+
+    IRTypeLayout* getElementTypeLayout()
+    {
+        return cast<IRTypeLayout>(getOperand(0));
+    }
+
+    struct Builder : Super::Builder
+    {
+        Builder(IRBuilder* irBuilder, IRTypeLayout* elementTypeLayout)
+            : Super::Builder(irBuilder)
+            , m_elementTypeLayout(elementTypeLayout)
+        {}
+
+        IRArrayTypeLayout* build()
+        {
+            return cast<IRArrayTypeLayout>(Super::Builder::build());
+        }
+
+    protected:
+        IROp getOp() SLANG_OVERRIDE { return kIROp_ArrayTypeLayout; }
+        void addOperandsImpl(List<IRInst*>& ioOperands) SLANG_OVERRIDE;
+
+        IRTypeLayout* m_elementTypeLayout;
+    };
+};
+
+    /// Specialized layout information for stream-output types
+struct IRStreamOutputTypeLayout : IRTypeLayout
+{
+    typedef IRTypeLayout Super;
+
+    IR_LEAF_ISA(StreamOutputTypeLayout)
+
+    IRTypeLayout* getElementTypeLayout()
+    {
+        return cast<IRTypeLayout>(getOperand(0));
+    }
+
+    struct Builder : Super::Builder
+    {
+        Builder(IRBuilder* irBuilder, IRTypeLayout* elementTypeLayout)
+            : Super::Builder(irBuilder)
+            , m_elementTypeLayout(elementTypeLayout)
+        {}
+
+        IRArrayTypeLayout* build()
+        {
+            return cast<IRArrayTypeLayout>(Super::Builder::build());
+        }
+
+    protected:
+        IROp getOp() SLANG_OVERRIDE { return kIROp_StreamOutputTypeLayout; }
+        void addOperandsImpl(List<IRInst*>& ioOperands) SLANG_OVERRIDE;
+
+        IRTypeLayout* m_elementTypeLayout;
+    };
+};
+
+    /// Specialized layout information for matrix types
+struct IRMatrixTypeLayout : IRTypeLayout
+{
+    typedef IRTypeLayout Super;
+
+    IR_LEAF_ISA(MatrixTypeLayout)
+
+    MatrixLayoutMode getMode()
+    {
+        return MatrixLayoutMode(GetIntVal(cast<IRIntLit>(getOperand(0))));
+    }
+
+    struct Builder : Super::Builder
+    {
+        Builder(IRBuilder* irBuilder, MatrixLayoutMode mode);
+
+        IRMatrixTypeLayout* build()
+        {
+            return cast<IRMatrixTypeLayout>(Super::Builder::build());
+        }
+
+    protected:
+        IROp getOp() SLANG_OVERRIDE { return kIROp_MatrixTypeLayout; }
+        void addOperandsImpl(List<IRInst*>& ioOperands) SLANG_OVERRIDE;
+
+        IRInst* m_modeInst = nullptr;
+    };
+};
+
+    /// Attribute that specifies the layout for one field of a structure type.
+struct IRStructFieldLayoutAttr : IRAttr
+{
+    IR_LEAF_ISA(StructFieldLayoutAttr)
+
+    IRStructKey* getFieldKey()
+    {
+        return cast<IRStructKey>(getOperand(0));
+    }
+
+    IRVarLayout* getLayout()
+    {
+        return cast<IRVarLayout>(getOperand(1));
+    }
+};
+
+    /// Specialized layout information for structure types.
+struct IRStructTypeLayout : IRTypeLayout
+{
+    IR_LEAF_ISA(StructTypeLayout)
+
+    typedef IRTypeLayout Super;
+
+        /// Get all of the attributes that represent field layouts.
+    IROperandList<IRStructFieldLayoutAttr> getFieldLayoutAttrs()
+    {
+        return findAttrs<IRStructFieldLayoutAttr>();
+    }
+
+        /// Get the number of fields for which layout information is stored.
+    UInt getFieldCount()
+    {
+        return getFieldLayoutAttrs().getCount();
+    }
+
+        /// Get the layout information for a field by `index`
+    IRVarLayout* getFieldLayout(UInt index)
+    {
+        return getFieldLayoutAttrs()[index]->getLayout();
+    }
+
+        /// Specialized builder for structure type layouts.
+    struct Builder : Super::Builder
+    {
+        Builder(IRBuilder* irBuilder)
+            : Super::Builder(irBuilder)
+        {}
+
+        void addField(IRStructKey* key, IRVarLayout* layout)
+        {
+            FieldInfo info;
+            info.key = key;
+            info.layout = layout;
+            m_fields.add(info);
+        }
+
+        IRStructTypeLayout* build()
+        {
+            return cast<IRStructTypeLayout>(Super::Builder::build());
+        }
+
+    protected:
+        IROp getOp() SLANG_OVERRIDE { return kIROp_StructTypeLayout; }
+        void addAttrsImpl(List<IRInst*>& ioOperands) SLANG_OVERRIDE;
+
+        struct FieldInfo
+        {
+            IRStructKey* key;
+            IRVarLayout* layout;
+        };
+
+        List<FieldInfo> m_fields;
+    };
+};
+
+    /// Attribute that represents the layout for one case of a union type
+struct IRCaseTypeLayoutAttr : IRAttr
+{
+    IR_LEAF_ISA(CaseTypeLayoutAttr);
+
+    IRTypeLayout* getTypeLayout()
+    {
+        return cast<IRTypeLayout>(getOperand(0));
+    }
+};
+
+    /// Specialized layout information for tagged union types
+struct IRTaggedUnionTypeLayout : IRTypeLayout
+{
+    typedef IRTypeLayout Super;
+
+    IR_LEAF_ISA(TaggedUnionTypeLayout)
+
+        /// Get the (byte) offset of the tagged union's tag (aka "discriminator") field
+    LayoutSize getTagOffset()
+    {
+        return LayoutSize::fromRaw(LayoutSize::RawValue(GetIntVal(cast<IRIntLit>(getOperand(0)))));
+    }
+
+        /// Get all the attributes representing layouts for the difference cases
+    IROperandList<IRCaseTypeLayoutAttr> getCaseTypeLayoutAttrs()
+    {
+        return findAttrs<IRCaseTypeLayoutAttr>();
+    }
+
+        /// Get the number of cases for which layout information is stored
+    UInt getCaseCount()
+    {
+        return getCaseTypeLayoutAttrs().getCount();
+    }
+
+        /// Get the layout information for the case at the given `index`
+    IRTypeLayout* getCaseTypeLayout(UInt index)
+    {
+        return getCaseTypeLayoutAttrs()[index]->getTypeLayout();
+    }
+
+        /// Specialized builder for tagged union type layouts
+    struct Builder : Super::Builder
+    {
+        Builder(IRBuilder* irBuilder, LayoutSize tagOffset);
+
+        void addCaseTypeLayout(IRTypeLayout* typeLayout);
+
+        IRTaggedUnionTypeLayout* build()
+        {
+            return cast<IRTaggedUnionTypeLayout>(Super::Builder::build());
+        }
+
+    protected:
+        IROp getOp() SLANG_OVERRIDE { return kIROp_TaggedUnionTypeLayout; }
+        void addOperandsImpl(List<IRInst*>& ioOperands) SLANG_OVERRIDE;
+        void addAttrsImpl(List<IRInst*>& ioOperands) SLANG_OVERRIDE;
+
+        IRInst* m_tagOffset = nullptr;
+        List<IRAttr*> m_caseTypeLayoutAttrs;
+    };
+};
+
+    /// Layout information for an entry point
 struct IREntryPointLayout : IRLayout
 {
     IR_LEAF_ISA(EntryPointLayout)
-    EntryPointLayout* getLayout() { return static_cast<EntryPointLayout*>(getASTLayout()); }
+
+        /// Get the layout information for the entry point parameters.
+        ///
+        /// The parameters layout will either be a structure type layout
+        /// with one field per parameter, or a parameter group type
+        /// layout wrapping such a structure, if the entry point parameters
+        /// needed to be allocated into a constant buffer.
+        ///
+    IRVarLayout* getParamsLayout()
+    {
+        return cast<IRVarLayout>(getOperand(0));
+    }
+
+        /// Get the layout information for the entry point result.
+        ///
+        /// This represents the return value of the entry point.
+        /// Note that it does *not* represent all of the entry
+        /// point outputs, because the parameter list may also
+        /// contain `out` or `inout` parameters.
+        ///
+    IRVarLayout* getResultLayout()
+    {
+        return cast<IRVarLayout>(getOperand(1));
+    }
 };
 
-// Associated data can be attached via the following decorations
-// * SemanticDecoration/SystemSemanticDecoration for semantics
-// * (potentially multiple) ResourceInfoLayoutDecoration
-// * StageLayoutDecoration to indicate a specific associated stage
-// * PendingVarLayoutDecoration to indicate pending var layout 
-// The VarLayoutFlag::HasSemantic flag is equivalent to having the SemanticDecoration
+    /// Given an entry-point layout, extract the layout for the parameters struct.
+IRStructTypeLayout* getScopeStructLayout(IREntryPointLayout* scopeLayout);
+
+    /// Attribute that associates a variable layout with a known stage.
+struct IRStageAttr : IRAttr
+{
+    IR_LEAF_ISA(StageAttr);
+
+    IRIntLit* getStageOperand() { return cast<IRIntLit>(getOperand(0)); }
+    Stage getStage() { return Stage(GetIntVal(getStageOperand())); }
+};
+
+    /// Base type for attributes that associate a variable layout with a semantic name and index.
+struct IRSemanticAttr : IRAttr
+{
+    IR_PARENT_ISA(SemanticAttr);
+
+    IRStringLit* getNameOperand() { return cast<IRStringLit>(getOperand(0)); }
+    UnownedStringSlice getName() { return getNameOperand()->getStringSlice(); }
+
+    IRIntLit* getIndexOperand() { return cast<IRIntLit>(getOperand(1)); }
+    UInt getIndex() { return UInt(GetIntVal(getIndexOperand())); }
+};
+
+    /// Attribute that associates a variable with a system-value semantic name and index
+struct IRSystemValueSemanticAttr : IRSemanticAttr
+{
+    IR_LEAF_ISA(SystemValueSemanticAttr);
+};
+
+    /// Attribute that associates a variable with a user-defined semantic name and index
+struct IRUserSemanticAttr : IRSemanticAttr
+{
+    IR_LEAF_ISA(UserSemanticAttr);
+};
+
+    /// Layout infromation for a single parameter/field
 struct IRVarLayout : IRLayout
 {
     IR_LEAF_ISA(VarLayout)
 
-        /// The name of this variable
-    IRStringLit* getName() { return cast<IRStringLit>(getOperand(1)); }
-        /// For now this uses a link back into the AST representation. Will be replaced by IR based type representation
-    IRTypeLayout* getTypeLayout() { return cast<IRTypeLayout>(getOperand(2)); }
+        /// Get the type layout information for this variable
+    IRTypeLayout* getTypeLayout() { return cast<IRTypeLayout>(getOperand(0)); }
 
-        /// Get/set absolute layout
-    IRVarLayout* getAbsoluteLayout() { return cast<IRVarLayout>(getOperand(3)); }
-    void setAbsoluteLayout(IRVarLayout* layout) { getOperands()[3].set(layout); }
+        /// Get all the attributes representing resource-kind-specific offsets
+    IROperandList<IRVarOffsetAttr> getOffsetAttrs();
+
+        /// Find the offset information (if present) for the given resource `kind`
+    IRVarOffsetAttr* findOffsetAttr(LayoutResourceKind kind);
+
+        /// Does this variable use any resources of the given `kind`?
+    bool usesResourceKind(LayoutResourceKind kind);
+
+        /// Get the fixed/known stage that this variable is associated with.
+        ///
+        /// This will be a specific stage for entry-point parameters, but
+        /// will be `Stage::Unknown` for any parameter that is not bound
+        /// solely to one entry point.
+        ///
+    Stage getStage();
+
+        /// Find the system-value semantic attribute for this variable, if any.
+    IRSystemValueSemanticAttr* findSystemValueSemanticAttr();
+
+        /// Get the (optional) layout for any "pending" data assocaited with this variable.
+    IRVarLayout* getPendingVarLayout();
+
+        /// Builder for construction `IRVarLayout`s in a stateful fashion
+    struct Builder
+    {
+            /// Begin building a variable layout with the given `typeLayout`
+            ///
+            /// The result layout and any instructions needed along the way
+            /// will be allocated with `irBuilder`.
+            ///
+        Builder(
+            IRBuilder*      irBuilder,
+            IRTypeLayout*   typeLayout);
+
+            /// Represents resource-kind-specific offset information
+        struct ResInfo
+        {
+            LayoutResourceKind  kind = LayoutResourceKind::None;
+            UInt                offset = 0;
+            UInt                space = 0;
+        };
+
+            /// Has any resource usage/offset been registered for the given resource `kind`?
+        bool usesResourceKind(LayoutResourceKind kind);
+
+            /// Either fetch or add a `ResInfo` record for `kind` and return it
+        ResInfo* findOrAddResourceInfo(LayoutResourceKind kind);
+
+            /// Set the (optional) variable layout for pending data.
+        void setPendingVarLayout(IRVarLayout* varLayout)
+        {
+            m_pendingVarLayout = varLayout;
+        }
+
+            /// Set the (optional) system-valeu semantic for this variable.
+        void setSystemValueSemantic(String const& name, UInt index);
+
+            /// Set the (optional) user-defined semantic for this variable.
+        void setUserSemantic(String const& name, UInt index);
+
+            /// Set the (optional) known stage for this variable.
+        void setStage(Stage stage);
+
+            /// Clone all of the layout information from the `other` layout, except for offsets.
+            ///
+            /// This is convenience when one wants to build a variable layout "like that other one, but..."
+        void cloneEverythingButOffsetsFrom(
+            IRVarLayout* other);
+
+            /// Build a variable layout using the current state that has been set.
+        IRVarLayout* build();
+
+    private:
+        IRBuilder* m_irBuilder;
+        IRBuilder* getIRBuilder() { return m_irBuilder; };
+
+        IRTypeLayout* m_typeLayout = nullptr;
+        IRVarLayout* m_pendingVarLayout = nullptr;
+
+        IRSystemValueSemanticAttr* m_systemValueSemantic = nullptr;
+        IRUserSemanticAttr* m_userSemantic = nullptr;
+        IRStageAttr* m_stageAttr = nullptr;
+
+        ResInfo m_resInfos[SLANG_PARAMETER_CATEGORY_COUNT];
+    };
 };
 
-// Associates an IR-level decoration with a source layout
+    /// Associate layout information with an instruction.
+    ///
+    /// This decoration is used in three main ways:
+    ///
+    /// * To attach an `IRVarLayout` to an `IRGlobalParam` or entry-point `IRParam` representing a shader parameter
+    /// * To attach an `IREntryPointLayout` to an `IRFunc` representing an entry point
+    /// * To attach an `IRTaggedUnionTypeLayout` to an `IRTaggedUnionType`
+    ///
 struct IRLayoutDecoration : IRDecoration
 {
     enum { kOp = kIROp_LayoutDecoration };
     IR_LEAF_ISA(LayoutDecoration)
 
-    IRLayout* getIRLayout() { return cast<IRLayout>(getOperand(0)); }
-
-    Layout* getASTLayout()
-    {
-        IRLayout* irLayout = getIRLayout();
-        if (!irLayout)
-        {
-            return nullptr;
-        }
-        return irLayout->getASTLayout();
-    }
+        /// Get the layout that is being attached to the parent instruction
+    IRLayout* getLayout() { return cast<IRLayout>(getOperand(0)); }
 };
 
 //
@@ -1434,9 +1993,57 @@ struct IRBuilder
 
     void addHighLevelDeclDecoration(IRInst* value, Decl* decl);
 
-    void addLayoutDecoration(IRInst* value, Layout* layout);
+//    void addLayoutDecoration(IRInst* value, Layout* layout);
+    void addLayoutDecoration(IRInst* value, IRLayout* layout);
 
-    IRLayout* getLayout(Layout* astLayout);
+//    IRLayout* getLayout(Layout* astLayout);
+
+    IRTypeSizeAttr* getTypeSizeAttr(
+        LayoutResourceKind kind,
+        LayoutSize size);
+    IRVarOffsetAttr* getVarOffsetAttr(
+        LayoutResourceKind  kind,
+        UInt                offset,
+        UInt                space = 0);
+    IRPendingLayoutAttr* getPendingLayoutAttr(
+        IRLayout* pendingLayout);
+    IRStructFieldLayoutAttr* getFieldLayoutAttr(
+        IRStructKey*    key,
+        IRVarLayout*    layout);
+    IRCaseTypeLayoutAttr* getCaseTypeLayoutAttr(
+        IRTypeLayout*   layout);
+
+    IRSemanticAttr* getSemanticAttr(
+        IROp            op,
+        String const&   name,
+        UInt            index);
+    IRSystemValueSemanticAttr* getSystemValueSemanticAttr(
+        String const&   name,
+        UInt            index)
+    {
+        return cast<IRSystemValueSemanticAttr>(getSemanticAttr(
+            kIROp_SystemValueSemanticAttr,
+            name,
+            index));
+    }
+    IRUserSemanticAttr* getUserSemanticAttr(
+        String const&   name,
+        UInt            index)
+    {
+        return cast<IRUserSemanticAttr>(getSemanticAttr(
+            kIROp_UserSemanticAttr,
+            name,
+            index));
+    }
+
+    IRStageAttr* getStageAttr(Stage stage);
+
+    IRTypeLayout* getTypeLayout(IROp op, List<IRInst*> const& operands);
+    IRVarLayout* getVarLayout(List<IRInst*> const& operands);
+    IREntryPointLayout* getEntryPointLayout(
+        IRVarLayout* paramsLayout,
+        IRVarLayout* resultLayout);
+
 
     void addNameHintDecoration(IRInst* value, IRStringLit* name)
     {

--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -754,23 +754,26 @@ static void maybeCopyLayoutInformationToParameters(
     if(!layoutDecor)
         return;
 
-    auto entryPointLayout = as<EntryPointLayout>(layoutDecor->getASTLayout());
+    auto entryPointLayout = as<IREntryPointLayout>(layoutDecor->getLayout());
     if(!entryPointLayout)
         return;
 
     if( auto firstBlock = func->getFirstBlock() )
     {
         auto paramsStructLayout = getScopeStructLayout(entryPointLayout);
-        Index paramLayoutCount = paramsStructLayout->fields.getCount();
+        Index paramLayoutCount = paramsStructLayout->getFieldCount();
         Index paramCounter = 0;
         for( auto pp = firstBlock->getFirstParam(); pp; pp = pp->getNextParam() )
         {
             Index paramIndex = paramCounter++;
             if( paramIndex < paramLayoutCount )
             {
-                auto paramLayout = paramsStructLayout->fields[paramIndex];
+                auto paramLayout = paramsStructLayout->getFieldLayout(paramIndex);
 
-                auto offsetParamLayout = applyOffsetToVarLayout(paramLayout, entryPointLayout->parametersLayout);
+                auto offsetParamLayout = applyOffsetToVarLayout(
+                    builder,
+                    paramLayout,
+                    entryPointLayout->getParamsLayout());
 
                 builder->addLayoutDecoration(
                     pp,

--- a/source/slang/slang-legalize-types.cpp
+++ b/source/slang/slang-legalize-types.cpp
@@ -1288,22 +1288,22 @@ LegalType legalizeType(
 
 //
 
-RefPtr<TypeLayout> getDerefTypeLayout(
-    TypeLayout* typeLayout)
+IRTypeLayout* getDerefTypeLayout(
+    IRTypeLayout* typeLayout)
 {
     if (!typeLayout)
         return nullptr;
 
-    if (auto parameterGroupTypeLayout = as<ParameterGroupTypeLayout>(typeLayout))
+    if (auto parameterGroupTypeLayout = as<IRParameterGroupTypeLayout>(typeLayout))
     {
-        return parameterGroupTypeLayout->offsetElementTypeLayout;
+        return parameterGroupTypeLayout->getOffsetElementTypeLayout();
     }
 
     return typeLayout;
 }
 
-RefPtr<VarLayout> getFieldLayout(
-    TypeLayout*     typeLayout,
+IRVarLayout* getFieldLayout(
+    IRTypeLayout*     typeLayout,
     IRInst*         fieldKey)
 {
     if (!typeLayout)
@@ -1311,13 +1311,13 @@ RefPtr<VarLayout> getFieldLayout(
 
     for(;;)
     {
-        if(auto arrayTypeLayout = as<ArrayTypeLayout>(typeLayout))
+        if(auto arrayTypeLayout = as<IRArrayTypeLayout>(typeLayout))
         {
-            typeLayout = arrayTypeLayout->elementTypeLayout;
+            typeLayout = arrayTypeLayout->getElementTypeLayout();
         }
-        else if(auto parameterGroupTypeLayout = as<ParameterGroupTypeLayout>(typeLayout))
+        else if(auto parameterGroupTypeLayout = as<IRParameterGroupTypeLayout>(typeLayout))
         {
-            typeLayout = parameterGroupTypeLayout->offsetElementTypeLayout;
+            typeLayout = parameterGroupTypeLayout->getOffsetElementTypeLayout();
         }
         else
         {
@@ -1326,30 +1326,13 @@ RefPtr<VarLayout> getFieldLayout(
     }
 
 
-    if (auto structTypeLayout = as<StructTypeLayout>(typeLayout))
+    if (auto structTypeLayout = as<IRStructTypeLayout>(typeLayout))
     {
-        // First, let's see if the field had a layout registered
-        // directly using its IR key.
-        //
-        RefPtr<VarLayout> fieldLayout;
-        if(structTypeLayout->mapKeyToLayout.TryGetValue(fieldKey, fieldLayout))
-            return fieldLayout;
-
-        // Otherwise, fall back to doing lookup using the linkage
-        // attached to the key, and its mangled name.
-        //
-        auto fieldLinkage = fieldKey->findDecoration<IRLinkageDecoration>();
-        if(!fieldLinkage)
-            return nullptr;
-        auto mangledFieldName = fieldLinkage->getMangledName();
-
-        // In this case we fall back to a linear search over the fields.
-        //
-        for(auto ff : structTypeLayout->fields)
+        for(auto ff : structTypeLayout->getFieldLayoutAttrs())
         {
-            if(mangledFieldName == getMangledName(ff->varDecl.getDecl()).getUnownedSlice() )
+            if(ff->getFieldKey() == fieldKey)
             {
-                return ff;
+                return ff->getLayout();
             }
         }
     }
@@ -1357,22 +1340,22 @@ RefPtr<VarLayout> getFieldLayout(
     return nullptr;
 }
 
-RefPtr<VarLayout> createSimpleVarLayout(
+void buildSimpleVarLayout(
+    IRVarLayout::Builder*   builder,
     SimpleLegalVarChain*    varChain,
-    TypeLayout*             typeLayout)
+    IRTypeLayout*           typeLayout)
 {
-    if (!typeLayout)
-        return nullptr;
-
     // We need to construct a layout for the new variable
     // that reflects both the type we have given it, as
     // well as all the offset information that has accumulated
     // along the chain of parent variables.
 
-    // TODO: this logic needs to propagate through semantics...
-
-    RefPtr<VarLayout> varLayout = new VarLayout();
-    varLayout->typeLayout = typeLayout;
+    // TODO: This logic doesn't currently handle semantics or
+    // other attributes that might have been present on the
+    // original variable layout. That is probably okay for now
+    // as the legalization logic does not apply to varying
+    // parameters (where resource types would be illegal anyway),
+    // but it is probably worth addressing sooner or later.
 
     // For most resource kinds, the register index/space to use should
     // be the sum along the entire chain of variables.
@@ -1387,16 +1370,17 @@ RefPtr<VarLayout> createSimpleVarLayout(
     // the offset for `s` (10 texture registers) to get the final
     // binding to apply.
     //
-    for (auto rr : typeLayout->resourceInfos)
+    for (auto rr : typeLayout->getSizeAttrs())
     {
-        auto resInfo = varLayout->findOrAddResourceInfo(rr.kind);
+        auto kind = rr->getResourceKind();
+        auto resInfo = builder->findOrAddResourceInfo(kind);
 
         for (auto vv = varChain; vv; vv = vv->next)
         {
-            if (auto parentResInfo = vv->varLayout->FindResourceInfo(rr.kind))
+            if (auto parentResInfo = vv->varLayout->findOffsetAttr(kind))
             {
-                resInfo->index += parentResInfo->index;
-                resInfo->space += parentResInfo->space;
+                resInfo->offset += parentResInfo->getOffset();
+                resInfo->space += parentResInfo->getSpace();
             }
         }
     }
@@ -1404,44 +1388,57 @@ RefPtr<VarLayout> createSimpleVarLayout(
     // As a special case, if the leaf variable doesn't hold an entry for
     // `RegisterSpace`, but at least one declaration in the chain *does*,
     // then we want to make sure that we add such an entry.
-    if (!varLayout->FindResourceInfo(LayoutResourceKind::RegisterSpace))
+    //
+    if (!builder->usesResourceKind(LayoutResourceKind::RegisterSpace))
     {
         // Sum up contributions from all parents.
         UInt space = 0;
         for (auto vv = varChain; vv; vv = vv->next)
         {
-            if (auto parentResInfo = vv->varLayout->FindResourceInfo(LayoutResourceKind::RegisterSpace))
+            if (auto parentResInfo = vv->varLayout->findOffsetAttr(LayoutResourceKind::RegisterSpace))
             {
-                space += parentResInfo->index;
+                space += parentResInfo->getOffset();
             }
         }
 
         // If there were non-zero contributions, then add an entry to represent them.
         if (space)
         {
-            varLayout->findOrAddResourceInfo(LayoutResourceKind::RegisterSpace)->index = space;
+            builder->findOrAddResourceInfo(LayoutResourceKind::RegisterSpace)->offset = space;
         }
     }
-
-    return varLayout;
 }
 
+IRVarLayout* createSimpleVarLayout(
+    IRBuilder*              irBuilder,
+    SimpleLegalVarChain*    varChain,
+    IRTypeLayout*           typeLayout)
+{
+    if (!typeLayout)
+        return nullptr;
+    IRVarLayout::Builder varLayoutBuilder(irBuilder, typeLayout);
+    buildSimpleVarLayout(&varLayoutBuilder, varChain, typeLayout);
+    return varLayoutBuilder.build();
+}
 
-RefPtr<VarLayout> createVarLayout(
+IRVarLayout* createVarLayout(
+    IRBuilder*              irBuilder,
     LegalVarChain const&    varChain,
-    TypeLayout*             typeLayout)
+    IRTypeLayout*           typeLayout)
 {
     if(!typeLayout)
         return nullptr;
 
-    auto varLayout = createSimpleVarLayout(varChain.primaryChain, typeLayout);
+    IRVarLayout::Builder varLayoutBuilder(irBuilder, typeLayout);
+    buildSimpleVarLayout(&varLayoutBuilder, varChain.primaryChain, typeLayout);
 
-    if(auto pendingDataTypeLayout = typeLayout->pendingDataTypeLayout)
+    if(auto pendingDataTypeLayout = typeLayout->getPendingDataTypeLayout())
     {
-        varLayout->pendingVarLayout = createSimpleVarLayout(varChain.pendingChain, typeLayout);
+        varLayoutBuilder.setPendingVarLayout(
+            createSimpleVarLayout(irBuilder, varChain.pendingChain, typeLayout));
     }
 
-    return varLayout;
+    return varLayoutBuilder.build();
 }
 
 //

--- a/source/slang/slang-type-layout.h
+++ b/source/slang/slang-type-layout.h
@@ -44,6 +44,13 @@ struct LayoutSize
         SLANG_ASSERT(size != RawValue(-1));
     }
 
+    static LayoutSize fromRaw(RawValue raw)
+    {
+        LayoutSize size;
+        size.raw = raw;
+        return size;
+    }
+
     static LayoutSize infinite()
     {
         LayoutSize result;
@@ -469,21 +476,6 @@ public:
     }
 
     RefPtr<VarLayout> pendingVarLayout;
-
-
-        /// Get the "absolute" layout of this variable, if applicable.
-        ///
-        /// The `parentAbsoluteLayout` must be the absolute layout
-        /// of the parent of this variable.
-        ///
-        /// The absolute layout will be created once and cached on
-        /// future accesses; if `parentAbsoluteLayout` is not
-        /// consistent at different call sites an unexpected
-        /// layout could be returned.
-        ///
-    VarLayout* getAbsoluteLayout(VarLayout* parentAbsoluteLayout);
-
-    RefPtr<VarLayout> m_absoluteLayout;
 };
 
 // type layout for a variable that has a constant-buffer type
@@ -510,16 +502,6 @@ public:
     // so that any fields (if the element type is a `struct`)
     // will be offset by the resource usage of the container.
     RefPtr<TypeLayout>  offsetElementTypeLayout;
-
-    // If the element type layout had any "pending" data, then
-    // as much of that data as possible will be flushed to
-    // fit into the overall layout of the parameter group.
-    //
-    // This field stores the offset information for where
-    // the pending data got stored relative to the start of
-    // the group.
-    //
-//    RefPtr<VarLayout> flushedDataVarLayout;
 };
 
 // type layout for a variable that has a constant-buffer type
@@ -604,12 +586,6 @@ public:
     // in the array above, rather than to the actual pointer,
     // so that we 
     Dictionary<VarDeclBase*, RefPtr<VarLayout>> mapVarToLayout;
-
-    // As an accellerator for type layouts created at the
-    // IR layer, we include a second map that use IR "key"
-    // instructions to map to fields.
-    //
-    Dictionary<IRInst*, RefPtr<VarLayout>> mapKeyToLayout;
 };
 
 class GenericParamTypeLayout : public TypeLayout
@@ -691,9 +667,9 @@ public:
     };
     unsigned flags = 0;
 
-    EntryPointLayout* getAbsoluteLayout(VarLayout* parentLayout);
+//    EntryPointLayout* getAbsoluteLayout(VarLayout* parentLayout);
 
-    RefPtr<EntryPointLayout> m_absoluteLayout;
+//    RefPtr<EntryPointLayout> m_absoluteLayout;
 };
 
     /// Reflection/layout information about a specialization parameter
@@ -1170,10 +1146,20 @@ RefPtr<TypeLayout> applyOffsetToTypeLayout(
     RefPtr<TypeLayout>  oldTypeLayout,
     RefPtr<VarLayout>   offsetVarLayout);
 
+struct IRBuilder;
+struct IRTypeLayout;
+struct IRVarLayout;
+
+IRTypeLayout* applyOffsetToTypeLayout(
+    IRBuilder*      irBuilder,
+    IRTypeLayout*   oldTypeLayout,
+    IRVarLayout*    offsetVarLayout);
+
     /// Create a layout like `baseLayout`, but offset by `offsetLayout`
-RefPtr<VarLayout> applyOffsetToVarLayout(
-    VarLayout* baseLayout,
-    VarLayout* offsetLayout);
+IRVarLayout* applyOffsetToVarLayout(
+    IRBuilder*      irBuilder,
+    IRVarLayout*    baseLayout,
+    IRVarLayout*    offsetLayout);
 
 }
 


### PR DESCRIPTION
This change builds on previous work that moves toward a more IR-based representation of layout.
Those steps added some instructions for representing layout in the IR (initially just proxies for the AST layout objects), and an explicit lowering pass that could build a target-specific IR module that binds parameters and entry points to layout information.

This change aims to complete that work, in the sense that the IR representation of layout is now self-contained and does not rely on having pointers back into the AST-level representation.
Achieving this requires two main kinds of work:

1. Update any code that used layout information derived from the IR (most notably all the `slang-emit-*` code) to use the new IR representation and its accessors.

2. Update any code that *constructs* layouts using information derived from the IR to construct IR layouts instead.

The biggest new infrastructure feature in this change is support for "attributes" in the IR (I'd welcome feedback on the naming).
An attribute can either be thought of like key/value arguments that can be added to certain instructions to encode optional data, or alternatively like a decoration that is referenced as an operand instead of a child.
The value of attributes over decorations is that they can affect the hash/identity of an instruction (which decorations can't), while the advantage of decorations is that they can easily be added/removed over the lifetime of an instruction (which attributes can't).
We mostly use them here to represent operands that are logically optional.

Once attributes are available, the encoding of layout information into the IR is mostly straightforward:

* An `IRVarLayout` has a fixed operand for its type layout, and can accept a few different attributes
  * Zero or more `IRVarOffsetAttr`s that specify the offset of the variable for a given resource kind. These are equivalent to the `VarLayout::ResourceInfo`s at the AST level.
  * An optional `IRUserSemanticAttr` and `IRSystemValueSemanticAttr` to represent the (possibly derived) semantic of a varying input/output parameter.
  * An option `IRStageAttr` to represent the known stage for a parameter.

* An `IREntryPointLayout` has a var layout for the entry point parameters (logically grouped in to a struct) and another var layout for the result parameter.

* There is a small type hierarchy rooted at `IRTypeLayout` where each subtype can add fixed operands and attributes that are expected to appear. It also supports `IRTypeSizeAttr`s that serve a similar role to the `IRVarOffsetAttr`s.

* Structure types maintain the mapping of fields to their var layouts using `IRStructFieldLayoutAttr`s.

With the encoding in place, most of the changes in category (1) (code that just *uses* rather than *creates* layouts) was straightforward. The biggest different beyond name changes was that everything needs to be fetched using accessors instead of bare fields. It would have been possible to stage this commit and make the diffs smaller by first introducing mandatory acessors to the AST layout types.

The changes in category (2) were more involved. There were a lot of places in the existing code where a `TypeLayout` or `VarLayout` would be created, and then initialized piecemeal over several lines of code (and sometimes even across functions). Because of the way that layouts need to support many optional properties, it did not seem practical to just have monolithic factory functions that took all the options as arguments, so I instead opted for a builder approach.

The builders for `IRVarLayout` and `IREntryPointLayout` are both straightforward, and honestly there is no realy need for a builder for entry point layouts right now, but I was trying to future-proof in case we decidd to add some optional attributes to them.

The builders for type layouts are more involved because of the inheritance hierarchy. Each concrete sub-type of type layout needs to define its own builder type that customizes the opcode, operands, and attributes of the final instruction.

The refactoring that had to go into this change was a nice excuse to clean up a few ugly warts in the AST layout code that were largely there to support IR use cases. While this change adds a lot of new infrastructure code to the IR, most of the client code has stayed the same or gotten simpler.

One annoying wart that remains with this change is the notion of an "offset element type layout" for parameter group types. That idea was added to deal with a legacy feature in the reflection API that we realized was a mistake, but unfortunately having that "offset" layout handy made writing a few other pieces of code simpler so that there are use cases of the feature even in the IR. Removing those uses is do-able, but requires careful refactoring so it is best left to a follow-on change.

Another thing that could be considered for a follow-on change is how much information should be specified when constructing a `Builder` for an IR type layout, and how much should be allowed to be specified statefully/piecemeal. It would be nice to force all the required operands to be specified up front, but `IRParameterGroupTypeLayout::Builder` doesn't currently work that way because so much of the client code that needs it involved a lot of stateful setting and would need to be refactored heavily to provide the necessary information up front.