### PR TITLE
Fix problem with C++ extractor ernoneous concating of type tokens 

### DIFF
--- a/tools/slang-cpp-extractor/slang-cpp-extractor-main.cpp
+++ b/tools/slang-cpp-extractor/slang-cpp-extractor-main.cpp
@@ -1288,12 +1288,37 @@ void CPPExtractor::_consumeTypeModifiers()
     while (advanceIfStyle(IdentifierStyle::TypeModifier));
 }
 
+// True if two of these token types of the same type placed immediately after one another 
+// produce a different token. Can be conservative, as if not strictly required
+// it will just mean more spacing in the output
+static bool _canRepeatTokenType(TokenType type)
+{
+    switch (type)
+    {
+        case TokenType::OpAdd:
+        case TokenType::OpSub:
+        case TokenType::OpAnd:
+        case TokenType::OpOr:
+        case TokenType::OpGreater:
+        case TokenType::OpLess:
+        case TokenType::Identifier:
+        case TokenType::OpAssign:
+        case TokenType::Colon:
+        {
+            return false;
+        }
+        default: break;
+    }
+    return true;
+}
+
 // Returns true if there needs to be a spave between the previous token type, and the current token
 // type for correct output. It is assumed that the token stream is appropriate.
 // The implementation might need more sophistication, but this at least avoids Blah const *  -> Blahconst* 
 static bool _tokenConcatNeedsSpace(TokenType prev, TokenType cur)
 {
-    if (prev == TokenType::Identifier && cur == TokenType::Identifier)
+    if ((cur == TokenType::OpAssign) ||
+        (prev == cur && !_canRepeatTokenType(cur)))
     {
         return true;
     }


### PR DESCRIPTION
When producing text from a stream of token care must be taken, as some concats can change meaning.

For example previously

```
'Thing' 'const' '*' -> Thingconst*
```
The change checks consecutive token types and adds a space if needed. 