### PR TITLE
GFX renaming work part 2: slang-gfx.h renames

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -664,7 +664,7 @@ public:
         int quality = 0;                        ///< The quality measure for the samples
     };
 
-    struct Size
+    struct Extents
     {
         GfxCount width = 0;              ///< Width in pixels
         GfxCount height = 0;             ///< Height in pixels (if 2d or 3d)
@@ -673,7 +673,7 @@ public:
 
     struct Desc: public DescBase
     {
-        Size size;
+        Extents size;
 
         GfxCount arraySize = 0;          ///< Array size
 
@@ -1586,7 +1586,7 @@ public:
         ResourceState srcState,
         SubresourceRange srcSubresource,
         ITextureResource::Offset3D srcOffset,
-        ITextureResource::Size extent) = 0;
+        ITextureResource::Extents extent) = 0;
 
     /// Copies texture to a buffer. Each row is aligned to kTexturePitchAlignment.
     virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
@@ -1598,12 +1598,12 @@ public:
         ResourceState srcState,
         SubresourceRange srcSubresource,
         ITextureResource::Offset3D srcOffset,
-        ITextureResource::Size extent) = 0;
+        ITextureResource::Extents extent) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL uploadTextureData(
         ITextureResource* dst,
         SubresourceRange subResourceRange,
         ITextureResource::Offset3D offset,
-        ITextureResource::Size extent,
+        ITextureResource::Extents extent,
         ITextureResource::SubresourceData* subResourceData,
         GfxCount subResourceDataCount) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1775,7 +1775,7 @@ public:
         IAccelerationStructure* src,
         AccelerationStructureCopyMode mode) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL queryAccelerationStructureProperties(
-        int accelerationStructureCount,
+        GfxCount accelerationStructureCount,
         IAccelerationStructure* const* accelerationStructures,
         GfxCount queryCount,
         AccelerationStructureQueryDesc* queryDescs) = 0;

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -35,6 +35,7 @@
 // GLOBAL TODO: Rationalize integer types (not a smush of uint/int/Uint/Int/etc)
 //    - need typedefs in gfx namespace for Count, Index, Size, Offset (ex. DeviceAddress)
 //    - Index and Count are for arrays, and indexing into array - like things(XY coordinates of pixels, etc.)
+//         - Count is also for anything where we need to measure how many of something there are. This includes things like extents.
 //    - Offset and Size are almost always for bytes and things measured in bytes.
 namespace gfx {
 
@@ -46,8 +47,8 @@ typedef SlangResult Result;
 typedef SlangInt Int;
 typedef SlangUInt UInt;
 typedef uint64_t DeviceAddress;
-typedef int32_t GfxIndex;
-typedef int32_t GfxCount;
+typedef int GfxIndex;
+typedef int GfxCount;
 typedef size_t Size;
 typedef size_t Offset;
 
@@ -125,7 +126,7 @@ enum class AccessFlag
 };
 
 // TODO: Needed? Shouldn't be hard-coded if so
-const uint32_t kMaxRenderTargetCount = 8;
+const GfxCount kMaxRenderTargetCount = 8;
 
 class ITransientResourceHeap;
 
@@ -149,16 +150,14 @@ public:
         // The linking style of this program.
         LinkingStyle linkingStyle = LinkingStyle::SingleProgram;
 
-        // TODO: Remove slang prefix?
         // The global scope or a Slang composite component that represents the entire program.
         slang::IComponentType*  slangGlobalScope;
 
         // Number of separate entry point components in the `slangEntryPoints` array to link in.
         // If set to 0, then `slangGlobalScope` must contain Slang EntryPoint components.
         // If not 0, then `slangGlobalScope` must not contain any EntryPoint components.
-        uint32_t entryPointCount = 0;
+        GfxCount entryPointCount = 0;
 
-        // TODO: Remove slang prefix?
         // An array of Slang entry points. The size of the array must be `entryPointCount`.
         // Each element must define only 1 Slang EntryPoint.
         slang::IComponentType** slangEntryPoints = nullptr;
@@ -382,7 +381,7 @@ enum class Format
     BC7_UNORM,
     BC7_UNORM_SRGB,
 
-    CountOf, // TODO: Rename to Count
+    _Count,
 };
 
 // TODO: Aspect = Color, Depth, Stencil, etc.
@@ -392,14 +391,13 @@ enum class Format
 // TODO: Width/Height/Depth/whatever should not be used. We should use extentX, extentY, etc.
 struct FormatInfo
 {
-    // TODO: Change to uint32_t
-    uint8_t channelCount;          ///< The amount of channels in the format. Only set if the channelType is set 
-    uint8_t channelType;           ///< One of SlangScalarType None if type isn't made up of elements of type.
+    GfxCount channelCount;         ///< The amount of channels in the format. Only set if the channelType is set 
+    uint8_t channelType;           ///< One of SlangScalarType None if type isn't made up of elements of type. TODO: Change to uint32_t?
 
-    uint32_t blockSizeInBytes;     ///< The size of a block in bytes.
-    uint32_t pixelsPerBlock;       ///< The number of pixels contained in a block.
-    uint32_t blockWidth;
-    uint32_t blockHeight;
+    Size blockSizeInBytes;         ///< The size of a block in bytes.
+    GfxCount pixelsPerBlock;       ///< The number of pixels contained in a block.
+    GfxCount blockWidth;           ///< The width of a block in pixels.
+    GfxCount blockHeight;          ///< The height of a block in pixels.
 };
 
 enum class InputSlotClass
@@ -409,18 +407,18 @@ enum class InputSlotClass
 
 struct InputElementDesc
 {
-    char const* semanticName;
-    UInt semanticIndex;
-    Format format;
-    UInt offset;
-    UInt bufferSlotIndex;
+    char const* semanticName;      ///< The name of the corresponding parameter in shader code.
+    GfxIndex semanticIndex;        ///< The index of the corresponding parameter in shader code. Only needed if multiple parameters share a semantic name.
+    Format format;                 ///< The format of the data being fetched for this element.
+    Offset offset;                 ///< The offset in bytes of this element from the start of the corresponding chunk of vertex stream data.
+    GfxIndex bufferSlotIndex;      ///< The index of the vertex stream to fetch this element's data from.
 };
 
 struct VertexStreamDesc
 {
-    uint32_t stride;
-    InputSlotClass slotClass;
-    UInt instanceDataStepRate;
+    Size stride;                   ///< The stride in bytes for this vertex stream.
+    InputSlotClass slotClass;      ///< Whether the stream contains per-vertex or per-instance data.
+    GfxCount instanceDataStepRate; ///< How many instances to draw per chunk of data.
 };
 
 enum class PrimitiveType
@@ -524,9 +522,9 @@ public:
     struct Desc
     {
         InputElementDesc const* inputElements = nullptr;
-        Int inputElementCount = 0;
+        GfxCount inputElementCount = 0;
         VertexStreamDesc const* vertexStreams = nullptr;
-        Int vertexStreamCount = 0;
+        GfxCount vertexStreamCount = 0;
     };
 };
 #define SLANG_UUID_IInputLayout                                                         \
@@ -547,7 +545,7 @@ public:
         Texture2D,          ///< A 2d texture
         Texture3D,          ///< A 3d texture
         TextureCube,        ///< A cubemap consists of 6 Texture2D like faces
-        CountOf,
+        _Count,
     };
 
         /// Base class for Descs
@@ -576,6 +574,7 @@ public:
 
 struct MemoryRange
 {
+    // TODO: Change to Offset/Size?
     uint64_t offset;
     uint64_t size;
 };
@@ -585,8 +584,8 @@ class IBufferResource: public IResource
 public:
     struct Desc: public DescBase
     {
-        Size sizeInBytes = 0;     ///< Total size in bytes
-        int elementSize = 0;        ///< Get the element stride. If > 0, this is a structured buffer
+        Size sizeInBytes = 0;        ///< Total size in bytes
+        Size elementSize = 0;        ///< Get the element stride. If > 0, this is a structured buffer
         Format format = Format::Unknown;
     };
 
@@ -618,6 +617,7 @@ struct ClearValue
 
 struct BufferRange
 {
+    // TODO: Change to Index and Count?
     uint64_t firstElement;
     uint64_t elementCount;
 };
@@ -639,47 +639,47 @@ enum class TextureAspect : uint32_t
 struct SubresourceRange
 {
     TextureAspect aspectMask;
-    uint32_t mipLevel;
-    uint32_t mipLevelCount;
-    uint32_t baseArrayLayer; // For Texture3D, this is WSlice.
-    uint32_t layerCount; // For cube maps, this is a multiple of 6.
+    GfxIndex mipLevel;
+    GfxCount mipLevelCount;
+    GfxIndex baseArrayLayer; // For Texture3D, this is WSlice.
+    GfxCount layerCount; // For cube maps, this is a multiple of 6.
 };
 
 class ITextureResource: public IResource
 {
 public:
-    static const uint32_t kRemainingTextureSize = 0xFFFFFFFF;
+    static const Size kRemainingTextureSize = 0xFFFFFFFF;
     struct Offset3D
     {
-        uint32_t x = 0;
-        uint32_t y = 0;
-        uint32_t z = 0;
+        GfxIndex x = 0;
+        GfxIndex y = 0;
+        GfxIndex z = 0;
         Offset3D() = default;
-        Offset3D(uint32_t _x, uint32_t _y, uint32_t _z) :x(_x), y(_y), z(_z) {}
+        Offset3D(GfxIndex _x, GfxIndex _y, GfxIndex _z) :x(_x), y(_y), z(_z) {}
     };
 
     struct SampleDesc
     {
-        int numSamples = 1;                     ///< Number of samples per pixel
+        GfxCount numSamples = 1;                ///< Number of samples per pixel
         int quality = 0;                        ///< The quality measure for the samples
     };
 
     struct Size
     {
-        int width = 0;              ///< Width in pixels
-        int height = 0;             ///< Height in pixels (if 2d or 3d)
-        int depth = 0;              ///< Depth (if 3d)
+        GfxCount width = 0;              ///< Width in pixels
+        GfxCount height = 0;             ///< Height in pixels (if 2d or 3d)
+        GfxCount depth = 0;              ///< Depth (if 3d)
     };
 
     struct Desc: public DescBase
     {
         Size size;
 
-        int arraySize = 0;          ///< Array size
+        GfxCount arraySize = 0;          ///< Array size
 
-        int numMipLevels = 0;       ///< Number of mip levels - if 0 will create all mip levels
-        Format format;              ///< The resources format
-        SampleDesc sampleDesc;      ///< How the resource is sampled
+        GfxCount numMipLevels = 0;       ///< Number of mip levels - if 0 will create all mip levels
+        Format format;                   ///< The resources format
+        SampleDesc sampleDesc;           ///< How the resource is sampled
         ClearValue optimalClearValue;
     };
 
@@ -715,7 +715,7 @@ public:
             /// Devices may not support all possible values for `strideY`.
             /// In particular, they may only support strictly positive strides.
             ///
-        int64_t     strideY;
+        gfx::Size strideY;
 
             /// Stride in bytes between layers of the subresource tensor.
             ///
@@ -725,7 +725,7 @@ public:
             /// Devices may not support all possible values for `strideZ`.
             /// In particular, they may only support strictly positive strides.
             ///
-        int64_t     strideZ;
+        gfx::Size strideZ;
     };
 
     virtual SLANG_NO_THROW Desc* SLANG_MCALL getDesc() = 0;
@@ -834,8 +834,8 @@ public:
         SubresourceRange subresourceRange;
         // Specifies the range of a buffer resource for a ShaderResource/UnorderedAccess view.
         BufferRange bufferRange;
-        // Specifies the element size of a structured buffer. Pass 0 for a raw buffer view.
-        uint32_t bufferElementSize;
+        // Specifies the element size in bytes of a structured buffer. Pass 0 for a raw buffer view.
+        Size bufferElementSize;
     };
     virtual SLANG_NO_THROW Desc* SLANG_MCALL getViewDesc() = 0;
 
@@ -898,11 +898,11 @@ public:
         DeviceAddress transform3x4;
         Format indexFormat;
         Format vertexFormat;
-        uint32_t indexCount;
-        uint32_t vertexCount;
+        GfxCount indexCount;
+        GfxCount vertexCount;
         DeviceAddress indexData;
         DeviceAddress vertexData;
-        uint64_t vertexStride;
+        Size vertexStride;
     };
 
     struct ProceduralAABB
@@ -918,13 +918,13 @@ public:
     struct ProceduralAABBDesc
     {
         /// Number of AABBs.
-        uint64_t count;
+        GfxCount count;
 
         /// Pointer to an array of `ProceduralAABB` values in device memory.
         DeviceAddress data;
 
         /// Stride in bytes of the AABB values array.
-        uint64_t stride;
+        Size stride;
     };
 
     struct GeometryDesc
@@ -952,6 +952,7 @@ public:
         };
     };
 
+    // TODO: Should any of these be changed?
     // The layout of this struct is intentionally consistent with D3D12_RAYTRACING_INSTANCE_DESC
     // and VkAccelerationStructureInstanceKHR.
     struct InstanceDesc
@@ -966,9 +967,9 @@ public:
 
     struct PrebuildInfo
     {
-        uint64_t resultDataMaxSize;
-        uint64_t scratchDataSize;
-        uint64_t updateScratchDataSize;
+        Size resultDataMaxSize;
+        Size scratchDataSize;
+        Size updateScratchDataSize;
     };
 
     struct BuildInputs
@@ -977,7 +978,7 @@ public:
 
         BuildFlags::Enum flags;
 
-        int32_t descCount;
+        GfxCount descCount;
 
         /// Array of `InstanceDesc` values in device memory.
         /// Used when `kind` is `TopLevel`.
@@ -992,8 +993,8 @@ public:
     {
         Kind kind;
         IBufferResource* buffer;
-        uint64_t offset;
-        uint64_t size;
+        Offset offset;
+        Size size;
     };
 
     struct BuildDesc
@@ -1037,8 +1038,8 @@ public:
 struct ShaderOffset
 {
     SlangInt uniformOffset = 0; // TODO: Change to Offset?
-    SlangInt bindingRangeIndex = 0;
-    SlangInt bindingArrayIndex = 0;
+    GfxIndex bindingRangeIndex = 0;
+    GfxIndex bindingArrayIndex = 0;
     uint32_t getHashCode() const
     {
         return (uint32_t)(((bindingRangeIndex << 20) + bindingArrayIndex) ^ uniformOffset);
@@ -1087,16 +1088,16 @@ public:
 
     virtual SLANG_NO_THROW slang::TypeLayoutReflection* SLANG_MCALL getElementTypeLayout() = 0;
     virtual SLANG_NO_THROW ShaderObjectContainerType SLANG_MCALL getContainerType() = 0;
-    virtual SLANG_NO_THROW UInt SLANG_MCALL getEntryPointCount() = 0;
+    virtual SLANG_NO_THROW GfxCount SLANG_MCALL getEntryPointCount() = 0;
 
-    ComPtr<IShaderObject> getEntryPoint(UInt index)
+    ComPtr<IShaderObject> getEntryPoint(GfxIndex index)
     {
         ComPtr<IShaderObject> entryPoint = nullptr;
         SLANG_RETURN_NULL_ON_FAIL(getEntryPoint(index, entryPoint.writeRef()));
         return entryPoint;
     }
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getEntryPoint(UInt index, IShaderObject** entryPoint) = 0;
+        getEntryPoint(GfxIndex index, IShaderObject** entryPoint) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL
         setData(ShaderOffset const& offset, void const* data, Size size) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL
@@ -1116,7 +1117,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL setSpecializationArgs(
         ShaderOffset const& offset,
         const slang::SpecializationArg* args,
-        uint32_t count) = 0;
+        GfxCount count) = 0;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentVersion(
         ITransientResourceHeap* transientHeap,
@@ -1180,8 +1181,8 @@ struct DepthStencilDesc
     ComparisonFunc  depthFunc           = ComparisonFunc::Less;
 
     bool                stencilEnable       = false;
-    uint32_t             stencilReadMask     = 0xFFFFFFFF;
-    uint32_t             stencilWriteMask    = 0xFFFFFFFF;
+    uint32_t            stencilReadMask     = 0xFFFFFFFF;
+    uint32_t            stencilWriteMask    = 0xFFFFFFFF;
     DepthStencilOpDesc  frontFace;
     DepthStencilOpDesc  backFace;
 
@@ -1273,7 +1274,7 @@ struct TargetBlendDesc
 struct BlendDesc
 {
     TargetBlendDesc         targets[kMaxRenderTargetCount];
-    UInt                    targetCount = 0;
+    GfxCount                targetCount = 0;
 
     bool alphaToCoverageEnable  = false;
 };
@@ -1284,11 +1285,11 @@ public:
     struct AttachmentLayout
     {
         Format format;
-        int sampleCount;
+        GfxCount sampleCount;
     };
     struct Desc
     {
-        uint32_t renderTargetCount;
+        GfxCount renderTargetCount;
         AttachmentLayout* renderTargets = nullptr;
         AttachmentLayout* depthStencil = nullptr;
     };
@@ -1337,11 +1338,11 @@ struct HitGroupDesc
 struct RayTracingPipelineStateDesc
 {
     IShaderProgram* program = nullptr;
-    int32_t hitGroupCount = 0;
+    GfxCount hitGroupCount = 0;
     const HitGroupDesc* hitGroups = nullptr;
     int maxRecursion = 0;
-    int maxRayPayloadSize = 0;
-    int maxAttributeSizeInBytes = 8;
+    Size maxRayPayloadSize = 0;
+    Size maxAttributeSizeInBytes = 8;
     RayTracingPipelineFlags::Enum flags = RayTracingPipelineFlags::None;
 };
 
@@ -1351,22 +1352,22 @@ public:
     // Specifies the bytes to overwrite into a record in the shader table.
     struct ShaderRecordOverwrite
     {
-        uint32_t offset; // Offset within the shader record.
-        uint32_t size; // Number of bytes to overwrite.
+        Offset offset; // Offset within the shader record.
+        Size size; // Number of bytes to overwrite.
         uint8_t data[8]; // Content to overwrite.
     };
 
     struct Desc
     {
-        uint32_t rayGenShaderCount;
+        GfxCount rayGenShaderCount;
         const char** rayGenShaderEntryPointNames;
         const ShaderRecordOverwrite* rayGenShaderRecordOverwrites;
 
-        uint32_t missShaderCount;
+        GfxCount missShaderCount;
         const char** missShaderEntryPointNames;
         const ShaderRecordOverwrite* missShaderRecordOverwrites;
 
-        uint32_t hitGroupCount;
+        GfxCount hitGroupCount;
         const char** hitGroupNames;
         const ShaderRecordOverwrite* hitGroupRecordOverwrites;
 
@@ -1412,7 +1413,7 @@ class IFramebuffer : public ISlangUnknown
 public:
     struct Desc
     {
-        uint32_t renderTargetCount;
+        GfxCount renderTargetCount;
         IResourceView* const* renderTargetViews;
         IResourceView* depthStencilView;
         IFramebufferLayout* layout;
@@ -1481,7 +1482,7 @@ public:
     struct Desc
     {
         IFramebufferLayout* framebufferLayout = nullptr;
-        uint32_t renderTargetCount;
+        GfxCount renderTargetCount;
         AttachmentAccessDesc* renderTargetAccess = nullptr;
         AttachmentAccessDesc* depthStencilAccess = nullptr;
     };
@@ -1505,10 +1506,10 @@ public:
     struct Desc
     {
         QueryType type;
-        SlangInt count;
+        GfxCount count;
     };
 public:
-    virtual SLANG_NO_THROW Result SLANG_MCALL getResult(SlangInt queryIndex, SlangInt count, uint64_t* data) = 0;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getResult(GfxIndex queryIndex, GfxCount count, uint64_t* data) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL reset() = 0;
 };
 #define SLANG_UUID_IQueryPool                                                         \
@@ -1519,31 +1520,31 @@ class ICommandEncoder
 {
 public:
     virtual SLANG_NO_THROW void SLANG_MCALL endEncoding() = 0;
-    virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, SlangInt queryIndex) = 0;
+    virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, GfxIndex queryIndex) = 0;
 };
 
 struct IndirectDispatchArguments
 {
-    uint32_t ThreadGroupCountX;
-    uint32_t ThreadGroupCountY;
-    uint32_t ThreadGroupCountZ;
+    GfxCount ThreadGroupCountX;
+    GfxCount ThreadGroupCountY;
+    GfxCount ThreadGroupCountZ;
 };
 
 struct IndirectDrawArguments
 {
-    uint32_t VertexCountPerInstance;
-    uint32_t InstanceCount;
-    uint32_t StartVertexLocation;
-    uint32_t StartInstanceLocation;
+    GfxCount VertexCountPerInstance;
+    GfxCount InstanceCount;
+    GfxIndex StartVertexLocation;
+    GfxIndex StartInstanceLocation;
 };
 
 struct IndirectDrawIndexedArguments
 {
-    uint32_t IndexCountPerInstance;
-    uint32_t InstanceCount;
-    uint32_t StartIndexLocation;
-    int32_t  BaseVertexLocation;
-    uint32_t StartInstanceLocation;
+    GfxCount IndexCountPerInstance;
+    GfxCount InstanceCount;
+    GfxIndex StartIndexLocation;
+    GfxIndex BaseVertexLocation;
+    GfxIndex StartInstanceLocation;
 };
 
 struct SamplePosition
@@ -1568,9 +1569,9 @@ class IResourceCommandEncoder : public ICommandEncoder
 public:
     virtual SLANG_NO_THROW void SLANG_MCALL copyBuffer(
         IBufferResource* dst,
-        Size dstOffset,
+        Offset dstOffset,
         IBufferResource* src,
-        Size srcOffset,
+        Offset srcOffset,
         Size size) = 0;
 
     /// Copies texture from src to dst. If dstSubresource and srcSubresource has mipLevelCount = 0
@@ -1590,7 +1591,7 @@ public:
     /// Copies texture to a buffer. Each row is aligned to kTexturePitchAlignment.
     virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
         IBufferResource* dst,
-        Size dstOffset,
+        Offset dstOffset,
         Size dstSize,
         Size dstRowStride,
         ITextureResource* src,
@@ -1604,11 +1605,11 @@ public:
         ITextureResource::Offset3D offset,
         ITextureResource::Size extent,
         ITextureResource::SubresourceData* subResourceData,
-        size_t subResourceDataCount) = 0; // TODO: Change size_t to Count?
+        GfxCount subResourceDataCount) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL
         uploadBufferData(IBufferResource* dst, Offset offset, Size size, void* data) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL textureBarrier(
-        size_t count, ITextureResource* const* textures, ResourceState src, ResourceState dst) = 0; // TODO: Change size_t to Count?
+        GfxCount count, ITextureResource* const* textures, ResourceState src, ResourceState dst) = 0;
     void textureBarrier(ITextureResource* texture, ResourceState src, ResourceState dst)
     {
         textureBarrier(1, &texture, src, dst);
@@ -1619,7 +1620,7 @@ public:
         ResourceState src,
         ResourceState dst) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL bufferBarrier(
-        size_t count, IBufferResource* const* buffers, ResourceState src, ResourceState dst) = 0; // TODO: Change size_t to Count?
+        GfxCount count, IBufferResource* const* buffers, ResourceState src, ResourceState dst) = 0;
     void bufferBarrier(IBufferResource* buffer, ResourceState src, ResourceState dst)
     {
         bufferBarrier(1, &buffer, src, dst);
@@ -1635,10 +1636,10 @@ public:
         SubresourceRange destRange) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL resolveQuery(
         IQueryPool* queryPool,
-        uint32_t index,
-        uint32_t count,
+        GfxIndex index,
+        GfxCount count,
         IBufferResource* buffer,
-        uint64_t offset) = 0;
+        Offset offset) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL beginDebugEvent(const char* name, float rgbColor[3]) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL endDebugEvent() = 0;
 };
@@ -1665,9 +1666,9 @@ public:
         bindPipelineWithRootObject(IPipelineState* state, IShaderObject* rootObject) = 0;
 
     virtual SLANG_NO_THROW void
-        SLANG_MCALL setViewports(uint32_t count, const Viewport* viewports) = 0;
+        SLANG_MCALL setViewports(GfxCount count, const Viewport* viewports) = 0;
     virtual SLANG_NO_THROW void
-        SLANG_MCALL setScissorRects(uint32_t count, const ScissorRect* scissors) = 0;
+        SLANG_MCALL setScissorRects(GfxCount count, const ScissorRect* scissors) = 0;
 
     /// Sets the viewport, and sets the scissor rect to match the viewport.
     inline void setViewportAndScissor(Viewport const& viewport)
@@ -1681,48 +1682,48 @@ public:
 
     virtual SLANG_NO_THROW void SLANG_MCALL setPrimitiveTopology(PrimitiveTopology topology) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL setVertexBuffers(
-        uint32_t startSlot,
-        uint32_t slotCount,
+        GfxIndex startSlot,
+        GfxCount slotCount,
         IBufferResource* const* buffers,
-        const uint32_t* offsets) = 0;
+        const Offset* offsets) = 0;
     inline void setVertexBuffer(
-        uint32_t slot, IBufferResource* buffer, uint32_t offset = 0)
+        GfxIndex slot, IBufferResource* buffer, Offset offset = 0)
     {
         setVertexBuffers(slot, 1, &buffer, &offset);
     }
 
     virtual SLANG_NO_THROW void SLANG_MCALL
-        setIndexBuffer(IBufferResource* buffer, Format indexFormat, uint32_t offset = 0) = 0;
+        setIndexBuffer(IBufferResource* buffer, Format indexFormat, Offset offset = 0) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        draw(uint32_t vertexCount, uint32_t startVertex = 0) = 0;
+        draw(GfxCount vertexCount, GfxIndex startVertex = 0) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        drawIndexed(uint32_t indexCount, uint32_t startIndex = 0, uint32_t baseVertex = 0) = 0;
+        drawIndexed(GfxCount indexCount, GfxIndex startIndex = 0, GfxIndex baseVertex = 0) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndirect(
-        uint32_t maxDrawCount,
+        GfxCount maxDrawCount,
         IBufferResource* argBuffer,
-        uint64_t argOffset,
+        Offset argOffset,
         IBufferResource* countBuffer = nullptr,
-        uint64_t countOffset = 0) = 0;
+        Offset countOffset = 0) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedIndirect(
-        uint32_t maxDrawCount,
+        GfxCount maxDrawCount,
         IBufferResource* argBuffer,
-        uint64_t argOffset,
+        Offset argOffset,
         IBufferResource* countBuffer = nullptr,
-        uint64_t countOffset = 0) = 0;
+        Offset countOffset = 0) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL setStencilReference(uint32_t referenceValue) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL setSamplePositions(
-        uint32_t samplesPerPixel, uint32_t pixelCount, const SamplePosition* samplePositions) = 0;
+        GfxCount samplesPerPixel, GfxCount pixelCount, const SamplePosition* samplePositions) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL drawInstanced(
-        uint32_t vertexCount,
-        uint32_t instanceCount,
-        uint32_t startVertex,
-        uint32_t startInstanceLocation) = 0;
+        GfxCount vertexCount,
+        GfxCount instanceCount,
+        GfxIndex startVertex,
+        GfxIndex startInstanceLocation) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedInstanced(
-        uint32_t indexCount,
-        uint32_t instanceCount,
-        uint32_t startIndexLocation,
-        int32_t baseVertexLocation,
-        uint32_t startInstanceLocation) = 0;
+        GfxCount indexCount,
+        GfxCount instanceCount,
+        GfxIndex startIndexLocation,
+        GfxIndex baseVertexLocation,
+        GfxIndex startInstanceLocation) = 0;
 };
 
 class IComputeCommandEncoder : public IResourceCommandEncoder
