### PR TITLE
Fixes to make all CPU compute shaders work on CUDA

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -896,7 +896,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
-                    sb << "__target_intrinsic(cuda, \"tex" << kBaseTextureTypes[tt].coordCount << "D<$S0>($0";
+                    sb << "__target_intrinsic(cuda, \"tex" << kBaseTextureTypes[tt].coordCount << "D<$T0>($0";
                     if (kBaseTextureTypes[tt].coordCount == 1)
                     {
                         sb << ", $2";
@@ -1049,10 +1049,27 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 // `SampleLevel`
 
                 sb << "__target_intrinsic(glsl, \"$ctextureLod($p, $2, $3)$z\")\n";
+
+                // CUDA
+                if (!isArray)
+                {
+                    sb << "__target_intrinsic(cuda, \"tex" << kBaseTextureTypes[tt].coordCount << "DLod<$T0>($0";
+                    for (int i = 0; i < kBaseTextureTypes[tt].coordCount; ++i)
+                    {
+                        sb << ", $2";
+                        if (kBaseTextureTypes[tt].coordCount > 1)
+                        {
+                            sb << '.' << char(i + 'x');
+                        }
+                    }
+                    sb << ", $3)\")\n";
+                }
+
                 sb << "T SampleLevel(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                 sb << "float level);\n";
 
+                
                 if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     sb << "__target_intrinsic(glsl, \"$ctextureLodOffset($p, $2, $3, $4)$z\")\n";

--- a/source/slang/core.meta.slang.h
+++ b/source/slang/core.meta.slang.h
@@ -917,7 +917,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                 if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
-                    sb << "__target_intrinsic(cuda, \"tex" << kBaseTextureTypes[tt].coordCount << "D<$S0>($0";
+                    sb << "__target_intrinsic(cuda, \"tex" << kBaseTextureTypes[tt].coordCount << "D<$T0>($0";
                     if (kBaseTextureTypes[tt].coordCount == 1)
                     {
                         sb << ", $2";
@@ -1070,10 +1070,27 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                 // `SampleLevel`
 
                 sb << "__target_intrinsic(glsl, \"$ctextureLod($p, $2, $3)$z\")\n";
+
+                // CUDA
+                if (!isArray)
+                {
+                    sb << "__target_intrinsic(cuda, \"tex" << kBaseTextureTypes[tt].coordCount << "DLod<$T0>($0";
+                    for (int i = 0; i < kBaseTextureTypes[tt].coordCount; ++i)
+                    {
+                        sb << ", $2";
+                        if (kBaseTextureTypes[tt].coordCount > 1)
+                        {
+                            sb << '.' << char(i + 'x');
+                        }
+                    }
+                    sb << ", $3)\")\n";
+                }
+
                 sb << "T SampleLevel(SamplerState s, ";
                 sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                 sb << "float level);\n";
 
+                
                 if( baseShape != TextureFlavor::Shape::ShapeCube )
                 {
                     sb << "__target_intrinsic(glsl, \"$ctextureLodOffset($p, $2, $3, $4)$z\")\n";
@@ -1282,7 +1299,7 @@ for (auto op : binaryOps)
         sb << "__intrinsic_op(" << int(op.opCode) << ") matrix<" << resultType << ",N,M> operator" << op.opName << "(" << leftQual << "matrix<" << leftType << ",N,M> left, " << rightType << " right);\n";
     }
 }
-SLANG_RAW("#line 1264 \"core.meta.slang\"")
+SLANG_RAW("#line 1281 \"core.meta.slang\"")
 SLANG_RAW("\n")
 SLANG_RAW("\n")
 SLANG_RAW("// Specialized function\n")

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -1367,6 +1367,22 @@ void CLikeSourceEmitter::emitIntrinsicCallExprImpl(
                 }
                 break;
 
