### PR TITLE
gfx: Add tests for instanced, indexed instanced, and indirect draw calls

### DIFF
--- a/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj
+++ b/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj
@@ -275,7 +275,7 @@
     <ClCompile Include="..\..\..\tools\gfx-unit-test\buffer-barrier-test.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\compute-smoke.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\create-buffer-from-handle.cpp" />
-    <ClCompile Include="..\..\..\tools\gfx-unit-test\draw-instanced-test.cpp" />
+    <ClCompile Include="..\..\..\tools\gfx-unit-test\instanced-draw-tests.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\existing-device-handle-test.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\format-unit-tests.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\get-buffer-resource-handle-test.cpp" />

--- a/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj.filters
+++ b/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj.filters
@@ -62,7 +62,7 @@
     <ClCompile Include="..\..\..\tools\unit-test\slang-unit-test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\tools\gfx-unit-test\draw-instanced-test.cpp">
+    <ClCompile Include="..\..\..\tools\gfx-unit-test\instanced-draw-tests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/tools/gfx-unit-test/draw-instanced-test.cpp
+++ b/tools/gfx-unit-test/draw-instanced-test.cpp
@@ -5,28 +5,10 @@
 #include "tools/gfx-util/shader-cursor.h"
 #include "source/core/slang-basic.h"
 
