### PR TITLE
Implement instanced and indirect draw calls

### DIFF
--- a/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj
+++ b/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj
@@ -275,6 +275,7 @@
     <ClCompile Include="..\..\..\tools\gfx-unit-test\buffer-barrier-test.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\compute-smoke.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\create-buffer-from-handle.cpp" />
+    <ClCompile Include="..\..\..\tools\gfx-unit-test\draw-instanced-test.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\existing-device-handle-test.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\format-unit-tests.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\get-buffer-resource-handle-test.cpp" />
@@ -293,6 +294,7 @@
     <None Include="..\..\..\tools\gfx-unit-test\compute-smoke.slang" />
     <None Include="..\..\..\tools\gfx-unit-test\compute-trivial.slang" />
     <None Include="..\..\..\tools\gfx-unit-test\format-test-shaders.slang" />
+    <None Include="..\..\..\tools\gfx-unit-test\graphics-smoke.slang" />
     <None Include="..\..\..\tools\gfx-unit-test\mutable-shader-object.slang" />
     <None Include="..\..\..\tools\gfx-unit-test\trivial-copy.slang" />
   </ItemGroup>

--- a/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj.filters
+++ b/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj.filters
@@ -62,6 +62,9 @@
     <ClCompile Include="..\..\..\tools\unit-test\slang-unit-test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\tools\gfx-unit-test\draw-instanced-test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\..\tools\gfx-unit-test\buffer-barrier-test.slang">
@@ -80,6 +83,9 @@
       <Filter>Source Files</Filter>
     </None>
     <None Include="..\..\..\tools\gfx-unit-test\trivial-copy.slang">
+      <Filter>Source Files</Filter>
+    </None>
+    <None Include="..\..\..\tools\gfx-unit-test\graphics-smoke.slang">
       <Filter>Source Files</Filter>
     </None>
   </ItemGroup>

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1345,10 +1345,10 @@ public:
     };
     struct Desc
     {
-        IFramebufferLayout* framebufferLayout;
+        IFramebufferLayout* framebufferLayout = nullptr;
         uint32_t renderTargetCount;
-        AttachmentAccessDesc* renderTargetAccess;
-        AttachmentAccessDesc* depthStencilAccess;
+        AttachmentAccessDesc* renderTargetAccess = nullptr;
+        AttachmentAccessDesc* depthStencilAccess = nullptr;
     };
 };
 #define SLANG_UUID_IRenderPassLayout                                                   \

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1190,8 +1190,8 @@ public:
     struct Desc
     {
         uint32_t renderTargetCount;
-        AttachmentLayout* renderTargets;
-        AttachmentLayout* depthStencil;
+        AttachmentLayout* renderTargets = nullptr;
+        AttachmentLayout* depthStencil = nullptr;
     };
 };
 #define SLANG_UUID_IFramebufferLayout                                                \

--- a/tools/gfx-unit-test/draw-instanced-test.cpp
+++ b/tools/gfx-unit-test/draw-instanced-test.cpp
@@ -97,7 +97,7 @@ namespace gfx_test
         colorBufferDesc.numMipLevels = 1;
         colorBufferDesc.format = format;
         colorBufferDesc.defaultState = ResourceState::RenderTarget;
-        colorBufferDesc.allowedStates = { ResourceState::RenderTarget, ResourceState::CopySource, ResourceState::Present };
+        colorBufferDesc.allowedStates = { ResourceState::RenderTarget, ResourceState::CopySource };
         ComPtr<ITextureResource> colorBuffer = device->createTextureResource(colorBufferDesc, nullptr);
 
         gfx::IResourceView::Desc colorBufferViewDesc;
@@ -137,9 +137,9 @@ namespace gfx_test
         queue->executeCommandBuffer(commandBuffer);
         queue->waitOnHost();
 
-        float expectedResult[] = { 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f,
-                                   0.0f, 0.0f, 1.0f, 1.0f, 0.5f, 0.5f, 0.5f, 1.0f };
-        compareComputeResult(device, colorBuffer, ResourceState::CopySource, expectedResult, sizeof(expectedResult));
+        float expectedResult[] = { 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+                                   1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f };
+        compareComputeResult(device, colorBuffer, ResourceState::CopySource, expectedResult, 32, 2);
     }
 
     SLANG_UNIT_TEST(drawInstancedD3D12)
