### PR TITLE
gfx: d3d12 performance optimizations.

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1821,8 +1821,6 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL close() = 0;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(InteropHandle* outHandle) = 0;
-
-    virtual SLANG_NO_THROW Result SLANG_MCALL resetDescriptorHeaps() = 0;
 };
 #define SLANG_UUID_ICommandBuffer                                                      \
     {                                                                                  \
@@ -1912,6 +1910,23 @@ public:
         0xcd48bd29, 0xee72, 0x41b8, { 0xbc, 0xff, 0xa, 0x2b, 0x3a, 0xaa, 0x6d, 0xeb } \
     }
 
+class ID3D12TransientResourceHeap : public ISlangUnknown
+{
+public:
+    enum class DescriptorType
+    {
+        ResourceView, Sampler
+    };
+    virtual SLANG_NO_THROW Result SLANG_MCALL allocateTransientDescriptorTable(
+        DescriptorType type,
+        uint32_t count,
+        uint64_t& outDescriptorOffset,
+        void** outD3DDescriptorHeapHandle) = 0;
+};
+#define SLANG_UUID_ID3D12TransientResourceHeap                                             \
+    {                                                                                  \
+        0x9bc6a8bc, 0x5f7a, 0x454a, { 0x93, 0xef, 0x3b, 0x10, 0x5b, 0xb7, 0x63, 0x7e } \
+    }
 
 class ISwapchain : public ISlangUnknown
 {

--- a/tools/gfx-unit-test/nested-parameter-block.cpp
+++ b/tools/gfx-unit-test/nested-parameter-block.cpp
@@ -68,7 +68,7 @@ namespace gfx_test
             srvDesc.type = IResourceView::Type::ShaderResource;
             srvDesc.format = Format::Unknown;
             srvDesc.bufferElementSize = sizeof(uint32_t) * 4;
-            srvDesc.bufferRange.elementCount = 4;
+            srvDesc.bufferRange.elementCount = 1;
             srvDesc.bufferRange.firstElement = 0;
             srvs.add(device->createBufferView(srvBuffers[i], nullptr, srvDesc));
         }
@@ -78,7 +78,7 @@ namespace gfx_test
         resultBufferViewDesc.type = IResourceView::Type::UnorderedAccess;
         resultBufferViewDesc.format = Format::Unknown;
         resultBufferViewDesc.bufferElementSize = sizeof(uint32_t) * 4;
