### PR TITLE
Cover a few corner cases in reflection API

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -1986,12 +1986,14 @@ extern "C"
 
     SLANG_API SlangReflectionType* spReflectionTypeLayout_GetType(SlangReflectionTypeLayout* type);
     SLANG_API size_t spReflectionTypeLayout_GetSize(SlangReflectionTypeLayout* type, SlangParameterCategory category);
+    SLANG_API int32_t spReflectionTypeLayout_getAlignment(SlangReflectionTypeLayout* type, SlangParameterCategory category);
 
     SLANG_API SlangReflectionVariableLayout* spReflectionTypeLayout_GetFieldByIndex(SlangReflectionTypeLayout* type, unsigned index);
 
     SLANG_API size_t spReflectionTypeLayout_GetElementStride(SlangReflectionTypeLayout* type, SlangParameterCategory category);
     SLANG_API SlangReflectionTypeLayout* spReflectionTypeLayout_GetElementTypeLayout(SlangReflectionTypeLayout* type);
     SLANG_API SlangReflectionVariableLayout* spReflectionTypeLayout_GetElementVarLayout(SlangReflectionTypeLayout* type);
+    SLANG_API SlangReflectionVariableLayout* spReflectionTypeLayout_getContainerVarLayout(SlangReflectionTypeLayout* type);
 
     SLANG_API SlangParameterCategory spReflectionTypeLayout_GetParameterCategory(SlangReflectionTypeLayout* type);
 
@@ -2070,6 +2072,9 @@ extern "C"
         SlangReflectionEntryPoint* entryPoint);
 
     SLANG_API SlangReflectionVariableLayout* spReflectionEntryPoint_getVarLayout(
+        SlangReflectionEntryPoint* entryPoint);
+
+    SLANG_API SlangReflectionVariableLayout* spReflectionEntryPoint_getResultVarLayout(
         SlangReflectionEntryPoint* entryPoint);
 
     SLANG_API int spReflectionEntryPoint_hasDefaultConstantBuffer(
@@ -2346,6 +2351,11 @@ namespace slang
             return spReflectionTypeLayout_GetSize((SlangReflectionTypeLayout*) this, category);
         }
 
