### PR TITLE
Deduplicate AST type nodes and cache lookup operations.

### DIFF
--- a/source/core/slang-array.h
+++ b/source/core/slang-array.h
@@ -125,6 +125,23 @@ namespace Slang
 		insertArray(rs, args...);
 		return rs;
 	}
+
+
+    template<typename TList>
+    void addToList(TList&)
+    {
+    }
+    template<typename TList, typename T>
+    void addToList(TList& list, T node)
+    {
+        list.add(node);
+    }
+    template<typename TList, typename T, typename ... TArgs>
+    void addToList(TList& list, T node, TArgs ... args)
+    {
+        list.add(node);
+        addToList(list, args...);
+    }
 }
 
 #endif

--- a/source/core/slang-short-list.h
+++ b/source/core/slang-short-list.h
@@ -288,6 +288,8 @@ namespace Slang
 
         void addRange(ArrayView<T> list) { addRange(list.m_buffer, list.m_count); }
 
+        void addRange(ConstArrayView<T> list) { addRange(list.m_buffer, list.m_count); }
+
         template<int _otherShortListSize, typename TOtherAllocator>
         void addRange(const ShortList<T, _otherShortListSize, TOtherAllocator>& list)
         {

--- a/source/slang/slang-api.cpp
+++ b/source/slang/slang-api.cpp
@@ -98,7 +98,7 @@ SLANG_API SlangResult slang_createGlobalSession(
     {
         Slang::String cacheFilename;
         uint64_t dllTimestamp = 0;
-#define SLANG_PROFILE_STDLIB_COMPILE 1
+#define SLANG_PROFILE_STDLIB_COMPILE 0
 #if SLANG_PROFILE_STDLIB_COMPILE
         auto startTime = std::chrono::high_resolution_clock::now();
 #else

--- a/source/slang/slang-api.cpp
+++ b/source/slang/slang-api.cpp
@@ -98,11 +98,19 @@ SLANG_API SlangResult slang_createGlobalSession(
     {
         Slang::String cacheFilename;
         uint64_t dllTimestamp = 0;
+#define SLANG_PROFILE_STDLIB_COMPILE 1
+#if SLANG_PROFILE_STDLIB_COMPILE
+        auto startTime = std::chrono::high_resolution_clock::now();
+#else
         if (tryLoadStdLibFromCache(globalSession, cacheFilename, dllTimestamp) != SLANG_OK)
+#endif
         {
             // Compile std lib from embeded source.
             SLANG_RETURN_ON_FAIL(globalSession->compileStdLib(0));
-
+#if SLANG_PROFILE_STDLIB_COMPILE
+            auto timeElapsed = std::chrono::high_resolution_clock::now() - startTime;
+            printf("stdlib compilation time: %.1fms\n", timeElapsed.count() / 1000000.0);
+#endif
             // Store the compiled stdlib to cache file.
             trySaveStdLibToCache(globalSession, cacheFilename, dllTimestamp);
         }

--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -22,7 +22,18 @@ class NodeBase
 
         // MUST be called before used. Called automatically via the ASTBuilder.
         // Note that the astBuilder is not stored in the NodeBase derived types by default.
-    SLANG_FORCE_INLINE void init(ASTNodeType inAstNodeType, ASTBuilder* /* astBuilder*/ ) { astNodeType = inAstNodeType; }
+    SLANG_FORCE_INLINE void init(ASTNodeType inAstNodeType, ASTBuilder* /* astBuilder*/)
+    {
+        astNodeType = inAstNodeType;
+#ifdef _DEBUG
+        static uint32_t uidCounter = 0;
+        static uint32_t breakValue = 0;
+        uidCounter++;
+        _debugUID = uidCounter;
+        if (breakValue != 0 && _debugUID == breakValue)
+            SLANG_BREAKPOINT(0)
+#endif
+    }
 
         /// Get the class info 
     SLANG_FORCE_INLINE const ReflectClassInfo& getClassInfo() const { return *ASTClassInfo::getInfo(astNodeType); }
@@ -36,6 +47,9 @@ class NodeBase
 
     // Handy when debugging, shouldn't be checked in though!
     // virtual ~NodeBase() {}
+#ifdef _DEBUG
+    SLANG_UNREFLECTED uint32_t _debugUID = 0;
+#endif
 };
 
 // Casting of NodeBase
@@ -228,13 +242,28 @@ class GenericSubstitution : public Substitutions
     // parameters we are binding to arguments
     GenericDecl* genericDecl = nullptr;
 
+private:
     // The actual values of the arguments
     List<Val* > args;
-
+public:
+    const List<Val*>& getArgs() const { return args; }
     // Overrides should be public so base classes can access
     Substitutions* _applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, Substitutions* substOuter, int* ioDiff);
     bool _equalsOverride(Substitutions* subst);
     HashCode _getHashCodeOverride() const;
+
+    GenericSubstitution(GenericDecl* decl)
+    {
+        genericDecl = decl;
+    }
+
+    template<typename... TArgs>
+    GenericSubstitution(GenericDecl* decl, TArgs... inArgs)
+    {
+        genericDecl = decl;
+        addToList(args, inArgs...);
+    }
+
 };
 
 class ThisTypeSubstitution : public Substitutions
@@ -253,6 +282,10 @@ class ThisTypeSubstitution : public Substitutions
     Substitutions* _applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, Substitutions* substOuter, int* ioDiff);
     bool _equalsOverride(Substitutions* subst);
     HashCode _getHashCodeOverride() const;
+
+    ThisTypeSubstitution(InterfaceDecl* inInterfaceDecl, SubtypeWitness* inWitness)
+        : interfaceDecl(inInterfaceDecl), witness(inWitness)
+    {}
 };
 
 class SyntaxNode : public SyntaxNodeBase

--- a/source/slang/slang-ast-print.cpp
+++ b/source/slang/slang-ast-print.cpp
@@ -190,7 +190,7 @@ void ASTPrinter::_addDeclPathRec(const DeclRef<Decl>& declRef, Index depth)
 
             sb << "<";
             bool first = true;
-            for (auto arg : genSubst->args)
+            for (auto arg : genSubst->getArgs())
             {
                 // When printing the representation of a specialized
                 // generic declaration we don't want to include the

--- a/source/slang/slang-ast-substitutions.cpp
+++ b/source/slang/slang-ast-substitutions.cpp
@@ -63,10 +63,8 @@ Substitutions* GenericSubstitution::_applySubstitutionsShallowOverride(ASTBuilde
     if (!diff) return this;
 
     (*ioDiff)++;
-    auto substSubst = astBuilder->create<GenericSubstitution>();
-    substSubst->genericDecl = genericDecl;
-    substSubst->args = substArgs;
-    substSubst->outer = substOuter;
+
+    auto substSubst = astBuilder->getOrCreateGenericSubstitution(genericDecl, substArgs, substOuter);
     return substSubst;
 }
 
@@ -126,10 +124,9 @@ Substitutions* ThisTypeSubstitution::_applySubstitutionsShallowOverride(ASTBuild
     if (!diff) return this;
 
     (*ioDiff)++;
-    auto substSubst = astBuilder->create<ThisTypeSubstitution>();
-    substSubst->interfaceDecl = interfaceDecl;
-    substSubst->witness = substWitness;
-    substSubst->outer = substOuter;
+    ThisTypeSubstitution* substSubst;
+
+    substSubst = astBuilder->getOrCreateThisTypeSubstitution(interfaceDecl, substWitness, substOuter);
     return substSubst;
 }
 

--- a/source/slang/slang-ast-type.cpp
+++ b/source/slang/slang-ast-type.cpp
@@ -224,7 +224,7 @@ Val* DeclRefType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSe
                 {
                     // We've found it, so return the corresponding specialization argument
                     (*ioDiff)++;
-                    return genericSubst->args[index];
+                    return genericSubst->getArgs()[index];
                 }
                 else if (auto typeParam = as<GenericTypeParamDecl>(m))
                 {
@@ -351,17 +351,17 @@ BasicExpressionType* MatrixExpressionType::_getScalarTypeOverride()
 
 Type* MatrixExpressionType::getElementType()
 {
-    return as<Type>(findInnerMostGenericSubstitution(declRef.substitutions)->args[0]);
+    return as<Type>(findInnerMostGenericSubstitution(declRef.substitutions)->getArgs()[0]);
 }
 
 IntVal* MatrixExpressionType::getRowCount()
 {
-    return as<IntVal>(findInnerMostGenericSubstitution(declRef.substitutions)->args[1]);
+    return as<IntVal>(findInnerMostGenericSubstitution(declRef.substitutions)->getArgs()[1]);
 }
 
 IntVal* MatrixExpressionType::getColumnCount()
 {
-    return as<IntVal>(findInnerMostGenericSubstitution(declRef.substitutions)->args[2]);
+    return as<IntVal>(findInnerMostGenericSubstitution(declRef.substitutions)->getArgs()[2]);
 }
 
 Type* MatrixExpressionType::getRowType()
@@ -518,12 +518,12 @@ Type* NamespaceType::_createCanonicalTypeOverride()
 
 Type* PtrTypeBase::getValueType()
 {
-    return as<Type>(findInnerMostGenericSubstitution(declRef.substitutions)->args[0]);
+    return as<Type>(findInnerMostGenericSubstitution(declRef.substitutions)->getArgs()[0]);
 }
 
 Type* OptionalType::getValueType()
 {
-    return as<Type>(findInnerMostGenericSubstitution(declRef.substitutions)->args[0]);
+    return as<Type>(findInnerMostGenericSubstitution(declRef.substitutions)->getArgs()[0]);
 }
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! NamedExpressionType !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -78,8 +78,12 @@ class DeclRefType : public Type
     Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 
 protected:
-    DeclRefType( DeclRef<Decl> declRef)
+    DeclRefType(DeclRef<Decl> declRef)
         : declRef(declRef)
+    {}
+
+    DeclRefType(Decl* decl, Substitutions* substitutions)
+        : declRef(decl, substitutions)
     {}
 };
 
@@ -210,6 +214,11 @@ class SamplerStateType : public BuiltinType
 
     // What flavor of sampler state is this
     SamplerStateFlavor flavor;
+
+    SamplerStateType(SamplerStateFlavor inFlavor)
+    {
+        flavor = inFlavor;
+    }
 };
 
 // Other cases of generic types known to the compiler
