### PR TITLE
Remove support for explicit register/binding syntax on TEST_INPUT

### DIFF
--- a/examples/cpu-hello-world/shader.slang
+++ b/examples/cpu-hello-world/shader.slang
@@ -1,6 +1,6 @@
 // shader.slang
 
-//TEST_INPUT:ubuffer(random(float, 4096, -1.0, 1.0), stride=4):dxbinding(0),glbinding(0),name=ioBuffer
+//TEST_INPUT:ubuffer(random(float, 4096, -1.0, 1.0), stride=4):name=ioBuffer
 RWStructuredBuffer<float> ioBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/bugs/bool-init.slang
+++ b/tests/bugs/bool-init.slang
@@ -7,7 +7,7 @@ struct Thing
     bool b;
 };
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/bugs/bool-op.slang
+++ b/tests/bugs/bool-op.slang
@@ -4,7 +4,7 @@
 
 // Confirm operations that produce bools - such as comparisons, or && ||, ! work correctly
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out
 RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(16, 1, 1)]

--- a/tests/bugs/gh-357.slang
+++ b/tests/bugs/gh-357.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 //TEST_INPUT:type AssocImpl
 
 

--- a/tests/bugs/gh-471.slang
+++ b/tests/bugs/gh-471.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:
-//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):out
 
 // Test that "operator comma" works as expected
 

--- a/tests/bugs/gh-487.slang
+++ b/tests/bugs/gh-487.slang
@@ -15,7 +15,7 @@ int test(int val)
 	return int(result);
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> gBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/bugs/gh-518.slang
+++ b/tests/bugs/gh-518.slang
@@ -8,11 +8,11 @@
 // Confirm that we can handle arrays of resources
 // being passed to a function.
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> gBuffer;
 
-//TEST_INPUT: Texture2D(size=4, content=one):dxbinding(0),glbinding(0)
-//TEST_INPUT: Texture2D(size=4, content=one):dxbinding(1),glbinding(1)
+//TEST_INPUT: Texture2D(size=4, content=one):
+//TEST_INPUT: Texture2D(size=4, content=one):
 Texture2D gTextures[2];
 
 float broken(Texture2D t[2])

--- a/tests/bugs/gh-519.slang
+++ b/tests/bugs/gh-519.slang
@@ -29,7 +29,7 @@ int test(int val)
     return tmp;
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> gBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/bugs/gh-566.slang
+++ b/tests/bugs/gh-566.slang
@@ -1,8 +1,8 @@
 // legalize-struct-init.slang
 
 //TEST(compute):COMPARE_COMPUTE:
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
-//TEST_INPUT:ubuffer(data=[4 3 2 1], stride=4):dxbinding(1),glbinding(1)
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
+//TEST_INPUT:ubuffer(data=[4 3 2 1], stride=4):
 
 
 RWStructuredBuffer<uint> outputBuffer;

--- a/tests/bugs/gh-569.slang
+++ b/tests/bugs/gh-569.slang
@@ -21,7 +21,7 @@ uint test(uint inVal)
     return tmp + inVal;
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<uint> gBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/bugs/gh-775.slang
+++ b/tests/bugs/gh-775.slang
@@ -17,7 +17,7 @@ int test(int inVal)
     return int(dot(v, float4(1, 16, 256, 4096)));
 }
 
-//TEST_INPUT:ubuffer(data=[9 9 9 9], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[9 9 9 9], stride=4):out
 RWStructuredBuffer<int> outputBuffer : register(u0);
 
 [numthreads(4, 1, 1)]

--- a/tests/bugs/gl-33.slang
+++ b/tests/bugs/gl-33.slang
@@ -13,7 +13,7 @@ int test(int val)
     return b.next();
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> gBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/bugs/glsl-static-const-array.slang
+++ b/tests/bugs/glsl-static-const-array.slang
@@ -7,7 +7,7 @@ static const int gData[4] =
     0xA, 0xB, 0xC, 0xD,
 };
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> gBuffer;
 
 [numthreads(4,1,1)]

--- a/tests/bugs/nested-generics-call.slang
+++ b/tests/bugs/nested-generics-call.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 
 RWStructuredBuffer<float> outputBuffer;
 

--- a/tests/bugs/nested-generics-method-call.slang
+++ b/tests/bugs/nested-generics-method-call.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 
 RWStructuredBuffer<float> outputBuffer;
 

--- a/tests/bugs/paren-insertion-bug.slang
+++ b/tests/bugs/paren-insertion-bug.slang
@@ -19,7 +19,7 @@ int test(float a)
 }
 
 
-//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<uint> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/bugs/static-var.slang
+++ b/tests/bugs/static-var.slang
@@ -7,7 +7,7 @@ int test(int inVal)
     return inVal + kVal;
 }
 
-//TEST_INPUT:ubuffer(data=[9 9 9 9], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[9 9 9 9], stride=4):out
 RWStructuredBuffer<int> outputBuffer : register(u0);
 
 [numthreads(4, 1, 1)]

--- a/tests/bugs/texture2d-gather.hlsl
+++ b/tests/bugs/texture2d-gather.hlsl
@@ -1,6 +1,6 @@
 //TEST(smoke):COMPARE_HLSL_RENDER:
-//TEST_INPUT: Texture2D(size=16, content=chessboard, format=R_Float32):dxbinding(0),glbinding(0)
-//TEST_INPUT: Sampler : dxbinding(0),glbinding(0)
+//TEST_INPUT: Texture2D(size=16, content=chessboard, format=R_Float32):
+//TEST_INPUT: Sampler :
 
 Texture2D<float> g_texture : register(t0);
 SamplerState g_sampler : register(s0);

--- a/tests/bugs/vec-compare.slang
+++ b/tests/bugs/vec-compare.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out
 
 RWStructuredBuffer<int> outputBuffer;
 

--- a/tests/bugs/while-in-generic.slang
+++ b/tests/bugs/while-in-generic.slang
@@ -12,7 +12,7 @@ struct Context
         return i;
     }
 };
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/array-param.slang
+++ b/tests/compute/array-param.slang
@@ -4,7 +4,7 @@
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
 
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 void writeArray(inout float3 a[4])

--- a/tests/compute/assoctype-complex.slang
+++ b/tests/compute/assoctype-complex.slang
@@ -1,7 +1,7 @@
 //TEST(compute):COMPARE_COMPUTE: -cpu
 //TEST(compute):COMPARE_COMPUTE:
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 interface IBase

--- a/tests/compute/assoctype-func-param.slang
+++ b/tests/compute/assoctype-func-param.slang
@@ -3,7 +3,7 @@
 
 // Test type checking of associatedtype and typedef
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 interface IBase

--- a/tests/compute/assoctype-generic-arg.slang
+++ b/tests/compute/assoctype-generic-arg.slang
@@ -3,7 +3,7 @@
 
 //TEST_INPUT:type AssocImpl
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 interface IBase

--- a/tests/compute/assoctype-nested.slang
+++ b/tests/compute/assoctype-nested.slang
@@ -49,7 +49,7 @@ int test(int val)
 	return helper(strategy, val);
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=gOutputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=gOutputBuffer
 RWStructuredBuffer<int> gOutputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/assoctype-simple.slang
+++ b/tests/compute/assoctype-simple.slang
@@ -4,7 +4,7 @@
 // Confirm that generics syntax can be used in user
 // code and generates valid output.
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 interface ISimple

--- a/tests/compute/atomics-buffer.slang
+++ b/tests/compute/atomics-buffer.slang
@@ -7,7 +7,7 @@
 //
 //TEST_DISABLED(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
 
-//TEST_INPUT:ubuffer(format=R_UInt32, data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(format=R_UInt32, data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]):out
 
 RWBuffer<uint> outputBuffer;
 

--- a/tests/compute/atomics-groupshared.slang
+++ b/tests/compute/atomics-groupshared.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 
 RWStructuredBuffer<uint> outputBuffer;
 

--- a/tests/compute/atomics.slang
+++ b/tests/compute/atomics.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 
 RWStructuredBuffer<uint> outputBuffer;
 

--- a/tests/compute/bit-cast-double.slang
+++ b/tests/compute/bit-cast-double.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/bit-cast.slang
+++ b/tests/compute/bit-cast.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 
 RWStructuredBuffer<int> outputBuffer;
 

