### PR TITLE
Simplify workflow when using NVAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ tests/**/*.slang-module
 /source/slang/slang-ast-generated-macro.h
 /source/slang/hlsl.meta.slang.h
 /source/slang/core.meta.slang.h
+prelude/*.h.cpp

--- a/prelude/slang-hlsl-prelude.h
+++ b/prelude/slang-hlsl-prelude.h
@@ -1,0 +1,3 @@
+#ifdef SLANG_HLSL_ENABLE_NVAPI
+#include "nvHLSLExtns.h"
+#endif

--- a/premake5.lua
+++ b/premake5.lua
@@ -954,7 +954,10 @@ standardProject "slang"
     -- compile for their embedded code, since they will not
     -- exist at the time projects/makefiles are generated,
     -- and thus a glob would not match anything.
-    files { "prelude/slang-cuda-prelude.h.cpp" }
+    files {
+        "prelude/slang-cuda-prelude.h.cpp",
+        "prelude/slang-hlsl-prelude.h.cpp",
+    }
 
     -- 
     -- The most challenging part of building `slang` is that we need

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -161,6 +161,11 @@ namespace Slang
             return !(*this == other);
         }
 
+        bool operator!=(char const* str) const
+        {
+            return (*this) != UnownedStringSlice(str, str + ::strlen(str));
+        }
+
         bool startsWith(UnownedStringSlice const& other) const;
         bool startsWith(char const* str) const;
 

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2079,3 +2079,6 @@ attribute_syntax [anyValueSize(size:int)] : AnyValueSizeAttribute;
 
 __attributeTarget(DeclBase)
 attribute_syntax [builtin] : BuiltinAttribute;
+
+__attributeTarget(DeclBase)
+attribute_syntax [__requiresNVAPI] : RequiresNVAPIAttribute;

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -285,6 +285,7 @@ ${{{{
     __target_intrinsic(hlsl, "($3 = NvInterlockedAddFp32($0, $1, $2))")
     __cuda_sm_version(2.0)
     __target_intrinsic(cuda, "(*$3 = atomicAdd((float*)$0._getPtrAt($1), $2))")
+    [__requiresNVAPI]
     void InterlockedAddF32(uint byteAddress, float valueToAdd, out float originalValue);
 
     __specialized_for_target(glsl)

--- a/source/slang/run-generators.vcxproj
+++ b/source/slang/run-generators.vcxproj
@@ -209,6 +209,19 @@
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../../bin/windows-x86/release/slang-embed.exe</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">../../bin/windows-x64/release/slang-embed.exe</AdditionalInputs>
     </CustomBuild>
+    <CustomBuild Include="..\..\prelude\slang-hlsl-prelude.h">
+      <FileType>Document</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"../../bin/windows-x86/debug/slang-embed" %(Identity)</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"../../bin/windows-x64/debug/slang-embed" %(Identity)</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"../../bin/windows-x86/release/slang-embed" %(Identity)</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"../../bin/windows-x64/release/slang-embed" %(Identity)</Command>
+      <Outputs>../../prelude/slang-hlsl-prelude.h.cpp</Outputs>
+      <Message>slang-embed %(Identity)</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">../../bin/windows-x86/debug/slang-embed.exe</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">../../bin/windows-x64/debug/slang-embed.exe</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../../bin/windows-x86/release/slang-embed.exe</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">../../bin/windows-x64/release/slang-embed.exe</AdditionalInputs>
+    </CustomBuild>
     <CustomBuild Include="core.meta.slang">
       <FileType>Document</FileType>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"../../bin/windows-x86/debug/slang-generate" %(Identity)</Command>

--- a/source/slang/run-generators.vcxproj.filters
+++ b/source/slang/run-generators.vcxproj.filters
@@ -26,6 +26,9 @@
     <CustomBuild Include="..\..\prelude\slang-cuda-prelude.h">
       <Filter>Header Files</Filter>
     </CustomBuild>
+    <CustomBuild Include="..\..\prelude\slang-hlsl-prelude.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
     <CustomBuild Include="core.meta.slang">
       <Filter>Source Files</Filter>
     </CustomBuild>

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -893,4 +893,47 @@ class AnyValueSizeAttribute : public Attribute
     int32_t size;
 };
 
+    /// A `[__requiresNVAPI]` attribute indicates that the declaration being modifed
+    /// requires NVAPI operations for its implementation on D3D.
+class RequiresNVAPIAttribute : public Attribute
+{
+    SLANG_CLASS(RequiresNVAPIAttribute)
+};
+
+    /// Indicates that the modified declaration is one of the "magic" declarations
+    /// that NVAPI uses to communicate extended operations. When NVAPI is being included
+    /// via the prelude for downstream compilation, declarations with this modifier
+    /// will not be emitted, instead allowing the versions from the prelude to be used.
+class NVAPIMagicModifier : public Modifier
+{
+    SLANG_CLASS(NVAPIMagicModifier)
+};
+
+    /// A modifier that attaches to a `ModuleDecl` to indicate the register/space binding
+    /// that NVAPI wants to use, as indicated by, e.g., the `NV_SHADER_EXTN_SLOT` and
+    /// `NV_SHADER_EXTN_REGISTER_SPACE` preprocessor definitions.
+class NVAPISlotModifier : public Modifier
+{
+    SLANG_CLASS(NVAPISlotModifier)
+
+        /// The name of the register that is to be used (e.g., `"u3"`)
+        ///
+        /// This value will come from the `NV_SHADER_EXTN_SLOT` macro, if set.
+        ///
+        /// The `registerName` field must always be filled in when adding
+        /// an `NVAPISlotModifier` to a module; if no register name is defined,
+        /// then the modifier should not be added.
+        ///
+    String registerName;
+
+        /// The name of the register space to be used (e.g., `space1`)
+        ///
+        /// This value will come from the `NV_SHADER_EXTN_REGISTER_SPACE` macro,
+        /// if set.
+        ///
+        /// It is valid for a user to specify a register name but not a space name,
+        /// and in that case `spaceName` will be set to `"space0"`.
+    String spaceName;
+};
+
 } // namespace Slang

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -555,6 +555,15 @@ DIAGNOSTIC(52003, Error, cppCompilerNotFound, "Could not find a suitable C/C++ c
 DIAGNOSTIC(52004, Error, unableToWriteFile, "Unable to write file '$0'")
 DIAGNOSTIC(52005, Error, unableToReadFile, "Unable to read file '$0'")
 
+//
+// 8xxxx - Issues specific to a particular library/technology/platform/etc.
+//
+
+// 811xx - NVAPI
+
+DIAGNOSTIC(81110, Error, nvapiMacroMismatch, "conflicting definitions for NVAPI macro '$0': '$1' and '$2'")
+
+
 // 99999 - Internal compiler errors, and not-yet-classified diagnostics.
 
 DIAGNOSTIC(99999, Internal, unimplemented, "unimplemented feature in Slang compiler: $0")

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -674,6 +674,18 @@ String CLikeSourceEmitter::generateName(IRInst* inst)
         return String(intrinsicDecoration->getDefinition());
     }
 
+    // If the instruction reprsents one of the "magic" declarations
+    // that makes the NVAPI library work, then we want to make sure
+    // it uses the original name it was declared with, so that our
+    // generated code will work correctly with either a Slang-compiled
+    // or directly `#include`d version of those declarations during
+    // downstream compilation.
+    //
+    if(auto nvapiDecor = inst->findDecoration<IRNVAPIMagicDecoration>())
+    {
+        return String(nvapiDecor->getName());
+    }
+
     auto entryPointDecor = inst->findDecoration<IREntryPointDecoration>();
     if (entryPointDecor)
     {
@@ -1997,12 +2009,23 @@ void CLikeSourceEmitter::_emitCallArgList(IRCall* inst)
     m_writer->emit(")");
 }
 
+void CLikeSourceEmitter::handleRequiredCapabilities(IRInst* inst)
+{
+    auto decoratedValue = inst;
+    while (auto specInst = as<IRSpecialize>(decoratedValue))
+    {
+        decoratedValue = getSpecializedValue(specInst);
+    }
+
+    handleRequiredCapabilitiesImpl(decoratedValue);
+}
+
 void CLikeSourceEmitter::emitCallExpr(IRCall* inst, EmitOpInfo outerPrec)
 {
     auto funcValue = inst->getOperand(0);
 
     // Does this function declare any requirements.
-    handleCallExprDecorationsImpl(funcValue);
+    handleRequiredCapabilities(funcValue);
 
     // We want to detect any call to an intrinsic operation,
     // that we can emit it directly without mangling, etc.
@@ -3214,6 +3237,10 @@ void CLikeSourceEmitter::emitSimpleFuncImpl(IRFunc* func)
         emitEntryPointAttributes(func, entryPointDecor);
     }
 
+    // Deal with required features/capabilities of the function
+    //
+    handleRequiredCapabilitiesImpl(func);
+
     emitFunctionPreambleImpl(func);
 
     auto name = getName(func);
@@ -3734,6 +3761,11 @@ void CLikeSourceEmitter::emitGlobalParam(IRGlobalParam* varDecl)
 }
 
 void CLikeSourceEmitter::emitGlobalInst(IRInst* inst)
+{
+    emitGlobalInstImpl(inst);
+}
+
+void CLikeSourceEmitter::emitGlobalInstImpl(IRInst* inst)
 {
     m_writer->advanceToSourceLocation(inst->sourceLoc);
 

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -270,6 +270,7 @@ public:
     void emitGlobalParam(IRGlobalParam* varDecl);
 
     void emitGlobalInst(IRInst* inst);
+    virtual void emitGlobalInstImpl(IRInst* inst);
 
     void ensureInstOperand(ComputeEmitActionsContext* ctx, IRInst* inst, EmitAction::Level requiredLevel = EmitAction::Level::Definition);
 
@@ -281,6 +282,13 @@ public:
 
     void executeEmitActions(List<EmitAction> const& actions);
     void emitModule(IRModule* module) { m_irModule = module; emitModuleImpl(module); }
+
+        /// Emit any preprocessor directives that should come *before* the prelude code
+        ///
+        /// These are directives that are intended to customize some aspect(s) of the
+        /// prelude's behavior.
+        ///
+    void emitPreludeDirectives() { emitPreludeDirectivesImpl(); }
 
     void emitPreprocessorDirectives() { emitPreprocessorDirectivesImpl(); }
     void emitSimpleType(IRType* type);
@@ -308,6 +316,7 @@ public:
 
     virtual void emitImageFormatModifierImpl(IRInst* varDecl, IRType* varType) { SLANG_UNUSED(varDecl); SLANG_UNUSED(varType); }
     virtual void emitLayoutQualifiersImpl(IRVarLayout* layout) { SLANG_UNUSED(layout); }
+    virtual void emitPreludeDirectivesImpl() {}
     virtual void emitPreprocessorDirectivesImpl() {}
     virtual void emitLayoutDirectivesImpl(TargetRequest* targetReq) { SLANG_UNUSED(targetReq); }
     virtual void emitRateQualifiersImpl(IRRate* rate) { SLANG_UNUSED(rate); }
@@ -338,10 +347,14 @@ public:
     virtual void emitInterface(IRInterfaceType* interfaceType);
     virtual void emitRTTIObject(IRRTTIObject* rttiObject);
 
-    virtual void handleCallExprDecorationsImpl(IRInst* funcValue) { SLANG_UNUSED(funcValue); }
-
     virtual bool tryEmitGlobalParamImpl(IRGlobalParam* varDecl, IRType* varType) { SLANG_UNUSED(varDecl); SLANG_UNUSED(varType); return false; }
     virtual bool tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec) { SLANG_UNUSED(inst); SLANG_UNUSED(inOuterPrec); return false; }
+
+        /// Inspect the capabilities required by `inst` (according to its decorations),
+        /// and ensure that those capabilities have been detected and stored in the
+        /// target-specific extension tracker.
+    void handleRequiredCapabilities(IRInst* inst);
+    virtual void handleRequiredCapabilitiesImpl(IRInst* inst) { SLANG_UNUSED(inst); }
 
     void _emitArrayType(IRArrayType* arrayType, EDeclarator* declarator);
     void _emitUnsizedArrayType(IRUnsizedArrayType* arrayType, EDeclarator* declarator);

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -2184,7 +2184,7 @@ bool CPPSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOut
             auto funcValue = inst->getOperand(0);
 
             // Does this function declare any requirements.
-            handleCallExprDecorationsImpl(funcValue);
+            handleRequiredCapabilities(funcValue);
 
             // try doing automatically
             return _tryEmitInstExprAsIntrinsic(inst, inOuterPrec);

--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -592,18 +592,12 @@ void CUDASourceEmitter::_requireCUDASMVersion(SemanticVersion const& version)
     }
 }
 
-void CUDASourceEmitter::handleCallExprDecorationsImpl(IRInst* funcValue)
+void CUDASourceEmitter::handleRequiredCapabilitiesImpl(IRInst* inst)
 {
-    // Does this function declare any requirements on GLSL version or
-    // extensions, which should affect our output?
+    // Does this function declare any requirements on CUDA capabilities
+    // that should affect output?
 
-    auto decoratedValue = funcValue;
-    while (auto specInst = as<IRSpecialize>(decoratedValue))
-    {
-        decoratedValue = getSpecializedValue(specInst);
-    }
-
-    for (auto decoration : decoratedValue->getDecorations())
+    for (auto decoration : inst->getDecorations())
     {
         if( auto smDecoration = as<IRRequireCUDASMVersionDecoration>(decoration))
         {

--- a/source/slang/slang-emit-cuda.h
+++ b/source/slang/slang-emit-cuda.h
@@ -64,7 +64,7 @@ protected:
 
     virtual void emitLoopControlDecorationImpl(IRLoopControlDecoration* decl) SLANG_OVERRIDE;
 
-    virtual void handleCallExprDecorationsImpl(IRInst* funcValue) SLANG_OVERRIDE;
+    virtual void handleRequiredCapabilitiesImpl(IRInst* inst) SLANG_OVERRIDE;
 
     virtual bool tryEmitGlobalParamImpl(IRGlobalParam* varDecl, IRType* varType) SLANG_OVERRIDE;
     virtual bool tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -1452,18 +1452,12 @@ bool GLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
     return false;
 }
 
-void GLSLSourceEmitter::handleCallExprDecorationsImpl(IRInst* funcValue)
+void GLSLSourceEmitter::handleRequiredCapabilitiesImpl(IRInst* inst)
 {
     // Does this function declare any requirements on GLSL version or
     // extensions, which should affect our output?
 
-    auto decoratedValue = funcValue;
-    while (auto specInst = as<IRSpecialize>(decoratedValue))
-    {
-        decoratedValue = getSpecializedValue(specInst);
-    }
-
-    for (auto decoration : decoratedValue->getDecorations())
+    for (auto decoration : inst->getDecorations())
     {
         switch (decoration->op)
         {

--- a/source/slang/slang-emit-glsl.h
+++ b/source/slang/slang-emit-glsl.h
@@ -44,7 +44,7 @@ protected:
     virtual void emitVarDecorationsImpl(IRInst* varDecl) SLANG_OVERRIDE;
     virtual void emitMatrixLayoutModifiersImpl(IRVarLayout* layout) SLANG_OVERRIDE;
 
-    virtual void handleCallExprDecorationsImpl(IRInst* funcValue) SLANG_OVERRIDE;
+    virtual void handleRequiredCapabilitiesImpl(IRInst* inst) SLANG_OVERRIDE;
 
     virtual bool tryEmitGlobalParamImpl(IRGlobalParam* varDecl, IRType* varType) SLANG_OVERRIDE;
     virtual bool tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;

--- a/source/slang/slang-emit-hlsl.h
+++ b/source/slang/slang-emit-hlsl.h
@@ -7,16 +7,27 @@
 namespace Slang
 {
 
+class HLSLExtensionTracker : public RefObject
+{
+public:
+        /// Has any operation been used that requires NVAPI to be included via prelude?
+    bool m_requiresNVAPI = false;
+};
+
 class HLSLSourceEmitter : public CLikeSourceEmitter
 {
 public:
     typedef CLikeSourceEmitter Super;
 
-    HLSLSourceEmitter(const Desc& desc) :
-        Super(desc)
+    HLSLSourceEmitter(const Desc& desc)
+        : Super(desc)
+        , m_extensionTracker(new HLSLExtensionTracker)
     {}
 
+    virtual RefObject* getExtensionTracker() SLANG_OVERRIDE { return m_extensionTracker; }
+
 protected:
+    RefPtr<HLSLExtensionTracker> m_extensionTracker;
 
     virtual void emitLayoutSemanticsImpl(IRInst* inst, char const* uniformSemanticSpelling) SLANG_OVERRIDE;
     virtual void emitParameterGroupImpl(IRGlobalParam* varDecl, IRUniformParameterGroupType* type) SLANG_OVERRIDE;
@@ -34,6 +45,11 @@ protected:
     virtual bool tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;
     virtual void emitSimpleValueImpl(IRInst* inst) SLANG_OVERRIDE;
     virtual void emitLoopControlDecorationImpl(IRLoopControlDecoration* decl) SLANG_OVERRIDE;
+
+    virtual void handleRequiredCapabilitiesImpl(IRInst* inst) SLANG_OVERRIDE;
+    virtual void emitPreludeDirectivesImpl() SLANG_OVERRIDE;
+
+    virtual void emitGlobalInstImpl(IRInst* inst) SLANG_OVERRIDE;
 
         // Emit a single `register` semantic, as appropriate for a given resource-type-specific layout info
         // Keyword to use in the uniform case (`register` for globals, `packoffset` inside a `cbuffer`)

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -825,6 +825,8 @@ SlangResult emitEntryPointsSourceFromIR(
     // Now that we've emitted the code for all the declarations in the file,
     // it is time to stitch together the final output.
 
+    sourceEmitter->emitPreludeDirectives();
+
     {
         // If there is a prelude emit it
         const auto& prelude = compileRequest->getSession()->getPreludeForLanguage(sourceLanguage);

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -565,6 +565,16 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
 
     INST(BuiltinDecoration, BuiltinDecoration, 0, 0)
 
+        /// The decorated instruction requires NVAPI to be included via prelude when compiling for D3D.
+    INST(RequiresNVAPIDecoration, requiresNVAPI, 0, 0)
+
+        /// The decorated instruction is part of the NVAPI "magic" and should always use its original name
+    INST(NVAPIMagicDecoration, nvapiMagic, 1, 0)
+
+        /// A decoration that applies to an entire IR module, and indicates the register/space binding
+        /// that the NVAPI shader parameter intends to use.
+    INST(NVAPISlotDecoration, nvapiSlot, 2, 0)
+
     INST(SemanticDecoration, semantic, 2, 0)
 
     INST_RANGE(Decoration, HighLevelDeclDecoration, SemanticDecoration)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -260,7 +260,28 @@ IR_SIMPLE_DECORATION(GloballyCoherentDecoration)
 IR_SIMPLE_DECORATION(PreciseDecoration)
 IR_SIMPLE_DECORATION(PublicDecoration)
 IR_SIMPLE_DECORATION(KeepAliveDecoration)
+IR_SIMPLE_DECORATION(RequiresNVAPIDecoration)
 
+struct IRNVAPIMagicDecoration : IRDecoration
+{
+    enum { kOp = kIROp_NVAPIMagicDecoration };
+    IR_LEAF_ISA(NVAPIMagicDecoration)
+
+    IRStringLit* getNameOperand() { return cast<IRStringLit>(getOperand(0)); }
+    UnownedStringSlice getName() { return getNameOperand()->getStringSlice(); }
+};
+
+struct IRNVAPISlotDecoration : IRDecoration
+{
+    enum { kOp = kIROp_NVAPISlotDecoration };
+    IR_LEAF_ISA(NVAPISlotDecoration)
+
+    IRStringLit* getRegisterNameOperand() { return cast<IRStringLit>(getOperand(0)); }
+    UnownedStringSlice getRegisterName() { return getRegisterNameOperand()->getStringSlice(); }
+
+    IRStringLit* getSpaceNameOperand() { return cast<IRStringLit>(getOperand(1)); }
+    UnownedStringSlice getSpaceName() { return getSpaceNameOperand()->getStringSlice(); }
+};
 
 struct IROutputControlPointsDecoration : IRDecoration
 {
@@ -2455,6 +2476,16 @@ struct IRBuilder
     void addPublicDecoration(IRInst* value)
     {
         addDecoration(value, kIROp_PublicDecoration);
+    }
+
+    void addNVAPIMagicDecoration(IRInst* value, UnownedStringSlice const& name)
+    {
+        addDecoration(value, kIROp_NVAPIMagicDecoration, getStringValue(name));
+    }
+
+    void addNVAPISlotDecoration(IRInst* value, UnownedStringSlice const& registerName, UnownedStringSlice const& spaceName)
+    {
+        addDecoration(value, kIROp_NVAPISlotDecoration, getStringValue(registerName), getStringValue(spaceName));
     }
 
         /// Add a decoration that indicates that the given `inst` depends on the given `dependency`.

--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -1499,6 +1499,45 @@ LinkedIR linkIR(
         }
     }
 
+    // It is possible that metadata has been attached to the input modules
+    // themselves, which should be copied over to the output module.
+    //
+    // In cases where multiple input modules specify the same metadata
+    // decoration, we will need rules to merge such decorations according
+    // to opcode-specific policy (e.g., a `[maxStackSizeRequired(...)]`
+    // decoration might use a maximum over all specified values, while a
+    // `[assumedWaveSize(...)]` decoration might require that all specified
+    // values match exactly).
+    //
+    for (IRModule* irModule : irModules)
+    {
+        for( auto decoration : irModule->getModuleInst()->getDecorations() )
+        {
+            switch( decoration->op )
+            {
+            case kIROp_NVAPISlotDecoration:
+                {
+                    // For now we just clone every decoration we see,
+                    // which means that an arbitrary one will end up
+                    // "winning" and being the one found by searches
+                    // in later code.
+                    //
+                    // TODO: need validation to check if decorations are
+                    // consistent with one another, in the case where
+                    // multiple input modules have matching decorations.
+                    //
+                    auto cloned = cloneInst(context, context->builder, decoration);
+                    cloned->insertAtStart(state->irModule->getModuleInst());
+                }
+                break;
+
+            default:
+                break;
+            }
+        }
+    }
+
+
     // TODO: *technically* we should consider the case where
     // we have global variables with initializers, since
     // these should get run whether or not the entry point

--- a/source/slang/slang-preprocessor.h
+++ b/source/slang/slang-preprocessor.h
@@ -10,6 +10,7 @@
 
 namespace Slang {
 
+class ASTBuilder;
 class DiagnosticSink;
 class Linkage;
 class Module;
@@ -22,7 +23,8 @@ TokenList preprocessSource(
     IncludeSystem*              includeSystem,
     Dictionary<String, String>  defines,
     Linkage*                    linkage,
-    Module*                     parentModule);
+    Module*                     parentModule,
+    ASTBuilder*                 astBuilder = nullptr);
 
 } // namespace Slang
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -42,6 +42,7 @@
 #endif
 
 extern char const* slang_cuda_prelude;
+extern char const* slang_hlsl_prelude;
 
 namespace Slang {
 
@@ -189,6 +190,7 @@ void Session::init()
 
     // Set up default prelude code for target languages that need a prelude
     m_languagePreludes[Index(SourceLanguage::CUDA)] = slang_cuda_prelude;
+    m_languagePreludes[Index(SourceLanguage::HLSL)] = slang_hlsl_prelude;
 }
 
 ISlangUnknown* Session::getInterface(const Guid& guid)
@@ -989,7 +991,8 @@ void FrontEndCompileRequest::parseTranslationUnit(
             &includeSystem,
             combinedPreprocessorDefinitions,
             getLinkage(),
-            module);
+            module,
+            astBuilder);
 
         parseSourceFile(
             astBuilder,

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -298,10 +298,8 @@
     <ClInclude Include="slang-visitor.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\prelude\slang-cpp-prelude.h.cpp" />
-    <ClCompile Include="..\..\prelude\slang-cpp-scalar-intrinsics.h.cpp" />
-    <ClCompile Include="..\..\prelude\slang-cpp-types.h.cpp" />
     <ClCompile Include="..\..\prelude\slang-cuda-prelude.h.cpp" />
+    <ClCompile Include="..\..\prelude\slang-hlsl-prelude.h.cpp" />
     <ClCompile Include="slang-ast-builder.cpp" />
     <ClCompile Include="slang-ast-decl.cpp" />
     <ClCompile Include="slang-ast-dump.cpp" />

--- a/source/slang/slang.vcxproj.filters
+++ b/source/slang/slang.vcxproj.filters
@@ -341,16 +341,10 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\prelude\slang-cpp-prelude.h.cpp">
-      <Filter>Header Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\prelude\slang-cpp-scalar-intrinsics.h.cpp">
-      <Filter>Header Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\prelude\slang-cpp-types.h.cpp">
-      <Filter>Header Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\prelude\slang-cuda-prelude.h.cpp">
+      <Filter>Header Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\prelude\slang-hlsl-prelude.h.cpp">
       <Filter>Header Files</Filter>
     </ClCompile>
     <ClCompile Include="slang-ast-builder.cpp">


### PR DESCRIPTION
In some cases, functionality is available as either a GLSL extension for Vulkan/SPIR-V, or through the NVAPI system for D3D. This situation creates complications because while GLSL extensions are generally all supported by the open-source glslang compiler (which we can bundle and ship), NVAPI operations are exposed through a specific header (`nvHLSLExtns.h`) that ships as part of the NVAPI SDK.

When a user wants to explicitly use NVAPI-provided operations in their shader code, there are no major complications for Slang; the user sets up their include paths, `#include`s the relevant header, calls functions in it, and lets Slang deal with the details of compilation.

The challenge for Slang arises when we want to provide a cross-platform interface in our standard library (e.g., the `RWByteAddressBuffer.InterlockedAddF32` method that was recently added) that uses either a GLSL extension (when compiling for Vulkan/SPIR-V) or an NVAPI (when compiling to DXBC or DXIL). In that case, the code *generated* by Slang now has a dependency on NVAPI, and we need to somehow emit a `#include` directive that pulls it in when invoking fxc or dxc. Because we do not (and seemingly cannot) bundle the NVAPI header with the compiler, we have to rely on ther user to have it available and to somehow communicate to Slang where it is.

Exposing portable routines that sometimes use NVAPI currently creates two main challenges:

1. The user is forced to interact with the "prelude" mechanism in the compiler, which allows the programmer to define code in a given target language that gets prepended to the Slang-generated code. While the prelude mechanism is powerful, it is also hard for users to integrate into their workflow, and our experience so far is that users want something that Just Works.

2. If the user writes code that uses some of our abstract operations that layer on NVAPI *and* they also want to use NVAPI explicitly, they end up with two copies of the NVAPI header (one included by the Slang front-end, and another included by the downstream fxc/dxc compiler). This puts the user in the situation of (a) having to ensure that they set the defines like `NV_SHADER_EXTN_SLOT` consistently both when invoking Slang and when adding their prelude, and (b) even if they do make the definitions consistent, they run into the problem that fxc/dxc complain about overlapping register bindings on the two copies of the `g_NvidiaExt` global shader paraemter that the NVAPI header declares.

This change attempts to resolve both issues by adding a lot of "do what I mean" logic to the compiler to try to ease things in the common case. In particular:

1. The user no longer needs to use the "prelude" mechanism when using NVAPI. The compiler now embeds a default prelude for HLSL output, which will `#include` the NVAPI header if and only if the generated code needs NVAPI access because of portable standard library routines that were used.

2. The user can mix-and-match explicit NVAPI use and stdlib functions that compile to use NVAPI. The register/space to be used by NVAPI when included via prelude is now set based on whatever the user set via the preprocessor so that it should automatically be consistent between both cases. Furthermore, the code we emit for the declaration of `g_NvidiaExt` when compiling explicit NVAPI use is set up to be conditional, so that it is skipped in the case where the prelude will pull in its own declaration of that parameter.

The way all this is achieved involves a lot of moving pieces:

* We now have an HLSL prelude, which mostly just serves to `#include "nvHLSLExtns.h"` in the case where NVAPI support is needed downstream.

* Standard library operations that require NVAPI for their implementation on HLSL include a new `[__requiresNVAPI]` attribute.

* The preprocessor has been extended so that after tokenizing an input file it looks up the NVAPI-relevant macros in the resulting environment, and if they are set it attached a modifier (`NVAPISlotModifier1) to the AST `ModuleDecl` that is based on their values. Logic is added to detect if multiple input files specify values for the macros in ways that conflict.

* The semantic checking step is extended so that it detects the "magic" NVAPI declarations (the `g_NvidiaExt` paramter and the `NvShaderExtnStruct` type that it uses) and attaches a modifier to them so that they can be identified as such in later steps.

* Parameter binding is extended to collect a list of the AST modifiers that reflect NVAPI binding, and to reserve the relevant register(s) so that ordinary user-defined parameters cannot conflict with them.

* IR lowering translates the three new AST modifiers related to NVAPI over to IR equivalents.

* IR linking is extended to make sure that it clones any `IRNVAPISlotDecoration`s attached to the input modules. The pass intentionally does not care where the modifiers came from; it just collects them all and leaves it to downstream code to sort out what they mean.

* Emit logic is extended to have a notion of "prelude directives" which are preprocessor directives that should come *before* the prelude in the generated code, because they can impact the way that the prelude compiles. This is done so that we don't have to introduce ad hoc logic for each downstream compiler to set any relevant `-D` flags (e.g., both fxc and dxc would need to duplicate such logic for NVAPI support).

* The HLSL source emitter is extended to track whether it emits any operations that require NVAPI support.

* The HLSL source emitter is extended to emit prelude directives based on whether NVAPI is needed and, if it is, to also set the register and space that NVAPI should use based on what was stored in the decoration(s) on the IR module.

* The HLSL source emitter is extended so that it detects global instructions that represent "magic" NVAPI constructs , and emit them as conditional definitions so that they are skipped when NVAPI is included via the prelude.

* The handling of requires capabilities during emit logic was cleaned up a bit so that more logic is shared across targets, and also so that the same logic is used both when emitting a function declaration/definition and when emitting a call to an instrinsic function (which won't get declared/defined).