### PR TITLE
Fix errors when building with the latest Xcode

### DIFF
--- a/source/compiler-core/slang-include-system.h
+++ b/source/compiler-core/slang-include-system.h
@@ -15,6 +15,7 @@ struct SearchDirectory
     SearchDirectory(String const& path)
         : path(path)
     {}
+    SearchDirectory& operator=(SearchDirectory const& other) = default;
 
     String path;
 };

--- a/source/core/slang-smart-pointer.h
+++ b/source/core/slang-smart-pointer.h
@@ -285,6 +285,7 @@ namespace Slang
         TransformablePtr(T* ptr) { *this = ptr; }
         TransformablePtr(RefPtr<T> ptr) { *this = ptr; }
         TransformablePtr(const TransformablePtr<T>& ptr) = default;
+        TransformablePtr<T>& operator=(const TransformablePtr<T>& ptr) = default;
 
         void promoteToStrongReference() { m_strongPtr = m_weakPtr; }
         void demoteToWeakReference() { m_strongPtr = nullptr; }

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -1180,8 +1180,6 @@ namespace Slang
         auto genericSpecializationParamCount = getGenericSpecializationParamCount();
         SLANG_ASSERT(argCount >= genericSpecializationParamCount);
 
-        Result result = SLANG_OK;
-
         RefPtr<EntryPointSpecializationInfo> info = new EntryPointSpecializationInfo();
 
         DeclRef<FuncDecl> specializedFuncDeclRef = m_funcDeclRef;
@@ -1226,7 +1224,6 @@ namespace Slang
                 {
                     // TODO: diagnose a problem here
                     sink->diagnose(constraintDecl, Diagnostics::typeArgumentDoesNotConformToInterface, sub, sup);
-                    result = SLANG_FAIL;
                     continue;
                 }
             }
@@ -1263,7 +1260,6 @@ namespace Slang
                 // If no witness was found, then we will be unable to satisfy
                 // the conformances required.
                 sink->diagnose(SourceLoc(), Diagnostics::typeArgumentDoesNotConformToInterface, argType, paramType);
-                result = SLANG_FAIL;
                 continue;
             }
 

