### PR TITLE
Add an accessor for IRInst opcode

### DIFF
--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -274,7 +274,7 @@ void CLikeSourceEmitter::_emitUnsizedArrayType(IRUnsizedArrayType* arrayType, ED
 
 void CLikeSourceEmitter::_emitType(IRType* type, EDeclarator* declarator)
 {
-    switch (type->op)
+    switch (type->getOp())
     {
     default:
         emitSimpleType(type);
@@ -774,7 +774,7 @@ void CLikeSourceEmitter::emitDeclarator(IRDeclaratorInfo* declarator)
 
 void CLikeSourceEmitter::emitSimpleValueImpl(IRInst* inst)
 {
-    switch(inst->op)
+    switch(inst->getOp())
     {
     case kIROp_IntLit:
     {
@@ -880,7 +880,7 @@ void CLikeSourceEmitter::emitSimpleValueImpl(IRInst* inst)
 bool CLikeSourceEmitter::shouldFoldInstIntoUseSites(IRInst* inst)
 {
     // Certain opcodes should never/always be folded in
-    switch( inst->op )
+    switch( inst->getOp() )
     {
     default:
         break;
@@ -935,7 +935,7 @@ bool CLikeSourceEmitter::shouldFoldInstIntoUseSites(IRInst* inst)
     if(as<IRAttr>(inst))
         return true;
 
-    switch( inst->op )
+    switch( inst->getOp() )
     {
     default:
         break;
@@ -1078,7 +1078,7 @@ bool CLikeSourceEmitter::shouldFoldInstIntoUseSites(IRInst* inst)
     // definition for certain types on certain targets (e.g. `out TriangleStream<T>`
     // for GLSL), so we check this only after all those special cases are
     // considered.
-    if (inst->op == kIROp_undefined)
+    if (inst->getOp() == kIROp_undefined)
         return false;
 
     // Okay, at this point we know our instruction must have a single use.
@@ -1186,7 +1186,7 @@ void CLikeSourceEmitter::emitDereferenceOperand(IRInst* inst, EmitOpInfo const& 
         // emit its name. i.e. *&var ==> var.
         // We apply this peep hole optimization here to reduce the clutter of
         // resulting code.
-        if (inst->op == kIROp_Var)
+        if (inst->getOp() == kIROp_Var)
         {
             m_writer->emit(getName(inst));
             return;
@@ -1230,7 +1230,7 @@ void CLikeSourceEmitter::emitOperandImpl(IRInst* inst, EmitOpInfo const&  outerP
         return;
     }
 
-    switch(inst->op)
+    switch(inst->getOp())
     {
     case kIROp_Var:
     case kIROp_GlobalVar:
@@ -1503,7 +1503,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
 {
     EmitOpInfo outerPrec = inOuterPrec;
     bool needClose = false;
-    switch(inst->op)
+    switch(inst->getOp())
     {
     case kIROp_GlobalHashedStringLiterals:
         /* Don't need to to output anything for this instruction - it's used for reflecting string literals that
@@ -1617,7 +1617,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
     case kIROp_Geq:
     case kIROp_Leq:
     {
-        const auto emitOp = getEmitOpForOp(inst->op);
+        const auto emitOp = getEmitOpForOp(inst->getOp());
 
         auto prec = getInfo(emitOp);
         needClose = maybeEmitParens(outerPrec, prec);
@@ -1645,7 +1645,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
     case kIROp_Or:
     case kIROp_Mul:
     {
-        const auto emitOp = getEmitOpForOp(inst->op);
+        const auto emitOp = getEmitOpForOp(inst->getOp());
         const auto info = getInfo(emitOp);
 
         needClose = maybeEmitParens(outerPrec, info);
@@ -1663,12 +1663,12 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
     {        
         IRInst* operand = inst->getOperand(0);
 
-        const auto emitOp = getEmitOpForOp(inst->op);
+        const auto emitOp = getEmitOpForOp(inst->getOp());
         const auto prec = getInfo(emitOp);
 
         needClose = maybeEmitParens(outerPrec, prec);
 
-        switch (inst->op)
+        switch (inst->getOp())
         {
             case kIROp_BitNot:
             {
@@ -1744,7 +1744,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
         }
         else
         {
-            if (inst->op == kIROp_getElementPtr && doesTargetSupportPtrTypes())
+            if (inst->getOp() == kIROp_getElementPtr && doesTargetSupportPtrTypes())
             {
                 const auto info = getInfo(EmitOp::Prefix);
                 needClose = maybeEmitParens(outerPrec, info);
@@ -1784,7 +1784,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
             for (Index ee = 0; ee < elementCount; ++ee)
             {
                 IRInst* irElementIndex = ii->getElementIndex(ee);
-                SLANG_RELEASE_ASSERT(irElementIndex->op == kIROp_IntLit);
+                SLANG_RELEASE_ASSERT(irElementIndex->getOp() == kIROp_IntLit);
                 IRConstant* irConst = (IRConstant*)irElementIndex;
 
                 UInt elementIndex = (UInt)irConst->value.intVal;
@@ -1988,7 +1988,7 @@ void CLikeSourceEmitter::_emitInst(IRInst* inst)
 
     m_writer->advanceToSourceLocation(inst->sourceLoc);
 
-    switch(inst->op)
+    switch(inst->getOp())
     {
     default:
         emitInstResultDecl(inst);
@@ -2057,7 +2057,7 @@ void CLikeSourceEmitter::_emitInst(IRInst* inst)
             for (UInt ee = 0; ee < elementCount; ++ee)
             {
                 IRInst* irElementIndex = ii->getElementIndex(ee);
-                SLANG_RELEASE_ASSERT(irElementIndex->op == kIROp_IntLit);
+                SLANG_RELEASE_ASSERT(irElementIndex->getOp() == kIROp_IntLit);
                 IRConstant* irConst = (IRConstant*)irElementIndex;
 
                 UInt elementIndex = (UInt)irConst->value.intVal;
@@ -2088,7 +2088,7 @@ void CLikeSourceEmitter::_emitInst(IRInst* inst)
             for (UInt ee = 0; ee < elementCount; ++ee)
             {
                 IRInst* irElementIndex = ii->getElementIndex(ee);
-                SLANG_RELEASE_ASSERT(irElementIndex->op == kIROp_IntLit);
+                SLANG_RELEASE_ASSERT(irElementIndex->getOp() == kIROp_IntLit);
                 IRConstant* irConst = (IRConstant*)irElementIndex;
 
                 UInt elementIndex = (UInt)irConst->value.intVal;
@@ -2398,7 +2398,7 @@ void CLikeSourceEmitter::emitRegion(Region* inRegion)
                 // them into the current block.
                 //
                 m_writer->advanceToSourceLocation(terminator->sourceLoc);
-                switch(terminator->op)
+                switch(terminator->getOp())
                 {
                 default:
                     // Don't do anything with the terminator, and assume
@@ -3231,7 +3231,7 @@ void CLikeSourceEmitter::emitGlobalInstImpl(IRInst* inst)
 {
     m_writer->advanceToSourceLocation(inst->sourceLoc);
 
-    switch(inst->op)
+    switch(inst->getOp())
     {
     case kIROp_GlobalHashedStringLiterals:
         /* Don't need to to output anything for this instruction - it's used for reflecting string literals that
@@ -3304,7 +3304,7 @@ void CLikeSourceEmitter::ensureInstOperandsRec(ComputeEmitActionsContext* ctx, I
 
     UInt operandCount = inst->operandCount;
     auto requiredLevel = EmitAction::Definition;
-    if (inst->op == kIROp_InterfaceType)
+    if (inst->getOp() == kIROp_InterfaceType)
         requiredLevel = EmitAction::ForwardDeclaration;
 
     for(UInt ii = 0; ii < operandCount; ++ii)
@@ -3330,7 +3330,7 @@ void CLikeSourceEmitter::ensureInstOperandsRec(ComputeEmitActionsContext* ctx, I
 void CLikeSourceEmitter::ensureGlobalInst(ComputeEmitActionsContext* ctx, IRInst* inst, EmitAction::Level requiredLevel)
 {
     // Skip certain instructions that don't affect output.
-    switch(inst->op)
+    switch(inst->getOp())
     {
     case kIROp_Generic:
         return;
@@ -3373,7 +3373,7 @@ void CLikeSourceEmitter::ensureGlobalInst(ComputeEmitActionsContext* ctx, IRInst
     ctx->mapInstToLevel[inst] = requiredLevel;
 
     // Skip instructions that don't correspond to an independent entity in output.
-    switch (inst->op)
+    switch (inst->getOp())
     {
     case kIROp_InterfaceRequirementEntry:
         return;

--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -123,7 +123,7 @@ SlangResult CUDASourceEmitter::calcScalarFuncName(HLSLIntrinsic::Op op, IRBasicT
     {
         case Op::FRem:
         {
-            if (type->op == kIROp_FloatType || type->op == kIROp_DoubleType)
+            if (type->getOp() == kIROp_FloatType || type->getOp() == kIROp_DoubleType)
             {
                 funcName = HLSLIntrinsic::getInfo(op).funcName;
             }
@@ -135,7 +135,7 @@ SlangResult CUDASourceEmitter::calcScalarFuncName(HLSLIntrinsic::Op op, IRBasicT
     if (funcName.getLength())
     {
         outBuilder << funcName;
-        if (type->op == kIROp_FloatType)
+        if (type->getOp() == kIROp_FloatType)
         {
             outBuilder << "f";
         }
@@ -158,7 +158,7 @@ SlangResult CUDASourceEmitter::calcTypeName(IRType* type, CodeGenTarget target, 
     // We allow C source, because if we need a name 
     SLANG_ASSERT(target == CodeGenTarget::CUDASource);
 
-    switch (type->op)
+    switch (type->getOp())
     {
         case kIROp_HalfType:
         {
@@ -170,7 +170,7 @@ SlangResult CUDASourceEmitter::calcTypeName(IRType* type, CodeGenTarget target, 
         {
             auto vecType = static_cast<IRVectorType*>(type);
             auto vecCount = int(getIntVal(vecType->getElementCount()));
-            const IROp elemType = vecType->getElementType()->op;
+            const IROp elemType = vecType->getElementType()->getOp();
 
             UnownedStringSlice prefix = getVectorPrefix(elemType);
             if (prefix.getLength() <= 0)
@@ -206,28 +206,28 @@ SlangResult CUDASourceEmitter::calcTypeName(IRType* type, CodeGenTarget target, 
 #endif
         default:
         {
-            if (isNominalOp(type->op))
+            if (isNominalOp(type->getOp()))
             {
                 out << getName(type);
                 return SLANG_OK;
             }
 
-            if (IRBasicType::isaImpl(type->op))
+            if (IRBasicType::isaImpl(type->getOp()))
             {
-                out << getBuiltinTypeName(type->op);
+                out << getBuiltinTypeName(type->getOp());
                 return SLANG_OK;
             }
 
             if (auto texType = as<IRTextureTypeBase>(type))
             {
                 // We don't support TextureSampler, so ignore that
-                if (texType->op != kIROp_TextureSamplerType)
+                if (texType->getOp() != kIROp_TextureSamplerType)
                 {
                     return _calcCUDATextureTypeName(texType, out);
                 }
             }
 
-            switch (type->op)
+            switch (type->getOp())
             {
                 case kIROp_SamplerStateType:                    out << "SamplerState"; return SLANG_OK;
                 case kIROp_SamplerComparisonStateType:          out << "SamplerComparisonState"; return SLANG_OK;
@@ -393,12 +393,12 @@ static bool _areEquivalent(IRType* a, IRType* b)
     {
         return true;
     }
-    if (a->op != b->op)
+    if (a->getOp() != b->getOp())
     {
         return false;
     }
 
-    switch (a->op)
+    switch (a->getOp())
     {
         case kIROp_VectorType:
         {
@@ -426,7 +426,7 @@ void CUDASourceEmitter::_emitInitializerListValue(IRType* dstType, IRInst* value
 {
     // When constructing a matrix or vector from a single value this is handled by the default path
 
-    switch (value->op)
+    switch (value->getOp())
     {
         case kIROp_Construct:
         case kIROp_MakeMatrix:
@@ -521,7 +521,7 @@ void CUDASourceEmitter::_emitInitializerList(IRType* elementType, IRUse* operand
 
 bool CUDASourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec)
 {
-    switch(inst->op)
+    switch(inst->getOp())
     {
         case kIROp_Construct:
         {
@@ -529,7 +529,7 @@ bool CUDASourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
             // On CUDA some of the built in types can't be used as constructors directly
 
             IRType* type = inst->getDataType();
-            if (auto basicType = as<IRBasicType>(type) && !_isSingleNameBasicType(type->op))
+            if (auto basicType = as<IRBasicType>(type) && !_isSingleNameBasicType(type->getOp()))
             {
                 m_writer->emit("(");
                 emitType(inst->getDataType());
@@ -615,7 +615,7 @@ void CUDASourceEmitter::emitLayoutDirectivesImpl(TargetRequest* targetReq)
 
 void CUDASourceEmitter::emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount)
 {
-    m_writer->emit(getVectorPrefix(elementType->op));
+    m_writer->emit(getVectorPrefix(elementType->getOp()));
     m_writer->emit(elementCount);
 }
 

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -602,7 +602,7 @@ void GLSLSourceEmitter::_emitGLSLLayoutQualifiers(IRVarLayout* layout, EmitVarCh
 
 void GLSLSourceEmitter::_emitGLSLTextureOrTextureSamplerType(IRTextureTypeBase*  type, char const* baseName)
 {
-    if (type->getElementType()->op == kIROp_HalfType)
+    if (type->getElementType()->getOp() == kIROp_HalfType)
     {
         // Texture access is always as float types if half is specified
 
@@ -637,7 +637,7 @@ void GLSLSourceEmitter::_emitGLSLTextureOrTextureSamplerType(IRTextureTypeBase* 
 
 void GLSLSourceEmitter::_emitGLSLTypePrefix(IRType* type, bool promoteHalfToFloat)
 {
-    switch (type->op)
+    switch (type->getOp())
     {
         case kIROp_FloatType:
             // no prefix
@@ -708,7 +708,7 @@ void GLSLSourceEmitter::_maybeEmitGLSLFlatModifier(IRType* valueType)
     if (auto vecType = as<IRMatrixType>(tt))
         tt = vecType->getElementType();
 
-    switch (tt->op)
+    switch (tt->getOp())
     {
         default:
             break;
@@ -738,7 +738,7 @@ void GLSLSourceEmitter::emitLoopControlDecorationImpl(IRLoopControlDecoration* d
 
 void GLSLSourceEmitter::emitSimpleValueImpl(IRInst* inst) 
 {
-    switch (inst->op)
+    switch (inst->getOp())
     {
         case kIROp_IntLit:
         {
@@ -873,7 +873,7 @@ void GLSLSourceEmitter::emitEntryPointAttributesImpl(IRFunc* irFunc, IREntryPoin
             // The actual parameters have become potentially multiple global parameters.
             if (auto decor = irFunc->findDecoration<IRGeometryInputPrimitiveTypeDecoration>())
             {
-                switch (decor->op)
+                switch (decor->getOp())
                 {
                     case kIROp_TriangleInputPrimitiveTypeDecoration:       m_writer->emit("layout(triangles) in;\n"); break;
                     case kIROp_LineInputPrimitiveTypeDecoration:           m_writer->emit("layout(lines) in;\n"); break;
@@ -891,7 +891,7 @@ void GLSLSourceEmitter::emitEntryPointAttributesImpl(IRFunc* irFunc, IREntryPoin
             {
                 IRType* type = decor->getStreamType();
 
-                switch (type->op)
+                switch (type->getOp())
                 {
                     case kIROp_HLSLPointStreamType:     m_writer->emit("layout(points) out;\n"); break;
                     case kIROp_HLSLLineStreamType:      m_writer->emit("layout(line_strip) out;\n"); break;
@@ -1232,7 +1232,7 @@ bool GLSLSourceEmitter::_tryEmitBitBinOp(IRInst* inst, const EmitOpInfo& bitOp, 
 
 bool GLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec)
 {
-    switch (inst->op)
+    switch (inst->getOp())
     {
         case kIROp_constructVectorFromScalar:
         {
@@ -1273,7 +1273,7 @@ bool GLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
         }
         case kIROp_Select:
         {
-            if (inst->getOperand(0)->getDataType()->op != kIROp_BoolType)
+            if (inst->getOperand(0)->getDataType()->getOp() != kIROp_BoolType)
             {
                 // For GLSL, emit a call to `mix` if condition is a vector
                 m_writer->emit("mix(");
@@ -1376,7 +1376,7 @@ bool GLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
             // If either side is a vector handle as a vector
             if (leftVectorType || rightVectorType)
             {
-                const char* funcName = _getGLSLVectorCompareFunctionName(inst->op);
+                const char* funcName = _getGLSLVectorCompareFunctionName(inst->getOp());
                 SLANG_ASSERT(funcName);
 
                 // Determine the vector type
@@ -1503,7 +1503,7 @@ void GLSLSourceEmitter::handleRequiredCapabilitiesImpl(IRInst* inst)
 
     for (auto decoration : inst->getDecorations())
     {
-        switch (decoration->op)
+        switch (decoration->getOp())
         {
             default:
                 break;
@@ -1625,18 +1625,18 @@ void GLSLSourceEmitter::emitVectorTypeNameImpl(IRType* elementType, IRIntegerVal
 
 void GLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
 {
-    switch (type->op)
+    switch (type->getOp())
     {
         case kIROp_Int64Type:
         {
             _requireBaseType(BaseType::Int64);
-            m_writer->emit(getDefaultBuiltinTypeName(type->op));
+            m_writer->emit(getDefaultBuiltinTypeName(type->getOp()));
             return;
         }
         case kIROp_UInt64Type:
         {
             _requireBaseType(BaseType::UInt64);
-            m_writer->emit(getDefaultBuiltinTypeName(type->op));
+            m_writer->emit(getDefaultBuiltinTypeName(type->getOp()));
             return;
         }
         case kIROp_VoidType:
@@ -1651,7 +1651,7 @@ void GLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
         case kIROp_DoubleType:
         {
             _requireBaseType(cast<IRBasicType>(type)->getBaseType());
-            m_writer->emit(getDefaultBuiltinTypeName(type->op));
+            m_writer->emit(getDefaultBuiltinTypeName(type->getOp()));
             return;
         }
         case kIROp_HalfType:
@@ -1687,7 +1687,7 @@ void GLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
         case kIROp_SamplerComparisonStateType:
         {
             auto samplerStateType = cast<IRSamplerStateTypeBase>(type);
-            switch (samplerStateType->op)
+            switch (samplerStateType->getOp())
             {
                 case kIROp_SamplerStateType:			m_writer->emit("sampler");		break;
                 case kIROp_SamplerComparisonStateType:	m_writer->emit("samplerShadow");	break;
@@ -1743,7 +1743,7 @@ void GLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
     }
     else if (auto untypedBufferType = as<IRUntypedBufferResourceType>(type))
     {
-        switch (untypedBufferType->op)
+        switch (untypedBufferType->getOp())
         {
             case kIROp_RaytracingAccelerationStructureType:
             {
@@ -1808,7 +1808,7 @@ void GLSLSourceEmitter::emitInterpolationModifiersImpl(IRInst* varInst, IRType* 
 
     for (auto dd : varInst->getDecorations())
     {
-        if (dd->op != kIROp_InterpolationModeDecoration)
+        if (dd->getOp() != kIROp_InterpolationModeDecoration)
             continue;
 
         auto decoration = (IRInterpolationModeDecoration*)dd;

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -414,7 +414,7 @@ void HLSLSourceEmitter::emitEntryPointAttributesImpl(IRFunc* irFunc, IREntryPoin
 
 bool HLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec)
 {
-    switch (inst->op)
+    switch (inst->getOp())
     {
         case kIROp_Construct:
         case kIROp_makeVector:
@@ -577,7 +577,7 @@ bool HLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
                 }
             }
 
-            if( elementType->op == kIROp_UIntType )
+            if( elementType->getOp() == kIROp_UIntType )
             {
                 // If we are in the case that can use `Load`/`Load2`/`Load3`/`Load4`,
                 // then we will always prefer to use it.
@@ -620,7 +620,7 @@ bool HLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
                     elementCount = elementCountInst->getValue();
                 }
             }
-            if( elementType->op == kIROp_UIntType )
+            if( elementType->getOp() == kIROp_UIntType )
             {
                 auto outerPrec = inOuterPrec;
                 auto prec = getInfo(EmitOp::Postfix);
@@ -695,7 +695,7 @@ void HLSLSourceEmitter::emitLoopControlDecorationImpl(IRLoopControlDecoration* d
 
 void HLSLSourceEmitter::emitFuncDecorationImpl(IRDecoration* decoration)
 {
-    switch( decoration->op )
+    switch( decoration->getOp() )
     {
     case kIROp_NoInlineDecoration:
         m_writer->emit("[noinline]\n");
@@ -709,7 +709,7 @@ void HLSLSourceEmitter::emitFuncDecorationImpl(IRDecoration* decoration)
 
 void HLSLSourceEmitter::emitSimpleValueImpl(IRInst* inst)
 {
-    switch (inst->op)
+    switch (inst->getOp())
     {
         case kIROp_FloatLit:
         {
@@ -745,7 +745,7 @@ void HLSLSourceEmitter::emitSimpleValueImpl(IRInst* inst)
 
 void HLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
 {
-    switch (type->op)
+    switch (type->getOp())
     {
         case kIROp_VoidType:
         case kIROp_BoolType:
@@ -761,7 +761,7 @@ void HLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
         case kIROp_DoubleType:
         case kIROp_HalfType:
         {
-            m_writer->emit(getDefaultBuiltinTypeName(type->op));
+            m_writer->emit(getDefaultBuiltinTypeName(type->getOp()));
             return;
         }
         case kIROp_StructType:
@@ -793,7 +793,7 @@ void HLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
         {
             auto samplerStateType = cast<IRSamplerStateTypeBase>(type);
 
-            switch (samplerStateType->op)
+            switch (samplerStateType->getOp())
             {
                 case kIROp_SamplerStateType:			m_writer->emit("SamplerState");			break;
                 case kIROp_SamplerComparisonStateType:	m_writer->emit("SamplerComparisonState");	break;
@@ -827,7 +827,7 @@ void HLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
     }
     else if (auto structuredBufferType = as<IRHLSLStructuredBufferTypeBase>(type))
     {
-        switch (structuredBufferType->op)
+        switch (structuredBufferType->getOp())
         {
             case kIROp_HLSLStructuredBufferType:                    m_writer->emit("StructuredBuffer");                   break;
             case kIROp_HLSLRWStructuredBufferType:                  m_writer->emit("RWStructuredBuffer");                 break;
@@ -848,7 +848,7 @@ void HLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
     }
     else if (auto untypedBufferType = as<IRUntypedBufferResourceType>(type))
     {
-        switch (type->op)
+        switch (type->getOp())
         {
             case kIROp_HLSLByteAddressBufferType:                   m_writer->emit("ByteAddressBuffer");                  break;
             case kIROp_HLSLRWByteAddressBufferType:                 m_writer->emit("RWByteAddressBuffer");                break;
@@ -882,7 +882,7 @@ void HLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
     // HACK: As a fallback for HLSL targets, assume that the name of the
     // instruction being used is the same as the name of the HLSL type.
     {
-        auto opInfo = getIROpInfo(type->op);
+        auto opInfo = getIROpInfo(type->getOp());
         m_writer->emit(opInfo.name);
         UInt operandCount = type->getOperandCount();
         if (operandCount)
@@ -967,7 +967,7 @@ void HLSLSourceEmitter::emitSimpleFuncParamImpl(IRParam* param)
 {
     if (auto decor = param->findDecoration<IRGeometryInputPrimitiveTypeDecoration>())
     {
-        switch (decor->op)
+        switch (decor->getOp())
         {
             case kIROp_TriangleInputPrimitiveTypeDecoration:             m_writer->emit("triangle "); break;
             case kIROp_PointInputPrimitiveTypeDecoration:                m_writer->emit("point "); break;
@@ -1001,7 +1001,7 @@ void HLSLSourceEmitter::emitInterpolationModifiersImpl(IRInst* varInst, IRType* 
 
     for (auto dd : varInst->getDecorations())
     {
-        if (dd->op != kIROp_InterpolationModeDecoration)
+        if (dd->getOp() != kIROp_InterpolationModeDecoration)
             continue;
 
         auto decoration = (IRInterpolationModeDecoration*)dd;

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -788,7 +788,7 @@ struct SPIRVEmitContext
         ///
     SpvInst* emitGlobalInst(IRInst* inst)
     {
-        switch( inst->op )
+        switch( inst->getOp() )
         {
         // [3.32.6: Type-Declaration Instructions]
         //
@@ -1036,7 +1036,7 @@ struct SPIRVEmitContext
         /// Emit an instruction that is local to the body of the given `parent`.
     SpvInst* emitLocalInst(SpvInstParent* parent, IRInst* inst)
     {
-        switch( inst->op )
+        switch( inst->getOp() )
         {
         default:
             SLANG_UNIMPLEMENTED_X("unhandled instruction opcode");
@@ -1087,7 +1087,7 @@ struct SPIRVEmitContext
         // this code path is a catch-all for stuff that only needs to
         // be emitted if the owning instruction gets emitted.
 
-        switch( decoration->op )
+        switch( decoration->getOp() )
         {
         default:
             break;

--- a/source/slang/slang-hlsl-intrinsic-set.cpp
+++ b/source/slang/slang-hlsl-intrinsic-set.cpp
@@ -24,7 +24,7 @@ HLSLIntrinsicSet::HLSLIntrinsicSet(IRTypeSet* typeSet, HLSLIntrinsicOpLookup* lo
 
 static IRBasicType* _getElementType(IRType* type)
 {
-    switch (type->op)
+    switch (type->getOp())
     {
         case kIROp_VectorType:      type = static_cast<IRVectorType*>(type)->getElementType(); break;
         case kIROp_MatrixType:      type = static_cast<IRMatrixType*>(type)->getElementType(); break;
@@ -63,7 +63,7 @@ void HLSLIntrinsicSet::_calcIntrinsic(HLSLIntrinsic::Op op, IRType* returnType, 
             // TODO(JS):
             // HACK! GetAt can be from getElementPtr or from getElement. Get element ptr means the return type will be
             // a pointer. We don't want to deal with that, so strip it
-            if (returnType->op == kIROp_PtrType)
+            if (returnType->getOp() == kIROp_PtrType)
             {
                 returnType = as<IRType>(returnType->getOperand(0));
             }
@@ -73,7 +73,7 @@ void HLSLIntrinsicSet::_calcIntrinsic(HLSLIntrinsic::Op op, IRType* returnType, 
             {
                 IRType* argType = inArgs[i];
 
-                if (argType->op == kIROp_PtrType)
+                if (argType->getOp() == kIROp_PtrType)
                 {
                     argType = as<IRType>(argType->getOperand(0));
                 }
@@ -210,7 +210,7 @@ SlangResult HLSLIntrinsicSet::makeIntrinsic(IRInst* inst, HLSLIntrinsic& out)
 
     {
         // See if we can just directly convert
-        Op op = HLSLIntrinsicOpLookup::getOpForIROp(inst->op);
+        Op op = HLSLIntrinsicOpLookup::getOpForIROp(inst->getOp());
 
 
         // HACK: some cases we want to stop handling via the synthesis
@@ -231,7 +231,7 @@ SlangResult HLSLIntrinsicSet::makeIntrinsic(IRInst* inst, HLSLIntrinsic& out)
 //        case Op::All:
             {
                 IRType* srcType = inst->getOperand(0)->getDataType();
-                switch( srcType->op )
+                switch( srcType->getOp() )
                 {
                 default:
                     break;
@@ -253,7 +253,7 @@ SlangResult HLSLIntrinsicSet::makeIntrinsic(IRInst* inst, HLSLIntrinsic& out)
     }
 
     // All the special cases
-    switch (inst->op)
+    switch (inst->getOp())
     {
         case kIROp_constructVectorFromScalar:
         {
@@ -266,7 +266,7 @@ SlangResult HLSLIntrinsicSet::makeIntrinsic(IRInst* inst, HLSLIntrinsic& out)
             IRType* dstType = inst->getDataType();
             IRType* srcType = inst->getOperand(0)->getDataType();
 
-            if ((dstType->op == kIROp_VectorType || dstType->op == kIROp_MatrixType) &&
+            if ((dstType->getOp() == kIROp_VectorType || dstType->getOp() == kIROp_MatrixType) &&
                 inst->getOperandCount() == 1)
             {
                 if (as<IRBasicType>(srcType))
@@ -284,7 +284,7 @@ SlangResult HLSLIntrinsicSet::makeIntrinsic(IRInst* inst, HLSLIntrinsic& out)
             else
             {
                 // If we are constructing a basic type, we don't need an Op::Init
-                if (!IRBasicType::isaImpl(dstType->op))
+                if (!IRBasicType::isaImpl(dstType->getOp()))
                 {
                     // Emit the 'init' intrinsic
                     calcIntrinsic(Op::Init, inst, inst->getOperandCount(), out);
@@ -331,7 +331,7 @@ SlangResult HLSLIntrinsicSet::makeIntrinsic(IRInst* inst, HLSLIntrinsic& out)
                 if (!as<IRBasicType>(dstType))
                 {
                     // If it's a scalar make sure we have construct from scalar, because we will want to use that
-                    SLANG_ASSERT(dstType->op == kIROp_VectorType);
+                    SLANG_ASSERT(dstType->getOp() == kIROp_VectorType);
                     IRType* argTypes[] = { baseType };
                     calcIntrinsic(Op::ConstructFromScalar, inst->getDataType(), argTypes, 1,  out);
                     return SLANG_OK;
@@ -353,7 +353,7 @@ SlangResult HLSLIntrinsicSet::makeIntrinsic(IRInst* inst, HLSLIntrinsic& out)
         {
             IRInst* target = inst->getOperand(0);
             IRType* targetType = target->getDataType();
-            if (targetType->op == kIROp_VectorType || targetType->op == kIROp_MatrixType)
+            if (targetType->getOp() == kIROp_VectorType || targetType->getOp() == kIROp_MatrixType)
             {
                 // Specially handle this
                 calcIntrinsic(Op::GetAt, inst, out);
@@ -369,7 +369,7 @@ SlangResult HLSLIntrinsicSet::makeIntrinsic(IRInst* inst, HLSLIntrinsic& out)
             if (auto ptrType = as<IRPtrType>(targetType))
             {
                 targetType = as<IRType>(ptrType->getOperand(0));
-                if (targetType->op == kIROp_VectorType || targetType->op == kIROp_MatrixType)
+                if (targetType->getOp() == kIROp_VectorType || targetType->getOp() == kIROp_MatrixType)
                 {
                     // Specially handle this
                     calcIntrinsic(Op::GetAt, inst, out);
@@ -533,7 +533,7 @@ HLSLIntrinsic::Op HLSLIntrinsicOpLookup::getOpFromTargetDecoration(IRInst* inIns
 
 HLSLIntrinsic::Op HLSLIntrinsicOpLookup::getOpForIROp(IRInst* inst)
 {
-    switch (inst->op)
+    switch (inst->getOp())
     {
         case kIROp_Call:
         {
@@ -541,7 +541,7 @@ HLSLIntrinsic::Op HLSLIntrinsicOpLookup::getOpForIROp(IRInst* inst)
         }
         default: break;
     }
-    return getOpForIROp(inst->op);
+    return getOpForIROp(inst->getOp());
 }
 
 /* static */HLSLIntrinsic::Op HLSLIntrinsicOpLookup::getOpForIROp(IROp op)

--- a/source/slang/slang-hlsl-intrinsic-set.h
+++ b/source/slang/slang-hlsl-intrinsic-set.h
@@ -98,12 +98,12 @@ struct HLSLIntrinsic
     static bool isTypeScalar(IRType* type)
     {
         // Strip off ptr if it's an operand type
-        if (type->op == kIROp_PtrType)
+        if (type->getOp() == kIROp_PtrType)
         {
             type = as<IRType>(type->getOperand(0));
         }
         // If any are vec or matrix, then we
-        return !(type->op == kIROp_MatrixType || type->op == kIROp_VectorType);
+        return !(type->getOp() == kIROp_MatrixType || type->getOp() == kIROp_VectorType);
     }
 
     bool isScalar() const

--- a/source/slang/slang-intrinsic-expand.cpp
+++ b/source/slang/slang-intrinsic-expand.cpp
@@ -192,7 +192,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
                 }
 
                 // We only need to output a cast if the underlying type is half.
-                if (underlyingType && underlyingType->op == kIROp_HalfType)
+                if (underlyingType && underlyingType->getOp() == kIROp_HalfType)
                 {
                     m_emitter->emitSimpleType(elementType);
                     m_writer->emit("(");
@@ -332,7 +332,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
             SLANG_RELEASE_ASSERT(m_argCount > argIndex);
 
             auto arg = m_args[argIndex].get();
-            if (arg->op == kIROp_ImageSubscript)
+            if (arg->getOp() == kIROp_ImageSubscript)
             {
                 m_writer->emit("imageA");
             }
@@ -357,7 +357,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
             SLANG_RELEASE_ASSERT(m_argCount > argIndex);
 
             auto arg = m_args[argIndex].get();
-            if (arg->op == kIROp_ImageSubscript)
+            if (arg->getOp() == kIROp_ImageSubscript)
             {
                 if (m_emitter->getSourceLanguage() == SourceLanguage::GLSL)
                 {
@@ -389,7 +389,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
                         elementCount = getIntVal(coordsVecType->getElementCount());
                     }
 
-                    SLANG_ASSERT(coordsType->op == kIROp_UIntType);
+                    SLANG_ASSERT(coordsType->getOp() == kIROp_UIntType);
 
                     if (elementCount > 1)
                     {
@@ -479,7 +479,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
             auto argType = arg->getDataType();
 
             const char* str = "";
-            switch (argType->op)
+            switch (argType->getOp())
             {
 #define CASE(OP, STR) \
                     case kIROp_##OP: str = #STR; break

--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -107,7 +107,7 @@ namespace Slang
             IRInst* concreteTypedVar)
         {
             auto dataType = cast<IRPtrTypeBase>(concreteTypedVar->getDataType())->getValueType();
-            switch (dataType->op)
+            switch (dataType->getOp())
             {
             case kIROp_IntType:
             case kIROp_FloatType:
@@ -203,7 +203,7 @@ namespace Slang
         {
             virtual void marshalBasicType(IRBuilder* builder, IRType* dataType, IRInst* concreteVar) override
             {
-                switch (dataType->op)
+                switch (dataType->getOp())
                 {
                 case kIROp_IntType:
                 case kIROp_FloatType:
@@ -327,7 +327,7 @@ namespace Slang
         {
             virtual void marshalBasicType(IRBuilder* builder, IRType* dataType, IRInst* concreteVar) override
             {
-                switch (dataType->op)
+                switch (dataType->getOp())
                 {
                 case kIROp_IntType:
                 case kIROp_FloatType:

--- a/source/slang/slang-ir-augment-make-existential.cpp
+++ b/source/slang/slang-ir-augment-make-existential.cpp
@@ -40,7 +40,7 @@ struct AugmentMakeExistentialContext
 
     void processInst(IRInst* inst)
     {
-        switch (inst->op)
+        switch (inst->getOp())
         {
         case kIROp_MakeExistential:
             processMakeExistential((IRMakeExistential*)inst);

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -53,7 +53,7 @@ struct ByteAddressBufferLegalizationContext
     //
     void processInstRec(IRInst* inst)
     {
-        switch( inst->op )
+        switch( inst->getOp() )
         {
         case kIROp_ByteAddressBufferLoad:
             processLoad(inst);
@@ -592,7 +592,7 @@ struct ByteAddressBufferLegalizationContext
     }
     IRBasicType* getSameSizeUIntType(IRType* type)
     {
-        auto unsignedBaseType = getSameSizeUIntBaseType(type->op);
+        auto unsignedBaseType = getSameSizeUIntBaseType(type->getOp());
         if(unsignedBaseType == BaseType::Void)
             return nullptr;
 
@@ -623,7 +623,7 @@ struct ByteAddressBufferLegalizationContext
             return getEquivalentStructuredBufferParam(elementType, byteAddressBufferParam);
         }
 
-        if( byteAddressBuffer->op == kIROp_getElement )
+        if( byteAddressBuffer->getOp() == kIROp_getElement )
         {
             // If the code is fetching the byte-address buffer from an
             // array, then we need to create an "equivalent" structured
@@ -727,7 +727,7 @@ struct ByteAddressBufferLegalizationContext
         // a structure buffer that is equivalent to `byteAddressBufferType`,
         // but with the given `elementType`.
 
-        switch( byteAddressBufferType->op )
+        switch( byteAddressBufferType->getOp() )
         {
             // The basic `*ByteAddressBuffer` types map directly to the `*StructuredBuffer<elementType>` cases.
         case kIROp_HLSLByteAddressBufferType:                   return m_builder.getType(kIROp_HLSLStructuredBufferType, elementType);
@@ -743,7 +743,7 @@ struct ByteAddressBufferLegalizationContext
                 //
                 auto arrayType = cast<IRArrayTypeBase>(byteAddressBufferType);
                 return m_builder.getArrayTypeBase(
-                    byteAddressBufferType->op,
+                    byteAddressBufferType->getOp(),
                     getEquivalentStructuredBufferParamType(elementType, arrayType->getElementType()),
                     arrayType->getElementCount());
             }

--- a/source/slang/slang-ir-clone.cpp
+++ b/source/slang/slang-ir-clone.cpp
@@ -79,7 +79,7 @@ IRInst* cloneInstAndOperands(
     UInt operandCount = oldInst->getOperandCount();
     auto newInst = builder->emitIntrinsicInst(
         newType,
-        oldInst->op,
+        oldInst->getOp(),
         operandCount,
         nullptr);
 

--- a/source/slang/slang-ir-collect-global-uniforms.cpp
+++ b/source/slang/slang-ir-collect-global-uniforms.cpp
@@ -52,7 +52,7 @@ struct CollectGlobalUniformParametersContext
 
     IRGlobalParam* _getGlobalParamFromLayoutFieldKey(IRInst* key)
     {
-        switch (key->op)
+        switch (key->getOp())
         {
         case kIROp_GlobalParam:
             return cast<IRGlobalParam>(key);

--- a/source/slang/slang-ir-constexpr.cpp
+++ b/source/slang/slang-ir-constexpr.cpp
@@ -44,7 +44,7 @@ bool isConstExpr(IRInst* value)
     //
     // TODO: should we just go ahead and make that explicit
     // in the type system?
-    switch(value->op)
+    switch(value->getOp())
     {
     case kIROp_IntLit:
     case kIROp_FloatLit:
@@ -95,7 +95,7 @@ bool opCanBeConstExpr(IRInst* value)
     // callee function is fixed/known, and if it is
     // whether it has been decoared as constant-foldable
 
-    return opCanBeConstExpr(value->op);
+    return opCanBeConstExpr(value->getOp());
 }
 
 void markConstExpr(
@@ -186,7 +186,7 @@ bool maybeMarkConstExpr(
     // (Or eventually we'd have a rule that only non-`public` symbols
     // can have this kind of propagation applied).
 
-    if(value->op == kIROp_Param)
+    if(value->getOp() == kIROp_Param)
     {
         auto param = (IRParam*) value;
         auto block = (IRBlock*) param->parent;
@@ -203,7 +203,7 @@ bool maybeMarkConstExpr(
             {
                 auto user = u->getUser();
 
-                switch( user->op )
+                switch( user->getOp() )
                 {
                 case kIROp_Call:
                     {
@@ -272,7 +272,7 @@ bool propagateConstExprBackward(
                         }
                     }
                 }
-                else if( ii->op == kIROp_Call )
+                else if( ii->getOp() == kIROp_Call )
                 {
                     // A non-constexpr call might be calling a function with one or
                     // more constexpr parameters. We should check if we can resolve
@@ -391,7 +391,7 @@ bool propagateConstExprBackward(
                     for(auto pred : bb->getPredecessors())
                     {
                         auto terminator = pred->getLastInst();
-                        if(terminator->op != kIROp_unconditionalBranch)
+                        if(terminator->getOp() != kIROp_unconditionalBranch)
                             continue;
 
                         UInt operandIndex = paramIndex + 1;
@@ -496,7 +496,7 @@ void propagateConstExpr(
         context.workList.fastRemoveAt(0);
         context.onWorkList.Remove(gv);
 
-        switch( gv->op )
+        switch( gv->getOp() )
         {
         default:
             break;
@@ -532,7 +532,7 @@ void propagateConstExpr(
 
     for(auto ii : module->getGlobalInsts())
     {
-        switch( ii->op )
+        switch( ii->getOp() )
         {
         default:
             break;

--- a/source/slang/slang-ir-dce.cpp
+++ b/source/slang/slang-ir-dce.cpp
@@ -280,7 +280,7 @@ struct DeadCodeEliminationContext
         // There are a few special cases of "structural" instructions
         // that we don't want to eliminate, so we'll check for those next.
         //
-        switch( inst->op )
+        switch( inst->getOp() )
         {
             // Function parameters obviously shouldn't get eliminated,
             // even if nothing references them, and block parameters

--- a/source/slang/slang-ir-deduplicate.cpp
+++ b/source/slang/slang-ir-deduplicate.cpp
@@ -26,7 +26,7 @@ namespace Slang
         IRInst* addTypeValue(IRInst* value)
         {
             // Do not deduplicate struct or interface types.
-            switch (value->op)
+            switch (value->getOp())
             {
             case kIROp_StructType:
             case kIROp_InterfaceType:

--- a/source/slang/slang-ir-explicit-global-context.cpp
+++ b/source/slang/slang-ir-explicit-global-context.cpp
@@ -39,7 +39,7 @@ struct IntroduceExplicitGlobalContextPass
         //
         for( auto inst : m_module->getGlobalInsts() )
         {
-            switch( inst->op )
+            switch( inst->getOp() )
             {
             case kIROp_GlobalVar:
                 {

--- a/source/slang/slang-ir-extract-value-from-type.cpp
+++ b/source/slang/slang-ir-extract-value-from-type.cpp
@@ -33,7 +33,7 @@ FindLeafValueResult findLeafValueAtOffset(
         result.offsetInValue = (uint32_t)(offset - layout.size);
         return result;
     }
-    switch (dataType->op)
+    switch (dataType->getOp())
     {
     case kIROp_StructType:
         {
@@ -125,7 +125,7 @@ FindLeafValueResult findLeafValueAtOffset(
             // Note: this code is assuming row major odering.
             auto matrixType = as<IRMatrixType>(dataType);
             auto elementType = matrixType->getElementType();
-            SLANG_RELEASE_ASSERT(matrixType->getColumnCount()->op == kIROp_IntLit);
+            SLANG_RELEASE_ASSERT(matrixType->getColumnCount()->getOp() == kIROp_IntLit);
             auto columnCount = as<IRIntLit>(matrixType->getColumnCount())->value.intVal;
             auto rowType = builder.getVectorType(elementType, matrixType->getColumnCount());
             IRSizeAndAlignment rowLayout;

--- a/source/slang/slang-ir-generics-lowering-context.cpp
+++ b/source/slang/slang-ir-generics-lowering-context.cpp
@@ -10,7 +10,7 @@ namespace Slang
     {
         if (as<IRParam>(typeInst) && as<IRTypeType>(typeInst->getDataType()))
             return true;
-        switch (typeInst->op)
+        switch (typeInst->getOp())
         {
         case kIROp_ThisType:
         case kIROp_AssociatedType:
@@ -40,7 +40,7 @@ namespace Slang
     {
         if (typeInst)
         {
-            switch (typeInst->op)
+            switch (typeInst->getOp())
             {
             case kIROp_TypeType:
             case kIROp_TypeKind:
@@ -107,7 +107,7 @@ namespace Slang
 
     IRType* SharedGenericsLoweringContext::lowerAssociatedType(IRBuilder* builder, IRInst* type)
     {
-        if (type->op != kIROp_AssociatedType)
+        if (type->getOp() != kIROp_AssociatedType)
             return (IRType*)type;
         IRIntegerValue anyValueSize = kInvalidAnyValueSize;
         for (UInt i = 0; i < type->getOperandCount(); i++)
@@ -144,7 +144,7 @@ namespace Slang
             return builder->getRTTIHandleType();
         }
 
-        switch (paramType->op)
+        switch (paramType->getOp())
         {
         case kIROp_WitnessTableType:
         case kIROp_WitnessTableIDType:
@@ -295,7 +295,7 @@ namespace Slang
             auto reqVal = findInterfaceRequirementVal(
                 interfaceType,
                 lookupInterface->getRequirementKey());
-            SLANG_ASSERT(reqVal && reqVal->op == kIROp_AssociatedType);
+            SLANG_ASSERT(reqVal && reqVal->getOp() == kIROp_AssociatedType);
             return lowerType(builder, reqVal, typeMapping, nullptr);
         }
         case kIROp_BoundInterfaceType:
@@ -322,7 +322,7 @@ namespace Slang
                     translated = true;
             }
             if (translated)
-                return builder->getType(paramType->op, loweredOperands.getCount(), loweredOperands.getBuffer());
+                return builder->getType(paramType->getOp(), loweredOperands.getCount(), loweredOperands.getBuffer());
             return (IRType*)paramType;
         }
         }
@@ -333,7 +333,7 @@ namespace Slang
         List<IRWitnessTable*> witnessTables;
         for (auto globalInst : module->getGlobalInsts())
         {
-            if (globalInst->op == kIROp_WitnessTable &&
+            if (globalInst->getOp() == kIROp_WitnessTable &&
                 cast<IRWitnessTableType>(globalInst->getDataType())->getConformanceType() ==
                     interfaceType)
             {

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -909,7 +909,7 @@ ScalarizedVal extractField(
             auto ptrType = as<IRPtrTypeBase>(val.irValue->getDataType());
             auto valType = ptrType->getValueType();
             auto fieldType = getFieldType(valType, fieldKey);
-            auto fieldPtrType = builder->getPtrType(ptrType->op, fieldType);
+            auto fieldPtrType = builder->getPtrType(ptrType->getOp(), fieldType);
             return ScalarizedVal::address(
                 builder->emitFieldAddress(
                     fieldPtrType,
@@ -1314,7 +1314,7 @@ void legalizeEntryPointParameterForGLSL(
     {
         if (!func->findDecoration<IRGeometryInputPrimitiveTypeDecoration>())
         {
-            builder->addDecoration(func, geomDecor->op);
+            builder->addDecoration(func, geomDecor->getOp());
         }
         else
         {
@@ -1336,7 +1336,7 @@ void legalizeEntryPointParameterForGLSL(
             if (auto decor = func->findDecoration<IRStreamOutputTypeDecoration>())
             {
                 // If it has the same stream out type, we *may* be ok (might not work for all types of streams)
-                SLANG_ASSERT(decor->getStreamType()->op == streamType->op);
+                SLANG_ASSERT(decor->getStreamType()->getOp() == streamType->getOp());
             }
             else
             {
@@ -1393,7 +1393,7 @@ void legalizeEntryPointParameterForGLSL(
                 for( auto ii = bb->getFirstInst(); ii; ii = ii->getNextInst() )
                 {
                     // Is it a call?
-                    if(ii->op != kIROp_Call)
+                    if(ii->getOp() != kIROp_Call)
                         continue;
 
                     // Is it calling the append operation?
@@ -1413,7 +1413,7 @@ void legalizeEntryPointParameterForGLSL(
                         // that decorations are added to the generic instead of the
                         // value it returns.
                         //
-                        switch(callee->op)
+                        switch(callee->getOp())
                         {
                         case kIROp_Specialize:
                             {
@@ -1436,7 +1436,7 @@ void legalizeEntryPointParameterForGLSL(
                         }
                         break;
                     }
-                    if(callee->op != kIROp_Func)
+                    if(callee->getOp() != kIROp_Func)
                         continue;
 
                     // HACK: we will identify the operation based
@@ -1558,7 +1558,7 @@ void legalizeEntryPointParameterForGLSL(
             if(!terminatorInst)
                 continue;
 
-            switch( terminatorInst->op )
+            switch( terminatorInst->getOp() )
             {
             default:
                 continue;
@@ -1702,7 +1702,7 @@ void legalizeEntryPointForGLSL(
             // terminator...
             for( auto ii = bb->getFirstInst(); ii; ii = ii->getNextInst() )
             {
-                if(ii->op != kIROp_ReturnVal)
+                if(ii->getOp() != kIROp_ReturnVal)
                     continue;
 
                 IRReturnVal* returnInst = (IRReturnVal*) ii;

--- a/source/slang/slang-ir-hoist-local-types.cpp
+++ b/source/slang/slang-ir-hoist-local-types.cpp
@@ -65,7 +65,7 @@ struct HoistLocalTypesContext
         if (hoistable)
         {
             auto newType = builder.getType(
-                inst->op, mappedOperands.getCount(), mappedOperands.getArrayView().getBuffer());
+                inst->getOp(), mappedOperands.getCount(), mappedOperands.getArrayView().getBuffer());
             inst->transferDecorationsTo(newType);
             inst->replaceUsesWith(newType);
             inst->removeAndDeallocate();

--- a/source/slang/slang-ir-inline.cpp
+++ b/source/slang/slang-ir-inline.cpp
@@ -420,7 +420,7 @@ struct InliningPassBase
         //
         for( auto inst : firstBlock->getChildren() )
         {
-            switch( inst->op )
+            switch( inst->getOp() )
             {
             default:
                 // The default value is to clone the instruction using

--- a/source/slang/slang-ir-layout.cpp
+++ b/source/slang/slang-ir-layout.cpp
@@ -79,7 +79,7 @@ static Result _calcNaturalArraySizeAndAlignment(
 
 IRIntegerValue getIntegerValueFromInst(IRInst* inst)
 {
-    SLANG_ASSERT(inst->op == kIROp_IntLit);
+    SLANG_ASSERT(inst->getOp() == kIROp_IntLit);
     return as<IRIntLit>(inst)->value.intVal;
 }
 
@@ -88,7 +88,7 @@ static Result _calcNaturalSizeAndAlignment(
     IRType*             type,
     IRSizeAndAlignment* outSizeAndAlignment)
 {
-    switch( type->op )
+    switch( type->getOp() )
     {
 
 #define CASE(TYPE, SIZE, ALIGNMENT)                                 \

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -1205,7 +1205,7 @@ static LegalVal legalizeInst(
     LegalType                   type,
     LegalVal const*             args)
 {
-    switch (inst->op)
+    switch (inst->getOp())
     {
     case kIROp_Load:
         return legalizeLoad(context, args[0]);
@@ -1381,7 +1381,7 @@ static LegalVal legalizeInst(
     context->builder->setInsertBefore(inst);
 
     // Special-case certain operations
-    switch (inst->op)
+    switch (inst->getOp())
     {
     case kIROp_Var:
         return legalizeLocalVar(context, cast<IRVar>(inst));
@@ -1649,7 +1649,7 @@ static LegalVal declareSimpleVar(
         {
             for( auto decoration : leafVar->getDecorations() )
             {
-                switch( decoration->op )
+                switch( decoration->getOp() )
                 {
                 case kIROp_FormatDecoration:
                     cloneDecoration(decoration, irVar);
@@ -2557,7 +2557,7 @@ struct IRTypeLegalizationPass
         // as having already been processed, since there is no particular
         // need for us to handle them as part of legalization.
         //
-        if(inst->op == kIROp_InterfaceRequirementEntry) return true;
+        if(inst->getOp() == kIROp_InterfaceRequirementEntry) return true;
 
         return addedToWorkListSet.Contains(inst);
     }
@@ -2629,7 +2629,7 @@ struct IRTypeLegalizationPass
         // would not be a valid location at which to
         // store their replacements.
         //
-        if(!inst->getParent() && inst->op != kIROp_Module)
+        if(!inst->getParent() && inst->getOp() != kIROp_Module)
             return;
 
         // The main logic for legalizing an instruction is defined

--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -222,7 +222,7 @@ IRType* cloneType(
 
 IRInst* IRSpecContext::maybeCloneValue(IRInst* originalValue)
 {
-    switch (originalValue->op)
+    switch (originalValue->getOp())
     {
     case kIROp_StructType:
     case kIROp_Func:
@@ -280,7 +280,7 @@ IRInst* IRSpecContext::maybeCloneValue(IRInst* originalValue)
             UInt argCount = originalValue->getOperandCount();
             IRInst* clonedValue = builder->createIntrinsicInst(
                 cloneType(this, originalValue->getFullType()),
-                originalValue->op,
+                originalValue->getOp(),
                 argCount, nullptr);
             registerClonedValue(this, clonedValue, originalValue);
             for (UInt aa = 0; aa < argCount; ++aa)
@@ -432,14 +432,14 @@ static void cloneExtraDecorations(
     {
         for(auto decoration : sym->irGlobalValue->getDecorations())
         {
-            switch(decoration->op)
+            switch(decoration->getOp())
             {
             default:
                 break;
 
             case kIROp_BindExistentialSlotsDecoration:
             case kIROp_LayoutDecoration:
-                if(!clonedInst->findDecorationImpl(decoration->op))
+                if(!clonedInst->findDecorationImpl(decoration->getOp()))
                 {
                     cloneInst(context, builder, decoration);
                 }
@@ -1059,7 +1059,7 @@ IRInst* cloneInst(
     IRInst*                         originalInst,
     IROriginalValuesForClone const& originalValues)
 {
-    switch (originalInst->op)
+    switch (originalInst->getOp())
     {
         // We need to special-case any instruction that is not
         // allocated like an ordinary `IRInst` with trailing args.
@@ -1103,7 +1103,7 @@ IRInst* cloneInst(
     UInt argCount = originalInst->getOperandCount();
     IRInst* clonedInst = builder->createIntrinsicInst(
         cloneType(context, originalInst->getFullType()),
-        originalInst->op,
+        originalInst->getOp(),
         argCount, nullptr);
     registerClonedValue(context, clonedInst, originalValues);
     auto oldBuilder = context->builder;
@@ -1493,7 +1493,7 @@ LinkedIR linkIR(
     {
         for( auto decoration : irModule->getModuleInst()->getDecorations() )
         {
-            switch( decoration->op )
+            switch( decoration->getOp() )
             {
             case kIROp_NVAPISlotDecoration:
                 {

--- a/source/slang/slang-ir-lower-bit-cast.cpp
+++ b/source/slang/slang-ir-lower-bit-cast.cpp
@@ -30,7 +30,7 @@ struct BitCastLoweringContext
 
     void processInst(IRInst* inst)
     {
-        switch (inst->op)
+        switch (inst->getOp())
         {
         case kIROp_BitCast:
             processBitCast(inst);
@@ -70,7 +70,7 @@ struct BitCastLoweringContext
     // Extract an object of `type` from `offset` in `src`.
     IRInst* readObject(IRBuilder& builder, IRInst* src, IRType* type, uint32_t offset)
     {
-        switch (type->op)
+        switch (type->getOp())
         {
         case kIROp_StructType:
             {
@@ -187,7 +187,7 @@ struct BitCastLoweringContext
                         builder.getUInt64Type(),
                         high,
                         builder.getIntValue(builder.getUIntType(), 32)));
-                if (type->op == kIROp_UInt64Type)
+                if (type->getOp() == kIROp_UInt64Type)
                     return combined;
                 return builder.emitBitCast(type, combined);
             }

--- a/source/slang/slang-ir-lower-existential.cpp
+++ b/source/slang/slang-ir-lower-existential.cpp
@@ -38,7 +38,7 @@ namespace Slang
                 rttiObject = builder->emitGetAddress(rttiType, rttiObject);
             }
             IRInst* packedValue = value;
-            if (valueType->op != kIROp_AnyValueType)
+            if (valueType->getOp() != kIROp_AnyValueType)
                 packedValue = builder->emitPackAnyValue(anyValueType, value);
             IRInst* tupleArgs[] = {rttiObject, inst->getWitnessTable(), packedValue};
             auto tuple = builder->emitMakeTuple(tupleType, 3, tupleArgs);

--- a/source/slang/slang-ir-lower-generic-call.cpp
+++ b/source/slang/slang-ir-lower-generic-call.cpp
@@ -122,7 +122,7 @@ namespace Slang
             auto callee = builder->emitLookupInterfaceMethodInst(
                 reqFuncType, witnessTableParam, requirementKey);
             auto call = (IRCall*)builder->emitCallInst(reqFuncType->getResultType(), callee, params);
-            if (call->getDataType()->op == kIROp_VoidType)
+            if (call->getDataType()->getOp() == kIROp_VoidType)
                 builder->emitReturn();
             else
                 builder->emitReturn(call);
@@ -195,14 +195,14 @@ namespace Slang
                             builder->getRTTIHandleType(),
                             rttiObject);
                     }
-                    else if (arg->op == kIROp_Specialize)
+                    else if (arg->getOp() == kIROp_Specialize)
                     {
                         // The type argument used to specialize a callee is itself a
                         // specialization of some generic type.
                         // TODO: generate RTTI object for specializations of generic types.
                         SLANG_UNIMPLEMENTED_X("RTTI object generation for generic types");
                     }
-                    else if (arg->op == kIROp_RTTIObject)
+                    else if (arg->getOp() == kIROp_RTTIObject)
                     {
                         // We are inside a generic function and using a generic parameter
                         // to specialize another callee. The generic parameter of the caller
@@ -247,17 +247,17 @@ namespace Slang
             // All callees should have already been lowered in lower-generic-functions pass.
             // For intrinsic generic functions, they are left as is, and we also need to ignore
             // them here.
-            if (loweredFunc->op == kIROp_Generic)
+            if (loweredFunc->getOp() == kIROp_Generic)
             {
                 return;
             }
-            else if (loweredFunc->op == kIROp_Specialize)
+            else if (loweredFunc->getOp() == kIROp_Specialize)
             {
                 // All nested generic functions are supposed to be flattend before this pass.
                 // If they are not, they represent an intrinsic function that should not be
                 // modified in this pass.
                 auto innerMostFunc = findInnerMostSpecializingBase(static_cast<IRSpecialize*>(loweredFunc));
-                if (innerMostFunc && innerMostFunc->op == kIROp_Generic)
+                if (innerMostFunc && innerMostFunc->getOp() == kIROp_Generic)
                 {
                     innerMostFunc =
                         findInnerMostGenericReturnVal(static_cast<IRGeneric*>(innerMostFunc));
@@ -266,7 +266,7 @@ namespace Slang
                     return;
                 SLANG_UNEXPECTED("Nested generics specialization.");
             }
-            else if (loweredFunc->op == kIROp_lookup_interface_method)
+            else if (loweredFunc->getOp() == kIROp_lookup_interface_method)
             {
                 lowerCallToInterfaceMethod(
                     callInst, cast<IRLookupWitnessMethod>(loweredFunc), specializeInst);

--- a/source/slang/slang-ir-lower-generic-function.cpp
+++ b/source/slang/slang-ir-lower-generic-function.cpp
@@ -54,11 +54,11 @@ namespace Slang
             {
                 if (genericChild == func)
                     continue;
-                if (genericChild->op == kIROp_ReturnVal)
+                if (genericChild->getOp() == kIROp_ReturnVal)
                     continue;
                 // Process all generic parameters and local type definitions.
                 auto clonedChild = cloneInst(&cloneEnv, &builder, genericChild);
-                if (clonedChild->op == kIROp_Param)
+                if (clonedChild->getOp() == kIROp_Param)
                 {
                     auto paramType = clonedChild->getFullType();
                     auto loweredParamType = sharedContext->lowerType(&builder, paramType);
@@ -176,7 +176,7 @@ namespace Slang
                     {
                         loweredVal = lowerGenericFuncType(&builder, genericFuncType);
                     }
-                    else if (requirementVal->op == kIROp_AssociatedType)
+                    else if (requirementVal->getOp() == kIROp_AssociatedType)
                     {
                         loweredVal = builder.getRTTIHandleType();
                     }
@@ -201,7 +201,7 @@ namespace Slang
         {
             auto type = inst->getDataType();
             if (!type) return false;
-            return type->op == kIROp_TypeKind;
+            return type->getOp() == kIROp_TypeKind;
         }
 
         // Lower items in a witness table. This triggers lowering of generic functions,
@@ -228,7 +228,7 @@ namespace Slang
                 if (auto genericVal = as<IRGeneric>(entry->getSatisfyingVal()))
                 {
                     // Lower generic functions in witness table.
-                    if (findGenericReturnVal(genericVal)->op == kIROp_Func)
+                    if (findGenericReturnVal(genericVal)->getOp() == kIROp_Func)
                     {
                         auto loweredFunc = lowerGenericFunction(genericVal);
                         entry->satisfyingVal.set(loweredFunc);
@@ -270,7 +270,7 @@ namespace Slang
             // translate it into call(gFunc, args, Targs).
             IRInst* loweredFunc = nullptr;
             auto funcToSpecialize = specializeInst->getBase();
-            if (funcToSpecialize->op == kIROp_Generic)
+            if (funcToSpecialize->getOp() == kIROp_Generic)
             {
                 loweredFunc = lowerGenericFunction(funcToSpecialize);
                 if (loweredFunc != funcToSpecialize)

--- a/source/slang/slang-ir-lower-generic-type.cpp
+++ b/source/slang/slang-ir-lower-generic-type.cpp
@@ -38,7 +38,7 @@ namespace Slang
             if (newType != inst->getFullType())
                 inst->setFullType((IRType*)newType);
 
-            switch (inst->op)
+            switch (inst->getOp())
             {
             default:
                 break;

--- a/source/slang/slang-ir-lower-generics.cpp
+++ b/source/slang/slang-ir-lower-generics.cpp
@@ -37,7 +37,7 @@ namespace Slang
             for (auto use = rtti.Value->firstUse; use; use = nextUse)
             {
                 nextUse = use->nextUse;
-                if (use->getUser()->op == kIROp_getAddr)
+                if (use->getUser()->getOp() == kIROp_getAddr)
                 {
                     use->getUser()->replaceUsesWith(idOperand);
                 }
@@ -51,7 +51,7 @@ namespace Slang
         List<IRInst*> instsToRemove;
         for (auto inst : sharedContext->module->getGlobalInsts())
         {
-            switch (inst->op)
+            switch (inst->getOp())
             {
             case kIROp_WitnessTableIDType:
             case kIROp_RTTIHandleType:
@@ -81,7 +81,7 @@ namespace Slang
         List<IRInst*> interfaceInsts;
         for (auto inst : sharedContext->module->getGlobalInsts())
         {
-            if (inst->op == kIROp_InterfaceType)
+            if (inst->getOp() == kIROp_InterfaceType)
             {
                 interfaceInsts.add(inst);
             }

--- a/source/slang/slang-ir-lower-tuple-types.cpp
+++ b/source/slang/slang-ir-lower-tuple-types.cpp
@@ -42,7 +42,7 @@ namespace Slang
 
             if (!type)
                 return nullptr;
-            if (type->op != kIROp_TupleType)
+            if (type->getOp() != kIROp_TupleType)
                 return nullptr;
 
             RefPtr<LoweredTupleInfo> info = new LoweredTupleInfo();
@@ -123,7 +123,7 @@ namespace Slang
 
         void processInst(IRInst* inst)
         {
-            switch (inst->op)
+            switch (inst->getOp())
             {
             case kIROp_MakeTuple:
                 processMakeTuple((IRMakeTuple*)inst);

--- a/source/slang/slang-ir-restructure-scoping.cpp
+++ b/source/slang/slang-ir-restructure-scoping.cpp
@@ -150,7 +150,7 @@ IRInst* getDefaultInitVal(
     IRBuilder*  builder,
     IRType*     type)
 {
-    switch( type->op )
+    switch( type->getOp() )
     {
     default:
         return nullptr;
@@ -181,7 +181,7 @@ void defaultInitializeVar(
     IRType*     type)
 {
     IRInst* initVal = nullptr;
-    switch( type->op )
+    switch( type->getOp() )
     {
     case kIROp_VoidType:
     default:
@@ -217,7 +217,7 @@ static void fixValueScopingForInst(
     // because the emit logic will already create variables for them.
     // We could consider folding the logic to move out of SSA form
     // into this function, but that would add a lot of complexity for now.
-    if(def->op == kIROp_Param)
+    if(def->getOp() == kIROp_Param)
         return;
 
     // We would have a scoping violation if there exists some

--- a/source/slang/slang-ir-restructure.cpp
+++ b/source/slang/slang-ir-restructure.cpp
@@ -241,7 +241,7 @@ namespace Slang
             //
             auto terminator = block->getTerminator();
             SLANG_ASSERT(terminator != nullptr);
-            switch (terminator->op)
+            switch (terminator->getOp())
             {
             default:
             case kIROp_conditionalBranch:

--- a/source/slang/slang-ir-sccp.cpp
+++ b/source/slang/slang-ir-sccp.cpp
@@ -187,7 +187,7 @@ struct SCCPContext
         // Instructions that represent constant values should always
         // have a lattice value that reflects this.
         //
-        switch( inst->op )
+        switch( inst->getOp() )
         {
         case kIROp_IntLit:
         case kIROp_FloatLit:
@@ -237,7 +237,7 @@ struct SCCPContext
 
         // Certain instruction always produce constants, and we
         // want to special-case them here.
-        switch( inst->op )
+        switch( inst->getOp() )
         {
         case kIROp_IntLit:
         case kIROp_FloatLit:

--- a/source/slang/slang-ir-specialize-dispatch.cpp
+++ b/source/slang/slang-ir-specialize-dispatch.cpp
@@ -24,7 +24,7 @@ IRFunc* specializeDispatchFunction(SharedGenericsLoweringContext* sharedContext,
     IRReturn* returnInst = nullptr;
     for (auto inst : block->getOrdinaryInsts())
     {
-        switch (inst->op)
+        switch (inst->getOp())
         {
         case kIROp_Call:
             callInst = cast<IRCall>(inst);
@@ -114,7 +114,7 @@ IRFunc* specializeDispatchFunction(SharedGenericsLoweringContext* sharedContext,
         auto callee = sharedContext->findWitnessTableEntry(witnessTable, requirementKey);
         SLANG_ASSERT(callee);
         auto specializedCallInst = builder->emitCallInst(callInst->getFullType(), callee, params);
-        if (callInst->getDataType()->op == kIROp_VoidType)
+        if (callInst->getDataType()->getOp() == kIROp_VoidType)
             builder->emitReturn();
         else
             builder->emitReturn(specializedCallInst);
@@ -163,7 +163,7 @@ void ensureWitnessTableSequentialIDs(SharedGenericsLoweringContext* sharedContex
     auto linkage = sharedContext->targetReq->getLinkage();
     for (auto inst : sharedContext->module->getGlobalInsts())
     {
-        if (inst->op == kIROp_WitnessTable)
+        if (inst->getOp() == kIROp_WitnessTable)
         {
             UnownedStringSlice witnessTableMangledName;
             if (auto instLinkage = inst->findDecoration<IRLinkageDecoration>())

--- a/source/slang/slang-ir-specialize-dynamic-associatedtype-lookup.cpp
+++ b/source/slang/slang-ir-specialize-dynamic-associatedtype-lookup.cpp
@@ -143,7 +143,7 @@ struct AssociatedTypeLookupSpecializationContext
         builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
         builder.setInsertBefore(inst);
         auto witnessTableArg = inst->getWitnessTable();
-        if (witnessTableArg->getDataType()->op == kIROp_WitnessTableType)
+        if (witnessTableArg->getDataType()->getOp() == kIROp_WitnessTableType)
         {
             witnessTableArg = builder.emitGetSequentialIDInst(witnessTableArg);
         }
@@ -155,7 +155,7 @@ struct AssociatedTypeLookupSpecializationContext
 
     void processGetSequentialIDInst(IRGetSequentialID* inst)
     {
-        if (inst->getRTTIOperand()->getDataType()->op == kIROp_WitnessTableIDType)
+        if (inst->getRTTIOperand()->getDataType()->getOp() == kIROp_WitnessTableIDType)
         {
             inst->replaceUsesWith(inst->getRTTIOperand());
             inst->removeAndDeallocate();
@@ -179,7 +179,7 @@ struct AssociatedTypeLookupSpecializationContext
             sharedContext->workListSet.Remove(inst);
 
             func(inst);
-            if (inst->op == kIROp_lookup_interface_method)
+            if (inst->getOp() == kIROp_lookup_interface_method)
             {
                 processLookupInterfaceMethodInst(cast<IRLookupWitnessMethod>(inst));
             }
@@ -196,7 +196,7 @@ struct AssociatedTypeLookupSpecializationContext
         // Replace all `lookup_interface_method():IRWitnessTable` with call to specialized functions.
         workOnModule([this](IRInst* inst)
         {
-            if (inst->op == kIROp_lookup_interface_method)
+            if (inst->getOp() == kIROp_lookup_interface_method)
             {
                 processLookupInterfaceMethodInst(cast<IRLookupWitnessMethod>(inst));
             }
@@ -205,7 +205,7 @@ struct AssociatedTypeLookupSpecializationContext
         // Replace all direct uses of IRWitnessTables with its sequential ID.
         workOnModule([this](IRInst* inst)
         {
-            if (inst->op == kIROp_WitnessTable)
+            if (inst->getOp() == kIROp_WitnessTable)
             {
                 auto seqId = inst->findDecoration<IRSequentialIDDecoration>();
                 SLANG_ASSERT(seqId);
@@ -232,7 +232,7 @@ struct AssociatedTypeLookupSpecializationContext
         // Replace all `IRWitnessTableType`s with `IRWitnessTableIDType`.
         for (auto globalInst : sharedContext->module->getGlobalInsts())
         {
-            if (globalInst->op == kIROp_WitnessTableType)
+            if (globalInst->getOp() == kIROp_WitnessTableType)
             {
                 IRBuilder builder;
                 builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
@@ -243,7 +243,7 @@ struct AssociatedTypeLookupSpecializationContext
                 for (auto use = globalInst->firstUse; use; use = nextUse)
                 {
                     nextUse = use->nextUse;
-                    if (use->getUser()->op == kIROp_WitnessTable)
+                    if (use->getUser()->getOp() == kIROp_WitnessTable)
                         continue;
                     use->set(witnessTableIDType);
                 }
@@ -253,7 +253,7 @@ struct AssociatedTypeLookupSpecializationContext
         // `GetSequentialID(WitnessTableIDOperand)` becomes just `WitnessTableIDOperand`.
         workOnModule([this](IRInst* inst)
         {
-            if (inst->op == kIROp_GetSequentialID)
+            if (inst->getOp() == kIROp_GetSequentialID)
             {
                 processGetSequentialIDInst(cast<IRGetSequentialID>(inst));
             }

--- a/source/slang/slang-ir-specialize-function-call.cpp
+++ b/source/slang/slang-ir-specialize-function-call.cpp
@@ -211,7 +211,7 @@ struct FunctionParameterSpecializationContext
             // of the indexing operation is also
             // suitable for specialization.
             //
-            if( arg->op == kIROp_getElement || arg->op == kIROp_Load )
+            if( arg->getOp() == kIROp_getElement || arg->getOp() == kIROp_Load )
             {
                 auto base = arg->getOperand(0);
 
@@ -493,7 +493,7 @@ struct FunctionParameterSpecializationContext
             //
             ioInfo.key.vals.add(oldGlobalParam);
         }
-        else if( oldArg->op == kIROp_getElement )
+        else if( oldArg->getOp() == kIROp_getElement )
         {
             // This is the case where the `oldArg` is
             // in the form `oldBase[oldIndex]`
@@ -519,7 +519,7 @@ struct FunctionParameterSpecializationContext
             //
             ioInfo.newArgs.add(oldIndex);
         }
-        else if (oldArg->op == kIROp_Load)
+        else if (oldArg->getOp() == kIROp_Load)
         {
             auto oldBase = oldArg->getOperand(0);
             getCallInfoForArg(ioInfo, oldBase);
@@ -614,7 +614,7 @@ struct FunctionParameterSpecializationContext
             //
             return globalParam;
         }
-        else if( oldArg->op == kIROp_getElement )
+        else if( oldArg->getOp() == kIROp_getElement )
         {
             // This is the case where the argument is
             // in the form `oldBase[oldIndex]`.
@@ -677,7 +677,7 @@ struct FunctionParameterSpecializationContext
 
             return newVal;
         }
-        else if (oldArg->op == kIROp_Load)
+        else if (oldArg->getOp() == kIROp_Load)
         {
             return getSpecializedValueForArg(ioInfo, oldArg->getOperand(0));
         }

--- a/source/slang/slang-ir-specialize-resources.cpp
+++ b/source/slang/slang-ir-specialize-resources.cpp
@@ -614,7 +614,7 @@ struct ResourceOutputSpecializationPass
         // At the very least, we expect them to be operations with
         // the same opcode.
         //
-        if(value->op != representative->op)
+        if(value->getOp() != representative->getOp())
             return SLANG_FAIL;
 
         // Furthermore, only certain instructions are amenable to
@@ -628,7 +628,7 @@ struct ResourceOutputSpecializationPass
         // Each supported instruction opcode might introduce new
         // constraints on how `value` and `representative` must match.
         //
-        switch( value->op )
+        switch( value->getOp() )
         {
         default:
             // Any opcode we do not specifically enable should cause
@@ -1030,7 +1030,7 @@ struct ResourceOutputSpecializationPass
         // value in the context of the caller.
         //
         auto representative = info.representative;
-        switch( representative->op )
+        switch( representative->getOp() )
         {
         default:
             // Because we only allow certain instructions when specializing

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -76,7 +76,7 @@ struct SpecializationContext
         // can't mark an interface as used until its requirements are
         // used, etc.
         //
-        if(inst->op == kIROp_InterfaceRequirementEntry)
+        if(inst->getOp() == kIROp_InterfaceRequirementEntry)
             return true;
 
         return fullySpecializedInsts.Contains(inst);
@@ -396,7 +396,7 @@ struct SpecializationContext
         // since values are an important class of instruction we want
         // to deduplicate.
 
-        switch(inst->op)
+        switch(inst->getOp())
         {
         default:
             // The default case is that an instruction can
@@ -476,7 +476,7 @@ struct SpecializationContext
     void maybeSpecializeInst(
         IRInst*                     inst)
     {
-        switch(inst->op)
+        switch(inst->getOp())
         {
         default:
             // By default we assume that specialization is
@@ -1135,7 +1135,7 @@ struct SpecializationContext
             // we can simply check if the `concreteType` is a compile-time
             // constant value.
             //
-            if(concreteType->op == kIROp_ExtractExistentialType)
+            if(concreteType->getOp() == kIROp_ExtractExistentialType)
                 return false;
 
             return true;
@@ -1822,7 +1822,7 @@ struct SpecializationContext
                 slotOperands.add(wrapInst->getSlotOperand(ii));
             }
 
-            auto elementPtrType = builder.getPtrType(ptrType->op, elementType);
+            auto elementPtrType = builder.getPtrType(ptrType->getOp(), elementType);
             auto newElementAddr = builder.emitElementAddress(elementPtrType, val, index);
 
             auto newWrapExistentialInst = builder.emitWrapExistential(
@@ -1921,7 +1921,7 @@ struct SpecializationContext
                 type->getExistentialArgs());
 
             auto newPtrLikeType = builder.getType(
-                baseType->op,
+                baseType->getOp(),
                 1,
                 &wrappedElementType);
             addUsersToWorkList(type);
@@ -2049,7 +2049,7 @@ struct SpecializationContext
             {
                 next = inst->getNextInst();
 
-                switch(inst->op)
+                switch(inst->getOp())
                 {
                 default:
                     break;

--- a/source/slang/slang-ir-ssa.cpp
+++ b/source/slang/slang-ir-ssa.cpp
@@ -112,7 +112,7 @@ bool allUsesLeadToLoads(IRInst* inst)
     for (auto u = inst->firstUse; u; u = u->nextUse)
     {
         auto user = u->getUser();
-        switch (user->op)
+        switch (user->getOp())
         {
         default:
             return false;
@@ -178,7 +178,7 @@ bool isPromotableVar(
     for (auto u = var->firstUse; u; u = u->nextUse)
     {
         auto user = u->getUser();
-        switch (user->op)
+        switch (user->getOp())
         {
         default:
             // If the variable gets used by any operation
@@ -240,7 +240,7 @@ void identifyPromotableVars(
     {
         for (auto ii = bb->getFirstInst(); ii; ii = ii->getNextInst())
         {
-            if (ii->op != kIROp_Var)
+            if (ii->getOp() != kIROp_Var)
                 continue;
 
             IRVar* var = (IRVar*)ii;
@@ -258,7 +258,7 @@ IRVar* asPromotableVar(
     ConstructSSAContext*    context,
     IRInst*                value)
 {
-    if (value->op != kIROp_Var)
+    if (value->getOp() != kIROp_Var)
         return nullptr;
 
     IRVar* var = (IRVar*)value;
@@ -274,7 +274,7 @@ IRVar* asPromotableVarAccessChain(
     ConstructSSAContext*    context,
     IRInst*                 value)
 {
-    switch (value->op)
+    switch (value->getOp())
     {
     case kIROp_Var:
         return asPromotableVar(context, value);
@@ -301,7 +301,7 @@ IRInst* applyAccessChain(
     IRInst*                 accessChain,
     IRInst*                 leafVarValue)
 {
-    switch (accessChain->op)
+    switch (accessChain->getOp())
     {
     default:
         SLANG_UNEXPECTED("unexpected op along access chain");
@@ -363,7 +363,7 @@ static void cloneRelevantDecorations(
     //
     for( auto decoration : var->getDecorations() )
     {
-        switch(decoration->op)
+        switch(decoration->getOp())
         {
         default:
             // Ignore most decorations.
@@ -376,7 +376,7 @@ static void cloneRelevantDecorations(
             // Copy these decorations if the target doesn't already have them,
             // but don't make duplicate decorations on the target.
             //
-            if( !val->findDecorationImpl(decoration->op) )
+            if( !val->findDecorationImpl(decoration->getOp()) )
             {
                 cloneDecoration(decoration, val, var->getModule());
             }
@@ -476,7 +476,7 @@ IRInst* tryRemoveTrivialPhi(
         if(!user) continue;
         if(user == phi) continue;
 
-        if( user->op == kIROp_Param )
+        if( user->getOp() == kIROp_Param )
         {
             auto maybeOtherPhi = (IRParam*) user;
             if( auto otherPhiInfo = context->getPhiInfo(maybeOtherPhi) )
@@ -622,7 +622,7 @@ IRInst* maybeGetPhiReplacement(
 {
     IRInst* val = inVal;
 
-    while( val->op == kIROp_Param )
+    while( val->getOp() == kIROp_Param )
     {
         // The value is a parameter, but is it a phi?
         IRParam* maybePhi = (IRParam*) val;
@@ -816,7 +816,7 @@ void processBlock(
         // instruction we are working with.
         blockInfo->builder.setInsertBefore(ii);
 
-        switch (ii->op)
+        switch (ii->getOp())
         {
         default:
             // Ordinary instruction -> leave as-is
@@ -1148,7 +1148,7 @@ void constructSSA(ConstructSSAContext* context)
 
         IRTerminatorInst* newTerminator = (IRTerminatorInst*)blockInfo->builder.emitIntrinsicInst(
             oldTerminator->getFullType(),
-            oldTerminator->op,
+            oldTerminator->getOp(),
             newArgCount,
             newArgs.getBuffer());
 
@@ -1204,7 +1204,7 @@ void constructSSA(IRModule* module, IRGlobalValueWithCode* globalVal)
 
 void constructSSA(IRModule* module, IRInst* globalVal)
 {
-    switch (globalVal->op)
+    switch (globalVal->getOp())
     {
     case kIROp_Func:
     case kIROp_GlobalVar:

--- a/source/slang/slang-ir-strip.cpp
+++ b/source/slang/slang-ir-strip.cpp
@@ -11,7 +11,7 @@ static bool _shouldStripInst(
     IRInst*                 inst,
     IRStripOptions const&   options)
 {
-    switch( inst->op )
+    switch( inst->getOp() )
     {
     default:
         return false;

--- a/source/slang/slang-ir-synthesize-active-mask.cpp
+++ b/source/slang/slang-ir-synthesize-active-mask.cpp
@@ -269,7 +269,7 @@ struct SynthesizeActiveMaskForModuleContext
         // instructions. When we find one we mark the function
         // that contains it.
 
-        if( inst->op == kIROp_WaveGetActiveMask )
+        if( inst->getOp() == kIROp_WaveGetActiveMask )
         {
             markInstUsingActiveMask(inst);
         }
@@ -642,7 +642,7 @@ struct SynthesizeActiveMaskForFunctionContext
         {
             for( auto inst : block->getOrdinaryInsts() )
             {
-                if( inst->op == kIROp_WaveGetActiveMask )
+                if( inst->getOp() == kIROp_WaveGetActiveMask )
                 {
                     m_blocksNeedingActiveMask.Add(block);
                     break;
@@ -1027,7 +1027,7 @@ struct SynthesizeActiveMaskForFunctionContext
         {
             nextInst = inst->getNextInst();
 
-            if( inst->op == kIROp_WaveGetActiveMask )
+            if( inst->getOp() == kIROp_WaveGetActiveMask )
             {
                 inst->replaceUsesWith(activeMaskOnRegionEntry);
                 inst->removeAndDeallocate();
@@ -1042,7 +1042,7 @@ struct SynthesizeActiveMaskForFunctionContext
         //
         auto terminator = regionEntry->getTerminator();
         SLANG_ASSERT(terminator);
-        switch( terminator->op )
+        switch( terminator->getOp() )
         {
             // There are some cases of terminator instructions that
             // we explicit do not or cannot handle.
@@ -1896,7 +1896,7 @@ struct SynthesizeActiveMaskForFunctionContext
 
             IRInst* newTerminator = builder.emitIntrinsicInst(
                 terminator->getFullType(),
-                terminator->op,
+                terminator->getOp(),
                 newOperands.getCount(),
                 newOperands.getBuffer());
 

--- a/source/slang/slang-ir-type-set.cpp
+++ b/source/slang/slang-ir-type-set.cpp
@@ -77,7 +77,7 @@ IRInst* IRTypeSet::cloneInst(IRInst* inst)
         return inst;
     }
 
-    if (isNominalOp(inst->op))
+    if (isNominalOp(inst->getOp()))
     {
         // We can clone without any definition, and add the linkage
 
@@ -100,7 +100,7 @@ IRInst* IRTypeSet::cloneInst(IRInst* inst)
     // it's no use
 
     IRInst* clone = nullptr;
-    switch (inst->op)
+    switch (inst->getOp())
     {
         case kIROp_IntLit:
         {
@@ -143,9 +143,9 @@ IRInst* IRTypeSet::cloneInst(IRInst* inst)
 
     if (!clone)
     {
-        if (IRBasicType::isaImpl(inst->op))
+        if (IRBasicType::isaImpl(inst->getOp()))
         {
-            clone = m_builder.getType(inst->op);
+            clone = m_builder.getType(inst->getOp());
         }
         else
         {
@@ -168,7 +168,7 @@ IRInst* IRTypeSet::cloneInst(IRInst* inst)
                 UInt operandCounts[1] = { UInt(operandCount) };
                 IRInst*const* listOperands[1] = { cloneOperands.getBuffer() };
 
-                clone = m_builder.findOrAddInst(clonedType, inst->op, 1, operandCounts, listOperands);
+                clone = m_builder.findOrAddInst(clonedType, inst->getOp(), 1, operandCounts, listOperands);
             }
             else
             {
@@ -176,7 +176,7 @@ IRInst* IRTypeSet::cloneInst(IRInst* inst)
                 auto clonedType = cloneType(inst->getFullType());
 
                 Index operandCount = Index(inst->getOperandCount());
-                clone = m_builder.emitIntrinsicInst(clonedType, inst->op, operandCount, nullptr);
+                clone = m_builder.emitIntrinsicInst(clonedType, inst->getOp(), operandCount, nullptr);
                 for (Index i = 0; i < operandCount; ++i)
                 {
                     auto cloneOperand = cloneInst(inst->getOperand(i));
@@ -278,7 +278,7 @@ static bool _hasNominalOperand(IRInst* inst)
     for (Index i = 0; i < operandCount; ++i)
     {
         IRInst* operand = operands[i].get();
-        if (isNominalOp(operand->op))
+        if (isNominalOp(operand->getOp()))
         {
             return true;
         }

--- a/source/slang/slang-ir-union.cpp
+++ b/source/slang/slang-ir-union.cpp
@@ -178,7 +178,7 @@ struct DesugarUnionTypesContext
     //
     void processInst(IRInst* inst)
     {
-        switch( inst->op )
+        switch( inst->getOp() )
         {
         default:
             // Any instruction not listed below either doesn't involve union types,

--- a/source/slang/slang-ir-witness-table-wrapper.cpp
+++ b/source/slang/slang-ir-witness-table-wrapper.cpp
@@ -163,7 +163,7 @@ namespace Slang
             }
             else
             {
-                if (call->getDataType()->op == kIROp_VoidType)
+                if (call->getDataType()->getOp() == kIROp_VoidType)
                     builder->emitReturn();
                 else
                     builder->emitReturn(call);

--- a/source/slang/slang-ir-wrap-structured-buffers.cpp
+++ b/source/slang/slang-ir-wrap-structured-buffers.cpp
@@ -113,7 +113,7 @@ struct WrapStructuredBuffersContext
         // replacing one type A with another type B globally, and doing
         // so could affect any type that in turn referenced A...
         //
-        auto newStructuredBufferType = builder->getType(oldStructuredBufferType->op, wrapperStruct);
+        auto newStructuredBufferType = builder->getType(oldStructuredBufferType->getOp(), wrapperStruct);
         oldStructuredBufferType->replaceUsesWith(newStructuredBufferType);
 
         // Any values that used our old structured bufer type
@@ -280,7 +280,7 @@ struct WrapStructuredBuffersContext
                         // non-pointer case above, so please refer
                         // there if you want the comments.
 
-                        auto newResultType = builder->getPtrType(oldPtrType->op, wrapperStruct);
+                        auto newResultType = builder->getPtrType(oldPtrType->getOp(), wrapperStruct);
                         builder->setDataType(call, newResultType);
 
                         auto newVal = builder->emitFieldAddress(oldResultType, call, wrappedFieldKey);

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -312,7 +312,9 @@ public:
 struct IRInst
 {
     // The operation that this value represents
-    IROp op;
+    IROp m_op;
+
+    IROp getOp() const { return m_op; }
 
     // The total number of operands of this instruction.
     //
@@ -531,7 +533,7 @@ struct IRInst
 template<typename T>
 T* dynamicCast(IRInst* inst)
 {
-    if (inst && T::isaImpl(inst->op))
+    if (inst && T::isaImpl(inst->getOp()))
         return static_cast<T*>(inst);
     return nullptr;
 }
@@ -609,7 +611,7 @@ IRType* unwrapArray(IRType* type);
 
 struct IRBasicType : IRType
 {
-    BaseType getBaseType() { return BaseType(op - kIROp_FirstBasicType); }
+    BaseType getBaseType() { return BaseType(getOp() - kIROp_FirstBasicType); }
 
     IR_PARENT_ISA(BasicType)
 };
@@ -930,7 +932,7 @@ struct IRResourceTypeBase : IRType
 {
     TextureFlavor getFlavor() const
     {
-        return TextureFlavor((op >> kIROpMeta_OtherShift) & 0xFFFF);
+        return TextureFlavor((getOp() >> kIROpMeta_OtherShift) & 0xFFFF);
     }
 
     TextureFlavor::Shape GetBaseShape() const

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -541,7 +541,7 @@ T* dynamicCast(IRInst* inst)
 template<typename T>
 const T* dynamicCast(const IRInst* inst)
 {
-    if (inst && T::isaImpl(inst->op))
+    if (inst && T::isaImpl(inst->getOp()))
         return static_cast<const T*>(inst);
     return nullptr;
 }

--- a/source/slang/slang-legalize-types.cpp
+++ b/source/slang/slang-legalize-types.cpp
@@ -876,7 +876,7 @@ static LegalType createLegalUniformBufferType(
 {
     return createLegalUniformBufferType(
         context,
-        uniformBufferType->op,
+        uniformBufferType->getOp(),
         legalElementType);
 }
 
@@ -990,7 +990,7 @@ struct ArrayLegalTypeWrapper : LegalTypeWrapper
     LegalType wrap(TypeLegalizationContext* context, IRType* type)
     {
         return LegalType::simple(context->getBuilder()->getArrayTypeBase(
-            arrayType->op,
+            arrayType->getOp(),
             type,
             arrayType->getElementCount()));
     }
@@ -1151,7 +1151,7 @@ LegalType legalizeTypeImpl(
             // be handled by the pass-specific logic in the context.
             //
             return context->createLegalUniformBufferType(
-                uniformBufferType->op,
+                uniformBufferType->getOp(),
                 legalElementType);
         }
 
@@ -1225,7 +1225,7 @@ LegalType legalizeTypeImpl(
         if (legalValueType.flavor == LegalType::Flavor::simple &&
             legalValueType.getSimple() == ptrType->getValueType())
             return LegalType::simple(ptrType);
-        return createLegalPtrType(context, ptrType->op, legalValueType);
+        return createLegalPtrType(context, ptrType->getOp(), legalValueType);
     }
     else if(auto structType = as<IRStructType>(type))
     {

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -5963,7 +5963,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         for (auto constraintDecl : decl->getMembersOfType<GenericTypeConstraintDecl>())
         {
             auto baseType = lowerType(context, constraintDecl->sup.type);
-            SLANG_ASSERT(baseType && baseType->op == kIROp_InterfaceType);
+            SLANG_ASSERT(baseType && baseType->getOp() == kIROp_InterfaceType);
             constraintInterfaces.add((IRInterfaceType*)baseType);
         }
         auto assocType = context->irBuilder->getAssociatedType(
@@ -6039,7 +6039,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             IRInst* requirementVal = ensureDecl(subContext, requirementDecl).val;
             if (requirementVal)
             {
-                switch (requirementVal->op)
+                switch (requirementVal->getOp())
                 {
                 case kIROp_Func:
                 case kIROp_Generic:
@@ -8038,7 +8038,7 @@ struct SpecializedComponentTypeIRGenContext : ComponentTypeVisitor
                     auto irType = lowerSimpleVal(context, specializationArg.val);
                     auto irWitness = lowerSimpleVal(context, specializationArg.witness);
 
-                    if (irType->op != kIROp_DynamicType)
+                    if (irType->getOp() != kIROp_DynamicType)
                         hasConcreteTypeArg = true;
 
                     irSlotArgs.add(irType);

--- a/source/slang/slang-serialize-ir.cpp
+++ b/source/slang/slang-serialize-ir.cpp
@@ -190,7 +190,7 @@ Result IRSerialWriter::write(IRModule* module, SerialSourceLocWriter* sourceLocW
             IRInst* srcInst = m_insts[i];
             Ser::Inst& dstInst = m_serialData->m_insts[i];
 
-            dstInst.m_op = uint16_t(srcInst->op & kIROpMeta_OpMask);
+            dstInst.m_op = uint16_t(srcInst->getOp() & kIROpMeta_OpMask);
             dstInst.m_payloadType = PayloadType::Empty;
             
             dstInst.m_resultTypeIndex = getInstIndex(srcInst->getFullType());
@@ -198,7 +198,7 @@ Result IRSerialWriter::write(IRModule* module, SerialSourceLocWriter* sourceLocW
             IRConstant* irConst = as<IRConstant>(srcInst);
             if (irConst)
             {
-                switch (srcInst->op)
+                switch (srcInst->getOp())
                 {
                     // Special handling for the ir const derived types
                     case kIROp_StringLit:
@@ -245,7 +245,7 @@ Result IRSerialWriter::write(IRModule* module, SerialSourceLocWriter* sourceLocW
             if (textureBase)
             {
                 dstInst.m_payloadType = PayloadType::OperandAndUInt32;
-                dstInst.m_payload.m_operandAndUInt32.m_uint32 = uint32_t(srcInst->op) >> kIROpMeta_OtherShift;
+                dstInst.m_payload.m_operandAndUInt32.m_uint32 = uint32_t(srcInst->getOp()) >> kIROpMeta_OtherShift;
                 dstInst.m_payload.m_operandAndUInt32.m_operand = getInstIndex(textureBase->getElementType());
                 continue;
             }
@@ -793,7 +793,7 @@ Result IRSerialReader::read(const IRSerialData& data, Session* session, SerialSo
 
             // Reintroduce the texture type bits into the the
             const uint32_t other = srcInst.m_payload.m_operandAndUInt32.m_uint32;
-            inst->op = IROp(uint32_t(inst->op) | (other << kIROpMeta_OtherShift));
+            inst->m_op = IROp(uint32_t(inst->getOp()) | (other << kIROpMeta_OtherShift));
 
             insts[i] = inst;
         }


### PR DESCRIPTION
This main changing is renaming `IRInst::op` over to `IRInst::m_op` and then adds an accessor `IRInst::getOp()` to read it. The rest of the changes are just changing use sites to `getOp` (or to `m_op` in the limited cases where we write to it).

This work is in anticipation of a future change that might need to store an extra bit in the same field as the opcode. It seemed better to do this massive refactoring as a separate PR.