### PR TITLE
gfx: add coverage for more resource commands.

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -27,6 +27,10 @@
 #    define SLANG_GFX_API
 #endif
 
+// Needed for building on cygwin with gcc
+#undef Always
+#undef None
+
 namespace gfx {
 
 using Slang::ComPtr;
@@ -522,7 +526,7 @@ struct BufferRange
 
 enum class TextureAspect : uint32_t
 {
-    None = 0,
+    Default = 0,
     Color = 0x00000001,
     Depth = 0x00000002,
     Stencil = 0x00000004,
@@ -630,9 +634,6 @@ public:
         0xcf88a31c, 0x6187, 0x46c5, { 0xa4, 0xb7, 0xeb, 0x58, 0xc7, 0x33, 0x40, 0x17 } \
     }
 
-// Needed for building on cygwin with gcc
-#undef Always
-#undef None
 
 enum class ComparisonFunc : uint8_t
 {
@@ -826,7 +827,7 @@ public:
     {
         // The enum values are kept consistent with D3D12_RAYTRACING_INSTANCE_FLAGS
         // and VkGeometryInstanceFlagBitsKHR.
-        enum Enum : uint32_t
+        enum Enum : uint8_t
         {
             None = 0,
             TriangleFacingCullDisable = 0x00000001,

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -830,7 +830,7 @@ public:
     {
         // The enum values are kept consistent with D3D12_RAYTRACING_INSTANCE_FLAGS
         // and VkGeometryInstanceFlagBitsKHR.
-        enum Enum : uint8_t
+        enum Enum : uint32_t
         {
             None = 0,
             TriangleFacingCullDisable = 0x00000001,

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1520,6 +1520,11 @@ public:
         ResourceState dst) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL clearResourceView(
         IResourceView* view, ClearValue* clearValue, ClearResourceViewFlags::Enum flags) = 0;
+    virtual SLANG_NO_THROW void SLANG_MCALL resolveResource(
+        ITextureResource* source,
+        SubresourceRange sourceRange,
+        ITextureResource* dest,
+        SubresourceRange destRange) = 0;
 };
 
 enum class AccelerationStructureCopyMode

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -514,29 +514,36 @@ struct ClearValue
     DepthStencilClearValue depthStencil;
 };
 
+struct BufferRange
+{
+    uint32_t firstElement;
+    uint32_t elementCount;
+};
+
+enum class TextureAspect : uint32_t
+{
+    None = 0,
+    Color = 0x00000001,
+    Depth = 0x00000002,
+    Stencil = 0x00000004,
+    MetaData = 0x00000008,
+    Plane0 = 0x00000010,
+    Plane1 = 0x00000020,
+    Plane2 = 0x00000040,
+};
+
+struct SubresourceRange
+{
+    TextureAspect aspectMask;
+    uint32_t mipLevel;
+    uint32_t mipLevelCount;
+    uint32_t baseArrayLayer; // For Texture3D, this is WSlice.
+    uint32_t layerCount; // For cube maps, this is a multiple of 6.
+};
 
 class ITextureResource: public IResource
 {
 public:
-    enum class Aspect : uint32_t
-    {
-        Color = 0x00000001,
-        Depth = 0x00000002,
-        Stencil = 0x00000004,
-        MetaData = 0x00000008,
-        Plane0 = 0x00000010,
-        Plane1 = 0x00000020,
-        Plane2 = 0x00000040,
-    };
-
-    struct SubresourceRange
-    {
-        Aspect aspectMask;
-        uint32_t mipLevel;
-        uint32_t baseArrayLayer;
-        uint32_t layerCount;
-    };
-
     struct Offset3D
     {
         uint32_t x = 0;
@@ -718,6 +725,8 @@ public:
 
         // Fields for `RenderTarget` and `DepthStencil` views.
         RenderTargetDesc renderTarget;
+        SubresourceRange subresourceRange;
+        BufferRange bufferRange;
     };
     virtual SLANG_NO_THROW Desc* SLANG_MCALL getViewDesc() = 0;
 };
@@ -1483,15 +1492,15 @@ public:
         size_t size) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL copyTexture(
         ITextureResource* dst,
-        ITextureResource::SubresourceRange dstSubresource,
+        SubresourceRange dstSubresource,
         ITextureResource::Offset3D dstOffset,
         ITextureResource* src,
-        ITextureResource::SubresourceRange srcSubresource,
+        SubresourceRange srcSubresource,
         ITextureResource::Offset3D srcOffset,
         ITextureResource::Size extent) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL uploadTextureData(
         ITextureResource* dst,
-        ITextureResource::SubresourceRange subResourceRange,
+        SubresourceRange subResourceRange,
         ITextureResource::Offset3D offset,
         ITextureResource::Offset3D extent,
         ITextureResource::SubresourceData* subResourceData,

--- a/tools/gfx/cuda/render-cuda.cpp
+++ b/tools/gfx/cuda/render-cuda.cpp
@@ -1044,10 +1044,10 @@ public:
 
             virtual SLANG_NO_THROW void SLANG_MCALL copyTexture(
                 ITextureResource* dst,
-                ITextureResource::SubresourceRange dstSubresource,
+                SubresourceRange dstSubresource,
                 ITextureResource::Offset3D dstOffset,
                 ITextureResource* src,
-                ITextureResource::SubresourceRange srcSubresource,
+                SubresourceRange srcSubresource,
                 ITextureResource::Offset3D srcOffset,
                 ITextureResource::Size extent) override
             {
@@ -1063,7 +1063,7 @@ public:
 
             virtual SLANG_NO_THROW void SLANG_MCALL uploadTextureData(
                 ITextureResource* dst,
-                ITextureResource::SubresourceRange subResourceRange,
+                SubresourceRange subResourceRange,
                 ITextureResource::Offset3D offset,
                 ITextureResource::Offset3D extent,
                 ITextureResource::SubresourceData* subResourceData,

--- a/tools/gfx/cuda/render-cuda.cpp
+++ b/tools/gfx/cuda/render-cuda.cpp
@@ -1088,6 +1088,19 @@ public:
                 SLANG_UNUSED(flags);
                 SLANG_UNIMPLEMENTED_X("clearResourceView");
             }
+
+            virtual SLANG_NO_THROW void SLANG_MCALL resolveResource(
+                ITextureResource* source,
+                SubresourceRange sourceRange,
+                ITextureResource* dest,
+                SubresourceRange destRange) override
+            {
+                SLANG_UNUSED(source);
+                SLANG_UNUSED(sourceRange);
+                SLANG_UNUSED(dest);
+                SLANG_UNUSED(destRange);
+                SLANG_UNIMPLEMENTED_X("resolveResource");
+            }
         };
 
         ResourceCommandEncoderImpl m_resourceCommandEncoder;

--- a/tools/gfx/cuda/render-cuda.cpp
+++ b/tools/gfx/cuda/render-cuda.cpp
@@ -1101,6 +1101,38 @@ public:
                 SLANG_UNUSED(destRange);
                 SLANG_UNIMPLEMENTED_X("resolveResource");
             }
+
+            virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
+                IBufferResource* dst,
+                size_t dstOffset,
+                size_t dstSize,
+                ITextureResource* src,
+                SubresourceRange srcSubresource,
+                ITextureResource::Offset3D srcOffset,
+                ITextureResource::Size extent) override
+            {
+                SLANG_UNUSED(dst);
+                SLANG_UNUSED(dstOffset);
+                SLANG_UNUSED(dstSize);
+                SLANG_UNUSED(src);
+                SLANG_UNUSED(srcSubresource);
+                SLANG_UNUSED(srcOffset);
+                SLANG_UNUSED(extent);
+                SLANG_UNIMPLEMENTED_X("copyTextureToBuffer");
+            }
+
+            virtual SLANG_NO_THROW void SLANG_MCALL textureSubresourceBarrier(
+                ITextureResource* texture,
+                SubresourceRange subresourceRange,
+                ResourceState src,
+                ResourceState dst) override
+            {
+                SLANG_UNUSED(texture);
+                SLANG_UNUSED(subresourceRange);
+                SLANG_UNUSED(src);
+                SLANG_UNUSED(dst);
+                SLANG_UNIMPLEMENTED_X("textureSubresourceBarrier");
+            }
         };
 
         ResourceCommandEncoderImpl m_resourceCommandEncoder;

