### PR TITLE
Basic pointer usages.

### DIFF
--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -471,6 +471,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClCompile Include="..\..\..\source\slang\slang-ast-print.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ast-reflect.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ast-substitutions.cpp" />
+    <ClCompile Include="..\..\..\source\slang\slang-ast-support-types.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ast-type.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ast-val.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-capability.cpp" />

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -506,6 +506,9 @@
     <ClCompile Include="..\..\..\source\slang\slang-ast-substitutions.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\source\slang\slang-ast-support-types.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-ast-type.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/examples/heterogeneous-hello-world/main.slang
+++ b/examples/heterogeneous-hello-world/main.slang
@@ -4,9 +4,9 @@ __target_intrinsic(cpp, "printf(\"%s\", ($0).getBuffer())")
 public void writeln(String text);
 
 [DllImport("User32")]
-int MessageBoxA(Ptr<void> hwnd, String text, String caption, uint flags);
+int MessageBoxA(void* hwnd, String text, String caption, uint flags);
 
-[COM]
+[COM("111702C2-2FD7-46F9-A318-DCCEEC96357E")]
 interface IObject
 {
     int getValue(int value) throws int;
@@ -17,9 +17,8 @@ IObject createObject();
 
 public __extern_cpp void main() throws int
 {
-    //writeln("hello world");
-    //MessageBoxA(nullptr, "hello world!", "example", 0);
-
+    writeln("hello world");
+    MessageBoxA(nullptr, "hello world!", "example", 0);
     IObject object = createObject();
 
     int rs = try object.getValue(2);

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -358,7 +358,97 @@ __magic_type(PtrType)
 __intrinsic_type($(kIROp_PtrType))
 struct Ptr
 {
+    __intrinsic_op($(kIROp_Load))
+    static T __load(Ptr<T> ptr);
+
+    __intrinsic_op($(kIROp_Store))
+    static void __store(Ptr<T> ptr, T val);
+
+    __intrinsic_op($(kIROp_getElementPtr))
+    static Ptr<T> __getElementPtr(Ptr<T> ptr, int index);
+
+    __intrinsic_op($(kIROp_Neq))
+    __generic<U:__BuiltinArithmeticType>
+    static bool __neq(Ptr<T> ptr, U val);
+
+    __intrinsic_op($(kIROp_Eql))
+    __generic<U:__BuiltinArithmeticType>
+    static bool __eql(Ptr<T> ptr, U val);
+
+    __generic<U>
+    __intrinsic_op($(kIROp_BitCast))
+    __init(Ptr<U> ptr);
+
+    __intrinsic_op($(kIROp_BitCast))
+    __init(uint64_t val);
+
+    __intrinsic_op($(kIROp_BitCast))
+    __init(int64_t val);
+
+    __subscript(int index) -> T
+    {
+        [__unsafeForceInlineEarly]
+        get
+        {
+            return __load(__getElementPtr(this, index));
+        }
+
+        [__unsafeForceInlineEarly]
+        set(T newValue)
+        {
+            __store(__getElementPtr(this, index), newValue);
+        }
+
+        __intrinsic_op($(kIROp_getElementPtr))
+        ref;
+    }
 };
+
+__generic<T>
+__intrinsic_op($(kIROp_Less))
+bool operator<(Ptr<T> p1, Ptr<T> p2);
+
+__generic<T>
+__intrinsic_op($(kIROp_Leq))
+bool operator<=(Ptr<T> p1, Ptr<T> p2);
+
+__generic<T>
+__intrinsic_op($(kIROp_Greater))
+bool operator>(Ptr<T> p1, Ptr<T> p2);
+
+__generic<T>
+__intrinsic_op($(kIROp_Geq))
+bool operator>=(Ptr<T> p1, Ptr<T> p2);
+
+__generic<T>
+__intrinsic_op($(kIROp_Neq))
+bool operator!=(Ptr<T> p1, Ptr<T> p2);
+
+__generic<T>
+__intrinsic_op($(kIROp_Eql))
+bool operator==(Ptr<T> p1, Ptr<T> p2);
+
+extension bool
+{
+    __generic<T>
+    __implicit_conversion($(kConversionCost_PtrToBool))
+    __intrinsic_op($(kIROp_CastPtrToBool))
+    __init(Ptr<T> ptr);
+}
+
+extension uint64_t
+{
+    __generic<T>
+    __intrinsic_op($(kIROp_Construct))
+    __init(Ptr<T> ptr);
+}
+
+extension int64_t
+{
+    __generic<T>
+    __intrinsic_op($(kIROp_Construct))
+    __init(Ptr<T> ptr);
+}
 
 __generic<T>
 __magic_type(OutType)
@@ -1620,6 +1710,25 @@ for (auto op : intrinsicUnaryOps)
 
 }}}}
 
