### PR TITLE
Heterogeneous Flag Error Visibility

### DIFF
--- a/examples/heterogeneous-hello-world/shader.slang
+++ b/examples/heterogeneous-hello-world/shader.slang
@@ -3,6 +3,7 @@
 //TEST_INPUT:ubuffer(random(float, 4096, -1.0, 1.0), stride=4):name=ioBuffer
 RWStructuredBuffer<float> convertBuffer(Ptr<gfx::BufferResource> x);
 
+[shader("compute")]
 [numthreads(4, 1, 1)]
 void computeMain(uniform RWStructuredBuffer<float> ioBuffer, uint3 dispatchThreadID : SV_DispatchThreadID)
 {

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -3892,12 +3892,14 @@ void CLikeSourceEmitter::executeEmitActions(List<EmitAction> const& actions)
     }
 }
 
-void CLikeSourceEmitter::emitModuleImpl(IRModule* module)
+void CLikeSourceEmitter::emitModuleImpl(IRModule* module, DiagnosticSink* sink)
 {
     // The IR will usually come in an order that respects
     // dependencies between global declarations, but this
     // isn't guaranteed, so we need to be careful about
     // the order in which we emit things.
+
+    SLANG_UNUSED(sink);
 
     List<EmitAction> actions;
 

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -283,7 +283,8 @@ public:
     void computeEmitActions(IRModule* module, List<EmitAction>& ioActions);
 
     void executeEmitActions(List<EmitAction> const& actions);
-    void emitModule(IRModule* module) { m_irModule = module; emitModuleImpl(module); }
+    void emitModule(IRModule* module, DiagnosticSink* sink)
+        { m_irModule = module; emitModuleImpl(module, sink); }
 
         /// Emit any preprocessor directives that should come *before* the prelude code
         ///
@@ -331,7 +332,7 @@ public:
     virtual void emitMatrixLayoutModifiersImpl(IRVarLayout* layout) { SLANG_UNUSED(layout);  }
     virtual void emitTypeImpl(IRType* type, const StringSliceLoc* nameLoc);
     virtual void emitSimpleValueImpl(IRInst* inst);
-    virtual void emitModuleImpl(IRModule* module);
+    virtual void emitModuleImpl(IRModule* module, DiagnosticSink* sink);
     virtual void emitSimpleFuncImpl(IRFunc* func);
     virtual void emitVarExpr(IRInst* inst, EmitOpInfo const& outerPrec);
     virtual void emitOperandImpl(IRInst* inst, EmitOpInfo const& outerPrec);

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -2553,7 +2553,7 @@ void CPPSourceEmitter::_emitForwardDeclarations(const List<EmitAction>& actions)
     }
 }
 
