### PR TITLE
gfx: use uint32_t in draw calls and implement current size query.

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1524,6 +1524,9 @@ public:
         IBufferResource* src,
         size_t srcOffset,
         size_t size) = 0;
+
+    /// Copies texture from src to dst. If dstSubresource and srcSubresource has mipLevelCount = 0 and layerCount = 0,
+    /// the entire resource is being copied and dstOffset, srcOffset and extent arguments are ignored.
     virtual SLANG_NO_THROW void SLANG_MCALL copyTexture(
         ITextureResource* dst,
         SubresourceRange dstSubresource,

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1451,21 +1451,23 @@ public:
 
     virtual SLANG_NO_THROW void SLANG_MCALL setPrimitiveTopology(PrimitiveTopology topology) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL setVertexBuffers(
-        UInt startSlot,
-        UInt slotCount,
+        uint32_t startSlot,
+        uint32_t slotCount,
         IBufferResource* const* buffers,
-        const UInt* strides,
-        const UInt* offsets) = 0;
-    inline void setVertexBuffer(UInt slot, IBufferResource* buffer, UInt stride, UInt offset = 0)
+        const uint32_t* strides,
+        const uint32_t* offsets) = 0;
+    inline void setVertexBuffer(
+        uint32_t slot, IBufferResource* buffer, uint32_t stride, uint32_t offset = 0)
     {
         setVertexBuffers(slot, 1, &buffer, &stride, &offset);
     }
 
     virtual SLANG_NO_THROW void SLANG_MCALL
-        setIndexBuffer(IBufferResource* buffer, Format indexFormat, UInt offset = 0) = 0;
-    virtual SLANG_NO_THROW void SLANG_MCALL draw(UInt vertexCount, UInt startVertex = 0) = 0;
+        setIndexBuffer(IBufferResource* buffer, Format indexFormat, uint32_t offset = 0) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        drawIndexed(UInt indexCount, UInt startIndex = 0, UInt baseVertex = 0) = 0;
+        draw(uint32_t vertexCount, uint32_t startVertex = 0) = 0;
+    virtual SLANG_NO_THROW void SLANG_MCALL
+        drawIndexed(uint32_t indexCount, uint32_t startIndex = 0, uint32_t baseVertex = 0) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndirect(
         uint32_t maxDrawCount,
         IBufferResource* argBuffer,
@@ -1482,10 +1484,10 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL setSamplePositions(
         uint32_t samplesPerPixel, uint32_t pixelCount, const SamplePosition* samplePositions) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL drawInstanced(
-        UInt vertexCount,
-        UInt instanceCount,
-        UInt startVertex,
-        UInt startInstanceLocation) = 0;
+        uint32_t vertexCount,
+        uint32_t instanceCount,
+        uint32_t startVertex,
+        uint32_t startInstanceLocation) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedInstanced(
         uint32_t indexCount,
         uint32_t instanceCount,

--- a/tools/gfx/command-writer.h
+++ b/tools/gfx/command-writer.h
@@ -195,11 +195,11 @@ public:
     }
 
     void setVertexBuffers(
-        UInt startSlot,
-        UInt slotCount,
+        uint32_t startSlot,
+        uint32_t slotCount,
         IBufferResource* const* buffers,
-        const UInt* strides,
-        const UInt* offsets)
+        const uint32_t* strides,
+        const uint32_t* offsets)
     {
         uint32_t bufferOffset = 0;
         for (UInt i = 0; i < slotCount; i++)
@@ -208,12 +208,12 @@ public:
             if (i == 0)
                 bufferOffset = offset;
         }
-        uint32_t stridesOffset = encodeData(strides, sizeof(UInt) * slotCount);
-        uint32_t offsetsOffset = encodeData(offsets, sizeof(UInt) * slotCount);
+        uint32_t stridesOffset = encodeData(strides, sizeof(uint32_t) * slotCount);
+        uint32_t offsetsOffset = encodeData(offsets, sizeof(uint32_t) * slotCount);
         m_commands.add(Command(
             CommandName::SetVertexBuffers,
-            (uint32_t)startSlot,
-            (uint32_t)slotCount,
+            startSlot,
+            slotCount,
             bufferOffset,
             stridesOffset,
             offsetsOffset));

--- a/tools/gfx/d3d/d3d-util.cpp
+++ b/tools/gfx/d3d/d3d-util.cpp
@@ -635,6 +635,18 @@ int D3DUtil::getShaderModelFromProfileName(const char* name)
     return 0;
 }
 
+uint32_t D3DUtil::getPlaneSliceCount(DXGI_FORMAT format)
+{
+    switch (format)
+    {
+    case DXGI_FORMAT_D24_UNORM_S8_UINT:
+    case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+        return 2;
+    default:
+        return 1;
+    }
+}
+
 uint32_t D3DUtil::getPlaneSlice(DXGI_FORMAT format, TextureAspect aspect)
 {
     switch (aspect)
@@ -770,6 +782,68 @@ D3D12_BLEND D3DUtil::getBlendFactor(BlendFactor factor)
     default:
         SLANG_ASSERT_FAILURE("Unknown blend factor.");
         return D3D12_BLEND_ZERO;
+    }
+}
+
+uint32_t D3DUtil::getSubresourceIndex(
+    uint32_t mipIndex,
+    uint32_t arrayIndex,
+    uint32_t planeIndex,
+    uint32_t mipLevelCount,
+    uint32_t arraySize)
+{
+    return mipIndex + arrayIndex * mipLevelCount + planeIndex * mipLevelCount * arraySize;
+}
+
+uint32_t D3DUtil::getSubresourceMipLevel(uint32_t subresourceIndex, uint32_t mipLevelCount)
+{
+    return subresourceIndex % mipLevelCount;
+}
+
+D3D12_RESOURCE_STATES D3DUtil::getResourceState(ResourceState state)
+{
+    switch (state)
+    {
+    case ResourceState::Undefined:
+        return D3D12_RESOURCE_STATE_COMMON;
+    case ResourceState::General:
+        return D3D12_RESOURCE_STATE_COMMON;
+    case ResourceState::PreInitialized:
+        return D3D12_RESOURCE_STATE_COMMON;
+    case ResourceState::VertexBuffer:
+        return D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER;
+    case ResourceState::IndexBuffer:
+        return D3D12_RESOURCE_STATE_INDEX_BUFFER;
+    case ResourceState::ConstantBuffer:
+        return D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER;
+    case ResourceState::StreamOutput:
+        return D3D12_RESOURCE_STATE_STREAM_OUT;
+    case ResourceState::ShaderResource:
+        return D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+    case ResourceState::UnorderedAccess:
+        return D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+    case ResourceState::RenderTarget:
+        return D3D12_RESOURCE_STATE_RENDER_TARGET;
+    case ResourceState::DepthRead:
+        return D3D12_RESOURCE_STATE_DEPTH_READ;
+    case ResourceState::DepthWrite:;
+        return D3D12_RESOURCE_STATE_DEPTH_WRITE;
+    case ResourceState::Present:
+        return D3D12_RESOURCE_STATE_PRESENT;
+    case ResourceState::IndirectArgument:
+        return D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT;
+    case ResourceState::CopySource:
+        return D3D12_RESOURCE_STATE_COPY_SOURCE;
+    case ResourceState::CopyDestination:
+        return D3D12_RESOURCE_STATE_COPY_DEST;
+    case ResourceState::ResolveSource:
+        return D3D12_RESOURCE_STATE_RESOLVE_SOURCE;
+    case ResourceState::ResolveDestination:
+        return D3D12_RESOURCE_STATE_RESOLVE_DEST;
+    case ResourceState::AccelerationStructure:
+        return D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE;
+    default:
+        return D3D12_RESOURCE_STATE_COMMON;
     }
 }
 

