### PR TITLE
Reduce the size of Token

### DIFF
--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -396,7 +396,7 @@ namespace Slang
                 {
                     const auto& semanticToken = semantic->name;
 
-                    String lowerName = String(semanticToken.Content).toLower();
+                    String lowerName = String(semanticToken.getContent()).toLower();
 
                     if(lowerName == "sv_dispatchthreadid")
                     {

--- a/source/slang/slang-diagnostics.cpp
+++ b/source/slang/slang-diagnostics.cpp
@@ -70,7 +70,7 @@ void printDiagnosticArg(StringBuilder& sb, TokenType tokenType)
 
 void printDiagnosticArg(StringBuilder& sb, Token const& token)
 {
-    sb << token.Content;
+    sb << token.getContent();
 }
 
 SourceLoc const& getDiagnosticPos(Token const& token)

--- a/source/slang/slang-lexer.cpp
+++ b/source/slang/slang-lexer.cpp
@@ -545,8 +545,10 @@ namespace Slang
     {
         IntegerLiteralValue value = 0;
 
-        char const* cursor = token.Content.begin();
-        char const* end = token.Content.end();
+        const UnownedStringSlice content = token.getContent();
+
+        char const* cursor = content.begin();
+        char const* end = content.end();
 
         int base = _readOptionalBase(&cursor);
 
@@ -571,8 +573,10 @@ namespace Slang
     {
         FloatingPointLiteralValue value = 0;
 
-        char const* cursor = token.Content.begin();
-        char const* end = token.Content.end();
+        const UnownedStringSlice content = token.getContent();
+
+        char const* cursor = content.begin();
+        char const* end = content.end();
 
         int radix = _readOptionalBase(&cursor);
 
@@ -756,8 +760,10 @@ namespace Slang
         SLANG_ASSERT(token.type == TokenType::StringLiteral
             || token.type == TokenType::CharLiteral);
 
-        char const* cursor = token.Content.begin();
-        char const* end = token.Content.end();
+        const UnownedStringSlice content = token.getContent();
+
+        char const* cursor = content.begin();
+        char const* end = content.end();
         SLANG_UNREFERENCED_VARIABLE(end);
 
         auto quote = *cursor++;
@@ -879,13 +885,15 @@ namespace Slang
 
     String getFileNameTokenValue(Token const& token)
     {
+        const UnownedStringSlice content = token.getContent();
+
         // A file name usually doesn't process escape sequences
         // (this is import on Windows, where `\\` is a valid
         // path separator character).
 
         // Just trim off the first and last characters to remove the quotes
         // (whether they were `""` or `<>`.
-        return String(token.Content.begin() + 1, token.Content.end() - 1); 
+        return String(content.begin() + 1, content.end() - 1); 
     }
 
 
@@ -1298,11 +1306,11 @@ namespace Slang
                         }
                         *dst++ = c;
                     }
-                    token.Content = UnownedStringSlice(startDst, dst);
+                    token.setContent(UnownedStringSlice(startDst, dst));
                 }
                 else
                 {
-                    token.Content = UnownedStringSlice(textBegin, textEnd);
+                    token.setContent(UnownedStringSlice(textBegin, textEnd));
                 }
             }
 
@@ -1312,7 +1320,7 @@ namespace Slang
 
             if (tokenType == TokenType::Identifier)
             {
-                token.ptrValue = m_namePool->getName(token.Content);
+                token.setName(m_namePool->getName(token.getContent()));
             }
 
             return token;

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -5625,7 +5625,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             }
             else if(definitionToken.type == TokenType::Identifier)
             {
-                definition = definitionToken.Content;
+                definition = definitionToken.getContent();
             }
             else
             {
@@ -5636,7 +5636,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             auto& targetToken = targetMod->targetToken;
             if( targetToken.type != TokenType::Unknown )
             {
-                targetName = targetToken.Content;
+                targetName = targetToken.getContent();
             }
 
             builder->addTargetIntrinsicDecoration(irInst, targetName, definition.getUnownedSlice());
@@ -5723,7 +5723,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                 //
                 if(targetMod->targetToken.type == TokenType::Unknown)
                     return;
-                else if(targetMod->targetToken.Content.getLength() == 0)
+                else if(targetMod->targetToken.getContent().getLength() == 0)
                     return;
             }
         }
