### PR TITLE
Fix the way extension declarations are cached for lookup

### DIFF
--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -96,18 +96,12 @@ class ExtensionDecl : public AggTypeDeclBase
     SLANG_CLASS(ExtensionDecl)
 
     TypeExp targetType;
-
-    // next extension attached to the same nominal type
-    ExtensionDecl* nextCandidateExtension = nullptr;
 };
 
 // Declaration of a type that represents some sort of aggregate
 class AggTypeDecl : public  AggTypeDeclBase
 {
     SLANG_ABSTRACT_CLASS(AggTypeDecl)
-
-    // extensions that might apply to this declaration
-    ExtensionDecl* candidateExtensions = nullptr;
 
     FilteredMemberList<VarDecl> getFields()
     {
@@ -371,6 +365,12 @@ class ModuleDecl : public NamespaceDeclBase
     // its chain of parents.
     //
     Module* module = nullptr;
+
+        /// Map a type to the list of extensions of that type (if any) declared in this module
+        ///
+        /// This mapping is filled in during semantic checking, as `ExtensionDecl`s get checked.
+        ///
+    Dictionary<AggTypeDecl*, RefPtr<CandidateExtensionList>> mapTypeToCandidateExtensions;
 };
 
 class ImportDecl : public Decl

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -1337,6 +1337,14 @@ namespace Slang
     };
     typedef List<ExpandedSpecializationArg> ExpandedSpecializationArgs;
 
+        /// A reference-counted object to hold a list of candidate extensions
+        /// that might be applicable to a type based on its declaration.
+        ///
+    struct CandidateExtensionList : RefObject
+    {
+        List<ExtensionDecl*> candidateExtensions;
+    };
+
 } // namespace Slang
 
 #endif

