### PR TITLE
Add basic support for entry points in `.slang-lib` files.

### DIFF
--- a/source/core/slang-riff.cpp
+++ b/source/core/slang-riff.cpp
@@ -548,6 +548,19 @@ void RiffContainer::ListChunk::findContained(FourCC type, List<ListChunk*>& out)
     }
 }
 
+void RiffContainer::ListChunk::findContained(FourCC type, List<DataChunk*>& out)
+{
+    Chunk* chunk = m_containedChunks;
+    while (chunk)
+    {
+        if (chunk->m_fourCC == type && chunk->m_kind == Chunk::Kind::Data)
+        {
+            out.add(static_cast<DataChunk*>(chunk));
+        }
+        chunk = chunk->m_next;
+    }
+}
+
 RiffContainer::Data* RiffContainer::ListChunk::findContainedData(FourCC type) const
 {
     Chunk* found = findContained(type);

--- a/source/core/slang-riff.h
+++ b/source/core/slang-riff.h
@@ -128,6 +128,16 @@ public:
     {
     }
 
+    SlangResult skip(size_t size)
+    {
+        if (m_cur + size > m_end)
+        {
+            return SLANG_FAIL;
+        }
+        m_cur += size;
+        return SLANG_OK;
+    }
+
 protected:
     const uint8_t* m_start;
     const uint8_t* m_end;
@@ -247,6 +257,9 @@ public:
 
             /// Find all contained that match the type
         void findContained(FourCC type, List<ListChunk*>& out);
+
+            /// Find all contained that match the type
+        void findContained(FourCC type, List<DataChunk*>& out);
 
             /// Find the list (including self) that matches subtype recursively
         ListChunk* findListRec(FourCC subType);

--- a/source/core/slang-riff.h
+++ b/source/core/slang-riff.h
@@ -109,8 +109,8 @@ public:
         {
             return SLANG_FAIL;
         }
-        // Make sure the alignment is plausible
-        SLANG_ASSERT((size_t(m_cur) & (SLANG_ALIGN_OF(T) - 1)) == 0);
+        // TODO: consider whether this type should enforce alignment.
+        // SLANG_ASSERT((size_t(m_cur) & (SLANG_ALIGN_OF(T) - 1)) == 0);
         ::memcpy(&out, m_cur, sizeof(T));
         m_cur += sizeof(T);
         return SLANG_OK;

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -695,6 +695,13 @@ namespace Slang
             Name*       name,
             Profile     profile);
 
+            /// Create a dummy `EntryPoint` that stands in for a serialized entry point
+        static RefPtr<EntryPoint> createDummyForDeserialize(
+            Linkage*    linkage,
+            Name*       name,
+            Profile     profile,
+            String      mangledName);
+
             /// Get the number of existential type parameters for the entry point.
         Index getSpecializationParamCount() SLANG_OVERRIDE;
 
@@ -751,6 +758,9 @@ namespace Slang
         // The declaration of the entry-point function itself.
         //
         DeclRef<FuncDecl> m_funcDeclRef;
+
+            /// The mangled name of the entry point function
+        String m_mangledName;
 
         SpecializationParams m_genericSpecializationParams;
         SpecializationParams m_existentialSpecializationParams;
@@ -1444,6 +1454,17 @@ namespace Slang
         bool m_isStandardLibraryCode = false;
 
         Name* m_defaultModuleName = nullptr;
+
+            /// An "extra" entry point that was added via a library reference
+        struct ExtraEntryPointInfo
+        {
+            Name*   name;
+            Profile profile;
+            String  mangledName;
+        };
+
+            /// A list of "extra" entry points added via a library reference
+        List<ExtraEntryPointInfo> m_extraEntryPoints;
 
     private:
             /// A component type that includes only the global scopes of the translation unit(s) that were compiled.

--- a/source/slang/slang-ir-serialize.h
+++ b/source/slang/slang-ir-serialize.h
@@ -383,6 +383,8 @@ struct IRSerialBinary
     static const FourCC kDebugSourceInfoFourCc = SLANG_FOUR_CC('S', 'd', 's', 'o');
     static const FourCC kDebugSourceLocRunFourCc = SLANG_FOUR_CC('S', 'd', 's', 'r');
 