@@ -6156,7 +6156,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             // a specialized definition of the particular function for the given
             // target, and we need to reflect that at the IR level.
 
-            getBuilder()->addTargetDecoration(irFunc, targetMod->targetToken.Content);
+            getBuilder()->addTargetDecoration(irFunc, targetMod->targetToken.getContent());
         }
 
         // If this declaration was marked as having a target-specific lowering
@@ -6173,7 +6173,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         //
         for(auto extensionMod : decl->GetModifiersOfType<RequiredGLSLExtensionModifier>())
         {
-            getBuilder()->addRequireGLSLExtensionDecoration(irFunc, extensionMod->extensionNameToken.Content);
+            getBuilder()->addRequireGLSLExtensionDecoration(irFunc, extensionMod->extensionNameToken.getContent());
         }
         for(auto versionMod : decl->GetModifiersOfType<RequiredGLSLVersionModifier>())
         {

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -5723,7 +5723,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                 //
                 if(targetMod->targetToken.type == TokenType::Unknown)
                     return;
-                else if(targetMod->targetToken.getContent().getLength() == 0)
+                else if(!targetMod->targetToken.hasContent())
                     return;
             }
         }

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -564,7 +564,7 @@ LayoutSemanticInfo ExtractLayoutSemanticInfo(
     }
 
     // TODO: handle component mask part of things...
