### PR TITLE
Fix shader-toy example.

### DIFF
--- a/examples/ray-tracing-pipeline/main.cpp
+++ b/examples/ray-tracing-pipeline/main.cpp
@@ -367,12 +367,12 @@ Slang::Result initialize()
         IBufferResource::Desc asDraftBufferDesc;
         asDraftBufferDesc.type = IResource::Type::Buffer;
         asDraftBufferDesc.defaultState = ResourceState::AccelerationStructure;
-        asDraftBufferDesc.sizeInBytes = accelerationStructurePrebuildInfo.resultDataMaxSize;
+        asDraftBufferDesc.sizeInBytes = (size_t)accelerationStructurePrebuildInfo.resultDataMaxSize;
         ComPtr<IBufferResource> draftBuffer = gDevice->createBufferResource(asDraftBufferDesc);
         IBufferResource::Desc scratchBufferDesc;
         scratchBufferDesc.type = IResource::Type::Buffer;
         scratchBufferDesc.defaultState = ResourceState::UnorderedAccess;
-        scratchBufferDesc.sizeInBytes = accelerationStructurePrebuildInfo.scratchDataSize;
+        scratchBufferDesc.sizeInBytes = (size_t)accelerationStructurePrebuildInfo.scratchDataSize;
         ComPtr<IBufferResource> scratchBuffer = gDevice->createBufferResource(scratchBufferDesc);
 
         // Build acceleration structure.
@@ -412,13 +412,13 @@ Slang::Result initialize()
         IBufferResource::Desc asBufferDesc;
         asBufferDesc.type = IResource::Type::Buffer;
         asBufferDesc.defaultState = ResourceState::AccelerationStructure;
-        asBufferDesc.sizeInBytes = compactedSize;
+        asBufferDesc.sizeInBytes = (size_t)compactedSize;
         gBLASBuffer = gDevice->createBufferResource(asBufferDesc);
         IAccelerationStructure::CreateDesc createDesc;
         createDesc.buffer = gBLASBuffer;
         createDesc.kind = IAccelerationStructure::Kind::BottomLevel;
         createDesc.offset = 0;
-        createDesc.size = compactedSize;
+        createDesc.size = (size_t)compactedSize;
         gDevice->createAccelerationStructure(createDesc, gBLAS.writeRef());
 
         commandBuffer = gTransientHeaps[0]->createCommandBuffer();
@@ -465,20 +465,20 @@ Slang::Result initialize()
         IBufferResource::Desc asBufferDesc;
         asBufferDesc.type = IResource::Type::Buffer;
         asBufferDesc.defaultState = ResourceState::AccelerationStructure;
-        asBufferDesc.sizeInBytes = accelerationStructurePrebuildInfo.resultDataMaxSize;
+        asBufferDesc.sizeInBytes = (size_t)accelerationStructurePrebuildInfo.resultDataMaxSize;
         gTLASBuffer = gDevice->createBufferResource(asBufferDesc);
 
         IBufferResource::Desc scratchBufferDesc;
         scratchBufferDesc.type = IResource::Type::Buffer;
         scratchBufferDesc.defaultState = ResourceState::UnorderedAccess;
-        scratchBufferDesc.sizeInBytes = accelerationStructurePrebuildInfo.scratchDataSize;
+        scratchBufferDesc.sizeInBytes = (size_t)accelerationStructurePrebuildInfo.scratchDataSize;
         ComPtr<IBufferResource> scratchBuffer = gDevice->createBufferResource(scratchBufferDesc);
 
         IAccelerationStructure::CreateDesc createDesc;
         createDesc.buffer = gTLASBuffer;
         createDesc.kind = IAccelerationStructure::Kind::TopLevel;
         createDesc.offset = 0;
