### PR TITLE
Small improvements around DiagnosticSink

### DIFF
--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -1258,7 +1258,7 @@ namespace Slang
         //
         List<SpecializationArg> args;
         _extractSpecializationArgs(unspecializedEntryPoint, argExprs, args, sink);
-        if(sink->GetErrorCount())
+        if(sink->getErrorCount())
             return nullptr;
 
         return ((ComponentType*) unspecializedEntryPoint)->specialize(
@@ -1418,7 +1418,7 @@ namespace Slang
 
         List<SpecializationArg> specializationArgs;
         _extractSpecializationArgs(unspecializedProgram, specializationArgExprs, specializationArgs, sink);
-        if(sink->GetErrorCount())
+        if(sink->getErrorCount())
             return nullptr;
 
         auto specializedProgram = unspecializedProgram->specialize(
@@ -1500,7 +1500,7 @@ namespace Slang
             globalSpecializationArgs);
 
         // Don't proceed further if anything failed to parse.
-        if(sink->GetErrorCount())
+        if(sink->getErrorCount())
             return nullptr;
 
         // Now we create the initial specialized program by
@@ -1624,7 +1624,7 @@ namespace Slang
         // then try to create a composite where some of the constituent
         // component types might be null.
         //
-        if(endToEndReq->getSink()->GetErrorCount() != 0)
+        if(endToEndReq->getSink()->getErrorCount() != 0)
             return nullptr;
 
         // Any entry points beyond those that were specified up front will be

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -711,7 +711,7 @@ namespace Slang
 
     static String _getDisplayPath(DiagnosticSink* sink, SourceFile* sourceFile)
     {
-        if (sink->flags & DiagnosticSink::Flag::VerbosePath)
+        if (sink->isFlagSet(DiagnosticSink::Flag::VerbosePath))
         {
             return sourceFile->calcVerbosePath();
         }

--- a/source/slang/slang-diagnostics.cpp
+++ b/source/slang/slang-diagnostics.cpp
@@ -160,7 +160,7 @@ static void formatDiagnostic(
     Diagnostic const&   diagnostic,
     StringBuilder&      sb)
 {
-    auto sourceManager = sink->sourceManager;
+    auto sourceManager = sink->getSourceManager();
 
     SourceView* sourceView = nullptr;
     HumaneSourceLoc humaneLoc;
@@ -174,7 +174,7 @@ static void formatDiagnostic(
         formatDiagnostic(humaneLoc, diagnostic, sb);
     }
      
-    if (sourceView && (sink->flags & DiagnosticSink::Flag::VerbosePath))
+    if (sourceView && sink->isFlagSet(DiagnosticSink::Flag::VerbosePath))
     {
         auto actualHumaneLoc = sourceView->getHumaneLoc(diagnostic.loc, SourceLocType::Actual);
 
@@ -204,7 +204,7 @@ void DiagnosticSink::diagnoseImpl(SourceLoc const& pos, DiagnosticInfo const& in
 
     if (diagnostic.severity >= Severity::Error)
     {
-        errorCount++;
+        m_errorCount++;
     }
 
     // Did the client supply a callback for us to use?
@@ -243,7 +243,7 @@ void DiagnosticSink::diagnoseRaw(
 {
     if (severity >= Severity::Error)
     {
-        errorCount++;
+        m_errorCount++;
     }
 
     // Did the client supply a callback for us to use?

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -559,7 +559,7 @@ struct OptionsParser
                 }
                 else if (argStr == "-verbose-paths")
                 {
-                    requestImpl->getSink()->flags |= DiagnosticSink::Flag::VerbosePath;
+                    requestImpl->getSink()->setFlag(DiagnosticSink::Flag::VerbosePath);
                 }
                 else if (argStr == "-verify-debug-serial-ir")
                 {
@@ -1494,7 +1494,7 @@ struct OptionsParser
             }
         }
 
-        return (sink->GetErrorCount() == 0) ? SLANG_OK : SLANG_FAIL;
+        return (sink->getErrorCount() == 0) ? SLANG_OK : SLANG_FAIL;
     }
 };
 
@@ -1514,7 +1514,7 @@ SlangResult parseOptions(
     Result res = parser.parse(argc, argv);
 
     DiagnosticSink* sink = compileRequest->getSink();
-    if (sink->GetErrorCount() > 0)
+    if (sink->getErrorCount() > 0)
     {
         // Put the errors in the diagnostic 
         compileRequest->mDiagnosticOutput = sink->outputBuffer.ProduceString();

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -692,7 +692,7 @@ namespace Slang
         }
 
         // Make a 'token'
-        SourceManager* sourceManager = parser->sink->sourceManager;
+        SourceManager* sourceManager = parser->sink->getSourceManager();
         const UnownedStringSlice scopedIdentifier(sourceManager->allocateStringSlice(scopedIdentifierBuilder.getUnownedSlice()));   
         Token token(TokenType::Identifier, scopedIdentifier, scopedIdSourceLoc);
 
@@ -1741,11 +1741,11 @@ namespace Slang
         TokenSpan tokenSpan;
         tokenSpan.m_begin = parser->tokenReader.m_cursor;
         tokenSpan.m_end = parser->tokenReader.m_end;
-        DiagnosticSink newSink(parser->sink->sourceManager);
+        DiagnosticSink newSink(parser->sink->getSourceManager());
         Parser newParser(*parser);
         newParser.sink = &newSink;
         auto speculateParseRs = parseGenericApp(&newParser, base);
-        if (newSink.errorCount == 0)
+        if (newSink.getErrorCount() == 0)
         {
             // disambiguate based on FOLLOW set
             switch (peekTokenType(&newParser))

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -1150,12 +1150,12 @@ SlangResult FrontEndCompileRequest::executeActionsInner()
         parseTranslationUnit(translationUnit.Ptr());
     }
 
-    if (getSink()->GetErrorCount() != 0)
+    if (getSink()->getErrorCount() != 0)
         return SLANG_FAIL;
 
     // Perform semantic checking on the whole collection
     checkAllTranslationUnits();
-    if (getSink()->GetErrorCount() != 0)
+    if (getSink()->getErrorCount() != 0)
         return SLANG_FAIL;
 
 
@@ -1163,13 +1163,13 @@ SlangResult FrontEndCompileRequest::executeActionsInner()
     // and use them to populate the `program` member.
     //
     m_globalComponentType = createUnspecializedGlobalComponentType(this);
-    if (getSink()->GetErrorCount() != 0)
+    if (getSink()->getErrorCount() != 0)
         return SLANG_FAIL;
 
     m_globalAndEntryPointsComponentType = createUnspecializedGlobalAndEntryPointsComponentType(
         this,
         m_unspecializedEntryPoints);
-    if (getSink()->GetErrorCount() != 0)
+    if (getSink()->getErrorCount() != 0)
         return SLANG_FAIL;
 
     // We always generate IR for all the translation units.
@@ -1181,7 +1181,7 @@ SlangResult FrontEndCompileRequest::executeActionsInner()
     // makes sense.
     //
     generateIR();
-    if (getSink()->GetErrorCount() != 0)
+    if (getSink()->getErrorCount() != 0)
         return SLANG_FAIL;
 
     // Do parameter binding generation, for each compilation target.
@@ -1192,7 +1192,7 @@ SlangResult FrontEndCompileRequest::executeActionsInner()
         targetProgram->getOrCreateLayout(getSink());
         targetProgram->getOrCreateIRModuleForLayout(getSink());
     }
-    if (getSink()->GetErrorCount() != 0)
+    if (getSink()->getErrorCount() != 0)
         return SLANG_FAIL;
 
     return SLANG_OK;
@@ -1227,7 +1227,7 @@ EndToEndCompileRequest::EndToEndCompileRequest(
 
 void EndToEndCompileRequest::init()
 {
-    m_sink.sourceManager = m_linkage->getSourceManager();
+    m_sink.setSourceManager(m_linkage->getSourceManager());
 
     // Set all the default writers
     for (int i = 0; i < int(WriterChannel::CountOf); ++i)
@@ -1300,13 +1300,13 @@ SlangResult EndToEndCompileRequest::executeActionsInner()
     if (passThrough == PassThroughMode::None)
     {
         m_specializedGlobalComponentType = createSpecializedGlobalComponentType(this);
-        if (getSink()->GetErrorCount() != 0)
+        if (getSink()->getErrorCount() != 0)
             return SLANG_FAIL;
 
         m_specializedGlobalAndEntryPointsComponentType = createSpecializedGlobalAndEntryPointsComponentType(
             this,
             m_specializedEntryPoints);
-        if (getSink()->GetErrorCount() != 0)
+        if (getSink()->getErrorCount() != 0)
             return SLANG_FAIL;
 
         // For each code generation target, we will generate specialized
@@ -1318,7 +1318,7 @@ SlangResult EndToEndCompileRequest::executeActionsInner()
             auto targetProgram = m_specializedGlobalAndEntryPointsComponentType->getTargetProgram(targetReq);
             targetProgram->getOrCreateLayout(getSink());
         }
-        if (getSink()->GetErrorCount() != 0)
+        if (getSink()->getErrorCount() != 0)
             return SLANG_FAIL;
     }
     else
@@ -1350,7 +1350,7 @@ SlangResult EndToEndCompileRequest::executeActionsInner()
     // Generate output code, in whatever format was requested
     getBackEndReq()->setProgram(getSpecializedGlobalAndEntryPointsComponentType());
     generateOutput(this);
-    if (getSink()->GetErrorCount() != 0)
+    if (getSink()->getErrorCount() != 0)
         return SLANG_FAIL;
 
     return SLANG_OK;
@@ -1521,9 +1521,9 @@ void Linkage::loadParsedModule(
 
     auto sink = translationUnit->compileRequest->getSink();
 
-    int errorCountBefore = sink->GetErrorCount();
+    int errorCountBefore = sink->getErrorCount();
     checkTranslationUnit(translationUnit.Ptr());
-    int errorCountAfter = sink->GetErrorCount();
+    int errorCountAfter = sink->getErrorCount();
 
     if (errorCountAfter != errorCountBefore)
     {
@@ -1578,9 +1578,9 @@ RefPtr<Module> Linkage::loadModule(
     
     translationUnit->addSourceFile(sourceFile);
 
-    int errorCountBefore = sink->GetErrorCount();
+    int errorCountBefore = sink->getErrorCount();
     frontEndReq->parseTranslationUnit(translationUnit);
-    int errorCountAfter = sink->GetErrorCount();
+    int errorCountAfter = sink->getErrorCount();
 
     if( errorCountAfter != errorCountBefore )
     {
@@ -1597,7 +1597,7 @@ RefPtr<Module> Linkage::loadModule(
         name,
         filePathInfo);
 
-    errorCountAfter = sink->GetErrorCount();
+    errorCountAfter = sink->getErrorCount();
 
     if (errorCountAfter != errorCountBefore)
     {
@@ -2436,11 +2436,11 @@ void DiagnosticSink::noteInternalErrorLoc(SourceLoc const& loc)
     // If this is the first source location being noted,
     // then emit a message to help the user isolate what
     // code might have confused the compiler.
-    if(internalErrorLocsNoted == 0)
+    if(m_internalErrorLocsNoted == 0)
     {
         diagnose(loc, Diagnostics::noteLocationOfInternalError);
     }
-    internalErrorLocsNoted++;
+    m_internalErrorLocsNoted++;
 }
 
 SlangResult DiagnosticSink::getBlobIfNeeded(ISlangBlob** outBlob)
@@ -2449,8 +2449,14 @@ SlangResult DiagnosticSink::getBlobIfNeeded(ISlangBlob** outBlob)
     //
     if(!outBlob) return SLANG_OK;
 
+    // For outputBuffer to be valid and hold diagnostics, writer must not be set
+    SLANG_ASSERT(writer == nullptr);
+
     // If there were no errors, and there was no diagnostic output, there is nothing to do.
-    if(!GetErrorCount() && !outputBuffer.getLength()) return SLANG_OK;
+    if(getErrorCount() == 0 && outputBuffer.getLength() == 0)
+    {
+        return SLANG_OK;
+    }
 
     Slang::ComPtr<ISlangBlob> blob = Slang::StringUtil::createStringBlob(outputBuffer);
     *outBlob = blob.detach();
@@ -2554,7 +2560,7 @@ void Session::addBuiltinSource(
     compileRequest->m_isStandardLibraryCode = true;
 
     // Set the source manager on the sink
-    sink.sourceManager = sourceManager;
+    sink.setSourceManager(sourceManager);
     // Make the linkage use the builtin source manager
     Linkage* linkage = compileRequest->getLinkage();
     linkage->setSourceManager(sourceManager);

--- a/tools/slang-cpp-extractor/slang-cpp-extractor-main.cpp
+++ b/tools/slang-cpp-extractor/slang-cpp-extractor-main.cpp
@@ -1365,7 +1365,7 @@ SlangResult CPPExtractor::_maybeParseType(UnownedStringSlice& outType)
 {
     Index templateDepth = 0;
     SlangResult res = _maybeParseType(outType, templateDepth);
-    if (SLANG_FAILED(res) && m_sink->errorCount)
+    if (SLANG_FAILED(res) && m_sink->getErrorCount())
     {
         return res;
     }
@@ -1472,7 +1472,7 @@ SlangResult CPPExtractor::_maybeParseField()
     UnownedStringSlice typeName;
     if (SLANG_FAILED(_maybeParseType(typeName)))
     {
-        if (m_sink->errorCount)
+        if (m_sink->getErrorCount())
         {
             return SLANG_FAIL;
         }
@@ -1565,7 +1565,7 @@ SlangResult CPPExtractor::parse(SourceFile* sourceFile, const Options* options)
     lexer.initialize(sourceView, m_sink, m_namePool, manager->getMemoryArena());
     m_tokenList = lexer.lexAllTokens();
     // See if there were any errors
-    if (m_sink->errorCount)
+    if (m_sink->getErrorCount())
     {
         return SLANG_FAIL;
     }
@@ -2446,7 +2446,7 @@ int main(int argc, const char*const* argv)
         {
             return 1;
         }
-        if (sink.errorCount)
+        if (sink.getErrorCount())
         {
             return 1;
         }


### PR DESCRIPTION
* GetErrorCount -> getErrorCount
* Documented some of the more of how some of the more esoteric aspects of the sink works (like writer/outputBuffer)
  * There is an argument to change this behavior - to say always output to a writer, and have an implementation that is String backed
* Made some members non public