### PR TITLE
Add a batch file for invoke premake

### DIFF
--- a/premake.bat
+++ b/premake.bat
@@ -1,0 +1,3 @@
+@echo off
+set ROOT=%~dp0
+"%ROOT%\external\slang-binaries\premake\premake-5.0.0-alpha13\bin\windows-x64\premake5.exe" %*


### PR DESCRIPTION
This change adds `./premake.bat` to the repository, which users in Windows (64-bit) can use to conveniently invoke the copy of premake that is pulled via the `slang-binaries` submodule. It should be possible to pass whatever options you passed to `premake5.exe` through to `premake.bat`. E.g., if you invoke:

```
.\premake.bat vs2015
```

then you should get the desired results for the project/solution files we want to check in.