### PR TITLE
GFX renaming work part 1

### DIFF
--- a/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj.filters
+++ b/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj.filters
@@ -9,14 +9,14 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\tools\gfx-unit-test\gfx-test-texture-util.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\tools\gfx-unit-test\gfx-test-util.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\tools\unit-test\slang-unit-test.h">
       <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\tools\gfx-unit-test\gfx-test-texture-util.h">
-      <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -56,6 +56,9 @@
     <ClCompile Include="..\..\..\tools\gfx-unit-test\get-texture-resource-handle-test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\tools\gfx-unit-test\gfx-test-texture-util.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\tools\gfx-unit-test\gfx-test-util.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -86,13 +89,10 @@
     <ClCompile Include="..\..\..\tools\gfx-unit-test\shared-textures-tests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\tools\unit-test\slang-unit-test.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\tools\gfx-unit-test\gfx-test-texture-util.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\tools\gfx-unit-test\texture-types-tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\tools\unit-test\slang-unit-test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -127,10 +127,10 @@
     <None Include="..\..\..\tools\gfx-unit-test\sampler-array.slang">
       <Filter>Source Files</Filter>
     </None>
-    <None Include="..\..\..\tools\gfx-unit-test\trivial-copy.slang">
+    <None Include="..\..\..\tools\gfx-unit-test\trivial-copy-textures.slang">
       <Filter>Source Files</Filter>
     </None>
-    <None Include="..\..\..\tools\gfx-unit-test\trivial-copy-textures.slang">
+    <None Include="..\..\..\tools\gfx-unit-test\trivial-copy.slang">
       <Filter>Source Files</Filter>
     </None>
   </ItemGroup>

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -31,6 +31,11 @@
 #undef Always
 #undef None
 
+// GLOBAL TODO: doc comments
+// GLOBAL TODO: Rationalize integer types (not a smush of uint/int/Uint/Int/etc)
+//    - need typedefs in gfx namespace for Count, Index, Size, Offset (ex. DeviceAddress)
+//    - Index and Count are for arrays, and indexing into array - like things(XY coordinates of pixels, etc.)
+//    - Offset and Size are almost always for bytes and things measured in bytes.
 namespace gfx {
 
 using Slang::ComPtr;
@@ -41,6 +46,10 @@ typedef SlangResult Result;
 typedef SlangInt Int;
 typedef SlangUInt UInt;
 typedef uint64_t DeviceAddress;
+typedef SlangInt Index;
+typedef SlangInt Count;
+typedef size_t Size;
+typedef size_t Offset;
 
 const uint64_t kTimeoutInfinite = 0xFFFFFFFFFFFFFFFF;
 
@@ -49,6 +58,7 @@ enum class StructType
     D3D12ExtendedDesc,
 };
 
+// TODO: Rename to Stage
 enum class StageType
 {
     Unknown,
@@ -69,6 +79,7 @@ enum class StageType
     CountOf,
 };
 
+// TODO: Implementation or backend or something else?
 enum class DeviceType
 {
     Unknown,
@@ -82,6 +93,7 @@ enum class DeviceType
     CountOf,
 };
 
+// TODO: Why does this exist it should go poof
 enum class ProjectionStyle
 {
     Unknown,
@@ -91,6 +103,7 @@ enum class ProjectionStyle
     CountOf,
 };
 
+// TODO: This should also go poof
 /// The style of the binding
 enum class BindingStyle
 {
@@ -103,6 +116,7 @@ enum class BindingStyle
     CountOf,
 };
 
+// TODO: Is this actually a flag when there are no bit fields?
 enum class AccessFlag
 {
     None,
@@ -110,6 +124,7 @@ enum class AccessFlag
     Write,
 };
 
+// TODO: Needed? Shouldn't be hard-coded if so
 const uint32_t kMaxRenderTargetCount = 8;
 
 class ITransientResourceHeap;
@@ -130,9 +145,11 @@ public:
 
     struct Desc
     {
+        // TODO: Tess doesn't like this but doesn't know what to do about it
         // The linking style of this program.
         LinkingStyle linkingStyle = LinkingStyle::SingleProgram;
 
+        // TODO: Remove slang prefix?
         // The global scope or a Slang composite component that represents the entire program.
         slang::IComponentType*  slangGlobalScope;
 
@@ -141,6 +158,7 @@ public:
         // If not 0, then `slangGlobalScope` must not contain any EntryPoint components.
         uint32_t entryPointCount = 0;
 
+        // TODO: Remove slang prefix?
         // An array of Slang entry points. The size of the array must be `entryPointCount`.
         // Each element must define only 1 Slang EntryPoint.
         slang::IComponentType** slangEntryPoints = nullptr;
@@ -151,6 +169,8 @@ public:
         0x9d32d0ad, 0x915c, 0x4ffd, { 0x91, 0xe2, 0x50, 0x85, 0x54, 0xa0, 0x4a, 0x76 } \
     }
 
+// TODO: Confirm with Yong that we really want this naming convention
+// TODO: Rename to what?
 // Dont' change without keeping in sync with Format
 #define GFX_FORMAT(x) \
     x( Unknown, 0, 0) \
@@ -253,6 +273,8 @@ public:
     x(BC7_UNORM, 16, 16) \
     x(BC7_UNORM_SRGB, 16, 16)
 
+// TODO: This should be generated from above
+// TODO: enum class should be explicitly uint32_t or whatever's appropriate
 /// Different formats of things like pixels or elements of vertices
 /// NOTE! Any change to this type (adding, removing, changing order) - must also be reflected in changes GFX_FORMAT
 enum class Format
@@ -360,11 +382,17 @@ enum class Format
     BC7_UNORM,
     BC7_UNORM_SRGB,
 
-    CountOf,
+    CountOf, // TODO: Rename to Count
 };
 
