### PR TITLE
Clean up the concept of "pseudo ops"

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -58,8 +58,16 @@ interface __FlagsEnumType : __EnumType
 {
 };
 
-__generic<T,U> __intrinsic_op(Sequence) U operator,(T left, U right);
+// The "comma operator" is effectively just a generic function that returns its second
+// argument. The left-to-right evaluation order guaranteed by Slang then ensures that
+// `left` is evaluated before `right`.
+//
+__generic<T,U> __intrinsic_op($(kCompoundIntrinsicOp_Sequence)) U operator,(T left, U right);
 
+// The ternary `?:` operator does not short-circuit in HLSL, and Slang continues to
+// follow that definition, so that this operator is effectively just an ordinary
+// function, rather than a special-case piece of syntax.
+//
 __generic<T> __intrinsic_op(select) T operator?:(bool condition, T ifTrue, T ifFalse);
 __generic<T, let N : int> __intrinsic_op(select) vector<T,N> operator?:(vector<bool,N> condition, vector<T,N> ifTrue, vector<T,N> ifFalse);
 
@@ -956,7 +964,6 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
 
                 sb << "__target_intrinsic(glsl, \"$ctextureGrad($p, $2, $3, $4)$z\")\n";
-//                sb << "__intrinsic_op(sampleGrad)\n";
                 sb << "T SampleGrad(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount << " gradX, ";
@@ -966,7 +973,6 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     sb << "__target_intrinsic(glsl, \"$ctextureGradOffset($p, $2, $3, $4, $5)$z\")\n";
-//                    sb << "__intrinsic_op(sampleGrad)\n";
                     sb << "T SampleGrad(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount << " gradX, ";
@@ -1158,7 +1164,7 @@ for (auto op : binaryOps)
         switch (op.opCode)
         {
         case kIROp_Mul:
-        case kIRPseudoOp_MulAssign:
+        case kCompoundIntrinsicOp_MulAssign:
             break;
 
         default:

--- a/source/slang/core.meta.slang.h
+++ b/source/slang/core.meta.slang.h
@@ -58,8 +58,19 @@ SLANG_RAW("interface __FlagsEnumType : __EnumType\n")
 SLANG_RAW("{\n")
 SLANG_RAW("};\n")
 SLANG_RAW("\n")
-SLANG_RAW("__generic<T,U> __intrinsic_op(Sequence) U operator,(T left, U right);\n")
+SLANG_RAW("// The \"comma operator\" is effectively just a generic function that returns its second\n")
+SLANG_RAW("// argument. The left-to-right evaluation order guaranteed by Slang then ensures that\n")
+SLANG_RAW("// `left` is evaluated before `right`.\n")
+SLANG_RAW("//\n")
+SLANG_RAW("__generic<T,U> __intrinsic_op(")
+SLANG_SPLICE(kCompoundIntrinsicOp_Sequence
+)
+SLANG_RAW(") U operator,(T left, U right);\n")
 SLANG_RAW("\n")
+SLANG_RAW("// The ternary `?:` operator does not short-circuit in HLSL, and Slang continues to\n")
+SLANG_RAW("// follow that definition, so that this operator is effectively just an ordinary\n")
+SLANG_RAW("// function, rather than a special-case piece of syntax.\n")
+SLANG_RAW("//\n")
 SLANG_RAW("__generic<T> __intrinsic_op(select) T operator?:(bool condition, T ifTrue, T ifFalse);\n")
 SLANG_RAW("__generic<T, let N : int> __intrinsic_op(select) vector<T,N> operator?:(vector<bool,N> condition, vector<T,N> ifTrue, vector<T,N> ifFalse);\n")
 SLANG_RAW("\n")
@@ -142,7 +153,7 @@ for (int tt = 0; tt < kBaseTypeCount; ++tt)
         // TODO: should this cover the full gamut of integer types?
     case BaseType::Int:
     case BaseType::UInt:
-SLANG_RAW("#line 145 \"core.meta.slang\"")
+SLANG_RAW("#line 153 \"core.meta.slang\"")
 SLANG_RAW("\n")
 SLANG_RAW("        __generic<T:__EnumType>\n")
 SLANG_RAW("        __init(T value);\n")
@@ -158,7 +169,7 @@ SLANG_RAW("        __init(T value);\n")
 
 // Declare built-in pointer type
 // (eventually we can have the traditional syntax sugar for this)
-SLANG_RAW("#line 160 \"core.meta.slang\"")
+SLANG_RAW("#line 168 \"core.meta.slang\"")
 SLANG_RAW("\n")
 SLANG_RAW("\n")
 SLANG_RAW("__generic<T>\n")
@@ -220,7 +231,7 @@ sb << "    __init(T value);\n";
 sb << "    __init(vector<T,N> value);\n";
 
 sb << "};\n";
-SLANG_RAW("#line 206 \"core.meta.slang\"")
+SLANG_RAW("#line 214 \"core.meta.slang\"")
 SLANG_RAW("\n")
 SLANG_RAW("\n")
 SLANG_RAW("__generic<T = float, let R : int = 4, let C : int = 4>\n")
@@ -974,7 +985,6 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
 
                 sb << "__target_intrinsic(glsl, \"$ctextureGrad($p, $2, $3, $4)$z\")\n";
-//                sb << "__intrinsic_op(sampleGrad)\n";
                 sb << "T SampleGrad(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount << " gradX, ";
@@ -984,7 +994,6 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     sb << "__target_intrinsic(glsl, \"$ctextureGradOffset($p, $2, $3, $4, $5)$z\")\n";
-//                    sb << "__intrinsic_op(sampleGrad)\n";
                     sb << "T SampleGrad(SamplerState s, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                     sb << "float" << kBaseTextureTypes[tt].coordCount << " gradX, ";
@@ -1176,7 +1185,7 @@ for (auto op : binaryOps)
         switch (op.opCode)
         {
         case kIROp_Mul:
-        case kIRPseudoOp_MulAssign:
+        case kCompoundIntrinsicOp_MulAssign:
             break;
 
         default:
@@ -1207,7 +1216,7 @@ for (auto op : binaryOps)
         sb << "__intrinsic_op(" << int(op.opCode) << ") matrix<" << resultType << ",N,M> operator" << op.opName << "(" << leftQual << "matrix<" << leftType << ",N,M> left, " << rightType << " right);\n";
     }
 }
