### PR TITLE
Language server fixes and improvements

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -106,6 +106,7 @@ jobs:
           7z a slang-macos-dist.zip slangc
           timeout 1000 gon ./extras/macos-notarize.json
       - name: UploadNotarizedBinary
+        if: always()
         uses: softprops/action-gh-release@v1
         with:
           files: |

--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -416,6 +416,7 @@ IF EXIST ..\..\..\external\slang-binaries\bin\windows-aarch64\slang-glslang.dll\
     <ClInclude Include="..\..\..\source\slang\slang-ir-wrap-structured-buffers.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir.h" />
     <ClInclude Include="..\..\..\source\slang\slang-language-server-ast-lookup.h" />
+    <ClInclude Include="..\..\..\source\slang\slang-language-server-auto-format.h" />
     <ClInclude Include="..\..\..\source\slang\slang-language-server-completion.h" />
     <ClInclude Include="..\..\..\source\slang\slang-language-server-document-symbols.h" />
     <ClInclude Include="..\..\..\source\slang\slang-language-server-inlay-hints.h" />
@@ -573,6 +574,7 @@ IF EXIST ..\..\..\external\slang-binaries\bin\windows-aarch64\slang-glslang.dll\
     <ClCompile Include="..\..\..\source\slang\slang-ir-wrap-structured-buffers.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-language-server-ast-lookup.cpp" />
+    <ClCompile Include="..\..\..\source\slang\slang-language-server-auto-format.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-language-server-completion.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-language-server-document-symbols.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-language-server-inlay-hints.cpp" />

--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -418,6 +418,7 @@ IF EXIST ..\..\..\external\slang-binaries\bin\windows-aarch64\slang-glslang.dll\
     <ClInclude Include="..\..\..\source\slang\slang-language-server-ast-lookup.h" />
     <ClInclude Include="..\..\..\source\slang\slang-language-server-completion.h" />
     <ClInclude Include="..\..\..\source\slang\slang-language-server-document-symbols.h" />
+    <ClInclude Include="..\..\..\source\slang\slang-language-server-inlay-hints.h" />
     <ClInclude Include="..\..\..\source\slang\slang-language-server-semantic-tokens.h" />
     <ClInclude Include="..\..\..\source\slang\slang-language-server.h" />
     <ClInclude Include="..\..\..\source\slang\slang-legalize-types.h" />
@@ -574,6 +575,7 @@ IF EXIST ..\..\..\external\slang-binaries\bin\windows-aarch64\slang-glslang.dll\
     <ClCompile Include="..\..\..\source\slang\slang-language-server-ast-lookup.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-language-server-completion.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-language-server-document-symbols.cpp" />
+    <ClCompile Include="..\..\..\source\slang\slang-language-server-inlay-hints.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-language-server-semantic-tokens.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-language-server.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-legalize-types.cpp" />

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -351,6 +351,9 @@
     <ClInclude Include="..\..\..\source\slang\slang-language-server-document-symbols.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\slang\slang-language-server-inlay-hints.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-language-server-semantic-tokens.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -813,6 +816,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-language-server-document-symbols.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\source\slang\slang-language-server-inlay-hints.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-language-server-semantic-tokens.cpp">

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -345,6 +345,9 @@
     <ClInclude Include="..\..\..\source\slang\slang-language-server-ast-lookup.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\slang\slang-language-server-auto-format.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-language-server-completion.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -810,6 +813,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-language-server-ast-lookup.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\source\slang\slang-language-server-auto-format.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-language-server-completion.cpp">

--- a/source/compiler-core/slang-language-server-protocol.cpp
+++ b/source/compiler-core/slang-language-server-protocol.cpp
@@ -25,6 +25,17 @@ static const StructRttiInfo _makeWorkDoneProgressParamsRtti()
 }
 const StructRttiInfo WorkDoneProgressParams::g_rttiInfo = _makeWorkDoneProgressParamsRtti();
 
+static const StructRttiInfo _makeInlayHintOptionsRtti()
+{
+    InlayHintOptions obj;
+    StructRttiBuilder builder(&obj, "LanguageServerProtocol::InlayHintOptions", nullptr);
+    builder.addField("resolveProvider", &obj.resolveProvider);
+    builder.ignoreUnknownFields();
+    return builder.make();
+}
+const StructRttiInfo InlayHintOptions::g_rttiInfo = _makeInlayHintOptionsRtti();
+
+
 static const StructRttiInfo _makeCompletionOptionsRtti()
 {
     CompletionOptions obj;
@@ -211,6 +222,7 @@ static const StructRttiInfo _makeServerCapabilitiesRtti()
     builder.addField("textDocumentSync", &obj.textDocumentSync);
     builder.addField("workspace", &obj.workspace);
     builder.addField("hoverProvider", &obj.hoverProvider);
+    builder.addField("inlayHintProvider", &obj.inlayHintProvider);
     builder.addField("definitionProvider", &obj.definitionProvider);
     builder.addField("completionProvider", &obj.completionProvider);
     builder.addField("semanticTokensProvider", &obj.semanticTokensProvider);
@@ -603,6 +615,48 @@ static const StructRttiInfo _makeDocumentSymbolRtti()
     return builder.make();
 }
 const StructRttiInfo DocumentSymbol::g_rttiInfo = _makeDocumentSymbolRtti();
+
+static const StructRttiInfo _makeTextEditRtti()
+{
+    TextEdit obj;
+    StructRttiBuilder builder(&obj, "LanguageServerProtocol::TextEdit", nullptr);
+    builder.addField("range", &obj.range);
+    builder.addField("newText", &obj.newText);
+    builder.ignoreUnknownFields();
+    return builder.make();
+}
+const StructRttiInfo TextEdit::g_rttiInfo = _makeTextEditRtti();
+
+static const StructRttiInfo _makeInlayHintParamsRtti()
+{
+    InlayHintParams obj;
+    StructRttiBuilder builder(
+        &obj, "LanguageServerProtocol::InlayHintParams", nullptr);
+    builder.addField("range", &obj.range);
+    builder.addField("textDocument", &obj.textDocument);
+    builder.ignoreUnknownFields();
+    return builder.make();
+}
+const StructRttiInfo InlayHintParams::g_rttiInfo = _makeInlayHintParamsRtti();
+const UnownedStringSlice InlayHintParams::methodName =
+    UnownedStringSlice::fromLiteral("textDocument/inlayHint");
+
+static const StructRttiInfo _makeInlayHintRtti()
+{
+    InlayHint obj;
+    StructRttiBuilder builder(
+        &obj, "LanguageServerProtocol::InlayHint", nullptr);
+    builder.addField("position", &obj.position);
+    builder.addField("label", &obj.label);
+    builder.addField("kind", &obj.kind);
+    builder.addField("paddingLeft", &obj.paddingLeft);
+    builder.addField("paddingRight", &obj.paddingRight);
+    builder.addField("textEdits", &obj.textEdits);
+
+    builder.ignoreUnknownFields();
+    return builder.make();
+}
+const StructRttiInfo InlayHint::g_rttiInfo = _makeInlayHintRtti();
 
 } // namespace LanguageServerProtocol
 

