### PR TITLE
Add smoke test for language server.

### DIFF
--- a/build/visual-studio/compiler-core/compiler-core.vcxproj
+++ b/build/visual-studio/compiler-core/compiler-core.vcxproj
@@ -294,6 +294,7 @@
     <ClInclude Include="..\..\..\source\compiler-core\slang-json-rpc-connection.h" />
     <ClInclude Include="..\..\..\source\compiler-core\slang-json-rpc.h" />
     <ClInclude Include="..\..\..\source\compiler-core\slang-json-value.h" />
+    <ClInclude Include="..\..\..\source\compiler-core\slang-language-server-protocol.h" />
     <ClInclude Include="..\..\..\source\compiler-core\slang-lexer-diagnostic-defs.h" />
     <ClInclude Include="..\..\..\source\compiler-core\slang-lexer.h" />
     <ClInclude Include="..\..\..\source\compiler-core\slang-llvm-compiler.h" />
@@ -328,6 +329,7 @@
     <ClCompile Include="..\..\..\source\compiler-core\slang-json-rpc-connection.cpp" />
     <ClCompile Include="..\..\..\source\compiler-core\slang-json-rpc.cpp" />
     <ClCompile Include="..\..\..\source\compiler-core\slang-json-value.cpp" />
+    <ClCompile Include="..\..\..\source\compiler-core\slang-language-server-protocol.cpp" />
     <ClCompile Include="..\..\..\source\compiler-core\slang-lexer.cpp" />
     <ClCompile Include="..\..\..\source\compiler-core\slang-llvm-compiler.cpp" />
     <ClCompile Include="..\..\..\source\compiler-core\slang-name-convention-util.cpp" />

--- a/build/visual-studio/compiler-core/compiler-core.vcxproj.filters
+++ b/build/visual-studio/compiler-core/compiler-core.vcxproj.filters
@@ -69,6 +69,9 @@
     <ClInclude Include="..\..\..\source\compiler-core\slang-json-value.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\compiler-core\slang-language-server-protocol.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\source\compiler-core\slang-lexer-diagnostic-defs.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -165,6 +168,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\compiler-core\slang-json-value.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\source\compiler-core\slang-language-server-protocol.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\compiler-core\slang-lexer.cpp">

--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -408,7 +408,6 @@ IF EXIST ..\..\..\external\slang-binaries\bin\windows-aarch64\slang-glslang.dll\
     <ClInclude Include="..\..\..\source\slang\slang-ir.h" />
     <ClInclude Include="..\..\..\source\slang\slang-language-server-ast-lookup.h" />
     <ClInclude Include="..\..\..\source\slang\slang-language-server-collect-member.h" />
-    <ClInclude Include="..\..\..\source\slang\slang-language-server-protocol.h" />
     <ClInclude Include="..\..\..\source\slang\slang-language-server-semantic-tokens.h" />
     <ClInclude Include="..\..\..\source\slang\slang-language-server.h" />
     <ClInclude Include="..\..\..\source\slang\slang-legalize-types.h" />
@@ -558,7 +557,6 @@ IF EXIST ..\..\..\external\slang-binaries\bin\windows-aarch64\slang-glslang.dll\
     <ClCompile Include="..\..\..\source\slang\slang-ir.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-language-server-ast-lookup.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-language-server-collect-member.cpp" />
-    <ClCompile Include="..\..\..\source\slang\slang-language-server-protocol.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-language-server-semantic-tokens.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-language-server.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-legalize-types.cpp" />

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -321,9 +321,6 @@
     <ClInclude Include="..\..\..\source\slang\slang-language-server-collect-member.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\source\slang\slang-language-server-protocol.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-language-server-semantic-tokens.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -765,9 +762,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-language-server-collect-member.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\source\slang\slang-language-server-protocol.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-language-server-semantic-tokens.cpp">

--- a/source/compiler-core/slang-json-native.cpp
+++ b/source/compiler-core/slang-json-native.cpp
@@ -308,7 +308,7 @@ SlangResult NativeToJSONConverter::_structToJSON(const StructRttiInfo* structRtt
     // Do the super class first
     if (structRttiInfo->m_super)
     {
-        SLANG_RETURN_ON_FAIL(_structToJSON(structRttiInfo, src, outPairs));
+        SLANG_RETURN_ON_FAIL(_structToJSON(structRttiInfo->m_super, src, outPairs));
     }
 
     const Byte* base = (const Byte*)src;

--- a/source/compiler-core/slang-language-server-protocol.cpp
+++ b/source/compiler-core/slang-language-server-protocol.cpp
@@ -15,14 +15,23 @@ static const StructRttiInfo _makeTextDocumentSyncOptionsRtti()
 }
 const StructRttiInfo TextDocumentSyncOptions::g_rttiInfo = _makeTextDocumentSyncOptionsRtti();
 
