### PR TITLE
Shader object specialization work-in-progress

### DIFF
--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -365,6 +365,10 @@ public:
 
     virtual SLANG_NO_THROW Result SLANG_MCALL createShaderObject(slang::TypeReflection* type, IShaderObject** outObject) SLANG_OVERRIDE;
 
+    Result getShaderObjectLayout(
+        slang::TypeReflection*      type,
+        ShaderObjectLayoutBase**    outLayout);
+
 protected:
     // Retrieves the currently bound unspecialized pipeline.
     // If the bound pipeline is not created from a Slang component, an implementation should return null.
@@ -377,10 +381,6 @@ protected:
     virtual Result createShaderObjectLayout(
         slang::TypeLayoutReflection* typeLayout,
         ShaderObjectLayoutBase** outLayout) = 0;
-
-    Result getShaderObjectLayout(
-        slang::TypeReflection*      type,
-        ShaderObjectLayoutBase**    outLayout);
 
     virtual Result createShaderObject(
         ShaderObjectLayoutBase* layout,


### PR DESCRIPTION
The biggest change here is that the common graphics-API implementation of shader objects now handles `setObject()` cases where the value is being set for an existential-type field *and* the value being set fits into the any-value payload. In that case the content of the object being assigned gets copied into the any-value payload and tests that use static specialization with types that "fit" should work.

The other smaller change is that we now compute a specialized layout for a shader object when the time comes to fill int its ordinary/uniform data, and the size of the GPU buffer that is allocated is based on the *specialized* layout and not the original layout. This change means that the allocated GPU buffer will include space for any "pending" data that needed to be allocated outside of the original type layout.

Note that the logic for computing and using a specialized layout is only included in the graphics-API path and not in the CUDA path; nor would it be included in our CPU back-end. On platforms with pervasive "bindless" support (such that resource types are just ordinary types), and general-purpose support for indirection through pointers, there is no need to deal with the kind of layout schemes that result in "pending" data. On those platforms data that doesn't fit in the any-value payload should be referred to indirectly via a pointer.

The main missing features when it comes to supporting interface types are now:

* Nothing in the code is filling in the RTTI field; this requires querying and then caching the ID of types (probably as part of a shader-object layout). Writing type IDs into existential-type fields will be needed to get dynamic dispatch working. Note that RTTI type IDs could seemingly be used as an alternative to the "component IDs" that the code currently traffics in.

* Nothing in the code is writing witness table IDs either. That work would be similar to handling type IDs, but requires a bit more clever caching to avoid repeatedly running type-checking logic in the compiler runtime.

* The logic for recursively writing the ordinary bytes of a shader object into a buffer contains recursive logic for the case of sub-objects for existential-type fields that need to be writtne to an allocated range for "pending" data, but the relevant Slang reflection operations that would enable that code are not yet implemented and are thus being stubbed out for now.

* We are also missing the logic for recursively writing the resource ranges of sub-objects bound to interface-type fields into the descriptor set(s) of the parent object. The missing link there is again reflection API support; we need a way to get the binding range offset (and binding array stride) for the "pending" data of a specialized interface-type field.

* The logic for computing specialization arguments based on the shader objects bound to interface-type fields has a lot of holes. Some of the indexing math is flat-out incorrect, and it also doesn't make any attempt to handle sub-object ranges with more than one element in them.