### PR TITLE
Add basic GLSL support for SV_Barycentrics

### DIFF
--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -575,6 +575,17 @@ GLSLSystemValueInfo* getGLSLSystemValueInfo(
 //            globalVarExpr = createGLSLBuiltinRef("gl_ViewportMaskPerViewNV",
 //                getUnsizedArrayType(getIntType()));
     }
+    else if (semanticName == "sv_barycentrics")
+    {
+        context->requireGLSLVersion(ProfileVersion::GLSL_450);
+        context->requireGLSLExtension(UnownedStringSlice::fromLiteral("GL_NV_fragment_shader_barycentric"));
+
+        name = "gl_BaryCoordNV";
+
+        // TODO: There is also the `gl_BaryCoordNoPerspNV` builtin, which
+        // we ought to use if the `noperspective` modifier has been
+        // applied to this varying input.
+    }
 
     if( name )
     {

--- a/tests/cross-compile/barycentrics.slang
+++ b/tests/cross-compile/barycentrics.slang
@@ -1,0 +1,6 @@
+//TEST:CROSS_COMPILE:-target spirv-assembly -entry main -stage fragment
+
+float4 main(float3 bary : SV_Barycentrics) : SV_Target
+{
+    return float4(bary, 0);
+}

--- a/tests/cross-compile/barycentrics.slang.glsl
+++ b/tests/cross-compile/barycentrics.slang.glsl
@@ -1,0 +1,12 @@
+#version 450
+
+#extension GL_NV_fragment_shader_barycentric : enable
+
+layout(location = 0)
+out vec4 _S1;
+
+void main()
+{
+    _S1 = vec4(gl_BaryCoordNV, float(0));
+    return;
+}


### PR DESCRIPTION
This change allows for fragment shader varying inputs marked with the `SV_Barycentrics` semantic to be mapped to GLSL code using the `gl_BaryCoordNV` builtin variable (from he `GL_NV_fragment_shader_barycentric` extension).

This is the simplest possible change to get the functionality up and running, and it leaves out many things that could be desired in a more feature-complete version of the feature later:

* There is no support for alternative extensions that provide similar functionality. Selection of which extension to favor could eventually be based on the "capability" work that has been put in place.

* There is no attempt made to check that the input has the expected type (or to coerce it if it doesn't), so for now this is only going to be guaranteed to work for a `float3` input.

* This change does not expose the `pervertexNV` qualifier added in the `GL_NV_fragment_shader_barycentric` extension, which can be used by a shader to access the uninterpolated vertex inputs.

The last issue is an important one, since the HLSL `GetAttributeAtVertex` function seems to be defiend to work with *any* incoming varying parameter that was marked with `nointerpolation`. When we have a `nointerpolation` input, it would seem that we need to know whether it will be used with `GetAttributeAtVertex` (in which case it should be declared as a `pervertexNV` array input in GLSL) or not (in which case it should be declared as a `nointerpolation` input, without an array).