### PR TITLE
Use GLSL scalar layout for constant buffers.

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -2278,6 +2278,12 @@ public:
         slang::TypeReflection* type,
         ShaderObjectContainerType container,
         IShaderObject** outObject) = 0;
+    
+    virtual SLANG_NO_THROW Result SLANG_MCALL createShaderObjectFromTypeLayout(
+        slang::TypeLayoutReflection* typeLayout, IShaderObject** outObject) = 0;
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL createMutableShaderObjectFromTypeLayout(
+        slang::TypeLayoutReflection* typeLayout, IShaderObject** outObject) = 0;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL createMutableRootShaderObject(
         IShaderProgram* program,

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -426,6 +426,7 @@ enum class ResourceState
     ResolveSource,
     ResolveDestination,
     AccelerationStructure,
+    AccelerationStructureBuildInput,
     _Count
 };
 

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -290,14 +290,18 @@ void GLSLSourceEmitter::_emitGLSLParameterGroup(IRGlobalParam* varDecl, IRUnifor
     }
     else if (as<IRGLSLShaderStorageBufferType>(type))
     {
-        // Is writable 
-        m_writer->emit("layout(std430) buffer ");
+        // Is writable
+        m_writer->emit("layout(");
+        m_writer->emit(m_targetRequest->getForceGLSLScalarBufferLayout() ? "scalar" : "std430");
+        m_writer->emit(") buffer ");
     }
     // TODO: what to do with HLSL `tbuffer` style buffers?
     else
     {
         // uniform is implicitly read only
-        m_writer->emit("layout(std140) uniform ");
+        m_writer->emit("layout(");
+        m_writer->emit(m_targetRequest->getForceGLSLScalarBufferLayout() ? "scalar" : "std140");
+        m_writer->emit(") uniform ");
     }
 
     // Generate a dummy name for the block

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -678,7 +678,7 @@ RefPtr<TypeLayout> getTypeLayoutForGlobalShaderParameter(
     // An "ordinary" global variable is implicitly a uniform
     // shader parameter.
     return createTypeLayout(
-        layoutContext.with(rules->getConstantBufferRules()),
+        layoutContext.with(rules->getConstantBufferRules(context->getTargetRequest())),
         type);
 }
 
@@ -2080,7 +2080,8 @@ static RefPtr<TypeLayout> computeEntryPointParameterTypeLayout(
         // constant buffer (e.g., the `$Params` constant buffer seen in fxc/dxc output).
         //
         return createTypeLayout(
-            context->layoutContext.with(context->getRulesFamily()->getConstantBufferRules()),
+            context->layoutContext.with(
+                context->getRulesFamily()->getConstantBufferRules(context->getTargetRequest())),
             paramType);
     }
     else
