### PR TITLE
Streamline shader object creation

### DIFF
--- a/examples/shader-object/main.cpp
+++ b/examples/shader-object/main.cpp
@@ -196,16 +196,12 @@ int main()
 
     // Next, we create a shader object that represents the transformer we want to use.
     // To do so, we first need to lookup for the `AddTransformer` type defined in the shader code.
-    ComPtr<gfx::IShaderObject> transformer;
-    ComPtr<gfx::IShaderObjectLayout> transformerObjectLayout;
-    slang::TypeLayoutReflection* addTransformerTypeLayout = slangReflection->getTypeLayout(
-        slangReflection->findTypeByName("AddTransformer"));
+    slang::TypeReflection* addTransformerType = slangReflection->findTypeByName("AddTransformer");
 
     // Now we can use this type to create a shader object that can be bound to the root object.
-    SLANG_RETURN_ON_FAIL(renderer->createShaderObjectLayout(
-        addTransformerTypeLayout, transformerObjectLayout.writeRef()));
+    ComPtr<gfx::IShaderObject> transformer;
     SLANG_RETURN_ON_FAIL(
-        renderer->createShaderObject(transformerObjectLayout, transformer.writeRef()));
+        renderer->createShaderObject(addTransformerType, transformer.writeRef()));
     // Set the `c` field of the `AddTransformer`.
     float c = 1.0f;
     gfx::ShaderCursor(transformer).getPath("c").setData(&c, sizeof(float));

