### PR TITLE
gfx ShaderObject interface update, getTextureAllocationInfo()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ prelude/*.h.cpp
 /source/slang/slang-stdlib-generated.h
 
 /examples/heterogeneous-hello-world/shader.cpp
+/multiple-definitions.hlsl

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -983,6 +983,13 @@ public:
 
         /// Copies contents from another shader object to this object.
     virtual SLANG_NO_THROW Result SLANG_MCALL copyFrom(IShaderObject* other) = 0;
+
+    virtual SLANG_NO_THROW const void* SLANG_MCALL getRawData() = 0;
+
+    virtual SLANG_NO_THROW size_t SLANG_MCALL getSize() = 0;
+
+        /// Use the provided constant buffer instead of the internally created one.
+    virtual SLANG_NO_THROW Result SLANG_MCALL setConstantBufferOverride(IBufferResource* constantBuffer) = 0;
 };
 #define SLANG_UUID_IShaderObject                                                       \
     {                                                                                 \
@@ -2077,6 +2084,9 @@ public:
         uint64_t* values,
         bool waitForAll,
         uint64_t timeout) = 0;
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL getTextureAllocationInfo(
+        const ITextureResource::Desc& desc, size_t* outSize, size_t* outAlignment) = 0;
 };
 
 #define SLANG_UUID_IDevice                                                               \

--- a/tools/gfx/cpu/render-cpu.cpp
+++ b/tools/gfx/cpu/render-cpu.cpp
@@ -844,6 +844,17 @@ public:
         *outEntryPoint = nullptr;
         return SLANG_OK;
     }
+
+    virtual SLANG_NO_THROW const void* SLANG_MCALL getRawData() override
+    {
+        return m_data.getBuffer();
+    }
+
+    virtual SLANG_NO_THROW size_t SLANG_MCALL getSize() override
+    {
+        return (size_t)m_data.getCount();
+    }
+
     virtual SLANG_NO_THROW Result SLANG_MCALL
         setData(ShaderOffset const& offset, void const* data, size_t size) override
     {

--- a/tools/gfx/cuda/render-cuda.cpp
+++ b/tools/gfx/cuda/render-cuda.cpp
@@ -557,6 +557,17 @@ public:
         *outEntryPoint = nullptr;
         return SLANG_OK;
     }
+
+    virtual SLANG_NO_THROW const void* SLANG_MCALL getRawData() override
+    {
+        return m_data.getBuffer();
+    }
+
+    virtual SLANG_NO_THROW size_t SLANG_MCALL getSize() override
+    {
+        return (size_t)m_data.getCount();
+    }
+
     virtual SLANG_NO_THROW Result SLANG_MCALL
         setData(ShaderOffset const& offset, void const* data, size_t size) override
     {

--- a/tools/gfx/d3d11/render-d3d11.cpp
+++ b/tools/gfx/d3d11/render-d3d11.cpp
@@ -1240,6 +1240,16 @@ protected:
             return SLANG_OK;
         }
 
+        virtual SLANG_NO_THROW const void* SLANG_MCALL getRawData() override
+        {
+            return m_data.getBuffer();
+        }
+
+        virtual SLANG_NO_THROW size_t SLANG_MCALL getSize() override
+        {
+            return (size_t)m_data.getCount();
+        }
+
         SLANG_NO_THROW Result SLANG_MCALL
             setData(ShaderOffset const& inOffset, void const* data, size_t inSize) SLANG_OVERRIDE
         {

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -80,6 +80,8 @@ public:
         WindowHandle window,
         ISwapchain** outSwapchain) override;
 
+    virtual SLANG_NO_THROW Result SLANG_MCALL getTextureAllocationInfo(
+        const ITextureResource::Desc& desc, size_t* outSize, size_t* outAlignment) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createTextureResource(
         const ITextureResource::Desc& desc,
         const ITextureResource::SubresourceData* initData,
@@ -2077,6 +2079,16 @@ public:
         {
             *outEntryPoint = nullptr;
             return SLANG_OK;
+        }
+
+        virtual SLANG_NO_THROW const void* SLANG_MCALL getRawData() override
+        {
+            return m_data.getBuffer();
+        }
+
+        virtual SLANG_NO_THROW size_t SLANG_MCALL getSize() override
+        {
+            return (size_t)m_data.getCount();
         }
 
         SLANG_NO_THROW Result SLANG_MCALL
@@ -4789,13 +4801,8 @@ static D3D12_RESOURCE_DIMENSION _calcResourceDimension(IResource::Type type)
     }
 }
 
-Result D3D12Device::createTextureResource(const ITextureResource::Desc& descIn, const ITextureResource::SubresourceData* initData, ITextureResource** outResource)
+Result setupResourceDesc(D3D12_RESOURCE_DESC& resourceDesc, const ITextureResource::Desc& srcDesc)
 {
-    // Description of uploading on Dx12
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/dn899215%28v=vs.85%29.aspx
-
-    TextureResource::Desc srcDesc = fixupTextureDesc(descIn);
-
     const DXGI_FORMAT pixelFormat = D3DUtil::getMapFormat(srcDesc.format);
     if (pixelFormat == DXGI_FORMAT_UNKNOWN)
     {
@@ -4811,10 +4818,6 @@ Result D3D12Device::createTextureResource(const ITextureResource::Desc& descIn, 
     }
 
     const int numMipMaps = srcDesc.numMipLevels;
-
-    // Setup desc
-    D3D12_RESOURCE_DESC resourceDesc;
-
     resourceDesc.Dimension = dimension;
     resourceDesc.Format = pixelFormat;
     resourceDesc.Width = srcDesc.size.width;
@@ -4831,6 +4834,33 @@ Result D3D12Device::createTextureResource(const ITextureResource::Desc& descIn, 
     resourceDesc.Flags |= _calcResourceFlags(srcDesc.allowedStates);
 
     resourceDesc.Alignment = 0;
+
+    return SLANG_OK;
+}
+
+Result D3D12Device::getTextureAllocationInfo(
+    const ITextureResource::Desc& desc, size_t* outSize, size_t* outAlignment)
+{
+    TextureResource::Desc srcDesc = fixupTextureDesc(desc);
+    D3D12_RESOURCE_DESC resourceDesc = {};
+    setupResourceDesc(resourceDesc, srcDesc);
+    auto allocInfo = m_device->GetResourceAllocationInfo(0xFF, 1, &resourceDesc);
+    *outSize = allocInfo.SizeInBytes;
+    *outAlignment = allocInfo.Alignment;
+    return SLANG_OK;
+}
+
+Result D3D12Device::createTextureResource(const ITextureResource::Desc& descIn, const ITextureResource::SubresourceData* initData, ITextureResource** outResource)
+{
+    // Description of uploading on Dx12
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/dn899215%28v=vs.85%29.aspx
+
+    TextureResource::Desc srcDesc = fixupTextureDesc(descIn);
+
+    D3D12_RESOURCE_DESC resourceDesc = {};
+    setupResourceDesc(resourceDesc, srcDesc);
+    const int arraySize = calcEffectiveArraySize(srcDesc);
+    const int numMipMaps = srcDesc.numMipLevels;
 
     RefPtr<TextureResourceImpl> texture(new TextureResourceImpl(srcDesc));
 
@@ -4851,7 +4881,7 @@ Result D3D12Device::createTextureResource(const ITextureResource::Desc& descIn, 
         {
             clearValuePtr = nullptr;
         }
-        clearValue.Format = pixelFormat;
+        clearValue.Format = resourceDesc.Format;
         memcpy(clearValue.Color, &descIn.optimalClearValue.color, sizeof(clearValue.Color));
         clearValue.DepthStencil.Depth = descIn.optimalClearValue.depthStencil.depth;
         clearValue.DepthStencil.Stencil = descIn.optimalClearValue.depthStencil.stencil;
@@ -4870,13 +4900,21 @@ Result D3D12Device::createTextureResource(const ITextureResource::Desc& descIn, 
     List<D3D12_PLACED_SUBRESOURCE_FOOTPRINT> layouts;
     layouts.setCount(numMipMaps);
     List<UInt64> mipRowSizeInBytes;
-    mipRowSizeInBytes.setCount(numMipMaps);
+    mipRowSizeInBytes.setCount(srcDesc.numMipLevels);
     List<UInt32> mipNumRows;
     mipNumRows.setCount(numMipMaps);
 
     // NOTE! This is just the size for one array upload -> not for the whole texture
     UInt64 requiredSize = 0;
-    m_device->GetCopyableFootprints(&resourceDesc, 0, numMipMaps, 0, layouts.begin(), mipNumRows.begin(), mipRowSizeInBytes.begin(), &requiredSize);
+    m_device->GetCopyableFootprints(
+        &resourceDesc,
+        0,
+        srcDesc.numMipLevels,
+        0,
+        layouts.begin(),
+        mipNumRows.begin(),
+        mipRowSizeInBytes.begin(),
+        &requiredSize);
 
     // Sub resource indexing
     // https://msdn.microsoft.com/en-us/library/windows/desktop/dn705766(v=vs.85).aspx#subresource_indexing

--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -770,6 +770,13 @@ Result DebugDevice::waitForFences(
     return baseObject->waitForFences(fenceCount, fences, values, waitForAll, timeout);
 }
 
+Result DebugDevice::getTextureAllocationInfo(
+    const ITextureResource::Desc& desc, size_t* outSize, size_t* outAlignment)
+{
+    SLANG_GFX_API_FUNC;
+    return baseObject->getTextureAllocationInfo(desc, outSize, outAlignment);
+}
+
 IResource::Type DebugBufferResource::getType()
 {
     SLANG_GFX_API_FUNC;
@@ -1629,6 +1636,24 @@ Result DebugShaderObject::copyFrom(IShaderObject* other)
 {
     SLANG_GFX_API_FUNC;
     return baseObject->copyFrom(getInnerObj(other));
+}
+
+const void* DebugShaderObject::getRawData()
+{
+    SLANG_GFX_API_FUNC;
+    return baseObject->getRawData();
+}
+
+size_t DebugShaderObject::getSize()
+{
+    SLANG_GFX_API_FUNC;
+    return baseObject->getSize();
+}
+
+Result DebugShaderObject::setConstantBufferOverride(IBufferResource* constantBuffer)
+{
+    SLANG_GFX_API_FUNC;
+    return baseObject->setConstantBufferOverride(getInnerObj(constantBuffer));
 }
 
 DebugObjectBase::DebugObjectBase()

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -150,6 +150,8 @@ public:
         uint64_t* values,
         bool waitForAll,
         uint64_t timeout) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getTextureAllocationInfo(
+        const ITextureResource::Desc& desc, size_t* outSize, size_t* outAlignment) override;
 };
 
 class DebugQueryPool : public DebugObject<IQueryPool>
@@ -279,6 +281,10 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentVersion(
         ITransientResourceHeap* transientHeap, IShaderObject** outObject) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL copyFrom(IShaderObject* other) override;
+    virtual SLANG_NO_THROW const void* SLANG_MCALL getRawData() override;
+    virtual SLANG_NO_THROW size_t SLANG_MCALL getSize() override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL
+        setConstantBufferOverride(IBufferResource* constantBuffer) override;
 
 public:
     Slang::String m_typeName;

--- a/tools/gfx/mutable-shader-object.h
+++ b/tools/gfx/mutable-shader-object.h
@@ -115,6 +115,14 @@ namespace gfx
             return SLANG_OK;
         }
     public:
+        virtual SLANG_NO_THROW const void* SLANG_MCALL getRawData() override
+        {
+            return this->m_data.getBuffer();
+        }
+        virtual SLANG_NO_THROW size_t SLANG_MCALL getSize() override
+        {
+            return this->m_data.getCount();
+        }
         virtual SLANG_NO_THROW Result SLANG_MCALL setData(ShaderOffset const& offset, void const* data, size_t size) override
         {
             if (!size) return SLANG_OK;

--- a/tools/gfx/open-gl/render-gl.cpp
+++ b/tools/gfx/open-gl/render-gl.cpp
@@ -955,6 +955,16 @@ public:
             return static_cast<ShaderObjectLayoutImpl*>(m_layout.Ptr());
         }
 
+        virtual SLANG_NO_THROW const void* SLANG_MCALL getRawData() override
+        {
+            return m_data.getBuffer();
+        }
+
+        virtual SLANG_NO_THROW size_t SLANG_MCALL getSize() override
+        {
+            return (size_t)m_data.getCount();
+        }
+
         SLANG_NO_THROW Result SLANG_MCALL
             setData(ShaderOffset const& inOffset, void const* data, size_t inSize) SLANG_OVERRIDE
         {

--- a/tools/gfx/renderer-shared.cpp
+++ b/tools/gfx/renderer-shared.cpp
@@ -450,6 +450,15 @@ Result RendererBase::waitForFences(
     return SLANG_E_NOT_AVAILABLE;
 }
 
+Result RendererBase::getTextureAllocationInfo(
+    const ITextureResource::Desc& desc, size_t* outSize, size_t* outAlignment)
+{
+    SLANG_UNUSED(desc);
+    *outSize = 0;
+    *outAlignment = 0;
+    return SLANG_E_NOT_AVAILABLE;
+}
+
 Result RendererBase::getShaderObjectLayout(
     slang::TypeReflection* type,
     ShaderObjectContainerType container,

--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -542,6 +542,16 @@ public:
         SLANG_UNUSED(other);
         return SLANG_E_NOT_AVAILABLE;
     }
+
+    virtual SLANG_NO_THROW const void* SLANG_MCALL getRawData() override
+    {
+        return nullptr;
+    }
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL setConstantBufferOverride(IBufferResource* outBuffer) override
+    {
+        return SLANG_E_NOT_AVAILABLE;
+    }
 };
 
 template<typename TShaderObjectImpl, typename TShaderObjectLayoutImpl, typename TShaderObjectData>
@@ -1240,6 +1250,10 @@ public:
     // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE.
     virtual SLANG_NO_THROW Result SLANG_MCALL
         waitForFences(uint32_t fenceCount, IFence** fences, uint64_t* fenceValues, bool waitForAll, uint64_t timeout) override;
+
+    // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE.
+    virtual SLANG_NO_THROW Result SLANG_MCALL getTextureAllocationInfo(
+        const ITextureResource::Desc& desc, size_t* outSize, size_t* outAlignment) override;
 
     Result getShaderObjectLayout(
         slang::TypeReflection*      type,

--- a/tools/gfx/vulkan/vk-util.h
+++ b/tools/gfx/vulkan/vk-util.h
@@ -45,6 +45,32 @@ struct VulkanUtil
     static VkPipelineBindPoint getPipelineBindPoint(PipelineType pipelineType);
 
     static VkImageLayout getImageLayoutFromState(ResourceState state);
+
+    static inline bool isDepthFormat(VkFormat format)
+    {
+        switch (format)
+        {
+        case VK_FORMAT_D16_UNORM:
+        case VK_FORMAT_D24_UNORM_S8_UINT:
+        case VK_FORMAT_X8_D24_UNORM_PACK32:
+        case VK_FORMAT_D32_SFLOAT:
+        case VK_FORMAT_D32_SFLOAT_S8_UINT:
+            return true;
+        }
+        return false;
+    }
+
+    static inline bool isStencilFormat(VkFormat format)
+    {
+        switch (format)
+        {
+        case VK_FORMAT_S8_UINT:
+        case VK_FORMAT_D24_UNORM_S8_UINT:
+        case VK_FORMAT_D32_SFLOAT_S8_UINT:
+            return true;
+        }
+        return false;
+    }
 };
 
 struct AccelerationStructureBuildGeometryInfoBuilder


### PR DESCRIPTION
Add `IShaderObject::getSize`, `getRawData()` and `setConstantBufferOverride()` methods.

Add `IDevice::getTextureAllocationInfo()` method and its d3d12 and vulkan implementations.