### PR TITLE
Attempt to get CI consistently passing

### DIFF
--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -3575,7 +3575,7 @@ SlangResult innerMain(int argc, char** argv)
 #if 0
             // TODO(JS): Disable gfx unit tests for now as having problems with CI failing
             // and it may(?) be related.
-            // Test: 1 2 3....
+            // Test: 1 2 3.....
             {
                 TestOptions testOptions;
                 testOptions.categories.add(unitTestCategory);


### PR DESCRIPTION
This is on top of previously merged PR that disabled swiftshader.

It's not clear, but it seems like something related to swiftshader and/or gfx unit tests may be causing issues on CI testing.