-SLANG_RAW("#line 1192 \"core.meta.slang\"")
+SLANG_RAW("#line 1198 \"core.meta.slang\"")
 SLANG_RAW("\n")
 SLANG_RAW("\n")
 SLANG_RAW("// Operators to apply to `enum` types\n")

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -393,13 +393,13 @@ __target_intrinsic(glsl, "uintBitsToFloat")
 vector<float,N> asfloat(vector<uint,N> x);
 
 // No op
-__intrinsic_op($(kIRPseudoOp_Pos))
+__intrinsic_op($(kCompoundIntrinsicOp_Pos))
 float asfloat(float x);
 __generic<let N : int>
-__intrinsic_op($(kIRPseudoOp_Pos))
+__intrinsic_op($(kCompoundIntrinsicOp_Pos))
 vector<float,N> asfloat(vector<float,N> x);
 __generic<let N : int, let M : int>
-__intrinsic_op($(kIRPseudoOp_Pos))
+__intrinsic_op($(kCompoundIntrinsicOp_Pos))
 matrix<float,N,M> asfloat(matrix<float,N,M> x);
 
 // Pass thru to HLSL
@@ -430,13 +430,13 @@ __target_intrinsic(glsl, "ivec$N0($0)")
 vector<int,N> asint(vector<uint,N> x);
 
 // No op
-__intrinsic_op($(kIRPseudoOp_Pos))
+__intrinsic_op($(kCompoundIntrinsicOp_Pos))
 int asint(int x);
 __generic<let N : int>
-__intrinsic_op($(kIRPseudoOp_Pos))
+__intrinsic_op($(kCompoundIntrinsicOp_Pos))
 vector<int,N> asint(vector<int,N> x);
 __generic<let N : int, let M : int>
-__intrinsic_op($(kIRPseudoOp_Pos))
+__intrinsic_op($(kCompoundIntrinsicOp_Pos))
 matrix<int,N,M> asint(matrix<int,N,M> x);
 
 // Pass thru HLSL
@@ -473,13 +473,13 @@ __target_intrinsic(glsl, "uvec$N0($0)")
 vector<uint,N> asuint(vector<int,N> x);
 
 // No op
-__intrinsic_op($(kIRPseudoOp_Pos))
+__intrinsic_op($(kCompoundIntrinsicOp_Pos))
 uint asuint(uint x);
 __generic<let N : int>
-__intrinsic_op($(kIRPseudoOp_Pos))
+__intrinsic_op($(kCompoundIntrinsicOp_Pos))
 vector<uint,N> asuint(vector<uint,N> x);
 __generic<let N : int, let M : int>
-__intrinsic_op($(kIRPseudoOp_Pos))
+__intrinsic_op($(kCompoundIntrinsicOp_Pos))
 matrix<uint,N,M> asuint(matrix<uint,N,M> x);
 
 // Pass thru HLSL
