### PR TITLE
Language Server: Auto format bug fixes.

### DIFF
--- a/source/slang/slang-language-server-auto-format.cpp
+++ b/source/slang/slang-language-server-auto-format.cpp
@@ -202,7 +202,24 @@ List<Edit> formatSource(UnownedStringSlice text, Index lineStart, Index lineEnd,
         // Never allow clang-format to put the semicolon after `}` in its own line.
         if (edt.offset < text.getLength() && edt.length == 0 && text[edt.offset] == ';' && edt.offset >0 && text[edt.offset - 1] == '}')
             continue;
-
+        // If need to preserve line break, turn all edits with a line break into a space.
+        if (options.behavior == FormatBehavior::PreserveLineBreak)
+        {
+            auto originalText = text.subString(edt.offset, edt.length);
+            bool originalHasLineBreak = originalText.indexOf('\n') != -1;
+            bool newHasLineBreak = edt.text.indexOf('\n') != -1;
+            if (originalHasLineBreak == newHasLineBreak)
+            {
+            }
+            else if (!originalHasLineBreak && newHasLineBreak)
+            {
+                edt.text = " ";
+            }
+            else
+            {
+                continue;
+            }
+        }
         edits.add(edt);
     }
     return edits;

--- a/source/slang/slang-language-server-auto-format.h
+++ b/source/slang/slang-language-server-auto-format.h
@@ -13,10 +13,19 @@ struct Edit
     String text;
 };
 
+enum class FormatBehavior
+{
+    Standard,
+    PreserveLineBreak,
+};
+
 struct FormatOptions
 {
     String clangFormatLocation;
     String style = "{BasedOnStyle: Microsoft}";
+    bool allowLineBreakInOnTypeFormatting = false;
+    bool allowLineBreakInRangeFormatting = false;
+    FormatBehavior behavior = FormatBehavior::Standard;
 };
 
 String findClangFormatTool();

--- a/source/slang/slang-language-server-completion.cpp
+++ b/source/slang/slang-language-server-completion.cpp
@@ -107,18 +107,15 @@ List<LanguageServerProtocol::TextEditCompletionItem> CompletionContext::gatherFi
     Index sectionEnd,
     char closingChar)
 {
-    Index parentUpLevel = 0;
     auto realPrefix = prefixPath.getUnownedSlice();
     while (realPrefix.startsWith(".."))
     {
         realPrefix = realPrefix.tail(2);
-        if (realPrefix.startsWith("."))
+        if (realPrefix.startsWith("/") || realPrefix.startsWith("\\"))
         {
             realPrefix = realPrefix.tail(1);
         }
-        parentUpLevel++;
     }
-    auto parentPrefix = prefixPath.getUnownedSlice().head(parentUpLevel * 3);
 
     struct FileEnumerationContext
     {

--- a/source/slang/slang-language-server-completion.cpp
+++ b/source/slang/slang-language-server-completion.cpp
@@ -107,6 +107,19 @@ List<LanguageServerProtocol::TextEditCompletionItem> CompletionContext::gatherFi
     Index sectionEnd,
     char closingChar)
 {
+    Index parentUpLevel = 0;
+    auto realPrefix = prefixPath.getUnownedSlice();
+    while (realPrefix.startsWith(".."))
+    {
+        realPrefix = realPrefix.tail(2);
+        if (realPrefix.startsWith("."))
+        {
+            realPrefix = realPrefix.tail(1);
+        }
+        parentUpLevel++;
+    }
+    auto parentPrefix = prefixPath.getUnownedSlice().head(parentUpLevel * 3);
+
     struct FileEnumerationContext
     {
         List<LanguageServerProtocol::TextEditCompletionItem> items;
@@ -132,7 +145,8 @@ List<LanguageServerProtocol::TextEditCompletionItem> CompletionContext::gatherFi
     auto addCandidate = [&](const String& path)
     {
         context.path = path;
-        if (path.getUnownedSlice().endsWithCaseInsensitive(prefixPath.getUnownedSlice()))
+        Path::getCanonical(context.path, context.path);
+        if (path.getUnownedSlice().endsWithCaseInsensitive(realPrefix))
         {
             OSFileSystem::getExtSingleton()->enumeratePathContents(
                 path.getBuffer(),
@@ -253,12 +267,21 @@ List<LanguageServerProtocol::TextEditCompletionItem> CompletionContext::gatherFi
         }
     }
 
-    if (commitCharacterBehavior != CommitCharacterBehavior::Disabled && !isIncomplete)
+    if (!isIncomplete)
     {
-        for (auto& item : context.items)
+        bool useCommitChars = translateModuleName && (commitCharacterBehavior != CommitCharacterBehavior::Disabled);
+        if (useCommitChars)
         {
-            for (auto ch : getCommitChars())
-                item.commitCharacters.add(ch);
+            if (translateModuleName)
+            {
+                for (auto& item : context.items)
+                {
+                    for (auto ch : getCommitChars())
+                    {
+                        item.commitCharacters.add(ch);
+                    }
+                }
+            }
         }
     }
     return context.items;

--- a/source/slang/slang-language-server.h
+++ b/source/slang/slang-language-server.h
@@ -141,7 +141,7 @@ private:
     void updateSearchPaths(const JSONValue& value);
     void updateSearchInWorkspace(const JSONValue& value);
     void updateCommitCharacters(const JSONValue& value);
-    void updateFormattingOptions(const JSONValue& clangFormatLoc, const JSONValue& clangFormatStyle);
+    void updateFormattingOptions(const JSONValue& clangFormatLoc, const JSONValue& clangFormatStyle, const JSONValue& allowLineBreakOnType, const JSONValue& allowLineBreakInRange);
     void updateInlayHintOptions(const JSONValue& deducedTypes, const JSONValue& parameterNames);
     void updateTraceOptions(const JSONValue& value);
 


### PR DESCRIPTION
This changes fixes several undesired behaviors reported by user.

Add option to prevent auto formatting to make any line break changes (default is not making line-break changes on auto-format).
Prevent formatting code (and therefore potentially changing the indent) after the cursor when pasting.
Fix auto indent adjustment when typing "{".
Prevent "." from commiting auto completion changes in an include path.
Fix auto complete suggestions after typing "../" in include path.

