### PR TITLE
Add -depfile option to save dependency info

### DIFF
--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -2177,12 +2177,12 @@ namespace Slang
         return SLANG_OK;
     }
 
-    static void writeString(Stream& stream, const char* string)
+    static void _writeString(Stream& stream, const char* string)
     {
         stream.write(string, strlen(string));
     }
 
-    static void escapeDependencyString(const char* string, StringBuilder& builder)
+    static void _escapeDependencyString(const char* string, StringBuilder& outBuilder)
     {
         // make has unusual escaping rules, but we only care about characters that are acceptable in a path
         for (const char* p = string; *p; ++p)
@@ -2196,37 +2196,37 @@ namespace Slang
             case '[':
             case ']':
             case '\\':
-                builder.appendChar('\\');
+                outBuilder.appendChar('\\');
                 break;
 
             case '$':
-                builder.appendChar('$');
+                outBuilder.appendChar('$');
                 break;
             }
 
-            builder.appendChar(c);
+            outBuilder.appendChar(c);
         }
     }
 
     // Writes a line to the file stream, formatted like this:
     //   <output-file>: <dependency-file> <dependency-file...>
-    static void writeDependencyStatement(Stream& stream, EndToEndCompileRequest* compileRequest, const String& outputPath)
+    static void _writeDependencyStatement(Stream& stream, EndToEndCompileRequest* compileRequest, const String& outputPath)
     {
         if (outputPath.getLength() == 0)
             return;
 
         StringBuilder builder;
-        escapeDependencyString(outputPath.begin(), builder);
-        writeString(stream, builder.begin());
-        writeString(stream, ": ");
+        _escapeDependencyString(outputPath.begin(), builder);
+        _writeString(stream, builder.begin());
+        _writeString(stream, ": ");
 
         int dependencyCount = compileRequest->getDependencyFileCount();
         for (int dependencyIndex = 0; dependencyIndex < dependencyCount; ++dependencyIndex)
         {
             builder.Clear();
-            escapeDependencyString(compileRequest->getDependencyFilePath(dependencyIndex), builder);
-            writeString(stream, builder.begin());
-            writeString(stream, (dependencyIndex + 1 < dependencyCount) ? " " : "\n");
+            _escapeDependencyString(compileRequest->getDependencyFilePath(dependencyIndex), builder);
+            _writeString(stream, builder.begin());
+            _writeString(stream, (dependencyIndex + 1 < dependencyCount) ? " " : "\n");
         }
     }
 
@@ -2250,7 +2250,7 @@ namespace Slang
                 RefPtr<EndToEndCompileRequest::TargetInfo> targetInfo;
                 if (compileRequest->m_targetInfos.TryGetValue(targetReq, targetInfo))
                 {
-                    writeDependencyStatement(stream, compileRequest, targetInfo->wholeTargetOutputPath);
+                    _writeDependencyStatement(stream, compileRequest, targetInfo->wholeTargetOutputPath);
                 }
             }
             else
@@ -2264,7 +2264,7 @@ namespace Slang
                         String outputPath;
                         if (targetInfo->entryPointOutputPaths.TryGetValue(entryPointIndex, outputPath))
                         {
-                            writeDependencyStatement(stream, compileRequest, outputPath);
+                            _writeDependencyStatement(stream, compileRequest, outputPath);
                         }
                     }
                 }

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -2231,7 +2231,7 @@ namespace Slang
     }
 
     // Writes a file with dependency info, with one line in the output file per compile product.
-    static SlangResult writeDependencyFile(EndToEndCompileRequest* compileRequest)
+    static SlangResult _writeDependencyFile(EndToEndCompileRequest* compileRequest)
     {
         if (compileRequest->m_dependencyOutputPath.getLength() == 0)
             return SLANG_OK;
@@ -2363,7 +2363,7 @@ namespace Slang
             compileRequest->maybeCreateContainer();
             compileRequest->maybeWriteContainer(compileRequest->m_containerOutputPath);
 
-            writeDependencyFile(compileRequest);
+            _writeDependencyFile(compileRequest);
         }
     }
 

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -2177,6 +2177,98 @@ namespace Slang
         return SLANG_OK;
     }
 
