### PR TITLE
Make natvis to discover and display IRInst names more directly.

### DIFF
--- a/source/slang/slang.natvis
+++ b/source/slang/slang.natvis
@@ -76,6 +76,24 @@
     <Expand>
       <Item Name="[op]">op</Item>
       <Item Name="[type]">typeUse.usedValue</Item>
+      <CustomListItems MaxItemsPerView="3">
+		  <Variable Name="child" InitialValue="m_decorationsAndChildren.first"/>
+		  <Loop>
+			  <If Condition="child == 0">
+				  <Break/>
+			  </If>
+			  <If Condition="child->op == Slang::kIROp_NameHintDecoration">
+				  <Item Name="[name]">((Slang::IRStringLit*)(((Slang::IRUse*)(child + 1))->usedValue))->value.stringVal.chars,[((Slang::IRStringLit*)(((Slang::IRUse*)(child + 1))->usedValue))->value.stringVal.numChars]s8</Item>
+			  </If>
+			  <If Condition="child->op == Slang::kIROp_ExportDecoration">
+				  <Item Name="[exportName]">((Slang::IRStringLit*)(((Slang::IRUse*)(child + 1))->usedValue))->value.stringVal.chars,[((Slang::IRStringLit*)(((Slang::IRUse*)(child + 1))->usedValue))->value.stringVal.numChars]s8</Item>
+			  </If>
+			  <If Condition="child->op == Slang::kIROp_ImportDecoration">
+				  <Item Name="[importName]">((Slang::IRStringLit*)(((Slang::IRUse*)(child + 1))->usedValue))->value.stringVal.chars,[((Slang::IRStringLit*)(((Slang::IRUse*)(child + 1))->usedValue))->value.stringVal.numChars]s8</Item>
+			  </If>
+			  <Exec>child = child->next</Exec>
+		  </Loop>
+      </CustomListItems>
       <Item Name="[value]" Condition="op == Slang::kIROp_StringLit">((IRStringLit*)this)->value.stringVal.chars,[((IRStringLit*)this)->value.stringVal.numChars]s8</Item>
       <Item Name="[value]" Condition="op == Slang::kIROp_IntLit">((IRIntLit*)this)->value.intVal</Item>
       <Synthetic Name="[operands]">


### PR DESCRIPTION
This allows the name string defined in an `IRNameHintDecoration`, `IRExportDecoration` or `IRImportDecoration` directly under the expand of an `IRInst` object if the inst contains such a decoration.

![image](https://user-images.githubusercontent.com/2652293/105429389-2ed1e980-5c06-11eb-9755-463a8365adde.png)
