### PR TITLE
Update gfx interface.

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -887,20 +887,19 @@ public:
 class IFence : public ISlangUnknown
 {
 public:
-    enum class FenceStatus
-    {
-        Completed,
-        NotReady,
-        DeviceLost
-    };
     struct Desc
     {
-        bool initiallySignaled = false;
+        uint64_t initialValue = 0;
     };
-    virtual SLANG_NO_THROW FenceStatus SLANG_MCALL getStatus() = 0;
-    virtual SLANG_NO_THROW Result SLANG_MCALL reset() = 0;
-    virtual SLANG_NO_THROW Result SLANG_MCALL getSharedHandle(uint64_t* outHandle) = 0;
-    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(void** outNativeHandle) = 0;
+
+    /// Returns the currently signaled value on the device.
+    virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentValue(uint64_t* outValue) = 0;
+
+    /// Signals the fence from the host with the specified value.
+    virtual SLANG_NO_THROW Result SLANG_MCALL setCurrentValue(uint64_t value) = 0;
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL getSharedHandle(InteropHandle* outHandle) = 0;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(InteropHandle* outNativeHandle) = 0;
 };
 #define SLANG_UUID_IFence                                                             \
     {                                                                                 \
@@ -979,6 +978,9 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentVersion(
         ITransientResourceHeap* transientHeap,
         IShaderObject** outObject) = 0;
+
+        /// Copies contents from another shader object to this object.
+    virtual SLANG_NO_THROW Result SLANG_MCALL copyFrom(IShaderObject* other) = 0;
 };
 #define SLANG_UUID_IShaderObject                                                       \
     {                                                                                 \
@@ -1374,12 +1376,6 @@ public:
         return rootObject;
     }
 
-    // Sets the pipeline state with a mutable root object. The root object is allowed to change
-    // between this call and future draw calls.
-    virtual SLANG_NO_THROW Result SLANG_MCALL bindPipelineAndRootObject(
-        IPipelineState* state,
-        IShaderObject* rootObject) = 0;
-
     virtual SLANG_NO_THROW void
         SLANG_MCALL setViewports(uint32_t count, const Viewport* viewports) = 0;
     virtual SLANG_NO_THROW void
@@ -1443,12 +1439,6 @@ public:
         SLANG_RETURN_NULL_ON_FAIL(bindPipeline(state, &rootObject));
         return rootObject;
     }
-
-    // Sets the pipeline state with a mutable root object. The root object is allowed to change
-    // between this call and future dispatch calls.
-    virtual SLANG_NO_THROW Result SLANG_MCALL bindPipelineAndRootObject(
-        IPipelineState* state,
-        IShaderObject* rootObject) = 0;
 
     virtual SLANG_NO_THROW void SLANG_MCALL dispatchCompute(int x, int y, int z) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL dispatchComputeIndirect(IBufferResource* cmdBuffer, uint64_t offset) = 0;
@@ -1535,11 +1525,6 @@ public:
 
     virtual SLANG_NO_THROW void SLANG_MCALL
         bindPipeline(IPipelineState* state, IShaderObject** outRootObject) = 0;
-
-    // Binds pipeline with a mutable root object. The root object is allowed to change
-    // between this call and dispatchRays calls.
-    virtual SLANG_NO_THROW void SLANG_MCALL
-        bindPipelineAndRootObject(IPipelineState* state, IShaderObject* mutableRootObject) = 0;
 
     /// Issues a dispatch command to start ray tracing workload with a ray tracing pipeline.
     /// `rayGenShaderName` specifies the name of the ray generation shader to launch. Pass nullptr for
@@ -1631,11 +1616,15 @@ public:
 
     virtual SLANG_NO_THROW const Desc& SLANG_MCALL getDesc() = 0;
 