+__generic<T>
+__intrinsic_op(0)
+__prefix Ref<T> operator*(Ptr<T> value);
+
+__generic<T>
+__intrinsic_op(0)
+__prefix Ptr<T> operator&(__ref T value);
+
+__generic<T>
+__intrinsic_op($(kIROp_getElementPtr))
+Ptr<T> operator+(Ptr<T> value, int64_t offset);
+
+__generic<T>
+[__unsafeForceInlineEarly]
+Ptr<T> operator-(Ptr<T> value, int64_t offset)
+{
+    return Ptr<T>.__getElementPtr(value, -offset);
+}
+
 __generic<T : __BuiltinArithmeticType>
 [__unsafeForceInlineEarly]
 __prefix T operator+(T value)
@@ -1678,6 +1787,12 @@ __generic<T : __BuiltinArithmeticType, let R : int, let C : int>
 [__unsafeForceInlineEarly]
 matrix<T,R,C> operator$(op.name)(in out matrix<T,R,C> value)
 {$(fixity.bodyPrefix) value = value $(op.binOp) T(1); return $(fixity.returnVal); }
+
+$(fixity.qual)
+__generic<T>
+[__unsafeForceInlineEarly]
+Ptr<T> operator$(op.name)(in out Ptr<T> value)
+{$(fixity.bodyPrefix) value = value $(op.binOp) 1; return $(fixity.returnVal); }
 
 ${{{{
 }

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -374,6 +374,13 @@ class ExtractExistentialValueExpr: public Expr
     DeclRef<VarDeclBase> declRef;
 };
 
+class OpenRefExpr : public Expr
+{
+    SLANG_AST_CLASS(OpenRefExpr)
+
+    Expr* innerExpr = nullptr;
+};
+
     /// An expression of the form `__jvp(fn)` to access the 
     /// forward-mode derivative version of the function `fn`
     ///
@@ -421,6 +428,14 @@ class ModifiedTypeExpr : public Expr
     SLANG_AST_CLASS(ModifiedTypeExpr);
 
     Modifiers modifiers;
+    TypeExp base;
+};
+
+    /// A type expression that rrepresents a pointer type, e.g. T*
+class PointerTypeExpr : public Expr
+{
+    SLANG_AST_CLASS(PointerTypeExpr)
+
     TypeExp base;
 };
 

--- a/source/slang/slang-ast-support-types.cpp
+++ b/source/slang/slang-ast-support-types.cpp
@@ -1,0 +1,13 @@
+#include "slang-ast-support-types.h"
+#include "slang-ast-base.h"
+#include "slang-ast-type.h"
+
+Slang::QualType::QualType(Type* type)
+    : type(type)
+    , isLeftValue(false)
+{
+    if (as<RefType>(type))
+    {
+        isLeftValue = true;
+    }
+}

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -98,6 +98,9 @@ namespace Slang
         // Cost of converting an integer to a floating-point type
         kConversionCost_IntegerToFloatConversion = 400,
 
+        // Cost of converting a pointer to bool
+        kConversionCost_PtrToBool = 400,
+
         // Default case (usable for user-defined conversions)
         kConversionCost_Default = 500,
 
@@ -472,10 +475,7 @@ namespace Slang
             : isLeftValue(false)
         {}
 
-        QualType(Type* type)
-            : type(type)
-            , isLeftValue(false)
-        {}
+        QualType(Type* type);
 
         Type* Ptr() { return type; }
 

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -639,6 +639,11 @@ namespace Slang
             return true;
         }
 