+// TODO: Aspect = Color, Depth, Stencil, etc.
+// TODO: Channel = R, G, B, A, D, S, etc.
+// TODO: Pick : pixel or texel
+// TODO: Block is a good term for what it is
+// TODO: Width/Height/Depth/whatever should not be used. We should use extentX, extentY, etc.
 struct FormatInfo
 {
+    // TODO: Change to uint32_t
     uint8_t channelCount;          ///< The amount of channels in the format. Only set if the channelType is set 
     uint8_t channelType;           ///< One of SlangScalarType None if type isn't made up of elements of type.
 
@@ -557,7 +585,7 @@ class IBufferResource: public IResource
 public:
     struct Desc: public DescBase
     {
-        size_t sizeInBytes = 0;     ///< Total size in bytes
+        Size sizeInBytes = 0;     ///< Total size in bytes
         int elementSize = 0;        ///< Get the element stride. If > 0, this is a structured buffer
         Format format = Format::Unknown;
     };
@@ -1008,7 +1036,7 @@ public:
 
 struct ShaderOffset
 {
-    SlangInt uniformOffset = 0;
+    SlangInt uniformOffset = 0; // TODO: Change to Offset?
     SlangInt bindingRangeIndex = 0;
     SlangInt bindingArrayIndex = 0;
     uint32_t getHashCode() const
@@ -1070,7 +1098,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
         getEntryPoint(UInt index, IShaderObject** entryPoint) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        setData(ShaderOffset const& offset, void const* data, size_t size) = 0;
+        setData(ShaderOffset const& offset, void const* data, Size size) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL
         getObject(ShaderOffset const& offset, IShaderObject** object) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL
@@ -1096,7 +1124,7 @@ public:
 
     virtual SLANG_NO_THROW const void* SLANG_MCALL getRawData() = 0;
 
-    virtual SLANG_NO_THROW size_t SLANG_MCALL getSize() = 0;
+    virtual SLANG_NO_THROW Size SLANG_MCALL getSize() = 0;
 
         /// Use the provided constant buffer instead of the internally created one.
     virtual SLANG_NO_THROW Result SLANG_MCALL setConstantBufferOverride(IBufferResource* constantBuffer) = 0;
@@ -1540,10 +1568,10 @@ class IResourceCommandEncoder : public ICommandEncoder
 public:
     virtual SLANG_NO_THROW void SLANG_MCALL copyBuffer(
         IBufferResource* dst,
-        size_t dstOffset,
+        Size dstOffset,
         IBufferResource* src,
-        size_t srcOffset,
-        size_t size) = 0;
+        Size srcOffset,
+        Size size) = 0;
 
     /// Copies texture from src to dst. If dstSubresource and srcSubresource has mipLevelCount = 0
     /// and layerCount = 0, the entire resource is being copied and dstOffset, srcOffset and extent
@@ -1562,9 +1590,9 @@ public:
     /// Copies texture to a buffer. Each row is aligned to kTexturePitchAlignment.
     virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
         IBufferResource* dst,
-        size_t dstOffset,
-        size_t dstSize,
-        size_t dstRowStride,
+        Size dstOffset,
+        Size dstSize,
+        Size dstRowStride,
         ITextureResource* src,
         ResourceState srcState,
         SubresourceRange srcSubresource,
@@ -1576,12 +1604,11 @@ public:
         ITextureResource::Offset3D offset,
         ITextureResource::Size extent,
         ITextureResource::SubresourceData* subResourceData,
-        size_t subResourceDataCount) = 0;
+        size_t subResourceDataCount) = 0; // TODO: Change size_t to Count?
     virtual SLANG_NO_THROW void SLANG_MCALL
-        uploadBufferData(IBufferResource* dst, size_t offset, size_t size, void* data) = 0;
-
+        uploadBufferData(IBufferResource* dst, Offset offset, Size size, void* data) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL textureBarrier(
-        size_t count, ITextureResource* const* textures, ResourceState src, ResourceState dst) = 0;
+        size_t count, ITextureResource* const* textures, ResourceState src, ResourceState dst) = 0; // TODO: Change size_t to Count?
     void textureBarrier(ITextureResource* texture, ResourceState src, ResourceState dst)
     {
         textureBarrier(1, &texture, src, dst);
@@ -1592,7 +1619,7 @@ public:
         ResourceState src,
         ResourceState dst) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL bufferBarrier(
-        size_t count, IBufferResource* const* buffers, ResourceState src, ResourceState dst) = 0;
+        size_t count, IBufferResource* const* buffers, ResourceState src, ResourceState dst) = 0; // TODO: Change size_t to Count?
     void bufferBarrier(IBufferResource* buffer, ResourceState src, ResourceState dst)
     {
         bufferBarrier(1, &buffer, src, dst);
@@ -1887,7 +1914,7 @@ public:
     struct Desc
     {
         Flags::Enum flags;
-        size_t constantBufferSize;
+        Size constantBufferSize;
         uint32_t samplerDescriptorCount;
         uint32_t uavDescriptorCount;
         uint32_t srvDescriptorCount;
@@ -2139,7 +2166,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL createTextureFromSharedHandle(
         InteropHandle handle,
         const ITextureResource::Desc& srcDesc,
-        const size_t size,
+        const Size size,
         ITextureResource** outResource) = 0;
 
         /// Create a buffer resource
@@ -2248,7 +2275,7 @@ public:
         return layout;
     }
 
-    inline Result createInputLayout(size_t vertexSize, InputElementDesc const* inputElements, Int inputElementCount, IInputLayout** outLayout)
+    inline Result createInputLayout(Size vertexSize, InputElementDesc const* inputElements, Int inputElementCount, IInputLayout** outLayout)
     {
         VertexStreamDesc streamDesc = { (uint32_t)vertexSize, InputSlotClass::PerVertex, 0 };
 
@@ -2260,7 +2287,7 @@ public:
         return createInputLayout(inputLayoutDesc, outLayout);
     }
 
-    inline ComPtr<IInputLayout> createInputLayout(size_t vertexSize, InputElementDesc const* inputElements, Int inputElementCount)
+    inline ComPtr<IInputLayout> createInputLayout(Size vertexSize, InputElementDesc const* inputElements, Int inputElementCount)
     {
         ComPtr<IInputLayout> layout;
         SLANG_RETURN_NULL_ON_FAIL(createInputLayout(vertexSize, inputElements, inputElementCount, layout.writeRef()));
@@ -2350,13 +2377,13 @@ public:
         ITextureResource* resource,
         ResourceState state,
         ISlangBlob** outBlob,
-        size_t* outRowPitch,
-        size_t* outPixelSize) = 0;
+        Size* outRowPitch,
+        Size* outPixelSize) = 0;
 
     virtual SLANG_NO_THROW SlangResult SLANG_MCALL readBufferResource(
         IBufferResource* buffer,
-        size_t offset,
-        size_t size,
+        Offset offset,
+        Size size,
         ISlangBlob** outBlob) = 0;
 
         /// Get the type of this renderer
