### PR TITLE
Fix a bug in the "operator cache"

### DIFF
--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -44,8 +44,10 @@ namespace Slang
         {
             if (auto elemCount = as<ConstantIntVal>(vectorType->elementCount))
             {
-                auto elemBasicType = as<BasicExpressionType>(vectorType->elementType);
-                return makeBasicTypeKey(elemBasicType->baseType, elemCount->value);
+                if( auto elemBasicType = as<BasicExpressionType>(vectorType->elementType) )
+                {
+                    return makeBasicTypeKey(elemBasicType->baseType, elemCount->value);
+                }
             }
         }
         else if (auto matrixType = as<MatrixExpressionType>(typeIn))
@@ -54,8 +56,10 @@ namespace Slang
             {
                 if (auto elemCount2 = as<ConstantIntVal>(matrixType->getColumnCount()))
                 {
-                    auto elemBasicType = as<BasicExpressionType>(matrixType->getElementType());
-                    return makeBasicTypeKey(elemBasicType->baseType, elemCount1->value, elemCount2->value);
+                    if( auto elemBasicType = as<BasicExpressionType>(matrixType->getElementType()) )
+                    {
+                        return makeBasicTypeKey(elemBasicType->baseType, elemCount1->value, elemCount2->value);
+                    }
                 }
             }
         }


### PR DESCRIPTION
In order to speed up compilation, the semantic checking step uses a cache for overload resolution in the case of an operator being applied to operations of basic scalar types and vectors/matrices thereof.

The logic for construct keys for that cache was defensive against the case of, e.g., `vector<int,N>` where the element count `N` of the vector was not a literal value but a generic parameter. For some reason it did not have equivalent safeguards for a case like `vector<T,2>` where the element type was not a basic type, and it would instead assume all vector/matrix types had basic types as their element type.

This change fixes the logic to make it properly defensive against this case.