### PR TITLE
Fix a subtle bug introduced into type legalization

### DIFF
--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -2620,6 +2620,18 @@ struct IRTypeLegalizationPass
 
     void processInst(IRInst* inst)
     {
+        // It is possible that an insturction we
+        // encounterer during the legalization process
+        // will be one that was already removed or
+        // otherwise made redundant.
+        //
+        // We want to skip such instructions since there
+        // would not be a valid location at which to
+        // store their replacements.
+        //
+        if(!inst->getParent() && inst->op != kIROp_Module)
+            return;
+
         // The main logic for legalizing an instruction is defined
         // earlier in this file.
         //


### PR DESCRIPTION
The refactor of type legalization in PR #1594 introduced a subtle problem where an IR instruction might be removed from the hierachy (perhaps because its parent was removed during legalization) but would still be on the work list. Legalization of such instructions is wasteful (since it would never impact the output), but it also creates a problem if we try to insert new legalized instructions next to such a removed instruction. The logic for inserting an instruction before/after another asserts that the sibling instruction must have a parent, and leads to a failure in debug builds and a potential crash in release builds.

This change adds a bit of defensive code to skip any instructions that appear to have been removed from the hierarchy (because they have no parent and are not the root/module instruction). An alternative approach would be to try to detect these instructions at the point where they would be added to the work list, but this approach seems simpler and more general.