### PR TITLE
Dynamic dispatch bug fixes.

### DIFF
--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -1724,6 +1724,10 @@ void CPPSourceEmitter::emitRTTIObject(IRRTTIObject* rttiObject)
 void CPPSourceEmitter::_maybeEmitWitnessTableTypeDefinition(
     IRInterfaceType* interfaceType)
 {
+    if (m_interfaceTypesEmitted.Contains(interfaceType))
+        return;
+    m_interfaceTypesEmitted.Add(interfaceType);
+
     m_writer->emit("struct ");
     emitSimpleType(interfaceType);
     m_writer->emit("\n{\n");

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -137,6 +137,8 @@ protected:
 
     HashSet<const HLSLIntrinsic*> m_intrinsicEmitted;
 
+    HashSet<IRInterfaceType*> m_interfaceTypesEmitted;
+
     StringSlicePool m_slicePool;
 
     SemanticUsedFlags m_semanticUsedFlags;


### PR DESCRIPTION
Bug fixes for dynamic dispatch compiler passes.

- Prevent redundant witness table types being emitted.
- Prevent lower-generic passes that does in-place instruction modification from corrupting `IRSharedBuilder::globalValueNumberingMap` and `IRSharedBuilder::constantMap`s.