@@ -2431,7 +2432,9 @@ static ParameterBindingAndKindInfo maybeAllocateConstantBufferBinding(
     UInt space = context->shared->defaultSpace;
     auto usedRangeSet = findUsedRangeSetForSpace(context, space);
 
-    auto layoutInfo = context->getRulesFamily()->getConstantBufferRules()->GetObjectLayout(
+    auto layoutInfo = context->getRulesFamily()
+                          ->getConstantBufferRules(context->getTargetRequest())
+                          ->GetObjectLayout(
         ShaderParameterKind::ConstantBuffer);
 
     ParameterBindingAndKindInfo info;

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -767,14 +767,14 @@ CUDARayTracingLayoutRulesImpl kCUDAHitAttributesParameterLayoutRulesImpl(LayoutR
 struct GLSLLayoutRulesFamilyImpl : LayoutRulesFamilyImpl
 {
     virtual LayoutRulesImpl* getAnyValueRules() override;
-    virtual LayoutRulesImpl* getConstantBufferRules() override;
+    virtual LayoutRulesImpl* getConstantBufferRules(TargetRequest* request) override;
     virtual LayoutRulesImpl* getPushConstantBufferRules() override;
     virtual LayoutRulesImpl* getTextureBufferRules() override;
     virtual LayoutRulesImpl* getVaryingInputRules() override;
     virtual LayoutRulesImpl* getVaryingOutputRules() override;
     virtual LayoutRulesImpl* getSpecializationConstantRules() override;
     virtual LayoutRulesImpl* getShaderStorageBufferRules(TargetRequest* request) override;
-    virtual LayoutRulesImpl* getParameterBlockRules() override;
+    virtual LayoutRulesImpl* getParameterBlockRules(TargetRequest* request) override;
 
     LayoutRulesImpl* getRayPayloadParameterRules()      override;
     LayoutRulesImpl* getCallablePayloadParameterRules() override;
@@ -782,20 +782,20 @@ struct GLSLLayoutRulesFamilyImpl : LayoutRulesFamilyImpl
 
     LayoutRulesImpl* getShaderRecordConstantBufferRules() override;
 
-    LayoutRulesImpl* getStructuredBufferRules() override;
+    LayoutRulesImpl* getStructuredBufferRules(TargetRequest* request) override;
 };
 
 struct HLSLLayoutRulesFamilyImpl : LayoutRulesFamilyImpl
 {
     virtual LayoutRulesImpl* getAnyValueRules() override;
-    virtual LayoutRulesImpl* getConstantBufferRules() override;
+    virtual LayoutRulesImpl* getConstantBufferRules(TargetRequest* request) override;
     virtual LayoutRulesImpl* getPushConstantBufferRules() override;
     virtual LayoutRulesImpl* getTextureBufferRules() override;
     virtual LayoutRulesImpl* getVaryingInputRules() override;
     virtual LayoutRulesImpl* getVaryingOutputRules() override;
     virtual LayoutRulesImpl* getSpecializationConstantRules() override;
     virtual LayoutRulesImpl* getShaderStorageBufferRules(TargetRequest* request) override;
-    virtual LayoutRulesImpl* getParameterBlockRules() override;
+    virtual LayoutRulesImpl* getParameterBlockRules(TargetRequest* request) override;
 
     LayoutRulesImpl* getRayPayloadParameterRules()      override;
     LayoutRulesImpl* getCallablePayloadParameterRules() override;
@@ -803,47 +803,47 @@ struct HLSLLayoutRulesFamilyImpl : LayoutRulesFamilyImpl
 
     LayoutRulesImpl* getShaderRecordConstantBufferRules() override;
     
-    LayoutRulesImpl* getStructuredBufferRules() override;
+    LayoutRulesImpl* getStructuredBufferRules(TargetRequest* request) override;
 };
 
 struct CPULayoutRulesFamilyImpl : LayoutRulesFamilyImpl
 {
     virtual LayoutRulesImpl* getAnyValueRules() override;
-    virtual LayoutRulesImpl* getConstantBufferRules() override;
+    virtual LayoutRulesImpl* getConstantBufferRules(TargetRequest* request) override;
     virtual LayoutRulesImpl* getPushConstantBufferRules() override;
     virtual LayoutRulesImpl* getTextureBufferRules() override;
     virtual LayoutRulesImpl* getVaryingInputRules() override;
     virtual LayoutRulesImpl* getVaryingOutputRules() override;
     virtual LayoutRulesImpl* getSpecializationConstantRules() override;
     virtual LayoutRulesImpl* getShaderStorageBufferRules(TargetRequest* request) override;
-    virtual LayoutRulesImpl* getParameterBlockRules() override;
+    virtual LayoutRulesImpl* getParameterBlockRules(TargetRequest* request) override;
 
     LayoutRulesImpl* getRayPayloadParameterRules()      override;
     LayoutRulesImpl* getCallablePayloadParameterRules() override;
     LayoutRulesImpl* getHitAttributesParameterRules()   override;
 
     LayoutRulesImpl* getShaderRecordConstantBufferRules() override;
-    LayoutRulesImpl* getStructuredBufferRules() override;
+    LayoutRulesImpl* getStructuredBufferRules(TargetRequest* request) override;
 };
 
 struct CUDALayoutRulesFamilyImpl : LayoutRulesFamilyImpl
 {
     virtual LayoutRulesImpl* getAnyValueRules() override;
-    virtual LayoutRulesImpl* getConstantBufferRules() override;
+    virtual LayoutRulesImpl* getConstantBufferRules(TargetRequest* request) override;
     virtual LayoutRulesImpl* getPushConstantBufferRules() override;
     virtual LayoutRulesImpl* getTextureBufferRules() override;
     virtual LayoutRulesImpl* getVaryingInputRules() override;
     virtual LayoutRulesImpl* getVaryingOutputRules() override;
     virtual LayoutRulesImpl* getSpecializationConstantRules() override;
     virtual LayoutRulesImpl* getShaderStorageBufferRules(TargetRequest* request) override;
-    virtual LayoutRulesImpl* getParameterBlockRules() override;
+    virtual LayoutRulesImpl* getParameterBlockRules(TargetRequest* request) override;
 
     LayoutRulesImpl* getRayPayloadParameterRules()      override;
     LayoutRulesImpl* getCallablePayloadParameterRules() override;
     LayoutRulesImpl* getHitAttributesParameterRules()   override;
 
     LayoutRulesImpl* getShaderRecordConstantBufferRules() override;
-    LayoutRulesImpl* getStructuredBufferRules() override;
+    LayoutRulesImpl* getStructuredBufferRules(TargetRequest* request) override;
 };
 
 GLSLLayoutRulesFamilyImpl kGLSLLayoutRulesFamilyImpl;
@@ -1013,6 +1013,12 @@ LayoutRulesImpl kStd430LayoutRulesImpl_ = {
     &kGLSLLayoutRulesFamilyImpl, &kStd430LayoutRulesImpl, &kGLSLObjectLayoutRulesImpl,
 };
 
+LayoutRulesImpl kScalarLayoutRulesImpl_ = {
+    &kGLSLLayoutRulesFamilyImpl,
+    &kDefaultLayoutRulesImpl,
+    &kGLSLObjectLayoutRulesImpl,
+};
+
 LayoutRulesImpl kGLSLAnyValueLayoutRulesImpl_ = {
     &kGLSLLayoutRulesFamilyImpl,
     &kDefaultLayoutRulesImpl,
@@ -1099,14 +1105,17 @@ LayoutRulesImpl* GLSLLayoutRulesFamilyImpl::getAnyValueRules()
     return &kGLSLAnyValueLayoutRulesImpl_;
 }
 
-LayoutRulesImpl* GLSLLayoutRulesFamilyImpl::getConstantBufferRules()
+LayoutRulesImpl* GLSLLayoutRulesFamilyImpl::getConstantBufferRules(TargetRequest* targetReq)
 {
+    if (targetReq->getForceGLSLScalarBufferLayout())
+        return &kScalarLayoutRulesImpl_;
     return &kStd140LayoutRulesImpl_;
 }
 
-LayoutRulesImpl* GLSLLayoutRulesFamilyImpl::getParameterBlockRules()
+LayoutRulesImpl* GLSLLayoutRulesFamilyImpl::getParameterBlockRules(TargetRequest* targetReq)
 {
-    // TODO: actually pick something appropriate
+    if (targetReq->getForceGLSLScalarBufferLayout())
+        return &kScalarLayoutRulesImpl_;
     return &kStd140LayoutRulesImpl_;
 }
 
@@ -1143,7 +1152,7 @@ LayoutRulesImpl* GLSLLayoutRulesFamilyImpl::getSpecializationConstantRules()
 LayoutRulesImpl* GLSLLayoutRulesFamilyImpl::getShaderStorageBufferRules(TargetRequest* request)
 {
     if (request->getForceGLSLScalarBufferLayout())
-        return &kHLSLStructuredBufferLayoutRulesImpl_;
+        return &kScalarLayoutRulesImpl_;
     return &kStd430LayoutRulesImpl_;
 }
 
@@ -1162,8 +1171,10 @@ LayoutRulesImpl* GLSLLayoutRulesFamilyImpl::getHitAttributesParameterRules()
     return &kGLSLHitAttributesParameterLayoutRulesImpl_;
 }
 
-LayoutRulesImpl* GLSLLayoutRulesFamilyImpl::getStructuredBufferRules()
+LayoutRulesImpl* GLSLLayoutRulesFamilyImpl::getStructuredBufferRules(TargetRequest* targetReq)
 {
+    if (targetReq->getForceGLSLScalarBufferLayout())
+        return &kScalarLayoutRulesImpl_;
     return &kGLSLStructuredBufferLayoutRulesImpl_;
 }
 
@@ -1174,12 +1185,12 @@ LayoutRulesImpl* HLSLLayoutRulesFamilyImpl::getAnyValueRules()
     return &kHLSLAnyValueLayoutRulesImpl_;
 }
 
-LayoutRulesImpl* HLSLLayoutRulesFamilyImpl::getConstantBufferRules()
+LayoutRulesImpl* HLSLLayoutRulesFamilyImpl::getConstantBufferRules(TargetRequest*)
 {
     return &kHLSLConstantBufferLayoutRulesImpl_;
 }
 
-LayoutRulesImpl* HLSLLayoutRulesFamilyImpl::getParameterBlockRules()
+LayoutRulesImpl* HLSLLayoutRulesFamilyImpl::getParameterBlockRules(TargetRequest*)
 {
     // TODO: actually pick something appropriate...
     return &kHLSLConstantBufferLayoutRulesImpl_;
@@ -1196,7 +1207,7 @@ LayoutRulesImpl* HLSLLayoutRulesFamilyImpl::getShaderRecordConstantBufferRules()
     return &kHLSLConstantBufferLayoutRulesImpl_;
 }
 
-LayoutRulesImpl* HLSLLayoutRulesFamilyImpl::getStructuredBufferRules()
+LayoutRulesImpl* HLSLLayoutRulesFamilyImpl::getStructuredBufferRules(TargetRequest*)
 {
     return &kHLSLStructuredBufferLayoutRulesImpl_;
 }
@@ -1248,7 +1259,7 @@ LayoutRulesImpl* CPULayoutRulesFamilyImpl::getAnyValueRules()
     return &kCPUAnyValueLayoutRulesImpl_;
 }
 
