### PR TITLE
Change representation of initial data for textures

### DIFF
--- a/tools/gfx/cuda/render-cuda.cpp
+++ b/tools/gfx/cuda/render-cuda.cpp
@@ -1365,7 +1365,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL createTextureResource(
         IResource::Usage initialUsage,
         const ITextureResource::Desc& desc,
-        const ITextureResource::Data* initData,
+        const ITextureResource::SubresourceData* initData,
         ITextureResource** outResource) override
     {
         RefPtr<TextureCUDAResource> tex = new TextureCUDAResource(desc);
@@ -1611,7 +1611,7 @@ public:
                 {
                     for (Index j = 0; j < faceCount; j++)
                     {
-                        const auto srcData = initData->subResources[mipLevel + j * desc.numMipLevels];
+                        const auto srcData = initData[mipLevel + j * desc.numMipLevels].data;
                         // Copy over to the workspace to make contiguous
                         ::memcpy(
                             workspace.begin() + faceSizeInBytes * j, srcData,
@@ -1633,7 +1633,7 @@ public:
                     for (Index j = 0; j < 6; j++)
                     {
                         const auto srcData =
-                            initData->subResources[mipLevel + j * desc.numMipLevels];
+                            initData[mipLevel + j * desc.numMipLevels].data;
                         ::memcpy(
                             workspace.getBuffer() + faceSizeInBytes * j, srcData,
                             faceSizeInBytes);
@@ -1643,7 +1643,7 @@ public:
                 }
                 else
                 {
-                    const auto srcData = initData->subResources[mipLevel];
+                    const auto srcData = initData[mipLevel].data;
                     srcDataPtr = srcData;
                 }
             }

--- a/tools/gfx/open-gl/render-gl.cpp
+++ b/tools/gfx/open-gl/render-gl.cpp
@@ -106,7 +106,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL createTextureResource(
         IResource::Usage initialUsage,
         const ITextureResource::Desc& desc,
-        const ITextureResource::Data* initData,
+        const ITextureResource::SubresourceData* initData,
         ITextureResource** outResource) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createBufferResource(
         IResource::Usage initialUsage,
@@ -1450,7 +1450,7 @@ SLANG_NO_THROW Result SLANG_MCALL GLDevice::readTextureResource(
 SLANG_NO_THROW Result SLANG_MCALL GLDevice::createTextureResource(
     IResource::Usage initialUsage,
     const ITextureResource::Desc& descIn,
-    const ITextureResource::Data* initData,
+    const ITextureResource::SubresourceData* initData,
     ITextureResource** outResource)
 {
     TextureResource::Desc srcDesc(descIn);
@@ -1479,6 +1479,10 @@ SLANG_NO_THROW Result SLANG_MCALL GLDevice::createTextureResource(
     // Set on texture so will be freed if failure
     texture->m_handle = handle;
 
+    // TODO: The logic below seems to be ignoring the row/layer stride of
+    // the subresources that have been passed in, despite OpenGL having
+    // the ability to set the image unpack stride, etc.
+
     switch (srcDesc.type)
     {
         case IResource::Type::Texture1D:
@@ -1493,6 +1497,7 @@ SLANG_NO_THROW Result SLANG_MCALL GLDevice::createTextureResource(
                 {
                     for (int j = 0; j < srcDesc.numMipLevels; j++)
                     {
+                        // TODO: Double-check this logic - we are passing in `i` as the height?
                         glTexImage2D(
                             target,
                             j,
@@ -1502,7 +1507,7 @@ SLANG_NO_THROW Result SLANG_MCALL GLDevice::createTextureResource(
                             0,
                             format,
                             formatType,
-                            initData ? initData->subResources[slice++] : nullptr);
+                            initData ? initData[slice++].data : nullptr);
                     }
                 }
             }
@@ -1520,7 +1525,7 @@ SLANG_NO_THROW Result SLANG_MCALL GLDevice::createTextureResource(
                         0,
                         format,
                         formatType,
-                        initData ? initData->subResources[i] : nullptr);
+                        initData ? initData[i].data : nullptr);
                 }
             }
             break;
@@ -1556,7 +1561,7 @@ SLANG_NO_THROW Result SLANG_MCALL GLDevice::createTextureResource(
                             0,
                             format,
                             formatType,
-                            initData ? initData->subResources[slice++] : nullptr);
+                            initData ? initData[slice++].data : nullptr);
                     }
                 }
             }
@@ -1581,7 +1586,7 @@ SLANG_NO_THROW Result SLANG_MCALL GLDevice::createTextureResource(
                                 0,
                                 format,
                                 formatType,
-                                initData ? initData->subResources[slice++] : nullptr);
+                                initData ? initData[slice++].data : nullptr);
                         }
                     }
                 }
@@ -1600,7 +1605,7 @@ SLANG_NO_THROW Result SLANG_MCALL GLDevice::createTextureResource(
                             0,
                             format,
                             formatType,
-                            initData ? initData->subResources[i] : nullptr);
+                            initData ? initData[i].data : nullptr);
                     }
                 }
             }
