### PR TITLE
NodeBase types constructed with astNodeType member set

### DIFF
--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -163,7 +163,7 @@ SLANG_FORCE_INLINE const T* as(const Type* obj) { return obj ? dynamicCast<T>(co
 
 // A substitution represents a binding of certain
 // type-level variables to concrete argument values
-class Substitutions: public RefObject
+class Substitutions: public NodeBase
 {
     SLANG_ABSTRACT_CLASS(Substitutions)
 

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -132,7 +132,7 @@ void SharedASTBuilder::registerMagicDecl(RefPtr<Decl> decl, RefPtr<MagicTypeModi
     m_magicDecls[modifier->name] = declToRegister.Ptr();
 }
 
-RefPtr<Decl> SharedASTBuilder::findMagicDecl(const String&   name)
+RefPtr<Decl> SharedASTBuilder::findMagicDecl(const String& name)
 {
     return m_magicDecls[name].GetValue();
 }
@@ -150,7 +150,7 @@ ASTBuilder::ASTBuilder():
 {
 }
 
-RefPtr<PtrType> ASTBuilder::getPtrType( RefPtr<Type>    valueType)
+RefPtr<PtrType> ASTBuilder::getPtrType(RefPtr<Type> valueType)
 {
     return getPtrType(valueType, "PtrType").dynamicCast<PtrType>();
 }
@@ -206,7 +206,7 @@ RefPtr<VectorExpressionType> ASTBuilder::getVectorType(
         
     auto vectorTypeDecl = vectorGenericDecl->inner;
 
-    auto substitutions = new GenericSubstitution();
+    auto substitutions = create<GenericSubstitution>();
     substitutions->genericDecl = vectorGenericDecl.Ptr();
     substitutions->args.add(elementType);
     substitutions->args.add(elementCount);

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -91,13 +91,13 @@ public:
 
         /// Create AST type. 
     template <typename T>
-    T* create() { SLANG_COMPILE_TIME_ASSERT(IsValidType<T>::Value);  T* node = new T; node->setASTBuilder(this); return node; }
+    T* create() { SLANG_COMPILE_TIME_ASSERT(IsValidType<T>::Value);  T* node = new T; node->init(T::kType, this); return node; }
 
     template<typename T, typename P0>
-    T* create(const P0& p0) { SLANG_COMPILE_TIME_ASSERT(IsValidType<T>::Value); T* node = new T(p0); node->setASTBuilder(this); return node;}
+    T* create(const P0& p0) { SLANG_COMPILE_TIME_ASSERT(IsValidType<T>::Value); T* node = new T(p0); node->init(T::kType, this); return node;}
 
     template<typename T, typename P0, typename P1>
-    T* create(const P0& p0, const P1& p1) { SLANG_COMPILE_TIME_ASSERT(IsValidType<T>::Value); T* node = new T(p0, p1); node->setASTBuilder(this); return node; }
+    T* create(const P0& p0, const P1& p1) { SLANG_COMPILE_TIME_ASSERT(IsValidType<T>::Value); T* node = new T(p0, p1); node->init(T::kType, this); return node; }
 
         /// Get the built in types
     SLANG_FORCE_INLINE Type* getBoolType() { return m_sharedASTBuilder->m_builtinTypes[Index(BaseType::Bool)]; }

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -85,7 +85,7 @@ public:
     {
         enum
         {
-            Value = IsBaseOf<NodeBase, T>::Value || IsBaseOf<Substitutions, T>::Value
+            Value = IsBaseOf<NodeBase, T>::Value
         };
     };
 

--- a/source/slang/slang-ast-dump.cpp
+++ b/source/slang/slang-ast-dump.cpp
@@ -545,6 +545,12 @@ struct Context
         m_writer->emit("\n");
     }
 
+    void dump(ASTNodeType nodeType)
+    {
+        SLANG_UNUSED(nodeType)
+        // Don't bother to output anything - as will already have been dumped with the object name
+    }
+
     void dumpObjectFull(NodeBase* node);
 
     Context(SourceWriter* writer, ASTDumpUtil::Style dumpStyle):

--- a/source/slang/slang-ast-dump.cpp
+++ b/source/slang/slang-ast-dump.cpp
@@ -546,7 +546,6 @@ struct Context
     }
 
     void dumpObjectFull(NodeBase* node);
-    void dumpObjectFull(Substitutions* subs);
 
     Context(SourceWriter* writer, ASTDumpUtil::Style dumpStyle):
         m_writer(writer),
@@ -585,7 +584,6 @@ static void dumpFields_##NAME(NAME* node, Context& context) \
     SLANG_FIELDS_ASTNode_##NAME(SLANG_AST_DUMP_FIELD, _) \
 }
 
-SLANG_ALL_ASTNode_Substitutions(SLANG_AST_DUMP_FIELDS_IMPL, _)
 SLANG_ALL_ASTNode_NodeBase(SLANG_AST_DUMP_FIELDS_IMPL, _)
 
 };