--- a/tools/gfx/d3d/d3d-util.cpp
+++ b/tools/gfx/d3d/d3d-util.cpp
@@ -639,7 +639,7 @@ uint32_t D3DUtil::getPlaneSlice(DXGI_FORMAT format, TextureAspect aspect)
 {
     switch (aspect)
     {
-    case TextureAspect::None:
+    case TextureAspect::Default:
     case TextureAspect::Color:
         return 0;
     case TextureAspect::Depth:

--- a/tools/gfx/d3d/d3d-util.cpp
+++ b/tools/gfx/d3d/d3d-util.cpp
@@ -635,6 +635,36 @@ int D3DUtil::getShaderModelFromProfileName(const char* name)
     return 0;
 }
 
+uint32_t D3DUtil::getPlaneSlice(DXGI_FORMAT format, TextureAspect aspect)
+{
+    switch (aspect)
+    {
+    case TextureAspect::None:
+    case TextureAspect::Color:
+        return 0;
+    case TextureAspect::Depth:
+        return 0;
+    case TextureAspect::Stencil:
+        switch (format)
+        {
+        case DXGI_FORMAT_D24_UNORM_S8_UINT:
+        case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+            return 1;
+        default:
+            return 0;
+        }
+    case TextureAspect::Plane0:
+        return 0;
+    case TextureAspect::Plane1:
+        return 1;
+    case TextureAspect::Plane2:
+        return 2;
+    default:
+        SLANG_ASSERT_FAILURE("Unknown texture aspect.");
+        return 0;
+    }
+}
+
 /* static */SlangResult D3DUtil::findAdapters(DeviceCheckFlags flags, const UnownedStringSlice& adapterName, IDXGIFactory* dxgiFactory, List<ComPtr<IDXGIAdapter>>& outDxgiAdapters)
 {
     Slang::String lowerAdapterName = Slang::String(adapterName).toLower();

--- a/tools/gfx/d3d/d3d-util.h
+++ b/tools/gfx/d3d/d3d-util.h
@@ -96,6 +96,8 @@ class D3DUtil
 
     static int getShaderModelFromProfileName(const char* profile);
 
+    static uint32_t getPlaneSlice(DXGI_FORMAT format, TextureAspect aspect);
+
 };
 
 #if SLANG_GFX_HAS_DXR_SUPPORT

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -3616,6 +3616,38 @@ public:
                 SLANG_UNUSED(destRange);
                 SLANG_UNIMPLEMENTED_X("resolveResource");
             }
