### PR TITLE
Fix a crash in gfx d3d TransientHeap implementation.

### DIFF
--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -604,7 +604,7 @@ public:
         {
             uint64_t waitValue;
             HANDLE fenceEvent;
-            ID3D12Fence* fence = nullptr;
+            ComPtr<ID3D12Fence> fence = nullptr;
         };
         ShortList<QueueWaitInfo, 4> m_waitInfos;
 


### PR DESCRIPTION
`TransientHeap::waitInfo` needs to hold a strong reference to `ID3DFence` to avoid crash when the user release the Fence before TransientHeap.