-#include <stdlib.h>
-#include <stdio.h>
-
-#define STB_IMAGE_WRITE_IMPLEMENTATION
-#include "external/stb/stb_image_write.h"
-
 using namespace gfx;
 
 namespace gfx_test
 {
-    /* static */ Slang::Result writeImage(
-        const char* filename,
-        ISlangBlob* pixels,
-        uint32_t width,
-        uint32_t height)
-    {
-        int stbResult =
-            stbi_write_hdr(filename, width, height, 4, (float*)pixels->getBufferPointer());
-
-        return stbResult ? SLANG_OK : SLANG_FAIL;
-    }
-
     struct Vertex
     {
         float position[3];

--- a/tools/gfx-unit-test/draw-instanced-test.cpp
+++ b/tools/gfx-unit-test/draw-instanced-test.cpp
@@ -5,10 +5,28 @@
 #include "tools/gfx-util/shader-cursor.h"
 #include "source/core/slang-basic.h"
 
+#include <stdlib.h>
+#include <stdio.h>
+
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "external/stb/stb_image_write.h"
+
 using namespace gfx;
 
 namespace gfx_test
 {
+    /* static */ Slang::Result writeImage(
+        const char* filename,
+        ISlangBlob* pixels,
+        uint32_t width,
+        uint32_t height)
+    {
+        int stbResult =
+            stbi_write_hdr(filename, width, height, 4, (float*)pixels->getBufferPointer());
+
+        return stbResult ? SLANG_OK : SLANG_FAIL;
+    }
+
     struct Vertex
     {
         float position[3];
@@ -37,35 +55,23 @@ namespace gfx_test
     static const int kInstanceCount = 2;
     static const Instance kInstanceData[kInstanceCount] =
     {
-        { { 0,  0, 0 }, {1, 0, 0} },
-        { { 0, -1, 0 }, {0, 0, 1} },
+        { { 0,  0, 0 }, { 1, 0, 0 } },
+        { { 0, -1, 0 }, { 0, 0, 1 } },
     };
 
-    void drawInstancedTestImpl(IDevice* device, UnitTestContext* context)
+    static const int kIndexCount = 6;
+    static const uint32_t kIndexData[kIndexCount] =
     {
-        Slang::ComPtr<ITransientResourceHeap> transientHeap;
-        ITransientResourceHeap::Desc transientHeapDesc = {};
-        transientHeapDesc.constantBufferSize = 4096;
-        GFX_CHECK_CALL_ABORT(
-            device->createTransientResourceHeap(transientHeapDesc, transientHeap.writeRef()));
+        0, 1, 2,
+        3, 4, 5,
+    };
 
-        ComPtr<IShaderProgram> shaderProgram;
-        slang::ProgramLayout* slangReflection;
-        GFX_CHECK_CALL_ABORT(loadGraphicsProgram(device, shaderProgram, "graphics-smoke", "vertexMain", "fragmentMain", slangReflection));
+    const int kWidth = 256;
+    const int kHeight = 256;
+    const Format format = Format::R32G32B32A32_FLOAT;
 
-        Format format = Format::R32G32B32A32_FLOAT;
-
-        InputElementDesc inputElements[] = {
-            // Vertex buffer data
-            { "POSITIONA", 0, Format::R32G32B32_FLOAT, offsetof(Vertex, position), InputSlotClass::PerVertex, 0 },
-
-            // Instance buffer data
-            { "POSITIONB", 0, Format::R32G32B32_FLOAT, offsetof(Instance, position), InputSlotClass::PerInstance, 1, 1 },
-            { "COLOR",     0, Format::R32G32B32_FLOAT, offsetof(Instance, color),    InputSlotClass::PerInstance, 1, 1 },
-        };
-        ComPtr<gfx::IInputLayout> inputLayout = device->createInputLayout(inputElements, 3);
-        SLANG_CHECK_ABORT(inputLayout != nullptr);
-
+    ComPtr<IBufferResource> createVertexBuffer(IDevice* device)
+    {
         IBufferResource::Desc vertexBufferDesc;
         vertexBufferDesc.type = IResource::Type::Buffer;
         vertexBufferDesc.sizeInBytes = kVertexCount * sizeof(Vertex);
@@ -73,7 +79,11 @@ namespace gfx_test
         vertexBufferDesc.allowedStates = ResourceState::VertexBuffer;
         ComPtr<IBufferResource> vertexBuffer = device->createBufferResource(vertexBufferDesc, &kVertexData[0]);
         SLANG_CHECK_ABORT(vertexBuffer != nullptr);
+        return vertexBuffer;
+    }
 
+    ComPtr<IBufferResource> createInstanceBuffer(IDevice* device)
+    {
         IBufferResource::Desc instanceBufferDesc;
         instanceBufferDesc.type = IResource::Type::Buffer;
         instanceBufferDesc.sizeInBytes = kInstanceCount * sizeof(Instance);
@@ -81,123 +91,318 @@ namespace gfx_test
         instanceBufferDesc.allowedStates = ResourceState::VertexBuffer;
         ComPtr<IBufferResource> instanceBuffer = device->createBufferResource(instanceBufferDesc, &kInstanceData[0]);
         SLANG_CHECK_ABORT(instanceBuffer != nullptr);
+        return instanceBuffer;
+    }
 
-        IFramebufferLayout::AttachmentLayout attachmentLayout;
-        attachmentLayout.format = format;
-        attachmentLayout.sampleCount = 1;
+    ComPtr<IBufferResource> createIndexBuffer(IDevice* device)
+    {
+        IBufferResource::Desc indexBufferDesc;
+        indexBufferDesc.type = IResource::Type::Buffer;
+        indexBufferDesc.sizeInBytes = kIndexCount * sizeof(uint32_t);
+        indexBufferDesc.defaultState = ResourceState::VertexBuffer;
+        indexBufferDesc.allowedStates = ResourceState::VertexBuffer;
+        ComPtr<IBufferResource> indexBuffer = device->createBufferResource(indexBufferDesc, &kIndexData[0]);
+        SLANG_CHECK_ABORT(indexBuffer != nullptr);
+        return indexBuffer;
+    }
 
-        IFramebufferLayout::Desc framebufferLayoutDesc;
-        framebufferLayoutDesc.renderTargetCount = 1;
-        framebufferLayoutDesc.renderTargets = &attachmentLayout;
-        ComPtr<gfx::IFramebufferLayout> framebufferLayout = device->createFramebufferLayout(framebufferLayoutDesc);
-
-        GraphicsPipelineStateDesc pipelineDesc = {};
-        pipelineDesc.program = shaderProgram.get();
-        pipelineDesc.inputLayout = inputLayout;
-        pipelineDesc.framebufferLayout = framebufferLayout;
-        pipelineDesc.depthStencil.depthTestEnable = false;
-        pipelineDesc.depthStencil.depthWriteEnable = false;
-        ComPtr<gfx::IPipelineState> pipelineState;
-        GFX_CHECK_CALL_ABORT(
-            device->createGraphicsPipelineState(pipelineDesc, pipelineState.writeRef()));
-
-        ICommandQueue::Desc queueDesc = { ICommandQueue::QueueType::Graphics };
-        auto queue = device->createCommandQueue(queueDesc);
-        auto commandBuffer = transientHeap->createCommandBuffer();
-
-        IRenderPassLayout::Desc renderPassDesc = {};
-        renderPassDesc.framebufferLayout = framebufferLayout;
-        renderPassDesc.renderTargetCount = 1;
-        IRenderPassLayout::AttachmentAccessDesc renderTargetAccess = {};
-        renderTargetAccess.loadOp = IRenderPassLayout::AttachmentLoadOp::Clear;
-        renderTargetAccess.storeOp = IRenderPassLayout::AttachmentStoreOp::Store;
-        renderTargetAccess.initialState = ResourceState::Undefined;
-        renderTargetAccess.finalState = ResourceState::CopySource;
-        renderPassDesc.renderTargetAccess = &renderTargetAccess;
-        ComPtr<IRenderPassLayout> renderPass = device->createRenderPassLayout(renderPassDesc);
-
-        const int width = 256;
-        const int height = 256;
-
+    ComPtr<ITextureResource> createColorBuffer(IDevice* device)
+    {
         gfx::ITextureResource::Desc colorBufferDesc;
         colorBufferDesc.type = IResource::Type::Texture2D;
-        colorBufferDesc.size.width = width;
-        colorBufferDesc.size.height = height;
+        colorBufferDesc.size.width = kWidth;
+        colorBufferDesc.size.height = kHeight;
         colorBufferDesc.size.depth = 1;
         colorBufferDesc.numMipLevels = 1;
         colorBufferDesc.format = format;
         colorBufferDesc.defaultState = ResourceState::RenderTarget;
         colorBufferDesc.allowedStates = { ResourceState::RenderTarget, ResourceState::CopySource };
         ComPtr<ITextureResource> colorBuffer = device->createTextureResource(colorBufferDesc, nullptr);
+        SLANG_CHECK_ABORT(colorBuffer != nullptr);
+        return colorBuffer;
+    }
 
-        gfx::IResourceView::Desc colorBufferViewDesc;
-        memset(&colorBufferViewDesc, 0, sizeof(colorBufferViewDesc));
-        colorBufferViewDesc.format = format;
-        colorBufferViewDesc.renderTarget.shape = gfx::IResource::Type::Texture2D;
-        colorBufferViewDesc.type = gfx::IResourceView::Type::RenderTarget;
-        ComPtr<gfx::IResourceView> rtv =
-            device->createTextureView(colorBuffer.get(), colorBufferViewDesc);
+    class BaseDrawTest
+    {
+    public:
+        ComPtr<IDevice> device;
+        UnitTestContext* context;
 
-        gfx::IFramebuffer::Desc framebufferDesc;
-        framebufferDesc.renderTargetCount = 1;
-        framebufferDesc.depthStencilView = nullptr;
-        framebufferDesc.renderTargetViews = rtv.readRef();
-        framebufferDesc.layout = framebufferLayout;
-        ComPtr<gfx::IFramebuffer> framebuffer = device->createFramebuffer(framebufferDesc);
+        ComPtr<ITransientResourceHeap> transientHeap;
+        ComPtr<IPipelineState> pipelineState;
+        ComPtr<IRenderPassLayout> renderPass;
+        ComPtr<IFramebuffer> framebuffer;
+        ComPtr<IInputLayout> inputLayout;
 
-        auto encoder = commandBuffer->encodeRenderCommands(renderPass, framebuffer);
-        auto rootObject = encoder->bindPipeline(pipelineState);
+        ComPtr<IBufferResource> vertexBuffer;
+        ComPtr<ITextureResource> colorBuffer;
 
-        gfx::Viewport viewport = {};
-        viewport.maxZ = 1.0f;
-        viewport.extentX = width;
-        viewport.extentY = height;
-        encoder->setViewportAndScissor(viewport);
-
-        UInt startVertex = 0;
-        UInt startInstanceLocation = 0;
-
-        encoder->setVertexBuffer(0, vertexBuffer, sizeof(Vertex));
-        encoder->setVertexBuffer(1, instanceBuffer, sizeof(Instance));
-        encoder->setPrimitiveTopology(PrimitiveTopology::TriangleList);
-        encoder->drawInstanced(kVertexCount, kInstanceCount, startVertex, startInstanceLocation);
-        encoder->endEncoding();
-        commandBuffer->close();
-        queue->executeCommandBuffer(commandBuffer);
-        queue->waitOnHost();
-
-        // Read texture values back from four specific pixels located within the triangles
-        // and compare against expected values (because testing every single pixel will be too long and tedious
-        // and requires maintaining reference images).
-        ComPtr<ISlangBlob> resultBlob;
-        size_t rowPitch = 0;
-        size_t pixelSize = 0;
-        GFX_CHECK_CALL_ABORT(device->readTextureResource(
-            colorBuffer, ResourceState::CopySource, resultBlob.writeRef(), &rowPitch, &pixelSize));
-        auto result = (float*)resultBlob->getBufferPointer();
-
-        const int kPixelCount = 4;
-        const int kChannelCount = 4;
-        int testXCoords[kPixelCount] = { 64, 192, 64, 192 };
-        int testYCoords[kPixelCount] = { 100, 100, 250, 250 };
-        float testResults[kPixelCount * kChannelCount];
-
-        int cursor = 0;
-        for (int i = 0; i < kPixelCount; ++i)
+        void init(IDevice* device, UnitTestContext* context)
         {
-            auto x = testXCoords[i];
-            auto y = testYCoords[i];
-            auto pixelPtr = result + x * kChannelCount + y * rowPitch / sizeof(float);
-            for (int j = 0; j < kChannelCount; ++j)
-            {
-                testResults[cursor] = pixelPtr[j];
-                cursor++;
-            }
+            this->device = device;
+            this->context = context;
         }
 
-        float expectedResult[] = { 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f,
-                                   0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f };
-        compareComputeResultFuzzy(testResults, expectedResult, sizeof(expectedResult));
+        void createRequiredDrawCallResources()
+        {
+            ITransientResourceHeap::Desc transientHeapDesc = {};
+            transientHeapDesc.constantBufferSize = 4096;
+            GFX_CHECK_CALL_ABORT(
+                device->createTransientResourceHeap(transientHeapDesc, transientHeap.writeRef()));
+
+            ComPtr<IShaderProgram> shaderProgram;
+            slang::ProgramLayout* slangReflection;
+            GFX_CHECK_CALL_ABORT(loadGraphicsProgram(device, shaderProgram, "graphics-smoke", "vertexMain", "fragmentMain", slangReflection));
+
+            IFramebufferLayout::AttachmentLayout attachmentLayout;
+            attachmentLayout.format = format;
+            attachmentLayout.sampleCount = 1;
+
+            IFramebufferLayout::Desc framebufferLayoutDesc;
+            framebufferLayoutDesc.renderTargetCount = 1;
+            framebufferLayoutDesc.renderTargets = &attachmentLayout;
+            ComPtr<gfx::IFramebufferLayout> framebufferLayout = device->createFramebufferLayout(framebufferLayoutDesc);
+            SLANG_CHECK_ABORT(framebufferLayout != nullptr);
+
+            GraphicsPipelineStateDesc pipelineDesc = {};
+            pipelineDesc.program = shaderProgram.get();
+            pipelineDesc.inputLayout = inputLayout;
+            pipelineDesc.framebufferLayout = framebufferLayout;
+            pipelineDesc.depthStencil.depthTestEnable = false;
+            pipelineDesc.depthStencil.depthWriteEnable = false;
+            GFX_CHECK_CALL_ABORT(
+                device->createGraphicsPipelineState(pipelineDesc, pipelineState.writeRef()));
+
+            IRenderPassLayout::Desc renderPassDesc = {};
+            renderPassDesc.framebufferLayout = framebufferLayout;
+            renderPassDesc.renderTargetCount = 1;
+            IRenderPassLayout::AttachmentAccessDesc renderTargetAccess = {};
+            renderTargetAccess.loadOp = IRenderPassLayout::AttachmentLoadOp::Clear;
+            renderTargetAccess.storeOp = IRenderPassLayout::AttachmentStoreOp::Store;
+            renderTargetAccess.initialState = ResourceState::Undefined;
+            renderTargetAccess.finalState = ResourceState::CopySource;
+            renderPassDesc.renderTargetAccess = &renderTargetAccess;
+            GFX_CHECK_CALL_ABORT(device->createRenderPassLayout(renderPassDesc, renderPass.writeRef()));
+
+            gfx::IResourceView::Desc colorBufferViewDesc;
+            memset(&colorBufferViewDesc, 0, sizeof(colorBufferViewDesc));
+            colorBufferViewDesc.format = format;
+            colorBufferViewDesc.renderTarget.shape = gfx::IResource::Type::Texture2D;
+            colorBufferViewDesc.type = gfx::IResourceView::Type::RenderTarget;
+            auto rtv = device->createTextureView(colorBuffer, colorBufferViewDesc);
+
+            gfx::IFramebuffer::Desc framebufferDesc;
+            framebufferDesc.renderTargetCount = 1;
+            framebufferDesc.depthStencilView = nullptr;
+            framebufferDesc.renderTargetViews = rtv.readRef();
+            framebufferDesc.layout = framebufferLayout;
+            GFX_CHECK_CALL_ABORT(device->createFramebuffer(framebufferDesc, framebuffer.writeRef()));
+        }  
+    };
+
+    struct DrawInstancedTest : BaseDrawTest
+    {
+        ComPtr<IBufferResource> instanceBuffer;
+
+        void setUpAndRunTest(
+            IBufferResource* vertexBuffer,
+            IBufferResource* instanceBuffer)
+        {
+            createRequiredDrawCallResources();
+
+            ICommandQueue::Desc queueDesc = { ICommandQueue::QueueType::Graphics };
+            auto queue = device->createCommandQueue(queueDesc);
+            auto commandBuffer = transientHeap->createCommandBuffer();
+
+            auto encoder = commandBuffer->encodeRenderCommands(renderPass, framebuffer);
+            auto rootObject = encoder->bindPipeline(pipelineState);
+
+            gfx::Viewport viewport = {};
+            viewport.maxZ = 1.0f;
+            viewport.extentX = kWidth;
+            viewport.extentY = kHeight;
+            encoder->setViewportAndScissor(viewport);
+
+            UInt startVertex = 0;
+            UInt startInstanceLocation = 0;
+
+            encoder->setVertexBuffer(0, vertexBuffer, sizeof(Vertex));
+            encoder->setVertexBuffer(1, instanceBuffer, sizeof(Instance));
+            encoder->setPrimitiveTopology(PrimitiveTopology::TriangleList);
+
+            encoder->drawInstanced(kVertexCount, kInstanceCount, startVertex, startInstanceLocation);
+            encoder->endEncoding();
+            commandBuffer->close();
+            queue->executeCommandBuffer(commandBuffer);
+            queue->waitOnHost();
+        }
+
+        void run()
+        {
+            InputElementDesc inputElements[] = {
+                // Vertex buffer data
+                { "POSITIONA", 0, Format::R32G32B32_FLOAT, offsetof(Vertex, position), InputSlotClass::PerVertex, 0 },
+
+                // Instance buffer data
+                { "POSITIONB", 0, Format::R32G32B32_FLOAT, offsetof(Instance, position), InputSlotClass::PerInstance, 1, 1 },
+                { "COLOR",     0, Format::R32G32B32_FLOAT, offsetof(Instance, color),    InputSlotClass::PerInstance, 1, 1 },
+            };
+            inputLayout = device->createInputLayout(inputElements, 3);
+            SLANG_CHECK_ABORT(inputLayout != nullptr);
+
+            vertexBuffer = createVertexBuffer(device);
+            instanceBuffer = createInstanceBuffer(device);
+            colorBuffer = createColorBuffer(device);
+
+            setUpAndRunTest(vertexBuffer, instanceBuffer);
+
+            // Read texture values back from four specific pixels located within the triangles
+            // and compare against expected values (because testing every single pixel will be too long and tedious
+            // and requires maintaining reference images).
+            ComPtr<ISlangBlob> resultBlob;
+            size_t rowPitch = 0;
+            size_t pixelSize = 0;
+            GFX_CHECK_CALL_ABORT(device->readTextureResource(
+                colorBuffer, ResourceState::CopySource, resultBlob.writeRef(), &rowPitch, &pixelSize));
+            auto result = (float*)resultBlob->getBufferPointer();
+
+            writeImage("C:/Users/lucchen/Documents/dump.hdr", resultBlob, kWidth, kHeight);
+
+            const int kPixelCount = 4;
+            const int kChannelCount = 4;
+            int testXCoords[kPixelCount] = { 64, 192, 64, 192 };
+            int testYCoords[kPixelCount] = { 100, 100, 250, 250 };
+            float testResults[kPixelCount * kChannelCount];
+
+            int cursor = 0;
+            for (int i = 0; i < kPixelCount; ++i)
+            {
+                auto x = testXCoords[i];
+                auto y = testYCoords[i];
+                auto pixelPtr = result + x * kChannelCount + y * rowPitch / sizeof(float);
+                for (int j = 0; j < kChannelCount; ++j)
+                {
+                    testResults[cursor] = pixelPtr[j];
+                    cursor++;
+                }
+            }
+
+            float expectedResult[] = { 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+                                       0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f };
+            compareComputeResultFuzzy(testResults, expectedResult, sizeof(expectedResult));
+        }
+    };
+
+    struct DrawIndexedInstancedTest : BaseDrawTest
+    {
+        ComPtr<IBufferResource> instanceBuffer;
+        ComPtr<IBufferResource> indexBuffer;
+
+        void setUpAndRunTest(
+            IBufferResource* vertexBuffer,
+            IBufferResource* instanceBuffer,
+            IBufferResource* indexBuffer)
+        {
+            createRequiredDrawCallResources();
+
+            ICommandQueue::Desc queueDesc = { ICommandQueue::QueueType::Graphics };
+            auto queue = device->createCommandQueue(queueDesc);
+            auto commandBuffer = transientHeap->createCommandBuffer();
+
+            auto encoder = commandBuffer->encodeRenderCommands(renderPass, framebuffer);
+            auto rootObject = encoder->bindPipeline(pipelineState);
+
+            gfx::Viewport viewport = {};
+            viewport.maxZ = 1.0f;
+            viewport.extentX = kWidth;
+            viewport.extentY = kHeight;
+            encoder->setViewportAndScissor(viewport);
+
+            uint32_t startIndex = 0;
+            int32_t startVertex = 0;
+            uint32_t startInstanceLocation = 0;
+
+            encoder->setVertexBuffer(0, vertexBuffer, sizeof(Vertex));
+            encoder->setVertexBuffer(1, instanceBuffer, sizeof(Instance));
+            encoder->setVertexBuffer(2, indexBuffer, sizeof(uint32_t));
+            encoder->setPrimitiveTopology(PrimitiveTopology::TriangleList);
+
+            encoder->drawIndexedInstanced(kIndexCount, kInstanceCount, startIndex, startVertex, startInstanceLocation);
+            encoder->endEncoding();
+            commandBuffer->close();
+            queue->executeCommandBuffer(commandBuffer);
+            queue->waitOnHost();
+        }
+
+        void run()
+        {
+            InputElementDesc inputElements[] = {
+                // Vertex buffer data
+                { "POSITIONA", 0, Format::R32G32B32_FLOAT, offsetof(Vertex, position), InputSlotClass::PerVertex, 0 },
+
+                // Instance buffer data
+                { "POSITIONB", 0, Format::R32G32B32_FLOAT, offsetof(Instance, position), InputSlotClass::PerInstance, 1, 1 },
+                { "COLOR",     0, Format::R32G32B32_FLOAT, offsetof(Instance, color),    InputSlotClass::PerInstance, 1, 1 },
+            };
+            inputLayout = device->createInputLayout(inputElements, 3);
+            SLANG_CHECK_ABORT(inputLayout != nullptr);
+
+            vertexBuffer = createVertexBuffer(device);
+            instanceBuffer = createInstanceBuffer(device);
+            indexBuffer = createIndexBuffer(device);
+            colorBuffer = createColorBuffer(device);
+
+            setUpAndRunTest(vertexBuffer, instanceBuffer, indexBuffer);
+
+            // Read texture values back from four specific pixels located within the triangles
+            // and compare against expected values (because testing every single pixel will be too long and tedious
+            // and requires maintaining reference images).
+            ComPtr<ISlangBlob> resultBlob;
+            size_t rowPitch = 0;
+            size_t pixelSize = 0;
+            GFX_CHECK_CALL_ABORT(device->readTextureResource(
+                colorBuffer, ResourceState::CopySource, resultBlob.writeRef(), &rowPitch, &pixelSize));
+            auto result = (float*)resultBlob->getBufferPointer();
+
+            writeImage("C:/Users/lucchen/Documents/dump.hdr", resultBlob, kWidth, kHeight);
+
+            const int kPixelCount = 4;
+            const int kChannelCount = 4;
+            int testXCoords[kPixelCount] = { 64, 192, 64, 192 };
+            int testYCoords[kPixelCount] = { 100, 100, 250, 250 };
+            float testResults[kPixelCount * kChannelCount];
+
+            int cursor = 0;
+            for (int i = 0; i < kPixelCount; ++i)
+            {
+                auto x = testXCoords[i];
+                auto y = testYCoords[i];
+                auto pixelPtr = result + x * kChannelCount + y * rowPitch / sizeof(float);
+                for (int j = 0; j < kChannelCount; ++j)
+                {
+                    testResults[cursor] = pixelPtr[j];
+                    cursor++;
+                }
+            }
+
+            float expectedResult[] = { 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+                                       0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f };
+            compareComputeResultFuzzy(testResults, expectedResult, sizeof(expectedResult));
+        }
+    };
+
+    void drawInstancedTestImpl(IDevice* device, UnitTestContext* context)
+    {
+        DrawInstancedTest test;
+        test.init(device, context);
+        test.run();
+    }
+
+    void drawIndexedInstancedTestImpl(IDevice* device, UnitTestContext* context)
+    {
+        DrawIndexedInstancedTest test;
+        test.init(device, context);
+        test.run();
     }
 
     SLANG_UNIT_TEST(drawInstancedD3D12)
@@ -205,10 +410,20 @@ namespace gfx_test
         runTestImpl(drawInstancedTestImpl, unitTestContext, Slang::RenderApiFlag::D3D12);
     }
 
+    SLANG_UNIT_TEST(drawIndexedInstancedD3D12)
+    {
+        runTestImpl(drawIndexedInstancedTestImpl, unitTestContext, Slang::RenderApiFlag::D3D12);
+    }
+
 #if 0
     SLANG_UNIT_TEST(drawInstancedVulkan)
     {
         runTestImpl(drawInstancedTestImpl, unitTestContext, Slang::RenderApiFlag::Vulkan);
+    }
+
+    SLANG_UNIT_TEST(drawIndexedInstancedVulkan)
+    {
+        runTestImpl(drawIndexedInstancedTestImpl, unitTestContext, Slang::RenderApiFlag::Vulkan);
     }
 #endif
     }

--- a/tools/gfx-unit-test/gfx-test-util.cpp
+++ b/tools/gfx-unit-test/gfx-test-util.cpp
@@ -150,6 +150,14 @@ namespace gfx_test
         SLANG_CHECK(memcmp(resultBlob->getBufferPointer(), expectedResult, expectedBufferSize) == 0);
     }
 
+    void compareComputeResultFuzzy(const float* result, float* expectedResult, size_t expectedBufferSize)
+    {
+        for (int i = 0; i < expectedBufferSize / sizeof(float); ++i)
+        {
+            SLANG_CHECK(abs(result[i] - expectedResult[i]) <= 0.01);
+        }
+    }
+
     void compareComputeResultFuzzy(gfx::IDevice* device, gfx::IBufferResource* buffer, float* expectedResult, size_t expectedBufferSize)
     {
         // Read back the results.
@@ -159,10 +167,7 @@ namespace gfx_test
         SLANG_CHECK(resultBlob->getBufferSize() == expectedBufferSize);
         // Compare results with a tolerance of 0.01.
         auto result = (float*)resultBlob->getBufferPointer();
-        for (int i = 0; i < expectedBufferSize / sizeof(float); ++i)
-        {
-            SLANG_CHECK(abs(result[i] - expectedResult[i]) <= 0.01);
-        }
+        compareComputeResultFuzzy(result, expectedResult, expectedBufferSize);
     }
 
     Slang::ComPtr<gfx::IDevice> createTestingDevice(UnitTestContext* context, Slang::RenderApiFlag::Enum api)

--- a/tools/gfx-unit-test/gfx-test-util.h
+++ b/tools/gfx-unit-test/gfx-test-util.h
@@ -42,6 +42,11 @@ namespace gfx_test
         size_t expectedResultRowPitch,
         size_t rowCount);
 
