### PR TITLE
Fix two test cases that were causing problems

### DIFF
--- a/tests/compute/half-texture-simple.slang
+++ b/tests/compute/half-texture-simple.slang
@@ -7,23 +7,23 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute  -shaderobj
 
 // Doesn't work on CUDA, not clear why yet
-//DISABLE_TEST_INPUT: Texture1D(format=R_Float16, size=4, content = one, mipMaps=1):name tLoad1D
+//DISABLE_TEST_INPUT: Texture1D(format=R16_FLOAT, size=4, content = one, mipMaps=1):name tLoad1D
 //Texture1D<float> tLoad1D;
 
-//TEST_INPUT: Texture1D(format=R_Float16, size=4, content = one):name t1D
+//TEST_INPUT: Texture1D(format=R16_FLOAT, size=4, content = one):name t1D
 Texture1D<float> t1D;
-//TEST_INPUT: Texture2D(format=R_Float16, size=4, content = one):name t2D
+//TEST_INPUT: Texture2D(format=R16_FLOAT, size=4, content = one):name t2D
 Texture2D<float> t2D;
-//TEST_INPUT: Texture3D(format=R_Float16, size=4, content = one):name t3D
+//TEST_INPUT: Texture3D(format=R16_FLOAT, size=4, content = one):name t3D
 Texture3D<float> t3D;
-//TEST_INPUT: TextureCube(format=R_Float16, size=4, content = one):name tCube
+//TEST_INPUT: TextureCube(format=R16_FLOAT, size=4, content = one):name tCube
 TextureCube<float> tCube;
 
-//TEST_INPUT: Texture1D(format=R_Float16, size=4, content = one, arrayLength=2):name t1DArray
+//TEST_INPUT: Texture1D(format=R16_FLOAT, size=4, content = one, arrayLength=2):name t1DArray
 Texture1DArray<float> t1DArray;
-//TEST_INPUT: Texture2D(format=R_Float16, size=4, content = one, arrayLength=2):name t2DArray
+//TEST_INPUT: Texture2D(format=R16_FLOAT, size=4, content = one, arrayLength=2):name t2DArray
 Texture2DArray<float> t2DArray;
-//TEST_INPUT: TextureCube(format=R_Float16, size=4, content = one, arrayLength=2):name tCubeArray
+//TEST_INPUT: TextureCube(format=R16_FLOAT, size=4, content = one, arrayLength=2):name tCubeArray
 TextureCubeArray<float> tCubeArray;
 
 //TEST_INPUT: Sampler:name samplerState

--- a/tests/hlsl-intrinsic/active-mask/switch-trivial-fallthrough.slang
+++ b/tests/hlsl-intrinsic/active-mask/switch-trivial-fallthrough.slang
@@ -4,10 +4,19 @@
 // that exhibits "trivial fall-through" from one `case`
 // to another.
 
+// We've ended up having to disable this test everywhere,
+// which really speaks to the way that the "active mask" concept
+// in D3D and Vulkan was never really specified to a level
+// that makes it meaningful.
+//
+// Even if the specs get fixed at some point down the line,
+// we can't really re-enable these tests because they'd fail on way
+// too many GPUs and driver versions.
+
 //DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
 //DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
 //DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -xslang -DHACK -shaderobj
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -xslang -DHACK -shaderobj
+//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -xslang -DHACK -shaderobj
 
 // Note: this test is currently disabled on the CUDA
 // target because we do not synthesize the active


### PR DESCRIPTION
First, we have a CUDA-only test that simply needed a format name to be changed to match the new conventions in `gfx`.

Second, we have one of the "active mask" tests that seems to produce different results locally for developers (under Vulkan) than it does on CI. This is almost certainly down to differences in GPUs and/or drivers. The inconsistency ultimately proves the point that I was trying to make when I wrote those tests - the "active mask" concept is effectively meaningless as exposed in D3D and Vulkan because it has not been specified in a way that allows programmers to reason about its value, and drivers have implemented wildly different interpretations of its supposed semantics for so long that there is no real hope of turning `WaveGetActiveMask()` into something that returns a well-defined value in any but the most trivial cases.

TLDR: I disabled that test for Vulkan, which means it is completely disabled.