### PR TITLE
Fix reinterpret lowering not done for generic functions.

### DIFF
--- a/source/slang/slang-ir-lower-reinterpret.cpp
+++ b/source/slang/slang-ir-lower-reinterpret.cpp
@@ -17,12 +17,6 @@ struct ReinterpretLoweringContext
 
     void addToWorkList(IRInst* inst)
     {
-        for (auto ii = inst->getParent(); ii; ii = ii->getParent())
-        {
-            if (as<IRGeneric>(ii))
-                return;
-        }
-
         if (workList.Contains(inst))
             return;
 


### PR DESCRIPTION
`reinterpret` lowering is currently skipped for generic functions, this is not intended.
This change removes the logic that skips the lowering logic.