@@ -147,8 +147,10 @@ namespace gfx_test
         runTestImpl(drawInstancedTestImpl, unitTestContext, Slang::RenderApiFlag::D3D12);
     }
 
+#if 0
     SLANG_UNIT_TEST(drawInstancedVulkan)
     {
         runTestImpl(drawInstancedTestImpl, unitTestContext, Slang::RenderApiFlag::Vulkan);
     }
-}
+#endif
+    }

--- a/tools/gfx-unit-test/draw-instanced-test.cpp
+++ b/tools/gfx-unit-test/draw-instanced-test.cpp
@@ -1,0 +1,154 @@
+#include "tools/unit-test/slang-unit-test.h"
+
+#include "slang-gfx.h"
+#include "gfx-test-util.h"
+#include "tools/gfx-util/shader-cursor.h"
+#include "source/core/slang-basic.h"
+
+using namespace gfx;
+
+namespace gfx_test
+{
+    struct Vertex
+    {
+        float position[3];
+        float color[3];
+    };
+
+    static const int kVertexCount = 3;
+    static const Vertex kVertexData[kVertexCount] =
+    {
+        { { -1, -1, 0.5 }, { 1, 0, 0 } },
+        { { -1,  3, 0.5 }, { 1, 0, 0 } },
+        { {  3, -1, 0.5 }, { 1, 0, 0 } },
+    };
+
+    void drawInstancedTestImpl(IDevice* device, UnitTestContext* context)
+    {
+        Slang::ComPtr<ITransientResourceHeap> transientHeap;
+        ITransientResourceHeap::Desc transientHeapDesc = {};
+        transientHeapDesc.constantBufferSize = 4096;
+        GFX_CHECK_CALL_ABORT(
+            device->createTransientResourceHeap(transientHeapDesc, transientHeap.writeRef()));
+
+        ComPtr<IShaderProgram> shaderProgram;
+        slang::ProgramLayout* slangReflection;
+        GFX_CHECK_CALL_ABORT(loadGraphicsProgram(device, shaderProgram, "graphics-smoke", "vertexMain", "fragmentMain", slangReflection));
+
+        Format format = Format::R32G32B32A32_FLOAT;
+
+        InputElementDesc inputElements[] = {
+            { "POSITION", 0, Format::R32G32B32_FLOAT, offsetof(Vertex, position) },
+            { "COLOR",    0, Format::R32G32B32_FLOAT, offsetof(Vertex, color) },
+        };
+        ComPtr<gfx::IInputLayout> inputLayout = device->createInputLayout(inputElements, 2);
+        SLANG_CHECK_ABORT(inputLayout != nullptr);
+
+        IBufferResource::Desc vertexBufferDesc;
+        vertexBufferDesc.type = IResource::Type::Buffer;
+        vertexBufferDesc.sizeInBytes = kVertexCount * sizeof(Vertex);
+        vertexBufferDesc.defaultState = ResourceState::VertexBuffer;
+        vertexBufferDesc.allowedStates = ResourceState::VertexBuffer;
+        ComPtr<IBufferResource> vertexBuffer = device->createBufferResource(vertexBufferDesc, &kVertexData[0]);
+        SLANG_CHECK_ABORT(vertexBuffer != nullptr);
+
+        IFramebufferLayout::AttachmentLayout attachmentLayout;
+        attachmentLayout.format = format;
+        attachmentLayout.sampleCount = 1;
+
+        IFramebufferLayout::Desc framebufferLayoutDesc;
+        framebufferLayoutDesc.renderTargetCount = 1;
+        framebufferLayoutDesc.renderTargets = &attachmentLayout;
+        ComPtr<gfx::IFramebufferLayout> framebufferLayout = device->createFramebufferLayout(framebufferLayoutDesc);
+
+        GraphicsPipelineStateDesc pipelineDesc = {};
+        pipelineDesc.program = shaderProgram.get();
+        pipelineDesc.inputLayout = inputLayout;
+        pipelineDesc.framebufferLayout = framebufferLayout;
+        pipelineDesc.depthStencil.depthTestEnable = false;
+        pipelineDesc.depthStencil.depthWriteEnable = false;
+        ComPtr<gfx::IPipelineState> pipelineState;
+        GFX_CHECK_CALL_ABORT(
+            device->createGraphicsPipelineState(pipelineDesc, pipelineState.writeRef()));
+
+        ICommandQueue::Desc queueDesc = { ICommandQueue::QueueType::Graphics };
+        auto queue = device->createCommandQueue(queueDesc);
+        auto commandBuffer = transientHeap->createCommandBuffer();
+
+        IRenderPassLayout::Desc renderPassDesc = {};
+        renderPassDesc.framebufferLayout = framebufferLayout;
+        renderPassDesc.renderTargetCount = 1;
+        IRenderPassLayout::AttachmentAccessDesc renderTargetAccess = {};
+        renderTargetAccess.loadOp = IRenderPassLayout::AttachmentLoadOp::Clear;
+        renderTargetAccess.storeOp = IRenderPassLayout::AttachmentStoreOp::Store;
+        renderTargetAccess.initialState = ResourceState::Undefined;
+        renderTargetAccess.finalState = ResourceState::CopySource;
+        renderPassDesc.renderTargetAccess = &renderTargetAccess;
+        ComPtr<IRenderPassLayout> renderPass = device->createRenderPassLayout(renderPassDesc);
+
+        const int width = 2;
+        const int height = 2;
+
+        gfx::ITextureResource::Desc colorBufferDesc;
+        colorBufferDesc.type = IResource::Type::Texture2D;
+        colorBufferDesc.size.width = width;
+        colorBufferDesc.size.height = height;
+        colorBufferDesc.size.depth = 1;
+        colorBufferDesc.numMipLevels = 1;
+        colorBufferDesc.format = format;
+        colorBufferDesc.defaultState = ResourceState::RenderTarget;
+        colorBufferDesc.allowedStates = { ResourceState::RenderTarget, ResourceState::CopySource, ResourceState::Present };
+        ComPtr<ITextureResource> colorBuffer = device->createTextureResource(colorBufferDesc, nullptr);
+
+        gfx::IResourceView::Desc colorBufferViewDesc;
+        memset(&colorBufferViewDesc, 0, sizeof(colorBufferViewDesc));
+        colorBufferViewDesc.format = format;
+        colorBufferViewDesc.renderTarget.shape = gfx::IResource::Type::Texture2D;
+        colorBufferViewDesc.type = gfx::IResourceView::Type::RenderTarget;
+        ComPtr<gfx::IResourceView> rtv =
+            device->createTextureView(colorBuffer.get(), colorBufferViewDesc);
+
+        gfx::IFramebuffer::Desc framebufferDesc;
+        framebufferDesc.renderTargetCount = 1;
+        framebufferDesc.depthStencilView = nullptr;
+        framebufferDesc.renderTargetViews = rtv.readRef();
+        framebufferDesc.layout = framebufferLayout;
+        ComPtr<gfx::IFramebuffer> framebuffer = device->createFramebuffer(framebufferDesc);
+
+        auto encoder = commandBuffer->encodeRenderCommands(renderPass, framebuffer);
+        auto rootObject = encoder->bindPipeline(pipelineState);
+
+        UInt vertexCount = 3;
+        UInt instanceCount = 1;
+        UInt startVertex = 0;
+        UInt startInstanceLocation = 0;
+
+        gfx::Viewport viewport = {};
+        viewport.maxZ = 1.0f;
+        viewport.extentX = width;
+        viewport.extentY = height;
+        encoder->setViewportAndScissor(viewport);
+
+        encoder->setVertexBuffer(0, vertexBuffer, sizeof(Vertex));
+        encoder->setPrimitiveTopology(PrimitiveTopology::TriangleList);
+        encoder->drawInstanced(vertexCount, instanceCount, startVertex, startInstanceLocation);
+        encoder->endEncoding();
+        commandBuffer->close();
+        queue->executeCommandBuffer(commandBuffer);
+        queue->waitOnHost();
+
+        float expectedResult[] = { 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f,
+                                   0.0f, 0.0f, 1.0f, 1.0f, 0.5f, 0.5f, 0.5f, 1.0f };
+        compareComputeResult(device, colorBuffer, ResourceState::CopySource, expectedResult, sizeof(expectedResult));
+    }
+
+    SLANG_UNIT_TEST(drawInstancedD3D12)
+    {
+        runTestImpl(drawInstancedTestImpl, unitTestContext, Slang::RenderApiFlag::D3D12);
+    }
+
+    SLANG_UNIT_TEST(drawInstancedVulkan)
+    {
+        runTestImpl(drawInstancedTestImpl, unitTestContext, Slang::RenderApiFlag::Vulkan);
+    }
+}

