### PR TITLE
Make RTTI objects `__constant__` in CUDA

### DIFF
--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -333,7 +333,7 @@ String CUDASourceEmitter::generateEntryPointNameImpl(IREntryPointDecoration* ent
 
 void CUDASourceEmitter::emitGlobalRTTISymbolPrefix()
 {
-    m_writer->emit("__device__ ");
+    m_writer->emit("__constant__ ");
 }
 
 void CUDASourceEmitter::emitCall(const HLSLIntrinsic* specOp, IRInst* inst, const IRUse* operands, int numOperands, const EmitOpInfo& inOuterPrec)


### PR DESCRIPTION
This change defines witness tables and RTTI objects as `__constant__` global values in CUDA instead of `__device__` to make sure they are placed in constant memory.