### PR TITLE
Use `printf` in tests.

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -605,6 +605,9 @@ struct NativeString
     Ptr<void> getBuffer();
 
     property int length { [__unsafeForceInlineEarly] get{return getLength();} }
+
+    __intrinsic_op($(kIROp_getNativeStr))
+    __init(String value);
 };
 
 extension Ptr<void>

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -2736,35 +2736,70 @@ matrix<T,N,M> pow(matrix<T,N,M> x, matrix<T,N,M> y)
 }
 
 // Output message
+// TODO: add check to ensure format is const literal.
+
 __target_intrinsic(hlsl)
+__target_intrinsic(cpp)
+__target_intrinsic(cuda)
 __glsl_extension(GL_EXT_debug_printf)
 __target_intrinsic(glsl, "debugPrintfEXT($0)")
 void printf(NativeString format);
 
 __target_intrinsic(hlsl)
+__target_intrinsic(cpp)
+__target_intrinsic(cuda)
 __glsl_extension(GL_EXT_debug_printf)
 __target_intrinsic(glsl, "debugPrintfEXT($0, $1)")
 void printf<T0>(NativeString format, T0 arg0);
 
 __target_intrinsic(hlsl)
+__target_intrinsic(cpp)
+__target_intrinsic(cuda)
 __glsl_extension(GL_EXT_debug_printf)
 __target_intrinsic(glsl, "debugPrintfEXT($0, $1, $2)")
 void printf<T0, T1>(NativeString format, T0 arg0, T1 arg1);
 
 __target_intrinsic(hlsl)
+__target_intrinsic(cpp)
+__target_intrinsic(cuda)
 __glsl_extension(GL_EXT_debug_printf)
 __target_intrinsic(glsl, "debugPrintfEXT($0, $1, $2, $3)")
 void printf<T0, T1, T2>(NativeString format, T0 arg0, T1 arg1, T2 arg2);
 
 __target_intrinsic(hlsl)
+__target_intrinsic(cpp)
+__target_intrinsic(cuda)
 __glsl_extension(GL_EXT_debug_printf)
 __target_intrinsic(glsl, "debugPrintfEXT($0, $1, $2, $3, $4)")
 void printf<T0, T1, T2, T3>(NativeString format, T0 arg0, T1 arg1, T2 arg2, T3 arg3);
 
 __target_intrinsic(hlsl)
+__target_intrinsic(cpp)
+__target_intrinsic(cuda)
 __glsl_extension(GL_EXT_debug_printf)
 __target_intrinsic(glsl, "debugPrintfEXT($0, $1, $2, $3, $4, $5)")
 void printf<T0, T1, T2, T3, T4>(NativeString format, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4);
+
+__target_intrinsic(hlsl)
+__target_intrinsic(cpp)
+__target_intrinsic(cuda)
+__glsl_extension(GL_EXT_debug_printf)
+__target_intrinsic(glsl, "debugPrintfEXT($0, $1, $2, $3, $4, $5, $6)")
+void printf<T0, T1, T2, T3, T4, T5>(NativeString format, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5);
+
+__target_intrinsic(hlsl)
+__target_intrinsic(cpp)
+__target_intrinsic(cuda)
+__glsl_extension(GL_EXT_debug_printf)
+__target_intrinsic(glsl, "debugPrintfEXT($0, $1, $2, $3, $4, $5, $6, $7)")
+void printf<T0, T1, T2, T3, T4, T5, T6>(NativeString format, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6);
+
+__target_intrinsic(hlsl)
+__target_intrinsic(cpp)
+__target_intrinsic(cuda)
+__glsl_extension(GL_EXT_debug_printf)
+__target_intrinsic(glsl, "debugPrintfEXT($0, $1, $2, $3, $4, $5, $6, $7, $8)")
+void printf<T0, T1, T2, T3, T4, T5, T6, T7>(NativeString format, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7);
 
 // Tessellation factor fixup routines
 

--- a/tests/cpu-program/class-com.slang
+++ b/tests/cpu-program/class-com.slang
@@ -1,7 +1,4 @@
 //TEST:EXECUTABLE:
