### PR TITLE
Small improvements to `gfx`.

### DIFF
--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -72,7 +72,7 @@ namespace Slang
 
         explicit UnownedStringSlice(char const* a) :
             m_begin(a),
-            m_end(a + strlen(a))
+            m_end(a ? a + strlen(a) : nullptr)
         {}
         UnownedStringSlice(char const* b, char const* e)
             : m_begin(b)

--- a/tools/gfx/render-graphics-common.cpp
+++ b/tools/gfx/render-graphics-common.cpp
@@ -146,7 +146,7 @@ public:
                 CASE(MutableTexture, StorageImage);
                 CASE(TypedBuffer, UniformTexelBuffer);
                 CASE(MutableTypedBuffer, StorageTexelBuffer);
-                CASE(RawBuffer, UniformBuffer);
+                CASE(RawBuffer, ReadOnlyStorageBuffer);
                 CASE(MutableRawBuffer, StorageBuffer);
                 CASE(InputRenderTarget, InputAttachment);
                 CASE(InlineUniformData, InlineUniformBlock);

--- a/tools/gfx/render.h
+++ b/tools/gfx/render.h
@@ -684,6 +684,7 @@ enum class DescriptorSlotType
     UniformTexelBuffer,
     StorageTexelBuffer,
     UniformBuffer,
+    ReadOnlyStorageBuffer,
     StorageBuffer,
     DynamicUniformBuffer,
     DynamicStorageBuffer,

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -2418,6 +2418,7 @@ static VkDescriptorType translateDescriptorType(DescriptorSlotType type)
         CASE(UniformTexelBuffer,    UNIFORM_TEXEL_BUFFER);
         CASE(StorageTexelBuffer,    STORAGE_TEXEL_BUFFER);
         CASE(UniformBuffer,         UNIFORM_BUFFER);
+        CASE(ReadOnlyStorageBuffer, STORAGE_BUFFER);
         CASE(StorageBuffer,         STORAGE_BUFFER);
         CASE(DynamicUniformBuffer,  UNIFORM_BUFFER_DYNAMIC);
         CASE(DynamicStorageBuffer,  STORAGE_BUFFER_DYNAMIC);


### PR DESCRIPTION
This change contains two small (and temporary) improvements to `gfx`. Although these chagnes can become irrelavent in the future when we refactor the interface, they allow me to make progress on other pieces of work now.

Add `StructuredBuffer` support in `gfx`.
Allow `gfx` to be used without a window handle in d3d11/d3d12.