### PR TITLE
Export witness table and RTTI objects in compiled libraries.

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -3102,6 +3102,13 @@ namespace slang
             LayoutRules     rules = LayoutRules::Default,
             ISlangBlob**    outDiagnostics = nullptr) = 0;
 
+            /** Get the mangled name for a type witness.
+            */
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL getTypeConformanceWitnessMangledName(
+            TypeReflection* type,
+            TypeReflection* interfaceType,
+            ISlangBlob** outNameBlob) = 0;
+
             /** Create a request to load/compile front-end code.
             */
         virtual SLANG_NO_THROW SlangResult SLANG_MCALL createCompileRequest(

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -1318,6 +1318,9 @@ namespace Slang
 
         // The type that the witness table witnesses conformance to (e.g. an Interface)
         Type* baseType;
+
+        // The type witnessesd by the witness table (a concrete type).
+        Type* witnessedType;
     };
 
     typedef Dictionary<unsigned int, NodeBase*> AttributeArgumentValueDict;

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2450,6 +2450,7 @@ namespace Slang
         {
             witnessTable = new WitnessTable();
             witnessTable->baseType = DeclRefType::create(m_astBuilder, interfaceDeclRef);
+            witnessTable->witnessedType = type;
         }
         context->mapInterfaceToWitnessTable.Add(interfaceDeclRef, witnessTable);
 
@@ -3021,6 +3022,7 @@ namespace Slang
             //
             RefPtr<WitnessTable> witnessTable = new WitnessTable();
             witnessTable->baseType = enumConformanceDecl->base.type;
+            witnessTable->witnessedType = enumTypeType;
             enumConformanceDecl->witnessTable = witnessTable;
 
             Name* tagAssociatedTypeName = getSession()->getNameObj("__Tag");

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1205,6 +1205,10 @@ namespace Slang
             SlangInt               targetIndex = 0,
             slang::LayoutRules     rules = slang::LayoutRules::Default,
             ISlangBlob**    outDiagnostics = nullptr) override;
