### PR TITLE
[gfx] Add `IBufferResource::getDeviceAddress()`.

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -36,6 +36,7 @@ typedef SlangResult Result;
 // Had to move here, because Options needs types defined here
 typedef SlangInt Int;
 typedef SlangUInt UInt;
+typedef uint64_t DeviceAddress;
 
 // Declare opaque type
 class IInputLayout: public ISlangUnknown
@@ -295,6 +296,7 @@ public:
         Format format = Format::Unknown;
     };
     virtual SLANG_NO_THROW Desc* SLANG_MCALL getDesc() = 0;
+    virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() = 0;
 };
 #define SLANG_UUID_IBufferResource                                                     \
     {                                                                                  \

--- a/tools/gfx/cpu/render-cpu.cpp
+++ b/tools/gfx/cpu/render-cpu.cpp
@@ -37,7 +37,8 @@ public:
     SlangResult init()
     {
         m_data = malloc(m_desc.sizeInBytes);
-        if(!m_data) return SLANG_E_OUT_OF_MEMORY;
+        if (!m_data)
+            return SLANG_E_OUT_OF_MEMORY;
         return SLANG_OK;
     }
 
@@ -48,6 +49,11 @@ public:
     }
 
     void* m_data = nullptr;
+
+    virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() override
+    {
+        return (DeviceAddress)m_data;
+    }
 };
 
 struct CPUTextureBaseShapeInfo

--- a/tools/gfx/cuda/render-cuda.cpp
+++ b/tools/gfx/cuda/render-cuda.cpp
@@ -188,6 +188,11 @@ public:
     void* m_cudaMemory = nullptr;
 
     RefPtr<CUDAContext> m_cudaContext;
+
+    virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() override
+    {
+        return (DeviceAddress)m_cudaMemory;
+    }
 };
 
 class TextureCUDAResource : public TextureResource

--- a/tools/gfx/d3d11/render-d3d11.cpp
+++ b/tools/gfx/d3d11/render-d3d11.cpp
@@ -210,6 +210,11 @@ protected:
         ComPtr<ID3D11Buffer> m_buffer;
         ComPtr<ID3D11Buffer> m_staging;
         List<uint8_t> m_uploadStagingBuffer;
+
+        virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() override
+        {
+            return 0;
+        }
     };
     class TextureResourceImpl : public TextureResource
     {

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -198,6 +198,11 @@ public:
         D3D12Resource m_uploadResource;     ///< If the resource can be written to, and is in gpu memory (ie not Memory backed), will have upload resource
 
         D3D12_RESOURCE_STATES m_defaultState;
+
+        virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() override
+        {
+            return (DeviceAddress)m_resource.getResource()->GetGPUVirtualAddress();
+        }
     };
 
     class TextureResourceImpl: public TextureResource

--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -501,6 +501,11 @@ IBufferResource::Desc* DebugBufferResource::getDesc()
     return baseObject->getDesc();
 }
 
+DeviceAddress DebugBufferResource::getDeviceAddress()
+{
+    return baseObject->getDeviceAddress();
+}
+
 IResource::Type DebugTextureResource::getType()
 {
     SLANG_GFX_API_FUNC;

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -124,6 +124,7 @@ public:
     IBufferResource* getInterface(const Slang::Guid& guid);
     virtual SLANG_NO_THROW Type SLANG_MCALL getType() override;
     virtual SLANG_NO_THROW Desc* SLANG_MCALL getDesc() override;
+    virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() override;
 };
 
 class DebugTextureResource : public DebugObject<ITextureResource>

--- a/tools/gfx/open-gl/render-gl.cpp
+++ b/tools/gfx/open-gl/render-gl.cpp
@@ -242,6 +242,11 @@ public:
 		GLuint m_handle;
         GLenum m_target;
         UInt m_size;
+
+        virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() override
+        {
+            return 0;
+        }
 	};
 
     class TextureResourceImpl: public TextureResource

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -179,6 +179,17 @@ public:
         RefPtr<VKDevice> m_renderer;
         Buffer m_buffer;
         Buffer m_uploadBuffer;
+
+        virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() override
+        {
+            if (!m_buffer.m_api->vkGetBufferDeviceAddress)
+                return 0;
+            VkBufferDeviceAddressInfo info = {};
+            info.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
+            info.buffer = m_buffer.m_buffer;
+            return (DeviceAddress)m_buffer.m_api->vkGetBufferDeviceAddress(
+                m_buffer.m_api->m_device, &info);
+        }
     };
 
     class TextureResourceImpl : public TextureResource

--- a/tools/gfx/vulkan/vk-api.cpp
+++ b/tools/gfx/vulkan/vk-api.cpp
@@ -87,6 +87,11 @@ Slang::Result VulkanApi::initDeviceProcs(VkDevice device)
         return SLANG_FAIL;
     }
 
+    if (!vkGetBufferDeviceAddressKHR && vkGetBufferDeviceAddressEXT)
+        vkGetBufferDeviceAddressKHR = vkGetBufferDeviceAddressEXT;
+    if (!vkGetBufferDeviceAddress && vkGetBufferDeviceAddressKHR)
+        vkGetBufferDeviceAddress = vkGetBufferDeviceAddressKHR;
+
     m_device = device;
     return SLANG_OK;
 }

--- a/tools/gfx/vulkan/vk-api.h
+++ b/tools/gfx/vulkan/vk-api.h
@@ -143,6 +143,7 @@ namespace gfx {
     x(vkGetPhysicalDeviceSurfacePresentModesKHR) \
     x(vkGetPhysicalDeviceSurfaceCapabilitiesKHR) \
     x(vkDestroySurfaceKHR) \
+
     /* */
 
 #define VK_API_DEVICE_KHR_PROCS(x) \
@@ -155,6 +156,10 @@ namespace gfx {
 
 #define VK_API_DEVICE_OPT_PROCS(x) \
     x(vkCmdSetPrimitiveTopologyEXT) \
+    x(vkGetBufferDeviceAddress) \
+    x(vkGetBufferDeviceAddressKHR) \
+    x(vkGetBufferDeviceAddressEXT) \
+
     /* */
 
 #define VK_API_ALL_GLOBAL_PROCS(x) \


### PR DESCRIPTION
Needed for ray tracing APIs.
D3D11 doesn't support this API, will return 0.
OpenGL support is possible via bindless extensions, but not currently implemented with this change, and will also return 0.