### PR TITLE
Fully implement the ray tracing pipeline for Vulkan

### DIFF
--- a/examples/ray-tracing-pipeline/main.cpp
+++ b/examples/ray-tracing-pipeline/main.cpp
@@ -293,7 +293,7 @@ void onMouseUp(platform::MouseEventArgs args) { isMouseDown = false; }
 
 Slang::Result initialize()
 {
-    initializeBase("Ray Tracing Pipeline", 1024, 768);
+    initializeBase("Ray Tracing Pipeline", 1024, 768, DeviceType::Vulkan);
     gWindow->events.mouseMove = [this](const platform::MouseEventArgs& e) { onMouseMove(e); };
     gWindow->events.mouseUp = [this](const platform::MouseEventArgs& e) { onMouseUp(e); };
     gWindow->events.mouseDown = [this](const platform::MouseEventArgs& e) { onMouseDown(e); };

--- a/examples/ray-tracing-pipeline/main.cpp
+++ b/examples/ray-tracing-pipeline/main.cpp
@@ -293,7 +293,7 @@ void onMouseUp(platform::MouseEventArgs args) { isMouseDown = false; }
 
 Slang::Result initialize()
 {
-    initializeBase("Ray Tracing Pipeline", 1024, 768, DeviceType::Vulkan);
+    initializeBase("Ray Tracing Pipeline", 1024, 768);
     gWindow->events.mouseMove = [this](const platform::MouseEventArgs& e) { onMouseMove(e); };
     gWindow->events.mouseUp = [this](const platform::MouseEventArgs& e) { onMouseUp(e); };
     gWindow->events.mouseDown = [this](const platform::MouseEventArgs& e) { onMouseDown(e); };

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -3512,7 +3512,7 @@ public:
                 copyShaderIdInto(
                     stagingBufferPtr + m_rayGenTableOffset +
                         D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES * i,
-                    m_entryPointNames[i],
+                    m_shaderGroupNames[i],
                     m_recordOverwrites[i]);
             }
             for (uint32_t i = 0; i < m_missShaderCount; i++)
@@ -3520,7 +3520,7 @@ public:
                 copyShaderIdInto(
                     stagingBufferPtr + m_missTableOffset +
                         D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES * i,
-                    m_entryPointNames[m_rayGenShaderCount + i],
+                    m_shaderGroupNames[m_rayGenShaderCount + i],
                     m_recordOverwrites[m_rayGenShaderCount + i]);
             }
             for (uint32_t i = 0; i < m_hitGroupCount; i++)
@@ -3528,7 +3528,7 @@ public:
                 copyShaderIdInto(
                     stagingBufferPtr + m_hitGroupTableOffset +
                         D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES * i,
-                    m_entryPointNames[m_rayGenShaderCount + m_missShaderCount + i],
+                    m_shaderGroupNames[m_rayGenShaderCount + m_missShaderCount + i],
                     m_recordOverwrites[m_rayGenShaderCount + m_missShaderCount + i]);
             }
 

--- a/tools/gfx/renderer-shared.cpp
+++ b/tools/gfx/renderer-shared.cpp
@@ -956,11 +956,11 @@ Result ShaderTableBase::init(const IShaderTable::Desc& desc)
     m_rayGenShaderCount = desc.rayGenShaderCount;
     m_missShaderCount = desc.missShaderCount;
     m_hitGroupCount = desc.hitGroupCount;
