### PR TITLE
Fix for Vulkan ray tracing test using a non-zero raygen shader index

### DIFF
--- a/tools/gfx-unit-test/ray-tracing-tests.cpp
+++ b/tools/gfx-unit-test/ray-tracing-tests.cpp
@@ -488,11 +488,8 @@ namespace gfx_test
         runTestImpl(rayTracingTestImpl<RayTracingTestB>, unitTestContext, Slang::RenderApiFlag::D3D12);
     }
 
-#if 0
-    //TODO: fix test failure.
     SLANG_UNIT_TEST(RayTracingTestBVulkan)
     {
         runTestImpl(rayTracingTestImpl<RayTracingTestB>, unitTestContext, Slang::RenderApiFlag::Vulkan);
     }
-#endif
 }

--- a/tools/gfx/vulkan/vk-command-encoder.h
+++ b/tools/gfx/vulkan/vk-command-encoder.h
@@ -4,14 +4,6 @@
 #include "vk-base.h"
 #include "vk-pipeline-state.h"
 
-#ifndef ENABLE_VALIDATION_LAYER
-#    if _DEBUG
-#        define ENABLE_VALIDATION_LAYER 1
-#    else
-#        define ENABLE_VALIDATION_LAYER 0
-#    endif
-#endif
-
 namespace gfx
 {
 

--- a/tools/gfx/vulkan/vk-command-encoder.h
+++ b/tools/gfx/vulkan/vk-command-encoder.h
@@ -4,6 +4,14 @@
 #include "vk-base.h"
 #include "vk-pipeline-state.h"
 
+#ifndef ENABLE_VALIDATION_LAYER
+#    if _DEBUG
+#        define ENABLE_VALIDATION_LAYER 1
+#    else
+#        define ENABLE_VALIDATION_LAYER 0
+#    endif
+#endif
+
 namespace gfx
 {
 

--- a/tools/gfx/vulkan/vk-shader-table.cpp
+++ b/tools/gfx/vulkan/vk-shader-table.cpp
@@ -83,7 +83,8 @@ RefPtr<BufferResource> ShaderTableImpl::createDeviceBuffer(
 
         auto shaderGroupIndex = *shaderGroupIndexPtr;
         auto srcHandlePtr = handles.getBuffer() + shaderGroupIndex * handleSize;
-        memcpy(dstHandlePtr, srcHandlePtr, rtProps.shaderGroupBaseAlignment);
+        memcpy(dstHandlePtr, srcHandlePtr, handleSize);
+        memset(dstHandlePtr + handleSize, 0, rtProps.shaderGroupBaseAlignment - handleSize);
     }
     subTablePtr += m_raygenTableSize;
 

--- a/tools/gfx/vulkan/vk-shader-table.cpp
+++ b/tools/gfx/vulkan/vk-shader-table.cpp
@@ -22,8 +22,7 @@ RefPtr<BufferResource> ShaderTableImpl::createDeviceBuffer(
     auto vkApi = m_device->m_api;
     auto rtProps = vkApi.m_rtProperties;
     uint32_t handleSize = rtProps.shaderGroupHandleSize;
-    m_raygenTableSize = (uint32_t)VulkanUtil::calcAligned(
-        m_rayGenShaderCount * handleSize, rtProps.shaderGroupBaseAlignment);
+    m_raygenTableSize = m_rayGenShaderCount * rtProps.shaderGroupBaseAlignment;
     m_missTableSize = (uint32_t)VulkanUtil::calcAligned(
         m_missShaderCount * handleSize, rtProps.shaderGroupBaseAlignment);
     m_hitTableSize = (uint32_t)VulkanUtil::calcAligned(
@@ -75,7 +74,7 @@ RefPtr<BufferResource> ShaderTableImpl::createDeviceBuffer(
     // index in the buffer of handles.
     for (uint32_t i = 0; i < m_rayGenShaderCount; i++)
     {
-        auto dstHandlePtr = subTablePtr + i * handleSize;
+        auto dstHandlePtr = subTablePtr + i * rtProps.shaderGroupBaseAlignment;
         auto shaderGroupName = m_shaderGroupNames[shaderTableEntryCounter++];
         auto shaderGroupIndexPtr =
             pipelineImpl->shaderGroupNameToIndex.TryGetValue(shaderGroupName);
@@ -84,7 +83,7 @@ RefPtr<BufferResource> ShaderTableImpl::createDeviceBuffer(
 
         auto shaderGroupIndex = *shaderGroupIndexPtr;
         auto srcHandlePtr = handles.getBuffer() + shaderGroupIndex * handleSize;
-        memcpy(dstHandlePtr, srcHandlePtr, handleSize);
+        memcpy(dstHandlePtr, srcHandlePtr, rtProps.shaderGroupBaseAlignment);
     }
     subTablePtr += m_raygenTableSize;
 


### PR DESCRIPTION
Changes:
- Fixed math and alignment errors in Vulkan SBT creation resulting in all raygen shaders after the first being copied into the incorrect locations