+        int32_t getAlignment(SlangParameterCategory category = SLANG_PARAMETER_CATEGORY_UNIFORM)
+        {
+            return spReflectionTypeLayout_getAlignment((SlangReflectionTypeLayout*) this, category);
+        }
+
         unsigned int getFieldCount()
         {
             return getType()->getFieldCount();
@@ -2392,6 +2402,11 @@ namespace slang
         VariableLayoutReflection* getElementVarLayout()
         {
             return (VariableLayoutReflection*)spReflectionTypeLayout_GetElementVarLayout((SlangReflectionTypeLayout*) this);
+        }
+
+        VariableLayoutReflection* getContainerVarLayout()
+        {
+            return (VariableLayoutReflection*)spReflectionTypeLayout_getContainerVarLayout((SlangReflectionTypeLayout*) this);
         }
 
         // How is this type supposed to be bound?
@@ -2634,6 +2649,11 @@ namespace slang
         TypeLayoutReflection* getTypeLayout()
         {
             return getVarLayout()->getTypeLayout();
+        }
+
+        VariableLayoutReflection* getResultVarLayout()
+        {
+            return (VariableLayoutReflection*) spReflectionEntryPoint_getResultVarLayout((SlangReflectionEntryPoint*) this);
         }
 
         bool hasDefaultConstantBuffer()

--- a/source/slang/slang-reflection.cpp
+++ b/source/slang/slang-reflection.cpp
@@ -357,9 +357,9 @@ SLANG_API SlangReflectionType* spReflectionType_GetElementType(SlangReflectionTy
     {
         return (SlangReflectionType*) arrayType->baseType.Ptr();
     }
-    else if( auto constantBufferType = as<ConstantBufferType>(type))
+    else if( auto parameterGroupType = as<ParameterGroupType>(type))
     {
-        return convert(constantBufferType->elementType.Ptr());
+        return convert(parameterGroupType->elementType.Ptr());
     }
     else if( auto vectorType = as<VectorExpressionType>(type))
     {
@@ -680,6 +680,21 @@ SLANG_API size_t spReflectionTypeLayout_GetSize(SlangReflectionTypeLayout* inTyp
     return getReflectionSize(info->count);
 }
 
+SLANG_API int32_t spReflectionTypeLayout_getAlignment(SlangReflectionTypeLayout* inTypeLayout, SlangParameterCategory category)
+{
+    auto typeLayout = convert(inTypeLayout);
+    if(!typeLayout) return 0;
+
+    if( category == SLANG_PARAMETER_CATEGORY_UNIFORM )
+    {
+        return int32_t(typeLayout->uniformAlignment);
+    }
+    else
+    {
+        return 1;
+    }
+}
+
 SLANG_API SlangReflectionVariableLayout* spReflectionTypeLayout_GetFieldByIndex(SlangReflectionTypeLayout* inTypeLayout, unsigned index)
 {
     auto typeLayout = convert(inTypeLayout);
@@ -758,9 +773,22 @@ SLANG_API SlangReflectionVariableLayout* spReflectionTypeLayout_GetElementVarLay
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return nullptr;
 
-    if( auto constantBufferTypeLayout = as<ParameterGroupTypeLayout>(typeLayout))
+    if( auto parameterGroupTypeLayout = as<ParameterGroupTypeLayout>(typeLayout))
     {
-        return convert(constantBufferTypeLayout->elementVarLayout.Ptr());
+        return convert(parameterGroupTypeLayout->elementVarLayout.Ptr());
+    }
+
+    return nullptr;
+}
+
+SLANG_API SlangReflectionVariableLayout* spReflectionTypeLayout_getContainerVarLayout(SlangReflectionTypeLayout* inTypeLayout)
+{
+    auto typeLayout = convert(inTypeLayout);
+    if(!typeLayout) return nullptr;
+
+    if( auto parameterGroupTypeLayout = as<ParameterGroupTypeLayout>(typeLayout))
+    {
+        return convert(parameterGroupTypeLayout->containerVarLayout.Ptr());
     }
 
     return nullptr;
@@ -1299,6 +1327,17 @@ SLANG_API SlangReflectionVariableLayout* spReflectionEntryPoint_getVarLayout(
 
     return convert(entryPointLayout->parametersLayout);
 }
+
+SLANG_API SlangReflectionVariableLayout* spReflectionEntryPoint_getResultVarLayout(
+    SlangReflectionEntryPoint* inEntryPoint)
+{
+    auto entryPointLayout = convert(inEntryPoint);
+    if(!entryPointLayout)
+        return nullptr;
+
+    return convert(entryPointLayout->resultLayout);
+}
+
 
 static bool hasDefaultConstantBuffer(ScopeLayout* layout)
 {

--- a/tests/cross-compile/cpp-resource-reflection.slang.32.expected
+++ b/tests/cross-compile/cpp-resource-reflection.slang.32.expected
@@ -38,6 +38,42 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 8, "size": 4}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "Thing",
+                        "fields": [
+                            {
+                                "name": "a",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "int32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                            },
+                            {
+                                "name": "b",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 4, "size": 4}
+                            },
+                            {
+                                "name": "c",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 8, "size": 4}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 12}
                 }
             }
         },

--- a/tests/cross-compile/cpp-resource-reflection.slang.64.expected
+++ b/tests/cross-compile/cpp-resource-reflection.slang.64.expected
@@ -38,6 +38,42 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 8, "size": 4}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "uniform", "offset": 0, "size": 8}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "Thing",
+                        "fields": [
+                            {
+                                "name": "a",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "int32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                            },
+                            {
+                                "name": "b",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 4, "size": 4}
+                            },
+                            {
+                                "name": "c",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 8, "size": 4}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 12}
                 }
             }
         },

--- a/tests/reflection/arrays.hlsl.expected
+++ b/tests/reflection/arrays.hlsl.expected
@@ -42,6 +42,46 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 164, "size": 4}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "constantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "x",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                            },
+                            {
+                                "name": "a",
+                                "type": {
+                                    "kind": "array",
+                                    "elementCount": 10,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    },
+                                    "uniformStride": 16
+                                },
+                                "binding": {"kind": "uniform", "offset": 16, "size": 148}
+                            },
+                            {
+                                "name": "y",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 164, "size": 4}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 168}
                 }
             }
         },