--- a/tools/gfx/d3d/d3d-util.h
+++ b/tools/gfx/d3d/d3d-util.h
@@ -98,6 +98,8 @@ class D3DUtil
 
     static uint32_t getPlaneSlice(DXGI_FORMAT format, TextureAspect aspect);
 
+    static uint32_t getPlaneSliceCount(DXGI_FORMAT format);
+
     static D3D12_INPUT_CLASSIFICATION getInputSlotClass(InputSlotClass slotClass);
 
     static D3D12_FILL_MODE getFillMode(FillMode mode);
@@ -107,6 +109,17 @@ class D3DUtil
     static D3D12_BLEND_OP getBlendOp(BlendOp op);
 
     static D3D12_BLEND getBlendFactor(BlendFactor factor);
+
+    static uint32_t getSubresourceIndex(
+        uint32_t mipIndex,
+        uint32_t arrayIndex,
+        uint32_t planeIndex,
+        uint32_t mipLevelCount,
+        uint32_t arraySize);
+
+    static uint32_t getSubresourceMipLevel(uint32_t subresourceIndex, uint32_t mipLevelCount);
+
+    static D3D12_RESOURCE_STATES getResourceState(ResourceState state);
 };
 
 #if SLANG_GFX_HAS_DXR_SUPPORT

--- a/tools/gfx/d3d11/render-d3d11.cpp
+++ b/tools/gfx/d3d11/render-d3d11.cpp
@@ -135,17 +135,19 @@ public:
     virtual void setPrimitiveTopology(PrimitiveTopology topology) override;
 
     virtual void setVertexBuffers(
-        UInt startSlot,
-        UInt slotCount,
+        uint32_t startSlot,
+        uint32_t slotCount,
         IBufferResource* const* buffers,
-        const UInt* strides,
-        const UInt* offsets) override;
-    virtual void setIndexBuffer(IBufferResource* buffer, Format indexFormat, UInt offset) override;
+        const uint32_t* strides,
+        const uint32_t* offsets) override;
+    virtual void setIndexBuffer(
+        IBufferResource* buffer, Format indexFormat, uint32_t offset) override;
     virtual void setViewports(UInt count, Viewport const* viewports) override;
     virtual void setScissorRects(UInt count, ScissorRect const* rects) override;
     virtual void setPipelineState(IPipelineState* state) override;
-    virtual void draw(UInt vertexCount, UInt startVertex) override;
-    virtual void drawIndexed(UInt indexCount, UInt startIndex, UInt baseVertex) override;
+    virtual void draw(uint32_t vertexCount, uint32_t startVertex) override;
+    virtual void drawIndexed(
+        uint32_t indexCount, uint32_t startIndex, uint32_t baseVertex) override;
     virtual void dispatchCompute(int x, int y, int z) override;
     virtual void submitGpuWork() override {}
     virtual void waitForGpu() override
@@ -3241,7 +3243,12 @@ void D3D11Device::setPrimitiveTopology(PrimitiveTopology topology)
     m_immediateContext->IASetPrimitiveTopology(D3DUtil::getPrimitiveTopology(topology));
 }
 
