### PR TITLE
Improvements around CompileResult::getBlob 

### DIFF
--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -122,13 +122,17 @@ namespace Slang
         {
             switch(format)
             {
-                case ResultFormat::None:
                 default:
-                    break;
-
+                case ResultFormat::None:
+                {
+                    // If no blob is returned, it's an error
+                    return SLANG_FAIL;
+                }
                 case ResultFormat::Text:
+                {
                     blob = StringUtil::createStringBlob(outputString);
                     break;
+                }
                 case ResultFormat::Binary:
                 {
                     if (downstreamResult)
@@ -1968,7 +1972,11 @@ SlangResult dissassembleDXILUsingDXC(
         case ResultFormat::Binary:
             {
                 ComPtr<ISlangBlob> blob;
-                result.getBlob(blob);
+                if (SLANG_FAILED(result.getBlob(blob)))
+                {
+                    SLANG_UNEXPECTED("No blob to emit");
+                    return;
+                }
                 writeOutputFile(compileRequest,
                     outputPath,
                     blob->getBufferPointer(),
@@ -2020,6 +2028,7 @@ SlangResult dissassembleDXILUsingDXC(
                 ComPtr<ISlangBlob> blob;
                 if (SLANG_FAILED(result.getBlob(blob)))
                 {
+                    SLANG_UNEXPECTED("No blob to emit");
                     return;
                 }
 

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -2598,7 +2598,12 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
                                     targetProgram->getOrCreateEntryPointResult(index, &sink);
 
                                 Slang::ComPtr<ISlangBlob> blob;
-                                result.getBlob(blob);
+                                if (SLANG_FAILED(result.getBlob(blob)))
+                                {
+                                    SLANG_UNEXPECTED("No blob to emit");
+                                    return;
+                                }
+
                                 auto ptr = (const unsigned char*)blob->getBufferPointer();
 
                                 m_writer->emit("size_t __");

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3390,6 +3390,13 @@ SLANG_API void const* spGetEntryPointCode(
     size_t*                 outSize)
 {
     using namespace Slang;
+
+    // Zero the size initially, in case need to return nullptr for error.
+    if (outSize)
+    {
+        *outSize = 0;
+    }
+
     auto req = Slang::asInternal(request);
     auto linkage = req->getLinkage();
     auto program = req->getSpecializedGlobalAndEntryPointsComponentType();
@@ -3411,22 +3418,15 @@ SLANG_API void const* spGetEntryPointCode(
         return nullptr;
     CompileResult& result = targetProgram->getExistingEntryPointResult(entryPointIndex);
 
-    void const* data = nullptr;
-    size_t size = 0;
-
     ComPtr<ISlangBlob> blob;
-    if (SLANG_SUCCEEDED(result.getBlob(blob)))
-    {
-        data = blob->getBufferPointer();
-        size = blob->getBufferSize();
-    }
+    SLANG_RETURN_NULL_ON_FAIL(result.getBlob(blob));
 
     if (outSize)
     {
-        *outSize = size;
+        *outSize = blob->getBufferSize();
     }
 
-    return data;
+    return (void*)blob->getBufferPointer();
 }
 
 static SlangResult _getEntryPointResult(


### PR DESCRIPTION
* If a blob is not returned from CompileResult return a failure
* Test for failures when getBlob is used
* Make spGetEntryPointCode handle lack of blob gracefully