+    void compareComputeResultFuzzy(
+        const float* result,
+        float* expectedResult,
+        size_t expectedBufferSize);
+
         /// Reads back the content of `buffer` and compares it against `expectedResult` with a set tolerance.
     void compareComputeResultFuzzy(
         gfx::IDevice* device,

--- a/tools/gfx-unit-test/graphics-smoke.slang
+++ b/tools/gfx-unit-test/graphics-smoke.slang
@@ -3,7 +3,8 @@
 // Per-vertex attributes to be assembled from bound vertex buffers.
 struct AssembledVertex
 {
-    float3	position : POSITION;
+    float3	positionA : POSITIONA;
+    float3  positionB : POSITIONB;
     float3	color    : COLOR;
 };
 
@@ -33,7 +34,7 @@ VertexStageOutput vertexMain(
 {
     VertexStageOutput output;
 
-    float3 position = assembledVertex.position;
+    float3 position = assembledVertex.positionA + assembledVertex.positionB;
     float3 color    = assembledVertex.color;
 
     output.coarseVertex.color = color;

--- a/tools/gfx-unit-test/instanced-draw-tests.cpp
+++ b/tools/gfx-unit-test/instanced-draw-tests.cpp
@@ -15,17 +15,19 @@ using namespace gfx;
 
 namespace gfx_test
 {
-    /* static */ Slang::Result writeImage(
-        const char* filename,
-        ISlangBlob* pixels,
-        uint32_t width,
-        uint32_t height)
-    {
-        int stbResult =
-            stbi_write_hdr(filename, width, height, 4, (float*)pixels->getBufferPointer());
-
-        return stbResult ? SLANG_OK : SLANG_FAIL;
-    }
+    // Testing only code used to dump images to visually confirm correctness.
+    // Will be removed once all draw tests are complete.
+//     Slang::Result writeImage(
+//         const char* filename,
+//         ISlangBlob* pixels,
+//         uint32_t width,
+//         uint32_t height)
+//     {
+//         int stbResult =
+//             stbi_write_hdr(filename, width, height, 4, (float*)pixels->getBufferPointer());
+// 
+//         return stbResult ? SLANG_OK : SLANG_FAIL;
+//     }
 
     struct Vertex
     {

--- a/tools/gfx-unit-test/instanced-draw-tests.cpp
+++ b/tools/gfx-unit-test/instanced-draw-tests.cpp
@@ -216,7 +216,7 @@ namespace gfx_test
             GFX_CHECK_CALL_ABORT(device->createFramebuffer(framebufferDesc, framebuffer.writeRef()));
         }
 
-        void getTestResults(int pixelCount, int channelCount, const int* testXCoords, const int* testYCoords, float* testResults)
+        void checkTestResults(int pixelCount, int channelCount, const int* testXCoords, const int* testYCoords, float* testResults)
         {
             // Read texture values back from four specific pixels located within the triangles
             // and compare against expected values (because testing every single pixel will be too long and tedious
@@ -243,6 +243,10 @@ namespace gfx_test
                     cursor++;
                 }
             }
+
+            float expectedResult[] = { 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+                                       0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f };
+            compareComputeResultFuzzy(testResults, expectedResult, sizeof(expectedResult));
         }
     };
 
@@ -289,11 +293,7 @@ namespace gfx_test
             int testYCoords[kPixelCount] = { 100, 100, 250, 250 };
             float testResults[kPixelCount * kChannelCount];
 
-            getTestResults(kPixelCount, kChannelCount, testXCoords, testYCoords, testResults);
-
-            float expectedResult[] = { 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f,
-                                       0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f };
-            compareComputeResultFuzzy(testResults, expectedResult, sizeof(expectedResult));
+            checkTestResults(kPixelCount, kChannelCount, testXCoords, testYCoords, testResults);
         }
     };
 
