### PR TITLE
Add sequential ID cache in Linkage for witness tables and RTTI objects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ tests/**/*.slang-module
 /source/slang/core.meta.slang.h
 prelude/*.h.cpp
 /source/slang/cpp.hint
+/source/slang/slang-value-generated.h
+/source/slang/slang-value-generated-macro.h
+/source/slang/slang-ref-object-generated.h
+/source/slang/slang-ref-object-generated-macro.h
+/source/slang/slang-ast-generated.h
+/source/slang/slang-ast-generated-macro.h

--- a/slang.h
+++ b/slang.h
@@ -3166,6 +3166,13 @@ namespace slang
             TypeReflection* interfaceType,
             ISlangBlob** outNameBlob) = 0;
 
+            /** Get the sequantial ID used to identify a type witness in a dynamic object.
+            */
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL getTypeConformanceWitnessSequentialID(
+            slang::TypeReflection* type,
+            slang::TypeReflection* interfaceType,
+            uint32_t*              outId) = 0;
+
             /** Create a request to load/compile front-end code.
             */
         virtual SLANG_NO_THROW SlangResult SLANG_MCALL createCompileRequest(

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1216,6 +1216,10 @@ namespace Slang
             slang::TypeReflection* type,
             slang::TypeReflection* interfaceType,
             ISlangBlob** outNameBlob) override;
+        SLANG_NO_THROW SlangResult SLANG_MCALL getTypeConformanceWitnessSequentialID(
+            slang::TypeReflection* type,
+            slang::TypeReflection* interfaceType,
+            uint32_t*              outId) override;
         SLANG_NO_THROW SlangResult SLANG_MCALL createCompileRequest(
             SlangCompileRequest**   outCompileRequest) override;
 
@@ -1285,6 +1289,13 @@ namespace Slang
 
         // Map from the logical name of a module to its definition
         Dictionary<Name*, RefPtr<LoadedModule>> mapNameToLoadedModules;
+
+        // Map from the mangled name of RTTI objects to sequential IDs
+        // used by `switch`-based dynamic dispatch.
+        Dictionary<String, uint32_t> mapMangledNameToRTTIObjectIndex;
+
+        // Counters for allocating sequential IDs to witness tables conforming to each interface type.
+        Dictionary<String, uint32_t> mapInterfaceMangledNameToSequentialIDCounters;
 
         // The resulting specialized IR module for each entry point request
         List<RefPtr<IRModule>> compiledModules;

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -560,6 +560,7 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     /* Decorations for RTTI objects */
         INST(RTTITypeSizeDecoration, RTTI_typeSize, 1, 0)
     INST(AnyValueSizeDecoration, AnyValueSize, 1, 0)
+    INST(SequentialIDDecoration, SequentialIDDecoration, 1, 0)
 
     INST(TypeConstraintDecoration, TypeConstraintDecoration, 1, 0)
     INST_RANGE(LinkageDecoration, ImportDecoration, ExportDecoration)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -454,6 +454,18 @@ struct IRBuiltinDecoration : IRDecoration
     IR_LEAF_ISA(BuiltinDecoration)
 };
 
+struct IRSequentialIDDecoration : IRDecoration
+{
+    enum
+    {
+        kOp = kIROp_SequentialIDDecoration
+    };
+    IR_LEAF_ISA(SequentialIDDecoration)
+
+    IRIntLit* getSequentialIDOperand() { return cast<IRIntLit>(getOperand(0)); }
+    IRIntegerValue getSequentialID() { return getSequentialIDOperand()->getValue(); }
+};
+
 // An instruction that specializes another IR value
 // (representing a generic) to a particular set of generic arguments 
 // (instructions representing types, witness tables, etc.)
@@ -2532,6 +2544,11 @@ struct IRBuilder
     void addBuiltinDecoration(IRInst* inst)
     {
         addDecoration(inst, kIROp_BuiltinDecoration);
+    }
+
+    void addSequentialIDDecoration(IRInst* inst, IRIntegerValue id)
+    {
+        addDecoration(inst, kIROp_SequentialIDDecoration, getIntValue(getUIntType(), id));
     }
 };
 


### PR DESCRIPTION
This change is the first step towards identifying witness tables and RTTI objects with integer IDs and generating dynamic dispatch logic consisting of a `switch` statement on the integer ID instead of using cascading `if`s to do pointer comparisons.

This change adds a mapping from a witness table's mangled name (a.k.a the mangled name of a TypeConformance) to an integer value in `Linkage`, along with a user facing API that queries the dictionary for (or assigns) a witness table's sequential ID. This mapping is used by the generics lowering pass to identify witness table objects with sequential IDs. The lowering generics pass also writes to the mapping for all witness tables that the user did not assign sequential IDs for, so that if the user decides to query the ID after code gen they will get the correct ID used by the code gen.

The next step (not included in this PR) is to include a field in the emitted witness table that stores the sequential ID, and change the dispatch function to use a `switch` statement based on the ID.

The final step (not included in this PR)  is to replace all uses of witness table pointers to just directly the sequential ID. But that requires us to properly handle the lookup for associated type entries from a witness table just like how we handle function lookups: function lookups are already converted into a call to a dispatch function, associated type witness table lookups should be converted into a function call that returns a witness table sequentaial ID for the associated type.