### PR TITLE
Enable all dynamic dispatch tests on CUDA.

### DIFF
--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -999,7 +999,8 @@ bool CLikeSourceEmitter::shouldFoldInstIntoUseSites(IRInst* inst)
     // if target langauge doesn't support pointers.
     if(as<IRPtrTypeBase>(type))
     {
-        return !doesTargetSupportPtrTypes();
+        if (!doesTargetSupportPtrTypes())
+            return true;
     }
 
     // First we check for uniform parameter groups,

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -254,7 +254,7 @@ public:
     UInt getCallablePayloadLocation(IRInst* inst);
 
         /// Emit modifiers that should apply even for a declaration of an SSA temporary.
-    void emitTempModifiers(IRInst* temp);
+    virtual void emitTempModifiers(IRInst* temp);
 
     void emitVarModifiers(IRVarLayout* layout, IRInst* varDecl, IRType* varType);
 

--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -79,6 +79,15 @@ static bool _isSingleNameBasicType(IROp op)
     }
 }
 
+void CUDASourceEmitter::emitTempModifiers(IRInst* temp)
+{
+    CPPSourceEmitter::emitTempModifiers(temp);
+    if (as<IRModuleInst>(temp->getParent()))
+    {
+        m_writer->emit("__device__ ");
+    }
+}
+
 SlangResult CUDASourceEmitter::_calcCUDATextureTypeName(IRTextureTypeBase* texType, StringBuilder& outName)
 {
     // Not clear how to do this yet
@@ -324,7 +333,7 @@ String CUDASourceEmitter::generateEntryPointNameImpl(IREntryPointDecoration* ent
 
 void CUDASourceEmitter::emitGlobalRTTISymbolPrefix()
 {
-    m_writer->emit("__device__");
+    m_writer->emit("__device__ ");
 }
 
 void CUDASourceEmitter::emitCall(const HLSLIntrinsic* specOp, IRInst* inst, const IRUse* operands, int numOperands, const EmitOpInfo& inOuterPrec)

--- a/source/slang/slang-emit-cuda.h
+++ b/source/slang/slang-emit-cuda.h
@@ -34,6 +34,7 @@ public:
     static UnownedStringSlice getVectorPrefix(IROp op);
 
     virtual RefObject* getExtensionTracker() SLANG_OVERRIDE { return m_extensionTracker; }
+    virtual void emitTempModifiers(IRInst* temp) SLANG_OVERRIDE;
 
     CUDASourceEmitter(const Desc& desc) :
         Super(desc),

--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -1480,7 +1480,7 @@ LinkedIR linkIR(
             cloneValue(context, bindInst);
         }
     }
-    if (target == CodeGenTarget::CPPSource)
+    if (target == CodeGenTarget::CPPSource || target == CodeGenTarget::CUDASource)
     {
         for (IRModule* irModule : irModules)
         {

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -5274,6 +5274,7 @@ namespace Slang
         case kIROp_RTTIType:
         case kIROp_Func:
         case kIROp_Generic:
+        case kIROp_Var:
         case kIROp_GlobalVar: // Note: the IRGlobalVar represents the *address*, so only a load/store would have side effects
         case kIROp_GlobalConstant:
         case kIROp_GlobalParam:

--- a/tests/bugs/vk-image-atomics.slang.glsl
+++ b/tests/bugs/vk-image-atomics.slang.glsl
@@ -9,10 +9,8 @@ out vec4 _S1;
 
 void main()
 {
-    const uint _S2 = uint(1);
-
-    uint _S3;
-    _S3 = imageAtomicAdd(t_0, ivec2(uvec2(0)), _S2);
-    _S1 = vec4(_S3);
+    uint _S2;
+    _S2 = imageAtomicAdd(t_0, ivec2(uvec2(0)), 1);
+    _S1 = vec4(_S2);
     return;
 }

--- a/tests/compute/dynamic-dispatch-10.slang
+++ b/tests/compute/dynamic-dispatch-10.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
 
 // Test dynamic dispatch code gen for specializing a generic with
 // an existential value.

--- a/tests/compute/dynamic-dispatch-11.slang
+++ b/tests/compute/dynamic-dispatch-11.slang
@@ -1,7 +1,7 @@
 // Test using interface typed shader parameters with dynamic dispatch.
 
 //TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
 
 [anyValueSize(8)]
 interface IInterface

--- a/tests/compute/dynamic-dispatch-12.slang
+++ b/tests/compute/dynamic-dispatch-12.slang
@@ -1,7 +1,7 @@
 // Test using interface typed shader parameters with dynamic dispatch.
 
 //TEST(compute):COMPARE_COMPUTE:-cpu
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-cuda
 
 [anyValueSize(8)]
 interface IInterface

--- a/tests/compute/dynamic-dispatch-13.slang
+++ b/tests/compute/dynamic-dispatch-13.slang
@@ -1,7 +1,7 @@
 // Test using interface typed shader parameters wrapped inside a `StructuredBuffer`.
 
 //TEST(compute):COMPARE_COMPUTE:-cpu
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-cuda
 
 [anyValueSize(8)]
 interface IInterface

--- a/tests/compute/dynamic-dispatch-2.slang
+++ b/tests/compute/dynamic-dispatch-2.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
 
 // Test dynamic dispatch code gen for static member functions
 // of associated type.

--- a/tests/compute/dynamic-dispatch-3.slang
+++ b/tests/compute/dynamic-dispatch-3.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
 
 // Test dynamic dispatch code gen for static member functions
 // of associated type.

--- a/tests/compute/dynamic-dispatch-4.slang
+++ b/tests/compute/dynamic-dispatch-4.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
 
 // Test dynamic dispatch code gen for generic-typed local variables.
 

--- a/tests/compute/dynamic-dispatch-5.slang
+++ b/tests/compute/dynamic-dispatch-5.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
 
 // Test dynamic dispatch code gen for general `This` type.
 [anyValueSize(8)]

--- a/tests/compute/dynamic-dispatch-6.slang
+++ b/tests/compute/dynamic-dispatch-6.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
 
 // Test dynamic dispatch code gen for generic-typed return values.
 [anyValueSize(8)]

--- a/tests/compute/dynamic-dispatch-7.slang
+++ b/tests/compute/dynamic-dispatch-7.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
 
 // Test dynamic dispatch code gen for associated-typed return values
 // and local variables.

--- a/tests/compute/dynamic-dispatch-8.slang
+++ b/tests/compute/dynamic-dispatch-8.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
 
 // Test dynamic dispatch code gen for extential type parameters.
 

--- a/tests/compute/dynamic-dispatch-9.slang
+++ b/tests/compute/dynamic-dispatch-9.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
 
 // Test dynamic dispatch code gen for initializing an extential value
 // from a generic value.

--- a/tests/cross-compile/sv-coverage.slang.glsl
+++ b/tests/cross-compile/sv-coverage.slang.glsl
@@ -9,11 +9,8 @@ in vec4 _S2;
 
 void main()
 {
-    uint _S3 = uint(gl_SampleMaskIn[0]);
-    uint _S4;
-
-    _S4 = _S3 ^ uint(1);
+    uint _S3 = uint(gl_SampleMaskIn[0]) ^ uint(1);
     _S1 = _S2;
-    gl_SampleMask[0] = int(_S4);
+    gl_SampleMask[0] = int(_S3);
     return;
 }

--- a/tests/slang-extension/atomic-float-byte-address-buffer-cross.slang.glsl
+++ b/tests/slang-extension/atomic-float-byte-address-buffer-cross.slang.glsl
@@ -38,12 +38,9 @@ layout(local_size_x = 16, local_size_y = 1, local_size_z = 1) in;void main()
 
     float delta_0 = ((anotherBuffer_0)._data[(uint(idx_0 & 3))]);
 
-
-    uint _S13 = uint(idx_0 << 2);
-
 #line 21
-    float _S14;
-    RWByteAddressBuffer_InterlockedAddF32_0(_S13, 1.00000000000000000000, _S14);
+    float _S13;
+    RWByteAddressBuffer_InterlockedAddF32_0(uint(idx_0 << 2), 1.00000000000000000000, _S13);
     RWByteAddressBuffer_InterlockedAddF32_1(uint(int(tid_0 >> 2) << 2), delta_0);
 
 #line 13

--- a/tests/vkray/intersection.slang.glsl
+++ b/tests/vkray/intersection.slang.glsl
@@ -9,12 +9,10 @@
 #define tmp_direction _S4
 #define tmp_tmin _S5
 #define tmp_tmax _S6
-#define tmp_ray _S7
-#define tmp_sphere _S8
-#define tmp_thit _S9
-#define tmp_hitattrs _S10
-#define tmp_dithit _S11
-#define tmp_reportresult _S12
+#define tmp_thit _S7
+#define tmp_hitattrs _S8
+#define tmp_dithit _S9
+#define tmp_reportresult _S10
 
 struct Sphere_0
 {
@@ -83,13 +81,9 @@ void main()
     float tmp_tmax = gl_RayTmaxNV;
     ray_1.TMax_0 = tmp_tmax;
 
-    RayDesc_0 tmp_ray = ray_1;
-
-    Sphere_0 tmp_sphere = U_0._data.gSphere_0;
-
     float tmp_thit;
     SphereHitAttributes_0 tmp_hitattrs;
-    bool tmp_dithit = rayIntersectsSphere_0(tmp_ray, tmp_sphere, tmp_thit, tmp_hitattrs);
+    bool tmp_dithit = rayIntersectsSphere_0(ray_1, U_0._data.gSphere_0, tmp_thit, tmp_hitattrs);
 
     float tHit_2 = tmp_thit;
     SphereHitAttributes_0 attrs_1 = tmp_hitattrs;


### PR DESCRIPTION
This change enables all the remaining dynamic dispatch tests on CUDA.

The main issue being addressed is that some global temporaries are not being emitted to CUDA code correctly (missing the `__device__`) specifier, and caused CUDA compiler to fail. The fix is to overload `emitTempModifiers` for CUDA and emit an `__device__` specifier there.

The second issue is that none of these temporaries are necessary (e.g. `getAddress(witnessTable)`) as they should be folded as an expression. They are somehow being emitted because the logic around pointer type is over conservative.

The last issue is that the handling of `public` modifiers in linking step should be turned on for CUDA in addition to C++ target.