-LayoutRulesImpl* CPULayoutRulesFamilyImpl::getConstantBufferRules()
+LayoutRulesImpl* CPULayoutRulesFamilyImpl::getConstantBufferRules(TargetRequest*)
 {
     return &kCPULayoutRulesImpl_;
 }
@@ -1279,7 +1290,7 @@ LayoutRulesImpl* CPULayoutRulesFamilyImpl::getShaderStorageBufferRules(TargetReq
 {
     return nullptr;
 }
-LayoutRulesImpl* CPULayoutRulesFamilyImpl::getParameterBlockRules()
+LayoutRulesImpl* CPULayoutRulesFamilyImpl::getParameterBlockRules(TargetRequest*)
 {
     // Not clear - just use similar to CPU 
     return &kCPULayoutRulesImpl_;
@@ -1302,7 +1313,7 @@ LayoutRulesImpl* CPULayoutRulesFamilyImpl::getShaderRecordConstantBufferRules()
     return &kCPULayoutRulesImpl_;
 }
 
-LayoutRulesImpl* CPULayoutRulesFamilyImpl::getStructuredBufferRules()
+LayoutRulesImpl* CPULayoutRulesFamilyImpl::getStructuredBufferRules(TargetRequest*)
 {
     return &kCPULayoutRulesImpl_;
 }
@@ -1314,7 +1325,7 @@ LayoutRulesImpl* CUDALayoutRulesFamilyImpl::getAnyValueRules()
     return &kCUDAAnyValueLayoutRulesImpl_;
 }
 
