### PR TITLE
Disable OptiX tests by default.

### DIFF
--- a/tests/pipeline/ray-tracing/raygen.slang
+++ b/tests/pipeline/ray-tracing/raygen.slang
@@ -1,6 +1,6 @@
 // raygen.slang
 
-//TEST:COMPARE_COMPUTE_EX:-cuda -rt -output-using-type -compute-dispatch 4,1,1
+//TEST(optix):COMPARE_COMPUTE_EX:-cuda -rt -output-using-type -compute-dispatch 4,1,1
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0],stride=4):name gOutput,out
 

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -3105,6 +3105,7 @@ SlangResult innerMain(int argc, char** argv)
     auto vulkanTestCategory = categorySet.add("vulkan", fullTestCategory);
     auto unitTestCatagory = categorySet.add("unit-test", fullTestCategory);
     auto cudaTestCategory = categorySet.add("cuda", fullTestCategory);
+    auto optixTestCategory = categorySet.add("optix", cudaTestCategory);
 
     auto compatibilityIssueCategory = categorySet.add("compatibility-issue", fullTestCategory);
         
@@ -3204,6 +3205,12 @@ SlangResult innerMain(int argc, char** argv)
     if( options.includeCategories.Count() == 0 )
     {
         options.includeCategories.Add(fullTestCategory, fullTestCategory);
+    }
+
+    // Don't include OptiX tests unless the client has explicit opted into them.
+    if( !options.includeCategories.ContainsKey(optixTestCategory) )
+    {
+        options.excludeCategories.Add(optixTestCategory, optixTestCategory);
     }
 
     // Exclude rendering tests when building under AppVeyor.


### PR DESCRIPTION
When running `slang-test`, the OptiX tests will be skipped by default for now, and must be explicitly enabled by adding `-category optix` on the command line.

I will need to add a better discovery mechanism down the line, closer to how support for different graphics APIs is being tested, but for now this should be enough to unblock our CI builds.