+static const StructRttiInfo _makeWorkDoneProgressParamsRtti()
+{
+    WorkDoneProgressParams obj;
+    StructRttiBuilder builder(&obj, "LanguageServerProtocol::WorkDoneProgressParams", nullptr);
+    builder.addField("workDoneToken", &obj.workDoneToken, StructRttiInfo::Flag::Optional);
+    builder.ignoreUnknownFields();
+    return builder.make();
+}
+const StructRttiInfo WorkDoneProgressParams::g_rttiInfo = _makeWorkDoneProgressParamsRtti();
+
 static const StructRttiInfo _makeCompletionOptionsRtti()
 {
     CompletionOptions obj;
-    StructRttiBuilder builder(&obj, "LanguageServerProtocol::CompletionOptions", nullptr);
+    StructRttiBuilder builder(&obj, "LanguageServerProtocol::CompletionOptions", &WorkDoneProgressParams::g_rttiInfo);
     builder.addField("triggerCharacters", &obj.triggerCharacters);
     builder.addField("resolveProvider", &obj.resolveProvider);
     builder.addField("allCommitCharacters", &obj.allCommitCharacters);
-    builder.addField("workDoneToken", &obj.workDoneToken);
     builder.ignoreUnknownFields();
     return builder.make();
 }
@@ -314,23 +323,12 @@ static const StructRttiInfo _makeTextDocumentPositionParamsRtti()
 }
 const StructRttiInfo TextDocumentPositionParams::g_rttiInfo = _makeTextDocumentPositionParamsRtti();
 
-static const StructRttiInfo _makeWorkDoneProgressParamsRtti()
-{
-    WorkDoneProgressParams obj;
-    StructRttiBuilder builder(&obj, "LanguageServerProtocol::WorkDoneProgressParams", nullptr);
-    builder.addField("workDoneToken", &obj.workDoneToken, StructRttiInfo::Flag::Optional);
-    builder.ignoreUnknownFields();
-    return builder.make();
-}
-const StructRttiInfo WorkDoneProgressParams::g_rttiInfo = _makeWorkDoneProgressParamsRtti();
-
 static const StructRttiInfo _makeHoverParamsRtti()
 {
     HoverParams obj;
-    StructRttiBuilder builder(&obj, "LanguageServerProtocol::HoverParams", nullptr);
+    StructRttiBuilder builder(&obj, "LanguageServerProtocol::HoverParams", &WorkDoneProgressParams::g_rttiInfo);
     builder.addField("textDocument", &obj.textDocument);
     builder.addField("position", &obj.position);
-    builder.addField("workDoneToken", &obj, StructRttiInfo::Flag::Optional);
     builder.ignoreUnknownFields();
     return builder.make();
 }
@@ -363,10 +361,9 @@ const StructRttiInfo Hover::g_rttiInfo = _makeHoverRtti();
 static const StructRttiInfo _makeDefinitionParamsRtti()
 {
     DefinitionParams obj;
-    StructRttiBuilder builder(&obj, "LanguageServerProtocol::DefinitionParams", nullptr);
+    StructRttiBuilder builder(&obj, "LanguageServerProtocol::DefinitionParams", &WorkDoneProgressParams::g_rttiInfo);
     builder.addField("textDocument", &obj.textDocument);
     builder.addField("position", &obj.position);
-    builder.addField("workDoneToken", &obj, StructRttiInfo::Flag::Optional);
     builder.ignoreUnknownFields();
     return builder.make();
 }
@@ -377,10 +374,9 @@ const UnownedStringSlice DefinitionParams::methodName =
 static const StructRttiInfo _makeCompletionParamsRtti()
 {
     CompletionParams obj;
-    StructRttiBuilder builder(&obj, "LanguageServerProtocol::CompletionParams", nullptr);
+    StructRttiBuilder builder(&obj, "LanguageServerProtocol::CompletionParams", &WorkDoneProgressParams::g_rttiInfo);
     builder.addField("textDocument", &obj.textDocument);
     builder.addField("position", &obj.position);
-    builder.addField("workDoneToken", &obj, StructRttiInfo::Flag::Optional);
     builder.ignoreUnknownFields();
     return builder.make();
 }
