### PR TITLE
Add specialization args test

### DIFF
--- a/source/core/slang-digest.h
+++ b/source/core/slang-digest.h
@@ -2,10 +2,10 @@
 #include "slang-md5.h"
 #include "../../slang.h"
 
-using slang::Digest;
-
 namespace Slang
 {
+    using slang::Digest;
+
     // Wrapper struct that holds objects necessary for hashing.
     struct DigestBuilder
     {

--- a/source/core/slang-digest.h
+++ b/source/core/slang-digest.h
@@ -2,6 +2,8 @@
 #include "slang-md5.h"
 #include "../../slang.h"
 
+using slang::Digest;
+
 namespace Slang
 {
     // Wrapper struct that holds objects necessary for hashing.
@@ -19,9 +21,11 @@ namespace Slang
             hashGen.update(&context, item);
         }
 
-        void finalize(slang::Digest* outHash)
+        Digest finalize()
         {
-            hashGen.finalize(&context, outHash);
+            Digest hash;
+            hashGen.finalize(&context, &hash);
+            return hash;
         }
 
     private:

--- a/source/slang/slang-hash-utils.h
+++ b/source/slang/slang-hash-utils.h
@@ -12,11 +12,7 @@ namespace Slang
     {
         DigestBuilder builder;
         builder.addToDigest(text);
-
-        slang::Digest textHash;
-        builder.finalize(&textHash);
-
-        return textHash;
+        return builder.finalize();
     }
 
     // Combines the two provided hashes.
@@ -25,10 +21,7 @@ namespace Slang
         DigestBuilder builder;
         builder.addToDigest(hashA);
         builder.addToDigest(hashB);
-
-        slang::Digest combined;
-        builder.finalize(&combined);
-        return combined;
+        return builder.finalize();
     }
 
     // Returns the stored hash in checksum as a String.

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3482,19 +3482,14 @@ SLANG_NO_THROW void SLANG_MCALL ComponentType::computeDependencyBasedHash(
     auto entryPointNameOverride = getEntryPointNameOverride(entryPointIndex);
     builder.addToDigest(entryPointNameOverride);
 
-    slang::Digest hash;
-    builder.finalize(&hash);
-    *outHash = hash;
+    *outHash = builder.finalize();
 }
 
 SLANG_NO_THROW void SLANG_MCALL ComponentType::computeASTBasedHash(slang::Digest* outHash)
 {
     DigestBuilder builder;
     updateASTBasedHash(builder);
-
-    slang::Digest hash;
-    builder.finalize(&hash);
-    *outHash = hash;
+    *outHash = builder.finalize();
 }
 
 SLANG_NO_THROW SlangResult SLANG_MCALL ComponentType::getEntryPointHostCallable(


### PR DESCRIPTION
Changes:
- Added a shader cache test for specialization args - This uses compute-smoke.slang and simply creates an add and a mul transformer, binds a transformer to the shader, and checks that changing the transformer type results in a cache miss.
- Small leftover cleanup change in `slang-digest.h`

Redo of the specialization args test PR. Rebase was reintroducing lines that were removed and not producing the clean commit history I was looking for.