### PR TITLE
Make translation units in the same CompileReq visible to `import`.

### DIFF
--- a/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj.filters
+++ b/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj.filters
@@ -9,14 +9,14 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\tools\gfx-unit-test\gfx-test-texture-util.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\tools\gfx-unit-test\gfx-test-util.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\tools\unit-test\slang-unit-test.h">
       <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\tools\gfx-unit-test\gfx-test-texture-util.h">
-      <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -56,6 +56,9 @@
     <ClCompile Include="..\..\..\tools\gfx-unit-test\get-texture-resource-handle-test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\tools\gfx-unit-test\gfx-test-texture-util.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\tools\gfx-unit-test\gfx-test-util.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -86,13 +89,10 @@
     <ClCompile Include="..\..\..\tools\gfx-unit-test\shared-textures-tests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\tools\unit-test\slang-unit-test.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\tools\gfx-unit-test\gfx-test-texture-util.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\tools\gfx-unit-test\texture-types-tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\tools\unit-test\slang-unit-test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -127,10 +127,10 @@
     <None Include="..\..\..\tools\gfx-unit-test\sampler-array.slang">
       <Filter>Source Files</Filter>
     </None>
-    <None Include="..\..\..\tools\gfx-unit-test\trivial-copy.slang">
+    <None Include="..\..\..\tools\gfx-unit-test\trivial-copy-textures.slang">
       <Filter>Source Files</Filter>
     </None>
-    <None Include="..\..\..\tools\gfx-unit-test\trivial-copy-textures.slang">
+    <None Include="..\..\..\tools\gfx-unit-test\trivial-copy.slang">
       <Filter>Source Files</Filter>
     </None>
   </ItemGroup>

--- a/build/visual-studio/slang-unit-test-tool/slang-unit-test-tool.vcxproj
+++ b/build/visual-studio/slang-unit-test-tool/slang-unit-test-tool.vcxproj
@@ -287,6 +287,7 @@
     <ClCompile Include="..\..\..\tools\slang-unit-test\unit-test-rtti.cpp" />
     <ClCompile Include="..\..\..\tools\slang-unit-test\unit-test-short-list.cpp" />
     <ClCompile Include="..\..\..\tools\slang-unit-test\unit-test-string.cpp" />
+    <ClCompile Include="..\..\..\tools\slang-unit-test\unit-test-translation-unit-import.cpp" />
     <ClCompile Include="..\..\..\tools\unit-test\slang-unit-test.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/build/visual-studio/slang-unit-test-tool/slang-unit-test-tool.vcxproj.filters
+++ b/build/visual-studio/slang-unit-test-tool/slang-unit-test-tool.vcxproj.filters
@@ -62,6 +62,9 @@
     <ClCompile Include="..\..\..\tools\slang-unit-test\unit-test-string.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\tools\slang-unit-test\unit-test-translation-unit-import.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\tools\unit-test\slang-unit-test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -5033,7 +5033,8 @@ namespace Slang
             getLinkage(),
             name,
             decl->moduleNameAndLoc.loc,
-            getSink());
+            getSink(),
+            m_shared->m_environmentModules);
 
         // If we didn't find a matching module, then bail out
         if (!importedModule)

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -210,6 +210,11 @@ namespace Slang
 
         DiagnosticSink* m_sink      = nullptr;
 
+            /// (optional) modules that comes from previously processed translation units in the
+            /// front-end request that are made visible to the module being checked. This allows
+            /// `import` to use them instead of trying to find the files in file system.
+        LoadedModuleDictionary* m_environmentModules = nullptr;
+
         DiagnosticSink* getSink()
         {
             return m_sink;
@@ -227,10 +232,12 @@ namespace Slang
         SharedSemanticsContext(
             Linkage*        linkage,
             Module*         module,
-            DiagnosticSink* sink)
+            DiagnosticSink* sink,
+            LoadedModuleDictionary* environmentModules = nullptr)
             : m_linkage(linkage)
             , m_module(module)
             , m_sink(sink)
+            , m_environmentModules(environmentModules)
         {}
 
         Session* getSession()

