### PR TITLE
Various gfx fixes.

### DIFF
--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -875,7 +875,7 @@ void HLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
         case kIROp_NativeStringType:
         case kIROp_StringType: 
         {
-            m_writer->emit("string"); 
+            m_writer->emit("int"); 
             return;
         }
         default: break;

--- a/tools/gfx/d3d12/d3d12-command-encoder.cpp
+++ b/tools/gfx/d3d12/d3d12-command-encoder.cpp
@@ -353,6 +353,7 @@ void ResourceCommandEncoderImpl::clearResourceView(
     IResourceView* view, ClearValue* clearValue, ClearResourceViewFlags::Enum flags)
 {
     auto viewImpl = static_cast<ResourceViewImpl*>(view);
+    m_commandBuffer->bindDescriptorHeaps();
     switch (view->getViewDesc()->type)
     {
     case IResourceView::Type::RenderTarget:

--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -440,30 +440,31 @@ Result DeviceImpl::initialize(const Desc& desc)
             (PFN_EndEventOnCommandList)GetProcAddress(pixModule, "PIXEndEventOnCommandList");
     }
 
-#if ENABLE_DEBUG_LAYER
-    m_D3D12GetDebugInterface =
-        (PFN_D3D12_GET_DEBUG_INTERFACE)loadProc(d3dModule, "D3D12GetDebugInterface");
-    if (m_D3D12GetDebugInterface)
+    if (ENABLE_DEBUG_LAYER || isGfxDebugLayerEnabled())
     {
-        if (SLANG_SUCCEEDED(m_D3D12GetDebugInterface(IID_PPV_ARGS(m_dxDebug.writeRef()))))
+        m_D3D12GetDebugInterface =
+            (PFN_D3D12_GET_DEBUG_INTERFACE)loadProc(d3dModule, "D3D12GetDebugInterface");
+        if (m_D3D12GetDebugInterface)
         {
-#    if 0
-            // Can enable for extra validation. NOTE! That d3d12 warns if you do.... 
-            // D3D12 MESSAGE : Device Debug Layer Startup Options : GPU - Based Validation is enabled(disabled by default).
-            // This results in new validation not possible during API calls on the CPU, by creating patched shaders that have validation
-            // added directly to the shader. However, it can slow things down a lot, especially for applications with numerous
-            // PSOs.Time to see the first render frame may take several minutes.
-            // [INITIALIZATION MESSAGE #1016: CREATEDEVICE_DEBUG_LAYER_STARTUP_OPTIONS]
-
-            ComPtr<ID3D12Debug1> debug1;
-            if (SLANG_SUCCEEDED(m_dxDebug->QueryInterface(debug1.writeRef())))
+            if (SLANG_SUCCEEDED(m_D3D12GetDebugInterface(IID_PPV_ARGS(m_dxDebug.writeRef()))))
             {
-                debug1->SetEnableGPUBasedValidation(true);
-            }
+#    if 0
+                // Can enable for extra validation. NOTE! That d3d12 warns if you do.... 
+                // D3D12 MESSAGE : Device Debug Layer Startup Options : GPU - Based Validation is enabled(disabled by default).
+                // This results in new validation not possible during API calls on the CPU, by creating patched shaders that have validation
+                // added directly to the shader. However, it can slow things down a lot, especially for applications with numerous
+                // PSOs.Time to see the first render frame may take several minutes.
+                // [INITIALIZATION MESSAGE #1016: CREATEDEVICE_DEBUG_LAYER_STARTUP_OPTIONS]
+
+                ComPtr<ID3D12Debug1> debug1;
+                if (SLANG_SUCCEEDED(m_dxDebug->QueryInterface(debug1.writeRef())))
+                {
+                    debug1->SetEnableGPUBasedValidation(true);
+                }
 #    endif
+            }
         }
     }
-#endif
 
     m_D3D12CreateDevice = (PFN_D3D12_CREATE_DEVICE)loadProc(d3dModule, "D3D12CreateDevice");
     if (!m_D3D12CreateDevice)

--- a/tools/gfx/d3d12/d3d12-helper-functions.cpp
+++ b/tools/gfx/d3d12/d3d12-helper-functions.cpp
@@ -533,6 +533,37 @@ Result createNullDescriptor(
         d3dDevice->CreateShaderResourceView(nullptr, &srvDesc, destDescriptor);
     }
     break;