+
+            virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
+                IBufferResource* dst,
+                size_t dstOffset,
+                size_t dstSize,
+                ITextureResource* src,
+                SubresourceRange srcSubresource,
+                ITextureResource::Offset3D srcOffset,
+                ITextureResource::Size extent) override
+            {
+                SLANG_UNUSED(dst);
+                SLANG_UNUSED(dstOffset);
+                SLANG_UNUSED(dstSize);
+                SLANG_UNUSED(src);
+                SLANG_UNUSED(srcSubresource);
+                SLANG_UNUSED(srcOffset);
+                SLANG_UNUSED(extent);
+                SLANG_UNIMPLEMENTED_X("copyTextureToBuffer");
+            }
+
+            virtual SLANG_NO_THROW void SLANG_MCALL textureSubresourceBarrier(
+                ITextureResource* texture,
+                SubresourceRange subresourceRange,
+                ResourceState src,
+                ResourceState dst) override
+            {
+                SLANG_UNUSED(texture);
+                SLANG_UNUSED(subresourceRange);
+                SLANG_UNUSED(src);
+                SLANG_UNUSED(dst);
+                SLANG_UNIMPLEMENTED_X("textureSubresourceBarrier");
+            }
         };
 
         ResourceCommandEncoderImpl m_resourceCommandEncoder;

--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -1268,6 +1268,30 @@ void DebugResourceCommandEncoder::resolveResource(
     baseObject->resolveResource(getInnerObj(source), sourceRange, getInnerObj(dest), destRange);
 }
 