+        SLANG_NO_THROW SlangResult SLANG_MCALL getTypeConformanceWitnessMangledName(
+            slang::TypeReflection* type,
+            slang::TypeReflection* interfaceType,
+            ISlangBlob** outNameBlob) override;
         SLANG_NO_THROW SlangResult SLANG_MCALL createCompileRequest(
             SlangCompileRequest**   outCompileRequest) override;
 

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -1631,6 +1631,7 @@ void CPPSourceEmitter::_emitWitnessTableDefinitions()
     {
         auto interfaceType = cast<IRInterfaceType>(witnessTable->getOperand(0));
         List<IRWitnessTableEntry*> sortedWitnessTableEntries = getSortedWitnessTableEntries(witnessTable);
+        m_writer->emit("extern \"C\" ");
         emitSimpleType(interfaceType);
         m_writer->emit(" ");
         m_writer->emit(getName(witnessTable));
@@ -1692,7 +1693,7 @@ void CPPSourceEmitter::emitInterface(IRInterfaceType* interfaceType)
 
 void CPPSourceEmitter::emitRTTIObject(IRRTTIObject* rttiObject)
 {
-    m_writer->emit("static TypeInfo ");
+    m_writer->emit("extern \"C\" TypeInfo ");
     m_writer->emit(getName(rttiObject));
     m_writer->emit(" = {");
     auto typeSizeDecoration = rttiObject->findDecoration<IRRTTITypeSizeDecoration>();

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -1611,7 +1611,7 @@ void CPPSourceEmitter::emitWitnessTable(IRWitnessTable* witnessTable)
     _maybeEmitWitnessTableTypeDefinition(interfaceType);
 
     // Define a global variable for the witness table.
-    m_writer->emit("extern ");
+    m_writer->emit("extern \"C\" ");
     emitSimpleType(interfaceType);
     m_writer->emit(" ");
     m_writer->emit(getName(witnessTable));
@@ -1631,7 +1631,6 @@ void CPPSourceEmitter::_emitWitnessTableDefinitions()
     {
         auto interfaceType = cast<IRInterfaceType>(witnessTable->getOperand(0));
         List<IRWitnessTableEntry*> sortedWitnessTableEntries = getSortedWitnessTableEntries(witnessTable);
-        m_writer->emit("extern \"C\" ");
         emitSimpleType(interfaceType);
         m_writer->emit(" ");
         m_writer->emit(getName(witnessTable));
@@ -1693,7 +1692,13 @@ void CPPSourceEmitter::emitInterface(IRInterfaceType* interfaceType)
 
 void CPPSourceEmitter::emitRTTIObject(IRRTTIObject* rttiObject)
 {
+    // Declare the type info object as `extern "C"` first.
     m_writer->emit("extern \"C\" TypeInfo ");
+    m_writer->emit(getName(rttiObject));
+    m_writer->emit(";\n");
+
+    // Now actually define the object.
+    m_writer->emit("TypeInfo ");
     m_writer->emit(getName(rttiObject));
     m_writer->emit(" = {");
     auto typeSizeDecoration = rttiObject->findDecoration<IRRTTITypeSizeDecoration>();

--- a/source/slang/slang-ir-generics-lowering-context.cpp
+++ b/source/slang/slang-ir-generics-lowering-context.cpp
@@ -72,7 +72,7 @@ namespace Slang
         // Give a name to the rtti object.
         if (auto exportDecoration = typeInst->findDecoration<IRExportDecoration>())
         {
-            String rttiObjName = String(exportDecoration->getMangledName()) + "_rtti";
+            String rttiObjName = exportDecoration->getMangledName();
             builder->addExportDecoration(result, rttiObjName.getUnownedSlice());
         }
         mapTypeToRTTIObject[typeInst] = result;

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -5170,7 +5170,11 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                         // Need to construct a sub-witness-table
                         auto irWitnessTableBaseType = lowerType(subContext, astReqWitnessTable->baseType);
                         irSatisfyingWitnessTable = subBuilder->createWitnessTable(irWitnessTableBaseType);
-
+                        auto mangledName = getMangledNameForConformanceWitness(
+                            subContext->astBuilder,
+                            astReqWitnessTable->witnessedType,
+                            astReqWitnessTable->baseType);
+                        subBuilder->addExportDecoration(irSatisfyingWitnessTable, mangledName.getUnownedSlice());
                         // Recursively lower the sub-table.
                         lowerWitnessTable(
                             subContext,

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -623,6 +623,17 @@ SLANG_NO_THROW slang::TypeLayoutReflection* SLANG_MCALL Linkage::getTypeLayout(
     return asExternal(typeLayout);
 }
 
+SLANG_NO_THROW SlangResult SLANG_MCALL Linkage::getTypeConformanceWitnessMangledName(
+    slang::TypeReflection* type, slang::TypeReflection* interfaceType, ISlangBlob** outNameBlob)
+{
+    auto subType = asInternal(type);
+    auto supType = asInternal(interfaceType);
+    auto name = getMangledNameForConformanceWitness(subType->getASTBuilder(), subType, supType);
+    Slang::ComPtr<ISlangBlob> blob = Slang::StringUtil::createStringBlob(name);
+    *outNameBlob = blob.detach();
+    return SLANG_OK;
+}
+
 SLANG_NO_THROW SlangResult SLANG_MCALL Linkage::createCompileRequest(
     SlangCompileRequest**   outCompileRequest)
 {


### PR DESCRIPTION
This PR includes a series of changes to expose witness tables and RTTI objects in the compiled DLL, and provide a reflection function to get the mangled name of a type witness. These changes allows the host to fill in an existential value.

Detailed changes:

- Ensure that witness tables and RTTI objects are defined with the `extern "C"` modifier in the generated C++ code.
- RTTI objects use the mangled name of the type directly, so that can be queried using the type's mangled name directly from the resulting DLL.
- Expose `Linkage::getTypeConformanceWitnessMangledName` to return the mangled name of witness tables to the host.
- Ensure that all witness tables (including those for associated types) have proper mangled name.