### PR TITLE
Minor refactor to gfx D3D12 implementation.

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -909,6 +909,25 @@ struct ComputePipelineStateDesc
     IShaderProgram*  program;
 };
 
+struct RayTracingPipelineFlags
+{
+    enum Enum : uint32_t
+    {
+        None = 0,
+        SkipTriangles = 1,
+        SkipProcedurals = 2,
+    };
+};
+
+struct RayTracingPipelineStateDesc
+{
+    IShaderProgram* program = nullptr;
+
+    int maxRecursion;
+    int maxRayPayloadSize;
+    RayTracingPipelineFlags::Enum flags;
+};
+
 class IPipelineState : public ISlangUnknown
 {
 };
@@ -1596,6 +1615,9 @@ public:
         SLANG_RETURN_NULL_ON_FAIL(createComputePipelineState(desc, state.writeRef()));
         return state;
     }
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL createRayTracingPipelineState(
+        const RayTracingPipelineStateDesc& desc, IPipelineState** outState) = 0;
 
         /// Read back texture resource and stores the result in `outBlob`.
     virtual SLANG_NO_THROW SlangResult SLANG_MCALL readTextureResource(

--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -612,6 +612,24 @@ Result DebugDevice::createComputePipelineState(
     return result;
 }
 
+Result DebugDevice::createRayTracingPipelineState(
+    const RayTracingPipelineStateDesc& desc,
+    IPipelineState** outState)
+{
+    SLANG_GFX_API_FUNC;
+
+    RayTracingPipelineStateDesc innerDesc = desc;
+    innerDesc.program = static_cast<DebugShaderProgram*>(desc.program)->baseObject;
+
+    RefPtr<DebugPipelineState> outObject = new DebugPipelineState();
+    auto result =
+        baseObject->createRayTracingPipelineState(innerDesc, outObject->baseObject.writeRef());
+    if (SLANG_FAILED(result))
+        return result;
+    returnComPtr(outState, outObject);
+    return result;
+}
+
 SlangResult DebugDevice::readTextureResource(
     ITextureResource* resource,
     ResourceState state,

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -102,6 +102,9 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL createComputePipelineState(
         const ComputePipelineStateDesc& desc,
         IPipelineState** outState) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL createRayTracingPipelineState(
+        const RayTracingPipelineStateDesc& desc,
+        IPipelineState** outState) override;
     virtual SLANG_NO_THROW SlangResult SLANG_MCALL readTextureResource(
         ITextureResource* resource,
         ResourceState state,

--- a/tools/gfx/renderer-shared.cpp
+++ b/tools/gfx/renderer-shared.cpp
@@ -303,6 +303,13 @@ Result RendererBase::createAccelerationStructure(
     return SLANG_E_NOT_AVAILABLE;
 }
 
+Result RendererBase::createRayTracingPipelineState(const RayTracingPipelineStateDesc& desc, IPipelineState** outState)
+{
+    SLANG_UNUSED(desc);
+    SLANG_UNUSED(outState);
+    return SLANG_E_NOT_AVAILABLE;
+}
+
 Result RendererBase::getShaderObjectLayout(
     slang::TypeReflection* type,
     ShaderObjectContainerType container,

--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -1092,6 +1092,11 @@ public:
         const IAccelerationStructure::CreateDesc& desc,
         IAccelerationStructure** outView) override;
 
+    // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE for platforms
+    // without ray tracing support.
+    virtual SLANG_NO_THROW Result SLANG_MCALL createRayTracingPipelineState(
+        const RayTracingPipelineStateDesc& desc, IPipelineState** outState) override;
+
     Result getShaderObjectLayout(
         slang::TypeReflection*      type,
         ShaderObjectContainerType   container,

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -5612,9 +5612,11 @@ SlangResult VKDevice::initialize(const Desc& desc)
     SlangResult initDeviceResult = SLANG_OK;
     for (int forceSoftware = 0; forceSoftware <= 1; forceSoftware++)
     {
-        if (m_module.init(forceSoftware != 0) != SLANG_OK)
+        initDeviceResult = m_module.init(forceSoftware != 0);
+        if (initDeviceResult != SLANG_OK)
             continue;
-        if (m_api.initGlobalProcs(m_module) != SLANG_OK)
+        initDeviceResult = m_api.initGlobalProcs(m_module);
+        if (initDeviceResult != SLANG_OK)
             continue;
         descriptorSetAllocator.m_api = &m_api;
         initDeviceResult = initVulkanInstanceAndDevice(ENABLE_VALIDATION_LAYER != 0);


### PR DESCRIPTION
- Allow more flexible collection of shader stages in a shader program.
- Add `createRayTracingPipelineState` public interface. (no implementation).
- Fix a bug in vulkan initialization that causes a crash when vulkan is not available.