### PR TITLE
Add additional texture to texture copying tests

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -604,6 +604,8 @@ enum class TextureAspect : uint32_t
     Plane0 = 0x00000010,
     Plane1 = 0x00000020,
     Plane2 = 0x00000040,
+
+    DepthStencil = Depth | Stencil,
 };
 
 struct SubresourceRange

--- a/tools/gfx-unit-test/copy-texture-tests.cpp
+++ b/tools/gfx-unit-test/copy-texture-tests.cpp
@@ -139,6 +139,113 @@ namespace gfx_test
         }
     };
 
+    RefPtr<ValidationTextureFormatBase> getValidationTextureFormat(Format format)
+    {
+        switch (format)
+        {
+        case Format::R32G32B32A32_TYPELESS:         return new ValidationTextureFormat<uint32_t>(4);
+        case Format::R32G32B32_TYPELESS:            return new ValidationTextureFormat<uint32_t>(3);
+        case Format::R32G32_TYPELESS:               return new ValidationTextureFormat<uint32_t>(2);
+        case Format::R32_TYPELESS:                  return new ValidationTextureFormat<uint32_t>(1);
+
+        case Format::R16G16B16A16_TYPELESS:         return new ValidationTextureFormat<uint16_t>(4);
+        case Format::R16G16_TYPELESS:               return new ValidationTextureFormat<uint16_t>(2);
+        case Format::R16_TYPELESS:                  return new ValidationTextureFormat<uint16_t>(1);
+
+        case Format::R8G8B8A8_TYPELESS:             return new ValidationTextureFormat<uint8_t>(4);
+        case Format::R8G8_TYPELESS:                 return new ValidationTextureFormat<uint8_t>(2);
+        case Format::R8_TYPELESS:                   return new ValidationTextureFormat<uint8_t>(1);
+        case Format::B8G8R8A8_TYPELESS:             return new ValidationTextureFormat<uint8_t>(4);
+
+        case Format::R32G32B32A32_FLOAT:            return new ValidationTextureFormat<float>(4);
+        case Format::R32G32B32_FLOAT:               return new ValidationTextureFormat<float>(3);
+        case Format::R32G32_FLOAT:                  return new ValidationTextureFormat<float>(2);
+        case Format::R32_FLOAT:                     return new ValidationTextureFormat<float>(1);
+
+        case Format::R16G16B16A16_FLOAT:            return new ValidationTextureFormat<uint16_t>(4);
+        case Format::R16G16_FLOAT:                  return new ValidationTextureFormat<uint16_t>(2);
+        case Format::R16_FLOAT:                     return new ValidationTextureFormat<uint16_t>(1);
+
+        case Format::R32G32B32A32_UINT:             return new ValidationTextureFormat<uint32_t>(4);
+        case Format::R32G32B32_UINT:                return new ValidationTextureFormat<uint32_t>(3);
+        case Format::R32G32_UINT:                   return new ValidationTextureFormat<uint32_t>(2);
+        case Format::R32_UINT:                      return new ValidationTextureFormat<uint32_t>(1);
+
+        case Format::R16G16B16A16_UINT:             return new ValidationTextureFormat<uint16_t>(4);
+        case Format::R16G16_UINT:                   return new ValidationTextureFormat<uint16_t>(2);
+        case Format::R16_UINT:                      return new ValidationTextureFormat<uint16_t>(1);
+
+        case Format::R8G8B8A8_UINT:                 return new ValidationTextureFormat<uint8_t>(4);
+        case Format::R8G8_UINT:                     return new ValidationTextureFormat<uint8_t>(2);
+        case Format::R8_UINT:                       return new ValidationTextureFormat<uint8_t>(1);
+
+        case Format::R32G32B32A32_SINT:             return new ValidationTextureFormat<int32_t>(4);
+        case Format::R32G32B32_SINT:                return new ValidationTextureFormat<int32_t>(3);
+        case Format::R32G32_SINT:                   return new ValidationTextureFormat<int32_t>(2);
+        case Format::R32_SINT:                      return new ValidationTextureFormat<int32_t>(1);
+
+        case Format::R16G16B16A16_SINT:             return new ValidationTextureFormat<int16_t>(4);
+        case Format::R16G16_SINT:                   return new ValidationTextureFormat<int16_t>(2);
+        case Format::R16_SINT:                      return new ValidationTextureFormat<int16_t>(1);
+
+        case Format::R8G8B8A8_SINT:                 return new ValidationTextureFormat<int8_t>(4);
+        case Format::R8G8_SINT:                     return new ValidationTextureFormat<int8_t>(2);
+        case Format::R8_SINT:                       return new ValidationTextureFormat<int8_t>(1);
+
+        case Format::R16G16B16A16_UNORM:            return new ValidationTextureFormat<uint16_t>(4);
+        case Format::R16G16_UNORM:                  return new ValidationTextureFormat<uint16_t>(2);
+        case Format::R16_UNORM:                     return new ValidationTextureFormat<uint16_t>(1);
+
+        case Format::R8G8B8A8_UNORM:                return new ValidationTextureFormat<uint8_t>(4);
+        case Format::R8G8B8A8_UNORM_SRGB:           return new ValidationTextureFormat<uint8_t>(4);
+        case Format::R8G8_UNORM:                    return new ValidationTextureFormat<uint8_t>(2);
+        case Format::R8_UNORM:                      return new ValidationTextureFormat<uint8_t>(1);
+        case Format::B8G8R8A8_UNORM:                return new ValidationTextureFormat<uint8_t>(4);
+        case Format::B8G8R8A8_UNORM_SRGB:           return new ValidationTextureFormat<uint8_t>(4);
+        case Format::B8G8R8X8_UNORM:                return new ValidationTextureFormat<uint8_t>(3);
+        case Format::B8G8R8X8_UNORM_SRGB:           return new ValidationTextureFormat<uint8_t>(3);
+
+        case Format::R16G16B16A16_SNORM:            return new ValidationTextureFormat<int16_t>(4);
+        case Format::R16G16_SNORM:                  return new ValidationTextureFormat<int16_t>(2);
+        case Format::R16_SNORM:                     return new ValidationTextureFormat<int16_t>(1);
+
+        case Format::R8G8B8A8_SNORM:                return new ValidationTextureFormat<int8_t>(4);
+        case Format::R8G8_SNORM:                    return new ValidationTextureFormat<int8_t>(2);
+        case Format::R8_SNORM:                      return new ValidationTextureFormat<int8_t>(1);
+
+        case Format::D32_FLOAT:                     return new ValidationTextureFormat<float>(1);
+        case Format::D16_UNORM:                     return new ValidationTextureFormat<uint16_t>(1);
+
+        case Format::B4G4R4A4_UNORM:                return new PackedValidationTextureFormat<uint16_t>(4, 4, 4, 4);
+        case Format::B5G6R5_UNORM:                  return new PackedValidationTextureFormat<uint16_t>(5, 6, 5, 0);
+        case Format::B5G5R5A1_UNORM:                return new PackedValidationTextureFormat<uint16_t>(5, 5, 5, 1);
+
+        case Format::R9G9B9E5_SHAREDEXP:            return new ValidationTextureFormat<uint32_t>(1);
+        case Format::R10G10B10A2_TYPELESS:          return new PackedValidationTextureFormat<uint32_t>(10, 10, 10, 2);
+        case Format::R10G10B10A2_UNORM:             return new PackedValidationTextureFormat<uint32_t>(10, 10, 10, 2);
+        case Format::R10G10B10A2_UINT:              return new PackedValidationTextureFormat<uint32_t>(10, 10, 10, 2);
+        case Format::R11G11B10_FLOAT:               return new PackedValidationTextureFormat<uint32_t>(11, 11, 10, 0);
+
+            // TODO: Add testing support for BC formats
+//                     BC1_UNORM,
+//                     BC1_UNORM_SRGB,
+//                     BC2_UNORM,
+//                     BC2_UNORM_SRGB,
+//                     BC3_UNORM,
+//                     BC3_UNORM_SRGB,
+//                     BC4_UNORM,
+//                     BC4_SNORM,
+//                     BC5_UNORM,
+//                     BC5_SNORM,
+//                     BC6H_UF16,
+//                     BC6H_SF16,
+//                     BC7_UNORM,
+//                     BC7_UNORM_SRGB,
+        default:
+            return nullptr;
+        }
+    }
+
     struct ValidationTextureData : RefObject
     {
         const void* textureData;
@@ -170,11 +277,13 @@ namespace gfx_test
         IDevice* device;
         UnitTestContext* context;
 
+        Format format;
+        size_t alignedRowStride;
+
         ComPtr<ITextureResource> srcTexture;
         ComPtr<ITextureResource> dstTexture;
         ComPtr<IBufferResource> resultsBuffer;
-
-        size_t alignedRowStride;
+        RefPtr<ValidationTextureFormatBase> validationFormat;
 
         struct TextureInfo
         {
@@ -184,13 +293,15 @@ namespace gfx_test
             ITextureResource::SubresourceData const* initData;
         };
 
-        void init(IDevice* device, UnitTestContext* context)
+        void init(IDevice* device, UnitTestContext* context, Format format, RefPtr<ValidationTextureFormatBase> validationFormat)
         {
             this->device = device;
             this->context = context;
+            this->format = format;
+            this->validationFormat = validationFormat;
         }
 
-        RefPtr<TextureStuff> generateTextureData(int width, int height, uint32_t mipLevels, uint32_t arrayLayers, Format format)
+        RefPtr<TextureStuff> generateTextureData(int width, int height, uint32_t mipLevels, uint32_t arrayLayers)
         {
             FormatInfo formatInfo;
             gfxGetFormatInfo(format, &formatInfo);
@@ -215,7 +326,7 @@ namespace gfx_test
                     subresource->strides.x = texelSize;
                     subresource->strides.y = mipWidth * texelSize;
                     subresource->strides.z = mipHeight * subresource->strides.y;
-                    subresource->format = getValidationTextureFormat(format);
+                    subresource->format = validationFormat;
                     texture->subresourceObjects.add(subresource);
 
                     for (int h = 0; h < mipHeight; ++h)
@@ -237,7 +348,19 @@ namespace gfx_test
             return texture;
         }
 
-        void createRequiredResources(TextureInfo srcTextureInfo, TextureInfo dstTextureInfo, ITextureResource::Size bufferCopyExtents, Format format)
+        TextureAspect getTextureAspect()
+        {
+            switch (format)
+            {
+            case Format::D16_UNORM:
+            case Format::D32_FLOAT:
+                return TextureAspect::Depth;
+            default:
+                return TextureAspect::Color;
+            }
+        }
+
+        void createRequiredResources(TextureInfo srcTextureInfo, TextureInfo dstTextureInfo, ITextureResource::Size bufferCopyExtents)
         {
             ITextureResource::Desc srcTexDesc = {};
             srcTexDesc.type = IResource::Type::Texture2D;
@@ -248,6 +371,11 @@ namespace gfx_test
             srcTexDesc.allowedStates = ResourceStateSet(
                 ResourceState::ShaderResource,
                 ResourceState::CopySource);
+            if (format == Format::D32_FLOAT || format == Format::D16_UNORM)
+            {
+                srcTexDesc.allowedStates.add(ResourceState::DepthWrite);
+                srcTexDesc.allowedStates.add(ResourceState::DepthRead);
+            }
             srcTexDesc.format = format;
 
             GFX_CHECK_CALL_ABORT(device->createTextureResource(
@@ -265,6 +393,11 @@ namespace gfx_test
                 ResourceState::ShaderResource,
                 ResourceState::CopyDestination,
                 ResourceState::CopySource);
+            if (format == Format::D32_FLOAT || format == Format::D16_UNORM)
+            {
+                srcTexDesc.allowedStates.add(ResourceState::DepthWrite);
+                srcTexDesc.allowedStates.add(ResourceState::DepthRead);
+            }
             dstTexDesc.format = format;
 
             GFX_CHECK_CALL_ABORT(device->createTextureResource(
@@ -286,6 +419,11 @@ namespace gfx_test
                 ResourceState::UnorderedAccess,
                 ResourceState::CopyDestination,
                 ResourceState::CopySource);
+            if (format == Format::D32_FLOAT || format == Format::D16_UNORM)
+            {
+                srcTexDesc.allowedStates.add(ResourceState::DepthWrite);
+                srcTexDesc.allowedStates.add(ResourceState::DepthRead);
+            }
             bufferDesc.defaultState = ResourceState::CopyDestination;
             bufferDesc.memoryType = MemoryType::DeviceLocal;
 
@@ -326,114 +464,6 @@ namespace gfx_test
             commandBuffer->close();
             queue->executeCommandBuffer(commandBuffer);
             queue->waitOnHost();
-        }
-
-        // should return refptr to avoid leaking memory
-        RefPtr<ValidationTextureFormatBase> getValidationTextureFormat(Format format)
-        {
-            switch (format)
-            {
-            case Format::R32G32B32A32_TYPELESS:         return new ValidationTextureFormat<uint32_t>(4);
-            case Format::R32G32B32_TYPELESS:            return new ValidationTextureFormat<uint32_t>(3);
-            case Format::R32G32_TYPELESS:               return new ValidationTextureFormat<uint32_t>(2);
-            case Format::R32_TYPELESS:                  return new ValidationTextureFormat<uint32_t>(1);
-
-            case Format::R16G16B16A16_TYPELESS:         return new ValidationTextureFormat<uint16_t>(4);
-            case Format::R16G16_TYPELESS:               return new ValidationTextureFormat<uint16_t>(2);
-            case Format::R16_TYPELESS:                  return new ValidationTextureFormat<uint16_t>(1);
-
-            case Format::R8G8B8A8_TYPELESS:             return new ValidationTextureFormat<uint8_t>(4);
-            case Format::R8G8_TYPELESS:                 return new ValidationTextureFormat<uint8_t>(2);
-            case Format::R8_TYPELESS:                   return new ValidationTextureFormat<uint8_t>(1);
-            case Format::B8G8R8A8_TYPELESS:             return new ValidationTextureFormat<uint8_t>(4);
-
-            case Format::R32G32B32A32_FLOAT:            return new ValidationTextureFormat<float>(4);
-            case Format::R32G32B32_FLOAT:               return new ValidationTextureFormat<float>(3);
-            case Format::R32G32_FLOAT:                  return new ValidationTextureFormat<float>(2);
-            case Format::R32_FLOAT:                     return new ValidationTextureFormat<float>(1);
-
-//                     R16G16B16A16_FLOAT,
-//                     R16G16_FLOAT,
-//                     R16_FLOAT,
- 
-            case Format::R32G32B32A32_UINT:             return new ValidationTextureFormat<uint32_t>(4);
-            case Format::R32G32B32_UINT:                return new ValidationTextureFormat<uint32_t>(3);
-            case Format::R32G32_UINT:                   return new ValidationTextureFormat<uint32_t>(2);
-            case Format::R32_UINT:                      return new ValidationTextureFormat<uint32_t>(1);
-
-            case Format::R16G16B16A16_UINT:             return new ValidationTextureFormat<uint16_t>(4);
-            case Format::R16G16_UINT:                   return new ValidationTextureFormat<uint16_t>(2);
-            case Format::R16_UINT:                      return new ValidationTextureFormat<uint16_t>(1);
-
-            case Format::R8G8B8A8_UINT:                 return new ValidationTextureFormat<uint8_t>(4);
-            case Format::R8G8_UINT:                     return new ValidationTextureFormat<uint8_t>(2);
-            case Format::R8_UINT:                       return new ValidationTextureFormat<uint8_t>(1);
-
-            case Format::R32G32B32A32_SINT:             return new ValidationTextureFormat<int32_t>(4);
-            case Format::R32G32B32_SINT:                return new ValidationTextureFormat<int32_t>(3);
-            case Format::R32G32_SINT:                   return new ValidationTextureFormat<int32_t>(2);
-            case Format::R32_SINT:                      return new ValidationTextureFormat<int32_t>(1);
-
-            case Format::R16G16B16A16_SINT:             return new ValidationTextureFormat<int16_t>(4);
-            case Format::R16G16_SINT:                   return new ValidationTextureFormat<int16_t>(2);
-            case Format::R16_SINT:                      return new ValidationTextureFormat<int16_t>(1);
-
-            case Format::R8G8B8A8_SINT:                 return new ValidationTextureFormat<int8_t>(4);
-            case Format::R8G8_SINT:                     return new ValidationTextureFormat<int8_t>(2);
-            case Format::R8_SINT:                       return new ValidationTextureFormat<int8_t>(1);
-
-            case Format::R16G16B16A16_UNORM:            return new ValidationTextureFormat<uint16_t>(4);
-            case Format::R16G16_UNORM:                  return new ValidationTextureFormat<uint16_t>(2);
-            case Format::R16_UNORM:                     return new ValidationTextureFormat<uint16_t>(1);
-
-            case Format::R8G8B8A8_UNORM:                return new ValidationTextureFormat<uint8_t>(4);
-            case Format::R8G8B8A8_UNORM_SRGB:           return new ValidationTextureFormat<uint8_t>(4);
-            case Format::R8G8_UNORM:                    return new ValidationTextureFormat<uint8_t>(2);
-            case Format::R8_UNORM:                      return new ValidationTextureFormat<uint8_t>(1);
-            case Format::B8G8R8A8_UNORM:                return new ValidationTextureFormat<uint8_t>(4);
-            case Format::B8G8R8A8_UNORM_SRGB:           return new ValidationTextureFormat<uint8_t>(4);
-            case Format::B8G8R8X8_UNORM:                return new ValidationTextureFormat<uint8_t>(3); // 3 or 4 channels?
-            case Format::B8G8R8X8_UNORM_SRGB:           return new ValidationTextureFormat<uint8_t>(3);
-
-            case Format::R16G16B16A16_SNORM:            return new ValidationTextureFormat<int16_t>(4);
-            case Format::R16G16_SNORM:                  return new ValidationTextureFormat<int16_t>(2);
-            case Format::R16_SNORM:                     return new ValidationTextureFormat<int16_t>(1);
-
-            case Format::R8G8B8A8_SNORM:                return new ValidationTextureFormat<int8_t>(4);
-            case Format::R8G8_SNORM:                    return new ValidationTextureFormat<int8_t>(2);
-            case Format::R8_SNORM:                      return new ValidationTextureFormat<int8_t>(1);
-
-            case Format::D32_FLOAT:                     return new ValidationTextureFormat<float>(1); // broken in VK
-            case Format::D16_UNORM:                     return new ValidationTextureFormat<uint16_t>(1); // broken in VK
-
-            case Format::B4G4R4A4_UNORM:                return new PackedValidationTextureFormat<uint16_t>(4, 4, 4, 4);
-            case Format::B5G6R5_UNORM:                  return new PackedValidationTextureFormat<uint16_t>(5, 6, 5, 0);
-            case Format::B5G5R5A1_UNORM:                return new PackedValidationTextureFormat<uint16_t>(5, 5, 5, 1);
-
-//                     R9G9B9E5_SHAREDEXP,
-            case Format::R10G10B10A2_TYPELESS:          return new PackedValidationTextureFormat<uint32_t>(10, 10, 10, 2);
-            case Format::R10G10B10A2_UNORM:             return new PackedValidationTextureFormat<uint32_t>(10, 10, 10, 2);
-            case Format::R10G10B10A2_UINT:              return new PackedValidationTextureFormat<uint32_t>(10, 10, 10, 2);
-            case Format::R11G11B10_FLOAT:               return new PackedValidationTextureFormat<uint32_t>(11, 11, 10, 0);
-
-//                     BC1_UNORM,
-//                     BC1_UNORM_SRGB,
-//                     BC2_UNORM,
-//                     BC2_UNORM_SRGB,
-//                     BC3_UNORM,
-//                     BC3_UNORM_SRGB,
-//                     BC4_UNORM,
-//                     BC4_SNORM,
-//                     BC5_UNORM,
-//                     BC5_SNORM,
-//                     BC6H_UF16,
-//                     BC6H_SF16,
-//                     BC7_UNORM,
-//                     BC7_UNORM_SRGB,
-            default:
-                SLANG_CHECK_ABORT(false);
-                return nullptr;
-            }
         }
 
         bool isWithinCopyBounds(int x, int y, int z, ITextureResource::Offset3D copyOffset, ITextureResource::Size copyExtents)
@@ -501,9 +531,6 @@ namespace gfx_test
             ComPtr<ISlangBlob> resultBlob;
             auto resultsSize = dstExtent.depth * dstExtent.height * alignedRowStride;
             GFX_CHECK_CALL_ABORT(device->readBufferResource(resultsBuffer, 0, resultsSize, resultBlob.writeRef()));
-//             size_t outRowPitch;
-//             size_t outPixelSize;
-//             GFX_CHECK_CALL_ABORT(device->readTextureResource(srcTexture, ResourceState::CopySource, resultBlob.writeRef(), &outRowPitch, &outPixelSize));
             auto results = resultBlob->getBufferPointer();
 
             auto validationFormat = getValidationTextureFormat(format);
@@ -541,112 +568,53 @@ namespace gfx_test
 
             validateTestResults(actual, expectedCopied, expectedOriginal, copyExtent, srcTexOffset, dstTexOffset);
         }
-
-//         template <typename T>
-//         void checkTestResults(
-//             ITextureResource::Size srcExtent,
-//             ITextureResource::Size dstExtent,
-//             ITextureResource::Size copyExtent,
-//             ITextureResource::Offset3D srcOffset,
-//             const void* expectedSubresourceData)
-//         {
-//             ComPtr<ISlangBlob> resultBlob;
-//             auto resultsSize = dstExtent.width * dstExtent.height * dstExtent.depth * 4 * sizeof(T);
-//             GFX_CHECK_CALL_ABORT(device->readBufferResource(resultsBuffer, 0, resultsSize, resultBlob.writeRef()));
-//             auto results = (T*)resultBlob->getBufferPointer();
-//             auto expecteds = (T*)expectedSubresourceData;
-//             for (Int w = 0; w < dstExtent.width; ++w)
-//             {
-//                 for (Int h = 0; h < dstExtent.height; ++h)
-//                 {
-//                     if (w < srcOffset.x || h < srcOffset.y || w >= copyExtent.width + srcOffset.x || h >= copyExtent.height + srcOffset.y)
-//                     {
-//                         // Outside of the bounds of the copy operation
-//                         SLANG_CHECK(results[4 * (h * dstExtent.width + w)] == 0);
-//                         SLANG_CHECK(results[4 * (h * dstExtent.width + w) + 1] == 0);
-//                         SLANG_CHECK(results[4 * (h * dstExtent.width + w) + 2] == 0);
-//                         SLANG_CHECK(results[4 * (h * dstExtent.width + w) + 3] == 0);
-//                     }
-//                     else
-//                     {
-//                         // Inside the bounds of the copy operation
-//                         SLANG_CHECK(results[4 * (h * dstExtent.width + w)] == expecteds[4 * (h * srcExtent.width + w)]);
-//                         SLANG_CHECK(results[4 * (h * dstExtent.width + w) + 1] == expecteds[4 * (h * srcExtent.width + w) + 1]);
-//                         SLANG_CHECK(results[4 * (h * dstExtent.width + w) + 2] == expecteds[4 * (h * srcExtent.width + w) + 2]);
-//                         SLANG_CHECK(results[4 * (h * dstExtent.width + w) + 3] == expecteds[4 * (h * srcExtent.width + w) + 3]);
-//                     }
-//                 }
-//             }
-//         }
     };
 
     struct SimpleCopyTexture : BaseCopyTextureTest
     {
         void run()
         {
-            // Skip Format::Unknown
-            for (uint32_t i = 1; i < (uint32_t)Format::CountOf; ++i)
-            {
-                if (i == 16 || i == 17 || i == 18 || i == 61 || i >= 66)
-                {
-                    continue;
-                }
+            ITextureResource::Size extent = {};
+            extent.width = 4;
+            extent.height = 4;
+            extent.depth = 1;
+            auto mipLevelCount = 1;
+            auto arrayLayerCount = 1;
 
-                //if (i == 56 || i == 57) continue;
+            auto srcTextureStuff = generateTextureData(extent.width, extent.height, mipLevelCount, arrayLayerCount);
 
-                printf("%d", i);
-                auto format = (Format)i;
+            TextureInfo srcTextureInfo = { extent, mipLevelCount, arrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
+            TextureInfo dstTextureInfo = { extent, mipLevelCount, arrayLayerCount, nullptr };
 
-                ITextureResource::Size extent = {};
-                extent.width = 4;
-                extent.height = 4;
-                extent.depth = 1;
-                auto mipLevelCount = 1;
-                auto arrayLayerCount = 1;
+            createRequiredResources(srcTextureInfo, dstTextureInfo, extent);
 
-                auto srcTextureStuff = generateTextureData(extent.width, extent.height, mipLevelCount, arrayLayerCount, format);
+            SubresourceRange srcSubresource = {};
+            srcSubresource.aspectMask = getTextureAspect();
+            srcSubresource.mipLevel = 0;
+            srcSubresource.mipLevelCount = 1;
+            srcSubresource.baseArrayLayer = 0;
+            srcSubresource.layerCount = 1;
 
-                TextureInfo srcTextureInfo = { extent, mipLevelCount, arrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
-                TextureInfo dstTextureInfo = { extent, mipLevelCount, arrayLayerCount, nullptr };
+            ITextureResource::Offset3D srcOffset;
 
-                createRequiredResources(srcTextureInfo, dstTextureInfo, extent, format);
+            SubresourceRange dstSubresource = {};
+            dstSubresource.aspectMask = getTextureAspect();
+            dstSubresource.mipLevel = 0;
+            dstSubresource.mipLevelCount = 1;
+            dstSubresource.baseArrayLayer = 0;
+            dstSubresource.layerCount = 1;
 
-//                 ComPtr<ISlangBlob> resultBlob;
-//                 size_t outRowPitch;
-//                 size_t outPixelSize;
-//                 GFX_CHECK_CALL_ABORT(device->readTextureResource(srcTexture, ResourceState::CopySource, resultBlob.writeRef(), &outRowPitch, &outPixelSize));
-//                 auto results = resultBlob->getBufferPointer();
+            ITextureResource::Offset3D dstOffset;
 
-                SubresourceRange srcSubresource = {};
-                srcSubresource.aspectMask = TextureAspect::Color;
-                srcSubresource.mipLevel = 0;
-                srcSubresource.mipLevelCount = 1;
-                srcSubresource.baseArrayLayer = 0;
-                srcSubresource.layerCount = 1;
+            submitGPUWork(srcSubresource, dstSubresource, srcOffset, dstOffset, extent, extent, 16);
 
-                ITextureResource::Offset3D srcOffset;
-
-                SubresourceRange dstSubresource = {};
-                dstSubresource.aspectMask = TextureAspect::Color;
-                dstSubresource.mipLevel = 0;
-                dstSubresource.mipLevelCount = 1;
-                dstSubresource.baseArrayLayer = 0;
-                dstSubresource.layerCount = 1;
-
-                ITextureResource::Offset3D dstOffset;
-
-                submitGPUWork(srcSubresource, dstSubresource, srcOffset, dstOffset, extent, extent, 16);
-
-                auto expectedData = srcTextureStuff->subresourceDatas[0];
-                checkTestResults(extent, extent, extent, srcOffset, dstOffset, format, expectedData.data, nullptr);
-            }
+            auto expectedData = srcTextureStuff->subresourceDatas[0];
+            checkTestResults(extent, extent, extent, srcOffset, dstOffset, format, expectedData.data, nullptr);
         }
     };
 
     struct CopyTextureSection : BaseCopyTextureTest
     {
-        Format format = Format::R32G32B32A32_FLOAT;
-
         void run()
         {
             ITextureResource::Size extent = {};
@@ -657,15 +625,15 @@ namespace gfx_test
             auto mipLevelCount = 2;
             auto arrayLayerCount = 2;
 
-            auto srcTextureStuff = generateTextureData(extent.width, extent.height, mipLevelCount, arrayLayerCount, format);
+            auto srcTextureStuff = generateTextureData(extent.width, extent.height, mipLevelCount, arrayLayerCount);
             
             TextureInfo srcTextureInfo = { extent, mipLevelCount, arrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
             TextureInfo dstTextureInfo = { extent, mipLevelCount, arrayLayerCount, nullptr };
 
-            createRequiredResources(srcTextureInfo, dstTextureInfo, extent, format);
+            createRequiredResources(srcTextureInfo, dstTextureInfo, extent);
 
             SubresourceRange srcSubresource = {};
-            srcSubresource.aspectMask = TextureAspect::Color;
+            srcSubresource.aspectMask = getTextureAspect();
             srcSubresource.mipLevel = 0;
             srcSubresource.mipLevelCount = 1;
             srcSubresource.baseArrayLayer = 1;
@@ -674,7 +642,7 @@ namespace gfx_test
             ITextureResource::Offset3D srcOffset;
 
             SubresourceRange dstSubresource = {};
-            dstSubresource.aspectMask = TextureAspect::Color;
+            dstSubresource.aspectMask = getTextureAspect();
             dstSubresource.mipLevel = 0;
             dstSubresource.mipLevelCount = 1;
             dstSubresource.baseArrayLayer = 0;
@@ -693,8 +661,6 @@ namespace gfx_test
     {
         void run()
         {
-            Format format = Format::R32G32B32A32_FLOAT;
-
             ITextureResource::Size srcExtent = {};
             srcExtent.width = 16;
             srcExtent.height = 16;
@@ -702,7 +668,7 @@ namespace gfx_test
             auto srcMipLevelCount = 1;
             auto srcArrayLayerCount = 1;
 
-            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount, format);
+            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount);
             TextureInfo srcTextureInfo = { srcExtent, srcMipLevelCount, srcArrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
 
             ITextureResource::Size dstExtent = {};
@@ -714,10 +680,10 @@ namespace gfx_test
 
             TextureInfo dstTextureInfo = { dstExtent, dstMipLevelCount, dstArrayLayerCount, nullptr };
 
-            createRequiredResources(srcTextureInfo, dstTextureInfo, dstExtent, format);
+            createRequiredResources(srcTextureInfo, dstTextureInfo, dstExtent);
 
             SubresourceRange srcSubresource = {};
-            srcSubresource.aspectMask = TextureAspect::Color;
+            srcSubresource.aspectMask = getTextureAspect();
             srcSubresource.mipLevel = 0;
             srcSubresource.mipLevelCount = 1;
             srcSubresource.baseArrayLayer = 0;
@@ -726,7 +692,7 @@ namespace gfx_test
             ITextureResource::Offset3D srcOffset;
 
             SubresourceRange dstSubresource = {};
-            dstSubresource.aspectMask = TextureAspect::Color;
+            dstSubresource.aspectMask = getTextureAspect();
             dstSubresource.mipLevel = 0;
             dstSubresource.mipLevelCount = 1;
             dstSubresource.baseArrayLayer = 0;
@@ -745,8 +711,6 @@ namespace gfx_test
     {
         void run()
         {
-            Format format = Format::R32G32B32A32_FLOAT;
-
             ITextureResource::Size srcExtent = {};
             srcExtent.width = 4;
             srcExtent.height = 4;
@@ -754,7 +718,7 @@ namespace gfx_test
             auto srcMipLevelCount = 1;
             auto srcArrayLayerCount = 1;
 
-            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount, format);
+            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount);
             TextureInfo srcTextureInfo = { srcExtent, srcMipLevelCount, srcArrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
 
             ITextureResource::Size dstExtent = {};
@@ -764,11 +728,11 @@ namespace gfx_test
             auto dstMipLevelCount = 1;
             auto dstArrayLayerCount = 1;
 
-            auto dstTextureStuff = generateTextureData(dstExtent.width, dstExtent.height, dstMipLevelCount, dstArrayLayerCount, format);
+            auto dstTextureStuff = generateTextureData(dstExtent.width, dstExtent.height, dstMipLevelCount, dstArrayLayerCount);
             TextureInfo dstTextureInfo = { dstExtent, dstMipLevelCount, dstArrayLayerCount, dstTextureStuff->subresourceDatas.getBuffer() };
 
             SubresourceRange srcSubresource = {};
-            srcSubresource.aspectMask = TextureAspect::Color;
+            srcSubresource.aspectMask = getTextureAspect();
             srcSubresource.mipLevel = 0;
             srcSubresource.mipLevelCount = 1;
             srcSubresource.baseArrayLayer = 0;
@@ -777,7 +741,7 @@ namespace gfx_test
             ITextureResource::Offset3D srcOffset;
 
             SubresourceRange dstSubresource = {};
-            dstSubresource.aspectMask = TextureAspect::Color;
+            dstSubresource.aspectMask = getTextureAspect();
             dstSubresource.mipLevel = 0;
             dstSubresource.mipLevelCount = 1;
             dstSubresource.baseArrayLayer = 0;
@@ -788,7 +752,7 @@ namespace gfx_test
             ITextureResource::Size texCopyExtent = srcExtent;
             ITextureResource::Size bufferCopyExtent = dstExtent;
 
-            createRequiredResources(srcTextureInfo, dstTextureInfo, bufferCopyExtent, format);
+            createRequiredResources(srcTextureInfo, dstTextureInfo, bufferCopyExtent);
             submitGPUWork(srcSubresource, dstSubresource, srcOffset, dstOffset, texCopyExtent, bufferCopyExtent, dstExtent.height * alignedRowStride);
 
             auto expectedCopiedData = srcTextureStuff->subresourceDatas[0];
@@ -801,8 +765,6 @@ namespace gfx_test
     {
         void run()
         {
-            Format format = Format::R32G32B32A32_FLOAT;
-
             ITextureResource::Size srcExtent = {};
             srcExtent.width = 16;
             srcExtent.height = 16;
@@ -810,7 +772,7 @@ namespace gfx_test
             auto srcMipLevelCount = 4;
             auto srcArrayLayerCount = 1;
 
-            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount, format);
+            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount);
             TextureInfo srcTextureInfo = { srcExtent, srcMipLevelCount, srcArrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
 
             ITextureResource::Size dstExtent = {};
@@ -820,11 +782,11 @@ namespace gfx_test
             auto dstMipLevelCount = 4;
             auto dstArrayLayerCount = 1;
 
-            auto dstTextureStuff = generateTextureData(dstExtent.width, dstExtent.height, dstMipLevelCount, dstArrayLayerCount, format);
+            auto dstTextureStuff = generateTextureData(dstExtent.width, dstExtent.height, dstMipLevelCount, dstArrayLayerCount);
             TextureInfo dstTextureInfo = { dstExtent, dstMipLevelCount, dstArrayLayerCount, dstTextureStuff->subresourceDatas.getBuffer() };
 
             SubresourceRange srcSubresource = {};
-            srcSubresource.aspectMask = TextureAspect::Color;
+            srcSubresource.aspectMask = getTextureAspect();
             srcSubresource.mipLevel = 2;
             srcSubresource.mipLevelCount = 1;
             srcSubresource.baseArrayLayer = 0;
@@ -833,7 +795,7 @@ namespace gfx_test
             ITextureResource::Offset3D srcOffset;
 
             SubresourceRange dstSubresource = {};
-            dstSubresource.aspectMask = TextureAspect::Color;
+            dstSubresource.aspectMask = getTextureAspect();
             dstSubresource.mipLevel = 1;
             dstSubresource.mipLevelCount = 1;
             dstSubresource.baseArrayLayer = 0;
@@ -853,7 +815,7 @@ namespace gfx_test
             bufferCopyExtent.height = 8;
             bufferCopyExtent.depth = 1;
 
-            createRequiredResources(srcTextureInfo, dstTextureInfo, bufferCopyExtent, format);
+            createRequiredResources(srcTextureInfo, dstTextureInfo, bufferCopyExtent);
             submitGPUWork(srcSubresource, dstSubresource, srcOffset, dstOffset, texCopyExtent, bufferCopyExtent, bufferCopyExtent.height * alignedRowStride);
 
             auto expectedCopiedData = srcTextureStuff->subresourceDatas[2];
@@ -866,8 +828,6 @@ namespace gfx_test
     {
         void run()
         {
-            Format format = Format::R32G32B32A32_FLOAT;
-
             ITextureResource::Size srcExtent = {};
             srcExtent.width = 4;
             srcExtent.height = 4;
@@ -875,7 +835,7 @@ namespace gfx_test
             auto srcMipLevelCount = 1;
             auto srcArrayLayerCount = 2;
 
-            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount, format);
+            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount);
             TextureInfo srcTextureInfo = { srcExtent, srcMipLevelCount, srcArrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
 
             ITextureResource::Size dstExtent = {};
@@ -885,11 +845,11 @@ namespace gfx_test
             auto dstMipLevelCount = 1;
             auto dstArrayLayerCount = 2;
 
-            auto dstTextureStuff = generateTextureData(dstExtent.width, dstExtent.height, dstMipLevelCount, dstArrayLayerCount, format);
+            auto dstTextureStuff = generateTextureData(dstExtent.width, dstExtent.height, dstMipLevelCount, dstArrayLayerCount);
             TextureInfo dstTextureInfo = { dstExtent, dstMipLevelCount, dstArrayLayerCount, dstTextureStuff->subresourceDatas.getBuffer() };
 
             SubresourceRange srcSubresource = {};
-            srcSubresource.aspectMask = TextureAspect::Color;
+            srcSubresource.aspectMask = getTextureAspect();
             srcSubresource.mipLevel = 0;
             srcSubresource.mipLevelCount = 1;
             srcSubresource.baseArrayLayer = 0;
@@ -898,7 +858,7 @@ namespace gfx_test
             ITextureResource::Offset3D srcOffset;
 
             SubresourceRange dstSubresource = {};
-            dstSubresource.aspectMask = TextureAspect::Color;
+            dstSubresource.aspectMask = getTextureAspect();
             dstSubresource.mipLevel = 0;
             dstSubresource.mipLevelCount = 1;
             dstSubresource.baseArrayLayer = 1;
@@ -908,7 +868,7 @@ namespace gfx_test
 
             ITextureResource::Size copyExtent = srcExtent;
 
-            createRequiredResources(srcTextureInfo, dstTextureInfo, copyExtent, format);
+            createRequiredResources(srcTextureInfo, dstTextureInfo, copyExtent);
             submitGPUWork(srcSubresource, dstSubresource, srcOffset, dstOffset, copyExtent, copyExtent, copyExtent.height * alignedRowStride);
 
             auto expectedCopiedData = srcTextureStuff->subresourceDatas[0];
@@ -921,8 +881,6 @@ namespace gfx_test
     {
         void run()
         {
-            Format format = Format::R32G32B32A32_FLOAT;
-
             ITextureResource::Size srcExtent = {};
             srcExtent.width = 8;
             srcExtent.height = 8;
@@ -930,7 +888,7 @@ namespace gfx_test
             auto srcMipLevelCount = 1;
             auto srcArrayLayerCount = 1;
 
-            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount, format);
+            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount);
             TextureInfo srcTextureInfo = { srcExtent, srcMipLevelCount, srcArrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
 
             ITextureResource::Size dstExtent = {};
@@ -940,11 +898,11 @@ namespace gfx_test
             auto dstMipLevelCount = 1;
             auto dstArrayLayerCount = 1;
 
-            auto dstTextureStuff = generateTextureData(dstExtent.width, dstExtent.height, dstMipLevelCount, dstArrayLayerCount, format);
+            auto dstTextureStuff = generateTextureData(dstExtent.width, dstExtent.height, dstMipLevelCount, dstArrayLayerCount);
             TextureInfo dstTextureInfo = { dstExtent, dstMipLevelCount, dstArrayLayerCount, dstTextureStuff->subresourceDatas.getBuffer() };
 
             SubresourceRange srcSubresource = {};
-            srcSubresource.aspectMask = TextureAspect::Color;
+            srcSubresource.aspectMask = getTextureAspect();
             srcSubresource.mipLevel = 0;
             srcSubresource.mipLevelCount = 1;
             srcSubresource.baseArrayLayer = 0;
@@ -956,7 +914,7 @@ namespace gfx_test
             srcOffset.z = 0;
 
             SubresourceRange dstSubresource = {};
-            dstSubresource.aspectMask = TextureAspect::Color;
+            dstSubresource.aspectMask = getTextureAspect();
             dstSubresource.mipLevel = 0;
             dstSubresource.mipLevelCount = 1;
             dstSubresource.baseArrayLayer = 0;
@@ -977,7 +935,7 @@ namespace gfx_test
             bufferCopyExtent.height = 16;
             bufferCopyExtent.depth = 1;
 
-            createRequiredResources(srcTextureInfo, dstTextureInfo, dstExtent, format);
+            createRequiredResources(srcTextureInfo, dstTextureInfo, dstExtent);
             submitGPUWork(srcSubresource, dstSubresource, srcOffset, dstOffset, texCopyExtent, bufferCopyExtent, bufferCopyExtent.height * alignedRowStride);
 
             auto expectedCopiedData = srcTextureStuff->subresourceDatas[0];
@@ -990,8 +948,6 @@ namespace gfx_test
     {
         void run()
         {
-            Format format = Format::R32G32B32A32_FLOAT;
-
             ITextureResource::Size srcExtent = {};
             srcExtent.width = 8;
             srcExtent.height = 8;
@@ -999,7 +955,7 @@ namespace gfx_test
             auto srcMipLevelCount = 1;
             auto srcArrayLayerCount = 1;
 
-            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount, format);
+            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount);
             TextureInfo srcTextureInfo = { srcExtent, srcMipLevelCount, srcArrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
 
             ITextureResource::Size dstExtent = {};
@@ -1009,11 +965,11 @@ namespace gfx_test
             auto dstMipLevelCount = 1;
             auto dstArrayLayerCount = 1;
 
-            auto dstTextureStuff = generateTextureData(dstExtent.width, dstExtent.height, dstMipLevelCount, dstArrayLayerCount, format);
+            auto dstTextureStuff = generateTextureData(dstExtent.width, dstExtent.height, dstMipLevelCount, dstArrayLayerCount);
             TextureInfo dstTextureInfo = { dstExtent, dstMipLevelCount, dstArrayLayerCount, dstTextureStuff->subresourceDatas.getBuffer() };
 
             SubresourceRange srcSubresource = {};
-            srcSubresource.aspectMask = TextureAspect::Color;
+            srcSubresource.aspectMask = getTextureAspect();
             srcSubresource.mipLevel = 0;
             srcSubresource.mipLevelCount = 1;
             srcSubresource.baseArrayLayer = 0;
@@ -1022,7 +978,7 @@ namespace gfx_test
             ITextureResource::Offset3D srcOffset;
 
             SubresourceRange dstSubresource = {};
-            dstSubresource.aspectMask = TextureAspect::Color;
+            dstSubresource.aspectMask = getTextureAspect();
             dstSubresource.mipLevel = 0;
             dstSubresource.mipLevelCount = 1;
             dstSubresource.baseArrayLayer = 0;
@@ -1038,7 +994,7 @@ namespace gfx_test
             copyExtent.height = 4;
             copyExtent.depth = 1;
 
-            createRequiredResources(srcTextureInfo, dstTextureInfo, dstExtent, format);
+            createRequiredResources(srcTextureInfo, dstTextureInfo, dstExtent);
             submitGPUWork(srcSubresource, dstSubresource, srcOffset, dstOffset, copyExtent, dstExtent, dstExtent.height * alignedRowStride);
 
             auto expectedCopiedData = srcTextureStuff->subresourceDatas[0];
@@ -1060,7 +1016,7 @@ namespace gfx_test
             auto srcMipLevelCount = 1;
             auto srcArrayLayerCount = 1;
 
-            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount, format);
+            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount);
             TextureInfo srcTextureInfo = { srcExtent, srcMipLevelCount, srcArrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
 
             ITextureResource::Size dstExtent = {};
@@ -1070,7 +1026,7 @@ namespace gfx_test
             auto dstMipLevelCount = 1;
             auto dstArrayLayerCount = 1;
 
-            auto dstTextureStuff = generateTextureData(dstExtent.width, dstExtent.height, dstMipLevelCount, dstArrayLayerCount, format);
+            auto dstTextureStuff = generateTextureData(dstExtent.width, dstExtent.height, dstMipLevelCount, dstArrayLayerCount);
             TextureInfo dstTextureInfo = { dstExtent, dstMipLevelCount, dstArrayLayerCount, dstTextureStuff->subresourceDatas.getBuffer() };
 
             SubresourceRange srcSubresource = {};
@@ -1099,7 +1055,7 @@ namespace gfx_test
 
             ITextureResource::Offset3D dstOffset;
 
-            createRequiredResources(srcTextureInfo, dstTextureInfo, dstExtent, format);
+            createRequiredResources(srcTextureInfo, dstTextureInfo, dstExtent);
 
             auto textureSize = copyExtent.width * copyExtent.height * copyExtent.depth * 16; // Size of the texture section being copied.
 
@@ -1131,27 +1087,38 @@ namespace gfx_test
     template<typename T>
     void copyTextureTestImpl(IDevice* device, UnitTestContext* context)
     {
-        T test;
-        test.init(device, context);
-        test.run();
+        for (uint32_t i = 1; i < (uint32_t)Format::CountOf; ++i)
+        {
+            auto format = (Format)i;
+            auto validationFormat = getValidationTextureFormat(format);
+            if (!validationFormat)
+                continue;
+
+            printf("%d", i);
+            T test;
+            test.init(device, context, format, validationFormat);
+            test.run();
+        }
     }
 
     SLANG_UNIT_TEST(copyTextureTests)
     {
-        //runTestImpl(copyTextureTestImpl<SimpleCopyTexture>, unitTestContext, Slang::RenderApiFlag::D3D12);
-        runTestImpl(copyTextureTestImpl<SimpleCopyTexture>, unitTestContext, Slang::RenderApiFlag::Vulkan);
+//         runTestImpl(copyTextureTestImpl<SimpleCopyTexture>, unitTestContext, Slang::RenderApiFlag::D3D12);
+//         runTestImpl(copyTextureTestImpl<SimpleCopyTexture>, unitTestContext, Slang::RenderApiFlag::Vulkan);
 //         runTestImpl(copyTextureTestImpl<CopyTextureSection>, unitTestContext, Slang::RenderApiFlag::D3D12);
 //         runTestImpl(copyTextureTestImpl<CopyTextureSection>, unitTestContext, Slang::RenderApiFlag::Vulkan);
+//         runTestImpl(copyTextureTestImpl<LargeSrcToSmallDst>, unitTestContext, Slang::RenderApiFlag::D3D12);
+//         runTestImpl(copyTextureTestImpl<LargeSrcToSmallDst>, unitTestContext, Slang::RenderApiFlag::Vulkan);
 //         runTestImpl(copyTextureTestImpl<SmallSrcToLargeDst>, unitTestContext, Slang::RenderApiFlag::D3D12);
 //         runTestImpl(copyTextureTestImpl<SmallSrcToLargeDst>, unitTestContext, Slang::RenderApiFlag::Vulkan);
-//         runTestImpl(copyTextureTestImpl<CopyBetweenMips>, unitTestContext, Slang::RenderApiFlag::D3D12);
-//         runTestImpl(copyTextureTestImpl<CopyBetweenMips>, unitTestContext, Slang::RenderApiFlag::Vulkan);
-//         runTestImpl(copyTextureTestImpl<CopyBetweenLayers>, unitTestContext, Slang::RenderApiFlag::D3D12);
-//         runTestImpl(copyTextureTestImpl<CopyBetweenLayers>, unitTestContext, Slang::RenderApiFlag::Vulkan);
-//         runTestImpl(copyTextureTestImpl<CopyWithOffsets>, unitTestContext, Slang::RenderApiFlag::D3D12);
-//         runTestImpl(copyTextureTestImpl<CopyWithOffsets>, unitTestContext, Slang::RenderApiFlag::Vulkan);
-//         runTestImpl(copyTextureTestImpl<CopySectionWithSetExtent>, unitTestContext, Slang::RenderApiFlag::D3D12);
-//         runTestImpl(copyTextureTestImpl<CopySectionWithSetExtent>, unitTestContext, Slang::RenderApiFlag::Vulkan);
+        runTestImpl(copyTextureTestImpl<CopyBetweenMips>, unitTestContext, Slang::RenderApiFlag::D3D12);
+        runTestImpl(copyTextureTestImpl<CopyBetweenMips>, unitTestContext, Slang::RenderApiFlag::Vulkan);
+        runTestImpl(copyTextureTestImpl<CopyBetweenLayers>, unitTestContext, Slang::RenderApiFlag::D3D12);
+        runTestImpl(copyTextureTestImpl<CopyBetweenLayers>, unitTestContext, Slang::RenderApiFlag::Vulkan);
+        runTestImpl(copyTextureTestImpl<CopyWithOffsets>, unitTestContext, Slang::RenderApiFlag::D3D12);
+        runTestImpl(copyTextureTestImpl<CopyWithOffsets>, unitTestContext, Slang::RenderApiFlag::Vulkan);
+        runTestImpl(copyTextureTestImpl<CopySectionWithSetExtent>, unitTestContext, Slang::RenderApiFlag::D3D12);
+        runTestImpl(copyTextureTestImpl<CopySectionWithSetExtent>, unitTestContext, Slang::RenderApiFlag::Vulkan);
 
 //         runTestImpl(copyTextureTestImpl<CopyToBufferWithOffset>, unitTestContext, Slang::RenderApiFlag::D3D12);
 //         runTestImpl(copyTextureTestImpl<CopyToBufferWithOffset>, unitTestContext, Slang::RenderApiFlag::Vulkan);

--- a/tools/gfx-unit-test/copy-texture-tests.cpp
+++ b/tools/gfx-unit-test/copy-texture-tests.cpp
@@ -1082,8 +1082,6 @@ namespace gfx_test
         {
             for (uint32_t j = 1; j < (uint32_t)Format::CountOf; ++j)
             {
-                printf("Type: %d, Format: %d\n", i, j);
-//                 if (i != 4) continue;
                 auto type = (ITextureResource::Type)i;
                 auto format = (Format)j;
                 auto validationFormat = getValidationTextureFormat(format);
@@ -1095,29 +1093,6 @@ namespace gfx_test
                 test.run();
             }
         }
-    }
-
-    SLANG_UNIT_TEST(copyTextureTests)
-    {
-//         runTestImpl(copyTextureTestImpl<SimpleCopyTexture>, unitTestContext, Slang::RenderApiFlag::D3D12);
-//         runTestImpl(copyTextureTestImpl<SimpleCopyTexture>, unitTestContext, Slang::RenderApiFlag::Vulkan);
-//         runTestImpl(copyTextureTestImpl<CopyTextureSection>, unitTestContext, Slang::RenderApiFlag::D3D12);
-//         runTestImpl(copyTextureTestImpl<CopyTextureSection>, unitTestContext, Slang::RenderApiFlag::Vulkan);
-//         runTestImpl(copyTextureTestImpl<LargeSrcToSmallDst>, unitTestContext, Slang::RenderApiFlag::D3D12);
-//         runTestImpl(copyTextureTestImpl<LargeSrcToSmallDst>, unitTestContext, Slang::RenderApiFlag::Vulkan);
-//         runTestImpl(copyTextureTestImpl<SmallSrcToLargeDst>, unitTestContext, Slang::RenderApiFlag::D3D12);
-//         runTestImpl(copyTextureTestImpl<SmallSrcToLargeDst>, unitTestContext, Slang::RenderApiFlag::Vulkan);
-//         runTestImpl(copyTextureTestImpl<CopyBetweenMips>, unitTestContext, Slang::RenderApiFlag::D3D12);
-//         runTestImpl(copyTextureTestImpl<CopyBetweenMips>, unitTestContext, Slang::RenderApiFlag::Vulkan);
-//         runTestImpl(copyTextureTestImpl<CopyBetweenLayers>, unitTestContext, Slang::RenderApiFlag::D3D12);
-//         runTestImpl(copyTextureTestImpl<CopyBetweenLayers>, unitTestContext, Slang::RenderApiFlag::Vulkan);
-//         runTestImpl(copyTextureTestImpl<CopyWithOffsets>, unitTestContext, Slang::RenderApiFlag::D3D12);
-//         runTestImpl(copyTextureTestImpl<CopyWithOffsets>, unitTestContext, Slang::RenderApiFlag::Vulkan);
-        runTestImpl(copyTextureTestImpl<CopySectionWithSetExtent>, unitTestContext, Slang::RenderApiFlag::D3D12);
-        runTestImpl(copyTextureTestImpl<CopySectionWithSetExtent>, unitTestContext, Slang::RenderApiFlag::Vulkan);
-
-//         runTestImpl(copyTextureTestImpl<CopyToBufferWithOffset>, unitTestContext, Slang::RenderApiFlag::D3D12);
-//         runTestImpl(copyTextureTestImpl<CopyToBufferWithOffset>, unitTestContext, Slang::RenderApiFlag::Vulkan);
     }
 
     SLANG_UNIT_TEST(copyTextureSimple)

--- a/tools/gfx-unit-test/copy-texture-tests.cpp
+++ b/tools/gfx-unit-test/copy-texture-tests.cpp
@@ -978,7 +978,9 @@ namespace gfx_test
 
             texCopyInfo.srcSubresource = srcSubresource;
             texCopyInfo.dstSubresource = dstSubresource;
-            texCopyInfo.extent = { 4, 4, 1 };
+            texCopyInfo.extent.width = 4;
+            texCopyInfo.extent.height = 4;
+            texCopyInfo.extent.depth = 1;
             texCopyInfo.srcOffset = { 2, 2, 0 };
             texCopyInfo.dstOffset = { 4, 4, 0 };
 
@@ -1043,7 +1045,9 @@ namespace gfx_test
 
             texCopyInfo.srcSubresource = srcSubresource;
             texCopyInfo.dstSubresource = dstSubresource;
-            texCopyInfo.extent = { 4, 4, 1 };
+            texCopyInfo.extent.width = 4;
+            texCopyInfo.extent.height = 4;
+            texCopyInfo.extent.depth = 1;
             texCopyInfo.srcOffset = { 0, 0, 0 };
             texCopyInfo.dstOffset = { 4, 4, 0 };
 

--- a/tools/gfx-unit-test/copy-texture-tests.cpp
+++ b/tools/gfx-unit-test/copy-texture-tests.cpp
@@ -14,6 +14,61 @@ using namespace gfx;
 
 namespace gfx_test
 {
+    struct Texel
+    {
+        float channels[4];
+    };
+
+    struct SubresourceStuff : RefObject
+    {
+        List<Texel> texels;
+    };
+
+    struct TextureStuff : RefObject
+    {
+        List<RefPtr<SubresourceStuff>> subresourceObjects;
+        List<ITextureResource::SubresourceData> subresourceDatas;
+    };
+
+    struct ValidationTextureFormatBase
+    {
+        virtual void validateBlocksEqual(const void* actual, const void* expected) = 0;
+    };
+
+    struct ValidationTextureFormat_float4 : ValidationTextureFormatBase
+    {
+        virtual void validateBlocksEqual(const void* actual, const void* expected) override
+        {
+            auto a = (const float*)actual;
+            auto e = (const float*)expected;
+
+            for (Int i = 0; i < 4; ++i)
+            {
+                SLANG_CHECK(a[i] == e[i]);
+            }
+        }
+    };
+
+    struct ValidationTextureData
+    {
+        const void* textureData;
+        ITextureResource::Size extents;
+        ITextureResource::Offset3D strides;
+
+        ValidationTextureFormatBase* format;
+
+        const void* getBlockAt(Int x, Int y, Int z)
+        {
+            assert(x >= 0 && x < extents.width);
+            assert(y >= 0 && y < extents.height);
+            assert(z >= 0 && z < extents.depth);
+
+            const char* layerData = (const char*)textureData + z * strides.z;
+            const char* rowData = layerData + y * strides.y;
+            return rowData + x * strides.x;
+        }
+    };
+
     struct BaseCopyTextureTest
     {
         IDevice* device;
@@ -23,7 +78,7 @@ namespace gfx_test
         ComPtr<ITextureResource> dstTexture;
         ComPtr<IBufferResource> resultsBuffer;
 
-        size_t alignedRowPitch;
+        size_t alignedRowStride;
 
         struct TextureInfo
         {
@@ -37,6 +92,43 @@ namespace gfx_test
         {
             this->device = device;
             this->context = context;
+        }
+
+        RefPtr<TextureStuff> generateTextureData(int width, int height, uint32_t mipLevels, uint32_t arrayLayers)
+        {
+            RefPtr<TextureStuff> texture = new TextureStuff();
+            for (uint32_t layer = 0; layer < arrayLayers; ++layer)
+            {
+                for (uint32_t mip = 0; mip < mipLevels; ++mip)
+                {
+                    RefPtr<SubresourceStuff> subresource = new SubresourceStuff();
+                    texture->subresourceObjects.add(subresource);
+
+                    int mipWidth = Math::Max(width >> mip, 1);
+                    int mipHeight = Math::Max(height >> mip, 1);
+
+                    int mipTexelCount = mipWidth * mipHeight;
+                    subresource->texels.setCount(mipTexelCount);
+                    for (int h = 0; h < mipHeight; ++h)
+                    {
+                        for (int w = 0; w < mipWidth; ++w)
+                        {
+                            // 4 channels per pixel
+                            subresource->texels[h * mipWidth + w].channels[0] = (float)w;
+                            subresource->texels[h * mipWidth + w].channels[1] = (float)h;
+                            subresource->texels[h * mipWidth + w].channels[2] = (float)mip;
+                            subresource->texels[h * mipWidth + w].channels[3] = (float)layer;
+                        }
+                    }
+
+                    ITextureResource::SubresourceData subData = {};
+                    subData.data = subresource->texels.getBuffer();
+                    subData.strideY = mipWidth * sizeof(Texel);
+                    subData.strideZ = mipHeight * subData.strideY;
+                    texture->subresourceDatas.add(subData);
+                }
+            }
+            return texture;
         }
 
         void createRequiredResources(TextureInfo srcTextureInfo, TextureInfo dstTextureInfo, Format format)
@@ -79,9 +171,9 @@ namespace gfx_test
             gfxGetFormatInfo(format, &formatInfo);
             size_t alignment;
             device->getTextureRowAlignment(&alignment);
-            alignedRowPitch = (dstTextureInfo.extent.width * formatInfo.blockSizeInBytes + alignment - 1) & ~(alignment - 1);
+            alignedRowStride = (dstTextureInfo.extent.width * formatInfo.blockSizeInBytes + alignment - 1) & ~(alignment - 1);
             IBufferResource::Desc bufferDesc = {};
-            bufferDesc.sizeInBytes = dstTextureInfo.extent.height * alignedRowPitch;
+            bufferDesc.sizeInBytes = dstTextureInfo.extent.height * alignedRowStride;
             bufferDesc.format = gfx::Format::Unknown;
             bufferDesc.elementSize = 0;
             bufferDesc.allowedStates = ResourceStateSet(
@@ -121,34 +213,143 @@ namespace gfx_test
             encoder->textureSubresourceBarrier(srcTexture, srcSubresource, ResourceState::UnorderedAccess, ResourceState::CopySource);
             encoder->copyTexture(dstTexture, ResourceState::CopyDestination, dstSubresource, dstOffset, srcTexture, ResourceState::CopySource, srcSubresource, srcOffset, extent);
             encoder->textureSubresourceBarrier(dstTexture, dstSubresource, ResourceState::CopyDestination, ResourceState::CopySource);
-            encoder->copyTextureToBuffer(resultsBuffer, 0, textureSize, alignedRowPitch, dstTexture, ResourceState::CopySource, dstSubresource, dstOffset, extent);
+            encoder->copyTextureToBuffer(resultsBuffer, 0, textureSize, alignedRowStride, dstTexture, ResourceState::CopySource, dstSubresource, dstOffset, extent);
             encoder->endEncoding();
             commandBuffer->close();
             queue->executeCommandBuffer(commandBuffer);
             queue->waitOnHost();
         }
+
+        void validateTestResults(ValidationTextureData actual, ValidationTextureData expectedCopied, ValidationTextureData expectedOriginal)
+        {
+            auto actualExtents = actual.extents;
+            auto expectedCopiedExtents = expectedCopied.extents;
+            auto format = actual.format;
+            for (Int x = 0; x < actualExtents.width; ++x)
+            {
+                for (Int y = 0; y < actualExtents.height; ++y)
+                {
+                    for (Int z = 0; z < actualExtents.depth; ++z)
+                    {
+                        auto actualBlock = actual.getBlockAt(x, y, z);
+                        if (x < expectedCopiedExtents.width && y < expectedCopiedExtents.height && z < expectedCopiedExtents.depth)
+                        {
+                            // Block is located within the bounds of the source texture
+                            auto expectedBlock = expectedCopied.getBlockAt(x, y, z);
+                            format->validateBlocksEqual(actualBlock, expectedBlock);
+                        }
+                        else
+                        {
+                            // Block is located outside the bounds of the source texture and should be compared
+                            // against known expected values for the destination texture.
+                            auto expectedBlock = expectedOriginal.getBlockAt(x, y, z);
+                            format->validateBlocksEqual(actualBlock, expectedBlock);
+                        }
+                    }
+                }
+            }
+        }
+
+        void checkTestResults(
+            ITextureResource::Size srcExtent,
+            ITextureResource::Size dstExtent,
+            ITextureResource::Size copyExtent,
+            ITextureResource::Offset3D srcOffset,
+            const void* expectedCopiedData,
+            const void* expectedOriginalData)
+        {
+            ComPtr<ISlangBlob> resultBlob;
+            auto resultsSize = dstExtent.depth * dstExtent.height * alignedRowStride;
+            GFX_CHECK_CALL_ABORT(device->readBufferResource(resultsBuffer, 0, resultsSize, resultBlob.writeRef()));
+            auto results = resultBlob->getBufferPointer();
+
+            ValidationTextureFormat_float4 validationFormat;
+
+            ValidationTextureData actual;
+            actual.extents = dstExtent;
+            actual.format = &validationFormat;
+            actual.textureData = results;
+            actual.strides.x = sizeof(Texel);
+            actual.strides.y = (uint32_t)alignedRowStride;
+            actual.strides.z = dstExtent.height * actual.strides.y;
+
+            ValidationTextureData expectedCopied;
+            expectedCopied.extents = srcExtent;
+            expectedCopied.format = &validationFormat;
+            expectedCopied.textureData = expectedCopiedData;
+            expectedCopied.strides.x = sizeof(Texel);
+            expectedCopied.strides.y = srcExtent.width * expectedCopied.strides.x;
+            expectedCopied.strides.z = srcExtent.height * expectedCopied.strides.y;
+
+            ValidationTextureData expectedOriginal;
+            if (expectedOriginalData)
+            {
+                expectedOriginal.extents = dstExtent;
+                expectedOriginal.format = &validationFormat;
+                expectedOriginal.textureData = expectedOriginalData;
+                expectedOriginal.strides.x = sizeof(Texel);
+                expectedOriginal.strides.y = dstExtent.width * expectedOriginal.strides.x;
+                expectedOriginal.strides.z = dstExtent.height * expectedOriginal.strides.y;
+            }
+
+            validateTestResults(actual, expectedCopied, expectedOriginal);
+        }
+
+//         template <typename T>
+//         void checkTestResults(
+//             ITextureResource::Size srcExtent,
+//             ITextureResource::Size dstExtent,
+//             ITextureResource::Size copyExtent,
+//             ITextureResource::Offset3D srcOffset,
+//             const void* expectedSubresourceData)
+//         {
+//             ComPtr<ISlangBlob> resultBlob;
+//             auto resultsSize = dstExtent.width * dstExtent.height * dstExtent.depth * 4 * sizeof(T);
+//             GFX_CHECK_CALL_ABORT(device->readBufferResource(resultsBuffer, 0, resultsSize, resultBlob.writeRef()));
+//             auto results = (T*)resultBlob->getBufferPointer();
+//             auto expecteds = (T*)expectedSubresourceData;
+//             for (Int w = 0; w < dstExtent.width; ++w)
+//             {
+//                 for (Int h = 0; h < dstExtent.height; ++h)
+//                 {
+//                     if (w < srcOffset.x || h < srcOffset.y || w >= copyExtent.width + srcOffset.x || h >= copyExtent.height + srcOffset.y)
+//                     {
+//                         // Outside of the bounds of the copy operation
+//                         SLANG_CHECK(results[4 * (h * dstExtent.width + w)] == 0);
+//                         SLANG_CHECK(results[4 * (h * dstExtent.width + w) + 1] == 0);
+//                         SLANG_CHECK(results[4 * (h * dstExtent.width + w) + 2] == 0);
+//                         SLANG_CHECK(results[4 * (h * dstExtent.width + w) + 3] == 0);
+//                     }
+//                     else
+//                     {
+//                         // Inside the bounds of the copy operation
+//                         SLANG_CHECK(results[4 * (h * dstExtent.width + w)] == expecteds[4 * (h * srcExtent.width + w)]);
+//                         SLANG_CHECK(results[4 * (h * dstExtent.width + w) + 1] == expecteds[4 * (h * srcExtent.width + w) + 1]);
+//                         SLANG_CHECK(results[4 * (h * dstExtent.width + w) + 2] == expecteds[4 * (h * srcExtent.width + w) + 2]);
+//                         SLANG_CHECK(results[4 * (h * dstExtent.width + w) + 3] == expecteds[4 * (h * srcExtent.width + w) + 3]);
+//                     }
+//                 }
+//             }
+//         }
     };
 
     struct SimpleCopyTexture : BaseCopyTextureTest
     {
-        Format format = Format::R8G8B8A8_UINT;
+        Format format = Format::R32G32B32A32_FLOAT;
 
         void run()
         {
             ITextureResource::Size extent = {};
-            extent.width = 2;
-            extent.height = 2;
+            extent.width = 4;
+            extent.height = 4;
             extent.depth = 1;
+            auto mipLevelCount = 1;
+            auto arrayLayerCount = 1;
+            
+            auto srcTextureStuff = generateTextureData(extent.width, extent.height, mipLevelCount, arrayLayerCount);
 
-            uint8_t srcTexData[16] = { 255u, 0u, 0u, 255u, 0u, 255u, 0u, 255u,
-                                       0u, 0u, 255u, 255u, 127u, 127u, 127u, 255u };
-            ITextureResource::SubresourceData srcSubData = { (void*)srcTexData, 8, 0 };
-
-            uint8_t dstTexData[16] = { 0u };
-            ITextureResource::SubresourceData dstSubData = { (void*)dstTexData, 8, 0 };
-
-            TextureInfo srcTextureInfo = { extent, 1, 1, &srcSubData };
-            TextureInfo dstTextureInfo = { extent, 1, 1, &dstSubData };
+            TextureInfo srcTextureInfo = { extent, mipLevelCount, arrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
+            TextureInfo dstTextureInfo = { extent, mipLevelCount, arrayLayerCount, nullptr };
 
             createRequiredResources(srcTextureInfo, dstTextureInfo, format);
 
@@ -172,100 +373,14 @@ namespace gfx_test
 
             submitGPUWork(srcSubresource, dstSubresource, srcOffset, dstOffset, extent, 16);
 
-            if (device->getDeviceInfo().deviceType == DeviceType::DirectX12)
-            {
-                // D3D12 has to pad out the rows in order to adhere to alignment, so when comparing results
-                // we need to make sure not to include the padding.
-                size_t testOffset = 0;
-                for (Int i = 0; i < extent.height; ++i)
-                {
-                    compareComputeResult(
-                        device,
-                        resultsBuffer,
-                        testOffset,
-                        srcTexData + 8 * i,
-                        8);
-                    testOffset += alignedRowPitch;
-                }
-            }
-            else if (device->getDeviceInfo().deviceType == DeviceType::Vulkan)
-            {
-                compareComputeResult(
-                    device,
-                    resultsBuffer,
-                    0,
-                    srcTexData,
-                    16);
-            }
+            auto expectedData = srcTextureStuff->subresourceDatas[0];
+            checkTestResults(extent, extent, extent, srcOffset, expectedData.data, nullptr);
         }
-    };
-
-    struct Texel
-    {
-        float channels[4];
-    };
-
-    struct SubresourceStuff : RefObject
-    {
-        List<Texel> texels;
-    };
-
-    struct TextureStuff : RefObject
-    {
-        List<RefPtr<SubresourceStuff>> subresourceObjects;
-        List<ITextureResource::SubresourceData> subresourceDatas;
     };
 
     struct CopyTextureSection : BaseCopyTextureTest
     {
         Format format = Format::R32G32B32A32_FLOAT;
-
-        RefPtr<TextureStuff> generateTextureData(int width, int height, uint32_t mipLevels, uint32_t arrayLayers)
-        {
-            RefPtr<TextureStuff> texture = new TextureStuff();
-            for (uint32_t layer = 0; layer < arrayLayers; ++layer)
-            {
-                for (uint32_t mip = 0; mip < mipLevels; ++mip)
-                {
-                    RefPtr<SubresourceStuff> subresource = new SubresourceStuff();
-                    texture->subresourceObjects.add(subresource);
-
-                    int mipWidth = Math::Max(width >> mip, 1);
-                    int mipHeight = Math::Max(height >> mip, 1);
-
-                    int mipTexelCount = mipWidth * mipHeight;
-                    subresource->texels.setCount(mipTexelCount);
-                    for (int h = 0; h < mipHeight; ++h)
-                    {
-                        for (int w = 0; w < mipWidth; ++w)
-                        {
-                            // 4 channels per pixel
-                            subresource->texels[h * mipWidth + w].channels[0] = (float)w;
-                            subresource->texels[h * mipWidth + w].channels[1] = (float)h;
-                            subresource->texels[h * mipWidth + w].channels[2] = (float)mip;
-                            subresource->texels[h * mipWidth + w].channels[3] = (float)layer;
-                        }
-                    }
-
-                    ITextureResource::SubresourceData subData = {};
-                    subData.data = subresource->texels.getBuffer();
-                    subData.strideY = mipWidth * sizeof(Texel);
-                    subData.strideZ = mipHeight * subData.strideY;
-                    texture->subresourceDatas.add(subData);
-                }
-            }
-            return texture;
-        }
-
-        // TODO: Things to test in the future
-        // 1. Size of src texture(W, H, mips, layers)
-        // 2. Size of dst texture(...)
-        // 3. src subresource(mip, layer)
-        // 4. dst subresource(mip, layer)
-        // 5. copy extents(x, y)
-        // 6. copy src coords(x, y)
-        // 7. copy dst coords(x, y)
-        // 8. Final buffer offset
 
         void run()
         {
@@ -305,24 +420,189 @@ namespace gfx_test
             submitGPUWork(srcSubresource, dstSubresource, srcOffset, dstOffset, extent, extent.height * 256);
 
             ITextureResource::SubresourceData expectedData = srcTextureStuff->subresourceDatas[2];
+            checkTestResults(extent, extent, extent, srcOffset, expectedData.data, nullptr);
+        }
+    };
+
+    struct LargeSrcToSmallDst : BaseCopyTextureTest
+    {
+        void run()
+        {
+            Format format = Format::R32G32B32A32_FLOAT;
+
+            ITextureResource::Size srcExtent = {};
+            srcExtent.width = 16;
+            srcExtent.height = 16;
+            srcExtent.depth = 1;
+            auto srcMipLevelCount = 1;
+            auto srcArrayLayerCount = 1;
+
+            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount);
+            TextureInfo srcTextureInfo = { srcExtent, srcMipLevelCount, srcArrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
+
+            ITextureResource::Size dstExtent = {};
+            dstExtent.width = 4;
+            dstExtent.height = 4;
+            dstExtent.depth = 1;
+            auto dstMipLevelCount = 1;
+            auto dstArrayLayerCount = 1;
+
+            TextureInfo dstTextureInfo = { dstExtent, dstMipLevelCount, dstArrayLayerCount, nullptr };
+
+            createRequiredResources(srcTextureInfo, dstTextureInfo, format);
+
+            SubresourceRange srcSubresource = {};
+            srcSubresource.aspectMask = TextureAspect::Color;
+            srcSubresource.mipLevel = 0;
+            srcSubresource.mipLevelCount = 1;
+            srcSubresource.baseArrayLayer = 0;
+            srcSubresource.layerCount = 1;
+
+            ITextureResource::Offset3D srcOffset;
+
+            SubresourceRange dstSubresource = {};
+            dstSubresource.aspectMask = TextureAspect::Color;
+            dstSubresource.mipLevel = 0;
+            dstSubresource.mipLevelCount = 1;
+            dstSubresource.baseArrayLayer = 0;
+            dstSubresource.layerCount = 1;
+
+            ITextureResource::Offset3D dstOffset;
+
+            submitGPUWork(srcSubresource, dstSubresource, srcOffset, dstOffset, dstExtent, dstExtent.height * 256);
+
+            ITextureResource::SubresourceData expectedData = srcTextureStuff->subresourceDatas[0];
+            checkTestResults(srcExtent, dstExtent, dstExtent, srcOffset, expectedData.data, nullptr);
+        }
+    };
+
+    struct SmallSrcToLargeDst : BaseCopyTextureTest
+    {
+        void run()
+        {
+            Format format = Format::R32G32B32A32_FLOAT;
+
+            ITextureResource::Size srcExtent = {};
+            srcExtent.width = 4;
+            srcExtent.height = 4;
+            srcExtent.depth = 1;
+            auto srcMipLevelCount = 1;
+            auto srcArrayLayerCount = 1;
+
+            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount);
+            TextureInfo srcTextureInfo = { srcExtent, srcMipLevelCount, srcArrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
+
+            ITextureResource::Size dstExtent = {};
+            dstExtent.width = 16;
+            dstExtent.height = 16;
+            dstExtent.depth = 1;
+            auto dstMipLevelCount = 1;
+            auto dstArrayLayerCount = 1;
+
+            auto dstTextureStuff = generateTextureData(dstExtent.width, dstExtent.height, dstMipLevelCount, dstArrayLayerCount);
+            TextureInfo dstTextureInfo = { dstExtent, dstMipLevelCount, dstArrayLayerCount, nullptr };
+
+            createRequiredResources(srcTextureInfo, dstTextureInfo, format);
+
+            SubresourceRange srcSubresource = {};
+            srcSubresource.aspectMask = TextureAspect::Color;
+            srcSubresource.mipLevel = 0;
+            srcSubresource.mipLevelCount = 1;
+            srcSubresource.baseArrayLayer = 0;
+            srcSubresource.layerCount = 1;
+
+            ITextureResource::Offset3D srcOffset;
+
+            SubresourceRange dstSubresource = {};
+            dstSubresource.aspectMask = TextureAspect::Color;
+            dstSubresource.mipLevel = 0;
+            dstSubresource.mipLevelCount = 1;
+            dstSubresource.baseArrayLayer = 0;
+            dstSubresource.layerCount = 1;
+
+            ITextureResource::Offset3D dstOffset;
+
+            ITextureResource::Size copyExtent = srcExtent;
+
+            submitGPUWork(srcSubresource, dstSubresource, srcOffset, dstOffset, copyExtent, copyExtent.height * 256);
+
+            auto expectedCopiedData = srcTextureStuff->subresourceDatas[0];
+            auto expectedOriginalData = dstTextureStuff->subresourceDatas[0];
+            checkTestResults(srcExtent, dstExtent, copyExtent, srcOffset, expectedCopiedData.data, expectedOriginalData.data);
+        }
+    };
+
+    struct CopyBetweenMips : BaseCopyTextureTest
+    {
+        void run()
+        {
+            Format format = Format::R32G32B32A32_FLOAT;
+
+            ITextureResource::Size srcExtent = {};
+            srcExtent.width = 16;
+            srcExtent.height = 16;
+            srcExtent.depth = 1;
+            auto srcMipLevelCount = 4;
+            auto srcArrayLayerCount = 1;
+
+            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount);
+            TextureInfo srcTextureInfo = { srcExtent, srcMipLevelCount, srcArrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
+
+            ITextureResource::Size dstExtent = {};
+            dstExtent.width = 16;
+            dstExtent.height = 16;
+            dstExtent.depth = 1;
+            auto dstMipLevelCount = 4;
+            auto dstArrayLayerCount = 1;
+
+            TextureInfo dstTextureInfo = { dstExtent, dstMipLevelCount, dstArrayLayerCount, nullptr };
+
+            createRequiredResources(srcTextureInfo, dstTextureInfo, format);
+
+            SubresourceRange srcSubresource = {};
+            srcSubresource.aspectMask = TextureAspect::Color;
+            srcSubresource.mipLevel = 2;
+            srcSubresource.mipLevelCount = 1;
+            srcSubresource.baseArrayLayer = 0;
+            srcSubresource.layerCount = 1;
+
+            ITextureResource::Offset3D srcOffset;
+
+            SubresourceRange dstSubresource = {};
+            dstSubresource.aspectMask = TextureAspect::Color;
+            dstSubresource.mipLevel = 1;
+            dstSubresource.mipLevelCount = 1;
+            dstSubresource.baseArrayLayer = 0;
+            dstSubresource.layerCount = 1;
+
+            ITextureResource::Offset3D dstOffset;
+
+            // These are the extents of the mip layer being copied from.
+            ITextureResource::Size copyExtent;
+            copyExtent.width = 4;
+            copyExtent.height = 4;
+            copyExtent.depth = 1;
+
+            submitGPUWork(srcSubresource, dstSubresource, srcOffset, dstOffset, copyExtent, copyExtent.height * 256);
+
+            ITextureResource::SubresourceData expectedData = srcTextureStuff->subresourceDatas[0];
             if (device->getDeviceInfo().deviceType == DeviceType::DirectX12)
             {
                 // D3D12 has to pad out the rows in order to adhere to alignment, so when comparing results
                 // we need to make sure not to include the padding.
                 size_t testOffset = 0;
-                size_t dataOffset = 0;
-                auto rowStride = expectedData.strideY / 4;
-                for (Int i = 0; i < extent.height; ++i)
+                Int srcRowStride = expectedData.strideY / 4;
+                Int dstRowStride = copyExtent.width * sizeof(Texel) / 4;
+                for (Int i = 0; i < copyExtent.height; ++i)
                 {
                     compareComputeResult(
                         device,
                         resultsBuffer,
                         testOffset,
-                        (float*) expectedData.data + rowStride * i,
-                        rowStride * 4);
-                    testOffset += alignedRowPitch;
+                        (float*)expectedData.data + srcRowStride * i,
+                        dstRowStride * 4);
+                    testOffset += alignedRowStride;
                 }
-                dataOffset += srcTextureStuff->subresourceDatas[0].strideZ / 4;
             }
             else if (device->getDeviceInfo().deviceType == DeviceType::Vulkan)
             {
@@ -336,6 +616,335 @@ namespace gfx_test
         }
     };
 
+    struct CopyBetweenLayers : BaseCopyTextureTest
+    {
+        void run()
+        {
+            Format format = Format::R32G32B32A32_FLOAT;
+
+            ITextureResource::Size srcExtent = {};
+            srcExtent.width = 4;
+            srcExtent.height = 4;
+            srcExtent.depth = 1;
+            auto srcMipLevelCount = 1;
+            auto srcArrayLayerCount = 2;
+
+            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount);
+            TextureInfo srcTextureInfo = { srcExtent, srcMipLevelCount, srcArrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
+
+            ITextureResource::Size dstExtent = {};
+            dstExtent.width = 4;
+            dstExtent.height = 4;
+            dstExtent.depth = 1;
+            auto dstMipLevelCount = 1;
+            auto dstArrayLayerCount = 2;
+
+            TextureInfo dstTextureInfo = { dstExtent, dstMipLevelCount, dstArrayLayerCount, nullptr };
+
+            createRequiredResources(srcTextureInfo, dstTextureInfo, format);
+
+            SubresourceRange srcSubresource = {};
+            srcSubresource.aspectMask = TextureAspect::Color;
+            srcSubresource.mipLevel = 0;
+            srcSubresource.mipLevelCount = 1;
+            srcSubresource.baseArrayLayer = 0;
+            srcSubresource.layerCount = 1;
+
+            ITextureResource::Offset3D srcOffset;
+
+            SubresourceRange dstSubresource = {};
+            dstSubresource.aspectMask = TextureAspect::Color;
+            dstSubresource.mipLevel = 0;
+            dstSubresource.mipLevelCount = 1;
+            dstSubresource.baseArrayLayer = 1;
+            dstSubresource.layerCount = 1;
+
+            ITextureResource::Offset3D dstOffset;
+
+            ITextureResource::Size copyExtent = srcExtent;
+
+            submitGPUWork(srcSubresource, dstSubresource, srcOffset, dstOffset, copyExtent, copyExtent.height * 256);
+
+            ITextureResource::SubresourceData expectedData = srcTextureStuff->subresourceDatas[0];
+            if (device->getDeviceInfo().deviceType == DeviceType::DirectX12)
+            {
+                // D3D12 has to pad out the rows in order to adhere to alignment, so when comparing results
+                // we need to make sure not to include the padding.
+                size_t testOffset = 0;
+                Int srcRowStride = expectedData.strideY / 4;
+                Int dstRowStride = copyExtent.width * sizeof(Texel) / 4;
+                for (Int i = 0; i < copyExtent.height; ++i)
+                {
+                    compareComputeResult(
+                        device,
+                        resultsBuffer,
+                        testOffset,
+                        (float*)expectedData.data + srcRowStride * i,
+                        dstRowStride * 4);
+                    testOffset += alignedRowStride;
+                }
+            }
+            else if (device->getDeviceInfo().deviceType == DeviceType::Vulkan)
+            {
+                compareComputeResult(
+                    device,
+                    resultsBuffer,
+                    0,
+                    expectedData.data,
+                    64);
+            }
+        }
+    };
+
+    struct CopyWithOffsets : BaseCopyTextureTest
+    {
+        void run()
+        {
+            Format format = Format::R32G32B32A32_FLOAT;
+
+            ITextureResource::Size srcExtent = {};
+            srcExtent.width = 8;
+            srcExtent.height = 8;
+            srcExtent.depth = 1;
+            auto srcMipLevelCount = 1;
+            auto srcArrayLayerCount = 1;
+
+            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount);
+            TextureInfo srcTextureInfo = { srcExtent, srcMipLevelCount, srcArrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
+
+            ITextureResource::Size dstExtent = {};
+            dstExtent.width = 16;
+            dstExtent.height = 16;
+            dstExtent.depth = 1;
+            auto dstMipLevelCount = 1;
+            auto dstArrayLayerCount = 1;
+
+            TextureInfo dstTextureInfo = { dstExtent, dstMipLevelCount, dstArrayLayerCount, nullptr };
+
+            createRequiredResources(srcTextureInfo, dstTextureInfo, format);
+
+            SubresourceRange srcSubresource = {};
+            srcSubresource.aspectMask = TextureAspect::Color;
+            srcSubresource.mipLevel = 0;
+            srcSubresource.mipLevelCount = 1;
+            srcSubresource.baseArrayLayer = 0;
+            srcSubresource.layerCount = 1;
+
+            ITextureResource::Offset3D srcOffset;
+            srcOffset.x = 4;
+            srcOffset.y = 4;
+            srcOffset.z = 0;
+
+            SubresourceRange dstSubresource = {};
+            dstSubresource.aspectMask = TextureAspect::Color;
+            dstSubresource.mipLevel = 0;
+            dstSubresource.mipLevelCount = 1;
+            dstSubresource.baseArrayLayer = 0;
+            dstSubresource.layerCount = 1;
+
+            ITextureResource::Offset3D dstOffset;
+            dstOffset.x = 4;
+            dstOffset.y = 4;
+            dstOffset.z = 0;
+
+            ITextureResource::Size copyExtent = srcExtent;
+
+            submitGPUWork(srcSubresource, dstSubresource, srcOffset, dstOffset, copyExtent, copyExtent.height * 256);
+
+            ITextureResource::SubresourceData expectedData = srcTextureStuff->subresourceDatas[0];
+            if (device->getDeviceInfo().deviceType == DeviceType::DirectX12)
+            {
+                // D3D12 has to pad out the rows in order to adhere to alignment, so when comparing results
+                // we need to make sure not to include the padding.
+                size_t testOffset = 0;
+                Int srcRowStride = expectedData.strideY / 4;
+                Int dstRowStride = copyExtent.width * sizeof(Texel) / 4;
+                for (Int i = 0; i < copyExtent.height; ++i)
+                {
+                    compareComputeResult(
+                        device,
+                        resultsBuffer,
+                        testOffset,
+                        (float*)expectedData.data + srcRowStride * i,
+                        dstRowStride * 4);
+                    testOffset += alignedRowStride;
+                }
+            }
+            else if (device->getDeviceInfo().deviceType == DeviceType::Vulkan)
+            {
+                compareComputeResult(
+                    device,
+                    resultsBuffer,
+                    0,
+                    expectedData.data,
+                    64);
+            }
+        }
+    };
+
+    struct CopySectionWithSetExtent : BaseCopyTextureTest
+    {
+        void run()
+        {
+            Format format = Format::R32G32B32A32_FLOAT;
+
+            ITextureResource::Size srcExtent = {};
+            srcExtent.width = 8;
+            srcExtent.height = 8;
+            srcExtent.depth = 1;
+            auto srcMipLevelCount = 1;
+            auto srcArrayLayerCount = 1;
+
+            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount);
+            TextureInfo srcTextureInfo = { srcExtent, srcMipLevelCount, srcArrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
+
+            ITextureResource::Size dstExtent = {};
+            dstExtent.width = 8;
+            dstExtent.height = 8;
+            dstExtent.depth = 1;
+            auto dstMipLevelCount = 1;
+            auto dstArrayLayerCount = 1;
+
+            TextureInfo dstTextureInfo = { dstExtent, dstMipLevelCount, dstArrayLayerCount, nullptr };
+
+            createRequiredResources(srcTextureInfo, dstTextureInfo, format);
+
+            SubresourceRange srcSubresource = {};
+            srcSubresource.aspectMask = TextureAspect::Color;
+            srcSubresource.mipLevel = 0;
+            srcSubresource.mipLevelCount = 1;
+            srcSubresource.baseArrayLayer = 0;
+            srcSubresource.layerCount = 1;
+
+            ITextureResource::Offset3D srcOffset;
+
+            SubresourceRange dstSubresource = {};
+            dstSubresource.aspectMask = TextureAspect::Color;
+            dstSubresource.mipLevel = 0;
+            dstSubresource.mipLevelCount = 1;
+            dstSubresource.baseArrayLayer = 0;
+            dstSubresource.layerCount = 1;
+
+            ITextureResource::Offset3D dstOffset;
+            dstOffset.x = 4;
+            dstOffset.y = 4;
+            dstOffset.z = 0;
+
+            ITextureResource::Size copyExtent;
+            copyExtent.width = 4;
+            copyExtent.height = 4;
+            copyExtent.depth = 1;
+
+            submitGPUWork(srcSubresource, dstSubresource, srcOffset, dstOffset, copyExtent, copyExtent.height * 256);
+
+            ITextureResource::SubresourceData expectedData = srcTextureStuff->subresourceDatas[0];
+            if (device->getDeviceInfo().deviceType == DeviceType::DirectX12)
+            {
+                // D3D12 has to pad out the rows in order to adhere to alignment, so when comparing results
+                // we need to make sure not to include the padding.
+                size_t testOffset = 0;
+                Int srcRowStride = expectedData.strideY / 4;
+                Int dstRowStride = copyExtent.width * sizeof(Texel) / 4;
+                for (Int i = 0; i < copyExtent.height; ++i)
+                {
+                    
+                    compareComputeResult(
+                        device,
+                        resultsBuffer,
+                        testOffset,
+                        (float*)expectedData.data + srcRowStride * i,
+                        dstRowStride * 4);
+                    testOffset += alignedRowStride;
+                }
+            }
+            else if (device->getDeviceInfo().deviceType == DeviceType::Vulkan)
+            {
+                compareComputeResult(
+                    device,
+                    resultsBuffer,
+                    0,
+                    expectedData.data,
+                    64);
+            }
+        }
+    };
+
+    struct CopyToBufferWithOffset : BaseCopyTextureTest
+    {
+        void run()
+        {
+            Format format = Format::R32G32B32A32_FLOAT;
+
+            ITextureResource::Size srcExtent = {};
+            srcExtent.width = 8;
+            srcExtent.height = 8;
+            srcExtent.depth = 1;
+            auto srcMipLevelCount = 1;
+            auto srcArrayLayerCount = 1;
+
+            auto srcTextureStuff = generateTextureData(srcExtent.width, srcExtent.height, srcMipLevelCount, srcArrayLayerCount);
+            TextureInfo srcTextureInfo = { srcExtent, srcMipLevelCount, srcArrayLayerCount, srcTextureStuff->subresourceDatas.getBuffer() };
+
+            ITextureResource::Size dstExtent = {};
+            dstExtent.width = 4;
+            dstExtent.height = 6;
+            dstExtent.depth = 1;
+            auto dstMipLevelCount = 1;
+            auto dstArrayLayerCount = 1;
+
+            TextureInfo dstTextureInfo = { dstExtent, dstMipLevelCount, dstArrayLayerCount, nullptr };
+
+            createRequiredResources(srcTextureInfo, dstTextureInfo, format);
+
+            SubresourceRange srcSubresource = {};
+            srcSubresource.aspectMask = TextureAspect::Color;
+            srcSubresource.mipLevel = 0;
+            srcSubresource.mipLevelCount = 1;
+            srcSubresource.baseArrayLayer = 0;
+            srcSubresource.layerCount = 1;
+
+            ITextureResource::Offset3D srcOffset;
+            srcOffset.x = 4;
+            srcOffset.y = 4;
+            srcOffset.z = 0;
+
+            SubresourceRange dstSubresource = {};
+            dstSubresource.aspectMask = TextureAspect::Color;
+            dstSubresource.mipLevel = 0;
+            dstSubresource.mipLevelCount = 1;
+            dstSubresource.baseArrayLayer = 0;
+            dstSubresource.layerCount = 1;
+
+            ITextureResource::Size copyExtent;
+            copyExtent.width = 4;
+            copyExtent.height = 4;
+            copyExtent.depth = 1;
+
+            auto textureSize = copyExtent.width * copyExtent.height * copyExtent.depth * 16; // Size of the texture section being copied.
+
+            Slang::ComPtr<ITransientResourceHeap> transientHeap;
+            ITransientResourceHeap::Desc transientHeapDesc = {};
+            transientHeapDesc.constantBufferSize = 4096;
+            GFX_CHECK_CALL_ABORT(
+                device->createTransientResourceHeap(transientHeapDesc, transientHeap.writeRef()));
+
+            ICommandQueue::Desc queueDesc = { ICommandQueue::QueueType::Graphics };
+            auto queue = device->createCommandQueue(queueDesc);
+
+            auto commandBuffer = transientHeap->createCommandBuffer();
+            auto encoder = commandBuffer->encodeResourceCommands();
+
+            encoder->textureSubresourceBarrier(srcTexture, srcSubresource, ResourceState::UnorderedAccess, ResourceState::CopySource);
+            encoder->copyTextureToBuffer(resultsBuffer, 512, textureSize, alignedRowStride, srcTexture, ResourceState::CopySource, srcSubresource, srcOffset, copyExtent);
+            encoder->endEncoding();
+            commandBuffer->close();
+            queue->executeCommandBuffer(commandBuffer);
+            queue->waitOnHost();
+
+            //checkTestResults<float>(srcExtent, dstExtent, copyExtent, srcOffset, srcTextureStuff->subresourceDatas[0].data);
+        }
+    };
+
     template<typename T>
     void copyTextureTestImpl(IDevice* device, UnitTestContext* context)
     {
@@ -344,23 +953,63 @@ namespace gfx_test
         test.run();
     }
 
-    SLANG_UNIT_TEST(copyTextureSimpleD3D12)
+    SLANG_UNIT_TEST(copyTextureTests)
+    {
+        runTestImpl(copyTextureTestImpl<SmallSrcToLargeDst>, unitTestContext, Slang::RenderApiFlag::D3D12);
+        runTestImpl(copyTextureTestImpl<SmallSrcToLargeDst>, unitTestContext, Slang::RenderApiFlag::Vulkan);
+    }
+
+    SLANG_UNIT_TEST(copyTextureSimple)
     {
         runTestImpl(copyTextureTestImpl<SimpleCopyTexture>, unitTestContext, Slang::RenderApiFlag::D3D12);
-    }
-
-    SLANG_UNIT_TEST(copyTextureSectionD3D12)
-    {
-        runTestImpl(copyTextureTestImpl<CopyTextureSection>, unitTestContext, Slang::RenderApiFlag::D3D12);
-    }
-
-    SLANG_UNIT_TEST(copyTextureSimpleVulkan)
-    {
         runTestImpl(copyTextureTestImpl<SimpleCopyTexture>, unitTestContext, Slang::RenderApiFlag::Vulkan);
     }
 
-    SLANG_UNIT_TEST(copyTextureSectionVulkan)
+    SLANG_UNIT_TEST(copyTextureSection)
     {
+        runTestImpl(copyTextureTestImpl<CopyTextureSection>, unitTestContext, Slang::RenderApiFlag::D3D12);
         runTestImpl(copyTextureTestImpl<CopyTextureSection>, unitTestContext, Slang::RenderApiFlag::Vulkan);
+    }
+
+    SLANG_UNIT_TEST(copyLargeToSmallTexture)
+    {
+        runTestImpl(copyTextureTestImpl<LargeSrcToSmallDst>, unitTestContext, Slang::RenderApiFlag::D3D12);
+        runTestImpl(copyTextureTestImpl<LargeSrcToSmallDst>, unitTestContext, Slang::RenderApiFlag::Vulkan);
+    }
+
+    SLANG_UNIT_TEST(copySmallToLargeTexture)
+    {
+        runTestImpl(copyTextureTestImpl<SmallSrcToLargeDst>, unitTestContext, Slang::RenderApiFlag::D3D12);
+        runTestImpl(copyTextureTestImpl<SmallSrcToLargeDst>, unitTestContext, Slang::RenderApiFlag::Vulkan);
+    }
+
+    SLANG_UNIT_TEST(copyBetweenMips)
+    {
+        runTestImpl(copyTextureTestImpl<CopyBetweenMips>, unitTestContext, Slang::RenderApiFlag::D3D12);
+        runTestImpl(copyTextureTestImpl<CopyBetweenMips>, unitTestContext, Slang::RenderApiFlag::Vulkan);
+    }
+
+    SLANG_UNIT_TEST(copyBetweenLayers)
+    {
+        runTestImpl(copyTextureTestImpl<CopyBetweenLayers>, unitTestContext, Slang::RenderApiFlag::D3D12);
+        runTestImpl(copyTextureTestImpl<CopyBetweenLayers>, unitTestContext, Slang::RenderApiFlag::Vulkan);
+    }
+
+    SLANG_UNIT_TEST(copyWithOffsets)
+    {
+        runTestImpl(copyTextureTestImpl<CopyWithOffsets>, unitTestContext, Slang::RenderApiFlag::D3D12);
+        runTestImpl(copyTextureTestImpl<CopyWithOffsets>, unitTestContext, Slang::RenderApiFlag::Vulkan);
+    }
+
+    SLANG_UNIT_TEST(copySectionWithSetExtent)
+    {
+        runTestImpl(copyTextureTestImpl<CopySectionWithSetExtent>, unitTestContext, Slang::RenderApiFlag::D3D12);
+        runTestImpl(copyTextureTestImpl<CopySectionWithSetExtent>, unitTestContext, Slang::RenderApiFlag::Vulkan);
+    }
+
+    SLANG_UNIT_TEST(copyToBufferWithOffset)
+    {
+        runTestImpl(copyTextureTestImpl<CopyToBufferWithOffset>, unitTestContext, Slang::RenderApiFlag::D3D12);
+        runTestImpl(copyTextureTestImpl<CopyToBufferWithOffset>, unitTestContext, Slang::RenderApiFlag::Vulkan);
     }
 }


### PR DESCRIPTION
Changes:
- Added texture to texture copying tests that copy between differently sized textures and between different mip levels and array layers with different offsets and specific copy extents
- Added testing support for all non-compressed formats and all texture types other than TextureCube
- Significantly restructured `copy-texture-tests.cpp` to support testing different formats and texture types

This PR DOES NOT currently include tests for `TextureCube`s and tests for BC formats. These are commented in the code as a todo item and will be addressed in a future PR. I also originally had a test for copying from a texture to a buffer at an offset; however, I think it'll be better to put that in a separate file.

@csyonghe @tangent-vector 