### PR TITLE
Convert more tests to use shader objects

### DIFF
--- a/tests/bugs/bool-init.slang
+++ b/tests/bugs/bool-init.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute,vulkan):COMPARE_COMPUTE_EX:-vk -slang -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute,vulkan):COMPARE_COMPUTE_EX:-vk -slang -compute -shaderobj
 
 struct Thing
 {

--- a/tests/bugs/bool-op.slang
+++ b/tests/bugs/bool-op.slang
@@ -1,6 +1,6 @@
 // enum.slang
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
 
 // Confirm operations that produce bools - such as comparisons, or && ||, ! work correctly
 

--- a/tests/bugs/dxbc-double-problem.slang
+++ b/tests/bugs/dxbc-double-problem.slang
@@ -1,8 +1,8 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-dx12 -compute -use-dxil -output-using-type
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-dx12 -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-dx12 -compute -use-dxil -output-using-type -shaderobj
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-dx12 -compute -output-using-type -shaderobj
 
 // The problem this test shows is around handling of double with dxbc on D3D12. In that combination
 // this code does not write the correct value into the first element - it appears as 0, where 

--- a/tests/bugs/empty-switch.slang
+++ b/tests/bugs/empty-switch.slang
@@ -1,7 +1,7 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute,vulkan):COMPARE_COMPUTE_EX:-vk -slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cuda -slang -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute,vulkan):COMPARE_COMPUTE_EX:-vk -slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cuda -slang -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out, name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/bugs/gh-357.slang
+++ b/tests/bugs/gh-357.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 

--- a/tests/bugs/gh-471.slang
+++ b/tests/bugs/gh-471.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 //TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):out,name outputBuffer
 
 // Test that "operator comma" works as expected

--- a/tests/bugs/gh-487.slang
+++ b/tests/bugs/gh-487.slang
@@ -1,5 +1,5 @@
 // gh-487.slang
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
 
 // This test is to confirm that we can apply builtin functions taht expect
 // a floating-point argument to an integer, with the compiler filling

--- a/tests/bugs/gh-518.slang
+++ b/tests/bugs/gh-518.slang
@@ -1,6 +1,6 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST_DISABLED(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST_DISABLED(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
 
 // Note: can't actually test this on Vulkan right now because
 // the support in render-test isn't good enough.

--- a/tests/bugs/gh-519.slang
+++ b/tests/bugs/gh-519.slang
@@ -1,6 +1,6 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
 
 // This bug involved incorrect computation of the successor
 // blocks for a `switch`, which led to incorrect SSA form.

--- a/tests/bugs/gh-566.slang
+++ b/tests/bugs/gh-566.slang
@@ -1,6 +1,6 @@
 // legalize-struct-init.slang
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 //TEST_INPUT:ubuffer(data=[4 3 2 1], stride=4):name inputBuffer
 

--- a/tests/bugs/gh-569.slang
+++ b/tests/bugs/gh-569.slang
@@ -1,5 +1,5 @@
 // gh-569.slang
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // Test that correct scoping is used in generated HLSL/GLSL,
 // even when dominator tree and structured control flow disagree.

--- a/tests/bugs/gh-775.slang
+++ b/tests/bugs/gh-775.slang
@@ -1,5 +1,5 @@
 // gh-775.slang
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 int test(int inVal)
 {

--- a/tests/bugs/gl-33.slang
+++ b/tests/bugs/gl-33.slang
@@ -1,5 +1,5 @@
 // gl-33.slang
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // Test for GitLab issue # 33
 

--- a/tests/bugs/glsl-static-const-array.slang
+++ b/tests/bugs/glsl-static-const-array.slang
@@ -1,6 +1,6 @@
 // glsl-static-const-array.slang
 
-//TEST(compute):COMPARE_COMPUTE:-vk
+//TEST(compute):COMPARE_COMPUTE:-vk -shaderobj
 
 static const int gData[4] =
 {

--- a/tests/bugs/mutating/mutating-generic-method.slang
+++ b/tests/bugs/mutating/mutating-generic-method.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute,vulkan):COMPARE_COMPUTE_EX:-vk -slang -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute,vulkan):COMPARE_COMPUTE_EX:-vk -slang -compute -shaderobj
 
 // Confirm that a generic method marked `[mutating]`
 // produces an `inout` parameter for `this`.
@@ -38,7 +38,7 @@ int test(int val)
     return r.state;
 }
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out, name outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/bugs/negative-literal.slang
+++ b/tests/bugs/negative-literal.slang
@@ -1,7 +1,7 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -compile-arg -O3
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -compile-arg -O3 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/bugs/nested-generics-call.slang
+++ b/tests/bugs/nested-generics-call.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/bugs/nested-generics-method-call.slang
+++ b/tests/bugs/nested-generics-method-call.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/bugs/paren-insertion-bug.slang
+++ b/tests/bugs/paren-insertion-bug.slang
@@ -3,7 +3,7 @@
 // Confirm that precedence is correctly handled
 // for cast from scalar to vector.
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 int test(float a)
 {

--- a/tests/bugs/specialize-function-array-args.slang
+++ b/tests/bugs/specialize-function-array-args.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute,vulkan):COMPARE_COMPUTE_EX:-vk -slang -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute,vulkan):COMPARE_COMPUTE_EX:-vk -slang -compute -shaderobj
 
 // When a function is passed a parameter that contains an array, it specialized it as a performance
 // improvement for VK. If the struct contained a structured buffer, though it meant that the 

