### PR TITLE
Expose more repro in API, support output params.

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -1647,7 +1647,7 @@ extern "C"
         ISlangBlob** outBlob
     );
 
-    /** Enable Repro capture.
+    /** Enable repro capture.
 
     Should be set after any ISlangFileSystem has been set, but before any compilation. It ensures that everything
     that the ISlangFileSystem accesses will be correctly recorded.
@@ -1657,7 +1657,25 @@ extern "C"
     @param request          The request
     @returns                A `SlangResult` to indicate success or failure.
     */
-    SLANG_API SlangResult spEnableReproCapture(SlangCompileRequest* request);
+    SLANG_API SlangResult spEnableReproCapture(
+        SlangCompileRequest* request);
+
+    /** Extract contents of a repro.
+
+    Writes the contained files and manifest with their 'unique' names into fileSystem. For more details read the
+    docs/repro.md documentation. 
+
+    @param session          The slang session
+    @param reproData        Holds the repro data
+    @param reproDataSize    The size of the repro data
+    @param fileSystem       File system that the contents of the repro will be written to
+    @returns                A `SlangResult` to indicate success or failure.
+    */
+    SLANG_API SlangResult spExtractRepro(
+        SlangSession* session,
+        const void* reproData,
+        size_t reproDataSize,
+        ISlangFileSystemExt* fileSystem);
 
     /*
     Forward declarations of types used in the reflection interface;

--- a/slang.h
+++ b/slang.h
@@ -1647,6 +1647,18 @@ extern "C"
         ISlangBlob** outBlob
     );
 
+    /** Enable Repro capture.
+
+    Should be set after any ISlangFileSystem has been set, but before any compilation. It ensures that everything
+    that the ISlangFileSystem accesses will be correctly recorded.
+    Note that if a ISlangFileSystem/ISlangFileSystemExt isn't explicitly set (ie the default is used), then the
+    request will automatically be set up to record everything appropriate. 
+
+    @param request          The request
+    @returns                A `SlangResult` to indicate success or failure.
+    */
+    SLANG_API SlangResult spEnableReproCapture(SlangCompileRequest* request);
+
     /*
     Forward declarations of types used in the reflection interface;
     */

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -660,10 +660,10 @@ namespace Slang
 	{
 		RefPtr<FileStream> fs = new FileStream(fileName, FileMode::Open, FileAccess::Read, FileShare::ReadWrite);
 		List<unsigned char> buffer;
-		while (!fs->IsEnd())
+		while (!fs->isEnd())
 		{
 			unsigned char ch;
-			int read = (int)fs->Read(&ch, 1);
+			int read = (int)fs->read(&ch, 1);
 			if (read)
 				buffer.add(ch);
 			else

--- a/source/core/slang-riff.cpp
+++ b/source/core/slang-riff.cpp
@@ -20,7 +20,7 @@ namespace Slang
     }
 
     // Skip the payload (we don't need to skip the Chunk because that was already read
-    stream->Seek(SeekOrigin::Current, chunkSize - sizeof(RiffChunk));
+    stream->seek(SeekOrigin::Current, chunkSize - sizeof(RiffChunk));
     return SLANG_OK;
 }
 
@@ -29,7 +29,7 @@ namespace Slang
 {
     try
     {
-        stream->Read(&outChunk, sizeof(RiffChunk));
+        stream->read(&outChunk, sizeof(RiffChunk));
     }
     catch (IOException&)
     {
@@ -53,13 +53,13 @@ namespace Slang
 
     try
     {
-        out->Write(&chunk, sizeof(chunk));
-        out->Write(data, size);
+        out->write(&chunk, sizeof(chunk));
+        out->write(data, size);
         size_t remaining = size & 3;
         if (remaining)
         {
             uint8_t end[4] = { 0, 0, 0, 0};
-            out->Write(end, 4 - remaining);
+            out->write(end, 4 - remaining);
         }
     }
     catch (IOException&)
@@ -79,13 +79,13 @@ namespace Slang
 
     try
     {
-        stream->Read(data.getBuffer(), outChunk.m_size);
+        stream->read(data.getBuffer(), outChunk.m_size);
 
         // Skip to the alignment
         uint32_t remaining = outChunk.m_size & 3;
         if (remaining)
         {
-            stream->Seek(SeekOrigin::Current, 4 - remaining);
+            stream->seek(SeekOrigin::Current, 4 - remaining);
         }
     }
     catch (IOException&)

--- a/source/core/slang-stream.cpp
+++ b/source/core/slang-stream.cpp
@@ -235,7 +235,7 @@ void MemoryStreamBase::seek(SeekOrigin origin, Int64 offset)
             pos = offset;
             break;
         case SeekOrigin::End:
-            pos = Int64(m_contentSize) + offset;
+            pos = Int64(m_contentsSize) + offset;
             break;
         case SeekOrigin::Current:
             pos = Int64(m_position) + offset;
@@ -249,7 +249,7 @@ void MemoryStreamBase::seek(SeekOrigin origin, Int64 offset)
 
     // Clamp to the valid range
     pos = (pos < 0) ? 0 : pos;
-    pos = (pos > Int64(m_contentSize)) ? Int64(m_contentSize) : pos;
+    pos = (pos > Int64(m_contentsSize)) ? Int64(m_contentsSize) : pos;
 
     m_position = UInt(pos);
 }
@@ -261,7 +261,7 @@ Int64 MemoryStreamBase::read(void* buffer, Int64 length)
         throw IOException("Cannot read this stream.");
     }
 
