### PR TITLE
Non virtual accept implementation on AST types

### DIFF
--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -74,7 +74,7 @@ class Val : public NodeBase
 
     typedef IValVisitor Visitor;
 
-    virtual void accept(IValVisitor* visitor, void* extra) = 0;
+    void accept(IValVisitor* visitor, void* extra);
 
     // construct a new value by applying a set of parameter
     // substitutions to this one
@@ -122,8 +122,7 @@ class Type: public Val
 
     typedef ITypeVisitor Visitor;
 
-    virtual void accept(IValVisitor* visitor, void* extra) override;
-    virtual void accept(ITypeVisitor* visitor, void* extra) = 0;
+    void accept(ITypeVisitor* visitor, void* extra);
 
 public:
     Session* getSession() { return this->session; }
@@ -270,7 +269,7 @@ class Modifier : public SyntaxNode
     SLANG_ABSTRACT_CLASS(Modifier)
     typedef IModifierVisitor Visitor;
 
-    virtual void accept(IModifierVisitor* visitor, void* extra) = 0;
+    void accept(IModifierVisitor* visitor, void* extra);
 
     // Next modifier in linked list of modifiers on same piece of syntax
     RefPtr<Modifier> next;
@@ -311,7 +310,7 @@ class DeclBase : public ModifiableSyntaxNode
 
     typedef IDeclVisitor Visitor;
 
-    virtual void accept(IDeclVisitor* visitor, void* extra) = 0;
+    void accept(IDeclVisitor* visitor, void* extra);
 };
 
 class Decl : public DeclBase
@@ -349,7 +348,7 @@ class Expr : public SyntaxNode
 
     QualType type;
 
-    virtual void accept(IExprVisitor* visitor, void* extra) = 0;
+    void accept(IExprVisitor* visitor, void* extra);
 };
 
 class Stmt : public ModifiableSyntaxNode
@@ -358,7 +357,7 @@ class Stmt : public ModifiableSyntaxNode
 
     typedef IStmtVisitor Visitor;
 
-    virtual void accept(IStmtVisitor* visitor, void* extra) = 0;
+    void accept(IStmtVisitor* visitor, void* extra);
 };
 
 } // namespace Slang

--- a/source/slang/slang-ast-reflect.cpp
+++ b/source/slang/slang-ast-reflect.cpp
@@ -75,15 +75,14 @@ SLANG_ALL_ASTNode_Substitutions(SLANG_REFLECT_CLASS_INFO, _)
 #define SLANG_CASE_DISPATCH(NAME, SUPER, ORIGIN, LAST, MARKER, TYPE, param)  SLANG_CASE_##MARKER(NAME)
 
 // A special case used in Val::accept, because can be Type derived too
-#define SLANG_CASE_TYPE_NONE(NAME)           case ASTNodeType::NAME: return ((ITypeVisitor*)visitor)->dispatch_##NAME(static_cast<NAME*>(this), extra);
-#define SLANG_CASE_TYPE_ABSTRACT(NAME)
 
-#define SLANG_CASE_TYPE_DISPATCH(NAME, SUPER, ORIGIN, LAST, MARKER, TYPE, param)  SLANG_CASE_TYPE_##MARKER(NAME)
+#define SLANG_CASE_ORIGIN_VAL(NAME)        case ASTNodeType::NAME: return visitor->dispatch_##NAME(static_cast<NAME*>(this), extra);
+#define SLANG_CASE_ORIGIN_TYPE(NAME)       case ASTNodeType::NAME: return ((ITypeVisitor*)visitor)->dispatch_##NAME(static_cast<NAME*>(this), extra);
 
-// Use origin lists, to generate regular and type dispatch
+#define SLANG_CASE_TYPE_NONE(NAME, ORIGIN)              SLANG_CASE_ORIGIN_##ORIGIN(NAME)
+#define SLANG_CASE_TYPE_ABSTRACT(NAME, ORIGIN)
 
-#define SLANG_ORIGIN_CASE_DISPATCH(NAME, param) SLANG_ASTNode_##NAME(SLANG_CASE_DISPATCH, param)
-#define SLANG_ORIGIN_CASE_TYPE_DISPATCH(NAME, param) SLANG_ASTNode_##NAME(SLANG_CASE_TYPE_DISPATCH, param)
+#define SLANG_CASE_TYPE_DISPATCH(NAME, SUPER, ORIGIN, LAST, MARKER, TYPE, param)  SLANG_CASE_TYPE_##MARKER(NAME, ORIGIN)
 
 void Val::accept(IValVisitor* visitor, void* extra)
 {
@@ -95,15 +94,15 @@ void Val::accept(IValVisitor* visitor, void* extra)
         // Here some trickery is used. When virtual methods were used, the override of the IValVistor
         // function on Type, would cast to a ITypeVisitor and then 'accept' that.
         //
-        // Here I want to dispatch to the correct visitor depending on the underlying type.
-        // A problem is that the 'Val' hierachy contains both Type and other things, so if I want a single
+        // I want to dispatch to the correct visitor depending on the underlying type.
+        // A problem is that the 'Val' hierarchy contains both Type and other things, so if I want a single
         // switch I have to partition.
         //
         // A simpler (but less efficient) method would be to cast this to a type, and if that works use the ITypeVistor.
         // Here I use the 'ORIGIN' which uses the file 'ORIGIN' of the class. It turns out that Type and Val are partitioned
-        // such that there is no cross over, and contain the appropriate split of types
-        SLANG_ORIGIN_TYPE_ASTNode(SLANG_ORIGIN_CASE_TYPE_DISPATCH, _)
-        SLANG_ORIGIN_VAL_ASTNode(SLANG_ORIGIN_CASE_DISPATCH, _)
+        // such that there is no cross over, and contain the appropriate split of types.
+
+        SLANG_CHILDREN_ASTNode_Val(SLANG_CASE_TYPE_DISPATCH, _)
 
         default: SLANG_ASSERT(!"Unknown type");
     }

