### PR TITLE
Fix a bug around byte-address buffer loads of vectors

### DIFF
--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -2399,7 +2399,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
         emitOperand(inst->getOperand(0), getInfo(EmitOp::General));
         m_writer->emit(").Load<");
         emitType(inst->getDataType());
-        m_writer->emit(">(");
+        m_writer->emit(" >(");
         emitOperand(inst->getOperand(1), getInfo(EmitOp::General));
         m_writer->emit(")");
         break;


### PR DESCRIPTION
This problem is only visible when

* using `RWByteAddressBuffer.Load<V>`,
* when `V` is `vector<T,N>`,
* and `V` is a non-32-bit type

In such a case, the Slang compiler generates output HLSL like:

    someBuffer.Load<vector<T,N>>(someOffset);

and dxc balks because it fails to parse the `>>` as closing the generics, and instead parses it as a shift operator.

The solution here is simple: add a space before the closing `>` when emitting a `.Load<T>` operation.

Note that this change does not come with a test fix *yet* because writing the test case exposed a more complicated issue with GLSL codegen for this same scenario. This change includes the simple single-byte fix, to unblock users while we work on a fix for the GLSL case (and that fix will include the test coverage).