### PR TITLE
Fixed 2 typos on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Slang
 
 [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/3jptgsry13k6wdwp/branch/master?svg=true)](https://ci.appveyor.com/project/shader-slang/slang/branch/master) [![Travis build status](https://travis-ci.org/shader-slang/slang.svg?branch=master)](https://travis-ci.org/shader-slang/slang)
 
-Slang is a shading language that makes it easier to build and maintain large shader codebases in a modular and estensible fashion, while also maintaining the higest possible performance on modern GPUs and graphics APIs.
+Slang is a shading language that makes it easier to build and maintain large shader codebases in a modular and extensible fashion, while also maintaining the highest possible performance on modern GPUs and graphics APIs.
 Slang is based on years of collaboration between researchers at NVIDIA, Carnegie Mellon University, and Stanford.
 
 Key Features


### PR DESCRIPTION
Introduction part of the README.md had 2 misspelled words: higest and estensible, fixed those