### PR TITLE
Implement IFence::getSharedHandle() for Vulkan and D3D12

### DIFF
--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -4947,8 +4947,19 @@ public:
 
         virtual SLANG_NO_THROW Result SLANG_MCALL getSharedHandle(InteropHandle* outHandle) override
         {
-            outHandle->handleValue = 0;
-            return SLANG_FAIL;
+            // Check if a shared handle already exists.
+            if (sharedHandle.handleValue != 0)
+            {
+                *outHandle = sharedHandle;
+                return SLANG_OK;
+            }
+
+            ComPtr<ID3D12Device> devicePtr;
+            m_fence->GetDevice(IID_PPV_ARGS(devicePtr.writeRef()));
+            SLANG_RETURN_ON_FAIL(devicePtr->CreateSharedHandle(m_fence, NULL, GENERIC_ALL, nullptr, (HANDLE*)&outHandle->handleValue));
+            outHandle->api = InteropHandleAPI::D3D12;
+            sharedHandle = *outHandle;
+            return SLANG_OK;
         }
 
         virtual SLANG_NO_THROW Result SLANG_MCALL

--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -192,6 +192,8 @@ class FenceBase : public IFence, public Slang::ComObject
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL
     IFence* getInterface(const Slang::Guid& guid);
+protected:
+    InteropHandle sharedHandle = {};
 };
 
 class Resource : public Slang::ComObject

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -410,8 +410,25 @@ public:
 
         virtual SLANG_NO_THROW Result SLANG_MCALL getSharedHandle(InteropHandle* outHandle) override
         {
-            outHandle->handleValue = 0;
-            return SLANG_FAIL;
+            // Check if a shared handle already exists.
+            if (sharedHandle.handleValue != 0)
+            {
+                *outHandle = sharedHandle;
+                return SLANG_OK;
+            }
+
+#if SLANG_WINDOWS_FAMILY
+            VkSemaphoreGetWin32HandleInfoKHR handleInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR };
+            handleInfo.pNext = nullptr;
+            handleInfo.semaphore = m_semaphore;
+            handleInfo.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
+
+            SLANG_VK_RETURN_ON_FAIL(
+                m_device->m_api.vkGetSemaphoreWin32HandleKHR(m_device->m_api.m_device, &handleInfo, (HANDLE*)&outHandle->handleValue)
+            );
+#endif
+            sharedHandle.api = InteropHandleAPI::Vulkan;
+            return SLANG_OK;
         }
 
         virtual SLANG_NO_THROW Result SLANG_MCALL

--- a/tools/gfx/vulkan/vk-api.h
+++ b/tools/gfx/vulkan/vk-api.h
@@ -169,6 +169,7 @@ namespace gfx {
 #if SLANG_WINDOWS_FAMILY
 #   define VK_API_DEVICE_PLATFORM_OPT_PROCS(x) \
     x(vkGetMemoryWin32HandleKHR) \
+    x(vkGetSemaphoreWin32HandleKHR) \
     /* */
 #else
 #   define VK_API_DEVICE_PLATFORM_OPT_PROCS(x) \


### PR DESCRIPTION
Changes:
- Added implementations for `IFence::getSharedHandle()` for both Vulkan and D3D12

Note: These implementations are untested for the time being.

@csyonghe 