--- a/source/compiler-core/slang-language-server-protocol.cpp
+++ b/source/compiler-core/slang-language-server-protocol.cpp
@@ -407,6 +407,17 @@ static const StructRttiInfo _makeHoverRtti()
 }
 const StructRttiInfo Hover::g_rttiInfo = _makeHoverRtti();
 
+static const StructRttiInfo _makeCompletionContextRtti()
+{
+    CompletionContext obj;
+    StructRttiBuilder builder(&obj, "LanguageServerProtocol::CompletionContext", nullptr);
+    builder.addField("triggerKind", &obj.triggerKind);
+    builder.addField("triggerCharacter", &obj.triggerCharacter, StructRttiInfo::Flag::Optional);
+    builder.ignoreUnknownFields();
+    return builder.make();
+}
+const StructRttiInfo CompletionContext::g_rttiInfo = _makeCompletionContextRtti();
+
 static const StructRttiInfo _makeDefinitionParamsRtti()
 {
     DefinitionParams obj;
@@ -426,6 +437,7 @@ static const StructRttiInfo _makeCompletionParamsRtti()
     StructRttiBuilder builder(&obj, "LanguageServerProtocol::CompletionParams", &WorkDoneProgressParams::g_rttiInfo);
     builder.addField("textDocument", &obj.textDocument);
     builder.addField("position", &obj.position);
+    builder.addField("context", &obj.context, StructRttiInfo::Flag::Optional);
     builder.ignoreUnknownFields();
     return builder.make();
 }

--- a/source/compiler-core/slang-language-server-protocol.cpp
+++ b/source/compiler-core/slang-language-server-protocol.cpp
@@ -35,6 +35,16 @@ static const StructRttiInfo _makeInlayHintOptionsRtti()
 }
 const StructRttiInfo InlayHintOptions::g_rttiInfo = _makeInlayHintOptionsRtti();
 
+static const StructRttiInfo _makeDocumentOnTypeFormattingOptionsRtti()
+{
+    DocumentOnTypeFormattingOptions obj;
+    StructRttiBuilder builder(&obj, "LanguageServerProtocol::DocumentOnTypeFormattingOptions", nullptr);
+    builder.addField("firstTriggerCharacter", &obj.firstTriggerCharacter);
+    builder.addField("moreTriggerCharacter", &obj.moreTriggerCharacter);
+    builder.ignoreUnknownFields();
+    return builder.make();
+}
+const StructRttiInfo DocumentOnTypeFormattingOptions::g_rttiInfo = _makeDocumentOnTypeFormattingOptionsRtti();
 
 static const StructRttiInfo _makeCompletionOptionsRtti()
 {
@@ -223,6 +233,9 @@ static const StructRttiInfo _makeServerCapabilitiesRtti()
     builder.addField("workspace", &obj.workspace);
     builder.addField("hoverProvider", &obj.hoverProvider);
     builder.addField("inlayHintProvider", &obj.inlayHintProvider);
+    builder.addField("documentOnTypeFormattingProvider", &obj.documentOnTypeFormattingProvider);
+    builder.addField("documentFormattingProvider", &obj.documentFormattingProvider);
+    builder.addField("documentRangeFormattingProvider", &obj.documentRangeFormattingProvider);
     builder.addField("definitionProvider", &obj.definitionProvider);
     builder.addField("completionProvider", &obj.completionProvider);
     builder.addField("semanticTokensProvider", &obj.semanticTokensProvider);
@@ -657,6 +670,45 @@ static const StructRttiInfo _makeInlayHintRtti()
     return builder.make();
 }
 const StructRttiInfo InlayHint::g_rttiInfo = _makeInlayHintRtti();
+
+static const StructRttiInfo _makeDocumentFormattingParamsRtti()
+{
+    DocumentFormattingParams obj;
+    StructRttiBuilder builder(&obj, "LanguageServerProtocol::DocumentFormattingParams", nullptr);
+    builder.addField("textDocument", &obj.textDocument);
+    builder.ignoreUnknownFields();
+    return builder.make();
+}
+const StructRttiInfo DocumentFormattingParams::g_rttiInfo = _makeDocumentFormattingParamsRtti();
+const UnownedStringSlice DocumentFormattingParams::methodName =
+    UnownedStringSlice::fromLiteral("textDocument/formatting");
+
+static const StructRttiInfo _makeDocumentRangeFormattingParamsRtti()
+{
+    DocumentRangeFormattingParams obj;
+    StructRttiBuilder builder(&obj, "LanguageServerProtocol::DocumentRangeFormattingParams", nullptr);
+    builder.addField("textDocument", &obj.textDocument);
+    builder.addField("range", &obj.range);
+    builder.ignoreUnknownFields();
+    return builder.make();
+}
+const StructRttiInfo DocumentRangeFormattingParams::g_rttiInfo = _makeDocumentRangeFormattingParamsRtti();
+const UnownedStringSlice DocumentRangeFormattingParams::methodName =
+    UnownedStringSlice::fromLiteral("textDocument/rangeFormatting");
+
+static const StructRttiInfo _makeDocumentOnTypeFormattingParamsRtti()
+{
+    DocumentOnTypeFormattingParams obj;
+    StructRttiBuilder builder(&obj, "LanguageServerProtocol::DocumentOnTypeFormattingParams", nullptr);
+    builder.addField("textDocument", &obj.textDocument);
+    builder.addField("position", &obj.position);
+    builder.addField("ch", &obj.ch);
+    builder.ignoreUnknownFields();
+    return builder.make();
+}
+const StructRttiInfo DocumentOnTypeFormattingParams::g_rttiInfo = _makeDocumentOnTypeFormattingParamsRtti();
+const UnownedStringSlice DocumentOnTypeFormattingParams::methodName =
+    UnownedStringSlice::fromLiteral("textDocument/onTypeFormatting");
 
 } // namespace LanguageServerProtocol
 

