### PR TITLE
Implicit pointer dereference when using member operator.

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -358,23 +358,6 @@ __magic_type(PtrType)
 __intrinsic_type($(kIROp_PtrType))
 struct Ptr
 {
-    __intrinsic_op($(kIROp_Load))
-    static T __load(Ptr<T> ptr);
-
-    __intrinsic_op($(kIROp_Store))
-    static void __store(Ptr<T> ptr, T val);
-
-    __intrinsic_op($(kIROp_getElementPtr))
-    static Ptr<T> __getElementPtr(Ptr<T> ptr, int index);
-
-    __intrinsic_op($(kIROp_Neq))
-    __generic<U:__BuiltinArithmeticType>
-    static bool __neq(Ptr<T> ptr, U val);
-
-    __intrinsic_op($(kIROp_Eql))
-    __generic<U:__BuiltinArithmeticType>
-    static bool __eql(Ptr<T> ptr, U val);
-
     __generic<U>
     __intrinsic_op($(kIROp_BitCast))
     __init(Ptr<U> ptr);
@@ -403,6 +386,15 @@ struct Ptr
         ref;
     }
 };
+
+__intrinsic_op($(kIROp_Load))
+T __load<T>(Ptr<T> ptr);
+
+__intrinsic_op($(kIROp_Store))
+void __store<T>(Ptr<T> ptr, T val);
+
+__intrinsic_op($(kIROp_getElementPtr))
+Ptr<T> __getElementPtr<T>(Ptr<T> ptr, int index);
 
 __generic<T>
 __intrinsic_op($(kIROp_Less))
@@ -1726,7 +1718,7 @@ __generic<T>
 [__unsafeForceInlineEarly]
 Ptr<T> operator-(Ptr<T> value, int64_t offset)
 {
-    return Ptr<T>.__getElementPtr(value, -offset);
+    return __getElementPtr(value, -offset);
 }
 
 __generic<T : __BuiltinArithmeticType>

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -1121,6 +1121,7 @@ namespace Slang
         None = 0,
         IgnoreBaseInterfaces = 1 << 0,
         Completion = 1 << 1, ///< Lookup all applicable decls for code completion suggestions
+        NoDeref = 1 << 2,
     };
 
     class SerialRefObject;

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -382,15 +382,15 @@ namespace Slang
         Expr*    base,
         SourceLoc       loc)
     {
-        auto ptrLikeType = as<PointerLikeType>(base->type);
-        SLANG_ASSERT(ptrLikeType);
+        auto elementType = getPointedToTypeIfCanImplicitDeref(base->type);
+        SLANG_ASSERT(elementType);
 
         auto derefExpr = m_astBuilder->create<DerefExpr>();
         derefExpr->loc = loc;
         derefExpr->base = base;
-        derefExpr->type = QualType(ptrLikeType->elementType);
+        derefExpr->type = QualType(elementType);
 
-        // TODO(tfoley): handle l-value status here
+        derefExpr->type.isLeftValue = base->type.isLeftValue;
 
         return derefExpr;
     }

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -1258,7 +1258,9 @@ namespace Slang
                 m_astBuilder,
                 this,
                 name,
-                baseType);
+                baseType,
+                LookupMask::Default,
+                LookupOptions::NoDeref);
             if (!lookupResult.isValid())
             {
                 goto fail;

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -21,6 +21,10 @@ namespace Slang
         TypeExp         typeExp,
         DiagnosticSink* sink);
 
+        /// Get the element type if `type` is Ptr or PtrLike type, otherwise returns null.
+        /// Note: this currently does not include PtrTypeBase.
+    Type* getPointedToTypeIfCanImplicitDeref(Type* type);
+
     // A flat representation of basic types (scalars, vectors and matrices)
     // that can be used as lookup key in caches
     enum class BasicTypeKey : uint16_t

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1242,7 +1242,9 @@ namespace Slang
             m_astBuilder,
             this,
             getName("$init"),
-            type);
+            type,
+            LookupMask::Default,
+            LookupOptions::NoDeref);
 
         AddOverloadCandidates(initializers, context);
     }

--- a/source/slang/slang-check-type.cpp
+++ b/source/slang/slang-check-type.cpp
@@ -22,6 +22,19 @@ namespace Slang
         return typeOut.type;
     }
 
