### PR TITLE
Bug fix in C++ extractor

### DIFF
--- a/tools/slang-cpp-extractor/slang-cpp-extractor-diagnostics.cpp
+++ b/tools/slang-cpp-extractor/slang-cpp-extractor-diagnostics.cpp
@@ -6,7 +6,7 @@ namespace CPPDiagnostics
 {
 using namespace Slang;
 
-#define DIAGNOSTIC(id, severity, name, messageFormat) const DiagnosticInfo name = { id, Severity::severity, messageFormat };
+#define DIAGNOSTIC(id, severity, name, messageFormat) const DiagnosticInfo name = { id, Severity::severity, #name, messageFormat };
 #include "slang-cpp-extractor-diagnostic-defs.h"
 }
 

--- a/tools/slang-cpp-extractor/slang-cpp-extractor-main.cpp
+++ b/tools/slang-cpp-extractor/slang-cpp-extractor-main.cpp
@@ -2478,26 +2478,34 @@ int main(int argc, const char*const* argv)
     using namespace Slang;
 
     {
-        RootNamePool rootNamePool;
-
-        SourceManager sourceManager;
-        sourceManager.initialize(nullptr, nullptr);
-
         ComPtr<ISlangWriter> writer(new FileWriter(stderr, WriterFlag::AutoFlush));
 
-        DiagnosticSink sink(&sourceManager);
-        sink.writer = writer;
-
-        CPPExtractorApp app(&sink, &sourceManager, &rootNamePool);
-        if (SLANG_FAILED(app.executeWithArgs(argc - 1, argv + 1)))
+        try
         {
+            RootNamePool rootNamePool;
+
+            SourceManager sourceManager;
+            sourceManager.initialize(nullptr, nullptr);
+
+            DiagnosticSink sink(&sourceManager);
+            sink.writer = writer;
+
+            CPPExtractorApp app(&sink, &sourceManager, &rootNamePool);
+            if (SLANG_FAILED(app.executeWithArgs(argc - 1, argv + 1)))
+            {
+                return 1;
+            }
+            if (sink.getErrorCount())
+            {
+                return 1;
+            }
+        }
+        catch (...)
+        {
+            WriterHelper helper(writer);
+            helper.print("Unknown internal error in C++ extractor, aborted!\n");
             return 1;
         }
-        if (sink.getErrorCount())
-        {
-            return 1;
-        }
-
     }
     return 0;
 }


### PR DESCRIPTION
* The diagnostic structure in Slang changed, but the macro wasn't altered in C++ extractor making diagnostics broken 
* Add a clause to catch uncaught exceptions and display an error in C++ extractor