### PR TITLE
Fix front-end handling of generic static methods

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -539,6 +539,9 @@ namespace Slang
     bool SemanticsVisitor::isDeclUsableAsStaticMember(
         Decl*   decl)
     {
+        if(auto genericDecl = as<GenericDecl>(decl))
+            decl = genericDecl->inner;
+
         if(decl->HasModifier<HLSLStaticModifier>())
             return true;
 

--- a/tests/language-feature/static-members/generic-static-method.slang
+++ b/tests/language-feature/static-members/generic-static-method.slang
@@ -1,0 +1,30 @@
+// generic-static-method.slang
+
+// Confirm that the compiler can handle a generic
+// `static` method declaration and call.
+
+//TEST:SIMPLE:
+
+interface IFrobnicator
+{
+	float frobnicate(float value);
+}
+
+struct Doubler : IFrobnicator
+{
+	float frobnicate(float value) { return 2.0f * value; }
+}
+
+struct FrobnicateHelpers
+{
+	static float doubleFrobnicate<F : IFrobnicator>(F f, float value)
+	{
+		return f.frobnicate(f.frobnicate(value));
+	}
+}
+
+float test(float value)
+{
+	Doubler d;
+	return FrobnicateHelpers.doubleFrobnicate(d, value);
+}

--- a/tests/language-feature/static-members/generic-static-method.slang
+++ b/tests/language-feature/static-members/generic-static-method.slang
@@ -7,24 +7,24 @@
 
 interface IFrobnicator
 {
-	float frobnicate(float value);
+    float frobnicate(float value);
 }
 
 struct Doubler : IFrobnicator
 {
-	float frobnicate(float value) { return 2.0f * value; }
+    float frobnicate(float value) { return 2.0f * value; }
 }
 
 struct FrobnicateHelpers
 {
-	static float doubleFrobnicate<F : IFrobnicator>(F f, float value)
-	{
-		return f.frobnicate(f.frobnicate(value));
-	}
+    static float doubleFrobnicate<F : IFrobnicator>(F f, float value)
+    {
+        return f.frobnicate(f.frobnicate(value));
+    }
 }
 
 float test(float value)
 {
-	Doubler d;
-	return FrobnicateHelpers.doubleFrobnicate(d, value);
+    Doubler d;
+    return FrobnicateHelpers.doubleFrobnicate(d, value);
 }


### PR DESCRIPTION
The front-end logic that was testing if a member was usable as a static member neglected to unwrap any generic-ness and look at the declaration inside (the parser currently puts all modifiers on the inner declaration instead of the outer generic).

The test case included here is not a full compute test so that it only runs the front-end checking logic (where we had the bug).