### PR TITLE
Riff Container Stream Writing

### DIFF
--- a/source/core/slang-memory-arena.h
+++ b/source/core/slang-memory-arena.h
@@ -84,6 +84,11 @@ public:
         @return The allocation (or nullptr if unable to allocate).  */
     void* allocateUnaligned(size_t sizeInBytes);
 
+        /** Allocate some aligned memory of at least size bytes, without alignment, and only from current block.
+        @param sizeInBytes Size of allocation wanted. 
+        @return The allocation (or nullptr if unable to allocate in current block).  */
+    void* allocateCurrentUnaligned(size_t sizeInBytes);
+
         /** Allocates a null terminated string.
 
         NOTE, it is not possible to rewind to a zero length string allocation (because such a strings memory is not held on the arena)
@@ -126,6 +131,9 @@ public:
  
         /// Gets the block alignment that is passed at initialization otherwise 0 an invalid block alignment.
     size_t getBlockAlignment() const { return m_blockAlignment; }
+
+        /// Get the default block payload size
+    size_t getBlockPayloadSize() const { return m_blockPayloadSize; }
 
         /// Estimate of total amount of memory used in bytes. The number can never be smaller than actual used memory but may be larger
     size_t calcTotalMemoryUsed() const;
@@ -237,6 +245,23 @@ SLANG_FORCE_INLINE void* MemoryArena::allocateUnaligned(size_t sizeInBytes)
     else
     {
         return _allocateAlignedFromNewBlock(sizeInBytes, kMinAlignment);
+    }
+}
+
+// --------------------------------------------------------------------------
+SLANG_FORCE_INLINE void* MemoryArena::allocateCurrentUnaligned(size_t sizeInBytes)
+{
+    // Align with the minimum alignment
+    uint8_t* mem = m_current;
+    uint8_t* end = mem + sizeInBytes;
+    if (end <= m_end)
+    {
+        m_current = end;
+        return mem;
+    }
+    else
+    {
+        return nullptr;
     }
 }
 

--- a/source/core/slang-random-generator.h
+++ b/source/core/slang-random-generator.h
@@ -30,6 +30,9 @@ class RandomGenerator: public RefObject
         /// Get the next bool
     virtual bool nextBool();
 
+        /// Get multiple int32s 
+    virtual void nextInt32s(int32_t* dst, size_t count) = 0;
+
         /// Next uint32_t
     uint32_t nextUInt32() { return uint32_t(nextInt32()); }
 
@@ -53,6 +56,10 @@ class RandomGenerator: public RefObject
         /// Returns value from min up to BUT NOT INCLUDING max
     int64_t nextInt64InRange(int64_t min, int64_t max);
 
+        /// Fill with random data.
+        /// NOTE! Output is only identical bytes if generator in same state *and* size_t(dst) & 3 is the same on calls. 
+    void nextData(void* dst, size_t size);
+
         /// Create a RandomGenerator with specified seed using default generator type
     static RandomGenerator* create(int32_t seed);
 };
@@ -73,7 +80,8 @@ class Mt19937RandomGenerator: public RandomGenerator
     Mt19937RandomGenerator* clone() SLANG_OVERRIDE { return new ThisType(*this); }
     void reset(int32_t seed) SLANG_OVERRIDE;
     int32_t nextInt32() SLANG_OVERRIDE;
-    
+    void nextInt32s(int32_t* dst, size_t count) SLANG_OVERRIDE;
+
         /// Ctor
     Mt19937RandomGenerator();
     Mt19937RandomGenerator(const ThisType& rhs);

--- a/source/core/slang-riff.cpp
+++ b/source/core/slang-riff.cpp
@@ -864,6 +864,25 @@ RiffContainer::Data* RiffContainer::addData()
 
 void RiffContainer::write(const void* inData, size_t size)
 {
+    // We must be in a chunk
+    SLANG_ASSERT(m_dataChunk);
+    // Get the last data chunk
+    Data* endData = m_dataChunk->m_endData;
+    if (endData)
+    {
+        uint8_t* end = ((uint8_t*)endData->m_payload) + endData->m_size;
+        // See if can just add to end of current data
+        if ( end == m_arena.getCursor() && m_arena.allocateCurrentUnaligned(size))
+        {
+            ::memcpy(end, inData, size);
+            endData->m_size += size;
+
+            // Add current chunks data
+            m_dataChunk->m_payloadSize += size;
+            return;
+        }
+    }
+
     auto data = addData();
     setPayload(data, inData, size);
 }

--- a/source/core/slang-riff.h
+++ b/source/core/slang-riff.h
@@ -347,11 +347,17 @@ public:
         /// Get the root
     ListChunk* getRoot() const { return m_rootList; }
 
+        /// Get the current chunk
+    Chunk* getCurrentChunk() { return m_dataChunk ? static_cast<Chunk*>(m_dataChunk) : static_cast<Chunk*>(m_listChunk); }
+
         /// Reset the container
     void reset();
 
         /// true if has a root container, and nothing remains open
     bool isFullyConstructed() { return m_rootList && m_listChunk == nullptr && m_dataChunk == nullptr; }
+
+        /// Get the memory arena that is backing the storage of data
+    MemoryArena& getMemoryArena() { return m_arena; }
 
         /// The if the list and sublists appear correct
     static bool isChunkOk(Chunk* chunk);

--- a/source/core/slang-riff.h
+++ b/source/core/slang-riff.h
@@ -284,6 +284,12 @@ public:
             /// Calculate the payload size
         size_t calcPayloadSize() const;
 
+            /// Copy the payload to dst. Dst must be at least the payload size. 
+        void getPayload(void* dst) const;
+
+            /// True if payloads contents is equal to data
+        bool isEqual(const void* data, size_t count) const;
+
             /// Get single data payload.
         Data* getSingleData() const;
 
@@ -355,6 +361,9 @@ public:
 
         /// true if has a root container, and nothing remains open
     bool isFullyConstructed() { return m_rootList && m_listChunk == nullptr && m_dataChunk == nullptr; }
+
+        /// Makes a data chunk contain a single contiguous data block
+    Data* makeSingleData(DataChunk* dataChunk);
 
         /// Get the memory arena that is backing the storage of data
     MemoryArena& getMemoryArena() { return m_arena; }

--- a/tools/slang-test/unit-test-riff.cpp
+++ b/tools/slang-test/unit-test-riff.cpp
@@ -111,6 +111,7 @@ static void riffUnitTest()
 
     }
 
+    // Test writing as a stream only allocates a single data block (as long as there is enough space).
     {
         RiffContainer container;
 
@@ -134,6 +135,7 @@ static void riffUnitTest()
         }
     } 
 
+    // Test writing across multiple data blocks
     {
         RefPtr<RandomGenerator> rand = RandomGenerator::create(0x345234);
 


### PR DESCRIPTION
 * Added option to get random bytes from RandomGenerator
* Added ability to allocate only in current block on MemoryArena
* Allowed RiffContainer to not allocate new Data blocks, if can just extend the Data it has (because it's at the end of current block and there is space for the new data).
* Added coverage for change on Riff unit test - for single block and multiblock