--- a/source/compiler-core/slang-language-server-protocol.h
+++ b/source/compiler-core/slang-language-server-protocol.h
@@ -232,6 +232,22 @@ struct WorkspaceCapabilities
     static const StructRttiInfo g_rttiInfo;
 };
 
+/**
+ * Inlay hint options used during static registration.
+ *
+ * @since 3.17.0
+ */
+struct InlayHintOptions
+{
+    /**
+     * The server provides support to resolve additional
+     * information for an inlay hint item.
+     */
+    bool resolveProvider = false;
+    static const StructRttiInfo g_rttiInfo;
+
+};
+
 struct ServerCapabilities
 {
     String positionEncoding;
@@ -239,6 +255,7 @@ struct ServerCapabilities
     bool hoverProvider = false;
     bool definitionProvider = false;
     bool documentSymbolProvider = false;
+    InlayHintOptions inlayHintProvider;
     CompletionOptions completionProvider;
     SemanticTokensOptions semanticTokensProvider;
     SignatureHelpOptions signatureHelpProvider;
@@ -786,8 +803,8 @@ const int kSymbolKindTypeParameter = 26;
  * have two ranges: one that encloses its definition and one that points to its
  * most interesting range, e.g. the range of an identifier.
  */
-struct DocumentSymbol {
-
+struct DocumentSymbol
+{
     /**
      * The name of this symbol. Will be displayed in the user interface and
      * therefore must not be an empty string or a string only consisting of
@@ -825,6 +842,99 @@ struct DocumentSymbol {
     List<DocumentSymbol> children;
 
     static const StructRttiInfo g_rttiInfo;
+};
+
+/**
+ * A parameter literal used in inlay hint requests.
+ *
+ * @since 3.17.0
+ */
+struct InlayHintParams
+{
+    /**
+     * The text document.
+     */
+    TextDocumentIdentifier textDocument;
+
+    /**
+     * The visible document range for which inlay hints should be computed.
+     */
+    Range range;
+
+    static const StructRttiInfo g_rttiInfo;
+    static const UnownedStringSlice methodName;
+};
+
+struct TextEdit
+{
+    /**
+     * The range of the text document to be manipulated. To insert
+     * text into a document create a range where start === end.
+     */
+    Range range;
+
+    /**
+     * The string to be inserted. For delete operations use an
+     * empty string.
+     */
+    String newText;
+
+    static const StructRttiInfo g_rttiInfo;
+
+};
+
+typedef int InlayHintKind;
+const int kInlayHintKindType = 1;
+const int kInlayHintKindParameter = 2;
+
+/**
+ * Inlay hint information.
+ *
+ * @since 3.17.0
+ */
+struct InlayHint
+{
+    /**
+     * The position of this hint.
+     */
+    Position position;
+
+    /**
+     * The label of this hint. A human readable string or an array of
+     * InlayHintLabelPart label parts.
+     *
+     * *Note* that neither the string nor the label part can be empty.
+     */
+    String label;
+
+    /**
+     * The kind of this hint. Can be omitted in which case the client
+     * should fall back to a reasonable default.
+     */
+    InlayHintKind kind = 1;
+
+    List<TextEdit> textEdits;
+
+    /**
+     * Render padding before the hint.
+     *
+     * Note: Padding should use the editor's background color, not the
+     * background color of the hint itself. That means padding can be used
+     * to visually align/separate an inlay hint.
+     */
+    bool paddingLeft = false;
+
+    /**
+     * Render padding after the hint.
+     *
+     * Note: Padding should use the editor's background color, not the
+     * background color of the hint itself. That means padding can be used
+     * to visually align/separate an inlay hint.
+     */
+    bool paddingRight = false;
+
+    static const StructRttiInfo g_rttiInfo;
+
 };
 
 } // namespace LanguageServerProtocol

--- a/source/compiler-core/slang-language-server-protocol.h
+++ b/source/compiler-core/slang-language-server-protocol.h
@@ -248,6 +248,21 @@ struct InlayHintOptions
 
 };
 
+struct DocumentOnTypeFormattingOptions
+{
+    /**
+     * A character on which formatting should be triggered, like `{`.
+     */
+    String firstTriggerCharacter;
+
+    /**
+     * More trigger characters.
+     */
+    List<String> moreTriggerCharacter;
+
+    static const StructRttiInfo g_rttiInfo;
+};
+
 struct ServerCapabilities
 {
     String positionEncoding;
@@ -255,6 +270,9 @@ struct ServerCapabilities
     bool hoverProvider = false;
     bool definitionProvider = false;
     bool documentSymbolProvider = false;
+    bool documentFormattingProvider = false;
+    bool documentRangeFormattingProvider = false;
+    DocumentOnTypeFormattingOptions documentOnTypeFormattingProvider;
     InlayHintOptions inlayHintProvider;
     CompletionOptions completionProvider;
     SemanticTokensOptions semanticTokensProvider;
@@ -935,6 +953,74 @@ struct InlayHint
 
     static const StructRttiInfo g_rttiInfo;
 
+};
+
+struct DocumentOnTypeFormattingParams
+{
+    /**
+     * The document to format.
+     */
+    TextDocumentIdentifier textDocument;
+
+    /**
+     * The position around which the on type formatting should happen.
+     * This is not necessarily the exact position where the character denoted
+     * by the property `ch` got typed.
+     */
+    Position position;
+
+    /**
+     * The character that has been typed that triggered the formatting
+     * on type request. That is not necessarily the last character that
+     * got inserted into the document since the client could auto insert
+     * characters as well (e.g. like automatic brace completion).
+     */
+    String ch;
+
+    /**
+     * The formatting options.
+     */
+    //FormattingOptions options;
+
+    static const StructRttiInfo g_rttiInfo;
+    static const UnownedStringSlice methodName;
+};
+
+struct DocumentRangeFormattingParams
+{
+    /**
+     * The document to format.
+     */
+    TextDocumentIdentifier textDocument;
+
+    /**
+     * The range to format
+     */
+    Range range;
+
+    /**
+     * The format options
+     */
+    //FormattingOptions options;
+
+    static const StructRttiInfo g_rttiInfo;
+    static const UnownedStringSlice methodName;
+};
+
+struct DocumentFormattingParams
+{
+    /**
+     * The document to format.
+     */
+    TextDocumentIdentifier textDocument;
+
+    /**
+     * The format options
+     */
+    //FormattingOptions options;
+
+    static const StructRttiInfo g_rttiInfo;
+    static const UnownedStringSlice methodName;
 };
 
 } // namespace LanguageServerProtocol

