### PR TITLE
Add command line option to override language file extension

### DIFF
--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -460,6 +460,32 @@ namespace Slang
         }
     }
 
+    static const struct
+    {
+        char const*     name;
+        SourceLanguage  sourceLanguage;
+    } kSourceLanguages[] =
+    {
+        { "slang", SourceLanguage::Slang },
+        { "hlsl", SourceLanguage::HLSL },
+        { "glsl", SourceLanguage::GLSL },
+        { "c", SourceLanguage::C },
+        { "cxx", SourceLanguage::CPP },
+    };
+
+    SourceLanguage findSourceLanguageByName(String const& name)
+    {
+        for (auto entry : kSourceLanguages)
+        {
+            if (name == entry.name)
+            {
+                return entry.sourceLanguage;
+            }
+        }
+
+        return SourceLanguage::Unknown;
+    };
+
     SlangResult checkExternalCompilerSupport(Session* session, PassThroughMode passThrough)
     {
         switch (passThrough)

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -70,6 +70,7 @@ DIAGNOSTIC(    15, Error, unknownStage, "unknown stage '$0'");
 DIAGNOSTIC(    16, Error, unknownPassThroughTarget, "unknown pass-through target '$0'");
 DIAGNOSTIC(    17, Error, unknownCommandLineOption, "unknown command-line option '$0'");
 DIAGNOSTIC(    18, Error, unknownFileSystemOption, "unknown file-system option '$0'");
+DIAGNOSTIC(    19, Error, unknownSourceLanguage, "unknown source language '$0'");
 
 DIAGNOSTIC(    20, Error, entryPointsNeedToBeAssociatedWithTranslationUnits, "when using multiple source files, entry points must be specified after their corresponding source file(s)");
 DIAGNOSTIC(    21, Error, expectedArgumentForOption, "expected an argument for command-line option '$0'");

--- a/source/slang/slang-profile.h
+++ b/source/slang/slang-profile.h
@@ -105,6 +105,8 @@ namespace Slang
     Stage findStageByName(String const& name);
 
     UnownedStringSlice getStageText(Stage stage);
+
+    SourceLanguage findSourceLanguageByName(String const& name);
 }
 
 #endif


### PR DESCRIPTION
 * Adds a new `-lang` slangc command line option that can precede an input file
 * `-lang` valid options are `slang,hlsl,glsl,c,cxx`
 * Can be used to override the file extension when using the slangc command line tool
 * Any filenames that follow the option will be built using the translation unit specified