-    const Int64 maxRead = Int64(m_contentSize - m_position);
+    const Int64 maxRead = Int64(m_contentsSize - m_position);
 
     if (maxRead == 0 && length > 0)
     {
@@ -271,7 +271,7 @@ Int64 MemoryStreamBase::read(void* buffer, Int64 length)
 
     length = length > maxRead ? maxRead : length;
 
-    ::memcpy(buffer, m_content + m_position, size_t(length));
+    ::memcpy(buffer, m_contents + m_position, size_t(length));
     m_position += UInt(length);
     return maxRead;
 }
@@ -285,17 +285,17 @@ Int64 OwnedMemoryStream::write(const void * buffer, Int64 length)
         throw IOException("Cannot write this stream.");
     }
 
-    if (m_position == m_ownedContent.getCount())
+    if (m_position == m_ownedContents.getCount())
     {
-        m_ownedContent.addRange((const uint8_t*)buffer, UInt(length));
+        m_ownedContents.addRange((const uint8_t*)buffer, UInt(length));
     }
     else
     {
-        m_ownedContent.insertRange(m_position, (const uint8_t*)buffer, UInt(length));
+        m_ownedContents.insertRange(m_position, (const uint8_t*)buffer, UInt(length));
     }
 
-    m_content = m_ownedContent.getBuffer();
-    m_contentSize = ptrdiff_t(m_ownedContent.getCount());
+    m_contents = m_ownedContents.getBuffer();
+    m_contentsSize = ptrdiff_t(m_ownedContents.getCount());
 
     m_atEnd = false;
 

