### PR TITLE
Feature/target intrinsic fold

### DIFF
--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -957,7 +957,7 @@ bool CLikeSourceEmitter::shouldFoldInstIntoUseSites(IRInst* inst)
             // Find the index of the original instruction, to see if it's multiply used.
             IRUse* args = callInst->getArgs();
             const Index paramIndex = Index(use - args);
-            SLANG_ASSERT(index >= 0 && index < Index(callInst->getArgCount()));
+            SLANG_ASSERT(paramIndex >= 0 && paramIndex < Index(callInst->getArgCount()));
 
             // Look through the slice to seeing how many times this parameters is used (signified via the $0...$9)
             {

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -900,70 +900,6 @@ bool CLikeSourceEmitter::shouldFoldInstIntoUseSites(IRInst* inst)
         }
     }
 
-    // If it's single uses we check for target intrinsic usage.
-    // We have to do this before the later single use, because the global test below
-    // makes fold when we don't want that
-    if (inst->firstUse && inst->firstUse->nextUse == nullptr)
-    {
-        auto use = inst->firstUse;
-        auto user = use->getUser();
-
-        if (auto callInst = as<IRCall>(user))
-        {
-            auto funcValue = callInst->getCallee();
-
-            // Let's see if this instruction is a intrinsic call
-            // This is significant, because we can within a target intrinsics definition multiple accesses to the same
-            // parameter. This is not indicated into the call, and can lead to output code computes something multiple
-            // times as it is folding into the expression of the the target intrinsic.
-            if (auto targetIntrinsicDecoration = findTargetIntrinsicDecoration(funcValue))
-            {
-                // Find the index of the parameter. If we don't determine, use -1 and if
-                // any parameter is used more than once we won't fold
-
-                // We work out the operand index for the invocation and see if that
-                // is used multiple times, but that depends on how operands are interpreted for the specific instruction
-                // we know call, but for others will just look for any multiple use.
-                
-                IRUse* args = callInst->getArgs();
-                
-                // Find the index
-                const Index paramIndex = Index(use - args);
-                SLANG_ASSERT(index >= 0 && index < Index(callInst->getArgCount()));
-
-                {
-                    UnownedStringSlice slice = targetIntrinsicDecoration->getDefinition();
-                    // Look through the slice to see if any of the the parameters are indexed more than one.
-
-                    const char* cur = slice.begin();
-                    const char* end = slice.end();
-
-                    // Count the amount of uses
-                    Index useCount = 0;
-                    while (cur < end)
-                    {
-                        const char c = *cur;
-                        if (c == '$' && cur + 1 < end && cur[1] >= '0' && cur[1] <= '9')
-                        {
-                            const Index index = Index(cur[1] - '0');
-                            useCount += Index(index == paramIndex);
-                            cur += 2;
-                        }
-                        else
-                        {
-                            cur++;
-                        }
-                    }
-
-                    // If there is more than one use can't fold.
-                    if (useCount > 1)
-                    {
-                        return false;
-                    }
-                }
-            }
-        }
-    }
 
 
     // If the instruction is at global scope, then it might represent
@@ -1006,6 +942,56 @@ bool CLikeSourceEmitter::shouldFoldInstIntoUseSites(IRInst* inst)
 
     auto user = use->getUser();
 
+    // Check if the use is a call using a target intrinsic that uses the parameter more than once
+    // in the intrinsic definition.
+    if (auto callInst = as<IRCall>(user))
+    {
+        const auto funcValue = callInst->getCallee();
+
+        // Let's see if this instruction is a intrinsic call
+        // This is significant, because we can within a target intrinsics definition multiple accesses to the same
+        // parameter. This is not indicated into the call, and can lead to output code computes something multiple
+        // times as it is folding into the expression of the the target intrinsic, which we don't want.
+        if (auto targetIntrinsicDecoration = findTargetIntrinsicDecoration(funcValue))
+        {         
+            // Find the index of the original instruction, to see if it's multiply used.
+            IRUse* args = callInst->getArgs();
+            const Index paramIndex = Index(use - args);
+            SLANG_ASSERT(index >= 0 && index < Index(callInst->getArgCount()));
+
+            // Look through the slice to seeing how many times this parameters is used (signified via the $0...$9)
+            {
+                UnownedStringSlice slice = targetIntrinsicDecoration->getDefinition();
+                
+                const char* cur = slice.begin();
+                const char* end = slice.end();
+
+                // Count the amount of uses
+                Index useCount = 0;
+                while (cur < end)
+                {
+                    const char c = *cur;
+                    if (c == '$' && cur + 1 < end && cur[1] >= '0' && cur[1] <= '9')
+                    {
+                        const Index index = Index(cur[1] - '0');
+                        useCount += Index(index == paramIndex);
+                        cur += 2;
+                    }
+                    else
+                    {
+                        cur++;
+                    }
+                }
+
+                // If there is more than one use can't fold.
+                if (useCount > 1)
+                {
+                    return false;
+                }
+            }
+        }
+    }
+    
     // We'd like to figure out if it is safe to fold our instruction into `user`
 
     // First, let's make sure they are in the same block/parent:

--- a/tests/cross-compile/texture-load.slang.glsl
+++ b/tests/cross-compile/texture-load.slang.glsl
@@ -30,10 +30,12 @@ uniform image2D outputTexture_0;
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 void main()
 {
+    ivec3 _S2 = ivec3(C_0._data.pos_0, 0);
+
     vec2 tmp_0 = texelFetch(
     	inputTexture_0,
-    	ivec3(C_0._data.pos_0, 0).xy,
-    	ivec3(C_0._data.pos_0, 0).z).xy;
+    	_S2.xy,
+    	_S2.z).xy;
 
     imageStore(
     	outputTexture_0,


### PR DESCRIPTION
When target intrinsics contain reference to a parameter multiple times, the multiple referencing isn't directly visible as regular instruction multiple uses. In practice this means the logic in folding cannot see multiple use, and so allows folding even if used multiple times, if the parameter is only used once (folding is already stopped with regular more than one inst usage). This can produce some awkward output code. 

This change checks within folding, if a inst is used in a target intrinsic call if it's used more than once. If so it is not folded. 