### PR TITLE
Remove some "do what I mean" logic from reflection API

### DIFF
--- a/source/slang/slang-reflection.cpp
+++ b/source/slang/slang-reflection.cpp
@@ -831,26 +831,10 @@ static SlangParameterCategory getParameterCategory(
     return SLANG_PARAMETER_CATEGORY_MIXED;
 }
 
-static TypeLayout* maybeGetContainerLayout(TypeLayout* typeLayout)
-{
-    if (auto parameterGroupTypeLayout = as<ParameterGroupTypeLayout>(typeLayout))
-    {
-        auto containerTypeLayout = parameterGroupTypeLayout->containerVarLayout->typeLayout;
-        if (containerTypeLayout->resourceInfos.getCount() != 0)
-        {
-            return containerTypeLayout;
-        }
-    }
-
-    return typeLayout;
-}
-
 SLANG_API SlangParameterCategory spReflectionTypeLayout_GetParameterCategory(SlangReflectionTypeLayout* inTypeLayout)
 {
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return SLANG_PARAMETER_CATEGORY_NONE;
-
-    typeLayout = maybeGetContainerLayout(typeLayout);
 
     return getParameterCategory(typeLayout);
 }
@@ -860,8 +844,6 @@ SLANG_API unsigned spReflectionTypeLayout_GetCategoryCount(SlangReflectionTypeLa
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return 0;
 
-    typeLayout = maybeGetContainerLayout(typeLayout);
-
     return (unsigned) typeLayout->resourceInfos.getCount();
 }
 
@@ -869,8 +851,6 @@ SLANG_API SlangParameterCategory spReflectionTypeLayout_GetCategoryByIndex(Slang
 {
     auto typeLayout = convert(inTypeLayout);
     if(!typeLayout) return SLANG_PARAMETER_CATEGORY_NONE;
-
-    typeLayout = maybeGetContainerLayout(typeLayout);
 
     return typeLayout->resourceInfos[index].kind;
 }

--- a/tests/reflection/mix-explicit-and-implicit-spaces.slang.expected
+++ b/tests/reflection/mix-explicit-and-implicit-spaces.slang.expected
@@ -6,10 +6,7 @@ standard output = {
     "parameters": [
         {
             "name": "a",
-            "bindings": [
-                {"kind": "constantBuffer", "index": 0, "count": 0},
-                {"kind": "registerSpace", "index": 0}
-            ],
+            "binding": {"kind": "registerSpace", "index": 0},
             "type": {
                 "kind": "parameterBlock",
                 "elementType": {
@@ -53,10 +50,7 @@ standard output = {
         },
         {
             "name": "b",
-            "bindings": [
-                {"kind": "constantBuffer", "index": 0, "count": 0},
-                {"kind": "registerSpace", "index": 1}
-            ],
+            "binding": {"kind": "registerSpace", "index": 1},
             "type": {
                 "kind": "parameterBlock",
                 "elementType": {
@@ -100,10 +94,7 @@ standard output = {
         },
         {
             "name": "c",
-            "bindings": [
-                {"kind": "constantBuffer", "index": 0, "count": 0},
-                {"kind": "registerSpace", "index": 2}
-            ],
+            "binding": {"kind": "registerSpace", "index": 2},
             "type": {
                 "kind": "parameterBlock",
                 "elementType": {

--- a/tests/reflection/parameter-block-explicit-space.slang.expected
+++ b/tests/reflection/parameter-block-explicit-space.slang.expected
@@ -6,10 +6,7 @@ standard output = {
     "parameters": [
         {
             "name": "a",
-            "bindings": [
-                {"kind": "constantBuffer", "index": 0, "count": 0},
-                {"kind": "registerSpace", "index": 2}
-            ],
+            "binding": {"kind": "registerSpace", "index": 2},
             "type": {
                 "kind": "parameterBlock",
                 "elementType": {
@@ -111,10 +108,7 @@ standard output = {
         },
         {
             "name": "b",
-            "bindings": [
-                {"kind": "constantBuffer", "index": 0, "count": 0},
-                {"kind": "registerSpace", "index": 3}
-            ],
+            "binding": {"kind": "registerSpace", "index": 3},
             "type": {
                 "kind": "parameterBlock",
                 "elementType": {

--- a/tests/reflection/resource-in-cbuffer.hlsl.expected
+++ b/tests/reflection/resource-in-cbuffer.hlsl.expected
@@ -6,7 +6,11 @@ standard output = {
     "parameters": [
         {
             "name": "MyConstantBuffer",
-            "binding": {"kind": "constantBuffer", "index": 0},
+            "bindings": [
+                {"kind": "constantBuffer", "index": 0},
+                {"kind": "shaderResource", "index": 0},
+                {"kind": "samplerState", "index": 0}
+            ],
             "type": {
                 "kind": "constantBuffer",
                 "elementType": {


### PR DESCRIPTION
The reflection API had a bit of DWIM (Do What I Mean) logic in that a client could query the resource usage/bindings of a `ParameterBlock<X>` and see not only the register `space` or descriptor `set` for the block itself, but also the constant buffer `register` or `binding` for its default constant buffer (if any).

The reason for this behavior was that there was existing client code in Falcor that relied on that behavior for parameter blocks, and even after changing the way that parameter block layouts were computed and stored we sought to maintain backwards compatibility with that client code. The trouble is that the weird behavior then goes on to cause confusion for other clients of the Slang reflection API.

This change removes the special-case logic, and fixes up our reflection tests to mirror the new (correct) information that we return.

When this change is released, it will be a breaking change for any client code that still relies on the old behavior. We will need to coordinate with client application developers to fix their reflection logic. Note that all the same information can still be accessed, simply by using new reflection API that we have added.