### PR TITLE
Glslang texel offset bug fix

### DIFF
--- a/source/slang-glslang/slang-glslang.cpp
+++ b/source/slang-glslang/slang-glslang.cpp
@@ -61,6 +61,9 @@ static TBuiltInResource _calcBuiltinResources()
             dst[i] = UNLIMITED;
         }
     }
+
+    resource.minProgramTexelOffset = -UNLIMITED;
+
     // Set up the bools
     {
         TLimits* limits = &resource.limits;

--- a/source/slang-glslang/slang-glslang.cpp
+++ b/source/slang-glslang/slang-glslang.cpp
@@ -44,7 +44,8 @@
 static TBuiltInResource _calcBuiltinResources()
 {
     // NOTE! This is a bit of a hack - to set all the fields to true/UNLIMITED.
-
+    // Care must be taken if new variables are introduced, the default may not be appropriate.
+    
     // We are relying on limits being after the other fields. 
     SLANG_COMPILE_TIME_ASSERT(SLANG_OFFSET_OF(TBuiltInResource, limits) > 0);
     // We are relying on maxLights being the first parameter, and all values will have the same type
@@ -62,6 +63,7 @@ static TBuiltInResource _calcBuiltinResources()
         }
     }
 
+    // In the sea of variables there is a min value
     resource.minProgramTexelOffset = -UNLIMITED;
 
     // Set up the bools


### PR DESCRIPTION
In glslang upgrade a change was made to automatically set the majority of TBuiltInResource in glslang. Unfortunately this missed the member `minProgramTexelOffset` which should be -UNLIMITED.