-    if( semantic->componentMask.getContent().getLength() != 0 )
+    if( semantic->componentMask.hasContent())
     {
         getSink(context)->diagnose(semantic->componentMask, Diagnostics::componentMaskNotSupported);
     }

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -490,7 +490,7 @@ LayoutSemanticInfo ExtractLayoutSemanticInfo(
     info.index = 0;
     info.kind = LayoutResourceKind::None;
 
-    UnownedStringSlice registerName = semantic->registerName.Content;
+    UnownedStringSlice registerName = semantic->registerName.getContent();
     if (registerName.getLength() == 0)
         return info;
 
@@ -533,7 +533,7 @@ LayoutSemanticInfo ExtractLayoutSemanticInfo(
     UInt space = 0;
     if( auto registerSemantic = as<HLSLRegisterSemantic>(semantic) )
     {
-        auto const& spaceName = registerSemantic->spaceName.Content;
+        auto const& spaceName = registerSemantic->spaceName.getContent();
         if(spaceName.getLength() != 0)
         {
             UnownedStringSlice spaceSpelling;
@@ -564,7 +564,7 @@ LayoutSemanticInfo ExtractLayoutSemanticInfo(
     }
 
     // TODO: handle component mask part of things...
-    if( semantic->componentMask.Content.getLength() != 0 )
+    if( semantic->componentMask.getContent().getLength() != 0 )
     {
         getSink(context)->diagnose(semantic->componentMask, Diagnostics::componentMaskNotSupported);
     }
@@ -589,7 +589,7 @@ static bool findLayoutArg(
     {
         if( modifier )
         {
-            *outVal = (UInt) strtoull(String(modifier->valToken.Content).getBuffer(), nullptr, 10);
+            *outVal = (UInt) strtoull(String(modifier->valToken.getContent()).getBuffer(), nullptr, 10);
             return true;
         }
     }
@@ -1336,7 +1336,7 @@ struct SimpleSemanticInfo
 SimpleSemanticInfo decomposeSimpleSemantic(
     HLSLSimpleSemantic* semantic)
 {
-    auto composedName = semantic->name.Content;
+    auto composedName = semantic->name.getContent();
 
     // look for a trailing sequence of decimal digits
     // at the end of the composed name

--- a/source/slang/slang-preprocessor.cpp
+++ b/source/slang/slang-preprocessor.cpp
@@ -999,7 +999,7 @@ top:
         // We are pasting tokens, which could get messy
 
         StringBuilder sb;
-        sb << token.Content;
+        sb << token.getContent();
 
         while (PeekRawTokenType(preprocessor) == TokenType::PoundPound)
         {
@@ -1012,7 +1012,7 @@ top:
             // Read the next raw token (now that expansion has been triggered)
             Token nextToken = AdvanceRawToken(preprocessor);
 
-            sb << nextToken.Content;
+            sb << nextToken.getContent();
         }
 
         // Now re-lex the input
@@ -1106,9 +1106,9 @@ inline Token const& GetDirective(PreprocessorDirectiveContext* context)
 }
 
 // Get the name of the directive being parsed.
-inline UnownedStringSlice const& GetDirectiveName(PreprocessorDirectiveContext* context)
+inline UnownedStringSlice GetDirectiveName(PreprocessorDirectiveContext* context)
 {
-    return context->directiveToken.Content;
+    return context->directiveToken.getContent();
 }
 
 // Get the location of the directive being parsed.
@@ -1360,12 +1360,12 @@ static PreprocessorExpressionValue ParseAndEvaluateUnaryExpression(PreprocessorD
         }
 
     case TokenType::IntegerLiteral:
-        return StringToInt(AdvanceToken(context).Content);
+        return StringToInt(AdvanceToken(context).getContent());
 
     case TokenType::Identifier:
         {
             Token token = AdvanceToken(context);
-            if (token.Content == "defined")
+            if (token.getContent() == "defined")
             {
                 // handle `defined(someName)`
 
@@ -1994,7 +1994,7 @@ static void HandleWarningDirective(PreprocessorDirectiveContext* context)
     Expect(context, TokenType::DirectiveMessage, Diagnostics::expectedTokenInPreprocessorDirective, &messageToken);
 
     // Report the custom error.
-    GetSink(context)->diagnose(GetDirectiveLoc(context), Diagnostics::userDefinedWarning, messageToken.Content);
+    GetSink(context)->diagnose(GetDirectiveLoc(context), Diagnostics::userDefinedWarning, messageToken.getContent());
 }
 
 // Handle a `#error` directive
@@ -2008,7 +2008,7 @@ static void HandleErrorDirective(PreprocessorDirectiveContext* context)
     Expect(context, TokenType::DirectiveMessage, Diagnostics::expectedTokenInPreprocessorDirective, &messageToken);
 
     // Report the custom error.
-    GetSink(context)->diagnose(GetDirectiveLoc(context), Diagnostics::userDefinedError, messageToken.Content);
+    GetSink(context)->diagnose(GetDirectiveLoc(context), Diagnostics::userDefinedError, messageToken.getContent());
 }
 
 // Handle a `#line` directive
@@ -2023,14 +2023,14 @@ static void HandleLineDirective(PreprocessorDirectiveContext* context)
     // `#line <integer-literal> ...`
     if (PeekTokenType(context) == TokenType::IntegerLiteral)
     {
-        line = StringToInt(AdvanceToken(context).Content);
+        line = StringToInt(AdvanceToken(context).getContent());
     }
     // `#line`
     // `#line default`
     else if (
         PeekTokenType(context) == TokenType::EndOfDirective
         || (PeekTokenType(context) == TokenType::Identifier
-            && PeekToken(context).Content == "default"))
+            && PeekToken(context).getContent() == "default"))
     {
         AdvanceToken(context);
 
@@ -2064,7 +2064,7 @@ static void HandleLineDirective(PreprocessorDirectiveContext* context)
     {
         // Note(tfoley): GLSL allows the "source string" to be indicated by an integer
         // TODO(tfoley): Figure out a better way to handle this, if it matters
-        file = AdvanceToken(context).Content;
+        file = AdvanceToken(context).getContent();
     }
     else
     {

--- a/source/slang/slang-reflection.cpp
+++ b/source/slang/slang-reflection.cpp
@@ -183,8 +183,8 @@ SLANG_API const char* spReflectionUserAttribute_GetArgumentValueString(SlangRefl
     if (auto cexpr = as<StringLiteralExpr>(userAttr->args[index]))
     {
         if (bufLen)
-            *bufLen = cexpr->token.Content.getLength();
-        return cexpr->token.Content.begin();
+            *bufLen = cexpr->token.getContent().getLength();
+        return cexpr->token.getContent().begin();
     }
     return nullptr;
 }

--- a/source/slang/slang-reflection.cpp
+++ b/source/slang/slang-reflection.cpp
@@ -183,7 +183,7 @@ SLANG_API const char* spReflectionUserAttribute_GetArgumentValueString(SlangRefl
     if (auto cexpr = as<StringLiteralExpr>(userAttr->args[index]))
     {
         if (bufLen)
-            *bufLen = cexpr->token.getContent().getLength();
+            *bufLen = cexpr->token.getContentLength();
         return cexpr->token.getContent().begin();
     }
     return nullptr;

--- a/source/slang/slang-token.cpp
+++ b/source/slang/slang-token.cpp
@@ -6,22 +6,7 @@
 namespace Slang {
 
 
-Name* Token::getName() const
-{
-    return getNameOrNull();
-}
 
-Name* Token::getNameOrNull() const
-{
-    switch (type)
-    {
-    default:
-        return nullptr;
-
-    case TokenType::Identifier:
-        return (Name*) ptrValue;
-    }
-}
 
 char const* TokenTypeToString(TokenType type)
 {

--- a/source/slang/slang-token.h
+++ b/source/slang/slang-token.h
@@ -5,12 +5,13 @@
 #include "../core/slang-basic.h"
 
 #include "slang-source-loc.h"
+#include "slang-name.h"
 
 namespace Slang {
 
 class Name;
 
-enum class TokenType
+enum class TokenType : uint8_t
 {
 #define TOKEN(NAME, DESC) NAME,
 #include "slang-token-defs.h"
@@ -18,27 +19,54 @@ enum class TokenType
 
 char const* TokenTypeToString(TokenType type);
 
-enum TokenFlag : unsigned int
+typedef uint8_t TokenFlags;
+struct TokenFlag
 {
-    AtStartOfLine           = 1 << 0,
-    AfterWhitespace         = 1 << 1,
-    SuppressMacroExpansion  = 1 << 2,
-    ScrubbingNeeded         = 1 << 3,
+    enum Enum : TokenFlags
+    {
+        AtStartOfLine           = 1 << 0,
+        AfterWhitespace         = 1 << 1,
+        SuppressMacroExpansion  = 1 << 2,
+        ScrubbingNeeded         = 1 << 3,
+        Name                    = 1 << 4,           ///< If set the ptr points to the name
+    };
 };
-typedef unsigned int TokenFlags;
 
 class Token
 {
 public:
+
     TokenType   type = TokenType::Unknown;
     TokenFlags  flags = 0;
 
     SourceLoc   loc;
-    void*       ptrValue;
+    uint32_t charsCount;              ///< Only valid if the chars is valid (ie is not a name)
 
-    UnownedStringSlice Content;
+    union CharsNameUnion
+    {
+        const char* chars;
+        Name* name;
+    };
 
-    Token() = default;
+    CharsNameUnion charsNameUnion;
+
+    UnownedStringSlice getContent() const;
+        /// Set content
+    void setContent(const UnownedStringSlice& content);
+
+    Name* getName() const;
+
+    Name* getNameOrNull() const;
+
+    SourceLoc getLoc() const { return loc; }
+
+    SLANG_FORCE_INLINE void setName(Name* inName) { flags |= TokenFlag::Name; charsNameUnion.name = inName; }
+
+    Token():
+        charsCount(0)
+    {
+        charsNameUnion.chars = nullptr;
+    }
 
     Token(
         TokenType typeIn,
@@ -47,18 +75,39 @@ public:
         TokenFlags flagsIn = 0)
         : flags(flagsIn)
 	{
+        SLANG_ASSERT((flagsIn & TokenFlag::Name) == 0); 
 		type = typeIn;
-		Content = contentIn;
+        charsNameUnion.chars = contentIn.begin();
+        charsCount = uint32_t(contentIn.getLength());
         loc = locIn;
-        ptrValue = nullptr;
 	}
-
-    Name* getName() const;
-
-    Name* getNameOrNull() const;
-
-    SourceLoc getLoc() const { return loc; }
 };
+
+// ---------------------------------------------------------------------------
+SLANG_FORCE_INLINE UnownedStringSlice Token::getContent() const
+{
+    return (flags & TokenFlag::Name) ? charsNameUnion.name->text.getUnownedSlice() : UnownedStringSlice(charsNameUnion.chars, charsCount);
+}
+
+// ---------------------------------------------------------------------------
+SLANG_FORCE_INLINE Name* Token::getName() const
+{
+    return getNameOrNull();
+}
+
+// ---------------------------------------------------------------------------
+SLANG_FORCE_INLINE Name* Token::getNameOrNull() const
+{
+    return (flags & TokenFlag::Name) ? charsNameUnion.name : nullptr;
+}
+
+// ---------------------------------------------------------------------------
+SLANG_FORCE_INLINE void Token::setContent(const UnownedStringSlice& content)
+{
+    flags &= ~TokenFlag::Name;
+    charsNameUnion.chars = content.begin();
+    charsCount = uint32_t(content.getLength());
+}
 
 
 

--- a/tools/slang-cpp-extractor/slang-cpp-extractor-main.cpp
+++ b/tools/slang-cpp-extractor/slang-cpp-extractor-main.cpp
@@ -443,7 +443,7 @@ static void _indent(Index indentCount, StringBuilder& out)
 
 void Node::dumpDerived(int indentCount, StringBuilder& out)
 {
-    if (isClassLike() && m_isReflected && m_name.getContent().getLength() > 0)
+    if (isClassLike() && m_isReflected && m_name.hasContent())
     {
         _indent(indentCount, out);
         out << m_name.getContent() << "\n";
@@ -467,7 +467,7 @@ void Node::dump(int indentCount, StringBuilder& out)
         }
         case Type::Namespace:
         {
-            if (m_name.getContent().getLength())
+            if (m_name.hasContent())
             {
                 out << "namespace " << m_name.getContent() << " {\n";
             }
@@ -494,7 +494,7 @@ void Node::dump(int indentCount, StringBuilder& out)
                 out << ") ";
             }
 
-            if (m_super.getContent().getLength())
+            if (m_super.hasContent())
             {
                 out << " : " << m_super.getContent(); 
             }
@@ -523,7 +523,7 @@ void Node::calcAbsoluteName(StringBuilder& outName) const
 {
     if (m_parentScope == nullptr)
     {
-        if (m_name.getContent().getLength() == 0)
+        if (!m_name.hasContent())
         {
             return;
         }
@@ -902,7 +902,7 @@ SlangResult CPPExtractor::pushNode(Node* node)
         m_origin->addNode(node);
     }
 
-    if (node->m_name.getContent().getLength())
+    if (node->m_name.hasContent())
     {
         // For anonymous namespace, we should look if we already have one and just reopen that. Doing so will mean will
         // find anonymous namespace clashes
@@ -1648,7 +1648,7 @@ SlangResult CPPExtractor::_calcDerivedTypesRec(Node* node)
 {
     if (node->isClassLike() && node->m_baseType == Node::BaseType::None)
     {
-        if (node->m_super.getContent().getLength())
+        if (node->m_super.hasContent())
         {
             Node* parentScope = node->m_parentScope;
             if (parentScope == nullptr)

--- a/tools/slang-profile/slang-profile-main.cpp
+++ b/tools/slang-profile/slang-profile-main.cpp
@@ -19,8 +19,11 @@ SlangResult innerMain(int argc, char** argv)
     {
         const auto startTick = ProcessUtil::getClockTick();
 
-        ComPtr<slang::IGlobalSession> slangSession;
-        slangSession.attach(spCreateSession(nullptr));
+        for (Int i = 0; i < 32; ++i)
+        {
+            ComPtr<slang::IGlobalSession> slangSession;
+            slangSession.attach(spCreateSession(nullptr));
+        }
 
         const auto endTick = ProcessUtil::getClockTick();
 


### PR DESCRIPTION
The 64 bits Token type was taking up 40 bytes per token, the changes here bring this down to 24. This was due to 3 reasons

* The token type/flags were each 32 bits by default
* Identifers can hold a pointer to a Name
* The lexeme is held as a UnownedStringSlice

To save space therefore we

* Use 8 bits for type/flags
* Have a union that either holds a Name* or chars* which is identified by a flag (rather than TokenType)
* We don't need to use a pointer sized value for the length of the lexeme, 32 bit is enough

The  current layout is still somewhat wasteful, with 6 bytes not being used on 64 bits.

```
struct Token
{
    TokenType   type = TokenType::Unknown;
    TokenFlags  flags = 0;
   SourceLoc   loc;
    uint32_t charsCount = 0;              ///< Amount of characters. Is set if name or not.
    void* charsOrName;
};
```

Unfortunately there doesn't seem like a straightforward way to improve on this for now, if we want a single structure.