### PR TITLE
Make  `ShaderCursor` no longer depend on core.

### DIFF
--- a/tools/gfx-util/shader-cursor.cpp
+++ b/tools/gfx-util/shader-cursor.cpp
@@ -20,7 +20,7 @@ Result gfx::ShaderCursor::getDereferenced(ShaderCursor& outCursor) const
     }
 }
 
-Result ShaderCursor::getField(const char* name, ShaderCursor& outCursor)
+Result ShaderCursor::getField(const char* name, const char* nameEnd, ShaderCursor& outCursor)
 {
     // If this cursor is invalid, then can't possible fetch a field.
     //
@@ -40,7 +40,7 @@ Result ShaderCursor::getField(const char* name, ShaderCursor& outCursor)
             //
             // If there is no such field, we have an error.
             //
-            SlangInt fieldIndex = m_typeLayout->findFieldIndexByName(name, nullptr);
+            SlangInt fieldIndex = m_typeLayout->findFieldIndexByName(name, nameEnd);
             if (fieldIndex == -1)
                 return SLANG_E_INVALID_ARG;
 
@@ -110,7 +110,7 @@ Result ShaderCursor::getField(const char* name, ShaderCursor& outCursor)
             // to the *contents* of the constant buffer.
             //
             ShaderCursor d = getDereferenced();
-            return d.getField(name, outCursor);
+            return d.getField(name, nameEnd, outCursor);
         }
         break;
     }
@@ -232,7 +232,8 @@ Result ShaderCursor::followPath(const char* path, ShaderCursor& ioCursor)
                 }
                 break;
             }
-            cursor.getField(nameBegin, cursor);
+            char const* nameEnd = rest;
+            cursor.getField(nameBegin, nameEnd, cursor);
             state = ALLOW_DOT | ALLOW_SUBSCRIPT;
             continue;
         }

--- a/tools/gfx-util/shader-cursor.cpp
+++ b/tools/gfx-util/shader-cursor.cpp
@@ -233,7 +233,9 @@ Result ShaderCursor::followPath(const char* path, ShaderCursor& ioCursor)
                 break;
             }
             char const* nameEnd = rest;
-            cursor.getField(nameBegin, nameEnd, cursor);
+            ShaderCursor newCursor;
+            cursor.getField(nameBegin, nameEnd, newCursor);
+            cursor = newCursor;
             state = ALLOW_DOT | ALLOW_SUBSCRIPT;
             continue;
         }

--- a/tools/gfx-util/shader-cursor.cpp
+++ b/tools/gfx-util/shader-cursor.cpp
@@ -20,7 +20,7 @@ Result gfx::ShaderCursor::getDereferenced(ShaderCursor& outCursor) const
     }
 }
 
