### PR TITLE
GFX: improve d3d12 performance.

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -477,6 +477,8 @@ enum class ResourceState
     ResolveDestination,
     AccelerationStructure,
     AccelerationStructureBuildInput,
+    PixelShaderResource,
+    NonPixelShaderResource,
     _Count
 };
 

--- a/tools/gfx/d3d/d3d-util.cpp
+++ b/tools/gfx/d3d/d3d-util.cpp
@@ -810,6 +810,10 @@ D3D12_RESOURCE_STATES D3DUtil::getResourceState(ResourceState state)
     case ResourceState::ShaderResource:
     case ResourceState::AccelerationStructureBuildInput:
         return D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+    case ResourceState::PixelShaderResource:
+        return D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+    case ResourceState::NonPixelShaderResource:
+        return D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
     case ResourceState::UnorderedAccess:
         return D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
     case ResourceState::RenderTarget:

--- a/tools/gfx/d3d11/d3d11-helper-functions.cpp
+++ b/tools/gfx/d3d11/d3d11-helper-functions.cpp
@@ -43,6 +43,8 @@ namespace d3d11
         case ResourceState::UnorderedAccess:
             return D3D11_BIND_UNORDERED_ACCESS;
         case ResourceState::ShaderResource:
+        case ResourceState::PixelShaderResource:
+        case ResourceState::NonPixelShaderResource:
             return D3D11_BIND_SHADER_RESOURCE;
         default:
             return D3D11_BIND_FLAG(0);

--- a/tools/gfx/d3d12/d3d12-device.h
+++ b/tools/gfx/d3d12/d3d12-device.h
@@ -78,7 +78,7 @@ public:
     PFN_D3D12_GET_DEBUG_INTERFACE m_D3D12GetDebugInterface = nullptr;
     PFN_D3D12_CREATE_DEVICE m_D3D12CreateDevice = nullptr;
     PFN_D3D12_SERIALIZE_ROOT_SIGNATURE m_D3D12SerializeRootSignature = nullptr;
-
+    PFN_D3D12_SERIALIZE_VERSIONED_ROOT_SIGNATURE m_D3D12SerializeVersionedRootSignature = nullptr;
     PFN_BeginEventOnCommandList m_BeginEventOnCommandList = nullptr;
     PFN_EndEventOnCommandList m_EndEventOnCommandList = nullptr;
 

--- a/tools/gfx/d3d12/d3d12-shader-object-layout.h
+++ b/tools/gfx/d3d12/d3d12-shader-object-layout.h
@@ -257,8 +257,8 @@ public:
 
     struct DescriptorSetLayout
     {
-        List<D3D12_DESCRIPTOR_RANGE> m_resourceRanges;
-        List<D3D12_DESCRIPTOR_RANGE> m_samplerRanges;
+        List<D3D12_DESCRIPTOR_RANGE1> m_resourceRanges;
+        List<D3D12_DESCRIPTOR_RANGE1> m_samplerRanges;
         uint32_t m_resourceCount = 0;
         uint32_t m_samplerCount = 0;
     };
@@ -275,8 +275,10 @@ public:
         // descriptor set for each `ParameterBlock` binding range in the shader object
         // hierarchy, regardless of the shader's `space` indices.
         List<DescriptorSetLayout> m_descriptorSets;
-        List<D3D12_ROOT_PARAMETER> m_rootParameters;
-        D3D12_ROOT_SIGNATURE_DESC m_rootSignatureDesc = {};
+        List<D3D12_ROOT_PARAMETER1> m_rootParameters;
+        List<D3D12_ROOT_PARAMETER1> m_rootDescTableParameters;
+
+        D3D12_ROOT_SIGNATURE_DESC1 m_rootSignatureDesc = {};
 
         static Result translateDescriptorRangeType(
             slang::BindingType c, D3D12_DESCRIPTOR_RANGE_TYPE* outType);
@@ -449,7 +451,7 @@ public:
             BindingRegisterOffsetPair const& containerOffset,
             BindingRegisterOffsetPair const& elementOffset);
 