-    virtual SLANG_NO_THROW void SLANG_MCALL
-        executeCommandBuffers(uint32_t count, ICommandBuffer* const* commandBuffers, IFence* fenceToSignal) = 0;
-    inline void executeCommandBuffer(ICommandBuffer* commandBuffer, IFence* fenceToSignal = nullptr)
+    virtual SLANG_NO_THROW void SLANG_MCALL executeCommandBuffers(
+        uint32_t count,
+        ICommandBuffer* const* commandBuffers,
+        IFence* fenceToSignal,
+        uint64_t newFenceValue) = 0;
+    inline void executeCommandBuffer(
+        ICommandBuffer* commandBuffer, IFence* fenceToSignal = nullptr, uint64_t newFenceValue = 0)
     {
-        executeCommandBuffers(1, &commandBuffer, fenceToSignal);
+        executeCommandBuffers(1, &commandBuffer, fenceToSignal, newFenceValue);
     }
 
     virtual SLANG_NO_THROW void SLANG_MCALL wait() = 0;
@@ -2059,8 +2048,12 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
         createFence(const IFence::Desc& desc, IFence** outFence) = 0;
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL
-        waitForFences(IFence** fences, uint32_t fenceCount, bool waitForAll, uint64_t timeout) = 0;
+    virtual SLANG_NO_THROW Result SLANG_MCALL waitForFences(
+        uint32_t fenceCount,
+        IFence** fences,
+        uint64_t* values,
+        bool waitForAll,
+        uint64_t timeout) = 0;
 };
 
 #define SLANG_UUID_IDevice                                                               \

--- a/slang.h
+++ b/slang.h
@@ -857,6 +857,8 @@ extern "C"
 #define SLANG_E_INTERNAL_FAIL               SLANG_MAKE_CORE_ERROR(6)
     //! Could not complete because some underlying feature (hardware or software) was not available 
 #define SLANG_E_NOT_AVAILABLE               SLANG_MAKE_CORE_ERROR(7)