-Result ShaderCursor::getField(Slang::UnownedStringSlice const& name, ShaderCursor& outCursor)
+Result ShaderCursor::getField(const char* name, ShaderCursor& outCursor)
 {
     // If this cursor is invalid, then can't possible fetch a field.
     //
@@ -40,7 +40,7 @@ Result ShaderCursor::getField(Slang::UnownedStringSlice const& name, ShaderCurso
             //
             // If there is no such field, we have an error.
             //
-            SlangInt fieldIndex = m_typeLayout->findFieldIndexByName(name.begin(), name.end());
+            SlangInt fieldIndex = m_typeLayout->findFieldIndexByName(name, nullptr);
             if (fieldIndex == -1)
                 return SLANG_E_INVALID_ARG;
 
@@ -118,7 +118,7 @@ Result ShaderCursor::getField(Slang::UnownedStringSlice const& name, ShaderCurso
     return SLANG_E_INVALID_ARG;
 }
 
-ShaderCursor ShaderCursor::getElement(Slang::Index index)
+ShaderCursor ShaderCursor::getElement(SlangInt index)
 {
     // TODO: need to auto-dereference various buffer types...
 
@@ -140,27 +140,25 @@ ShaderCursor ShaderCursor::getElement(Slang::Index index)
 }
 
 
-static int _peek(Slang::UnownedStringSlice const& slice)
+static int _peek(const char* slice)
 {
-    const char* b = slice.begin();
-    const char* e = slice.end();
-    if (b == e)
+    const char* b = slice;
+    if (!b || !*b)
         return -1;
     return *b;
 }
 
-static int _get(Slang::UnownedStringSlice& slice)
+static int _get(const char*& slice)
 {
-    const char* b = slice.begin();
-    const char* e = slice.end();
-    if (b == e)
+    const char* b = slice;
+    if (!b || !*b)
         return -1;
     auto result = *b++;
-    slice = Slang::UnownedStringSlice(b, e);
+    slice = b;
     return result;
 }
 
-Result ShaderCursor::followPath(Slang::UnownedStringSlice const& path, ShaderCursor& ioCursor)
+Result ShaderCursor::followPath(const char* path, ShaderCursor& ioCursor)
 {
     ShaderCursor cursor = ioCursor;
 
@@ -172,7 +170,7 @@ Result ShaderCursor::followPath(Slang::UnownedStringSlice const& path, ShaderCur
     };
     int state = ALLOW_NAME | ALLOW_SUBSCRIPT;
 
-    Slang::UnownedStringSlice rest = path;
+    const char* rest = path;
     for (;;)
     {
         int c = _peek(rest);
@@ -194,7 +192,7 @@ Result ShaderCursor::followPath(Slang::UnownedStringSlice const& path, ShaderCur
                 return SLANG_E_INVALID_ARG;
 
             _get(rest);
-            Slang::Index index = 0;
+            SlangInt index = 0;
             while (_peek(rest) != ']')
             {
                 int d = _get(rest);
@@ -218,7 +216,7 @@ Result ShaderCursor::followPath(Slang::UnownedStringSlice const& path, ShaderCur
         }
         else
         {
-            const char* nameBegin = rest.begin();
+            const char* nameBegin = rest;
             for (;;)
             {
                 switch (_peek(rest))
@@ -234,9 +232,7 @@ Result ShaderCursor::followPath(Slang::UnownedStringSlice const& path, ShaderCur
                 }
                 break;
             }
-            char const* nameEnd = rest.begin();
-            Slang::UnownedStringSlice name(nameBegin, nameEnd);
-            cursor = cursor.getField(name);
+            cursor.getField(nameBegin, cursor);
             state = ALLOW_DOT | ALLOW_SUBSCRIPT;
             continue;
         }

--- a/tools/gfx-util/shader-cursor.h
+++ b/tools/gfx-util/shader-cursor.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "tools/gfx/render.h"
-#include "core/slang-basic.h"
 
 namespace gfx
 {
@@ -54,34 +53,20 @@ struct ShaderCursor
     /// points at.
     ///
     /// If the operation succeeds, then the field cursor is written to `outCursor`.
-    Result getField(Slang::UnownedStringSlice const& name, ShaderCursor& outCursor);
+    Result getField(const char* name, ShaderCursor& outCursor);
 
-    ShaderCursor getField(Slang::UnownedStringSlice const& name)
+    ShaderCursor getField(const char* name)
     {
         ShaderCursor cursor;
         getField(name, cursor);
         return cursor;
     }
 
-    ShaderCursor getField(Slang::String const& name) { return getField(name.getUnownedSlice()); }
+    ShaderCursor getElement(SlangInt index);
 
-    ShaderCursor getElement(Slang::Index index);
+    static Result followPath(const char* path, ShaderCursor& ioCursor);
 
-    static Result followPath(Slang::UnownedStringSlice const& path, ShaderCursor& ioCursor);
-
-    static Result followPath(Slang::String const& path, ShaderCursor& ioCursor)
-    {
-        return followPath(path.getUnownedSlice(), ioCursor);
-    }
-
-    ShaderCursor getPath(Slang::UnownedStringSlice const& path)
-    {
-        ShaderCursor result(*this);
-        followPath(path, result);
-        return result;
-    }
-
-    ShaderCursor getPath(Slang::String const& path)
+    ShaderCursor getPath(const char* path)
     {
         ShaderCursor result(*this);
         followPath(path, result);

--- a/tools/gfx-util/shader-cursor.h
+++ b/tools/gfx-util/shader-cursor.h
@@ -53,12 +53,12 @@ struct ShaderCursor
     /// points at.
     ///
     /// If the operation succeeds, then the field cursor is written to `outCursor`.
-    Result getField(const char* name, ShaderCursor& outCursor);
+    Result getField(const char* nameBegin, const char* nameEnd, ShaderCursor& outCursor);
 
     ShaderCursor getField(const char* name)
     {
         ShaderCursor cursor;
-        getField(name, cursor);
+        getField(name, nullptr, cursor);
         return cursor;
     }
 

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -1723,8 +1723,8 @@ Result VKRenderer::createTextureResource(IResource::Usage initialUsage, const IT
         {
             const TextureResource::Size mipSize = desc.size.calcMipSize(j);
 
-            const int rowSizeInBytes = calcRowSize(desc.format, mipSize.width);
-            const int numRows = calcNumRows(desc.format, mipSize.height);
+            auto rowSizeInBytes = calcRowSize(desc.format, mipSize.width);
+            auto numRows = calcNumRows(desc.format, mipSize.height);
 
             mipSizes.add(mipSize);
 
@@ -1754,8 +1754,8 @@ Result VKRenderer::createTextureResource(IResource::Usage initialUsage, const IT
                     const auto& mipSize = mipSizes[j];
 
                     const ptrdiff_t srcRowStride = initData->mipRowStrides[j];
-                    const int dstRowSizeInBytes = calcRowSize(desc.format, mipSize.width);
-                    const int numRows = calcNumRows(desc.format, mipSize.height);
+                    auto dstRowSizeInBytes = calcRowSize(desc.format, mipSize.width);
+                    auto numRows = calcNumRows(desc.format, mipSize.height);
 
                     for (int k = 0; k < mipSize.depth; k++)
                     {
@@ -1787,8 +1787,8 @@ Result VKRenderer::createTextureResource(IResource::Usage initialUsage, const IT
                 {
                     const auto& mipSize = mipSizes[j];
 
-                    const int rowSizeInBytes = calcRowSize(desc.format, mipSize.width);
-                    const int numRows = calcNumRows(desc.format, mipSize.height);
+                    auto rowSizeInBytes = calcRowSize(desc.format, mipSize.width);
+                    auto numRows = calcNumRows(desc.format, mipSize.height);
 
                     // https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferImageCopy.html
                     // bufferRowLength and bufferImageHeight specify the data in buffer memory as a subregion of a larger two- or three-dimensional image,

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -190,13 +190,13 @@ SlangResult _assignVarsFromLayout(
             return SLANG_E_INVALID_ARG;
         }
 
-        auto entryCursor = rootCursor.getPath(entry.name);
+        auto entryCursor = rootCursor.getPath(entry.name.getBuffer());
 
         if(!entryCursor.isValid())
         {
             for(gfx::UInt i = 0; i < shaderObject->getEntryPointCount(); i++)
             {
-                entryCursor = ShaderCursor(shaderObject->getEntryPoint(i)).getPath(entry.name);
+                entryCursor = ShaderCursor(shaderObject->getEntryPoint(i)).getPath(entry.name.getBuffer());
                 if(entryCursor.isValid())
                     break;
             }
@@ -839,10 +839,10 @@ Result RenderTestApp::writeScreen(const char* filename)
     size_t width = rowPitch / pixelSize;
     size_t height = bufferSize / rowPitch;
     surface.setUnowned(
-        width,
-        height,
+        (int)width,
+        (int)height,
         gfx::Format::RGBA_Unorm_UInt8,
-        rowPitch,
+        (int)rowPitch,
         buffer.getBuffer());
     return PngSerializeUtil::write(filename, surface);
 }
@@ -1286,7 +1286,7 @@ static SlangResult _innerMain(Slang::StdWriters* stdWriters, SlangSession* sessi
         for (auto & name : options.renderFeatures)
             requiredFeatureList.add(name.getBuffer());
         desc.requiredFeatures = requiredFeatureList.getBuffer();
-        desc.requiredFeatureCount = requiredFeatureList.getCount();
+        desc.requiredFeatureCount = (int)requiredFeatureList.getCount();
         desc.nvapiExtnSlot = int(nvapiExtnSlot);
 
         window = renderer_test::Window::create();


### PR DESCRIPTION
This change removes the `ShaderCursor`'s dependency on `core`, so that it may be used by users who do not wish to use`core`.