### PR TITLE
Added -dump-intermediate-prefix option

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -1198,6 +1198,10 @@ extern "C"
         SlangCompileRequest*    request,
         int                     enable);
 
+    SLANG_API void spSetDumpIntermediatePrefix(
+        SlangCompileRequest*    request,
+        const char* prefix);
+
     /*!
     @brief Set whether (and how) `#line` directives should be output.
     */

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -2472,7 +2472,7 @@ SlangResult dissassembleDXILUsingDXC(
     //
 
     void dumpIntermediate(
-        BackEndCompileRequest*,
+        BackEndCompileRequest* request,
         void const*     data,
         size_t          size,
         char const*     ext,
@@ -2494,7 +2494,7 @@ SlangResult dissassembleDXILUsingDXC(
 #endif
 
         String path;
-        path.append("slang-dump-");
+        path.append(request->m_dumpIntermediatePrefix);
         path.append(id);
         path.append(ext);
 

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1703,6 +1703,8 @@ namespace Slang
             /// Should SPIR-V be generated directly from Slang IR rather than via translation to GLSL?
         bool shouldEmitSPIRVDirectly = false;
 
+        String m_dumpIntermediatePrefix;
+
     private:
         RefPtr<ComponentType> m_program;
     };

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -109,7 +109,6 @@ DIAGNOSTIC(    70, Error, cannotMatchOutputFileToEntryPoint, "the output path '$
 
 DIAGNOSTIC(    80, Error, duplicateOutputPathsForEntryPointAndTarget, "multiple output paths have been specified entry point '$0' on target '$1'")
 
-DIAGNOSTIC(    81, Error, parametersAfterLoadReproIgnored, "parameters after -load-repro [file] are ignored")
 DIAGNOSTIC(    82, Error, unableToWriteReproFile, "unable to write repro file '%0'");
 DIAGNOSTIC(    83, Error, unableToWriteModuleContainer, "unable to write module container '%0'");
 DIAGNOSTIC(    84, Error, unableToReadModuleContainer, "unable to read module container '%0'");

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -512,6 +512,8 @@ struct OptionsParser
 
         SlangMatrixLayoutMode defaultMatrixLayoutMode = SLANG_MATRIX_LAYOUT_MODE_UNKNOWN;
 
+        bool hasLoadedRepro = false;
+
         char const* const* argCursor = &argv[0];
         char const* const* argEnd = &argv[argc];
         while (argCursor != argEnd)
@@ -592,6 +594,8 @@ struct OptionsParser
                     }
 
                     SLANG_RETURN_ON_FAIL(StateSerializeUtil::load(base, requestState, fileSystem, requestImpl));
+
+                    hasLoadedRepro = true;
                 }
                 else if (argStr == "-repro-file-system")
                 {
@@ -1051,6 +1055,15 @@ struct OptionsParser
             {
                 SLANG_RETURN_ON_FAIL(addInputPath(arg));
             }
+        }
+
+        // TODO(JS): This is a restriction because of how setting of state works for load repro
+        // If a repro has been loaded, then many of the following options will overwrite
+        // what was set up. So for now they are ignored, and only parameters set as part
+        // of the loop work if they are after -load-repro
+        if (hasLoadedRepro)
+        {
+            return SLANG_OK;
         }
 
         spSetCompileFlags(compileRequest, flags);

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -533,6 +533,12 @@ struct OptionsParser
                 {
                     spSetDumpIntermediates(compileRequest, true);
                 }
+                else if (argStr == "-dump-intermediate-prefix")
+                {
+                    String prefix;
+                    SLANG_RETURN_ON_FAIL(tryReadCommandLineArgument(sink, arg, &argCursor, argEnd, prefix));
+                    requestImpl->getBackEndReq()->m_dumpIntermediatePrefix = prefix;
+                }
                 else if(argStr == "-dump-ir" )
                 {
                     requestImpl->getFrontEndReq()->shouldDumpIR = true;
@@ -586,14 +592,6 @@ struct OptionsParser
                     }
 
                     SLANG_RETURN_ON_FAIL(StateSerializeUtil::load(base, requestState, fileSystem, requestImpl));
-
-                    if (argCursor < argEnd)
-                    {
-                        sink->diagnose(SourceLoc(), Diagnostics::parametersAfterLoadReproIgnored);
-                        return SLANG_FAIL;
-                    }
-
-                    return SLANG_OK;
                 }
                 else if (argStr == "-repro-file-system")
                 {

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -1265,6 +1265,7 @@ BackEndCompileRequest::BackEndCompileRequest(
     ComponentType*  program)
     : CompileRequestBase(linkage, sink)
     , m_program(program)
+    , m_dumpIntermediatePrefix("slang-dump-")
 {}
 
 EndToEndCompileRequest::EndToEndCompileRequest(
@@ -2878,6 +2879,13 @@ SLANG_API void spSetDumpIntermediates(
     int                     enable)
 {
     Slang::asInternal(request)->getBackEndReq()->shouldDumpIntermediates = enable != 0;
+}
+
+SLANG_API void spSetDumpIntermediatePrefix(
+    SlangCompileRequest*    request,
+    const char* prefix)
+{
+    Slang::asInternal(request)->getBackEndReq()->m_dumpIntermediatePrefix = prefix; 
 }
 
 SLANG_API void spSetLineDirectiveMode(


### PR DESCRIPTION
* Added ability to name the prefix for intermediates
* Allowed parameters after -load-repro - as pretty useful if somewhat risky thing to do (depending on parameters)