### PR TITLE
Fix D3D12 DescriptorSet::setSampler bug

### DIFF
--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -2849,7 +2849,7 @@ void D3D12Renderer::DescriptorSetImpl::setSampler(UInt range, UInt index, ISampl
 #endif
 
     auto arrayIndex = rangeInfo.arrayIndex + index;
-    auto descriptorIndex = m_resourceTable + arrayIndex;
+    auto descriptorIndex = m_samplerTable + arrayIndex;
 
     m_samplerObjects[arrayIndex] = samplerImpl;
     dxDevice->CopyDescriptorsSimple(


### PR DESCRIPTION
Fix a bug in `DescriptorSet::setSampler` that is writing into the wrong descriptor table.