+    static void writeString(Stream& stream, const char* string)
+    {
+        stream.write(string, strlen(string));
+    }
+
+    static void escapeDependencyString(const char* string, StringBuilder& builder)
+    {
+        // make has unusual escaping rules, but we only care about characters that are acceptable in a path
+        for (const char* p = string; *p; ++p)
+        {
+            char c = *p;
+            switch(c)
+            {
+            case ' ':
+                builder.appendChar('\\');
+                break;
+
+            case '$':
+                builder.appendChar('$');
+                break;
+            }
+
+            builder.appendChar(c);
+        }
+    }
+
+    // Writes a line to the file stream, formatted like this:
+    //   <output-file>: <dependency-file> <dependency-file...>
+    static void writeDependencyStatement(Stream& stream, EndToEndCompileRequest* compileRequest, const String& outputPath)
+    {
+        if (outputPath.getLength() == 0)
+            return;
+
+        StringBuilder builder;
+        escapeDependencyString(outputPath.begin(), builder);
+        writeString(stream, builder.begin());
+        writeString(stream, ": ");
+
+        int dependencyCount = compileRequest->getDependencyFileCount();
+        for (int dependencyIndex = 0; dependencyIndex < dependencyCount; ++dependencyIndex)
+        {
+            builder.Clear();
+            escapeDependencyString(compileRequest->getDependencyFilePath(dependencyIndex), builder);
+            writeString(stream, builder.begin());
+            writeString(stream, (dependencyIndex + 1 < dependencyCount) ? " " : "\n");
+        }
+    }
+
+    // Writes a file with dependency info, with one line in the output file per compile product.
+    static SlangResult writeDependencyFile(EndToEndCompileRequest* compileRequest)
+    {
+        if (compileRequest->m_dependencyOutputPath.getLength() == 0)
+            return SLANG_OK;
+
+        FileStream stream;
+        SLANG_RETURN_ON_FAIL(stream.init(compileRequest->m_dependencyOutputPath, FileMode::Create, FileAccess::Write, FileShare::ReadWrite));
+
+        auto linkage = compileRequest->getLinkage();
+        auto program = compileRequest->getSpecializedGlobalAndEntryPointsComponentType();
+
+        // Iterate over all the targets and their outputs
+        for (const auto& targetReq : linkage->targets)
+        {
+            if (targetReq->isWholeProgramRequest())
+            {
+                RefPtr<EndToEndCompileRequest::TargetInfo> targetInfo;
+                if (compileRequest->m_targetInfos.TryGetValue(targetReq, targetInfo))
+                {
+                    writeDependencyStatement(stream, compileRequest, targetInfo->wholeTargetOutputPath);
+                }
+            }
+            else
+            {
+                Index entryPointCount = program->getEntryPointCount();
+                for (Index entryPointIndex = 0; entryPointIndex < entryPointCount; ++entryPointIndex)
+                {
+                    RefPtr<EndToEndCompileRequest::TargetInfo> targetInfo;
+                    if (compileRequest->m_targetInfos.TryGetValue(targetReq, targetInfo))
+                    {
+                        String outputPath;
+                        if (targetInfo->entryPointOutputPaths.TryGetValue(entryPointIndex, outputPath))
+                        {
+                            writeDependencyStatement(stream, compileRequest, outputPath);
+                        }
+                    }
+                }
+            }
+        }
+
+        return SLANG_OK;
+    }
+
 
     static void _generateOutput(
         BackEndCompileRequest* compileRequest,
@@ -2265,6 +2357,8 @@ namespace Slang
 
             compileRequest->maybeCreateContainer();
             compileRequest->maybeWriteContainer(compileRequest->m_containerOutputPath);
+
+            writeDependencyFile(compileRequest);
         }
     }
 

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -2191,6 +2191,11 @@ namespace Slang
             switch(c)
             {
             case ' ':
+            case ':':
+            case '#':
+            case '[':
+            case ']':
+            case '\\':
                 builder.appendChar('\\');
                 break;
 

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -2369,6 +2369,8 @@ namespace Slang
             String wholeTargetOutputPath;
         };
         Dictionary<TargetRequest*, RefPtr<TargetInfo>> m_targetInfos;
+        
+        String m_dependencyOutputPath;
 
             /// Writes the modules in a container to the stream
         SlangResult writeContainerToStream(Stream* stream);

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -108,6 +108,7 @@ DIAGNOSTIC(    70, Error, cannotMatchOutputFileToEntryPoint, "the output path '$
 
 DIAGNOSTIC(    80, Error, duplicateOutputPathsForEntryPointAndTarget, "multiple output paths have been specified entry point '$0' on target '$1'")
 DIAGNOSTIC(    81, Error, duplicateOutputPathsForTarget, "multiple output paths have been specified for target '$0'")
+DIAGNOSTIC(    82, Error, duplicateDependencyOutputPaths, "the -dep argument can only be specified once")
 
 DIAGNOSTIC(    82, Error, unableToWriteReproFile, "unable to write repro file '%0'")
 DIAGNOSTIC(    83, Error, unableToWriteModuleContainer, "unable to write module container '%0'")

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -501,6 +501,7 @@ struct OptionsParser
             "General options:\n"
             "\n"
             "  -D<name>[=<value>], -D <name>[=<value>]: Insert a preprocessor macro.\n"
+            "  -depfile <path>: Save the source file dependency list in a file.\n"
             "  -entry <name>: Specify the name of an entry-point function.\n"
             "    Multiple -entry options may be used in a single invocation.\n"
             "    If no -entry options are given, compiler will use [shader(...)]\n"
@@ -1258,6 +1259,22 @@ struct OptionsParser
                     SLANG_RETURN_ON_FAIL(reader.expectArg(outputPath));
 
                     addOutputPath(outputPath.value.getBuffer());
+                }
+                // A -depfile option is used to specify the file name where the dependency lists will be written
+                else if (argValue == "-depfile")
+                {
+                    CommandLineArg dependencyPath;
+                    SLANG_RETURN_ON_FAIL(reader.expectArg(dependencyPath));
+
+                    if (requestImpl->m_dependencyOutputPath.getLength() == 0)
+                    {
+                        requestImpl->m_dependencyOutputPath = dependencyPath.value;
+                    }
+                    else
+                    {
+                        sink->diagnose(dependencyPath.loc, Diagnostics::duplicateDependencyOutputPaths);
+                        return SLANG_FAIL;
+                    }
                 }
                 else if(argValue == "-matrix-layout-row-major")
                 {


### PR DESCRIPTION
This change adds a `-depfile` command line option to `slangc` to save the dependency information, i.e. which source files does every output of the current compile request depend on. The deps are saved in a regular Makefile-type format, similar to e.g. `glslangValidator`.