### PR TITLE
Fix D3D11 `uploadBufferResource`.

### DIFF
--- a/tools/gfx/cpu/render-cpu.cpp
+++ b/tools/gfx/cpu/render-cpu.cpp
@@ -1085,7 +1085,11 @@ public:
 
     virtual SLANG_NO_THROW SlangResult SLANG_MCALL initialize(const Desc& desc) override
     {
-        SLANG_RETURN_ON_FAIL(slangContext.initialize(desc.slang, SLANG_HOST_CALLABLE, "sm_5_1"));
+        SLANG_RETURN_ON_FAIL(slangContext.initialize(
+            desc.slang,
+            SLANG_HOST_CALLABLE,
+            "sm_5_1",
+            makeArray(slang::PreprocessorMacroDesc{ "__CPU__", "1" }).getView()));
 
         SLANG_RETURN_ON_FAIL(RendererBase::initialize(desc));
 
@@ -1244,7 +1248,12 @@ public:
         auto bufferImpl = static_cast<CPUBufferResource*>(buffer);
         return bufferImpl->m_data;
     }
-    virtual void unmap(IBufferResource* buffer) override { SLANG_UNUSED(buffer); }
+    virtual void unmap(IBufferResource* buffer, size_t offsetWritten, size_t sizeWritten) override
+    {
+        SLANG_UNUSED(buffer);
+        SLANG_UNUSED(offsetWritten);
+        SLANG_UNUSED(sizeWritten);
+    }
 };
 
 SlangResult CPUShaderObject::init(IDevice* device, CPUShaderObjectLayout* typeLayout)