--- a/tests/bugs/ssa-loop.slang
+++ b/tests/bugs/ssa-loop.slang
@@ -2,7 +2,7 @@
 
 // Bug related to SSA form for loops
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
 
 int test(int val)
 {

--- a/tests/bugs/static-method.slang
+++ b/tests/bugs/static-method.slang
@@ -1,6 +1,6 @@
 // static-method.slang
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
 
 struct S
 {

--- a/tests/bugs/static-var.slang
+++ b/tests/bugs/static-var.slang
@@ -1,5 +1,5 @@
 // gh-775-ext.slang
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 int test(int inVal)
 {

--- a/tests/bugs/vec-compare.slang
+++ b/tests/bugs/vec-compare.slang
@@ -1,6 +1,6 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/bugs/while-in-generic.slang
+++ b/tests/bugs/while-in-generic.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
 struct Context
 {
     int genFunc<TGenType>(TGenType t)

--- a/tests/compute/array-param.slang
+++ b/tests/compute/array-param.slang
@@ -1,8 +1,8 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -compile-arg -O3
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -compile-arg -O3 -shaderobj
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
 
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer

--- a/tests/compute/assoctype-complex.slang
+++ b/tests/compute/assoctype-complex.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE: -cpu
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -cpu -shaderobj
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/compute/assoctype-func-param.slang
+++ b/tests/compute/assoctype-func-param.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:-cpu
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // Test type checking of associatedtype and typedef
 

--- a/tests/compute/assoctype-generic-arg.slang
+++ b/tests/compute/assoctype-generic-arg.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:-cpu
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 //TEST_INPUT:type AssocImpl
 

--- a/tests/compute/assoctype-lookup.slang
+++ b/tests/compute/assoctype-lookup.slang
@@ -2,10 +2,10 @@
 
 // Confirm that an associated type can be correctly looked up.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
 
 interface IBoneWeightSet
 {

--- a/tests/compute/assoctype-nested.slang
+++ b/tests/compute/assoctype-nested.slang
@@ -2,10 +2,10 @@
 
 // Confirm that an associated type can be declared nested in its parent.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
 
 interface IRandomGenerator
 {

--- a/tests/compute/assoctype-simple.slang
+++ b/tests/compute/assoctype-simple.slang
@@ -1,5 +1,5 @@
-//TEST(smoke,compute):COMPARE_COMPUTE:-cpu
-//TEST(smoke,compute):COMPARE_COMPUTE:
+//TEST(smoke,compute):COMPARE_COMPUTE:-cpu -shaderobj
+//TEST(smoke,compute):COMPARE_COMPUTE: -shaderobj
 
 // Confirm that generics syntax can be used in user
 // code and generates valid output.

--- a/tests/compute/atomics-buffer.slang
+++ b/tests/compute/atomics-buffer.slang
@@ -1,14 +1,14 @@
 // atomics-buffer.slang
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
 // Doesn't work on VK - GLSL output doesn't replace InterlockedAdd.  
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -vk
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -vk -shaderobj
 // Cannot work on CUDA, as outputBuffer becomes a CUsurfObject - which do not appear to have atomics available.
 // If the buffer was a StructuredBuffer this would work on CUDA.
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cuda
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cuda -shaderobj
 // Atomics not available on CPU currently
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu -shaderobj
 
 //TEST_INPUT:ubuffer(format=R_UInt32, data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]):out,name outputBuffer
 

--- a/tests/compute/atomics-groupshared.slang
+++ b/tests/compute/atomics-groupshared.slang
@@ -1,9 +1,9 @@
 // atomics-groupshared.slang
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -vk
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cuda
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -vk -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cuda -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 

--- a/tests/compute/atomics.slang
+++ b/tests/compute/atomics.slang
@@ -1,9 +1,9 @@
 // atomics.slang
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -vk
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cuda
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -vk -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cuda -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out, name outputBuffer
 

--- a/tests/compute/break-stmt.slang
+++ b/tests/compute/break-stmt.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:-cpu
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // Test that `break` from a loop works.
 

--- a/tests/compute/buffer-layout.slang
+++ b/tests/compute/buffer-layout.slang
@@ -3,10 +3,10 @@
 // The goal of this test is to make sure that constant and structured
 // buffers obey the rules we expect of the each target API.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu -shaderobj
 
 //TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/compute/buffer-type-splitting.slang
+++ b/tests/compute/buffer-type-splitting.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 //TEST_INPUT:ubuffer(data=[0 2 3 3]):name=s[0].a

--- a/tests/compute/byte-address-buffer.slang
+++ b/tests/compute/byte-address-buffer.slang
@@ -1,9 +1,9 @@
 // byte-address-buffer.slang
 
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-d3d12 -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-d3d12 -compute -shaderobj
 
 // Confirm cross-compilation of `(RW)ByteAddressBuffer`
 //

--- a/tests/compute/cast-zero-to-struct.slang
+++ b/tests/compute/cast-zero-to-struct.slang
@@ -3,8 +3,8 @@
 // Test that HLSL legacy syntax for casting from literal zero
 // to a `struct` type works.
 
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 struct S
 {

--- a/tests/compute/cbuffer-legalize.slang
+++ b/tests/compute/cbuffer-legalize.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 //TEST(compute):COMPARE_COMPUTE:-shaderobj
 
 //TEST_INPUT: Uniform(data=[1 2 3 4]):name=C.p.c

--- a/tests/compute/comma-operator.slang
+++ b/tests/compute/comma-operator.slang
@@ -1,7 +1,7 @@
 // comma-operator.slang
 
-//TEST(compute):COMPARE_COMPUTE:-cpu
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // Test that the "comma operator" behaves as expected
 

--- a/tests/compute/compile-time-loop.slang
+++ b/tests/compute/compile-time-loop.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_RENDER_COMPUTE:
+//TEST(compute):COMPARE_RENDER_COMPUTE: -shaderobj
 
 //TEST_INPUT: Texture2D(size=4, content = one):name t
 //TEST_INPUT: Sampler:name s

--- a/tests/compute/constexpr.slang
+++ b/tests/compute/constexpr.slang
@@ -1,6 +1,6 @@
 // constexpr.slang
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -gcompute
-//DISABLED://TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -gcompute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -gcompute -shaderobj
+//DISABLED://TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -gcompute -shaderobj
 
 //TEST_INPUT: Texture2D(size=4, content = one):name tex
 //TEST_INPUT: Sampler:name samp

--- a/tests/compute/continue-stmt.slang
+++ b/tests/compute/continue-stmt.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Test that `break` from a loop works.
 

--- a/tests/compute/default-initializer.slang
+++ b/tests/compute/default-initializer.slang
@@ -3,8 +3,8 @@
 // Confirm that a type with a default initializer gets
 // default-initialized where appropriate.
 
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 struct Stuff
 {

--- a/tests/compute/default-parameter.slang
+++ b/tests/compute/default-parameter.slang
@@ -1,6 +1,6 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cpu -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/compute/discard-stmt.slang
+++ b/tests/compute/discard-stmt.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_RENDER_COMPUTE:
+//TEST(compute):COMPARE_RENDER_COMPUTE: -shaderobj
 //TEST_INPUT: Texture2D(size=4, content = one):name tex
 //TEST_INPUT: Sampler:name samp
 //TEST_INPUT: ubuffer(data=[0 0], stride=4):out,name outputBuffer

--- a/tests/compute/dump-repro.slang
+++ b/tests/compute/dump-repro.slang
@@ -1,8 +1,8 @@
 //DISABLE_TEST(compute):SIMPLE:-profile cs_5_0 -entry computeMain -target dxbc -dump-repro repro.slang-repro
 //TEST:COMPILE:tests/compute/dump-repro.slang -profile cs_5_0 -entry computeMain -target dxbc -dump-repro repro.slang-repro
-//TEST(compute):COMPARE_COMPUTE_EX:-dx11 -compute -no-default-entry-point -compile-arg -load-repro -compile-arg repro.slang-repro
+//TEST(compute):COMPARE_COMPUTE_EX:-dx11 -compute -no-default-entry-point -compile-arg -load-repro -compile-arg repro.slang-repro -shaderobj
 // We only want to run on one API to test load worked
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-dx12 -load-repro repro.slang-repro
+//DISABLE_TEST(compute):COMPARE_COMPUTE:-dx12 -load-repro repro.slang-repro -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/compute/dynamic-dispatch-1.slang
+++ b/tests/compute/dynamic-dispatch-1.slang
@@ -1,7 +1,7 @@
-//TEST(compute):COMPARE_COMPUTE:-dx11
-//TEST(compute):COMPARE_COMPUTE:-vk
-//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-dx11 -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -xslang -disable-specialization -shaderobj
 
 // Test dynamic dispatch code gen for non-static member functions.
 

--- a/tests/compute/dynamic-dispatch-10.slang
+++ b/tests/compute/dynamic-dispatch-10.slang
@@ -1,7 +1,7 @@
-//TEST(compute):COMPARE_COMPUTE:-dx11
-//TEST(compute):COMPARE_COMPUTE:-vk
-//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-dx11 -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization -shaderobj
 
 // Test dynamic dispatch code gen for specializing a generic with
 // an existential value.

--- a/tests/compute/dynamic-dispatch-11.slang
+++ b/tests/compute/dynamic-dispatch-11.slang
@@ -1,9 +1,9 @@
 // Test using interface typed shader parameters with dynamic dispatch.
 
-//TEST(compute):COMPARE_COMPUTE:-dx11
-//TEST(compute):COMPARE_COMPUTE:-vk
-//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-dx11 -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization -shaderobj
 
 [anyValueSize(8)]
 interface IInterface

--- a/tests/compute/dynamic-dispatch-12.slang
+++ b/tests/compute/dynamic-dispatch-12.slang
@@ -1,9 +1,9 @@
 // Test using interface typed shader parameters with dynamic dispatch.
 
-//TEST(compute):COMPARE_COMPUTE:-dx11
-//TEST(compute):COMPARE_COMPUTE:-cpu
-//TEST(compute):COMPARE_COMPUTE:-vk
-//TEST(compute):COMPARE_COMPUTE:-cuda
+//TEST(compute):COMPARE_COMPUTE:-dx11 -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cuda -shaderobj
 
 [anyValueSize(8)]
 interface IInterface

--- a/tests/compute/dynamic-dispatch-13.slang
+++ b/tests/compute/dynamic-dispatch-13.slang
@@ -1,9 +1,9 @@
 // Test using interface typed shader parameters wrapped inside a `StructuredBuffer`.
 
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 //TEST(compute):COMPARE_COMPUTE:-dx11
 //TEST(compute):COMPARE_COMPUTE:-vk
-//TEST(compute):COMPARE_COMPUTE:-cuda
+//TEST(compute):COMPARE_COMPUTE:-cuda -shaderobj
 
 [anyValueSize(8)]
 interface IInterface

--- a/tests/compute/dynamic-dispatch-14.slang
+++ b/tests/compute/dynamic-dispatch-14.slang
@@ -1,9 +1,9 @@
 // Test using interface typed shader parameters with associated types.
 
 //TEST(compute):COMPARE_COMPUTE:-dx11
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 //TEST(compute):COMPARE_COMPUTE:-vk
-//TEST(compute):COMPARE_COMPUTE:-cuda
+//TEST(compute):COMPARE_COMPUTE:-cuda -shaderobj
 
 [anyValueSize(8)]
 interface IAssoc

--- a/tests/compute/dynamic-dispatch-2.slang
+++ b/tests/compute/dynamic-dispatch-2.slang
@@ -1,7 +1,7 @@
-//TEST(compute):COMPARE_COMPUTE:-dx11
-//TEST(compute):COMPARE_COMPUTE:-vk
-//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-dx11 -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization -shaderobj
 
 // Test dynamic dispatch code gen for static member functions
 // of associated type.

--- a/tests/compute/dynamic-dispatch-3.slang
+++ b/tests/compute/dynamic-dispatch-3.slang
@@ -1,7 +1,7 @@
-//TEST(compute):COMPARE_COMPUTE:-dx11
-//TEST(compute):COMPARE_COMPUTE:-vk
-//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-dx11 -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization -shaderobj
 
 // Test dynamic dispatch code gen for static member functions
 // of associated type.

--- a/tests/compute/dynamic-dispatch-4.slang
+++ b/tests/compute/dynamic-dispatch-4.slang
@@ -1,7 +1,7 @@
-//TEST(compute):COMPARE_COMPUTE:-dx11
-//TEST(compute):COMPARE_COMPUTE:-vk
-//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-dx11 -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization -shaderobj
 
 // Test dynamic dispatch code gen for generic-typed local variables.
 

--- a/tests/compute/dynamic-dispatch-5.slang
+++ b/tests/compute/dynamic-dispatch-5.slang
@@ -1,7 +1,7 @@
-//TEST(compute):COMPARE_COMPUTE:-dx11
-//TEST(compute):COMPARE_COMPUTE:-vk
-//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-dx11 -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization -shaderobj
 
 // Test dynamic dispatch code gen for general `This` type.
 [anyValueSize(8)]

--- a/tests/compute/dynamic-dispatch-6.slang
+++ b/tests/compute/dynamic-dispatch-6.slang
@@ -1,7 +1,7 @@
-//TEST(compute):COMPARE_COMPUTE:-dx11
-//TEST(compute):COMPARE_COMPUTE:-vk
-//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-dx11 -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization -shaderobj
 
 // Test dynamic dispatch code gen for generic-typed return values.
 [anyValueSize(8)]

--- a/tests/compute/dynamic-dispatch-7.slang
+++ b/tests/compute/dynamic-dispatch-7.slang
@@ -1,7 +1,7 @@
-//TEST(compute):COMPARE_COMPUTE:-dx11
-//TEST(compute):COMPARE_COMPUTE:-vk
-//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-dx11 -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization -shaderobj
 
 // Test dynamic dispatch code gen for associated-typed return values
 // and local variables.

--- a/tests/compute/dynamic-dispatch-8.slang
+++ b/tests/compute/dynamic-dispatch-8.slang
@@ -1,7 +1,7 @@
-//TEST(compute):COMPARE_COMPUTE:-dx11
-//TEST(compute):COMPARE_COMPUTE:-vk
-//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-dx11 -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization -shaderobj
 
 // Test dynamic dispatch code gen for extential type parameters.
 

--- a/tests/compute/dynamic-dispatch-9.slang
+++ b/tests/compute/dynamic-dispatch-9.slang
@@ -1,7 +1,7 @@
-//TEST(compute):COMPARE_COMPUTE:-dx11
-//TEST(compute):COMPARE_COMPUTE:-vk
-//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization
-//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization
+//TEST(compute):COMPARE_COMPUTE:-dx11 -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -xslang -disable-specialization -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cuda -xslang -disable-specialization -shaderobj
 
 // Test dynamic dispatch code gen for initializing an extential value
 // from a generic value.

--- a/tests/compute/empty-struct.slang
+++ b/tests/compute/empty-struct.slang
@@ -1,5 +1,5 @@
-//TEST(smoke,compute):COMPARE_COMPUTE:
-//TEST(smoke,compute):COMPARE_COMPUTE:-cpu
+//TEST(smoke,compute):COMPARE_COMPUTE: -shaderobj
+//TEST(smoke,compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Confirm that generics syntax can be used in user
 // code and generates valid output.

--- a/tests/compute/empty-struct2.slang
+++ b/tests/compute/empty-struct2.slang
@@ -1,5 +1,5 @@
-//TEST(smoke,compute):COMPARE_COMPUTE:
-//TEST(smoke,compute):COMPARE_COMPUTE:-cpu
+//TEST(smoke,compute):COMPARE_COMPUTE: -shaderobj
+//TEST(smoke,compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // This is a basic test for Slang compute shader.
 

--- a/tests/compute/enum-conversion2.slang
+++ b/tests/compute/enum-conversion2.slang
@@ -1,8 +1,8 @@
 // enum-conversion2.slang
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 
 // More significant stress testing of `enum` types
 

--- a/tests/compute/enum-tag-conversion.slang
+++ b/tests/compute/enum-tag-conversion.slang
@@ -1,8 +1,8 @@
 // enum-tag-conversion.slang
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 
 // Confirm that a value of `enum` type can have an initializer
 // that includes basic operations like type conversion.

--- a/tests/compute/enum.slang
+++ b/tests/compute/enum.slang
@@ -1,7 +1,7 @@
 // enum.slang
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 
 // Confirm that basic `enum` declarations are supported.
 

--- a/tests/compute/explicit-this-expr.slang
+++ b/tests/compute/explicit-this-expr.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 
 // Access fields of a `struct` type from within a "method" by

--- a/tests/compute/extension-multi-interface.slang
+++ b/tests/compute/extension-multi-interface.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/compute/frem.slang
+++ b/tests/compute/frem.slang
@@ -1,8 +1,8 @@
 // frem.slang
 
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
-//TEST(compute):COMPARE_COMPUTE:-vk
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -shaderobj
 
 // Test uses of floating-point `%` operator.
 

--- a/tests/compute/func-cbuffer-param.slang
+++ b/tests/compute/func-cbuffer-param.slang
@@ -5,10 +5,10 @@
 
 // This has a compatibility issue on Windows 10.0.10586 on Dx12 - dxcompiler will crash (can remove form tests with -exclude compatibility-issue)
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute, vulkan, compatibility-issue):COMPARE_COMPUTE_EX:-dx12 -compute -use-dxil
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cpu -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute, vulkan, compatibility-issue):COMPARE_COMPUTE_EX:-dx12 -compute -use-dxil -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 
 struct Data
 {

--- a/tests/compute/func-param-legalize.slang
+++ b/tests/compute/func-param-legalize.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 struct Param
 {

--- a/tests/compute/func-resource-param.slang
+++ b/tests/compute/func-resource-param.slang
@@ -4,10 +4,10 @@
 // requires non-trivial legalization can be compiled
 // to work on GLSL-based targets.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-dx12 -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cpu -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-dx12 -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 
 //NO_TEST:SIMPLE:-target glsl -entry computeMain -stage compute -validate-ir -dump-ir
 

--- a/tests/compute/generic-closer.slang
+++ b/tests/compute/generic-closer.slang
@@ -1,7 +1,7 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 
 interface IGetter
 {

--- a/tests/compute/generic-interface-method-simple.slang
+++ b/tests/compute/generic-interface-method-simple.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/compute/generic-interface-method.slang
+++ b/tests/compute/generic-interface-method.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/compute/generic-list.slang
+++ b/tests/compute/generic-list.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Confirm that generics syntax can be used in user
 // code and generates valid output.

--- a/tests/compute/generic-struct-with-constraint.slang
+++ b/tests/compute/generic-struct-with-constraint.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Confirm that generics syntax can be used in user
 // code and generates valid output.

--- a/tests/compute/generic-struct.slang
+++ b/tests/compute/generic-struct.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Check that user code can declare and use a generic
 // `struct` type.

--- a/tests/compute/generics-constrained.slang
+++ b/tests/compute/generics-constrained.slang
@@ -1,5 +1,5 @@
-//TEST(smoke,compute):COMPARE_COMPUTE:
-//TEST(smoke,compute):COMPARE_COMPUTE:-cpu
+//TEST(smoke,compute):COMPARE_COMPUTE: -shaderobj
+//TEST(smoke,compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Use interface constraints on a generic parameter
 

--- a/tests/compute/generics-constructor.slang
+++ b/tests/compute/generics-constructor.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/compute/generics-overload.slang
+++ b/tests/compute/generics-overload.slang
@@ -1,5 +1,5 @@
-//TEST(smoke,compute):COMPARE_COMPUTE:
-//TEST(smoke,compute):COMPARE_COMPUTE:-cpu
+//TEST(smoke,compute):COMPARE_COMPUTE: -shaderobj
+//TEST(smoke,compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Confirm that generics syntax can be used in user
 // code and generates valid output.

--- a/tests/compute/generics-simple.slang
+++ b/tests/compute/generics-simple.slang
@@ -1,5 +1,5 @@
-//TEST(smoke,compute):COMPARE_COMPUTE:
-//TEST(smoke,compute):COMPARE_COMPUTE:-cpu
+//TEST(smoke,compute):COMPARE_COMPUTE: -shaderobj
+//TEST(smoke,compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Confirm that generics syntax can be used in user
 // code and generates valid output.

--- a/tests/compute/generics-syntax-2.slang
+++ b/tests/compute/generics-syntax-2.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Confirm that generics syntax can be used in user
 // code and generates valid output.

--- a/tests/compute/generics-syntax.slang
+++ b/tests/compute/generics-syntax.slang
@@ -1,5 +1,5 @@
-//TEST(smoke,compute):COMPARE_COMPUTE:
-//TEST(smoke,compute):COMPARE_COMPUTE:-cpu
+//TEST(smoke,compute):COMPARE_COMPUTE: -shaderobj
+//TEST(smoke,compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Confirm that generics syntax can be used in user
 // code and generates valid output.

--- a/tests/compute/global-generic-value-param.slang
+++ b/tests/compute/global-generic-value-param.slang
@@ -1,6 +1,6 @@
 // global-generic-value-param.slang
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // This is a basic test of support for global generic
 // value parameters: explicit named parameters at global

--- a/tests/compute/global-init.slang
+++ b/tests/compute/global-init.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Test that a global variable (not a shader parameter)
 // with an initializer works.

--- a/tests/compute/global-type-param-in-entrypoint.slang
+++ b/tests/compute/global-type-param-in-entrypoint.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_RENDER_COMPUTE:
+//TEST(compute):COMPARE_RENDER_COMPUTE: -shaderobj
 
 //TEST_INPUT: cbuffer(data=[1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0], stride=16):name Uniforms
 //TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer

--- a/tests/compute/global-type-param.slang
+++ b/tests/compute/global-type-param.slang
@@ -1,4 +1,4 @@
-//TEST(smoke,compute):COMPARE_COMPUTE:
+//TEST(smoke,compute):COMPARE_COMPUTE: -shaderobj
 
 //TEST_INPUT:type Wrapper<Impl>
 

--- a/tests/compute/groupshared.slang
+++ b/tests/compute/groupshared.slang
@@ -1,9 +1,9 @@
 // groupshared.slang
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out, name=gBuffer
 RWStructuredBuffer<int> gBuffer;

--- a/tests/compute/half-calc.slang
+++ b/tests/compute/half-calc.slang
@@ -1,5 +1,5 @@
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-dx12 -compute -use-dxil -profile cs_6_2 -render-features half
-//TEST(compute):COMPARE_COMPUTE:-vk -compute -profile cs_6_2 -render-features half
+//DISABLE_TEST(compute):COMPARE_COMPUTE:-dx12 -compute -use-dxil -profile cs_6_2 -render-features half -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -compute -profile cs_6_2 -render-features half -shaderobj
 
 
 // Test for doing a calculation using half

--- a/tests/compute/half-structured-buffer.slang
+++ b/tests/compute/half-structured-buffer.slang
@@ -1,6 +1,6 @@
-//TEST(compute):COMPARE_COMPUTE:-vk -compute -profile cs_6_2 -render-features half
+//TEST(compute):COMPARE_COMPUTE:-vk -compute -profile cs_6_2 -render-features half -shaderobj
 //Disable on Dx12 for now - because writing to structured buffer produces unexpected results
-//TEST_DISABLED(compute):COMPARE_COMPUTE:-dx12 -compute -use-dxil -profile cs_6_2 -render-features half
+//TEST_DISABLED(compute):COMPARE_COMPUTE:-dx12 -compute -use-dxil -profile cs_6_2 -render-features half -shaderobj
 
 struct Thing
 {

--- a/tests/compute/half-texture.slang
+++ b/tests/compute/half-texture.slang
@@ -1,5 +1,5 @@
 //TEST:CROSS_COMPILE: -target spirv -entry computeMain -profile cs_6_2
-//TEST:SIMPLE: -target hlsl -entry computeMain -profile cs_6_2 
+//TEST:SIMPLE: -target hlsl -entry computeMain -profile cs_6_2
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=16):out
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/compute/implicit-generic-app.slang
+++ b/tests/compute/implicit-generic-app.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Testing that we can implicitly specialize a generic
 // that has a constrained type parameter.

--- a/tests/compute/implicit-this-expr.slang
+++ b/tests/compute/implicit-this-expr.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Access fields of a `struct` type from within a "method" by
 // using an implicit `this` expression.

--- a/tests/compute/init-list-defaults.slang
+++ b/tests/compute/init-list-defaults.slang
@@ -1,6 +1,6 @@
 // init-list-defaults.slang
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Confirm that initializer lists correctly default-initialize elements past those specified.
 

--- a/tests/compute/initializer-list.slang
+++ b/tests/compute/initializer-list.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 struct Test
 {

--- a/tests/compute/inout.slang
+++ b/tests/compute/inout.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Test that we correctly support both `out`
 // and `inout` function parameters.

--- a/tests/compute/int-generic.slang
+++ b/tests/compute/int-generic.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 //TEST_INPUT:type Material<1,2>
 

--- a/tests/compute/interface-assoc-type-param.slang
+++ b/tests/compute/interface-assoc-type-param.slang
@@ -1,7 +1,7 @@
 // Tests using associated types through an existential-struct-typed param.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cuda
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cuda -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu -shaderobj
 
 [anyValueSize(8)]
 interface IInterface

--- a/tests/compute/interface-func-param-in-struct.slang
+++ b/tests/compute/interface-func-param-in-struct.slang
@@ -1,7 +1,7 @@
 // Tests specializing a function with existential-struct-typed param.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cuda
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cuda -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu -shaderobj
 
 [anyValueSize(8)]
 interface IInterface

--- a/tests/compute/interface-local.slang
+++ b/tests/compute/interface-local.slang
@@ -10,10 +10,10 @@
 
 // on a generic type parameter.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 
 
 interface IHelper

--- a/tests/compute/interface-param-partial-specialize.slang
+++ b/tests/compute/interface-param-partial-specialize.slang
@@ -3,8 +3,8 @@
 // with __Dynamic. This verifies that the handling of
 // "partially" specializing an existential type is correct.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cuda
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cuda -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu -shaderobj
 
 [anyValueSize(8)]
 interface IInterface

--- a/tests/compute/interface-param.slang
+++ b/tests/compute/interface-param.slang
@@ -4,10 +4,10 @@
 // for a value parameter, instead of just as a constraint
 // on a generic type parameter.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 
 interface IHelper
 {

--- a/tests/compute/interface-static-method.slang
+++ b/tests/compute/interface-static-method.slang
@@ -1,9 +1,9 @@
 // interface-static-method.slang
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 
 interface IHideout
 {

--- a/tests/compute/loop-unroll.slang
+++ b/tests/compute/loop-unroll.slang
@@ -1,11 +1,11 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-dx12 
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-dx12  -shaderobj
 //TODO(JS): This test fails with a crash in CreateComputePipelineState, so disabled for now
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-dx12 -use-dxil
-//TEST(compute):COMPARE_COMPUTE:-cpu
-//TEST(compute):COMPARE_COMPUTE:-cuda
+//DISABLE_TEST(compute):COMPARE_COMPUTE:-dx12 -use-dxil -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cuda -shaderobj
 // Note VK output is not loop unrolled
-//TEST(compute):COMPARE_COMPUTE:-vk
+//TEST(compute):COMPARE_COMPUTE:-vk -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out, name buffers[0]
 //TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):name buffers[1]

--- a/tests/compute/matrix-layout-structured-buffer.slang
+++ b/tests/compute/matrix-layout-structured-buffer.slang
@@ -5,8 +5,8 @@
 // buffers of matrices, where fxc/dxc do *not* respect
 // the matrix layout mode by default.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -xslang -matrix-layout-row-major
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -xslang -matrix-layout-column-major
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -xslang -matrix-layout-row-major -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -xslang -matrix-layout-column-major -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23], stride=48):name=gMatrices
 RWStructuredBuffer<int3x4> gMatrices;

--- a/tests/compute/matrix-layout.hlsl
+++ b/tests/compute/matrix-layout.hlsl
@@ -7,8 +7,8 @@
 
 // This has a compatibility issue on Windows 10.0.10586 on Dx12 - dxcompiler will crash (can remove form tests with -exclude compatibility-issue)
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -xslang -matrix-layout-row-major
-//TEST(compute,compatibility-issue):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -xslang -matrix-layout-row-major
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -xslang -matrix-layout-row-major -shaderobj
+//TEST(compute,compatibility-issue):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -xslang -matrix-layout-row-major -shaderobj
 
 // Not testing on Vulkan because of lack of support
 // for integer matrices in GLSL. Slang needs to

--- a/tests/compute/modern-syntax.slang
+++ b/tests/compute/modern-syntax.slang
@@ -1,6 +1,6 @@
 // modern-syntax.slang
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -slang -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -slang -compute -shaderobj
 
 // This file exists to confirm that declarations using "modern"
 // syntax are handled correctly by the compiler front-end.

--- a/tests/compute/multi-interface.slang
+++ b/tests/compute/multi-interface.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/compute/multiple-continue-sites.slang
+++ b/tests/compute/multiple-continue-sites.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Test that a loop with multiple `continue` sites works.
 //

--- a/tests/compute/mutating-and-inout.slang
+++ b/tests/compute/mutating-and-inout.slang
@@ -2,7 +2,7 @@
 
 // Test that calling a `[mutating]` method on an `inout` function parameter works.
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/compute/mutating-methods.slang
+++ b/tests/compute/mutating-methods.slang
@@ -1,8 +1,8 @@
 // mutating-methods.slang
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -xslang -serial-ir
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -xslang -serial-ir
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -xslang -serial-ir
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -xslang -serial-ir
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -xslang -serial-ir -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -xslang -serial-ir -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -xslang -serial-ir -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -xslang -serial-ir -shaderobj
 
 interface IAccumulator
 {

--- a/tests/compute/nested-generics.slang
+++ b/tests/compute/nested-generics.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // test specialization of nested generic functions
 

--- a/tests/compute/nested-generics2.slang
+++ b/tests/compute/nested-generics2.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // test specialization of nested generic functions
 

--- a/tests/compute/performance-profile.slang
+++ b/tests/compute/performance-profile.slang
@@ -1,8 +1,8 @@
-//TEST(compute):PERFORMANCE_PROFILE:-cpu -compute -compile-arg -O3 -compute-dispatch 256,1,1 
-//TEST(compute):PERFORMANCE_PROFILE:-cpu -compute -source-language cpp -compile-arg -O3 -compute-dispatch 256,1,1 
-//TEST(compute):PERFORMANCE_PROFILE:-slang -compute -compute-dispatch 256,1,1
-//TEST(compute):PERFORMANCE_PROFILE:-slang -compute -dx12 -compute-dispatch 256,1,1
-//TEST(compute, vulkan):PERFORMANCE_PROFILE:-vk -compute -compute-dispatch 256,1,1
+//TEST(compute):PERFORMANCE_PROFILE:-cpu -compute -compile-arg -O3 -compute-dispatch 256,1,1  -shaderobj
+//TEST(compute):PERFORMANCE_PROFILE:-cpu -compute -source-language cpp -compile-arg -O3 -compute-dispatch 256,1,1  -shaderobj
+//TEST(compute):PERFORMANCE_PROFILE:-slang -compute -compute-dispatch 256,1,1 -shaderobj
+//TEST(compute):PERFORMANCE_PROFILE:-slang -compute -dx12 -compute-dispatch 256,1,1 -shaderobj
+//TEST(compute, vulkan):PERFORMANCE_PROFILE:-vk -compute -compute-dispatch 256,1,1 -shaderobj
 
 //TEST_INPUT:ubuffer(random(float, 4096, -1, 1), stride=4):out,name outputBuffer
 

--- a/tests/compute/pointer-emit.slang
+++ b/tests/compute/pointer-emit.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 // Test emitting logic of pointer types.
 
 

--- a/tests/compute/rewriter-parameter-block-complex.hlsl
+++ b/tests/compute/rewriter-parameter-block-complex.hlsl
@@ -1,12 +1,18 @@
 //TEST(compute):COMPARE_COMPUTE:
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out, name=outputBuffer
 
-//TEST_INPUT:cbuffer(data=[256]):
-//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):
+//TEST_INPUT:cbuffer(data=[256]):name=C.gA.val
+//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):name=C.gA.buf
+//TEST_INPUT:cbuffer(data=[4096]):name=C.gB.val
+//TEST_INPUT:ubuffer(data=[16 32 48 64], stride=4):name=C.gB.buf
 
-//TEST_INPUT:cbuffer(data=[4096]):
-//TEST_INPUT:ubuffer(data=[16 32 48 64], stride=4):
+//TODO_TEST_INPUT:object:name=C
+//TODO_TEST_INPUT:object:name=C.gA
+//TODO_TEST_INPUT:root_constants(data=[256]):name=C.gA.val
+//TODO_TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):name=C.gA.buf
+//TODO_TEST_INPUT:root_constants(data=[4096]):name=C.gB.val
+//TODO_TEST_INPUT:ubuffer(data=[16 32 48 64], stride=4):name=C.gB.buf
 
 // Test that we can declare a `ParameterBlock<...>` type as a shader
 // parameter (potentially nested inside a `cbuffer`) and use it in

--- a/tests/compute/rw-texture-simple.slang
+++ b/tests/compute/rw-texture-simple.slang
@@ -1,13 +1,13 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type -shaderobj
 // Doesn't work on DX11 currently - locks up on binding
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type -shaderobj
 // Produces a different result on DX12 with DXBC than expected(!). So disabled for now
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_0 -use-dxil -output-using-type
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_0 -use-dxil -output-using-type -shaderobj
 // TODO(JS): Doesn't work on vk currently, because createTextureView not implemented on vk renderer
-//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type
+//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type -shaderobj
 // TODO(JS): Doesn't work on certain CI systems. 
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type -shaderobj
 
 //TEST_INPUT: RWTexture1D(format=R_Float32, size=4, content = one):name rwt1D
 RWTexture1D<float> rwt1D;

--- a/tests/compute/scope-operator.slang
+++ b/tests/compute/scope-operator.slang
@@ -1,7 +1,7 @@
 // scope.slang
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 
 // Confirm that scoping on enums and types works 
 

--- a/tests/compute/select-expr.slang
+++ b/tests/compute/select-expr.slang
@@ -1,5 +1,5 @@
-//TEST(smoke,compute):COMPARE_COMPUTE:
-//TEST(smoke,compute):COMPARE_COMPUTE:-cpu
+//TEST(smoke,compute):COMPARE_COMPUTE: -shaderobj
+//TEST(smoke,compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Test IR code generation for the `?:` "select" operator
 

--- a/tests/compute/semantic.slang
+++ b/tests/compute/semantic.slang
@@ -1,7 +1,7 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -compile-arg -O3 -compute-dispatch 3,1,1
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -compute-dispatch 3,1,1
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -compute-dispatch 3,1,1
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -compute-dispatch 3,1,1
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -compile-arg -O3 -compute-dispatch 3,1,1 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -compute-dispatch 3,1,1 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -compute-dispatch 3,1,1 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -compute-dispatch 3,1,1 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0  0 0 0 0  0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/compute/simple.slang
+++ b/tests/compute/simple.slang
@@ -1,5 +1,5 @@
-//TEST(smoke,compute):COMPARE_COMPUTE:
-//TEST(smoke,compute):COMPARE_COMPUTE:-cpu
+//TEST(smoke,compute):COMPARE_COMPUTE: -shaderobj
+//TEST(smoke,compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // This is a basic test for Slang compute shader.
 

--- a/tests/compute/ssa-reduce-bug.slang
+++ b/tests/compute/ssa-reduce-bug.slang
@@ -1,6 +1,6 @@
 // ssa-reduce-bug.slang
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -slang -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -slang -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 3 1 2 6 4 7 6], stride=4):name=inputBuffer
 RWStructuredBuffer<int> inputBuffer;

--- a/tests/compute/static-const-array.slang
+++ b/tests/compute/static-const-array.slang
@@ -1,8 +1,8 @@
 // static-const-array.slang
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -slang -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -slang -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out, name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/compute/static-const-matrix-array.slang
+++ b/tests/compute/static-const-matrix-array.slang
@@ -1,8 +1,8 @@
 // static-const-array.slang
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -slang -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -slang -compute -output-using-type -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0  0 0 0 0], stride=4):out, name outputBuffer
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/compute/static-const-vector-array.slang
+++ b/tests/compute/static-const-vector-array.slang
@@ -1,8 +1,8 @@
 // static-const-array.slang
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -slang -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -slang -compute -output-using-type -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0  0 0 0 0], stride=4):out, name outputBuffer
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/compute/struct-default-init.slang
+++ b/tests/compute/struct-default-init.slang
@@ -1,5 +1,5 @@
 // struct-default-init.slang
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 struct Test
 {
@@ -25,7 +25,7 @@ int test(int inVal)
 	     + t.d;
 }
 
-//TEST_INPUT:ubuffer(data=[9 9 9 9], stride=4):out
+//TEST_INPUT:ubuffer(data=[9 9 9 9], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer : register(u0);
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/struct-in-generic.slang
+++ b/tests/compute/struct-in-generic.slang
@@ -1,8 +1,8 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // Confirm that a struct type defined in a generic parent works
 
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 struct GenStruct<T>

--- a/tests/compute/struct-make.slang
+++ b/tests/compute/struct-make.slang
@@ -1,7 +1,7 @@
 // scope.slang
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 
 // Confirm that scoping on enums and types works 
 

--- a/tests/compute/structured-buffer-of-matrices.slang
+++ b/tests/compute/structured-buffer-of-matrices.slang
@@ -11,10 +11,10 @@
 // output on all targets, correctly respecting the user's
 // request for row-major layout via command-line option.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -compile-arg -O3 -xslang -matrix-layout-row-major
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -xslang -matrix-layout-row-major
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -xslang -matrix-layout-row-major
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -xslang -matrix-layout-row-major
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -compile-arg -O3 -xslang -matrix-layout-row-major -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -xslang -matrix-layout-row-major -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -xslang -matrix-layout-row-major -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -xslang -matrix-layout-row-major -shaderobj
 
 // Note: we are using a buffer of floating-point matrices, but fill it with integer
 // data, to allow this test to work on the Vulkan targets, which do not currently

--- a/tests/compute/switch-stmt.slang
+++ b/tests/compute/switch-stmt.slang
@@ -1,5 +1,4 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST_INPUT:ubuffer(data=[0 1 2 3 4 5 6 7], stride=4):out
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // Test that `swith` statement works
 
@@ -30,6 +29,7 @@ int test(int inVal)
 	return result;
 }
 
+//TEST_INPUT:ubuffer(data=[0 1 2 3 4 5 6 7], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer : register(u0);
 
 [numthreads(8, 1, 1)]

--- a/tests/compute/texture-get-dimensions.slang
+++ b/tests/compute/texture-get-dimensions.slang
@@ -1,11 +1,11 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_0 -use-dxil
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12  -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_0 -use-dxil -shaderobj
 // TODO(JS): Doesn't work on vk currently, because createTextureView not implemented on vk renderer
-//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
+//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
 // TODO(JS): Doesn't work on CUDA as there aren't any CUDA functions to get dimensions.
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute 
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute  -shaderobj
 
 //TEST_INPUT: Texture1D(size=4, content = one):name t1D
 Texture1D<float> t1D;

--- a/tests/compute/texture-sampling.slang
+++ b/tests/compute/texture-sampling.slang
@@ -1,14 +1,14 @@
-//TEST(compute):COMPARE_RENDER_COMPUTE:
+//TEST(compute):COMPARE_RENDER_COMPUTE: -shaderobj
 
-//TEST_INPUT: Texture1D(size=4, content = one):
-//TEST_INPUT: Texture2D(size=4, content = one):
-//TEST_INPUT: Texture3D(size=4, content = one):
-//TEST_INPUT: TextureCube(size=4, content = one):
-//TEST_INPUT: Texture1D(size=4, content = one, arrayLength=2):
-//TEST_INPUT: Texture2D(size=4, content = one, arrayLength=2):
-//TEST_INPUT: TextureCube(size=4, content = one, arrayLength=2):
-//TEST_INPUT: Sampler:
-//TEST_INPUT: ubuffer(data=[0], stride=4):out
+//TEST_INPUT: Texture1D(size=4, content = one):name=t1D
+//TEST_INPUT: Texture2D(size=4, content = one):name=t2D
+//TEST_INPUT: Texture3D(size=4, content = one):name=t3D
+//TEST_INPUT: TextureCube(size=4, content = one):name=tCube
+//TEST_INPUT: Texture1D(size=4, content = one, arrayLength=2):name=t1dArray
+//TEST_INPUT: Texture2D(size=4, content = one, arrayLength=2):name=t2dArray
+//TEST_INPUT: TextureCube(size=4, content = one, arrayLength=2):name=tCubeArray
+//TEST_INPUT: Sampler:name=samplerState
+//TEST_INPUT: ubuffer(data=[0], stride=4):out,name=outputBuffer
 
 Texture1D t1D;
 Texture2D t2D;

--- a/tests/compute/texture-simple.slang
+++ b/tests/compute/texture-simple.slang
@@ -1,10 +1,10 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_0 -use-dxil
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute  -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12  -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_0 -use-dxil -shaderobj
 // TODO(JS): Doesn't work on vk currently, because createTextureView not implemented on vk renderer
-//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute 
+//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute  -shaderobj
 
 // Doesn't work on CUDA, not clear why yet
 //DISABLE_TEST_INPUT: Texture1D(format=R_Float32, size=4, content = one, mipMaps=1):name tLoad1D

--- a/tests/compute/this-type.slang
+++ b/tests/compute/this-type.slang
@@ -2,8 +2,8 @@
 
 // Confirm that that `This` type works as expected
 
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 interface IFrobable
 {

--- a/tests/compute/transcendental.slang
+++ b/tests/compute/transcendental.slang
@@ -1,7 +1,7 @@
-//TEST(compute):COMPARE_COMPUTE:-cuda
-//TEST(compute):COMPARE_COMPUTE:-cpu
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute,vulcan):COMPARE_COMPUTE:-vk
+//TEST(compute):COMPARE_COMPUTE:-cuda -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute,vulcan):COMPARE_COMPUTE:-vk -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer : register(u0);

--- a/tests/compute/transitive-interface.slang
+++ b/tests/compute/transitive-interface.slang
@@ -1,7 +1,7 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 interface IAdd

--- a/tests/compute/type-legalize-global-with-init.slang
+++ b/tests/compute/type-legalize-global-with-init.slang
@@ -4,12 +4,12 @@
 // with a resource type or a type that recursively contains
 // resources.
 //
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 //
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
 
-//TEST_INPUT:ubuffer(data=[1 2 3 4 5 6 7 8], stride=4):
+//TEST_INPUT:ubuffer(data=[1 2 3 4 5 6 7 8], stride=4):name=inputBuffer
 RWStructuredBuffer<uint> inputBuffer;
 
 static const RWStructuredBuffer<uint> gBuffer = inputBuffer;

--- a/tests/compute/typedef-member.slang
+++ b/tests/compute/typedef-member.slang
@@ -1,8 +1,8 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // Confirm that a struct type defined in a generic parent works
 
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 struct SubType<T>

--- a/tests/compute/unbounded-array-of-array-syntax.slang
+++ b/tests/compute/unbounded-array-of-array-syntax.slang
@@ -1,8 +1,8 @@
-//IGNORE_TEST:CPU_REFLECTION: -profile cs_5_0 -entry computeMain -target cpp 
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
+//IGNORE_TEST:CPU_REFLECTION: -profile cs_5_0 -entry computeMain -target cpp
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 //TEST:CROSS_COMPILE:-target dxbc-assembly -entry computeMain -profile cs_5_1
 //TEST:CROSS_COMPILE:-target spirv-assembly -entry computeMain -profile cs_5_1
-//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute 
+//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/compute/unbounded-array-of-array.slang
+++ b/tests/compute/unbounded-array-of-array.slang
@@ -1,5 +1,5 @@
 //DISABLE_TEST:CPU_REFLECTION: -profile cs_5_0 -entry computeMain -target cpp 
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute
 
 struct IntAoa { RWStructuredBuffer<int> array[]; }
 

--- a/tests/compute/user-defined-initializer.slang
+++ b/tests/compute/user-defined-initializer.slang
@@ -3,8 +3,8 @@
 // Confirm that user-defined initializer/constructor
 // methods in a type work as expected.
 
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 struct Pair
 {

--- a/tests/compute/vector-scalar-compare.slang
+++ b/tests/compute/vector-scalar-compare.slang
@@ -1,8 +1,9 @@
-//TEST(compute):COMPARE_COMPUTE:-dx12 -compute 
-//TEST(compute):COMPARE_COMPUTE:-vk -compute 
-//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out
+//TEST(compute):COMPARE_COMPUTE:-dx12 -compute -shaderobj 
+//TEST(compute):COMPARE_COMPUTE:-vk -compute  -shaderobj
 
 // Test doing vector comparisons 
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(4, 4, 1)]

--- a/tests/compute/write-structured-buffer-field.slang
+++ b/tests/compute/write-structured-buffer-field.slang
@@ -1,6 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
-//TEST_INPUT:ubuffer(data=[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32], stride=32):out
 
 struct S
 {
@@ -8,6 +7,7 @@ struct S
 	int4 b;
 };
 
+//TEST_INPUT:ubuffer(data=[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32], stride=32):out,name=outputBuffer
 RWStructuredBuffer<S> outputBuffer;
 
 [numthreads(4, 1, 1)]

--- a/tests/cross-compile/fmod.slang
+++ b/tests/cross-compile/fmod.slang
@@ -3,8 +3,8 @@
 // Ensure that HLSL `fmod` works and produces
 // expected output on Vulkan/GLSL.
 
-//TEST(compute):COMPARE_COMPUTE:-dx11 -compute
-//TEST(compute):COMPARE_COMPUTE:-vk -compute
+//TEST(compute):COMPARE_COMPUTE:-dx11 -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -compute -shaderobj
 
 //TEST_INPUT:cbuffer(data=[4 0 0 0]):name=C
 cbuffer C

--- a/tests/cross-compile/get-dimensions.slang
+++ b/tests/cross-compile/get-dimensions.slang
@@ -1,8 +1,8 @@
 //DISABLE_TEST:REFLECTION: -profile cs_5_0 -entry computeMain -target cpp 
-//TEST(compute):COMPARE_COMPUTE_EX:-vk -compute 
-//TEST(compute):COMPARE_COMPUTE_EX:-d3d12 -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-d3d11 -compute  
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
+//TEST(compute):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-d3d12 -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-d3d11 -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 
 struct Thing
 {

--- a/tests/cross-compile/glsl-bool-ops.slang
+++ b/tests/cross-compile/glsl-bool-ops.slang
@@ -3,8 +3,8 @@
 // This test exists to ensure that binary operations on
 // vectors of `bool` produce correct GLSL/SPIR-V output.
 
-//TEST(compute):COMPARE_COMPUTE:-dx11 -compute
-//TEST(compute):COMPARE_COMPUTE:-vk -compute
+//TEST(compute):COMPARE_COMPUTE:-dx11 -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -compute -shaderobj
 
 uint test(uint val)
 {

--- a/tests/hlsl-intrinsic/active-mask/switch-trivial-fallthrough.slang
+++ b/tests/hlsl-intrinsic/active-mask/switch-trivial-fallthrough.slang
@@ -4,10 +4,10 @@
 // that exhibits "trivial fall-through" from one `case`
 // to another.
 
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -xslang -DHACK
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -xslang -DHACK
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -xslang -DHACK -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -xslang -DHACK -shaderobj
 
 // Note: this test is currently disabled on the CUDA
 // target because we do not synthesize the active

--- a/tests/hlsl-intrinsic/active-mask/switch.slang
+++ b/tests/hlsl-intrinsic/active-mask/switch.slang
@@ -2,10 +2,10 @@
 
 // Test active mask synthesis for a trivial `switch` statement
 
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -xslang -DHACK
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -xslang -DHACK
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -xslang -DHACK -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -xslang -DHACK -shaderobj
 
 // Note: this test is currently disabled on the CUDA
 // target because we do not synthesize the active

--- a/tests/hlsl-intrinsic/bit-cast-double.slang
+++ b/tests/hlsl-intrinsic/bit-cast-double.slang
@@ -1,8 +1,8 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-slang -vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-slang -vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/bit-cast.slang
+++ b/tests/hlsl-intrinsic/bit-cast.slang
@@ -1,8 +1,8 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 

--- a/tests/hlsl-intrinsic/bit-cast/bit-cast-16-bit.slang
+++ b/tests/hlsl-intrinsic/bit-cast/bit-cast-16-bit.slang
@@ -1,7 +1,7 @@
 // bit-cast-16-bit.slang
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile sm_6_2
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile sm_6_2 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], stride=4):name inputBuffer
 RWStructuredBuffer<int> inputBuffer;

--- a/tests/hlsl-intrinsic/byte-address-buffer/byte-address-16bit-vector.slang
+++ b/tests/hlsl-intrinsic/byte-address-buffer/byte-address-16bit-vector.slang
@@ -4,21 +4,21 @@
 // byte-address buffers works as expected, on targets
 // that support it.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu -shaderobj
 
 // Note: disabled on D3D12 because some of the CI services don't have
 // a recent enough build of dxc to support generic load/store.
 //
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_2 -render-features half
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_2 -render-features half -shaderobj
 
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-slang -vk -compute -profile cs_6_2 -render-features half
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -cuda -compute
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-slang -vk -compute -profile cs_6_2 -render-features half -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -cuda -compute -shaderobj
 
 // Unavailable on D3D and fxc-based targets, because fxc doesn't
 // support loading anything besides `uint` from a byte-address
 // buffer.
 //
-//TEST_DISABLED(compute):COMPARE_COMPUTE_EX:-slang -compute
+//TEST_DISABLED(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
 
 
 //TEST_INPUT:ubuffer(data=[0x00010002 0x00030004 0x00050006 0x00070008]):name=inputBuffer

--- a/tests/hlsl-intrinsic/byte-address-buffer/byte-address-16bit.slang
+++ b/tests/hlsl-intrinsic/byte-address-buffer/byte-address-16bit.slang
@@ -4,15 +4,15 @@
 // byte-address buffers works as expected, on targets
 // that support it.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu -shaderobj
 
 // Note: disabled on D3D12 because some of the CI services don't have
 // a recent enough build of dxc to support generic load/store.
 //
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_2 -render-features half
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_2 -render-features half -shaderobj
 
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-slang -vk -compute -profile cs_6_2 -render-features half
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -cuda -compute
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-slang -vk -compute -profile cs_6_2 -render-features half -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -cuda -compute -shaderobj
 
 // Unavailable on D3D and fxc-based targets, because fxc doesn't
 // support loading anything besides `uint` from a byte-address

--- a/tests/hlsl-intrinsic/byte-address-buffer/byte-address-struct.slang
+++ b/tests/hlsl-intrinsic/byte-address-buffer/byte-address-struct.slang
@@ -4,11 +4,11 @@
 // buffer can be translated into per-field loads on
 // all targets that support loads of the field types.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-slang -vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-slang -vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -cuda -compute -shaderobj
 
 // Note: This input should really be just a `ByteAddressBuffer`,
 // so that we can confirm that the functionality works in the

--- a/tests/hlsl-intrinsic/classify-double.slang
+++ b/tests/hlsl-intrinsic/classify-double.slang
@@ -1,8 +1,8 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 // inf, -inf, nan, finite
 //TEST_INPUT:ubuffer(data=[ 0 0x7ff00000 0 0xfff00000 0xffffffff 0x7fffffff 1 0], stride=4):name inputBuffer

--- a/tests/hlsl-intrinsic/classify-float.slang
+++ b/tests/hlsl-intrinsic/classify-float.slang
@@ -1,8 +1,8 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 // inf, -inf, nan, finite
 //TEST_INPUT:ubuffer(data=[ 0x7f800000 0xff800000 0x7fffffff 1 ], stride=4):name inputBuffer

--- a/tests/hlsl-intrinsic/literal-int64.slang
+++ b/tests/hlsl-intrinsic/literal-int64.slang
@@ -1,11 +1,11 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 // No support for int64_t on D3D11 (no sm 6.0)
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
 // No support with Dx12 with dxbc. Needs SM6.0 + dxil
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -profile cs_6_0 -dx12 -use-dxil
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -profile cs_6_0 -dx12 -use-dxil -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 // Note that the behavior we expect here, is a int without suffix is assumed to 
 // be an int literal.

--- a/tests/hlsl-intrinsic/matrix-double-reduced-intrinsic.slang
+++ b/tests/hlsl-intrinsic/matrix-double-reduced-intrinsic.slang
@@ -1,12 +1,12 @@
 // We currently don't support matrix intrinsics on glsl based targets
 // There are problems with double on dx12/dxbc so we disable that
 
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile sm_6_0 -use-dxil -output-using-type
-//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type -shaderobj
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type -shaderobj
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile sm_6_0 -use-dxil -output-using-type -shaderobj
+//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<double> outputBuffer;

--- a/tests/hlsl-intrinsic/matrix-float.slang
+++ b/tests/hlsl-intrinsic/matrix-float.slang
@@ -1,11 +1,11 @@
 // TODO(JS):
 // NOTE we can't test on VK/gl at the moment because we don't support intrinsics over matrices on that target currently
 
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -output-using-type
-//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -output-using-type -shaderobj
+//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/hlsl-intrinsic/matrix-int-runtime-index.slang
+++ b/tests/hlsl-intrinsic/matrix-int-runtime-index.slang
@@ -1,11 +1,11 @@
 // NOTE we can't test on VK/gl because we will output imat3 - and imat3 is not supported by glsl.
 // NOTE we also can't do this test on fxc - as it does not allow runtime non constant indexing.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil
-//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -shaderobj
+//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/matrix-int.slang
+++ b/tests/hlsl-intrinsic/matrix-int.slang
@@ -1,10 +1,10 @@
 // NOTE we can't test on VK/gl at the moment because we don't support intrinsics over matrices on that target currently
 
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil
-//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -shaderobj
+//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/scalar-double-d3d-intrinsic.slang
+++ b/tests/hlsl-intrinsic/scalar-double-d3d-intrinsic.slang
@@ -1,11 +1,11 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type -shaderobj
 // On dx11 this causes a crash on CI (not currently not repeatable on test systems)
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type -shaderobj
 // This is disabled because Dx12/DXBC doing double writes to a structured buffer can fail
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile sm_6_0 -use-dxil -output-using-type
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile sm_6_0 -use-dxil -output-using-type -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<double> outputBuffer;

--- a/tests/hlsl-intrinsic/scalar-double-simple.slang
+++ b/tests/hlsl-intrinsic/scalar-double-simple.slang
@@ -1,12 +1,12 @@
 // Here we are going to do a very simple calculation with double. 
 // For simplicity we are not going to use any intrinsics, and not use any resources that use double
 
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile sm_6_0 -use-dxil
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile sm_6_0 -use-dxil -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<uint> outputBuffer;

--- a/tests/hlsl-intrinsic/scalar-double-vk-intrinsic.slang
+++ b/tests/hlsl-intrinsic/scalar-double-vk-intrinsic.slang
@@ -1,10 +1,10 @@
 // This test is to see what intrinsics are available on VK
 
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type -shaderobj
 
 // We don't want to run a cuda test here...
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<double> outputBuffer;

--- a/tests/hlsl-intrinsic/scalar-float.slang
+++ b/tests/hlsl-intrinsic/scalar-float.slang
@@ -1,8 +1,8 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/scalar-int.slang
+++ b/tests/hlsl-intrinsic/scalar-int.slang
@@ -1,8 +1,8 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/scalar-int64.slang
+++ b/tests/hlsl-intrinsic/scalar-int64.slang
@@ -1,11 +1,11 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 // No support for int64_t on D3D11 (no sm 6.0)
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
 // No support with Dx12 with dxbc. Needs SM6.0 + dxil
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -profile cs_6_0 -dx12 -use-dxil
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -profile cs_6_0 -dx12 -use-dxil -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/scalar-uint.slang
+++ b/tests/hlsl-intrinsic/scalar-uint.slang
@@ -1,8 +1,8 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/scalar-uint64.slang
+++ b/tests/hlsl-intrinsic/scalar-uint64.slang
@@ -1,12 +1,12 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 // No support for uint64_t on DX11
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
 // No support for uint64_t on fxc - we need SM6.0 and dxil
 // https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/hlsl-shader-model-6-0-features-for-direct3d-12
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_0 -use-dxil 
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_0 -use-dxil -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/vector-double-reduced-intrinsic.slang
+++ b/tests/hlsl-intrinsic/vector-double-reduced-intrinsic.slang
@@ -1,10 +1,10 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type -shaderobj
 // TODO(JS):
 // On CI systems DX11 test failed, so disable for now
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -output-using-type
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -output-using-type -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<double4> outputBuffer;

--- a/tests/hlsl-intrinsic/vector-float.slang
+++ b/tests/hlsl-intrinsic/vector-float.slang
@@ -1,8 +1,8 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -output-using-type
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -output-using-type -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<float4> outputBuffer;

--- a/tests/hlsl-intrinsic/vector-int-runtime-index.slang
+++ b/tests/hlsl-intrinsic/vector-int-runtime-index.slang
@@ -1,8 +1,8 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/vector-int.slang
+++ b/tests/hlsl-intrinsic/vector-int.slang
@@ -1,8 +1,8 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-active-count-bits.slang
+++ b/tests/hlsl-intrinsic/wave-active-count-bits.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-active-product.slang
+++ b/tests/hlsl-intrinsic/wave-active-product.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-broadcast-lane-at-vk.slang
+++ b/tests/hlsl-intrinsic/wave-broadcast-lane-at-vk.slang
@@ -1,6 +1,6 @@
 //TEST_CATEGORY(wave, compute)
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-broadcast-lane-at.slang
+++ b/tests/hlsl-intrinsic/wave-broadcast-lane-at.slang
@@ -1,10 +1,10 @@
 //TEST_CATEGORY(wave, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
 // Disabled on VK because glsl can't do WaveReadLaneAt on matrix. 
-//DISABLE_TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0
+//DISABLE_TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-diverge.slang
+++ b/tests/hlsl-intrinsic/wave-diverge.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-equality.slang
+++ b/tests/hlsl-intrinsic/wave-equality.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-get-lane-index.slang
+++ b/tests/hlsl-intrinsic/wave-get-lane-index.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-is-first-lane.slang
+++ b/tests/hlsl-intrinsic/wave-is-first-lane.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave-active-product.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave-active-product.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave-mask, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave-broadcast-lane-at-vk.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave-broadcast-lane-at-vk.slang
@@ -1,6 +1,6 @@
 //TEST_CATEGORY(wave-mask, compute)
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave-broadcast-lane-at.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave-broadcast-lane-at.slang
@@ -1,10 +1,10 @@
 //TEST_CATEGORY(wave-mask, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
 // Disabled on VK because glsl can't do WaveReadLaneAt on matrix. 
-//DISABLE_TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave-diverge.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave-diverge.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave-mask, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave-equality.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave-equality.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave-mask, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave-get-active.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave-get-active.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave-mask, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave-get-converged.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave-get-converged.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave-mask, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave-is-first-lane.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave-is-first-lane.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave-mask, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave-matrix.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave-matrix.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave-mask, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//DISABLE_TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//DISABLE_TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave-prefix-product.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave-prefix-product.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave-mask, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave-prefix-sum.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave-prefix-sum.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave-mask, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave-read-lane-at-vk.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave-read-lane-at-vk.slang
@@ -2,8 +2,8 @@
 // We have this 'simple' test, because we can't do matrix (or imat) operations on GLSL/Vk target
 
 //TEST_CATEGORY(wave-mask, compute)
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave-read-lane-at.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave-read-lane-at.slang
@@ -1,10 +1,10 @@
 //TEST_CATEGORY(wave-mask, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
 // Disabled on VK because glsl can't do WaveReadLaneAt on matrix. 
-//DISABLE_TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave-shuffle-vk.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave-shuffle-vk.slang
@@ -1,10 +1,10 @@
 //TEST_CATEGORY(wave-mask, compute)
 // Disabled because main tests is wave-shuffle.slang, this just tests VK 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave-shuffle.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave-shuffle.slang
@@ -1,11 +1,11 @@
 //TEST_CATEGORY(wave-mask, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
 //Disabled on D3D, because in general WaveShuffle requires hardware that doesn't have the 'uniform laneId across Wave' restriction. 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
 // Disabled because vk doesn't currently support matrix types. See wave-shuffle-vk.slang
-//DISABLE_TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave-vector.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave-vector.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave-mask, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-mask/wave.slang
+++ b/tests/hlsl-intrinsic/wave-mask/wave.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave-mask, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0  0 0 0 0  0 0 0 0  0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-matrix.slang
+++ b/tests/hlsl-intrinsic/wave-matrix.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//DISABLE_TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//DISABLE_TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-multi-prefix.slang
+++ b/tests/hlsl-intrinsic/wave-multi-prefix.slang
@@ -1,12 +1,12 @@
 //TEST_CATEGORY(wave, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
 // We need SM6.5 for these tests
 // Disable because version of dxc we are currently using doesn't support SM6.5
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile sm_6_5
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile sm_6_5 -shaderobj
 // Disabled because we don't have GLSL intrinsics for these it seems 
-//DISABLE_TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0
+//DISABLE_TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-prefix-count-bits.slang
+++ b/tests/hlsl-intrinsic/wave-prefix-count-bits.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-prefix-product.slang
+++ b/tests/hlsl-intrinsic/wave-prefix-product.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-prefix-sum.slang
+++ b/tests/hlsl-intrinsic/wave-prefix-sum.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-read-lane-at-vk.slang
+++ b/tests/hlsl-intrinsic/wave-read-lane-at-vk.slang
@@ -1,8 +1,8 @@
 // This is similar to wave-lane-at.slang but tests more limited supported types for vk.
 // We have this 'simple' test, because we can't do matrix (or imat) operations on GLSL/Vk target
 //TEST_CATEGORY(wave, compute)
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-read-lane-at.slang
+++ b/tests/hlsl-intrinsic/wave-read-lane-at.slang
@@ -1,10 +1,10 @@
 //TEST_CATEGORY(wave, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
 // Disabled on VK because glsl can't do WaveReadLaneAt on matrix. 
-//DISABLE_TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0
+//DISABLE_TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-shuffle-vk.slang
+++ b/tests/hlsl-intrinsic/wave-shuffle-vk.slang
@@ -1,10 +1,10 @@
 //TEST_CATEGORY(wave, compute)
 // Disabled because main tests is wave-shuffle.slang, this just tests VK 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave-vector.slang
+++ b/tests/hlsl-intrinsic/wave-vector.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/wave.slang
+++ b/tests/hlsl-intrinsic/wave.slang
@@ -1,9 +1,9 @@
 //TEST_CATEGORY(wave, compute)
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute 
-//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0
-//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-cuda -compute -render-features cuda_sm_7_0 -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/ir/string-literal-hash.slang
+++ b/tests/ir/string-literal-hash.slang
@@ -1,5 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE: -vk
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE: -vk -shaderobj
 
 // Note: disabled on CPU target until we can fill
 // in a more correct/complete `String` and `getStringHash`

--- a/tests/language-feature/constants/static-const-in-struct.slang
+++ b/tests/language-feature/constants/static-const-in-struct.slang
@@ -1,6 +1,6 @@
 // static-const-in-struct.slang
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // Test that `static const` variable declarations inside of
 // a `struct` type correctly translate to constants in

--- a/tests/language-feature/enums/enum-equality.slang
+++ b/tests/language-feature/enums/enum-equality.slang
@@ -3,7 +3,7 @@
 // Test that equality (and inequality) of `enum`
 // types works as expected.
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 enum Channel
 {

--- a/tests/language-feature/enums/explicit-tag-type.slang
+++ b/tests/language-feature/enums/explicit-tag-type.slang
@@ -2,7 +2,7 @@
 
 // Test that the underlying "tag type" of an `enum` can be set.
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 enum Channel : uint
 {

--- a/tests/language-feature/enums/nested-enum.slang
+++ b/tests/language-feature/enums/nested-enum.slang
@@ -2,7 +2,7 @@
 
 // Test enums defined nested in a struct work as expected. 
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 struct Outer
 {

--- a/tests/language-feature/extensions/interface-extension.slang
+++ b/tests/language-feature/extensions/interface-extension.slang
@@ -2,7 +2,7 @@
 
 // Test that an `extension` applied to an interface type works as users expect
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 interface ICounter
 {

--- a/tests/language-feature/generics/struct-generic-value-param.slang
+++ b/tests/language-feature/generics/struct-generic-value-param.slang
@@ -16,7 +16,7 @@
 // it can reproduce a bug that was encountered by a user
 // when trying out the feature.
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 import struct_generic_value_param_import;
 

--- a/tests/language-feature/inheritance/struct-inherit-interface-requirement.slang
+++ b/tests/language-feature/inheritance/struct-inherit-interface-requirement.slang
@@ -1,6 +1,6 @@
 // struct-inherit-interface-requirement.slang
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // Test that a `struct` type can use an inherited
 // member to satisfy an interface requirement.

--- a/tests/language-feature/inheritance/struct-inheritance.slang
+++ b/tests/language-feature/inheritance/struct-inheritance.slang
@@ -1,6 +1,6 @@
 // struct-inheritance.slang
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // Test that we can define a `struct` type
 // that inherits from another `struct`.

--- a/tests/language-feature/namespaces/simple-namespace.slang
+++ b/tests/language-feature/namespaces/simple-namespace.slang
@@ -1,6 +1,6 @@
 // simple-namespace.slang
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // Test that simple `namespace` declarations work as expected
 

--- a/tests/language-feature/namespaces/using-namespace.slang
+++ b/tests/language-feature/namespaces/using-namespace.slang
@@ -2,7 +2,7 @@
 
 // Test that `using` can bring declarations from a namespace into scope
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 namespace X
 {

--- a/tests/language-feature/properties/property-decl.slang
+++ b/tests/language-feature/properties/property-decl.slang
@@ -1,6 +1,6 @@
 // property-decl.slang
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // Test that users can declare properties and access them
 // with ordinary dot syntax.

--- a/tests/language-feature/properties/property-in-interface.slang
+++ b/tests/language-feature/properties/property-in-interface.slang
@@ -1,6 +1,6 @@
 // property-in-interface.slang
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // Test that interfaces can include property declarations.
 

--- a/tests/language-feature/shader-params/entry-point-uniform-params.slang
+++ b/tests/language-feature/shader-params/entry-point-uniform-params.slang
@@ -1,8 +1,8 @@
 // entry-point-uniform-params.slang
 
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE:-cuda
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cuda -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 
 // Test that a shader can be written that
 // only uses entry point `uniform` parameters,

--- a/tests/language-feature/swizzles/matrix-swizzles.slang
+++ b/tests/language-feature/swizzles/matrix-swizzles.slang
@@ -1,6 +1,6 @@
 // matrix-swizzle.slang
 
-//TEST(compute):COMPARE_COMPUTE:
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // Test that matrix swizzle works correctly
 // Matrix swizzles can either be one or zero indexed

--- a/tests/optimization/func-resource-result/func-resource-result-simple.slang
+++ b/tests/optimization/func-resource-result/func-resource-result-simple.slang
@@ -1,8 +1,8 @@
 // func-resource-result-simple.slang
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 
 // Test that a function that returns a resource type can be
 // compiled for targets that don't natively support resource

--- a/tests/pipeline/compute/compute-system-values.slang
+++ b/tests/pipeline/compute/compute-system-values.slang
@@ -1,7 +1,7 @@
 // compute-system-values.slang
 
-//TEST(compute):COMPARE_COMPUTE:
-//TEST(compute):COMPARE_COMPUTE: -cpu
+//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE: -cpu -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/serialization/extern/extern-test.slang
+++ b/tests/serialization/extern/extern-test.slang
@@ -2,7 +2,7 @@
 
 //TEST:COMPILE: -module-name module -no-codegen tests/serialization/extern/module-a.slang -o tests/serialization/extern/module-a.slang-lib
 //TEST:COMPILE: -module-name module -no-codegen tests/serialization/extern/module-b.slang -o tests/serialization/extern/module-b.slang-lib
-//TEST:COMPARE_COMPUTE_EX: -xslang -module-name -xslang module -slang -compute -xslang -r -xslang tests/serialization/extern/module-a.slang-lib -xslang -r -xslang tests/serialization/extern/module-b.slang-lib 
+//TEST:COMPARE_COMPUTE_EX: -xslang -module-name -xslang module -slang -compute -xslang -r -xslang tests/serialization/extern/module-a.slang-lib -xslang -r -xslang tests/serialization/extern/module-b.slang-lib -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 ], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/serialization/serialized-module-test.slang
+++ b/tests/serialization/serialized-module-test.slang
@@ -4,7 +4,7 @@
 // serialization.
 
 //TEST:COMPILE: tests/serialization/serialized-module.slang -o tests/serialization/serialized-module.slang-module
-//TEST:COMPARE_COMPUTE_EX:-slang -compute -xslang -r -xslang tests/serialization/serialized-module.slang-module
+//TEST:COMPARE_COMPUTE_EX:-slang -compute -xslang -r -xslang tests/serialization/serialized-module.slang-module -shaderobj
 
 //import serialized_module;
 

--- a/tests/serialization/std-lib-serialize.slang
+++ b/tests/serialization/std-lib-serialize.slang
@@ -1,5 +1,5 @@
 //TEST:COMPILE: -save-stdlib slang-std-lib.zip
-//TEST:COMPARE_COMPUTE: -compile-arg -load-stdlib -compile-arg slang-std-lib.zip
+//TEST:COMPARE_COMPUTE: -compile-arg -load-stdlib -compile-arg slang-std-lib.zip -shaderobj
 
 struct A
 {

--- a/tests/slang-extension/atomic-float-byte-address-buffer.slang
+++ b/tests/slang-extension/atomic-float-byte-address-buffer.slang
@@ -1,11 +1,11 @@
 // atomic-float-byte-address-buffer.slang
 
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-dx11 -slang -compute -render-features atomic-float -output-using-type -nvapi-slot u0
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -render-features atomic-float -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-d3d12 -compute -render-features atomic-float -output-using-type -compile-arg -O2 -nvapi-slot u0
-//TEST(compute):COMPARE_COMPUTE_EX:-d3d12 -compute -use-dxil -render-features atomic-float -output-using-type -compile-arg -O2 -nvapi-slot u0
-//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type 
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-dx11 -slang -compute -render-features atomic-float -output-using-type -nvapi-slot u0 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -render-features atomic-float -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-d3d12 -compute -render-features atomic-float -output-using-type -compile-arg -O2 -nvapi-slot u0 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-d3d12 -compute -use-dxil -render-features atomic-float -output-using-type -compile-arg -O2 -nvapi-slot u0 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type -shaderobj
 
 // The test doesn't directly use this, but having this defined makes the 0 slot available if NVAPI is going to be used
 // Only strictly necessary on the D3D11/D3D12 paths
@@ -15,7 +15,7 @@ RWStructuredBuffer<int> nvapiBuffer;
 //TEST_INPUT:ubuffer(data=[1.0 2.0 3.0 4.0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-//TEST_INPUT:ubuffer(data=[1.0 2.0 3.0 4.0], stride=4):name=workBuffer
+//TEST_INPUT:ubuffer(data=[1.0 2.0 3.0 4.0]):name=workBuffer
 RWByteAddressBuffer workBuffer;
 
 //TEST_INPUT:ubuffer(data=[0.7 0.5 0.2 0.6], stride=4):name=anotherBuffer

--- a/tests/slang-extension/atomic-int64-byte-address-buffer.slang
+++ b/tests/slang-extension/atomic-int64-byte-address-buffer.slang
@@ -1,13 +1,13 @@
 // No atomic support on CPU
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 // No support for int64_t on DX11
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
 // No support for int64_t on fxc - we need SM6.0 and dxil
 // https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/hlsl-shader-model-6-0-features-for-direct3d-12
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -nvapi-slot u0
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_0 -use-dxil -render-features atomic-int64 -nvapi-slot u0 -compile-arg -O2
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -render-features atomic-int64
-//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -nvapi-slot u0 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_0 -use-dxil -render-features atomic-int64 -nvapi-slot u0 -compile-arg -O2 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -render-features atomic-int64 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 // The test doesn't directly use this, but having this defined makes the 0 slot available if NVAPI is going to be used
 // Only strictly necessary on the D3D12 path

--- a/tests/slang-extension/atomic-min-max-u64-byte-address-buffer.slang
+++ b/tests/slang-extension/atomic-min-max-u64-byte-address-buffer.slang
@@ -1,15 +1,15 @@
 // No atomic support on CPU
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 // No support for int64_t on DX11
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
 // No support for int64_t on fxc - we need SM6.0 and dxil
 // https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/hlsl-shader-model-6-0-features-for-direct3d-12
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -nvapi-slot u0
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_0 -use-dxil -render-features atomic-int64 -nvapi-slot u0 -compile-arg -O2
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -render-features atomic-int64
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -nvapi-slot u0 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_0 -use-dxil -render-features atomic-int64 -nvapi-slot u0 -compile-arg -O2 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -render-features atomic-int64 -shaderobj
 // For some reason this doesn't work correctly on CUDA? That it behaves as if always does Min. Min and Max do appropriate 
 // things tho, because if I force the condition I do get the right answer
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 // The test doesn't directly use this, but having this defined makes the 0 slot available if NVAPI is going to be used
 // Only strictly necessary on the D3D12 path

--- a/tests/slang-extension/cas-int64-byte-address-buffer.slang
+++ b/tests/slang-extension/cas-int64-byte-address-buffer.slang
@@ -1,13 +1,13 @@
 // No atomic support on CPU
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 // No support for int64_t on DX11
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
 // No support for int64_t on fxc - we need SM6.0 and dxil
 // https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/hlsl-shader-model-6-0-features-for-direct3d-12
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -nvapi-slot u0
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_0 -use-dxil -render-features atomic-int64 -nvapi-slot u0 -compile-arg -O2
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -render-features atomic-int64
-//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -nvapi-slot u0 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_0 -use-dxil -render-features atomic-int64 -nvapi-slot u0 -compile-arg -O2 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -render-features atomic-int64 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 // The test doesn't directly use this, but having this defined makes the 0 slot available if NVAPI is going to be used
 // Only strictly necessary on the D3D12 path

--- a/tests/slang-extension/exchange-int64-byte-address-buffer.slang
+++ b/tests/slang-extension/exchange-int64-byte-address-buffer.slang
@@ -1,13 +1,13 @@
 // No atomic support on CPU
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute 
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 // No support for int64_t on DX11
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
 // No support for int64_t on fxc - we need SM6.0 and dxil
 // https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/hlsl-shader-model-6-0-features-for-direct3d-12
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -nvapi-slot u0
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_0 -use-dxil -render-features atomic-int64 -nvapi-slot u0 -compile-arg -O2
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -render-features atomic-int64
-//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -nvapi-slot u0 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_0 -use-dxil -render-features atomic-int64 -nvapi-slot u0 -compile-arg -O2 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -render-features atomic-int64 -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
 
 // The test doesn't directly use this, but having this defined makes the 0 slot available if NVAPI is going to be used
 // Only strictly necessary on the D3D12 path

--- a/tools/gfx/render-graphics-common.cpp
+++ b/tools/gfx/render-graphics-common.cpp
@@ -592,6 +592,10 @@ public:
             {
                 info.rangeOffset = m_descriptorSetBuildInfos[0]->slotRangeDescs.getCount();
             }
+            else
+            {
+                info.rangeOffset = 0;
+            }
 
             auto slangEntryPointLayout = entryPointLayout->getSlangLayout();
             _addDescriptorSets(
@@ -647,7 +651,20 @@ protected:
         }
 
         IPipelineLayout::Desc pipelineLayoutDesc;
-        pipelineLayoutDesc.renderTargetCount = m_renderTargetCount;
+
+        // HACK: we set `renderTargetCount` to zero here becasue otherwise the D3D12
+        // render back-end will adjust all UAV registers by this value to account
+        // for the `SV_Target<N>` outputs implicitly consuming `u<N>` registers for
+        // Shader Model 5.0.
+        //
+        // When using the shader object path, all registers are being set via Slang
+        // reflection information, and we do not need/want the automatic adjustment.
+        //
+        // TODO: Once we eliminate the non-shader-object path, this whole issue should
+        // be moot, because the `ProgramLayout` should own/be the pipeline layout anyway.
+        //
+        pipelineLayoutDesc.renderTargetCount = 0;
+
         pipelineLayoutDesc.descriptorSetCount = pipelineDescriptorSets.getCount();
         pipelineLayoutDesc.descriptorSets = pipelineDescriptorSets.getBuffer();
 


### PR DESCRIPTION
This change converts a large number of our existing tests to use the `ShaderObject` support that was added to the `gfx` layer.

In many cases, tests were just updated to pass `-shaderobj` and the result Just Worked.
In other cases, a `name` attribute had to be added to one or more `TEST_INPUT` lines.

For tests that did not work with shader objects "out of the box," I spent a little bit of time trying to get them work, but fell back to letting those tests run in the older mode.
Future changes to the infrastructure will be needed to get those additional tests working in the new path.

Along with the changes to test files, the following implementation changes were made to get additional tests working:

* Because the shader object mode uses explicit register bindings (from reflection), the hacky logic that was offseting `u` registers for D3D12 based on the number of render targets gets disabled (by another hack).

* The "flat" reflection information coming from Slang was not correctly reporting "binding ranges" for things that consumed only uniform data (which would be everything on CUDA/CPU), so it was refactored to properly include binding ranges for anything where the type of the field/variable implied a binding range should be created (even if the `LayoutResourceKind` was `::Uniform`).

* A few fixes were made to the CUDA implementation of `Renderer`, in order to get additional tests up and running. Most of these changes had to do with texture bindings, which hadn't really been tested previously.

In addition, a few changes were made that were attempts at getting more tests working, but didn't actually help. These could be dropped if requested:

* As a quality-of-life feature (not being used) the `object` style of `TEST_INPUT` line is upgraded to support inferring the type to use from the type of the input being set.

* Any `object` shader input lines get ignored in non-shader-object mode.