--- a/source/core/slang-stream.cpp
+++ b/source/core/slang-stream.cpp
@@ -6,294 +6,301 @@
 
 namespace Slang
 {
-	FileStream::FileStream(const Slang::String & fileName, FileMode fileMode)
-	{
-		Init(fileName, fileMode, fileMode==FileMode::Open?FileAccess::Read:FileAccess::Write, FileShare::None);
-	}
-	FileStream::FileStream(const Slang::String & fileName, FileMode fileMode, FileAccess access, FileShare share)
-	{
-		Init(fileName, fileMode, access, share);
-	}
-	void FileStream::Init(const Slang::String & fileName, FileMode fileMode, FileAccess access, FileShare share)
-	{
-		const wchar_t * mode = L"rt";
-		const char* modeMBCS = "rt";
-		switch (fileMode)
-		{
-		case Slang::FileMode::Create:
-			if (access == FileAccess::Read)
-				throw ArgumentException("Read-only access is incompatible with Create mode.");
-			else if (access == FileAccess::ReadWrite)
-			{
-				mode = L"w+b";
-				modeMBCS = "w+b";
-				this->fileAccess = FileAccess::ReadWrite;
-			}
-			else
-			{
-				mode = L"wb";
-				modeMBCS = "wb";
-				this->fileAccess = FileAccess::Write;
-			}
-			break;
-		case Slang::FileMode::Open:
-			if (access == FileAccess::Read)
-			{
-				mode = L"rb";
-				modeMBCS = "rb";
-				this->fileAccess = FileAccess::Read;
-			}
-			else if (access == FileAccess::ReadWrite)
-			{
-				mode = L"r+b";
-				modeMBCS = "r+b";
-				this->fileAccess = FileAccess::ReadWrite;
-			}
-			else
-			{
-				mode = L"wb";
-				modeMBCS = "wb";
-				this->fileAccess = FileAccess::Write;
-			}
-			break;
-		case Slang::FileMode::CreateNew:
-			if (File::exists(fileName))
-			{
-				throw IOException("Failed opening '" + fileName + "', file already exists.");
-			}
-			if (access == FileAccess::Read)
-				throw ArgumentException("Read-only access is incompatible with Create mode.");
-			else if (access == FileAccess::ReadWrite)
-			{
-				mode = L"w+b";
-				this->fileAccess = FileAccess::ReadWrite;
-			}
-			else
-			{
-				mode = L"wb";
-				this->fileAccess = FileAccess::Write;
-			}
-			break;
-		case Slang::FileMode::Append:
-			if (access == FileAccess::Read)
-				throw ArgumentException("Read-only access is incompatible with Append mode.");
-			else if (access == FileAccess::ReadWrite)
-			{
-				mode = L"a+b";
-				this->fileAccess = FileAccess::ReadWrite;
-			}
-			else
-			{
-				mode = L"ab";
-				this->fileAccess = FileAccess::Write;
-			}
-			break;
-		default:
-			break;
-		}
-#ifdef _WIN32
-        int shFlag = _SH_DENYRW;
-        switch (share)
-		{
-		case Slang::FileShare::None:
-			shFlag = _SH_DENYRW;
-			break;
-		case Slang::FileShare::ReadOnly:
-			shFlag = _SH_DENYWR;
-			break;
-		case Slang::FileShare::WriteOnly:
-			shFlag = _SH_DENYRD;
-			break;
-		case Slang::FileShare::ReadWrite:
-			shFlag = _SH_DENYNO;
-			break;
-		default:
-			throw ArgumentException("Invalid file share mode.");
-			break;
-		}
-        if (share == Slang::FileShare::None)
-#pragma warning(suppress:4996)
-            handle = _wfopen(fileName.toWString(), mode);
-        else
-			handle = _wfsopen(fileName.toWString(), mode, shFlag);
-#else
-		handle = fopen(fileName.getBuffer(), modeMBCS);
-#endif
-		if (!handle)
-		{
-			throw IOException("Cannot open file '" + fileName + "'");
-		}
-	}
-	FileStream::~FileStream()
-	{
-		Close();
-	}
-	Int64 FileStream::GetPosition()
-	{
-#if defined(_WIN32) || defined(__CYGWIN__)
-		fpos_t pos;
-		fgetpos(handle, &pos);
-		return pos;
-#elif defined(__APPLE__)
-		return ftell(handle);
-#else 
-		fpos64_t pos;
-		fgetpos64(handle, &pos);
-		return *(Int64*)(&pos);
-#endif
-	}
-	void FileStream::Seek(SeekOrigin origin, Int64 offset)
-	{
-		int _origin;
-		switch (origin)
-		{
-		case Slang::SeekOrigin::Start:
-			_origin = SEEK_SET;
-			endReached = false;
-			break;
-		case Slang::SeekOrigin::End:
-			_origin = SEEK_END;
-            // JS TODO: This doesn't seem right, the offset can mean it's not at the end
-			endReached = true;
-			break;
-		case Slang::SeekOrigin::Current:
-			_origin = SEEK_CUR;
-			endReached = false;
-			break;
-		default:
-			throw NotSupportedException("Unsupported seek origin.");
-			break;
-		}
-#ifdef _WIN32
-		int rs = _fseeki64(handle, offset, _origin);
-#else
-		int rs = fseek(handle, (int)offset, _origin);
-#endif
-		if (rs != 0)
-		{
-			throw IOException("FileStream seek failed.");
-		}
-	}
-	Int64 FileStream::Read(void * buffer, Int64 length)
-	{
-		auto bytes = fread_s(buffer, (size_t)length, 1, (size_t)length, handle);
-		if (bytes == 0 && length > 0)
-		{
-			if (!feof(handle))
-				throw IOException("FileStream read failed.");
-			else if (endReached)
-				throw EndOfStreamException("End of file is reached.");
-			endReached = true;
-		}
-		return (int)bytes;
-	}
-	Int64 FileStream::Write(const void * buffer, Int64 length)
-	{
-		auto bytes = (Int64)fwrite(buffer, 1, (size_t)length, handle);
-		if (bytes < length)
-		{
-			throw IOException("FileStream write failed.");
-		}
-		return bytes;
-	}
-	bool FileStream::CanRead()
-	{
-		return ((int)fileAccess & (int)FileAccess::Read) != 0;
-	}
-	bool FileStream::CanWrite()
-	{
-		return ((int)fileAccess & (int)FileAccess::Write) != 0;
-	}
-	void FileStream::Close()
-	{
-		if (handle)
-		{
-			fclose(handle);
-			handle = 0;
-		}
-	}
-	bool FileStream::IsEnd()
-	{
-		return endReached;
-	}
 
-    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! MemoryStreamBase !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! FileStream !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    void MemoryStreamBase::Seek(SeekOrigin origin, Int64 offset)
-    {
-        Int64 pos = 0;
-        switch (origin)
-        {
-            case Slang::SeekOrigin::Start:
-                pos = offset;
-                break;
-            case Slang::SeekOrigin::End:
-                pos = Int64(m_dataSize) + offset;
-                break;
-            case Slang::SeekOrigin::Current:
-                pos = Int64(m_position) + offset;
-                break;
-            default:
-                throw NotSupportedException("Unsupported seek origin.");
-                break;
-        }
-
-        m_atEnd = false;
-
-        // Clamp to the valid range
-        pos = (pos < 0) ? 0 : pos;
-        pos = (pos > Int64(m_dataSize)) ? Int64(m_dataSize) : pos;
-
-        m_position = UInt(pos);
-    }
-
-    Int64 MemoryStreamBase::Read(void* buffer, Int64 length)
-    {
-        if (!CanRead())
-        {
-            throw IOException("Cannot read this stream.");
-        }
-
-        const Int64 maxRead = Int64(m_dataSize - m_position);
-
-        if (maxRead == 0 && length > 0)
-        {
-            m_atEnd = true;
-            throw EndOfStreamException("End of file is reached.");
-        }
-
-        length = length > maxRead ? maxRead : length;
-
-        ::memcpy(buffer, m_data + m_position, size_t(length));
-        m_position += UInt(length);
-        return maxRead;
-    }
-
-    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! MemoryStream !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-    Int64 MemoryStream::Write(const void * buffer, Int64 length)
-    {
-        if (!CanWrite())
-        {
-            throw IOException("Cannot write this stream.");
-        }
-
-        if (m_position == m_contents.getCount())
-        {
-            m_contents.addRange((const uint8_t*)buffer, UInt(length));
-        }
-        else
-        {
-            m_contents.insertRange(m_position, (const uint8_t*)buffer, UInt(length));
-        }
-
-        m_data = m_contents.getBuffer();
-        m_dataSize = ptrdiff_t(m_contents.getCount());
-
-        m_atEnd = false;
-
-        m_position += ptrdiff_t(length);
-        return length;
-    }
-
+FileStream::FileStream(const String& fileName, FileMode fileMode)
+{
+	_init(fileName, fileMode, fileMode==FileMode::Open?FileAccess::Read:FileAccess::Write, FileShare::None);
 }
+
+FileStream::FileStream(const String& fileName, FileMode fileMode, FileAccess access, FileShare share)
+{
+	_init(fileName, fileMode, access, share);
+}
+
+void FileStream::_init(const String& fileName, FileMode fileMode, FileAccess access, FileShare share)
+{
+	const wchar_t * mode = L"rt";
+	const char* modeMBCS = "rt";
+	switch (fileMode)
+	{
+	case FileMode::Create:
+		if (access == FileAccess::Read)
+			throw ArgumentException("Read-only access is incompatible with Create mode.");
+		else if (access == FileAccess::ReadWrite)
+		{
+			mode = L"w+b";
+			modeMBCS = "w+b";
+			this->m_fileAccess = FileAccess::ReadWrite;
+		}
+		else
+		{
+			mode = L"wb";
+			modeMBCS = "wb";
+			this->m_fileAccess = FileAccess::Write;
+		}
+		break;
+	case FileMode::Open:
+		if (access == FileAccess::Read)
+		{
+			mode = L"rb";
+			modeMBCS = "rb";
+			this->m_fileAccess = FileAccess::Read;
+		}
+		else if (access == FileAccess::ReadWrite)
+		{
+			mode = L"r+b";
+			modeMBCS = "r+b";
+			this->m_fileAccess = FileAccess::ReadWrite;
+		}
+		else
+		{
+			mode = L"wb";
+			modeMBCS = "wb";
+			this->m_fileAccess = FileAccess::Write;
+		}
+		break;
+	case FileMode::CreateNew:
+		if (File::exists(fileName))
+		{
+			throw IOException("Failed opening '" + fileName + "', file already exists.");
+		}
+		if (access == FileAccess::Read)
+			throw ArgumentException("Read-only access is incompatible with Create mode.");
+		else if (access == FileAccess::ReadWrite)
+		{
+			mode = L"w+b";
+			this->m_fileAccess = FileAccess::ReadWrite;
+		}
+		else
+		{
+			mode = L"wb";
+			this->m_fileAccess = FileAccess::Write;
+		}
+		break;
+	case FileMode::Append:
+		if (access == FileAccess::Read)
+			throw ArgumentException("Read-only access is incompatible with Append mode.");
+		else if (access == FileAccess::ReadWrite)
+		{
+			mode = L"a+b";
+			this->m_fileAccess = FileAccess::ReadWrite;
+		}
+		else
+		{
+			mode = L"ab";
+			this->m_fileAccess = FileAccess::Write;
+		}
+		break;
+	default:
+		break;
+	}
+#ifdef _WIN32
+    int shFlag = _SH_DENYRW;
+    switch (share)
+	{
+	case FileShare::None:
+		shFlag = _SH_DENYRW;
+		break;
+	case FileShare::ReadOnly:
+		shFlag = _SH_DENYWR;
+		break;
+	case FileShare::WriteOnly:
+		shFlag = _SH_DENYRD;
+		break;
+	case FileShare::ReadWrite:
+		shFlag = _SH_DENYNO;
+		break;
+	default:
+		throw ArgumentException("Invalid file share mode.");
+		break;
+	}
+    if (share == FileShare::None)
+#pragma warning(suppress:4996)
+        m_handle = _wfopen(fileName.toWString(), mode);
+    else
+		m_handle = _wfsopen(fileName.toWString(), mode, shFlag);
+#else
+	m_handle = fopen(fileName.getBuffer(), modeMBCS);
+#endif
+	if (!m_handle)
+	{
+		throw IOException("Cannot open file '" + fileName + "'");
+	}
+}
+
+FileStream::~FileStream()
+{
+	close();
+}
+
+Int64 FileStream::getPosition()
+{
+#if defined(_WIN32) || defined(__CYGWIN__)
+	fpos_t pos;
+	fgetpos(m_handle, &pos);
+	return pos;
+#elif defined(__APPLE__)
+	return ftell(m_handle);
+#else 
+	fpos64_t pos;
+	fgetpos64(m_handle, &pos);
+	return *(Int64*)(&pos);
+#endif
+}
+void FileStream::seek(SeekOrigin origin, Int64 offset)
+{
+	int _origin;
+	switch (origin)
+	{
+	case SeekOrigin::Start:
+		_origin = SEEK_SET;
+		m_endReached = false;
+		break;
+	case SeekOrigin::End:
+		_origin = SEEK_END;
+        // JS TODO: This doesn't seem right, the offset can mean it's not at the end
+		m_endReached = true;
+		break;
+	case SeekOrigin::Current:
+		_origin = SEEK_CUR;
+		m_endReached = false;
+		break;
+	default:
+		throw NotSupportedException("Unsupported seek origin.");
+		break;
+	}
+#ifdef _WIN32
+	int rs = _fseeki64(m_handle, offset, _origin);
+#else
+	int rs = fseek(m_handle, (int)offset, _origin);
+#endif
+	if (rs != 0)
+	{
+		throw IOException("FileStream seek failed.");
+	}
+}
+Int64 FileStream::read(void* buffer, Int64 length)
+{
+	auto bytes = fread_s(buffer, (size_t)length, 1, (size_t)length, m_handle);
+	if (bytes == 0 && length > 0)
+	{
+		if (!feof(m_handle))
+			throw IOException("FileStream read failed.");
+		else if (m_endReached)
+			throw EndOfStreamException("End of file is reached.");
+		m_endReached = true;
+	}
+	return (int)bytes;
+}
+Int64 FileStream::write(const void* buffer, Int64 length)
+{
+	auto bytes = (Int64)fwrite(buffer, 1, (size_t)length, m_handle);
+	if (bytes < length)
+	{
+		throw IOException("FileStream write failed.");
+	}
+	return bytes;
+}
+bool FileStream::canRead()
+{
+	return ((int)m_fileAccess & (int)FileAccess::Read) != 0;
+}
+bool FileStream::canWrite()
+{
+	return ((int)m_fileAccess & (int)FileAccess::Write) != 0;
+}
+void FileStream::close()
+{
+	if (m_handle)
+	{
+		fclose(m_handle);
+		m_handle = 0;
+	}
+}
+bool FileStream::isEnd()
+{
+	return m_endReached;
+}
+
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!! MemoryStreamBase !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+void MemoryStreamBase::seek(SeekOrigin origin, Int64 offset)
+{
+    Int64 pos = 0;
+    switch (origin)
+    {
+        case SeekOrigin::Start:
+            pos = offset;
+            break;
+        case SeekOrigin::End:
+            pos = Int64(m_contentSize) + offset;
+            break;
+        case SeekOrigin::Current:
+            pos = Int64(m_position) + offset;
+            break;
+        default:
+            throw NotSupportedException("Unsupported seek origin.");
+            break;
+    }
+
+    m_atEnd = false;
+
+    // Clamp to the valid range
+    pos = (pos < 0) ? 0 : pos;
+    pos = (pos > Int64(m_contentSize)) ? Int64(m_contentSize) : pos;
+
+    m_position = UInt(pos);
+}
+
+Int64 MemoryStreamBase::read(void* buffer, Int64 length)
+{
+    if (!canRead())
+    {
+        throw IOException("Cannot read this stream.");
+    }
+
+    const Int64 maxRead = Int64(m_contentSize - m_position);
+
+    if (maxRead == 0 && length > 0)
+    {
+        m_atEnd = true;
+        throw EndOfStreamException("End of file is reached.");
+    }
+
+    length = length > maxRead ? maxRead : length;
+
+    ::memcpy(buffer, m_content + m_position, size_t(length));
+    m_position += UInt(length);
+    return maxRead;
+}
+
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!! OwnedMemoryStream !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+Int64 OwnedMemoryStream::write(const void * buffer, Int64 length)
+{
+    if (!canWrite())
+    {
+        throw IOException("Cannot write this stream.");
+    }
+
+    if (m_position == m_ownedContent.getCount())
+    {
+        m_ownedContent.addRange((const uint8_t*)buffer, UInt(length));
+    }
+    else
+    {
+        m_ownedContent.insertRange(m_position, (const uint8_t*)buffer, UInt(length));
+    }
+
+    m_content = m_ownedContent.getBuffer();
+    m_contentSize = ptrdiff_t(m_ownedContent.getCount());
+
+    m_atEnd = false;
+
+    m_position += ptrdiff_t(length);
+    return length;
+}
+
+} // namespace Slang

