### PR TITLE
Fix scoping issue around use of IRTypeSet

### DIFF
--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -197,18 +197,15 @@ static UnownedStringSlice _getCTypeVecPostFix(IROp op)
 
 void CPPSourceEmitter::emitTypeDefinition(IRType* inType)
 {
+#if 0
     if (m_target == CodeGenTarget::CPPSource)
     {
         // All types are templates in C++
         return;
     }
+#endif
 
     IRType* type = m_typeSet.getType(inType);
-    if (m_typeEmittedMap.TryGetValue(type))
-    {
-        return;
-    }
-
     if (!m_typeSet.isOwned(type))
     {
         // If defined in a different module, we assume they are emitted already. (Assumed to
@@ -249,8 +246,6 @@ void CPPSourceEmitter::emitTypeDefinition(IRType* inType)
 
             writer->dedent();
             writer->emit("};\n\n");
-
-            m_typeEmittedMap.Add(type, true);
             break;
         }
         case kIROp_MatrixType:
@@ -261,8 +256,7 @@ void CPPSourceEmitter::emitTypeDefinition(IRType* inType)
             const auto colCount = int(GetIntVal(matType->getColumnCount()));
 
             IRType* vecType = m_typeSet.addVectorType(matType->getElementType(), colCount);
-            emitTypeDefinition(vecType);
-
+            
             UnownedStringSlice typeName = _getTypeName(type);
             UnownedStringSlice rowTypeName = _getTypeName(vecType);
 
@@ -278,8 +272,6 @@ void CPPSourceEmitter::emitTypeDefinition(IRType* inType)
 
             writer->dedent();
             writer->emit("};\n\n");
-
-            m_typeEmittedMap.Add(type, true);
             break;
         }
         case kIROp_PtrType:
@@ -317,18 +309,6 @@ UnownedStringSlice CPPSourceEmitter::_getTypeName(IRType* inType)
     if (m_typeNameMap.TryGetValue(type, handle))
     {
         return m_slicePool.getSlice(handle);
-    }
-
-    if (type->op == kIROp_MatrixType)
-    {
-        auto matType = static_cast<IRMatrixType*>(type);
-
-        auto elementType = matType->getElementType();
-        const auto rowCount = int(GetIntVal(matType->getRowCount()));
-        const auto colCount = int(GetIntVal(matType->getColumnCount()));
-
-        // Make sure the vector type the matrix is built on is added
-        useType(m_typeSet.addVectorType(elementType, colCount));
     }
 
     StringBuilder builder;
