### PR TITLE
Add target option to force `scalar` layout for storage buffers.

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -1365,6 +1365,12 @@ extern "C"
         int targetIndex,
         SlangLineDirectiveMode  mode);
 
+    /*! @see slang::ICompileRequest::setTargetLineDirectiveMode */
+    SLANG_API void spSetTargetForceGLSLScalarBufferLayout(
+        SlangCompileRequest*    request,
+        int targetIndex,
+        bool forceScalarLayout);
+
     /*! @see slang::ICompileRequest::setCodeGenTarget */
     SLANG_API void spSetCodeGenTarget(
         SlangCompileRequest*    request,
@@ -3867,6 +3873,12 @@ namespace slang
         virtual SLANG_NO_THROW void SLANG_MCALL setTargetLineDirectiveMode(
             SlangInt targetIndex,
             SlangLineDirectiveMode mode) = 0;
+
+            /** Set whether to use scalar buffer layouts for GLSL/Vulkan targets.
+                If true, the generated GLSL/Vulkan code will use `scalar` layout for storage buffers.
+                If false, the resulting code will std430 for storage buffers.
+            */
+        virtual SLANG_NO_THROW void SLANG_MCALL setTargetForceGLSLScalarBufferLayout(int targetIndex, bool forceScalarLayout) = 0;
     };
 
     #define SLANG_UUID_ICompileRequest ICompileRequest::getTypeGuid()
@@ -3901,6 +3913,10 @@ namespace slang
             /** The line directive mode for output source code.
             */
         SlangLineDirectiveMode lineDirectiveMode = SLANG_LINE_DIRECTIVE_MODE_DEFAULT;
+
+            /** Whether to force `scalar` layout for glsl shader storage buffers.
+            */
+        bool forceGLSLScalarBufferLayout = false;
     };
 
     typedef uint32_t SessionFlags;

--- a/source/slang/slang-api.cpp
+++ b/source/slang/slang-api.cpp
@@ -269,6 +269,14 @@ SLANG_API void spSetLineDirectiveMode(
     request->setLineDirectiveMode(mode);
 }
 
+
+SLANG_API void spSetTargetForceGLSLScalarBufferLayout(
+    slang::ICompileRequest* request, int targetIndex, bool forceScalarLayout)
+{
+    SLANG_ASSERT(request);
+    request->setTargetForceGLSLScalarBufferLayout(targetIndex, forceScalarLayout);
+}
+
 SLANG_API void spSetTargetLineDirectiveMode(
     slang::ICompileRequest* request,
     int targetIndex,

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1461,6 +1461,11 @@ namespace Slang
         {
             dumpIntermediates = value;
         }
+        void setForceGLSLScalarBufferLayout(bool value)
+        {
+            forceGLSLScalarBufferLayout = value;
+        }
+
         void addCapability(CapabilityAtom capability);
 
         bool shouldEmitSPIRVDirectly()
@@ -1482,6 +1487,7 @@ namespace Slang
         LineDirectiveMode getLineDirectiveMode() { return lineDirectiveMode; }
         SlangTargetFlags getTargetFlags() { return targetFlags; }
         CapabilitySet getTargetCaps();
+        bool getForceGLSLScalarBufferLayout() { return forceGLSLScalarBufferLayout; }
 
         Session* getSession();
         MatrixLayoutMode getDefaultMatrixLayoutMode();
@@ -1503,6 +1509,7 @@ namespace Slang
         CapabilitySet           cookedCapabilities;
         LineDirectiveMode       lineDirectiveMode = LineDirectiveMode::Default;
         bool                    dumpIntermediates = false;
+        bool                    forceGLSLScalarBufferLayout = false;
     };
 
         /// Are we generating code for a D3D API?
@@ -2243,6 +2250,7 @@ namespace Slang
         virtual SLANG_NO_THROW void SLANG_MCALL setTargetFlags(int targetIndex, SlangTargetFlags flags) SLANG_OVERRIDE;
         virtual SLANG_NO_THROW void SLANG_MCALL setTargetFloatingPointMode(int targetIndex, SlangFloatingPointMode mode) SLANG_OVERRIDE;
         virtual SLANG_NO_THROW void SLANG_MCALL setTargetMatrixLayoutMode(int targetIndex, SlangMatrixLayoutMode mode) SLANG_OVERRIDE;
