### PR TITLE
Support timestamp queries in `gfx`.

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -849,10 +849,31 @@ public:
         0xdaab0b1a, 0xf45d, 0x4ae9, { 0xbf, 0x2c, 0xe0, 0xbb, 0x76, 0x7d, 0xfa, 0xd1 } \
     }
 
+enum class QueryType
+{
+    Timestamp,
+};
+
+class IQueryPool : public ISlangUnknown
+{
+public:
+    struct Desc
+    {
+        QueryType type;
+        SlangInt count;
+    };
+public:
+    virtual SLANG_NO_THROW Result SLANG_MCALL getResult(SlangInt queryIndex, SlangInt count, uint64_t* data) = 0;
+};
+#define SLANG_UUID_IQueryPool                                                         \
+    { 0xc2cc3784, 0x12da, 0x480a, { 0xa8, 0x74, 0x8b, 0x31, 0x96, 0x1c, 0xa4, 0x36 } }
+
+
 class ICommandEncoder : public ISlangUnknown
 {
 public:
     virtual SLANG_NO_THROW void SLANG_MCALL endEncoding() = 0;
+    virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, SlangInt queryIndex) = 0;
 };
 #define SLANG_UUID_ICommandEncoder                                                     \
     {                                                                                  \
@@ -1104,6 +1125,9 @@ struct DeviceInfo
 
     /// The name of the graphics adapter.
     const char* adapterName = nullptr;
+
+    /// The clock frequency used in timestamp queries.
+    uint64_t timestampFrequency = 0;
 };
 
 enum class DebugMessageType
@@ -1378,6 +1402,9 @@ public:
 
         /// Get the type of this renderer
     virtual SLANG_NO_THROW const DeviceInfo& SLANG_MCALL getDeviceInfo() const = 0;
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL createQueryPool(
+        const IQueryPool::Desc& desc, IQueryPool** outPool) = 0;
 };
 
 #define SLANG_UUID_IDevice                                                             \

--- a/tools/gfx/command-writer.h
+++ b/tools/gfx/command-writer.h
@@ -23,7 +23,8 @@ enum class CommandName
     SetStencilReference,
     DispatchCompute,
     UploadBufferData,
-    CopyBuffer
+    CopyBuffer,
+    WriteTimestamp,
 };
 
 const uint8_t kMaxCommandOperands = 5;
@@ -82,6 +83,7 @@ public:
     Slang::List<Command> m_commands;
     Slang::List<Slang::ComPtr<ISlangUnknown>> m_objects;
     Slang::List<uint8_t> m_data;
+    bool m_hasWriteTimestamps = false;
 
 public:
     void clear()
@@ -91,6 +93,7 @@ public:
             obj = nullptr;
         m_objects.clear();
         m_data.clear();
+        m_hasWriteTimestamps = false;
     }
 
     // Copies user data into `m_data` buffer and returns the offset to retrieve the data.
@@ -247,6 +250,14 @@ public:
     {
         m_commands.add(
             Command(CommandName::DispatchCompute, (uint32_t)x, (uint32_t)y, (uint32_t)z));
+    }
+
+    void writeTimestamp(IQueryPool* pool, SlangInt index)
+    {
+        auto poolOffset = encodeObject(pool);
+        m_commands.add(
+            Command(CommandName::WriteTimestamp, poolOffset, (uint32_t)index));
+        m_hasWriteTimestamps = true;
     }
 };
 }

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -99,6 +99,20 @@ public:
         size_t size,
         ISlangBlob** outBlob) override;
     virtual SLANG_NO_THROW const DeviceInfo& SLANG_MCALL getDeviceInfo() const override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL createQueryPool(
+        const IQueryPool::Desc& desc,
+        IQueryPool** outPool) override;
+};
+
+class DebugQueryPool : public DebugObject<IQueryPool>
+{
+public:
+    SLANG_COM_OBJECT_IUNKNOWN_ALL;
+
+    IQueryPool::Desc desc;
+public:
+    IQueryPool* getInterface(const Slang::Guid& guid);
+    virtual SLANG_NO_THROW Result SLANG_MCALL getResult(SlangInt index, SlangInt count, uint64_t* data) override;
 };
 
 class DebugBufferResource : public DebugObject<IBufferResource>