+        if (auto refType = as<RefType>(toType))
+        {
+            return _coerce(refType->getValueType(), outToExpr, fromType, fromExpr, outCost);
+        }
+
         // If both are string types we assume they are convertable in both directions
         if (as<StringTypeBase>(fromType) && as<StringTypeBase>(toType))
         {

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -499,6 +499,10 @@ namespace Slang
             ///
         Expr* maybeOpenExistential(Expr* expr);
 
+            /// If `expr` has Ref<T> Type, convert it into an l-value expr that has T type.
+        Expr* maybeOpenRef(Expr* expr);
+
+
         Expr* ConstructDeclRefExpr(
             DeclRef<Decl>   declRef,
             Expr*    baseExpr,
@@ -1722,6 +1726,7 @@ namespace Slang
         CASE(ModifierCastExpr)
         CASE(LetExpr)
         CASE(ExtractExistentialValueExpr)
+        CASE(OpenRefExpr)
 
     #undef CASE
 
@@ -1734,12 +1739,14 @@ namespace Slang
         Expr* visitThisExpr(ThisExpr* expr);
         Expr* visitThisTypeExpr(ThisTypeExpr* expr);
         Expr* visitAndTypeExpr(AndTypeExpr* expr);
+        Expr* visitPointerTypeExpr(PointerTypeExpr* expr);
         Expr* visitModifiedTypeExpr(ModifiedTypeExpr* expr);
 
         Expr* visitJVPDifferentiateExpr(JVPDifferentiateExpr* expr);
 
             /// Perform semantic checking on a `modifier` that is being applied to the given `type`
         Val* checkTypeModifier(Modifier* modifier, Type* type);
+
     };
 
     struct SemanticsStmtVisitor

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1438,6 +1438,11 @@ namespace Slang
 
         for (auto& arg : expr->arguments)
         {
+            arg = maybeOpenRef(arg);
+        }
+
+        for (auto& arg : expr->arguments)
+        {
             arg = maybeOpenExistential(arg);
         }
 

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -1943,7 +1943,10 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
                 auto rightSidePrec = rightSide(outerPrec, info);
                 auto postfixInfo = getInfo(EmitOp::Postfix);
                 bool rightSideNeedClose = maybeEmitParens(rightSidePrec, postfixInfo);
-                emitOperand(inst->getOperand(0), leftSide(rightSidePrec, postfixInfo));
+                if (isPtrToArrayType(inst->getOperand(0)->getDataType()))
+                    emitDereferenceOperand(inst->getOperand(0), leftSide(rightSidePrec, postfixInfo));
+                else
+                    emitOperand(inst->getOperand(0), leftSide(rightSidePrec, postfixInfo));
                 m_writer->emit("[");
                 emitOperand(inst->getOperand(1), getInfo(EmitOp::General));
                 m_writer->emit("]");

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -1943,7 +1943,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
                 auto rightSidePrec = rightSide(outerPrec, info);
                 auto postfixInfo = getInfo(EmitOp::Postfix);
                 bool rightSideNeedClose = maybeEmitParens(rightSidePrec, postfixInfo);
-                emitDereferenceOperand(inst->getOperand(0), leftSide(rightSidePrec, postfixInfo));
+                emitOperand(inst->getOperand(0), leftSide(rightSidePrec, postfixInfo));
                 m_writer->emit("[");
                 emitOperand(inst->getOperand(1), getInfo(EmitOp::General));
                 m_writer->emit("]");
@@ -2061,7 +2061,6 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
             m_writer->emit(")");
         }
         break;
-
     case kIROp_GlobalConstant:
     case kIROp_GetValueFromBoundInterface:
         emitOperand(inst->getOperand(0), outerPrec);

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -738,7 +738,7 @@ INST(ExtractTaggedUnionPayload,         extractTaggedUnionPayload,  1, 0)
 
 INST(BitCast,                           bitCast,                    1, 0)
 INST(Reinterpret,                       reinterpret,                1, 0)
-
+INST(CastPtrToBool, CastPtrToBool, 1, 0)
 INST(JVPDifferentiate,                   jvpDifferentiate,            1, 0)
 
 // Converts other resources (such as ByteAddressBuffer) to the equivalent StructuredBuffer

--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -85,6 +85,17 @@ struct PeepholeContext : InstPassBase
                 }
             }
             break;
+        case kIROp_CastPtrToBool:
+            {
+                auto ptr = inst->getOperand(0);
+                IRBuilder builder(&sharedBuilderStorage);
+                builder.setInsertBefore(inst);
+                auto neq = builder.emitNeq(ptr, builder.getIntValue(builder.getIntType(), 0));
+                inst->replaceUsesWith(neq);
+                inst->removeAndDeallocate();
+                changed = true;
+            }
+            break;
         default:
             break;
         }

--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -90,7 +90,7 @@ struct PeepholeContext : InstPassBase
                 auto ptr = inst->getOperand(0);
                 IRBuilder builder(&sharedBuilderStorage);
                 builder.setInsertBefore(inst);
-                auto neq = builder.emitNeq(ptr, builder.getIntValue(builder.getIntType(), 0));
+                auto neq = builder.emitNeq(ptr, builder.getPtrValue(nullptr));
                 inst->replaceUsesWith(neq);
                 inst->removeAndDeallocate();
                 changed = true;

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -38,4 +38,9 @@ bool isPtrToClassType(IRInst* type)
     return isPointerOfType(type, kIROp_ClassType);
 }
 
+bool isPtrToArrayType(IRInst* type)
+{
+    return isPointerOfType(type, kIROp_ArrayType) || isPointerOfType(type, kIROp_UnsizedArrayType);
+}
+
 }

