### PR TITLE
Draw call tests for Vulkan

### DIFF
--- a/examples/model-viewer/main.cpp
+++ b/examples/model-viewer/main.cpp
@@ -748,6 +748,7 @@ Result initialize()
         {"UV",       0, Format::R32G32_FLOAT,  offsetof(Model::Vertex, uv) },
     };
     auto inputLayout = gDevice->createInputLayout(
+        sizeof(Model::Vertex),
         &inputElements[0],
         3);
     if(!inputLayout) return SLANG_FAIL;
@@ -868,7 +869,7 @@ void renderFrame(int frameIndex) override
     //
     for(auto& model : gModels)
     {
-        drawCommandEncoder->setVertexBuffer(0, model->vertexBuffer, sizeof(Model::Vertex));
+        drawCommandEncoder->setVertexBuffer(0, model->vertexBuffer);
         drawCommandEncoder->setIndexBuffer(model->indexBuffer, Format::R32_UINT);
         // For each model we provide a parameter
         // block that holds the per-model transformation

--- a/examples/ray-tracing-pipeline/main.cpp
+++ b/examples/ray-tracing-pipeline/main.cpp
@@ -504,7 +504,7 @@ Slang::Result initialize()
     InputElementDesc inputElements[] = {
         {"POSITION", 0, Format::R32G32_FLOAT, offsetof(FullScreenTriangle::Vertex, position)},
     };
-    auto inputLayout = gDevice->createInputLayout(&inputElements[0], SLANG_COUNT_OF(inputElements));
+    auto inputLayout = gDevice->createInputLayout(sizeof(FullScreenTriangle::Vertex), &inputElements[0], SLANG_COUNT_OF(inputElements));
     if (!inputLayout)
         return SLANG_FAIL;
 
@@ -643,7 +643,7 @@ virtual void renderFrame(int frameBufferIndex) override
         auto cursor = ShaderCursor(rootObject->getEntryPoint(1));
         cursor["t"].setResource(gResultTextureUAV);
         presentEncoder->setVertexBuffer(
-            0, gFullScreenVertexBuffer, sizeof(FullScreenTriangle::Vertex));
+            0, gFullScreenVertexBuffer);
         presentEncoder->setPrimitiveTopology(PrimitiveTopology::TriangleList);
         presentEncoder->draw(3);
         presentEncoder->endEncoding();

--- a/examples/ray-tracing/main.cpp
+++ b/examples/ray-tracing/main.cpp
@@ -496,7 +496,7 @@ Slang::Result initialize()
     InputElementDesc inputElements[] = {
         {"POSITION", 0, Format::R32G32_FLOAT, offsetof(FullScreenTriangle::Vertex, position)},
     };
-    auto inputLayout = gDevice->createInputLayout(&inputElements[0], SLANG_COUNT_OF(inputElements));
+    auto inputLayout = gDevice->createInputLayout(sizeof(FullScreenTriangle::Vertex), &inputElements[0], SLANG_COUNT_OF(inputElements));
     if (!inputLayout)
         return SLANG_FAIL;
 
@@ -622,7 +622,7 @@ virtual void renderFrame(int frameBufferIndex) override
         auto cursor = ShaderCursor(rootObject->getEntryPoint(1));
         cursor["t"].setResource(gResultTextureUAV);
         presentEncoder->setVertexBuffer(
-            0, gFullScreenVertexBuffer, sizeof(FullScreenTriangle::Vertex));
+            0, gFullScreenVertexBuffer);
         presentEncoder->setPrimitiveTopology(PrimitiveTopology::TriangleList);
         presentEncoder->draw(3);
         presentEncoder->endEncoding();

--- a/examples/shader-toy/main.cpp
+++ b/examples/shader-toy/main.cpp
@@ -284,6 +284,7 @@ Result initialize()
         { "POSITION", 0, Format::R32G32_FLOAT, offsetof(FullScreenTriangle::Vertex, position) },
     };
     auto inputLayout = gDevice->createInputLayout(
+        sizeof(FullScreenTriangle::Vertex),
         &inputElements[0],
         SLANG_COUNT_OF(inputElements));
     if(!inputLayout) return SLANG_FAIL;
@@ -367,7 +368,7 @@ virtual void renderFrame(int frameIndex) override
     auto constantBuffer = rootObject->getObject(ShaderOffset());
     constantBuffer->setData(ShaderOffset(), &uniforms, sizeof(uniforms));
 
-    encoder->setVertexBuffer(0, gVertexBuffer, sizeof(FullScreenTriangle::Vertex));
+    encoder->setVertexBuffer(0, gVertexBuffer);
     encoder->setPrimitiveTopology(PrimitiveTopology::TriangleList);
     encoder->draw(3);
     encoder->endEncoding();

--- a/examples/triangle/main.cpp
+++ b/examples/triangle/main.cpp
@@ -227,6 +227,7 @@ Slang::Result initialize()
         { "COLOR",    0, Format::R32G32B32_FLOAT, offsetof(Vertex, color) },
     };
     auto inputLayout = gDevice->createInputLayout(
+        sizeof(Vertex),
         &inputElements[0],
         2);
     if(!inputLayout) return SLANG_FAIL;
@@ -373,7 +374,7 @@ virtual void renderFrame(int frameBufferIndex) override
     // We also need to set up a few pieces of fixed-function pipeline
     // state that are not bound by the pipeline state above.
     //
