### PR TITLE
Two small fixes.

### DIFF
--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -23,15 +23,15 @@ namespace Slang
 
     // A flat representation of basic types (scalars, vectors and matrices)
     // that can be used as lookup key in caches
-    enum class BasicTypeKey : uint8_t
+    enum class BasicTypeKey : uint16_t
     {
-        Invalid = 0xff,                 ///< Value that can never be a valid type                
+        Invalid = 0xffff,                 ///< Value that can never be a valid type
     };
 
-    SLANG_FORCE_INLINE BasicTypeKey makeBasicTypeKey(BaseType baseType, IntegerLiteralValue dim1 = 1, IntegerLiteralValue dim2 = 1)
+    SLANG_FORCE_INLINE BasicTypeKey makeBasicTypeKey(BaseType baseType, IntegerLiteralValue dim1 = 0, IntegerLiteralValue dim2 = 0)
     {
-        SLANG_ASSERT(dim1 > 0 && dim2 > 0);
-        return BasicTypeKey((uint8_t(baseType) << 4) | ((uint8_t(dim1) - 1) << 2) | (uint8_t(dim2) - 1));
+        SLANG_ASSERT(dim1 >= 0 && dim2 >= 0);
+        return BasicTypeKey((uint8_t(baseType) << 8) | (uint8_t(dim1) << 4) | uint8_t(dim2));
     }
 
     inline BasicTypeKey makeBasicTypeKey(Type* typeIn)

--- a/source/slang/slang-mangle.cpp
+++ b/source/slang/slang-mangle.cpp
@@ -83,11 +83,13 @@ namespace Slang
             //
             for (auto c : str)
             {
-                if (('a' <= c) && (c <= 'z'))   { encoded.append(c); }
-                if (('A' <= c) && (c <= 'Z'))   { encoded.append(c); }
-                if (('0' <= c) && (c <= '9'))   { encoded.append(c); }
-
-                if (c == '_')
+                if (('a' <= c) && (c <= 'z')
+                    || ('A' <= c) && (c <= 'Z')
+                    || ('0' <= c) && (c <= '9'))
+                {
+                    encoded.append(c);
+                }
+                else if (c == '_')
                 {
                     encoded.append("_u");
                 }


### PR DESCRIPTION
* Fix mangling logic for the case where a symbol name contains characters that aren't permitted (this usually occurs when a module name consists of the actual path to the module). There were multiple early-out `if` cases that accidentally fell through to the fallback path, so that symbol names would end up being excessively long.

* Fix type conversion cost lookup cache, by allowing single-element vectors (e.g., `vector<float,1>`) and single row/column matrix types to be distinguished from types of lower rank. Previously, `float` and `float1` and `float1x1` would share a single cache entry, even though each (currently) has very different conversion rules.