--- a/tests/compute/break-stmt.slang
+++ b/tests/compute/break-stmt.slang
@@ -15,7 +15,7 @@ int test(int inVal)
 	return -ii;
 }
 
-//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer : register(u0);
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/buffer-layout.slang
+++ b/tests/compute/buffer-layout.slang
@@ -8,7 +8,7 @@
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu
 
-//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 struct A
@@ -103,10 +103,10 @@ struct S
     int    d;
 }
 
-//TEST_INPUT:cbuffer(data=[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32]):dxbinding(0),glbinding(0),name=cb
+//TEST_INPUT:cbuffer(data=[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32]):name=cb
 ConstantBuffer<S> cb;
 
-//TEST_INPUT:ubuffer(data=[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32],stride=4):dxbinding(0),glbinding(1),name=sb
+//TEST_INPUT:ubuffer(data=[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32],stride=4):name=sb
 RWStructuredBuffer<S> sb;
 
 int test(int val)

--- a/tests/compute/buffer-type-splitting.slang
+++ b/tests/compute/buffer-type-splitting.slang
@@ -1,11 +1,11 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu
 //TEST(compute):COMPARE_COMPUTE:
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
-//TEST_INPUT:ubuffer(data=[0 2 3 3]):dxbinding(1),glbinding(1),name=s[0].a
-//TEST_INPUT:ubuffer(data=[4 5 6 7]):dxbinding(2),glbinding(2),name=s[1].a
-//TEST_INPUT:ubuffer(data=[8 9 10 11]):dxbinding(3),glbinding(3),name=s[0].b
-//TEST_INPUT:ubuffer(data=[12 13 14 15]):dxbinding(4),glbinding(4),name=s[1].b
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 2 3 3]):name=s[0].a
+//TEST_INPUT:ubuffer(data=[4 5 6 7]):name=s[1].a
+//TEST_INPUT:ubuffer(data=[8 9 10 11]):name=s[0].b
+//TEST_INPUT:ubuffer(data=[12 13 14 15]):name=s[1].b
 
 RWStructuredBuffer<int> outputBuffer;
 

--- a/tests/compute/byte-address-buffer.slang
+++ b/tests/compute/byte-address-buffer.slang
@@ -10,10 +10,10 @@
 // TODO: I'm only using `RWByteAddressBuffer` for now because I don't
 // know if `render-test` supports the non-UAV case.
 
-//TEST_INPUT:ubuffer(data=[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]):dxbinding(0),glbinding(0),name=inputBuffer
+//TEST_INPUT:ubuffer(data=[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]):name=inputBuffer
 RWByteAddressBuffer inputBuffer;
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0]):dxbinding(1),glbinding(1),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0]):out,name=outputBuffer
 RWByteAddressBuffer outputBuffer;
 
 void test(int val)

--- a/tests/compute/cast-zero-to-struct.slang
+++ b/tests/compute/cast-zero-to-struct.slang
@@ -25,7 +25,7 @@ int test(int val)
 	return t.x + t.y*16;
 }
 
-//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=gOutputBuffer
+//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):out,name=gOutputBuffer
 RWStructuredBuffer<int> gOutputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/cbuffer-legalize.slang
+++ b/tests/compute/cbuffer-legalize.slang
@@ -1,10 +1,10 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu
 //TEST(compute):COMPARE_COMPUTE:
 
-//TEST_INPUT:cbuffer(data=[1 2 3 4]):dxbinding(0),glbinding(0),name=C.p.c
-//TEST_INPUT:Texture2D(size=4, content = one) : dxbinding(0),glbinding(0),name=C.p.t
-//TEST_INPUT: Sampler : dxbinding(0),glbinding(0,1,2,3,4,5,6),name=C.p.s
-//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:cbuffer(data=[1 2 3 4]):name=C.p.c
+//TEST_INPUT:Texture2D(size=4, content = one):name=C.p.t
+//TEST_INPUT: Sampler:name=C.p.s
+//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 
 struct P
 {

--- a/tests/compute/compile-time-loop.slang
+++ b/tests/compute/compile-time-loop.slang
@@ -1,9 +1,8 @@
 //TEST(compute):COMPARE_RENDER_COMPUTE:
 
-//TEST_INPUT: Texture2D(size=4, content = one) : dxbinding(0),glbinding(0)
-//TEST_INPUT: Sampler : dxbinding(0),glbinding(0)
-
-//TEST_INPUT: ubuffer(data=[0], stride=4):dxbinding(1),glbinding(0),out
+//TEST_INPUT: Texture2D(size=4, content = one):
+//TEST_INPUT: Sampler:
+//TEST_INPUT: ubuffer(data=[0], stride=4):out
 
 Texture2D t;
 SamplerState s;

--- a/tests/compute/constexpr.slang
+++ b/tests/compute/constexpr.slang
@@ -1,9 +1,9 @@
 // constexpr.slang
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -gcompute
 //DISABLED://TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -gcompute
-//TEST_INPUT: Texture2D(size=4, content = one) : dxbinding(0),glbinding(0)
-//TEST_INPUT: Sampler : dxbinding(0),glbinding(0)
-//TEST_INPUT: ubuffer(data=[0 0], stride=4):dxbinding(1),glbinding(0),out
+//TEST_INPUT: Texture2D(size=4, content = one):
+//TEST_INPUT: Sampler:
+//TEST_INPUT: ubuffer(data=[0 0], stride=4):out
 
 // Note: Vulkan version of this test is disabled pending adding
 // support for rendering tests to the harness.

--- a/tests/compute/continue-stmt.slang
+++ b/tests/compute/continue-stmt.slang
@@ -20,7 +20,7 @@ int test(int inVal)
 	return -ii;
 }
 
-//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer : register(u0);
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/default-parameter.slang
+++ b/tests/compute/default-parameter.slang
@@ -2,7 +2,7 @@
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cpu -compute
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 int helper(int val, int a = 16)

--- a/tests/compute/discard-stmt.slang
+++ b/tests/compute/discard-stmt.slang
@@ -1,7 +1,7 @@
 //TEST(compute):COMPARE_RENDER_COMPUTE:
-//TEST_INPUT: Texture2D(size=4, content = one) : dxbinding(0),glbinding(0)
-//TEST_INPUT: Sampler : dxbinding(0),glbinding(0)
-//TEST_INPUT: ubuffer(data=[0 0], stride=4):dxbinding(1),glbinding(0),out
+//TEST_INPUT: Texture2D(size=4, content = one):
+//TEST_INPUT: Sampler:
+//TEST_INPUT: ubuffer(data=[0 0], stride=4):out
 
 
 Texture2D tex;

--- a/tests/compute/dump-repro.slang
+++ b/tests/compute/dump-repro.slang
@@ -1,6 +1,6 @@
 //TEST(compute):SIMPLE:-target hlsl -dump-repro repro.slang-repro
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 //TEST_INPUT:array(size=2):name g_aoa

--- a/tests/compute/empty-struct.slang
+++ b/tests/compute/empty-struct.slang
@@ -4,7 +4,7 @@
 // Confirm that generics syntax can be used in user
 // code and generates valid output.
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 struct Simple

--- a/tests/compute/empty-struct2.slang
+++ b/tests/compute/empty-struct2.slang
@@ -3,7 +3,7 @@
 
 // This is a basic test for Slang compute shader.
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
 
 interface IInterface

--- a/tests/compute/entry-point-uniform-params.slang
+++ b/tests/compute/entry-point-uniform-params.slang
@@ -27,17 +27,17 @@ struct Things
 // A shader parameter at global scope should be assigned
 // a register/binding before any related to the entry point.
 
-//TEST_INPUT:cbuffer(data=[1 0 0 0]):dxbinding(0),glbinding(0),name=signs
+//TEST_INPUT:cbuffer(data=[1 0 0 0]):name=signs
 ConstantBuffer<Signs> signs;
 
 [numthreads(4, 1, 1)]
 void computeMain(
-//TEST_INPUT:cbuffer(data=[2 0 0 0 3 0 0 0]):dxbinding(1),glbinding(1),name=stuff
+//TEST_INPUT:cbuffer(data=[2 0 0 0 3 0 0 0]):name=stuff
 	uniform Stuff  stuff,
-//TEST_INPUT:cbuffer(data=[3]):,isCPUOnly,name=things    
+//TEST_INPUT:cbuffer(data=[3]):isCPUOnly,name=things
 	uniform Things things,
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(2),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 	uniform RWStructuredBuffer<int> outputBuffer,
 
 	uint3 dispatchThreadID : SV_DispatchThreadID)

