### PR TITLE
Catch exceptions inside FindTypeByName()

### DIFF
--- a/source/slang/slang-reflection.cpp
+++ b/source/slang/slang-reflection.cpp
@@ -598,8 +598,15 @@ SLANG_API SlangReflectionType * spReflection_FindTypeByName(SlangReflection * re
     Slang::DiagnosticSink sink(
         programLayout->getTargetReq()->getLinkage()->getSourceManager());
 
-    RefPtr<Type> result = program->getTypeFromString(name, &sink);
-    return (SlangReflectionType*)result.Ptr();
+    try
+    {
+        RefPtr<Type> result = program->getTypeFromString(name, &sink);
+        return (SlangReflectionType*)result.Ptr();
+    }
+    catch( ... )
+    {
+        return nullptr;
+    }
 }
 
 SLANG_API SlangReflectionTypeLayout* spReflection_GetTypeLayout(


### PR DESCRIPTION
If `spReflection_FindTypeByName` is called with a string that refers to the name of a variable instead of a type, then it ends up causing a fatal error to be diagnosed, leading to an `AbortCompilationException` being thrown. This exception then propagates up to the application that called `spReflection_FindTypeByName()`, which actually violates the contract for our `extern "C"` API.

This change adds a wrapper `try`/`catch` around the meat of the operation and turns any exception into a null result (this function has no other way to report errors to the caller).

It would be nice for a separate change to make the error message that caused the problem non-fatal, but that is orthogonal to this fix.