@@ -406,9 +402,8 @@ const StructRttiInfo CompletionItem::g_rttiInfo = _makeCompletionItemRtti();
 static const StructRttiInfo _makeSemanticTokensParamsRtti()
 {
     SemanticTokensParams obj;
-    StructRttiBuilder builder(&obj, "LanguageServerProtocol::SemanticTokensParams", nullptr);
+    StructRttiBuilder builder(&obj, "LanguageServerProtocol::SemanticTokensParams", &WorkDoneProgressParams::g_rttiInfo);
     builder.addField("textDocument", &obj.textDocument);
-    builder.addField("workDoneToken", &obj.workDoneToken, StructRttiInfo::Flag::Optional);
     builder.ignoreUnknownFields();
     return builder.make();
 }
@@ -430,10 +425,9 @@ const StructRttiInfo SemanticTokens::g_rttiInfo = _makeSemanticTokensRtti();
 static const StructRttiInfo _makeSignatureHelpParamsRtti()
 {
     SignatureHelpParams obj;
-    StructRttiBuilder builder(&obj, "LanguageServerProtocol::SignatureHelpParams", nullptr);
+    StructRttiBuilder builder(&obj, "LanguageServerProtocol::SignatureHelpParams", &WorkDoneProgressParams::g_rttiInfo);
     builder.addField("textDocument", &obj.textDocument);
     builder.addField("position", &obj.position);
-    builder.addField("workDoneToken", &obj.workDoneToken, StructRttiInfo::Flag::Optional);
     builder.ignoreUnknownFields();
     return builder.make();
 }

--- a/source/compiler-core/slang-language-server-protocol.h
+++ b/source/compiler-core/slang-language-server-protocol.h
@@ -245,13 +245,11 @@ struct InitializeResult
     static const StructRttiInfo g_rttiInfo;
 };
 
-struct ShutdownParams
-{
+struct ShutdownParams {
     static const UnownedStringSlice methodName;
 };
 
-struct ExitParams
-{
+struct ExitParams {
     static const UnownedStringSlice methodName;
 };
 
@@ -377,16 +375,16 @@ struct TextDocumentPositionParams
 };
 
 struct HoverParams
-    : TextDocumentPositionParams
-    , WorkDoneProgressParams
+    : WorkDoneProgressParams
+    ,TextDocumentPositionParams 
 {
     static const StructRttiInfo g_rttiInfo;
     static const UnownedStringSlice methodName;
 };
 
 struct DefinitionParams
-    : TextDocumentPositionParams
-    , WorkDoneProgressParams
+    : WorkDoneProgressParams
+    , TextDocumentPositionParams
 {
     static const StructRttiInfo g_rttiInfo;
     static const UnownedStringSlice methodName;
@@ -424,8 +422,8 @@ struct Hover
 };
 
 struct CompletionParams
-    : TextDocumentPositionParams
-    , WorkDoneProgressParams
+    : WorkDoneProgressParams
+    , TextDocumentPositionParams
 {
     static const StructRttiInfo g_rttiInfo;
     static const UnownedStringSlice methodName;
@@ -532,8 +530,8 @@ struct SemanticTokens
 };
 
 struct SignatureHelpParams
-    : TextDocumentPositionParams
-    , WorkDoneProgressParams
+    : WorkDoneProgressParams
+    , TextDocumentPositionParams
 {
     static const UnownedStringSlice methodName;
 

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -4,6 +4,7 @@
 #include "../../slang-com-helper.h"
 
 #include "slang-string-util.h"
+#include "slang-char-util.h"
 
 #ifndef __STDC__
 #   define __STDC__ 1
@@ -918,7 +919,90 @@ namespace Slang
 
         return SLANG_OK;
     }
+    
+    String URI::getPath() const
+    {
+        Index startIndex = uri.indexOf("://");
+        if (startIndex == -1)
+            return String();
+        startIndex += 3;
+        Index endIndex = uri.indexOf('?');
+        if (endIndex == -1)
+            endIndex = uri.getLength();
+        StringBuilder sb;
+#if SLANG_WINDOWS_FAMILY
+        if (uri[startIndex] == '/')
+            startIndex++;
+#endif
+        for (Index i = startIndex; i < endIndex;)
+        {
+            auto ch = uri[i];
+            if (ch == '%')
+            {
+                Int charVal = CharUtil::getHexDigitValue(uri[i + 1]) * 16 +
+                              CharUtil::getHexDigitValue(uri[i + 2]);
+                sb.appendChar((char)charVal);
+                i += 3;
+            }
+            else
+            {
+                sb.appendChar(uri[i]);
+                i++;
+            }
+        }
+        return sb.ProduceString();
+    }
 
+    StringSlice URI::getProtocol() const
+    {
+        Index separatorIndex = uri.indexOf("://");
+        if (separatorIndex != -1)
+            return uri.subString(0, separatorIndex);
+        return StringSlice();
+    }
+
+    bool URI::isSafeURIChar(char ch)
+    {
+        return (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') ||
+               ch == '-' || ch == '_' || ch == '/' || ch == '.';
+    }
+
+    URI URI::fromLocalFilePath(UnownedStringSlice path)
+    {
+        URI uri;
+        StringBuilder sb;
+        sb << "file://";
+
+#if SLANG_WINDOWS_FAMILY
+        sb << "/";
+#endif
+
+        for (auto ch : path)
+        {
+            if (isSafeURIChar(ch))
+            {
+                sb.appendChar(ch);
+            }
+            else if (ch == '\\')
+            {
+                sb.appendChar('/');
+            }
+            else
+            {
+                char buffer[32];
+                int length = IntToAscii(buffer, (int)ch, 16);
+                ReverseInternalAscii(buffer, length);
+                sb << "%" << buffer;
+            }
+        }
+        return URI::fromString(sb.getUnownedSlice());
+    }
+
+    URI URI::fromString(UnownedStringSlice uriString)
+    {
+        URI uri;
+        uri.uri = uriString;
+        return uri;
+    }
 
 }
-

--- a/source/core/slang-io.h
+++ b/source/core/slang-io.h
@@ -157,6 +157,23 @@ namespace Slang
         static SlangResult remove(const String& path);
     };
 