--- a/tests/compute/enum-tag-conversion.slang
+++ b/tests/compute/enum-tag-conversion.slang
@@ -17,7 +17,7 @@ int test(int val)
 	return val + int(RoseColors.Red);
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/enum.slang
+++ b/tests/compute/enum.slang
@@ -52,7 +52,7 @@ int test(int val)
     return (val << 4) + int(c);
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/explicit-this-expr.slang
+++ b/tests/compute/explicit-this-expr.slang
@@ -15,7 +15,7 @@ struct A
 	}
 };
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer : register(u0);
 
 

--- a/tests/compute/extension-multi-interface.slang
+++ b/tests/compute/extension-multi-interface.slang
@@ -1,7 +1,7 @@
 //TEST(compute):COMPARE_COMPUTE:
 //TEST(compute):COMPARE_COMPUTE:-cpu
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 interface IAdd

--- a/tests/compute/extension-on-interface.slang
+++ b/tests/compute/extension-on-interface.slang
@@ -1,7 +1,7 @@
 //TEST(compute):COMPARE_COMPUTE:
 //TEST(compute):COMPARE_COMPUTE:-cpu
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 interface IOp

--- a/tests/compute/frem.slang
+++ b/tests/compute/frem.slang
@@ -7,7 +7,7 @@
 // Test uses of floating-point `%` operator.
 
 RWStructuredBuffer<float> gInput;
-//TEST_INPUT:ubuffer(data=[2.0 1.0 5.0 2.0 2.0 -4.0 -5.0 2.0], stride=4):dxbinding(0),glbinding(0),name=gInput
+//TEST_INPUT:ubuffer(data=[2.0 1.0 5.0 2.0 2.0 -4.0 -5.0 2.0], stride=4):name=gInput
 
 int test(int inVal)
 {
@@ -16,7 +16,7 @@ int test(int inVal)
     return int(a % b);
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(1),glbinding(1),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/func-cbuffer-param.slang
+++ b/tests/compute/func-cbuffer-param.slang
@@ -15,13 +15,13 @@ struct Data
 	int4 val[4];
 }
 
-//TEST_INPUT:cbuffer(data=[0 1 2 3  16 17 18 19  32 33 34 35  48 49 50 51]):dxbinding(0),glbinding(0),name=a
+//TEST_INPUT:cbuffer(data=[0 1 2 3  16 17 18 19  32 33 34 35  48 49 50 51]):name=a
 ConstantBuffer<Data> a;
 
-//TEST_INPUT:cbuffer(data=[16 17 18 19  32 33 34 35  48 49 50 51  64 65 66 67]):dxbinding(1),glbinding(1),name=b
+//TEST_INPUT:cbuffer(data=[16 17 18 19  32 33 34 35  48 49 50 51  64 65 66 67]):name=b
 ConstantBuffer<Data> b;
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(2),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 int helper(ConstantBuffer<Data>  buffer, int index)

--- a/tests/compute/func-param-legalize.slang
+++ b/tests/compute/func-param-legalize.slang
@@ -7,11 +7,11 @@ struct Param
     float base;
 };
 
-//TEST_INPUT:Texture2D(size=4, content = one) : dxbinding(0),glbinding(0),name=diffuseMap
+//TEST_INPUT:Texture2D(size=4, content = one):name=diffuseMap
 Texture2D diffuseMap;
-//TEST_INPUT: Sampler : dxbinding(0),glbinding(0,1,2,3,4,5,6),name=samplerState
+//TEST_INPUT: Sampler:name=samplerState
 SamplerState samplerState;
-//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 float4 run(Param p)

--- a/tests/compute/func-resource-param.slang
+++ b/tests/compute/func-resource-param.slang
@@ -11,10 +11,10 @@
 
 //NO_TEST:SIMPLE:-target glsl -entry computeMain -stage compute -validate-ir -dump-ir
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
-//TEST_INPUT:ubuffer(data=[0 16 32 48], stride=4):dxbinding(1),glbinding(1),name=inputBuffer
+//TEST_INPUT:ubuffer(data=[0 16 32 48], stride=4):name=inputBuffer
 RWStructuredBuffer<int> inputBuffer;
 
 int helper(RWStructuredBuffer<int> buffer, int index)

--- a/tests/compute/generic-closer.slang
+++ b/tests/compute/generic-closer.slang
@@ -17,7 +17,7 @@ struct Gen1<TGetter : IGetter> : IGetter
     int get() { return g.get(); }
 };
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 void writeArray(inout float3 a[4])

--- a/tests/compute/generic-interface-method-simple.slang
+++ b/tests/compute/generic-interface-method-simple.slang
@@ -1,7 +1,7 @@
 //TEST(compute):COMPARE_COMPUTE:
 //TEST(compute):COMPARE_COMPUTE:-cpu
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 interface IVertexInterpolant

--- a/tests/compute/generic-interface-method.slang
+++ b/tests/compute/generic-interface-method.slang
@@ -1,7 +1,7 @@
 //TEST(compute):COMPARE_COMPUTE:
 //TEST(compute):COMPARE_COMPUTE:-cpu
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 struct DisneyBRDFPattern

--- a/tests/compute/generic-list.slang
+++ b/tests/compute/generic-list.slang
@@ -4,7 +4,7 @@
 // Confirm that generics syntax can be used in user
 // code and generates valid output.
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float4> outputBuffer;
 
 interface IElement

--- a/tests/compute/generic-struct-with-constraint.slang
+++ b/tests/compute/generic-struct-with-constraint.slang
@@ -4,7 +4,7 @@
 // Confirm that generics syntax can be used in user
 // code and generates valid output.
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float4> outputBuffer;
 
 interface IElement

--- a/tests/compute/generic-struct.slang
+++ b/tests/compute/generic-struct.slang
@@ -4,7 +4,7 @@
 // Check that user code can declare and use a generic
 // `struct` type.
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 __generic<T>

--- a/tests/compute/generics-constrained.slang
+++ b/tests/compute/generics-constrained.slang
@@ -27,7 +27,7 @@ float testHelp(T helper)
 	return helper.getHelp();
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer : register(u0);
 
 

--- a/tests/compute/generics-constructor.slang
+++ b/tests/compute/generics-constructor.slang
@@ -1,7 +1,7 @@
 //TEST(compute):COMPARE_COMPUTE:
 //TEST(compute):COMPARE_COMPUTE:-cpu
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 __generic<T:__BuiltinFloatingPointType>

--- a/tests/compute/generics-overload.slang
+++ b/tests/compute/generics-overload.slang
@@ -4,7 +4,7 @@
 // Confirm that generics syntax can be used in user
 // code and generates valid output.
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 

--- a/tests/compute/generics-simple.slang
+++ b/tests/compute/generics-simple.slang
@@ -4,7 +4,7 @@
 // Confirm that generics syntax can be used in user
 // code and generates valid output.
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 

--- a/tests/compute/generics-syntax-2.slang
+++ b/tests/compute/generics-syntax-2.slang
@@ -4,7 +4,7 @@
 // Confirm that generics syntax can be used in user
 // code and generates valid output.
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 struct GenStruct<T>

--- a/tests/compute/generics-syntax.slang
+++ b/tests/compute/generics-syntax.slang
@@ -4,7 +4,7 @@
 // Confirm that generics syntax can be used in user
 // code and generates valid output.
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 struct GenStruct<T>

--- a/tests/compute/global-generic-value-param.slang
+++ b/tests/compute/global-generic-value-param.slang
@@ -29,7 +29,7 @@ __generic_value_param kOffset : uint = 0;
 // bit less trivial.
 //
 RWStructuredBuffer<uint> vals;
-//TEST_INPUT: ubuffer(data=[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15], stride=4):dxbinding(0),glbinding(0)
+//TEST_INPUT: ubuffer(data=[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15], stride=4):
 
 // The core test function will use the `kOffset` value
 // we declared above along with the input value (the
