### PR TITLE
Try to stop AppVeyor from clobbering release logs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -126,7 +126,7 @@ deploy:
   artifact: 'binary_archive,source_archive'
   draft: false
   prerelease: false
-  force_update: true # TODO: consider if we can avoid this
+  force_update: false
   on:
     configuration: Release
     appveyor_repo_tag: true        # deploy on tag push only


### PR DESCRIPTION
We trigger releases by creating tags on GitHub, and ideally we try to include a commit log of stuff that changed since the previous release. Unfortunately, the way that AppVeyor CI is currently set up, it clobbers the information for a release (including its description) as part of the deployment step, so all releases just list `Slang <verison>` as the description even if the programmer manually created a suitable release log message.

This change tweaks a setting in `appveyor.yml` that seems (AFAICT from the documentation and various issues I've been reading) to make it so that AppVeyor will simply push the binary artifacts to the release if it already exists, rather than set all of the release information from scratch.

We will have to wait until we next do a release to see how this works.