### PR TITLE
Add a streamlined syntax for TEST_INPUT lines

### DIFF
--- a/source/core/slang-token-reader.h
+++ b/source/core/slang-token-reader.h
@@ -175,6 +175,15 @@ namespace Slang
             }
             throw TextFormatException("Text parsing error: \'" + expectedStr + "\' expected.");
         }
+        bool Read(TokenType tokenType)
+        {
+            if( NextToken().Type == tokenType )
+            {
+                ReadToken();
+                return true;
+            }
+            throw TextFormatException("Text parsing error: unexpected '" + NextToken().Content + "'.");
+        }
 
         String ReadStringLiteral()
         {
@@ -225,6 +234,18 @@ namespace Slang
             {
                 auto next = NextToken();
                 return next.Content == token;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        bool LookAhead(TokenType tokenType)
+        {
+            if (tokenPtr < (int)tokens.getCount())
+            {
+                auto next = NextToken();
+                return next.Type == tokenType;
             }
             else
             {

--- a/tests/compute/array-existential-parameter.slang
+++ b/tests/compute/array-existential-parameter.slang
@@ -1,7 +1,7 @@
 // Test using existential shader parameter that is an interface array.
 
-//DISABLED_TEST(compute):COMPARE_COMPUTE:-cpu
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-cuda
+//TEST(compute):COMPARE_COMPUTE:-cpu
+//TEST(compute):COMPARE_COMPUTE:-cuda
 
 [anyValueSize(8)]
 interface IInterface
@@ -17,10 +17,10 @@ struct Params
     IInterface values[2];
 };
 
-//TEST_INPUT:cbuffer(data=[rtti(MyImpl) witness(MyImpl, IInterface) 1 0], stride=4):name=gCb
+//TEST_INPUT:set gCb = new{ values: [ new MyImpl{ val: 1 } ] }
 ConstantBuffer<Params> gCb;
 
-//TEST_INPUT:cbuffer(data=[rtti(MyImpl) witness(MyImpl, IInterface) 1 0], stride=4):name=gCb2
+//TEST_INPUT:set gCb2 = new{ values: [ new MyImpl{ val: 1 } ] }
 ConstantBuffer<Params> gCb2;
 
 [numthreads(4, 1, 1)]

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -334,6 +334,17 @@ struct AssignValsFromLayoutContext
         return SLANG_OK;
     }
 
+    SlangResult assignArray(ShaderCursor const& dstCursor, ShaderInputLayout::ArrayVal* srcVal)
+    {
+        Index elementCounter = 0;
+        for(auto elementVal : srcVal->vals)
+        {
+            Index elementIndex = elementCounter++;
+            SLANG_RETURN_ON_FAIL(assign(dstCursor[elementIndex], elementVal));
+        }
+        return SLANG_OK;
+    }
+
     SlangResult assign(ShaderCursor const& dstCursor, ShaderInputLayout::ValPtr const& srcVal)
     {
         auto& entryCursor = dstCursor;
@@ -359,6 +370,9 @@ struct AssignValsFromLayoutContext
 
         case ShaderInputType::Aggregate:
             return assignAggregate(dstCursor, (ShaderInputLayout::AggVal*) srcVal.Ptr());
+
+        case ShaderInputType::Array:
+            return assignArray(dstCursor, (ShaderInputLayout::ArrayVal*) srcVal.Ptr());
 
         default:
             assert(!"Unhandled type");


### PR DESCRIPTION
This change allows the `TEST_INPUT` syntax used by `render-test` to support aggregate values with a single input line more easily.
The test writer can now use a syntax like:

```
//TEST_INPUT:set someVar = 3.0
```

Input lines that start with the `set` keyword will now use a simpler `dst = src` format (instead of `dst:name=src` as the existing syntax used). The right-hand side expression can include:

* Numeric literals, both integer and floating-point (currently only supporting 32-bit scalar types; we could fix this later)
* Arrays, consisting of zero or more comma-separated expressions inside `[]`
* Aggregates, consisting of zero or more comma-separated "fields" inside `{}`. A field can either be `name: <expr>` or just `<expr>`
* Objects, which can be written as either `new SomeType{ <fields> }` or `new{ <fields> }` in the case where the type is know-able from context

With this approach is should be possible to support almost arbitrary-type inputs on a single line. For now, I have used this support to re-enable an existing test that had been disabled due to lack of support for setting up arrays of objects.

Major things left to do:

* The new syntax doesn't support the existing cases we had for `Texture2D`, etc. Those should probably be supported but I'd like to find a way to do it without duplicating the parsing logic (ideally the value cases from the existing code should Just Work in the new model)

* There is no support right now for non-32-bit scalar types

* It would be good if this support (and the shader cursor system) supported treating vectors like aggregates

* The actual value-setting logic doesn't currently handle aggregates without field names, so `{ a:0, b:1 }` will work but `{ 0, 1 }` will parse but fail when it comes time to set values

* While this approach lets complicated values be set with a single line, that isn't always what a user will want to do: in the future we should provide a way to break up an aggregate value over multiple lines that is consistent with this approach

* Once we port all of the relvant tests over, it would be great to drop the `set` prefix and have these lines look as simple and conventional as possible