### PR TITLE
Add a -capability command-line option

### DIFF
--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -717,6 +717,35 @@ struct OptionsParser
                         addCapabilityAtom(getCurrentTarget(), atom);
                     }
                 }
+                else if( argStr == "-capability" )
+                {
+                    // The `-capability` option is similar to `-profile` but does not set the actual profile
+                    // for a target (it just adds capabilities).
+                    //
+                    // TODO: Once profiles are treated as capabilities themselves, it might be possible
+                    // to treat `-profile` and `-capability` as aliases, although there might still be
+                    // value in only allowing a single `-profile` option per target while still allowing
+                    // zero or more `-capability` options.
+
+                    String operand;
+                    SLANG_RETURN_ON_FAIL(tryReadCommandLineArgument(sink, arg, &argCursor, argEnd, operand));
+
+                    List<UnownedStringSlice> slices;
+                    StringUtil::split(operand.getUnownedSlice(), '+', slices);
+                    Index sliceCount = slices.getCount();
+                    for(Index i = 0; i < sliceCount; ++i)
+                    {
+                        UnownedStringSlice atomName = slices[i];
+                        CapabilityAtom atom = findCapabilityAtom(atomName);
+                        if( atom == CapabilityAtom::Invalid )
+                        {
+                            sink->diagnose(SourceLoc(), Diagnostics::unknownProfile, atomName);
+                            return SLANG_FAIL;
+                        }
+
+                        addCapabilityAtom(getCurrentTarget(), atom);
+                    }
+                }
                 else if (argStr == "-stage")
                 {
                     String name;

--- a/tests/vkray/callable-caller.slang
+++ b/tests/vkray/callable-caller.slang
@@ -1,6 +1,6 @@
 // callable-caller.slang
 
-//TEST:CROSS_COMPILE: -profile glsl_460+GL_NV_ray_tracing -stage raygeneration -entry main -target spirv-assembly
+//TEST:CROSS_COMPILE: -profile glsl_460 -capability GL_NV_ray_tracing -stage raygeneration -entry main -target spirv-assembly
 
 import callable_shared;
 


### PR DESCRIPTION
This provides a stand-alone option distinct from `-profile` that can be used to add capabilities to a target. A test has been added to confirm that `-profile X -capability Y` works the same as `-profile X+Y`.

The intention is that this option could be used in applications that use the API to set up their target but then use the options-parsing logic to handle things like capabilities.

Note: that latter bit has not been confirmed, so it is possible that this approach does not actually suffice for hybrid API + options usage. That will need to be confirmed in follow-up work.