### PR TITLE
Fix for literal constant folding for not.

### DIFF
--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -4710,7 +4710,6 @@ namespace Slang
     {
         switch (tokenType)
         {
-            case TokenType::OpNot:      return !value;
             case TokenType::OpBitNot:   return ~value;
             case TokenType::OpAdd:      return value;
             case TokenType::OpSub:      return -value;
@@ -4726,7 +4725,6 @@ namespace Slang
     {
         switch (tokenType)
         {
-            case TokenType::OpNot:      return !value;
             case TokenType::OpAdd:      return value;
             case TokenType::OpSub:      return -value;
             default:
@@ -4745,7 +4743,7 @@ namespace Slang
         default:
             return parsePostfixExpr(parser);
 
-
+        case TokenType::OpNot:
         case TokenType::OpInc:
         case TokenType::OpDec:
         {
@@ -4758,7 +4756,6 @@ namespace Slang
             prefixExpr->Arguments.add(arg);
             return prefixExpr;
         }
-        case TokenType::OpNot:
         case TokenType::OpBitNot:
         case TokenType::OpAdd:
         case TokenType::OpSub:


### PR DESCRIPTION
A previous changed attempted to perform more constant folding - in particular around prefix ops. One of the ops that was supported is !, but the simple logic used there assumed the type returned from the folding is the same as the originating type. That's not right for ! - as it will turn a float or int into a bool.

One fix would be to do the folding and emit true or false based on the literal. That's not the choice taken here though, that here the folding is just removed. 

That discussed elsewhere a more complete constant folding pass is probably wanted, and ideally it will only be implemented for one representation - probably the IR. 