--- a/tools/gfx/cuda/render-cuda.cpp
+++ b/tools/gfx/cuda/render-cuda.cpp
@@ -1176,7 +1176,11 @@ public:
 public:
     virtual SLANG_NO_THROW SlangResult SLANG_MCALL initialize(const Desc& desc) override
     {
-        SLANG_RETURN_ON_FAIL(slangContext.initialize(desc.slang, SLANG_PTX, "sm_5_1"));
+        SLANG_RETURN_ON_FAIL(slangContext.initialize(
+            desc.slang,
+            SLANG_PTX,
+            "sm_5_1",
+            makeArray(slang::PreprocessorMacroDesc{ "__CUDA_COMPUTE__", "1" }).getView()));
 
         SLANG_RETURN_ON_FAIL(RendererBase::initialize(desc));
 

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -4254,7 +4254,11 @@ static bool _isSupportedNVAPIOp(ID3D12Device* dev, uint32_t op)
 
 Result D3D12Device::initialize(const Desc& desc)
 {
-    SLANG_RETURN_ON_FAIL(slangContext.initialize(desc.slang, SLANG_DXBC, "sm_5_1"));
+    SLANG_RETURN_ON_FAIL(slangContext.initialize(
+        desc.slang,
+        SLANG_DXBC,
+        "sm_5_1",
+        makeArray(slang::PreprocessorMacroDesc{ "__D3D12__", "1" }).getView()));
 
     SLANG_RETURN_ON_FAIL(RendererBase::initialize(desc));
 

--- a/tools/gfx/immediate-renderer-base.cpp
+++ b/tools/gfx/immediate-renderer-base.cpp
@@ -471,7 +471,7 @@ void ImmediateRendererBase::uploadBufferData(
 {
     auto buffer = map(dst, gfx::MapFlavor::WriteDiscard);
     memcpy((uint8_t*)buffer + offset, data, size);
-    unmap(dst);
+    unmap(dst, offset, size);
 }
 
 SLANG_NO_THROW SlangResult SLANG_MCALL ImmediateRendererBase::readBufferResource(
@@ -486,7 +486,7 @@ SLANG_NO_THROW SlangResult SLANG_MCALL ImmediateRendererBase::readBufferResource
     if (!content)
         return SLANG_FAIL;
     memcpy(blob->m_data.getBuffer(), content + offset, size);
-    unmap(buffer);
+    unmap(buffer, offset, size);
     returnComPtr(outBlob, blob);
     return SLANG_OK;
 }

--- a/tools/gfx/immediate-renderer-base.h
+++ b/tools/gfx/immediate-renderer-base.h
@@ -74,7 +74,7 @@ public:
     virtual void submitGpuWork() = 0;
     virtual void waitForGpu() = 0;
     virtual void* map(IBufferResource* buffer, MapFlavor flavor) = 0;
-    virtual void unmap(IBufferResource* buffer) = 0;
+    virtual void unmap(IBufferResource* buffer, size_t offsetWritten, size_t sizeWritten) = 0;
 
 public:
     Slang::RefPtr<ImmediateCommandQueueBase> m_queue;

--- a/tools/gfx/open-gl/render-gl.cpp
+++ b/tools/gfx/open-gl/render-gl.cpp
@@ -152,7 +152,7 @@ public:
         ITextureResource* texture, ResourceState state, ISlangBlob** outBlob, size_t* outRowPitch, size_t* outPixelSize) override;
 
     virtual void* map(IBufferResource* buffer, MapFlavor flavor) override;
-    virtual void unmap(IBufferResource* buffer) override;
+    virtual void unmap(IBufferResource* buffer, size_t offsetWritten, size_t sizeWritten) override;
     virtual void setPrimitiveTopology(PrimitiveTopology topology) override;
 
     virtual void setVertexBuffers(
@@ -1937,7 +1937,12 @@ HGLRC GLDevice::createGLContext(HDC hdc)
 
 SLANG_NO_THROW Result SLANG_MCALL GLDevice::initialize(const Desc& desc)
 {
-    SLANG_RETURN_ON_FAIL(slangContext.initialize(desc.slang, SLANG_GLSL, "glsl_440"));
+    SLANG_RETURN_ON_FAIL(slangContext.initialize(
+        desc.slang,
+        SLANG_GLSL,
+        "glsl_440",
+        makeArray(
+            slang::PreprocessorMacroDesc{ "__GL__", "1" }).getView()));
 
     SLANG_RETURN_ON_FAIL(RendererBase::initialize(desc));
 
@@ -2557,8 +2562,10 @@ void* GLDevice::map(IBufferResource* bufferIn, MapFlavor flavor)
     return glMapBuffer(buffer->m_target, access);
 }
 
-void GLDevice::unmap(IBufferResource* bufferIn)
+void GLDevice::unmap(IBufferResource* bufferIn, size_t offsetWritten, size_t sizeWritten)
 {
+    SLANG_UNUSED(offsetWritten);
+    SLANG_UNUSED(sizeWritten);
     BufferResourceImpl* buffer = static_cast<BufferResourceImpl*>(bufferIn);
     glUnmapBuffer(buffer->m_target);
 }

--- a/tools/gfx/slang-context.h
+++ b/tools/gfx/slang-context.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "slang-gfx.h"
+#include "core/slang-basic.h"
 
 namespace gfx
 {
@@ -9,7 +10,8 @@ namespace gfx
     public:
         Slang::ComPtr<slang::IGlobalSession> globalSession;
         Slang::ComPtr<slang::ISession> session;
-        Result initialize(const gfx::IDevice::SlangDesc& desc, SlangCompileTarget compileTarget, const char* defaultProfileName)
+        Result initialize(const gfx::IDevice::SlangDesc& desc, SlangCompileTarget compileTarget, const char* defaultProfileName,
+            Slang::ConstArrayView<slang::PreprocessorMacroDesc> additionalMacros)
         {
             if (desc.slangGlobalSession)
             {
@@ -24,8 +26,11 @@ namespace gfx
             slangSessionDesc.defaultMatrixLayoutMode = desc.defaultMatrixLayoutMode;
             slangSessionDesc.searchPathCount = desc.searchPathCount;
             slangSessionDesc.searchPaths = desc.searchPaths;
-            slangSessionDesc.preprocessorMacroCount = desc.preprocessorMacroCount;
-            slangSessionDesc.preprocessorMacros = desc.preprocessorMacros;
+            slangSessionDesc.preprocessorMacroCount = desc.preprocessorMacroCount + additionalMacros.getCount();
+            Slang::List<slang::PreprocessorMacroDesc> macros;
+            macros.addRange(desc.preprocessorMacros, desc.preprocessorMacroCount);
+            macros.addRange(additionalMacros.getBuffer(), additionalMacros.getCount());
+            slangSessionDesc.preprocessorMacros = macros.getBuffer();
             slang::TargetDesc targetDesc = {};
             targetDesc.format = compileTarget;
             auto targetProfile = desc.targetProfile;

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -6473,4 +6473,4 @@ Result VKDevice::createComputePipelineState(const ComputePipelineStateDesc& inDe
     return SLANG_OK;
 }
 
-} // renderer_test
+} //  renderer_test

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -5120,7 +5120,11 @@ SlangResult VKDevice::initialize(const Desc& desc)
         SLANG_RETURN_ON_FAIL(m_deviceQueue.init(m_api, queue, m_queueFamilyIndex));
     }
 
-    SLANG_RETURN_ON_FAIL(slangContext.initialize(desc.slang, SLANG_SPIRV, "sm_5_1"));
+    SLANG_RETURN_ON_FAIL(slangContext.initialize(
+        desc.slang,
+        SLANG_SPIRV,
+        "sm_5_1",
+        makeArray(slang::PreprocessorMacroDesc{ "__VK__", "1" }).getView()));
     return SLANG_OK;
 }
 


### PR DESCRIPTION
Also: `[gfx]` nows sets define per-platform preprocessor macro when compiling shaders, this is needed to write platform-dependent shader code.