### PR TITLE
Improved type printing

### DIFF
--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -1152,7 +1152,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
                 if (parentGeneric && parentGeneric->inner == decl)
                     return;
 
-                out << "::";
+                out << ".";
             }
         }
         

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -1132,16 +1132,68 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         return builder;
     }
 
+    // Prints a partially qualified type name with generic substitutions.
+    static void _printNestedDecl(const Substitutions* substitutions, Decl* decl, StringBuilder& out)
+    {
+        // If there is a parent scope for the declaration, print it first.
+        // Exclude top-level namespaces like `tu0` or `core`.
+        if (decl->parentDecl && !Slang::as<ModuleDecl>(decl->parentDecl))
+        {
+            auto parentGeneric = Slang::as<GenericDecl>(decl->parentDecl);
+
+            // Exclude function or operator names.
+            // Avoids excessively verbose messages like `func<T>(func::T)`
+            if (!(parentGeneric && Slang::as<CallableDecl>(parentGeneric->inner)))
+            {
+                _printNestedDecl(substitutions, decl->parentDecl, out);
+
+                // If the parent is a generic for this type, skip *this* type.
+                // Avoids duplicate types like `MyType<T>::MyType`
+                if (parentGeneric && parentGeneric->inner == decl)
+                    return;
+
+                out << "::";
+            }
+        }
+        
+        // Print this type's name.
+        auto name = decl->getName();
+        if (name)
+        {
+            out << name->text;
+        }
+
+        // Look for generic substitutions on this type.
+        for (const Substitutions* subst = substitutions; subst; subst = subst->outer)
+        {
+            auto genericSubstitution = Slang::as<GenericSubstitution>(subst);
+            if (!genericSubstitution)
+                continue;
+
+            // If the substitution is for this type, print it.
+            if (genericSubstitution->genericDecl == decl)
+            {
+                out << "<";
+                bool isFirst = true;
+                for (const auto& it : genericSubstitution->args)
+                {
+                    if (!isFirst)
+                        out << ", ";
+                    isFirst = false;
+                    it->toText(out);
+                }
+                out << ">";
+
+                break;
+            }
+        }
+    }
+
     void DeclRefBase::toText(StringBuilder& out) const
     {
         if (decl)
         {
-            auto name = decl->getName();
-            if (name)
-            {
-                // TODO: need to print out substitutions too!
-                out << name->text;
-            }
+            _printNestedDecl(substitutions, decl, out);
         }
     }
 

--- a/tests/diagnostics/mismatching-types.slang
+++ b/tests/diagnostics/mismatching-types.slang
@@ -45,23 +45,23 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     GenericOuter<int> a;
     GenericOuter<float> b;
     NonGenericOuter c;
-    NonGenericOuter::GenericInner<int> d;
+    NonGenericOuter.GenericInner<int> d;
     
     // expected an expression of type 'GenericOuter<int>', got 'int'
     a = 0;
-    // expected an expression of type 'GenericOuter<int>::GenericInner<int>', got 'int'
+    // expected an expression of type 'GenericOuter<int>.GenericInner<int>', got 'int'
     a.g = 0;
-    // expected an expression of type 'GenericOuter<int>::NonGenericInner', got 'int'
+    // expected an expression of type 'GenericOuter<int>.NonGenericInner', got 'int'
     a.ng = 0;
-    // expected an expression of type 'GenericOuter<int>::GenericInner<int>', got 'GenericOuter<float>::GenericInner<float>'
+    // expected an expression of type 'GenericOuter<int>.GenericInner<int>', got 'GenericOuter<float>.GenericInner<float>'
     a.g = b.g;
-    // expected an expression of type 'GenericOuter<int>::NonGenericInner', got 'GenericOuter<float>::NonGenericInner'
+    // expected an expression of type 'GenericOuter<int>.NonGenericInner', got 'GenericOuter<float>.NonGenericInner'
     a.ng = b.ng;
