### PR TITLE
Fill out support for calls to non-decl values

### DIFF
--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -1474,6 +1474,15 @@ namespace Slang
         List<ExtensionDecl*> candidateExtensions;
     };
 
+        /// Represents the "direction" that a parameter is being passed (e.g., `in` or `out`
+    enum ParameterDirection
+    {
+        kParameterDirection_In,     ///< Copy in
+        kParameterDirection_Out,    ///< Copy out
+        kParameterDirection_InOut,  ///< Copy in, copy out
+        kParameterDirection_Ref,    ///< By-reference
+    };
+
 } // namespace Slang
 
 #endif

--- a/source/slang/slang-ast-type.cpp
+++ b/source/slang/slang-ast-type.cpp
@@ -557,6 +557,27 @@ HashCode NamedExpressionType::_getHashCodeOverride()
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! FuncType !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+ParameterDirection FuncType::getParamDirection(Index index)
+{
+    auto paramType = getParamType(index);
+    if (as<RefType>(paramType))
+    {
+        return kParameterDirection_Ref;
+    }
+    else if (as<InOutType>(paramType))
+    {
+        return kParameterDirection_InOut;
+    }
+    else if (as<OutType>(paramType))
+    {
+        return kParameterDirection_Out;
+    }
+    else
+    {
+        return kParameterDirection_In;
+    }
+}
+
 void FuncType::_toTextOverride(StringBuilder& out)
 {
     out << toSlice("(");

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -525,10 +525,16 @@ class PtrType : public PtrTypeBase
     SLANG_AST_CLASS(PtrType)
 };
 
+/// A pointer-like type used to represent a parameter "direction"
+class ParamDirectionType : public PtrTypeBase
+{
+    SLANG_AST_CLASS(ParamDirectionType)
+};
+
 // A type that represents the behind-the-scenes
 // logical pointer that is passed for an `out`
 // or `in out` parameter
-class OutTypeBase : public PtrTypeBase 
+class OutTypeBase : public ParamDirectionType
 {
     SLANG_AST_CLASS(OutTypeBase)
 };
@@ -546,7 +552,7 @@ class InOutType : public OutTypeBase
 };
 
 // The type for an `ref` parameter, e.g., `ref T`
-class RefType : public PtrTypeBase 
+class RefType : public ParamDirectionType
 {
     SLANG_AST_CLASS(RefType)
 };
@@ -594,6 +600,8 @@ class FuncType : public Type
     Type* getParamType(UInt index) { return paramTypes[index]; }
     Type* getResultType() { return resultType; }
     Type* getErrorType() { return errorType; }
+
+    ParameterDirection getParamDirection(Index index);
 
     // Overrides should be public so base classes can access
     void _toTextOverride(StringBuilder& out);

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -160,6 +160,7 @@ namespace Slang
             Func,
             Generic,
             UnspecializedGeneric,
+            Expr,
         };
         Flavor flavor;
 
@@ -177,6 +178,9 @@ namespace Slang
 
         // Reference to the declaration being applied
         LookupResultItem item;
+
+        // Type of function being applied (for cases where `item` is not used)
+        FuncType* funcType = nullptr;
 
         // The type of the result expression if this candidate is selected
         Type*	resultType = nullptr;

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -3473,9 +3473,8 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         List<OutArgumentFixup>* ioFixups)
     {
         Count argCount = expr->arguments.getCount();
-        Count paramCount = funcType->getParamCount();
+        SLANG_ASSERT(argCount == funcType->getParamCount());
 
-        SLANG_ASSERT(argCount == paramCount);
         for(Index i = 0; i < argCount; ++i)
         {
             IRType* paramType = lowerType(context, funcType->getParamType(i));

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -755,16 +755,6 @@ LoweredValInfo emitCallToDeclRef(
         tryEnv);
 }
 
-    /// Represents the "direction" that a parameter is being passed (e.g., `in` or `out`
-enum ParameterDirection
-{
-    kParameterDirection_In,     ///< Copy in
-    kParameterDirection_Out,    ///< Copy out
-    kParameterDirection_InOut,  ///< Copy in, copy out
-    kParameterDirection_Ref,    ///< By-reference
-};
-
-
     /// Emit a call to the given `accessorDeclRef`.
     ///
     /// The `base` value represents the object on which the accessor is being invoked.
@@ -3403,74 +3393,113 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         // TODO: also need to handle this-type substitution here?
     }
 
