### PR TITLE
Clean up render-test handling of input

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -197,6 +197,8 @@ public:
         NonPixelShaderResource,
         ShaderResource,
         GenericRead,
+        CopySource,
+        CopyDest,
         CountOf,
     };
 
@@ -268,6 +270,10 @@ public:
             return BindFlag::Enum(
                 BindFlag::PixelShaderResource |
                 BindFlag::NonPixelShaderResource);
+        case Usage::CopySource:
+            return BindFlag::Enum(0);
+        case Usage::CopyDest:
+            return BindFlag::Enum(0);
         default:
             return BindFlag::Enum(-1);
         }

--- a/source/core/slang-token-reader.h
+++ b/source/core/slang-token-reader.h
@@ -231,6 +231,15 @@ namespace Slang
                 return false;
             }
         }
+        bool AdvanceIf(String token)
+        {
+            if( LookAhead(token) )
+            {
+                ReadToken();
+                return true;
+            }
+            return false;
+        }
         bool IsEnd()
         {
             return tokenPtr == (int)tokens.getCount();

--- a/tests/compute/array-existential-parameter.slang
+++ b/tests/compute/array-existential-parameter.slang
@@ -1,6 +1,6 @@
 // Test using existential shader parameter that is an interface array.
 
-//TEST(compute):COMPARE_COMPUTE:-cpu
+//DISABLED_TEST(compute):COMPARE_COMPUTE:-cpu
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda
 
 [anyValueSize(8)]

--- a/tests/compute/cbuffer-legalize.slang
+++ b/tests/compute/cbuffer-legalize.slang
@@ -1,7 +1,7 @@
 //TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj
 //TEST(compute):COMPARE_COMPUTE:-shaderobj
 
-//TEST_INPUT: Uniform(data=[1 2 3 4]):name=C.p.c
+//TEST_INPUT: uniform(data=[1 2 3 4]):name=C.p.c
 //TEST_INPUT: Texture2D(size=4, content = one):name=C.p.t
 //TEST_INPUT: Sampler:name=C.p.s
 //TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer

--- a/tests/compute/entry-point-uniform-params.slang
+++ b/tests/compute/entry-point-uniform-params.slang
@@ -35,9 +35,9 @@ ConstantBuffer<Signs> signs;
 
 [numthreads(4, 1, 1)]
 void computeMain(
-//TEST_INPUT:root_constants(data=[2 0 0 0 3 0 0 0]):name=stuff
+//TEST_INPUT:uniform(data=[2]):name=stuff
 	uniform Stuff  stuff,
-//TEST_INPUT:root_constants(data=[3]):onlyCPULikeBinding,name=things
+//TEST_INPUT:uniform(data=[3]):name=things
 	uniform Things things,
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer

--- a/tests/compute/global-type-param-in-entrypoint.slang
+++ b/tests/compute/global-type-param-in-entrypoint.slang
@@ -1,6 +1,6 @@
 //TEST(compute):COMPARE_RENDER_COMPUTE: -shaderobj
 
-//TEST_INPUT: cbuffer(data=[1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0], stride=16):name Uniforms
+//TEST_INPUT: cbuffer(data=[1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0]):name Uniforms
 //TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 //TEST_INPUT: global_type VertImpl
 

--- a/tests/compute/interface-param-partial-specialize.slang
+++ b/tests/compute/interface-param-partial-specialize.slang
@@ -3,8 +3,8 @@
 // with __Dynamic. This verifies that the handling of
 // "partially" specializing an existential type is correct.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cuda -shaderobj
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu -shaderobj
+//DISABLED_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cuda -shaderobj
+//DISABLED_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -cpu -shaderobj
 
 [anyValueSize(8)]
 interface IInterface
@@ -38,7 +38,12 @@ void compute(uint tid, Params p)
 
 [numthreads(4, 1, 1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID,
-//TEST_INPUT:ubuffer(data=[rtti(Impl) witness(Impl, IInterface) 1 0], stride=4):name=params.obj
+
+//TEST_INPUT:begin_buffer(stride=8):name=params.obj
+//TEST_INPUT:begin_object(type=Impl)
+//TEST_INPUT:uniform(data=[1]):name=val
+//TEST_INPUT:end
+//TEST_INPUT:end
     uniform Params params)
 {
 	uint tid = dispatchThreadID.x;

--- a/tests/disabled-tests.txt
+++ b/tests/disabled-tests.txt
@@ -39,3 +39,5 @@ These tests will need to be re-enabled together with changes to the shader objec
 * render/render0.hlsl
 * render/tess.hlsl
 * render/unused-discard.hlsl
+* compute/interface-param-partial-specialize.slang
+* compute/array-existential-parameter.slang

--- a/tests/language-feature/shader-params/entry-point-uniform-params.slang
+++ b/tests/language-feature/shader-params/entry-point-uniform-params.slang
@@ -23,7 +23,7 @@ int test(int val, int a, int b)
 [shader("compute")]
 void computeMain(
 
-//TEST_INPUT:root_constants(data=[256 1]):name=d
+//TEST_INPUT:uniform(data=[256 1]):name=d
 	uniform Data d,
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -2840,11 +2840,15 @@ public:
                 size_t srcOffset,
                 size_t size) override
             {
-                SLANG_UNUSED(dst);
-                SLANG_UNUSED(srcOffset);
-                SLANG_UNUSED(src);
-                SLANG_UNUSED(dstOffset);
-                SLANG_UNUSED(size);
+                auto dstBuffer = static_cast<BufferResourceImpl*>(dst);
+                auto srcBuffer = static_cast<BufferResourceImpl*>(src);
+
+                m_commandBuffer->m_cmdList->CopyBufferRegion(
+                    dstBuffer->m_resource.getResource(),
+                    dstOffset,
+                    srcBuffer->m_resource.getResource(),
+                    srcOffset,
+                    size);
             }
             virtual SLANG_NO_THROW void SLANG_MCALL uploadBufferData(
                 IBufferResource* dst,
@@ -3810,6 +3814,8 @@ static D3D12_RESOURCE_STATES _calcResourceState(IResource::Usage usage)
         case Usage::ShaderResource:         return D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE |
                                                    D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
         case Usage::GenericRead:            return D3D12_RESOURCE_STATE_GENERIC_READ;
+        case Usage::CopySource:             return D3D12_RESOURCE_STATE_COPY_SOURCE;
+        case Usage::CopyDest:               return D3D12_RESOURCE_STATE_COPY_DEST;
         default: return D3D12_RESOURCE_STATES(0);
     }
 }

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -3116,11 +3116,26 @@ public:
                 size_t srcOffset,
                 size_t size) override
             {
-                SLANG_UNUSED(dst);
-                SLANG_UNUSED(srcOffset);
-                SLANG_UNUSED(src);
-                SLANG_UNUSED(dstOffset);
-                SLANG_UNUSED(size);
+                auto& vkAPI = m_commandBuffer->m_renderer->m_api;
+
+                auto dstBuffer = static_cast<BufferResourceImpl*>(dst);
+                auto srcBuffer = static_cast<BufferResourceImpl*>(src);
+
+                VkBufferCopy copyRegion;
+                copyRegion.dstOffset = dstOffset;
+                copyRegion.srcOffset = srcOffset;
+                copyRegion.size = size;
+
+                // Note: Vulkan puts the source buffer first in the copy
+                // command, going against the dominant tradition for copy
+                // operations in C/C++.
+                //
+                vkAPI.vkCmdCopyBuffer(
+                    m_commandBuffer->m_commandBuffer,
+                    srcBuffer->m_buffer.m_buffer,
+                    dstBuffer->m_buffer.m_buffer,
+                    /* regionCount: */ 1,
+                    &copyRegion);
             }
             virtual SLANG_NO_THROW void SLANG_MCALL
                 uploadBufferData(IBufferResource* buffer, size_t offset, size_t size, void* data) override

--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -42,596 +42,641 @@ namespace renderer_test
         return SLANG_SCALAR_TYPE_NONE;
     }
 
-    Index ShaderInputLayout::findEntryIndexByName(const String& name) const
+    void ShaderInputLayout::AggVal::addField(ShaderInputLayout::Field const& field)
     {
-        const Index count = Index(entries.getCount());
-        for (Index i = 0; i < count; ++i)
-        {
-            const auto& entry = entries[i];
-            if (entry.name == name)
-            {
-                return Index(i);
-            }
-        }
-        return -1;
+        fields.add(field);
     }
 
-    static bool _isCPULikeBindingTarget(SlangCompileTarget target)
+    void ShaderInputLayout::ArrayVal::addField(ShaderInputLayout::Field const& field)
     {
-        // CUDA and C++ are 'CPULike' in terms of their binding mechanism
-        switch (target)
-        {
-            case SLANG_C_SOURCE:
-            case SLANG_CPP_SOURCE:
-            case SLANG_EXECUTABLE:
-            case SLANG_SHARED_LIBRARY:
-            case SLANG_HOST_CALLABLE:
-            case SLANG_CUDA_SOURCE:
-            case SLANG_PTX:
-            {
-                return true;
-            }
-            default: return false;
-        }
+        vals.add(field.val);
     }
 
-    void ShaderInputLayout::updateForTarget(SlangCompileTarget target)
+    class ShaderInputLayoutFormatException : public Exception
     {
-        if (!_isCPULikeBindingTarget(target))
+    public:
+        ShaderInputLayoutFormatException(String message)
+            : Exception(message)
+        {}
+    };
+
+    struct ShaderInputLayoutParser
+    {
+        ShaderInputLayout* layout;
+        RandomGenerator* rand;
+
+        ShaderInputLayoutParser(ShaderInputLayout* layout, RandomGenerator* rand)
+            : layout(layout)
+            , rand(rand)
+        {}
+
+        RefPtr<ShaderInputLayout::ParentVal> parentVal;
+        List<RefPtr<ShaderInputLayout::ParentVal>> parentValStack;
+
+        SlangResult parseOption(TokenReader& parser, String const& word, ShaderInputLayout::TextureVal* val)
         {
-            int count = int(entries.getCount());
-            for (int i = 0; i < count; ++i)
+            if (word == "depth")
             {
-                auto& entry = entries[i];
-                if (entry.onlyCPULikeBinding)
+                val->textureDesc.isDepthTexture = true;
+            }
+            else if (word == "arrayLength")
+            {
+                parser.Read("=");
+                val->textureDesc.arrayLength = parser.ReadInt();
+            }
+            else if (word == "size")
+            {
+                parser.Read("=");
+                auto size = parser.ReadInt();
+                val->textureDesc.size = size;
+            }
+            else if (word == "content")
+            {
+                parser.Read("=");
+                auto contentWord = parser.ReadWord();
+                if (contentWord == "zero")
+                    val->textureDesc.content = InputTextureContent::Zero;
+                else if (contentWord == "one")
+                    val->textureDesc.content = InputTextureContent::One;
+                else if (contentWord == "chessboard")
+                    val->textureDesc.content = InputTextureContent::ChessBoard;
+                else
+                    val->textureDesc.content = InputTextureContent::Gradient;
+            }
+            else if(word == "mipMaps")
+            {
+                parser.Read("=");
+                val->textureDesc.mipMapCount = int(parser.ReadInt());
+            }
+            else if(word == "format")
+            {
+                val->textureDesc.format = parseFormatOption(parser);
+            }
+            else
+            {
+                return SLANG_FAIL;
+            }
+            return SLANG_OK;
+        }
+
+        SlangResult parseOption(TokenReader& parser, String const& word, ShaderInputLayout::SamplerVal* val)
+        {
+            if (word == "depthCompare")
+            {
+                val->samplerDesc.isCompareSampler = true;
+            }
+            else
+            {
+                return SLANG_FAIL;
+            }
+            return SLANG_OK;
+        }
+
+        SlangResult parseOption(TokenReader& parser, String const& word, ShaderInputLayout::DataValBase* val)
+        {
+            if (word == "data")
+            {
+                parser.Read("=");
+
+                parser.Read("[");
+                uint32_t offset = 0;
+                while (!parser.IsEnd() && !parser.LookAhead("]"))
                 {
-                    entries.removeAt(i);
-                    i--;
-                    count--;
-                }
-            }
-        }
-    }
-
-    void ShaderInputLayout::parse(RandomGenerator* rand, const char * source)
-    {
-        entries.clear();
-        globalSpecializationArgs.clear();
-        entryPointSpecializationArgs.clear();
-        auto lines = Split(source, '\n');
-        for (auto & line : lines)
-        {
-            if (line.startsWith("//TEST_INPUT:"))
-            {
-                auto lineContent = line.subString(13, line.getLength() - 13);
-                TokenReader parser(lineContent);
-                try
-                {
-                    if (parser.LookAhead("entryPointSpecializationArg")
-                        || parser.LookAhead("type")
-                        || parser.LookAhead("entryPointExistentialType"))
+                    bool negate = false;
+                    if(parser.NextToken().Type == TokenType::OpSub)
                     {
                         parser.ReadToken();
-                        StringBuilder typeExp;
-                        while (!parser.IsEnd())
-                            typeExp << parser.ReadToken().Content;
-                        entryPointSpecializationArgs.add(typeExp);
+                        negate = true;
                     }
-                    else if (parser.LookAhead("globalSpecializationArg")
-                        || parser.LookAhead("global_type")
-                        || parser.LookAhead("globalExistentialType"))
+
+                    if (parser.NextToken().Type == TokenType::IntLiteral)
                     {
-                        parser.ReadToken();
-                        StringBuilder typeExp;
-                        while (!parser.IsEnd())
-                            typeExp << parser.ReadToken().Content;
-                        globalSpecializationArgs.add(typeExp);
+                        uint32_t value = parser.ReadUInt();
+                        if(negate) value = uint32_t(-int32_t(value));
+                        val->bufferData.add(value);
                     }
                     else
                     {
-                        ShaderInputLayoutEntry entry;
+                        auto floatNum = parser.ReadFloat();
+                        if(negate) floatNum = -floatNum;
+                        val->bufferData.add(*(unsigned int*)&floatNum);
+                    }
+                    offset += 4;
+                }
+                parser.Read("]");
+            }
+            else
+            {
+                return SLANG_FAIL;
+            }
+            return SLANG_OK;
+        }
 
-                        if (parser.LookAhead("array"))
+        SlangResult parseOption(TokenReader& parser, String const& word, ShaderInputLayout::BufferVal* val)
+        {
+            if (word == "stride")
+            {
+                parser.Read("=");
+                val->bufferDesc.stride = parser.ReadInt();
+            }
+            else if (word == "random")
+            {
+                parser.Read("(");
+                // Read the type
+                String type = parser.ReadWord();
+                SlangScalarType scalarType = _getScalarType(type.getUnownedSlice());
+                if (scalarType == SLANG_SCALAR_TYPE_NONE)
+                {
+                    StringBuilder scalarTypeNames;
+                    for (const auto& info : g_scalarTypeInfos)
+                    {
+                        if (scalarTypeNames.getLength() != 0)
                         {
-                            entry.type = ShaderInputType::Array;
+                            scalarTypeNames << ", ";
                         }
-                        else if (parser.LookAhead("cbuffer"))
+                        scalarTypeNames << info.name;
+                    }
+
+                    throw ShaderInputLayoutFormatException(StringBuilder() << "Expecting " << scalarTypeNames << " " << parser.NextToken().Position.Line);
+                }
+
+                parser.Read(",");
+                const int size = int(parser.ReadUInt());
+
+                switch (scalarType)
+                {
+                    case SLANG_SCALAR_TYPE_INT32:
+                    {
+                        bool hasRange = false;
+
+                        int32_t minValue = -0x7fffffff - 1;
+                        int32_t maxValue = 0x7fffffff;
+
+                        if (parser.LookAhead(","))
                         {
-                            entry.type = ShaderInputType::Buffer;
-                            entry.bufferDesc.type = InputBufferType::ConstantBuffer;
-                        }
-                        else if (parser.LookAhead("object"))
-                        {
-                            entry.type = ShaderInputType::Object;
-                        }
-                        else if (parser.LookAhead("root_constants"))
-                        {
-                            entry.type = ShaderInputType::Buffer;
-                            entry.bufferDesc.type = InputBufferType::RootConstantBuffer;
-                        }
-                        else if (parser.LookAhead("Uniform"))
-                        {
-                            entry.type = ShaderInputType::Uniform;
-                        }
-                        else if (parser.LookAhead("ubuffer"))
-                        {
-                            entry.type = ShaderInputType::Buffer;
-                            entry.bufferDesc.type = InputBufferType::StorageBuffer;
-                        }
-                        else if (parser.LookAhead("Texture1D"))
-                        {
-                            entry.type = ShaderInputType::Texture;
-                            entry.textureDesc.dimension = 1;
-                        }
-                        else if (parser.LookAhead("Texture2D"))
-                        {
-                            entry.type = ShaderInputType::Texture;
-                            entry.textureDesc.dimension = 2;
-                        }
-                        else if (parser.LookAhead("Texture3D"))
-                        {
-                            entry.type = ShaderInputType::Texture;
-                            entry.textureDesc.dimension = 3;
-                        }
-                        else if (parser.LookAhead("TextureCube"))
-                        {
-                            entry.type = ShaderInputType::Texture;
-                            entry.textureDesc.dimension = 2;
-                            entry.textureDesc.isCube = true;
-                        }
-                        else if (parser.LookAhead("RWTexture1D"))
-                        {
-                            entry.type = ShaderInputType::Texture;
-                            entry.textureDesc.dimension = 1;
-                            entry.textureDesc.isRWTexture = true;
-                        }
-                        else if (parser.LookAhead("RWTexture2D"))
-                        {
-                            entry.type = ShaderInputType::Texture;
-                            entry.textureDesc.dimension = 2;
-                            entry.textureDesc.isRWTexture = true;
-                        }
-                        else if (parser.LookAhead("RWTexture3D"))
-                        {
-                            entry.type = ShaderInputType::Texture;
-                            entry.textureDesc.dimension = 3;
-                            entry.textureDesc.isRWTexture = true;
-                        }
-                        else if (parser.LookAhead("RWTextureCube"))
-                        {
-                            entry.type = ShaderInputType::Texture;
-                            entry.textureDesc.dimension = 2;
-                            entry.textureDesc.isCube = true;
-                            entry.textureDesc.isRWTexture = true;
-                        }
-                        else if (parser.LookAhead("Sampler"))
-                        {
-                            entry.type = ShaderInputType::Sampler;
-                        }
-                        else if (parser.LookAhead("Sampler1D"))
-                        {
-                            entry.type = ShaderInputType::CombinedTextureSampler;
-                            entry.textureDesc.dimension = 1;
-                        }
-                        else if (parser.LookAhead("Sampler2D"))
-                        {
-                            entry.type = ShaderInputType::CombinedTextureSampler;
-                            entry.textureDesc.dimension = 2;
-                        }
-                        else if (parser.LookAhead("Sampler3D"))
-                        {
-                            entry.type = ShaderInputType::CombinedTextureSampler;
-                            entry.textureDesc.dimension = 3;
-                        }
-                        else if (parser.LookAhead("SamplerCube"))
-                        {
-                            entry.type = ShaderInputType::CombinedTextureSampler;
-                            entry.textureDesc.dimension = 2;
-                            entry.textureDesc.isCube = true;
-                        }
-                        else if (parser.LookAhead("render_targets"))
-                        {
-                            numRenderTargets = parser.ReadInt();
-                            continue;
-                        }
-                        else
-                        {
-                            throw TextFormatException(String("Invalid input syntax at line ") + String(parser.NextToken().Position.Line));
-                        }
-                        parser.ReadToken();
-                        // parse options
-                        if (parser.LookAhead("("))
-                        {
-                            parser.Read("(");
-                            while (!parser.IsEnd() && !parser.LookAhead(")"))
+                            hasRange = true;
+                            parser.ReadToken();
+                            minValue = parser.ReadInt();
+
+                            if (parser.LookAhead(","))
                             {
-                                auto word = parser.ReadWord();
-                                if (word == "depth")
-                                {
-                                    entry.textureDesc.isDepthTexture = true;
-                                }
-                                else if (word == "depthCompare")
-                                {
-                                    entry.samplerDesc.isCompareSampler = true;
-                                }
-                                else if (word == "arrayLength")
-                                {
-                                    parser.Read("=");
-                                    entry.textureDesc.arrayLength = parser.ReadInt();
-                                }
-                                else if (word == "stride")
-                                {
-                                    parser.Read("=");
-                                    entry.bufferDesc.stride = parser.ReadInt();
-                                }
-                                else if (word == "size")
-                                {
-                                    parser.Read("=");
-                                    auto size = parser.ReadInt();
-                                    if (entry.type == ShaderInputType::Array)
-                                    {
-                                        entry.arrayDesc.size = size;
-                                    }
-                                    else
-                                    {
-                                        entry.textureDesc.size = size;
-                                    }
-                                }
-                                else if (word == "random")
-                                {
-                                    parser.Read("(");
-                                    // Read the type
-                                    String type = parser.ReadWord();
-                                    SlangScalarType scalarType = _getScalarType(type.getUnownedSlice());
-                                    if (scalarType == SLANG_SCALAR_TYPE_NONE)
-                                    {
-                                        StringBuilder scalarTypeNames;
-                                        for (const auto& info : g_scalarTypeInfos)
-                                        {
-                                            if (scalarTypeNames.getLength() != 0)
-                                            {
-                                                scalarTypeNames << ", ";
-                                            }
-                                            scalarTypeNames << info.name;
-                                        }
+                                parser.ReadToken();
+                                maxValue = parser.ReadInt();
+                            }
+                        }
+                        SLANG_ASSERT(minValue <= maxValue);
+                        maxValue = (maxValue >= minValue) ? maxValue : minValue;
 
-                                        throw TextFormatException(StringBuilder() << "Expecting " << scalarTypeNames << " " << parser.NextToken().Position.Line);
-                                    }
+                        // Generate the data
+                        val->bufferData.setCount(size);
 
-                                    parser.Read(",");
-                                    const int size = int(parser.ReadUInt());
+                        int32_t* dst = (int32_t*)val->bufferData.getBuffer();
+                        for (int i = 0; i < size; ++i)
+                        {
+                            dst[i] = hasRange ? rand->nextInt32InRange(minValue, maxValue) : rand->nextInt32();
+                        }
+                        break;
+                    }
+                    case SLANG_SCALAR_TYPE_UINT32:
+                    {
+                        bool hasRange = false;
+                        uint32_t minValue = 0;
+                        uint32_t maxValue = 0xffffffff;
 
-                                    switch (scalarType)
-                                    {
-                                        case SLANG_SCALAR_TYPE_INT32:
-                                        {
-                                            bool hasRange = false;
+                        if (parser.LookAhead(","))
+                        {
+                            parser.ReadToken();
+                            minValue = parser.ReadUInt();
 
-                                            int32_t minValue = -0x7fffffff - 1;
-                                            int32_t maxValue = 0x7fffffff;
+                            hasRange = true;
 
-                                            if (parser.LookAhead(","))
-                                            {
-                                                hasRange = true;
-                                                parser.ReadToken();
-                                                minValue = parser.ReadInt();
+                            if (parser.LookAhead(","))
+                            {
+                                parser.ReadToken();
+                                maxValue = parser.ReadUInt();
+                            }
+                        }
 
-                                                if (parser.LookAhead(","))
-                                                {
-                                                    parser.ReadToken();
-                                                    maxValue = parser.ReadInt();
-                                                }
-                                            }
-                                            SLANG_ASSERT(minValue <= maxValue);
-                                            maxValue = (maxValue >= minValue) ? maxValue : minValue;
+                        SLANG_ASSERT(minValue <= maxValue);
+                        maxValue = (maxValue >= minValue) ? maxValue : minValue;
 
-                                            // Generate the data
-                                            entry.bufferData.setCount(size);
+                        // Generate the data
+                        val->bufferData.setCount(size);
 
-                                            int32_t* dst = (int32_t*)entry.bufferData.getBuffer();
-                                            for (int i = 0; i < size; ++i)
-                                            {
-                                                dst[i] = hasRange ? rand->nextInt32InRange(minValue, maxValue) : rand->nextInt32();
-                                            }
-                                            break;
-                                        }
-                                        case SLANG_SCALAR_TYPE_UINT32:
-                                        {
-                                            bool hasRange = false;
-                                            uint32_t minValue = 0;
-                                            uint32_t maxValue = 0xffffffff;
+                        uint32_t* dst = (uint32_t*)val->bufferData.getBuffer();
+                        for (int i = 0; i < size; ++i)
+                        {
+                            dst[i] = hasRange ? rand->nextUInt32InRange(minValue, maxValue) : rand->nextUInt32();
+                        }
 
-                                            if (parser.LookAhead(","))
-                                            {
-                                                parser.ReadToken();
-                                                minValue = parser.ReadUInt();
-
-                                                hasRange = true;
-
-                                                if (parser.LookAhead(","))
-                                                {
-                                                    parser.ReadToken();
-                                                    maxValue = parser.ReadUInt();
-                                                }
-                                            }
-
-                                            SLANG_ASSERT(minValue <= maxValue);
-                                            maxValue = (maxValue >= minValue) ? maxValue : minValue;
-
-                                            // Generate the data
-                                            entry.bufferData.setCount(size);
-
-                                            uint32_t* dst = (uint32_t*)entry.bufferData.getBuffer();
-                                            for (int i = 0; i < size; ++i)
-                                            {
-                                                dst[i] = hasRange ? rand->nextUInt32InRange(minValue, maxValue) : rand->nextUInt32();
-                                            }
-
-                                            break;
-                                        }
-                                        case SLANG_SCALAR_TYPE_FLOAT32:
-                                        {
-                                            float minValue = -1.0f;
-                                            float maxValue = 1.0f;
+                        break;
+                    }
+                    case SLANG_SCALAR_TYPE_FLOAT32:
+                    {
+                        float minValue = -1.0f;
+                        float maxValue = 1.0f;
                                             
-                                            if (parser.LookAhead(","))
-                                            {
-                                                parser.ReadToken();
-                                                minValue = parser.ReadFloat();
-
-                                                if (parser.LookAhead(","))
-                                                {
-                                                    parser.ReadToken();
-                                                    maxValue = parser.ReadFloat();
-                                                }
-                                            }
-
-                                            SLANG_ASSERT(minValue <= maxValue);
-                                            maxValue = (maxValue >= minValue) ? maxValue : minValue;
-
-                                            // Generate the data
-                                            entry.bufferData.setCount(size);
-
-                                            float* dst = (float*)entry.bufferData.getBuffer();
-                                            for (int i = 0; i < size; ++i)
-                                            {
-                                                dst[i] = (rand->nextUnitFloat32() * (maxValue - minValue)) + minValue;
-                                            }
-                                            break;
-                                        }
-                                    }
-
-                                    // Read the range
-
-                                    parser.Read(")");
-                                }
-                                else if (word == "data")
-                                {
-                                    parser.Read("=");
-
-                                    parser.Read("[");
-                                    uint32_t offset = 0;
-                                    while (!parser.IsEnd() && !parser.LookAhead("]"))
-                                    {
-                                        RTTIDataEntry rttiEntry;
-                                        if (parser.LookAhead("rtti"))
-                                        {
-                                            parser.ReadToken();
-                                            parser.Read("(");
-                                            rttiEntry.type = RTTIDataEntryType::RTTIObject;
-                                            rttiEntry.typeName = parser.ReadWord();
-                                            rttiEntry.offset = offset;
-                                            parser.Read(")");
-                                            offset += 8;
-                                            entry.rttiEntries.add(rttiEntry);
-                                            entry.bufferData.add(0);
-                                            entry.bufferData.add(0);
-                                            continue;
-                                        }
-                                        else if (parser.LookAhead("witness"))
-                                        {
-                                            parser.ReadToken();
-                                            parser.Read("(");
-                                            rttiEntry.type = RTTIDataEntryType::WitnessTable;
-                                            rttiEntry.typeName = parser.ReadWord();
-                                            parser.Read(",");
-                                            rttiEntry.interfaceName = parser.ReadWord();
-                                            rttiEntry.offset = offset;
-                                            parser.Read(")");
-                                            offset += 8;
-                                            entry.rttiEntries.add(rttiEntry);
-                                            entry.bufferData.add(0);
-                                            entry.bufferData.add(0);
-                                            continue;
-                                        }
-                                        else if (parser.LookAhead("handle"))
-                                        {
-                                            BindlessHandleDataEntry handleEntry;
-                                            parser.ReadToken();
-                                            parser.Read("(");
-                                            handleEntry.name = parser.ReadWord();
-                                            handleEntry.offset = offset;
-                                            parser.Read(")");
-                                            offset += 8;
-                                            entry.bindlessHandleEntry.add(handleEntry);
-                                            entry.bufferData.add(0);
-                                            entry.bufferData.add(0);
-                                            continue;
-                                        }
-
-                                        bool negate = false;
-                                        if(parser.NextToken().Type == TokenType::OpSub)
-                                        {
-                                            parser.ReadToken();
-                                            negate = true;
-                                        }
-
-                                        if (parser.NextToken().Type == TokenType::IntLiteral)
-                                        {
-                                            uint32_t val = parser.ReadUInt();
-                                            if(negate) val = uint32_t(-int32_t(val));
-                                            entry.bufferData.add(val);
-                                        }
-                                        else
-                                        {
-                                            auto floatNum = parser.ReadFloat();
-                                            if(negate) floatNum = -floatNum;
-                                            entry.bufferData.add(*(unsigned int*)&floatNum);
-                                        }
-                                        offset += 4;
-                                    }
-                                    parser.Read("]");
-                                }
-                                else if (word == "content")
-                                {
-                                    parser.Read("=");
-                                    auto contentWord = parser.ReadWord();
-                                    if (contentWord == "zero")
-                                        entry.textureDesc.content = InputTextureContent::Zero;
-                                    else if (contentWord == "one")
-                                        entry.textureDesc.content = InputTextureContent::One;
-                                    else if (contentWord == "chessboard")
-                                        entry.textureDesc.content = InputTextureContent::ChessBoard;
-                                    else
-                                        entry.textureDesc.content = InputTextureContent::Gradient;
-                                }
-                                else if(word == "format")
-                                {
-                                    Format format = Format::Unknown;
-
-                                    parser.Read("=");
-                                    auto formatWord = parser.ReadWord();
-                                    if(formatWord == "R_UInt32")
-                                    {
-                                        format = Format::R_UInt32;
-                                    }
-                                    else if (formatWord == "R_Float32")
-                                    {
-                                        format = Format::R_Float32;
-                                    }
-                                    else if (formatWord == "RGBA_Unorm_UInt8")
-                                    {
-                                        format = Format::RGBA_Unorm_UInt8;
-                                    }
-
-                                    entry.textureDesc.format = format;
-                                    entry.bufferDesc.format = format;
-                                }
-                                else if(word == "mipMaps")
-                                {
-                                    parser.Read("=");
-                                    entry.textureDesc.mipMapCount = int(parser.ReadInt());
-                                }
-                                else if( word == "type" )
-                                {
-                                    parser.Read("=");
-                                    entry.objectDesc.typeName = parser.ReadWord();
-                                }
-
-                                if (parser.LookAhead(","))
-                                    parser.Read(",");
-                                else
-                                    break;
-                            }
-                            parser.Read(")");
-                        }
-                        // parse bindings
-                        if (parser.LookAhead(":"))
+                        if (parser.LookAhead(","))
                         {
-                            parser.Read(":");
-                            while (!parser.IsEnd())
+                            parser.ReadToken();
+                            minValue = parser.ReadFloat();
+
+                            if (parser.LookAhead(","))
                             {
-                                if (parser.LookAhead("onlyCPULikeBinding"))
-                                {
-                                    entry.onlyCPULikeBinding = true;
-                                    parser.ReadToken();
-                                }
-                                else if (parser.LookAhead("out"))
-                                {
-                                    parser.ReadToken();
-                                    entry.isOutput = true;
-                                }
-                                else if (parser.LookAhead("name"))
-                                {
-                                    parser.ReadToken();
-
-                                    // Optionally consume '=' 
-                                    if (parser.NextToken().Type == TokenType::OpAssign)
-                                    {
-                                        parser.ReadToken();
-                                    }
-
-                                    StringBuilder builder;
-
-                                    Token nameToken = parser.ReadToken();
-                                    if (nameToken.Type != TokenType::Identifier)
-                                    {
-                                        throw TextFormatException(StringBuilder() << "Invalid input syntax at line " << parser.NextToken().Position.Line);
-                                    }
-                                    builder << nameToken.Content;
-
-                                    while (!parser.IsEnd())
-                                    {
-                                        Token token = parser.NextToken(0);
-
-                                        if (token.Type == TokenType::LBracket)
-                                        {
-                                            parser.ReadToken();
-                                            int index = parser.ReadInt();
-                                            SLANG_ASSERT(index >= 0);
-                                            parser.ReadMatchingToken(TokenType::RBracket);
-
-                                            builder << "[" << index << "]";
-                                        }
-                                        else if (token.Type == TokenType::Dot)
-                                        {
-                                            parser.ReadToken();
-                                            Token identifierToken = parser.ReadMatchingToken(TokenType::Identifier);
-
-                                            builder << "." << identifierToken.Content; 
-                                        }
-                                        else if (token.Type == TokenType::Comma)
-                                        {
-                                            // Break out
-                                            break;
-                                        }
-                                        else
-                                        {
-                                            throw TextFormatException(StringBuilder() << "Invalid input syntax at line " << parser.NextToken().Position.Line);
-                                        }
-                                    }
-
-                                    entry.name = builder;
-                                }
-                                else if (parser.LookAhead("bindless"))
-                                {
-                                    parser.ReadToken();
-                                    entry.isBindlessObject = true;
-                                }
-                                else
-                                {
-                                    fprintf(stderr, "Invalid TEST_INPUT syntax '%s'\n", parser.NextToken().Content.getBuffer());
-                                    break;
-                                }
-
-                                if (parser.LookAhead(","))
-                                    parser.Read(",");
+                                parser.ReadToken();
+                                maxValue = parser.ReadFloat();
                             }
                         }
-                        entries.add(entry);
+
+                        SLANG_ASSERT(minValue <= maxValue);
+                        maxValue = (maxValue >= minValue) ? maxValue : minValue;
+
+                        // Generate the data
+                        val->bufferData.setCount(size);
+
+                        float* dst = (float*)val->bufferData.getBuffer();
+                        for (int i = 0; i < size; ++i)
+                        {
+                            dst[i] = (rand->nextUnitFloat32() * (maxValue - minValue)) + minValue;
+                        }
+                        break;
                     }
                 }
-                catch (const TextFormatException&)
+
+                // Read the range
+
+                parser.Read(")");
+            }
+            else if(word == "format")
+            {
+                val->bufferDesc.format = parseFormatOption(parser);
+            }
+            else
+            {
+                return parseOption(parser, word, static_cast<ShaderInputLayout::DataValBase*>(val));
+            }
+            return SLANG_OK;
+        }
+
+        SlangResult parseOption(TokenReader& parser, String const& word, ShaderInputLayout::ObjectVal* val)
+        {
+            if( word == "type" )
+            {
+                parser.Read("=");
+                val->typeName = parser.ReadWord();
+            }
+            else
+            {
+                return SLANG_FAIL;
+            }
+            return SLANG_OK;
+        }
+
+        Format parseFormatOption(TokenReader& parser)
+        {
+            Format format = Format::Unknown;
+
+            parser.Read("=");
+            auto formatWord = parser.ReadWord();
+            if(formatWord == "R_UInt32")
+            {
+                format = Format::R_UInt32;
+            }
+            else if (formatWord == "R_Float32")
+            {
+                format = Format::R_Float32;
+            }
+            else if (formatWord == "RGBA_Unorm_UInt8")
+            {
+                format = Format::RGBA_Unorm_UInt8;
+            }
+            else
+            {
+                // TODO: an error message here
+            }
+            return format;
+        }
+
+        template<typename T>
+        void maybeParseOptions(TokenReader& parser, T* val)
+        {
+            // parse options
+            if (parser.LookAhead("("))
+            {
+                parser.Read("(");
+                while (!parser.IsEnd() && !parser.LookAhead(")"))
                 {
-                    StringBuilder msg;
-                    msg << "Invalid input syntax at line " << parser.NextToken().Position.Line;
-                    throw TextFormatException(msg);
+                    auto word = parser.ReadWord();
+                    if( SLANG_FAILED(parseOption(parser, word, val)) )
+                    {
+                        throw ShaderInputLayoutFormatException(String("Unsupported option '") + word + String("' at line ") + String(parser.NextToken().Position.Line));
+                    }
+
+                    if (parser.LookAhead(","))
+                        parser.Read(",");
+                    else
+                        break;
+                }
+                parser.Read(")");
+            }
+        }
+
+        RefPtr<ShaderInputLayout::Val> parseVal(TokenReader& parser)
+        {
+            auto word = parser.NextToken().Content;
+            if (parser.AdvanceIf("begin_array"))
+            {
+                RefPtr<ShaderInputLayout::ArrayVal> val = new ShaderInputLayout::ArrayVal;
+                pushParentVal(val);
+                return val;
+            }
+            else if (parser.AdvanceIf("begin_object"))
+            {
+                RefPtr<ShaderInputLayout::ObjectVal> val = new ShaderInputLayout::ObjectVal;
+                maybeParseOptions(parser, val.Ptr());
+
+                RefPtr<ShaderInputLayout::AggVal> contentVal = new ShaderInputLayout::AggVal;
+                val->contentVal = contentVal;
+                pushParentVal(contentVal);
+
+                return val;
+            }
+            else if (parser.AdvanceIf("uniform"))
+            {
+                RefPtr<ShaderInputLayout::DataVal> val = new ShaderInputLayout::DataVal;
+                maybeParseOptions(parser, val.Ptr());
+                return val;
+            }
+            else if (parser.AdvanceIf("cbuffer"))
+            {
+                // A `cbuffer` is basically just an object where the content of
+                // the object is being provided by `uniform` data instead.
+
+                RefPtr<ShaderInputLayout::ObjectVal> objVal = new ShaderInputLayout::ObjectVal;
+
+                RefPtr<ShaderInputLayout::DataVal> dataVal = new ShaderInputLayout::DataVal;
+                maybeParseOptions(parser, dataVal.Ptr());
+
+                objVal->contentVal = dataVal;
+
+                return objVal;
+            }
+            else if (parser.AdvanceIf("ubuffer"))
+            {
+                RefPtr<ShaderInputLayout::BufferVal> val = new ShaderInputLayout::BufferVal;
+                val->bufferDesc.type = InputBufferType::StorageBuffer;
+                maybeParseOptions(parser, val.Ptr());
+                return val;
+            }
+            else if (parser.AdvanceIf("Texture1D"))
+            {
+                RefPtr<ShaderInputLayout::TextureVal> val = new ShaderInputLayout::TextureVal;
+                val->textureDesc.dimension = 1;
+                maybeParseOptions(parser, val.Ptr());
+                return val;
+            }
+            else if (parser.AdvanceIf("Texture2D"))
+            {
+                RefPtr<ShaderInputLayout::TextureVal> val = new ShaderInputLayout::TextureVal;
+                val->textureDesc.dimension = 2;
+                maybeParseOptions(parser, val.Ptr());
+                return val;
+            }
+            else if (parser.AdvanceIf("Texture3D"))
+            {
+                RefPtr<ShaderInputLayout::TextureVal> val = new ShaderInputLayout::TextureVal;
+                val->textureDesc.dimension = 3;
+                maybeParseOptions(parser, val.Ptr());
+                return val;
+            }
+            else if (parser.AdvanceIf("TextureCube"))
+            {
+                RefPtr<ShaderInputLayout::TextureVal> val = new ShaderInputLayout::TextureVal;
+                val->textureDesc.dimension = 2;
+                val->textureDesc.isCube = true;
+                maybeParseOptions(parser, val.Ptr());
+                return val;
+            }
+            else if (parser.AdvanceIf("RWTexture1D"))
+            {
+                RefPtr<ShaderInputLayout::TextureVal> val = new ShaderInputLayout::TextureVal;
+                val->textureDesc.dimension = 1;
+                val->textureDesc.isRWTexture = true;
+                maybeParseOptions(parser, val.Ptr());
+                return val;
+            }
+            else if (parser.AdvanceIf("RWTexture2D"))
+            {
+                RefPtr<ShaderInputLayout::TextureVal> val = new ShaderInputLayout::TextureVal;
+                val->textureDesc.dimension = 2;
+                val->textureDesc.isRWTexture = true;
+                maybeParseOptions(parser, val.Ptr());
+                return val;
+            }
+            else if (parser.AdvanceIf("RWTexture3D"))
+            {
+                RefPtr<ShaderInputLayout::TextureVal> val = new ShaderInputLayout::TextureVal;
+                val->textureDesc.dimension = 3;
+                val->textureDesc.isRWTexture = true;
+                maybeParseOptions(parser, val.Ptr());
+                return val;
+            }
+            else if (parser.AdvanceIf("RWTextureCube"))
+            {
+                RefPtr<ShaderInputLayout::TextureVal> val = new ShaderInputLayout::TextureVal;
+                val->textureDesc.dimension = 2;
+                val->textureDesc.isCube = true;
+                val->textureDesc.isRWTexture = true;
+                maybeParseOptions(parser, val.Ptr());
+                return val;
+            }
+            else if (parser.AdvanceIf("Sampler"))
+            {
+                RefPtr<ShaderInputLayout::SamplerVal> val = new ShaderInputLayout::SamplerVal;
+                maybeParseOptions(parser, val.Ptr());
+                return val;
+            }
+            // TODO: We can include combined texture/sampler cases
+            // here, but we don't really have tests for them and
+            // it might be better to save it for a point where
+            // we support hierarchical binding values more directly.
+            else
+            {
+                throw ShaderInputLayoutFormatException(String("Unknown shader input type '") + word + String("' at line") + String(parser.NextToken().Position.Line));
+            }
+            parser.ReadToken();
+        }
+
+        void parseFieldBindings(TokenReader& parser, ShaderInputLayout::Field& ioField)
+        {
+            // parse bindings
+            if (parser.LookAhead(":"))
+            {
+                parser.Read(":");
+                while (!parser.IsEnd())
+                {
+                    if (parser.AdvanceIf("out"))
+                    {
+                        ioField.val->isOutput = true;
+                    }
+                    else if (parser.AdvanceIf("name"))
+                    {
+                        // Optionally consume '=' 
+                        if (parser.NextToken().Type == TokenType::OpAssign)
+                        {
+                            parser.ReadToken();
+                        }
+
+                        StringBuilder builder;
+
+                        Token nameToken = parser.ReadToken();
+                        if (nameToken.Type != TokenType::Identifier)
+                        {
+                            throw ShaderInputLayoutFormatException(StringBuilder() << "Invalid input syntax at line " << parser.NextToken().Position.Line);
+                        }
+                        builder << nameToken.Content;
+
+                        while (!parser.IsEnd())
+                        {
+                            Token token = parser.NextToken(0);
+
+                            if (token.Type == TokenType::LBracket)
+                            {
+                                parser.ReadToken();
+                                int index = parser.ReadInt();
+                                SLANG_ASSERT(index >= 0);
+                                parser.ReadMatchingToken(TokenType::RBracket);
+
+                                builder << "[" << index << "]";
+                            }
+                            else if (token.Type == TokenType::Dot)
+                            {
+                                parser.ReadToken();
+                                Token identifierToken = parser.ReadMatchingToken(TokenType::Identifier);
+
+                                builder << "." << identifierToken.Content; 
+                            }
+                            else if (token.Type == TokenType::Comma)
+                            {
+                                // Break out
+                                break;
+                            }
+                            else
+                            {
+                                throw ShaderInputLayoutFormatException(StringBuilder() << "Invalid input syntax at line " << parser.NextToken().Position.Line);
+                            }
+                        }
+
+                        ioField.name = builder;
+                    }
+                    else
+                    {
+                        fprintf(stderr, "Invalid TEST_INPUT syntax '%s'\n", parser.NextToken().Content.getBuffer());
+                        break;
+                    }
+
+                    if (parser.LookAhead(","))
+                        parser.Read(",");
                 }
             }
         }
