### PR TITLE
Simplify AST reflection macros

### DIFF
--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -14,10 +14,6 @@
 namespace Slang
 {
 
-#define SLANG_ABSTRACT_CLASS(x) SLANG_ABSTRACT_CLASS_REFLECT(x)
-// We don't use SLANG_CLASS_REFLECT_WITH_ACCEPT(x), as we don't want accept method on these classes 
-#define SLANG_CLASS(x) SLANG_CLASS_REFLECT_DEFAULT(x)
-
 // Signals to C++ extractor that RefObject is a base class, that isn't reflected to C++ extractor
 SLANG_REFLECT_BASE_CLASS(RefObject)
 
@@ -362,9 +358,5 @@ class Stmt : public ModifiableSyntaxNode
 
     virtual void accept(IStmtVisitor* visitor, void* extra) = 0;
 };
-
-#undef SLANG_ABSTRACT_CLASS
-#undef SLANG_CLASS
-
 
 } // namespace Slang

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -6,9 +6,6 @@
 
 namespace Slang {
 
-#define SLANG_ABSTRACT_CLASS(x) SLANG_ABSTRACT_CLASS_REFLECT(x)
-#define SLANG_CLASS(x) SLANG_CLASS_REFLECT_WITH_ACCEPT(x)
-
 // Syntax class definitions for declarations.
 
 // A group of declarations that should be treated as a unit
@@ -457,8 +454,5 @@ class AttributeDecl : public ContainerDecl
     // What type of syntax node will be produced to represent this attribute.
     SyntaxClass<RefObject> syntaxClass;
 };
-
-#undef SLANG_ABSTRACT_CLASS
-#undef SLANG_CLASS
 
 } // namespace Slang

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -6,9 +6,6 @@
 
 namespace Slang {
 
-#define SLANG_ABSTRACT_CLASS(x) SLANG_ABSTRACT_CLASS_REFLECT(x)
-#define SLANG_CLASS(x) SLANG_CLASS_REFLECT_WITH_ACCEPT(x)
-
 // Syntax class definitions for expressions.
 
 // Base class for expressions that will reference declarations
@@ -304,8 +301,5 @@ class ThisTypeExpr: public Expr
     SLANG_CLASS(ThisTypeExpr)
     RefPtr<Scope> scope;
 };
-
-#undef SLANG_ABSTRACT_CLASS
-#undef SLANG_CLASS
 
 } // namespace Slang

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -6,9 +6,6 @@
 
 namespace Slang { 
 
-#define SLANG_ABSTRACT_CLASS(x) SLANG_ABSTRACT_CLASS_REFLECT(x)
-#define SLANG_CLASS(x) SLANG_CLASS_REFLECT_WITH_ACCEPT(x)
-
 // Syntax class definitions for modifiers.
 
 // Simple modifiers have no state beyond their identity
@@ -875,9 +872,5 @@ class UnsafeForceInlineEarlyAttribute : public Attribute
 {
     SLANG_CLASS(UnsafeForceInlineEarlyAttribute)
 };
-
-
-#undef SLANG_ABSTRACT_CLASS
-#undef SLANG_CLASS
 
 } // namespace Slang

--- a/source/slang/slang-ast-reflect.h
+++ b/source/slang/slang-ast-reflect.h
@@ -5,33 +5,53 @@
 
 #include "slang-ast-generated.h"
 
+// Switch based on node type - only inner and leaf classes define override
 #define SLANG_AST_OVERRIDE_BASE
 #define SLANG_AST_OVERRIDE_INNER override
 #define SLANG_AST_OVERRIDE_LEAF override
 
