### PR TITLE
Add isOccluded() and setFullScreenMode() to ISwapchain

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1955,6 +1955,12 @@ public:
     /// Resizes the back buffers of this swapchain. All render target views and framebuffers
     /// referencing the back buffer images must be freed before calling this method.
     virtual SLANG_NO_THROW Result SLANG_MCALL resize(uint32_t width, uint32_t height) = 0;
+
+    // Check if the window is occluded.
+    virtual SLANG_NO_THROW bool SLANG_MCALL isOccluded() = 0;
+
+    // Toggle full screen mode.
+    virtual SLANG_NO_THROW Result SLANG_MCALL setFullScreenMode(bool mode) = 0;
 };
 #define SLANG_UUID_ISwapchain                                                        \
     {                                                                                \

--- a/tools/gfx/d3d/d3d-swapchain.h
+++ b/tools/gfx/d3d/d3d-swapchain.h
@@ -143,6 +143,7 @@ public:
     ISwapchain::Desc m_desc;
     ComPtr<IDXGISwapChain2> m_swapChain;
     Slang::ShortList<Slang::RefPtr<TextureResource>> m_images;
+    bool isWindowOccluded = false;
 };
 
 }

--- a/tools/gfx/d3d/d3d-swapchain.h
+++ b/tools/gfx/d3d/d3d-swapchain.h
@@ -143,7 +143,6 @@ public:
     ISwapchain::Desc m_desc;
     ComPtr<IDXGISwapChain2> m_swapChain;
     Slang::ShortList<Slang::RefPtr<TextureResource>> m_images;
-    bool isWindowOccluded = false;
 };
 
 }

--- a/tools/gfx/d3d11/render-d3d11.cpp
+++ b/tools/gfx/d3d11/render-d3d11.cpp
@@ -370,6 +370,14 @@ protected:
             m_renderer->m_immediateContext->ClearState();
             return D3DSwapchainBase::resize(width, height);
         }
+        virtual SLANG_NO_THROW bool SLANG_MCALL isOccluded() override
+        {
+            return false;
+        }
+        virtual SLANG_NO_THROW Result SLANG_MCALL setFullScreenMode(bool mode) override
+        {
+            return SLANG_FAIL;
+        }
     };
 
     class InputLayoutImpl: public InputLayoutBase

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -5438,11 +5438,7 @@ public:
         }
         virtual SLANG_NO_THROW bool SLANG_MCALL isOccluded() override
         {
-            if (isWindowOccluded)
-            {
-                isWindowOccluded = (m_swapChain3->Present(0, DXGI_PRESENT_TEST) == DXGI_STATUS_OCCLUDED);
-            }
-            return isWindowOccluded;
+            return (m_swapChain3->Present(0, DXGI_PRESENT_TEST) == DXGI_STATUS_OCCLUDED);
         }
         virtual SLANG_NO_THROW Result SLANG_MCALL setFullScreenMode(bool mode) override
         {

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -5436,6 +5436,18 @@ public:
 
             return SLANG_OK;
         }
+        virtual SLANG_NO_THROW bool SLANG_MCALL isOccluded() override
+        {
+            if (isWindowOccluded)
+            {
+                isWindowOccluded = (m_swapChain3->Present(0, DXGI_PRESENT_TEST) == DXGI_STATUS_OCCLUDED);
+            }
+            return isWindowOccluded;
+        }
+        virtual SLANG_NO_THROW Result SLANG_MCALL setFullScreenMode(bool mode) override
+        {
+            return m_swapChain3->SetFullscreenState(mode, nullptr);
+        }
     };
 
     static PROC loadProc(HMODULE module, char const* name);

--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -1638,6 +1638,18 @@ Result DebugSwapchain::resize(uint32_t width, uint32_t height)
     return baseObject->resize(width, height);
 }
 
+bool DebugSwapchain::isOccluded()
+{
+    SLANG_GFX_API_FUNC;
+    return baseObject->isOccluded();
+}
+
+Result DebugSwapchain::setFullScreenMode(bool mode)
+{
+    SLANG_GFX_API_FUNC;
+    return baseObject->setFullScreenMode(mode);
+}
+
 void DebugSwapchain::maybeRebuildImageList()
 {
     SLANG_GFX_API_FUNC;

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -735,6 +735,8 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
     virtual SLANG_NO_THROW int SLANG_MCALL acquireNextImage() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL resize(uint32_t width, uint32_t height) override;
+    virtual SLANG_NO_THROW bool SLANG_MCALL isOccluded() override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL setFullScreenMode(bool mode) override;
 
 public:
     Slang::RefPtr<DebugCommandQueue> queue;

--- a/tools/gfx/open-gl/render-gl.cpp
+++ b/tools/gfx/open-gl/render-gl.cpp
@@ -582,6 +582,15 @@ public:
             return SLANG_OK;
         }
 
+        virtual SLANG_NO_THROW bool SLANG_MCALL isOccluded() override
+        {
+            return false;
+        }
+        virtual SLANG_NO_THROW Result SLANG_MCALL setFullScreenMode(bool mode) override
+        {
+            return SLANG_FAIL;
+        }
+
     public:
         RefPtr<WeakSink<GLDevice>> m_renderer = nullptr;
         GLuint m_framebuffer;

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -6449,6 +6449,14 @@ public:
             m_queue->m_pendingWaitSemaphores[1] = m_nextImageSemaphore;
             return m_currentImageIndex;
         }
+        virtual SLANG_NO_THROW bool SLANG_MCALL isOccluded() override
+        {
+            return false;
+        }
+        virtual SLANG_NO_THROW Result SLANG_MCALL setFullScreenMode(bool mode) override
+        {
+            return SLANG_FAIL;
+        }
     };
 
     VkBool32 handleDebugMessage(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT objType, uint64_t srcObject,


### PR DESCRIPTION
Changes:
- Added `isOccluded()` and `setFullScreenMode()` to `ISwapchain`
- Added implementations for D3D12 (all others currently return `false`/`SLANG_FAIL`)

@csyonghe 