### PR TITLE
Clean up the way that lookup "through" a base type is encoded

### DIFF
--- a/source/slang/slang-ast-serialize.cpp
+++ b/source/slang/slang-ast-serialize.cpp
@@ -1624,7 +1624,7 @@ SlangResult ASTSerialReader::load(const uint8_t* data, size_t dataCount, ASTBuil
                     {
                         typedef LookupResultItem::Breadcrumb Breadcrumb;
 
-                        auto breadcrumb = new LookupResultItem::Breadcrumb(Breadcrumb::Kind::Member, DeclRef<Decl>(), nullptr);
+                        auto breadcrumb = new LookupResultItem::Breadcrumb(Breadcrumb::Kind::Member, DeclRef<Decl>(), nullptr, nullptr);
                         m_scope.add(breadcrumb);
                         m_objects[i] = breadcrumb;
                         break;

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -1118,7 +1118,7 @@ namespace Slang
                 // `T` is a subtype of some other type `U`, so that
                 // lookup was able to find a member through type `U`
                 // instead.
-                Constraint,
+                SuperType,
 
                 // The lookup process considered a member of an
                 // enclosing type as being in scope, so that any
@@ -1154,6 +1154,8 @@ namespace Slang
             //
             DeclRef<Decl> declRef;
 
+            Val* val = nullptr;
+
             // The next implicit step that the lookup process took to
             // arrive at a final value.
             RefPtr<Breadcrumb> next;
@@ -1161,11 +1163,13 @@ namespace Slang
             Breadcrumb(
                 Kind                kind,
                 DeclRef<Decl>       declRef,
+                Val*                val,
                 RefPtr<Breadcrumb>  next,
                 ThisParameterMode   thisParameterMode = ThisParameterMode::Default)
                 : kind(kind)
                 , thisParameterMode(thisParameterMode)
                 , declRef(declRef)
+                , val(val)
                 , next(next)
             {}
         };

--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -363,7 +363,7 @@ bool TransitiveSubtypeWitness::_equalsValOverride(Val* val)
     return sub->equals(otherWitness->sub)
         && sup->equals(otherWitness->sup)
         && subToMid->equalsVal(otherWitness->subToMid)
-        && midToSup.equals(otherWitness->midToSup);
+        && midToSup->equalsVal(otherWitness->midToSup);
 }
 
 Val* TransitiveSubtypeWitness::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int * ioDiff)
@@ -373,7 +373,7 @@ Val* TransitiveSubtypeWitness::_substituteImplOverride(ASTBuilder* astBuilder, S
     Type* substSub = as<Type>(sub->substituteImpl(astBuilder, subst, &diff));
     Type* substSup = as<Type>(sup->substituteImpl(astBuilder, subst, &diff));
     SubtypeWitness* substSubToMid = as<SubtypeWitness>(subToMid->substituteImpl(astBuilder, subst, &diff));
-    DeclRef<Decl> substMidToSup = midToSup.substituteImpl(astBuilder, subst, &diff);
+    SubtypeWitness* substMidToSup = as<SubtypeWitness>(midToSup->substituteImpl(astBuilder, subst, &diff));
 
     // If nothing changed, then we can bail out early.
     if (!diff)
@@ -416,7 +416,7 @@ String TransitiveSubtypeWitness::_toStringOverride()
     sb << "TransitiveSubtypeWitness(";
     sb << this->subToMid->toString();
     sb << ", ";
-    sb << this->midToSup.toString();
+    sb << this->midToSup->toString();
     sb << ")";
     return sb.ProduceString();
 }
@@ -426,7 +426,7 @@ HashCode TransitiveSubtypeWitness::_getHashCodeOverride()
     auto hash = sub->getHashCode();
     hash = combineHash(hash, sup->getHashCode());
     hash = combineHash(hash, subToMid->getHashCode());
-    hash = combineHash(hash, midToSup.getHashCode());
+    hash = combineHash(hash, midToSup->getHashCode());
     return hash;
 }
 

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -154,7 +154,7 @@ class TransitiveSubtypeWitness : public SubtypeWitness
     SubtypeWitness* subToMid = nullptr;
 
     // Witness that `mid : sup`
-    DeclRef<Decl> midToSup;
+    SubtypeWitness* midToSup = nullptr;
 
     // Overrides should be public so base classes can access
     bool _equalsValOverride(Val* val);
@@ -198,6 +198,11 @@ class TaggedUnionSubtypeWitness : public SubtypeWitness
     String _toStringOverride();
     HashCode _getHashCodeOverride();
     Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+};
+
+class ThisTypeSubtypeWitness : public SubtypeWitness
+{
+    SLANG_CLASS(ThisTypeSubtypeWitness)
 };
 
 } // namespace Slang

