### PR TITLE
Fixed RayQuery generic flags on GLSL

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -5026,7 +5026,7 @@ __target_intrinsic(hlsl, RayQuery)
 __target_intrinsic(glsl, rayQueryEXT)
 __glsl_extension(GL_EXT_ray_query)
 __glsl_version(460)
-struct RayQuery <let rayFlags : RAY_FLAG = RAY_FLAG_NONE>
+struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
 {
     // Initialize the query object in a "fresh" state.
     //
@@ -5074,7 +5074,7 @@ struct RayQuery <let rayFlags : RAY_FLAG = RAY_FLAG_NONE>
     {
         __rayQueryInitializeEXT(
             accelerationStructure,
-            rayFlags,
+            rayFlags | rayFlagsGeneric,
             instanceInclusionMask,
             ray.Origin,
             ray.TMin,

--- a/tests/pipeline/ray-tracing/trace-ray-inline.slang
+++ b/tests/pipeline/ray-tracing/trace-ray-inline.slang
@@ -104,7 +104,7 @@ void main(uint3 tid : SV_DispatchThreadID)
 {
 	uint index = tid.x;
 
-	RayQuery<RAY_FLAG_NONE> query;
+	RayQuery<RAY_FLAG_SKIP_PROCEDURAL_PRIMITIVES> query;
 	MyProceduralHitAttrs committedProceduralAttrs;
 
 	MyRayPayload payload = { -1 };

--- a/tests/pipeline/ray-tracing/trace-ray-inline.slang.glsl
+++ b/tests/pipeline/ray-tracing/trace-ray-inline.slang.glsl
@@ -93,7 +93,7 @@ void main()
     payload_5 = _S2;
 
     RayDesc_0 ray_0 = { C_0._data.origin_0, C_0._data.tMin_0, C_0._data.direction_0, C_0._data.tMax_0 };
-    rayQueryInitializeEXT((query_0), (myAccelerationStructure_0), (C_0._data.rayFlags_0), (C_0._data.instanceMask_0), (ray_0.Origin_0), (ray_0.TMin_0), (ray_0.Direction_0), (ray_0.TMax_0));
+    rayQueryInitializeEXT((query_0), (myAccelerationStructure_0), (C_0._data.rayFlags_0 | 512), (C_0._data.instanceMask_0), (ray_0.Origin_0), (ray_0.TMin_0), (ray_0.Direction_0), (ray_0.TMax_0));
 
     MyProceduralHitAttrs_0 _S3;
     committedProceduralAttrs_0 = _S3;

--- a/tests/pipeline/ray-tracing/trace-ray-inline.slang.hlsl
+++ b/tests/pipeline/ray-tracing/trace-ray-inline.slang.hlsl
@@ -75,7 +75,7 @@ void main(vector<uint,3> tid_0 : SV_DISPATCHTHREADID)
     MyRayPayload_0 payload_7;
     MyProceduralHitAttrs_0 committedProceduralAttrs_3;
 
-    RayQuery<int(0) > query_0;
+    RayQuery<int(512) > query_0;
 
     MyRayPayload_0 _S1 = { int(-1) };
     RayDesc ray_0 = { C_0.origin_0, C_0.tMin_0, C_0.direction_0, C_0.tMax_0 };


### PR DESCRIPTION
The flags passed as `RayQuery<flags>` were ignored when generating GLSL code.
This change adds the necessary OR operation and improves the test to pass nonzero generic flags.

Relevant spec bit:
https://github.com/microsoft/DirectX-Specs/blob/master/d3d/Raytracing.md#rayquery 
> [RayQuery::TraceRayInline()](https://github.com/microsoft/DirectX-Specs/blob/master/d3d/Raytracing.md#rayquery-tracerayinline) also has a [RAY_FLAGS](https://github.com/microsoft/DirectX-Specs/blob/master/d3d/Raytracing.md#ray-flags) field which allows dynamic ray flags configuration - the template flags are OR'd with the dynamic flags during a raytrace.