### PR TITLE
GFX texture testing utils

### DIFF
--- a/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj
+++ b/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj
@@ -268,6 +268,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\tools\gfx-unit-test\gfx-test-texture-util.h" />
     <ClInclude Include="..\..\..\tools\gfx-unit-test\gfx-test-util.h" />
     <ClInclude Include="..\..\..\tools\unit-test\slang-unit-test.h" />
   </ItemGroup>
@@ -284,6 +285,7 @@
     <ClCompile Include="..\..\..\tools\gfx-unit-test\get-cmd-queue-handle-test.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\get-supported-resource-states-test.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\get-texture-resource-handle-test.cpp" />
+    <ClCompile Include="..\..\..\tools\gfx-unit-test\gfx-test-texture-util.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\gfx-test-util.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\instanced-draw-tests.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\mutable-shader-object.cpp" />

--- a/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj.filters
+++ b/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj.filters
@@ -15,6 +15,9 @@
     <ClInclude Include="..\..\..\tools\unit-test\slang-unit-test.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\tools\gfx-unit-test\gfx-test-texture-util.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\tools\gfx-unit-test\buffer-barrier-test.cpp">
@@ -84,6 +87,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\tools\unit-test\slang-unit-test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\tools\gfx-unit-test\gfx-test-texture-util.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/tools/gfx-unit-test/gfx-test-texture-util.cpp
+++ b/tools/gfx-unit-test/gfx-test-texture-util.cpp
@@ -1,0 +1,191 @@
+#include "gfx-test-texture-util.h"
+#include "tools/unit-test/slang-unit-test.h"
+
+#include <slang-com-ptr.h>
+
+#define GFX_ENABLE_RENDERDOC_INTEGRATION 0
+
+#if GFX_ENABLE_RENDERDOC_INTEGRATION
+#    include "external/renderdoc_app.h"
+#    define WIN32_LEAN_AND_MEAN
+#    include <Windows.h>
+#endif
+
+using namespace Slang;
+using namespace gfx;
+
+namespace gfx_test
+{
+    TextureAspect getTextureAspect(Format format)
+    {
+        switch (format)
+        {
+        case Format::D16_UNORM:
+        case Format::D32_FLOAT:
+            return TextureAspect::Depth;
+        default:
+            return TextureAspect::Color;
+        }
+    }
+
+    uint32_t getSubresourceIndex(uint32_t mipLevel, uint32_t mipLevelCount, uint32_t baseArrayLayer)
+    {
+        return baseArrayLayer * mipLevelCount + mipLevel;
+    }
+
+    RefPtr<ValidationTextureFormatBase> getValidationTextureFormat(Format format)
+    {
+        switch (format)
+        {
+        case Format::R32G32B32A32_TYPELESS:         return new ValidationTextureFormat<uint32_t>(4);
+        case Format::R32G32B32_TYPELESS:            return new ValidationTextureFormat<uint32_t>(3);
+        case Format::R32G32_TYPELESS:               return new ValidationTextureFormat<uint32_t>(2);
+        case Format::R32_TYPELESS:                  return new ValidationTextureFormat<uint32_t>(1);
+
+        case Format::R16G16B16A16_TYPELESS:         return new ValidationTextureFormat<uint16_t>(4);
+        case Format::R16G16_TYPELESS:               return new ValidationTextureFormat<uint16_t>(2);
+        case Format::R16_TYPELESS:                  return new ValidationTextureFormat<uint16_t>(1);
+
+        case Format::R8G8B8A8_TYPELESS:             return new ValidationTextureFormat<uint8_t>(4);
+        case Format::R8G8_TYPELESS:                 return new ValidationTextureFormat<uint8_t>(2);
+        case Format::R8_TYPELESS:                   return new ValidationTextureFormat<uint8_t>(1);
+        case Format::B8G8R8A8_TYPELESS:             return new ValidationTextureFormat<uint8_t>(4);
+
+        case Format::R32G32B32A32_FLOAT:            return new ValidationTextureFormat<float>(4);
+        case Format::R32G32B32_FLOAT:               return new ValidationTextureFormat<float>(3);
+        case Format::R32G32_FLOAT:                  return new ValidationTextureFormat<float>(2);
+        case Format::R32_FLOAT:                     return new ValidationTextureFormat<float>(1);
+
+        case Format::R16G16B16A16_FLOAT:            return new ValidationTextureFormat<uint16_t>(4);
+        case Format::R16G16_FLOAT:                  return new ValidationTextureFormat<uint16_t>(2);
+        case Format::R16_FLOAT:                     return new ValidationTextureFormat<uint16_t>(1);
+
+        case Format::R32G32B32A32_UINT:             return new ValidationTextureFormat<uint32_t>(4);
+        case Format::R32G32B32_UINT:                return new ValidationTextureFormat<uint32_t>(3);
+        case Format::R32G32_UINT:                   return new ValidationTextureFormat<uint32_t>(2);
+        case Format::R32_UINT:                      return new ValidationTextureFormat<uint32_t>(1);
+
+        case Format::R16G16B16A16_UINT:             return new ValidationTextureFormat<uint16_t>(4);
+        case Format::R16G16_UINT:                   return new ValidationTextureFormat<uint16_t>(2);
+        case Format::R16_UINT:                      return new ValidationTextureFormat<uint16_t>(1);
+
+        case Format::R8G8B8A8_UINT:                 return new ValidationTextureFormat<uint8_t>(4);
+        case Format::R8G8_UINT:                     return new ValidationTextureFormat<uint8_t>(2);
+        case Format::R8_UINT:                       return new ValidationTextureFormat<uint8_t>(1);
+
+        case Format::R32G32B32A32_SINT:             return new ValidationTextureFormat<int32_t>(4);
+        case Format::R32G32B32_SINT:                return new ValidationTextureFormat<int32_t>(3);
+        case Format::R32G32_SINT:                   return new ValidationTextureFormat<int32_t>(2);
+        case Format::R32_SINT:                      return new ValidationTextureFormat<int32_t>(1);
+
+        case Format::R16G16B16A16_SINT:             return new ValidationTextureFormat<int16_t>(4);
+        case Format::R16G16_SINT:                   return new ValidationTextureFormat<int16_t>(2);
+        case Format::R16_SINT:                      return new ValidationTextureFormat<int16_t>(1);
+
+        case Format::R8G8B8A8_SINT:                 return new ValidationTextureFormat<int8_t>(4);
+        case Format::R8G8_SINT:                     return new ValidationTextureFormat<int8_t>(2);
+        case Format::R8_SINT:                       return new ValidationTextureFormat<int8_t>(1);
+
+        case Format::R16G16B16A16_UNORM:            return new ValidationTextureFormat<uint16_t>(4);
+        case Format::R16G16_UNORM:                  return new ValidationTextureFormat<uint16_t>(2);
+        case Format::R16_UNORM:                     return new ValidationTextureFormat<uint16_t>(1);
+
+        case Format::R8G8B8A8_UNORM:                return new ValidationTextureFormat<uint8_t>(4);
+        case Format::R8G8B8A8_UNORM_SRGB:           return new ValidationTextureFormat<uint8_t>(4);
+        case Format::R8G8_UNORM:                    return new ValidationTextureFormat<uint8_t>(2);
+        case Format::R8_UNORM:                      return new ValidationTextureFormat<uint8_t>(1);
+        case Format::B8G8R8A8_UNORM:                return new ValidationTextureFormat<uint8_t>(4);
+        case Format::B8G8R8A8_UNORM_SRGB:           return new ValidationTextureFormat<uint8_t>(4);
+        case Format::B8G8R8X8_UNORM:                return new ValidationTextureFormat<uint8_t>(3);
+        case Format::B8G8R8X8_UNORM_SRGB:           return new ValidationTextureFormat<uint8_t>(3);
+
+        case Format::R16G16B16A16_SNORM:            return new ValidationTextureFormat<int16_t>(4);
+        case Format::R16G16_SNORM:                  return new ValidationTextureFormat<int16_t>(2);
+        case Format::R16_SNORM:                     return new ValidationTextureFormat<int16_t>(1);
+
+        case Format::R8G8B8A8_SNORM:                return new ValidationTextureFormat<int8_t>(4);
+        case Format::R8G8_SNORM:                    return new ValidationTextureFormat<int8_t>(2);
+        case Format::R8_SNORM:                      return new ValidationTextureFormat<int8_t>(1);
+
+        case Format::D32_FLOAT:                     return new ValidationTextureFormat<float>(1);
+        case Format::D16_UNORM:                     return new ValidationTextureFormat<uint16_t>(1);
+
+        case Format::B4G4R4A4_UNORM:                return new PackedValidationTextureFormat<uint16_t>(4, 4, 4, 4);
+        case Format::B5G6R5_UNORM:                  return new PackedValidationTextureFormat<uint16_t>(5, 6, 5, 0);
+        case Format::B5G5R5A1_UNORM:                return new PackedValidationTextureFormat<uint16_t>(5, 5, 5, 1);
+
+        case Format::R9G9B9E5_SHAREDEXP:            return new ValidationTextureFormat<uint32_t>(1);
+        case Format::R10G10B10A2_TYPELESS:          return new PackedValidationTextureFormat<uint32_t>(10, 10, 10, 2);
+        case Format::R10G10B10A2_UNORM:             return new PackedValidationTextureFormat<uint32_t>(10, 10, 10, 2);
+        case Format::R10G10B10A2_UINT:              return new PackedValidationTextureFormat<uint32_t>(10, 10, 10, 2);
+        case Format::R11G11B10_FLOAT:               return new PackedValidationTextureFormat<uint32_t>(11, 11, 10, 0);
+
+            // TODO: Add testing support for BC formats
+//                     BC1_UNORM,
+//                     BC1_UNORM_SRGB,
+//                     BC2_UNORM,
+//                     BC2_UNORM_SRGB,
+//                     BC3_UNORM,
+//                     BC3_UNORM_SRGB,
+//                     BC4_UNORM,
+//                     BC4_SNORM,
+//                     BC5_UNORM,
+//                     BC5_SNORM,
+//                     BC6H_UF16,
+//                     BC6H_SF16,
+//                     BC7_UNORM,
+//                     BC7_UNORM_SRGB,
+        default:
+            return nullptr;
+        }
+    }
+
+    void generateTextureData(RefPtr<TextureInfo> texture, ValidationTextureFormatBase* validationFormat)
+    {
+        auto extents = texture->extents;
+        auto arrayLayers = texture->arrayLayerCount;
+        auto mipLevels = texture->mipLevelCount;
+        auto texelSize = texture->texelSize;
+
+        for (uint32_t layer = 0; layer < arrayLayers; ++layer)
+        {
+            for (uint32_t mip = 0; mip < mipLevels; ++mip)
+            {
+                RefPtr<ValidationTextureData> subresource = new ValidationTextureData();
+
+                auto mipWidth = Math::Max(extents.width >> mip, 1);
+                auto mipHeight = Math::Max(extents.height >> mip, 1);
+                auto mipDepth = Math::Max(extents.depth >> mip, 1);
+                auto mipSize = mipWidth * mipHeight * mipDepth * texelSize;
+                subresource->textureData = malloc(mipSize);
+                SLANG_CHECK_ABORT(subresource->textureData);
+
+                subresource->extents.width = mipWidth;
+                subresource->extents.height = mipHeight;
+                subresource->extents.depth = mipDepth;
+                subresource->strides.x = texelSize;
+                subresource->strides.y = mipWidth * texelSize;
+                subresource->strides.z = mipHeight * subresource->strides.y;
+                texture->subresourceObjects.add(subresource);
+
+                for (int z = 0; z < mipDepth; ++z)
+                {
+                    for (int y = 0; y < mipHeight; ++y)
+                    {
+                        for (int x = 0; x < mipWidth; ++x)
+                        {
+                            auto texel = subresource->getBlockAt(x, y, z);
+                            validationFormat->initializeTexel(texel, x, y, z, mip, layer);
+                        }
+                    }
+                }
+
+                ITextureResource::SubresourceData subData = {};
+                subData.data = subresource->textureData;
+                subData.strideY = subresource->strides.y;
+                subData.strideZ = subresource->strides.z;
+                texture->subresourceDatas.add(subData);
+            }
+        }
+    }
+}

