### PR TITLE
Generate `if` based dispatch logic on GPU targets.

### DIFF
--- a/source/slang/slang-ir-generics-lowering-context.h
+++ b/source/slang/slang-ir-generics-lowering-context.h
@@ -31,6 +31,9 @@ namespace Slang
         // Dictionaries for interface type requirement key-value lookups.
         // Used by `findInterfaceRequirementVal`.
         Dictionary<IRInterfaceType*, Dictionary<IRInst*, IRInst*>> mapInterfaceRequirementKeyValue;
+        
+        // Map from interface requirement keys to its corresponding dispatch method.
+        OrderedDictionary<IRInst*, IRFunc*> mapInterfaceRequirementKeyToDispatchMethods;
 
         SharedIRBuilder sharedBuilderStorage;
 

--- a/source/slang/slang-ir-lower-generic-call.cpp
+++ b/source/slang/slang-ir-lower-generic-call.cpp
@@ -8,9 +8,6 @@ namespace Slang
     {
         SharedGenericsLoweringContext* sharedContext;
 
-        // Map from interface requirement keys to its corresponding dispatch method.
-        OrderedDictionary<IRInst*, IRFunc*> mapInterfaceRequirementKeyToDispatchMethods;
-
         // Represents a work item for unpacking `inout` or `out` arguments after a generic call.
         struct ArgumentUnpackWorkItem
         {
@@ -91,8 +88,8 @@ namespace Slang
         // Create a dispatch function for a interface method.
         // On CPU, the dispatch function is implemented as a witness table lookup followed by
         // a function-pointer call.
-        // TODO: On GPU targets, we should implement the dispatch function with a `switch` statement
-        // based on the type ID.
+        // On GPU targets, we can modify the body of the dispatch function in a follow-up
+        // pass to implement it with a `switch` statement based on the type ID.
         IRFunc* _createInterfaceDispatchMethod(
             IRBuilder* builder,
             IRInterfaceType* interfaceType,
@@ -140,11 +137,11 @@ namespace Slang
             IRInst* requirementKey,
             IRInst* requirementVal)
         {
-            if (auto func = mapInterfaceRequirementKeyToDispatchMethods.TryGetValue(requirementKey))
+            if (auto func = sharedContext->mapInterfaceRequirementKeyToDispatchMethods.TryGetValue(requirementKey))
                 return *func;
             auto dispatchFunc =
                 _createInterfaceDispatchMethod(builder, interfaceType, requirementKey, requirementVal);
-            mapInterfaceRequirementKeyToDispatchMethods.AddIfNotExists(
+            sharedContext->mapInterfaceRequirementKeyToDispatchMethods.AddIfNotExists(
                 requirementKey, dispatchFunc);
             return dispatchFunc;
         }

--- a/source/slang/slang-ir-lower-generics.cpp
+++ b/source/slang/slang-ir-lower-generics.cpp
@@ -8,6 +8,7 @@
 #include "slang-ir-lower-generic-function.h"
 #include "slang-ir-lower-generic-call.h"
 #include "slang-ir-lower-generic-type.h"
+#include "slang-ir-specialize-dispatch.h"
 #include "slang-ir-witness-table-wrapper.h"
 #include "slang-ir-ssa.h"
 #include "slang-ir-dce.h"
@@ -57,6 +58,15 @@ namespace Slang
         generateAnyValueMarshallingFunctions(&sharedContext);
         if (sink->getErrorCount() != 0)
             return;
+
+        // On non-CPU targets, generate `if` based dispatch functions.
+        if (sharedContext.targetReq->getTarget() != CodeGenTarget::CPPSource)
+        {
+            specializeDispatchFunctions(&sharedContext);
+            if (sink->getErrorCount() != 0)
+                return;
+        }
+
         // We might have generated new temporary variables during lowering.
         // An SSA pass can clean up unnecessary load/stores.
         constructSSA(module);

--- a/source/slang/slang-ir-specialize-dispatch.cpp
+++ b/source/slang/slang-ir-specialize-dispatch.cpp
@@ -1,0 +1,127 @@
+#include "slang-ir-specialize-dispatch.h"
+
+#include "slang-ir-generics-lowering-context.h"
+#include "slang-ir-insts.h"
+#include "slang-ir.h"
+
+namespace Slang
+{
+IRInst* findWitnessTableEntry(IRWitnessTable* table, IRInst* key)
+{
+    for (auto entry : table->getEntries())
+    {
+        if (entry->getRequirementKey() == key)
+            return entry->getSatisfyingVal();
+    }
+    return nullptr;
+}
+
+void specializeDispatchFunction(SharedGenericsLoweringContext* sharedContext, IRFunc* dispatchFunc)
+{
+    auto witnessTableType = cast<IRFuncType>(dispatchFunc->getDataType())->getParamType(0);
+
+    // Collect all witness tables of `witnessTableType` in current module.
+    List<IRWitnessTable*> witnessTables;
+    for (auto globalInst : sharedContext->module->getGlobalInsts())
+    {
+        if (globalInst->op == kIROp_WitnessTable && globalInst->getDataType() == witnessTableType)
+        {
+            witnessTables.add(cast<IRWitnessTable>(globalInst));
+        }
+    }
+
+    SLANG_ASSERT(dispatchFunc->getFirstBlock() == dispatchFunc->getLastBlock());
+    auto block = dispatchFunc->getFirstBlock();
+
+    // The dispatch function before modification must be in the form of
+    // call(lookup_interface_method(witnessTableParam, interfaceReqKey), args)
+    // We now find the relavent instructions.
+    IRCall* callInst = nullptr;
+    IRLookupWitnessMethod* lookupInst = nullptr;
+    IRReturn* returnInst = nullptr;
+    for (auto inst : block->getOrdinaryInsts())
+    {
+        switch (inst->op)
+        {
+        case kIROp_Call:
+            callInst = cast<IRCall>(inst);
+            break;
+        case kIROp_lookup_interface_method:
+            lookupInst = cast<IRLookupWitnessMethod>(inst);
+            break;
+        case kIROp_ReturnVal:
+        case kIROp_ReturnVoid:
+            returnInst = cast<IRReturn>(inst);
+            break;
+        default:
+            break;
+        }
+    }
+    SLANG_ASSERT(callInst && lookupInst && returnInst);
+
+    IRBuilder builderStorage;
+    auto builder = &builderStorage;
+    builder->sharedBuilder = &sharedContext->sharedBuilderStorage;
+    builder->setInsertBefore(callInst);
+
+    auto witnessTableParam = block->getFirstParam();
+    auto requirementKey = lookupInst->getRequirementKey();
+    List<IRInst*> params;
+    for (auto param = block->getFirstParam()->getNextParam(); param; param = param->getNextParam())
+    {
+        params.add(param);
+    }
+
+    // Emit cascaded if statements to call the correct concrete function based on
+    // the witness table pointer passed in.
+    auto ifBlock = block;
+    for (Index i = 0; i < witnessTables.getCount(); i++)
+    {
+        auto witnessTable = witnessTables[i];
+        bool isLast = (i == witnessTables.getCount() - 1);
+        IRInst* cmpArgs[] =
+        {
+            builder->emitBitCast(builder->getUInt64Type(), witnessTableParam),
+            builder->emitBitCast(builder->getUInt64Type(),(IRInst*)witnessTable)
+        };
+        IRInst* condition = nullptr;
+        IRBlock* trueBlock = nullptr;
+        if (!isLast)
+        {
+            condition = builder->emitIntrinsicInst(builder->getBoolType(), kIROp_Eql, 2, cmpArgs);
+            trueBlock = builder->emitBlock();
+        }
+        auto callee = findWitnessTableEntry(witnessTable, requirementKey);
+        SLANG_ASSERT(callee);
+        auto specializedCallInst = builder->emitCallInst(callInst->getFullType(), callee, params);
+        if (callInst->getDataType()->op == kIROp_VoidType)
+            builder->emitReturn();
+        else
+            builder->emitReturn(specializedCallInst);
+        if (!isLast)
+        {
+            auto falseBlock = builder->emitBlock();
+            builder->setInsertInto(ifBlock);
+            builder->emitIf(condition, trueBlock, falseBlock);
+            builder->setInsertInto(falseBlock);
+            ifBlock = falseBlock;
+        }
+    }
+
+    // Remove old implementation.
+    lookupInst->removeAndDeallocate();
+    callInst->removeAndDeallocate();
+    returnInst->removeAndDeallocate();
+}
+
+void specializeDispatchFunctions(SharedGenericsLoweringContext* sharedContext)
+{
+    sharedContext->sharedBuilderStorage.deduplicateAndRebuildGlobalNumberingMap();
+
+    for (auto kv : sharedContext->mapInterfaceRequirementKeyToDispatchMethods)
+    {
+        auto dispatchFunc = kv.Value;
+        specializeDispatchFunction(sharedContext, dispatchFunc);
+    }
+}
+} // namespace Slang

--- a/source/slang/slang-ir-specialize-dispatch.h
+++ b/source/slang/slang-ir-specialize-dispatch.h
@@ -1,0 +1,13 @@
+// slang-ir-specialize-dispatch.h
+#pragma once
+
+namespace Slang
+{
+struct SharedGenericsLoweringContext;
+
+/// Modifies the body of interface dispatch functions to use branching instead
+/// of function pointer calls to implement the dynamic dispatch logic.
+/// This is only used on GPU targets where function pointers are not supported
+/// or are not efficient.
+void specializeDispatchFunctions(SharedGenericsLoweringContext* sharedContext);
+}

--- a/source/slang/slang.vcxproj
+++ b/source/slang/slang.vcxproj
@@ -254,6 +254,7 @@
     <ClInclude Include="slang-ir-restructure.h" />
     <ClInclude Include="slang-ir-sccp.h" />
     <ClInclude Include="slang-ir-specialize-arrays.h" />
+    <ClInclude Include="slang-ir-specialize-dispatch.h" />
     <ClInclude Include="slang-ir-specialize-function-call.h" />
     <ClInclude Include="slang-ir-specialize-resources.h" />
     <ClInclude Include="slang-ir-specialize.h" />
@@ -380,6 +381,7 @@
     <ClCompile Include="slang-ir-restructure.cpp" />
     <ClCompile Include="slang-ir-sccp.cpp" />
     <ClCompile Include="slang-ir-specialize-arrays.cpp" />
+    <ClCompile Include="slang-ir-specialize-dispatch.cpp" />
     <ClCompile Include="slang-ir-specialize-function-call.cpp" />
     <ClCompile Include="slang-ir-specialize-resources.cpp" />
     <ClCompile Include="slang-ir-specialize.cpp" />
@@ -443,4 +445,4 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
-</Project>
+</Project> 

--- a/source/slang/slang.vcxproj.filters
+++ b/source/slang/slang.vcxproj.filters
@@ -213,6 +213,9 @@
     <ClInclude Include="slang-ir-specialize-arrays.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="slang-ir-specialize-dispatch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="slang-ir-specialize-function-call.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -585,6 +588,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="slang-ir-specialize-arrays.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="slang-ir-specialize-dispatch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="slang-ir-specialize-function-call.cpp">

--- a/tests/compute/dynamic-dispatch-13.slang
+++ b/tests/compute/dynamic-dispatch-13.slang
@@ -43,3 +43,11 @@ public struct MyImpl : IInterface
         return input + val;
     }
 };
+public struct MyImpl2 : IInterface
+{
+    int val;
+    int run(int input)
+    {
+        return input - val;
+    }
+};


### PR DESCRIPTION
Our previous implementation of dynamic dispatch makes use of function pointers on both CPU and GPU. Upon initial performance benchmarks, we observed very slow performance of function-pointer calls on CUDA. Combined with CUDA's restriction that all functions callable from a function pointer must be defined in the same CUDA module, the function-pointer based implementation is not beneficial in anyways in practice.

This change adds a new subpass `specializeDispatchFunctions` to the `lower-generics` pass that modifies the dispatch functions introduced in #1584 with `if` statement based dispatch logic. This subpass is enabled on GPU targets only.

Currently the dispatch function produced by this pass will perform cascaded `if` comparisons on the witness table argument to all witness tables of the same interface type defined in the current module, and calls the corresponding witness table entry when the comparison result is true. The pass can be further improved to use a `switch` statement to match type ids instead of witness table pointers, but that requires coordination with the user-facing compiler API and front-end logic to determine type ids and pass them through to the lowering pass.

The `lower-generic-call` subpass will identify all interface method dispatch calls and generate intial dispatch function implementations that are of the form 
```
func dispatch_func(IRWitnessTableType(IRInterfaceType) witnessTable, OrignalFuncParams args)
{
    return call(lookup_interface_method(witnessTable, memberFuncKey), args);
}
```

These functions will be hold in `mapInterfaceRequirementKeyToDispatchFunction` dictionary in `SharedGenericsLoweringContext`, and be processed in the subsequent newly added `specializeDispatchFunctions` pass, which translates them into the form of
```
func dispatch_func(IRWitnessTableType(IRInterfaceType) witnessTable, OrignalFuncParams args)
{
    if (bit_cast<uint64_t>(witnessTable) == bit_cast<uint64_t>(type1_witnessTable))
          return call(type1_memberFunc, args);
    if (bit_cast<uint64_t>(witnessTable) == bit_cast<uint64_t>(type2_witnessTable))
          return call(type2_memberFunc, args);
    ...
    return call(typeN_memberFunc, args);
}
```

A minor detail is that since we did not have a comparison intrinsic function for `IRWitnessTable` type, the witness table argument is first `bit_cast`ed into a `uint64_t`, and then do a integer comparison.


