### PR TITLE
Treat warnings as errors in slang-gfx

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -875,6 +875,7 @@ standardProject("slang-rt", "source/slang-rt")
      kind "SharedLib"
      links { "core", "slang" }
      pic "On"
+	 flags { "FatalWarnings" }
  
      defines { "SLANG_GFX_DYNAMIC", "SLANG_GFX_DYNAMIC_EXPORT" }
  

--- a/premake5.lua
+++ b/premake5.lua
@@ -875,7 +875,7 @@ standardProject("slang-rt", "source/slang-rt")
      kind "SharedLib"
      links { "core", "slang" }
      pic "On"
-	 flags { "FatalWarnings" }
+     flags { "FatalWarnings" }
  
      defines { "SLANG_GFX_DYNAMIC", "SLANG_GFX_DYNAMIC_EXPORT" }
  


### PR DESCRIPTION
Changes:
- Added `flags { "FatalWarnings"}` under `tool "gfx"` to `premake5.lua`

@csyonghe 