### PR TITLE
Disable a test that was breaking on CI

### DIFF
--- a/tests/hlsl-intrinsic/byte-address-buffer/byte-address-16bit.slang
+++ b/tests/hlsl-intrinsic/byte-address-buffer/byte-address-16bit.slang
@@ -5,7 +5,12 @@
 // that support it.
 
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_2 -render-features half
+
+// Note: disabled on D3D12 because some of the CI services don't have
+// a recent enough build of dxc to support generic load/store.
+//
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_2 -render-features half
+
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-slang -vk -compute -profile cs_6_2 -render-features half
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -cuda -compute
 


### PR DESCRIPTION
The CI system doesn't have a new enough dxc to support 16-bit load/store from byte-addressed buffers, so I am disabling the test for now.

A better long-term fix is to put an appropriate version of dxc into `slang-binaries` and use that for our CI tests.