@@ -599,7 +597,6 @@ struct DumpFieldFuncs
     DumpFieldFuncs()
     {
         memset(m_funcs, 0, sizeof(m_funcs));
-        SLANG_ALL_ASTNode_Substitutions(SLANG_AST_GET_DUMP_FUNC, _)
         SLANG_ALL_ASTNode_NodeBase(SLANG_AST_GET_DUMP_FUNC, _)
     }
 
@@ -679,33 +676,11 @@ void Context::dumpObjectFull(NodeBase* node)
     }
 }
 
-void Context::dumpObjectFull(Substitutions* subs)
-{
-    if (!subs)
-    {
-        _dumpPtr(nullptr);
-    }
-    else
-    {
-        const ReflectClassInfo& typeInfo = subs->getClassInfo();
-        Index index = getObjectIndex(typeInfo, subs);
-        dumpObjectFull(typeInfo, subs, index);
-    }
-}
-
 /* static */void ASTDumpUtil::dump(NodeBase* node, Style style, SourceWriter* writer)
 {
     Context context(writer, style);
     context.dumpObjectFull(node);
     context.dumpRemaining();
-}
-
-/* static */void ASTDumpUtil::dump(Substitutions* subs, Style style, SourceWriter* writer)
-{
-    Context context(writer, style);
-    context.dumpObjectFull(subs);
-    context.dumpRemaining();
-
 }
 
 } // namespace Slang

--- a/source/slang/slang-ast-dump.h
+++ b/source/slang/slang-ast-dump.h
@@ -20,7 +20,6 @@ struct ASTDumpUtil
     };
 
     static void dump(NodeBase* node, Style style, SourceWriter* writer);
-    static void dump(Substitutions* subs, Style style, SourceWriter* writer);
 };
 
 } // namespace Slang

--- a/source/slang/slang-ast-reflect.cpp
+++ b/source/slang/slang-ast-reflect.cpp
@@ -23,7 +23,6 @@ static ReflectClassInfo::Infos _calcInfos()
     ReflectClassInfo::Infos infos;
     memset(&infos, 0, sizeof(infos));
     SLANG_ALL_ASTNode_NodeBase(SLANG_REFLECT_GET_REFLECT_CLASS_INFO, _)
-    SLANG_ALL_ASTNode_Substitutions(SLANG_REFLECT_GET_REFLECT_CLASS_INFO, _)
     return infos;
 }
 
