### PR TITLE
Fill in some missing bits of capability API

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -642,6 +642,10 @@ extern "C"
     };
 
     typedef SlangInt32 SlangCapabilityID;
+    enum
+    {
+        SLANG_CAPABILITY_UNKNOWN = 0,
+    };
 
     typedef unsigned int SlangMatrixLayoutMode;
     enum

--- a/source/slang/slang-api.cpp
+++ b/source/slang/slang-api.cpp
@@ -127,6 +127,13 @@ SLANG_API SlangProfileID spFindProfile(
     return session->findProfile(name);
 }
 
+SLANG_API SlangCapabilityID spFindCapability(
+    SlangSession*   session,
+    char const*     name)
+{
+    return session->findCapability(name);
+}
+
 /* !!!!!!!!!!!!!!!!!!SlangCompileRequest API!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
 
 /*!

--- a/source/slang/slang-capability.cpp
+++ b/source/slang/slang-capability.cpp
@@ -97,11 +97,7 @@ struct CapabilityAtomInfo
     CapabilityAtom              bases[kCapabilityAtom_MaxBases];
 };
 //
-// The array is going to be sized to include an entry for `CapabilityAtom::Invalid`
-// which as a value of -1, so we need to size the array one larger than the `Count`
-// value.
-//
-static const CapabilityAtomInfo kCapabilityAtoms[Int(CapabilityAtom::Count) + 1] =
+static const CapabilityAtomInfo kCapabilityAtoms[Int(CapabilityAtom::Count)] =
 {
     { "invalid", CapabilityAtomFlavor::Concrete, CapabilityAtomConflictMask::None, 0, { CapabilityAtom::Invalid, CapabilityAtom::Invalid, CapabilityAtom::Invalid, CapabilityAtom::Invalid } },
 
@@ -114,7 +110,7 @@ static const CapabilityAtomInfo kCapabilityAtoms[Int(CapabilityAtom::Count) + 1]
 static CapabilityAtomInfo const& _getInfo(CapabilityAtom atom)
 {
     SLANG_ASSERT(Int(atom) < Int(CapabilityAtom::Count));
-    return kCapabilityAtoms[Int(atom) + 1];
+    return kCapabilityAtoms[Int(atom)];
 }
 
 CapabilityAtom findCapabilityAtom(UnownedStringSlice const& name)
@@ -124,11 +120,6 @@ CapabilityAtom findCapabilityAtom(UnownedStringSlice const& name)
     //
     for( Index i = 0; i < Index(CapabilityAtom::Count); ++i )
     {
-        // Note: using `_getInfo` here instead of accessing
-        // the `kCapabilityAtoms` array directly lets us
-        // avoid dealing with the offset-by-one indexing
-        // choice.
-        //
         auto& capInfo = _getInfo(CapabilityAtom(i));
         if(name == UnownedTerminatedStringSlice(capInfo.name))
             return CapabilityAtom(i);

--- a/source/slang/slang-capability.h
+++ b/source/slang/slang-capability.h
@@ -32,7 +32,7 @@ enum class CapabilityAtom : int32_t
     // function needs the invalid capability, it would be reasonable
     // to report that situation as an error.
     //
-    Invalid = -1,
+    Invalid = 0,
 
 #define SLANG_CAPABILITY_ATOM(ENUMERATOR, NAME, FLAVOR, CONFLICT, RANK, BASE0, BASE1, BASE2, BASE3) \
     ENUMERATOR,


### PR DESCRIPTION
* Make invalid/unknown capability have a zero value (this aligns it better with the public API for `SlangProfileID`, so that the two can be merged down the line)

* Actually provide an implementation of `spFindCapability()` public API