-    renderEncoder->setVertexBuffer(0, gVertexBuffer, sizeof(Vertex));
+    renderEncoder->setVertexBuffer(0, gVertexBuffer);
     renderEncoder->setPrimitiveTopology(PrimitiveTopology::TriangleList);
 
     // Finally, we are ready to issue a draw call for a single triangle.

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -2073,7 +2073,8 @@ public:
 
     inline Result createInputLayout(size_t vertexSize, InputElementDesc const* inputElements, Int inputElementCount, IInputLayout** outLayout)
     {
-        VertexStreamDesc streamDesc = { (uint32_t)vertexSize };
+        VertexStreamDesc streamDesc = {};
+        streamDesc.stride = (uint32_t)vertexSize;
 
         IInputLayout::Desc inputLayoutDesc = {};
         inputLayoutDesc.inputElementCount = inputElementCount;

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1485,14 +1485,14 @@ public:
         uint32_t maxDrawCount,
         IBufferResource* argBuffer,
         uint64_t argOffset,
-        IBufferResource* countBuffer,
-        uint64_t countOffset) = 0;
+        IBufferResource* countBuffer = nullptr,
+        uint64_t countOffset = 0) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedIndirect(
         uint32_t maxDrawCount,
         IBufferResource* argBuffer,
         uint64_t argOffset,
-        IBufferResource* countBuffer,
-        uint64_t countOffset) = 0;
+        IBufferResource* countBuffer = nullptr,
+        uint64_t countOffset = 0) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL setStencilReference(uint32_t referenceValue) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL setSamplePositions(
         uint32_t samplesPerPixel, uint32_t pixelCount, const SamplePosition* samplePositions) = 0;

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -2073,7 +2073,7 @@ public:
 
     inline Result createInputLayout(size_t vertexSize, InputElementDesc const* inputElements, Int inputElementCount, IInputLayout** outLayout)
     {
-        VertexStreamDesc streamDesc = { (uint32_t)vertexSize, InputSlotClass::PerVertex };
+        VertexStreamDesc streamDesc = { (uint32_t)vertexSize };
 
         IInputLayout::Desc inputLayoutDesc = {};
         inputLayoutDesc.inputElementCount = inputElementCount;

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -349,8 +349,8 @@ struct InputElementDesc
 struct VertexStreamDesc
 {
     uint32_t stride;
-    InputSlotClass slotClass = InputSlotClass::PerVertex;
-    UInt instanceDataStepRate = 0;
+    InputSlotClass slotClass;
+    UInt instanceDataStepRate;
 };
 
 enum class PrimitiveType
@@ -2073,8 +2073,7 @@ public:
 
     inline Result createInputLayout(size_t vertexSize, InputElementDesc const* inputElements, Int inputElementCount, IInputLayout** outLayout)
     {
-        VertexStreamDesc streamDesc = {};
-        streamDesc.stride = (uint32_t)vertexSize;
+        VertexStreamDesc streamDesc = { (uint32_t)vertexSize, InputSlotClass::PerVertex, 0 };
 
         IInputLayout::Desc inputLayoutDesc = {};
         inputLayoutDesc.inputElementCount = inputElementCount;

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -350,7 +350,7 @@ struct VertexStreamDesc
 {
     uint32_t stride;
     InputSlotClass slotClass = InputSlotClass::PerVertex;
-    UInt instanceDataStepRate = 1;
+    UInt instanceDataStepRate = 0;
 };
 
 enum class PrimitiveType

--- a/tools/gfx-unit-test/instanced-draw-tests.cpp
+++ b/tools/gfx-unit-test/instanced-draw-tests.cpp
@@ -368,7 +368,6 @@ namespace gfx_test
         {
             float padding; // Ensure args and count don't start at 0 offset for testing purposes
             IndirectDrawArguments args;
-            uint32_t count;
         };
 
         ComPtr<IBufferResource> createIndirectBuffer(IDevice* device)
@@ -377,7 +376,6 @@ namespace gfx_test
             {
                 42.0f, // padding
                 {6, 2, 0, 0}, // args
-                1, // count
             };
 
             IBufferResource::Desc indirectBufferDesc;
@@ -413,9 +411,8 @@ namespace gfx_test
 
             uint32_t maxDrawCount = 1;
             uint64_t argOffset = offsetof(IndirectArgData, args);
-            uint64_t countOffset = offsetof(IndirectArgData, count);
 
-            encoder->drawIndirect(maxDrawCount, indirectBuffer, argOffset, indirectBuffer, countOffset);
+            encoder->drawIndirect(maxDrawCount, indirectBuffer, argOffset);
             encoder->endEncoding();
             commandBuffer->close();
             queue->executeCommandBuffer(commandBuffer);
@@ -447,7 +444,6 @@ namespace gfx_test
         {
             float padding; // Ensure args and count don't start at 0 offset for testing purposes
             IndirectDrawIndexedArguments args;
-            uint32_t count;
         };
 
         ComPtr<IBufferResource> createIndirectBuffer(IDevice* device)
@@ -456,7 +452,6 @@ namespace gfx_test
             {
                 42.0f, // padding
                 {6, 2, 0, 0, 0}, // args
-                1, // count
             };
 
             IBufferResource::Desc indirectBufferDesc;
@@ -493,9 +488,8 @@ namespace gfx_test
 
             uint32_t maxDrawCount = 1;
             uint64_t argOffset = offsetof(IndexedIndirectArgData, args);
-            uint64_t countOffset = offsetof(IndexedIndirectArgData, count);
 
-            encoder->drawIndexedIndirect(maxDrawCount, indirectBuffer, argOffset, indirectBuffer, countOffset);
+            encoder->drawIndexedIndirect(maxDrawCount, indirectBuffer, argOffset);
             encoder->endEncoding();
             commandBuffer->close();
             queue->executeCommandBuffer(commandBuffer);

--- a/tools/gfx-unit-test/instanced-draw-tests.cpp
+++ b/tools/gfx-unit-test/instanced-draw-tests.cpp
@@ -5,30 +5,10 @@
 #include "tools/gfx-util/shader-cursor.h"
 #include "source/core/slang-basic.h"
 
-#include <stdlib.h>
-#include <stdio.h>
-
-#define STB_IMAGE_WRITE_IMPLEMENTATION
-#include "external/stb/stb_image_write.h"
-
 using namespace gfx;
 
 namespace gfx_test
 {
-    // Testing only code used to dump images to visually confirm correctness.
-    // Will be removed once all draw tests are complete.
-    Slang::Result writeImage(
-        const char* filename,
-        ISlangBlob* pixels,
-        uint32_t width,
-        uint32_t height)
-    {
-        int stbResult =
-            stbi_write_hdr(filename, width, height, 4, (float*)pixels->getBufferPointer());
-
-        return stbResult ? SLANG_OK : SLANG_FAIL;
-    }
-
     struct Vertex
     {
         float position[3];
@@ -237,9 +217,6 @@ namespace gfx_test
             GFX_CHECK_CALL_ABORT(device->readTextureResource(
                 colorBuffer, ResourceState::CopySource, resultBlob.writeRef(), &rowPitch, &pixelSize));
             auto result = (float*)resultBlob->getBufferPointer();
-
-            // Dump image to disk so we can visually confirm the output
-            writeImage("C:/Users/lucchen/Documents/dump.hdr", resultBlob, kWidth, kHeight);
 
             int cursor = 0;
             for (int i = 0; i < pixelCount; ++i)

--- a/tools/gfx-unit-test/instanced-draw-tests.cpp
+++ b/tools/gfx-unit-test/instanced-draw-tests.cpp
@@ -521,6 +521,20 @@ namespace gfx_test
         test.run();
     }
 
+#if 0
+    // D3D11's readTextureResource() currently only supports 32 bit formats, resulting in the tests breaking on D3D11
+    // as these tests use 128 bit.
+    SLANG_UNIT_TEST(drawInstancedD3D11)
+    {
+        runTestImpl(drawTestImpl<DrawInstancedTest>, unitTestContext, Slang::RenderApiFlag::D3D11);
+    }
+
+    SLANG_UNIT_TEST(drawIndexedInstancedD3D11)
+    {
+        runTestImpl(drawTestImpl<DrawIndexedInstancedTest>, unitTestContext, Slang::RenderApiFlag::D3D11);
+    }
+#endif
+
     SLANG_UNIT_TEST(drawInstancedD3D12)
     {
         runTestImpl(drawTestImpl<DrawInstancedTest>, unitTestContext, Slang::RenderApiFlag::D3D12);

--- a/tools/gfx-unit-test/instanced-draw-tests.cpp
+++ b/tools/gfx-unit-test/instanced-draw-tests.cpp
@@ -498,9 +498,6 @@ namespace gfx_test
         test.run();
     }
 
-#if 0
-    // D3D11's readTextureResource() currently only supports 32 bit formats, resulting in the tests breaking on D3D11
-    // as these tests use 128 bit.
     SLANG_UNIT_TEST(drawInstancedD3D11)
     {
         runTestImpl(drawTestImpl<DrawInstancedTest>, unitTestContext, Slang::RenderApiFlag::D3D11);
@@ -510,7 +507,6 @@ namespace gfx_test
     {
         runTestImpl(drawTestImpl<DrawIndexedInstancedTest>, unitTestContext, Slang::RenderApiFlag::D3D11);
     }
-#endif
 
     SLANG_UNIT_TEST(drawInstancedD3D12)
     {

--- a/tools/gfx-unit-test/instanced-draw-tests.cpp
+++ b/tools/gfx-unit-test/instanced-draw-tests.cpp
@@ -128,7 +128,7 @@ namespace gfx_test
         void createRequiredResources()
         {
             VertexStreamDesc vertexStreams[] = {
-                { sizeof(Vertex), InputSlotClass::PerVertex },
+                { sizeof(Vertex), InputSlotClass::PerVertex, 0 },
                 { sizeof(Instance), InputSlotClass::PerInstance, 1 },
             };
 

--- a/tools/gfx/command-writer.h
+++ b/tools/gfx/command-writer.h
@@ -198,7 +198,6 @@ public:
         uint32_t startSlot,
         uint32_t slotCount,
         IBufferResource* const* buffers,
-        const uint32_t* strides,
         const uint32_t* offsets)
     {
         uint32_t bufferOffset = 0;
@@ -208,14 +207,12 @@ public:
             if (i == 0)
                 bufferOffset = offset;
         }
-        uint32_t stridesOffset = encodeData(strides, sizeof(uint32_t) * slotCount);
         uint32_t offsetsOffset = encodeData(offsets, sizeof(uint32_t) * slotCount);
         m_commands.add(Command(
             CommandName::SetVertexBuffers,
             startSlot,
             slotCount,
             bufferOffset,
-            stridesOffset,
             offsetsOffset));
     }
 

--- a/tools/gfx/command-writer.h
+++ b/tools/gfx/command-writer.h
@@ -21,6 +21,8 @@ enum class CommandName
     SetIndexBuffer,
     Draw,
     DrawIndexed,
+    DrawInstanced,
+    DrawIndexedInstanced,
     SetStencilReference,
     DispatchCompute,
     UploadBufferData,
@@ -235,6 +237,36 @@ public:
             (uint32_t)indexCount,
             (uint32_t)startIndex,
             (uint32_t)baseVertex));
+    }
+
+    void drawInstanced(
+        uint32_t vertexCount,
+        uint32_t instanceCount,
+        uint32_t startVertex,
+        uint32_t startInstanceLocation)
+    {
+        m_commands.add(Command(
+            CommandName::DrawInstanced,
+            (uint32_t)vertexCount,
+            (uint32_t)instanceCount,
+            (uint32_t)startVertex,
+            (uint32_t)startInstanceLocation));
+    }
+
+    void drawIndexedInstanced(
+        uint32_t indexCount,
+        uint32_t instanceCount,
+        uint32_t startIndexLocation,
+        int32_t baseVertexLocation,
+        uint32_t startInstanceLocation)
+    {
+        m_commands.add(Command(
+            CommandName::DrawIndexedInstanced,
+            (uint32_t)indexCount,
+            (uint32_t)instanceCount,
+            (uint32_t)startIndexLocation,
+            (int32_t)baseVertexLocation,
+            (uint32_t)startInstanceLocation));
     }
 
     void setStencilReference(uint32_t referenceValue)

--- a/tools/gfx/cuda/render-cuda.cpp
+++ b/tools/gfx/cuda/render-cuda.cpp
@@ -2282,12 +2282,10 @@ public:
     }
     
     virtual SLANG_NO_THROW Result SLANG_MCALL createInputLayout(
-        const InputElementDesc* inputElements,
-        UInt inputElementCount,
+        IInputLayout::Desc const& desc,
         IInputLayout** outLayout) override
     {
-        SLANG_UNUSED(inputElements);
-        SLANG_UNUSED(inputElementCount);
+        SLANG_UNUSED(desc);
         SLANG_UNUSED(outLayout);
         return SLANG_E_NOT_AVAILABLE;
     }

