### PR TITLE
Fix memory leak in `CacheFileSystem`

### DIFF
--- a/source/core/slang-file-system.h
+++ b/source/core/slang-file-system.h
@@ -116,7 +116,6 @@ class CacheFileSystem: public ISlangFileSystemExt, public RefObject
         PathInfo(const String& uniqueIdentity)
         {
             m_uniqueIdentity = new StringBlob(uniqueIdentity);
-            m_uniqueIdentity->addRef();
 
             m_loadFileResult = CompressedResult::Uninitialized;
             m_getPathTypeResult = CompressedResult::Uninitialized;


### PR DESCRIPTION
Not sure if this call to `addRef` is intentional, but it is causing memory leaks.