### PR TITLE
Disable dynamic dispatch tests on CUDA 

### DIFF
--- a/tests/compute/dynamic-dispatch-1.slang
+++ b/tests/compute/dynamic-dispatch-1.slang
@@ -1,4 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu -xslang -allow-dynamic-code
+//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda -xslang -allow-dynamic-code
 
 // Test dynamic dispatch code gen for non-static member functions.
 

--- a/tests/compute/dynamic-dispatch-2.slang
+++ b/tests/compute/dynamic-dispatch-2.slang
@@ -1,4 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu -xslang -allow-dynamic-code
+//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda -xslang -allow-dynamic-code
 
 // Test dynamic dispatch code gen for static member functions
 // of associated type.

--- a/tests/compute/dynamic-dispatch-3.slang
+++ b/tests/compute/dynamic-dispatch-3.slang
@@ -1,4 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu -xslang -allow-dynamic-code
+//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda -xslang -allow-dynamic-code
 
 // Test dynamic dispatch code gen for static member functions
 // of associated type.

--- a/tests/compute/dynamic-generics-simple.slang
+++ b/tests/compute/dynamic-generics-simple.slang
@@ -1,4 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu -xslang -allow-dynamic-code
+//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda -xslang -allow-dynamic-code
 
 // Test basic dynamic dispatch code gen
 


### PR DESCRIPTION
When CUDA support is available, tests can be synthesized, and since it is derived from cpu path, the synthesizing code assumes a CPU compute test will work on CUDA. 

To disable it requires an explicit DISABLE_TEST(...) that specifies -cuda. This could be better.

I'm not clear in this if the CUDA tests were expected to work - but I'm assuming for now disabling is ok.