### PR TITLE
Fix -api to ignore tests if 'API' not specified

### DIFF
--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -2844,6 +2844,12 @@ static bool _canIgnore(TestContext* context, const TestDetails& details)
         return true;
     }
 
+    // Are the required rendering APIs enabled from the -api command line switch
+    if ((requirements.usedRenderApiFlags & context->options.enabledApis) != requirements.usedRenderApiFlags)
+    {
+        return true;
+    }
+
     return false;
 }
 


### PR DESCRIPTION
The -api option (which is perhaps badly named), does have some effect in so far as it limits what tests can be synthesized. But that can already be explicitly controlled via synthesizedTestApis. 

The original intention I believe was to be able to limit tests, and it currently doesn't have that behavior. The fix, makes -api control which tests are run, by ignoring tests which require APIs that aren't specified in the -api line.  Note this only effects the execution of render-test tests. 

The -api line allows simple expressions to specify the apis to use

all-dx11    (all render APIs except dx11)
cpu+cuda (cpu and cuda)

etc

```
none - no render api 
all - all 'render apis'
gl,ogl,opengl
vk,vulkan
dx12,d3d12
dx11,d3d11
cpu
cuda
```