-        resultBufferViewDesc.bufferRange.elementCount = 4;
+        resultBufferViewDesc.bufferRange.elementCount = 1;
         resultBufferViewDesc.bufferRange.firstElement = 0;
         Slang::ComPtr<IResourceView> resultBufferView;
         SLANG_CHECK(SLANG_SUCCEEDED(device->createBufferView(

--- a/tools/gfx/cuda/render-cuda.cpp
+++ b/tools/gfx/cuda/render-cuda.cpp
@@ -945,12 +945,6 @@ public:
                 return static_cast<ICommandBuffer*>(this);
             return nullptr;
         }
-
-        virtual SLANG_NO_THROW Result SLANG_MCALL resetDescriptorHeaps() override
-        {
-            return SLANG_OK;
-        }
-
     public:
         CUDADevice* m_device;
         TransientResourceHeapBase* m_transientHeap;

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -2778,7 +2778,7 @@ public:
 
             SLANG_ASSERT(srcSize <= destSize);
 
-            _uploadBufferData(encoder->m_device, encoder->m_d3dCmdList, encoder->m_transientHeap, buffer, offset, srcSize, src, false);
+            _uploadBufferData(encoder->m_device, encoder->m_d3dCmdList, encoder->m_transientHeap, buffer, offset, srcSize, src);
 
             // In the case where this object has any sub-objects of
             // existential/interface type, we need to recurse on those objects

--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -1015,12 +1015,6 @@ Result DebugCommandBuffer::getNativeHandle(InteropHandle* outHandle)
     return baseObject->getNativeHandle(outHandle);
 }
 
-Result DebugCommandBuffer::resetDescriptorHeaps()
-{
-    SLANG_GFX_API_FUNC;
-    return baseObject->resetDescriptorHeaps();
-}
-
 void DebugCommandBuffer::checkEncodersClosedBeforeNewEncoder()
 {
     if (m_renderCommandEncoder.isOpen || m_resourceCommandEncoder.isOpen ||

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -624,7 +624,6 @@ public:
         encodeRayTracingCommands(IRayTracingCommandEncoder** outEncoder) override;
     virtual SLANG_NO_THROW void SLANG_MCALL close() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(InteropHandle* outHandle) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL resetDescriptorHeaps() override;
 
 private:
     void checkEncodersClosedBeforeNewEncoder();

--- a/tools/gfx/immediate-renderer-base.cpp
+++ b/tools/gfx/immediate-renderer-base.cpp
@@ -31,8 +31,6 @@ public:
         return nullptr;
     }
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL resetDescriptorHeaps() override { return SLANG_OK; }
-
 public:
     CommandWriter m_writer;
     bool m_hasWriteTimestamps = false;

--- a/tools/gfx/renderer-shared.cpp
+++ b/tools/gfx/renderer-shared.cpp
@@ -34,6 +34,7 @@ const Slang::Guid GfxGUID::IID_IAccelerationStructure = SLANG_UUID_IAcceleration
 const Slang::Guid GfxGUID::IID_IFence = SLANG_UUID_IFence;
 const Slang::Guid GfxGUID::IID_IShaderTable = SLANG_UUID_IShaderTable;
 const Slang::Guid GfxGUID::IID_IPipelineCreationAPIDispatcher = SLANG_UUID_IPipelineCreationAPIDispatcher;
+const Slang::Guid GfxGUID::IID_ID3D12TransientResourceHeap = SLANG_UUID_ID3D12TransientResourceHeap;
 
 
 StageType translateStage(SlangStage slangStage)

--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -41,6 +41,7 @@ struct GfxGUID
     static const Slang::Guid IID_IFence;
     static const Slang::Guid IID_IShaderTable;
     static const Slang::Guid IID_IPipelineCreationAPIDispatcher;
+    static const Slang::Guid IID_ID3D12TransientResourceHeap;
 };
 
 // We use a `BreakableReference` to avoid the cyclic reference situation in gfx implementation.

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -2482,22 +2482,29 @@ public:
         {
             auto& api = buffer->m_renderer->m_api;
             IBufferResource* stagingBuffer = nullptr;
-            transientHeap->allocateStagingBuffer(size, stagingBuffer, ResourceState::CopySource);
+            size_t stagingBufferOffset = 0;
+            transientHeap->allocateStagingBuffer(
+                size, stagingBuffer, stagingBufferOffset, MemoryType::Upload);
 
             BufferResourceImpl* stagingBufferImpl =
                 static_cast<BufferResourceImpl*>(stagingBuffer);
 
             void* mappedData = nullptr;
             SLANG_VK_CHECK(api.vkMapMemory(
-                api.m_device, stagingBufferImpl->m_buffer.m_memory, 0, size, 0, &mappedData));
-            memcpy(mappedData, data, size);
+                api.m_device,
+                stagingBufferImpl->m_buffer.m_memory,
+                0,
+                stagingBufferOffset + size,
+                0,
+                &mappedData));
+            memcpy((char*)mappedData + stagingBufferOffset, data, size);
             api.vkUnmapMemory(api.m_device, stagingBufferImpl->m_buffer.m_memory);
 
             // Copy from staging buffer to real buffer
             VkBufferCopy copyInfo = {};
             copyInfo.size = size;
             copyInfo.dstOffset = offset;
-            copyInfo.srcOffset = 0;
+            copyInfo.srcOffset = stagingBufferOffset;
             api.vkCmdCopyBuffer(
                 commandBuffer,
                 stagingBufferImpl->m_buffer.m_buffer,
@@ -3962,8 +3969,9 @@ public:
                 static_cast<TransientResourceHeapImpl*>(transientHeap);
 
             IBufferResource* stagingBuffer = nullptr;
+            size_t stagingBufferOffset = 0;
             transientHeapImpl->allocateStagingBuffer(
-                tableSize, stagingBuffer, ResourceState::General);
+                tableSize, stagingBuffer, stagingBufferOffset, MemoryType::Upload);
 
             assert(stagingBuffer);
             void* stagingPtr = nullptr;
@@ -3975,7 +3983,7 @@ public:
             handles.setCount(totalHandleSize);
             auto result = vkApi.vkGetRayTracingShaderGroupHandlesKHR(m_device->m_device, pipelineImpl->m_pipeline, 0, (uint32_t)handleCount, totalHandleSize, handles.getBuffer());
 
-            uint8_t* stagingBufferPtr = (uint8_t*)stagingPtr;
+            uint8_t* stagingBufferPtr = (uint8_t*)stagingPtr + stagingBufferOffset;
             auto subTablePtr = stagingBufferPtr;
             Int shaderTableEntryCounter = 0;
 
