### PR TITLE
Support dynamic existential shader parameters in render-test

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -891,6 +891,7 @@ extern "C"
             @return The function pointer related to the name or nullptr if not found 
             */
         virtual SLANG_NO_THROW SlangFuncPtr SLANG_MCALL findFuncByName(char const* name) = 0;
+        virtual SLANG_NO_THROW void* SLANG_MCALL findObjectByName(char const* name) = 0;
     };
     #define SLANG_UUID_ISlangSharedLibrary { 0x9c9d5bc5, 0xeb61, 0x496f,{ 0x80, 0xd7, 0xd1, 0x47, 0xc4, 0xa2, 0x37, 0x30 } };
 

--- a/slang.h
+++ b/slang.h
@@ -3374,6 +3374,11 @@ SLANG_API SlangResult spCompileRequest_getModule(
     SlangInt                translationUnitIndex,
     slang::IModule**        outModule);
 
+/** Get the `ISession` handle behind the `SlangCompileRequest`.
+*/
+SLANG_API SlangResult spCompileRequest_getSession(
+    SlangCompileRequest* request,
+    slang::ISession** outSession);
 #endif
 
 /* DEPRECATED DEFINITIONS

--- a/slang.h
+++ b/slang.h
@@ -892,7 +892,7 @@ extern "C"
             */
         inline SlangFuncPtr SLANG_MCALL findFuncByName(char const* name)
         {
-            return static_cast<SlangFuncPtr>(findSymbolAddressByName(name));
+            return reinterpret_cast<SlangFuncPtr>(findSymbolAddressByName(name));
         }
             /** Get a symbol by name. If the library is unloaded will only return nullptr. 
             @param name The name of the symbol 

--- a/slang.h
+++ b/slang.h
@@ -890,8 +890,15 @@ extern "C"
             @param name The name of the function 
             @return The function pointer related to the name or nullptr if not found 
             */
-        virtual SLANG_NO_THROW SlangFuncPtr SLANG_MCALL findFuncByName(char const* name) = 0;
-        virtual SLANG_NO_THROW void* SLANG_MCALL findObjectByName(char const* name) = 0;
+        inline SlangFuncPtr SLANG_MCALL findFuncByName(char const* name)
+        {
+            return static_cast<SlangFuncPtr>(findSymbolAddressByName(name));
+        }
+            /** Get a symbol by name. If the library is unloaded will only return nullptr. 
+            @param name The name of the symbol 
+            @return The pointer related to the name or nullptr if not found 
+            */
+        virtual SLANG_NO_THROW void* SLANG_MCALL findSymbolAddressByName(char const* name) = 0;
     };
     #define SLANG_UUID_ISlangSharedLibrary { 0x9c9d5bc5, 0xeb61, 0x496f,{ 0x80, 0xd7, 0xd1, 0x47, 0xc4, 0xa2, 0x37, 0x30 } };
 

--- a/source/core/slang-platform.cpp
+++ b/source/core/slang-platform.cpp
@@ -173,16 +173,10 @@ SLANG_COMPILE_TIME_ASSERT(E_OUTOFMEMORY == SLANG_E_OUT_OF_MEMORY);
 	dlclose(handle);
 }
 
-/* static */SharedLibrary::FuncPtr SharedLibrary::findFuncByName(Handle handle, char const* name)
+/* static */SharedLibrary::FuncPtr SharedLibrary::findSymbolAddressByName(Handle handle, char const* name)
 {
     SLANG_ASSERT(handle);
 	return (FuncPtr)dlsym((void*)handle, name);
-}
-
-/* static */ void* SharedLibrary::findObjectByName(Handle handle, char const* name)
-{
-    SLANG_ASSERT(handle);
-    return dlsym((void*)handle, name);
 }
 
 /* static */void SharedLibrary::appendPlatformFileName(const UnownedStringSlice& name, StringBuilder& dst)

--- a/source/core/slang-platform.cpp
+++ b/source/core/slang-platform.cpp
@@ -128,13 +128,7 @@ SLANG_COMPILE_TIME_ASSERT(E_OUTOFMEMORY == SLANG_E_OUT_OF_MEMORY);
     ::FreeLibrary((HMODULE)handle);
 }
 