@@ -1745,7 +1746,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
         bindPipelineWithRootObject(IPipelineState* state, IShaderObject* rootObject) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL dispatchCompute(int x, int y, int z) = 0;
-    virtual SLANG_NO_THROW void SLANG_MCALL dispatchComputeIndirect(IBufferResource* cmdBuffer, uint64_t offset) = 0;
+    virtual SLANG_NO_THROW void SLANG_MCALL dispatchComputeIndirect(IBufferResource* cmdBuffer, Offset offset) = 0;
 };
 
 enum class AccelerationStructureCopyMode
@@ -1759,7 +1760,7 @@ struct AccelerationStructureQueryDesc
 
     IQueryPool* queryPool;
 
-    int32_t firstQueryIndex;
+    GfxIndex firstQueryIndex;
 };
 
 class IRayTracingCommandEncoder : public IResourceCommandEncoder
@@ -1767,7 +1768,7 @@ class IRayTracingCommandEncoder : public IResourceCommandEncoder
 public:
     virtual SLANG_NO_THROW void SLANG_MCALL buildAccelerationStructure(
         const IAccelerationStructure::BuildDesc& desc,
-        int propertyQueryCount,
+        GfxCount propertyQueryCount,
         AccelerationStructureQueryDesc* queryDescs) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL copyAccelerationStructure(
         IAccelerationStructure* dest,
@@ -1776,7 +1777,7 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL queryAccelerationStructureProperties(
         int accelerationStructureCount,
         IAccelerationStructure* const* accelerationStructures,
-        int queryCount,
+        GfxCount queryCount,
         AccelerationStructureQueryDesc* queryDescs) = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL
         serializeAccelerationStructure(DeviceAddress dest, IAccelerationStructure* source) = 0;
@@ -1792,11 +1793,11 @@ public:
     /// Issues a dispatch command to start ray tracing workload with a ray tracing pipeline.
     /// `rayGenShaderIndex` specifies the index into the shader table that identifies the ray generation shader.
     virtual SLANG_NO_THROW void SLANG_MCALL dispatchRays(
-        uint32_t rayGenShaderIndex,
+        GfxIndex rayGenShaderIndex,
         IShaderTable* shaderTable,
-        int32_t width,
-        int32_t height,
-        int32_t depth) = 0;
+        GfxCount width,
+        GfxCount height,
+        GfxCount depth) = 0;
 };
 #define SLANG_UUID_IRayTracingCommandEncoder                                           \
     {                                                                                  \
@@ -1877,7 +1878,7 @@ public:
     virtual SLANG_NO_THROW const Desc& SLANG_MCALL getDesc() = 0;
 
     virtual SLANG_NO_THROW void SLANG_MCALL executeCommandBuffers(
-        uint32_t count,
+        GfxCount count,
         ICommandBuffer* const* commandBuffers,
         IFence* fenceToSignal,
         uint64_t newFenceValue) = 0;
@@ -1893,7 +1894,7 @@ public:
 
     /// Queues a device side wait for the given fences.
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        waitForFenceValuesOnDevice(uint32_t fenceCount, IFence** fences, uint64_t* waitValues) = 0;
+        waitForFenceValuesOnDevice(GfxCount fenceCount, IFence** fences, uint64_t* waitValues) = 0;
 };
 #define SLANG_UUID_ICommandQueue                                                    \
     {                                                                               \
@@ -1915,11 +1916,11 @@ public:
     {
         Flags::Enum flags;
         Size constantBufferSize;
-        uint32_t samplerDescriptorCount;
-        uint32_t uavDescriptorCount;
-        uint32_t srvDescriptorCount;
-        uint32_t constantBufferDescriptorCount;
-        uint32_t accelerationStructureDescriptorCount;
+        GfxCount samplerDescriptorCount;
+        GfxCount uavDescriptorCount;
+        GfxCount srvDescriptorCount;
+        GfxCount constantBufferDescriptorCount;
+        GfxCount accelerationStructureDescriptorCount;
     };
 
     // Waits until GPU commands issued before last call to `finish()` has been completed, and resets
@@ -1960,8 +1961,8 @@ public:
     };
     virtual SLANG_NO_THROW Result SLANG_MCALL allocateTransientDescriptorTable(
         DescriptorType type,
-        uint32_t count,
-        uint64_t& outDescriptorOffset,
+        GfxCount count,
+        Offset& outDescriptorOffset,
         void** outD3DDescriptorHeapHandle) = 0;
 };
 #define SLANG_UUID_ID3D12TransientResourceHeap                                             \
@@ -1975,8 +1976,8 @@ public:
     struct Desc
     {
         Format format;
-        uint32_t width, height;
-        uint32_t imageCount;
+        GfxCount width, height;
+        GfxCount imageCount;
         ICommandQueue* queue;
         bool enableVSync;
     };
@@ -1984,7 +1985,7 @@ public:
 
     /// Returns the back buffer image at `index`.
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getImage(uint32_t index, ITextureResource** outResource) = 0;
+        getImage(GfxIndex index, ITextureResource** outResource) = 0;
 
     /// Present the next image in the swapchain.
     virtual SLANG_NO_THROW Result SLANG_MCALL present() = 0;
@@ -1995,7 +1996,7 @@ public:
 
     /// Resizes the back buffers of this swapchain. All render target views and framebuffers
     /// referencing the back buffer images must be freed before calling this method.
-    virtual SLANG_NO_THROW Result SLANG_MCALL resize(uint32_t width, uint32_t height) = 0;
+    virtual SLANG_NO_THROW Result SLANG_MCALL resize(GfxCount width, GfxCount height) = 0;
 
     // Check if the window is occluded.
     virtual SLANG_NO_THROW bool SLANG_MCALL isOccluded() = 0;
@@ -2055,10 +2056,10 @@ public:
         SlangMatrixLayoutMode defaultMatrixLayoutMode = SLANG_MATRIX_LAYOUT_ROW_MAJOR;
 
         char const* const* searchPaths = nullptr;
-        SlangInt            searchPathCount = 0;
+        GfxCount           searchPathCount = 0;
 
         slang::PreprocessorMacroDesc const* preprocessorMacros = nullptr;
-        SlangInt                        preprocessorMacroCount = 0;
+        GfxCount                            preprocessorMacroCount = 0;
 
         const char* targetProfile = nullptr; // (optional) Target shader profile. If null this will be set to platform dependent default.
         SlangFloatingPointMode floatingPointMode = SLANG_FLOATING_POINT_MODE_DEFAULT;
@@ -2083,20 +2084,20 @@ public:
         // Name to identify the adapter to use
         const char* adapter = nullptr;
         // Number of required features.
-        int requiredFeatureCount = 0;
+        GfxCount requiredFeatureCount = 0;
         // Array of required feature names, whose size is `requiredFeatureCount`.
         const char** requiredFeatures = nullptr;
         // A command dispatcher object that intercepts and handles actual low-level API call.
         ISlangUnknown* apiCommandDispatcher = nullptr;
         // The slot (typically UAV) used to identify NVAPI intrinsics. If >=0 NVAPI is required.
-        int nvapiExtnSlot = -1;
+        GfxIndex nvapiExtnSlot = -1;
         // The file system for loading cached shader kernels. The layer does not maintain a strong reference to the object,
         // instead the user is responsible for holding the object alive during the lifetime of an `IDevice`.
         ISlangFileSystem* shaderCacheFileSystem = nullptr;
         // Configurations for Slang compiler.
         SlangDesc slang = {};
 
-        uint32_t extendedDescCount = 0;
+        GfxCount extendedDescCount = 0;
         void** extendedDescs = nullptr;
     };
 
@@ -2105,7 +2106,7 @@ public:
     virtual SLANG_NO_THROW bool SLANG_MCALL hasFeature(const char* feature) = 0;
 
         /// Returns a list of features supported by the renderer.
-    virtual SLANG_NO_THROW Result SLANG_MCALL getFeatures(const char** outFeatures, UInt bufferSize, UInt* outFeatureCount) = 0;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getFeatures(const char** outFeatures, Size bufferSize, GfxCount* outFeatureCount) = 0;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getFormatSupportedResourceStates(Format format, ResourceStateSet* outStates) = 0;
 
@@ -2275,9 +2276,9 @@ public:
         return layout;
     }
 
-    inline Result createInputLayout(Size vertexSize, InputElementDesc const* inputElements, Int inputElementCount, IInputLayout** outLayout)
+    inline Result createInputLayout(Size vertexSize, InputElementDesc const* inputElements, GfxCount inputElementCount, IInputLayout** outLayout)
     {
-        VertexStreamDesc streamDesc = { (uint32_t)vertexSize, InputSlotClass::PerVertex, 0 };
+        VertexStreamDesc streamDesc = { vertexSize, InputSlotClass::PerVertex, 0 };
 
         IInputLayout::Desc inputLayoutDesc = {};
         inputLayoutDesc.inputElementCount = inputElementCount;
@@ -2287,7 +2288,7 @@ public:
         return createInputLayout(inputLayoutDesc, outLayout);
     }
 
-    inline ComPtr<IInputLayout> createInputLayout(Size vertexSize, InputElementDesc const* inputElements, Int inputElementCount)
+    inline ComPtr<IInputLayout> createInputLayout(Size vertexSize, InputElementDesc const* inputElements, GfxCount inputElementCount)
     {
         ComPtr<IInputLayout> layout;
         SLANG_RETURN_NULL_ON_FAIL(createInputLayout(vertexSize, inputElements, inputElementCount, layout.writeRef()));
@@ -2407,16 +2408,16 @@ public:
     /// Wait on the host for the fences to signals.
     /// `timeout` is in nanoseconds, can be set to `kTimeoutInfinite`.
     virtual SLANG_NO_THROW Result SLANG_MCALL waitForFences(
-        uint32_t fenceCount,
+        GfxCount fenceCount,
         IFence** fences,
         uint64_t* values,
         bool waitForAll,
         uint64_t timeout) = 0;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureAllocationInfo(
-        const ITextureResource::Desc& desc, Size* outSize, size_t* outAlignment) = 0;
+        const ITextureResource::Desc& desc, Size* outSize, Size* outAlignment) = 0;
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(size_t* outAlignment) = 0;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(Size* outAlignment) = 0;
 };
 
 #define SLANG_UUID_IDevice                                                               \

--- a/tools/gfx-unit-test/copy-texture-tests.cpp
+++ b/tools/gfx-unit-test/copy-texture-tests.cpp
@@ -19,7 +19,7 @@ namespace gfx_test
     {
         SubresourceRange srcSubresource;
         SubresourceRange dstSubresource;
-        ITextureResource::Size extent;
+        ITextureResource::Extents extent;
         ITextureResource::Offset3D srcOffset;
         ITextureResource::Offset3D dstOffset;
     };
@@ -27,7 +27,7 @@ namespace gfx_test
     struct TextureToBufferCopyInfo
     {
         SubresourceRange srcSubresource;
-        ITextureResource::Size extent;
+        ITextureResource::Extents extent;
         ITextureResource::Offset3D textureOffset;
         Offset bufferOffset;
         Offset bufferSize;
@@ -241,7 +241,7 @@ namespace gfx_test
             }
         }
 
-        void checkTestResults(ITextureResource::Size srcMipExtent, const void* expectedCopiedData, const void* expectedOriginalData)
+        void checkTestResults(ITextureResource::Extents srcMipExtent, const void* expectedCopiedData, const void* expectedOriginalData)
         {
             ComPtr<ISlangBlob> resultBlob;
             GFX_CHECK_CALL_ABORT(device->readBufferResource(resultsBuffer, 0, bufferCopyInfo.bufferSize, resultBlob.writeRef()));

--- a/tools/gfx-unit-test/copy-texture-tests.cpp
+++ b/tools/gfx-unit-test/copy-texture-tests.cpp
@@ -29,8 +29,8 @@ namespace gfx_test
         SubresourceRange srcSubresource;
         ITextureResource::Size extent;
         ITextureResource::Offset3D textureOffset;
-        size_t bufferOffset;
-        size_t bufferSize;
+        Offset bufferOffset;
+        Offset bufferSize;
     };
 
     struct BaseCopyTextureTest
@@ -38,7 +38,7 @@ namespace gfx_test
         IDevice* device;
         UnitTestContext* context;
 
-        size_t alignedRowStride;
+        Size alignedRowStride;
 
         RefPtr<TextureInfo> srcTextureInfo;
         RefPtr<TextureInfo> dstTextureInfo;
@@ -185,7 +185,7 @@ namespace gfx_test
             queue->waitOnHost();
         }
 