--- a/tools/gfx-unit-test/gfx-test-util.cpp
+++ b/tools/gfx-unit-test/gfx-test-util.cpp
@@ -105,7 +105,6 @@ namespace gfx_test
         slangReflection = composedProgram->getLayout();
 
         gfx::IShaderProgram::Desc programDesc = {};
-        programDesc.pipelineType = gfx::PipelineType::Graphics;
         programDesc.slangProgram = composedProgram.get();
 
         auto shaderProgram = device->createProgram(programDesc);

--- a/tools/gfx-unit-test/gfx-test-util.cpp
+++ b/tools/gfx-unit-test/gfx-test-util.cpp
@@ -115,7 +115,13 @@ namespace gfx_test
         return SLANG_OK;
     }
 
-    void compareComputeResult(gfx::IDevice* device, gfx::ITextureResource* texture, gfx::ResourceState state, float* expectedResult, size_t expectedBufferSize)
+    void compareComputeResult(
+        gfx::IDevice* device,
+        gfx::ITextureResource* texture,
+        gfx::ResourceState state,
+        float* expectedResult,
+        size_t expectedResultRowPitch,
+        size_t rowCount)
     {
         // Read back the results.
         ComPtr<ISlangBlob> resultBlob;
@@ -123,10 +129,16 @@ namespace gfx_test
         size_t pixelSize = 0;
         GFX_CHECK_CALL_ABORT(device->readTextureResource(
             texture, state, resultBlob.writeRef(), &rowPitch, &pixelSize));
-        SLANG_CHECK(resultBlob->getBufferSize() == expectedBufferSize);
         auto result = (float*)resultBlob->getBufferPointer();
         // Compare results.
-        SLANG_CHECK(memcmp(resultBlob->getBufferPointer(), expectedResult, expectedBufferSize) == 0);
+        for (size_t row = 0; row < rowCount; row++)
+        {
+            SLANG_CHECK(
+                memcmp(
+                    (uint8_t*)resultBlob->getBufferPointer() + rowPitch * row,
+                    (uint8_t*)expectedResult + expectedResultRowPitch * row,
+                    expectedResultRowPitch) == 0);
+        }
     }
 
     void compareComputeResult(gfx::IDevice* device, gfx::IBufferResource* buffer, uint8_t* expectedResult, size_t expectedBufferSize)

