### PR TITLE
Fix cyclic reference in `ExtendedTypeLayout`.

### DIFF
--- a/source/slang/slang-reflection-api.cpp
+++ b/source/slang/slang-reflection-api.cpp
@@ -1405,6 +1405,7 @@ namespace Slang
 
             RefPtr<VarLayout> varLayout = new VarLayout();
             varLayout->typeLayout = typeLayout;
+            varLayout->typeLayout.demoteToWeakReference();
 
             for(auto typeResInfo : typeLayout->resourceInfos)
             {

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -2819,7 +2819,7 @@ static RefPtr<TypeLayout> maybeAdjustLayoutForArrayElementType(
 
         // If nothing needed to be changed on the inner element type,
         // then we are done.
-        if(adjustedInnerElementTypeLayout == originalInnerElementTypeLayout)
+        if (originalInnerElementTypeLayout == adjustedInnerElementTypeLayout)
             return originalTypeLayout;
 
         // TODO: actually adjust the element type, and create all the required bits and

--- a/source/slang/slang-type-layout.h
+++ b/source/slang/slang-type-layout.h
@@ -467,7 +467,7 @@ public:
     Name* getName() { return getVariable()->getName(); }
 
     // The result of laying out the variable's type
-    RefPtr<TypeLayout>      typeLayout;
+    TransformablePtr<TypeLayout> typeLayout;
     TypeLayout* getTypeLayout() { return typeLayout.Ptr(); }
 
     // Additional flags


### PR DESCRIPTION
This change fixes a cyclic reference in `ExtendedTypeLayout`.
The problematic reference is in `TypeLayout::m_extendedLayout::subObjectRange::varOffsetLayout::typeLayout`, which references back to the initial `TypeLayout` object in a `RefPtr`. The solution is to introduce a `TransformablePtr` that can be demoted into a weak pointer, and demote the `varOffsetLayout::typeLayout` into a weak pointer when creating the `varOffsetLayout`.