-        bool isWithinCopyBounds(Int x, Int y, Int z)
+        bool isWithinCopyBounds(GfxIndex x, GfxIndex y, GfxIndex z)
         {
             auto copyExtents = texCopyInfo.extent;
             auto copyOffset = texCopyInfo.dstOffset;
@@ -213,11 +213,11 @@ namespace gfx_test
             auto srcTexOffset = texCopyInfo.srcOffset;
             auto dstTexOffset = texCopyInfo.dstOffset;
 
-            for (Int x = 0; x < actualExtents.width; ++x)
+            for (GfxIndex x = 0; x < actualExtents.width; ++x)
             {
-                for (Int y = 0; y < actualExtents.height; ++y)
+                for (GfxIndex y = 0; y < actualExtents.height; ++y)
                 {
-                    for (Int z = 0; z < actualExtents.depth; ++z)
+                    for (GfxIndex z = 0; z < actualExtents.depth; ++z)
                     {
                         auto actualBlock = actual.getBlockAt(x, y, z);
                         if (isWithinCopyBounds(x, y, z))
@@ -251,7 +251,7 @@ namespace gfx_test
             actual.extents = bufferCopyInfo.extent;
             actual.textureData = results;
             actual.strides.x = getTexelSize(dstTextureInfo->format);
-            actual.strides.y = (uint32_t)alignedRowStride;
+            actual.strides.y = alignedRowStride;
             actual.strides.z = actual.extents.height * actual.strides.y;
 
             ValidationTextureData expectedCopied;
@@ -746,9 +746,9 @@ namespace gfx_test
     {
         // Skip Type::Unknown and Type::Buffer as well as Format::Unknown
         // TODO: Add support for TextureCube
-        for (uint32_t i = 2; i < (uint32_t)ITextureResource::Type::CountOf - 1; ++i)
+        for (uint32_t i = 2; i < (uint32_t)ITextureResource::Type::_Count - 1; ++i)
         {
-            for (uint32_t j = 1; j < (uint32_t)Format::CountOf; ++j)
+            for (uint32_t j = 1; j < (uint32_t)Format::_Count; ++j)
             {
                 auto type = (ITextureResource::Type)i;
                 auto format = (Format)j;

--- a/tools/gfx-unit-test/format-unit-tests.cpp
+++ b/tools/gfx-unit-test/format-unit-tests.cpp
@@ -97,7 +97,7 @@ namespace gfx_test
 
     ComPtr<IResourceView> createTexView(
         IDevice* device,
-        ITextureResource::Size size,
+        ITextureResource::Extents size,
         gfx::Format format,
         ITextureResource::SubresourceData* data,
         int mips = 1)
@@ -175,12 +175,12 @@ namespace gfx_test
         auto intResults = createBuffer<uint32_t>(device, 16, initIntData);
         auto intBufferView = createBufferView(device, intResults);
 
-        ITextureResource::Size size = {};
+        ITextureResource::Extents size = {};
         size.width = 2;
         size.height = 2;
         size.depth = 1;
 
-        ITextureResource::Size bcSize = {};
+        ITextureResource::Extents bcSize = {};
         bcSize.width = 4;
         bcSize.height = 4;
         bcSize.depth = 1;
@@ -939,7 +939,7 @@ namespace gfx_test
                 ITextureResource::SubresourceData {(void*)texData, 16, 32},
                 ITextureResource::SubresourceData {(void*)(texData + 32), 8, 0}
             };
-            ITextureResource::Size size = {};
+            ITextureResource::Extents size = {};
             size.width = 8;
             size.height = 8;
             size.depth = 1;

--- a/tools/gfx-unit-test/get-supported-resource-states-test.cpp
+++ b/tools/gfx-unit-test/get-supported-resource-states-test.cpp
@@ -109,7 +109,7 @@ namespace
         void run()
         {
             // Skip Format::Unknown
-            for (uint32_t i = 1; i < (uint32_t)Format::CountOf; ++i)
+            for (uint32_t i = 1; i < (uint32_t)Format::_Count; ++i)
             {
                 auto baseFormat = (Format)i;
                 FormatInfo info;

--- a/tools/gfx-unit-test/get-supported-resource-states-test.cpp
+++ b/tools/gfx-unit-test/get-supported-resource-states-test.cpp
@@ -148,7 +148,7 @@ namespace
                     ResourceState::CopyDestination);
 
                 ResourceState currentState = ResourceState::CopySource;
-                ITextureResource::Size extent;
+                ITextureResource::Extents extent;
                 extent.width = 4;
                 extent.height = 4;
                 extent.depth = 1;

--- a/tools/gfx-unit-test/gfx-test-texture-util.cpp
+++ b/tools/gfx-unit-test/gfx-test-texture-util.cpp
@@ -29,14 +29,14 @@ namespace gfx_test
         }
     }
 
-    uint32_t getTexelSize(Format format)
+    Size getTexelSize(Format format)
     {
         FormatInfo info;
         GFX_CHECK_CALL_ABORT(gfxGetFormatInfo(format, &info));
         return info.blockSizeInBytes / info.pixelsPerBlock;
     }
 
-    uint32_t getSubresourceIndex(uint32_t mipLevel, uint32_t mipLevelCount, uint32_t baseArrayLayer)
+    GfxIndex getSubresourceIndex(GfxIndex mipLevel, GfxCount mipLevelCount, GfxIndex baseArrayLayer)
     {
         return baseArrayLayer * mipLevelCount + mipLevel;
     }
@@ -155,9 +155,9 @@ namespace gfx_test
         auto mipLevels = texture->mipLevelCount;
         auto texelSize = getTexelSize(texture->format);
 
-        for (uint32_t layer = 0; layer < arrayLayers; ++layer)
+        for (GfxIndex layer = 0; layer < arrayLayers; ++layer)
         {
-            for (uint32_t mip = 0; mip < mipLevels; ++mip)
+            for (GfxIndex mip = 0; mip < mipLevels; ++mip)
             {
                 RefPtr<ValidationTextureData> subresource = new ValidationTextureData();
 

--- a/tools/gfx-unit-test/gfx-test-texture-util.h
+++ b/tools/gfx-unit-test/gfx-test-texture-util.h
@@ -144,7 +144,7 @@ namespace gfx_test
     struct ValidationTextureData : RefObject
     {
         const void* textureData;
-        ITextureResource::Size extents;
+        ITextureResource::Extents extents;
         Strides strides;
 
         void* getBlockAt(GfxIndex x, GfxIndex y, GfxIndex z)
@@ -166,7 +166,7 @@ namespace gfx_test
         Format format;
         ITextureResource::Type textureType;
 
-        ITextureResource::Size extents;
+        ITextureResource::Extents extents;
         GfxCount mipLevelCount;
         GfxCount arrayLayerCount;
 

--- a/tools/gfx-unit-test/gfx-test-texture-util.h
+++ b/tools/gfx-unit-test/gfx-test-texture-util.h
@@ -10,11 +10,18 @@ using namespace gfx;
 
 namespace gfx_test
 {
+    struct Strides
+    {
+        Size x;
+        Size y;
+        Size z;
+    };
+
     struct ValidationTextureFormatBase : RefObject
     {
         virtual void validateBlocksEqual(const void* actual, const void* expected) = 0;
 
-        virtual void initializeTexel(void* texel, int x, int y, int z, int mipLevel, int arrayLayer) = 0;
+        virtual void initializeTexel(void* texel, GfxIndex x, GfxIndex y, GfxIndex z, GfxIndex mipLevel, GfxIndex arrayLayer) = 0;
     };
 
     template <typename T>
@@ -35,7 +42,7 @@ namespace gfx_test
             }
         }
 
-        virtual void initializeTexel(void* texel, int x, int y, int z, int mipLevel, int arrayLayer) override
+        virtual void initializeTexel(void* texel, GfxIndex x, GfxIndex y, GfxIndex z, GfxIndex mipLevel, GfxIndex arrayLayer) override
         {
             auto temp = (T*)texel;
 
@@ -90,7 +97,7 @@ namespace gfx_test
             }
         }
 
-        virtual void initializeTexel(void* texel, int x, int y, int z, int mipLevel, int arrayLayer) override
+        virtual void initializeTexel(void* texel, GfxIndex x, GfxIndex y, GfxIndex z, GfxIndex mipLevel, GfxIndex arrayLayer) override
         {
             T temp = 0;
 
@@ -138,9 +145,9 @@ namespace gfx_test
     {
         const void* textureData;
         ITextureResource::Size extents;
-        ITextureResource::Offset3D strides;
+        Strides strides;
 
-        void* getBlockAt(Int x, Int y, Int z)
+        void* getBlockAt(GfxIndex x, GfxIndex y, GfxIndex z)
         {
             assert(x >= 0 && x < extents.width);
             assert(y >= 0 && y < extents.height);
@@ -160,16 +167,16 @@ namespace gfx_test
         ITextureResource::Type textureType;
 
         ITextureResource::Size extents;
-        uint32_t mipLevelCount;
-        uint32_t arrayLayerCount;
+        GfxCount mipLevelCount;
+        GfxCount arrayLayerCount;
 
         List<RefPtr<ValidationTextureData>> subresourceObjects;
         List<ITextureResource::SubresourceData> subresourceDatas;
     };
 
     TextureAspect getTextureAspect(Format format);
-    uint32_t getTexelSize(Format format);
-    uint32_t getSubresourceIndex(uint32_t mipLevel, uint32_t mipLevelCount, uint32_t baseArrayLayer);
+    Size getTexelSize(Format format);
+    GfxIndex getSubresourceIndex(GfxIndex mipLevel, GfxCount mipLevelCount, GfxIndex baseArrayLayer);
     RefPtr<ValidationTextureFormatBase> getValidationTextureFormat(Format format);
     void generateTextureData(RefPtr<TextureInfo> texture, ValidationTextureFormatBase* validationFormat);
 }

--- a/tools/gfx-unit-test/resolve-resource-tests.cpp
+++ b/tools/gfx-unit-test/resolve-resource-tests.cpp
@@ -101,7 +101,7 @@ namespace
 
         struct TextureInfo
         {
-            ITextureResource::Size extent;
+            ITextureResource::Extents extent;
             int numMipLevels;
             int arraySize;
             ITextureResource::SubresourceData const* initData;
@@ -222,7 +222,7 @@ namespace
             GFX_CHECK_CALL_ABORT(device->createFramebuffer(framebufferDesc, framebuffer.writeRef()));
         }
 
-        void submitGPUWork(SubresourceRange msaaSubresource, SubresourceRange dstSubresource, ITextureResource::Size extent)
+        void submitGPUWork(SubresourceRange msaaSubresource, SubresourceRange dstSubresource, ITextureResource::Extents extent)
         {
             Slang::ComPtr<ITransientResourceHeap> transientHeap;
             ITransientResourceHeap::Desc transientHeapDesc = {};
@@ -296,7 +296,7 @@ namespace
     {
         void run()
         {
-            ITextureResource::Size extent = {};
+            ITextureResource::Extents extent = {};
             extent.width = kWidth;
             extent.height = kHeight;
             extent.depth = 1;

--- a/tools/gfx-unit-test/shared-textures-tests.cpp
+++ b/tools/gfx-unit-test/shared-textures-tests.cpp
@@ -67,7 +67,7 @@ namespace gfx_test
         }
     }
 
-    ComPtr<ITextureResource> createTexture(IDevice* device, ITextureResource::Size extents, gfx::Format format, ITextureResource::SubresourceData* initialData)
+    ComPtr<ITextureResource> createTexture(IDevice* device, ITextureResource::Extents extents, gfx::Format format, ITextureResource::SubresourceData* initialData)
     {
         ITextureResource::Desc texDesc = {};
         texDesc.type = IResource::Type::Texture2D;
@@ -152,12 +152,12 @@ namespace gfx_test
         auto intResults = createBuffer<uint32_t>(dstDevice, 16, initIntData);
         auto intBufferView = createOutBufferView(dstDevice, intResults);
 
-        ITextureResource::Size size = {};
+        ITextureResource::Extents size = {};
         size.width = 2;
         size.height = 2;
         size.depth = 1;
 
-        ITextureResource::Size bcSize = {};
+        ITextureResource::Extents bcSize = {};
         bcSize.width = 4;
         bcSize.height = 4;
         bcSize.depth = 1;

--- a/tools/gfx-unit-test/texture-types-tests.cpp
+++ b/tools/gfx-unit-test/texture-types-tests.cpp
@@ -234,11 +234,11 @@ namespace gfx_test
         void validateTextureValues(ValidationTextureData actual, ValidationTextureData original)
         {
             // TODO: needs to be extended to cover mip levels and array layers
-            for (Int x = 0; x < actual.extents.width; ++x)
+            for (GfxIndex x = 0; x < actual.extents.width; ++x)
             {
-                for (Int y = 0; y < actual.extents.height; ++y)
+                for (GfxIndex y = 0; y < actual.extents.height; ++y)
                 {
-                    for (Int z = 0; z < actual.extents.depth; ++z)
+                    for (GfxIndex z = 0; z < actual.extents.depth; ++z)
                     {
                         auto actualBlock = (uint8_t*)actual.getBlockAt(x, y, z);
                         for (Int i = 0; i < 4; ++i)
@@ -536,11 +536,11 @@ namespace gfx_test
         // TODO: Needs to handle either the correct slice or array layer (will not always check z)
         void validateTextureValues(ValidationTextureData actual)
         {
-            for (Int x = 0; x < actual.extents.width; ++x)
+            for (GfxIndex x = 0; x < actual.extents.width; ++x)
             {
-                for (Int y = 0; y < actual.extents.height; ++y)
+                for (GfxIndex y = 0; y < actual.extents.height; ++y)
                 {
-                    for (Int z = 0; z < actual.extents.depth; ++z)
+                    for (GfxIndex z = 0; z < actual.extents.depth; ++z)
                     {
                         auto actualBlock = (float*)actual.getBlockAt(x, y, z);
                         for (Int i = 0; i < 4; ++i)

--- a/tools/gfx-util/shader-cursor.cpp
+++ b/tools/gfx-util/shader-cursor.cpp
@@ -66,7 +66,7 @@ Result ShaderCursor::getField(const char* name, const char* nameEnd, ShaderCurso
             //
             fieldCursor.m_offset.uniformOffset = m_offset.uniformOffset + fieldLayout->getOffset();
             fieldCursor.m_offset.bindingRangeIndex =
-                m_offset.bindingRangeIndex + m_typeLayout->getFieldBindingRangeOffset(fieldIndex);
+                m_offset.bindingRangeIndex + (GfxIndex)m_typeLayout->getFieldBindingRangeOffset(fieldIndex);
 
             // The index of the field within any binding ranges will be the same
             // as the index computed for the parent structure.
@@ -126,8 +126,8 @@ Result ShaderCursor::getField(const char* name, const char* nameEnd, ShaderCurso
     //
     // TODO: figure out whether we should support this long-term.
     //
-    auto entryPointCount = (gfx::Int) m_baseObject->getEntryPointCount();
-    for( gfx::Int e = 0; e < entryPointCount; ++e )
+    auto entryPointCount = (GfxIndex) m_baseObject->getEntryPointCount();
+    for( GfxIndex e = 0; e < entryPointCount; ++e )
     {
         ComPtr<IShaderObject> entryPoint;
         m_baseObject->getEntryPoint(e, entryPoint.writeRef());
@@ -142,7 +142,7 @@ Result ShaderCursor::getField(const char* name, const char* nameEnd, ShaderCurso
     return SLANG_E_INVALID_ARG;
 }
 
-ShaderCursor ShaderCursor::getElement(SlangInt index) const
+ShaderCursor ShaderCursor::getElement(GfxIndex index) const
 {
     if (m_containerType != ShaderObjectContainerType::None)
     {
@@ -168,7 +168,7 @@ ShaderCursor ShaderCursor::getElement(SlangInt index) const
                 index * m_typeLayout->getElementStride(SLANG_PARAMETER_CATEGORY_UNIFORM);
             elementCursor.m_offset.bindingRangeIndex = m_offset.bindingRangeIndex;
             elementCursor.m_offset.bindingArrayIndex =
-                m_offset.bindingArrayIndex * m_typeLayout->getElementCount() + index;
+                m_offset.bindingArrayIndex * (GfxCount)m_typeLayout->getElementCount() + index;
             return elementCursor;
         }
         break;
@@ -189,7 +189,7 @@ ShaderCursor ShaderCursor::getElement(SlangInt index) const
             fieldCursor.m_typeLayout = fieldLayout->getTypeLayout();
             fieldCursor.m_offset.uniformOffset = m_offset.uniformOffset + fieldLayout->getOffset();
             fieldCursor.m_offset.bindingRangeIndex =
-                m_offset.bindingRangeIndex + m_typeLayout->getFieldBindingRangeOffset(fieldIndex);
+                m_offset.bindingRangeIndex + (GfxIndex)m_typeLayout->getFieldBindingRangeOffset(fieldIndex);
             fieldCursor.m_offset.bindingArrayIndex = m_offset.bindingArrayIndex;
 
             return fieldCursor;
@@ -266,7 +266,7 @@ Result ShaderCursor::followPath(const char* path, ShaderCursor& ioCursor)
                 return SLANG_E_INVALID_ARG;
 
             _get(rest);
-            SlangInt index = 0;
+            GfxCount index = 0;
             while (_peek(rest) != ']')
             {
                 int d = _get(rest);

--- a/tools/gfx-util/shader-cursor.h
+++ b/tools/gfx-util/shader-cursor.h
@@ -63,7 +63,7 @@ struct ShaderCursor
         return cursor;
     }
 
-    ShaderCursor getElement(SlangInt index) const;
+    ShaderCursor getElement(GfxIndex index) const;
 
     static Result followPath(const char* path, ShaderCursor& ioCursor);
 
@@ -82,7 +82,7 @@ struct ShaderCursor
         , m_containerType(object->getContainerType())
     {}
 
-    SlangResult setData(void const* data, size_t size) const
+    SlangResult setData(void const* data, Size size) const
     {
         return m_baseObject->setData(m_offset, data, size);
     }
@@ -98,7 +98,7 @@ struct ShaderCursor
         return m_baseObject->setObject(m_offset, object);
     }
 
-    SlangResult setSpecializationArgs(const slang::SpecializationArg* args, uint32_t count) const
+    SlangResult setSpecializationArgs(const slang::SpecializationArg* args, GfxCount count) const
     {
         return m_baseObject->setSpecializationArgs(m_offset, args, count);
     }
@@ -129,13 +129,13 @@ struct ShaderCursor
         /// Produce a cursor to the element or field with the given `index`.
         ///
         /// This is a convenience wrapper around `getElement()`.
-    ShaderCursor operator[](int64_t index) const { return getElement((SlangInt)index); }
-    ShaderCursor operator[](uint64_t index) const { return getElement((SlangInt)index); }
-    ShaderCursor operator[](int32_t index) const { return getElement((SlangInt)index); }
-    ShaderCursor operator[](uint32_t index) const { return getElement((SlangInt)index); }
-    ShaderCursor operator[](int16_t index) const { return getElement((SlangInt)index); }
-    ShaderCursor operator[](uint16_t index) const { return getElement((SlangInt)index); }
-    ShaderCursor operator[](int8_t index) const { return getElement((SlangInt)index); }
-    ShaderCursor operator[](uint8_t index) const { return getElement((SlangInt)index); }
+    ShaderCursor operator[](int64_t index) const { return getElement((GfxIndex)index); }
+    ShaderCursor operator[](uint64_t index) const { return getElement((GfxIndex)index); }
+    ShaderCursor operator[](int32_t index) const { return getElement((GfxIndex)index); }
+    ShaderCursor operator[](uint32_t index) const { return getElement((GfxIndex)index); }
+    ShaderCursor operator[](int16_t index) const { return getElement((GfxIndex)index); }
+    ShaderCursor operator[](uint16_t index) const { return getElement((GfxIndex)index); }
+    ShaderCursor operator[](int8_t index) const { return getElement((GfxIndex)index); }
+    ShaderCursor operator[](uint8_t index) const { return getElement((GfxIndex)index); }
 };
 }

--- a/tools/gfx/command-encoder-com-forward.h
+++ b/tools/gfx/command-encoder-com-forward.h
@@ -19,7 +19,7 @@
         ResourceState srcState,                                                                         \
         SubresourceRange srcSubresource,                                                                \
         ITextureResource::Offset3D srcOffset,                                                           \
-        ITextureResource::Size extent) override                                                         \
+        ITextureResource::Extents extent) override                                                         \
     {                                                                                                   \
         ResourceCommandEncoderBase::copyTexture(                                                        \
             dst,                                                                                        \
@@ -41,7 +41,7 @@
         ResourceState srcState,                                                                         \
         SubresourceRange srcSubresource,                                                                \
         ITextureResource::Offset3D srcOffset,                                                           \
-        ITextureResource::Size extent) override                                                         \
+        ITextureResource::Extents extent) override                                                         \
     {                                                                                                   \
         ResourceCommandEncoderBase::copyTextureToBuffer(                                                \
             dst, dstOffset, dstSize, dstRowStride, src, srcState, srcSubresource, srcOffset, extent);   \
@@ -50,7 +50,7 @@
         ITextureResource* dst,                                                                          \
         SubresourceRange subResourceRange,                                                              \
         ITextureResource::Offset3D offset,                                                              \
-        ITextureResource::Size extent,                                                                  \
+        ITextureResource::Extents extent,                                                                  \
         ITextureResource::SubresourceData* subResourceData,                                             \
         GfxCount subResourceDataCount) override                                                         \
     {                                                                                                   \

--- a/tools/gfx/command-encoder-com-forward.h
+++ b/tools/gfx/command-encoder-com-forward.h
@@ -3,10 +3,10 @@
 #define SLANG_GFX_FORWARD_RESOURCE_COMMAND_ENCODER_IMPL(ResourceCommandEncoderBase)                     \
     virtual SLANG_NO_THROW void SLANG_MCALL copyBuffer(                                                 \
         IBufferResource* dst,                                                                           \
-        size_t dstOffset,                                                                               \
+        Offset dstOffset,                                                                               \
         IBufferResource* src,                                                                           \
-        size_t srcOffset,                                                                               \
-        size_t size) override                                                                           \
+        Offset srcOffset,                                                                               \
+        Size size) override                                                                             \
     {                                                                                                   \
         ResourceCommandEncoderBase::copyBuffer(dst, dstOffset, src, srcOffset, size);                   \
     }                                                                                                   \
@@ -34,9 +34,9 @@
     }                                                                                                   \
     virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(                                        \
         IBufferResource* dst,                                                                           \
-        size_t dstOffset,                                                                               \
-        size_t dstSize,                                                                                 \
-        size_t dstRowStride,                                                                            \
+        Offset dstOffset,                                                                               \
+        Size dstSize,                                                                                   \
+        Size dstRowStride,                                                                              \
         ITextureResource* src,                                                                          \
         ResourceState srcState,                                                                         \
         SubresourceRange srcSubresource,                                                                \
@@ -52,18 +52,18 @@
         ITextureResource::Offset3D offset,                                                              \
         ITextureResource::Size extent,                                                                  \
         ITextureResource::SubresourceData* subResourceData,                                             \
-        size_t subResourceDataCount) override                                                           \
+        GfxCount subResourceDataCount) override                                                         \
     {                                                                                                   \
         ResourceCommandEncoderBase::uploadTextureData(                                                  \
             dst, subResourceRange, offset, extent, subResourceData, subResourceDataCount);              \
     }                                                                                                   \
     virtual SLANG_NO_THROW void SLANG_MCALL uploadBufferData(                                           \
-        IBufferResource* dst, size_t offset, size_t size, void* data) override                          \
+        IBufferResource* dst, Offset offset, Size size, void* data) override                            \
     {                                                                                                   \
         ResourceCommandEncoderBase::uploadBufferData(dst, offset, size, data);                          \
     }                                                                                                   \
     virtual SLANG_NO_THROW void SLANG_MCALL textureBarrier(                                             \
-        size_t count, ITextureResource* const* textures, ResourceState src, ResourceState dst)          \
+        GfxCount count, ITextureResource* const* textures, ResourceState src, ResourceState dst)        \
         override                                                                                        \
     {                                                                                                   \
         ResourceCommandEncoderBase::textureBarrier(count, textures, src, dst);                          \
@@ -78,7 +78,7 @@
             texture, subresourceRange, src, dst);                                                       \
     }                                                                                                   \
     virtual SLANG_NO_THROW void SLANG_MCALL bufferBarrier(                                              \
-        size_t count, IBufferResource* const* buffers, ResourceState src, ResourceState dst)            \
+        GfxCount count, IBufferResource* const* buffers, ResourceState src, ResourceState dst)          \
         override                                                                                        \
     {                                                                                                   \
         ResourceCommandEncoderBase::bufferBarrier(count, buffers, src, dst);                            \
@@ -101,14 +101,14 @@
     }                                                                                                   \
     virtual SLANG_NO_THROW void SLANG_MCALL resolveQuery(                                               \
         IQueryPool* queryPool,                                                                          \
-        uint32_t index,                                                                                 \
-        uint32_t count,                                                                                 \
+        GfxIndex index,                                                                                 \
+        GfxCount count,                                                                                 \
         IBufferResource* buffer,                                                                        \
-        uint64_t offset) override                                                                       \
+        Offset offset) override                                                                         \
     {                                                                                                   \
         ResourceCommandEncoderBase::resolveQuery(queryPool, index, count, buffer, offset);              \
     }                                                                                                   \
-    virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* pool, SlangInt index)            \
+    virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* pool, GfxIndex index)            \
         override                                                                                        \
     {                                                                                                   \
         ResourceCommandEncoderBase::writeTimestamp(pool, index);                                        \

--- a/tools/gfx/command-writer.h
+++ b/tools/gfx/command-writer.h
@@ -100,17 +100,17 @@ public:
     }
 
     // Copies user data into `m_data` buffer and returns the offset to retrieve the data.
-    uint32_t encodeData(const void* data, size_t size)
+    Offset encodeData(const void* data, Size size)
     {
-        uint32_t offset = (uint32_t)m_data.getCount();
-        m_data.setCount(m_data.getCount() + (Slang::Index)size);
+        Offset offset = (Offset)m_data.getCount();
+        m_data.setCount(m_data.getCount() + size);
         memcpy(m_data.getBuffer() + offset, data, size);
         return offset;
     }
 
-    uint32_t encodeObject(Slang::RefObject* obj)
+    Offset encodeObject(Slang::RefObject* obj)
     {
-        uint32_t offset = (uint32_t)m_objects.getCount();
+        Offset offset = (Offset)m_objects.getCount();
         m_objects.add(obj);
         return offset;
     }
@@ -120,7 +120,7 @@ public:
         return static_cast<T*>(m_objects[offset].Ptr());
     }
 
-    template <typename T> T* getData(uint32_t offset)
+    template <typename T> T* getData(Offset offset)
     {
         return reinterpret_cast<T*>(m_data.getBuffer() + offset);
     }
@@ -128,49 +128,49 @@ public:
     void setPipelineState(IPipelineState* state)
     {
         auto offset = encodeObject(static_cast<PipelineStateBase*>(state));
-        m_commands.add(Command(CommandName::SetPipelineState, offset));
+        m_commands.add(Command(CommandName::SetPipelineState, (uint32_t)offset));
     }
 
     void bindRootShaderObject(IShaderObject* object)
     {
         auto rootOffset = encodeObject(static_cast<ShaderObjectBase*>(object));
-        m_commands.add(Command(CommandName::BindRootShaderObject, rootOffset));
+        m_commands.add(Command(CommandName::BindRootShaderObject, (uint32_t)rootOffset));
     }
 
-    void uploadBufferData(IBufferResource* buffer, size_t offset, size_t size, void* data)
+    void uploadBufferData(IBufferResource* buffer, Offset offset, Size size, void* data)
     {
         auto bufferOffset = encodeObject(static_cast<BufferResource*>(buffer));
         auto dataOffset = encodeData(data, size);
         m_commands.add(Command(
             CommandName::UploadBufferData,
-            bufferOffset,
+            (uint32_t)bufferOffset,
             (uint32_t)offset,
             (uint32_t)size,
-            dataOffset));
+            (uint32_t)dataOffset));
     }
 
     void copyBuffer(
         IBufferResource* dst,
-        size_t dstOffset,
+        Offset dstOffset,
         IBufferResource* src,
-        size_t srcOffset,
-        size_t size)
+        Offset srcOffset,
+        Size size)
     {
         auto dstBuffer = encodeObject(static_cast<BufferResource*>(dst));
         auto srcBuffer = encodeObject(static_cast<BufferResource*>(src));
         m_commands.add(Command(
             CommandName::CopyBuffer,
-            dstBuffer,
+            (uint32_t)dstBuffer,
             (uint32_t)dstOffset,
-            srcBuffer,
+            (uint32_t)srcBuffer,
             (uint32_t)srcOffset,
             (uint32_t)size));
     }
 
     void setFramebuffer(IFramebuffer* frameBuffer)
     {
-        uint32_t framebufferOffset = encodeObject(static_cast<FramebufferBase*>(frameBuffer));
-        m_commands.add(Command(CommandName::SetFramebuffer, framebufferOffset));
+        auto framebufferOffset = encodeObject(static_cast<FramebufferBase*>(frameBuffer));
+        m_commands.add(Command(CommandName::SetFramebuffer, (uint32_t)framebufferOffset));
     }
 
     void clearFrame(uint32_t colorBufferMask, bool clearDepth, bool clearStencil)
@@ -179,16 +179,16 @@ public:
             CommandName::ClearFrame, colorBufferMask, clearDepth ? 1 : 0, clearStencil ? 1 : 0));
     }
 
-    void setViewports(UInt count, const Viewport* viewports)
+    void setViewports(GfxCount count, const Viewport* viewports)
     {
         auto offset = encodeData(viewports, sizeof(Viewport) * count);
-        m_commands.add(Command(CommandName::SetViewports, (uint32_t)count, offset));
+        m_commands.add(Command(CommandName::SetViewports, (uint32_t)count, (uint32_t)offset));
     }
 
-    void setScissorRects(UInt count, const ScissorRect* scissors)
+    void setScissorRects(GfxCount count, const ScissorRect* scissors)
     {
         auto offset = encodeData(scissors, sizeof(ScissorRect) * count);
-        m_commands.add(Command(CommandName::SetScissorRects, (uint32_t)count, offset));
+        m_commands.add(Command(CommandName::SetScissorRects, (uint32_t)count, (uint32_t)offset));
     }
 
     void setPrimitiveTopology(PrimitiveTopology topology)
@@ -197,40 +197,40 @@ public:
     }
 
     void setVertexBuffers(
-        uint32_t startSlot,
-        uint32_t slotCount,
+        GfxIndex startSlot,
+        GfxCount slotCount,
         IBufferResource* const* buffers,
-        const uint32_t* offsets)
+        const Offset* offsets)
     {
-        uint32_t bufferOffset = 0;
-        for (UInt i = 0; i < slotCount; i++)
+        Offset bufferOffset = 0;
+        for (GfxCount i = 0; i < slotCount; i++)
         {
             auto offset = encodeObject(static_cast<BufferResource*>(buffers[i]));
             if (i == 0)
                 bufferOffset = offset;
         }
-        uint32_t offsetsOffset = encodeData(offsets, sizeof(uint32_t) * slotCount);
+        auto offsetsOffset = encodeData(offsets, sizeof(Size) * slotCount);
         m_commands.add(Command(
             CommandName::SetVertexBuffers,
-            startSlot,
-            slotCount,
-            bufferOffset,
-            offsetsOffset));
+            (uint32_t)startSlot,
+            (uint32_t)slotCount,
+            (uint32_t)bufferOffset,
+            (uint32_t)offsetsOffset));
     }
 
-    void setIndexBuffer(IBufferResource* buffer, Format indexFormat, UInt offset)
+    void setIndexBuffer(IBufferResource* buffer, Format indexFormat, Offset offset)
     {
         auto bufferOffset = encodeObject(static_cast<BufferResource*>(buffer));
         m_commands.add(Command(
-            CommandName::SetIndexBuffer, bufferOffset, (uint32_t)indexFormat, (uint32_t)offset));
+            CommandName::SetIndexBuffer, (uint32_t)bufferOffset, (uint32_t)indexFormat, (uint32_t)offset));
     }
 
-    void draw(UInt vertexCount, UInt startVertex)
+    void draw(GfxCount vertexCount, GfxIndex startVertex)
     {
         m_commands.add(Command(CommandName::Draw, (uint32_t)vertexCount, (uint32_t)startVertex));
     }
 
-    void drawIndexed(UInt indexCount, UInt startIndex, UInt baseVertex)
+    void drawIndexed(GfxCount indexCount, GfxIndex startIndex, GfxIndex baseVertex)
     {
         m_commands.add(Command(
             CommandName::DrawIndexed,
@@ -240,10 +240,10 @@ public:
     }
 
     void drawInstanced(
-        uint32_t vertexCount,
-        uint32_t instanceCount,
-        uint32_t startVertex,
-        uint32_t startInstanceLocation)
+        GfxCount vertexCount,
+        GfxCount instanceCount,
+        GfxIndex startVertex,
+        GfxIndex startInstanceLocation)
     {
         m_commands.add(Command(
             CommandName::DrawInstanced,
@@ -254,18 +254,18 @@ public:
     }
 
     void drawIndexedInstanced(
-        uint32_t indexCount,
-        uint32_t instanceCount,
-        uint32_t startIndexLocation,
-        int32_t baseVertexLocation,
-        uint32_t startInstanceLocation)
+        GfxCount indexCount,
+        GfxCount instanceCount,
+        GfxIndex startIndexLocation,
+        GfxIndex baseVertexLocation,
+        GfxIndex startInstanceLocation)
     {
         m_commands.add(Command(
             CommandName::DrawIndexedInstanced,
             (uint32_t)indexCount,
             (uint32_t)instanceCount,
             (uint32_t)startIndexLocation,
-            (int32_t)baseVertexLocation,
+            (uint32_t)baseVertexLocation,
             (uint32_t)startInstanceLocation));
     }
 
@@ -280,11 +280,11 @@ public:
             Command(CommandName::DispatchCompute, (uint32_t)x, (uint32_t)y, (uint32_t)z));
     }
 
-    void writeTimestamp(IQueryPool* pool, SlangInt index)
+    void writeTimestamp(IQueryPool* pool, GfxIndex index)
     {
         auto poolOffset = encodeObject(static_cast<QueryPoolBase*>(pool));
         m_commands.add(
-            Command(CommandName::WriteTimestamp, poolOffset, (uint32_t)index));
+            Command(CommandName::WriteTimestamp, (uint32_t)poolOffset, (uint32_t)index));
         m_hasWriteTimestamps = true;
     }
 };

--- a/tools/gfx/cpu/render-cpu.cpp
+++ b/tools/gfx/cpu/render-cpu.cpp
@@ -78,7 +78,7 @@ struct CPUTextureBaseShapeInfo
     int32_t implicitArrayElementCount;
 };
 
-static const CPUTextureBaseShapeInfo kCPUTextureBaseShapeInfos[(int)ITextureResource::Type::CountOf] =
+static const CPUTextureBaseShapeInfo kCPUTextureBaseShapeInfos[(int)ITextureResource::Type::_Count] =
 {
     /* Unknown */       { 0, 0, 0 },
     /* Buffer */        { 1, 1, 1 },
@@ -208,7 +208,7 @@ struct CPUFormatInfoMap
     }
     SLANG_FORCE_INLINE const CPUTextureFormatInfo& get(Format format) const { return m_infos[Index(format)]; }
 
-    CPUTextureFormatInfo m_infos[Index(Format::CountOf)];
+    CPUTextureFormatInfo m_infos[Index(Format::_Count)];
 };
 
 static const CPUFormatInfoMap g_formatInfoMap;
@@ -852,9 +852,9 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
         init(IDevice* device, CPUShaderObjectLayout* typeLayout);
 
-    virtual SLANG_NO_THROW UInt SLANG_MCALL getEntryPointCount() override { return 0; }
+    virtual SLANG_NO_THROW GfxCount SLANG_MCALL getEntryPointCount() override { return 0; }
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getEntryPoint(UInt index, IShaderObject** outEntryPoint) override
+        getEntryPoint(GfxIndex index, IShaderObject** outEntryPoint) override
     {
         *outEntryPoint = nullptr;
         return SLANG_OK;
@@ -993,9 +993,9 @@ public:
 
     List<RefPtr<CPUEntryPointShaderObject>> m_entryPoints;
 
-    virtual SLANG_NO_THROW UInt SLANG_MCALL getEntryPointCount() override { return m_entryPoints.getCount(); }
+    virtual SLANG_NO_THROW GfxCount SLANG_MCALL getEntryPointCount() override { return (GfxCount)m_entryPoints.getCount(); }
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getEntryPoint(UInt index, IShaderObject** outEntryPoint) override
+        getEntryPoint(GfxIndex index, IShaderObject** outEntryPoint) override
     {
         returnComPtr(outEntryPoint, m_entryPoints[index]);
         return SLANG_OK;
@@ -1045,9 +1045,9 @@ public:
         return SLANG_OK;
     }
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
-        SlangInt queryIndex, SlangInt count, uint64_t* data) override
+        GfxIndex queryIndex, GfxCount count, uint64_t* data) override
     {
-        for (SlangInt i = 0; i < count; i++)
+        for (GfxCount i = 0; i < count; i++)
         {
             data[i] = m_queries[queryIndex + i];
         }
@@ -1305,7 +1305,7 @@ public:
         return SLANG_OK;
     }
 
-    virtual void writeTimestamp(IQueryPool* pool, SlangInt index) override
+    virtual void writeTimestamp(IQueryPool* pool, GfxIndex index) override
     {
         static_cast<CPUQueryPool*>(pool)->m_queries[index] =
             std::chrono::high_resolution_clock::now().time_since_epoch().count();
@@ -1395,8 +1395,8 @@ SlangResult CPUShaderObject::init(IDevice* device, CPUShaderObjectLayout* typeLa
 
             ShaderOffset offset;
             offset.uniformOffset = bindingRangeInfo.uniformOffset + sizeof(void*) * i;
-            offset.bindingRangeIndex = subObjectRange.bindingRangeIndex;
-            offset.bindingArrayIndex = i;
+            offset.bindingRangeIndex = (GfxIndex)subObjectRange.bindingRangeIndex;
+            offset.bindingArrayIndex = (GfxIndex)i;
 
             SLANG_RETURN_ON_FAIL(setObject(offset, subObject));
         }

--- a/tools/gfx/cuda/render-cuda.cpp
+++ b/tools/gfx/cuda/render-cuda.cpp
@@ -1018,7 +1018,7 @@ public:
                 ResourceState srcState,
                 SubresourceRange srcSubresource,
                 ITextureResource::Offset3D srcOffset,
-                ITextureResource::Size extent) override
+                ITextureResource::Extents extent) override
             {
                 SLANG_UNUSED(dst);
                 SLANG_UNUSED(dstState);
@@ -1036,7 +1036,7 @@ public:
                 ITextureResource* dst,
                 SubresourceRange subResourceRange,
                 ITextureResource::Offset3D offset,
-                ITextureResource::Size extent,
+                ITextureResource::Extents extent,
                 ITextureResource::SubresourceData* subResourceData,
                 GfxCount subResourceDataCount) override
             {
@@ -1101,7 +1101,7 @@ public:
                 ResourceState srcState,
                 SubresourceRange srcSubresource,
                 ITextureResource::Offset3D srcOffset,
-                ITextureResource::Size extent) override
+                ITextureResource::Extents extent) override
             {
                 SLANG_UNUSED(dst);
                 SLANG_UNUSED(dstOffset);

--- a/tools/gfx/cuda/render-cuda.cpp
+++ b/tools/gfx/cuda/render-cuda.cpp
@@ -567,9 +567,9 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
         init(IDevice* device, CUDAShaderObjectLayout* typeLayout);
 
-    virtual SLANG_NO_THROW UInt SLANG_MCALL getEntryPointCount() override { return 0; }
+    virtual SLANG_NO_THROW GfxCount SLANG_MCALL getEntryPointCount() override { return 0; }
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getEntryPoint(UInt index, IShaderObject** outEntryPoint) override
+        getEntryPoint(GfxIndex index, IShaderObject** outEntryPoint) override
     {
         *outEntryPoint = nullptr;
         return SLANG_OK;
@@ -580,15 +580,15 @@ public:
         return m_data.getBuffer();
     }
 
-    virtual SLANG_NO_THROW size_t SLANG_MCALL getSize() override
+    virtual SLANG_NO_THROW Size SLANG_MCALL getSize() override
     {
-        return (size_t)m_data.getCount();
+        return (Size)m_data.getCount();
     }
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        setData(ShaderOffset const& offset, void const* data, size_t size) override
+        setData(ShaderOffset const& offset, void const* data, Size size) override
     {
-        size = Math::Min(size, (size_t)m_data.getCount() - offset.uniformOffset);
+        size = Math::Min(size, (Size)m_data.getCount() - offset.uniformOffset);
         SLANG_CUDA_RETURN_ON_FAIL(cudaMemcpy(
             (uint8_t*)m_data.getBuffer() + offset.uniformOffset, data, size, cudaMemcpyDefault));
         return SLANG_OK;
@@ -709,9 +709,9 @@ public:
     List<RefPtr<CUDAEntryPointShaderObject>> entryPointObjects;
     virtual SLANG_NO_THROW Result SLANG_MCALL
         init(IDevice* device, CUDAShaderObjectLayout* typeLayout) override;
-    virtual SLANG_NO_THROW UInt SLANG_MCALL getEntryPointCount() override { return entryPointObjects.getCount(); }
+    virtual SLANG_NO_THROW GfxCount SLANG_MCALL getEntryPointCount() override { return (GfxCount)entryPointObjects.getCount(); }
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getEntryPoint(UInt index, IShaderObject** outEntryPoint) override
+        getEntryPoint(GfxIndex index, IShaderObject** outEntryPoint) override
     {
         returnComPtr(outEntryPoint, entryPointObjects[index]);
         return SLANG_OK;
@@ -786,9 +786,9 @@ public:
     }
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
-        SlangInt queryIndex, SlangInt count, uint64_t* data) override
+        GfxIndex queryIndex, GfxCount count, uint64_t* data) override
     {
-        for (SlangInt i = 0; i < count; i++)
+        for (GfxIndex i = 0; i < count; i++)
         {
             float time = 0.0f;
             cuEventSynchronize(m_events[i + queryIndex]);
@@ -975,36 +975,36 @@ public:
             virtual SLANG_NO_THROW void SLANG_MCALL endEncoding() override {}
             virtual SLANG_NO_THROW void SLANG_MCALL copyBuffer(
                 IBufferResource* dst,
-                size_t dstOffset,
+                Offset dstOffset,
                 IBufferResource* src,
-                size_t srcOffset,
-                size_t size) override
+                Offset srcOffset,
+                Size size) override
             {
                 m_writer->copyBuffer(dst, dstOffset, src, srcOffset, size);
             }
 
             virtual SLANG_NO_THROW void SLANG_MCALL textureBarrier(
-                size_t count,
+                GfxCount count,
                 ITextureResource* const* textures,
                 ResourceState src,
                 ResourceState dst) override
             {}
 
             virtual SLANG_NO_THROW void SLANG_MCALL bufferBarrier(
-                size_t count,
+                GfxCount count,
                 IBufferResource* const* buffers,
                 ResourceState src,
                 ResourceState dst) override
             {}
 
             virtual SLANG_NO_THROW void SLANG_MCALL uploadBufferData(
-                IBufferResource* dst, size_t offset, size_t size, void* data) override
+                IBufferResource* dst, Offset offset, Size size, void* data) override
             {
                 m_writer->uploadBufferData(dst, offset, size, data);
             }
 
             virtual SLANG_NO_THROW void SLANG_MCALL
