### PR TITLE
Bug fix for incorrect freeing of memory allocated in List in IR serialization

### DIFF
--- a/source/core/slang-riff.h
+++ b/source/core/slang-riff.h
@@ -363,9 +363,10 @@ public:
         /// Set the payload on a data. Payload can be passed as nullptr, if it is no memory will be copied.
     void setPayload(Data* data, const void* payload, size_t size);
 
-        /// Move ownership to
+        /// Move ownership to.
+        /// NOTE! The payload *must* be deallocatable via 'free'
     void moveOwned(Data* data, void* payload, size_t size);
-        /// Move unowned
+        /// Move unowned. The payload scope must last longer than the RiffContainer
     void setUnowned(Data* data, void* payload, size_t size);
 
         /// End a chunk

--- a/source/slang/slang-ir-serialize.cpp
+++ b/source/slang/slang-ir-serialize.cpp
@@ -462,9 +462,7 @@ static Result _writeArrayChunk(IRSerialCompressionType compressionType, FourCC c
             header.numCompressedEntries = uint32_t(numCompressedEntries);
 
             container->write(&header, sizeof(header));
-
-            const size_t compressedSize = compressedPayload.getCount();
-            container->moveOwned(container->addData(), compressedPayload.detachBuffer(), compressedSize);
+            container->write(compressedPayload.getBuffer(), compressedPayload.getCount());
             break;
         }
         default:
@@ -600,9 +598,7 @@ Result _writeInstArrayChunk(IRSerialCompressionType compressionType, FourCC chun
             header.numCompressedEntries = 0;          
 
             container->write(&header, sizeof(header));
-
-            const size_t compressedPayloadSize = compressedPayload.getCount();
-            container->moveOwned(container->addData(), compressedPayload.detachBuffer(), compressedPayloadSize);
+            container->write(compressedPayload.getBuffer(), compressedPayload.getCount());
 
             return SLANG_OK;
         }


### PR DESCRIPTION
As an optimization inside of the IR serialization, when it compresses lists of uint32_t (instructions or whatever). The result of the compression is to store the result in a List<uint8_t>. As an optimization the implementation attempted not to copy and reallocate memory, by just taking the allocation of the contents of the list, and giving ownership to the RiffContainer (which then gave it to the MemoryArena). 

Unfortunately this is a serious bug - because memory in the list is allocated via new T[N], and so it can only be freed with delete []. MemoryArena only deals with chunks of memory through malloc and free. Using free on something allocated with new T[N] is as serious error that will typically lead to the memory not being freed and/or crash, but worse leaving the memory system in a corrupt state that can lead to random crashes and/or undefined later in later execution. 

The fix here is to remove the optimization and just use 'write' to write out the compressed buffer avoiding the problem, but being slightly less efficient in requiring a copy and maybe an allocation.