### PR TITLE
Remove KernelContext wrapper from CPU/CUDA emit

### DIFF
--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -2341,16 +2341,20 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
 
     case kIROp_BitCast:
         {
-            // TODO: we can simplify the logic for arbitrary bitcasts
-            // by always bitcasting the source to a `uint*` type (if it
-            // isn't already) and then bitcasting that to the destination
-            // type (if it isn't already `uint*`.
+            // Note: we are currently emitting casts as plain old
+            // C-style casts, which may not always perform a bitcast.
             //
-            // For now we are assuming the source type is *already*
-            // a `uint*` type of the appropriate size.
-            //
-            //  auto fromType = extractBaseType(inst->getOperand(0)->getDataType());
+            // TODO: This operation should map to an intrinsic to be
+            // provided in a prelude for C/C++, so that the target
+            // can easily emit code for whatever the best possible
+            // bitcast is on the platform.
          
+            auto prec = getInfo(EmitOp::Prefix);
+            needClose = maybeEmitParens(outerPrec, prec);
+
+            m_writer->emit("(");
+            emitType(inst->getDataType());
+            m_writer->emit(")");
             m_writer->emit("(");
             emitOperand(inst->getOperand(0), getInfo(EmitOp::General));
             m_writer->emit(")");

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -1767,7 +1767,6 @@ void CPPSourceEmitter::_emitWitnessTableDefinitions()
                 else
                     isFirstEntry = false;
 
-                m_writer->emit("&KernelContext::");
                 m_writer->emit(_getWitnessTableWrapperFuncName(funcVal));
             }
             else if (auto witnessTableVal = as<IRWitnessTable>(entry->getSatisfyingVal()))
@@ -1830,7 +1829,7 @@ void CPPSourceEmitter::_maybeEmitWitnessTableTypeDefinition(
         if (auto funcVal = as<IRFuncType>(entry->getRequirementVal()))
         {
             emitType(funcVal->getResultType());
-            m_writer->emit(" (KernelContext::*");
+            m_writer->emit(" (*");
             m_writer->emit(getName(entry->getRequirementKey()));
             m_writer->emit(")");
             m_writer->emit("(");
@@ -1964,8 +1963,7 @@ void CPPSourceEmitter::emitSimpleFuncImpl(IRFunc* func)
         // on CPU/CUDA, and these all bottleneck through the actual `IRFunc`
         // here as a workhorse.
         //
-        // Because the workhorse function is currently emitted as a member of
-        // `KernelContext`, and doesn't have the right signature to service
+        // Because the workhorse function doesn't have the right signature to service
         // general-purpose calls, it is being emitted with a `_` prefix.
         //
         StringBuilder prefixName;
@@ -2288,15 +2286,6 @@ bool CPPSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOut
             // Does this function declare any requirements.
             handleCallExprDecorationsImpl(funcValue);
 
-            if (funcValue->op == kIROp_lookup_interface_method)
-            {
-                m_writer->emit("(this->*(");
-                emitOperand(funcValue, EmitOpInfo());
-                m_writer->emit("))");
-                _emitCallArgList(as<IRCall>(inst));
-                return true;
-            }
-
             // try doing automatically
             return _tryEmitInstExprAsIntrinsic(inst, inOuterPrec);
         }
@@ -2389,8 +2378,6 @@ void CPPSourceEmitter::emitPreprocessorDirectivesImpl()
         m_writer->emit("#ifdef SLANG_PRELUDE_NAMESPACE\n");
         m_writer->emit("using namespace SLANG_PRELUDE_NAMESPACE;\n");
         m_writer->emit("#endif\n\n");
-
-        m_writer->emit("struct KernelContext;\n\n");
     }
 
     if (m_target == CodeGenTarget::CSource)
@@ -2470,7 +2457,7 @@ static bool _isFunction(IROp op)
     return op == kIROp_Func;
 }
 
-void CPPSourceEmitter::_emitEntryPointDefinitionStart(IRFunc* func, IRGlobalParam* entryPointParams, IRGlobalParam* globalParams, const String& funcName, const UnownedStringSlice& varyingTypeName)
+void CPPSourceEmitter::_emitEntryPointDefinitionStart(IRFunc* func, const String& funcName, const UnownedStringSlice& varyingTypeName)
 {
     auto resultType = func->getResultType();
     
@@ -2488,31 +2475,6 @@ void CPPSourceEmitter::_emitEntryPointDefinitionStart(IRFunc* func, IRGlobalPara
     m_writer->emit("\n{\n");
 
     m_writer->indent();
-    // Initialize when constructing so that globals are zeroed
-    m_writer->emit("KernelContext context = {};\n");
-    
-    if (entryPointParams)
-    {
-        auto param = entryPointParams;
-        auto paramType = param->getDataType();
-
-        m_writer->emit("context.");
-        m_writer->emit(getName(param));
-        m_writer->emit(" =  (");
-        emitType(paramType);
-        m_writer->emit(")entryPointParams; \n");
-    }
-    if (globalParams)
-    {
-        auto param = globalParams;
-        auto paramType = param->getDataType();
-
-        m_writer->emit("context.");
-        m_writer->emit(getName(param));
-        m_writer->emit(" =  (");
-        emitType(paramType);
-        m_writer->emit(")globalParams; \n");
-    }
 }
 
 void CPPSourceEmitter::_emitEntryPointDefinitionEnd(IRFunc* func)
@@ -2577,9 +2539,9 @@ void CPPSourceEmitter::_emitEntryPointGroup(const Int sizeAlongAxis[kThreadGroup
     }
 
     // just call at inner loop point
-    m_writer->emit("context._");
+    m_writer->emit("_");
     m_writer->emit(funcName);
-    m_writer->emit("(&threadInput);\n");
+    m_writer->emit("(&threadInput, entryPointParams, globalParams);\n");
 
     // Close all the loops
     for (Index i = Index(axes.getCount() - 1); i >= 0; --i)
@@ -2675,97 +2637,6 @@ void CPPSourceEmitter::_emitForwardDeclarations(const List<EmitAction>& actions)
     }
 }
 
