### PR TITLE
Add support for GetAttributeAtVertex for D3D

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -1805,6 +1805,61 @@ matrix<T, N, M> fwidth(matrix<T, N, M> x)
     MATRIX_MAP_UNARY(T, N, M, fwidth, x);
 }
 
+/// Get the value of a vertex attribute at a specific vertex.
+///
+/// The `GetAttributeAtVertex()` function can be used in a fragment shader
+/// to get the value of the given `attribute` at the vertex of the primitive
+/// that corresponds to the given `vertexIndex`.
+///
+/// Note that the `attribute` must have been a declared varying input to
+/// the fragment shader with the `nointerpolation` modifier.
+///
+/// This function can be applied to scalars, vectors, and matrices of
+/// built-in scalar types.
+///
+/// Note: these functions are not curently implemented for Vulkan/SPIR-V output.
+///
+__generic<T : __BuiltinType>
+[__readNone]
+T GetAttributeAtVertex(T attribute, uint vertexIndex);
+
+/// Get the value of a vertex attribute at a specific vertex.
+///
+/// The `GetAttributeAtVertex()` function can be used in a fragment shader
+/// to get the value of the given `attribute` at the vertex of the primitive
+/// that corresponds to the given `vertexIndex`.
+///
+/// Note that the `attribute` must have been a declared varying input to
+/// the fragment shader with the `nointerpolation` modifier.
+///
+/// This function can be applied to scalars, vectors, and matrices of
+/// built-in scalar types.
+///
+/// Note: these functions are not curently implemented for Vulkan/SPIR-V output.
+///
+__generic<T : __BuiltinType, let N : int>
+[__readNone]
+vector<T,N> GetAttributeAtVertex(vector<T,N> attribute, uint vertexIndex);
+
+/// Get the value of a vertex attribute at a specific vertex.
+///
+/// The `GetAttributeAtVertex()` function can be used in a fragment shader
+/// to get the value of the given `attribute` at the vertex of the primitive
+/// that corresponds to the given `vertexIndex`.
+///
+/// Note that the `attribute` must have been a declared varying input to
+/// the fragment shader with the `nointerpolation` modifier.
+///
+/// This function can be applied to scalars, vectors, and matrices of
+/// built-in scalar types.
+///
+/// Note: these functions are not curently implemented for Vulkan/SPIR-V output.
+///
+__generic<T : __BuiltinType, let N : int, let M : int>
+[__readNone]
+matrix<T,N,M> GetAttributeAtVertex(matrix<T,N,M> attribute, uint vertexIndex);
+
+
 // Get number of samples in render target
 uint GetRenderTargetSampleCount();
 

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -2663,6 +2663,18 @@ void CLikeSourceEmitter::emitSimpleFuncParamImpl(IRParam* param)
     auto paramName = getName(param);
     auto paramType = param->getDataType();
 
+    if(auto layoutDecoration = param->findDecoration<IRLayoutDecoration>() )
+    {
+        auto layout = as<IRVarLayout>(layoutDecoration->getLayout());
+        SLANG_ASSERT(layout);
+
+        if(layout->usesResourceKind(LayoutResourceKind::VaryingInput)
+            || layout->usesResourceKind(LayoutResourceKind::VaryingOutput))
+        {
+            emitInterpolationModifiers(param, paramType, layout);
+        }
+    }
+
     emitParamType(paramType, paramName);
     emitSemantics(param);
 }

--- a/tests/pipeline/rasterization/get-attribute-at-vertex.slang
+++ b/tests/pipeline/rasterization/get-attribute-at-vertex.slang
@@ -1,0 +1,16 @@
+// get-attribute-at-vertex.slang
+
+// Basic test for `GetAttributeAtVertex` function
+
+//TEST:CROSS_COMPILE:-target dxil -entry main -stage fragment -profile sm_6_1
+
+[shader("fragment")]
+void main(
+    nointerpolation float4 color : COLOR,
+    float3 bary : SV_Barycentrics,
+    out float4 result : SV_Target)
+{
+    result = bary.x * GetAttributeAtVertex(color, 0)
+           + bary.y * GetAttributeAtVertex(color, 1)
+           + bary.z * GetAttributeAtVertex(color, 2);
+}

--- a/tests/pipeline/rasterization/get-attribute-at-vertex.slang.hlsl
+++ b/tests/pipeline/rasterization/get-attribute-at-vertex.slang.hlsl
@@ -1,0 +1,14 @@
+// get-attribute-at-vertex.slang.hlsl
+
+//TEST_IGNORE_FILE:
+
+[shader("pixel")]
+void main(
+    nointerpolation vector<float,4> color_0 : COLOR,
+    vector<float,3> bary_0 : SV_BARYCENTRICS,
+    out vector<float,4> result_0 : SV_TARGET)
+{
+    result_0 = bary_0.x * GetAttributeAtVertex(color_0, (uint) int(0))
+             + bary_0.y * GetAttributeAtVertex(color_0, (uint) int(1))
+             + bary_0.z * GetAttributeAtVertex(color_0, (uint) int(2));
+}


### PR DESCRIPTION
This operation was added along with the `SV_Barycentrics` system-value input, and allows for a `nointerpolation` varying input to a fragment shader to be fetched at a specific vertex index within the primitive that is causing the fragment shader to be invoked.

This change adds support for the new operations in the standard library, and also includes a test case to make sure that we emit it correctly when producing HLSL/DXIL.

This change also includes a small bug fix to our emission logic for function parameters so that we properly emit layout-related attributes for varying parameters declared directly on an entry point.
(Note that most attribute end up being declared in `struct` types in existing HLSL shaders, and our IR passes produce only global variables for attributes on GLSL; the only case this affects is inidividual scalar/vector attributes declared declared as entry-point parameters, when outputting HLSL)

Note that this change only adds support for the new function on the HLSL/DXIL path, and doesn't yet add any cross-compilation support for GLSL/SPIR-V. The reason for this is that the equivalent GLSL feature(s) appear to use a different model to the HLSL version, and we need to invent a suitable approach to align them to make portable code possible.