-LayoutRulesImpl* CUDALayoutRulesFamilyImpl::getConstantBufferRules()
+LayoutRulesImpl* CUDALayoutRulesFamilyImpl::getConstantBufferRules(TargetRequest*)
 {
     return &kCUDALayoutRulesImpl_;
 }
@@ -1345,7 +1356,7 @@ LayoutRulesImpl* CUDALayoutRulesFamilyImpl::getShaderStorageBufferRules(TargetRe
 {
     return nullptr;
 }
-LayoutRulesImpl* CUDALayoutRulesFamilyImpl::getParameterBlockRules()
+LayoutRulesImpl* CUDALayoutRulesFamilyImpl::getParameterBlockRules(TargetRequest*)
 {
     // Not clear - just use similar to CPU 
     return &kCUDALayoutRulesImpl_;
@@ -1369,7 +1380,7 @@ LayoutRulesImpl* CUDALayoutRulesFamilyImpl::getShaderRecordConstantBufferRules()
     return &kCUDALayoutRulesImpl_;
 }
 
-LayoutRulesImpl* CUDALayoutRulesFamilyImpl::getStructuredBufferRules()
+LayoutRulesImpl* CUDALayoutRulesFamilyImpl::getStructuredBufferRules(TargetRequest*)
 {
     return &kCUDALayoutRulesImpl_;
 }
@@ -1436,7 +1447,7 @@ TypeLayoutContext getInitialLayoutContextForTarget(TargetRequest* targetReq, Pro
 
     if( rulesFamily )
     {
-        context.rules = rulesFamily->getConstantBufferRules();
+        context.rules = rulesFamily->getConstantBufferRules(targetReq);
     }
 
     return context;
@@ -2545,7 +2556,7 @@ LayoutRulesImpl* getParameterBufferElementTypeLayoutRules(
 {
     if( as<ConstantBufferType>(parameterGroupType) )
     {
-        return rules->getLayoutRulesFamily()->getConstantBufferRules();
+        return rules->getLayoutRulesFamily()->getConstantBufferRules(targetRequest);
     }
     else if( as<TextureBufferType>(parameterGroupType) )
     {
@@ -2565,7 +2576,7 @@ LayoutRulesImpl* getParameterBufferElementTypeLayoutRules(
     }
     else if (as<ParameterBlockType>(parameterGroupType))
     {
-        return rules->getLayoutRulesFamily()->getParameterBlockRules();
+        return rules->getLayoutRulesFamily()->getParameterBlockRules(targetRequest);
     }
     else
     {
@@ -2647,7 +2658,7 @@ createStructuredBufferTypeLayout(
     Type*                elementType)
 {
     // look up the appropriate rules via the `LayoutRulesFamily` 
-    auto structuredBufferLayoutRules = context.getRulesFamily()->getStructuredBufferRules();
+    auto structuredBufferLayoutRules = context.getRulesFamily()->getStructuredBufferRules(context.targetReq);
 
     // Create and save type layout for the buffer contents.
     auto elementTypeLayout = createTypeLayout(

--- a/source/slang/slang-type-layout.h
+++ b/source/slang/slang-type-layout.h
@@ -995,14 +995,14 @@ struct LayoutRulesImpl
 struct LayoutRulesFamilyImpl
 {
     virtual LayoutRulesImpl* getAnyValueRules()             = 0;
-    virtual LayoutRulesImpl* getConstantBufferRules()       = 0;
+    virtual LayoutRulesImpl* getConstantBufferRules(TargetRequest* request) = 0;
     virtual LayoutRulesImpl* getPushConstantBufferRules()   = 0;
     virtual LayoutRulesImpl* getTextureBufferRules()        = 0;
     virtual LayoutRulesImpl* getVaryingInputRules()         = 0;
     virtual LayoutRulesImpl* getVaryingOutputRules()        = 0;
     virtual LayoutRulesImpl* getSpecializationConstantRules()= 0;
     virtual LayoutRulesImpl* getShaderStorageBufferRules(TargetRequest* request)  = 0;
-    virtual LayoutRulesImpl* getParameterBlockRules()       = 0;
+    virtual LayoutRulesImpl* getParameterBlockRules(TargetRequest* request) = 0;
 
     virtual LayoutRulesImpl* getRayPayloadParameterRules()  = 0;
     virtual LayoutRulesImpl* getCallablePayloadParameterRules()  = 0;
@@ -1010,7 +1010,7 @@ struct LayoutRulesFamilyImpl
 
     virtual LayoutRulesImpl* getShaderRecordConstantBufferRules() = 0;
 
-    virtual LayoutRulesImpl* getStructuredBufferRules() = 0;
+    virtual LayoutRulesImpl* getStructuredBufferRules(TargetRequest* request) = 0;
 };
 
 struct TypeLayoutContext

--- a/tools/gfx/d3d/d3d-util.cpp
+++ b/tools/gfx/d3d/d3d-util.cpp
@@ -808,6 +808,7 @@ D3D12_RESOURCE_STATES D3DUtil::getResourceState(ResourceState state)
     case ResourceState::StreamOutput:
         return D3D12_RESOURCE_STATE_STREAM_OUT;
     case ResourceState::ShaderResource:
+    case ResourceState::AccelerationStructureBuildInput:
         return D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
     case ResourceState::UnorderedAccess:
         return D3D12_RESOURCE_STATE_UNORDERED_ACCESS;

--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -669,6 +669,42 @@ Result DebugDevice::createMutableRootShaderObject(
     return result;
 }
 
+Result DebugDevice::createShaderObjectFromTypeLayout(
+    slang::TypeLayoutReflection* typeLayout, IShaderObject** outShaderObject)
+{
+    SLANG_GFX_API_FUNC;
+
+    RefPtr<DebugShaderObject> outObject = new DebugShaderObject();
+    auto result = baseObject->createShaderObjectFromTypeLayout(typeLayout, outObject->baseObject.writeRef());
+    auto type = typeLayout->getType();
+    auto typeName = type->getName();
+    outObject->m_typeName = typeName;
+    outObject->m_device = this;
+    outObject->m_slangType = type;
+    if (SLANG_FAILED(result))
+        return result;
+    returnComPtr(outShaderObject, outObject);
+    return result;
+}
+
+Result DebugDevice::createMutableShaderObjectFromTypeLayout(
+    slang::TypeLayoutReflection* typeLayout, IShaderObject** outShaderObject)
+{
+    SLANG_GFX_API_FUNC;
+    RefPtr<DebugShaderObject> outObject = new DebugShaderObject();
+    auto result = baseObject->createMutableShaderObjectFromTypeLayout(
+        typeLayout, outObject->baseObject.writeRef());
+    if (SLANG_FAILED(result))
+        return result;
+    auto type = typeLayout->getType();
+    auto typeName = type->getName();
+    outObject->m_typeName = typeName;
+    outObject->m_device = this;
+    outObject->m_slangType = type;
+    returnComPtr(outShaderObject, outObject);
+    return result;
+}
+
 Result DebugDevice::createProgram(
     const IShaderProgram::Desc& desc, IShaderProgram** outProgram, ISlangBlob** outDiagnostics)
 {

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -120,6 +120,10 @@ public:
         slang::TypeReflection* type,
         ShaderObjectContainerType container,
         IShaderObject** outObject) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL createShaderObjectFromTypeLayout(
+        slang::TypeLayoutReflection* typeLayout, IShaderObject** outObject) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL createMutableShaderObjectFromTypeLayout(
+        slang::TypeLayoutReflection* typeLayout, IShaderObject** outObject) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
         createMutableRootShaderObject(IShaderProgram* program, IShaderObject** outObject) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL

--- a/tools/gfx/renderer-shared.cpp
+++ b/tools/gfx/renderer-shared.cpp
@@ -366,6 +366,7 @@ Result RendererBase::getFormatSupportedResourceStates(Format format, ResourceSta
 {
     SLANG_UNUSED(format);
     outStates->add(ResourceState::AccelerationStructure);
+    outStates->add(ResourceState::AccelerationStructureBuildInput);
     outStates->add(ResourceState::ConstantBuffer);
     outStates->add(ResourceState::CopyDestination);
     outStates->add(ResourceState::CopySource);

--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -1240,6 +1240,12 @@ public:
         ShaderObjectContainerType containerType,
         IShaderObject** outObject) SLANG_OVERRIDE;
 
+    virtual SLANG_NO_THROW Result SLANG_MCALL createShaderObjectFromTypeLayout(
+        slang::TypeLayoutReflection* typeLayout, IShaderObject** outObject) override;
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL createMutableShaderObjectFromTypeLayout(
+        slang::TypeLayoutReflection* typeLayout, IShaderObject** outObject) override;
+
     // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE for platforms
     // without ray tracing support.
     virtual SLANG_NO_THROW Result SLANG_MCALL getAccelerationStructurePrebuildInfo(
@@ -1283,6 +1289,10 @@ public:
         ShaderObjectContainerType   container,
         ShaderObjectLayoutBase**    outLayout);
 
+    Result getShaderObjectLayout(
+        slang::TypeLayoutReflection* typeLayout,
+        ShaderObjectLayoutBase** outLayout);
+
 public:
     ExtendedShaderObjectTypeList specializationArgs;
     // Given current pipeline and root shader object binding, generate and bind a specialized pipeline if necessary.
@@ -1316,7 +1326,7 @@ public:
     SlangContext slangContext;
     ShaderCache shaderCache;
 
-    Slang::Dictionary<slang::TypeReflection*, Slang::RefPtr<ShaderObjectLayoutBase>> m_shaderObjectLayoutCache;
+    Slang::Dictionary<slang::TypeLayoutReflection*, Slang::RefPtr<ShaderObjectLayoutBase>> m_shaderObjectLayoutCache;
 };
 
 bool isDepthFormat(Format format);

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -6393,7 +6393,7 @@ public:
                 m_desc.format = Format::B8G8R8A8_UNORM;
             }
 
-            SLANG_RETURN_ON_FAIL(createSwapchainAndImages());
+            createSwapchainAndImages();
             return SLANG_OK;
         }
 

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -804,7 +804,7 @@ void RenderTestApp::_initializeAccelerationStructure()
         instanceBufferDesc.type = IResource::Type::Buffer;
         instanceBufferDesc.sizeInBytes =
             instanceDescs.getCount() * sizeof(IAccelerationStructure::InstanceDesc);
-        instanceBufferDesc.defaultState = ResourceState::ShaderResource;
+        instanceBufferDesc.defaultState = ResourceState::AccelerationStructureBuildInput;
         ComPtr<IBufferResource> instanceBuffer =
             m_device->createBufferResource(instanceBufferDesc, instanceDescs.getBuffer());
 


### PR DESCRIPTION
This change makes Slang to use `scalar` constant buffer layout when `forceGLSLScalarBufferLayout` target flag is set.
Also updates the type reflection logic to respect this target flag.

Adds `createShaderObjectFromTypeLayout` method in gfx to make gfx shader object use the consistent type layout.