+void DebugResourceCommandEncoder::copyTextureToBuffer(
+    IBufferResource* dst,
+    size_t dstOffset,
+    size_t dstSize,
+    ITextureResource* src,
+    SubresourceRange srcSubresource,
+    ITextureResource::Offset3D srcOffset,
+    ITextureResource::Size extent)
+{
+    SLANG_GFX_API_FUNC;
+    baseObject->copyTextureToBuffer(
+        getInnerObj(dst), dstOffset, dstSize, getInnerObj(src), srcSubresource, srcOffset, extent);
+}
+
+void DebugResourceCommandEncoder::textureSubresourceBarrier(
+    ITextureResource* texture,
+    SubresourceRange subresourceRange,
+    ResourceState src,
+    ResourceState dst)
+{
+    SLANG_GFX_API_FUNC;
+    baseObject->textureSubresourceBarrier(getInnerObj(texture), subresourceRange, src, dst);
+}
+
 void DebugRayTracingCommandEncoder::endEncoding()
 {
     SLANG_GFX_API_FUNC;

--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -1258,6 +1258,16 @@ void DebugResourceCommandEncoder::clearResourceView(
     baseObject->clearResourceView(getInnerObj(view), clearValue, flags);
 }
 
+void DebugResourceCommandEncoder::resolveResource(
+    ITextureResource* source,
+    SubresourceRange sourceRange,
+    ITextureResource* dest,
+    SubresourceRange destRange)
+{
+    SLANG_GFX_API_FUNC;
+    baseObject->resolveResource(getInnerObj(source), sourceRange, getInnerObj(dest), destRange);
+}
+
 void DebugRayTracingCommandEncoder::endEncoding()
 {
     SLANG_GFX_API_FUNC;

--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -1220,10 +1220,10 @@ void DebugResourceCommandEncoder::bufferBarrier(
 
 void DebugResourceCommandEncoder::copyTexture(
     ITextureResource* dst,
-    ITextureResource::SubresourceRange dstSubresource,
+    SubresourceRange dstSubresource,
     ITextureResource::Offset3D dstOffset,
     ITextureResource* src,
-    ITextureResource::SubresourceRange srcSubresource,
+    SubresourceRange srcSubresource,
     ITextureResource::Offset3D srcOffset,
     ITextureResource::Size extent)
 {
@@ -1240,7 +1240,7 @@ void DebugResourceCommandEncoder::copyTexture(
 
 void DebugResourceCommandEncoder::uploadTextureData(
     ITextureResource* dst,
-    ITextureResource::SubresourceRange subResourceRange,
+    SubresourceRange subResourceRange,
     ITextureResource::Offset3D offset,
     ITextureResource::Offset3D extent,
     ITextureResource::SubresourceData* subResourceData,

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -418,6 +418,12 @@ public:
         ClearValue* clearValue,
         ClearResourceViewFlags::Enum flags) override;
 
+    virtual SLANG_NO_THROW void SLANG_MCALL resolveResource(
+        ITextureResource* source,
+        SubresourceRange sourceRange,
+        ITextureResource* dest,
+        SubresourceRange destRange) override;
+
 public:
     DebugCommandBuffer* commandBuffer;
     bool isOpen = false;

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -398,16 +398,16 @@ public:
         ResourceState dst) override;
     virtual SLANG_NO_THROW void SLANG_MCALL copyTexture(
         ITextureResource* dst,
-        ITextureResource::SubresourceRange dstSubresource,
+        SubresourceRange dstSubresource,
         ITextureResource::Offset3D dstOffset,
         ITextureResource* src,
-        ITextureResource::SubresourceRange srcSubresource,
+        SubresourceRange srcSubresource,
         ITextureResource::Offset3D srcOffset,
         ITextureResource::Size extent) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL uploadTextureData(
         ITextureResource* dst,
-        ITextureResource::SubresourceRange subResourceRange,
+        SubresourceRange subResourceRange,
         ITextureResource::Offset3D offset,
         ITextureResource::Offset3D extent,
         ITextureResource::SubresourceData* subResourceData,

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -424,6 +424,21 @@ public:
         ITextureResource* dest,
         SubresourceRange destRange) override;
 
+    virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
+        IBufferResource* dst,
+        size_t dstOffset,
+        size_t dstSize,
+        ITextureResource* src,
+        SubresourceRange srcSubresource,
+        ITextureResource::Offset3D srcOffset,
+        ITextureResource::Size extent) override;
+
+    virtual SLANG_NO_THROW void SLANG_MCALL textureSubresourceBarrier(
+        ITextureResource* texture,
+        SubresourceRange subresourceRange,
+        ResourceState src,
+        ResourceState dst) override;
+
 public:
     DebugCommandBuffer* commandBuffer;
     bool isOpen = false;

--- a/tools/gfx/immediate-renderer-base.cpp
+++ b/tools/gfx/immediate-renderer-base.cpp
@@ -357,6 +357,19 @@ public:
             SLANG_UNUSED(flags);
             SLANG_UNIMPLEMENTED_X("clearResourceView");
         }
+
+        virtual SLANG_NO_THROW void SLANG_MCALL resolveResource(
+            ITextureResource* source,
+            SubresourceRange sourceRange,
+            ITextureResource* dest,
+            SubresourceRange destRange) override
+        {
+            SLANG_UNUSED(source);
+            SLANG_UNUSED(sourceRange);
+            SLANG_UNUSED(dest);
+            SLANG_UNUSED(destRange);
+            SLANG_UNIMPLEMENTED_X("resolveResource");
+        }
     };
 
     ResourceCommandEncoderImpl m_resourceCommandEncoder;

--- a/tools/gfx/immediate-renderer-base.cpp
+++ b/tools/gfx/immediate-renderer-base.cpp
@@ -313,10 +313,10 @@ public:
 
         virtual SLANG_NO_THROW void SLANG_MCALL copyTexture(
             ITextureResource* dst,
-            ITextureResource::SubresourceRange dstSubresource,
+            SubresourceRange dstSubresource,
             ITextureResource::Offset3D dstOffset,
             ITextureResource* src,
-            ITextureResource::SubresourceRange srcSubresource,
+            SubresourceRange srcSubresource,
             ITextureResource::Offset3D srcOffset,
             ITextureResource::Size extent) override
         {
@@ -332,7 +332,7 @@ public:
 
         virtual SLANG_NO_THROW void SLANG_MCALL uploadTextureData(
             ITextureResource* dst,
-            ITextureResource::SubresourceRange subResourceRange,
+            SubresourceRange subResourceRange,
             ITextureResource::Offset3D offset,
             ITextureResource::Offset3D extend,
             ITextureResource::SubresourceData* subResourceData,

--- a/tools/gfx/immediate-renderer-base.cpp
+++ b/tools/gfx/immediate-renderer-base.cpp
@@ -370,6 +370,38 @@ public:
             SLANG_UNUSED(destRange);
             SLANG_UNIMPLEMENTED_X("resolveResource");
         }
+
+        virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
+            IBufferResource* dst,
+            size_t dstOffset,
+            size_t dstSize,
+            ITextureResource* src,
+            SubresourceRange srcSubresource,
+            ITextureResource::Offset3D srcOffset,
+            ITextureResource::Size extent) override
+        {
+            SLANG_UNUSED(dst);
+            SLANG_UNUSED(dstOffset);
+            SLANG_UNUSED(dstSize);
+            SLANG_UNUSED(src);
+            SLANG_UNUSED(srcSubresource);
+            SLANG_UNUSED(srcOffset);
+            SLANG_UNUSED(extent);
+            SLANG_UNIMPLEMENTED_X("copyTextureToBuffer");
+        }
+
+        virtual SLANG_NO_THROW void SLANG_MCALL textureSubresourceBarrier(
+            ITextureResource* texture,
+            SubresourceRange subresourceRange,
+            ResourceState src,
+            ResourceState dst) override
+        {
+            SLANG_UNUSED(texture);
+            SLANG_UNUSED(subresourceRange);
+            SLANG_UNUSED(src);
+            SLANG_UNUSED(dst);
+            SLANG_UNIMPLEMENTED_X("textureSubresourceBarrier");
+        }
     };
 
     ResourceCommandEncoderImpl m_resourceCommandEncoder;

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -4387,6 +4387,38 @@ public:
                 SLANG_UNUSED(destRange);
                 SLANG_UNIMPLEMENTED_X("resolveResource");
             }
