### PR TITLE
Fixed FXC diagnostics

### DIFF
--- a/source/compiler-core/slang-fxc-compiler.cpp
+++ b/source/compiler-core/slang-fxc-compiler.cpp
@@ -299,6 +299,12 @@ SlangResult FXCDownstreamCompiler::compile(const CompileOptions& options, RefPtr
         SLANG_ASSERT(SLANG_SUCCEEDED(diagnosticParseRes));
     }
 
+    // If FXC failed, make sure we have an error in the diagnostics
+    if (FAILED(hr))
+    {
+        diagnostics.requireErrorDiagnostic();
+    }
+
     // ID3DBlob is compatible with ISlangBlob, so just cast away...
     ISlangBlob* slangCodeBlob = (ISlangBlob*)codeBlob.get();
 


### PR DESCRIPTION
When the FXC downstream compiler is used with invalid arguments, such as unsupported profile, Slang would silently ignore that error and report a successful compilation. The code blob would be empty, which is confusing.