-    // expected an expression of type 'NonGenericOuter::GenericInner<int>', got 'int'
+    // expected an expression of type 'NonGenericOuter.GenericInner<int>', got 'int'
     c.i = 0;
-    // expected an expression of type 'NonGenericOuter::GenericInner<int>', got 'NonGenericOuter::GenericInner<float>'
+    // expected an expression of type 'NonGenericOuter.GenericInner<int>', got 'NonGenericOuter.GenericInner<float>'
     c.i = c.f;
-    // expected an expression of type 'NonGenericOuter::GenericInner<int>::ReallyNested', got 'int'
+    // expected an expression of type 'NonGenericOuter.GenericInner<int>.ReallyNested', got 'int'
     c.i.n = 0;
     // OK
     c.i.n.val = 0;

--- a/tests/diagnostics/mismatching-types.slang
+++ b/tests/diagnostics/mismatching-types.slang
@@ -1,0 +1,77 @@
+// mismatching-types.slang
+//DIAGNOSTIC_TEST:SIMPLE:-target hlsl
+
+Texture1D<float> tex;
+
+struct GenericOuter<T>
+{
+    struct GenericInner<Q>
+    {
+        T val;
+    };
+
+    struct NonGenericInner
+    {
+        T val;
+    };
+
+    GenericInner<T> g;
+    NonGenericInner ng;
+};
+
+struct NonGenericOuter
+{
+    struct GenericInner<T>
+    {
+        T val;
+
+        struct ReallyNested
+        {
+            T val;
+        };
+
+        ReallyNested n;
+    };
+
+    GenericInner<int> i;
+    GenericInner<float> f;
+};
+
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main(uint3 dispatchThreadID : SV_DispatchThreadID)
+{    
+    GenericOuter<int> a;
+    GenericOuter<float> b;
+    NonGenericOuter c;
+    NonGenericOuter::GenericInner<int> d;
+    
+    // expected an expression of type 'GenericOuter<int>', got 'int'
+    a = 0;
+    // expected an expression of type 'GenericOuter<int>::GenericInner<int>', got 'int'
+    a.g = 0;
+    // expected an expression of type 'GenericOuter<int>::NonGenericInner', got 'int'
+    a.ng = 0;
+    // expected an expression of type 'GenericOuter<int>::GenericInner<int>', got 'GenericOuter<float>::GenericInner<float>'
+    a.g = b.g;
+    // expected an expression of type 'GenericOuter<int>::NonGenericInner', got 'GenericOuter<float>::NonGenericInner'
+    a.ng = b.ng;
+    // expected an expression of type 'NonGenericOuter::GenericInner<int>', got 'int'
+    c.i = 0;
+    // expected an expression of type 'NonGenericOuter::GenericInner<int>', got 'NonGenericOuter::GenericInner<float>'
+    c.i = c.f;
+    // expected an expression of type 'NonGenericOuter::GenericInner<int>::ReallyNested', got 'int'
+    c.i.n = 0;
+    // OK
+    c.i.n.val = 0;
+    // OK
+    d.val = 0;
+    // OK
+    c.i = d;
+
+    // expected an expression of type 'Texture1D<int>', got 'Texture1D<float>'
+    Texture1D<int> t1 = tex;
+    // expected an expression of type 'Texture2D<float>', got 'Texture1D<float>'
+    Texture2D<float> t2 = tex;
+}