@@ -346,11 +346,7 @@ namespace gfx_test
             int testYCoords[kPixelCount] = { 32, 100, 150, 250 };
             float testResults[kPixelCount * kChannelCount];
 
-            getTestResults(kPixelCount, kChannelCount, testXCoords, testYCoords, testResults);
-
-            float expectedResult[] = { 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f,
-                                       0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f };
-            compareComputeResultFuzzy(testResults, expectedResult, sizeof(expectedResult));
+            checkTestResults(kPixelCount, kChannelCount, testXCoords, testYCoords, testResults);
         }
     };
 
@@ -428,11 +424,7 @@ namespace gfx_test
             int testYCoords[kPixelCount] = { 100, 100, 250, 250 };
             float testResults[kPixelCount * kChannelCount];
 
-            getTestResults(kPixelCount, kChannelCount, testXCoords, testYCoords, testResults);
-
-            float expectedResult[] = { 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f,
-                                       0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f };
-            compareComputeResultFuzzy(testResults, expectedResult, sizeof(expectedResult));
+            checkTestResults(kPixelCount, kChannelCount, testXCoords, testYCoords, testResults);
         }
     };
 
@@ -513,11 +505,7 @@ namespace gfx_test
             int testYCoords[kPixelCount] = { 32, 100, 150, 250 };
             float testResults[kPixelCount * kChannelCount];
 
-            getTestResults(kPixelCount, kChannelCount, testXCoords, testYCoords, testResults);
-
-            float expectedResult[] = { 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f,
-                                       0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f };
-            compareComputeResultFuzzy(testResults, expectedResult, sizeof(expectedResult));
+            checkTestResults(kPixelCount, kChannelCount, testXCoords, testYCoords, testResults);
         }
     };
 


### PR DESCRIPTION
Changes:
- Renamed draw-instanced-test.cpp to instanced-draw-tests.cpp and factored out all shared boilerplate code into a base test class
- Added tests for `drawInstanced()`, `drawIndexedInstanced()`, `drawIndirect()`, and `drawIndexedIndirect()`
- Moved the required command signatures for indirect draw calls into `D3D12Device` and moved initialization of these signatures into `D3D12Device::initialize()`

This PR is currently still missing the implementation of `readTextureResource()` for Vulkan, which is required for checking test results. All D3D12 tests should work correctly.