### PR TITLE
Tidy up around AST nodes

### DIFF
--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -78,14 +78,14 @@ class Val : public NodeBase
 
     // construct a new value by applying a set of parameter
     // substitutions to this one
-    RefPtr<Val> Substitute(SubstitutionSet subst);
+    RefPtr<Val> substitute(SubstitutionSet subst);
 
     // Lower-level interface for substitution. Like the basic
     // `Substitute` above, but also takes a by-reference
     // integer parameter that should be incremented when
     // returning a modified value (this can help the caller
     // decide whether they need to do anything).
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff);
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff);
 
     virtual bool EqualsVal(Val* val) = 0;
     virtual String ToString() = 0;
@@ -133,7 +133,7 @@ public:
     
     Type* getCanonicalType();
 
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
 
     virtual bool EqualsVal(Val* val) override;
 

--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -290,17 +290,17 @@ class ModifiableSyntaxNode : public SyntaxNode
     Modifiers modifiers;
 
     template<typename T>
-    FilteredModifierList<T> GetModifiersOfType() { return FilteredModifierList<T>(modifiers.first.Ptr()); }
+    FilteredModifierList<T> getModifiersOfType() { return FilteredModifierList<T>(modifiers.first.Ptr()); }
 
     // Find the first modifier of a given type, or return `nullptr` if none is found.
     template<typename T>
-    T* FindModifier()
+    T* findModifier()
     {
-        return *GetModifiersOfType<T>().begin();
+        return *getModifiersOfType<T>().begin();
     }
 
     template<typename T>
-    bool HasModifier() { return FindModifier<T>() != nullptr; }
+    bool hasModifier() { return findModifier<T>() != nullptr; }
 };
 
 
@@ -333,8 +333,8 @@ public:
     // The next declaration defined in the same container with the same name
     Decl* nextInContainerWithSameName = nullptr;
 
-    bool IsChecked(DeclCheckState state) { return checkState >= state; }
-    void SetCheckState(DeclCheckState state)
+    bool isChecked(DeclCheckState state) { return checkState >= state; }
+    void setCheckState(DeclCheckState state)
     {
         SLANG_RELEASE_ASSERT(state >= checkState.getState());
         checkState.setState(state);

--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -87,12 +87,12 @@ class Val : public NodeBase
     // decide whether they need to do anything).
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff);
 
-    virtual bool EqualsVal(Val* val) = 0;
-    virtual String ToString() = 0;
+    virtual bool equalsVal(Val* val) = 0;
+    virtual String toString() = 0;
     virtual int GetHashCode() = 0;
     bool operator == (const Val & v)
     {
-        return EqualsVal(const_cast<Val*>(&v));
+        return equalsVal(const_cast<Val*>(&v));
     }
 };
 
@@ -129,18 +129,18 @@ public:
     Session* getSession() { return this->session; }
     void setSession(Session* s) { this->session = s; }
 
-    bool Equals(Type* type);
+    bool equals(Type* type);
     
     Type* getCanonicalType();
 
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
 
-    virtual bool EqualsVal(Val* val) override;
+    virtual bool equalsVal(Val* val) override;
 
     ~Type();
 
 protected:
-    virtual bool EqualsImpl(Type* type) = 0;
+    virtual bool equalsImpl(Type* type) = 0;
 
     virtual RefPtr<Type> CreateCanonicalType() = 0;
     Type* canonicalType = nullptr;
@@ -166,7 +166,7 @@ class Substitutions: public RefObject
     virtual RefPtr<Substitutions> applySubstitutionsShallow(SubstitutionSet substSet, RefPtr<Substitutions> substOuter, int* ioDiff) = 0;
 
     // Check if these are equivalent substitutions to another set
-    virtual bool Equals(Substitutions* subst) = 0;
+    virtual bool equals(Substitutions* subst) = 0;
     virtual int GetHashCode() const = 0;
 };
 
@@ -185,7 +185,7 @@ class GenericSubstitution : public Substitutions
     virtual RefPtr<Substitutions> applySubstitutionsShallow(SubstitutionSet substSet, RefPtr<Substitutions> substOuter, int* ioDiff)  override;
 
     // Check if these are equivalent substitutions to another set
-    virtual bool Equals(Substitutions* subst) override;
+    virtual bool equals(Substitutions* subst) override;
 
     virtual int GetHashCode() const override
     {
@@ -215,7 +215,7 @@ class ThisTypeSubstitution : public Substitutions
     virtual RefPtr<Substitutions> applySubstitutionsShallow(SubstitutionSet substSet, RefPtr<Substitutions> substOuter, int* ioDiff)  override;
 
     // Check if these are equivalent substitutions to another set
-    virtual bool Equals(Substitutions* subst) override;
+    virtual bool equals(Substitutions* subst) override;
 
     virtual int GetHashCode() const override;
 };
@@ -242,7 +242,7 @@ class GlobalGenericParamSubstitution : public Substitutions
     virtual RefPtr<Substitutions> applySubstitutionsShallow(SubstitutionSet substSet, RefPtr<Substitutions> substOuter, int* ioDiff)  override;
 
     // Check if these are equivalent substitutions to another set
-    virtual bool Equals(Substitutions* subst) override;
+    virtual bool equals(Substitutions* subst) override;
 
     virtual int GetHashCode() const override
     {

--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -320,7 +320,7 @@ class Decl : public DeclBase
 public:
     SLANG_ABSTRACT_CLASS(Decl)
 
-    ContainerDecl* ParentDecl = nullptr;
+    ContainerDecl* parentDecl = nullptr;
 
     NameLoc nameAndLoc;
 

--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -131,7 +131,7 @@ public:
 
     bool Equals(Type* type);
     
-    Type* GetCanonicalType();
+    Type* getCanonicalType();
 
     virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
 
@@ -149,9 +149,9 @@ protected:
 };
 
 template <typename T>
-SLANG_FORCE_INLINE T* as(Type* obj) { return obj ? dynamicCast<T>(obj->GetCanonicalType()) : nullptr; }
+SLANG_FORCE_INLINE T* as(Type* obj) { return obj ? dynamicCast<T>(obj->getCanonicalType()) : nullptr; }
 template <typename T>
-SLANG_FORCE_INLINE const T* as(const Type* obj) { return obj ? dynamicCast<T>(const_cast<Type*>(obj)->GetCanonicalType()) : nullptr; }
+SLANG_FORCE_INLINE const T* as(const Type* obj) { return obj ? dynamicCast<T>(const_cast<Type*>(obj)->getCanonicalType()) : nullptr; }
 
 // A substitution represents a binding of certain
 // type-level variables to concrete argument values

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -107,7 +107,7 @@ class AggTypeDecl : public  AggTypeDeclBase
     // extensions that might apply to this declaration
     ExtensionDecl* candidateExtensions = nullptr;
 
-    FilteredMemberList<VarDecl> GetFields()
+    FilteredMemberList<VarDecl> getFields()
     {
         return getMembersOfType<VarDecl>();
     }
@@ -170,7 +170,7 @@ class TypeConstraintDecl : public  Decl
 {
     SLANG_ABSTRACT_CLASS(TypeConstraintDecl)
     
-    virtual TypeExp& getSup() = 0;
+    SLANG_INLINE const TypeExp& getSup() const;
 };
 
 // A kind of pseudo-member that represents an explicit
@@ -180,7 +180,7 @@ class InheritanceDecl : public TypeConstraintDecl
 {
     SLANG_CLASS(InheritanceDecl)
 
-// The type expression as written
+    // The type expression as written
     TypeExp base;
 
     // After checking, this dictionary will map members
@@ -188,10 +188,6 @@ class InheritanceDecl : public TypeConstraintDecl
     // implementations in the type that contains
     // this inheritance declaration.
     RefPtr<WitnessTable> witnessTable;
-    virtual TypeExp& getSup() override
-    {
-        return base;
-    }
 };
 
 // TODO: may eventually need sub-classes for explicit/direct vs. implicit/indirect inheritance
@@ -262,12 +258,12 @@ class CallableDecl : public ContainerDecl
 {
     SLANG_ABSTRACT_CLASS(CallableDecl)
 
-    FilteredMemberList<ParamDecl> GetParameters()
+    FilteredMemberList<ParamDecl> getParameters()
     {
         return getMembersOfType<ParamDecl>();
     }
 
-    TypeExp ReturnType;
+    TypeExp returnType;
 
     // Fields related to redeclaration, so that we
     // can support multiple specialized variations
@@ -290,7 +286,7 @@ class FunctionDeclBase : public CallableDecl
 {
     SLANG_ABSTRACT_CLASS(FunctionDeclBase)
 
-    RefPtr<Stmt> Body;
+    RefPtr<Stmt> body;
 };
 
 // A constructor/initializer to create instances of a type
@@ -405,11 +401,6 @@ class GenericTypeConstraintDecl : public TypeConstraintDecl
     // think of these fields as the sub-type and super-type, respectively.
     TypeExp sub;
     TypeExp sup;
-    
-    virtual TypeExp& getSup() override
-    {
-        return sup;
-    }
 };
 
 class GenericValueParamDecl : public VarDeclBase
@@ -456,5 +447,19 @@ class AttributeDecl : public ContainerDecl
     // What type of syntax node will be produced to represent this attribute.
     SyntaxClass<RefObject> syntaxClass;
 };
+
+// ------------------------------------------------------------------------
+
+const TypeExp& TypeConstraintDecl::getSup() const
+{
+    ASTNodeType type = ASTNodeType(getClassInfo().m_classId);
+    switch (type)
+    {
+        case ASTNodeType::InheritanceDecl:              return static_cast<const InheritanceDecl*>(this)->base;
+        case ASTNodeType::GenericTypeConstraintDecl:    return static_cast<const GenericTypeConstraintDecl*>(this)->sup;
+        default:                                        SLANG_ASSERT(!"getSup not implemented for this type!"); return TypeExp::empty;
+    }
+}
+
 
 } // namespace Slang

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -22,15 +22,15 @@ class ContainerDecl: public Decl
 {
     SLANG_ABSTRACT_CLASS(ContainerDecl)
 
-    List<RefPtr<Decl>> Members;
+    List<RefPtr<Decl>> members;
 
     template<typename T>
     FilteredMemberList<T> getMembersOfType()
     {
-        return FilteredMemberList<T>(Members);
+        return FilteredMemberList<T>(members);
     }
 
-    bool isMemberDictionaryValid() const { return dictionaryLastCount == Members.getCount(); }
+    bool isMemberDictionaryValid() const { return dictionaryLastCount == members.getCount(); }
 
     void invalidateMemberDictionary() { dictionaryLastCount = -1; }
 

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -111,7 +111,7 @@ class ExprWithArgsBase : public Expr
 {
     SLANG_ABSTRACT_CLASS(ExprWithArgsBase)
 
-    List<RefPtr<Expr>> Arguments;
+    List<RefPtr<Expr>> arguments;
 };
 
 // An aggregate type constructor
@@ -119,7 +119,7 @@ class AggTypeCtorExpr : public ExprWithArgsBase
 {
     SLANG_CLASS(AggTypeCtorExpr)
 
-    TypeExp base;;
+    TypeExp base;
 };
 
 
@@ -129,7 +129,7 @@ class AppExprBase : public ExprWithArgsBase
 {
     SLANG_ABSTRACT_CLASS(AppExprBase)
 
-    RefPtr<Expr> FunctionExpr;
+    RefPtr<Expr> functionExpr;
 };
 
 class InvokeExpr: public AppExprBase
@@ -159,21 +159,21 @@ class IndexExpr: public Expr
 {
     SLANG_CLASS(IndexExpr)
 
-    RefPtr<Expr> BaseExpression;
-    RefPtr<Expr> IndexExpression;
+    RefPtr<Expr> baseExpression;
+    RefPtr<Expr> indexExpression;
 };
 
 class MemberExpr: public DeclRefExpr
 {
     SLANG_CLASS(MemberExpr)
-    RefPtr<Expr> BaseExpression;
+    RefPtr<Expr> baseExpression;
 };
 
 // Member looked up on a type, rather than a value
 class StaticMemberExpr: public DeclRefExpr
 {
     SLANG_CLASS(StaticMemberExpr)
-    RefPtr<Expr> BaseExpression;
+    RefPtr<Expr> baseExpression;
 };
 
 class SwizzleExpr: public Expr
@@ -245,8 +245,8 @@ class SharedTypeExpr: public Expr
 class AssignExpr: public Expr
 {
     SLANG_CLASS(AssignExpr)
-    RefPtr<Expr> left;;
-    RefPtr<Expr> right;;
+    RefPtr<Expr> left;
+    RefPtr<Expr> right;
 };
 
 // Just an expression inside parentheses `(exp)`
@@ -256,7 +256,7 @@ class AssignExpr: public Expr
 class ParenExpr: public Expr
 {
     SLANG_CLASS(ParenExpr)
-    RefPtr<Expr> base;;
+    RefPtr<Expr> base;
 };
 
 // An object-oriented `this` expression, used to
@@ -264,7 +264,7 @@ class ParenExpr: public Expr
 class ThisExpr: public Expr
 {
     SLANG_CLASS(ThisExpr)
-    RefPtr<Scope> scope;;
+    RefPtr<Scope> scope;
 };
 
 // An expression that binds a temporary variable in a local expression context

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -728,7 +728,7 @@ class EntryPointAttribute : public Attribute
     //
     // TODO: This should be an accessor that uses the
     // ordinary `args` list, rather than side data.
-    Stage stage;;
+    Stage stage;
 };
 
 // A `[__vulkanRayPayload]` attribute, which is used in the

--- a/source/slang/slang-ast-stmt.h
+++ b/source/slang/slang-ast-stmt.h
@@ -28,7 +28,7 @@ class BlockStmt : public ScopeStmt
 {
     SLANG_CLASS(BlockStmt)
 
-    RefPtr<Stmt> body;;
+    RefPtr<Stmt> body;
 };
 
 // A statement that we aren't going to parse or check, because
@@ -62,9 +62,9 @@ class IfStmt : public Stmt
 {
     SLANG_CLASS(IfStmt)
 
-    RefPtr<Expr> Predicate;
-    RefPtr<Stmt> PositiveStatement;
-    RefPtr<Stmt> NegativeStatement;
+    RefPtr<Expr> predicate;
+    RefPtr<Stmt> positiveStatement;
+    RefPtr<Stmt> negativeStatement;
 };
 
 // A statement that can be escaped with a `break`
@@ -129,10 +129,10 @@ class ForStmt : public LoopStmt
 {
     SLANG_CLASS(ForStmt)
 
-    RefPtr<Stmt> InitialStatement;
-    RefPtr<Expr> SideEffectExpression;
-    RefPtr<Expr> PredicateExpression;
-    RefPtr<Stmt> Statement;
+    RefPtr<Stmt> initialStatement;
+    RefPtr<Expr> sideEffectExpression;
+    RefPtr<Expr> predicateExpression;
+    RefPtr<Stmt> statement;
 };
 
 // A `for` statement in a language that doesn't restrict the scope
@@ -147,16 +147,16 @@ class WhileStmt : public LoopStmt
 {
     SLANG_CLASS(WhileStmt)
 
-    RefPtr<Expr> Predicate;
-    RefPtr<Stmt> Statement;
+    RefPtr<Expr> predicate;
+    RefPtr<Stmt> statement;
 };
 
 class DoWhileStmt : public LoopStmt 
 {
     SLANG_CLASS(DoWhileStmt)
 
-    RefPtr<Stmt> Statement;
-    RefPtr<Expr> Predicate;
+    RefPtr<Stmt> statement;
+    RefPtr<Expr> predicate;
 };
 
 // A compile-time, range-based `for` loop, which will not appear in the output code
@@ -194,14 +194,14 @@ class ReturnStmt : public Stmt
 {
     SLANG_CLASS(ReturnStmt)
 
-    RefPtr<Expr> Expression;
+    RefPtr<Expr> expression;
 };
 
 class ExpressionStmt : public Stmt 
 {
     SLANG_CLASS(ExpressionStmt)
 
-    RefPtr<Expr> Expression;
+    RefPtr<Expr> expression;
 };
 
 } // namespace Slang

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -994,6 +994,9 @@ namespace Slang
         Type* operator->() { return Ptr(); }
 
         TypeExp Accept(SyntaxVisitor* visitor);
+
+            /// A global immutable TypeExp, that has no type or exp set.
+        static const TypeExp empty;
     };
 
 

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -391,7 +391,7 @@ class ArrayExpressionType : public Type
     SLANG_CLASS(ArrayExpressionType)
 
     RefPtr<Type> baseType;
-    RefPtr<IntVal> ArrayLength;
+    RefPtr<IntVal> arrayLength;
 
     virtual Slang::String ToString() override;
 

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -46,7 +46,7 @@ public:
 
 protected:
     virtual bool EqualsImpl(Type * type) override;
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
     virtual RefPtr<Type> CreateCanonicalType() override;
     virtual int GetHashCode() override;
 };
@@ -59,7 +59,7 @@ class DeclRefType : public Type
     DeclRef<Decl> declRef;
 
     virtual String ToString() override;
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
 
     static RefPtr<DeclRefType> Create(
         Session*        session,
@@ -398,7 +398,7 @@ class ArrayExpressionType : public Type
 protected:
     virtual bool EqualsImpl(Type * type) override;
     virtual RefPtr<Type> CreateCanonicalType() override;
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
     virtual int GetHashCode() override;
 };
 
@@ -568,7 +568,7 @@ class FuncType : public Type
 
     virtual String ToString() override;
 protected:
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
     virtual bool EqualsImpl(Type * type) override;
     virtual RefPtr<Type> CreateCanonicalType() override;
     virtual int GetHashCode() override;
@@ -630,7 +630,7 @@ class ExtractExistentialType : public Type
     virtual bool EqualsImpl(Type * type) override;
     virtual int GetHashCode() override;
     virtual RefPtr<Type> CreateCanonicalType() override;
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
 };
 
     /// A tagged union of zero or more other types.
@@ -649,7 +649,7 @@ class TaggedUnionType : public Type
     virtual bool EqualsImpl(Type * type) override;
     virtual int GetHashCode() override;
     virtual RefPtr<Type> CreateCanonicalType() override;
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
 };
 
 class ExistentialSpecializedType : public Type 
@@ -663,7 +663,7 @@ class ExistentialSpecializedType : public Type
     virtual bool EqualsImpl(Type * type) override;
     virtual int GetHashCode() override;
     virtual RefPtr<Type> CreateCanonicalType() override;
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
 };
 
     /// The type of `this` within a polymorphic declaration
@@ -677,7 +677,7 @@ class ThisType : public Type
     virtual bool EqualsImpl(Type * type) override;
     virtual int GetHashCode() override;
     virtual RefPtr<Type> CreateCanonicalType() override;
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
 
 };
 

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -14,10 +14,10 @@ class OverloadGroupType : public Type
     SLANG_CLASS(OverloadGroupType)
 
 public:
-    virtual String ToString() override;
+    virtual String toString() override;
 
 protected:
-    virtual bool EqualsImpl(Type * type) override;
+    virtual bool equalsImpl(Type * type) override;
     virtual RefPtr<Type> CreateCanonicalType() override;
     virtual int GetHashCode() override;
 };
@@ -28,10 +28,10 @@ class InitializerListType : public Type
 {
     SLANG_CLASS(InitializerListType)
 
-    virtual String ToString() override;
+    virtual String toString() override;
 
 protected:
-    virtual bool EqualsImpl(Type * type) override;
+    virtual bool equalsImpl(Type * type) override;
     virtual RefPtr<Type> CreateCanonicalType() override;
     virtual int GetHashCode() override;
 };
@@ -42,10 +42,10 @@ class ErrorType : public Type
     SLANG_CLASS(ErrorType)
 
 public:
-    virtual String ToString() override;
+    virtual String toString() override;
 
 protected:
-    virtual bool EqualsImpl(Type * type) override;
+    virtual bool equalsImpl(Type * type) override;
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
     virtual RefPtr<Type> CreateCanonicalType() override;
     virtual int GetHashCode() override;
@@ -58,7 +58,7 @@ class DeclRefType : public Type
 
     DeclRef<Decl> declRef;
 
-    virtual String ToString() override;
+    virtual String toString() override;
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
 
     static RefPtr<DeclRefType> Create(
@@ -73,7 +73,7 @@ class DeclRefType : public Type
     {}
 protected:
     virtual int GetHashCode() override;
-    virtual bool EqualsImpl(Type * type) override;
+    virtual bool equalsImpl(Type * type) override;
     virtual RefPtr<Type> CreateCanonicalType() override;
 };
 
@@ -100,7 +100,7 @@ class BasicExpressionType : public ArithmeticExpressionType
     {}
 protected:
     virtual BasicExpressionType* GetScalarType() override;
-    virtual bool EqualsImpl(Type * type) override;
+    virtual bool equalsImpl(Type * type) override;
     virtual RefPtr<Type> CreateCanonicalType() override;
 
 };
@@ -393,10 +393,10 @@ class ArrayExpressionType : public Type
     RefPtr<Type> baseType;
     RefPtr<IntVal> arrayLength;
 
-    virtual String ToString() override;
+    virtual String toString() override;
 
 protected:
-    virtual bool EqualsImpl(Type * type) override;
+    virtual bool equalsImpl(Type * type) override;
     virtual RefPtr<Type> CreateCanonicalType() override;
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
     virtual int GetHashCode() override;
@@ -419,10 +419,10 @@ public:
         : type(type)
     {}
 
-    virtual String ToString() override;
+    virtual String toString() override;
 
 protected:
-    virtual bool EqualsImpl(Type * type) override;
+    virtual bool equalsImpl(Type * type) override;
     virtual RefPtr<Type> CreateCanonicalType() override;
     virtual int GetHashCode() override;
 };
@@ -439,7 +439,7 @@ class VectorExpressionType : public ArithmeticExpressionType
     // The number of elements
     RefPtr<IntVal> elementCount;
 
-    virtual String ToString() override;
+    virtual String toString() override;
 
 protected:
     virtual BasicExpressionType* GetScalarType() override;
@@ -456,7 +456,7 @@ class MatrixExpressionType : public ArithmeticExpressionType
 
     RefPtr<Type> getRowType();
 
-    virtual String ToString() override;
+    virtual String toString() override;
 
 protected:
     virtual BasicExpressionType* GetScalarType() override;
@@ -536,10 +536,10 @@ class NamedExpressionType : public Type
         : declRef(declRef)
     {}
 
-    virtual String ToString() override;
+    virtual String toString() override;
 
 protected:
-    virtual bool EqualsImpl(Type * type) override;
+    virtual bool equalsImpl(Type * type) override;
     virtual RefPtr<Type> CreateCanonicalType() override;
     virtual int GetHashCode() override;
 };
@@ -566,10 +566,10 @@ class FuncType : public Type
     Type* getParamType(UInt index) { return paramTypes[index]; }
     Type* getResultType() { return resultType; }
 
-    virtual String ToString() override;
+    virtual String toString() override;
 protected:
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
-    virtual bool EqualsImpl(Type * type) override;
+    virtual bool equalsImpl(Type * type) override;
     virtual RefPtr<Type> CreateCanonicalType() override;
     virtual int GetHashCode() override;
 };
@@ -590,10 +590,10 @@ class GenericDeclRefType : public Type
 
     DeclRef<GenericDecl> const& getDeclRef() const { return declRef; }
 
-    virtual String ToString() override;
+    virtual String toString() override;
 
 protected:
-    virtual bool EqualsImpl(Type * type) override;
+    virtual bool equalsImpl(Type * type) override;
     virtual int GetHashCode() override;
     virtual RefPtr<Type> CreateCanonicalType() override;
 };
@@ -610,10 +610,10 @@ class NamespaceType : public Type
 
     DeclRef<NamespaceDeclBase> const& getDeclRef() const { return declRef; }
 
-    virtual String ToString() override;
+    virtual String toString() override;
 
 protected:
-    virtual bool EqualsImpl(Type * type) override;
+    virtual bool equalsImpl(Type * type) override;
     virtual int GetHashCode() override;
     virtual RefPtr<Type> CreateCanonicalType() override;    
 };
@@ -626,8 +626,8 @@ class ExtractExistentialType : public Type
 
     DeclRef<VarDeclBase> declRef;
 
-    virtual String ToString() override;
-    virtual bool EqualsImpl(Type * type) override;
+    virtual String toString() override;
+    virtual bool equalsImpl(Type * type) override;
     virtual int GetHashCode() override;
     virtual RefPtr<Type> CreateCanonicalType() override;
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
@@ -645,8 +645,8 @@ class TaggedUnionType : public Type
         ///
     List<RefPtr<Type>> caseTypes;
 
-    virtual String ToString() override;
-    virtual bool EqualsImpl(Type * type) override;
+    virtual String toString() override;
+    virtual bool equalsImpl(Type * type) override;
     virtual int GetHashCode() override;
     virtual RefPtr<Type> CreateCanonicalType() override;
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
@@ -659,8 +659,8 @@ class ExistentialSpecializedType : public Type
     RefPtr<Type> baseType;
     ExpandedSpecializationArgs args;
 
