### PR TITLE
Improve Vulkan shader-objects implementation.

### DIFF
--- a/examples/hello-world/main.cpp
+++ b/examples/hello-world/main.cpp
@@ -244,7 +244,6 @@ Slang::Result initialize()
     // platforms/APIs.
     //
     IDevice::Desc deviceDesc = {};
-    deviceDesc.deviceType = DeviceType::Vulkan;
     gfx::Result res = gfxCreateDevice(&deviceDesc, gDevice.writeRef());
     if(SLANG_FAILED(res)) return res;
 

--- a/examples/shader-object/main.cpp
+++ b/examples/shader-object/main.cpp
@@ -136,7 +136,6 @@ int main()
     // interacting with the graphics API.
     Slang::ComPtr<gfx::IDevice> device;
     IDevice::Desc deviceDesc = {};
-    deviceDesc.deviceType = DeviceType::Vulkan;
     SLANG_RETURN_ON_FAIL(gfxCreateDevice(&deviceDesc, device.writeRef()));
 
     // Now we can load the shader code.

--- a/examples/shader-toy/main.cpp
+++ b/examples/shader-toy/main.cpp
@@ -315,7 +315,6 @@ Result initialize()
     gWindow->events.sizeChanged = Slang::Action<>(this, &ShaderToyApp::windowSizeChanged);
 
     IDevice::Desc deviceDesc;
-    deviceDesc.deviceType = DeviceType::Vulkan;
     Result res = gfxCreateDevice(&deviceDesc, gDevice.writeRef());
     if(SLANG_FAILED(res)) return res;
 

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -116,7 +116,6 @@ public:
     struct Desc
     {
         PipelineType        pipelineType;
-            /// Use instead of `kernels`/`kernelCount` if loading a Slang program.
         slang::IComponentType*  slangProgram;
     };
 };

--- a/source/slang/slang-reflection-api.cpp
+++ b/source/slang/slang-reflection-api.cpp
@@ -1152,6 +1152,10 @@ namespace Slang
         {
             return SLANG_BINDING_TYPE_SAMPLER;
         }