--- a/tools/gfx/d3d11/render-d3d11.cpp
+++ b/tools/gfx/d3d11/render-d3d11.cpp
@@ -3273,7 +3273,7 @@ void D3D11Device::setVertexBuffers(
 {
     static const int kMaxVertexBuffers = 16;
 	assert(slotCount <= kMaxVertexBuffers);
-    assert(m_currentPipelineState);
+    assert(m_currentPipelineState); // The pipeline state should be created before setting vertex buffers.
 
     UINT vertexStrides[kMaxVertexBuffers];
     UINT vertexOffsets[kMaxVertexBuffers];

--- a/tools/gfx/d3d11/render-d3d11.cpp
+++ b/tools/gfx/d3d11/render-d3d11.cpp
@@ -2462,7 +2462,9 @@ SlangResult D3D11Device::readTextureResource(
         return E_INVALIDARG;
     }
 
-    size_t bytesPerPixel = sizeof(uint32_t);
+    FormatInfo sizeInfo;
+    gfxGetFormatInfo(texture->getDesc()->format, &sizeInfo);
+    size_t bytesPerPixel = sizeInfo.blockSizeInBytes / sizeInfo.pixelsPerBlock;
     size_t rowPitch = int(texture->getDesc()->size.width) * bytesPerPixel;
     size_t bufferSize = rowPitch * int(texture->getDesc()->size.height);
     if (outRowPitch)

--- a/tools/gfx/d3d11/render-d3d11.cpp
+++ b/tools/gfx/d3d11/render-d3d11.cpp
@@ -97,8 +97,7 @@ public:
         IResourceView** outView) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL createInputLayout(
-        const InputElementDesc* inputElements,
-        UInt inputElementCount,
+        IInputLayout::Desc const& desc,
         IInputLayout** outLayout) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL createQueryPool(
@@ -138,7 +137,6 @@ public:
         uint32_t startSlot,
         uint32_t slotCount,
         IBufferResource* const* buffers,
-        const uint32_t* strides,
         const uint32_t* offsets) override;
     virtual void setIndexBuffer(
         IBufferResource* buffer, Format indexFormat, uint32_t offset) override;
@@ -3069,7 +3067,7 @@ Result D3D11Device::createBufferView(IBufferResource* buffer, IResourceView::Des
     }
 }
 