@@ -1622,7 +1627,7 @@ SLANG_NO_THROW Result SLANG_MCALL GLDevice::createTextureResource(
                     0,
                     format,
                     formatType,
-                    initData ? initData->subResources[i] : nullptr);
+                    initData ? initData[i].data : nullptr);
             }
             break;
         }

--- a/tools/platform/gui.cpp
+++ b/tools/platform/gui.cpp
@@ -217,14 +217,9 @@ GUI::GUI(
         desc.init2D(IResource::Type::Texture2D, Format::RGBA_Unorm_UInt8, width, height, 1);
         desc.setDefaults(IResource::Usage::PixelShaderResource);
 
-
-        ptrdiff_t mipRowStrides[] = { ptrdiff_t(width * 4 * sizeof(unsigned char)) };
-        void* subResourceData[] = { pixels };
-        ITextureResource::Data initData;
-        initData.mipRowStrides = mipRowStrides;
-        initData.numMips = 1;
-        initData.numSubResources = 1;
-        initData.subResources = subResourceData;
+        ITextureResource::SubresourceData initData = {};
+        initData.data = pixels;
+        initData.strideY = width * 4 * sizeof(unsigned char);
 
         auto texture =
             device->createTextureResource(IResource::Usage::PixelShaderResource, desc, &initData);

--- a/tools/platform/model.cpp
+++ b/tools/platform/model.cpp
@@ -128,13 +128,16 @@ ComPtr<ITextureResource> loadTextureImage(
     // results when loading the image with stb_image.
     }
 
-    std::vector<void*> subresourceInitData;
-    std::vector<ptrdiff_t> mipRowStrides;
+    std::vector<ITextureResource::SubresourceData> subresourceInitData;
 
     ptrdiff_t stride = extentX * channelCount * sizeof(stbi_uc);
 
-    subresourceInitData.push_back(data);
-    mipRowStrides.push_back(stride);
+    ITextureResource::SubresourceData baseInitData;
+    baseInitData.data = data;
+    baseInitData.strideY = stride;
+    baseInitData.strideZ = 0;
+
+    subresourceInitData.push_back(baseInitData);
 
     // create down-sampled images for the different mip levels
     bool generateMips = true;
@@ -166,8 +169,13 @@ ComPtr<ITextureResource> loadTextureImage(
                 STBIR_ALPHA_CHANNEL_NONE,
                 STBIR_FLAG_ALPHA_PREMULTIPLIED);
 
-            subresourceInitData.push_back(newData);
-            mipRowStrides.push_back(newStride);
+
+            ITextureResource::SubresourceData mipInitData;
+            mipInitData.data = newData;
+            mipInitData.strideY = newStride;
+            mipInitData.strideZ = 0;
+
+            subresourceInitData.push_back(mipInitData);
 
             prevExtentX = newExtentX;
             prevExtentY = newExtentY;
@@ -176,19 +184,13 @@ ComPtr<ITextureResource> loadTextureImage(
         }
     }
 
-    int mipCount = (int) mipRowStrides.size();
+    int mipCount = (int) subresourceInitData.size();
 
     ITextureResource::Desc desc;
     desc.init2D(IResource::Type::Texture2D, format, extentX, extentY, mipCount);
 
-    ITextureResource::Data initData;
-    initData.numSubResources = mipCount;
-    initData.numMips = mipCount;
-    initData.subResources = &subresourceInitData[0];
-    initData.mipRowStrides = &mipRowStrides[0];
-
     auto texture =
-        device->createTextureResource(IResource::Usage::PixelShaderResource, desc, &initData);
+        device->createTextureResource(IResource::Usage::PixelShaderResource, desc, subresourceInitData.data());
 
     free(data);
 


### PR DESCRIPTION
Before this change, initial data for a texture has been provided with the `ITextureResource::Data` type, where a call to `IDevice::createTexture()` would take zero or one `Data` and, if present, use it to initialize all the subresources of a texture.

The organization of `Data` was not actually quite how its own documentation comment described it (the implementations didn't agree with the comment), and while it aggressively factored out redundancies (e.g., only storing the stride for each mip level once, instead of once per subresource for large arrays), the result was that setting up a `Data` correcty was a bit confusing.

This change makes the initial data for a texture using a `SubresourceData` type that is almost identical to what D3D11 uses, so that developers are more likely to be comfortable filling it in. All of the existing implementations were easily adapted to use the new type, so it seems like a net win.

Note: Both Vulkan and D3D11 do away with the idea of initializing a texture with data as part of allocating it, and we might eventually want to do the same given the complexity that this system entails. The main reason to preserve this detail is for better compatibility with D3D11, where immutable textures/buffers need to have their data specified at creation time. It seems good to preserve the ability to have immutable resources on target APIs where this distinction could affect performance (e.g., immutable resources do not need state/transition tracking on APIs like D3D11).