### PR TITLE
Add syntax for multi-level break.

### DIFF
--- a/source/slang/slang-ast-iterator.h
+++ b/source/slang/slang-ast-iterator.h
@@ -297,6 +297,12 @@ struct ASTIterator
                 dispatchIfNotNull(stmt);
         }
 
+        void visitLabelStmt(LabelStmt* stmt)
+        {
+            iterator->maybeDispatchCallback(stmt);
+            dispatchIfNotNull(stmt->innerStmt);
+        }
+
         void visitBreakStmt(BreakStmt* stmt) { iterator->maybeDispatchCallback(stmt); }
 
         void visitContinueStmt(ContinueStmt* stmt) { iterator->maybeDispatchCallback(stmt); }

--- a/source/slang/slang-ast-stmt.h
+++ b/source/slang/slang-ast-stmt.h
@@ -23,6 +23,15 @@ class SeqStmt : public Stmt
     List<Stmt*> stmts;
 };
 
+// A statement with a label.
+class LabelStmt : public Stmt
+{
+    SLANG_AST_CLASS(LabelStmt)
+
+    Token label;
+    Stmt* innerStmt;
+};
+
 // The simplest kind of scope statement: just a `{...}` block
 class BlockStmt : public ScopeStmt 
 {
@@ -196,6 +205,8 @@ class JumpStmt : public ChildStmt
 class BreakStmt : public JumpStmt 
 {
     SLANG_AST_CLASS(BreakStmt)
+
+    Token targetLabel;
 };
 
 class ContinueStmt : public JumpStmt 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1849,11 +1849,15 @@ namespace Slang
         template<typename T>
         T* FindOuterStmt();
 
+        Stmt* findOuterStmtWithLabel(Name* label);
+
         void visitDeclStmt(DeclStmt* stmt);
 
         void visitBlockStmt(BlockStmt* stmt);
 
         void visitSeqStmt(SeqStmt* stmt);
+
+        void visitLabelStmt(LabelStmt* stmt);
 
         void visitBreakStmt(BreakStmt *stmt);
 

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -235,7 +235,7 @@ DIAGNOSTIC(20014, Error, classIsReservedKeyword, "'class' is a reserved keyword 
 // 3xxxx - Semantic analysis
 //
 DIAGNOSTIC(30002, Error, divideByZero, "divide by zero")
-DIAGNOSTIC(30003, Error, breakOutsideLoop, "'break' must appear inside loop constructs.")
+DIAGNOSTIC(30003, Error, breakOutsideLoop, "'break' must appear inside loop or switch constructs.")
 DIAGNOSTIC(30004, Error, continueOutsideLoop, "'continue' must appear inside loop constructs.")
 DIAGNOSTIC(30005, Error, whilePredicateTypeError, "'while': expression must evaluate to int.")
 DIAGNOSTIC(30006, Error, ifPredicateTypeError,  "'if': expression must evaluate to int.")
@@ -272,6 +272,8 @@ DIAGNOSTIC(30050, Error,  mutatingMethodOnImmutableValue, "mutating method '$0' 
 
 DIAGNOSTIC(30051, Error, invalidValueForArgument, "invalid value for argument '$0'")
 DIAGNOSTIC(30052, Error, invalidSwizzleExpr, "invalid swizzle pattern '$0' on type '$1'")
+DIAGNOSTIC(30053, Error, breakLabelNotFound, "label '$0' used as break target is not found.")
+DIAGNOSTIC(30054, Error, targetLabelDoesNotMarkBreakableStmt, "invalid break target: statement labeled '$0' is not breakable.")
 DIAGNOSTIC(30043, Error, getStringHashRequiresStringLiteral, "getStringHash parameter can only accept a string literal")
 
 DIAGNOSTIC(30060, Error, expectedAType, "expected a type, got a '$0'")

--- a/source/slang/slang-language-server-ast-lookup.cpp
+++ b/source/slang/slang-language-server-ast-lookup.cpp
@@ -451,6 +451,13 @@ struct ASTLookupStmtVisitor : public StmtVisitor<ASTLookupStmtVisitor, bool>
         return false;
     }
 
+    bool visitLabelStmt(LabelStmt* stmt)
+    {
+        if (_isLocInRange(context, stmt->label.loc, stmt->label.getContent().getLength()))
+            return true;
+        return dispatchIfNotNull(stmt->innerStmt);
+    }
+
     bool visitBreakStmt(BreakStmt*) { return false; }
 
     bool visitContinueStmt(ContinueStmt*) { return false; }

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -4508,6 +4508,11 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
         SLANG_UNEXPECTED("`case` or `default` not under `switch`");
     }
 
+    void visitLabelStmt(LabelStmt* stmt)
+    {
+        lowerStmt(context, stmt->innerStmt);
+    }
+
     void visitCompileTimeForStmt(CompileTimeForStmt* stmt)
     {
         // The user is asking us to emit code for the loop

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -4270,12 +4270,6 @@ namespace Slang
 
     Stmt* Parser::ParseStatement()
     {
-        if (LookAheadToken(TokenType::Identifier) && LookAheadToken(TokenType::Colon, 1))
-        {
-            // An identifier followed by an ":" is a label.
-            return parseLabelStatement();
-        }
-
         auto modifiers = ParseModifiers(this);
 
         Stmt* statement = nullptr;
@@ -4320,6 +4314,12 @@ namespace Slang
         }
         else if (LookAheadToken(TokenType::Identifier))
         {
+            if (LookAheadToken(TokenType::Colon, 1))
+            {
+                // An identifier followed by an ":" is a label.
+                return parseLabelStatement();
+            }
+
             // We might be looking at a local declaration, or an
             // expression statement, and we need to figure out which.
             //

--- a/tests/diagnostics/break-outside-loop.slang.expected
+++ b/tests/diagnostics/break-outside-loop.slang.expected
@@ -1,6 +1,6 @@
 result code = -1
 standard error = {
-tests/diagnostics/break-outside-loop.slang(6): error 30003: 'break' must appear inside loop constructs.
+tests/diagnostics/break-outside-loop.slang(6): error 30003: 'break' must appear inside loop or switch constructs.
 void foo() { break; }
              ^~~~~
 }

--- a/tests/diagnostics/continue-outside-loop.slang.expected
+++ b/tests/diagnostics/continue-outside-loop.slang.expected
@@ -1,6 +1,6 @@
 result code = -1
 standard error = {
-tests/diagnostics/continue-outside-loop.slang(4): error 30004: 'continue' must appear inside loop constructs.
+tests/diagnostics/continue-outside-loop.slang(4): error 30004: 'continue' must appear inside loop or switch constructs.
 void foo() { continue; }
              ^~~~~~~~
 }

--- a/tests/diagnostics/continue-outside-loop.slang.expected
+++ b/tests/diagnostics/continue-outside-loop.slang.expected
@@ -1,6 +1,6 @@
 result code = -1
 standard error = {
-tests/diagnostics/continue-outside-loop.slang(4): error 30004: 'continue' must appear inside loop or switch constructs.
+tests/diagnostics/continue-outside-loop.slang(4): error 30004: 'continue' must appear inside loop constructs.
 void foo() { continue; }
              ^~~~~~~~
 }

--- a/tests/diagnostics/token-line-continuation.slang.expected
+++ b/tests/diagnostics/token-line-continuation.slang.expected
@@ -1,6 +1,6 @@
 result code = -1
 standard error = {
-tests/diagnostics/token-line-continuation.slang(5): error 30003: 'break' must appear inside loop constructs.
+tests/diagnostics/token-line-continuation.slang(5): error 30003: 'break' must appear inside loop or switch constructs.
 void foo() { br\
              ^~
 }


### PR DESCRIPTION
This change adds the syntax for multi-level `break` statement.

A future IR pass will be implemented to lower the multi-level breaks out to ordinary breaks.