-                writeTimestamp(IQueryPool* pool, SlangInt index) override
+                writeTimestamp(IQueryPool* pool, GfxIndex index) override
             {
                 m_writer->writeTimestamp(pool, index);
             }
@@ -1038,7 +1038,7 @@ public:
                 ITextureResource::Offset3D offset,
                 ITextureResource::Size extent,
                 ITextureResource::SubresourceData* subResourceData,
-                size_t subResourceDataCount) override
+                GfxCount subResourceDataCount) override
             {
                 SLANG_UNUSED(dst);
                 SLANG_UNUSED(subResourceRange);
@@ -1079,10 +1079,10 @@ public:
 
             virtual SLANG_NO_THROW void SLANG_MCALL resolveQuery(
                 IQueryPool* queryPool,
-                uint32_t index,
-                uint32_t count,
+                GfxIndex index,
+                GfxCount count,
                 IBufferResource* buffer,
-                uint64_t offset) override
+                Offset offset) override
             {
                 SLANG_UNUSED(queryPool);
                 SLANG_UNUSED(index);
@@ -1094,9 +1094,9 @@ public:
 
             virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
                 IBufferResource* dst,
-                size_t dstOffset,
-                size_t dstSize,
-                size_t dstRowStride,
+                Offset dstOffset,
+                Size dstSize,
+                Size dstRowStride,
                 ITextureResource* src,
                 ResourceState srcState,
                 SubresourceRange srcSubresource,
@@ -1260,12 +1260,12 @@ public:
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL executeCommandBuffers(
-            uint32_t count, ICommandBuffer* const* commandBuffers, IFence* fence, uint64_t valueToSignal) override
+            GfxCount count, ICommandBuffer* const* commandBuffers, IFence* fence, uint64_t valueToSignal) override
         {
             SLANG_UNUSED(valueToSignal);
             // TODO: implement fence.
             assert(fence == nullptr);
-            for (uint32_t i = 0; i < count; i++)
+            for (GfxIndex i = 0; i < count; i++)
             {
                 execute(static_cast<CommandBufferImpl*>(commandBuffers[i]));
             }
@@ -1279,7 +1279,7 @@ public:
         }
 
         virtual SLANG_NO_THROW Result SLANG_MCALL waitForFenceValuesOnDevice(
-            uint32_t fenceCount, IFence** fences, uint64_t* waitValues) override
+            GfxCount fenceCount, IFence** fences, uint64_t* waitValues) override
         {
             return SLANG_FAIL;
         }
@@ -2472,8 +2472,8 @@ SlangResult CUDAShaderObject::init(IDevice* device, CUDAShaderObjectLayout* type
 
             ShaderOffset offset;
             offset.uniformOffset = bindingRangeInfo.uniformOffset + sizeof(void*) * i;
-            offset.bindingRangeIndex = subObjectRange.bindingRangeIndex;
-            offset.bindingArrayIndex = i;
+            offset.bindingRangeIndex = (GfxIndex)subObjectRange.bindingRangeIndex;
+            offset.bindingArrayIndex = (GfxIndex)i;
 
             SLANG_RETURN_ON_FAIL(setObject(offset, subObject));
         }

--- a/tools/gfx/cuda/render-cuda.cpp
+++ b/tools/gfx/cuda/render-cuda.cpp
@@ -1191,7 +1191,7 @@ public:
             }
 
             virtual SLANG_NO_THROW void SLANG_MCALL
-                dispatchComputeIndirect(IBufferResource* argBuffer, uint64_t offset) override
+                dispatchComputeIndirect(IBufferResource* argBuffer, Offset offset) override
             {
                 SLANG_UNIMPLEMENTED_X("dispatchComputeIndirect");
             }

--- a/tools/gfx/d3d/d3d-swapchain.h
+++ b/tools/gfx/d3d/d3d-swapchain.h
@@ -92,7 +92,7 @@ public:
     }
     virtual SLANG_NO_THROW const Desc& SLANG_MCALL getDesc() override { return m_desc; }
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getImage(uint32_t index, ITextureResource** outResource) override
+        getImage(GfxIndex index, ITextureResource** outResource) override
     {
         returnComPtr(outResource, m_images[index]);
         return SLANG_OK;
@@ -114,7 +114,7 @@ public:
     }
 
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL resize(uint32_t width, uint32_t height) override
+    virtual SLANG_NO_THROW Result SLANG_MCALL resize(GfxCount width, GfxCount height) override
     {
         if (width == m_desc.width && height == m_desc.height)
             return SLANG_OK;

--- a/tools/gfx/d3d11/render-d3d11.cpp
+++ b/tools/gfx/d3d11/render-d3d11.cpp
@@ -3320,7 +3320,7 @@ void D3D11Device::setVertexBuffers(
 
 	auto buffers = (BufferResourceImpl*const*)buffersIn;
 
-    for (UInt ii = 0; ii < slotCount; ++ii)
+    for (GfxIndex ii = 0; ii < slotCount; ++ii)
     {
         auto inputLayout = (InputLayoutImpl*)m_currentPipelineState->inputLayout.Ptr();
         vertexStrides[ii] = inputLayout->m_vertexStreamStrides[startSlot + ii];
@@ -3343,7 +3343,7 @@ void D3D11Device::setViewports(GfxCount count, Viewport const* viewports)
     assert(count <= kMaxViewports);
 
     D3D11_VIEWPORT dxViewports[kMaxViewports];
-    for(UInt ii = 0; ii < count; ++ii)
+    for(GfxIndex ii = 0; ii < count; ++ii)
     {
         auto& inViewport = viewports[ii];
         auto& dxViewport = dxViewports[ii];
@@ -3365,7 +3365,7 @@ void D3D11Device::setScissorRects(GfxCount count, ScissorRect const* rects)
     assert(count <= kMaxScissorRects);
 
     D3D11_RECT dxRects[kMaxScissorRects];
-    for(UInt ii = 0; ii < count; ++ii)
+    for(GfxIndex ii = 0; ii < count; ++ii)
     {
         auto& inRect = rects[ii];
         auto& dxRect = dxRects[ii];
@@ -3903,7 +3903,7 @@ Result D3D11Device::createGraphicsPipelineState(const GraphicsPipelineStateDesc&
         static const UInt kMaxTargets = D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT;
         if(srcDesc.targetCount > kMaxTargets) return SLANG_FAIL;
 
-        for(UInt ii = 0; ii < kMaxTargets; ++ii)
+        for(GfxIndex ii = 0; ii < kMaxTargets; ++ii)
         {
             TargetBlendDesc const* srcTargetBlendDescPtr = nullptr;
             if(ii < srcDesc.targetCount)
@@ -3983,10 +3983,10 @@ Result D3D11Device::createComputePipelineState(const ComputePipelineStateDesc& i
 
 void D3D11Device::copyBuffer(
     IBufferResource* dst,
-    size_t dstOffset,
+    Offset dstOffset,
     IBufferResource* src,
-    size_t srcOffset,
-    size_t size)
+    Offset srcOffset,
+    Size size)
 {
     auto dstImpl = static_cast<BufferResourceImpl*>(dst);
     auto srcImpl = static_cast<BufferResourceImpl*>(src);

--- a/tools/gfx/d3d11/render-d3d11.cpp
+++ b/tools/gfx/d3d11/render-d3d11.cpp
@@ -137,29 +137,29 @@ public:
     virtual void setPrimitiveTopology(PrimitiveTopology topology) override;
 
     virtual void setVertexBuffers(
-        uint32_t startSlot,
-        uint32_t slotCount,
+        GfxIndex startSlot,
+        GfxCount slotCount,
         IBufferResource* const* buffers,
-        const uint32_t* offsets) override;
+        const Offset* offsets) override;
     virtual void setIndexBuffer(
-        IBufferResource* buffer, Format indexFormat, uint32_t offset) override;
-    virtual void setViewports(UInt count, Viewport const* viewports) override;
-    virtual void setScissorRects(UInt count, ScissorRect const* rects) override;
+        IBufferResource* buffer, Format indexFormat, Offset  offset) override;
+    virtual void setViewports(GfxCount count, Viewport const* viewports) override;
+    virtual void setScissorRects(GfxCount count, ScissorRect const* rects) override;
     virtual void setPipelineState(IPipelineState* state) override;
-    virtual void draw(uint32_t vertexCount, uint32_t startVertex) override;
+    virtual void draw(GfxCount vertexCount, GfxIndex startVertex) override;
     virtual void drawIndexed(
-        uint32_t indexCount, uint32_t startIndex, uint32_t baseVertex) override;
+        GfxCount indexCount, GfxIndex startIndex, GfxIndex baseVertex) override;
     virtual void drawInstanced(
-        uint32_t vertexCount,
-        uint32_t instanceCount,
-        uint32_t startVertex,
-        uint32_t startInstanceLocation) override;
+        GfxCount vertexCount,
+        GfxCount instanceCount,
+        GfxIndex startVertex,
+        GfxIndex startInstanceLocation) override;
     virtual void drawIndexedInstanced(
-        uint32_t indexCount,
-        uint32_t instanceCount,
-        uint32_t startIndexLocation,
-        int32_t baseVertexLocation,
-        uint32_t startInstanceLocation) override;
+        GfxCount indexCount,
+        GfxCount instanceCount,
+        GfxIndex startIndexLocation,
+        GfxIndex baseVertexLocation,
+        GfxIndex startInstanceLocation) override;
     virtual void dispatchCompute(int x, int y, int z) override;
     virtual void submitGpuWork() override {}
     virtual void waitForGpu() override
@@ -184,7 +184,7 @@ public:
             m_immediateContext->End(m_disjointQuery);
         }
     }
-    virtual void writeTimestamp(IQueryPool* pool, SlangInt index) override
+    virtual void writeTimestamp(IQueryPool* pool, GfxIndex index) override
     {
         auto poolImpl = static_cast<QueryPoolImpl*>(pool);
         m_immediateContext->End(poolImpl->getQuery(index));
@@ -357,14 +357,14 @@ protected:
                 ResourceState::RenderTarget);
             RefPtr<TextureResourceImpl> image = new TextureResourceImpl(imageDesc);
             image->m_resource = d3dResource;
-            for (uint32_t i = 0; i < m_desc.imageCount; i++)
+            for (GfxIndex i = 0; i < m_desc.imageCount; i++)
             {
                 m_images.add(image);
             }
         }
         virtual IDXGIFactory* getDXGIFactory() override { return m_dxgiFactory; }
         virtual IUnknown* getOwningDevice() override { return m_device; }
-        virtual SLANG_NO_THROW Result SLANG_MCALL resize(uint32_t width, uint32_t height) override
+        virtual SLANG_NO_THROW Result SLANG_MCALL resize(GfxCount width, GfxCount height) override
         {
             m_renderer->m_currentFramebuffer = nullptr;
             m_renderer->m_immediateContext->ClearState();
@@ -416,7 +416,7 @@ protected:
         }
 
         virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