@@ -45,7 +45,7 @@ uint test(uint value)
 // And finally we have the boilerplate cruft that almost
 // all of our compute tests use.
 
-//TEST_INPUT: ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):dxbinding(0),glbinding(1),out
+//TEST_INPUT: ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out
 RWStructuredBuffer<uint> outputBuffer;
 
 [numthreads(16, 1, 1)]

--- a/tests/compute/global-init.slang
+++ b/tests/compute/global-init.slang
@@ -11,7 +11,7 @@ int test(int inVal)
 	return inVal + gVar;
 }
 
-//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer : register(u0);
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/global-type-param-array.slang
+++ b/tests/compute/global-type-param-array.slang
@@ -1,6 +1,6 @@
 //TEST(compute):COMPARE_COMPUTE:
-//TEST_INPUT: cbuffer(data=[1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0], stride=4):dxbinding(0),glbinding(0)
-//TEST_INPUT: ubuffer(data=[0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT: cbuffer(data=[1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0], stride=4):
+//TEST_INPUT: ubuffer(data=[0], stride=4):out
 //TEST_INPUT: type Pair<Arr<Base,1>, Pair<Arr<Base,2> , Base> >
 
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/compute/global-type-param-in-entrypoint.slang
+++ b/tests/compute/global-type-param-in-entrypoint.slang
@@ -1,6 +1,6 @@
 //TEST(compute):COMPARE_RENDER_COMPUTE:
-//TEST_INPUT: cbuffer(data=[1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0], stride=16):dxbinding(0),glbinding(0)
-//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):dxbinding(1),glbinding(0),out
+//TEST_INPUT: cbuffer(data=[1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0], stride=16):
+//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):out
 //TEST_INPUT: global_type VertImpl
 
 interface IVertInterpolant

--- a/tests/compute/global-type-param.slang
+++ b/tests/compute/global-type-param.slang
@@ -2,7 +2,7 @@
 
 //TEST_INPUT:type Wrapper<Impl>
 
-//TEST_INPUT:ubuffer(data=[0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 interface IBase

--- a/tests/compute/global-type-param1.slang
+++ b/tests/compute/global-type-param1.slang
@@ -1,11 +1,11 @@
 //TEST(smoke,compute):COMPARE_COMPUTE:
-//TEST_INPUT: cbuffer(data=[0.5 0 0 0 1.0], stride=4):dxbinding(0),glbinding(0)
-//TEST_INPUT: cbuffer(data=[1.0], stride=4):dxbinding(1),glbinding(1)
-//TEST_INPUT: Texture2D(size=4, content = zero) : dxbinding(0),glbinding(0)
-//TEST_INPUT: Texture2D(size=4, content = one) : dxbinding(1),glbinding(1)
-//TEST_INPUT: Sampler : dxbinding(0),glbinding(0,1,2,3,4,5,6)
-//TEST_INPUT: Sampler : dxbinding(1),glbinding(0,1,2,3,4,5,6)
-//TEST_INPUT: ubuffer(data=[0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT: cbuffer(data=[0.5 0 0 0 1.0], stride=4):
+//TEST_INPUT: cbuffer(data=[1.0], stride=4):
+//TEST_INPUT: Texture2D(size=4, content = zero):
+//TEST_INPUT: Texture2D(size=4, content = one):
+//TEST_INPUT: Sampler:
+//TEST_INPUT: Sampler:
+//TEST_INPUT: ubuffer(data=[0], stride=4):out
 //TEST_INPUT: type Impl
 
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/compute/global-type-param2.slang
+++ b/tests/compute/global-type-param2.slang
@@ -1,11 +1,11 @@
 //TEST(smoke,compute):COMPARE_COMPUTE:
-//TEST_INPUT: cbuffer(data=[0.5 0 0 0], stride=4):dxbinding(0),glbinding(0)
-//TEST_INPUT: cbuffer(data=[1.0], stride=4):dxbinding(1),glbinding(1)
-//TEST_INPUT: Texture2D(size=4, content = zero) : dxbinding(0),glbinding(0)
-//TEST_INPUT: Texture2D(size=4, content = one) : dxbinding(1),glbinding(1)
-//TEST_INPUT: Sampler : dxbinding(0),glbinding(0,1,2,3,4,5,6)
-//TEST_INPUT: Sampler : dxbinding(1),glbinding(0,1,2,3,4,5,6)
-//TEST_INPUT: ubuffer(data=[0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT: cbuffer(data=[0.5 0 0 0], stride=4):
+//TEST_INPUT: cbuffer(data=[1.0], stride=4):
+//TEST_INPUT: Texture2D(size=4, content = zero):
+//TEST_INPUT: Texture2D(size=4, content = one):
+//TEST_INPUT: Sampler:
+//TEST_INPUT: Sampler:
+//TEST_INPUT: ubuffer(data=[0], stride=4):out
 //TEST_INPUT: type Impl
 
 

--- a/tests/compute/groupshared.slang
+++ b/tests/compute/groupshared.slang
@@ -4,7 +4,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 
 #define THREAD_COUNT 4
 

--- a/tests/compute/half-calc.slang
+++ b/tests/compute/half-calc.slang
@@ -1,6 +1,6 @@
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-dx12 -compute -use-dxil -profile cs_6_2 -render-features half
 //TEST(compute):COMPARE_COMPUTE:-vk -compute -profile cs_6_2 -render-features half
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 
 // Test for doing a calculation using half
 

--- a/tests/compute/half-structured-buffer.slang
+++ b/tests/compute/half-structured-buffer.slang
@@ -2,7 +2,7 @@
 //Disable on Dx12 for now - because writing to structured buffer produces unexpected results
 //TEST_DISABLED(compute):COMPARE_COMPUTE:-dx12 -compute -use-dxil -profile cs_6_2 -render-features half
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=16):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=16):out
 
 struct Thing
 {

--- a/tests/compute/half-texture.slang
+++ b/tests/compute/half-texture.slang
@@ -1,17 +1,17 @@
 //TEST:CROSS_COMPILE: -target spirv -entry computeMain -profile cs_6_2
 //TEST:SIMPLE: -target hlsl -entry computeMain -profile cs_6_2 
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=16):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=16):out
 RWStructuredBuffer<int> outputBuffer;
 
-//TEST_INPUT: Texture2D(size=4):dxbinding(1),glbinding(1)
+//TEST_INPUT: Texture2D(size=4):
 RWTexture2D<half> halfTexture;
-//TEST_INPUT: Texture2D(size=4):dxbinding(2),glbinding(2)
+//TEST_INPUT: Texture2D(size=4):
 RWTexture2D<half2> halfTexture2;
-//TEST_INPUT: Texture2D(size=4):dxbinding(3),glbinding(3)
+//TEST_INPUT: Texture2D(size=4):
 RWTexture2D<half4> halfTexture4;
 
-//TEST_INPUT: Sampler : dxbinding(0),glbinding(0)
+//TEST_INPUT: Sampler:
 SamplerState 	s;
 
 [numthreads(4, 4, 1)]

--- a/tests/compute/implicit-generic-app.slang
+++ b/tests/compute/implicit-generic-app.slang
@@ -29,7 +29,7 @@ int test(int val)
 	return doIt(simple);
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer : register(u0);
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/implicit-this-expr.slang
+++ b/tests/compute/implicit-this-expr.slang
@@ -14,7 +14,7 @@ struct A
 	}
 };
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer : register(u0);
 
 float test(float inVal)

--- a/tests/compute/init-list-defaults.slang
+++ b/tests/compute/init-list-defaults.slang
@@ -23,7 +23,7 @@ int test(int inVal)
 		+ (inVal+1)*4096;
 }
 
-//TEST_INPUT:ubuffer(data=[9 9 9 9], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[9 9 9 9], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer : register(u0);
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/initializer-list.slang
+++ b/tests/compute/initializer-list.slang
@@ -15,7 +15,7 @@ uint test(uint val)
 	return val + t.b;
 }
 
-//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/inout.slang
+++ b/tests/compute/inout.slang
@@ -35,7 +35,7 @@ int test(int inVal)
 	return x3;
 }
 
