### PR TITLE
Fix d3d12 implementation of `uploadBufferData`.

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1894,6 +1894,7 @@ class ICommandBufferD3D12 : public ICommandBuffer
 {
 public:
     virtual SLANG_NO_THROW void SLANG_MCALL invalidateDescriptorHeapBinding() = 0;
+    virtual SLANG_NO_THROW void SLANG_MCALL ensureInternalDescriptorHeapsBound() = 0;
 };
 #define SLANG_UUID_ICommandBufferD3D12                                                 \
     {                                                                                  \

--- a/tools/gfx/d3d12/d3d12-command-buffer.h
+++ b/tools/gfx/d3d12/d3d12-command-buffer.h
@@ -49,6 +49,7 @@ public:
     void bindDescriptorHeaps();
 
     virtual SLANG_NO_THROW void SLANG_MCALL invalidateDescriptorHeapBinding() override { m_descriptorHeapsBound = false; }
+    virtual SLANG_NO_THROW void SLANG_MCALL ensureInternalDescriptorHeapsBound() override { bindDescriptorHeaps(); }
 
     void reinit();
 

--- a/tools/gfx/d3d12/d3d12-helper-functions.cpp
+++ b/tools/gfx/d3d12/d3d12-helper-functions.cpp
@@ -408,7 +408,10 @@ Result uploadBufferDataImpl(
         SLANG_RETURN_ON_FAIL(transientHeap->allocateStagingBuffer(
             size, uploadResource, uploadResourceOffset, MemoryType::Upload));
     }
-
+    else
+    {
+        uploadResourceOffset = offset;
+    }
     D3D12Resource& uploadResourceRef =
         (buffer->getDesc()->memoryType == MemoryType::Upload)
         ? buffer->m_resource

--- a/tools/gfx/d3d12/d3d12-helper-functions.cpp
+++ b/tools/gfx/d3d12/d3d12-helper-functions.cpp
@@ -420,10 +420,10 @@ Result uploadBufferDataImpl(
     void* uploadData;
     SLANG_RETURN_ON_FAIL(
         uploadResourceRef.getResource()->Map(0, &readRange, reinterpret_cast<void**>(&uploadData)));
-    memcpy((uint8_t*)uploadData + uploadResourceOffset + offset, data, size);
+    memcpy((uint8_t*)uploadData + uploadResourceOffset, data, size);
     D3D12_RANGE writtenRange = {};
-    writtenRange.Begin = uploadResourceOffset + offset;
-    writtenRange.End = uploadResourceOffset + offset + size;
+    writtenRange.Begin = uploadResourceOffset;
+    writtenRange.End = uploadResourceOffset + size;
     uploadResourceRef.getResource()->Unmap(0, &writtenRange);
 
     if (buffer->getDesc()->memoryType != MemoryType::Upload)
@@ -432,7 +432,7 @@ Result uploadBufferDataImpl(
             buffer->m_resource.getResource(),
             offset,
             uploadResourceRef.getResource(),
-            uploadResourceOffset + offset,
+            uploadResourceOffset,
             size);
     }
 


### PR DESCRIPTION
Also added `ICommandBufferD3D12::ensureInternalDescriptorHeapsBound()` for raw d3d api interop.