--- a/tools/gfx-unit-test/gfx-test-util.h
+++ b/tools/gfx-unit-test/gfx-test-util.h
@@ -18,6 +18,14 @@ namespace gfx_test
         const char* entryPointName,
         slang::ProgramLayout*& slangReflection);
 
+    Slang::Result loadGraphicsProgram(
+        gfx::IDevice* device,
+        Slang::ComPtr<gfx::IShaderProgram>& outShaderProgram,
+        const char* shaderModuleName,
+        const char* vertexEntryPointName,
+        const char* fragmentEntryPointName,
+        slang::ProgramLayout*& slangReflection);
+
         /// Reads back the content of `buffer` and compares it against `expectedResult`.
     void compareComputeResult(
         gfx::IDevice* device,

--- a/tools/gfx-unit-test/gfx-test-util.h
+++ b/tools/gfx-unit-test/gfx-test-util.h
@@ -39,7 +39,8 @@ namespace gfx_test
         gfx::ITextureResource* texture,
         gfx::ResourceState state,
         float* expectedResult,
-        size_t expectedBufferSize);
+        size_t expectedResultRowPitch,
+        size_t rowCount);
 
         /// Reads back the content of `buffer` and compares it against `expectedResult` with a set tolerance.
     void compareComputeResultFuzzy(

--- a/tools/gfx-unit-test/graphics-smoke.slang
+++ b/tools/gfx-unit-test/graphics-smoke.slang
@@ -1,0 +1,54 @@
+// graphics-smoke.slang
+
+// Per-vertex attributes to be assembled from bound vertex buffers.
+struct AssembledVertex
+{
+    float3	position : POSITION;
+    float3	color    : COLOR;
+};
+
+// Output of the vertex shader, and input to the fragment shader.
+struct CoarseVertex
+{
+    float3 color;
+};
+
+// Output of the fragment shader
+struct Fragment
+{
+    float4 color;
+};
+
+// Vertex  Shader
+
+struct VertexStageOutput
+{
+    CoarseVertex    coarseVertex    : CoarseVertex;
+    float4          sv_position     : SV_Position;
+};
+
+[shader("vertex")]
+VertexStageOutput vertexMain(
+    AssembledVertex assembledVertex)
+{
+    VertexStageOutput output;
+
+    float3 position = assembledVertex.position;
+    float3 color    = assembledVertex.color;
+
+    output.coarseVertex.color = color;
+    output.sv_position = float4(position, 1.0);
+
+    return output;
+}
+
+// Fragment Shader
+
+[shader("fragment")]
+float4 fragmentMain(
+    CoarseVertex coarseVertex : CoarseVertex) : SV_Target
+{
+    float3 color = coarseVertex.color;
+
+    return float4(color, 1.0);
+}

--- a/tools/gfx-unit-test/shared-textures-tests.cpp
+++ b/tools/gfx-unit-test/shared-textures-tests.cpp
@@ -184,7 +184,8 @@ namespace gfx_test
                 dstTexture,
                 ResourceState::ShaderResource,
                 texData,
-                sizeof(texData));
+                32,
+                2);
 
             auto texView = createTexView(dstDevice, dstTexture);
             setUpAndRunShader(dstDevice, dstTexture, texView, floatBufferView, "copyTexFloat4");

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -3435,19 +3435,19 @@ public:
                 desc.NumArgumentDescs = 1;
                 desc.pArgumentDescs = args;
 
