### PR TITLE
Add a custom RTTI implementation for the AST

### DIFF
--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -85,6 +85,15 @@ bool SyntaxClassBase::isSubClassOfImpl(SyntaxClassBase const& super) const
     return false;
 }
 
+NodeBase* _dynamicCastImpl(NodeBase* node, SyntaxClassBase const& toClass)
+{
+    if(!node) return nullptr;
+    if(node->getClass().isSubClassOfImpl(toClass))
+        return node;
+    return nullptr;
+}
+
+
 void Type::accept(IValVisitor* visitor, void* extra)
 {
     accept((ITypeVisitor*)visitor, extra);

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -12,7 +12,7 @@ namespace Slang
 
     bool BasicExpressionType::EqualsImpl(Type * type)
     {
-        auto basicType = dynamicCast<const BasicExpressionType>(type);
+        auto basicType = as<BasicExpressionType>(type);
         return basicType && basicType->baseType == this->baseType;
     }
 

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -541,6 +541,24 @@ namespace Slang
         return SyntaxClass<T>::getClass();
     }
 
+    template<typename T>
+    T* dynamicCast(NodeBase* node)
+    {
+        if(!node) return nullptr;
+        if(node->getClass().isSubClassOf<T>())
+            return (T*) node;
+        return nullptr;
+    }
+
+    template<typename T>
+    const T* dynamicCast(const NodeBase* node) { return dynamicCast<T>(const_cast<NodeBase*>(node)); }
+
+    template<typename T>
+    T* as(NodeBase* node) { return dynamicCast<T>(node); }
+
+    template<typename T>
+    const T* as(const NodeBase* node) { return dynamicCast<T>(const_cast<NodeBase*>(node)); }
+
     struct SubstitutionSet
     {
         RefPtr<Substitutions> substitutions;

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -541,13 +541,12 @@ namespace Slang
         return SyntaxClass<T>::getClass();
     }
 
+    NodeBase* _dynamicCastImpl(NodeBase* node, SyntaxClassBase const& toClass);
+
     template<typename T>
     T* dynamicCast(NodeBase* node)
     {
-        if(!node) return nullptr;
-        if(node->getClass().isSubClassOf<T>())
-            return (T*) node;
-        return nullptr;
+        return (T*) _dynamicCastImpl(node, getClass<T>());
     }
 
     template<typename T>


### PR DESCRIPTION
Profiling was showing that the internal routines behind `dynamic_cast` were the worst offenders in the whole codebase, and a lot of this was being driven by casting inside the semantic checking logic.

This change takes advantage of the fact that we *already* had a custom RTTI structure built up for the classes of syntax nodes that was previously being used to implement string->class lookup and factory services to support "magic" types and modifier in the stdlib (e.g., the way that a modifier declaration in the stdlib just lists the *name* of a C++ class that should be instantiated for it).

That RTTI information already included a pointer from each syntax class to its base class (if any), based on the restriction that the AST node types form a single-inheritance hierarchy.
The existing code already had a virtual `getClass()` routine on AST nodes, and an `isSubClassOf` query on the class information.
Putting those pieces together to implement the `dynamicCast` and `as` routines was a cinch.

The work in previous PRs to layer an abstraction over all the existing `dynamic_cast` call sites and to support type-specific `dynamicCast` implementations inside `RefPtr<>` pays off greatly here.