--- a/source/slang/slang-check-conformance.cpp
+++ b/source/slang/slang-check-conformance.cpp
@@ -82,10 +82,15 @@ namespace Slang
             // where `[...]` represents the "hole" we leave
             // open to fill in next.
             //
+            DeclaredSubtypeWitness* declaredWitness = m_astBuilder->create<DeclaredSubtypeWitness>();
+            declaredWitness->sub = bb->sub;
+            declaredWitness->sup = bb->sup;
+            declaredWitness->declRef = bb->declRef;
+
             TransitiveSubtypeWitness* transitiveWitness = m_astBuilder->create<TransitiveSubtypeWitness>();
-            transitiveWitness->sub = bb->sub;
+            transitiveWitness->sub = subType;
             transitiveWitness->sup = bb->sup;
-            transitiveWitness->midToSup = bb->declRef;
+            transitiveWitness->midToSup = declaredWitness;
 
             // Fill in the current hole, and then set the
             // hole to point into the node we just created.

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1014,6 +1014,7 @@ namespace Slang
         ctorItem.breadcrumbs = new LookupResultItem::Breadcrumb(
             LookupResultItem::Breadcrumb::Kind::Member,
             typeItem.declRef,
+            nullptr,
             typeItem.breadcrumbs);
 
         OverloadCandidate candidate;

--- a/tests/compute/extension-on-interface.slang
+++ b/tests/compute/extension-on-interface.slang
@@ -1,5 +1,8 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+// Note: disabled because extension of interfaces shouldn't
+// work the way this test assumes it does...
+
+//TEST_DISABLED(compute):COMPARE_COMPUTE:
+//TEST_DISABLED(compute):COMPARE_COMPUTE:-cpu
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;


### PR DESCRIPTION
In order to undestand this change, it is important to undestand how lookup through base interfaces works prior to this change. In order to understand *that* it helps to be reminded of how inheritance relationships get encoded in the AST.

Suppose the user writes:

    struct Base { int val; }
    struct Derived : Base { ... }
    ...
    Derived d = ...;
    int v = d.val;

The question is how an expression like `d.val` gets semantically checked, and how it is encoded into the IR after semantic checking. You might assume it gets checked and encoded so that we end up with:

    int v = ((Base) d).val;

and that seems like it should Just Work... so of course that isn't what Slang has been doing. Instead, we relied on the fact that the inheritance relationship `Derived : Base` is represented as an `InheritanceDecl` member of the `Derived` type, and we ended up checking the code into something like:

   int v = d.<anonymous>.val;

where `<anonymous>` stands in for the name of the `InheritanceDecl` that represents inheritance from `Base`. This design choice makes a limited amount of sense when you consider how inheritance would typically be lowered to a C-like output language:

    // struct Derived : Base { ... }
    //   =>
    struct Derived { Base base; ... }

The problem with that encoding is that it really doesn't make sense for almost any other scenario. In particular, if you have a generic type parameter `T` that was constrianed with `T : ISomething`, then the constraint isn't even technically a *member* of the type parameter `T`, so expressing thing as a member reference in the AST is completely incorrect. Unfortunately, by the time it was clear that we needed something better, a bunch of implementation work was done based on the existing representation.

This change tries to clean things up so that lookup of a super-type member through a value of a sub-type does the obvious thing: cast the value to the super-type and then look up the member (as in `((Base) d).val`).

The core of the change is that in lookup, instead of creating `Constraint` breadcrumbs whenever we are looking up in a super-type (with a reference to the `TypeConstraintDecl` being used) we instead use `SuperType` breadcrumbs (with a reference to a `SubtypeWitness`). Then when we create the expression from a `LookupResultItem`, we translate any `SuperType` breadcrumbs into `CastToSuperTypeExpr`s (an expression type that already existed).

This change also adds support for lookup through the `This` type in the context of an interface, and in order for that to work we need a new kind of subtype witness to represent the knowledge that a `This` type is a subtype of the enclosing interface. Making that work forces us to change the representation of `TransitiveSubtypeWitness` so that it takes a pair of subtype witnesses (and not one subtype witness plus one `TypeConstraintDecl`). For the most part this is a small change, but it raises the possibility that some pieces of the code aren't going to be robust against all possible shapes of subtype witnesses.

The IR lowering logic has relied on the weird `d.<anonymous>` representation in order to ensure that when looking up interface members we weren't always casting to the interface type (which would create a `makeExistential` instruction), and then calling using that. Basically, the IR lowering would ignore the `d.<anonymous>` part and just emit `d`, but we can't do that for `((Base) d)` or `((IThing) d)` because whehter or not we should actually perform the cast depends on context.

For now we solve that problem by adding specific logic to ignore up-casts to interface types when they appear in member expressions or method calls. A more robust solution might be needed down the line, but this seems to work in practice.

All of this work is cleanup that I found was needed in order to make `extension`s of `interface` types workable.