### PR TITLE
Generate `switch` based dynamic dispatch logic.

### DIFF
--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -229,6 +229,7 @@ INST(DefaultConstruct, defaultConstruct, 0, 0)
 
 INST(Specialize, specialize, 2, 0)
 INST(lookup_interface_method, lookup_interface_method, 2, 0)
+INST(GetSequentialID, GetSequentialID, 1, 0)
 INST(lookup_witness_table, lookup_witness_table, 2, 0)
 INST(BindGlobalGenericParam, bind_global_generic_param, 2, 0)
 

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -497,6 +497,14 @@ struct IRLookupWitnessMethod : IRInst
     IR_LEAF_ISA(lookup_interface_method)
 };
 
+// Returns the sequential ID of an RTTI object.
+struct IRGetSequentialID : IRInst
+{
+    IR_LEAF_ISA(GetSequentialID)
+
+    IRInst* getRTTIOperand() { return getOperand(0); }
+};
+
 struct IRLookupWitnessTable : IRInst
 {
     IRUse sourceType;
@@ -1915,6 +1923,8 @@ struct IRBuilder
         IRType* type,
         IRInst* witnessTableVal,
         IRInst* interfaceMethodVal);
+
+    IRInst* emitGetSequentialIDInst(IRInst* rttiObj);
 
     IRInst* emitAlloca(IRInst* type, IRInst* rttiObjPtr);
 

--- a/source/slang/slang-ir-lower-generics.cpp
+++ b/source/slang/slang-ir-lower-generics.cpp
@@ -59,13 +59,9 @@ namespace Slang
         if (sink->getErrorCount() != 0)
             return;
 
-        // On non-CPU targets, generate `if` based dispatch functions.
-        if (sharedContext.targetReq->getTarget() != CodeGenTarget::CPPSource)
-        {
-            specializeDispatchFunctions(&sharedContext);
-            if (sink->getErrorCount() != 0)
-                return;
-        }
+        specializeDispatchFunctions(&sharedContext);
+        if (sink->getErrorCount() != 0)
+            return;
 
         // We might have generated new temporary variables during lowering.
         // An SSA pass can clean up unnecessary load/stores.

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -2642,6 +2642,14 @@ namespace Slang
         return inst;
     }
 
+    IRInst* IRBuilder::emitGetSequentialIDInst(IRInst* rttiObj)
+    {
+        auto inst = createInst<IRAlloca>(this, kIROp_GetSequentialID, getUIntType(), rttiObj);
+
+        addInst(inst);
+        return inst;
+    }
+
     IRInst* IRBuilder::emitAlloca(IRInst* type, IRInst* rttiObjPtr)
     {
         auto inst = createInst<IRAlloca>(

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -73,8 +73,8 @@ enum IROp : int32_t
 /* IROpMeta describe values for layout of IROp, as well as values for accessing aspects of IROp bits. */
 enum IROpMeta
 {
-    kIROpMeta_OtherShift = 8,   ///< Number of bits for op (shift right by this to get the other bits)
-    kIROpMeta_OpMask = 0xff,    ///< Mask for just opcode
+    kIROpMeta_OtherShift = 10,   ///< Number of bits for op (shift right by this to get the other bits)
+    kIROpMeta_OpMask = 0x3ff,    ///< Mask for just opcode
 };
 
 IROp findIROp(const UnownedStringSlice& name);


### PR DESCRIPTION
This PR changes the dynamic dispatch function from using cascading `if` statements to a `switch` statement.

The key to enable `switch` statement is to turn witness table pointer comparisons into a sequential ID based dispatch.

All witness tables are assigned a sequential ID generated in the natural order regarding to the interface it is implementing. The user-facing API for querying/specifying the sequential IDs has been added in PR #1590. The existing `specializeDispatchFunction` pass is changed to:
1. Generate a new version of the dispatch functions, with the first argument changed from an `IRWitnessTable` to `UInt`.
2. Add a new inst, `GetSequentialID` that returns the sequential ID of a witness table.
3. All call sites to the dispatch function are modified to `call(dispatchFunc, GetSequentialID(wt), args...)`
4. Emit logic is updated to support `GetSequentialID`.
5. Inst op code bit width changed from 8 to 10 since the number of opcodes exceeds 255 with the addition of the new inst.