@@ -102,7 +142,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/attribute.slang.expected
+++ b/tests/reflection/attribute.slang.expected
@@ -45,6 +45,49 @@ standard output = {
                         ]
                     }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "constantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "A",
+                        "fields": [
+                            {
+                                "name": "x",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                            },
+                            {
+                                "name": "y",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 4, "size": 4},
+                                "userAttribs": [{
+                                    "name": "DefaultValue",
+                                    "arguments": [
+                                        1
+                                    ]
+                                }
+                                ]
+                            }
+                        ],
+                        "userAttribs": [{
+                            "name": "MyStruct",
+                            "arguments": [
+                                0,
+                                1.000000
+                            ]
+                        }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 8}
                 }
             }
         },
@@ -89,6 +132,49 @@ standard output = {
                         ]
                     }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "constantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "B",
+                        "fields": [
+                            {
+                                "name": "x",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                            },
+                            {
+                                "name": "z",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 4, "size": 4},
+                                "userAttribs": [{
+                                    "name": "DefaultValue",
+                                    "arguments": [
+                                        2
+                                    ]
+                                }
+                                ]
+                            }
+                        ],
+                        "userAttribs": [{
+                            "name": "MyStruct",
+                            "arguments": [
+                                0,
+                                2.000000
+                            ]
+                        }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 8}
                 }
             }
         }

--- a/tests/reflection/binding-gl.hlsl.expected
+++ b/tests/reflection/binding-gl.hlsl.expected
@@ -42,6 +42,46 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 176, "size": 4}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "descriptorTableSlot", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "x",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                            },
+                            {
+                                "name": "a",
+                                "type": {
+                                    "kind": "array",
+                                    "elementCount": 10,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    },
+                                    "uniformStride": 16
+                                },
+                                "binding": {"kind": "uniform", "offset": 16, "size": 160}
+                            },
+                            {
+                                "name": "y",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 176, "size": 4}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 192}
                 }
             }
         },
@@ -98,7 +138,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/binding-push-constant-gl.hlsl.expected
+++ b/tests/reflection/binding-push-constant-gl.hlsl.expected
@@ -42,6 +42,46 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 176, "size": 4}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "descriptorTableSlot", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "x",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                            },
+                            {
+                                "name": "a",
+                                "type": {
+                                    "kind": "array",
+                                    "elementCount": 10,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    },
+                                    "uniformStride": 16
+                                },
+                                "binding": {"kind": "uniform", "offset": 16, "size": 160}
+                            },
+                            {
+                                "name": "y",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 176, "size": 4}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 192}
                 }
             }
         },
@@ -71,6 +111,34 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 4, "size": 4}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "pushConstantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "MyPushConstantStruct",
+                        "fields": [
+                            {
+                                "name": "pushX",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                            },
+                            {
+                                "name": "pushY",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 4, "size": 4}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 16}
                 }
             }
         },
@@ -127,7 +195,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/buffer-layout.slang.1.expected
+++ b/tests/reflection/buffer-layout.slang.1.expected
@@ -81,6 +81,85 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 80, "size": 4}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "descriptorTableSlot", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "S",
+                        "fields": [
+                            {
+                                "name": "z",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                            },
+                            {
+                                "name": "a",
+                                "type": {
+                                    "kind": "struct",
+                                    "name": "A",
+                                    "fields": [
+                                        {
+                                            "name": "x",
+                                            "type": {
+                                                "kind": "scalar",
+                                                "scalarType": "float32"
+                                            },
+                                            "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                                        },
+                                        {
+                                            "name": "y",
+                                            "type": {
+                                                "kind": "scalar",
+                                                "scalarType": "float32"
+                                            },
+                                            "binding": {"kind": "uniform", "offset": 4, "size": 4}
+                                        }
+                                    ]
+                                },
+                                "binding": {"kind": "uniform", "offset": 16, "size": 16}
+                            },
+                            {
+                                "name": "b",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "int32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 32, "size": 4}
+                            },
+                            {
+                                "name": "c",
+                                "type": {
+                                    "kind": "array",
+                                    "elementCount": 2,
+                                    "elementType": {
+                                        "kind": "vector",
+                                        "elementCount": 2,
+                                        "elementType": {
+                                            "kind": "scalar",
+                                            "scalarType": "float32"
+                                        }
+                                    },
+                                    "uniformStride": 16
+                                },
+                                "binding": {"kind": "uniform", "offset": 48, "size": 32}
+                            },
+                            {
+                                "name": "d",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "int32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 80, "size": 4}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 96}
                 }
             }
         },

