### PR TITLE
Fixed the mapping of the ray tracing instance functions to GLSL

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -4736,12 +4736,12 @@ uint RayFlags();
 
 // 10.4.3 - Primitive/Object Space System Values
 
-__target_intrinsic(GL_NV_ray_tracing, "(gl_InstanceCustomIndexNV)")
-__target_intrinsic(GL_EXT_ray_tracing, "(gl_InstanceCustomIndexEXT)")
+__target_intrinsic(__glslRayTracing, "(gl_InstanceID)")
 __target_intrinsic(cuda, "optixGetInstanceIndex")
 uint InstanceIndex();
 
-__target_intrinsic(__glslRayTracing, "(gl_InstanceID)")
+__target_intrinsic(GL_NV_ray_tracing, "(gl_InstanceCustomIndexNV)")
+__target_intrinsic(GL_EXT_ray_tracing, "(gl_InstanceCustomIndexEXT)")
 __target_intrinsic(cuda, "optixGetInstanceId")
 uint InstanceID();
 
@@ -5148,12 +5148,12 @@ struct RayQuery <let rayFlags : RAY_FLAG = RAY_FLAG_NONE>
     __glsl_version(460)
     float4x3 CandidateWorldToObject4x3();
 
-    __target_intrinsic(glsl, "rayQueryGetIntersectionInstanceCustomIndexEXT($0, false)")
+    __target_intrinsic(glsl, "rayQueryGetIntersectionInstanceIdEXT($0, false)")
     __glsl_extension(GL_EXT_ray_query)
     __glsl_version(460)
     uint CandidateInstanceIndex();
 
-    __target_intrinsic(glsl, "rayQueryGetIntersectionInstanceIdEXT($0, false)")
+    __target_intrinsic(glsl, "rayQueryGetIntersectionInstanceCustomIndexEXT($0, false)")
     __glsl_extension(GL_EXT_ray_query)
     __glsl_version(460)
     uint CandidateInstanceID();
@@ -5255,12 +5255,12 @@ struct RayQuery <let rayFlags : RAY_FLAG = RAY_FLAG_NONE>
     __glsl_version(460)
     float CommittedRayT();
 
-    __target_intrinsic(glsl, "rayQueryGetIntersectionInstanceCustomIndexEXT($0, true)")
+    __target_intrinsic(glsl, "rayQueryGetIntersectionInstanceIdEXT($0, true)")
     __glsl_extension(GL_EXT_ray_query)
     __glsl_version(460)
     uint CommittedInstanceIndex();
 
-    __target_intrinsic(glsl, "rayQueryGetIntersectionInstanceIdEXT($0, true)")
+    __target_intrinsic(glsl, "rayQueryGetIntersectionInstanceCustomIndexEXT($0, true)")
     __glsl_extension(GL_EXT_ray_query)
     __glsl_version(460)
     uint CommittedInstanceID();

--- a/tests/vkray/closesthit.slang
+++ b/tests/vkray/closesthit.slang
@@ -18,7 +18,7 @@ void main(
 	BuiltInTriangleIntersectionAttributes 	attributes,
 	in out ReflectionRay 					ioPayload)
 {
-	uint materialID = InstanceIndex()
+	uint materialID = (InstanceIndex() << 1)
 		+ InstanceID()
 		+ PrimitiveIndex()
 		+ HitKind()

--- a/tests/vkray/closesthit.slang.glsl
+++ b/tests/vkray/closesthit.slang.glsl
@@ -48,10 +48,12 @@ rayPayloadInNV ReflectionRay_0 tmp_payload;
 
 void main()
 {
-    uint tmp_customidx = gl_InstanceCustomIndexNV;
     uint tmp_instanceid = gl_InstanceID;
+    uint tmp_shift_0 = tmp_instanceid << 1;
 
-    uint tmp_add_0 = tmp_customidx + tmp_instanceid;
+    uint tmp_customidx = gl_InstanceCustomIndexNV;
+
+    uint tmp_add_0 = tmp_shift_0 + tmp_customidx;
     uint tmp_primid = gl_PrimitiveID;
 
     uint tmp_add_1 = tmp_add_0 + tmp_primid;


### PR DESCRIPTION
It is confusing, but HLSL (and by extension Slang) and GLSL define these functions in opposite ways.

In HLSL, `InstanceID` is the user-provided index coming from the TLAS instance descriptor, and `InstanceIndex` is the autogenerated index. 

[DXR spec for ray queries](https://microsoft.github.io/DirectX-Specs/d3d/Raytracing.html#rayquery-committedinstanceindex)
[DXR spec for ray pipelines](https://microsoft.github.io/DirectX-Specs/d3d/Raytracing.html#instanceindex)

In GLSL, `InstanceId` is the autogenerated index, and `InstanceCustomIndex` is the user-provided index. 

[GLSL spec for ray queries](https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_ray_query.txt)
[Vulkan spec for ray pipelines](https://www.khronos.org/registry/vulkan/specs/1.2-khr-extensions/html/chap15.html#VUID-InstanceCustomIndexKHR-InstanceCustomIndexKHR)

This applies both to ray query functions (candidate and committed) and to ray pipeline functions.

The OptiX mappings are correct.
[OptiX spec for ray pipelines](https://raytracing-docs.nvidia.com/optix7/api/group__optix__device__api.html#ga4d70272186506b1a5cb4813f1047021f)