### PR TITLE
Fix handling of RT accelerations structures for non-RT stages

### DIFF
--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -1831,17 +1831,13 @@ void GLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
                     // could provide the `accelerationSturctureEXT` type, but there
                     // can be drivers that provide only one and not the other.
                     //
-                    // Because we can't pick one upon just seeing the type, we need to
-                    // emit the type here but *not* call `_requireRayTracing()` or
-                    // anything like it, because we don't yet know the specific extension
-                    // we should ask for.
+                    // For now we will just kludge this by assuming that any driver
+                    // that supports one of these extensions supports the other.
                     //
-                    // TODO: We might eventually want to have this step set a flag that
-                    // will cause a compilation error if nothing else in the code requires
-                    // a specific concrete ray-tracing extension. Ideally all of these
-                    // details could be subusmed under the capability system sooner or
-                    // later.
-                    // 
+                    // TODO: Revisit that decision once the driver landscape is more stable/clear.
+                    //
+                    _requireRayTracing();
+
                     m_writer->emit("accelerationStructureEXT");
                 }
                 break;

--- a/tests/pipeline/ray-tracing/acceleration-structure-in-compute.slang
+++ b/tests/pipeline/ray-tracing/acceleration-structure-in-compute.slang
@@ -1,0 +1,20 @@
+// acceleration-structure-in-compute.slang
+
+// Test for using ray-tracing acceleration structures as a shader input
+// in non-ray-tracing shader code (that never actually traces rays)
+
+//TEST:CROSS_COMPILE:-target spirv-asm -stage compute -profile glsl_460+spirv_1_4 -entry main
+
+uniform RaytracingAccelerationStructure gScene;
+
+int helper(RaytracingAccelerationStructure a, int b)
+{
+    return b;
+}
+
+[shader("compute")]
+void main(
+    uniform RaytracingAccelerationStructure x)
+{
+    helper(x, 1);
+}

--- a/tests/pipeline/ray-tracing/acceleration-structure-in-compute.slang.glsl
+++ b/tests/pipeline/ray-tracing/acceleration-structure-in-compute.slang.glsl
@@ -1,0 +1,17 @@
+#version 460
+#extension GL_EXT_ray_tracing : require
+
+int helper_0(accelerationStructureEXT a_0, int b_0)
+{
+    return b_0;
+}
+
+layout(binding = 1)
+uniform accelerationStructureEXT entryPointParams_x_0;
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+void main()
+{
+    int _S1 = helper_0(entryPointParams_x_0, 1);
+    return;
+}

--- a/tests/pipeline/ray-tracing/trace-ray-inline.slang
+++ b/tests/pipeline/ray-tracing/trace-ray-inline.slang
@@ -1,7 +1,7 @@
 // trace-ray-inline.slang
 
 //TEST:CROSS_COMPILE:-target dxil-asm -stage compute -profile sm_6_5 -entry main
-//TEST:CROSS_COMPILE:-target spirv-asm -stage compute -profile sm_6_5 -entry main
+//TEST:CROSS_COMPILE:-target spirv-asm -stage compute -profile glsl_460+spirv_1_4 -entry main
 
 // The goal of this shader is to use all the main pieces
 // of functionality in DXR 1.1's `TraceRayInline` feature,

--- a/tests/pipeline/ray-tracing/trace-ray-inline.slang.glsl
+++ b/tests/pipeline/ray-tracing/trace-ray-inline.slang.glsl
@@ -2,6 +2,7 @@
 //TEST_IGNORE_FILE:
 
 #version 460
+#extension GL_EXT_ray_tracing : require
 #extension GL_EXT_ray_query : require
 
 struct SLANG_ParameterGroup_C_0


### PR DESCRIPTION
The recent change that added support for the `GL_EXT_ray_query` extension made is so that a shader that declares a `RaytracingAccelerationStructure` as an input to a non-RT shader stage but then never *uses* it wouldn't enable any RT extension, resulting in a compilation failure in glslang.

This change reverts that behavior so that such shaders enable `GL_EXT_ray_tracing`, since that is the older of the two RT extensions that introduce `accelerationStructureEXT`. It is possible that we will need to revisit this decision based on which of the two extensions ends up being more broadly supported, but I think that right now it is fair to say that there exist drivers that support `GL_EXT_ray_tracing` but not `GL_EXT_ray_query`, so the former is the better default.