### PR TITLE
Partial fix for macro expasnion of token pastes

### DIFF
--- a/tests/preprocessor/if-macro-token-paste.slang
+++ b/tests/preprocessor/if-macro-token-paste.slang
@@ -1,0 +1,17 @@
+// if-macro.slang
+
+//TEST:SIMPLE:
+
+// Test that a `#if` test can invoke a function-like macro.
+//
+// Note: this test is a reproducer for a bug reported by a user.
+
+#define is_valid_TEST 1
+#define isValid(name) (is_valid_##name != 0)
+int test() {
+#if isValid(TEST)
+    return 1;
+#else
+    return NO_SUCH_SYMBOL;
+#endif
+}


### PR DESCRIPTION
The underlying problem here requires that we have an object-like macro with an expansion that starts with a non-identifier token:

```
```

Then we need a function-like macro that uses a token paste in a way that can expand to that object-like macro:

```
```

Finally, for the specific case a user ran into, we need to invoke that function-like macro in the context of a preprocessor conditional expression:

```
    // ...
    #error "unimplemented"
```

The way a problem manifest is that the preprocessor logic that handles conditional expressions tries to "peek" one token ahead and see what is coming, and while the peeking logic handles macro expansion it does *not* handle token pasting right now. That means that the peek operation sees `MY_FEATURE` and assumes that it is seeing an identifier in a preprocessor conditional that doesn't have a macro expansion. The logic then goes on to read the token, but what it gets back is *not* an identifier, and is instead the numeric literal token `1`, because the reading logic handles token pasting.

The quick fix I applied here is to make the logic that deals with preprocessor conditionals go ahead and automatically consume a token from the input, and then decide what to do based on that token, so that it always makes use of the reading logic that handles token pasting.

The lingering problem is that we still have cases in the preprocessor that use the peeking logic which doesn't handle pasting, and we might find that those cases have reason to want the same kind of expansion behavior we needed here. A more systematic fix would be to have the peeking logic automatically handle token pasting as well as macro expansion, but doing so would be a more complicated change because detecting the `##` when peeking ahead requires two tokens of lookahead, and our current implementation only assumes we can support one.