### PR TITLE
Properly fill `declref` in `Linkage::getContainerType`.

### DIFF
--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -257,6 +257,29 @@ VectorExpressionType* ASTBuilder::getVectorType(
     return as<VectorExpressionType>(DeclRefType::create(this, declRef));
 }
 
+DeclRef<Decl> ASTBuilder::getBuiltinDeclRef(const char* bubiltinMagicTypeName, ConstArrayView<Val*> genericArgs)
+{
+    DeclRef<Decl> declRef;
+    declRef.decl = m_sharedASTBuilder->findMagicDecl(bubiltinMagicTypeName);
+    if (auto genericDecl = as<GenericDecl>(declRef.decl))
+    {
+        if (genericArgs.getCount())
+        {
+            auto substitutions = create<GenericSubstitution>();
+            substitutions->genericDecl = genericDecl;
+            for (auto arg : genericArgs)
+                substitutions->args.add(arg);
+            declRef.substitutions = substitutions;
+        }
+        declRef.decl = genericDecl->inner;
+    }
+    else
+    {
+        SLANG_ASSERT(genericArgs.getCount() == 0);
+    }
+    return declRef;
+}
+
 Type* ASTBuilder::getAndType(Type* left, Type* right)
 {
     auto type = create<AndType>();

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -257,10 +257,10 @@ VectorExpressionType* ASTBuilder::getVectorType(
     return as<VectorExpressionType>(DeclRefType::create(this, declRef));
 }
 
-DeclRef<Decl> ASTBuilder::getBuiltinDeclRef(const char* bubiltinMagicTypeName, ConstArrayView<Val*> genericArgs)
+DeclRef<Decl> ASTBuilder::getBuiltinDeclRef(const char* builtinMagicTypeName, ConstArrayView<Val*> genericArgs)
 {
     DeclRef<Decl> declRef;
-    declRef.decl = m_sharedASTBuilder->findMagicDecl(bubiltinMagicTypeName);
+    declRef.decl = m_sharedASTBuilder->findMagicDecl(builtinMagicTypeName);
     if (auto genericDecl = as<GenericDecl>(declRef.decl))
     {
         if (genericArgs.getCount())

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -153,7 +153,7 @@ public:
 
     VectorExpressionType* getVectorType(Type* elementType, IntVal* elementCount);
 
-    DeclRef<Decl> getBuiltinDeclRef(const char* bubiltinMagicTypeName, ConstArrayView<Val*> genericArgs);
+    DeclRef<Decl> getBuiltinDeclRef(const char* builtinMagicTypeName, ConstArrayView<Val*> genericArgs);
 
     Type* getAndType(Type* left, Type* right);
 

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -153,6 +153,8 @@ public:
 
     VectorExpressionType* getVectorType(Type* elementType, IntVal* elementCount);
 
+    DeclRef<Decl> getBuiltinDeclRef(const char* bubiltinMagicTypeName, ConstArrayView<Val*> genericArgs);
+
     Type* getAndType(Type* left, Type* right);
 
     TypeType* getTypeType(Type* type);

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -939,6 +939,8 @@ SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL Linkage::getContainerType(
             {
                 ConstantBufferType* cbType = getASTBuilder()->create<ConstantBufferType>();
                 cbType->elementType = type;
+                cbType->declRef = getASTBuilder()->getBuiltinDeclRef(
+                    "ConstantBuffer", makeConstArrayView<Val*>(static_cast<Val*>(type)));
                 containerTypeReflection = cbType;
             }
             break;
@@ -946,6 +948,8 @@ SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL Linkage::getContainerType(
             {
                 ParameterBlockType* pbType = getASTBuilder()->create<ParameterBlockType>();
                 pbType->elementType = type;
+                pbType->declRef = getASTBuilder()->getBuiltinDeclRef(
+                    "ParameterBlock", makeConstArrayView<Val*>(static_cast<Val*>(type)));
                 containerTypeReflection = pbType;
             }
             break;
@@ -954,14 +958,14 @@ SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL Linkage::getContainerType(
                 HLSLStructuredBufferType* sbType =
                     getASTBuilder()->create<HLSLStructuredBufferType>();
                 sbType->elementType = type;
+                sbType->declRef = getASTBuilder()->getBuiltinDeclRef(
+                    "HLSLStructuredBufferType", makeConstArrayView<Val*>(static_cast<Val*>(type)));
                 containerTypeReflection = sbType;
             }
             break;
         case slang::ContainerType::UnsizedArray:
             {
-                ArrayExpressionType* arrType = getASTBuilder()->create<ArrayExpressionType>();
-                arrType->baseType = type;
-                arrType->arrayLength = nullptr;
+                ArrayExpressionType* arrType = getASTBuilder()->getArrayType(type, nullptr);
                 containerTypeReflection = arrType;
             }
             break;

--- a/tools/gfx/cpu/render-cpu.cpp
+++ b/tools/gfx/cpu/render-cpu.cpp
@@ -1259,6 +1259,7 @@ public:
         const IQueryPool::Desc& desc, IQueryPool** outPool) override
     {
         RefPtr<CPUQueryPool> pool = new CPUQueryPool();
+        pool->init(desc);
         returnComPtr(outPool, pool);
         return SLANG_OK;
     }

--- a/tools/gfx/cpu/render-cpu.cpp
+++ b/tools/gfx/cpu/render-cpu.cpp
@@ -1132,6 +1132,7 @@ public:
             static const float kIdentity[] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
             ::memcpy(m_info.identityProjectionMatrix, kIdentity, sizeof(kIdentity));
             m_info.adapterName = "CPU";
+            m_info.timestampFrequency = 1000000000;
         }
 
         return SLANG_OK;


### PR DESCRIPTION
`Linkage::getContainerType` is introduced in #1851 to allow users to conveniently obtain a specialized `StructuredBuffer<T>` or `ParameterBlock<T>` types with a given element type.

The implementation was not complete in that it does not fill in the `declRef` field of the resulting `Type`. This can lead to crashes when the `declRef` is used, such as in `Type::getName()`. This change fixes this issue by properly looking up and fill in the declref.

Also includes a small fix to the cpu timestamp query implementation.