### PR TITLE
Fix missing implementations in ConjunctionSubtypeWitness.

### DIFF
--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -558,6 +558,107 @@ Val* TaggedUnionSubtypeWitness::_substituteImplOverride(ASTBuilder* astBuilder, 
     return substWitness;
 }
 
+bool ConjunctionSubtypeWitness::_equalsValOverride(Val* val)
+{
+    if (auto other = as<ConjunctionSubtypeWitness>(val))
+    {
+        return other->leftWitness && other->leftWitness->equalsVal(leftWitness) &&
+               other->rightWitness && other->rightWitness->equalsVal(rightWitness);
+    }
+    return false;
+}
+
+void ConjunctionSubtypeWitness::_toTextOverride(StringBuilder& out)
+{
+    out << "ConjunctionSubtypeWitness(";
+    if (leftWitness) out << leftWitness;
+    out << ",";
+    if (rightWitness) out << rightWitness;
+    out << ")";
+}
+
+HashCode ConjunctionSubtypeWitness::_getHashCodeOverride()
+{
+    HashCode result = 0;
+    if (leftWitness) result = leftWitness->getHashCode();
+    if (rightWitness) result = combineHash(result, rightWitness->getHashCode());
+    return result;
+}
+
+Val* ConjunctionSubtypeWitness::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
+{
+    int diff = 0;
+    Val* left = nullptr;
+    Val* right = nullptr;
+
+    auto substSub = as<Type>(sub->substituteImpl(astBuilder, subst, &diff));
+    auto substSup = as<Type>(sup->substituteImpl(astBuilder, subst, &diff));
+
+    if (leftWitness)
+        left = leftWitness->substituteImpl(astBuilder, subst, &diff);
+    if (rightWitness)
+        right = rightWitness->substituteImpl(astBuilder, subst, &diff);
+
+    *ioDiff += diff;
+
+    if (diff)
+    {
+        auto result = astBuilder->create<ConjunctionSubtypeWitness>();
+        result->leftWitness = left;
+        result->rightWitness = right;
+        result->sub = substSub;
+        result->sup = substSup;
+        return result;
+    }
+    return this;
+}
+
+bool ExtractFromConjunctionSubtypeWitness::_equalsValOverride(Val* val)
+{
+    if (auto other = as<ExtractFromConjunctionSubtypeWitness>(val))
+    {
+        return other->conjunctionWitness && other->conjunctionWitness->equalsVal(conjunctionWitness) &&
+            other->indexInConjunction == indexInConjunction;
+    }
+    return false;
+}
+
+void ExtractFromConjunctionSubtypeWitness::_toTextOverride(StringBuilder& out)
+{
+    out << "ExtractFromConjunctionSubtypeWitness(";
+    if (conjunctionWitness)
+        out << conjunctionWitness;
+    out << "," << indexInConjunction;
+}
+
+HashCode ExtractFromConjunctionSubtypeWitness::_getHashCodeOverride()
+{
+    return combineHash(indexInConjunction, conjunctionWitness ? conjunctionWitness->getHashCode() : 0);
+}
+
+Val* ExtractFromConjunctionSubtypeWitness::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
+{
+    int diff = 0;
+    Val* newConjunctionWitness = nullptr;
+
+    auto substSub = as<Type>(sub->substituteImpl(astBuilder, subst, &diff));
+    auto substSup = as<Type>(sup->substituteImpl(astBuilder, subst, &diff));
+
+    if (this->conjunctionWitness)
+        newConjunctionWitness = conjunctionWitness->substituteImpl(astBuilder, subst, &diff);
+    *ioDiff += diff;
+
+    if (diff)
+    {
+        auto result = astBuilder->create<ExtractFromConjunctionSubtypeWitness>();
+        result->conjunctionWitness = newConjunctionWitness;
+        result->sub = substSub;
+        result->sup = substSup;
+        return result;
+    }
+    return this;
+}
+
 // ModifierVal
 
 bool ModifierVal::_equalsValOverride(Val* val)

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -410,6 +410,11 @@ class ConjunctionSubtypeWitness : public SubtypeWitness
 
         /// Witness that `sub : sup->right`
     Val* rightWitness;
+
+    bool _equalsValOverride(Val* val);
+    void _toTextOverride(StringBuilder& out);
+    HashCode _getHashCodeOverride();
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 };
 
     /// A witness that `T : X` because `T : X & Y` or `T : Y & X`
@@ -418,14 +423,19 @@ class ExtractFromConjunctionSubtypeWitness : public SubtypeWitness
     SLANG_AST_CLASS(ExtractFromConjunctionSubtypeWitness)
 
         /// Witness that `T : L & R` for some `R`
-    Val* conunctionWitness;
+    Val* conjunctionWitness;
 
         /// The zero-based index of the super-type we care about in the conjunction
         ///
-        /// If `conunctionWitness` is `T : X & Y` then this index should be zero if
+        /// If `conjunctionWitness` is `T : X & Y` then this index should be zero if
         /// we want to represent `T : X` and one if we want `T : Y`.
         ///
     int indexInConjunction;
+
+    bool _equalsValOverride(Val* val);
+    void _toTextOverride(StringBuilder& out);
+    HashCode _getHashCodeOverride();
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 };
 
     /// A value that represents a modifier attached to some other value

--- a/source/slang/slang-lookup.cpp
+++ b/source/slang/slang-lookup.cpp
@@ -712,7 +712,7 @@ static void _lookUpMembersInSuperTypeImpl(
         // The evidence for the subtype relationship will be a witness
         // proving that `leafType : leftType & rightType`:
         //
-        leafIsLeftWitness->conunctionWitness = leafIsSuperWitness;
+        leafIsLeftWitness->conjunctionWitness = leafIsSuperWitness;
         //
         // ... along with the index of the desired super-type in
         // that conjunction. The index of `leftType` in `leftType & rightType`
@@ -725,7 +725,7 @@ static void _lookUpMembersInSuperTypeImpl(
         // the conjunction.
         //
         auto leafIsRightWitness = astBuilder->create<ExtractFromConjunctionSubtypeWitness>();
-        leafIsRightWitness->conunctionWitness = leafIsSuperWitness;
+        leafIsRightWitness->conjunctionWitness = leafIsSuperWitness;
         leafIsRightWitness->indexInConjunction = 1;
         leafIsRightWitness->sub = leafType;
         leafIsRightWitness->sup = rightType;

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -1671,7 +1671,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
         // witness that `T : L & R`, so lower that first and expect it to be
         // a value of tuple type.
         //
-        auto conjunctionWitness = lowerSimpleVal(context, val->conunctionWitness);
+        auto conjunctionWitness = lowerSimpleVal(context, val->conjunctionWitness);
         auto conjunctionTupleType = as<IRTupleType>(conjunctionWitness->getDataType());
         SLANG_ASSERT(conjunctionTupleType);
 


### PR DESCRIPTION
The missing implementations is causing a crash when compiling code that uses `AndType`.