### PR TITLE
Initial support for variadic macros

### DIFF
--- a/source/compiler-core/slang-lexer.cpp
+++ b/source/compiler-core/slang-lexer.cpp
@@ -951,7 +951,23 @@ namespace Slang
             case '5': case '6': case '7': case '8': case '9':
                 return _lexNumberAfterDecimalPoint(lexer, 10);
 
-            // TODO(tfoley): handle ellipsis (`...`)
+            case '.':
+                // Note: consuming the second `.` here means that
+                // we cannot back up and return a `.` token by itself
+                // any more. We thus end up having distinct tokens for
+                // `.`, `..`, and `...` even though the `..` case is
+                // not part of HLSL.
+                //
+                _advance(lexer);
+                switch(_peek(lexer))
+                {
+                case '.':
+                    _advance(lexer);
+                    return TokenType::Ellipsis;
+
+                default:
+                    return TokenType::DotDot;
+                }
 
             default:
                 return TokenType::Dot;

--- a/source/compiler-core/slang-token-defs.h
+++ b/source/compiler-core/slang-token-defs.h
@@ -35,6 +35,8 @@ TOKEN(BlockComment,     "block comment")
 PUNCTUATION(Semicolon,  ";")
 PUNCTUATION(Comma,      ",")
 PUNCTUATION(Dot,        ".")
+PUNCTUATION(DotDot,     "..")
+PUNCTUATION(Ellipsis,   "...")
 
 PUNCTUATION(LBrace,     "{")
 PUNCTUATION(RBrace,     "}")

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -172,6 +172,7 @@ DIAGNOSTIC(15405, Error, tokenPasteAtStart, "'##' is not allowed at the start of
 DIAGNOSTIC(15406, Error, tokenPasteAtEnd, "'##' is not allowed at the end of a macro body")
 DIAGNOSTIC(15407, Error, expectedMacroParameterAfterStringize, "'#' in macro body must be followed by the name of a macro parameter")
 DIAGNOSTIC(15408, Error, duplicateMacroParameterName, "redefinition of macro parameter '$0'")
+DIAGNOSTIC(15409, Error, variadicMacroParameterMustBeLast, "a variadic macro parameter is only allowed at the end of the parameter list")
 
 // 155xx - macro expansion
 DIAGNOSTIC(15500, Warning, expectedTokenInMacroArguments, "expected '$0' in macro invocation")

--- a/tests/preprocessor/macros/variadic-macro.slang
+++ b/tests/preprocessor/macros/variadic-macro.slang
@@ -1,0 +1,30 @@
+// variadic-macro.slang
+//DIAGNOSTIC_TEST:SIMPLE:-E
+
+// First we text a variadic macro with the default variadic
+// parameter name (`__VA_ARGS__`) and other non-variadic parameter.
+
+#define A(X, ...) (X ; __VA_ARGS__)
+
+A(1, 2, 3)
+
+// Next we test a varadic macro where the variadic parameter
+// has been given an explicit name.
+
+#define B(B_ARGS...) (B_ARGS)
+
+B(4, 5)
+
+// Finally, we test the case where the variadic parameter
+// might have zero arguments passed for it, so that
+// the result produces a trailing comma.
+//
+// TODO: If we add support for deleting trailing commas
+// in these cases to Slang, we can update this case to
+// test that support.
+
+#define C(Y, ARGS...) (Y , ARGS)
+
+C(1)
+C(2, 3)
+C(4, 5, 6)

--- a/tests/preprocessor/macros/variadic-macro.slang.expected
+++ b/tests/preprocessor/macros/variadic-macro.slang.expected
@@ -1,0 +1,6 @@
+result code = 0
+standard error = {
+}
+standard output = {
+( 1 ; 2 , 3 ) ( 4 , 5 ) ( 1 , ) ( 2 , 3 ) ( 4 , 5 , 6 ) 
+}


### PR DESCRIPTION
This change adds support for variadic macros in the C-style
preprocessor, e.g.:

    #define DEBUG(MSG, ...) print(__FILE__, __LINE__, MSG, __VA_ARGS__)

Similar to the gcc preprocessor, this feature supports both named
variadic macro parameters and unnamed ones (which then default to
`__VA_ARGS__`.

The implementation work is mostly straightforward, although there are a
few subtle design choices worth mentioning:

* A variadic macro is represented by it having a variadic *parameter*
  that is part of the ordinary parameter list.

* Argument parsing does *not* detect whether the macro being invoked is
  variadic and collect/combine arguments to form a single argument value
  for the variadic parameter. This is motivated by the need for some
  extensions to differentiate a variadic parameter receiving a single
  empty argument vs. zero arguments.

* Because any reference to the variadic parameter needs to expand to the
  comma-separated arguments that match it, the logic for turning a macro
  parameter reference into a list of tokens has been factored out into a
  subroutine that handles the details.

* The choice in the earlier refactor to have a macro invocation collect
  all the argument tokens (including the intervening commas) into a
  single token list seems to pay off here, because it means that the
  tokens in the expansion of a variadic parameter reference were already
  stored contiguously.

* The special-case logic for handling an empty argument list had to be
  tweaked again to ensure that an empty argument list is treated as
  having zero arguments for the variadic parameter. Note that
  historically C did not define the behavior of this case, and always
  required at least one argument for any variadic macro parameter.

* The logic for checking whether the number of arguments to a macro
  invocation is valid needed to handle variadic and non-variadic macros
  as distinct cases. There really isn't much overlap in how the checks
  need to work, even if we tried to change the underling representation.

The main missing feature here is any way to discard a comma in a macro
body that appears before a variadic parameter reference, e.g.:

    #define DEBUG(...) print("debug:", __VA_ARGS__)

In this case, an empty invocation list `DEBUG()` will expand to
`print("debug:",)` - a call with a trailing comma in the argument list.

If users end up needing a way to discard commas in cases like this, we
have many options we can consider. This change does not implement any of
them to keep the initial work as minimal as possible.