### PR TITLE
Add two missing RAY_FLAG cases

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -1605,6 +1605,8 @@ static const RAY_FLAG RAY_FLAG_CULL_BACK_FACING_TRIANGLES       = 0x10;
 static const RAY_FLAG RAY_FLAG_CULL_FRONT_FACING_TRIANGLES      = 0x20;
 static const RAY_FLAG RAY_FLAG_CULL_OPAQUE                      = 0x40;
 static const RAY_FLAG RAY_FLAG_CULL_NON_OPAQUE                  = 0x80;
+static const RAY_FLAG RAY_FLAG_SKIP_TRIANGLES                   = 0x100;
+static const RAY_FLAG RAY_FLAG_SKIP_PROCEDURAL_PRIMITIVES       = 0x200;
 
 // 10.1.2 - Ray Description Structure
 


### PR DESCRIPTION
These new cases were added in DXR 1.1 (Shader Model 6.5), while the `enum` type came from DXR 1.0, so that I failed to revisit it when adding the new features.