+
+            virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
+                IBufferResource* dst,
+                size_t dstOffset,
+                size_t dstSize,
+                ITextureResource* src,
+                SubresourceRange srcSubresource,
+                ITextureResource::Offset3D srcOffset,
+                ITextureResource::Size extent) override
+            {
+                SLANG_UNUSED(dst);
+                SLANG_UNUSED(dstOffset);
+                SLANG_UNUSED(dstSize);
+                SLANG_UNUSED(src);
+                SLANG_UNUSED(srcSubresource);
+                SLANG_UNUSED(srcOffset);
+                SLANG_UNUSED(extent);
+                SLANG_UNIMPLEMENTED_X("copyTextureToBuffer");
+            }
+
+            virtual SLANG_NO_THROW void SLANG_MCALL textureSubresourceBarrier(
+                ITextureResource* texture,
+                SubresourceRange subresourceRange,
+                ResourceState src,
+                ResourceState dst) override
+            {
+                SLANG_UNUSED(texture);
+                SLANG_UNUSED(subresourceRange);
+                SLANG_UNUSED(src);
+                SLANG_UNUSED(dst);
+                SLANG_UNIMPLEMENTED_X("textureSubresourceBarrier");
+            }
         };
 
         RefPtr<ResourceCommandEncoder> m_resourceCommandEncoder;

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -4374,6 +4374,19 @@ public:
                 SLANG_UNUSED(flags);
                 SLANG_UNIMPLEMENTED_X("clearResourceView");
             }