-                ID3D12CommandSignature* cmdSignature = nullptr;
-                m_device->CreateCommandSignature(&desc, nullptr, IID_PPV_ARGS(&cmdSignature)); // Problem when wrapped in SLANG_RETURN_ON_FAIL?
-
-                if (cmdSignature)
+                ComPtr<ID3D12CommandSignature> cmdSignature = nullptr;
+                if (FAILED(m_device->CreateCommandSignature(&desc, nullptr, IID_PPV_ARGS(cmdSignature.writeRef()))))
                 {
-                    m_d3dCmdList->ExecuteIndirect(
-                        cmdSignature,
-                        maxDrawCount,
-                        (ID3D12Resource*)argBuffer,
-                        argOffset,
-                        (ID3D12Resource*)countBuffer,
-                        countOffset);
+                    return;
                 }
+
+                m_d3dCmdList->ExecuteIndirect(
+                    cmdSignature,
+                    maxDrawCount,
+                    (ID3D12Resource*)argBuffer,
+                    argOffset,
+                    (ID3D12Resource*)countBuffer,
+                    countOffset);
             }
 
             virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedIndirect(
@@ -3467,19 +3467,19 @@ public:
                 desc.NumArgumentDescs = 1;
                 desc.pArgumentDescs = args;
 
-                ID3D12CommandSignature* cmdSignature = nullptr;
-                m_device->CreateCommandSignature(&desc, nullptr, IID_PPV_ARGS(&cmdSignature)); // Problem when wrapped in SLANG_RETURN_ON_FAIL?
-
-                if (cmdSignature)
+                ComPtr<ID3D12CommandSignature> cmdSignature = nullptr;
+                if (FAILED(m_device->CreateCommandSignature(&desc, nullptr, IID_PPV_ARGS(cmdSignature.writeRef()))))
                 {
-                    m_d3dCmdList->ExecuteIndirect(
-                        cmdSignature,
-                        maxDrawCount,
-                        (ID3D12Resource*)argBuffer,
-                        argOffset,
-                        (ID3D12Resource*)countBuffer,
-                        countOffset);
+                    return;
                 }
+
+                m_d3dCmdList->ExecuteIndirect(
+                    cmdSignature,
+                    maxDrawCount,
+                    (ID3D12Resource*)argBuffer,
+                    argOffset,
+                    (ID3D12Resource*)countBuffer,
+                    countOffset);
             }
 
             virtual SLANG_NO_THROW Result SLANG_MCALL setSamplePositions(

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -3425,12 +3425,29 @@ public:
                 IBufferResource* countBuffer,
                 uint64_t countOffset) override
             {
-                SLANG_UNUSED(maxDrawCount);
-                SLANG_UNUSED(argBuffer);
-                SLANG_UNUSED(argOffset);
-                SLANG_UNUSED(countBuffer);
-                SLANG_UNUSED(countOffset);
-                SLANG_UNIMPLEMENTED_X("drawIndirect");
+                prepareDraw();
+
+                D3D12_INDIRECT_ARGUMENT_DESC args[1];
+                args[0].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW;
+
+                D3D12_COMMAND_SIGNATURE_DESC desc;
+                desc.ByteStride = 36;
+                desc.NumArgumentDescs = 1;
+                desc.pArgumentDescs = args;
+
+                ID3D12CommandSignature* cmdSignature = nullptr;
+                m_device->CreateCommandSignature(&desc, nullptr, IID_PPV_ARGS(&cmdSignature)); // Problem when wrapped in SLANG_RETURN_ON_FAIL?
+
+                if (cmdSignature)
+                {
+                    m_d3dCmdList->ExecuteIndirect(
+                        cmdSignature,
+                        maxDrawCount,
+                        (ID3D12Resource*)argBuffer,
+                        argOffset,
+                        (ID3D12Resource*)countBuffer,
+                        countOffset);
+                }
             }
 
             virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedIndirect(
@@ -3440,12 +3457,29 @@ public:
                 IBufferResource* countBuffer,
                 uint64_t countOffset) override
             {
-                SLANG_UNUSED(maxDrawCount);
-                SLANG_UNUSED(argBuffer);
-                SLANG_UNUSED(argOffset);
-                SLANG_UNUSED(countBuffer);
-                SLANG_UNUSED(countOffset);
-                SLANG_UNIMPLEMENTED_X("drawIndirect");
+                prepareDraw();
+
+                D3D12_INDIRECT_ARGUMENT_DESC args[1];
+                args[0].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED;
+
+                D3D12_COMMAND_SIGNATURE_DESC desc;
+                desc.ByteStride = 36;
+                desc.NumArgumentDescs = 1;
+                desc.pArgumentDescs = args;
+
+                ID3D12CommandSignature* cmdSignature = nullptr;
+                m_device->CreateCommandSignature(&desc, nullptr, IID_PPV_ARGS(&cmdSignature)); // Problem when wrapped in SLANG_RETURN_ON_FAIL?
+
+                if (cmdSignature)
+                {
+                    m_d3dCmdList->ExecuteIndirect(
+                        cmdSignature,
+                        maxDrawCount,
+                        (ID3D12Resource*)argBuffer,
+                        argOffset,
+                        (ID3D12Resource*)countBuffer,
+                        countOffset);
+                }
             }
 
             virtual SLANG_NO_THROW Result SLANG_MCALL setSamplePositions(
@@ -3465,11 +3499,8 @@ public:
                 UInt startVertex,
                 UInt startInstanceLocation) override
             {
-                SLANG_UNUSED(vertexCount);
-                SLANG_UNUSED(instanceCount);
-                SLANG_UNUSED(startVertex);
-                SLANG_UNUSED(startInstanceLocation);
-                SLANG_UNIMPLEMENTED_X("drawInstanced");
+                prepareDraw();
+                m_d3dCmdList->DrawInstanced(vertexCount, instanceCount, startVertex, startInstanceLocation);
             }
 
             virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedInstanced(
@@ -3479,12 +3510,8 @@ public:
                 int32_t baseVertexLocation,
                 uint32_t startInstanceLocation) override
             {
-                SLANG_UNUSED(indexCount);
-                SLANG_UNUSED(instanceCount);
-                SLANG_UNUSED(startIndexLocation);
-                SLANG_UNUSED(baseVertexLocation);
-                SLANG_UNUSED(startInstanceLocation);
-                SLANG_UNIMPLEMENTED_X("drawIndexedInstanced");
+                prepareDraw();
+                m_d3dCmdList->DrawIndexedInstanced(indexCount, instanceCount, startIndexLocation, baseVertexLocation, startInstanceLocation);
             }
         };
 

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -4097,12 +4097,19 @@ public:
                 IBufferResource* countBuffer,
                 uint64_t countOffset) override
             {
-                SLANG_UNUSED(maxDrawCount);
-                SLANG_UNUSED(argBuffer);
-                SLANG_UNUSED(argOffset);
-                SLANG_UNUSED(countBuffer);
-                SLANG_UNUSED(countOffset);
-                SLANG_UNIMPLEMENTED_X("drawIndirect");
+                prepareDraw();
+                auto& api = *m_api;
+                // Bind the vertex buffer
+                if (m_boundVertexBuffers.getCount() > 0 && m_boundVertexBuffers[0].m_buffer)
+                {
+                    const BoundVertexBuffer& boundVertexBuffer = m_boundVertexBuffers[0];
+
+                    VkBuffer vertexBuffers[] = { boundVertexBuffer.m_buffer->m_buffer.m_buffer };
+                    VkDeviceSize offsets[] = { VkDeviceSize(boundVertexBuffer.m_offset) };
+
+                    api.vkCmdBindVertexBuffers(m_vkCommandBuffer, 0, 1, vertexBuffers, offsets);
+                }
+                api.vkCmdDrawIndirect(m_vkCommandBuffer, (VkBuffer)argBuffer, argOffset, maxDrawCount, sizeof(VkDrawIndirectCommand));
             }
 
             virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedIndirect(
@@ -4112,12 +4119,24 @@ public:
                 IBufferResource* countBuffer,
                 uint64_t countOffset) override
             {
-                SLANG_UNUSED(maxDrawCount);
-                SLANG_UNUSED(argBuffer);
-                SLANG_UNUSED(argOffset);
-                SLANG_UNUSED(countBuffer);
-                SLANG_UNUSED(countOffset);
-                SLANG_UNIMPLEMENTED_X("drawIndirect");
+                prepareDraw();
+                auto& api = *m_api;
+                api.vkCmdBindIndexBuffer(
+                    m_vkCommandBuffer,
+                    m_boundIndexBuffer.m_buffer->m_buffer.m_buffer,
+                    m_boundIndexBuffer.m_offset,
+                    m_boundIndexFormat);
+                // Bind the vertex buffer
+                if (m_boundVertexBuffers.getCount() > 0 && m_boundVertexBuffers[0].m_buffer)
+                {
+                    const BoundVertexBuffer& boundVertexBuffer = m_boundVertexBuffers[0];
+
+                    VkBuffer vertexBuffers[] = { boundVertexBuffer.m_buffer->m_buffer.m_buffer };
+                    VkDeviceSize offsets[] = { VkDeviceSize(boundVertexBuffer.m_offset) };
+
+                    api.vkCmdBindVertexBuffers(m_vkCommandBuffer, 0, 1, vertexBuffers, offsets);
+                }
+                api.vkCmdDrawIndirect(m_vkCommandBuffer, (VkBuffer)argBuffer, argOffset, maxDrawCount, sizeof(VkDrawIndexedIndirectCommand));
             }
 
             virtual SLANG_NO_THROW Result SLANG_MCALL setSamplePositions(
@@ -4137,11 +4156,20 @@ public:
                 UInt startVertex,
                 UInt startInstanceLocation) override
             {
-                SLANG_UNUSED(vertexCount);
-                SLANG_UNUSED(instanceCount);
-                SLANG_UNUSED(startVertex);
-                SLANG_UNUSED(startInstanceLocation);
-                SLANG_UNIMPLEMENTED_X("drawInstanced");
+                prepareDraw();
+                auto& api = *m_api;
+                // Bind the vertex buffer
+                if (m_boundVertexBuffers.getCount() > 0 && m_boundVertexBuffers[0].m_buffer)
+                {
+                    const BoundVertexBuffer& boundVertexBuffer = m_boundVertexBuffers[0];
+
+                    VkBuffer vertexBuffers[] = { boundVertexBuffer.m_buffer->m_buffer.m_buffer };
+                    VkDeviceSize offsets[] = { VkDeviceSize(boundVertexBuffer.m_offset) };
+
+                    api.vkCmdBindVertexBuffers(m_vkCommandBuffer, 0, 1, vertexBuffers, offsets);
+                }
+                api.vkCmdDraw(m_vkCommandBuffer, static_cast<uint32_t>(vertexCount), static_cast<uint32_t>(instanceCount),
+                    static_cast<uint32_t>(startVertex), static_cast<uint32_t>(startInstanceLocation));
             }
 
             virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedInstanced(
@@ -4151,12 +4179,25 @@ public:
                 int32_t baseVertexLocation,
                 uint32_t startInstanceLocation) override
             {
-                SLANG_UNUSED(indexCount);
-                SLANG_UNUSED(instanceCount);
-                SLANG_UNUSED(startIndexLocation);
-                SLANG_UNUSED(baseVertexLocation);
-                SLANG_UNUSED(startInstanceLocation);
-                SLANG_UNIMPLEMENTED_X("drawIndexedInstanced");
+                prepareDraw();
+                auto& api = *m_api;
+                api.vkCmdBindIndexBuffer(
+                    m_vkCommandBuffer,
+                    m_boundIndexBuffer.m_buffer->m_buffer.m_buffer,
+                    m_boundIndexBuffer.m_offset,
+                    m_boundIndexFormat);
+                // Bind the vertex buffer
+                if (m_boundVertexBuffers.getCount() > 0 && m_boundVertexBuffers[0].m_buffer)
+                {
+                    const BoundVertexBuffer& boundVertexBuffer = m_boundVertexBuffers[0];
+
+                    VkBuffer vertexBuffers[] = { boundVertexBuffer.m_buffer->m_buffer.m_buffer };
+                    VkDeviceSize offsets[] = { VkDeviceSize(boundVertexBuffer.m_offset) };
+
+                    api.vkCmdBindVertexBuffers(m_vkCommandBuffer, 0, 1, vertexBuffers, offsets);
+                }
+                api.vkCmdDraw(m_vkCommandBuffer, static_cast<uint32_t>(indexCount), static_cast<uint32_t>(instanceCount),
+                    static_cast<uint32_t>(baseVertexLocation), static_cast<uint32_t>(startInstanceLocation));
             }
         };
 

--- a/tools/gfx/vulkan/vk-api.h
+++ b/tools/gfx/vulkan/vk-api.h
@@ -85,6 +85,8 @@ namespace gfx {
     x(vkCmdBindDescriptorSets) \
     x(vkCmdDispatch) \
     x(vkCmdDraw) \
+    x(vkCmdDrawIndirect) \
+    x(vkCmdDrawIndexedIndirect) \
     x(vkCmdSetScissor) \
     x(vkCmdSetViewport) \
     x(vkCmdBindVertexBuffers) \


### PR DESCRIPTION
Changes:
- Provided implementations for `drawInstanced`, `drawIndexedInstanced`, `drawIndirect`, and `drawIndexedIndirect` in both D3D12 and Vulkan
- Added a preliminary test for `drawInstanced` for D3D12 ONLY - The test doesn't actually contain any instancing yet, will be added along with the remaining tests

Note: This PR does NOT contain tests for the other three draw calls, nor does it contain functional Vulkan tests. Tests for the other three calls for D3D12 will be coming in a later PR, and Vulkan tests will be enabled once `readTextureResource` is implemented.