--- a/source/compiler-core/slang-language-server-protocol.h
+++ b/source/compiler-core/slang-language-server-protocol.h
@@ -371,7 +371,7 @@ struct Diagnostic
      * The diagnostic's severity. Can be omitted. If omitted it is up to the
      * client to interpret diagnostics as error, warning, info or hint.
      */
-    DiagnosticSeverity severity;
+    DiagnosticSeverity severity = 1;
 
     /**
      * The diagnostic's code, which might appear in the user interface.
@@ -487,10 +487,48 @@ struct Hover
     static const StructRttiInfo g_rttiInfo;
 };
 
+typedef int CompletionTriggerKind;
+const CompletionTriggerKind kCompletionTriggerKindInvoked = 1;
+
+/**
+ * Completion was triggered by a trigger character specified by
+ * the `triggerCharacters` properties of the
+ * `CompletionRegistrationOptions`.
+ */
+const CompletionTriggerKind kCompletionTriggerKindTriggerCharacter = 2;
+
+/**
+ * Completion was re-triggered as the current completion list is incomplete.
+ */
+const CompletionTriggerKind kCompletionTriggerKindTriggerForIncompleteCompletions = 3;
+
+/**
+ * Contains additional information about the context in which a completion
+ * request is triggered.
+ */
+struct CompletionContext
+{
+    /**
+     * How the completion was triggered.
+     */
+    CompletionTriggerKind triggerKind = 1;
+
+    /**
+     * The trigger character (a single character) that has trigger code
+     * complete. Is undefined if
+     * `triggerKind !== CompletionTriggerKind.TriggerCharacter`
+     */
+    String triggerCharacter;
+
+    static const StructRttiInfo g_rttiInfo;
+};
+
 struct CompletionParams
     : WorkDoneProgressParams
     , TextDocumentPositionParams
 {
+    CompletionContext context;
+
     static const StructRttiInfo g_rttiInfo;
     static const UnownedStringSlice methodName;
 };
@@ -838,7 +876,7 @@ struct DocumentSymbol
     /**
      * The kind of this symbol.
      */
