### PR TITLE
Fix stdlib definitions of half<->float conversion

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -1158,19 +1158,25 @@ matrix<T,N,M> exp2(matrix<T,N,M> x)
 
 // Convert 16-bit float stored in low bits of integer
 __target_intrinsic(glsl, "unpackHalf2x16($0).x")
+__glsl_version(420)
 float f16tof32(uint value);
 
 __generic<let N : int>
-__target_intrinsic(glsl, "unpackHalf2x16($0).x")
-vector<float,N> f16tof32(vector<uint,N> value);
+vector<float, N> f16tof32(vector<uint, N> value)
+{
+    VECTOR_MAP_UNARY(float, N, f16tof32, value);
+}
 
 // Convert to 16-bit float stored in low bits of integer
 __target_intrinsic(glsl, "packHalf2x16(vec2($0,0.0))")
+__glsl_version(420)
 uint f32tof16(float value);
 
 __generic<let N : int>
-__target_intrinsic(glsl, "packHalf2x16(vec2($0,0.0))")
-vector<uint,N> f32tof16(vector<float,N> value);
+vector<uint, N> f32tof16(vector<float, N> value)
+{
+    VECTOR_MAP_UNARY(uint, N, f32tof16, value);
+}
 
 // Flip surface normal to face forward, if needed
 __generic<T : __BuiltinFloatingPointType, let N : int>

--- a/tests/cross-compile/half-conversion.slang
+++ b/tests/cross-compile/half-conversion.slang
@@ -1,0 +1,13 @@
+// half-conversion.slang
+
+//TEST:CROSS_COMPILE:-target spirv-assembly -entry main -stage fragment
+
+cbuffer C
+{
+	uint4 u;
+}
+
+float4 main() : SV_Target
+{
+	return f16tof32(u);
+}

--- a/tests/cross-compile/half-conversion.slang.glsl
+++ b/tests/cross-compile/half-conversion.slang.glsl
@@ -1,0 +1,42 @@
+//half-conversion.slang.glsl
+//TEST_IGNORE_FILE:
+
+#version 450
+
+struct SLANG_ParameterGroup_C_0
+{
+    uvec4 u_0;
+};
+
+layout(binding = 0)
+layout(std140) uniform _S1
+{
+    SLANG_ParameterGroup_C_0 _data;
+} C_0;
+
+vec4 f16tof32_0(uvec4 value_0)
+{
+    int i_0;
+    vec4 result_0;
+    i_0 = 0;
+    for(;;)
+    {
+        if(i_0 < 4) {} else break;
+
+        float _S2 = (unpackHalf2x16((value_0[i_0])).x);
+        result_0[i_0] = _S2;
+        int _S3 = i_0 + int(1);
+        i_0 = _S3;
+    }
+    return result_0;
+}
+
+layout(location = 0)
+out vec4 _S4;
+
+void main()
+{
+    vec4 _S5 = f16tof32_0(C_0._data.u_0);
+    _S4 = _S5;
+    return;
+}


### PR DESCRIPTION
These ended up being additional cases where we needed to use an explicit loop over components in the stdlib in order to produce valid GLSL output, but the existing declarations weren't doing it.

I added a very minimal cross-compilation test just to confirm that we generate valid SPIR-V for code using `f16tof32()`.