### PR TITLE
Make Optional<PointerType> lower to PointerType instead of a struct.

### DIFF
--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -338,6 +338,10 @@ DIAGNOSTIC(32003, Error, unexpectedEnumTagExpr,     "unexpected form for 'enum' 
 // 303xx: interfaces and associated types
 DIAGNOSTIC(30300, Error, assocTypeInInterfaceOnly, "'associatedtype' can only be defined in an 'interface'.")
 DIAGNOSTIC(30301, Error, globalGenParamInGlobalScopeOnly, "'type_param' can only be defined global scope.")
+
+// Interop
+DIAGNOSTIC(30400, Error, cannotDefinePtrTypeToManagedResource, "pointer to a managed resource is invalid, use `NativeRef<T>` instead")
+
 // TODO: need to assign numbers to all these extra diagnostics...
 DIAGNOSTIC(39999, Fatal, cyclicReference, "cyclic reference '$0'.")
 DIAGNOSTIC(39999, Error, localVariableUsedBeforeDeclared, "local variable '$0' is being used before its declaration.")

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -212,22 +212,6 @@ Result linkAndOptimizeIR(
     // un-specialized IR.
     dumpIRIfEnabled(codeGenContext, irModule);
 
-    switch (target)
-    {
-        case CodeGenTarget::CPPSource:
-        case CodeGenTarget::HostCPPSource:
-        {
-            lowerComInterfaces(irModule, artifactDesc.style, sink);
-            generateDllImportFuncs(codeGenContext->getTargetReq(), irModule, sink);
-            generateDllExportFuncs(irModule, sink);
-            break;
-        }
-        default: break;
-    }
-
-    // Lower `Result<T,E>` types into ordinary struct types.
-    lowerResultType(irModule, sink);
-
     // Replace any global constants with their values.
     //
     replaceGlobalConstants(irModule);
@@ -323,6 +307,24 @@ Result linkAndOptimizeIR(
         break;
     }
 
+    lowerOptionalType(irModule, sink);
+    simplifyIR(irModule);
+
+    switch (target)
+    {
+    case CodeGenTarget::CPPSource:
+    case CodeGenTarget::HostCPPSource:
+    {
+        lowerComInterfaces(irModule, artifactDesc.style, sink);
+        generateDllImportFuncs(codeGenContext->getTargetReq(), irModule, sink);
+        generateDllExportFuncs(irModule, sink);
+        break;
+    }
+    default: break;
+    }
+
+    // Lower `Result<T,E>` types into ordinary struct types.
+    lowerResultType(irModule, sink);
 
     // Desguar any union types, since these will be illegal on
     // various targets.
@@ -392,8 +394,6 @@ Result linkAndOptimizeIR(
     // will run a DCE pass to clean up after the specialization.
     //
     simplifyIR(irModule);
-
-    lowerOptionalType(irModule, sink);
 
 #if 0
     dumpIRIfEnabled(codeGenContext, irModule, "AFTER DCE");

--- a/source/slang/slang-ir-generics-lowering-context.cpp
+++ b/source/slang/slang-ir-generics-lowering-context.cpp
@@ -3,6 +3,7 @@
 #include "slang-ir-generics-lowering-context.h"
 
 #include "slang-ir-layout.h"
+#include "slang-ir-util.h"
 
 namespace Slang
 {
@@ -33,24 +34,6 @@ namespace Slang
         {
             return isPolymorphicType(ptrType->getValueType());
         }
-        return false;
-    }
-
-    bool isComInterfaceType(IRType* type)
-    {
-        if (!type) return false;
-        if (type->findDecoration<IRComInterfaceDecoration>() || 
-            type->getOp() == kIROp_ComPtrType)
-        {
-            return true;
-        }
-
-        if (auto ptrType = as<IRNativePtrType>(type))
-        {
-            auto valueType = ptrType->getValueType();
-            return valueType->findDecoration<IRComInterfaceDecoration>() != nullptr;
-        }
-
         return false;
     }
 

--- a/source/slang/slang-ir-generics-lowering-context.h
+++ b/source/slang/slang-ir-generics-lowering-context.h
@@ -104,8 +104,6 @@ namespace Slang
 
     bool isPolymorphicType(IRInst* typeInst);
 
-    bool isComInterfaceType(IRType* type);
-
     // Returns true if typeInst represents a type and should be lowered into
     // Ptr(RTTIType).
     bool isTypeValue(IRInst* typeInst);

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -2927,6 +2927,8 @@ public:
         IRType* type,
         IRInst* val);
 
+    IRInst* emitCastPtrToBool(IRInst* val);
+
     IRGlobalConstant* emitGlobalConstant(
         IRType* type);
 

--- a/source/slang/slang-ir-lower-existential.cpp
+++ b/source/slang/slang-ir-lower-existential.cpp
@@ -4,6 +4,7 @@
 #include "slang-ir-generics-lowering-context.h"
 #include "slang-ir.h"
 #include "slang-ir-insts.h"
+#include "slang-ir-util.h"
 
 namespace Slang
 {

--- a/source/slang/slang-ir-lower-generic-call.cpp
+++ b/source/slang/slang-ir-lower-generic-call.cpp
@@ -1,6 +1,7 @@
 // slang-ir-lower-generic-call.cpp
 #include "slang-ir-lower-generic-call.h"
 #include "slang-ir-generics-lowering-context.h"
+#include "slang-ir-util.h"
 
 namespace Slang
 {

--- a/source/slang/slang-ir-lower-generic-function.cpp
+++ b/source/slang/slang-ir-lower-generic-function.cpp
@@ -5,6 +5,7 @@
 #include "slang-ir.h"
 #include "slang-ir-clone.h"
 #include "slang-ir-insts.h"
+#include "slang-ir-util.h"
 
 namespace Slang
 {

--- a/source/slang/slang-ir-lower-generics.cpp
+++ b/source/slang/slang-ir-lower-generics.cpp
@@ -14,6 +14,7 @@
 #include "slang-ir-specialize-dynamic-associatedtype-lookup.h"
 #include "slang-ir-witness-table-wrapper.h"
 #include "slang-ir-ssa-simplification.h"
+#include "slang-ir-util.h"
 
 
 namespace Slang

--- a/source/slang/slang-ir-specialize-dynamic-associatedtype-lookup.cpp
+++ b/source/slang/slang-ir-specialize-dynamic-associatedtype-lookup.cpp
@@ -3,6 +3,7 @@
 #include "slang-ir-generics-lowering-context.h"
 #include "slang-ir-insts.h"
 #include "slang-ir.h"
+#include "slang-ir-util.h"
 
 namespace Slang
 {

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -1,4 +1,5 @@
 #include "slang-ir-util.h"
+#include "slang-ir-insts.h"
 
 namespace Slang
 {
@@ -42,5 +43,25 @@ bool isPtrToArrayType(IRInst* type)
 {
     return isPointerOfType(type, kIROp_ArrayType) || isPointerOfType(type, kIROp_UnsizedArrayType);
 }
+
+
+bool isComInterfaceType(IRType* type)
+{
+    if (!type) return false;
+    if (type->findDecoration<IRComInterfaceDecoration>() ||
+        type->getOp() == kIROp_ComPtrType)
+    {
+        return true;
+    }
+
+    if (auto ptrType = as<IRNativePtrType>(type))
+    {
+        auto valueType = ptrType->getValueType();
+        return valueType->findDecoration<IRComInterfaceDecoration>() != nullptr;
+    }
+
+    return false;
+}
+
 
 }

--- a/source/slang/slang-ir-util.h
+++ b/source/slang/slang-ir-util.h
@@ -22,6 +22,8 @@ bool isPointerOfType(IRInst* ptrType, IROp opCode);
 // Builds a dictionary that maps from requirement key to requirement value for `interfaceType`.
 Dictionary<IRInst*, IRInst*> buildInterfaceRequirementDict(IRInterfaceType* interfaceType);
 
+bool isComInterfaceType(IRType* type);
+
 }
 
 #endif

--- a/source/slang/slang-ir-witness-table-wrapper.cpp
+++ b/source/slang/slang-ir-witness-table-wrapper.cpp
@@ -5,6 +5,7 @@
 #include "slang-ir.h"
 #include "slang-ir-clone.h"
 #include "slang-ir-insts.h"
+#include "slang-ir-util.h"
 
 namespace Slang
 {

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -4369,6 +4369,17 @@ namespace Slang
         return inst;
     }
 
+    IRInst* IRBuilder::emitCastPtrToBool(IRInst* val)
+    {
+        auto inst = createInst<IRInst>(
+            this,
+            kIROp_CastPtrToBool,
+            getBoolType(),
+            val);
+        addInst(inst);
+        return inst;
+    }
+
     IRGlobalConstant* IRBuilder::emitGlobalConstant(
         IRType* type)
     {

--- a/tests/cpu-program/gfx-smoke.slang
+++ b/tests/cpu-program/gfx-smoke.slang
@@ -8,8 +8,8 @@ public __extern_cpp int main()
 {
     gfx.DeviceDesc deviceDesc = {};
     deviceDesc.deviceType = gfx.DeviceType.CPU;
-    gfx.IDevice obj;
-    if (gfx.succeeded(gfx.gfxCreateDevice(&deviceDesc, obj)))
+    Optional<gfx.IDevice> obj;
+    if (gfx.succeeded(gfx.gfxCreateDevice(&deviceDesc, obj)) && obj.hasValue)
         writeln("succ");
     else
         writeln("fail");

--- a/tools/gfx/gfx.slang
+++ b/tools/gfx/gfx.slang
@@ -808,7 +808,7 @@ struct AccelerationStructureBuildInputs
 struct AccelerationStructureCreateDesc
 {
     AccelerationStructureKind kind;
-    IBufferResource *buffer;
+    NativeRef<IBufferResource> buffer;
     Offset offset;
     Size size;
 };
@@ -816,8 +816,8 @@ struct AccelerationStructureCreateDesc
 struct AccelerationStructureBuildDesc
 {
     AccelerationStructureBuildInputs inputs;
-    IAccelerationStructure *source;
-    IAccelerationStructure *dest;
+    NativeRef<IAccelerationStructure> source;
+    NativeRef<IAccelerationStructure> dest;
     DeviceAddress scratchData;
 };
 
@@ -889,7 +889,7 @@ interface IShaderObject
     Size getSize();
 
     /// Use the provided constant buffer instead of the internally created one.
-    Result setConstantBufferOverride(IBufferResource *constantBuffer);
+    Result setConstantBufferOverride(IBufferResource constantBuffer);
 };
 
 enum class StencilOp : uint8_t
@@ -1358,7 +1358,7 @@ interface IResourceCommandEncoder : ICommandEncoder
         ResourceState dstState,
         SubresourceRange dstSubresource,
         int3 dstOffset,
-        ITextureResource *src,
+        NativeRef<ITextureResource> src,
         ResourceState srcState,
         SubresourceRange srcSubresource,
         int3 srcOffset,
@@ -1422,7 +1422,7 @@ interface IRenderCommandEncoder : IResourceCommandEncoder
     Result bindPipeline(IPipelineState state, out IShaderObject outRootShaderObject);
 
     // Sets the current pipeline state along with a pre-created mutable root shader object.
-    Result bindPipelineWithRootObject(IPipelineState state, IShaderObject *rootObject);
+    Result bindPipelineWithRootObject(IPipelineState state, NativeRef<IShaderObject> rootObject);
 
     void setViewports(GfxCount count, Viewport *viewports);
     void setScissorRects(GfxCount count, ScissorRect *scissors);
@@ -1504,8 +1504,8 @@ interface IRayTracingCommandEncoder : IResourceCommandEncoder
                  GfxCount propertyQueryCount,
                  AccelerationStructureQueryDesc *queryDescs);
     void copyAccelerationStructure(
-        IAccelerationStructure *dest,
-        IAccelerationStructure *src,
+        NativeRef<IAccelerationStructure> dest,
+        NativeRef<IAccelerationStructure> src,
         AccelerationStructureCopyMode mode);
     void queryAccelerationStructureProperties(
         GfxCount accelerationStructureCount,
@@ -1523,7 +1523,7 @@ interface IRayTracingCommandEncoder : IResourceCommandEncoder
     /// `rayGenShaderIndex` specifies the index into the shader table that identifies the ray generation shader.
     void dispatchRays(
         GfxIndex rayGenShaderIndex,
-        IShaderTable *shaderTable,
+        NativeRef<IShaderTable> shaderTable,
         GfxCount width,
         GfxCount height,
         GfxCount depth);
@@ -1565,9 +1565,6 @@ struct CommandQueueDesc
 [COM("14e2bed0-0ad0-4dc8-b341-06-3f-e7-2d-bf-0e")]
 interface ICommandQueue
 {
-    // For D3D12, this is the pointer to the queue. For Vulkan, this is the queue itself.
-    typedef uint64_t NativeHandle;
-
     const CommandQueueDesc* getDesc();
 
     void executeCommandBuffers(
@@ -1936,7 +1933,7 @@ SLANG_GFX_IMPORT bool gfxIsTypelessFormat(Format format);
 SLANG_GFX_IMPORT Result gfxGetFormatInfo(Format format, FormatInfo *outInfo);
 
 /// Given a type returns a function that can construct it, or nullptr if there isn't one
-SLANG_GFX_IMPORT Result gfxCreateDevice(const DeviceDesc* desc, out IDevice outDevice);
+SLANG_GFX_IMPORT Result gfxCreateDevice(const DeviceDesc* desc, out Optional<IDevice> outDevice);
 
 /// Sets a callback for receiving debug messages.
 /// The layer does not hold a strong reference to the callback object.


### PR DESCRIPTION
By default, an `Optional<T>` lowers into a `struct` with a `T` field for the value and a `bool` field representing whether or not there is value.

For types that can be lowered into a pointer, such as `NativePtr`, `Ptr`, `ComPtr` or a `class`, we don't need to generate a struct. Instead, we can simply test if the lowered pointer is a `nullptr`.

This PR implements this optimization.

Also adds a compile time check to prevent forming direct pointers to managed types (e.g. classes or interfaces). These should be referred to with the `NativeRef` type which must be explicitly converted to managed type before use.