--- a/source/slang/slang-ir-deduplicate.cpp
+++ b/source/slang/slang-ir-deduplicate.cpp
@@ -51,7 +51,6 @@ namespace Slang
     {
         DeduplicateContext context;
         context.builder = this;
-        bool changed = true;
         m_constantMap.Clear();
         m_globalValueNumberingMap.Clear();
         for (auto inst : m_module->getGlobalInsts())
@@ -69,7 +68,6 @@ namespace Slang
                 auto newInst = context.addTypeValue(inst);
                 if (newInst != inst)
                 {
-                    changed = true;
                     inst->replaceUsesWith(newInst);
                     instToRemove.add(inst);
                 }

--- a/source/slang/slang-ir-lower-generic-call.cpp
+++ b/source/slang/slang-ir-lower-generic-call.cpp
@@ -36,17 +36,13 @@ namespace Slang
             IRType* paramValType = paramType;
             IRType* argValType = arg->getDataType();
             IRInst* argVal = arg;
-            bool isParamPointer = false;
             if (auto ptrType = as<IRPtrTypeBase>(paramType))
             {
-                isParamPointer = true;
                 paramValType = ptrType->getValueType();
             }
-            bool isArgPointer = false;
             auto argType = arg->getDataType();
             if (auto argPtrType = as<IRPtrTypeBase>(argType))
             {
-                isArgPointer = true;
                 argValType = argPtrType->getValueType();
                 argVal = builder->emitLoad(arg);
             }

--- a/source/slang/slang-ir-witness-table-wrapper.cpp
+++ b/source/slang/slang-ir-witness-table-wrapper.cpp
@@ -42,17 +42,13 @@ namespace Slang
             IRType* paramValType = paramType;
             IRType* argValType = arg->getDataType();
             IRInst* argVal = arg;
-            bool isParamPointer = false;
             if (auto ptrType = as<IRPtrTypeBase>(paramType))
             {
-                isParamPointer = true;
                 paramValType = ptrType->getValueType();
             }
-            bool isArgPointer = false;
             auto argType = arg->getDataType();
             if (auto argPtrType = as<IRPtrTypeBase>(argType))
             {
-                isArgPointer = true;
                 argValType = argPtrType->getValueType();
                 argVal = builder->emitLoad(arg);
             }

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -4165,7 +4165,7 @@ namespace Slang
             // isn't a keyword should we fall back to the approach
             // here.
             //
-            Expr* type = ParseType();
+            ParseType();
 
             // We don't actually care about the type, though, so
             // don't retain it
@@ -4178,7 +4178,6 @@ namespace Slang
             // then we can use `A.b` as the left-hand-side expression
             // when starting to parse an infix expression.
             //
-            type = nullptr;
 
             // TODO: If we decide to intermix parsing of statement bodies
             // with semantic checking (by delaying the parsing of bodies

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -4165,7 +4165,7 @@ namespace Slang
             // isn't a keyword should we fall back to the approach
             // here.
             //
-            ParseType();
+            Expr* type = ParseType();
 
             // We don't actually care about the type, though, so
             // don't retain it
@@ -4178,6 +4178,8 @@ namespace Slang
             // then we can use `A.b` as the left-hand-side expression
             // when starting to parse an infix expression.
             //
+            type = nullptr;
+            SLANG_UNUSED(type);
 
             // TODO: If we decide to intermix parsing of statement bodies
             // with semantic checking (by delaying the parsing of bodies


### PR DESCRIPTION
Hello,
As I tried to build this project with the default settings on my Mac with the latest version of Xcode (13.3.1), I got errors about unused variables and copy assignment operator needing to be explicit. Here are a excerpt:
```
../../../source/slang/slang-check-shader.cpp:1183:16: error: variable 'result' set but not used [-Werror,-Wunused-but-set-variable]
        Result result = SLANG_OK;
               ^
In file included from ../../../source/slang/slang-compiler.cpp:13:
In file included from ../../../source/slang/slang-compiler.h:11:
../../../source/slang/../compiler-core/slang-include-system.h:14:5: error: definition of implicit copy assignment operator for 'SearchDirectory' is deprecated because it has a user-declared copy constructor [-Werror,-Wdeprecated-copy]
    SearchDirectory(SearchDirectory const& other) = default;
    ^
../../../source/slang/../core/slang-list.h:242:42: note: in implicit copy assignment operator for 'Slang::SearchDirectory' first required here
                            newBuffer[i] = m_buffer[i];
                                         ^
../../../source/slang/../core/slang-list.h:276:46: note: in instantiation of member function 'Slang::List<Slang::SearchDirectory>::insertRange' requested here
        void addRange(const List<T>& list) { insertRange(m_count, list.m_buffer, list.m_count); }
                                             ^
../../../source/slang/../core/slang-list.h:70:13: note: in instantiation of member function 'Slang::List<Slang::SearchDirectory>::addRange' requested here
            addRange(list);
            ^
../../../source/slang/../core/slang-list.h:48:19: note: in instantiation of member function 'Slang::List<Slang::SearchDirectory>::operator=' requested here
            this->operator=(list);
                  ^
../../../source/slang/../compiler-core/slang-include-system.h:23:8: note: in instantiation of member function 'Slang::List<Slang::SearchDirectory>::List' requested here
struct SearchDirectoryList
       ^
```

This PR fixes all those errors, though I am not sure about what to do about unused variables. I just went the simplest route, and removed them, but they were probably left for a reason (especially the `slang-parser.cpp` one).
Another solution would be to use `[[maybe_unused]]`. It's C++17 but in theory old older compilers that should be simply ignored. Though with your high level of warnings and warnings treated as errors it might cause an error, so a conditional `#define` might be needed.