+        else if (as<ParameterBlockType>(type))
+        {
+            return SLANG_BINDING_TYPE_PARAMETER_BLOCK;
+        }
         else
         {
             return SLANG_BINDING_TYPE_UNKNOWN;

--- a/tests/compute/entry-point-uniform-params.slang
+++ b/tests/compute/entry-point-uniform-params.slang
@@ -4,11 +4,13 @@
 // entry points are allowed, and work as expected.
 
 //DISABLE_TEST:CPU_REFLECTION: -profile cs_5_0 -entry computeMain -target cpp
-//TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
-//DISABLED_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu
-//DISABLED_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute
-//DISABLED_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12
-//DISABLED_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute
+//TEST(compute):COMPARE_COMPUTE: -dx12 -shaderobj
+//TEST(compute):COMPARE_COMPUTE: -vk -shaderobj
+//TEST(compute):COMPARE_COMPUTE: -dx11 -shaderobj
+//TEST(compute):COMPARE_COMPUTE: -cuda -shaderobj
+//TEST(compute):COMPARE_COMPUTE: -cpu -shaderobj
+
+
 
 struct Signs
 {

--- a/tests/compute/parameter-block.slang
+++ b/tests/compute/parameter-block.slang
@@ -1,5 +1,8 @@
-//TEST_DISABLED(compute):COMPARE_COMPUTE:
-//TEST_DISABLED(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-cuda -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-vk -shaderobj
+//TEST(compute):COMPARE_COMPUTE:-shaderobj
+
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=block0.buffer
 //TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):name=block1.buffer

--- a/tests/disabled-tests.txt
+++ b/tests/disabled-tests.txt
@@ -13,14 +13,12 @@ These tests will need to be re-enabled together with changes to the shader objec
 * compute/dynamic-dispatch-13.slang
 * compute/dynamic-dispatch-14.slang
 * compute/dynamic-dispatch-bindless-texture.slang
-* compute/entry-point-uniform-params.slang
 * compute/global-type-param2.slang
 * compute/global-type-param-array.slang
 * compute/global-type-param1.slang
 * compute/interface-shader-param-in-struct.slang
 * compute/interface-shader-param-legalization.slang
 * compute/interface-shader-param.slang
-* compute/parameter-block.slang
 * compute/performance-profile.slang
 * compute/rewriter-parameter-block-complex.hlsl
 * compute/unbounded-array-of-array-syntax.slang
@@ -35,7 +33,6 @@ These tests will need to be re-enabled together with changes to the shader objec
 * language-feature/shader-params/global-uniform-params.slang
 * tests/serialization/serialized-module-entry-point-test.slang
 * serialization/library-entry-point/library-entry-point-test.slang
-* render/cross-compile-entry-point.slang
 * render/cross-compile0.hlsl
 * render/imported-parameters.hlsl
 * render/nointerpolation.hlsl

--- a/tests/render/cross-compile-entry-point.slang
+++ b/tests/render/cross-compile-entry-point.slang
@@ -1,5 +1,6 @@
-//DISABLED_TEST(render):COMPARE_HLSL_CROSS_COMPILE_RENDER:
-//DISABLED_TEST(render):COMPARE_HLSL_CROSS_COMPILE_RENDER: -dx12
+//TEST(render):COMPARE_HLSL_CROSS_COMPILE_RENDER:
+//TEST(render):COMPARE_HLSL_CROSS_COMPILE_RENDER: -dx12
+
 
 // This is a test to ensure that we can cross-compile a complete entry point.
 

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -2210,15 +2210,13 @@ public:
     public:
         virtual Result bindObject(PipelineCommandEncoder* encoder, RootBindingState* bindingState) override
         {
-            RootBindingState globalBindingState = *bindingState;
             SLANG_RETURN_ON_FAIL(Super::bindObject(encoder, bindingState));
 
             auto entryPointCount = m_entryPoints.getCount();
             for (Index i = 0; i < entryPointCount; ++i)
             {
                 auto entryPoint = m_entryPoints[i];
-                auto bindingStateCopy = globalBindingState;
-                SLANG_RETURN_ON_FAIL(entryPoint->bindObject(encoder, &bindingStateCopy));
+                SLANG_RETURN_ON_FAIL(entryPoint->bindObject(encoder, bindingState));
             }
 
             return SLANG_OK;

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -4251,7 +4251,7 @@ SlangResult VKDevice::initialize(const Desc& desc)
     SLANG_RETURN_ON_FAIL(m_module.init());
     SLANG_RETURN_ON_FAIL(m_api.initGlobalProcs(m_module));
     descriptorSetAllocator.m_api = &m_api;
-    SLANG_RETURN_ON_FAIL(initVulkanInstanceAndDevice(_DEBUG));
+    SLANG_RETURN_ON_FAIL(initVulkanInstanceAndDevice(ENABLE_VALIDATION_LAYER != 0));
     {
         VkQueue queue;
         m_api.vkGetDeviceQueue(m_device, m_queueFamilyIndex, 0, &queue);

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -1975,8 +1975,8 @@ public:
         };
 
         // A shared template function for composing a VkWriteDescriptorSet structure.
-        // WriteDescriptorInfoFunc is `void(VkWriteDescriptorSet&, RootBindingState*,
-        // TResourceArrayView, int startElement, int elementCount)`, which sets up
+        // The signature for `WriteDescriptorInfoFunc` is
+        // `void(VkWriteDescriptorSet&, int startElement, int elementCount)`, which sets up
         // `VkWriteDescriptorSet::pBufferInfo`, `pImageInfo` or `pTexelBufferView` fields.
         template<typename WriteDescriptorInfoFunc, typename TResourceArrayView>
         static void _writeDescriptorRange(

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -2362,7 +2362,6 @@ public:
                         VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER,
                         m_resourceViews.getArrayView(baseIndex, count));
                     offset.descriptorRangeOffset++;
-                    offset.descriptorRangeOffset++;
                     break;
 
                 case slang::BindingType::VaryingInput:


### PR DESCRIPTION
1. Null bindings no longer crashes.
2. No longer copies push constants to staging CPU buffer before setting it into command buffer. The entry-point shader object now directly sets it into command buffer upon `bindObject` call.
3. Improved vulkan implementation so that each shader object is responsible for creating descriptor sets on-demand.
4. Fixed slang reflection to correctly report `ParameterBlock` binding.
5. Re-enabled 3 tests that were previously disabled.