### PR TITLE
Change rules for layout of buffers/blocks containing only interface t…

### DIFF
--- a/tests/compute/interface-shader-param-in-struct.slang
+++ b/tests/compute/interface-shader-param-in-struct.slang
@@ -44,19 +44,38 @@ int test(
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> gOutputBuffer;
 
+// Note: even though `C` doesn't include any
+// uniform/ordinary dat as declared, it gets a
+// constant buffer allocated for it because
+// there is no way to rule out the possibility
+// that it *will* contain uniform/ordinary data
+// after specialization.
+//
+//TEST_INPUT:cbuffer(data=[0]):
 cbuffer C
 {
    IRandomNumberGenerationStrategy gStrategy;
 }
-
-//TEST_INPUT: globalExistentialType MyStrategy
-//TEST_INPUT:ubuffer(data=[1 2 4 8], stride=4):
 
 struct Stuff
 {
     IModifier modifier;
     int extra;
 }
+
+// Note: the data for global-scope existential parameters
+// is being introduced *before* the entry point declaration,
+// because the default policy used by `slangc` (which the
+// render test also uses) is to specialize the parameters at
+// the global scope (producing a new layout) and then compose
+// that specialized global scope with the entry point.
+//
+// (The net result is that data related to global-scope
+// specialization always precedes the data for entry point
+// parameters in these tests today)
+//
+//TEST_INPUT: globalExistentialType MyStrategy
+//TEST_INPUT:ubuffer(data=[1 2 4 8], stride=4):
 
 [numthreads(4, 1, 1)]
 void computeMain(

--- a/tests/compute/interface-shader-param4.slang
+++ b/tests/compute/interface-shader-param4.slang
@@ -46,6 +46,14 @@ int test(
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
 RWStructuredBuffer<int> gOutputBuffer;
 
+// Note: a constant buffer register/binding is always claimed
+// for `gStrategy` during initial compilation (before specialization)
+// because the layout logic has no way of knowing if the type
+// that gets plugged in will involve uniform/ordinary data
+// or not.
+//
+//TEST_INPUT:cbuffer(data=[0]):
+//
 ConstantBuffer<IRandomNumberGenerationStrategy> gStrategy;
 
 // The concrete types we plug in for `gStrategy` and `modifier`


### PR DESCRIPTION
…ypes

TL;DR: This is a tweak the rules for layout that only affects a corner case for people who actually use `interface`-type shader parameters (which for now is just our own test cases). The tweaked rules seem like they make it easier to write the application code for interfacing with Slang, but even if we change our minds later the risk here should be low (again: nobody is using this stuff right now).

Slang already has a rule that a constant buffer that contains no ordinary/uniform data doesn't actually allocate a constant buffer `binding`/`register`:

    struct A { float4 x; Texture2D y; } // has uniform/ordinary data
    struct B { Texture2D u; SamplerState v; } // has none

    ConstantBuffer<A> gA; // gets a constant buffer register/binding
    ConstantBuffer<B> gB; // does not

There is similar logic for `ParameterBlock`, where the feature makes more sense. A user would be somewhat surprised if they declared a parmaeter block with a texture and a sampler in it, but then the generating code reserved Vulkan `binding=0` for a constant buffer they never asked for. The behavior in the case of a plain `ConstantBuffer` is chosen to be consistent with the parameter block case.

(Aside: all of this is a non-issue for targets with direct support for pointers, like CUDA and CPU. On those platforms a constant buffer or parameter block always translates to a pointer to the contained data.)

Now, suppose the user declares a constant buffer with an interface type in it:

    interface IFoo { ... }

    ConstantBuffer<IFoo> gBuffer;

When the layout logic sees the declaration of `gBuffer` it doesn't yet know what type will be plugged in as `IFoo` there. Will it contain uniform/ordinary data, such that a constant buffer is needed?

The existing logic in the type layout step implemented a complicated rule that amounted to:

* A `ConstantBuffer` or `cbuffer` that only contains `interface`/existential-type data will *not* be allocated a constant buffer `register`/`binding` during the initial layout process (on unspecialized code). That means that any resources declared after it will take the next consecutive `register`/`binding` without leaving any "gap" for the `ConstantBuffer` variable.

* After specialization (e.g., when we know that `Thing` should be plugged in for `IFoo`), if we discover that there is uniform/ordinary data in `Thing` then we will allocate a constant buffer `register`/`binding` for the `ConstantBuffer`, but that register/binding will necessarily come *after* any `register`s/`binding`s that were allocated to parameters during the first pass.

* Parameter blocks were intended to work the same when when it comes to whether or not they allocate a default `space`/`set`, but that logic appears to not have worked as intended.

These rules make some logical sense: a `ConstantBuffer` declaration only pays for what the element type actually needs, and if that changes due to specialization then the new resource allocation comes after the unspecialized resources (so that the locations of unspecialized parameters are stable across specializations).

The problem is that in practice it is almost impossible to write client application code that uses the Slang reflection API and makes reasonable choices in the presence of these rules. A general-purpose `ShaderObject` abstraction in application code ends up having to deal with multiple possible states that an object could be in:

1. An object where the element type `E` contains no uniform/ordinary data, and no interface/existential fields, so a constant buffer doesn't need to be allocated or bound.

2. An object where the element type `E` contains no uniform/ordinary data, but has interace/existential fields, with two sub-cases:

   a. When no values bound to interface/existential fields use uniform/ordinary dat, then the parent object must not bind a buffer

   b. When the type of value bound to an interface/existential field uses uniform/ordinary data, then the parent object needs to have a buffer allocated, and bind it.

3. When the element type `E` contains uniform/ordinary data, then a buffer should be allocated and bound (although its size/contents may change as interface/existential fields get re-bound)

Needing to deal with a possible shift between cases (2a) and (2b) based on what gets bound at runtime is a mess, and it is important to note that even though both (2a) and (3) require a buffer to be bound, the rules about *where* the buffer gets bound aren't consistent (so that the application needs to undrestand the distinction between "primary" and "pending" data in a type layout).

This change introduces a different rule, which seems to be more complicated to explain, but actually seems to simplify things for the application:

* A `ConstantBuffer` or `cbuffer` that only contains `interface`/existential-type data always has a constant buffer `register`/`binding` allocated for it "just in case."

* If after specialization there is any uniform/ordinary data, then that will use the buffer `register`/`binding` that was already allocated (that's easy enough).

* If after speciazliation there *isn't* any uniform/ordinary data, then the generated HLSL/GLSL shader code won't declare a buffer, but the `register`/`binding` is still claimed.

* A `ParameterBlock` behaves equivalently, so that if it contains any `interface`/existential fields, then it will always allocate a `space`/`set` "just in case"

The effect of these rules is to streamline the cases that an application needs to deal with down to two:

1. If the element type `E` of a shader object contains no uniform/ordinary or interface/existential fields, then no buffer needs to be allocated or bound

2. If the element type `E` contains *any* uniform/ordinary or interface/existential fields, then it is always safe to allocate and bind a buffer (even in the cases where it might be ignored).

Furthermore, the reflection data for the constant buffer `register`/`binding` becomes consistent in case (2), so that the application can always expect to find it in the same way.