@@ -227,6 +241,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
         bindPipeline(IPipelineState* state, IShaderObject** outRootShaderObject) override;
     virtual SLANG_NO_THROW void SLANG_MCALL dispatchCompute(int x, int y, int z) override;
+    virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* pool, SlangInt index) override;
 
 public:
     DebugCommandBuffer* commandBuffer;
@@ -264,6 +279,7 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL
         drawIndexed(UInt indexCount, UInt startIndex = 0, UInt baseVertex = 0) override;
     virtual SLANG_NO_THROW void SLANG_MCALL setStencilReference(uint32_t referenceValue) override;
+    virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* pool, SlangInt index) override;
 
 public:
     DebugCommandBuffer* commandBuffer;
@@ -289,6 +305,7 @@ public:
         size_t size) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
         uploadBufferData(IBufferResource* dst, size_t offset, size_t size, void* data) override;
+    virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* pool, SlangInt index) override;
 
 public:
     DebugCommandBuffer* commandBuffer;

--- a/tools/gfx/immediate-renderer-base.h
+++ b/tools/gfx/immediate-renderer-base.h
@@ -40,6 +40,11 @@ public:
     void establishStrongReferenceToDevice() { m_renderer.establishStrongReference(); }
 };
 
+struct CommandBufferInfo
+{
+    bool hasWriteTimestamps;
+};
+
 class ImmediateRendererBase : public RendererBase
 {
 public:
@@ -75,6 +80,9 @@ public:
     virtual void waitForGpu() = 0;
     virtual void* map(IBufferResource* buffer, MapFlavor flavor) = 0;
     virtual void unmap(IBufferResource* buffer, size_t offsetWritten, size_t sizeWritten) = 0;
+    virtual void writeTimestamp(IQueryPool* pool, SlangInt index) = 0;
+    virtual void beginCommandBuffer(const CommandBufferInfo&) {}
+    virtual void endCommandBuffer(const CommandBufferInfo&) {}
 
 public:
     Slang::RefPtr<ImmediateCommandQueueBase> m_queue;

--- a/tools/gfx/open-gl/render-gl.cpp
+++ b/tools/gfx/open-gl/render-gl.cpp
@@ -170,6 +170,18 @@ public:
     virtual void dispatchCompute(int x, int y, int z) override;
     virtual void submitGpuWork() override {}
     virtual void waitForGpu() override {}
+    virtual void writeTimestamp(IQueryPool* pool, SlangInt index) override
+    {
+        SLANG_UNUSED(pool);
+        SLANG_UNUSED(index);
+    }
+    virtual SLANG_NO_THROW Result SLANG_MCALL createQueryPool(
+        const IQueryPool::Desc& desc, IQueryPool** pool) override
+    {
+        SLANG_UNUSED(desc);
+        *pool = nullptr;
+        return SLANG_E_NOT_IMPLEMENTED;
+    }
     virtual SLANG_NO_THROW const DeviceInfo& SLANG_MCALL getDeviceInfo() const override
     {
         return m_info;

--- a/tools/gfx/renderer-shared.cpp
+++ b/tools/gfx/renderer-shared.cpp
@@ -31,6 +31,8 @@ const Slang::Guid GfxGUID::IID_IComputeCommandEncoder = SLANG_UUID_IComputeComma
 const Slang::Guid GfxGUID::IID_IResourceCommandEncoder = SLANG_UUID_IResourceCommandEncoder;
 const Slang::Guid GfxGUID::IID_ICommandBuffer = SLANG_UUID_ICommandBuffer;
 const Slang::Guid GfxGUID::IID_ICommandQueue = SLANG_UUID_ICommandQueue;
+const Slang::Guid GfxGUID::IID_IQueryPool = SLANG_UUID_IQueryPool;
+
 
 StageType translateStage(SlangStage slangStage)
 {

--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -35,6 +35,7 @@ struct GfxGUID
     static const Slang::Guid IID_IResourceCommandEncoder;
     static const Slang::Guid IID_ICommandBuffer;
     static const Slang::Guid IID_ICommandQueue;
+    static const Slang::Guid IID_IQueryPool;
 };
 
 // We use a `BreakableReference` to avoid the cyclic reference situation in gfx implementation.

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -3451,7 +3451,7 @@ public:
         // a `CommandBuffer` created from the heap. We need to break the cycle when
         // the public reference count of a command buffer drops to 0.
         SLANG_COM_OBJECT_IUNKNOWN_ALL
-            ICommandBuffer* getInterface(const Guid& guid)
+        ICommandBuffer* getInterface(const Guid& guid)
         {
             if (guid == GfxGUID::IID_ISlangUnknown || guid == GfxGUID::IID_ICommandBuffer)
                 return static_cast<ICommandBuffer*>(this);

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -104,6 +104,9 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL createComputePipelineState(
         const ComputePipelineStateDesc& desc,
         IPipelineState** outState) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL createQueryPool(
+        const IQueryPool::Desc& desc,
+        IQueryPool** outPool) override;
 
     virtual SLANG_NO_THROW SlangResult SLANG_MCALL readTextureResource(
         ITextureResource* texture,
@@ -3448,7 +3451,7 @@ public:
         // a `CommandBuffer` created from the heap. We need to break the cycle when
         // the public reference count of a command buffer drops to 0.
         SLANG_COM_OBJECT_IUNKNOWN_ALL
-        ICommandBuffer* getInterface(const Guid& guid)
+            ICommandBuffer* getInterface(const Guid& guid)
         {
             if (guid == GfxGUID::IID_ISlangUnknown || guid == GfxGUID::IID_ICommandBuffer)
                 return static_cast<ICommandBuffer*>(this);
@@ -3498,7 +3501,7 @@ public:
             VkCommandBufferBeginInfo beginInfo = {
                 VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
                 nullptr,
-                VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT};
+                VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT };
             api.vkBeginCommandBuffer(m_commandBuffer, &beginInfo);
             if (m_preCommandBuffer)
             {
@@ -3520,7 +3523,7 @@ public:
             VkCommandBufferBeginInfo beginInfo = {
                 VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
                 nullptr,
-                VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT};
+                VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT };
             api.vkBeginCommandBuffer(m_preCommandBuffer, &beginInfo);
             return SLANG_OK;
         }
@@ -3532,6 +3535,20 @@ public:
                 return m_preCommandBuffer;
             createPreCommandBuffer();
             return m_preCommandBuffer;
+        }
+
+        static void _writeTimestamp(
+            VulkanApi* api,
+            VkCommandBuffer vkCmdBuffer,
+            IQueryPool* queryPool,
+            SlangInt index)
+        {
+            auto queryPoolImpl = static_cast<QueryPoolImpl*>(queryPool);
+            api->vkCmdResetQueryPool(vkCmdBuffer, queryPoolImpl->m_pool, (uint32_t)index, 1);
+            api->vkCmdWriteTimestamp(vkCmdBuffer,
+                VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                queryPoolImpl->m_pool,
+                (uint32_t)index);
         }
 
     public:
@@ -3590,6 +3607,11 @@ public:
                 auto& api = *m_api;
                 api.vkCmdEndRenderPass(m_vkCommandBuffer);
                 endEncodingImpl();
+            }
+
+            virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, SlangInt index) override
+            {
+                _writeTimestamp(m_api, m_vkCommandBuffer, queryPool, index);
             }
 
             virtual SLANG_NO_THROW Result SLANG_MCALL