-/* static */SharedLibrary::FuncPtr SharedLibrary::findFuncByName(Handle handle, char const* name)
-{
-    SLANG_ASSERT(handle);
-    return (FuncPtr)GetProcAddress((HMODULE)handle, name);
-}
-
-/* static */ void* SharedLibrary::findObjectByName(Handle handle, char const* name)
+/* static */ void* SharedLibrary::findSymbolAddressByName(Handle handle, char const* name)
 {
     SLANG_ASSERT(handle);
     return GetProcAddress((HMODULE)handle, name);

--- a/source/core/slang-platform.cpp
+++ b/source/core/slang-platform.cpp
@@ -173,10 +173,10 @@ SLANG_COMPILE_TIME_ASSERT(E_OUTOFMEMORY == SLANG_E_OUT_OF_MEMORY);
 	dlclose(handle);
 }
 
-/* static */SharedLibrary::FuncPtr SharedLibrary::findSymbolAddressByName(Handle handle, char const* name)
+/* static */void* SharedLibrary::findSymbolAddressByName(Handle handle, char const* name)
 {
     SLANG_ASSERT(handle);
-	return (FuncPtr)dlsym((void*)handle, name);
+	return dlsym((void*)handle, name);
 }
 
 /* static */void SharedLibrary::appendPlatformFileName(const UnownedStringSlice& name, StringBuilder& dst)

--- a/source/core/slang-platform.cpp
+++ b/source/core/slang-platform.cpp
@@ -134,6 +134,12 @@ SLANG_COMPILE_TIME_ASSERT(E_OUTOFMEMORY == SLANG_E_OUT_OF_MEMORY);
     return (FuncPtr)GetProcAddress((HMODULE)handle, name);
 }
 
+/* static */ void* SharedLibrary::findObjectByName(Handle handle, char const* name)
+{
+    SLANG_ASSERT(handle);
+    return GetProcAddress((HMODULE)handle, name);
+}
+
 /* static */void SharedLibrary::appendPlatformFileName(const UnownedStringSlice& name, StringBuilder& dst)
 {
     dst.Append(name);
@@ -177,6 +183,12 @@ SLANG_COMPILE_TIME_ASSERT(E_OUTOFMEMORY == SLANG_E_OUT_OF_MEMORY);
 {
     SLANG_ASSERT(handle);
 	return (FuncPtr)dlsym((void*)handle, name);
+}
+
+/* static */ void* SharedLibrary::findObjectByName(Handle handle, char const* name)
+{
+    SLANG_ASSERT(handle);
+    return dlsym((void*)handle, name);
 }
 
 /* static */void SharedLibrary::appendPlatformFileName(const UnownedStringSlice& name, StringBuilder& dst)

--- a/source/core/slang-platform.h
+++ b/source/core/slang-platform.h
@@ -98,6 +98,11 @@ namespace Slang
             /// @param The shared library handle as returned by loadPlatformLibrary
         static FuncPtr findFuncByName(Handle handle, char const* name);
 
+            /// Given a shared library handle and a name, return the associated object
+            /// Return nullptr if object is not found
+            /// @param The shared library handle as returned by loadPlatformLibrary
+        static void* findObjectByName(Handle handle, char const* name);
+
             /// Append to the end of dst, the name, with any platform specific additions
             /// The input name should be unadorned with any 'lib' prefix or extension
         static void appendPlatformFileName(const UnownedStringSlice& name, StringBuilder& dst);

--- a/source/core/slang-platform.h
+++ b/source/core/slang-platform.h
@@ -93,15 +93,10 @@ namespace Slang
             /// @param The valid handle returned from load 
         static void unload(Handle handle);
 
-            /// Given a shared library handle and a name, return the associated function
-            /// Return nullptr if function is not found
-            /// @param The shared library handle as returned by loadPlatformLibrary
-        static FuncPtr findFuncByName(Handle handle, char const* name);
-
             /// Given a shared library handle and a name, return the associated object
             /// Return nullptr if object is not found
             /// @param The shared library handle as returned by loadPlatformLibrary
-        static void* findObjectByName(Handle handle, char const* name);
+        static void* findSymbolAddressByName(Handle handle, char const* name);
 
             /// Append to the end of dst, the name, with any platform specific additions
             /// The input name should be unadorned with any 'lib' prefix or extension

--- a/source/core/slang-shared-library.cpp
+++ b/source/core/slang-shared-library.cpp
@@ -82,14 +82,9 @@ DefaultSharedLibrary::~DefaultSharedLibrary()
     }
 }
 
