### PR TITLE
Improvements around stripping and Obfuscation

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -474,15 +474,6 @@ String emitEntryPoint(
             break;
         }
 
-        // If we have obfuscation strip
-        if (compileRequest->getLinkage()->m_obfuscateCode)
-        {
-            IRStripOptions options;
-            options.shouldStripNameHints = true;
-            options.stripSourceLocs = true;
-            stripFrontEndOnlyInstructions(irModule, options);
-        }
-
         // The resource-based specialization pass above
         // may create specialized versions of functions, but
         // it does not try to completely eliminate the original

--- a/source/slang/slang-ir-dce.cpp
+++ b/source/slang/slang-ir-dce.cpp
@@ -256,6 +256,11 @@ struct DeadCodeEliminationContext
             }
         }
 
+        if (options.keepLayoutsAlive && inst->findDecoration<IRLayoutDecoration>())
+        {
+            return true;
+        }
+
         // A basic block is an interesting case. Knowing that a function
         // is live means that its entry block is live, but the liveness
         // of any other blocks is determined by whether they are referenced

--- a/source/slang/slang-ir-dce.h
+++ b/source/slang/slang-ir-dce.h
@@ -8,6 +8,7 @@ namespace Slang
     struct IRDeadCodeEliminationOptions
     {
         bool keepExportsAlive = false;
+        bool keepLayoutsAlive = false;
     };
 
         /// Eliminate "dead" code from the given IR module.


### PR DESCRIPTION
* Removed strip pass from emit as no longer needed
* If obfuscate is enabled do strip on Layout
* Add option to keep insts that have layout decoration (else DCE strips layout)
* Add NameHint back in lowering - as strip now correctly removes. 

On last point we may want NameHintDecoration in some stages even with obfuscation, as long as they are removed appropriately at the end. One reason is such that earlier IR stages can give more meaningful error messages because NameHintDecorations are available to them.  

These fixes came out of trying to resolve how some symbols were leaking into slanglib and our emit code without a strip in emit.