### PR TITLE
Diagnostic compare special case for stdlib line number changes

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -336,6 +336,7 @@ static const struct {
 
     {"bool",        "b"},
 };
+
 static const int kTypeCount = sizeof(kTypes) / sizeof(kTypes[0]);
 
 for (int tt = 0; tt < kTypeCount; ++tt)


### PR DESCRIPTION
* Added diagnostic compare which ignores line number changes in std libs.

This is a rather brute force fix. That one of the tests bad-operator.slang was breaking every small change was made to stdlib. The reason for the fail was that line numbers are included in the output, and they would change, even though the actual diagnostic would not.

This fix looks for lines that aren't the same. If they are from the standard libraries, and the the actual diagnostic is the same the line is allowed to be equal. This only happens on tests marked as DIAGNOSTIC_TEST, and currently only if it's a 'simple test'. 