### PR TITLE
Fix ref counting bug in cpu-hello-world

### DIFF
--- a/examples/cpu-hello-world/main.cpp
+++ b/examples/cpu-hello-world/main.cpp
@@ -49,7 +49,10 @@ static SlangResult _innerMain(int argc, char** argv)
     // somewhat heavy-weight operation. When possible, an application
     // should try to re-use the same session across multiple compiles.
     //
-    ComPtr<slang::IGlobalSession> slangSession(spCreateSession(NULL));
+    // NOTE that we use attach instead of setting via assignment, as assingment will increase
+    // the refcount. spCreateSession returns a IGlobalSession with a refcount of 1.
+    ComPtr<slang::IGlobalSession> slangSession;
+    slangSession.attach(spCreateSession(NULL));
 
     // As touched on earlier, in order to generate the final executable code,
     // the slang code is converted into C++, and that C++ needs a 'prelude' which

--- a/examples/cpu-hello-world/main.cpp
+++ b/examples/cpu-hello-world/main.cpp
@@ -49,7 +49,7 @@ static SlangResult _innerMain(int argc, char** argv)
     // somewhat heavy-weight operation. When possible, an application
     // should try to re-use the same session across multiple compiles.
     //
-    // NOTE that we use attach instead of setting via assignment, as assingment will increase
+    // NOTE that we use attach instead of setting via assignment, as assignment will increase
     // the refcount. spCreateSession returns a IGlobalSession with a refcount of 1.
     ComPtr<slang::IGlobalSession> slangSession;
     slangSession.attach(spCreateSession(NULL));


### PR DESCRIPTION
Fix ref counting bug in cpu-hello-world that meant session was not released correctly.

Care is needed with using ComPtr and spCreateSession. Create session returns a session with a ref count of 1. ComPtr on ctor/assigning adds a ref count. Neither is especially 'wrong'. With interfaces as out parameters, which is more common, this is less of an issue as using ComPtr, the method writeRef is used/needed.

There may be an argument for adding a method that that returns a SlangResult and outputs the session as an out parameter. 

```
{
    /// Wrong - session will never be released. But is the most natural way to write the code.
    ComPtr<ISlangSession> session(spCreateSession(nullptr));
}
{
    /// Correct (albeit clunky)
    ComPtr<ISlangSession> session;
    session.attach(spCreateSession(nullptr));
}
```