+    case slang::BindingType::MutableTexture:
+    {
+        D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+        uavDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        switch (bindingRange.resourceShape)
+        {
+        case SLANG_TEXTURE_1D:
+            uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE1D;
+            break;
+        case SLANG_TEXTURE_1D_ARRAY:
+            uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE1DARRAY;
+            break;
+        case SLANG_TEXTURE_2D:
+            uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
+            break;
+        case SLANG_TEXTURE_2D_ARRAY:
+            uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2DARRAY;
+            break;
+        case SLANG_TEXTURE_3D:
+            uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE3D;
+            break;
+        case SLANG_TEXTURE_CUBE:
+        case SLANG_TEXTURE_CUBE_ARRAY:
+        case SLANG_TEXTURE_2D_MULTISAMPLE:
+        case SLANG_TEXTURE_2D_MULTISAMPLE_ARRAY:
+        default:
+            return SLANG_OK;
+        }
+        d3dDevice->CreateUnorderedAccessView(nullptr, nullptr, &uavDesc, destDescriptor);
+    }
+    break;
     default:
         break;
     }

--- a/tools/gfx/d3d12/d3d12-helper-functions.h
+++ b/tools/gfx/d3d12/d3d12-helper-functions.h
@@ -5,6 +5,7 @@
 #include "d3d12-base.h"
 #include "d3d12-shader-object-layout.h"
 #include "d3d12-submitter.h"
+#include "../../../source/core/slang-short-list.h"
 
 #ifndef __ID3D12GraphicsCommandList1_FWD_DEFINED__
 // If can't find a definition of CommandList1, just use an empty definition
@@ -19,6 +20,12 @@ using namespace Slang;
 
 namespace d3d12
 {
+struct PendingDescriptorTableBinding
+{
+    uint32_t rootIndex;
+    D3D12_GPU_DESCRIPTOR_HANDLE handle;
+};
+
 /// Contextual data and operations required when binding shader objects to the pipeline state
 struct BindingContext
 {
@@ -28,6 +35,7 @@ struct BindingContext
     DeviceImpl* device;
     D3D12_DESCRIPTOR_HEAP_TYPE
         outOfMemoryHeap; // The type of descriptor heap that is OOM during binding.
+    ShortList<PendingDescriptorTableBinding>* pendingTableBindings;
 };
 
 bool isSupportedNVAPIOp(ID3D12Device* dev, uint32_t op);

--- a/tools/gfx/debug-layer/debug-shader-object.h
+++ b/tools/gfx/debug-layer/debug-shader-object.h
@@ -32,6 +32,7 @@ class DebugShaderObject : public DebugObject<IShaderObject>
 {
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
+    void checkCompleteness();
 
 public:
     IShaderObject* getInterface(const Slang::Guid& guid);
@@ -83,6 +84,7 @@ public:
     Slang::Dictionary<ShaderOffsetKey, Slang::RefPtr<DebugShaderObject>> m_objects;
     Slang::Dictionary<ShaderOffsetKey, Slang::RefPtr<DebugResourceView>> m_resources;
     Slang::Dictionary<ShaderOffsetKey, Slang::RefPtr<DebugSamplerState>> m_samplers;
+    Slang::HashSet<SlangInt> m_initializedBindingRanges;
 };
 
 class DebugRootShaderObject : public DebugShaderObject

--- a/tools/gfx/vulkan/vk-device.cpp
+++ b/tools/gfx/vulkan/vk-device.cpp
@@ -158,9 +158,8 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
 #elif defined(SLANG_ENABLE_XLIB)
             instanceExtensions.add(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
 #endif
-#if ENABLE_VALIDATION_LAYER
+        if (ENABLE_VALIDATION_LAYER || isGfxDebugLayerEnabled())
             instanceExtensions.add(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
-#endif
         }
 
         VkInstanceCreateInfo instanceCreateInfo = { VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO };


### PR DESCRIPTION
Fixes gfx bugs:
1. Enable d3d12 debug layer if gfx debug layer is enabled.
2. Enable vk debug layer if gfx debug layer is enabled.
3. Add check for uninitialized bindings in shader object.
4. Set descriptor table root argument only when the descriptor table is finalized to prevent d3d12 debug layer errors.