--- a/tests/diagnostics/mismatching-types.slang.expected
+++ b/tests/diagnostics/mismatching-types.slang.expected
@@ -1,0 +1,35 @@
+result code = -1
+standard error = {
+tests/diagnostics/mismatching-types.slang(51): error 30019: expected an expression of type 'GenericOuter<int>', got 'int'
+    a = 0;
+        ^
+tests/diagnostics/mismatching-types.slang(53): error 30019: expected an expression of type 'GenericOuter<int>::GenericInner<int>', got 'int'
+    a.g = 0;
+          ^
+tests/diagnostics/mismatching-types.slang(55): error 30019: expected an expression of type 'GenericOuter<int>::NonGenericInner', got 'int'
+    a.ng = 0;
+           ^
+tests/diagnostics/mismatching-types.slang(57): error 30019: expected an expression of type 'GenericOuter<int>::GenericInner<int>', got 'GenericOuter<float>::GenericInner<float>'
+    a.g = b.g;
+           ^
+tests/diagnostics/mismatching-types.slang(59): error 30019: expected an expression of type 'GenericOuter<int>::NonGenericInner', got 'GenericOuter<float>::NonGenericInner'
+    a.ng = b.ng;
+            ^
+tests/diagnostics/mismatching-types.slang(61): error 30019: expected an expression of type 'NonGenericOuter::GenericInner<int>', got 'int'
+    c.i = 0;
+          ^
+tests/diagnostics/mismatching-types.slang(63): error 30019: expected an expression of type 'NonGenericOuter::GenericInner<int>', got 'NonGenericOuter::GenericInner<float>'
+    c.i = c.f;
+           ^
+tests/diagnostics/mismatching-types.slang(65): error 30019: expected an expression of type 'NonGenericOuter::GenericInner<int>::ReallyNested', got 'int'
+    c.i.n = 0;
+            ^
+tests/diagnostics/mismatching-types.slang(74): error 30019: expected an expression of type 'Texture1D<int>', got 'Texture1D<float>'
+    Texture1D<int> t1 = tex;
+                        ^~~
+tests/diagnostics/mismatching-types.slang(76): error 30019: expected an expression of type 'Texture2D<float>', got 'Texture1D<float>'
+    Texture2D<float> t2 = tex;
+                          ^~~
+}
+standard output = {
+}

