### PR TITLE
Improvements to the unit test framework.

### DIFF
--- a/tools/gfx-unit-test/gfx-test-util.h
+++ b/tools/gfx-unit-test/gfx-test-util.h
@@ -35,7 +35,7 @@ namespace gfx_test
         return compareComputeResult(device, buffer, expectedBuffer.getBuffer(), bufferSize);
     }
 
-#define GFX_CHECK_CALL(x) {auto callResult = (x); SLANG_CHECK(!SLANG_FAILED(callResult))}
-#define GFX_CHECK_CALL_ABORT(x) {auto callResult = (x); SLANG_CHECK_ABORT(!SLANG_FAILED(callResult))}
+#define GFX_CHECK_CALL(x) SLANG_CHECK(!SLANG_FAILED(x))
+#define GFX_CHECK_CALL_ABORT(x) SLANG_CHECK_ABORT(!SLANG_FAILED(x))
 
 }

--- a/tools/slang-test/test-reporter.h
+++ b/tools/slang-test/test-reporter.h
@@ -68,12 +68,12 @@ class TestReporter : public ITestReporter
     void startSuite(const Slang::String& name);
     void endSuite();
 
-    virtual void startTest(const char* testName) override;
-    virtual void addResult(TestResult result) override;
-    virtual void addResultWithLocation(TestResult result, const char* testText, const char* file, int line) override;
-    virtual void addResultWithLocation(bool testSucceeded, const char* testText, const char* file, int line) override;
-    virtual void addExecutionTime(double time) override;
-    virtual void endTest() override;
+    virtual SLANG_NO_THROW void SLANG_MCALL startTest(const char* testName) override;
+    virtual SLANG_NO_THROW void SLANG_MCALL addResult(TestResult result) override;
+    virtual SLANG_NO_THROW void SLANG_MCALL addResultWithLocation(TestResult result, const char* testText, const char* file, int line) override;
+    virtual SLANG_NO_THROW void SLANG_MCALL addResultWithLocation(bool testSucceeded, const char* testText, const char* file, int line) override;
+    virtual SLANG_NO_THROW void SLANG_MCALL addExecutionTime(double time) override;
+    virtual SLANG_NO_THROW void SLANG_MCALL endTest() override;
     
         /// Runs start/endTest and outputs the result
     TestResult addTest(const Slang::String& testName, bool isPass);
@@ -83,7 +83,7 @@ class TestReporter : public ITestReporter
         // Called for an error in the test-runner (not for an error involving a test itself).
     void message(TestMessageType type, const Slang::String& errorText);
     void messageFormat(TestMessageType type, char const* message, ...);
-    virtual void message(TestMessageType type, char const* message) override;
+    virtual SLANG_NO_THROW void SLANG_MCALL message(TestMessageType type, char const* message) override;
 
     void dumpOutputDifference(const Slang::String& expectedOutput, const Slang::String& actualOutput);
 

--- a/tools/unit-test/slang-unit-test.cpp
+++ b/tools/unit-test/slang-unit-test.cpp
@@ -14,26 +14,26 @@ public:
     Slang::List<SlangUnitTest> tests;
     ITestReporter* testReporter = nullptr;
 
-    virtual SlangInt getTestCount() override
+    virtual SLANG_NO_THROW SlangInt SLANG_MCALL getTestCount() override
     {
         return tests.getCount();
     }
-    virtual const char* getTestName(SlangInt index) override
+    virtual SLANG_NO_THROW const char* SLANG_MCALL getTestName(SlangInt index) override
     {
         return tests[index].name;
     }
 
-    virtual UnitTestFunc getTestFunc(SlangInt index) override
+    virtual SLANG_NO_THROW UnitTestFunc SLANG_MCALL getTestFunc(SlangInt index) override
     {
         return tests[index].func;
     }
 
-    virtual void setTestReporter(ITestReporter* reporter) override
+    virtual SLANG_NO_THROW void SLANG_MCALL setTestReporter(ITestReporter* reporter) override
     {
         testReporter = reporter;
     }
 
-    virtual void destroy() override
+    virtual SLANG_NO_THROW void SLANG_MCALL destroy() override
     {
         tests = decltype(tests)();
     }


### PR DESCRIPTION
Add NO_THROW and MCALL to unit test interfaces.
Properly implement SLANG_CHECK_ABORT to actually abort the unit test.