-            SlangInt queryIndex, SlangInt count, uint64_t* data) override
+            GfxIndex queryIndex, GfxCount count, uint64_t* data) override
         {
             D3D11_QUERY_DATA_TIMESTAMP_DISJOINT disjointData;
             while (S_OK != m_device->m_immediateContext->GetData(
@@ -1268,9 +1268,9 @@ protected:
 
         RendererBase* getDevice() { return m_layout->getDevice(); }
 
-        SLANG_NO_THROW UInt SLANG_MCALL getEntryPointCount() SLANG_OVERRIDE { return 0; }
+        SLANG_NO_THROW GfxCount SLANG_MCALL getEntryPointCount() SLANG_OVERRIDE { return 0; }
 
-        SLANG_NO_THROW Result SLANG_MCALL getEntryPoint(UInt index, IShaderObject** outEntryPoint)
+        SLANG_NO_THROW Result SLANG_MCALL getEntryPoint(GfxIndex index, IShaderObject** outEntryPoint)
             SLANG_OVERRIDE
         {
             *outEntryPoint = nullptr;
@@ -1859,8 +1859,8 @@ protected:
 
         RootShaderObjectLayoutImpl* getLayout() { return static_cast<RootShaderObjectLayoutImpl*>(m_layout.Ptr()); }
 
-        UInt SLANG_MCALL getEntryPointCount() SLANG_OVERRIDE { return (UInt)m_entryPoints.getCount(); }
-        SlangResult SLANG_MCALL getEntryPoint(UInt index, IShaderObject** outEntryPoint) SLANG_OVERRIDE
+        GfxCount SLANG_MCALL getEntryPointCount() SLANG_OVERRIDE { return (GfxCount)m_entryPoints.getCount(); }
+        SlangResult SLANG_MCALL getEntryPoint(GfxIndex index, IShaderObject** outEntryPoint) SLANG_OVERRIDE
         {
             returnComPtr(outEntryPoint, m_entryPoints[index]);
             return SLANG_OK;
@@ -2417,7 +2417,7 @@ Result D3D11Device::createFramebufferLayout(
 {
     RefPtr<FramebufferLayoutImpl> layout = new FramebufferLayoutImpl();
     layout->m_renderTargets.setCount(desc.renderTargetCount);
-    for (uint32_t i = 0; i < desc.renderTargetCount; i++)
+    for (GfxIndex i = 0; i < desc.renderTargetCount; i++)
     {
         layout->m_renderTargets[i] = desc.renderTargets[i];
     }
@@ -2441,7 +2441,7 @@ Result D3D11Device::createFramebuffer(
     RefPtr<FramebufferImpl> framebuffer = new FramebufferImpl();
     framebuffer->renderTargetViews.setCount(desc.renderTargetCount);
     framebuffer->d3dRenderTargetViews.setCount(desc.renderTargetCount);
-    for (uint32_t i = 0; i < desc.renderTargetCount; i++)
+    for (GfxIndex i = 0; i < desc.renderTargetCount; i++)
     {
         framebuffer->renderTargetViews[i] = static_cast<RenderTargetViewImpl*>(desc.renderTargetViews[i]);
         framebuffer->d3dRenderTargetViews[i] = framebuffer->renderTargetViews[i]->m_rtv;
@@ -2782,7 +2782,7 @@ Result D3D11Device::createBufferResource(const IBufferResource::Desc& descIn, co
         //desc.BindFlags = D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE;
         if (srcDesc.elementSize != 0)
         {
-            bufferDesc.StructureByteStride = srcDesc.elementSize;
+            bufferDesc.StructureByteStride = (UINT)srcDesc.elementSize;
             bufferDesc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
         }
         else
@@ -3191,7 +3191,7 @@ Result D3D11Device::createInputLayout(IInputLayout::Desc const& desc, IInputLayo
     impl->m_vertexStreamStrides.setCount(vertexStreamCount);
     for (Int i = 0; i < vertexStreamCount; ++i)
     {
-        impl->m_vertexStreamStrides[i] = desc.vertexStreams[i].stride;
+        impl->m_vertexStreamStrides[i] = (UINT)desc.vertexStreams[i].stride;
     }
 
     returnComPtr(outLayout, impl);
@@ -3305,10 +3305,10 @@ void D3D11Device::setPrimitiveTopology(PrimitiveTopology topology)
 }
 
 void D3D11Device::setVertexBuffers(
-    uint32_t startSlot,
-    uint32_t slotCount,
+    GfxIndex startSlot,
+    GfxCount slotCount,
     IBufferResource* const* buffersIn,
-    const uint32_t* offsetsIn)
+    const Offset* offsetsIn)
 {
     static const int kMaxVertexBuffers = 16;
 	assert(slotCount <= kMaxVertexBuffers);
@@ -3331,13 +3331,13 @@ void D3D11Device::setVertexBuffers(
     m_immediateContext->IASetVertexBuffers((UINT)startSlot, (UINT)slotCount, dxBuffers, &vertexStrides[0], &vertexOffsets[0]);
 }
 
-void D3D11Device::setIndexBuffer(IBufferResource* buffer, Format indexFormat, uint32_t offset)
+void D3D11Device::setIndexBuffer(IBufferResource* buffer, Format indexFormat, Offset offset)
 {
     DXGI_FORMAT dxFormat = D3DUtil::getMapFormat(indexFormat);
     m_immediateContext->IASetIndexBuffer(((BufferResourceImpl*)buffer)->m_buffer, dxFormat, UINT(offset));
 }
 
-void D3D11Device::setViewports(UInt count, Viewport const* viewports)
+void D3D11Device::setViewports(GfxCount count, Viewport const* viewports)
 {
     static const int kMaxViewports = D3D11_VIEWPORT_AND_SCISSORRECT_MAX_INDEX + 1;
     assert(count <= kMaxViewports);
@@ -3359,7 +3359,7 @@ void D3D11Device::setViewports(UInt count, Viewport const* viewports)
     m_immediateContext->RSSetViewports(UINT(count), dxViewports);
 }
 
-void D3D11Device::setScissorRects(UInt count, ScissorRect const* rects)
+void D3D11Device::setScissorRects(GfxCount count, ScissorRect const* rects)
 {
     static const int kMaxScissorRects = D3D11_VIEWPORT_AND_SCISSORRECT_MAX_INDEX + 1;
     assert(count <= kMaxScissorRects);
@@ -3451,23 +3451,23 @@ void D3D11Device::setPipelineState(IPipelineState* state)
     /// ...
 }
 
-void D3D11Device::draw(uint32_t vertexCount, uint32_t startVertex)
+void D3D11Device::draw(GfxCount vertexCount, GfxIndex startVertex)
 {
     _flushGraphicsState();
     m_immediateContext->Draw(vertexCount, startVertex);
 }
 
-void D3D11Device::drawIndexed(uint32_t indexCount, uint32_t startIndex, uint32_t baseVertex)
+void D3D11Device::drawIndexed(GfxCount indexCount, GfxIndex startIndex, GfxIndex baseVertex)
 {
     _flushGraphicsState();
     m_immediateContext->DrawIndexed(indexCount, startIndex, baseVertex);
 }
 
 void D3D11Device::drawInstanced(
-    uint32_t vertexCount,
-    uint32_t instanceCount,
-    uint32_t startVertex,
-    uint32_t startInstanceLocation)
+    GfxCount vertexCount,
+    GfxCount instanceCount,
+    GfxIndex startVertex,
+    GfxIndex startInstanceLocation)
 {
     _flushGraphicsState();
     m_immediateContext->DrawInstanced(
@@ -3478,11 +3478,11 @@ void D3D11Device::drawInstanced(
 }
 
 void D3D11Device::drawIndexedInstanced(
-    uint32_t indexCount,
-    uint32_t instanceCount,
-    uint32_t startIndexLocation,
-    int32_t baseVertexLocation,
-    uint32_t startInstanceLocation)
+    GfxCount indexCount,
+    GfxCount instanceCount,
+    GfxIndex startIndexLocation,
+    GfxIndex baseVertexLocation,
+    GfxIndex startInstanceLocation)
 {
     _flushGraphicsState();
     m_immediateContext->DrawIndexedInstanced(

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -1500,7 +1500,7 @@ Result DeviceImpl::createTextureResource(
                 const D3D12_PLACED_SUBRESOURCE_FOOTPRINT& layout = layouts[j];
                 const D3D12_SUBRESOURCE_FOOTPRINT& footprint = layout.Footprint;
 
-                TextureResource::Size mipSize = calcMipSize(srcDesc.size, j);
+                TextureResource::Extents mipSize = calcMipSize(srcDesc.size, j);
                 if (gfxIsCompressedFormat(descIn.format))
                 {
                     mipSize.width = int(D3DUtil::calcAligned(mipSize.width, 4));
@@ -6618,7 +6618,7 @@ void ResourceCommandEncoderImpl::copyTexture(
     ResourceState srcState,
     SubresourceRange srcSubresource,
     ITextureResource::Offset3D srcOffset,
-    ITextureResource::Size extent)
+    ITextureResource::Extents extent)
 {
     auto dstTexture = static_cast<TextureResourceImpl*>(dst);
     auto srcTexture = static_cast<TextureResourceImpl*>(src);
@@ -6684,7 +6684,7 @@ void ResourceCommandEncoderImpl::uploadTextureData(
     ITextureResource* dst,
     SubresourceRange subResourceRange,
     ITextureResource::Offset3D offset,
-    ITextureResource::Size extent,
+    ITextureResource::Extents extent,
     ITextureResource::SubresourceData* subResourceData,
     GfxCount subResourceDataCount)
 {
@@ -6968,7 +6968,7 @@ void ResourceCommandEncoderImpl::copyTextureToBuffer(
     ResourceState srcState,
     SubresourceRange srcSubresource,
     ITextureResource::Offset3D srcOffset,
-    ITextureResource::Size extent)
+    ITextureResource::Extents extent)
 {
     assert(srcSubresource.mipLevelCount <= 1);
 

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -2865,7 +2865,7 @@ Result TransientResourceHeapImpl::queryInterface(SlangUUID const& uuid, void** o
 Result TransientResourceHeapImpl::allocateTransientDescriptorTable(
     DescriptorType type,
     GfxCount count,
-    uint64_t& outDescriptorOffset,
+    Offset& outDescriptorOffset,
     void** outD3DDescriptorHeapHandle)
 {
     auto& heap =
@@ -2875,7 +2875,7 @@ Result TransientResourceHeapImpl::allocateTransientDescriptorTable(
     {
         return SLANG_E_OUT_OF_MEMORY;
     }
-    outDescriptorOffset = (uint64_t)allocResult;
+    outDescriptorOffset = (Offset)allocResult;
     *outD3DDescriptorHeapHandle = heap.getHeap();
     return SLANG_OK;
 }
@@ -3343,7 +3343,7 @@ void translatePostBuildInfoDescs(
 
 void RayTracingCommandEncoderImpl::buildAccelerationStructure(
     const IAccelerationStructure::BuildDesc& desc,
-    int propertyQueryCount,
+    GfxCount propertyQueryCount,
     AccelerationStructureQueryDesc* queryDescs)
 {
     if (!m_commandBuffer->m_cmdList4)

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -2451,9 +2451,9 @@ Result DeviceImpl::getAccelerationStructurePrebuildInfo(
     D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuildInfo;
     m_device5->GetRaytracingAccelerationStructurePrebuildInfo(&inputsBuilder.desc, &prebuildInfo);
 
-    outPrebuildInfo->resultDataMaxSize = prebuildInfo.ResultDataMaxSizeInBytes;
-    outPrebuildInfo->scratchDataSize = prebuildInfo.ScratchDataSizeInBytes;
-    outPrebuildInfo->updateScratchDataSize = prebuildInfo.UpdateScratchDataSizeInBytes;
+    outPrebuildInfo->resultDataMaxSize = (Size)prebuildInfo.ResultDataMaxSizeInBytes;
+    outPrebuildInfo->scratchDataSize = (Size)prebuildInfo.ScratchDataSizeInBytes;
+    outPrebuildInfo->updateScratchDataSize = (Size)prebuildInfo.UpdateScratchDataSizeInBytes;
     return SLANG_OK;
 }
 
@@ -3401,15 +3401,15 @@ void RayTracingCommandEncoderImpl::copyAccelerationStructure(
 }
 
 void RayTracingCommandEncoderImpl::queryAccelerationStructureProperties(
-    int accelerationStructureCount,
+    GfxCount accelerationStructureCount,
     IAccelerationStructure* const* accelerationStructures,
-    int queryCount,
+    GfxCount queryCount,
     AccelerationStructureQueryDesc* queryDescs)
 {
     List<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC> postBuildInfoDescs;
     List<DeviceAddress> asAddresses;
     asAddresses.setCount(accelerationStructureCount);
-    for (int i = 0; i < accelerationStructureCount; i++)
+    for (GfxIndex i = 0; i < accelerationStructureCount; i++)
         asAddresses[i] = accelerationStructures[i]->getDeviceAddress();
     translatePostBuildInfoDescs(queryCount, queryDescs, postBuildInfoDescs);
     m_commandBuffer->m_cmdList4->EmitRaytracingAccelerationStructurePostbuildInfo(

--- a/tools/gfx/d3d12/render-d3d12.h
+++ b/tools/gfx/d3d12/render-d3d12.h
@@ -1608,7 +1608,7 @@ public:
 public:
     virtual SLANG_NO_THROW void SLANG_MCALL buildAccelerationStructure(
         const IAccelerationStructure::BuildDesc& desc,
-        int propertyQueryCount,
+        GfxCount propertyQueryCount,
         AccelerationStructureQueryDesc* queryDescs) override;
     virtual SLANG_NO_THROW void SLANG_MCALL copyAccelerationStructure(
         IAccelerationStructure* dest,

--- a/tools/gfx/d3d12/render-d3d12.h
+++ b/tools/gfx/d3d12/render-d3d12.h
@@ -1615,9 +1615,9 @@ public:
         IAccelerationStructure* src,
         AccelerationStructureCopyMode mode) override;
     virtual SLANG_NO_THROW void SLANG_MCALL queryAccelerationStructureProperties(
-        int accelerationStructureCount,
+        GfxCount accelerationStructureCount,
         IAccelerationStructure* const* accelerationStructures,
-        int queryCount,
+        GfxCount queryCount,
         AccelerationStructureQueryDesc* queryDescs) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
         serializeAccelerationStructure(DeviceAddress dest, IAccelerationStructure* source) override;

--- a/tools/gfx/d3d12/render-d3d12.h
+++ b/tools/gfx/d3d12/render-d3d12.h
@@ -205,7 +205,7 @@ public:
         createFence(const IFence::Desc& desc, IFence** outFence) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL waitForFences(
-        uint32_t fenceCount,
+        GfxCount fenceCount,
         IFence** fences,
         uint64_t* fenceValues,
         bool waitForAll,
@@ -425,9 +425,9 @@ public:
     Result init(const IQueryPool::Desc& desc, DeviceImpl* device);
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getResult(SlangInt queryIndex, SlangInt count, uint64_t* data) override;
+        getResult(GfxIndex queryIndex, GfxCount count, uint64_t* data) override;
 
-    void writeTimestamp(ID3D12GraphicsCommandList* cmdList, SlangInt index);
+    void writeTimestamp(ID3D12GraphicsCommandList* cmdList, GfxIndex index);
 
 public:
     D3D12_QUERY_TYPE m_queryType;
@@ -455,7 +455,7 @@ public:
 
     virtual SLANG_NO_THROW Result SLANG_MCALL reset() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getResult(SlangInt queryIndex, SlangInt count, uint64_t* data) override;
+        getResult(GfxIndex queryIndex, GfxCount count, uint64_t* data) override;
 
 public:
     QueryType m_queryType;
@@ -525,8 +525,8 @@ public:
 
     virtual SLANG_NO_THROW Result SLANG_MCALL allocateTransientDescriptorTable(
         DescriptorType type,
-        uint32_t count,
-        uint64_t& outDescriptorOffset,
+        GfxCount count,
+        Offset& outDescriptorOffset,
         void** outD3DDescriptorHeapHandle) override;
 
     ~TransientResourceHeapImpl();
@@ -1182,18 +1182,18 @@ public:
 
     RendererBase* getDevice() { return m_device.get(); }
 
-    virtual SLANG_NO_THROW UInt SLANG_MCALL getEntryPointCount() override;
+    virtual SLANG_NO_THROW GfxCount SLANG_MCALL getEntryPointCount() override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getEntryPoint(UInt index, IShaderObject** outEntryPoint) override;
+        getEntryPoint(GfxIndex index, IShaderObject** outEntryPoint) override;
 
     virtual SLANG_NO_THROW const void* SLANG_MCALL getRawData() override;
 
-    // TODO: Change size_t to Count?
-    virtual SLANG_NO_THROW size_t SLANG_MCALL getSize() override;
+    virtual SLANG_NO_THROW Size SLANG_MCALL getSize() override;
 
+    // TODO: What to do with size_t?
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        setData(ShaderOffset const& inOffset, void const* data, Size inSize) override;
+        setData(ShaderOffset const& inOffset, void const* data, size_t inSize) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
         setObject(ShaderOffset const& offset, IShaderObject* object) override;
 
@@ -1340,9 +1340,9 @@ public:
 public:
     RootShaderObjectLayoutImpl* getLayout();
 
-    virtual SLANG_NO_THROW UInt SLANG_MCALL getEntryPointCount() override;
+    virtual SLANG_NO_THROW GfxCount SLANG_MCALL getEntryPointCount() override;
     virtual SLANG_NO_THROW SlangResult SLANG_MCALL
-        getEntryPoint(UInt index, IShaderObject** outEntryPoint) override;
+        getEntryPoint(GfxIndex index, IShaderObject** outEntryPoint) override;
     virtual Result collectSpecializationArgs(ExtendedShaderObjectTypeList& args) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
         copyFrom(IShaderObject* object, ITransientResourceHeap* transientHeap) override;
@@ -1407,18 +1407,18 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL
         uploadBufferData(IBufferResource* dst, Offset offset, Size size, void* data) override;
     virtual SLANG_NO_THROW void SLANG_MCALL textureBarrier(
-        size_t count, // TODO: Change size_t to Count?
+        GfxCount count,
         ITextureResource* const* textures,
         ResourceState src,
         ResourceState dst) override;
     virtual SLANG_NO_THROW void SLANG_MCALL bufferBarrier(
-        size_t count, // TODO: Change size_t to Count?
+        GfxCount count,
         IBufferResource* const* buffers,
         ResourceState src,
         ResourceState dst) override;
     virtual SLANG_NO_THROW void SLANG_MCALL endEncoding() {}
     virtual SLANG_NO_THROW void SLANG_MCALL
-        writeTimestamp(IQueryPool* pool, SlangInt index) override;
+        writeTimestamp(IQueryPool* pool, GfxIndex index) override;
     virtual SLANG_NO_THROW void SLANG_MCALL copyTexture(
         ITextureResource* dst,
         ResourceState dstState,
@@ -1436,7 +1436,7 @@ public:
         ITextureResource::Offset3D offset,
         ITextureResource::Size extent,
         ITextureResource::SubresourceData* subResourceData,
-        size_t subResourceDataCount) override; // TODO: Change size_t to Count?
+        GfxCount subResourceDataCount) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL clearResourceView(
         IResourceView* view, ClearValue* clearValue, ClearResourceViewFlags::Enum flags) override;
@@ -1451,10 +1451,10 @@ public:
 
     virtual SLANG_NO_THROW void SLANG_MCALL resolveQuery(
         IQueryPool* queryPool,
-        uint32_t index,
-        uint32_t count,
+        GfxIndex index,
+        GfxCount count,
         IBufferResource* buffer,
-        uint64_t offset) override;
+        Offset offset) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
         IBufferResource* dst,
@@ -1500,7 +1500,7 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL dispatchCompute(int x, int y, int z) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL
-        dispatchComputeIndirect(IBufferResource* argBuffer, uint64_t offset) override;
+        dispatchComputeIndirect(IBufferResource* argBuffer, Offset offset) override;
 };
 class RenderCommandEncoderImpl
     : public IRenderCommandEncoder
@@ -1539,63 +1539,63 @@ public:
         bindPipelineWithRootObject(IPipelineState* state, IShaderObject* rootObject) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL
-        setViewports(uint32_t count, const Viewport* viewports) override;
+        setViewports(GfxCount count, const Viewport* viewports) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL
-        setScissorRects(uint32_t count, const ScissorRect* rects) override;
+        setScissorRects(GfxCount count, const ScissorRect* rects) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL
         setPrimitiveTopology(PrimitiveTopology topology) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL setVertexBuffers(
-        uint32_t startSlot,
-        uint32_t slotCount,
+        GfxIndex startSlot,
+        GfxCount slotCount,
         IBufferResource* const* buffers,
-        const uint32_t* offsets) override;
+        const Offset* offsets) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL
-        setIndexBuffer(IBufferResource* buffer, Format indexFormat, uint32_t offset = 0) override;
+        setIndexBuffer(IBufferResource* buffer, Format indexFormat, Offset offset = 0) override;
 
     void prepareDraw();
     virtual SLANG_NO_THROW void SLANG_MCALL
-        draw(uint32_t vertexCount, uint32_t startVertex = 0) override;
+        draw(GfxCount vertexCount, GfxIndex startVertex = 0) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        drawIndexed(uint32_t indexCount, uint32_t startIndex = 0, uint32_t baseVertex = 0) override;
+        drawIndexed(GfxCount indexCount, GfxIndex startIndex = 0, GfxIndex baseVertex = 0) override;
     virtual SLANG_NO_THROW void SLANG_MCALL endEncoding() override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL setStencilReference(uint32_t referenceValue) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndirect(
-        uint32_t maxDrawCount,
+        GfxCount maxDrawCount,
         IBufferResource* argBuffer,
-        uint64_t argOffset,
+        Offset argOffset,
         IBufferResource* countBuffer,
-        uint64_t countOffset) override;
+        Offset countOffset) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedIndirect(
-        uint32_t maxDrawCount,
+        GfxCount maxDrawCount,
         IBufferResource* argBuffer,
-        uint64_t argOffset,
+        Offset argOffset,
         IBufferResource* countBuffer,
-        uint64_t countOffset) override;
+        Offset countOffset) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL setSamplePositions(
-        uint32_t samplesPerPixel,
-        uint32_t pixelCount,
+        GfxCount samplesPerPixel,
+        GfxCount pixelCount,
         const SamplePosition* samplePositions) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL drawInstanced(
-        uint32_t vertexCount,
-        uint32_t instanceCount,
-        uint32_t startVertex,
-        uint32_t startInstanceLocation) override;
+        GfxCount vertexCount,
+        GfxCount instanceCount,
+        GfxIndex startVertex,
+        GfxIndex startInstanceLocation) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedInstanced(
-        uint32_t indexCount,
-        uint32_t instanceCount,
-        uint32_t startIndexLocation,
-        int32_t baseVertexLocation,
-        uint32_t startInstanceLocation) override;
+        GfxCount indexCount,
+        GfxCount instanceCount,
+        GfxIndex startIndexLocation,
+        GfxIndex baseVertexLocation,
+        GfxIndex startInstanceLocation) override;
 };
 
 #if SLANG_GFX_HAS_DXR_SUPPORT
@@ -1631,11 +1631,11 @@ public:
         return bindPipelineWithRootObjectImpl(state, rootObject);
     }
     virtual SLANG_NO_THROW void SLANG_MCALL dispatchRays(
-        uint32_t rayGenShaderIndex,
+        GfxIndex rayGenShaderIndex,
         IShaderTable* shaderTable,
-        int32_t width,
-        int32_t height,
-        int32_t depth) override;
+        GfxCount width,
+        GfxCount height,
+        GfxCount depth) override;
     virtual SLANG_NO_THROW void SLANG_MCALL endEncoding() {}
 };
 #endif
@@ -1750,7 +1750,7 @@ public:
     virtual SLANG_NO_THROW const Desc& SLANG_MCALL getDesc() override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL executeCommandBuffers(
-        uint32_t count,
+        GfxCount count,
         ICommandBuffer* const* commandBuffers,
         IFence* fence,
         uint64_t valueToSignal) override;
@@ -1758,7 +1758,7 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL waitOnHost() override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL waitForFenceValuesOnDevice(
-        uint32_t fenceCount, IFence** fences, uint64_t* waitValues) override;
+        GfxCount fenceCount, IFence** fences, uint64_t* waitValues) override;
 };
 
 class SwapchainImpl : public D3DSwapchainBase
@@ -1772,7 +1772,7 @@ public:
     uint64_t fenceValue = 0;
     Result init(DeviceImpl* renderer, const ISwapchain::Desc& swapchainDesc, WindowHandle window);
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL resize(uint32_t width, uint32_t height) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL resize(GfxCount width, GfxCount height) override;
 
     virtual void createSwapchainBufferImages() override;
     virtual IDXGIFactory* getDXGIFactory() override { return m_dxgiFactory; }

--- a/tools/gfx/d3d12/render-d3d12.h
+++ b/tools/gfx/d3d12/render-d3d12.h
@@ -1428,13 +1428,13 @@ public:
         ResourceState srcState,
         SubresourceRange srcSubresource,
         ITextureResource::Offset3D srcOffset,
-        ITextureResource::Size extent) override;
+        ITextureResource::Extents extent) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL uploadTextureData(
         ITextureResource* dst,
         SubresourceRange subResourceRange,
         ITextureResource::Offset3D offset,
-        ITextureResource::Size extent,
+        ITextureResource::Extents extent,
         ITextureResource::SubresourceData* subResourceData,
         GfxCount subResourceDataCount) override;
 
@@ -1465,7 +1465,7 @@ public:
         ResourceState srcState,
         SubresourceRange srcSubresource,
         ITextureResource::Offset3D srcOffset,
-        ITextureResource::Size extent) override;
+        ITextureResource::Extents extent) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL textureSubresourceBarrier(
         ITextureResource* texture,

--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -293,7 +293,7 @@ Result DebugDevice::getNativeDeviceHandles(InteropHandles* outHandles)
     return baseObject->getNativeDeviceHandles(outHandles);
 }
 
-Result DebugDevice::getFeatures(const char** outFeatures, UInt bufferSize, UInt* outFeatureCount)
+Result DebugDevice::getFeatures(const char** outFeatures, Size bufferSize, GfxCount* outFeatureCount)
 {
     SLANG_GFX_API_FUNC;
 
@@ -532,7 +532,7 @@ Result DebugDevice::createFramebuffer(IFramebuffer::Desc const& desc, IFramebuff
             ? static_cast<DebugResourceView*>(desc.depthStencilView)->baseObject.get()
             : nullptr;
     List<IResourceView*> innerRenderTargets;
-    for (uint32_t i = 0; i < desc.renderTargetCount; i++)
+    for (GfxIndex i = 0; i < desc.renderTargetCount; i++)
     {
         auto innerRenderTarget =
             desc.renderTargetViews[i]
@@ -828,7 +828,7 @@ Result DebugDevice::createFence(const IFence::Desc& desc, IFence** outFence)
 }
 
 Result DebugDevice::waitForFences(
-    uint32_t fenceCount, IFence** fences, uint64_t* values , bool waitForAll, uint64_t timeout)
+    GfxCount fenceCount, IFence** fences, uint64_t* values , bool waitForAll, uint64_t timeout)
 {
     SLANG_GFX_API_FUNC;
     return baseObject->waitForFences(fenceCount, fences, values, waitForAll, timeout);
@@ -1148,13 +1148,13 @@ Result DebugRenderCommandEncoder::bindPipelineWithRootObject(
     return baseObject->bindPipelineWithRootObject(getInnerObj(state), getInnerObj(rootObject));
 }
 
-void DebugRenderCommandEncoder::setViewports(uint32_t count, const Viewport* viewports)
+void DebugRenderCommandEncoder::setViewports(GfxCount count, const Viewport* viewports)
 {
     SLANG_GFX_API_FUNC;
     baseObject->setViewports(count, viewports);
 }
 
-void DebugRenderCommandEncoder::setScissorRects(uint32_t count, const ScissorRect* scissors)
+void DebugRenderCommandEncoder::setScissorRects(GfxCount count, const ScissorRect* scissors)
 {
     SLANG_GFX_API_FUNC;
     baseObject->setScissorRects(count, scissors);
@@ -1167,10 +1167,10 @@ void DebugRenderCommandEncoder::setPrimitiveTopology(PrimitiveTopology topology)
 }
 
 void DebugRenderCommandEncoder::setVertexBuffers(
-    uint32_t startSlot,
-    uint32_t slotCount,
+    GfxIndex startSlot,
+    GfxCount slotCount,
     IBufferResource* const* buffers,
-    const uint32_t* offsets)
+    const Offset* offsets)
 {
     SLANG_GFX_API_FUNC;
 
@@ -1183,32 +1183,32 @@ void DebugRenderCommandEncoder::setVertexBuffers(
 }
 
 void DebugRenderCommandEncoder::setIndexBuffer(
-    IBufferResource* buffer, Format indexFormat, uint32_t offset)
+    IBufferResource* buffer, Format indexFormat, Offset offset)
 {
     SLANG_GFX_API_FUNC;
     auto innerBuffer = static_cast<DebugBufferResource*>(buffer)->baseObject.get();
     baseObject->setIndexBuffer(innerBuffer, indexFormat, offset);
 }
 
-void DebugRenderCommandEncoder::draw(uint32_t vertexCount, uint32_t startVertex)
+void DebugRenderCommandEncoder::draw(GfxCount vertexCount, GfxIndex startVertex)
 {
     SLANG_GFX_API_FUNC;
     baseObject->draw(vertexCount, startVertex);
 }
 
 void DebugRenderCommandEncoder::drawIndexed(
-    uint32_t indexCount, uint32_t startIndex, uint32_t baseVertex)
+    GfxCount indexCount, GfxIndex startIndex, GfxIndex baseVertex)
 {
     SLANG_GFX_API_FUNC;
     baseObject->drawIndexed(indexCount, startIndex, baseVertex);
 }
 
 void DebugRenderCommandEncoder::drawIndirect(
-    uint32_t maxDrawCount,
+    GfxCount maxDrawCount,
     IBufferResource* argBuffer,
-    uint64_t argOffset,
+    Offset argOffset,
     IBufferResource* countBuffer,
-    uint64_t countOffset)
+    Offset countOffset)
 {
     SLANG_GFX_API_FUNC;
     baseObject->drawIndirect(
@@ -1216,11 +1216,11 @@ void DebugRenderCommandEncoder::drawIndirect(
 }
 
 void DebugRenderCommandEncoder::drawIndexedIndirect(
-    uint32_t maxDrawCount,
+    GfxCount maxDrawCount,
     IBufferResource* argBuffer,
-    uint64_t argOffset,
+    Offset argOffset,
     IBufferResource* countBuffer,
-    uint64_t countOffset)
+    Offset countOffset)
 {
     SLANG_GFX_API_FUNC;
     baseObject->drawIndexedIndirect(
@@ -1234,17 +1234,17 @@ void DebugRenderCommandEncoder::setStencilReference(uint32_t referenceValue)
 }
 
 Result DebugRenderCommandEncoder::setSamplePositions(
-    uint32_t samplesPerPixel, uint32_t pixelCount, const SamplePosition* samplePositions)
+    GfxCount samplesPerPixel, GfxCount pixelCount, const SamplePosition* samplePositions)
 {
     SLANG_GFX_API_FUNC;
     return baseObject->setSamplePositions(samplesPerPixel, pixelCount, samplePositions);
 }
 
 void DebugRenderCommandEncoder::drawInstanced(
-    uint32_t vertexCount,
-    uint32_t instanceCount,
-    uint32_t startVertex,
-    uint32_t startInstanceLocation)
+    GfxCount vertexCount,
+    GfxCount instanceCount,
+    GfxIndex startVertex,
+    GfxIndex startInstanceLocation)
 {
     SLANG_GFX_API_FUNC;
     return baseObject->drawInstanced(
@@ -1252,11 +1252,11 @@ void DebugRenderCommandEncoder::drawInstanced(
 }
 
 void DebugRenderCommandEncoder::drawIndexedInstanced(
-    uint32_t indexCount,
-    uint32_t instanceCount,
-    uint32_t startIndexLocation,
-    int32_t baseVertexLocation,
-    uint32_t startInstanceLocation)
+    GfxCount indexCount,
+    GfxCount instanceCount,
+    GfxIndex startIndexLocation,
+    GfxIndex baseVertexLocation,
+    GfxIndex startInstanceLocation)
 {
     SLANG_GFX_API_FUNC;
     return baseObject->drawIndexedInstanced(
@@ -1270,7 +1270,7 @@ void DebugResourceCommandEncoder::endEncoding()
     baseObject->endEncoding();
 }
 
-void DebugResourceCommandEncoderImpl::writeTimestamp(IQueryPool* pool, SlangInt index)
+void DebugResourceCommandEncoderImpl::writeTimestamp(IQueryPool* pool, GfxIndex index)
 {
     SLANG_GFX_API_FUNC;
     getBaseResourceEncoder()->writeTimestamp(static_cast<DebugQueryPool*>(pool)->baseObject, index);
@@ -1302,7 +1302,7 @@ void DebugResourceCommandEncoderImpl::uploadBufferData(
 }
 
 void DebugResourceCommandEncoderImpl::textureBarrier(
-    size_t count,
+    GfxCount count,
     ITextureResource* const* textures,
     ResourceState src,
     ResourceState dst)
@@ -1310,7 +1310,7 @@ void DebugResourceCommandEncoderImpl::textureBarrier(
     SLANG_GFX_API_FUNC;
 
     List<ITextureResource*> innerTextures;
-    for (size_t i = 0; i < count; i++)
+    for (GfxIndex i = 0; i < count; i++)
     {
         innerTextures.add(static_cast<DebugTextureResource*>(textures[i])->baseObject.get());
     }
@@ -1318,7 +1318,7 @@ void DebugResourceCommandEncoderImpl::textureBarrier(
 }
 
 void DebugResourceCommandEncoderImpl::bufferBarrier(
-    size_t count,
+    GfxCount count,
     IBufferResource* const* buffers,
     ResourceState src,
     ResourceState dst)
@@ -1326,7 +1326,7 @@ void DebugResourceCommandEncoderImpl::bufferBarrier(
     SLANG_GFX_API_FUNC;
 
     List<IBufferResource*> innerBuffers;
-    for(size_t i = 0; i < count; i++)
+    for(GfxIndex i = 0; i < count; i++)
     {
         innerBuffers.add(static_cast<DebugBufferResource*>(buffers[i])->baseObject.get());
     }
@@ -1363,7 +1363,7 @@ void DebugResourceCommandEncoderImpl::uploadTextureData(
     ITextureResource::Offset3D offset,
     ITextureResource::Size extent,
     ITextureResource::SubresourceData* subResourceData,
-    size_t subResourceDataCount)
+    GfxCount subResourceDataCount)
 {
     SLANG_GFX_API_FUNC;
     getBaseResourceEncoder()->uploadTextureData(
@@ -1403,7 +1403,7 @@ void DebugResourceCommandEncoderImpl::resolveResource(
 }
 
 void DebugResourceCommandEncoderImpl::resolveQuery(
-    IQueryPool* queryPool, uint32_t index, uint32_t count, IBufferResource* buffer, uint64_t offset)
+    IQueryPool* queryPool, GfxIndex index, GfxCount count, IBufferResource* buffer, Offset offset)
 {
     SLANG_GFX_API_FUNC;
     getBaseResourceEncoder()->resolveQuery(getInnerObj(queryPool), index, count, buffer, offset);
@@ -1411,9 +1411,9 @@ void DebugResourceCommandEncoderImpl::resolveQuery(
 
 void DebugResourceCommandEncoderImpl::copyTextureToBuffer(
     IBufferResource* dst,
-    size_t dstOffset,
-    size_t dstSize,
-    size_t dstRowStride,
+    Offset dstOffset,
+    Size dstSize,
+    Size dstRowStride,
     ITextureResource* src,
     ResourceState srcState,
     SubresourceRange srcSubresource,
@@ -1544,11 +1544,11 @@ Result DebugRayTracingCommandEncoder::bindPipelineWithRootObject(
 }
 
 void DebugRayTracingCommandEncoder::dispatchRays(
-    uint32_t rayGenShaderIndex,
+    GfxIndex rayGenShaderIndex,
     IShaderTable* shaderTable,
-    int32_t width,
-    int32_t height,
-    int32_t depth)
+    GfxCount width,
+    GfxCount height,
+    GfxCount depth)
 {
     SLANG_GFX_API_FUNC;
     baseObject->dispatchRays(rayGenShaderIndex, getInnerObj(shaderTable), width, height, depth);
@@ -1560,11 +1560,11 @@ const ICommandQueue::Desc& DebugCommandQueue::getDesc()
     return baseObject->getDesc();
 }
 
-void DebugCommandQueue::executeCommandBuffers(uint32_t count, ICommandBuffer* const* commandBuffers, IFence* fence, uint64_t valueToSignal)
+void DebugCommandQueue::executeCommandBuffers(GfxCount count, ICommandBuffer* const* commandBuffers, IFence* fence, uint64_t valueToSignal)
 {
     SLANG_GFX_API_FUNC;
     List<ICommandBuffer*> innerCommandBuffers;
-    for (uint32_t i = 0; i < count; i++)
+    for (GfxIndex i = 0; i < count; i++)
     {
         auto cmdBufferIn = commandBuffers[i];
         auto cmdBufferImpl = static_cast<DebugCommandBuffer*>(cmdBufferIn);
@@ -1596,11 +1596,11 @@ void DebugCommandQueue::waitOnHost()
 }
 
 Result DebugCommandQueue::waitForFenceValuesOnDevice(
-    uint32_t fenceCount, IFence** fences, uint64_t* waitValues)
+    GfxCount fenceCount, IFence** fences, uint64_t* waitValues)
 {
     SLANG_GFX_API_FUNC;
     List<IFence*> innerFences;
-    for (uint32_t i = 0; i < fenceCount; ++i)
+    for (GfxIndex i = 0; i < fenceCount; ++i)
     {
         innerFences.add(getInnerObj(fences[i]));
     }
@@ -1645,11 +1645,11 @@ const ISwapchain::Desc& DebugSwapchain::getDesc()
     return desc;
 }
 
-Result DebugSwapchain::getImage(uint32_t index, ITextureResource** outResource)
+Result DebugSwapchain::getImage(GfxIndex index, ITextureResource** outResource)
 {
     SLANG_GFX_API_FUNC;
     maybeRebuildImageList();
-    if (index > (uint32_t)m_images.getCount())
+    if (index > (GfxCount)m_images.getCount())
     {
         GFX_DIAGNOSE_ERROR_FORMAT(
             "`index`(%d) must not exceed total number of images (%d) in the swapchain.",
@@ -1672,7 +1672,7 @@ int DebugSwapchain::acquireNextImage()
     return baseObject->acquireNextImage();
 }
 
-Result DebugSwapchain::resize(uint32_t width, uint32_t height)
+Result DebugSwapchain::resize(GfxCount width, GfxCount height)
 {
     SLANG_GFX_API_FUNC;
     for (auto& image : m_images)
@@ -1705,7 +1705,7 @@ void DebugSwapchain::maybeRebuildImageList()
     if (m_images.getCount() != 0)
         return;
     m_images.clearAndDeallocate();
-    for (uint32_t i = 0; i < baseObject->getDesc().imageCount; i++)
+    for (GfxIndex i = 0; i < baseObject->getDesc().imageCount; i++)
     {
         RefPtr<DebugTextureResource> image = new DebugTextureResource();
         baseObject->getImage(i, image->baseObject.writeRef());
@@ -1725,18 +1725,18 @@ slang::TypeLayoutReflection* DebugShaderObject::getElementTypeLayout()
     return baseObject->getElementTypeLayout();
 }
 
-UInt DebugShaderObject::getEntryPointCount()
+GfxCount DebugShaderObject::getEntryPointCount()
 {
     SLANG_GFX_API_FUNC;
     return baseObject->getEntryPointCount();
 }
 
-Result DebugShaderObject::getEntryPoint(UInt index, IShaderObject** entryPoint)
+Result DebugShaderObject::getEntryPoint(GfxIndex index, IShaderObject** entryPoint)
 {
     SLANG_GFX_API_FUNC;
     if (m_entryPoints.getCount() == 0)
     {
-        for (UInt i = 0; i < getEntryPointCount(); i++)
+        for (GfxIndex i = 0; i < getEntryPointCount(); i++)
         {
             RefPtr<DebugShaderObject> entryPointObj = new DebugShaderObject();
             SLANG_RETURN_ON_FAIL(
@@ -1744,7 +1744,7 @@ Result DebugShaderObject::getEntryPoint(UInt index, IShaderObject** entryPoint)
             m_entryPoints.add(entryPointObj);
         }
     }
-    if (index > (UInt)m_entryPoints.getCount())
+    if (index > (GfxCount)m_entryPoints.getCount())
     {
         GFX_DIAGNOSE_ERROR("`index` must not exceed `entryPointCount`.");
         return SLANG_FAIL;
@@ -1753,7 +1753,7 @@ Result DebugShaderObject::getEntryPoint(UInt index, IShaderObject** entryPoint)
     return SLANG_OK;
 }
 
-Result DebugShaderObject::setData(ShaderOffset const& offset, void const* data, size_t size)
+Result DebugShaderObject::setData(ShaderOffset const& offset, void const* data, Size size)
 {
     SLANG_GFX_API_FUNC;
     return baseObject->setData(offset, data, size);
@@ -1824,7 +1824,7 @@ Result DebugShaderObject::setCombinedTextureSampler(
 Result DebugShaderObject::setSpecializationArgs(
     ShaderOffset const& offset,
     const slang::SpecializationArg* args,
-    uint32_t count)
+    GfxCount count)
 {
     SLANG_GFX_API_FUNC;
     return baseObject->setSpecializationArgs(offset, args, count);
@@ -1870,7 +1870,7 @@ DebugObjectBase::DebugObjectBase()
 Result DebugRootShaderObject::setSpecializationArgs(
     ShaderOffset const& offset,
     const slang::SpecializationArg* args,
-    uint32_t count)
+    GfxCount count)
 {
     SLANG_GFX_API_FUNC;
 
@@ -1886,7 +1886,7 @@ void DebugRootShaderObject::reset()
     baseObject.detach();
 }
 
-Result DebugQueryPool::getResult(SlangInt index, SlangInt count, uint64_t* data)
+Result DebugQueryPool::getResult(GfxIndex index, GfxCount count, uint64_t* data)
 {
     SLANG_GFX_API_FUNC;
 

--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -1113,7 +1113,7 @@ void DebugComputeCommandEncoder::dispatchCompute(int x, int y, int z)
 }
 
 void DebugComputeCommandEncoder::dispatchComputeIndirect(
-    IBufferResource* cmdBuffer, uint64_t offset)
+    IBufferResource* cmdBuffer, Offset offset)
 {
     SLANG_GFX_API_FUNC;
     baseObject->dispatchComputeIndirect(getInnerObj(cmdBuffer), offset);
@@ -1175,7 +1175,7 @@ void DebugRenderCommandEncoder::setVertexBuffers(
     SLANG_GFX_API_FUNC;
 
     List<IBufferResource*> innerBuffers;
-    for (UInt i = 0; i < slotCount; i++)
+    for (GfxIndex i = 0; i < slotCount; i++)
     {
         innerBuffers.add(static_cast<DebugBufferResource*>(buffers[i])->baseObject.get());
     }
@@ -1278,10 +1278,10 @@ void DebugResourceCommandEncoderImpl::writeTimestamp(IQueryPool* pool, GfxIndex 
 
 void DebugResourceCommandEncoderImpl::copyBuffer(
     IBufferResource* dst,
-    size_t dstOffset,
+    Offset dstOffset,
     IBufferResource* src,
-    size_t srcOffset,
-    size_t size)
+    Offset srcOffset,
+    Size size)
 {
     SLANG_GFX_API_FUNC;
     auto dstImpl = static_cast<DebugBufferResource*>(dst);
@@ -1292,8 +1292,8 @@ void DebugResourceCommandEncoderImpl::copyBuffer(
 
 void DebugResourceCommandEncoderImpl::uploadBufferData(
     IBufferResource* dst,
-    size_t offset,
-    size_t size,
+    Offset offset,
+    Size size,
     void* data)
 {
     SLANG_GFX_API_FUNC;
@@ -1487,14 +1487,14 @@ void DebugRayTracingCommandEncoder::copyAccelerationStructure(
 }
 
 void DebugRayTracingCommandEncoder::queryAccelerationStructureProperties(
-    int accelerationStructureCount,
+    GfxCount accelerationStructureCount,
     IAccelerationStructure* const* accelerationStructures,
-    int queryCount,
+    GfxCount queryCount,
     AccelerationStructureQueryDesc* queryDescs)
 {
     SLANG_GFX_API_FUNC;
     List<IAccelerationStructure*> innerAS;
-    for (int i = 0; i < accelerationStructureCount; i++)
+    for (GfxIndex i = 0; i < accelerationStructureCount; i++)
     {
         innerAS.add(getInnerObj(accelerationStructures[i]));
     }

--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -1457,7 +1457,7 @@ void DebugRayTracingCommandEncoder::endEncoding()
 
 void DebugRayTracingCommandEncoder::buildAccelerationStructure(
     const IAccelerationStructure::BuildDesc& desc,
-    int propertyQueryCount,
+    GfxCount propertyQueryCount,
     AccelerationStructureQueryDesc* queryDescs)
 {
     SLANG_GFX_API_FUNC;

--- a/tools/gfx/debug-layer.cpp
+++ b/tools/gfx/debug-layer.cpp
@@ -1342,7 +1342,7 @@ void DebugResourceCommandEncoderImpl::copyTexture(
     ResourceState srcState,
     SubresourceRange srcSubresource,
     ITextureResource::Offset3D srcOffset,
-    ITextureResource::Size extent)
+    ITextureResource::Extents extent)
 {
     SLANG_GFX_API_FUNC;
     getBaseResourceEncoder()->copyTexture(
@@ -1361,7 +1361,7 @@ void DebugResourceCommandEncoderImpl::uploadTextureData(
     ITextureResource* dst,
     SubresourceRange subResourceRange,
     ITextureResource::Offset3D offset,
-    ITextureResource::Size extent,
+    ITextureResource::Extents extent,
     ITextureResource::SubresourceData* subResourceData,
     GfxCount subResourceDataCount)
 {
@@ -1418,7 +1418,7 @@ void DebugResourceCommandEncoderImpl::copyTextureToBuffer(
     ResourceState srcState,
     SubresourceRange srcSubresource,
     ITextureResource::Offset3D srcOffset,
-    ITextureResource::Size extent)
+    ITextureResource::Extents extent)
 {
     SLANG_GFX_API_FUNC;
     getBaseResourceEncoder()->copyTextureToBuffer(

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -44,7 +44,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(InteropHandles* outHandles) override;
     virtual SLANG_NO_THROW bool SLANG_MCALL hasFeature(const char* feature) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getFeatures(const char** outFeatures, UInt bufferSize, UInt* outFeatureCount) override;
+        getFeatures(const char** outFeatures, Size bufferSize, GfxCount* outFeatureCount) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
         getFormatSupportedResourceStates(Format format, ResourceStateSet* outStates) override;
 
@@ -64,7 +64,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL createTextureFromSharedHandle(
         InteropHandle handle,
         const ITextureResource::Desc& srcDesc,
-        const size_t size,
+        const Size size,
         ITextureResource** outResource) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createBufferResource(
         const IBufferResource::Desc& desc,
@@ -141,12 +141,12 @@ public:
         ITextureResource* resource,
         ResourceState state,
         ISlangBlob** outBlob,
-        size_t* outRowPitch,
-        size_t* outPixelSize) override;
+        Size* outRowPitch,
+        Size* outPixelSize) override;
     virtual SLANG_NO_THROW SlangResult SLANG_MCALL readBufferResource(
         IBufferResource* buffer,
-        size_t offset,
-        size_t size,
+        Offset offset,
+        Size size,
         ISlangBlob** outBlob) override;
     virtual SLANG_NO_THROW const DeviceInfo& SLANG_MCALL getDeviceInfo() const override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createQueryPool(
@@ -155,7 +155,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
         createFence(const IFence::Desc& desc, IFence** outFence) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL waitForFences(
-        uint32_t fenceCount,
+        GfxCount fenceCount,
         IFence** fences,
         uint64_t* values,
         bool waitForAll,
@@ -183,7 +183,7 @@ public:
 public:
     IQueryPool* getInterface(const Slang::Guid& guid);
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getResult(SlangInt index, SlangInt count, uint64_t* data) override;
+        getResult(GfxIndex index, GfxCount count, uint64_t* data) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL reset() override;
 };
 
@@ -286,9 +286,9 @@ public:
     IShaderObject* getInterface(const Slang::Guid& guid);
     virtual SLANG_NO_THROW slang::TypeLayoutReflection* SLANG_MCALL getElementTypeLayout() override;
     virtual SLANG_NO_THROW ShaderObjectContainerType SLANG_MCALL getContainerType() override;
-    virtual SLANG_NO_THROW UInt SLANG_MCALL getEntryPointCount() override;
+    virtual SLANG_NO_THROW GfxCount SLANG_MCALL getEntryPointCount() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getEntryPoint(UInt index, IShaderObject** entryPoint) override;
+        getEntryPoint(GfxIndex index, IShaderObject** entryPoint) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
         setData(ShaderOffset const& offset, void const* data, size_t size) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
@@ -306,7 +306,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL setSpecializationArgs(
         ShaderOffset const& offset,
         const slang::SpecializationArg* args,
-        uint32_t count) override;
+        GfxCount count) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentVersion(
         ITransientResourceHeap* transientHeap, IShaderObject** outObject) override;
@@ -342,7 +342,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL setSpecializationArgs(
         ShaderOffset const& offset,
         const slang::SpecializationArg* args,
-        uint32_t count) override;
+        GfxCount count) override;
     void reset();
 };
 
@@ -358,21 +358,21 @@ public:
 public:
     virtual SLANG_NO_THROW void SLANG_MCALL copyBuffer(
         IBufferResource* dst,
-        size_t dstOffset,
+        Offset dstOffset,
         IBufferResource* src,
-        size_t srcOffset,
-        size_t size);
+        Offset srcOffset,
+        Size size);
     virtual SLANG_NO_THROW void SLANG_MCALL
-        uploadBufferData(IBufferResource* dst, size_t offset, size_t size, void* data);
+        uploadBufferData(IBufferResource* dst, Offset offset, Size size, void* data);
     virtual SLANG_NO_THROW void SLANG_MCALL
-        writeTimestamp(IQueryPool* pool, SlangInt index);
+        writeTimestamp(IQueryPool* pool, GfxIndex index);
     virtual SLANG_NO_THROW void SLANG_MCALL textureBarrier(
-        size_t count,
+        GfxCount count,
         ITextureResource* const* textures,
         ResourceState src,
         ResourceState dst);
     virtual SLANG_NO_THROW void SLANG_MCALL bufferBarrier(
-        size_t count,
+        GfxCount count,
         IBufferResource* const* buffers,
         ResourceState src,
         ResourceState dst);
@@ -392,7 +392,7 @@ public:
         ITextureResource::Offset3D offset,
         ITextureResource::Size extent,
         ITextureResource::SubresourceData* subResourceData,
-        size_t subResourceDataCount);
+        GfxCount subResourceDataCount);
     virtual SLANG_NO_THROW void SLANG_MCALL clearResourceView(
         IResourceView* view, ClearValue* clearValue, ClearResourceViewFlags::Enum flags);
     virtual SLANG_NO_THROW void SLANG_MCALL resolveResource(
@@ -404,9 +404,9 @@ public:
         SubresourceRange destRange);
     virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
         IBufferResource* dst,
-        size_t dstOffset,
-        size_t dstSize,
-        size_t dstRowStride,
+        Offset dstOffset,
+        Size dstSize,
+        Size dstRowStride,
         ITextureResource* src,
         ResourceState srcState,
         SubresourceRange srcSubresource,
@@ -419,10 +419,10 @@ public:
         ResourceState dst);
     virtual SLANG_NO_THROW void SLANG_MCALL resolveQuery(
         IQueryPool* queryPool,
-        uint32_t index,
-        uint32_t count,
+        GfxIndex index,
+        GfxCount count,
         IBufferResource* buffer,
-        uint64_t offset);
+        Offset offset);
     virtual SLANG_NO_THROW void SLANG_MCALL beginDebugEvent(const char* name, float rgbColor[3]);
     virtual SLANG_NO_THROW void SLANG_MCALL endDebugEvent();
 };
@@ -491,51 +491,51 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
         bindPipelineWithRootObject(IPipelineState* state, IShaderObject* rootObject) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        setViewports(uint32_t count, const Viewport* viewports) override;
+        setViewports(GfxCount count, const Viewport* viewports) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        setScissorRects(uint32_t count, const ScissorRect* scissors) override;
+        setScissorRects(GfxCount count, const ScissorRect* scissors) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
         setPrimitiveTopology(PrimitiveTopology topology) override;
     virtual SLANG_NO_THROW void SLANG_MCALL setVertexBuffers(
-        uint32_t startSlot,
-        uint32_t slotCount,
+        GfxIndex startSlot,
+        GfxCount slotCount,
         IBufferResource* const* buffers,
-        const uint32_t* offsets) override;
+        const Offset* offsets) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        setIndexBuffer(IBufferResource* buffer, Format indexFormat, uint32_t offset = 0) override;
+        setIndexBuffer(IBufferResource* buffer, Format indexFormat, Offset offset = 0) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        draw(uint32_t vertexCount, uint32_t startVertex = 0) override;
+        draw(GfxCount vertexCount, GfxIndex startVertex = 0) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        drawIndexed(uint32_t indexCount, uint32_t startIndex = 0, uint32_t baseVertex = 0) override;
+        drawIndexed(GfxCount indexCount, GfxIndex startIndex = 0, GfxIndex baseVertex = 0) override;
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndirect(
-        uint32_t maxDrawCount,
+        GfxCount maxDrawCount,
         IBufferResource* argBuffer,
-        uint64_t argOffset,
+        Offset argOffset,
         IBufferResource* countBuffer,
-        uint64_t countOffset) override;
+        Offset countOffset) override;
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedIndirect(
-        uint32_t maxDrawCount,
+        GfxCount maxDrawCount,
         IBufferResource* argBuffer,
-        uint64_t argOffset,
+        Offset argOffset,
         IBufferResource* countBuffer,
-        uint64_t countOffset) override;
+        Offset countOffset) override;
     virtual SLANG_NO_THROW void SLANG_MCALL setStencilReference(uint32_t referenceValue) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL setSamplePositions(
-        uint32_t samplesPerPixel,
-        uint32_t pixelCount,
+        GfxCount samplesPerPixel,
+        GfxCount pixelCount,
         const SamplePosition* samplePositions) override;
     virtual SLANG_NO_THROW void SLANG_MCALL drawInstanced(
-        uint32_t vertexCount,
-        uint32_t instanceCount,
-        uint32_t startVertex,
-        uint32_t startInstanceLocation) override;
+        GfxCount vertexCount,
+        GfxCount instanceCount,
+        GfxIndex startVertex,
+        GfxIndex startInstanceLocation) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedInstanced(
-        uint32_t indexCount,
-        uint32_t instanceCount,
-        uint32_t startIndexLocation,
-        int32_t baseVertexLocation,
-        uint32_t startInstanceLocation) override;
+        GfxCount indexCount,
+        GfxCount instanceCount,
+        GfxIndex startIndexLocation,
+        GfxIndex baseVertexLocation,
+        GfxIndex startInstanceLocation) override;
 
 public:
     DebugCommandBuffer* commandBuffer;
@@ -577,11 +577,11 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
         bindPipelineWithRootObject(IPipelineState* state, IShaderObject* rootObject) override;
     virtual SLANG_NO_THROW void SLANG_MCALL dispatchRays(
-        uint32_t rayGenShaderIndex,
+        GfxIndex rayGenShaderIndex,
         IShaderTable* shaderTable,
-        int32_t width,
-        int32_t height,
-        int32_t depth) override;
+        GfxCount width,
+        GfxCount height,
+        GfxCount depth) override;
 
 public:
     DebugCommandBuffer* commandBuffer;
@@ -648,10 +648,10 @@ public:
     ICommandQueue* getInterface(const Slang::Guid& guid);
     virtual SLANG_NO_THROW const Desc& SLANG_MCALL getDesc() override;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        executeCommandBuffers(uint32_t count, ICommandBuffer* const* commandBuffers, IFence* fence, uint64_t valueToSignal) override;
+        executeCommandBuffers(GfxCount count, ICommandBuffer* const* commandBuffers, IFence* fence, uint64_t valueToSignal) override;
     virtual SLANG_NO_THROW void SLANG_MCALL waitOnHost() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL waitForFenceValuesOnDevice(
-        uint32_t fenceCount, IFence** fences, uint64_t* waitValues) override;
+        GfxCount fenceCount, IFence** fences, uint64_t* waitValues) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(InteropHandle* outHandle) override;
 };
 
@@ -738,10 +738,10 @@ public:
     ISwapchain* getInterface(const Slang::Guid& guid);
     virtual SLANG_NO_THROW const Desc& SLANG_MCALL getDesc() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getImage(uint32_t index, ITextureResource** outResource) override;
+        getImage(GfxIndex index, ITextureResource** outResource) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
     virtual SLANG_NO_THROW int SLANG_MCALL acquireNextImage() override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL resize(uint32_t width, uint32_t height) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL resize(GfxCount width, GfxCount height) override;
     virtual SLANG_NO_THROW bool SLANG_MCALL isOccluded() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL setFullScreenMode(bool mode) override;
 

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -385,12 +385,12 @@ public:
         ResourceState srcState,
         SubresourceRange srcSubresource,
         ITextureResource::Offset3D srcOffset,
-        ITextureResource::Size extent);
+        ITextureResource::Extents extent);
     virtual SLANG_NO_THROW void SLANG_MCALL uploadTextureData(
         ITextureResource* dst,
         SubresourceRange subResourceRange,
         ITextureResource::Offset3D offset,
-        ITextureResource::Size extent,
+        ITextureResource::Extents extent,
         ITextureResource::SubresourceData* subResourceData,
         GfxCount subResourceDataCount);
     virtual SLANG_NO_THROW void SLANG_MCALL clearResourceView(
@@ -411,7 +411,7 @@ public:
         ResourceState srcState,
         SubresourceRange srcSubresource,
         ITextureResource::Offset3D srcOffset,
-        ITextureResource::Size extent);
+        ITextureResource::Extents extent);
     virtual SLANG_NO_THROW void SLANG_MCALL textureSubresourceBarrier(
         ITextureResource* texture,
         SubresourceRange subresourceRange,

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -445,7 +445,7 @@ public:
         bindPipelineWithRootObject(IPipelineState* state, IShaderObject* rootObject) override;
     virtual SLANG_NO_THROW void SLANG_MCALL dispatchCompute(int x, int y, int z) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        dispatchComputeIndirect(IBufferResource* cmdBuffer, uint64_t offset) override;
+        dispatchComputeIndirect(IBufferResource* cmdBuffer, Offset offset) override;
 
 public:
     DebugCommandBuffer* commandBuffer;
@@ -563,9 +563,9 @@ public:
         IAccelerationStructure* src,
         AccelerationStructureCopyMode mode) override;
     virtual SLANG_NO_THROW void SLANG_MCALL queryAccelerationStructureProperties(
-        int accelerationStructureCount,
+        GfxCount accelerationStructureCount,
         IAccelerationStructure* const* accelerationStructures,
-        int queryCount,
+        GfxCount queryCount,
         AccelerationStructureQueryDesc* queryDescs) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
         serializeAccelerationStructure(DeviceAddress dest, IAccelerationStructure* source) override;

--- a/tools/gfx/debug-layer.h
+++ b/tools/gfx/debug-layer.h
@@ -556,7 +556,7 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL endEncoding() override;
     virtual SLANG_NO_THROW void SLANG_MCALL buildAccelerationStructure(
         const IAccelerationStructure::BuildDesc& desc,
-        int propertyQueryCount,
+        GfxCount propertyQueryCount,
         AccelerationStructureQueryDesc* queryDescs) override;
     virtual SLANG_NO_THROW void SLANG_MCALL copyAccelerationStructure(
         IAccelerationStructure* dest,

--- a/tools/gfx/immediate-renderer-base.cpp
+++ b/tools/gfx/immediate-renderer-base.cpp
@@ -106,7 +106,7 @@ public:
             ResourceState srcState,
             SubresourceRange srcSubresource,
             ITextureResource::Offset3D srcOffset,
-            ITextureResource::Size extent) override
+            ITextureResource::Extents extent) override
         {
             SLANG_UNUSED(dst);
             SLANG_UNUSED(dstState);
@@ -124,7 +124,7 @@ public:
             ITextureResource* dst,
             SubresourceRange subResourceRange,
             ITextureResource::Offset3D offset,
-            ITextureResource::Size extend,
+            ITextureResource::Extents extend,
             ITextureResource::SubresourceData* subResourceData,
             GfxCount subResourceDataCount) override
         {
@@ -189,7 +189,7 @@ public:
             ResourceState srcState,
             SubresourceRange srcSubresource,
             ITextureResource::Offset3D srcOffset,
-            ITextureResource::Size extent) override
+            ITextureResource::Extents extent) override
         {
             SLANG_UNUSED(dst);
             SLANG_UNUSED(dstOffset);

--- a/tools/gfx/immediate-renderer-base.cpp
+++ b/tools/gfx/immediate-renderer-base.cpp
@@ -466,7 +466,7 @@ public:
             m_writer->dispatchCompute(x, y, z);
         }
 
-        virtual SLANG_NO_THROW void SLANG_MCALL dispatchComputeIndirect(IBufferResource* argBuffer, uint64_t offset) override
+        virtual SLANG_NO_THROW void SLANG_MCALL dispatchComputeIndirect(IBufferResource* argBuffer, Offset offset) override
         {
             SLANG_UNIMPLEMENTED_X("ImmediateRenderBase::dispatchComputeIndirect");
         }

--- a/tools/gfx/immediate-renderer-base.cpp
+++ b/tools/gfx/immediate-renderer-base.cpp
@@ -78,20 +78,20 @@ public:
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL
-            writeTimestamp(IQueryPool* pool, SlangInt index) override
+            writeTimestamp(IQueryPool* pool, GfxIndex index) override
         {
             m_writer->writeTimestamp(pool, index);
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL textureBarrier(
-            size_t count,
+            GfxCount count,
             ITextureResource* const* textures,
             ResourceState src,
             ResourceState dst) override
         {}
 
         virtual SLANG_NO_THROW void SLANG_MCALL bufferBarrier(
-            size_t count,
+            GfxCount count,
             IBufferResource* const* buffers,
             ResourceState src,
             ResourceState dst) override
@@ -126,7 +126,7 @@ public:
             ITextureResource::Offset3D offset,
             ITextureResource::Size extend,
             ITextureResource::SubresourceData* subResourceData,
-            size_t subResourceDataCount) override
+            GfxCount subResourceDataCount) override
         {
             SLANG_UNUSED(dst);
             SLANG_UNUSED(subResourceRange);
@@ -167,10 +167,10 @@ public:
 
         virtual SLANG_NO_THROW void SLANG_MCALL resolveQuery(
             IQueryPool* queryPool,
-            uint32_t index,
-            uint32_t count,
+            GfxIndex index,
+            GfxCount count,
             IBufferResource* buffer,
-            uint64_t offset) override
+            Offset offset) override
         {
             SLANG_UNUSED(queryPool);
             SLANG_UNUSED(index);
@@ -182,9 +182,9 @@ public:
 
         virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
             IBufferResource* dst,
-            size_t dstOffset,
-            size_t dstSize,
-            size_t dstRowStride,
+            Offset dstOffset,
+            Size dstSize,
+            Size dstRowStride,
             ITextureResource* src,
             ResourceState srcState,
             SubresourceRange srcSubresource,
@@ -303,12 +303,12 @@ public:
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL
-            setViewports(uint32_t count, const Viewport* viewports) override
+            setViewports(GfxCount count, const Viewport* viewports) override
         {
             m_writer->setViewports(count, viewports);
         }
         virtual SLANG_NO_THROW void SLANG_MCALL
-            setScissorRects(uint32_t count, const ScissorRect* scissors) override
+            setScissorRects(GfxCount count, const ScissorRect* scissors) override
         {
             m_writer->setScissorRects(count, scissors);
         }
@@ -317,29 +317,29 @@ public:
             m_writer->setPrimitiveTopology(topology);
         }
         virtual SLANG_NO_THROW void SLANG_MCALL setVertexBuffers(
-            uint32_t startSlot,
-            uint32_t slotCount,
+            GfxIndex startSlot,
+            GfxCount slotCount,
             IBufferResource* const* buffers,
-            const uint32_t* offsets) override
+            const Offset* offsets) override
         {
             m_writer->setVertexBuffers(startSlot, slotCount, buffers, offsets);
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL
-            setIndexBuffer(IBufferResource* buffer, Format indexFormat, uint32_t offset) override
+            setIndexBuffer(IBufferResource* buffer, Format indexFormat, Offset offset) override
         {
             m_writer->setIndexBuffer(buffer, indexFormat, offset);
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL
-            draw(uint32_t vertexCount, uint32_t startVertex) override
+            draw(GfxCount vertexCount, GfxIndex startVertex) override
         {
             m_writer->bindRootShaderObject(m_commandBuffer->m_rootShaderObject);
             m_writer->draw(vertexCount, startVertex);
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL
-            drawIndexed(uint32_t indexCount, uint32_t startIndex, uint32_t baseVertex) override
+            drawIndexed(GfxCount indexCount, GfxIndex startIndex, GfxIndex baseVertex) override
         {
             m_writer->bindRootShaderObject(m_commandBuffer->m_rootShaderObject);
             m_writer->drawIndexed(indexCount, startIndex, baseVertex);
@@ -351,11 +351,11 @@ public:
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL drawIndirect(
-            uint32_t maxDrawCount,
+            GfxCount maxDrawCount,
             IBufferResource* argBuffer,
-            uint64_t argOffset,
+            Offset argOffset,
             IBufferResource* countBuffer,
-            uint64_t countOffset) override
+            Offset countOffset) override
         {
             SLANG_UNUSED(maxDrawCount);
             SLANG_UNUSED(argBuffer);
@@ -366,11 +366,11 @@ public:
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedIndirect(
-            uint32_t maxDrawCount,
+            GfxCount maxDrawCount,
             IBufferResource* argBuffer,
-            uint64_t argOffset,
+            Offset argOffset,
             IBufferResource* countBuffer,
-            uint64_t countOffset) override
+            Offset countOffset) override
         {
             SLANG_UNUSED(maxDrawCount);
             SLANG_UNUSED(argBuffer);
@@ -381,8 +381,8 @@ public:
         }
 
         virtual SLANG_NO_THROW Result SLANG_MCALL setSamplePositions(
-            uint32_t samplesPerPixel,
-            uint32_t pixelCount,
+            GfxCount samplesPerPixel,
+            GfxCount pixelCount,
             const SamplePosition* samplePositions) override
         {
             SLANG_UNUSED(samplesPerPixel);
@@ -392,21 +392,21 @@ public:
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL drawInstanced(
-            uint32_t vertexCount,
-            uint32_t instanceCount,
-            uint32_t startVertex,
-            uint32_t startInstanceLocation) override
+            GfxCount vertexCount,
+            GfxCount instanceCount,
+            GfxIndex startVertex,
+            GfxIndex startInstanceLocation) override
         {
             m_writer->bindRootShaderObject(m_commandBuffer->m_rootShaderObject);
             m_writer->drawInstanced(vertexCount, instanceCount, startVertex, startInstanceLocation);
         }
 
         virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedInstanced(
-            uint32_t indexCount,
-            uint32_t instanceCount,
-            uint32_t startIndexLocation,
-            int32_t baseVertexLocation,
-            uint32_t startInstanceLocation) override
+            GfxCount indexCount,
+            GfxCount instanceCount,
+            GfxIndex startIndexLocation,
+            GfxIndex baseVertexLocation,
+            GfxIndex startInstanceLocation) override
         {
             m_writer->bindRootShaderObject(m_commandBuffer->m_rootShaderObject);
             m_writer->drawIndexedInstanced(indexCount, instanceCount, startIndexLocation, baseVertexLocation, startInstanceLocation);
@@ -536,7 +536,7 @@ public:
                         cmd.operands[0],
                         cmd.operands[1],
                         bufferResources.getArrayView().getBuffer(),
-                        m_writer.getData<uint32_t>(cmd.operands[3]));
+                        m_writer.getData<Offset>(cmd.operands[3]));
                 }
                 break;
             case CommandName::SetIndexBuffer:
@@ -583,7 +583,7 @@ public:
                     cmd.operands[4]);
                 break;
             case CommandName::WriteTimestamp:
