### PR TITLE
Constant time dynamic cast

### DIFF
--- a/source/slang/slang-syntax-base-defs.h
+++ b/source/slang/slang-syntax-base-defs.h
@@ -6,8 +6,8 @@
 
 ABSTRACT_SYNTAX_CLASS(NodeBase, RefObject)
     // A helper to access the corresponding class on a concrete instance
-    RAW(virtual SyntaxClass<NodeBase> getClass() = 0;)
     RAW(virtual const SyntaxClassBase::ClassInfo& getClassInfo() const = 0;)
+    RAW(SyntaxClass<NodeBase> getClass() { return SyntaxClass<NodeBase>(&getClassInfo()); } )
 END_SYNTAX_CLASS()
 
 // Base class for all nodes representing actual syntax

--- a/source/slang/slang-syntax-base-defs.h
+++ b/source/slang/slang-syntax-base-defs.h
@@ -6,9 +6,8 @@
 
 ABSTRACT_SYNTAX_CLASS(NodeBase, RefObject)
     // A helper to access the corresponding class on a concrete instance
-    RAW(
-    virtual SyntaxClass<NodeBase> getClass() = 0;
-    )
+    RAW(virtual SyntaxClass<NodeBase> getClass() = 0;)
+    RAW(virtual const SyntaxClassBase::ClassInfo& getClassInfo() const = 0;)
 END_SYNTAX_CLASS()
 
 // Base class for all nodes representing actual syntax

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -35,15 +35,14 @@ namespace Slang
     SyntaxClassBase::ClassInfo const SyntaxClassBase::Impl<NAME>::kClassInfo(#NAME, nullptr, &SyntaxClassBase::Impl<BASE>::kClassInfo);
 
 #define SYNTAX_CLASS(NAME, BASE)                                                \
-    void NAME::accept(NAME::Visitor* visitor, void* extra)                      \
-    { visitor->dispatch_##NAME(this, extra); }                                  \
     template<>                                                                  \
     void* SyntaxClassBase::Impl<NAME>::createFunc() { return new NAME(); }      \
-    SyntaxClass<NodeBase> NAME::getClass() { return Slang::getClass<NAME>(); }  \
-    const SyntaxClassBase::ClassInfo& NAME::getClassInfo() const { return SyntaxClassBase::Impl<NAME>::kClassInfo; } \
     template<>                                                                  \
-    SyntaxClassBase::ClassInfo const SyntaxClassBase::Impl<NAME>::kClassInfo( #NAME, &SyntaxClassBase::Impl<NAME>::createFunc, &SyntaxClassBase::Impl<BASE>::kClassInfo);
-
+    SyntaxClassBase::ClassInfo const SyntaxClassBase::Impl<NAME>::kClassInfo( #NAME, &SyntaxClassBase::Impl<NAME>::createFunc, &SyntaxClassBase::Impl<BASE>::kClassInfo); \
+    void NAME::accept(NAME::Visitor* visitor, void* extra)                      \
+    { visitor->dispatch_##NAME(this, extra); }                                  \
+    const SyntaxClassBase::ClassInfo& NAME::getClassInfo() const { return SyntaxClassBase::Impl<NAME>::kClassInfo; }  
+    
 template<>
 SyntaxClassBase::ClassInfo const SyntaxClassBase::Impl<RefObject>::kClassInfo("RefObject", nullptr, nullptr);
 

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -80,8 +80,8 @@ SyntaxClassBase::ClassInfo::ClassInfo(const char* name, CreateFunc createFunc, c
     m_superClass(superClass),
     m_next(s_first)
 {
-    m_rangeStart = 0;
-    m_rangeEnd = 0;
+    m_classId = 0;
+    m_childrenEndClassId = 0;
 
     s_first = this;
 }
@@ -90,7 +90,7 @@ SyntaxClassBase::ClassInfo::ClassInfo(const char* name, CreateFunc createFunc, c
 
 static uint32_t _calcRangeRec(const SyntaxClassBase::ClassInfo* classInfo, const Dictionary<const SyntaxClassBase::ClassInfo*, List<const SyntaxClassBase::ClassInfo*> >& childMap, uint32_t index)
 {
-    classInfo->m_rangeStart = index++;
+    classInfo->m_classId = index++;
     // Do the calc range for all the children
     auto list = childMap.TryGetValue(classInfo);
 
@@ -102,7 +102,7 @@ static uint32_t _calcRangeRec(const SyntaxClassBase::ClassInfo* classInfo, const
         }
     }
 
-    classInfo->m_rangeEnd = index;
+    classInfo->m_childrenEndClassId = index;
     return index;
 }
 

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -8,6 +8,9 @@
 
 namespace Slang
 {
+    // We want this first, before the kClassInfo variables so it is constructed before anything else. 
+    /* static*/ SyntaxClassBase::ClassInfo* SyntaxClassBase::ClassInfo::s_first = nullptr;
+
     // BasicExpressionType
 
     bool BasicExpressionType::EqualsImpl(Type * type)
@@ -70,9 +73,6 @@ ABSTRACT_SYNTAX_CLASS(GlobalGenericParamSubstitution, Substitutions);
 #include "slang-type-defs.h"
 #include "slang-val-defs.h"
 #include "slang-object-meta-end.h"
-
-
-/* static*/ SyntaxClassBase::ClassInfo* SyntaxClassBase::ClassInfo::s_first = nullptr;
 
 SyntaxClassBase::ClassInfo::ClassInfo(const char* name, CreateFunc createFunc, const ClassInfo* superClass):
     m_name(name),

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -32,7 +32,7 @@ namespace Slang
 
 #define ABSTRACT_SYNTAX_CLASS(NAME, BASE)   \
     template<>                              \
-    SyntaxClassBase::ClassInfo const SyntaxClassBase::Impl<NAME>::kClassInfo = { #NAME, &SyntaxClassBase::Impl<BASE>::kClassInfo, nullptr };
+    SyntaxClassBase::ClassInfo const SyntaxClassBase::Impl<NAME>::kClassInfo(#NAME, nullptr, &SyntaxClassBase::Impl<BASE>::kClassInfo);
 
 #define SYNTAX_CLASS(NAME, BASE)                                                \
     void NAME::accept(NAME::Visitor* visitor, void* extra)                      \
@@ -40,11 +40,12 @@ namespace Slang
     template<>                                                                  \
     void* SyntaxClassBase::Impl<NAME>::createFunc() { return new NAME(); }      \
     SyntaxClass<NodeBase> NAME::getClass() { return Slang::getClass<NAME>(); }  \
+    const SyntaxClassBase::ClassInfo& NAME::getClassInfo() const { return SyntaxClassBase::Impl<NAME>::kClassInfo; } \
     template<>                                                                  \
-    SyntaxClassBase::ClassInfo const SyntaxClassBase::Impl<NAME>::kClassInfo = { #NAME, &SyntaxClassBase::Impl<BASE>::kClassInfo, &SyntaxClassBase::Impl<NAME>::createFunc };
+    SyntaxClassBase::ClassInfo const SyntaxClassBase::Impl<NAME>::kClassInfo( #NAME, &SyntaxClassBase::Impl<NAME>::createFunc, &SyntaxClassBase::Impl<BASE>::kClassInfo);
 
 template<>
-SyntaxClassBase::ClassInfo const SyntaxClassBase::Impl<RefObject>::kClassInfo = { "RefObject", nullptr, nullptr };
+SyntaxClassBase::ClassInfo const SyntaxClassBase::Impl<RefObject>::kClassInfo("RefObject", nullptr, nullptr);
 
 ABSTRACT_SYNTAX_CLASS(NodeBase, RefObject);
 ABSTRACT_SYNTAX_CLASS(SyntaxNodeBase, NodeBase);
@@ -71,26 +72,117 @@ ABSTRACT_SYNTAX_CLASS(GlobalGenericParamSubstitution, Substitutions);
 #include "slang-val-defs.h"
 #include "slang-object-meta-end.h"
 
-bool SyntaxClassBase::isSubClassOfImpl(SyntaxClassBase const& super) const
-{
-    SyntaxClassBase::ClassInfo const* info = classInfo;
-    while (info)
-    {
-        if (info == super.classInfo)
-            return true;
 
-        info = info->baseClass;
+/* static*/ SyntaxClassBase::ClassInfo* SyntaxClassBase::ClassInfo::s_first = nullptr;
+
+SyntaxClassBase::ClassInfo::ClassInfo(const char* name, CreateFunc createFunc, const ClassInfo* superClass):
+    m_name(name),
+    m_createFunc(createFunc),
+    m_superClass(superClass),
+    m_next(s_first)
+{
+    m_rangeStart = 0;
+    m_rangeEnd = 0;
+
+    s_first = this;
+}
+
+
+
+static uint32_t _calcRangeRec(const SyntaxClassBase::ClassInfo* classInfo, const Dictionary<const SyntaxClassBase::ClassInfo*, List<const SyntaxClassBase::ClassInfo*> >& childMap, uint32_t index)
+{
+    classInfo->m_rangeStart = index++;
+    // Do the calc range for all the children
+    auto list = childMap.TryGetValue(classInfo);
+
+    if (list)
+    {
+        for (auto child : *list)
+        {
+            index = _calcRangeRec(child, childMap, index);
+        }
     }
 
+    classInfo->m_rangeEnd = index;
+    return index;
+}
+
+bool SyntaxClassBase::ClassInfo::isSubClassOfSlow(const ThisType& super) const
+{
+    SyntaxClassBase::ClassInfo const* info = this;
+    while (info)
+    {
+        if (info == &super)
+            return true;
+        info = info->m_superClass;
+    }
     return false;
 }
 
-NodeBase* _dynamicCastImpl(NodeBase* node, SyntaxClassBase const& toClass)
+static bool _checkSubClassRange()
 {
-    if(!node) return nullptr;
-    if(node->getClass().isSubClassOfImpl(toClass))
-        return node;
-    return nullptr;
+    typedef SyntaxClassBase::ClassInfo ClassInfo;
+
+    List<const ClassInfo*> list;
+    for (const ClassInfo* type = ClassInfo::s_first; type; type = type->m_next)
+    {
+        list.add(type);
+    }
+
+    for (Index i = 0; i < list.getCount(); ++i)
+    {
+        for (Index j = 0; j < list.getCount(); ++j)
+        {
+            auto a = list[i];
+            auto b = list[j];
+            if (a->isSubClassOf(*b) != a->isSubClassOfSlow(*b))
+            {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+
+/* static */SlangResult SyntaxClassBase::ClassInfo::initRanges()
+{
+    // Remove the warning about not referenced
+    SLANG_UNUSED(&_checkSubClassRange);
+
+    // TODO(JS):
+    // Note that the calculating of the ranges could be done more efficiently by adding to an array of struct { super, class }, sorting, by super classs
+    // and using a dictionary to map from class it's first in list of super class use. This works for now though.
+  
+    // We want to produce a map from a node that holds all of it's children
+    Dictionary<const ThisType*, List<const ThisType*> > childMap;
+
+    const List<const ThisType*> emptyList;
+
+    {
+         for (const ThisType* type = s_first; type; type = type->m_next)
+         {
+             if (type->m_superClass)
+             {
+                 // Add to that item
+                 List<const ThisType*>* list = childMap.TryGetValueOrAdd(type->m_superClass, emptyList);
+                 if (!list)
+                 {
+                     list = childMap.TryGetValue(type->m_superClass);
+                 }
+                 SLANG_ASSERT(list);
+                 list->add(type);
+             }
+         }
+    }
+
+    // We want to recursively work out a range
+    _calcRangeRec(&SyntaxClassBase::Impl<RefObject>::kClassInfo, childMap, 1);
+
+    SLANG_ASSERT(_checkSubClassRange());
+
+    return SLANG_OK;
 }
 
 

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -488,7 +488,7 @@ namespace Slang
                 /// Non inclusive end of range of children.
             mutable uint32_t m_childrenEndClassId;        
 
-            const ClassInfo* m_superClass;          ///< Base class for runtime queries
+            const ClassInfo* m_superClass;          ///< The super class of this class, or nullptr if has no super class. 
             const char* m_name;                     ///< Textual class name, for debugging 
             CreateFunc m_createFunc;                ///< Callback to use when creating instances
             

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -468,13 +468,14 @@ namespace Slang
                 /// A constant time implementation of isSubClassOf
             SLANG_FORCE_INLINE bool isSubClassOf(const ThisType& super) const
             {
-                return m_rangeStart >= super.m_rangeStart && m_rangeStart < super.m_rangeEnd;
+                // We include super.m_classId, because it's a subclass of itself.
+                return m_classId >= super.m_classId && m_classId < super.m_childrenEndClassId;
             }
                 /// Will produce the same result as isSubClassOf, but more slowly by traversing the m_superClass
                 /// Works without initRange being called. 
             bool isSubClassOfSlow(const ThisType& super) const;
 
-                /// This function must have been called before any dynamic casting will work
+                /// This function must have been called before any dynamic casting will work (via the m_classId/m_childrenEndClassId.
                 /// It sets up the m_rangeStart/m_rangeEnd values to make.
                 /// Is called within the creation of Session
             static SlangResult initRanges();
@@ -482,8 +483,10 @@ namespace Slang
                 /// Ctor
             ClassInfo(const char* name, CreateFunc createFunc, const ClassInfo* superClass);
 
-            mutable uint32_t m_rangeStart;          ///< The first element is for this class
-            mutable uint32_t m_rangeEnd;            ///< Non inclusive end of range
+                /// The id for this class. The children of this class are in the range of m_classId + 1 to (but not including) m_childrenEndId.
+            mutable uint32_t m_classId;
+                /// Non inclusive end of range of children.
+            mutable uint32_t m_childrenEndClassId;        
 
             const ClassInfo* m_superClass;          ///< Base class for runtime queries
             const char* m_name;                     ///< Textual class name, for debugging 

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -463,14 +463,34 @@ namespace Slang
         // Run-time type representation for syntax nodes
         struct ClassInfo
         {
-            // Textual class name, for debugging
-            char const* name;
+            typedef ClassInfo ThisType;
 
-            // Base class for runtime queries
-            ClassInfo const*  baseClass;
+                /// A constant time implementation of isSubClassOf
+            SLANG_FORCE_INLINE bool isSubClassOf(const ThisType& super) const
+            {
+                return m_rangeStart >= super.m_rangeStart && m_rangeStart < super.m_rangeEnd;
+            }
+                /// Will produce the same result as isSubClassOf, but more slowly by traversing the m_superClass
+                /// Works without initRange being called. 
+            bool isSubClassOfSlow(const ThisType& super) const;
 
-            // Callback to use when creating instances
-            CreateFunc createFunc;
+                /// This function must have been called before any dynamic casting will work
+                /// It sets up the m_rangeStart/m_rangeEnd values to make.
+                /// Is called within the creation of Session
+            static SlangResult initRanges();
+
+                /// Ctor
+            ClassInfo(const char* name, CreateFunc createFunc, const ClassInfo* superClass);
+
+            mutable uint32_t m_rangeStart;          ///< The first element is for this class
+            mutable uint32_t m_rangeEnd;            ///< Non inclusive end of range
+
+            const ClassInfo* m_superClass;          ///< Base class for runtime queries
+            const char* m_name;                     ///< Textual class name, for debugging 
+            CreateFunc m_createFunc;                ///< Callback to use when creating instances
+            
+            ClassInfo* m_next;                      ///< Next in list starting from s_first
+            static ClassInfo* s_first;
         };
 
         SyntaxClassBase()
@@ -485,13 +505,13 @@ namespace Slang
             auto ci = classInfo;
             if (!ci) return nullptr;
 
-            auto cf = ci->createFunc;
+            auto cf = ci->m_createFunc;
             if (!cf) return nullptr;
 
             return cf();
         }
 
-        bool isSubClassOfImpl(SyntaxClassBase const& super) const;
+        SLANG_FORCE_INLINE bool isSubClassOfImpl(SyntaxClassBase const& super) const { return classInfo->isSubClassOf(*super.classInfo); }
 
         ClassInfo const* classInfo = nullptr;
 
@@ -549,23 +569,18 @@ namespace Slang
         return SyntaxClass<T>::getClass();
     }
 
-    NodeBase* _dynamicCastImpl(NodeBase* node, SyntaxClassBase const& toClass);
+    template<typename T>
+    SLANG_FORCE_INLINE T* dynamicCast(NodeBase* node);
 
     template<typename T>
-    T* dynamicCast(NodeBase* node)
-    {
-        return (T*) _dynamicCastImpl(node, getClass<T>());
-    }
+    SLANG_FORCE_INLINE const T* dynamicCast(const NodeBase* node);
 
     template<typename T>
-    const T* dynamicCast(const NodeBase* node) { return dynamicCast<T>(const_cast<NodeBase*>(node)); }
+    SLANG_FORCE_INLINE T* as(NodeBase* node);
 
     template<typename T>
-    T* as(NodeBase* node) { return dynamicCast<T>(node); }
-
-    template<typename T>
-    const T* as(const NodeBase* node) { return dynamicCast<T>(const_cast<NodeBase*>(node)); }
-
+    SLANG_FORCE_INLINE const T* as(const NodeBase* node);
+    
     struct SubstitutionSet
     {
         RefPtr<Substitutions> substitutions;
@@ -1306,6 +1321,7 @@ namespace Slang
     class NAME : public BASE {                                          \
     virtual void accept(NAME::Visitor* visitor, void* extra) override;  \
     public: virtual SyntaxClass<NodeBase> getClass() override;          \
+    public: virtual const SyntaxClassBase::ClassInfo& getClassInfo() const override; \
     public: /* ... */
 #include "slang-expr-defs.h"
 #include "slang-decl-defs.h"
@@ -1569,6 +1585,30 @@ namespace Slang
 
         /// Get the module that a declaration is associated with, if any.
     Module* getModule(Decl* decl);
+
+    template<typename T>
+    SLANG_FORCE_INLINE T* dynamicCast(NodeBase* node)
+    {
+        return (node && node->getClassInfo().isSubClassOf(SyntaxClassBase::Impl<T>::kClassInfo)) ? static_cast<T*>(node) : nullptr; 
+    }
+
+    template<typename T>
+    SLANG_FORCE_INLINE const T* dynamicCast(const NodeBase* node)
+    {
+        return (node && node->getClassInfo().isSubClassOf(SyntaxClassBase::Impl<T>::kClassInfo)) ? static_cast<const T*>(node) : nullptr;
+    }
+
+    template<typename T>
+    SLANG_FORCE_INLINE T* as(NodeBase* node)
+    {
+        return (node && node->getClassInfo().isSubClassOf(SyntaxClassBase::Impl<T>::kClassInfo)) ? static_cast<T*>(node) : nullptr;
+    }
+
+    template<typename T>
+    SLANG_FORCE_INLINE const T* as(const NodeBase* node)
+    {
+        return (node && node->getClassInfo().isSubClassOf(SyntaxClassBase::Impl<T>::kClassInfo)) ? static_cast<const T*>(node) : nullptr;
+    }
 
 } // namespace Slang
 

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -1320,8 +1320,7 @@ namespace Slang
 #define SYNTAX_CLASS(NAME, BASE, ...)                                   \
     class NAME : public BASE {                                          \
     virtual void accept(NAME::Visitor* visitor, void* extra) override;  \
-    public: virtual SyntaxClass<NodeBase> getClass() override;          \
-    public: virtual const SyntaxClassBase::ClassInfo& getClassInfo() const override; \
+    public: virtual const SyntaxClassBase::ClassInfo& getClassInfo() const override;          \
     public: /* ... */
 #include "slang-expr-defs.h"
 #include "slang-decl-defs.h"

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -116,20 +116,21 @@ void Session::init()
     // Set all the shared library function pointers to nullptr
     ::memset(m_sharedLibraryFunctions, 0, sizeof(m_sharedLibraryFunctions));
 
+    {
+        static auto res = SyntaxClassBase::ClassInfo::initRanges();
+    }
+
     // Initialize the lookup table of syntax classes:
 
-    #define SYNTAX_CLASS(NAME, BASE) \
-        mapNameToSyntaxClass.Add(getNamePool()->getName(#NAME), getClass<NAME>());
-
-#include "slang-object-meta-begin.h"
-#include "slang-syntax-base-defs.h"
-#include "slang-expr-defs.h"
-#include "slang-decl-defs.h"
-#include "slang-modifier-defs.h"
-#include "slang-stmt-defs.h"
-#include "slang-type-defs.h"
-#include "slang-val-defs.h"
-#include "slang-object-meta-end.h"
+    // We can just iterate over the class pointers.
+    // NOTE! That this adds the names of the abstract classes too(!)
+    {
+        const SyntaxClassBase::ClassInfo* info = SyntaxClassBase::ClassInfo::s_first;
+        for (; info; info = info->m_next)
+        {
+            mapNameToSyntaxClass.Add(getNamePool()->getName(info->m_name), SyntaxClass<Slang::RefObject>(info));
+        }
+    }
 
     // Make sure our source manager is initialized
     builtinSourceManager.initialize(nullptr, nullptr);


### PR DESCRIPTION
* Replaced getClass with getClassInfo on NodeBase
* Calculate a range for each ClassInfo that all sub classes must be in
* Implement dynamic cast/as inline
* Use range for dynamic casting

On Visual Studio nearly halves stdlib compile time on release.