### PR TITLE
Fix IR serialization to use variable length encoding for opcode.

### DIFF
--- a/source/core/slang-byte-encode-util.h
+++ b/source/core/slang-byte-encode-util.h
@@ -9,6 +9,7 @@ struct ByteEncodeUtil
 {
     enum
     {
+        kMaxLiteEncodeUInt16 = 3, /// One byte for prefix, the remaining 2 bytes hold the value
         kMaxLiteEncodeUInt32 = 5,                   /// One byte for prefix, the remaining 4 bytes hold the value
         // Cut values for 'Lite' encoding style
         kLiteCut1 = 185,

--- a/source/slang/slang-serialize-ir-types.h
+++ b/source/slang/slang-serialize-ir-types.h
@@ -129,7 +129,7 @@ struct IRSerialData
         
         SLANG_FORCE_INLINE bool operator!=(const ThisType& rhs) const { return !(*this == rhs); }
 
-        uint8_t m_op;                       ///< For now one of IROp 
+        uint16_t m_op;                      ///< For now one of IROp 
         PayloadType m_payloadType;	 		///< The type of payload 
         uint16_t m_pad0;                    ///< Not currently used             
 

--- a/source/slang/slang-serialize-ir-types.h
+++ b/source/slang/slang-serialize-ir-types.h
@@ -131,7 +131,7 @@ struct IRSerialData
 
         uint16_t m_op;                      ///< For now one of IROp 
         PayloadType m_payloadType;	 		///< The type of payload 
-        uint16_t m_pad0;                    ///< Not currently used             
+        uint8_t m_pad0;                    ///< Not currently used             
 
         InstIndex m_resultTypeIndex;	    //< 0 if has no type. The result type of this instruction
 

--- a/source/slang/slang-serialize-ir.cpp
+++ b/source/slang/slang-serialize-ir.cpp
@@ -357,8 +357,7 @@ Result _encodeInsts(SerialCompressionType compressionType, const List<IRSerialDa
             encodeOut = encodeArrayOut.begin() + offset;
             encodeEnd = encodeArrayOut.end();
         }
-        memcpy(encodeOut, &inst.m_op, sizeof(inst.m_op));
-        encodeOut += sizeof(inst.m_op);
+        encodeOut += ByteEncodeUtil::encodeLiteUInt32(inst.m_op, encodeOut);
 
         *encodeOut++ = uint8_t(inst.m_payloadType);
 
@@ -525,9 +524,10 @@ static Result _decodeInsts(SerialCompressionType compressionType, const uint8_t*
         }
 
         auto& inst = insts[i];
+        uint32_t instOp = 0;
+        encodeCur += ByteEncodeUtil::decodeLiteUInt32(encodeCur, &instOp);
+        inst.m_op = (uint16_t)instOp;
 
-        memcpy(&inst.m_op, encodeCur, sizeof(inst.m_op));
-        encodeCur += sizeof(inst.m_op);
         const PayloadType payloadType = PayloadType(*encodeCur++);
         inst.m_payloadType = payloadType;
         

--- a/source/slang/slang-serialize-ir.cpp
+++ b/source/slang/slang-serialize-ir.cpp
@@ -696,7 +696,7 @@ Result IRSerialReader::read(const IRSerialData& data, Session* session, SerialSo
     insts.setCount(numInsts);
     insts[0] = nullptr;
 
-    // 0 holds null&
+    // 0 holds null
     // 1 holds the IRModuleInst
     {
         // Check that insts[1] is the module inst

--- a/source/slang/slang-serialize-ir.cpp
+++ b/source/slang/slang-serialize-ir.cpp
@@ -337,7 +337,7 @@ Result _encodeInsts(SerialCompressionType compressionType, const List<IRSerialDa
     // Calculate the maximum instruction size with worst case possible encoding
     // 2 bytes hold the payload size, and the result type
     // Note that if there were some free bits, we could encode some of this stuff into bits, but if we remove payloadType, then there are no free bits
-    const size_t maxInstSize = 2 + ByteEncodeUtil::kMaxLiteEncodeUInt32 + Math::Max(sizeof(insts->m_payload.m_float64), size_t(2 * ByteEncodeUtil::kMaxLiteEncodeUInt32));
+    const size_t maxInstSize = 1 + ByteEncodeUtil::kMaxLiteEncodeUInt16 + Math::Max(sizeof(insts->m_payload.m_float64), size_t(2 * ByteEncodeUtil::kMaxLiteEncodeUInt32));
 
     for (size_t i = 0; i < numInsts; ++i)
     {


### PR DESCRIPTION
The number of IR instructions has expanded beyond 256, so 8 bits is no longer sufficient to represent all possible IR opcodes.

The `kIROpMeta_OpMask` value has been changed to 0x3FF and number of opcode bits has been changed to 10 previously.

This change modifies the IR encoding/decoding logic and use variable length integer encoding for opcodes to fix serialization errors.