--- a/tests/reflection/buffer-layout.slang.expected
+++ b/tests/reflection/buffer-layout.slang.expected
@@ -81,6 +81,85 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 56, "size": 4}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "constantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "S",
+                        "fields": [
+                            {
+                                "name": "z",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                            },
+                            {
+                                "name": "a",
+                                "type": {
+                                    "kind": "struct",
+                                    "name": "A",
+                                    "fields": [
+                                        {
+                                            "name": "x",
+                                            "type": {
+                                                "kind": "scalar",
+                                                "scalarType": "float32"
+                                            },
+                                            "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                                        },
+                                        {
+                                            "name": "y",
+                                            "type": {
+                                                "kind": "scalar",
+                                                "scalarType": "float32"
+                                            },
+                                            "binding": {"kind": "uniform", "offset": 4, "size": 4}
+                                        }
+                                    ]
+                                },
+                                "binding": {"kind": "uniform", "offset": 16, "size": 8}
+                            },
+                            {
+                                "name": "b",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "int32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 24, "size": 4}
+                            },
+                            {
+                                "name": "c",
+                                "type": {
+                                    "kind": "array",
+                                    "elementCount": 2,
+                                    "elementType": {
+                                        "kind": "vector",
+                                        "elementCount": 2,
+                                        "elementType": {
+                                            "kind": "scalar",
+                                            "scalarType": "float32"
+                                        }
+                                    },
+                                    "uniformStride": 16
+                                },
+                                "binding": {"kind": "uniform", "offset": 32, "size": 24}
+                            },
+                            {
+                                "name": "d",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "int32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 56, "size": 4}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 60}
                 }
             }
         },

--- a/tests/reflection/cross-compile.slang.expected
+++ b/tests/reflection/cross-compile.slang.expected
@@ -40,6 +40,29 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 0, "size": 12}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "descriptorTableSlot", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "c",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 3,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 12}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 16}
                 }
             }
         }
@@ -47,7 +70,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/default-space.slang.expected
+++ b/tests/reflection/default-space.slang.expected
@@ -30,6 +30,26 @@ standard output = {
                             "binding": {"kind": "shaderResource", "index": 0}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "registerSpace", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "B",
+                        "fields": [
+                            {
+                                "name": "b",
+                                "type": {
+                                    "kind": "resource",
+                                    "baseShape": "texture2D"
+                                },
+                                "binding": {"kind": "shaderResource", "index": 0}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "shaderResource", "index": 0}
                 }
             }
         }
@@ -37,7 +57,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/explicit-register-space.slang.expected
+++ b/tests/reflection/explicit-register-space.slang.expected
@@ -16,7 +16,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/global-type-params.slang.expected
+++ b/tests/reflection/global-type-params.slang.expected
@@ -22,6 +22,26 @@ standard output = {
                             "binding": {"kind": "generic", "index": 0}
                         }
                     ]
+                },
+                "containerVarLayout": {
+
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "S",
+                        "fields": [
+                            {
+                                "name": "p",
+                                "type": {
+                                    "kind": "GenericTypeParameter",
+                                    "name": "TParam2"
+                                },
+                                "binding": {"kind": "generic", "index": 0}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "generic", "index": 0}
                 }
             }
         },
@@ -33,6 +53,16 @@ standard output = {
                 "elementType": {
                     "kind": "GenericTypeParameter",
                     "name": "TParam"
+                },
+                "containerVarLayout": {
+
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "GenericTypeParameter",
+                        "name": "TParam"
+                    },
+                    "binding": {"kind": "generic", "index": 0}
                 }
             }
         },
@@ -96,6 +126,53 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 32, "size": 16}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "constantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "u",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 4,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 16}
+                            },
+                            {
+                                "name": "v",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 4,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 16, "size": 16}
+                            },
+                            {
+                                "name": "w",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 4,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 32, "size": 16}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 48}
                 }
             }
         }