--- a/source/core/slang-stream.h
+++ b/source/core/slang-stream.h
@@ -77,33 +77,33 @@ public:
     virtual bool canWrite() SLANG_OVERRIDE { return (int(m_access) & int(FileAccess::Write)) != 0; }
     virtual void close() SLANG_OVERRIDE { m_access = FileAccess::None; }
 
-    MemoryStreamBase(FileAccess access = FileAccess::Read, const void* content = nullptr, size_t contentSize = 0):
+    MemoryStreamBase(FileAccess access = FileAccess::Read, const void* contents = nullptr, size_t contentsSize = 0):
         m_access(access)
     {
-        _setContent(content, contentSize);
+        _setContents(contents, contentsSize);
     }
 
 protected:
         /// Set to replace wholly current content with specified content
-    void _setContent(const void* content, size_t contentSize)
+    void _setContents(const void* contents, size_t contentsSize)
     {
-        m_content = (const uint8_t*)content;
-        m_contentSize = ptrdiff_t(contentSize);
+        m_contents = (const uint8_t*)contents;
+        m_contentsSize = ptrdiff_t(contentsSize);
         m_position = 0;
         m_atEnd = false;    
     }
         /// Update means that the content has changed, but position should be maintained
-    void _updateContent(const void* content, size_t contentSize)
+    void _updateContents(const void* contents, size_t contentsSize)
     {
-        const ptrdiff_t newPosition = (m_position > ptrdiff_t(contentSize)) ? ptrdiff_t(contentSize) : m_position;
-        _setContent(content, contentSize);
+        const ptrdiff_t newPosition = (m_position > ptrdiff_t(contentsSize)) ? ptrdiff_t(contentsSize) : m_position;
+        _setContents(contents, contentsSize);
         m_position = newPosition;
     }
 
