### PR TITLE
Fix GenericCCPP compiler not being found

### DIFF
--- a/source/slang/slang-check.cpp
+++ b/source/slang/slang-check.cpp
@@ -126,17 +126,15 @@ namespace Slang
 
         // Do we have a locator
         auto locator = m_downstreamCompilerLocators[int(type)];
-        if (!locator)
+        if (locator)
         {
-            return nullptr;
+            m_downstreamCompilerSet->remove(SlangPassThrough(type));
+
+            SinkSharedLibraryLoader loader(m_sharedLibraryLoader, sink);
+            locator(m_downstreamCompilerPaths[int(type)], &loader, m_downstreamCompilerSet);
+
+            DownstreamCompilerUtil::updateDefaults(m_downstreamCompilerSet);
         }
-
-        m_downstreamCompilerSet->remove(SlangPassThrough(type));
-
-        SinkSharedLibraryLoader loader(m_sharedLibraryLoader, sink);
-        locator(m_downstreamCompilerPaths[int(type)], &loader, m_downstreamCompilerSet);
-
-        DownstreamCompilerUtil::updateDefaults(m_downstreamCompilerSet);
 
         if (type == PassThroughMode::GenericCCpp)
         {


### PR DESCRIPTION
If a locator is not set for a SlangPassThrough type, that doesn't *necessarily* mean that there isn't a suitable DownstreamCompiler. 

For example with the GENERIC_C_CPP option - it relies on *other* DownstreamCompilers to be present. This could also be fixed by say giving this type an empty locator, or special casing. The option chosen here, is to allow lookup even if there isn't a locator. Note that there is some special case handling, where a generic lookup, will prime all of the specific types.