### PR TITLE
Add `createDynamicObject` stdlib function.

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1901,6 +1901,12 @@ __generic<T, U>
 __intrinsic_op($(kIROp_BitCast))
 T bit_cast(U value);
 
+// Create Existential object
+__generic<T, U>
+[__unsafeForceInlineEarly]
+__intrinsic_op($(kIROp_CreateExistentialObject))
+T createDynamicObject(uint typeId, U value);
+
 // Specialized function
 
 /// Given a string returns an integer hash of that string.

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -644,6 +644,9 @@ INST(MakeExistential,                   makeExistential,                2, 0)
 // but with the type of `v` being an explict operand.
 INST(MakeExistentialWithRTTI,           makeExistentialWithRTTI,        3, 0)
 
+// A 'CreateExistentialObject<I>(typeID, T)` packs user-provided `typeID` and a
+// value of any type, and constructs an existential value of type `I`.
+INST(CreateExistentialObject,           createExistentialObject,        2, 0)
 
 // A `wrapExistential(v, T0,w0, T1,w0) : T` instruction is similar to `makeExistential`.
 // but applies to a value `v` that is of type `BindExistentials(T, T0,w0, ...)`. The

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -1726,6 +1726,14 @@ struct IRMakeExistentialWithRTTI : IRInst
     IR_LEAF_ISA(MakeExistentialWithRTTI)
 };
 
+struct IRCreateExistentialObject : IRInst
+{
+    IRInst* getTypeID() { return getOperand(0); }
+    IRInst* getValue() { return getOperand(1); }
+
+    IR_LEAF_ISA(CreateExistentialObject)
+};
+
     /// Generalizes `IRMakeExistential` by allowing a type with existential sub-fields to be boxed
 struct IRWrapExistential : IRInst
 {

--- a/tests/compute/dynamic-dispatch-16.slang
+++ b/tests/compute/dynamic-dispatch-16.slang
@@ -1,0 +1,56 @@
+// Test packing a user provided value and typeID into an existential value.
+
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -vk -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile sm_6_0 -use-dxil -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx11 -profile sm_5_0 -output-using-type
+
+[anyValueSize(16)]
+interface IInterface
+{
+    float run();
+}
+
+struct UserDefinedPackedType
+{
+    float3 val;
+    uint flags;
+};
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=gOutputBuffer
+RWStructuredBuffer<float> gOutputBuffer;
+
+//TEST_INPUT: set gObj = new StructuredBuffer<UserDefinedPackedType>[new UserDefinedPackedType{[1.0, 0.0, 0.0], 0}, new UserDefinedPackedType{[2.0, 3.0, 4.0], 1}];
+RWStructuredBuffer<UserDefinedPackedType> gObj;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3       dispatchThreadID : SV_DispatchThreadID)
+{
+    float result = 0.0;
+    for (int i = 0; i < 2; i++)
+    {
+        var rawObj = gObj.Load(i);
+        IInterface dynamicObj = createDynamicObject<IInterface, UserDefinedPackedType>(rawObj.flags, rawObj);
+        result += dynamicObj.run();
+    }
+    gOutputBuffer[0] = result;
+}
+
+// Type must be marked `public` to ensure it is visible in the generated DLL.
+public struct FloatVal : IInterface
+{
+    float val;
+    float run()
+    {
+        return val;
+    }
+};
+interface ISomething{void g();}
+struct Float4Struct : ISomething { float4 val; void g() {} }
+public struct Float4Val : IInterface
+{
+    Float4Struct val;
+    float run()
+    {
+        return val.val.x + val.val.y;
+    }
+};

--- a/tests/compute/dynamic-dispatch-16.slang.expected.txt
+++ b/tests/compute/dynamic-dispatch-16.slang.expected.txt
@@ -1,0 +1,2 @@
+type: float
+6.0


### PR DESCRIPTION
This function takes a user provided `typeID` and arbitrary typed value, and turns them into an existential value whose `witnessTableID` is `typeID` and whose `anyValue` is  the user provided  value. This allows the users to pack the runtime type id info in arbitrary way.