### PR TITLE
Consolidate naming for render/depth stencil targets/attachments

### DIFF
--- a/examples/example-base/example-base.cpp
+++ b/examples/example-base/example-base.cpp
@@ -58,8 +58,8 @@ Slang::Result WindowedAppBase::initializeBase(
     gfx::WindowHandle windowHandle = gWindow->getNativeHandle().convert<gfx::WindowHandle>();
     gSwapchain = gDevice->createSwapchain(swapchainDesc, windowHandle);
 
-    IFramebufferLayout::AttachmentLayout renderTargetLayout = {gSwapchain->getDesc().format, 1};
-    IFramebufferLayout::AttachmentLayout depthLayout = {gfx::Format::D32_FLOAT, 1};
+    IFramebufferLayout::TargetLayout renderTargetLayout = {gSwapchain->getDesc().format, 1};
+    IFramebufferLayout::TargetLayout depthLayout = {gfx::Format::D32_FLOAT, 1};
     IFramebufferLayout::Desc framebufferLayoutDesc;
     framebufferLayoutDesc.renderTargetCount = 1;
     framebufferLayoutDesc.renderTargets = &renderTargetLayout;
@@ -80,14 +80,14 @@ Slang::Result WindowedAppBase::initializeBase(
     gfx::IRenderPassLayout::Desc renderPassDesc = {};
     renderPassDesc.framebufferLayout = gFramebufferLayout;
     renderPassDesc.renderTargetCount = 1;
-    IRenderPassLayout::AttachmentAccessDesc renderTargetAccess = {};
-    IRenderPassLayout::AttachmentAccessDesc depthStencilAccess = {};
-    renderTargetAccess.loadOp = IRenderPassLayout::AttachmentLoadOp::Clear;
-    renderTargetAccess.storeOp = IRenderPassLayout::AttachmentStoreOp::Store;
+    IRenderPassLayout::TargetAccessDesc renderTargetAccess = {};
+    IRenderPassLayout::TargetAccessDesc depthStencilAccess = {};
+    renderTargetAccess.loadOp = IRenderPassLayout::TargetLoadOp::Clear;
+    renderTargetAccess.storeOp = IRenderPassLayout::TargetStoreOp::Store;
     renderTargetAccess.initialState = ResourceState::Undefined;
     renderTargetAccess.finalState = ResourceState::Present;
-    depthStencilAccess.loadOp = IRenderPassLayout::AttachmentLoadOp::Clear;
-    depthStencilAccess.storeOp = IRenderPassLayout::AttachmentStoreOp::Store;
+    depthStencilAccess.loadOp = IRenderPassLayout::TargetLoadOp::Clear;
+    depthStencilAccess.storeOp = IRenderPassLayout::TargetStoreOp::Store;
     depthStencilAccess.initialState = ResourceState::Undefined;
     depthStencilAccess.finalState = ResourceState::DepthWrite;
     renderPassDesc.renderTargetAccess = &renderTargetAccess;

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1282,7 +1282,7 @@ struct BlendDesc
 class IFramebufferLayout : public ISlangUnknown
 {
 public:
-    struct AttachmentLayout
+    struct TargetLayout
     {
         Format format;
         GfxCount sampleCount;
@@ -1290,8 +1290,8 @@ public:
     struct Desc
     {
         GfxCount renderTargetCount;
-        AttachmentLayout* renderTargets = nullptr;
-        AttachmentLayout* depthStencil = nullptr;
+        TargetLayout* renderTargets = nullptr;
+        TargetLayout* depthStencil = nullptr;
     };
 };
 #define SLANG_UUID_IFramebufferLayout                                                \
@@ -1462,20 +1462,20 @@ struct FaceMask
 class IRenderPassLayout : public ISlangUnknown
 {
 public:
-    enum class AttachmentLoadOp
+    enum class TargetLoadOp
     {
         Load, Clear, DontCare
     };
-    enum class AttachmentStoreOp
+    enum class TargetStoreOp
     {
         Store, DontCare
     };
-    struct AttachmentAccessDesc
+    struct TargetAccessDesc
     {
-        AttachmentLoadOp loadOp;
-        AttachmentLoadOp stencilLoadOp;
-        AttachmentStoreOp storeOp;
-        AttachmentStoreOp stencilStoreOp;
+        TargetLoadOp loadOp;
+        TargetLoadOp stencilLoadOp;
+        TargetStoreOp storeOp;
+        TargetStoreOp stencilStoreOp;
         ResourceState initialState;
         ResourceState finalState;
     };
@@ -1483,8 +1483,8 @@ public:
     {
         IFramebufferLayout* framebufferLayout = nullptr;
         GfxCount renderTargetCount;
-        AttachmentAccessDesc* renderTargetAccess = nullptr;
-        AttachmentAccessDesc* depthStencilAccess = nullptr;
+        TargetAccessDesc* renderTargetAccess = nullptr;
+        TargetAccessDesc* depthStencilAccess = nullptr;
     };
 };
 #define SLANG_UUID_IRenderPassLayout                                                   \

--- a/tools/gfx-unit-test/instanced-draw-tests.cpp
+++ b/tools/gfx-unit-test/instanced-draw-tests.cpp
@@ -161,13 +161,13 @@ namespace gfx_test
             slang::ProgramLayout* slangReflection;
             GFX_CHECK_CALL_ABORT(loadGraphicsProgram(device, shaderProgram, "graphics-smoke", "vertexMain", "fragmentMain", slangReflection));
 
-            IFramebufferLayout::AttachmentLayout attachmentLayout;
-            attachmentLayout.format = format;
-            attachmentLayout.sampleCount = 1;
+            IFramebufferLayout::TargetLayout targetLayout;
+            targetLayout.format = format;
+            targetLayout.sampleCount = 1;
 
             IFramebufferLayout::Desc framebufferLayoutDesc;
             framebufferLayoutDesc.renderTargetCount = 1;
-            framebufferLayoutDesc.renderTargets = &attachmentLayout;
+            framebufferLayoutDesc.renderTargets = &targetLayout;
             ComPtr<gfx::IFramebufferLayout> framebufferLayout = device->createFramebufferLayout(framebufferLayoutDesc);
             SLANG_CHECK_ABORT(framebufferLayout != nullptr);
 
@@ -183,9 +183,9 @@ namespace gfx_test
             IRenderPassLayout::Desc renderPassDesc = {};
             renderPassDesc.framebufferLayout = framebufferLayout;
             renderPassDesc.renderTargetCount = 1;
-            IRenderPassLayout::AttachmentAccessDesc renderTargetAccess = {};
-            renderTargetAccess.loadOp = IRenderPassLayout::AttachmentLoadOp::Clear;
-            renderTargetAccess.storeOp = IRenderPassLayout::AttachmentStoreOp::Store;
+            IRenderPassLayout::TargetAccessDesc renderTargetAccess = {};
+            renderTargetAccess.loadOp = IRenderPassLayout::TargetLoadOp::Clear;
+            renderTargetAccess.storeOp = IRenderPassLayout::TargetStoreOp::Store;
             renderTargetAccess.initialState = ResourceState::RenderTarget;
             renderTargetAccess.finalState = ResourceState::CopySource;
             renderPassDesc.renderTargetAccess = &renderTargetAccess;

--- a/tools/gfx-unit-test/resolve-resource-tests.cpp
+++ b/tools/gfx-unit-test/resolve-resource-tests.cpp
@@ -177,13 +177,13 @@ namespace
             slang::ProgramLayout* slangReflection;
             GFX_CHECK_CALL_ABORT(loadGraphicsProgram(device, shaderProgram, "resolve-resource-shader", "vertexMain", "fragmentMain", slangReflection));
 
-            IFramebufferLayout::AttachmentLayout attachmentLayout;
-            attachmentLayout.format = format;
-            attachmentLayout.sampleCount = 4;
+            IFramebufferLayout::TargetLayout targetLayout;
+            targetLayout.format = format;
+            targetLayout.sampleCount = 4;
 
             IFramebufferLayout::Desc framebufferLayoutDesc;
             framebufferLayoutDesc.renderTargetCount = 1;
-            framebufferLayoutDesc.renderTargets = &attachmentLayout;
+            framebufferLayoutDesc.renderTargets = &targetLayout;
             ComPtr<gfx::IFramebufferLayout> framebufferLayout = device->createFramebufferLayout(framebufferLayoutDesc);
             SLANG_CHECK_ABORT(framebufferLayout != nullptr);
 
@@ -199,9 +199,9 @@ namespace
             IRenderPassLayout::Desc renderPassDesc = {};
             renderPassDesc.framebufferLayout = framebufferLayout;
             renderPassDesc.renderTargetCount = 1;
-            IRenderPassLayout::AttachmentAccessDesc renderTargetAccess = {};
-            renderTargetAccess.loadOp = IRenderPassLayout::AttachmentLoadOp::Clear;
-            renderTargetAccess.storeOp = IRenderPassLayout::AttachmentStoreOp::Store;
+            IRenderPassLayout::TargetAccessDesc renderTargetAccess = {};
+            renderTargetAccess.loadOp = IRenderPassLayout::TargetLoadOp::Clear;
+            renderTargetAccess.storeOp = IRenderPassLayout::TargetStoreOp::Store;
             renderTargetAccess.initialState = ResourceState::RenderTarget;
             renderTargetAccess.finalState = ResourceState::ResolveSource;
             renderPassDesc.renderTargetAccess = &renderTargetAccess;

--- a/tools/gfx-unit-test/texture-types-tests.cpp
+++ b/tools/gfx-unit-test/texture-types-tests.cpp
@@ -431,13 +431,13 @@ namespace gfx_test
             slang::ProgramLayout* slangReflection;
             GFX_CHECK_CALL_ABORT(loadGraphicsProgram(device, shaderProgram, "trivial-copy-textures", "vertexMain", "fragmentMain", slangReflection));
 
-            IFramebufferLayout::AttachmentLayout attachmentLayout;
-            attachmentLayout.format = textureInfo->format;
-            attachmentLayout.sampleCount = sampleCount;
+            IFramebufferLayout::TargetLayout targetLayout;
+            targetLayout.format = textureInfo->format;
+            targetLayout.sampleCount = sampleCount;
 
             IFramebufferLayout::Desc framebufferLayoutDesc;
             framebufferLayoutDesc.renderTargetCount = 1;
-            framebufferLayoutDesc.renderTargets = &attachmentLayout;
+            framebufferLayoutDesc.renderTargets = &targetLayout;
             ComPtr<gfx::IFramebufferLayout> framebufferLayout = device->createFramebufferLayout(framebufferLayoutDesc);
             SLANG_CHECK_ABORT(framebufferLayout != nullptr);
 
@@ -453,9 +453,9 @@ namespace gfx_test
             IRenderPassLayout::Desc renderPassDesc = {};
             renderPassDesc.framebufferLayout = framebufferLayout;
             renderPassDesc.renderTargetCount = 1;
-            IRenderPassLayout::AttachmentAccessDesc renderTargetAccess = {};
-            renderTargetAccess.loadOp = IRenderPassLayout::AttachmentLoadOp::Clear;
-            renderTargetAccess.storeOp = IRenderPassLayout::AttachmentStoreOp::Store;
+            IRenderPassLayout::TargetAccessDesc renderTargetAccess = {};
+            renderTargetAccess.loadOp = IRenderPassLayout::TargetLoadOp::Clear;
+            renderTargetAccess.storeOp = IRenderPassLayout::TargetStoreOp::Store;
             renderTargetAccess.initialState = getDefaultResourceStateForViewType(viewType);
             renderTargetAccess.finalState = ResourceState::ResolveSource;
             renderPassDesc.renderTargetAccess = &renderTargetAccess;

--- a/tools/gfx/d3d11/render-d3d11.cpp
+++ b/tools/gfx/d3d11/render-d3d11.cpp
@@ -308,9 +308,9 @@ protected:
     class FramebufferLayoutImpl : public FramebufferLayoutBase
     {
     public:
-        ShortList<IFramebufferLayout::AttachmentLayout> m_renderTargets;
+        ShortList<IFramebufferLayout::TargetLayout> m_renderTargets;
         bool m_hasDepthStencil = false;
-        IFramebufferLayout::AttachmentLayout m_depthStencil;
+        IFramebufferLayout::TargetLayout m_depthStencil;
     };
 
     class FramebufferImpl : public FramebufferBase

--- a/tools/gfx/d3d12/render-d3d12.cpp
+++ b/tools/gfx/d3d12/render-d3d12.cpp
@@ -7193,7 +7193,7 @@ void RenderCommandEncoderImpl::init(
             }
         }
         // Clear.
-        if (access.loadOp == IRenderPassLayout::AttachmentLoadOp::Clear)
+        if (access.loadOp == IRenderPassLayout::TargetLoadOp::Clear)
         {
             m_d3dCmdList->ClearRenderTargetView(
                 framebuffer->renderTargetDescriptors[i],
@@ -7226,12 +7226,12 @@ void RenderCommandEncoderImpl::init(
         }
         // Clear.
         uint32_t clearFlags = 0;
-        if (renderPass->m_depthStencilAccess.loadOp == IRenderPassLayout::AttachmentLoadOp::Clear)
+        if (renderPass->m_depthStencilAccess.loadOp == IRenderPassLayout::TargetLoadOp::Clear)
         {
             clearFlags |= D3D12_CLEAR_FLAG_DEPTH;
         }
         if (renderPass->m_depthStencilAccess.stencilLoadOp ==
-            IRenderPassLayout::AttachmentLoadOp::Clear)
+            IRenderPassLayout::TargetLoadOp::Clear)
         {
             clearFlags |= D3D12_CLEAR_FLAG_STENCIL;
         }

--- a/tools/gfx/d3d12/render-d3d12.h
+++ b/tools/gfx/d3d12/render-d3d12.h
@@ -357,9 +357,9 @@ public:
 class FramebufferLayoutImpl : public FramebufferLayoutBase
 {
 public:
-    ShortList<IFramebufferLayout::AttachmentLayout> m_renderTargets;
+    ShortList<IFramebufferLayout::TargetLayout> m_renderTargets;
     bool m_hasDepthStencil = false;
-    IFramebufferLayout::AttachmentLayout m_depthStencil;
+    IFramebufferLayout::TargetLayout m_depthStencil;
 };
 
 class FramebufferImpl : public FramebufferBase

--- a/tools/gfx/immediate-renderer-base.cpp
+++ b/tools/gfx/immediate-renderer-base.cpp
@@ -256,7 +256,7 @@ public:
             {
                 auto& access = renderPass->m_renderTargetAccesses[i];
                 // Clear.
-                if (access.loadOp == IRenderPassLayout::AttachmentLoadOp::Clear)
+                if (access.loadOp == IRenderPassLayout::TargetLoadOp::Clear)
                 {
                     clearMask |= (1 << (uint32_t)i);
                 }
@@ -267,12 +267,12 @@ public:
             {
                 // Clear.
                 if (renderPass->m_depthStencilAccess.loadOp ==
-                    IRenderPassLayout::AttachmentLoadOp::Clear)
+                    IRenderPassLayout::TargetLoadOp::Clear)
                 {
                     clearDepth = true;
                 }
                 if (renderPass->m_depthStencilAccess.stencilLoadOp ==
-                    IRenderPassLayout::AttachmentLoadOp::Clear)
+                    IRenderPassLayout::TargetLoadOp::Clear)
                 {
                     clearStencil = true;
                 }

--- a/tools/gfx/open-gl/render-gl.cpp
+++ b/tools/gfx/open-gl/render-gl.cpp
@@ -362,9 +362,9 @@ public:
     class FramebufferLayoutImpl : public FramebufferLayoutBase
     {
     public:
-        ShortList<IFramebufferLayout::AttachmentLayout> m_renderTargets;
+        ShortList<IFramebufferLayout::TargetLayout> m_renderTargets;
         bool m_hasDepthStencil = false;
-        IFramebufferLayout::AttachmentLayout m_depthStencil;
+        IFramebufferLayout::TargetLayout m_depthStencil;
     };
 
     class FramebufferImpl : public FramebufferBase

--- a/tools/gfx/simple-render-pass-layout.h
+++ b/tools/gfx/simple-render-pass-layout.h
@@ -21,8 +21,8 @@ public:
     IRenderPassLayout* getInterface(const Slang::Guid& guid);
 
 public:
-    Slang::ShortList<AttachmentAccessDesc> m_renderTargetAccesses;
-    AttachmentAccessDesc m_depthStencilAccess;
+    Slang::ShortList<TargetAccessDesc> m_renderTargetAccesses;
+    TargetAccessDesc m_depthStencilAccess;
     bool m_hasDepthStencil;
     void init(const IRenderPassLayout::Desc& desc);
 };

--- a/tools/gfx/vulkan/render-vk.h
+++ b/tools/gfx/vulkan/render-vk.h
@@ -19,7 +19,7 @@ using namespace Slang;
 enum
 {
     kMaxRenderTargets = 8,
-    kMaxAttachments = kMaxRenderTargets + 1,
+    kMaxTargets = kMaxRenderTargets + 1,
     kMaxPushConstantSize = 256,
     kMaxDescriptorSets = 8,
 };
@@ -411,10 +411,10 @@ class FramebufferLayoutImpl : public FramebufferLayoutBase
 public:
     VkRenderPass m_renderPass;
     DeviceImpl* m_renderer;
-    Array<VkAttachmentDescription, kMaxAttachments> m_attachmentDescs;
+    Array<VkAttachmentDescription, kMaxTargets> m_targetDescs;
     Array<VkAttachmentReference, kMaxRenderTargets> m_colorReferences;
     VkAttachmentReference m_depthReference;
-    bool m_hasDepthStencilAttachment;
+    bool m_hasDepthStencilTarget;
     uint32_t m_renderTargetCount;
     VkSampleCountFlagBits m_sampleCount = VK_SAMPLE_COUNT_1_BIT;
 
@@ -448,7 +448,7 @@ public:
     uint32_t m_width;
     uint32_t m_height;
     BreakableReference<DeviceImpl> m_renderer;
-    VkClearValue m_clearValues[kMaxAttachments];
+    VkClearValue m_clearValues[kMaxTargets];
     RefPtr<FramebufferLayoutImpl> m_layout;
 
 public:

--- a/tools/platform/gui.cpp
+++ b/tools/platform/gui.cpp
@@ -174,12 +174,12 @@ GUI::GUI(
     {
         IRenderPassLayout::Desc desc;
         desc.framebufferLayout = framebufferLayout;
-        IRenderPassLayout::AttachmentAccessDesc colorAccess;
+        IRenderPassLayout::TargetAccessDesc colorAccess;
         desc.depthStencilAccess = nullptr;
         colorAccess.initialState = ResourceState::Present;
         colorAccess.finalState = ResourceState::Present;
-        colorAccess.loadOp = IRenderPassLayout::AttachmentLoadOp::Load;
-        colorAccess.storeOp = IRenderPassLayout::AttachmentStoreOp::Store;
+        colorAccess.loadOp = IRenderPassLayout::TargetLoadOp::Load;
+        colorAccess.storeOp = IRenderPassLayout::TargetStoreOp::Store;
         desc.renderTargetAccess = &colorAccess;
         desc.renderTargetCount = 1;
         renderPass = device->createRenderPassLayout(desc);

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -640,12 +640,12 @@ void RenderTestApp::_initializeRenderPass()
     ComPtr<gfx::IResourceView> dsv =
         m_device->createTextureView(depthBufferResource.get(), depthBufferViewDesc);
 
-    IFramebufferLayout::AttachmentLayout colorAttachment = {gfx::Format::R8G8B8A8_UNORM, 1};
-    IFramebufferLayout::AttachmentLayout depthAttachment = {gfx::Format::D32_FLOAT, 1};
+    IFramebufferLayout::TargetLayout colorTarget = {gfx::Format::R8G8B8A8_UNORM, 1};
+    IFramebufferLayout::TargetLayout depthTarget = {gfx::Format::D32_FLOAT, 1};
     gfx::IFramebufferLayout::Desc framebufferLayoutDesc;
     framebufferLayoutDesc.renderTargetCount = 1;
-    framebufferLayoutDesc.renderTargets = &colorAttachment;
-    framebufferLayoutDesc.depthStencil = &depthAttachment;
+    framebufferLayoutDesc.renderTargets = &colorTarget;
+    framebufferLayoutDesc.depthStencil = &depthTarget;
     m_device->createFramebufferLayout(framebufferLayoutDesc, m_framebufferLayout.writeRef());
 
     gfx::IFramebuffer::Desc framebufferDesc;
@@ -658,14 +658,14 @@ void RenderTestApp::_initializeRenderPass()
     IRenderPassLayout::Desc renderPassDesc = {};
     renderPassDesc.framebufferLayout = m_framebufferLayout;
     renderPassDesc.renderTargetCount = 1;
-    IRenderPassLayout::AttachmentAccessDesc renderTargetAccess = {};
-    IRenderPassLayout::AttachmentAccessDesc depthStencilAccess = {};
-    renderTargetAccess.loadOp = IRenderPassLayout::AttachmentLoadOp::Clear;
-    renderTargetAccess.storeOp = IRenderPassLayout::AttachmentStoreOp::Store;
+    IRenderPassLayout::TargetAccessDesc renderTargetAccess = {};
+    IRenderPassLayout::TargetAccessDesc depthStencilAccess = {};
+    renderTargetAccess.loadOp = IRenderPassLayout::TargetLoadOp::Clear;
+    renderTargetAccess.storeOp = IRenderPassLayout::TargetStoreOp::Store;
     renderTargetAccess.initialState = ResourceState::Undefined;
     renderTargetAccess.finalState = ResourceState::RenderTarget;
-    depthStencilAccess.loadOp = IRenderPassLayout::AttachmentLoadOp::Clear;
-    depthStencilAccess.storeOp = IRenderPassLayout::AttachmentStoreOp::Store;
+    depthStencilAccess.loadOp = IRenderPassLayout::TargetLoadOp::Clear;
+    depthStencilAccess.storeOp = IRenderPassLayout::TargetStoreOp::Store;
     depthStencilAccess.initialState = ResourceState::Undefined;
     depthStencilAccess.finalState = ResourceState::DepthWrite;
     renderPassDesc.renderTargetAccess = &renderTargetAccess;


### PR DESCRIPTION
Changes:
- Changed all uses of "attachment" in the context of render and depth stencil targets/attachments to "target"

Render/depth-stencil target and color/depth-stencil attachment are used interchangeably throughout the gfx header and implementation, so this PR changes all such instances to follow D3D12 naming convention.

@csyonghe 