-//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer : register(u0);
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/int-generic.slang
+++ b/tests/compute/int-generic.slang
@@ -2,7 +2,7 @@
 
 //TEST_INPUT:type Material<1,2>
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 interface IBRDF

--- a/tests/compute/interface-local.slang
+++ b/tests/compute/interface-local.slang
@@ -37,7 +37,7 @@ int test(int val)
     return existentialHelper.getVal();
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=gOutputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=gOutputBuffer
 RWStructuredBuffer<int> gOutputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/interface-param.slang
+++ b/tests/compute/interface-param.slang
@@ -32,7 +32,7 @@ int test(int val)
     return doTheThing(helperImpl);
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=gOutputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=gOutputBuffer
 RWStructuredBuffer<int> gOutputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/interface-shader-param-in-struct.slang
+++ b/tests/compute/interface-shader-param-in-struct.slang
@@ -41,7 +41,7 @@ int test(
 }
 
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> gOutputBuffer;
 
 cbuffer C
@@ -50,7 +50,7 @@ cbuffer C
 }
 
 //TEST_INPUT: globalExistentialType MyStrategy
-//TEST_INPUT:ubuffer(data=[1 2 4 8], stride=4):dxbinding(1),glbinding(1)
+//TEST_INPUT:ubuffer(data=[1 2 4 8], stride=4):
 
 struct Stuff
 {
@@ -60,7 +60,7 @@ struct Stuff
 
 [numthreads(4, 1, 1)]
 void computeMain(
-//TEST_INPUT:cbuffer(data=[256]):dxbinding(0),glbinding(2)
+//TEST_INPUT:cbuffer(data=[256]):
     uniform Stuff stuff,
 
     uint3       dispatchThreadID : SV_DispatchThreadID)
@@ -111,4 +111,4 @@ struct MyModifier : IModifier
 }
 
 //TEST_INPUT: entryPointExistentialType MyModifier
-//TEST_INPUT:ubuffer(data=[16 32 64 128], stride=4):dxbinding(2),glbinding(3)
+//TEST_INPUT:ubuffer(data=[16 32 64 128], stride=4):

--- a/tests/compute/interface-shader-param-legalization.slang
+++ b/tests/compute/interface-shader-param-legalization.slang
@@ -19,7 +19,7 @@ int test(
 }
 
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> gOutputBuffer;
 
 [numthreads(4, 1, 1)]
@@ -51,4 +51,4 @@ struct ConcreteModifier : IModifier
 }
 
 //TEST_INPUT: globalExistentialType ConcreteModifier
-//TEST_INPUT:cbuffer(data=[256], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:cbuffer(data=[256], stride=4):out

--- a/tests/compute/interface-shader-param.slang
+++ b/tests/compute/interface-shader-param.slang
@@ -75,7 +75,7 @@ int test(
 //
 // We'll start with the buffer for writing the test output.
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=gOutputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=gOutputBuffer
 RWStructuredBuffer<int> gOutputBuffer;
 
 // Now we'll define a global shader parameter for the

--- a/tests/compute/interface-shader-param2.slang
+++ b/tests/compute/interface-shader-param2.slang
@@ -42,16 +42,16 @@ int test(
 }
 
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> gOutputBuffer;
 
-//TEST_INPUT:cbuffer(data=[1 0 0 0], stride=4):dxbinding(0),glbinding(1)
+//TEST_INPUT:cbuffer(data=[1 0 0 0], stride=4):
 ConstantBuffer<IRandomNumberGenerationStrategy> gStrategy;
 
 [numthreads(4, 1, 1)]
 void computeMain(
 
-//TEST_INPUT:cbuffer(data=[8 0 0 0], stride=4):dxbinding(1),glbinding(2)
+//TEST_INPUT:cbuffer(data=[8 0 0 0], stride=4):
     uniform IModifier   modifier,
             uint3       dispatchThreadID : SV_DispatchThreadID)
 {

--- a/tests/compute/interface-shader-param3.slang
+++ b/tests/compute/interface-shader-param3.slang
@@ -42,7 +42,7 @@ int test(
 }
 
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> gOutputBuffer;
 
 ConstantBuffer<IRandomNumberGenerationStrategy> gStrategy;
@@ -56,7 +56,7 @@ ConstantBuffer<IRandomNumberGenerationStrategy> gStrategy;
 // type argument at the same time.
 //
 //TEST_INPUT: globalExistentialType MyStrategy
-//TEST_INPUT:cbuffer(data=[1 0 0 0], stride=4):dxbinding(0),glbinding(1)
+//TEST_INPUT:cbuffer(data=[1 0 0 0], stride=4):
 
 [numthreads(4, 1, 1)]
 void computeMain(
@@ -83,7 +83,7 @@ void computeMain(
 //
 // Here's the incantation to make the test runner fill in the constant buffer:
 //
-//TEST_INPUT:cbuffer(data=[256 0 0 0 16 0 0 0], stride=4):dxbinding(1),glbinding(2)
+//TEST_INPUT:cbuffer(data=[256 0 0 0 16 0 0 0], stride=4):
 //
 // So, the value `256` will be used for `extra` and the value `16`
 // will be written to the first four bytes of the concrete value

--- a/tests/compute/interface-shader-param4.slang
+++ b/tests/compute/interface-shader-param4.slang
@@ -43,7 +43,7 @@ int test(
 }
 
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> gOutputBuffer;
 
 ConstantBuffer<IRandomNumberGenerationStrategy> gStrategy;
@@ -57,7 +57,7 @@ ConstantBuffer<IRandomNumberGenerationStrategy> gStrategy;
 // Here's the data for `gStrategy`:
 //
 //TEST_INPUT: globalExistentialType MyStrategy
-//TEST_INPUT:ubuffer(data=[1 2 4 8], stride=4):dxbinding(1),glbinding(1)
+//TEST_INPUT:ubuffer(data=[1 2 4 8], stride=4):
 
 
 [numthreads(4, 1, 1)]
@@ -75,7 +75,7 @@ void computeMain(
 // the previous test, the concrete type plugged in for `modifier`
 // has no uniform/ordinary data, so we don't need to fill it in.
 //
-//TEST_INPUT:cbuffer(data=[256]):dxbinding(0),glbinding(2)
+//TEST_INPUT:cbuffer(data=[256]):
 
             uint3       dispatchThreadID : SV_DispatchThreadID)
 {
@@ -127,4 +127,4 @@ struct MyModifier : IModifier
 // Here's the data for `modifier`:
 //
 //TEST_INPUT: entryPointExistentialType MyModifier
-//TEST_INPUT:ubuffer(data=[16 32 64 128], stride=4):dxbinding(2),glbinding(3)
+//TEST_INPUT:ubuffer(data=[16 32 64 128], stride=4):

--- a/tests/compute/interface-static-method.slang
+++ b/tests/compute/interface-static-method.slang
@@ -46,7 +46,7 @@ int test(int val)
 }
 
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/loop-unroll.slang
+++ b/tests/compute/loop-unroll.slang
@@ -1,7 +1,7 @@
 //TEST(compute):COMPARE_COMPUTE:
 
-//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):dxbinding(0),glbinding(0),out
-//TEST_INPUT:ubuffer(data=[1 2 3 0], stride=4):dxbinding(1),glbinding(1)
+//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):out
+//TEST_INPUT:ubuffer(data=[1 2 3 0], stride=4):
 
 // Check that we propagate the `[unroll]` attribute
 // through to HLSL output correctly.

--- a/tests/compute/matrix-layout-structured-buffer.slang
+++ b/tests/compute/matrix-layout-structured-buffer.slang
@@ -17,7 +17,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -xslang -matrix-layout-row-major
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -xslang -matrix-layout-column-major
 
-//TEST_INPUT:ubuffer(data=[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23], stride=48):dxbinding(0),glbinding(0),name=gMatrices
+//TEST_INPUT:ubuffer(data=[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23], stride=48):name=gMatrices
 RWStructuredBuffer<int3x4> gMatrices;
 
 int test(int val)
@@ -35,7 +35,7 @@ int test(int val)
     return tmp;
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0], stride=4):dxbinding(0),glbinding(1),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out
 RWStructuredBuffer<int> buffer;
 
 [numthreads(12, 1, 1)]

--- a/tests/compute/matrix-layout.hlsl
+++ b/tests/compute/matrix-layout.hlsl
@@ -23,13 +23,13 @@ struct S
     int    b;
 };
 
-//TEST_INPUT:cbuffer(data=[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24]):dxbinding(0),glbinding(0)
+//TEST_INPUT:cbuffer(data=[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24]):
 cbuffer C0
 {
     S s;
 };
 
-//TEST_INPUT:cbuffer(data=[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24]):dxbinding(1),glbinding(1)
+//TEST_INPUT:cbuffer(data=[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24]):
 cbuffer C1
 {
 
@@ -60,7 +60,7 @@ int test(int val)
     return ((a*N + b) * N + c) * N + d;
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0], stride=4):dxbinding(0),glbinding(2),out,name=buffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=buffer
 RWStructuredBuffer<int> buffer;
 
 [numthreads(12, 1, 1)]