-    const uint8_t* m_content;   ///< The content held in the stream
+    const uint8_t* m_contents;   ///< The content held in the stream
 
     // Using ptrdiff_t (as opposed to size_t) as makes maths simpler
-    ptrdiff_t m_contentSize;    ///< Total size of the content in bytes
+    ptrdiff_t m_contentsSize;    ///< Total size of the content in bytes
     ptrdiff_t m_position;       ///< The current position within content (valid values can only be between 0 and m_contentSize)
 
     bool m_atEnd;               ///< Happens when a read is done and nothing can be returned because already at end
@@ -117,20 +117,20 @@ class OwnedMemoryStream : public MemoryStreamBase
 public:
     typedef MemoryStreamBase Super;
 
-    virtual Int64 write(const void * buffer, Int64 length) SLANG_OVERRIDE;
+    virtual Int64 write(const void* buffer, Int64 length) SLANG_OVERRIDE;
 
         /// Set the contents
-    void setContent(const void* data, size_t size)
+    void setContent(const void* contents, size_t contentsSize)
     {
-        m_ownedContent.setCount(size);
-        ::memcpy(m_ownedContent.getBuffer(), data, size);
-        _setContent(m_ownedContent.getBuffer(), m_ownedContent.getCount());
+        m_ownedContents.setCount(contentsSize);
+        ::memcpy(m_ownedContents.getBuffer(), contents, contentsSize);
+        _setContents(m_ownedContents.getBuffer(), m_ownedContents.getCount());
     }
 