--- a/source/slang/slang-check.cpp
+++ b/source/slang/slang-check.cpp
@@ -164,10 +164,11 @@ namespace Slang
         TranslationUnitRequest* translationUnit,
         LoadedModuleDictionary& loadedModules)
     {
-        SharedSemanticsContext sharedSemanticsContext(translationUnit->compileRequest->getLinkage(),
-                                                      translationUnit->getModule(),
-                                                      translationUnit->compileRequest->getSink(),
-                                                      &loadedModules);
+        SharedSemanticsContext sharedSemanticsContext(
+            translationUnit->compileRequest->getLinkage(),
+            translationUnit->getModule(),
+            translationUnit->compileRequest->getSink(),
+            &loadedModules);
 
         SemanticsDeclVisitorBase visitor(&sharedSemanticsContext);
 

--- a/source/slang/slang-check.cpp
+++ b/source/slang/slang-check.cpp
@@ -161,12 +161,13 @@ namespace Slang
     }
 
     void checkTranslationUnit(
-        TranslationUnitRequest* translationUnit)
+        TranslationUnitRequest* translationUnit,
+        LoadedModuleDictionary& loadedModules)
     {
-        SharedSemanticsContext sharedSemanticsContext(
-            translationUnit->compileRequest->getLinkage(),
-            translationUnit->getModule(),
-            translationUnit->compileRequest->getSink());
+        SharedSemanticsContext sharedSemanticsContext(translationUnit->compileRequest->getLinkage(),
+                                                      translationUnit->getModule(),
+                                                      translationUnit->compileRequest->getSink(),
+                                                      &loadedModules);
 
         SemanticsDeclVisitorBase visitor(&sharedSemanticsContext);
 

--- a/source/slang/slang-check.h
+++ b/source/slang/slang-check.h
@@ -18,22 +18,6 @@ namespace Slang
 
     class TranslationUnitRequest;
 
-    void checkTranslationUnit(
-        TranslationUnitRequest* translationUnit);
-
-    // Look for a module that matches the given name:
-    // either one we've loaded already, or one we
-    // can find vai the search paths available to us.
-    //
-    // Needed by import declaration checking.
-    //
-    // TODO: need a better location to declare this.
-    RefPtr<Module> findOrImportModule(
-        Linkage*            linkage,
-        Name*               name,
-        SourceLoc const&    loc,
-        DiagnosticSink*     sink);
-
     bool isGlobalShaderParameter(VarDeclBase* decl);
     bool isFromStdLib(Decl* decl);
 

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1569,6 +1569,8 @@ namespace Slang
         }
     };
 
+        /// A dictionary of currently loaded modules. Used by `findOrImportModule` to
+        /// lookup additional loaded modules.
     typedef Dictionary<Name*, Module*> LoadedModuleDictionary;
 
         /// A context for loading and re-using code modules.

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1568,7 +1568,9 @@ namespace Slang
                 Slang::getHashCode(elementType), Slang::getHashCode(containerType));
         }
     };
-    
+
+    typedef Dictionary<Name*, Module*> LoadedModuleDictionary;
+
         /// A context for loading and re-using code modules.
     class Linkage : public RefObject, public slang::ISession
     {
@@ -1763,7 +1765,8 @@ namespace Slang
         RefPtr<Module> findOrImportModule(
             Name*               name,
             SourceLoc const&    loc,
-            DiagnosticSink*     sink);
+            DiagnosticSink*     sink,
+            const LoadedModuleDictionary* loadedModules = nullptr);
 
         SourceManager* getSourceManager()
         {
@@ -2915,6 +2918,21 @@ namespace Slang
         double m_downstreamCompileTime = 0.0;
     };
 
