### PR TITLE
Diagnose attempts to call instance methods from static methods

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -557,6 +557,9 @@ namespace Slang
         if(as<SimpleTypeDecl>(decl))
             return true;
 
+        if(as<TypeConstraintDecl>(decl))
+            return true;
+
         return false;
     }
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -345,11 +345,6 @@ namespace Slang
             RefPtr<Expr>    base,
             SourceLoc       loc);
 
-        RefPtr<Expr> createImplicitThisMemberExpr(
-            Type*                                           type,
-            SourceLoc                                       loc,
-            LookupResultItem::Breadcrumb::ThisParameterMode thisParameterMode);
-
         RefPtr<Expr> ConstructLookupResultExpr(
             LookupResultItem const& item,
             RefPtr<Expr>            baseExpr,

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -445,9 +445,9 @@ namespace Slang
     }
 
     RefPtr<Expr> SemanticsVisitor::createGenericDeclRef(
-        RefPtr<Expr>            baseExpr,
-        RefPtr<Expr>            originalExpr,
-        RefPtr<GenericSubstitution>   subst)
+        RefPtr<Expr>                baseExpr,
+        RefPtr<Expr>                originalExpr,
+        RefPtr<GenericSubstitution> subst)
     {
         auto baseDeclRefExpr = as<DeclRefExpr>(baseExpr);
         if (!baseDeclRefExpr)

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -1112,15 +1112,18 @@ namespace Slang
             // The kind of lookup step that was performed
             Kind kind;
 
-            // For the `Kind::This` case, is the `this` parameter
-            // mutable or not?
+            // For the `Kind::This` case, what does the implicit
+            // `this` or `This` parameter refer to?
+            //
             enum class ThisParameterMode : uint8_t
             {
-                Default,
-                Mutating,
+                ImmutableValue, // An immutable `this` value
+                MutableValue,   // A mutable `this` value
+                Type,           // A `This` type
+
+                Default = ImmutableValue,
             };
             ThisParameterMode thisParameterMode = ThisParameterMode::Default;
-
 
             // As needed, a reference to the declaration that faciliated
             // the lookup step.

--- a/tests/diagnostics/call-instance-from-static.slang
+++ b/tests/diagnostics/call-instance-from-static.slang
@@ -1,0 +1,21 @@
+// call-instance-from-static.slang
+
+// Test that calling an instance method from a static method is an error.
+
+//DIAGNOSTIC_TEST:SIMPLE:-target hlsl -entry main -stage compute
+
+struct Test
+{
+	void instanceMethod()
+	{}
+
+	static void staticMethod()
+	{
+		instanceMethod();
+	}
+}
+
+void main()
+{
+	Test.staticMethod();
+}

--- a/tests/diagnostics/call-instance-from-static.slang.expected
+++ b/tests/diagnostics/call-instance-from-static.slang.expected
@@ -1,0 +1,6 @@
+result code = -1
+standard error = {
+tests/diagnostics/call-instance-from-static.slang(14): error 30100: type 'Test' cannot be used to refer to non-static member 'instanceMethod'
+}
+standard output = {
+}


### PR DESCRIPTION
Currently we fail to diagnose code that calls an instance method from a static method using implicit `this`, and instead crash during lowering of the AST to the IR.

This change introduces a bit more detail to the "this parameter mode" that is computed during lookup, so that it differentiates three cases. The existing two cases of a mutable `this` and immutable `this` remain, but we add a third case where the "this parameter mode" only allows for a reference to the `This` type.

When turning lookup "breadcrumb" information into actual expressions, we respect this setting to construct either a `This` or `this` expression.

In order to actually diagnose the incorrect reference, I had to add code around an existing `TODO` comment that noted how we should diagnose attempts to refer to instance members through a type. Enabling that diagnostic revealed a missing case needed by generics (including those in the stdlib) - a type-constraint member is always referenced statically.

Putting the diagnostic for a static reference to a non-static member in its new bottleneck location meant that some code higher up the call static that handles explicit static member references had to be tweaked to not produce double error messages.

This change includes a new diagnostic test to show that we now give an error message on code that makes this mistake, instead of crashing.