-// Implement the part that uses the class definition
-#define SLANG_CLASS_REFLECT_DEFAULT_IMPL(NAME, SUPER, ORIGIN, LAST, MARKER, TYPE, param) \
+// Switch based on the origin - classes defined in slang-ast-base.h do not have accept defined on them
+// The 'origin' is based on the file where the class definition is located.
+
+// Define what the accept method looks like, so don't have to repeat
+#define SLANG_AST_ACCEPT_IMPL(NAME) virtual void accept(NAME::Visitor* visitor, void* extra) override;
+
+// A macro for *all* of the different origin/files where AST files are defined. 
+#define SLANG_AST_ACCEPT_BASE(NAME) 
+#define SLANG_AST_ACCEPT_DECL(NAME) SLANG_AST_ACCEPT_IMPL(NAME)
+#define SLANG_AST_ACCEPT_EXPR(NAME) SLANG_AST_ACCEPT_IMPL(NAME)
+#define SLANG_AST_ACCEPT_MODIFIER(NAME) SLANG_AST_ACCEPT_IMPL(NAME)
+#define SLANG_AST_ACCEPT_TYPE(NAME) SLANG_AST_ACCEPT_IMPL(NAME)
+#define SLANG_AST_ACCEPT_VAL(NAME) SLANG_AST_ACCEPT_IMPL(NAME)
+#define SLANG_AST_ACCEPT_STMT(NAME) SLANG_AST_ACCEPT_IMPL(NAME)
+
+// Implementation for SLANG_ABSTRACT_CLASS(x) using reflection from C++ extractor in slang-ast-generated.h
+#define SLANG_ABSTRACT_CLASS_REFLECT_IMPL(NAME, SUPER, ORIGIN, LAST, MARKER, TYPE, param) \
+    public:     \
     typedef SUPER Super; \
+    static const ASTNodeType kType = ASTNodeType::NAME; \
+    static const ReflectClassInfo kReflectClassInfo;  \
     SLANG_FORCE_INLINE static bool isDerivedFrom(ASTNodeType type) { return int(type) >= int(kType) && int(type) <= int(ASTNodeType::LAST); } \
     virtual const ReflectClassInfo& getClassInfo() const SLANG_AST_OVERRIDE_##TYPE { return kReflectClassInfo; } \
 
-
-#define SLANG_CLASS_REFLECT_DEFAULT(NAME) \
+// Implementation for SLANG_CLASS(x) using reflection from C++ extractor in slang-ast-generated.h.
+// This implementation is the same as for SLANG_ABSTRACT_CLASS_REFLECT_IMPL, except for the SLANG_AST_ACCEPT_ line which inserts the accept
+// method for non 'BASE' origin classes. 
+#define SLANG_CLASS_REFLECT_IMPL(NAME, SUPER, ORIGIN, LAST, MARKER, TYPE, param) \
     public:     \
+    typedef SUPER Super; \
     static const ASTNodeType kType = ASTNodeType::NAME; \
-    static const ReflectClassInfo kReflectClassInfo; \
-    SLANG_ASTNode_##NAME(SLANG_CLASS_REFLECT_DEFAULT_IMPL, _)
+    static const ReflectClassInfo kReflectClassInfo;  \
+    SLANG_FORCE_INLINE static bool isDerivedFrom(ASTNodeType type) { return int(type) >= int(kType) && int(type) <= int(ASTNodeType::LAST); } \
+    virtual const ReflectClassInfo& getClassInfo() const SLANG_AST_OVERRIDE_##TYPE { return kReflectClassInfo; } \
+    SLANG_AST_ACCEPT_##ORIGIN(NAME)
 
-#define SLANG_CLASS_REFLECT_WITH_ACCEPT(NAME) \
-    SLANG_CLASS_REFLECT_DEFAULT(NAME) \
-    virtual void accept(NAME::Visitor* visitor, void* extra) override;
+// Macro definitions - use the SLANG_ASTNode_ definitions to invoke the IMPL to produce the code
+// injected into AST classes
+#define SLANG_ABSTRACT_CLASS(NAME)  SLANG_ASTNode_##NAME(SLANG_ABSTRACT_CLASS_REFLECT_IMPL, _)
+#define SLANG_CLASS(NAME)           SLANG_ASTNode_##NAME(SLANG_CLASS_REFLECT_IMPL, _)
 
