### PR TITLE
Bug fix problem with ray tracing from fragment shader

### DIFF
--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -136,6 +136,11 @@ CLikeSourceEmitter::CLikeSourceEmitter(const Desc& desc)
     m_effectiveProfile = desc.effectiveProfile;
 }
 
+SlangResult CLikeSourceEmitter::init()
+{
+    return SLANG_OK;
+}
+
 //
 // Types
 //

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -96,8 +96,12 @@ public:
         {}
     };
 
+        /// Must be called before used
+    virtual SlangResult init();
+
         /// Ctor
     CLikeSourceEmitter(const Desc& desc);
+
     
         /// Get the source manager
     SourceManager* getSourceManager() { return m_compileRequest->getSourceManager(); }

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -27,14 +27,19 @@ SlangResult GLSLSourceEmitter::init()
         case Stage::Miss:
         case Stage::RayGeneration:
         {
-            m_glslExtensionTracker->requireExtension(UnownedStringSlice::fromLiteral("GL_NV_ray_tracing"));
-            m_glslExtensionTracker->requireVersion(ProfileVersion::GLSL_460);   
+            _requireRayTracing();   
             break;
         }
         default: break;
     }
 
     return SLANG_OK;
+}
+
+void GLSLSourceEmitter::_requireRayTracing()
+{
+    m_glslExtensionTracker->requireExtension(UnownedStringSlice::fromLiteral("GL_NV_ray_tracing"));
+    m_glslExtensionTracker->requireVersion(ProfileVersion::GLSL_460);
 }
 
 void GLSLSourceEmitter::_requireGLSLExtension(const UnownedStringSlice& name)
@@ -1698,12 +1703,11 @@ void GLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
         switch (untypedBufferType->op)
         {
             case kIROp_RaytracingAccelerationStructureType:
-                // GL_NV_ray_tracing requires GLSL_460
-                _requireGLSLExtension(UnownedStringSlice::fromLiteral("GL_NV_ray_tracing"));
-                m_glslExtensionTracker->requireVersion(ProfileVersion::GLSL_460);
-
+            {
+                _requireRayTracing();
                 m_writer->emit("accelerationStructureNV");
                 break;
+            }
 
                 // TODO: These "translations" are obviously wrong for GLSL.
             case kIROp_HLSLByteAddressBufferType:                   m_writer->emit("ByteAddressBuffer");                  break;

--- a/source/slang/slang-emit-glsl.h
+++ b/source/slang/slang-emit-glsl.h
@@ -104,6 +104,8 @@ protected:
         ///
     bool _tryEmitBitBinOp(IRInst* inst, const EmitOpInfo& bitOp, const EmitOpInfo& boolOp, const EmitOpInfo& inOuterPrec);
 
+    void _requireRayTracing();
+
     RefPtr<GLSLExtensionTracker> m_glslExtensionTracker;
 };
 

--- a/source/slang/slang-emit-glsl.h
+++ b/source/slang/slang-emit-glsl.h
@@ -14,11 +14,15 @@ class GLSLSourceEmitter : public CLikeSourceEmitter
 public:
     typedef CLikeSourceEmitter Super;
 
+    virtual SlangResult init() SLANG_OVERRIDE;
+
     GLSLSourceEmitter(const Desc& desc) :
         Super(desc)
     {
         m_glslExtensionTracker = new GLSLExtensionTracker;
     }
+
+    
 
     virtual RefObject* getExtensionTracker() SLANG_OVERRIDE { return m_glslExtensionTracker; }
 

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -662,6 +662,8 @@ SlangResult emitEntryPointSourceFromIR(
         return SLANG_FAIL;
     }
 
+    SLANG_RETURN_ON_FAIL(sourceEmitter->init());
+
     {
         LinkingAndOptimizationOptions linkingAndOptimizationOptions;
 
@@ -696,29 +698,6 @@ SlangResult emitEntryPointSourceFromIR(
         // TODO: do we want to emit directly from IR, or translate the
         // IR back into AST for emission?
         sourceEmitter->emitModule(irModule);
-    }
-
-    // Deal with cases where a particular stage requires certain GLSL versions
-    // and/or extensions.
-    switch( entryPoint->getStage() )
-    {
-    default:
-        break;
-
-    case Stage::AnyHit:
-    case Stage::Callable:
-    case Stage::ClosestHit:
-    case Stage::Intersection:
-    case Stage::Miss:
-    case Stage::RayGeneration:
-        if( target == CodeGenTarget::GLSL )
-        {
-            auto glslExtensionTracker = as<GLSLExtensionTracker>(sourceEmitter->getExtensionTracker());
-
-            glslExtensionTracker->requireExtension(UnownedStringSlice::fromLiteral("GL_NV_ray_tracing"));
-            glslExtensionTracker->requireVersion(ProfileVersion::GLSL_460);
-        }
-        break;
     }
 
     String code = sourceWriter.getContent();


### PR DESCRIPTION
A fragment shader that uses ray casting features did not add the #version 460 requirement. This was correctly handled for ray tracing specific stages. 

* Added the 460 requirement when not in a 'ray tracing' stage
* Moved part of CLikeSourceEmitter setup into init, so that some GLSL setup could be moved into the GLSLSourceEmitter.