-    virtual String ToString() override;
-    virtual bool EqualsImpl(Type * type) override;
+    virtual String toString() override;
+    virtual bool equalsImpl(Type * type) override;
     virtual int GetHashCode() override;
     virtual RefPtr<Type> CreateCanonicalType() override;
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
@@ -673,8 +673,8 @@ class ThisType : public Type
 
     DeclRef<InterfaceDecl> interfaceDeclRef;
 
-    virtual String ToString() override;
-    virtual bool EqualsImpl(Type * type) override;
+    virtual String toString() override;
+    virtual bool equalsImpl(Type * type) override;
     virtual int GetHashCode() override;
     virtual RefPtr<Type> CreateCanonicalType() override;
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -125,9 +125,9 @@ class ResourceType : public BuiltinType
     // Shape and access level information for this resource type
     TextureFlavor flavor;
 
-    TextureFlavor::Shape GetBaseShape()
+    TextureFlavor::Shape getBaseShape()
     {
-        return flavor.GetBaseShape();
+        return flavor.getBaseShape();
     }
     bool isMultisample() { return flavor.isMultisample(); }
     bool isArray() { return flavor.isArray(); }
@@ -393,7 +393,7 @@ class ArrayExpressionType : public Type
     RefPtr<Type> baseType;
     RefPtr<IntVal> arrayLength;
 
-    virtual Slang::String ToString() override;
+    virtual String ToString() override;
 
 protected:
     virtual bool EqualsImpl(Type * type) override;
@@ -450,7 +450,7 @@ class MatrixExpressionType : public ArithmeticExpressionType
 {
     SLANG_CLASS(MatrixExpressionType)
 
-    Type* getElementType();
+    Type*           getElementType();
     IntVal*         getRowCount();
     IntVal*         getColumnCount();
 
@@ -462,7 +462,7 @@ protected:
     virtual BasicExpressionType* GetScalarType() override;
 
 private:
-    RefPtr<Type> mRowType;
+    RefPtr<Type> rowType;
 };
 
 // The built-in `String` type
@@ -588,7 +588,7 @@ class GenericDeclRefType : public Type
         : declRef(declRef)
     {}
 
-    DeclRef<GenericDecl> const& GetDeclRef() const { return declRef; }
+    DeclRef<GenericDecl> const& getDeclRef() const { return declRef; }
 
     virtual String ToString() override;
 
@@ -603,12 +603,12 @@ class NamespaceType : public Type
 {
     SLANG_CLASS(NamespaceType)
 
-    DeclRef<NamespaceDeclBase> m_declRef;
+    DeclRef<NamespaceDeclBase> declRef;
 
     NamespaceType()
     {}
 
-    DeclRef<NamespaceDeclBase> const& getDeclRef() const { return m_declRef; }
+    DeclRef<NamespaceDeclBase> const& getDeclRef() const { return declRef; }
 
     virtual String ToString() override;
 

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -48,7 +48,7 @@ class GenericParamIntVal : public IntVal
     virtual bool EqualsVal(Val* val) override;
     virtual String ToString() override;
     virtual int GetHashCode() override;
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
 };
 
     /// An unknown integer value indicating an erroneous sub-expression
@@ -66,7 +66,7 @@ class ErrorIntVal : public IntVal
     virtual bool EqualsVal(Val* val) override;
     virtual String ToString() override;
     virtual int GetHashCode() override;
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int* ioDiff) override;
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
 };
 
 // A witness to the fact that some proposition is true, encoded
@@ -128,7 +128,7 @@ class TypeEqualityWitness : public SubtypeWitness
     virtual bool EqualsVal(Val* val) override;
     virtual String ToString() override;
     virtual int GetHashCode() override;
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int * ioDiff) override;
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int * ioDiff) override;
 };
 
 // A witness that one type is a subtype of another
@@ -142,7 +142,7 @@ class DeclaredSubtypeWitness : public SubtypeWitness
     virtual bool EqualsVal(Val* val) override;
     virtual String ToString() override;
     virtual int GetHashCode() override;
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int * ioDiff) override;
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int * ioDiff) override;
 };
 
 // A witness that `sub : sup` because `sub : mid` and `mid : sup`
@@ -159,7 +159,7 @@ class TransitiveSubtypeWitness : public SubtypeWitness
     virtual bool EqualsVal(Val* val) override;
     virtual String ToString() override;
     virtual int GetHashCode() override;
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int * ioDiff) override;
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int * ioDiff) override;
 };
 
 // A witness taht `sub : sup` because `sub` was wrapped into
@@ -174,7 +174,7 @@ class ExtractExistentialSubtypeWitness : public SubtypeWitness
     virtual bool EqualsVal(Val* val) override;
     virtual String ToString() override;
     virtual int GetHashCode() override;
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int * ioDiff) override;
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int * ioDiff) override;
 };
 
 // A witness that `sub : sup`, because `sub` is a tagged union
@@ -193,7 +193,7 @@ class TaggedUnionSubtypeWitness : public SubtypeWitness
     virtual bool EqualsVal(Val* val) override;
     virtual String ToString() override;
     virtual int GetHashCode() override;
-    virtual RefPtr<Val> SubstituteImpl(SubstitutionSet subst, int * ioDiff) override;
+    virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int * ioDiff) override;
 };
 
 } // namespace Slang

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -27,8 +27,8 @@ class ConstantIntVal : public IntVal
         : value(value)
     {}
 
-    virtual bool EqualsVal(Val* val) override;
-    virtual String ToString() override;
+    virtual bool equalsVal(Val* val) override;
+    virtual String toString() override;
     virtual int GetHashCode() override;
 };
 
@@ -45,8 +45,8 @@ class GenericParamIntVal : public IntVal
         : declRef(declRef)
     {}
 
-    virtual bool EqualsVal(Val* val) override;
-    virtual String ToString() override;
+    virtual bool equalsVal(Val* val) override;
+    virtual String toString() override;
     virtual int GetHashCode() override;
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
 };
@@ -63,8 +63,8 @@ class ErrorIntVal : public IntVal
     ErrorIntVal()
     {}
 
-    virtual bool EqualsVal(Val* val) override;
-    virtual String ToString() override;
+    virtual bool equalsVal(Val* val) override;
+    virtual String toString() override;
     virtual int GetHashCode() override;
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int* ioDiff) override;
 };
@@ -125,8 +125,8 @@ class TypeEqualityWitness : public SubtypeWitness
     SLANG_CLASS(TypeEqualityWitness)
 
 
-    virtual bool EqualsVal(Val* val) override;
-    virtual String ToString() override;
+    virtual bool equalsVal(Val* val) override;
+    virtual String toString() override;
     virtual int GetHashCode() override;
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int * ioDiff) override;
 };
@@ -139,8 +139,8 @@ class DeclaredSubtypeWitness : public SubtypeWitness
 
     DeclRef<Decl> declRef;
 
-    virtual bool EqualsVal(Val* val) override;
-    virtual String ToString() override;
+    virtual bool equalsVal(Val* val) override;
+    virtual String toString() override;
     virtual int GetHashCode() override;
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int * ioDiff) override;
 };
@@ -156,8 +156,8 @@ class TransitiveSubtypeWitness : public SubtypeWitness
     // Witness that `mid : sup`
     DeclRef<Decl> midToSup;
 
-    virtual bool EqualsVal(Val* val) override;
-    virtual String ToString() override;
+    virtual bool equalsVal(Val* val) override;
+    virtual String toString() override;
     virtual int GetHashCode() override;
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int * ioDiff) override;
 };
@@ -171,8 +171,8 @@ class ExtractExistentialSubtypeWitness : public SubtypeWitness
     // The declaration of the existential value that has been opened
     DeclRef<VarDeclBase> declRef;
 
-    virtual bool EqualsVal(Val* val) override;
-    virtual String ToString() override;
+    virtual bool equalsVal(Val* val) override;
+    virtual String toString() override;
     virtual int GetHashCode() override;
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int * ioDiff) override;
 };
@@ -190,8 +190,8 @@ class TaggedUnionSubtypeWitness : public SubtypeWitness
     //
     List<RefPtr<Val>> caseWitnesses;
 
-    virtual bool EqualsVal(Val* val) override;
-    virtual String ToString() override;
+    virtual bool equalsVal(Val* val) override;
+    virtual String toString() override;
     virtual int GetHashCode() override;
     virtual RefPtr<Val> substituteImpl(SubstitutionSet subst, int * ioDiff) override;
 };

--- a/source/slang/slang-check-conformance.cpp
+++ b/source/slang/slang-check-conformance.cpp
@@ -126,7 +126,7 @@ namespace Slang
             // A `static` method requirement can't be satisfied by a
             // tagged union, because there is no tag to dispatch on.
             //
-            if(requirementDeclRef.getDecl()->HasModifier<HLSLStaticModifier>())
+            if(requirementDeclRef.getDecl()->hasModifier<HLSLStaticModifier>())
                 return false;
 
             // TODO: We will eventually want to check that any callable

--- a/source/slang/slang-check-conformance.cpp
+++ b/source/slang/slang-check-conformance.cpp
@@ -356,7 +356,7 @@ namespace Slang
         RefPtr<Type>    sub,
         RefPtr<Type>    sup)
     {
-        if(sub->Equals(sup))
+        if(sub->equals(sup))
         {
             // They are the same type, so we just need a witness
             // for type equality.

--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -592,7 +592,7 @@ namespace Slang
         // specialized (don't accidentially constrain
         // parameters of a generic function based on
         // calls in its body).
-        if(paramDecl->ParentDecl != constraints.genericDecl)
+        if(paramDecl->parentDecl != constraints.genericDecl)
             return false;
 
         // We want to constrain the given parameter to equal the given value.
@@ -684,7 +684,7 @@ namespace Slang
 
             if (auto typeParamDecl = as<GenericTypeParamDecl>(fstDeclRef.getDecl()))
             {
-                if(typeParamDecl->ParentDecl == constraints.genericDecl )
+                if(typeParamDecl->parentDecl == constraints.genericDecl )
                     return TryUnifyTypeParam(constraints, typeParamDecl, snd);
             }
         }
@@ -695,7 +695,7 @@ namespace Slang
 
             if (auto typeParamDecl = as<GenericTypeParamDecl>(sndDeclRef.getDecl()))
             {
-                if(typeParamDecl->ParentDecl == constraints.genericDecl )
+                if(typeParamDecl->parentDecl == constraints.genericDecl )
                     return TryUnifyTypeParam(constraints, typeParamDecl, fst);
             }
         }

