### PR TITLE
Upgrade slang-binaries for glslang 11.1.0

### DIFF
--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -110,6 +110,9 @@
       <ImportLibrary>..\..\..\bin\windows-x86\debug\slang.lib</ImportLibrary>
       <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
+    <PostBuildEvent>
+      <Command>IF EXIST ..\..\..\external\slang-binaries\bin\windows-x86\slang-glslang.dll\ (xcopy /Q /E /Y /I ..\..\..\external\slang-binaries\bin\windows-x86\slang-glslang.dll ..\..\..\bin\windows-x86\debug &gt; nul) ELSE (xcopy /Q /Y /I ..\..\..\external\slang-binaries\bin\windows-x86\slang-glslang.dll ..\..\..\bin\windows-x86\debug &gt; nul)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -128,6 +131,9 @@
       <ImportLibrary>..\..\..\bin\windows-x64\debug\slang.lib</ImportLibrary>
       <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
+    <PostBuildEvent>
+      <Command>IF EXIST ..\..\..\external\slang-binaries\bin\windows-x64\slang-glslang.dll\ (xcopy /Q /E /Y /I ..\..\..\external\slang-binaries\bin\windows-x64\slang-glslang.dll ..\..\..\bin\windows-x64\debug &gt; nul) ELSE (xcopy /Q /Y /I ..\..\..\external\slang-binaries\bin\windows-x64\slang-glslang.dll ..\..\..\bin\windows-x64\debug &gt; nul)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -150,6 +156,9 @@
       <ImportLibrary>..\..\..\bin\windows-x86\release\slang.lib</ImportLibrary>
       <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
+    <PostBuildEvent>
+      <Command>IF EXIST ..\..\..\external\slang-binaries\bin\windows-x86\slang-glslang.dll\ (xcopy /Q /E /Y /I ..\..\..\external\slang-binaries\bin\windows-x86\slang-glslang.dll ..\..\..\bin\windows-x86\release &gt; nul) ELSE (xcopy /Q /Y /I ..\..\..\external\slang-binaries\bin\windows-x86\slang-glslang.dll ..\..\..\bin\windows-x86\release &gt; nul)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -172,6 +181,9 @@
       <ImportLibrary>..\..\..\bin\windows-x64\release\slang.lib</ImportLibrary>
       <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
+    <PostBuildEvent>
+      <Command>IF EXIST ..\..\..\external\slang-binaries\bin\windows-x64\slang-glslang.dll\ (xcopy /Q /E /Y /I ..\..\..\external\slang-binaries\bin\windows-x64\slang-glslang.dll ..\..\..\bin\windows-x64\release &gt; nul) ELSE (xcopy /Q /Y /I ..\..\..\external\slang-binaries\bin\windows-x64\slang-glslang.dll ..\..\..\bin\windows-x64\release &gt; nul)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\slang.h" />

--- a/premake5.lua
+++ b/premake5.lua
@@ -79,7 +79,7 @@ newoption {
    trigger     = "build-glslang",
    description = "(Optional) If true glslang and spirv-opt will be built",
    value       = "bool",
-   default     = "true",
+   default     = "false",
    allowed     = { { "true", "True"}, { "false", "False" } }
 }
 

--- a/slang.sln
+++ b/slang.sln
@@ -35,10 +35,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "slang", "build\visual-studi
 		{E145B2B8-CD13-A6BE-B6A7-16E5A2148223} = {E145B2B8-CD13-A6BE-B6A7-16E5A2148223}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "slang-glslang", "build\visual-studio\slang-glslang\slang-glslang.vcxproj", "{C495878A-832C-485B-B347-0998A90CC936}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "slang-spirv-tools", "build\visual-studio\slang-spirv-tools\slang-spirv-tools.vcxproj", "{C36F6185-49B3-467E-8388-D0E9BF5F7BB8}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "slangc", "build\visual-studio\slangc\slangc.vcxproj", "{D56CBCEB-1EB5-4CA8-AEC4-48EA35ED61C7}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test-tool", "test-tool", "{57B5AA5E-C340-1823-CC51-9B17385C7423}"
@@ -159,22 +155,6 @@ Global
 		{DB00DA62-0533-4AFD-B59F-A67D5B3A0808}.Release|Win32.Build.0 = Release|Win32
 		{DB00DA62-0533-4AFD-B59F-A67D5B3A0808}.Release|x64.ActiveCfg = Release|x64
 		{DB00DA62-0533-4AFD-B59F-A67D5B3A0808}.Release|x64.Build.0 = Release|x64
-		{C495878A-832C-485B-B347-0998A90CC936}.Debug|Win32.ActiveCfg = Debug|Win32
-		{C495878A-832C-485B-B347-0998A90CC936}.Debug|Win32.Build.0 = Debug|Win32
-		{C495878A-832C-485B-B347-0998A90CC936}.Debug|x64.ActiveCfg = Debug|x64
-		{C495878A-832C-485B-B347-0998A90CC936}.Debug|x64.Build.0 = Debug|x64
-		{C495878A-832C-485B-B347-0998A90CC936}.Release|Win32.ActiveCfg = Release|Win32
-		{C495878A-832C-485B-B347-0998A90CC936}.Release|Win32.Build.0 = Release|Win32
-		{C495878A-832C-485B-B347-0998A90CC936}.Release|x64.ActiveCfg = Release|x64
-		{C495878A-832C-485B-B347-0998A90CC936}.Release|x64.Build.0 = Release|x64
-		{C36F6185-49B3-467E-8388-D0E9BF5F7BB8}.Debug|Win32.ActiveCfg = Debug|Win32
-		{C36F6185-49B3-467E-8388-D0E9BF5F7BB8}.Debug|Win32.Build.0 = Debug|Win32
-		{C36F6185-49B3-467E-8388-D0E9BF5F7BB8}.Debug|x64.ActiveCfg = Debug|x64
-		{C36F6185-49B3-467E-8388-D0E9BF5F7BB8}.Debug|x64.Build.0 = Debug|x64
-		{C36F6185-49B3-467E-8388-D0E9BF5F7BB8}.Release|Win32.ActiveCfg = Release|Win32
-		{C36F6185-49B3-467E-8388-D0E9BF5F7BB8}.Release|Win32.Build.0 = Release|Win32
-		{C36F6185-49B3-467E-8388-D0E9BF5F7BB8}.Release|x64.ActiveCfg = Release|x64
-		{C36F6185-49B3-467E-8388-D0E9BF5F7BB8}.Release|x64.Build.0 = Release|x64
 		{D56CBCEB-1EB5-4CA8-AEC4-48EA35ED61C7}.Debug|Win32.ActiveCfg = Debug|Win32
 		{D56CBCEB-1EB5-4CA8-AEC4-48EA35ED61C7}.Debug|Win32.Build.0 = Debug|Win32
 		{D56CBCEB-1EB5-4CA8-AEC4-48EA35ED61C7}.Debug|x64.ActiveCfg = Debug|x64


### PR DESCRIPTION
This change also switches the build back to using prebuilt glslang binaries instead of always building from source.