### PR TITLE
Workaround for matching of dxc diagnostics

### DIFF
--- a/source/core/slang-string-util.cpp
+++ b/source/core/slang-string-util.cpp
@@ -6,6 +6,40 @@ namespace Slang {
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! StringUtil !!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+/* static */bool StringUtil::areAllEqual(const List<UnownedStringSlice>& a, const List<UnownedStringSlice>& b, EqualFn equalFn)
+{
+    if (a.getCount() != b.getCount())
+    {
+        return false;
+    }
+
+    const Index count = a.getCount();
+    for (Index i = 0; i < count; ++i)
+    {
+        if (!equalFn(a[i], b[i]))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+/* static */bool StringUtil::areAllEqualWithSplit(const UnownedStringSlice& a, const UnownedStringSlice& b, char splitChar, EqualFn equalFn)
+{
+    List<UnownedStringSlice> slicesA;
+    List<UnownedStringSlice> slicesB;
+
+    StringUtil::split(a, splitChar, slicesA);
+    StringUtil::split(b, splitChar, slicesB);
+
+    if (slicesA.getCount() != slicesB.getCount())
+    {
+        return false;
+    }
+
+    return areAllEqual(slicesA, slicesB, equalFn);
+}
+
 /* static */void StringUtil::split(const UnownedStringSlice& in, char splitChar, List<UnownedStringSlice>& slicesOut)
 {
     slicesOut.clear();

--- a/source/core/slang-string-util.cpp
+++ b/source/core/slang-string-util.cpp
@@ -26,17 +26,9 @@ namespace Slang {
 
 /* static */bool StringUtil::areAllEqualWithSplit(const UnownedStringSlice& a, const UnownedStringSlice& b, char splitChar, EqualFn equalFn)
 {
-    List<UnownedStringSlice> slicesA;
-    List<UnownedStringSlice> slicesB;
-
+    List<UnownedStringSlice> slicesA, slicesB;
     StringUtil::split(a, splitChar, slicesA);
     StringUtil::split(b, splitChar, slicesB);
-
-    if (slicesA.getCount() != slicesB.getCount())
-    {
-        return false;
-    }
-
     return areAllEqual(slicesA, slicesB, equalFn);
 }
 

--- a/source/core/slang-string-util.h
+++ b/source/core/slang-string-util.h
@@ -13,6 +13,14 @@ namespace Slang {
 
 struct StringUtil
 {
+    typedef bool (*EqualFn)(const UnownedStringSlice& a, const UnownedStringSlice& b);
+
+        /// True if the splits of a and b (via splitChar) are all equal as compared with the equalFn function
+    static bool areAllEqualWithSplit(const UnownedStringSlice& a, const UnownedStringSlice& b, char splitChar, EqualFn equalFn);
+
+        /// True if all slices in match are all equal as compared with the equalFn function
+    static bool areAllEqual(const List<UnownedStringSlice>& a, const List<UnownedStringSlice>& b, EqualFn equalFn);
+
         /// Split in, by specified splitChar into slices out
         /// Slices contents will directly address into in, so contents will only stay valid as long as in does.
     static void split(const UnownedStringSlice& in, char splitChar, List<UnownedStringSlice>& slicesOut);

--- a/tests/cross-compile/dxc-error.hlsl
+++ b/tests/cross-compile/dxc-error.hlsl
@@ -1,4 +1,4 @@
-//TEST(dxc):SIMPLE:-pass-through dxc -target dxil -entry computeMain -stage compute -profile sm_6_1 
+//DIAGNOSTIC_TEST(dxc):SIMPLE:-pass-through dxc -target dxil -entry computeMain -stage compute -profile sm_6_1 
 
 [numthreads(4, 1, 1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)


### PR DESCRIPTION
There seem to be at least two official DXC versions that are reporting the same errors with different line numbers.

This was causing failures on some machines and not others. Some CI tests failed on some machines and others didn't. In particular this was a problem for dxc-error.hlsl.

The 'fix' here was to make the dxc-error.hlsl a diagnostic test, which is presumably should have been. Then there is a more difficult problem - that DXC diagnostic output does not match say standardized Slang diagnostic output. 

For now the 'fix' used here is to have special case handling for lines that start with 'dxc:', such that line/column numbers are ignored.

In the future we may want to remove this loosening of the test - because ideally the diagnostic *would* match. 

It could be argued adding the functions to do the majority of the comparison into the StringUtil is perhaps a bit much. If it ends up not being used elsewhere, then that may be so. It's not the ideal way to do it - something more composable/functional/stream-like would be better.   