### PR TITLE
Fix expected output for dxc-error test.

### DIFF
--- a/tests/cross-compile/dxc-error.hlsl.expected
+++ b/tests/cross-compile/dxc-error.hlsl.expected
@@ -1,6 +1,6 @@
 result code = -1
 standard error = {
-dxc: tests/cross-compile/dxc-error.hlsl:9:2: error: use of undeclared identifier 'gOutputBuffer'
+dxc: tests/cross-compile/dxc-error.hlsl:8:2: error: use of undeclared identifier 'gOutputBuffer'
         gOutputBuffer[tid] = dispatchThreadID.x * 0.5f;
         ^
 }


### PR DESCRIPTION
I'm not sure how this slipped in, but I know that I missed this when testing all my recent PRs because I end up havign a bunch of random not-ready-to-commit repro tests in my source tree which means I always get at least *some* test failures and have to scan them for the ones that are real. Somehow I have had a blind spot for this one.