+    struct URI
+    {
+        String uri;
+        bool operator==(const URI& other) const { return uri == other.uri; }
+        bool operator!=(const URI& other) const { return uri != other.uri; }
+
+        HashCode getHashCode() const { return uri.getHashCode(); }
+
+        bool isLocalFile() { return uri.startsWith("file://"); };
+        String getPath() const;
+        StringSlice getProtocol() const;
+
+        static URI fromLocalFilePath(UnownedStringSlice path);
+        static URI fromString(UnownedStringSlice uriString);
+        static bool isSafeURIChar(char ch);
+    };
+
     // Helper class to clean up temporary files on dtor
     class TemporaryFileSet: public RefObject
     {

--- a/source/core/slang-string-util.cpp
+++ b/source/core/slang-string-util.cpp
@@ -645,4 +645,28 @@ ComPtr<ISlangBlob> StringUtil::createStringBlob(const String& string)
     return (cur == end) ? SLANG_OK : SLANG_FAIL;
 }
 
+int StringUtil::parseIntAndAdvancePos(UnownedStringSlice text, Index& pos)
+{
+    int result = 0;
+    while (text[pos] == ' ' && pos < text.getLength())
+    {
+        pos++;
+        continue;
+    }
+    while (pos < text.getLength())
+    {
+        if (text[pos] >= '0' && text[pos] <= '9')
+        {
+            result *= 10;
+            result += text[pos] - '0';
+            pos++;
+        }
+        else
+        {
+            break;
+        }
+    }
+    return result;
+}
+
 } // namespace Slang

--- a/source/core/slang-string-util.h
+++ b/source/core/slang-string-util.h
@@ -109,6 +109,11 @@ struct StringUtil
 
         /// Convert into int64_t. Returns SLANG_OK on success. 
     static SlangResult parseInt64(const UnownedStringSlice& text, int64_t& out);
+
+        /// Parse an integer from text starting at pos until the end or the first non-digit char.
+        /// Modifies pos to the position where parsing ends.
+        /// Returns parsed integer.
+    static int parseIntAndAdvancePos(UnownedStringSlice text, Index& pos);
 };
 
 /* A helper class that allows parsing of lines from text with iteration. Uses StringUtil::extractLine for the actual underlying implementation. */

--- a/source/slang/slang-language-server.cpp
+++ b/source/slang/slang-language-server.cpp
@@ -13,7 +13,7 @@
 #include "../core/slang-range.h"
 #include "../../slang-com-helper.h"
 #include "../compiler-core/slang-json-rpc-connection.h"
-#include "slang-language-server-protocol.h"
+#include "../compiler-core/slang-language-server-protocol.h"
 #include "slang-language-server.h"
 #include "slang-workspace-version.h"
 #include "slang-language-server-ast-lookup.h"

--- a/source/slang/slang-workspace-version.h
+++ b/source/slang/slang-workspace-version.h
@@ -5,32 +5,12 @@
 #include "../../slang.h"
 #include "../core/slang-basic.h"
 #include "../core/slang-com-object.h"