-__target_intrinsic(cpp, "printf(\"%s\\n\", ($0).getBuffer())")
-void writeln(String text);
-
 [COM("BE18F5D2-4522-4AB0-A6EE-1D157FA2B083")]
 interface IFoo
 {
@@ -17,7 +14,7 @@ class MyClass : IFoo
     }
     int method()
     {
-        writeln("method");
+        printf("method\n");
         return intMember;
     }
 };

--- a/tests/cpu-program/class.slang
+++ b/tests/cpu-program/class.slang
@@ -1,7 +1,4 @@
 //TEST:EXECUTABLE:
-__target_intrinsic(cpp, "printf(\"%s\\n\", ($0).getBuffer())")
-void writeln(String text);
-
 class MyClass
 {
     int intMember;
@@ -11,7 +8,7 @@ class MyClass
     }
     int method()
     {
-        writeln("method");
+        printf("method\n");
         return intMember;
     }
 }

--- a/tests/cpu-program/cpu-hello-world.slang
+++ b/tests/cpu-program/cpu-hello-world.slang
@@ -1,9 +1,7 @@
 //TEST:EXECUTABLE:
-__target_intrinsic(cpp, "printf(\"%s\\n\", ($0).getBuffer())")
-void writeln(String text);
 
 public __extern_cpp int main()
 {
-    writeln("Hello World.");
+    printf("Hello World.\n");
     return 0;
 }

--- a/tests/cpu-program/gfx-smoke.slang
+++ b/tests/cpu-program/gfx-smoke.slang
@@ -1,7 +1,4 @@
 //TEST:EXECUTABLE:
-__target_intrinsic(cpp, "printf(\"%s\\n\", ($0).getBuffer())")
-void writeln(String text);
-
 import gfx;
 import slang;
 
@@ -13,7 +10,7 @@ public __extern_cpp int main()
     gfx.gfxCreateDevice(&deviceDesc, device);
     if (device == none)
     {
-        writeln("fail");
+        printf("fail\n");
         return -1;
     }
     
@@ -98,7 +95,7 @@ public __extern_cpp int main()
     for (int i = 0; i < 4; i++)
     {
         float val = ((float *)blob.value.getBufferPointer())[i];
-        writeln(String(val));
+        printf("%.1f\n", val);
     }
     return 0;
 }

--- a/tests/cpu-program/gfx-smoke.slang.expected
+++ b/tests/cpu-program/gfx-smoke.slang.expected
@@ -2,8 +2,8 @@ result code = 0
 standard error = {
 }
 standard output = {
-0
-1
-2
-3
+0.0
+1.0
+2.0
+3.0
 }

--- a/tests/cpu-program/pointer-basics.slang
+++ b/tests/cpu-program/pointer-basics.slang
@@ -1,7 +1,4 @@
 //TEST:EXECUTABLE:
-__target_intrinsic(cpp, "printf(\"%s\\n\", ($0).getBuffer())")
-void writeln(String text);
-
 public __extern_cpp int main()
 {
     uint2 value;
@@ -19,8 +16,8 @@ public __extern_cpp int main()
         && ptrVal != 0
         && value[0] == 3
         && pValue[1] == 1)
-        writeln("Success");
+        printf("Success\n");
     else
-        writeln("Fail");
+        printf("Fail\n");
     return 0;
 }

--- a/tests/cpu-program/pointer-deref.slang
+++ b/tests/cpu-program/pointer-deref.slang
@@ -1,7 +1,4 @@
 //TEST:EXECUTABLE:
-__target_intrinsic(cpp, "printf(\"%s\\n\", ($0).getBuffer())")
-void writeln(String text);
-
 struct SubRecord
 {
     int field2;
@@ -23,11 +20,11 @@ public __extern_cpp int main()
     pRec.sub.field3 = 3.0f;
     if (rec.field == 1 && rec.sub.field2 == 2 && pRec.sub.field3 == 3.0f)
     {
-        writeln("success");
+        printf("success\n");
     }
     else
     {
-        writeln("fail");
+        printf("fail\n");
     }
     return 0;
 }


### PR DESCRIPTION
Now that `printf` is defined in stdlib, we can use them instead of custom-defined target intrinsic functions in our tests.