-                m_renderer->writeTimestamp(m_writer.getObject<QueryPoolBase>(cmd.operands[0]), (SlangInt)cmd.operands[1]);
+                m_renderer->writeTimestamp(m_writer.getObject<QueryPoolBase>(cmd.operands[0]), (GfxIndex)cmd.operands[1]);
                 break;
             default:
                 assert(!"unknown command");
@@ -619,18 +619,18 @@ public:
     virtual SLANG_NO_THROW const Desc& SLANG_MCALL getDesc() override { return m_desc; }
 
     virtual SLANG_NO_THROW void SLANG_MCALL executeCommandBuffers(
-        uint32_t count, ICommandBuffer* const* commandBuffers, IFence* fence, uint64_t valueToSignal) override
+        GfxCount count, ICommandBuffer* const* commandBuffers, IFence* fence, uint64_t valueToSignal) override
     {
         // TODO: implement fence signal.
         assert(fence == nullptr);
 
         CommandBufferInfo info = {};
-        for (uint32_t i = 0; i < count; i++)
+        for (GfxIndex i = 0; i < count; i++)
         {
             info.hasWriteTimestamps |= static_cast<CommandBufferImpl*>(commandBuffers[i])->m_writer.m_hasWriteTimestamps;
         }
         static_cast<ImmediateRendererBase*>(m_renderer.get())->beginCommandBuffer(info);
-        for (uint32_t i = 0; i < count; i++)
+        for (GfxIndex i = 0; i < count; i++)
         {
             static_cast<CommandBufferImpl*>(commandBuffers[i])->execute();
         }
@@ -640,7 +640,7 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL waitOnHost() override { getRenderer()->waitForGpu(); }
 
     virtual SLANG_NO_THROW Result SLANG_MCALL waitForFenceValuesOnDevice(
-        uint32_t fenceCount, IFence** fences, uint64_t* waitValues) override
+        GfxCount fenceCount, IFence** fences, uint64_t* waitValues) override
     {
         return SLANG_FAIL;
     }

