### PR TITLE
Fix a bug in handling explicit register space bindings

### DIFF
--- a/tests/reflection/mix-explicit-and-implicit-spaces.slang
+++ b/tests/reflection/mix-explicit-and-implicit-spaces.slang
@@ -1,0 +1,18 @@
+// mix-explicit-and-implicit-spaces.slang
+//TEST:REFLECTION:-profile cs_5_1 -target hlsl
+
+// Ensure that correct layout/reflection is computed
+// when mixing implicit and explicit spaces for
+// parameter blocks.
+
+struct A { float x; }
+ParameterBlock<A> a : register(space0);
+
+struct B { float y; }
+ParameterBlock<B> b : register(space1);
+
+struct C { float z; }
+ParameterBlock<C> c;
+
+void main()
+{}

--- a/tests/reflection/mix-explicit-and-implicit-spaces.slang.expected
+++ b/tests/reflection/mix-explicit-and-implicit-spaces.slang.expected
@@ -1,0 +1,157 @@
+result code = 0
+standard error = {
+}
+standard output = {
+{
+    "parameters": [
+        {
+            "name": "a",
+            "bindings": [
+                {"kind": "constantBuffer", "index": 0, "count": 0},
+                {"kind": "registerSpace", "index": 0}
+            ],
+            "type": {
+                "kind": "parameterBlock",
+                "elementType": {
+                    "kind": "struct",
+                    "name": "A",
+                    "fields": [
+                        {
+                            "name": "x",
+                            "type": {
+                                "kind": "scalar",
+                                "scalarType": "float32"
+                            },
+                            "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                        }
+                    ]
+                },
+                "containerVarLayout": {
+                    "bindings": [
+                        {"kind": "constantBuffer", "index": 0},
+                        {"kind": "registerSpace", "index": 0}
+                    ]
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "A",
+                        "fields": [
+                            {
+                                "name": "x",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                }
+            }
+        },
+        {
+            "name": "b",
+            "bindings": [
+                {"kind": "constantBuffer", "index": 0, "count": 0},
+                {"kind": "registerSpace", "index": 1}
+            ],
+            "type": {
+                "kind": "parameterBlock",
+                "elementType": {
+                    "kind": "struct",
+                    "name": "B",
+                    "fields": [
+                        {
+                            "name": "y",
+                            "type": {
+                                "kind": "scalar",
+                                "scalarType": "float32"
+                            },
+                            "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                        }
+                    ]
+                },
+                "containerVarLayout": {
+                    "bindings": [
+                        {"kind": "constantBuffer", "index": 0},
+                        {"kind": "registerSpace", "index": 0}
+                    ]
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "B",
+                        "fields": [
+                            {
+                                "name": "y",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                }
+            }
+        },
+        {
+            "name": "c",
+            "bindings": [
+                {"kind": "constantBuffer", "index": 0, "count": 0},
+                {"kind": "registerSpace", "index": 2}
+            ],
+            "type": {
+                "kind": "parameterBlock",
+                "elementType": {
+                    "kind": "struct",
+                    "name": "C",
+                    "fields": [
+                        {
+                            "name": "z",
+                            "type": {
+                                "kind": "scalar",
+                                "scalarType": "float32"
+                            },
+                            "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                        }
+                    ]
+                },
+                "containerVarLayout": {
+                    "bindings": [
+                        {"kind": "constantBuffer", "index": 0},
+                        {"kind": "registerSpace", "index": 0}
+                    ]
+                },
+                "elementVarLayout": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "C",
+                        "fields": [
+                            {
+                                "name": "z",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "float32"
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                            }
+                        ]
+                    },
+                    "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                }
+            }
+        }
+    ],
+    "entryPoints": [
+        {
+            "name": "main",
+            "stage:": "compute",
+            "threadGroupSize": [1, 1, 1]
+        }
+    ]
+}
+}


### PR DESCRIPTION
The logic for handling explicit `space`/`set` bindings on shader parameters for parameter blocks was not correctly marking the `space`/`set` that gets grabbed as used, and as a result it was possible for another parameter block that relies on implicit assignment to end up with a conflicting space.

This change fixes the original oversight, and adds a test case to prevent against regression.