### PR TITLE
Made translation units visible to transitive `import`s.

### DIFF
--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1754,7 +1754,8 @@ namespace Slang
             const PathInfo&     filePathInfo,
             ISlangBlob*         fileContentsBlob,
             SourceLoc const&    loc,
-            DiagnosticSink*     sink);
+            DiagnosticSink*     sink,
+            const LoadedModuleDictionary* additionalLoadedModules);
 
         void loadParsedModule(
             RefPtr<FrontEndCompileRequest>  compileRequest,
@@ -1937,6 +1938,9 @@ namespace Slang
 
         // Translation units we are being asked to compile
         List<RefPtr<TranslationUnitRequest> > translationUnits;
+
+        // Additional modules that needs to be made visible to `import` while checking.
+        const LoadedModuleDictionary* additionalLoadedModules = nullptr;
 
         RefPtr<TranslationUnitRequest> getTranslationUnit(UInt index) { return translationUnits[index]; }
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -960,7 +960,8 @@ SLANG_NO_THROW slang::IModule* SLANG_MCALL Linkage::loadModuleFromSource(
             PathInfo::makeFromString(moduleName),
             source,
             SourceLoc(),
-            &sink);
+            &sink,
+            nullptr);
         sink.getBlobIfNeeded(outDiagnostics);
         return asExternal(module);
 
@@ -2003,6 +2004,8 @@ RefPtr<ComponentType> createSpecializedGlobalAndEntryPointsComponentType(
 void FrontEndCompileRequest::checkAllTranslationUnits()
 {
     LoadedModuleDictionary loadedModules;
+    if (additionalLoadedModules)
+        loadedModules = *additionalLoadedModules;
 
     // Iterate over all translation units and
     // apply the semantic checking logic.
@@ -2604,9 +2607,12 @@ RefPtr<Module> Linkage::loadModule(
     const PathInfo&     filePathInfo,
     ISlangBlob*         sourceBlob, 
     SourceLoc const&    srcLoc,
-    DiagnosticSink*     sink)
+    DiagnosticSink*     sink,
+    const LoadedModuleDictionary* additionalLoadedModules)
 {
     RefPtr<FrontEndCompileRequest> frontEndReq = new FrontEndCompileRequest(this, nullptr, sink);
+
+    frontEndReq->additionalLoadedModules = additionalLoadedModules;
 
     RefPtr<TranslationUnitRequest> translationUnit = new TranslationUnitRequest(frontEndReq);
     translationUnit->compileRequest = frontEndReq;
@@ -2767,7 +2773,8 @@ RefPtr<Module> Linkage::findOrImportModule(
         filePathInfo,
         fileContents,
         loc,
-        sink);
+        sink,
+        loadedModules);
 }
 
 //

--- a/tools/slang-unit-test/unit-test-translation-unit-import.cpp
+++ b/tools/slang-unit-test/unit-test-translation-unit-import.cpp
@@ -7,6 +7,7 @@
 
 #include "tools/unit-test/slang-unit-test.h"
 #include "../../slang-com-ptr.h"
+#include "../../source/core/slang-io.h"
 
 using namespace Slang;
 
@@ -20,27 +21,38 @@ SLANG_UNIT_TEST(translationUnitImport)
         "   return 5;"
         "};";
 
-    // Source for the second translation unit that imports the first translation unit.
+    // Source for the a file that imports the first translation unit.
     // The import should succeed and `f` should be visible to this module.
-    const char* userSource =
+    const char* fileSource =
         R"(
         import generatedUnit;
 
+        int g(){ return f(); }
+        )";
+
+    // Source for a module that transitively uses the generated source via a file.
+    const char* userSource = R"(
+        import moduleG;
         [shader("compute")]
         [numthreads(4,1,1)]
         void computeMain(
             uint3 sv_dispatchThreadID : SV_DispatchThreadID,
             uniform RWStructuredBuffer<int> buffer)
         {
-            buffer[sv_dispatchThreadID.x] = f();
-        }
-        )";    
+            buffer[sv_dispatchThreadID.x] = g();
+        })";
+
+    
     auto session = spCreateSession();
     auto request = spCreateCompileRequest(session);
+
+    File::writeAllText("moduleG.slang", fileSource);
+
     spAddCodeGenTarget(request, SLANG_HLSL);
     int generatedTranslationUnitIndex = spAddTranslationUnit(request, SLANG_SOURCE_LANGUAGE_SLANG, "generatedUnit");
     spAddTranslationUnitSourceString(
         request, generatedTranslationUnitIndex, "generatedFile", generatedSource);
+
     int entryPointTranslationUnitIndex = spAddTranslationUnit(request, SLANG_SOURCE_LANGUAGE_SLANG, "userUnit");
     spAddTranslationUnitSourceString(
         request, entryPointTranslationUnitIndex, "userFile", userSource);
@@ -52,8 +64,10 @@ SLANG_UNIT_TEST(translationUnitImport)
     Slang::ComPtr<ISlangBlob> outBlob;
     spGetEntryPointCodeBlob(request, 0, 0, outBlob.writeRef());
     SLANG_CHECK(outBlob && outBlob->getBufferSize() != 0);
-
+    
     spDestroyCompileRequest(request);
     spDestroySession(session);
+
+    File::remove("moduleG.slang");
 }
 


### PR DESCRIPTION
This PR allows the following case to work:
```
GeneratedModule
int f() {}

TestModule.slang
import GeneratedModule
int g() { return f(); }

MainModule.cs.slang
import TestModule;
..
```

Before this change, the transitive import via `TestModule.slang` does not work.