-void D3D11Device::setVertexBuffers(UInt startSlot, UInt slotCount, IBufferResource*const* buffersIn, const UInt* stridesIn, const UInt* offsetsIn)
+void D3D11Device::setVertexBuffers(
+    uint32_t startSlot,
+    uint32_t slotCount,
+    IBufferResource* const* buffersIn,
+    const uint32_t* stridesIn,
+    const uint32_t* offsetsIn)
 {
     static const int kMaxVertexBuffers = 16;
 	assert(slotCount <= kMaxVertexBuffers);
@@ -3262,7 +3269,7 @@ void D3D11Device::setVertexBuffers(UInt startSlot, UInt slotCount, IBufferResour
     m_immediateContext->IASetVertexBuffers((UINT)startSlot, (UINT)slotCount, dxBuffers, &vertexStrides[0], &vertexOffsets[0]);
 }
 
-void D3D11Device::setIndexBuffer(IBufferResource* buffer, Format indexFormat, UInt offset)
+void D3D11Device::setIndexBuffer(IBufferResource* buffer, Format indexFormat, uint32_t offset)
 {
     DXGI_FORMAT dxFormat = D3DUtil::getMapFormat(indexFormat);
     m_immediateContext->IASetIndexBuffer(((BufferResourceImpl*)buffer)->m_buffer, dxFormat, UINT(offset));
@@ -3382,16 +3389,16 @@ void D3D11Device::setPipelineState(IPipelineState* state)
     /// ...
 }
 
-void D3D11Device::draw(UInt vertexCount, UInt startVertex)
+void D3D11Device::draw(uint32_t vertexCount, uint32_t startVertex)
 {
     _flushGraphicsState();
-    m_immediateContext->Draw((UINT)vertexCount, (UINT)startVertex);
+    m_immediateContext->Draw(vertexCount, startVertex);
 }
 
-void D3D11Device::drawIndexed(UInt indexCount, UInt startIndex, UInt baseVertex)
+void D3D11Device::drawIndexed(uint32_t indexCount, uint32_t startIndex, uint32_t baseVertex)
 {
     _flushGraphicsState();
-    m_immediateContext->DrawIndexed((UINT)indexCount, (UINT)startIndex, (INT)baseVertex);
+    m_immediateContext->DrawIndexed(indexCount, startIndex, baseVertex);
 }
 
 Result D3D11Device::createProgram(const IShaderProgram::Desc& desc, IShaderProgram** outProgram)

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -3632,7 +3632,49 @@ public:
                 ResourceState src,
                 ResourceState dst) override
             {
-                assert(!"Unimplemented");
+                ShortList<D3D12_RESOURCE_BARRIER> barriers;
+
+                for (size_t i = 0; i < count; i++)
+                {
+                    auto textureImpl = static_cast<TextureResourceImpl*>(textures[i]);
+                    auto d3dFormat = D3DUtil::getMapFormat(textureImpl->getDesc()->format);
+                    auto textureDesc = textureImpl->getDesc();
+                    D3D12_RESOURCE_BARRIER barrier;
+                    barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+                    if (src == dst && src == ResourceState::UnorderedAccess)
+                    {
+                        barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
+                        barrier.UAV.pResource = textureImpl->m_resource.getResource();
+                    }
+                    else
+                    {
+                        barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+                        barrier.Transition.StateBefore = D3DUtil::getResourceState(src);
+                        barrier.Transition.StateAfter = D3DUtil::getResourceState(dst);
+                        barrier.Transition.pResource = textureImpl->m_resource.getResource();
+                        auto planeCount = D3DUtil::getPlaneSliceCount(
+                            D3DUtil::getMapFormat(textureImpl->getDesc()->format));
+                        for (uint32_t planeIndex = 0; planeIndex < planeCount; planeIndex++)
+                        {
+                            for (int layer = 0; layer < textureDesc->arraySize; layer++)
+                            {
+                                for (int mip = 0; mip < textureDesc->numMipLevels; mip++)
+                                {
+                                    barrier.Transition.Subresource = D3DUtil::getSubresourceIndex(
+                                        mip,
+                                        layer,
+                                        planeIndex,
+                                        textureImpl->getDesc()->numMipLevels,
+                                        textureImpl->getDesc()->arraySize);
+                                    barriers.add(barrier);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                m_commandBuffer->m_cmdList->ResourceBarrier(
+                    (UINT)barriers.getCount(), barriers.getArrayView().getBuffer());
             }
             virtual SLANG_NO_THROW void SLANG_MCALL bufferBarrier(
                 size_t count,
@@ -3655,14 +3697,70 @@ public:
                 ITextureResource::Offset3D srcOffset,
                 ITextureResource::Size extent) override
             {
-                SLANG_UNUSED(dst);
-                SLANG_UNUSED(dstSubresource);
-                SLANG_UNUSED(dstOffset);
-                SLANG_UNUSED(src);
-                SLANG_UNUSED(srcSubresource);
-                SLANG_UNUSED(srcOffset);
-                SLANG_UNUSED(extent);
-                SLANG_UNIMPLEMENTED_X("copyTexture");
+                auto dstTexture = static_cast<TextureResourceImpl*>(dst);
+                auto srcTexture = static_cast<TextureResourceImpl*>(src);
+
+                if (dstSubresource.layerCount == 0 && dstSubresource.mipLevelCount == 0 &&
+                    srcSubresource.layerCount == 0 && srcSubresource.mipLevelCount == 0)
+                {
+                    m_commandBuffer->m_cmdList->CopyResource(
+                        dstTexture->m_resource.getResource(), srcTexture->m_resource.getResource());
+                    return;
+                }
+
+                auto d3dFormat = D3DUtil::getMapFormat(dstTexture->getDesc()->format);
+                auto aspectMask = (int32_t)dstSubresource.aspectMask;
+                if (dstSubresource.aspectMask == TextureAspect::Default)
+                    aspectMask = (int32_t)TextureAspect::Color;
+                while (aspectMask)
+                {
+                    auto aspect = (int32_t)aspectMask & (-(int32_t)aspectMask); // get lowest bit of aspectMask.
+                    aspectMask &= ~aspect;
+                    auto planeIndex = D3DUtil::getPlaneSlice(d3dFormat, (TextureAspect)aspect);
+                    for (uint32_t layer = 0; layer < dstSubresource.layerCount; layer++)
+                    {
+                        for (uint32_t mipLevel = 0; mipLevel < dstSubresource.mipLevelCount;
+                             mipLevel++)
+                        {
+                            D3D12_TEXTURE_COPY_LOCATION dstRegion = {};
+
+                            dstRegion.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+                            dstRegion.pResource = dstTexture->m_resource.getResource();
+                            dstRegion.SubresourceIndex = D3DUtil::getSubresourceIndex(
+                                dstSubresource.mipLevel + mipLevel,
+                                dstSubresource.baseArrayLayer + layer,
+                                planeIndex,
+                                dstTexture->getDesc()->numMipLevels,
+                                dstTexture->getDesc()->arraySize);
+
+                            D3D12_TEXTURE_COPY_LOCATION srcRegion = {};
+                            srcRegion.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+                            srcRegion.pResource = srcTexture->m_resource.getResource();
+                            srcRegion.SubresourceIndex = D3DUtil::getSubresourceIndex(
+                                srcSubresource.mipLevel + mipLevel,
+                                srcSubresource.baseArrayLayer + layer,
+                                planeIndex,
+                                srcTexture->getDesc()->numMipLevels,
+                                srcTexture->getDesc()->arraySize);
+
+                            D3D12_BOX srcBox = {};
+                            srcBox.left = srcOffset.x;
+                            srcBox.top = srcOffset.y;
+                            srcBox.front = srcOffset.z;
+                            srcBox.right = srcBox.left + extent.width;
+                            srcBox.bottom = srcBox.top + extent.height;
+                            srcBox.back = srcBox.front + extent.depth;
+
+                            m_commandBuffer->m_cmdList->CopyTextureRegion(
+                                &dstRegion,
+                                dstOffset.x,
+                                dstOffset.y,
+                                dstOffset.z,
+                                &srcRegion,
+                                &srcBox);
+                        }
+                    }
+                }
             }
 
             virtual SLANG_NO_THROW void SLANG_MCALL uploadTextureData(
@@ -3673,13 +3771,100 @@ public:
                 ITextureResource::SubresourceData* subResourceData,
                 size_t subResourceDataCount) override
             {
-                SLANG_UNUSED(dst);
-                SLANG_UNUSED(subResourceRange);
-                SLANG_UNUSED(offset);
-                SLANG_UNUSED(extent);
-                SLANG_UNUSED(subResourceData);
-                SLANG_UNUSED(subResourceDataCount);
-                SLANG_UNIMPLEMENTED_X("uploadTextureData");
+                auto dstTexture = static_cast<TextureResourceImpl*>(dst);
+                auto baseSubresourceIndex = D3DUtil::getSubresourceIndex(
+                    subResourceRange.mipLevel,
+                    subResourceRange.baseArrayLayer,
+                    0,
+                    dstTexture->getDesc()->numMipLevels,
+                    dstTexture->getDesc()->arraySize);
+                auto textureSize = dstTexture->getDesc()->size;
+                FormatInfo formatInfo = {};
+                gfxGetFormatInfo(dstTexture->getDesc()->format, &formatInfo);
+                for (uint32_t i = 0; i < (uint32_t)subResourceDataCount; i++)
+                {
+                    auto subresourceIndex = baseSubresourceIndex + i;
+                    // Get the footprint
+                    D3D12_RESOURCE_DESC texDesc = dstTexture->m_resource.getResource()->GetDesc();
+
+                    D3D12_TEXTURE_COPY_LOCATION dstRegion = {};
+
+                    dstRegion.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+                    dstRegion.SubresourceIndex = subresourceIndex;
+                    dstRegion.pResource = dstTexture->m_resource.getResource();
+
+                    D3D12_TEXTURE_COPY_LOCATION srcRegion = {};
+                    srcRegion.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+                    D3D12_PLACED_SUBRESOURCE_FOOTPRINT& footprint = srcRegion.PlacedFootprint;
+                    
+                    footprint.Offset = 0;
+                    footprint.Footprint.Format = texDesc.Format;
+                    uint32_t mipLevel = D3DUtil::getSubresourceMipLevel(
+                        subresourceIndex, dstTexture->getDesc()->numMipLevels);
+                    if (extent.x != 0xFFFFFFFF)
+                    {
+                        footprint.Footprint.Width = extent.x;
+                    }
+                    else
+                    {
+                        footprint.Footprint.Width = Math::Max(1, (textureSize.width >> mipLevel)) - offset.x;
+                    }
+                    if (extent.y != 0xFFFFFFFF)
+                    {
+                        footprint.Footprint.Height = extent.y;
+                    }
+                    else
+                    {
+                        footprint.Footprint.Height =
+                            Math::Max(1, (textureSize.height >> mipLevel)) - offset.y;
+                    }
+                    if (extent.z != 0xFFFFFFFF)
+                    {
+                        footprint.Footprint.Depth = extent.z;
+                    }
+                    else
+                    {
+                        footprint.Footprint.Depth =
+                            Math::Max(1, (textureSize.depth >> mipLevel)) - offset.z;
+                    }
+                    footprint.Footprint.RowPitch = (UINT)D3DUtil::calcAligned(
+                        footprint.Footprint.Width * (UInt)formatInfo.blockSizeInBytes,
+                        (uint32_t)D3D12_TEXTURE_DATA_PITCH_ALIGNMENT);
+
+                    auto bufferSize = footprint.Footprint.RowPitch * footprint.Footprint.Height *
+                                      footprint.Footprint.Depth;
+
+                    IBufferResource* stagingBuffer;
+                    m_commandBuffer->m_transientHeap->allocateStagingBuffer(
+                        bufferSize, stagingBuffer, ResourceState::CopySource);
+
+                    BufferResourceImpl* bufferImpl = static_cast<BufferResourceImpl*>(stagingBuffer);
+                    uint8_t* bufferData = nullptr;
+                    D3D12_RANGE mapRange = {0, 0};
+                    bufferImpl->m_resource.getResource()->Map(0, &mapRange, (void**)&bufferData);
+                    for (uint32_t z = 0; z < footprint.Footprint.Depth; z++)
+                    {
+                        auto imageStart = bufferData + footprint.Footprint.RowPitch *
+                                                           footprint.Footprint.Height * (size_t)z;
+                        auto srcData =
+                            (uint8_t*)subResourceData->data + subResourceData->strideZ * z;
+                        for (uint32_t row = 0; row < footprint.Footprint.Height; row++)
+                        {
+                            memcpy(
+                                imageStart + row * (size_t)footprint.Footprint.RowPitch,
+                                srcData + subResourceData->strideY * row,
+                                subResourceData->strideY);
+                        }
+                    }
+                    bufferImpl->m_resource.getResource()->Unmap(0, nullptr);
+
+                    srcRegion.pResource = bufferImpl->m_resource.getResource();
+                    D3D12_BOX srcBox = {};
+                    srcBox.right = (UINT)bufferSize;
+                    srcBox.bottom = srcBox.back = 1;
+                    m_commandBuffer->m_cmdList->CopyTextureRegion(
+                        &dstRegion, offset.x, offset.y, offset.z, &srcRegion, &srcBox);
+                }
             }
 
             virtual SLANG_NO_THROW void SLANG_MCALL clearResourceView(
@@ -3793,14 +3978,93 @@ public:
                 ITextureResource::Offset3D srcOffset,
                 ITextureResource::Size extent) override
             {
-                SLANG_UNUSED(dst);
-                SLANG_UNUSED(dstOffset);
-                SLANG_UNUSED(dstSize);
-                SLANG_UNUSED(src);
-                SLANG_UNUSED(srcSubresource);
-                SLANG_UNUSED(srcOffset);
-                SLANG_UNUSED(extent);
-                SLANG_UNIMPLEMENTED_X("copyTextureToBuffer");
+                auto srcTexture = static_cast<TextureResourceImpl*>(src);
+                auto dstBuffer = static_cast<BufferResourceImpl*>(dst);
+                auto baseSubresourceIndex = D3DUtil::getSubresourceIndex(
+                    srcSubresource.mipLevel,
+                    srcSubresource.baseArrayLayer,
+                    0,
+                    srcTexture->getDesc()->numMipLevels,
+                    srcTexture->getDesc()->arraySize);
+                auto textureSize = srcTexture->getDesc()->size;
+                FormatInfo formatInfo = {};
+                gfxGetFormatInfo(srcTexture->getDesc()->format, &formatInfo);
+                if (srcSubresource.mipLevelCount == 0)
+                    srcSubresource.mipLevelCount = srcTexture->getDesc()->numMipLevels;
+                if (srcSubresource.layerCount == 0)
+                    srcSubresource.layerCount = srcTexture->getDesc()->arraySize;
+
+                for (uint32_t layer = 0; layer < srcSubresource.layerCount; layer++)
+                {
+                    for (uint32_t mipId = 0; mipId < srcSubresource.mipLevelCount; mipId++)
+                    {
+                        // Get the footprint
+                        D3D12_RESOURCE_DESC texDesc =
+                            srcTexture->m_resource.getResource()->GetDesc();
+
+                        D3D12_TEXTURE_COPY_LOCATION dstRegion = {};
+                        dstRegion.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+                        dstRegion.pResource = dstBuffer->m_resource.getResource();
+                        D3D12_PLACED_SUBRESOURCE_FOOTPRINT& footprint = dstRegion.PlacedFootprint;
+
+                        D3D12_TEXTURE_COPY_LOCATION srcRegion = {};
+                        srcRegion.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+                        srcRegion.SubresourceIndex = D3DUtil::getSubresourceIndex(
+                            mipId + srcSubresource.mipLevel,
+                            layer + srcSubresource.baseArrayLayer,
+                            0,
+                            srcTexture->getDesc()->numMipLevels,
+                            srcTexture->getDesc()->arraySize);
+                        srcRegion.pResource = srcTexture->m_resource.getResource();
+
+                        footprint.Offset = 0;
+                        footprint.Footprint.Format = texDesc.Format;
+                        uint32_t mipLevel = mipId + srcSubresource.mipLevel;
+                        if (extent.width != 0xFFFFFFFF)
+                        {
+                            footprint.Footprint.Width = extent.width;
+                        }
+                        else
+                        {
+                            footprint.Footprint.Width =
+                                Math::Max(1, (textureSize.width >> mipLevel)) - srcOffset.x;
+                        }
+                        if (extent.height != 0xFFFFFFFF)
+                        {
+                            footprint.Footprint.Height = extent.height;
+                        }
+                        else
+                        {
+                            footprint.Footprint.Height =
+                                Math::Max(1, (textureSize.height >> mipLevel)) - srcOffset.y;
+                        }
+                        if (extent.depth != 0xFFFFFFFF)
+                        {
+                            footprint.Footprint.Depth = extent.depth;
+                        }
+                        else
+                        {
+                            footprint.Footprint.Depth =
+                                Math::Max(1, (textureSize.depth >> mipLevel)) - srcOffset.z;
+                        }
+                        footprint.Footprint.RowPitch = (UINT)D3DUtil::calcAligned(
+                            footprint.Footprint.Width * (UInt)formatInfo.blockSizeInBytes,
+                            (uint32_t)D3D12_TEXTURE_DATA_PITCH_ALIGNMENT);
+
+                        auto bufferSize = footprint.Footprint.RowPitch *
+                                          footprint.Footprint.Height * footprint.Footprint.Depth;
+
+                        D3D12_BOX srcBox = {};
+                        srcBox.left = srcOffset.x;
+                        srcBox.top = srcOffset.y;
+                        srcBox.front = srcOffset.z;
+                        srcBox.right = srcOffset.x + extent.width;
+                        srcBox.bottom = srcOffset.y + extent.height;
+                        srcBox.back = srcOffset.z + extent.depth;
+                        m_commandBuffer->m_cmdList->CopyTextureRegion(
+                            &dstRegion, (UINT)dstOffset, 0, 0, &srcRegion, &srcBox);
+                    }
+                }
             }
 
             virtual SLANG_NO_THROW void SLANG_MCALL textureSubresourceBarrier(
@@ -3809,11 +4073,55 @@ public:
                 ResourceState src,
                 ResourceState dst) override
             {
-                SLANG_UNUSED(texture);
-                SLANG_UNUSED(subresourceRange);
-                SLANG_UNUSED(src);
-                SLANG_UNUSED(dst);
-                SLANG_UNIMPLEMENTED_X("textureSubresourceBarrier");
+                auto textureImpl = static_cast<TextureResourceImpl*>(texture);
+
+                if (subresourceRange.mipLevelCount == 0)
+                    subresourceRange.mipLevelCount = textureImpl->getDesc()->numMipLevels;
+                if (subresourceRange.layerCount == 0)
+                    subresourceRange.layerCount = textureImpl->getDesc()->arraySize;
+
+                auto d3dFormat = D3DUtil::getMapFormat(textureImpl->getDesc()->format);
+
+                ShortList<D3D12_RESOURCE_BARRIER> barriers;
+                D3D12_RESOURCE_BARRIER barrier;
+                barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+                if (src == dst && src == ResourceState::UnorderedAccess)
+                {
+                    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
+                    barrier.UAV.pResource = textureImpl->m_resource.getResource();
+                }
+                else
+                {
+                    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+                    barrier.Transition.StateBefore = D3DUtil::getResourceState(src);
+                    barrier.Transition.StateAfter = D3DUtil::getResourceState(dst);
+                    barrier.Transition.pResource = textureImpl->m_resource.getResource();
+                    auto aspectMask = (int32_t)subresourceRange.aspectMask;
+                    if (subresourceRange.aspectMask == TextureAspect::Default)
+                        aspectMask = (int32_t)TextureAspect::Color;
+                    while (aspectMask)
+                    {
+                        auto aspect = (int32_t)aspectMask &
+                                      (-(int32_t)aspectMask); // get lowest bit of aspectMask.
+                        aspectMask &= ~aspect;
+                        auto planeIndex = D3DUtil::getPlaneSlice(d3dFormat, (TextureAspect)aspect);
+                        for (uint32_t layer = 0; layer < subresourceRange.baseArrayLayer; layer++)
+                        {
+                            for (uint32_t mip = 0; mip < subresourceRange.mipLevelCount; mip++)
+                            {
+                                barrier.Transition.Subresource = D3DUtil::getSubresourceIndex(
+                                    mip + subresourceRange.mipLevel,
+                                    layer + subresourceRange.baseArrayLayer,
+                                    planeIndex,
+                                    textureImpl->getDesc()->numMipLevels,
+                                    textureImpl->getDesc()->arraySize);
+                                barriers.add(barrier);
+                            }
+                        }
+                    }
+                }
+                m_commandBuffer->m_cmdList->ResourceBarrier(
+                    (UINT)barriers.getCount(), barriers.getArrayView().getBuffer());
             }
         };
 

--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -1084,11 +1084,11 @@ void DebugRenderCommandEncoder::setPrimitiveTopology(PrimitiveTopology topology)
 }
 
 void DebugRenderCommandEncoder::setVertexBuffers(
-    UInt startSlot,
-    UInt slotCount,
+    uint32_t startSlot,
+    uint32_t slotCount,
     IBufferResource* const* buffers,
-    const UInt* strides,
-    const UInt* offsets)
+    const uint32_t* strides,
+    const uint32_t* offsets)
 {
     SLANG_GFX_API_FUNC;
 
@@ -1101,22 +1101,21 @@ void DebugRenderCommandEncoder::setVertexBuffers(
 }
 
 void DebugRenderCommandEncoder::setIndexBuffer(
-    IBufferResource* buffer,
-    Format indexFormat,
-    UInt offset)
+    IBufferResource* buffer, Format indexFormat, uint32_t offset)
 {
     SLANG_GFX_API_FUNC;
     auto innerBuffer = static_cast<DebugBufferResource*>(buffer)->baseObject.get();
     baseObject->setIndexBuffer(innerBuffer, indexFormat, offset);
 }
 
-void DebugRenderCommandEncoder::draw(UInt vertexCount, UInt startVertex)
+void DebugRenderCommandEncoder::draw(uint32_t vertexCount, uint32_t startVertex)
 {
     SLANG_GFX_API_FUNC;
     baseObject->draw(vertexCount, startVertex);
 }
 
-void DebugRenderCommandEncoder::drawIndexed(UInt indexCount, UInt startIndex, UInt baseVertex)
+void DebugRenderCommandEncoder::drawIndexed(
+    uint32_t indexCount, uint32_t startIndex, uint32_t baseVertex)
 {
     SLANG_GFX_API_FUNC;
     baseObject->drawIndexed(indexCount, startIndex, baseVertex);
@@ -1166,7 +1165,10 @@ Result DebugRenderCommandEncoder::setSamplePositions(
 }
 
 void DebugRenderCommandEncoder::drawInstanced(
-    UInt vertexCount, UInt instanceCount, UInt startVertex, UInt startInstanceLocation)
+    uint32_t vertexCount,
+    uint32_t instanceCount,
+    uint32_t startVertex,
+    uint32_t startInstanceLocation)
 {
     SLANG_GFX_API_FUNC;
     return baseObject->drawInstanced(

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -345,16 +345,17 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL
         setPrimitiveTopology(PrimitiveTopology topology) override;
     virtual SLANG_NO_THROW void SLANG_MCALL setVertexBuffers(
-        UInt startSlot,
-        UInt slotCount,
+        uint32_t startSlot,
+        uint32_t slotCount,
         IBufferResource* const* buffers,
-        const UInt* strides,
-        const UInt* offsets) override;
+        const uint32_t* strides,
+        const uint32_t* offsets) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        setIndexBuffer(IBufferResource* buffer, Format indexFormat, UInt offset = 0) override;
-    virtual SLANG_NO_THROW void SLANG_MCALL draw(UInt vertexCount, UInt startVertex = 0) override;
+        setIndexBuffer(IBufferResource* buffer, Format indexFormat, uint32_t offset = 0) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        drawIndexed(UInt indexCount, UInt startIndex = 0, UInt baseVertex = 0) override;
+        draw(uint32_t vertexCount, uint32_t startVertex = 0) override;
+    virtual SLANG_NO_THROW void SLANG_MCALL
+        drawIndexed(uint32_t indexCount, uint32_t startIndex = 0, uint32_t baseVertex = 0) override;
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndirect(
         uint32_t maxDrawCount,
         IBufferResource* argBuffer,
@@ -374,10 +375,10 @@ public:
         uint32_t pixelCount,
         const SamplePosition* samplePositions) override;
     virtual SLANG_NO_THROW void SLANG_MCALL drawInstanced(
-        UInt vertexCount,
-        UInt instanceCount,
-        UInt startVertex,
-        UInt startInstanceLocation) override;
+        uint32_t vertexCount,
+        uint32_t instanceCount,
+        uint32_t startVertex,
+        uint32_t startInstanceLocation) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedInstanced(
         uint32_t indexCount,

--- a/tools/gfx/immediate-renderer-base.cpp
+++ b/tools/gfx/immediate-renderer-base.cpp
@@ -116,29 +116,30 @@ public:
             m_writer->setPrimitiveTopology(topology);
         }
         virtual SLANG_NO_THROW void SLANG_MCALL setVertexBuffers(
-            UInt startSlot,
-            UInt slotCount,
+            uint32_t startSlot,
+            uint32_t slotCount,
             IBufferResource* const* buffers,
-            const UInt* strides,
-            const UInt* offsets) override
+            const uint32_t* strides,
+            const uint32_t* offsets) override
         {
             m_writer->setVertexBuffers(startSlot, slotCount, buffers, strides, offsets);
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL
-            setIndexBuffer(IBufferResource* buffer, Format indexFormat, UInt offset) override
+            setIndexBuffer(IBufferResource* buffer, Format indexFormat, uint32_t offset) override
         {
             m_writer->setIndexBuffer(buffer, indexFormat, offset);
         }
 
-        virtual SLANG_NO_THROW void SLANG_MCALL draw(UInt vertexCount, UInt startVertex) override
+        virtual SLANG_NO_THROW void SLANG_MCALL
+            draw(uint32_t vertexCount, uint32_t startVertex) override
         {
             m_writer->bindRootShaderObject(m_commandBuffer->m_rootShaderObject);
             m_writer->draw(vertexCount, startVertex);
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL
-            drawIndexed(UInt indexCount, UInt startIndex, UInt baseVertex) override
+            drawIndexed(uint32_t indexCount, uint32_t startIndex, uint32_t baseVertex) override
         {
             m_writer->bindRootShaderObject(m_commandBuffer->m_rootShaderObject);
             m_writer->drawIndexed(indexCount, startIndex, baseVertex);
@@ -196,10 +197,10 @@ public:
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL drawInstanced(
-            UInt vertexCount,
-            UInt instanceCount,
-            UInt startVertex,
-            UInt startInstanceLocation) override
+            uint32_t vertexCount,
+            uint32_t instanceCount,
+            uint32_t startVertex,
+            uint32_t startInstanceLocation) override
         {
             SLANG_UNUSED(vertexCount);
             SLANG_UNUSED(instanceCount);
@@ -496,11 +497,11 @@ public:
                             m_writer.getObject<BufferResource>(cmd.operands[2] + i));
                     }
                     m_renderer->setVertexBuffers(
-                        (UInt)cmd.operands[0],
-                        (UInt)cmd.operands[1],
+                        cmd.operands[0],
+                        cmd.operands[1],
                         bufferResources.getArrayView().getBuffer(),
-                        m_writer.getData<UInt>(cmd.operands[3]),
-                        m_writer.getData<UInt>(cmd.operands[4]));
+                        m_writer.getData<uint32_t>(cmd.operands[3]),
+                        m_writer.getData<uint32_t>(cmd.operands[4]));
                 }
                 break;
             case CommandName::SetIndexBuffer:
