### PR TITLE
Unroll target improvements

### DIFF
--- a/docs/target-compatibility.md
+++ b/docs/target-compatibility.md
@@ -34,6 +34,7 @@ Items with ^ means there is some discussion about support later in the document 
 | tex.Load                    |     Yes      |   Yes        |   Yes      |  Limited ^    |    Yes
 | Full bool                   |     Yes      |   Yes        |   Yes      |     No        |    Yes ^ 
 | Mesh Shader                 |     No       |   No +       |   No +     |     No        |    No
+| `[unroll]`                  |     Yes      |   Yes        |   No +     |     Yes       |    Limited + 
 
 ## Half Type
 
@@ -114,3 +115,12 @@ tex.Load is only supported on CUDA for Texture1D. Additionally CUDA only allows 
 Means fully featured bool support. CUDA has issues around bool because there isn't a vector bool type built in. Currently bool aliases to an int vector type. 
 
 On CPU there are some issues in so far as bool's size is not well defined in size an alignment. Most C++ compilers now use a byte to represent a bool. In the past it has been backed by an int on some compilers. 
+
+## `[unroll]`
+
+The unroll attribute allows for unrolling `for` loops. At the moment the feature is dependent on downstream compiler support which is mixed. In the longer term the intention is for Slang to contain it's own loop unroller - and therefore not be dependent on the feature on downstream compilers. 
+
+On C++ this attribute becomes SLANG_UNROLL which is defined in the prelude. This can be predefined if there is a suitable mechanism.  
+
+Slang does have a mechanism to [unroll loops directly within Slang code](languge-reference/06-statements.md), in the section `Compile-Time For Statement`.
+

--- a/docs/target-compatibility.md
+++ b/docs/target-compatibility.md
@@ -34,7 +34,7 @@ Items with ^ means there is some discussion about support later in the document 
 | tex.Load                    |     Yes      |   Yes        |   Yes      |  Limited ^    |    Yes
 | Full bool                   |     Yes      |   Yes        |   Yes      |     No        |    Yes ^ 
 | Mesh Shader                 |     No       |   No +       |   No +     |     No        |    No
-| `[unroll]`                  |     Yes      |   Yes        |   No +     |     Yes       |    Limited + 
+| `[unroll]`                  |     Yes      |   Yes        |   Yes ^    |     Yes       |    Limited + 
 
 ## Half Type
 
@@ -120,7 +120,9 @@ On CPU there are some issues in so far as bool's size is not well defined in siz
 
 The unroll attribute allows for unrolling `for` loops. At the moment the feature is dependent on downstream compiler support which is mixed. In the longer term the intention is for Slang to contain it's own loop unroller - and therefore not be dependent on the feature on downstream compilers. 
 
-On C++ this attribute becomes SLANG_UNROLL which is defined in the prelude. This can be predefined if there is a suitable mechanism.  
+On C++ this attribute becomes SLANG_UNROLL which is defined in the prelude. This can be predefined if there is a suitable mechanism, if there isn't a definition SLANG_UNROLL will be an empty definition. 
 
-Slang does have a mechanism to [unroll loops directly within Slang code](languge-reference/06-statements.md), in the section `Compile-Time For Statement`.
+On GLSL and VK targets loop unrolling uses the [GL_EXT_control_flow_attributes](https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GL_EXT_control_flow_attributes.txt) extension.
+
+Slang does have a cross target mechanism to [unroll loops](language-reference/06-statements.md), in the section `Compile-Time For Statement`.
 

--- a/prelude/slang-cpp-prelude.h
+++ b/prelude/slang-cpp-prelude.h
@@ -34,4 +34,8 @@
 #   pragma warning(disable : 4700)
 #endif
 