--- a/source/slang/slang-ir-util.h
+++ b/source/slang/slang-ir-util.h
@@ -11,6 +11,8 @@ namespace Slang
 
 bool isPtrToClassType(IRInst* type);
 
+bool isPtrToArrayType(IRInst* type);
+
 // True if ptrType is a pointer type to elementType
 bool isPointerOfType(IRInst* ptrType, IRInst* elementType);
 

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -2015,6 +2015,17 @@ namespace Slang
         memberExpr->name = expectIdentifier(parser).name;
         return memberExpr;
     }
+    static Expr* parseStaticMemberType(Parser* parser, Expr* base, SourceLoc opLoc)
+    {
+        // When called the :: or . have been consumed, so don't need to consume here.
+
+        StaticMemberExpr* memberExpr = parser->astBuilder->create<StaticMemberExpr>();
+        memberExpr->memberOperatorLoc = opLoc;
+        parser->FillPosition(memberExpr);
+        memberExpr->baseExpression = base;
+        memberExpr->name = expectIdentifier(parser).name;
+        return memberExpr;
+    }
 
     // Parse option `[]` braces after a type expression, that indicate an array type
     static Expr* parsePostfixTypeSuffix(
@@ -2323,7 +2334,7 @@ namespace Slang
             case TokenType::Scope:
                 {
                     auto opToken = parser->ReadToken(TokenType::Scope);
-                    typeExpr = parseMemberType(parser, typeExpr, opToken.loc);
+                    typeExpr = parseStaticMemberType(parser, typeExpr, opToken.loc);
                     break;
                 }
             case TokenType::Dot:

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -5331,14 +5331,14 @@ namespace Slang
         return false;
     }
 
-    static bool lookAheadAfterTypeExp(Parser* parser, Expr* &outExpr, TokenType tokenTypeAfter)
+    static bool tryParseExpression(Parser* parser, Expr* &outExpr, TokenType tokenTypeAfter)
     {
         auto cursor = parser->tokenReader.getCursor();
         auto isRecovering = parser->isRecovering;
         auto oldSink = parser->sink;
         DiagnosticSink newSink(parser->sink->getSourceManager(), nullptr);
         parser->sink = &newSink;
-        outExpr = parser->ParseType();
+        outExpr = parser->ParseExpression();
         parser->sink = oldSink;
         parser->isRecovering = isRecovering;
         if (outExpr && newSink.getErrorCount() == 0 && parser->LookAheadToken(tokenTypeAfter))
@@ -5389,9 +5389,9 @@ namespace Slang
                     // as an expression.
                     
                     Expr* base = nullptr;
-                    if (!lookAheadAfterTypeExp(parser, base, TokenType::RParent))
+                    if (!tryParseExpression(parser, base, TokenType::RParent))
                     {
-                        base = parser->ParseExpression();
+                        base = parser->ParseType();
                     }
 
                     parser->ReadToken(TokenType::RParent);

--- a/tests/cpu-program/pointer-basics.slang
+++ b/tests/cpu-program/pointer-basics.slang
@@ -1,0 +1,26 @@
+//TEST:EXECUTABLE:
+__target_intrinsic(cpp, "printf(\"%s\\n\", ($0).getBuffer())")
+void writeln(String text);
+
+public __extern_cpp int main()
+{
+    uint2 value;
+    int *pValue = (int*)&value;
+    *pValue = 1;
+    (*pValue)++;
+    ++pValue[0];
+    ++pValue;
+    *pValue = 1;
+    pValue = (int *)&value;
+    int64_t ptrVal = int64_t(pValue);
+    pValue = (int *)ptrVal;
+    if (pValue
+        && pValue != nullptr
+        && ptrVal != 0
+        && value[0] == 3
+        && pValue[1] == 1)
+        writeln("Success");
+    else
+        writeln("Fail");
+    return 0;
+}

--- a/tests/cpu-program/pointer-basics.slang.expected
+++ b/tests/cpu-program/pointer-basics.slang.expected
@@ -1,0 +1,6 @@
+result code = 0
+standard error = {
+}
+standard output = {
+Success
+}


### PR DESCRIPTION
This PR adds parsing, checking and basic operators for pointer types.

Now it is valid to use `*` in c-style declarator to define pointer-typed variables.

Pointers can be compared, cast explicitly to and from uint64/int64 and implicitly to bool.

Pointers can be dereferenced with the `*` operator which results in a `RefType<T>` that can be "opened" to an l-value `T` at assignments and calls.

The `&` operator can be used on l-values to return a pointer.