@@ -510,11 +511,11 @@ public:
                     (UInt)cmd.operands[2]);
                 break;
             case CommandName::Draw:
-                m_renderer->draw((UInt)cmd.operands[0], (UInt)cmd.operands[1]);
+                m_renderer->draw(cmd.operands[0], cmd.operands[1]);
                 break;
             case CommandName::DrawIndexed:
                 m_renderer->drawIndexed(
-                    (UInt)cmd.operands[0], (UInt)cmd.operands[1], (UInt)cmd.operands[2]);
+                    cmd.operands[0], cmd.operands[1], cmd.operands[2]);
                 break;
             case CommandName::SetStencilReference:
                 m_renderer->setStencilReference(cmd.operands[0]);

--- a/tools/gfx/immediate-renderer-base.h
+++ b/tools/gfx/immediate-renderer-base.h
@@ -60,14 +60,16 @@ public:
     virtual void setScissorRects(UInt count, const ScissorRect* scissors) = 0;
     virtual void setPrimitiveTopology(PrimitiveTopology topology) = 0;
     virtual void setVertexBuffers(
-        UInt startSlot,
-        UInt slotCount,
+        uint32_t startSlot,
+        uint32_t slotCount,
         IBufferResource* const* buffers,
-        const UInt* strides,
-        const UInt* offsets) = 0;
-    virtual void setIndexBuffer(IBufferResource* buffer, Format indexFormat, UInt offset = 0) = 0;
-    virtual void draw(UInt vertexCount, UInt startVertex = 0) = 0;
-    virtual void drawIndexed(UInt indexCount, UInt startIndex = 0, UInt baseVertex = 0) = 0;
+        const uint32_t* strides,
+        const uint32_t* offsets) = 0;
+    virtual void setIndexBuffer(
+        IBufferResource* buffer, Format indexFormat, uint32_t offset = 0) = 0;
+    virtual void draw(uint32_t vertexCount, uint32_t startVertex = 0) = 0;
+    virtual void drawIndexed(
+        uint32_t indexCount, uint32_t startIndex = 0, uint32_t baseVertex = 0) = 0;
     virtual void setStencilReference(uint32_t referenceValue) = 0;
     virtual void dispatchCompute(int x, int y, int z) = 0;
     virtual void copyBuffer(
@@ -137,11 +139,11 @@ public:
         SLANG_UNUSED(topology);
     }
     virtual void setVertexBuffers(
-        UInt startSlot,
-        UInt slotCount,
+        uint32_t startSlot,
+        uint32_t slotCount,
         IBufferResource* const* buffers,
-        const UInt* strides,
-        const UInt* offsets) override
+        const uint32_t* strides,
+        const uint32_t* offsets) override
     {
         SLANG_UNUSED(startSlot);
         SLANG_UNUSED(slotCount);
@@ -149,19 +151,21 @@ public:
         SLANG_UNUSED(strides);
         SLANG_UNUSED(offsets);
     }