+#ifndef SLANG_UNROLL
+#   define SLANG_UNROLL
+#endif
+
 #endif

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -2592,37 +2592,8 @@ void CLikeSourceEmitter::emitRegion(Region* inRegion)
                 //
                 if (auto loopControlDecoration = loopInst->findDecoration<IRLoopControlDecoration>())
                 {
-                    const auto loopMode = loopControlDecoration->getMode();
-                    if (loopMode == kIRLoopControl_Unroll)
-                    {
-                        switch (getSourceStyle())
-                        {
-                            case SourceStyle::HLSL:
-                            {
-                                m_writer->emit("[unroll]\n");
-                                break;
-                            }
-                            case SourceStyle::GLSL:
-                            {
-                                // Note: loop unrolling control not available in GLSL
-                                break;
-                            }
-                            case SourceStyle::CUDA:
-                            {
-                                m_writer->emit("#pragma unroll\n");
-                                break;
-                            }
-                            case SourceStyle::C:
-                            case SourceStyle::CPP:
-                            {
-                                // This relies on a suitable definition in slang-cpp-prelude.h or defined in C++ compiler invocation.
-                                m_writer->emit("SLANG_UNROLL\n");
-                                break;
-                            }
-                            default: break;
-                        }
-                    }
-                }
+                    emitLoopControlDecorationImpl(loopControlDecoration);
+               }
 
                 m_writer->emit("for(;;)\n{\n");
                 m_writer->indent();

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -2592,17 +2592,38 @@ void CLikeSourceEmitter::emitRegion(Region* inRegion)
                 //
                 if (auto loopControlDecoration = loopInst->findDecoration<IRLoopControlDecoration>())
                 {
-                    switch (loopControlDecoration->getMode())
+                    const auto loopMode = loopControlDecoration->getMode();
+                    if (loopMode == kIRLoopControl_Unroll)
                     {
-                    case kIRLoopControl_Unroll:
-                        // Note: loop unrolling control is only available in HLSL, not GLSL
-                        if(getSourceStyle() == SourceStyle::HLSL)
+                        switch (getSourceStyle())
                         {
-                            m_writer->emit("[unroll]\n");
+                            case SourceStyle::HLSL:
+                            {
+                                m_writer->emit("[unroll]\n");
+                                break;
+                            }
+                            case SourceStyle::GLSL:
+                            {
+                                // Note: loop unrolling control not available in GLSL
+                                break;
+                            }
+                            case SourceStyle::CUDA:
+                            {
+                                m_writer->emit("#pragma unroll\n");
+                                break;
+                            }
+                            case SourceStyle::C:
+                            case SourceStyle::CPP:
+                            {
+                                // This relies on a suitable definition in slang-cpp-prelude.h or defined in C++ compiler invocation.
+                                m_writer->emit("SLANG_UNROLL\n");
+                                break;
+                            }
+                            default:
+                            {
+                                break;
+                            }
                         }
-                        break;
-
-                    default:
                         break;
                     }
                 }

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -2619,12 +2619,8 @@ void CLikeSourceEmitter::emitRegion(Region* inRegion)
                                 m_writer->emit("SLANG_UNROLL\n");
                                 break;
                             }
-                            default:
-                            {
-                                break;
-                            }
+                            default: break;
                         }
-                        break;
                     }
                 }
 

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -328,6 +328,7 @@ public:
     virtual void emitParamTypeImpl(IRType* type, String const& name);
     virtual void emitIntrinsicCallExprImpl(IRCall* inst, IRTargetIntrinsicDecoration* targetIntrinsic, EmitOpInfo const& inOuterPrec);
     virtual void emitFunctionPreambleImpl(IRInst* inst) { SLANG_UNUSED(inst); }
+    virtual void emitLoopControlDecorationImpl(IRLoopControlDecoration* decl) { SLANG_UNUSED(decl); }
 
         // Only needed for glsl output with $ prefix intrinsics - so perhaps removable in the future
     virtual void emitTextureOrTextureSamplerTypeImpl(IRTextureTypeBase*  type, char const* baseName) { SLANG_UNUSED(type); SLANG_UNUSED(baseName); }

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -1868,6 +1868,15 @@ void CPPSourceEmitter::emitIntrinsicCallExprImpl(
     return Super::emitIntrinsicCallExprImpl(inst, targetIntrinsic, inOuterPrec);
 }
 