@@ -467,6 +476,10 @@ class VectorExpressionType : public ArithmeticExpressionType
     // Overrides should be public so base classes can access
     void _toTextOverride(StringBuilder& out);
     BasicExpressionType* _getScalarTypeOverride();
+
+    VectorExpressionType(Type* inElementType, IntVal* inElementCount)
+        : elementType(inElementType), elementCount(inElementCount)
+    {}
 };
 
 // A matrix type, e.g., `matrix<T,R,C>`
@@ -486,6 +499,8 @@ class MatrixExpressionType : public ArithmeticExpressionType
 
 private:
     Type* rowType = nullptr;
+
+    MatrixExpressionType(Type*, IntVal*, IntVal*) {}
 };
 
 // Base class for built in string types
@@ -793,6 +808,10 @@ class AndType : public Type
 
     Type* left;
     Type* right;
+
+    AndType(Type* leftType, Type* rightType)
+        : left(leftType), right(rightType)
+    {}
 
     // Overrides should be public so base classes can access
     void _toTextOverride(StringBuilder& out);

--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -137,7 +137,7 @@ Val* GenericParamIntVal::_substituteImplOverride(ASTBuilder* /* astBuilder */, S
             {
                 // We've found it, so return the corresponding specialization argument
                 (*ioDiff)++;
-                return genSubst->args[index];
+                return genSubst->getArgs()[index];
             }
             else if (auto typeParam = as<GenericTypeParamDecl>(m))
             {
@@ -265,8 +265,8 @@ Val* DeclaredSubtypeWitness::_substituteImplOverride(ASTBuilder* astBuilder, Sub
                     (*ioDiff)++;
                     auto ordinaryParamCount = genericDecl->getMembersOfType<GenericTypeParamDecl>().getCount() +
                         genericDecl->getMembersOfType<GenericValueParamDecl>().getCount();
-                    SLANG_ASSERT(index + ordinaryParamCount < genericSubst->args.getCount());
-                    return genericSubst->args[index + ordinaryParamCount];
+                    SLANG_ASSERT(index + ordinaryParamCount < genericSubst->getArgs().getCount());
+                    return genericSubst->getArgs()[index + ordinaryParamCount];
                 }
             }
         }
@@ -323,7 +323,8 @@ Val* DeclaredSubtypeWitness::_substituteImplOverride(ASTBuilder* astBuilder, Sub
         }
     }
 
-    DeclaredSubtypeWitness* rs = astBuilder->create<DeclaredSubtypeWitness>();
+    DeclaredSubtypeWitness* rs = astBuilder->getOrCreate<DeclaredSubtypeWitness>(
+        substSub, substSup, substDeclRef.getDecl(), substDeclRef.substitutions.substitutions);
     rs->sub = substSub;
     rs->sup = substSup;
     rs->declRef = substDeclRef;
@@ -722,7 +723,7 @@ Val* PolynomialIntVal::_substituteImplOverride(ASTBuilder* astBuilder, Substitut
     *ioDiff += diff;
 
     if (evaluatedTerms.getCount() == 0)
-        return astBuilder->create<ConstantIntVal>(type, evaluatedConstantTerm);
+        return astBuilder->getOrCreate<ConstantIntVal>(type, evaluatedConstantTerm);
     if (diff != 0)
     {
         auto newPolynomial = astBuilder->create<PolynomialIntVal>(type);
@@ -1035,7 +1036,7 @@ IntVal* PolynomialIntVal::canonicalize(ASTBuilder* builder)
         return terms[0]->paramFactors[0]->param;
     }
     if (terms.getCount() == 0)
-        return builder->create<ConstantIntVal>(type, constantTerm);
+        return builder->getOrCreate<ConstantIntVal>(type, constantTerm);
     return this;
 }
 
@@ -1207,7 +1208,7 @@ Val* FuncCallIntVal::tryFoldImpl(ASTBuilder* astBuilder, Type* resultType, DeclR
         {
             SLANG_UNREACHABLE("constant folding of FuncCallIntVal");
         }
-        return astBuilder->create<ConstantIntVal>(resultType, resultValue);
+        return astBuilder->getOrCreate<ConstantIntVal>(resultType, resultValue);
     }
     return nullptr;
 }

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -53,6 +53,10 @@ class GenericParamIntVal : public IntVal
     HashCode _getHashCodeOverride();
     Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 
+    GenericParamIntVal(Type* inType, VarDeclBase* inDecl, Substitutions* inSubst)
+        : IntVal(inType), declRef(inDecl, inSubst)
+    {}
+
 protected:
     GenericParamIntVal(Type* inType, DeclRef<VarDeclBase> inDeclRef)
         : IntVal(inType), declRef(inDeclRef)
@@ -315,6 +319,13 @@ class DeclaredSubtypeWitness : public SubtypeWitness
     void _toTextOverride(StringBuilder& out);
     HashCode _getHashCodeOverride();
     Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+
+    DeclaredSubtypeWitness(Type* inSub, Type* inSup, Decl* decl, Substitutions* subst)
+        : declRef(decl, subst)
+    {
+        sub = inSub;
+        sup = inSup;
+    }
 };
 
 // A witness that `sub : sup` because `sub : mid` and `mid : sup`
@@ -333,6 +344,10 @@ class TransitiveSubtypeWitness : public SubtypeWitness
     void _toTextOverride(StringBuilder& out);
     HashCode _getHashCodeOverride();
     Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+
+    TransitiveSubtypeWitness(SubtypeWitness* inSubToMid, SubtypeWitness* inMidToSup)
+        : subToMid(inSubToMid), midToSup(inMidToSup)
+    {}
 };
 
 // A witness taht `sub : sup` because `sub` was wrapped into

