### PR TITLE
Fix a crashing issue for non-end-to-end compilation

### DIFF
--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -1226,7 +1226,7 @@ SlangResult dissassembleDXILUsingDXC(
         CodeGenTarget sourceTarget = CodeGenTarget::None;
         SourceLanguage sourceLanguage = SourceLanguage::Unknown;
 
-        PassThroughMode downstreamCompiler = endToEndReq->passThrough;
+        PassThroughMode downstreamCompiler = endToEndReq ? endToEndReq->passThrough : PassThroughMode::None;
 
         // If we are not in pass through, lookup the default compiler for the emitted source type
         if (downstreamCompiler == PassThroughMode::None)


### PR DESCRIPTION
The refactorings that added support for multiple entry points in an output file seemingly introduced a regression such that we crash on compilation that is not "end-to-end." Unfortunately, all of our testing only covers end-to-end compilation, and many users only use that mode.

I've added a fix for the issue I ran into, but I haven't addressed the testing gap in this change. Without adding testing for non-end-to-end compilation, I expect further regressions to slip in over time.