### PR TITLE
CUDA Structured Buffer/ByteAddressBuffer

### DIFF
--- a/docs/cuda-target.md
+++ b/docs/cuda-target.md
@@ -69,7 +69,7 @@ struct UniformState
 {
     CUtexObject tex;                // This is the combination of a texture and a sampler(!)
     SamplerState sampler;           // This variable exists within the layout, but it's value is not used.
-    int32_t* outputBuffer;          // Currently Structured buffers are converted to pointers - this will likely change in the future (for bounds checking and other reasons)
+    RWStructuredBuffer<int32_t> outputBuffer;    // This is implemented as a template in the CUDA prelude. It's just a pointer, and a size
     Thing* thing3;                  // Constant buffers map to pointers
 };   
 
@@ -80,6 +80,20 @@ extern "C" __global__  void computeMain(UniformEntryPointParams* params, Uniform
 With CUDA - the caller specifies how threading is broken up, so `[numthreads]` is available through reflection, and in a comment in output source code but does not produce varying code. 
 
 The UniformState and UniformEntryPointParams struct typically vary by shader. UniformState holds 'normal' bindings, whereas UniformEntryPointParams hold the uniform entry point parameters. Where specific bindings or parameters are located can be determined by reflection. The structures for the example above would be something like the following... 
+
+`StructuredBuffer<T>`,`RWStructuredBuffer<T>` become
+
+```
+    T* data;
+    size_t count;
+```    
+
+`ByteAddressBuffer`, `RWByteAddressBuffer` become 
+
+```
+    uint32_t* data;
+    size_t sizeInBytes;
+```  
 
 ## Unsized arrays
 

--- a/source/core/slang-nvrtc-compiler.cpp
+++ b/source/core/slang-nvrtc-compiler.cpp
@@ -174,6 +174,16 @@ static SlangResult _parseLocation(const UnownedStringSlice& in, DownstreamDiagno
     return SLANG_OK;
 }
 
+static bool _isDriveLetter(char c)
+{
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+static bool _hasDriveLetter(const UnownedStringSlice& line)
+{
+    return line.size() > 2 && line[1] == ':' && _isDriveLetter(line[0]);
+}
+
 static SlangResult _parseNVRTCLine(const UnownedStringSlice& line, DownstreamDiagnostic& outDiagnostic)
 {
     typedef DownstreamDiagnostic Diagnostic;
@@ -182,7 +192,17 @@ static SlangResult _parseNVRTCLine(const UnownedStringSlice& line, DownstreamDia
     outDiagnostic.stage = Diagnostic::Stage::Compile;
 
     List<UnownedStringSlice> split;
-    StringUtil::split(line, ':', split);
+    if (_hasDriveLetter(line))
+    {
+        // The drive letter has :, which confuses things, so skip that and then fix up first entry 
+        UnownedStringSlice lineWithoutDrive(line.begin() + 2, line.end());
+        StringUtil::split(lineWithoutDrive, ':', split);
+        split[0] = UnownedStringSlice(line.begin(), split[0].end());
+    }
+    else
+    {
+        StringUtil::split(line, ':', split);
+    }
 
     if (split.getCount() == 3)
     {

--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -254,21 +254,6 @@ SlangResult CUDASourceEmitter::calcTypeName(IRType* type, CodeGenTarget target, 
             out << prefix << vecCount;
             return SLANG_OK;
         }
-        case kIROp_HLSLStructuredBufferType:
-        {
-            auto bufferType = as<IRHLSLStructuredBufferType>(type);
-            out << "const ";
-            calcTypeName(bufferType->getElementType(), target, out);
-            out << "* ";
-            return SLANG_OK;
-        }
-        case kIROp_HLSLRWStructuredBufferType:
-        {
-            auto bufferType = as<IRHLSLRWStructuredBufferType>(type);
-            calcTypeName(bufferType->getElementType(), target, out);
-            out << "* ";
-            return SLANG_OK;
-        }
 
 #if 0
         case kIROp_MatrixType:

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -694,29 +694,29 @@ struct CPUObjectLayoutRulesImpl : ObjectLayoutRulesImpl
         {
             case ShaderParameterKind::ConstantBuffer:
                 // It's a pointer to the actual uniform data
-                return SimpleLayoutInfo(LayoutResourceKind::Uniform, sizeof(void*), sizeof(void*));
+                return SimpleLayoutInfo(LayoutResourceKind::Uniform, sizeof(void*), SLANG_ALIGN_OF(void*));
 
             case ShaderParameterKind::MutableTexture:
             case ShaderParameterKind::TextureUniformBuffer:
             case ShaderParameterKind::Texture:
                 // It's a pointer to a texture interface 
-                return SimpleLayoutInfo(LayoutResourceKind::Uniform, sizeof(void*), sizeof(void*));
+                return SimpleLayoutInfo(LayoutResourceKind::Uniform, sizeof(void*), SLANG_ALIGN_OF(void*));
                 
             case ShaderParameterKind::StructuredBuffer:            
             case ShaderParameterKind::MutableStructuredBuffer:
                 // It's a ptr and a size of the amount of elements
-                return SimpleLayoutInfo(LayoutResourceKind::Uniform, sizeof(void*) * 2, sizeof(void*));
+                return SimpleLayoutInfo(LayoutResourceKind::Uniform, sizeof(void*) * 2, SLANG_ALIGN_OF(void*));
 
             case ShaderParameterKind::RawBuffer:
             case ShaderParameterKind::Buffer:
             case ShaderParameterKind::MutableRawBuffer:
             case ShaderParameterKind::MutableBuffer:
                 // It's a pointer and a size in bytes
-                return SimpleLayoutInfo(LayoutResourceKind::Uniform, sizeof(void*) * 2, sizeof(void*));
+                return SimpleLayoutInfo(LayoutResourceKind::Uniform, sizeof(void*) * 2, SLANG_ALIGN_OF(void*));
 
             case ShaderParameterKind::SamplerState:
                 // It's a pointer
-                return SimpleLayoutInfo(LayoutResourceKind::Uniform, sizeof(void*), sizeof(void*));
+                return SimpleLayoutInfo(LayoutResourceKind::Uniform, sizeof(void*), SLANG_ALIGN_OF(void*));
  
             case ShaderParameterKind::TextureSampler:
             case ShaderParameterKind::MutableTextureSampler:
@@ -756,19 +756,15 @@ struct CUDAObjectLayoutRulesImpl : CPUObjectLayoutRulesImpl
 
             case ShaderParameterKind::StructuredBuffer:
             case ShaderParameterKind::MutableStructuredBuffer:
-                // TODO(JS): We are just storing as a pointer for now
-                // It's a ptr and a size of the amount of elements
-                return SimpleLayoutInfo(LayoutResourceKind::Uniform, sizeof(void*), SLANG_ALIGN_OF(void*));
+                // It's a pointer and a size
+                return SimpleLayoutInfo(LayoutResourceKind::Uniform, sizeof(void*) * 2, SLANG_ALIGN_OF(void*));
 
             case ShaderParameterKind::RawBuffer:
             case ShaderParameterKind::Buffer:
             case ShaderParameterKind::MutableRawBuffer:
             case ShaderParameterKind::MutableBuffer:
-
-                // TODO(JS): We are storing as a pointer for now
-
                 // It's a pointer and a size in bytes
-                return SimpleLayoutInfo(LayoutResourceKind::Uniform, sizeof(void*), SLANG_ALIGN_OF(void*));
+                return SimpleLayoutInfo(LayoutResourceKind::Uniform, sizeof(void*) * 2, SLANG_ALIGN_OF(void*));
 
             case ShaderParameterKind::SamplerState:
                 // In CUDA it seems that sampler states are combined into texture objects.

--- a/tools/render-test/cuda/cuda-compute-util.cpp
+++ b/tools/render-test/cuda/cuda-compute-util.cpp
@@ -44,15 +44,15 @@ public:
         }
     }
 
+    static CUDAResource* getCUDAResource(BindSet::Value* value)
+    {
+        return value ? dynamic_cast<CUDAResource*>(value->m_target.Ptr()) : nullptr;
+    }
         /// Helper function to get the cuda memory pointer when given a value
     static void* getCUDAData(BindSet::Value* value)
     {
-        if (value)
-        {
-            auto resource = dynamic_cast<CUDAResource*>(value->m_target.Ptr());
-            return resource ? resource->m_cudaMemory : nullptr;
-        }
-        return nullptr;
+        auto resource = getCUDAResource(value);
+        return resource ? resource->m_cudaMemory : nullptr;
     }
 
     void* m_cudaMemory;
@@ -63,6 +63,7 @@ class CUDATextureResource : public RefObject
 public:
     typedef RefObject Super;
 
+    CUDATextureResource() {}
     CUDATextureResource(CUtexObject cudaTexObj, CUdeviceptr cudaMemory, CUarray cudaArray):
         m_cudaTexObj(cudaTexObj),
         m_cudaMemory(cudaMemory),
@@ -85,16 +86,16 @@ public:
         }
     }
 
+    static CUDATextureResource* getCUDATextureResource(BindSet::Value* value)
+    {
+        return value ? dynamic_cast<CUDATextureResource*>(value->m_target.Ptr()) : nullptr;
+    }
+
     static CUtexObject getCUDATexObject(BindSet::Value* value)
     {
-        if (value)
-        {
-            auto resource = dynamic_cast<CUDATextureResource*>(value->m_target.Ptr());
-            // It's an assumption here that 0 is okay for null. Seems to work...
-            return resource ? resource->m_cudaTexObj : CUtexObject(0);
-        }
-
-        return CUtexObject(0);
+        auto resource = getCUDATextureResource(value);
+        // It's an assumption here that 0 is okay for null. Seems to work...
+        return resource ? resource->m_cudaTexObj : CUtexObject(0);
     }
 
 protected:
@@ -526,7 +527,7 @@ static SlangResult _compute(CUcontext context, CUmodule module, const ShaderComp
                             case SLANG_TEXTURE_CUBE:
                             case SLANG_TEXTURE_BUFFER:
                             {
-                                // Need a CPU impl for these...
+                                // Need a CUDA impl for these...
                                 // For now we can just leave as target will just be nullptr
                                 break;
                             }
@@ -535,7 +536,6 @@ static SlangResult _compute(CUcontext context, CUmodule module, const ShaderComp
                             case SLANG_STRUCTURED_BUFFER:
                             {
                                 // On CPU we just use the memory in the BindSet buffer, so don't need to create anything
-
                                 void* cudaMem = nullptr;
                                 SLANG_CUDA_RETURN_ON_FAIL(cudaMalloc(&cudaMem, value->m_sizeInBytes));
                                 value->m_target = new CUDAResource(cudaMem);
@@ -598,12 +598,31 @@ static SlangResult _compute(CUcontext context, CUmodule module, const ShaderComp
 
                         switch (shape & SLANG_RESOURCE_BASE_SHAPE_MASK)
                         {
-                            case SLANG_BYTE_ADDRESS_BUFFER:
                             case SLANG_STRUCTURED_BUFFER:
                             {
-                                // TODO(JS): These will need bounds ... 
-                                // For the moment these are just pointers
-                                *location.getUniform<void*>() = CUDAResource::getCUDAData(value);
+                                CUDAComputeUtil::StructuredBuffer buffer = { nullptr, 0 };
+                                auto resource = CUDAResource::getCUDAResource(value);
+                                if (resource)
+                                {
+                                    buffer.data = resource->m_cudaMemory;
+                                    buffer.count = value->m_elementCount;
+                                }
+
+                                location.setUniform(&buffer, sizeof(buffer));
+                                break;
+                            }
+                            case SLANG_BYTE_ADDRESS_BUFFER:
+                            {
+                                CUDAComputeUtil::ByteAddressBuffer buffer = { nullptr, 0 };
+
+                                auto resource = CUDAResource::getCUDAResource(value);
+                                if (resource)
+                                {
+                                    buffer.data = resource->m_cudaMemory;
+                                    buffer.sizeInBytes = value->m_sizeInBytes;
+                                }
+
+                                location.setUniform(&buffer, sizeof(buffer));
                                 break;
                             }
                             case SLANG_TEXTURE_1D:

--- a/tools/render-test/cuda/cuda-compute-util.h
+++ b/tools/render-test/cuda/cuda-compute-util.h
@@ -10,6 +10,18 @@ namespace renderer_test {
 
 struct CUDAComputeUtil
 {
+        /// NOTE! MUST match up to definitions in the CUDA prelude
+    struct ByteAddressBuffer
+    {
+        void* data;
+        size_t sizeInBytes;
+    };
+    struct StructuredBuffer
+    {
+        void* data;
+        size_t count;
+    };
+
     struct Context
     {
             /// Holds the binding information


### PR DESCRIPTION
* CUDA implement StructuredBuffer/ByteAddressBuffer as pointer/count as is on CPU.
* Allow bounds check to zero index.
* Update docs
* Fix bug reporting from nvrtc when filename contained a drive letter 
* Update render-test to support StructuredBuffer/ByteAddressBuffer layout change