--- a/tools/gfx/immediate-renderer-base.h
+++ b/tools/gfx/immediate-renderer-base.h
@@ -56,43 +56,43 @@ public:
     virtual void setPipelineState(IPipelineState* state) = 0;
     virtual void setFramebuffer(IFramebuffer* frameBuffer) = 0;
     virtual void clearFrame(uint32_t colorBufferMask, bool clearDepth, bool clearStencil) = 0;
-    virtual void setViewports(UInt count, const Viewport* viewports) = 0;
-    virtual void setScissorRects(UInt count, const ScissorRect* scissors) = 0;
+    virtual void setViewports(GfxCount count, const Viewport* viewports) = 0;
+    virtual void setScissorRects(GfxCount count, const ScissorRect* scissors) = 0;
     virtual void setPrimitiveTopology(PrimitiveTopology topology) = 0;
     virtual void setVertexBuffers(
-        uint32_t startSlot,
-        uint32_t slotCount,
+        GfxIndex startSlot,
+        GfxCount slotCount,
         IBufferResource* const* buffers,
-        const uint32_t* offsets) = 0;
+        const Offset* offsets) = 0;
     virtual void setIndexBuffer(
-        IBufferResource* buffer, Format indexFormat, uint32_t offset = 0) = 0;
-    virtual void draw(uint32_t vertexCount, uint32_t startVertex = 0) = 0;
+        IBufferResource* buffer, Format indexFormat, Offset offset = 0) = 0;
+    virtual void draw(GfxCount vertexCount, GfxIndex startVertex = 0) = 0;
     virtual void drawIndexed(
-        uint32_t indexCount, uint32_t startIndex = 0, uint32_t baseVertex = 0) = 0;
+        GfxCount indexCount, GfxIndex startIndex = 0, GfxIndex baseVertex = 0) = 0;
     virtual void drawInstanced(
-        uint32_t vertexCount,
-        uint32_t instanceCount,
-        uint32_t startVertex,
-        uint32_t startInstanceLocation) = 0;
+        GfxCount vertexCount,
+        GfxCount instanceCount,
+        GfxIndex startVertex,
+        GfxIndex startInstanceLocation) = 0;
     virtual void drawIndexedInstanced(
-        uint32_t indexCount,
-        uint32_t instanceCount,
-        uint32_t startIndexLocation,
-        int32_t baseVertexLocation,
-        uint32_t startInstanceLocation) = 0;
+        GfxCount indexCount,
+        GfxCount instanceCount,
+        GfxIndex startIndexLocation,
+        GfxIndex baseVertexLocation,
+        GfxIndex startInstanceLocation) = 0;
     virtual void setStencilReference(uint32_t referenceValue) = 0;
     virtual void dispatchCompute(int x, int y, int z) = 0;
     virtual void copyBuffer(
         IBufferResource* dst,
-        size_t dstOffset,
+        Offset dstOffset,
         IBufferResource* src,
-        size_t srcOffset,
-        size_t size) = 0;
+        Offset srcOffset,
+        Size size) = 0;
     virtual void submitGpuWork() = 0;
     virtual void waitForGpu() = 0;
     virtual void* map(IBufferResource* buffer, MapFlavor flavor) = 0;
     virtual void unmap(IBufferResource* buffer, size_t offsetWritten, size_t sizeWritten) = 0;
-    virtual void writeTimestamp(IQueryPool* pool, SlangInt index) = 0;
+    virtual void writeTimestamp(IQueryPool* pool, GfxIndex index) = 0;
     virtual void beginCommandBuffer(const CommandBufferInfo&) {}
     virtual void endCommandBuffer(const CommandBufferInfo&) {}
 
@@ -113,13 +113,13 @@ public:
 
     void uploadBufferData(
         IBufferResource* dst,
-        size_t offset,
-        size_t size, void* data);
+        Offset offset,
+        Size size, void* data);
 
     virtual SLANG_NO_THROW SlangResult SLANG_MCALL readBufferResource(
         IBufferResource* buffer,
-        size_t offset,
-        size_t size,
+        Offset offset,
+        Size size,
         ISlangBlob** outBlob) override;
 };
 
@@ -134,12 +134,12 @@ public:
         SLANG_UNUSED(clearDepth);
         SLANG_UNUSED(clearStencil);
     }
-    virtual void setViewports(UInt count, const Viewport* viewports) override
+    virtual void setViewports(GfxCount count, const Viewport* viewports) override
     {
         SLANG_UNUSED(count);
         SLANG_UNUSED(viewports);
     }
-    virtual void setScissorRects(UInt count, const ScissorRect* scissors) override
+    virtual void setScissorRects(GfxCount count, const ScissorRect* scissors) override
     {
         SLANG_UNUSED(count);
         SLANG_UNUSED(scissors);
@@ -149,10 +149,10 @@ public:
         SLANG_UNUSED(topology);
     }
     virtual void setVertexBuffers(
-        uint32_t startSlot,
-        uint32_t slotCount,
+        GfxIndex startSlot,
+        GfxCount slotCount,
         IBufferResource* const* buffers,
-        const uint32_t* offsets) override
+        const Offset* offsets) override
     {
         SLANG_UNUSED(startSlot);
         SLANG_UNUSED(slotCount);
@@ -160,30 +160,30 @@ public:
         SLANG_UNUSED(offsets);
     }
     virtual void setIndexBuffer(
-        IBufferResource* buffer, Format indexFormat, uint32_t offset = 0)
+        IBufferResource* buffer, Format indexFormat, Offset offset = 0)
         override
     {
         SLANG_UNUSED(buffer);
         SLANG_UNUSED(indexFormat);
         SLANG_UNUSED(offset);
     }
-    virtual void draw(uint32_t vertexCount, uint32_t startVertex = 0) override
+    virtual void draw(GfxCount vertexCount, GfxIndex startVertex = 0) override
     {
         SLANG_UNUSED(vertexCount);
         SLANG_UNUSED(startVertex);
     }
     virtual void drawIndexed(
-        uint32_t indexCount, uint32_t startIndex = 0, uint32_t baseVertex = 0) override
+        GfxCount indexCount, GfxIndex startIndex = 0, GfxIndex baseVertex = 0) override
     {
         SLANG_UNUSED(indexCount);
         SLANG_UNUSED(startIndex);
         SLANG_UNUSED(baseVertex);
     }
     virtual void drawInstanced(
-        uint32_t vertexCount,
-        uint32_t instanceCount,
-        uint32_t startVertex,
-        uint32_t startInstanceLocation) override
+        GfxCount vertexCount,
+        GfxCount instanceCount,
+        GfxIndex startVertex,
+        GfxIndex startInstanceLocation) override
     {
         SLANG_UNUSED(vertexCount);
         SLANG_UNUSED(instanceCount);
@@ -192,11 +192,11 @@ public:
     }
 
     virtual void drawIndexedInstanced(
-        uint32_t indexCount,
-        uint32_t instanceCount,
-        uint32_t startIndexLocation,
-        int32_t baseVertexLocation,
-        uint32_t startInstanceLocation) override
+        GfxCount indexCount,
+        GfxCount instanceCount,
+        GfxIndex startIndexLocation,
+        GfxIndex baseVertexLocation,
+        GfxIndex startInstanceLocation) override
     {
         SLANG_UNUSED(indexCount);
         SLANG_UNUSED(instanceCount);
@@ -263,8 +263,8 @@ public:
         ITextureResource* texture,
         ResourceState state,
         ISlangBlob** outBlob,
-        size_t* outRowPitch,
-        size_t* outPixelSize) override
+        Size* outRowPitch,
+        Size* outPixelSize) override
     {
         SLANG_UNUSED(texture);
         SLANG_UNUSED(outBlob);

--- a/tools/gfx/mutable-shader-object.h
+++ b/tools/gfx/mutable-shader-object.h
@@ -276,20 +276,20 @@ namespace gfx
             return ShaderObjectContainerType::None;
         }
 
-        virtual SLANG_NO_THROW UInt SLANG_MCALL getEntryPointCount() override
+        virtual SLANG_NO_THROW GfxCount SLANG_MCALL getEntryPointCount() override
         {
-            return (UInt)m_entryPoints.getCount();
+            return (GfxCount)m_entryPoints.getCount();
         }
 
         virtual SLANG_NO_THROW Result SLANG_MCALL
-            getEntryPoint(UInt index, IShaderObject** entryPoint) override
+            getEntryPoint(GfxIndex index, IShaderObject** entryPoint) override
         {
             returnComPtr(entryPoint, m_entryPoints[index]);
             return SLANG_OK;
         }
 
         virtual SLANG_NO_THROW Result SLANG_MCALL
-            setData(ShaderOffset const& offset, void const* data, size_t size) override
+            setData(ShaderOffset const& offset, void const* data, Size size) override
         {
             auto newSize = Slang::Index(size + offset.uniformOffset);
             if (newSize > m_data.getCount())
@@ -342,7 +342,7 @@ namespace gfx
         virtual SLANG_NO_THROW Result SLANG_MCALL setSpecializationArgs(
             ShaderOffset const& offset,
             const slang::SpecializationArg* args,
-            uint32_t count) override
+            GfxCount count) override
         {
             Slang::List<slang::SpecializationArg> specArgs;
             specArgs.addRange(args, count);
@@ -368,9 +368,9 @@ namespace gfx
             return m_data.begin();
         }
 
-        virtual SLANG_NO_THROW size_t SLANG_MCALL getSize() override
+        virtual SLANG_NO_THROW Size SLANG_MCALL getSize() override
         {
-            return (size_t)m_data.getCount();
+            return (Size)m_data.getCount();
         }
 
         virtual SLANG_NO_THROW Result SLANG_MCALL

--- a/tools/gfx/open-gl/render-gl.cpp
+++ b/tools/gfx/open-gl/render-gl.cpp
@@ -170,33 +170,33 @@ public:
     virtual void setPrimitiveTopology(PrimitiveTopology topology) override;
 
     virtual void setVertexBuffers(
-        uint32_t startSlot,
-        uint32_t slotCount,
+        GfxIndex startSlot,
+        GfxCount slotCount,
         IBufferResource* const* buffers,
-        const uint32_t* offsets) override;
+        const Offset* offsets) override;
     virtual void setIndexBuffer(
-        IBufferResource* buffer, Format indexFormat, uint32_t offset) override;
-    virtual void setViewports(UInt count, Viewport const* viewports) override;
-    virtual void setScissorRects(UInt count, ScissorRect const* rects) override;
+        IBufferResource* buffer, Format indexFormat, Offset offset) override;
+    virtual void setViewports(GfxCount count, Viewport const* viewports) override;
+    virtual void setScissorRects(GfxCount count, ScissorRect const* rects) override;
     virtual void setPipelineState(IPipelineState* state) override;
-    virtual void draw(uint32_t vertexCount, uint32_t startVertex) override;
+    virtual void draw(GfxCount vertexCount, GfxCount startVertex) override;
     virtual void drawIndexed(
-        uint32_t indexCount, uint32_t startIndex, uint32_t baseVertex) override;
+        GfxCount indexCount, GfxIndex startIndex, GfxIndex baseVertex) override;
     virtual void drawInstanced(
-        uint32_t vertexCount,
-        uint32_t instanceCount,
-        uint32_t startVertex,
-        uint32_t startInstanceLocation) override;
+        GfxCount vertexCount,
+        GfxCount instanceCount,
+        GfxIndex startVertex,
+        GfxIndex startInstanceLocation) override;
     virtual void drawIndexedInstanced(
-        uint32_t indexCount,
-        uint32_t instanceCount,
-        uint32_t startIndexLocation,
-        int32_t baseVertexLocation,
-        uint32_t startInstanceLocation) override;
+        GfxCount indexCount,
+        GfxCount instanceCount,
+        GfxIndex startIndexLocation,
+        GfxIndex baseVertexLocation,
+        GfxIndex startInstanceLocation) override;
     virtual void dispatchCompute(int x, int y, int z) override;
     virtual void submitGpuWork() override {}
     virtual void waitForGpu() override {}
-    virtual void writeTimestamp(IQueryPool* pool, SlangInt index) override
+    virtual void writeTimestamp(IQueryPool* pool, GfxIndex index) override
     {
         SLANG_UNUSED(pool);
         SLANG_UNUSED(index);
@@ -496,7 +496,7 @@ public:
                     GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_backBuffer, 0);
 
                 m_images.clear();