-    virtual void setIndexBuffer(IBufferResource* buffer, Format indexFormat, UInt offset = 0)
+    virtual void setIndexBuffer(
+        IBufferResource* buffer, Format indexFormat, uint32_t offset = 0)
         override
     {
         SLANG_UNUSED(buffer);
         SLANG_UNUSED(indexFormat);
         SLANG_UNUSED(offset);
     }
-    virtual void draw(UInt vertexCount, UInt startVertex = 0) override
+    virtual void draw(uint32_t vertexCount, uint32_t startVertex = 0) override
     {
         SLANG_UNUSED(vertexCount);
         SLANG_UNUSED(startVertex);
     }
-    virtual void drawIndexed(UInt indexCount, UInt startIndex = 0, UInt baseVertex = 0) override
+    virtual void drawIndexed(
+        uint32_t indexCount, uint32_t startIndex = 0, uint32_t baseVertex = 0) override
     {
         SLANG_UNUSED(indexCount);
         SLANG_UNUSED(startIndex);

--- a/tools/gfx/open-gl/render-gl.cpp
+++ b/tools/gfx/open-gl/render-gl.cpp
@@ -166,17 +166,19 @@ public:
     virtual void setPrimitiveTopology(PrimitiveTopology topology) override;
 
     virtual void setVertexBuffers(
-        UInt startSlot,
-        UInt slotCount,
+        uint32_t startSlot,
+        uint32_t slotCount,
         IBufferResource* const* buffers,
-        const UInt* strides,
-        const UInt* offsets) override;
-    virtual void setIndexBuffer(IBufferResource* buffer, Format indexFormat, UInt offset) override;
+        const uint32_t* strides,
+        const uint32_t* offsets) override;
+    virtual void setIndexBuffer(
+        IBufferResource* buffer, Format indexFormat, uint32_t offset) override;
     virtual void setViewports(UInt count, Viewport const* viewports) override;
     virtual void setScissorRects(UInt count, ScissorRect const* rects) override;
     virtual void setPipelineState(IPipelineState* state) override;
