### PR TITLE
Fix stdlib declarations for texture Gather()

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1459,24 +1459,24 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
                             sb << "__target_intrinsic(cuda, \"tex2Dgather<$T0>($0, ($2).x, ($2).y, " << componentIndex << ")\")\n";
                         }
                         sb << outputType << " Gather" << componentName << "(SamplerState s, ";
-                        sb << "float" << kBaseTextureTypes[tt].coordCount << " location);\n";
+                        sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location);\n";
 
                         EMIT_LINE_DIRECTIVE();
                         sb << "__target_intrinsic(glsl, \"textureGatherOffset($p, $2, $3, " << componentIndex << ")\")\n";
                         sb << outputType << " Gather" << componentName << "(SamplerState s, ";
-                        sb << "float" << kBaseTextureTypes[tt].coordCount << " location, ";
+                        sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                         sb << "constexpr int" << kBaseTextureTypes[tt].coordCount << " offset);\n";
 
                         EMIT_LINE_DIRECTIVE();
                         sb << outputType << " Gather" << componentName << "(SamplerState s, ";
-                        sb << "float" << kBaseTextureTypes[tt].coordCount << " location, ";
+                        sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                         sb << "constexpr int" << kBaseTextureTypes[tt].coordCount << " offset, ";
                         sb << "out uint status);\n";
 
                         EMIT_LINE_DIRECTIVE();
                         sb << "__target_intrinsic(glsl, \"textureGatherOffsets($p, $2, int" << kBaseTextureTypes[tt].coordCount << "[]($3, $4, $5, $6), " << componentIndex << ")\")\n";
                         sb << outputType << " Gather" << componentName << "(SamplerState s, ";
-                        sb << "float" << kBaseTextureTypes[tt].coordCount << " location, ";
+                        sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                         sb << "int" << kBaseTextureTypes[tt].coordCount << " offset1, ";
                         sb << "int" << kBaseTextureTypes[tt].coordCount << " offset2, ";
                         sb << "int" << kBaseTextureTypes[tt].coordCount << " offset3, ";
@@ -1484,7 +1484,7 @@ for (int tt = 0; tt < kBaseTextureTypeCount; ++tt)
 
                         EMIT_LINE_DIRECTIVE();
                         sb << outputType << " Gather" << componentName << "(SamplerState s, ";
-                        sb << "float" << kBaseTextureTypes[tt].coordCount << " location, ";
+                        sb << "float" << kBaseTextureTypes[tt].coordCount + isArray << " location, ";
                         sb << "int" << kBaseTextureTypes[tt].coordCount << " offset1, ";
                         sb << "int" << kBaseTextureTypes[tt].coordCount << " offset2, ";
                         sb << "int" << kBaseTextureTypes[tt].coordCount << " offset3, ";

--- a/tests/hlsl-intrinsic/texture/gather-texture2darray.slang
+++ b/tests/hlsl-intrinsic/texture/gather-texture2darray.slang
@@ -1,0 +1,16 @@
+// gather-texture2darray.slang
+
+//TEST:CROSS_COMPILE: -target dxbc -profile sm_5_1 -entry main -stage compute
+
+// Test gathering from a `Texture2DArray`
+
+Texture2DArray<uint> t;
+SamplerState s;
+RWBuffer<uint4> b;
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID)
+{
+    b[tid.x] = t.Gather(s, tid);
+}

--- a/tests/hlsl-intrinsic/texture/gather-texture2darray.slang.hlsl
+++ b/tests/hlsl-intrinsic/texture/gather-texture2darray.slang.hlsl
@@ -1,0 +1,14 @@
+// gather-texture2darray.slang.hlsl
+
+//TEST_IGNORE_FILE:
+
+Texture2DArray<uint> t_0;
+SamplerState s_0;
+RWBuffer<uint4> b_0;
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void main(uint3 tid : SV_DISPATCHTHREADID)
+{
+    b_0[tid.x] = t_0.Gather(s_0, tid);
+}

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1732,6 +1732,7 @@ TestResult runCrossCompilerTest(TestContext* context, TestInput& input)
 
         switch (target)
         {
+            case SLANG_DXIL:
             case SLANG_DXIL_ASM:
             {
                 expectedCmdLine.addArg(filePath + ".hlsl");
@@ -1739,6 +1740,7 @@ TestResult runCrossCompilerTest(TestContext* context, TestInput& input)
                 expectedCmdLine.addArg("dxc");
                 break;
             }
+            case SLANG_DXBC:
             case SLANG_DXBC_ASM:
             {
                 expectedCmdLine.addArg(filePath + ".hlsl");


### PR DESCRIPTION
Fixes #1507

These operations were failing to take into account the way that array textures require an extra coordinate to be passed in for the primary location (but not the additional offsets). Adding `isArray` to the component count is the existing solution used for similar intrinsics elsewhere in the stdlib, and it is adopted here.

Because our test framework isn't really set up to do a lot of texture testing (including having no support for texture arrays), the test added here is just a cross-compilation test that compares output with fxc for comparable input.