### PR TITLE
WIP: Have ASTNodeType as set field in all AST types.

### DIFF
--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -26,8 +26,9 @@ struct ReflectClassInfo;
 class NodeBase : public RefObject
 {
     SLANG_ABSTRACT_CLASS(NodeBase)
-   
+
     SyntaxClass<NodeBase> getClass() { return SyntaxClass<NodeBase>(&getClassInfo()); }
+    ASTNodeType m_astType;
 };
 
 // Casting of NodeBase
@@ -35,25 +36,25 @@ class NodeBase : public RefObject
 template<typename T>
 SLANG_FORCE_INLINE T* dynamicCast(NodeBase* node)
 {
-    return (node && node->getClassInfo().isSubClassOf(T::kReflectClassInfo)) ? static_cast<T*>(node) : nullptr;
+    return (node && ReflectClassInfo::isSubClassOf(node->m_astType, T::kReflectClassInfo)) ? static_cast<T*>(node) : nullptr;
 }
 
 template<typename T>
 SLANG_FORCE_INLINE const T* dynamicCast(const NodeBase* node)
 {
-    return (node && node->getClassInfo().isSubClassOf(T::kReflectClassInfo)) ? static_cast<const T*>(node) : nullptr;
+    return (node && ReflectClassInfo::isSubClassOf(node->m_astType, T::kReflectClassInfo)) ? static_cast<const T*>(node) : nullptr;
 }
 
 template<typename T>
 SLANG_FORCE_INLINE T* as(NodeBase* node)
 {
-    return (node && node->getClassInfo().isSubClassOf(T::kReflectClassInfo)) ? static_cast<T*>(node) : nullptr;
+    return (node && ReflectClassInfo::isSubClassOf(node->m_astType, T::kReflectClassInfo)) ? static_cast<T*>(node) : nullptr;
 }
 
 template<typename T>
 SLANG_FORCE_INLINE const T* as(const NodeBase* node)
 {
-    return (node && node->getClassInfo().isSubClassOf(T::kReflectClassInfo)) ? static_cast<const T*>(node) : nullptr;
+    return (node && ReflectClassInfo::isSubClassOf(node->m_astType, T::kReflectClassInfo)) ? static_cast<const T*>(node) : nullptr;
 }
 
 
@@ -170,7 +171,34 @@ class Substitutions: public RefObject
     // Check if these are equivalent substitutions to another set
     virtual bool Equals(Substitutions* subst) = 0;
     virtual int GetHashCode() const = 0;
+
+    ASTNodeType m_astType;
 };
+
+
+template<typename T>
+SLANG_FORCE_INLINE T* dynamicCast(Substitutions* node)
+{
+    return (node && ReflectClassInfo::isSubClassOf(node->m_astType, T::kReflectClassInfo)) ? static_cast<T*>(node) : nullptr;
+}
+
+template<typename T>
+SLANG_FORCE_INLINE const T* dynamicCast(const Substitutions* node)
+{
+    return (node && ReflectClassInfo::isSubClassOf(node->m_astType, T::kReflectClassInfo)) ? static_cast<const T*>(node) : nullptr;
+}
+
+template<typename T>
+SLANG_FORCE_INLINE T* as(Substitutions* node)
+{
+    return (node && ReflectClassInfo::isSubClassOf(node->m_astType, T::kReflectClassInfo)) ? static_cast<T*>(node) : nullptr;
+}
+
+template<typename T>
+SLANG_FORCE_INLINE const T* as(const Substitutions* node)
+{
+    return (node && ReflectClassInfo::isSubClassOf(node->m_astType, T::kReflectClassInfo)) ? static_cast<const T*>(node) : nullptr;
+}
 
 class GenericSubstitution : public Substitutions
 {

--- a/source/slang/slang-ast-reflect.h
+++ b/source/slang/slang-ast-reflect.h
@@ -14,7 +14,7 @@
     typedef SUPER Super; \
     SLANG_FORCE_INLINE static bool isDerivedFrom(ASTNodeType type) { return int(type) >= int(kType) && int(type) <= int(ASTNodeType::LAST); } \
     virtual const ReflectClassInfo& getClassInfo() const SLANG_AST_OVERRIDE_##TYPE { return kReflectClassInfo; } \
-
+    SLANG_FORCE_INLINE NAME() { m_astType = ASTNodeType::NAME; }
 
 #define SLANG_CLASS_REFLECT_DEFAULT(NAME) \
     public:     \

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -491,6 +491,13 @@ namespace Slang
             // We include super.m_classId, because it's a subclass of itself.
             return m_classId >= super.m_classId && m_classId <= super.m_lastClassId;
         }