@@ -103,7 +180,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ],
     "typeParams":

--- a/tests/reflection/matrix-layout.slang.1.expected
+++ b/tests/reflection/matrix-layout.slang.1.expected
@@ -52,6 +52,56 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 96, "size": 60}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "constantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "aa",
+                                "type": {
+                                    "kind": "matrix",
+                                    "rowCount": 3,
+                                    "columnCount": 4,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 48}
+                            },
+                            {
+                                "name": "ab",
+                                "type": {
+                                    "kind": "matrix",
+                                    "rowCount": 3,
+                                    "columnCount": 4,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 48, "size": 48}
+                            },
+                            {
+                                "name": "ac",
+                                "type": {
+                                    "kind": "matrix",
+                                    "rowCount": 3,
+                                    "columnCount": 4,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 96, "size": 60}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 156}
                 }
             }
         },
@@ -113,6 +163,66 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 0, "size": 156}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "constantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "b",
+                                "type": {
+                                    "kind": "struct",
+                                    "name": "SB",
+                                    "fields": [
+                                        {
+                                            "name": "ba",
+                                            "type": {
+                                                "kind": "matrix",
+                                                "rowCount": 3,
+                                                "columnCount": 4,
+                                                "elementType": {
+                                                    "kind": "scalar",
+                                                    "scalarType": "float32"
+                                                }
+                                            },
+                                            "binding": {"kind": "uniform", "offset": 0, "size": 48}
+                                        },
+                                        {
+                                            "name": "bb",
+                                            "type": {
+                                                "kind": "matrix",
+                                                "rowCount": 3,
+                                                "columnCount": 4,
+                                                "elementType": {
+                                                    "kind": "scalar",
+                                                    "scalarType": "float32"
+                                                }
+                                            },
+                                            "binding": {"kind": "uniform", "offset": 48, "size": 48}
+                                        },
+                                        {
+                                            "name": "bc",
+                                            "type": {
+                                                "kind": "matrix",
+                                                "rowCount": 3,
+                                                "columnCount": 4,
+                                                "elementType": {
+                                                    "kind": "scalar",
+                                                    "scalarType": "float32"
+                                                }
+                                            },
+                                            "binding": {"kind": "uniform", "offset": 96, "size": 60}
+                                        }
+                                    ]
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 156}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 156}
                 }
             }
         }
@@ -120,7 +230,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/matrix-layout.slang.expected
+++ b/tests/reflection/matrix-layout.slang.expected
@@ -52,6 +52,56 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 112, "size": 60}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "constantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "aa",
+                                "type": {
+                                    "kind": "matrix",
+                                    "rowCount": 3,
+                                    "columnCount": 4,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 60}
+                            },
+                            {
+                                "name": "ab",
+                                "type": {
+                                    "kind": "matrix",
+                                    "rowCount": 3,
+                                    "columnCount": 4,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 64, "size": 48}
+                            },
+                            {
+                                "name": "ac",
+                                "type": {
+                                    "kind": "matrix",
+                                    "rowCount": 3,
+                                    "columnCount": 4,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 112, "size": 60}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 172}
                 }
             }
         },
@@ -113,6 +163,66 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 0, "size": 172}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "constantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "b",
+                                "type": {
+                                    "kind": "struct",
+                                    "name": "SB",
+                                    "fields": [
+                                        {
+                                            "name": "ba",
+                                            "type": {
+                                                "kind": "matrix",
+                                                "rowCount": 3,
+                                                "columnCount": 4,
+                                                "elementType": {
+                                                    "kind": "scalar",
+                                                    "scalarType": "float32"
+                                                }
+                                            },
+                                            "binding": {"kind": "uniform", "offset": 0, "size": 60}
+                                        },
+                                        {
+                                            "name": "bb",
+                                            "type": {
+                                                "kind": "matrix",
+                                                "rowCount": 3,
+                                                "columnCount": 4,
+                                                "elementType": {
+                                                    "kind": "scalar",
+                                                    "scalarType": "float32"
+                                                }
+                                            },
+                                            "binding": {"kind": "uniform", "offset": 64, "size": 48}
+                                        },
+                                        {
+                                            "name": "bc",
+                                            "type": {
+                                                "kind": "matrix",
+                                                "rowCount": 3,
+                                                "columnCount": 4,
+                                                "elementType": {
+                                                    "kind": "scalar",
+                                                    "scalarType": "float32"
+                                                }
+                                            },
+                                            "binding": {"kind": "uniform", "offset": 112, "size": 60}
+                                        }
+                                    ]
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 172}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 172}
                 }
             }
         }