--- a/tools/gfx/cuda/render-cuda.cpp
+++ b/tools/gfx/cuda/render-cuda.cpp
@@ -1348,8 +1348,9 @@ private:
         return SLANG_OK;
     }
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL createShaderObjectLayout(
-        slang::TypeLayoutReflection* typeLayout, IShaderObjectLayout** outLayout) override
+    virtual Result createShaderObjectLayout(
+        slang::TypeLayoutReflection*    typeLayout,
+        ShaderObjectLayoutBase**        outLayout) override
     {
         RefPtr<CUDAShaderObjectLayout> cudaLayout;
         cudaLayout = new CUDAShaderObjectLayout(this, typeLayout);
@@ -1357,9 +1358,11 @@ private:
         return SLANG_OK;
     }
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL
-        createShaderObject(IShaderObjectLayout* layout, IShaderObject** outObject) override
+    virtual SLANG_NO_THROW Result SLANG_MCALL createShaderObject(
+        ShaderObjectLayoutBase* layout,
+        IShaderObject**         outObject) override
     {
+
         RefPtr<CUDAShaderObject> result = new CUDAShaderObject();
         SLANG_RETURN_ON_FAIL(result->init(this, dynamic_cast<CUDAShaderObjectLayout*>(layout)));
         *outObject = result.detach();

--- a/tools/gfx/render-graphics-common.cpp
+++ b/tools/gfx/render-graphics-common.cpp
@@ -26,7 +26,7 @@ public:
 
     struct SubObjectRangeInfo
     {
-        ComPtr<GraphicsCommonShaderObjectLayout> layout;
+        RefPtr<GraphicsCommonShaderObjectLayout> layout;
         //        Index                       baseIndex;
         //        Index                       count;
         Index bindingRangeIndex;
@@ -317,7 +317,7 @@ public:
         SlangResult build(GraphicsCommonShaderObjectLayout** outLayout)
         {
             auto layout =
-                ComPtr<GraphicsCommonShaderObjectLayout>(new GraphicsCommonShaderObjectLayout());
+                RefPtr<GraphicsCommonShaderObjectLayout>(new GraphicsCommonShaderObjectLayout());
             SLANG_RETURN_ON_FAIL(layout->_init(this));
 
             *outLayout = layout.detach();
@@ -980,7 +980,7 @@ protected:
     Result _writeOrdinaryData(char* dest, size_t destSize)
     {
         auto src = m_ordinaryData.getBuffer();
-        auto srcSize = m_ordinaryData.getCount();
+        auto srcSize = size_t(m_ordinaryData.getCount());
 
         SLANG_ASSERT(srcSize <= destSize);
 
@@ -1374,8 +1374,9 @@ protected:
 };
 
 
-Result SLANG_MCALL GraphicsAPIRenderer::createShaderObjectLayout(
-    slang::TypeLayoutReflection* typeLayout, IShaderObjectLayout** outLayout)
+Result GraphicsAPIRenderer::createShaderObjectLayout(
+    slang::TypeLayoutReflection* typeLayout,
+    ShaderObjectLayoutBase** outLayout)
 {
     RefPtr<GraphicsCommonShaderObjectLayout> layout;
     SLANG_RETURN_ON_FAIL(GraphicsCommonShaderObjectLayout::createForElementType(
@@ -1384,8 +1385,9 @@ Result SLANG_MCALL GraphicsAPIRenderer::createShaderObjectLayout(
     return SLANG_OK;
 }
 
-Result SLANG_MCALL
-    GraphicsAPIRenderer::createShaderObject(IShaderObjectLayout* layout, IShaderObject** outObject)
+Result GraphicsAPIRenderer::createShaderObject(
+    ShaderObjectLayoutBase* layout,
+    IShaderObject** outObject)
 {
     RefPtr<GraphicsCommonShaderObject> shaderObject;
     SLANG_RETURN_ON_FAIL(GraphicsCommonShaderObject::create(this,

--- a/tools/gfx/render-graphics-common.h
+++ b/tools/gfx/render-graphics-common.h
@@ -20,10 +20,12 @@ private:
 class GraphicsAPIRenderer : public RendererBase
 {
 public:
-    virtual SLANG_NO_THROW Result SLANG_MCALL createShaderObjectLayout(
-        slang::TypeLayoutReflection* typeLayout, IShaderObjectLayout** outLayout) SLANG_OVERRIDE;
-    virtual SLANG_NO_THROW Result SLANG_MCALL
-        createShaderObject(IShaderObjectLayout* layout, IShaderObject** outObject) SLANG_OVERRIDE;
+    virtual Result createShaderObjectLayout(
+        slang::TypeLayoutReflection*    typeLayout,
+        ShaderObjectLayoutBase**        outLayout) SLANG_OVERRIDE;
+    virtual Result createShaderObject(
+        ShaderObjectLayoutBase* layout,
+        IShaderObject**         outObject) SLANG_OVERRIDE;
     virtual SLANG_NO_THROW Result SLANG_MCALL createRootShaderObject(
         IShaderProgram* program,
         IShaderObject** outObject) SLANG_OVERRIDE;

--- a/tools/gfx/render.h
+++ b/tools/gfx/render.h
@@ -840,14 +840,6 @@ struct ShaderOffset
     SlangInt bindingArrayIndex = 0;
 };
 
-class IShaderObjectLayout : public ISlangUnknown
-{};
-#define SLANG_UUID_IShaderObjectLayout                                                 \
-    {                                                                                 \
-        0x27f3f67e, 0xa49d, 0x4aae, { 0xa6, 0xd, 0xfa, 0xc2, 0x6b, 0x1c, 0x10, 0x7c } \
-    }
-
-
 class IShaderObject : public ISlangUnknown
 {
 public:
@@ -1220,22 +1212,12 @@ public:
         return layout;
     }
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL createShaderObjectLayout(
-        slang::TypeLayoutReflection* typeLayout, IShaderObjectLayout** outLayout) = 0;
+    virtual SLANG_NO_THROW Result SLANG_MCALL createShaderObject(slang::TypeReflection* type, IShaderObject** outObject) = 0;
 
-    inline ComPtr<IShaderObjectLayout> createShaderObjectLayout(slang::TypeLayoutReflection* typeLayout)
-    {
-        ComPtr<IShaderObjectLayout> layout;
-        SLANG_RETURN_NULL_ON_FAIL(createShaderObjectLayout(typeLayout, layout.writeRef()));
-        return layout;
-    }
-
-    virtual SLANG_NO_THROW Result SLANG_MCALL createShaderObject(IShaderObjectLayout* layout, IShaderObject** outObject) = 0;
-
-    inline ComPtr<IShaderObject> createShaderObject(IShaderObjectLayout* layout)
+    inline ComPtr<IShaderObject> createShaderObject(slang::TypeReflection* type)
     {
         ComPtr<IShaderObject> object;
-        SLANG_RETURN_NULL_ON_FAIL(createShaderObject(layout, object.writeRef()));
+        SLANG_RETURN_NULL_ON_FAIL(createShaderObject(type, object.writeRef()));
         return object;
     }
 

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -397,14 +397,13 @@ SlangResult _assignVarsFromLayout(
         case ShaderInputType::Object:
             {
                 auto typeName = entry.objectDesc.typeName;
-                slang::TypeLayoutReflection* slangTypeLayout = nullptr;
+                slang::TypeReflection* slangType = nullptr;
                 if(typeName.getLength() != 0)
                 {
                     // If the input line specified the name of the type
                     // to allocate, then we use it directly.
                     //
-                    auto slangType = slangReflection->findTypeByName(typeName.getBuffer());
-                    slangTypeLayout = slangReflection->getTypeLayout(slangType);
+                    slangType = slangReflection->findTypeByName(typeName.getBuffer());
                 }
                 else
                 {
@@ -412,7 +411,7 @@ SlangResult _assignVarsFromLayout(
                     // then we will infer the type from the type of the
                     // value pointed to by `entryCursor`.
                     //
-                    slangTypeLayout = entryCursor.getTypeLayout();
+                    auto slangTypeLayout = entryCursor.getTypeLayout();
                     switch(slangTypeLayout->getKind())
                     {
                     default:
@@ -428,11 +427,11 @@ SlangResult _assignVarsFromLayout(
                         slangTypeLayout = slangTypeLayout->getElementTypeLayout();
                         break;
                     }
+                    slangType = slangTypeLayout->getType();
                 }
 
-                ComPtr<IShaderObjectLayout> shaderObjectLayout = renderer->createShaderObjectLayout(slangTypeLayout);
                 ComPtr<IShaderObject> shaderObject =
-                    renderer->createShaderObject(shaderObjectLayout);
+                    renderer->createShaderObject(slangType);
 
                 entryCursor.setObject(shaderObject);
             }


### PR DESCRIPTION
This change kind of rolls together two different simplifications:

1. The `createShaderObject()` shouldn't really need to take an `IShaderObjectLayout` because it could just take the `slang::TypeLayoutReflection` instead and create the shader-object layout behind the scenes.

2. For that matter, it needn't take a `slang::TypeLayoutReflection` either, becaues it could just take a `slang::TypeReflection` and query the layout of that type behind the scenes.

The combination of these two changes means:

* `IShaderObjectLayout` is gone from the public API, as is `createShaderObjectLayout()`

* `createShaderObject()` directly takes a `slang::TypeReflection` and allocates a shader object of that type

The result is simpler and more streamlined application code.

Note that under the hood the implementation still has shader-object layouts, using the `ShaderObjectLayoutBase` class. A few locations had to change to use `RefPtr`s instead of `ComPtr`s now that the class is no longer a public COM-lite API type.

The hope is that this change makes it easier to allocate/cache layouts for things like specialized types "under the hood," as is needed to implement parameter setting for static specialization.