@@ -1431,7 +1431,7 @@ for(auto op : binaryOps)
         continue;
 
     case kIROp_Mul:
-    case kIRPseudoOp_MulAssign:
+    case kCompoundIntrinsicOp_MulAssign:
         break;
     }
 

--- a/source/slang/hlsl.meta.slang.h
+++ b/source/slang/hlsl.meta.slang.h
@@ -443,19 +443,19 @@ SLANG_RAW("vector<float,N> asfloat(vector<uint,N> x);\n")
 SLANG_RAW("\n")
 SLANG_RAW("// No op\n")
 SLANG_RAW("__intrinsic_op(")
-SLANG_SPLICE(kIRPseudoOp_Pos
+SLANG_SPLICE(kCompoundIntrinsicOp_Pos
 )
 SLANG_RAW(")\n")
 SLANG_RAW("float asfloat(float x);\n")
 SLANG_RAW("__generic<let N : int>\n")
 SLANG_RAW("__intrinsic_op(")
-SLANG_SPLICE(kIRPseudoOp_Pos
+SLANG_SPLICE(kCompoundIntrinsicOp_Pos
 )
 SLANG_RAW(")\n")
 SLANG_RAW("vector<float,N> asfloat(vector<float,N> x);\n")
 SLANG_RAW("__generic<let N : int, let M : int>\n")
 SLANG_RAW("__intrinsic_op(")
-SLANG_SPLICE(kIRPseudoOp_Pos
+SLANG_SPLICE(kCompoundIntrinsicOp_Pos
 )
 SLANG_RAW(")\n")
 SLANG_RAW("matrix<float,N,M> asfloat(matrix<float,N,M> x);\n")
@@ -489,19 +489,19 @@ SLANG_RAW("vector<int,N> asint(vector<uint,N> x);\n")
 SLANG_RAW("\n")
 SLANG_RAW("// No op\n")
 SLANG_RAW("__intrinsic_op(")
-SLANG_SPLICE(kIRPseudoOp_Pos
+SLANG_SPLICE(kCompoundIntrinsicOp_Pos
 )
 SLANG_RAW(")\n")
 SLANG_RAW("int asint(int x);\n")
 SLANG_RAW("__generic<let N : int>\n")
 SLANG_RAW("__intrinsic_op(")
-SLANG_SPLICE(kIRPseudoOp_Pos
+SLANG_SPLICE(kCompoundIntrinsicOp_Pos
 )
 SLANG_RAW(")\n")
 SLANG_RAW("vector<int,N> asint(vector<int,N> x);\n")
 SLANG_RAW("__generic<let N : int, let M : int>\n")
 SLANG_RAW("__intrinsic_op(")
-SLANG_SPLICE(kIRPseudoOp_Pos
+SLANG_SPLICE(kCompoundIntrinsicOp_Pos
 )
 SLANG_RAW(")\n")
 SLANG_RAW("matrix<int,N,M> asint(matrix<int,N,M> x);\n")
@@ -541,19 +541,19 @@ SLANG_RAW("vector<uint,N> asuint(vector<int,N> x);\n")
 SLANG_RAW("\n")
 SLANG_RAW("// No op\n")
 SLANG_RAW("__intrinsic_op(")
-SLANG_SPLICE(kIRPseudoOp_Pos
+SLANG_SPLICE(kCompoundIntrinsicOp_Pos
 )
 SLANG_RAW(")\n")
 SLANG_RAW("uint asuint(uint x);\n")
 SLANG_RAW("__generic<let N : int>\n")
 SLANG_RAW("__intrinsic_op(")
-SLANG_SPLICE(kIRPseudoOp_Pos
+SLANG_SPLICE(kCompoundIntrinsicOp_Pos
 )
 SLANG_RAW(")\n")
 SLANG_RAW("vector<uint,N> asuint(vector<uint,N> x);\n")
 SLANG_RAW("__generic<let N : int, let M : int>\n")
 SLANG_RAW("__intrinsic_op(")
-SLANG_SPLICE(kIRPseudoOp_Pos
+SLANG_SPLICE(kCompoundIntrinsicOp_Pos
 )
 SLANG_RAW(")\n")
 SLANG_RAW("matrix<uint,N,M> asuint(matrix<uint,N,M> x);\n")
@@ -1507,7 +1507,7 @@ for(auto op : binaryOps)
         continue;
 
     case kIROp_Mul:
-    case kIRPseudoOp_MulAssign:
+    case kCompoundIntrinsicOp_MulAssign:
         break;
     }
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -80,7 +80,7 @@ namespace Slang
 
     struct OperatorOverloadCacheKey
     {
-        IROp operatorName;
+        intptr_t operatorName;
         BasicTypeKey args[2];
         bool operator == (OperatorOverloadCacheKey key)
         {

--- a/source/slang/slang-compound-intrinsics.h
+++ b/source/slang/slang-compound-intrinsics.h
@@ -1,0 +1,73 @@
+// slang-compound-intrinsics.h
+
+// Intrinsic functions in the Slang standard library are marked
+// with the `__intrinsic_op(...)` modifier. Many of these map
+// one-to-one to instruction opcodes in the Slang IR, and the
+// argument to `__intrinsic_op(...)` is the IR instruction
+// opcode in that case.
+//
+// In other cases, we have intrinsic operations like the `+=` or
+// `&&` operator that either need to map to multiple IR instructions
+// (or more generally, a number of instructions not equal to one),
+// or otherwise have complications thake one-to-one lowering
+// not possible.
+//
+// We refer to these as "compound" intrinsic ops, since the common
+// case is that they represent a composition of multiple instructions.
+//
+// In order to not conflict with the opcodes of any IR instructions,
+// these compound intrinsic ops will all be identified by *negative*
+// integer opcodes.
+
+// We start by defining an "X-macro" that lists all the compound
+// intrinsic ops we support.
+
+#define FOREACH_COMPOUND_INTRINSIC_OP(M) \
+    M(Pos)                   \
+    M(PreInc)                \
+    M(PreDec)                \
+    M(PostInc)               \
+    M(PostDec)               \
+    M(Sequence)              \
+    M(AddAssign)             \
+    M(SubAssign)             \
+    M(MulAssign)             \
+    M(DivAssign)             \
+    M(IRemAssign)            \
+    M(FRemAssign)            \
+    M(AndAssign)             \
+    M(OrAssign)              \
+    M(XorAssign )            \
+    M(LshAssign)             \
+    M(RshAssign)             \
+    M(Assign)                \
+    M(And)                   \
+    M(Or)                    \
+    /* end */
+
+// Next we use an enumeration declaration as an implementation
+// detail, to associate each of the above cases with a (positive)
+// integer.
+//
+enum class _CompoundIntrinsicOpVal
+{
+#define DECLARE_COMPOUND_INTRINSIC_OP_VAL(NAME) NAME,
+    FOREACH_COMPOUND_INTRINSIC_OP(DECLARE_COMPOUND_INTRINSIC_OP_VAL)
+#undef DECLARE_COMPOUND_INTRINSIC_OP_VAL
+};
+
+// Finally, we define a second enumeration that takes the values
+// from the first and performs a bitwise negation on them, which
+// guarantees we get strictly negative values.
+
+    /// Compound/complex intrinsic operations, which do not map to a single IR instruction.
+    ///
+    /// All of the values of this enumeration are guaranteed to be negative, and thus
+    /// cannot conflict with any valid value of type `IROp`
+    ///
+enum CompoundIntrinsicOp : int32_t
+{
+#define DECLARE_COMPOUND_INTRINSIC_OP(NAME) kCompoundIntrinsicOp_##NAME = ~int32_t(_CompoundIntrinsicOpVal::NAME),
+    FOREACH_COMPOUND_INTRINSIC_OP(DECLARE_COMPOUND_INTRINSIC_OP)
+#undef DECLARE_COMPOUND_INTRINSIC_OP
+};

--- a/source/slang/slang-compound-intrinsics.h
+++ b/source/slang/slang-compound-intrinsics.h
@@ -1,4 +1,5 @@
 // slang-compound-intrinsics.h
+#pragma once
 
 // Intrinsic functions in the Slang standard library are marked
 // with the `__intrinsic_op(...)` modifier. Many of these map
@@ -45,11 +46,18 @@
     M(Or)                    \
     /* end */
 
+// We will use a simple type alias to capture the fact that
+// a 32-bit integer is sufficient to represent compound
+// intrinsic ops (as negative values) plus IR opcode values
+// for single-instruction intrinsics (as non-negative values)
+//
+typedef int32_t IntrinsicOp;
+
 // Next we use an enumeration declaration as an implementation
 // detail, to associate each of the above cases with a (positive)
 // integer.
 //
-enum class _CompoundIntrinsicOpVal
+enum class _CompoundIntrinsicOpVal : IntrinsicOp
 {
 #define DECLARE_COMPOUND_INTRINSIC_OP_VAL(NAME) NAME,
     FOREACH_COMPOUND_INTRINSIC_OP(DECLARE_COMPOUND_INTRINSIC_OP_VAL)
@@ -65,9 +73,9 @@ enum class _CompoundIntrinsicOpVal
     /// All of the values of this enumeration are guaranteed to be negative, and thus
     /// cannot conflict with any valid value of type `IROp`
     ///
-enum CompoundIntrinsicOp : int32_t
+enum CompoundIntrinsicOp : IntrinsicOp
 {
-#define DECLARE_COMPOUND_INTRINSIC_OP(NAME) kCompoundIntrinsicOp_##NAME = ~int32_t(_CompoundIntrinsicOpVal::NAME),
+#define DECLARE_COMPOUND_INTRINSIC_OP(NAME) kCompoundIntrinsicOp_##NAME = ~IntrinsicOp(_CompoundIntrinsicOpVal::NAME),
     FOREACH_COMPOUND_INTRINSIC_OP(DECLARE_COMPOUND_INTRINSIC_OP)
 #undef DECLARE_COMPOUND_INTRINSIC_OP
 };

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -8,10 +8,6 @@
 #define INST_RANGE(BASE, FIRST, LAST) /* empty */
 #endif
 
-#ifndef PSEUDO_INST
-#define PSEUDO_INST(ID) /* empty */
-#endif
-
 #define PARENT kIROpFlag_Parent
 #define USE_OTHER kIROpFlag_UseOther
 
@@ -516,30 +512,6 @@ INST_RANGE(Layout, VarLayout, EntryPointLayout)
     INST_RANGE(LayoutResourceInfoAttr, TypeSizeAttr, VarOffsetAttr)
 INST_RANGE(Attr, PendingLayoutAttr, VarOffsetAttr)
 
-PSEUDO_INST(Pos)
-PSEUDO_INST(PreInc)
-
-PSEUDO_INST(PreDec)
-PSEUDO_INST(PostInc)
-PSEUDO_INST(PostDec)
-PSEUDO_INST(Sequence)
-PSEUDO_INST(AddAssign)
-PSEUDO_INST(SubAssign)
-PSEUDO_INST(MulAssign)
-PSEUDO_INST(DivAssign)
-PSEUDO_INST(IRemAssign)
-PSEUDO_INST(FRemAssign)
-PSEUDO_INST(AndAssign)
-PSEUDO_INST(OrAssign)
-PSEUDO_INST(XorAssign )
-PSEUDO_INST(LshAssign)
-PSEUDO_INST(RshAssign)
-PSEUDO_INST(Assign)
-PSEUDO_INST(And)
-PSEUDO_INST(Or)
-
-
-#undef PSEUDO_INST
 #undef PARENT
 #undef USE_OTHER
 #undef INST_RANGE

--- a/source/slang/slang-ir-serialize.cpp
+++ b/source/slang/slang-ir-serialize.cpp
@@ -12,13 +12,13 @@ namespace Slang {
 
 static bool _isTextureTypeBase(IROp opIn)
 {
-    const int op = (kIROpMeta_PseudoOpMask & opIn);
+    const int op = (kIROpMeta_OpMask & opIn);
     return op >= kIROp_FirstTextureTypeBase && op <= kIROp_LastTextureTypeBase;
 }
 
 static bool _isConstant(IROp opIn)
 {
-    const int op = (kIROpMeta_PseudoOpMask & opIn);
+    const int op = (kIROpMeta_OpMask & opIn);
     return op >= kIROp_FirstConstant && op <= kIROp_LastConstant;
 }
 
@@ -293,9 +293,6 @@ Result IRSerialWriter::write(IRModule* module, SourceManager* sourceManager, Opt
         {
             IRInst* srcInst = m_insts[i];
             Ser::Inst& dstInst = m_serialData->m_insts[i];
-            
-            // Can't be any pseudo ops
-            SLANG_ASSERT(!isPseudoOp(srcInst->op)); 
 
             dstInst.m_op = uint8_t(srcInst->op & kIROpMeta_OpMask);
             dstInst.m_payloadType = PayloadType::Empty;

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -11,7 +11,7 @@ namespace Slang
     struct IRSpecContext;
 
 
-    SLANG_COMPILE_TIME_ASSERT(kIROpCount < kIRPseudoOp_First);
+//    SLANG_COMPILE_TIME_ASSERT(kIROpCount < kCompoundIntrinsicOp_First);
 
     IRInst* cloneGlobalValueWithLinkage(
         IRSpecContext*          context,
@@ -39,31 +39,14 @@ namespace Slang
     { kIROp_##ID, { #MNEMONIC, ARG_COUNT, FLAGS, } },
 #include "slang-ir-inst-defs.h"
 
-    // Pseudo ops
-#define INST(ID, MNEMONIC, ARG_COUNT, FLAGS)  /* empty */
-#define PSEUDO_INST(ID)  \
-    { kIRPseudoOp_##ID, { #ID, 0, 0 } },
-
-    // First is 'invalid' 
+    // Invalid op sentinel value comes after all the valid ones
     { kIROp_Invalid,{ "invalid", 0, 0 } },
-    // Then all the other psuedo ops
-#include "slang-ir-inst-defs.h"
-
     };
 
     IROpInfo getIROpInfo(IROp opIn)
     {
-        const int op = opIn & kIROpMeta_PseudoOpMask;
-        if ((op & kIROpMeta_IsPseudoOp) && op < kIRPseudoOp_LastPlusOne)
-        {
-            // It's a pseudo op
-            const int index = op - kIRPseudoOp_First;
-            // Pseudo ops start from kIROpcount
-            const auto& entry =  kIROps[kIROpCount + index];
-            SLANG_ASSERT(entry.op == op);
-            return entry.info;
-        }
-        else if (op < kIROpCount)
+        const int op = opIn & kIROpMeta_OpMask;
+        if (op < kIROpCount)
         {
             // It's a main op
             const auto& entry = kIROps[op];
@@ -4460,8 +4443,8 @@ namespace Slang
             return false;
         }
 
-        const IROp opA = IROp(a->op & kIROpMeta_PseudoOpMask);
-        const IROp opB = IROp(b->op & kIROpMeta_PseudoOpMask);
+        const IROp opA = IROp(a->op & kIROpMeta_OpMask);
+        const IROp opB = IROp(b->op & kIROpMeta_OpMask);
 
         if (opA != opB)
         {

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -10,9 +10,6 @@ namespace Slang
 {
     struct IRSpecContext;
 
-
-//    SLANG_COMPILE_TIME_ASSERT(kIROpCount < kCompoundIntrinsicOp_First);
-
     IRInst* cloneGlobalValueWithLinkage(
         IRSpecContext*          context,
         IRInst*                 originalVal,

--- a/source/slang/slang-modifier-defs.h
+++ b/source/slang/slang-modifier-defs.h
@@ -28,7 +28,6 @@ SIMPLE_MODIFIER(GloballyCoherent)
 #undef SIMPLE_MODIFIER
 
 // A modifier that marks something as an operation that
-// translates to special
 // has a one-to-one translation to the IR, and thus
 // has no direct definition in the high-level language.
 //
@@ -47,7 +46,7 @@ SYNTAX_CLASS(IntrinsicOpModifier, Modifier)
     // which maps to zero or more IR instructions using
     // special-case logic in the IR lowering phase.
     //
-    FIELD_INIT(int32_t, op, 0)
+    FIELD_INIT(IntrinsicOp, op, 0)
 END_SYNTAX_CLASS()
 
 // A modifier that marks something as an intrinsic function,

--- a/source/slang/slang-modifier-defs.h
+++ b/source/slang/slang-modifier-defs.h
@@ -28,16 +28,26 @@ SIMPLE_MODIFIER(GloballyCoherent)
 #undef SIMPLE_MODIFIER
 
 // A modifier that marks something as an operation that
+// translates to special
 // has a one-to-one translation to the IR, and thus
 // has no direct definition in the high-level language.
 //
 SYNTAX_CLASS(IntrinsicOpModifier, Modifier)
 
-    // token that names the intrinsic op
+    // Token that names the intrinsic op.
     FIELD(Token, opToken)
 
-    // The opcode for the intrinsic operation
-    FIELD_INIT(IROp, op, kIROp_Nop)
+    // The opcode for the intrinsic operation.
+    //
+    // If greather than or equal to zero, then `op`
+    // is an `IROp` and directly identifies an IR
+    // instruction that the intrinsic should translate to.
+    //
+    // If less than zero, then `op` is a `CompoundIntrinsicOp`
+    // which maps to zero or more IR instructions using
+    // special-case logic in the IR lowering phase.
+    //
+    FIELD_INIT(int32_t, op, 0)
 END_SYNTAX_CLASS()
 
 // A modifier that marks something as an intrinsic function,

--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -1,6 +1,7 @@
 // slang-stdlib.cpp
 
 #include "slang-compiler.h"
+#include "slang-compound-intrinsics.h"
 #include "slang-ir.h"
 #include "slang-syntax.h"
 
@@ -201,14 +202,14 @@ namespace Slang
     struct OpInfo { int32_t opCode; char const* opName; unsigned flags; };
 
     static const OpInfo unaryOps[] = {
-        { kIRPseudoOp_Pos,     "+",    ARITHMETIC_MASK },
+        { kCompoundIntrinsicOp_Pos,     "+",    ARITHMETIC_MASK },
         { kIROp_Neg,     "-",    ARITHMETIC_MASK },
         { kIROp_Not,     "!",    BOOL_MASK | BOOL_RESULT },
         { kIROp_BitNot,    "~",    INT_MASK        },
-        { kIRPseudoOp_PreInc,  "++",   ARITHMETIC_MASK | ASSIGNMENT },
-        { kIRPseudoOp_PreDec,  "--",   ARITHMETIC_MASK | ASSIGNMENT },
-        { kIRPseudoOp_PostInc, "++",   ARITHMETIC_MASK | ASSIGNMENT | POSTFIX },
-        { kIRPseudoOp_PostDec, "--",   ARITHMETIC_MASK | ASSIGNMENT | POSTFIX },
+        { kCompoundIntrinsicOp_PreInc,  "++",   ARITHMETIC_MASK | ASSIGNMENT },
+        { kCompoundIntrinsicOp_PreDec,  "--",   ARITHMETIC_MASK | ASSIGNMENT },
+        { kCompoundIntrinsicOp_PostInc, "++",   ARITHMETIC_MASK | ASSIGNMENT | POSTFIX },
+        { kCompoundIntrinsicOp_PostDec, "--",   ARITHMETIC_MASK | ASSIGNMENT | POSTFIX },
     };
 
     static const OpInfo binaryOps[] = {
@@ -231,17 +232,17 @@ namespace Slang
         { kIROp_Less,    "<",    ARITHMETIC_MASK | BOOL_RESULT },
         { kIROp_Geq,     ">=",   ARITHMETIC_MASK | BOOL_RESULT },
         { kIROp_Leq,     "<=",   ARITHMETIC_MASK | BOOL_RESULT },
-        { kIRPseudoOp_AddAssign,     "+=",    ASSIGNMENT | ARITHMETIC_MASK },
-        { kIRPseudoOp_SubAssign,     "-=",    ASSIGNMENT | ARITHMETIC_MASK },
-        { kIRPseudoOp_MulAssign,     "*=",    ASSIGNMENT | ARITHMETIC_MASK },
-        { kIRPseudoOp_DivAssign,     "/=",    ASSIGNMENT | ARITHMETIC_MASK },
-        { kIRPseudoOp_IRemAssign,    "%=",    ASSIGNMENT | INT_MASK },
-        { kIRPseudoOp_FRemAssign,    "%=",    ASSIGNMENT | FLOAT_MASK },
-        { kIRPseudoOp_AndAssign,     "&=",    ASSIGNMENT | LOGICAL_MASK },
-        { kIRPseudoOp_OrAssign,      "|=",    ASSIGNMENT | LOGICAL_MASK },
-        { kIRPseudoOp_XorAssign,     "^=",    ASSIGNMENT | LOGICAL_MASK },
-        { kIRPseudoOp_LshAssign,     "<<=",   ASSIGNMENT | INT_MASK },
-        { kIRPseudoOp_RshAssign,     ">>=",   ASSIGNMENT | INT_MASK },
+        { kCompoundIntrinsicOp_AddAssign,     "+=",    ASSIGNMENT | ARITHMETIC_MASK },
+        { kCompoundIntrinsicOp_SubAssign,     "-=",    ASSIGNMENT | ARITHMETIC_MASK },
+        { kCompoundIntrinsicOp_MulAssign,     "*=",    ASSIGNMENT | ARITHMETIC_MASK },
+        { kCompoundIntrinsicOp_DivAssign,     "/=",    ASSIGNMENT | ARITHMETIC_MASK },
+        { kCompoundIntrinsicOp_IRemAssign,    "%=",    ASSIGNMENT | INT_MASK },
+        { kCompoundIntrinsicOp_FRemAssign,    "%=",    ASSIGNMENT | FLOAT_MASK },
+        { kCompoundIntrinsicOp_AndAssign,     "&=",    ASSIGNMENT | LOGICAL_MASK },
+        { kCompoundIntrinsicOp_OrAssign,      "|=",    ASSIGNMENT | LOGICAL_MASK },
+        { kCompoundIntrinsicOp_XorAssign,     "^=",    ASSIGNMENT | LOGICAL_MASK },
+        { kCompoundIntrinsicOp_LshAssign,     "<<=",   ASSIGNMENT | INT_MASK },
+        { kCompoundIntrinsicOp_RshAssign,     ">>=",   ASSIGNMENT | INT_MASK },
     };
 
     String Session::getCoreLibraryCode()

--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -199,7 +199,7 @@ namespace Slang
         }
     }
 
-    struct OpInfo { int32_t opCode; char const* opName; unsigned flags; };
+    struct OpInfo { IntrinsicOp opCode; char const* opName; unsigned flags; };
 
     static const OpInfo unaryOps[] = {
         { kCompoundIntrinsicOp_Pos,     "+",    ARITHMETIC_MASK },

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -2,7 +2,7 @@
 #define SLANG_SYNTAX_H
 
 #include "../core/slang-basic.h"
-#include "slang-ir.h"
+#include "slang-compound-intrinsics.h"
 #include "slang-lexer.h"
 #include "slang-profile.h"
 #include "slang-type-system-shared.h"

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -193,6 +193,7 @@
     <ClInclude Include="slang-check-impl.h" />
     <ClInclude Include="slang-check.h" />
     <ClInclude Include="slang-compiler.h" />
+    <ClInclude Include="slang-compound-intrinsics.h" />
     <ClInclude Include="slang-decl-defs.h" />
     <ClInclude Include="slang-diagnostic-defs.h" />
     <ClInclude Include="slang-diagnostics.h" />
@@ -337,7 +338,7 @@
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"../../bin/windows-x64/debug/slang-generate" %(Identity)</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"../../bin/windows-x86/release/slang-generate" %(Identity)</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"../../bin/windows-x64/release/slang-generate" %(Identity)</Command>
-      <Outputs>%(Identity).h</Outputs>
+      <Outputs>../../core.meta.slang.h</Outputs>
       <Message>slang-generate %(Identity)</Message>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">../../bin/windows-x86/debug/slang-generate.exe</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">../../bin/windows-x64/debug/slang-generate.exe</AdditionalInputs>
@@ -350,7 +351,7 @@
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"../../bin/windows-x64/debug/slang-generate" %(Identity)</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"../../bin/windows-x86/release/slang-generate" %(Identity)</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"../../bin/windows-x64/release/slang-generate" %(Identity)</Command>
-      <Outputs>%(Identity).h</Outputs>
+      <Outputs>../../hlsl.meta.slang.h</Outputs>
       <Message>slang-generate %(Identity)</Message>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">../../bin/windows-x86/debug/slang-generate.exe</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">../../bin/windows-x64/debug/slang-generate.exe</AdditionalInputs>

--- a/source/slang/slang.vcxproj.filters
+++ b/source/slang/slang.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="slang-compiler.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="slang-compound-intrinsics.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="slang-decl-defs.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
Built-in functions in the Slang standard library can be marked with `__intrinsic_op(...)` to indicate that they should not lower to functions in the IR, and that instead call sites to those functions should be translated directly to the IR.
There are two cases where `__intrinsic_op(...)` gets used:

1. In the case where the argument to `__intrinsic_op(...)` is an actual IR instruction opcode, the IR lowering logic directly translates a call into an instruction with the given opcode. The arguments to the call become the operands of the instruction.

2. In the case where the argument to `__intrinsic_op(...)` is one of a set of "pseudo" instruction opcodes, the IR lowering logic directly handles the lowering to IR with dedicated code. The operands to the call might be handled differently depending on the kind of operation.

The compound operators like `+=` are the most important example of these "pseudo" instructions.
It doesn't make sense to handle them as true function calls (although that would work semantically), nor does it make sense to have a single IR instruction with such complicated semantics.

An earlier version of the compiler used the same enumeration for both the true IR instruction opcodes and these "pseudo" opcodes, with the simple constraint that the pseudo opcodes were all negative while the real opcodes were positive. That design got changed up over a few refactorings, and because there was never a good explanation in the code itself of what "pseudo" opcodes were, we eventually ended up in a place where the in-memory and serialized IR encodings included logic to try to deal with the possibility of these "pseudo" opcodes, even though the entire design of the lowering pass meant that they'd never appear in generated IR.

This change tries to clean up the mess in a few ways:

* The terminology is now that these are "compound" intrinsic ops, to differentiate them from the more common case of intrinsic ops that map one-to-one to IR instructions.

* The declaration of the compound intrinsic ops is no longer in a file related to the IR, and doesn't use the `IR` naming prefix, so somebody looking at the IR opcodes cannot become confused and think the compound ops are allowed there.

* The IR encoding in memory and when serialized is updated to not account for or worry about the possibility of "pseudo" ops.

* The compound ops are declared in such a way that ensures their enumerant values are all negative, so that they are yet again trivially disjoint from the true IR opcodes.

A more drastic change might have split `__intrinsic_op` into two different modifier types: one for the trivial single-instruction case and one for the compound case.
Doing this would make the change more invasive, though, because there are places in the meta-code that generates the standard library that intentionally handle both single-instruction and compound ops (because built-in operators can translate to either case).