### PR TITLE
Revise entrypoint renaming interface.

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -4248,33 +4248,39 @@ namespace slang
             (and hence the global layout) that results will be deterministic,
             but is not currently documented.
             */
-            virtual SLANG_NO_THROW SlangResult SLANG_MCALL link(
-                IComponentType**            outLinkedComponentType,
-                ISlangBlob**                outDiagnostics = nullptr) = 0;
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL link(
+            IComponentType**            outLinkedComponentType,
+            ISlangBlob**                outDiagnostics = nullptr) = 0;
 
-                /** Get entry point 'callable' functions accessible through the ISlangSharedLibrary interface.
+            /** Get entry point 'callable' functions accessible through the ISlangSharedLibrary interface.
 
-                The functions remain in scope as long as the ISlangSharedLibrary interface is in scope.
+            The functions remain in scope as long as the ISlangSharedLibrary interface is in scope.
 
-                NOTE! Requires a compilation target of SLANG_HOST_CALLABLE.
+            NOTE! Requires a compilation target of SLANG_HOST_CALLABLE.
     
-                @param entryPointIndex  The index of the entry point to get code for.
-                @param targetIndex      The index of the target to get code for (default: zero).
-                @param outSharedLibrary A pointer to a ISharedLibrary interface which functions can be queried on.
-                @returns                A `SlangResult` to indicate success or failure.
-                */
-            virtual SLANG_NO_THROW SlangResult SLANG_MCALL getEntryPointHostCallable(
-                int                     entryPointIndex,
-                int                     targetIndex,
-                ISlangSharedLibrary**   outSharedLibrary,
-                slang::IBlob**          outDiagnostics = 0) = 0;
+            @param entryPointIndex  The index of the entry point to get code for.
+            @param targetIndex      The index of the target to get code for (default: zero).
+            @param outSharedLibrary A pointer to a ISharedLibrary interface which functions can be queried on.
+            @returns                A `SlangResult` to indicate success or failure.
+            */
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL getEntryPointHostCallable(
+            int                     entryPointIndex,
+            int                     targetIndex,
+            ISlangSharedLibrary**   outSharedLibrary,
+            slang::IBlob**          outDiagnostics = 0) = 0;
+
+            /** Get a new ComponentType object that represents a renamed entry point.
+
+            The current object must be a single EntryPoint, or a CompositeComponentType or
+            SpecializedComponentType that contains one EntryPoint component.
+            */
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL renameEntryPoint(
+            const char* newName, IComponentType** outEntryPoint) = 0;
     };
     #define SLANG_UUID_IComponentType IComponentType::getTypeGuid()
 
     struct IEntryPoint : public IComponentType
     {
-        virtual SLANG_NO_THROW SlangResult SLANG_MCALL getRenamedEntryPoint(const char* newName, IEntryPoint** outEntryPoint) = 0;
-
         SLANG_COM_INTERFACE(0x8f241361, 0xf5bd, 0x4ca0, { 0xa3, 0xac, 0x2, 0xf7, 0xfa, 0x24, 0x2, 0xb8 })
     };
 

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -287,7 +287,7 @@ namespace Slang
         SLANG_UNUSED(index);
         SLANG_ASSERT(index == 0);
 
-        return m_nameOverride;
+        return m_name ? m_name->text : "";
     }
 
     void EntryPoint::acceptVisitor(ComponentTypeVisitor* visitor, SpecializationInfo* specializationInfo)

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -8242,6 +8242,13 @@ struct SpecializedComponentTypeIRGenContext : ComponentTypeVisitor
         lowerProgramEntryPointToIR(context, entryPoint, specializationInfo);
     }
 
+    void visitRenamedEntryPoint(
+        RenamedEntryPointComponentType* entryPoint,
+        EntryPoint::EntryPointSpecializationInfo* specializationInfo) SLANG_OVERRIDE
+    {
+        entryPoint->getBase()->acceptVisitor(this, specializationInfo);
+    }
+
     void visitModule(Module* module, Module::ModuleSpecializationInfo* specializationInfo) SLANG_OVERRIDE
     {
         // We've hit a leaf module, so we should be able to bind any global

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -2729,6 +2729,13 @@ struct CollectGlobalGenericArgumentsVisitor : ComponentTypeVisitor
 
     ParameterBindingContext* m_context;
 
+    void visitRenamedEntryPoint(
+        RenamedEntryPointComponentType* entryPoint,
+        EntryPoint::EntryPointSpecializationInfo* specializationInfo) SLANG_OVERRIDE
+    {
+        entryPoint->getBase()->acceptVisitor(this, specializationInfo);
+    }
+
     void visitEntryPoint(EntryPoint* entryPoint, EntryPoint::EntryPointSpecializationInfo* specializationInfo) SLANG_OVERRIDE
     {
         SLANG_UNUSED(entryPoint);
@@ -2887,6 +2894,13 @@ struct CollectParametersVisitor : ComponentTypeVisitor
         context->stage = entryPoint->getStage();
 
         collectEntryPointParameters(context, entryPoint, specializationInfo);
+    }
+
+    void visitRenamedEntryPoint(
+        RenamedEntryPointComponentType* renamedEntryPoint,
+        EntryPoint::EntryPointSpecializationInfo* specializationInfo) SLANG_OVERRIDE
+    {
+        renamedEntryPoint->getBase()->acceptVisitor(this, specializationInfo);
     }
 
     void visitModule(Module* module, Module::ModuleSpecializationInfo* specializationInfo) SLANG_OVERRIDE
@@ -3107,6 +3121,13 @@ struct CompleteBindingsVisitor : ComponentTypeVisitor
         completeBindingsForParameter(m_context, globalEntryPointInfo->parametersLayout);
     }
 
+    void visitRenamedEntryPoint(
+        RenamedEntryPointComponentType* renamedEntryPoint,
+        EntryPoint::EntryPointSpecializationInfo* specializationInfo) SLANG_OVERRIDE
+    {
+        renamedEntryPoint->getBase()->acceptVisitor(this, specializationInfo);
+    }
+
     void visitModule(Module* module, Module::ModuleSpecializationInfo* specializationInfo) SLANG_OVERRIDE
     {
         SLANG_UNUSED(specializationInfo);
@@ -3234,6 +3255,13 @@ struct FlushPendingDataVisitor : ComponentTypeVisitor
         // appeared in the entry-point parameter list.
         //
         _allocateBindingsForPendingData(m_context, globalEntryPointInfo->parametersLayout->pendingVarLayout);
+    }
+
+    void visitRenamedEntryPoint(
+        RenamedEntryPointComponentType* entryPoint,
+        EntryPoint::EntryPointSpecializationInfo* specializationInfo) SLANG_OVERRIDE
+    {
+        entryPoint->getBase()->acceptVisitor(this, specializationInfo);
     }
 
     void visitModule(Module* module, Module::ModuleSpecializationInfo* specializationInfo) SLANG_OVERRIDE


### PR DESCRIPTION
Changed the interface from `IEntryPoint::getRenamedEntryPoint` to `IComponentType::renameEntryPoint`.

The underlying implementation creates a `RenamedEntryPointComponentType` wrapper object around the base entry-point.

This new implementation allows the user to specify entry point renaming on an IComponentType that isn't just a `EntryPoint`, but also on `SpecializedComponentType` or `CompositeComponentType` as long as the component defines a single entry point.