-                for (uint32_t i = 0; i < m_desc.imageCount; i++)
+                for (GfxIndex i = 0; i < m_desc.imageCount; i++)
                 {
                     ITextureResource::Desc imageDesc = {};
                     imageDesc.allowedStates = ResourceStateSet(
@@ -535,7 +535,7 @@ public:
         }
         virtual SLANG_NO_THROW const Desc& SLANG_MCALL getDesc() override { return m_desc; }
         virtual SLANG_NO_THROW Result SLANG_MCALL
-            getImage(uint32_t index, ITextureResource** outResource) override
+            getImage(GfxIndex index, ITextureResource** outResource) override
         {
             returnComPtr(outResource, m_images[index]);
             return SLANG_OK;
@@ -570,7 +570,7 @@ public:
             return -1;
         }
 
-        virtual SLANG_NO_THROW Result SLANG_MCALL resize(uint32_t width, uint32_t height) override
+        virtual SLANG_NO_THROW Result SLANG_MCALL resize(GfxCount width, GfxCount height) override
         {
             if (width > 0 && height > 0 && (width != m_desc.width || height != m_desc.height))
             {
@@ -983,9 +983,9 @@ public:
 
         RendererBase* getDevice() { return m_layout->getDevice(); }
 
-        SLANG_NO_THROW UInt SLANG_MCALL getEntryPointCount() SLANG_OVERRIDE { return 0; }
+        SLANG_NO_THROW GfxCount SLANG_MCALL getEntryPointCount() SLANG_OVERRIDE { return 0; }
 
-        SLANG_NO_THROW Result SLANG_MCALL getEntryPoint(UInt index, IShaderObject** outEntryPoint)
+        SLANG_NO_THROW Result SLANG_MCALL getEntryPoint(GfxIndex index, IShaderObject** outEntryPoint)
             SLANG_OVERRIDE
         {
             *outEntryPoint = nullptr;
@@ -1450,8 +1450,8 @@ public:
 
         RootShaderObjectLayoutImpl* getLayout() { return static_cast<RootShaderObjectLayoutImpl*>(m_layout.Ptr()); }
 
-        UInt SLANG_MCALL getEntryPointCount() SLANG_OVERRIDE { return (UInt)m_entryPoints.getCount(); }
-        SlangResult SLANG_MCALL getEntryPoint(UInt index, IShaderObject** outEntryPoint) SLANG_OVERRIDE
+        GfxCount SLANG_MCALL getEntryPointCount() SLANG_OVERRIDE { return (GfxCount)m_entryPoints.getCount(); }
+        SlangResult SLANG_MCALL getEntryPoint(GfxIndex index, IShaderObject** outEntryPoint) SLANG_OVERRIDE
         {
             *outEntryPoint = m_entryPoints[index];
             m_entryPoints[index]->addRef();
@@ -2175,7 +2175,7 @@ SLANG_NO_THROW Result SLANG_MCALL GLDevice::createFramebufferLayout(
 {
     RefPtr<FramebufferLayoutImpl> layout = new FramebufferLayoutImpl();
     layout->m_renderTargets.setCount(desc.renderTargetCount);
-    for (uint32_t i = 0; i < desc.renderTargetCount; i++)
+    for (GfxIndex i = 0; i < desc.renderTargetCount; i++)
     {
         layout->m_renderTargets[i] = desc.renderTargets[i];
     }
@@ -2198,7 +2198,7 @@ SLANG_NO_THROW Result SLANG_MCALL
 {
     RefPtr<FramebufferImpl> framebuffer = new FramebufferImpl(m_weakRenderer);
     framebuffer->renderTargetViews.setCount(desc.renderTargetCount);
-    for (uint32_t i = 0; i < desc.renderTargetCount; i++)
+    for (GfxIndex i = 0; i < desc.renderTargetCount; i++)
     {
         framebuffer->renderTargetViews[i] =
             static_cast<TextureViewImpl*>(desc.renderTargetViews[i]);
@@ -2222,10 +2222,10 @@ void GLDevice::setStencilReference(uint32_t referenceValue)
 
 void GLDevice::copyBuffer(
     IBufferResource* dst,
-    size_t dstOffset,
+    Offset dstOffset,
     IBufferResource* src,
-    size_t srcOffset,
-    size_t size)
+    Offset srcOffset,
+    Size size)
 {
     auto dstImpl = static_cast<BufferResourceImpl*>(dst);
     auto srcImpl = static_cast<BufferResourceImpl*>(src);
@@ -2235,7 +2235,7 @@ void GLDevice::copyBuffer(
 }
 
 SLANG_NO_THROW Result SLANG_MCALL GLDevice::readTextureResource(
-    ITextureResource* texture, ResourceState state, ISlangBlob** outBlob, size_t* outRowPitch, size_t* outPixelSize)
+    ITextureResource* texture, ResourceState state, ISlangBlob** outBlob, Size* outRowPitch, Size* outPixelSize)
 {
     SLANG_UNUSED(state);
     auto resource = static_cast<TextureResourceImpl*>(texture);
@@ -2652,10 +2652,10 @@ void GLDevice::setPrimitiveTopology(PrimitiveTopology topology)
 }
 
 void GLDevice::setVertexBuffers(
-    uint32_t startSlot,
-    uint32_t slotCount,
+    GfxIndex startSlot,
+    GfxCount slotCount,
     IBufferResource* const* buffers,
-    const uint32_t* offsets)
+    const Offset* offsets)
 {
     for (UInt ii = 0; ii < slotCount; ++ii)
     {
@@ -2669,7 +2669,7 @@ void GLDevice::setVertexBuffers(
     }
 }
 
-void GLDevice::setIndexBuffer(IBufferResource* buffer, Format indexFormat, uint32_t offset)
+void GLDevice::setIndexBuffer(IBufferResource* buffer, Format indexFormat, Offset offset)
 {
     auto bufferImpl = static_cast<BufferResourceImpl*>(buffer);
     m_boundIndexBuffer = bufferImpl->m_handle;
@@ -2677,7 +2677,7 @@ void GLDevice::setIndexBuffer(IBufferResource* buffer, Format indexFormat, uint3
     m_boundIndexBufferSize = bufferImpl->m_size;
 }
 
-void GLDevice::setViewports(UInt count, Viewport const* viewports)
+void GLDevice::setViewports(GfxCount count, Viewport const* viewports)
 {
     assert(count == 1);
     auto viewport = viewports[0];
@@ -2689,7 +2689,7 @@ void GLDevice::setViewports(UInt count, Viewport const* viewports)
     glDepthRange(viewport.minZ, viewport.maxZ);
 }
 
-void GLDevice::setScissorRects(UInt count, ScissorRect const* rects)
+void GLDevice::setScissorRects(GfxCount count, ScissorRect const* rects)
 {
     assert(count <= 1);
     if( count )
@@ -2728,14 +2728,14 @@ void GLDevice::setPipelineState(IPipelineState* state)
     glUseProgram(programID);
 }
 
-void GLDevice::draw(uint32_t vertexCount, uint32_t startVertex = 0)
+void GLDevice::draw(GfxCount vertexCount, GfxIndex startVertex = 0)
 {
     flushStateForDraw();
 
     glDrawArrays(m_boundPrimitiveTopology, (GLint)startVertex, (GLsizei)vertexCount);
 }
 
-void GLDevice::drawIndexed(uint32_t indexCount, uint32_t startIndex, uint32_t baseVertex)
+void GLDevice::drawIndexed(GfxCount indexCount, GfxIndex startIndex, GfxIndex baseVertex)
 {
     flushStateForDraw();
 
@@ -2748,20 +2748,20 @@ void GLDevice::drawIndexed(uint32_t indexCount, uint32_t startIndex, uint32_t ba
 }
 
 void GLDevice::drawInstanced(
-    uint32_t vertexCount,
-    uint32_t instanceCount,
-    uint32_t startVertex,
-    uint32_t startInstanceLocation)
+    GfxCount vertexCount,
+    GfxCount instanceCount,
+    GfxIndex startVertex,
+    GfxIndex startInstanceLocation)
 {
     SLANG_UNIMPLEMENTED_X("drawInstanced");
 }
 
 void GLDevice::drawIndexedInstanced(
-    uint32_t indexCount,
-    uint32_t instanceCount,
-    uint32_t startIndexLocation,
-    int32_t baseVertexLocation,
-    uint32_t startInstanceLocation)
+    GfxCount indexCount,
+    GfxCount instanceCount,
+    GfxIndex startIndexLocation,
+    GfxIndex baseVertexLocation,
+    GfxIndex startInstanceLocation)
 {
     SLANG_UNIMPLEMENTED_X("drawIndexedInstanced");
 }

--- a/tools/gfx/render.cpp
+++ b/tools/gfx/render.cpp
@@ -35,7 +35,7 @@ static bool _checkFormat()
 #define GFX_FORMAT_CHECK(name, blockSizeInBytes, pixelsPerblock) count += Index(Index(Format::name) == value++);
     GFX_FORMAT(GFX_FORMAT_CHECK)
 
-    const bool r = (count == Index(Format::CountOf));
+    const bool r = (count == Index(Format::_Count));
     SLANG_ASSERT(r);
     return r;
 }
@@ -168,14 +168,14 @@ struct FormatInfoMap
 
     const FormatInfo& get(Format format) const { return m_infos[Index(format)]; }
 
-    FormatInfo m_infos[Index(Format::CountOf)];
+    FormatInfo m_infos[Index(Format::_Count)];
 };
 
 static const FormatInfoMap s_formatInfoMap;
 
 static void _compileTimeAsserts()
 {
-    SLANG_COMPILE_TIME_ASSERT(SLANG_COUNT_OF(s_formatSizeInfo) == int(Format::CountOf));
+    SLANG_COMPILE_TIME_ASSERT(SLANG_COUNT_OF(s_formatSizeInfo) == int(Format::_Count));
 }
 
 extern "C"

--- a/tools/gfx/renderer-shared.cpp
+++ b/tools/gfx/renderer-shared.cpp
@@ -343,7 +343,7 @@ SLANG_NO_THROW Result SLANG_MCALL RendererBase::getNativeDeviceHandles(InteropHa
 }
 
 SLANG_NO_THROW Result SLANG_MCALL RendererBase::getFeatures(
-    const char** outFeatures, UInt bufferSize, UInt* outFeatureCount)
+    const char** outFeatures, Size bufferSize, GfxCount* outFeatureCount)
 {
     if (bufferSize >= (UInt)m_features.getCount())
     {
@@ -353,7 +353,7 @@ SLANG_NO_THROW Result SLANG_MCALL RendererBase::getFeatures(
         }
     }
     if (outFeatureCount)
-        *outFeatureCount = (UInt)m_features.getCount();
+        *outFeatureCount = (GfxCount)m_features.getCount();
     return SLANG_OK;
 }
 
@@ -524,7 +524,7 @@ Result RendererBase::createFence(const IFence::Desc& desc, IFence** outFence)
 }
 
 Result RendererBase::waitForFences(
-    uint32_t fenceCount, IFence** fences, uint64_t* fenceValues, bool waitForAll, uint64_t timeout)
+    GfxCount fenceCount, IFence** fences, uint64_t* fenceValues, bool waitForAll, uint64_t timeout)
 {
     SLANG_UNUSED(fenceCount);
     SLANG_UNUSED(fences);
@@ -781,7 +781,7 @@ void ShaderProgramBase::init(const IShaderProgram::Desc& inDesc)
     desc = inDesc;
 
     slangGlobalScope = desc.slangGlobalScope;
-    for (uint32_t i = 0; i < desc.entryPointCount; i++)
+    for (GfxIndex i = 0; i < desc.entryPointCount; i++)
     {
         slangEntryPoints.add(ComPtr<slang::IComponentType>(desc.slangEntryPoints[i]));
     }
@@ -794,7 +794,7 @@ void ShaderProgramBase::init(const IShaderProgram::Desc& inDesc)
         {
             components.add(desc.slangGlobalScope);
         }
-        for (uint32_t i = 0; i < desc.entryPointCount; i++)
+        for (GfxIndex i = 0; i < desc.entryPointCount; i++)
         {
             if (!session)
             {
@@ -807,7 +807,7 @@ void ShaderProgramBase::init(const IShaderProgram::Desc& inDesc)
     }
     else
     {
-        for (uint32_t i = 0; i < desc.entryPointCount; i++)
+        for (GfxIndex i = 0; i < desc.entryPointCount; i++)
         {
             if (desc.slangGlobalScope)
             {
@@ -1044,7 +1044,7 @@ Result ShaderTableBase::init(const IShaderTable::Desc& desc)
     m_hitGroupCount = desc.hitGroupCount;
     m_shaderGroupNames.reserve(desc.hitGroupCount + desc.missShaderCount + desc.rayGenShaderCount);
     m_recordOverwrites.reserve(desc.hitGroupCount + desc.missShaderCount + desc.rayGenShaderCount);
-    for (uint32_t i = 0; i < desc.rayGenShaderCount; i++)
+    for (GfxIndex i = 0; i < desc.rayGenShaderCount; i++)
     {
         m_shaderGroupNames.add(desc.rayGenShaderEntryPointNames[i]);
         if (desc.rayGenShaderRecordOverwrites)
@@ -1056,7 +1056,7 @@ Result ShaderTableBase::init(const IShaderTable::Desc& desc)
             m_recordOverwrites.add(ShaderRecordOverwrite{});
         }
     }
-    for (uint32_t i = 0; i < desc.missShaderCount; i++)
+    for (GfxIndex i = 0; i < desc.missShaderCount; i++)
     {
         m_shaderGroupNames.add(desc.missShaderEntryPointNames[i]);
         if (desc.missShaderRecordOverwrites)
@@ -1068,7 +1068,7 @@ Result ShaderTableBase::init(const IShaderTable::Desc& desc)
             m_recordOverwrites.add(ShaderRecordOverwrite{});
         }
     }
-    for (uint32_t i = 0; i < desc.hitGroupCount; i++)
+    for (GfxIndex i = 0; i < desc.hitGroupCount; i++)
     {
         m_shaderGroupNames.add(desc.hitGroupNames[i]);
         if (desc.hitGroupRecordOverwrites)

--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -520,9 +520,9 @@ public:
         ShaderOffset offset);
 
 public:
-    SLANG_NO_THROW UInt SLANG_MCALL getEntryPointCount() SLANG_OVERRIDE { return 0; }
+    SLANG_NO_THROW GfxCount SLANG_MCALL getEntryPointCount() SLANG_OVERRIDE { return 0; }
 
-    SLANG_NO_THROW Result SLANG_MCALL getEntryPoint(UInt index, IShaderObject** outEntryPoint)
+    SLANG_NO_THROW Result SLANG_MCALL getEntryPoint(GfxIndex index, IShaderObject** outEntryPoint)
         SLANG_OVERRIDE
     {
         *outEntryPoint = nullptr;
@@ -774,7 +774,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL setSpecializationArgs(
         ShaderOffset const& offset,
         const slang::SpecializationArg* args,
-        uint32_t count) override
+        GfxCount count) override
     {
         auto layout = getLayout();
 
@@ -939,8 +939,8 @@ struct OwnedRayTracingPipelineStateDesc
     Slang::List<OwnedHitGroupDesc> hitGroups;
     Slang::List<HitGroupDesc> hitGroupDescs;
     int maxRecursion = 0;
-    int maxRayPayloadSize = 0;
-    int maxAttributeSizeInBytes = 8;
+    Size maxRayPayloadSize = 0;
+    Size maxAttributeSizeInBytes = 8;
     RayTracingPipelineFlags::Enum flags = RayTracingPipelineFlags::None;
 
     RayTracingPipelineStateDesc get()
@@ -1208,7 +1208,7 @@ public:
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(InteropHandles* outHandles) SLANG_OVERRIDE;
     virtual SLANG_NO_THROW Result SLANG_MCALL getFeatures(
-        const char** outFeatures, UInt bufferSize, UInt* outFeatureCount) SLANG_OVERRIDE;
+        const char** outFeatures, Size bufferSize, GfxCount* outFeatureCount) SLANG_OVERRIDE;
     virtual SLANG_NO_THROW bool SLANG_MCALL hasFeature(const char* featureName) SLANG_OVERRIDE;
     virtual SLANG_NO_THROW Result SLANG_MCALL
         getFormatSupportedResourceStates(Format format, ResourceStateSet* outStates) override;
@@ -1284,7 +1284,7 @@ public:
 
     // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE.
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        waitForFences(uint32_t fenceCount, IFence** fences, uint64_t* fenceValues, bool waitForAll, uint64_t timeout) override;
+        waitForFences(GfxCount fenceCount, IFence** fences, uint64_t* fenceValues, bool waitForAll, uint64_t timeout) override;
 
     // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE.
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureAllocationInfo(

--- a/tools/gfx/resource-desc-utils.h
+++ b/tools/gfx/resource-desc-utils.h
@@ -12,9 +12,9 @@ inline int calcMipSize(int size, int level)
     return size > 0 ? size : 1;
 }
 
-inline ITextureResource::Size calcMipSize(ITextureResource::Size size, int mipLevel)
+inline ITextureResource::Extents calcMipSize(ITextureResource::Extents size, int mipLevel)
 {
-    ITextureResource::Size rs;
+    ITextureResource::Extents rs;
     rs.width = calcMipSize(size.width, mipLevel);
     rs.height = calcMipSize(size.height, mipLevel);
     rs.depth = calcMipSize(size.depth, mipLevel);
@@ -45,7 +45,7 @@ inline int calcEffectiveArraySize(const ITextureResource::Desc& desc)
 }
 
 /// Given the type works out the maximum dimension size
-inline int calcMaxDimension(ITextureResource::Size size, IResource::Type type)
+inline int calcMaxDimension(ITextureResource::Extents size, IResource::Type type)
 {
     switch (type)
     {
@@ -64,7 +64,7 @@ inline int calcMaxDimension(ITextureResource::Size size, IResource::Type type)
 }
 
 /// Given the type, calculates the number of mip maps. 0 on error
-inline int calcNumMipLevels(IResource::Type type, ITextureResource::Size size)
+inline int calcNumMipLevels(IResource::Type type, ITextureResource::Extents size)
 {
     const int maxDimensionSize = calcMaxDimension(size, type);
     return (maxDimensionSize > 0) ? (Slang::Math::Log2Floor(maxDimensionSize) + 1) : 0;

--- a/tools/gfx/simple-render-pass-layout.cpp
+++ b/tools/gfx/simple-render-pass-layout.cpp
@@ -15,7 +15,7 @@ IRenderPassLayout* SimpleRenderPassLayout::getInterface(const Slang::Guid& guid)
 void SimpleRenderPassLayout::init(const IRenderPassLayout::Desc& desc)
 {
     m_renderTargetAccesses.setCount(desc.renderTargetCount);
-    for (uint32_t i = 0; i < desc.renderTargetCount; i++)
+    for (GfxIndex i = 0; i < desc.renderTargetCount; i++)
         m_renderTargetAccesses[i] = desc.renderTargetAccess[i];
     m_hasDepthStencil = (desc.depthStencilAccess != nullptr);
     if (m_hasDepthStencil)

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -1389,9 +1389,9 @@ Result DeviceImpl::getAccelerationStructurePrebuildInfo(
         &geomInfoBuilder.buildInfo,
         geomInfoBuilder.primitiveCounts.getBuffer(),
         &sizeInfo);
-    outPrebuildInfo->resultDataMaxSize = sizeInfo.accelerationStructureSize;
-    outPrebuildInfo->scratchDataSize = sizeInfo.buildScratchSize;
-    outPrebuildInfo->updateScratchDataSize = sizeInfo.updateScratchSize;
+    outPrebuildInfo->resultDataMaxSize = (Size)sizeInfo.accelerationStructureSize;
+    outPrebuildInfo->scratchDataSize = (Size)sizeInfo.buildScratchSize;
+    outPrebuildInfo->updateScratchDataSize = (Size)sizeInfo.updateScratchSize;
     return SLANG_OK;
 }
 
@@ -6472,7 +6472,7 @@ void ResourceCommandEncoder::textureBarrier(
 {
     ShortList<VkImageMemoryBarrier, 16> barriers;
 
-    for (size_t i = 0; i < count; i++)
+    for (GfxIndex i = 0; i < count; i++)
     {
         auto image = static_cast<TextureResourceImpl*>(textures[i]);
         auto desc = image->getDesc();
@@ -6516,7 +6516,7 @@ void ResourceCommandEncoder::bufferBarrier(
     List<VkBufferMemoryBarrier> barriers;
     barriers.reserve(count);
 
-    for (size_t i = 0; i < count; i++)
+    for (GfxIndex i = 0; i < count; i++)
     {
         auto bufferImpl = static_cast<BufferResourceImpl*>(buffers[i]);
 
@@ -7555,7 +7555,7 @@ void RayTracingCommandEncoder::_queryAccelerationStructureProperties(
 
 void RayTracingCommandEncoder::buildAccelerationStructure(
     const IAccelerationStructure::BuildDesc& desc,
-    int propertyQueryCount,
+    GfxCount propertyQueryCount,
     AccelerationStructureQueryDesc* queryDescs)
 {
     AccelerationStructureBuildGeometryInfoBuilder geomInfoBuilder;

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -1251,7 +1251,7 @@ SlangResult DeviceImpl::readTextureResource(
     Size pixelSize = sizeInfo.blockSizeInBytes / sizeInfo.pixelsPerBlock;
     Size rowPitch = width * pixelSize;
 
-    List<TextureResource::Size> mipSizes;
+    List<TextureResource::Extents> mipSizes;
 
     const int numMipMaps = desc->numMipLevels;
     auto arraySize = calcEffectiveArraySize(*desc);
@@ -1261,7 +1261,7 @@ SlangResult DeviceImpl::readTextureResource(
     // Calculate how large an array entry is
     for (int j = 0; j < numMipMaps; ++j)
     {
-        const TextureResource::Size mipSize = calcMipSize(desc->size, j);
+        const TextureResource::Extents mipSize = calcMipSize(desc->size, j);
 
         auto rowSizeInBytes = calcRowSize(desc->format, mipSize.width);
         auto numRows = calcNumRows(desc->format, mipSize.height);
@@ -1709,7 +1709,7 @@ Result DeviceImpl::createTextureResource(
     VKBufferHandleRAII uploadBuffer;
     if (initData)
     {
-        List<TextureResource::Size> mipSizes;
+        List<TextureResource::Extents> mipSizes;
 
         VkCommandBuffer commandBuffer = m_deviceQueue.getCommandBuffer();
 
@@ -1720,7 +1720,7 @@ Result DeviceImpl::createTextureResource(
         // Calculate how large an array entry is
         for (int j = 0; j < numMipMaps; ++j)
         {
-            const TextureResource::Size mipSize = calcMipSize(desc.size, j);
+            const TextureResource::Extents mipSize = calcMipSize(desc.size, j);
 
             auto rowSizeInBytes = calcRowSize(desc.format, mipSize.width);
             auto numRows = calcNumRows(desc.format, mipSize.height);
@@ -6597,7 +6597,7 @@ void ResourceCommandEncoder::copyTexture(
     ResourceState srcState,
     SubresourceRange srcSubresource,
     ITextureResource::Offset3D srcOffset,
-    ITextureResource::Size extent)
+    ITextureResource::Extents extent)
 {
     auto srcImage = static_cast<TextureResourceImpl*>(src);
     auto srcDesc = srcImage->getDesc();
@@ -6649,7 +6649,7 @@ void ResourceCommandEncoder::uploadTextureData(
     ITextureResource* dst,
     SubresourceRange subResourceRange,
     ITextureResource::Offset3D offset,
-    ITextureResource::Size extend,
+    ITextureResource::Extents extend,
     ITextureResource::SubresourceData* subResourceData,
     GfxCount subResourceDataCount)
 {
@@ -6657,7 +6657,7 @@ void ResourceCommandEncoder::uploadTextureData(
 
     auto& vkApi = m_commandBuffer->m_renderer->m_api;
     auto dstImpl = static_cast<TextureResourceImpl*>(dst);
-    List<TextureResource::Size> mipSizes;
+    List<TextureResource::Extents> mipSizes;
 
     VkCommandBuffer commandBuffer = m_commandBuffer->m_commandBuffer;
     auto& desc = *dstImpl->getDesc();
@@ -6668,7 +6668,7 @@ void ResourceCommandEncoder::uploadTextureData(
          j < subResourceRange.mipLevel + subResourceRange.mipLevelCount;
          ++j)
     {
-        const TextureResource::Size mipSize = calcMipSize(desc.size, j);
+        const TextureResource::Extents mipSize = calcMipSize(desc.size, j);
 
         auto rowSizeInBytes = calcRowSize(desc.format, mipSize.width);
         auto numRows = calcNumRows(desc.format, mipSize.height);
@@ -7064,7 +7064,7 @@ void ResourceCommandEncoder::copyTextureToBuffer(
     ResourceState srcState,
     SubresourceRange srcSubresource,
     ITextureResource::Offset3D srcOffset,
-    ITextureResource::Size extent)
+    ITextureResource::Extents extent)
 {
     assert(srcSubresource.mipLevelCount <= 1);
 

--- a/tools/gfx/vulkan/render-vk.cpp
+++ b/tools/gfx/vulkan/render-vk.cpp
@@ -7504,20 +7504,20 @@ void RayTracingCommandEncoder::_memoryBarrier(
 }
 
 void RayTracingCommandEncoder::_queryAccelerationStructureProperties(
-    int accelerationStructureCount,
+    GfxCount accelerationStructureCount,
     IAccelerationStructure* const* accelerationStructures,
-    int queryCount,
+    GfxCount queryCount,
     AccelerationStructureQueryDesc* queryDescs)
 {
     ShortList<VkAccelerationStructureKHR> vkHandles;
     vkHandles.setCount(accelerationStructureCount);
-    for (int i = 0; i < accelerationStructureCount; i++)
+    for (GfxIndex i = 0; i < accelerationStructureCount; i++)
     {
         vkHandles[i] =
             static_cast<AccelerationStructureImpl*>(accelerationStructures[i])->m_vkHandle;
     }
     auto vkHandlesView = vkHandles.getArrayView();
-    for (int i = 0; i < queryCount; i++)
+    for (GfxIndex i = 0; i < queryCount; i++)
     {
         VkQueryType queryType;
         switch (queryDescs[i].queryType)
@@ -7623,9 +7623,9 @@ void RayTracingCommandEncoder::copyAccelerationStructure(
 }
 
 void RayTracingCommandEncoder::queryAccelerationStructureProperties(
-    int accelerationStructureCount,
+    GfxCount accelerationStructureCount,
     IAccelerationStructure* const* accelerationStructures,
-    int queryCount,
+    GfxCount queryCount,
     AccelerationStructureQueryDesc* queryDescs)
 {
     _queryAccelerationStructureProperties(

--- a/tools/gfx/vulkan/render-vk.h
+++ b/tools/gfx/vulkan/render-vk.h
@@ -1419,13 +1419,13 @@ public:
         ResourceState srcState,
         SubresourceRange srcSubresource,
         ITextureResource::Offset3D srcOffset,
-        ITextureResource::Size extent) override;
+        ITextureResource::Extents extent) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL uploadTextureData(
         ITextureResource* dst,
         SubresourceRange subResourceRange,
         ITextureResource::Offset3D offset,
-        ITextureResource::Size extend,
+        ITextureResource::Extents extend,
         ITextureResource::SubresourceData* subResourceData,
         GfxCount subResourceDataCount) override;
 
@@ -1466,7 +1466,7 @@ public:
         ResourceState srcState,
         SubresourceRange srcSubresource,
         ITextureResource::Offset3D srcOffset,
-        ITextureResource::Size extent) override;
+        ITextureResource::Extents extent) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL textureSubresourceBarrier(
         ITextureResource* texture,

--- a/tools/gfx/vulkan/render-vk.h
+++ b/tools/gfx/vulkan/render-vk.h
@@ -126,7 +126,7 @@ public:
         createFence(const IFence::Desc& desc, IFence** outFence) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL waitForFences(
-        uint32_t fenceCount,
+        GfxCount fenceCount,
         IFence** fences,
         uint64_t* fenceValues,
         bool waitForAll,
@@ -1125,15 +1125,14 @@ public:
 
     RendererBase* getDevice();
 
-    virtual SLANG_NO_THROW UInt SLANG_MCALL getEntryPointCount() override;
+    virtual SLANG_NO_THROW GfxCount SLANG_MCALL getEntryPointCount() override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getEntryPoint(UInt index, IShaderObject** outEntryPoint) override;
+        getEntryPoint(GfxIndex index, IShaderObject** outEntryPoint) override;
 
     virtual SLANG_NO_THROW const void* SLANG_MCALL getRawData() override;
 
-    // TODO: Change size_t to Count?
-    virtual SLANG_NO_THROW size_t SLANG_MCALL getSize() override;
+    virtual SLANG_NO_THROW Size SLANG_MCALL getSize() override;
 
     // TODO: Changed size_t to Size? inSize assigned to an Index variable inside implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL
@@ -1342,8 +1341,8 @@ public:
 
     List<RefPtr<EntryPointShaderObject>> const& getEntryPoints() const;
 
-    virtual UInt SLANG_MCALL getEntryPointCount() override;
-    virtual Result SLANG_MCALL getEntryPoint(UInt index, IShaderObject** outEntryPoint) override;
+    virtual GfxCount SLANG_MCALL getEntryPointCount() override;
+    virtual Result SLANG_MCALL getEntryPoint(GfxIndex index, IShaderObject** outEntryPoint) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
         copyFrom(IShaderObject* object, ITransientResourceHeap* transientHeap) override;
@@ -1395,19 +1394,19 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL
         uploadBufferData(IBufferResource* buffer, Offset offset, Size size, void* data) override;
     virtual SLANG_NO_THROW void SLANG_MCALL textureBarrier(
-        size_t count, // TODO: Change size_t to Count?
+        GfxCount count,
         ITextureResource* const* textures,
         ResourceState src,
         ResourceState dst) override;
     virtual SLANG_NO_THROW void SLANG_MCALL bufferBarrier(
-        size_t count, // TODO: Change size_t to Count?
+        GfxCount count,
         IBufferResource* const* buffers,
         ResourceState src,
         ResourceState dst) override;
     virtual SLANG_NO_THROW void SLANG_MCALL endEncoding() override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL
-        writeTimestamp(IQueryPool* queryPool, SlangInt index) override;
+        writeTimestamp(IQueryPool* queryPool, GfxIndex index) override;
 
     VkImageAspectFlags getAspectMask(TextureAspect aspect);
 
@@ -1428,7 +1427,7 @@ public:
         ITextureResource::Offset3D offset,
         ITextureResource::Size extend,
         ITextureResource::SubresourceData* subResourceData,
-        size_t subResourceDataCount) override; // TODO: Change size_t to Count?
+        GfxCount subResourceDataCount) override;
 
     void _clearColorImage(TextureResourceViewImpl* viewImpl, ClearValue* clearValue);
 
@@ -1453,10 +1452,10 @@ public:
 
     virtual SLANG_NO_THROW void SLANG_MCALL resolveQuery(
         IQueryPool* queryPool,
-        uint32_t index,
-        uint32_t count,
+        GfxIndex index,
+        GfxCount count,
         IBufferResource* buffer,
-        uint64_t offset) override;
+        Offset offset) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
         IBufferResource* dst,
@@ -1502,63 +1501,63 @@ public:
         IPipelineState* pipelineState, IShaderObject* rootObject) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL
-        setViewports(uint32_t count, const Viewport* viewports) override;
+        setViewports(GfxCount count, const Viewport* viewports) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL
-        setScissorRects(uint32_t count, const ScissorRect* rects) override;
+        setScissorRects(GfxCount count, const ScissorRect* rects) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL
         setPrimitiveTopology(PrimitiveTopology topology) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL setVertexBuffers(
-        uint32_t startSlot,
-        uint32_t slotCount,
+        GfxIndex startSlot,
+        GfxCount slotCount,
         IBufferResource* const* buffers,
-        const uint32_t* offsets) override;
+        const Offset* offsets) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL
-        setIndexBuffer(IBufferResource* buffer, Format indexFormat, uint32_t offset = 0) override;
+        setIndexBuffer(IBufferResource* buffer, Format indexFormat, Offset offset = 0) override;
 
     void prepareDraw();
 
     virtual SLANG_NO_THROW void SLANG_MCALL
-        draw(uint32_t vertexCount, uint32_t startVertex = 0) override;
+        draw(GfxCount vertexCount, GfxIndex startVertex = 0) override;
     virtual SLANG_NO_THROW void SLANG_MCALL
-        drawIndexed(uint32_t indexCount, uint32_t startIndex = 0, uint32_t baseVertex = 0) override;
+        drawIndexed(GfxCount indexCount, GfxIndex startIndex = 0, GfxIndex baseVertex = 0) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL setStencilReference(uint32_t referenceValue) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndirect(
-        uint32_t maxDrawCount,
+        GfxCount maxDrawCount,
         IBufferResource* argBuffer,
-        uint64_t argOffset,
+        Offset argOffset,
         IBufferResource* countBuffer,
-        uint64_t countOffset) override;
+        Offset countOffset) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedIndirect(
-        uint32_t maxDrawCount,
+        GfxCount maxDrawCount,
         IBufferResource* argBuffer,
-        uint64_t argOffset,
+        Offset argOffset,
         IBufferResource* countBuffer,
-        uint64_t countOffset) override;
+        Offset countOffset) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL setSamplePositions(
-        uint32_t samplesPerPixel,
-        uint32_t pixelCount,
+        GfxCount samplesPerPixel,
+        GfxCount pixelCount,
         const SamplePosition* samplePositions) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL drawInstanced(
-        uint32_t vertexCount,
-        uint32_t instanceCount,
-        uint32_t startVertex,
-        uint32_t startInstanceLocation) override;
+        GfxCount vertexCount,
+        GfxCount instanceCount,
+        GfxIndex startVertex,
+        GfxIndex startInstanceLocation) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL drawIndexedInstanced(
-        uint32_t indexCount,
-        uint32_t instanceCount,
-        uint32_t startIndexLocation,
-        int32_t baseVertexLocation,
-        uint32_t startInstanceLocation) override;
+        GfxCount indexCount,
+        GfxCount instanceCount,
+        GfxIndex startIndexLocation,
+        GfxIndex baseVertexLocation,
+        GfxIndex startInstanceLocation) override;
 };
 
 class ComputeCommandEncoder
@@ -1579,7 +1578,7 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL dispatchCompute(int x, int y, int z) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL
-        dispatchComputeIndirect(IBufferResource* argBuffer, uint64_t offset) override;
+        dispatchComputeIndirect(IBufferResource* argBuffer, Offset offset) override;
 };
 
 class RayTracingCommandEncoder
@@ -1630,11 +1629,11 @@ public:
         IPipelineState* pipelineState, IShaderObject* rootObject) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL dispatchRays(
-        uint32_t raygenShaderIndex,
+        GfxIndex raygenShaderIndex,
         IShaderTable* shaderTable,
-        int32_t width,
-        int32_t height,
-        int32_t depth) override;
+        GfxCount width,
+        GfxCount height,
+        GfxCount depth) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL endEncoding() override;
 };
@@ -1725,7 +1724,7 @@ public:
     virtual SLANG_NO_THROW const Desc& SLANG_MCALL getDesc() override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL waitForFenceValuesOnDevice(
-        uint32_t fenceCount, IFence** fences, uint64_t* waitValues) override;
+        GfxCount fenceCount, IFence** fences, uint64_t* waitValues) override;
 
     void queueSubmitImpl(
         uint32_t count,
@@ -1734,7 +1733,7 @@ public:
         uint64_t valueToSignal);
 
     virtual SLANG_NO_THROW void SLANG_MCALL executeCommandBuffers(
-        uint32_t count,
+        GfxCount count,
         ICommandBuffer* const* commandBuffers,
         IFence* fence,
         uint64_t valueToSignal) override;
@@ -1773,7 +1772,7 @@ public:
 
 public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getResult(SlangInt index, SlangInt count, uint64_t* data) override;
+        getResult(GfxIndex index, GfxCount count, uint64_t* data) override;
 
 public:
     VkQueryPool m_pool;
@@ -1832,8 +1831,8 @@ public:
 
     virtual SLANG_NO_THROW const Desc& SLANG_MCALL getDesc() override { return m_desc; }
     virtual SLANG_NO_THROW Result SLANG_MCALL
-        getImage(uint32_t index, ITextureResource** outResource) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL resize(uint32_t width, uint32_t height) override;
+        getImage(GfxIndex index, ITextureResource** outResource) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL resize(GfxCount width, GfxCount height) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
     virtual SLANG_NO_THROW int SLANG_MCALL acquireNextImage() override;
     virtual SLANG_NO_THROW bool SLANG_MCALL isOccluded() override { return false; }

--- a/tools/gfx/vulkan/render-vk.h
+++ b/tools/gfx/vulkan/render-vk.h
@@ -1602,7 +1602,7 @@ public:
 
     virtual SLANG_NO_THROW void SLANG_MCALL buildAccelerationStructure(
         const IAccelerationStructure::BuildDesc& desc,
-        int propertyQueryCount,
+        GfxCount propertyQueryCount,
         AccelerationStructureQueryDesc* queryDescs) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL copyAccelerationStructure(

--- a/tools/gfx/vulkan/render-vk.h
+++ b/tools/gfx/vulkan/render-vk.h
@@ -1595,9 +1595,9 @@ public:
         AccessFlag destAccess);
 
     void _queryAccelerationStructureProperties(
-        int accelerationStructureCount,
+        GfxCount accelerationStructureCount,
         IAccelerationStructure* const* accelerationStructures,
-        int queryCount,
+        GfxCount queryCount,
         AccelerationStructureQueryDesc* queryDescs);
 
     virtual SLANG_NO_THROW void SLANG_MCALL buildAccelerationStructure(
@@ -1611,9 +1611,9 @@ public:
         AccelerationStructureCopyMode mode) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL queryAccelerationStructureProperties(
-        int accelerationStructureCount,
+        GfxCount accelerationStructureCount,
         IAccelerationStructure* const* accelerationStructures,
-        int queryCount,
+        GfxCount queryCount,
         AccelerationStructureQueryDesc* queryDescs) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -293,7 +293,7 @@ struct AssignValsFromLayoutContext
             if(field.name.getLength() == 0)
             {
                 // If no name was given, assume by-indexing matching is requested
-                auto fieldCursor = dstCursor.getElement(fieldIndex);
+                auto fieldCursor = dstCursor.getElement((GfxIndex)fieldIndex);
                 if(!fieldCursor.isValid())
                 {
                     StdWriters::getError().print("error: could not find shader parameter at index %d\n", (int)fieldIndex);


### PR DESCRIPTION
Changes:
- Numerous changes in `slang-gfx.h` to use the previously introduced `GfxIndex`, `GfxCount`, `Size`, and `Offset` typedefs where appropriate
- Updated a large number of additional header and implementation files to reflect these changes in the gfx header
- Updated some renames from the last pass that were missed inside implementation files
- Added casts where appropriate to avoid type conversion warnings
- Renamed `ITextureResource::Size` (which contains width/height/depth values) to `ITextureResource::Extents` to avoid confusion with the new `Size` typedef

Lots of renames in lots of files just to get everything working again, definitely will want checks to make sure there isn't anything that's been misnamed. (I'm less concerned about missed renames at the moment.)

@csyonghe @tangent-vector