### PR TITLE
Fix `spSetDumpIntermediates`.

### DIFF
--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -2049,6 +2049,7 @@ namespace Slang
             m_program);
         backEndRequest->shouldDumpIR =
             (m_targetReq->getTargetFlags() & SLANG_TARGET_FLAG_DUMP_IR) != 0;
+        backEndRequest->shouldDumpIntermediates = m_targetReq->shouldDumpIntermediates();
 
         return _createEntryPointResult(
             entryPointIndex,

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1301,6 +1301,10 @@ namespace Slang
         {
             lineDirectiveMode = mode;
         }
+        void setDumpIntermediates(bool value)
+        {
+            dumpIntermediates = value;
+        }
         void addCapability(CapabilityAtom capability);
 
         bool shouldEmitSPIRVDirectly()
@@ -1312,6 +1316,8 @@ namespace Slang
         {
             return (targetFlags & SLANG_TARGET_FLAG_GENERATE_WHOLE_PROGRAM) != 0;
         }
+
+        bool shouldDumpIntermediates() { return dumpIntermediates; }
 
         Linkage* getLinkage() { return linkage; }
         CodeGenTarget getTarget() { return format; }
@@ -1340,6 +1346,7 @@ namespace Slang
         List<CapabilityAtom>    rawCapabilities;
         CapabilitySet           cookedCapabilities;
         LineDirectiveMode       lineDirectiveMode = LineDirectiveMode::Default;
+        bool                    dumpIntermediates = false;
     };
 
         /// Are we generating code for a D3D API?

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3920,6 +3920,13 @@ void EndToEndCompileRequest::setCompileFlags(SlangCompileFlags flags)
 void EndToEndCompileRequest::setDumpIntermediates(int enable)
 {
     getBackEndReq()->shouldDumpIntermediates = (enable != 0);
+
+    // Change all existing targets to use the new setting.
+    auto linkage = getLinkage();
+    for (auto& target : linkage->targets)
+    {
+        target->setDumpIntermediates(enable != 0);
+    }
 }
 
 void EndToEndCompileRequest::setDumpIntermediatePrefix(const char* prefix)


### PR DESCRIPTION
This change fixes a bug that `spSetDumpIntermediates` is not effective when using the new `IComponentType` based compilation API. The new logic ensures the setting is conserved through `TargetRequest` from the `Linkage` backing the legacy `SlangCompileRequest` object.