### PR TITLE
Feature/profile tool

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -749,11 +749,7 @@ if enableProfile then
         
         -- gprof needs symbols
         symbols "On"
-
-        filter { "system:linux" }
-            linkoptions{  "-pg" }
-            buildoptions{ "-pg" }
-
+        
         dependson { "slang" }
 
         includedirs { "external/spirv-headers/include" }
@@ -772,6 +768,11 @@ if enableProfile then
 
         includedirs { "." }
         links { "core"}
+        
+        filter { "system:linux" }
+            linkoptions{  "-pg" }
+            buildoptions{ "-pg" }
+
 end
 
 if buildGlslang then

--- a/premake5.lua
+++ b/premake5.lua
@@ -92,11 +92,20 @@ newoption {
    allowed     = { { "true", "True"}, { "false", "False" } }
 }
 
+newoption {
+   trigger     = "enable-profile",
+   description = "(Optional) If true will enable slang-profile tool - suitable for gprof usage on linux",
+   value       = "bool",
+   default     = "false",
+   allowed     = { { "true", "True"}, { "false", "False" } }
+}
+
 buildLocation = _OPTIONS["build-location"]
 executeBinary = (_OPTIONS["execute-binary"] == "true")
 targetDetail = _OPTIONS["target-detail"]
 buildGlslang = (_OPTIONS["build-glslang"] == "true")
 enableCuda = (_OPTIONS["enable-cuda"] == "true")
+enableProfile = (_OPTIONS["enable-profile"] == "true")
 
 -- cudaPath is only set if cuda is enabled, and CUDA_PATH enviromental variable is set
 cudaPath = nil
@@ -733,6 +742,34 @@ standardProject "slang"
             --
             buildinputs { "%{cfg.targetdir}/slang-generate" .. executableSuffix }
     end
+
+if enableProfile then
+    tool "slang-profile"
+        uuid "375CC87D-F34A-4DF1-9607-C5C990FD6227"
+
+        filter { "system:linux" }
+            linkoptions{  "-pg" }
+            buildoptions{ "-pg" }
+
+        dependson { "slang" }
+
+        includedirs { "external/spirv-headers/include" }
+
+        defines { "SLANG_STATIC" }
+
+        -- The `standardProject` operation already added all the code in
+        -- `source/slang/*`, but we also want to incldue the umbrella
+        -- `slang.h` header in this prject, so we do that manually here.
+        files { "slang.h" }
+
+        files { "source/core/core.natvis" }
+
+        -- Add the slang source
+        addSourceDir "source/slang"
+
+        includedirs { "." }
+        links { "core"}
+end
 
 if buildGlslang then
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -746,6 +746,9 @@ standardProject "slang"
 if enableProfile then
     tool "slang-profile"
         uuid "375CC87D-F34A-4DF1-9607-C5C990FD6227"
+        
+        -- gprof needs symbols
+        symbols "On"
 
         filter { "system:linux" }
             linkoptions{  "-pg" }

--- a/source/core/slang-std-writers.cpp
+++ b/source/core/slang-std-writers.cpp
@@ -30,13 +30,5 @@ namespace Slang
     return defaults;
 }
 
-void StdWriters::setRequestWriters(SlangCompileRequest* request)
-{
-    for (int i = 0; i < SLANG_WRITER_CHANNEL_COUNT_OF; ++i)
-    {
-        spSetWriter(request, SlangWriterChannel(i), m_writers[i]);
-    }
-}
-
 }
 

--- a/source/core/slang-std-writers.h
+++ b/source/core/slang-std-writers.h
@@ -12,11 +12,8 @@ class StdWriters: public RefObject
 {
 public:
 
-    ISlangWriter * getWriter(SlangWriterChannel chan) const { return m_writers[chan]; }
+    ISlangWriter* getWriter(SlangWriterChannel chan) const { return m_writers[chan]; }
     void setWriter(SlangWriterChannel chan, ISlangWriter* writer) { m_writers[chan] = writer; }
-
-        /// Set the writers on the SlangCompileRequest
-    void setRequestWriters(SlangCompileRequest* request);
 
         /// Ctor
     StdWriters() {}

--- a/tools/slang-profile/slang-profile-main.cpp
+++ b/tools/slang-profile/slang-profile-main.cpp
@@ -1,0 +1,41 @@
+// slang-profile-main.cpp
+
+#include "../../source/core/slang-io.h"
+#include "../../source/core/slang-std-writers.h"
+
+#include "../../source/core/slang-process-util.h"
+
+#include "../../slang-com-helper.h"
+
+#include "../../source/core/slang-string-util.h"
+
+using namespace Slang;
+
+SlangResult innerMain(int argc, char** argv)
+{
+    auto stdWriters = StdWriters::initDefaultSingleton();
+
+    // Time the creation of the session
+    {
+        const auto startTick = ProcessUtil::getClockTick();
+
+        ComPtr<slang::IGlobalSession> slangSession;
+        slangSession.attach(spCreateSession(nullptr));
+
+        const auto endTick = ProcessUtil::getClockTick();
+
+        printf("Ticks %f\n", double(endTick - startTick) / ProcessUtil::getClockFrequency());
+        return SLANG_OK;
+    }
+
+    return SLANG_OK;
+}
+
+int main(int argc, char** argv)
+{
+    const SlangResult res = innerMain(argc, argv);
+#ifdef _MSC_VER
+    _CrtDumpMemoryLeaks();
+#endif
+    return SLANG_SUCCEEDED(res) ? 0 : 1;
+}

--- a/tools/slang-reflection-test/slang-reflection-test-main.cpp
+++ b/tools/slang-reflection-test/slang-reflection-test-main.cpp
@@ -1272,8 +1272,10 @@ SLANG_TEST_TOOL_API SlangResult innerMain(Slang::StdWriters* stdWriters, SlangSe
     Slang::StdWriters::setSingleton(stdWriters);
     
     SlangCompileRequest* request = spCreateCompileRequest(session);
-
-    stdWriters->setRequestWriters(request);
+    for (int i = 0; i < SLANG_WRITER_CHANNEL_COUNT_OF; ++i)
+    {
+        spSetWriter(request, SlangWriterChannel(i), stdWriters->getWriter(i));
+    }
 
     char const* appName = "slang-reflection-test";
     if (argc > 0) appName = argv[0];

--- a/tools/slang-test/slangc-tool.cpp
+++ b/tools/slang-test/slangc-tool.cpp
@@ -55,8 +55,11 @@ SlangResult SlangCTool::innerMain(StdWriters* stdWriters, SlangSession* session,
 
     spSetCommandLineCompilerMode(compileRequest);
     // Do any app specific configuration
-    stdWriters->setRequestWriters(compileRequest);
-
+    for (int i = 0; i < SLANG_WRITER_CHANNEL_COUNT_OF; ++i)
+    {
+        spSetWriter(compileRequest, SlangWriterChannel(i), stdWriters->getWriter(i));
+    }
+    
     SlangResult res = _compile(compileRequest, argc, argv);
 
     // Now that we are done, clean up after ourselves


### PR DESCRIPTION
* Added slang-profile 'tool'
  * For moment just times how long to compile stdlib 
* Statically links slang 
* Enables gprof on linux targets
* Moved a reference to slang library from core (confused profiler, because of different linkage)

Enable the option with 

`premake5 gmake --enable-profile=true`