@@ -120,7 +230,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/multi-file.hlsl.expected
+++ b/tests/reflection/multi-file.hlsl.expected
@@ -72,6 +72,61 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 32, "size": 8}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "constantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "vertexCA",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 3,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 12}
+                            },
+                            {
+                                "name": "vertexCB",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 12, "size": 4}
+                            },
+                            {
+                                "name": "vertexCC",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 3,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 16, "size": 12}
+                            },
+                            {
+                                "name": "vertexCD",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 2,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 32, "size": 8}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 40}
                 }
             }
         },
@@ -143,6 +198,61 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 32, "size": 8}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "constantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "fragmentCA",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 3,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 12}
+                            },
+                            {
+                                "name": "fragmentCB",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 12, "size": 4}
+                            },
+                            {
+                                "name": "fragmentCC",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 3,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 16, "size": 12}
+                            },
+                            {
+                                "name": "fragmentCD",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 2,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 32, "size": 8}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 40}
                 }
             }
         },
@@ -214,6 +324,61 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 32, "size": 8}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "constantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "sharedCA",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 3,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 12}
+                            },
+                            {
+                                "name": "sharedCB",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 12, "size": 4}
+                            },
+                            {
+                                "name": "sharedCC",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 3,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 16, "size": 12}
+                            },
+                            {
+                                "name": "sharedCD",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 2,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 32, "size": 8}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 40}
                 }
             }
         },
@@ -237,11 +402,35 @@ standard output = {
     "entryPoints": [
         {
             "name": "mainVS",
-            "stage:": "vertex"
+            "stage:": "vertex",
+            "result:": {
+                "semanticName": "SV_POSITION",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         },
         {
             "name": "mainFS",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/parameter-block-explicit-space.slang.expected
+++ b/tests/reflection/parameter-block-explicit-space.slang.expected
@@ -52,6 +52,60 @@ standard output = {
                             "binding": {"kind": "samplerState", "index": 0}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "bindings": [
+                        {"kind": "constantBuffer", "index": 0},
+                        {"kind": "registerSpace", "index": 0}
+                    ]
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "A",
+                        "fields": [
+                            {
+                                "name": "au",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 4,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 16}
+                            },
+                            {
+                                "name": "at1",
+                                "type": {
+                                    "kind": "resource",
+                                    "baseShape": "texture2D"
+                                },
+                                "binding": {"kind": "shaderResource", "index": 0}
+                            },
+                            {
+                                "name": "at2",
+                                "type": {
+                                    "kind": "resource",
+                                    "baseShape": "texture2D"
+                                },
+                                "binding": {"kind": "shaderResource", "index": 1}
+                            },
+                            {
+                                "name": "as",
+                                "type": {
+                                    "kind": "samplerState"
+                                },
+                                "binding": {"kind": "samplerState", "index": 0}
+                            }
+                        ]
+                    },
+                    "bindings": [
+                        {"kind": "shaderResource", "index": 0, "count": 2},
+                        {"kind": "samplerState", "index": 0},
+                        {"kind": "uniform", "offset": 0, "size": 16}
+                    ]
                 }
             }
         },
@@ -95,6 +149,52 @@ standard output = {
                             "binding": {"kind": "samplerState", "index": 0}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "bindings": [
+                        {"kind": "constantBuffer", "index": 0},
+                        {"kind": "registerSpace", "index": 0}
+                    ]
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "B",
+                        "fields": [
+                            {
+                                "name": "bu",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 4,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 16}
+                            },
+                            {
+                                "name": "bt",
+                                "type": {
+                                    "kind": "resource",
+                                    "baseShape": "texture2D"
+                                },
+                                "binding": {"kind": "shaderResource", "index": 0}
+                            },
+                            {
+                                "name": "bs",
+                                "type": {
+                                    "kind": "samplerState"
+                                },
+                                "binding": {"kind": "samplerState", "index": 0}
+                            }
+                        ]
+                    },
+                    "bindings": [
+                        {"kind": "shaderResource", "index": 0},
+                        {"kind": "samplerState", "index": 0},
+                        {"kind": "uniform", "offset": 0, "size": 16}
+                    ]
                 }
             }
         }