-SlangFuncPtr DefaultSharedLibrary::findFuncByName(char const* name)
+void* DefaultSharedLibrary::findSymbolAddressByName(char const* name)
 {
-    return SharedLibrary::findFuncByName(m_sharedLibraryHandle, name); 
-}
-
-void* DefaultSharedLibrary::findObjectByName(char const* name)
-{
-    return SharedLibrary::findObjectByName(m_sharedLibraryHandle, name);
+    return SharedLibrary::findSymbolAddressByName(m_sharedLibraryHandle, name);
 }
 
 } 

--- a/source/core/slang-shared-library.cpp
+++ b/source/core/slang-shared-library.cpp
@@ -87,4 +87,9 @@ SlangFuncPtr DefaultSharedLibrary::findFuncByName(char const* name)
     return SharedLibrary::findFuncByName(m_sharedLibraryHandle, name); 
 }
 
+void* DefaultSharedLibrary::findObjectByName(char const* name)
+{
+    return SharedLibrary::findObjectByName(m_sharedLibraryHandle, name);
+}
+
 } 

--- a/source/core/slang-shared-library.h
+++ b/source/core/slang-shared-library.h
@@ -53,6 +53,7 @@ class DefaultSharedLibrary : public ISlangSharedLibrary, public RefObject
 
     // ISlangSharedLibrary
     virtual SLANG_NO_THROW SlangFuncPtr SLANG_MCALL findFuncByName(char const* name) SLANG_OVERRIDE;
+    virtual SLANG_NO_THROW void* SLANG_MCALL findObjectByName(char const* name) SLANG_OVERRIDE;
 
         /// Ctor.
     DefaultSharedLibrary(const SharedLibrary::Handle sharedLibraryHandle):

--- a/source/core/slang-shared-library.h
+++ b/source/core/slang-shared-library.h
@@ -52,8 +52,7 @@ class DefaultSharedLibrary : public ISlangSharedLibrary, public RefObject
     SLANG_REF_OBJECT_IUNKNOWN_ALL
 
     // ISlangSharedLibrary
-    virtual SLANG_NO_THROW SlangFuncPtr SLANG_MCALL findFuncByName(char const* name) SLANG_OVERRIDE;
-    virtual SLANG_NO_THROW void* SLANG_MCALL findObjectByName(char const* name) SLANG_OVERRIDE;
+    virtual SLANG_NO_THROW void* SLANG_MCALL findSymbolAddressByName(char const* name) SLANG_OVERRIDE;
 
         /// Ctor.
     DefaultSharedLibrary(const SharedLibrary::Handle sharedLibraryHandle):

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3652,6 +3652,14 @@ SLANG_API SlangResult spCompileRequest_getModule(
     return SLANG_OK;
 }
 