-Result D3D11Device::createInputLayout(const InputElementDesc* inputElementsIn, UInt inputElementCount, IInputLayout** outLayout)
+Result D3D11Device::createInputLayout(IInputLayout::Desc const& desc, IInputLayout** outLayout)
 {
     D3D11_INPUT_ELEMENT_DESC inputElements[16] = {};
 
@@ -3078,6 +3076,8 @@ Result D3D11Device::createInputLayout(const InputElementDesc* inputElementsIn, U
 
     hlslCursor += sprintf(hlslCursor, "float4 main(\n");
 
+    auto inputElementCount = desc.inputElementCount;
+    auto inputElementsIn = desc.inputElements;
     for (UInt ii = 0; ii < inputElementCount; ++ii)
     {
         inputElements[ii].SemanticName = inputElementsIn[ii].semanticName;
@@ -3246,7 +3246,6 @@ void D3D11Device::setVertexBuffers(
     uint32_t startSlot,
     uint32_t slotCount,
     IBufferResource* const* buffersIn,
-    const uint32_t* stridesIn,
     const uint32_t* offsetsIn)
 {
     static const int kMaxVertexBuffers = 16;
@@ -3260,7 +3259,7 @@ void D3D11Device::setVertexBuffers(
 
     for (UInt ii = 0; ii < slotCount; ++ii)
     {
-        vertexStrides[ii] = (UINT)stridesIn[ii];
+        // FIXME: vertexhate
         vertexOffsets[ii] = (UINT)offsetsIn[ii];
 		dxBuffers[ii] = buffers[ii]->m_buffer;
 	}

--- a/tools/gfx/d3d11/render-d3d11.cpp
+++ b/tools/gfx/d3d11/render-d3d11.cpp
@@ -3273,6 +3273,7 @@ void D3D11Device::setVertexBuffers(
 {
     static const int kMaxVertexBuffers = 16;
 	assert(slotCount <= kMaxVertexBuffers);
+    assert(m_currentPipelineState);
 
     UINT vertexStrides[kMaxVertexBuffers];
     UINT vertexOffsets[kMaxVertexBuffers];
@@ -3282,7 +3283,6 @@ void D3D11Device::setVertexBuffers(
 
     for (UInt ii = 0; ii < slotCount; ++ii)
     {
-        // FIXME: vertexhate
         auto inputLayout = (InputLayoutImpl*)m_currentPipelineState->inputLayout.Ptr();
         vertexStrides[ii] = inputLayout->m_vertexStreamStrides[startSlot + ii];
         vertexOffsets[ii] = (UINT)offsetsIn[ii];

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -530,7 +530,6 @@ public:
     struct BoundVertexBuffer
     {
         RefPtr<BufferResourceImpl> m_buffer;
-        //int m_stride;
         int m_offset;
     };
 
@@ -3302,7 +3301,6 @@ public:
 
                     BoundVertexBuffer& boundBuffer = m_boundVertexBuffers[startSlot + i];
                     boundBuffer.m_buffer = buffer;
-                    //boundBuffer.m_stride = int(strides[i]);
                     boundBuffer.m_offset = int(offsets[i]);
                 }
             }

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -3338,6 +3338,7 @@ public:
 
                 // Set up vertex buffer views
                 {
+                    auto inputLayout = (InputLayoutImpl*)pipelineState->inputLayout.Ptr();
                     int numVertexViews = 0;
                     D3D12_VERTEX_BUFFER_VIEW vertexViews[16];
                     for (Index i = 0; i < m_boundVertexBuffers.getCount(); i++)
@@ -3352,8 +3353,7 @@ public:
                                 boundVertexBuffer.m_offset;
                             vertexView.SizeInBytes =
                                 UINT(buffer->getDesc()->sizeInBytes - boundVertexBuffer.m_offset);
-                            // FIXME: vertexhate
-                            //vertexView.StrideInBytes = UINT(boundVertexBuffer.m_stride);
+                            vertexView.StrideInBytes = inputLayout->m_vertexStreamStrides[i];
                         }
                     }
                     m_d3dCmdList->IASetVertexBuffers(0, numVertexViews, vertexViews);
@@ -6295,7 +6295,6 @@ Result D3D12Device::createInputLayout(IInputLayout::Desc const& desc, IInputLayo
     layout->m_text.setCount(textSize);
     char* textPos = layout->m_text.getBuffer();
 
-    //
     List<D3D12_INPUT_ELEMENT_DESC>& elements = layout->m_elements;
     elements.setCount(inputElementCount);
 
@@ -6325,9 +6324,11 @@ Result D3D12Device::createInputLayout(IInputLayout::Desc const& desc, IInputLayo
         dstEle.InstanceDataStepRate = (UINT)srcStream.instanceDataStepRate;
     }
 
+    auto& vertexStreamStrides = layout->m_vertexStreamStrides;
+    vertexStreamStrides.setCount(vertexStreamCount);
     for (UInt i = 0; i < vertexStreamCount; ++i)
     {
-        layout->m_vertexStreamStrides[i] = vertexStreams[i].stride;
+        vertexStreamStrides[i] = vertexStreams[i].stride;
     }
 
     returnComPtr(outLayout, layout);

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -3449,7 +3449,7 @@ public:
                     maxDrawCount,
                     argBufferImpl->m_resource,
                     argOffset,
-                    countBufferImpl->m_resource,
+                    countBufferImpl ? countBufferImpl->m_resource.getResource() : nullptr,
                     countOffset);
             }
 
@@ -3470,7 +3470,7 @@ public:
                     maxDrawCount,
                     argBufferImpl->m_resource,
                     argOffset,
-                    countBufferImpl->m_resource,
+                    countBufferImpl ? countBufferImpl->m_resource.getResource() : nullptr,
                     countOffset);
             }
 

--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -584,15 +584,14 @@ Result DebugDevice::createSwapchain(
 }
 
 Result DebugDevice::createInputLayout(
-    const InputElementDesc* inputElements,
-    UInt inputElementCount,
+    IInputLayout::Desc const& desc,
     IInputLayout** outLayout)
 {
     SLANG_GFX_API_FUNC;
 
     RefPtr<DebugInputLayout> outObject = new DebugInputLayout();
     auto result = baseObject->createInputLayout(
-        inputElements, inputElementCount, outObject->baseObject.writeRef());
+        desc, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
     returnComPtr(outLayout, outObject);
@@ -1096,7 +1095,6 @@ void DebugRenderCommandEncoder::setVertexBuffers(
     uint32_t startSlot,
     uint32_t slotCount,
     IBufferResource* const* buffers,
-    const uint32_t* strides,
     const uint32_t* offsets)
 {
     SLANG_GFX_API_FUNC;
@@ -1106,7 +1104,7 @@ void DebugRenderCommandEncoder::setVertexBuffers(
     {
         innerBuffers.add(static_cast<DebugBufferResource*>(buffers[i])->baseObject.get());
     }
-    baseObject->setVertexBuffers(startSlot, slotCount, innerBuffers.getBuffer(), strides, offsets);
+    baseObject->setVertexBuffers(startSlot, slotCount, innerBuffers.getBuffer(), offsets);
 }
 
 void DebugRenderCommandEncoder::setIndexBuffer(

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -106,8 +106,7 @@ public:
         WindowHandle window,
         ISwapchain** outSwapchain) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createInputLayout(
-        const InputElementDesc* inputElements,
-        UInt inputElementCount,
+        IInputLayout::Desc const& desc,
         IInputLayout** outLayout) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
         createCommandQueue(const ICommandQueue::Desc& desc, ICommandQueue** outQueue) override;
@@ -357,7 +356,6 @@ public:
         uint32_t startSlot,
         uint32_t slotCount,
         IBufferResource* const* buffers,
-        const uint32_t* strides,
         const uint32_t* offsets) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
         setIndexBuffer(IBufferResource* buffer, Format indexFormat, uint32_t offset = 0) override;

--- a/tools/gfx/immediate-renderer-base.cpp
+++ b/tools/gfx/immediate-renderer-base.cpp
@@ -201,11 +201,8 @@ public:
             uint32_t startVertex,
             uint32_t startInstanceLocation) override
         {
-            SLANG_UNUSED(vertexCount);
-            SLANG_UNUSED(instanceCount);
-            SLANG_UNUSED(startVertex);
-            SLANG_UNUSED(startInstanceLocation);
-            SLANG_UNIMPLEMENTED_X("drawInstanced");
+            m_writer->bindRootShaderObject(m_commandBuffer->m_rootShaderObject);
+            m_writer->drawInstanced(vertexCount, instanceCount, startVertex, startInstanceLocation);
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedInstanced(
@@ -514,6 +511,14 @@ public:
             case CommandName::DrawIndexed:
                 m_renderer->drawIndexed(
                     cmd.operands[0], cmd.operands[1], cmd.operands[2]);
+                break;
+            case CommandName::DrawInstanced:
+                m_renderer->drawInstanced(
+                    cmd.operands[0], cmd.operands[1], cmd.operands[2], cmd.operands[3]);
+                break;
+            case CommandName::DrawIndexedInstanced:
+                m_renderer->drawIndexedInstanced(
+                    cmd.operands[0], cmd.operands[1], cmd.operands[2], cmd.operands[3], cmd.operands[4]);
                 break;
             case CommandName::SetStencilReference:
                 m_renderer->setStencilReference(cmd.operands[0]);

--- a/tools/gfx/immediate-renderer-base.cpp
+++ b/tools/gfx/immediate-renderer-base.cpp
@@ -212,12 +212,8 @@ public:
             int32_t baseVertexLocation,
             uint32_t startInstanceLocation) override
         {
-            SLANG_UNUSED(indexCount);
-            SLANG_UNUSED(instanceCount);
-            SLANG_UNUSED(startIndexLocation);
-            SLANG_UNUSED(baseVertexLocation);
-            SLANG_UNUSED(startInstanceLocation);
-            SLANG_UNIMPLEMENTED_X("drawIndexedInstanced");
+            m_writer->bindRootShaderObject(m_commandBuffer->m_rootShaderObject);
+            m_writer->drawIndexedInstanced(indexCount, instanceCount, startIndexLocation, baseVertexLocation, startInstanceLocation);
         }
     };
 

--- a/tools/gfx/immediate-renderer-base.cpp
+++ b/tools/gfx/immediate-renderer-base.cpp
@@ -119,10 +119,9 @@ public:
             uint32_t startSlot,
             uint32_t slotCount,
             IBufferResource* const* buffers,
-            const uint32_t* strides,
             const uint32_t* offsets) override
         {
-            m_writer->setVertexBuffers(startSlot, slotCount, buffers, strides, offsets);
+            m_writer->setVertexBuffers(startSlot, slotCount, buffers, offsets);
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL
@@ -500,8 +499,7 @@ public:
                         cmd.operands[0],
                         cmd.operands[1],
                         bufferResources.getArrayView().getBuffer(),
-                        m_writer.getData<uint32_t>(cmd.operands[3]),
-                        m_writer.getData<uint32_t>(cmd.operands[4]));
+                        m_writer.getData<uint32_t>(cmd.operands[3]));
                 }
                 break;
             case CommandName::SetIndexBuffer:

