### PR TITLE
Native call marshalling for ComPtr parameters and return values.

### DIFF
--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -522,6 +522,14 @@ SlangResult CPPSourceEmitter::calcTypeName(IRType* type, CodeGenTarget target, S
             out << "*";
             return SLANG_OK;
         }
+        case kIROp_NativePtrType:
+        case kIROp_PtrType:
+        {
+            auto elementType = (IRType*)type->getOperand(0);
+            SLANG_RETURN_ON_FAIL(calcTypeName(elementType, target, out));
+            out << "*";
+            return SLANG_OK;
+        }
         case kIROp_RTTIType:
         {
             out << "TypeInfo";

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -112,6 +112,8 @@ INST(Nop, nop, 0, 0)
 
     // A ComPtr<T> type is treated as a opaque type that represents a reference-counted handle to a COM object.
     INST(ComPtrType, ComPtr, 1, 0)
+    // A NativePtr<T> type represents a native pointer to a managed resource.
+    INST(NativePtrType, NativePtr, 1, 0)
 
     /* SamplerStateTypeBase */
         INST(SamplerStateType, SamplerState, 0, 0)
@@ -313,6 +315,18 @@ INST(getNativeStr, getNativeStr, 1, 0)
 
 // Make String from a NativeString.
 INST(makeString, makeString, 1, 0)
+
+// Get a native ptr from a ComPtr or RefPtr
+INST(GetNativePtr, getNativePtr, 1, 0)
+
+// Get a write reference to a managed ptr var (operand must be Ptr<ComPtr<T>> or Ptr<RefPtr<T>>).
+INST(GetManagedPtrWriteRef, getManagedPtrWriteRef, 1, 0)
+
+// Attach a managedPtr var to a NativePtr without changing its ref count.
+INST(ManagedPtrAttach, ManagedPtrAttach, 1, 0)
+
+// Attach a managedPtr var to a NativePtr without changing its ref count.
+INST(ManagedPtrDetach, ManagedPtrDetach, 1, 0)
 
 // "Subscript" an image at a pixel coordinate to get pointer
 INST(ImageSubscript, imageSubscript, 2, 0)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -1425,6 +1425,18 @@ struct IRGetElementPtr : IRInst
     IRInst* getIndex() { return getOperand(1); }
 };
 
+struct IRGetNativePtr : IRInst
+{
+    IR_LEAF_ISA(GetNativePtr);
+    IRInst* getElementType() { return getOperand(0); }
+};
+
+struct IRGetManagedPtrWriteRef : IRInst
+{
+    IR_LEAF_ISA(GetManagedPtrWriteRef);
+    IRInst* getPtrToManagedPtr() { return getOperand(0); }
+};
+
 struct IRGetAddress : IRInst
 {
     IR_LEAF_ISA(getAddr);
@@ -2175,6 +2187,7 @@ public:
     IRBasicType* getCharType();
     IRStringType* getStringType();
     IRNativeStringType* getNativeStringType();
+    IRNativePtrType* getNativePtrType(IRType* valueType);
 
     IRType* getCapabilitySetType();
 
@@ -2505,6 +2518,14 @@ public:
 
         return emitWrapExistential(type, value, slotArgCount, slotArgVals.getBuffer());
     }
+
+    IRInst* emitManagedPtrAttach(IRInst* managedPtrVar, IRInst* value);
+
+    IRInst* emitManagedPtrDetach(IRInst* managedPtrVar);
+
+    IRInst* emitGetNativePtr(IRInst* value);
+
+    IRInst* emitGetManagedPtrWriteRef(IRInst* ptrToManagedPtr);
 
     IRInst* emitGpuForeach(List<IRInst*> args);
 

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1300,6 +1300,7 @@ SIMPLE_IR_TYPE(OutType, OutTypeBase)
 SIMPLE_IR_TYPE(InOutType, OutTypeBase)
 
 SIMPLE_IR_TYPE(ComPtrType, Type)
+SIMPLE_IR_TYPE(NativePtrType, Type)
 
 struct IRPseudoPtrType : public IRPtrTypeBase
 {


### PR DESCRIPTION
This change implements marshalling between `ComPtr` and native pointers when making COM method calls.

- Add an `IRNativePtr` type to represent a native pointer of a ref-counted resource.
- Add `IRManagedPtrGetWriteRef`, `IRManagedPtrAttach`, `IRManagedPtrDetach` instructions.
- Add `IRGetNativePtr` instruction.