-    m_entryPointNames.reserve(desc.hitGroupCount + desc.missShaderCount + desc.rayGenShaderCount);
+    m_shaderGroupNames.reserve(desc.hitGroupCount + desc.missShaderCount + desc.rayGenShaderCount);
     m_recordOverwrites.reserve(desc.hitGroupCount + desc.missShaderCount + desc.rayGenShaderCount);
     for (uint32_t i = 0; i < desc.rayGenShaderCount; i++)
     {
-        m_entryPointNames.add(desc.rayGenShaderEntryPointNames[i]);
+        m_shaderGroupNames.add(desc.rayGenShaderEntryPointNames[i]);
         if (desc.rayGenShaderRecordOverwrites)
         {
             m_recordOverwrites.add(desc.rayGenShaderRecordOverwrites[i]);
@@ -972,7 +972,7 @@ Result ShaderTableBase::init(const IShaderTable::Desc& desc)
     }
     for (uint32_t i = 0; i < desc.missShaderCount; i++)
     {
-        m_entryPointNames.add(desc.missShaderEntryPointNames[i]);
+        m_shaderGroupNames.add(desc.missShaderEntryPointNames[i]);
         if (desc.missShaderRecordOverwrites)
         {
             m_recordOverwrites.add(desc.missShaderRecordOverwrites[i]);
@@ -984,7 +984,7 @@ Result ShaderTableBase::init(const IShaderTable::Desc& desc)
     }
     for (uint32_t i = 0; i < desc.hitGroupCount; i++)
     {
-        m_entryPointNames.add(desc.hitGroupNames[i]);
+        m_shaderGroupNames.add(desc.hitGroupNames[i]);
         if (desc.hitGroupRecordOverwrites)
         {
             m_recordOverwrites.add(desc.hitGroupRecordOverwrites[i]);

--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -1076,7 +1076,7 @@ class ShaderTableBase
     , public Slang::ComObject
 {
 public:
-    Slang::List<Slang::String> m_entryPointNames;
+    Slang::List<Slang::String> m_shaderGroupNames;
     Slang::List<ShaderRecordOverwrite> m_recordOverwrites;
 
     uint32_t m_rayGenShaderCount;

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -7101,6 +7101,7 @@ Result VKDevice::initVulkanInstanceAndDevice(const InteropHandle* handles, bool 
             deviceExtensions.add(VK_KHR_SHADER_SUBGROUP_EXTENDED_TYPES_EXTENSION_NAME);
             m_features.add("shader-subgroup-extended-types");
         }
+
         if (extendedFeatures.accelerationStructureFeatures.accelerationStructure)
         {
             extendedFeatures.accelerationStructureFeatures.pNext = (void*)deviceCreateInfo.pNext;
@@ -7109,6 +7110,7 @@ Result VKDevice::initVulkanInstanceAndDevice(const InteropHandle* handles, bool 
             deviceExtensions.add(VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME);
             m_features.add("acceleration-structure");
         }
+
         if (extendedFeatures.rayTracingPipelineFeatures.rayTracingPipeline)
         {
             extendedFeatures.rayTracingPipelineFeatures.pNext = (void*)deviceCreateInfo.pNext;
@@ -7116,6 +7118,7 @@ Result VKDevice::initVulkanInstanceAndDevice(const InteropHandle* handles, bool 
             deviceExtensions.add(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
             m_features.add("ray-tracing-pipeline");
         }
+
         if (extendedFeatures.rayQueryFeatures.rayQuery)
         {
             extendedFeatures.rayQueryFeatures.pNext = (void*)deviceCreateInfo.pNext;
@@ -7124,6 +7127,7 @@ Result VKDevice::initVulkanInstanceAndDevice(const InteropHandle* handles, bool 
             m_features.add("ray-query");
             m_features.add("ray-tracing");
         }
+
         if (extendedFeatures.bufferDeviceAddressFeatures.bufferDeviceAddress)
         {
             extendedFeatures.bufferDeviceAddressFeatures.pNext = (void*)deviceCreateInfo.pNext;
@@ -7148,7 +7152,6 @@ Result VKDevice::initVulkanInstanceAndDevice(const InteropHandle* handles, bool 
             deviceExtensions.add(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
             m_features.add("robustness2");
         }
-
 
         VkPhysicalDeviceProperties2 extendedProps = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2 };
         VkPhysicalDeviceRayTracingPipelinePropertiesKHR rtProps = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR };

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -8604,8 +8604,8 @@ Result VKDevice::getFormatSupportedResourceStates(Format format, ResourceStateSe
         allowedStates.add(ResourceState::DepthWrite);
     }
     // Present
-//     if (presentableFormats.Contains(vkFormat))
-//         allowedStates.add(ResourceState::Present);
+    if (presentableFormats.Contains(vkFormat))
+        allowedStates.add(ResourceState::Present);
     // IndirectArgument
     allowedStates.add(ResourceState::IndirectArgument);
     // CopySource, ResolveSource
@@ -8849,7 +8849,7 @@ Result VKDevice::createProgram(
         // uses "main" as the name. We should introduce a compiler parameter
         // to control the entry point naming behavior in SPIRV-direct path
         // so we can remove the ad-hoc logic here.
-        auto realEntryPointName = entryPointInfo->getName();
+        auto realEntryPointName = entryPointInfo->getNameOverride();
         const char* spirvBinaryEntryPointName = "main";
         if (m_desc.slang.targetFlags & SLANG_TARGET_FLAG_GENERATE_SPIRV_DIRECTLY)
             spirvBinaryEntryPointName = realEntryPointName;

--- a/tools/gfx/vulkan/vk-api.h
+++ b/tools/gfx/vulkan/vk-api.h
@@ -253,6 +253,10 @@ struct VulkanExtendedFeatureProperties
     // Acceleration structure features
     VkPhysicalDeviceAccelerationStructureFeaturesKHR accelerationStructureFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR};
+    // Ray tracing pipeline features
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR rayTracingPipelineFeatures = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR
+    };
     // Ray query (inline ray-tracing) features
     VkPhysicalDeviceRayQueryFeaturesKHR rayQueryFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR};
@@ -306,6 +310,7 @@ struct VulkanApi
     VkPhysicalDevice m_physicalDevice = VK_NULL_HANDLE;
 
     VkPhysicalDeviceProperties          m_deviceProperties;
+    VkPhysicalDeviceRayTracingPipelinePropertiesKHR         m_rtProperties;
     VkPhysicalDeviceFeatures            m_deviceFeatures;
     VkPhysicalDeviceMemoryProperties    m_deviceMemoryProperties;
     VulkanExtendedFeatureProperties     m_extendedFeatures;

--- a/tools/gfx/vulkan/vk-api.h
+++ b/tools/gfx/vulkan/vk-api.h
@@ -309,11 +309,11 @@ struct VulkanApi
     VkDevice m_device = VK_NULL_HANDLE;
     VkPhysicalDevice m_physicalDevice = VK_NULL_HANDLE;
 
-    VkPhysicalDeviceProperties          m_deviceProperties;
+    VkPhysicalDeviceProperties                              m_deviceProperties;
     VkPhysicalDeviceRayTracingPipelinePropertiesKHR         m_rtProperties;
-    VkPhysicalDeviceFeatures            m_deviceFeatures;
-    VkPhysicalDeviceMemoryProperties    m_deviceMemoryProperties;
-    VulkanExtendedFeatureProperties     m_extendedFeatures;
+    VkPhysicalDeviceFeatures                                m_deviceFeatures;
+    VkPhysicalDeviceMemoryProperties                        m_deviceMemoryProperties;
+    VulkanExtendedFeatureProperties                         m_extendedFeatures;
 };
 
 } // renderer_test

--- a/tools/gfx/vulkan/vk-api.h
+++ b/tools/gfx/vulkan/vk-api.h
@@ -164,6 +164,8 @@ namespace gfx {
     x(vkDestroySwapchainKHR) \
     x(vkAcquireNextImageKHR) \
     x(vkCreateRayTracingPipelinesKHR) \
+    x(vkCmdTraceRaysKHR) \
+    x(vkGetRayTracingShaderGroupHandlesKHR) \
     /* */
 
 #if SLANG_WINDOWS_FAMILY

--- a/tools/gfx/vulkan/vk-util.cpp
+++ b/tools/gfx/vulkan/vk-util.cpp
@@ -140,6 +140,8 @@ VkShaderStageFlags VulkanUtil::getShaderStage(SlangStage stage)
         return VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
     case SLANG_STAGE_INTERSECTION:
         return VK_SHADER_STAGE_INTERSECTION_BIT_KHR;
+    case SLANG_STAGE_MISS:
+        return VK_SHADER_STAGE_MISS_BIT_KHR;
     case SLANG_STAGE_RAY_GENERATION:
         return VK_SHADER_STAGE_RAYGEN_BIT_KHR;
     case SLANG_STAGE_VERTEX:

--- a/tools/gfx/vulkan/vk-util.h
+++ b/tools/gfx/vulkan/vk-util.h
@@ -44,6 +44,9 @@ struct VulkanUtil
 
     static VkImageLayout getImageLayoutFromState(ResourceState state);
 
+    /// Calculate size taking into account alignment. Alignment must be a power of 2
+    static UInt calcAligned(UInt size, UInt alignment) { return (size + alignment - 1) & ~(alignment - 1); }
+
     static inline bool isDepthFormat(VkFormat format)
     {
         switch (format)


### PR DESCRIPTION
Changes:
- Added implementation for `dispatchRays()`, `bindPipeline()`, and `endEncoding()` and added the `ShaderTableImpl` class, which implements the inherited function `createDeviceBuffer()` - Combined with the implementation of `createRayTracingPipelineState()`, these allow the `ray-tracing-pipeline` example to successfully run.
- Changed `ShaderTableBase::m_entryPointNames` to `m_shaderGroupNames` to better reflect its contents
- Added an `extendedFeatures` check that adds Vulkan's ray tracing pipeline extension if supported and added code to get the ray tracing pipeline properties, which is saved to the new member variable `m_rtProperties` in `VulkanApi`

@csyonghe 