### PR TITLE
Add API for whole program compilation.

### DIFF
--- a/examples/cpu-hello-world/shader.slang
+++ b/examples/cpu-hello-world/shader.slang
@@ -3,6 +3,7 @@
 //TEST_INPUT:ubuffer(random(float, 4096, -1.0, 1.0), stride=4):name=ioBuffer
 RWStructuredBuffer<float> ioBuffer;
 
+[shader("compute")]
 [numthreads(4, 1, 1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {

--- a/slang.h
+++ b/slang.h
@@ -584,6 +584,7 @@ extern "C"
            @deprecated This behavior is now enabled unconditionally.
         */
         SLANG_TARGET_FLAG_PARAMETER_BLOCKS_USE_REGISTER_SPACES = 1 << 4,
+        SLANG_TARGET_FLAG_GENERATE_WHOLE_PROGRAM = 1 << 8
     };
 
     /*!
@@ -1656,6 +1657,36 @@ extern "C"
     SLANG_API SlangResult spGetEntryPointHostCallable(
         SlangCompileRequest*    request,
         int                     entryPointIndex,
+        int                     targetIndex,
+        ISlangSharedLibrary**   outSharedLibrary);
+
+    /** Get the output code associated with a specific target.
+
+    @param request   The request 
+    @param targetIndex The index of the target to get code for (default: zero).
+    @param outBlob A pointer that will receive the blob of code
+    @returns A `SlangResult` to indicate success or failure.
+
+    The lifetime of the output pointer is the same as `request`.
+    */
+    SLANG_API SlangResult spGetTargetCodeBlob(
+        SlangCompileRequest*    request,
+        int                     targetIndex,
+        ISlangBlob**            outBlob);
+
+    /** Get 'callable' functions for a target accessible through the ISlangSharedLibrary interface.
+
+    That the functions remain in scope as long as the ISlangSharedLibrary interface is in scope.
+
+    NOTE! Requires a compilation target of SLANG_HOST_CALLABLE.
+    
+    @param request          The request 
+    @param targetIndex      The index of the target to get code for (default: zero).
+    @param outSharedLibrary A pointer to a ISharedLibrary interface which functions can be queried on.
+    @returns                A `SlangResult` to indicate success or failure.
+    */
+    SLANG_API SlangResult spGetTargetHostCallable(
+        SlangCompileRequest*    request,
         int                     targetIndex,
         ISlangSharedLibrary**   outSharedLibrary);
 

--- a/slang.h
+++ b/slang.h
@@ -584,6 +584,11 @@ extern "C"
            @deprecated This behavior is now enabled unconditionally.
         */
         SLANG_TARGET_FLAG_PARAMETER_BLOCKS_USE_REGISTER_SPACES = 1 << 4,
+
+        /* When set, will generate target code that contains all entrypoints defined
+           in the input source or specified via the `spAddEntryPoint` function in a
+           single output module (library/source file).
+        */
         SLANG_TARGET_FLAG_GENERATE_WHOLE_PROGRAM = 1 << 8
     };
 
@@ -1633,8 +1638,6 @@ extern "C"
     @param targetIndex The index of the target to get code for (default: zero).
     @param outBlob A pointer that will receive the blob of code
     @returns A `SlangResult` to indicate success or failure.
-
-    The lifetime of the output pointer is the same as `request`.
     */
     SLANG_API SlangResult spGetEntryPointCodeBlob(
         SlangCompileRequest*    request,
@@ -1666,8 +1669,6 @@ extern "C"
     @param targetIndex The index of the target to get code for (default: zero).
     @param outBlob A pointer that will receive the blob of code
     @returns A `SlangResult` to indicate success or failure.
-
-    The lifetime of the output pointer is the same as `request`.
     */
     SLANG_API SlangResult spGetTargetCodeBlob(
         SlangCompileRequest*    request,

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -2197,24 +2197,23 @@ SlangResult dissassembleDXILUsingDXC(
     }
 
     CompileResult& TargetProgram::_createWholeProgramResult(
-        const List<Int>&        entryPointIndices,
         BackEndCompileRequest*  backEndRequest,
         EndToEndCompileRequest* endToEndRequest)
     {
-        for (auto entryPointIndex = entryPointIndices.begin(); entryPointIndex != entryPointIndices.end(); entryPointIndex++) {
-            if (*entryPointIndex >= m_entryPointResults.getCount())
-                m_entryPointResults.setCount(*entryPointIndex + 1);
+        // It is possible that entry points goot added to the `Program`
+        // *after* we created this `TargetProgram`, so there might be
+        // a request for an entry point that we didn't allocate space for.
+        //
+        // TODO: Change the construction logic so that a `Program` is
+        // constructed all at once rather than incrementally, to avoid
+        // this problem.
+        //
+        List<Int> entryPointIndices;
+        m_entryPointResults.setCount(m_program->getEntryPointCount());
+        entryPointIndices.setCount(m_program->getEntryPointCount());
+        for (Index i = 0; i < entryPointIndices.getCount(); i++)
+            entryPointIndices[i] = i;
 
-            // It is possible that entry points goot added to the `Program`
-            // *after* we created this `TargetProgram`, so there might be
-            // a request for an entry point that we didn't allocate space for.
-            //
-            // TODO: Change the construction logic so that a `Program` is
-            // constructed all at once rather than incrementally, to avoid
-            // this problem.
-            //
-            //auto entryPoint = m_program->getEntryPoint(*entryPointIndex);
-        }
         auto& result = m_wholeProgramResult;
         result = emitEntryPoints(
             m_program,
@@ -2224,7 +2223,6 @@ SlangResult dissassembleDXILUsingDXC(
             endToEndRequest);
 
         return result;
-
     }
 
     CompileResult& TargetProgram::_createEntryPointResult(
@@ -2256,7 +2254,6 @@ SlangResult dissassembleDXILUsingDXC(
     }
 
     CompileResult& TargetProgram::getOrCreateWholeProgramResult(
-        const List<Int>& entryPointIndices,
         DiagnosticSink* sink)
     {
         auto& result = m_wholeProgramResult;
@@ -2278,7 +2275,6 @@ SlangResult dissassembleDXILUsingDXC(
             m_program);
 
         return _createWholeProgramResult(
-            entryPointIndices,
             backEndRequest,
             nullptr);
     }
@@ -2325,10 +2321,9 @@ SlangResult dissassembleDXILUsingDXC(
         // Generate target code any entry points that
         // have been requested for compilation.
         auto entryPointCount = program->getEntryPointCount();
-        if (targetReq->isWholeProgramRequest)
+        if (targetReq->isWholeProgramRequest())
         {
             targetProgram->_createWholeProgramResult(
-                List<Int>(),
                 compileReq,
                 endToEndReq);
         }
@@ -2497,7 +2492,7 @@ SlangResult dissassembleDXILUsingDXC(
             for (auto targetReq : linkage->targets)
             {
                 Index entryPointCount = program->getEntryPointCount();
-                if (targetReq->isWholeProgramRequest) {
+                if (targetReq->isWholeProgramRequest()) {
                     writeWholeProgramResult(
                         compileRequest,
                         targetReq);

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -2200,14 +2200,10 @@ SlangResult dissassembleDXILUsingDXC(
         BackEndCompileRequest*  backEndRequest,
         EndToEndCompileRequest* endToEndRequest)
     {
-        // It is possible that entry points goot added to the `Program`
-        // *after* we created this `TargetProgram`, so there might be
-        // a request for an entry point that we didn't allocate space for.
-        //
-        // TODO: Change the construction logic so that a `Program` is
-        // constructed all at once rather than incrementally, to avoid
-        // this problem.
-        //
+        // We want to call `emitEntryPoints` function to generate code that contains
+        // all the entrypoints defined in `m_program`.
+        // The current logic of `emitEntryPoints` takes a list of entry-point indices to
+        // emit code for, so we construct such a list first.
         List<Int> entryPointIndices;
         m_entryPointResults.setCount(m_program->getEntryPointCount());
         entryPointIndices.setCount(m_program->getEntryPointCount());

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1132,7 +1132,10 @@ namespace Slang
         SlangTargetFlags    targetFlags = 0;
         Slang::Profile      targetProfile = Slang::Profile();
         FloatingPointMode   floatingPointMode = FloatingPointMode::Default;
-        bool                isWholeProgramRequest = false;
+        bool isWholeProgramRequest()
+        {
+            return (targetFlags & SLANG_TARGET_FLAG_GENERATE_WHOLE_PROGRAM) != 0;
+        }
 
         Linkage* getLinkage() { return linkage; }
         CodeGenTarget getTarget() { return target; }
@@ -1673,7 +1676,7 @@ namespace Slang
             /// code generation to the given `sink`.
             ///
         CompileResult& getOrCreateEntryPointResult(Int entryPointIndex, DiagnosticSink* sink);
-        CompileResult& getOrCreateWholeProgramResult(const List<Int>& entryPointIndices, DiagnosticSink* sink);
+        CompileResult& getOrCreateWholeProgramResult(DiagnosticSink* sink);
 
 
         CompileResult& getExistingWholeProgramResult()
@@ -1691,7 +1694,6 @@ namespace Slang
         }
 
         CompileResult& _createWholeProgramResult(
-            const List<Int>&        entryPointIndices,
             BackEndCompileRequest*  backEndRequest,
             EndToEndCompileRequest* endToEndRequest);
             /// Internal helper for `getOrCreateEntryPointResult`.

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -160,7 +160,6 @@ struct OptionsParser
         SlangTargetFlags    targetFlags = 0;
         int                 targetID = -1;
         FloatingPointMode   floatingPointMode = FloatingPointMode::Default;
-        bool                isWholeProgramRequest = false;
 
         // State for tracking command-line errors
         bool conflictingProfilesSet = false;
@@ -1511,7 +1510,7 @@ struct OptionsParser
                 }
                 else
                 {
-                    target->isWholeProgramRequest = true;
+                    target->targetFlags |= SLANG_TARGET_FLAG_GENERATE_WHOLE_PROGRAM;
                     targetInfo->wholeTargetOutputPath = rawOutput.path;
                 }
             }


### PR DESCRIPTION
This change exposes a new target flag: `SLANG_TARGET_FLAG_GENERATE_WHOLE_PROGRAM` that can be set on a target with `spSetTargetFlags`. When this flag is set, `spCompile` function generates target code for the entire input module instead of just the specified entrypoints. The resulting code will include all the entrypoints defined in the input source.

The resulting whole program code can be retrieved with two new functions: `spGetTargetCodeBlob` and `spGetTargetHostCallable`.

This change also cleans up the unnecessary `entryPointIndices` parameter of `TargetProgram::getOrCreateWholeProgramResult`, and modifies the `cpu-hello-world` example to make use of the new whole-program compilation API to simplify its logic.