### PR TITLE
Work around MacOS compilation issue with embed stlib

### DIFF
--- a/github_macos_build.sh
+++ b/github_macos_build.sh
@@ -8,12 +8,7 @@ git describe --tags | sed -e "s/\(.*\)/\#define SLANG_TAG_VERSION \"\1\"/" > sla
 cat slang-tag-version.h 
 
 # Create the makefile
-#
-# NOTE! For now we disable stdlib embedding, because on OSX it produces an error when generating
-# thinking it's creating a lib, but has no source
-#
-# --enable-embed-stdlib=true
-./premake5 gmake --cc=${CC}  --enable-xlib=false --arch=${ARCH} --deps=true --no-progress=true 
+./premake5 gmake --cc=${CC} --enable-xlib=false --enable-embed-stdlib=true --arch=${ARCH} --deps=true --no-progress=true
 
 # Build the configuration
 make config=${CONFIGURATION}_x64 -j`sysctl -n hw.ncpu`

--- a/premake5.lua
+++ b/premake5.lua
@@ -628,7 +628,7 @@ newoption {
  -- build items needed for other dependencies
  ---
  
- function generatorProject(name, sourcePath)
+ function generatorProject(name, sourcePath, isSharedLib)
      -- We use the `group` command here to specify that the
      -- next project we create shold be placed into a group
      -- named "generator" in a generated IDE solution/workspace.
@@ -642,9 +642,13 @@ newoption {
      -- Set up the project, but do NOT add any source files.
      baseSlangProject(name, sourcePath)
  
-     -- For now we just use static lib to force something
+     -- By default, just use static lib to force something
      -- to build.
-     kind "StaticLib"
+     if isSharedLib then
+         kind "SharedLib"
+     else
+        kind "StaticLib"
+    end
  end
  
  --
@@ -1222,7 +1226,7 @@ standardProject("slang-rt", "source/slang-rt")
  end
  
  if enableEmbedStdLib then
-     generatorProject("embed-stdlib-generator", nil)
+     generatorProject("embed-stdlib-generator", nil, true)
  
          -- We include these, even though they are not really part of the dummy
          -- build, so that the filters below can pick up the appropriate locations.

--- a/source/core/slang-shared-library.cpp
+++ b/source/core/slang-shared-library.cpp
@@ -8,7 +8,7 @@
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(SLANG_OSX)
 #include <dlfcn.h>
 #endif
 #include <sys/stat.h>
@@ -125,7 +125,7 @@ String SharedLibraryUtils::getSharedLibraryFileName(void* symbolInLib)
     }
     return String::fromWString(filenameBuffer);
 
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(SLANG_OSX)
     Dl_info dllInfo;
     if (!dladdr(symbolInLib, &dllInfo))
     {


### PR DESCRIPTION
- The embed-stdlib-generator project is created with
  `kind = "StaticLib"` to allow the build to work, even though
  the project doesn't actually create a library.

- Unlike some other platforms, MacOs `ar` emits an error if no
  object files are listed to be added to an archive. This causes
  enable-stdlib-generator to fail on MacOS.

- Changing the project's kind to `"SharedLib"` works around the issue.
  Other values for `kind` do not seem to work around the issue.

- Add an optional flag to `generatorProject` to indicate that
  `kind = "SharedLib"` should be used, rather than `"StaticLib"`

- Add MacOS fix for `SharedLibraryUtils::getSharedLibraryFileName()`.

- Enable embed stdlib in `github_macos_build.sh`