+        /// Create IR instructions for an argument at a call site, based on
+        /// AST-level expressions plus function signature information.
+        ///
+        /// The `funcType` parameter is always required, and specifies the types
+        /// of all the parameters. The `funcDeclRef` parameter is only required
+        /// if there are parameter positions for which the matching argument is
+        /// absent.
+        ///
+    void addDirectCallArgs(
+        InvokeExpr*             expr,
+        Index                   argIndex,
+        IRType*                 paramType,
+        ParameterDirection      paramDirection,
+        DeclRef<ParamDecl>      paramDeclRef,
+        List<IRInst*>*          ioArgs,
+        List<OutArgumentFixup>* ioFixups)
+    {
+        Count argCount = expr->arguments.getCount();
+        if (argIndex < argCount)
+        {
+            auto argExpr = expr->arguments[argIndex];
+            addCallArgsForParam(context, paramType, paramDirection, argExpr, ioArgs, ioFixups);
+        }
+        else
+        {
+            // We have run out of arguments supplied at the call site,
+            // but there are still parameters remaining. This must mean
+            // that these parameters have default argument expressions
+            // associated with them.
+            //
+            // Currently we simply extract the initial-value expression
+            // from the parameter declaration and then lower it in
+            // the context of the caller.
+            //
+            // Note that the expression could involve subsitutions because
+            // in the general case it could depend on the generic parameters
+            // used the specialize the callee. For now we do not handle that
+            // case, and simply ignore generic arguments.
+            //
+            SubstExpr<Expr> argExpr = getInitExpr(getASTBuilder(), paramDeclRef);
+            SLANG_ASSERT(argExpr);
+
+            IRGenEnv subEnvStorage;
+            IRGenEnv* subEnv = &subEnvStorage;
+            subEnv->outer = context->env;
+
+            IRGenContext subContextStorage = *context;
+            IRGenContext* subContext = &subContextStorage;
+            subContext->env = subEnv;
+
+            _lowerSubstitutionEnv(subContext, argExpr.getSubsts());
+
+            addCallArgsForParam(subContext, paramType, paramDirection, argExpr.getExpr(), ioArgs, ioFixups);
+
+            // TODO: The approach we are taking here to default arguments
+            // is simplistic, and has consequences for the front-end as
+            // well as binary serialization of modules.
+            //
+            // We could consider some more refined approaches where, e.g.,
+            // functions with default arguments generate multiple IR-level
+            // functions, that compute and provide the default values.
+            //
+            // Alternatively, each parameter with defaults could be generated
+            // into its own callable function that provides the default value,
+            // so that calling modules can call into a pre-generated function.
+            //
+            // Each of these options involves trade-offs, and we need to
+            // make a conscious decision at some point.
+
+            // Assert that such an expression must have been present.
+        }
+    }
+
+    void addDirectCallArgs(
+        InvokeExpr*             expr,
+        FuncType*               funcType,
+        List<IRInst*>*          ioArgs,
+        List<OutArgumentFixup>* ioFixups)
+    {
+        Count argCount = expr->arguments.getCount();
+        Count paramCount = funcType->getParamCount();
+
+        SLANG_ASSERT(argCount == paramCount);
+        for(Index i = 0; i < argCount; ++i)
+        {
+            IRType* paramType = lowerType(context, funcType->getParamType(i));
+            ParameterDirection paramDirection = funcType->getParamDirection(i);
+            addDirectCallArgs(expr, i, paramType, paramDirection, DeclRef<ParamDecl>(), ioArgs, ioFixups);
+        }
+    }
+
+
     void addDirectCallArgs(
         InvokeExpr*             expr,
         DeclRef<CallableDecl>   funcDeclRef,
-        List<IRInst*>*         ioArgs,
+        List<IRInst*>*          ioArgs,
         List<OutArgumentFixup>* ioFixups)
     {
-        UInt argCount = expr->arguments.getCount();
-        UInt argCounter = 0;
+        Count argCounter = 0;
         for (auto paramDeclRef : getMembersOfType<ParamDecl>(funcDeclRef))
         {
             auto paramDecl = paramDeclRef.getDecl();
             IRType* paramType = lowerType(context, getType(getASTBuilder(), paramDeclRef));
             auto paramDirection = getParameterDirection(paramDecl);
 
-            UInt argIndex = argCounter++;
-            if(argIndex < argCount)
-            {
-                auto argExpr = expr->arguments[argIndex];
-                addCallArgsForParam(context, paramType, paramDirection, argExpr, ioArgs, ioFixups);
-            }
-            else
-            {
-                // We have run out of arguments supplied at the call site,
-                // but there are still parameters remaining. This must mean
-                // that these parameters have default argument expressions
-                // associated with them.
-                //
-                // Currently we simply extract the initial-value expression
-                // from the parameter declaration and then lower it in
-                // the context of the caller.
-                //
-                // Note that the expression could involve subsitutions because
-                // in the general case it could depend on the generic parameters
-                // used the specialize the callee. For now we do not handle that
-                // case, and simply ignore generic arguments.
-                //
-                SubstExpr<Expr> argExpr = getInitExpr(getASTBuilder(), paramDeclRef);
-                SLANG_ASSERT(argExpr);
-
-                IRGenEnv subEnvStorage;
-                IRGenEnv* subEnv = &subEnvStorage;
-                subEnv->outer = context->env;
-
-                IRGenContext subContextStorage = *context;
-                IRGenContext* subContext = &subContextStorage;
-                subContext->env = subEnv;
-
-                _lowerSubstitutionEnv(subContext, argExpr.getSubsts());
-
-                addCallArgsForParam(subContext, paramType, paramDirection, argExpr.getExpr(), ioArgs, ioFixups);
-
-                // TODO: The approach we are taking here to default arguments
-                // is simplistic, and has consequences for the front-end as
-                // well as binary serialization of modules.
-                //
-                // We could consider some more refined approaches where, e.g.,
-                // functions with default arguments generate multiple IR-level
-                // functions, that compute and provide the default values.
-                //
-                // Alternatively, each parameter with defaults could be generated
-                // into its own callable function that provides the default value,
-                // so that calling modules can call into a pre-generated function.
-                //
-                // Each of these options involves trade-offs, and we need to
-                // make a conscious decision at some point.
-
-                // Assert that such an expression must have been present.
-            }
+            Index argIndex = argCounter++;
+            addDirectCallArgs(expr, argIndex, paramType, paramDirection, paramDeclRef, ioArgs, ioFixups);
         }
     }
 