-static bool isVaryingResourceKind(LayoutResourceKind kind)
-{
-    switch(kind)
-    {
-    default:
-        return false;
-
-    case LayoutResourceKind::VaryingInput:
-    case LayoutResourceKind::VaryingOutput:
-        return true;
-    }
-}
-
-static bool isVaryingParameter(IRTypeLayout* typeLayout)
-{
-    for(auto sizeAttr : typeLayout->getSizeAttrs())
-    {
-        if(!isVaryingResourceKind(sizeAttr->getResourceKind()))
-            return false;
-    }
-    return true;
-}
-
-static bool isVaryingParameter(IRVarLayout* varLayout)
-{
-    return isVaryingParameter(varLayout->getTypeLayout());
-}
-
-void CPPSourceEmitter::_findShaderParams(
-    IRGlobalParam** outEntryPointParam,
-    IRGlobalParam** outGlobalParam)
-{
-    SLANG_ASSERT(outEntryPointParam);
-    SLANG_ASSERT(outGlobalParam);
-
-    IRGlobalParam*& entryPointParam = *outEntryPointParam;
-    IRGlobalParam*& globalParam = *outGlobalParam;
-
-    for(auto inst : m_irModule->getGlobalInsts())
-    {
-        auto param = as<IRGlobalParam>(inst);
-        if(!param)
-            continue;
-
-        if(auto layoutDecor = param->findDecoration<IRLayoutDecoration>())
-        {
-            if(auto varLayout = as<IRVarLayout>(layoutDecor->getLayout()))
-            {
-                if(isVaryingParameter(varLayout))
-                    continue;
-                auto typeLayout = varLayout->getTypeLayout();
-                if(typeLayout->findSizeAttr(LayoutResourceKind::VaryingInput))
-                    continue;
-                if(typeLayout->findSizeAttr(LayoutResourceKind::VaryingOutput))
-                    continue;
-            }
-        }
-
-        // Currently, the entry-point parameters
-        // are represented as a single parameter
-        // at the global scope, and the same is
-        // true of the parameters that were
-        // originally declared as globals.
-        //
-        // We need to find capture each of these
-        // parameters, and we need to tell them
-        // apart. Luckily, the logic that
-        // moved the entry-point parameters to
-        // global scope will ahve also marked
-        // the entry-point parameters with
-        // a decoration that we can detect.
-        //
-        if (inst->findDecorationImpl(kIROp_EntryPointParamDecoration))
-        {
-            // Should only be one instruction marked this way
-            SLANG_ASSERT(entryPointParam == nullptr);
-            entryPointParam = param;
-            continue;
-        }
-        else
-        {
-            // There should only be one instruction representing
-            // the global-scope shader parameters.
-            //
-            SLANG_ASSERT(globalParam == nullptr);
-            globalParam = param;
-            continue;
-        }
-    }
-}
-
 void CPPSourceEmitter::emitModuleImpl(IRModule* module)
 {
     // Setup all built in types used in the module
@@ -2778,24 +2649,8 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
     
     _emitForwardDeclarations(actions);
 
-    IRGlobalParam* entryPointParams = nullptr;
-    IRGlobalParam* globalParams = nullptr;
-    _findShaderParams(&entryPointParams, &globalParams);
     
-    // Output the 'Context' which will be used for execution
     {
-        m_writer->emit("struct KernelContext\n{\n");
-        m_writer->indent();
-
-        if (globalParams)
-        {
-            emitGlobalInst(globalParams);
-        }
-        if (entryPointParams)
-        {
-            emitGlobalInst(entryPointParams);
-        }
-
         // Output all the thread locals 
         for (auto action : actions)
         {
@@ -2818,9 +2673,6 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
         // These wrapper functions takes an abstract type parameter (void*)
         // in the place of `this` parameter.
         _emitWitnessTableWrappers();
-
-        m_writer->dedent();
-        m_writer->emit("};\n\n");   
     }
 
     // Emit all witness table definitions.
@@ -2856,11 +2708,11 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
 
                     String threadFuncName = builder;
 
-                    _emitEntryPointDefinitionStart(func, entryPointParams, globalParams, threadFuncName, UnownedStringSlice::fromLiteral("ComputeThreadVaryingInput"));
+                    _emitEntryPointDefinitionStart(func, threadFuncName, UnownedStringSlice::fromLiteral("ComputeThreadVaryingInput"));
 
-                    m_writer->emit("context._");
+                    m_writer->emit("_");
                     m_writer->emit(funcName);
-                    m_writer->emit("(varyingInput);\n");
+                    m_writer->emit("(varyingInput, entryPointParams, globalParams);\n");
 
                     _emitEntryPointDefinitionEnd(func);
                 }
@@ -2873,7 +2725,7 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
 
                     String groupFuncName = builder;
 
-                    _emitEntryPointDefinitionStart(func, entryPointParams, globalParams, groupFuncName, UnownedStringSlice::fromLiteral("ComputeVaryingInput"));
+                    _emitEntryPointDefinitionStart(func, groupFuncName, UnownedStringSlice::fromLiteral("ComputeVaryingInput"));
 
                     m_writer->emit("ComputeThreadVaryingInput threadInput = {};\n");
                     m_writer->emit("threadInput.groupID = varyingInput->startGroupID;\n");
@@ -2884,7 +2736,7 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
 
                 // Emit the main version - which takes a dispatch size
                 {
-                    _emitEntryPointDefinitionStart(func, entryPointParams, globalParams, funcName, UnownedStringSlice::fromLiteral("ComputeVaryingInput"));
+                    _emitEntryPointDefinitionStart(func, funcName, UnownedStringSlice::fromLiteral("ComputeVaryingInput"));
 
                     m_writer->emit("ComputeVaryingInput vi = *varyingInput;\n");
                     m_writer->emit("ComputeVaryingInput groupVaryingInput = {};\n");

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -84,11 +84,6 @@ protected:
 
     void _emitForwardDeclarations(const List<EmitAction>& actions);
 
-        /// Find the IR global parameters representing the entry-point and global shader parameters (if any)
-    void _findShaderParams(
-        IRGlobalParam** outEntryPointParam,
-        IRGlobalParam** outGlobalParam);
-
     void _emitAryDefinition(const HLSLIntrinsic* specOp);
 
     // Really we don't want any of these defined like they are here, they should be defined in slang stdlib 
@@ -119,7 +114,7 @@ protected:
     
     SlangResult _calcCPPTextureTypeName(IRTextureTypeBase* texType, StringBuilder& outName);
 
-    void _emitEntryPointDefinitionStart(IRFunc* func, IRGlobalParam* entryPointParams, IRGlobalParam* globalParams, const String& funcName, const UnownedStringSlice& varyingTypeName);
+    void _emitEntryPointDefinitionStart(IRFunc* func, const String& funcName, const UnownedStringSlice& varyingTypeName);
     void _emitEntryPointDefinitionEnd(IRFunc* func);
     void _emitEntryPointGroup(const Int sizeAlongAxis[kThreadGroupAxisCount], const String& funcName);
     void _emitEntryPointGroupRange(const Int sizeAlongAxis[kThreadGroupAxisCount], const String& funcName);

--- a/source/slang/slang-emit-cuda.h
+++ b/source/slang/slang-emit-cuda.h
@@ -56,7 +56,7 @@ protected:
     virtual void emitVarDecorationsImpl(IRInst* varDecl) SLANG_OVERRIDE;
     virtual void emitMatrixLayoutModifiersImpl(IRVarLayout* layout) SLANG_OVERRIDE;
     virtual void emitCall(const HLSLIntrinsic* specOp, IRInst* inst, const IRUse* operands, int numOperands, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;
-    virtual void emitFunctionPreambleImpl(IRInst* inst) SLANG_OVERRIDE { SLANG_UNUSED(inst); m_writer->emit("__device__ "); }
+    virtual void emitFunctionPreambleImpl(IRInst* inst) SLANG_OVERRIDE;
 
     virtual void emitLoopControlDecorationImpl(IRLoopControlDecoration* decl) SLANG_OVERRIDE;
 

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -9,6 +9,9 @@
 #include "slang-ir-collect-global-uniforms.h"
 #include "slang-ir-dce.h"
 #include "slang-ir-entry-point-uniforms.h"
+#include "slang-ir-entry-point-raw-ptr-params.h"
+#include "slang-ir-explicit-global-context.h"
+#include "slang-ir-explicit-global-init.h"
 #include "slang-ir-glsl-legalize.h"
 #include "slang-ir-insts.h"
 #include "slang-ir-legalize-varying-params.h"
@@ -255,11 +258,42 @@ Result linkAndOptimizeIR(
     // parameters of a shader entry point and move them into
     // the global scope instead.
     //
-    moveEntryPointUniformParamsToGlobalScope(irModule);
-#if 0
-    dumpIRIfEnabled(compileRequest, irModule, "ENTRY POINT UNIFORMS MOVED");
-#endif
-    validateIRModuleIfEnabled(compileRequest, irModule);
+    // TODO: We should skip this step for CUDA targets.
+    //
+    {
+        CollectEntryPointUniformParamsOptions passOptions;
+        switch( target )
+        {
+        default:
+            break;
+
+        case CodeGenTarget::CPPSource:
+        case CodeGenTarget::CUDASource:
+            passOptions.alwaysCreateCollectedParam = true;
+            break;
+        }
+
+        collectEntryPointUniformParams(irModule, passOptions);
+    #if 0
+        dumpIRIfEnabled(compileRequest, irModule, "ENTRY POINT UNIFORMS COLLECTED");
+    #endif
+        validateIRModuleIfEnabled(compileRequest, irModule);
+    }
+
+    switch( target )
+    {
+    default:
+        moveEntryPointUniformParamsToGlobalScope(irModule);
+    #if 0
+        dumpIRIfEnabled(compileRequest, irModule, "ENTRY POINT UNIFORMS MOVED");
+    #endif
+        validateIRModuleIfEnabled(compileRequest, irModule);
+        break;
+
+    case CodeGenTarget::CPPSource:
+    case CodeGenTarget::CUDASource:
+        break;
+    }
 
 
     // Desguar any union types, since these will be illegal on
@@ -605,6 +639,24 @@ Result linkAndOptimizeIR(
         break;
 
     default:
+        break;
+    }
+
+
+    switch( target )
+    {
+    default:
+        break;
+
+    case CodeGenTarget::CPPSource:
+    case CodeGenTarget::CUDASource:
+        moveGlobalVarInitializationToEntryPoints(irModule);
+        introduceExplicitGlobalContext(irModule, target);
+        convertEntryPointPtrParamsToRawPtrs(irModule);
+    #if 0
+        dumpIRIfEnabled(compileRequest, irModule, "EXPLICIT GLOBAL CONTEXT INTRODUCED");
+    #endif
+        validateIRModuleIfEnabled(compileRequest, irModule);
         break;
     }
 

--- a/source/slang/slang-ir-entry-point-raw-ptr-params.cpp
+++ b/source/slang/slang-ir-entry-point-raw-ptr-params.cpp
@@ -1,0 +1,121 @@
+// slang-ir-entry-point-raw-ptr-params.cpp
+#include "slang-ir-entry-point-raw-ptr-params.h"
+
+#include "slang-ir-insts.h"
+
+namespace Slang
+{
+
+// This pass transforms the entry points in a module
+// so that any entry-point parameters of pointer
+// type (or a pointer-like type like `ConstantBuffer<T>`)
+// are replaced with parameters of raw pointer (`void*`)
+// type, with a cast in teh function body used to
+// produce a value of the expected type.
+
+struct ConvertEntryPointPtrParamsToRawPtrsPass
+{
+    IRModule* m_module;
+
+    void processModule()
+    {
+        SharedIRBuilder sharedBuilder(m_module);
+        IRBuilder builder(&sharedBuilder);
+
+        // We start by getting and caching the raw pointer type.
+        //
+        auto rawPtrType = builder.getRawPointerType();
+
+        // Now we loop over global-scope instructions searching
+        // for any entry points.
+        //
+        for( auto inst : m_module->getGlobalInsts() )
+        {
+            auto func = as<IRFunc>(inst);
+            if(!func)
+                continue;
+
+            if( !func->findDecoration<IREntryPointDecoration>() )
+                continue;
+
+            // We can only modify entry points with definitions here.
+            //
+            auto firstBlock = func->getFirstBlock();
+            if(!firstBlock)
+                continue;
+
+            // Any code we introduce for casts will need to be inserted
+            // before the first ordinary instruction in the first block
+            // of the function (right after the parameters).
+            //
+            builder.setInsertBefore(firstBlock->getFirstOrdinaryInst());
+
+            // Note: because we are inserting code right after the parameters
+            // it doesn't work here to use `firstBlock->getParams()`, because
+            // that captures a begin/end range where the "end" is the 
+            // first ordinary instruction at the time of the call, which will
+            // chane when we insert code.
+            //
+            // TODO: We chould probably change the represnetation of ranges
+            // of instructions to use first/last instead of begin/end so
+            // that ranges are robust against changes to instructions outside
+            // of a range.
+            //
+            for( auto param = firstBlock->getFirstParam(); param; param = param->getNextParam() )
+            {
+                // We only want to transform parameters of pointer or
+                // pointer-like type.
+                //
+                auto paramType = param->getDataType();
+                if(!as<IRPtrTypeBase>(paramType) && !as<IRPointerLikeType>(paramType))
+                    continue;
+
+                // We will overwrite the type of the parameter to
+                // be the raw pointer type instead.
+                //
+                builder.setDataType(param, rawPtrType);
+
+                // We are going to replace uses of the parameter with
+                // uses of a bit-cast operation based on the parameter,
+                // but we need to be careful because that bit-cast operation
+                // will itself be a use (which we don't want to replace
+                // because that would create a circularity).
+                //
+                // Instead we capture the list of uses *before* we create
+                // the bit cast instruction.
+                //
+                List<IRUse*> uses;
+                for(auto use = param->firstUse; use; use = use->nextUse)
+                    uses.add(use);
+
+                // Now we emit a bit-cast operation into the first block
+                // of the entry-point function to cast the raw-pointer
+                // parameter to the type that the body code expects.
+                //
+                auto cast = builder.emitBitCast(paramType, param);
+
+                // Now we can replace all the (captured) uses of the
+                // parameter with the bit-cast operation instead.
+                //
+                for(auto use : uses)
+                    use->set(cast);
+            }
+
+            // Because our operation might have changed the parameter
+            // types of the function, we need to make sure to fix up
+            // the IR type of the function to match its parameter list.
+            //
+            fixUpFuncType(func);
+        }
+    }
+};
+
+void convertEntryPointPtrParamsToRawPtrs(
+    IRModule*   module)
+{
+    ConvertEntryPointPtrParamsToRawPtrsPass pass;
+    pass.m_module = module;
+    pass.processModule();
+}
+
+}

--- a/source/slang/slang-ir-entry-point-raw-ptr-params.h
+++ b/source/slang/slang-ir-entry-point-raw-ptr-params.h
@@ -1,0 +1,12 @@
+// slang-ir-entry-point-raw-ptr-params.h
+#pragma once
+
+namespace Slang
+{
+struct IRModule;
+
+    /// Convert any entry-point parameters that use pointer types to use raw pointers (`void*`)
+void convertEntryPointPtrParamsToRawPtrs(
+    IRModule*   module);
+
+}

--- a/source/slang/slang-ir-entry-point-uniforms.h
+++ b/source/slang/slang-ir-entry-point-uniforms.h
@@ -7,6 +7,16 @@ namespace Slang
 {
 struct IRModule;
 
+struct CollectEntryPointUniformParamsOptions
+{
+    bool alwaysCreateCollectedParam;
+};
+
+    /// Collect entry point uniform parameters into a wrapper `struct` and/or buffer
+void collectEntryPointUniformParams(
+    IRModule*                                       module,
+    CollectEntryPointUniformParamsOptions const&    options);
+
     /// Move any uniform parameters of entry points to the global scope instead.
 void moveEntryPointUniformParamsToGlobalScope(
     IRModule*   module);

--- a/source/slang/slang-ir-explicit-global-context.cpp
+++ b/source/slang/slang-ir-explicit-global-context.cpp
@@ -1,0 +1,523 @@
+// slang-ir-explicit-global-context.cpp
+#include "slang-ir-explicit-global-context.h"
+
+#include "slang-ir-insts.h"
+
+namespace Slang
+{
+
+// The job of this pass is take global-scope declarations
+// that are actually scoped to a single shader thread or
+// thread-group, and wrap them up in an explicit "context"
+// type that gets passed between functions.
+
+struct IntroduceExplicitGlobalContextPass
+{
+    IRModule*       m_module = nullptr;
+    CodeGenTarget   m_target = CodeGenTarget::Unknown;
+
+    SharedIRBuilder*    m_sharedBuilder         = nullptr;
+    IRStructType*       m_contextStructType     = nullptr;
+    IRPtrType*          m_contextStructPtrType  = nullptr;
+
+    IRGlobalParam*      m_globalUniformsParam   = nullptr;
+    List<IRGlobalVar*>  m_globalVars;
+    List<IRFunc*>       m_entryPoints;
+
+    void processModule()
+    {
+        SharedIRBuilder sharedBuilder(m_module);
+        m_sharedBuilder = &sharedBuilder;
+
+        IRBuilder builder(&sharedBuilder);
+
+        // The global context will be represneted by a `struct`
+        // type with a name hint of `KernelContext`.
+        //
+        m_contextStructType = builder.createStructType();
+        builder.addNameHintDecoration(m_contextStructType, UnownedTerminatedStringSlice("KernelContext"));
+
+        // The context will usually be passed around by pointer,
+        // so we get and cache that pointer type up front.
+        //
+        m_contextStructPtrType = builder.getPtrType(m_contextStructType);
+
+        // The transformation we will perform will need to affect
+        // global variables, global shader parameters, and entry-point
+        // function (at the very least), and we start with an explicit
+        // pass to collect these entities into explicit lists to simplify
+        // looping over them later.
+        //
+        for( auto inst : m_module->getGlobalInsts() )
+        {
+            switch( inst->op )
+            {
+            case kIROp_GlobalVar:
+                {
+                    // A "global variable" in HLSL (and thus Slang) is actually
+                    // a weird kind of thread-local variable, and so it cannot
+                    // actually be lowered to a global variable on targets where
+                    // globals behave like, well, globals.
+                    //
+                    auto globalVar = cast<IRGlobalVar>(inst);
+
+                    // One important exception is that CUDA *does* support
+                    // global variables with the `__shared__` qualifer, with
+                    // semantics that exactly match HLSL/Slang `groupshared`.
+                    //
+                    // We thus need to skip processing of global variables
+                    // that were marked `groupshared`. In our current IR,
+                    // this is represented as a variable with the `@GroupShared`
+                    // rate on its type.
+                    //
+                    if( m_target == CodeGenTarget::CUDASource )
+                    {
+                        if( as<IRGroupSharedRate>(globalVar->getRate()) )
+                            continue;
+                    }
+
+                    m_globalVars.add(globalVar);
+                }
+                break;
+
+            case kIROp_GlobalParam:
+                {
+                    // Global parameters are another HLSL/Slang concept
+                    // that doesn't have a parallel in langauges like C/C++.
+                    //
+                    auto globalParam = cast<IRGlobalParam>(inst);
+
+
+                    // One detail we need to be careful about is that as a result
+                    // of legalizing the varying parameters of kernels, we can end
+                    // up with global parameters for varying parameters on CUDA
+                    // (e.g., to represent `threadIdx`. We thus skip any global-scope
+                    // parameters that are varying instead of uniform.
+                    //
+                    auto layoutDecor = globalParam->findDecoration<IRLayoutDecoration>();
+                    SLANG_ASSERT(layoutDecor);
+                    auto layout = as<IRVarLayout>(layoutDecor->getLayout());
+                    SLANG_ASSERT(layout);
+                    if(isVaryingParameter(layout))
+                        continue;
+
+                    // Because of upstream passes, we expect there to be only a
+                    // single global uniform parameter (at most).
+                    //
+                    // Note: If we ever changed out mind about the representation
+                    // and wanted to support multiple global parameters, we could
+                    // easily generalize this code to work with a list.
+                    //
+                    SLANG_ASSERT(!m_globalUniformsParam);
+                    m_globalUniformsParam = globalParam;
+                }
+                break;
+
+            case kIROp_Func:
+                {
+                    // Every entry point function is going to need to be modified,
+                    // so that it can explicit create the context that other
+                    // operations will use.
+
+                    // We need to filter the IR functions to find only those
+                    // that represent entry points.
+                    //
+                    auto func = cast<IRFunc>(inst);
+                    if(!func->findDecoration<IREntryPointDecoration>())
+                        continue;
+
+                    m_entryPoints.add(func);
+                }
+                break;
+            }
+        }
+
+        // Now that we've capture all the relevant global entities from the IR,
+        // we can being to transform them in an appropriate order.
+        //
+        // The first step will be to create fields in the `KernelContext`
+        // type to represent any global parameters or global variables.
+        //
+        // The keys for the fields that are created will be remembered
+        // in a dictionary, so that we can find them later based on
+        // the global parameter/variable.
+        //
+        if( m_globalUniformsParam )
+        {
+            // For the parameter representing all the global uniform shader
+            // parameters, we create a field that exactly matches its type.
+            //
+            createContextStructField(m_globalUniformsParam, m_globalUniformsParam->getFullType());
+        }
+        for( auto globalVar : m_globalVars )
+        {
+            // A `IRGlobalVar` represents a pointer to where the variable is stored,
+            // so we need to create a field of the pointed-to type to represent it.
+            //
+            createContextStructField(globalVar, globalVar->getDataType()->getValueType());
+        }
+
+        // Once all the fields have been created, we can process the entry points.
+        //
+        // Each entry point will create a local `KernelContext` variable and
+        // initialize it based on the parameters passed to the entry point.
+        //
+        // The local variable introduced here will be registered as the representation
+        // of the context to be used in the body of the entry point.
+        //
+        for( auto entryPoint : m_entryPoints )
+        {
+            createContextForEntryPoint(entryPoint);
+        }
+
+        // Now that we've prepared all the entry points, we can make another
+        // pass over the global parameters/variables and start to replace
+        // their use sites with references to the fields of the context.
+        //
+        // Wherever a global parameter/variable is being referenced in a function,
+        // we will need to find or create a context value for that function
+        // to use. The context value for entry points has already been established
+        // above, but other functions will have an explicit context parameter
+        // added on demand.
+        //
+        if( m_globalUniformsParam )
+        {
+            replaceUsesOfGlobalParam(m_globalUniformsParam);
+        }
+        for( auto globalVar : m_globalVars )
+        {
+            replaceUsesOfGlobalVar(globalVar);
+        }
+    }
+
+    // As noted above, we will maintain mappings to record
+    // the key for the context field created for a global
+    // variable parameter, and to record the context pointer
+    // value to use for a function.
+    //
+    Dictionary<IRInst*, IRStructKey*> m_mapInstToContextFieldKey;
+    Dictionary<IRFunc*, IRInst*> m_mapFuncToContextPtr;
+
+    void createContextStructField(IRInst* originalInst, IRType* type)
+    {
+        // Creating a field in the context struct to represent
+        // `originalInst` is straightforward.
+
+        IRBuilder builder(m_sharedBuilder);
+        builder.setInsertBefore(m_contextStructType);
+
+        // We create a "key" for the new field, and then a field
+        // of the appropraite type.
+        //
+        auto key = builder.createStructKey();
+        auto field = builder.createStructField(m_contextStructType, key, type);
+
+        // If the original instruction had a name hint on it,
+        // then we transfer that name hint over to the key,
+        // so that the field will have the name of the former
+        // global variable/parameter.
+        //
+        if( auto nameHint = originalInst->findDecoration<IRNameHintDecoration>() )
+        {
+            nameHint->insertAtStart(key);
+        }
+
+        // Any other decorations on the original instruction
+        // (e.g., pertaining to layout) need to be transferred
+        // over to the field (not the key).
+        //
+        originalInst->transferDecorationsTo(field);
+
+        // We end by making note of the key that was created
+        // for the instruction, so that we can use the key
+        // to access the field later.
+        //
+        m_mapInstToContextFieldKey.Add(originalInst, key);
+    }
+
+    void createContextForEntryPoint(IRFunc* entryPointFunc)
+    {
+        // We can only introduce the explicit context into
+        // entry points that have definitions.
+        //
+        auto firstBlock = entryPointFunc->getFirstBlock();
+        if(!firstBlock)
+            return;
+
+        IRBuilder builder(m_sharedBuilder);
+
+        // The code we introduce will all be added to the start
+        // of the first block of the function.
+        //
+        auto firstOrdinary = firstBlock->getFirstOrdinaryInst();
+        builder.setInsertBefore(firstOrdinary);
+
+        // If there was a global-scope uniform parameter before,
+        // then we need to introduce an explicit parameter onto
+        // each entry-point function to represent it.
+        //
+        IRParam* globalUniformsParam = nullptr;
+        if( m_globalUniformsParam )
+        {
+            globalUniformsParam = builder.createParam(m_globalUniformsParam->getFullType());
+            if( auto nameHint = m_globalUniformsParam->findDecoration<IRNameHintDecoration>() )
+            {
+                builder.addNameHintDecoration(globalUniformsParam, nameHint->getNameOperand());
+            }
+
+            // The new parameter will be the last one in the
+            // parameter list of the entry point.
+            //
+            globalUniformsParam->insertBefore(firstOrdinary);
+        }
+
+        // The `KernelContext` to use inside the entry point
+        // will be a local variable declared in the first block.
+        //
+        auto contextVarPtr = builder.emitVar(m_contextStructType);
+        addKernelContextNameHint(contextVarPtr);
+        m_mapFuncToContextPtr.Add(entryPointFunc, contextVarPtr);
+
+        // If there is a global-scope uniform parameter, then
+        // we need to use our new explicit entry point parameter
+        // to inialize the corresponding field of the `KernelContext`
+        // before moving on with execution of the kernel body.
+        //
+        if(m_globalUniformsParam)
+        {
+            auto fieldKey = m_mapInstToContextFieldKey[m_globalUniformsParam];
+            auto fieldType = globalUniformsParam->getFullType();
+            auto fieldPtrType = builder.getPtrType(fieldType);
+
+            // We compute the addrress of the field and store the
+            // value of the parameter into it.
+            //
+            auto fieldPtr = builder.emitFieldAddress(fieldPtrType, contextVarPtr, fieldKey);
+            builder.emitStore(fieldPtr, globalUniformsParam);
+        }
+
+        // Note: at this point the `KernelContext` has additional
+        // fields for global variables that do not seem to have
+        // been initialized.
+        //
+        // Instead of making this pass take responsibility for initializing
+        // global variables, it is instead expected that clients will
+        // run the pass in `slang-ir-explicit-global-init` first,
+        // in order to move all initialization of globals into the
+        // entry point functions.
+    }
+
+    void replaceUsesOfGlobalParam(IRGlobalParam* globalParam)
+    {
+        IRBuilder builder(m_sharedBuilder);
+
+        // A global shader parameter was mapped to a field
+        // in the context structure, so we find the appropriate key.
+        //
+        auto key = m_mapInstToContextFieldKey[globalParam];
+
+        auto valType = globalParam->getFullType();
+        auto ptrType = builder.getPtrType(valType);
+
+        // We then iterate over the uses of the parameter,
+        // being careful to defend against the use/def information
+        // being changed while we walk it.
+        //
+        IRUse* nextUse = nullptr;
+        for( IRUse* use = globalParam->firstUse; use; use = nextUse )
+        {
+            nextUse = use->nextUse;
+
+            // At each use site, we need to look up the context
+            // pointer that is appropriate for that use.
+            //
+            auto user = use->getUser();
+            auto contextParam = findOrCreateContextPtrForInst(user);
+            builder.setInsertBefore(user);
+
+            // The value of the parameter can be produced by
+            // taking the address of the corresponding field
+            // in the context struct and loading from it.
+            //
+            auto ptr = builder.emitFieldAddress(ptrType, contextParam, key);
+            auto val = builder.emitLoad(valType, ptr);
+            use->set(val);
+        }
+    }
+
+    void replaceUsesOfGlobalVar(IRGlobalVar* globalVar)
+    {
+        IRBuilder builder(m_sharedBuilder);
+
+        // A global variable was mapped to a field
+        // in the context structure, so we find the appropriate key.
+        //
+        auto key = m_mapInstToContextFieldKey[globalVar];
+
+        auto ptrType = globalVar->getDataType();
+
+        // We then iterate over the uses of the variable,
+        // being careful to defend against the use/def information
+        // being changed while we walk it.
+        //
+        IRUse* nextUse = nullptr;
+        for( IRUse* use = globalVar->firstUse; use; use = nextUse )
+        {
+            nextUse = use->nextUse;
+
+            // At each use site, we need to look up the context
+            // pointer that is appropriate for that use.
+            //
+            auto user = use->getUser();
+            auto contextParam = findOrCreateContextPtrForInst(user);
+            builder.setInsertBefore(user);
+
+            // The address of the variable can be produced by
+            // taking the address of the corresponding field
+            // in the context struct.
+            //
+            auto ptr = builder.emitFieldAddress(ptrType, contextParam, key);
+            use->set(ptr);
+        }
+    }
+
+    IRInst* findOrCreateContextPtrForInst(IRInst* inst)
+    {
+        // When looking up the context pointer to use for
+        // an instruction, we need to find the enclosing
+        // function and use whatever context pointer it uses.
+        //
+        for( IRInst* i = inst; i; i = i->getParent() )
+        {
+            if( auto func = as<IRFunc>(i) )
+            {
+                return findOrCreateContextPtrForFunc(func);
+            }
+        }
+
+        // If a non-constant global entity is being referenced by
+        // something that is *not* nested under an IR function, then
+        // we are in trouble.
+        //
+        SLANG_UNEXPECTED("no outer func at use site for global");
+        UNREACHABLE_RETURN(nullptr);
+    }
+
+    IRInst* findOrCreateContextPtrForFunc(IRFunc* func)
+    {
+        // At this point we are being asked to either find or
+        // produce a context pointer for use inside `func`.
+        //
+        // If we already created such a pointer (perhaps because
+        // `func` is an entry point), then we are home free.
+        //
+        if( auto found = m_mapFuncToContextPtr.TryGetValue(func) )
+        {
+            return *found;
+        }
+
+        // Otherwise, we are going to need to introduce an
+        // explicit parameter to `func` to represent the
+        // context.
+        //
+        IRBuilder builder(m_sharedBuilder);
+
+        // We can safely assume that `func` has a body, because
+        // otherwise we wouldn't be getting a request for the
+        // context pointer value to use in its body.
+        //
+        auto firstBlock = func->getFirstBlock();
+        SLANG_ASSERT(firstBlock);
+
+        // We create a new parameter at the end of the parameter
+        // list for `func`, with a type of `KernelContext*`.
+        //
+        IRParam* contextParam = builder.createParam(m_contextStructPtrType);
+        addKernelContextNameHint(contextParam);
+        contextParam->insertBefore(firstBlock->getFirstOrdinaryInst());
+
+        // The new parameter can be registerd as the context value
+        // to be used for `func` right away.
+        //
+        // Note: we register the value *before* modifying locations
+        // that call `func` to protect against a possible infinite-recursion
+        // situation if `func` is recursive along some path.
+        //
+        m_mapFuncToContextPtr.Add(func, contextParam);
+
+        // Any code that calls `func` now needs to be updated to pass
+        // the context parameter.
+        //
+        // TODO: There is an issue here if `func` might be called
+        // dynamically, through something like a witness table.
+        //
+        List<IRUse*> uses;
+        for( auto use = func->firstUse; use; use = use->nextUse )
+        {
+            // We will only fix up calls to `func`, and ignore
+            // other operations that might refer to it.
+            //
+            // TODO: We need to allow things like decorations that might
+            // refer to `func`, but this logic is also going to
+            // ignore things like witness tables that refer to `func`,
+            // or operations that pass `func` as a function pointer
+            // to a higher-order function.
+            //
+            auto call = as<IRCall>(use->getUser());
+            if(!call)
+                continue;
+
+            // We are going to construct a new call to `func`
+            // that has all of the arguments of the original call...
+            //
+            UInt originalArgCount = call->getArgCount();
+            List<IRInst*> args;
+            for( UInt aa = 0; aa < originalArgCount; ++aa )
+            {
+                args.add(call->getArg(aa));
+            }
+
+            // ... plus an additional argument representing
+            // the context pointer at the call site (note that
+            // this step leads to a potential for recursion in this pass;
+            // the maximum depth of the recursion is bounded by the
+            // maximum length of a cycle-free path through the call
+            // graph of the program).
+            //
+            args.add(findOrCreateContextPtrForInst(call));
+
+            // The new call will be emitted right before the old one,
+            // then used to replace it.
+            //
+            builder.setInsertBefore(call);
+            auto newCall = builder.emitCallInst(call->getFullType(), call->getCallee(), args);
+            call->replaceUsesWith(newCall);
+            call->removeAndDeallocate();
+        }
+
+        return contextParam;
+    }
+
+    // Because we have multiple places where instructions representing
+    // the kernel context get introduced, we have factored out a subroutine
+    // for setting up the name hint to be used by those instructions.
+    //
+    void addKernelContextNameHint(IRInst* inst)
+    {
+        IRBuilder builder(m_sharedBuilder);
+        builder.addNameHintDecoration(inst, UnownedTerminatedStringSlice("kernelContext"));
+    }
+};
+
+    /// Collect global-scope variables/paramters to form an explicit context that gets threaded through
+void introduceExplicitGlobalContext(
+    IRModule*       module,
+    CodeGenTarget   target)
+{
+    IntroduceExplicitGlobalContextPass pass;
+    pass.m_module = module;
+    pass.m_target = target;
+    pass.processModule();
+}
+
+}

--- a/source/slang/slang-ir-explicit-global-context.h
+++ b/source/slang/slang-ir-explicit-global-context.h
@@ -1,0 +1,15 @@
+// slang-ir-explicit-global-context.h
+#pragma once
+
+#include "slang-compiler.h"
+
+namespace Slang
+{
+struct IRModule;
+
+    /// Collect global-scope variables/paramters to form an explicit context that gets threaded through
+void introduceExplicitGlobalContext(
+    IRModule*       module,
+    CodeGenTarget   target);
+
+}

--- a/source/slang/slang-ir-explicit-global-init.cpp
+++ b/source/slang/slang-ir-explicit-global-init.cpp
@@ -1,0 +1,207 @@
+// slang-ir-explicit-global-init.cpp
+#include "slang-ir-explicit-global-init.h"
+
+#include "slang-ir-insts.h"
+
+namespace Slang
+{
+
+// This pass is responsible for taking code in a form like:
+//
+//      static int gCounter = 1;
+//
+//      void computeMain()
+//      {
+//          ...
+//          int tmp = gCounter++;
+//      }
+//
+// and transforming it so that the initialization of global
+// variables is performed explicitly at the start of each
+// entry-point funciton:
+//
+//      static int gCounter;
+//
+//      void computeMain()
+//      {
+//          gCounter = 1;
+//          ...
+//          int tmp = gCounter++;
+//      }
+//
+// Transforming the code in this way may be required for targets
+// that do not support initial-value expressions on global
+// variables (e.g., SPIR-V is such a target). It can also be
+// useful as a pre-process before other transformations that
+// might work with global variables, because after this change
+// there cannot be any global variables with initializers.
+
+struct MoveGlobalVarInitializationToEntryPointsPass
+{
+    IRModule* m_module;
+
+    SharedIRBuilder* m_sharedBuilder;
+
+    // In the Slang IR, a global variable represents a pointer
+    // to the storage for the variable but it *also* encodes
+    // the logic used to compute the initial value of that
+    // variable. This works because `IRGlobalVar` is a subtype
+    // of `IRGlobalValueWithCode`, which is also the base
+    // type of `IRFunc`. Thus a global variable behaves a
+    // bit like a function, which just happens to compute
+    // the initial value for the variable.
+    //
+    // Part of the work in this pass will be to split those
+    // two pars of the variable, so that we end up with
+    // a global variable with not initialization logic,
+    // plus an ordinary `IRFunc` to compute the initial
+    // value.
+    //
+    // We will compute this split representation and then
+    // hold onto it so that we can use it for injecting
+    // the initialization logic into entry points.
+    //
+    struct GlobalVarInfo
+    {
+        IRGlobalVar*    globalVar   = nullptr;
+        IRFunc*         initFunc    = nullptr;
+    };
+    List<GlobalVarInfo> m_globalVarsWithInit;
+
+    void processModule(IRModule* module)
+    {
+        m_module = module;
+
+        SharedIRBuilder sharedBuilder(module);
+        m_sharedBuilder = &sharedBuilder;
+
+        // We start by looking for global variables with
+        // initialization logic in the IR, and processing
+        // each to produce a split variable (now without
+        // initialization) and function (to compute the
+        // initial value).
+        //
+        for( auto inst : m_module->getGlobalInsts() )
+        {
+            auto globalVar = as<IRGlobalVar>(inst);
+            if(!globalVar)
+                continue;
+
+            auto firstBlock = globalVar->getFirstBlock();
+            if(!firstBlock)
+                continue;
+
+            processGlobalVarWithInit(globalVar, firstBlock);
+        }
+
+        // Then we loop over all the entry points in the
+        // module and modify them to explicitly initialize
+        // all the global variables that were identified
+        // and processed in the first pass.
+        //
+        for( auto inst : m_module->getGlobalInsts() )
+        {
+            auto func = as<IRFunc>(inst);
+            if(!func)
+                continue;
+
+            if(!func->findDecoration<IREntryPointDecoration>())
+                continue;
+
+            processEntryPoint(func);
+        }
+    }
+
+    void processGlobalVarWithInit(IRGlobalVar* globalVar, IRBlock* firstBlock)
+    {
+        IRBuilder builder(m_sharedBuilder);
+        builder.setInsertBefore(globalVar);
+
+        // Becaue an `IRGlobalVar` reprsents a pointer to the storage
+        // for the variable, we need to extract the underlying value
+        // type from the pointer type.
+        //
+        auto valueType = globalVar->getDataType()->getValueType();
+
+        // We are going to construct an explicit IR function to compute
+        // the initial value of the variable. That function will alway
+        // take zero parameters.
+        //
+        auto initFunc = builder.createFunc();
+        initFunc->setFullType(builder.getFuncType(0, nullptr, valueType));
+
+        // The basic blocks under teh `IRGlobalVar` define its initialization
+        // logic, and we can simply move those blocks over to the new
+        // `IRFunc` to define its behavior.
+        //
+        // As a result, the `globalVar` will no longer have its own
+        // initialization logic, which is a postcondition this pass
+        // needed to guarantee.
+        //
+        IRBlock* nextBlock = nullptr;
+        for( IRBlock* block = firstBlock; block; block = nextBlock )
+        {
+            nextBlock = block->getNextBlock();
+
+            block->removeFromParent();
+            block->insertAtEnd(initFunc);
+        }
+
+        // We need to remember the variable and the assocaited
+        // initial-value function so that we can iterate over
+        // them in the per-entry-point logic below.
+        //
+        GlobalVarInfo info;
+        info.globalVar = globalVar;
+        info.initFunc = initFunc;
+        m_globalVarsWithInit.add(info);
+    }
+
+    void processEntryPoint(IRFunc* entryPointFunc)
+    {
+        // We can only process entry point definitions, not declarations.
+        //
+        auto firstBlock = entryPointFunc->getFirstBlock();
+        if(!firstBlock)
+            return;
+
+        // We are going to insert initiailization logic at the start
+        // of the first block of the entry point.
+        //
+        IRBuilder builder(m_sharedBuilder);
+        builder.setInsertBefore(firstBlock->getFirstOrdinaryInst());
+
+        for( auto globalVarInfo : m_globalVarsWithInit )
+        {
+            // The earlier step split each global variable into
+            // a variable with no initialization logic, plus a function
+            // that can be called to compute the initial value.
+            //
+            auto globalVar = globalVarInfo.globalVar;
+            auto initFunc = globalVarInfo.initFunc;
+
+            // Because the `IRGlobalVar` represents a pointer to
+            // storage, we need to get the pointed-to type to
+            // get the type of the initial value.
+            //
+            auto valType = globalVar->getDataType()->getValueType();
+
+            // We compute the initial value for the variable by calling
+            // the initial-value function with no arguments, and then
+            // we store that value into the corresponding global.
+            //
+            auto initVal = builder.emitCallInst(valType, initFunc, 0, nullptr);
+            builder.emitStore(globalVar, initVal);
+        }
+    }
+};
+
+    /// Move initialization logic off of global variables and onto each entry point
+void moveGlobalVarInitializationToEntryPoints(
+    IRModule* module)
+{
+    MoveGlobalVarInitializationToEntryPointsPass pass;
+    pass.processModule(module);
+}
+
+}

--- a/source/slang/slang-ir-explicit-global-init.h
+++ b/source/slang/slang-ir-explicit-global-init.h
@@ -1,0 +1,11 @@
+// slang-ir-explicit-global-init.h
+#pragma once
+
+namespace Slang
+{
+struct IRModule;
+
+    /// Move initialization logic off of global variables and onto each entry point
+void moveGlobalVarInitializationToEntryPoints(
+    IRModule* module);
+}

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -1124,6 +1124,10 @@ struct IRVarLayout : IRLayout
     };
 };
 
+bool isVaryingResourceKind(LayoutResourceKind kind);
+bool isVaryingParameter(IRTypeLayout* typeLayout);
+bool isVaryingParameter(IRVarLayout* varLayout);
+
     /// Associate layout information with an instruction.
     ///
     /// This decoration is used in three main ways:
@@ -1402,6 +1406,8 @@ struct IRVar : IRInst
 /// blocks nested inside this value.
 struct IRGlobalVar : IRGlobalValueWithCode
 {
+    IR_LEAF_ISA(GlobalVar)
+
     IRPtrType* getDataType()
     {
         return cast<IRPtrType>(IRInst::getDataType());

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -406,7 +406,8 @@ protected:
         m_paramLayout = as<IRVarLayout>(paramLayoutDecoration->getLayout());
         SLANG_ASSERT(m_paramLayout);
 
-        // TODO: We need to detect and skip parameters here that are not varying.
+        if(!isVaryingParameter(m_paramLayout))
+            return;
 
         // TODO: The GLSL-specific variant of this pass has several
         // special cases that handle entry-point parameters for things like

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -227,7 +227,9 @@
     <ClInclude Include="slang-ir-constexpr.h" />
     <ClInclude Include="slang-ir-dce.h" />
     <ClInclude Include="slang-ir-dominators.h" />
+    <ClInclude Include="slang-ir-entry-point-raw-ptr-params.h" />
     <ClInclude Include="slang-ir-entry-point-uniforms.h" />
+    <ClInclude Include="slang-ir-explicit-global-init.h" />
     <ClInclude Include="slang-ir-glsl-legalize.h" />
     <ClInclude Include="slang-ir-inline.h" />
     <ClInclude Include="slang-ir-inst-defs.h" />
@@ -237,6 +239,7 @@
     <ClInclude Include="slang-ir-link.h" />
     <ClInclude Include="slang-ir-lower-generics.h" />
     <ClInclude Include="slang-ir-missing-return.h" />
+    <ClInclude Include="slang-ir-explicit-global-context.h" />
     <ClInclude Include="slang-ir-restructure-scoping.h" />
     <ClInclude Include="slang-ir-restructure.h" />
     <ClInclude Include="slang-ir-sccp.h" />
@@ -319,7 +322,9 @@
     <ClCompile Include="slang-ir-constexpr.cpp" />
     <ClCompile Include="slang-ir-dce.cpp" />
     <ClCompile Include="slang-ir-dominators.cpp" />
+    <ClCompile Include="slang-ir-entry-point-raw-ptr-params.cpp" />
     <ClCompile Include="slang-ir-entry-point-uniforms.cpp" />
+    <ClCompile Include="slang-ir-explicit-global-init.cpp" />
     <ClCompile Include="slang-ir-glsl-legalize.cpp" />
     <ClCompile Include="slang-ir-inline.cpp" />
     <ClCompile Include="slang-ir-layout.cpp" />
@@ -328,6 +333,7 @@
     <ClCompile Include="slang-ir-link.cpp" />
     <ClCompile Include="slang-ir-lower-generics.cpp" />
     <ClCompile Include="slang-ir-missing-return.cpp" />
+    <ClCompile Include="slang-ir-explicit-global-context.cpp" />
     <ClCompile Include="slang-ir-restructure-scoping.cpp" />
     <ClCompile Include="slang-ir-restructure.cpp" />
     <ClCompile Include="slang-ir-sccp.cpp" />
@@ -420,4 +426,4 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
-</Project> 
+</Project>

--- a/source/slang/slang.vcxproj.filters
+++ b/source/slang/slang.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Header Files">
@@ -279,6 +279,13 @@
     <ClInclude Include="slang-visitor.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="slang-ir-explicit-global-context.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="slang-ir-entry-point-raw-ptr-params.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="slang-ir-explicit-global-init.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="slang-ast-builder.cpp">
@@ -545,6 +552,13 @@
     <ClCompile Include="slang.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="slang-ir-explicit-global-context.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="slang-ir-entry-point-raw-ptr-params.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="slang-ir-explicit-global-init.cpp" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="core.meta.slang">

--- a/tools/render-test/render-test-tool.vcxproj
+++ b/tools/render-test/render-test-tool.vcxproj
@@ -98,8 +98,8 @@
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>_DEBUG;SLANG_SHARED_LIBRARY_TOOL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..;..\..\external;..\..\source;..\gfx;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_DEBUG;SLANG_SHARED_LIBRARY_TOOL;RENDER_TEST_CUDA;RENDER_TEST_OPTIX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..;..\..\external;..\..\source;..\gfx;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\include;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\common\inc;C:\ProgramData\NVIDIA Corporation\OptiX SDK 7.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -107,6 +107,8 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cuda.lib;cudart.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\lib\Win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ImportLibrary>..\..\bin\windows-x86\debug\render-test-tool.lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
@@ -117,8 +119,8 @@
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>_DEBUG;SLANG_SHARED_LIBRARY_TOOL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..;..\..\external;..\..\source;..\gfx;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_DEBUG;SLANG_SHARED_LIBRARY_TOOL;RENDER_TEST_CUDA;RENDER_TEST_OPTIX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..;..\..\external;..\..\source;..\gfx;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\include;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\common\inc;C:\ProgramData\NVIDIA Corporation\OptiX SDK 7.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -126,6 +128,8 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cuda.lib;cudart.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ImportLibrary>..\..\bin\windows-x64\debug\render-test-tool.lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
@@ -136,8 +140,8 @@
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>NDEBUG;SLANG_SHARED_LIBRARY_TOOL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..;..\..\external;..\..\source;..\gfx;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;SLANG_SHARED_LIBRARY_TOOL;RENDER_TEST_CUDA;RENDER_TEST_OPTIX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..;..\..\external;..\..\source;..\gfx;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\include;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\common\inc;C:\ProgramData\NVIDIA Corporation\OptiX SDK 7.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -149,6 +153,8 @@
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>cuda.lib;cudart.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\lib\Win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ImportLibrary>..\..\bin\windows-x86\release\render-test-tool.lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
@@ -159,8 +165,8 @@
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>NDEBUG;SLANG_SHARED_LIBRARY_TOOL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..;..\..\external;..\..\source;..\gfx;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;SLANG_SHARED_LIBRARY_TOOL;RENDER_TEST_CUDA;RENDER_TEST_OPTIX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..;..\..\external;..\..\source;..\gfx;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\include;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\common\inc;C:\ProgramData\NVIDIA Corporation\OptiX SDK 7.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -172,6 +178,8 @@
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>cuda.lib;cudart.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ImportLibrary>..\..\bin\windows-x64\release\render-test-tool.lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
@@ -181,6 +189,7 @@
   <ItemGroup>
     <ClInclude Include="bind-location.h" />
     <ClInclude Include="cpu-compute-util.h" />
+    <ClInclude Include="cuda\cuda-compute-util.h" />
     <ClInclude Include="options.h" />
     <ClInclude Include="png-serialize-util.h" />
     <ClInclude Include="shader-input-layout.h" />
@@ -191,6 +200,7 @@
   <ItemGroup>
     <ClCompile Include="bind-location.cpp" />
     <ClCompile Include="cpu-compute-util.cpp" />
+    <ClCompile Include="cuda\cuda-compute-util.cpp" />
     <ClCompile Include="options.cpp" />
     <ClCompile Include="png-serialize-util.cpp" />
     <ClCompile Include="render-test-main.cpp" />

--- a/tools/render-test/render-test-tool.vcxproj.filters
+++ b/tools/render-test/render-test-tool.vcxproj.filters
@@ -15,6 +15,9 @@
     <ClInclude Include="cpu-compute-util.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="cuda\cuda-compute-util.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="options.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -39,6 +42,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="cpu-compute-util.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="cuda\cuda-compute-util.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="options.cpp">


### PR DESCRIPTION
Currently, the CPU and CUDA C++ targets rely on a `KernelContext` type that is generated during emit, as a way to provide implicit access to things that were global in the input Slang code, but that can't actually be emitted as globals in the target language (because the semantics of global declarations differ).

For example, input like:

```hlsl
ConstantBuffer<Stuff> gStuff; // shader parameter
groupshared int gData[1024];  // thread-group shared variable
static int gCounter = 0;      // "thread-local" global-scope variable

void subroutine() { ... }

[shader("compute")] void computeMain() { ... }
```

would translate to output C++ for CPU a bit like:

```c++
struct KernelContext
{
    ConstantBuffer<Stuff> gStuff;
    int gData[1024];
    int gCounter = 0;

    void subroutine() { ... }

    void computeMain() { ... }
};
```

Note that both `computeMain()` and `subroutine()` are non-`static` members functions on `KernelContext`, so they have an implicit `this` parameter of type `KernelContext`, which allows the bodies of those functions to implicitly reference `gStuff`, etc. by name in their bodies.

Because `KernelContext::computeMain()` is a member function, we end up emitting an additional global-scope function to expose the entry point to the outside world, and that function is responsible for declaring a local `KernelContext` and invoking the generated entry point on it.

This approach has several important drawbacks:

* It complicates the emit logic for CPU and CUDA, with many special cases around when/how things get emitted

* It complicates the implementation of dynamic dispatch, because what seems like a function pointer in Slang IR needs to be a pointer-to-member-function in C++.

* It makes it difficult to have a non-kernel-oriented mode of compilation for CPU where a Slang function with a given signature gets output as a C++ CPU function with the "same" signature (not wrapped up as a member function of `KernelContext`.

This change makes a step toward addressing these issues by making the introducing of the `KernelContext` type be something that is done in an explicit IR pass instead of being handled as part of the last-mile emit logic.

The most important change is the removal of code related to `KernelContext` from the `slang-emit-{cpp,cuda}.{h,cpp}` files, with the equivalent logic instead being handled in a new pass in `slang-ir-explicit-global-context.{h,cpp}`. It should be noted that further cleanups to the emit logic should now be possible; in particular, both the CPU and CUDA emit paths are manually sequencing the `EmitAction`s instead of relying on the default logic, but at this point they should be able to just use the default. The additional cleanups are left for future work.

The explicit IR pass does more or less what one would expect: it identifies global-scope entities (global variables and parameters) that need to be wrapped and turns them into fields of a `KernelContext` type. It then modifies all entry points to initialize a `KernelContext` as part of their startup. Finally, any code that used to refer to the global entities is changed to refer to a field of the context, with the context passed via new function parameters (the new parameter is only added to functions that need it for now).

Transforming global variables into fields of a `KernelContext` type in the IR pass ends up dropping their initial-value expressions (since those were attached as basic blocks on the `IRGlobalVar`). To avoid breaking code that relies on global-scope (but thread-local) variables, this change also adds an explicit pass that takes the initialization logic on all global variables and moves it to explicit logic that runs at the start of every entry point in a linked module (`slang-ir-explicit-global-init.{h,cpp}`). This pass would also be useful when we get back to direct SPIR-V emit, since SPIR-V also requires initialization logic for globals to be emitted into entry points.

One complication that arises when the IR is introducing the types for entry-point parameters, global-scope parameters, and the `KernelContext` type is that it becomes harder for the emit logic to utter the names of those types (they might not even have names, since `IRNameHint`s might get stripped). This created a problem since the wrapper operations that were being generated for CPU were taking `void*` parameters and casting them to the appropriate type. To work around this issue, we have added an explicit IR pass (`slang-ir-entry-point-raw-ptr-params.{h,cpp}`) that transforms the signature of entry points so that any pointer parameters instead become raw pointer (`void*`) parameters, with the casting being handled inside the entry point itself.

One consequence of all the above changes is that for the CUDA target we no longer need a wrapper function to invoke the generated entry point any more, because the IR function for the entry point ends up having the correct/expected signature already. This is also the case for CPU when it comes to the `*_Thread` wrapper function, but this change doesn't try to eliminate the wrapper because of a belief that the `*_Thread`-level interface is going away anyway.

Because the IR is now responsible for ensuring the signature of the IR entry point for CUDA and CPU is what is expected, I needed to modify the `slang-ir-entry-point-uniforms` pass to always create an explicit parameter for the entry point uniforms when compiling for CUDA/CPU, even if there were no `uniform` parameters on the entry point as written. This also ended up requiring some tweaks to the parameter layout logic to ensure that CPU/CUDA targets always treat `ConstantBuffer<T>` as a `T*` even in the case where `T` is an empty `struct` type (which happens when we construct a `struct` type to represent the uniform parameters of an entry point with no uniform parameters...).

There are several future changes that can/should build on this work:

* We should change the generated signatures for CUDA kernels, so that they don't rely on `KernelContext` for global-scope parameters. At that point we can avoid generating a `KernelContext` at all for CUDA, except when a program uses global-scope thread-local variables.

* We should figure out how to make the "ABI" for dynamic-dispatch calls ensure that the kernel context is either always passed, or always *not* passed. Making a hard-and-fast rule as part of the calling convention for dynamic calls would ensure that they access through the context continues to work with dynamic calls (this change might break it in some cases).

* We should figure out how to handle the layout for the `KernelContext` in cases where a program is composed of multiple separately-compiled modules. Right now the layout of the `KernelContext` requires global knowledge (as does the pass that introduces explicit initialization for global-scope thread-locals).

* We should try to further clean up the CPU/CUDA C++ emit logic to fall back on the default emit behavior more, now that the various special-case approaches that were taken are no longer needed