### PR TITLE
Allow D3D12Device to use an existing device handle

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1424,8 +1424,13 @@ public:
         DeviceType deviceType = DeviceType::Default;
         // Name to identify the adapter to use
         const char* adapter = nullptr;
-        // The device handle. If 0, a device will need to be created.
-        uint64_t existingDeviceHandle = 0;
+        // Device handles (if they already exist)
+        struct existingDeviceHandles
+        {
+            // For D3D12, this only contains a single value for the ID3D12Device.
+            // For Vulkan, the first value is the VkInstance and the second is the VkDevice.
+            uint64_t values[2] = { 0 };
+        } existingDeviceHandles;
         // Number of required features.
         int requiredFeatureCount = 0;
         // Array of required feature names, whose size is `requiredFeatureCount`.

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1424,6 +1424,8 @@ public:
         DeviceType deviceType = DeviceType::Default;
         // Name to identify the adapter to use
         const char* adapter = nullptr;
+        // The device handle. If 0, a device will need to be created.
+        uint64_t existingDeviceHandle = 0;
         // Number of required features.
         int requiredFeatureCount = 0;
         // Array of required feature names, whose size is `requiredFeatureCount`.

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1425,7 +1425,7 @@ public:
         // Name to identify the adapter to use
         const char* adapter = nullptr;
         // Device handles (if they already exist)
-        struct existingDeviceHandles
+        struct ExistingDeviceHandles
         {
             // For D3D12, this only contains a single value for the ID3D12Device.
             // For Vulkan, the first value is the VkInstance and the second is the VkDevice.

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -4287,7 +4287,7 @@ Result D3D12Device::initialize(const Desc& desc)
         return SLANG_FAIL;
     }
 
-    if (desc.existingDeviceHandle == 0)
+    if (desc.existingDeviceHandles.values[0] == 0)
     {
         FlagCombiner combiner;
         // TODO: we should probably provide a command-line option
@@ -4316,15 +4316,15 @@ Result D3D12Device::initialize(const Desc& desc)
             // Couldn't find an adapter
             return SLANG_FAIL;
         }
-
-        // Set the device
-        m_device = m_deviceInfo.m_device;
     }
     else
     {
-        // Set the existing device stored in desc
-        m_device = (ID3D12Device*)desc.existingDeviceHandle;
+        // Store the existing device handle in desc in m_deviceInfo
+        m_deviceInfo.m_device = (ID3D12Device*)desc.existingDeviceHandles.values[0];
     }
+
+    // Set the device
+    m_device = m_deviceInfo.m_device;
 
     // NVAPI
     if (desc.nvapiExtnSlot >= 0)


### PR DESCRIPTION
Changes:
- Added a new field `existingDeviceHandle` to `IDevice::Desc`, which is 0 by default to indicate that a device does not yet exist and will need to be created
- Modified `D3D12Device::initialize` to check if `desc.existingDeviceHandle` is 0. If not 0, then it stores the value in `m_device` instead of creating a new device through `_createDevice`

@csyonghe Here are the changes I made based on the conversation and notes from yesterday.