+
+        void pushParentVal(ShaderInputLayout::ParentVal* val)
+        {
+            parentValStack.add(parentVal);
+            parentVal = val;
+        }
+
+        void parseValEntry(TokenReader& parser)
+        {
+            auto parentForNewVal = parentVal;
+
+            ShaderInputLayout::Field field;
+            field.val = parseVal(parser);
+            parseFieldBindings(parser, field);
+
+            parentForNewVal->addField(field);
+        }
+
+        void parseLine(TokenReader& parser)
+        {
+            if (parser.LookAhead("entryPointSpecializationArg")
+                || parser.LookAhead("type")
+                || parser.LookAhead("entryPointExistentialType"))
+            {
+                parser.ReadToken();
+                StringBuilder typeExp;
+                while (!parser.IsEnd())
+                    typeExp << parser.ReadToken().Content;
+                layout->entryPointSpecializationArgs.add(typeExp);
+            }
+            else if (parser.LookAhead("globalSpecializationArg")
+                || parser.LookAhead("global_type")
+                || parser.LookAhead("globalExistentialType"))
+            {
+                parser.ReadToken();
+                StringBuilder typeExp;
+                while (!parser.IsEnd())
+                    typeExp << parser.ReadToken().Content;
+                layout->globalSpecializationArgs.add(typeExp);
+            }
+            else if (parser.AdvanceIf("render_targets"))
+            {
+                layout->numRenderTargets = parser.ReadInt();
+            }
+            else if( parser.AdvanceIf("end") )
+            {
+                parentVal = parentValStack.getLast();
+                parentValStack.removeLast();
+            }
+            else
+            {
+                parseValEntry(parser);
+            }
+        }
+
+        RefPtr<ShaderInputLayout::AggVal> parse(const char * source)
+        {
+            RefPtr<ShaderInputLayout::AggVal> rootVal = new ShaderInputLayout::AggVal;
+            parentVal = rootVal;
+
+            auto lines = Split(source, '\n');
+            for (auto & line : lines)
+            {
+                if (line.startsWith("//TEST_INPUT:"))
+                {
+                    auto lineContent = line.subString(13, line.getLength() - 13);
+                    TokenReader parser(lineContent);
+                    try
+                    {
+                        parseLine(parser);
+                    }
+                    catch (const TextFormatException&)
+                    {
+                        StringBuilder msg;
+                        msg << "Invalid input syntax at line " << parser.NextToken().Position.Line;
+                        throw ShaderInputLayoutFormatException(msg);
+                    }
+                }
+            }
+
+            // TODO: check that stack has been maintained correctly...
+
+            return rootVal;
+        }
+    };
+
+    void ShaderInputLayout::parse(RandomGenerator* rand, const char * source)
+    {
+        rootVal = nullptr;
+        globalSpecializationArgs.clear();
+        entryPointSpecializationArgs.clear();
+
+        ShaderInputLayoutParser parser(this, rand);
+        rootVal = parser.parse(source);
     }
 
