### PR TITLE
Search for multiple NVRTC versions

### DIFF
--- a/source/slang/slang-check.cpp
+++ b/source/slang/slang-check.cpp
@@ -157,7 +157,10 @@ namespace Slang
                 // "I need all of these libraries" vs. "I need at least one of these
                 // libraries").
                 //
-                sink->diagnose(SourceLoc(), Diagnostics::failedToLoadDownstreamCompiler, type);
+                if( sink )
+                {
+                    sink->diagnose(SourceLoc(), Diagnostics::failedToLoadDownstreamCompiler, type);
+                }
                 SinkSharedLibraryLoader loader(m_sharedLibraryLoader, sink);
                 locator(m_downstreamCompilerPaths[int(type)], &loader, m_downstreamCompilerSet);
             }

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -105,6 +105,12 @@ namespace Slang
         }
     }
 
+    void printDiagnosticArg(StringBuilder& sb, PassThroughMode val)
+    {
+        sb << TypeTextUtil::getPassThroughName(SlangPassThrough(val));
+    }
+
+
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!! CompileResult !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     SlangResult CompileResult::getSharedLibrary(ComPtr<ISlangSharedLibrary>& outSharedLibrary)

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -845,6 +845,7 @@ namespace Slang
         NVRTC = SLANG_PASS_THROUGH_NVRTC,
         CountOf = SLANG_PASS_THROUGH_COUNT_OF,              
     };
+    void printDiagnosticArg(StringBuilder& sb, PassThroughMode val);
 
     class SourceFile;
 

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -118,6 +118,15 @@ DIAGNOSTIC(    86, Error, unableToCreateModuleContainer, "unable to create modul
 
 DIAGNOSTIC(    87, Error, unableToSetDefaultDownstreamCompiler, "unable to set default downstream compiler for source language '%0' to '%1'")
 
+
+//
+// 001xx - Downstream Compilers
+//
+
+DIAGNOSTIC(  100, Error, failedToLoadDownstreamCompiler, "failed to load downstream compiler '$0'")
+DIAGNOSTIC(99999, Note, noteFailedToLoadDynamicLibrary, "failed to load dynamic library '$0'")
+
+
 //
 // 1xxxx - Lexical analysis
 //

--- a/tools/slang-test/options.h
+++ b/tools/slang-test/options.h
@@ -47,7 +47,7 @@ struct Options
     char const* testPrefix = nullptr;
 
     // generate extra output (notably: command lines we run)
-    bool shouldBeVerbose = true;
+    bool shouldBeVerbose = false;
 
     // When true results from ignored tests are not shown
     bool hideIgnored = false;

--- a/tools/slang-test/options.h
+++ b/tools/slang-test/options.h
@@ -47,7 +47,7 @@ struct Options
     char const* testPrefix = nullptr;
 
     // generate extra output (notably: command lines we run)
-    bool shouldBeVerbose = false;
+    bool shouldBeVerbose = true;
 
     // When true results from ignored tests are not shown
     bool hideIgnored = false;


### PR DESCRIPTION
The main change here is that when locating the NVRTC compiler we try multiple library names and take the first one that loads successfully (with an ordering that means we try newer versions before older ones).

In order to support this change, I needed to fix the wrapping logic that invokes the downstream compiler "locator" function, so that it does not report every failed dynamic library load as an error diagnostic (leading to compilation failure), but instead only reports such failures once the locator has reported failure.

The form of the diagnostic output for failures is also changed, in that we now report a single umbrella error about failing to load a downstream compiler, and then report the actuall dynamic library load failures as notes on that diagnostic instead of errors of their own. This choice seems appropriate since for cases like NVRTC it is *not* the case that each failed library load is a compilation error. We only need one of the listed libraries to be loadable, so that reporting them all as errors risks confusing users.

One wrinkle that arose during testing is that the 11.0 release of NVRTC dropped support for the `compute_30` target, which had previously been the minimum and default. I had to add logic to check for versions of 11 or greater and switch to `compute_35` as the default. Similar changes may be required as part of supporting newer NVRTC versions if support for more architectures gets deprecated and removed.

A more complete implementation of this logic might try to load multiple NVRTC versions such that the Slang compiler can identify a suitable compiler based on the minimum feature level that code actually requires. That kind of cleanup is left as future work, since for most users the current approach will be sufficient.