--- a/tests/diagnostics/mismatching-types.slang.expected
+++ b/tests/diagnostics/mismatching-types.slang.expected
@@ -3,25 +3,25 @@ standard error = {
 tests/diagnostics/mismatching-types.slang(51): error 30019: expected an expression of type 'GenericOuter<int>', got 'int'
     a = 0;
         ^
-tests/diagnostics/mismatching-types.slang(53): error 30019: expected an expression of type 'GenericOuter<int>::GenericInner<int>', got 'int'
+tests/diagnostics/mismatching-types.slang(53): error 30019: expected an expression of type 'GenericOuter<int>.GenericInner<int>', got 'int'
     a.g = 0;
           ^
-tests/diagnostics/mismatching-types.slang(55): error 30019: expected an expression of type 'GenericOuter<int>::NonGenericInner', got 'int'
+tests/diagnostics/mismatching-types.slang(55): error 30019: expected an expression of type 'GenericOuter<int>.NonGenericInner', got 'int'
     a.ng = 0;
            ^
-tests/diagnostics/mismatching-types.slang(57): error 30019: expected an expression of type 'GenericOuter<int>::GenericInner<int>', got 'GenericOuter<float>::GenericInner<float>'
+tests/diagnostics/mismatching-types.slang(57): error 30019: expected an expression of type 'GenericOuter<int>.GenericInner<int>', got 'GenericOuter<float>.GenericInner<float>'
     a.g = b.g;
            ^
-tests/diagnostics/mismatching-types.slang(59): error 30019: expected an expression of type 'GenericOuter<int>::NonGenericInner', got 'GenericOuter<float>::NonGenericInner'
+tests/diagnostics/mismatching-types.slang(59): error 30019: expected an expression of type 'GenericOuter<int>.NonGenericInner', got 'GenericOuter<float>.NonGenericInner'
     a.ng = b.ng;
             ^
-tests/diagnostics/mismatching-types.slang(61): error 30019: expected an expression of type 'NonGenericOuter::GenericInner<int>', got 'int'
+tests/diagnostics/mismatching-types.slang(61): error 30019: expected an expression of type 'NonGenericOuter.GenericInner<int>', got 'int'
     c.i = 0;
           ^
-tests/diagnostics/mismatching-types.slang(63): error 30019: expected an expression of type 'NonGenericOuter::GenericInner<int>', got 'NonGenericOuter::GenericInner<float>'
+tests/diagnostics/mismatching-types.slang(63): error 30019: expected an expression of type 'NonGenericOuter.GenericInner<int>', got 'NonGenericOuter.GenericInner<float>'
     c.i = c.f;
            ^
-tests/diagnostics/mismatching-types.slang(65): error 30019: expected an expression of type 'NonGenericOuter::GenericInner<int>::ReallyNested', got 'int'
+tests/diagnostics/mismatching-types.slang(65): error 30019: expected an expression of type 'NonGenericOuter.GenericInner<int>.ReallyNested', got 'int'
     c.i.n = 0;
             ^
 tests/diagnostics/mismatching-types.slang(74): error 30019: expected an expression of type 'Texture1D<int>', got 'Texture1D<float>'

--- a/tests/doc/doc.slang.expected
+++ b/tests/doc/doc.slang.expected
@@ -49,7 +49,7 @@ A useless method hey ho
 ## Signature 
 
 ```
-ParentStruct::T ParentStruct<T>.ChildStruct<S>.getValue(ParentStruct<ParentStruct::T>::ChildStruct::S v);
+ParentStruct.T ParentStruct<T>.ChildStruct<S>.getValue(ParentStruct<ParentStruct.T>.ChildStruct.S v);
 ```
 
 ## Parameters
@@ -77,7 +77,7 @@ ParentStruct::T ParentStruct<T>.ChildStruct<S>.getValue(ParentStruct<ParentStruc
 ## Signature 
 
 ```
-GenericStruct::T GenericStruct<T>.getValue();
+GenericStruct.T GenericStruct<T>.getValue();
 ```
 
 --------------------------------------------------------------------------------
@@ -160,9 +160,9 @@ Add two integers
 ## Signature 
 
 ```
-IDoThing::V IDoThing.add(
-    IDoThing::V          a,
-    IDoThing::V          b);
+IDoThing.V IDoThing.add(
+    IDoThing.V           a,
+    IDoThing.V           b);
 ```
 
 ## Parameters

--- a/tests/doc/doc.slang.expected
+++ b/tests/doc/doc.slang.expected
@@ -49,7 +49,7 @@ A useless method hey ho
 ## Signature 
 
 ```
-T ParentStruct<T>.ChildStruct<S>.getValue(S v);
+ParentStruct::T ParentStruct<T>.ChildStruct<S>.getValue(ParentStruct<ParentStruct::T>::ChildStruct::S v);
 ```
 
 ## Parameters
@@ -77,7 +77,7 @@ T ParentStruct<T>.ChildStruct<S>.getValue(S v);
 ## Signature 
 
 ```
-T GenericStruct<T>.getValue();
+GenericStruct::T GenericStruct<T>.getValue();
 ```
 
 --------------------------------------------------------------------------------
@@ -120,7 +120,7 @@ void Hey::doAnotherThing(int a);
 # inputBuffer
 
 ```
-RWStructuredBuffer inputBuffer
+RWStructuredBuffer<int> inputBuffer
 ```
 
 ## Description
@@ -160,9 +160,9 @@ Add two integers
 ## Signature 
 
 ```
-V IDoThing.add(
-    V                    a,
-    V                    b);
+IDoThing::V IDoThing.add(
+    IDoThing::V          a,
+    IDoThing::V          b);
 ```
 
 ## Parameters
@@ -330,7 +330,7 @@ An enum
 # outputBuffer
 
 ```
-RWStructuredBuffer outputBuffer
+RWStructuredBuffer<int> outputBuffer
 ```
 
 ## Description


### PR DESCRIPTION
Improved the type printing function to include the generic substitutions and parent types.

See the new test `mismatching-types.slang` for examples.

Addresses the `resource.slang` example from https://github.com/shader-slang/slang/issues/2112