-    virtual void draw(UInt vertexCount, UInt startVertex) override;
-    virtual void drawIndexed(UInt indexCount, UInt startIndex, UInt baseVertex) override;
+    virtual void draw(uint32_t vertexCount, uint32_t startVertex) override;
+    virtual void drawIndexed(
+        uint32_t indexCount, uint32_t startIndex, uint32_t baseVertex) override;
     virtual void dispatchCompute(int x, int y, int z) override;
     virtual void submitGpuWork() override {}
     virtual void waitForGpu() override {}
@@ -2597,11 +2599,11 @@ void GLDevice::setPrimitiveTopology(PrimitiveTopology topology)
 }
 
 void GLDevice::setVertexBuffers(
-    UInt startSlot,
-    UInt slotCount,
+    uint32_t startSlot,
+    uint32_t slotCount,
     IBufferResource* const* buffers,
-    const UInt* strides,
-    const UInt* offsets)
+    const uint32_t* strides,
+    const uint32_t* offsets)
 {
     for (UInt ii = 0; ii < slotCount; ++ii)
     {
@@ -2616,7 +2618,7 @@ void GLDevice::setVertexBuffers(
     }
 }
 
-void GLDevice::setIndexBuffer(IBufferResource* buffer, Format indexFormat, UInt offset)
+void GLDevice::setIndexBuffer(IBufferResource* buffer, Format indexFormat, uint32_t offset)
 {
     auto bufferImpl = static_cast<BufferResourceImpl*>(buffer);
     m_boundIndexBuffer = bufferImpl->m_handle;
@@ -2675,14 +2677,14 @@ void GLDevice::setPipelineState(IPipelineState* state)
     glUseProgram(programID);
 }
 
-void GLDevice::draw(UInt vertexCount, UInt startVertex = 0)
+void GLDevice::draw(uint32_t vertexCount, uint32_t startVertex = 0)
 {
     flushStateForDraw();
 
     glDrawArrays(m_boundPrimitiveTopology, (GLint)startVertex, (GLsizei)vertexCount);
 }
 
-void GLDevice::drawIndexed(UInt indexCount, UInt startIndex, UInt baseVertex)
+void GLDevice::drawIndexed(uint32_t indexCount, uint32_t startIndex, uint32_t baseVertex)
 {
     flushStateForDraw();
 

--- a/tools/gfx/transient-resource-heap-base.h
+++ b/tools/gfx/transient-resource-heap-base.h
@@ -12,6 +12,8 @@ public:
 public:
     BreakableReference<TDevice> m_device;
     Slang::List<Slang::RefPtr<TBufferResource>> m_constantBuffers;
+    Slang::List<Slang::RefPtr<TBufferResource>> m_stagingBuffers;
+
     Slang::Index m_constantBufferAllocCounter = 0;
     size_t m_constantBufferOffsetAllocCounter = 0;
     uint32_t m_alignment = 256;
@@ -43,6 +45,26 @@ public:
     static size_t alignUp(size_t value, uint32_t alignment)
     {
         return (value + alignment - 1) / alignment * alignment;
+    }
+
+    Result allocateStagingBuffer(size_t size, IBufferResource*& outBufferWeakPtr, ResourceState state)
+    {
+        Slang::ComPtr<IBufferResource> bufferPtr;
+        IBufferResource::Desc bufferDesc;
+        bufferDesc.type = IResource::Type::Buffer;
+        bufferDesc.defaultState = state;
+        bufferDesc.allowedStates =
+            ResourceStateSet(ResourceState::CopyDestination, ResourceState::CopySource);
+        if (state == ResourceState::CopySource)
+            bufferDesc.cpuAccessFlags |= AccessFlag::Write;
+        else
+            bufferDesc.cpuAccessFlags |= AccessFlag::Read;
+        bufferDesc.sizeInBytes = size;
+        SLANG_RETURN_ON_FAIL(
+            m_device->createBufferResource(bufferDesc, nullptr, bufferPtr.writeRef()));
+        m_stagingBuffers.add(static_cast<TBufferResource*>(bufferPtr.get()));
+        outBufferWeakPtr = bufferPtr.get();
+        return SLANG_OK;
     }
 
     Result allocateConstantBuffer(
@@ -100,6 +122,9 @@ public:
     {
         m_constantBufferAllocCounter = 0;
         m_constantBufferOffsetAllocCounter = 0;
+        for (auto& stagingBuffer : m_stagingBuffers)
+            stagingBuffer = nullptr;
+        m_stagingBuffers.clear();
         m_version = getVersionCounter();
         getVersionCounter()++;
     }


### PR DESCRIPTION
This change cleans up the parameters of draw calls to use uint32_t to stick with the underlying APIs.
Also implements the AcclerationStructureCurrentSize query for d3d12, for vulkan this always returns 0 since it is not supported.