### PR TITLE
Add support for RWBuffer writes on GLSL/SPIR-V target

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -1504,7 +1504,9 @@ for (int aa = 0; aa < kBaseBufferAccessLevelCount; ++aa)
 
     if (access != SLANG_RESOURCE_ACCESS_READ)
     {
-        sb << "ref;\n";
+        sb << "__target_intrinsic(glsl, \"imageStore($0, int($1), $V2)\") set;\n";
+
+        sb << "__intrinsic_op(" << int(kIROp_ImageSubscript) << ") ref;\n";
     }
 
     sb << "}\n";

--- a/source/slang/hlsl.meta.slang.h
+++ b/source/slang/hlsl.meta.slang.h
@@ -1580,14 +1580,16 @@ for (int aa = 0; aa < kBaseBufferAccessLevelCount; ++aa)
 
     if (access != SLANG_RESOURCE_ACCESS_READ)
     {
-        sb << "ref;\n";
+        sb << "__target_intrinsic(glsl, \"imageStore($0, int($1), $V2)\") set;\n";
+
+        sb << "__intrinsic_op(" << int(kIROp_ImageSubscript) << ") ref;\n";
     }
 
     sb << "}\n";
 
     sb << "};\n";
 }
-SLANG_RAW("#line 1514 \"hlsl.meta.slang\"")
+SLANG_RAW("#line 1516 \"hlsl.meta.slang\"")
 SLANG_RAW("\n")
 SLANG_RAW("\n")
 SLANG_RAW("\n")

--- a/tests/cross-compile/rw-buffer.slang
+++ b/tests/cross-compile/rw-buffer.slang
@@ -1,0 +1,14 @@
+// rw-buffer.slang
+
+// Confirm that writing into a `RWBuffer` generates appropriate GLSL/SPIR-V.
+
+//TEST:CROSS_COMPILE: -profile ps_5_0 -entry main -target spirv-assembly
+
+RWBuffer<float> buffer;
+
+
+float4 main(float u : U, int idx : IDX) : SV_Target
+{
+	buffer[idx] = u;
+	return u;
+}

--- a/tests/cross-compile/rw-buffer.slang.glsl
+++ b/tests/cross-compile/rw-buffer.slang.glsl
@@ -1,0 +1,26 @@
+// rw-buffer.slang.glsl
+//TEST_IGNORE_FILE:
+
+#version 450
+layout(row_major) uniform;
+layout(row_major) buffer;
+
+layout(r32f)
+layout(binding = 0)
+uniform imageBuffer buffer_0;
+
+layout(location = 0)
+out vec4 _S1;
+
+layout(location = 0)
+in float _S2;
+
+flat layout(location = 1)
+in int _S3;
+
+void main()
+{
+	imageStore(buffer_0, int(uint(_S3)), vec4(_S2, float(0), float(0), float(0)));
+    _S1 = vec4(_S2);
+    return;
+}


### PR DESCRIPTION
This appears to have been an oversight in the work that added support for `imageStore` as well as atomics when writing to `RWTexture*` and friends. The HLSL/Slang `RWBuffer` type maps to GLSL as an `imageBuffer`, which is effectively just another case of writable texture image (bonus points to anybody who can explain to me the meaningful distinction between an `imageBuffer` and an `image1D`).

This change copies the handling of subscript access (`operator[]`) from textures over to buffers, and adds a test case to confirm that the new handling works for the simple case of setting a buffer element.