### PR TITLE
Fix a bug with CUDA entry-point params

### DIFF
--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -349,6 +349,7 @@ IF EXIST ..\..\..\external\slang-binaries\bin\windows-aarch64\slang-glslang.dll\
     <ClInclude Include="..\..\..\source\slang\slang-ir-constexpr.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-dce.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-dominators.h" />
+    <ClInclude Include="..\..\..\source\slang\slang-ir-entry-point-pass.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-entry-point-raw-ptr-params.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-entry-point-uniforms.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-explicit-global-context.h" />
@@ -480,6 +481,7 @@ IF EXIST ..\..\..\external\slang-binaries\bin\windows-aarch64\slang-glslang.dll\
     <ClCompile Include="..\..\..\source\slang\slang-ir-dce.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-deduplicate.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-dominators.cpp" />
+    <ClCompile Include="..\..\..\source\slang\slang-ir-entry-point-pass.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-entry-point-raw-ptr-params.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-entry-point-uniforms.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-explicit-global-context.cpp" />

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -144,6 +144,9 @@
     <ClInclude Include="..\..\..\source\slang\slang-ir-dominators.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\slang\slang-ir-entry-point-pass.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-ir-entry-point-raw-ptr-params.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -531,6 +534,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-ir-dominators.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\source\slang\slang-ir-entry-point-pass.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-ir-entry-point-raw-ptr-params.cpp">

--- a/source/slang/slang-ir-entry-point-pass.cpp
+++ b/source/slang/slang-ir-entry-point-pass.cpp
@@ -1,0 +1,52 @@
+// slang-ir-entry-point-pass.cpp
+#include "slang-ir-entry-point-pass.h"
+
+namespace Slang
+{
+
+void PerEntryPointPass::processModule(IRModule* module)
+{
+    m_module = module;
+
+    SharedIRBuilder sharedBuilder(module);
+    m_sharedBuilder = &sharedBuilder;
+
+    // Note that we are only looking at true global-scope
+    // functions and not functions nested inside of
+    // IR generics. When using generic entry points, this
+    // pass should be run after the entry point(s) have
+    // been specialized to their generic type parameters.
+
+    for (auto inst : module->getGlobalInsts())
+    {
+        // We are only interested in entry points.
+        //
+        // Every entry point must be a function.
+        //
+        auto func = as<IRFunc>(inst);
+        if (!func)
+            continue;
+
+        // Entry points will always have the `[entryPoint]`
+        // decoration to differentiate them from ordinary
+        // functions.
+        //
+        auto entryPointDecoration = func->findDecoration<IREntryPointDecoration>();
+        if (!entryPointDecoration)
+            continue;
+
+        // If we find a candidate entry point, then we
+        // will process it.
+        //
+        processEntryPoint(func, entryPointDecoration);
+    }
+}
+
+void PerEntryPointPass::processEntryPoint(IRFunc* entryPointFunc, IREntryPointDecoration* entryPointDecoration)
+{
+    m_entryPoint.func = entryPointFunc;
+    m_entryPoint.decoration = entryPointDecoration;
+    processEntryPointImpl(m_entryPoint);
+}
+
+}

--- a/source/slang/slang-ir-entry-point-pass.h
+++ b/source/slang/slang-ir-entry-point-pass.h
@@ -1,0 +1,39 @@
+// ir-entry-point-pass.h
+#pragma once
+
+#include "slang-ir.h"
+#include "slang-ir-insts.h"
+
+namespace Slang
+{
+
+struct PerEntryPointPass
+{
+public:
+    // We will process a whole module by visiting all
+    // its global functions, looking for entry points.
+    //
+    void processModule(IRModule* module);
+
+    struct EntryPointInfo
+    {
+        IRFunc* func = nullptr;
+        IREntryPointDecoration* decoration = nullptr;
+    };
+
+protected:
+    void processEntryPoint(IRFunc* entryPointFunc, IREntryPointDecoration* entryPointDecoration);
+
+    virtual void processEntryPointImpl(EntryPointInfo const& info) = 0;
+
+    // We'll hang on to the module we are processing,
+    // so that we can refer to it when setting up `IRBuilder`s.
+    //
+    IRModule* m_module = nullptr;
+
+    SharedIRBuilder* m_sharedBuilder = nullptr;
+
+    EntryPointInfo m_entryPoint;
+};
+
+}


### PR DESCRIPTION
Recent work that added support for translating DXR-style ray tracing shaders to work with OptiX seems to have accidentally applied its transformations even when compute shaders are translated for CUDA. As a result, compute entry points with `uniform` parameters at entry-point scope would be miscompiled to use OptiX calls that are not available for non-OptiX compiles.

This change fixes the relevant pass so that it correctly opts-out on compute entry points, and also unifies some pieces of code that were being shared between a few different IR passes but that had gotten copy-pasted for the OptiX case.

The fix has been confirmed by running relevant CUDA tests locally, but CUDA is still disabled in the default CI builds, so this change is not yet actively being tested to avoid further regression.