@@ -102,7 +202,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/parameter-block.slang.1.expected
+++ b/tests/reflection/parameter-block.slang.1.expected
@@ -32,6 +32,36 @@ standard output = {
                             "binding": {"kind": "samplerState", "index": 0}
                         }
                     ]
+                },
+                "containerVarLayout": {
+
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "Helper",
+                        "fields": [
+                            {
+                                "name": "t",
+                                "type": {
+                                    "kind": "resource",
+                                    "baseShape": "texture2D"
+                                },
+                                "binding": {"kind": "shaderResource", "index": 0}
+                            },
+                            {
+                                "name": "s",
+                                "type": {
+                                    "kind": "samplerState"
+                                },
+                                "binding": {"kind": "samplerState", "index": 0}
+                            }
+                        ]
+                    },
+                    "bindings": [
+                        {"kind": "shaderResource", "index": 0},
+                        {"kind": "samplerState", "index": 0}
+                    ]
                 }
             }
         },
@@ -47,7 +77,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/parameter-block.slang.2.expected
+++ b/tests/reflection/parameter-block.slang.2.expected
@@ -29,6 +29,36 @@ standard output = {
                             "binding": {"kind": "samplerState", "index": 0}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "registerSpace", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "Helper",
+                        "fields": [
+                            {
+                                "name": "t",
+                                "type": {
+                                    "kind": "resource",
+                                    "baseShape": "texture2D"
+                                },
+                                "binding": {"kind": "shaderResource", "index": 0}
+                            },
+                            {
+                                "name": "s",
+                                "type": {
+                                    "kind": "samplerState"
+                                },
+                                "binding": {"kind": "samplerState", "index": 0}
+                            }
+                        ]
+                    },
+                    "bindings": [
+                        {"kind": "shaderResource", "index": 0},
+                        {"kind": "samplerState", "index": 0}
+                    ]
                 }
             }
         },
@@ -44,7 +74,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/parameter-block.slang.expected
+++ b/tests/reflection/parameter-block.slang.expected
@@ -29,6 +29,33 @@ standard output = {
                             "binding": {"kind": "descriptorTableSlot", "index": 1}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "registerSpace", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "Helper",
+                        "fields": [
+                            {
+                                "name": "t",
+                                "type": {
+                                    "kind": "resource",
+                                    "baseShape": "texture2D"
+                                },
+                                "binding": {"kind": "descriptorTableSlot", "index": 0}
+                            },
+                            {
+                                "name": "s",
+                                "type": {
+                                    "kind": "samplerState"
+                                },
+                                "binding": {"kind": "descriptorTableSlot", "index": 1}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "descriptorTableSlot", "index": 0, "count": 2}
                 }
             }
         },
@@ -44,7 +71,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/reflect-imported-code.hlsl.expected
+++ b/tests/reflection/reflect-imported-code.hlsl.expected
@@ -36,6 +36,25 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 0, "size": 4}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "constantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "c",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 4}
                 }
             }
         },
@@ -71,6 +90,25 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 0, "size": 4}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "constantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "c_i",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 4}
                 }
             }
         }
@@ -78,7 +116,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/reflection0.hlsl.expected
+++ b/tests/reflection/reflection0.hlsl.expected
@@ -36,6 +36,25 @@ standard output = {
                             "binding": {"kind": "uniform", "offset": 0, "size": 4}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "constantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "c",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 4}
                 }
             }
         }
@@ -43,7 +62,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/resource-in-cbuffer.hlsl.expected
+++ b/tests/reflection/resource-in-cbuffer.hlsl.expected
@@ -48,6 +48,56 @@ standard output = {
                             "binding": {"kind": "samplerState", "index": 0}
                         }
                     ]
