### PR TITLE
Fix a few issues around opaque types as outputs

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -465,7 +465,7 @@ Result linkAndOptimizeIR(
     // and turned into SSA temporaries. Such optimization may enable
     // the following passes to "see" and specialize more cases.
     //
-    // TODO: We should consider whether there are cases that would require
+    // TODO: We should consider whether there are cases that will require
     // iterating the passes as given here in order to achieve a fully
     // specialized result. If that is the case, we might consider implementing
     // a single combined pass that makes all of the relevant changes and

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -452,6 +452,20 @@ Result linkAndOptimizeIR(
     // pass down the target request along with the IR.
     //
     specializeResourceOutputs(compileRequest, targetRequest, irModule);
+    //
+    // After specialization of function outputs, we may find that there
+    // are cases where opaque-typed local variables can now be eliminated
+    // and turned into SSA temporaries. Such optimization may enable
+    // the following passes to "see" and specialize more cases.
+    //
+    // TODO: We should consider whether there are cases that would require
+    // iterating the passes as given here in order to achieve a fully
+    // specialized reuslt. If that is the case, we might consider implementing
+    // a single combined pass that makes all of the relevant changes and
+    // iterates to convergence.
+    //
+    constructSSA(irModule);
+    //
     specializeFuncsForBufferLoadArgs(compileRequest, targetRequest, irModule);
     specializeResourceParameters(compileRequest, targetRequest, irModule);
 

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -467,7 +467,7 @@ Result linkAndOptimizeIR(
     //
     // TODO: We should consider whether there are cases that would require
     // iterating the passes as given here in order to achieve a fully
-    // specialized reuslt. If that is the case, we might consider implementing
+    // specialized result. If that is the case, we might consider implementing
     // a single combined pass that makes all of the relevant changes and
     // iterates to convergence.
     //

--- a/source/slang/slang-ir-specialize-resources.cpp
+++ b/source/slang/slang-ir-specialize-resources.cpp
@@ -342,6 +342,9 @@ struct ResourceOutputSpecializationPass
         if(as<IRByteAddressBufferTypeBase>(type))
             return true;
 
+        if(as<IRSamplerStateTypeBase>(type))
+            return true;
+
         // TODO: more cases here?
 
         return false;


### PR DESCRIPTION
Slang and HLSL support opaque types (textures, buffers, samplers, etc.) as members of `struct`s, mutable local variables, function results, and `out`/`inout` parameters. GLSL and SPIR-V do not.

In order to translate Slang code over to GLSL/SPIR-V we use a variety of passes that seek to eliminate all of the above use cases and produce code that only uses opaque types in the limited ways that GLSL/SPIR-V allow. This change relates to the passes that deal with function results and `out`/`inout` parameters.

There are two basic changes here:

1. The `specializeResourceOutputs` pass was only dealing with resource (texture/buffer) types. This change updates it to process sampler types as well.

2. The sequencing of the passes made it possible that an opaque-typed local variable might be left around after `specializeResourceOutputs`, which would mean the code is still invalid for GLSL/SPIR-V. This change adds an additional SSA-formation pass which would eliminate any opaque-type local variables whose lifetimes were made simple enough by the optimizations.

Together these changes fix a problem-case user shader that was failing to compile for Vulkan.