### PR TITLE
Hotfix/slangc unreleased compile request

### DIFF
--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -11,7 +11,13 @@ using namespace Slang;
 
 #include <assert.h>
 
-static void diagnosticCallback(
+#ifdef _WIN32
+#define MAIN slangc_main
+#else
+#define MAIN main
+#endif
+
+static void _diagnosticCallback(
     char const* message,
     void*       /*userData*/)
 {
@@ -20,23 +26,9 @@ static void diagnosticCallback(
     stdError.flush();
 }
 
-#ifdef _WIN32
-#define MAIN slangc_main
-#else
-#define MAIN main
-#endif
-
-SLANG_TEST_TOOL_API SlangResult innerMain(StdWriters* stdWriters, SlangSession* session, int argc, const char*const* argv)
+static SlangResult _compile(SlangCompileRequest* compileRequest, int argc, const char*const* argv)
 {
-    StdWriters::setSingleton(stdWriters);
-
-    SlangCompileRequest* compileRequest = spCreateCompileRequest(session);
-
-    spSetDiagnosticCallback(
-        compileRequest,
-        &diagnosticCallback,
-        nullptr);
-
+    spSetDiagnosticCallback(compileRequest, &_diagnosticCallback, nullptr);
     spSetCommandLineCompilerMode(compileRequest);
 
     char const* appName = "slangc";
@@ -47,8 +39,6 @@ SLANG_TEST_TOOL_API SlangResult innerMain(StdWriters* stdWriters, SlangSession* 
         if (SLANG_FAILED(res))
         {
             // TODO: print usage message
-
-            spDestroyCompileRequest(compileRequest);
             return res;
         }
     }
@@ -73,8 +63,18 @@ SLANG_TEST_TOOL_API SlangResult innerMain(StdWriters* stdWriters, SlangSession* 
     }
 #endif
 
+    return res;
+}
+
+SLANG_TEST_TOOL_API SlangResult innerMain(StdWriters* stdWriters, SlangSession* session, int argc, const char*const* argv)
+{
+    StdWriters::setSingleton(stdWriters);
+
+    SlangCompileRequest* compileRequest = spCreateCompileRequest(session);
+    SlangResult res = _compile(compileRequest, argc, argv);
     // Now that we are done, clean up after ourselves
     spDestroyCompileRequest(compileRequest);
+
     return res;
 }
 

--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -47,6 +47,8 @@ SLANG_TEST_TOOL_API SlangResult innerMain(StdWriters* stdWriters, SlangSession* 
         if (SLANG_FAILED(res))
         {
             // TODO: print usage message
+
+            spDestroyCompileRequest(compileRequest);
             return res;
         }
     }


### PR DESCRIPTION
On the slangc compiler, if an error occurred with command line processing, the request is not released. This subsequently led to the session not being released and an assert on debug builds around ref counting (requiring all requests to have been destroyed before the session).

Slightly rearranged the slangc code such that scope of request is clearer/simpler. 