### PR TITLE
Disable aarch64 build for releases.

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         configuration: ['Release']
-        platform: ['Win32', 'x64', 'aarch64']
+        platform: ['Win32', 'x64']
     steps:
       - uses: actions/checkout@v2.3.4
         with:


### PR DESCRIPTION
Aarch64 release build on github is now failing. Disabling it to enable us to make releases for x64 and x86 until this is fixed in the future.