--- a/tools/gfx-unit-test/gfx-test-texture-util.h
+++ b/tools/gfx-unit-test/gfx-test-texture-util.h
@@ -1,0 +1,175 @@
+#pragma once
+
+#include "slang-gfx.h"
+#include "source/core/slang-basic.h"
+#include "source/core/slang-render-api-util.h"
+#include "tools/unit-test/slang-unit-test.h"
+
+using namespace Slang;
+using namespace gfx;
+
+namespace gfx_test
+{
+    struct ValidationTextureFormatBase : RefObject
+    {
+        virtual void validateBlocksEqual(const void* actual, const void* expected) = 0;
+
+        virtual void initializeTexel(void* texel, int x, int y, int z, int mipLevel, int arrayLayer) = 0;
+    };
+
+    template <typename T>
+    struct ValidationTextureFormat : ValidationTextureFormatBase
+    {
+        int componentCount;
+
+        ValidationTextureFormat(int componentCount) : componentCount(componentCount) {};
+
+        virtual void validateBlocksEqual(const void* actual, const void* expected) override
+        {
+            auto a = (const T*)actual;
+            auto e = (const T*)expected;
+
+            for (Int i = 0; i < componentCount; ++i)
+            {
+                SLANG_CHECK(a[i] == e[i]);
+            }
+        }
+
+        virtual void initializeTexel(void* texel, int x, int y, int z, int mipLevel, int arrayLayer) override
+        {
+            auto temp = (T*)texel;
+
+            switch (componentCount)
+            {
+            case 1:
+                temp[0] = T(x + y + z + mipLevel + arrayLayer);
+                break;
+            case 2:
+                temp[0] = T(x + z + arrayLayer);
+                temp[1] = T(y + mipLevel);
+                break;
+            case 3:
+                temp[0] = T(x + mipLevel);
+                temp[1] = T(y + arrayLayer);
+                temp[2] = T(z);
+                break;
+            case 4:
+                temp[0] = T(x + arrayLayer);
+                temp[1] = (T)y;
+                temp[2] = (T)z;
+                temp[3] = (T)mipLevel;
+                break;
+            default:
+                assert(!"component count should be no greater than 4");
+                SLANG_CHECK_ABORT(false);
+            }
+        }
+    };
+
+    template <typename T>
+    struct PackedValidationTextureFormat : ValidationTextureFormatBase
+    {
+        int rBits;
+        int gBits;
+        int bBits;
+        int aBits;
+
+        PackedValidationTextureFormat(int rBits, int gBits, int bBits, int aBits)
+            : rBits(rBits), gBits(gBits), bBits(bBits), aBits(aBits) {};
+
+        virtual void validateBlocksEqual(const void* actual, const void* expected) override
+        {
+            T a[4];
+            T e[4];
+            unpackTexel(*(const T*)actual, a);
+            unpackTexel(*(const T*)expected, e);
+
+            for (Int i = 0; i < 4; ++i)
+            {
+                SLANG_CHECK(a[i] == e[i]);
+            }
+        }
+
+        virtual void initializeTexel(void* texel, int x, int y, int z, int mipLevel, int arrayLayer) override
+        {
+            T temp = 0;
+
+            // The only formats which currently use this have either 3 or 4 channels. TODO: BC formats?
+            if (aBits == 0)
+            {
+                temp |= z;
+                temp <<= gBits;
+                temp |= (y + arrayLayer);
+                temp <<= rBits;
+                temp |= (x + mipLevel);
+            }
+            else
+            {
+                temp |= mipLevel;
+                temp <<= bBits;
+                temp |= z;
+                temp <<= gBits;
+                temp |= y;
+                temp <<= rBits;
+                temp |= (x + arrayLayer);
+            }
+
+            *(T*)texel = temp;
+        }
+
+        void unpackTexel(T texel, T* outComponents)
+        {
+            outComponents[0] = texel & ((1 << rBits) - 1);
+            texel >>= rBits;
+
+            outComponents[1] = texel & ((1 << gBits) - 1);
+            texel >>= gBits;
+
+            outComponents[2] = texel & ((1 << bBits) - 1);
+            texel >>= bBits;
+
+            outComponents[3] = texel & ((1 << aBits) - 1);
+            texel >>= aBits;
+        }
+    };
+
+    // Struct containing texture data and information for a specific subresource.
+    struct ValidationTextureData : RefObject
+    {
+        const void* textureData;
+        ITextureResource::Size extents;
+        ITextureResource::Offset3D strides;
+
+        void* getBlockAt(Int x, Int y, Int z)
+        {
+            assert(x >= 0 && x < extents.width);
+            assert(y >= 0 && y < extents.height);
+            assert(z >= 0 && z < extents.depth);
+
+            char* layerData = (char*)textureData + z * strides.z;
+            char* rowData = layerData + y * strides.y;
+            return rowData + x * strides.x;
+        }
+    };
+
+    // Struct containing relevant information for a texture, including a list of its subresources
+    // and all relevant information for each subresource.
+    struct TextureInfo : RefObject
+    {
+        Format format;
+        uint32_t texelSize;
+        ITextureResource::Type textureType;
+
+        ITextureResource::Size extents;
+        uint32_t mipLevelCount;
+        uint32_t arrayLayerCount;
+
+        List<RefPtr<ValidationTextureData>> subresourceObjects;
+        List<ITextureResource::SubresourceData> subresourceDatas;
+    };
+
+    RefPtr<ValidationTextureFormatBase> getValidationTextureFormat(Format format);
+    TextureAspect getTextureAspect(gfx::Format format);
+    uint32_t getSubresourceIndex(uint32_t mipLevel, uint32_t mipLevelCount, uint32_t baseArrayLayer);
+    void generateTextureData(RefPtr<TextureInfo> texture, ValidationTextureFormatBase* validationFormat);
+}


### PR DESCRIPTION
Changes:
- Moved numerous texture data related structs as well as a few getters and `generateTextureData()` out of the texture to texture copy tests into a new set of `gfx-test-texture-util` header/cpp files
- Updated all tests in `copy-texture-tests.cpp` to reflect the new code structure

@csyonghe This is an intermediate change to move all the new texture-related testing code added with the expansion of texture copying tests up a level to make them available to all gfx unit tests.