+void CPPSourceEmitter::emitLoopControlDecorationImpl(IRLoopControlDecoration* decl)
+{
+    if (decl->getMode() == kIRLoopControl_Unroll)
+    {
+        // This relies on a suitable definition in slang-cpp-prelude.h or defined in C++ compiler invocation.
+        m_writer->emit("SLANG_UNROLL\n");
+    }
+}
+
 bool CPPSourceEmitter::_tryEmitInstExprAsIntrinsic(IRInst* inst, const EmitOpInfo& inOuterPrec)
 {
     HLSLIntrinsic* specOp = m_intrinsicSet.add(inst);

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -79,6 +79,7 @@ protected:
     virtual bool tryEmitGlobalParamImpl(IRGlobalParam* varDecl, IRType* varType) SLANG_OVERRIDE;
     virtual void emitIntrinsicCallExprImpl(IRCall* inst, IRTargetIntrinsicDecoration* targetIntrinsic, EmitOpInfo const& inOuterPrec) SLANG_OVERRIDE;
 
+    virtual void emitLoopControlDecorationImpl(IRLoopControlDecoration* decl) SLANG_OVERRIDE;
 
     // Replaceable for classes derived from CPPSourceEmitter
     virtual SlangResult calcTypeName(IRType* type, CodeGenTarget target, StringBuilder& out);

--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -341,6 +341,14 @@ void CUDASourceEmitter::emitCall(const HLSLIntrinsic* specOp, IRInst* inst, cons
     return Super::emitCall(specOp, inst, operands, numOperands, inOuterPrec);
 }
 
+void CUDASourceEmitter::emitLoopControlDecorationImpl(IRLoopControlDecoration* decl)
+{
+    if (decl->getMode() == kIRLoopControl_Unroll)
+    {
+        m_writer->emit("#pragma unroll\n");
+    }
+}
+
 bool CUDASourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec)
 {
     switch(inst->op)

--- a/source/slang/slang-emit-cuda.h
+++ b/source/slang/slang-emit-cuda.h
@@ -49,6 +49,8 @@ protected:
     virtual void emitCall(const HLSLIntrinsic* specOp, IRInst* inst, const IRUse* operands, int numOperands, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;
     virtual void emitFunctionPreambleImpl(IRInst* inst) SLANG_OVERRIDE { SLANG_UNUSED(inst); m_writer->emit("__device__ "); }
 
+    virtual void emitLoopControlDecorationImpl(IRLoopControlDecoration* decl) SLANG_OVERRIDE;
+
 
     //virtual bool tryEmitGlobalParamImpl(IRGlobalParam* varDecl, IRType* varType) SLANG_OVERRIDE;
     virtual bool tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -668,6 +668,16 @@ void GLSLSourceEmitter::_maybeEmitGLSLFlatModifier(IRType* valueType)
     }
 }
 
