### PR TITLE
gfx: Implement clearResourceView

### DIFF
--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -1291,6 +1291,18 @@ void DebugResourceCommandEncoder::clearResourceView(
     IResourceView* view, ClearValue* clearValue, ClearResourceViewFlags::Enum flags)
 {
     SLANG_GFX_API_FUNC;
+    switch (view->getViewDesc()->type)
+    {
+    case IResourceView::Type::DepthStencil:
+    case IResourceView::Type::RenderTarget:
+    case IResourceView::Type::UnorderedAccess:
+        break;
+    default:
+        GFX_DIAGNOSE_ERROR_FORMAT(
+            "Resource view %lld cannot be cleared. Only DepthStencil, "
+            "RenderTarget or UnorderedAccess views can be cleared.",
+            getDebugObj(view)->uid);
+    }
     baseObject->clearResourceView(getInnerObj(view), clearValue, flags);
 }
 

--- a/tools/gfx/vulkan/vk-api.h
+++ b/tools/gfx/vulkan/vk-api.h
@@ -79,6 +79,9 @@ namespace gfx {
     \
     x(vkCmdBindPipeline) \
     x(vkCmdClearAttachments) \
+    x(vkCmdClearColorImage) \
+    x(vkCmdClearDepthStencilImage) \
+    x(vkCmdFillBuffer) \
     x(vkCmdBindDescriptorSets) \
     x(vkCmdDispatch) \
     x(vkCmdDraw) \


### PR DESCRIPTION
This change implements `clearResourceView` method on D3D12 and Vulkan.