--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -178,7 +178,7 @@ namespace Slang
         RefPtr<Type>  right)
     {
         // Easy case: they are the same type!
-        if (left->Equals(right))
+        if (left->equals(right))
             return left;
 
         // We can join two basic types by picking the "better" of the two
@@ -217,7 +217,7 @@ namespace Slang
             if(auto rightVector = as<VectorExpressionType>(right))
             {
                 // Check if the vector sizes match
-                if(!leftVector->elementCount->EqualsVal(rightVector->elementCount.Ptr()))
+                if(!leftVector->elementCount->equalsVal(rightVector->elementCount.Ptr()))
                     return nullptr;
 
                 // Try to join the element types
@@ -352,7 +352,7 @@ namespace Slang
                     }
                     else
                     {
-                        if(!val->EqualsVal(cVal))
+                        if(!val->equalsVal(cVal))
                         {
                             // failure!
                             return SubstitutionSet();
@@ -664,7 +664,7 @@ namespace Slang
         RefPtr<Type>  fst,
         RefPtr<Type>  snd)
     {
-        if (fst->Equals(snd)) return true;
+        if (fst->equals(snd)) return true;
 
         // An error type can unify with anything, just so we avoid cascading errors.
 

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -487,7 +487,7 @@ namespace Slang
     {
         // An important and easy case is when the "to" and "from" types are equal.
         //
-        if( toType->Equals(fromType) )
+        if( toType->equals(fromType) )
         {
             if(outToExpr)
                 *outToExpr = fromExpr;

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -15,7 +15,7 @@ namespace Slang
     ConversionCost SemanticsVisitor::getImplicitConversionCost(
         Decl* decl)
     {
-        if(auto modifier = decl->FindModifier<ImplicitConversionModifier>())
+        if(auto modifier = decl->findModifier<ImplicitConversionModifier>())
         {
             return modifier->cost;
         }

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -722,7 +722,7 @@ namespace Slang
                 //
                 auto castExpr = createImplicitCastExpr();
                 castExpr->loc = fromExpr->loc;
-                castExpr->Arguments.add(fromExpr);
+                castExpr->arguments.add(fromExpr);
                 //
                 // Next we need to set our cast expression as the "original"
                 // expression and then complete the overload process.
@@ -744,8 +744,8 @@ namespace Slang
                 // because we don't allow nested implicit conversions,
                 // but I'd rather play it safe.
                 //
-                castExpr->Arguments.clear();
-                castExpr->Arguments.add(fromExpr);
+                castExpr->arguments.clear();
+                castExpr->arguments.add(fromExpr);
             }
 
             return true;
@@ -830,9 +830,9 @@ namespace Slang
         typeExpr->base.type = toType;
 
         castExpr->loc = fromExpr->loc;
-        castExpr->FunctionExpr = typeExpr;
+        castExpr->functionExpr = typeExpr;
         castExpr->type = QualType(toType);
-        castExpr->Arguments.add(fromExpr);
+        castExpr->arguments.add(fromExpr);
         return castExpr;
     }
 

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -239,7 +239,7 @@ namespace Slang
 
             auto toElementType = toArrayType->baseType;
 
-            if(auto toElementCount = toArrayType->ArrayLength)
+            if(auto toElementCount = toArrayType->arrayLength)
             {
                 // In the case of a sized array, we need to check that the number
                 // of elements being initialized matches what was declared.

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -755,7 +755,7 @@ namespace Slang
         if (!arrayType) return false;
 
         // Explicit element count given?
-        auto elementCount = arrayType->ArrayLength;
+        auto elementCount = arrayType->arrayLength;
         if (elementCount) return true;
 
         return true;
@@ -2802,7 +2802,7 @@ namespace Slang
         if (!arrayType) return;
 
         // Explicit element count given?
-        auto elementCount = arrayType->ArrayLength;
+        auto elementCount = arrayType->arrayLength;
         if (elementCount) return;
 
         // No initializer?
@@ -2812,7 +2812,7 @@ namespace Slang
         // Is the type of the initializer an array type?
         if(auto arrayInitType = as<ArrayExpressionType>(initExpr->type))
         {
-            elementCount = arrayInitType->ArrayLength;
+            elementCount = arrayInitType->arrayLength;
         }
         else
         {
@@ -2832,7 +2832,7 @@ namespace Slang
         auto arrayType = as<ArrayExpressionType>(varDecl->type);
         if (!arrayType) return;
 
-        auto elementCount = arrayType->ArrayLength;
+        auto elementCount = arrayType->arrayLength;
         if (!elementCount)
         {
             // Note(tfoley): For now we allow arrays of unspecified size

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -169,7 +169,7 @@ namespace Slang
         // Anything explicitly marked `static` and not at module scope
         // counts as a static rather than instance declaration.
         //
-        if(decl->HasModifier<HLSLStaticModifier>())
+        if(decl->hasModifier<HLSLStaticModifier>())
             return true;
 
         // Next we need to deal with cases where a declaration is
@@ -243,13 +243,13 @@ namespace Slang
         // global variable (albeit one that is implicitly local to
         // the translation unit)
         //
-        if(decl->HasModifier<HLSLStaticModifier>()) return false;
+        if(decl->hasModifier<HLSLStaticModifier>()) return false;
 
         // The `groupshared` modifier indicates that a variable cannot
         // be a shader parameters, but is instead transient storage
         // allocated for the duration of a thread-group's execution.
         //
-        if(decl->HasModifier<HLSLGroupSharedModifier>()) return false;
+        if(decl->hasModifier<HLSLGroupSharedModifier>()) return false;
 
         return true;
     }
@@ -325,7 +325,7 @@ namespace Slang
             qualType.type = GetType(varDeclRef);
 
             bool isLValue = true;
-            if(varDeclRef.getDecl()->FindModifier<ConstModifier>())
+            if(varDeclRef.getDecl()->findModifier<ConstModifier>())
                 isLValue = false;
 
             // Global-scope shader parameters should not be writable,
@@ -356,7 +356,7 @@ namespace Slang
                 // the class for the `out` modifier so that we can
                 // make simple checks like this.
                 //
-                if( !varDeclRef.getDecl()->HasModifier<OutModifier>() )
+                if( !varDeclRef.getDecl()->hasModifier<OutModifier>() )
                 {
                     isLValue = false;
                 }
@@ -542,7 +542,7 @@ namespace Slang
         if(auto genericDecl = as<GenericDecl>(decl))
             decl = genericDecl->inner;
 
-        if(decl->HasModifier<HLSLStaticModifier>())
+        if(decl->hasModifier<HLSLStaticModifier>())
             return true;
 
         if(as<ConstructorDecl>(decl))
@@ -621,7 +621,7 @@ namespace Slang
         // If the `decl` has already been checked up to or beyond `state`
         // then there is nothing for us to do.
         //
-        if (decl->IsChecked(state)) return;
+        if (decl->isChecked(state)) return;
 
         // Is the declaration already being checked, somewhere up the
         // call stack from us?
@@ -690,14 +690,14 @@ namespace Slang
             //
             if(nextState > decl->checkState.getState())
             {
-                decl->SetCheckState(nextState);
+                decl->setCheckState(nextState);
             }
         }
 
         // Once we are done here, the state of `decl` should have
         // been upgraded to (at least) `state`.
         //
-        SLANG_ASSERT(decl->IsChecked(state));
+        SLANG_ASSERT(decl->isChecked(state));
 
         // Now that we are done checking `decl` we need to restore
         // its "is being checked" flag so that we don't generate
@@ -794,7 +794,7 @@ namespace Slang
 
             // If we've gone down this path, then the variable
             // declaration is actually pretty far along in checking
-            varDecl->SetCheckState(DeclCheckState::Checked);
+            varDecl->setCheckState(DeclCheckState::Checked);
         }
         else
         {
@@ -824,7 +824,7 @@ namespace Slang
 
                     maybeInferArraySizeForVariable(varDecl);
 
-                    varDecl->SetCheckState(DeclCheckState::Checked);
+                    varDecl->setCheckState(DeclCheckState::Checked);
                 }
             }
             //
@@ -957,7 +957,7 @@ namespace Slang
 
     void SemanticsDeclHeaderVisitor::visitGenericDecl(GenericDecl* genericDecl)
     {
-        genericDecl->SetCheckState(DeclCheckState::ReadyForLookup);
+        genericDecl->setCheckState(DeclCheckState::ReadyForLookup);
 
         for (auto m : genericDecl->Members)
         {
@@ -1041,11 +1041,11 @@ namespace Slang
         ///
     static void _registerBuiltinDeclsRec(Session* session, Decl* decl)
     {
-        if (auto builtinMod = decl->FindModifier<BuiltinTypeModifier>())
+        if (auto builtinMod = decl->findModifier<BuiltinTypeModifier>())
         {
             registerBuiltinDecl(session, decl, builtinMod);
         }
-        if (auto magicMod = decl->FindModifier<MagicTypeModifier>())
+        if (auto magicMod = decl->findModifier<MagicTypeModifier>())
         {
             registerMagicDecl(session, decl, magicMod);
         }
@@ -1188,16 +1188,16 @@ namespace Slang
         DeclRef<CallableDecl>   requiredMemberDeclRef,
         RefPtr<WitnessTable>    witnessTable)
     {
-        if(satisfyingMemberDeclRef.getDecl()->HasModifier<MutatingAttribute>()
-            && !requiredMemberDeclRef.getDecl()->HasModifier<MutatingAttribute>())
+        if(satisfyingMemberDeclRef.getDecl()->hasModifier<MutatingAttribute>()
+            && !requiredMemberDeclRef.getDecl()->hasModifier<MutatingAttribute>())
         {
             // A `[mutating]` method can't satisfy a non-`[mutating]` requirement,
             // but vice-versa is okay.
             return false;
         }
 
-        if(satisfyingMemberDeclRef.getDecl()->HasModifier<HLSLStaticModifier>()
-            != requiredMemberDeclRef.getDecl()->HasModifier<HLSLStaticModifier>())
+        if(satisfyingMemberDeclRef.getDecl()->hasModifier<HLSLStaticModifier>()
+            != requiredMemberDeclRef.getDecl()->hasModifier<HLSLStaticModifier>())
         {
             // A `static` method can't satisfy a non-`static` requirement and vice versa.
             return false;
@@ -1915,7 +1915,7 @@ namespace Slang
             // the min/max tag values, or the total number of tags, so that people don't
             // have to declare these as additional cases.
 
-            enumConformanceDecl->SetCheckState(DeclCheckState::Checked);
+            enumConformanceDecl->setCheckState(DeclCheckState::Checked);
         }
     }
 
@@ -2343,12 +2343,12 @@ namespace Slang
             //
             // Note(tfoley): we don't consider `out` and `inout` as distinct here,
             // because there is no way for overload resolution to pick between them.
-            if (fstParam.getDecl()->HasModifier<OutModifier>() != sndParam.getDecl()->HasModifier<OutModifier>())
+            if (fstParam.getDecl()->hasModifier<OutModifier>() != sndParam.getDecl()->hasModifier<OutModifier>())
                 return false;
 
             // If one parameter is `ref` and the other isn't, then they don't match.
             //
-            if(fstParam.getDecl()->HasModifier<RefModifier>() != sndParam.getDecl()->HasModifier<RefModifier>())
+            if(fstParam.getDecl()->hasModifier<RefModifier>() != sndParam.getDecl()->hasModifier<RefModifier>())
                 return false;
         }
 
@@ -2399,7 +2399,7 @@ namespace Slang
     // having a target intrinsic isn't a 'body'.
     bool _isDefinition(FuncDecl* decl)
     {
-        return decl->body || decl->HasModifier<TargetIntrinsicModifier>();
+        return decl->body || decl->hasModifier<TargetIntrinsicModifier>();
     }
 
     Result SemanticsVisitor::checkFuncRedeclaration(
@@ -2438,9 +2438,9 @@ namespace Slang
         // ordinary function-call syntax (if we decided to allow it)
         // would be ambiguous in such a case, of course.
         //
-        if (newDecl->HasModifier<PrefixModifier>() != oldDecl->HasModifier<PrefixModifier>())
+        if (newDecl->hasModifier<PrefixModifier>() != oldDecl->hasModifier<PrefixModifier>())
             return SLANG_OK;
-        if (newDecl->HasModifier<PostfixModifier>() != oldDecl->HasModifier<PostfixModifier>())
+        if (newDecl->hasModifier<PostfixModifier>() != oldDecl->hasModifier<PostfixModifier>())
             return SLANG_OK;
 
         // If one is generic and the other isn't, then there is no match.
@@ -2755,7 +2755,7 @@ namespace Slang
             // Note: the `InOutModifier` class inherits from `OutModifier`,
             // so we only need to check for the base case.
             //
-            if(paramDecl->FindModifier<OutModifier>())
+            if(paramDecl->findModifier<OutModifier>())
             {
                 getSink()->diagnose(initExpr, Diagnostics::outputParameterCannotHaveDefaultValue);
             }
@@ -3187,7 +3187,7 @@ namespace Slang
         // with the `__exported` modifier
         for (auto importDecl : moduleDecl->getMembersOfType<ImportDecl>())
         {
-            if (!importDecl->HasModifier<ExportedModifier>())
+            if (!importDecl->hasModifier<ExportedModifier>())
                 continue;
 
             importModuleIntoScope(scope, importDecl->importedModuleDecl.Ptr());

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2068,7 +2068,7 @@ namespace Slang
 
     void SemanticsDeclBodyVisitor::visitFunctionDeclBase(FunctionDeclBase* decl)
     {
-        if (auto body = decl->Body)
+        if (auto body = decl->body)
         {
             checkBodyStmt(body, decl);
         }
@@ -2399,7 +2399,7 @@ namespace Slang
     // having a target intrinsic isn't a 'body'.
     bool _isDefinition(FuncDecl* decl)
     {
-        return decl->Body || decl->HasModifier<TargetIntrinsicModifier>();
+        return decl->body || decl->HasModifier<TargetIntrinsicModifier>();
     }
 
     Result SemanticsVisitor::checkFuncRedeclaration(
@@ -2764,7 +2764,7 @@ namespace Slang
 
     void SemanticsDeclHeaderVisitor::checkCallableDeclCommon(CallableDecl* decl)
     {
-        for(auto& paramDecl : decl->GetParameters())
+        for(auto& paramDecl : decl->getParameters())
         {
             ensureDecl(paramDecl, DeclCheckState::ReadyForReference);
         }
@@ -2772,7 +2772,7 @@ namespace Slang
 
     void SemanticsDeclHeaderVisitor::visitFuncDecl(FuncDecl* funcDecl)
     {
-        auto resultType = funcDecl->ReturnType;
+        auto resultType = funcDecl->returnType;
         if(resultType.exp)
         {
             resultType = CheckProperType(resultType);
@@ -2781,7 +2781,7 @@ namespace Slang
         {
             resultType = TypeExp(getSession()->getVoidType());
         }
-        funcDecl->ReturnType = resultType;
+        funcDecl->returnType = resultType;
 
         checkCallableDeclCommon(funcDecl);
     }
@@ -2973,14 +2973,14 @@ namespace Slang
     {
         // We need to compute the result tyep for this declaration,
         // since it wasn't filled in for us.
-        decl->ReturnType.type = findResultTypeForConstructorDecl(decl);
+        decl->returnType.type = findResultTypeForConstructorDecl(decl);
 
         checkCallableDeclCommon(decl);
     }
 
     void SemanticsDeclHeaderVisitor::visitSubscriptDecl(SubscriptDecl* decl)
     {
-        decl->ReturnType = CheckUsableType(decl->ReturnType);
+        decl->returnType = CheckUsableType(decl->returnType);
 
         // If we have a subscript declaration with no accessor declarations,
         // then we should create a single `GetterDecl` to represent
@@ -3017,7 +3017,7 @@ namespace Slang
         if (auto parentSubscript = as<SubscriptDecl>(parent))
         {
             ensureDecl(parentSubscript, DeclCheckState::CanUseTypeOfValueDecl);
-            decl->ReturnType = parentSubscript->ReturnType;
+            decl->returnType = parentSubscript->returnType;
         }
         // TODO: when we add "property" declarations, check for them here
         else

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1234,7 +1234,7 @@ namespace Slang
             {
                 if (auto requiredGenValMbr = as<GenericValueParamDecl>(requiredGenMbr))
                 {
-                    if (!genValMbr->type->Equals(requiredGenValMbr->type))
+                    if (!genValMbr->type->equals(requiredGenValMbr->type))
                         return false;
                 }
                 else
@@ -1244,7 +1244,7 @@ namespace Slang
             {
                 if (auto requiredTypeConstraintMbr = as<GenericTypeConstraintDecl>(requiredGenMbr))
                 {
-                    if (!genTypeConstraintMbr->sup->Equals(requiredTypeConstraintMbr->sup))
+                    if (!genTypeConstraintMbr->sup->equals(requiredTypeConstraintMbr->sup))
                     {
                         return false;
                     }
@@ -2164,7 +2164,7 @@ namespace Slang
                     // parameters in the same signature. This is a reasonable
                     // assumption for now, but could get thorny down the road.
                     //
-                    if (!leftValueParam->getType()->Equals(rightValueParam->getType()))
+                    if (!leftValueParam->getType()->equals(rightValueParam->getType()))
                     {
                         // If the value parameters have non-matching types,
                         // then the full generic signatures do not match.
@@ -2298,12 +2298,12 @@ namespace Slang
             //
             auto leftSub = leftConstraint->sub;
             auto rightSub = GetSub(rightConstraint);
-            if(!leftSub->Equals(rightSub))
+            if(!leftSub->equals(rightSub))
                 return false;
 
             auto leftSup = leftConstraint->sup;
             auto rightSup = GetSup(rightConstraint);
-            if(!leftSup->Equals(rightSup))
+            if(!leftSup->equals(rightSup))
                 return false;
         }
 
@@ -2336,7 +2336,7 @@ namespace Slang
             auto sndParam = sndParams[ii];
 
             // If a given parameter type doesn't match, then signatures don't match
-            if (!GetType(fstParam)->Equals(GetType(sndParam)))
+            if (!GetType(fstParam)->equals(GetType(sndParam)))
                 return false;
 
             // If one parameter is `out` and the other isn't, then they don't match
@@ -2546,7 +2546,7 @@ namespace Slang
         //
         auto resultType = GetResultType(newDeclRef);
         auto prevResultType = GetResultType(oldDeclRef);
-        if (!resultType->Equals(prevResultType))
+        if (!resultType->equals(prevResultType))
         {
             // Bad redeclaration
             getSink()->diagnose(newDecl, Diagnostics::functionRedeclarationWithDifferentReturnType, newDecl->getName(), resultType, prevResultType);
@@ -3144,7 +3144,7 @@ namespace Slang
 
         // In order for this extension to apply to the given type, we
         // need to have a match on the target types.
-        if (!type->Equals(targetType))
+        if (!type->equals(targetType))
             return DeclRef<ExtensionDecl>();
 
 

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -675,7 +675,7 @@ namespace Slang
         if (!funcDeclRefExpr) return nullptr;
 
         auto funcDeclRef = funcDeclRefExpr->declRef;
-        auto intrinsicMod = funcDeclRef.getDecl()->FindModifier<IntrinsicOpModifier>();
+        auto intrinsicMod = funcDeclRef.getDecl()->findModifier<IntrinsicOpModifier>();
         if (!intrinsicMod)
         {
             // We can't constant fold anything that doesn't map to a builtin
@@ -821,9 +821,9 @@ namespace Slang
                 auto varDecl = varRef.getDecl();
 
                 // In HLSL, `static const` is used to mark compile-time constant expressions
-                if(auto staticAttr = varDecl->FindModifier<HLSLStaticModifier>())
+                if(auto staticAttr = varDecl->findModifier<HLSLStaticModifier>())
                 {
-                    if(auto constAttr = varDecl->FindModifier<ConstModifier>())
+                    if(auto constAttr = varDecl->findModifier<ConstModifier>())
                     {
                         // HLSL `static const` can be used as a constant expression
                         if(auto initExpr = getInitExpr(varRef))
@@ -1756,7 +1756,7 @@ namespace Slang
 
             if( auto funcDeclBase = as<FunctionDeclBase>(containerDecl) )
             {
-                if( funcDeclBase->HasModifier<MutatingAttribute>() )
+                if( funcDeclBase->hasModifier<MutatingAttribute>() )
                 {
                     expr->type.IsLeftValue = true;
                 }

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -923,8 +923,8 @@ namespace Slang
         auto baseExpr = subscriptExpr->baseExpression;
         auto indexExpr = subscriptExpr->indexExpression;
 
-        if (!indexExpr->type->Equals(getSession()->getIntType()) &&
-            !indexExpr->type->Equals(getSession()->getUIntType()))
+        if (!indexExpr->type->equals(getSession()->getIntType()) &&
+            !indexExpr->type->equals(getSession()->getUIntType()))
         {
             getSink()->diagnose(indexExpr, Diagnostics::subscriptIndexNonInteger);
             return CreateErrorExpr(subscriptExpr.Ptr());
@@ -1387,7 +1387,7 @@ namespace Slang
             case 'w': case 'a': elementIndex = 3; break;
             default:
                 // An invalid character in the swizzle is an error
-                getSink()->diagnose(swizExpr, Diagnostics::invalidSwizzleExpr, swizzleText, baseElementType->ToString());
+                getSink()->diagnose(swizExpr, Diagnostics::invalidSwizzleExpr, swizzleText, baseElementType->toString());
                 anyError = true;
                 continue;
             }
@@ -1398,7 +1398,7 @@ namespace Slang
             // Make sure the index is in range for the source type
             if (elementIndex >= limitElement)
             {
-                getSink()->diagnose(swizExpr, Diagnostics::invalidSwizzleExpr, swizzleText, baseElementType->ToString());
+                getSink()->diagnose(swizExpr, Diagnostics::invalidSwizzleExpr, swizzleText, baseElementType->toString());
                 anyError = true;
                 continue;
             }

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -221,7 +221,7 @@ namespace Slang
                 auto expr = new StaticMemberExpr();
                 expr->loc = loc;
                 expr->type = type;
-                expr->BaseExpression = baseExpr;
+                expr->baseExpression = baseExpr;
                 expr->name = declRef.GetName();
                 expr->declRef = declRef;
                 return expr;
@@ -237,7 +237,7 @@ namespace Slang
                 auto expr = new StaticMemberExpr();
                 expr->loc = loc;
                 expr->type = type;
-                expr->BaseExpression = baseTypeExpr;
+                expr->baseExpression = baseTypeExpr;
                 expr->name = declRef.GetName();
                 expr->declRef = declRef;
                 return expr;
@@ -250,7 +250,7 @@ namespace Slang
                 auto expr = new MemberExpr();
                 expr->loc = loc;
                 expr->type = type;
-                expr->BaseExpression = baseExpr;
+                expr->baseExpression = baseExpr;
                 expr->name = declRef.GetName();
                 expr->declRef = declRef;
 
@@ -606,7 +606,7 @@ namespace Slang
     {
         if (auto memberExpr = as<MemberExpr>(expr))
         {
-            return memberExpr->BaseExpression;
+            return memberExpr->baseExpression;
         }
         else if(auto overloadedExpr = as<OverloadedExpr>(expr))
         {
@@ -671,7 +671,7 @@ namespace Slang
         //
         // For right now we will look for calls to intrinsic functions, and then inspect
         // their names (this is bad and slow).
-        auto funcDeclRefExpr = invokeExpr->FunctionExpr.as<DeclRefExpr>();
+        auto funcDeclRefExpr = invokeExpr->functionExpr.as<DeclRefExpr>();
         if (!funcDeclRefExpr) return nullptr;
 
         auto funcDeclRef = funcDeclRefExpr->declRef;
@@ -690,7 +690,7 @@ namespace Slang
 
         // Let's not constant-fold operations with more than a certain number of arguments, for simplicity
         static const int kMaxArgs = 8;
-        if (invokeExpr->Arguments.getCount() > kMaxArgs)
+        if (invokeExpr->arguments.getCount() > kMaxArgs)
             return nullptr;
 
         // Before checking the operation name, let's look at the arguments
@@ -698,7 +698,7 @@ namespace Slang
         IntegerLiteralValue constArgVals[kMaxArgs];
         int argCount = 0;
         bool allConst = true;
-        for (auto argExpr : invokeExpr->Arguments)
+        for (auto argExpr : invokeExpr->arguments)
         {
             auto argVal = TryCheckIntegerConstantExpression(argExpr.Ptr());
             if (!argVal)
@@ -845,7 +845,7 @@ namespace Slang
 
         if(auto castExpr = as<TypeCastExpr>(expr))
         {
-            auto val = TryConstantFoldExpr(castExpr->Arguments[0].Ptr());
+            auto val = TryConstantFoldExpr(castExpr->arguments[0].Ptr());
             if(val)
                 return val;
         }
@@ -920,8 +920,8 @@ namespace Slang
         RefPtr<IndexExpr>   subscriptExpr,
         RefPtr<Type>              elementType)
     {
-        auto baseExpr = subscriptExpr->BaseExpression;
-        auto indexExpr = subscriptExpr->IndexExpression;
+        auto baseExpr = subscriptExpr->baseExpression;
+        auto indexExpr = subscriptExpr->indexExpression;
 
         if (!indexExpr->type->Equals(getSession()->getIntType()) &&
             !indexExpr->type->Equals(getSession()->getUIntType()))
@@ -940,17 +940,17 @@ namespace Slang
 
     RefPtr<Expr> SemanticsExprVisitor::visitIndexExpr(IndexExpr* subscriptExpr)
     {
-        auto baseExpr = subscriptExpr->BaseExpression;
+        auto baseExpr = subscriptExpr->baseExpression;
         baseExpr = CheckExpr(baseExpr);
 
-        RefPtr<Expr> indexExpr = subscriptExpr->IndexExpression;
+        RefPtr<Expr> indexExpr = subscriptExpr->indexExpression;
         if (indexExpr)
         {
             indexExpr = CheckExpr(indexExpr);
         }
 
-        subscriptExpr->BaseExpression = baseExpr;
-        subscriptExpr->IndexExpression = indexExpr;
+        subscriptExpr->baseExpression = baseExpr;
+        subscriptExpr->indexExpression = indexExpr;
 
         // If anything went wrong in the base expression,
         // then just move along...
@@ -1026,14 +1026,14 @@ namespace Slang
             // case the attempt to call it will trigger overload
             // resolution.
             RefPtr<Expr> subscriptFuncExpr = createLookupResultExpr(
-                name, lookupResult, subscriptExpr->BaseExpression, subscriptExpr->loc);
+                name, lookupResult, subscriptExpr->baseExpression, subscriptExpr->loc);
 
             RefPtr<InvokeExpr> subscriptCallExpr = new InvokeExpr();
             subscriptCallExpr->loc = subscriptExpr->loc;
-            subscriptCallExpr->FunctionExpr = subscriptFuncExpr;
+            subscriptCallExpr->functionExpr = subscriptFuncExpr;
 
             // TODO(tfoley): This path can support multiple arguments easily
-            subscriptCallExpr->Arguments.add(subscriptExpr->IndexExpression);
+            subscriptCallExpr->arguments.add(subscriptExpr->indexExpression);
 
             return CheckInvokeExprWithCheckedOperands(subscriptCallExpr.Ptr());
         }
@@ -1069,11 +1069,11 @@ namespace Slang
         {
             if(auto memberExpr = as<MemberExpr>(e))
             {
-                e = memberExpr->BaseExpression;
+                e = memberExpr->baseExpression;
             }
             else if(auto subscriptExpr = as<IndexExpr>(e))
             {
-                e = subscriptExpr->BaseExpression;
+                e = subscriptExpr->baseExpression;
             }
             else
             {
@@ -1138,7 +1138,7 @@ namespace Slang
         if (auto invoke = as<InvokeExpr>(rs.Ptr()))
         {
             // if this is still an invoke expression, test arguments passed to inout/out parameter are LValues
-            if(auto funcType = as<FuncType>(invoke->FunctionExpr->type))
+            if(auto funcType = as<FuncType>(invoke->functionExpr->type))
             {
                 Index paramCount = funcType->getParamCount();
                 for (Index pp = 0; pp < paramCount; ++pp)
@@ -1153,9 +1153,9 @@ namespace Slang
                         // for an `inout` parameter to be converted in both
                         // directions.
                         //
-                        if( pp < expr->Arguments.getCount() )
+                        if( pp < expr->arguments.getCount() )
                         {
-                            auto argExpr = expr->Arguments[pp];
+                            auto argExpr = expr->arguments[pp];
                             if( !argExpr->type.IsLeftValue )
                             {
                                 getSink()->diagnose(
@@ -1168,7 +1168,7 @@ namespace Slang
                                     getSink()->diagnose(
                                         argExpr,
                                         Diagnostics::implicitCastUsedAsLValue,
-                                        implicitCastExpr->Arguments[0]->type,
+                                        implicitCastExpr->arguments[0]->type,
                                         implicitCastExpr->type);
                                 }
 
@@ -1207,9 +1207,9 @@ namespace Slang
     RefPtr<Expr> SemanticsExprVisitor::visitInvokeExpr(InvokeExpr *expr)
     {
         // check the base expression first
-        expr->FunctionExpr = CheckExpr(expr->FunctionExpr);
+        expr->functionExpr = CheckExpr(expr->functionExpr);
         // Next check the argument expressions
-        for (auto & arg : expr->Arguments)
+        for (auto & arg : expr->arguments)
         {
             arg = CheckExpr(arg);
         }
@@ -1244,7 +1244,7 @@ namespace Slang
     RefPtr<Expr> SemanticsExprVisitor::visitTypeCastExpr(TypeCastExpr * expr)
     {
         // Check the term we are applying first
-        auto funcExpr = expr->FunctionExpr;
+        auto funcExpr = expr->functionExpr;
         funcExpr = CheckTerm(funcExpr);
 
         // Now ensure that the term represnets a (proper) type.
@@ -1252,11 +1252,11 @@ namespace Slang
         typeExp.exp = funcExpr;
         typeExp = CheckProperType(typeExp);
 
-        expr->FunctionExpr = typeExp.exp;
+        expr->functionExpr = typeExp.exp;
         expr->type.type = typeExp.type;
 
         // Next check the argument expression (there should be only one)
-        for (auto & arg : expr->Arguments)
+        for (auto & arg : expr->arguments)
         {
             arg = CheckExpr(arg);
         }
@@ -1270,9 +1270,9 @@ namespace Slang
         {
             if(auto structDeclRef = declRefType->declRef.as<StructDecl>())
             {
-                if( expr->Arguments.getCount() == 1 )
+                if( expr->arguments.getCount() == 1 )
                 {
-                    auto arg = expr->Arguments[0];
+                    auto arg = expr->arguments[0];
                     if( auto intLitArg = arg.as<IntegerLiteralExpr>() )
                     {
                         if(getIntegerLiteralValue(intLitArg->token) == 0)
@@ -1362,7 +1362,7 @@ namespace Slang
     {
         RefPtr<SwizzleExpr> swizExpr = new SwizzleExpr();
         swizExpr->loc = memberRefExpr->loc;
-        swizExpr->base = memberRefExpr->BaseExpression;
+        swizExpr->base = memberRefExpr->baseExpression;
 
         IntegerLiteralValue limitElement = baseElementCount;
 
@@ -1615,10 +1615,10 @@ namespace Slang
 
     RefPtr<Expr> SemanticsExprVisitor::visitStaticMemberExpr(StaticMemberExpr* expr)
     {
-        expr->BaseExpression = CheckExpr(expr->BaseExpression);
+        expr->baseExpression = CheckExpr(expr->baseExpression);
 
         // Not sure this is needed -> but guess someone could do 
-        expr->BaseExpression = MaybeDereference(expr->BaseExpression);
+        expr->baseExpression = MaybeDereference(expr->baseExpression);
 
         // If the base of the member lookup has an interface type
         // *without* a suitable this-type substitution, then we are
@@ -1627,9 +1627,9 @@ namespace Slang
         // can expose its structure.
         //
 
-        expr->BaseExpression = maybeOpenExistential(expr->BaseExpression);
+        expr->baseExpression = maybeOpenExistential(expr->baseExpression);
         // Do a static lookup
-        return _lookupStaticMember(expr, expr->BaseExpression);
+        return _lookupStaticMember(expr, expr->baseExpression);
     }
 
     RefPtr<Expr> SemanticsVisitor::lookupMemberResultFailure(
@@ -1646,9 +1646,9 @@ namespace Slang
 
     RefPtr<Expr> SemanticsExprVisitor::visitMemberExpr(MemberExpr * expr)
     {
-        expr->BaseExpression = CheckExpr(expr->BaseExpression);
+        expr->baseExpression = CheckExpr(expr->baseExpression);
 
-        expr->BaseExpression = MaybeDereference(expr->BaseExpression);
+        expr->baseExpression = MaybeDereference(expr->baseExpression);
 
         // If the base of the member lookup has an interface type
         // *without* a suitable this-type substitution, then we are
@@ -1656,14 +1656,14 @@ namespace Slang
         // and we should "open" the existential here so that we
         // can expose its structure.
         //
-        expr->BaseExpression = maybeOpenExistential(expr->BaseExpression);
+        expr->baseExpression = maybeOpenExistential(expr->baseExpression);
 
         // TODO: Handle the case of an overloaded base expression
         // here, in case we can use the name of the member to
         // disambiguate which of the candidates is meant, or if
         // we can return an overloaded result.
 
-        auto & baseType = expr->BaseExpression->type;
+        auto & baseType = expr->baseExpression->type;
 
         // Note: Checking for vector types before declaration-reference types,
         // because vectors are also declaration reference types...
@@ -1690,11 +1690,11 @@ namespace Slang
         }
         else if( as<NamespaceType>(baseType) )
         {
-            return _lookupStaticMember(expr, expr->BaseExpression);
+            return _lookupStaticMember(expr, expr->baseExpression);
         }
         else if(auto typeType = as<TypeType>(baseType))
         {
-            return _lookupStaticMember(expr, expr->BaseExpression);
+            return _lookupStaticMember(expr, expr->baseExpression);
         }
         else if (as<ErrorType>(baseType))
         {
@@ -1718,7 +1718,7 @@ namespace Slang
             return createLookupResultExpr(
                 expr->name,
                 lookupResult,
-                expr->BaseExpression,
+                expr->baseExpression,
                 expr->loc);
         }
     }

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -32,7 +32,7 @@ namespace Slang
     RefPtr<Expr> SemanticsVisitor::moveTemp(RefPtr<Expr> const& expr, F const& func)
     {
         RefPtr<VarDecl> varDecl = new VarDecl();
-        varDecl->ParentDecl = nullptr; // TODO: need to fill this in somehow!
+        varDecl->parentDecl = nullptr; // TODO: need to fill this in somehow!
         varDecl->checkState = DeclCheckState::Checked;
         varDecl->nameAndLoc.loc = expr->loc;
         varDecl->initExpr = expr;

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -135,12 +135,12 @@ namespace Slang
 
                     // Reject definitions that have the wrong fixity.
                     //
-                    if(prefixExpr && !funcDecl->FindModifier<PrefixModifier>())
+                    if(prefixExpr && !funcDecl->findModifier<PrefixModifier>())
                         continue;
-                    if(postfixExpr && !funcDecl->FindModifier<PostfixModifier>())
+                    if(postfixExpr && !funcDecl->findModifier<PostfixModifier>())
                         continue;
 
-                    if (auto intrinsicOp = funcDecl->FindModifier<IntrinsicOpModifier>())
+                    if (auto intrinsicOp = funcDecl->findModifier<IntrinsicOpModifier>())
                     {
                         operatorName = intrinsicOp->op;
                         return true;

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -96,12 +96,12 @@ namespace Slang
             // that we can encode in our space of keys.
             args[0] = BasicTypeKey::Invalid;
             args[1] = BasicTypeKey::Invalid;
-            if (opExpr->Arguments.getCount() > 2)
+            if (opExpr->arguments.getCount() > 2)
                 return false;
 
-            for (Index i = 0; i < opExpr->Arguments.getCount(); i++)
+            for (Index i = 0; i < opExpr->arguments.getCount(); i++)
             {
-                auto key = makeBasicTypeKey(opExpr->Arguments[i]->type.Ptr());
+                auto key = makeBasicTypeKey(opExpr->arguments[i]->type.Ptr());
                 if (key == BasicTypeKey::Invalid)
                 {
                     return false;
@@ -122,7 +122,7 @@ namespace Slang
             auto prefixExpr = as<PrefixExpr>(opExpr);
             auto postfixExpr = as<PostfixExpr>(opExpr);
 
-            if (auto overloadedBase = as<OverloadedExpr>(opExpr->FunctionExpr))
+            if (auto overloadedBase = as<OverloadedExpr>(opExpr->functionExpr))
             {
                 for(auto item : overloadedBase->lookupResult2 )
                 {

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -163,7 +163,7 @@ namespace Slang
         //
         // TODO: This step should skip `static` fields.
         //
-        for(auto member : structDecl->Members)
+        for(auto member : structDecl->members)
         {
             if(auto varMember = as<VarDecl>(member))
             {
@@ -175,20 +175,20 @@ namespace Slang
                 paramDecl->loc = member->loc;
                 paramDecl->setCheckState(DeclCheckState::Checked);
 
-                paramDecl->ParentDecl = attrDecl;
-                attrDecl->Members.add(paramDecl);
+                paramDecl->parentDecl = attrDecl;
+                attrDecl->members.add(paramDecl);
             }
         }
 
         // We need to end by putting the new attribute declaration
         // into the AST, so that it can be found via lookup.
         //
-        auto parentDecl = structDecl->ParentDecl;
+        auto parentDecl = structDecl->parentDecl;
         //
         // TODO: handle the case where `parentDecl` is generic?
         //
-        attrDecl->ParentDecl = parentDecl;
-        parentDecl->Members.add(attrDecl);
+        attrDecl->parentDecl = parentDecl;
+        parentDecl->members.add(attrDecl);
         
         // Finally, we perform any required semantic checks on
         // the newly constructed attribute decl.

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -133,7 +133,7 @@ namespace Slang
         auto structDecl = lookupResult.item.declRef.as<StructDecl>().getDecl();
         if(!structDecl)
             return nullptr;
-        auto attrUsageAttr = structDecl->FindModifier<AttributeUsageAttribute>();
+        auto attrUsageAttr = structDecl->findModifier<AttributeUsageAttribute>();
         if (!attrUsageAttr)
             return nullptr;
 
@@ -173,7 +173,7 @@ namespace Slang
                 paramDecl->nameAndLoc = member->nameAndLoc;
                 paramDecl->type = varMember->type;
                 paramDecl->loc = member->loc;
-                paramDecl->SetCheckState(DeclCheckState::Checked);
+                paramDecl->setCheckState(DeclCheckState::Checked);
 
                 paramDecl->ParentDecl = attrDecl;
                 attrDecl->Members.add(paramDecl);
@@ -615,7 +615,7 @@ namespace Slang
         // If any of these match `attrTarget`, then we are good.
         //
         bool validTarget = false;
-        for(auto attrTargetMod : attrDecl->GetModifiersOfType<AttributeTargetModifier>())
+        for(auto attrTargetMod : attrDecl->getModifiersOfType<AttributeTargetModifier>())
         {
             if(attrTarget->getClass().isSubClassOf(attrTargetMod->syntaxClass))
             {

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -469,7 +469,7 @@ namespace Slang
 
         RefPtr<Expr> base;
         if (auto mbrExpr = as<MemberExpr>(baseExpr))
-            base = mbrExpr->BaseExpression;
+            base = mbrExpr->baseExpression;
 
         return ConstructDeclRefExpr(
             innerDeclRef,
@@ -527,11 +527,11 @@ namespace Slang
                         callExpr->loc = context.loc;
 
                         for(Index aa = 0; aa < context.argCount; ++aa)
-                            callExpr->Arguments.add(context.getArg(aa));
+                            callExpr->arguments.add(context.getArg(aa));
                     }
 
 
-                    callExpr->FunctionExpr = baseExpr;
+                    callExpr->functionExpr = baseExpr;
                     callExpr->type = QualType(candidate.resultType);
 
                     // A call may yield an l-value, and we should take a look at the candidate to be sure
@@ -1461,7 +1461,7 @@ namespace Slang
         }
 
         // Look at the base expression for the call, and figure out how to invoke it.
-        auto funcExpr = expr->FunctionExpr;
+        auto funcExpr = expr->functionExpr;
         auto funcExprType = funcExpr->type;
 
         // If we are trying to apply an erroneous expression, then just bail out now.
@@ -1472,7 +1472,7 @@ namespace Slang
         // If any of the arguments is an error, then we should bail out, to avoid
         // cascading errors where we successfully pick an overload, but not the one
         // the user meant.
-        for (auto arg : expr->Arguments)
+        for (auto arg : expr->arguments)
         {
             if (IsErrorExpr(arg))
                 return CreateErrorExpr(expr);
@@ -1481,13 +1481,13 @@ namespace Slang
         context.originalExpr = expr;
         context.funcLoc = funcExpr->loc;
 
-        context.argCount = expr->Arguments.getCount();
-        context.args = expr->Arguments.getBuffer();
+        context.argCount = expr->arguments.getCount();
+        context.args = expr->arguments.getBuffer();
         context.loc = expr->loc;
 
         if (auto funcMemberExpr = as<MemberExpr>(funcExpr))
         {
-            context.baseExpr = funcMemberExpr->BaseExpression;
+            context.baseExpr = funcMemberExpr->baseExpression;
         }
         else if (auto funcOverloadExpr = as<OverloadedExpr>(funcExpr))
         {
@@ -1528,7 +1528,7 @@ namespace Slang
             //
             // If any argument was an error, we skip out on printing
             // another message, to avoid cascading errors.
-            for (auto arg : expr->Arguments)
+            for (auto arg : expr->arguments)
             {
                 if (IsErrorExpr(arg))
                 {
@@ -1541,7 +1541,7 @@ namespace Slang
                 Expr* baseExpr = funcExpr;
 
                 if(auto baseGenericApp = as<GenericAppExpr>(baseExpr))
-                    baseExpr = baseGenericApp->FunctionExpr;
+                    baseExpr = baseGenericApp->functionExpr;
 
                 if (auto baseVar = as<VarExpr>(baseExpr))
                     funcName = baseVar->name;
@@ -1631,7 +1631,7 @@ namespace Slang
         else
         {
             // Nothing at all was found that we could even consider invoking
-            getSink()->diagnose(expr->FunctionExpr, Diagnostics::expectedFunction, funcExprType);
+            getSink()->diagnose(expr->functionExpr, Diagnostics::expectedFunction, funcExprType);
             expr->type = QualType(getSession()->getErrorType());
             return expr;
         }
@@ -1681,9 +1681,9 @@ namespace Slang
     RefPtr<Expr> SemanticsExprVisitor::visitGenericAppExpr(GenericAppExpr* genericAppExpr)
     {
         // Start by checking the base expression and arguments.
-        auto& baseExpr = genericAppExpr->FunctionExpr;
+        auto& baseExpr = genericAppExpr->functionExpr;
         baseExpr = CheckTerm(baseExpr);
-        auto& args = genericAppExpr->Arguments;
+        auto& args = genericAppExpr->arguments;
         for (auto& arg : args)
         {
             arg = CheckTerm(arg);
@@ -1699,8 +1699,8 @@ namespace Slang
         // declarations with the same name, so this becomes a specialized case of
         // overload resolution.
 
-        auto& baseExpr = genericAppExpr->FunctionExpr;
-        auto& args = genericAppExpr->Arguments;
+        auto& baseExpr = genericAppExpr->functionExpr;
+        auto& args = genericAppExpr->arguments;
 
         // If there was an error in the base expression,  or in any of
         // the arguments, then just bail.

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -110,7 +110,7 @@ namespace Slang
 
         if(auto prefixExpr = as<PrefixExpr>(expr))
         {
-            if(decl->HasModifier<PrefixModifier>())
+            if(decl->hasModifier<PrefixModifier>())
                 return true;
 
             if (context.mode != OverloadResolveContext::Mode::JustTrying)
@@ -123,7 +123,7 @@ namespace Slang
         }
         else if(auto postfixExpr = as<PostfixExpr>(expr))
         {
-            if(decl->HasModifier<PostfixModifier>())
+            if(decl->hasModifier<PostfixModifier>())
                 return true;
 
             if (context.mode != OverloadResolveContext::Mode::JustTrying)

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -343,7 +343,7 @@ namespace Slang
                 if( context.disallowNestedConversions )
                 {
                     // We need an exact match in this case.
-                    if(!GetType(param)->Equals(argType))
+                    if(!GetType(param)->equals(argType))
                         return false;
                 }
                 else if (!canCoerce(GetType(param), argType, &cost))
@@ -1230,12 +1230,12 @@ namespace Slang
 
     void SemanticsVisitor::formatType(StringBuilder& sb, RefPtr<Type> type)
     {
-        sb << type->ToString();
+        sb << type->toString();
     }
 
     void SemanticsVisitor::formatVal(StringBuilder& sb, RefPtr<Val> val)
     {
-        sb << val->ToString();
+        sb << val->toString();
     }
 
     static void formatDeclName(StringBuilder& sb, Decl* decl)
@@ -1429,7 +1429,7 @@ namespace Slang
         for( UInt aa = 0; aa < argCount; ++aa )
         {
             if(aa != 0) argsListBuilder << ", ";
-            argsListBuilder << context.getArgType(aa)->ToString();
+            argsListBuilder << context.getArgType(aa)->toString();
         }
         argsListBuilder << ")";
         return argsListBuilder.ProduceString();

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -37,7 +37,7 @@ namespace Slang
     SemanticsVisitor::ParamCounts SemanticsVisitor::CountParameters(DeclRef<GenericDecl> genericRef)
     {
         ParamCounts counts = { 0, 0 };
-        for (auto m : genericRef.getDecl()->Members)
+        for (auto m : genericRef.getDecl()->members)
         {
             if (auto typeParam = as<GenericTypeParamDecl>(m))
             {

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -390,7 +390,7 @@ namespace Slang
         }
         else if(stage == Stage::Compute)
         {
-            for(const auto& param : entryPointFuncDecl->GetParameters())
+            for(const auto& param : entryPointFuncDecl->getParameters())
             {
                 if(auto semantic = param->FindModifier<HLSLSimpleSemantic>())
                 {

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -404,7 +404,7 @@ namespace Slang
 
                         if(!isValidThreadDispatchIDType(paramType))
                         {
-                            String typeString = paramType->ToString();
+                            String typeString = paramType->toString();
                             sink->diagnose(param->loc, Diagnostics::invalidDispatchThreadIDType, typeString);
                             return;
                         }

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -342,7 +342,7 @@ namespace Slang
             // TODO: We could consider *always* checking any `[patchconsantfunc("...")]`
             // attributes, so that they need to resolve to a function.
 
-            auto attr = entryPointFuncDecl->FindModifier<PatchConstantFuncAttribute>();
+            auto attr = entryPointFuncDecl->findModifier<PatchConstantFuncAttribute>();
 
             if (attr)
             {
@@ -392,7 +392,7 @@ namespace Slang
         {
             for(const auto& param : entryPointFuncDecl->getParameters())
             {
-                if(auto semantic = param->FindModifier<HLSLSimpleSemantic>())
+                if(auto semantic = param->findModifier<HLSLSimpleSemantic>())
                 {
                     const auto& semanticToken = semantic->name;
 
@@ -534,7 +534,7 @@ namespace Slang
         // it didn't have one, *or* issue a diagnostic if there is a mismatch.
         //
         auto entryPointProfile = entryPointReq->getProfile();
-        if( auto entryPointAttribute = entryPointFuncDecl->FindModifier<EntryPointAttribute>() )
+        if( auto entryPointAttribute = entryPointFuncDecl->findModifier<EntryPointAttribute>() )
         {
             auto entryPointStage = entryPointProfile.GetStage();
             if( entryPointStage == Stage::Unknown )
@@ -569,7 +569,7 @@ namespace Slang
         /// Get the name a variable will use for reflection purposes
     Name* getReflectionName(VarDeclBase* varDecl)
     {
-        if (auto reflectionNameModifier = varDecl->FindModifier<ParameterGroupReflectionName>())
+        if (auto reflectionNameModifier = varDecl->findModifier<ParameterGroupReflectionName>())
             return reflectionNameModifier->nameAndLoc.name;
 
         return varDecl->getName();
@@ -869,7 +869,7 @@ namespace Slang
                     if(!funcDecl)
                         continue;
 
-                    auto entryPointAttr = funcDecl->FindModifier<EntryPointAttribute>();
+                    auto entryPointAttr = funcDecl->findModifier<EntryPointAttribute>();
                     if(!entryPointAttr)
                         continue;
 

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -136,13 +136,13 @@ namespace Slang
         if(!decl)
             return;
 
-        _collectGenericSpecializationParamsRec(decl->ParentDecl);
+        _collectGenericSpecializationParamsRec(decl->parentDecl);
 
         auto genericDecl = as<GenericDecl>(decl);
         if(!genericDecl)
             return;
 
-        for(auto m : genericDecl->Members)
+        for(auto m : genericDecl->members)
         {
             if(auto genericTypeParam = as<GenericTypeParamDecl>(m))
             {
@@ -594,7 +594,7 @@ namespace Slang
         //
         HashSet<Module*> requiredModuleSet;
 
-        for( auto globalDecl : moduleDecl->Members )
+        for( auto globalDecl : moduleDecl->members )
         {
             if(auto globalVar = globalDecl.as<VarDecl>())
             {
@@ -857,7 +857,7 @@ namespace Slang
             for(Index tt = 0; tt < translationUnitCount; ++tt)
             {
                 auto translationUnit = compileRequest->translationUnits[tt];
-                for( auto globalDecl : translationUnit->getModuleDecl()->Members )
+                for( auto globalDecl : translationUnit->getModuleDecl()->members )
                 {
                     auto maybeFuncDecl = globalDecl;
                     if( auto genericDecl = as<GenericDecl>(maybeFuncDecl) )

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -155,7 +155,7 @@ namespace Slang
 
         stmt->varDecl->type.type = getSession()->getIntType();
         addModifier(stmt->varDecl, new ConstModifier());
-        stmt->varDecl->SetCheckState(DeclCheckState::Checked);
+        stmt->varDecl->setCheckState(DeclCheckState::Checked);
 
         RefPtr<IntVal> rangeBeginVal;
         RefPtr<IntVal> rangeEndVal;

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -250,7 +250,7 @@ namespace Slang
         auto function = getParentFunc();
         if (!stmt->Expression)
         {
-            if (function && !function->ReturnType.Equals(getSession()->getVoidType()))
+            if (function && !function->returnType.Equals(getSession()->getVoidType()))
             {
                 getSink()->diagnose(stmt, Diagnostics::returnNeedsExpression);
             }
@@ -262,7 +262,7 @@ namespace Slang
             {
                 if (function)
                 {
-                    stmt->Expression = coerce(function->ReturnType.Ptr(), stmt->Expression);
+                    stmt->Expression = coerce(function->returnType.Ptr(), stmt->Expression);
                 }
                 else
                 {

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -258,7 +258,7 @@ namespace Slang
         else
         {
             stmt->expression = CheckTerm(stmt->expression);
-            if (!stmt->expression->type->Equals(getSession()->getErrorType()))
+            if (!stmt->expression->type->equals(getSession()->getErrorType()))
             {
                 if (function)
                 {

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -120,24 +120,24 @@ namespace Slang
     {
         WithOuterStmt subContext(this, stmt);
 
-        stmt->Predicate = checkPredicateExpr(stmt->Predicate);
-        subContext.checkStmt(stmt->Statement);
+        stmt->predicate = checkPredicateExpr(stmt->predicate);
+        subContext.checkStmt(stmt->statement);
     }
 
     void SemanticsStmtVisitor::visitForStmt(ForStmt *stmt)
     {
         WithOuterStmt subContext(this, stmt);
 
-        checkStmt(stmt->InitialStatement);
-        if (stmt->PredicateExpression)
+        checkStmt(stmt->initialStatement);
+        if (stmt->predicateExpression)
         {
-            stmt->PredicateExpression = checkPredicateExpr(stmt->PredicateExpression);
+            stmt->predicateExpression = checkPredicateExpr(stmt->predicateExpression);
         }
-        if (stmt->SideEffectExpression)
+        if (stmt->sideEffectExpression)
         {
-            stmt->SideEffectExpression = CheckExpr(stmt->SideEffectExpression);
+            stmt->sideEffectExpression = CheckExpr(stmt->sideEffectExpression);
         }
-        subContext.checkStmt(stmt->Statement);
+        subContext.checkStmt(stmt->statement);
     }
 
     RefPtr<Expr> SemanticsVisitor::checkExpressionAndExpectIntegerConstant(RefPtr<Expr> expr, RefPtr<IntVal>* outIntVal)
@@ -225,9 +225,9 @@ namespace Slang
 
     void SemanticsStmtVisitor::visitIfStmt(IfStmt *stmt)
     {
-        stmt->Predicate = checkPredicateExpr(stmt->Predicate);
-        checkStmt(stmt->PositiveStatement);
-        checkStmt(stmt->NegativeStatement);
+        stmt->predicate = checkPredicateExpr(stmt->predicate);
+        checkStmt(stmt->positiveStatement);
+        checkStmt(stmt->negativeStatement);
     }
 
     void SemanticsStmtVisitor::visitUnparsedStmt(UnparsedStmt*)
@@ -248,7 +248,7 @@ namespace Slang
     void SemanticsStmtVisitor::visitReturnStmt(ReturnStmt *stmt)
     {
         auto function = getParentFunc();
-        if (!stmt->Expression)
+        if (!stmt->expression)
         {
             if (function && !function->returnType.Equals(getSession()->getVoidType()))
             {
@@ -257,12 +257,12 @@ namespace Slang
         }
         else
         {
-            stmt->Expression = CheckTerm(stmt->Expression);
-            if (!stmt->Expression->type->Equals(getSession()->getErrorType()))
+            stmt->expression = CheckTerm(stmt->expression);
+            if (!stmt->expression->type->Equals(getSession()->getErrorType()))
             {
                 if (function)
                 {
-                    stmt->Expression = coerce(function->returnType.Ptr(), stmt->Expression);
+                    stmt->expression = coerce(function->returnType.Ptr(), stmt->expression);
                 }
                 else
                 {
@@ -279,13 +279,13 @@ namespace Slang
     void SemanticsStmtVisitor::visitWhileStmt(WhileStmt *stmt)
     {
         WithOuterStmt subContext(this, stmt);
-        stmt->Predicate = checkPredicateExpr(stmt->Predicate);
-        subContext.checkStmt(stmt->Statement);
+        stmt->predicate = checkPredicateExpr(stmt->predicate);
+        subContext.checkStmt(stmt->statement);
     }
 
     void SemanticsStmtVisitor::visitExpressionStmt(ExpressionStmt *stmt)
     {
-        stmt->Expression = CheckExpr(stmt->Expression);
+        stmt->expression = CheckExpr(stmt->expression);
     }
 
 }

--- a/source/slang/slang-check-type.cpp
+++ b/source/slang/slang-check-type.cpp
@@ -207,7 +207,7 @@ namespace Slang
             auto genericDeclRef = genericDeclRefType->getDeclRef();
             ensureDecl(genericDeclRef, DeclCheckState::CanSpecializeGeneric);
             List<RefPtr<Expr>> args;
-            for (RefPtr<Decl> member : genericDeclRef.getDecl()->Members)
+            for (RefPtr<Decl> member : genericDeclRef.getDecl()->members)
             {
                 if (auto typeParam = as<GenericTypeParamDecl>(member))
                 {

--- a/source/slang/slang-check-type.cpp
+++ b/source/slang/slang-check-type.cpp
@@ -204,7 +204,7 @@ namespace Slang
             // "fresh" variables and then solve for their values...
             //
 
-            auto genericDeclRef = genericDeclRefType->GetDeclRef();
+            auto genericDeclRef = genericDeclRefType->getDeclRef();
             ensureDecl(genericDeclRef, DeclCheckState::CanSpecializeGeneric);
             List<RefPtr<Expr>> args;
             for (RefPtr<Decl> member : genericDeclRef.getDecl()->Members)

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -905,7 +905,7 @@ struct IRResourceTypeBase : IRType
 
     TextureFlavor::Shape GetBaseShape() const
     {
-        return getFlavor().GetBaseShape();
+        return getFlavor().getBaseShape();
     }
     bool isMultisample() const { return getFlavor().isMultisample(); }
     bool isArray() const { return getFlavor().isArray(); }

--- a/source/slang/slang-legalize-types.cpp
+++ b/source/slang/slang-legalize-types.cpp
@@ -201,7 +201,7 @@ bool isResourceType(IRType* type)
 ModuleDecl* findModuleForDecl(
     Decl*   decl)
 {
-    for (auto dd = decl; dd; dd = dd->ParentDecl)
+    for (auto dd = decl; dd; dd = dd->parentDecl)
     {
         if (auto moduleDecl = as<ModuleDecl>(dd))
             return moduleDecl;

--- a/source/slang/slang-lookup.cpp
+++ b/source/slang/slang-lookup.cpp
@@ -44,13 +44,13 @@ void buildMemberDictionary(ContainerDecl* decl)
     // are we a generic?
     GenericDecl* genericDecl = as<GenericDecl>(decl);
 
-    const Index membersCount = decl->Members.getCount();
+    const Index membersCount = decl->members.getCount();
 
     SLANG_ASSERT(decl->dictionaryLastCount >= 0 && decl->dictionaryLastCount <= membersCount);
 
     for (Index i = decl->dictionaryLastCount; i < membersCount; ++i)
     {
-        Decl* m = decl->Members[i];
+        Decl* m = decl->members[i];
 
         auto name = m->getName();
 

--- a/source/slang/slang-lookup.cpp
+++ b/source/slang/slang-lookup.cpp
@@ -55,7 +55,7 @@ void buildMemberDictionary(ContainerDecl* decl)
         auto name = m->getName();
 
         // Add any transparent members to a separate list for lookup
-        if (m->HasModifier<TransparentModifier>())
+        if (m->hasModifier<TransparentModifier>())
         {
             TransparentMemberInfo info;
             info.decl = m;
@@ -734,14 +734,14 @@ static void _lookUpInScopes(
                 // The implicit `this`/`This` for a function-like declaration
                 // depends on modifiers attached to the declaration.
                 //
-                if( funcDeclRef.getDecl()->HasModifier<HLSLStaticModifier>() )
+                if( funcDeclRef.getDecl()->hasModifier<HLSLStaticModifier>() )
                 {
                     // A `static` method only has access to an implicit `This`,
                     // and does not have a `this` expression available.
                     //
                     thisParameterMode = LookupResultItem::Breadcrumb::ThisParameterMode::Type;
                 }
-                else if( funcDeclRef.getDecl()->HasModifier<MutatingAttribute>() )
+                else if( funcDeclRef.getDecl()->hasModifier<MutatingAttribute>() )
                 {
                     // In a non-`static` method marked `[mutating]` there is
                     // an implicit `this` parameter that is mutable.

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -2018,8 +2018,8 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
     LoweredValInfo visitIndexExpr(IndexExpr* expr)
     {
         auto type = lowerType(context, expr->type);
-        auto baseVal = lowerSubExpr(expr->BaseExpression);
-        auto indexVal = getSimpleVal(context, lowerRValueExpr(context, expr->IndexExpression));
+        auto baseVal = lowerSubExpr(expr->baseExpression);
+        auto indexVal = getSimpleVal(context, lowerRValueExpr(context, expr->indexExpression));
 
         return subscriptValue(type, baseVal, indexVal);
     }
@@ -2032,7 +2032,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
     LoweredValInfo visitMemberExpr(MemberExpr* expr)
     {
         auto loweredType = lowerType(context, expr->type);
-        auto loweredBase = lowerRValueExpr(context, expr->BaseExpression);
+        auto loweredBase = lowerRValueExpr(context, expr->baseExpression);
 
         auto declRef = expr->declRef;
         if (auto fieldDeclRef = declRef.as<VarDecl>())
@@ -2509,7 +2509,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         List<IRInst*>*         ioArgs,
         List<OutArgumentFixup>* ioFixups)
     {
-        UInt argCount = expr->Arguments.getCount();
+        UInt argCount = expr->arguments.getCount();
         UInt argCounter = 0;
         for (auto paramDeclRef : getMembersOfType<ParamDecl>(funcDeclRef))
         {
@@ -2521,7 +2521,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             RefPtr<Expr> argExpr;
             if(argIndex < argCount)
             {
-                argExpr = expr->Arguments[argIndex];
+                argExpr = expr->arguments[argIndex];
             }
             else
             {
@@ -2637,7 +2637,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         if (auto memberFuncExpr = as<MemberExpr>(funcExpr))
         {
             outInfo->funcDeclRef = memberFuncExpr->declRef;
-            outInfo->baseExpr = memberFuncExpr->BaseExpression;
+            outInfo->baseExpr = memberFuncExpr->baseExpression;
             return true;
         }
         else if (auto staticMemberFuncExpr = as<StaticMemberExpr>(funcExpr))
@@ -2687,7 +2687,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         // back to their arguments.
         List<OutArgumentFixup> argFixups;
 
-        auto funcExpr = expr->FunctionExpr;
+        auto funcExpr = expr->functionExpr;
         ResolvedCallInfo resolvedInfo;
         if( tryResolveDeclRefForCall(funcExpr, &resolvedInfo) )
         {

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -3178,9 +3178,9 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
         auto builder = getBuilder();
         startBlockIfNeeded(stmt);
 
-        auto condExpr = stmt->Predicate;
-        auto thenStmt = stmt->PositiveStatement;
-        auto elseStmt = stmt->NegativeStatement;
+        auto condExpr = stmt->predicate;
+        auto thenStmt = stmt->positiveStatement;
+        auto elseStmt = stmt->negativeStatement;
 
         auto irCond = getSimpleVal(context,
             lowerRValueExpr(context, condExpr));
@@ -3234,7 +3234,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
 
         // The initializer clause for the statement
         // can always safetly be emitted to the current block.
-        if (auto initStmt = stmt->InitialStatement)
+        if (auto initStmt = stmt->initialStatement)
         {
             lowerStmt(context, initStmt);
         }
@@ -3267,10 +3267,10 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
 
         // Now that we are within the header block, we
         // want to emit the expression for the loop condition:
-        if (auto condExpr = stmt->PredicateExpression)
+        if (auto condExpr = stmt->predicateExpression)
         {
             auto irCondition = getSimpleVal(context,
-                lowerRValueExpr(context, stmt->PredicateExpression));
+                lowerRValueExpr(context, stmt->predicateExpression));
 
             // Now we want to `break` if the loop condition is false.
             builder->emitLoopTest(
@@ -3281,11 +3281,11 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
 
         // Emit the body of the loop
         insertBlock(bodyLabel);
-        lowerStmt(context, stmt->Statement);
+        lowerStmt(context, stmt->statement);
 
         // Insert the `continue` block
         insertBlock(continueLabel);
-        if (auto incrExpr = stmt->SideEffectExpression)
+        if (auto incrExpr = stmt->sideEffectExpression)
         {
             lowerRValueExpr(context, incrExpr);
         }
@@ -3336,7 +3336,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
 
         // Now that we are within the header block, we
         // want to emit the expression for the loop condition:
-        if (auto condExpr = stmt->Predicate)
+        if (auto condExpr = stmt->predicate)
         {
             auto irCondition = getSimpleVal(context,
                 lowerRValueExpr(context, condExpr));
@@ -3350,7 +3350,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
 
         // Emit the body of the loop
         insertBlock(bodyLabel);
-        lowerStmt(context, stmt->Statement);
+        lowerStmt(context, stmt->statement);
 
         // At the end of the body we need to jump back to the top.
         emitBranchIfNeeded(loopHead);
@@ -3397,13 +3397,13 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
         insertBlock(loopHead);
 
         // Emit the body of the loop
-        lowerStmt(context, stmt->Statement);
+        lowerStmt(context, stmt->statement);
 
         insertBlock(testLabel);
 
         // Now that we are within the header block, we
         // want to emit the expression for the loop condition:
-        if (auto condExpr = stmt->Predicate)
+        if (auto condExpr = stmt->predicate)
         {
             auto irCondition = getSimpleVal(context,
                 lowerRValueExpr(context, condExpr));
@@ -3434,7 +3434,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
         // so that an expression statement that names
         // a location (but doesn't load from it)
         // will not actually emit a load.
-        lowerLValueExpr(context, stmt->Expression);
+        lowerLValueExpr(context, stmt->expression);
     }
 
     void visitDeclStmt(DeclStmt* stmt)
@@ -3480,7 +3480,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
         // instruction. If the statement had an argument
         // expression, then we need to lower that to
         // a value first, and then emit the resulting value.
-        if( auto expr = stmt->Expression )
+        if( auto expr = stmt->expression )
         {
             auto loweredExpr = lowerRValueExpr(context, expr);
 

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -1389,9 +1389,9 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
     IRType* visitArrayExpressionType(ArrayExpressionType* type)
     {
         auto elementType = lowerType(context, type->baseType);
-        if (type->ArrayLength)
+        if (type->arrayLength)
         {
-            auto elementCount = lowerSimpleVal(context, type->ArrayLength);
+            auto elementCount = lowerSimpleVal(context, type->arrayLength);
             return getBuilder()->getArrayType(
                 elementType,
                 elementCount);
@@ -2179,7 +2179,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         }
         else if (auto arrayType = as<ArrayExpressionType>(type))
         {
-            UInt elementCount = (UInt) GetIntVal(arrayType->ArrayLength);
+            UInt elementCount = (UInt) GetIntVal(arrayType->arrayLength);
 
             auto irDefaultElement = getSimpleVal(context, getDefaultVal(arrayType->baseType));
 
@@ -2247,7 +2247,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         // fill in the appropriate field of the result
         if (auto arrayType = as<ArrayExpressionType>(type))
         {
-            UInt elementCount = (UInt) GetIntVal(arrayType->ArrayLength);
+            UInt elementCount = (UInt) GetIntVal(arrayType->arrayLength);
 
             for (UInt ee = 0; ee < argCount; ++ee)
             {

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -646,7 +646,7 @@ LoweredValInfo emitCallToDeclRef(
 
     if( auto ctorDeclRef = funcDeclRef.as<ConstructorDecl>() )
     {
-        if(!ctorDeclRef.getDecl()->Body)
+        if(!ctorDeclRef.getDecl()->body)
         {
             // HACK: For legacy reasons, all of the built-in initializers
             // in the standard library are declared without proper
@@ -5461,7 +5461,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             // we are in a `static` context.
             if( mode == kParameterListCollectMode_Default )
             {
-                for( auto paramDecl : callableDecl->GetParameters() )
+                for( auto paramDecl : callableDecl->getParameters() )
                 {
                     ioParameterLists->params.add(getParameterInfo(paramDecl));
                 }
@@ -5694,7 +5694,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // We don't need an intrinsic decoration on a function that has a body,
         // since the body can be used as the "catch-all" case.
         //
-        if(decl->Body)
+        if(decl->body)
             return;
 
         // Only standard library declarations should get any kind of catch-all
@@ -5882,7 +5882,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             paramTypes.add(irParamType);
         }
 
-        auto irResultType = lowerType(subContext, declForReturnType->ReturnType);
+        auto irResultType = lowerType(subContext, declForReturnType->returnType);
 
         if (auto setterDecl = as<SetterDecl>(decl))
         {
@@ -5934,7 +5934,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             // Always emit imported declarations as declarations,
             // and not definitions.
         }
-        else if (!decl->Body)
+        else if (!decl->body)
         {
             // This is a function declaration without a body.
             // In Slang we currently try not to support forward declarations
@@ -6108,7 +6108,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             // We lower whatever statement was stored on the declaration
             // as the body of the new IR function.
             //
-            lowerStmt(subContext, decl->Body);
+            lowerStmt(subContext, decl->body);
 
             // We need to carefully add a terminator instruction to the end
             // of the body, in case the user didn't do so.
@@ -6606,7 +6606,7 @@ static void lowerFrontEndEntryPointToIR(
     // But only if this is a definition not a declaration
     if (isDefinition(instToDecorate))
     {
-        FilteredMemberList<ParamDecl> params = entryPointFuncDecl->GetParameters();
+        FilteredMemberList<ParamDecl> params = entryPointFuncDecl->getParameters();
 
         IRGlobalValueWithParams* valueWithParams = as<IRGlobalValueWithParams>(instToDecorate);
         if (valueWithParams)

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -1355,7 +1355,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
 
     IRType* visitNamedExpressionType(NamedExpressionType* type)
     {
-        return (IRType*)getSimpleVal(context, dispatchType(type->GetCanonicalType()));
+        return (IRType*)getSimpleVal(context, dispatchType(type->getCanonicalType()));
     }
 
     IRType* visitBasicExpressionType(BasicExpressionType* type)

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -417,7 +417,7 @@ void setValue(IRGenContext* context, Decl* decl, LoweredValInfo value)
 
 ModuleDecl* findModuleDecl(Decl* decl)
 {
-    for (auto dd = decl; dd; dd = dd->ParentDecl)
+    for (auto dd = decl; dd; dd = dd->parentDecl)
     {
         if (auto moduleDecl = as<ModuleDecl>(dd))
             return moduleDecl;
@@ -427,7 +427,7 @@ ModuleDecl* findModuleDecl(Decl* decl)
 
 bool isFromStdLib(Decl* decl)
 {
-    for (auto dd = decl; dd; dd = dd->ParentDecl)
+    for (auto dd = decl; dd; dd = dd->parentDecl)
     {
         if (dd->hasModifier<FromStdLibModifier>())
             return true;
@@ -1708,11 +1708,11 @@ static String getNameForNameHint(
 
     // For other cases of declaration, we want to consider
     // merging its name with the name of its parent declaration.
-    auto parentDecl = decl->ParentDecl;
+    auto parentDecl = decl->parentDecl;
 
     // Skip past a generic parent, if we are a declaration nested in a generic.
     if(auto genericParentDecl = as<GenericDecl>(parentDecl))
-        parentDecl = genericParentDecl->ParentDecl;
+        parentDecl = genericParentDecl->parentDecl;
 
     // A `ModuleDecl` can have a name too, but in the common case
     // we don't want to generate name hints that include the module
@@ -1726,7 +1726,7 @@ static String getNameForNameHint(
     // For now we skip past a `ModuleDecl` parent.
     //
     if(auto moduleParentDecl = as<ModuleDecl>(parentDecl))
-        parentDecl = moduleParentDecl->ParentDecl;
+        parentDecl = moduleParentDecl->parentDecl;
 
     if(!parentDecl)
     {
@@ -4247,7 +4247,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
     LoweredValInfo visitExtensionDecl(ExtensionDecl* decl)
     {
-        for (auto & member : decl->Members)
+        for (auto & member : decl->members)
             ensureDecl(context, member);
         return LoweredValInfo();
     }
@@ -4299,13 +4299,13 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // This might be a type constraint on an associated type,
         // in which case it should lower as the key for that
         // interface requirement.
-        if(auto assocTypeDecl = as<AssocTypeDecl>(decl->ParentDecl))
+        if(auto assocTypeDecl = as<AssocTypeDecl>(decl->parentDecl))
         {
             // TODO: might need extra steps if we ever allow
             // generic associated types.
 
 
-            if(auto interfaceDecl = as<InterfaceDecl>(assocTypeDecl->ParentDecl))
+            if(auto interfaceDecl = as<InterfaceDecl>(assocTypeDecl->parentDecl))
             {
                 // Okay, this seems to be an interface rquirement, and
                 // we should lower it as such.
@@ -4313,7 +4313,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             }
         }
 
-        if(auto globalGenericParamDecl = as<GlobalGenericParamDecl>(decl->ParentDecl))
+        if(auto globalGenericParamDecl = as<GlobalGenericParamDecl>(decl->parentDecl))
         {
             // This is a constraint on a global generic type parameters,
             // and so it should lower as a parameter of its own.
@@ -4426,7 +4426,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // table, because it represents something the
         // interface requires, and not what it provides.
         //
-        auto parentDecl = inheritanceDecl->ParentDecl;
+        auto parentDecl = inheritanceDecl->parentDecl;
         if (auto parentInterfaceDecl = as<InterfaceDecl>(parentDecl))
         {
             return LoweredValInfo::simple(getInterfaceRequirementKey(inheritanceDecl));
@@ -4561,7 +4561,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
     bool isGlobalVarDecl(VarDecl* decl)
     {
-        auto parent = decl->ParentDecl;
+        auto parent = decl->parentDecl;
         if (as<NamespaceDeclBase>(parent))
         {
             // Variable declared at global/namespace scope? -> Global.
@@ -4581,7 +4581,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
     bool isMemberVarDecl(VarDecl* decl)
     {
-        auto parent = decl->ParentDecl;
+        auto parent = decl->parentDecl;
         if (as<AggTypeDecl>(parent))
         {
             // A variable declared inside of an aggregate type declaration is a member.
@@ -4778,7 +4778,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // TODO: right now the parent links for scopes are *not*
         // set correctly, so we can't just scan up and look
         // for a function in the parent chain...
-        auto parent = decl->ParentDecl;
+        auto parent = decl->parentDecl;
         if( as<ScopeDecl>(parent) )
         {
             return true;
@@ -4808,7 +4808,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         //
         // First we start with type and value parameters,
         // in the order they were declared.
-        for (auto member : genericDecl->Members)
+        for (auto member : genericDecl->members)
         {
             if (auto typeParamDecl = as<GenericTypeParamDecl>(member))
             {
@@ -4821,7 +4821,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         }
         // Then we emit constraint parameters, again in
         // declaration order.
-        for (auto member : genericDecl->Members)
+        for (auto member : genericDecl->members)
         {
             if (auto constraintDecl = as<GenericTypeConstraintDecl>(member))
             {
@@ -4849,7 +4849,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         if(!parentVal)
             return val;
 
-        for(auto pp = decl->ParentDecl; pp; pp = pp->ParentDecl)
+        for(auto pp = decl->parentDecl; pp; pp = pp->parentDecl)
         {
             if(auto genericAncestor = as<GenericDecl>(pp))
             {
@@ -5097,7 +5097,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // a witness table for the interface type's conformance
         // to its own interface.
         //
-        for (auto requirementDecl : decl->Members)
+        for (auto requirementDecl : decl->members)
         {
             getInterfaceRequirementKey(requirementDecl);
 
@@ -5424,7 +5424,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // The parameters introduced by any "parent" declarations
         // will need to come first, so we'll deal with that
         // logic here.
-        if( auto parentDecl = decl->ParentDecl )
+        if( auto parentDecl = decl->parentDecl )
         {
             // Compute the mode to use when collecting parameters from
             // the outer declaration. The most important question here
@@ -5522,7 +5522,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         //
         // First we start with type and value parameters,
         // in the order they were declared.
-        for (auto member : genericDecl->Members)
+        for (auto member : genericDecl->members)
         {
             if (auto typeParamDecl = as<GenericTypeParamDecl>(member))
             {
@@ -5542,7 +5542,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         }
         // Then we emit constraint parameters, again in
         // declaration order.
-        for (auto member : genericDecl->Members)
+        for (auto member : genericDecl->members)
         {
             if (auto constraintDecl = as<GenericTypeConstraintDecl>(member))
             {
@@ -5564,7 +5564,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
     //
     IRGeneric* emitOuterGenerics(IRGenContext* subContext, Decl* decl, Decl* leafDecl)
     {
-        for(auto pp = decl->ParentDecl; pp; pp = pp->ParentDecl)
+        for(auto pp = decl->parentDecl; pp; pp = pp->parentDecl)
         {
             if(auto genericAncestor = as<GenericDecl>(pp))
             {
@@ -5658,18 +5658,18 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         if(as<ConstructorDecl>(decl))
             return false;
 
-        auto dd = decl->ParentDecl;
+        auto dd = decl->parentDecl;
         for(;;)
         {
             if(auto genericDecl = as<GenericDecl>(dd))
             {
-                dd = genericDecl->ParentDecl;
+                dd = genericDecl->parentDecl;
                 continue;
             }
 
             if( auto subscriptDecl = as<SubscriptDecl>(dd) )
             {
-                dd = subscriptDecl->ParentDecl;
+                dd = subscriptDecl->parentDecl;
             }
 
             break;
@@ -5753,7 +5753,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         //
         Decl* declForName = decl;
         if(auto accessorDecl = as<AccessorDecl>(decl))
-            declForName = decl->ParentDecl;
+            declForName = decl->parentDecl;
 
         definition.append(getText(declForName->getName()));
 
@@ -5827,7 +5827,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             // We are some kind of accessor, so the parent declaration should
             // know the correct return type to expose.
             //
-            auto parentDecl = accessorDecl->ParentDecl;
+            auto parentDecl = accessorDecl->parentDecl;
             if (auto subscriptDecl = as<SubscriptDecl>(parentDecl))
             {
                 declForReturnType = subscriptDecl;
@@ -6713,7 +6713,7 @@ static void ensureAllDeclsRec(
     //
     if(auto containerDecl = as<AggTypeDeclBase>(decl))
     {
-        for (auto memberDecl : containerDecl->Members)
+        for (auto memberDecl : containerDecl->members)
         {
             ensureAllDeclsRec(context, memberDecl);
         }
@@ -6769,7 +6769,7 @@ IRModule* generateIRForTranslationUnit(
     //
     // Next, ensure that all other global declarations have
     // been emitted.
-    for (auto decl : translationUnit->getModuleDecl()->Members)
+    for (auto decl : translationUnit->getModuleDecl()->members)
     {
         ensureAllDeclsRec(context, decl);
     }

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -429,7 +429,7 @@ bool isFromStdLib(Decl* decl)
 {
     for (auto dd = decl; dd; dd = dd->ParentDecl)
     {
-        if (dd->HasModifier<FromStdLibModifier>())
+        if (dd->hasModifier<FromStdLibModifier>())
             return true;
     }
     return false;
@@ -448,7 +448,7 @@ bool isImportedDecl(IRGenContext* context, Decl* decl)
     // Note that in practice for matching during linking uses the fully qualified name - including module name.
     // Thus using extern __attribute isn't useful for symbols that are imported via `import`, only symbols
     // that notionally come from the same module but are split into separate compilations (as can be done with -module-name)
-    if (decl->FindModifier<ExternAttribute>())
+    if (decl->findModifier<ExternAttribute>())
     {
         return true;
     }
@@ -477,7 +477,7 @@ bool isImportedDecl(IRGenContext* context, Decl* decl)
     /// Is `decl` a function that should be force-inlined early in compilation (before linking)?
 static bool isForceInlineEarly(Decl* decl)
 {
-    if(decl->HasModifier<UnsafeForceInlineEarlyAttribute>())
+    if(decl->hasModifier<UnsafeForceInlineEarlyAttribute>())
         return true;
 
     return false;
@@ -630,7 +630,7 @@ LoweredValInfo emitCallToDeclRef(
     }
 
     auto funcDecl = funcDeclRef.getDecl();
-    if(auto intrinsicOpModifier = funcDecl->FindModifier<IntrinsicOpModifier>())
+    if(auto intrinsicOpModifier = funcDecl->findModifier<IntrinsicOpModifier>())
     {
         // The intrinsic op maps to a single IR instruction,
         // so we will emit an instruction with the chosen
@@ -1341,7 +1341,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
         auto decl = declRef.getDecl();
 
         // Check for types with teh `__intrinsic_type` modifier.
-        if(decl->FindModifier<IntrinsicTypeModifier>())
+        if(decl->findModifier<IntrinsicTypeModifier>())
         {
             return lowerSimpleIntrinsicType(type);
         }
@@ -1408,7 +1408,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
     // type with the appropriate opcode.
     IRType* lowerSimpleIntrinsicType(DeclRefType* type)
     {
-        auto intrinsicTypeModifier = type->declRef.getDecl()->FindModifier<IntrinsicTypeModifier>();
+        auto intrinsicTypeModifier = type->declRef.getDecl()->findModifier<IntrinsicTypeModifier>();
         SLANG_ASSERT(intrinsicTypeModifier);
         IROp op = IROp(intrinsicTypeModifier->irOp);
         return getBuilder()->getType(op);
@@ -1419,7 +1419,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
     // which can thus be lowered to a simple IR type with the appropriate opcode.
     IRType* lowerGenericIntrinsicType(DeclRefType* type, Type* elementType)
     {
-        auto intrinsicTypeModifier = type->declRef.getDecl()->FindModifier<IntrinsicTypeModifier>();
+        auto intrinsicTypeModifier = type->declRef.getDecl()->findModifier<IntrinsicTypeModifier>();
         SLANG_ASSERT(intrinsicTypeModifier);
         IROp op = IROp(intrinsicTypeModifier->irOp);
         IRInst* irElementType = lowerType(context, elementType);
@@ -1431,7 +1431,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
 
     IRType* lowerGenericIntrinsicType(DeclRefType* type, Type* elementType, IntVal* count)
     {
-        auto intrinsicTypeModifier = type->declRef.getDecl()->FindModifier<IntrinsicTypeModifier>();
+        auto intrinsicTypeModifier = type->declRef.getDecl()->findModifier<IntrinsicTypeModifier>();
         SLANG_ASSERT(intrinsicTypeModifier);
         IROp op = IROp(intrinsicTypeModifier->irOp);
         IRInst* irElementType = lowerType(context, elementType);
@@ -1663,7 +1663,7 @@ void maybeSetRate(
 {
     auto builder = context->irBuilder;
 
-    if (decl->HasModifier<HLSLGroupSharedModifier>())
+    if (decl->hasModifier<HLSLGroupSharedModifier>())
     {
         inst->setFullType(builder->getRateQualifiedType(
             builder->getGroupSharedRate(),
@@ -1680,7 +1680,7 @@ static String getNameForNameHint(
     Name* leafName = decl->getName();
 
     // Handle custom name for a global parameter group (e.g., a `cbuffer`)
-    if(auto reflectionNameModifier = decl->FindModifier<ParameterGroupReflectionName>())
+    if(auto reflectionNameModifier = decl->findModifier<ParameterGroupReflectionName>())
     {
         leafName = reflectionNameModifier->nameAndLoc.name;
     }
@@ -1869,21 +1869,21 @@ enum ParameterDirection
     /// Compute the direction for a parameter based on its declaration
 ParameterDirection getParameterDirection(VarDeclBase* paramDecl)
 {
-    if( paramDecl->HasModifier<RefModifier>() )
+    if( paramDecl->hasModifier<RefModifier>() )
     {
         // The AST specified `ref`:
         return kParameterDirection_Ref;
     }
-    if( paramDecl->HasModifier<InOutModifier>() )
+    if( paramDecl->hasModifier<InOutModifier>() )
     {
         // The AST specified `inout`:
         return kParameterDirection_InOut;
     }
-    if (paramDecl->HasModifier<OutModifier>())
+    if (paramDecl->hasModifier<OutModifier>())
     {
         // We saw an `out` modifier, so now we need
         // to check if there was a paired `in`.
-        if(paramDecl->HasModifier<InModifier>())
+        if(paramDecl->hasModifier<InModifier>())
             return kParameterDirection_InOut;
         else
             return kParameterDirection_Out;
@@ -1902,7 +1902,7 @@ ParameterDirection getThisParamDirection(Decl* parentDecl)
     // by applying the `[mutating]` attribute to their
     // declaration.
     //
-    if( parentDecl->HasModifier<MutatingAttribute>() )
+    if( parentDecl->hasModifier<MutatingAttribute>() )
     {
         return kParameterDirection_InOut;
     }
@@ -3220,7 +3220,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
         IRInst* inst,
         Stmt*   stmt)
     {
-        if( stmt->FindModifier<UnrollAttribute>() )
+        if( stmt->findModifier<UnrollAttribute>() )
         {
             getBuilder()->addLoopControlDecoration(inst, kIRLoopControl_Unroll);
         }
@@ -4543,7 +4543,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         for (auto accessor : decl->getMembersOfType<AccessorDecl>())
         {
-            if (accessor->HasModifier<IntrinsicOpModifier>())
+            if (accessor->hasModifier<IntrinsicOpModifier>())
                 continue;
 
             ensureDecl(context, accessor);
@@ -4569,7 +4569,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         }
         else if(as<AggTypeDeclBase>(parent))
         {
-            if(decl->HasModifier<HLSLStaticModifier>())
+            if(decl->hasModifier<HLSLStaticModifier>())
             {
                 // A `static` member variable is effectively global.
                 return true;
@@ -4707,7 +4707,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         // A `static const` global is actually a compile-time constant.
         //
-        if (decl->HasModifier<HLSLStaticModifier>() && decl->HasModifier<ConstModifier>())
+        if (decl->hasModifier<HLSLStaticModifier>() && decl->hasModifier<ConstModifier>())
         {
             return lowerGlobalConstantDecl(decl);
         }
@@ -4769,7 +4769,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
     bool isFunctionStaticVarDecl(VarDeclBase* decl)
     {
         // Only a variable marked `static` can be static.
-        if(!decl->FindModifier<HLSLStaticModifier>())
+        if(!decl->findModifier<HLSLStaticModifier>())
             return false;
 
         // The immediate parent of a function-scope variable
@@ -4903,7 +4903,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         VarDeclBase*    decl)
     {
         // We know the variable is `static`, but it might also be `const.
-        if(decl->HasModifier<ConstModifier>())
+        if(decl->hasModifier<ConstModifier>())
             return lowerFunctionStaticConstVarDecl(decl);
 
         // A global variable may need to be generic, if one
@@ -5186,7 +5186,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
     LoweredValInfo visitAggTypeDecl(AggTypeDecl* decl)
     {
         // Don't generate an IR `struct` for intrinsic types
-        if(decl->FindModifier<IntrinsicTypeModifier>() || decl->FindModifier<BuiltinTypeModifier>())
+        if(decl->findModifier<IntrinsicTypeModifier>() || decl->findModifier<BuiltinTypeModifier>())
         {
             return LoweredValInfo();
         }
@@ -5217,7 +5217,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         for (auto fieldDecl : decl->getMembersOfType<VarDeclBase>())
         {
-            if (fieldDecl->HasModifier<HLSLStaticModifier>())
+            if (fieldDecl->hasModifier<HLSLStaticModifier>())
             {
                 // A `static` field is actually a global variable,
                 // and we should emit it as such.
@@ -5279,7 +5279,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         addLinkageDecoration(context, irFieldKey, fieldDecl);
 
-        if (auto semanticModifier = fieldDecl->FindModifier<HLSLSimpleSemantic>())
+        if (auto semanticModifier = fieldDecl->findModifier<HLSLSimpleSemantic>())
         {
             builder->addSemanticDecoration(irFieldKey, semanticModifier->name.getName()->text.getUnownedSlice());
         }
@@ -5476,11 +5476,11 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
     bool isConstExprVar(Decl* decl)
     {
-        if( decl->HasModifier<ConstExprModifier>() )
+        if( decl->hasModifier<ConstExprModifier>() )
         {
             return true;
         }
-        else if(decl->HasModifier<HLSLStaticModifier>() && decl->HasModifier<ConstModifier>())
+        else if(decl->hasModifier<HLSLStaticModifier>() && decl->hasModifier<ConstModifier>())
         {
             return true;
         }
@@ -5615,7 +5615,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
     {
         auto builder = getBuilder();
 
-        for (auto targetMod : decl->GetModifiersOfType<TargetIntrinsicModifier>())
+        for (auto targetMod : decl->getModifiersOfType<TargetIntrinsicModifier>())
         {
             String definition;
             auto definitionToken = targetMod->definitionToken;
@@ -5708,7 +5708,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // No need to worry about functions that lower to intrinsic IR opcodes
         // (or pseudo-ops).
         //
-        if(decl->FindModifier<IntrinsicOpModifier>())
+        if(decl->findModifier<IntrinsicOpModifier>())
             return;
 
         // We also don't need an intrinsic decoration if the function already
@@ -5716,7 +5716,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         //
         for( auto f = decl->primaryDecl; f; f = f->nextDecl )
         {
-            for(auto targetMod : f->GetModifiersOfType<TargetIntrinsicModifier>())
+            for(auto targetMod : f->getModifiersOfType<TargetIntrinsicModifier>())
             {
                 // If we find a catch-all case (marked as either *no* target
                 // token or an empty target name), then we should bail out.
@@ -6011,7 +6011,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                         // TODO: we should consider having all parameter be implicitly
                         // immutable except in a specific "compatibility mode."
                         //
-                        if(paramDecl && paramDecl->FindModifier<ConstModifier>())
+                        if(paramDecl && paramDecl->findModifier<ConstModifier>())
                         {
                             // This parameter was declared to be immutable,
                             // so there should be no assignment to it in the
@@ -6064,7 +6064,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
             {
 
-                auto attr = decl->FindModifier<PatchConstantFuncAttribute>();
+                auto attr = decl->findModifier<PatchConstantFuncAttribute>();
 
                 // I needed to test for patchConstantFuncDecl here
                 // because it is only set if validateEntryPoint is called with Hull as the required stage
@@ -6150,7 +6150,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         // If this declaration was marked as being an intrinsic for a particular
         // target, then we should reflect that here.
-        for( auto targetMod : decl->GetModifiersOfType<SpecializedForTargetModifier>() )
+        for( auto targetMod : decl->getModifiersOfType<SpecializedForTargetModifier>() )
         {
             // `targetMod` indicates that this particular declaration represents
             // a specialized definition of the particular function for the given
@@ -6171,36 +6171,36 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // TODO: We should wrap this an `SpecializedForTargetModifier` together into a single
         // case for enumerating the "capabilities" that a declaration requires.
         //
-        for(auto extensionMod : decl->GetModifiersOfType<RequiredGLSLExtensionModifier>())
+        for(auto extensionMod : decl->getModifiersOfType<RequiredGLSLExtensionModifier>())
         {
             getBuilder()->addRequireGLSLExtensionDecoration(irFunc, extensionMod->extensionNameToken.getContent());
         }
-        for(auto versionMod : decl->GetModifiersOfType<RequiredGLSLVersionModifier>())
+        for(auto versionMod : decl->getModifiersOfType<RequiredGLSLVersionModifier>())
         {
             getBuilder()->addRequireGLSLVersionDecoration(irFunc, Int(getIntegerLiteralValue(versionMod->versionNumberToken)));
         }
-        for (auto versionMod : decl->GetModifiersOfType<RequiredSPIRVVersionModifier>())
+        for (auto versionMod : decl->getModifiersOfType<RequiredSPIRVVersionModifier>())
         {
             getBuilder()->addRequireSPIRVVersionDecoration(irFunc, versionMod->version);
         }
-        for (auto versionMod : decl->GetModifiersOfType<RequiredCUDASMVersionModifier>())
+        for (auto versionMod : decl->getModifiersOfType<RequiredCUDASMVersionModifier>())
         {
             getBuilder()->addRequireCUDASMVersionDecoration(irFunc, versionMod->version);
         }
 
-        if (auto attr = decl->FindModifier<InstanceAttribute>())
+        if (auto attr = decl->findModifier<InstanceAttribute>())
         {
             IRIntLit* intLit = _getIntLitFromAttribute(getBuilder(), attr);
             getBuilder()->addDecoration(irFunc, kIROp_InstanceDecoration, intLit);
         }
 
-        if(auto attr = decl->FindModifier<MaxVertexCountAttribute>())
+        if(auto attr = decl->findModifier<MaxVertexCountAttribute>())
         {
             IRIntLit* intLit = _getIntLitFromAttribute(getBuilder(), attr);
             getBuilder()->addDecoration(irFunc, kIROp_MaxVertexCountDecoration, intLit);
         }
 
-        if(auto attr = decl->FindModifier<NumThreadsAttribute>())
+        if(auto attr = decl->findModifier<NumThreadsAttribute>())
         {
             auto builder = getBuilder();
             IRType* intType = builder->getIntType();
@@ -6214,41 +6214,41 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
            builder->addDecoration(irFunc, kIROp_NumThreadsDecoration, operands, 3);
         }
 
-        if(decl->FindModifier<ReadNoneAttribute>())
+        if(decl->findModifier<ReadNoneAttribute>())
         {
             getBuilder()->addSimpleDecoration<IRReadNoneDecoration>(irFunc);
         }
 
-        if (decl->FindModifier<EarlyDepthStencilAttribute>())
+        if (decl->findModifier<EarlyDepthStencilAttribute>())
         {
             getBuilder()->addSimpleDecoration<IREarlyDepthStencilDecoration>(irFunc);
         }
 
-        if (auto attr = decl->FindModifier<DomainAttribute>())
+        if (auto attr = decl->findModifier<DomainAttribute>())
         {
             IRStringLit* stringLit = _getStringLitFromAttribute(getBuilder(), attr);
             getBuilder()->addDecoration(irFunc, kIROp_DomainDecoration, stringLit);
         }
 
-        if (auto attr = decl->FindModifier<PartitioningAttribute>())
+        if (auto attr = decl->findModifier<PartitioningAttribute>())
         {
             IRStringLit* stringLit = _getStringLitFromAttribute(getBuilder(), attr);
             getBuilder()->addDecoration(irFunc, kIROp_PartitioningDecoration, stringLit);
         }
 
-        if (auto attr = decl->FindModifier<OutputTopologyAttribute>())
+        if (auto attr = decl->findModifier<OutputTopologyAttribute>())
         {
             IRStringLit* stringLit = _getStringLitFromAttribute(getBuilder(), attr);
             getBuilder()->addDecoration(irFunc, kIROp_OutputTopologyDecoration, stringLit);
         }
 
-        if (auto attr = decl->FindModifier<OutputControlPointsAttribute>())
+        if (auto attr = decl->findModifier<OutputControlPointsAttribute>())
         {
             IRIntLit* intLit = _getIntLitFromAttribute(getBuilder(), attr);
             getBuilder()->addDecoration(irFunc, kIROp_OutputControlPointsDecoration, intLit);
         }
 
-        if(decl->FindModifier<UnsafeForceInlineEarlyAttribute>())
+        if(decl->findModifier<UnsafeForceInlineEarlyAttribute>())
         {
             getBuilder()->addDecoration(irFunc, kIROp_UnsafeForceInlineEarlyDecoration);
         }
@@ -6615,7 +6615,7 @@ static void lowerFrontEndEntryPointToIR(
 
             for (auto param : params)
             {
-                if (auto modifier = param->FindModifier<HLSLGeometryShaderInputPrimitiveTypeModifier>())
+                if (auto modifier = param->findModifier<HLSLGeometryShaderInputPrimitiveTypeModifier>())
                 {
                     IROp op = kIROp_Invalid;
 

--- a/source/slang/slang-mangle.cpp
+++ b/source/slang/slang-mangle.cpp
@@ -276,8 +276,8 @@ namespace Slang
         // Special case: need a way to tell prefix and postfix unary
         // operators apart.
         {
-            if(declRef.getDecl()->HasModifier<PostfixModifier>()) emitRaw(context, "P");
-            if(declRef.getDecl()->HasModifier<PrefixModifier>()) emitRaw(context, "p");
+            if(declRef.getDecl()->hasModifier<PostfixModifier>()) emitRaw(context, "P");
+            if(declRef.getDecl()->hasModifier<PrefixModifier>()) emitRaw(context, "p");
         }
 
 

--- a/source/slang/slang-mangle.cpp
+++ b/source/slang/slang-mangle.cpp
@@ -139,7 +139,7 @@ namespace Slang
         else if (auto arrType = dynamicCast<ArrayExpressionType>(type))
         {
             emitRaw(context, "a");
-            emitSimpleIntVal(context, arrType->ArrayLength);
+            emitSimpleIntVal(context, arrType->arrayLength);
             emitType(context, arrType->baseType);
         }
         else if( auto taggedUnionType = dynamicCast<TaggedUnionType>(type) )

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -776,7 +776,7 @@ static bool shouldDisableDiagnostic(
     Decl*                   decl,
     DiagnosticInfo const&   diagnosticInfo)
 {
-    for( auto dd = decl; dd; dd = dd->ParentDecl )
+    for( auto dd = decl; dd; dd = dd->parentDecl )
     {
         for( auto modifier : dd->modifiers )
         {

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -2578,7 +2578,7 @@ static RefPtr<EntryPointLayout> collectEntryPointParameters(
     auto resultType = GetResultType(entryPointFuncDeclRef);
     SLANG_ASSERT(resultType);
 
-    if( !resultType->Equals(resultType->getSession()->getVoidType()) )
+    if( !resultType->equals(resultType->getSession()->getVoidType()) )
     {
         state.loc = entryPointFuncDeclRef.getLoc();
         state.directionMask = kEntryPointParameterDirection_Output;

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -1856,7 +1856,7 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
         // Note: Bad Things will happen if we have an array input
         // without a semantic already being enforced.
         
-        auto elementCount = (UInt) GetIntVal(arrayType->ArrayLength);
+        auto elementCount = (UInt) GetIntVal(arrayType->arrayLength);
 
         // We use the first element to derive the layout for the element type
         auto elementTypeLayout = processEntryPointVaryingParameter(context, arrayType->baseType, state, varLayout);

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -703,7 +703,7 @@ static void collectGlobalScopeParameter(
     auto varDeclRef = shaderParamInfo.paramDeclRef;
 
     // We apply any substitutions for global generic parameters here.
-    auto type = GetType(varDeclRef)->Substitute(globalGenericSubst).as<Type>();
+    auto type = GetType(varDeclRef)->substitute(globalGenericSubst).as<Type>();
 
     // We use a single operation to both check whether the
     // variable represents a shader parameter, and to compute

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -1310,13 +1310,13 @@ namespace Slang
             replaceScopeVisitor.scope = parser->currentScope;
             declaratorInfo.typeSpec->accept(&replaceScopeVisitor, nullptr);
 
-            decl->ReturnType = TypeExp(declaratorInfo.typeSpec);
+            decl->returnType = TypeExp(declaratorInfo.typeSpec);
 
             parser->PushScope(decl);
 
             parseParameterList(parser, decl);
             ParseOptSemantics(parser, decl.Ptr());
-            decl->Body = parseOptBody(parser);
+            decl->body = parseOptBody(parser);
 
             parser->PopScope();
 
@@ -2629,7 +2629,7 @@ namespace Slang
 
         parseParameterList(parser, decl);
 
-        decl->Body = parseOptBody(parser);
+        decl->body = parseOptBody(parser);
 
         parser->PopScope();
         return decl;
@@ -2662,7 +2662,7 @@ namespace Slang
 
         if( parser->tokenReader.peekTokenType() == TokenType::LBrace )
         {
-            decl->Body = parser->parseBlockStatement();
+            decl->body = parser->parseBlockStatement();
         }
         else
         {
@@ -2685,7 +2685,7 @@ namespace Slang
 
         if( AdvanceIf(parser, TokenType::RightArrow) )
         {
-            decl->ReturnType = parser->ParseTypeExp();
+            decl->returnType = parser->ParseTypeExp();
         }
 
         if( AdvanceIf(parser, TokenType::LBrace) )
@@ -2801,9 +2801,9 @@ namespace Slang
             parseModernParamList(parser, decl);
             if(AdvanceIf(parser, TokenType::RightArrow))
             {
-                decl->ReturnType = parser->ParseTypeExp();
+                decl->returnType = parser->ParseTypeExp();
             }
-            decl->Body = parseOptBody(parser);
+            decl->body = parseOptBody(parser);
             parser->PopScope();
             return decl;
         });

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -122,7 +122,7 @@ namespace Slang
 
         void pushScopeAndSetParent(ContainerDecl* containerDecl)
         {
-            containerDecl->ParentDecl = currentScope->containerDecl;
+            containerDecl->parentDecl = currentScope->containerDecl;
             PushScope(containerDecl);
         }
 
@@ -1078,8 +1078,8 @@ namespace Slang
     {
         if (container)
         {
-            member->ParentDecl = container.Ptr();
-            container->Members.add(member);
+            member->parentDecl = container.Ptr();
+            container->members.add(member);
         }
     }
 
@@ -1166,7 +1166,7 @@ namespace Slang
         parser->genericDepth--;
         parser->ReadToken(TokenType::OpGreater);
         decl->inner = parseInnerFunc(decl);
-        decl->inner->ParentDecl = decl;
+        decl->inner->parentDecl = decl;
 
         // A generic decl hijacks the name of the declaration
         // it wraps, so that lookup can find it.

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -3634,13 +3634,13 @@ namespace Slang
         FillPosition(ifStatement.Ptr());
         ReadToken("if");
         ReadToken(TokenType::LParent);
-        ifStatement->Predicate = ParseExpression();
+        ifStatement->predicate = ParseExpression();
         ReadToken(TokenType::RParent);
-        ifStatement->PositiveStatement = ParseStatement();
+        ifStatement->positiveStatement = ParseStatement();
         if (LookAheadToken("else"))
         {
             ReadToken("else");
-            ifStatement->NegativeStatement = ParseStatement();
+            ifStatement->negativeStatement = ParseStatement();
         }
         return ifStatement;
     }
@@ -3679,13 +3679,13 @@ namespace Slang
         ReadToken(TokenType::LParent);
         if (peekTypeName(this))
         {
-            stmt->InitialStatement = parseVarDeclrStatement(Modifiers());
+            stmt->initialStatement = parseVarDeclrStatement(Modifiers());
         }
         else
         {
             if (!LookAheadToken(TokenType::Semicolon))
             {
-                stmt->InitialStatement = ParseExpressionStatement();
+                stmt->initialStatement = ParseExpressionStatement();
             }
             else
             {
@@ -3693,12 +3693,12 @@ namespace Slang
             }
         }
         if (!LookAheadToken(TokenType::Semicolon))
-            stmt->PredicateExpression = ParseExpression();
+            stmt->predicateExpression = ParseExpression();
         ReadToken(TokenType::Semicolon);
         if (!LookAheadToken(TokenType::RParent))
-            stmt->SideEffectExpression = ParseExpression();
+            stmt->sideEffectExpression = ParseExpression();
         ReadToken(TokenType::RParent);
-        stmt->Statement = ParseStatement();
+        stmt->statement = ParseStatement();
 
         if (!brokenScoping)
             PopScope();
@@ -3712,9 +3712,9 @@ namespace Slang
         FillPosition(whileStatement.Ptr());
         ReadToken("while");
         ReadToken(TokenType::LParent);
-        whileStatement->Predicate = ParseExpression();
+        whileStatement->predicate = ParseExpression();
         ReadToken(TokenType::RParent);
-        whileStatement->Statement = ParseStatement();
+        whileStatement->statement = ParseStatement();
         return whileStatement;
     }
 
@@ -3723,10 +3723,10 @@ namespace Slang
         RefPtr<DoWhileStmt> doWhileStatement = new DoWhileStmt();
         FillPosition(doWhileStatement.Ptr());
         ReadToken("do");
-        doWhileStatement->Statement = ParseStatement();
+        doWhileStatement->statement = ParseStatement();
         ReadToken("while");
         ReadToken(TokenType::LParent);
-        doWhileStatement->Predicate = ParseExpression();
+        doWhileStatement->predicate = ParseExpression();
         ReadToken(TokenType::RParent);
         ReadToken(TokenType::Semicolon);
         return doWhileStatement;
@@ -3756,7 +3756,7 @@ namespace Slang
         FillPosition(returnStatement.Ptr());
         ReadToken("return");
         if (!LookAheadToken(TokenType::Semicolon))
-            returnStatement->Expression = ParseExpression();
+            returnStatement->expression = ParseExpression();
         ReadToken(TokenType::Semicolon);
         return returnStatement;
     }
@@ -3766,7 +3766,7 @@ namespace Slang
         RefPtr<ExpressionStmt> statement = new ExpressionStmt();
 
         FillPosition(statement.Ptr());
-        statement->Expression = ParseExpression();
+        statement->expression = ParseExpression();
 
         ReadToken(TokenType::Semicolon);
         return statement;

--- a/source/slang/slang-reflection.cpp
+++ b/source/slang/slang-reflection.cpp
@@ -339,7 +339,7 @@ SLANG_API size_t spReflectionType_GetElementCount(SlangReflectionType* inType)
 
     if(auto arrayType = as<ArrayExpressionType>(type))
     {
-        return arrayType->ArrayLength ? (size_t) GetIntVal(arrayType->ArrayLength) : 0;
+        return arrayType->arrayLength ? (size_t) GetIntVal(arrayType->arrayLength) : 0;
     }
     else if( auto vectorType = as<VectorExpressionType>(type))
     {

--- a/source/slang/slang-reflection.cpp
+++ b/source/slang/slang-reflection.cpp
@@ -101,7 +101,7 @@ static inline SlangReflection* convert(ProgramLayout* program)
 unsigned int getUserAttributeCount(Decl* decl)
 {
     unsigned int count = 0;
-    for (auto x : decl->GetModifiersOfType<UserDefinedAttribute>())
+    for (auto x : decl->getModifiersOfType<UserDefinedAttribute>())
     {
         SLANG_UNUSED(x);
         count++;
@@ -112,7 +112,7 @@ unsigned int getUserAttributeCount(Decl* decl)
 SlangReflectionUserAttribute* findUserAttributeByName(Session* session, Decl* decl, const char* name)
 {
     auto nameObj = session->tryGetNameObj(name);
-    for (auto x : decl->GetModifiersOfType<UserDefinedAttribute>())
+    for (auto x : decl->getModifiersOfType<UserDefinedAttribute>())
     {
         if (x->name == nameObj)
             return (SlangReflectionUserAttribute*)(x);
@@ -123,7 +123,7 @@ SlangReflectionUserAttribute* findUserAttributeByName(Session* session, Decl* de
 SlangReflectionUserAttribute* getUserAttributeByIndex(Decl* decl, unsigned int index)
 {
     unsigned int id = 0;
-    for (auto x : decl->GetModifiersOfType<UserDefinedAttribute>())
+    for (auto x : decl->getModifiersOfType<UserDefinedAttribute>())
     {
         if (id == index)
             return convert(x);
@@ -579,7 +579,7 @@ SLANG_API char const* spReflectionType_GetName(SlangReflectionType* inType)
         // Don't return a name for auto-generated anonymous types
         // that represent `cbuffer` members, etc.
         auto decl = declRef.getDecl();
-        if(decl->HasModifier<ImplicitParameterGroupElementTypeModifier>())
+        if(decl->hasModifier<ImplicitParameterGroupElementTypeModifier>())
             return nullptr;
 
         return getText(declRef.GetName()).begin();
@@ -943,7 +943,7 @@ SLANG_API char const* spReflectionVariable_GetName(SlangReflectionVariable* inVa
 
     // If the variable is one that has an "external" name that is supposed
     // to be exposed for reflection, then report it here
-    if(auto reflectionNameMod = var->FindModifier<ParameterGroupReflectionName>())
+    if(auto reflectionNameMod = var->findModifier<ParameterGroupReflectionName>())
         return getText(reflectionNameMod->nameAndLoc.name).getBuffer();
 
     return getText(var->getName()).getBuffer();
@@ -966,7 +966,7 @@ SLANG_API SlangReflectionModifier* spReflectionVariable_FindModifier(SlangReflec
     switch( modifierID )
     {
     case SLANG_MODIFIER_SHARED:
-        modifier = var->FindModifier<HLSLEffectSharedModifier>();
+        modifier = var->findModifier<HLSLEffectSharedModifier>();
         break;
 
     default:
@@ -1294,7 +1294,7 @@ SLANG_API void spReflectionEntryPoint_getComputeThreadGroupSize(
     SlangUInt sizeAlongAxis[3] = { 1, 1, 1 };
 
     // First look for the HLSL case, where we have an attribute attached to the entry point function
-    auto numThreadsAttribute = entryPointFunc.getDecl()->FindModifier<NumThreadsAttribute>();
+    auto numThreadsAttribute = entryPointFunc.getDecl()->findModifier<NumThreadsAttribute>();
     if (numThreadsAttribute)
     {
         sizeAlongAxis[0] = numThreadsAttribute->x;

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -261,10 +261,10 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return false;
     }
 
-    RefPtr<Val> Type::SubstituteImpl(SubstitutionSet subst, int* ioDiff)
+    RefPtr<Val> Type::substituteImpl(SubstitutionSet subst, int* ioDiff)
     {
         int diff = 0;
-        auto canSubst = getCanonicalType()->SubstituteImpl(subst, &diff);
+        auto canSubst = getCanonicalType()->substituteImpl(subst, &diff);
 
         // If nothing changed, then don't drop any sugar that is applied
         if (!diff)
@@ -466,11 +466,11 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return (areValsEqual(arrayLength, arrType->arrayLength) && baseType->Equals(arrType->baseType.Ptr()));
     }
 
-    RefPtr<Val> ArrayExpressionType::SubstituteImpl(SubstitutionSet subst, int* ioDiff)
+    RefPtr<Val> ArrayExpressionType::substituteImpl(SubstitutionSet subst, int* ioDiff)
     {
         int diff = 0;
-        auto elementType = baseType->SubstituteImpl(subst, &diff).as<Type>();
-        auto arrlen = arrayLength->SubstituteImpl(subst, &diff).as<IntVal>();
+        auto elementType = baseType->substituteImpl(subst, &diff).as<Type>();
+        auto arrlen = arrayLength->substituteImpl(subst, &diff).as<IntVal>();
         SLANG_ASSERT(arrlen);
         if (diff)
         {
@@ -577,7 +577,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
                 SLANG_ASSERT(val);
 
                 return RequirementWitness(
-                    val->Substitute(subst));
+                    val->substitute(subst));
             }
         }
     }
@@ -654,7 +654,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return RequirementWitness();
     }
 
-    RefPtr<Val> DeclRefType::SubstituteImpl(SubstitutionSet subst, int* ioDiff)
+    RefPtr<Val> DeclRefType::substituteImpl(SubstitutionSet subst, int* ioDiff)
     {
         if (!subst) return this;
 
@@ -1101,7 +1101,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return this;
     }
 
-    RefPtr<Val> ErrorType::SubstituteImpl(SubstitutionSet /*subst*/, int* /*ioDiff*/)
+    RefPtr<Val> ErrorType::substituteImpl(SubstitutionSet /*subst*/, int* /*ioDiff*/)
     {
         return this;
     }
@@ -1191,18 +1191,18 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return false;
     }
 
-    RefPtr<Val> FuncType::SubstituteImpl(SubstitutionSet subst, int* ioDiff)
+    RefPtr<Val> FuncType::substituteImpl(SubstitutionSet subst, int* ioDiff)
     {
         int diff = 0;
 
         // result type
-        RefPtr<Type> substResultType = resultType->SubstituteImpl(subst, &diff).as<Type>();
+        RefPtr<Type> substResultType = resultType->substituteImpl(subst, &diff).as<Type>();
 
         // parameter types
         List<RefPtr<Type>> substParamTypes;
         for( auto pp : paramTypes )
         {
-            substParamTypes.add(pp->SubstituteImpl(subst, &diff).as<Type>());
+            substParamTypes.add(pp->substituteImpl(subst, &diff).as<Type>());
         }
 
         // early exit for no change...
@@ -1452,7 +1452,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return declRef.GetHashCode() ^ 0xFFFF;
     }
 
-    RefPtr<Val> GenericParamIntVal::SubstituteImpl(SubstitutionSet subst, int* ioDiff)
+    RefPtr<Val> GenericParamIntVal::substituteImpl(SubstitutionSet subst, int* ioDiff)
     {
         // search for a substitution that might apply to us
         for(auto s = subst.substitutions; s; s = s->outer)
@@ -1515,7 +1515,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return int(typeid(this).hash_code());
     }
 
-    RefPtr<Val> ErrorIntVal::SubstituteImpl(SubstitutionSet subst, int* ioDiff)
+    RefPtr<Val> ErrorIntVal::substituteImpl(SubstitutionSet subst, int* ioDiff)
     {
         SLANG_UNUSED(subst);
         SLANG_UNUSED(ioDiff);
@@ -1533,7 +1533,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         List<RefPtr<Val>> substArgs;
         for (auto a : args)
         {
-            substArgs.add(a->SubstituteImpl(substSet, &diff));
+            substArgs.add(a->substituteImpl(substSet, &diff));
         }
 
         if (!diff) return this;
@@ -1584,7 +1584,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         if(substOuter != outer) diff++;
 
         // NOTE: Must use .as because we must have a smart pointer here to keep in scope.
-        auto substWitness = witness->SubstituteImpl(substSet, &diff).as<SubtypeWitness>();
+        auto substWitness = witness->substituteImpl(substSet, &diff).as<SubtypeWitness>();
         
         if (!diff) return this;
 
@@ -1634,14 +1634,14 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
         if(substOuter != outer) diff++;
 
-        auto substActualType = actualType->SubstituteImpl(substSet, &diff).as<Type>();
+        auto substActualType = actualType->substituteImpl(substSet, &diff).as<Type>();
 
         List<ConstraintArg> substConstraintArgs;
         for(auto constraintArg : constraintArgs)
         {
             ConstraintArg substConstraintArg;
             substConstraintArg.decl = constraintArg.decl;
-            substConstraintArg.val = constraintArg.val->SubstituteImpl(substSet, &diff);
+            substConstraintArg.val = constraintArg.val->substituteImpl(substSet, &diff);
 
             substConstraintArgs.add(substConstraintArg);
         }
@@ -1699,7 +1699,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
         // Otherwise we need to recurse on the type structure
         // and apply substitutions where it makes sense
-        return type->Substitute(substitutions).as<Type>();
+        return type->substitute(substitutions).as<Type>();
     }
 
     DeclRefBase DeclRefBase::Substitute(DeclRefBase declRef) const
@@ -2155,14 +2155,14 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // Val
 
-    RefPtr<Val> Val::Substitute(SubstitutionSet subst)
+    RefPtr<Val> Val::substitute(SubstitutionSet subst)
     {
         if (!subst) return this;
         int diff = 0;
-        return SubstituteImpl(subst, &diff);
+        return substituteImpl(subst, &diff);
     }
 
-    RefPtr<Val> Val::SubstituteImpl(SubstitutionSet /*subst*/, int* /*ioDiff*/)
+    RefPtr<Val> Val::substituteImpl(SubstitutionSet /*subst*/, int* /*ioDiff*/)
     {
         // Default behavior is to not substitute at all
         return this;
@@ -2386,11 +2386,11 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return sub->Equals(otherWitness->sub);
     }
 
-    RefPtr<Val> TypeEqualityWitness::SubstituteImpl(SubstitutionSet subst, int * ioDiff)
+    RefPtr<Val> TypeEqualityWitness::substituteImpl(SubstitutionSet subst, int * ioDiff)
     {
         RefPtr<TypeEqualityWitness> rs = new TypeEqualityWitness();
-        rs->sub = sub->SubstituteImpl(subst, ioDiff).as<Type>();
-        rs->sup = sup->SubstituteImpl(subst, ioDiff).as<Type>();
+        rs->sub = sub->substituteImpl(subst, ioDiff).as<Type>();
+        rs->sup = sup->substituteImpl(subst, ioDiff).as<Type>();
         return rs;
     }
 
@@ -2434,7 +2434,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return nullptr;
     }
 
-    RefPtr<Val> DeclaredSubtypeWitness::SubstituteImpl(SubstitutionSet subst, int * ioDiff)
+    RefPtr<Val> DeclaredSubtypeWitness::substituteImpl(SubstitutionSet subst, int * ioDiff)
     {
         if (auto genConstraintDeclRef = declRef.as<GenericTypeConstraintDecl>())
         {
@@ -2494,8 +2494,8 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
         // Perform substitution on the constituent elements.
         int diff = 0;
-        auto substSub = sub->SubstituteImpl(subst, &diff).as<Type>();
-        auto substSup = sup->SubstituteImpl(subst, &diff).as<Type>();
+        auto substSub = sub->substituteImpl(subst, &diff).as<Type>();
+        auto substSup = sup->substituteImpl(subst, &diff).as<Type>();
         auto substDeclRef = declRef.SubstituteImpl(subst, &diff);
         if (!diff)
             return this;
@@ -2585,13 +2585,13 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
             && midToSup.Equals(otherWitness->midToSup);
     }
 
-    RefPtr<Val> TransitiveSubtypeWitness::SubstituteImpl(SubstitutionSet subst, int * ioDiff)
+    RefPtr<Val> TransitiveSubtypeWitness::substituteImpl(SubstitutionSet subst, int * ioDiff)
     {
         int diff = 0;
 
-        RefPtr<Type> substSub = sub->SubstituteImpl(subst, &diff).as<Type>();
-        RefPtr<Type> substSup = sup->SubstituteImpl(subst, &diff).as<Type>();
-        RefPtr<SubtypeWitness> substSubToMid = subToMid->SubstituteImpl(subst, &diff).as<SubtypeWitness>();
+        RefPtr<Type> substSub = sub->substituteImpl(subst, &diff).as<Type>();
+        RefPtr<Type> substSup = sup->substituteImpl(subst, &diff).as<Type>();
+        RefPtr<SubtypeWitness> substSubToMid = subToMid->substituteImpl(subst, &diff).as<SubtypeWitness>();
         DeclRef<Decl> substMidToSup = midToSup.SubstituteImpl(subst, &diff);
 
         // If nothing changed, then we can bail out early.
@@ -2712,7 +2712,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return this;
     }
 
-    RefPtr<Val> ExtractExistentialType::SubstituteImpl(SubstitutionSet subst, int* ioDiff)
+    RefPtr<Val> ExtractExistentialType::substituteImpl(SubstitutionSet subst, int* ioDiff)
     {
         int diff = 0;
         auto substDeclRef = declRef.SubstituteImpl(subst, &diff);
@@ -2751,13 +2751,13 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return declRef.GetHashCode();
     }
 
-    RefPtr<Val> ExtractExistentialSubtypeWitness::SubstituteImpl(SubstitutionSet subst, int* ioDiff)
+    RefPtr<Val> ExtractExistentialSubtypeWitness::substituteImpl(SubstitutionSet subst, int* ioDiff)
     {
         int diff = 0;
 
         auto substDeclRef = declRef.SubstituteImpl(subst, &diff);
-        auto substSub = sub->SubstituteImpl(subst, &diff).as<Type>();
-        auto substSup = sup->SubstituteImpl(subst, &diff).as<Type>();
+        auto substSub = sub->substituteImpl(subst, &diff).as<Type>();
+        auto substSup = sup->substituteImpl(subst, &diff).as<Type>();
 
         if(!diff)
             return this;
@@ -2833,14 +2833,14 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return canType;
     }
 
-    RefPtr<Val> TaggedUnionType::SubstituteImpl(SubstitutionSet subst, int* ioDiff)
+    RefPtr<Val> TaggedUnionType::substituteImpl(SubstitutionSet subst, int* ioDiff)
     {
         int diff = 0;
 
         List<RefPtr<Type>> substCaseTypes;
         for( auto caseType : caseTypes )
         {
-            substCaseTypes.add(caseType->SubstituteImpl(subst, &diff).as<Type>());
+            substCaseTypes.add(caseType->substituteImpl(subst, &diff).as<Type>());
         }
         if(!diff)
             return this;
@@ -2902,17 +2902,17 @@ int TaggedUnionSubtypeWitness::GetHashCode()
     return hash;
 }
 
-RefPtr<Val> TaggedUnionSubtypeWitness::SubstituteImpl(SubstitutionSet subst, int* ioDiff)
+RefPtr<Val> TaggedUnionSubtypeWitness::substituteImpl(SubstitutionSet subst, int* ioDiff)
 {
     int diff = 0;
 
-    auto substSub = sub->SubstituteImpl(subst, &diff).as<Type>();
-    auto substSup = sup->SubstituteImpl(subst, &diff).as<Type>();
+    auto substSub = sub->substituteImpl(subst, &diff).as<Type>();
+    auto substSup = sup->substituteImpl(subst, &diff).as<Type>();
 
     List<RefPtr<Val>> substCaseWitnesses;
     for( auto caseWitness : caseWitnesses )
     {
-        substCaseWitnesses.add(caseWitness->SubstituteImpl(subst, &diff));
+        substCaseWitnesses.add(caseWitness->substituteImpl(subst, &diff));
     }
 
     if(!diff)
@@ -3061,14 +3061,14 @@ RefPtr<Type> ExistentialSpecializedType::CreateCanonicalType()
 RefPtr<Val> substituteImpl(Val* val, SubstitutionSet subst, int* ioDiff)
 {
     if(!val) return nullptr;
-    return val->SubstituteImpl(subst, ioDiff);
+    return val->substituteImpl(subst, ioDiff);
 }
 
-RefPtr<Val> ExistentialSpecializedType::SubstituteImpl(SubstitutionSet subst, int* ioDiff)
+RefPtr<Val> ExistentialSpecializedType::substituteImpl(SubstitutionSet subst, int* ioDiff)
 {
     int diff = 0;
 
-    auto substBaseType = baseType->SubstituteImpl(subst, &diff).as<Type>();
+    auto substBaseType = baseType->substituteImpl(subst, &diff).as<Type>();
 
     ExpandedSpecializationArgs substArgs;
     for( auto arg : args )
@@ -3132,7 +3132,7 @@ RefPtr<Type> ThisType::CreateCanonicalType()
     return canType;
 }
 
-RefPtr<Val> ThisType::SubstituteImpl(SubstitutionSet subst, int* ioDiff)
+RefPtr<Val> ThisType::substituteImpl(SubstitutionSet subst, int* ioDiff)
 {
     int diff = 0;
 

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -672,11 +672,11 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
                 // the generic decl associated with the substitution list must be
                 // the generic decl that declared this parameter
                 auto genericDecl = genericSubst->genericDecl;
-                if (genericDecl != genericTypeParamDecl->ParentDecl)
+                if (genericDecl != genericTypeParamDecl->parentDecl)
                     continue;
 
                 int index = 0;
-                for (auto m : genericDecl->Members)
+                for (auto m : genericDecl->members)
                 {
                     if (m.Ptr() == genericTypeParamDecl)
                     {
@@ -736,7 +736,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
                 if(!thisSubst)
                     continue;
 
-                if(auto interfaceDecl = as<InterfaceDecl>(substAssocTypeDecl->ParentDecl))
+                if(auto interfaceDecl = as<InterfaceDecl>(substAssocTypeDecl->parentDecl))
                 {
                     if(thisSubst->interfaceDecl == interfaceDecl)
                     {
@@ -808,7 +808,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         for(;;)
         {
             RefPtr<Decl> childDecl = dd;
-            RefPtr<Decl> parentDecl = dd->ParentDecl;
+            RefPtr<Decl> parentDecl = dd->parentDecl;
             if(!parentDecl)
                 break;
 
@@ -1464,11 +1464,11 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
             // the generic decl associated with the substitution list must be
             // the generic decl that declared this parameter
             auto genericDecl = genSubst->genericDecl;
-            if (genericDecl != declRef.getDecl()->ParentDecl)
+            if (genericDecl != declRef.getDecl()->parentDecl)
                 continue;
 
             int index = 0;
-            for (auto m : genericDecl->Members)
+            for (auto m : genericDecl->members)
             {
                 if (m.Ptr() == declRef.getDecl())
                 {
@@ -1732,7 +1732,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
             if(auto interfaceDecl = as<InterfaceDecl>(dd))
                 return interfaceDecl;
 
-            dd = dd->ParentDecl;
+            dd = dd->parentDecl;
         }
         return nullptr;
     }
@@ -1883,7 +1883,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         // nested directly in a generic, then `substToSpecialize` will either start with
         // the corresponding `GenericSubstitution` or there will be *no* generic substitutions
         // corresponding to that decl.
-        for(Decl* ancestorDecl = declToSpecialize; ancestorDecl; ancestorDecl = ancestorDecl->ParentDecl)
+        for(Decl* ancestorDecl = declToSpecialize; ancestorDecl; ancestorDecl = ancestorDecl->parentDecl)
         {
             if(auto ancestorGenericDecl = as<GenericDecl>(ancestorDecl))
             {
@@ -1897,7 +1897,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
                         // keep one matching it in place.
                         int diff = 0;
                         auto restSubst = specializeSubstitutions(
-                            ancestorGenericDecl->ParentDecl,
+                            ancestorGenericDecl->parentDecl,
                             specGenericSubst->outer,
                             substsToApply,
                             &diff);
@@ -1937,7 +1937,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
                     int diff = 0;
                     auto restSubst = specializeSubstitutions(
-                        ancestorGenericDecl->ParentDecl,
+                        ancestorGenericDecl->parentDecl,
                         substsToSpecialize,
                         substsToApply,
                         &diff);
@@ -1967,7 +1967,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
                         // keep one matching it in place.
                         int diff = 0;
                         auto restSubst = specializeSubstitutions(
-                            ancestorInterfaceDecl->ParentDecl,
+                            ancestorInterfaceDecl->parentDecl,
                             specThisTypeSubst->outer,
                             substsToApply,
                             &diff);
@@ -1997,7 +1997,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
                     int diff = 0;
                     auto restSubst = specializeSubstitutions(
-                        ancestorInterfaceDecl->ParentDecl,
+                        ancestorInterfaceDecl->parentDecl,
                         substsToSpecialize,
                         substsToApply,
                         &diff);
@@ -2103,7 +2103,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         // Can access as method with this->as because it removes any ambiguity.
         using Slang::as;
 
-        auto parentDecl = decl->ParentDecl;
+        auto parentDecl = decl->parentDecl;
         if (!parentDecl)
             return DeclRefBase();
 
@@ -2222,7 +2222,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         // actually want to register is the generic itself.
         //
         auto declToRegister = decl;
-        if(auto genericDecl = as<GenericDecl>(decl->ParentDecl))
+        if(auto genericDecl = as<GenericDecl>(decl->parentDecl))
             declToRegister = genericDecl;
 
         session->magicDecls[modifier->name] = declToRegister.Ptr();
@@ -2448,12 +2448,12 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
                     // the generic decl associated with the substitution list must be
                     // the generic decl that declared this parameter
                     auto genericDecl = genericSubst->genericDecl;
-                    if (genericDecl != genConstraintDecl->ParentDecl)
+                    if (genericDecl != genConstraintDecl->parentDecl)
                         continue;
 
                     bool found = false;
                     Index index = 0;
-                    for (auto m : genericDecl->Members)
+                    for (auto m : genericDecl->members)
                     {
                         if (auto constraintParam = as<GenericTypeConstraintDecl>(m))
                         {
@@ -2477,7 +2477,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
                 else if(auto globalGenericSubst = s.as<GlobalGenericParamSubstitution>())
                 {
                     // check if the substitution is really about this global generic type parameter
-                    if (globalGenericSubst->paramDecl != genConstraintDecl->ParentDecl)
+                    if (globalGenericSubst->paramDecl != genConstraintDecl->parentDecl)
                         continue;
 
                     for(auto constraintArg : globalGenericSubst->constraintArgs)
@@ -2514,9 +2514,9 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         //
         if (auto substTypeConstraintDecl = as<GenericTypeConstraintDecl>(substDeclRef.decl))
         {
-            if (auto substAssocTypeDecl = as<AssocTypeDecl>(substTypeConstraintDecl->ParentDecl))
+            if (auto substAssocTypeDecl = as<AssocTypeDecl>(substTypeConstraintDecl->parentDecl))
             {
-                if (auto interfaceDecl = as<InterfaceDecl>(substAssocTypeDecl->ParentDecl))
+                if (auto interfaceDecl = as<InterfaceDecl>(substAssocTypeDecl->parentDecl))
                 {
                     // At this point we have a constraint decl for an associated type,
                     // and we nee to see if we are dealing with a concrete substitution
@@ -2929,7 +2929,7 @@ RefPtr<Val> TaggedUnionSubtypeWitness::substituteImpl(SubstitutionSet subst, int
 
 Module* getModule(Decl* decl)
 {
-    for( auto dd = decl; dd; dd = dd->ParentDecl )
+    for( auto dd = decl; dd; dd = dd->parentDecl )
     {
         if(auto moduleDecl = as<ModuleDecl>(dd))
             return moduleDecl->module;

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -1314,7 +1314,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
     {
         String result;
         result.append("namespace ");
-        result.append(m_declRef.toString());
+        result.append(declRef.toString());
         return result;
     }
 
@@ -1322,14 +1322,14 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
     {
         if (auto namespaceType = as<NamespaceType>(type))
         {
-            return m_declRef.Equals(namespaceType->m_declRef);
+            return declRef.Equals(namespaceType->declRef);
         }
         return false;
     }
 
     int NamespaceType::GetHashCode()
     {
-        return m_declRef.GetHashCode();
+        return declRef.GetHashCode();
     }
 
     RefPtr<Type> NamespaceType::CreateCanonicalType()
@@ -1396,11 +1396,11 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     RefPtr<Type> MatrixExpressionType::getRowType()
     {
-        if( !mRowType )
+        if( !rowType )
         {
-            mRowType = getSession()->getVectorType(getElementType(), getColumnCount());
+            rowType = getSession()->getVectorType(getElementType(), getColumnCount());
         }
-        return mRowType;
+        return rowType;
     }
 
     RefPtr<VectorExpressionType> Session::getVectorType(
@@ -2364,7 +2364,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
     {
         auto type = new NamespaceType;
         type->setSession(session);
-        type->m_declRef = declRef;
+        type->declRef = declRef;
         return type;
     }
 

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -251,7 +251,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     bool Type::Equals(Type * type)
     {
-        return GetCanonicalType()->EqualsImpl(type->GetCanonicalType());
+        return getCanonicalType()->EqualsImpl(type->getCanonicalType());
     }
 
     bool Type::EqualsVal(Val* val)
@@ -264,7 +264,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
     RefPtr<Val> Type::SubstituteImpl(SubstitutionSet subst, int* ioDiff)
     {
         int diff = 0;
-        auto canSubst = GetCanonicalType()->SubstituteImpl(subst, &diff);
+        auto canSubst = getCanonicalType()->SubstituteImpl(subst, &diff);
 
         // If nothing changed, then don't drop any sugar that is applied
         if (!diff)
@@ -276,7 +276,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return canSubst;
     }
 
-    Type* Type::GetCanonicalType()
+    Type* Type::getCanonicalType()
     {
         Type* et = const_cast<Type*>(this);
         if (!et->canonicalType)
@@ -485,7 +485,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     RefPtr<Type> ArrayExpressionType::CreateCanonicalType()
     {
-        auto canonicalElementType = baseType->GetCanonicalType();
+        auto canonicalElementType = baseType->getCanonicalType();
         auto canonicalArrayType = getArrayType(
             canonicalElementType,
             arrayLength);
@@ -1129,7 +1129,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
     {
         if (!innerType)
             innerType = GetType(declRef);
-        return innerType->GetCanonicalType();
+        return innerType->getCanonicalType();
     }
 
     int NamedExpressionType::GetHashCode()
@@ -1143,7 +1143,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         // for now (and hopefully equivalent) to just have any
         // named types automaticlaly route hash-code requests
         // to their canonical type.
-        return GetCanonicalType()->GetHashCode();
+        return getCanonicalType()->GetHashCode();
     }
 
     // FuncType
@@ -1220,13 +1220,13 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
     RefPtr<Type> FuncType::CreateCanonicalType()
     {
         // result type
-        RefPtr<Type> canResultType = resultType->GetCanonicalType();
+        RefPtr<Type> canResultType = resultType->getCanonicalType();
 
         // parameter types
         List<RefPtr<Type>> canParamTypes;
         for( auto pp : paramTypes )
         {
-            canParamTypes.add(pp->GetCanonicalType());
+            canParamTypes.add(pp->getCanonicalType());
         }
 
         RefPtr<FuncType> canType = new FuncType();
@@ -1271,7 +1271,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     RefPtr<Type> TypeType::CreateCanonicalType()
     {
-        auto canType = getTypeType(type->GetCanonicalType());
+        auto canType = getTypeType(type->getCanonicalType());
         return canType;
     }
 
@@ -2826,7 +2826,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
         for( auto caseType : caseTypes )
         {
-            auto canCaseType = caseType->GetCanonicalType();
+            auto canCaseType = caseType->getCanonicalType();
             canType->caseTypes.add(canCaseType);
         }
 
@@ -3035,7 +3035,7 @@ RefPtr<Val> getCanonicalValue(Val* val)
         return nullptr;
     if(auto type = as<Type>(val))
     {
-        return type->GetCanonicalType();
+        return type->getCanonicalType();
     }
     // TODO: We may eventually need/want some sort of canonicalization
     // for non-type values, but for now there is nothing to do.
@@ -3047,7 +3047,7 @@ RefPtr<Type> ExistentialSpecializedType::CreateCanonicalType()
     RefPtr<ExistentialSpecializedType> canType = new ExistentialSpecializedType();
     canType->setSession(getSession());
 
-    canType->baseType = baseType->GetCanonicalType();
+    canType->baseType = baseType->getCanonicalType();
     for( auto arg : args )
     {
         ExpandedSpecializationArg canArg;

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -94,7 +94,7 @@ const RefPtr<Decl>* adjustFilterCursorImpl(const ReflectClassInfo& clsInfo, Memb
             for (; ptr != end; ptr++)
             {
                 Decl* decl = *ptr;
-                if (decl->getClassInfo().isSubClassOf(clsInfo) && !decl->HasModifier<HLSLStaticModifier>())
+                if (decl->getClassInfo().isSubClassOf(clsInfo) && !decl->hasModifier<HLSLStaticModifier>())
                 {
                     return ptr;
                 }
@@ -106,7 +106,7 @@ const RefPtr<Decl>* adjustFilterCursorImpl(const ReflectClassInfo& clsInfo, Memb
             for (; ptr != end; ptr++)
             {
                 Decl* decl = *ptr;
-                if (decl->getClassInfo().isSubClassOf(clsInfo) && decl->HasModifier<HLSLStaticModifier>())
+                if (decl->getClassInfo().isSubClassOf(clsInfo) && decl->hasModifier<HLSLStaticModifier>())
                 {
                     return ptr;
                 }
@@ -143,7 +143,7 @@ const RefPtr<Decl>* getFilterCursorByIndexImpl(const ReflectClassInfo& clsInfo, 
             for (; ptr != end; ptr++)
             {
                 Decl* decl = *ptr;
-                if (decl->getClassInfo().isSubClassOf(clsInfo) && !decl->HasModifier<HLSLStaticModifier>())
+                if (decl->getClassInfo().isSubClassOf(clsInfo) && !decl->hasModifier<HLSLStaticModifier>())
                 {
                     if (index <= 0)
                     {
@@ -159,7 +159,7 @@ const RefPtr<Decl>* getFilterCursorByIndexImpl(const ReflectClassInfo& clsInfo, 
             for (; ptr != end; ptr++)
             {
                 Decl* decl = *ptr;
-                if (decl->getClassInfo().isSubClassOf(clsInfo) && decl->HasModifier<HLSLStaticModifier>())
+                if (decl->getClassInfo().isSubClassOf(clsInfo) && decl->hasModifier<HLSLStaticModifier>())
                 {
                     if (index <= 0)
                     {
@@ -194,7 +194,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
             for (; ptr != end; ptr++)
             {
                 Decl* decl = *ptr;
-                count += Index(decl->getClassInfo().isSubClassOf(clsInfo)&& !decl->HasModifier<HLSLStaticModifier>());
+                count += Index(decl->getClassInfo().isSubClassOf(clsInfo)&& !decl->hasModifier<HLSLStaticModifier>());
             }
             break;
         }
@@ -203,7 +203,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
             for (; ptr != end; ptr++)
             {
                 Decl* decl = *ptr;
-                count += Index(decl->getClassInfo().isSubClassOf(clsInfo) && decl->HasModifier<HLSLStaticModifier>());
+                count += Index(decl->getClassInfo().isSubClassOf(clsInfo) && decl->hasModifier<HLSLStaticModifier>());
             }
             break;
         }
@@ -865,14 +865,14 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
     {
         declRef = createDefaultSubstitutionsIfNeeded(session, declRef);
 
-        if (auto builtinMod = declRef.getDecl()->FindModifier<BuiltinTypeModifier>())
+        if (auto builtinMod = declRef.getDecl()->findModifier<BuiltinTypeModifier>())
         {
             auto type = new BasicExpressionType(builtinMod->tag);
             type->setSession(session);
             type->declRef = declRef;
             return type;
         }
-        else if (auto magicMod = declRef.getDecl()->FindModifier<MagicTypeModifier>())
+        else if (auto magicMod = declRef.getDecl()->findModifier<MagicTypeModifier>())
         {
             GenericSubstitution* subst = nullptr;
             for(auto s = declRef.substitutions.substitutions; s; s = s->outer)
@@ -2328,13 +2328,13 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         {
             auto paramDecl = paramDeclRef.getDecl();
             auto paramType = GetType(paramDeclRef);
-            if( paramDecl->FindModifier<RefModifier>() )
+            if( paramDecl->findModifier<RefModifier>() )
             {
                 paramType = session->getRefType(paramType);
             }
-            else if( paramDecl->FindModifier<OutModifier>() )
+            else if( paramDecl->findModifier<OutModifier>() )
             {
-                if(paramDecl->FindModifier<InOutModifier>() || paramDecl->FindModifier<InModifier>())
+                if(paramDecl->findModifier<InOutModifier>() || paramDecl->findModifier<InModifier>())
                 {
                     paramType = session->getInOutType(paramType);
                 }

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -14,6 +14,8 @@ namespace Slang
 
 SLANG_ALL_ASTNode_NodeBase(SLANG_CLASS_ONLY, SLANG_CLASS_ACCEPT_IMPL)
 
+/* static */const TypeExp TypeExp::empty;
+
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!! DiagnosticSink impls !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 void printDiagnosticArg(StringBuilder& sb, Decl* decl)

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -25,23 +25,23 @@ void printDiagnosticArg(StringBuilder& sb, Decl* decl)
 
 void printDiagnosticArg(StringBuilder& sb, Type* type)
 {
-    sb << type->ToString();
+    sb << type->toString();
 }
 
 void printDiagnosticArg(StringBuilder& sb, Val* val)
 {
-    sb << val->ToString();
+    sb << val->toString();
 }
 
 void printDiagnosticArg(StringBuilder& sb, TypeExp const& type)
 {
-    sb << type.type->ToString();
+    sb << type.type->toString();
 }
 
 void printDiagnosticArg(StringBuilder& sb, QualType const& type)
 {
     if (type.type)
-        sb << type.type->ToString();
+        sb << type.type->toString();
     else
         sb << "<null>";
 }
@@ -58,7 +58,7 @@ SourceLoc const& getDiagnosticPos(TypeExp const& typeExp)
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!! BasicExpressionType !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-bool BasicExpressionType::EqualsImpl(Type * type)
+bool BasicExpressionType::equalsImpl(Type * type)
 {
     auto basicType = as<BasicExpressionType>(type);
     return basicType && basicType->baseType == this->baseType;
@@ -222,12 +222,12 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     bool TypeExp::Equals(Type* other)
     {
-        return type->Equals(other);
+        return type->equals(other);
     }
 
     bool TypeExp::Equals(RefPtr<Type> other)
     {
-        return type->Equals(other.Ptr());
+        return type->equals(other.Ptr());
     }
 
     // BasicExpressionType
@@ -249,15 +249,15 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         }
     }
 
-    bool Type::Equals(Type * type)
+    bool Type::equals(Type* type)
     {
-        return getCanonicalType()->EqualsImpl(type->getCanonicalType());
+        return getCanonicalType()->equalsImpl(type->getCanonicalType());
     }
 
-    bool Type::EqualsVal(Val* val)
+    bool Type::equalsVal(Val* val)
     {
         if (auto type = dynamicCast<Type>(val))
-            return const_cast<Type*>(this)->Equals(type);
+            return const_cast<Type*>(this)->equals(type);
         return false;
     }
 
@@ -458,12 +458,12 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
 
 
-    bool ArrayExpressionType::EqualsImpl(Type* type)
+    bool ArrayExpressionType::equalsImpl(Type* type)
     {
         auto arrType = as<ArrayExpressionType>(type);
         if (!arrType)
             return false;
-        return (areValsEqual(arrayLength, arrType->arrayLength) && baseType->Equals(arrType->baseType.Ptr()));
+        return (areValsEqual(arrayLength, arrType->arrayLength) && baseType->equals(arrType->baseType.Ptr()));
     }
 
     RefPtr<Val> ArrayExpressionType::substituteImpl(SubstitutionSet subst, int* ioDiff)
@@ -498,17 +498,17 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         else
             return baseType->GetHashCode();
     }
-    Slang::String ArrayExpressionType::ToString()
+    Slang::String ArrayExpressionType::toString()
     {
         if (arrayLength)
-            return baseType->ToString() + "[" + arrayLength->ToString() + "]";
+            return baseType->toString() + "[" + arrayLength->toString() + "]";
         else
-            return baseType->ToString() + "[]";
+            return baseType->toString() + "[]";
     }
 
     // DeclRefType
 
-    String DeclRefType::ToString()
+    String DeclRefType::toString()
     {
         return declRef.toString();
     }
@@ -518,7 +518,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return (declRef.GetHashCode() * 16777619) ^ (int)(typeid(this).hash_code());
     }
 
-    bool DeclRefType::EqualsImpl(Type * type)
+    bool DeclRefType::equalsImpl(Type * type)
     {
         if (auto declRefType = as<DeclRefType>(type))
         {
@@ -1040,12 +1040,12 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // OverloadGroupType
 
-    String OverloadGroupType::ToString()
+    String OverloadGroupType::toString()
     {
         return "overload group";
     }
 
-    bool OverloadGroupType::EqualsImpl(Type * /*type*/)
+    bool OverloadGroupType::equalsImpl(Type * /*type*/)
     {
         return false;
     }
@@ -1062,12 +1062,12 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // InitializerListType
 
-    String InitializerListType::ToString()
+    String InitializerListType::toString()
     {
         return "initializer list";
     }
 
-    bool InitializerListType::EqualsImpl(Type * /*type*/)
+    bool InitializerListType::equalsImpl(Type * /*type*/)
     {
         return false;
     }
@@ -1084,12 +1084,12 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // ErrorType
 
-    String ErrorType::ToString()
+    String ErrorType::toString()
     {
         return "error";
     }
 
-    bool ErrorType::EqualsImpl(Type* type)
+    bool ErrorType::equalsImpl(Type* type)
     {
         if (auto errorType = as<ErrorType>(type))
             return true;
@@ -1114,12 +1114,12 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // NamedExpressionType
 
-    String NamedExpressionType::ToString()
+    String NamedExpressionType::toString()
     {
         return getText(declRef.GetName());
     }
 
-    bool NamedExpressionType::EqualsImpl(Type * /*type*/)
+    bool NamedExpressionType::equalsImpl(Type * /*type*/)
     {
         SLANG_UNEXPECTED("unreachable");
         UNREACHABLE_RETURN(false);
@@ -1148,7 +1148,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // FuncType
 
-    String FuncType::ToString()
+    String FuncType::toString()
     {
         StringBuilder sb;
         sb << "(";
@@ -1156,14 +1156,14 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         for (UInt pp = 0; pp < paramCount; ++pp)
         {
             if (pp != 0) sb << ", ";
-            sb << getParamType(pp)->ToString();
+            sb << getParamType(pp)->toString();
         }
         sb << ") -> ";
-        sb << getResultType()->ToString();
+        sb << getResultType()->toString();
         return sb.ProduceString();
     }
 
-    bool FuncType::EqualsImpl(Type * type)
+    bool FuncType::equalsImpl(Type * type)
     {
         if (auto funcType = as<FuncType>(type))
         {
@@ -1176,11 +1176,11 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
             {
                 auto paramType = getParamType(pp);
                 auto otherParamType = funcType->getParamType(pp);
-                if (!paramType->Equals(otherParamType))
+                if (!paramType->equals(otherParamType))
                     return false;
             }
 
-            if(!resultType->Equals(funcType->resultType))
+            if(!resultType->equals(funcType->resultType))
                 return false;
 
             // TODO: if we ever introduce other kinds
@@ -1253,18 +1253,18 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // TypeType
 
-    String TypeType::ToString()
+    String TypeType::toString()
     {
         StringBuilder sb;
-        sb << "typeof(" << type->ToString() << ")";
+        sb << "typeof(" << type->toString() << ")";
         return sb.ProduceString();
     }
 
-    bool TypeType::EqualsImpl(Type * t)
+    bool TypeType::equalsImpl(Type * t)
     {
         if (auto typeType = as<TypeType>(t))
         {
-            return t->Equals(typeType->type);
+            return t->equals(typeType->type);
         }
         return false;
     }
@@ -1283,13 +1283,13 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // GenericDeclRefType
 
-    String GenericDeclRefType::ToString()
+    String GenericDeclRefType::toString()
     {
         // TODO: what is appropriate here?
         return "<DeclRef<GenericDecl>>";
     }
 
-    bool GenericDeclRefType::EqualsImpl(Type * type)
+    bool GenericDeclRefType::equalsImpl(Type * type)
     {
         if (auto genericDeclRefType = as<GenericDeclRefType>(type))
         {
@@ -1310,7 +1310,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // NamespaceType
 
-    String NamespaceType::ToString()
+    String NamespaceType::toString()
     {
         String result;
         result.append("namespace ");
@@ -1318,7 +1318,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return result;
     }
 
-    bool NamespaceType::EqualsImpl(Type * type)
+    bool NamespaceType::equalsImpl(Type * type)
     {
         if (auto namespaceType = as<NamespaceType>(type))
         {
@@ -1341,10 +1341,10 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // VectorExpressionType
 
-    String VectorExpressionType::ToString()
+    String VectorExpressionType::toString()
     {
         StringBuilder sb;
-        sb << "vector<" << elementType->ToString() << "," << elementCount->ToString() << ">";
+        sb << "vector<" << elementType->toString() << "," << elementCount->toString() << ">";
         return sb.ProduceString();
     }
 
@@ -1367,10 +1367,10 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // MatrixExpressionType
 
-    String MatrixExpressionType::ToString()
+    String MatrixExpressionType::toString()
     {
         StringBuilder sb;
-        sb << "matrix<" << getElementType()->ToString() << "," << getRowCount()->ToString() << "," << getColumnCount()->ToString() << ">";
+        sb << "matrix<" << getElementType()->toString() << "," << getRowCount()->toString() << "," << getColumnCount()->toString() << ">";
         return sb.ProduceString();
     }
 
@@ -1433,7 +1433,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // GenericParamIntVal
 
-    bool GenericParamIntVal::EqualsVal(Val* val)
+    bool GenericParamIntVal::equalsVal(Val* val)
     {
         if (auto genericParamVal = as<GenericParamIntVal>(val))
         {
@@ -1442,7 +1442,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return false;
     }
 
-    String GenericParamIntVal::ToString()
+    String GenericParamIntVal::toString()
     {
         return getText(declRef.GetName());
     }
@@ -1496,7 +1496,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // ErrorIntVal
 
-    bool ErrorIntVal::EqualsVal(Val* val)
+    bool ErrorIntVal::equalsVal(Val* val)
     {
         if( auto errorIntVal = as<ErrorIntVal>(val) )
         {
@@ -1505,7 +1505,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return false;
     }
 
-    String ErrorIntVal::ToString()
+    String ErrorIntVal::toString()
     {
         return "<error>";
     }
@@ -1546,7 +1546,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return substSubst;
     }
 
-    bool GenericSubstitution::Equals(Substitutions* subst)
+    bool GenericSubstitution::equals(Substitutions* subst)
     {
         // both must be NULL, or non-NULL
         if (subst == nullptr)
@@ -1564,14 +1564,14 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         SLANG_RELEASE_ASSERT(args.getCount() == genericSubst->args.getCount());
         for (Index aa = 0; aa < argCount; ++aa)
         {
-            if (!args[aa]->EqualsVal(genericSubst->args[aa].Ptr()))
+            if (!args[aa]->equalsVal(genericSubst->args[aa].Ptr()))
                 return false;
         }
 
         if (!outer)
             return !genericSubst->outer;
 
-        if (!outer->Equals(genericSubst->outer.Ptr()))
+        if (!outer->equals(genericSubst->outer.Ptr()))
             return false;
 
         return true;
@@ -1596,7 +1596,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return substSubst;
     }
 
-    bool ThisTypeSubstitution::Equals(Substitutions* subst)
+    bool ThisTypeSubstitution::equals(Substitutions* subst)
     {
         if (!subst)
             return false;
@@ -1613,7 +1613,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
             if(this->interfaceDecl != thisTypeSubst->interfaceDecl)
                 return false;
 
-            if(!this->witness->sub->Equals(thisTypeSubst->witness->sub))
+            if(!this->witness->sub->equals(thisTypeSubst->witness->sub))
                 return false;
 
             return true;
@@ -1659,7 +1659,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return substSubst;
     }
 
-    bool GlobalGenericParamSubstitution::Equals(Substitutions* subst)
+    bool GlobalGenericParamSubstitution::equals(Substitutions* subst)
     {
         if (!subst)
             return false;
@@ -1670,13 +1670,13 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         {
             if (paramDecl != genSubst->paramDecl)
                 return false;
-            if (!actualType->EqualsVal(genSubst->actualType))
+            if (!actualType->equalsVal(genSubst->actualType))
                 return false;
             if (constraintArgs.getCount() != genSubst->constraintArgs.getCount())
                 return false;
             for (Index i = 0; i < constraintArgs.getCount(); i++)
             {
-                if (!constraintArgs[i].val->EqualsVal(genSubst->constraintArgs[i].val))
+                if (!constraintArgs[i].val->equalsVal(genSubst->constraintArgs[i].val))
                     return false;
             }
             return true;
@@ -2182,14 +2182,14 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // ConstantIntVal
 
-    bool ConstantIntVal::EqualsVal(Val* val)
+    bool ConstantIntVal::equalsVal(Val* val)
     {
         if (auto intVal = as<ConstantIntVal>(val))
             return value == intVal->value;
         return false;
     }
 
-    String ConstantIntVal::ToString()
+    String ConstantIntVal::toString()
     {
         return String(value);
     }
@@ -2378,12 +2378,12 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // TODO: should really have a `type.cpp` and a `witness.cpp`
 
-    bool TypeEqualityWitness::EqualsVal(Val* val)
+    bool TypeEqualityWitness::equalsVal(Val* val)
     {
         auto otherWitness = as<TypeEqualityWitness>(val);
         if (!otherWitness)
             return false;
-        return sub->Equals(otherWitness->sub);
+        return sub->equals(otherWitness->sub);
     }
 
     RefPtr<Val> TypeEqualityWitness::substituteImpl(SubstitutionSet subst, int * ioDiff)
@@ -2394,9 +2394,9 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return rs;
     }
 
-    String TypeEqualityWitness::ToString()
+    String TypeEqualityWitness::toString()
     {
-        return "TypeEqualityWitness(" + sub->ToString() + ")";
+        return "TypeEqualityWitness(" + sub->toString() + ")";
     }
 
     int TypeEqualityWitness::GetHashCode()
@@ -2404,14 +2404,14 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return sub->GetHashCode();
     }
 
-    bool DeclaredSubtypeWitness::EqualsVal(Val* val)
+    bool DeclaredSubtypeWitness::equalsVal(Val* val)
     {
         auto otherWitness = as<DeclaredSubtypeWitness>(val);
         if(!otherWitness)
             return false;
 
-        return sub->Equals(otherWitness->sub)
-            && sup->Equals(otherWitness->sup)
+        return sub->equals(otherWitness->sub)
+            && sup->equals(otherWitness->sup)
             && declRef.Equals(otherWitness->declRef);
     }
 
@@ -2553,13 +2553,13 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return rs;
     }
 
-    String DeclaredSubtypeWitness::ToString()
+    String DeclaredSubtypeWitness::toString()
     {
         StringBuilder sb;
         sb << "DeclaredSubtypeWitness(";
-        sb << this->sub->ToString();
+        sb << this->sub->toString();
         sb << ", ";
-        sb << this->sup->ToString();
+        sb << this->sup->toString();
         sb << ", ";
         sb << this->declRef.toString();
         sb << ")";
@@ -2573,15 +2573,15 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // TransitiveSubtypeWitness
 
-    bool TransitiveSubtypeWitness::EqualsVal(Val* val)
+    bool TransitiveSubtypeWitness::equalsVal(Val* val)
     {
         auto otherWitness = as<TransitiveSubtypeWitness>(val);
         if(!otherWitness)
             return false;
 
-        return sub->Equals(otherWitness->sub)
-            && sup->Equals(otherWitness->sup)
-            && subToMid->EqualsVal(otherWitness->subToMid)
+        return sub->equals(otherWitness->sub)
+            && sup->equals(otherWitness->sup)
+            && subToMid->equalsVal(otherWitness->subToMid)
             && midToSup.Equals(otherWitness->midToSup);
     }
 
@@ -2626,14 +2626,14 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return result;
     }
 
-    String TransitiveSubtypeWitness::ToString()
+    String TransitiveSubtypeWitness::toString()
     {
         // Note: we only print the constituent
         // witnesses, and rely on them to print
         // the starting and ending types.
         StringBuilder sb;
         sb << "TransitiveSubtypeWitness(";
-        sb << this->subToMid->ToString();
+        sb << this->subToMid->toString();
         sb << ", ";
         sb << this->midToSup.toString();
         sb << ")";
@@ -2672,7 +2672,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         {
             return false;
         }
-        return substitutions->Equals(substSet.substitutions);
+        return substitutions->equals(substSet.substitutions);
     }
 
     int SubstitutionSet::GetHashCode() const
@@ -2685,7 +2685,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // ExtractExistentialType
 
-    String ExtractExistentialType::ToString()
+    String ExtractExistentialType::toString()
     {
         String result;
         result.append(declRef.toString());
@@ -2693,7 +2693,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return result;
     }
 
-    bool ExtractExistentialType::EqualsImpl(Type* type)
+    bool ExtractExistentialType::equalsImpl(Type* type)
     {
         if( auto extractExistential = as<ExtractExistentialType>(type) )
         {
@@ -2728,7 +2728,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // ExtractExistentialSubtypeWitness
 
-    bool ExtractExistentialSubtypeWitness::EqualsVal(Val* val)
+    bool ExtractExistentialSubtypeWitness::equalsVal(Val* val)
     {
         if( auto extractWitness = as<ExtractExistentialSubtypeWitness>(val) )
         {
@@ -2737,7 +2737,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return false;
     }
 
-    String ExtractExistentialSubtypeWitness::ToString()
+    String ExtractExistentialSubtypeWitness::toString()
     {
         String result;
         result.append("extractExistentialValue(");
@@ -2775,7 +2775,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
     // TaggedUnionType
     //
 
-    String TaggedUnionType::ToString()
+    String TaggedUnionType::toString()
     {
         String result;
         result.append("__TaggedUnion(");
@@ -2785,13 +2785,13 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
             if(!first) result.append(", ");
             first = false;
 
-            result.append(caseType->ToString());
+            result.append(caseType->toString());
         }
         result.append(")");
         return result;
     }
 
-    bool TaggedUnionType::EqualsImpl(Type* type)
+    bool TaggedUnionType::equalsImpl(Type* type)
     {
         auto taggedUnion = as<TaggedUnionType>(type);
         if(!taggedUnion)
@@ -2803,7 +2803,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
         for( Index ii = 0; ii < caseCount; ++ii )
         {
-            if(!caseTypes[ii]->Equals(taggedUnion->caseTypes[ii]))
+            if(!caseTypes[ii]->equals(taggedUnion->caseTypes[ii]))
                 return false;
         }
         return true;
@@ -2858,7 +2858,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 //
 
 
-bool TaggedUnionSubtypeWitness::EqualsVal(Val* val)
+bool TaggedUnionSubtypeWitness::equalsVal(Val* val)
 {
     auto taggedUnionWitness = as<TaggedUnionSubtypeWitness>(val);
     if(!taggedUnionWitness)
@@ -2870,14 +2870,14 @@ bool TaggedUnionSubtypeWitness::EqualsVal(Val* val)
 
     for(Index ii = 0; ii < caseCount; ++ii)
     {
-        if(!caseWitnesses[ii]->EqualsVal(taggedUnionWitness->caseWitnesses[ii]))
+        if(!caseWitnesses[ii]->equalsVal(taggedUnionWitness->caseWitnesses[ii]))
             return false;
     }
 
     return true;
 }
 
-String TaggedUnionSubtypeWitness::ToString()
+String TaggedUnionSubtypeWitness::toString()
 {
     String result;
     result.append("TaggedUnionSubtypeWitness(");
@@ -2887,7 +2887,7 @@ String TaggedUnionSubtypeWitness::ToString()
         if(!first) result.append(", ");
         first = false;
 
-        result.append(caseWitness->ToString());
+        result.append(caseWitness->toString());
     }
     return result;
 }
@@ -2975,27 +2975,27 @@ char const* getGLSLNameForImageFormat(ImageFormat format)
 // ExistentialSpecializedType
 //
 
-String ExistentialSpecializedType::ToString()
+String ExistentialSpecializedType::toString()
 {
     String result;
     result.append("__ExistentialSpecializedType(");
-    result.append(baseType->ToString());
+    result.append(baseType->toString());
     for( auto arg : args )
     {
         result.append(", ");
-        result.append(arg.val->ToString());
+        result.append(arg.val->toString());
     }
     result.append(")");
     return result;
 }
 
-bool ExistentialSpecializedType::EqualsImpl(Type * type)
+bool ExistentialSpecializedType::equalsImpl(Type * type)
 {
     auto other = as<ExistentialSpecializedType>(type);
     if(!other)
         return false;
 
-    if(!baseType->Equals(other->baseType))
+    if(!baseType->equals(other->baseType))
         return false;
 
     auto argCount = args.getCount();
@@ -3007,7 +3007,7 @@ bool ExistentialSpecializedType::EqualsImpl(Type * type)
         auto arg = args[ii];
         auto otherArg = other->args[ii];
 
-        if(!arg.val->EqualsVal(otherArg.val))
+        if(!arg.val->equalsVal(otherArg.val))
             return false;
 
         if(!areValsEqual(arg.witness, otherArg.witness))
@@ -3095,7 +3095,7 @@ RefPtr<Val> ExistentialSpecializedType::substituteImpl(SubstitutionSet subst, in
 // ThisType
 //
 
-String ThisType::ToString()
+String ThisType::toString()
 {
     String result;
     result.append(interfaceDeclRef.toString());
@@ -3103,7 +3103,7 @@ String ThisType::ToString()
     return result;
 }
 
-bool ThisType::EqualsImpl(Type * type)
+bool ThisType::equalsImpl(Type * type)
 {
     auto other = as<ThisType>(type);
     if(!other)

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -443,7 +443,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         RefPtr<ArrayExpressionType> arrayType = new ArrayExpressionType();
         arrayType->setSession(this);
         arrayType->baseType = elementType;
-        arrayType->ArrayLength = elementCount;
+        arrayType->arrayLength = elementCount;
         return arrayType;
     }
 
@@ -463,14 +463,14 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         auto arrType = as<ArrayExpressionType>(type);
         if (!arrType)
             return false;
-        return (areValsEqual(ArrayLength, arrType->ArrayLength) && baseType->Equals(arrType->baseType.Ptr()));
+        return (areValsEqual(arrayLength, arrType->arrayLength) && baseType->Equals(arrType->baseType.Ptr()));
     }
 
     RefPtr<Val> ArrayExpressionType::SubstituteImpl(SubstitutionSet subst, int* ioDiff)
     {
         int diff = 0;
         auto elementType = baseType->SubstituteImpl(subst, &diff).as<Type>();
-        auto arrlen = ArrayLength->SubstituteImpl(subst, &diff).as<IntVal>();
+        auto arrlen = arrayLength->SubstituteImpl(subst, &diff).as<IntVal>();
         SLANG_ASSERT(arrlen);
         if (diff)
         {
@@ -488,20 +488,20 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         auto canonicalElementType = baseType->GetCanonicalType();
         auto canonicalArrayType = getArrayType(
             canonicalElementType,
-            ArrayLength);
+            arrayLength);
         return canonicalArrayType;
     }
     int ArrayExpressionType::GetHashCode()
     {
-        if (ArrayLength)
-            return (baseType->GetHashCode() * 16777619) ^ ArrayLength->GetHashCode();
+        if (arrayLength)
+            return (baseType->GetHashCode() * 16777619) ^ arrayLength->GetHashCode();
         else
             return baseType->GetHashCode();
     }
     Slang::String ArrayExpressionType::ToString()
     {
-        if (ArrayLength)
-            return baseType->ToString() + "[" + ArrayLength->ToString() + "]";
+        if (arrayLength)
+            return baseType->ToString() + "[" + arrayLength->ToString() + "]";
         else
             return baseType->ToString() + "[]";
     }
@@ -2282,7 +2282,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         auto arrayType = new ArrayExpressionType();
         arrayType->setSession(session);
         arrayType->baseType = elementType;
-        arrayType->ArrayLength = elementCount;
+        arrayType->arrayLength = elementCount;
         return arrayType;
     }
 

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -77,13 +77,13 @@ namespace Slang
 
     inline FilteredMemberRefList<Decl> getMembers(DeclRef<ContainerDecl> const& declRef, MemberFilterStyle filterStyle = MemberFilterStyle::All)
     {
-        return FilteredMemberRefList<Decl>(declRef.getDecl()->Members, declRef.substitutions, filterStyle);
+        return FilteredMemberRefList<Decl>(declRef.getDecl()->members, declRef.substitutions, filterStyle);
     }
 
     template<typename T>
     inline FilteredMemberRefList<T> getMembersOfType( DeclRef<ContainerDecl> const& declRef, MemberFilterStyle filterStyle = MemberFilterStyle::All)
     {
-        return FilteredMemberRefList<T>(declRef.getDecl()->Members, declRef.substitutions, filterStyle);
+        return FilteredMemberRefList<T>(declRef.getDecl()->members, declRef.substitutions, filterStyle);
     }
 
     template<typename T>

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -163,7 +163,7 @@ namespace Slang
 
     inline RefPtr<Type> GetResultType(DeclRef<CallableDecl> const& declRef)
     {
-        return declRef.Substitute(declRef.getDecl()->ReturnType.type.Ptr());
+        return declRef.Substitute(declRef.getDecl()->returnType.type.Ptr());
     }
 
     inline FilteredMemberRefList<ParamDecl> GetParameters(DeclRef<CallableDecl> const& declRef)

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -46,7 +46,7 @@ namespace Slang
     inline bool areValsEqual(Val* left, Val* right)
     {
         if(!left || !right) return left == right;
-        return left->EqualsVal(right);
+        return left->equalsVal(right);
     }
 
     //

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -3294,7 +3294,7 @@ static TypeLayoutResult _createTypeLayout(
         // The layout rules for these vary heavily by resource kind and API.
         //
 
-        auto elementCount = GetElementCount(arrayType->ArrayLength);
+        auto elementCount = GetElementCount(arrayType->arrayLength);
 
         //
         // We can compute the uniform storage layout of an array using

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -2488,10 +2488,10 @@ static TypeLayoutResult _createTypeLayout(
         // are only applied to leaf fields/variables of matrix type
         // the difference should be immaterial.
 
-        if (declForModifiers->HasModifier<RowMajorLayoutModifier>())
+        if (declForModifiers->hasModifier<RowMajorLayoutModifier>())
             subContext.matrixLayoutMode = kMatrixLayoutMode_RowMajor;
 
-        if (declForModifiers->HasModifier<ColumnMajorLayoutModifier>())
+        if (declForModifiers->hasModifier<ColumnMajorLayoutModifier>())
             subContext.matrixLayoutMode = kMatrixLayoutMode_ColumnMajor;
 
         // TODO: really need to look for other modifiers that affect

--- a/source/slang/slang-type-system-shared.h
+++ b/source/slang/slang-type-system-shared.h
@@ -74,7 +74,7 @@ FOREACH_BASE_TYPE(DEFINE_BASE_TYPE)
 
         uint16_t flavor;
 
-        Shape GetBaseShape() const { return Shape(flavor & BaseShapeMask); }
+        Shape getBaseShape() const { return Shape(flavor & BaseShapeMask); }
         bool isArray() const { return (flavor & ArrayFlag) != 0; }
         bool isMultisample() const { return (flavor & MultisampleFlag) != 0; }
         //            bool isShadow() const { return (flavor & ShadowFlag) != 0; }


### PR DESCRIPTION
* Use lowerCamel for method and member names 
* Made getSup non virtual
* Other small fixes/tidy ups

GetHashCode was left as it's usage reaches to other parts of the code base.