### PR TITLE
Attempt to silence some warnings

### DIFF
--- a/source/slang/slang-ast-serialize.cpp
+++ b/source/slang/slang-ast-serialize.cpp
@@ -930,7 +930,7 @@ ASTSerialField _calcField(const char* name, T& in)
 
 static ASTSerialClass _makeClass(MemoryArena* arena, ASTNodeType type, const List<ASTSerialField>& fields)
 {
-    ASTSerialClass cls = {};
+    ASTSerialClass cls;
     cls.type = type;
     cls.fieldsCount = fields.getCount();
     cls.fields = arena->allocateAndCopyArray(fields.getBuffer(), fields.getCount());

--- a/source/slang/slang-ast-serialize.cpp
+++ b/source/slang/slang-ast-serialize.cpp
@@ -930,8 +930,7 @@ ASTSerialField _calcField(const char* name, T& in)
 
 static ASTSerialClass _makeClass(MemoryArena* arena, ASTNodeType type, const List<ASTSerialField>& fields)
 {
-    ASTSerialClass cls;
-    cls.type = type;
+    ASTSerialClass cls = { type, 0, 0, 0, 0 };
     cls.fieldsCount = fields.getCount();
     cls.fields = arena->allocateAndCopyArray(fields.getBuffer(), fields.getCount());
     return cls;


### PR DESCRIPTION
This is an attempt to change code in `slang-ast-serialize.cpp` so that it doesn't trigger a warning(-as-error) in one of our build configurations.

The original code is fine in terms of expressing its intent, so the right answer might actually be to silence the warning.