--- a/tools/gfx/immediate-renderer-base.h
+++ b/tools/gfx/immediate-renderer-base.h
@@ -69,6 +69,17 @@ public:
     virtual void draw(uint32_t vertexCount, uint32_t startVertex = 0) = 0;
     virtual void drawIndexed(
         uint32_t indexCount, uint32_t startIndex = 0, uint32_t baseVertex = 0) = 0;
+    virtual void drawInstanced(
+        uint32_t vertexCount,
+        uint32_t instanceCount,
+        uint32_t startVertex,
+        uint32_t startInstanceLocation) = 0;
+    virtual void drawIndexedInstanced(
+        uint32_t indexCount,
+        uint32_t instanceCount,
+        uint32_t startIndexLocation,
+        int32_t baseVertexLocation,
+        uint32_t startInstanceLocation) = 0;
     virtual void setStencilReference(uint32_t referenceValue) = 0;
     virtual void dispatchCompute(int x, int y, int z) = 0;
     virtual void copyBuffer(
@@ -167,6 +178,31 @@ public:
         SLANG_UNUSED(indexCount);
         SLANG_UNUSED(startIndex);
         SLANG_UNUSED(baseVertex);
+    }
+    virtual void drawInstanced(
+        uint32_t vertexCount,
+        uint32_t instanceCount,
+        uint32_t startVertex,
+        uint32_t startInstanceLocation) override
+    {
+        SLANG_UNUSED(vertexCount);
+        SLANG_UNUSED(instanceCount);
+        SLANG_UNUSED(startVertex);
+        SLANG_UNUSED(startInstanceLocation);
+    }
+
+    virtual void drawIndexedInstanced(
+        uint32_t indexCount,
+        uint32_t instanceCount,
+        uint32_t startIndexLocation,
+        int32_t baseVertexLocation,
+        uint32_t startInstanceLocation) override
+    {
+        SLANG_UNUSED(indexCount);
+        SLANG_UNUSED(instanceCount);
+        SLANG_UNUSED(startIndexLocation);
+        SLANG_UNUSED(baseVertexLocation);
+        SLANG_UNUSED(startInstanceLocation);
     }
     virtual void setStencilReference(uint32_t referenceValue) override
     {

--- a/tools/gfx/immediate-renderer-base.h
+++ b/tools/gfx/immediate-renderer-base.h
@@ -63,7 +63,6 @@ public:
         uint32_t startSlot,
         uint32_t slotCount,
         IBufferResource* const* buffers,
-        const uint32_t* strides,
         const uint32_t* offsets) = 0;
     virtual void setIndexBuffer(
         IBufferResource* buffer, Format indexFormat, uint32_t offset = 0) = 0;
