### PR TITLE
Make spReflectionEntryPoint_getName work with entry point in a library

### DIFF
--- a/source/slang/slang-name.cpp
+++ b/source/slang/slang-name.cpp
@@ -14,6 +14,11 @@ UnownedStringSlice getUnownedStringSliceText(Name* name)
     return name ? name->text.getUnownedSlice() : UnownedStringSlice();
 }
 
+const char* getCstr(Name* name)
+{
+    return name ? name->text.getBuffer() : nullptr;
+}
+
 Name* NamePool::getName(String const& text)
 {
     RefPtr<Name> name;

--- a/source/slang/slang-name.h
+++ b/source/slang/slang-name.h
@@ -39,6 +39,9 @@ String getText(Name* name);
 /// Get the text as unowned string slice 
 UnownedStringSlice getUnownedStringSliceText(Name* name);
 
+// Get a name as a C style string, or nullptr if name is nullptr
+const char* getCstr(Name* name);
+
 // A `RootNamePool` is used to store and look up names.
 // If two systems need to work together with names, and be sure that they
 // get equivalent names for a string like `"Foo"`, then they need to use

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -2166,6 +2166,7 @@ static RefPtr<EntryPointLayout> collectEntryPointParameters(
     //
     RefPtr<EntryPointLayout> entryPointLayout = new EntryPointLayout();
     entryPointLayout->profile = entryPoint->getProfile();
+    entryPointLayout->name = entryPoint->getName();
 
     // The entry point layout must be added to the output
     // program layout so that it can be accessed by reflection.

--- a/source/slang/slang-reflection.cpp
+++ b/source/slang/slang-reflection.cpp
@@ -1210,9 +1210,7 @@ SLANG_API char const* spReflectionEntryPoint_getName(
     SlangReflectionEntryPoint* inEntryPoint)
 {
     auto entryPointLayout = convert(inEntryPoint);
-    if(!entryPointLayout) return 0;
-
-    return getText(entryPointLayout->entryPoint.GetName()).begin();
+    return entryPointLayout ? getCstr(entryPointLayout->name) : nullptr;
 }
 
 SLANG_API unsigned spReflectionEntryPoint_getParameterCount(

--- a/source/slang/slang-type-layout.h
+++ b/source/slang/slang-type-layout.h
@@ -658,6 +658,9 @@ public:
     // The shader profile that was used to compile the entry point
     Profile profile;
 
+    // The name of the entry point. Always available even if entryPoint is nullptr (for example when it came from a library)
+    Name* name = nullptr;
+
     // Layout for any results of the entry point
     RefPtr<VarLayout> resultLayout;
 

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1106,6 +1106,18 @@ TestResult runCompile(TestContext* context, TestInput& input)
         return TestResult::Pass;
     }
 
+    if (exeRes.resultCode != 0)
+    {
+        auto reporter = context->reporter;
+        if (reporter)
+        {
+            auto output = getOutput(exeRes);
+            reporter->message(TestMessageType::TestFailure, output);
+        }
+
+        return TestResult::Fail;
+    }
+
     return TestResult::Pass;
 }
 


### PR DESCRIPTION
* Added the name to the EntryPointLayout so is always available
* Made spReflectionEntryPoint_getName use name
* Improved checking for entry point name in render-test
* Improved COMPILE test type to allow failure and output of failure.
* Added getCStr(Name*)