### PR TITLE
Rework shader object specialization control interface.

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -545,12 +545,13 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL setCombinedTextureSampler(
         ShaderOffset const& offset, IResourceView* textureView, ISamplerState* sampler) = 0;
 
-        /// Manually setting the specialization arguments for the shader object, overriding
-        /// the default arguments computed from the sub-objects.
+        /// Manually overrides the specialization argument for the sub-object binding at `offset`.
         /// Specialization arguments are passed to the shader compiler to specialize the type
         /// of interface-typed shader parameters.
-    virtual SLANG_NO_THROW Result SLANG_MCALL
-        setSpecializationArgs(const slang::SpecializationArg* args, uint32_t count) = 0;
+    virtual SLANG_NO_THROW Result SLANG_MCALL setSpecializationArgs(
+        ShaderOffset const& offset,
+        const slang::SpecializationArg* args,
+        uint32_t count) = 0;
 };
 #define SLANG_UUID_IShaderObject                                                       \
     {                                                                                 \

--- a/tests/compute/dynamic-dispatch-14.slang
+++ b/tests/compute/dynamic-dispatch-14.slang
@@ -29,7 +29,7 @@ RWStructuredBuffer<int> gOutputBuffer;
 //TEST_INPUT: set gCb = new StructuredBuffer<IInterface>{new MyImpl{1}};
 RWStructuredBuffer<IInterface> gCb;
 
-//TEST_INPUT: set gCb1 = new StructuredBuffer<IInterface>{new MyImpl{1}} : specialization_args(__Dynamic);
+//TEST_INPUT: set gCb1 = dynamic new StructuredBuffer<IInterface>{new MyImpl{1}}
 RWStructuredBuffer<IInterface> gCb1;
 
 [numthreads(4, 1, 1)]

--- a/tools/gfx-util/shader-cursor.h
+++ b/tools/gfx-util/shader-cursor.h
@@ -92,6 +92,11 @@ struct ShaderCursor
         return m_baseObject->setObject(m_offset, object);
     }
 
+    SlangResult setSpecializationArgs(const slang::SpecializationArg* args, uint32_t count) const
+    {
+        return m_baseObject->setSpecializationArgs(m_offset, args, count);
+    }
+
     SlangResult setResource(IResourceView* resourceView) const
     {
         return m_baseObject->setResource(m_offset, resourceView);

--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -955,23 +955,12 @@ Result DebugShaderObject::setCombinedTextureSampler(
 }
 
 Result DebugShaderObject::setSpecializationArgs(
+    ShaderOffset const& offset,
     const slang::SpecializationArg* args,
     uint32_t count)
 {
-    ComPtr<slang::ISession> session;
-    m_device->getSlangSession(session.writeRef());
-    auto expectedCount = (uint32_t)session->getTypeLayout(m_slangType)
-                             ->getSize(SLANG_PARAMETER_CATEGORY_EXISTENTIAL_TYPE_PARAM);
-    if (expectedCount != count)
-    {
-        GFX_DIAGNOSE_ERROR_FORMAT(
-            "specialization argument count for shader object type %s mismatch: expecting %d but %d "
-            "provided.",
-            m_typeName.getBuffer(),
-            expectedCount,
-            count);
-    };
-    return baseObject->setSpecializationArgs(args, count);
+
+    return baseObject->setSpecializationArgs(offset, args, count);
 }
 
 DebugObjectBase::DebugObjectBase()
@@ -981,11 +970,11 @@ DebugObjectBase::DebugObjectBase()
 }
 
 Result DebugRootShaderObject::setSpecializationArgs(
+    ShaderOffset const& offset,
     const slang::SpecializationArg* args,
     uint32_t count)
 {
-    GFX_DIAGNOSE_ERROR("`setSpecializationArgs` should not be called directly on root objects.");
-    return baseObject->setSpecializationArgs(args, count);
+    return baseObject->setSpecializationArgs(offset, args, count);
 }
 
 } // namespace gfx

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -168,6 +168,7 @@ public:
         IResourceView* textureView,
         ISamplerState* sampler) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL setSpecializationArgs(
+        ShaderOffset const& offset,
         const slang::SpecializationArg* args,
         uint32_t count) override;
 
@@ -204,8 +205,10 @@ class DebugRootShaderObject : public DebugShaderObject
 public:
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL addRef() override { return 1; }
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL release() override { return 1; }
-    virtual SLANG_NO_THROW Result SLANG_MCALL
-        setSpecializationArgs(const slang::SpecializationArg* args, uint32_t count) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL setSpecializationArgs(
+        ShaderOffset const& offset,
+        const slang::SpecializationArg* args,
+        uint32_t count) override;
 };
 
 class DebugCommandBuffer;

--- a/tools/render-test/shader-input-layout.h
+++ b/tools/render-test/shader-input-layout.h
@@ -22,6 +22,7 @@ enum class ShaderInputType
     UniformData,
     Object,
     Aggregate,
+    Specialize,
 };
 
 enum class InputTextureContent
@@ -248,7 +249,16 @@ public:
 
         Slang::String typeName;
         ValPtr contentVal;
-        Slang::List<Slang::String> specializationArgs;
+    };
+
+    class SpecializeVal : public Val
+    {
+    public:
+        ValPtr contentVal;
+        Slang::List<Slang::String> typeArgs;
+        SpecializeVal()
+            : Val(ShaderInputType::Specialize)
+        {}
     };
 
     class ArrayVal : public ParentVal


### PR DESCRIPTION
This PR changes the shader object's `setSpecializationArgs` implementation to operate on a sub-object range instead of on the parent shader object itself. This design preserves better modularity.

The `render_test` comment syntax is also updated so you user can write:
```
//TEST_INPUT: set gCb1 = dynamic new StructuredBuffer<IInterface>{new MyImpl{1}}
RWStructuredBuffer<IInterface> gCb1;
```
or
```
//TEST_INPUT: set gCb1 = specialize(__Dynamic) new StructuredBuffer<IInterface>{new MyImpl{1}}
RWStructuredBuffer<IInterface> gCb1;
```
This code sets the specialization arg on the `gCb1` object instead of on the `StructuredBuffer` objects.