@@ -142,13 +141,11 @@ public:
         uint32_t startSlot,
         uint32_t slotCount,
         IBufferResource* const* buffers,
-        const uint32_t* strides,
         const uint32_t* offsets) override
     {
         SLANG_UNUSED(startSlot);
         SLANG_UNUSED(slotCount);
         SLANG_UNUSED(buffers);
-        SLANG_UNUSED(strides);
         SLANG_UNUSED(offsets);
     }
     virtual void setIndexBuffer(
@@ -211,12 +208,10 @@ public:
     }
 
     virtual SLANG_NO_THROW Result SLANG_MCALL createInputLayout(
-        const InputElementDesc* inputElements,
-        UInt inputElementCount,
+        IInputLayout::Desc const& desc,
         IInputLayout** outLayout) override
     {
-        SLANG_UNUSED(inputElements);
-        SLANG_UNUSED(inputElementCount);
+        SLANG_UNUSED(desc);
         SLANG_UNUSED(outLayout);
         return SLANG_E_NOT_AVAILABLE;
     }

--- a/tools/gfx/open-gl/render-gl.cpp
+++ b/tools/gfx/open-gl/render-gl.cpp
@@ -133,8 +133,7 @@ public:
         IBufferResource* buffer, IResourceView::Desc const& desc, IResourceView** outView) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL createInputLayout(
-        const InputElementDesc* inputElements,
-        UInt inputElementCount,
+        IInputLayout::Desc const& desc,
         IInputLayout** outLayout) override;
 
     virtual Result createShaderObjectLayout(
@@ -169,7 +168,6 @@ public:
         uint32_t startSlot,
         uint32_t slotCount,
         IBufferResource* const* buffers,
-        const uint32_t* strides,
         const uint32_t* offsets) override;
     virtual void setIndexBuffer(
         IBufferResource* buffer, Format indexFormat, uint32_t offset) override;
@@ -206,6 +204,7 @@ public:
     protected:
     enum
     {
+        kMaxVertexAttributes = 16,
         kMaxVertexStreams = 16,
         kMaxDescriptorSetCount = 8,
     };
@@ -226,8 +225,10 @@ public:
     class InputLayoutImpl : public InputLayoutBase
 	{
     public:
-        VertexAttributeDesc m_attributes[kMaxVertexStreams];
+        VertexAttributeDesc m_attributes[kMaxVertexAttributes];
+        VertexStreamDesc m_streams[kMaxVertexStreams];
         UInt m_attributeCount = 0;
+        UInt m_streamCount = 0;
     };
 
 	class BufferResourceImpl: public BufferResource
@@ -1590,7 +1591,6 @@ public:
 
     GLenum m_boundPrimitiveTopology = GL_TRIANGLES;
     GLuint  m_boundVertexStreamBuffers[kMaxVertexStreams];
-    UInt    m_boundVertexStreamStrides[kMaxVertexStreams];
     UInt    m_boundVertexStreamOffsets[kMaxVertexStreams];
     GLuint m_boundIndexBuffer = 0;
     UInt m_boundIndexBufferOffset = 0;