+
+            virtual SLANG_NO_THROW void SLANG_MCALL resolveResource(
+                ITextureResource* source,
+                SubresourceRange sourceRange,
+                ITextureResource* dest,
+                SubresourceRange destRange) override
+            {
+                SLANG_UNUSED(source);
+                SLANG_UNUSED(sourceRange);
+                SLANG_UNUSED(dest);
+                SLANG_UNUSED(destRange);
+                SLANG_UNIMPLEMENTED_X("resolveResource");
+            }
         };
 
         RefPtr<ResourceCommandEncoder> m_resourceCommandEncoder;

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -4330,10 +4330,10 @@ public:
 
             virtual SLANG_NO_THROW void SLANG_MCALL copyTexture(
                 ITextureResource* dst,
-                ITextureResource::SubresourceRange dstSubresource,
+                SubresourceRange dstSubresource,
                 ITextureResource::Offset3D dstOffset,
                 ITextureResource* src,
-                ITextureResource::SubresourceRange srcSubresource,
+                SubresourceRange srcSubresource,
                 ITextureResource::Offset3D srcOffset,
                 ITextureResource::Size extent) override
             {
@@ -4349,7 +4349,7 @@ public:
 
             virtual SLANG_NO_THROW void SLANG_MCALL uploadTextureData(
                 ITextureResource* dst,
-                ITextureResource::SubresourceRange subResourceRange,
+                SubresourceRange subResourceRange,
                 ITextureResource::Offset3D offset,
                 ITextureResource::Offset3D extend,
                 ITextureResource::SubresourceData* subResourceData,
@@ -7183,10 +7183,10 @@ Result VKDevice::createTextureView(ITextureResource* texture, IResourceView::Des
         break;
     }
     createInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    createInfo.subresourceRange.baseArrayLayer = 0;
-    createInfo.subresourceRange.baseMipLevel = 0;
-    createInfo.subresourceRange.layerCount = VK_REMAINING_ARRAY_LAYERS;
-    createInfo.subresourceRange.levelCount = VK_REMAINING_MIP_LEVELS;
+    createInfo.subresourceRange.baseArrayLayer = desc.subresourceRange.baseArrayLayer;
+    createInfo.subresourceRange.baseMipLevel = desc.subresourceRange.mipLevel;
+    createInfo.subresourceRange.layerCount = desc.subresourceRange.layerCount;
+    createInfo.subresourceRange.levelCount = desc.subresourceRange.mipLevelCount;
     switch (desc.type)
     {
     case IResourceView::Type::DepthStencil:
@@ -7236,8 +7236,24 @@ Result VKDevice::createBufferView(IBufferResource* buffer, IResourceView::Desc c
     auto resourceImpl = (BufferResourceImpl*) buffer;
 
     // TODO: These should come from the `ResourceView::Desc`
-    VkDeviceSize offset = 0;
-    VkDeviceSize size = resourceImpl->getDesc()->sizeInBytes;
+    auto stride = resourceImpl->getDesc()->elementSize;
+    if (stride == 0)
+    {
+        if (desc.format == Format::Unknown)
+        {
+            stride = 1;
+        }
+        else
+        {
+            FormatInfo info;
+            gfxGetFormatInfo(desc.format, &info);
+            stride = info.blockSizeInBytes;
+            assert(info.pixelsPerBlock == 1);
+        }
+    }
+    VkDeviceSize offset = (VkDeviceSize)desc.bufferRange.firstElement * stride;
+    VkDeviceSize size = desc.bufferRange.elementCount == 0 ? resourceImpl->getDesc()->sizeInBytes
+                                                           : (VkDeviceSize)desc.bufferRange.elementCount * stride;
 
     // There are two different cases we need to think about for buffers.
     //
@@ -7274,7 +7290,7 @@ Result VKDevice::createBufferView(IBufferResource* buffer, IResourceView::Desc c
             // require a view in Vulkan.
             RefPtr<PlainBufferResourceViewImpl> viewImpl = new PlainBufferResourceViewImpl(this);
             viewImpl->m_buffer = resourceImpl;
-            viewImpl->offset = 0;
+            viewImpl->offset = offset;
             viewImpl->size = size;
             viewImpl->m_desc = desc;
 

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -7230,8 +7230,12 @@ Result VKDevice::createTextureView(ITextureResource* texture, IResourceView::Des
     createInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     createInfo.subresourceRange.baseArrayLayer = desc.subresourceRange.baseArrayLayer;
     createInfo.subresourceRange.baseMipLevel = desc.subresourceRange.mipLevel;
-    createInfo.subresourceRange.layerCount = desc.subresourceRange.layerCount;
-    createInfo.subresourceRange.levelCount = desc.subresourceRange.mipLevelCount;
+    createInfo.subresourceRange.layerCount = desc.subresourceRange.layerCount == 0
+                                                 ? VK_REMAINING_ARRAY_LAYERS
+                                                 : desc.subresourceRange.layerCount;
+    createInfo.subresourceRange.levelCount = desc.subresourceRange.mipLevelCount == 0
+                                                 ? VK_REMAINING_MIP_LEVELS
+                                                 : desc.subresourceRange.mipLevelCount;
     switch (desc.type)
     {
     case IResourceView::Type::DepthStencil:

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -202,7 +202,7 @@ struct AssignValsFromLayoutContext
         ComPtr<IBufferResource> bufferResource;
         SLANG_RETURN_ON_FAIL(ShaderRendererUtil::createBufferResource(srcBuffer, /*entry.isOutput,*/ bufferSize, bufferData.getBuffer(), device, bufferResource));
 
-        IResourceView::Desc viewDesc;
+        IResourceView::Desc viewDesc = {};
         viewDesc.type = IResourceView::Type::UnorderedAccess;
         viewDesc.format = srcBuffer.format;
         auto bufferView = device->createBufferView(
@@ -225,7 +225,7 @@ struct AssignValsFromLayoutContext
 
         auto sampler = _createSamplerState(device, samplerEntry->samplerDesc);
 
-        IResourceView::Desc viewDesc;
+        IResourceView::Desc viewDesc = {};
         viewDesc.type = IResourceView::Type::ShaderResource;
         auto textureView = device->createTextureView(
             texture,
@@ -252,7 +252,7 @@ struct AssignValsFromLayoutContext
         SLANG_RETURN_ON_FAIL(ShaderRendererUtil::generateTextureResource(
             srcVal->textureDesc, defaultState, device, texture));
 
-        IResourceView::Desc viewDesc;
+        IResourceView::Desc viewDesc = {};
         viewDesc.type = viewType;
         viewDesc.format = texture->getDesc()->format;
         auto textureView = device->createTextureView(
@@ -618,7 +618,7 @@ void RenderTestApp::_initializeRenderPass()
     colorBufferDesc.allowedStates = ResourceState::RenderTarget;
     m_colorBuffer = m_device->createTextureResource(colorBufferDesc, nullptr);
 
-    gfx::IResourceView::Desc colorBufferViewDesc;
+    gfx::IResourceView::Desc colorBufferViewDesc = {};
     memset(&colorBufferViewDesc, 0, sizeof(colorBufferViewDesc));
     colorBufferViewDesc.format = gfx::Format::R8G8B8A8_UNORM;
     colorBufferViewDesc.renderTarget.shape = gfx::IResource::Type::Texture2D;
@@ -626,7 +626,7 @@ void RenderTestApp::_initializeRenderPass()
     ComPtr<gfx::IResourceView> rtv =
         m_device->createTextureView(m_colorBuffer.get(), colorBufferViewDesc);
 
-    gfx::IResourceView::Desc depthBufferViewDesc;
+    gfx::IResourceView::Desc depthBufferViewDesc = {};
     memset(&depthBufferViewDesc, 0, sizeof(depthBufferViewDesc));
     depthBufferViewDesc.format = gfx::Format::D32_FLOAT;
     depthBufferViewDesc.renderTarget.shape = gfx::IResource::Type::Texture2D;


### PR DESCRIPTION
Adds the API for:
* Specify `SubresourceRange` for resource view creation.
* `resolveResource` (MSAA texture)
* `copyTextureToBuffer` and `textureSubresourceBarrier`.
* Add `operator<` for `gfx::ShaderOffset` so it may be used in a `std::map`.