### PR TITLE
Fully implemented test for drawInstanced()

### DIFF
--- a/tools/gfx-unit-test/draw-instanced-test.cpp
+++ b/tools/gfx-unit-test/draw-instanced-test.cpp
@@ -5,28 +5,10 @@
 #include "tools/gfx-util/shader-cursor.h"
 #include "source/core/slang-basic.h"
 
-#include <stdlib.h>
-#include <stdio.h>
-
-#define STB_IMAGE_WRITE_IMPLEMENTATION
-#include "external/stb/stb_image_write.h"
-
 using namespace gfx;
 
 namespace gfx_test
 {
-    /* static */ Slang::Result writeImage(
-        const char* filename,
-        ISlangBlob* pixels,
-        uint32_t width,
-        uint32_t height)
-    {
-        int stbResult =
-            stbi_write_hdr(filename, width, height, 4, (float*)pixels->getBufferPointer());
-
-        return stbResult ? SLANG_OK : SLANG_FAIL;
-    }
-
     struct Vertex
     {
         float position[3];

--- a/tools/gfx-unit-test/gfx-test-util.cpp
+++ b/tools/gfx-unit-test/gfx-test-util.cpp
@@ -150,6 +150,14 @@ namespace gfx_test
         SLANG_CHECK(memcmp(resultBlob->getBufferPointer(), expectedResult, expectedBufferSize) == 0);
     }
 
+    void compareComputeResultFuzzy(const float* result, float* expectedResult, size_t expectedBufferSize)
+    {
+        for (int i = 0; i < expectedBufferSize / sizeof(float); ++i)
+        {
+            SLANG_CHECK(abs(result[i] - expectedResult[i]) <= 0.01);
+        }
+    }
+
     void compareComputeResultFuzzy(gfx::IDevice* device, gfx::IBufferResource* buffer, float* expectedResult, size_t expectedBufferSize)
     {
         // Read back the results.
@@ -159,10 +167,7 @@ namespace gfx_test
         SLANG_CHECK(resultBlob->getBufferSize() == expectedBufferSize);
         // Compare results with a tolerance of 0.01.
         auto result = (float*)resultBlob->getBufferPointer();
-        for (int i = 0; i < expectedBufferSize / sizeof(float); ++i)
-        {
-            SLANG_CHECK(abs(result[i] - expectedResult[i]) <= 0.01);
-        }
+        compareComputeResultFuzzy(result, expectedResult, expectedBufferSize);
     }
 
     Slang::ComPtr<gfx::IDevice> createTestingDevice(UnitTestContext* context, Slang::RenderApiFlag::Enum api)

--- a/tools/gfx-unit-test/gfx-test-util.h
+++ b/tools/gfx-unit-test/gfx-test-util.h
@@ -42,6 +42,11 @@ namespace gfx_test
         size_t expectedResultRowPitch,
         size_t rowCount);
 
+    void compareComputeResultFuzzy(
+        const float* result,
+        float* expectedResult,
+        size_t expectedBufferSize);
+
         /// Reads back the content of `buffer` and compares it against `expectedResult` with a set tolerance.
     void compareComputeResultFuzzy(
         gfx::IDevice* device,

--- a/tools/gfx-unit-test/graphics-smoke.slang
+++ b/tools/gfx-unit-test/graphics-smoke.slang
@@ -3,7 +3,8 @@
 // Per-vertex attributes to be assembled from bound vertex buffers.
 struct AssembledVertex
 {
-    float3	position : POSITION;
+    float3	positionA : POSITIONA;
+    float3  positionB : POSITIONB;
     float3	color    : COLOR;
 };
 
@@ -33,7 +34,7 @@ VertexStageOutput vertexMain(
 {
     VertexStageOutput output;
 
-    float3 position = assembledVertex.position;
+    float3 position = assembledVertex.positionA + assembledVertex.positionB;
     float3 color    = assembledVertex.color;
 
     output.coarseVertex.color = color;


### PR DESCRIPTION
Changes:
- Fully implemented the test for `drawInstanced()` with instancing - This test was incomplete when the PR with draw calls was opened due to issues getting the basic pipeline working. Instancing has since been added and this test now runs as advertised.

Remaining draw tests and the implementation for Vulkan's `readTextureResource` to allow these tests to run on Vulkan are coming later.