--- a/source/slang/slang-ast-reflect.cpp
+++ b/source/slang/slang-ast-reflect.cpp
@@ -74,16 +74,6 @@ SLANG_ALL_ASTNode_Substitutions(SLANG_REFLECT_CLASS_INFO, _)
 
 #define SLANG_CASE_DISPATCH(NAME, SUPER, ORIGIN, LAST, MARKER, TYPE, param)  SLANG_CASE_##MARKER(NAME)
 
-// A special case used in Val::accept, because can be Type derived too
-
-#define SLANG_CASE_ORIGIN_VAL(NAME)        case ASTNodeType::NAME: return visitor->dispatch_##NAME(static_cast<NAME*>(this), extra);
-#define SLANG_CASE_ORIGIN_TYPE(NAME)       case ASTNodeType::NAME: return ((ITypeVisitor*)visitor)->dispatch_##NAME(static_cast<NAME*>(this), extra);
-
-#define SLANG_CASE_TYPE_NONE(NAME, ORIGIN)              SLANG_CASE_ORIGIN_##ORIGIN(NAME)
-#define SLANG_CASE_TYPE_ABSTRACT(NAME, ORIGIN)
-
-#define SLANG_CASE_TYPE_DISPATCH(NAME, SUPER, ORIGIN, LAST, MARKER, TYPE, param)  SLANG_CASE_TYPE_##MARKER(NAME, ORIGIN)
-
 void Val::accept(IValVisitor* visitor, void* extra)
 {
     const ReflectClassInfo& classInfo = getClassInfo();
@@ -91,19 +81,7 @@ void Val::accept(IValVisitor* visitor, void* extra)
 
     switch (astType)
     {
-        // Here some trickery is used. When virtual methods were used, the override of the IValVistor
-        // function on Type, would cast to a ITypeVisitor and then 'accept' that.
-        //
-        // I want to dispatch to the correct visitor depending on the underlying type.
-        // A problem is that the 'Val' hierarchy contains both Type and other things, so if I want a single
-        // switch I have to partition.
-        //
-        // A simpler (but less efficient) method would be to cast this to a type, and if that works use the ITypeVistor.
-        // Here I use the 'ORIGIN' which uses the file 'ORIGIN' of the class. It turns out that Type and Val are partitioned
-        // such that there is no cross over, and contain the appropriate split of types.
-
-        SLANG_CHILDREN_ASTNode_Val(SLANG_CASE_TYPE_DISPATCH, _)
-
+        SLANG_CHILDREN_ASTNode_Val(SLANG_CASE_DISPATCH, _)
         default: SLANG_ASSERT(!"Unknown type");
     }
 }

--- a/source/slang/slang-ast-reflect.h
+++ b/source/slang/slang-ast-reflect.h
@@ -10,33 +10,7 @@
 #define SLANG_AST_OVERRIDE_INNER override
 #define SLANG_AST_OVERRIDE_LEAF override
 
-// Switch based on the origin - classes defined in slang-ast-base.h do not have accept defined on them
-// The 'origin' is based on the file where the class definition is located.
-
-// Define what the accept method looks like, so don't have to repeat
-#define SLANG_AST_ACCEPT_IMPL(NAME) virtual void accept(NAME::Visitor* visitor, void* extra) override;
-
-// A macro for *all* of the different origin/files where AST files are defined. 
-#define SLANG_AST_ACCEPT_BASE(NAME) 
-#define SLANG_AST_ACCEPT_DECL(NAME) SLANG_AST_ACCEPT_IMPL(NAME)
-#define SLANG_AST_ACCEPT_EXPR(NAME) SLANG_AST_ACCEPT_IMPL(NAME)
-#define SLANG_AST_ACCEPT_MODIFIER(NAME) SLANG_AST_ACCEPT_IMPL(NAME)
-#define SLANG_AST_ACCEPT_TYPE(NAME) SLANG_AST_ACCEPT_IMPL(NAME)
-#define SLANG_AST_ACCEPT_VAL(NAME) SLANG_AST_ACCEPT_IMPL(NAME)
-#define SLANG_AST_ACCEPT_STMT(NAME) SLANG_AST_ACCEPT_IMPL(NAME)
-
 // Implementation for SLANG_ABSTRACT_CLASS(x) using reflection from C++ extractor in slang-ast-generated.h