-        createDesc.size = accelerationStructurePrebuildInfo.resultDataMaxSize;
+        createDesc.size = (size_t)accelerationStructurePrebuildInfo.resultDataMaxSize;
         SLANG_RETURN_ON_FAIL(gDevice->createAccelerationStructure(createDesc, gTLAS.writeRef()));
 
         auto commandBuffer = gTransientHeaps[0]->createCommandBuffer();

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1073,7 +1073,7 @@ struct DepthStencilOpDesc
 
 struct DepthStencilDesc
 {
-    bool            depthTestEnable     = true;
+    bool            depthTestEnable     = false;
     bool            depthWriteEnable    = true;
     ComparisonFunc  depthFunc           = ComparisonFunc::Less;
 

--- a/source/slang/slang-ir-clone.cpp
+++ b/source/slang/slang-ir-clone.cpp
@@ -139,6 +139,17 @@ static void _cloneInstDecorationsAndChildren(
     builder->sharedBuilder = sharedBuilder;
     builder->setInsertInto(newInst);
 
+    // If `newInst` already has non-decoration children, we want to
+    // insert the new children between the existing decoration and non-decoration children
+    // so that we maintain the invariant that all decorations are defined before non-decorations.
+    if (auto lastDecor = newInst->getLastDecoration())
+    {
+        if (auto nextInstBeforeLastDecor = lastDecor->getNextInst())
+        {
+            builder->setInsertBefore(nextInstBeforeLastDecor);
+        }
+    }
+
     // When applying the first phase of cloning to
     // children, we will keep track of those that
     // require the second phase.

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -5967,6 +5967,7 @@ Result D3D12Device::createGraphicsPipelineState(const GraphicsPipelineStateDesc&
         D3D12_BLEND_DESC& blend = psoDesc.BlendState;
         blend.IndependentBlendEnable = FALSE;
         blend.AlphaToCoverageEnable = desc.blend.alphaToCoverageEnable ? TRUE : FALSE;
+        blend.RenderTarget[0].RenderTargetWriteMask = (uint8_t)RenderTargetWriteMask::EnableAll;
         for (uint32_t i = 0; i < desc.blend.targetCount; i++)
         {
             auto& d3dDesc = blend.RenderTarget[i];

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -2741,7 +2741,8 @@ public:
             for(Index i = 0; i < count; ++i)
             {
                 auto resourceView = static_cast<TexelBufferResourceViewImpl*>(resourceViews[i].Ptr());
-
+                if (!resourceView)
+                    continue;
                 VkBufferView bufferView = resourceView->m_view;
 
                 VkWriteDescriptorSet write = {};
@@ -2770,7 +2771,8 @@ public:
             {
                 auto texture = slots[i].textureView;
                 auto sampler = slots[i].sampler;
-
+                if (!texture)
+                    continue;
                 VkDescriptorImageInfo imageInfo = {};
                 imageInfo.imageView = texture->m_view;
                 imageInfo.imageLayout = texture->m_layout;
@@ -2802,7 +2804,8 @@ public:
             {
                 auto accelerationStructure =
                     static_cast<AccelerationStructureImpl*>(resourceViews[i].Ptr());
-                
+                if (!accelerationStructure)
+                    continue;
                 VkWriteDescriptorSetAccelerationStructureKHR writeAS = {};
                 writeAS.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_KHR;
                 writeAS.accelerationStructureCount = 1;
@@ -2831,7 +2834,8 @@ public:
             for(Index i = 0; i < count; ++i)
             {
                 auto texture = static_cast<TextureResourceViewImpl*>(resourceViews[i].Ptr());
-
+                if (!texture)
+                    continue;
                 VkDescriptorImageInfo imageInfo = {};
                 imageInfo.imageView = texture->m_view;
                 imageInfo.imageLayout = texture->m_layout;
@@ -2862,7 +2866,8 @@ public:
             for(Index i = 0; i < count; ++i)
             {
                 auto sampler = samplers[i];
-
+                if (!sampler)
+                    continue;
                 VkDescriptorImageInfo imageInfo = {};
                 imageInfo.imageView = 0;
                 imageInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -813,13 +813,13 @@ void RenderTestApp::_initializeAccelerationStructure()
         IBufferResource::Desc asBufferDesc;
         asBufferDesc.type = IResource::Type::Buffer;
         asBufferDesc.defaultState = ResourceState::AccelerationStructure;
-        asBufferDesc.sizeInBytes = accelerationStructurePrebuildInfo.resultDataMaxSize;
+        asBufferDesc.sizeInBytes = (size_t)accelerationStructurePrebuildInfo.resultDataMaxSize;
         m_tlasBuffer = m_device->createBufferResource(asBufferDesc);
 
         IBufferResource::Desc scratchBufferDesc;
         scratchBufferDesc.type = IResource::Type::Buffer;
         scratchBufferDesc.defaultState = ResourceState::UnorderedAccess;
-        scratchBufferDesc.sizeInBytes = accelerationStructurePrebuildInfo.scratchDataSize;
+        scratchBufferDesc.sizeInBytes = (size_t)accelerationStructurePrebuildInfo.scratchDataSize;
         ComPtr<IBufferResource> scratchBuffer = m_device->createBufferResource(scratchBufferDesc);
 
         IAccelerationStructure::CreateDesc createDesc;


### PR DESCRIPTION
This change contains several fixes to issues that break shader-toy example.

1. Fix function specialization that breaks the invariant where all decorations appear before other insts in an `IRFunc`.
2. Properly set d3d12 color write mask when no blend desc is specified.
3. Fix Vulkan binding logic to not crash when a bound resource view is `nullptr`.