### PR TITLE
Bottleneck interface dispatch calls through a single function.

### DIFF
--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -5559,5 +5559,16 @@ namespace Slang
     {
         return inst->findDecoration<IRBuiltinDecoration>() != nullptr;
     }
+    IRFunc* getParentFunc(IRInst* inst)
+    {
+        auto parent = inst->getParent();
+        while (parent)
+        {
+            if (auto func = as<IRFunc>(parent))
+                return func;
+            parent = parent->getParent();
+        }
+        return nullptr;
+    }
 } // namespace Slang
 

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1488,6 +1488,9 @@ bool isPointerOfType(IRInst* ptrType, IROp opCode);
     // True if the IR inst represents a builtin object (e.g. __BuiltinFloatingPointType).
 bool isBuiltin(IRInst* inst);
 
+    // Get the enclosuing function of an instruction.
+IRFunc* getParentFunc(IRInst* inst);
+
 }
 
 #endif


### PR DESCRIPTION
This change makes dynamic dispatch pass to bottleneck all interface method calls through dedicated dispatch functions.
For example, when we see `call(lookup_interface_method(witnessTable, reqKey), args)`, we will create a dispatch function `IInterface_MethodName`, and change the call to `call(IInterface_MethodName, witnessTable, args)`.

This allows us to implement the dispatch logic differently based on the target we emit code for.
Currently the `IInterface_MethodName` function is still implemented as `call(lookup_interface_method(witnessTable, reqKey), args)`. This change sets up the stage for a `switch` statement based dispatching logic implementation for GPU targets.