+SLANG_API SlangResult spCompileRequest_getSession(
+    SlangCompileRequest* request,
+    slang::ISession** outSession)
+{
+    *outSession = Slang::asInternal(request)->getLinkage();
+    return SLANG_OK;
+}
+
 SLANG_API SlangResult spCompileRequest_getEntryPoint(
     SlangCompileRequest*    request,
     SlangInt                entryPointIndex,

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3656,7 +3656,8 @@ SLANG_API SlangResult spCompileRequest_getSession(
     SlangCompileRequest* request,
     slang::ISession** outSession)
 {
-    *outSession = Slang::asInternal(request)->getLinkage();
+    auto session = Slang::asInternal(request)->getLinkage();
+    *outSession = Slang::ComPtr<slang::ISession>(session).detach();
     return SLANG_OK;
 }
 

--- a/tools/render-test/cpu-compute-util.cpp
+++ b/tools/render-test/cpu-compute-util.cpp
@@ -363,8 +363,8 @@ SlangResult CPUComputeUtil::populateRTTIEntries(
     ShaderCompilerUtil::OutputAndLayout& compilationAndLayout,
     ISlangSharedLibrary* sharedLib)
 {
-    slang::ISession* linkage = nullptr;
-    spCompileRequest_getSession(compilationAndLayout.output.request, &linkage);
+    Slang::ComPtr<slang::ISession> linkage;
+    spCompileRequest_getSession(compilationAndLayout.output.request, linkage.writeRef());
     auto& inputLayout = compilationAndLayout.layout;
     for (auto& entry : inputLayout.entries)
     {
@@ -374,7 +374,7 @@ SlangResult CPUComputeUtil::populateRTTIEntries(
             switch (rtti.type)
             {
             case RTTIDataEntryType::RTTIObject:
-                ptrValue = sharedLib->findObjectByName(rtti.typeName.getBuffer());
+                ptrValue = sharedLib->findSymbolAddressByName(rtti.typeName.getBuffer());
                 break;
             case RTTIDataEntryType::WitnessTable:
             {
@@ -389,7 +389,7 @@ SlangResult CPUComputeUtil::populateRTTIEntries(
                 linkage->getTypeConformanceWitnessMangledName(concreteType, interfaceType, &outName);
                 if (!outName)
                     return SLANG_FAIL;
-                ptrValue = sharedLib->findObjectByName((char*)outName->getBufferPointer());
+                ptrValue = sharedLib->findSymbolAddressByName((char*)outName->getBufferPointer());
                 break;
             }
             default:

--- a/tools/render-test/cpu-compute-util.cpp
+++ b/tools/render-test/cpu-compute-util.cpp
@@ -374,7 +374,7 @@ SlangResult CPUComputeUtil::populateRTTIEntries(
             switch (rtti.type)
             {
             case RTTIDataEntryType::RTTIObject:
-                ptrValue = sharedLib->findFuncByName(rtti.typeName.getBuffer());
+                ptrValue = sharedLib->findObjectByName(rtti.typeName.getBuffer());
                 break;
             case RTTIDataEntryType::WitnessTable:
             {
@@ -389,7 +389,7 @@ SlangResult CPUComputeUtil::populateRTTIEntries(
                 linkage->getTypeConformanceWitnessMangledName(concreteType, interfaceType, &outName);
                 if (!outName)
                     return SLANG_FAIL;
-                ptrValue = sharedLib->findFuncByName((char*)outName->getBufferPointer());
+                ptrValue = sharedLib->findObjectByName((char*)outName->getBufferPointer());
                 break;
             }
             default:

--- a/tools/render-test/cpu-compute-util.h
+++ b/tools/render-test/cpu-compute-util.h
@@ -55,6 +55,11 @@ struct CPUComputeUtil
         /// Runs code across run styles and makes sure output buffers match
     static SlangResult checkStyleConsistency(ISlangSharedLibrary* sharedLib, const uint32_t dispatchSize[3], const ShaderCompilerUtil::OutputAndLayout& compilationAndLayout);
 
+        /// Query and fill in the RTTI pointer values in data buffers.
+    static SlangResult populateRTTIEntries(
+        ShaderCompilerUtil::OutputAndLayout& compilationAndLayout,
+        ISlangSharedLibrary* sharedLib);
+
     static SlangResult calcBindings(const ShaderCompilerUtil::OutputAndLayout& compilationAndLayout, Context& outContext);
     
     static SlangResult calcExecuteInfo(ExecuteStyle style, ISlangSharedLibrary* sharedLib, const uint32_t dispatchSize[3], const ShaderCompilerUtil::OutputAndLayout& compilationAndLayout, Context& context, ExecuteInfo& out);

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -650,6 +650,7 @@ static SlangResult _innerMain(Slang::StdWriters* stdWriters, SlangSession* sessi
 
             // calculate binding
             CPUComputeUtil::Context context;
+            SLANG_RETURN_ON_FAIL(CPUComputeUtil::populateRTTIEntries(compilationAndLayout, sharedLibrary.get()));
             SLANG_RETURN_ON_FAIL(CPUComputeUtil::calcBindings(compilationAndLayout, context));
 
             // Get the execution info from the lib

--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -398,8 +398,37 @@ namespace renderer_test
                                     parser.Read("=");
 
                                     parser.Read("[");
+                                    uint32_t offset = 0;
                                     while (!parser.IsEnd() && !parser.LookAhead("]"))
                                     {
+                                        RTTIDataEntry rttiEntry;
+                                        if (parser.LookAhead("rtti"))
+                                        {
+                                            parser.ReadToken();
+                                            parser.Read("(");
+                                            rttiEntry.type = RTTIDataEntryType::RTTIObject;
+                                            rttiEntry.typeName = parser.ReadWord();
+                                            rttiEntry.offset = offset;
+                                            parser.Read(")");
+                                            offset += 8;
+                                            entry.rttiEntries.add(rttiEntry);
+                                            continue;
+                                        }
+                                        else if (parser.LookAhead("witness"))
+                                        {
+                                            parser.ReadToken();
+                                            parser.Read("(");
+                                            rttiEntry.type = RTTIDataEntryType::WitnessTable;
+                                            rttiEntry.typeName = parser.ReadWord();
+                                            parser.Read(",");
+                                            rttiEntry.interfaceName = parser.ReadWord();
+                                            rttiEntry.offset = offset;
+                                            parser.Read(")");
+                                            offset += 8;
+                                            entry.rttiEntries.add(rttiEntry);
+                                            continue;
+                                        }
+
                                         bool negate = false;
                                         if(parser.NextToken().Type == TokenType::OpSub)
                                         {
@@ -419,6 +448,7 @@ namespace renderer_test
                                             if(negate) floatNum = -floatNum;
                                             entry.bufferData.add(*(unsigned int*)&floatNum);
                                         }
+                                        offset += 4;
                                     }
                                     parser.Read("]");
                                 }

--- a/tools/render-test/shader-input-layout.h
+++ b/tools/render-test/shader-input-layout.h
@@ -63,11 +63,24 @@ struct ArrayDesc
     int size = 0;
 };
 
+enum class RTTIDataEntryType
+{
+    RTTIObject, WitnessTable
+};
+struct RTTIDataEntry
+{
+    RTTIDataEntryType type;
+    Slang::String typeName;
+    Slang::String interfaceName;
+    unsigned int offset;
+};
+
 class ShaderInputLayoutEntry
 {
 public:
     ShaderInputType type;
     Slang::List<unsigned int> bufferData;
+    Slang::List<RTTIDataEntry> rttiEntries;
     InputTextureDesc textureDesc;
     InputBufferDesc bufferDesc;
     InputSamplerDesc samplerDesc;

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1576,7 +1576,7 @@ static TestResult runCPPCompilerSharedLibrary(TestContext* context, TestInput& i
         typedef int(*TestFunc)(int intValue, const char* textValue, char* outTextValue);
 
         // We could capture output if we passed in a ISlangWriter - but for that to work we'd need a 
-        TestFunc testFunc = (TestFunc)SharedLibrary::findFuncByName(handle, "test");
+        TestFunc testFunc = (TestFunc)SharedLibrary::findSymbolAddressByName(handle, "test");
         if (testFunc)
         {
             value = testFunc(inValue, inBuffer, buffer);


### PR DESCRIPTION
This change adds support for specifying dynamic existential shader parameter values in render-test.

Specifically:
1. allow two new types of element in a `data=[]` block: `rtti(typename`) and `witness(c, I)`, so this is now valid:
    ```
    //TEST_INPUT:cbuffer(data=[rtti(MyImpl) witness(MyImpl, IInterface) 1 0], stride=4):
    ConstantBuffer<IInterface> gCb;
    ```
2. Add a new `spCompileRequest_getSession` to get a `ISession` handle from the legacy end-to-end compile request object. This allows the test infra to call `Linkage::getTypeConformanceMangledName`.
3. Add `CPUComputeUtil::populateRTTIEntries` that is run as a setup step, which fills in actual rtti pointer values in the data buffer of the provided `shaderInputLayout`.