### PR TITLE
Handle unexpected character in mangled names

### DIFF
--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -540,19 +540,28 @@ void CLikeSourceEmitter::appendScrubbedName(const UnownedStringSlice& name, Stri
 
     for(auto c : name)
     {
-        // We will treat a dot character just like an underscore
-        // for the purposes of producing a scrubbed name, so
-        // that we translate `SomeType.someMethod` into
-        // `SomeType_someMethod`.
+        // We will treat a dot character or any path separator
+        // just like an underscore for the purposes of producing
+        // a scrubbed name, so that we translate `SomeType.someMethod`
+        // into `SomeType_someMethod`. This increases the readability
+        // of output code when the input used lots of nesting of
+        // code under types/namespaces/etc.
         //
         // By handling this case at the top of this loop, we
         // ensure that a `.`-turned-`_` is handled just like
         // a `_` in the original name, and will be properly
         // scrubbed for GLSL output.
         //
-        if(c == '.')
+        switch(c)
         {
+        default:
+            break;
+
+        case '.':
+        case '\\':
+        case '/':
             c = '_';
+            break;
         }
 
         if(((c >= 'a') && (c <= 'z'))


### PR DESCRIPTION
This change is related to a case where a user saw a `/` character printed as part of a structure field name in output HLSL (which obviously broke downstream compilation).

The root cause in that case was that a module that was `import`ed was found via a file system directory path, and thus the module name that the Slang compiler formed included a `/`. Due to other factors the structure field was emitted based on its mangled name (missing name hint), and that meant the bare `/` escaped into the output.

That situation implies some other things maybe are questionable:

* Could we have avoided a `/` ending up in the module name to begin with? Maybe, but we kind of want to support non-ASCII characters in names in the long run.

* Could we have fixed whatever was causing the name hint to be dropped? Maybe, but we don't ever want name hints to be *required* for valid compilation (hence why they are "hints").

Even if we investigate these other issues, it is important that the name mangling scheme only ever produce output that uses a constrained subset of ASCII that we expect most compilation targets can support (GLSL being an annoying outlier because of its rules around `_`).

This change adds a path where when mangling a `Name` as part of a mangled symbol name we check for the presence of bytes that aren't allowed and then produce an escaped form instead if needed. Note that the code is still byte-oriented for now aothough in the long-run it might want to be oriented around Unicode code points or extended grapheme clusters.