### PR TITLE
Add a premake flag to control whether glslang is built from source

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -76,6 +76,14 @@ newoption {
    allowed     = { {"cygwin"}, {"mingw"} }
 }
 
+newoption {
+   trigger     = "build-glslang",
+   description = "(Optional) If true glslang and spirv-opt will be built",
+   value       = "bool",
+   default     = "false",
+   allowed     = { { "true", "True"}, { "false", "False" } }
+}
+
 buildLocation = _OPTIONS["build-location"]
 executeBinary = (_OPTIONS["execute-binary"] == "true")
 targetDetail = _OPTIONS["target-detail"]


### PR DESCRIPTION
This change adds the flag, but doesn't wire it up to anything.
The idea is to allow us to modify CI build scripts to use the flag in cases where it will be needed, so that we can later on disable building glslang from source by default, without an intermediate step where CI is broken.