### PR TITLE
Check building with new glslang binaries on CI.

### DIFF
--- a/source/slang-glslang/slang-glslang.h
+++ b/source/slang-glslang/slang-glslang.h
@@ -59,7 +59,7 @@ struct glslang_CompileRequest_1_0
     unsigned            debugInfoType;   
 };
 
-// 1.1 version
+// 1.1 version  
 struct glslang_CompileRequest_1_1
 {
         /// Set from 1.0 


### PR DESCRIPTION
A change to force CI builds using new glslang binaries.