+        //! Could not complete because the operation times out. 
+#define SLANG_E_TIME_OUT                    SLANG_MAKE_CORE_ERROR(8)
 
     /** A "Universally Unique Identifier" (UUID)
 

--- a/tools/gfx/cuda/render-cuda.cpp
+++ b/tools/gfx/cuda/render-cuda.cpp
@@ -956,13 +956,6 @@ public:
                 return SLANG_OK;
             }
 
-            virtual SLANG_NO_THROW Result SLANG_MCALL
-                bindPipelineAndRootObject(IPipelineState* state, IShaderObject* rootObject) override
-            {
-                SLANG_UNIMPLEMENTED_X("bindPipelineAndRootObject");
-                return SLANG_E_NOT_AVAILABLE;
-            }
-
             virtual SLANG_NO_THROW void SLANG_MCALL dispatchCompute(int x, int y, int z) override
             {
                 m_writer->bindRootShaderObject(m_rootObject);
@@ -1141,8 +1134,9 @@ public:
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL executeCommandBuffers(
-            uint32_t count, ICommandBuffer* const* commandBuffers, IFence* fence) override
+            uint32_t count, ICommandBuffer* const* commandBuffers, IFence* fence, uint64_t valueToSignal) override
         {
+            SLANG_UNUSED(valueToSignal);
             // TODO: implement fence.
             assert(fence == nullptr);
             for (uint32_t i = 0; i < count; i++)

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -3157,13 +3157,6 @@ public:
             {
                 return bindPipelineImpl(state, outRootObject);
             }
-                        
-            virtual SLANG_NO_THROW Result SLANG_MCALL
-                bindPipelineAndRootObject(IPipelineState* state, IShaderObject* rootObject) override
-            {
-                SLANG_UNIMPLEMENTED_X("bindPipelineAndRootObject");
-                return SLANG_E_NOT_AVAILABLE;
-            }
 
             virtual SLANG_NO_THROW void SLANG_MCALL
                 setViewports(uint32_t count, const Viewport* viewports) override
@@ -3454,13 +3447,6 @@ public:
                 return bindPipelineImpl(state, outRootObject);
             }
 
-            virtual SLANG_NO_THROW Result SLANG_MCALL
-                bindPipelineAndRootObject(IPipelineState* state, IShaderObject* rootObject) override
-            {
-                SLANG_UNIMPLEMENTED_X("bindPipelineAndRootObject");
-                return SLANG_E_NOT_AVAILABLE;
-            }
-
             virtual SLANG_NO_THROW void SLANG_MCALL dispatchCompute(int x, int y, int z) override
             {
                 // Submit binding for compute
@@ -3632,8 +3618,6 @@ public:
                 AccessFlag::Enum destAccess) override;
             virtual SLANG_NO_THROW void SLANG_MCALL
                 bindPipeline(IPipelineState* state, IShaderObject** outRootObject) override;
-            virtual SLANG_NO_THROW void SLANG_MCALL bindPipelineAndRootObject(
-                IPipelineState* state, IShaderObject* rootObject) override;
             virtual SLANG_NO_THROW void SLANG_MCALL dispatchRays(
                 const char* rayGenShaderName,
                 int32_t width,
@@ -3725,7 +3709,7 @@ public:
         }
         
         virtual SLANG_NO_THROW void SLANG_MCALL
-            executeCommandBuffers(uint32_t count, ICommandBuffer* const* commandBuffers, IFence* fence) override
+            executeCommandBuffers(uint32_t count, ICommandBuffer* const* commandBuffers, IFence* fence, uint64_t valueToSignal) override
         {
             // TODO: implement fence signal.
             assert(fence == nullptr);
@@ -6160,12 +6144,6 @@ void D3D12Device::CommandBufferImpl::RayTracingCommandEncoderImpl::bindPipeline(
     IPipelineState* state, IShaderObject** outRootObject)
 {
     bindPipelineImpl(state, outRootObject);
-}
-
-void D3D12Device::CommandBufferImpl::RayTracingCommandEncoderImpl::bindPipelineAndRootObject(
-    IPipelineState* state, IShaderObject* rootObject)
-{
-    SLANG_UNIMPLEMENTED_X("bindPipelineAndRootObject");
 }
 
 void D3D12Device::CommandBufferImpl::RayTracingCommandEncoderImpl::dispatchRays(

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -144,8 +144,12 @@ public:
         IQueryPool** outPool) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
         createFence(const IFence::Desc& desc, IFence** outFence) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL
-        waitForFences(IFence** fences, uint32_t fenceCount, bool waitForAll, uint64_t timeout) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL waitForFences(
+        uint32_t fenceCount,
+        IFence** fences,
+        uint64_t* values,
+        bool waitForAll,
+        uint64_t timeout) override;
 };
 
 class DebugQueryPool : public DebugObject<IQueryPool>
@@ -274,6 +278,7 @@ public:
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentVersion(
         ITransientResourceHeap* transientHeap, IShaderObject** outObject) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL copyFrom(IShaderObject* other) override;
 
 public:
     Slang::String m_typeName;
@@ -305,8 +310,6 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL endEncoding() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
         bindPipeline(IPipelineState* state, IShaderObject** outRootShaderObject) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL
-        bindPipelineAndRootObject(IPipelineState* state, IShaderObject* rootObject) override;
     virtual SLANG_NO_THROW void SLANG_MCALL dispatchCompute(int x, int y, int z) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
         dispatchComputeIndirect(IBufferResource* cmdBuffer, uint64_t offset) override;
@@ -323,8 +326,6 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL endEncoding() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
         bindPipeline(IPipelineState* state, IShaderObject** outRootShaderObject) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL
-        bindPipelineAndRootObject(IPipelineState* state, IShaderObject* rootObject) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
         setViewports(uint32_t count, const Viewport* viewports) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
@@ -438,8 +439,6 @@ public:
         AccessFlag::Enum destAccess) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
         bindPipeline(IPipelineState* state, IShaderObject** outRootObject) override;
-    virtual SLANG_NO_THROW void SLANG_MCALL
-        bindPipelineAndRootObject(IPipelineState* state, IShaderObject* rootObject) override;
     virtual SLANG_NO_THROW void SLANG_MCALL dispatchRays(
         const char* rayGenShaderName,
         int32_t width,
@@ -456,10 +455,10 @@ class DebugFence : public DebugObject<IFence>
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
     IFence* getInterface(const Slang::Guid& guid);
-    virtual SLANG_NO_THROW FenceStatus SLANG_MCALL getStatus() override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL reset() override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL getSharedHandle(uint64_t* outHandle) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(void** outNativeHandle) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentValue(uint64_t* outValue) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL setCurrentValue(uint64_t value) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getSharedHandle(InteropHandle* outHandle) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(InteropHandle* outNativeHandle) override;
 };
 
 class DebugTransientResourceHeap;
@@ -511,7 +510,7 @@ public:
     ICommandQueue* getInterface(const Slang::Guid& guid);
     virtual SLANG_NO_THROW const Desc& SLANG_MCALL getDesc() override;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        executeCommandBuffers(uint32_t count, ICommandBuffer* const* commandBuffers, IFence* fence) override;
+        executeCommandBuffers(uint32_t count, ICommandBuffer* const* commandBuffers, IFence* fence, uint64_t valueToSignal) override;
     virtual SLANG_NO_THROW void SLANG_MCALL wait() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
 };

--- a/tools/gfx/immediate-renderer-base.cpp
+++ b/tools/gfx/immediate-renderer-base.cpp
@@ -154,13 +154,6 @@ public:
             m_writer->writeTimestamp(pool, index);
         }
 
-        virtual SLANG_NO_THROW Result SLANG_MCALL
-            bindPipelineAndRootObject(IPipelineState* state, IShaderObject* rootObject) override
-        {
-            SLANG_UNIMPLEMENTED_X("ImmediateRenderBase::bindPipelineAndRootObject");
-            return SLANG_E_NOT_AVAILABLE;
-        }
-
         virtual SLANG_NO_THROW void SLANG_MCALL drawIndirect(
             uint32_t maxDrawCount,
             IBufferResource* argBuffer,
@@ -231,13 +224,6 @@ public:
                 stateImpl->m_program, m_commandBuffer->m_rootShaderObject.writeRef()));
             *outRootObject = m_commandBuffer->m_rootShaderObject.Ptr();
             return SLANG_OK;
-        }
-
-        virtual SLANG_NO_THROW Result SLANG_MCALL
-            bindPipelineAndRootObject(IPipelineState* state, IShaderObject* rootObject) override
-        {
-            SLANG_UNIMPLEMENTED_X("ImmediateRenderBase::bindPipelineAndRootObject");
-            return SLANG_E_NOT_AVAILABLE;
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL dispatchCompute(int x, int y, int z) override
@@ -494,7 +480,7 @@ public:
     virtual SLANG_NO_THROW const Desc& SLANG_MCALL getDesc() override { return m_desc; }
 
     virtual SLANG_NO_THROW void SLANG_MCALL executeCommandBuffers(
-        uint32_t count, ICommandBuffer* const* commandBuffers, IFence* fence) override
+        uint32_t count, ICommandBuffer* const* commandBuffers, IFence* fence, uint64_t valueToSignal) override
     {
         // TODO: implement fence signal.
         assert(fence == nullptr);

--- a/tools/gfx/renderer-shared.cpp
+++ b/tools/gfx/renderer-shared.cpp
@@ -440,10 +440,11 @@ Result RendererBase::createFence(const IFence::Desc& desc, IFence** outFence)
 }
 
 Result RendererBase::waitForFences(
-    IFence** fences, uint32_t fenceCount, bool waitForAll, uint64_t timeout)
+    uint32_t fenceCount, IFence** fences, uint64_t* fenceValues, bool waitForAll, uint64_t timeout)
 {
-    SLANG_UNUSED(fences);
     SLANG_UNUSED(fenceCount);
+    SLANG_UNUSED(fences);
+    SLANG_UNUSED(fenceValues);
     SLANG_UNUSED(waitForAll);
     SLANG_UNUSED(timeout);
     return SLANG_E_NOT_AVAILABLE;

--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -536,6 +536,12 @@ public:
         SLANG_UNUSED(outObject);
         return SLANG_E_NOT_AVAILABLE;
     }
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL copyFrom(IShaderObject* other) override
+    {
+        SLANG_UNUSED(other);
+        return SLANG_E_NOT_AVAILABLE;
+    }
 };
 
 template<typename TShaderObjectImpl, typename TShaderObjectLayoutImpl, typename TShaderObjectData>
@@ -1233,7 +1239,7 @@ public:
 
     // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE.
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        waitForFences(IFence** fences, uint32_t fenceCount, bool waitForAll, uint64_t timeout) override;
+        waitForFences(uint32_t fenceCount, IFence** fences, uint64_t* fenceValues, bool waitForAll, uint64_t timeout) override;
 
     Result getShaderObjectLayout(
         slang::TypeReflection*      type,

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -3709,13 +3709,6 @@ public:
                 return setPipelineStateImpl(pipelineState, outRootObject);
             }
 
-            virtual SLANG_NO_THROW Result SLANG_MCALL
-                bindPipelineAndRootObject(IPipelineState* state, IShaderObject* rootObject) override
-            {
-                SLANG_UNIMPLEMENTED_X("bindPipelineAndRootObject");
-                return SLANG_E_NOT_AVAILABLE;
-            }
-
             virtual SLANG_NO_THROW void SLANG_MCALL
                 setViewports(uint32_t count, const Viewport* viewports) override
             {
@@ -3958,13 +3951,6 @@ public:
                 bindPipeline(IPipelineState* pipelineState, IShaderObject** outRootObject) override
             {
                 return setPipelineStateImpl(pipelineState, outRootObject);
-            }
-
-            virtual SLANG_NO_THROW Result SLANG_MCALL
-                bindPipelineAndRootObject(IPipelineState* state, IShaderObject* rootObject) override
-            {
-                SLANG_UNIMPLEMENTED_X("bindPipelineAndRootObject");
-                return SLANG_E_NOT_AVAILABLE;
             }
 
             virtual SLANG_NO_THROW void SLANG_MCALL dispatchCompute(int x, int y, int z) override
@@ -4551,14 +4537,6 @@ public:
                 SLANG_UNUSED(outRootObject);
             }
 
-            virtual SLANG_NO_THROW void SLANG_MCALL
-                bindPipelineAndRootObject(IPipelineState* state, IShaderObject* rootObject) override
-            {
-                SLANG_UNUSED(state);
-                SLANG_UNUSED(rootObject);
-                SLANG_UNIMPLEMENTED_X("bindPipelineAndRootObject");
-            }
-
             virtual SLANG_NO_THROW void SLANG_MCALL dispatchRays(
                 const char* rayGenShaderName,
                 int32_t width,
@@ -4707,7 +4685,7 @@ public:
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL executeCommandBuffers(
-            uint32_t count, ICommandBuffer* const* commandBuffers, IFence* fence) override
+            uint32_t count, ICommandBuffer* const* commandBuffers, IFence* fence, uint64_t valueToSignal) override
         {
             // TODO: implement fence signaling.
             assert(fence == nullptr);


### PR DESCRIPTION
This change updates the gfx interface around `IFence` and `RootShaderObject`.

1. Instead of having a `bindPipelineAndRootObject` for binding mutable root shader objects, we add a `copyFrom` method in `IShaderObject` so the user can do the usual `auto rootObj = bindPipeline(..);` followed by a `rootObj->copyFrom(existingMutableRootObject)`.
2. Change the `IFence` interface to reflect what is offered by VkTimelineSempahore instead of VkSemaphore, this provides a more convenient interface and a closer match to a d3d12 Fence.
3. Add `SLANG_E_TIME_OUT` return code for `waitForFences()` operation.
4. Change the `getNativeHandle` and `getSharedHandle` interface to use the new `InteropHandle` type.