-#include "slang-language-server-protocol.h"
+#include "../compiler-core/slang-language-server-protocol.h"
 #include "slang-compiler.h"
 #include "slang-doc-ast.h"
 
 namespace Slang
 {
-    struct URI
-    {
-        String uri;
-        bool operator==(const URI& other) const
-        {
-            return uri == other.uri;
-        }
-        bool operator!=(const URI& other) const { return uri != other.uri; }
-
-        HashCode getHashCode() const { return uri.getHashCode(); }
-
-        bool isLocalFile() { return uri.startsWith("file://"); };
-        String getPath() const;
-        StringSlice getProtocol() const;
-
-        static URI fromLocalFilePath(UnownedStringSlice path);
-        static URI fromString(UnownedStringSlice uriString);
-        static bool isSafeURIChar(char ch);
-    };
-
     class Workspace;
 
     class DocumentVersion : public RefObject

--- a/tests/language-server/smoke.slang
+++ b/tests/language-server/smoke.slang
@@ -1,0 +1,33 @@
+//TEST(smoke):LANG_SERVER:
+//COMPLETE:31,21
+//HOVER:25,30
+//SIGNATURE:25,40
+interface IFoo
+{
+    /**
+    Returns the sum of the contents.
+    */
+    int getSum();
+}
+
+struct MyType : IFoo
+{
+    int getSum() { return 0; }
+}
+
+struct Pair<T:IFoo, U: IFoo> : IFoo
+{
+    T first;
+    U second;
+    /**
+    Returns the sum of the contents.
+    */
+    int getSum() { return first.getSum() + second.getSum(); }
+}
+
+void m()
+{
+    Pair<MyType, Pair<MyType, MyType>> v;
+    v.first = v.second.first;
+    
+}

--- a/tests/language-server/smoke.slang.expected.txt
+++ b/tests/language-server/smoke.slang.expected.txt
@@ -1,0 +1,25 @@
+--------
+first: 6  ().;:,<>[]{}-*/%+=&|! 
+second: 6  ().;:,<>[]{}-*/%+=&|! 
+getSum: 2  ([ 
+--------
+range: 24,26 - 24,31
+content:
+```
+Pair.T Pair<Pair.T, Pair.U>.first
+```
+
+
+
+{REDACTED}.slang(20)
+
+--------
+activeParameter: 0
+activeSignature: 0
+func IFoo.getSum() -> int:
+
+Returns the sum of the contents.
+
+{REDACTED}.slang(10)
+
+

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -171,6 +171,30 @@ SlangResult TestContext::_createJSONRPCConnection(RefPtr<JSONRPCConnection>& out
     return SLANG_OK;
 }
 
+SlangResult TestContext::createLanguageServerJSONRPCConnection(RefPtr<JSONRPCConnection>& out)
+{
+    RefPtr<Process> process;
+
+    {
+        CommandLine cmdLine;
+        cmdLine.setExecutableLocation(ExecutableLocation(exeDirectoryPath, "slangd"));
+        SLANG_RETURN_ON_FAIL(Process::create(cmdLine, Process::Flag::AttachDebugger, process));
+    }
+
+    Stream* writeStream = process->getStream(StdStreamType::In);
+    RefPtr<BufferedReadStream> readStream(
+        new BufferedReadStream(process->getStream(StdStreamType::Out)));
+
+    RefPtr<HTTPPacketConnection> connection = new HTTPPacketConnection(readStream, writeStream);
+    RefPtr<JSONRPCConnection> rpcConnection = new JSONRPCConnection;
+
+    SLANG_RETURN_ON_FAIL(
+        rpcConnection->init(connection, JSONRPCConnection::CallStyle::Object, process));
+
+    out = rpcConnection;
+
+    return SLANG_OK;
+}
 
 void TestContext::destroyRPCConnection()
 {

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -162,6 +162,7 @@ class TestContext
 
     void setTestReporter(TestReporter* reporter);
     TestReporter* getTestReporter();
+    SlangResult createLanguageServerJSONRPCConnection(Slang::RefPtr<Slang::JSONRPCConnection>& out);
 
     std::mutex mutex;
 


### PR DESCRIPTION
This PR adds a new `LANG_SERVER` test type to our testing infrastructure that can test the language server.
We can now create a `.slang` file with the following comment to test the language server:

```
//TEST:LANG_SERVER:
//COMPLETE:line,col           // request completion info at specified location
//SIGNATURE:line,col          // request signature info at specified location
//HOVER:line,col                 // request hover info at specified location
//DIAGNOSTIC                    // if used, this should be placed as the last request to
                                           // print all the diagnostics received from the server.
```

The responses of each request are concatenated as the output of the test, which is then compared to the expected output.
All filenames that appear in the output will be redacted so the expected output is agnostic to the running environment.
