### PR TITLE
Fix some IR logic around load from a rate-qualified pointer

### DIFF
--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -244,7 +244,7 @@ namespace Slang
     {
         if( auto rateQualType = as<IRRateQualifiedType>(type) )
         {
-            type = rateQualType->getDataType();
+            type = rateQualType->getValueType();
         }
 
         // The "true" pointers and the pointer-like stdlib types are the easy cases.


### PR DESCRIPTION
We currently represent the `groupshared` qualifier as a kind of "rate" at the IR level (where a rate can qualify a type to indicate the frequency/rate at which a value is stored and/or computed). This means that when computing the type that a pointer points to, we need to handle both, e.g., `Ptr<Int>` and `@GroupShared Ptr<Int>`.

The logic that was trying to handle the rate-qualified case when deducing the "pointee" type of a pointer was somehow written incorrectly, and was querying `getDataType()` on an `IRRateQualifiedType` which is asking for the type of the type itself (null in this case), rather than `getValueType()` which gets the `T` part from a rate-qualified type `@R T`.

Somehow none of our tests were hitting this case, and I'm not immediately clear on how to write a targeted reproducer for this, since the problem arose as a debug-only assertion failure in a user shader with thousands of lines.