### PR TITLE
Enable running tests in parallel.

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -793,12 +793,13 @@ end
      uuid "0C768A18-1D25-4000-9F37-DA5FE99E3B64"
      includedirs { "." }
      links { "compiler-core", "slang", "core", "miniz", "lz4" }
- 
      -- We want to set to the root of the project, but that doesn't seem to work with '.'.
      -- So set a path that resolves to the same place.
- 
      debugdir("source/..")
- 
+    if not targetInfo.isWindows then
+        links { "pthread" }
+    end
+     
  --
  -- The reflection test harness `slang-reflection-test` is pretty
  -- simple, in that it only needs to link against the slang library

--- a/source/compiler-core/slang-visual-studio-compiler-util.cpp
+++ b/source/compiler-core/slang-visual-studio-compiler-util.cpp
@@ -87,8 +87,7 @@ namespace Slang
     // https://docs.microsoft.com/en-us/cpp/build/reference/compiler-options-listed-alphabetically?view=vs-2019
 
     cmdLine.addArg("/nologo");
-    // Generate complete debugging information
-    cmdLine.addArg("/Zi");
+
     // Display full path of source files in diagnostics
     cmdLine.addArg("/FC");
 
@@ -139,6 +138,8 @@ namespace Slang
     // /Fd - followed by name of the pdb file
     if (options.debugInfoType != DebugInfoType::None)
     {
+        // Generate complete debugging information
+        cmdLine.addArg("/Zi");
         cmdLine.addPrefixPathArg("/Fd", options.modulePath, ".pdb");
     }
 

--- a/source/core/slang-writer.cpp
+++ b/source/core/slang-writer.cpp
@@ -71,6 +71,7 @@ ISlangUnknown* BaseWriter::getInterface(const Guid& guid)
 
 SLANG_NO_THROW char* SLANG_MCALL AppendBufferWriter::beginAppendBuffer(size_t maxNumChars)
 {
+    mutex.lock();
     m_appendBuffer.setCount(maxNumChars);
     return m_appendBuffer.getBuffer();
 }
@@ -82,6 +83,7 @@ SLANG_NO_THROW SlangResult SLANG_MCALL AppendBufferWriter::endAppendBuffer(char*
     SlangResult res = write(buffer, numChars);
     // Clear so that buffer can't be written from again without assert
     m_appendBuffer.clear();
+    mutex.unlock();
     return res;
 }
 

--- a/source/core/slang-writer.h
+++ b/source/core/slang-writer.h
@@ -8,6 +8,8 @@
 
 #include "slang-list.h"
 
+#include <mutex>
+
 namespace Slang
 {
 
@@ -81,6 +83,7 @@ public:
 
 protected:
     List<char> m_appendBuffer;
+    std::mutex mutex;
 };
 
 class CallbackWriter : public AppendBufferWriter

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -23,12 +23,11 @@ TestCategory* TestCategorySet::add(String const& name, TestCategory* parent)
 
 TestCategory* TestCategorySet::find(String const& name)
 {
-    RefPtr<TestCategory> category;
-    if (!m_categoryMap.TryGetValue(name, category))
+    if (auto category = m_categoryMap.TryGetValue(name))
     {
-        return nullptr;
+        return category->Ptr();
     }
-    return category;
+    return nullptr;
 }
 
 TestCategory* TestCategorySet::findOrError(String const& name)
@@ -190,6 +189,19 @@ static bool _isSubCommand(const char* arg)
                 return SLANG_FAIL;
             }
             optionsOut->adapter = *argCursor++;