--- a/source/slang/slang-check-conformance.cpp
+++ b/source/slang/slang-check-conformance.cpp
@@ -180,7 +180,8 @@ namespace Slang
             {
                 ensureDecl(aggTypeDeclRef, DeclCheckState::CanEnumerateBases);
 
-                for( auto inheritanceDeclRef : getMembersOfTypeWithExt<InheritanceDecl>(aggTypeDeclRef))
+                bool found = false;
+                foreachDirectOrExtensionMemberOfType<InheritanceDecl>(this, aggTypeDeclRef, [&](DeclRef<InheritanceDecl> const& inheritanceDeclRef)
                 {
                     ensureDecl(inheritanceDeclRef, DeclCheckState::CanUseBaseOfInheritanceDecl);
 
@@ -209,9 +210,12 @@ namespace Slang
 
                     if(_isDeclaredSubtype(originalSubType, inheritedType, superTypeDeclRef, outWitness, &breadcrumb))
                     {
-                        return true;
+                        found = true;
                     }
-                }
+                });
+                if(found)
+                    return true;
+
                 // if an inheritance decl is not found, try to find a GenericTypeConstraintDecl
                 for (auto genConstraintDeclRef : getMembersOfType<GenericTypeConstraintDecl>(aggTypeDeclRef))
                 {

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -199,8 +199,12 @@ namespace Slang
         /// Shared state for a semantics-checking session.
     struct SharedSemanticsContext
     {
-        Linkage* m_linkage = nullptr;
-        DiagnosticSink* m_sink = nullptr;
+        Linkage*        m_linkage   = nullptr;
+
+            /// The (optional) "primary" module that is the parent to everything that will be checked.
+        Module*         m_module    = nullptr;
+
+        DiagnosticSink* m_sink      = nullptr;
 
         DiagnosticSink* getSink()
         {
@@ -217,8 +221,10 @@ namespace Slang
     public:
         SharedSemanticsContext(
             Linkage*        linkage,
+            Module*         module,
             DiagnosticSink* sink)
             : m_linkage(linkage)
+            , m_module(module)
             , m_sink(sink)
         {}
 
@@ -231,6 +237,27 @@ namespace Slang
         {
             return m_linkage;
         }
+
+        Module* getModule()
+        {
+            return m_module;
+        }
+
+            /// Get the list of extension declarations that appear to apply to `decl` in this context
+        List<ExtensionDecl*> const& getCandidateExtensionsForTypeDecl(AggTypeDecl* decl);
+
+            /// Register a candidate extension `extDecl` for `typeDecl` encountered during checking.
+        void registerCandidateExtension(AggTypeDecl* typeDecl, ExtensionDecl* extDecl);
+
+    private:
+            /// Mapping from type declarations to the known extensiosn that apply to them
+        Dictionary<AggTypeDecl*, RefPtr<CandidateExtensionList>> m_mapTypeDeclToCandidateExtensions;
+
+            /// Is the `m_mapTypeDeclToCandidateExtensions` dictionary valid and up to date?
+        bool m_candidateExtensionListsBuilt = false;
+
+            /// Add candidate extensions declared in `moduleDecl` to `m_mapTypeDeclToCandidateExtensions`
+        void _addCandidateExtensionsFromModule(ModuleDecl* moduleDecl);
     };
 
     struct SemanticsVisitor

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -954,7 +954,7 @@ namespace Slang
     {
         SLANG_ASSERT(argCount == getSpecializationParamCount());
 
-        SharedSemanticsContext semanticsContext(getLinkage(), sink);
+        SharedSemanticsContext semanticsContext(getLinkage(), this, sink);
         SemanticsVisitor visitor(&semanticsContext);
 
         RefPtr<Module::ModuleSpecializationInfo> specializationInfo = new Module::ModuleSpecializationInfo();
@@ -1129,7 +1129,7 @@ namespace Slang
     {
         auto linkage = componentType->getLinkage();
 
-        SharedSemanticsContext semanticsContext(linkage, sink);
+        SharedSemanticsContext semanticsContext(linkage, nullptr, sink);
         SemanticsVisitor semanticsVisitor(&semanticsContext);
 
         auto argCount = argExprs.getCount();
@@ -1152,7 +1152,7 @@ namespace Slang
         auto args = inArgs;
         auto argCount = inArgCount;
 
-        SharedSemanticsContext sharedSemanticsContext(getLinkage(), sink);
+        SharedSemanticsContext sharedSemanticsContext(getLinkage(), nullptr, sink);
         SemanticsVisitor visitor(&sharedSemanticsContext);
 
         // The first N arguments will be for the explicit generic parameters
@@ -1331,6 +1331,7 @@ namespace Slang
 
         SharedSemanticsContext sharedSemanticsContext(
             linkage,
+            nullptr,
             sink);
         SemanticsVisitor semantics(&sharedSemanticsContext);
 
@@ -1367,7 +1368,7 @@ namespace Slang
         // TODO: We should cache and re-use specialized types
         // when the exact same arguments are provided again later.
 
-        SharedSemanticsContext sharedSemanticsContext(this, sink);
+        SharedSemanticsContext sharedSemanticsContext(this, nullptr, sink);
         SemanticsVisitor visitor(&sharedSemanticsContext);
 
         SpecializationParams specializationParams;
@@ -1425,7 +1426,7 @@ namespace Slang
         // We have an appropriate number of arguments for the global specialization parameters,
         // and now we need to check that the arguments conform to the declared constraints.
         //
-        SharedSemanticsContext visitor(linkage, sink);
+        SharedSemanticsContext visitor(linkage, nullptr, sink);
 
         List<SpecializationArg> specializationArgs;
         _extractSpecializationArgs(unspecializedProgram, specializationArgExprs, specializationArgs, sink);

--- a/source/slang/slang-check-type.cpp
+++ b/source/slang/slang-check-type.cpp
@@ -13,6 +13,7 @@ namespace Slang
     {
         SharedSemanticsContext sharedSemanticsContext(
             linkage,
+            nullptr,
             sink);
         SemanticsVisitor visitor(&sharedSemanticsContext);
 

--- a/source/slang/slang-check.cpp
+++ b/source/slang/slang-check.cpp
@@ -201,6 +201,7 @@ namespace Slang
     {
         SharedSemanticsContext sharedSemanticsContext(
             translationUnit->compileRequest->getLinkage(),
+            translationUnit->getModule(),
             translationUnit->compileRequest->getSink());
 
         SemanticsDeclVisitorBase visitor(&sharedSemanticsContext);

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -2078,7 +2078,7 @@ namespace Slang
         RefPtr<Scope>   slangLanguageScope;
 
         ModuleDecl* baseModuleDecl = nullptr;
-        List<RefPtr<Module>> loadedModuleCode;
+        List<RefPtr<Module>> stdlibModules;
 
         SourceManager   builtinSourceManager;
 

--- a/source/slang/slang-lookup.cpp
+++ b/source/slang/slang-lookup.cpp
@@ -492,7 +492,7 @@ static void _lookUpMembersInSuperTypeDeclImpl(
                 // directly with that type.
                 //
                 ensureDecl(request.semantics, aggTypeDeclRef.getDecl(), DeclCheckState::ReadyForLookup);
-                for(auto extDecl = getCandidateExtensions(aggTypeDeclRef); extDecl; extDecl = extDecl->nextCandidateExtension)
+                for(auto extDecl : getCandidateExtensions(aggTypeDeclRef, semantics))
                 {
                     // Note: In this case `extDecl` is an extension that was declared to apply
                     // (conditionally) to `aggTypeDeclRef`, which is the decl-ref part of

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -1242,16 +1242,24 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return rs;
     }
 
-    
-    
-Module* getModule(Decl* decl)
+
+ModuleDecl* getModuleDecl(Decl* decl)
 {
     for( auto dd = decl; dd; dd = dd->parentDecl )
     {
         if(auto moduleDecl = as<ModuleDecl>(dd))
-            return moduleDecl->module;
+            return moduleDecl;
     }
     return nullptr;
+}
+
+Module* getModule(Decl* decl)
+{
+    auto moduleDecl = getModuleDecl(decl);
+    if(!moduleDecl)
+        return nullptr;
+
+    return moduleDecl->module;
 }
 
 bool findImageFormatByName(char const* name, ImageFormat* outFormat)

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -2683,13 +2683,13 @@ void Session::addBuiltinSource(
 
     // We need to retain this AST so that we can use it in other code
     // (Note that the `Scope` type does not retain the AST it points to)
-    loadedModuleCode.add(module);
+    stdlibModules.add(module);
 }
 
 Session::~Session()
 {
     // destroy modules next
-    loadedModuleCode = decltype(loadedModuleCode)();
+    stdlibModules = decltype(stdlibModules)();
 }
 
 }

--- a/tests/bugs/extension-lifetime.slang
+++ b/tests/bugs/extension-lifetime.slang
@@ -1,0 +1,41 @@
+// extension-lifetime.slang
+
+// This test is a regresion test for a bug where `extension`
+// declarations are incorrectly being cached on the declarations
+// they extend, so that an extension of a stdlib type (like `float`)
+// ends up attaching a declaration from one compile request to that
+// type, and then later compile requests that use that stdlib type
+// try to look up through that extension even though (1) that
+// shouldn't make sense semantically, and (2) that extension will
+// have been deallocated when its parent compile request was
+// destroyed.
+//
+// This test relies on the fact that our test runner uses a single
+// slang compilation session (which loads the stdlib code) across
+// multiple compilation tests. We can thus make this file contain
+// two identical tests, with the knowledge that the second one
+// will lead to the bad/crashing behavior if the first one ran
+// and did a Bad Thing.
+
+//TEST:SIMPLE:
+//TEST:SIMPLE:
+
+interface IThing
+{
+	float getThing();
+}
+
+extension float : IThing
+{
+	float getThing() { return this; }
+}
+
+float getThing<T : IThing>(T value)
+{
+	return value.getThing();
+}
+
+float test( float value )
+{
+	return getThing(value);
+}

--- a/tests/diagnostics/extension-visibility-a.slang
+++ b/tests/diagnostics/extension-visibility-a.slang
@@ -1,0 +1,17 @@
+// extension-visibility-a.slang
+
+interface IThing
+{
+	int getValue();
+}
+
+// Note: not implementing the interface here!
+struct MyThing
+{
+	int value;
+}
+
+int helper<T : IThing>(T thing)
+{
+	return thing.getValue();
+}

--- a/tests/diagnostics/extension-visibility-b.slang
+++ b/tests/diagnostics/extension-visibility-b.slang
@@ -1,0 +1,8 @@
+// extension-visibility-b.slang
+
+import extension_visibility_a;
+
+extension MyThing : IThing
+{
+	int getValue() { return value; }	
+}

--- a/tests/diagnostics/extension-visibility-c.slang
+++ b/tests/diagnostics/extension-visibility-c.slang
@@ -1,0 +1,9 @@
+// extension-visibility-c.slang
+
+import extension_visibility_a;
+import extension_visibility_b;
+
+int works(MyThing thing)
+{
+	return helper(thing);
+}

--- a/tests/diagnostics/extension-visibility.slang
+++ b/tests/diagnostics/extension-visibility.slang
@@ -1,0 +1,18 @@
+// extension-visibility.slang
+
+// Confirm that visibility of `extensions` is
+// correctly scoped via `import`.
+
+//DIAGNOSTIC_TEST:SIMPLE:
+
+import extension_visibility_a;
+
+// Note: not importing b:
+// import extension_visibility_b;
+
+import extension_visibility_c;
+
+int shouldntWork(MyThing thing)
+{
+	return helper(thing);
+}

--- a/tests/diagnostics/extension-visibility.slang.expected
+++ b/tests/diagnostics/extension-visibility.slang.expected
@@ -1,0 +1,7 @@
+result code = -1
+standard error = {
+tests/diagnostics/extension-visibility.slang(17): error 39999: could not specialize generic for arguments of type (MyThing)
+tests/diagnostics/extension-visibility-a.slang(14): note 39999: see declaration of func helper<T>(T) -> int
+}
+standard output = {
+}

--- a/tests/language-feature/extensions/extension-import-helper.slang
+++ b/tests/language-feature/extensions/extension-import-helper.slang
@@ -1,0 +1,13 @@
+// extension-import-helper.slang
+
+//TEST_IGNORE_FILE:
+
+interface IThing
+{
+	float getValue();
+}
+
+extension float : IThing
+{
+	float getValue() { return this; }
+}

--- a/tests/language-feature/extensions/extension-import.slang
+++ b/tests/language-feature/extensions/extension-import.slang
@@ -1,0 +1,17 @@
+// extension-import.slang
+
+// Confirm that visibility of extensions through `import` is working.
+
+//TEST:SIMPLE:
+
+import extension_import_helper;
+
+float test<T : IThing>(T value)
+{
+	return value.getValue();
+}
+
+float id(float x)
+{
+	return test(x);
+}


### PR DESCRIPTION
During semantic checking, the compiler used to link together `ExtensionDecl`s into a singly-linked list dangling off of the `AggTypeDecl` that they applied to. This approach made lookup relatively easy, because given a `DeclRef` to an `AggTypeDecl` one could easily find and walk the list of candidate extensions.

Unfortunately, the simple approach has two major strikes against it:

* First, as we recently ran into, it creates a lifetime/ownership problem, in cases where the `ExtensionDecl` is outlived by the `AggTypeDecl` it applies to. This creates the one and only place in the compiler today where an "old" AST node might point to a "new" AST node, and it resulted in use-after-free problems in client code.

* Second, the scoping of `extension`s ends up being completely wrong. All of the `extension` methods on a type end up being visible in all cases, instead of just in the context of modules where the `extension` itself is visible. The comparable feature in C# (static extension methods) is careful to not make scoping mistakes like this. The Swift langauge has loose scoping for `extension` more akin to what we have in Slang today, but the maintainers seem to consider it a misfeature.

This change attempts to clean up both issues by changing the way that extension declarations are stored. There are two main pieces:

1. The primary "source of truth" for extension lookup has been moved to the `ModuleDecl`, where a module is responsible for storing a cache of the extensions declared within that module (keyed by the declaration of the type being extended). This cache is updated at the same point where the old code would mutate the AST node being depended on.

2. A secondary aggregated cache is added to the `SharedSemanticsContext` used during semantic checking. This cache includes entries from across multiple modules, and is intended to be invalidated and rebuilt on demand if new modules are added during checking.

Access to the candidate extensions has now been put behind subroutines that require a semantics-checking context to be passed in (there was always one available in contexts that care about extensions).

In addition, the operation for looking up members including those from extensions was refactored heavily to involve internal rather than external iteration and, more importantly, was changed so that it actually tests whether the `ExtensionDecl`s it loops over apply to the type in question, rather than blindly letting extensions members be looked up in ways that don't make sense.

There are three test cases added here to confirm aspects of the fix:

* First, I added a test that reproduces the crash that was being seen, so that we have a regression test for the fix.

* Second, I added a basic semantic-checking test to confirm that an `extension` from an `import`ed module is still visible/usable, to confirm that I didn't break existing valid uses of extensions.

* Third, I added a diagnostic test that ensures that we correctly ignore extensions that should not be visible in a given context as a result of `import` declarations.