--- a/tests/compute/modern-syntax.slang
+++ b/tests/compute/modern-syntax.slang
@@ -15,7 +15,7 @@ func test(val: MyInt) -> MyInt
 	return tmp;
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/multi-interface.slang
+++ b/tests/compute/multi-interface.slang
@@ -1,7 +1,7 @@
 //TEST(compute):COMPARE_COMPUTE:
 //TEST(compute):COMPARE_COMPUTE:-cpu
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 interface IAdd

--- a/tests/compute/multiple-continue-sites.slang
+++ b/tests/compute/multiple-continue-sites.slang
@@ -27,7 +27,7 @@ int test(int inVal)
 	return ii;
 }
 
-//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer : register(u0);
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/mutating-methods.slang
+++ b/tests/compute/mutating-methods.slang
@@ -41,7 +41,7 @@ int test(int x)
     return a.state;
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/nested-generics.slang
+++ b/tests/compute/nested-generics.slang
@@ -3,7 +3,7 @@
 
 // test specialization of nested generic functions
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 interface IGetF

--- a/tests/compute/nested-generics2.slang
+++ b/tests/compute/nested-generics2.slang
@@ -3,7 +3,7 @@
 
 // test specialization of nested generic functions
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 interface IBRDF

--- a/tests/compute/parameter-block.slang
+++ b/tests/compute/parameter-block.slang
@@ -1,8 +1,8 @@
 //TEST(compute):COMPARE_COMPUTE:
 //TEST(compute):COMPARE_COMPUTE:-cpu
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=block0.buffer
-//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):dxbinding(1),glbinding(1),name=block1.buffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=block0.buffer
+//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):name=block1.buffer
 
 // Ensure that Slang `ParameterBlock` type is lowered
 // to HLSL in the fashion that we expect.

--- a/tests/compute/performance-profile.slang
+++ b/tests/compute/performance-profile.slang
@@ -4,7 +4,7 @@
 //TEST(compute):PERFORMANCE_PROFILE:-slang -compute -dx12 -compute-dispatch 256,1,1
 //TEST(compute, vulkan):PERFORMANCE_PROFILE:-vk -compute -compute-dispatch 256,1,1
 
-//TEST_INPUT:ubuffer(random(float, 4096, -1, 1), stride=4):dxbinding(0),glbinding(0),out,name outputBuffer
+//TEST_INPUT:ubuffer(random(float, 4096, -1, 1), stride=4):out,name outputBuffer
 
 #ifndef __cplusplus
 

--- a/tests/compute/rewriter-parameter-block-complex.hlsl
+++ b/tests/compute/rewriter-parameter-block-complex.hlsl
@@ -1,12 +1,12 @@
 //TEST(compute):COMPARE_COMPUTE:
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 
-//TEST_INPUT:cbuffer(data=[256]):dxbinding(0),glbinding(0)
-//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):dxbinding(1),glbinding(1)
+//TEST_INPUT:cbuffer(data=[256]):
+//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):
 
-//TEST_INPUT:cbuffer(data=[4096]):dxbinding(1),glbinding(1)
-//TEST_INPUT:ubuffer(data=[16 32 48 64], stride=4):dxbinding(2),glbinding(2)
+//TEST_INPUT:cbuffer(data=[4096]):
+//TEST_INPUT:ubuffer(data=[16 32 48 64], stride=4):
 
 // Test that we can declare a `ParameterBlock<...>` type as a shader
 // parameter (potentially nested inside a `cbuffer`) and use it in

--- a/tests/compute/rewriter-parameter-block.hlsl
+++ b/tests/compute/rewriter-parameter-block.hlsl
@@ -1,14 +1,14 @@
 //TEST(compute):COMPARE_COMPUTE:
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 
-//TEST_INPUT:cbuffer(data=[256]):dxbinding(0),glbinding(0)
-//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):dxbinding(1),glbinding(1)
+//TEST_INPUT:cbuffer(data=[256]):
+//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):
 
-//TEST_INPUT:cbuffer(data=[65536]):dxbinding(1),glbinding(1)
+//TEST_INPUT:cbuffer(data=[65536]):
 
-//TEST_INPUT:cbuffer(data=[4096]):dxbinding(2),glbinding(2)
-//TEST_INPUT:ubuffer(data=[16 32 48 64], stride=4):dxbinding(2),glbinding(2)
+//TEST_INPUT:cbuffer(data=[4096]):
+//TEST_INPUT:ubuffer(data=[16 32 48 64], stride=4):
 
 // Test that we can declare a `ParameterBlock<...>` type as a shader
 // parameter (potentially nested inside a `cbuffer`) and use it in

--- a/tests/compute/scope-operator.slang
+++ b/tests/compute/scope-operator.slang
@@ -5,7 +5,7 @@
 
 // Confirm that scoping on enums and types works 
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 enum Color

--- a/tests/compute/select-expr.slang
+++ b/tests/compute/select-expr.slang
@@ -8,7 +8,7 @@ int test(int input)
 	return input > 1 ? -input : input;
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/semantic.slang
+++ b/tests/compute/semantic.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -compute-dispatch 3,1,1
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -compute-dispatch 3,1,1
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0  0 0 0 0  0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0  0 0 0 0  0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/simple.slang
+++ b/tests/compute/simple.slang
@@ -3,7 +3,7 @@
 
 // This is a basic test for Slang compute shader.
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/ssa-reduce-bug.slang
+++ b/tests/compute/ssa-reduce-bug.slang
@@ -2,9 +2,9 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
 //TEST(compute):COMPARE_COMPUTE_EX:-cpu -slang -compute
 
-//TEST_INPUT:ubuffer(data=[0 3 1 2 6 4 7 6], stride=4):dxbinding(0),glbinding(0),name=inputBuffer
+//TEST_INPUT:ubuffer(data=[0 3 1 2 6 4 7 6], stride=4):name=inputBuffer
 RWStructuredBuffer<int> inputBuffer;
-//TEST_INPUT:ubuffer(data=[8 8 8 8 8 8 8 8], stride=4):dxbinding(1),glbinding(1),out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[8 8 8 8 8 8 8 8], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 int2 reduce(int2 val)

--- a/tests/compute/static-const-array.slang
+++ b/tests/compute/static-const-array.slang
@@ -4,7 +4,7 @@
 //TEST_DISABLED(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
 
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> outputBuffer;
 
 static const int kArray[] = { 16, 1, 32, 2 };

--- a/tests/compute/struct-default-init.slang
+++ b/tests/compute/struct-default-init.slang
@@ -25,7 +25,7 @@ int test(int inVal)
 	     + t.d;
 }
 
-//TEST_INPUT:ubuffer(data=[9 9 9 9], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[9 9 9 9], stride=4):out
 RWStructuredBuffer<int> outputBuffer : register(u0);
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/struct-in-generic.slang
+++ b/tests/compute/struct-in-generic.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 
 // Confirm that a struct type defined in a generic parent works
 

--- a/tests/compute/switch-stmt.slang
+++ b/tests/compute/switch-stmt.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:
-//TEST_INPUT:ubuffer(data=[0 1 2 3 4 5 6 7], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 1 2 3 4 5 6 7], stride=4):out
 
 // Test that `swith` statement works
 

--- a/tests/compute/tagged-union.slang
+++ b/tests/compute/tagged-union.slang
@@ -92,10 +92,10 @@ void computeMain
 // We will thus set up the same data buffer to look like an `A`
 // value to Vulkan!
 //