+        virtual SLANG_NO_THROW void SLANG_MCALL setTargetForceGLSLScalarBufferLayout(int targetIndex, bool value) SLANG_OVERRIDE;
         virtual SLANG_NO_THROW void SLANG_MCALL setMatrixLayoutMode(SlangMatrixLayoutMode mode) SLANG_OVERRIDE;
         virtual SLANG_NO_THROW void SLANG_MCALL setDebugInfoLevel(SlangDebugInfoLevel level) SLANG_OVERRIDE;
         virtual SLANG_NO_THROW void SLANG_MCALL setOptimizationLevel(SlangOptimizationLevel level) SLANG_OVERRIDE;

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -98,6 +98,7 @@ CLikeSourceEmitter::CLikeSourceEmitter(const Desc& desc)
     m_targetCaps = desc.targetCaps;
 
     m_compileRequest = desc.compileRequest;
+    m_targetRequest = desc.targetRequest;
     m_entryPointStage = desc.entryPointStage;
     m_effectiveProfile = desc.effectiveProfile;
 }

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -41,6 +41,8 @@ public:
         ExtensionTracker* extensionTracker = nullptr;
 
         SourceWriter* sourceWriter = nullptr;
+
+        TargetRequest* targetRequest = nullptr;
     };
 
     enum
@@ -475,6 +477,7 @@ public:
     List<IRWitnessTableEntry*> getSortedWitnessTableEntries(IRWitnessTable* witnessTable);
     
     BackEndCompileRequest* m_compileRequest = nullptr;
+    TargetRequest* m_targetRequest = nullptr;
     IRModule* m_irModule = nullptr;
 
     // The stage for which we are emitting code.

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -40,6 +40,11 @@ SlangResult GLSLSourceEmitter::init()
         default: break;
     }
 
+    if (m_targetRequest->getForceGLSLScalarBufferLayout())
+    {
+        m_glslExtensionTracker->requireExtension(
+            UnownedStringSlice::fromLiteral("GL_EXT_scalar_block_layout"));
+    }
     return SLANG_OK;
 }
 
@@ -115,7 +120,8 @@ void GLSLSourceEmitter::_emitGLSLStructuredBuffer(IRGlobalParam* varDecl, IRHLSL
     // TODO: we should require either the extension or the version...
     _requireGLSLVersion(430);
 
-    m_writer->emit("layout(std430");
+    m_writer->emit("layout(");
+    m_writer->emit(m_targetRequest->getForceGLSLScalarBufferLayout() ? "scalar" : "std430");
 
     auto layout = getVarLayout(varDecl);
     if (layout)
@@ -189,7 +195,8 @@ void GLSLSourceEmitter::_emitGLSLByteAddressBuffer(IRGlobalParam* varDecl, IRByt
     // TODO: we should require either the extension or the version...
     _requireGLSLVersion(430);
 
-    m_writer->emit("layout(std430");
+    m_writer->emit("layout(");
+    m_writer->emit(m_targetRequest->getForceGLSLScalarBufferLayout() ? "scalar" : "std430");
 
     auto layout = getVarLayout(varDecl);
     if (layout)

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -774,6 +774,7 @@ SlangResult emitEntryPointsSourceFromIR(
     CLikeSourceEmitter::Desc desc;
 
     desc.compileRequest = compileRequest;
+    desc.targetRequest = targetRequest;
     desc.target = target;
     // TODO(DG): Can't assume a single entry point stage for multiple entry points
     if (entryPointIndices.getCount() == 1)

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -899,6 +899,7 @@ void Linkage::addTarget(
     target->addTargetFlags(desc.flags);
     target->setTargetProfile(Profile(desc.profile));
     target->setLineDirectiveMode(LineDirectiveMode(desc.lineDirectiveMode));
+    target->setForceGLSLScalarBufferLayout(desc.forceGLSLScalarBufferLayout);
 }
 
 #if 0
@@ -4187,6 +4188,11 @@ void EndToEndCompileRequest::setTargetFlags(int targetIndex, SlangTargetFlags fl
     getLinkage()->targets[targetIndex]->addTargetFlags(flags);
 }
 
+void EndToEndCompileRequest::setTargetForceGLSLScalarBufferLayout(int targetIndex, bool value)
+{
+    getLinkage()->targets[targetIndex]->setForceGLSLScalarBufferLayout(value);
+}
+
 void EndToEndCompileRequest::setTargetFloatingPointMode(int targetIndex, SlangFloatingPointMode  mode)
 {
     getLinkage()->targets[targetIndex]->setFloatingPointMode(FloatingPointMode(mode));
@@ -4848,5 +4854,3 @@ SlangResult EndToEndCompileRequest::getEntryPoint(SlangInt entryPointIndex, slan
 }
 
 } // namespace Slang
-
-


### PR DESCRIPTION
This change adds an option to `TargetRequest` that forces glsl emit to use `scalar` layout instead of `std430` layout for storage buffers.