### PR TITLE
Define proper diagnostic item for two common "unimplemented" cases.

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -3039,8 +3039,13 @@ namespace Slang
                 return true;
             }
         }
-
-        getSink()->diagnose(inheritanceDecl, Diagnostics::unimplemented, "type not supported for inheritance");
+        if (!as<ErrorType>(superType))
+        {
+            getSink()->diagnose(
+                inheritanceDecl,
+                Diagnostics::invalidTypeForInheritance,
+                superType);
+        }
         return false;
     }
 
@@ -4566,7 +4571,10 @@ namespace Slang
                 return;
             }
         }
-        getSink()->diagnose(decl->targetType.exp, Diagnostics::unimplemented, "an 'extension' can only extend a nominal type");
+        if (!as<ErrorType>(decl->targetType.type))
+        {
+            getSink()->diagnose(decl->targetType.exp, Diagnostics::invalidExtensionOnType, decl->targetType);
+        }
     }
 
     void SemanticsDeclBasesVisitor::visitExtensionDecl(ExtensionDecl* decl)

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -364,6 +364,9 @@ DIAGNOSTIC(30821, Error, tagTypeMustBeListedFirst, "an unum type may only have a
 
 DIAGNOSTIC(30820, Error, cannotInheritFromExplicitlySealedDeclarationInAnotherModule, "cannot inherit from type '$0' marked 'sealed' in module '$1'")
 DIAGNOSTIC(30821, Error, cannotInheritFromImplicitlySealedDeclarationInAnotherModule, "cannot inherit from type '$0' in module '$1' because it is implicitly 'sealed'; mark the base type 'open' to allow inheritance across modules")
+DIAGNOSTIC(30822, Error, invalidTypeForInheritance, "type '$0' cannot be used for inheritance")
+
+DIAGNOSTIC(30850, Error, invalidExtensionOnType, "type '$0' cannot be extended. `extension` can only be used to extend a nominal type.")
 
 // 309xx: subscripts
 

--- a/tests/language-server/incomplete-inheritance.slang
+++ b/tests/language-server/incomplete-inheritance.slang
@@ -1,0 +1,10 @@
+//TEST:LANG_SERVER:
+
+struct MyType : INotExist{};
+
+void m()
+{
+//HOVER:8,9
+    MyType b;
+    reinterpret<MyType, MyType>(b);
+}

--- a/tests/language-server/incomplete-inheritance.slang.expected.txt
+++ b/tests/language-server/incomplete-inheritance.slang.expected.txt
@@ -1,0 +1,12 @@
+--------
+range: 7,4 - 7,10
+content:
+```
+struct MyType
+```
+
+
+
+{REDACTED}.slang(3)
+
+


### PR DESCRIPTION
An `unimplemented` diagnostic causes the type checker to abort by throwing an exception. When that happens the language server will not be able to provide any enhanced services that requires a checked AST.

This change turns two commonly encountered diagnostic into proper diagnostics to improve langauge server experience.