### PR TITLE
Fix the "acceleration structure in compute" bug for GL_NV_ray_tracing…

### DIFF
--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -1822,6 +1822,7 @@ void GLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
                     // We know that the acceleration structure type will translate
                     // to the one from that extension:
                     //
+                    _requireRayTracing();
                     m_writer->emit("accelerationStructureNV");
                 }
                 else

--- a/tests/pipeline/ray-tracing/acceleration-structure-in-compute-nv.slang
+++ b/tests/pipeline/ray-tracing/acceleration-structure-in-compute-nv.slang
@@ -1,0 +1,20 @@
+// acceleration-structure-in-compute.slang
+
+// Test for using ray-tracing acceleration structures as a shader input
+// in non-ray-tracing shader code (that never actually traces rays)
+
+//TEST:CROSS_COMPILE:-target spirv-asm -stage compute -profile glsl_460+GL_NV_ray_tracing -entry main -DUSE_NV_EXT=1
+
+uniform RaytracingAccelerationStructure gScene;
+
+int helper(RaytracingAccelerationStructure a, int b)
+{
+    return b;
+}
+
+[shader("compute")]
+void main(
+    uniform RaytracingAccelerationStructure x)
+{
+    helper(x, 1);
+}

--- a/tests/pipeline/ray-tracing/acceleration-structure-in-compute-nv.slang.glsl
+++ b/tests/pipeline/ray-tracing/acceleration-structure-in-compute-nv.slang.glsl
@@ -1,0 +1,18 @@
+#version 460
+
+#extension GL_NV_ray_tracing : require
+
+int helper_0(accelerationStructureNV a_0, int b_0)
+{
+    return b_0;
+}
+
+layout(binding = 1)
+uniform accelerationStructureNV entryPointParams_x_0;
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+void main()
+{
+    int _S1 = helper_0(entryPointParams_x_0, 1);
+    return;
+}


### PR DESCRIPTION
… too

A recent change broke code that uses `RayTracingAccelerationStructure` in non-RT shader stages for Vulkan/GLSL when also *not* doing any ray tracing in the shader code.
A recent fix patched that up for code using `GL_EXT_ray_tracing` and/or `GL_EXT_ray_query`, but that fix didn't apply on the path that uses `GL_NV_ray_tracing` via an opt-in.

This change fixes that gap and checks in a test for it.