### PR TITLE
Fix language server crash when processing predefind macros.

### DIFF
--- a/source/slang/slang-workspace-version.cpp
+++ b/source/slang/slang-workspace-version.cpp
@@ -75,10 +75,14 @@ bool Workspace::updatePredefinedMacros(List<String> macros)
     {
         auto index = macro.indexOf('=');
         OwnedPreprocessorMacroDefinition def;
-        def.name = macro.getUnownedSlice().head(index).trim();
         if (index != -1)
         {
+            def.name = macro.getUnownedSlice().head(index).trim();
             def.value = macro.getUnownedSlice().tail(index + 1).trim();
+        }
+        else
+        {
+            def.name = macro.trim();
         }
         newDefs.add(def);
     }


### PR DESCRIPTION
When defining a macro without value via configurations, the language server crashes.

This change fixes the crash.