-//TEST_INPUT: cbuffer(data=[16 9 1 0 0], stride=4):dxbinding(0),glbinding(0)
+//TEST_INPUT: cbuffer(data=[16 9 1 0 0], stride=4):
 
 
-//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(1),out
+//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):out
     uniform RWStructuredBuffer<int> gOutputBuffer,
     uint3 dispatchThreadID : SV_DispatchThreadID)
 {

--- a/tests/compute/texture-sampling.slang
+++ b/tests/compute/texture-sampling.slang
@@ -1,14 +1,14 @@
 //TEST(compute):COMPARE_RENDER_COMPUTE:
 
-//TEST_INPUT: Texture1D(size=4, content = one) : dxbinding(0),glbinding(0)
-//TEST_INPUT: Texture2D(size=4, content = one) : dxbinding(1),glbinding(1)
-//TEST_INPUT: Texture3D(size=4, content = one) : dxbinding(2),glbinding(2)
-//TEST_INPUT: TextureCube(size=4, content = one) : dxbinding(3),glbinding(3)
-//TEST_INPUT: Texture1D(size=4, content = one, arrayLength=2) : dxbinding(4),glbinding(4)
-//TEST_INPUT: Texture2D(size=4, content = one, arrayLength=2) : dxbinding(5),glbinding(5)
-//TEST_INPUT: TextureCube(size=4, content = one, arrayLength=2) : dxbinding(6),glbinding(6)
-//TEST_INPUT: Sampler : dxbinding(0),glbinding(0,1,2,3,4,5,6)
-//TEST_INPUT: ubuffer(data=[0], stride=4):dxbinding(1),glbinding(0),out
+//TEST_INPUT: Texture1D(size=4, content = one):
+//TEST_INPUT: Texture2D(size=4, content = one):
+//TEST_INPUT: Texture3D(size=4, content = one):
+//TEST_INPUT: TextureCube(size=4, content = one):
+//TEST_INPUT: Texture1D(size=4, content = one, arrayLength=2):
+//TEST_INPUT: Texture2D(size=4, content = one, arrayLength=2):
+//TEST_INPUT: TextureCube(size=4, content = one, arrayLength=2):
+//TEST_INPUT: Sampler:
+//TEST_INPUT: ubuffer(data=[0], stride=4):out
 
 Texture1D t1D;
 Texture2D t2D;

--- a/tests/compute/transitive-interface.slang
+++ b/tests/compute/transitive-interface.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 
 
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/compute/type-legalize-global-with-init.slang
+++ b/tests/compute/type-legalize-global-with-init.slang
@@ -6,10 +6,10 @@
 //
 //TEST(compute):COMPARE_COMPUTE:
 //
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<uint> outputBuffer;
 
-//TEST_INPUT:ubuffer(data=[1 2 3 4 5 6 7 8], stride=4):dxbinding(1),glbinding(0)
+//TEST_INPUT:ubuffer(data=[1 2 3 4 5 6 7 8], stride=4):
 RWStructuredBuffer<uint> inputBuffer;
 
 static const RWStructuredBuffer<uint> gBuffer = inputBuffer;

--- a/tests/compute/type-param-varying.slang
+++ b/tests/compute/type-param-varying.slang
@@ -1,7 +1,7 @@
 //TEST(compute):COMPARE_RENDER_COMPUTE:
 
 //TEST_INPUT: global_type AssembledVertex
-//TEST_INPUT: ubuffer(data=[0], stride=4):dxbinding(1),glbinding(0),out
+//TEST_INPUT: ubuffer(data=[0], stride=4):out
 
 // Testing associated types in a varying parameter field
 

--- a/tests/compute/typedef-member.slang
+++ b/tests/compute/typedef-member.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 
 // Confirm that a struct type defined in a generic parent works
 

--- a/tests/compute/unbounded-array-of-array-syntax.slang
+++ b/tests/compute/unbounded-array-of-array-syntax.slang
@@ -3,7 +3,7 @@
 //TEST:CROSS_COMPILE:-target dxbc-assembly -entry computeMain -profile cs_5_1
 //TEST:CROSS_COMPILE:-target spirv-assembly -entry computeMain -profile cs_5_1
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 //TEST_INPUT:array(size=2):name g_aoa

--- a/tests/compute/unbounded-array-of-array.slang
+++ b/tests/compute/unbounded-array-of-array.slang
@@ -3,7 +3,7 @@
 
 struct IntAoa { RWStructuredBuffer<int> array[]; }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 //TEST_INPUT:array(size=2):name g_aoa.array

--- a/tests/compute/vector-scalar-compare.slang
+++ b/tests/compute/vector-scalar-compare.slang
@@ -1,6 +1,6 @@
 //TEST(compute):COMPARE_COMPUTE:-dx12 -compute 
 //TEST(compute):COMPARE_COMPUTE:-vk -compute 
-//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out
 
 // Test doing vector comparisons 
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/compute/write-structured-buffer-field.slang
+++ b/tests/compute/write-structured-buffer-field.slang
@@ -1,6 +1,6 @@
 //TEST(compute):COMPARE_COMPUTE:
 
-//TEST_INPUT:ubuffer(data=[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32], stride=32):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32], stride=32):out
 
 struct S
 {

--- a/tests/cross-compile/c-cross-compile.slang
+++ b/tests/cross-compile/c-cross-compile.slang
@@ -62,7 +62,7 @@ struct Thing
     float b;
 };
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> outputBuffer;
 
 RWStructuredBuffer<int> outputBuffer2;

--- a/tests/cross-compile/cpp-resource-reflection.slang
+++ b/tests/cross-compile/cpp-resource-reflection.slang
@@ -15,7 +15,7 @@ static int value;
 
 ConstantBuffer<Thing> thing3;
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> outputBuffer;
 
 Texture2D<float> tex;

--- a/tests/cross-compile/cpp-resource.slang
+++ b/tests/cross-compile/cpp-resource.slang
@@ -13,7 +13,7 @@ static int value;
 
 ConstantBuffer<Thing> thing3;
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):dxbinding(0),glbinding(0),out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> outputBuffer;
 
 Texture2D<float> tex;

--- a/tests/cross-compile/get-dimensions.slang
+++ b/tests/cross-compile/get-dimensions.slang
@@ -10,19 +10,19 @@ struct Thing
     float b;
 };
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):dxbinding(0),glbinding(0),out,name outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
-//TEST_INPUT:ubuffer(data=[7 2 9 53], stride=4):dxbinding(1),glbinding(1),name buffer0
+//TEST_INPUT:ubuffer(data=[7 2 9 53], stride=4):name buffer0
 RWStructuredBuffer<int> buffer0;
 
-//TEST_INPUT:ubuffer(data=[23 2], stride=4):dxbinding(2),glbinding(2),name buffer1
+//TEST_INPUT:ubuffer(data=[23 2], stride=4):name buffer1
 RWStructuredBuffer<int> buffer1;
 
-//TEST_INPUT:ubuffer(data=[-10 17 9 4 2 0], stride=4):dxbinding(3),glbinding(3),name buffer2
+//TEST_INPUT:ubuffer(data=[-10 17 9 4 2 0], stride=4):name buffer2
 RWStructuredBuffer<float> buffer2;
 
-//TEST_INPUT:ubuffer(data=[1 0 3 0 7 0], stride=8):dxbinding(4),glbinding(4),name buffer3
+//TEST_INPUT:ubuffer(data=[1 0 3 0 7 0], stride=8):name buffer3
 RWStructuredBuffer<Thing> buffer3;
 
 [numthreads(4, 1, 1)]

--- a/tests/serialization/extern/extern-test.slang
+++ b/tests/serialization/extern/extern-test.slang
@@ -4,7 +4,7 @@
 //TEST:COMPILE: -module-name module -no-codegen tests/serialization/extern/module-b.slang -o tests/serialization/extern/module-b.slang-lib
 //TEST:COMPARE_COMPUTE_EX: -xslang -module-name -xslang module -slang -compute -xslang -r -xslang tests/serialization/extern/module-a.slang-lib -xslang -r -xslang tests/serialization/extern/module-b.slang-lib 
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0 ], stride=4):dxbinding(0),glbinding(0),out,name outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0 ], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 // Declare the type exists