@@ -1210,12 +1190,6 @@ void CPPSourceEmitter::emitSpecializedOperationDefinition(const HLSLIntrinsic* s
 {
     typedef HLSLIntrinsic::Op Op;
 
-    // Check if it's been emitted already, if not add it.
-    if (!m_intrinsicEmittedMap.AddIfNotExists(specOp, true))
-    {
-        return;
-    }
-
     switch (specOp->op)
     {
         case Op::VecMatMul:
@@ -1948,20 +1922,59 @@ bool CPPSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOut
     }
 }
 
+// We want order of built in types (typically output nothing), vector, matrix, other types
+// Types that aren't output have negative indices
+static Index _calcTypeOrder(IRType* a)
+{
+    switch (a->op)
+    {
+        case kIROp_FuncType:
+        {
+            return -2;
+        }
+        case kIROp_VectorType: return 1;
+        case kIROp_MatrixType: return 2;
+        default:
+        {
+            if (as<IRBasicType>(a))
+            {
+                return -1;
+            }
+            return 3;
+        }
+    }
+}
+
 void CPPSourceEmitter::emitPreprocessorDirectivesImpl()
 {
     SourceWriter* writer = getSourceWriter();
 
     writer->emit("\n");
 
-    // Emit the type definitions
-    for (const auto& keyValue : m_typeNameMap)
+    if (m_target == CodeGenTarget::CPPSource)
     {
-        emitTypeDefinition(keyValue.Key);
+        List<IRType*> types;
+        m_typeSet.getTypes(types);
+
+        for (Index i = 0; i < types.getCount(); ++i)
+        {
+            if (_calcTypeOrder(types[i]) < 0)
+            {
+                types.fastRemoveAt(i);
+                --i;
+            }
+        }
+
+        types.sort([&](IRType* a, IRType* b) { return _calcTypeOrder(a) < _calcTypeOrder(b); });
+
+        // Emit the type definitions
+        for (auto type : types)
+        {
+            emitTypeDefinition(type);
+        }
     }
 
     // Emit all the intrinsics that were used
-
     for (const auto& keyValue : m_intrinsicNameMap)
     {
         emitSpecializedOperationDefinition(keyValue.Key);
@@ -2297,6 +2310,11 @@ void CPPSourceEmitter::_emitInitAxisValues(const Int sizeAlongAxis[kThreadGroupA
 
 void CPPSourceEmitter::emitModuleImpl(IRModule* module)
 {
+    // Setup all built in types used in the module
+    m_typeSet.addAllBuiltinTypes(module);
+    // If any matrix types are used, then we need appropriate vector types too.
+    m_typeSet.addVectorForMatrixTypes();
+
     List<EmitAction> actions;
     computeEmitActions(module, actions);
 

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -122,7 +122,9 @@ protected:
     IRTypeSet m_typeSet;
     RefPtr<HLSLIntrinsicOpLookup> m_opLookup;
     HLSLIntrinsicSet m_intrinsicSet;
-    
+
+    HashSet<const HLSLIntrinsic*> m_intrinsicEmitted;
+
     StringSlicePool m_slicePool;
 
     SemanticUsedFlags m_semanticUsedFlags;

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -101,7 +101,7 @@ protected:
     StringSlicePool::Handle _calcFuncName(const HLSLIntrinsic* specOp);
 
     UnownedStringSlice _getTypeName(IRType* type);
-    StringSlicePool::Handle _calcTypeName(IRType* type);
+    //StringSlicePool::Handle _calcTypeName(IRType* type);
 
     SlangResult _calcTypeName(IRType* type, CodeGenTarget target, StringBuilder& out);
 
@@ -123,9 +123,6 @@ protected:
     RefPtr<HLSLIntrinsicOpLookup> m_opLookup;
     HLSLIntrinsicSet m_intrinsicSet;
     
-    Dictionary<IRType*, bool> m_typeEmittedMap;
-    Dictionary<const HLSLIntrinsic*, bool> m_intrinsicEmittedMap;
-
     StringSlicePool m_slicePool;
 
     SemanticUsedFlags m_semanticUsedFlags;

--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -227,6 +227,24 @@ SlangResult CUDASourceEmitter::_calcCUDATypeName(IRType* type, StringBuilder& ou
                 }
             }
 
+#if 0
+            switch (type->op)
+            {
+                case kIROp_HLSLStructuredBufferType:
+                case kIROp_HLSLRWStructuredBufferType:
+                {
+                    auto structuredBufferType = as<IRHLSLStructuredBufferType>(type);
+                    auto elementType = structuredBufferType->getElementType();
+
+                    // Is the same as a pointer to the item
+
+
+
+                }
+                default: break;
+            }
+#endif
+
             // If _getResourceTypePrefix returns something, we assume can output any specialization after it in order.
             {
                 UnownedStringSlice prefix = _getCUDAResourceTypePrefix(type->op);

--- a/source/slang/slang-emit-cuda.h
+++ b/source/slang/slang-emit-cuda.h
@@ -70,6 +70,8 @@ protected:
     UnownedStringSlice _getCUDATypeName(IRType* inType);
     SlangResult _calcCUDATextureTypeName(IRTextureTypeBase* texType, StringBuilder& outName);
 
+
+
     Dictionary<IRType*, StringSlicePool::Handle> m_typeNameMap;
     StringSlicePool m_slicePool;
 

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -466,6 +466,10 @@ String emitEntryPointSourceFromIR(
     desc.effectiveProfile = getEffectiveProfile(entryPoint, targetRequest);
     desc.sourceWriter = &sourceWriter;
 
+    // Define here, because must be in scope longer than the sourceEmitter, as sourceEmitter might reference
+    // items in the linkedIR module
+    LinkedIR linkedIR;
+
     RefPtr<CLikeSourceEmitter> sourceEmitter;
 
     typedef CLikeSourceEmitter::SourceStyle SourceStyle;
@@ -502,8 +506,6 @@ String emitEntryPointSourceFromIR(
         return String();
     }
 
-    // Outside because we want to keep IR in scope whilst we are processing emits
-    LinkedIR linkedIR;
     {
         LinkingAndOptimizationOptions linkingAndOptimizationOptions;
 

--- a/source/slang/slang-ir-type-set.cpp
+++ b/source/slang/slang-ir-type-set.cpp
@@ -23,6 +23,22 @@ IRTypeSet::IRTypeSet(Session* session)
 
 IRTypeSet::~IRTypeSet()
 {
+    _clearTypes();
+}
+
+void IRTypeSet::clear()
+{
+    _clearTypes();
+
+    m_cloneMap.Clear();
+
+    m_module = m_builder.createModule();
+    m_sharedBuilder.module = m_module;
+    m_builder.setInsertInto(m_module->getModuleInst());
+}
+
+void IRTypeSet::_clearTypes()
+{
     List<IRType*> types;
     getTypes(types);
 
@@ -215,7 +231,6 @@ IRType* IRTypeSet::addVectorType(IRType* inElementType, int colsCount)
 
 void IRTypeSet::addVectorForMatrixTypes()
 {
-#if 0
     // Make a copy so we can alter m_types dictionary
     List<IRType*> types;
     getTypes(Kind::Matrix, types);
@@ -225,31 +240,53 @@ void IRTypeSet::addVectorForMatrixTypes()
         IRMatrixType* matType = static_cast<IRMatrixType*>(type);
         m_builder.getVectorType(matType->getElementType(), matType->getColumnCount());
     }
-#endif
+}
+
+static bool _hasNominalOperand(IRInst* inst)
+{
+    const Index operandCount = Index(inst->getOperandCount());
+    auto operands = inst->getOperands();
+
+    for (Index i = 0; i < operandCount; ++i)
+    {
+        IRInst* operand = operands[i].get();
+        if (isNominalOp(operand->op))
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 void IRTypeSet::_addAllBuiltinTypesRec(IRInst* inst)
 {
     for (IRInst* child = inst->getFirstDecorationOrChild(); child; child = child->getNextInst())
     {
+        IRType* type = nullptr;
+
         if (auto vectorType = as<IRVectorType>(child))
         {
-            add(vectorType);
-            continue;
+            type = vectorType;
         }
-        if (auto matrixType = as<IRMatrixType>(child))
+        else if (auto matrixType = as<IRMatrixType>(child))
         {
-            add(matrixType);
-            continue;
+            type = matrixType;
         }
-        _addAllBuiltinTypesRec(child);
+        if (type && !_hasNominalOperand(type))
+        {
+            add(type);
+        }
+        else
+        {
+            _addAllBuiltinTypesRec(child);
+        }
     }
 }
 
 void IRTypeSet::addAllBuiltinTypes(IRModule* module)
 {
-    SLANG_UNUSED(module);
-    //_addAllBuiltinTypesRec(module->getModuleInst());
+    _addAllBuiltinTypesRec(module->getModuleInst());
 }
 
 }

--- a/source/slang/slang-ir-type-set.cpp
+++ b/source/slang/slang-ir-type-set.cpp
@@ -215,6 +215,7 @@ IRType* IRTypeSet::addVectorType(IRType* inElementType, int colsCount)
 
 void IRTypeSet::addVectorForMatrixTypes()
 {
+#if 0
     // Make a copy so we can alter m_types dictionary
     List<IRType*> types;
     getTypes(Kind::Matrix, types);
@@ -224,6 +225,31 @@ void IRTypeSet::addVectorForMatrixTypes()
         IRMatrixType* matType = static_cast<IRMatrixType*>(type);
         m_builder.getVectorType(matType->getElementType(), matType->getColumnCount());
     }
+#endif
+}
+
+void IRTypeSet::_addAllBuiltinTypesRec(IRInst* inst)
+{
+    for (IRInst* child = inst->getFirstDecorationOrChild(); child; child = child->getNextInst())
+    {
+        if (auto vectorType = as<IRVectorType>(child))
+        {
+            add(vectorType);
+            continue;
+        }
+        if (auto matrixType = as<IRMatrixType>(child))
+        {
+            add(matrixType);
+            continue;
+        }
+        _addAllBuiltinTypesRec(child);
+    }
+}
+
+void IRTypeSet::addAllBuiltinTypes(IRModule* module)
+{
+    SLANG_UNUSED(module);
+    //_addAllBuiltinTypesRec(module->getModuleInst());
 }
 
 }

--- a/source/slang/slang-ir-type-set.h
+++ b/source/slang/slang-ir-type-set.h
@@ -50,6 +50,8 @@ public:
     IRType* add(IRType* type);    
     IRType* addVectorType(IRType* elementType, int colsCount);
 
+    void addAllBuiltinTypes(IRModule* module);
+
     void addVectorForMatrixTypes();
 
     void getTypes(List<IRType*>& outTypes) const;
@@ -70,7 +72,8 @@ public:
     ~IRTypeSet();
 
 protected:
-    
+    void _addAllBuiltinTypesRec(IRInst* inst);
+
         // Maps insts from source modules into m_module.
         // NOTE! That nominal types are not cloned, as they are identified by pointer. They are just 
     Dictionary<IRInst*, IRInst*> m_cloneMap;

--- a/source/slang/slang-ir-type-set.h
+++ b/source/slang/slang-ir-type-set.h
@@ -68,11 +68,14 @@ public:
     IRBuilder& getBuilder() { return m_builder; }
     IRModule* getModule() const { return m_module; }
 
+    void clear();
+
     IRTypeSet(Session* session);
     ~IRTypeSet();
 
 protected:
     void _addAllBuiltinTypesRec(IRInst* inst);
+    void _clearTypes();
 
         // Maps insts from source modules into m_module.
         // NOTE! That nominal types are not cloned, as they are identified by pointer. They are just 

--- a/tests/cuda/compile-to-cuda.slang
+++ b/tests/cuda/compile-to-cuda.slang
@@ -1,4 +1,4 @@
-//TEST(smoke):SIMPLE: -target ptx -entry computeMain -stage compute 
+//DISABLE_TEST(smoke):SIMPLE: -target ptx -entry computeMain -stage compute 
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer : register(u0);

--- a/tests/cuda/compile-to-cuda.slang
+++ b/tests/cuda/compile-to-cuda.slang
@@ -1,4 +1,4 @@
-//DISABLE_TEST(smoke):SIMPLE: -target ptx -entry computeMain -stage compute 
+//TEST(smoke):SIMPLE: -target ptx -entry computeMain -stage compute 
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer : register(u0);


### PR DESCRIPTION
* Added 'clear' to IRTypeSet
* Fix scoping issue around the module used in CPPSourceEmitter and IRTypeSet - the IRTypeSet was being dtored after a module it referenced. 
* Removed need to add vector types for matrices on the fly
* Added addAllBuiltinTypes to find all built in types used from a module