@@ -3636,7 +3665,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
 
         auto funcExpr = expr->functionExpr;
         ResolvedCallInfo resolvedInfo;
-        if( tryResolveDeclRefForCall(funcExpr, &resolvedInfo) )
+        if (tryResolveDeclRefForCall(funcExpr, &resolvedInfo))
         {
             // In this case we know exactly what declaration we
             // are going to call, and so we can resolve things
@@ -3690,7 +3719,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
 
             // First comes the `this` argument if we are calling
             // a member function:
-            if( baseExpr )
+            if (baseExpr)
             {
                 // The base expression might be an "upcast" to a base interface, in
                 // which case we don't want to emit the result of the cast, but instead
@@ -3725,6 +3754,17 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             applyOutArgumentFixups(context, argFixups);
             return result;
         }
+        else if(auto funcType = as<FuncType>(expr->functionExpr->type))
+        {
+            auto funcVal = lowerRValueExpr(context, expr->functionExpr);
+            addDirectCallArgs(expr, funcType, &irArgs, &argFixups);
+
+            auto result = emitCallToVal(context, type, funcVal, irArgs.getCount(), irArgs.getBuffer(), tryEnv);
+
+            applyOutArgumentFixups(context, argFixups);
+            return result;
+        }
+        
 
         // TODO: In this case we should be emitting code for the callee as
         // an ordinary expression, then emitting the arguments according


### PR DESCRIPTION
The existing compiler logic has a few places (semantic checking plus AST-to-IR lowering) where it assumes that function calls (`InvokeExpr`) are only ever made to expressions that resolve to a specific `Decl` (`DeclRefExpr`). This assumption allows semantic checking and lowering code to inspect things like the parameter list of an actual declaration, rather than just the type signature of the callee, and that infrastructure is used to support various features (e.g., default argument values on parameters).

The AST and IR representations themselves have no matching requirement, and the places where the more general case of call expressions would need to be supported were relatively clear in the code. This change attempts to add suitable logic into each of those places.

Note that this change does *not* surface any valid way to form input code that would cause these new code paths to be executed, so it is entirely possible that there are bugs in the logic as written here. The primary goal of this change is simply to get a sketch of the correct code checked in so that we have something to build on once we have language features that will require this support.