@@ -1702,6 +1702,8 @@ void GLDevice::flushStateForDraw()
 
         auto streamIndex = attr.streamIndex;
 
+        auto stride = inputLayout->m_streams[streamIndex].stride;
+
         glBindBuffer(GL_ARRAY_BUFFER, m_boundVertexStreamBuffers[streamIndex]);
 
         glVertexAttribPointer(
@@ -1709,7 +1711,7 @@ void GLDevice::flushStateForDraw()
             attr.format.componentCount,
             attr.format.componentType,
             attr.format.normalized,
-            (GLsizei)m_boundVertexStreamStrides[streamIndex],
+            (GLsizei)stride,
             (GLvoid*)(attr.offset + m_boundVertexStreamOffsets[streamIndex]));
 
         glEnableVertexAttribArray((GLuint)ii);
@@ -2534,19 +2536,28 @@ SLANG_NO_THROW Result SLANG_MCALL GLDevice::createBufferView(
 }
 
 SLANG_NO_THROW Result SLANG_MCALL GLDevice::createInputLayout(
-    const InputElementDesc* inputElements, UInt inputElementCount, IInputLayout** outLayout)
+    IInputLayout::Desc const& desc, IInputLayout** outLayout)
 {
     RefPtr<InputLayoutImpl> inputLayout = new InputLayoutImpl;
 
+    auto inputElements = desc.inputElements;
+    Int inputElementCount = desc.inputElementCount;
     inputLayout->m_attributeCount = inputElementCount;
-    for (UInt ii = 0; ii < inputElementCount; ++ii)
+    for (Int ii = 0; ii < inputElementCount; ++ii)
     {
         auto& inputAttr = inputElements[ii];
         auto& glAttr = inputLayout->m_attributes[ii];
 
-        glAttr.streamIndex = 0;
+        glAttr.streamIndex = (GLuint)inputAttr.bufferSlotIndex;
         glAttr.format = getVertexAttributeFormat(inputAttr.format);
         glAttr.offset = (GLsizei)inputAttr.offset;
+    }
+
+    Int inputStreamCount = desc.vertexStreamCount;
+    inputLayout->m_streamCount = inputStreamCount;
+    for (Int i = 0; i < inputStreamCount; ++i)
+    {
+        inputLayout->m_streams[i].stride = desc.vertexStreams[i].stride;
     }
 
     returnComPtr(outLayout, inputLayout);
@@ -2602,7 +2613,6 @@ void GLDevice::setVertexBuffers(
     uint32_t startSlot,
     uint32_t slotCount,
     IBufferResource* const* buffers,
-    const uint32_t* strides,
     const uint32_t* offsets)
 {
     for (UInt ii = 0; ii < slotCount; ++ii)
@@ -2613,7 +2623,6 @@ void GLDevice::setVertexBuffers(
         GLuint bufferID = buffer ? buffer->m_handle : 0;
 
         m_boundVertexStreamBuffers[slot] = bufferID;
-        m_boundVertexStreamStrides[slot] = strides[ii];
         m_boundVertexStreamOffsets[slot] = offsets[ii];
     }
 }

--- a/tools/gfx/open-gl/render-gl.cpp
+++ b/tools/gfx/open-gl/render-gl.cpp
@@ -177,6 +177,17 @@ public:
     virtual void draw(uint32_t vertexCount, uint32_t startVertex) override;
     virtual void drawIndexed(
         uint32_t indexCount, uint32_t startIndex, uint32_t baseVertex) override;
+    virtual void drawInstanced(
+        uint32_t vertexCount,
+        uint32_t instanceCount,
+        uint32_t startVertex,
+        uint32_t startInstanceLocation) override;
+    virtual void drawIndexedInstanced(
+        uint32_t indexCount,
+        uint32_t instanceCount,
+        uint32_t startIndexLocation,
+        int32_t baseVertexLocation,
+        uint32_t startInstanceLocation) override;
     virtual void dispatchCompute(int x, int y, int z) override;
     virtual void submitGpuWork() override {}
     virtual void waitForGpu() override {}
@@ -2703,6 +2714,25 @@ void GLDevice::drawIndexed(uint32_t indexCount, uint32_t startIndex, uint32_t ba
         GL_UNSIGNED_INT,
         (GLvoid*)(startIndex*sizeof(uint32_t)),
         (GLint)baseVertex);
+}
+
+void GLDevice::drawInstanced(
+    uint32_t vertexCount,
+    uint32_t instanceCount,
+    uint32_t startVertex,
+    uint32_t startInstanceLocation)
+{
+    SLANG_UNIMPLEMENTED_X("drawInstanced");
+}
+
+void GLDevice::drawIndexedInstanced(
+    uint32_t indexCount,
+    uint32_t instanceCount,
+    uint32_t startIndexLocation,
+    int32_t baseVertexLocation,
+    uint32_t startInstanceLocation)
+{
+    SLANG_UNIMPLEMENTED_X("drawIndexedInstanced");
 }
 
 void GLDevice::dispatchCompute(int x, int y, int z)

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -3860,9 +3860,6 @@ public:
         public:
             List<VkViewport> m_viewports;
             List<VkRect2D> m_scissorRects;
-//             List<BoundVertexBuffer> m_boundVertexBuffers;
-//             BoundVertexBuffer m_boundIndexBuffer;
-//             VkIndexType m_boundIndexFormat;
 
         public:
             void beginPass(IRenderPassLayout* renderPass, IFramebuffer* framebuffer)

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -3917,9 +3917,9 @@ public:
                     auto& vkViewport = m_viewports[ii];
 
                     vkViewport.x = inViewport.originX;
-                    vkViewport.y = inViewport.originY;
+                    vkViewport.y = inViewport.originY + inViewport.extentY;
                     vkViewport.width = inViewport.extentX;
-                    vkViewport.height = inViewport.extentY;
+                    vkViewport.height = -inViewport.extentY;
                     vkViewport.minDepth = inViewport.minZ;
                     vkViewport.maxDepth = inViewport.maxZ;
                 }
@@ -6616,7 +6616,7 @@ SlangResult VKDevice::initialize(const Desc& desc)
         m_info.bindingStyle = BindingStyle::Vulkan;
         m_info.projectionStyle = ProjectionStyle::Vulkan;
         m_info.deviceType = DeviceType::Vulkan;