-    SymbolKind kind;
+    SymbolKind kind = 0;
 
     /**
      * The range enclosing this symbol not including leading/trailing whitespace

--- a/source/compiler-core/slang-lexer.cpp
+++ b/source/compiler-core/slang-lexer.cpp
@@ -1340,9 +1340,12 @@ namespace Slang
                 }
             }
 
-            if (tokenType == TokenType::Identifier || tokenType == TokenType::CompletionRequest)
+            if (m_namePool)
             {
-                token.setName(m_namePool->getName(token.getContent()));
+                if (tokenType == TokenType::Identifier || tokenType == TokenType::CompletionRequest)
+                {
+                    token.setName(m_namePool->getName(token.getContent()));
+                }
             }
 
             return token;

--- a/source/core/slang-string.cpp
+++ b/source/core/slang-string.cpp
@@ -633,7 +633,7 @@ namespace Slang
         const char* chars = m_begin;
         const char firstChar = inChars[0];
 
-        for (Int i = 0; i < len - inLen; ++i)
+        for (Int i = 0; i <= len - inLen; ++i)
         {
             if (chars[i] == firstChar && in == UnownedStringSlice(chars + i, inLen))
             {

--- a/source/slang/slang-language-server-auto-format.cpp
+++ b/source/slang/slang-language-server-auto-format.cpp
@@ -162,7 +162,7 @@ List<Edit> formatSource(UnownedStringSlice text, Index lineStart, Index lineEnd,
     // Adhoc parsing of clang-format's result.
     List<UnownedStringSlice> lines;
     auto offsetStr = UnownedStringSlice("offset=");
-    auto legnthStr = UnownedStringSlice("length=");
+    auto lengthStr = UnownedStringSlice("length=");
     auto endStr = UnownedStringSlice("</replacement>");
     auto replacementStr = UnownedStringSlice("<replacement ");
     StringUtil::calcLines(result.standardOutput.getUnownedSlice(), lines);
@@ -180,10 +180,10 @@ List<Edit> formatSource(UnownedStringSlice text, Index lineStart, Index lineEnd,
             pos++;
         Edit edt;
         edt.offset = StringUtil::parseIntAndAdvancePos(line, pos);
-        pos = line.indexOf(legnthStr);
+        pos = line.indexOf(lengthStr);
         if (pos == -1)
             continue;
-        pos += legnthStr.getLength();
+        pos += lengthStr.getLength();
         if (pos < line.getLength() && line[pos] == '\'')
             pos++;
         edt.length = StringUtil::parseIntAndAdvancePos(line, pos);

--- a/source/slang/slang-language-server-auto-format.cpp
+++ b/source/slang/slang-language-server-auto-format.cpp
@@ -1,0 +1,202 @@
+#include "slang-language-server-auto-format.h"
+#include "../core/slang-char-util.h"
+#include "../compiler-core/slang-lexer.h"
+
+namespace Slang
+{
+
+String findClangFormatTool()
+{
+    String processName = "clang-format" + Process::getExecutableSuffix();
+    if (File::exists(processName))
+        return processName;
+    auto fileName =
+        Slang::SharedLibraryUtils::getSharedLibraryFileName((void*)slang_createGlobalSession);
+    auto dirName = Slang::Path::getParentDirectory(fileName);
+    auto localProcess = Path::combine(dirName, processName);
+    if (File::exists(localProcess))
+        return localProcess;
+
+    Index vsCodeLoc = dirName.indexOf(".vscode");
+    if (vsCodeLoc != -1)
+    {
+        // If we still cannot find clang-format, try to use the clang-format bundled with VSCode's C++ extension.
+        String vsCodeExtDir = dirName.subString(0, vsCodeLoc + 7);
+        struct CallbackContext
+        {
+            String foundPath;
+            String parentDir;
+            String processName;
+        } callbackContext;
+        callbackContext.processName = processName;
+        callbackContext.parentDir = vsCodeExtDir;
+        OSFileSystem::getExtSingleton()->enumeratePathContents(vsCodeExtDir.getBuffer(), [](SlangPathType /*pathType*/, const char* name, void* userData)
+        {
+            CallbackContext* context = (CallbackContext*)userData;
+            if (UnownedStringSlice(name).indexOf(UnownedStringSlice("ms-vscode.cpptools-")) != -1)
+            {
+                String candidateFileName = Path::combine(Path::combine(context->parentDir, name, "LLVM"), "bin", context->processName);
+                if (File::exists(candidateFileName))
+                    context->foundPath = candidateFileName;
+            }
+        }, & callbackContext);
+        if (callbackContext.foundPath.getLength())
+            return callbackContext.foundPath;
+    }
+    return String();
+}
+
+void translateXmlEscape(StringBuilder& sb, UnownedStringSlice text)
+{
+    if (text.getLength() == 0)
+        return;
+    if (text[0] == '#')
+    {
+        Int charVal = 0;
+        StringUtil::parseInt(text.tail(1), charVal);
+        if (charVal != 0)
+            sb.appendChar((char)charVal);
+    }
+    else if (text == "lt")
+    {
+        sb.appendChar('<');
+    }
+    else if (text == "gt")
+    {
+        sb.appendChar('>');
+    }
+    else if (text == "amp")
+    {
+        sb.appendChar('&');
+    }
+    else if (text == "apos")
+    {
+        sb.appendChar('\'');
+    }
+    else if (text == "quot")
+    {
+        sb.appendChar('\"');
+    }
+}
+
+String parseXmlText(UnownedStringSlice text)
+{
+    StringBuilder sb;
+    Index pos = 0;
+    for (; pos < text.getLength();)
+    {
+        if (text[pos] == '&')
+        {
+            pos++;
+            Index endPos = pos;
+            while (endPos < text.getLength() && text[endPos] != ';')
+                endPos++;
+            auto escapedToken = text.subString(pos, endPos - pos);
+            pos = endPos + 1;
+            translateXmlEscape(sb, escapedToken);
+        }
+        else
+        {
+            sb.appendChar(text[pos]);
+            pos++;
+        }
+    }
+    return sb.ProduceString();
+}
+
+List<Edit> formatSource(UnownedStringSlice text, Index lineStart, Index lineEnd, Index cursorOffset, const FormatOptions& options)
+{
+    List<Edit> edits;
+
+    String clangProcessName = options.clangFormatLocation;
+    CommandLine cmdLine;
+    cmdLine.setExecutableLocation(ExecutableLocation(clangProcessName));
+    cmdLine.addArg("--assume-filename=source.cs");
+    if (cursorOffset != -1)
+    {
+        cmdLine.addArg("--cursor=" + String(cursorOffset));
+    }
+    if (lineStart != -1)
+    {
+        cmdLine.addArg("--lines=" + String(lineStart) + ":" + String(lineEnd + 1));
+    }
+    cmdLine.addArg("--output-replacements-xml");
+    if (options.style.getLength())
+    {
+        cmdLine.addArg("-style");
+        cmdLine.addArg(options.style);
+    }
+    RefPtr<Process> proc;
+    if (SLANG_FAILED(Process::create(cmdLine, 0, proc)))
+        return edits;
+
+    auto inStream = proc->getStream(StdStreamType::In);
+    inStream->write(text.begin(), text.getLength());
+    char terminator = '\0';
+    inStream->write(&terminator, 1);
+    inStream->flush();
+    inStream->close();
+    ExecuteResult result;
+    ProcessUtil::readUntilTermination(proc, result);
+
+    /*
+    Example result of clang-format:
+
+    <?xml version='1.0'?>
+    <replacements xml:space='preserve' incomplete_format='false'>
+    <replacement offset='26' length='2'>&#13;&#10;  </replacement>
+    </replacements>
+    */
+
+    // Adhoc parsing of clang-format's result.
+    List<UnownedStringSlice> lines;
+    auto offsetStr = UnownedStringSlice("offset=");
+    auto legnthStr = UnownedStringSlice("length=");
+    auto endStr = UnownedStringSlice("</replacement>");
+    auto replacementStr = UnownedStringSlice("<replacement ");
+    StringUtil::calcLines(result.standardOutput.getUnownedSlice(), lines);
+    for (auto line : lines)
+    {
+        line = line.trim();
+        if (!line.startsWith(replacementStr))
+            continue;
+        line = line.tail(replacementStr.getLength());
+        Index pos = line.indexOf(offsetStr);
+        if (pos == -1)
+            continue;
+        pos += offsetStr.getLength();
+        if (pos < line.getLength() && line[pos] == '\'')
+            pos++;
+        Edit edt;
+        edt.offset = StringUtil::parseIntAndAdvancePos(line, pos);
+        pos = line.indexOf(legnthStr);
+        if (pos == -1)
+            continue;
+        pos += legnthStr.getLength();
+        if (pos < line.getLength() && line[pos] == '\'')
+            pos++;
+        edt.length = StringUtil::parseIntAndAdvancePos(line, pos);
+        line = line.tail(pos);
+        pos = line.indexOf('>');
+        if (pos == -1)
+            continue;
+        line = line.tail(pos + 1);
+        Index endPos = line.indexOf(endStr);
+        if (endPos == -1)
+            continue;
+        line = line.head(endPos);
+        edt.text = parseXmlText(line);
+        // For on-type formatting, don't make any changes beyond the current cursor position.
+        if (cursorOffset != -1 && edt.offset >= cursorOffset)
+            break;
+        // Never allow clang-format to put the semicolon after `}` in its own line.
+        if (edt.offset < text.getLength() && edt.length == 0 && text[edt.offset] == ';' && edt.offset >0 && text[edt.offset - 1] == '}')
+            continue;
+
+        edits.add(edt);
+    }
+    return edits;
+}
+
+
+} // namespace Slang