@@ -4026,7 +4034,7 @@ public:
             // TODO: Callable shaders?
 
             stagingBuffer->unmap(nullptr);
-            encoder->copyBuffer(bufferResource, 0, stagingBuffer, 0, tableSize);
+            encoder->copyBuffer(bufferResource, 0, stagingBuffer, stagingBufferOffset, tableSize);
             encoder->bufferBarrier(
                 1,
                 bufferResource.readRef(),
@@ -4557,8 +4565,9 @@ public:
                 bufferSize *= subResourceRange.layerCount;
 
                 IBufferResource* uploadBuffer = nullptr;
+                size_t uploadBufferOffset = 0;
                 m_commandBuffer->m_transientHeap->allocateStagingBuffer(
-                    bufferSize, uploadBuffer, gfx::ResourceState::CopySource);
+                    bufferSize, uploadBuffer, uploadBufferOffset, MemoryType::Upload);
 
                 // Copy into upload buffer
                 {
@@ -4566,8 +4575,9 @@ public:
 
                     uint8_t* dstData;
                     uploadBuffer->map(nullptr, (void**)&dstData);
+                    dstData += uploadBufferOffset;
                     uint8_t* dstDataStart;
-                    dstDataStart = dstData;
+                    dstDataStart = dstData ;
 
                     size_t dstSubresourceOffset = 0;
                     for (uint32_t i = 0; i < subResourceRange.layerCount; ++i)
@@ -4612,7 +4622,7 @@ public:
                     uploadBuffer->unmap(nullptr);
                 }
                 {
-                    size_t srcOffset = 0;
+                    size_t srcOffset = uploadBufferOffset;
                     for (uint32_t i = 0; i < subResourceRange.layerCount; ++i)
                     {
                         for (Index j = 0; j < mipSizes.getCount(); ++j)
@@ -6569,15 +6579,18 @@ Result VKDevice::PipelineCommandEncoder::bindRootShaderObjectImpl(
     // Once we've filled in all the descriptor sets, we bind them
     // to the pipeline at once.
     //
-    m_device->m_api.vkCmdBindDescriptorSets(
-        m_commandBuffer->m_commandBuffer,
-        bindPoint,
-        specializedLayout->m_pipelineLayout,
-        0,
-        (uint32_t) descriptorSetCount,
-        descriptorSets,
-        0,
-        nullptr);
+    if (descriptorSetCount > 0)
+    {
+        m_device->m_api.vkCmdBindDescriptorSets(
+            m_commandBuffer->m_commandBuffer,
+            bindPoint,
+            specializedLayout->m_pipelineLayout,
+            0,
+            (uint32_t) descriptorSetCount,
+            descriptorSets,
+            0,
+            nullptr);
+    }
 
     return SLANG_OK;
 }
@@ -7226,9 +7239,13 @@ Result VKDevice::initVulkanInstanceAndDevice(const InteropHandle* handles, bool 
 #endif
             m_features.add("external-memory");
         }
-        if (extensionNames.Contains(VK_EXT_DEBUG_MARKER_EXTENSION_NAME))
+        if (extensionNames.Contains(VK_EXT_DEBUG_REPORT_EXTENSION_NAME))
         {
-            deviceExtensions.add(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
+            deviceExtensions.add(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
+            if (extensionNames.Contains(VK_EXT_DEBUG_MARKER_EXTENSION_NAME))
+            {
+                deviceExtensions.add(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
+            }
         }
         if (extensionNames.Contains(VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME))
         {

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -4061,10 +4061,6 @@ public:
             return nullptr;
         }
         virtual void comFree() override { m_transientHeap.breakStrongReference(); }
-        virtual SLANG_NO_THROW Result SLANG_MCALL resetDescriptorHeaps() override
-        {
-            return SLANG_OK;
-        }
     public:
         VkCommandBuffer m_commandBuffer;
         VkCommandBuffer m_preCommandBuffer = VK_NULL_HANDLE;


### PR DESCRIPTION
* Remove the logic for waitable objects in d3d12 swapchain implementation.
* Fixed a frame fence syncing bug (signaling the wrong fence after present)
* Reset the command allocator for QueryHeap to prevent leaking
* Refactored `TransientResourceHeap` implementation to reuse the same logic for transient constant buffer and staging buffer allocation.
* Make D3D12 `TransientResourceHeap` implement `ID3D12TransientResourceHeap` interface that provides method for allocating descriptor tables on the currently bound GPU heap.
* Improve `textureBarrier` implementation to issue a single barrier when transitioning the entire resource instead of one barrier for each subresource.