@@ -3843,6 +3865,11 @@ public:
                 flushBindingState(VK_PIPELINE_BIND_POINT_COMPUTE);
                 m_api->vkCmdDispatch(m_vkCommandBuffer, x, y, z);
             }
+
+            virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, SlangInt index) override
+            {
+                _writeTimestamp(m_api, m_vkCommandBuffer, queryPool, index);
+            }
         };
 
         RefPtr<ComputeCommandEncoder> m_computeCommandEncoder;
@@ -3938,6 +3965,15 @@ public:
                     nullptr,
                     0,
                     nullptr);
+            }
+
+            virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, SlangInt index) override
+            {
+                _writeTimestamp(
+                    &m_commandBuffer->m_renderer->m_api,
+                    m_commandBuffer->m_commandBuffer,
+                    queryPool,
+                    index);
             }
 
             void init(CommandBufferImpl* commandBuffer)
@@ -4118,6 +4154,59 @@ public:
         virtual SLANG_NO_THROW Result SLANG_MCALL
             createCommandBuffer(ICommandBuffer** outCommandBuffer) override;
         virtual SLANG_NO_THROW Result SLANG_MCALL synchronizeAndReset() override;
+    };
+
+    class QueryPoolImpl
+        : public IQueryPool
+        , public ComObject
+    {
+    public:
+        SLANG_COM_OBJECT_IUNKNOWN_ALL
+        IQueryPool* getInterface(const Guid& guid)
+        {
+            if (guid == GfxGUID::IID_ISlangUnknown || guid == GfxGUID::IID_IQueryPool)
+                return static_cast<IQueryPool*>(this);
+            return nullptr;
+        }
+    public:
+        Result init(const IQueryPool::Desc& desc, VKDevice* device)
+        {
+            m_device = device;
+            VkQueryPoolCreateInfo createInfo = {};
+            createInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+            createInfo.queryCount = (uint32_t)desc.count;
+            switch (desc.type)
+            {
+            case QueryType::Timestamp:
+                createInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
+                break;
+            default:
+                return SLANG_E_INVALID_ARG;
+            }
+            SLANG_VK_RETURN_ON_FAIL(m_device->m_api.vkCreateQueryPool(
+                m_device->m_api.m_device, &createInfo, nullptr, &m_pool));
+            return SLANG_OK;
+        }
+        ~QueryPoolImpl()
+        {
+            m_device->m_api.vkDestroyQueryPool(m_device->m_api.m_device, m_pool, nullptr);
+        }
+    public:
+        virtual SLANG_NO_THROW Result SLANG_MCALL getResult(SlangInt index, SlangInt count, uint64_t* data) override
+        {
+            SLANG_VK_RETURN_ON_FAIL(m_device->m_api.vkGetQueryPoolResults(
+                m_device->m_api.m_device,
+                m_pool,
+                (uint32_t)index,
+                (uint32_t)count,
+                sizeof(uint64_t) * count,
+                data,
+                sizeof(uint64_t), 0));
+            return SLANG_OK;
+        }
+    public:
+        VkQueryPool m_pool;
+        RefPtr<VKDevice> m_device;
     };
 
     class SwapchainImpl