+
+        SLANG_FORCE_INLINE static bool isSubClassOf(ASTNodeType type, const ThisType& super)
+        {
+            // We include super.m_classId, because it's a subclass of itself.
+            return uint32_t(type) >= super.m_classId && uint32_t(type) <= super.m_lastClassId;
+        }
+
         /// Will produce the same result as isSubClassOf, but more slowly by traversing the m_superClass
         /// Works without initRange being called. 
         bool isSubClassOfSlow(const ThisType& super) const;

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -68,12 +68,12 @@ class DeclRefType : public Type
         Session*        session,
         DeclRef<Decl>   declRef);
 
-    DeclRefType()
-    {}
     DeclRefType(
         DeclRef<Decl> declRef)
         : declRef(declRef)
-    {}
+    {
+        m_astType = kType;
+    }
 protected:
     virtual int GetHashCode() override;
     virtual bool EqualsImpl(Type * type) override;
@@ -93,14 +93,14 @@ class BasicExpressionType : public ArithmeticExpressionType
 {
     SLANG_CLASS(BasicExpressionType)
 
-
     BaseType baseType;
 
-    BasicExpressionType() {}
     BasicExpressionType(
         Slang::BaseType baseType)
         : baseType(baseType)
-    {}
+    {
+        m_astType = kType;
+    }
 protected:
     virtual BasicExpressionType* GetScalarType() override;
     virtual bool EqualsImpl(Type * type) override;
@@ -142,14 +142,13 @@ class TextureTypeBase : public ResourceType
 {
     SLANG_ABSTRACT_CLASS(TextureTypeBase)
 
-    TextureTypeBase()
-    {}
     TextureTypeBase(
         TextureFlavor flavor,
         RefPtr<Type> elementType)
     {
         this->elementType = elementType;
         this->flavor = flavor;
+        m_astType = kType;
     }
 };
 
@@ -157,13 +156,13 @@ class TextureType : public TextureTypeBase
 {
     SLANG_CLASS(TextureType)
 
-    TextureType()
-    {}
     TextureType(
         TextureFlavor flavor,
         RefPtr<Type> elementType)
         : TextureTypeBase(flavor, elementType)
-    {}
+    {
+        m_astType = kType;
+    }
 };
 
 // This is a base type for texture/sampler pairs,
@@ -172,13 +171,13 @@ class TextureSamplerType : public TextureTypeBase
 {
     SLANG_CLASS(TextureSamplerType)
 
-    TextureSamplerType()
-    {}
     TextureSamplerType(
         TextureFlavor flavor,
         RefPtr<Type> elementType)
         : TextureTypeBase(flavor, elementType)
-    {}
+    {
+        m_astType = kType;
+    }
 };
 
 // This is a base type for `image*` types, as they exist in GLSL
@@ -186,13 +185,13 @@ class GLSLImageType : public TextureTypeBase
 {
     SLANG_CLASS(GLSLImageType)
 
-    GLSLImageType()
-    {}
     GLSLImageType(
         TextureFlavor flavor,
         RefPtr<Type> elementType)
         : TextureTypeBase(flavor, elementType)
-    {}
+    {
+        m_astType = kType;
+    }
 };
 
 class SamplerStateType : public BuiltinType 
@@ -416,11 +415,11 @@ class TypeType : public Type
     RefPtr<Type> type;
 
 public:
-    TypeType()
-    {}
     TypeType(RefPtr<Type> type)
         : type(type)
-    {}
+    {
+        m_astType = kType;
+    }
 
     virtual String ToString() override;
 
@@ -532,12 +531,13 @@ class NamedExpressionType : public Type
     DeclRef<TypeDefDecl> declRef;
 
     RefPtr<Type> innerType;
-    NamedExpressionType()
-    {}
+    
     NamedExpressionType(
         DeclRef<TypeDefDecl> declRef)
         : declRef(declRef)
-    {}
+    {
+        m_astType = kType;
+    }
 
     virtual String ToString() override;
 
@@ -562,9 +562,6 @@ class FuncType : public Type
     List<RefPtr<Type>> paramTypes;
     RefPtr<Type> resultType;
 
-    FuncType()
-    {}
-
     UInt getParamCount() { return paramTypes.getCount(); }
     Type* getParamType(UInt index) { return paramTypes[index]; }
     Type* getResultType() { return resultType; }
@@ -584,12 +581,12 @@ class GenericDeclRefType : public Type
 
     DeclRef<GenericDecl> declRef;
 
-    GenericDeclRefType()
-    {}
     GenericDeclRefType(
         DeclRef<GenericDecl> declRef)
         : declRef(declRef)
-    {}
+    {
+        m_astType = kType;
+    }
 
     DeclRef<GenericDecl> const& GetDeclRef() const { return declRef; }
 
@@ -607,9 +604,6 @@ class NamespaceType : public Type
     SLANG_CLASS(NamespaceType)
 
     DeclRef<NamespaceDeclBase> m_declRef;
-
-    NamespaceType()
-    {}
 
     DeclRef<NamespaceDeclBase> const& getDeclRef() const { return m_declRef; }
 

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -24,11 +24,11 @@ class ConstantIntVal : public IntVal
 
     IntegerLiteralValue value;
 
-    ConstantIntVal()
-    {}
     ConstantIntVal(IntegerLiteralValue value)
         : value(value)
-    {}
+    {
+        m_astType = kType;
+    }
 
     virtual bool EqualsVal(Val* val) override;
     virtual String ToString() override;
@@ -42,11 +42,11 @@ class GenericParamIntVal : public IntVal
 
     DeclRef<VarDeclBase> declRef;
 
-    GenericParamIntVal()
-    {}
     GenericParamIntVal(DeclRef<VarDeclBase> declRef)
         : declRef(declRef)
-    {}
+    {
+        m_astType = kType;
+    }
 
     virtual bool EqualsVal(Val* val) override;
     virtual String ToString() override;
@@ -62,9 +62,6 @@ class ErrorIntVal : public IntVal
     // TODO: We should probably eventually just have an `ErrorVal` here
     // and have all `Val`s that represent ordinary values hold their
     // `Type` so that we can have an `ErrorVal` of any type.
-
-    ErrorIntVal()
-    {}
 
     virtual bool EqualsVal(Val* val) override;
     virtual String ToString() override;
@@ -126,7 +123,6 @@ class SubtypeWitness : public Witness
 class TypeEqualityWitness : public SubtypeWitness 
 {
     SLANG_CLASS(TypeEqualityWitness)
-
 
     virtual bool EqualsVal(Val* val) override;
     virtual String ToString() override;


### PR DESCRIPTION
Have ASTNodeType set on all AST nodes, such that casting can be performed without calling virtual function getClassInfo().

The mechanism used here is to set a default Ctor to set the field. If a class implements a non default constructor - they must also set the m_astType = kType in their constructor.

This mechanism is not ideal in that the m_astType might be set multiple times during construction. Really what we want is to set the type once, but there doesn't seem like a straight forward way to do that. Doing it through threading the type through constructors also seems fragile.

If we had say a 'create' function on the base class we could default construct and set the parameter. With perhaps variadic template, or a range of parameter sizes.

