### PR TITLE
gfx: defer downstream shader compilation until draw/dispatch.

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -110,6 +110,8 @@ enum class AccessFlag
     Write,
 };
 
+const uint32_t kMaxRenderTargetCount = 8;
+
 class ITransientResourceHeap;
 
 class IShaderProgram: public ISlangUnknown
@@ -1238,7 +1240,7 @@ struct TargetBlendDesc
 
 struct BlendDesc
 {
-    TargetBlendDesc const*  targets     = nullptr;
+    TargetBlendDesc         targets[kMaxRenderTargetCount];
     UInt                    targetCount = 0;
 
     bool alphaToCoverageEnable  = false;

--- a/tools/gfx/renderer-shared.cpp
+++ b/tools/gfx/renderer-shared.cpp
@@ -873,7 +873,7 @@ Result RendererBase::maybeSpecializePipeline(
             case PipelineType::Graphics:
             {
                 auto pipelineDesc = currentPipeline->desc.graphics;
-                pipelineDesc.program = specializedProgram;
+                pipelineDesc.program = static_cast<ShaderProgramBase*>(specializedProgram.get());
                 SLANG_RETURN_ON_FAIL(createGraphicsPipelineState(
                     pipelineDesc, specializedPipelineComPtr.writeRef()));
                 break;
@@ -881,9 +881,9 @@ Result RendererBase::maybeSpecializePipeline(
             case PipelineType::RayTracing:
             {
                 auto pipelineDesc = currentPipeline->desc.rayTracing;
-                pipelineDesc.program = specializedProgram;
+                pipelineDesc.program = static_cast<ShaderProgramBase*>(specializedProgram.get());
                 SLANG_RETURN_ON_FAIL(createRayTracingPipelineState(
-                    pipelineDesc, specializedPipelineComPtr.writeRef()));
+                    pipelineDesc.get(), specializedPipelineComPtr.writeRef()));
                 break;
             }
             default:

--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -902,6 +902,72 @@ enum class PipelineType
     CountOf,
 };
 
+struct OwnedHitGroupDesc
+{
+    Slang::String hitGroupName;
+    Slang::String closestHitEntryPoint;
+    Slang::String anyHitEntryPoint;
+    Slang::String intersectionEntryPoint;
+
+    void set(const HitGroupDesc& desc)
+    {
+        hitGroupName = desc.hitGroupName;
+        closestHitEntryPoint = desc.closestHitEntryPoint;
+        anyHitEntryPoint = desc.anyHitEntryPoint;
+        intersectionEntryPoint = desc.intersectionEntryPoint;
+    }
+
+    HitGroupDesc get()
+    {
+        HitGroupDesc desc;
+        desc.hitGroupName = hitGroupName.getBuffer();
+        desc.closestHitEntryPoint = closestHitEntryPoint.getBuffer();
+        desc.anyHitEntryPoint = anyHitEntryPoint.getBuffer();
+        desc.intersectionEntryPoint = intersectionEntryPoint.getBuffer();
+        return desc;
+    }
+};
+
+struct OwnedRayTracingPipelineStateDesc
+{
+    Slang::RefPtr<ShaderProgramBase> program;
+    Slang::List<OwnedHitGroupDesc> hitGroups;
+    Slang::List<HitGroupDesc> hitGroupDescs;
+    int maxRecursion = 0;
+    int maxRayPayloadSize = 0;
+    int maxAttributeSizeInBytes = 8;
+    RayTracingPipelineFlags::Enum flags = RayTracingPipelineFlags::None;
+
+    RayTracingPipelineStateDesc get()
+    {
+        RayTracingPipelineStateDesc desc;
+        desc.program = program.Ptr();
+        desc.hitGroupCount = (int32_t)hitGroupDescs.getCount();
+        desc.hitGroups = hitGroupDescs.getBuffer();
+        desc.maxRecursion = maxRecursion;
+        desc.maxRayPayloadSize = maxRayPayloadSize;
+        desc.maxAttributeSizeInBytes = maxAttributeSizeInBytes;
+        desc.flags = flags;
+        return desc;
+    }
+
+    void set(const RayTracingPipelineStateDesc& inDesc)
+    {
+        program = static_cast<ShaderProgramBase*>(inDesc.program);
+        for (int32_t i = 0; i < inDesc.hitGroupCount; i++)
+        {
+            OwnedHitGroupDesc ownedHitGroupDesc;
+            ownedHitGroupDesc.set(inDesc.hitGroups[i]);
+            hitGroups.add(ownedHitGroupDesc);
+            hitGroupDescs.add(ownedHitGroupDesc.get());
+        }
+        maxRecursion = inDesc.maxRecursion;
+        maxRayPayloadSize = inDesc.maxRayPayloadSize;
+        maxAttributeSizeInBytes = inDesc.maxAttributeSizeInBytes;
+        flags = inDesc.flags;
+    }
+};
+
 class PipelineStateBase
     : public IPipelineState
     , public Slang::ComObject
@@ -915,7 +981,7 @@ public:
         PipelineType type;
         GraphicsPipelineStateDesc graphics;
         ComputePipelineStateDesc compute;
-        RayTracingPipelineStateDesc rayTracing;
+        OwnedRayTracingPipelineStateDesc rayTracing;
         ShaderProgramBase* getProgram()
         {
             switch (type)
@@ -950,6 +1016,7 @@ public:
     }
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(InteropHandle* outHandle) override;
+    virtual Result ensureAPIPipelineStateCreated() { return SLANG_OK; };
 
 protected:
     void initializeBase(const PipelineStateDesc& inDesc);
@@ -1439,5 +1506,4 @@ Result ShaderObjectBaseImpl<TShaderObjectImpl, TShaderObjectLayoutImpl, TShaderO
     }
     return SLANG_OK;
 }
-
 }

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -1023,7 +1023,7 @@ public:
         {
             PipelineStateDesc pipelineDesc;
             pipelineDesc.type = PipelineType::RayTracing;
-            pipelineDesc.rayTracing = inDesc;
+            pipelineDesc.rayTracing.set(inDesc);
             initializeBase(pipelineDesc);
         }
 

--- a/tools/platform/gui.cpp
+++ b/tools/platform/gui.cpp
@@ -123,7 +123,7 @@ GUI::GUI(
     pipelineDesc.framebufferLayout = framebufferLayout;
     pipelineDesc.program = program;
     pipelineDesc.inputLayout = inputLayout;
-    pipelineDesc.blend.targets = &targetBlendDesc;
+    pipelineDesc.blend.targets[0] = targetBlendDesc;
     pipelineDesc.blend.targetCount = 1;
     pipelineDesc.rasterizer.cullMode = CullMode::None;
 


### PR DESCRIPTION
This change defers the shader compilation and actual pipeline state creation until it is needed by a draw call.

The reason for this is that creating a `MutableRootShaderObject` requires a `IShaderProgram`. If the user is creating a mutable root shader object, they will first need to create a `IShaderProgram`. Before this change, creating a `IShaderProgram` with a slang program that has 0 specialization arguments will immediately trigger downstream shader compilation. However there are cases where the user is creating MutableRootShaderObjects but never actually use them. Actively compiling the shaders is causing a slow down in user application's start up time. To address this issue, we always compile shaders and create pipeline state objects lazily until it is definitely needed.