### PR TITLE
Cleanup refactoring work around the IR builder

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1209,8 +1209,7 @@ struct SPIRVEmitContext
     {
         if (!inst)
         {
-            IRBuilder builder;
-            builder.sharedBuilder = &m_sharedIRBuilder;
+            IRBuilder builder(m_sharedIRBuilder);
             builder.setInsertInto(m_irModule->getModuleInst());
             inst = builder.getVectorType(
                 builder.getBasicType(baseType),
@@ -1970,8 +1969,7 @@ struct SPIRVEmitContext
         {
             return result;
         }
-        IRBuilder builder;
-        builder.sharedBuilder = &m_sharedIRBuilder;
+        IRBuilder builder(m_sharedIRBuilder);
         builder.setInsertBefore(type);
         auto ptrType = as<IRPtrTypeBase>(type);
         SLANG_ASSERT(ptrType && "`getBuiltinGlobalVar`: `type` must be ptr type.");
@@ -1995,8 +1993,7 @@ struct SPIRVEmitContext
 
     SpvInst* maybeEmitSystemVal(IRInst* inst)
     {
-        IRBuilder builder;
-        builder.sharedBuilder = &m_sharedIRBuilder;
+        IRBuilder builder(m_sharedIRBuilder);
         builder.setInsertBefore(inst);
         if (auto layout = getVarLayout(inst))
         {
@@ -2214,8 +2211,7 @@ struct SPIRVEmitContext
         {
             for (auto storageClass : snippet->usedResultTypeStorageClasses)
             {
-                IRBuilder builder;
-                builder.sharedBuilder = &m_sharedIRBuilder;
+                IRBuilder builder(m_sharedIRBuilder);
                 builder.setInsertBefore(inst);
                 auto newPtrType = builder.getPtrType(
                     oldPtrType->getOp(), oldPtrType->getValueType(), storageClass);
@@ -2234,8 +2230,7 @@ struct SPIRVEmitContext
         if (m_spvSnippetConstantInsts.TryGetValue(constant, result))
             return result;
 
-        IRBuilder builder;
-        builder.sharedBuilder = &m_sharedIRBuilder;
+        IRBuilder builder(m_sharedIRBuilder);
         builder.setInsertInto(m_irModule->getModuleInst());
         switch (constant.type)
         {
@@ -2282,8 +2277,7 @@ struct SPIRVEmitContext
     // Emit SPV Inst that represents a type defined in a SpvSnippet.
     void emitSpvSnippetASMTypeOperand(SpvSnippet::ASMType type)
     {
-        IRBuilder builder;
-        builder.sharedBuilder = &m_sharedIRBuilder;
+        IRBuilder builder(m_sharedIRBuilder);
         builder.setInsertInto(m_irModule->getModuleInst());
         IRType* irType = nullptr;
         switch (type)
@@ -2449,8 +2443,7 @@ struct SPIRVEmitContext
 
     SpvInst* emitFieldAddress(SpvInstParent* parent, IRFieldAddress* fieldAddress)
     {
-        IRBuilder builder;
-        builder.sharedBuilder = &m_sharedIRBuilder;
+        IRBuilder builder(m_sharedIRBuilder);
         builder.setInsertBefore(fieldAddress);
 
         auto base = fieldAddress->getBase();
@@ -2493,8 +2486,7 @@ struct SPIRVEmitContext
 
     SpvInst* emitFieldExtract(SpvInstParent* parent, IRFieldExtract* inst)
     {
-        IRBuilder builder;
-        builder.sharedBuilder = &m_sharedIRBuilder;
+        IRBuilder builder(m_sharedIRBuilder);
         builder.setInsertBefore(inst);
 
         IRStructType* baseStructType = as<IRStructType>(inst->getBase()->getDataType());
@@ -2566,8 +2558,7 @@ struct SPIRVEmitContext
         }
         SLANG_ASSERT(baseArrayType && "getElement require base to be an array.");
 
-        IRBuilder builder;
-        builder.sharedBuilder = &m_sharedIRBuilder;
+        IRBuilder builder(m_sharedIRBuilder);
         builder.setInsertBefore(inst);
 
         auto ptr = emitInst(

--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -52,8 +52,7 @@ namespace Slang
             if (auto typeInfo = generatedAnyValueTypes.TryGetValue(size))
                 return typeInfo->Ptr();
             RefPtr<AnyValueTypeInfo> info = new AnyValueTypeInfo();
-            IRBuilder builder;
-            builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
+            IRBuilder builder(sharedContext->sharedBuilderStorage);
             builder.setInsertBefore(type);
             auto structType = builder.createStructType();
             info->type = structType;
@@ -344,8 +343,7 @@ namespace Slang
 
         IRFunc* generatePackingFunc(IRType* type, IRAnyValueType* anyValueType)
         {
-            IRBuilder builder;
-            builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
+            IRBuilder builder(sharedContext->sharedBuilderStorage);
             builder.setInsertBefore(type);
             auto anyValInfo = ensureAnyValueType(anyValueType);
 
@@ -507,8 +505,7 @@ namespace Slang
 
         IRFunc* generateUnpackingFunc(IRType* type, IRAnyValueType* anyValueType)
         {
-            IRBuilder builder;
-            builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
+            IRBuilder builder(sharedContext->sharedBuilderStorage);
             builder.setInsertBefore(type);
             auto anyValInfo = ensureAnyValueType(anyValueType);
 
@@ -563,9 +560,8 @@ namespace Slang
             auto func = ensureMarshallingFunc(
                 operand->getDataType(),
                 cast<IRAnyValueType>(packInst->getDataType()));
-            IRBuilder builderStorage;
+            IRBuilder builderStorage(sharedContext->sharedBuilderStorage);
             auto builder = &builderStorage;
-            builder->sharedBuilder = &sharedContext->sharedBuilderStorage;
             builder->setInsertBefore(packInst);
             auto callInst = builder->emitCallInst(packInst->getDataType(), func.packFunc, 1, &operand);
             packInst->replaceUsesWith(callInst);
@@ -578,9 +574,8 @@ namespace Slang
             auto func = ensureMarshallingFunc(
                 unpackInst->getDataType(),
                 cast<IRAnyValueType>(operand->getDataType()));
-            IRBuilder builderStorage;
+            IRBuilder builderStorage(sharedContext->sharedBuilderStorage);
             auto builder = &builderStorage;
-            builder->sharedBuilder = &sharedContext->sharedBuilderStorage;
             builder->setInsertBefore(unpackInst);
             auto callInst = builder->emitCallInst(unpackInst->getDataType(), func.unpackFunc, 1, &operand);
             unpackInst->replaceUsesWith(callInst);
@@ -612,8 +607,7 @@ namespace Slang
             // generate along the way.
             //
             SharedIRBuilder* sharedBuilder = &sharedContext->sharedBuilderStorage;
-            sharedBuilder->module = sharedContext->module;
-            sharedBuilder->session = sharedContext->module->session;
+            sharedBuilder->init(sharedContext->module);
 
             sharedContext->addToWorkList(sharedContext->module->getModuleInst());
 

--- a/source/slang/slang-ir-augment-make-existential.cpp
+++ b/source/slang/slang-ir-augment-make-existential.cpp
@@ -24,9 +24,8 @@ struct AugmentMakeExistentialContext
 
     void processMakeExistential(IRMakeExistential* inst)
     {
-        IRBuilder builderStorage;
+        IRBuilder builderStorage(sharedBuilderStorage);
         auto builder = &builderStorage;
-        builder->sharedBuilder = &sharedBuilderStorage;
         builder->setInsertBefore(inst);
 
         auto augInst = builder->emitMakeExistentialWithRTTI(
@@ -53,8 +52,7 @@ struct AugmentMakeExistentialContext
     void processModule()
     {
         SharedIRBuilder* sharedBuilder = &sharedBuilderStorage;
-        sharedBuilder->module = module;
-        sharedBuilder->session = module->session;
+        sharedBuilder->init(module);
 
         addToWorkList(module->getModuleInst());
 

--- a/source/slang/slang-ir-bind-existentials.cpp
+++ b/source/slang/slang-ir-bind-existentials.cpp
@@ -275,12 +275,8 @@ struct BindExistentialSlots
 
         auto fullType = inst->getFullType();
 
-        SharedIRBuilder sharedBuilder;
-        sharedBuilder.session = module->getSession();
-        sharedBuilder.module = module;
-
-        IRBuilder builder;
-        builder.sharedBuilder = &sharedBuilder;
+        SharedIRBuilder sharedBuilder(module);
+        IRBuilder builder(sharedBuilder);
 
         // Every argument that is filling an existential
         // type param/slot comprises both a type and

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -39,10 +39,8 @@ struct ByteAddressBufferLegalizationContext
     //
     void processModule(IRModule* module)
     {
-        m_sharedBuilder.session = m_session;
-        m_sharedBuilder.module = module;
-
-        m_builder.sharedBuilder = &m_sharedBuilder;
+        m_sharedBuilder.init(module);
+        m_builder.init(m_sharedBuilder);
 
         processInstRec(module->getModuleInst());
     }
@@ -704,8 +702,7 @@ struct ByteAddressBufferLegalizationContext
         // of legalizing a load or store, and we don't want to mess with
         // the insertion location of `m_builder`.
         //
-        IRBuilder paramBuilder;
-        paramBuilder.sharedBuilder = &m_sharedBuilder;
+        IRBuilder paramBuilder(m_sharedBuilder);
         paramBuilder.setInsertBefore(byteAddressBufferParam);
 
         auto structuredBufferParam = paramBuilder.createGlobalParam(structuredBufferParamType);

--- a/source/slang/slang-ir-clone.cpp
+++ b/source/slang/slang-ir-clone.cpp
@@ -134,9 +134,8 @@ static void _cloneInstDecorationsAndChildren(
     // We will set up an IR builder that inserts
     // into the new parent instruction.
     //
-    IRBuilder builderStorage;
+    IRBuilder builderStorage(sharedBuilder);
     auto builder = &builderStorage;
-    builder->sharedBuilder = sharedBuilder;
     builder->setInsertInto(newInst);
 
     // If `newInst` already has non-decoration children, we want to
@@ -264,7 +263,7 @@ IRInst* cloneInst(
     env->mapOldValToNew.Add(oldInst, newInst);
 
     cloneInstDecorationsAndChildren(
-        env, builder->sharedBuilder, oldInst, newInst);
+        env, builder->getSharedBuilder(), oldInst, newInst);
 
     return newInst;
 }
@@ -274,11 +273,8 @@ void cloneDecoration(
     IRInst*         newParent,
     IRModule*       module)
 {
-    SharedIRBuilder sharedBuilder;
-    sharedBuilder.module = module;
-
-    IRBuilder builder;
-    builder.sharedBuilder = &sharedBuilder;
+    SharedIRBuilder sharedBuilder(module);
+    IRBuilder builder(sharedBuilder);
 
     if(auto first = newParent->getFirstDecorationOrChild())
         builder.setInsertBefore(first);

--- a/source/slang/slang-ir-collect-global-uniforms.cpp
+++ b/source/slang/slang-ir-collect-global-uniforms.cpp
@@ -122,14 +122,9 @@ struct CollectGlobalUniformParametersContext
         // the collected global-scope parameters. The `IRBuilder` we construct
         // for this will also be used when replacing the individual parameters.
         //
-        SharedIRBuilder sharedBuilder;
-        sharedBuilder.module = this->module;
-        sharedBuilder.session = module->session;
-
-        IRBuilder builderStorage;
+        SharedIRBuilder sharedBuilder(module);
+        IRBuilder builderStorage(sharedBuilder);
         IRBuilder* builder = &builderStorage;
-
-        builder->sharedBuilder = &sharedBuilder;
         builder->setInsertInto(module->getModuleInst());
 
         // The packaged-up global parameters will be turned into fields of

--- a/source/slang/slang-ir-deduplicate.cpp
+++ b/source/slang/slang-ir-deduplicate.cpp
@@ -18,9 +18,9 @@ namespace Slang
         {
             IRConstantKey key = { value };
             value->setFullType((IRType*)addValue(value->getFullType()));
-            if (auto newValue = builder->constantMap.TryGetValue(key))
+            if (auto newValue = builder->getConstantMap().TryGetValue(key))
                 return *newValue;
-            builder->constantMap[key] = value;
+            builder->getConstantMap()[key] = value;
             return value;
         }
         IRInst* addTypeValue(IRInst* value)
@@ -41,9 +41,9 @@ namespace Slang
             }
             value->setFullType((IRType*)addValue(value->getFullType()));
             IRInstKey key = { value };
-            if (auto newValue = builder->globalValueNumberingMap.TryGetValue(key))
+            if (auto newValue = builder->getGlobalValueNumberingMap().TryGetValue(key))
                 return *newValue;
-            builder->globalValueNumberingMap[key] = value;
+            builder->getGlobalValueNumberingMap()[key] = value;
             return value;
         }
     };
@@ -52,9 +52,9 @@ namespace Slang
         DeduplicateContext context;
         context.builder = this;
         bool changed = true;
-        constantMap.Clear();
-        globalValueNumberingMap.Clear();
-        for (auto inst : module->getGlobalInsts())
+        m_constantMap.Clear();
+        m_globalValueNumberingMap.Clear();
+        for (auto inst : m_module->getGlobalInsts())
         {
             if (auto constVal = as<IRConstant>(inst))
             {
@@ -62,7 +62,7 @@ namespace Slang
             }
         }
         List<IRInst*> instToRemove;
-        for (auto inst : module->getGlobalInsts())
+        for (auto inst : m_module->getGlobalInsts())
         {
             if (as<IRType>(inst))
             {

--- a/source/slang/slang-ir-generics-lowering-context.cpp
+++ b/source/slang/slang-ir-generics-lowering-context.cpp
@@ -57,9 +57,8 @@ namespace Slang
         IRInst* result = nullptr;
         if (mapTypeToRTTIObject.TryGetValue(typeInst, result))
             return result;
-        IRBuilder builderStorage;
+        IRBuilder builderStorage(sharedBuilderStorage);
         auto builder = &builderStorage;
-        builder->sharedBuilder = &sharedBuilderStorage;
         builder->setInsertBefore(typeInst->next);
 
         result = builder->emitMakeRTTIObject(typeInst);

--- a/source/slang/slang-ir-generics-lowering-context.h
+++ b/source/slang/slang-ir-generics-lowering-context.h
@@ -107,8 +107,7 @@ namespace Slang
     void workOnModule(SharedGenericsLoweringContext* sharedContext, const TFunc& func)
     {
         SharedIRBuilder* sharedBuilder = &sharedContext->sharedBuilderStorage;
-        sharedBuilder->module = sharedContext->module;
-        sharedBuilder->session = sharedContext->module->session;
+        sharedBuilder->init(sharedContext->module);
 
         sharedContext->addToWorkList(sharedContext->module->getModuleInst());
 

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -17,14 +17,9 @@ IRGlobalParam* addGlobalParam(
     IRModule*   module,
     IRType*     valueType)
 {
-    auto session = module->session;
+    SharedIRBuilder shared(module);
+    IRBuilder builder(shared);
 
-    SharedIRBuilder shared;
-    shared.module = module;
-    shared.session = session;
-
-    IRBuilder builder;
-    builder.sharedBuilder = &shared;
     return builder.createGlobalParam(valueType);
 }
 
@@ -1597,8 +1592,7 @@ void legalizeEntryPointParameterForGLSL(
             // disrupt the source location it is using for inserting
             // temporary variables at the top of the function.
             //
-            IRBuilder terminatorBuilder;
-            terminatorBuilder.sharedBuilder = builder->sharedBuilder;
+            IRBuilder terminatorBuilder(builder->getSharedBuilder());
             terminatorBuilder.setInsertBefore(terminatorInst);
 
             // Assign from the local variabel to the global output
@@ -1668,11 +1662,8 @@ void legalizeEntryPointForGLSL(
     //
     // TODO: make some of these free functions...
     //
-    SharedIRBuilder shared;
-    shared.module = module;
-    shared.session = session;
-    IRBuilder builder;
-    builder.sharedBuilder = &shared;
+    SharedIRBuilder shared(module);
+    IRBuilder builder(shared);
     builder.setInsertInto(func);
 
     context.builder = &builder;

--- a/source/slang/slang-ir-inline.cpp
+++ b/source/slang/slang-ir-inline.cpp
@@ -230,11 +230,8 @@ struct InliningPassBase
         // and will set it up to insert before the `call` that
         // is going to be replaced.
         //
-        SharedIRBuilder sharedBuilder;
-        sharedBuilder.session = m_module->getSession();
-        sharedBuilder.module = m_module;
-        IRBuilder builder;
-        builder.sharedBuilder = &sharedBuilder;
+        SharedIRBuilder sharedBuilder(m_module);
+        IRBuilder builder(sharedBuilder);
         builder.setInsertBefore(call);
 
         // If the callee is a generic function, then we will

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -1856,12 +1856,6 @@ public:
     IRBuilder()
     {}
 
-    IRBuilder(IRBuilder const& builder)
-        : m_sharedBuilder(builder.getSharedBuilder())
-        , m_insertLoc(builder.getInsertLoc())
-        , m_sourceLocInfo(builder.getSourceLocInfo())
-    {}
-
     explicit IRBuilder(SharedIRBuilder* sharedBuilder)
         : m_sharedBuilder(sharedBuilder)
     {}

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -1787,79 +1787,200 @@ struct IRConstantKey
 
 struct SharedIRBuilder
 {
+public:
     SharedIRBuilder()
     {}
 
-    SharedIRBuilder(Session* session, IRModule* module)
-        : session(session)
-        , module(module)
-    {}
-
     explicit SharedIRBuilder(IRModule* module)
-        : session(module->getSession())
-        , module(module)
-    {}
-
-    // The parent compilation session
-    Session* session;
-    Session* getSession()
     {
-        return session;
+        init(module);
     }
 
-    // The module that will own all of the IR
-    IRModule*       module;
+    void init(IRModule* module)
+    {
+        m_module = module;
+        m_session = module->getSession();
 
-    Dictionary<IRInstKey,       IRInst*>    globalValueNumberingMap;
-    Dictionary<IRConstantKey,   IRConstant*>    constantMap;
+        m_globalValueNumberingMap.Clear();
+        m_constantMap.Clear();
+    }
+
+    IRModule* getModule()
+    {
+        return m_module;
+    }
+
+    Session* getSession()
+    {
+        return m_session;
+    }
 
     void insertBlockAlongEdge(IREdge const& edge);
 
     // Rebuilds `globalValueNumberingMap`. This is necessary if any existing
     // keys are modified (thus its hash code is changed).
     void deduplicateAndRebuildGlobalNumberingMap();
+
+    typedef Dictionary<IRInstKey, IRInst*> GlobalValueNumberingMap;
+    typedef Dictionary<IRConstantKey, IRConstant*> ConstantMap;
+
+    GlobalValueNumberingMap& getGlobalValueNumberingMap() { return m_globalValueNumberingMap; }
+    ConstantMap& getConstantMap() { return m_constantMap; }
+
+private:
+    // The module that will own all of the IR
+    IRModule* m_module;
+
+    // The parent compilation session
+    Session* m_session;
+
+    GlobalValueNumberingMap m_globalValueNumberingMap;
+    ConstantMap m_constantMap;
 };
 
 struct IRBuilderSourceLocRAII;
 
 struct IRBuilder
 {
+private:
+        /// Shared state for all IR builders working on the same module
+    SharedIRBuilder*    m_sharedBuilder = nullptr;
+
+        /// Default location for inserting new instructions as they are emitted
+    IRInsertLoc m_insertLoc;
+
+        /// Information that controls how source locations are associatd with instructions that get emitted
+    IRBuilderSourceLocRAII* m_sourceLocInfo = nullptr;
+
+public:
     IRBuilder()
     {}
 
-    IRBuilder(SharedIRBuilder* sharedBuilder)
-        : sharedBuilder(sharedBuilder)
+    IRBuilder(IRBuilder const& builder)
+        : m_sharedBuilder(builder.getSharedBuilder())
+        , m_insertLoc(builder.getInsertLoc())
+        , m_sourceLocInfo(builder.getSourceLocInfo())
     {}
 
-    // Shared state for all IR builders working on the same module
-    SharedIRBuilder*    sharedBuilder = nullptr;
+    explicit IRBuilder(SharedIRBuilder* sharedBuilder)
+        : m_sharedBuilder(sharedBuilder)
+    {}
 
-    Session* getSession()
+    explicit IRBuilder(SharedIRBuilder& sharedBuilder)
+        : m_sharedBuilder(&sharedBuilder)
+    {}
+
+    void init(SharedIRBuilder* sharedBuilder)
     {
-        return sharedBuilder->getSession();
+        *this = IRBuilder(sharedBuilder);
     }
 
-    IRModule* getModule() { return sharedBuilder->module; }
+    void init(SharedIRBuilder& sharedBuilder)
+    {
+        *this = IRBuilder(sharedBuilder);
+    }
 
-    // The current parent being inserted into (this might
-    // be the global scope, a function, a block inside
-    // a function, etc.)
-    IRInst*   insertIntoParent = nullptr;
-    //
-    // An instruction in the current parent that we should insert before
-    IRInst*         insertBeforeInst = nullptr;
+    SharedIRBuilder* getSharedBuilder() const
+    {
+        return m_sharedBuilder;
+    }
+
+    Session* getSession() const
+    {
+        return m_sharedBuilder->getSession();
+    }
+
+    IRModule* getModule() const
+    {
+        return m_sharedBuilder->getModule();
+    }
+
+    IRInsertLoc const& getInsertLoc() const { return m_insertLoc; }
+
+    void setInsertLoc(IRInsertLoc const& loc) { m_insertLoc = loc; }
 
     // Get the current basic block we are inserting into (if any)
-    IRBlock*                getBlock();
+    IRBlock*                getBlock() { return m_insertLoc.getBlock(); }
 
     // Get the current function (or other value with code)
     // that we are inserting into (if any).
-    IRGlobalValueWithCode*  getFunc();
+    IRGlobalValueWithCode*  getFunc() { return m_insertLoc.getFunc(); }
 
-    void setInsertInto(IRInst* insertInto);
-    void setInsertBefore(IRInst* insertBefore);
+    void setInsertInto(IRInst* insertInto) { setInsertLoc(IRInsertLoc::atEnd(insertInto)); }
+    void setInsertBefore(IRInst* insertBefore) { setInsertLoc(IRInsertLoc::before(insertBefore)); }
 
-    IRBuilderSourceLocRAII* sourceLocInfo = nullptr;
+    void setInsertInto(IRModule* module) { setInsertInto(module->getModuleInst()); }
+
+    IRBuilderSourceLocRAII* getSourceLocInfo() const { return m_sourceLocInfo; }
+    void setSourceLocInfo(IRBuilderSourceLocRAII* sourceLocInfo) { m_sourceLocInfo = sourceLocInfo; }
+
+    //
+    // Low-level interface for instruction creation/insertion.
+    //
+
+        /// Either find or create an `IRConstant` that matches the value of `keyInst`.
+        ///
+        /// This operation will re-use an existing constant with the same type and
+        /// value if one can be found (currently identified through the `SharedIRBuilder`).
+        /// Otherwise it will create a new `IRConstant` with the given value and register it.
+        ///
+    IRConstant* _findOrEmitConstant(
+        IRConstant&     keyInst);
+
+        /// Create a new instruction with the given `type` and `op`, with an allocated
+        /// size of at least `minSizeInBytes`, and with its operand list initialized
+        /// from the provided lists of "fixed" and "variable" operands.
+        ///
+        /// The `fixedArgs` array must contain `fixedArgCount` operands, and will be
+        /// the initial operands in the operand list of the instruction.
+        ///
+        /// After the fixed arguments, the instruction may have zero or more additional
+        /// lists of "variable" operands, which are all concatenated. The total number
+        /// of such additional lists is given by `varArgsListCount`. The number of
+        /// operands in list `i` is given by `listArgCounts[i]`, and the arguments in
+        /// list `i` are pointed to by `listArgs[i]`.
+        ///
+        /// The allocation for the instruction created will be at least `minSizeInBytes`,
+        /// but may be larger if the total number of operands provided implies a larger
+        /// size.
+        ///
+        /// Note: This is an extremely low-level operation and clients of an `IRBuilder`
+        /// should not be using it when other options are available.
+        ///
+    IRInst* _createInst(
+        size_t                  minSizeInBytes,
+        IRType*                 type,
+        IROp                    op,
+        Int                     fixedArgCount,
+        IRInst* const*          fixedArgs,
+        Int                     varArgListCount,
+        Int const*              listArgCounts,
+        IRInst* const* const*   listArgs);
+
+
+
+        /// Create a new instruction with the given `type` and `op`, with an allocated
+        /// size of at least `minSizeInBytes`, and with zero operands.
+        ///
+    IRInst* _createInst(
+        size_t          minSizeInBytes,
+        IRType*         type,
+        IROp            op)
+    {
+        return _createInst(minSizeInBytes, type, op, 0, nullptr, 0, nullptr, nullptr);
+    }
+
+        /// Attempt to attach a useful source location to `inst`.
+        ///
+        /// This operation looks at the source location information that has been
+        /// attached to the builder. If it finds a valid source location, it will
+        /// attach that location to `inst`.
+        ///
+    void _maybeSetSourceLoc(
+        IRInst*     inst);
+
+
+    //
 
     void addInst(IRInst* inst);
 
@@ -2188,8 +2309,6 @@ struct IRBuilder
         IRInst*         operand,
         UInt            operandCount,
         IRInst* const*  operands);
-
-    IRModule* createModule();
 
     IRFunc* createFunc();
     IRGlobalVar* createGlobalVar(
@@ -2716,14 +2835,14 @@ struct IRBuilderSourceLocRAII
         , sourceLoc(sourceLoc)
         , next(nullptr)
     {
-        next = builder->sourceLocInfo;
-        builder->sourceLocInfo = this;
+        next = builder->getSourceLocInfo();
+        builder->setSourceLocInfo(this);
     }
 
     ~IRBuilderSourceLocRAII()
     {
-        SLANG_ASSERT(builder->sourceLocInfo == this);
-        builder->sourceLocInfo = next;
+        SLANG_ASSERT(builder->getSourceLocInfo() == this);
+        builder->setSourceLocInfo(next);
     }
 };
 

--- a/source/slang/slang-ir-layout.cpp
+++ b/source/slang/slang-ir-layout.cpp
@@ -153,12 +153,9 @@ static Result _calcNaturalSizeAndAlignment(
                     // cache the field offset on the IR field
                     // instruction.
                     //
-                    SharedIRBuilder sharedBuilder;
-                    sharedBuilder.module = module;
-                    sharedBuilder.session = module->getSession();
+                    SharedIRBuilder sharedBuilder(module);
 
-                    IRBuilder builder;
-                    builder.sharedBuilder = &sharedBuilder;
+                    IRBuilder builder(sharedBuilder);
 
                     auto intType = builder.getIntType();
                     builder.addDecoration(
@@ -203,12 +200,8 @@ static Result _calcNaturalSizeAndAlignment(
             auto matType = cast<IRMatrixType>(type);
             auto rowCount = getIntegerValueFromInst(matType->getRowCount());
             auto colCount = getIntegerValueFromInst(matType->getColumnCount());
-            SharedIRBuilder sharedBuilder;
-            sharedBuilder.module = type->getModule();
-            sharedBuilder.session = sharedBuilder.module->getSession();
-
-            IRBuilder builder;
-            builder.sharedBuilder = &sharedBuilder;
+            SharedIRBuilder sharedBuilder(type->getModule());
+            IRBuilder builder(sharedBuilder);
 
             return _calcNaturalArraySizeAndAlignment(
                 target, matType->getElementType(),
@@ -254,12 +247,9 @@ Result getNaturalSizeAndAlignment(TargetRequest* target, IRType* type, IRSizeAnd
 
     if( auto module = type->getModule() )
     {
-        SharedIRBuilder sharedBuilder;
-        sharedBuilder.module = module;
-        sharedBuilder.session = module->getSession();
+        SharedIRBuilder sharedBuilder(module);
 
-        IRBuilder builder;
-        builder.sharedBuilder = &sharedBuilder;
+        IRBuilder builder(sharedBuilder);
 
         auto intType = builder.getIntType();
         builder.addDecoration(

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -99,11 +99,10 @@ IRTypeLegalizationContext::IRTypeLegalizationContext(
     module = inModule;
 
     auto sharedBuilder = &sharedBuilderStorage;
-    sharedBuilder->session = session;
-    sharedBuilder->module = module;
+    sharedBuilder->init(module);
 
     builder = &builderStorage;
-    builder->sharedBuilder = sharedBuilder;
+    builder->init(sharedBuilder);
 }
 
 static void registerLegalizedValue(

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -203,9 +203,7 @@ public:
         // shared builder to avoid unnecessary duplication of
         // types/constants.
         //
-        SharedIRBuilder sharedBuilderStorage;
-        sharedBuilderStorage.module = module;
-        sharedBuilderStorage.session = module->getSession();
+        SharedIRBuilder sharedBuilderStorage(module);
         m_sharedBuilder = &sharedBuilderStorage;
 
         // Once the basic initialization is done, we will allow

--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -1279,24 +1279,24 @@ void insertGlobalValueSymbols(
 void initializeSharedSpecContext(
     IRSharedSpecContext*    sharedContext,
     Session*                session,
-    IRModule*               module,
+    IRModule*               inModule,
     CodeGenTarget           target,
     TargetRequest*          targetReq)
 {
 
     SharedIRBuilder* sharedBuilder = &sharedContext->sharedBuilderStorage;
-    sharedBuilder->module = nullptr;
-    sharedBuilder->session = session;
 
     IRBuilder* builder = &sharedContext->builderStorage;
-    builder->sharedBuilder = sharedBuilder;
 
+    RefPtr<IRModule> module = inModule;
     if( !module )
     {
-        module = builder->createModule();
+        module = IRModule::create(session);
     }
 
-    sharedBuilder->module = module;
+    sharedBuilder->init(module);
+    builder->init(sharedBuilder);
+
     sharedContext->module = module;
     sharedContext->target = target;
     sharedContext->targetReq = targetReq;
@@ -1399,7 +1399,7 @@ LinkedIR linkIR(
         {
             findGlobalHashedStringLiterals(irModule, pool);
         }
-        addGlobalHashedStringLiterals(pool, *builder.sharedBuilder);
+        addGlobalHashedStringLiterals(pool, *builder.getSharedBuilder());
     }
 
     // Set up shared and builder insert point

--- a/source/slang/slang-ir-lower-bit-cast.cpp
+++ b/source/slang/slang-ir-lower-bit-cast.cpp
@@ -43,8 +43,7 @@ struct BitCastLoweringContext
     void processModule()
     {
         SharedIRBuilder* sharedBuilder = &sharedBuilderStorage;
-        sharedBuilder->module = module;
-        sharedBuilder->session = module->session;
+        sharedBuilder->init(module);
 
         // Deduplicate equivalent types.
         sharedBuilder->deduplicateAndRebuildGlobalNumberingMap();
@@ -239,8 +238,7 @@ struct BitCastLoweringContext
             return;
         }
         // Enumerate all fields in to-type and obtain its value from operand object.
-        IRBuilder builder;
-        builder.sharedBuilder = &sharedBuilderStorage;
+        IRBuilder builder(sharedBuilderStorage);
         builder.setInsertBefore(inst);
         auto finalObject = readObject(builder, operand, toType, 0);
         inst->replaceUsesWith(finalObject);

--- a/source/slang/slang-ir-lower-existential.cpp
+++ b/source/slang/slang-ir-lower-existential.cpp
@@ -16,9 +16,8 @@ namespace Slang
 
         void processMakeExistential(IRMakeExistentialWithRTTI* inst)
         {
-            IRBuilder builderStorage;
+            IRBuilder builderStorage(sharedContext->sharedBuilderStorage);
             auto builder = &builderStorage;
-            builder->sharedBuilder = &sharedContext->sharedBuilderStorage;
             builder->setInsertBefore(inst);
 
             auto value = inst->getWrappedValue();
@@ -52,9 +51,8 @@ namespace Slang
         // existential value.
         void processCreateExistentialObject(IRCreateExistentialObject* inst)
         {
-            IRBuilder builderStorage;
+            IRBuilder builderStorage(sharedContext->sharedBuilderStorage);
             auto builder = &builderStorage;
-            builder->sharedBuilder = &sharedContext->sharedBuilderStorage;
             builder->setInsertBefore(inst);
 
             // The result type of this `createExistentialObject` inst should already
@@ -103,9 +101,8 @@ namespace Slang
 
         void processExtractExistentialElement(IRInst* extractInst, UInt elementId)
         {
-            IRBuilder builderStorage;
+            IRBuilder builderStorage(sharedContext->sharedBuilderStorage);
             auto builder = &builderStorage;
-            builder->sharedBuilder = &sharedContext->sharedBuilderStorage;
             builder->setInsertBefore(extractInst);
 
             auto element = extractTupleElement(builder, extractInst->getOperand(0), elementId);
@@ -130,9 +127,8 @@ namespace Slang
 
         void processGetValueFromBoundInterface(IRGetValueFromBoundInterface* inst)
         {
-            IRBuilder builderStorage;
+            IRBuilder builderStorage(sharedContext->sharedBuilderStorage);
             auto builder = &builderStorage;
-            builder->sharedBuilder = &sharedContext->sharedBuilderStorage;
             builder->setInsertBefore(inst);
 
             // A value of interface will lower as a tuple, and
@@ -212,8 +208,7 @@ namespace Slang
             // generate along the way.
             //
             SharedIRBuilder* sharedBuilder = &sharedContext->sharedBuilderStorage;
-            sharedBuilder->module = sharedContext->module;
-            sharedBuilder->session = sharedContext->module->session;
+            sharedBuilder->init(sharedContext->module);
 
             sharedContext->addToWorkList(sharedContext->module->getModuleInst());
 

--- a/source/slang/slang-ir-lower-generic-call.cpp
+++ b/source/slang/slang-ir-lower-generic-call.cpp
@@ -159,9 +159,8 @@ namespace Slang
             for (UInt i = 0; i < funcType->getParamCount(); i++)
                 paramTypes.add(funcType->getParamType(i));
 
-            IRBuilder builderStorage;
+            IRBuilder builderStorage(sharedContext->sharedBuilderStorage);
             auto builder = &builderStorage;
-            builder->sharedBuilder = &sharedContext->sharedBuilderStorage;
             builder->setInsertBefore(callInst);
 
             // Process the argument list of the call.
@@ -285,9 +284,8 @@ namespace Slang
             if (isBuiltin(interfaceType))
                 return;
 
-            IRBuilder builderStorage;
+            IRBuilder builderStorage(sharedContext->sharedBuilderStorage);
             auto builder = &builderStorage;
-            builder->sharedBuilder = &sharedContext->sharedBuilderStorage;
             builder->setInsertBefore(callInst);
 
             // Create interface dispatch method that bottlenecks the dispatch logic.
@@ -346,8 +344,7 @@ namespace Slang
             // generate along the way.
             //
             SharedIRBuilder* sharedBuilder = &sharedContext->sharedBuilderStorage;
-            sharedBuilder->module = sharedContext->module;
-            sharedBuilder->session = sharedContext->module->session;
+            sharedBuilder->init(sharedContext->module);
 
             sharedContext->addToWorkList(sharedContext->module->getModuleInst());
 

--- a/source/slang/slang-ir-lower-generic-function.cpp
+++ b/source/slang/slang-ir-lower-generic-function.cpp
@@ -45,8 +45,7 @@ namespace Slang
                 return genericValue;
             }
             IRCloneEnv cloneEnv;
-            IRBuilder builder;
-            builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
+            IRBuilder builder(sharedContext->sharedBuilderStorage);
             builder.setInsertBefore(genericParent);
             auto loweredFunc = cast<IRFunc>(cloneInstAndOperands(&cloneEnv, &builder, func));
             auto loweredGenericType =
@@ -155,8 +154,7 @@ namespace Slang
                 return interfaceType;
             List<IRInterfaceRequirementEntry*> newEntries;
 
-            IRBuilder builder;
-            builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
+            IRBuilder builder(sharedContext->sharedBuilderStorage);
             builder.setInsertBefore(interfaceType);
 
             // Translate IRFuncType in interface requirements.
@@ -214,9 +212,8 @@ namespace Slang
         void lowerWitnessTable(IRWitnessTable* witnessTable)
         {
             auto interfaceType = maybeLowerInterfaceType(cast<IRInterfaceType>(witnessTable->getConformanceType()));
-            IRBuilder builderStorage;
+            IRBuilder builderStorage(sharedContext->sharedBuilderStorage);
             auto builder = &builderStorage;
-            builder->sharedBuilder = &sharedContext->sharedBuilderStorage;
             builder->setInsertBefore(witnessTable);
             if (interfaceType != witnessTable->getConformanceType())
             {
@@ -322,8 +319,7 @@ namespace Slang
             // generate along the way.
             //
             SharedIRBuilder* sharedBuilder = &sharedContext->sharedBuilderStorage;
-            sharedBuilder->module = sharedContext->module;
-            sharedBuilder->session = sharedContext->module->session;
+            sharedBuilder->init(sharedContext->module);
 
             sharedContext->addToWorkList(sharedContext->module->getModuleInst());
 

--- a/source/slang/slang-ir-lower-generic-type.cpp
+++ b/source/slang/slang-ir-lower-generic-type.cpp
@@ -29,9 +29,8 @@ namespace Slang
             if (as<IRType>(inst))
                 return;
 
-            IRBuilder builderStorage;
+            IRBuilder builderStorage(sharedContext->sharedBuilderStorage);
             auto builder = &builderStorage;
-            builder->sharedBuilder = &sharedContext->sharedBuilderStorage;
             builder->setInsertBefore(inst);
            
             auto newType = sharedContext->lowerType(builder, inst->getFullType());
@@ -61,8 +60,7 @@ namespace Slang
             // generate along the way.
             //
             SharedIRBuilder* sharedBuilder = &sharedContext->sharedBuilderStorage;
-            sharedBuilder->module = sharedContext->module;
-            sharedBuilder->session = sharedContext->module->session;
+            sharedBuilder->init(sharedContext->module);
 
             sharedContext->addToWorkList(sharedContext->module->getModuleInst());
 

--- a/source/slang/slang-ir-lower-generics.cpp
+++ b/source/slang/slang-ir-lower-generics.cpp
@@ -24,8 +24,7 @@ namespace Slang
         uint32_t id = 0;
         for (auto rtti : sharedContext->mapTypeToRTTIObject)
         {
-            IRBuilder builder;
-            builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
+            IRBuilder builder(sharedContext->sharedBuilderStorage);
             builder.setInsertBefore(rtti.Value);
             IRUse* nextUse = nullptr;
             auto uint2Type = builder.getVectorType(
@@ -56,8 +55,7 @@ namespace Slang
             case kIROp_WitnessTableIDType:
             case kIROp_RTTIHandleType:
                 {
-                    IRBuilder builder;
-                    builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
+                    IRBuilder builder(sharedContext->sharedBuilderStorage);
                     builder.setInsertBefore(inst);
                     auto uint2Type = builder.getVectorType(
                         builder.getUIntType(), builder.getIntValue(builder.getIntType(), 2));
@@ -74,8 +72,7 @@ namespace Slang
     // Remove all interface types from module.
     void cleanUpInterfaceTypes(SharedGenericsLoweringContext* sharedContext)
     {
-        IRBuilder builder;
-        builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
+        IRBuilder builder(sharedContext->sharedBuilderStorage);
         builder.setInsertInto(sharedContext->module->getModuleInst());
         auto dummyInterfaceObj = builder.getIntValue(builder.getIntType(), 0);
         List<IRInst*> interfaceInsts;

--- a/source/slang/slang-ir-lower-reinterpret.cpp
+++ b/source/slang/slang-ir-lower-reinterpret.cpp
@@ -38,8 +38,7 @@ struct ReinterpretLoweringContext
     void processModule()
     {
         SharedIRBuilder* sharedBuilder = &sharedBuilderStorage;
-        sharedBuilder->module = module;
-        sharedBuilder->session = module->session;
+        sharedBuilder->init(module);
 
         // Deduplicate equivalent types.
         sharedBuilder->deduplicateAndRebuildGlobalNumberingMap();
@@ -78,8 +77,7 @@ struct ReinterpretLoweringContext
         }
         SlangInt anyValueSize = Math::Max(fromTypeSize, toTypeSize);
 
-        IRBuilder builder;
-        builder.sharedBuilder = &sharedBuilderStorage;
+        IRBuilder builder(sharedBuilderStorage);
         builder.setInsertBefore(inst);
         auto anyValueType = builder.getAnyValueType(builder.getIntValue(builder.getUIntType(), anyValueSize));
         auto packInst = builder.emitPackAnyValue(

--- a/source/slang/slang-ir-lower-tuple-types.cpp
+++ b/source/slang/slang-ir-lower-tuple-types.cpp
@@ -85,9 +85,8 @@ namespace Slang
 
         void processMakeTuple(IRMakeTuple* inst)
         {
-            IRBuilder builderStorage;
+            IRBuilder builderStorage(sharedBuilderStorage);
             auto builder = &builderStorage;
-            builder->sharedBuilder = &sharedBuilderStorage;
             builder->setInsertBefore(inst);
 
             auto info = getLoweredTupleType(builder, inst->getDataType());
@@ -104,9 +103,8 @@ namespace Slang
 
         void processGetTupleElement(IRGetTupleElement* inst)
         {
-            IRBuilder builderStorage;
+            IRBuilder builderStorage(sharedBuilderStorage);
             auto builder = &builderStorage;
-            builder->sharedBuilder = &sharedBuilderStorage;
             builder->setInsertBefore(inst);
 
             auto base = inst->getTuple();
@@ -123,9 +121,8 @@ namespace Slang
 
         void processTupleType(IRTupleType* inst)
         {
-            IRBuilder builderStorage;
+            IRBuilder builderStorage(sharedBuilderStorage);
             auto builder = &builderStorage;
-            builder->sharedBuilder = &sharedBuilderStorage;
             builder->setInsertBefore(inst);
 
             auto loweredTupleInfo = getLoweredTupleType(builder, inst);
@@ -154,8 +151,7 @@ namespace Slang
         void processModule()
         {
             SharedIRBuilder* sharedBuilder = &sharedBuilderStorage;
-            sharedBuilder->module = module;
-            sharedBuilder->session = module->session;
+            sharedBuilder->init(module);
 
             // Deduplicate equivalent types.
             sharedBuilder->deduplicateAndRebuildGlobalNumberingMap();

--- a/source/slang/slang-ir-restructure-scoping.cpp
+++ b/source/slang/slang-ir-restructure-scoping.cpp
@@ -254,12 +254,9 @@ static void fixValueScopingForInst(
     //
     IRModule* module = regionTree->irCode->getModule();
 
-    SharedIRBuilder sharedBuilder;
-    sharedBuilder.session = module->session;
-    sharedBuilder.module = module;
+    SharedIRBuilder sharedBuilder(module);
 
-    IRBuilder builder;
-    builder.sharedBuilder = &sharedBuilder;
+    IRBuilder builder(sharedBuilder);
 
     // Because we will be changing some of the uses of `def`
     // to use other values while we iterate the list, we

--- a/source/slang/slang-ir-sccp.cpp
+++ b/source/slang/slang-ir-sccp.cpp
@@ -573,7 +573,7 @@ struct SCCPContext
     {
         // We start with the busy-work of setting up our IR builder.
         //
-        builderStorage.sharedBuilder = &shared->sharedBuilder;
+        builderStorage.init(shared->sharedBuilder);
 
         // We expect the caller to have filtered out functions with
         // no bodies, so there should always be at least one basic block.
@@ -940,8 +940,7 @@ void applySparseConditionalConstantPropagation(
 {
     SharedSCCPContext shared;
     shared.module = module;
-    shared.sharedBuilder.module = module;
-    shared.sharedBuilder.session = module->getSession();
+    shared.sharedBuilder.init(module);
 
     applySparseConditionalConstantPropagationRec(&shared, module->getModuleInst());
 }

--- a/source/slang/slang-ir-specialize-dispatch.cpp
+++ b/source/slang/slang-ir-specialize-dispatch.cpp
@@ -42,9 +42,8 @@ IRFunc* specializeDispatchFunction(SharedGenericsLoweringContext* sharedContext,
     }
     SLANG_ASSERT(callInst && lookupInst && returnInst);
 
-    IRBuilder builderStorage;
+    IRBuilder builderStorage(sharedContext->sharedBuilderStorage);
     auto builder = &builderStorage;
-    builder->sharedBuilder = &sharedContext->sharedBuilderStorage;
     builder->setInsertBefore(dispatchFunc);
 
     // Create a new dispatch func to replace the existing one.
@@ -209,8 +208,7 @@ void ensureWitnessTableSequentialIDs(SharedGenericsLoweringContext* sharedContex
             }
 
             // Add a decoration to the inst.
-            IRBuilder builder;
-            builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
+            IRBuilder builder(sharedContext->sharedBuilderStorage);
             builder.setInsertBefore(inst);
             builder.addSequentialIDDecoration(inst, seqID);
         }
@@ -232,8 +230,7 @@ void fixupDispatchFuncCall(SharedGenericsLoweringContext* sharedContext, IRFunc*
         {
             if (call->getCallee() != newDispatchFunc)
                 continue;
-            IRBuilder builder;
-            builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
+            IRBuilder builder(sharedContext->sharedBuilderStorage);
             builder.setInsertBefore(call);
             List<IRInst*> args;
             for (UInt i = 0; i < call->getArgCount(); i++)

--- a/source/slang/slang-ir-specialize-dynamic-associatedtype-lookup.cpp
+++ b/source/slang/slang-ir-specialize-dynamic-associatedtype-lookup.cpp
@@ -13,8 +13,7 @@ struct AssociatedTypeLookupSpecializationContext
 
     IRFunc* createWitnessTableLookupFunc(IRInterfaceType* interfaceType, IRInst* key)
     {
-        IRBuilder builder;
-        builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
+        IRBuilder builder(sharedContext->sharedBuilderStorage);
         builder.setInsertBefore(interfaceType);
 
         auto inputWitnessTableIDType = builder.getWitnessTableIDType(interfaceType);
@@ -123,8 +122,7 @@ struct AssociatedTypeLookupSpecializationContext
         // Ignore lookups for RTTI objects for now, since they are not used anywhere.
         if (!as<IRWitnessTableType>(inst->getDataType()))
         {
-            IRBuilder builder;
-            builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
+            IRBuilder builder(sharedContext->sharedBuilderStorage);
             builder.setInsertBefore(inst);
             auto uint2Type = builder.getVectorType(
                 builder.getUIntType(), builder.getIntValue(builder.getIntType(), 2));
@@ -150,8 +148,7 @@ struct AssociatedTypeLookupSpecializationContext
             func = createWitnessTableLookupFunc(interfaceType, key);
             sharedContext->mapInterfaceRequirementKeyToDispatchMethods[key] = func;
         }
-        IRBuilder builder;
-        builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
+        IRBuilder builder(sharedContext->sharedBuilderStorage);
         builder.setInsertBefore(inst);
         auto witnessTableArg = inst->getWitnessTable();
         if (witnessTableArg->getDataType()->getOp() == kIROp_WitnessTableType)
@@ -178,8 +175,7 @@ struct AssociatedTypeLookupSpecializationContext
             // at this point, where the first element in the uint2 is the id of the
             // witness table.
             auto vectorType = inst->getRTTIOperand()->getDataType();
-            IRBuilder builder;
-            builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
+            IRBuilder builder(sharedContext->sharedBuilderStorage);
             builder.setInsertBefore(inst);
             UInt index = 0;
             auto id = builder.emitSwizzle(as<IRVectorType>(vectorType)->getElementType(), inst->getRTTIOperand(), 1, &index);
@@ -210,8 +206,7 @@ struct AssociatedTypeLookupSpecializationContext
                 for (auto use = inst->firstUse; use; )
                 {
                     auto nextUse = use->nextUse;
-                    IRBuilder builder;
-                    builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
+                    IRBuilder builder(sharedContext->sharedBuilderStorage);
                     builder.setInsertBefore(use->getUser());
                     auto uint2Type = builder.getVectorType(
                         builder.getUIntType(), builder.getIntValue(builder.getIntType(), 2));
@@ -231,8 +226,7 @@ struct AssociatedTypeLookupSpecializationContext
         {
             if (globalInst->getOp() == kIROp_WitnessTableType)
             {
-                IRBuilder builder;
-                builder.sharedBuilder = &sharedContext->sharedBuilderStorage;
+                IRBuilder builder(sharedContext->sharedBuilderStorage);
                 builder.setInsertBefore(globalInst);
                 auto witnessTableIDType = builder.getWitnessTableIDType(
                     (IRType*)cast<IRWitnessTableType>(globalInst)->getConformanceType());

--- a/source/slang/slang-ir-specialize-resources.cpp
+++ b/source/slang/slang-ir-specialize-resources.cpp
@@ -115,8 +115,7 @@ struct ResourceOutputSpecializationPass
     {
         // We start by setting up the shared IR building state.
         //
-        sharedBuilder.module = module;
-        sharedBuilder.session = module->getSession();
+        sharedBuilder.init(module);
 
         // The main logic consists of iterating over all functions
         // (which must appear at the global level) and specializing

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -70,8 +70,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 }
             }
             // Make a pointer type of storageClass.
-            IRBuilder builder;
-            builder.sharedBuilder = &m_sharedContext->m_sharedIRBuilder;
+            IRBuilder builder(m_sharedContext->m_sharedIRBuilder);
             builder.setInsertBefore(inst);
             ptrType = builder.getPtrType(kIROp_PtrType, inst->getFullType(), storageClass);
             inst->setFullType(ptrType);
@@ -141,8 +140,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         {
             storageClass = SpvStorageClassWorkgroup;
         }
-        IRBuilder builder;
-        builder.sharedBuilder = &m_sharedContext->m_sharedIRBuilder;
+        IRBuilder builder(m_sharedContext->m_sharedIRBuilder);
         builder.setInsertBefore(inst);
         auto newPtrType =
             builder.getPtrType(oldPtrType->getOp(), oldPtrType->getValueType(), storageClass);
@@ -165,8 +163,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 auto ptrType = as<IRPtrTypeBase>(inst->getDataType());
                 if (!ptrType)
                     return;
-                IRBuilder builder;
-                builder.sharedBuilder = &m_sharedContext->m_sharedIRBuilder;
+                IRBuilder builder(m_sharedContext->m_sharedIRBuilder);
                 builder.setInsertBefore(inst);
                 auto qualPtrType = builder.getPtrType(
                     ptrType->getOp(), ptrType->getValueType(), snippet->resultStorageClass);
@@ -190,8 +187,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             auto oldResultType = as<IRPtrTypeBase>(inst->getDataType());
             if (oldResultType->getAddressSpace() != ptrType->getAddressSpace())
             {
-                IRBuilder builder;
-                builder.sharedBuilder = &m_sharedContext->m_sharedIRBuilder;
+                IRBuilder builder(m_sharedContext->m_sharedIRBuilder);
                 builder.setInsertBefore(inst);
                 auto newPtrType = builder.getPtrType(
                     oldResultType->getOp(),
@@ -215,8 +211,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             auto oldResultType = as<IRPtrTypeBase>(inst->getDataType());
             if (oldResultType->getAddressSpace() != ptrType->getAddressSpace())
             {
-                IRBuilder builder;
-                builder.sharedBuilder = &m_sharedContext->m_sharedIRBuilder;
+                IRBuilder builder(m_sharedContext->m_sharedIRBuilder);
                 builder.setInsertBefore(inst);
                 auto newPtrType = builder.getPtrType(
                     oldResultType->getOp(),
@@ -233,8 +228,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
 
     void processStructuredBufferType(IRHLSLStructuredBufferTypeBase* inst)
     {
-        IRBuilder builder;
-        builder.sharedBuilder = &m_sharedContext->m_sharedIRBuilder;
+        IRBuilder builder(m_sharedContext->m_sharedIRBuilder);
         builder.setInsertBefore(inst);
         auto arrayType = builder.getUnsizedArrayType(inst->getElementType());
         auto structType = builder.createStructType();

--- a/source/slang/slang-ir-ssa.cpp
+++ b/source/slang/slang-ir-ssa.cpp
@@ -921,8 +921,7 @@ void SharedIRBuilder::insertBlockAlongEdge(
     auto succ = edge.getSuccessor();
     auto edgeUse = edge.getUse();
 
-    IRBuilder builder;
-    builder.sharedBuilder = this;
+    IRBuilder builder(this);
     builder.setInsertInto(pred);
 
     // Create a new block that will sit "along" the edge
@@ -1065,7 +1064,7 @@ void constructSSA(ConstructSSAContext* context)
         auto blockInfo = new SSABlockInfo();
         blockInfo->block = bb;
 
-        blockInfo->builder.sharedBuilder = &context->sharedBuilder;
+        blockInfo->builder.init(context->sharedBuilder);
         blockInfo->builder.setInsertBefore(bb->getLastInst());
 
         context->blockInfos.Add(bb, blockInfo);
@@ -1196,11 +1195,10 @@ void constructSSA(IRModule* module, IRGlobalValueWithCode* globalVal)
     ConstructSSAContext context;
     context.globalVal = globalVal;
 
-    context.sharedBuilder.module = module;
-    context.sharedBuilder.session = module->session;
+    context.sharedBuilder.init(module);
 
-    context.builder.sharedBuilder = &context.sharedBuilder;
-    context.builder.setInsertInto(module->moduleInst);
+    context.builder.init(context.sharedBuilder);
+    context.builder.setInsertInto(module);
 
     constructSSA(&context);
 }

--- a/source/slang/slang-ir-synthesize-active-mask.cpp
+++ b/source/slang/slang-ir-synthesize-active-mask.cpp
@@ -117,8 +117,7 @@ struct SynthesizeActiveMaskForModuleContext
         // When asked to process an IR module, our pass first
         // sets up the shared state.
         //
-        m_sharedBuilder.session = m_module->getSession();
-        m_sharedBuilder.module = m_module;
+        m_sharedBuilder.init(m_module);
 
         // We use the plain 32-bit `uint` type masks we
         // generate here since it matches the current
@@ -129,8 +128,7 @@ struct SynthesizeActiveMaskForModuleContext
         // so that the pass is compatible with all targets that
         // support  a wave mask.
         //
-        IRBuilder builder;
-        builder.sharedBuilder = &m_sharedBuilder;
+        IRBuilder builder(m_sharedBuilder);
         m_maskType = builder.getBasicType(BaseType::UInt);
 
         // With the setup out of the way, the job of the module
@@ -331,8 +329,7 @@ struct SynthesizeActiveMaskForModuleContext
             //      mask = waveGetActiveMask();
             //      callee(arg0, arg1, arg2, ..., m);
             //
-            IRBuilder builder;
-            builder.sharedBuilder = &m_sharedBuilder;
+            IRBuilder builder(m_sharedBuilder);
             builder.setInsertBefore(call);
 
             // First we synthesize the mask to pass down by
@@ -734,8 +731,7 @@ struct SynthesizeActiveMaskForFunctionContext
             //
             // We will insert the code we generate at the start of the entry block.
             //
-            IRBuilder builder;
-            builder.sharedBuilder = m_sharedBuilder;
+            IRBuilder builder(m_sharedBuilder);
             builder.setInsertBefore(funcEntryBlock->getFirstOrdinaryInst());
             //
             // A naive approach would be to set the active mask to an all-ones
@@ -833,8 +829,7 @@ struct SynthesizeActiveMaskForFunctionContext
         //
         SLANG_ASSERT(doesBlockNeedActiveMask(block));
 
-        IRBuilder builder;
-        builder.sharedBuilder = m_sharedBuilder;
+        IRBuilder builder(m_sharedBuilder);
         builder.setInsertBefore(block->getFirstOrdinaryInst());
 
         auto activeMaskParam = builder.emitParam(m_maskType);
@@ -1226,8 +1221,7 @@ struct SynthesizeActiveMaskForFunctionContext
                 // code can take responsibility for computing the mask
                 // value to use for both `trueBlock` and `falseBlock`.
                 //
-                IRBuilder builder;
-                builder.sharedBuilder = m_sharedBuilder;
+                IRBuilder builder(m_sharedBuilder);
 
                 // To establish the mask value for `trueBlock` we will
                 // insert a `waveMaskBallot` before the branch:
@@ -1459,8 +1453,7 @@ struct SynthesizeActiveMaskForFunctionContext
                 // Next, we need to establish a mask value that will
                 // represent the active mask on entry to a given `case`.
                 //
-                IRBuilder builder;
-                builder.sharedBuilder = m_sharedBuilder;
+                IRBuilder builder(m_sharedBuilder);
                 builder.setInsertBefore(switchInst);
 
                 // For now we are computing a simple-but-inaccurate version
@@ -1693,8 +1686,7 @@ struct SynthesizeActiveMaskForFunctionContext
     //
     void transformUnconditionalEdge(RegionInfo* fromRegion, IRTerminatorInst* terminator, IRBlock* toBlock, IRInst* fromActiveMask)
     {
-        IRBuilder builder;
-        builder.sharedBuilder = m_sharedBuilder;
+        IRBuilder builder(m_sharedBuilder);
         builder.setInsertBefore(terminator);
 
         // The context here is that the `terminator` instruction,

--- a/source/slang/slang-ir-type-set.cpp
+++ b/source/slang/slang-ir-type-set.cpp
@@ -9,14 +9,10 @@ namespace Slang
 
 IRTypeSet::IRTypeSet(Session* session)
 {
-    m_sharedBuilder.module = nullptr;
-    m_sharedBuilder.session = session;
+    m_module = IRModule::create(session);
 
-    m_builder.sharedBuilder = &m_sharedBuilder;
-
-    m_module = m_builder.createModule();
-
-    m_sharedBuilder.module = m_module;
+    m_sharedBuilder.init(m_module);
+    m_builder.init(m_sharedBuilder);
 
     m_builder.setInsertInto(m_module->getModuleInst());
 }
@@ -32,8 +28,11 @@ void IRTypeSet::clear()
 
     m_cloneMap.Clear();
 
-    m_module = m_builder.createModule();
-    m_sharedBuilder.module = m_module;
+    m_module = IRModule::create(m_sharedBuilder.getSession());
+
+    m_sharedBuilder.init(m_module);
+    m_builder.init(m_sharedBuilder);
+
     m_builder.setInsertInto(m_module->getModuleInst());
 }
 

--- a/source/slang/slang-ir-union.cpp
+++ b/source/slang/slang-ir-union.cpp
@@ -39,9 +39,8 @@ struct DesugarUnionTypesContext
     {
         // We start by initializing our IR building state.
         //
-        sharedBuilderStorage.session = module->session;
-        sharedBuilderStorage.module = module;
-        builderStorage.sharedBuilder = &sharedBuilderStorage;
+        sharedBuilderStorage.init(module);
+        builderStorage.init(sharedBuilderStorage);
 
         // Next, we will search for any instruction that create or use
         // union types, and process them accordingingly (usually by

--- a/source/slang/slang-ir-validate.cpp
+++ b/source/slang/slang-ir-validate.cpp
@@ -216,14 +216,14 @@ namespace Slang
         context->module = module;
         context->sink = sink;
 
-        auto moduleInst = module->moduleInst;
+        auto moduleInst = module->getModuleInst();
 
         validate(context, moduleInst != nullptr,            moduleInst, "module instruction");
         validate(context, moduleInst->parent == nullptr,    moduleInst, "module instruction parent");
         validate(context, moduleInst->prev == nullptr,      moduleInst, "module instruction prev");
         validate(context, moduleInst->next == nullptr,      moduleInst, "module instruction next");
 
-        validateIRInst(context, module->moduleInst);
+        validateIRInst(context, moduleInst);
     }
 
     void validateIRModuleIfEnabled(

--- a/source/slang/slang-ir-witness-table-wrapper.cpp
+++ b/source/slang/slang-ir-witness-table-wrapper.cpp
@@ -83,9 +83,8 @@ namespace Slang
 
         IRStringLit* _getWitnessTableWrapperFuncName(IRFunc* func)
         {
-            IRBuilder builderStorage;
+            IRBuilder builderStorage(sharedContext->sharedBuilderStorage);
             auto builder = &builderStorage;
-            builder->sharedBuilder = &sharedContext->sharedBuilderStorage;
             builder->setInsertBefore(func);
             if (auto linkageDecoration = func->findDecoration<IRLinkageDecoration>())
             {
@@ -102,9 +101,8 @@ namespace Slang
         {
             auto funcTypeInInterface = cast<IRFuncType>(interfaceRequirementVal);
 
-            IRBuilder builderStorage;
+            IRBuilder builderStorage(sharedContext->sharedBuilderStorage);
             auto builder = &builderStorage;
-            builder->sharedBuilder = &sharedContext->sharedBuilderStorage;
             builder->setInsertBefore(func);
 
             auto wrapperFunc = builder->createFunc();
@@ -222,8 +220,7 @@ namespace Slang
             // generate along the way.
             //
             SharedIRBuilder* sharedBuilder = &sharedContext->sharedBuilderStorage;
-            sharedBuilder->module = sharedContext->module;
-            sharedBuilder->session = sharedContext->module->session;
+            sharedBuilder->init(sharedContext->module);
 
             sharedContext->addToWorkList(sharedContext->module->getModuleInst());
 

--- a/source/slang/slang-ir-wrap-structured-buffers.cpp
+++ b/source/slang/slang-ir-wrap-structured-buffers.cpp
@@ -53,7 +53,7 @@ struct WrapStructuredBuffersContext
     //
     void processModule()
     {
-        processInstRec(m_module->moduleInst);
+        processInstRec(m_module->getModuleInst());
     }
 
     void processInstRec(IRInst* inst)
@@ -83,13 +83,10 @@ struct WrapStructuredBuffersContext
         // Having found a `*StructuredBuffer<M>` we will now
         // need an IR builder to help us construct the wrapper code.
         //
-        SharedIRBuilder sharedBuilderStorage;
+        SharedIRBuilder sharedBuilderStorage(m_module);
         auto sharedBuilder = &sharedBuilderStorage;
-        sharedBuilder->module = m_module;
-        sharedBuilder->session = m_module->getSession();
-        IRBuilder builderStorage;
+        IRBuilder builderStorage(sharedBuilder);
         auto builder = &builderStorage;
-        builder->sharedBuilder = sharedBuilder;
 
         // We begin by constructing a structure type that wraps
         // our `matrixType`, into something like:

--- a/source/slang/slang-lower-to-ir.h
+++ b/source/slang/slang-lower-to-ir.h
@@ -26,7 +26,7 @@ namespace Slang
         /// module must be linked against other IR modules that define any symbols
         /// that are imported before code generation can be performed.
         ///
-    IRModule* generateIRForTranslationUnit(
+    RefPtr<IRModule> generateIRForTranslationUnit(
         ASTBuilder*             astBuilder,
         TranslationUnitRequest* translationUnit);
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -2040,7 +2040,7 @@ void FrontEndCompileRequest::generateIR()
             // Verify debug information
             if (SLANG_FAILED(SerialContainerUtil::verifyIRSerialize(irModule, getSession(), options)))
             {
-                getSink()->diagnose(irModule->moduleInst->sourceLoc, Diagnostics::serialDebugVerificationFailed);
+                getSink()->diagnose(irModule->getModuleInst()->sourceLoc, Diagnostics::serialDebugVerificationFailed);
             }
         }
 


### PR DESCRIPTION
We have some long-term goals for the IR that require a more centralized and disciplined set of rules for how IR instructions get created/emitted. I had been working on trying to set things up so that all IR instruction creation goes through a single bottleneck point, but the non-trivial work in that branch was getting drowned out by the sheer volume of cleanup and refactoring changes. This change tries to pull together several of the more important cleanups.

The big pieces are:

* `IRBuilder` and `SharedIRBuilder` now protect their data members and rely on users to initialize them more directly via constructor of an `init()` method. This change affects a *bunch* of sites where `IRBuilder`s were created. I changed use sites to use the constructors whenever possible, and to use `init()` in cases where we had longer-lived builders that needed to be initialized multiple times.

* The insertion location for the `IRBuilder` now uses an encapsulated type called `IRInsertLoc`. This new type can replace what used to be just two `IRInst*` fields in the builder, and also covers some new functionality (if we ever want to take advantage of it). Very little client code cares about this change, but it is still a nice cleanup in terms of making things more explicit.

* The creation of an `IRModule` has been moded *out* of `IRBuilder`, because in practice we `IRBuilder` always wants to be associated with a pre-existing `IRModule` at creation time (via its `SharedIRBuilder`). There is now an `IRModule::create()` operation instead. This required changing the sequencing at many `IRModule` creation sites, since most had been contriving to make an `IRBuilder` first. There were also several cleanups because code had been carelessly using non-reference-counted pointers for `IRModule`s in ways that broke now that `IRModule::create()` always returns a `RefPtr`.

* The core operations to actually allocate memory for IR instructions were moved into `IRModule` (since they interact with the memory pool that the module owns). These *were* called `createEmptyInst()` but have been renamed into `_allocateInst()`. In principle these seem like they should only be needed to be called by the `IRBuilder`, but in practice they are also needed by the IR deserialization logic.

* A few core operations for emitting IR instructions that were associted with `IRBuilder` were moved to actually be methods on `IRBuilder`. First is `_findOrEmitConstant` which is the primary bottleneck for creating simple scalar constant values. Another is `_createInst` (formerly part of the templated `createInstImpl` along with `createInstWithSizeImpl`) which is the main bottleneck for allocation and initialization of any instruction other than a constant (well, the `IRModuleInst` is the other exception...). Finally, there is also `_maybeSetSourceLoc()`, which is obvious to scope inside the `IRBuilder` once it is protecting the source-location info.

Notes:

* The `minSizeInBytes` parameter to `_createInst()` might not actually be needed at all. At this point any `IRInst` subtypes that need data allocated for things other than their operands already get created manually via `_allocateInst` or `_findOrEmitConstant`, so I *think* we could remove that part. I will handle that in a subsequent cleanup if it turns out to be the case.

* There is one IR pass (`slang-ir-string-hash.cpp`) that is using manual `_allocateInst()` instead of going through an `IRBuilder`. It could be easily cleaned up to not do so (and I will probably make that change down the line), but for now I wanted to avoid doing anything that wasn't close to pure refactoring if I could.

* At this point in our design an `IRBuilder` is a very lightweight thing - it basically just owns the insertion location plus a source location to write into instructions. A lot of our code currently treats `IRBuilder`s like they are expensive and/or need to be re-used (which leads to them being used in more mutable/stateful ways). It is quite likely that as we clean up other aspects of the implementation of IR creation/emission we can make `IRBuilder` use feel more lightweight in ways that can streamline and simplify code.

* The next step for this work is to identify the different paths that eventually lead to `_createInst()` being called, and unify them at a single bottleneck operation that can own the decisions around when to create an instruction vs. when to re-use an existing one (rather than those decisions being baked into the various `IRBuilder` subroutines that create instructions of the various subtypes).