-    void swapContent(List<uint8_t>& rhs)
+    void swapContents(List<uint8_t>& rhs)
     {
-        rhs.swapWith(m_ownedContent);
-        _setContent(m_ownedContent.getBuffer(), m_ownedContent.getCount());
+        rhs.swapWith(m_ownedContents);
+        _setContents(m_ownedContents.getBuffer(), m_ownedContents.getCount());
     }
 
     OwnedMemoryStream(FileAccess access) :
@@ -139,7 +139,7 @@ public:
 
 protected:
      
-    List<uint8_t> m_ownedContent;
+    List<uint8_t> m_ownedContents;
 };
 
 class FileStream : public Stream
@@ -150,8 +150,8 @@ public:
     // Stream interface
 	virtual Int64 getPosition();
 	virtual void seek(SeekOrigin origin, Int64 offset);
-	virtual Int64 read(void * buffer, Int64 length);
-	virtual Int64 write(const void * buffer, Int64 length);
+	virtual Int64 read(void* buffer, Int64 length);
+	virtual Int64 write(const void* buffer, Int64 length);
 	virtual bool canRead();
 	virtual bool canWrite();
 	virtual void close();
@@ -169,6 +169,6 @@ private:
     bool m_endReached = false;
 };
 
-}
+} // namespace Slang
 
 #endif

--- a/source/core/slang-text-io.cpp
+++ b/source/core/slang-text-io.cpp
@@ -126,11 +126,11 @@ namespace Slang
 		this->encoding = encoding;
 		if (encoding == Encoding::UTF16)
 		{
-			this->stream->Write(&Utf16Header, 2);
+			this->stream->write(&Utf16Header, 2);
 		}
 		else if (encoding == Encoding::UTF16Reversed)
 		{
-			this->stream->Write(&Utf16ReversedHeader, 2);
+			this->stream->write(&Utf16ReversedHeader, 2);
 		}
 	}
 	StreamWriter::StreamWriter(RefPtr<Stream> stream, Encoding * encoding)
@@ -139,11 +139,11 @@ namespace Slang
 		this->encoding = encoding;
 		if (encoding == Encoding::UTF16)
 		{
-			this->stream->Write(&Utf16Header, 2);
+			this->stream->write(&Utf16Header, 2);
 		}
 		else if (encoding == Encoding::UTF16Reversed)
 		{
-			this->stream->Write(&Utf16ReversedHeader, 2);
+			this->stream->write(&Utf16ReversedHeader, 2);
 		}
 	}
 	void StreamWriter::Write(const String & str)
@@ -169,7 +169,7 @@ namespace Slang
 				sb << str[i];
 		}
 		encoding->GetBytes(encodingBuffer, sb.ProduceString());