+    Type* getPointedToTypeIfCanImplicitDeref(Type* type)
+    {
+        if (auto ptrLike = as<PointerLikeType>(type))
+        {
+            return ptrLike->getElementType();
+        }
+        else if (auto ptrType = as<PtrType>(type))
+        {
+            return ptrType->getValueType();
+        }
+        return nullptr;
+    }
+
     Expr* SemanticsVisitor::TranslateTypeNodeImpl(Expr* node)
     {
         if (!node) return nullptr;

--- a/source/slang/slang-lookup.cpp
+++ b/source/slang/slang-lookup.cpp
@@ -607,7 +607,7 @@ static void _lookUpMembersInSuperTypeImpl(
 {
     // If the type was pointer-like, then dereference it
     // automatically here.
-    if (auto pointerLikeType = as<PointerLikeType>(superType))
+    if (auto pointerElementType = getPointedToTypeIfCanImplicitDeref(superType))
     {
         // Need to leave a breadcrumb to indicate that we
         // did an implicit dereference here
@@ -618,7 +618,7 @@ static void _lookUpMembersInSuperTypeImpl(
         // Recursively perform lookup on the result of deref
         _lookUpMembersInType(
             astBuilder, 
-            name, pointerLikeType->elementType, request, ioResult, &derefBreacrumb);
+            name, pointerElementType, request, ioResult, &derefBreacrumb);
         return;
     }
 

--- a/source/slang/slang-lookup.cpp
+++ b/source/slang/slang-lookup.cpp
@@ -607,19 +607,22 @@ static void _lookUpMembersInSuperTypeImpl(
 {
     // If the type was pointer-like, then dereference it
     // automatically here.
-    if (auto pointerElementType = getPointedToTypeIfCanImplicitDeref(superType))
+    if (((uint32_t)request.options & (uint32_t)LookupOptions::NoDeref) == 0)
     {
-        // Need to leave a breadcrumb to indicate that we
-        // did an implicit dereference here
-        BreadcrumbInfo derefBreacrumb;
-        derefBreacrumb.kind = LookupResultItem::Breadcrumb::Kind::Deref;
-        derefBreacrumb.prev = inBreadcrumbs;
+        if (auto pointerElementType = getPointedToTypeIfCanImplicitDeref(superType))
+        {
+            // Need to leave a breadcrumb to indicate that we
+            // did an implicit dereference here
+            BreadcrumbInfo derefBreacrumb;
+            derefBreacrumb.kind = LookupResultItem::Breadcrumb::Kind::Deref;
+            derefBreacrumb.prev = inBreadcrumbs;
 
-        // Recursively perform lookup on the result of deref
-        _lookUpMembersInType(
-            astBuilder, 
-            name, pointerElementType, request, ioResult, &derefBreacrumb);
-        return;
+            // Recursively perform lookup on the result of deref
+            _lookUpMembersInType(
+                astBuilder,
+                name, pointerElementType, request, ioResult, &derefBreacrumb);
+            return;
+        }
     }
 
     // Default case: no dereference needed

--- a/tests/cpu-program/pointer-deref.slang
+++ b/tests/cpu-program/pointer-deref.slang
@@ -1,0 +1,33 @@
+//TEST:EXECUTABLE:
+__target_intrinsic(cpp, "printf(\"%s\\n\", ($0).getBuffer())")
+void writeln(String text);
+
+struct SubRecord
+{
+    int field2;
+    float field3;
+}
+
+struct Record
+{
+    int field;
+    SubRecord sub;
+}
+
+public __extern_cpp int main()
+{
+    Record rec;
+    Record *pRec = &rec;
+    pRec.field = 1;
+    pRec.sub.field2 = 2;
+    pRec.sub.field3 = 3.0f;
+    if (rec.field == 1 && rec.sub.field2 == 2 && pRec.sub.field3 == 3.0f)
+    {
+        writeln("success");
+    }
+    else
+    {
+        writeln("fail");
+    }
+    return 0;
+}

--- a/tests/cpu-program/pointer-deref.slang.expected
+++ b/tests/cpu-program/pointer-deref.slang.expected
@@ -1,0 +1,6 @@
+result code = 0
+standard error = {
+}
+standard output = {
+success
+}


### PR DESCRIPTION
This PR makes it possible to use `.` operator on a pointer that implciitly dereferences the pointer to access the members.