### PR TITLE
Fix bugs related to mutating implementations of interface methods

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1576,7 +1576,7 @@ namespace Slang
             //
             auto synParamDecl = m_astBuilder->create<ParamDecl>();
             synParamDecl->nameAndLoc = paramDeclRef.getDecl()->nameAndLoc;
-            synParamDecl->type.type = resultType;
+            synParamDecl->type.type = paramType;
 
             // We need to add the parameter as a child declaration of
             // the method we are building.
@@ -1599,7 +1599,12 @@ namespace Slang
         // if any.
         //
         ThisExpr* synThis = nullptr;
-        if( !requiredMemberDeclRef.getDecl()->hasModifier<HLSLStaticModifier>() )
+        if( requiredMemberDeclRef.getDecl()->hasModifier<HLSLStaticModifier>() )
+        {
+            auto synStaticModifier = m_astBuilder->create<HLSLStaticModifier>();
+            synFuncDecl->modifiers.first = synStaticModifier;
+        }
+        else
         {
             // For a non-`static` requirement, we need a `this` parameter.
             //

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -248,6 +248,7 @@ DIAGNOSTIC(30041, Error, bitOperationNonIntegral, "bit operation: operand must b
 DIAGNOSTIC(30047, Error, argumentExpectedLValue, "argument passed to parameter '$0' must be l-value.")
 DIAGNOSTIC(30048, Note,  implicitCastUsedAsLValue, "argument was implicitly cast from '$0' to '$1', and Slang does not support using an implicit cast as an l-value")
 DIAGNOSTIC(30049, Note,  thisIsImmutableByDefault, "a 'this' parameter is an immutable parameter by default in Slang; apply the `[mutating]` attribute to the function declaration to opt in to a mutable `this`")
+DIAGNOSTIC(30050, Error,  mutatingMethodOnImmutableValue, "mutating method '$0' cannot be called on an immutable value")
 
 DIAGNOSTIC(30051, Error, invalidValueForArgument, "invalid value for argument '$0'")
 DIAGNOSTIC(30052, Error, invalidSwizzleExpr, "invalid swizzle pattern '$0' on type '$1'")

--- a/tests/diagnostics/interfaces/mutating-impl-of-non-mutating-req.slang
+++ b/tests/diagnostics/interfaces/mutating-impl-of-non-mutating-req.slang
@@ -1,0 +1,42 @@
+// mutating-impl-of-non-mutating-req.slang
+
+//DIAGNOSTIC_TEST:SIMPLE:-target hlsl -entry main
+
+interface IThing
+{
+    int processValue(int inValue);
+}
+
+struct Counter : IThing
+{
+    int state;
+
+    [mutating] int processValue(int inValue)
+    {
+        int result = state;
+        state += inValue;
+        return state;
+    }
+}
+
+int helper<T : IThing>(T thing, int value)
+{
+    return thing.processValue(value);
+}
+
+int test(int value)
+{
+    Counter counter = { value };
+    return helper(counter, value);
+}
+
+cbuffer C
+{
+    int gValue;
+}
+
+[shader("fragment")]
+int main() : SV_Target
+{
+    return test(gValue);
+}

--- a/tests/diagnostics/interfaces/mutating-impl-of-non-mutating-req.slang.expected
+++ b/tests/diagnostics/interfaces/mutating-impl-of-non-mutating-req.slang.expected
@@ -1,0 +1,6 @@
+result code = -1
+standard error = {
+tests/diagnostics/interfaces/mutating-impl-of-non-mutating-req.slang(10): error 38100: type 'Counter' does not provide required interface member 'processValue'
+}
+standard output = {
+}

--- a/tests/diagnostics/methods/mutating-method-on-rvalue.slang
+++ b/tests/diagnostics/methods/mutating-method-on-rvalue.slang
@@ -1,0 +1,26 @@
+// mutating-method-on-rvalue.slang
+
+//DIAGNOSTIC_TEST:SIMPLE:-target hlsl -entry main
+
+struct Counter
+{
+    int count;
+
+    [mutating] void increment() { count++; }
+
+    void bad()
+    {
+        increment();
+    }
+}
+
+cbuffer C
+{
+    Counter gCounter;
+}
+
+[shader("compute")]
+void main()
+{
+    gCounter.increment();
+}

--- a/tests/diagnostics/methods/mutating-method-on-rvalue.slang.expected
+++ b/tests/diagnostics/methods/mutating-method-on-rvalue.slang.expected
@@ -1,0 +1,8 @@
+result code = -1
+standard error = {
+tests/diagnostics/methods/mutating-method-on-rvalue.slang(13): error 30050: mutating method 'increment' cannot be called on an immutable value
+tests/diagnostics/methods/mutating-method-on-rvalue.slang(13): note 30049: a 'this' parameter is an immutable parameter by default in Slang; apply the `[mutating]` attribute to the function declaration to opt in to a mutable `this`
+tests/diagnostics/methods/mutating-method-on-rvalue.slang(25): error 30050: mutating method 'increment' cannot be called on an immutable value
+}
+standard output = {
+}


### PR DESCRIPTION
There are two main bug fixes here:

* We were failing to diagnose when code calls a `[mutating]` method on a value that doesn't support mutation (that is an r-value instead of an l-value).

* We had a bug in the synthesis logic for interface requirements where we used the *result* type of the requirement in place of each of the *parameter* types.

The second bug made synthesis often produce incorrect signatures with `void` parameters.

The first bug meant that even though a `[mutating]` method should not be able to satisfy a non-`[mutating]` method (and we had code to enforce this for the "exact match" case), when we go on to try and synthesize a non-`[mutating]` method that satisfies the requirement by delegating to the user-written one, it would end up succeeding, because nothing was stopping a non-`[mutating]` method from calling a `[mutating]` one.

In each case this code adds a fix and a test case to confirm it.