-#define SLANG_ABSTRACT_CLASS_REFLECT_IMPL(NAME, SUPER, ORIGIN, LAST, MARKER, TYPE, param) \
-    public:     \
-    typedef SUPER Super; \
-    static const ASTNodeType kType = ASTNodeType::NAME; \
-    static const ReflectClassInfo kReflectClassInfo;  \
-    SLANG_FORCE_INLINE static bool isDerivedFrom(ASTNodeType type) { return int(type) >= int(kType) && int(type) <= int(ASTNodeType::LAST); } \
-    virtual const ReflectClassInfo& getClassInfo() const SLANG_AST_OVERRIDE_##TYPE { return kReflectClassInfo; } \
-
-// Implementation for SLANG_CLASS(x) using reflection from C++ extractor in slang-ast-generated.h.
-// This implementation is the same as for SLANG_ABSTRACT_CLASS_REFLECT_IMPL, except for the SLANG_AST_ACCEPT_ line which inserts the accept
-// method for non 'BASE' origin classes. 
 #define SLANG_CLASS_REFLECT_IMPL(NAME, SUPER, ORIGIN, LAST, MARKER, TYPE, param) \
     public:     \
     typedef SUPER Super; \
@@ -44,11 +18,10 @@
     static const ReflectClassInfo kReflectClassInfo;  \
     SLANG_FORCE_INLINE static bool isDerivedFrom(ASTNodeType type) { return int(type) >= int(kType) && int(type) <= int(ASTNodeType::LAST); } \
     virtual const ReflectClassInfo& getClassInfo() const SLANG_AST_OVERRIDE_##TYPE { return kReflectClassInfo; } \
-    SLANG_AST_ACCEPT_##ORIGIN(NAME)
 
 // Macro definitions - use the SLANG_ASTNode_ definitions to invoke the IMPL to produce the code
 // injected into AST classes
-#define SLANG_ABSTRACT_CLASS(NAME)  SLANG_ASTNode_##NAME(SLANG_ABSTRACT_CLASS_REFLECT_IMPL, _)
+#define SLANG_ABSTRACT_CLASS(NAME)  SLANG_ASTNode_##NAME(SLANG_CLASS_REFLECT_IMPL, _)
 #define SLANG_CLASS(NAME)           SLANG_ASTNode_##NAME(SLANG_CLASS_REFLECT_IMPL, _)
 
 // Does nothing - just a mark to the C++ extractor

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -491,6 +491,12 @@ namespace Slang
             // We include super.m_classId, because it's a subclass of itself.
             return m_classId >= super.m_classId && m_classId <= super.m_lastClassId;
         }
+        // True if typeId derives from this type
+        SLANG_FORCE_INLINE bool isDerivedFrom(uint32_t typeId) const
+        {
+            return typeId >= m_classId && typeId <= m_lastClassId;
+        }
+
         /// Will produce the same result as isSubClassOf, but more slowly by traversing the m_superClass
         /// Works without initRange being called. 
         bool isSubClassOfSlow(const ThisType& super) const;

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -9,11 +9,6 @@
 namespace Slang
 {
 
-#define SLANG_CLASS_ACCEPT_IMPL(NAME, SUPER, ORIGIN, LAST, MARKER, TYPE, param) \
-    void NAME::accept(NAME::Visitor* visitor, void* extra) { visitor->dispatch_##NAME(this, extra); }
-
-SLANG_ALL_ASTNode_NodeBase(SLANG_CLASS_ONLY, SLANG_CLASS_ACCEPT_IMPL)
-
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!! DiagnosticSink impls !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 void printDiagnosticArg(StringBuilder& sb, Decl* decl)
@@ -208,13 +203,6 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
     }
     return count;
 }
-
-    // Type
-
-    void Type::accept(IValVisitor* visitor, void* extra)
-    {
-        accept((ITypeVisitor*)visitor, extra);
-    }
 
     // TypeExp
 


### PR DESCRIPTION
AST types had virtual accept methods, that would in turn call dispatch_X on the appropriate visitor. 

This code was generated via the output of the C++ extractor. One complication was that it required 'ABSTRACT' and 'NONE' (non ABSTRACT here) classes to inject different code in the SLANG_CLASS and SLANG_ABSTRACT_CLASS macros.

The change here uses the ASTNodeType and code generation to make the accept function not need to be virtual, and is replaced by a switch over appropriate types.

Note previously there was some special handling around IValVisitor. 

```
void Type::accept(IValVisitor* visitor, void* extra)
{
     accept((ITypeVisitor*)visitor, extra);
}
```

I did produce something that emulated this behavior. But on looking into it some more it's kind of fragile - it assumes that IValVisitor starts with the same methods as ITypeVistor, which it turns out it does.

I don't think this is required, in current scheme so I removed the special handling which simplified the code. 