+            case 'T':
+                // Get the the 'element' type for the type of the param at the index
+                {
+                    SLANG_RELEASE_ASSERT(*cursor >= '0' && *cursor <= '9');
+                    Index argIndex = (*cursor++) - '0';
+                    SLANG_RELEASE_ASSERT(argCount > argIndex);
+
+                    IRType* type = args[argIndex].get()->getDataType();
+                    if (auto baseTextureType = as<IRTextureType>(type))
+                    {
+                        type = baseTextureType->getElementType();
+                    }
+                    emitType(type);
+                }
+                break;
+            
             case 'S':
                 // Get the scalar type of a generic at specified index
                 {

--- a/tests/compute/entry-point-uniform-params.slang
+++ b/tests/compute/entry-point-uniform-params.slang
@@ -34,7 +34,7 @@ ConstantBuffer<Signs> signs;
 void computeMain(
 //TEST_INPUT:cbuffer(data=[2 0 0 0 3 0 0 0]):name=stuff
 	uniform Stuff  stuff,
-//TEST_INPUT:cbuffer(data=[3]):isCPUOnly,name=things
+//TEST_INPUT:cbuffer(data=[3]):onlyCPULikeBinding,name=things
 	uniform Things things,
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer

--- a/tools/render-test/cuda/cuda-compute-util.h
+++ b/tools/render-test/cuda/cuda-compute-util.h
@@ -36,7 +36,7 @@ struct CUDAComputeUtil
         List<BindSet::Value*> m_buffers;
     };
 
-    static SlangResult execute(const ShaderCompilerUtil::OutputAndLayout& outputAndLayout, Context& outContext);
+    static SlangResult execute(const ShaderCompilerUtil::OutputAndLayout& outputAndLayout, const uint32_t dispatchSize[3], Context& outContext);
 
     static bool canCreateDevice();
 };

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -613,7 +613,7 @@ SLANG_TEST_TOOL_API SlangResult innerMain(Slang::StdWriters* stdWriters, SlangSe
         const uint64_t startTicks = ProcessUtil::getClockTick();
 
         CUDAComputeUtil::Context context;
-        SLANG_RETURN_ON_FAIL(CUDAComputeUtil::execute(compilationAndLayout, context));
+        SLANG_RETURN_ON_FAIL(CUDAComputeUtil::execute(compilationAndLayout, gOptions.computeDispatchSize, context));
 
         if (gOptions.performanceProfile)
         {

--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -56,8 +56,9 @@ namespace renderer_test
         return -1;
     }
 
-    static bool _isCPUTarget(SlangCompileTarget target)
+    static bool _isCPULikeBindingTarget(SlangCompileTarget target)
     {
+        // CUDA and C++ are 'CPULike' in terms of their binding mechanism
         switch (target)
         {
             case SLANG_C_SOURCE:
@@ -65,16 +66,6 @@ namespace renderer_test
             case SLANG_EXECUTABLE:
             case SLANG_SHARED_LIBRARY:
             case SLANG_HOST_CALLABLE:
-            {
-                return true;
-            }
-            default: return false;
-        }
-    }
-    static bool _isPTXTarget(SlangCompileTarget target)
-    {
-        switch (target)
-        {
             case SLANG_CUDA_SOURCE:
             case SLANG_PTX:
             {
@@ -84,16 +75,15 @@ namespace renderer_test
         }
     }
 
-
     void ShaderInputLayout::updateForTarget(SlangCompileTarget target)
     {
-        if (!_isCPUTarget(target) && !_isPTXTarget(target))
+        if (!_isCPULikeBindingTarget(target))
         {
             int count = int(entries.getCount());
             for (int i = 0; i < count; ++i)
             {
                 auto& entry = entries[i];
-                if (entry.isCPUOnly)
+                if (entry.onlyCPULikeBinding)
                 {
                     entries.removeAt(i);
                     i--;
@@ -475,9 +465,9 @@ namespace renderer_test
                             parser.Read(":");
                             while (!parser.IsEnd())
                             {
-                                if (parser.LookAhead("isCPUOnly"))
+                                if (parser.LookAhead("onlyCPULikeBinding"))
                                 {
-                                    entry.isCPUOnly = true;
+                                    entry.onlyCPULikeBinding = true;
                                     parser.ReadToken();
                                 }
                                 else if (parser.LookAhead("out"))

--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -71,10 +71,23 @@ namespace renderer_test
             default: return false;
         }
     }
+    static bool _isPTXTarget(SlangCompileTarget target)
+    {
+        switch (target)
+        {
+            case SLANG_CUDA_SOURCE:
+            case SLANG_PTX:
+            {
+                return true;
+            }
+            default: return false;
+        }
+    }
+
 
     void ShaderInputLayout::updateForTarget(SlangCompileTarget target)
     {
-        if (!_isCPUTarget(target))
+        if (!_isCPUTarget(target) && !_isPTXTarget(target))
         {
             int count = int(entries.getCount());
             for (int i = 0; i < count; ++i)

--- a/tools/render-test/shader-input-layout.h
+++ b/tools/render-test/shader-input-layout.h
@@ -71,7 +71,7 @@ public:
     InputSamplerDesc samplerDesc;
     ArrayDesc arrayDesc;
     bool isOutput = false;
-    bool isCPUOnly = false;
+    bool onlyCPULikeBinding = false;        ///< If true, only use on targets that have 'uniform' or 'CPU like' binding, like CPU and CUDA
 
     Slang::String name;                     ///< Optional name. Useful for binding through reflection.
 };

--- a/tools/render-test/shader-renderer-util.cpp
+++ b/tools/render-test/shader-renderer-util.cpp
@@ -176,7 +176,7 @@ static RefPtr<SamplerState> _createSamplerState(
     for (Index i = 0; i < numEntries; i++)
     {
         const ShaderInputLayoutEntry& srcEntry = srcEntries[i];
-        SLANG_ASSERT(srcEntry.isCPUOnly == false);
+        SLANG_ASSERT(srcEntry.isUniformBindingOnly == false);
 
         DescriptorSetLayout::SlotRangeDesc slotRangeDesc;
 

--- a/tools/render-test/shader-renderer-util.cpp
+++ b/tools/render-test/shader-renderer-util.cpp
@@ -176,7 +176,7 @@ static RefPtr<SamplerState> _createSamplerState(
     for (Index i = 0; i < numEntries; i++)
     {
         const ShaderInputLayoutEntry& srcEntry = srcEntries[i];
-        SLANG_ASSERT(srcEntry.isUniformBindingOnly == false);
+        SLANG_ASSERT(srcEntry.onlyCPULikeBinding == false);
 
         DescriptorSetLayout::SlotRangeDesc slotRangeDesc;
 


### PR DESCRIPTION
* Add support for SampleLevel
  * Fixed problem with Sample - used the wrong type
* Added $T 'special macro magic' option. 
* Fixed kernel launch for CUDA to take into account blocks
* Turned isCPUOnly hack into 'onlyCPULikeBinding'. Still horrible - but hey it now works on CUDA!