--- a/tests/serialization/serialized-module-entry-point-test.slang
+++ b/tests/serialization/serialized-module-entry-point-test.slang
@@ -4,4 +4,4 @@
 //TEST:COMPILE: -module-name module tests/serialization/serialized-module.slang -o tests/serialization/serialized-module.slang-module -ir-compression none
 //TEST:COMPARE_COMPUTE_EX: -xslang -module-name -xslang module -slang -compute -xslang -r -xslang tests/serialization/serialized-module-entry-point.slang-module -xslang -r -xslang tests/serialization/serialized-module.slang-module -no-default-entry-point
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0 ], stride=4):dxbinding(0),glbinding(0),out,name outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0 ], stride=4):out,name outputBuffer

--- a/tests/serialization/serialized-module-test.slang
+++ b/tests/serialization/serialized-module-test.slang
@@ -18,7 +18,7 @@ struct Thing
 // TODO: need to get the name mangling to line up!
 int foo(Thing thing);
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0 ], stride=4):dxbinding(0),glbinding(0),out,name outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0 ], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -89,7 +89,7 @@ class RenderTestApp : public WindowListener
     uint64_t m_startTicks;
 
 	// variables for state to be used for rendering...
-	uintptr_t m_constantBufferSize, m_computeResultBufferSize;
+	uintptr_t m_constantBufferSize;
 
 	RefPtr<Renderer> m_renderer;
 

--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -463,27 +463,6 @@ namespace renderer_test
                                     entry.isCPUOnly = true;
                                     parser.ReadToken();
                                 }
-                                else if (parser.LookAhead("dxbinding"))
-                                {
-                                    parser.ReadToken();
-                                    parser.Read("(");
-                                    entry.hlslBinding = parser.ReadInt();
-                                    parser.Read(")");
-                                }
-                                else if (parser.LookAhead("glbinding"))
-                                {
-                                    parser.ReadToken();
-                                    parser.Read("(");
-                                    while (!parser.IsEnd() && !parser.LookAhead(")"))
-                                    {
-                                        entry.glslBinding.add(parser.ReadInt());
-                                        if (parser.LookAhead(","))
-                                            parser.Read(",");
-                                        else
-                                            break;
-                                    }
-                                    parser.Read(")");
-                                }
                                 else if (parser.LookAhead("out"))
                                 {
                                     parser.ReadToken();
@@ -540,6 +519,11 @@ namespace renderer_test
                                     }
 
                                     entry.name = builder;
+                                }
+                                else
+                                {
+                                    fprintf(stderr, "Invalid TEST_INPUT syntax '%s'\n", parser.NextToken().Content.getBuffer());
+                                    break;
                                 }
 
                                 if (parser.LookAhead(","))

--- a/tools/render-test/shader-input-layout.h
+++ b/tools/render-test/shader-input-layout.h
@@ -67,8 +67,6 @@ public:
     ArrayDesc arrayDesc;
     bool isOutput = false;
     bool isCPUOnly = false;
-    int hlslBinding = -1;
-    Slang::List<int> glslBinding;
 
     Slang::String name;                     ///< Optional name. Useful for binding through reflection.
 };

--- a/tools/render-test/shader-renderer-util.cpp
+++ b/tools/render-test/shader-renderer-util.cpp
@@ -156,53 +156,6 @@ static RefPtr<SamplerState> _createSamplerState(
     return renderer->createSamplerState(_calcSamplerDesc(srcDesc));
 }
 
-/* static */BindingStateImpl::RegisterRange ShaderRendererUtil::calcRegisterRange(Renderer* renderer, const ShaderInputLayoutEntry& entry)
-{
-    typedef BindingStateImpl::RegisterRange RegisterRange;
-
-    BindingStyle bindingStyle = RendererUtil::getBindingStyle(renderer->getRendererType());
-
-    switch (bindingStyle)
-    {
-        case BindingStyle::DirectX:
-        {
-            return RegisterRange::makeSingle(entry.hlslBinding);
-        }
-        case BindingStyle::Vulkan:
-        {
-            // USe OpenGls for now
-            // fallthru
-        }
-        case BindingStyle::OpenGl:
-        {
-            const int count = int(entry.glslBinding.getCount());
-
-            if (count <= 0)
-            {
-                break;
-            }
-
-            int baseIndex = entry.glslBinding[0];
-            // Make sure they are contiguous
-            for (Index i = 1; i < int(entry.glslBinding.getCount()); ++i)
-            {
-                if (baseIndex + i != entry.glslBinding[i])
-                {
-                    assert(!"Bindings must be contiguous");
-                    break;
-                }
-            }
-            return RegisterRange::makeRange(baseIndex, count);
-        }
-        /* case BindingStyle::Vulkan:
-        {
-        } */
-        default: break;
-    }
-    // Return invalid
-    return RegisterRange::makeInvalid();
-}
-
 /* static */Result ShaderRendererUtil::createBindingState(const ShaderInputLayout& layout, Renderer* renderer, BufferResource* addedConstantBuffer, BindingStateImpl** outBindingState)
 {
     auto srcEntries = layout.entries.getBuffer();
@@ -224,13 +177,6 @@ static RefPtr<SamplerState> _createSamplerState(
     {
         const ShaderInputLayoutEntry& srcEntry = srcEntries[i];
         SLANG_ASSERT(srcEntry.isCPUOnly == false);
-
-        const BindingStateImpl::RegisterRange registerSet = calcRegisterRange(renderer, srcEntry);
-        if (!registerSet.isValid())
-        {
-            assert(!"Couldn't find a binding");
-            return SLANG_FAIL;
-        }
 
         DescriptorSetLayout::SlotRangeDesc slotRangeDesc;
 

--- a/tools/render-test/shader-renderer-util.h
+++ b/tools/render-test/shader-renderer-util.h
@@ -62,9 +62,6 @@ struct ShaderRendererUtil
         /// Create BindingState::Desc from the contents of layout
     static Slang::Result createBindingState(const ShaderInputLayout& layout, Renderer* renderer, BufferResource* addedConstantBuffer, BindingStateImpl** outBindingState);
 
-        /// Get the binding register associated with this binding (or -1 if none defined)
-    static BindingStateImpl::RegisterRange calcRegisterRange(Renderer* renderer, const ShaderInputLayoutEntry& entry);
-
 private:
         /// Create BindingState::Desc from a list of ShaderInputLayout entries
     static Slang::Result _createBindingState(ShaderInputLayoutEntry* srcEntries, int numEntries, Renderer* renderer, BufferResource* addedConstantBuffer, BindingStateImpl** outBindingState);


### PR DESCRIPTION
The `TEST_INPUT` facility allows textual Slang test cases to provide two kinds of information to the `render-test` tool:

1. Information on what shader inputs exist
2. Information on what values/objects to bind into those shader inputs

Under the first category of information, there exists supporting for attaching a `dxbinding(...)` annotation to a `TEST_INPUT` which seemingly indicates what HLSL `register` the input uses. There is a similar `glbinding(...)` annotation, used for OpenGL and Vulkan.

It turns out that these annotations were, in practice, completely ignored and had no bearing on how `render-test` allocates or bindings graphics API objects. There was some amount of code attempting to validate that explicit registers/bindings were being set appropriately, but the actual values were being ignored.

The visible consequence of the `dxbinding` and `glbinding` annotations being ignored is issue #1036: the order of `TEST_INPUT` lines was *de facto* determining the registers/bindings that were being used by `render-test`.

This change simply removes the placebo features and strips things down to what is implemented in practice: the `TEST_INPUT` lines do not need target-API-specific binding/register numbers, because their order in the file implicitly defines them.

I added logic to the parsing of `TEST_INPUT` lines to make sure I got an error message on any leftover annotations, and went ahead and systematicaly deleted all of the placebo annotations from our test cases.

If we decide to make `TEST_INPUT` lines *not* depend on order of declaration in the future, we can build it up as a new and better considered feature.

The main alternative I considered was to keep the annotations in place, and change `render-test` and the `gfx` abstraction layer to properly respect them, but that path actually creates much more opportunity for breakage (since every single test case would suddenly be specifying its root signature / pipeline layout via a different path using data that has never been tested). The approach in this change has the benefit of giving me high confidence that all the test cases continue to work just as they had before.