+    static const FourCC kEntryPointFourCc = SLANG_FOUR_CC('E', 'P', 'n', 't');
+
     struct ModuleHeader
     {
         uint32_t compressionType;         ///< Holds the compression type used (if used at all)
@@ -504,7 +506,7 @@ struct IRSerialReader
     static Result readStream(Stream* stream, IRSerialData* dataOut);
 
         /// Read potentially multiple modules from a stream
-    static Result readStreamModules(Stream* stream, Session* session, SourceManager* manager, List<RefPtr<IRModule>>& outModules);
+    static Result readStreamModules(Stream* stream, Session* session, SourceManager* manager, List<RefPtr<IRModule>>& outModules, List<FrontEndCompileRequest::ExtraEntryPointInfo>& outEntryPoints);
 
         /// Read a stream to fill in dataOut IRSerialData
     static Result readContainer(RiffContainer::ListChunk* module, IRSerialData* outData);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -7265,6 +7265,12 @@ RefPtr<IRModule> TargetProgram::createIRModuleForLayout(DiagnosticSink* sink)
     {
         auto funcDeclRef = entryPointLayout->entryPoint;
 
+        // HACK: skip over entry points that came from deserialization,
+        // and thus don't have AST-level information for us to work with.
+        //
+        if(!funcDeclRef)
+            continue;
+
         auto irFuncType = lowerType(context, getFuncType(session, funcDeclRef));
         auto irFunc = getSimpleVal(context, emitDeclRef(context, funcDeclRef, irFuncType));
 

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -19,6 +19,8 @@
 
 namespace Slang {
 
+SlangResult _addLibraryReference(EndToEndCompileRequest* req, Stream* stream);
+
 SlangResult tryReadCommandLineArgumentRaw(DiagnosticSink* sink, char const* option, char const* const**ioCursor, char const* const*end, char const** argOut)
 {
     *argOut = nullptr;
@@ -917,17 +919,9 @@ struct OptionsParser
                     // We need to deserialize and add the modules
                     FileStream fileStream(referenceModuleName, FileMode::Open, FileAccess::Read, FileShare::ReadWrite);
 
-                    List<RefPtr<IRModule>> irModules;
-                    if (SLANG_FAILED(IRSerialReader::readStreamModules(&fileStream, asInternal(session), requestImpl->getFrontEndReq()->getSourceManager(), irModules)))
-                    {
-                        sink->diagnose(SourceLoc(), Diagnostics::unableToReadModuleContainer, referenceModuleName);
-                        return SLANG_FAIL;
-                    }
+                    // TODO: probalby near an error when we can't open the file?
 
-                    // TODO(JS): May be better to have a ITypeComponent that encapsulates a collection of modules
-                    // For now just add to the linkage
-                    auto linkage = requestImpl->getLinkage();
-                    linkage->m_libModules.addRange(irModules.getBuffer(), irModules.getCount());
+                    _addLibraryReference(requestImpl, &fileStream);
                 }
                 else if (argStr == "-v")
                 {

--- a/tests/serialization/serialized-module-entry-point-test.slang
+++ b/tests/serialization/serialized-module-entry-point-test.slang
@@ -2,9 +2,6 @@
 
 //TEST:COMPILE: -module-name module -target hlsl -profile cs_5_0 -entry computeMain tests/serialization/serialized-module-entry-point.slang -o tests/serialization/serialized-module-entry-point.slang-module
 //TEST:COMPILE: -module-name module tests/serialization/serialized-module.slang -o tests/serialization/serialized-module.slang-module
-//TEST:COMPARE_COMPUTE_EX: -xslang -module-name -xslang module -slang -compute -xslang -r -xslang tests/serialization/serialized-module-entry-point.slang-module -xslang -r -xslang tests/serialization/serialized-module.slang-module 
+//TEST:COMPARE_COMPUTE_EX: -xslang -module-name -xslang module -slang -compute -xslang -r -xslang tests/serialization/serialized-module-entry-point.slang-module -xslang -r -xslang tests/serialization/serialized-module.slang-module -no-default-entry-point
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 ], stride=4):dxbinding(0),glbinding(0),out,name outputBuffer
-
-[numthreads(4, 1, 1)]
-void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID);

--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -255,6 +255,10 @@ SlangResult parseOptions(int argc, const char*const* argv, Slang::WriterHelper s
 
             gOptions.sourceLanguage = sourceLanguage;
         }
+        else if( strcmp(arg, "-no-default-entry-point") == 0 )
+        {
+            gOptions.dontAddDefaultEntryPoints = true;
+        }
         else
         {
             // Lookup

--- a/tools/render-test/options.h
+++ b/tools/render-test/options.h
@@ -62,6 +62,8 @@ struct Options
 
     bool performanceProfile = false;
 
+    bool dontAddDefaultEntryPoints = false;
+
     Slang::List<Slang::String> renderFeatures;          /// Required render features for this test to run
 
     Slang::List<Slang::CommandLine::Arg> compileArgs;

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -149,13 +149,17 @@ static const char computeEntryPointName[] = "computeMain";
 
     if (request.computeShader.name)
     {
-        int computeEntryPoint = spAddEntryPointEx(slangRequest, computeTranslationUnit, 
-            computeEntryPointName,
-            SLANG_STAGE_COMPUTE,
-            (int)rawEntryPointTypeNames.getCount(),
-            rawEntryPointTypeNames.getBuffer());
+        int computeEntryPoint = 0;
+        if(!gOptions.dontAddDefaultEntryPoints)
+        {
+            computeEntryPoint = spAddEntryPointEx(slangRequest, computeTranslationUnit,
+                computeEntryPointName,
+                SLANG_STAGE_COMPUTE,
+                (int)rawEntryPointTypeNames.getCount(),
+                rawEntryPointTypeNames.getBuffer());
 
-        setEntryPointExistentialTypeArgs(computeEntryPoint);
+            setEntryPointExistentialTypeArgs(computeEntryPoint);
+        }
 
         spSetLineDirectiveMode(slangRequest, SLANG_LINE_DIRECTIVE_MODE_NONE);
         const SlangResult res = spCompile(slangRequest);
@@ -180,11 +184,16 @@ static const char computeEntryPointName[] = "computeMain";
     }
     else
     {
-        int vertexEntryPoint = spAddEntryPointEx(slangRequest, vertexTranslationUnit, vertexEntryPointName, SLANG_STAGE_VERTEX, (int)rawEntryPointTypeNames.getCount(), rawEntryPointTypeNames.getBuffer());
-        int fragmentEntryPoint = spAddEntryPointEx(slangRequest, fragmentTranslationUnit, fragmentEntryPointName, SLANG_STAGE_FRAGMENT, (int)rawEntryPointTypeNames.getCount(), rawEntryPointTypeNames.getBuffer());
+        int vertexEntryPoint = 0;
+        int fragmentEntryPoint = 1;
+        if( !gOptions.dontAddDefaultEntryPoints )
+        {
+            vertexEntryPoint = spAddEntryPointEx(slangRequest, vertexTranslationUnit, vertexEntryPointName, SLANG_STAGE_VERTEX, (int)rawEntryPointTypeNames.getCount(), rawEntryPointTypeNames.getBuffer());
+            fragmentEntryPoint = spAddEntryPointEx(slangRequest, fragmentTranslationUnit, fragmentEntryPointName, SLANG_STAGE_FRAGMENT, (int)rawEntryPointTypeNames.getCount(), rawEntryPointTypeNames.getBuffer());
 
-        setEntryPointExistentialTypeArgs(vertexEntryPoint);
-        setEntryPointExistentialTypeArgs(fragmentEntryPoint);
+            setEntryPointExistentialTypeArgs(vertexEntryPoint);
+            setEntryPointExistentialTypeArgs(fragmentEntryPoint);
+        }
 
         const SlangResult res = spCompile(slangRequest);
         if (auto diagnostics = spGetDiagnosticOutput(slangRequest))


### PR DESCRIPTION
The basic idea here is that when writing out a `.slang-lib` file based on a compile request, we include new sections in the generated RIFF that represent the entry points that were requested. The entry-point information is serialized in an entirely ad hoc fashion (a future change might clean it up to use the `OffsetContainer` machinery), and contains the name, profile, and mangled symbol name of an entry point.

When deserializing this information, we create a list of "extra" entry points that gets attached to the front-end compile requests. These "extra" entry points get turned into `EntryPoint` objects at the same place in the code that entry points specified on the command line or via API would be checked, but the extra entry points bypass the semantic checking and just create "dummy" `EntryPoint` objects.

Aside: the ability for a compile request to end up with entry points that weren't originally specified via API or command-line is not new. We already had support for compiling a translation unit with entry points entirely specified via `[shader(...)]` attributes, and this new support tries to function similarly.

Because the "dummy" entry points don't retain AST-level information, several parts of the code have been modified to defensively check for `EntryPoint` objects without a matching AST declaration, and skip over them.
The main place where this creates a problem is paramete binding, where ignoring the dummy entry point is appropriate since we currently assume linked-in library code has been laid out manually.

One small cleanup here is that the `-r` command-line flag and the `spAddLibraryReference` API functio now bottleneck through a common routine to do their work, so that they both gain the new behavior without needing copy-paste programming.

In order to keep the existing test case for library linking with entry points working, I had to add a flag to the `render-test` tool so that it can skip specifying entry point names as part of the compile request it creates. In that case it must instead assume that the entry points will be added to the compile request via other means. This logic is a bit magical, and hints that we should be looking for other ways to expose the library linking functionality over time.