-        D3D12_ROOT_SIGNATURE_DESC& build();
+        D3D12_ROOT_SIGNATURE_DESC1& build();
     };
 
     static Result createRootSignatureFromSlang(

--- a/tools/gfx/d3d12/d3d12-shader-table.cpp
+++ b/tools/gfx/d3d12/d3d12-shader-table.cpp
@@ -31,6 +31,7 @@ RefPtr<BufferResource> ShaderTableImpl::createDeviceBuffer(
     IBufferResource::Desc bufferDesc = {};
     bufferDesc.memoryType = gfx::MemoryType::DeviceLocal;
     bufferDesc.defaultState = ResourceState::General;
+    bufferDesc.allowedStates.add(ResourceState::NonPixelShaderResource);
     bufferDesc.type = IResource::Type::Buffer;
     bufferDesc.sizeInBytes = tableSize;
     m_device->createBufferResource(bufferDesc, nullptr, bufferResource.writeRef());
@@ -57,10 +58,6 @@ RefPtr<BufferResource> ShaderTableImpl::createDeviceBuffer(
             void* shaderId = stateObjectProperties->GetShaderIdentifier(name.toWString().begin());
             memcpy(dest, shaderId, D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES);
         }
-        else
-        {
-            memset(dest, 0, D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES);
-        }
         if (overwrite.size)
         {
             memcpy((uint8_t*)dest + overwrite.offset, overwrite.data, overwrite.size);
@@ -68,6 +65,8 @@ RefPtr<BufferResource> ShaderTableImpl::createDeviceBuffer(
     };
 
     uint8_t* stagingBufferPtr = (uint8_t*)stagingPtr + stagingBufferOffset;
+    memset(stagingBufferPtr, 0, tableSize);
+
     for (uint32_t i = 0; i < m_rayGenShaderCount; i++)
     {
         copyShaderIdInto(
@@ -96,7 +95,7 @@ RefPtr<BufferResource> ShaderTableImpl::createDeviceBuffer(
         1,
         bufferResource.readRef(),
         gfx::ResourceState::CopyDestination,
-        gfx::ResourceState::ShaderResource);
+        gfx::ResourceState::NonPixelShaderResource);
     RefPtr<BufferResource> resultPtr = static_cast<BufferResource*>(bufferResource.get());
     return _Move(resultPtr);
 }

--- a/tools/gfx/renderer-shared.cpp
+++ b/tools/gfx/renderer-shared.cpp
@@ -386,6 +386,8 @@ Result RendererBase::getFormatSupportedResourceStates(Format format, ResourceSta
     outStates->add(ResourceState::ResolveDestination);
     outStates->add(ResourceState::ResolveSource);
     outStates->add(ResourceState::ShaderResource);
+    outStates->add(ResourceState::PixelShaderResource);
+    outStates->add(ResourceState::NonPixelShaderResource);
     outStates->add(ResourceState::StreamOutput);
     outStates->add(ResourceState::Undefined);
     outStates->add(ResourceState::UnorderedAccess);

--- a/tools/gfx/vulkan/vk-helper-functions.cpp
+++ b/tools/gfx/vulkan/vk-helper-functions.cpp
@@ -83,6 +83,8 @@ VkImageLayout translateImageLayout(ResourceState state)
     case ResourceState::DepthWrite:
         return VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     case ResourceState::ShaderResource:
+    case ResourceState::NonPixelShaderResource:
+    case ResourceState::PixelShaderResource:
         return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     case ResourceState::ResolveDestination:
     case ResourceState::CopyDestination:
@@ -116,6 +118,8 @@ VkAccessFlagBits calcAccessFlags(ResourceState state)
         return VkAccessFlagBits(
             VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT);
     case ResourceState::ShaderResource:
+    case ResourceState::NonPixelShaderResource:
+    case ResourceState::PixelShaderResource:
         return VK_ACCESS_INPUT_ATTACHMENT_READ_BIT;
     case ResourceState::UnorderedAccess:
         return VkAccessFlagBits(VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT);
@@ -167,6 +171,8 @@ VkPipelineStageFlagBits calcPipelineStageFlags(ResourceState state, bool src)
             VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
             VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT | VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR);
     case ResourceState::ShaderResource:
+    case ResourceState::NonPixelShaderResource:
+    case ResourceState::PixelShaderResource:
         return VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
     case ResourceState::RenderTarget:
         return VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
@@ -237,6 +243,8 @@ VkBufferUsageFlagBits _calcBufferUsageFlags(ResourceState state)
         return (
             VkBufferUsageFlagBits)(VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
     case ResourceState::ShaderResource:
+    case ResourceState::NonPixelShaderResource:
+    case ResourceState::PixelShaderResource:
         return (
             VkBufferUsageFlagBits)(VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
     case ResourceState::CopySource:
@@ -277,6 +285,8 @@ VkImageUsageFlagBits _calcImageUsageFlags(ResourceState state)
     case ResourceState::DepthRead:
         return VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
     case ResourceState::ShaderResource:
+    case ResourceState::NonPixelShaderResource:
+    case ResourceState::PixelShaderResource:
         return VK_IMAGE_USAGE_SAMPLED_BIT;
     case ResourceState::UnorderedAccess:
         return VK_IMAGE_USAGE_STORAGE_BIT;

--- a/tools/gfx/vulkan/vk-util.cpp
+++ b/tools/gfx/vulkan/vk-util.cpp
@@ -201,6 +201,8 @@ VkImageLayout VulkanUtil::getImageLayoutFromState(ResourceState state)
     switch (state)
     {
     case ResourceState::ShaderResource:
+    case ResourceState::PixelShaderResource:
+    case ResourceState::NonPixelShaderResource:
         return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     case ResourceState::UnorderedAccess:
     case ResourceState::General:
@@ -555,6 +557,8 @@ VkImageLayout VulkanUtil::mapResourceStateToLayout(ResourceState state)
     case ResourceState::Undefined:
         return VK_IMAGE_LAYOUT_UNDEFINED;
     case ResourceState::ShaderResource:
+    case ResourceState::PixelShaderResource:
+    case ResourceState::NonPixelShaderResource:
         return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     case ResourceState::UnorderedAccess:
         return VK_IMAGE_LAYOUT_GENERAL;


### PR DESCRIPTION
The main change is to use root signature v1.1 instead of v1.0 to take advantage of the default flags which allows more aggressive driver optimizations.