### PR TITLE
Enable aarch64 build on MacOS

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -277,10 +277,10 @@ newoption {
          -- Makes all symbols hidden by default unless explicitly 'exported'
          buildoptions { "-fvisibility=hidden" } 
          -- Warnings
-         buildoptions { "-Wno-unused-parameter", "-Wno-type-limits", "-Wno-sign-compare", "-Wno-unused-variable", "-Wno-reorder", "-Wno-switch", "-Wno-return-type", "-Wno-unused-local-typedefs", "-Wno-parentheses",   "-Wno-ignored-optimization-argument", "-Wno-unknown-warning-option", "-Wno-class-memaccess"}
+         buildoptions { "-Wno-unused-but-set-variable", "-Wno-unused-parameter", "-Wno-type-limits", "-Wno-sign-compare", "-Wno-unused-variable", "-Wno-reorder", "-Wno-switch", "-Wno-return-type", "-Wno-unused-local-typedefs", "-Wno-parentheses",   "-Wno-ignored-optimization-argument", "-Wno-unknown-warning-option", "-Wno-class-memaccess"}
  
      filter { "toolset:gcc*"}
-         buildoptions { "-Wno-unused-but-set-variable", "-Wno-implicit-fallthrough"  }
+         buildoptions { "-Wno-implicit-fallthrough"  }
  
      filter { "toolset:clang" }
           buildoptions { "-Wno-deprecated-register", "-Wno-tautological-compare", "-Wno-missing-braces", "-Wno-undefined-var-template", "-Wno-unused-function", "-Wno-return-std-move"}
@@ -1542,4 +1542,4 @@ standardProject("slang-rt", "source/slang-rt")
  --
  
  end
- 
+

--- a/slang.h
+++ b/slang.h
@@ -96,10 +96,13 @@ Operating system defines, see http://sourceforge.net/p/predef/wiki/OperatingSyst
 #        define SLANG_ANDROID 1
 #    elif defined(__linux__) || defined(__CYGWIN__) /* note: __ANDROID__ implies __linux__ */
 #        define SLANG_LINUX 1
-#    elif defined(__APPLE__) && (defined(__arm__) || defined(__arm64__))
-#        define SLANG_IOS 1
 #    elif defined(__APPLE__)
-#        define SLANG_OSX 1
+#        include "TargetConditionals.h"
+#        if TARGET_OS_MAC
+#            define SLANG_OSX 1
+#        else
+#            define SLANG_IOS 1
+#        endif
 #    elif defined(__CELLOS_LV2__)
 #        define SLANG_PS3 1
 #    elif defined(__ORBIS__)


### PR DESCRIPTION
Minor changes to allow compiling for aarch64 on MacOS (i.e., _Apple silicon_) using clang

- Modify the Apple OS detection logic to allow differentiating between IOS and MacOS when targeting arm.
- Specify `-Wno-unused-but-set-variable` for clang as well as gcc