-void CPPSourceEmitter::emitModuleImpl(IRModule* module)
+void CPPSourceEmitter::emitModuleImpl(IRModule* module, DiagnosticSink* sink)
 {
     // If we are emitting a heterogeneous program
     // Emit the binary blob of each non-CPP target
@@ -2589,34 +2589,43 @@ void CPPSourceEmitter::emitModuleImpl(IRModule* module)
                             default:
 
                                 auto targetProgram = program->getTargetProgram(targetRequest);
-                                DiagnosticSink sink(linkage->getSourceManager());
+                                //DiagnosticSink sink(linkage->getSourceManager());
                                 CompileResult result =
-                                    targetProgram->getOrCreateEntryPointResult(index, &sink);
+                                    targetProgram->getOrCreateEntryPointResult(index, sink);
 
                                 Slang::ComPtr<ISlangBlob> blob;
                                 if (SLANG_FAILED(result.getBlob(blob)))
                                 {
-                                    SLANG_UNEXPECTED("No blob to emit");
-                                    return;
+                                    StringBuilder builder;
+                                    sink->diagnoseRaw(Severity::Error, UnownedStringSlice
+                                        ("Slang heterogeneous error: No blob to emit\n"));
+                                    m_writer->emit("size_t __");
+                                    m_writer->emit(entryPointName);
+                                    m_writer->emit("Size = 0;\n");
+                                    m_writer->emit("unsigned char __");
+                                    m_writer->emit(entryPointName);
+                                    m_writer->emit("[];\n");
                                 }
 
-                                auto ptr = (const unsigned char*)blob->getBufferPointer();
+                                else {
+                                    auto ptr = (const unsigned char*)blob->getBufferPointer();
 
-                                m_writer->emit("size_t __");
-                                m_writer->emit(entryPointName );
-                                m_writer->emit("Size = ");
-                                m_writer->emitInt64(blob->getBufferSize());
-                                m_writer->emit(";\n");
+                                    m_writer->emit("size_t __");
+                                    m_writer->emit(entryPointName);
+                                    m_writer->emit("Size = ");
+                                    m_writer->emitInt64(blob->getBufferSize());
+                                    m_writer->emit(";\n");
 
-                                m_writer->emit("unsigned char __");
-                                m_writer->emit(entryPointName );
-                                m_writer->emit("[] = {");
-                                for (unsigned int i = 0; i < blob->getBufferSize() - 1; i++) {
-                                    m_writer->emitUInt64(ptr[i]);
-                                    m_writer->emit(", ");
+                                    m_writer->emit("unsigned char __");
+                                    m_writer->emit(entryPointName);
+                                    m_writer->emit("[] = {");
+                                    for (unsigned int i = 0; i < blob->getBufferSize() - 1; i++) {
+                                        m_writer->emitUInt64(ptr[i]);
+                                        m_writer->emit(", ");
+                                    }
+                                    m_writer->emitUInt64(ptr[blob->getBufferSize() - 1]);
+                                    m_writer->emit("};\n");
                                 }
-                                m_writer->emitUInt64(ptr[blob->getBufferSize() - 1]);
-                                m_writer->emit("};\n");
                             }
                         }
                         // Emit a wrapper function for calling the shader blob

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -61,7 +61,7 @@ protected:
     virtual void emitPreprocessorDirectivesImpl() SLANG_OVERRIDE;
     virtual void emitSimpleValueImpl(IRInst* value) SLANG_OVERRIDE;
     virtual void emitSimpleFuncParamImpl(IRParam* param) SLANG_OVERRIDE;
-    virtual void emitModuleImpl(IRModule* module) SLANG_OVERRIDE;
+    virtual void emitModuleImpl(IRModule* module, DiagnosticSink* sink) SLANG_OVERRIDE;
     virtual void emitSimpleFuncImpl(IRFunc* func) SLANG_OVERRIDE;
     virtual void emitOperandImpl(IRInst* inst, EmitOpInfo const&  outerPrec) SLANG_OVERRIDE;
     virtual void emitParamTypeImpl(IRType* type, String const& name) SLANG_OVERRIDE;

--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -729,7 +729,7 @@ bool CUDASourceEmitter::tryEmitGlobalParamImpl(IRGlobalParam* varDecl, IRType* v
 }
 
 
-void CUDASourceEmitter::emitModuleImpl(IRModule* module)
+void CUDASourceEmitter::emitModuleImpl(IRModule* module, DiagnosticSink* sink)
 {
     // Setup all built in types used in the module
     m_typeSet.addAllBuiltinTypes(module);
@@ -747,7 +747,7 @@ void CUDASourceEmitter::emitModuleImpl(IRModule* module)
 
     // TODO(JS): We may need to generate types (for example for matrices)
 
-    CLikeSourceEmitter::emitModuleImpl(module);
+    CLikeSourceEmitter::emitModuleImpl(module, sink);
 
     // Emit all witness table definitions.
     _emitWitnessTableDefinitions();

--- a/source/slang/slang-emit-cuda.h
+++ b/source/slang/slang-emit-cuda.h
@@ -71,7 +71,7 @@ protected:
 
     virtual void emitPreprocessorDirectivesImpl() SLANG_OVERRIDE;
 
-    virtual void emitModuleImpl(IRModule* module) SLANG_OVERRIDE;
+    virtual void emitModuleImpl(IRModule* module, DiagnosticSink* sink) SLANG_OVERRIDE;
 
     // CPPSourceEmitter overrides 
     virtual SlangResult calcTypeName(IRType* type, CodeGenTarget target, StringBuilder& out) SLANG_OVERRIDE;

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -806,7 +806,7 @@ SlangResult emitEntryPointsSourceFromIR(
 #if 0
         dumpIR(compileRequest, irModule, "PRE-EMIT");
 #endif
-        sourceEmitter->emitModule(irModule);
+        sourceEmitter->emitModule(irModule, sink);
     }
 
     String code = sourceWriter.getContent();


### PR DESCRIPTION
PR to fix issue #1638.  This change introduces a diagnostic sink to the
emitModule function, and updates all associated calls to that function.
Additionally, this commit updates the heterogeneous hello world example
to not need the entry and stage flags for simplicity.