+                },
+                "containerVarLayout": {
+                    "binding": {"kind": "constantBuffer", "index": 0}
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "v",
+                                "type": {
+                                    "kind": "vector",
+                                    "elementCount": 3,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "float32"
+                                    }
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 12}
+                            },
+                            {
+                                "name": "myTexture",
+                                "type": {
+                                    "kind": "resource",
+                                    "baseShape": "texture2D"
+                                },
+                                "binding": {"kind": "shaderResource", "index": 0}
+                            },
+                            {
+                                "name": "c",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 12, "size": 4}
+                            },
+                            {
+                                "name": "mySampler",
+                                "type": {
+                                    "kind": "samplerState"
+                                },
+                                "binding": {"kind": "samplerState", "index": 0}
+                            }
+                        ]
+                    },
+                    "bindings": [
+                        {"kind": "shaderResource", "index": 0},
+                        {"kind": "samplerState", "index": 0},
+                        {"kind": "uniform", "offset": 0, "size": 16}
+                    ]
                 }
             }
         }
@@ -55,7 +105,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/sample-index-input.hlsl.expected
+++ b/tests/reflection/sample-index-input.hlsl.expected
@@ -45,7 +45,20 @@ standard output = {
                     }
                 }
             ],
-            "usesAnySampleRateInput": true
+            "usesAnySampleRateInput": true,
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/sample-rate-input.hlsl.expected
+++ b/tests/reflection/sample-rate-input.hlsl.expected
@@ -51,7 +51,20 @@ standard output = {
                     }
                 }
             ],
-            "usesAnySampleRateInput": true
+            "usesAnySampleRateInput": true,
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/shared-modifier.hlsl.expected
+++ b/tests/reflection/shared-modifier.hlsl.expected
@@ -40,7 +40,20 @@ standard output = {
                         }
                     }
                 }
-            ]
+            ],
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/structured-buffer.slang.expected
+++ b/tests/reflection/structured-buffer.slang.expected
@@ -78,7 +78,20 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage:": "fragment",
+            "result:": {
+                "stage": "fragment",
+                "binding": {"kind": "varyingOutput", "index": 0},
+                "semanticName": "SV_TARGET",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/reflection/vertex-input-semantics.hlsl.expected
+++ b/tests/reflection/vertex-input-semantics.hlsl.expected
@@ -160,7 +160,18 @@ standard output = {
                         ]
                     }
                 }
-            ]
+            ],
+            "result:": {
+                "semanticName": "SV_POSITION",
+                "type": {
+                    "kind": "vector",
+                    "elementCount": 4,
+                    "elementType": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
This change adds some new entry points to the reflection API to cover corner cases that a majority of applications won't care about.
These are most likely to come up for users who want to make a complete copy of the Slang reflection information into a data format of their own design.

All of the information is stuff that we already computed as part of layout, and just hadn't exposed:

* Alignment information for type layouts. This is only useful for ordinary/uniform data; in all other cases alignment is always one. Even for uniform/ordinary data, it is unlikely that any application would actually make use of it.

* Layout information for the result of an entry point function. This would be useful for applications that need to enumerate the varying outputs (user- or system-defined) of a shader. Having information available for `out` parameters but not the function result was inconsistent.

* The "element type" of a parameter block type (e.g., going from `ParameterBlock<X>` to `X`). This seems to have been an oversight since `ConstantBuffer<X>` appears to have been implemented, and the case for a type *layout* was handled.

* The "container" variable layout for a parameter block or constant buffer. It took a while for us to arrive at the current representation of layout for parameter groups, and most client code continues to use the original API that requires us to generated kludged "do what I mean" data. However, if we don't expose the more useful new representation fully, there is no way for users to take advantage of it!

The reflection test tool has been updated to print the new information where it makes sense, which provides us some level of coverage for the new code.
Unfortunately, this led to some cascading changes:

* First, a bunch of the tests had their output changed since they include new information. That's the easy bit.

* Next, the "container" and "element" var layouts don't actually have names (because there is no actual variable underlying them), which means that the code to emit variable names in the JSON dump needed to be condition.

* Making the `"name"` output conditional messed up a lot of the delicate logic that had been dealing with when to emit commas for the output JSON (JSON uses commas as separators, and doesn't allow trailing commas). I added a bit of new infrastructure to make it simple(-ish) to track when a comma actually needs to be output.