-		stream->Write(encodingBuffer.getBuffer(), encodingBuffer.getCount());
+		stream->write(encodingBuffer.getBuffer(), encodingBuffer.getCount());
 	}
 	void StreamWriter::Write(const char * str)
 	{
@@ -237,7 +237,7 @@ namespace Slang
 	{
 		buffer.setCount(4096);
         memset(buffer.getBuffer(), 0, buffer.getCount() * sizeof(buffer[0]));
-		auto len = stream->Read(buffer.getBuffer(), buffer.getCount());
+		auto len = stream->read(buffer.getBuffer(), buffer.getCount());
 		buffer.setCount((int)len);
 		ptr = 0;
 	}
@@ -248,7 +248,7 @@ namespace Slang
 		{
 			return buffer[ptr++];
 		}
-		if (!stream->IsEnd())
+		if (!stream->isEnd())
 			ReadBuffer();
 		if (ptr<buffer.getCount())
 		{

--- a/source/core/slang-text-io.h
+++ b/source/core/slang-text-io.h
@@ -259,7 +259,7 @@ namespace Slang
 		virtual void Write(const char * str);
 		virtual void Close()
 		{
-			stream->Close();
+			stream->close();
 		}
         void ReleaseStream()
         {
@@ -300,11 +300,11 @@ namespace Slang
 		virtual String ReadToEnd();
 		virtual bool IsEnd()
 		{
-			return ptr == buffer.getCount() && stream->IsEnd();
+			return ptr == buffer.getCount() && stream->isEnd();
 		}
 		virtual void Close()
 		{
-			stream->Close();
+			stream->close();
 		}
         void ReleaseStream()
         {

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1172,17 +1172,19 @@ namespace Slang
         /// If this member is `null`, a default implementation that tries
         /// to use the native OS filesystem will be used instead.
         ///
-        ComPtr<ISlangFileSystem> fileSystem;
+        ComPtr<ISlangFileSystem> m_fileSystem;
 
         /// The extended file system implementation. Will be set to a default implementation
         /// if fileSystem is nullptr. Otherwise it will either be fileSystem's interface, 
         /// or a wrapped impl that makes fileSystem operate as fileSystemExt
-        ComPtr<ISlangFileSystemExt> fileSystemExt;
+        ComPtr<ISlangFileSystemExt> m_fileSystemExt;
 
+        
         /// Set if fileSystemExt is a cache file system
-        RefPtr<CacheFileSystem> cacheFileSystem;
+        RefPtr<CacheFileSystem> m_cacheFileSystem;
 
-        ISlangFileSystemExt* getFileSystemExt() { return fileSystemExt; }
+        ISlangFileSystemExt* getFileSystemExt() { return m_fileSystemExt; }
+        CacheFileSystem* getCacheFileSystem() const { return m_cacheFileSystem; }
 
         /// Load a file into memory using the configured file system.
         ///
@@ -1191,7 +1193,6 @@ namespace Slang
         /// @returns A `SlangResult` to indicate success or failure.
         ///
         SlangResult loadFile(String const& path, PathInfo& outPathInfo, ISlangBlob** outBlob);
-
 
         RefPtr<Expr> parseTypeString(String typeStr, RefPtr<Scope> scope);
 
@@ -1230,7 +1231,7 @@ namespace Slang
             return m_sourceManager;
         }
 
-            /// Override the source manager for the linakge.
+            /// Override the source manager for the linkage.
             ///
             /// This is only used to install a temporary override when
             /// parsing stuff from strings (where we don't want to retain

--- a/source/slang/slang-file-system.cpp
+++ b/source/slang/slang-file-system.cpp
@@ -138,7 +138,7 @@ SLANG_NO_THROW SlangResult SLANG_MCALL OSFileSystemExt::saveFile(const char* pat
     {
         FileStream stream(pathIn, FileMode::Create, FileAccess::Write, FileShare::ReadWrite);
 
-        int64_t numWritten = stream.Write(data, size);
+        int64_t numWritten = stream.write(data, size);
 
         if (numWritten != int64_t(size))
         {

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -496,7 +496,7 @@ struct OptionsParser
                 else if (argStr == "-dump-repro")
                 {
                     SLANG_RETURN_ON_FAIL(tryReadCommandLineArgument(sink, arg, &argCursor, argEnd, requestImpl->dumpRepro));
-                    requestImpl->getLinkage()->setRequireCacheFileSystem(true);
+                    spEnableReproCapture(asExternal(requestImpl));
                 }
                 else if (argStr == "-extract-repro")
                 {

--- a/source/slang/slang-state-serialize.cpp
+++ b/source/slang/slang-state-serialize.cpp
@@ -383,7 +383,12 @@ static bool _isStorable(const PathInfo::Type type)
 
     // Find files from the file system, and mapping paths to files
     {
-        CacheFileSystem* cacheFileSystem = linkage->cacheFileSystem;
+        CacheFileSystem* cacheFileSystem = linkage->getCacheFileSystem();
+        if (!cacheFileSystem)
+        {
+            return SLANG_FAIL;
+        }
+
         // Traverse the references (in process we will construct the map from PathInfo)        
         {
             const auto& srcFiles = cacheFileSystem->getPathMap();
@@ -782,8 +787,8 @@ static void _loadDefines(const Relative32Array<StateSerializeUtil::StringPair>& 
         // This is a bit of a hack, we are going to replace the file system, with our one which is filled in
         // with what was read from the file. 
 
-        linkage->fileSystemExt = cacheFileSystem;
-        linkage->cacheFileSystem = cacheFileSystem;
+        linkage->m_fileSystemExt = cacheFileSystem;
+        linkage->m_cacheFileSystem = cacheFileSystem;
     }
 
     return SLANG_OK;

--- a/source/slang/slang-state-serialize.h
+++ b/source/slang/slang-state-serialize.h
@@ -52,6 +52,12 @@ struct StateSerializeUtil
         Relative32Ptr<PathInfoState> pathInfo;
     };
 
+    struct OutputState
+    {
+        int32_t entryPointIndex;
+        Relative32Ptr<RelativeString> outputPath;
+    };
+
         // spSetCodeGenTarget/spAddCodeGenTarget
         // spSetTargetProfile
         // spSetTargetFlags
@@ -63,6 +69,8 @@ struct StateSerializeUtil
         CodeGenTarget target;
         SlangTargetFlags targetFlags;
         FloatingPointMode floatingPointMode;
+
+        Relative32Array<OutputState> outputStates;
     };
 
     struct FileReference

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -800,11 +800,11 @@ SlangResult Linkage::loadFile(String const& path, PathInfo& outPathInfo, ISlangB
 {
     outPathInfo.type = PathInfo::Type::Unknown;
 
-    SLANG_RETURN_ON_FAIL(fileSystemExt->loadFile(path.getBuffer(), outBlob));
+    SLANG_RETURN_ON_FAIL(m_fileSystemExt->loadFile(path.getBuffer(), outBlob));
 
     ComPtr<ISlangBlob> uniqueIdentity;
     // Get the unique identity
-    SLANG_RETURN_ON_FAIL(fileSystemExt->getFileUniqueIdentity(path.getBuffer(), uniqueIdentity.writeRef()));
+    SLANG_RETURN_ON_FAIL(m_fileSystemExt->getFileUniqueIdentity(path.getBuffer(), uniqueIdentity.writeRef()));
 
     outPathInfo.foundPath = path;
     outPathInfo.type = PathInfo::Type::FoundPath;
@@ -2489,17 +2489,17 @@ static const Slang::Guid IID_SlangCacheFileSystem = SLANG_UUID_CacheFileSystem;
 void Linkage::setFileSystem(ISlangFileSystem* inFileSystem)
 {
     // Set the fileSystem
-    fileSystem = inFileSystem;
+    m_fileSystem = inFileSystem;
 
     // Release what's there
-    fileSystemExt.setNull();
-    cacheFileSystem.setNull();
+    m_fileSystemExt.setNull();
+    m_cacheFileSystem.setNull();
 
     // If nullptr passed in set up default 
     if (inFileSystem == nullptr)
     {
-        cacheFileSystem = new Slang::CacheFileSystem(Slang::OSFileSystemExt::getSingleton());
-        fileSystemExt = cacheFileSystem;
+        m_cacheFileSystem = new Slang::CacheFileSystem(Slang::OSFileSystemExt::getSingleton());
+        m_fileSystemExt = m_cacheFileSystem;
     }
     else
     {
@@ -2507,34 +2507,34 @@ void Linkage::setFileSystem(ISlangFileSystem* inFileSystem)
         inFileSystem->queryInterface(IID_SlangCacheFileSystem, (void**)&cacheFileSystemPtr);
         if (cacheFileSystemPtr)
         {
-            cacheFileSystem = cacheFileSystemPtr;
-            fileSystemExt = cacheFileSystemPtr;
+            m_cacheFileSystem = cacheFileSystemPtr;
+            m_fileSystemExt = cacheFileSystemPtr;
         }
         else 
         {
             if (m_requireCacheFileSystem)
             {
-                cacheFileSystem = new Slang::CacheFileSystem(inFileSystem);
-                fileSystemExt = cacheFileSystem;
+                m_cacheFileSystem = new Slang::CacheFileSystem(inFileSystem);
+                m_fileSystemExt = m_cacheFileSystem;
             }
             else
             {
                 // See if we have the full ISlangFileSystemExt interface, if we do just use it
-                inFileSystem->queryInterface(IID_ISlangFileSystemExt, (void**)fileSystemExt.writeRef());
+                inFileSystem->queryInterface(IID_ISlangFileSystemExt, (void**)m_fileSystemExt.writeRef());
 
                 // If not wrap with CacheFileSystem that emulates ISlangFileSystemExt from the ISlangFileSystem interface
-                if (!fileSystemExt)
+                if (!m_fileSystemExt)
                 {
                     // Construct a wrapper to emulate the extended interface behavior
-                    cacheFileSystem = new Slang::CacheFileSystem(fileSystem);
-                    fileSystemExt = cacheFileSystem;
+                    m_cacheFileSystem = new Slang::CacheFileSystem(m_fileSystem);
+                    m_fileSystemExt = m_cacheFileSystem;
                 }
             }
         }
     }
 
     // Set the file system used on the source manager
-    getSourceManager()->setFileSystemExt(fileSystemExt);
+    getSourceManager()->setFileSystemExt(m_fileSystemExt);
 }
 
 void Linkage::setRequireCacheFileSystem(bool requireCacheFileSystem)
@@ -2544,7 +2544,7 @@ void Linkage::setRequireCacheFileSystem(bool requireCacheFileSystem)
         return;
     }
 
-    ComPtr<ISlangFileSystem> scopeFileSystem(fileSystem);
+    ComPtr<ISlangFileSystem> scopeFileSystem(m_fileSystem);
     m_requireCacheFileSystem = requireCacheFileSystem;
 
     setFileSystem(scopeFileSystem);
@@ -3486,6 +3486,16 @@ SLANG_API SlangResult spSaveRepro(
     listBlob->m_data.swapWith(stream.m_contents);
 
     *outBlob = listBlob.detach();
+    return SLANG_OK;
+}
+
+SLANG_API SlangResult spEnableReproCapture(
+    SlangCompileRequest* inRequest)
+{
+    using namespace Slang;
+    auto request = asInternal(inRequest);
+
+    request->getLinkage()->setRequireCacheFileSystem(true);
     return SLANG_OK;
 }
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3485,7 +3485,7 @@ SLANG_API SlangResult spSaveRepro(
     RefPtr<ListBlob> listBlob(new ListBlob);
 
     // Put the content of the stream in the blob
-    stream.swapContent(listBlob->m_data);
+    stream.swapContents(listBlob->m_data);
 
     *outBlob = listBlob.detach();
     return SLANG_OK;

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3478,14 +3478,14 @@ SLANG_API SlangResult spSaveRepro(
     using namespace Slang;
     auto request = asInternal(inRequest);
 
-    MemoryStream stream(FileAccess::Write);
+    OwnedMemoryStream stream(FileAccess::Write);
 
     SLANG_RETURN_ON_FAIL(StateSerializeUtil::saveState(request, &stream));
 
     RefPtr<ListBlob> listBlob(new ListBlob);
 
-    // Put the contents of the stream in the blob
-    stream.swapContents(listBlob->m_data);
+    // Put the content of the stream in the blob
+    stream.swapContent(listBlob->m_data);
 
     *outBlob = listBlob.detach();
     return SLANG_OK;


### PR DESCRIPTION
* Added support for serializing output filenames - such that now should be able to replicate most command line invocations exactly. 
* Added API functions spEnableReproCapture and spExtractRepro.
* Added MemoryStreamBase - which can be used to read from without copying the data.
* Small improvements to documentation. 
* Renamed Stream related method/variables to be closer to conventions 
