### PR TITLE
Add macos CI configuration

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -23,9 +23,11 @@ jobs:
       run: 
         CC=${{matrix.compiler}}
         CONFIGURATION=${{matrix.configuration}}
+        OS=linux-64
         source ./github_build.sh
     - name: test
       run: 
         CONFIGURATION=${{matrix.configuration}}
         CC=${{matrix.compiler}}
+        OS=linux-64
         source ./github_test.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,9 +22,11 @@ jobs:
       run: 
         CC=clang
         CONFIGURATION=${{matrix.configuration}}
+        OS=osx
         source ./github_build.sh
     - name: test
       run: 
         CONFIGURATION=${{matrix.configuration}}
         CC=clang
+        OS=osx
         source ./github_test.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,30 @@
+name: MacOS
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        configuration: ['debug', 'release']
+    steps:
+    - uses: actions/checkout@v2.3.4
+      with:
+        submodules: 'true'
+        fetch-depth: '0'
+    - name: build
+      run: 
+        CC=clang
+        CONFIGURATION=${{matrix.configuration}}
+        source ./github_build.sh
+    - name: test
+      run: 
+        CONFIGURATION=${{matrix.configuration}}
+        CC=clang
+        source ./github_test.sh

--- a/github_build.sh
+++ b/github_build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Get premake
-wget https://github.com/shader-slang/slang-binaries/blob/master/premake/premake-5.0.0-alpha13/bin/linux-64/premake5?raw=true -O premake5
+wget https://github.com/shader-slang/slang-binaries/blob/master/premake/premake-5.0.0-alpha13/bin/${OS}/premake5?raw=true -O premake5
 chmod u+x premake5
 
 # generate slang-tag-version.h 


### PR DESCRIPTION
This currently doesn't work and fails with following output:
```
==== Building embed-stdlib-generator (release_x64) ====
Creating ../../../intermediate/macosx-x64/release/embed-stdlib-generator
Building ../../../source/slang/slang-stdlib-api.cpp
Linking embed-stdlib-generator
ar: no archive members specified
usage:  ar -d [-TLsv] archive file ...
	ar -m [-TLsv] archive file ...
	ar -m [-abiTLsv] position archive file ...
	ar -p [-TLsv] archive [file ...]
	ar -q [-cTLsv] archive file ...
	ar -r [-cuTLsv] archive file ...
	ar -r [-abciuTLsv] position archive file ...
	ar -t [-TLsv] archive [file ...]
	ar -x [-ouTLsv] archive [file ...]
make[1]: *** [../../../bin/macosx-x64/release/libembed-stdlib-generator.a] Error 1
make: *** [embed-stdlib-generator] Error 2
```