-    /* static */SlangResult ShaderInputLayout::writeBinding(const ShaderInputLayoutEntry& entry, slang::TypeLayoutReflection* typeLayout, const void* data, size_t sizeInBytes, WriterHelper writer)
+    /* static */SlangResult ShaderInputLayout::writeBinding(slang::TypeLayoutReflection* typeLayout, const void* data, size_t sizeInBytes, WriterHelper writer)
     {
         typedef slang::TypeReflection::ScalarType ScalarType;
 

--- a/tools/render-test/shader-renderer-util.cpp
+++ b/tools/render-test/shader-renderer-util.cpp
@@ -93,7 +93,6 @@ using Slang::Result;
 
 /* static */ Result ShaderRendererUtil::createBufferResource(
     const InputBufferDesc& inputDesc,
-    bool isOutput,
     size_t bufferSize,
     const void* initData,
     IDevice* device,
@@ -106,22 +105,10 @@ using Slang::Result;
     srcDesc.format = inputDesc.format;
 
     int bindFlags = 0;
-    if (inputDesc.type == InputBufferType::ConstantBuffer)
-    {
-        bindFlags |= IResource::BindFlag::ConstantBuffer;
-        srcDesc.cpuAccessFlags |= IResource::AccessFlag::Write;
-        initialUsage = IResource::Usage::ConstantBuffer;
-    }
-    else
     {
         bindFlags |= IResource::BindFlag::UnorderedAccess | IResource::BindFlag::PixelShaderResource | IResource::BindFlag::NonPixelShaderResource;
         srcDesc.elementSize = inputDesc.stride;
         initialUsage = IResource::Usage::UnorderedAccess;
-    }
-
-    if (isOutput)
-    {
-        srcDesc.cpuAccessFlags |= IResource::AccessFlag::Read;
     }
 
     srcDesc.bindFlags = bindFlags;

--- a/tools/render-test/shader-renderer-util.h
+++ b/tools/render-test/shader-renderer-util.h
@@ -31,7 +31,6 @@ struct ShaderRendererUtil
         /// Create the BufferResource using the renderer from the contents of inputDesc
     static Slang::Result createBufferResource(
         const InputBufferDesc& inputDesc,
-        bool isOutput,
         size_t bufferSize,
         const void* initData,
         IDevice* device,

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -363,7 +363,6 @@ void ShaderCompilerUtil::Output::reset()
 
     // Parse the layout
     layout.parse(rand, sourceText.getBuffer());
-    layout.updateForTarget(input.target);
 
     // Setup SourceInfo
     ShaderCompileRequest::SourceInfo sourceInfo;


### PR DESCRIPTION
The original goal of this change was to streamline the `TEST_INPUT` system by eliminating options that are no longer relevant once we have eliminated the non-shader-object execution paths. The result is more or less a re-implementation/refactor of the logic around how input is parsed and represented, that tries to set things up for a more general sytem going forward.

The main changes isthat the `ShaderInputLayout` no longer tracks a simple flat list of `ShaderInputLayoutEntry` (that is a kind of pseudo-union of the various buffer/texture/value cases), and it instead uses a hierarchical representation composed of `RefObject`-derived classes to represent "values."

There are several "simple" cases of values

* Textures

* Samplers

* Uniform/ordinary data (`uniform`)

* Buffers composed of uniform/ordinary data (`ubuffer`)

Then there are composed/aggregate values that nest other values:

* An *aggregate* value is a set of *fields* which are name/value pairs. It can be used to fill in a structure, for example.

* An *array* value is a list of values for the elements of an array. It can be used to fill out an array-of-textures parameter, for example.

* A combined texture/sampler value is a pair of a texture value and a sampler value (easy enough)

* An *object* holds an optional type name for a shader object to allocate (it defaults to the type that is "under" the current shader cursor when binding), and a nested value that describes how to fill in the contents of that object

Finally there are cases of values that are just syntactic sugar:

* A `cbuffer` is just shorthand for creating an object value with a nested uniform/ordinary data value

The big idea with this recursive structure is that it gives us a way to handle more arbitrary data types with name-based binding. Supporting this new capability requires changes to both how input layouts get parsed, and also how they get bound into shader objects.

On the parsing side, things have been refactored a bit so that parsing isn't a single monolithic routine. The refactor also tries to make it so that the various options on an input item (e.g., the `size=...` option for textures) are only supported on the relevant type of entry (so you can't specify as many useless options that will be ignored).

The bigger change to parsing is that it now supports a hierarchical structure, where certain input elements like `begin_array` can push a new "parent" value onto a stack, and subsequent `TEST_INPUT` lines will be parsed as children of that item until a matching `end` item. This approach means that we can now in principle describe arbitrary hierarchical structures as part of test input without endlessly increasing the complexity of invididual `TEST_INPUT` lines.

On the binding side, we now have a central recursive operation called `assign(ShaderCursor, ShaderInputLayout::ValPtr)` that assigns from a parsed `ShaderInputLayout` value to a particular cursor. That operation can then recurse on the fields/elements/contents of whatever the cursor points to.

Major open directions:

* With this change it is still necessary to use `uniform` entries to set things like individual integers or `float`s and that is a little silly. It would be good to have some streamlines cases for setting individual scalar values.

* Further, once we have a hierarchical representation of the values for `TEST_INPUT` lines, it becomes clear that we really ought to move to a format more like `TEST_INPUT: dstLocation = srcValue;` where `srcValue` is some kind of hierarchial expression grammar. Refactoring things in this way should make the binding logic even more clear and easy to understand. The refactored parser should make parsing hierarchical expressions easier to do in the future (even if it uses the push/pop model for now)

* One detailed note is that the representation of buffers in this change is kind of a compromise. Just as an "object" value is a thin wrapper around a recursively-contained value for its "content" it seems clear that a buffer could be represented as a wrapper around a content value that could include hierarchical aggregates/objects instead of just flat binary data (this would be important for things like a buffer over a structure type that lays out different on different targets). The main problem right now with changing the representation is actually needing to compute the size of a buffer based on its content, so that can/should be addressed in a subsequent change.

Details:

* The base `RenderTestApp` class and the `ShaderObjectRenderTestApp` classes have been merged, since the hierarchy no longer serves any purpose.

* Disabled the tess that rely on `StructuredBuffer<IWhatever>` because they aren't really supported by our current shader object implementation

* Replaced used of `Uniform` and `root_constants` in `TEST_INPUT` lines with just `uniform`

* Removed a bunch of uses of `stride` from `cbuffer` inputs, where it wasn't really correct/meaningful

* Added the `copyBuffer()` operation to VK/D3D renderers, along with some missing `Usage` cases to support it.

* Made `ShaderCursor` handle the logic to look up a name in the entry points of a root shader object, rather than just having that logic in `render-test`. (We probably need to make a clear design choice on this issue)