### PR TITLE
Allow overriding specialization args via `IShaderObject`.

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -544,6 +544,13 @@ public:
         setSampler(ShaderOffset const& offset, ISamplerState* sampler) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL setCombinedTextureSampler(
         ShaderOffset const& offset, IResourceView* textureView, ISamplerState* sampler) = 0;
+
+        /// Manually setting the specialization arguments for the shader object, overriding
+        /// the default arguments computed from the sub-objects.
+        /// Specialization arguments are passed to the shader compiler to specialize the type
+        /// of interface-typed shader parameters.
+    virtual SLANG_NO_THROW Result SLANG_MCALL
+        setSpecializationArgs(const slang::SpecializationArg* args, uint32_t count) = 0;
 };
 #define SLANG_UUID_IShaderObject                                                       \
     {                                                                                 \

--- a/tests/compute/dynamic-dispatch-14.slang
+++ b/tests/compute/dynamic-dispatch-14.slang
@@ -29,8 +29,7 @@ RWStructuredBuffer<int> gOutputBuffer;
 //TEST_INPUT: set gCb = new StructuredBuffer<IInterface>{new MyImpl{1}};
 RWStructuredBuffer<IInterface> gCb;
 
-// Add two elements into the structured buffer to prevent specialization.
-//TEST_INPUT: set gCb1 = new StructuredBuffer<IInterface>{new MyImpl{1}, new MyImpl2{2}};
+//TEST_INPUT: set gCb1 = new StructuredBuffer<IInterface>{new MyImpl{1}} : specialization_args(__Dynamic);
 RWStructuredBuffer<IInterface> gCb1;
 
 [numthreads(4, 1, 1)]

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -167,6 +167,9 @@ public:
         ShaderOffset const& offset,
         IResourceView* textureView,
         ISamplerState* sampler) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL setSpecializationArgs(
+        const slang::SpecializationArg* args,
+        uint32_t count) override;
 
 public:
     struct ShaderOffsetKey
@@ -188,6 +191,8 @@ public:
         }
     };
     Slang::String m_typeName;
+    slang::TypeReflection* m_slangType = nullptr;
+    DebugDevice* m_device;
     Slang::List<Slang::RefPtr<DebugShaderObject>> m_entryPoints;
     Slang::Dictionary<ShaderOffsetKey, Slang::RefPtr<DebugShaderObject>> m_objects;
     Slang::Dictionary<ShaderOffsetKey, Slang::RefPtr<DebugResourceView>> m_resources;
@@ -199,6 +204,8 @@ class DebugRootShaderObject : public DebugShaderObject
 public:
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL addRef() override { return 1; }
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL release() override { return 1; }
+    virtual SLANG_NO_THROW Result SLANG_MCALL
+        setSpecializationArgs(const slang::SpecializationArg* args, uint32_t count) override;
 };
 
 class DebugCommandBuffer;

--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -693,9 +693,8 @@ public:
         return SLANG_OK;
     }
 
-    virtual Result setSpecializationArgs(
-        const slang::SpecializationArg* args,
-        uint32_t count) override
+    virtual SLANG_NO_THROW Result SLANG_MCALL
+        setSpecializationArgs(const slang::SpecializationArg* args, uint32_t count) override
     {
         if (!m_userProvidedSpecializationArgs)
         {

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -341,6 +341,26 @@ struct AssignValsFromLayoutContext
 
         SLANG_RETURN_ON_FAIL(assign(ShaderCursor(shaderObject), srcVal->contentVal));
 
+        if (srcVal->specializationArgs.getCount())
+        {
+            List<slang::SpecializationArg> args;
+            for (auto srcArg : srcVal->specializationArgs)
+            {
+                auto argType = slangReflection->findTypeByName(srcArg.getBuffer());
+                if (argType)
+                {
+                    slang::SpecializationArg arg = slang::SpecializationArg::fromType(argType);
+                    args.add(arg);
+                }
+                else
+                {
+                    StdWriters::getError().print(
+                        "error: could not find shader type '%s'\n", srcArg.getBuffer());
+                    return SLANG_E_INVALID_ARG;
+                }
+            }
+            shaderObject->setSpecializationArgs(args.getBuffer(), args.getCount());
+        }
         dstCursor.setObject(shaderObject);
         return SLANG_OK;
     }

--- a/tools/render-test/shader-input-layout.h
+++ b/tools/render-test/shader-input-layout.h
@@ -248,6 +248,7 @@ public:
 
         Slang::String typeName;
         ValPtr contentVal;
+        Slang::List<Slang::String> specializationArgs;
     };
 
     class ArrayVal : public ParentVal


### PR DESCRIPTION
The purpose of this change is to provide a way for the user to override default specialization behavior of shader objects in the `gfx` layer.

A new method, `setSpecializationArgs(const slang::SpecializationArg* args, uint32_t count)` is added to the `gfx::IShaderObject` interface, which sets the specialization arguments to use for the shader object. If the method is not called by the user, the `gfx` layer will automatically derive them.

This change also extended the `render-test` infrastructure to make use of this feature.
The `TEST_INPUT` syntax now supports specifying specialization overrides for shader-object values, such as the following:
```
//TEST_INPUT: set gCb1 = new StructuredBuffer<IInterface>{new MyImpl{1}} : specialization_args(__Dynamic);
RWStructuredBuffer<IInterface> gCb1;
```

The existing test case `tests/compute/dynamic-dispatch-14.slang` has been modified to exercies this feature. Other test cases that involve `StructuredBuffer` parameters have not been modified so they can continue serve the purpose of testing the default specialization argument behavior.