@@ -4934,6 +5023,9 @@ Result VKDevice::initVulkanInstanceAndDevice(bool useValidationLayer)
 
     VkPhysicalDeviceProperties basicProps = {};
     m_api.vkGetPhysicalDeviceProperties(m_api.m_physicalDevice, &basicProps);
+
+    // Compute timestamp frequency.
+    m_info.timestampFrequency = uint64_t(1e9 / basicProps.limits.timestampPeriod);
 
     // Get the API version
     const uint32_t majorVersion = VK_VERSION_MAJOR(basicProps.apiVersion);
@@ -6470,6 +6562,16 @@ Result VKDevice::createComputePipelineState(const ComputePipelineStateDesc& inDe
     m_deviceObjectsWithPotentialBackReferences.add(pipelineStateImpl);
     pipelineStateImpl->establishStrongDeviceReference();
     returnComPtr(outState, pipelineStateImpl);
+    return SLANG_OK;
+}
+
+Result VKDevice::createQueryPool(
+    const IQueryPool::Desc& desc,
+    IQueryPool** outPool)
+{
+    RefPtr<QueryPoolImpl> result = new QueryPoolImpl();
+    SLANG_RETURN_ON_FAIL(result->init(desc, this));
+    returnComPtr(outPool, result);
     return SLANG_OK;
 }
 

--- a/tools/gfx/vulkan/vk-api.h
+++ b/tools/gfx/vulkan/vk-api.h
@@ -91,6 +91,10 @@ namespace gfx {
     x(vkCmdCopyBufferToImage)\
     x(vkCmdPushConstants) \
     x(vkCmdSetStencilReference) \
+    x(vkCmdWriteTimestamp) \
+    x(vkCmdBeginQuery) \
+    x(vkCmdEndQuery) \
+    x(vkCmdResetQueryPool) \
     \
     x(vkCreateFence) \
     x(vkDestroyFence) \
@@ -116,6 +120,10 @@ namespace gfx {
     \
     x(vkBindImageMemory) \
     x(vkBindBufferMemory) \
+    \
+    x(vkCreateQueryPool) \
+    x(vkGetQueryPoolResults) \
+    x(vkDestroyQueryPool) \
     /* */
 
 #if SLANG_WINDOWS_FAMILY


### PR DESCRIPTION
This changes add an `IQueryPool` interface that is similar to Vulkan's `VkQueryPool` to allow querying GPU timestamps.
This feature can be used to obtain performance data.