### PR TITLE
Add basic support for fragment shader interlock (FSI)

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1943,6 +1943,18 @@ __target_intrinsic(cuda, " @ ")
 __target_intrinsic(cpp, " @ ")
 int __SyntaxError();
 
+/// Mark beginning of "interlocked" operations in a fragment shader.
+__target_intrinsic(glsl, "beginInvocationInterlockARB")
+__glsl_extension(GL_ARB_fragment_shader_interlock)
+__glsl_version(420)
+void beginInvocationInterlock() {}
+
+/// Mark end of "interlocked" operations in a fragment shader.
+__target_intrinsic(glsl, "endInvocationInterlockARB")
+__glsl_extension(GL_ARB_fragment_shader_interlock)
+__glsl_version(420)
+void endInvocationInterlock() {}
+
 // Operators to apply to `enum` types
 
 __generic<E : __EnumType>

--- a/tests/pipeline/rasterization/fragment-shader-interlock.slang
+++ b/tests/pipeline/rasterization/fragment-shader-interlock.slang
@@ -1,0 +1,20 @@
+// fragment-shader-interlock.slang
+
+// Test that explicit use of fragment-shader interlock (FSI)
+// operations is supported by Slang
+
+//TEST:CROSS_COMPILE:-target spirv -entry main -stage fragment
+
+[shader("fragment")]
+void main(
+    float4 coords : COORDS,
+    uniform RasterizerOrderedTexture2D<float4> texture,
+    out float4 result : SV_Target)
+{
+    beginInvocationInterlock();
+
+    result = texture[coords.xy];
+    texture[coords.xy] = result + coords;
+
+    endInvocationInterlock();
+}

--- a/tests/pipeline/rasterization/fragment-shader-interlock.slang.glsl
+++ b/tests/pipeline/rasterization/fragment-shader-interlock.slang.glsl
@@ -1,0 +1,31 @@
+//TEST_IGNORE_FILE:
+
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(rgba32f)
+layout(binding = 0)
+uniform image2D entryPointParams_texture_0;
+
+layout(location = 0)
+in vec4 _S1;
+
+layout(location = 0)
+out vec4 _S2;
+
+void main()
+{
+    vec4 _S3;
+
+    beginInvocationInterlockARB();
+
+    vec4 _S4 = (imageLoad((entryPointParams_texture_0), ivec2((uvec2(_S1.xy)))));
+
+    _S3 = _S4;
+    imageStore((entryPointParams_texture_0), ivec2((uvec2(_S1.xy))), _S3 + _S1);
+
+    endInvocationInterlockARB();
+
+    _S2 = _S3;
+    return;
+}


### PR DESCRIPTION
Both D3D "rasterizer ordered views" (ROVs) and GLSL "fragment shader interlock" (FSI) are aimed at the same basic use case: they allow for fragment shaders to contain operations that require mutual exclusion and/or deterinistics ordering between fragment shader invocations that affect the same framebuffer coordinates. The language-level exposure of the features varies greatly between the two API families, though:

* ROVs define an implicit ordering and mutual exclusion constraint: certain resoure parameters are marked as `RasterizerOrdered`, and reads/writes to these resources must be sequences *as if* fragment-shader invocations ran in sequential order for each pixel.

* FSI defines paired begin/end functions that mark a critical section of code. All memory operations in the critical section must be sequences *as if* fragment-shader invocations ran in sequential order for each pixel. In order to make this model tractable, only a single critical section is allowed per fragment shader, and the begin/end must appear at the top level of the shader entry point function (not under control flow or after a possible conditional `return`.

The simplest way for Slang to support portable programs that run across both API families is to insist that code that cares about these ordering guarantees must use *both* mechanisms, and then each of them will only affect the API that cares about it.

Slang already supports ROV resource types, and already lowers them to plain textures for GLSL/SPIR-V.
This change adds the missing feature of a begin/end function pair for FSI, which will map to empty functions on non-GLSL targets.