### PR TITLE
Return diagnostics info on module load failure

### DIFF
--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -825,11 +825,11 @@ SLANG_NO_THROW slang::IModule* SLANG_MCALL Linkage::loadModule(
     const char*     moduleName,
     slang::IBlob**  outDiagnostics)
 {
+    DiagnosticSink sink(getSourceManager(), Lexer::sourceLocationLexer);
     try
     {
         auto name = getNamePool()->getName(moduleName);
 
-        DiagnosticSink sink(getSourceManager(), Lexer::sourceLocationLexer);
         auto module = findOrImportModule(name, SourceLoc(), &sink);
         sink.getBlobIfNeeded(outDiagnostics);
 
@@ -838,6 +838,7 @@ SLANG_NO_THROW slang::IModule* SLANG_MCALL Linkage::loadModule(
     }
     catch (const AbortCompilationException&)
     {
+        sink.getBlobIfNeeded(outDiagnostics);
         return nullptr;
     }
 }


### PR DESCRIPTION
I ran into an issue where I wasn't getting diagnostics info when trying to compile a shader with a syntax error. It appears something deeper in Slang is throwing an exception which skips writing diagnostics. Unsure if there are other implications regarding this issue, but this at least returns the data.