### PR TITLE
ASTNodes use MemoryArena

### DIFF
--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -36,6 +36,9 @@ class NodeBase : public RefObject
         /// correctly constructed (through ASTBuilder) NodeBase derived class. 
         /// The actual type is set when constructed on the ASTBuilder. 
     ASTNodeType astNodeType = ASTNodeType(-1);
+
+        ///
+    ~NodeBase();
 };
 
 // Casting of NodeBase

--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -184,7 +184,7 @@ class Substitutions: public NodeBase
     SLANG_ABSTRACT_CLASS(Substitutions)
 
     // The next outer that this one refines.
-    Substitutions* outer;
+    Substitutions* outer = nullptr;
 
     // Apply a set of substitutions to the bindings in this substitution
     Substitutions* applySubstitutionsShallow(ASTBuilder* astBuilder, SubstitutionSet substSet, Substitutions* substOuter, int* ioDiff);
@@ -205,7 +205,7 @@ class GenericSubstitution : public Substitutions
 
     // The generic declaration that defines the
     // parameters we are binding to arguments
-    GenericDecl* genericDecl;
+    GenericDecl* genericDecl = nullptr;
 
     // The actual values of the arguments
     List<Val* > args;
@@ -225,7 +225,7 @@ class ThisTypeSubstitution : public Substitutions
 
     // A witness that shows that the concrete type used to
     // specialize the interface conforms to the interface.
-    SubtypeWitness* witness;
+    SubtypeWitness* witness = nullptr;
 
     // Overrides should be public so base classes can access
     // The actual type that provides the lookup scope for an associated type
@@ -238,15 +238,15 @@ class GlobalGenericParamSubstitution : public Substitutions
 {
     SLANG_CLASS(GlobalGenericParamSubstitution)
     // the type_param decl to be substituted
-    GlobalGenericParamDecl* paramDecl;
+    GlobalGenericParamDecl* paramDecl = nullptr;
 
     // the actual type to substitute in
-    Type* actualType;
+    Type* actualType = nullptr;
 
     struct ConstraintArg
     {
-        Decl*    decl;
-        Val*     val;
+        Decl*    decl = nullptr;
+        Val*     val = nullptr;
     };
 
     // the values that satisfy any constraints on the type parameter
@@ -276,7 +276,7 @@ class Modifier : public SyntaxNode
     void accept(IModifierVisitor* visitor, void* extra);
 
     // Next modifier in linked list of modifiers on same piece of syntax
-    Modifier* next;
+    Modifier* next = nullptr;
 
     // The keyword that was used to introduce t that was used to name this modifier.
     Name* name;

--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -34,9 +34,6 @@ class NodeBase
         /// correctly constructed (through ASTBuilder) NodeBase derived class. 
         /// The actual type is set when constructed on the ASTBuilder. 
     ASTNodeType astNodeType = ASTNodeType(-1);
-
-        ///
-    ~NodeBase();
 };
 
 // Casting of NodeBase

--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -14,14 +14,12 @@
 namespace Slang
 {
 
-// Signals to C++ extractor that RefObject is a base class, that isn't reflected to C++ extractor
-SLANG_REFLECT_BASE_CLASS(RefObject)
-
 struct ReflectClassInfo;
 
-class NodeBase : public RefObject
+class NodeBase 
 {
     SLANG_ABSTRACT_CLASS(NodeBase)
+    SLANG_CLASS_ROOT
 
         // MUST be called before used. Called automatically via the ASTBuilder.
         // Note that the astBuilder is not stored in the NodeBase derived types by default.

--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -91,14 +91,14 @@ class Val : public NodeBase
 
     // construct a new value by applying a set of parameter
     // substitutions to this one
-    RefPtr<Val> substitute(ASTBuilder* astBuilder, SubstitutionSet subst);
+    Val* substitute(ASTBuilder* astBuilder, SubstitutionSet subst);
 
     // Lower-level interface for substitution. Like the basic
     // `Substitute` above, but also takes a by-reference
     // integer parameter that should be incremented when
     // returning a modified value (this can help the caller
     // decide whether they need to do anything).
-    RefPtr<Val> substituteImpl(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Val* substituteImpl(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 
     bool equalsVal(Val* val);
     String toString();
@@ -109,7 +109,7 @@ class Val : public NodeBase
     }
 
     // Overrides should be public so base classes can access
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
     bool _equalsValOverride(Val* val);
     String _toStringOverride();
     HashCode _getHashCodeOverride();
@@ -157,14 +157,14 @@ class Type: public Val
     ~Type();
 
     // Overrides should be public so base classes can access
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
     bool _equalsValOverride(Val* val);
     bool _equalsImplOverride(Type* type);
-    RefPtr<Type> _createCanonicalTypeOverride();
+    Type* _createCanonicalTypeOverride();
 
 protected:
     bool equalsImpl(Type* type);
-    RefPtr<Type> createCanonicalType();
+    Type* createCanonicalType();
 
     Type* canonicalType = nullptr;
 
@@ -184,17 +184,17 @@ class Substitutions: public NodeBase
     SLANG_ABSTRACT_CLASS(Substitutions)
 
     // The next outer that this one refines.
-    RefPtr<Substitutions> outer;
+    Substitutions* outer;
 
     // Apply a set of substitutions to the bindings in this substitution
-    RefPtr<Substitutions> applySubstitutionsShallow(ASTBuilder* astBuilder, SubstitutionSet substSet, RefPtr<Substitutions> substOuter, int* ioDiff);
+    Substitutions* applySubstitutionsShallow(ASTBuilder* astBuilder, SubstitutionSet substSet, Substitutions* substOuter, int* ioDiff);
 
     // Check if these are equivalent substitutions to another set
     bool equals(Substitutions* subst);
     HashCode getHashCode() const;
 
     // Overrides should be public so base classes can access
-    RefPtr<Substitutions> _applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, RefPtr<Substitutions> substOuter, int* ioDiff);
+    Substitutions* _applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, Substitutions* substOuter, int* ioDiff);
     bool _equalsOverride(Substitutions* subst);
     HashCode _getHashCodeOverride() const;
 };
@@ -208,10 +208,10 @@ class GenericSubstitution : public Substitutions
     GenericDecl* genericDecl;
 
     // The actual values of the arguments
-    List<RefPtr<Val> > args;
+    List<Val* > args;
 
     // Overrides should be public so base classes can access
-    RefPtr<Substitutions> _applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, RefPtr<Substitutions> substOuter, int* ioDiff);
+    Substitutions* _applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, Substitutions* substOuter, int* ioDiff);
     bool _equalsOverride(Substitutions* subst);
     HashCode _getHashCodeOverride() const;
 };
@@ -225,11 +225,11 @@ class ThisTypeSubstitution : public Substitutions
 
     // A witness that shows that the concrete type used to
     // specialize the interface conforms to the interface.
-    RefPtr<SubtypeWitness> witness;
+    SubtypeWitness* witness;
 
     // Overrides should be public so base classes can access
     // The actual type that provides the lookup scope for an associated type
-    RefPtr<Substitutions> _applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, RefPtr<Substitutions> substOuter, int* ioDiff);
+    Substitutions* _applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, Substitutions* substOuter, int* ioDiff);
     bool _equalsOverride(Substitutions* subst);
     HashCode _getHashCodeOverride() const;
 };
@@ -241,19 +241,19 @@ class GlobalGenericParamSubstitution : public Substitutions
     GlobalGenericParamDecl* paramDecl;
 
     // the actual type to substitute in
-    RefPtr<Type> actualType;
+    Type* actualType;
 
     struct ConstraintArg
     {
-        RefPtr<Decl>    decl;
-        RefPtr<Val>     val;
+        Decl*    decl;
+        Val*     val;
     };
 
     // the values that satisfy any constraints on the type parameter
     List<ConstraintArg> constraintArgs;
 
     // Overrides should be public so base classes can access
-    RefPtr<Substitutions> _applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, RefPtr<Substitutions> substOuter, int* ioDiff);
+    Substitutions* _applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, Substitutions* substOuter, int* ioDiff);
     bool _equalsOverride(Substitutions* subst);
     HashCode _getHashCodeOverride() const;
 };
@@ -276,7 +276,7 @@ class Modifier : public SyntaxNode
     void accept(IModifierVisitor* visitor, void* extra);
 
     // Next modifier in linked list of modifiers on same piece of syntax
-    RefPtr<Modifier> next;
+    Modifier* next;
 
     // The keyword that was used to introduce t that was used to name this modifier.
     Name* name;
@@ -293,7 +293,7 @@ class ModifiableSyntaxNode : public SyntaxNode
     Modifiers modifiers;
 
     template<typename T>
-    FilteredModifierList<T> getModifiersOfType() { return FilteredModifierList<T>(modifiers.first.Ptr()); }
+    FilteredModifierList<T> getModifiersOfType() { return FilteredModifierList<T>(modifiers.first); }
 
     // Find the first modifier of a given type, or return `nullptr` if none is found.
     template<typename T>

--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -157,8 +157,6 @@ class Type: public Val
     
     Type* getCanonicalType();
 
-    ~Type();
-
     // Overrides should be public so base classes can access
     Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
     bool _equalsValOverride(Val* val);

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -16,7 +16,6 @@ SharedASTBuilder::SharedASTBuilder()
 {    
 }
 
-
 void SharedASTBuilder::init(Session* session)
 {
     m_namePool = session->getNamePool();
@@ -145,15 +144,19 @@ Decl* SharedASTBuilder::findMagicDecl(const String& name)
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! ASTBuilder !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-ASTBuilder::ASTBuilder(SharedASTBuilder* sharedASTBuilder):
-    m_sharedASTBuilder(sharedASTBuilder)
+ASTBuilder::ASTBuilder(SharedASTBuilder* sharedASTBuilder, const String& name):
+    m_sharedASTBuilder(sharedASTBuilder),
+    m_name(name),
+    m_id(sharedASTBuilder->m_id++)
 {
     SLANG_ASSERT(sharedASTBuilder);
 }
 
 ASTBuilder::ASTBuilder():
-    m_sharedASTBuilder(nullptr)
+    m_sharedASTBuilder(nullptr),
+    m_id(-1)
 {
+    m_name = "ShadedASTBuilder::m_astBuilder";
 }
 
 ASTBuilder::~ASTBuilder()

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -6,10 +6,6 @@
 
 namespace Slang {
 
-NodeBase::~NodeBase()
-{
-}
-
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! SharedASTBuilder !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 SharedASTBuilder::SharedASTBuilder()

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -21,17 +21,19 @@ void SharedASTBuilder::init(Session* session)
     m_session = session;
 
     // We just want as a place to store allocations of shared types
-    RefPtr<ASTBuilder> astBuilder(new ASTBuilder);
+    {
+        RefPtr<ASTBuilder> astBuilder(new ASTBuilder);
+        astBuilder->m_sharedASTBuilder = this;
+        m_astBuilder = astBuilder.detach();
+    }
 
-    astBuilder->m_sharedASTBuilder = this;
-
+    // Clear the built in types
     memset(m_builtinTypes, 0, sizeof(m_builtinTypes));
 
+    // Create common shared types
     m_errorType = m_astBuilder->create<ErrorType>();
     m_initializerListType = m_astBuilder->create<InitializerListType>();
     m_overloadedType = m_astBuilder->create<OverloadGroupType>();
-
-    m_astBuilder = astBuilder.detach();
 
     // We can just iterate over the class pointers.
     // NOTE! That this adds the names of the abstract classes too(!)

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -106,7 +106,7 @@ SharedASTBuilder::~SharedASTBuilder()
     // Release built in types..
     for (Index i = 0; i < SLANG_COUNT_OF(m_builtinTypes); ++i)
     {
-        m_builtinTypes[i].setNull();
+        m_builtinTypes[i] = nullptr;
     }
 
     if (m_astBuilder)
@@ -115,13 +115,13 @@ SharedASTBuilder::~SharedASTBuilder()
     }
 }
 
-void SharedASTBuilder::registerBuiltinDecl(RefPtr<Decl> decl, RefPtr<BuiltinTypeModifier> modifier)
+void SharedASTBuilder::registerBuiltinDecl(Decl* decl, BuiltinTypeModifier* modifier)
 {
-    auto type = DeclRefType::create(m_astBuilder, DeclRef<Decl>(decl.Ptr(), nullptr));
+    auto type = DeclRefType::create(m_astBuilder, DeclRef<Decl>(decl, nullptr));
     m_builtinTypes[Index(modifier->tag)] = type;
 }
 
-void SharedASTBuilder::registerMagicDecl(RefPtr<Decl> decl, RefPtr<MagicTypeModifier> modifier)
+void SharedASTBuilder::registerMagicDecl(Decl* decl, MagicTypeModifier* modifier)
 {
     // In some cases the modifier will have been applied to the
     // "inner" declaration of a `GenericDecl`, but what we
@@ -131,10 +131,10 @@ void SharedASTBuilder::registerMagicDecl(RefPtr<Decl> decl, RefPtr<MagicTypeModi
     if (auto genericDecl = as<GenericDecl>(decl->parentDecl))
         declToRegister = genericDecl;
 
-    m_magicDecls[modifier->name] = declToRegister.Ptr();
+    m_magicDecls[modifier->name] = declToRegister;
 }
 
-RefPtr<Decl> SharedASTBuilder::findMagicDecl(const String& name)
+Decl* SharedASTBuilder::findMagicDecl(const String& name)
 {
     return m_magicDecls[name].GetValue();
 }
@@ -152,34 +152,34 @@ ASTBuilder::ASTBuilder():
 {
 }
 
-RefPtr<PtrType> ASTBuilder::getPtrType(RefPtr<Type> valueType)
+PtrType* ASTBuilder::getPtrType(Type* valueType)
 {
-    return getPtrType(valueType, "PtrType").dynamicCast<PtrType>();
+    return dynamicCast<PtrType>(getPtrType(valueType, "PtrType"));
 }
 
 // Construct the type `Out<valueType>`
-RefPtr<OutType> ASTBuilder::getOutType(RefPtr<Type> valueType)
+OutType* ASTBuilder::getOutType(Type* valueType)
 {
-    return getPtrType(valueType, "OutType").dynamicCast<OutType>();
+    return dynamicCast<OutType>(getPtrType(valueType, "OutType"));
 }
 
-RefPtr<InOutType> ASTBuilder::getInOutType(RefPtr<Type> valueType)
+InOutType* ASTBuilder::getInOutType(Type* valueType)
 {
-    return getPtrType(valueType, "InOutType").dynamicCast<InOutType>();
+    return dynamicCast<InOutType>(getPtrType(valueType, "InOutType"));
 }
 
-RefPtr<RefType> ASTBuilder::getRefType(RefPtr<Type> valueType)
+RefType* ASTBuilder::getRefType(Type* valueType)
 {
-    return getPtrType(valueType, "RefType").dynamicCast<RefType>();
+    return dynamicCast<RefType>(getPtrType(valueType, "RefType"));
 }
 
-RefPtr<PtrTypeBase> ASTBuilder::getPtrType(RefPtr<Type> valueType, char const* ptrTypeName)
+PtrTypeBase* ASTBuilder::getPtrType(Type* valueType, char const* ptrTypeName)
 {
-    auto genericDecl = m_sharedASTBuilder->findMagicDecl(ptrTypeName).dynamicCast<GenericDecl>();
+    auto genericDecl = dynamicCast<GenericDecl>(m_sharedASTBuilder->findMagicDecl(ptrTypeName));
     return getPtrType(valueType, genericDecl);
 }
 
-RefPtr<PtrTypeBase> ASTBuilder::getPtrType(RefPtr<Type> valueType, GenericDecl* genericDecl)
+PtrTypeBase* ASTBuilder::getPtrType(Type* valueType, GenericDecl* genericDecl)
 {
     auto typeDecl = genericDecl->inner;
 
@@ -187,38 +187,38 @@ RefPtr<PtrTypeBase> ASTBuilder::getPtrType(RefPtr<Type> valueType, GenericDecl* 
     substitutions->genericDecl = genericDecl;
     substitutions->args.add(valueType);
 
-    auto declRef = DeclRef<Decl>(typeDecl.Ptr(), substitutions);
+    auto declRef = DeclRef<Decl>(typeDecl, substitutions);
     auto rsType = DeclRefType::create(this, declRef);
     return as<PtrTypeBase>(rsType);
 }
 
-RefPtr<ArrayExpressionType> ASTBuilder::getArrayType(Type* elementType, IntVal* elementCount)
+ArrayExpressionType* ASTBuilder::getArrayType(Type* elementType, IntVal* elementCount)
 {
-    RefPtr<ArrayExpressionType> arrayType = create<ArrayExpressionType>();
+    ArrayExpressionType* arrayType = create<ArrayExpressionType>();
     arrayType->baseType = elementType;
     arrayType->arrayLength = elementCount;
     return arrayType;
 }
 
-RefPtr<VectorExpressionType> ASTBuilder::getVectorType(
-    RefPtr<Type>    elementType,
-    RefPtr<IntVal>  elementCount)
+VectorExpressionType* ASTBuilder::getVectorType(
+    Type*    elementType,
+    IntVal*  elementCount)
 {
-    auto vectorGenericDecl = m_sharedASTBuilder->findMagicDecl("Vector").as<GenericDecl>();
+    auto vectorGenericDecl = as<GenericDecl>(m_sharedASTBuilder->findMagicDecl("Vector"));
         
     auto vectorTypeDecl = vectorGenericDecl->inner;
 
     auto substitutions = create<GenericSubstitution>();
-    substitutions->genericDecl = vectorGenericDecl.Ptr();
+    substitutions->genericDecl = vectorGenericDecl;
     substitutions->args.add(elementType);
     substitutions->args.add(elementCount);
 
-    auto declRef = DeclRef<Decl>(vectorTypeDecl.Ptr(), substitutions);
+    auto declRef = DeclRef<Decl>(vectorTypeDecl, substitutions);
 
-    return DeclRefType::create(this, declRef).as<VectorExpressionType>();
+    return as<VectorExpressionType>(DeclRefType::create(this, declRef));
 }
 
-RefPtr<TypeType> ASTBuilder::getTypeType(Type* type)
+TypeType* ASTBuilder::getTypeType(Type* type)
 {
     return create<TypeType>(type);
 }

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -6,6 +6,10 @@
 
 namespace Slang {
 
+NodeBase::~NodeBase()
+{
+}
+
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! SharedASTBuilder !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 SharedASTBuilder::SharedASTBuilder()
@@ -150,6 +154,14 @@ ASTBuilder::ASTBuilder(SharedASTBuilder* sharedASTBuilder):
 ASTBuilder::ASTBuilder():
     m_sharedASTBuilder(nullptr)
 {
+}
+
+ASTBuilder::~ASTBuilder()
+{
+    for (NodeBase* node : m_nodes)
+    {
+        node->releaseReference();
+    }
 }
 
 PtrType* ASTBuilder::getPtrType(Type* valueType)

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -160,6 +160,9 @@ public:
         /// Ctor
     ASTBuilder(SharedASTBuilder* sharedASTBuilder);
 
+        /// Dtor
+    ~ASTBuilder();
+
 protected:
     // Special default Ctor that can only be used by SharedASTBuilder
     ASTBuilder();
@@ -169,7 +172,10 @@ protected:
     {
         SLANG_COMPILE_TIME_ASSERT(IsValidType<T>::Value);
 
-        node->init(T::kType, this); 
+        node->init(T::kType, this);
+
+        // Give it a reference, to keep in scope until the ASTBuilder dtors
+        node->addReference();
         m_nodes.add(node);
         return node;
     }

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -15,8 +15,8 @@ class SharedASTBuilder : public RefObject
     friend class ASTBuilder;
 public:
     
-    void registerBuiltinDecl(RefPtr<Decl> decl, RefPtr<BuiltinTypeModifier> modifier);
-    void registerMagicDecl(RefPtr<Decl> decl, RefPtr<MagicTypeModifier> modifier);
+    void registerBuiltinDecl(Decl* decl, BuiltinTypeModifier* modifier);
+    void registerMagicDecl(Decl* decl, MagicTypeModifier* modifier);
 
         /// Get the string type
     Type* getStringType();
@@ -30,7 +30,7 @@ public:
     SyntaxClass<RefObject> findSyntaxClass(const UnownedStringSlice& slice);
 
         // Look up a magic declaration by its name
-    RefPtr<Decl> findMagicDecl(String const& name);
+    Decl* findMagicDecl(String const& name);
 
         /// A name pool that can be used for lookup for findClassInfo etc. It is the same pool as the Session.
     NamePool* getNamePool() { return m_namePool; }
@@ -45,9 +45,9 @@ public:
 protected:
     // State shared between ASTBuilders
 
-    RefPtr<Type> m_errorType;
-    RefPtr<Type> m_initializerListType;
-    RefPtr<Type> m_overloadedType;
+    Type* m_errorType;
+    Type* m_initializerListType;
+    Type* m_overloadedType;
 
     // The following types are created lazily, such that part of their definition
     // can be in the standard library
@@ -57,10 +57,10 @@ protected:
     //
     // TODO(tfoley): These should really belong to the compilation context!
     //
-    RefPtr<Type> m_stringType;
-    RefPtr<Type> m_enumTypeType;
+    Type* m_stringType;
+    Type* m_enumTypeType;
 
-    RefPtr<Type> m_builtinTypes[Index(BaseType::CountOf)];
+    Type* m_builtinTypes[Index(BaseType::CountOf)];
 
     Dictionary<String, Decl*> m_magicDecls;
 
@@ -119,30 +119,30 @@ public:
 
         // Construct the type `Ptr<valueType>`, where `Ptr`
         // is looked up as a builtin type.
-    RefPtr<PtrType> getPtrType(RefPtr<Type> valueType);
+    PtrType* getPtrType(Type* valueType);
 
         // Construct the type `Out<valueType>`
-    RefPtr<OutType> getOutType(RefPtr<Type> valueType);
+    OutType* getOutType(Type* valueType);
 
         // Construct the type `InOut<valueType>`
-    RefPtr<InOutType> getInOutType(RefPtr<Type> valueType);
+    InOutType* getInOutType(Type* valueType);
 
         // Construct the type `Ref<valueType>`
-    RefPtr<RefType> getRefType(RefPtr<Type> valueType);
+    RefType* getRefType(Type* valueType);
 
         // Construct a pointer type like `Ptr<valueType>`, but where
         // the actual type name for the pointer type is given by `ptrTypeName`
-    RefPtr<PtrTypeBase> getPtrType(RefPtr<Type> valueType, char const* ptrTypeName);
+    PtrTypeBase* getPtrType(Type* valueType, char const* ptrTypeName);
 
         // Construct a pointer type like `Ptr<valueType>`, but where
         // the generic declaration for the pointer type is `genericDecl`
-    RefPtr<PtrTypeBase> getPtrType(RefPtr<Type> valueType, GenericDecl* genericDecl);
+    PtrTypeBase* getPtrType(Type* valueType, GenericDecl* genericDecl);
 
-    RefPtr<ArrayExpressionType> getArrayType(Type* elementType, IntVal* elementCount);
+    ArrayExpressionType* getArrayType(Type* elementType, IntVal* elementCount);
 
-    RefPtr<VectorExpressionType> getVectorType(RefPtr<Type> elementType, RefPtr<IntVal> elementCount);
+    VectorExpressionType* getVectorType(Type* elementType, IntVal* elementCount);
 
-    RefPtr<TypeType> getTypeType(Type* type);
+    TypeType* getTypeType(Type* type);
 
         /// Helpers to get type info from the SharedASTBuilder
     const ReflectClassInfo* findClassInfo(const UnownedStringSlice& slice) { return m_sharedASTBuilder->findClassInfo(slice); }

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -2,6 +2,8 @@
 #ifndef SLANG_AST_BUILDER_H
 #define SLANG_AST_BUILDER_H
 
+#include <type_traits>
+
 #include "slang-ast-support-types.h"
 #include "slang-ast-all.h"
 
@@ -180,8 +182,12 @@ protected:
 
         node->init(T::kType, this);
 
-        // Give it a reference, to keep in scope until the ASTBuilder dtors
-        m_nodes.add(node);
+        // Only add it if it has a dtor that does some work
+        if (!std::is_trivially_destructible<T>::value)
+        {
+            // Keep such that dtor can be run on ASTBuilder being dtored
+            m_nodes.add(node);
+        }
         return node;
     }
 

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -89,15 +89,13 @@ public:
         };
     };
 
-        /// Create AST type. 
+        /// Create AST types 
     template <typename T>
-    T* create() { SLANG_COMPILE_TIME_ASSERT(IsValidType<T>::Value);  T* node = new T; node->init(T::kType, this); return node; }
-
+    T* create() { return _initAndAdd(new T); }
     template<typename T, typename P0>
-    T* create(const P0& p0) { SLANG_COMPILE_TIME_ASSERT(IsValidType<T>::Value); T* node = new T(p0); node->init(T::kType, this); return node;}
-
+    T* create(const P0& p0) { return _initAndAdd(new T(p0)); }
     template<typename T, typename P0, typename P1>
-    T* create(const P0& p0, const P1& p1) { SLANG_COMPILE_TIME_ASSERT(IsValidType<T>::Value); T* node = new T(p0, p1); node->init(T::kType, this); return node; }
+    T* create(const P0& p0, const P1& p1) { return _initAndAdd(new T(p0, p1));}
 
         /// Get the built in types
     SLANG_FORCE_INLINE Type* getBoolType() { return m_sharedASTBuilder->m_builtinTypes[Index(BaseType::Bool)]; }
@@ -165,6 +163,19 @@ public:
 protected:
     // Special default Ctor that can only be used by SharedASTBuilder
     ASTBuilder();
+
+    template <typename T>
+    SLANG_FORCE_INLINE T* _initAndAdd(T* node)
+    {
+        SLANG_COMPILE_TIME_ASSERT(IsValidType<T>::Value);
+
+        node->init(T::kType, this); 
+        m_nodes.add(node);
+        return node;
+    }
+
+        /// All of the nodes constructed on this builder
+    List<NodeBase*> m_nodes;
 
     SharedASTBuilder* m_sharedASTBuilder;
 };

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -72,6 +72,8 @@ protected:
     // This is a private builder used for these shared types
     ASTBuilder* m_astBuilder = nullptr;
     Session* m_session = nullptr;
+
+    Index m_id = 1;
 };
 
 class ASTBuilder : public RefObject
@@ -158,7 +160,7 @@ public:
     Session* getGlobalSession() { return m_sharedASTBuilder->m_session; }
 
         /// Ctor
-    ASTBuilder(SharedASTBuilder* sharedASTBuilder);
+    ASTBuilder(SharedASTBuilder* sharedASTBuilder, const String& name);
 
         /// Dtor
     ~ASTBuilder();
@@ -179,6 +181,9 @@ protected:
         m_nodes.add(node);
         return node;
     }
+
+    String m_name;
+    Index m_id;
 
         /// All of the nodes constructed on this builder
     List<NodeBase*> m_nodes;

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -45,9 +45,9 @@ public:
 protected:
     // State shared between ASTBuilders
 
-    Type* m_errorType;
-    Type* m_initializerListType;
-    Type* m_overloadedType;
+    Type* m_errorType = nullptr;
+    Type* m_initializerListType = nullptr;
+    Type* m_overloadedType = nullptr;
 
     // The following types are created lazily, such that part of their definition
     // can be in the standard library
@@ -57,8 +57,8 @@ protected:
     //
     // TODO(tfoley): These should really belong to the compilation context!
     //
-    Type* m_stringType;
-    Type* m_enumTypeType;
+    Type* m_stringType = nullptr;
+    Type* m_enumTypeType = nullptr;
 
     Type* m_builtinTypes[Index(BaseType::CountOf)];
 

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -13,7 +13,7 @@ class DeclGroup: public DeclBase
 {
     SLANG_CLASS(DeclGroup)
 
-    List<RefPtr<Decl>> decls;
+    List<Decl*> decls;
 };
 
 
@@ -22,7 +22,7 @@ class ContainerDecl: public Decl
 {
     SLANG_ABSTRACT_CLASS(ContainerDecl)
 
-    List<RefPtr<Decl>> members;
+    List<Decl*> members;
 
     template<typename T>
     FilteredMemberList<T> getMembersOfType()
@@ -59,10 +59,10 @@ class VarDeclBase : public Decl
     // type of the variable
     TypeExp type;
 
-    Type* getType() { return (Type*)type.type.Ptr(); }
+    Type* getType() { return type.type; }
 
     // Initializer expression (optional)
-    RefPtr<Expr> initExpr;
+    Expr* initExpr;
 };
 
 // Ordinary potentially-mutable variables (locals, globals, and member variables)
@@ -135,7 +135,7 @@ class EnumDecl : public AggTypeDecl
 {
     SLANG_CLASS(EnumDecl)
 
-    RefPtr<Type> tagType;
+    Type* tagType;
 };
 
 // A single case in an enum.
@@ -155,10 +155,10 @@ class EnumCaseDecl : public Decl
     // type of the parent `enum`
     TypeExp type;
 
-    Type* getType() { return type.type.Ptr(); }
+    Type* getType() { return type.type; }
 
     // Tag value
-    RefPtr<Expr> tagExpr;
+    Expr* tagExpr;
 };
 
 // An interface which other types can conform to
@@ -294,7 +294,7 @@ class FunctionDeclBase : public CallableDecl
 {
     SLANG_ABSTRACT_CLASS(FunctionDeclBase)
 
-    RefPtr<Stmt> body;
+    Stmt* body;
 };
 
 // A constructor/initializer to create instances of a type
@@ -376,7 +376,7 @@ class ImportDecl : public Decl
     RefPtr<Scope> scope;
 
     // The module that actually got imported
-    RefPtr<ModuleDecl> importedModuleDecl;
+    ModuleDecl* importedModuleDecl;
 };
 
 // A generic declaration, parameterized on types/values
@@ -384,7 +384,7 @@ class GenericDecl : public ContainerDecl
 {
     SLANG_CLASS(GenericDecl)
     // The decl that is genericized...
-    RefPtr<Decl> inner;
+    Decl* inner;
 };
 
 class GenericTypeParamDecl : public SimpleTypeDecl

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -441,7 +441,7 @@ class SyntaxDecl : public Decl
     SLANG_CLASS(SyntaxDecl)
 
     // What type of syntax node will be produced when parsing with this keyword?
-    SyntaxClass<RefObject> syntaxClass;
+    SyntaxClass<NodeBase> syntaxClass;
 
     SLANG_UNREFLECTED
 
@@ -456,7 +456,7 @@ class AttributeDecl : public ContainerDecl
 {
     SLANG_CLASS(AttributeDecl)
     // What type of syntax node will be produced to represent this attribute.
-    SyntaxClass<RefObject> syntaxClass;
+    SyntaxClass<NodeBase> syntaxClass;
 };
 
 } // namespace Slang

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -62,7 +62,7 @@ class VarDeclBase : public Decl
     Type* getType() { return type.type; }
 
     // Initializer expression (optional)
-    Expr* initExpr;
+    Expr* initExpr = nullptr;
 };
 
 // Ordinary potentially-mutable variables (locals, globals, and member variables)
@@ -135,7 +135,7 @@ class EnumDecl : public AggTypeDecl
 {
     SLANG_CLASS(EnumDecl)
 
-    Type* tagType;
+    Type* tagType = nullptr;
 };
 
 // A single case in an enum.
@@ -158,7 +158,7 @@ class EnumCaseDecl : public Decl
     Type* getType() { return type.type; }
 
     // Tag value
-    Expr* tagExpr;
+    Expr* tagExpr = nullptr;
 };
 
 // An interface which other types can conform to
@@ -294,7 +294,7 @@ class FunctionDeclBase : public CallableDecl
 {
     SLANG_ABSTRACT_CLASS(FunctionDeclBase)
 
-    Stmt* body;
+    Stmt* body = nullptr;
 };
 
 // A constructor/initializer to create instances of a type
@@ -376,7 +376,7 @@ class ImportDecl : public Decl
     RefPtr<Scope> scope;
 
     // The module that actually got imported
-    ModuleDecl* importedModuleDecl;
+    ModuleDecl* importedModuleDecl = nullptr;
 };
 
 // A generic declaration, parameterized on types/values
@@ -384,7 +384,7 @@ class GenericDecl : public ContainerDecl
 {
     SLANG_CLASS(GenericDecl)
     // The decl that is genericized...
-    Decl* inner;
+    Decl* inner = nullptr;
 };
 
 class GenericTypeParamDecl : public SimpleTypeDecl

--- a/source/slang/slang-ast-dump.cpp
+++ b/source/slang/slang-ast-dump.cpp
@@ -17,7 +17,7 @@ struct Context
     struct ObjectInfo
     {
         const ReflectClassInfo* m_typeInfo;
-        RefObject* m_object;
+        NodeBase* m_object;
         bool m_isDumped;
     };
 
@@ -48,10 +48,10 @@ struct Context
         Context* m_context;
     };
 
-    void dumpObject(const ReflectClassInfo& type, RefObject* obj);
+    void dumpObject(const ReflectClassInfo& type, NodeBase* obj);
 
-    void dumpObjectFull(const ReflectClassInfo& type, RefObject* obj, Index objIndex);
-    void dumpObjectReference(const ReflectClassInfo& type, RefObject* obj, Index objIndex);
+    void dumpObjectFull(const ReflectClassInfo& type, NodeBase* obj, Index objIndex);
+    void dumpObjectReference(const ReflectClassInfo& type, NodeBase* obj, Index objIndex);
 
     void dump(NodeBase* node)
     {
@@ -264,7 +264,7 @@ struct Context
         m_writer->emit(" }");
     }
 
-    Index getObjectIndex(const ReflectClassInfo& typeInfo, RefObject* obj)
+    Index getObjectIndex(const ReflectClassInfo& typeInfo, NodeBase* obj)
     {
         Index* indexPtr = m_objectMap.TryGetValueOrAdd(obj, m_objects.getCount());
         if (indexPtr)
@@ -576,7 +576,7 @@ struct Context
     // Using the SourceWriter, for automatic indentation.
     SourceWriter* m_writer;
 
-    Dictionary<RefObject*, Index> m_objectMap;  ///< Object index
+    Dictionary<NodeBase*, Index> m_objectMap;  ///< Object index
     List<ObjectInfo> m_objects;
 
     StringBuilder m_buf;
@@ -605,7 +605,7 @@ SLANG_ALL_ASTNode_NodeBase(SLANG_AST_DUMP_FIELDS_IMPL, _)
 
 #define SLANG_AST_GET_DUMP_FUNC(NAME, SUPER, ORIGIN, LAST, MARKER, TYPE, param) m_funcs[Index(ASTNodeType::NAME)] = (DumpFieldsFunc)&ASTDumpAccess::dumpFields_##NAME;
 
-typedef void (*DumpFieldsFunc)(RefObject* obj, Context& context);
+typedef void (*DumpFieldsFunc)(NodeBase* obj, Context& context);
 
 struct DumpFieldFuncs
 {
@@ -620,13 +620,13 @@ struct DumpFieldFuncs
 
 static const DumpFieldFuncs s_funcs;
 
-void Context::dumpObjectReference(const ReflectClassInfo& type, RefObject* obj, Index objIndex)
+void Context::dumpObjectReference(const ReflectClassInfo& type, NodeBase* obj, Index objIndex)
 {
     SLANG_UNUSED(obj);
     ScopeWrite(this).getBuf() << type.m_name << ":" << objIndex;
 }
 
-void Context::dumpObjectFull(const ReflectClassInfo& type, RefObject* obj, Index objIndex)
+void Context::dumpObjectFull(const ReflectClassInfo& type, NodeBase* obj, Index objIndex)
 {
     ObjectInfo& info = m_objects[objIndex];
     SLANG_ASSERT(info.m_isDumped == false);
@@ -662,7 +662,7 @@ void Context::dumpObjectFull(const ReflectClassInfo& type, RefObject* obj, Index
     m_writer->emit("}\n");
 }
 
-void Context::dumpObject(const ReflectClassInfo& typeInfo, RefObject* obj)
+void Context::dumpObject(const ReflectClassInfo& typeInfo, NodeBase* obj)
 {
     Index index = getObjectIndex(typeInfo, obj);
 

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -39,7 +39,7 @@ class OverloadedExpr : public Expr
 
     // Optional: the base expression is this overloaded result
     // arose from a member-reference expression.
-    RefPtr<Expr> base;
+    Expr* base;
 
     // The lookup result that was ambiguous
     LookupResult lookupResult2;
@@ -53,10 +53,10 @@ class OverloadedExpr2: public Expr
 
     // Optional: the base expression is this overloaded result
     // arose from a member-reference expression.
-    RefPtr<Expr> base;
+    Expr* base;
 
     // The lookup result that was ambiguous
-    List<RefPtr<Expr>> candidiateExprs;
+    List<Expr*> candidiateExprs;
 };
 
 class LiteralExpr : public Expr
@@ -103,7 +103,7 @@ class StringLiteralExpr : public LiteralExpr
 class InitializerListExpr : public Expr
 {
     SLANG_CLASS(InitializerListExpr)
-    List<RefPtr<Expr>> args;
+    List<Expr*> args;
 };
 
 // A base class for expressions with arguments
@@ -111,7 +111,7 @@ class ExprWithArgsBase : public Expr
 {
     SLANG_ABSTRACT_CLASS(ExprWithArgsBase)
 
-    List<RefPtr<Expr>> arguments;
+    List<Expr*> arguments;
 };
 
 // An aggregate type constructor
@@ -129,7 +129,7 @@ class AppExprBase : public ExprWithArgsBase
 {
     SLANG_ABSTRACT_CLASS(AppExprBase)
 
-    RefPtr<Expr> functionExpr;
+    Expr* functionExpr;
 };
 
 class InvokeExpr: public AppExprBase
@@ -159,21 +159,21 @@ class IndexExpr: public Expr
 {
     SLANG_CLASS(IndexExpr)
 
-    RefPtr<Expr> baseExpression;
-    RefPtr<Expr> indexExpression;
+    Expr* baseExpression;
+    Expr* indexExpression;
 };
 
 class MemberExpr: public DeclRefExpr
 {
     SLANG_CLASS(MemberExpr)
-    RefPtr<Expr> baseExpression;
+    Expr* baseExpression;
 };
 
 // Member looked up on a type, rather than a value
 class StaticMemberExpr: public DeclRefExpr
 {
     SLANG_CLASS(StaticMemberExpr)
-    RefPtr<Expr> baseExpression;
+    Expr* baseExpression;
 };
 
 struct MatrixCoord
@@ -188,7 +188,7 @@ struct MatrixCoord
 class MatrixSwizzleExpr : public Expr
 {
     SLANG_CLASS(MatrixSwizzleExpr)
-    RefPtr<Expr> base;
+    Expr* base;
     int elementCount;
     MatrixCoord elementCoords[4];
 };
@@ -196,7 +196,7 @@ class MatrixSwizzleExpr : public Expr
 class SwizzleExpr: public Expr
 {
     SLANG_CLASS(SwizzleExpr)
-    RefPtr<Expr> base;
+    Expr* base;
     int elementCount;
     int elementIndices[4];
 };
@@ -205,7 +205,7 @@ class SwizzleExpr: public Expr
 class DerefExpr: public Expr
 {
     SLANG_CLASS(DerefExpr)
-    RefPtr<Expr> base;
+    Expr* base;
 };
 
 // Any operation that performs type-casting
@@ -213,7 +213,7 @@ class TypeCastExpr: public InvokeExpr
 {
     SLANG_CLASS(TypeCastExpr)
 //    TypeExp TargetType;
-//    RefPtr<Expr> Expression;
+//    Expr* Expression;
 };
 
 // An explicit type-cast that appear in the user's code with `(type) expr` syntax
@@ -234,10 +234,10 @@ class CastToInterfaceExpr: public Expr
     SLANG_CLASS(CastToInterfaceExpr)
 
         /// The value being cast to an interface type
-    RefPtr<Expr>    valueArg;
+    Expr*    valueArg;
 
         /// A witness showing that `valueArg` conforms to the chosen interface
-    RefPtr<Val>     witnessArg;
+    Val*     witnessArg;
 };
 
 class SelectExpr: public OperatorExpr
@@ -262,8 +262,8 @@ class SharedTypeExpr: public Expr
 class AssignExpr: public Expr
 {
     SLANG_CLASS(AssignExpr)
-    RefPtr<Expr> left;
-    RefPtr<Expr> right;
+    Expr* left;
+    Expr* right;
 };
 
 // Just an expression inside parentheses `(exp)`
@@ -273,7 +273,7 @@ class AssignExpr: public Expr
 class ParenExpr: public Expr
 {
     SLANG_CLASS(ParenExpr)
-    RefPtr<Expr> base;
+    Expr* base;
 };
 
 // An object-oriented `this` expression, used to
@@ -288,8 +288,8 @@ class ThisExpr: public Expr
 class LetExpr: public Expr
 {
     SLANG_CLASS(LetExpr)
-    RefPtr<VarDecl> decl;
-    RefPtr<Expr> body;
+    VarDecl* decl;
+    Expr* body;
 };
 
 class ExtractExistentialValueExpr: public Expr

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -39,7 +39,7 @@ class OverloadedExpr : public Expr
 
     // Optional: the base expression is this overloaded result
     // arose from a member-reference expression.
-    Expr* base;
+    Expr* base = nullptr;
 
     // The lookup result that was ambiguous
     LookupResult lookupResult2;
@@ -53,7 +53,7 @@ class OverloadedExpr2: public Expr
 
     // Optional: the base expression is this overloaded result
     // arose from a member-reference expression.
-    Expr* base;
+    Expr* base = nullptr;
 
     // The lookup result that was ambiguous
     List<Expr*> candidiateExprs;
@@ -129,7 +129,7 @@ class AppExprBase : public ExprWithArgsBase
 {
     SLANG_ABSTRACT_CLASS(AppExprBase)
 
-    Expr* functionExpr;
+    Expr* functionExpr = nullptr;
 };
 
 class InvokeExpr: public AppExprBase
@@ -159,21 +159,21 @@ class IndexExpr: public Expr
 {
     SLANG_CLASS(IndexExpr)
 
-    Expr* baseExpression;
-    Expr* indexExpression;
+    Expr* baseExpression = nullptr;
+    Expr* indexExpression = nullptr;
 };
 
 class MemberExpr: public DeclRefExpr
 {
     SLANG_CLASS(MemberExpr)
-    Expr* baseExpression;
+    Expr* baseExpression = nullptr;
 };
 
 // Member looked up on a type, rather than a value
 class StaticMemberExpr: public DeclRefExpr
 {
     SLANG_CLASS(StaticMemberExpr)
-    Expr* baseExpression;
+    Expr* baseExpression = nullptr;
 };
 
 struct MatrixCoord
@@ -188,7 +188,7 @@ struct MatrixCoord
 class MatrixSwizzleExpr : public Expr
 {
     SLANG_CLASS(MatrixSwizzleExpr)
-    Expr* base;
+    Expr* base = nullptr;
     int elementCount;
     MatrixCoord elementCoords[4];
 };
@@ -196,7 +196,7 @@ class MatrixSwizzleExpr : public Expr
 class SwizzleExpr: public Expr
 {
     SLANG_CLASS(SwizzleExpr)
-    Expr* base;
+    Expr* base = nullptr;
     int elementCount;
     int elementIndices[4];
 };
@@ -205,7 +205,7 @@ class SwizzleExpr: public Expr
 class DerefExpr: public Expr
 {
     SLANG_CLASS(DerefExpr)
-    Expr* base;
+    Expr* base = nullptr;
 };
 
 // Any operation that performs type-casting
@@ -213,7 +213,7 @@ class TypeCastExpr: public InvokeExpr
 {
     SLANG_CLASS(TypeCastExpr)
 //    TypeExp TargetType;
-//    Expr* Expression;
+//    Expr* Expression = nullptr;
 };
 
 // An explicit type-cast that appear in the user's code with `(type) expr` syntax
@@ -234,10 +234,10 @@ class CastToInterfaceExpr: public Expr
     SLANG_CLASS(CastToInterfaceExpr)
 
         /// The value being cast to an interface type
-    Expr*    valueArg;
+    Expr*    valueArg = nullptr;
 
         /// A witness showing that `valueArg` conforms to the chosen interface
-    Val*     witnessArg;
+    Val*     witnessArg = nullptr;
 };
 
 class SelectExpr: public OperatorExpr
@@ -262,8 +262,8 @@ class SharedTypeExpr: public Expr
 class AssignExpr: public Expr
 {
     SLANG_CLASS(AssignExpr)
-    Expr* left;
-    Expr* right;
+    Expr* left = nullptr;
+    Expr* right = nullptr;
 };
 
 // Just an expression inside parentheses `(exp)`
@@ -273,7 +273,7 @@ class AssignExpr: public Expr
 class ParenExpr: public Expr
 {
     SLANG_CLASS(ParenExpr)
-    Expr* base;
+    Expr* base = nullptr;
 };
 
 // An object-oriented `this` expression, used to
@@ -288,8 +288,8 @@ class ThisExpr: public Expr
 class LetExpr: public Expr
 {
     SLANG_CLASS(LetExpr)
-    VarDecl* decl;
-    Expr* body;
+    VarDecl* decl = nullptr;
+    Expr* body = nullptr;
 };
 
 class ExtractExistentialValueExpr: public Expr

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -668,7 +668,7 @@ class PatchConstantFuncAttribute : public Attribute
 {
     SLANG_CLASS(PatchConstantFuncAttribute)
  
-    FuncDecl* patchConstantFuncDecl;
+    FuncDecl* patchConstantFuncDecl = nullptr;
 };
 class DomainAttribute : public Attribute 
 {

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -511,7 +511,7 @@ class AttributeTargetModifier : public Modifier
     SLANG_CLASS(AttributeTargetModifier)
  
     // A class to which the declared attribute type is applicable
-    SyntaxClass<RefObject> syntaxClass;
+    SyntaxClass<NodeBase> syntaxClass;
 };
 
 // Base class for checked and unchecked `[name(arg0, ...)]` style attribute.
@@ -549,7 +549,7 @@ class AttributeUsageAttribute : public Attribute
 {
     SLANG_CLASS(AttributeUsageAttribute)
  
-    SyntaxClass<RefObject> targetSyntaxClass;
+    SyntaxClass<NodeBase> targetSyntaxClass;
 };
 
 // An `[unroll]` or `[unroll(count)]` attribute

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -519,7 +519,7 @@ class AttributeBase : public Modifier
 {
     SLANG_CLASS(AttributeBase)
  
-    List<RefPtr<Expr>> args;
+    List<Expr*> args;
 };
 
 // A `[name(...)]` attribute that hasn't undergone any semantic analysis.
@@ -668,7 +668,7 @@ class PatchConstantFuncAttribute : public Attribute
 {
     SLANG_CLASS(PatchConstantFuncAttribute)
  
-    RefPtr<FuncDecl> patchConstantFuncDecl;
+    FuncDecl* patchConstantFuncDecl;
 };
 class DomainAttribute : public Attribute 
 {

--- a/source/slang/slang-ast-reflect.cpp
+++ b/source/slang/slang-ast-reflect.cpp
@@ -54,6 +54,8 @@ struct ASTConstructAccess
         }
         static void destroy(void* ptr)
         {
+            // Needed because if type has non dtor, Visual Studio claims ptr not used
+            SLANG_UNUSED(ptr);
             reinterpret_cast<T*>(ptr)->~T();
         }
     };

--- a/source/slang/slang-ast-reflect.h
+++ b/source/slang/slang-ast-reflect.h
@@ -5,16 +5,20 @@
 
 #include "slang-ast-generated.h"
 
+#define SLANG_CLASS_REFLECT_SUPER_BASE(SUPER)
+#define SLANG_CLASS_REFLECT_SUPER_INNER(SUPER) typedef SUPER Super;
+#define SLANG_CLASS_REFLECT_SUPER_LEAF(SUPER) typedef SUPER Super;
+
 // Implementation for SLANG_ABSTRACT_CLASS(x) using reflection from C++ extractor in slang-ast-generated.h
 #define SLANG_CLASS_REFLECT_IMPL(NAME, SUPER, ORIGIN, LAST, MARKER, TYPE, param) \
     protected: \
     NAME() = default; \
     public:     \
     typedef NAME This; \
-    typedef SUPER Super; \
     static const ASTNodeType kType = ASTNodeType::NAME; \
     static const ReflectClassInfo kReflectClassInfo;  \
     SLANG_FORCE_INLINE static bool isDerivedFrom(ASTNodeType type) { return int(type) >= int(kType) && int(type) <= int(ASTNodeType::LAST); } \
+    SLANG_CLASS_REFLECT_SUPER_##TYPE(SUPER) \
     friend class ASTBuilder; \
     friend struct ASTConstructAccess;
 
@@ -27,6 +31,8 @@
 #define SLANG_REFLECT_BASE_CLASS(NAME)
 #define SLANG_REFLECTED
 #define SLANG_UNREFLECTED
+
+#define SLANG_CLASS_ROOT
 
 // Macros for simulating virtual methods without virtual methods
 

--- a/source/slang/slang-ast-stmt.h
+++ b/source/slang/slang-ast-stmt.h
@@ -12,7 +12,7 @@ class ScopeStmt : public Stmt
 {
     SLANG_ABSTRACT_CLASS(ScopeStmt)
 
-    RefPtr<ScopeDecl> scopeDecl;
+    ScopeDecl* scopeDecl;
 };
 
 // A sequence of statements, treated as a single statement
@@ -20,7 +20,7 @@ class SeqStmt : public Stmt
 {
     SLANG_CLASS(SeqStmt)
 
-    List<RefPtr<Stmt>> stmts;
+    List<Stmt*> stmts;
 };
 
 // The simplest kind of scope statement: just a `{...}` block
@@ -28,7 +28,7 @@ class BlockStmt : public ScopeStmt
 {
     SLANG_CLASS(BlockStmt)
 
-    RefPtr<Stmt> body;
+    Stmt* body;
 };
 
 // A statement that we aren't going to parse or check, because
@@ -55,16 +55,16 @@ class DeclStmt : public Stmt
 {
     SLANG_CLASS(DeclStmt)
 
-    RefPtr<DeclBase> decl;
+    DeclBase* decl;
 };
 
 class IfStmt : public Stmt 
 {
     SLANG_CLASS(IfStmt)
 
-    RefPtr<Expr> predicate;
-    RefPtr<Stmt> positiveStatement;
-    RefPtr<Stmt> negativeStatement;
+    Expr* predicate;
+    Stmt* positiveStatement;
+    Stmt* negativeStatement;
 };
 
 // A statement that can be escaped with a `break`
@@ -78,8 +78,8 @@ class SwitchStmt : public BreakableStmt
 {
     SLANG_CLASS(SwitchStmt)
 
-    RefPtr<Expr> condition;
-    RefPtr<Stmt> body;
+    Expr* condition;
+    Stmt* body;
 };
 
 // A statement that is expected to appear lexically nested inside
@@ -108,7 +108,7 @@ class CaseStmt : public CaseStmtBase
 {
     SLANG_CLASS(CaseStmt)
 
-    RefPtr<Expr> expr;
+    Expr* expr;
 };
 
 // a `default` statement inside a `switch`
@@ -129,10 +129,10 @@ class ForStmt : public LoopStmt
 {
     SLANG_CLASS(ForStmt)
 
-    RefPtr<Stmt> initialStatement;
-    RefPtr<Expr> sideEffectExpression;
-    RefPtr<Expr> predicateExpression;
-    RefPtr<Stmt> statement;
+    Stmt* initialStatement;
+    Expr* sideEffectExpression;
+    Expr* predicateExpression;
+    Stmt* statement;
 };
 
 // A `for` statement in a language that doesn't restrict the scope
@@ -147,16 +147,16 @@ class WhileStmt : public LoopStmt
 {
     SLANG_CLASS(WhileStmt)
 
-    RefPtr<Expr> predicate;
-    RefPtr<Stmt> statement;
+    Expr* predicate;
+    Stmt* statement;
 };
 
 class DoWhileStmt : public LoopStmt 
 {
     SLANG_CLASS(DoWhileStmt)
 
-    RefPtr<Stmt> statement;
-    RefPtr<Expr> predicate;
+    Stmt* statement;
+    Expr* predicate;
 };
 
 // A compile-time, range-based `for` loop, which will not appear in the output code
@@ -164,12 +164,12 @@ class CompileTimeForStmt : public ScopeStmt
 {
     SLANG_CLASS(CompileTimeForStmt)
 
-    RefPtr<VarDecl> varDecl;
-    RefPtr<Expr> rangeBeginExpr;
-    RefPtr<Expr> rangeEndExpr;
-    RefPtr<Stmt> body;
-    RefPtr<IntVal> rangeBeginVal;
-    RefPtr<IntVal> rangeEndVal;
+    VarDecl* varDecl;
+    Expr* rangeBeginExpr;
+    Expr* rangeEndExpr;
+    Stmt* body;
+    IntVal* rangeBeginVal;
+    IntVal* rangeEndVal;
 };
 
 // The case of child statements that do control flow relative
@@ -193,14 +193,14 @@ class ReturnStmt : public Stmt
 {
     SLANG_CLASS(ReturnStmt)
 
-    RefPtr<Expr> expression;
+    Expr* expression;
 };
 
 class ExpressionStmt : public Stmt 
 {
     SLANG_CLASS(ExpressionStmt)
 
-    RefPtr<Expr> expression;
+    Expr* expression;
 };
 
 } // namespace Slang

--- a/source/slang/slang-ast-stmt.h
+++ b/source/slang/slang-ast-stmt.h
@@ -12,7 +12,7 @@ class ScopeStmt : public Stmt
 {
     SLANG_ABSTRACT_CLASS(ScopeStmt)
 
-    ScopeDecl* scopeDecl;
+    ScopeDecl* scopeDecl = nullptr;
 };
 
 // A sequence of statements, treated as a single statement
@@ -28,7 +28,7 @@ class BlockStmt : public ScopeStmt
 {
     SLANG_CLASS(BlockStmt)
 
-    Stmt* body;
+    Stmt* body = nullptr;
 };
 
 // A statement that we aren't going to parse or check, because
@@ -55,16 +55,16 @@ class DeclStmt : public Stmt
 {
     SLANG_CLASS(DeclStmt)
 
-    DeclBase* decl;
+    DeclBase* decl = nullptr;
 };
 
 class IfStmt : public Stmt 
 {
     SLANG_CLASS(IfStmt)
 
-    Expr* predicate;
-    Stmt* positiveStatement;
-    Stmt* negativeStatement;
+    Expr* predicate = nullptr;
+    Stmt* positiveStatement = nullptr;
+    Stmt* negativeStatement = nullptr;
 };
 
 // A statement that can be escaped with a `break`
@@ -78,8 +78,8 @@ class SwitchStmt : public BreakableStmt
 {
     SLANG_CLASS(SwitchStmt)
 
-    Expr* condition;
-    Stmt* body;
+    Expr* condition = nullptr;
+    Stmt* body = nullptr;
 };
 
 // A statement that is expected to appear lexically nested inside
@@ -108,7 +108,7 @@ class CaseStmt : public CaseStmtBase
 {
     SLANG_CLASS(CaseStmt)
 
-    Expr* expr;
+    Expr* expr = nullptr;
 };
 
 // a `default` statement inside a `switch`
@@ -129,10 +129,10 @@ class ForStmt : public LoopStmt
 {
     SLANG_CLASS(ForStmt)
 
-    Stmt* initialStatement;
-    Expr* sideEffectExpression;
-    Expr* predicateExpression;
-    Stmt* statement;
+    Stmt* initialStatement = nullptr;
+    Expr* sideEffectExpression = nullptr;
+    Expr* predicateExpression = nullptr;
+    Stmt* statement = nullptr;
 };
 
 // A `for` statement in a language that doesn't restrict the scope
@@ -147,16 +147,16 @@ class WhileStmt : public LoopStmt
 {
     SLANG_CLASS(WhileStmt)
 
-    Expr* predicate;
-    Stmt* statement;
+    Expr* predicate = nullptr;
+    Stmt* statement = nullptr;
 };
 
 class DoWhileStmt : public LoopStmt 
 {
     SLANG_CLASS(DoWhileStmt)
 
-    Stmt* statement;
-    Expr* predicate;
+    Stmt* statement = nullptr;
+    Expr* predicate = nullptr;
 };
 
 // A compile-time, range-based `for` loop, which will not appear in the output code
@@ -164,12 +164,12 @@ class CompileTimeForStmt : public ScopeStmt
 {
     SLANG_CLASS(CompileTimeForStmt)
 
-    VarDecl* varDecl;
-    Expr* rangeBeginExpr;
-    Expr* rangeEndExpr;
-    Stmt* body;
-    IntVal* rangeBeginVal;
-    IntVal* rangeEndVal;
+    VarDecl* varDecl = nullptr;
+    Expr* rangeBeginExpr = nullptr;
+    Expr* rangeEndExpr = nullptr;
+    Stmt* body = nullptr;
+    IntVal* rangeBeginVal = nullptr;
+    IntVal* rangeEndVal = nullptr;
 };
 
 // The case of child statements that do control flow relative
@@ -193,14 +193,14 @@ class ReturnStmt : public Stmt
 {
     SLANG_CLASS(ReturnStmt)
 
-    Expr* expression;
+    Expr* expression = nullptr;
 };
 
 class ExpressionStmt : public Stmt 
 {
     SLANG_CLASS(ExpressionStmt)
 
-    Expr* expression;
+    Expr* expression = nullptr;
 };
 
 } // namespace Slang

--- a/source/slang/slang-ast-substitutions.cpp
+++ b/source/slang/slang-ast-substitutions.cpp
@@ -8,7 +8,7 @@ namespace Slang {
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Substitutions !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-RefPtr<Substitutions> Substitutions::applySubstitutionsShallow(ASTBuilder* astBuilder, SubstitutionSet substSet, RefPtr<Substitutions> substOuter, int* ioDiff)
+Substitutions* Substitutions::applySubstitutionsShallow(ASTBuilder* astBuilder, SubstitutionSet substSet, Substitutions* substOuter, int* ioDiff)
 {
     SLANG_AST_NODE_VIRTUAL_CALL(Substitutions, applySubstitutionsShallow, (astBuilder, substSet, substOuter, ioDiff))
 }
@@ -23,14 +23,14 @@ HashCode Substitutions::getHashCode() const
     SLANG_AST_NODE_CONST_VIRTUAL_CALL(Substitutions, getHashCode, ())
 }
 
-RefPtr<Substitutions> Substitutions::_applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, RefPtr<Substitutions> substOuter, int* ioDiff)
+Substitutions* Substitutions::_applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, Substitutions* substOuter, int* ioDiff)
 {
     SLANG_UNUSED(astBuilder);
     SLANG_UNUSED(substSet);
     SLANG_UNUSED(substOuter);
     SLANG_UNUSED(ioDiff);
     SLANG_UNEXPECTED("Substitutions::_applySubstitutionsShallowOverride not overridden");
-    //return RefPtr<Substitutions>();
+    //return Substitutions*();
 }
 
 bool Substitutions::_equalsOverride(Substitutions* subst)
@@ -48,13 +48,13 @@ HashCode Substitutions::_getHashCodeOverride() const
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! GenericSubstitution !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-RefPtr<Substitutions> GenericSubstitution::_applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, RefPtr<Substitutions> substOuter, int* ioDiff)
+Substitutions* GenericSubstitution::_applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, Substitutions* substOuter, int* ioDiff)
 {
     int diff = 0;
 
     if (substOuter != outer) diff++;
 
-    List<RefPtr<Val>> substArgs;
+    List<Val*> substArgs;
     for (auto a : args)
     {
         substArgs.add(a->substituteImpl(astBuilder, substSet, &diff));
@@ -88,14 +88,14 @@ bool GenericSubstitution::_equalsOverride(Substitutions* subst)
     SLANG_RELEASE_ASSERT(args.getCount() == genericSubst->args.getCount());
     for (Index aa = 0; aa < argCount; ++aa)
     {
-        if (!args[aa]->equalsVal(genericSubst->args[aa].Ptr()))
+        if (!args[aa]->equalsVal(genericSubst->args[aa]))
             return false;
     }
 
     if (!outer)
         return !genericSubst->outer;
 
-    if (!outer->equals(genericSubst->outer.Ptr()))
+    if (!outer->equals(genericSubst->outer))
         return false;
 
     return true;
@@ -114,14 +114,14 @@ HashCode GenericSubstitution::_getHashCodeOverride() const
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! ThisTypeSubstitution !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-RefPtr<Substitutions> ThisTypeSubstitution::_applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, RefPtr<Substitutions> substOuter, int* ioDiff)
+Substitutions* ThisTypeSubstitution::_applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, Substitutions* substOuter, int* ioDiff)
 {
     int diff = 0;
 
     if (substOuter != outer) diff++;
 
     // NOTE: Must use .as because we must have a smart pointer here to keep in scope.
-    auto substWitness = witness->substituteImpl(astBuilder, substSet, &diff).as<SubtypeWitness>();
+    auto substWitness = as<SubtypeWitness>(witness->substituteImpl(astBuilder, substSet, &diff));
 
     if (!diff) return this;
 
@@ -165,7 +165,7 @@ HashCode ThisTypeSubstitution::_getHashCodeOverride() const
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! GlobalGenericParamSubstitution !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-RefPtr<Substitutions> GlobalGenericParamSubstitution::_applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, RefPtr<Substitutions> substOuter, int* ioDiff)
+Substitutions* GlobalGenericParamSubstitution::_applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, Substitutions* substOuter, int* ioDiff)
 {
     // if we find a GlobalGenericParamSubstitution in subst that references the same type_param decl
     // return a copy of that GlobalGenericParamSubstitution
@@ -173,7 +173,7 @@ RefPtr<Substitutions> GlobalGenericParamSubstitution::_applySubstitutionsShallow
 
     if (substOuter != outer) diff++;
 
-    auto substActualType = actualType->substituteImpl(astBuilder, substSet, &diff).as<Type>();
+    auto substActualType = as<Type>(actualType->substituteImpl(astBuilder, substSet, &diff));
 
     List<ConstraintArg> substConstraintArgs;
     for (auto constraintArg : constraintArgs)
@@ -190,7 +190,7 @@ RefPtr<Substitutions> GlobalGenericParamSubstitution::_applySubstitutionsShallow
 
     (*ioDiff)++;
 
-    RefPtr<GlobalGenericParamSubstitution> substSubst = astBuilder->create<GlobalGenericParamSubstitution>();
+    GlobalGenericParamSubstitution* substSubst = astBuilder->create<GlobalGenericParamSubstitution>();
     substSubst->paramDecl = paramDecl;
     substSubst->actualType = substActualType;
     substSubst->constraintArgs = substConstraintArgs;

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -53,7 +53,7 @@ namespace Slang
     SourceLoc const& getDiagnosticPos(SyntaxNode const* syntax);
     SourceLoc const& getDiagnosticPos(TypeExp const& typeExp);
 
-    typedef RefPtr<RefObject> (*SyntaxParseCallback)(Parser* parser, void* userData);
+    typedef NodeBase* (*SyntaxParseCallback)(Parser* parser, void* userData);
 
     typedef unsigned int ConversionCost;
     enum : ConversionCost

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -45,6 +45,13 @@ namespace Slang
 
     class NodeBase;
 
+
+    template <typename T>
+    T* as(NodeBase* node);
+
+    template <typename T>
+    const T* as(const NodeBase* node);
+
     void printDiagnosticArg(StringBuilder& sb, Decl* decl);
     void printDiagnosticArg(StringBuilder& sb, Type* type);
     void printDiagnosticArg(StringBuilder& sb, TypeExp const& type);
@@ -276,7 +283,7 @@ namespace Slang
         Modifier* first = nullptr;
 
         template<typename T>
-        FilteredModifierList<T> getModifiersOfType() { return FilteredModifierList<T>(first.Ptr()); }
+        FilteredModifierList<T> getModifiersOfType() { return FilteredModifierList<T>(first); }
 
         // Find the first modifier of a given type, or return `nullptr` if none is found.
         template<typename T>

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -271,7 +271,7 @@ namespace Slang
     struct Modifiers
     {
         // The first modifier in the linked list of heap-allocated modifiers
-        RefPtr<Modifier> first;
+        Modifier* first;
 
         template<typename T>
         FilteredModifierList<T> getModifiersOfType() { return FilteredModifierList<T>(first.Ptr()); }
@@ -286,7 +286,7 @@ namespace Slang
         template<typename T>
         bool hasModifier() { return findModifier<T>() != nullptr; }
 
-        FilteredModifierList<Modifier>::Iterator begin() { return FilteredModifierList<Modifier>::Iterator(first.Ptr()); }
+        FilteredModifierList<Modifier>::Iterator begin() { return FilteredModifierList<Modifier>::Iterator(first); }
         FilteredModifierList<Modifier>::Iterator end() { return FilteredModifierList<Modifier>::Iterator(nullptr); }
     };
 
@@ -296,7 +296,7 @@ namespace Slang
 
     // Try to extract a simple integer value from an `IntVal`.
     // This fill assert-fail if the object doesn't represent a literal value.
-    IntegerLiteralValue getIntVal(RefPtr<IntVal> val);
+    IntegerLiteralValue getIntVal(IntVal* val);
 
         /// Represents how much checking has been applied to a declaration.
     enum class DeclCheckState : uint8_t
@@ -424,12 +424,12 @@ namespace Slang
     };
 
     void addModifier(
-        RefPtr<ModifiableSyntaxNode>    syntax,
-        RefPtr<Modifier>                modifier);
+        ModifiableSyntaxNode*    syntax,
+        Modifier*                modifier);
 
     struct QualType
     {
-        RefPtr<Type>	type;
+        Type*	type;
         bool	        isLeftValue;
 
         QualType()
@@ -441,11 +441,10 @@ namespace Slang
             , isLeftValue(false)
         {}
 
-        Type* Ptr() { return type.Ptr(); }
+        Type* Ptr() { return type; }
 
         operator Type*() { return type; }
-        operator RefPtr<Type>() { return type; }
-        RefPtr<Type> operator->() { return type; }
+        Type* operator->() { return type; }
     };
 
     class ASTBuilder;
@@ -573,14 +572,14 @@ namespace Slang
 
     struct SubstitutionSet
     {
-        RefPtr<Substitutions> substitutions;
+        Substitutions* substitutions;
         operator Substitutions*() const
         {
             return substitutions;
         }
 
         SubstitutionSet() {}
-        SubstitutionSet(RefPtr<Substitutions> subst)
+        SubstitutionSet(Substitutions* subst)
             : substitutions(subst)
         {
         }
@@ -618,18 +617,18 @@ namespace Slang
             substitutions(subst)
         {}
 
-        DeclRefBase(Decl* decl, RefPtr<Substitutions> subst)
+        DeclRefBase(Decl* decl, Substitutions* subst)
             : decl(decl)
             , substitutions(subst)
         {}
 
         // Apply substitutions to a type or declaration
-        RefPtr<Type> substitute(ASTBuilder* astBuilder, RefPtr<Type> type) const;
+        Type* substitute(ASTBuilder* astBuilder, Type* type) const;
 
         DeclRefBase substitute(ASTBuilder* astBuilder, DeclRefBase declRef) const;
 
         // Apply substitutions to an expression
-        RefPtr<Expr> substitute(ASTBuilder* astBuilder, RefPtr<Expr> expr) const;
+        Expr* substitute(ASTBuilder* astBuilder, Expr* expr) const;
 
         // Apply substitutions to this declaration reference
         DeclRefBase substituteImpl(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
@@ -672,7 +671,7 @@ namespace Slang
             : DeclRefBase(decl, subst)
         {}
 
-        DeclRef(T* decl, RefPtr<Substitutions> subst)
+        DeclRef(T* decl, Substitutions* subst)
             : DeclRefBase(decl, SubstitutionSet(subst))
         {}
 
@@ -699,11 +698,11 @@ namespace Slang
             return DeclRef<T>((T*) declRef.decl, declRef.substitutions);
         }
 
-        RefPtr<Type> substitute(ASTBuilder* astBuilder, RefPtr<Type> type) const
+        Type* substitute(ASTBuilder* astBuilder, Type* type) const
         {
             return DeclRefBase::substitute(astBuilder, type);
         }
-        RefPtr<Expr> substitute(ASTBuilder* astBuilder, RefPtr<Expr> expr) const
+        Expr* substitute(ASTBuilder* astBuilder, Expr* expr) const
         {
             return DeclRefBase::substitute(astBuilder, expr);
         }
@@ -749,32 +748,32 @@ namespace Slang
         Static,                     ///< Only static (ie non instance) members
     };
 
-    const RefPtr<Decl>* adjustFilterCursorImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filterStyle, const RefPtr<Decl>* ptr, const RefPtr<Decl>* end);
-    const RefPtr<Decl>* getFilterCursorByIndexImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filterStyle, const RefPtr<Decl>* ptr, const RefPtr<Decl>* end, Index index);
-    Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filterStyle, const RefPtr<Decl>* ptr, const RefPtr<Decl>* end);
+    Decl*const* adjustFilterCursorImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filterStyle, Decl*const* ptr, Decl*const* end);
+    Decl*const* getFilterCursorByIndexImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filterStyle, Decl*const* ptr, Decl*const* end, Index index);
+    Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filterStyle, Decl*const* ptr, Decl*const* end);
 
 
     template <typename T>
-    const RefPtr<Decl>* adjustFilterCursor(MemberFilterStyle filterStyle, const RefPtr<Decl>* ptr, const RefPtr<Decl>* end)
+    Decl*const* adjustFilterCursor(MemberFilterStyle filterStyle, Decl*const* ptr, Decl*const* end)
     {
         return adjustFilterCursorImpl(T::kReflectClassInfo, filterStyle, ptr, end);
     }
 
         /// Finds the element at index. If there is no element at the index (for example has too few elements), returns nullptr.
     template <typename T>
-    const RefPtr<Decl>* getFilterCursorByIndex(MemberFilterStyle filterStyle, const RefPtr<Decl>* ptr, const RefPtr<Decl>* end, Index index)
+    Decl*const* getFilterCursorByIndex(MemberFilterStyle filterStyle, Decl*const* ptr, Decl*const* end, Index index)
     {
         return getFilterCursorByIndexImpl(T::kReflectClassInfo, filterStyle, ptr, end, index);
     }
      
     template <typename T>
-    Index getFilterCount(MemberFilterStyle filterStyle, const RefPtr<Decl>* ptr, const RefPtr<Decl>* end)
+    Index getFilterCount(MemberFilterStyle filterStyle, Decl*const* ptr, Decl*const* end)
     {
         return getFilterCountImpl(T::kReflectClassInfo, filterStyle, ptr, end);
     }
      
     template <typename T>
-    bool isFilterNonEmpty(MemberFilterStyle filterStyle, const RefPtr<Decl>* ptr, const RefPtr<Decl>* end)
+    bool isFilterNonEmpty(MemberFilterStyle filterStyle, Decl*const* ptr, Decl*const* end)
     {
         return adjustFilterCursorImpl(T::kReflectClassInfo, filterStyle, ptr, end) != end;
     }
@@ -782,7 +781,7 @@ namespace Slang
     template<typename T>
     struct FilteredMemberList
     {
-        typedef RefPtr<Decl> Element;
+        typedef Decl* Element;
 
         FilteredMemberList()
             : m_begin(nullptr)
@@ -829,7 +828,7 @@ namespace Slang
 
         RefPtr<T> operator[](Index index) const
         {
-            const RefPtr<Decl>* ptr = getFilterCursorByIndex<T>(m_filterStyle, m_begin, m_end, index);
+            Decl*const* ptr = getFilterCursorByIndex<T>(m_filterStyle, m_begin, m_end, index);
             SLANG_ASSERT(ptr);
             return  *(RefPtr<T>*)(ptr);
         }
@@ -867,12 +866,12 @@ namespace Slang
     template<typename T>
     struct FilteredMemberRefList
     {
-        List<RefPtr<Decl>> const&	m_decls;
+        List<Decl*> const&	m_decls;
         SubstitutionSet		m_substitutions;
         MemberFilterStyle   m_filterStyle;
 
         FilteredMemberRefList(
-            List<RefPtr<Decl>> const&	decls,
+            List<Decl*> const&	decls,
             SubstitutionSet		substitutions,
             MemberFilterStyle   filterStyle = MemberFilterStyle::All)
             : m_decls(decls)
@@ -889,9 +888,9 @@ namespace Slang
 
         DeclRef<T> operator[](Index index) const
         {
-             const RefPtr<Decl>* decl = getFilterCursorByIndex<T>(m_filterStyle, m_decls.begin(), m_decls.end(), index);
+             Decl*const* decl = getFilterCursorByIndex<T>(m_filterStyle, m_decls.begin(), m_decls.end(), index);
              SLANG_ASSERT(decl);
-             return DeclRef<T>((T*) decl->Ptr(), m_substitutions);
+             return DeclRef<T>((T*) *decl, m_substitutions);
         }
 
         List<DeclRef<T>> toArray() const
@@ -905,15 +904,15 @@ namespace Slang
         struct Iterator
         {
             FilteredMemberRefList const* m_list;
-            const RefPtr<Decl>* m_ptr;
-            const RefPtr<Decl>* m_end;
+            Decl*const* m_ptr;
+            Decl*const* m_end;
             MemberFilterStyle m_filterStyle;
 
             Iterator() : m_list(nullptr), m_ptr(nullptr), m_filterStyle(MemberFilterStyle::All) {}
             Iterator(
                 FilteredMemberRefList const* list,
-                const RefPtr<Decl>* ptr,
-                const RefPtr<Decl>* end,
+                Decl*const* ptr,
+                Decl*const* end,
                 MemberFilterStyle filterStyle
                 )
                 : m_list(list)
@@ -926,7 +925,7 @@ namespace Slang
 
             void operator++() { m_ptr = adjustFilterCursor<T>(m_filterStyle, m_ptr + 1, m_end); }
 
-            DeclRef<T> operator*() { return DeclRef<T>((T*) m_ptr->Ptr(), m_list->m_substitutions); }
+            DeclRef<T> operator*() { return DeclRef<T>((T*)*m_ptr, m_list->m_substitutions); }
         };
 
         Iterator begin() const { return Iterator(this, adjustFilterCursor<T>(m_filterStyle, m_decls.begin(), m_decls.end()), m_decls.end(), m_filterStyle); }
@@ -948,23 +947,23 @@ namespace Slang
             : exp(other.exp)
             , type(other.type)
         {}
-        explicit TypeExp(RefPtr<Expr> exp)
+        explicit TypeExp(Expr* exp)
             : exp(exp)
         {}
-        explicit TypeExp(RefPtr<Type> type)
+        explicit TypeExp(Type* type)
             : type(type)
         {}
-        TypeExp(RefPtr<Expr> exp, RefPtr<Type> type)
+        TypeExp(Expr* exp, Type* type)
             : exp(exp)
             , type(type)
         {}
 
-        RefPtr<Expr> exp;
-        RefPtr<Type> type;
+        Expr* exp;
+        Type* type;
 
         bool equals(Type* other);
 
-        Type* Ptr() { return type.Ptr(); }
+        Type* Ptr() { return type; }
         operator Type*()
         {
             return type;
@@ -1233,7 +1232,7 @@ namespace Slang
             , m_declRef(declRef)
         {}
 
-        RequirementWitness(RefPtr<Val> val);
+        RequirementWitness(Val* val);
 
         RequirementWitness(RefPtr<WitnessTable> witnessTable);
 
@@ -1256,7 +1255,7 @@ namespace Slang
             return m_declRef;
         }
 
-        RefPtr<Val> getVal()
+        Val* getVal()
         {
             SLANG_ASSERT(getFlavor() == Flavor::val);
             return m_obj.as<Val>();
@@ -1292,19 +1291,19 @@ namespace Slang
         };
         Flavor              flavor;
         SourceLoc           loc;
-        RefPtr<NodeBase>    object;
+        NodeBase*    object;
     };
     typedef List<SpecializationParam> SpecializationParams;
 
     struct SpecializationArg
     {
-        RefPtr<Val> val;
+        Val* val;
     };
     typedef List<SpecializationArg> SpecializationArgs;
 
     struct ExpandedSpecializationArg : SpecializationArg
     {
-        RefPtr<Val> witness;
+        Val* witness;
     };
     typedef List<ExpandedSpecializationArg> ExpandedSpecializationArgs;
 

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -184,7 +184,7 @@ namespace Slang
     {
         struct Iterator
         {
-            Modifier* current;
+            Modifier* current = nullptr;
 
             Modifier* operator*()
             {
@@ -218,7 +218,7 @@ namespace Slang
         Iterator begin() { return Iterator(modifiers); }
         Iterator end() { return Iterator(nullptr); }
 
-        Modifier* modifiers;
+        Modifier* modifiers = nullptr;
     };
 
     // Helper class for iterating over heap-allocated modifiers
@@ -228,7 +228,7 @@ namespace Slang
     {
         struct Iterator
         {
-            Modifier* current;
+            Modifier* current = nullptr;
 
             T* operator*()
             {
@@ -264,14 +264,14 @@ namespace Slang
 
         static Modifier* adjust(Modifier* modifier);
 
-        Modifier* modifiers;
+        Modifier* modifiers = nullptr;
     };
 
     // A set of modifiers attached to a syntax node
     struct Modifiers
     {
         // The first modifier in the linked list of heap-allocated modifiers
-        Modifier* first;
+        Modifier* first = nullptr;
 
         template<typename T>
         FilteredModifierList<T> getModifiersOfType() { return FilteredModifierList<T>(first.Ptr()); }
@@ -429,7 +429,7 @@ namespace Slang
 
     struct QualType
     {
-        Type*	type;
+        Type*	type = nullptr;
         bool	        isLeftValue;
 
         QualType()
@@ -572,7 +572,7 @@ namespace Slang
 
     struct SubstitutionSet
     {
-        Substitutions* substitutions;
+        Substitutions* substitutions = nullptr;
         operator Substitutions*() const
         {
             return substitutions;
@@ -860,7 +860,7 @@ namespace Slang
     struct TransparentMemberInfo
     {
         // The declaration of the transparent member
-        Decl*	decl;
+        Decl*	decl = nullptr;
     };
 
     template<typename T>
@@ -958,8 +958,8 @@ namespace Slang
             , type(type)
         {}
 
-        Expr* exp;
-        Type* type;
+        Expr* exp = nullptr;
+        Type* type = nullptr;
 
         bool equals(Type* other);
 
@@ -993,7 +993,7 @@ namespace Slang
         // Note(tfoley): This is kept as an unowned pointer
         // so that a scope can't keep parts of the AST alive,
         // but the opposite it allowed.
-        ContainerDecl*          containerDecl;
+        ContainerDecl*          containerDecl = nullptr;
     };
 
     // Masks to be applied when lookup up declarations
@@ -1291,19 +1291,19 @@ namespace Slang
         };
         Flavor              flavor;
         SourceLoc           loc;
-        NodeBase*    object;
+        NodeBase*    object = nullptr;
     };
     typedef List<SpecializationParam> SpecializationParams;
 
     struct SpecializationArg
     {
-        Val* val;
+        Val* val = nullptr;
     };
     typedef List<SpecializationArg> SpecializationArgs;
 
     struct ExpandedSpecializationArg : SpecializationArg
     {
-        Val* witness;
+        Val* witness = nullptr;
     };
     typedef List<ExpandedSpecializationArg> ExpandedSpecializationArgs;
 

--- a/source/slang/slang-ast-type.cpp
+++ b/source/slang/slang-ast-type.cpp
@@ -21,7 +21,7 @@ Type::~Type()
     }
 }
 
-RefPtr<Type> Type::createCanonicalType()
+Type* Type::createCanonicalType()
 {
     SLANG_AST_NODE_VIRTUAL_CALL(Type, createCanonicalType, ())
 }
@@ -43,10 +43,10 @@ bool Type::_equalsImplOverride(Type* type)
     //return false;
 }
 
-RefPtr<Type> Type::_createCanonicalTypeOverride()
+Type* Type::_createCanonicalTypeOverride()
 {
     SLANG_UNEXPECTED("Type::_createCanonicalTypeOverride not overridden");
-    //return RefPtr<Type>();
+    //return Type*();
 }
 
 bool Type::_equalsValOverride(Val* val)
@@ -56,7 +56,7 @@ bool Type::_equalsValOverride(Val* val)
     return false;
 }
 
-RefPtr<Val> Type::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
+Val* Type::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
 {
     int diff = 0;
     auto canSubst = getCanonicalType()->substituteImpl(astBuilder, subst, &diff);
@@ -80,12 +80,6 @@ Type* Type::getCanonicalType()
         auto canType = et->createCanonicalType();
         et->canonicalType = canType;
 
-        // TODO(js): That this detachs when canType == this is a little surprising. It would seem
-        // as if this would create a circular reference on the object, but in practice there are
-        // no leaks so appears correct.
-        // That the dtor only releases if != this, also makes it surprising.
-        canType.detach();
-
         SLANG_ASSERT(et->canonicalType);
     }
     return et->canonicalType;
@@ -103,7 +97,7 @@ bool OverloadGroupType::_equalsImplOverride(Type * /*type*/)
     return false;
 }
 
-RefPtr<Type> OverloadGroupType::_createCanonicalTypeOverride()
+Type* OverloadGroupType::_createCanonicalTypeOverride()
 {
     return this;
 }
@@ -125,7 +119,7 @@ bool InitializerListType::_equalsImplOverride(Type * /*type*/)
     return false;
 }
 
-RefPtr<Type> InitializerListType::_createCanonicalTypeOverride()
+Type* InitializerListType::_createCanonicalTypeOverride()
 {
     return this;
 }
@@ -149,12 +143,12 @@ bool ErrorType::_equalsImplOverride(Type* type)
     return false;
 }
 
-RefPtr<Type> ErrorType::_createCanonicalTypeOverride()
+Type* ErrorType::_createCanonicalTypeOverride()
 {
     return this;
 }
 
-RefPtr<Val> ErrorType::_substituteImplOverride(ASTBuilder* /* astBuilder */, SubstitutionSet /*subst*/, int* /*ioDiff*/)
+Val* ErrorType::_substituteImplOverride(ASTBuilder* /* astBuilder */, SubstitutionSet /*subst*/, int* /*ioDiff*/)
 {
     return this;
 }
@@ -185,13 +179,13 @@ bool DeclRefType::_equalsImplOverride(Type * type)
     return false;
 }
 
-RefPtr<Type> DeclRefType::_createCanonicalTypeOverride()
+Type* DeclRefType::_createCanonicalTypeOverride()
 {
     // A declaration reference is already canonical
     return this;
 }
 
-RefPtr<Val> DeclRefType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
+Val* DeclRefType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
 {
     if (!subst) return this;
 
@@ -202,7 +196,7 @@ RefPtr<Val> DeclRefType::_substituteImplOverride(ASTBuilder* astBuilder, Substit
         // search for a substitution that might apply to us
         for (auto s = subst.substitutions; s; s = s->outer)
         {
-            auto genericSubst = s.as<GenericSubstitution>();
+            auto genericSubst = as<GenericSubstitution>(s);
             if (!genericSubst)
                 continue;
 
@@ -215,7 +209,7 @@ RefPtr<Val> DeclRefType::_substituteImplOverride(ASTBuilder* astBuilder, Substit
             int index = 0;
             for (auto m : genericDecl->members)
             {
-                if (m.Ptr() == genericTypeParamDecl)
+                if (m == genericTypeParamDecl)
                 {
                     // We've found it, so return the corresponding specialization argument
                     (*ioDiff)++;
@@ -269,7 +263,7 @@ RefPtr<Val> DeclRefType::_substituteImplOverride(ASTBuilder* astBuilder, Substit
     {
         for (auto s = substDeclRef.substitutions.substitutions; s; s = s->outer)
         {
-            auto thisSubst = s.as<ThisTypeSubstitution>();
+            auto thisSubst = as<ThisTypeSubstitution>(s);
             if (!thisSubst)
                 continue;
 
@@ -325,7 +319,7 @@ bool BasicExpressionType::_equalsImplOverride(Type * type)
     return basicType && basicType->baseType == this->baseType;
 }
 
-RefPtr<Type> BasicExpressionType::_createCanonicalTypeOverride()
+Type* BasicExpressionType::_createCanonicalTypeOverride()
 {
     // A basic type is already canonical, in our setup
     return this;
@@ -379,7 +373,7 @@ IntVal* MatrixExpressionType::getColumnCount()
     return as<IntVal>(findInnerMostGenericSubstitution(declRef.substitutions)->args[2]);
 }
 
-RefPtr<Type> MatrixExpressionType::getRowType()
+Type* MatrixExpressionType::getRowType()
 {
     if (!rowType)
     {
@@ -395,14 +389,14 @@ bool ArrayExpressionType::_equalsImplOverride(Type* type)
     auto arrType = as<ArrayExpressionType>(type);
     if (!arrType)
         return false;
-    return (areValsEqual(arrayLength, arrType->arrayLength) && baseType->equals(arrType->baseType.Ptr()));
+    return (areValsEqual(arrayLength, arrType->arrayLength) && baseType->equals(arrType->baseType));
 }
 
-RefPtr<Val> ArrayExpressionType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
+Val* ArrayExpressionType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
 {
     int diff = 0;
-    auto elementType = baseType->substituteImpl(astBuilder, subst, &diff).as<Type>();
-    auto arrlen = arrayLength->substituteImpl(astBuilder, subst, &diff).as<IntVal>();
+    auto elementType = as<Type>(baseType->substituteImpl(astBuilder, subst, &diff));
+    auto arrlen = as<IntVal>(arrayLength->substituteImpl(astBuilder, subst, &diff));
     SLANG_ASSERT(arrlen);
     if (diff)
     {
@@ -416,7 +410,7 @@ RefPtr<Val> ArrayExpressionType::_substituteImplOverride(ASTBuilder* astBuilder,
     return this;
 }
 
-RefPtr<Type> ArrayExpressionType::_createCanonicalTypeOverride()
+Type* ArrayExpressionType::_createCanonicalTypeOverride()
 {
     auto canonicalElementType = baseType->getCanonicalType();
     auto canonicalArrayType = getASTBuilder()->getArrayType(
@@ -459,7 +453,7 @@ bool TypeType::_equalsImplOverride(Type * t)
     return false;
 }
 
-RefPtr<Type> TypeType::_createCanonicalTypeOverride()
+Type* TypeType::_createCanonicalTypeOverride()
 {
     return getASTBuilder()->getTypeType(type->getCanonicalType());
 }
@@ -492,7 +486,7 @@ HashCode GenericDeclRefType::_getHashCodeOverride()
     return declRef.getHashCode();
 }
 
-RefPtr<Type> GenericDeclRefType::_createCanonicalTypeOverride()
+Type* GenericDeclRefType::_createCanonicalTypeOverride()
 {
     return this;
 }
@@ -521,7 +515,7 @@ HashCode NamespaceType::_getHashCodeOverride()
     return declRef.getHashCode();
 }
 
-RefPtr<Type> NamespaceType::_createCanonicalTypeOverride()
+Type* NamespaceType::_createCanonicalTypeOverride()
 {
     return this;
 }
@@ -547,7 +541,7 @@ bool NamedExpressionType::_equalsImplOverride(Type * /*type*/)
     //return false;
 }
 
-RefPtr<Type> NamedExpressionType::_createCanonicalTypeOverride()
+Type* NamedExpressionType::_createCanonicalTypeOverride()
 {
     if (!innerType)
         innerType = getType(m_astBuilder, declRef);
@@ -613,18 +607,18 @@ bool FuncType::_equalsImplOverride(Type * type)
     return false;
 }
 
-RefPtr<Val> FuncType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
+Val* FuncType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
 {
     int diff = 0;
 
     // result type
-    RefPtr<Type> substResultType = resultType->substituteImpl(astBuilder, subst, &diff).as<Type>();
+    Type* substResultType = as<Type>(resultType->substituteImpl(astBuilder, subst, &diff));
 
     // parameter types
-    List<RefPtr<Type>> substParamTypes;
+    List<Type*> substParamTypes;
     for (auto pp : paramTypes)
     {
-        substParamTypes.add(pp->substituteImpl(astBuilder, subst, &diff).as<Type>());
+        substParamTypes.add(as<Type>(pp->substituteImpl(astBuilder, subst, &diff)));
     }
 
     // early exit for no change...
@@ -632,26 +626,26 @@ RefPtr<Val> FuncType::_substituteImplOverride(ASTBuilder* astBuilder, Substituti
         return this;
 
     (*ioDiff)++;
-    RefPtr<FuncType> substType = astBuilder->create<FuncType>();
+    FuncType* substType = astBuilder->create<FuncType>();
     substType->resultType = substResultType;
     substType->paramTypes = substParamTypes;
     return substType;
 }
 
-RefPtr<Type> FuncType::_createCanonicalTypeOverride()
+Type* FuncType::_createCanonicalTypeOverride()
 {
     // result type
-    RefPtr<Type> canResultType = resultType->getCanonicalType();
+    Type* canResultType = resultType->getCanonicalType();
 
     // parameter types
-    List<RefPtr<Type>> canParamTypes;
+    List<Type*> canParamTypes;
     for (auto pp : paramTypes)
     {
         canParamTypes.add(pp->getCanonicalType());
     }
 
-    RefPtr<FuncType> canType = getASTBuilder()->create<FuncType>();
-    canType->resultType = resultType;
+    FuncType* canType = getASTBuilder()->create<FuncType>();
+    canType->resultType = canResultType;
     canType->paramTypes = canParamTypes;
 
     return canType;
@@ -695,12 +689,12 @@ HashCode ExtractExistentialType::_getHashCodeOverride()
     return declRef.getHashCode();
 }
 
-RefPtr<Type> ExtractExistentialType::_createCanonicalTypeOverride()
+Type* ExtractExistentialType::_createCanonicalTypeOverride()
 {
     return this;
 }
 
-RefPtr<Val> ExtractExistentialType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
+Val* ExtractExistentialType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
 {
     int diff = 0;
     auto substDeclRef = declRef.substituteImpl(astBuilder, subst, &diff);
@@ -709,7 +703,7 @@ RefPtr<Val> ExtractExistentialType::_substituteImplOverride(ASTBuilder* astBuild
 
     (*ioDiff)++;
 
-    RefPtr<ExtractExistentialType> substValue = astBuilder->create<ExtractExistentialType>();
+    ExtractExistentialType* substValue = astBuilder->create<ExtractExistentialType>();
     substValue->declRef = declRef;
     return substValue;
 }
@@ -760,9 +754,9 @@ HashCode TaggedUnionType::_getHashCodeOverride()
     return hashCode;
 }
 
-RefPtr<Type> TaggedUnionType::_createCanonicalTypeOverride()
+Type* TaggedUnionType::_createCanonicalTypeOverride()
 {
-    RefPtr<TaggedUnionType> canType = m_astBuilder->create<TaggedUnionType>();
+    TaggedUnionType* canType = m_astBuilder->create<TaggedUnionType>();
 
     for (auto caseType : caseTypes)
     {
@@ -773,21 +767,21 @@ RefPtr<Type> TaggedUnionType::_createCanonicalTypeOverride()
     return canType;
 }
 
-RefPtr<Val> TaggedUnionType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
+Val* TaggedUnionType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
 {
     int diff = 0;
 
-    List<RefPtr<Type>> substCaseTypes;
+    List<Type*> substCaseTypes;
     for (auto caseType : caseTypes)
     {
-        substCaseTypes.add(caseType->substituteImpl(astBuilder, subst, &diff).as<Type>());
+        substCaseTypes.add(as<Type>(caseType->substituteImpl(astBuilder, subst, &diff)));
     }
     if (!diff)
         return this;
 
     (*ioDiff)++;
 
-    RefPtr<TaggedUnionType> substType = astBuilder->create<TaggedUnionType>();
+    TaggedUnionType* substType = astBuilder->create<TaggedUnionType>();
     substType->caseTypes.swapWith(substCaseTypes);
     return substType;
 }
@@ -848,7 +842,7 @@ HashCode ExistentialSpecializedType::_getHashCodeOverride()
     return hasher.getResult();
 }
 
-static RefPtr<Val> _getCanonicalValue(Val* val)
+static Val* _getCanonicalValue(Val* val)
 {
     if (!val)
         return nullptr;
@@ -861,9 +855,9 @@ static RefPtr<Val> _getCanonicalValue(Val* val)
     return val;
 }
 
-RefPtr<Type> ExistentialSpecializedType::_createCanonicalTypeOverride()
+Type* ExistentialSpecializedType::_createCanonicalTypeOverride()
 {
-    RefPtr<ExistentialSpecializedType> canType = m_astBuilder->create<ExistentialSpecializedType>();
+    ExistentialSpecializedType* canType = m_astBuilder->create<ExistentialSpecializedType>();
 
     canType->baseType = baseType->getCanonicalType();
     for (auto arg : args)
@@ -876,17 +870,17 @@ RefPtr<Type> ExistentialSpecializedType::_createCanonicalTypeOverride()
     return canType;
 }
 
-static RefPtr<Val> _substituteImpl(ASTBuilder* astBuilder, Val* val, SubstitutionSet subst, int* ioDiff)
+static Val* _substituteImpl(ASTBuilder* astBuilder, Val* val, SubstitutionSet subst, int* ioDiff)
 {
     if (!val) return nullptr;
     return val->substituteImpl(astBuilder, subst, ioDiff);
 }
 
-RefPtr<Val> ExistentialSpecializedType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
+Val* ExistentialSpecializedType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
 {
     int diff = 0;
 
-    auto substBaseType = baseType->substituteImpl(astBuilder, subst, &diff).as<Type>();
+    auto substBaseType = as<Type>(baseType->substituteImpl(astBuilder, subst, &diff));
 
     ExpandedSpecializationArgs substArgs;
     for (auto arg : args)
@@ -902,7 +896,7 @@ RefPtr<Val> ExistentialSpecializedType::_substituteImplOverride(ASTBuilder* astB
 
     (*ioDiff)++;
 
-    RefPtr<ExistentialSpecializedType> substType = astBuilder->create<ExistentialSpecializedType>();
+    ExistentialSpecializedType* substType = astBuilder->create<ExistentialSpecializedType>();
     substType->baseType = substBaseType;
     substType->args = substArgs;
     return substType;
@@ -937,16 +931,16 @@ HashCode ThisType::_getHashCodeOverride()
         interfaceDeclRef.getHashCode());
 }
 
-RefPtr<Type> ThisType::_createCanonicalTypeOverride()
+Type* ThisType::_createCanonicalTypeOverride()
 {
-    RefPtr<ThisType> canType = m_astBuilder->create<ThisType>();
+    ThisType* canType = m_astBuilder->create<ThisType>();
 
     // TODO: need to canonicalize the decl-ref
     canType->interfaceDeclRef = interfaceDeclRef;
     return canType;
 }
 
-RefPtr<Val> ThisType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
+Val* ThisType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
 {
     int diff = 0;
 
@@ -963,7 +957,7 @@ RefPtr<Val> ThisType::_substituteImplOverride(ASTBuilder* astBuilder, Substituti
 
     (*ioDiff)++;
 
-    RefPtr<ThisType> substType = m_astBuilder->create<ThisType>();
+    ThisType* substType = m_astBuilder->create<ThisType>();
     substType->interfaceDeclRef = substInterfaceDeclRef;
     return substType;
 }

--- a/source/slang/slang-ast-type.cpp
+++ b/source/slang/slang-ast-type.cpp
@@ -11,16 +11,6 @@ namespace Slang {
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Type !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-Type::~Type()
-{
-    // If the canonicalType !=nullptr AND it is not set to this (ie the canonicalType is another object)
-    // then it needs to be released because it's owned by this object.
-    if (canonicalType && canonicalType != this)
-    {
-        canonicalType->releaseReference();
-    }
-}
-
 Type* Type::createCanonicalType()
 {
     SLANG_AST_NODE_VIRTUAL_CALL(Type, createCanonicalType, ())

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -113,7 +113,7 @@ class ResourceType : public BuiltinType
     SLANG_ABSTRACT_CLASS(ResourceType)
 
     // The type that results from fetching an element from this resource
-    Type* elementType;
+    Type* elementType = nullptr;
 
     // Shape and access level information for this resource type
     TextureFlavor flavor;
@@ -188,7 +188,7 @@ class BuiltinGenericType : public BuiltinType
 {
     SLANG_CLASS(BuiltinGenericType)
 
-    Type* elementType;
+    Type* elementType = nullptr;
 
     Type* getElementType() { return elementType; }
 };
@@ -373,8 +373,8 @@ class ArrayExpressionType : public Type
 {
     SLANG_CLASS(ArrayExpressionType)
 
-    Type* baseType;
-    IntVal* arrayLength;
+    Type* baseType = nullptr;
+    IntVal* arrayLength = nullptr;
 
     // Overrides should be public so base classes can access
     String _toStringOverride();
@@ -392,7 +392,7 @@ class TypeType : public Type
     SLANG_CLASS(TypeType)
 
     // The type that this is the type of...
-    Type* type;
+    Type* type = nullptr;
 
     // Overrides should be public so base classes can access
     String _toStringOverride();
@@ -415,10 +415,10 @@ class VectorExpressionType : public ArithmeticExpressionType
 
     // The type of vector elements.
     // As an invariant, this should be a basic type or an alias.
-    Type* elementType;
+    Type* elementType = nullptr;
 
     // The number of elements
-    IntVal* elementCount;
+    IntVal* elementCount = nullptr;
 
     // Overrides should be public so base classes can access
     String _toStringOverride();
@@ -441,7 +441,7 @@ class MatrixExpressionType : public ArithmeticExpressionType
     BasicExpressionType* _getScalarTypeOverride();
 
 private:
-    Type* rowType;
+    Type* rowType = nullptr;
 };
 
 // The built-in `String` type
@@ -506,7 +506,7 @@ class NamedExpressionType : public Type
     SLANG_CLASS(NamedExpressionType)
 
     DeclRef<TypeDefDecl> declRef;
-    Type* innerType;
+    Type* innerType = nullptr;
 
     // Overrides should be public so base classes can access
     String _toStringOverride();
@@ -536,7 +536,7 @@ class FuncType : public Type
     // semantic type underneath.
 
     List<Type*> paramTypes;
-    Type* resultType;
+    Type* resultType = nullptr;
 
     UInt getParamCount() { return paramTypes.getCount(); }
     Type* getParamType(UInt index) { return paramTypes[index]; }
@@ -628,7 +628,7 @@ class ExistentialSpecializedType : public Type
 {
     SLANG_CLASS(ExistentialSpecializedType)
 
-    Type* baseType;
+    Type* baseType = nullptr;
     ExpandedSpecializationArgs args;
 
     // Overrides should be public so base classes can access

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -15,7 +15,7 @@ class OverloadGroupType : public Type
 
     // Overrides should be public so base classes can access
     String _toStringOverride();
-    RefPtr<Type> _createCanonicalTypeOverride();
+    Type* _createCanonicalTypeOverride();
     bool _equalsImplOverride(Type* type);
     HashCode _getHashCodeOverride();
 };
@@ -29,7 +29,7 @@ class InitializerListType : public Type
     
     // Overrides should be public so base classes can access
     String _toStringOverride();
-    RefPtr<Type> _createCanonicalTypeOverride();
+    Type* _createCanonicalTypeOverride();
     bool _equalsImplOverride(Type* type);
     HashCode _getHashCodeOverride();
 };
@@ -41,10 +41,10 @@ class ErrorType : public Type
 
     // Overrides should be public so base classes can access
     String _toStringOverride();
-    RefPtr<Type> _createCanonicalTypeOverride();
+    Type* _createCanonicalTypeOverride();
     bool _equalsImplOverride(Type* type);
     HashCode _getHashCodeOverride();
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 };
 
 // A type that takes the form of a reference to some declaration
@@ -55,14 +55,14 @@ class DeclRefType : public Type
     DeclRef<Decl> declRef;
 
     
-    static RefPtr<DeclRefType> create(ASTBuilder* astBuilder, DeclRef<Decl> declRef);
+    static DeclRefType* create(ASTBuilder* astBuilder, DeclRef<Decl> declRef);
 
     // Overrides should be public so base classes can access
     String _toStringOverride();
-    RefPtr<Type> _createCanonicalTypeOverride();
+    Type* _createCanonicalTypeOverride();
     bool _equalsImplOverride(Type* type);
     HashCode _getHashCodeOverride();
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 
 protected:
     DeclRefType( DeclRef<Decl> declRef)
@@ -88,7 +88,7 @@ class BasicExpressionType : public ArithmeticExpressionType
     BaseType baseType;
 
     // Overrides should be public so base classes can access
-    RefPtr<Type> _createCanonicalTypeOverride();
+    Type* _createCanonicalTypeOverride();
     bool _equalsImplOverride(Type* type);
     BasicExpressionType* _getScalarTypeOverride();
 
@@ -113,7 +113,7 @@ class ResourceType : public BuiltinType
     SLANG_ABSTRACT_CLASS(ResourceType)
 
     // The type that results from fetching an element from this resource
-    RefPtr<Type> elementType;
+    Type* elementType;
 
     // Shape and access level information for this resource type
     TextureFlavor flavor;
@@ -133,7 +133,7 @@ class TextureTypeBase : public ResourceType
     SLANG_ABSTRACT_CLASS(TextureTypeBase)
 
 protected:
-    TextureTypeBase(TextureFlavor inFlavor, RefPtr<Type> inElementType)
+    TextureTypeBase(TextureFlavor inFlavor, Type* inElementType)
     {
         elementType = inElementType;
         flavor = inFlavor;
@@ -145,7 +145,7 @@ class TextureType : public TextureTypeBase
     SLANG_CLASS(TextureType)
 
 protected:
-    TextureType(TextureFlavor flavor, RefPtr<Type> elementType)
+    TextureType(TextureFlavor flavor, Type* elementType)
         : TextureTypeBase(flavor, elementType)
     {}
 };
@@ -157,7 +157,7 @@ class TextureSamplerType : public TextureTypeBase
     SLANG_CLASS(TextureSamplerType)
 
 protected:
-    TextureSamplerType(TextureFlavor flavor, RefPtr<Type> elementType)
+    TextureSamplerType(TextureFlavor flavor, Type* elementType)
         : TextureTypeBase(flavor, elementType)
     {}
 };
@@ -170,7 +170,7 @@ class GLSLImageType : public TextureTypeBase
 protected:
     GLSLImageType(
         TextureFlavor flavor,
-        RefPtr<Type> elementType)
+        Type* elementType)
         : TextureTypeBase(flavor, elementType)
     {}
 };
@@ -188,7 +188,7 @@ class BuiltinGenericType : public BuiltinType
 {
     SLANG_CLASS(BuiltinGenericType)
 
-    RefPtr<Type> elementType;
+    Type* elementType;
 
     Type* getElementType() { return elementType; }
 };
@@ -373,14 +373,14 @@ class ArrayExpressionType : public Type
 {
     SLANG_CLASS(ArrayExpressionType)
 
-    RefPtr<Type> baseType;
-    RefPtr<IntVal> arrayLength;
+    Type* baseType;
+    IntVal* arrayLength;
 
     // Overrides should be public so base classes can access
     String _toStringOverride();
-    RefPtr<Type> _createCanonicalTypeOverride();
+    Type* _createCanonicalTypeOverride();
     bool _equalsImplOverride(Type* type);
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
     HashCode _getHashCodeOverride();
 };
 
@@ -392,16 +392,16 @@ class TypeType : public Type
     SLANG_CLASS(TypeType)
 
     // The type that this is the type of...
-    RefPtr<Type> type;
+    Type* type;
 
     // Overrides should be public so base classes can access
     String _toStringOverride();
-    RefPtr<Type> _createCanonicalTypeOverride();
+    Type* _createCanonicalTypeOverride();
     bool _equalsImplOverride(Type* type);
     HashCode _getHashCodeOverride();
 
 protected:
-    TypeType(RefPtr<Type> type)
+    TypeType(Type* type)
         : type(type)
     {}
 
@@ -415,10 +415,10 @@ class VectorExpressionType : public ArithmeticExpressionType
 
     // The type of vector elements.
     // As an invariant, this should be a basic type or an alias.
-    RefPtr<Type> elementType;
+    Type* elementType;
 
     // The number of elements
-    RefPtr<IntVal> elementCount;
+    IntVal* elementCount;
 
     // Overrides should be public so base classes can access
     String _toStringOverride();
@@ -434,14 +434,14 @@ class MatrixExpressionType : public ArithmeticExpressionType
     IntVal*         getRowCount();
     IntVal*         getColumnCount();
 
-    RefPtr<Type> getRowType();
+    Type* getRowType();
 
     // Overrides should be public so base classes can access
     String _toStringOverride();
     BasicExpressionType* _getScalarTypeOverride();
 
 private:
-    RefPtr<Type> rowType;
+    Type* rowType;
 };
 
 // The built-in `String` type
@@ -506,11 +506,11 @@ class NamedExpressionType : public Type
     SLANG_CLASS(NamedExpressionType)
 
     DeclRef<TypeDefDecl> declRef;
-    RefPtr<Type> innerType;
+    Type* innerType;
 
     // Overrides should be public so base classes can access
     String _toStringOverride();
-    RefPtr<Type> _createCanonicalTypeOverride();
+    Type* _createCanonicalTypeOverride();
     bool _equalsImplOverride(Type* type);
     HashCode _getHashCodeOverride();
 
@@ -535,8 +535,8 @@ class FuncType : public Type
     // type, even if they don't affect the actual
     // semantic type underneath.
 
-    List<RefPtr<Type>> paramTypes;
-    RefPtr<Type> resultType;
+    List<Type*> paramTypes;
+    Type* resultType;
 
     UInt getParamCount() { return paramTypes.getCount(); }
     Type* getParamType(UInt index) { return paramTypes[index]; }
@@ -544,8 +544,8 @@ class FuncType : public Type
 
     // Overrides should be public so base classes can access
     String _toStringOverride();
-    RefPtr<Type> _createCanonicalTypeOverride();
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Type* _createCanonicalTypeOverride();
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
     bool _equalsImplOverride(Type* type);
     HashCode _getHashCodeOverride();
 };
@@ -563,7 +563,7 @@ class GenericDeclRefType : public Type
     String _toStringOverride();
     bool _equalsImplOverride(Type* type);
     HashCode _getHashCodeOverride();
-    RefPtr<Type> _createCanonicalTypeOverride();
+    Type* _createCanonicalTypeOverride();
 
 protected:
     GenericDeclRefType(
@@ -585,7 +585,7 @@ class NamespaceType : public Type
     String _toStringOverride();
     bool _equalsImplOverride(Type* type);
     HashCode _getHashCodeOverride();
-    RefPtr<Type> _createCanonicalTypeOverride();    
+    Type* _createCanonicalTypeOverride();    
 };
 
 // The concrete type for a value wrapped in an existential, accessible
@@ -600,8 +600,8 @@ class ExtractExistentialType : public Type
     String _toStringOverride();
     bool _equalsImplOverride(Type* type);
     HashCode _getHashCodeOverride();
-    RefPtr<Type> _createCanonicalTypeOverride();
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Type* _createCanonicalTypeOverride();
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 };
 
     /// A tagged union of zero or more other types.
@@ -614,29 +614,29 @@ class TaggedUnionType : public Type
         /// For each type in this array, the array index is the
         /// tag value for that case.
         ///
-    List<RefPtr<Type>> caseTypes;
+    List<Type*> caseTypes;
 
     // Overrides should be public so base classes can access
     String _toStringOverride();
     bool _equalsImplOverride(Type* type);
     HashCode _getHashCodeOverride();
-    RefPtr<Type> _createCanonicalTypeOverride();
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Type* _createCanonicalTypeOverride();
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 };
 
 class ExistentialSpecializedType : public Type 
 {
     SLANG_CLASS(ExistentialSpecializedType)
 
-    RefPtr<Type> baseType;
+    Type* baseType;
     ExpandedSpecializationArgs args;
 
     // Overrides should be public so base classes can access
     String _toStringOverride();
     bool _equalsImplOverride(Type* type);
     HashCode _getHashCodeOverride();
-    RefPtr<Type> _createCanonicalTypeOverride();
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Type* _createCanonicalTypeOverride();
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 };
 
     /// The type of `this` within a polymorphic declaration
@@ -650,8 +650,8 @@ class ThisType : public Type
     String _toStringOverride();
     bool _equalsImplOverride(Type* type);
     HashCode _getHashCodeOverride();
-    RefPtr<Type> _createCanonicalTypeOverride();
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Type* _createCanonicalTypeOverride();
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 };
 
 } // namespace Slang

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -44,7 +44,7 @@ class GenericParamIntVal : public IntVal
     bool _equalsValOverride(Val* val);
     String _toStringOverride();
     HashCode _getHashCodeOverride();
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 
 protected:
     GenericParamIntVal(DeclRef<VarDeclBase> inDeclRef)
@@ -65,7 +65,7 @@ class ErrorIntVal : public IntVal
     bool _equalsValOverride(Val* val);
     String _toStringOverride();
     HashCode _getHashCodeOverride();
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 };
 
 // A witness to the fact that some proposition is true, encoded
@@ -115,8 +115,8 @@ class SubtypeWitness : public Witness
 {
     SLANG_ABSTRACT_CLASS(SubtypeWitness)
 
-    RefPtr<Type> sub;
-    RefPtr<Type> sup;
+    Type* sub;
+    Type* sup;
 };
 
 class TypeEqualityWitness : public SubtypeWitness 
@@ -127,7 +127,7 @@ class TypeEqualityWitness : public SubtypeWitness
     bool _equalsValOverride(Val* val);
     String _toStringOverride();
     HashCode _getHashCodeOverride();
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 };
 
 // A witness that one type is a subtype of another
@@ -142,7 +142,7 @@ class DeclaredSubtypeWitness : public SubtypeWitness
     bool _equalsValOverride(Val* val);
     String _toStringOverride();
     HashCode _getHashCodeOverride();
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 };
 
 // A witness that `sub : sup` because `sub : mid` and `mid : sup`
@@ -151,7 +151,7 @@ class TransitiveSubtypeWitness : public SubtypeWitness
     SLANG_CLASS(TransitiveSubtypeWitness)
 
     // Witness that `sub : mid`
-    RefPtr<SubtypeWitness> subToMid;
+    SubtypeWitness* subToMid;
 
     // Witness that `mid : sup`
     DeclRef<Decl> midToSup;
@@ -160,7 +160,7 @@ class TransitiveSubtypeWitness : public SubtypeWitness
     bool _equalsValOverride(Val* val);
     String _toStringOverride();
     HashCode _getHashCodeOverride();
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 };
 
 // A witness taht `sub : sup` because `sub` was wrapped into
@@ -176,7 +176,7 @@ class ExtractExistentialSubtypeWitness : public SubtypeWitness
     bool _equalsValOverride(Val* val);
     String _toStringOverride();
     HashCode _getHashCodeOverride();
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 };
 
 // A witness that `sub : sup`, because `sub` is a tagged union
@@ -190,14 +190,14 @@ class TaggedUnionSubtypeWitness : public SubtypeWitness
     // Witnesses that each of the "case" types in the union
     // is a subtype of `sup`.
     //
-    List<RefPtr<Val>> caseWitnesses;
+    List<Val*> caseWitnesses;
 
 
     // Overrides should be public so base classes can access
     bool _equalsValOverride(Val* val);
     String _toStringOverride();
     HashCode _getHashCodeOverride();
-    RefPtr<Val> _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 };
 
 } // namespace Slang

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -115,8 +115,8 @@ class SubtypeWitness : public Witness
 {
     SLANG_ABSTRACT_CLASS(SubtypeWitness)
 
-    Type* sub;
-    Type* sup;
+    Type* sub = nullptr;
+    Type* sup = nullptr;
 };
 
 class TypeEqualityWitness : public SubtypeWitness 
@@ -151,7 +151,7 @@ class TransitiveSubtypeWitness : public SubtypeWitness
     SLANG_CLASS(TransitiveSubtypeWitness)
 
     // Witness that `sub : mid`
-    SubtypeWitness* subToMid;
+    SubtypeWitness* subToMid = nullptr;
 
     // Witness that `mid : sup`
     DeclRef<Decl> midToSup;

--- a/source/slang/slang-check-conformance.cpp
+++ b/source/slang/slang-check-conformance.cpp
@@ -61,7 +61,7 @@ namespace Slang
 
         // `witness` here will hold the first (outer-most) object
         // we create, which is the overall result.
-        SubtypeWitness* witness;
+        SubtypeWitness* witness = nullptr;
 
         // `link` will point at the remaining "hole" in the
         // data structure, to be filled in.
@@ -279,7 +279,7 @@ namespace Slang
             List<Val*> caseWitnesses;
             for(auto caseType : taggedUnionType->caseTypes)
             {
-                Val* caseWitness;
+                Val* caseWitness = nullptr;
 
                 if(!doesTypeConformToInterfaceImpl(
                     caseType,
@@ -343,7 +343,7 @@ namespace Slang
         Type*  type,
         DeclRef<InterfaceDecl>        interfaceDeclRef)
     {
-        Val* result;
+        Val* result = nullptr;
         doesTypeConformToInterfaceImpl(type, type, interfaceDeclRef, &result, nullptr);
         return result;
     }

--- a/source/slang/slang-check-conformance.cpp
+++ b/source/slang/slang-check-conformance.cpp
@@ -7,21 +7,24 @@
 
 namespace Slang
 {
-    RefPtr<DeclaredSubtypeWitness> SemanticsVisitor::createSimpleSubtypeWitness(
+    DeclaredSubtypeWitness* SemanticsVisitor::createSimpleSubtypeWitness(
         TypeWitnessBreadcrumb*  breadcrumb)
     {
-        RefPtr<DeclaredSubtypeWitness> witness = m_astBuilder->create<DeclaredSubtypeWitness>();
+        DeclaredSubtypeWitness* witness = m_astBuilder->create<DeclaredSubtypeWitness>();
         witness->sub = breadcrumb->sub;
         witness->sup = breadcrumb->sup;
         witness->declRef = breadcrumb->declRef;
         return witness;
     }
 
-    RefPtr<Val> SemanticsVisitor::createTypeWitness(
-        RefPtr<Type>            type,
+    Val* SemanticsVisitor::createTypeWitness(
+        Type*            type,
         DeclRef<InterfaceDecl>  interfaceDeclRef,
         TypeWitnessBreadcrumb*  inBreadcrumbs)
     {
+        SLANG_UNUSED(type);
+        SLANG_UNUSED(interfaceDeclRef);
+
         if(!inBreadcrumbs)
         {
             // We need to construct a witness to the fact
@@ -58,11 +61,11 @@ namespace Slang
 
         // `witness` here will hold the first (outer-most) object
         // we create, which is the overall result.
-        RefPtr<SubtypeWitness> witness;
+        SubtypeWitness* witness;
 
         // `link` will point at the remaining "hole" in the
         // data structure, to be filled in.
-        RefPtr<SubtypeWitness>* link = &witness;
+        SubtypeWitness** link = &witness;
 
         // As long as there is more than one breadcrumb, we
         // need to be creating transitive witnesses.
@@ -79,7 +82,7 @@ namespace Slang
             // where `[...]` represents the "hole" we leave
             // open to fill in next.
             //
-            RefPtr<TransitiveSubtypeWitness> transitiveWitness = m_astBuilder->create<TransitiveSubtypeWitness>();
+            TransitiveSubtypeWitness* transitiveWitness = m_astBuilder->create<TransitiveSubtypeWitness>();
             transitiveWitness->sub = bb->sub;
             transitiveWitness->sup = bb->sup;
             transitiveWitness->midToSup = bb->declRef;
@@ -97,7 +100,7 @@ namespace Slang
         // In our running example this would be `{ A : B }`. We create
         // a simple (declared) subtype witness for it, and plug the
         // final hole, after which there shouldn't be a hole to deal with.
-        RefPtr<DeclaredSubtypeWitness> declaredWitness = createSimpleSubtypeWitness(bb);
+        DeclaredSubtypeWitness* declaredWitness = createSimpleSubtypeWitness(bb);
         *link = declaredWitness;
 
         // We now know that our original `witness` variable has been
@@ -121,6 +124,8 @@ namespace Slang
         DeclRef<InterfaceDecl>  interfaceDeclRef,
         DeclRef<Decl>           requirementDeclRef)
     {
+        SLANG_UNUSED(interfaceDeclRef);
+
         if(auto callableDeclRef = requirementDeclRef.as<CallableDecl>())
         {
             // A `static` method requirement can't be satisfied by a
@@ -146,10 +151,10 @@ namespace Slang
     }
 
     bool SemanticsVisitor::doesTypeConformToInterfaceImpl(
-        RefPtr<Type>            originalType,
-        RefPtr<Type>            type,
+        Type*            originalType,
+        Type*            type,
         DeclRef<InterfaceDecl>  interfaceDeclRef,
-        RefPtr<Val>*            outWitness,
+        Val**            outWitness,
         TypeWitnessBreadcrumb*  inBreadcrumbs)
     {
         // for now look up a conformance member...
@@ -271,10 +276,10 @@ namespace Slang
             // value for the tagged union itself (that is, if
             // `outWitness` is non-null).
             //
-            List<RefPtr<Val>> caseWitnesses;
+            List<Val*> caseWitnesses;
             for(auto caseType : taggedUnionType->caseTypes)
             {
-                RefPtr<Val> caseWitness;
+                Val* caseWitness;
 
                 if(!doesTypeConformToInterfaceImpl(
                     caseType,
@@ -313,7 +318,7 @@ namespace Slang
             //
             if(outWitness)
             {
-                RefPtr<TaggedUnionSubtypeWitness> taggedUnionWitness = m_astBuilder->create<TaggedUnionSubtypeWitness>();
+                TaggedUnionSubtypeWitness* taggedUnionWitness = m_astBuilder->create<TaggedUnionSubtypeWitness>();
                 taggedUnionWitness->sub = taggedUnionType;
                 taggedUnionWitness->sup = DeclRefType::create(m_astBuilder, interfaceDeclRef);
                 taggedUnionWitness->caseWitnesses.swapWith(caseWitnesses);
@@ -328,33 +333,33 @@ namespace Slang
     }
 
     bool SemanticsVisitor::DoesTypeConformToInterface(
-        RefPtr<Type>  type,
+        Type*  type,
         DeclRef<InterfaceDecl>        interfaceDeclRef)
     {
         return doesTypeConformToInterfaceImpl(type, type, interfaceDeclRef, nullptr, nullptr);
     }
 
-    RefPtr<Val> SemanticsVisitor::tryGetInterfaceConformanceWitness(
-        RefPtr<Type>  type,
+    Val* SemanticsVisitor::tryGetInterfaceConformanceWitness(
+        Type*  type,
         DeclRef<InterfaceDecl>        interfaceDeclRef)
     {
-        RefPtr<Val> result;
+        Val* result;
         doesTypeConformToInterfaceImpl(type, type, interfaceDeclRef, &result, nullptr);
         return result;
     }
 
-    RefPtr<Val> SemanticsVisitor::createTypeEqualityWitness(
+    Val* SemanticsVisitor::createTypeEqualityWitness(
         Type*  type)
     {
-        RefPtr<TypeEqualityWitness> rs = m_astBuilder->create<TypeEqualityWitness>();
+        TypeEqualityWitness* rs = m_astBuilder->create<TypeEqualityWitness>();
         rs->sub = type;
         rs->sup = type;
         return rs;
     }
 
-    RefPtr<Val> SemanticsVisitor::tryGetSubtypeWitness(
-        RefPtr<Type>    sub,
-        RefPtr<Type>    sup)
+    Val* SemanticsVisitor::tryGetSubtypeWitness(
+        Type*    sub,
+        Type*    sup)
     {
         if(sub->equals(sup))
         {

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -215,7 +215,7 @@ namespace Slang
 
             for(UInt ee = 0; ee < elementCount; ++ee)
             {
-                Expr* coercedArg;
+                Expr* coercedArg = nullptr;
                 bool argResult = _readValueFromInitializerList(
                     toElementType,
                     outToExpr ? &coercedArg : nullptr,
@@ -263,7 +263,7 @@ namespace Slang
 
                 for(UInt ee = 0; ee < elementCount; ++ee)
                 {
-                    Expr* coercedArg;
+                    Expr* coercedArg = nullptr;
                     bool argResult = _readValueFromInitializerList(
                         toElementType,
                         outToExpr ? &coercedArg : nullptr,
@@ -289,7 +289,7 @@ namespace Slang
                 UInt elementCount = 0;
                 while(ioArgIndex < argCount)
                 {
-                    Expr* coercedArg;
+                    Expr* coercedArg = nullptr;
                     bool argResult = _readValueFromInitializerList(
                         toElementType,
                         outToExpr ? &coercedArg : nullptr,
@@ -352,7 +352,7 @@ namespace Slang
 
             for(UInt rr = 0; rr < rowCount; ++rr)
             {
-                Expr* coercedArg;
+                Expr* coercedArg = nullptr;
                 bool argResult = _readValueFromInitializerList(
                     toRowType,
                     outToExpr ? &coercedArg : nullptr,
@@ -380,7 +380,7 @@ namespace Slang
                 //
                 for(auto fieldDeclRef : getMembersOfType<VarDecl>(toStructDeclRef, MemberFilterStyle::Instance))
                 {
-                    Expr* coercedArg;
+                    Expr* coercedArg = nullptr;
                     bool argResult = _readValueFromInitializerList(
                         getType(m_astBuilder, fieldDeclRef),
                         outToExpr ? &coercedArg : nullptr,
@@ -852,7 +852,7 @@ namespace Slang
         Type*    toType,
         Expr*    fromExpr)
     {
-        Expr* expr;
+        Expr* expr = nullptr;
         if (!_coerce(
             toType,
             &expr,

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -24,7 +24,7 @@ namespace Slang
     }
 
     bool SemanticsVisitor::isEffectivelyScalarForInitializerLists(
-        RefPtr<Type>    type)
+        Type*    type)
     {
         if(as<ArrayExpressionType>(type)) return false;
         if(as<VectorExpressionType>(type)) return false;
@@ -58,8 +58,8 @@ namespace Slang
     }
 
     bool SemanticsVisitor::shouldUseInitializerDirectly(
-        RefPtr<Type>    toType,
-        RefPtr<Expr>    fromExpr)
+        Type*    toType,
+        Expr*    fromExpr)
     {
         // A nested initializer list should always be used directly.
         //
@@ -89,9 +89,9 @@ namespace Slang
     }
 
     bool SemanticsVisitor::_readValueFromInitializerList(
-        RefPtr<Type>                toType,
-        RefPtr<Expr>*               outToExpr,
-        RefPtr<InitializerListExpr> fromInitializerListExpr,
+        Type*                toType,
+        Expr**               outToExpr,
+        InitializerListExpr* fromInitializerListExpr,
         UInt                       &ioInitArgIndex)
     {
         // First, we will check if we have run out of arguments
@@ -152,9 +152,9 @@ namespace Slang
     }
 
     bool SemanticsVisitor::_readAggregateValueFromInitializerList(
-        RefPtr<Type>                inToType,
-        RefPtr<Expr>*               outToExpr,
-        RefPtr<InitializerListExpr> fromInitializerListExpr,
+        Type*                inToType,
+        Expr**               outToExpr,
+        InitializerListExpr* fromInitializerListExpr,
         UInt                       &ioArgIndex)
     {
         auto toType = inToType;
@@ -162,7 +162,7 @@ namespace Slang
 
         // In the case where we need to build a result expression,
         // we will collect the new arguments here
-        List<RefPtr<Expr>> coercedArgs;
+        List<Expr*> coercedArgs;
 
         if(isEffectivelyScalarForInitializerLists(toType))
         {
@@ -215,7 +215,7 @@ namespace Slang
 
             for(UInt ee = 0; ee < elementCount; ++ee)
             {
-                RefPtr<Expr> coercedArg;
+                Expr* coercedArg;
                 bool argResult = _readValueFromInitializerList(
                     toElementType,
                     outToExpr ? &coercedArg : nullptr,
@@ -263,7 +263,7 @@ namespace Slang
 
                 for(UInt ee = 0; ee < elementCount; ++ee)
                 {
-                    RefPtr<Expr> coercedArg;
+                    Expr* coercedArg;
                     bool argResult = _readValueFromInitializerList(
                         toElementType,
                         outToExpr ? &coercedArg : nullptr,
@@ -289,7 +289,7 @@ namespace Slang
                 UInt elementCount = 0;
                 while(ioArgIndex < argCount)
                 {
-                    RefPtr<Expr> coercedArg;
+                    Expr* coercedArg;
                     bool argResult = _readValueFromInitializerList(
                         toElementType,
                         outToExpr ? &coercedArg : nullptr,
@@ -352,7 +352,7 @@ namespace Slang
 
             for(UInt rr = 0; rr < rowCount; ++rr)
             {
-                RefPtr<Expr> coercedArg;
+                Expr* coercedArg;
                 bool argResult = _readValueFromInitializerList(
                     toRowType,
                     outToExpr ? &coercedArg : nullptr,
@@ -380,7 +380,7 @@ namespace Slang
                 //
                 for(auto fieldDeclRef : getMembersOfType<VarDecl>(toStructDeclRef, MemberFilterStyle::Instance))
                 {
-                    RefPtr<Expr> coercedArg;
+                    Expr* coercedArg;
                     bool argResult = _readValueFromInitializerList(
                         getType(m_astBuilder, fieldDeclRef),
                         outToExpr ? &coercedArg : nullptr,
@@ -429,9 +429,9 @@ namespace Slang
     }
 
     bool SemanticsVisitor::_coerceInitializerList(
-        RefPtr<Type>                toType,
-        RefPtr<Expr>*               outToExpr,
-        RefPtr<InitializerListExpr> fromInitializerListExpr)
+        Type*                toType,
+        Expr**               outToExpr,
+        InitializerListExpr* fromInitializerListExpr)
     {
         UInt argCount = fromInitializerListExpr->args.getCount();
         UInt argIndex = 0;
@@ -454,9 +454,9 @@ namespace Slang
     }
 
     bool SemanticsVisitor::_failedCoercion(
-        RefPtr<Type>    toType,
-        RefPtr<Expr>*   outToExpr,
-        RefPtr<Expr>    fromExpr)
+        Type*    toType,
+        Expr**   outToExpr,
+        Expr*    fromExpr)
     {
         if(outToExpr)
         {
@@ -478,10 +478,10 @@ namespace Slang
     }
 
     bool SemanticsVisitor::_coerce(
-        RefPtr<Type>    toType,
-        RefPtr<Expr>*   outToExpr,
-        RefPtr<Type>    fromType,
-        RefPtr<Expr>    fromExpr,
+        Type*    toType,
+        Expr**   outToExpr,
+        Type*    fromType,
+        Expr*    fromExpr,
         ConversionCost* outCost)
     {
         // An important and easy case is when the "to" and "from" types are equal.
@@ -571,7 +571,7 @@ namespace Slang
             //
             ConversionCost subCost = kConversionCost_None;
 
-            RefPtr<DerefExpr> derefExpr;
+            DerefExpr* derefExpr = nullptr;
             if(outToExpr)
             {
                 derefExpr = m_astBuilder->create<DerefExpr>();
@@ -754,8 +754,8 @@ namespace Slang
     }
 
     bool SemanticsVisitor::canCoerce(
-        RefPtr<Type>    toType,
-        RefPtr<Type>    fromType,
+        Type*    toType,
+        Type*    fromType,
         ConversionCost* outCost)
     {
         // As an optimization, we will maintain a cache of conversion results
@@ -767,8 +767,8 @@ namespace Slang
         TypeCheckingCache* typeCheckingCache = getSession()->getTypeCheckingCache();
 
         BasicTypeKeyPair cacheKey;
-        cacheKey.type1 = makeBasicTypeKey(toType.Ptr());
-        cacheKey.type2 = makeBasicTypeKey(fromType.Ptr());
+        cacheKey.type1 = makeBasicTypeKey(toType);
+        cacheKey.type2 = makeBasicTypeKey(fromType);
     
         if( cacheKey.isValid())
         {
@@ -811,16 +811,16 @@ namespace Slang
         return rs;
     }
 
-    RefPtr<TypeCastExpr> SemanticsVisitor::createImplicitCastExpr()
+    TypeCastExpr* SemanticsVisitor::createImplicitCastExpr()
     {
         return m_astBuilder->create<ImplicitCastExpr>();
     }
 
-    RefPtr<Expr> SemanticsVisitor::CreateImplicitCastExpr(
-        RefPtr<Type>	toType,
-        RefPtr<Expr>	fromExpr)
+    Expr* SemanticsVisitor::CreateImplicitCastExpr(
+        Type*	toType,
+        Expr*	fromExpr)
     {
-        RefPtr<TypeCastExpr> castExpr = createImplicitCastExpr();
+        TypeCastExpr* castExpr = createImplicitCastExpr();
 
         auto typeType = m_astBuilder->getTypeType(toType);
 
@@ -835,12 +835,12 @@ namespace Slang
         return castExpr;
     }
 
-    RefPtr<Expr> SemanticsVisitor::createCastToInterfaceExpr(
-        RefPtr<Type>    toType,
-        RefPtr<Expr>    fromExpr,
-        RefPtr<Val>     witness)
+    Expr* SemanticsVisitor::createCastToInterfaceExpr(
+        Type*    toType,
+        Expr*    fromExpr,
+        Val*     witness)
     {
-        RefPtr<CastToInterfaceExpr> expr = m_astBuilder->create<CastToInterfaceExpr>();
+        CastToInterfaceExpr* expr = m_astBuilder->create<CastToInterfaceExpr>();
         expr->loc = fromExpr->loc;
         expr->type = QualType(toType);
         expr->valueArg = fromExpr;
@@ -848,16 +848,16 @@ namespace Slang
         return expr;
     }
 
-    RefPtr<Expr> SemanticsVisitor::coerce(
-        RefPtr<Type>    toType,
-        RefPtr<Expr>    fromExpr)
+    Expr* SemanticsVisitor::coerce(
+        Type*    toType,
+        Expr*    fromExpr)
     {
-        RefPtr<Expr> expr;
+        Expr* expr;
         if (!_coerce(
             toType,
             &expr,
-            fromExpr->type.Ptr(),
-            fromExpr.Ptr(),
+            fromExpr->type,
+            fromExpr,
             nullptr))
         {
             // Note(tfoley): We don't call `CreateErrorExpr` here, because that would
@@ -872,8 +872,8 @@ namespace Slang
     }
 
     bool SemanticsVisitor::canConvertImplicitly(
-        RefPtr<Type> toType,
-        RefPtr<Type> fromType)
+        Type* toType,
+        Type* fromType)
     {
         // Can we convert at all?
         ConversionCost conversionCost;

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -764,7 +764,7 @@ namespace Slang
         
         bool shouldAddToCache = false;
         ConversionCost cost;
-        TypeCheckingCache* typeCheckingCache = getSession()->getTypeCheckingCache();
+        TypeCheckingCache* typeCheckingCache = getLinkage()->getTypeCheckingCache();
 
         BasicTypeKeyPair cacheKey;
         cacheKey.type1 = makeBasicTypeKey(toType);

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -438,7 +438,7 @@ namespace Slang
         DeclRef<Decl>   declRef,
         SourceLoc       loc)
     {
-        Type* typeResult;
+        Type* typeResult = nullptr;
         return getTypeForDeclRef(astBuilder, nullptr, nullptr, declRef, &typeResult, loc);
     }
 
@@ -2486,7 +2486,7 @@ namespace Slang
             // Then we will compare the parameter types of `foo2`
             // against the specialization `foo1<U>`.
             //
-            GenericSubstitution* subst;
+            GenericSubstitution* subst = nullptr;
             if(!doGenericSignaturesMatch(newGenericDecl, oldGenericDecl, &subst))
                 return SLANG_OK;
 
@@ -3152,7 +3152,7 @@ namespace Slang
 
     QualType SemanticsVisitor::GetTypeForDeclRef(DeclRef<Decl> declRef, SourceLoc loc)
     {
-        Type* typeResult;
+        Type* typeResult = nullptr;
         return getTypeForDeclRef(
             m_astBuilder,
             this,

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -42,7 +42,7 @@ namespace Slang
         void visitDecl(Decl*) {}
         void visitDeclGroup(DeclGroup*) {}
 
-        void checkVarDeclCommon(RefPtr<VarDeclBase> varDecl);
+        void checkVarDeclCommon(VarDeclBase* varDecl);
 
         void visitVarDecl(VarDecl* varDecl)
         {
@@ -135,7 +135,7 @@ namespace Slang
         void visitDecl(Decl*) {}
         void visitDeclGroup(DeclGroup*) {}
 
-        void checkVarDeclCommon(RefPtr<VarDeclBase> varDecl);
+        void checkVarDeclCommon(VarDeclBase* varDecl);
 
         void visitVarDecl(VarDecl* varDecl)
         {
@@ -276,7 +276,7 @@ namespace Slang
         SemanticsVisitor*       sema,
         DiagnosticSink*         sink,
         DeclRef<Decl>           declRef,
-        RefPtr<Type>*           outTypeResult,
+        Type**           outTypeResult,
         SourceLoc               loc)
     {
         if( sema )
@@ -438,14 +438,14 @@ namespace Slang
         DeclRef<Decl>   declRef,
         SourceLoc       loc)
     {
-        RefPtr<Type> typeResult;
+        Type* typeResult;
         return getTypeForDeclRef(astBuilder, nullptr, nullptr, declRef, &typeResult, loc);
     }
 
     DeclRef<ExtensionDecl> ApplyExtensionToType(
         SemanticsVisitor*       semantics,
         ExtensionDecl*          extDecl,
-        RefPtr<Type>  type)
+        Type*  type)
     {
         if(!semantics)
             return DeclRef<ExtensionDecl>();
@@ -453,12 +453,12 @@ namespace Slang
         return semantics->ApplyExtensionToType(extDecl, type);
     }
 
-    RefPtr<GenericSubstitution> createDefaultSubstitutionsForGeneric(
+    GenericSubstitution* createDefaultSubstitutionsForGeneric(
         ASTBuilder*             astBuilder, 
         GenericDecl*            genericDecl,
-        RefPtr<Substitutions>   outerSubst)
+        Substitutions*   outerSubst)
     {
-        RefPtr<GenericSubstitution> genericSubst = astBuilder->create<GenericSubstitution>();
+        GenericSubstitution* genericSubst = astBuilder->create<GenericSubstitution>();
         genericSubst->genericDecl = genericDecl;
         genericSubst->outer = outerSubst;
 
@@ -479,7 +479,7 @@ namespace Slang
         {
             if (auto genericTypeConstraintDecl = as<GenericTypeConstraintDecl>(mm))
             {
-                RefPtr<DeclaredSubtypeWitness> witness = astBuilder->create<DeclaredSubtypeWitness>();
+                DeclaredSubtypeWitness* witness = astBuilder->create<DeclaredSubtypeWitness>();
                 witness->declRef = DeclRef<Decl>(genericTypeConstraintDecl, outerSubst);
                 witness->sub = genericTypeConstraintDecl->sub.type;
                 witness->sup = genericTypeConstraintDecl->sup.type;
@@ -507,7 +507,7 @@ namespace Slang
             if(decl != genericDecl->inner)
                 return outerSubstSet;
 
-            RefPtr<GenericSubstitution> genericSubst = createDefaultSubstitutionsForGeneric(
+            GenericSubstitution* genericSubst = createDefaultSubstitutionsForGeneric(
                 astBuilder,
                 genericDecl,
                 outerSubstSet.substitutions);
@@ -761,7 +761,7 @@ namespace Slang
         return true;
     }
 
-    void SemanticsDeclHeaderVisitor::checkVarDeclCommon(RefPtr<VarDeclBase> varDecl)
+    void SemanticsDeclHeaderVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
     {
         // A variable that didn't have an explicit type written must
         // have its type inferred from the initial-value expression.
@@ -837,7 +837,7 @@ namespace Slang
         }
     }
 
-    void SemanticsDeclBodyVisitor::checkVarDeclCommon(RefPtr<VarDeclBase> varDecl)
+    void SemanticsDeclBodyVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
     {
         if (auto initExpr = varDecl->initExpr)
         {
@@ -994,7 +994,7 @@ namespace Slang
                 return;
             }
         }
-        else if(base.type.is<ErrorType>())
+        else if(as<ErrorType>(base.type))
         {
             // If an error was already produced, don't emit a cascading error.
             return;
@@ -1264,13 +1264,13 @@ namespace Slang
         // be compared).
 
         return doesMemberSatisfyRequirement(
-            DeclRef<Decl>(genDecl.getDecl()->inner.Ptr(), genDecl.substitutions),
-            DeclRef<Decl>(requirementGenDecl.getDecl()->inner.Ptr(), requirementGenDecl.substitutions),
+            DeclRef<Decl>(genDecl.getDecl()->inner, genDecl.substitutions),
+            DeclRef<Decl>(requirementGenDecl.getDecl()->inner, requirementGenDecl.substitutions),
             witnessTable);
     }
 
     bool SemanticsVisitor::doesTypeSatisfyAssociatedTypeRequirement(
-        RefPtr<Type>            satisfyingType,
+        Type*            satisfyingType,
         DeclRef<AssocTypeDecl>  requiredAssociatedTypeDeclRef,
         RefPtr<WitnessTable>    witnessTable)
     {
@@ -1427,6 +1427,8 @@ namespace Slang
         DeclRef<Decl>               requiredMemberDeclRef,
         RefPtr<WitnessTable>        witnessTable)
     {
+        SLANG_UNUSED(interfaceDeclRef)
+
         // The goal of this function is to find a suitable
         // value to satisfy the requirement.
         //
@@ -1609,7 +1611,7 @@ namespace Slang
             //
             // TODO: need to decide if a this-type substitution is needed here.
             // It probably it.
-            RefPtr<Type> targetType = DeclRefType::create(m_astBuilder, interfaceDeclRef);
+            Type* targetType = DeclRefType::create(m_astBuilder, interfaceDeclRef);
             auto extDeclRef = ApplyExtensionToType(candidateExt, targetType);
             if(!extDeclRef)
                 continue;
@@ -1800,7 +1802,7 @@ namespace Slang
         // "inherit" from a concrete type.
         // This will become the "tag" type
         // of the enum.
-        RefPtr<Type>        tagType;
+        Type* tagType = nullptr;
         InheritanceDecl*    tagTypeInheritanceDecl = nullptr;
         for(auto inheritanceDecl : decl->getMembersOfType<InheritanceDecl>())
         {
@@ -1869,9 +1871,9 @@ namespace Slang
         // seems like the best place to do it.
         {
             // First, look up the type of the `__EnumType` interface.
-            RefPtr<Type> enumTypeType = getASTBuilder()->getEnumTypeType();
+            Type* enumTypeType = getASTBuilder()->getEnumTypeType();
 
-            RefPtr<InheritanceDecl> enumConformanceDecl = m_astBuilder->create<InheritanceDecl>();
+            InheritanceDecl* enumConformanceDecl = m_astBuilder->create<InheritanceDecl>();
             enumConformanceDecl->parentDecl = decl;
             enumConformanceDecl->loc = decl->loc;
             enumConformanceDecl->base.type = getASTBuilder()->getEnumTypeType();
@@ -1887,7 +1889,7 @@ namespace Slang
 
             Name* tagAssociatedTypeName = getSession()->getNameObj("__Tag");
             Decl* tagAssociatedTypeDecl = nullptr;
-            if(auto enumTypeTypeDeclRefType = enumTypeType.dynamicCast<DeclRefType>())
+            if(auto enumTypeTypeDeclRefType = dynamicCast<DeclRefType>(enumTypeType))
             {
                 if(auto enumTypeTypeInterfaceDecl = as<InterfaceDecl>(enumTypeTypeDeclRefType->declRef.getDecl()))
                 {
@@ -1955,7 +1957,7 @@ namespace Slang
                 // the tag value for a successor case that doesn't
                 // provide an explicit tag.
 
-                RefPtr<IntVal> explicitTagVal = TryConstantFoldExpr(explicitTagValExpr);
+                IntVal* explicitTagVal = TryConstantFoldExpr(explicitTagValExpr);
                 if(explicitTagVal)
                 {
                     if(auto constIntVal = as<ConstantIntVal>(explicitTagVal))
@@ -1979,7 +1981,7 @@ namespace Slang
             {
                 // This tag has no initializer, so it should use
                 // the default tag value we are tracking.
-                RefPtr<IntegerLiteralExpr> tagValExpr = m_astBuilder->create<IntegerLiteralExpr>();
+                IntegerLiteralExpr* tagValExpr = m_astBuilder->create<IntegerLiteralExpr>();
                 tagValExpr->loc = caseDecl->loc;
                 tagValExpr->type = QualType(tagType);
                 tagValExpr->value = defaultTag;
@@ -2096,7 +2098,7 @@ namespace Slang
     bool SemanticsVisitor::doGenericSignaturesMatch(
         GenericDecl*                    left,
         GenericDecl*                    right,
-        RefPtr<GenericSubstitution>*    outSubstRightToLeft)
+        GenericSubstitution**    outSubstRightToLeft)
     {
         // Our first goal here is to determine if `left` and
         // `right` have equivalent lists of explicit
@@ -2358,10 +2360,10 @@ namespace Slang
         return true;
     }
 
-    RefPtr<GenericSubstitution> SemanticsVisitor::createDummySubstitutions(
+    GenericSubstitution* SemanticsVisitor::createDummySubstitutions(
         GenericDecl* genericDecl)
     {
-        RefPtr<GenericSubstitution> subst = m_astBuilder->create<GenericSubstitution>();
+        GenericSubstitution* subst = m_astBuilder->create<GenericSubstitution>();
         subst->genericDecl = genericDecl;
         for (auto dd : genericDecl->members)
         {
@@ -2484,7 +2486,7 @@ namespace Slang
             // Then we will compare the parameter types of `foo2`
             // against the specialization `foo1<U>`.
             //
-            RefPtr<GenericSubstitution> subst;
+            GenericSubstitution* subst;
             if(!doGenericSignaturesMatch(newGenericDecl, oldGenericDecl, &subst))
                 return SLANG_OK;
 
@@ -2785,7 +2787,7 @@ namespace Slang
         checkCallableDeclCommon(funcDecl);
     }
 
-    IntegerLiteralValue SemanticsVisitor::GetMinBound(RefPtr<IntVal> val)
+    IntegerLiteralValue SemanticsVisitor::GetMinBound(IntVal* val)
     {
         if (auto constantVal = as<ConstantIntVal>(val))
             return constantVal->value;
@@ -2870,7 +2872,7 @@ namespace Slang
         getSink()->diagnose(decl->targetType.exp, Diagnostics::unimplemented, "expected a nominal type here");
     }
 
-    RefPtr<Type> SemanticsVisitor::calcThisType(DeclRef<Decl> declRef)
+    Type* SemanticsVisitor::calcThisType(DeclRef<Decl> declRef)
     {
         if( auto interfaceDeclRef = declRef.as<InterfaceDecl>() )
         {
@@ -2879,7 +2881,7 @@ namespace Slang
             // conform to the interface and fill in its
             // requirements.
             //
-            RefPtr<ThisType> thisType = m_astBuilder->create<ThisType>();
+            ThisType* thisType = m_astBuilder->create<ThisType>();
             thisType->interfaceDeclRef = interfaceDeclRef;
             return thisType;
         }
@@ -2928,7 +2930,7 @@ namespace Slang
         }
     }
 
-    RefPtr<Type> SemanticsVisitor::calcThisType(Type* type)
+    Type* SemanticsVisitor::calcThisType(Type* type)
     {
         if( auto declRefType = as<DeclRefType>(type) )
         {
@@ -2940,7 +2942,7 @@ namespace Slang
         }
     }
 
-    RefPtr<Type> SemanticsVisitor::findResultTypeForConstructorDecl(ConstructorDecl* decl)
+    Type* SemanticsVisitor::findResultTypeForConstructorDecl(ConstructorDecl* decl)
     {
         // We want to look at the parent of the declaration,
         // but if the declaration is generic, the parent will be
@@ -2994,7 +2996,7 @@ namespace Slang
 
         if(!anyAccessors)
         {
-            RefPtr<GetterDecl> getterDecl = m_astBuilder->create<GetterDecl>();
+            GetterDecl* getterDecl = m_astBuilder->create<GetterDecl>();
             getterDecl->loc = decl->loc;
 
             getterDecl->parentDecl = decl;
@@ -3035,7 +3037,7 @@ namespace Slang
 
     DeclRef<ExtensionDecl> SemanticsVisitor::ApplyExtensionToType(
         ExtensionDecl*  extDecl,
-        RefPtr<Type>    type)
+        Type*    type)
     {
         DeclRef<ExtensionDecl> extDeclRef = makeDeclRef(extDecl);
 
@@ -3064,7 +3066,7 @@ namespace Slang
         }
 
         // Now extract the target type from our (possibly specialized) extension decl-ref.
-        RefPtr<Type> targetType = getTargetType(m_astBuilder, extDeclRef);
+        Type* targetType = getTargetType(m_astBuilder, extDeclRef);
 
         // As a bit of a kludge here, if the target type of the extension is
         // an interface, and the `type` we are trying to match up has a this-type
@@ -3085,17 +3087,17 @@ namespace Slang
                         {
                             // Looks like we have a match in the types,
                             // now let's see if we have a this-type substitution.
-                            if(auto appThisTypeSubst = appInterfaceDeclRef.substitutions.substitutions.as<ThisTypeSubstitution>())
+                            if(auto appThisTypeSubst = as<ThisTypeSubstitution>(appInterfaceDeclRef.substitutions.substitutions))
                             {
                                 if(appThisTypeSubst->interfaceDecl == appInterfaceDeclRef.getDecl())
                                 {
                                     // The type we want to apply to has a this-type substitution,
                                     // and (by construction) the target type currently does not.
                                     //
-                                    SLANG_ASSERT(!targetInterfaceDeclRef.substitutions.substitutions.as<ThisTypeSubstitution>());
+                                    SLANG_ASSERT(!as<ThisTypeSubstitution>(targetInterfaceDeclRef.substitutions.substitutions));
 
                                     // We will create a new substitution to apply to the target type.
-                                    RefPtr<ThisTypeSubstitution> newTargetSubst = m_astBuilder->create<ThisTypeSubstitution>();
+                                    ThisTypeSubstitution* newTargetSubst = m_astBuilder->create<ThisTypeSubstitution>();
                                     newTargetSubst->interfaceDecl = appThisTypeSubst->interfaceDecl;
                                     newTargetSubst->witness = appThisTypeSubst->witness;
                                     newTargetSubst->outer = targetInterfaceDeclRef.substitutions.substitutions;
@@ -3110,7 +3112,7 @@ namespace Slang
                                     // references to the target type of the extension
                                     // declaration have a chance to resolve the way we want them to.
 
-                                    RefPtr<ThisTypeSubstitution> newExtSubst = m_astBuilder->create<ThisTypeSubstitution>();
+                                    ThisTypeSubstitution* newExtSubst = m_astBuilder->create<ThisTypeSubstitution>();
                                     newExtSubst->interfaceDecl = appThisTypeSubst->interfaceDecl;
                                     newExtSubst->witness = appThisTypeSubst->witness;
                                     newExtSubst->outer = extDeclRef.substitutions.substitutions;
@@ -3150,7 +3152,7 @@ namespace Slang
 
     QualType SemanticsVisitor::GetTypeForDeclRef(DeclRef<Decl> declRef, SourceLoc loc)
     {
-        RefPtr<Type> typeResult;
+        Type* typeResult;
         return getTypeForDeclRef(
             m_astBuilder,
             this,
@@ -3187,7 +3189,7 @@ namespace Slang
             if (!importDecl->hasModifier<ExportedModifier>())
                 continue;
 
-            importModuleIntoScope(scope, importDecl->importedModuleDecl.Ptr());
+            importModuleIntoScope(scope, importDecl->importedModuleDecl);
         }
     }
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1094,7 +1094,7 @@ namespace Slang
         // TODO: This could be factored into another visitor pass
         // that fits more with the standard checking below.
         //
-        for(auto& importDecl : moduleDecl->getMembersOfType<ImportDecl>())
+        for(auto importDecl : moduleDecl->getMembersOfType<ImportDecl>())
         {
             ensureDecl(importDecl, DeclCheckState::Checked);
         }
@@ -2765,7 +2765,7 @@ namespace Slang
 
     void SemanticsDeclHeaderVisitor::checkCallableDeclCommon(CallableDecl* decl)
     {
-        for(auto& paramDecl : decl->getParameters())
+        for(auto paramDecl : decl->getParameters())
         {
             ensureDecl(paramDecl, DeclCheckState::ReadyForReference);
         }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -679,7 +679,7 @@ namespace Slang
         bool hasIntArgs(Attribute* attr, int numArgs);
         bool hasStringArgs(Attribute* attr, int numArgs);
 
-        bool getAttributeTargetSyntaxClasses(SyntaxClass<RefObject> & cls, uint32_t typeFlags);
+        bool getAttributeTargetSyntaxClasses(SyntaxClass<NodeBase> & cls, uint32_t typeFlags);
 
         bool validateAttribute(Attribute* attr, AttributeDecl* attribClassDecl);
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -16,7 +16,7 @@ namespace Slang
     bool isEffectivelyStatic(
         Decl*           decl);
 
-    RefPtr<Type> checkProperType(
+    Type* checkProperType(
         Linkage*        linkage,
         TypeExp         typeExp,
         DiagnosticSink* sink);
@@ -129,7 +129,7 @@ namespace Slang
                     //
                     Decl* funcDecl = overloadedBase->lookupResult2.item.declRef.decl;
                     if (auto genDecl = as<GenericDecl>(funcDecl))
-                        funcDecl = genDecl->inner.Ptr();
+                        funcDecl = genDecl->inner;
 
                     // Reject definitions that have the wrong fixity.
                     //
@@ -175,7 +175,7 @@ namespace Slang
         LookupResultItem item;
 
         // The type of the result expression if this candidate is selected
-        RefPtr<Type>	resultType;
+        Type*	resultType;
 
         // A system for tracking constraints introduced on generic parameters
         //            ConstraintSystem constraintSystem;
@@ -187,7 +187,7 @@ namespace Slang
         // When required, a candidate can store a pre-checked list of
         // arguments so that we don't have to repeat work across checking
         // phases. Currently this is only needed for generics.
-        RefPtr<Substitutions>   subst;
+        Substitutions*   subst;
     };
 
     struct TypeCheckingCache
@@ -276,13 +276,13 @@ namespace Slang
         // Translate Types
 
 
-        RefPtr<Expr> TranslateTypeNodeImpl(const RefPtr<Expr> & node);
-        RefPtr<Type> ExtractTypeFromTypeRepr(const RefPtr<Expr>& typeRepr);
-        RefPtr<Type> TranslateTypeNode(const RefPtr<Expr> & node);
+        Expr* TranslateTypeNodeImpl(Expr* node);
+        Type* ExtractTypeFromTypeRepr(Expr* typeRepr);
+        Type* TranslateTypeNode(Expr* node);
         TypeExp TranslateTypeNodeForced(TypeExp const& typeExp);
         TypeExp TranslateTypeNode(TypeExp const& typeExp);
 
-        RefPtr<DeclRefType> getExprDeclRefType(Expr * expr);
+        DeclRefType* getExprDeclRefType(Expr * expr);
 
             /// Is `decl` usable as a static member?
         bool isDeclUsableAsStaticMember(
@@ -298,7 +298,7 @@ namespace Slang
             /// the temporary, and the computation created by `func`.
             ///
         template<typename F>
-        RefPtr<Expr> moveTemp(RefPtr<Expr> const& expr, F const& func);
+        Expr* moveTemp(Expr* const& expr, F const& func);
 
             /// Execute `func` on a variable with the value of `expr`.
             ///
@@ -307,7 +307,7 @@ namespace Slang
             /// a new variable to hold `expr`, using `moveTemp()`.
             ///
         template<typename F>
-        RefPtr<Expr> maybeMoveTemp(RefPtr<Expr> const& expr, F const& func);
+        Expr* maybeMoveTemp(Expr* const& expr, F const& func);
 
             /// Return an expression that represents "opening" the existential `expr`.
             ///
@@ -327,8 +327,8 @@ namespace Slang
             /// returns an expression that logically corresponds to `v`: an expression
             /// of type `X`, where the type carries the knowledge that `X` implements `IMover`.
             ///
-        RefPtr<Expr> openExistential(
-            RefPtr<Expr>            expr,
+        Expr* openExistential(
+            Expr*            expr,
             DeclRef<InterfaceDecl>  interfaceDeclRef);
 
             /// If `expr` has existential type, then open it.
@@ -339,26 +339,26 @@ namespace Slang
             /// See `openExistential` for a discussion of what "opening" an
             /// existential-type value means.
             ///
-        RefPtr<Expr> maybeOpenExistential(RefPtr<Expr> expr);
+        Expr* maybeOpenExistential(Expr* expr);
 
-        RefPtr<Expr> ConstructDeclRefExpr(
+        Expr* ConstructDeclRefExpr(
             DeclRef<Decl>   declRef,
-            RefPtr<Expr>    baseExpr,
+            Expr*    baseExpr,
             SourceLoc       loc);
 
-        RefPtr<Expr> ConstructDerefExpr(
-            RefPtr<Expr>    base,
+        Expr* ConstructDerefExpr(
+            Expr*    base,
             SourceLoc       loc);
 
-        RefPtr<Expr> ConstructLookupResultExpr(
+        Expr* ConstructLookupResultExpr(
             LookupResultItem const& item,
-            RefPtr<Expr>            baseExpr,
+            Expr*            baseExpr,
             SourceLoc               loc);
 
-        RefPtr<Expr> createLookupResultExpr(
+        Expr* createLookupResultExpr(
             Name*                   name,
             LookupResult const&     lookupResult,
-            RefPtr<Expr>            baseExpr,
+            Expr*            baseExpr,
             SourceLoc               loc);
 
             /// Attempt to "resolve" an overloaded `LookupResult` to only include the "best" results
@@ -373,38 +373,38 @@ namespace Slang
             /// appropriate "ambiguous reference" error will be reported, and an error expression will be returned.
             /// Otherwise, the original expression is returned if resolution fails.
             ///
-        RefPtr<Expr> maybeResolveOverloadedExpr(RefPtr<Expr> expr, LookupMask mask, DiagnosticSink* diagSink);
+        Expr* maybeResolveOverloadedExpr(Expr* expr, LookupMask mask, DiagnosticSink* diagSink);
 
             /// Attempt to resolve `overloadedExpr` into an expression that refers to a single declaration/value.
             ///
             /// Equivalent to `maybeResolveOverloadedExpr` with `diagSink` bound to the sink for the `SemanticsVisitor`.
-        RefPtr<Expr> resolveOverloadedExpr(RefPtr<OverloadedExpr> overloadedExpr, LookupMask mask);
+        Expr* resolveOverloadedExpr(OverloadedExpr* overloadedExpr, LookupMask mask);
 
             /// Worker reoutine for `maybeResolveOverloadedExpr` and `resolveOverloadedExpr`.
-        RefPtr<Expr> _resolveOverloadedExprImpl(RefPtr<OverloadedExpr> overloadedExpr, LookupMask mask, DiagnosticSink* diagSink);
+        Expr* _resolveOverloadedExprImpl(OverloadedExpr* overloadedExpr, LookupMask mask, DiagnosticSink* diagSink);
 
         void diagnoseAmbiguousReference(OverloadedExpr* overloadedExpr, LookupResult const& lookupResult);
         void diagnoseAmbiguousReference(Expr* overloadedExpr);
 
 
-        RefPtr<Expr> ExpectATypeRepr(RefPtr<Expr> expr);
+        Expr* ExpectATypeRepr(Expr* expr);
 
-        RefPtr<Type> ExpectAType(RefPtr<Expr> expr);
+        Type* ExpectAType(Expr* expr);
 
-        RefPtr<Type> ExtractGenericArgType(RefPtr<Expr> exp);
+        Type* ExtractGenericArgType(Expr* exp);
 
-        RefPtr<IntVal> ExtractGenericArgInteger(RefPtr<Expr> exp, DiagnosticSink* sink);
-        RefPtr<IntVal> ExtractGenericArgInteger(RefPtr<Expr> exp);
+        IntVal* ExtractGenericArgInteger(Expr* exp, DiagnosticSink* sink);
+        IntVal* ExtractGenericArgInteger(Expr* exp);
 
-        RefPtr<Val> ExtractGenericArgVal(RefPtr<Expr> exp);
+        Val* ExtractGenericArgVal(Expr* exp);
 
         // Construct a type representing the instantiation of
         // the given generic declaration for the given arguments.
         // The arguments should already be checked against
         // the declaration.
-        RefPtr<Type> InstantiateGenericType(
+        Type* InstantiateGenericType(
             DeclRef<GenericDecl>        genericDeclRef,
-            List<RefPtr<Expr>> const&   args);
+            List<Expr*> const&   args);
 
         // These routines are bottlenecks for semantic checking,
         // so that we can add some quality-of-life features for users
@@ -459,7 +459,7 @@ namespace Slang
         // given type `Texture2D` will actually have type `Texture2D<float4>`).
         bool CoerceToProperTypeImpl(
             TypeExp const&  typeExp,
-            RefPtr<Type>*   outProperType,
+            Type**   outProperType,
             DiagnosticSink* diagSink);
 
         TypeExp CoerceToProperType(TypeExp const& typeExp);
@@ -482,20 +482,20 @@ namespace Slang
         // Check a type, and coerce it to be usable
         TypeExp CheckUsableType(TypeExp typeExp);
 
-        RefPtr<Expr> CheckTerm(RefPtr<Expr> term);
+        Expr* CheckTerm(Expr* term);
 
-        RefPtr<Expr> CreateErrorExpr(Expr* expr);
+        Expr* CreateErrorExpr(Expr* expr);
 
-        bool IsErrorExpr(RefPtr<Expr> expr);
+        bool IsErrorExpr(Expr* expr);
 
         // Capture the "base" expression in case this is a member reference
-        RefPtr<Expr> GetBaseExpr(RefPtr<Expr> expr);
+        Expr* GetBaseExpr(Expr* expr);
 
     public:
 
         bool ValuesAreEqual(
-            RefPtr<IntVal> left,
-            RefPtr<IntVal> right);
+            IntVal* left,
+            IntVal* right);
 
         // Compute the cost of using a particular declaration to
         // perform implicit type conversion.
@@ -503,12 +503,12 @@ namespace Slang
             Decl* decl);
 
         bool isEffectivelyScalarForInitializerLists(
-            RefPtr<Type>    type);
+            Type*    type);
 
             /// Should the provided expression (from an initializer list) be used directly to initialize `toType`?
         bool shouldUseInitializerDirectly(
-            RefPtr<Type>    toType,
-            RefPtr<Expr>    fromExpr);
+            Type*    toType,
+            Expr*    fromExpr);
 
             /// Read a value from an initializer list expression.
             ///
@@ -534,9 +534,9 @@ namespace Slang
             /// then a suitable diagnostic will be emitted.
             ///
         bool _readValueFromInitializerList(
-            RefPtr<Type>                toType,
-            RefPtr<Expr>*               outToExpr,
-            RefPtr<InitializerListExpr> fromInitializerListExpr,
+            Type*                toType,
+            Expr**               outToExpr,
+            InitializerListExpr* fromInitializerListExpr,
             UInt                       &ioInitArgIndex);
 
             /// Read an aggregate value from an initializer list expression.
@@ -559,9 +559,9 @@ namespace Slang
             /// then a suitable diagnostic will be emitted.
             ///
         bool _readAggregateValueFromInitializerList(
-            RefPtr<Type>                inToType,
-            RefPtr<Expr>*               outToExpr,
-            RefPtr<InitializerListExpr> fromInitializerListExpr,
+            Type*                inToType,
+            Expr**               outToExpr,
+            InitializerListExpr* fromInitializerListExpr,
             UInt                       &ioArgIndex);
 
             /// Coerce an initializer-list expression to a specific type.
@@ -584,15 +584,15 @@ namespace Slang
             /// then a suitable diagnostic will be emitted.
             ///
         bool _coerceInitializerList(
-            RefPtr<Type>                toType,
-            RefPtr<Expr>*               outToExpr,
-            RefPtr<InitializerListExpr> fromInitializerListExpr);
+            Type*                toType,
+            Expr**               outToExpr,
+            InitializerListExpr* fromInitializerListExpr);
 
             /// Report that implicit type coercion is not possible.
         bool _failedCoercion(
-            RefPtr<Type>    toType,
-            RefPtr<Expr>*   outToExpr,
-            RefPtr<Expr>    fromExpr);
+            Type*    toType,
+            Expr**   outToExpr,
+            Expr*    fromExpr);
 
             /// Central engine for implementing implicit coercion logic
             ///
@@ -615,10 +615,10 @@ namespace Slang
             /// should be emitted on failure.
             ///
         bool _coerce(
-            RefPtr<Type>    toType,
-            RefPtr<Expr>*   outToExpr,
-            RefPtr<Type>    fromType,
-            RefPtr<Expr>    fromExpr,
+            Type*    toType,
+            Expr**   outToExpr,
+            Type*    fromType,
+            Expr*    fromExpr,
             ConversionCost* outCost);
 
             /// Check whether implicit type coercion from `fromType` to `toType` is possible.
@@ -629,15 +629,15 @@ namespace Slang
             /// If conversion is not possible, returns `false`.
             ///
         bool canCoerce(
-            RefPtr<Type>    toType,
-            RefPtr<Type>    fromType,
+            Type*    toType,
+            Type*    fromType,
             ConversionCost* outCost = 0);
 
-        RefPtr<TypeCastExpr> createImplicitCastExpr();
+        TypeCastExpr* createImplicitCastExpr();
 
-        RefPtr<Expr> CreateImplicitCastExpr(
-            RefPtr<Type>	toType,
-            RefPtr<Expr>	fromExpr);
+        Expr* CreateImplicitCastExpr(
+            Type*	toType,
+            Expr*	fromExpr);
 
             /// Create an "up-cast" from a value to an interface type
             ///
@@ -645,31 +645,31 @@ namespace Slang
             /// which packages up the value, its type, and the witness
             /// of its conformance to the interface.
             ///
-        RefPtr<Expr> createCastToInterfaceExpr(
-            RefPtr<Type>    toType,
-            RefPtr<Expr>    fromExpr,
-            RefPtr<Val>     witness);
+        Expr* createCastToInterfaceExpr(
+            Type*    toType,
+            Expr*    fromExpr,
+            Val*     witness);
 
             /// Implicitly coerce `fromExpr` to `toType` and diagnose errors if it isn't possible
-        RefPtr<Expr> coerce(
-            RefPtr<Type>    toType,
-            RefPtr<Expr>    fromExpr);
+        Expr* coerce(
+            Type*    toType,
+            Expr*    fromExpr);
 
         // Fill in default substitutions for the 'subtype' part of a type constraint decl
         void CheckConstraintSubType(TypeExp& typeExp);
 
         void checkGenericDeclHeader(GenericDecl* genericDecl);
 
-        RefPtr<ConstantIntVal> checkConstantIntVal(
-            RefPtr<Expr>    expr);
+        ConstantIntVal* checkConstantIntVal(
+            Expr*    expr);
 
-        RefPtr<ConstantIntVal> checkConstantEnumVal(
-            RefPtr<Expr>    expr);
+        ConstantIntVal* checkConstantEnumVal(
+            Expr*    expr);
 
         // Check an expression, coerce it to the `String` type, and then
         // ensure that it has a literal (not just compile-time constant) value.
         bool checkLiteralStringVal(
-            RefPtr<Expr>    expr,
+            Expr*    expr,
             String*         outVal);
 
         void visitModifier(Modifier*);
@@ -681,14 +681,14 @@ namespace Slang
 
         bool getAttributeTargetSyntaxClasses(SyntaxClass<RefObject> & cls, uint32_t typeFlags);
 
-        bool validateAttribute(RefPtr<Attribute> attr, AttributeDecl* attribClassDecl);
+        bool validateAttribute(Attribute* attr, AttributeDecl* attribClassDecl);
 
-        RefPtr<AttributeBase> checkAttribute(
+        AttributeBase* checkAttribute(
             UncheckedAttribute*     uncheckedAttr,
             ModifiableSyntaxNode*   attrTarget);
 
-        RefPtr<Modifier> checkModifier(
-            RefPtr<Modifier>        m,
+        Modifier* checkModifier(
+            Modifier*        m,
             ModifiableSyntaxNode*   syntaxNode);
 
         void checkModifiers(ModifiableSyntaxNode* syntaxNode);
@@ -704,7 +704,7 @@ namespace Slang
             RefPtr<WitnessTable>        witnessTable);
 
         bool doesTypeSatisfyAssociatedTypeRequirement(
-            RefPtr<Type>            satisfyingType,
+            Type*            satisfyingType,
             DeclRef<AssocTypeDecl>  requiredAssociatedTypeDeclRef,
             RefPtr<WitnessTable>    witnessTable);
 
@@ -795,7 +795,7 @@ namespace Slang
         bool doGenericSignaturesMatch(
             GenericDecl*                    left,
             GenericDecl*                    right,
-            RefPtr<GenericSubstitution>*    outSubstRightToLeft);
+            GenericSubstitution**    outSubstRightToLeft);
 
         // Check if two functions have the same signature for the purposes
         // of overload resolution.
@@ -803,18 +803,18 @@ namespace Slang
             DeclRef<FuncDecl> fst,
             DeclRef<FuncDecl> snd);
 
-        RefPtr<GenericSubstitution> createDummySubstitutions(
+        GenericSubstitution* createDummySubstitutions(
             GenericDecl* genericDecl);
 
         Result checkRedeclaration(Decl* newDecl, Decl* oldDecl);
         Result checkFuncRedeclaration(FuncDecl* newDecl, FuncDecl* oldDecl);
         void checkForRedeclaration(Decl* decl);
 
-        RefPtr<Expr> checkPredicateExpr(Expr* expr);
+        Expr* checkPredicateExpr(Expr* expr);
 
-        RefPtr<Expr> checkExpressionAndExpectIntegerConstant(RefPtr<Expr> expr, RefPtr<IntVal>* outIntVal);
+        Expr* checkExpressionAndExpectIntegerConstant(Expr* expr, IntVal** outIntVal);
 
-        IntegerLiteralValue GetMinBound(RefPtr<IntVal> val);
+        IntegerLiteralValue GetMinBound(IntVal* val);
 
         void maybeInferArraySizeForVariable(VarDeclBase* varDecl);
 
@@ -827,26 +827,26 @@ namespace Slang
             return getNamePool()->getName(text);
         }
 
-        RefPtr<IntVal> TryConstantFoldExpr(
+        IntVal* TryConstantFoldExpr(
             InvokeExpr* invokeExpr);
 
-        RefPtr<IntVal> TryConstantFoldExpr(
+        IntVal* TryConstantFoldExpr(
             Expr* expr);
 
         // Try to check an integer constant expression, either returning the value,
         // or NULL if the expression isn't recognized as a constant.
-        RefPtr<IntVal> TryCheckIntegerConstantExpression(Expr* exp);
+        IntVal* TryCheckIntegerConstantExpression(Expr* exp);
 
         // Enforce that an expression resolves to an integer constant, and get its value
-        RefPtr<IntVal> CheckIntegerConstantExpression(Expr* inExpr);
-        RefPtr<IntVal> CheckIntegerConstantExpression(Expr* inExpr, DiagnosticSink* sink);
+        IntVal* CheckIntegerConstantExpression(Expr* inExpr);
+        IntVal* CheckIntegerConstantExpression(Expr* inExpr, DiagnosticSink* sink);
 
-        RefPtr<IntVal> CheckEnumConstantExpression(Expr* expr);
+        IntVal* CheckEnumConstantExpression(Expr* expr);
 
 
-        RefPtr<Expr> CheckSimpleSubscriptExpr(
-            RefPtr<IndexExpr>   subscriptExpr,
-            RefPtr<Type>              elementType);
+        Expr* CheckSimpleSubscriptExpr(
+            IndexExpr*   subscriptExpr,
+            Type*              elementType);
 
         // The way that we have designed out type system, pretyt much *every*
         // type is a reference to some declaration in the standard library.
@@ -858,9 +858,9 @@ namespace Slang
         // This function is used to construct a `vector<T,N>` type
         // programmatically, so that it will work just like a type of
         // that form constructed by the user.
-        RefPtr<VectorExpressionType> createVectorType(
-            RefPtr<Type>  elementType,
-            RefPtr<IntVal>          elementCount);
+        VectorExpressionType* createVectorType(
+            Type*  elementType,
+            IntVal*          elementCount);
 
         //
 
@@ -872,13 +872,13 @@ namespace Slang
         // Figure out what type an initializer/constructor declaration
         // is supposed to return. In most cases this is just the type
         // declaration that its declaration is nested inside.
-        RefPtr<Type> findResultTypeForConstructorDecl(ConstructorDecl* decl);
+        Type* findResultTypeForConstructorDecl(ConstructorDecl* decl);
 
             /// Determine what type `This` should refer to in the context of the given parent `decl`.
-        RefPtr<Type> calcThisType(DeclRef<Decl> decl);
+        Type* calcThisType(DeclRef<Decl> decl);
 
             /// Determine what type `This` should refer to in an extension of `type`.
-        RefPtr<Type> calcThisType(Type* type);
+        Type* calcThisType(Type* type);
 
 
         //
@@ -886,7 +886,7 @@ namespace Slang
         struct Constraint
         {
             Decl*		decl; // the declaration of the thing being constraints
-            RefPtr<Val>	val; // the value to which we are constraining it
+            Val*	val; // the value to which we are constraining it
             bool satisfied = false; // Has this constraint been met?
         };
 
@@ -899,33 +899,33 @@ namespace Slang
 
             // The generic declaration whose parameters we
             // are trying to solve for.
-            RefPtr<GenericDecl> genericDecl;
+            GenericDecl* genericDecl;
 
             // Constraints we have accumulated, which constrain
             // the possible arguments for those parameters.
             List<Constraint> constraints;
         };
 
-        RefPtr<Type> TryJoinVectorAndScalarType(
-            RefPtr<VectorExpressionType> vectorType,
-            RefPtr<BasicExpressionType>  scalarType);
+        Type* TryJoinVectorAndScalarType(
+            VectorExpressionType* vectorType,
+            BasicExpressionType*  scalarType);
 
         struct TypeWitnessBreadcrumb
         {
             TypeWitnessBreadcrumb*  prev;
 
-            RefPtr<Type>            sub;
-            RefPtr<Type>            sup;
+            Type*            sub;
+            Type*            sup;
             DeclRef<Decl>           declRef;
         };
 
         // Create a subtype witness based on the declared relationship
         // found in a single breadcrumb
-        RefPtr<DeclaredSubtypeWitness> createSimpleSubtypeWitness(
+        DeclaredSubtypeWitness* createSimpleSubtypeWitness(
             TypeWitnessBreadcrumb*  breadcrumb);
 
-        RefPtr<Val> createTypeWitness(
-            RefPtr<Type>            type,
+        Val* createTypeWitness(
+            Type*            type,
             DeclRef<InterfaceDecl>  interfaceDeclRef,
             TypeWitnessBreadcrumb*  inBreadcrumbs);
 
@@ -951,33 +951,33 @@ namespace Slang
             DeclRef<Decl>           requirementDeclRef);
 
         bool doesTypeConformToInterfaceImpl(
-            RefPtr<Type>            originalType,
-            RefPtr<Type>            type,
+            Type*            originalType,
+            Type*            type,
             DeclRef<InterfaceDecl>  interfaceDeclRef,
-            RefPtr<Val>*            outWitness,
+            Val**            outWitness,
             TypeWitnessBreadcrumb*  inBreadcrumbs);
 
         bool DoesTypeConformToInterface(
-            RefPtr<Type>  type,
+            Type*  type,
             DeclRef<InterfaceDecl>        interfaceDeclRef);
 
-        RefPtr<Val> tryGetInterfaceConformanceWitness(
-            RefPtr<Type>  type,
+        Val* tryGetInterfaceConformanceWitness(
+            Type*  type,
             DeclRef<InterfaceDecl>        interfaceDeclRef);
 
         /// Does there exist an implicit conversion from `fromType` to `toType`?
         bool canConvertImplicitly(
-            RefPtr<Type> toType,
-            RefPtr<Type> fromType);
+            Type* toType,
+            Type* fromType);
 
-        RefPtr<Type> TryJoinTypeWithInterface(
-            RefPtr<Type>            type,
+        Type* TryJoinTypeWithInterface(
+            Type*            type,
             DeclRef<InterfaceDecl>      interfaceDeclRef);
 
         // Try to compute the "join" between two types
-        RefPtr<Type> TryJoinTypes(
-            RefPtr<Type>  left,
-            RefPtr<Type>  right);
+        Type* TryJoinTypes(
+            Type*  left,
+            Type*  right);
 
         // Try to solve a system of generic constraints.
         // The `system` argument provides the constraints.
@@ -1008,19 +1008,19 @@ namespace Slang
             SourceLoc loc;
 
             // The original expression (if any) that triggered things
-            RefPtr<Expr> originalExpr;
+            Expr* originalExpr;
 
             // Source location of the "function" part of the expression, if any
             SourceLoc       funcLoc;
 
             // The original arguments to the call
             Index argCount = 0;
-            RefPtr<Expr>* args = nullptr;
-            RefPtr<Type>* argTypes = nullptr;
+            Expr** args = nullptr;
+            Type** argTypes = nullptr;
 
             Index getArgCount() { return argCount; }
-            RefPtr<Expr>& getArg(Index index) { return args[index]; }
-            RefPtr<Type>& getArgType(Index index)
+            Expr*& getArg(Index index) { return args[index]; }
+            Type*& getArgType(Index index)
             {
                 if(argTypes)
                     return argTypes[index];
@@ -1030,7 +1030,7 @@ namespace Slang
 
             bool disallowNestedConversions = false;
 
-            RefPtr<Expr> baseExpr;
+            Expr* baseExpr;
 
             // Are we still trying out candidates, or are we
             // checking the chosen one for real?
@@ -1079,14 +1079,14 @@ namespace Slang
 
         // Create a witness that attests to the fact that `type`
         // is equal to itself.
-        RefPtr<Val> createTypeEqualityWitness(
+        Val* createTypeEqualityWitness(
             Type*  type);
 
         // If `sub` is a subtype of `sup`, then return a value that
         // can serve as a "witness" for that fact.
-        RefPtr<Val> tryGetSubtypeWitness(
-            RefPtr<Type>    sub,
-            RefPtr<Type>    sup);
+        Val* tryGetSubtypeWitness(
+            Type*    sub,
+            Type*    sup);
 
         // In the case where we are explicitly applying a generic
         // to arguments (e.g., `G<A,B>`) check that the constraints
@@ -1107,10 +1107,10 @@ namespace Slang
             OverloadCandidate&			candidate);
 
         // Create the representation of a given generic applied to some arguments
-        RefPtr<Expr> createGenericDeclRef(
-            RefPtr<Expr>            baseExpr,
-            RefPtr<Expr>            originalExpr,
-            RefPtr<GenericSubstitution>   subst);
+        Expr* createGenericDeclRef(
+            Expr*            baseExpr,
+            Expr*            originalExpr,
+            GenericSubstitution*   subst);
 
         // Take an overload candidate that previously got through
         // `TryCheckOverloadCandidate` above, and try to finish
@@ -1118,7 +1118,7 @@ namespace Slang
         //
         // If the candidate isn't actually applicable, this is
         // where we'd start reporting the issue(s).
-        RefPtr<Expr> CompleteOverloadCandidate(
+        Expr* CompleteOverloadCandidate(
             OverloadResolveContext&		context,
             OverloadCandidate&			candidate);
 
@@ -1157,17 +1157,17 @@ namespace Slang
             OverloadResolveContext&		context);
 
         void AddFuncOverloadCandidate(
-            RefPtr<FuncType>		/*funcType*/,
+            FuncType*		/*funcType*/,
             OverloadResolveContext&	/*context*/);
 
         // Add a candidate callee for overload resolution, based on
         // calling a particular `ConstructorDecl`.
         void AddCtorOverloadCandidate(
             LookupResultItem            typeItem,
-            RefPtr<Type>                type,
+            Type*                type,
             DeclRef<ConstructorDecl>    ctorDeclRef,
             OverloadResolveContext&     context,
-            RefPtr<Type>                resultType);
+            Type*                resultType);
 
         // If the given declaration has generic parameters, then
         // return the corresponding `GenericDecl` that holds the
@@ -1177,48 +1177,48 @@ namespace Slang
         // Try to find a unification for two values
         bool TryUnifyVals(
             ConstraintSystem&	constraints,
-            RefPtr<Val>			fst,
-            RefPtr<Val>			snd);
+            Val*			fst,
+            Val*			snd);
 
         bool tryUnifySubstitutions(
             ConstraintSystem&       constraints,
-            RefPtr<Substitutions>   fst,
-            RefPtr<Substitutions>   snd);
+            Substitutions*   fst,
+            Substitutions*   snd);
 
         bool tryUnifyGenericSubstitutions(
             ConstraintSystem&           constraints,
-            RefPtr<GenericSubstitution> fst,
-            RefPtr<GenericSubstitution> snd);
+            GenericSubstitution* fst,
+            GenericSubstitution* snd);
 
         bool TryUnifyTypeParam(
             ConstraintSystem&				constraints,
-            RefPtr<GenericTypeParamDecl>	typeParamDecl,
-            RefPtr<Type>			type);
+            GenericTypeParamDecl*	typeParamDecl,
+            Type*			type);
 
         bool TryUnifyIntParam(
             ConstraintSystem&               constraints,
-            RefPtr<GenericValueParamDecl>	paramDecl,
-            RefPtr<IntVal>                  val);
+            GenericValueParamDecl*	paramDecl,
+            IntVal*                  val);
 
         bool TryUnifyIntParam(
             ConstraintSystem&       constraints,
             DeclRef<VarDeclBase> const&   varRef,
-            RefPtr<IntVal>          val);
+            IntVal*          val);
 
         bool TryUnifyTypesByStructuralMatch(
             ConstraintSystem&       constraints,
-            RefPtr<Type>  fst,
-            RefPtr<Type>  snd);
+            Type*  fst,
+            Type*  snd);
 
         bool TryUnifyTypes(
             ConstraintSystem&       constraints,
-            RefPtr<Type>  fst,
-            RefPtr<Type>  snd);
+            Type*  fst,
+            Type*  snd);
 
         // Is the candidate extension declaration actually applicable to the given type
         DeclRef<ExtensionDecl> ApplyExtensionToType(
             ExtensionDecl*  extDecl,
-            RefPtr<Type>    type);
+            Type*    type);
 
         // Take a generic declaration and try to specialize its parameters
         // so that the resulting inner declaration can be applicable in
@@ -1228,7 +1228,7 @@ namespace Slang
             OverloadResolveContext& context);
 
         void AddTypeOverloadCandidates(
-            RefPtr<Type>	        type,
+            Type*	        type,
             OverloadResolveContext&	context);
 
         void AddDeclRefOverloadCandidates(
@@ -1240,12 +1240,12 @@ namespace Slang
             OverloadResolveContext&	context);
 
         void AddOverloadCandidates(
-            RefPtr<Expr>	funcExpr,
+            Expr*	funcExpr,
             OverloadResolveContext&			context);
 
-        void formatType(StringBuilder& sb, RefPtr<Type> type);
+        void formatType(StringBuilder& sb, Type* type);
 
-        void formatVal(StringBuilder& sb, RefPtr<Val> val);
+        void formatVal(StringBuilder& sb, Val* val);
 
         void formatDeclPath(StringBuilder& sb, DeclRef<Decl> declRef);
 
@@ -1262,22 +1262,22 @@ namespace Slang
         String getCallSignatureString(
             OverloadResolveContext&     context);
 
-        RefPtr<Expr> ResolveInvoke(InvokeExpr * expr);
+        Expr* ResolveInvoke(InvokeExpr * expr);
 
         void AddGenericOverloadCandidate(
             LookupResultItem		baseItem,
             OverloadResolveContext&	context);
 
         void AddGenericOverloadCandidates(
-            RefPtr<Expr>	baseExpr,
+            Expr*	baseExpr,
             OverloadResolveContext&			context);
 
             /// Check a generic application where the operands have already been checked.
-        RefPtr<Expr> checkGenericAppWithCheckedArgs(GenericAppExpr* genericAppExpr);
+        Expr* checkGenericAppWithCheckedArgs(GenericAppExpr* genericAppExpr);
 
-        RefPtr<Expr> CheckExpr(RefPtr<Expr> expr);
+        Expr* CheckExpr(Expr* expr);
 
-        RefPtr<Expr> CheckInvokeExprWithCheckedOperands(InvokeExpr *expr);
+        Expr* CheckInvokeExprWithCheckedOperands(InvokeExpr *expr);
 
         // Get the type to use when referencing a declaration
         QualType GetTypeForDeclRef(DeclRef<Decl> declRef, SourceLoc loc);
@@ -1286,38 +1286,38 @@ namespace Slang
         //
         //
 
-        RefPtr<Expr> MaybeDereference(RefPtr<Expr> inExpr);
+        Expr* MaybeDereference(Expr* inExpr);
 
-        RefPtr<Expr> CheckMatrixSwizzleExpr(
+        Expr* CheckMatrixSwizzleExpr(
             MemberExpr* memberRefExpr,
-            RefPtr<Type>      baseElementType,
+            Type*      baseElementType,
             IntegerLiteralValue        baseElementRowCount,
             IntegerLiteralValue        baseElementColCount);
 
-        RefPtr<Expr> CheckMatrixSwizzleExpr(
+        Expr* CheckMatrixSwizzleExpr(
             MemberExpr* memberRefExpr,
-            RefPtr<Type>      baseElementType,
-            RefPtr<IntVal>        baseElementRowCount,
-            RefPtr<IntVal>        baseElementColCount);
+            Type*      baseElementType,
+            IntVal*        baseElementRowCount,
+            IntVal*        baseElementColCount);
 
-        RefPtr<Expr> CheckSwizzleExpr(
+        Expr* CheckSwizzleExpr(
             MemberExpr* memberRefExpr,
-            RefPtr<Type>      baseElementType,
+            Type*      baseElementType,
             IntegerLiteralValue         baseElementCount);
 
-        RefPtr<Expr> CheckSwizzleExpr(
+        Expr* CheckSwizzleExpr(
             MemberExpr*	memberRefExpr,
-            RefPtr<Type>		baseElementType,
-            RefPtr<IntVal>				baseElementCount);
+            Type*		baseElementType,
+            IntVal*				baseElementCount);
 
         // Look up a static member
         // @param expr Can be StaticMemberExpr or MemberExpr
         // @param baseExpression Is the underlying type expression determined from resolving expr
-        RefPtr<Expr> _lookupStaticMember(RefPtr<DeclRefExpr> expr, RefPtr<Expr> baseExpression);
+        Expr* _lookupStaticMember(DeclRefExpr* expr, Expr* baseExpression);
 
-        RefPtr<Expr> visitStaticMemberExpr(StaticMemberExpr* expr);
+        Expr* visitStaticMemberExpr(StaticMemberExpr* expr);
 
-        RefPtr<Expr> lookupMemberResultFailure(
+        Expr* lookupMemberResultFailure(
             DeclRefExpr*     expr,
             QualType const& baseType);
 
@@ -1331,35 +1331,35 @@ namespace Slang
 
     struct SemanticsExprVisitor
         : public SemanticsVisitor
-        , ExprVisitor<SemanticsExprVisitor, RefPtr<Expr>>
+        , ExprVisitor<SemanticsExprVisitor, Expr*>
     {
     public:
         SemanticsExprVisitor(SharedSemanticsContext* shared)
             : SemanticsVisitor(shared)
         {}
 
-        RefPtr<Expr> visitBoolLiteralExpr(BoolLiteralExpr* expr);
-        RefPtr<Expr> visitIntegerLiteralExpr(IntegerLiteralExpr* expr);
-        RefPtr<Expr> visitFloatingPointLiteralExpr(FloatingPointLiteralExpr* expr);
-        RefPtr<Expr> visitStringLiteralExpr(StringLiteralExpr* expr);
+        Expr* visitBoolLiteralExpr(BoolLiteralExpr* expr);
+        Expr* visitIntegerLiteralExpr(IntegerLiteralExpr* expr);
+        Expr* visitFloatingPointLiteralExpr(FloatingPointLiteralExpr* expr);
+        Expr* visitStringLiteralExpr(StringLiteralExpr* expr);
 
-        RefPtr<Expr> visitIndexExpr(IndexExpr* subscriptExpr);
+        Expr* visitIndexExpr(IndexExpr* subscriptExpr);
 
-        RefPtr<Expr> visitParenExpr(ParenExpr* expr);
+        Expr* visitParenExpr(ParenExpr* expr);
 
-        RefPtr<Expr> visitAssignExpr(AssignExpr* expr);
+        Expr* visitAssignExpr(AssignExpr* expr);
 
-        RefPtr<Expr> visitGenericAppExpr(GenericAppExpr* genericAppExpr);
+        Expr* visitGenericAppExpr(GenericAppExpr* genericAppExpr);
 
-        RefPtr<Expr> visitSharedTypeExpr(SharedTypeExpr* expr);
+        Expr* visitSharedTypeExpr(SharedTypeExpr* expr);
 
-        RefPtr<Expr> visitTaggedUnionTypeExpr(TaggedUnionTypeExpr* expr);
+        Expr* visitTaggedUnionTypeExpr(TaggedUnionTypeExpr* expr);
 
-        RefPtr<Expr> visitInvokeExpr(InvokeExpr *expr);
+        Expr* visitInvokeExpr(InvokeExpr *expr);
 
-        RefPtr<Expr> visitVarExpr(VarExpr *expr);
+        Expr* visitVarExpr(VarExpr *expr);
 
-        RefPtr<Expr> visitTypeCastExpr(TypeCastExpr * expr);
+        Expr* visitTypeCastExpr(TypeCastExpr * expr);
 
         //
         // Some syntax nodes should not occur in the concrete input syntax,
@@ -1368,7 +1368,7 @@ namespace Slang
         //
 
     #define CASE(NAME)                                  \
-        RefPtr<Expr> visit##NAME(NAME* expr)            \
+        Expr* visit##NAME(NAME* expr)            \
         {                                               \
             SLANG_DIAGNOSE_UNEXPECTED(getSink(), expr,  \
                 "should not appear in input syntax");   \
@@ -1387,14 +1387,14 @@ namespace Slang
 
     #undef CASE
 
-        RefPtr<Expr> visitStaticMemberExpr(StaticMemberExpr* expr);
+        Expr* visitStaticMemberExpr(StaticMemberExpr* expr);
 
-        RefPtr<Expr> visitMemberExpr(MemberExpr * expr);
+        Expr* visitMemberExpr(MemberExpr * expr);
 
-        RefPtr<Expr> visitInitializerListExpr(InitializerListExpr* expr);
+        Expr* visitInitializerListExpr(InitializerListExpr* expr);
 
-        RefPtr<Expr> visitThisExpr(ThisExpr* expr);
-        RefPtr<Expr> visitThisTypeExpr(ThisTypeExpr* expr);
+        Expr* visitThisExpr(ThisExpr* expr);
+        Expr* visitThisTypeExpr(ThisTypeExpr* expr);
     };
 
     struct SemanticsStmtVisitor

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -175,7 +175,7 @@ namespace Slang
         LookupResultItem item;
 
         // The type of the result expression if this candidate is selected
-        Type*	resultType;
+        Type*	resultType = nullptr;
 
         // A system for tracking constraints introduced on generic parameters
         //            ConstraintSystem constraintSystem;
@@ -187,7 +187,7 @@ namespace Slang
         // When required, a candidate can store a pre-checked list of
         // arguments so that we don't have to repeat work across checking
         // phases. Currently this is only needed for generics.
-        Substitutions*   subst;
+        Substitutions*   subst = nullptr;
     };
 
     struct TypeCheckingCache
@@ -268,7 +268,7 @@ namespace Slang
             ///
         struct OuterStmtInfo
         {
-            Stmt*           stmt;
+            Stmt*           stmt = nullptr;
             OuterStmtInfo*  next;
         };
 
@@ -885,8 +885,8 @@ namespace Slang
 
         struct Constraint
         {
-            Decl*		decl; // the declaration of the thing being constraints
-            Val*	val; // the value to which we are constraining it
+            Decl*		decl = nullptr; // the declaration of the thing being constraints
+            Val*	val = nullptr; // the value to which we are constraining it
             bool satisfied = false; // Has this constraint been met?
         };
 
@@ -899,7 +899,7 @@ namespace Slang
 
             // The generic declaration whose parameters we
             // are trying to solve for.
-            GenericDecl* genericDecl;
+            GenericDecl* genericDecl = nullptr;
 
             // Constraints we have accumulated, which constrain
             // the possible arguments for those parameters.
@@ -914,8 +914,8 @@ namespace Slang
         {
             TypeWitnessBreadcrumb*  prev;
 
-            Type*            sub;
-            Type*            sup;
+            Type*            sub = nullptr;
+            Type*            sup = nullptr;
             DeclRef<Decl>           declRef;
         };
 
@@ -1008,7 +1008,7 @@ namespace Slang
             SourceLoc loc;
 
             // The original expression (if any) that triggered things
-            Expr* originalExpr;
+            Expr* originalExpr = nullptr;
 
             // Source location of the "function" part of the expression, if any
             SourceLoc       funcLoc;
@@ -1030,7 +1030,7 @@ namespace Slang
 
             bool disallowNestedConversions = false;
 
-            Expr* baseExpr;
+            Expr* baseExpr = nullptr;
 
             // Are we still trying out candidates, or are we
             // checking the chosen one for real?

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -673,7 +673,7 @@ namespace Slang
         // The process of checking a modifier may produce a new modifier in its place,
         // so we will build up a new linked list of modifiers that will replace
         // the old list.
-        Modifier* resultModifiers;
+        Modifier* resultModifiers = nullptr;
         Modifier** resultModifierLink = &resultModifiers;
 
         Modifier* modifier = syntaxNode->modifiers.first;

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -230,7 +230,7 @@ namespace Slang
         return true;
     }
 
-    bool SemanticsVisitor::getAttributeTargetSyntaxClasses(SyntaxClass<RefObject> & cls, uint32_t typeFlags)
+    bool SemanticsVisitor::getAttributeTargetSyntaxClasses(SyntaxClass<NodeBase> & cls, uint32_t typeFlags)
     {
         if (typeFlags == (int)UserDefinedAttributeTargets::Struct)
         {
@@ -544,8 +544,8 @@ namespace Slang
         }
 
         // Manage scope
-        RefPtr<RefObject> attrInstance = attrDecl->syntaxClass.createInstance(m_astBuilder);
-        auto attr = attrInstance.as<Attribute>();
+        NodeBase* attrInstance = attrDecl->syntaxClass.createInstance(m_astBuilder);
+        auto attr = as<Attribute>(attrInstance);
         if(!attr)
         {
             SLANG_DIAGNOSE_UNEXPECTED(getSink(), attrDecl, "attribute class did not yield an attribute object");

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -11,13 +11,13 @@
 
 namespace Slang
 {
-    RefPtr<ConstantIntVal> SemanticsVisitor::checkConstantIntVal(
-        RefPtr<Expr>    expr)
+    ConstantIntVal* SemanticsVisitor::checkConstantIntVal(
+        Expr*    expr)
     {
         // First type-check the expression as normal
         expr = CheckExpr(expr);
 
-        auto intVal = CheckIntegerConstantExpression(expr.Ptr());
+        auto intVal = CheckIntegerConstantExpression(expr);
         if(!intVal)
             return nullptr;
 
@@ -30,13 +30,13 @@ namespace Slang
         return constIntVal;
     }
 
-    RefPtr<ConstantIntVal> SemanticsVisitor::checkConstantEnumVal(
-        RefPtr<Expr>    expr)
+    ConstantIntVal* SemanticsVisitor::checkConstantEnumVal(
+        Expr*    expr)
     {
         // First type-check the expression as normal
         expr = CheckExpr(expr);
 
-        auto intVal = CheckEnumConstantExpression(expr.Ptr());
+        auto intVal = CheckEnumConstantExpression(expr);
         if(!intVal)
             return nullptr;
 
@@ -52,7 +52,7 @@ namespace Slang
     // Check an expression, coerce it to the `String` type, and then
     // ensure that it has a literal (not just compile-time constant) value.
     bool SemanticsVisitor::checkLiteralStringVal(
-        RefPtr<Expr>    expr,
+        Expr*    expr,
         String*         outVal)
     {
         // TODO: This should actually perform semantic checking, etc.,
@@ -138,12 +138,12 @@ namespace Slang
         // We will now synthesize a new `AttributeDecl` to mirror
         // what was declared on the `struct` type.
         //
-        RefPtr<AttributeDecl> attrDecl = m_astBuilder->create<AttributeDecl>();
+        AttributeDecl* attrDecl = m_astBuilder->create<AttributeDecl>();
         attrDecl->nameAndLoc.name = attributeName;
         attrDecl->nameAndLoc.loc = structDecl->nameAndLoc.loc;
         attrDecl->loc = structDecl->loc;
 
-        RefPtr<AttributeTargetModifier> targetModifier = m_astBuilder->create<AttributeTargetModifier>();
+        AttributeTargetModifier* targetModifier = m_astBuilder->create<AttributeTargetModifier>();
         targetModifier->syntaxClass = attrUsageAttr->targetSyntaxClass;
         targetModifier->loc = attrUsageAttr->loc;
         addModifier(attrDecl, targetModifier);
@@ -167,7 +167,7 @@ namespace Slang
             {
                 ensureDecl(varMember, DeclCheckState::CanUseTypeOfValueDecl);
 
-                RefPtr<ParamDecl> paramDecl = m_astBuilder->create<ParamDecl>();
+                ParamDecl* paramDecl = m_astBuilder->create<ParamDecl>();
                 paramDecl->nameAndLoc = member->nameAndLoc;
                 paramDecl->type = varMember->type;
                 paramDecl->loc = member->loc;
@@ -250,7 +250,7 @@ namespace Slang
         return false;
     }
 
-    bool SemanticsVisitor::validateAttribute(RefPtr<Attribute> attr, AttributeDecl* attribClassDecl)
+    bool SemanticsVisitor::validateAttribute(Attribute* attr, AttributeDecl* attribClassDecl)
     {
         if(auto numThreadsAttr = as<NumThreadsAttribute>(attr))
         {
@@ -401,7 +401,7 @@ namespace Slang
             uint32_t targetClassId = (uint32_t)UserDefinedAttributeTargets::None;
             if (attr->args.getCount() == 1)
             {
-                RefPtr<IntVal> outIntVal;
+                //IntVal* outIntVal;
                 if (auto cInt = checkConstantEnumVal(attr->args[0]))
                 {
                     targetClassId = (uint32_t)(cInt->value);
@@ -522,7 +522,7 @@ namespace Slang
         return true;
     }
 
-    RefPtr<AttributeBase> SemanticsVisitor::checkAttribute(
+    AttributeBase* SemanticsVisitor::checkAttribute(
         UncheckedAttribute*     uncheckedAttr,
         ModifiableSyntaxNode*   attrTarget)
     {
@@ -637,8 +637,8 @@ namespace Slang
         return attr;
     }
 
-    RefPtr<Modifier> SemanticsVisitor::checkModifier(
-        RefPtr<Modifier>        m,
+    Modifier* SemanticsVisitor::checkModifier(
+        Modifier*        m,
         ModifiableSyntaxNode*   syntaxNode)
     {
         if(auto hlslUncheckedAttribute = as<UncheckedAttribute>(m))
@@ -673,10 +673,10 @@ namespace Slang
         // The process of checking a modifier may produce a new modifier in its place,
         // so we will build up a new linked list of modifiers that will replace
         // the old list.
-        RefPtr<Modifier> resultModifiers;
-        RefPtr<Modifier>* resultModifierLink = &resultModifiers;
+        Modifier* resultModifiers;
+        Modifier** resultModifierLink = &resultModifiers;
 
-        RefPtr<Modifier> modifier = syntaxNode->modifiers.first;
+        Modifier* modifier = syntaxNode->modifiers.first;
         while(modifier)
         {
             // Because we are rewriting the list in place, we need to extract

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1438,7 +1438,7 @@ namespace Slang
         // to speed up compilation
         bool shouldAddToCache = false;
         OperatorOverloadCacheKey key;
-        TypeCheckingCache* typeCheckingCache = getSession()->getTypeCheckingCache();
+        TypeCheckingCache* typeCheckingCache = getLinkage()->getTypeCheckingCache();
         if (auto opExpr = as<OperatorExpr>(expr))
         {
             if (key.fromOperatorExpr(opExpr))

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -138,8 +138,6 @@ namespace Slang
         {
             return true;
         }
-
-        return false;
     }
 
     bool SemanticsVisitor::TryCheckGenericOverloadCandidateTypes(
@@ -239,7 +237,7 @@ namespace Slang
                 // The case for a generic value parameter is similar to that
                 // for a generic type parameter.
                 //
-                RefPtr<Expr> arg;
+                Expr* arg = nullptr;
                 if( aa >= context.argCount )
                 {
                     // If there are no arguments left to consume, then
@@ -276,7 +274,7 @@ namespace Slang
                 // generalize in order to support generic value parameters
                 // with types other than `int`.
                 //
-                RefPtr<Val> val;
+                Val* val = nullptr;
                 if( arg )
                 {
                     val = ExtractGenericArgInteger(arg, context.mode == OverloadResolveContext::Mode::JustTrying ? nullptr : getSink());
@@ -383,7 +381,7 @@ namespace Slang
         // We should have the existing arguments to the generic
         // handy, so that we can construct a substitution list.
 
-        auto subst = candidate.subst.as<GenericSubstitution>();
+        auto subst = as<GenericSubstitution>(candidate.subst);
         SLANG_ASSERT(subst);
 
         subst->genericDecl = genericDeclRef.getDecl();
@@ -444,10 +442,10 @@ namespace Slang
         candidate.status = OverloadCandidate::Status::Applicable;
     }
 
-    RefPtr<Expr> SemanticsVisitor::createGenericDeclRef(
-        RefPtr<Expr>                baseExpr,
-        RefPtr<Expr>                originalExpr,
-        RefPtr<GenericSubstitution> subst)
+    Expr* SemanticsVisitor::createGenericDeclRef(
+        Expr*                baseExpr,
+        Expr*                originalExpr,
+        GenericSubstitution* subst)
     {
         auto baseDeclRefExpr = as<DeclRefExpr>(baseExpr);
         if (!baseDeclRefExpr)
@@ -467,7 +465,7 @@ namespace Slang
 
         DeclRef<Decl> innerDeclRef(getInner(baseGenericRef), subst);
 
-        RefPtr<Expr> base;
+        Expr* base = nullptr;
         if (auto mbrExpr = as<MemberExpr>(baseExpr))
             base = mbrExpr->baseExpression;
 
@@ -477,7 +475,7 @@ namespace Slang
             originalExpr->loc);
     }
 
-    RefPtr<Expr> SemanticsVisitor::CompleteOverloadCandidate(
+    Expr* SemanticsVisitor::CompleteOverloadCandidate(
         OverloadResolveContext&		context,
         OverloadCandidate&			candidate)
     {
@@ -520,7 +518,7 @@ namespace Slang
             {
             case OverloadCandidate::Flavor::Func:
                 {
-                    RefPtr<AppExprBase> callExpr = as<InvokeExpr>(context.originalExpr);
+                    AppExprBase* callExpr = as<InvokeExpr>(context.originalExpr);
                     if(!callExpr)
                     {
                         callExpr = m_astBuilder->create<InvokeExpr>();
@@ -555,7 +553,7 @@ namespace Slang
                 return createGenericDeclRef(
                     baseExpr,
                     context.originalExpr,
-                    candidate.subst.as<GenericSubstitution>());
+                    as<GenericSubstitution>(candidate.subst));
                 break;
 
             default:
@@ -569,7 +567,7 @@ namespace Slang
 
         if(context.originalExpr)
         {
-            return CreateErrorExpr(context.originalExpr.Ptr());
+            return CreateErrorExpr(context.originalExpr);
         }
         else
         {
@@ -615,7 +613,7 @@ namespace Slang
         // parent generic (and not somthing like a generic
         // parameter).
         //
-        if( parentGeneric.getDecl()->inner.Ptr() != declRef.getDecl())
+        if( parentGeneric.getDecl()->inner != declRef.getDecl())
             return 0;
 
         return CountParameters(parentGeneric).required;
@@ -946,7 +944,7 @@ namespace Slang
     }
 
     void SemanticsVisitor::AddFuncOverloadCandidate(
-        RefPtr<FuncType>        funcType,
+        FuncType*        funcType,
         OverloadResolveContext& context)
     {
         SLANG_UNUSED(funcType);
@@ -955,11 +953,13 @@ namespace Slang
 
     void SemanticsVisitor::AddCtorOverloadCandidate(
         LookupResultItem            typeItem,
-        RefPtr<Type>                type,
+        Type*                type,
         DeclRef<ConstructorDecl>    ctorDeclRef,
         OverloadResolveContext&     context,
-        RefPtr<Type>                resultType)
+        Type*                resultType)
     {
+        SLANG_UNUSED(type)
+
         ensureDecl(ctorDeclRef, DeclCheckState::CanUseFuncSignature);
 
         // `typeItem` refers to the type being constructed (the thing
@@ -1060,7 +1060,7 @@ namespace Slang
     }
 
     void SemanticsVisitor::AddTypeOverloadCandidates(
-        RefPtr<Type>            type,
+        Type*            type,
         OverloadResolveContext&	context)
     {
         // The code being checked is trying to apply `type` like a function.
@@ -1172,7 +1172,7 @@ namespace Slang
     }
 
     void SemanticsVisitor::AddOverloadCandidates(
-        RefPtr<Expr>            funcExpr,
+        Expr*            funcExpr,
         OverloadResolveContext& context)
     {
         // A call of the form `(<something>)(<args>)` should be
@@ -1224,12 +1224,12 @@ namespace Slang
         }
     }
 
-    void SemanticsVisitor::formatType(StringBuilder& sb, RefPtr<Type> type)
+    void SemanticsVisitor::formatType(StringBuilder& sb, Type* type)
     {
         sb << type->toString();
     }
 
-    void SemanticsVisitor::formatVal(StringBuilder& sb, RefPtr<Val> val)
+    void SemanticsVisitor::formatVal(StringBuilder& sb, Val* val)
     {
         sb << val->toString();
     }
@@ -1276,7 +1276,7 @@ namespace Slang
         // signature
         if( parentGenericDeclRef )
         {
-            auto genSubst = declRef.substitutions.substitutions.as<GenericSubstitution>();
+            auto genSubst = as<GenericSubstitution>(declRef.substitutions.substitutions);
             SLANG_RELEASE_ASSERT(genSubst);
             SLANG_RELEASE_ASSERT(genSubst->genericDecl == parentGenericDeclRef.getDecl());
 
@@ -1294,7 +1294,7 @@ namespace Slang
             bool first = true;
             for(auto arg : genSubst->args)
             {
-                // When printing the representation of a sepcialized
+                // When printing the representation of a specialized
                 // generic declaration we don't want to include the
                 // argument values for subtype witnesses since these
                 // do not correspond to parameters of the generic
@@ -1431,7 +1431,7 @@ namespace Slang
         return argsListBuilder.ProduceString();
     }
 
-    RefPtr<Expr> SemanticsVisitor::ResolveInvoke(InvokeExpr * expr)
+    Expr* SemanticsVisitor::ResolveInvoke(InvokeExpr * expr)
     {
         OverloadResolveContext context;
         // check if this is a stdlib operator call, if so we want to use cached results
@@ -1651,7 +1651,7 @@ namespace Slang
     }
 
     void SemanticsVisitor::AddGenericOverloadCandidates(
-        RefPtr<Expr>	baseExpr,
+        Expr*	baseExpr,
         OverloadResolveContext&			context)
     {
         if(auto baseDeclRefExpr = as<DeclRefExpr>(baseExpr))
@@ -1674,7 +1674,7 @@ namespace Slang
         }
     }
 
-    RefPtr<Expr> SemanticsExprVisitor::visitGenericAppExpr(GenericAppExpr* genericAppExpr)
+    Expr* SemanticsExprVisitor::visitGenericAppExpr(GenericAppExpr* genericAppExpr)
     {
         // Start by checking the base expression and arguments.
         auto& baseExpr = genericAppExpr->functionExpr;
@@ -1689,7 +1689,7 @@ namespace Slang
     }
 
         /// Check a generic application where the operands have already been checked.
-    RefPtr<Expr> SemanticsVisitor::checkGenericAppWithCheckedArgs(GenericAppExpr* genericAppExpr)
+    Expr* SemanticsVisitor::checkGenericAppWithCheckedArgs(GenericAppExpr* genericAppExpr)
     {
         // We are applying a generic to arguments, but there might be multiple generic
         // declarations with the same name, so this becomes a specialized case of

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -157,8 +157,8 @@ namespace Slang
         addModifier(stmt->varDecl, m_astBuilder->create<ConstModifier>());
         stmt->varDecl->setCheckState(DeclCheckState::Checked);
 
-        IntVal* rangeBeginVal;
-        IntVal* rangeEndVal;
+        IntVal* rangeBeginVal = nullptr;
+        IntVal* rangeEndVal = nullptr;
 
         if (stmt->rangeBeginExpr)
         {

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -108,9 +108,9 @@ namespace Slang
         stmt->parentStmt = outer;
     }
 
-    RefPtr<Expr> SemanticsVisitor::checkPredicateExpr(Expr* expr)
+    Expr* SemanticsVisitor::checkPredicateExpr(Expr* expr)
     {
-        RefPtr<Expr> e = expr;
+        Expr* e = expr;
         e = CheckTerm(e);
         e = coerce(m_astBuilder->getBoolType(), e);
         return e;
@@ -140,7 +140,7 @@ namespace Slang
         subContext.checkStmt(stmt->statement);
     }
 
-    RefPtr<Expr> SemanticsVisitor::checkExpressionAndExpectIntegerConstant(RefPtr<Expr> expr, RefPtr<IntVal>* outIntVal)
+    Expr* SemanticsVisitor::checkExpressionAndExpectIntegerConstant(Expr* expr, IntVal** outIntVal)
     {
         expr = CheckExpr(expr);
         auto intVal = CheckIntegerConstantExpression(expr);
@@ -157,8 +157,8 @@ namespace Slang
         addModifier(stmt->varDecl, m_astBuilder->create<ConstModifier>());
         stmt->varDecl->setCheckState(DeclCheckState::Checked);
 
-        RefPtr<IntVal> rangeBeginVal;
-        RefPtr<IntVal> rangeEndVal;
+        IntVal* rangeBeginVal;
+        IntVal* rangeEndVal;
 
         if (stmt->rangeBeginExpr)
         {
@@ -166,7 +166,7 @@ namespace Slang
         }
         else
         {
-            RefPtr<ConstantIntVal> rangeBeginConst = m_astBuilder->create<ConstantIntVal>();
+            ConstantIntVal* rangeBeginConst = m_astBuilder->create<ConstantIntVal>();
             rangeBeginConst->value = 0;
             rangeBeginVal = rangeBeginConst;
         }

--- a/source/slang/slang-check.cpp
+++ b/source/slang/slang-check.cpp
@@ -196,19 +196,6 @@ namespace Slang
         return func;
     }
 
-    TypeCheckingCache* Session::getTypeCheckingCache()
-    {
-        if (!typeCheckingCache)
-            typeCheckingCache = new TypeCheckingCache();
-        return typeCheckingCache;
-    }
-
-    void Session::destroyTypeCheckingCache()
-    {
-        delete typeCheckingCache;
-        typeCheckingCache = nullptr;
-    }
-
     void checkTranslationUnit(
         TranslationUnitRequest* translationUnit)
     {

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -989,8 +989,8 @@ namespace Slang
         public:
             struct GenericArgInfo
             {
-                Decl* paramDecl;
-                Val* argVal;
+                Decl* paramDecl = nullptr;
+                Val* argVal = nullptr;
             };
 
             List<GenericArgInfo> genericArgs;
@@ -1012,7 +1012,7 @@ namespace Slang
 
     private:
         // The AST for the module
-        ModuleDecl*  m_moduleDecl;
+        ModuleDecl*  m_moduleDecl = nullptr;
 
         // The IR for the module
         RefPtr<IRModule> m_irModule = nullptr;

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -483,7 +483,7 @@ namespace Slang
         //
         // TODO: Remove this. Type lookup should only be supported on `Module`s.
         //
-        Dictionary<String, RefPtr<Type>> m_types;
+        Dictionary<String, Type*> m_types;
     };
 
         /// A component type built up from other component types.
@@ -604,7 +604,7 @@ namespace Slang
         List<String> const& getFilePathDependencies() SLANG_OVERRIDE { return m_base->getFilePathDependencies(); }
 
                     /// Get a list of tagged-union types referenced by the specialization parameters.
-        List<RefPtr<TaggedUnionType>> const& getTaggedUnionTypes() { return m_taggedUnionTypes; }
+        List<TaggedUnionType*> const& getTaggedUnionTypes() { return m_taggedUnionTypes; }
 
         RefPtr<IRModule> getIRModule() { return m_irModule; }
 
@@ -632,7 +632,7 @@ namespace Slang
         List<String> m_entryPointMangledNames;
 
         // Any tagged union types that were referenced by the specialization arguments.
-        List<RefPtr<TaggedUnionType>> m_taggedUnionTypes;
+        List<TaggedUnionType*> m_taggedUnionTypes;
 
     };
 
@@ -711,7 +711,7 @@ namespace Slang
         DeclRef<FuncDecl> getFuncDeclRef() { return m_funcDeclRef; }
 
             /// Get the function declaration (without generic arguments).
-        RefPtr<FuncDecl> getFuncDecl() { return m_funcDeclRef.getDecl(); }
+        FuncDecl* getFuncDecl() { return m_funcDeclRef.getDecl(); }
 
             /// Get the name of the entry point
         Name* getName() { return m_name; }
@@ -989,8 +989,8 @@ namespace Slang
         public:
             struct GenericArgInfo
             {
-                RefPtr<Decl> paramDecl;
-                RefPtr<Val> argVal;
+                Decl* paramDecl;
+                Val* argVal;
             };
 
             List<GenericArgInfo> genericArgs;
@@ -1012,7 +1012,7 @@ namespace Slang
 
     private:
         // The AST for the module
-        RefPtr<ModuleDecl>  m_moduleDecl;
+        ModuleDecl*  m_moduleDecl;
 
         // The IR for the module
         RefPtr<IRModule> m_irModule = nullptr;
@@ -1092,7 +1092,7 @@ namespace Slang
         RefPtr<Module> module;
 
         Module* getModule() { return module; }
-        RefPtr<ModuleDecl> getModuleDecl() { return module->getModuleDecl(); }
+        ModuleDecl* getModuleDecl() { return module->getModuleDecl(); }
 
         Session* getSession();
         NamePool* getNamePool();
@@ -1308,7 +1308,7 @@ namespace Slang
         ///
         SlangResult loadFile(String const& path, PathInfo& outPathInfo, ISlangBlob** outBlob);
 
-        RefPtr<Expr> parseTermString(String str, RefPtr<Scope> scope);
+        Expr* parseTermString(String str, RefPtr<Scope> scope);
 
         Type* specializeType(
             Type*           unspecializedType,
@@ -1426,7 +1426,7 @@ namespace Slang
             /// Is the given module in the middle of being imported?
         bool isBeingImported(Module* module);
 
-        List<RefPtr<Type>> m_specializedTypes;
+        List<Type*> m_specializedTypes;
 
     };
 
@@ -2037,7 +2037,7 @@ namespace Slang
         RefPtr<Scope>   hlslLanguageScope;
         RefPtr<Scope>   slangLanguageScope;
 
-        List<RefPtr<ModuleDecl>> loadedModuleCode;
+        List<ModuleDecl*> loadedModuleCode;
 
         SourceManager   builtinSourceManager;
 

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1193,6 +1193,7 @@ namespace Slang
         /// Given a target returns the required downstream compiler
     PassThroughMode getDownstreamCompilerRequiredForTarget(CodeGenTarget target);
 
+    struct TypeCheckingCache;
     
         /// A context for loading and re-using code modules.
     class Linkage : public RefObject, public slang::ISession
@@ -1237,6 +1238,9 @@ namespace Slang
             /// Create an initially-empty linkage
         Linkage(Session* session, ASTBuilder* astBuilder);
 
+            /// Dtor
+        ~Linkage();
+
             /// Get the parent session for this linkage
         Session* getSessionImpl() { return m_session; }
 
@@ -1265,7 +1269,14 @@ namespace Slang
 
         ASTBuilder* getASTBuilder() { return m_astBuilder; }
 
+       
         RefPtr<ASTBuilder> m_astBuilder;
+
+            // cache used by type checking, implemented in check.cpp
+        TypeCheckingCache* getTypeCheckingCache();
+        void destroyTypeCheckingCache();
+
+        TypeCheckingCache* m_typeCheckingCache = nullptr;
 
         // Modules that have been dynamically loaded via `import`
         //
@@ -1952,7 +1963,6 @@ namespace Slang
         EndToEndCompileRequest* endToEndReq,
         SourceResult&           outSource);
 
-    struct TypeCheckingCache;
     //
 
     // Information about BaseType that's useful for checking literals 
@@ -2075,10 +2085,7 @@ namespace Slang
         
         RefPtr<SharedASTBuilder> m_sharedASTBuilder;
 
-        // cache used by type checking, implemented in check.cpp
-        TypeCheckingCache* typeCheckingCache = nullptr;
-        TypeCheckingCache* getTypeCheckingCache();
-        void destroyTypeCheckingCache();
+
         //
 
         void setSharedLibraryLoader(ISlangSharedLibraryLoader* loader);

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -2037,7 +2037,8 @@ namespace Slang
         RefPtr<Scope>   hlslLanguageScope;
         RefPtr<Scope>   slangLanguageScope;
 
-        List<ModuleDecl*> loadedModuleCode;
+        ModuleDecl* baseModuleDecl = nullptr;
+        List<RefPtr<Module>> loadedModuleCode;
 
         SourceManager   builtinSourceManager;
 

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -970,6 +970,9 @@ namespace Slang
         List<Module*> const& getModuleDependencies() SLANG_OVERRIDE { return m_moduleDependencyList.getModuleList(); }
         List<String> const& getFilePathDependencies() SLANG_OVERRIDE { return m_filePathDependencyList.getFilePathList(); }
 
+            /// Get the ASTBuilder
+        ASTBuilder* getASTBuilder() { return &m_astBuilder; }
+
             /// Collect information on the shader parameters of the module.
             ///
             /// This method should only be called once, after the core
@@ -1044,6 +1047,10 @@ namespace Slang
         // that was defined as part of the module.
         //
         List<RefPtr<EntryPoint>> m_entryPoints;
+
+        // The builder that owns all of the AST nodes from parsing the source of
+        // this module. 
+        ASTBuilder m_astBuilder;
     };
     typedef Module LoadedModule;
 

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -373,7 +373,7 @@ public:
     // we maintain a set of already-emitted modules.
     HashSet<ModuleDecl*> m_modulesAlreadyEmitted;
 
-    ModuleDecl* m_program;
+    ModuleDecl* m_program = nullptr;
 
     UInt m_uniqueIDCounter = 1;
     Dictionary<IRInst*, UInt> m_mapIRValueToID;

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3543,7 +3543,7 @@ namespace Slang
 
     void IRBuilder::addHighLevelDeclDecoration(IRInst* inst, Decl* decl)
     {
-        auto ptrConst = getPtrValue(addRefObjectToFree(decl));
+        auto ptrConst = getPtrValue(decl);
         addDecoration(inst, kIROp_HighLevelDeclDecoration, ptrConst);
     }
 

--- a/source/slang/slang-lookup.cpp
+++ b/source/slang/slang-lookup.cpp
@@ -11,7 +11,7 @@ void ensureDecl(SemanticsVisitor* visitor, Decl* decl, DeclCheckState state);
 DeclRef<ExtensionDecl> ApplyExtensionToType(
     SemanticsVisitor*   semantics,
     ExtensionDecl*          extDecl,
-    RefPtr<Type>  type);
+    Type*  type);
 
 //
 
@@ -268,7 +268,7 @@ LookupResult lookUpDirectAndTransparentMembers(
 }
 
 
-static RefPtr<SubtypeWitness> _makeSubtypeWitness(
+static SubtypeWitness* _makeSubtypeWitness(
     ASTBuilder*                 astBuilder,
     Type*                       subType,
     SubtypeWitness*             subToMidWitness,
@@ -277,7 +277,7 @@ static RefPtr<SubtypeWitness> _makeSubtypeWitness(
 {
     if(subToMidWitness)
     {
-        RefPtr<TransitiveSubtypeWitness> transitiveWitness = astBuilder->create<TransitiveSubtypeWitness>();
+        TransitiveSubtypeWitness* transitiveWitness = astBuilder->create<TransitiveSubtypeWitness>();
         transitiveWitness->subToMid = subToMidWitness;
         transitiveWitness->midToSup = midToSuperConstraint;
         transitiveWitness->sub = subType;
@@ -286,7 +286,7 @@ static RefPtr<SubtypeWitness> _makeSubtypeWitness(
     }
     else
     {
-        RefPtr<DeclaredSubtypeWitness> declaredWitness = astBuilder->create<DeclaredSubtypeWitness>();
+        DeclaredSubtypeWitness* declaredWitness = astBuilder->create<DeclaredSubtypeWitness>();
         declaredWitness->declRef = midToSuperConstraint;
         declaredWitness->sub = subType;
         declaredWitness->sup = superType;
@@ -295,7 +295,7 @@ static RefPtr<SubtypeWitness> _makeSubtypeWitness(
 }
 
 // Same as the above, but we are specializing a type instead of a decl-ref
-static RefPtr<Type> _maybeSpecializeSuperType(
+static Type* _maybeSpecializeSuperType(
     ASTBuilder*                 astBuilder, 
     Type*                       superType,
     SubtypeWitness*             subIsSuperWitness)
@@ -304,7 +304,7 @@ static RefPtr<Type> _maybeSpecializeSuperType(
     {
         if (auto superInterfaceDeclRef = superDeclRefType->declRef.as<InterfaceDecl>())
         {
-            RefPtr<ThisTypeSubstitution> thisTypeSubst = astBuilder->create<ThisTypeSubstitution>();
+            ThisTypeSubstitution* thisTypeSubst = astBuilder->create<ThisTypeSubstitution>();
             thisTypeSubst->interfaceDecl = superInterfaceDeclRef.getDecl();
             thisTypeSubst->witness = subIsSuperWitness;
             thisTypeSubst->outer = superInterfaceDeclRef.substitutions.substitutions;
@@ -322,7 +322,7 @@ static RefPtr<Type> _maybeSpecializeSuperType(
 static void _lookUpMembersInType(
     ASTBuilder*             astBuilder, 
     Name*                   name,
-    RefPtr<Type>            type,
+    Type*            type,
     LookupRequest const&    request,
     LookupResult&           ioResult,
     BreadcrumbInfo*         breadcrumbs);
@@ -584,7 +584,7 @@ static void _lookUpMembersInSuperTypeImpl(
 static void _lookUpMembersInType(
     ASTBuilder*             astBuilder,
     Name*                   name,
-    RefPtr<Type>            type,
+    Type*            type,
     LookupRequest const&    request,
     LookupResult&           ioResult,
     BreadcrumbInfo*         breadcrumbs)
@@ -679,7 +679,7 @@ static void _lookUpInScopes(
                 breadcrumb.declRef = aggTypeDeclBaseRef;
                 breadcrumb.prev = nullptr;
 
-                RefPtr<Type> type;
+                Type* type;
                 if(auto extDeclRef = aggTypeDeclBaseRef.as<ExtensionDecl>())
                 {
                     if( request.semantics )

--- a/source/slang/slang-lookup.cpp
+++ b/source/slang/slang-lookup.cpp
@@ -679,7 +679,7 @@ static void _lookUpInScopes(
                 breadcrumb.declRef = aggTypeDeclBaseRef;
                 breadcrumb.prev = nullptr;
 
-                Type* type;
+                Type* type = nullptr;
                 if(auto extDeclRef = aggTypeDeclBaseRef.as<ExtensionDecl>())
                 {
                     if( request.semantics )

--- a/source/slang/slang-lookup.h
+++ b/source/slang/slang-lookup.h
@@ -47,7 +47,7 @@ QualType getTypeForDeclRef(
     SemanticsVisitor*       sema,
     DiagnosticSink*         sink,
     DeclRef<Decl>           declRef,
-    RefPtr<Type>*           outTypeResult,
+    Type**           outTypeResult,
     SourceLoc               loc);
 
 QualType getTypeForDeclRef(

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -1606,7 +1606,7 @@ void addVarDecorations(
     Decl*           decl)
 {
     auto builder = context->irBuilder;
-    for(RefPtr<Modifier> mod : decl->modifiers)
+    for(Modifier* mod : decl->modifiers)
     {
         if(as<HLSLNoInterpolationModifier>(mod))
         {
@@ -1947,7 +1947,7 @@ DeclRef<D> createDefaultSpecializedDeclRef(IRGenContext* context, D* decl)
     /// includes things like function declarations themselves, which inherit the
     /// definition of `this` from their parent/outer declaration.
     ///
-RefPtr<Type> getThisParamTypeForContainer(
+Type* getThisParamTypeForContainer(
     IRGenContext*   context,
     DeclRef<Decl>   parentDeclRef)
 {
@@ -1963,7 +1963,7 @@ RefPtr<Type> getThisParamTypeForContainer(
     return nullptr;
 }
 
-RefPtr<Type> getThisParamTypeForCallable(
+Type* getThisParamTypeForCallable(
     IRGenContext*   context,
     DeclRef<Decl>   callableDeclRef)
 {
@@ -2522,7 +2522,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             auto paramDirection = getParameterDirection(paramDecl);
 
             UInt argIndex = argCounter++;
-            RefPtr<Expr> argExpr;
+            Expr* argExpr;
             if(argIndex < argCount)
             {
                 argExpr = expr->arguments[argIndex];
@@ -2606,7 +2606,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
     // with some contextual information about the declaration
     // we are calling.
     bool tryResolveDeclRefForCall(
-        RefPtr<Expr>        funcExpr,
+        Expr*        funcExpr,
         ResolvedCallInfo*   outInfo)
     {
         // TODO: unwrap any "identity" expressions that might
@@ -2658,7 +2658,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         {
             // Seems to be a case of declaration-reference we don't know about.
             SLANG_UNEXPECTED("unknown declaration reference kind");
-            return false;
+            //return false;
         }
     }
 
@@ -4511,7 +4511,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // the inheritance declaration is on an `extension` declaration,
         // then we need to identify the type being extended.
         //
-        RefPtr<Type> subType;
+        Type* subType;
         if (auto extParentDecl = as<ExtensionDecl>(parentDecl))
         {
             subType = extParentDecl->targetType.type;
@@ -4522,7 +4522,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         }
 
         // What is the super-type that we have declared we inherit from?
-        RefPtr<Type> superType = inheritanceDecl->base.type;
+        Type* superType = inheritanceDecl->base.type;
 
         // Construct the mangled name for the witness table, which depends
         // on the type that is conforming, and the type that it conforms to.
@@ -5392,7 +5392,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
     struct ParameterInfo
     {
         // This AST-level type of the parameter
-        RefPtr<Type>        type;
+        Type*        type;
 
         // The direction (`in` vs `out` vs `in out`)
         ParameterDirection  direction;
@@ -6461,7 +6461,7 @@ IRInst* lowerSubstitutionArg(
 }
 
 // Can the IR lowered version of this declaration ever be an `IRGeneric`?
-bool canDeclLowerToAGeneric(RefPtr<Decl> decl)
+bool canDeclLowerToAGeneric(Decl* decl)
 {
     // A callable decl lowers to an `IRFunc`, and can be generic
     if(as<CallableDecl>(decl)) return true;
@@ -6481,8 +6481,8 @@ bool canDeclLowerToAGeneric(RefPtr<Decl> decl)
 
 LoweredValInfo emitDeclRef(
     IRGenContext*           context,
-    RefPtr<Decl>            decl,
-    RefPtr<Substitutions>   subst,
+    Decl*            decl,
+    Substitutions*   subst,
     IRType*                 type)
 {
     // We need to proceed by considering the specializations that
@@ -6512,7 +6512,7 @@ LoweredValInfo emitDeclRef(
     }
 
     // Otherwise, we look at the kind of substitution, and let it guide us.
-    if(auto genericSubst = subst.as<GenericSubstitution>())
+    if(auto genericSubst = as<GenericSubstitution>(subst))
     {
         // A generic substitution means we will need to output
         // a `specialize` instruction to specialize the generic.
@@ -6561,9 +6561,9 @@ LoweredValInfo emitDeclRef(
 
         return LoweredValInfo::simple(irSpecializedVal);
     }
-    else if(auto thisTypeSubst = subst.as<ThisTypeSubstitution>())
+    else if(auto thisTypeSubst = as<ThisTypeSubstitution>(subst))
     {
-        if(decl.Ptr() == thisTypeSubst->interfaceDecl)
+        if(decl == thisTypeSubst->interfaceDecl)
         {
             // This is a reference to the interface type itself,
             // through the this-type substitution, so it is really

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -2522,7 +2522,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             auto paramDirection = getParameterDirection(paramDecl);
 
             UInt argIndex = argCounter++;
-            Expr* argExpr;
+            Expr* argExpr = nullptr;
             if(argIndex < argCount)
             {
                 argExpr = expr->arguments[argIndex];
@@ -4511,7 +4511,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // the inheritance declaration is on an `extension` declaration,
         // then we need to identify the type being extended.
         //
-        Type* subType;
+        Type* subType = nullptr;
         if (auto extParentDecl = as<ExtensionDecl>(parentDecl))
         {
             subType = extParentDecl->targetType.type;
@@ -5392,14 +5392,14 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
     struct ParameterInfo
     {
         // This AST-level type of the parameter
-        Type*        type;
+        Type*        type = nullptr;
 
         // The direction (`in` vs `out` vs `in out`)
         ParameterDirection  direction;
 
         // The variable/parameter declaration for
         // this parameter (if any)
-        VarDeclBase*        decl;
+        VarDeclBase*        decl = nullptr;
 
         // Is this the representation of a `this` parameter?
         bool                isThisParam = false;

--- a/source/slang/slang-mangle.cpp
+++ b/source/slang/slang-mangle.cpp
@@ -225,7 +225,7 @@ namespace Slang
         if( parentDeclRef )
         {
             // In certain cases we want to skip emitting the parent
-            if(parentGenericDeclRef && (parentGenericDeclRef.getDecl()->inner.Ptr() != declRef.getDecl()))
+            if(parentGenericDeclRef && (parentGenericDeclRef.getDecl()->inner != declRef.getDecl()))
             {
             }
             else if(parentDeclRef.as<FunctionDeclBase>())
@@ -287,7 +287,7 @@ namespace Slang
 
 
         // Are we the "inner" declaration beneath a generic decl?
-        if(parentGenericDeclRef && (parentGenericDeclRef.getDecl()->inner.Ptr() == declRef.getDecl()))
+        if(parentGenericDeclRef && (parentGenericDeclRef.getDecl()->inner == declRef.getDecl()))
         {
             // There are two cases here: either we have specializations
             // in place for the parent generic declaration, or we don't.

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -584,7 +584,7 @@ LayoutSemanticInfo ExtractLayoutSemanticInfo(
 // a particular sub-argument and extract its value if present.
 template<typename T>
 static bool findLayoutArg(
-    RefPtr<ModifiableSyntaxNode>    syntax,
+    ModifiableSyntaxNode*    syntax,
     UInt*                           outVal)
 {
     for( auto modifier : syntax->getModifiersOfType<T>() )
@@ -674,7 +674,7 @@ struct EntryPointParameterState
 
 static RefPtr<TypeLayout> processEntryPointVaryingParameter(
     ParameterBindingContext*        context,
-    RefPtr<Type>          type,
+    Type*          type,
     EntryPointParameterState const& state,
     RefPtr<VarLayout>               varLayout);
 
@@ -707,7 +707,7 @@ static void collectGlobalScopeParameter(
     auto varDeclRef = shaderParamInfo.paramDeclRef;
 
     // We apply any substitutions for global generic parameters here.
-    auto type = getType(astBuilder, varDeclRef)->substitute(astBuilder, globalGenericSubst).as<Type>();
+    auto type = as<Type>(getType(astBuilder, varDeclRef)->substitute(astBuilder, globalGenericSubst));
 
     // We use a single operation to both check whether the
     // variable represents a shader parameter, and to compute
@@ -1014,8 +1014,10 @@ static void addExplicitParameterBindings_GLSL(
     }
     else if( (resInfo = typeLayout->FindResourceInfo(LayoutResourceKind::SpecializationConstant)) != nullptr )
     {
+        DeclRef<Decl> varDecl2(varDecl);
+
         // Try to find `constant_id` binding
-        if(!findLayoutArg<GLSLConstantIDLayoutModifier>(varDecl, &semanticInfo.index))
+        if(!findLayoutArg<GLSLConstantIDLayoutModifier>(varDecl2, &semanticInfo.index))
             return;
     }
 
@@ -1382,7 +1384,7 @@ SimpleSemanticInfo decomposeSimpleSemantic(
 
 static RefPtr<TypeLayout> processSimpleEntryPointParameter(
     ParameterBindingContext*        context,
-    RefPtr<Type>          type,
+    Type*          type,
     EntryPointParameterState const& inState,
     RefPtr<VarLayout>               varLayout,
     int                             semanticSlotCount = 1)
@@ -1546,7 +1548,7 @@ static RefPtr<TypeLayout> processSimpleEntryPointParameter(
 static RefPtr<TypeLayout> processEntryPointVaryingParameterDecl(
     ParameterBindingContext*        context,
     Decl*                           decl,
-    RefPtr<Type>                    type,
+    Type*                    type,
     EntryPointParameterState const& inState,
     RefPtr<VarLayout>               varLayout)
 {
@@ -1703,7 +1705,7 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameterDecl(
 
 static RefPtr<TypeLayout> processEntryPointVaryingParameter(
     ParameterBindingContext*        context,
-    RefPtr<Type>                    type,
+    Type*                    type,
     EntryPointParameterState const& state,
     RefPtr<VarLayout>               varLayout)
 {
@@ -2712,7 +2714,7 @@ static void collectSpecializationParams(
         case SpecializationParam::Flavor::GenericValue:
             {
                 RefPtr<GenericSpecializationParamLayout> paramLayout = new GenericSpecializationParamLayout();
-                paramLayout->decl = specializationParam.object.as<Decl>();
+                paramLayout->decl = as<Decl>(specializationParam.object);
                 context->shared->programLayout->specializationParams.add(paramLayout);
             }
             break;
@@ -2721,7 +2723,7 @@ static void collectSpecializationParams(
         case SpecializationParam::Flavor::ExistentialValue:
             {
                 RefPtr<ExistentialSpecializationParamLayout> paramLayout = new ExistentialSpecializationParamLayout();
-                paramLayout->type = specializationParam.object.as<Type>();
+                paramLayout->type = as<Type>(specializationParam.object);
                 context->shared->programLayout->specializationParams.add(paramLayout);
             }
             break;

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -50,11 +50,11 @@ namespace Slang
         {
             return find<T>() != nullptr;
         }
-        RefPtr<Modifier> getFirst() { return m_result; };
+        Modifier* getFirst() { return m_result; };
     protected:
 
-        RefPtr<Modifier> m_result;
-        RefPtr<Modifier>* m_next;
+        Modifier* m_result;
+        Modifier** m_next;
     };
 
     enum Precedence : int
@@ -151,28 +151,28 @@ namespace Slang
         bool LookAheadToken(TokenType type, int offset = 0);
         bool LookAheadToken(const char * string, int offset = 0);
         void                                        parseSourceFile(ModuleDecl* program);
-        RefPtr<Decl>					ParseStruct();
-        RefPtr<ClassDecl>					    ParseClass();
-        RefPtr<Stmt>					ParseStatement();
-        RefPtr<Stmt>			        parseBlockStatement();
-        RefPtr<DeclStmt>			parseVarDeclrStatement(Modifiers modifiers);
-        RefPtr<IfStmt>				parseIfStatement();
-        RefPtr<ForStmt>				ParseForStatement();
-        RefPtr<WhileStmt>			ParseWhileStatement();
-        RefPtr<DoWhileStmt>			ParseDoWhileStatement();
-        RefPtr<BreakStmt>			ParseBreakStatement();
-        RefPtr<ContinueStmt>			ParseContinueStatement();
-        RefPtr<ReturnStmt>			ParseReturnStatement();
-        RefPtr<ExpressionStmt>		ParseExpressionStatement();
-        RefPtr<Expr>				ParseExpression(Precedence level = Precedence::Comma);
+        Decl*					ParseStruct();
+        ClassDecl*					    ParseClass();
+        Stmt*					ParseStatement();
+        Stmt*			        parseBlockStatement();
+        DeclStmt*			parseVarDeclrStatement(Modifiers modifiers);
+        IfStmt*				parseIfStatement();
+        ForStmt*				ParseForStatement();
+        WhileStmt*			ParseWhileStatement();
+        DoWhileStmt*			ParseDoWhileStatement();
+        BreakStmt*			ParseBreakStatement();
+        ContinueStmt*			ParseContinueStatement();
+        ReturnStmt*			ParseReturnStatement();
+        ExpressionStmt*		ParseExpressionStatement();
+        Expr*				ParseExpression(Precedence level = Precedence::Comma);
 
         // Parse an expression that might be used in an initializer or argument context, so we should avoid operator-comma
-        inline RefPtr<Expr>			ParseInitExpr() { return ParseExpression(Precedence::Assignment); }
-        inline RefPtr<Expr>			ParseArgExpr()  { return ParseExpression(Precedence::Assignment); }
+        inline Expr*			ParseInitExpr() { return ParseExpression(Precedence::Assignment); }
+        inline Expr*			ParseArgExpr()  { return ParseExpression(Precedence::Assignment); }
 
-        RefPtr<Expr>				ParseLeafExpression();
-        RefPtr<ParamDecl>					ParseParameter();
-        RefPtr<Expr>				ParseType();
+        Expr*				ParseLeafExpression();
+        ParamDecl*					ParseParameter();
+        Expr*				ParseType();
         TypeExp										ParseTypeExp();
 
         Parser & operator = (const Parser &) = delete;
@@ -191,20 +191,20 @@ namespace Slang
         Parser*         parser,
         ContainerDecl*  parent);
 
-    static RefPtr<Decl> parseEnumDecl(Parser* parser);
+    static Decl* parseEnumDecl(Parser* parser);
 
-    static RefPtr<Modifier> ParseOptSemantics(
+    static Modifier* ParseOptSemantics(
         Parser* parser);
 
     static void ParseOptSemantics(
         Parser* parser,
         Decl*	decl);
 
-    static RefPtr<DeclBase> ParseDecl(
+    static DeclBase* ParseDecl(
         Parser*			parser,
         ContainerDecl*	containerDecl);
 
-    static RefPtr<Decl> ParseSingleDecl(
+    static Decl* ParseSingleDecl(
         Parser*			parser,
         ContainerDecl*	containerDecl);
 
@@ -588,7 +588,7 @@ namespace Slang
 
     RefPtr<RefObject> ParseTypeDef(Parser* parser, void* /*userData*/)
     {
-        RefPtr<TypeDefDecl> typeDefDecl = parser->astBuilder->create<TypeDefDecl>();
+        TypeDefDecl* typeDefDecl = parser->astBuilder->create<TypeDefDecl>();
 
         // TODO(tfoley): parse an actual declarator
         auto type = parser->ParseTypeExp();
@@ -603,9 +603,9 @@ namespace Slang
     }
 
     // Add a modifier to a list of modifiers being built
-    static void AddModifier(RefPtr<Modifier>** ioModifierLink, RefPtr<Modifier> modifier)
+    static void AddModifier(Modifier*** ioModifierLink, Modifier* modifier)
     {
-        RefPtr<Modifier>*& modifierLink = *ioModifierLink;
+        Modifier**& modifierLink = *ioModifierLink;
 
         // We'd like to add the modifier to the end of the list,
         // but we need to be careful, in case there is a "shared"
@@ -620,7 +620,7 @@ namespace Slang
                 break;
 
             // About to look at shared modifiers? Done.
-            RefPtr<Modifier> linkMod = *modifierLink;
+            Modifier* linkMod = *modifierLink;
             if(as<SharedModifiers>(linkMod))
             {
                 break;
@@ -648,8 +648,8 @@ namespace Slang
     }
 
     void addModifier(
-        RefPtr<ModifiableSyntaxNode>    syntax,
-        RefPtr<Modifier>                modifier)
+        ModifiableSyntaxNode*    syntax,
+        Modifier*                modifier)
     {
         auto modifierLink = &syntax->modifiers.first;
         AddModifier(&modifierLink, modifier);
@@ -706,7 +706,7 @@ namespace Slang
     }
 
     // Parse HLSL-style `[name(arg, ...)]` style "attribute" modifiers
-    static void ParseSquareBracketAttributes(Parser* parser, RefPtr<Modifier>** ioModifierLink)
+    static void ParseSquareBracketAttributes(Parser* parser, Modifier*** ioModifierLink)
     {
         parser->ReadToken(TokenType::LBracket);
 
@@ -725,7 +725,7 @@ namespace Slang
 
             Token nameToken = parseAttributeName(parser);
 
-            RefPtr<UncheckedAttribute> modifier = parser->astBuilder->create<UncheckedAttribute>();
+            UncheckedAttribute* modifier = parser->astBuilder->create<UncheckedAttribute>();
             modifier->name = nameToken.getName();
             modifier->loc = nameToken.getLoc();
             modifier->scope = parser->currentScope;
@@ -811,7 +811,7 @@ namespace Slang
     bool tryParseUsingSyntaxDecl(
         Parser*     parser,
         SyntaxDecl* syntaxDecl,
-        RefPtr<T>*  outSyntax)
+        T**  outSyntax)
     {
         if (!syntaxDecl)
             return false;
@@ -822,7 +822,7 @@ namespace Slang
         // Consume the token that specified the keyword
         auto keywordToken = advanceToken(parser);
 
-        RefPtr<RefObject> parsedObject = syntaxDecl->parseCallback(parser, syntaxDecl->parseUserData);
+        RefObject* parsedObject = syntaxDecl->parseCallback(parser, syntaxDecl->parseUserData);
         if (!parsedObject)
         {
             return false;
@@ -849,7 +849,7 @@ namespace Slang
     template<typename T>
     bool tryParseUsingSyntaxDecl(
         Parser*     parser,
-        RefPtr<T>*  outSyntax)
+        T**  outSyntax)
     {
         if (peekTokenType(parser) != TokenType::Identifier)
             return false;
@@ -868,7 +868,7 @@ namespace Slang
     static Modifiers ParseModifiers(Parser* parser)
     {
         Modifiers modifiers;
-        RefPtr<Modifier>* modifierLink = &modifiers.first;
+        Modifier** modifierLink = &modifiers.first;
         for (;;)
         {
             SourceLoc loc = parser->tokenReader.peekLoc();
@@ -887,7 +887,7 @@ namespace Slang
 
                     Token nameToken = peekToken(parser);
 
-                    RefPtr<Modifier> parsedModifier;
+                    Modifier* parsedModifier;
                     if (tryParseUsingSyntaxDecl<Modifier>(parser, &parsedModifier))
                     {
                         parsedModifier->name = nameToken.getName();
@@ -1060,30 +1060,30 @@ namespace Slang
         SourceLoc openBracketLoc;
 
         // The expression that yields the element count, or NULL
-        RefPtr<Expr>	elementCountExpr;
+        Expr*	elementCountExpr;
     };
 
     // "Unwrapped" information about a declarator
     struct DeclaratorInfo
     {
-        RefPtr<Expr>	    typeSpec;
+        Expr*	    typeSpec;
         NameLoc             nameAndLoc;
-        RefPtr<Modifier>	semantics;
-        RefPtr<Expr>	    initializer;
+        Modifier*	semantics;
+        Expr*	    initializer;
     };
 
     // Add a member declaration to its container, and ensure that its
     // parent link is set up correctly.
-    static void AddMember(RefPtr<ContainerDecl> container, RefPtr<Decl> member)
+    static void AddMember(ContainerDecl* container, Decl* member)
     {
         if (container)
         {
-            member->parentDecl = container.Ptr();
+            member->parentDecl = container;
             container->members.add(member);
         }
     }
 
-    static void AddMember(RefPtr<Scope> scope, RefPtr<Decl> member)
+    static void AddMember(RefPtr<Scope> scope, Decl* member)
     {
         if (scope)
         {
@@ -1091,9 +1091,9 @@ namespace Slang
         }
     }
 
-    static RefPtr<Decl> ParseGenericParamDecl(
+    static Decl* ParseGenericParamDecl(
         Parser*             parser,
-        RefPtr<GenericDecl> genericDecl)
+        GenericDecl* genericDecl)
     {
         // simple syntax to introduce a value parameter
         if (AdvanceIf(parser, "let"))
@@ -1114,7 +1114,7 @@ namespace Slang
         else
         {
             // default case is a type parameter
-            RefPtr<GenericTypeParamDecl> paramDecl = parser->astBuilder->create<GenericTypeParamDecl>();
+            GenericTypeParamDecl* paramDecl = parser->astBuilder->create<GenericTypeParamDecl>();
             parser->FillPosition(paramDecl);
             paramDecl->nameAndLoc = NameLoc(parser->ReadToken(TokenType::Identifier));
             if (AdvanceIf(parser, TokenType::Colon))
@@ -1178,13 +1178,13 @@ namespace Slang
     }
 
     template<typename ParseFunc>
-    static RefPtr<Decl> parseOptGenericDecl(
+    static Decl* parseOptGenericDecl(
         Parser* parser, const ParseFunc& parseInner)
     {
         // TODO: may want more advanced disambiguation than this...
         if (parser->LookAheadToken(TokenType::OpLess))
         {
-            RefPtr<GenericDecl> genericDecl = parser->astBuilder->create<GenericDecl>();
+            GenericDecl* genericDecl = parser->astBuilder->create<GenericDecl>();
             parser->FillPosition(genericDecl);
             parser->PushScope(genericDecl);
             ParseGenericDeclImpl(parser, genericDecl, parseInner);
@@ -1199,17 +1199,17 @@ namespace Slang
 
     static RefPtr<RefObject> ParseGenericDecl(Parser* parser, void*)
     {
-        RefPtr<GenericDecl> decl = parser->astBuilder->create<GenericDecl>();
-        parser->FillPosition(decl.Ptr());
-        parser->PushScope(decl.Ptr());
-        ParseGenericDeclImpl(parser, decl.Ptr(), [=](GenericDecl* genDecl) {return ParseSingleDecl(parser, genDecl); });
+        GenericDecl* decl = parser->astBuilder->create<GenericDecl>();
+        parser->FillPosition(decl);
+        parser->PushScope(decl);
+        ParseGenericDeclImpl(parser, decl, [=](GenericDecl* genDecl) {return ParseSingleDecl(parser, genDecl); });
         parser->PopScope();
         return decl;
     }
 
     static void parseParameterList(
         Parser*                 parser,
-        RefPtr<CallableDecl>    decl)
+        CallableDecl*    decl)
     {
         parser->ReadToken(TokenType::LParent);
 
@@ -1270,7 +1270,7 @@ namespace Slang
     };
 
         /// Parse an optional body statement for a declaration that can have a body.
-    static RefPtr<Stmt> parseOptBody(Parser* parser)
+    static Stmt* parseOptBody(Parser* parser)
     {
         if (AdvanceIf(parser, TokenType::Semicolon))
         {
@@ -1284,12 +1284,12 @@ namespace Slang
     }
 
         /// Complete parsing of a function using traditional (C-like) declarator syntax
-    static RefPtr<Decl> parseTraditionalFuncDecl(
+    static Decl* parseTraditionalFuncDecl(
         Parser*                 parser,
         DeclaratorInfo const&   declaratorInfo)
     {
-        RefPtr<FuncDecl> decl = parser->astBuilder->create<FuncDecl>();
-        parser->FillPosition(decl.Ptr());
+        FuncDecl* decl = parser->astBuilder->create<FuncDecl>();
+        parser->FillPosition(decl);
         decl->loc = declaratorInfo.nameAndLoc.loc;
         decl->nameAndLoc = declaratorInfo.nameAndLoc;
 
@@ -1315,7 +1315,7 @@ namespace Slang
             parser->PushScope(decl);
 
             parseParameterList(parser, decl);
-            ParseOptSemantics(parser, decl.Ptr());
+            ParseOptSemantics(parser, decl);
             decl->body = parseOptBody(parser);
 
             parser->PopScope();
@@ -1324,7 +1324,7 @@ namespace Slang
         });
     }
 
-    static RefPtr<VarDeclBase> CreateVarDeclForContext(
+    static VarDeclBase* CreateVarDeclForContext(
         ASTBuilder* astBuilder, 
         ContainerDecl*  containerDecl )
     {
@@ -1343,12 +1343,12 @@ namespace Slang
     }
 
     // Add modifiers to the end of the modifier list for a declaration
-    void AddModifiers(Decl* decl, RefPtr<Modifier> modifiers)
+    void AddModifiers(Decl* decl, Modifier* modifiers)
     {
         if (!modifiers)
             return;
 
-        RefPtr<Modifier>* link = &decl->modifiers.first;
+        Modifier** link = &decl->modifiers.first;
         while (*link)
         {
             link = &(*link)->next;
@@ -1371,10 +1371,10 @@ namespace Slang
     // Set up a variable declaration based on what we saw in its declarator...
     static void CompleteVarDecl(
         Parser*					parser,
-        RefPtr<VarDeclBase>		decl,
+        VarDeclBase*		decl,
         DeclaratorInfo const&	declaratorInfo)
     {
-        parser->FillPosition(decl.Ptr());
+        parser->FillPosition(decl);
 
         if( !declaratorInfo.nameAndLoc.name )
         {
@@ -1388,7 +1388,7 @@ namespace Slang
         }
         decl->type = TypeExp(declaratorInfo.typeSpec);
 
-        AddModifiers(decl.Ptr(), declaratorInfo.semantics);
+        AddModifiers(decl, declaratorInfo.semantics);
 
         decl->initExpr = declaratorInfo.initializer;
     }
@@ -1527,8 +1527,8 @@ namespace Slang
     struct InitDeclarator
     {
         RefPtr<Declarator>  declarator;
-        RefPtr<Modifier>    semantics;
-        RefPtr<Expr>        initializer;
+        Modifier*    semantics;
+        Expr*        initializer;
     };
 
     // Parse a declarator plus optional semantics
@@ -1619,13 +1619,13 @@ namespace Slang
     struct DeclGroupBuilder
     {
         SourceLoc        startPosition;
-        RefPtr<Decl>        decl;
-        RefPtr<DeclGroup>   group;
+        Decl*        decl;
+        DeclGroup*   group;
         ASTBuilder*      astBuilder = nullptr;
 
         // Add a new declaration to the potential group
         void addDecl(
-            RefPtr<Decl>    newDecl)
+            Decl*    newDecl)
         {
             SLANG_ASSERT(newDecl);
 
@@ -1647,7 +1647,7 @@ namespace Slang
             }
         }
 
-        RefPtr<DeclBase> getResult()
+        DeclBase* getResult()
         {
             if(group) return group;
             return decl;
@@ -1655,14 +1655,14 @@ namespace Slang
     };
 
     // Pares an argument to an application of a generic
-    RefPtr<Expr> ParseGenericArg(Parser* parser)
+    Expr* ParseGenericArg(Parser* parser)
     {
         return parser->ParseArgExpr();
     }
 
     // Create a type expression that will refer to the given declaration
-    static RefPtr<Expr>
-    createDeclRefType(Parser* parser, RefPtr<Decl> decl)
+    static Expr*
+    createDeclRefType(Parser* parser, Decl* decl)
     {
         // For now we just construct an expression that
         // will look up the given declaration by name.
@@ -1681,19 +1681,19 @@ namespace Slang
     struct TypeSpec
     {
         // If the type-spec declared something, then put it here
-        RefPtr<Decl>                    decl;
+        Decl*                    decl;
 
         // Put the resulting expression (which should evaluate to a type) here
-        RefPtr<Expr>    expr;
+        Expr*    expr;
     };
 
-    static RefPtr<Expr> parseGenericApp(
+    static Expr* parseGenericApp(
         Parser*                         parser,
-        RefPtr<Expr>    base)
+        Expr*    base)
     {
-        RefPtr<GenericAppExpr> genericApp = parser->astBuilder->create<GenericAppExpr>();
+        GenericAppExpr* genericApp = parser->astBuilder->create<GenericAppExpr>();
 
-        parser->FillPosition(genericApp.Ptr()); // set up scope for lookup
+        parser->FillPosition(genericApp); // set up scope for lookup
         genericApp->functionExpr = base;
         parser->ReadToken(TokenType::OpLess);
         parser->genericDepth++;
@@ -1730,9 +1730,9 @@ namespace Slang
         return lookupResult.item.declRef.is<GenericDecl>();
     }
 
-    static RefPtr<Expr> tryParseGenericApp(
+    static Expr* tryParseGenericApp(
         Parser*                         parser,
-        RefPtr<Expr>    base)
+        Expr*    base)
     {
         Name * baseName = nullptr;
         if (auto varExpr = as<VarExpr>(base))
@@ -1748,7 +1748,9 @@ namespace Slang
         DiagnosticSink newSink(parser->sink->getSourceManager());
         Parser newParser(*parser);
         newParser.sink = &newSink;
-        auto speculateParseRs = parseGenericApp(&newParser, base);
+
+        /* auto speculateParseRs = */parseGenericApp(&newParser, base);
+
         if (newSink.getErrorCount() == 0)
         {
             // disambiguate based on FOLLOW set
@@ -1771,27 +1773,27 @@ namespace Slang
         }
         return base;
     }
-    static RefPtr<Expr> parseMemberType(Parser * parser, RefPtr<Expr> base)
+    static Expr* parseMemberType(Parser * parser, Expr* base)
     {
         // When called the :: or . have been consumed, so don't need to consume here.
 
-        RefPtr<MemberExpr> memberExpr = parser->astBuilder->create<MemberExpr>();
+        MemberExpr* memberExpr = parser->astBuilder->create<MemberExpr>();
 
-        parser->FillPosition(memberExpr.Ptr());
+        parser->FillPosition(memberExpr);
         memberExpr->baseExpression = base;
         memberExpr->name = expectIdentifier(parser).name;
         return memberExpr;
     }
 
     // Parse option `[]` braces after a type expression, that indicate an array type
-    static RefPtr<Expr> parsePostfixTypeSuffix(
+    static Expr* parsePostfixTypeSuffix(
         Parser* parser,
-        RefPtr<Expr> inTypeExpr)
+        Expr* inTypeExpr)
     {
         auto typeExpr = inTypeExpr;
         while (parser->LookAheadToken(TokenType::LBracket))
         {
-            RefPtr<IndexExpr> arrType = parser->astBuilder->create<IndexExpr>();
+            IndexExpr* arrType = parser->astBuilder->create<IndexExpr>();
             arrType->loc = typeExpr->loc;
             arrType->baseExpression = typeExpr;
             parser->ReadToken(TokenType::LBracket);
@@ -1805,9 +1807,9 @@ namespace Slang
         return typeExpr;
     }
 
-    static RefPtr<Expr> parseTaggedUnionType(Parser* parser)
+    static Expr* parseTaggedUnionType(Parser* parser)
     {
-        RefPtr<TaggedUnionTypeExpr> taggedUnionType = parser->astBuilder->create<TaggedUnionTypeExpr>();
+        TaggedUnionTypeExpr* taggedUnionType = parser->astBuilder->create<TaggedUnionTypeExpr>();
 
         parser->ReadToken(TokenType::LParent);
         while(!AdvanceIfMatch(parser, TokenType::RParent))
@@ -1830,9 +1832,9 @@ namespace Slang
     }
 
         /// Parse a `This` type expression
-    static RefPtr<Expr> parseThisTypeExpr(Parser* parser)
+    static Expr* parseThisTypeExpr(Parser* parser)
     {
-        RefPtr<ThisTypeExpr> expr = parser->astBuilder->create<ThisTypeExpr>();
+        ThisTypeExpr* expr = parser->astBuilder->create<ThisTypeExpr>();
         expr->scope = parser->currentScope;
         return expr;
     }
@@ -1909,7 +1911,7 @@ namespace Slang
         basicType->loc = typeName.loc;
         basicType->name = typeName.getNameOrNull();
 
-        RefPtr<Expr> typeExpr = basicType;
+        Expr* typeExpr = basicType;
 
         bool shouldLoop = true;
         while (shouldLoop)
@@ -1936,7 +1938,7 @@ namespace Slang
         return typeSpec;
     }
 
-    static RefPtr<DeclBase> ParseDeclaratorDecl(
+    static DeclBase* ParseDeclaratorDecl(
         Parser*         parser,
         ContainerDecl*  containerDecl)
     {
@@ -2045,7 +2047,7 @@ namespace Slang
         {
             // easy case: we only had a single declaration!
             UnwrapDeclarator(parser->astBuilder, initDeclarator, &declaratorInfo);
-            RefPtr<VarDeclBase> firstDecl = CreateVarDeclForContext(parser->astBuilder, containerDecl);
+            VarDeclBase* firstDecl = CreateVarDeclForContext(parser->astBuilder, containerDecl);
             CompleteVarDecl(parser, firstDecl, declaratorInfo);
 
             declGroupBuilder.addDecl(firstDecl);
@@ -2068,7 +2070,7 @@ namespace Slang
             declaratorInfo.typeSpec = sharedTypeSpec;
             UnwrapDeclarator(parser->astBuilder, initDeclarator, &declaratorInfo);
 
-            RefPtr<VarDeclBase> varDecl = CreateVarDeclForContext(parser->astBuilder, containerDecl);
+            VarDeclBase* varDecl = CreateVarDeclForContext(parser->astBuilder, containerDecl);
             CompleteVarDecl(parser, varDecl, declaratorInfo);
 
             declGroupBuilder.addDecl(varDecl);
@@ -2182,26 +2184,26 @@ namespace Slang
     //
     // semantic ::= identifier ( '(' args ')' )?
     //
-    static RefPtr<Modifier> ParseSemantic(
+    static Modifier* ParseSemantic(
         Parser* parser)
     {
         if (parser->LookAheadToken("register"))
         {
-            RefPtr<HLSLRegisterSemantic> semantic = parser->astBuilder->create<HLSLRegisterSemantic>();
+            HLSLRegisterSemantic* semantic = parser->astBuilder->create<HLSLRegisterSemantic>();
             parser->FillPosition(semantic);
-            parseHLSLRegisterSemantic(parser, semantic.Ptr());
+            parseHLSLRegisterSemantic(parser, semantic);
             return semantic;
         }
         else if (parser->LookAheadToken("packoffset"))
         {
-            RefPtr<HLSLPackOffsetSemantic> semantic = parser->astBuilder->create<HLSLPackOffsetSemantic>();
+            HLSLPackOffsetSemantic* semantic = parser->astBuilder->create<HLSLPackOffsetSemantic>();
             parser->FillPosition(semantic);
-            parseHLSLPackOffsetSemantic(parser, semantic.Ptr());
+            parseHLSLPackOffsetSemantic(parser, semantic);
             return semantic;
         }
         else if (parser->LookAheadToken(TokenType::Identifier))
         {
-            RefPtr<HLSLSimpleSemantic> semantic = parser->astBuilder->create<HLSLSimpleSemantic>();
+            HLSLSimpleSemantic* semantic = parser->astBuilder->create<HLSLSimpleSemantic>();
             parser->FillPosition(semantic);
             semantic->name = parser->ReadToken(TokenType::Identifier);
             return semantic;
@@ -2217,19 +2219,19 @@ namespace Slang
     //
     // opt-semantics ::= (':' semantic)*
     //
-    static RefPtr<Modifier> ParseOptSemantics(
+    static Modifier* ParseOptSemantics(
         Parser* parser)
     {
         if (!AdvanceIf(parser, TokenType::Colon))
             return nullptr;
 
-        RefPtr<Modifier> result;
-        RefPtr<Modifier>* link = &result;
+        Modifier* result;
+        Modifier** link = &result;
         SLANG_ASSERT(!*link);
 
         for (;;)
         {
-            RefPtr<Modifier> semantic = ParseSemantic(parser);
+            Modifier* semantic = ParseSemantic(parser);
             if (semantic)
             {
                 *link = semantic;
@@ -2268,7 +2270,7 @@ namespace Slang
         AddModifiers(decl, ParseOptSemantics(parser));
     }
 
-    static RefPtr<Decl> ParseHLSLBufferDecl(
+    static Decl* ParseHLSLBufferDecl(
         Parser*	parser,
         String  bufferWrapperTypeName)
     {
@@ -2291,12 +2293,12 @@ namespace Slang
         // We are going to represent each buffer as a pair of declarations.
         // The first is a type declaration that holds all the members, while
         // the second is a variable declaration that uses the buffer type.
-        RefPtr<StructDecl> bufferDataTypeDecl = parser->astBuilder->create<StructDecl>();
-        RefPtr<VarDecl> bufferVarDecl = parser->astBuilder->create<VarDecl>();
+        StructDecl* bufferDataTypeDecl = parser->astBuilder->create<StructDecl>();
+        VarDecl* bufferVarDecl = parser->astBuilder->create<VarDecl>();
 
         // Both declarations will have a location that points to the name
-        parser->FillPosition(bufferDataTypeDecl.Ptr());
-        parser->FillPosition(bufferVarDecl.Ptr());
+        parser->FillPosition(bufferDataTypeDecl);
+        parser->FillPosition(bufferVarDecl);
 
         auto reflectionNameToken = parser->ReadToken(TokenType::Identifier);
 
@@ -2343,10 +2345,10 @@ namespace Slang
 
         // Any semantics applied to the buffer declaration are taken as applying
         // to the variable instead.
-        ParseOptSemantics(parser, bufferVarDecl.Ptr());
+        ParseOptSemantics(parser, bufferVarDecl);
 
         // The declarations in the body belong to the data type.
-        parseDeclBody(parser, bufferDataTypeDecl.Ptr());
+        parseDeclBody(parser, bufferDataTypeDecl);
 
         // All HLSL buffer declarations are "transparent" in that their
         // members are implicitly made visible in the parent scope.
@@ -2403,11 +2405,11 @@ namespace Slang
 
     static RefPtr<RefObject> ParseExtensionDecl(Parser* parser, void* /*userData*/)
     {
-        RefPtr<ExtensionDecl> decl = parser->astBuilder->create<ExtensionDecl>();
-        parser->FillPosition(decl.Ptr());
+        ExtensionDecl* decl = parser->astBuilder->create<ExtensionDecl>();
+        parser->FillPosition(decl);
         decl->targetType = parser->ParseTypeExp();
         parseOptionalInheritanceClause(parser, decl);
-        parseDeclBody(parser, decl.Ptr());
+        parseDeclBody(parser, decl);
 
         return decl;
     }
@@ -2419,13 +2421,13 @@ namespace Slang
         {
             do
             {
-                RefPtr<GenericTypeConstraintDecl> paramConstraint = parser->astBuilder->create<GenericTypeConstraintDecl>();
+                GenericTypeConstraintDecl* paramConstraint = parser->astBuilder->create<GenericTypeConstraintDecl>();
                 parser->FillPosition(paramConstraint);
 
                 // substitution needs to be filled during check
-                RefPtr<DeclRefType> paramType = DeclRefType::create(parser->astBuilder, DeclRef<Decl>(decl, nullptr));
+                DeclRefType* paramType = DeclRefType::create(parser->astBuilder, DeclRef<Decl>(decl, nullptr));
 
-                RefPtr<SharedTypeExpr> paramTypeExpr = parser->astBuilder->create<SharedTypeExpr>();
+                SharedTypeExpr* paramTypeExpr = parser->astBuilder->create<SharedTypeExpr>();
                 paramTypeExpr->loc = decl->loc;
                 paramTypeExpr->base.type = paramType;
                 paramTypeExpr->type = QualType(parser->astBuilder->getTypeType(paramType));
@@ -2440,7 +2442,7 @@ namespace Slang
 
     RefPtr<RefObject> parseAssocType(Parser* parser, void *)
     {
-        RefPtr<AssocTypeDecl> assocTypeDecl = parser->astBuilder->create<AssocTypeDecl>();
+        AssocTypeDecl* assocTypeDecl = parser->astBuilder->create<AssocTypeDecl>();
 
         auto nameToken = parser->ReadToken(TokenType::Identifier);
         assocTypeDecl->nameAndLoc = NameLoc(nameToken);
@@ -2452,7 +2454,7 @@ namespace Slang
 
     RefPtr<RefObject> parseGlobalGenericTypeParamDecl(Parser * parser, void *)
     {
-        RefPtr<GlobalGenericParamDecl> genParamDecl = parser->astBuilder->create<GlobalGenericParamDecl>();
+        GlobalGenericParamDecl* genParamDecl = parser->astBuilder->create<GlobalGenericParamDecl>();
         auto nameToken = parser->ReadToken(TokenType::Identifier);
         genParamDecl->nameAndLoc = NameLoc(nameToken);
         genParamDecl->loc = nameToken.loc;
@@ -2463,7 +2465,7 @@ namespace Slang
 
     RefPtr<RefObject> parseGlobalGenericValueParamDecl(Parser * parser, void *)
     {
-        RefPtr<GlobalGenericValueParamDecl> genericParamDecl = parser->astBuilder->create<GlobalGenericValueParamDecl>();
+        GlobalGenericValueParamDecl* genericParamDecl = parser->astBuilder->create<GlobalGenericValueParamDecl>();
         auto nameToken = parser->ReadToken(TokenType::Identifier);
         genericParamDecl->nameAndLoc = NameLoc(nameToken);
         genericParamDecl->loc = nameToken.loc;
@@ -2484,13 +2486,13 @@ namespace Slang
 
     static RefPtr<RefObject> parseInterfaceDecl(Parser* parser, void* /*userData*/)
     {
-        RefPtr<InterfaceDecl> decl = parser->astBuilder->create<InterfaceDecl>();
-        parser->FillPosition(decl.Ptr());
+        InterfaceDecl* decl = parser->astBuilder->create<InterfaceDecl>();
+        parser->FillPosition(decl);
         decl->nameAndLoc = NameLoc(parser->ReadToken(TokenType::Identifier));
 
-        parseOptionalInheritanceClause(parser, decl.Ptr());
+        parseOptionalInheritanceClause(parser, decl);
 
-        parseDeclBody(parser, decl.Ptr());
+        parseDeclBody(parser, decl);
 
         return decl;
     }
@@ -2535,7 +2537,7 @@ namespace Slang
         // a declaration to the caller (since they will try to add
         // any non-null pointer we return to the AST).
         //
-        RefPtr<NamespaceDecl> namespaceDecl;
+        NamespaceDecl* namespaceDecl = nullptr;
         RefPtr<RefObject> result;
         //
         // In order to find out what case we are in, we start by looking
@@ -2609,15 +2611,15 @@ namespace Slang
         // `{}`-enclosed body to add declarations as children
         // of the namespace.
         //
-        parseDeclBody(parser, namespaceDecl.Ptr());
+        parseDeclBody(parser, namespaceDecl);
 
         return result;
     }
 
     static RefPtr<RefObject> parseConstructorDecl(Parser* parser, void* /*userData*/)
     {
-        RefPtr<ConstructorDecl> decl = parser->astBuilder->create<ConstructorDecl>();
-        parser->FillPosition(decl.Ptr());
+        ConstructorDecl* decl = parser->astBuilder->create<ConstructorDecl>();
+        parser->FillPosition(decl);
         parser->PushScope(decl);
 
         // TODO: we need to make sure that all initializers have
@@ -2638,11 +2640,11 @@ namespace Slang
         return decl;
     }
 
-    static RefPtr<AccessorDecl> parseAccessorDecl(Parser* parser)
+    static AccessorDecl* parseAccessorDecl(Parser* parser)
     {
         Modifiers modifiers = ParseModifiers(parser);
 
-        RefPtr<AccessorDecl> decl;
+        AccessorDecl* decl;
         if( AdvanceIf(parser, "get") )
         {
             decl = parser->astBuilder->create<GetterDecl>();
@@ -2677,8 +2679,8 @@ namespace Slang
 
     static RefPtr<RefObject> ParseSubscriptDecl(Parser* parser, void* /*userData*/)
     {
-        RefPtr<SubscriptDecl> decl = parser->astBuilder->create<SubscriptDecl>();
-        parser->FillPosition(decl.Ptr());
+        SubscriptDecl* decl = parser->astBuilder->create<SubscriptDecl>();
+        parser->FillPosition(decl);
         parser->PushScope(decl);
 
         // TODO: the use of this name here is a bit magical...
@@ -2718,9 +2720,9 @@ namespace Slang
 
     static void parseModernVarDeclBaseCommon(
         Parser*             parser,
-        RefPtr<VarDeclBase> decl)
+        VarDeclBase* decl)
     {
-        parser->FillPosition(decl.Ptr());
+        parser->FillPosition(decl);
         decl->nameAndLoc = NameLoc(parser->ReadToken(TokenType::Identifier));
 
         if(AdvanceIf(parser, TokenType::Colon))
@@ -2736,7 +2738,7 @@ namespace Slang
 
     static void parseModernVarDeclCommon(
         Parser*         parser,
-        RefPtr<VarDecl> decl)
+        VarDecl* decl)
     {
         parseModernVarDeclBaseCommon(parser, decl);
         expect(parser, TokenType::Semicolon);
@@ -2745,7 +2747,7 @@ namespace Slang
     static RefPtr<RefObject> parseLetDecl(
         Parser* parser, void* /*userData*/)
     {
-        RefPtr<LetDecl> decl = parser->astBuilder->create<LetDecl>();
+        LetDecl* decl = parser->astBuilder->create<LetDecl>();
         parseModernVarDeclCommon(parser, decl);
         return decl;
     }
@@ -2753,15 +2755,15 @@ namespace Slang
     static RefPtr<RefObject> parseVarDecl(
         Parser* parser, void* /*userData*/)
     {
-        RefPtr<VarDecl> decl = parser->astBuilder->create<VarDecl>();
+        VarDecl* decl = parser->astBuilder->create<VarDecl>();
         parseModernVarDeclCommon(parser, decl);
         return decl;
     }
 
-    static RefPtr<ParamDecl> parseModernParamDecl(
+    static ParamDecl* parseModernParamDecl(
         Parser* parser)
     {
-        RefPtr<ParamDecl> decl = parser->astBuilder->create<ParamDecl>();
+        ParamDecl* decl = parser->astBuilder->create<ParamDecl>();
 
         // TODO: "modern" parameters should not accept keyword-based
         // modifiers and should only accept `[attribute]` syntax for
@@ -2777,7 +2779,7 @@ namespace Slang
 
     static void parseModernParamList(
         Parser*                 parser,
-        RefPtr<CallableDecl>    decl)
+        CallableDecl*    decl)
     {
         parser->ReadToken(TokenType::LParent);
 
@@ -2793,14 +2795,14 @@ namespace Slang
     static RefPtr<RefObject> parseFuncDecl(
         Parser* parser, void* /*userData*/)
     {
-        RefPtr<FuncDecl> decl = parser->astBuilder->create<FuncDecl>();
+        FuncDecl* decl = parser->astBuilder->create<FuncDecl>();
 
-        parser->FillPosition(decl.Ptr());
+        parser->FillPosition(decl);
         decl->nameAndLoc = NameLoc(parser->ReadToken(TokenType::Identifier));
 
         return parseOptGenericDecl(parser, [&](GenericDecl*)
         {
-            parser->PushScope(decl.Ptr());
+            parser->PushScope(decl);
             parseModernParamList(parser, decl);
             if(AdvanceIf(parser, TokenType::RightArrow))
             {
@@ -2815,9 +2817,9 @@ namespace Slang
     static RefPtr<RefObject> parseTypeAliasDecl(
         Parser* parser, void* /*userData*/)
     {
-        RefPtr<TypeAliasDecl> decl = parser->astBuilder->create<TypeAliasDecl>();
+        TypeAliasDecl* decl = parser->astBuilder->create<TypeAliasDecl>();
 
-        parser->FillPosition(decl.Ptr());
+        parser->FillPosition(decl);
         decl->nameAndLoc = NameLoc(parser->ReadToken(TokenType::Identifier));
 
         return parseOptGenericDecl(parser, [&](GenericDecl*)
@@ -2914,7 +2916,7 @@ namespace Slang
         // TODO: skip creating the declaration if anything failed, just to not screw things
         // up for downstream code?
 
-        RefPtr<SyntaxDecl> syntaxDecl = parser->astBuilder->create<SyntaxDecl>();
+        SyntaxDecl* syntaxDecl = parser->astBuilder->create<SyntaxDecl>();
         syntaxDecl->nameAndLoc = nameAndLoc;
         syntaxDecl->loc = nameAndLoc.loc;
         syntaxDecl->syntaxClass = syntaxClass;
@@ -2928,11 +2930,11 @@ namespace Slang
     // We are going to use `name: type` syntax just for simplicty, and let the type
     // be optional, because we don't actually need it in all cases.
     //
-    static RefPtr<ParamDecl> parseAttributeParamDecl(Parser* parser)
+    static ParamDecl* parseAttributeParamDecl(Parser* parser)
     {
         auto nameAndLoc = expectIdentifier(parser);
 
-        RefPtr<ParamDecl> paramDecl = parser->astBuilder->create<ParamDecl>();
+        ParamDecl* paramDecl = parser->astBuilder->create<ParamDecl>();
         paramDecl->nameAndLoc = nameAndLoc;
 
         if(AdvanceIf(parser, TokenType::Colon))
@@ -2974,7 +2976,7 @@ namespace Slang
         // First we parse the attribute name.
         auto nameAndLoc = expectIdentifier(parser);
 
-        RefPtr<AttributeDecl> attrDecl = parser->astBuilder->create<AttributeDecl>();
+        AttributeDecl* attrDecl = parser->astBuilder->create<AttributeDecl>();
         if(AdvanceIf(parser, TokenType::LParent))
         {
             while(!AdvanceIfMatch(parser, TokenType::RParent))
@@ -3027,7 +3029,7 @@ namespace Slang
     // Finish up work on a declaration that was parsed
     static void CompleteDecl(
         Parser*				/*parser*/,
-        RefPtr<Decl>		decl,
+        Decl*		decl,
         ContainerDecl*		containerDecl,
         Modifiers			modifiers)
     {
@@ -3037,10 +3039,10 @@ namespace Slang
         // We need to be careful, because if `decl` is a generic declaration,
         // then we really want the modifiers to apply to the inner declaration.
         //
-        RefPtr<Decl> declToModify = decl;
+        Decl* declToModify = decl;
         if(auto genericDecl = as<GenericDecl>(decl))
             declToModify = genericDecl->inner;
-        AddModifiers(declToModify.Ptr(), modifiers.first);
+        AddModifiers(declToModify, modifiers.first);
 
         // Make sure the decl is properly nested inside its lexical parent
         if (containerDecl)
@@ -3049,12 +3051,12 @@ namespace Slang
         }
     }
 
-    static RefPtr<DeclBase> ParseDeclWithModifiers(
+    static DeclBase* ParseDeclWithModifiers(
         Parser*             parser,
         ContainerDecl*      containerDecl,
         Modifiers			modifiers )
     {
-        RefPtr<DeclBase> decl;
+        DeclBase* decl;
 
         auto loc = parser->tokenReader.peekLoc();
 
@@ -3070,7 +3072,7 @@ namespace Slang
                 // First we will check whether we can use the identifier token
                 // as a declaration keyword and parse a declaration using
                 // its associated callback:
-                RefPtr<Decl> parsedDecl;
+                Decl* parsedDecl;
                 if (tryParseUsingSyntaxDecl<Decl>(parser, &parsedDecl))
                 {
                     decl = parsedDecl;
@@ -3129,7 +3131,7 @@ namespace Slang
         return decl;
     }
 
-    static RefPtr<DeclBase> ParseDecl(
+    static DeclBase* ParseDecl(
         Parser*         parser,
         ContainerDecl*  containerDecl)
     {
@@ -3137,7 +3139,7 @@ namespace Slang
         return ParseDeclWithModifiers(parser, containerDecl, modifiers);
     }
 
-    static RefPtr<Decl> ParseSingleDecl(
+    static Decl* ParseSingleDecl(
         Parser*			parser,
         ContainerDecl*	containerDecl)
     {
@@ -3218,10 +3220,10 @@ namespace Slang
         currentScope = nullptr;
     }
 
-    RefPtr<Decl> Parser::ParseStruct()
+    Decl* Parser::ParseStruct()
     {
-        RefPtr<StructDecl> rs = astBuilder->create<StructDecl>();
-        FillPosition(rs.Ptr());
+        StructDecl* rs = astBuilder->create<StructDecl>();
+        FillPosition(rs);
         ReadToken("struct");
 
         // TODO: support `struct` declaration without tag
@@ -3231,28 +3233,28 @@ namespace Slang
         {
             // We allow for an inheritance clause on a `struct`
             // so that it can conform to interfaces.
-            parseOptionalInheritanceClause(this, rs.Ptr());
-            parseDeclBody(this, rs.Ptr());
+            parseOptionalInheritanceClause(this, rs);
+            parseDeclBody(this, rs);
             return rs;
         });
     }
 
-    RefPtr<ClassDecl> Parser::ParseClass()
+    ClassDecl* Parser::ParseClass()
     {
-        RefPtr<ClassDecl> rs = astBuilder->create<ClassDecl>();
-        FillPosition(rs.Ptr());
+        ClassDecl* rs = astBuilder->create<ClassDecl>();
+        FillPosition(rs);
         ReadToken("class");
         rs->nameAndLoc = expectIdentifier(this);
 
-        parseOptionalInheritanceClause(this, rs.Ptr());
+        parseOptionalInheritanceClause(this, rs);
 
-        parseDeclBody(this, rs.Ptr());
+        parseDeclBody(this, rs);
         return rs;
     }
 
-    static RefPtr<EnumCaseDecl> parseEnumCaseDecl(Parser* parser)
+    static EnumCaseDecl* parseEnumCaseDecl(Parser* parser)
     {
-        RefPtr<EnumCaseDecl> decl = parser->astBuilder->create<EnumCaseDecl>();
+        EnumCaseDecl* decl = parser->astBuilder->create<EnumCaseDecl>();
         decl->nameAndLoc = expectIdentifier(parser);
 
         if(AdvanceIf(parser, TokenType::OpAssign))
@@ -3263,9 +3265,9 @@ namespace Slang
         return decl;
     }
 
-    static RefPtr<Decl> parseEnumDecl(Parser* parser)
+    static Decl* parseEnumDecl(Parser* parser)
     {
-        RefPtr<EnumDecl> decl = parser->astBuilder->create<EnumDecl>();
+        EnumDecl* decl = parser->astBuilder->create<EnumDecl>();
         parser->FillPosition(decl);
 
         parser->ReadToken("enum");
@@ -3288,7 +3290,7 @@ namespace Slang
 
             while(!AdvanceIfMatch(parser, TokenType::RBrace))
             {
-                RefPtr<EnumCaseDecl> caseDecl = parseEnumCaseDecl(parser);
+                EnumCaseDecl* caseDecl = parseEnumCaseDecl(parser);
                 AddMember(decl, caseDecl);
 
                 if(AdvanceIf(parser, TokenType::RBrace))
@@ -3300,10 +3302,10 @@ namespace Slang
         });
     }
 
-    static RefPtr<Stmt> ParseSwitchStmt(Parser* parser)
+    static Stmt* ParseSwitchStmt(Parser* parser)
     {
-        RefPtr<SwitchStmt> stmt = parser->astBuilder->create<SwitchStmt>();
-        parser->FillPosition(stmt.Ptr());
+        SwitchStmt* stmt = parser->astBuilder->create<SwitchStmt>();
+        parser->FillPosition(stmt);
         parser->ReadToken("switch");
         parser->ReadToken(TokenType::LParent);
         stmt->condition = parser->ParseExpression();
@@ -3312,20 +3314,20 @@ namespace Slang
         return stmt;
     }
 
-    static RefPtr<Stmt> ParseCaseStmt(Parser* parser)
+    static Stmt* ParseCaseStmt(Parser* parser)
     {
-        RefPtr<CaseStmt> stmt = parser->astBuilder->create<CaseStmt>();
-        parser->FillPosition(stmt.Ptr());
+        CaseStmt* stmt = parser->astBuilder->create<CaseStmt>();
+        parser->FillPosition(stmt);
         parser->ReadToken("case");
         stmt->expr = parser->ParseExpression();
         parser->ReadToken(TokenType::Colon);
         return stmt;
     }
 
-    static RefPtr<Stmt> ParseDefaultStmt(Parser* parser)
+    static Stmt* ParseDefaultStmt(Parser* parser)
     {
-        RefPtr<DefaultStmt> stmt = parser->astBuilder->create<DefaultStmt>();
-        parser->FillPosition(stmt.Ptr());
+        DefaultStmt* stmt = parser->astBuilder->create<DefaultStmt>();
+        parser->FillPosition(stmt);
         parser->ReadToken("default");
         parser->ReadToken(TokenType::Colon);
         return stmt;
@@ -3365,11 +3367,11 @@ namespace Slang
         return isTypeName(parser, name);
     }
 
-    RefPtr<Stmt> parseCompileTimeForStmt(
+    Stmt* parseCompileTimeForStmt(
         Parser* parser)
     {
-        RefPtr<ScopeDecl> scopeDecl = parser->astBuilder->create<ScopeDecl>();
-        RefPtr<CompileTimeForStmt> stmt = parser->astBuilder->create<CompileTimeForStmt>();
+        ScopeDecl* scopeDecl = parser->astBuilder->create<ScopeDecl>();
+        CompileTimeForStmt* stmt = parser->astBuilder->create<CompileTimeForStmt>();
         stmt->scopeDecl = scopeDecl;
 
 
@@ -3377,7 +3379,7 @@ namespace Slang
         parser->ReadToken(TokenType::LParent);
 
         NameLoc varNameAndLoc = expectIdentifier(parser);
-        RefPtr<VarDecl> varDecl = parser->astBuilder->create<VarDecl>();
+        VarDecl* varDecl = parser->astBuilder->create<VarDecl>();
         varDecl->nameAndLoc = varNameAndLoc;
         varDecl->loc = varNameAndLoc.loc;
 
@@ -3387,8 +3389,8 @@ namespace Slang
         parser->ReadToken("Range");
         parser->ReadToken(TokenType::LParent);
 
-        RefPtr<Expr> rangeBeginExpr;
-        RefPtr<Expr> rangeEndExpr = parser->ParseArgExpr();
+        Expr* rangeBeginExpr = nullptr;
+        Expr* rangeEndExpr = parser->ParseArgExpr();
         if (AdvanceIf(parser, TokenType::Comma))
         {
             rangeBeginExpr = rangeEndExpr;
@@ -3411,7 +3413,7 @@ namespace Slang
         return stmt;
     }
 
-    RefPtr<Stmt> parseCompileTimeStmt(
+    Stmt* parseCompileTimeStmt(
         Parser* parser)
     {
         parser->ReadToken(TokenType::Dollar);
@@ -3426,11 +3428,11 @@ namespace Slang
         }
     }
 
-    RefPtr<Stmt> Parser::ParseStatement()
+    Stmt* Parser::ParseStatement()
     {
         auto modifiers = ParseModifiers(this);
 
-        RefPtr<Stmt> statement;
+        Stmt* statement;
         if (LookAheadToken(TokenType::LBrace))
             statement = parseBlockStatement();
         else if (LookAheadToken("if"))
@@ -3450,7 +3452,7 @@ namespace Slang
         else if (LookAheadToken("discard"))
         {
             statement = astBuilder->create<DiscardStmt>();
-            FillPosition(statement.Ptr());
+            FillPosition(statement);
             ReadToken("discard");
             ReadToken(TokenType::Semicolon);
         }
@@ -3492,7 +3494,7 @@ namespace Slang
             // isn't a keyword should we fall back to the approach
             // here.
             //
-            RefPtr<Expr> type = ParseType();
+            Expr* type = ParseType();
 
             // We don't actually care about the type, though, so
             // don't retain it
@@ -3547,7 +3549,7 @@ namespace Slang
         else if (LookAheadToken(TokenType::Semicolon))
         {
             statement = astBuilder->create<EmptyStmt>();
-            FillPosition(statement.Ptr());
+            FillPosition(statement);
             ReadToken(TokenType::Semicolon);
         }
         else
@@ -3569,19 +3571,19 @@ namespace Slang
         return statement;
     }
 
-    RefPtr<Stmt> Parser::parseBlockStatement()
+    Stmt* Parser::parseBlockStatement()
     {
-        RefPtr<ScopeDecl> scopeDecl = astBuilder->create<ScopeDecl>();
-        RefPtr<BlockStmt> blockStatement = astBuilder->create<BlockStmt>();
+        ScopeDecl* scopeDecl = astBuilder->create<ScopeDecl>();
+        BlockStmt* blockStatement = astBuilder->create<BlockStmt>();
         blockStatement->scopeDecl = scopeDecl;
-        pushScopeAndSetParent(scopeDecl.Ptr());
+        pushScopeAndSetParent(scopeDecl);
         ReadToken(TokenType::LBrace);
 
-        RefPtr<Stmt> body;
+        Stmt* body = nullptr;
 
         if(!tokenReader.isAtEnd())
         {
-            FillPosition(blockStatement.Ptr());
+            FillPosition(blockStatement);
         }
         while (!AdvanceIfMatch(this, TokenType::RBrace))
         {
@@ -3598,7 +3600,7 @@ namespace Slang
                 }
                 else
                 {
-                    RefPtr<SeqStmt> newBody = astBuilder->create<SeqStmt>();
+                    SeqStmt* newBody = astBuilder->create<SeqStmt>();
                     newBody->loc = blockStatement->loc;
                     newBody->stmts.add(body);
                     newBody->stmts.add(stmt);
@@ -3620,21 +3622,21 @@ namespace Slang
         return blockStatement;
     }
 
-    RefPtr<DeclStmt> Parser::parseVarDeclrStatement(
+    DeclStmt* Parser::parseVarDeclrStatement(
         Modifiers modifiers)
     {
-        RefPtr<DeclStmt>varDeclrStatement = astBuilder->create<DeclStmt>();
+        DeclStmt*varDeclrStatement = astBuilder->create<DeclStmt>();
 
-        FillPosition(varDeclrStatement.Ptr());
+        FillPosition(varDeclrStatement);
         auto decl = ParseDeclWithModifiers(this, currentScope->containerDecl, modifiers);
         varDeclrStatement->decl = decl;
         return varDeclrStatement;
     }
 
-    RefPtr<IfStmt> Parser::parseIfStatement()
+    IfStmt* Parser::parseIfStatement()
     {
-        RefPtr<IfStmt> ifStatement = astBuilder->create<IfStmt>();
-        FillPosition(ifStatement.Ptr());
+        IfStmt* ifStatement = astBuilder->create<IfStmt>();
+        FillPosition(ifStatement);
         ReadToken("if");
         ReadToken(TokenType::LParent);
         ifStatement->predicate = ParseExpression();
@@ -3648,9 +3650,9 @@ namespace Slang
         return ifStatement;
     }
 
-    RefPtr<ForStmt> Parser::ParseForStatement()
+    ForStmt* Parser::ParseForStatement()
     {
-        RefPtr<ScopeDecl> scopeDecl = astBuilder->create<ScopeDecl>();
+        ScopeDecl* scopeDecl = astBuilder->create<ScopeDecl>();
 
         // HLSL implements the bad approach to scoping a `for` loop
         // variable, and we want to respect that, but *only* when
@@ -3663,7 +3665,7 @@ namespace Slang
         // case, just so that we can correctly handle it in downstream
         // logic.
         //
-        RefPtr<ForStmt> stmt;
+        ForStmt* stmt;
         if (brokenScoping)
         {
             stmt = astBuilder->create<UnscopedForStmt>();
@@ -3676,8 +3678,8 @@ namespace Slang
         stmt->scopeDecl = scopeDecl;
 
         if(!brokenScoping)
-            pushScopeAndSetParent(scopeDecl.Ptr());
-        FillPosition(stmt.Ptr());
+            pushScopeAndSetParent(scopeDecl);
+        FillPosition(stmt);
         ReadToken("for");
         ReadToken(TokenType::LParent);
         if (peekTypeName(this))
@@ -3709,10 +3711,10 @@ namespace Slang
         return stmt;
     }
 
-    RefPtr<WhileStmt> Parser::ParseWhileStatement()
+    WhileStmt* Parser::ParseWhileStatement()
     {
-        RefPtr<WhileStmt> whileStatement = astBuilder->create<WhileStmt>();
-        FillPosition(whileStatement.Ptr());
+        WhileStmt* whileStatement = astBuilder->create<WhileStmt>();
+        FillPosition(whileStatement);
         ReadToken("while");
         ReadToken(TokenType::LParent);
         whileStatement->predicate = ParseExpression();
@@ -3721,10 +3723,10 @@ namespace Slang
         return whileStatement;
     }
 
-    RefPtr<DoWhileStmt> Parser::ParseDoWhileStatement()
+    DoWhileStmt* Parser::ParseDoWhileStatement()
     {
-        RefPtr<DoWhileStmt> doWhileStatement = astBuilder->create<DoWhileStmt>();
-        FillPosition(doWhileStatement.Ptr());
+        DoWhileStmt* doWhileStatement = astBuilder->create<DoWhileStmt>();
+        FillPosition(doWhileStatement);
         ReadToken("do");
         doWhileStatement->statement = ParseStatement();
         ReadToken("while");
@@ -3735,28 +3737,28 @@ namespace Slang
         return doWhileStatement;
     }
 
-    RefPtr<BreakStmt> Parser::ParseBreakStatement()
+    BreakStmt* Parser::ParseBreakStatement()
     {
-        RefPtr<BreakStmt> breakStatement = astBuilder->create<BreakStmt>();
-        FillPosition(breakStatement.Ptr());
+        BreakStmt* breakStatement = astBuilder->create<BreakStmt>();
+        FillPosition(breakStatement);
         ReadToken("break");
         ReadToken(TokenType::Semicolon);
         return breakStatement;
     }
 
-    RefPtr<ContinueStmt> Parser::ParseContinueStatement()
+    ContinueStmt* Parser::ParseContinueStatement()
     {
-        RefPtr<ContinueStmt> continueStatement = astBuilder->create<ContinueStmt>();
-        FillPosition(continueStatement.Ptr());
+        ContinueStmt* continueStatement = astBuilder->create<ContinueStmt>();
+        FillPosition(continueStatement);
         ReadToken("continue");
         ReadToken(TokenType::Semicolon);
         return continueStatement;
     }
 
-    RefPtr<ReturnStmt> Parser::ParseReturnStatement()
+    ReturnStmt* Parser::ParseReturnStatement()
     {
-        RefPtr<ReturnStmt> returnStatement = astBuilder->create<ReturnStmt>();
-        FillPosition(returnStatement.Ptr());
+        ReturnStmt* returnStatement = astBuilder->create<ReturnStmt>();
+        FillPosition(returnStatement);
         ReadToken("return");
         if (!LookAheadToken(TokenType::Semicolon))
             returnStatement->expression = ParseExpression();
@@ -3764,20 +3766,20 @@ namespace Slang
         return returnStatement;
     }
 
-    RefPtr<ExpressionStmt> Parser::ParseExpressionStatement()
+    ExpressionStmt* Parser::ParseExpressionStatement()
     {
-        RefPtr<ExpressionStmt> statement = astBuilder->create<ExpressionStmt>();
+        ExpressionStmt* statement = astBuilder->create<ExpressionStmt>();
 
-        FillPosition(statement.Ptr());
+        FillPosition(statement);
         statement->expression = ParseExpression();
 
         ReadToken(TokenType::Semicolon);
         return statement;
     }
 
-    RefPtr<ParamDecl> Parser::ParseParameter()
+    ParamDecl* Parser::ParseParameter()
     {
-        RefPtr<ParamDecl> parameter = astBuilder->create<ParamDecl>();
+        ParamDecl* parameter = astBuilder->create<ParamDecl>();
         parameter->modifiers = ParseModifiers(this);
 
         DeclaratorInfo declaratorInfo;
@@ -3791,7 +3793,7 @@ namespace Slang
         return parameter;
     }
 
-    RefPtr<Expr> Parser::ParseType()
+    Expr* Parser::ParseType()
     {
         auto typeSpec = parseTypeSpec(this);
         if( typeSpec.decl )
@@ -3889,7 +3891,7 @@ namespace Slang
         }
     }
 
-    static RefPtr<Expr> parseOperator(Parser* parser)
+    static Expr* parseOperator(Parser* parser)
     {
         Token opToken;
         switch(parser->tokenReader.peekTokenType())
@@ -3913,13 +3915,13 @@ namespace Slang
 
     }
 
-    static RefPtr<Expr> createInfixExpr(
+    static Expr* createInfixExpr(
         Parser*         parser,
-        RefPtr<Expr>    left,
-        RefPtr<Expr>    op,
-        RefPtr<Expr>    right)
+        Expr*    left,
+        Expr*    op,
+        Expr*    right)
     {
-        RefPtr<InfixExpr> expr = parser->astBuilder->create<InfixExpr>();
+        InfixExpr* expr = parser->astBuilder->create<InfixExpr>();
         expr->loc = op->loc;
         expr->functionExpr = op;
         expr->arguments.add(left);
@@ -3927,9 +3929,9 @@ namespace Slang
         return expr;
     }
 
-    static RefPtr<Expr> parseInfixExprWithPrecedence(
+    static Expr* parseInfixExprWithPrecedence(
         Parser*                         parser,
-        RefPtr<Expr>    inExpr,
+        Expr*    inExpr,
         Precedence                      prec)
     {
         auto expr = inExpr;
@@ -3946,7 +3948,7 @@ namespace Slang
             // one non-binary case we need to deal with.
             if(opTokenType == TokenType::QuestionMark)
             {
-                RefPtr<SelectExpr> select = parser->astBuilder->create<SelectExpr>();
+                SelectExpr* select = parser->astBuilder->create<SelectExpr>();
                 select->loc = op->loc;
                 select->functionExpr = op;
 
@@ -3974,7 +3976,7 @@ namespace Slang
 
             if (opTokenType == TokenType::OpAssign)
             {
-                RefPtr<AssignExpr> assignExpr = parser->astBuilder->create<AssignExpr>();
+                AssignExpr* assignExpr = parser->astBuilder->create<AssignExpr>();
                 assignExpr->loc = op->loc;
                 assignExpr->left = expr;
                 assignExpr->right = right;
@@ -3989,7 +3991,7 @@ namespace Slang
         return expr;
     }
 
-    RefPtr<Expr> Parser::ParseExpression(Precedence level)
+    Expr* Parser::ParseExpression(Precedence level)
     {
         auto expr = ParseLeafExpression();
         return parseInfixExprWithPrecedence(this, expr, level);
@@ -4004,7 +4006,7 @@ namespace Slang
             auto condition = ParseExpression(Precedence(level + 1));
             if (LookAheadToken(TokenType::QuestionMark))
             {
-                RefPtr<SelectExpr> select = new SelectExpr();
+                SelectExpr* select = new SelectExpr();
                 FillPosition(select.Ptr());
 
                 select->Arguments.Add(condition);
@@ -4026,7 +4028,7 @@ namespace Slang
                 auto left = ParseExpression(Precedence(level + 1));
                 while (GetOpLevel(this, tokenReader.PeekTokenType()) == level)
                 {
-                    RefPtr<OperatorExpr> tmp = new InfixExpr();
+                    OperatorExpr* tmp = new InfixExpr();
                     tmp->FunctionExpr = parseOperator(this);
 
                     tmp->Arguments.Add(left);
@@ -4041,7 +4043,7 @@ namespace Slang
                 auto left = ParseExpression(Precedence(level + 1));
                 if (GetOpLevel(this, tokenReader.PeekTokenType()) == level)
                 {
-                    RefPtr<OperatorExpr> tmp = new InfixExpr();
+                    OperatorExpr* tmp = new InfixExpr();
                     tmp->Arguments.Add(left);
                     FillPosition(tmp.Ptr());
                     tmp->FunctionExpr = parseOperator(this);
@@ -4056,30 +4058,30 @@ namespace Slang
 
     // We *might* be looking at an application of a generic to arguments,
     // but we need to disambiguate to make sure.
-    static RefPtr<Expr> maybeParseGenericApp(
+    static Expr* maybeParseGenericApp(
         Parser*                             parser,
 
         // TODO: need to support more general expressions here
-        RefPtr<Expr>     base)
+        Expr*     base)
     {
         if(peekTokenType(parser) != TokenType::OpLess)
             return base;
         return tryParseGenericApp(parser, base);
     }
 
-    static RefPtr<Expr> parsePrefixExpr(Parser* parser);
+    static Expr* parsePrefixExpr(Parser* parser);
 
     // Parse OOP `this` expression syntax
     static RefPtr<RefObject> parseThisExpr(Parser* parser, void* /*userData*/)
     {
-        RefPtr<ThisExpr> expr = parser->astBuilder->create<ThisExpr>();
+        ThisExpr* expr = parser->astBuilder->create<ThisExpr>();
         expr->scope = parser->currentScope;
         return expr;
     }
 
-    static RefPtr<Expr> parseBoolLitExpr(Parser* parser, bool value)
+    static Expr* parseBoolLitExpr(Parser* parser, bool value)
     {
-        RefPtr<BoolLiteralExpr> expr = parser->astBuilder->create<BoolLiteralExpr>();
+        BoolLiteralExpr* expr = parser->astBuilder->create<BoolLiteralExpr>();
         expr->value = value;
         return expr;
     }
@@ -4261,7 +4263,7 @@ namespace Slang
         return value;
     }
 
-    static RefPtr<Expr> parseAtomicExpr(Parser* parser)
+    static Expr* parseAtomicExpr(Parser* parser)
     {
         switch( peekTokenType(parser) )
         {
@@ -4283,8 +4285,8 @@ namespace Slang
 
                 if (peekTypeName(parser) && parser->LookAheadToken(TokenType::RParent, 1))
                 {
-                    RefPtr<TypeCastExpr> tcexpr = parser->astBuilder->create<ExplicitCastExpr>();
-                    parser->FillPosition(tcexpr.Ptr());
+                    TypeCastExpr* tcexpr = parser->astBuilder->create<ExplicitCastExpr>();
+                    parser->FillPosition(tcexpr);
                     tcexpr->functionExpr = parser->ParseType();
                     parser->ReadToken(TokenType::RParent);
 
@@ -4295,10 +4297,10 @@ namespace Slang
                 }
                 else
                 {
-                    RefPtr<Expr> base = parser->ParseExpression();
+                    Expr* base = parser->ParseExpression();
                     parser->ReadToken(TokenType::RParent);
 
-                    RefPtr<ParenExpr> parenExpr = parser->astBuilder->create<ParenExpr>();
+                    ParenExpr* parenExpr = parser->astBuilder->create<ParenExpr>();
                     parenExpr->loc = openParen.loc;
                     parenExpr->base = base;
                     return parenExpr;
@@ -4308,13 +4310,13 @@ namespace Slang
         // An initializer list `{ expr, ... }`
         case TokenType::LBrace:
             {
-                RefPtr<InitializerListExpr> initExpr = parser->astBuilder->create<InitializerListExpr>();
-                parser->FillPosition(initExpr.Ptr());
+                InitializerListExpr* initExpr = parser->astBuilder->create<InitializerListExpr>();
+                parser->FillPosition(initExpr);
 
                 // Initializer list
                 parser->ReadToken(TokenType::LBrace);
 
-                List<RefPtr<Expr>> exprs;
+                List<Expr*> exprs;
 
                 for(;;)
                 {
@@ -4338,8 +4340,8 @@ namespace Slang
 
         case TokenType::IntegerLiteral:
             {
-                RefPtr<IntegerLiteralExpr> constExpr = parser->astBuilder->create<IntegerLiteralExpr>();
-                parser->FillPosition(constExpr.Ptr());
+                IntegerLiteralExpr* constExpr = parser->astBuilder->create<IntegerLiteralExpr>();
+                parser->FillPosition(constExpr);
 
                 auto token = parser->tokenReader.advanceToken();
                 constExpr->token = token;
@@ -4427,8 +4429,8 @@ namespace Slang
 
         case TokenType::FloatingPointLiteral:
             {
-                RefPtr<FloatingPointLiteralExpr> constExpr = parser->astBuilder->create<FloatingPointLiteralExpr>();
-                parser->FillPosition(constExpr.Ptr());
+                FloatingPointLiteralExpr* constExpr = parser->astBuilder->create<FloatingPointLiteralExpr>();
+                parser->FillPosition(constExpr);
 
                 auto token = parser->tokenReader.advanceToken();
                 constExpr->token = token;
@@ -4541,10 +4543,10 @@ namespace Slang
 
         case TokenType::StringLiteral:
             {
-                RefPtr<StringLiteralExpr> constExpr = parser->astBuilder->create<StringLiteralExpr>();
+                StringLiteralExpr* constExpr = parser->astBuilder->create<StringLiteralExpr>();
                 auto token = parser->tokenReader.advanceToken();
                 constExpr->token = token;
-                parser->FillPosition(constExpr.Ptr());
+                parser->FillPosition(constExpr);
 
                 if (!parser->LookAheadToken(TokenType::StringLiteral))
                 {
@@ -4572,7 +4574,7 @@ namespace Slang
                 // keywords registered for use as expressions.
                 Token nameToken = peekToken(parser);
 
-                RefPtr<Expr> parsedExpr;
+                Expr* parsedExpr;
                 if (tryParseUsingSyntaxDecl<Expr>(parser, &parsedExpr))
                 {
                     if (!parsedExpr->loc.isValid())
@@ -4583,9 +4585,9 @@ namespace Slang
                 }
 
                 // Default behavior is just to create a name expression
-                RefPtr<VarExpr> varExpr = parser->astBuilder->create<VarExpr>();
-                varExpr->scope = parser->currentScope.Ptr();
-                parser->FillPosition(varExpr.Ptr());
+                VarExpr* varExpr = parser->astBuilder->create<VarExpr>();
+                varExpr->scope = parser->currentScope;
+                parser->FillPosition(varExpr);
 
                 auto nameAndLoc = expectIdentifier(parser);
                 varExpr->name = nameAndLoc.name;
@@ -4600,7 +4602,7 @@ namespace Slang
         }
     }
 
-    static RefPtr<Expr> parsePostfixExpr(Parser* parser)
+    static Expr* parsePostfixExpr(Parser* parser)
     {
         auto expr = parseAtomicExpr(parser);
         for(;;)
@@ -4614,8 +4616,8 @@ namespace Slang
             case TokenType::OpInc:
             case TokenType::OpDec:
                 {
-                    RefPtr<OperatorExpr> postfixExpr = parser->astBuilder->create<PostfixExpr>();
-                    parser->FillPosition(postfixExpr.Ptr());
+                    OperatorExpr* postfixExpr = parser->astBuilder->create<PostfixExpr>();
+                    parser->FillPosition(postfixExpr);
                     postfixExpr->functionExpr = parseOperator(parser);
                     postfixExpr->arguments.add(expr);
 
@@ -4626,9 +4628,9 @@ namespace Slang
             // Subscript operation `a[i]`
             case TokenType::LBracket:
                 {
-                    RefPtr<IndexExpr> indexExpr = parser->astBuilder->create<IndexExpr>();
+                    IndexExpr* indexExpr = parser->astBuilder->create<IndexExpr>();
                     indexExpr->baseExpression = expr;
-                    parser->FillPosition(indexExpr.Ptr());
+                    parser->FillPosition(indexExpr);
                     parser->ReadToken(TokenType::LBracket);
                     // TODO: eventually we may want to support multiple arguments inside the `[]`
                     if (!parser->LookAheadToken(TokenType::RBracket))
@@ -4644,9 +4646,9 @@ namespace Slang
             // Call oepration `f(x)`
             case TokenType::LParent:
                 {
-                    RefPtr<InvokeExpr> invokeExpr = parser->astBuilder->create<InvokeExpr>();
+                    InvokeExpr* invokeExpr = parser->astBuilder->create<InvokeExpr>();
                     invokeExpr->functionExpr = expr;
-                    parser->FillPosition(invokeExpr.Ptr());
+                    parser->FillPosition(invokeExpr);
                     parser->ReadToken(TokenType::LParent);
                     while (!parser->tokenReader.isAtEnd())
                     {
@@ -4669,12 +4671,12 @@ namespace Slang
             // Scope access `x::m`
             case TokenType::Scope:
             {
-                RefPtr<StaticMemberExpr> staticMemberExpr = parser->astBuilder->create<StaticMemberExpr>();
+                StaticMemberExpr* staticMemberExpr = parser->astBuilder->create<StaticMemberExpr>();
 
                 // TODO(tfoley): why would a member expression need this?
-                staticMemberExpr->scope = parser->currentScope.Ptr();
+                staticMemberExpr->scope = parser->currentScope;
 
-                parser->FillPosition(staticMemberExpr.Ptr());
+                parser->FillPosition(staticMemberExpr);
                 staticMemberExpr->baseExpression = expr;
                 parser->ReadToken(TokenType::Scope);
                 staticMemberExpr->name = expectIdentifier(parser).name;
@@ -4689,12 +4691,12 @@ namespace Slang
             // Member access `x.m`
             case TokenType::Dot:
                 {
-                    RefPtr<MemberExpr> memberExpr = parser->astBuilder->create<MemberExpr>();
+                    MemberExpr* memberExpr = parser->astBuilder->create<MemberExpr>();
 
                     // TODO(tfoley): why would a member expression need this?
                     memberExpr->scope = parser->currentScope.Ptr();
 
-                    parser->FillPosition(memberExpr.Ptr());
+                    parser->FillPosition(memberExpr);
                     memberExpr->baseExpression = expr;
                     parser->ReadToken(TokenType::Dot);
                     memberExpr->name = expectIdentifier(parser).name;
@@ -4738,7 +4740,7 @@ namespace Slang
         }
     }
 
-    static RefPtr<Expr> parsePrefixExpr(Parser* parser)
+    static Expr* parsePrefixExpr(Parser* parser)
     {
         auto tokenType = peekTokenType(parser);
         switch( tokenType )
@@ -4750,8 +4752,8 @@ namespace Slang
         case TokenType::OpInc:
         case TokenType::OpDec:
         {
-            RefPtr<PrefixExpr> prefixExpr = parser->astBuilder->create<PrefixExpr>();
-            parser->FillPosition(prefixExpr.Ptr());
+            PrefixExpr* prefixExpr = parser->astBuilder->create<PrefixExpr>();
+            parser->FillPosition(prefixExpr);
             prefixExpr->functionExpr = parseOperator(parser);
 
             auto arg = parsePrefixExpr(parser);
@@ -4763,15 +4765,15 @@ namespace Slang
         case TokenType::OpAdd:
         case TokenType::OpSub:
             {
-                RefPtr<PrefixExpr> prefixExpr = parser->astBuilder->create<PrefixExpr>();
-                parser->FillPosition(prefixExpr.Ptr());
+                PrefixExpr* prefixExpr = parser->astBuilder->create<PrefixExpr>();
+                parser->FillPosition(prefixExpr);
                 prefixExpr->functionExpr = parseOperator(parser);
 
                 auto arg = parsePrefixExpr(parser);
 
                 if (auto intLit = as<IntegerLiteralExpr>(arg))
                 {
-                    RefPtr<IntegerLiteralExpr> newLiteral = parser->astBuilder->create<IntegerLiteralExpr>(*intLit);
+                    IntegerLiteralExpr* newLiteral = parser->astBuilder->create<IntegerLiteralExpr>(*intLit);
 
                     IRIntegerValue value = _foldIntegerPrefixOp(tokenType, newLiteral->value);
 
@@ -4786,7 +4788,7 @@ namespace Slang
                 }
                 else if (auto floatLit = as<FloatingPointLiteralExpr>(arg))
                 {
-                    RefPtr<FloatingPointLiteralExpr> newLiteral = parser->astBuilder->create<FloatingPointLiteralExpr>(*floatLit);
+                    FloatingPointLiteralExpr* newLiteral = parser->astBuilder->create<FloatingPointLiteralExpr>(*floatLit);
                     newLiteral->value = _foldFloatPrefixOp(tokenType, floatLit->value);
                     return newLiteral;
                 }
@@ -4799,12 +4801,12 @@ namespace Slang
         }
     }
 
-    RefPtr<Expr> Parser::ParseLeafExpression()
+    Expr* Parser::ParseLeafExpression()
     {
         return parsePrefixExpr(this);
     }
 
-    RefPtr<Expr> parseTermFromSourceFile(
+    Expr* parseTermFromSourceFile(
         ASTBuilder*                     astBuilder,
         TokenSpan const&                tokens,
         DiagnosticSink*                 sink,
@@ -4846,7 +4848,7 @@ namespace Slang
 
         ASTBuilder* globalASTBuilder = session->getGlobalASTBuilder();
 
-        RefPtr<SyntaxDecl> syntaxDecl = globalASTBuilder->create<SyntaxDecl>();
+        SyntaxDecl* syntaxDecl = globalASTBuilder->create<SyntaxDecl>();
         syntaxDecl->nameAndLoc = NameLoc(name);
         syntaxDecl->syntaxClass = syntaxClass;
         syntaxDecl->parseCallback = callback;
@@ -4878,7 +4880,7 @@ namespace Slang
 
     static RefPtr<RefObject> parseIntrinsicOpModifier(Parser* parser, void* /*userData*/)
     {
-        RefPtr<IntrinsicOpModifier> modifier = parser->astBuilder->create<IntrinsicOpModifier>();
+        IntrinsicOpModifier* modifier = parser->astBuilder->create<IntrinsicOpModifier>();
 
         // We allow a few difference forms here:
         //
@@ -5045,7 +5047,7 @@ namespace Slang
     {
         ModifierListBuilder listBuilder;
 
-        RefPtr<UncheckedAttribute> numThreadsAttrib;
+        UncheckedAttribute* numThreadsAttrib = nullptr;
 
         listBuilder.add(parser->astBuilder->create<GLSLLayoutModifierGroupBegin>());
         
@@ -5121,7 +5123,7 @@ namespace Slang
             }
             else
             {
-                RefPtr<Modifier> modifier;
+                Modifier* modifier;
 
 #define CASE(key, type) if (nameText == #key) { modifier = parser->astBuilder->create<type>(); } else
                 CASE(push_constant, PushConstantAttribute) 
@@ -5166,7 +5168,7 @@ namespace Slang
 
     static RefPtr<RefObject> parseBuiltinTypeModifier(Parser* parser, void* /*userData*/)
     {
-        RefPtr<BuiltinTypeModifier> modifier = parser->astBuilder->create<BuiltinTypeModifier>();
+        BuiltinTypeModifier* modifier = parser->astBuilder->create<BuiltinTypeModifier>();
         parser->ReadToken(TokenType::LParent);
         modifier->tag = BaseType(StringToInt(parser->ReadToken(TokenType::IntegerLiteral).getContent()));
         parser->ReadToken(TokenType::RParent);
@@ -5176,7 +5178,7 @@ namespace Slang
 
     static RefPtr<RefObject> parseMagicTypeModifier(Parser* parser, void* /*userData*/)
     {
-        RefPtr<MagicTypeModifier> modifier = parser->astBuilder->create<MagicTypeModifier>();
+        MagicTypeModifier* modifier = parser->astBuilder->create<MagicTypeModifier>();
         parser->ReadToken(TokenType::LParent);
         modifier->name = parser->ReadToken(TokenType::Identifier).getContent();
         if (AdvanceIf(parser, TokenType::Comma))
@@ -5190,7 +5192,7 @@ namespace Slang
 
     static RefPtr<RefObject> parseIntrinsicTypeModifier(Parser* parser, void* /*userData*/)
     {
-        RefPtr<IntrinsicTypeModifier> modifier = parser->astBuilder->create<IntrinsicTypeModifier>();
+        IntrinsicTypeModifier* modifier = parser->astBuilder->create<IntrinsicTypeModifier>();
         parser->ReadToken(TokenType::LParent);
         modifier->irOp = uint32_t(StringToInt(parser->ReadToken(TokenType::IntegerLiteral).getContent()));
         while( AdvanceIf(parser, TokenType::Comma) )
@@ -5204,7 +5206,7 @@ namespace Slang
     }
     static RefPtr<RefObject> parseImplicitConversionModifier(Parser* parser, void* /*userData*/)
     {
-        RefPtr<ImplicitConversionModifier> modifier = parser->astBuilder->create<ImplicitConversionModifier>();
+        ImplicitConversionModifier* modifier = parser->astBuilder->create<ImplicitConversionModifier>();
 
         ConversionCost cost = kConversionCost_Default;
         if( AdvanceIf(parser, TokenType::LParent) )
@@ -5224,19 +5226,19 @@ namespace Slang
 
         auto syntaxClass = parser->astBuilder->findSyntaxClass(syntaxClassNameAndLoc.name);
 
-        RefPtr<AttributeTargetModifier> modifier = parser->astBuilder->create<AttributeTargetModifier>();
+        AttributeTargetModifier* modifier = parser->astBuilder->create<AttributeTargetModifier>();
         modifier->syntaxClass = syntaxClass;
 
         return modifier;
     }
 
-    RefPtr<ModuleDecl> populateBaseLanguageModule(
+    ModuleDecl* populateBaseLanguageModule(
         ASTBuilder*     astBuilder,
         RefPtr<Scope>   scope)
     {
         Session* session = astBuilder->getGlobalSession();
 
-        RefPtr<ModuleDecl> moduleDecl = astBuilder->create<ModuleDecl>();
+        ModuleDecl* moduleDecl = astBuilder->create<ModuleDecl>();
         scope->containerDecl = moduleDecl;
 
         // Add syntax for declaration keywords

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -53,7 +53,7 @@ namespace Slang
         Modifier* getFirst() { return m_result; };
     protected:
 
-        Modifier* m_result;
+        Modifier* m_result = nullptr;
         Modifier** m_next;
     };
 
@@ -586,7 +586,7 @@ namespace Slang
         return false;
     }
 
-    RefPtr<RefObject> ParseTypeDef(Parser* parser, void* /*userData*/)
+    NodeBase* ParseTypeDef(Parser* parser, void* /*userData*/)
     {
         TypeDefDecl* typeDefDecl = parser->astBuilder->create<TypeDefDecl>();
 
@@ -887,7 +887,7 @@ namespace Slang
 
                     Token nameToken = peekToken(parser);
 
-                    Modifier* parsedModifier;
+                    Modifier* parsedModifier = nullptr;
                     if (tryParseUsingSyntaxDecl<Modifier>(parser, &parsedModifier))
                     {
                         parsedModifier->name = nameToken.getName();
@@ -926,7 +926,7 @@ namespace Slang
     }
 
 
-    static RefPtr<RefObject> parseImportDecl(
+    static NodeBase* parseImportDecl(
         Parser* parser, void* /*userData*/)
     {
         parser->haveSeenAnyImportDecls = true;
@@ -1060,16 +1060,16 @@ namespace Slang
         SourceLoc openBracketLoc;
 
         // The expression that yields the element count, or NULL
-        Expr*	elementCountExpr;
+        Expr*	elementCountExpr = nullptr;
     };
 
     // "Unwrapped" information about a declarator
     struct DeclaratorInfo
     {
-        Expr*	    typeSpec;
+        Expr*	    typeSpec = nullptr;
         NameLoc             nameAndLoc;
-        Modifier*	semantics;
-        Expr*	    initializer;
+        Modifier*	semantics = nullptr;
+        Expr*	    initializer = nullptr;
     };
 
     // Add a member declaration to its container, and ensure that its
@@ -1197,7 +1197,7 @@ namespace Slang
         }
     }
 
-    static RefPtr<RefObject> ParseGenericDecl(Parser* parser, void*)
+    static NodeBase* ParseGenericDecl(Parser* parser, void*)
     {
         GenericDecl* decl = parser->astBuilder->create<GenericDecl>();
         parser->FillPosition(decl);
@@ -1527,8 +1527,8 @@ namespace Slang
     struct InitDeclarator
     {
         RefPtr<Declarator>  declarator;
-        Modifier*    semantics;
-        Expr*        initializer;
+        Modifier*    semantics = nullptr;
+        Expr*        initializer = nullptr;
     };
 
     // Parse a declarator plus optional semantics
@@ -1619,8 +1619,8 @@ namespace Slang
     struct DeclGroupBuilder
     {
         SourceLoc        startPosition;
-        Decl*        decl;
-        DeclGroup*   group;
+        Decl*        decl = nullptr;
+        DeclGroup*   group = nullptr;
         ASTBuilder*      astBuilder = nullptr;
 
         // Add a new declaration to the potential group
@@ -1681,10 +1681,10 @@ namespace Slang
     struct TypeSpec
     {
         // If the type-spec declared something, then put it here
-        Decl*                    decl;
+        Decl*                    decl = nullptr;
 
         // Put the resulting expression (which should evaluate to a type) here
-        Expr*    expr;
+        Expr*    expr = nullptr;
     };
 
     static Expr* parseGenericApp(
@@ -1826,7 +1826,7 @@ namespace Slang
         return taggedUnionType;
     }
 
-    static RefPtr<RefObject> parseTaggedUnionType(Parser* parser, void* /*unused*/)
+    static NodeBase* parseTaggedUnionType(Parser* parser, void* /*unused*/)
     {
         return parseTaggedUnionType(parser);
     }
@@ -1839,7 +1839,7 @@ namespace Slang
         return expr;
     }
 
-    static RefPtr<RefObject> parseThisTypeExpr(Parser* parser, void* /*userData*/)
+    static NodeBase* parseThisTypeExpr(Parser* parser, void* /*userData*/)
     {
         return parseThisTypeExpr(parser);
     }
@@ -2225,7 +2225,7 @@ namespace Slang
         if (!AdvanceIf(parser, TokenType::Colon))
             return nullptr;
 
-        Modifier* result;
+        Modifier* result = nullptr;
         Modifier** link = &result;
         SLANG_ASSERT(!*link);
 
@@ -2372,13 +2372,13 @@ namespace Slang
         return bufferVarDecl;
     }
 
-    static RefPtr<RefObject> parseHLSLCBufferDecl(
+    static NodeBase* parseHLSLCBufferDecl(
         Parser*	parser, void* /*userData*/)
     {
         return ParseHLSLBufferDecl(parser, "ConstantBuffer");
     }
 
-    static RefPtr<RefObject> parseHLSLTBufferDecl(
+    static NodeBase* parseHLSLTBufferDecl(
         Parser*	parser, void* /*userData*/)
     {
         return ParseHLSLBufferDecl(parser, "TextureBuffer");
@@ -2403,7 +2403,7 @@ namespace Slang
         }
     }
 
-    static RefPtr<RefObject> ParseExtensionDecl(Parser* parser, void* /*userData*/)
+    static NodeBase* ParseExtensionDecl(Parser* parser, void* /*userData*/)
     {
         ExtensionDecl* decl = parser->astBuilder->create<ExtensionDecl>();
         parser->FillPosition(decl);
@@ -2415,7 +2415,7 @@ namespace Slang
     }
 
 
-    void parseOptionalGenericConstraints(Parser* parser, ContainerDecl* decl)
+    static void parseOptionalGenericConstraints(Parser* parser, ContainerDecl* decl)
     {
         if (AdvanceIf(parser, TokenType::Colon))
         {
@@ -2440,7 +2440,7 @@ namespace Slang
         }
     }
 
-    RefPtr<RefObject> parseAssocType(Parser* parser, void *)
+    static NodeBase* parseAssocType(Parser* parser, void *)
     {
         AssocTypeDecl* assocTypeDecl = parser->astBuilder->create<AssocTypeDecl>();
 
@@ -2452,7 +2452,7 @@ namespace Slang
         return assocTypeDecl;
     }
 
-    RefPtr<RefObject> parseGlobalGenericTypeParamDecl(Parser * parser, void *)
+    static NodeBase* parseGlobalGenericTypeParamDecl(Parser * parser, void *)
     {
         GlobalGenericParamDecl* genParamDecl = parser->astBuilder->create<GlobalGenericParamDecl>();
         auto nameToken = parser->ReadToken(TokenType::Identifier);
@@ -2463,7 +2463,7 @@ namespace Slang
         return genParamDecl;
     }
 
-    RefPtr<RefObject> parseGlobalGenericValueParamDecl(Parser * parser, void *)
+    static NodeBase* parseGlobalGenericValueParamDecl(Parser * parser, void *)
     {
         GlobalGenericValueParamDecl* genericParamDecl = parser->astBuilder->create<GlobalGenericValueParamDecl>();
         auto nameToken = parser->ReadToken(TokenType::Identifier);
@@ -2484,7 +2484,7 @@ namespace Slang
         return genericParamDecl;
     }
 
-    static RefPtr<RefObject> parseInterfaceDecl(Parser* parser, void* /*userData*/)
+    static NodeBase* parseInterfaceDecl(Parser* parser, void* /*userData*/)
     {
         InterfaceDecl* decl = parser->astBuilder->create<InterfaceDecl>();
         parser->FillPosition(decl);
@@ -2497,7 +2497,7 @@ namespace Slang
         return decl;
     }
 
-    static RefPtr<RefObject> parseNamespaceDecl(Parser* parser, void* /*userData*/)
+    static NodeBase* parseNamespaceDecl(Parser* parser, void* /*userData*/)
     {
         // We start by parsing the name of the namespace that is being opened.
         //
@@ -2538,7 +2538,7 @@ namespace Slang
         // any non-null pointer we return to the AST).
         //
         NamespaceDecl* namespaceDecl = nullptr;
-        RefPtr<RefObject> result;
+        NodeBase* result = nullptr;
         //
         // In order to find out what case we are in, we start by looking
         // for a namespace declaration of the same name in the parent
@@ -2616,7 +2616,7 @@ namespace Slang
         return result;
     }
 
-    static RefPtr<RefObject> parseConstructorDecl(Parser* parser, void* /*userData*/)
+    static NodeBase* parseConstructorDecl(Parser* parser, void* /*userData*/)
     {
         ConstructorDecl* decl = parser->astBuilder->create<ConstructorDecl>();
         parser->FillPosition(decl);
@@ -2644,7 +2644,7 @@ namespace Slang
     {
         Modifiers modifiers = ParseModifiers(parser);
 
-        AccessorDecl* decl;
+        AccessorDecl* decl = nullptr;
         if( AdvanceIf(parser, "get") )
         {
             decl = parser->astBuilder->create<GetterDecl>();
@@ -2677,7 +2677,7 @@ namespace Slang
         return decl;
     }
 
-    static RefPtr<RefObject> ParseSubscriptDecl(Parser* parser, void* /*userData*/)
+    static NodeBase* ParseSubscriptDecl(Parser* parser, void* /*userData*/)
     {
         SubscriptDecl* decl = parser->astBuilder->create<SubscriptDecl>();
         parser->FillPosition(decl);
@@ -2744,7 +2744,7 @@ namespace Slang
         expect(parser, TokenType::Semicolon);
     }
 
-    static RefPtr<RefObject> parseLetDecl(
+    static NodeBase* parseLetDecl(
         Parser* parser, void* /*userData*/)
     {
         LetDecl* decl = parser->astBuilder->create<LetDecl>();
@@ -2752,7 +2752,7 @@ namespace Slang
         return decl;
     }
 
-    static RefPtr<RefObject> parseVarDecl(
+    static NodeBase* parseVarDecl(
         Parser* parser, void* /*userData*/)
     {
         VarDecl* decl = parser->astBuilder->create<VarDecl>();
@@ -2792,7 +2792,7 @@ namespace Slang
         }
     }
 
-    static RefPtr<RefObject> parseFuncDecl(
+    static NodeBase* parseFuncDecl(
         Parser* parser, void* /*userData*/)
     {
         FuncDecl* decl = parser->astBuilder->create<FuncDecl>();
@@ -2814,7 +2814,7 @@ namespace Slang
         });
     }
 
-    static RefPtr<RefObject> parseTypeAliasDecl(
+    static NodeBase* parseTypeAliasDecl(
         Parser* parser, void* /*userData*/)
     {
         TypeAliasDecl* decl = parser->astBuilder->create<TypeAliasDecl>();
@@ -2836,14 +2836,14 @@ namespace Slang
     // This is a catch-all syntax-construction callback to handle cases where
     // a piece of syntax is fully defined by the keyword to use, along with
     // the class of AST node to construct.
-    static RefPtr<RefObject> parseSimpleSyntax(Parser* parser, void* userData)
+    static NodeBase* parseSimpleSyntax(Parser* parser, void* userData)
     {
         SyntaxClassBase syntaxClass((ReflectClassInfo*) userData);
-        return (RefObject*) syntaxClass.createInstanceImpl(parser->astBuilder);
+        return (NodeBase*)syntaxClass.createInstanceImpl(parser->astBuilder);
     }
 
     // Parse a declaration of a keyword that can be used to define further syntax.
-    static RefPtr<RefObject> parseSyntaxDecl(Parser* parser, void* /*userData*/)
+    static NodeBase* parseSyntaxDecl(Parser* parser, void* /*userData*/)
     {
         // Right now the basic form is:
         //
@@ -2959,7 +2959,7 @@ namespace Slang
     // using the default attribute-parsing logic and then all specialized behavior takes
     // place during semantic checking.
     //
-    static RefPtr<RefObject> parseAttributeSyntaxDecl(Parser* parser, void* /*userData*/)
+    static NodeBase* parseAttributeSyntaxDecl(Parser* parser, void* /*userData*/)
     {
         // Right now the basic form is:
         //
@@ -3056,7 +3056,7 @@ namespace Slang
         ContainerDecl*      containerDecl,
         Modifiers			modifiers )
     {
-        DeclBase* decl;
+        DeclBase* decl = nullptr;
 
         auto loc = parser->tokenReader.peekLoc();
 
@@ -3072,7 +3072,7 @@ namespace Slang
                 // First we will check whether we can use the identifier token
                 // as a declaration keyword and parse a declaration using
                 // its associated callback:
-                Decl* parsedDecl;
+                Decl* parsedDecl = nullptr;
                 if (tryParseUsingSyntaxDecl<Decl>(parser, &parsedDecl))
                 {
                     decl = parsedDecl;
@@ -3432,7 +3432,7 @@ namespace Slang
     {
         auto modifiers = ParseModifiers(this);
 
-        Stmt* statement;
+        Stmt* statement = nullptr;
         if (LookAheadToken(TokenType::LBrace))
             statement = parseBlockStatement();
         else if (LookAheadToken("if"))
@@ -3665,7 +3665,7 @@ namespace Slang
         // case, just so that we can correctly handle it in downstream
         // logic.
         //
-        ForStmt* stmt;
+        ForStmt* stmt = nullptr;
         if (brokenScoping)
         {
             stmt = astBuilder->create<UnscopedForStmt>();
@@ -4072,7 +4072,7 @@ namespace Slang
     static Expr* parsePrefixExpr(Parser* parser);
 
     // Parse OOP `this` expression syntax
-    static RefPtr<RefObject> parseThisExpr(Parser* parser, void* /*userData*/)
+    static NodeBase* parseThisExpr(Parser* parser, void* /*userData*/)
     {
         ThisExpr* expr = parser->astBuilder->create<ThisExpr>();
         expr->scope = parser->currentScope;
@@ -4086,12 +4086,12 @@ namespace Slang
         return expr;
     }
 
-    static RefPtr<RefObject> parseTrueExpr(Parser* parser, void* /*userData*/)
+    static NodeBase* parseTrueExpr(Parser* parser, void* /*userData*/)
     {
         return parseBoolLitExpr(parser, true);
     }
 
-    static RefPtr<RefObject> parseFalseExpr(Parser* parser, void* /*userData*/)
+    static NodeBase* parseFalseExpr(Parser* parser, void* /*userData*/)
     {
         return parseBoolLitExpr(parser, false);
     }
@@ -4574,7 +4574,7 @@ namespace Slang
                 // keywords registered for use as expressions.
                 Token nameToken = peekToken(parser);
 
-                Expr* parsedExpr;
+                Expr* parsedExpr = nullptr;
                 if (tryParseUsingSyntaxDecl<Expr>(parser, &parsedExpr))
                 {
                     if (!parsedExpr->loc.isValid())
@@ -4878,7 +4878,7 @@ namespace Slang
         addBuiltinSyntaxImpl(session, scope, name, &parseSimpleSyntax, (void*) syntaxClass.classInfo, getClass<T>());
     }
 
-    static RefPtr<RefObject> parseIntrinsicOpModifier(Parser* parser, void* /*userData*/)
+    static NodeBase* parseIntrinsicOpModifier(Parser* parser, void* /*userData*/)
     {
         IntrinsicOpModifier* modifier = parser->astBuilder->create<IntrinsicOpModifier>();
 
@@ -4926,7 +4926,7 @@ namespace Slang
         return modifier;
     }
 
-    static RefPtr<RefObject> parseTargetIntrinsicModifier(Parser* parser, void* /*userData*/)
+    static NodeBase* parseTargetIntrinsicModifier(Parser* parser, void* /*userData*/)
     {
         auto modifier = parser->astBuilder->create<TargetIntrinsicModifier>();
 
@@ -4952,7 +4952,7 @@ namespace Slang
         return modifier;
     }
 
-    static RefPtr<RefObject> parseSpecializedForTargetModifier(Parser* parser, void* /*userData*/)
+    static NodeBase* parseSpecializedForTargetModifier(Parser* parser, void* /*userData*/)
     {
         auto modifier = parser->astBuilder->create<SpecializedForTargetModifier>();
         if (AdvanceIf(parser, TokenType::LParent))
@@ -4963,7 +4963,7 @@ namespace Slang
         return modifier;
     }
 
-    static RefPtr<RefObject> parseGLSLExtensionModifier(Parser* parser, void* /*userData*/)
+    static NodeBase* parseGLSLExtensionModifier(Parser* parser, void* /*userData*/)
     {
         auto modifier = parser->astBuilder->create<RequiredGLSLExtensionModifier>();
 
@@ -4974,7 +4974,7 @@ namespace Slang
         return modifier;
     }
 
-    static RefPtr<RefObject> parseGLSLVersionModifier(Parser* parser, void* /*userData*/)
+    static NodeBase* parseGLSLVersionModifier(Parser* parser, void* /*userData*/)
     {
         auto modifier = parser->astBuilder->create<RequiredGLSLVersionModifier>();
 
@@ -5015,7 +5015,7 @@ namespace Slang
         return SemanticVersion::parse(content, outVersion);
     }
 
-    static RefPtr<RefObject> parseSPIRVVersionModifier(Parser* parser, void* /*userData*/)
+    static NodeBase* parseSPIRVVersionModifier(Parser* parser, void* /*userData*/)
     {
         Token token;
         SemanticVersion version;
@@ -5026,10 +5026,10 @@ namespace Slang
             return modifier;
         }
         parser->sink->diagnose(token, Diagnostics::invalidSPIRVVersion);
-        return RefPtr<RefObject>();
+        return nullptr;
     }
 
-    static RefPtr<RefObject> parseCUDASMVersionModifier(Parser* parser, void* /*userData*/)
+    static NodeBase* parseCUDASMVersionModifier(Parser* parser, void* /*userData*/)
     {
         Token token;
         SemanticVersion version;
@@ -5040,10 +5040,10 @@ namespace Slang
             return modifier;
         }
         parser->sink->diagnose(token, Diagnostics::invalidCUDASMVersion);
-        return RefPtr<RefObject>();
+        return nullptr;
     }
 
-    static RefPtr<RefObject> parseLayoutModifier(Parser* parser, void* /*userData*/)
+    static NodeBase* parseLayoutModifier(Parser* parser, void* /*userData*/)
     {
         ModifierListBuilder listBuilder;
 
@@ -5123,7 +5123,7 @@ namespace Slang
             }
             else
             {
-                Modifier* modifier;
+                Modifier* modifier = nullptr;
 
 #define CASE(key, type) if (nameText == #key) { modifier = parser->astBuilder->create<type>(); } else
                 CASE(push_constant, PushConstantAttribute) 
@@ -5166,7 +5166,7 @@ namespace Slang
         return listBuilder.getFirst();
     }
 
-    static RefPtr<RefObject> parseBuiltinTypeModifier(Parser* parser, void* /*userData*/)
+    static NodeBase* parseBuiltinTypeModifier(Parser* parser, void* /*userData*/)
     {
         BuiltinTypeModifier* modifier = parser->astBuilder->create<BuiltinTypeModifier>();
         parser->ReadToken(TokenType::LParent);
@@ -5176,7 +5176,7 @@ namespace Slang
         return modifier;
     }
 
-    static RefPtr<RefObject> parseMagicTypeModifier(Parser* parser, void* /*userData*/)
+    static NodeBase* parseMagicTypeModifier(Parser* parser, void* /*userData*/)
     {
         MagicTypeModifier* modifier = parser->astBuilder->create<MagicTypeModifier>();
         parser->ReadToken(TokenType::LParent);
@@ -5190,7 +5190,7 @@ namespace Slang
         return modifier;
     }
 
-    static RefPtr<RefObject> parseIntrinsicTypeModifier(Parser* parser, void* /*userData*/)
+    static NodeBase* parseIntrinsicTypeModifier(Parser* parser, void* /*userData*/)
     {
         IntrinsicTypeModifier* modifier = parser->astBuilder->create<IntrinsicTypeModifier>();
         parser->ReadToken(TokenType::LParent);
@@ -5204,7 +5204,7 @@ namespace Slang
 
         return modifier;
     }
-    static RefPtr<RefObject> parseImplicitConversionModifier(Parser* parser, void* /*userData*/)
+    static NodeBase* parseImplicitConversionModifier(Parser* parser, void* /*userData*/)
     {
         ImplicitConversionModifier* modifier = parser->astBuilder->create<ImplicitConversionModifier>();
 
@@ -5218,7 +5218,7 @@ namespace Slang
         return modifier;
     }
 
-    static RefPtr<RefObject> parseAttributeTargetModifier(Parser* parser, void* /*userData*/)
+    static NodeBase* parseAttributeTargetModifier(Parser* parser, void* /*userData*/)
     {
         expect(parser, TokenType::LParent);
         auto syntaxClassNameAndLoc = expectIdentifier(parser);

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -822,7 +822,7 @@ namespace Slang
         // Consume the token that specified the keyword
         auto keywordToken = advanceToken(parser);
 
-        RefObject* parsedObject = syntaxDecl->parseCallback(parser, syntaxDecl->parseUserData);
+        NodeBase* parsedObject = syntaxDecl->parseCallback(parser, syntaxDecl->parseUserData);
         if (!parsedObject)
         {
             return false;
@@ -2859,7 +2859,7 @@ namespace Slang
         auto nameAndLoc = expectIdentifier(parser);
 
         // Next we look for a clause that specified the AST node class.
-        SyntaxClass<RefObject> syntaxClass;
+        SyntaxClass<NodeBase> syntaxClass;
         if (AdvanceIf(parser, TokenType::Colon))
         {
             // User is specifying the class that should be construted
@@ -2998,7 +2998,7 @@ namespace Slang
         // on the amount of per-attribute-type logic that has to occur later.
 
         // Next we look for a clause that specified the AST node class.
-        SyntaxClass<RefObject> syntaxClass;
+        SyntaxClass<NodeBase> syntaxClass;
         if (AdvanceIf(parser, TokenType::Colon))
         {
             // User is specifying the class that should be construted
@@ -4842,7 +4842,7 @@ namespace Slang
         char const*                 nameText,
         SyntaxParseCallback         callback,
         void*                       userData,
-        SyntaxClass<RefObject>      syntaxClass)
+        SyntaxClass<NodeBase>      syntaxClass)
     {
         Name* name = session->getNamePool()->getName(nameText);
 

--- a/source/slang/slang-parser.h
+++ b/source/slang/slang-parser.h
@@ -15,7 +15,7 @@ namespace Slang
         DiagnosticSink*                 sink,
         RefPtr<Scope> const&            outerScope);
 
-    RefPtr<Expr> parseTermFromSourceFile(
+    Expr* parseTermFromSourceFile(
         ASTBuilder*                     astBuilder,
         TokenSpan const&                tokens,
         DiagnosticSink*                 sink,
@@ -23,7 +23,7 @@ namespace Slang
         NamePool*                       namePool,
         SourceLanguage                  sourceLanguage);
 
-    RefPtr<ModuleDecl> populateBaseLanguageModule(
+    ModuleDecl* populateBaseLanguageModule(
         ASTBuilder*     astBuilder,
         RefPtr<Scope>   scope);
 }

--- a/source/slang/slang-reflection.cpp
+++ b/source/slang/slang-reflection.cpp
@@ -155,7 +155,7 @@ SLANG_API SlangResult spReflectionUserAttribute_GetArgumentValueInt(SlangReflect
     auto userAttr = convert(attrib);
     if (!userAttr) return SLANG_ERROR_INVALID_PARAMETER;
     if (index >= (unsigned int)userAttr->args.getCount()) return SLANG_ERROR_INVALID_PARAMETER;
-    RefPtr<RefObject> val;
+    NodeBase* val = nullptr;
     if (userAttr->intArgVals.TryGetValue(index, val))
     {
         *rs = (int)as<ConstantIntVal>(val)->value;

--- a/source/slang/slang-reflection.cpp
+++ b/source/slang/slang-reflection.cpp
@@ -148,7 +148,7 @@ SlangReflectionType* spReflectionUserAttribute_GetArgumentType(SlangReflectionUs
 {
     auto userAttr = convert(attrib);
     if (!userAttr) return nullptr;
-    return convert(userAttr->args[index]->type.type.Ptr());
+    return convert(userAttr->args[index]->type.type);
 }
 SLANG_API SlangResult spReflectionUserAttribute_GetArgumentValueInt(SlangReflectionUserAttribute* attrib, unsigned int index, int * rs)
 {
@@ -356,15 +356,15 @@ SLANG_API SlangReflectionType* spReflectionType_GetElementType(SlangReflectionTy
 
     if(auto arrayType = as<ArrayExpressionType>(type))
     {
-        return (SlangReflectionType*) arrayType->baseType.Ptr();
+        return (SlangReflectionType*) arrayType->baseType;
     }
     else if( auto parameterGroupType = as<ParameterGroupType>(type))
     {
-        return convert(parameterGroupType->elementType.Ptr());
+        return convert(parameterGroupType->elementType);
     }
     else if( auto vectorType = as<VectorExpressionType>(type))
     {
-        return convert(vectorType->elementType.Ptr());
+        return convert(vectorType->elementType);
     }
     else if( auto matrixType = as<MatrixExpressionType>(type))
     {
@@ -427,7 +427,7 @@ SLANG_API SlangScalarType spReflectionType_GetScalarType(SlangReflectionType* in
     }
     else if(auto vectorType = as<VectorExpressionType>(type))
     {
-        type = vectorType->elementType.Ptr();
+        type = vectorType->elementType;
     }
 
     if(auto basicType = as<BasicExpressionType>(type))
@@ -504,7 +504,7 @@ SLANG_API SlangResourceShape spReflectionType_GetResourceShape(SlangReflectionTy
 
     while(auto arrayType = as<ArrayExpressionType>(type))
     {
-        type = arrayType->baseType.Ptr();
+        type = arrayType->baseType;
     }
 
     if(auto textureType = as<TextureTypeBase>(type))
@@ -540,7 +540,7 @@ SLANG_API SlangResourceAccess spReflectionType_GetResourceAccess(SlangReflection
 
     while(auto arrayType = as<ArrayExpressionType>(type))
     {
-        type = arrayType->baseType.Ptr();
+        type = arrayType->baseType;
     }
 
     if(auto textureType = as<TextureTypeBase>(type))
@@ -604,8 +604,8 @@ SLANG_API SlangReflectionType * spReflection_FindTypeByName(SlangReflection * re
 
     try
     {
-        RefPtr<Type> result = program->getTypeFromString(name, &sink);
-        return (SlangReflectionType*)result.Ptr();
+        Type* result = program->getTypeFromString(name, &sink);
+        return (SlangReflectionType*)result;
     }
     catch( ... )
     {
@@ -633,18 +633,18 @@ SLANG_API SlangReflectionType* spReflectionType_GetResourceResultType(SlangRefle
 
     while(auto arrayType = as<ArrayExpressionType>(type))
     {
-        type = arrayType->baseType.Ptr();
+        type = arrayType->baseType;
     }
 
     if (auto textureType = as<TextureTypeBase>(type))
     {
-        return convert(textureType->elementType.Ptr());
+        return convert(textureType->elementType);
     }
 
     // TODO: need a better way to handle this stuff...
 #define CASE(TYPE, SHAPE, ACCESS)                                                       \
     else if(as<TYPE>(type)) do {                                                      \
-        return convert(as<TYPE>(type)->elementType.Ptr());                            \
+        return convert(as<TYPE>(type)->elementType);                            \
     } while(0)
 
     // TODO: structured buffer needs to expose type layout!
@@ -666,7 +666,7 @@ SLANG_API SlangReflectionType* spReflectionTypeLayout_GetType(SlangReflectionTyp
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return nullptr;
 
-    return (SlangReflectionType*) typeLayout->type.Ptr();
+    return (SlangReflectionType*) typeLayout->type;
 }
 
 namespace

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -206,7 +206,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     RequirementWitness::RequirementWitness(Val* val)
         : m_flavor(Flavor::val)
-        , m_obj(val)
+        , m_val(val)
     {}
 
 
@@ -561,7 +561,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
                     SLANG_UNEXPECTED("unhandled type");
                 }
 
-                RefPtr<RefObject> type = classInfo.createInstance(astBuilder);
+                NodeBase* type = classInfo.createInstance(astBuilder);
                 if (!type)
                 {
                     SLANG_UNEXPECTED("constructor failure");

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -359,7 +359,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
         // We are going to build up a list of substitutions that need
         // to be applied to the decl-ref to make it specialized.
-        Substitutions* substsToApply;
+        Substitutions* substsToApply = nullptr;
         Substitutions** link = &substsToApply;
 
         Decl* dd = declRef.getDecl();
@@ -738,7 +738,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         if(ioParametersFound.Count() == 0)
             return appGlobalGenericSubsts;
 
-        Substitutions* resultSubst;
+        Substitutions* resultSubst = nullptr;
         Substitutions** link = &resultSubst;
         for(auto appSubst = appGlobalGenericSubsts; appSubst; appSubst = appSubst->outer)
         {

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -54,7 +54,7 @@ SourceLoc const& getDiagnosticPos(TypeExp const& typeExp)
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!  Free functions !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-const RefPtr<Decl>* adjustFilterCursorImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filterStyle, const RefPtr<Decl>* ptr, const RefPtr<Decl>* end)
+Decl*const* adjustFilterCursorImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filterStyle, Decl*const* ptr, Decl*const* end)
 {
     switch (filterStyle)
     {
@@ -99,7 +99,7 @@ const RefPtr<Decl>* adjustFilterCursorImpl(const ReflectClassInfo& clsInfo, Memb
     return end;
 }
 
-const RefPtr<Decl>* getFilterCursorByIndexImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filterStyle, const RefPtr<Decl>* ptr, const RefPtr<Decl>* end, Index index)
+Decl*const* getFilterCursorByIndexImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filterStyle, Decl*const* ptr, Decl*const* end, Index index)
 {
     switch (filterStyle)
     {
@@ -156,7 +156,7 @@ const RefPtr<Decl>* getFilterCursorByIndexImpl(const ReflectClassInfo& clsInfo, 
     return nullptr;
 }
 
-Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filterStyle, const RefPtr<Decl>* ptr, const RefPtr<Decl>* end)
+Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filterStyle, Decl*const* ptr, Decl*const* end)
 {
     Index count = 0;
     switch (filterStyle)
@@ -204,7 +204,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
     // RequirementWitness
     //
 
-    RequirementWitness::RequirementWitness(RefPtr<Val> val)
+    RequirementWitness::RequirementWitness(Val* val)
         : m_flavor(Flavor::val)
         , m_obj(val)
     {}
@@ -324,17 +324,17 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
    
 
-    static RefPtr<Type> ExtractGenericArgType(RefPtr<Val> val)
+    static Type* ExtractGenericArgType(Val* val)
     {
-        auto type = val.as<Type>();
-        SLANG_RELEASE_ASSERT(type.Ptr());
+        auto type = as<Type>(val);
+        SLANG_RELEASE_ASSERT(type);
         return type;
     }
 
-    static RefPtr<IntVal> ExtractGenericArgInteger(RefPtr<Val> val)
+    static IntVal* ExtractGenericArgInteger(Val* val)
     {
-        auto intVal = val.as<IntVal>();
-        SLANG_RELEASE_ASSERT(intVal.Ptr());
+        auto intVal = as<IntVal>(val);
+        SLANG_RELEASE_ASSERT(intVal);
         return intVal;
     }
 
@@ -359,30 +359,30 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
         // We are going to build up a list of substitutions that need
         // to be applied to the decl-ref to make it specialized.
-        RefPtr<Substitutions> substsToApply;
-        RefPtr<Substitutions>* link = &substsToApply;
+        Substitutions* substsToApply;
+        Substitutions** link = &substsToApply;
 
-        RefPtr<Decl> dd = declRef.getDecl();
+        Decl* dd = declRef.getDecl();
         for(;;)
         {
-            RefPtr<Decl> childDecl = dd;
-            RefPtr<Decl> parentDecl = dd->parentDecl;
+            Decl* childDecl = dd;
+            Decl* parentDecl = dd->parentDecl;
             if(!parentDecl)
                 break;
 
             dd = parentDecl;
 
-            if(auto genericParentDecl = parentDecl.as<GenericDecl>())
+            if(auto genericParentDecl = as<GenericDecl>(parentDecl))
             {
                 // Don't specialize any parameters of a generic.
                 if(childDecl != genericParentDecl->inner)
                     break;
 
                 // We have a generic ancestor, but do we have an substitutions for it?
-                RefPtr<GenericSubstitution> foundSubst;
+                GenericSubstitution* foundSubst = nullptr;
                 for(auto s = declRef.substitutions.substitutions; s; s = s->outer)
                 {
-                    auto genSubst = s.as<GenericSubstitution>();
+                    auto genSubst = as<GenericSubstitution>(s);
                     if(!genSubst)
                         continue;
 
@@ -397,7 +397,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
                 if(!foundSubst)
                 {
-                    RefPtr<Substitutions> newSubst = createDefaultSubstitutionsForGeneric(
+                    Substitutions* newSubst = createDefaultSubstitutionsForGeneric(
                         astBuilder, 
                         genericParentDecl,
                         nullptr);
@@ -417,7 +417,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // TODO: need to figure out how to unify this with the logic
     // in the generic case...
-    RefPtr<DeclRefType> DeclRefType::create(
+    DeclRefType* DeclRefType::create(
         ASTBuilder*     astBuilder,
         DeclRef<Decl>   declRef)
     {
@@ -434,7 +434,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
             GenericSubstitution* subst = nullptr;
             for(auto s = declRef.substitutions.substitutions; s; s = s->outer)
             {
-                if(auto genericSubst = s.as<GenericSubstitution>())
+                if(auto genericSubst = as<GenericSubstitution>(s))
                 {
                     subst = genericSubst;
                     break;
@@ -584,9 +584,9 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     //
 
-    RefPtr<GenericSubstitution> findInnerMostGenericSubstitution(Substitutions* subst)
+    GenericSubstitution* findInnerMostGenericSubstitution(Substitutions* subst)
     {
-        for(RefPtr<Substitutions> s = subst; s; s = s->outer)
+        for(Substitutions* s = subst; s; s = s->outer)
         {
             if(auto genericSubst = as<GenericSubstitution>(s))
                 return genericSubst;
@@ -597,7 +597,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
    
     // DeclRefBase
 
-    RefPtr<Type> DeclRefBase::substitute(ASTBuilder* astBuilder, RefPtr<Type> type) const
+    Type* DeclRefBase::substitute(ASTBuilder* astBuilder, Type* type) const
     {
         // Note that type can be nullptr, and so this function can return nullptr (although only correctly when no substitutions) 
 
@@ -609,7 +609,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
         // Otherwise we need to recurse on the type structure
         // and apply substitutions where it makes sense
-        return type->substitute(astBuilder, substitutions).as<Type>();
+        return Slang::as<Type>(type->substitute(astBuilder, substitutions));
     }
 
     DeclRefBase DeclRefBase::substitute(ASTBuilder* astBuilder, DeclRefBase declRef) const
@@ -621,7 +621,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return declRef.substituteImpl(astBuilder, substitutions, &diff);
     }
 
-    RefPtr<Expr> DeclRefBase::substitute(ASTBuilder* /* astBuilder*/, RefPtr<Expr> expr) const
+    Expr* DeclRefBase::substitute(ASTBuilder* /* astBuilder*/, Expr* expr) const
     {
         // No substitutions? Easy.
         if (!substitutions)
@@ -647,13 +647,13 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return nullptr;
     }
 
-    RefPtr<GlobalGenericParamSubstitution> findGlobalGenericSubst(
-        RefPtr<Substitutions>   substs,
+    GlobalGenericParamSubstitution* findGlobalGenericSubst(
+        Substitutions*   substs,
         GlobalGenericParamDecl* paramDecl)
     {
         for(auto s = substs; s; s = s->outer)
         {
-            auto gSubst = s.as<GlobalGenericParamSubstitution>();
+            auto gSubst = as<GlobalGenericParamSubstitution>(s);
             if(!gSubst)
                 continue;
 
@@ -666,22 +666,22 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return nullptr;
     }
 
-    RefPtr<Substitutions> specializeSubstitutionsShallow(
+    Substitutions* specializeSubstitutionsShallow(
         ASTBuilder*             astBuilder, 
-        RefPtr<Substitutions>   substToSpecialize,
-        RefPtr<Substitutions>   substsToApply,
-        RefPtr<Substitutions>   restSubst,
+        Substitutions*   substToSpecialize,
+        Substitutions*   substsToApply,
+        Substitutions*   restSubst,
         int*                    ioDiff)
     {
         SLANG_ASSERT(substToSpecialize);
         return substToSpecialize->applySubstitutionsShallow(astBuilder, substsToApply, restSubst, ioDiff);
     }
 
-    RefPtr<Substitutions> specializeGlobalGenericSubstitutions(
+    Substitutions* specializeGlobalGenericSubstitutions(
         ASTBuilder*                         astBuilder,
         Decl*                               declToSpecialize,
-        RefPtr<Substitutions>               substsToSpecialize,
-        RefPtr<Substitutions>               substsToApply,
+        Substitutions*               substsToSpecialize,
+        Substitutions*               substsToApply,
         int*                                ioDiff,
         HashSet<GlobalGenericParamDecl*>&   ioParametersFound)
     {
@@ -689,7 +689,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         // a recursive case that skips the rest of the function.
         for(auto specSubst = substsToSpecialize; specSubst; specSubst = specSubst->outer)
         {
-            auto specGlobalGenericSubst = specSubst.as<GlobalGenericParamSubstitution>();
+            auto specGlobalGenericSubst = as<GlobalGenericParamSubstitution>(specSubst);
             if(!specGlobalGenericSubst)
                 continue;
 
@@ -721,8 +721,8 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         // We expect global generic substitutions to come at
         // the end of the list in all cases, so lets advance
         // until we see them.
-        RefPtr<Substitutions> appGlobalGenericSubsts = substsToApply;
-        while(appGlobalGenericSubsts && !appGlobalGenericSubsts.as<GlobalGenericParamSubstitution>())
+        Substitutions* appGlobalGenericSubsts = substsToApply;
+        while(appGlobalGenericSubsts && !as<GlobalGenericParamSubstitution>(appGlobalGenericSubsts))
             appGlobalGenericSubsts = appGlobalGenericSubsts->outer;
 
 
@@ -738,11 +738,11 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         if(ioParametersFound.Count() == 0)
             return appGlobalGenericSubsts;
 
-        RefPtr<Substitutions> resultSubst;
-        RefPtr<Substitutions>* link = &resultSubst;
+        Substitutions* resultSubst;
+        Substitutions** link = &resultSubst;
         for(auto appSubst = appGlobalGenericSubsts; appSubst; appSubst = appSubst->outer)
         {
-            auto appGlobalGenericSubst = appSubst.as<GlobalGenericParamSubstitution>();
+            auto appGlobalGenericSubst = as<GlobalGenericParamSubstitution>(appSubst);
             if(!appSubst)
                 continue;
 
@@ -750,7 +750,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
             if(ioParametersFound.Contains(appGlobalGenericSubst->paramDecl))
                 continue;
 
-            RefPtr<GlobalGenericParamSubstitution> newSubst = astBuilder->create<GlobalGenericParamSubstitution>();
+            GlobalGenericParamSubstitution* newSubst = astBuilder->create<GlobalGenericParamSubstitution>();
             newSubst->paramDecl = appGlobalGenericSubst->paramDecl;
             newSubst->actualType = appGlobalGenericSubst->actualType;
             newSubst->constraintArgs = appGlobalGenericSubst->constraintArgs;
@@ -762,11 +762,11 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return resultSubst;
     }
 
-    RefPtr<Substitutions> specializeGlobalGenericSubstitutions(
+    Substitutions* specializeGlobalGenericSubstitutions(
         ASTBuilder*             astBuilder,
         Decl*                   declToSpecialize,
-        RefPtr<Substitutions>   substsToSpecialize,
-        RefPtr<Substitutions>   substsToApply,
+        Substitutions*   substsToSpecialize,
+        Substitutions*   substsToApply,
         int*                    ioDiff)
     {
         // Keep track of any parameters already present in the
@@ -778,11 +778,11 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // Construct new substitutions to apply to a declaration,
     // based on a provided substitution set to be applied
-    RefPtr<Substitutions> specializeSubstitutions(
+    Substitutions* specializeSubstitutions(
         ASTBuilder*             astBuilder,
         Decl*                   declToSpecialize,
-        RefPtr<Substitutions>   substsToSpecialize,
-        RefPtr<Substitutions>   substsToApply,
+        Substitutions*   substsToSpecialize,
+        Substitutions*   substsToApply,
         int*                    ioDiff)
     {
         // No declaration? Then nothing to specialize.
@@ -861,7 +861,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
                         substsToApply,
                         &diff);
 
-                    RefPtr<GenericSubstitution> firstSubst = astBuilder->create<GenericSubstitution>();
+                    GenericSubstitution* firstSubst = astBuilder->create<GenericSubstitution>();
                     firstSubst->genericDecl = ancestorGenericDecl;
                     firstSubst->args = appGenericSubst->args;
                     firstSubst->outer = restSubst;
@@ -909,7 +909,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
                 //
                 for(auto s = substsToApply; s; s = s->outer)
                 {
-                    auto appThisTypeSubst = s.as<ThisTypeSubstitution>();
+                    auto appThisTypeSubst = as<ThisTypeSubstitution>(s);
                     if(!appThisTypeSubst)
                         continue;
 
@@ -924,7 +924,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
                         substsToApply,
                         &diff);
 
-                    RefPtr<ThisTypeSubstitution> firstSubst = astBuilder->create<ThisTypeSubstitution>();
+                    ThisTypeSubstitution* firstSubst = astBuilder->create<ThisTypeSubstitution>();
                     firstSubst->interfaceDecl = ancestorInterfaceDecl;
                     firstSubst->witness = appThisTypeSubst->witness;
                     firstSubst->outer = restSubst;
@@ -1033,7 +1033,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
         // Default is to apply the same set of substitutions/specializations
         // to the parent declaration as were applied to the child.
-        RefPtr<Substitutions> substToApply = substitutions.substitutions;
+        Substitutions* substToApply = substitutions.substitutions;
 
         if(auto interfaceDecl = as<InterfaceDecl>(decl))
         {
@@ -1079,14 +1079,14 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // IntVal
 
-    IntegerLiteralValue getIntVal(RefPtr<IntVal> val)
+    IntegerLiteralValue getIntVal(IntVal* val)
     {
         if (auto constantVal = as<ConstantIntVal>(val))
         {
             return constantVal->value;
         }
         SLANG_UNEXPECTED("needed a known integer value");
-        return 0;
+        //return 0;
     }
 
     //
@@ -1105,7 +1105,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // Constructors for types
 
-    RefPtr<ArrayExpressionType> getArrayType(
+    ArrayExpressionType* getArrayType(
         ASTBuilder* astBuilder,
         Type* elementType,
         IntVal*         elementCount)
@@ -1116,7 +1116,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return arrayType;
     }
 
-    RefPtr<ArrayExpressionType> getArrayType(
+    ArrayExpressionType* getArrayType(
         ASTBuilder* astBuilder,
         Type* elementType)
     {
@@ -1125,7 +1125,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return arrayType;
     }
 
-    RefPtr<NamedExpressionType> getNamedType(
+    NamedExpressionType* getNamedType(
         ASTBuilder*                 astBuilder,
         DeclRef<TypeDefDecl> const& declRef)
     {
@@ -1135,11 +1135,11 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
     }
 
     
-    RefPtr<FuncType> getFuncType(
+    FuncType* getFuncType(
         ASTBuilder*                     astBuilder,
         DeclRef<CallableDecl> const&    declRef)
     {
-        RefPtr<FuncType> funcType = astBuilder->create<FuncType>();
+        FuncType* funcType = astBuilder->create<FuncType>();
 
         funcType->resultType = getResultType(astBuilder, declRef);
         for (auto paramDeclRef : getParameters(declRef))
@@ -1167,14 +1167,14 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return funcType;
     }
 
-    RefPtr<GenericDeclRefType> getGenericDeclRefType(
+    GenericDeclRefType* getGenericDeclRefType(
         ASTBuilder*                 astBuilder,
         DeclRef<GenericDecl> const& declRef)
     {
         return astBuilder->create<GenericDeclRefType>(declRef);
     }
 
-    RefPtr<NamespaceType> getNamespaceType(
+    NamespaceType* getNamespaceType(
         ASTBuilder*                         astBuilder,
         DeclRef<NamespaceDeclBase> const&   declRef)
     {
@@ -1183,17 +1183,17 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return type;
     }
 
-    RefPtr<SamplerStateType> getSamplerStateType(
+    SamplerStateType* getSamplerStateType(
         ASTBuilder*     astBuilder)
     {
         return astBuilder->create<SamplerStateType>();
     }
 
-    RefPtr<ThisTypeSubstitution> findThisTypeSubstitution(
+    ThisTypeSubstitution* findThisTypeSubstitution(
         Substitutions*  substs,
         InterfaceDecl*  interfaceDecl)
     {
-        for(RefPtr<Substitutions> s = substs; s; s = s->outer)
+        for(Substitutions* s = substs; s; s = s->outer)
         {
             auto thisTypeSubst = as<ThisTypeSubstitution>(s);
             if(!thisTypeSubst)

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -6,12 +6,12 @@
 namespace Slang
 {
 
-    inline RefPtr<Type> getSub(ASTBuilder* astBuilder, DeclRef<GenericTypeConstraintDecl> const& declRef)
+    inline Type* getSub(ASTBuilder* astBuilder, DeclRef<GenericTypeConstraintDecl> const& declRef)
     {
         return declRef.substitute(astBuilder, declRef.getDecl()->sub.Ptr());
     }
 
-    inline RefPtr<Type> getSup(ASTBuilder* astBuilder, DeclRef<TypeConstraintDecl> const& declRef)
+    inline Type* getSup(ASTBuilder* astBuilder, DeclRef<TypeConstraintDecl> const& declRef)
     {
         return declRef.substitute(astBuilder, declRef.getDecl()->getSup().type);
     }
@@ -95,27 +95,27 @@ namespace Slang
         ///
     Name* getReflectionName(VarDeclBase* varDecl);
 
-    inline RefPtr<Type> getType(ASTBuilder* astBuilder, DeclRef<VarDeclBase> const& declRef)
+    inline Type* getType(ASTBuilder* astBuilder, DeclRef<VarDeclBase> const& declRef)
     {
         return declRef.substitute(astBuilder, declRef.getDecl()->type.Ptr());
     }
 
-    inline RefPtr<Expr> getInitExpr(ASTBuilder* astBuilder, DeclRef<VarDeclBase> const& declRef)
+    inline Expr* getInitExpr(ASTBuilder* astBuilder, DeclRef<VarDeclBase> const& declRef)
     {
         return declRef.substitute(astBuilder, declRef.getDecl()->initExpr);
     }
 
-    inline RefPtr<Type> getType(ASTBuilder* astBuilder, DeclRef<EnumCaseDecl> const& declRef)
+    inline Type* getType(ASTBuilder* astBuilder, DeclRef<EnumCaseDecl> const& declRef)
     {
         return declRef.substitute(astBuilder, declRef.getDecl()->type.Ptr());
     }
 
-    inline RefPtr<Expr> getTagExpr(ASTBuilder* astBuilder, DeclRef<EnumCaseDecl> const& declRef)
+    inline Expr* getTagExpr(ASTBuilder* astBuilder, DeclRef<EnumCaseDecl> const& declRef)
     {
         return declRef.substitute(astBuilder, declRef.getDecl()->tagExpr);
     }
 
-    inline RefPtr<Type> getTargetType(ASTBuilder* astBuilder, DeclRef<ExtensionDecl> const& declRef)
+    inline Type* getTargetType(ASTBuilder* astBuilder, DeclRef<ExtensionDecl> const& declRef)
     {
         return declRef.substitute(astBuilder, declRef.getDecl()->targetType.Ptr());
     }
@@ -127,19 +127,19 @@ namespace Slang
 
     
 
-    inline RefPtr<Type> getBaseType(ASTBuilder* astBuilder, DeclRef<InheritanceDecl> const& declRef)
+    inline Type* getBaseType(ASTBuilder* astBuilder, DeclRef<InheritanceDecl> const& declRef)
     {
         return declRef.substitute(astBuilder, declRef.getDecl()->base.type);
     }
     
-    inline RefPtr<Type> getType(ASTBuilder* astBuilder, DeclRef<TypeDefDecl> const& declRef)
+    inline Type* getType(ASTBuilder* astBuilder, DeclRef<TypeDefDecl> const& declRef)
     {
         return declRef.substitute(astBuilder, declRef.getDecl()->type.Ptr());
     }
 
-    inline RefPtr<Type> getResultType(ASTBuilder* astBuilder, DeclRef<CallableDecl> const& declRef)
+    inline Type* getResultType(ASTBuilder* astBuilder, DeclRef<CallableDecl> const& declRef)
     {
-        return declRef.substitute(astBuilder, declRef.getDecl()->returnType.type.Ptr());
+        return declRef.substitute(astBuilder, declRef.getDecl()->returnType.type);
     }
 
     inline FilteredMemberRefList<ParamDecl> getParameters(DeclRef<CallableDecl> const& declRef)
@@ -151,38 +151,38 @@ namespace Slang
     {
         // TODO: Should really return a `DeclRef<Decl>` for the inner
         // declaration, and not just a raw pointer
-        return declRef.getDecl()->inner.Ptr();
+        return declRef.getDecl()->inner;
     }
 
 
     //
 
-    RefPtr<ArrayExpressionType> getArrayType(
+    ArrayExpressionType* getArrayType(
         ASTBuilder* astBuilder,
         Type* elementType,
         IntVal*         elementCount);
 
-    RefPtr<ArrayExpressionType> getArrayType(
+    ArrayExpressionType* getArrayType(
         ASTBuilder* astBuilder,
         Type* elementType);
 
-    RefPtr<NamedExpressionType> getNamedType(
+    NamedExpressionType* getNamedType(
         ASTBuilder*                 astBuilder,
         DeclRef<TypeDefDecl> const& declRef);
 
-    RefPtr<FuncType> getFuncType(
+    FuncType* getFuncType(
         ASTBuilder*                     astBuilder,
         DeclRef<CallableDecl> const&    declRef);
 
-    RefPtr<GenericDeclRefType> getGenericDeclRefType(
+    GenericDeclRefType* getGenericDeclRefType(
         ASTBuilder*                 astBuilder,
         DeclRef<GenericDecl> const& declRef);
 
-    RefPtr<NamespaceType> getNamespaceType(
+    NamespaceType* getNamespaceType(
         ASTBuilder*                     astBuilder,
         DeclRef<NamespaceDeclBase> const&   declRef);
 
-    RefPtr<SamplerStateType> getSamplerStateType(
+    SamplerStateType* getSamplerStateType(
         ASTBuilder*     astBuilder);
 
 
@@ -192,7 +192,7 @@ namespace Slang
     template<typename T>
     void FilteredModifierList<T>::Iterator::operator++()
     {
-        current = adjust(current->next.Ptr());
+        current = adjust(current->next);
     }
     //
     template<typename T>
@@ -206,13 +206,13 @@ namespace Slang
             {
                 return m;
             }
-            m = m->next.Ptr();
+            m = m->next;
         }        
     }
 
     //
 
-    RefPtr<ThisTypeSubstitution> findThisTypeSubstitution(
+    ThisTypeSubstitution* findThisTypeSubstitution(
         Substitutions*  substs,
         InterfaceDecl*  interfaceDecl);
 
@@ -235,12 +235,12 @@ namespace Slang
         ASTBuilder*     astBuilder, 
         DeclRef<Decl>   declRef);
 
-    RefPtr<GenericSubstitution> createDefaultSubstitutionsForGeneric(
+    GenericSubstitution* createDefaultSubstitutionsForGeneric(
         ASTBuilder*             astBuilder, 
         GenericDecl*            genericDecl,
-        RefPtr<Substitutions>   outerSubst);
+        Substitutions*   outerSubst);
 
-    RefPtr<GenericSubstitution> findInnerMostGenericSubstitution(Substitutions* subst);
+    GenericSubstitution* findInnerMostGenericSubstitution(Substitutions* subst);
 
     enum class UserDefinedAttributeTargets
     {

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -2508,7 +2508,7 @@ Type* findGlobalGenericSpecializationArg(
     TypeLayoutContext const&    context,
     GlobalGenericParamDecl*     decl)
 {
-    Val* arg;
+    Val* arg = nullptr;
     context.programLayout->globalGenericArgs.TryGetValue(decl, arg);
     return as<Type>(arg);
 }

--- a/source/slang/slang-type-layout.h
+++ b/source/slang/slang-type-layout.h
@@ -304,8 +304,8 @@ class TypeLayout : public Layout
 {
 public:
     // The type that was laid out
-    RefPtr<Type>  type;
-    Type* getType() { return type.Ptr(); }
+    Type*  type;
+    Type* getType() { return type; }
 
     // The layout rules that were used to produce this type
     LayoutRulesImpl*        rules;
@@ -593,7 +593,7 @@ public:
 class GenericParamTypeLayout : public TypeLayout
 {
 public:
-    RefPtr<GlobalGenericParamDecl> getGlobalGenericParamDecl();
+    GlobalGenericParamDecl* getGlobalGenericParamDecl();
     Index paramIndex = 0;
 };
 
@@ -691,7 +691,7 @@ public:
         /// The declaration of the generic parameter.
         ///
         /// Could be any subclass of `Decl` that represents a generic value or type parameter.
-    RefPtr<Decl> decl;
+    Decl* decl;
 };
 
     /// Reflection/layout information about an existential/interface specialization parameter.
@@ -703,7 +703,7 @@ public:
         /// Currently, this will be an `interface` type that any concrete
         /// type argument getting plugged in must conform to.
         ///
-    RefPtr<Type> type;
+    Type* type;
 };
 
 // Layout information for the global scope of a program
@@ -751,7 +751,7 @@ public:
         ///
         /// Not useful for reflection, but valuable for code generation.
         ///
-    Dictionary<GlobalGenericParamDecl*, RefPtr<Val>> globalGenericArgs;
+    Dictionary<GlobalGenericParamDecl*, Val*> globalGenericArgs;
 
         /// Layouts for all tagged union types required by this program
         ///
@@ -1118,7 +1118,7 @@ RefPtr<TypeLayout> createTypeLayout(
     /// Create a layout for a parameter-group type (a `ConstantBuffer` or `ParameterBlock`).
 RefPtr<TypeLayout> createParameterGroupTypeLayout(
     TypeLayoutContext const&    context,
-    RefPtr<ParameterGroupType>  parameterGroupType);
+    ParameterGroupType*  parameterGroupType);
 
     /// Create a wrapper constant buffer type layout, if needed.
     ///
@@ -1140,8 +1140,8 @@ RefPtr<StructuredBufferTypeLayout>
 createStructuredBufferTypeLayout(
     TypeLayoutContext const&    context,
     ShaderParameterKind         kind,
-    RefPtr<Type>                structuredBufferType,
-    RefPtr<Type>                elementType);
+    Type*                structuredBufferType,
+    Type*                elementType);
 
     /// Create a type layout for an unspecialized `globalGenericParamDecl`.
 RefPtr<TypeLayout> createTypeLayoutForGlobalGenericTypeParam(
@@ -1150,7 +1150,7 @@ RefPtr<TypeLayout> createTypeLayoutForGlobalGenericTypeParam(
     GlobalGenericParamDecl*     globalGenericParamDecl);
 
     /// Find the concrete type (if any) that was plugged in for the global generic type parameter `decl`.
-RefPtr<Type> findGlobalGenericSpecializationArg(
+Type* findGlobalGenericSpecializationArg(
     TypeLayoutContext const&    context,
     GlobalGenericParamDecl*     decl);
 

--- a/source/slang/slang-type-layout.h
+++ b/source/slang/slang-type-layout.h
@@ -304,7 +304,7 @@ class TypeLayout : public Layout
 {
 public:
     // The type that was laid out
-    Type*  type;
+    Type*  type = nullptr;
     Type* getType() { return type; }
 
     // The layout rules that were used to produce this type
@@ -691,7 +691,7 @@ public:
         /// The declaration of the generic parameter.
         ///
         /// Could be any subclass of `Decl` that represents a generic value or type parameter.
-    Decl* decl;
+    Decl* decl = nullptr;
 };
 
     /// Reflection/layout information about an existential/interface specialization parameter.
@@ -703,7 +703,7 @@ public:
         /// Currently, this will be an `interface` type that any concrete
         /// type argument getting plugged in must conform to.
         ///
-    Type* type;
+    Type* type = nullptr;
 };
 
 // Layout information for the global scope of a program

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -820,7 +820,7 @@ SlangResult Linkage::loadFile(String const& path, PathInfo& outPathInfo, ISlangB
     return SLANG_OK;
 }
 
-RefPtr<Expr> Linkage::parseTermString(String typeStr, RefPtr<Scope> scope)
+Expr* Linkage::parseTermString(String typeStr, RefPtr<Scope> scope)
 {
     // Create a SourceManager on the stack, so any allocations for 'SourceFile'/'SourceView' etc will be cleaned up
     SourceManager localSourceManager;
@@ -868,7 +868,7 @@ RefPtr<Expr> Linkage::parseTermString(String typeStr, RefPtr<Scope> scope)
         tokens, &sink, scope, getNamePool(), SourceLanguage::Slang);
 }
 
-RefPtr<Type> checkProperType(
+Type* checkProperType(
     Linkage*        linkage,
     TypeExp         typeExp,
     DiagnosticSink* sink);
@@ -880,7 +880,7 @@ Type* ComponentType::getTypeFromString(
     // If we've looked up this type name before,
     // then we can re-use it.
     //
-    RefPtr<Type> type;
+    Type* type;
     if(m_types.TryGetValue(typeStr, type))
         return type;
 
@@ -891,7 +891,7 @@ Type* ComponentType::getTypeFromString(
     RefPtr<Scope> scope = _createScopeForLegacyLookup();
 
     auto linkage = getLinkage();
-    RefPtr<Expr> typeExpr = linkage->parseTermString(
+    Expr* typeExpr = linkage->parseTermString(
         typeStr, scope);
     type = checkProperType(linkage, TypeExp(typeExpr), sink);
 
@@ -959,7 +959,7 @@ void FrontEndCompileRequest::parseTranslationUnit(
 
     ASTBuilder* astBuilder = module->getASTBuilder();
 
-    RefPtr<ModuleDecl> translationUnitSyntax = astBuilder->create<ModuleDecl>();
+    ModuleDecl* translationUnitSyntax = astBuilder->create<ModuleDecl>();
     translationUnitSyntax->nameAndLoc.name = translationUnit->moduleName;
     translationUnitSyntax->module = module;
     module->setModuleDecl(translationUnitSyntax);
@@ -2603,13 +2603,13 @@ void Session::addBuiltinSource(
     if (!scope->containerDecl)
     {
         // We are the first chunk of code to be loaded for this scope
-        scope->containerDecl = syntax.Ptr();
+        scope->containerDecl = syntax;
     }
     else
     {
         // We need to create a new scope to link into the whole thing
         auto subScope = new Scope();
-        subScope->containerDecl = syntax.Ptr();
+        subScope->containerDecl = syntax;
         subScope->nextSibling = scope->nextSibling;
         scope->nextSibling = subScope;
     }

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -880,7 +880,7 @@ Type* ComponentType::getTypeFromString(
     // If we've looked up this type name before,
     // then we can re-use it.
     //
-    Type* type;
+    Type* type = nullptr;
     if(m_types.TryGetValue(typeStr, type))
         return type;
 


### PR DESCRIPTION
* Ast nodes no longer derive from RefObject
* There is no reference counting on AST Nodes
* The TypeCheckingCache is moved from Session to the Linkage 
  * Otherwise there is a scoping problem with ASTBuilder
* Some other small fixes and improvements
* Associate a name with ASTBuilder to better track scope + id (for debugging)
* Memory for backing AST nodes is from MemoryArena on ASTBuilder
* Only track (and dtor) AST types that have a non trivial dtor

On testing on the profile timing goes from 12.5 seconds to 8.3 seconds. Dll size goes from 2.49Mb to 2.17Mb.
