### PR TITLE
Fix mistake where some public API functions weren't extern "C"

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -4034,7 +4034,7 @@ namespace slang
 @param apiVersion Pass in SLANG_API_VERSION
 @param outGlobalSession (out)The created global session. 
 */
-SLANG_API SlangResult slang_createGlobalSession(
+SLANG_EXTERN_C SLANG_API SlangResult slang_createGlobalSession(
     SlangInt                apiVersion,
     slang::IGlobalSession** outGlobalSession);
 
@@ -4046,7 +4046,7 @@ then be loaded via loadStdLib or compileStdLib
 
 NOTE! API is experimental and not ready for production code 
 */
-SLANG_API SlangResult slang_createGlobalSessionWithoutStdLib(
+SLANG_EXTERN_C SLANG_API SlangResult slang_createGlobalSessionWithoutStdLib(
     SlangInt                apiVersion,
     slang::IGlobalSession** outGlobalSession);
 
@@ -4061,27 +4061,27 @@ namespace slang
 
 /** @see slang::ICompileRequest::getProgram
 */
-SLANG_API SlangResult spCompileRequest_getProgram(
+SLANG_EXTERN_C SLANG_API SlangResult spCompileRequest_getProgram(
     SlangCompileRequest*    request,
     slang::IComponentType** outProgram);
 
 /** @see slang::ICompileRequest::getEntryPoint
 */
-SLANG_API SlangResult spCompileRequest_getEntryPoint(
+SLANG_EXTERN_C SLANG_API SlangResult spCompileRequest_getEntryPoint(
     SlangCompileRequest*    request,
     SlangInt                entryPointIndex,
     slang::IComponentType** outEntryPoint);
 
 /** @see slang::ICompileRequest::getModule
 */
-SLANG_API SlangResult spCompileRequest_getModule(
+SLANG_EXTERN_C SLANG_API SlangResult spCompileRequest_getModule(
     SlangCompileRequest*    request,
     SlangInt                translationUnitIndex,
     slang::IModule**        outModule);
 
 /** @see slang::ICompileRequest::getSession
 */
-SLANG_API SlangResult spCompileRequest_getSession(
+SLANG_EXTERN_C SLANG_API SlangResult spCompileRequest_getSession(
     SlangCompileRequest* request,
     slang::ISession** outSession);
 #endif


### PR DESCRIPTION
This was a serious problem that meant that some of our public API functions (exported from the DLL) had mangled C++ symbol names (which are not guaranteed to be portable across different compilers).

The fix here is the expedient one: just add `extern "C"` to the relevant functions. The simplicity has a cost, though, in that this change introduces a significant break in binary compatibility.

Source code should be compatible before/after this change, but it would be necessary to match an application and Slang shared library so that they agree on the mangled names of these symbols. We will need to treat this as a breaking release when this change goes out.

Note that because of the way that C++ mangled names were being used, we *already* have introduced breaking changes to the binary interface in a recent change that made `SlangCompileRequest` into a `typedef` instead of a forward-declared `struct` type. To be clear, the breakage was due to the missing `extern "C"` and *not* the content of that change; the change would have been binary-compatible if the symbol names were correct.

Given that the cat is out of the bag to some extent (our next release is going to break compatibility one way or another), it seems best to just get the whole thing sorted at once.