### PR TITLE
Fix hexadecimal escape is string literals

### DIFF
--- a/source/compiler-core/slang-lexer.cpp
+++ b/source/compiler-core/slang-lexer.cpp
@@ -874,7 +874,6 @@ namespace Slang
             // Hexadecimal escape: any number of characters
             case 'x':
                 {
-                    cursor--;
                     int value = 0;
                     for(;;)
                     {


### PR DESCRIPTION
Hex escape issue affect all places where 'getStringLiteralTokenValue' are used.

Example:

test.slang
```
#line 1 "H\x65llo world"
#warning test
```

before:
```
slangc test.slang -target hlsl
H
```

after fix:
```
slangc test.slang -target hlsl
Hello world(1): warning 15901: #warning: test
#warning test
```