--- a/source/slang/slang-check-conformance.cpp
+++ b/source/slang/slang-check-conformance.cpp
@@ -10,10 +10,11 @@ namespace Slang
     DeclaredSubtypeWitness* SemanticsVisitor::createSimpleSubtypeWitness(
         TypeWitnessBreadcrumb*  breadcrumb)
     {
-        DeclaredSubtypeWitness* witness = m_astBuilder->create<DeclaredSubtypeWitness>();
-        witness->sub = breadcrumb->sub;
-        witness->sup = breadcrumb->sup;
-        witness->declRef = breadcrumb->declRef;
+        DeclaredSubtypeWitness* witness = m_astBuilder->getOrCreate<DeclaredSubtypeWitness>(
+            breadcrumb->sub,
+            breadcrumb->sup,
+            breadcrumb->declRef.decl,
+            breadcrumb->declRef.substitutions.substitutions);
         return witness;
     }
 
@@ -82,12 +83,11 @@ namespace Slang
             // where `[...]` represents the "hole" we leave
             // open to fill in next.
             //
-            DeclaredSubtypeWitness* declaredWitness = m_astBuilder->create<DeclaredSubtypeWitness>();
-            declaredWitness->sub = bb->sub;
-            declaredWitness->sup = bb->sup;
-            declaredWitness->declRef = bb->declRef;
+            DeclaredSubtypeWitness* declaredWitness =
+                m_astBuilder->getOrCreate<DeclaredSubtypeWitness>(
+                    bb->sub, bb->sup, bb->declRef.decl, bb->declRef.substitutions.substitutions);
 
-            TransitiveSubtypeWitness* transitiveWitness = m_astBuilder->create<TransitiveSubtypeWitness>();
+            TransitiveSubtypeWitness* transitiveWitness = m_astBuilder->getOrCreateWithDefaultCtor<TransitiveSubtypeWitness>(subType, bb->sup, declaredWitness);
             transitiveWitness->sub = subType;
             transitiveWitness->sup = bb->sup;
             transitiveWitness->midToSup = declaredWitness;

--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -391,11 +391,8 @@ namespace Slang
         // search for a conformance `Robin : ISidekick`, which involved
         // apply the substitutions we already know...
 
-        GenericSubstitution* solvedSubst = m_astBuilder->create<GenericSubstitution>();
-        solvedSubst->genericDecl = genericDeclRef.getDecl();
-        solvedSubst->outer = genericDeclRef.substitutions.substitutions;
-        solvedSubst->args = args;
-        resultSubst.substitutions = solvedSubst;
+        GenericSubstitution* solvedSubst = m_astBuilder->getOrCreateGenericSubstitution(
+            genericDeclRef.getDecl(), args, genericDeclRef.substitutions.substitutions);
 
         for( auto constraintDecl : genericDeclRef.getDecl()->getMembersOfType<GenericTypeConstraintDecl>() )
         {
@@ -412,7 +409,7 @@ namespace Slang
             if(subTypeWitness)
             {
                 // We found a witness, so it will become an (implicit) argument.
-                solvedSubst->args.add(subTypeWitness);
+                args.add(subTypeWitness);
             }
             else
             {
@@ -437,6 +434,8 @@ namespace Slang
             }
         }
 
+        resultSubst = m_astBuilder->getOrCreateGenericSubstitution(
+            genericDeclRef.getDecl(), args, genericDeclRef.substitutions.substitutions);
         return resultSubst;
     }
 
@@ -546,12 +545,12 @@ namespace Slang
             return false;
 
         // Their arguments must unify
-        SLANG_RELEASE_ASSERT(fstGen->args.getCount() == sndGen->args.getCount());
-        Index argCount = fstGen->args.getCount();
+        SLANG_RELEASE_ASSERT(fstGen->getArgs().getCount() == sndGen->getArgs().getCount());
+        Index argCount = fstGen->getArgs().getCount();
         bool okay = true;
         for (Index aa = 0; aa < argCount; ++aa)
         {
-            if (!TryUnifyVals(constraints, fstGen->args[aa], sndGen->args[aa]))
+            if (!TryUnifyVals(constraints, fstGen->getArgs()[aa], sndGen->getArgs()[aa]))
             {
                 okay = false;
             }

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -349,7 +349,7 @@ namespace Slang
                 // We have a new type for the conversion, based on what
                 // we learned.
                 toType = m_astBuilder->getArrayType(toElementType,
-                    m_astBuilder->create<ConstantIntVal>(m_astBuilder->getIntType(), elementCount));
+                    m_astBuilder->getOrCreate<ConstantIntVal>(m_astBuilder->getIntType(), elementCount));
             }
         }
         else if(auto toMatrixType = as<MatrixExpressionType>(toType))

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -519,42 +519,73 @@ namespace Slang
         return semantics->ApplyExtensionToType(extDecl, type);
     }
 
+    void ensureDecl(SemanticsVisitor* visitor, Decl* decl, DeclCheckState state)
+    {
+        visitor->ensureDecl(decl, state);
+    }
+
     GenericSubstitution* createDefaultSubstitutionsForGeneric(
-        ASTBuilder*             astBuilder, 
+        ASTBuilder*             astBuilder,
+        SemanticsVisitor* semantics,
         GenericDecl*            genericDecl,
         Substitutions*   outerSubst)
     {
-        GenericSubstitution* genericSubst = astBuilder->create<GenericSubstitution>();
-        genericSubst->genericDecl = genericDecl;
-        genericSubst->outer = outerSubst;
+        GenericSubstitution* cachedResult = nullptr;
+        if (astBuilder->m_genericDefaultSubst.TryGetValue(genericDecl, cachedResult))
+        {
+            if (cachedResult->outer == outerSubst)
+                return cachedResult;
+        }
+
+        List<Val*> args;
 
         for( auto mm : genericDecl->members )
         {
             if( auto genericTypeParamDecl = as<GenericTypeParamDecl>(mm) )
             {
-                genericSubst->args.add(DeclRefType::create(astBuilder, DeclRef<Decl>(genericTypeParamDecl, outerSubst)));
+                args.add(DeclRefType::create(astBuilder, DeclRef<Decl>(genericTypeParamDecl, outerSubst)));
             }
             else if( auto genericValueParamDecl = as<GenericValueParamDecl>(mm) )
             {
-                genericSubst->args.add(astBuilder->create<GenericParamIntVal>(
+                args.add(astBuilder->getOrCreate<GenericParamIntVal>(
                     genericValueParamDecl->getType(),
-                    DeclRef<GenericValueParamDecl>(genericValueParamDecl, outerSubst)));
+                    genericValueParamDecl, outerSubst));
             }
         }
+
+        bool shouldCache = true;
 
         // create default substitution arguments for constraints
         for (auto mm : genericDecl->members)
         {
             if (auto genericTypeConstraintDecl = as<GenericTypeConstraintDecl>(mm))
             {
-                DeclaredSubtypeWitness* witness = astBuilder->create<DeclaredSubtypeWitness>();
-                witness->declRef = DeclRef<Decl>(genericTypeConstraintDecl, outerSubst);
-                witness->sub = genericTypeConstraintDecl->sub.type;
-                witness->sup = genericTypeConstraintDecl->sup.type;
-                genericSubst->args.add(witness);
+                if (semantics)
+                {
+                    ensureDecl(semantics, genericTypeConstraintDecl, DeclCheckState::ReadyForReference);
+                }
+                auto constraintDeclRef = DeclRef<GenericTypeConstraintDecl>(genericTypeConstraintDecl, outerSubst);
+                DeclaredSubtypeWitness* witness =
+                    astBuilder->getOrCreate<DeclaredSubtypeWitness>(
+                        getSub(astBuilder, constraintDeclRef),
+                        getSup(astBuilder, constraintDeclRef),
+                        genericTypeConstraintDecl,
+                        outerSubst);
+                // TODO: this is an ugly hack to prevent crashing.
+                // In early stages of compilation witness->sub and witness->sup may not be checked yet.
+                // When semanticVisitor is present we have used that to ensure the type is checked.
+                // However due to how the code is written we cannot guarantee semanticVisitor is always available
+                // here, and if we can't get the checked sup/sub type this subst is incomplete and should not be
+                // cached.
+                if (!witness->sub)
+                    shouldCache = false;
+                args.add(witness);
             }
         }
 
+        GenericSubstitution* genericSubst = astBuilder->getOrCreateGenericSubstitution(genericDecl, args, outerSubst);
+        if (shouldCache)
+            astBuilder->m_genericDefaultSubst[genericDecl] = genericSubst;
         return genericSubst;
     }
 
