### PR TITLE
Small fix in d3d12 transient heap.

### DIFF
--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -2787,7 +2787,7 @@ Result AccelerationStructureImpl::getNativeHandle(InteropHandle* outHandle)
 Result TransientResourceHeapImpl::synchronizeAndReset()
 {
     WaitForMultipleObjects(
-        (DWORD)m_waitHandles.getCount(), m_waitHandles.getBuffer(), TRUE, INFINITE);
+        (DWORD)m_waitHandles.getCount(), m_waitHandles.getArrayView().getBuffer(), TRUE, INFINITE);
     m_waitHandles.clear();
     m_currentViewHeapIndex = -1;
     m_currentSamplerHeapIndex = -1;

--- a/tools/gfx/d3d12/render-d3d12.h
+++ b/tools/gfx/d3d12/render-d3d12.h
@@ -494,7 +494,7 @@ public:
         ComPtr<ID3D12Fence> fence = nullptr;
     };
     ShortList<QueueWaitInfo, 4> m_waitInfos;
-    Array<HANDLE, 16> m_waitHandles;
+    ShortList<HANDLE, 4> m_waitHandles;
 
     QueueWaitInfo& getQueueWaitInfo(uint32_t queueIndex);
     // During command submission, we need all the descriptor tables that get


### PR DESCRIPTION
Use `ShortList` instead of `Array` for `m_waitHandles`.