--- a/source/slang/slang-language-server-auto-format.cpp
+++ b/source/slang/slang-language-server-auto-format.cpp
@@ -22,6 +22,7 @@ String findClangFormatTool()
     {
         // If we still cannot find clang-format, try to use the clang-format bundled with VSCode's C++ extension.
         String vsCodeExtDir = dirName.subString(0, vsCodeLoc + 7);
+        vsCodeExtDir = Path::combine(vsCodeExtDir, "extensions");
         struct CallbackContext
         {
             String foundPath;

--- a/source/slang/slang-language-server-auto-format.cpp
+++ b/source/slang/slang-language-server-auto-format.cpp
@@ -10,6 +10,16 @@ String findClangFormatTool()
     String processName = String("clang-format") + String(Process::getExecutableSuffix());
     if (File::exists(processName))
         return processName;
+    RefPtr<Process> proc;
+    CommandLine cmdLine;
+    cmdLine.setExecutableLocation(ExecutableLocation(processName));
+    if (Process::create(cmdLine, 0, proc) == SLANG_OK)
+    {
+        auto inStream = proc->getStream(StdStreamType::In);
+        if (inStream) inStream->close();
+        proc->kill(0);
+        return processName;
+    }
     auto fileName =
         Slang::SharedLibraryUtils::getSharedLibraryFileName((void*)slang_createGlobalSession);
     auto dirName = Slang::Path::getParentDirectory(fileName);

--- a/source/slang/slang-language-server-auto-format.cpp
+++ b/source/slang/slang-language-server-auto-format.cpp
@@ -7,7 +7,7 @@ namespace Slang
 
 String findClangFormatTool()
 {
-    String processName = "clang-format" + Process::getExecutableSuffix();
+    String processName = String("clang-format") + String(Process::getExecutableSuffix());
     if (File::exists(processName))
         return processName;
     auto fileName =

--- a/source/slang/slang-language-server-auto-format.h
+++ b/source/slang/slang-language-server-auto-format.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "../../slang.h"
+#include "../core/slang-basic.h"
+#include "slang-workspace-version.h"
+
+namespace Slang
+{
+struct Edit
+{
+    Index offset;
+    Index length;
+    String text;
+};
+
+struct FormatOptions
+{
+    String clangFormatLocation;
+    String style = "{BasedOnStyle: Microsoft}";
+};
+
+String findClangFormatTool();
+List<Edit> formatSource(UnownedStringSlice text, Index lineStart, Index lineEnd, Index cursorOffset, const FormatOptions& options);
+
+} // namespace Slang

--- a/source/slang/slang-language-server-inlay-hints.cpp
+++ b/source/slang/slang-language-server-inlay-hints.cpp
@@ -8,7 +8,12 @@
 namespace Slang
 {
 List<LanguageServerProtocol::InlayHint> getInlayHints(
-    Linkage* linkage, Module* module, UnownedStringSlice fileName, DocumentVersion* doc, LanguageServerProtocol::Range range)
+    Linkage* linkage,
+    Module* module,
+    UnownedStringSlice fileName,
+    DocumentVersion* doc,
+    LanguageServerProtocol::Range range,
+    const InlayHintOptions& options)
 {
     List<LanguageServerProtocol::InlayHint> result;
     auto manager = linkage->getSourceManager();
@@ -17,6 +22,8 @@ List<LanguageServerProtocol::InlayHint> getInlayHints(
         {
             if (auto invokeExpr = as<InvokeExpr>(node))
             {
+                if (!options.showParameterNames)
+                    return;
                 auto humaneLoc = manager->getHumaneLoc(node->loc);
                 if (humaneLoc.line - 1 < range.start.line || humaneLoc.line - 1 > range.end.line)
                     return;
@@ -66,6 +73,8 @@ List<LanguageServerProtocol::InlayHint> getInlayHints(
             }
             else if (auto varDecl = as<VarDeclBase>(node))
             {
+                if (!options.showDeducedType)
+                    return;
                 auto humaneLoc = manager->getHumaneLoc(node->loc);
                 if (humaneLoc.line - 1 < range.start.line || humaneLoc.line - 1 > range.end.line)
                     return;

--- a/source/slang/slang-language-server-inlay-hints.cpp
+++ b/source/slang/slang-language-server-inlay-hints.cpp
@@ -1,0 +1,111 @@
+#include "slang-language-server-inlay-hints.h"
+#include "slang-visitor.h"
+#include "slang-ast-support-types.h"
+#include "slang-ast-iterator.h"
+#include "slang-language-server.h"
+#include "../core/slang-char-util.h"
+
+namespace Slang
+{
+List<LanguageServerProtocol::InlayHint> getInlayHints(
+    Linkage* linkage, Module* module, UnownedStringSlice fileName, DocumentVersion* doc, LanguageServerProtocol::Range range)
+{
+    List<LanguageServerProtocol::InlayHint> result;
+    auto manager = linkage->getSourceManager();
+    auto docText = doc->getText().getUnownedSlice();
+    iterateAST(fileName, manager, module->getModuleDecl(), [&](SyntaxNode* node)
+        {
+            if (auto invokeExpr = as<InvokeExpr>(node))
+            {
+                auto humaneLoc = manager->getHumaneLoc(node->loc);
+                if (humaneLoc.line - 1 < range.start.line || humaneLoc.line - 1 > range.end.line)
+                    return;
+                if (humaneLoc.pathInfo.foundPath != fileName)
+                    return;
+                auto funcExpr = as<DeclRefExpr>(invokeExpr->functionExpr);
+                if (!funcExpr)
+                    return;
+                if (as<ConstructorDecl>(funcExpr->declRef.getDecl()))
+                    return;
+                auto callable = as<CallableDecl>(funcExpr->declRef.getDecl());
+                if (!callable)
+                    return;
+                auto params = callable->getParameters();
+                Index i = 0;
+                for (auto param : params)
+                {
+                    if (i >= invokeExpr->argumentDelimeterLocs.getCount() - 1)
+                        break;
+                    if (auto name = param->getName())
+                    {
+                        LanguageServerProtocol::InlayHint hint;
+                        auto loc = manager->getHumaneLoc(invokeExpr->argumentDelimeterLocs[i]);
+                        auto offset = doc->getOffset(loc.line, loc.column);
+                        offset++;
+                        while (offset < docText.getLength() && CharUtil::isWhitespace(docText[offset]))
+                            offset++;
+                        Index posLine, posCol;
+                        doc->offsetToLineCol(offset, posLine, posCol);
+                        Index utf16line, utf16col;
+                        doc->oneBasedUTF8LocToZeroBasedUTF16Loc(posLine, posCol, utf16line, utf16col);
+                        hint.position.line = (int)utf16line;
+                        hint.position.character = (int)utf16col;
+                        hint.paddingLeft = false;
+                        hint.kind = LanguageServerProtocol::kInlayHintKindParameter;
+                        StringBuilder lblSb;
+                        if (param->hasModifier<OutModifier>()) lblSb << "out ";
+                        else if (param->hasModifier<InOutModifier>()) lblSb << "inout ";
+                        else if (param->hasModifier<RefModifier>()) lblSb << "ref ";
+                        lblSb << name->text;
+                        lblSb << ":";
+                        hint.label = lblSb.ProduceString();
+                        result.add(hint);
+                    }
+                    i++;
+                }
+            }
+            else if (auto varDecl = as<VarDeclBase>(node))
+            {
+                auto humaneLoc = manager->getHumaneLoc(node->loc);
+                if (humaneLoc.line - 1 < range.start.line || humaneLoc.line - 1 > range.end.line)
+                    return;
+                if (humaneLoc.pathInfo.foundPath != fileName)
+                    return;
+                if (varDecl->type.exp)
+                    return;
+                if (!varDecl->type.type)
+                    return;
+                if (as<ErrorType>(varDecl->type.type))
+                    return;
+                if (!varDecl->getName())
+                    return;
+
+                LanguageServerProtocol::InlayHint hint;
+                auto loc = manager->getHumaneLoc(varDecl->nameAndLoc.loc);
+                auto offset = doc->getOffset(loc.line, loc.column);
+                offset++;
+                while (offset < docText.getLength() && _isIdentifierChar(docText[offset]))
+                    offset++;
+                Index posLine, posCol;
+                doc->offsetToLineCol(offset, posLine, posCol);
+                Index utf16line, utf16col;
+                doc->oneBasedUTF8LocToZeroBasedUTF16Loc(posLine, posCol, utf16line, utf16col);
+                hint.position.line = (int)utf16line;
+                hint.position.character = (int)utf16col;
+                hint.kind = LanguageServerProtocol::kInlayHintKindParameter;
+                StringBuilder lblSb;
+                lblSb << ": " << varDecl->type.type->toString();
+                hint.label = lblSb.ProduceString();
+
+                LanguageServerProtocol::TextEdit edit;
+                edit.range.start = hint.position;
+                edit.range.end = hint.position;
+                edit.newText = " " + hint.label;
+                hint.textEdits.add(edit);
+                result.add(hint);
+            }
+        });
+    return result;
+}
+
+} // namespace Slang

--- a/source/slang/slang-language-server-inlay-hints.cpp
+++ b/source/slang/slang-language-server-inlay-hints.cpp
@@ -92,7 +92,7 @@ List<LanguageServerProtocol::InlayHint> getInlayHints(
                 doc->oneBasedUTF8LocToZeroBasedUTF16Loc(posLine, posCol, utf16line, utf16col);
                 hint.position.line = (int)utf16line;
                 hint.position.character = (int)utf16col;
-                hint.kind = LanguageServerProtocol::kInlayHintKindParameter;
+                hint.kind = LanguageServerProtocol::kInlayHintKindType;
                 StringBuilder lblSb;
                 lblSb << ": " << varDecl->type.type->toString();
                 hint.label = lblSb.ProduceString();

--- a/source/slang/slang-language-server-inlay-hints.h
+++ b/source/slang/slang-language-server-inlay-hints.h
@@ -9,6 +9,13 @@
 
 namespace Slang
 {
+
+struct InlayHintOptions
+{
+    bool showDeducedType = false;
+    bool showParameterNames = false;
+};
+
 List<LanguageServerProtocol::InlayHint> getInlayHints(
-    Linkage* linkage, Module* module, UnownedStringSlice fileName, DocumentVersion* doc, LanguageServerProtocol::Range range);
+    Linkage* linkage, Module* module, UnownedStringSlice fileName, DocumentVersion* doc, LanguageServerProtocol::Range range, const InlayHintOptions& options);
 } // namespace Slang

--- a/source/slang/slang-language-server-inlay-hints.h
+++ b/source/slang/slang-language-server-inlay-hints.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../../slang.h"
+#include "../core/slang-basic.h"
+#include "slang-ast-all.h"
+#include "slang-syntax.h"
+#include "slang-compiler.h"
+#include "slang-workspace-version.h"
+
+namespace Slang
+{
+List<LanguageServerProtocol::InlayHint> getInlayHints(
+    Linkage* linkage, Module* module, UnownedStringSlice fileName, DocumentVersion* doc, LanguageServerProtocol::Range range);
+} // namespace Slang

--- a/source/slang/slang-language-server.cpp
+++ b/source/slang/slang-language-server.cpp
@@ -774,7 +774,7 @@ SlangResult LanguageServer::signatureHelp(
             ASTPrinter::OptionFlag::SimplifiedBuiltinType);
 
         printer.getStringBuilder() << "func (";
-        bool isFirst = false;
+        bool isFirst = true;
         for (auto param : funcType->paramTypes)
         {
             if (!isFirst)

--- a/source/slang/slang-language-server.h
+++ b/source/slang/slang-language-server.h
@@ -6,6 +6,7 @@
 
 #include "slang-workspace-version.h"
 #include "slang-language-server-completion.h"
+#include "slang-language-server-auto-format.h"
 
 namespace Slang
 {
@@ -59,6 +60,9 @@ struct Command
     Optional<LanguageServerProtocol::CompletionItem> completionResolveArgs;
     Optional<LanguageServerProtocol::DocumentSymbolParams> documentSymbolArgs;
     Optional<LanguageServerProtocol::InlayHintParams> inlayHintArgs;
+    Optional<LanguageServerProtocol::DocumentFormattingParams> formattingArgs;
+    Optional<LanguageServerProtocol::DocumentRangeFormattingParams> rangeFormattingArgs;
+    Optional<LanguageServerProtocol::DocumentOnTypeFormattingParams> onTypeFormattingArgs;
     Optional<LanguageServerProtocol::DidChangeConfigurationParams> changeConfigArgs;
     Optional<LanguageServerProtocol::SignatureHelpParams> signatureHelpArgs;
     Optional<LanguageServerProtocol::DefinitionParams> definitionArgs;
@@ -83,6 +87,7 @@ public:
     RefPtr<Workspace> m_workspace;
     Dictionary<String, String> m_lastPublishedDiagnostics;
     time_t m_lastDiagnosticUpdateTime = 0;
+    FormatOptions m_formatOptions;
     bool m_quit = false;
     List<LanguageServerProtocol::WorkspaceFolder> m_workspaceFolders;
 
@@ -111,6 +116,12 @@ public:
         const LanguageServerProtocol::DocumentSymbolParams& args, const JSONValue& responseId);
     SlangResult inlayHint(
         const LanguageServerProtocol::InlayHintParams& args, const JSONValue& responseId);
+    SlangResult formatting(
+        const LanguageServerProtocol::DocumentFormattingParams& args, const JSONValue& responseId);
+    SlangResult rangeFormatting(
+        const LanguageServerProtocol::DocumentRangeFormattingParams& args, const JSONValue& responseId);
+    SlangResult onTypeFormatting(
+        const LanguageServerProtocol::DocumentOnTypeFormattingParams& args, const JSONValue& responseId);
 
 private:
     SlangResult parseNextMessage();
@@ -121,6 +132,7 @@ private:
     void updateSearchPaths(const JSONValue& value);
     void updateSearchInWorkspace(const JSONValue& value);
     void updateCommitCharacters(const JSONValue& value);
+    void updateFormattingOptions(const JSONValue& clangFormatLoc, const JSONValue& clangFormatStyle);
 
     void sendConfigRequest();
     void registerCapability(const char* methodName);

--- a/source/slang/slang-language-server.h
+++ b/source/slang/slang-language-server.h
@@ -7,6 +7,7 @@
 #include "slang-workspace-version.h"
 #include "slang-language-server-completion.h"
 #include "slang-language-server-auto-format.h"
+#include "slang-language-server-inlay-hints.h"
 
 namespace Slang
 {
@@ -88,6 +89,7 @@ public:
     Dictionary<String, String> m_lastPublishedDiagnostics;
     time_t m_lastDiagnosticUpdateTime = 0;
     FormatOptions m_formatOptions;
+    Slang::InlayHintOptions m_inlayHintOptions;
     bool m_quit = false;
     List<LanguageServerProtocol::WorkspaceFolder> m_workspaceFolders;
 
@@ -133,6 +135,7 @@ private:
     void updateSearchInWorkspace(const JSONValue& value);
     void updateCommitCharacters(const JSONValue& value);
     void updateFormattingOptions(const JSONValue& clangFormatLoc, const JSONValue& clangFormatStyle);
+    void updateInlayHintOptions(const JSONValue& deducedTypes, const JSONValue& parameterNames);
 
     void sendConfigRequest();
     void registerCapability(const char* methodName);

--- a/source/slang/slang-language-server.h
+++ b/source/slang/slang-language-server.h
@@ -58,6 +58,7 @@ struct Command
     Optional<LanguageServerProtocol::CompletionParams> completionArgs;
     Optional<LanguageServerProtocol::CompletionItem> completionResolveArgs;
     Optional<LanguageServerProtocol::DocumentSymbolParams> documentSymbolArgs;
+    Optional<LanguageServerProtocol::InlayHintParams> inlayHintArgs;
     Optional<LanguageServerProtocol::DidChangeConfigurationParams> changeConfigArgs;
     Optional<LanguageServerProtocol::SignatureHelpParams> signatureHelpArgs;
     Optional<LanguageServerProtocol::DefinitionParams> definitionArgs;
@@ -108,6 +109,8 @@ public:
         const LanguageServerProtocol::SignatureHelpParams& args, const JSONValue& responseId);
     SlangResult documentSymbol(
         const LanguageServerProtocol::DocumentSymbolParams& args, const JSONValue& responseId);
+    SlangResult inlayHint(
+        const LanguageServerProtocol::InlayHintParams& args, const JSONValue& responseId);
 
 private:
     SlangResult parseNextMessage();

--- a/tests/language-server/member-completion-subscript.slang
+++ b/tests/language-server/member-completion-subscript.slang
@@ -1,0 +1,9 @@
+//TEST:LANG_SERVER:
+//COMPLETE:7,19 CONTAINS index___
+void m()
+{
+    float3 vArray[3];
+    let index___ = 1;
+    vArray[index__]
+    var c = 3;
+}

--- a/tests/language-server/member-completion-subscript.slang.expected.txt
+++ b/tests/language-server/member-completion-subscript.slang.expected.txt
@@ -1,0 +1,1 @@
+CONTAINS index___

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1716,6 +1716,23 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
 
     if (!_areResultsEqual(input.testOptions->type, expectedOutput, actualOutput))
     {
+        if (expectedOutput.startsWith("CONTAINS"))
+        {
+            List<UnownedStringSlice> words;
+            List<UnownedStringSlice> expectedLines;
+            StringUtil::calcLines(expectedOutput.getUnownedSlice(), expectedLines);
+            if (expectedLines.getCount() >= 1)
+            {
+                StringUtil::split(expectedLines[0], ' ', words);
+                if (words.getCount() >= 2)
+                {
+                    if (actualOutput.contains(words[1].trim()))
+                    {
+                        return result;
+                    }
+                }
+            }
+        }
         context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
         result = TestResult::Fail;
     }


### PR DESCRIPTION
- Add inlay hint feature that shows the parameter names for each call argument and auto deduced types for each `var` or `let` declaration.
- Fix type checking of JVPDiff operator to prevent crashing the language server
- Add signature help for higher order functions.

Result of inlay hints:
![image](https://user-images.githubusercontent.com/2652293/175789169-96d6806f-6afc-45e6-8d4c-44bb25b94e8d.png)