@@ -563,7 +594,8 @@ namespace Slang
     // using their archetypes).
     //
     SubstitutionSet createDefaultSubstitutions(
-        ASTBuilder*     astBuilder, 
+        ASTBuilder*     astBuilder,
+        SemanticsVisitor* semantics,
         Decl*           decl,
         SubstitutionSet outerSubstSet)
     {
@@ -577,6 +609,7 @@ namespace Slang
 
             GenericSubstitution* genericSubst = createDefaultSubstitutionsForGeneric(
                 astBuilder,
+                semantics,
                 genericDecl,
                 outerSubstSet.substitutions);
 
@@ -587,21 +620,17 @@ namespace Slang
     }
 
     SubstitutionSet createDefaultSubstitutions(
-        ASTBuilder* astBuilder, 
+        ASTBuilder* astBuilder,
+        SemanticsVisitor* semantics,
         Decl*   decl)
     {
         SubstitutionSet subst;
         if( auto parentDecl = decl->parentDecl )
         {
-            subst = createDefaultSubstitutions(astBuilder, parentDecl);
+            subst = createDefaultSubstitutions(astBuilder, semantics, parentDecl);
         }
-        subst = createDefaultSubstitutions(astBuilder, decl, subst);
+        subst = createDefaultSubstitutions(astBuilder, semantics, decl, subst);
         return subst;
-    }
-
-    void ensureDecl(SemanticsVisitor* visitor, Decl* decl, DeclCheckState state)
-    {
-        visitor->ensureDecl(decl, state);
     }
 
     bool SemanticsVisitor::isDeclUsableAsStaticMember(
@@ -1195,7 +1224,7 @@ namespace Slang
         {
             if (auto declRefType = as<DeclRefType>(sharedTypeExpr->base))
             {
-                declRefType->declRef.substitutions = createDefaultSubstitutions(m_astBuilder, declRefType->declRef.getDecl());
+                declRefType->declRef.substitutions = createDefaultSubstitutions(m_astBuilder, this, declRefType->declRef.getDecl());
 
                 if (auto typetype = as<TypeType>(typeExp.exp->type))
                     typetype->type = declRefType;
@@ -1754,9 +1783,7 @@ namespace Slang
         // compare `Derived::doThing` against `IBase::doThing<U>` where the `U` there is
         // the parameter of `Dervived::doThing`.
         //
-        GenericSubstitution* requiredSubst = m_astBuilder->create<GenericSubstitution>();
-        requiredSubst->genericDecl = requiredGenericDeclRef.getDecl();
-        requiredSubst->outer = requiredGenericDeclRef.substitutions;
+        List<Val*> requiredSubstArgs;
 
         for (Index i = 0; i < memberCount; i++)
         {
@@ -1769,17 +1796,20 @@ namespace Slang
                 SLANG_ASSERT(satisfyingTypeParamDeclRef);
                 auto satisfyingType = DeclRefType::create(m_astBuilder, satisfyingTypeParamDeclRef);
 
-                requiredSubst->args.add(satisfyingType);
+                requiredSubstArgs.add(satisfyingType);
             }
             else if (auto requiredValueParamDeclRef = requiredMemberDeclRef.as<GenericValueParamDecl>())
             {
                 auto satisfyingValueParamDeclRef = satisfyingMemberDeclRef.as<GenericValueParamDecl>();
                 SLANG_ASSERT(satisfyingValueParamDeclRef);
 
-                auto satisfyingVal = m_astBuilder->create<GenericParamIntVal>();
+                auto satisfyingVal = m_astBuilder->getOrCreate<GenericParamIntVal>(
+                    requiredValueParamDeclRef.getDecl()->getType(),
+                    satisfyingValueParamDeclRef.getDecl(),
+                    satisfyingValueParamDeclRef.substitutions.substitutions);
                 satisfyingVal->declRef = satisfyingValueParamDeclRef;
 
-                requiredSubst->args.add(satisfyingVal);
+                requiredSubstArgs.add(satisfyingVal);
             }
         }
         for (Index i = 0; i < memberCount; i++)
@@ -1792,14 +1822,19 @@ namespace Slang
                 auto satisfyingConstraintDeclRef = satisfyingMemberDeclRef.as<GenericTypeConstraintDecl>();
                 SLANG_ASSERT(satisfyingConstraintDeclRef);
 
-                auto satisfyingWitness = m_astBuilder->create<DeclaredSubtypeWitness>();
+                auto satisfyingWitness = m_astBuilder->getOrCreate<DeclaredSubtypeWitness>();
                 satisfyingWitness->sub = getSub(m_astBuilder, satisfyingConstraintDeclRef);
                 satisfyingWitness->sup = getSup(m_astBuilder, satisfyingConstraintDeclRef);
                 satisfyingWitness->declRef = satisfyingConstraintDeclRef;
 
-                requiredSubst->args.add(satisfyingWitness);
+                requiredSubstArgs.add(satisfyingWitness);
             }
         }
+
+        GenericSubstitution* requiredSubst = m_astBuilder->getOrCreateGenericSubstitution(
+            requiredGenericDeclRef.getDecl(),
+            requiredSubstArgs,
+            requiredGenericDeclRef.substitutions);
 
         // Now that we have computed a set of specialization arguments that will
         // specialize the generic requirement at the type parameters of the satisfying
@@ -2764,13 +2799,15 @@ namespace Slang
 
             auto reqType = getBaseType(m_astBuilder, requiredInheritanceDeclRef);
 
-            DeclaredSubtypeWitness* interfaceIsReqWitness = m_astBuilder->create<DeclaredSubtypeWitness>();
-            interfaceIsReqWitness->sub = superInterfaceType;
-            interfaceIsReqWitness->sup = reqType;
-            interfaceIsReqWitness->declRef = requiredInheritanceDeclRef;
+            DeclaredSubtypeWitness* interfaceIsReqWitness =
+                m_astBuilder->getOrCreate<DeclaredSubtypeWitness>(
+                    superInterfaceType,
+                    reqType,
+                    requiredInheritanceDeclRef.getDecl(),
+                    requiredInheritanceDeclRef.substitutions.substitutions);
             // ...
 
-            TransitiveSubtypeWitness* subIsReqWitness = m_astBuilder->create<TransitiveSubtypeWitness>();
+            TransitiveSubtypeWitness* subIsReqWitness = m_astBuilder->getOrCreateWithDefaultCtor<TransitiveSubtypeWitness>(subType, reqType, interfaceIsReqWitness);
             subIsReqWitness->sub = subType;
             subIsReqWitness->sup = reqType;
             subIsReqWitness->subToMid = subTypeConformsToSuperInterfaceWitness;
@@ -3232,7 +3269,7 @@ namespace Slang
 
     void SemanticsVisitor::checkExtensionConformance(ExtensionDecl* decl)
     {
-        auto declRef = createDefaultSubstitutionsIfNeeded(m_astBuilder, makeDeclRef(decl)).as<ExtensionDecl>();
+        auto declRef = createDefaultSubstitutionsIfNeeded(m_astBuilder, this, makeDeclRef(decl)).as<ExtensionDecl>();
         auto targetType = getTargetType(m_astBuilder, declRef);
 
         for (auto inheritanceDecl : decl->getMembersOfType<InheritanceDecl>())
@@ -3265,7 +3302,7 @@ namespace Slang
 
             auto astBuilder = getASTBuilder();
 
-            auto declRef = createDefaultSubstitutionsIfNeeded(astBuilder, makeDeclRef(decl)).as<AggTypeDeclBase>();
+            auto declRef = createDefaultSubstitutionsIfNeeded(astBuilder, this, makeDeclRef(decl)).as<AggTypeDeclBase>();
             auto type = DeclRefType::create(astBuilder, declRef);
 
             // TODO: Need to figure out what this should do for
@@ -4222,8 +4259,7 @@ namespace Slang
     GenericSubstitution* SemanticsVisitor::createDummySubstitutions(
         GenericDecl* genericDecl)
     {
-        GenericSubstitution* subst = m_astBuilder->create<GenericSubstitution>();
-        subst->genericDecl = genericDecl;
+        List<Val*> args;
         for (auto dd : genericDecl->members)
         {
             if (dd == genericDecl->inner)
@@ -4232,17 +4268,19 @@ namespace Slang
             if (auto typeParam = as<GenericTypeParamDecl>(dd))
             {
                 auto type = DeclRefType::create(m_astBuilder, makeDeclRef(typeParam));
-                subst->args.add(type);
+                args.add(type);
             }
             else if (auto valueParam = as<GenericValueParamDecl>(dd))
             {
-                auto val = m_astBuilder->create<GenericParamIntVal>(
+                auto val = m_astBuilder->getOrCreate<GenericParamIntVal>(
                     valueParam->getType(),
-                    makeDeclRef(valueParam));
-                subst->args.add(val);
+                    valueParam,
+                    nullptr);
+                args.add(val);
             }
             // TODO: need to handle constraints here?
         }
+        GenericSubstitution* subst = m_astBuilder->getOrCreateGenericSubstitution(genericDecl, args, nullptr);
         return subst;
     }
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -202,10 +202,32 @@ namespace Slang
         Substitutions*   subst = nullptr;
     };
 
