### PR TITLE
Make witness and RTTI handles lower to `uint2`.

### DIFF
--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -1481,21 +1481,19 @@ LinkedIR linkIR(
             cloneValue(context, bindInst);
         }
     }
-    if (target == CodeGenTarget::CPPSource || target == CodeGenTarget::CUDASource)
-    {
-        for (IRModule* irModule : irModules)
-        {
-            for (auto inst : irModule->getGlobalInsts())
-            {
-                auto hasPublic = inst->findDecoration<IRPublicDecoration>();
-                if (!hasPublic)
-                    continue;
 
-                auto cloned = cloneValue(context, inst);
-                if (!cloned->findDecorationImpl(kIROp_KeepAliveDecoration))
-                {
-                    context->builder->addKeepAliveDecoration(cloned);
-                }
+    for (IRModule* irModule : irModules)
+    {
+        for (auto inst : irModule->getGlobalInsts())
+        {
+            auto hasPublic = inst->findDecoration<IRPublicDecoration>();
+            if (!hasPublic)
+                continue;
+
+            auto cloned = cloneValue(context, inst);
+            if (!cloned->findDecorationImpl(kIROp_KeepAliveDecoration))
+            {
+                context->builder->addKeepAliveDecoration(cloned);
             }
         }
     }

--- a/source/slang/slang-ir-lower-generics.cpp
+++ b/source/slang/slang-ir-lower-generics.cpp
@@ -108,6 +108,8 @@ namespace Slang
         if (sink->getErrorCount() != 0)
             return;
 
+        sharedContext->sharedBuilderStorage.deduplicateAndRebuildGlobalNumberingMap();
+
         specializeRTTIObjectReferences(sharedContext);
 
         cleanUpRTTIHandleTypes(sharedContext);

--- a/tests/compute/dynamic-dispatch-12.slang
+++ b/tests/compute/dynamic-dispatch-12.slang
@@ -1,6 +1,8 @@
 // Test using interface typed shader parameters with dynamic dispatch.
 
+//TEST(compute):COMPARE_COMPUTE:-dx11
 //TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE:-vk
 //TEST(compute):COMPARE_COMPUTE:-cuda
 
 [anyValueSize(8)]

--- a/tests/compute/dynamic-dispatch-13.slang
+++ b/tests/compute/dynamic-dispatch-13.slang
@@ -1,6 +1,8 @@
 // Test using interface typed shader parameters wrapped inside a `StructuredBuffer`.
 
 //TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE:-dx11
+//TEST(compute):COMPARE_COMPUTE:-vk
 //TEST(compute):COMPARE_COMPUTE:-cuda
 
 [anyValueSize(8)]
@@ -13,10 +15,10 @@ interface IInterface
 RWStructuredBuffer<int> gOutputBuffer;
 
 //TEST_INPUT:ubuffer(data=[rtti(MyImpl) witness(MyImpl, IInterface) 1 0], stride=4):name=gCb
-StructuredBuffer<IInterface> gCb;
+RWStructuredBuffer<IInterface> gCb;
 
 //TEST_INPUT:ubuffer(data=[rtti(MyImpl) witness(MyImpl, IInterface) 1 0], stride=4):name=gCb1
-StructuredBuffer<IInterface> gCb1;
+RWStructuredBuffer<IInterface> gCb1;
 
 [numthreads(4, 1, 1)]
 void computeMain(uint3       dispatchThreadID : SV_DispatchThreadID)

--- a/tests/compute/dynamic-dispatch-14.slang
+++ b/tests/compute/dynamic-dispatch-14.slang
@@ -1,6 +1,8 @@
 // Test using interface typed shader parameters with associated types.
 
+//TEST(compute):COMPARE_COMPUTE:-dx11
 //TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE:-vk
 //TEST(compute):COMPARE_COMPUTE:-cuda
 
 [anyValueSize(8)]
@@ -20,10 +22,10 @@ interface IInterface
 RWStructuredBuffer<int> gOutputBuffer;
 
 //TEST_INPUT:ubuffer(data=[rtti(MyImpl) witness(MyImpl, IInterface) 1 0], stride=4):name=gCb
-StructuredBuffer<IInterface> gCb;
+RWStructuredBuffer<IInterface> gCb;
 
 //TEST_INPUT:ubuffer(data=[rtti(MyImpl) witness(MyImpl, IInterface) 1 0], stride=4):name=gCb1
-StructuredBuffer<IInterface> gCb1;
+RWStructuredBuffer<IInterface> gCb1;
 
 [numthreads(4, 1, 1)]
 void computeMain(uint3       dispatchThreadID : SV_DispatchThreadID)


### PR DESCRIPTION
In previous PRs, we have already implemented a `switch` based dynamic dispatch without relying on pointers. This should allow all dynamic dispatch code to be supported for D3D/VK targets.

With PR #1612, the only remaining block to support `switch` based dynamic dispatch on D3D/VK is that the witness table and RTTI handles lower to `uint64_t`, which isn't supported by all platforms.

This PR makes all such handles lower to `uint2` instead, and adds the vector packing logic in places that are necessary.

One small issue with fxc is that if a `switch` statement contains only one `default` case, it sometimes complains that not all control paths return a value. To fix this, we omit the `switch` statement if there is only 1 case.

This PR also enables some dynamic dispatch tests on D3D/VK. Will enable all dynamic dispatch tests on D3D as a follow up PR.