-        static const float kIdentity[] = {1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
+        static const float kIdentity[] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
         ::memcpy(m_info.identityProjectionMatrix, kIdentity, sizeof(kIdentity));
     }
 

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -4075,7 +4075,7 @@ public:
                     m_vkCommandBuffer,
                     argBufferImpl->m_buffer.m_buffer,
                     argOffset,
-                    maxDrawCount, // Should be countBuffer + countOffset?
+                    maxDrawCount,
                     sizeof(VkDrawIndirectCommand));
             }
 
@@ -4096,7 +4096,7 @@ public:
                     m_vkCommandBuffer,
                     argBufferImpl->m_buffer.m_buffer,
                     argOffset,
-                    maxDrawCount, // Should be countBuffer + countOffset?
+                    maxDrawCount,
                     sizeof(VkDrawIndexedIndirectCommand));
             }
 

--- a/tools/gfx/vulkan/vk-api.h
+++ b/tools/gfx/vulkan/vk-api.h
@@ -85,6 +85,7 @@ namespace gfx {
     x(vkCmdBindDescriptorSets) \
     x(vkCmdDispatch) \
     x(vkCmdDraw) \
+    x(vkCmdDrawIndexed) \
     x(vkCmdDrawIndirect) \
     x(vkCmdDrawIndexedIndirect) \
     x(vkCmdSetScissor) \

--- a/tools/gfx/vulkan/vk-api.h
+++ b/tools/gfx/vulkan/vk-api.h
@@ -95,6 +95,7 @@ namespace gfx {
     x(vkCmdEndRenderPass) \
     x(vkCmdPipelineBarrier) \
     x(vkCmdCopyBufferToImage)\
+    x(vkCmdCopyImageToBuffer) \
     x(vkCmdPushConstants) \
     x(vkCmdSetStencilReference) \
     x(vkCmdWriteTimestamp) \

--- a/tools/platform/gui.cpp
+++ b/tools/platform/gui.cpp
@@ -107,6 +107,7 @@ GUI::GUI(
         {"U", 2, Format::R8G8B8A8_UNORM,  offsetof(ImDrawVert, col) },
     };
     auto inputLayout = device->createInputLayout(
+        sizeof(ImDrawVert),
         &inputElements[0],
         SLANG_COUNT_OF(inputElements));
 
@@ -287,7 +288,7 @@ void GUI::endFrame(ITransientResourceHeap* transientHeap, IFramebuffer* framebuf
 
     renderEncoder->bindPipeline(pipelineState);
 
-    renderEncoder->setVertexBuffer(0, vertexBuffer, sizeof(ImDrawVert));
+    renderEncoder->setVertexBuffer(0, vertexBuffer);
     renderEncoder->setIndexBuffer(
         indexBuffer, sizeof(ImDrawIdx) == 2 ? Format::R16_UINT : Format::R32_UINT);
     renderEncoder->setPrimitiveTopology(PrimitiveTopology::TriangleList);
@@ -319,7 +320,7 @@ void GUI::endFrame(ITransientResourceHeap* transientHeap, IFramebuffer* framebuf
 
                 // TODO: set parameter into root shader object.
                 
-                renderEncoder->drawIndexed(command->ElemCount, indexOffset, vertexOffset);
+                renderEncoder->drawIndexed(command->ElemCount, (uint32_t)indexOffset, (uint32_t)vertexOffset);
             }
             indexOffset += command->ElemCount;
         }

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -863,11 +863,10 @@ void RenderTestApp::setProjectionMatrix(IShaderObject* rootObject)
 void RenderTestApp::renderFrame(IRenderCommandEncoder* encoder)
 {
     auto pipelineType = PipelineType::Graphics;
+    applyBinding(pipelineType, encoder);
 
 	encoder->setPrimitiveTopology(PrimitiveTopology::TriangleList);
     encoder->setVertexBuffer(0, m_vertexBuffer);
-
-    applyBinding(pipelineType, encoder);
 
 	encoder->draw(3);
 }

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -553,7 +553,7 @@ SlangResult RenderTestApp::initialize(
 
                 ComPtr<IInputLayout> inputLayout;
                 SLANG_RETURN_ON_FAIL(device->createInputLayout(
-                    inputElements, SLANG_COUNT_OF(inputElements), inputLayout.writeRef()));
+                    sizeof(Vertex), inputElements, SLANG_COUNT_OF(inputElements), inputLayout.writeRef()));
 
                 IBufferResource::Desc vertexBufferDesc;
                 vertexBufferDesc.type = IResource::Type::Buffer;
@@ -865,7 +865,7 @@ void RenderTestApp::renderFrame(IRenderCommandEncoder* encoder)
     auto pipelineType = PipelineType::Graphics;
 
 	encoder->setPrimitiveTopology(PrimitiveTopology::TriangleList);
-    encoder->setVertexBuffer(0, m_vertexBuffer, sizeof(Vertex));
+    encoder->setVertexBuffer(0, m_vertexBuffer);
 
     applyBinding(pipelineType, encoder);
 


### PR DESCRIPTION
Changes:
- Fully implemented vertex buffer binding and input layouts for Vulkan - This comprises the bulk of the changes in this PR, which boil down to providing all vertex stride info when the `InputLayout` is created instead of being passed to `setVertexBuffers()` at call time because Vulkan requires that strides are known by the time pipeline states are created. To handle this, some elements of the current `InputElementDesc` were split off into a new `VertexStreamDesc` struct, and a new `Desc` struct was added under `IInputLayout` which contains both of these descs as well a count of both input elements and vertex streams. All other backends have had their `createInputLayout` and `setVertexBuffers` functions updated to account for these changes.
- Implemented `readTextureResource()` for Vulkan, making it possible to check the results of the draw call tests
- Moved Vulkan index and vertex buffer binding into `setIndexBuffer` and `setVertexBuffers`, respectively, instead of doing it inside each draw call
- Fixed an issue causing the Vulkan draw tests to render upside-down due to viewport orientation
- Added support for instanced and indexed instanced draws to D3D11 as well as tests for both calls

All four draw tests pass on both D3D12 and Vulkan now, and instanced and indexed instanced draws also pass on D3D11.