+    struct LookupRequestKey
+    {
+        Type* type;
+        Name* name;
+        LookupOptions options;
+        LookupMask mask;
+        bool operator==(const LookupRequestKey& other) const
+        {
+            return type == other.type && name == other.name && options == other.options && mask == other.mask;
+        }
+        HashCode getHashCode() const
+        {
+            Hasher hasher;
+            hasher.hashValue(type);
+            hasher.hashValue(name);
+            hasher.hashValue(options);
+            hasher.hashValue(mask);
+            return hasher.getResult();
+        }
+    };
+
     struct TypeCheckingCache
     {
         Dictionary<OperatorOverloadCacheKey, OverloadCandidate> resolvedOperatorOverloadCache;
         Dictionary<BasicTypeKeyPair, ConversionCost> conversionCostCache;
+        Dictionary<LookupRequestKey, LookupResult> lookupCache;
     };
 
         /// Shared state for a semantics-checking session.
@@ -1467,7 +1489,7 @@ namespace Slang
         //
         bool TryCheckOverloadCandidateConstraints(
             OverloadResolveContext&		context,
-            OverloadCandidate const&	candidate);
+            OverloadCandidate&	candidate);
 
         // Try to check an overload candidate, but bail out
         // if any step fails

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -204,18 +204,18 @@ namespace Slang
 
     struct LookupRequestKey
     {
-        Type* type;
+        NodeBase* base;
         Name* name;
         LookupOptions options;
         LookupMask mask;
         bool operator==(const LookupRequestKey& other) const
         {
-            return type == other.type && name == other.name && options == other.options && mask == other.mask;
+            return base == other.base && name == other.name && options == other.options && mask == other.mask;
         }
         HashCode getHashCode() const
         {
             Hasher hasher;
-            hasher.hashValue(type);
+            hasher.hashValue(base);
             hasher.hashValue(name);
             hasher.hashValue(options);
             hasher.hashValue(mask);

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -1120,7 +1120,7 @@ namespace Slang
                     if(!intVal)
                     {
                         sink->diagnose(param.loc, Diagnostics::expectedValueOfTypeForSpecializationArg, paramDecl->getType(), paramDecl);
-                        intVal = getLinkage()->getASTBuilder()->create<ConstantIntVal>(m_astBuilder->getIntType(), 0);
+                        intVal = getLinkage()->getASTBuilder()->getOrCreate<ConstantIntVal>(m_astBuilder->getIntType(), 0);
                     }
 
                     ModuleSpecializationInfo::GenericArgInfo expandedArg;
@@ -1192,15 +1192,18 @@ namespace Slang
             auto genericDeclRef = m_funcDeclRef.getParent().as<GenericDecl>();
             SLANG_ASSERT(genericDeclRef); // otherwise we wouldn't have generic parameters
 
-            GenericSubstitution* genericSubst = getLinkage()->getASTBuilder()->create<GenericSubstitution>();
-            genericSubst->outer = genericDeclRef.substitutions.substitutions;
-            genericSubst->genericDecl = genericDeclRef.getDecl();
+            List<Val*> genericArgs;
 
             for(Index ii = 0; ii < genericSpecializationParamCount; ++ii)
             {
                 auto specializationArg = args[ii];
-                genericSubst->args.add(specializationArg.val);
+                genericArgs.add(specializationArg.val);
             }
+            GenericSubstitution* genericSubst =
+                getLinkage()->getASTBuilder()->getOrCreateGenericSubstitution(
+                    genericDeclRef.getDecl(),
+                    genericArgs,
+                    genericDeclRef.substitutions.substitutions);
 
             for( auto constraintDecl : genericDeclRef.getDecl()->getMembersOfType<GenericTypeConstraintDecl>() )
             {
@@ -1218,7 +1221,7 @@ namespace Slang
                 auto subTypeWitness = visitor.tryGetSubtypeWitness(sub, sup);
                 if(subTypeWitness)
                 {
-                    genericSubst->args.add(subTypeWitness);
+                    genericArgs.add(subTypeWitness);
                 }
                 else
                 {
@@ -1228,6 +1231,11 @@ namespace Slang
                 }
             }
 
+            genericSubst =
+                getLinkage()->getASTBuilder()->getOrCreateGenericSubstitution(
+                    genericDeclRef.getDecl(),
+                    genericArgs,
+                    genericDeclRef.substitutions.substitutions);
             specializedFuncDeclRef.substitutions.substitutions = genericSubst;
         }
 

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -163,7 +163,7 @@ namespace Slang
         }
         else
         {
-            ConstantIntVal* rangeBeginConst = m_astBuilder->create<ConstantIntVal>();
+            ConstantIntVal* rangeBeginConst = m_astBuilder->getOrCreate<ConstantIntVal>();
             rangeBeginConst->value = 0;
             rangeBeginVal = rangeBeginConst;
         }