@@ -68,7 +67,6 @@ struct ASTConstructAccess
     /* static */const ReflectClassInfo NAME::kReflectClassInfo = { uint32_t(ASTNodeType::NAME), uint32_t(ASTNodeType::LAST), SLANG_GET_SUPER_##TYPE(SUPER), #NAME, SLANG_GET_CREATE_FUNC_##MARKER(NAME)  };
 
 SLANG_ALL_ASTNode_NodeBase(SLANG_REFLECT_CLASS_INFO, _)
-SLANG_ALL_ASTNode_Substitutions(SLANG_REFLECT_CLASS_INFO, _)
 
 // We dispatch to non 'abstract' types
 #define SLANG_CASE_NONE(NAME)           case ASTNodeType::NAME: return visitor->dispatch_##NAME(static_cast<NAME*>(this), extra);

--- a/source/slang/slang-ast-reflect.cpp
+++ b/source/slang/slang-ast-reflect.cpp
@@ -48,7 +48,7 @@ struct ASTConstructAccess
     template <typename T>
     struct CreateImpl
     {
-        static void* create() { return new T; }
+        static void* create(ASTBuilder* astBuilder) { return astBuilder->create<T>(); }
     };
 };
 

--- a/source/slang/slang-ast-reflect.h
+++ b/source/slang/slang-ast-reflect.h
@@ -5,11 +5,6 @@
 
 #include "slang-ast-generated.h"
 
-// Switch based on node type - only inner and leaf classes define override
-#define SLANG_AST_OVERRIDE_BASE
-#define SLANG_AST_OVERRIDE_INNER override
-#define SLANG_AST_OVERRIDE_LEAF override
-
 // Implementation for SLANG_ABSTRACT_CLASS(x) using reflection from C++ extractor in slang-ast-generated.h
 #define SLANG_CLASS_REFLECT_IMPL(NAME, SUPER, ORIGIN, LAST, MARKER, TYPE, param) \
     protected: \
@@ -20,7 +15,6 @@
     static const ASTNodeType kType = ASTNodeType::NAME; \
     static const ReflectClassInfo kReflectClassInfo;  \
     SLANG_FORCE_INLINE static bool isDerivedFrom(ASTNodeType type) { return int(type) >= int(kType) && int(type) <= int(ASTNodeType::LAST); } \
-    virtual const ReflectClassInfo& getClassInfo() const SLANG_AST_OVERRIDE_##TYPE { return kReflectClassInfo; } \
     friend class ASTBuilder; \
     friend struct ASTConstructAccess; 
 

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -544,7 +544,7 @@ namespace Slang
         }
 
         // Manage scope
-        RefPtr<RefObject> attrInstance = attrDecl->syntaxClass.createInstance();
+        RefPtr<RefObject> attrInstance = attrDecl->syntaxClass.createInstance(m_astBuilder);
         auto attr = attrInstance.as<Attribute>();
         if(!attr)
         {

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -2834,10 +2834,10 @@ namespace Slang
     // This is a catch-all syntax-construction callback to handle cases where
     // a piece of syntax is fully defined by the keyword to use, along with
     // the class of AST node to construct.
-    static RefPtr<RefObject> parseSimpleSyntax(Parser* /*parser*/, void* userData)
+    static RefPtr<RefObject> parseSimpleSyntax(Parser* parser, void* userData)
     {
         SyntaxClassBase syntaxClass((ReflectClassInfo*) userData);
-        return (RefObject*) syntaxClass.createInstanceImpl();
+        return (RefObject*) syntaxClass.createInstanceImpl(parser->astBuilder);
     }
 
     // Parse a declaration of a keyword that can be used to define further syntax.

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -827,7 +827,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
                     SLANG_UNEXPECTED("unhandled type");
                 }
 
-                RefPtr<RefObject> type = classInfo.createInstance();
+                RefPtr<RefObject> type = classInfo.createInstance(astBuilder);
                 if (!type)
                 {
                     SLANG_UNEXPECTED("constructor failure");


### PR DESCRIPTION
* Made Substitutions derive from NodeBase
* Added astNodeType member to NodeBase
* Made getClassInfo non virtual (can do so because of astNodeType member)
* Set the astNodeType on creation via ASTBuilder - via init function (that can also set ASTBuilder - replacing setASTBuilder)
* Make all NodeBase construction through ASTBuilder create functions
* Made the ReflectClassInfo create function type take an ASTBuilder parameter, such that it is constructed through the ASTBuilder