-#define SLANG_ABSTRACT_CLASS_REFLECT(NAME)  SLANG_CLASS_REFLECT_DEFAULT(NAME)
-#define SLANG_CLASS_REFLECT(NAME) SLANG_CLASS_REFLECT_DEFAULT(NAME)
-
-// Used for C++ extractor, does nothing here
-#define SLANG_REFLECT_BASE_CLASS(x) /* ... */
-
-
+// Does nothing - just a mark to the C++ extractor
+#define SLANG_REFLECT_BASE_CLASS(NAME)
 
 #endif // SLANG_AST_REFLECT_H

--- a/source/slang/slang-ast-stmt.h
+++ b/source/slang/slang-ast-stmt.h
@@ -6,9 +6,6 @@
 
 namespace Slang {
 
-#define SLANG_ABSTRACT_CLASS(x) SLANG_ABSTRACT_CLASS_REFLECT(x)
-#define SLANG_CLASS(x) SLANG_CLASS_REFLECT_WITH_ACCEPT(x)
-
 // Syntax class definitions for statements.
 
 class ScopeStmt : public Stmt 
@@ -206,8 +203,5 @@ class ExpressionStmt : public Stmt
 
     RefPtr<Expr> Expression;
 };
-
-#undef SLANG_ABSTRACT_CLASS
-#undef SLANG_CLASS
 
 } // namespace Slang

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -6,9 +6,6 @@
 
 namespace Slang {
 
-#define SLANG_ABSTRACT_CLASS(x) SLANG_ABSTRACT_CLASS_REFLECT(x)
-#define SLANG_CLASS(x) SLANG_CLASS_REFLECT_WITH_ACCEPT(x)
-
 // Syntax class definitions for types.
 
 // The type of a reference to an overloaded name
@@ -683,8 +680,5 @@ class ThisType : public Type
     virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
 
 };
-
-#undef SLANG_ABSTRACT_CLASS
-#undef SLANG_CLASS
 
 } // namespace Slang

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -6,9 +6,6 @@
 
 namespace Slang {
 
-#define SLANG_ABSTRACT_CLASS(x) SLANG_ABSTRACT_CLASS_REFLECT(x)
-#define SLANG_CLASS(x) SLANG_CLASS_REFLECT_WITH_ACCEPT(x)
-
 // Syntax class definitions for compile-time values.
 
 // A compile-time integer (may not have a specific concrete value)
@@ -198,9 +195,5 @@ class TaggedUnionSubtypeWitness : public SubtypeWitness
     virtual int GetHashCode() override;
     virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int * ioDiff) override;
 };
-
-
-#undef SLANG_ABSTRACT_CLASS
-#undef SLANG_CLASS
 
 } // namespace Slang


### PR DESCRIPTION
AST nodes now use the C++ extractor in order to generate the reflection material to make runtime casting work. 

That the definitions of AST nodes is somewhat complicated because we also want to declare a method on SLANG_CLASS tagged classes - the 'accept' method, but we don't want to do this for all classes. 

Prior to the C++ extractor this was achieved, by varying the macros when the 'base' types were included from the other types. With the extractor e have to inject the correct definition the first time the class is seen, as it's a regular C++ class.

In the prior C++ extractor version this was achieved by defining the specific implementation needed for each of the files in the file. This worked - but had a kind of code smell about it.

The challenge here is to at the point of injection 'know' if a class needs accept injected or not. Perhaps ideally this would be done via knowing what super class it is derived from. Doing so could perhaps be achieved via stepping up through the super macro definitions until the definition was found. Alternatively we could perhaps add some other kind of mark. 

By stepping up I mean use the SUPER reflected parameter, to then jump to the parents definition and so forth. The difficulty is knowing how to terminate. Clearly we can terminate by redefining the final class in some special way. 

That is not what is done here though. That because of the previous system, the ORIGIN (which is just part of the name of the file the class definition is in), already provides us what we need. In this case any class with SLANG_CLASS in BASE, does not want the accept method. So a macro 'switch' is used to achieve this. 

The main reasoning for doing this way is that it uses less macro magic, with the downside that it relies on where classes are defined (much like the previous system). 