--- a/source/slang/slang-lookup.cpp
+++ b/source/slang/slang-lookup.cpp
@@ -835,144 +835,166 @@ static void _lookUpInScopes(
         // also finding a hit in another
         for(auto link = scope; link; link = link->nextSibling)
         {
-            auto containerDecl = link->containerDecl;
-
-            // It is possible for the first scope in a list of
-            // siblings to be a "dummy" scope that only exists
-            // to combine the siblings; in that case it will
-            // have a null `containerDecl` and needs to be
-            // skipped over.
-            //
-            if(!containerDecl)
-                continue;
-
-            // TODO: If we need default substitutions to be applied to
-            // the `containerDecl`, then it might make sense to have
-            // each `link` in the scope store a decl-ref instead of
-            // just a decl.
-            //
-            DeclRef<ContainerDecl> containerDeclRef =
-                DeclRef<Decl>(containerDecl, createDefaultSubstitutions(astBuilder, containerDecl)).as<ContainerDecl>();
-            
-            // If the container we are looking into represents a type
-            // or an `extension` of a type, then we need to treat
-            // this step as lookup into the `this` variable (or the
-            // `This` type), which means including any `extension`s
-            // or inheritance clauses in the lookup process.
-            //
-            // Note: The `AggTypeDeclBase` class is the common superclass
-            // between `AggTypeDecl` and `ExtensionDecl`.
-            //
-            if (auto aggTypeDeclBaseRef = containerDeclRef.as<AggTypeDeclBase>())
+            TypeCheckingCache* typeCheckingCache =
+                request.semantics ? request.semantics->getLinkage()->getTypeCheckingCache() : nullptr;
+            LookupRequestKey key = {};
+            key.type = (Type*)link;
+            key.name = name;
+            key.options = request.options;
+            key.mask = request.mask;
+            LookupResult scopeResult;
+            if (typeCheckingCache && typeCheckingCache->lookupCache.TryGetValue(key, scopeResult))
             {
-                // When reconstructing the final expression for a result
-                // looked up through the type or extension, we will need
-                // a `this` expression (or a `This` type expression) to
-                // mark the base of the member reference, so we create
-                // a "breadcrumb" here to track that fact.
-                //
-                BreadcrumbInfo breadcrumb;
-                breadcrumb.kind = LookupResultItem::Breadcrumb::Kind::This;
-                breadcrumb.thisParameterMode = thisParameterMode;
-                breadcrumb.declRef = aggTypeDeclBaseRef;
-                breadcrumb.prev = nullptr;
+                goto scopeEnd;
+            }
+            {
+                auto containerDecl = link->containerDecl;
 
-                Type* type = nullptr;
-                if(auto extDeclRef = aggTypeDeclBaseRef.as<ExtensionDecl>())
+                // It is possible for the first scope in a list of
+                // siblings to be a "dummy" scope that only exists
+                // to combine the siblings; in that case it will
+                // have a null `containerDecl` and needs to be
+                // skipped over.
+                //
+                if (!containerDecl)
+                    continue;
+
+                // TODO: If we need default substitutions to be applied to
+                // the `containerDecl`, then it might make sense to have
+                // each `link` in the scope store a decl-ref instead of
+                // just a decl.
+                //
+                DeclRef<ContainerDecl> containerDeclRef =
+                    DeclRef<Decl>(containerDecl, createDefaultSubstitutions(astBuilder, request.semantics, containerDecl)).as<ContainerDecl>();
+
+                // If the container we are looking into represents a type
+                // or an `extension` of a type, then we need to treat
+                // this step as lookup into the `this` variable (or the
+                // `This` type), which means including any `extension`s
+                // or inheritance clauses in the lookup process.
+                //
+                // Note: The `AggTypeDeclBase` class is the common superclass
+                // between `AggTypeDecl` and `ExtensionDecl`.
+                //
+                if (auto aggTypeDeclBaseRef = containerDeclRef.as<AggTypeDeclBase>())
                 {
-                    if( request.semantics )
+                    // When reconstructing the final expression for a result
+                    // looked up through the type or extension, we will need
+                    // a `this` expression (or a `This` type expression) to
+                    // mark the base of the member reference, so we create
+                    // a "breadcrumb" here to track that fact.
+                    //
+                    BreadcrumbInfo breadcrumb;
+                    breadcrumb.kind = LookupResultItem::Breadcrumb::Kind::This;
+                    breadcrumb.thisParameterMode = thisParameterMode;
+                    breadcrumb.declRef = aggTypeDeclBaseRef;
+                    breadcrumb.prev = nullptr;
+
+                    Type* type = nullptr;
+                    if (auto extDeclRef = aggTypeDeclBaseRef.as<ExtensionDecl>())
                     {
-                        ensureDecl(request.semantics, extDeclRef.getDecl(), DeclCheckState::CanUseExtensionTargetType);
+                        if (request.semantics)
+                        {
+                            ensureDecl(request.semantics, extDeclRef.getDecl(), DeclCheckState::CanUseExtensionTargetType);
+                        }
+
+                        // If we are doing lookup from inside an `extension`
+                        // declaration, then the `this` expression will have
+                        // a type that uses the "target type" of the `extension`.
+                        //
+                        type = getTargetType(astBuilder, extDeclRef);
+                    }
+                    else
+                    {
+                        assert(aggTypeDeclBaseRef.as<AggTypeDecl>());
+                        type = DeclRefType::create(astBuilder, aggTypeDeclBaseRef);
                     }
 
-                    // If we are doing lookup from inside an `extension`
-                    // declaration, then the `this` expression will have
-                    // a type that uses the "target type" of the `extension`.
-                    //
-                    type = getTargetType(astBuilder, extDeclRef);
+                    _lookUpMembersInType(astBuilder, name, type, request, scopeResult, &breadcrumb);
                 }
                 else
                 {
-                    assert(aggTypeDeclBaseRef.as<AggTypeDecl>());
-                    type = DeclRefType::create(astBuilder, aggTypeDeclBaseRef);
-                }
-
-                _lookUpMembersInType(astBuilder, name, type, request, result, &breadcrumb);
-            }
-            else
-            {
-                // The default case is when the scope doesn't represent a
-                // type or `extension` declaration, so we can look up members
-                // in that scope much more simply.
-                //
-                _lookUpDirectAndTransparentMembers(astBuilder, name, containerDeclRef, request, result, nullptr);
-            }
-
-            // Before we proceed up to the next outer scope to perform lookup
-            // again, we need to consider what the current scope tells us
-            // about how to interpret uses of implicit `this` or `This`. For
-            // example, if we are inside a `[mutating]` method, then the implicit
-            // `this` that we use for lookup should be an l-value.
-            //
-            // Similarly, if we look up a member in a type from the scope
-            // of some nested type, then there shouldn't be an implicit `this`
-            // expression for the outer type, but instead an implicit `This`.
-            //
-            if( containerDeclRef.is<ConstructorDecl>() )
-            {
-                // In the context of an `__init` declaration, the members of
-                // the surrounding type are accessible through a mutable `this`.
-                //
-                thisParameterMode = LookupResultItem::Breadcrumb::ThisParameterMode::MutableValue;
-            }
-            else if( containerDeclRef.is<SetterDecl>() )
-            {
-                // In the context of a `set` accessor, the members of the
-                // surrounding type are accessible through a mutable `this`.
-                //
-                // TODO: At some point we may want a way to opt out of this
-                // behavior; it is possible to have a setter on a `struct`
-                // that actually just sets data into a buffer that is
-                // referenced by one of the `struct`'s fields.
-                //
-                thisParameterMode = LookupResultItem::Breadcrumb::ThisParameterMode::MutableValue;
-            }
-            else if( auto funcDeclRef = containerDeclRef.as<FunctionDeclBase>() )
-            {
-                // The implicit `this`/`This` for a function-like declaration
-                // depends on modifiers attached to the declaration.
-                //
-                if( funcDeclRef.getDecl()->hasModifier<HLSLStaticModifier>() )
-                {
-                    // A `static` method only has access to an implicit `This`,
-                    // and does not have a `this` expression available.
+                    // The default case is when the scope doesn't represent a
+                    // type or `extension` declaration, so we can look up members
+                    // in that scope much more simply.
                     //
-                    thisParameterMode = LookupResultItem::Breadcrumb::ThisParameterMode::Type;
+                    _lookUpDirectAndTransparentMembers(astBuilder, name, containerDeclRef, request, scopeResult, nullptr);
                 }
-                else if( funcDeclRef.getDecl()->hasModifier<MutatingAttribute>() )
+
+                // Before we proceed up to the next outer scope to perform lookup
+                // again, we need to consider what the current scope tells us
+                // about how to interpret uses of implicit `this` or `This`. For
+                // example, if we are inside a `[mutating]` method, then the implicit
+                // `this` that we use for lookup should be an l-value.
+                //
+                // Similarly, if we look up a member in a type from the scope
+                // of some nested type, then there shouldn't be an implicit `this`
+                // expression for the outer type, but instead an implicit `This`.
+                //
+                if (containerDeclRef.is<ConstructorDecl>())
                 {
-                    // In a non-`static` method marked `[mutating]` there is
-                    // an implicit `this` parameter that is mutable.
+                    // In the context of an `__init` declaration, the members of
+                    // the surrounding type are accessible through a mutable `this`.
                     //
                     thisParameterMode = LookupResultItem::Breadcrumb::ThisParameterMode::MutableValue;
                 }
-                else
+                else if (containerDeclRef.is<SetterDecl>())
                 {
-                    // In all other cases, there is an implicit `this` parameter
-                    // that is immutable.
+                    // In the context of a `set` accessor, the members of the
+                    // surrounding type are accessible through a mutable `this`.
                     //
-                    thisParameterMode = LookupResultItem::Breadcrumb::ThisParameterMode::ImmutableValue;
+                    // TODO: At some point we may want a way to opt out of this
+                    // behavior; it is possible to have a setter on a `struct`
+                    // that actually just sets data into a buffer that is
+                    // referenced by one of the `struct`'s fields.
+                    //
+                    thisParameterMode = LookupResultItem::Breadcrumb::ThisParameterMode::MutableValue;
                 }
+                else if (auto funcDeclRef = containerDeclRef.as<FunctionDeclBase>())
+                {
+                    // The implicit `this`/`This` for a function-like declaration
+                    // depends on modifiers attached to the declaration.
+                    //
+                    if (funcDeclRef.getDecl()->hasModifier<HLSLStaticModifier>())
+                    {
+                        // A `static` method only has access to an implicit `This`,
+                        // and does not have a `this` expression available.
+                        //
+                        thisParameterMode = LookupResultItem::Breadcrumb::ThisParameterMode::Type;
+                    }
+                    else if (funcDeclRef.getDecl()->hasModifier<MutatingAttribute>())
+                    {
+                        // In a non-`static` method marked `[mutating]` there is
+                        // an implicit `this` parameter that is mutable.
+                        //
+                        thisParameterMode = LookupResultItem::Breadcrumb::ThisParameterMode::MutableValue;
+                    }
+                    else
+                    {
+                        // In all other cases, there is an implicit `this` parameter
+                        // that is immutable.
+                        //
+                        thisParameterMode = LookupResultItem::Breadcrumb::ThisParameterMode::ImmutableValue;
+                    }
+                }
+                else if (containerDeclRef.as<AggTypeDeclBase>())
+                {
+                    // When lookup moves from a nested typed declaration to an
+                    // outer scope, there is no ability to use an implicit `this`
+                    // expression, and we have only the `This` type available.
+                    //
+                    thisParameterMode = LookupResultItem::Breadcrumb::ThisParameterMode::Type;
+                }
+                // TODO: What other cases need to be enumerated here?
             }
-            else if( containerDeclRef.as<AggTypeDeclBase>() )
+        scopeEnd:
+            if (typeCheckingCache)
             {
-                // When lookup moves from a nested typed declaration to an
-                // outer scope, there is no ability to use an implicit `this`
-                // expression, and we have only the `This` type available.
-                //
-                thisParameterMode = LookupResultItem::Breadcrumb::ThisParameterMode::Type;
+                typeCheckingCache->lookupCache[key] = scopeResult;
             }
-            // TODO: What other cases need to be enumerated here?
+
+            for (auto& item : scopeResult)
+                AddToLookupResult(result, item);
         }
 
         if (result.isValid())
@@ -1016,9 +1038,20 @@ LookupResult lookUpMember(
     LookupMask          mask,
     LookupOptions       options)
 {
-    LookupRequest request = initLookupRequest(semantics, name, mask, options, nullptr);
+    TypeCheckingCache* typeCheckingCache = semantics->getLinkage()->getTypeCheckingCache();
+    LookupRequestKey key;
+    key.type = type;
+    key.name = name;
+    key.options = options;
+    key.mask = mask;
     LookupResult result;
+    if (typeCheckingCache->lookupCache.TryGetValue(key, result))
+    {
+        return result;
+    }
+    LookupRequest request = initLookupRequest(semantics, name, mask, options, nullptr);
     _lookUpMembersInType(astBuilder, name, type, request, result, nullptr);
+    typeCheckingCache->lookupCache[key] = result;
     return result;
 }
 

--- a/source/slang/slang-mangle.cpp
+++ b/source/slang/slang-mangle.cpp
@@ -374,9 +374,9 @@ namespace Slang
             {
                 // This is the case where we *do* have substitutions.
                 emitRaw(context, "G");
-                UInt genericArgCount = subst->args.getCount();
+                UInt genericArgCount = subst->getArgs().getCount();
                 emit(context, genericArgCount);
-                for( auto aa : subst->args )
+                for (auto aa : subst->getArgs())
                 {
                     emitVal(context, aa);
                 }

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -355,6 +355,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     DeclRef<Decl> createDefaultSubstitutionsIfNeeded(
         ASTBuilder*     astBuilder,
+        SemanticsVisitor* semantics,
         DeclRef<Decl>   declRef)
     {
         // It is possible that `declRef` refers to a generic type,
@@ -413,7 +414,8 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
                 if(!foundSubst)
                 {
                     Substitutions* newSubst = createDefaultSubstitutionsForGeneric(
-                        astBuilder, 
+                        astBuilder,
+                        semantics,
                         genericParentDecl,
                         nullptr);
 
@@ -436,7 +438,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         ASTBuilder*     astBuilder,
         DeclRef<Decl>   declRef)
     {
-        declRef = createDefaultSubstitutionsIfNeeded(astBuilder, declRef);
+        declRef = createDefaultSubstitutionsIfNeeded(astBuilder, nullptr, declRef);
 
         if (auto builtinMod = declRef.getDecl()->findModifier<BuiltinTypeModifier>())
         {
@@ -458,58 +460,60 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
             if (magicMod->magicName == "SamplerState")
             {
-                auto type = astBuilder->create<SamplerStateType>();
+                auto type = astBuilder->getOrCreate<SamplerStateType>(SamplerStateFlavor(magicMod->tag));
                 type->declRef = declRef;
-                type->flavor = SamplerStateFlavor(magicMod->tag);
                 return type;
             }
             else if (magicMod->magicName == "Vector")
             {
-                SLANG_ASSERT(subst && subst->args.getCount() == 2);
-                auto vecType = astBuilder->create<VectorExpressionType>();
+                SLANG_ASSERT(subst && subst->getArgs().getCount() == 2);
+                auto vecType = astBuilder->getOrCreate<VectorExpressionType>(ExtractGenericArgType(subst->getArgs()[0]), ExtractGenericArgInteger(subst->getArgs()[1]));
                 vecType->declRef = declRef;
-                vecType->elementType = ExtractGenericArgType(subst->args[0]);
-                vecType->elementCount = ExtractGenericArgInteger(subst->args[1]);
+                vecType->elementType = ExtractGenericArgType(subst->getArgs()[0]);
+                vecType->elementCount = ExtractGenericArgInteger(subst->getArgs()[1]);
                 return vecType;
             }
             else if (magicMod->magicName == "Matrix")
             {
-                SLANG_ASSERT(subst && subst->args.getCount() == 3);
-                auto matType = astBuilder->create<MatrixExpressionType>();
+                SLANG_ASSERT(subst && subst->getArgs().getCount() == 3);
+                auto matType = astBuilder->getOrCreate<MatrixExpressionType>(
+                    ExtractGenericArgType(subst->getArgs()[0]),
+                    ExtractGenericArgInteger(subst->getArgs()[1]),
+                    ExtractGenericArgInteger(subst->getArgs()[2]));
                 matType->declRef = declRef;
                 return matType;
             }
             else if (magicMod->magicName == "Texture")
             {
-                SLANG_ASSERT(subst && subst->args.getCount() >= 1);
-                auto textureType = astBuilder->create<TextureType>(
+                SLANG_ASSERT(subst && subst->getArgs().getCount() >= 1);
+                auto textureType = astBuilder->getOrCreate<TextureType>(
                     TextureFlavor(magicMod->tag),
-                    ExtractGenericArgType(subst->args[0]));
+                    ExtractGenericArgType(subst->getArgs()[0]));
                 textureType->declRef = declRef;
                 return textureType;
             }
             else if (magicMod->magicName == "TextureSampler")
             {
-                SLANG_ASSERT(subst && subst->args.getCount() >= 1);
+                SLANG_ASSERT(subst && subst->getArgs().getCount() >= 1);
                 auto textureType = astBuilder->create<TextureSamplerType>(
                     TextureFlavor(magicMod->tag),
-                    ExtractGenericArgType(subst->args[0]));
+                    ExtractGenericArgType(subst->getArgs()[0]));
                 textureType->declRef = declRef;
                 return textureType;
             }
             else if (magicMod->magicName == "GLSLImageType")
             {
-                SLANG_ASSERT(subst && subst->args.getCount() >= 1);
-                auto textureType = astBuilder->create<GLSLImageType>(
+                SLANG_ASSERT(subst && subst->getArgs().getCount() >= 1);
+                auto textureType = astBuilder->getOrCreate<GLSLImageType>(
                     TextureFlavor(magicMod->tag),
-                    ExtractGenericArgType(subst->args[0]));
+                    ExtractGenericArgType(subst->getArgs()[0]));
                 textureType->declRef = declRef;
                 return textureType;
             }
             else if (magicMod->magicName == "FeedbackType")
             {
                 SLANG_ASSERT(subst == nullptr);
-                auto type = astBuilder->create<FeedbackType>();
+                auto type = astBuilder->getOrCreateWithDefaultCtor<FeedbackType>(magicMod->tag);
                 type->declRef = declRef;
                 type->kind = FeedbackType::Kind(magicMod->tag);
                 return type;
@@ -519,11 +523,13 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
             // and we can drive the dispatch with a table instead
             // of this ridiculously slow `if` cascade.
 
-        #define CASE(n,T)													\
-            else if(magicMod->magicName == #n) {									\
-                auto type = astBuilder->create<T>();						\
-                type->declRef = declRef;									\
-                return type;												\
+        #define CASE(n, T)                                              \
+            else if (magicMod->magicName == #n)                         \
+            {                                                           \
+                auto type = astBuilder->getOrCreateWithDefaultCtor<T>(  \
+                    declRef.decl, declRef.substitutions.substitutions); \
+                type->declRef = declRef;                                \
+                return type;                                            \
             }
 
             CASE(HLSLInputPatchType, HLSLInputPatchType)
@@ -531,14 +537,16 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
         #undef CASE
 
-            #define CASE(n,T)													\
-                else if(magicMod->magicName == #n) {									\
-                    SLANG_ASSERT(subst && subst->args.getCount() == 1);			\
-                    auto type = astBuilder->create<T>();						\
-                    type->elementType = ExtractGenericArgType(subst->args[0]);	\
-                    type->declRef = declRef;									\
-                    return type;												\
-                }
+        #define CASE(n, T)                                                                            \
+            else if (magicMod->magicName == #n)                                                       \
+            {                                                                                         \
+                SLANG_ASSERT(subst && subst->getArgs().getCount() == 1);                                   \
+                auto type =                                                                           \
+                    astBuilder->getOrCreateWithDefaultCtor<T>(ExtractGenericArgType(subst->getArgs()[0])); \
+                type->elementType = ExtractGenericArgType(subst->getArgs()[0]);                            \
+                type->declRef = declRef;                                                              \
+                return type;                                                                          \
+            }
 
             CASE(ConstantBuffer, ConstantBufferType)
             CASE(TextureBuffer, TextureBufferType)
@@ -561,8 +569,8 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
             // "magic" builtin types which have no generic parameters
             #define CASE(n,T)													\
-                else if(magicMod->magicName == #n) {									\
-                    auto type = astBuilder->create<T>();						\
+                else if(magicMod->magicName == #n) {		     				\
+                    auto type = astBuilder->getOrCreate<T>();					\
                     type->declRef = declRef;									\
                     return type;												\
                 }
@@ -601,7 +609,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         }
         else
         {
-            return astBuilder->create<DeclRefType>(declRef);
+            return astBuilder->getOrCreateDeclRefType(declRef.decl, declRef.substitutions.substitutions);
         }
     }
 
@@ -786,10 +794,8 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
                         substsToApply,
                         &diff);
 
-                    GenericSubstitution* firstSubst = astBuilder->create<GenericSubstitution>();
-                    firstSubst->genericDecl = ancestorGenericDecl;
-                    firstSubst->args = appGenericSubst->args;
-                    firstSubst->outer = restSubst;
+                    GenericSubstitution* firstSubst = astBuilder->getOrCreateGenericSubstitution(
+                        ancestorGenericDecl, appGenericSubst->getArgs(), restSubst);
 
                     (*ioDiff)++;
                     return firstSubst;
@@ -849,10 +855,8 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
                         substsToApply,
                         &diff);
 
-                    ThisTypeSubstitution* firstSubst = astBuilder->create<ThisTypeSubstitution>();
-                    firstSubst->interfaceDecl = ancestorInterfaceDecl;
-                    firstSubst->witness = appThisTypeSubst->witness;
-                    firstSubst->outer = restSubst;
+                    ThisTypeSubstitution* firstSubst = astBuilder->getOrCreateThisTypeSubstitution(
+                        ancestorInterfaceDecl, appThisTypeSubst->witness, restSubst);
 
                     (*ioDiff)++;
                     return firstSubst;
@@ -1013,12 +1017,12 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     Type* HLSLPatchType::getElementType()
     {
-        return as<Type>(findInnerMostGenericSubstitution(declRef.substitutions)->args[0]);
+        return as<Type>(findInnerMostGenericSubstitution(declRef.substitutions)->getArgs()[0]);
     }
 
     IntVal* HLSLPatchType::getElementCount()
     {
-        return as<IntVal>(findInnerMostGenericSubstitution(declRef.substitutions)->args[1]);
+        return as<IntVal>(findInnerMostGenericSubstitution(declRef.substitutions)->getArgs()[1]);
     }
 
     // Constructors for types
@@ -1047,7 +1051,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         ASTBuilder*                 astBuilder,
         DeclRef<TypeDefDecl> const& declRef)
     {
-        DeclRef<TypeDefDecl> specializedDeclRef = createDefaultSubstitutionsIfNeeded(astBuilder, declRef).as<TypeDefDecl>();
+        DeclRef<TypeDefDecl> specializedDeclRef = createDefaultSubstitutionsIfNeeded(astBuilder, nullptr, declRef).as<TypeDefDecl>();
 
         return astBuilder->create<NamedExpressionType>(specializedDeclRef);
     }
@@ -1179,7 +1183,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
             {
                 out << "<";
                 bool isFirst = true;
-                for (const auto& it : genericSubstitution->args)
+                for (const auto& it : genericSubstitution->getArgs())
                 {
                     if (!isFirst)
                         out << ", ";

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -286,20 +286,24 @@ namespace Slang
 
     // TODO: where should this live?
     SubstitutionSet createDefaultSubstitutions(
-        ASTBuilder*     astBuilder, 
+        ASTBuilder*     astBuilder,
+        SemanticsVisitor* semantics,
         Decl*           decl,
         SubstitutionSet  parentSubst);
 
     SubstitutionSet createDefaultSubstitutions(
-        ASTBuilder*     astBuilder, 
+        ASTBuilder*     astBuilder,
+        SemanticsVisitor* semantics,
         Decl*   decl);
 
     DeclRef<Decl> createDefaultSubstitutionsIfNeeded(
-        ASTBuilder*     astBuilder, 
+        ASTBuilder*     astBuilder,
+        SemanticsVisitor* semantics,
         DeclRef<Decl>   declRef);
 
     GenericSubstitution* createDefaultSubstitutionsForGeneric(
-        ASTBuilder*             astBuilder, 
+        ASTBuilder*             astBuilder,
+        SemanticsVisitor* semantics,
         GenericDecl*            genericDecl,
         Substitutions*   outerSubst);
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -1178,7 +1178,7 @@ SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL Linkage::getContainerType(
                 ConstantBufferType* cbType = getASTBuilder()->create<ConstantBufferType>();
                 cbType->elementType = type;
                 cbType->declRef = getASTBuilder()->getBuiltinDeclRef(
-                    "ConstantBuffer", makeConstArrayViewSingle<Val*>(static_cast<Val*>(type)));
+                    "ConstantBuffer", static_cast<Val*>(type));
                 containerTypeReflection = cbType;
             }
             break;
@@ -1187,7 +1187,7 @@ SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL Linkage::getContainerType(
                 ParameterBlockType* pbType = getASTBuilder()->create<ParameterBlockType>();
                 pbType->elementType = type;
                 pbType->declRef = getASTBuilder()->getBuiltinDeclRef(
-                    "ParameterBlock", makeConstArrayViewSingle<Val*>(static_cast<Val*>(type)));
+                    "ParameterBlock", static_cast<Val*>(type));
                 containerTypeReflection = pbType;
             }
             break;
@@ -1197,7 +1197,7 @@ SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL Linkage::getContainerType(
                     getASTBuilder()->create<HLSLStructuredBufferType>();
                 sbType->elementType = type;
                 sbType->declRef = getASTBuilder()->getBuiltinDeclRef(
-                    "HLSLStructuredBufferType", makeConstArrayViewSingle<Val*>(static_cast<Val*>(type)));
+                    "HLSLStructuredBufferType", static_cast<Val*>(type));
                 containerTypeReflection = sbType;
             }
             break;
@@ -3839,7 +3839,7 @@ struct SpecializationArgModuleCollector : ComponentTypeVisitor
     {
         if(auto genericSubst = as<GenericSubstitution>(substitution))
         {
-            for(auto arg : genericSubst->args)
+            for(auto arg : genericSubst->getArgs())
             {
                 collectReferencedModules(arg);
             }


### PR DESCRIPTION
This change extends `ASTBuilder::getOrCreate` to handle more cases, and use it for creating type nodes, substitutions, witnesses, and int vals.

Also added a cache for lookups.