+        }
+        else if (strcmp(arg, "-server-count") == 0)
+        {
+            if (argCursor == argEnd)
+            {
+                stdError.print("error: expected operand for '%s'\n", arg);
+                return SLANG_FAIL;
+            }
+            optionsOut->serverCount = StringToInt(* argCursor++);
+            if (optionsOut->serverCount <= 0)
+            {
+                optionsOut->serverCount = 1;
+            }
         }
         else if (strcmp(arg, "-appveyor") == 0)
         {

--- a/tools/slang-test/options.h
+++ b/tools/slang-test/options.h
@@ -112,6 +112,9 @@ struct Options
     // The adapter to use. If empty will match first found adapter.
     Slang::String adapter;
 
+    // Maximum number of test servers to run.
+    int serverCount = 4;
+
         /// Parse the args, report any errors into stdError, and write the results into optionsOut
     static SlangResult parse(int argc, char** argv, TestCategorySet* categorySet, Slang::WriterHelper stdError, Options* optionsOut);
 };

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1759,6 +1759,7 @@ static TestResult runCPPCompilerSharedLibrary(TestContext* context, TestInput& i
     DownstreamCompiler* compiler = context->getDefaultCompiler(SLANG_SOURCE_LANGUAGE_CPP);
     if (!compiler)
     {
+        std::lock_guard<std::mutex> lock(context->mutex);
         return TestResult::Ignored;
     }
 
@@ -1878,6 +1879,7 @@ static TestResult runCPPCompilerExecute(TestContext* context, TestInput& input)
     // If we are just collecting requirements, say it passed
     if (context->isCollectingRequirements())
     {
+        std::lock_guard<std::mutex> lock(context->mutex);
         context->getTestRequirements()->addUsedBackEnd(SLANG_PASS_THROUGH_GENERIC_C_CPP);
         return TestResult::Pass;
     }

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -3478,7 +3478,7 @@ void runTestsInDirectory(
         auto threadFunc = [&](int threadId)
         {
             TestReporter reporter;
-            reporter.init(context->options.outputMode);
+            reporter.init(context->options.outputMode, true);
             TestReporter::SuiteScope suiteScope(&reporter, "tests");
             context->setThreadIndex(threadId);
             do

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -979,6 +979,8 @@ static SlangResult _extractTestRequirements(const CommandLine& cmdLine, TestRequ
 
 static RenderApiFlags _getAvailableRenderApiFlags(TestContext* context)
 {
+    static std::mutex mutex;
+    std::lock_guard<std::mutex> lock(mutex);
     // Only evaluate if it hasn't already been evaluated (the actual evaluation is slow...)
     if (!context->isAvailableRenderApiFlagsValid)
     {
@@ -3048,7 +3050,7 @@ bool testCategoryMatches(
 
 bool testCategoryMatches(
     TestCategory*                           categoryToMatch,
-    Dictionary<TestCategory*, TestCategory*> categorySet)
+    const Dictionary<TestCategory*, TestCategory*>& categorySet)
 {
     for( auto item : categorySet )
     {

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -541,14 +541,16 @@ Result spawnAndWaitExe(TestContext* context, const String& testPath, const Comma
     if (options.shouldBeVerbose)
     {
         String commandLine = cmdLine.toString();
-        context->reporter->messageFormat(TestMessageType::Info, "%s\n", commandLine.begin());
+        context->getTestReporter()->messageFormat(
+            TestMessageType::Info, "%s\n", commandLine.begin());
     }
 
     Result res = ProcessUtil::execute(cmdLine, outRes);
     if (SLANG_FAILED(res))
     {
         //        fprintf(stderr, "failed to run test '%S'\n", testPath.ToWString());
-        context->reporter->messageFormat(TestMessageType::RunError, "failed to run test '%S'", testPath.toWString().begin());
+        context->getTestReporter()->messageFormat(
+            TestMessageType::RunError, "failed to run test '%S'", testPath.toWString().begin());
     }
     return res;
 }
@@ -576,7 +578,8 @@ Result spawnAndWaitSharedLibrary(TestContext* context, const String& testPath, c
         testCmdLine.addArg(exeName);
         testCmdLine.m_args.addRange(cmdLine.m_args);
 
-        context->reporter->messageFormat(TestMessageType::Info, "%s\n", testCmdLine.toString().getBuffer());
+        context->getTestReporter()->messageFormat(
+            TestMessageType::Info, "%s\n", testCmdLine.toString().getBuffer());
     }
 
     auto func = context->getInnerMainFunc(context->options.binDir, exeName);
@@ -649,7 +652,8 @@ Result spawnAndWaitProxy(TestContext* context, const String& testPath, const Com
     if (options.shouldBeVerbose)
     {
         String commandLine = cmdLine.toString();
-        context->reporter->messageFormat(TestMessageType::Info, "%s\n", commandLine.begin());
+        context->getTestReporter()->messageFormat(
+            TestMessageType::Info, "%s\n", commandLine.begin());
     }
 
     // Execute
@@ -657,7 +661,8 @@ Result spawnAndWaitProxy(TestContext* context, const String& testPath, const Com
     if (SLANG_FAILED(res))
     {
         //        fprintf(stderr, "failed to run test '%S'\n", testPath.ToWString());
-        context->reporter->messageFormat(TestMessageType::RunError, "failed to run test '%S'", testPath.toWString().begin());
+        context->getTestReporter()->messageFormat(
+            TestMessageType::RunError, "failed to run test '%S'", testPath.toWString().begin());
     }
 
     return res;
@@ -1301,7 +1306,7 @@ TestResult runDocTest(TestContext* context, TestInput& input)
     // Otherwise we compare to the expected output
     if (!_areResultsEqual(input.testOptions->type, expectedOutput, actualOutput))
     {
-        context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
+        context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
         result = TestResult::Fail;
     }
 
@@ -1313,7 +1318,7 @@ TestResult runDocTest(TestContext* context, TestInput& input)
         String actualOutputPath = outputStem + ".actual";
         Slang::File::writeAllText(actualOutputPath, actualOutput);
 
-        context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
+        context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
     }
 
     return result;
@@ -1386,7 +1391,7 @@ TestResult runSimpleTest(TestContext* context, TestInput& input)
     // Otherwise we compare to the expected output
     if (!_areResultsEqual(input.testOptions->type, expectedOutput, actualOutput))
     {
-        context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
+        context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
         result = TestResult::Fail;
     }
 
@@ -1398,7 +1403,7 @@ TestResult runSimpleTest(TestContext* context, TestInput& input)
         String actualOutputPath = outputStem + ".actual";
         Slang::File::writeAllText(actualOutputPath, actualOutput);
 
-        context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
+        context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
     }
 
     return result;
@@ -1495,14 +1500,14 @@ TestResult runSimpleLineTest(TestContext* context, TestInput& input)
         }
         else
         {
-            context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
+            context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
         }
     }
     else
     {
         StringBuilder buf;
         buf << "Unable to find expected output for '" << outputStem << "'";
-        context->reporter->message(TestMessageType::TestFailure, buf);
+        context->getTestReporter()->message(TestMessageType::TestFailure, buf);
     }
 
     // If the test failed, then we write the actual output to a file
@@ -1550,7 +1555,7 @@ TestResult runCompile(TestContext* context, TestInput& input)
 
     if (exeRes.resultCode != 0)
     {
-        auto reporter = context->reporter;
+        auto reporter = context->getTestReporter();
         if (reporter)
         {
             auto output = getOutput(exeRes);
@@ -1666,7 +1671,7 @@ TestResult runReflectionTest(TestContext* context, TestInput& input)
         String actualOutputPath = outputStem + ".actual";
         Slang::File::writeAllText(actualOutputPath, actualOutput);
 
-        context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
+        context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
     }
 
     return result;
@@ -1825,7 +1830,7 @@ static TestResult runCPPCompilerSharedLibrary(TestContext* context, TestInput& i
             // Compare if they are the same 
             if (!StringUtil::areLinesEqual(actualOutput.getUnownedSlice(), expectedOutput.getUnownedSlice()))
             {
-                context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
+                context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
                 return TestResult::Fail;
             }
         }
@@ -1964,7 +1969,7 @@ static TestResult runCPPCompilerExecute(TestContext* context, TestInput& input)
         // Compare if they are the same 
         if (!StringUtil::areLinesEqual(actualOutput.getUnownedSlice(), expectedOutput.getUnownedSlice()))
         {
-            context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
+            context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
             return TestResult::Fail;
         }
     }
@@ -2087,7 +2092,7 @@ TestResult runCrossCompilerTest(TestContext* context, TestInput& input)
         String actualOutputPath = outputStem + ".actual";
         Slang::File::writeAllText(actualOutputPath, actualOutput);
 
-        context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
+        context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
     }
 
     return result;
@@ -2241,7 +2246,7 @@ static TestResult _runHLSLComparisonTest(
         String actualOutputPath = outputStem + ".actual";
         Slang::File::writeAllText(actualOutputPath, actualOutput);
 
-        context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
+        context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
     }
 
     return result;
@@ -2358,7 +2363,7 @@ TestResult runGLSLComparisonTest(TestContext* context, TestInput& input)
 
     if (!StringUtil::areLinesEqual(actualOutput.getUnownedSlice(), expectedOutput.getUnownedSlice()))
     {
-        context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
+        context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
 
         return TestResult::Fail;
     }
@@ -2429,7 +2434,7 @@ TestResult runPerformanceProfile(TestContext* context, TestInput& input)
         return TestResult::Fail;
     }
 
-    context->reporter->addExecutionTime(time);
+    context->getTestReporter()->addExecutionTime(time);
 
     return TestResult::Pass;
 }
@@ -2598,7 +2603,7 @@ TestResult runComputeComparisonImpl(TestContext* context, TestInput& input, cons
     
     if (!StringUtil::areLinesEqual(actualOutput.getUnownedSlice(), expectedOutput.getUnownedSlice()))
     {
-        context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
+        context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
 
         String actualOutputPath = outputStem + ".actual";
         Slang::File::writeAllText(actualOutputPath, actualOutput);
@@ -2625,7 +2630,11 @@ TestResult runComputeComparisonImpl(TestContext* context, TestInput& input, cons
 
     if (SLANG_FAILED(_compareWithType(actualOutputContent.getUnownedSlice(), referenceOutputContent.getUnownedSlice())))
     {
-        context->reporter->messageFormat(TestMessageType::TestFailure, "output mismatch! actual output: {\n%s\n}, \n%s\n", actualOutputContent.getBuffer(), referenceOutputContent.getBuffer());
+        context->getTestReporter()->messageFormat(
+            TestMessageType::TestFailure,
+            "output mismatch! actual output: {\n%s\n}, \n%s\n",
+            actualOutputContent.getBuffer(),
+            referenceOutputContent.getBuffer());
         return TestResult::Fail;
     }
 
@@ -2774,7 +2783,7 @@ bool STBImage::isComparable(const ThisType& rhs) const
 
 TestResult doImageComparison(TestContext* context, String const& filePath)
 {
-    auto reporter = context->reporter;
+    auto reporter = context->getTestReporter();
 
     // Allow a difference in the low bits of the 8-bit result, just to play it safe
     static const int kAbsoluteDiffCutoff = 2;
@@ -2904,7 +2913,7 @@ TestResult runHLSLRenderComparisonTestImpl(
 
     if (!StringUtil::areLinesEqual(actualOutput.getUnownedSlice(), expectedOutput.getUnownedSlice()))
     {
-        context->reporter->dumpOutputDifference(expectedOutput, actualOutput);
+        context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
 
         return TestResult::Fail;
     }
@@ -3207,8 +3216,7 @@ static bool _canIgnore(TestContext* context, const TestDetails& details)
 
 static SlangResult _runTestsOnFile(
     TestContext*    context,
-    String          filePath,
-    TestReporter*   reporter)
+    String          filePath)
 {
     // Gather a list of tests to run
     FileTestList testList;
@@ -3224,7 +3232,7 @@ static SlangResult _runTestsOnFile(
     // Note cases where a test file exists, but we found nothing to run
     if( testList.tests.getCount() == 0 )
     {
-        reporter->addTest(filePath, TestResult::Ignored);
+        context->getTestReporter()->addTest(filePath, TestResult::Ignored);
         return SLANG_OK;
     }
 
@@ -3335,7 +3343,7 @@ static SlangResult _runTestsOnFile(
 
         // Report the test and run/ignore
         {
-            TestReporter::TestScope scope(reporter, testName);
+            TestReporter::TestScope scope(context->getTestReporter(), testName);
 
             TestResult testResult = TestResult::Fail;
 
@@ -3349,7 +3357,7 @@ static SlangResult _runTestsOnFile(
                 testResult = runTest(context, filePath, outputStem, testName, testDetails.options);
             }
 
-            reporter->addResult(testResult);
+            context->getTestReporter()->addResult(testResult);
 
             // Could determine if to continue or not here... based on result
         }        
@@ -3434,19 +3442,19 @@ void runTestsInDirectory(
 {
     List<String> files;
     getFilesInDirectory(directoryPath, files);
-    auto processFile = [&](TestReporter* reporter, String file)
+    auto processFile = [&](String file)
     {
         if (shouldRunTest(context, file))
         {
             //            fprintf(stderr, "slang-test: found '%s'\n", file.getBuffer());
-            if (SLANG_FAILED(_runTestsOnFile(context, file, reporter)))
+            if (SLANG_FAILED(_runTestsOnFile(context, file)))
             {
                 {
-                    TestReporter::TestScope scope(reporter, file);
-                    reporter->message(
+                    TestReporter::TestScope scope(context->getTestReporter(), file);
+                    context->getTestReporter()->message(
                         TestMessageType::RunError, "slang-test: unable to parse test");
 
-                    reporter->addResult(TestResult::Fail);
+                    context->getTestReporter()->addResult(TestResult::Fail);
                 }
 
                 // Output there was some kind of error trying to run the tests on this file
@@ -3470,11 +3478,12 @@ void runTestsInDirectory(
     {
         for (auto file : files)
         {
-            processFile(context->reporter, file);
+            processFile(file);
         }
     }
     else
     {
+        auto originalReporter = context->getTestReporter();
         std::atomic<int> consumePtr;
         consumePtr = 0;
         auto threadFunc = [&](int threadId)
@@ -3483,17 +3492,19 @@ void runTestsInDirectory(
             reporter.init(context->options.outputMode, true);
             TestReporter::SuiteScope suiteScope(&reporter, "tests");
             context->setThreadIndex(threadId);
+            context->setTestReporter(&reporter);
             do
             {
                 int index = consumePtr.fetch_add(1);
                 if (index >= (int)files.getCount())
                     break;
-                processFile(&reporter, files[index]);
+                processFile(files[index]);
             } while (true);
             {
                 std::lock_guard<std::mutex> lock(context->mutex);
-                context->reporter->consolidateWith(&reporter);
+                originalReporter->consolidateWith(&reporter);
             }
+            context->setTestReporter(nullptr);
         };
         List<std::thread> threads;
         for (int threadId = 0; threadId < context->options.serverCount; threadId++)
@@ -3502,6 +3513,7 @@ void runTestsInDirectory(
         }
         for (auto& t : threads)
             t.join();
+        context->setTestReporter(originalReporter);
     }
 }
 
@@ -3722,7 +3734,7 @@ SlangResult innerMain(int argc, char** argv)
 
     Options& options = context.options;
 
-    context.setMaxRPCConnectionCount(options.serverCount);
+    context.setMaxTestRunnerThreadCount(options.serverCount);
 
     // Set up the prelude/s
     TestToolUtil::setSessionDefaultPreludeFromExePath(argv[0], context.getSession());
@@ -3785,7 +3797,7 @@ SlangResult innerMain(int argc, char** argv)
         TestReporter reporter;
         SLANG_RETURN_ON_FAIL(reporter.init(options.outputMode));
 
-        context.reporter = &reporter;
+        context.setTestReporter(&reporter);
 
         reporter.m_dumpOutputOnFailure = options.dumpOutputOnFailure;
         reporter.m_isVerbose = options.shouldBeVerbose;

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1459,7 +1459,7 @@ TestResult runSimpleLineTest(TestContext* context, TestInput& input)
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
-     
+
     if (context->isCollectingRequirements())
     {
         return TestResult::Pass;

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -126,10 +126,9 @@ void TestContext::setInnerMainFunc(const String& name, InnerMainFunc func)
 
 DownstreamCompilerSet* TestContext::getCompilerSet()
 {
+    std::lock_guard<std::mutex> lock(mutex);
     if (!compilerSet)
     {
-        std::lock_guard<std::mutex> lock(mutex);
-
         compilerSet = new DownstreamCompilerSet;
 
         DownstreamCompilerLocatorFunc locators[int(SLANG_PASS_THROUGH_COUNT_OF)] = { nullptr };

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -12,6 +12,8 @@
 
 using namespace Slang;
 
+thread_local int slangTestThreadIndex = 0;
+
 TestContext::TestContext() 
 {
     m_session = nullptr;
@@ -21,6 +23,24 @@ TestContext::TestContext()
     // 10 mins(!). This seems to be the order of time needed for timeout on a CI ARM test system on debug
     connectionTimeOutInMs = 1000 * 60 * 10;
 #endif
+}
+
+void TestContext::setThreadIndex(int index) { slangTestThreadIndex = index; }
+
+void TestContext::setMaxRPCConnectionCount(int count)
+{
+    m_jsonRpcConnections.setCount(count);
+    m_testRequirements.setCount(count);
+}
+
+void TestContext::setTestRequirements(TestRequirements* req)
+{
+    m_testRequirements[slangTestThreadIndex] = req;
+}
+
+TestRequirements* TestContext::getTestRequirements() const
+{
+    return m_testRequirements[slangTestThreadIndex];
 }
 
 Result TestContext::init(const char* exePath)
@@ -138,24 +158,24 @@ SlangResult TestContext::_createJSONRPCConnection(RefPtr<JSONRPCConnection>& out
 
 void TestContext::destroyRPCConnection()
 {
-    if (m_jsonRpcConnection)
+    if (m_jsonRpcConnections[slangTestThreadIndex])
     {
-        m_jsonRpcConnection->disconnect();
-        m_jsonRpcConnection.setNull();
+        m_jsonRpcConnections[slangTestThreadIndex]->disconnect();
+        m_jsonRpcConnections[slangTestThreadIndex].setNull();
     }
 }
 
 Slang::JSONRPCConnection* TestContext::getOrCreateJSONRPCConnection()
 {
-    if (!m_jsonRpcConnection)
+    if (!m_jsonRpcConnections[slangTestThreadIndex])
     {
-        if (SLANG_FAILED(_createJSONRPCConnection(m_jsonRpcConnection)))
+        if (SLANG_FAILED(_createJSONRPCConnection(m_jsonRpcConnections[slangTestThreadIndex])))
         {
             return nullptr;
         }
     }
 
-    return m_jsonRpcConnection;
+    return m_jsonRpcConnections[slangTestThreadIndex];
 }
 
 

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -27,10 +27,15 @@ TestContext::TestContext()
 
 void TestContext::setThreadIndex(int index) { slangTestThreadIndex = index; }
 
-void TestContext::setMaxRPCConnectionCount(int count)
+void TestContext::setMaxTestRunnerThreadCount(int count)
 {
     m_jsonRpcConnections.setCount(count);
     m_testRequirements.setCount(count);
+    m_reporters.setCount(count);
+    for (auto& reporter : m_reporters)
+    {
+        reporter = nullptr;
+    }
 }
 
 void TestContext::setTestRequirements(TestRequirements* req)
@@ -41,6 +46,16 @@ void TestContext::setTestRequirements(TestRequirements* req)
 TestRequirements* TestContext::getTestRequirements() const
 {
     return m_testRequirements[slangTestThreadIndex];
+}
+
+void TestContext::setTestReporter(TestReporter* reporter)
+{
+    m_reporters[slangTestThreadIndex] = reporter;
+}
+
+TestReporter* TestContext::getTestReporter()
+{
+    return m_reporters[slangTestThreadIndex];
 }
 
 Result TestContext::init(const char* exePath)

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -113,6 +113,8 @@ DownstreamCompilerSet* TestContext::getCompilerSet()
 {
     if (!compilerSet)
     {
+        std::lock_guard<std::mutex> lock(mutex);
+
         compilerSet = new DownstreamCompilerSet;
 
         DownstreamCompilerLocatorFunc locators[int(SLANG_PASS_THROUGH_COUNT_OF)] = { nullptr };

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -17,6 +17,8 @@
 
 #include "options.h"
 
+#include <mutex>
+
 typedef uint32_t PassThroughFlags;
 struct PassThroughFlag
 {
@@ -93,10 +95,14 @@ class TestContext
         /// Set the function for the shared library
     void setInnerMainFunc(const Slang::String& name, InnerMainFunc func);
 
+    void setTestRequirements(TestRequirements* req);
+
+    TestRequirements* getTestRequirements() const;
+
         /// If true tests aren't being run just the information on testing is being accumulated
-    bool isCollectingRequirements() const { return testRequirements != nullptr; }
+    bool isCollectingRequirements() const { return getTestRequirements() != nullptr; }
         /// If set, then tests are executed
-    bool isExecuting() const { return testRequirements == nullptr; }
+    bool isExecuting() const { return getTestRequirements() == nullptr; }
 
         /// True if a render API filter is enabled
     bool isRenderApiFilterEnabled() const { return options.enabledApis != Slang::RenderApiFlag::AllOf && options.enabledApis != 0; }
@@ -130,7 +136,6 @@ class TestContext
     TestCategorySet categorySet;
 
         /// If set then tests are not run, but their requirements are set 
-    TestRequirements* testRequirements = nullptr;
 
     PassThroughFlags availableBackendFlags = 0;
     Slang::RenderApiFlags availableRenderApiFlags = 0;
@@ -153,6 +158,12 @@ class TestContext
         /// Current default is 2 mins.
     Slang::Int connectionTimeOutInMs = 2 * 60 * 1000;
 
+    void setThreadIndex(int index);
+    void setMaxRPCConnectionCount(int count);
+
+    std::mutex mutex;
+    Slang::List<TestRequirements*> m_testRequirements = nullptr;
+
 protected:
     SlangResult _createJSONRPCConnection(Slang::RefPtr<Slang::JSONRPCConnection>& out);
 
@@ -162,7 +173,7 @@ protected:
         InnerMainFunc m_func;
     };
 
-    Slang::RefPtr<Slang::JSONRPCConnection> m_jsonRpcConnection;
+    Slang::List<Slang::RefPtr<Slang::JSONRPCConnection>> m_jsonRpcConnections;
     
     SlangSession* m_session;
 

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -132,7 +132,6 @@ class TestContext
     ~TestContext();
 
     Options options;
-    TestReporter* reporter = nullptr;
     TestCategorySet categorySet;
 
         /// If set then tests are not run, but their requirements are set 
@@ -159,10 +158,12 @@ class TestContext
     Slang::Int connectionTimeOutInMs = 2 * 60 * 1000;
 
     void setThreadIndex(int index);
-    void setMaxRPCConnectionCount(int count);
+    void setMaxTestRunnerThreadCount(int count);
+
+    void setTestReporter(TestReporter* reporter);
+    TestReporter* getTestReporter();
 
     std::mutex mutex;
-    Slang::List<TestRequirements*> m_testRequirements = nullptr;
 
 protected:
     SlangResult _createJSONRPCConnection(Slang::RefPtr<Slang::JSONRPCConnection>& out);
@@ -174,6 +175,8 @@ protected:
     };
 
     Slang::List<Slang::RefPtr<Slang::JSONRPCConnection>> m_jsonRpcConnections;
+    Slang::List<TestReporter*> m_reporters;
+    Slang::List<TestRequirements*> m_testRequirements = nullptr;
     
     SlangSession* m_session;
 

--- a/tools/slang-test/test-reporter.cpp
+++ b/tools/slang-test/test-reporter.cpp
@@ -193,6 +193,15 @@ TestResult TestReporter::addTest(const String& testName, bool isPass)
     return res;
 }
 
+void TestReporter::consolidateWith(TestReporter* other)
+{
+    m_testInfos.addRange(other->m_testInfos);
+    m_failedTestCount += other->m_failedTestCount;
+    m_ignoredTestCount += other->m_ignoredTestCount;
+    m_passedTestCount += other->m_passedTestCount;
+    m_totalTestCount += other->m_totalTestCount;
+}
+
 void TestReporter::dumpOutputDifference(const String& expectedOutput, const String& actualOutput)
 {
     StringBuilder builder;

--- a/tools/slang-test/test-reporter.cpp
+++ b/tools/slang-test/test-reporter.cpp
@@ -7,6 +7,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <mutex>
+
 using namespace Slang;
 
 /* static */TestReporter* TestReporter::s_reporter = nullptr;
@@ -493,6 +495,8 @@ void TestReporter::addTest(const String& testName, TestResult testResult)
 
 void TestReporter::message(TestMessageType type, const String& message)
 {
+    static std::mutex mutex;
+    std::lock_guard<std::mutex> lock(mutex);
     if (type == TestMessageType::Info)
     {
         if (m_isVerbose && canWriteStdError())

--- a/tools/slang-test/test-reporter.cpp
+++ b/tools/slang-test/test-reporter.cpp
@@ -84,9 +84,10 @@ TestReporter::TestReporter() :
     m_isVerbose = false;
 }
 
-Result TestReporter::init(TestOutputMode outputMode)
+Result TestReporter::init(TestOutputMode outputMode, bool isSubReporter)
 {
     m_outputMode = outputMode;
+    m_isSubReporter = isSubReporter;
     return SLANG_OK;
 }
 
@@ -679,9 +680,12 @@ void TestReporter::startSuite(const String& name)
     {
         case TestOutputMode::TeamCity:
         {
-            StringBuilder escapedSuiteName;
-            _appendEncodedTeamCityString(name.getUnownedSlice(), escapedSuiteName);
-            printf("##teamcity[testSuiteStarted name='%s']\n", escapedSuiteName.begin());
+            if (!m_isSubReporter)
+            {
+                StringBuilder escapedSuiteName;
+                _appendEncodedTeamCityString(name.getUnownedSlice(), escapedSuiteName);
+                printf("##teamcity[testSuiteStarted name='%s']\n", escapedSuiteName.begin());
+            }
             break;
         }
         default: break;
@@ -696,10 +700,13 @@ void TestReporter::endSuite()
     {
         case TestOutputMode::TeamCity:
         {
-            const String& name = m_suiteStack.getLast();
-            StringBuilder escapedSuiteName;
-            _appendEncodedTeamCityString(name.getUnownedSlice(), escapedSuiteName);
-            printf("##teamcity[testSuiteFinished name='%s']\n", escapedSuiteName.begin());
+            if (!m_isSubReporter)
+            {
+                const String& name = m_suiteStack.getLast();
+                StringBuilder escapedSuiteName;
+                _appendEncodedTeamCityString(name.getUnownedSlice(), escapedSuiteName);
+                printf("##teamcity[testSuiteFinished name='%s']\n", escapedSuiteName.begin());
+            }
             break;
         }
         default: break;

--- a/tools/slang-test/test-reporter.h
+++ b/tools/slang-test/test-reporter.h
@@ -87,6 +87,8 @@ class TestReporter : public ITestReporter
 
     void dumpOutputDifference(const Slang::String& expectedOutput, const Slang::String& actualOutput);
 
+    void consolidateWith(TestReporter* other);
+
         /// True if can write output directly to stderr
     bool canWriteStdError() const;
 

--- a/tools/slang-test/test-reporter.h
+++ b/tools/slang-test/test-reporter.h
@@ -98,7 +98,7 @@ class TestReporter : public ITestReporter
 
     void outputSummary();
 
-    SlangResult init(TestOutputMode outputMode);
+    SlangResult init(TestOutputMode outputMode, bool isSubReporter = false);
 
         /// Ctor
     TestReporter();
@@ -125,6 +125,7 @@ class TestReporter : public ITestReporter
     bool m_dumpOutputOnFailure;
     bool m_isVerbose = false;
     bool m_hideIgnored = false;
+    bool m_isSubReporter = false;
 
 protected:
     


### PR DESCRIPTION
Allows slang-test to start multiple instances of TestServer and dispatch tests to them in parallel.
Modifies `TestContext` to make most its methods thread-safe.

This significantly reduces the amount of testing time. Using 4 threads, the test time on team city reduced from 13 minutes to 5 minutes.

This change only affects TestServer spawn mode, others test spawn modes are unaffected and still runs in a single thread.

The caveat is that because tests are running in more separate processes, there is a chance that TeamCity would mistake the test report from one build configuration as from another build configuration that is concurrently running on the same physical machine. For example, if a machine is running tests for both x64 debug and x64 release, it may some time report 1-2 less tests in x64debug and show them up in the test list of x64release.