+void GLSLSourceEmitter::emitLoopControlDecorationImpl(IRLoopControlDecoration* decl)
+{
+    if (decl->getMode() == kIRLoopControl_Unroll)
+    {
+        // https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GL_EXT_control_flow_attributes.txt
+        m_glslExtensionTracker->requireExtension(UnownedStringSlice::fromLiteral("GL_EXT_control_flow_attributes"));
+        m_writer->emit("[[unroll]]\n");
+    }
+}
+
 void GLSLSourceEmitter::emitSimpleValueImpl(IRInst* inst) 
 {
     switch (inst->op)

--- a/source/slang/slang-emit-glsl.h
+++ b/source/slang/slang-emit-glsl.h
@@ -46,7 +46,7 @@ protected:
     virtual bool tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;
 
     virtual void emitSimpleValueImpl(IRInst* inst) SLANG_OVERRIDE;
-
+    virtual void emitLoopControlDecorationImpl(IRLoopControlDecoration* decl) SLANG_OVERRIDE;
 
     void _emitGLSLTextureOrTextureSamplerType(IRTextureTypeBase* type, char const* baseName);
     void _emitGLSLStructuredBuffer(IRGlobalParam* varDecl, IRHLSLStructuredBufferTypeBase* structuredBufferType);

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -504,6 +504,14 @@ void HLSLSourceEmitter::emitVectorTypeNameImpl(IRType* elementType, IRIntegerVal
     m_writer->emit(">");
 }
 
+void HLSLSourceEmitter::emitLoopControlDecorationImpl(IRLoopControlDecoration* decl)
+{
+    if (decl->getMode() == kIRLoopControl_Unroll)
+    {
+        m_writer->emit("[unroll]\n");
+    }
+}
+
 void HLSLSourceEmitter::emitSimpleValueImpl(IRInst* inst)
 {
     switch (inst->op)

--- a/source/slang/slang-emit-hlsl.h
+++ b/source/slang/slang-emit-hlsl.h
@@ -33,6 +33,7 @@ protected:
 
     virtual bool tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;
     virtual void emitSimpleValueImpl(IRInst* inst) SLANG_OVERRIDE;
+    virtual void emitLoopControlDecorationImpl(IRLoopControlDecoration* decl) SLANG_OVERRIDE;
 
         // Emit a single `register` semantic, as appropriate for a given resource-type-specific layout info
         // Keyword to use in the uniform case (`register` for globals, `packoffset` inside a `cbuffer`)

--- a/tests/compute/loop-unroll.slang
+++ b/tests/compute/loop-unroll.slang
@@ -1,6 +1,6 @@
 //TEST(compute):COMPARE_COMPUTE:
 //TEST(compute):COMPARE_COMPUTE:-dx12 
-//TODO(JS): This test fails on binding with a crash(!)
+//TODO(JS): This test fails with a crash in CreateComputePipelineState, so disabled for now
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-dx12 -use-dxil
 //TEST(compute):COMPARE_COMPUTE:-cpu
 //TEST(compute):COMPARE_COMPUTE:-cuda

--- a/tests/compute/loop-unroll.slang
+++ b/tests/compute/loop-unroll.slang
@@ -1,7 +1,15 @@
 //TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE:-dx12 
+//TODO(JS): This test fails on binding with a crash(!)
+//DISABLE_TEST(compute):COMPARE_COMPUTE:-dx12 -use-dxil
+//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE:-cuda
+// Note VK output is not loop unrolled
+//TEST(compute):COMPARE_COMPUTE:-vk
 
-//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):out
-//TEST_INPUT:ubuffer(data=[1 2 3 0], stride=4):
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out, name buffers[0]
+//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):name buffers[1]
+//TEST_INPUT:ubuffer(data=[1 2 3 0], stride=4):name buffers[2]
 
 // Check that we propagate the `[unroll]` attribute
 // through to HLSL output correctly.
@@ -10,7 +18,7 @@
 // it will generate a warning output from fxc, and the
 // test will fail to match the expected output.
 
-RWStructuredBuffer<int> buffers[2];
+RWStructuredBuffer<int> buffers[3];
 
 [numthreads(4, 1, 1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
@@ -20,12 +28,12 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 	// Note: using `unroll` as a variable name to validate that
 	// the lookup process for attribute names doesn't run into
 	// problems because of local declarations with the same name.
-	int unroll = buffers[1][tid];
+	int unroll = buffers[2][tid];
 
 	[unroll]
 	for(int ii = 0; ii < 2; ii++)
 	{
-		unroll = buffers[ii][unroll];
+		unroll = buffers[ii + 1][unroll];
 	}
 
 	buffers[0][tid] = unroll;


### PR DESCRIPTION
* Add [unroll] support for CUDA
* Add a sort of placeholder support for [unroll] in C++
* Write up about unroll in target-compatibility.md
* Updated loop-unroll.slang so 
  * Doesn't assume all threads happen simultaneously (they don't currently on CPU)
  * Enable for other targets where it should work

That currently the DX12 DXC test is disabled, because it causes a crash. Not clear why yet (after all it works with DXBC). 