### PR TITLE
Re-enable `interface-shader-param` tests.

### DIFF
--- a/tests/compute/interface-shader-param-in-struct.slang
+++ b/tests/compute/interface-shader-param-in-struct.slang
@@ -3,8 +3,7 @@
 // This test puts interface-type shader parameters
 // inside of structure types to make sure that works
 
-// Note: D3D11 test disabled because of missing `uint64_t`; re-enable when `uint2` used instead.
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
 
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile sm_6_0 -use-dxil
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute

--- a/tests/compute/interface-shader-param.slang
+++ b/tests/compute/interface-shader-param.slang
@@ -3,8 +3,7 @@
 // Test using interface tops as top-level shader parameters
 // (whether global, or on an entry point).
 
-// Note: D3D11 test disabled because of missing `uint64_t`; re-enable when `uint2` used instead.
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
 
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile sm_6_0 -use-dxil
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute

--- a/tests/compute/interface-shader-param2.slang
+++ b/tests/compute/interface-shader-param2.slang
@@ -4,8 +4,7 @@
 // concrete types that have data within them, instead of
 // just empty types.
 
-// Note: D3D11 test disabled because of missing `uint64_t`; re-enable when `uint2` used instead.
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
 
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile sm_6_0 -use-dxil
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute

--- a/tests/compute/interface-shader-param3.slang
+++ b/tests/compute/interface-shader-param3.slang
@@ -4,8 +4,7 @@
 // interface types at more complicated places in the overall layout.
 //
 
-// Note: D3D11 test disabled because of missing `uint64_t`; re-enable when `uint2` used instead.
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
 
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile sm_6_0 -use-dxil
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute

--- a/tests/compute/interface-shader-param4.slang
+++ b/tests/compute/interface-shader-param4.slang
@@ -5,8 +5,7 @@
 // shader parameters.
 //
 
-// Note: D3D11 test disabled because of missing `uint64_t`; re-enable when `uint2` used instead.
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
 
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile sm_6_0 -use-dxil
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute


### PR DESCRIPTION
Since we no longer emit `uint64_t` for RTTI/witness table IDs, `lower-generics` pass should now work with HLSL static specialization.
This PR re-enables the tests that were previously disabled in PR #1612.