### PR TITLE
Fix regression in check-overload.

### DIFF
--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -494,6 +494,8 @@ class PartiallyAppliedGenericExpr : public Expr
     SLANG_AST_CLASS(PartiallyAppliedGenericExpr);
 
 public:
+    Expr* originalExpr = nullptr;
+
         /// The generic being applied
     DeclRef<GenericDecl> baseGenericDeclRef;
 

--- a/source/slang/slang-ast-iterator.h
+++ b/source/slang/slang-ast-iterator.h
@@ -258,6 +258,10 @@ struct ASTIterator
             dispatchIfNotNull(expr->value);
             dispatchIfNotNull(expr->typeExpr);
         }
+        void visitPartiallyAppliedGenericExpr(PartiallyAppliedGenericExpr* expr)
+        {
+            dispatchIfNotNull(expr->originalExpr);
+        }
     };
 
     struct ASTIteratorStmtVisitor : public StmtVisitor<ASTIteratorStmtVisitor>

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -729,7 +729,7 @@ namespace Slang
                 {
                     auto expr = m_astBuilder->create<PartiallyAppliedGenericExpr>();
                     expr->loc = context.loc;
-
+                    expr->originalExpr = originalAppExpr;
                     expr->baseGenericDeclRef = as<DeclRefExpr>(baseExpr)->declRef.as<GenericDecl>();
                     expr->substWithKnownGenericArgs = (GenericSubstitution*)candidate.subst;
                     return expr;

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1418,7 +1418,10 @@ namespace Slang
         }
         else if (auto genericDeclRef = item.declRef.as<GenericDecl>())
         {
-            addOverloadCandidatesForCallToGeneric(LookupResultItem(genericDeclRef), context);
+            LookupResultItem innerItem;
+            innerItem.breadcrumbs = item.breadcrumbs;
+            innerItem.declRef = genericDeclRef;
+            addOverloadCandidatesForCallToGeneric(innerItem, context);
         }
         else if( auto typeDefDeclRef = item.declRef.as<TypeDefDecl>() )
         {

--- a/source/slang/slang-language-server-ast-lookup.cpp
+++ b/source/slang/slang-language-server-ast-lookup.cpp
@@ -402,6 +402,10 @@ public:
             return true;
         return dispatchIfNotNull(expr->value);
     }
+    bool visitPartiallyAppliedGenericExpr(PartiallyAppliedGenericExpr* expr)
+    {
+        return dispatchIfNotNull(expr->originalExpr);
+    }
     bool visitModifiedTypeExpr(ModifiedTypeExpr* expr) { return dispatchIfNotNull(expr->base.exp); }
     bool visitTryExpr(TryExpr* expr) { return dispatchIfNotNull(expr->base); }
 

--- a/tests/bugs/nested-existential-dyndispatch.slang
+++ b/tests/bugs/nested-existential-dyndispatch.slang
@@ -49,8 +49,8 @@ void computeMain(int3 dispatchThreadID: SV_DispatchThreadID)
     Bar bar;
     bar.foo = f;
 
-    AnyVal data = reinterpret<AnyVal, Bar>(bar);
-    IBar dynBar = createDynamicObject<IBar, AnyVal>(0, data);
+    AnyVal data = reinterpret<AnyVal>(bar);
+    IBar dynBar = createDynamicObject<IBar>(0, data);
 
     outputBuffer[index] = dynBar.sample();
 }


### PR DESCRIPTION
PR #2404 introduced a regression that drops breadcrumbs when resolving a generic overload. This leads to a crash when lowering IR for a call to a generic member function due to missing `this` argument in a `call`.