+    void checkTranslationUnit(
+        TranslationUnitRequest* translationUnit, LoadedModuleDictionary& loadedModules);
+
+    // Look for a module that matches the given name:
+    // either one we've loaded already, or one we
+    // can find vai the search paths available to us.
+    //
+    // Needed by import declaration checking.
+    //
+    RefPtr<Module> findOrImportModule(
+        Linkage* linkage,
+        Name* name,
+        SourceLoc const& loc,
+        DiagnosticSink* sink,
+        const LoadedModuleDictionary* additionalLoadedModules);
 
 //
 // The following functions are utilties to convert between

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -2007,6 +2007,13 @@ void FrontEndCompileRequest::checkAllTranslationUnits()
     for( auto& translationUnit : translationUnits )
     {
         checkTranslationUnit(translationUnit.Ptr(), loadedModules);
+
+        // Add the checked module to list of loadedModules so that they can be
+        // discovered by `findOrImportModule` when processing future `import` decls.
+        // TODO: this does not handle the case where a translation unit to discover
+        // another translation unit added later to the compilation request.
+        // We should output an error message when we detect such a case, or support
+        // this scenario with a recursive style checking.
         loadedModules.Add(translationUnit->moduleName, translationUnit->getModule());
     }
     checkEntryPoints();

--- a/tools/slang-unit-test/unit-test-find-type-by-name.cpp
+++ b/tools/slang-unit-test/unit-test-find-type-by-name.cpp
@@ -1,4 +1,4 @@
-// unit-test-byte-encode.cpp
+// unit-test-find-type-by-name.cpp
 
 #include "../../slang.h"
 

--- a/tools/slang-unit-test/unit-test-translation-unit-import.cpp
+++ b/tools/slang-unit-test/unit-test-translation-unit-import.cpp
@@ -1,0 +1,59 @@
+// unit-test-translation-unit-import.cpp
+
+#include "../../slang.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "tools/unit-test/slang-unit-test.h"
+#include "../../slang-com-ptr.h"
+
+using namespace Slang;
+
+// Test that the API supports discovering previously checked translation unit in the same
+// FrontEndCompileRequest.
+SLANG_UNIT_TEST(translationUnitImport)
+{
+    // Source for the first translation unit.
+    const char* generatedSource =
+        "int f() {"
+        "   return 5;"
+        "};";
+
+    // Source for the second translation unit that imports the first translation unit.
+    // The import should succeed and `f` should be visible to this module.
+    const char* userSource =
+        R"(
+        import generatedUnit;
+
+        [shader("compute")]
+        [numthreads(4,1,1)]
+        void computeMain(
+            uint3 sv_dispatchThreadID : SV_DispatchThreadID,
+            uniform RWStructuredBuffer<int> buffer)
+        {
+            buffer[sv_dispatchThreadID.x] = f();
+        }
+        )";    
+    auto session = spCreateSession();
+    auto request = spCreateCompileRequest(session);
+    spAddCodeGenTarget(request, SLANG_HLSL);
+    int generatedTranslationUnitIndex = spAddTranslationUnit(request, SLANG_SOURCE_LANGUAGE_SLANG, "generatedUnit");
+    spAddTranslationUnitSourceString(
+        request, generatedTranslationUnitIndex, "generatedFile", generatedSource);
+    int entryPointTranslationUnitIndex = spAddTranslationUnit(request, SLANG_SOURCE_LANGUAGE_SLANG, "userUnit");
+    spAddTranslationUnitSourceString(
+        request, entryPointTranslationUnitIndex, "userFile", userSource);
+    spAddEntryPoint(request, entryPointTranslationUnitIndex, "computeMain", SLANG_STAGE_COMPUTE);
+
+    auto compileResult = spCompile(request);
+    SLANG_CHECK(compileResult == SLANG_OK);
+
+    Slang::ComPtr<ISlangBlob> outBlob;
+    spGetEntryPointCodeBlob(request, 0, 0, outBlob.writeRef());
+    SLANG_CHECK(outBlob && outBlob->getBufferSize() != 0);
+
+    spDestroyCompileRequest(request);
+    spDestroySession(session);
+}
+


### PR DESCRIPTION
This changes makes translation units processed in a front end compile request visible to `import` decls in the later translation units in the same compile request.

This allows the user to mix generated sources and file sources in a same compile request, without having to output the generated source to file first.

The main body of this change is to propagate a list of additional modules to use as loaded modules from the `FrontEndCompileRequest` all the way to `Linkage::findOrImportModule()`.