### PR TITLE
Remove `PipelineType` from gfx header.

### DIFF
--- a/examples/gpu-printing/main.cpp
+++ b/examples/gpu-printing/main.cpp
@@ -73,7 +73,6 @@ ComPtr<gfx::IShaderProgram> loadComputeProgram(slang::IModule* slangModule, char
     gGPUPrinting.loadStrings(linkedProgram->getLayout());
 
     gfx::IShaderProgram::Desc programDesc = {};
-    programDesc.pipelineType = gfx::PipelineType::Compute;
     programDesc.slangProgram = linkedProgram;
 
     auto shaderProgram = gDevice->createProgram(programDesc);

--- a/examples/model-viewer/main.cpp
+++ b/examples/model-viewer/main.cpp
@@ -108,7 +108,6 @@ struct RendererContext
         // We can create a `gfx::IShaderProgram` object from `composedProgram`
         // so it may be used by the graphics layer.
         gfx::IShaderProgram::Desc programDesc = {};
-        programDesc.pipelineType = gfx::PipelineType::Graphics;
         programDesc.slangProgram = composedProgram.get();
 
         shaderProgram = device->createProgram(programDesc);

--- a/examples/ray-tracing-pipeline/main.cpp
+++ b/examples/ray-tracing-pipeline/main.cpp
@@ -155,9 +155,7 @@ void diagnoseIfNeeded(slang::IBlob* diagnosticsBlob)
 
 // Load and compile shader code from souce.
 gfx::Result loadShaderProgram(
-    gfx::IDevice*         device,
-    gfx::PipelineType pipelineType,
-    gfx::IShaderProgram**   outProgram)
+    gfx::IDevice* device, bool isRayTracingPipeline, gfx::IShaderProgram** outProgram)
 {
     ComPtr<slang::ISession> slangSession;
     slangSession = device->getSlangSession();
@@ -170,7 +168,7 @@ gfx::Result loadShaderProgram(
 
     Slang::List<slang::IComponentType*> componentTypes;
     componentTypes.add(module);
-    if (pipelineType == PipelineType::RayTracing)
+    if (isRayTracingPipeline)
     {
         ComPtr<slang::IEntryPoint> entryPoint;
         SLANG_RETURN_ON_FAIL(module->findEntryPointByName("rayGenShader", entryPoint.writeRef()));
@@ -203,7 +201,6 @@ gfx::Result loadShaderProgram(
     SLANG_RETURN_ON_FAIL(result);
 
     gfx::IShaderProgram::Desc programDesc = {};
-    programDesc.pipelineType = pipelineType;
     programDesc.slangProgram = linkedProgram;
     SLANG_RETURN_ON_FAIL(device->createProgram(programDesc, outProgram));
 
@@ -512,7 +509,7 @@ Slang::Result initialize()
         return SLANG_FAIL;
 
     ComPtr<IShaderProgram> shaderProgram;
-    SLANG_RETURN_ON_FAIL(loadShaderProgram(gDevice, PipelineType::Graphics, shaderProgram.writeRef()));
+    SLANG_RETURN_ON_FAIL(loadShaderProgram(gDevice, false, shaderProgram.writeRef()));
     GraphicsPipelineStateDesc desc;
     desc.inputLayout = inputLayout;
     desc.program = shaderProgram;
@@ -523,7 +520,7 @@ Slang::Result initialize()
 
     ComPtr<IShaderProgram> rayTracingProgram;
     SLANG_RETURN_ON_FAIL(
-        loadShaderProgram(gDevice, PipelineType::RayTracing, rayTracingProgram.writeRef()));
+        loadShaderProgram(gDevice, true, rayTracingProgram.writeRef()));
     RayTracingPipelineStateDesc rtpDesc = {};
     rtpDesc.program = rayTracingProgram;
     rtpDesc.hitGroupCount = 2;

--- a/examples/ray-tracing/main.cpp
+++ b/examples/ray-tracing/main.cpp
@@ -155,9 +155,7 @@ void diagnoseIfNeeded(slang::IBlob* diagnosticsBlob)
 
 // Load and compile shader code from souce.
 gfx::Result loadShaderProgram(
-    gfx::IDevice*         device,
-    gfx::PipelineType pipelineType,
-    gfx::IShaderProgram**   outProgram)
+    gfx::IDevice* device, bool isComputePipeline, gfx::IShaderProgram** outProgram)
 {
     ComPtr<slang::ISession> slangSession;
     slangSession = device->getSlangSession();
@@ -170,7 +168,7 @@ gfx::Result loadShaderProgram(
 
     Slang::List<slang::IComponentType*> componentTypes;
     componentTypes.add(module);
-    if (pipelineType == PipelineType::Compute)
+    if (isComputePipeline)
     {
         ComPtr<slang::IEntryPoint> computeEntryPoint;
         SLANG_RETURN_ON_FAIL(module->findEntryPointByName("computeMain", computeEntryPoint.writeRef()));
@@ -195,7 +193,6 @@ gfx::Result loadShaderProgram(
     SLANG_RETURN_ON_FAIL(result);
 
     gfx::IShaderProgram::Desc programDesc = {};
-    programDesc.pipelineType = pipelineType;
     programDesc.slangProgram = linkedProgram;
     SLANG_RETURN_ON_FAIL(device->createProgram(programDesc, outProgram));
 
@@ -504,7 +501,7 @@ Slang::Result initialize()
         return SLANG_FAIL;
 
     ComPtr<IShaderProgram> shaderProgram;
-    SLANG_RETURN_ON_FAIL(loadShaderProgram(gDevice, PipelineType::Graphics, shaderProgram.writeRef()));
+    SLANG_RETURN_ON_FAIL(loadShaderProgram(gDevice, false, shaderProgram.writeRef()));
     GraphicsPipelineStateDesc desc;
     desc.inputLayout = inputLayout;
     desc.program = shaderProgram;
@@ -514,8 +511,7 @@ Slang::Result initialize()
         return SLANG_FAIL;
 
     ComPtr<IShaderProgram> computeProgram;
-    SLANG_RETURN_ON_FAIL(
-        loadShaderProgram(gDevice, PipelineType::Compute, computeProgram.writeRef()));
+    SLANG_RETURN_ON_FAIL(loadShaderProgram(gDevice, true, computeProgram.writeRef()));
     ComputePipelineStateDesc computeDesc;
     computeDesc.program = computeProgram;
     gRenderPipelineState = gDevice->createComputePipelineState(computeDesc);

--- a/examples/shader-object/main.cpp
+++ b/examples/shader-object/main.cpp
@@ -120,7 +120,6 @@ Result loadShaderProgram(
     // We can create a `gfx::IShaderProgram` object from `composedProgram`
     // so it may be used by the graphics layer.
     gfx::IShaderProgram::Desc programDesc = {};
-    programDesc.pipelineType = gfx::PipelineType::Compute;
     programDesc.slangProgram = composedProgram.get();
 
     auto shaderProgram = device->createProgram(programDesc);

--- a/examples/shader-toy/main.cpp
+++ b/examples/shader-toy/main.cpp
@@ -263,7 +263,6 @@ Result loadShaderProgram(gfx::IDevice* device, ComPtr<gfx::IShaderProgram>& outS
     SLANG_RETURN_ON_FAIL(result);
 
     gfx::IShaderProgram::Desc programDesc = {};
-    programDesc.pipelineType = gfx::PipelineType::Graphics;
     programDesc.slangProgram = linkedProgram.get();
     auto shaderProgram = device->createProgram(programDesc);
     outShaderProgram = shaderProgram;

--- a/examples/triangle/main.cpp
+++ b/examples/triangle/main.cpp
@@ -181,7 +181,6 @@ gfx::Result loadShaderProgram(
     // program representation.
     //
     gfx::IShaderProgram::Desc programDesc = {};
-    programDesc.pipelineType = gfx::PipelineType::Graphics;
     programDesc.slangProgram = linkedProgram;
     SLANG_RETURN_ON_FAIL(device->createProgram(programDesc, outProgram));
 

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -51,15 +51,6 @@ class IInputLayout: public ISlangUnknown
         0x45223711, 0xa84b, 0x455c, { 0xbe, 0xfa, 0x49, 0x37, 0x42, 0x1e, 0x8e, 0x2e } \
     }
 
-enum class PipelineType
-{
-    Unknown,
-    Graphics,
-    Compute,
-    RayTracing,
-    CountOf,
-};
-
 enum class StageType
 {
     Unknown,
@@ -121,7 +112,6 @@ class IShaderProgram: public ISlangUnknown
 public:
     struct Desc
     {
-        PipelineType        pipelineType;
         slang::IComponentType*  slangProgram;
     };
 };

--- a/tools/gfx-unit-test/gfx-test-util.cpp
+++ b/tools/gfx-unit-test/gfx-test-util.cpp
@@ -57,7 +57,6 @@ namespace gfx_test
         slangReflection = composedProgram->getLayout();
 
         gfx::IShaderProgram::Desc programDesc = {};
-        programDesc.pipelineType = gfx::PipelineType::Compute;
         programDesc.slangProgram = composedProgram.get();
 
         auto shaderProgram = device->createProgram(programDesc);

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -2061,7 +2061,6 @@ public:
     class ShaderProgramImpl : public ShaderProgramBase
     {
     public:
-        PipelineType m_pipelineType;
         List<ShaderBinary> m_shaders;
         RefPtr<RootShaderObjectLayoutImpl> m_rootObjectLayout;
     };
@@ -5872,7 +5871,6 @@ Result D3D12Device::readBufferResource(
 Result D3D12Device::createProgram(const IShaderProgram::Desc& desc, IShaderProgram** outProgram)
 {
     RefPtr<ShaderProgramImpl> shaderProgram = new ShaderProgramImpl();
-    shaderProgram->m_pipelineType = desc.pipelineType;
     shaderProgram->slangProgram = desc.slangProgram;
     RootShaderObjectLayoutImpl::create(
         this,

--- a/tools/gfx/renderer-shared.cpp
+++ b/tools/gfx/renderer-shared.cpp
@@ -752,7 +752,6 @@ Result RendererBase::maybeSpecializePipeline(
             ComPtr<IShaderProgram> specializedProgram;
             IShaderProgram::Desc specializedProgramDesc = {};
             specializedProgramDesc.slangProgram = specializedComponentType;
-            specializedProgramDesc.pipelineType = pipelineType;
             SLANG_RETURN_ON_FAIL(createProgram(specializedProgramDesc, specializedProgram.writeRef()));
 
             // Create specialized pipeline state.

--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -1008,6 +1008,15 @@ public:
     IQueryPool* getInterface(const Slang::Guid& guid);
 };
 
+enum class PipelineType
+{
+    Unknown,
+    Graphics,
+    Compute,
+    RayTracing,
+    CountOf,
+};
+
 class PipelineStateBase
     : public IPipelineState
     , public Slang::ComObject

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -2279,9 +2279,8 @@ public:
     class ShaderProgramImpl : public ShaderProgramBase
     {
     public:
-        ShaderProgramImpl(VKDevice* device, PipelineType pipelineType)
+        ShaderProgramImpl(VKDevice* device)
             : m_device(device)
-            , m_pipelineType(pipelineType)
         {
             for (auto& shaderModule : m_modules)
                 shaderModule = VK_NULL_HANDLE;
@@ -2305,8 +2304,6 @@ public:
         }
 
         BreakableReference<VKDevice> m_device;
-
-        PipelineType m_pipelineType;
 
         Array<VkPipelineShaderStageCreateInfo, 8> m_stageCreateInfos;
         Array<ComPtr<ISlangBlob>, 8> m_codeBlobs; //< To keep storage of code in scope
@@ -4033,8 +4030,7 @@ public:
             void prepareDraw()
             {
                 auto pipeline = static_cast<PipelineStateImpl*>(m_currentPipeline.Ptr());
-                if (!pipeline || static_cast<ShaderProgramImpl*>(pipeline->m_program.Ptr())
-                                         ->m_pipelineType != PipelineType::Graphics)
+                if (!pipeline)
                 {
                     assert(!"Invalid render pipeline");
                     return;
@@ -4195,9 +4191,7 @@ public:
             virtual SLANG_NO_THROW void SLANG_MCALL dispatchCompute(int x, int y, int z) override
             {
                 auto pipeline = static_cast<PipelineStateImpl*>(m_currentPipeline.Ptr());
-                if (!pipeline ||
-                    static_cast<ShaderProgramImpl*>(pipeline->m_program.Ptr())->m_pipelineType !=
-                        PipelineType::Compute)
+                if (!pipeline)
                 {
                     assert(!"Invalid compute pipeline");
                     return;
@@ -7670,8 +7664,7 @@ static VkImageViewType _calcImageViewType(ITextureResource::Type type, const ITe
 
 Result VKDevice::createProgram(const IShaderProgram::Desc& desc, IShaderProgram** outProgram)
 {
-    RefPtr<ShaderProgramImpl> shaderProgram = new ShaderProgramImpl(this, desc.pipelineType);
-    shaderProgram->m_pipelineType = desc.pipelineType;
+    RefPtr<ShaderProgramImpl> shaderProgram = new ShaderProgramImpl(this);
     shaderProgram->slangProgram = desc.slangProgram;
     m_deviceObjectsWithPotentialBackReferences.add(shaderProgram);
 

--- a/tools/gfx/vulkan/vk-util.cpp
+++ b/tools/gfx/vulkan/vk-util.cpp
@@ -148,21 +148,6 @@ VkShaderStageFlags VulkanUtil::getShaderStage(SlangStage stage)
     }
 }
 
-VkPipelineBindPoint VulkanUtil::getPipelineBindPoint(PipelineType pipelineType)
-{
-    switch (pipelineType)
-    {
-    case gfx::PipelineType::Graphics:
-        return VK_PIPELINE_BIND_POINT_GRAPHICS;
-    case gfx::PipelineType::Compute:
-        return VK_PIPELINE_BIND_POINT_COMPUTE;
-    case gfx::PipelineType::RayTracing:
-        return VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR;
-    default:
-        return VkPipelineBindPoint(-1);
-    }
-}
-
 VkImageLayout VulkanUtil::getImageLayoutFromState(ResourceState state)
 {
     switch (state)

--- a/tools/gfx/vulkan/vk-util.h
+++ b/tools/gfx/vulkan/vk-util.h
@@ -42,8 +42,6 @@ struct VulkanUtil
 
     static VkShaderStageFlags getShaderStage(SlangStage stage);
 
-    static VkPipelineBindPoint getPipelineBindPoint(PipelineType pipelineType);
-
     static VkImageLayout getImageLayoutFromState(ResourceState state);
 
     static inline bool isDepthFormat(VkFormat format)

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -80,6 +80,13 @@ struct ShaderOutputPlan
     List<Item> items;
 };
 
+enum class PipelineType
+{
+    Graphics,
+    Compute,
+    RayTracing,
+};
+
 class RenderTestApp
 {
 public:
@@ -1227,25 +1234,6 @@ static SlangResult _innerMain(Slang::StdWriters* stdWriters, SlangSession* sessi
 
         default:
             break;
-    }
-
-    switch( options.shaderType )
-    {
-    case Options::ShaderProgramType::Graphics:
-    case Options::ShaderProgramType::GraphicsCompute:
-        input.pipelineType = PipelineType::Graphics;
-        break;
-
-    case Options::ShaderProgramType::Compute:
-        input.pipelineType = PipelineType::Compute;
-        break;
-
-    case Options::ShaderProgramType::RayTracing:
-        input.pipelineType = PipelineType::RayTracing;
-        break;
-
-    default:
-        break;
     }
 
     if (options.sourceLanguage != SLANG_SOURCE_LANGUAGE_UNKNOWN)

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -51,18 +51,15 @@ gfx::StageType translateStage(SlangStage slangStage)
 }
 
 void ShaderCompilerUtil::Output::set(
-    PipelineType                        pipelineType,
     slang::IComponentType*              inSlangProgram)
 {
     slangProgram = inSlangProgram;
-    desc.pipelineType = pipelineType;
     desc.slangProgram = inSlangProgram;
 }
 
 void ShaderCompilerUtil::Output::reset()
 {
     {
-        desc.pipelineType = PipelineType::Unknown;
         desc.slangProgram = nullptr;
     }
 
@@ -266,7 +263,7 @@ void ShaderCompilerUtil::Output::reset()
             outDiagnostic.writeRef());
         linkedSlangProgram = newProgram;
     }
-    out.set(input.pipelineType, linkedSlangProgram);
+    out.set(linkedSlangProgram);
     return SLANG_OK;
 }
 

--- a/tools/render-test/slang-support.h
+++ b/tools/render-test/slang-support.h
@@ -57,14 +57,12 @@ struct ShaderCompilerUtil
         SlangCompileTarget          target;
         SlangSourceLanguage         sourceLanguage;
         SlangPassThrough            passThrough;
-        PipelineType                pipelineType = PipelineType::Unknown;
         Slang::String               profile;
     };
 
     struct Output
     {
         void set(
-            PipelineType                        pipelineType,
             slang::IComponentType*              slangProgram);
         void reset();
         ~Output()


### PR DESCRIPTION
`PipelineType` is used to create a `IShaderProgram`, but this is redundant since the slang `IComponentType` already contains info about what type of shader it is.