@@ -2387,7 +2414,7 @@ public:
         uint64_t timeout) = 0;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureAllocationInfo(
-        const ITextureResource::Desc& desc, size_t* outSize, size_t* outAlignment) = 0;
+        const ITextureResource::Desc& desc, Size* outSize, size_t* outAlignment) = 0;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(size_t* outAlignment) = 0;
 };

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -46,8 +46,8 @@ typedef SlangResult Result;
 typedef SlangInt Int;
 typedef SlangUInt UInt;
 typedef uint64_t DeviceAddress;
-typedef SlangInt Index;
-typedef SlangInt Count;
+typedef int32_t GfxIndex;
+typedef int32_t GfxCount;
 typedef size_t Size;
 typedef size_t Offset;
 

--- a/tools/gfx-unit-test/copy-texture-tests.cpp
+++ b/tools/gfx-unit-test/copy-texture-tests.cpp
@@ -185,7 +185,7 @@ namespace gfx_test
             queue->waitOnHost();
         }
 
-        bool isWithinCopyBounds(int x, int y, int z)
+        bool isWithinCopyBounds(Int x, Int y, Int z)
         {
             auto copyExtents = texCopyInfo.extent;
             auto copyOffset = texCopyInfo.dstOffset;

--- a/tools/gfx-unit-test/texture-types-tests.cpp
+++ b/tools/gfx-unit-test/texture-types-tests.cpp
@@ -10,50 +10,11 @@
 #include <d3d12.h>
 #endif
 
-#include <stdlib.h>
-#include <stdio.h>
-
-#define STB_IMAGE_WRITE_IMPLEMENTATION
-#include "external/stb/stb_image_write.h"
-
 using namespace Slang;
 using namespace gfx;
 
 namespace gfx_test
 {
-    Slang::Result writeImage(
-        const char* filename,
-        ISlangBlob* pixels,
-        uint32_t width,
-        uint32_t height,
-        size_t rowPitch = 0)
-    {
-        int stbResult = 0;
-        if (rowPitch == 0)
-        {
-            stbResult = stbi_write_hdr(filename, width, height, 4, (float*)pixels->getBufferPointer());
-        }
-        else
-        {
-            List<float> data;
-            for (Int y = 0; y < height; ++y)
-            {
-                for (Int x = 0; x < width; ++x)
-                {
-                    for (Int c = 0; c < 4; ++c)
-                    {
-                        auto rowPtr = (char*)pixels->getBufferPointer() + y * rowPitch;
-                        auto channelPtr = (float*)rowPtr + x * 4 + c;
-                        data.add(*channelPtr);
-                    }
-                }
-            }
-            stbResult = stbi_write_hdr(filename, width, height, 4, data.getBuffer());
-        }
-
-        return stbResult ? SLANG_OK : SLANG_FAIL;
-    }
-
     struct BaseTextureViewTest
     {
         IDevice* device;
@@ -303,14 +264,14 @@ namespace gfx_test
                 ValidationTextureData textureResults;
                 textureResults.extents = textureInfo->extents;
                 textureResults.textureData = textureValues;
-                textureResults.strides.x = pixelSize;
-                textureResults.strides.y = rowPitch;
+                textureResults.strides.x = (uint32_t)pixelSize;
+                textureResults.strides.y = (uint32_t)rowPitch;
                 textureResults.strides.z = textureResults.extents.height * textureResults.strides.y;
 
                 ValidationTextureData originalData;
                 originalData.extents = textureInfo->extents;
                 originalData.textureData = textureInfo->subresourceDatas.getBuffer();
-                originalData.strides.x = pixelSize;
+                originalData.strides.x = (uint32_t)pixelSize;
                 originalData.strides.y = textureInfo->extents.width * originalData.strides.x;
                 originalData.strides.z = textureInfo->extents.height * originalData.strides.y;
 
@@ -530,9 +491,9 @@ namespace gfx_test
             auto rootObject = renderEncoder->bindPipeline(pipelineState);
 
             gfx::Viewport viewport = {};
-            viewport.maxZ = textureInfo->extents.depth;
-            viewport.extentX = textureInfo->extents.width;
-            viewport.extentY = textureInfo->extents.height;
+            viewport.maxZ = (float)textureInfo->extents.depth;
+            viewport.extentX = (float)textureInfo->extents.width;
+            viewport.extentY = (float)textureInfo->extents.height;
             renderEncoder->setViewportAndScissor(viewport);
 
             renderEncoder->setVertexBuffer(0, vertexBuffer);
@@ -617,8 +578,8 @@ namespace gfx_test
             ValidationTextureData textureResults;
             textureResults.extents = textureInfo->extents;
             textureResults.textureData = textureValues;
-            textureResults.strides.x = pixelSize;
-            textureResults.strides.y = rowPitch;
+            textureResults.strides.x = (uint32_t)pixelSize;
+            textureResults.strides.y = (uint32_t)rowPitch;
             textureResults.strides.z = textureResults.extents.height * textureResults.strides.y;
 
             validateTextureValues(textureResults);

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -377,7 +377,7 @@ Result initTextureResourceDesc(
     return SLANG_OK;
 }
 
-void initBufferResourceDesc(size_t bufferSize, D3D12_RESOURCE_DESC& out)
+void initBufferResourceDesc(Size bufferSize, D3D12_RESOURCE_DESC& out)
 {
     out = {};
 
@@ -399,12 +399,12 @@ Result uploadBufferDataImpl(
     ID3D12GraphicsCommandList* cmdList,
     TransientResourceHeapImpl* transientHeap,
     BufferResourceImpl* buffer,
-    size_t offset,
-    size_t size,
+    Offset offset,
+    Size size,
     void* data)
 {
     IBufferResource* uploadResource;
-    size_t uploadResourceOffset = 0;
+    Offset uploadResourceOffset = 0;
     if (buffer->getDesc()->memoryType != MemoryType::Upload)
     {
         SLANG_RETURN_ON_FAIL(transientHeap->allocateStagingBuffer(
@@ -542,13 +542,13 @@ Result createNullDescriptor(
 Result DeviceImpl::createBuffer(
     const D3D12_RESOURCE_DESC& resourceDesc,
     const void* srcData,
-    size_t srcDataSize,
+    Size srcDataSize,
     D3D12_RESOURCE_STATES finalState,
     D3D12Resource& resourceOut,
     bool isShared,
     MemoryType memoryType)
 {
-    const size_t bufferSize = size_t(resourceDesc.Width);
+    const Size bufferSize = Size(resourceDesc.Width);
 
     D3D12_HEAP_PROPERTIES heapProps;
     heapProps.CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN;
@@ -645,8 +645,8 @@ Result DeviceImpl::captureTextureToSurface(
     TextureResourceImpl* resourceImpl,
     ResourceState state,
     ISlangBlob** outBlob,
-    size_t* outRowPitch,
-    size_t* outPixelSize)
+    Size* outRowPitch,
+    Size* outPixelSize)
 {
     auto& resource = resourceImpl->m_resource;
 
@@ -664,11 +664,11 @@ Result DeviceImpl::captureTextureToSurface(
 
     FormatInfo formatInfo;
     gfxGetFormatInfo(gfxDesc.format, &formatInfo);
-    size_t bytesPerPixel = formatInfo.blockSizeInBytes / formatInfo.pixelsPerBlock;
-    size_t rowPitch = int(desc.Width) * bytesPerPixel;
-    static const size_t align = 256; // D3D requires minimum 256 byte alignment for texture data.
+    Size bytesPerPixel = formatInfo.blockSizeInBytes / formatInfo.pixelsPerBlock;
+    Size rowPitch = int(desc.Width) * bytesPerPixel;
+    static const Size align = 256; // D3D requires minimum 256 byte alignment for texture data.
     rowPitch = (rowPitch + align - 1) & ~(align - 1); // Bit trick for rounding up
-    size_t bufferSize = rowPitch * int(desc.Height) * int(desc.DepthOrArraySize);
+    Size bufferSize = rowPitch * int(desc.Height) * int(desc.DepthOrArraySize);
     if (outRowPitch)
         *outRowPitch = rowPitch;
     if (outPixelSize)
@@ -1342,26 +1342,26 @@ SlangResult DeviceImpl::readTextureResource(
     ITextureResource* resource,
     ResourceState state,
     ISlangBlob** outBlob,
-    size_t* outRowPitch,
-    size_t* outPixelSize)
+    Size* outRowPitch,
+    Size* outPixelSize)
 {
     return captureTextureToSurface(
         static_cast<TextureResourceImpl*>(resource), state, outBlob, outRowPitch, outPixelSize);
 }
 
 Result DeviceImpl::getTextureAllocationInfo(
-    const ITextureResource::Desc& desc, size_t* outSize, size_t* outAlignment)
+    const ITextureResource::Desc& desc, Size* outSize, Size* outAlignment)
 {
     TextureResource::Desc srcDesc = fixupTextureDesc(desc);
     D3D12_RESOURCE_DESC resourceDesc = {};
     initTextureResourceDesc(resourceDesc, srcDesc);
     auto allocInfo = m_device->GetResourceAllocationInfo(0, 1, &resourceDesc);
-    *outSize = (size_t)allocInfo.SizeInBytes;
-    *outAlignment = (size_t)allocInfo.Alignment;
+    *outSize = (Size)allocInfo.SizeInBytes;
+    *outAlignment = (Size)allocInfo.Alignment;
     return SLANG_OK;
 }
 
-Result DeviceImpl::getTextureRowAlignment(size_t* outAlignment)
+Result DeviceImpl::getTextureRowAlignment(Size* outAlignment)
 {
     *outAlignment = D3D12_TEXTURE_DATA_PITCH_ALIGNMENT;
     return SLANG_OK;
@@ -1534,7 +1534,7 @@ Result DeviceImpl::createTextureResource(
                                 : 1; // BC compressed formats are organized into 4x4 blocks
                     for (int k = 0; k < mipSize.height; k += j)
                     {
-                        ::memcpy(dstRow, srcRow, (size_t)mipRowSize);
+                        ::memcpy(dstRow, srcRow, (Size)mipRowSize);
 
                         srcRow += srcMipRowPitch;
                         dstRow += dstMipRowPitch;
@@ -2155,7 +2155,7 @@ Result DeviceImpl::createInputLayout(IInputLayout::Desc const& desc, IInputLayou
     RefPtr<InputLayoutImpl> layout(new InputLayoutImpl);
 
     // Work out a buffer size to hold all text
-    size_t textSize = 0;
+    Size textSize = 0;
     auto inputElementCount = desc.inputElementCount;
     auto inputElements = desc.inputElements;
     auto vertexStreamCount = desc.vertexStreamCount;
@@ -2210,12 +2210,12 @@ Result DeviceImpl::createInputLayout(IInputLayout::Desc const& desc, IInputLayou
 const gfx::DeviceInfo& DeviceImpl::getDeviceInfo() const { return m_info; }
 
 Result DeviceImpl::readBufferResource(
-    IBufferResource* bufferIn, size_t offset, size_t size, ISlangBlob** outBlob)
+    IBufferResource* bufferIn, Offset offset, Size size, ISlangBlob** outBlob)
 {
 
     BufferResourceImpl* buffer = static_cast<BufferResourceImpl*>(bufferIn);
 
-    const size_t bufferSize = buffer->getDesc()->sizeInBytes;
+    const Size bufferSize = buffer->getDesc()->sizeInBytes;
 
     // This will be slow!!! - it blocks CPU on GPU completion
     D3D12Resource& resource = buffer->m_resource;
@@ -2500,7 +2500,7 @@ Result DeviceImpl::createRayTracingPipelineState(
 
 Result DeviceImpl::createTransientResourceHeapImpl(
     ITransientResourceHeap::Flags::Enum flags,
-    size_t constantBufferSize,
+    Size constantBufferSize,
     uint32_t viewDescriptors,
     uint32_t samplerDescriptors,
     TransientResourceHeapImpl** outHeap)
@@ -3256,7 +3256,7 @@ Result PlainBufferProxyQueryPoolImpl::getResult(SlangInt queryIndex, SlangInt co
 
         D3D12Resource stageBuf;
 
-        auto size = (size_t)m_count * m_stride;
+        auto size = (Size)m_count * m_stride;
         D3D12_HEAP_PROPERTIES heapProps;
         heapProps.Type = D3D12_HEAP_TYPE_READBACK;
         heapProps.CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN;
@@ -3679,8 +3679,10 @@ Result ShaderObjectImpl::getEntryPoint(UInt index, IShaderObject** outEntryPoint
 
 const void* ShaderObjectImpl::getRawData() { return m_data.getBuffer(); }
 
+// TODO: Change to Count?
 size_t ShaderObjectImpl::getSize() { return (size_t)m_data.getCount(); }
 
+// TODO: Change Index to Offset/Size?
 Result ShaderObjectImpl::setData(ShaderOffset const& inOffset, void const* data, size_t inSize)
 {
     Index offset = inOffset.uniformOffset;
@@ -3880,12 +3882,12 @@ Result ShaderObjectImpl::init(
 Result ShaderObjectImpl::_writeOrdinaryData(
     PipelineCommandEncoder* encoder,
     BufferResourceImpl* buffer,
-    size_t offset,
-    size_t destSize,
+    Offset offset,
+    Size destSize,
     ShaderObjectLayoutImpl* specializedLayout)
 {
     auto src = m_data.getBuffer();
-    auto srcSize = size_t(m_data.getCount());
+    auto srcSize = Size(m_data.getCount());
 
     SLANG_ASSERT(srcSize <= destSize);
 
@@ -3952,8 +3954,8 @@ Result ShaderObjectImpl::_writeOrdinaryData(
         // layout logic does for complex cases with multiple layers of nested arrays and
         // structures.
         //
-        size_t subObjectRangePendingDataOffset = subObjectRangeInfo.offset.pendingOrdinaryData;
-        size_t subObjectRangePendingDataStride = subObjectRangeInfo.stride.pendingOrdinaryData;
+        Offset subObjectRangePendingDataOffset = subObjectRangeInfo.offset.pendingOrdinaryData;
+        Size subObjectRangePendingDataStride = subObjectRangeInfo.stride.pendingOrdinaryData;
 
         // If the range doesn't actually need/use the "pending" allocation at all, then
         // we need to detect that case and skip such ranges.
@@ -6337,7 +6339,7 @@ RefPtr<BufferResource> ShaderTableImpl::createDeviceBuffer(
         static_cast<TransientResourceHeapImpl*>(transientHeap);
 
     IBufferResource* stagingBuffer = nullptr;
-    size_t stagingBufferOffset = 0;
+    Offset stagingBufferOffset = 0;
     transientHeapImpl->allocateStagingBuffer(
         tableSize, stagingBuffer, stagingBufferOffset, MemoryType::Upload);
 
@@ -6492,7 +6494,7 @@ void CommandBufferImpl::encodeRayTracingCommands(IRayTracingCommandEncoder** out
 void CommandBufferImpl::close() { m_cmdList->Close(); }
 
 void ResourceCommandEncoderImpl::copyBuffer(
-    IBufferResource* dst, size_t dstOffset, IBufferResource* src, size_t srcOffset, size_t size)
+    IBufferResource* dst, Offset dstOffset, IBufferResource* src, Offset srcOffset, Size size)
 {
     auto dstBuffer = static_cast<BufferResourceImpl*>(dst);
     auto srcBuffer = static_cast<BufferResourceImpl*>(src);
@@ -6506,7 +6508,7 @@ void ResourceCommandEncoderImpl::copyBuffer(
 }
 
 void ResourceCommandEncoderImpl::uploadBufferData(
-    IBufferResource* dst, size_t offset, size_t size, void* data)
+    IBufferResource* dst, Offset offset, Size size, void* data)
 {
     uploadBufferDataImpl(
         m_commandBuffer->m_renderer->m_device,
@@ -6518,6 +6520,7 @@ void ResourceCommandEncoderImpl::uploadBufferData(
         data);
 }
 
+// TODO: Change size_t to Count?
 void ResourceCommandEncoderImpl::textureBarrier(
     size_t count, ITextureResource* const* textures, ResourceState src, ResourceState dst)
 {
@@ -6559,6 +6562,7 @@ void ResourceCommandEncoderImpl::textureBarrier(
     }
 }
 
+// TODO: Change size_t to Count?
 void ResourceCommandEncoderImpl::bufferBarrier(
     size_t count, IBufferResource* const* buffers, ResourceState src, ResourceState dst)
 {
@@ -6672,6 +6676,7 @@ void ResourceCommandEncoderImpl::copyTexture(
     }
 }
 
+// TODO: Change size_t to Count?
 void ResourceCommandEncoderImpl::uploadTextureData(
     ITextureResource* dst,
     SubresourceRange subResourceRange,
@@ -6743,7 +6748,7 @@ void ResourceCommandEncoderImpl::uploadTextureData(
         auto bufferSize = footprint.Footprint.RowPitch * rowCount * footprint.Footprint.Depth;
 
         IBufferResource* stagingBuffer;
-        size_t stagingBufferOffset = 0;
+        Offset stagingBufferOffset = 0;
         m_commandBuffer->m_transientHeap->allocateStagingBuffer(
             bufferSize, stagingBuffer, stagingBufferOffset, MemoryType::Upload, true);
         assert(stagingBufferOffset == 0);
@@ -6753,12 +6758,12 @@ void ResourceCommandEncoderImpl::uploadTextureData(
         bufferImpl->m_resource.getResource()->Map(0, &mapRange, (void**)&bufferData);
         for (uint32_t z = 0; z < footprint.Footprint.Depth; z++)
         {
-            auto imageStart = bufferData + footprint.Footprint.RowPitch * rowCount * (size_t)z;
+            auto imageStart = bufferData + footprint.Footprint.RowPitch * rowCount * (Size)z;
             auto srcData = (uint8_t*)subResourceData->data + subResourceData->strideZ * z;
             for (uint32_t row = 0; row < rowCount; row++)
             {
                 memcpy(
-                    imageStart + row * (size_t)footprint.Footprint.RowPitch,
+                    imageStart + row * (Size)footprint.Footprint.RowPitch,
                     srcData + subResourceData->strideY * row,
                     rowSize);
             }
@@ -6953,9 +6958,9 @@ void ResourceCommandEncoderImpl::resolveQuery(
 
 void ResourceCommandEncoderImpl::copyTextureToBuffer(
     IBufferResource* dst,
-    size_t dstOffset,
-    size_t dstSize,
-    size_t dstRowStride,
+    Offset dstOffset,
+    Size dstSize,
+    Size dstRowStride,
     ITextureResource* src,
     ResourceState srcState,
     SubresourceRange srcSubresource,

--- a/tools/gfx/d3d12/render-d3d12.h
+++ b/tools/gfx/d3d12/render-d3d12.h
@@ -134,8 +134,8 @@ public:
         const ISwapchain::Desc& desc, WindowHandle window, ISwapchain** outSwapchain) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureAllocationInfo(
-        const ITextureResource::Desc& desc, size_t* outSize, size_t* outAlignment) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(size_t* outAlignment) override;
+        const ITextureResource::Desc& desc, Size* outSize, Size* outAlignment) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(Size* outAlignment) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createTextureResource(
         const ITextureResource::Desc& desc,
         const ITextureResource::SubresourceData* initData,
@@ -215,11 +215,11 @@ public:
         ITextureResource* resource,
         ResourceState state,
         ISlangBlob** outBlob,
-        size_t* outRowPitch,
-        size_t* outPixelSize) override;
+        Size* outRowPitch,
+        Size* outPixelSize) override;
 
     virtual SLANG_NO_THROW SlangResult SLANG_MCALL readBufferResource(
-        IBufferResource* resource, size_t offset, size_t size, ISlangBlob** outBlob) override;
+        IBufferResource* resource, Offset offset, Size size, ISlangBlob** outBlob) override;
 
     virtual SLANG_NO_THROW const gfx::DeviceInfo& SLANG_MCALL getDeviceInfo() const override;
 
@@ -243,7 +243,7 @@ public:
 
     Result createTransientResourceHeapImpl(
         ITransientResourceHeap::Flags::Enum flags,
-        size_t constantBufferSize,
+        Size constantBufferSize,
         uint32_t viewDescriptors,
         uint32_t samplerDescriptors,
         TransientResourceHeapImpl** outHeap);
@@ -251,7 +251,7 @@ public:
     Result createBuffer(
         const D3D12_RESOURCE_DESC& resourceDesc,
         const void* srcData,
-        size_t srcDataSize,
+        Size srcDataSize,
         D3D12_RESOURCE_STATES finalState,
         D3D12Resource& resourceOut,
         bool isShared,
@@ -261,8 +261,8 @@ public:
         TextureResourceImpl* resource,
         ResourceState state,
         ISlangBlob** blob,
-        size_t* outRowPitch,
-        size_t* outPixelSize);
+        Size* outRowPitch,
+        Size* outPixelSize);
 
     Result _createDevice(
         DeviceCheckFlags deviceCheckFlags,
@@ -1187,10 +1187,11 @@ public:
 
     virtual SLANG_NO_THROW const void* SLANG_MCALL getRawData() override;
 
+    // TODO: Change size_t to Count?
     virtual SLANG_NO_THROW size_t SLANG_MCALL getSize() override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        setData(ShaderOffset const& inOffset, void const* data, size_t inSize) override;
+        setData(ShaderOffset const& inOffset, void const* data, Size inSize) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
         setObject(ShaderOffset const& offset, IShaderObject* object) override;
 
@@ -1215,8 +1216,8 @@ protected:
     Result _writeOrdinaryData(
         PipelineCommandEncoder* encoder,
         BufferResourceImpl* buffer,
-        size_t offset,
-        size_t destSize,
+        Offset offset,
+        Size destSize,
         ShaderObjectLayoutImpl* specializedLayout);
 
     bool shouldAllocateConstantBuffer(TransientResourceHeapImpl* transientHeap);
@@ -1288,8 +1289,8 @@ public:
     ///
     /// Allocated from transient heap on demand with `_createOrdinaryDataBufferIfNeeded()`
     IBufferResource* m_constantBufferWeakPtr = nullptr;
-    size_t m_constantBufferOffset = 0;
-    size_t m_constantBufferSize = 0;
+    Offset m_constantBufferOffset = 0;
+    Size m_constantBufferSize = 0;
 
     /// Dirty bit tracking whether the constant buffer needs to be updated.
     bool m_isConstantBufferDirty = true;
@@ -1397,19 +1398,19 @@ class ResourceCommandEncoderImpl
 public:
     virtual SLANG_NO_THROW void SLANG_MCALL copyBuffer(
         IBufferResource* dst,
-        size_t dstOffset,
+        Offset dstOffset,
         IBufferResource* src,
-        size_t srcOffset,
-        size_t size) override;
+        Offset srcOffset,
+        Size size) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        uploadBufferData(IBufferResource* dst, size_t offset, size_t size, void* data) override;
+        uploadBufferData(IBufferResource* dst, Offset offset, Size size, void* data) override;
     virtual SLANG_NO_THROW void SLANG_MCALL textureBarrier(
-        size_t count,
+        size_t count, // TODO: Change size_t to Count?
         ITextureResource* const* textures,
         ResourceState src,
         ResourceState dst) override;
     virtual SLANG_NO_THROW void SLANG_MCALL bufferBarrier(
-        size_t count,
+        size_t count, // TODO: Change size_t to Count?
         IBufferResource* const* buffers,
         ResourceState src,
         ResourceState dst) override;
@@ -1433,7 +1434,7 @@ public:
         ITextureResource::Offset3D offset,
         ITextureResource::Size extent,
         ITextureResource::SubresourceData* subResourceData,
-        size_t subResourceDataCount) override;
+        size_t subResourceDataCount) override; // TODO: Change size_t to Count?
 
     virtual SLANG_NO_THROW void SLANG_MCALL clearResourceView(
         IResourceView* view, ClearValue* clearValue, ClearResourceViewFlags::Enum flags) override;
@@ -1455,9 +1456,9 @@ public:
 
     virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
         IBufferResource* dst,
-        size_t dstOffset,
-        size_t dstSize,
-        size_t dstRowStride,
+        Offset dstOffset,
+        Size dstSize,
+        Size dstRowStride,
         ITextureResource* src,
         ResourceState srcState,
         SubresourceRange srcSubresource,

--- a/tools/gfx/renderer-shared.cpp
+++ b/tools/gfx/renderer-shared.cpp
@@ -408,7 +408,7 @@ SLANG_NO_THROW Result SLANG_MCALL RendererBase::createTextureFromNativeHandle(
 SLANG_NO_THROW Result SLANG_MCALL RendererBase::createTextureFromSharedHandle(
     InteropHandle handle,
     const ITextureResource::Desc& srcDesc,
-    const size_t size,
+    const Size size,
     ITextureResource** outResource)
 {
     SLANG_UNUSED(handle);
@@ -535,7 +535,7 @@ Result RendererBase::waitForFences(
 }
 
 Result RendererBase::getTextureAllocationInfo(
-    const ITextureResource::Desc& desc, size_t* outSize, size_t* outAlignment)
+    const ITextureResource::Desc& desc, Size* outSize, Size* outAlignment)
 {
     SLANG_UNUSED(desc);
     *outSize = 0;
@@ -543,7 +543,7 @@ Result RendererBase::getTextureAllocationInfo(
     return SLANG_E_NOT_AVAILABLE;
 }
 
-Result RendererBase::getTextureRowAlignment(size_t* outAlignment)
+Result RendererBase::getTextureRowAlignment(Size* outAlignment)
 {
     *outAlignment = 0;
     return SLANG_E_NOT_AVAILABLE;
@@ -743,7 +743,7 @@ ResourceViewBase* SimpleShaderObjectData::getResourceView(
         desc.elementSize = (int)elementLayout->getSize();
         desc.format = Format::Unknown;
         desc.type = IResource::Type::Buffer;
-        desc.sizeInBytes = (size_t)m_ordinaryData.getCount();
+        desc.sizeInBytes = (Size)m_ordinaryData.getCount();
         ComPtr<IBufferResource> bufferResource;
         SLANG_RETURN_NULL_ON_FAIL(device->createBufferResource(
             desc, m_ordinaryData.getBuffer(), bufferResource.writeRef()));
@@ -1013,7 +1013,7 @@ Result ShaderObjectBase::copyFrom(IShaderObject* object, ITransientResourceHeap*
 {
     if (auto srcObj = dynamic_cast<MutableRootShaderObject*>(object))
     {
-        setData(gfx::ShaderOffset(), srcObj->m_data.begin(), (size_t)srcObj->m_data.getCount());
+        setData(gfx::ShaderOffset(), srcObj->m_data.begin(), (size_t)srcObj->m_data.getCount()); // TODO: Change size_t to Count?
         for (auto& kv : srcObj->m_objects)
         {
             ComPtr<IShaderObject> subObject;

--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -578,7 +578,7 @@ public:
     }
 
     void* getBuffer() { return m_data.getBuffer(); }
-    size_t getBufferSize() { return (size_t)m_data.getCount(); }
+    size_t getBufferSize() { return (size_t)m_data.getCount(); } // TODO: Change size_t to Count?
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
         getObject(ShaderOffset const& offset, IShaderObject** outObject) SLANG_OVERRIDE
@@ -663,7 +663,7 @@ public:
             SLANG_RETURN_ON_FAIL(setData(
                 payloadOffset,
                 subObject->m_data.getBuffer(),
-                (size_t)subObject->m_data.getCount()));
+                (size_t)subObject->m_data.getCount())); // TODO: Change size_t to Count?
 
             setSpecializationArgsForContainerElement(specializationArgs);
             return SLANG_OK;
@@ -1223,7 +1223,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL createTextureFromSharedHandle(
         InteropHandle handle,
         const ITextureResource::Desc& srcDesc,
-        const size_t size,
+        const Size size,
         ITextureResource** outResource) SLANG_OVERRIDE;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL createBufferFromNativeHandle(
@@ -1288,7 +1288,7 @@ public:
 
     // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE.
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureAllocationInfo(
-        const ITextureResource::Desc& desc, size_t* outSize, size_t* outAlignment) override;
+        const ITextureResource::Desc& desc, Size* outSize, Size* outAlignment) override;
 
     // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE.
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(size_t* outAlignment) override;

--- a/tools/gfx/vulkan/render-vk.h
+++ b/tools/gfx/vulkan/render-vk.h
@@ -104,11 +104,11 @@ public:
         ITextureResource* texture,
         ResourceState state,
         ISlangBlob** outBlob,
-        size_t* outRowPitch,
-        size_t* outPixelSize) override;
+        Size* outRowPitch,
+        Size* outPixelSize) override;
 
     virtual SLANG_NO_THROW SlangResult SLANG_MCALL readBufferResource(
-        IBufferResource* buffer, size_t offset, size_t size, ISlangBlob** outBlob) override;
+        IBufferResource* buffer, Offset offset, Size size, ISlangBlob** outBlob) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getAccelerationStructurePrebuildInfo(
         const IAccelerationStructure::BuildInputs& buildInputs,
@@ -118,9 +118,9 @@ public:
         const IAccelerationStructure::CreateDesc& desc, IAccelerationStructure** outView) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureAllocationInfo(
-        const ITextureResource::Desc& desc, size_t* outSize, size_t* outAlignment) override;
+        const ITextureResource::Desc& desc, Size* outSize, Size* outAlignment) override;
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(size_t* outAlignment) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(Size* outAlignment) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
         createFence(const IFence::Desc& desc, IFence** outFence) override;
@@ -146,7 +146,7 @@ public:
         VkDebugReportFlagsEXT flags,
         VkDebugReportObjectTypeEXT objType,
         uint64_t srcObject,
-        size_t location,
+        Size location, // TODO: Is "location" still needed for this function?
         int32_t msgCode,
         const char* pLayerPrefix,
         const char* pMsg);
@@ -155,7 +155,7 @@ public:
         VkDebugReportFlagsEXT flags,
         VkDebugReportObjectTypeEXT objType,
         uint64_t srcObject,
-        size_t location,
+        Size location, // TODO: Is "location" still needed? Calls handleDebugMessage() which doesn't use it
         int32_t msgCode,
         const char* pLayerPrefix,
         const char* pMsg,
@@ -222,7 +222,7 @@ public:
     /// Initialize a buffer with specified size, and memory props
     Result init(
         const VulkanApi& api,
-        size_t bufferSize,
+        Size bufferSize,
         VkBufferUsageFlags usage,
         VkMemoryPropertyFlags reqMemoryProperties,
         bool isShared = false,
@@ -1073,11 +1073,11 @@ public:
         VkCommandBuffer commandBuffer,
         TransientResourceHeapImpl* transientHeap,
         BufferResourceImpl* buffer,
-        size_t offset,
-        size_t size,
+        Offset offset,
+        Size size,
         void* data);
 
-    void uploadBufferDataImpl(IBufferResource* buffer, size_t offset, size_t size, void* data);
+    void uploadBufferDataImpl(IBufferResource* buffer, Offset offset, Size size, void* data);
 
     Result bindRootShaderObjectImpl(VkPipelineBindPoint bindPoint);
 
@@ -1132,8 +1132,10 @@ public:
 
     virtual SLANG_NO_THROW const void* SLANG_MCALL getRawData() override;
 
+    // TODO: Change size_t to Count?
     virtual SLANG_NO_THROW size_t SLANG_MCALL getSize() override;
 
+    // TODO: Changed size_t to Size? inSize assigned to an Index variable inside implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL
         setData(ShaderOffset const& inOffset, void const* data, size_t inSize) override;
 
@@ -1156,8 +1158,8 @@ protected:
     Result _writeOrdinaryData(
         PipelineCommandEncoder* encoder,
         IBufferResource* buffer,
-        size_t offset,
-        size_t destSize,
+        Offset offset,
+        Size destSize,
         ShaderObjectLayoutImpl* specializedLayout);
 
 public:
@@ -1169,8 +1171,8 @@ public:
         BindingOffset const& offset,
         VkDescriptorType descriptorType,
         BufferResourceImpl* buffer,
-        size_t bufferOffset,
-        size_t bufferSize);
+        Offset bufferOffset,
+        Size bufferSize);
 
     static void writeBufferDescriptor(
         RootBindingContext& context,
@@ -1272,8 +1274,8 @@ public:
     // weak referenced.
     IBufferResource* m_constantBuffer = nullptr;
     // The offset into the transient constant buffer where the constant data starts.
-    size_t m_constantBufferOffset = 0;
-    size_t m_constantBufferSize = 0;
+    Offset m_constantBufferOffset = 0;
+    Size m_constantBufferSize = 0;
 
     /// Dirty bit tracking whether the constant buffer needs to be updated.
     bool m_isConstantBufferDirty = true;
@@ -1386,19 +1388,19 @@ class ResourceCommandEncoder
 public:
     virtual SLANG_NO_THROW void SLANG_MCALL copyBuffer(
         IBufferResource* dst,
-        size_t dstOffset,
+        Offset dstOffset,
         IBufferResource* src,
-        size_t srcOffset,
-        size_t size) override;
+        Offset srcOffset,
+        Size size) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        uploadBufferData(IBufferResource* buffer, size_t offset, size_t size, void* data) override;
+        uploadBufferData(IBufferResource* buffer, Offset offset, Size size, void* data) override;
     virtual SLANG_NO_THROW void SLANG_MCALL textureBarrier(
-        size_t count,
+        size_t count, // TODO: Change size_t to Count?
         ITextureResource* const* textures,
         ResourceState src,
         ResourceState dst) override;
     virtual SLANG_NO_THROW void SLANG_MCALL bufferBarrier(
-        size_t count,
+        size_t count, // TODO: Change size_t to Count?
         IBufferResource* const* buffers,
         ResourceState src,
         ResourceState dst) override;
@@ -1426,7 +1428,7 @@ public:
         ITextureResource::Offset3D offset,
         ITextureResource::Size extend,
         ITextureResource::SubresourceData* subResourceData,
-        size_t subResourceDataCount) override;
+        size_t subResourceDataCount) override; // TODO: Change size_t to Count?
 
     void _clearColorImage(TextureResourceViewImpl* viewImpl, ClearValue* clearValue);
 
@@ -1458,9 +1460,9 @@ public:
 
     virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
         IBufferResource* dst,
-        size_t dstOffset,
-        size_t dstSize,
-        size_t dstRowStride,
+        Offset dstOffset,
+        Size dstSize,
+        Size dstRowStride,
         ITextureResource* src,
         ResourceState srcState,
         SubresourceRange srcSubresource,


### PR DESCRIPTION
Changes:
- Added new typdefs `Size`, `Offset`, `GfxCount`, and `GfxIndex` to `slang-gfx.h` (distinctions for gfx made to avoid conflict with otherwise similarly named typedefs in Slang)
- Replaced numerous instances of `size_t` in `slang-gfx.h`, `render-d3d12.h/cpp`, `render-vk.h/cpp` and `renderer-shared.h/cpp` with `Size`/`Offset` where appropriate
- Fixed numerical conversion warnings in `texture-types-tests.cpp` and `copy-texture-tests.cpp`

@csyonghe @tangent-vector Checkpoint PR, mostly. Lots of renames to go through so the more eyes checking I haven't missed any size/offset `size_t`s, the better