### PR TITLE
Make `optimalClearValue` optional in `ITextureResource::Desc`

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -706,7 +706,7 @@ public:
         GfxCount numMipLevels = 0;       ///< Number of mip levels - if 0 will create all mip levels
         Format format;                   ///< The resources format
         SampleDesc sampleDesc;           ///< How the resource is sampled
-        ClearValue optimalClearValue;
+        ClearValue* optimalClearValue = nullptr;
     };
 
         /// Data for a single subresource of a texture.

--- a/tools/gfx/d3d11/d3d11-device.cpp
+++ b/tools/gfx/d3d11/d3d11-device.cpp
@@ -668,11 +668,13 @@ Result DeviceImpl::createTextureView(ITextureResource* texture, IResourceView::D
         viewImpl->m_type = ResourceViewImpl::Type::RTV;
         viewImpl->m_rtv = rtv;
         viewImpl->m_desc = desc;
-
-        memcpy(
-            viewImpl->m_clearValue,
-            &resourceImpl->getDesc()->optimalClearValue.color,
-            sizeof(float) * 4);
+        if (resourceImpl->getDesc()->optimalClearValue)
+        {
+            memcpy(
+                viewImpl->m_clearValue,
+                &resourceImpl->getDesc()->optimalClearValue->color,
+                sizeof(float) * 4);
+        }
         returnComPtr(outView, viewImpl);
         return SLANG_OK;
     }
@@ -686,7 +688,8 @@ Result DeviceImpl::createTextureView(ITextureResource* texture, IResourceView::D
         RefPtr<DepthStencilViewImpl> viewImpl = new DepthStencilViewImpl();
         viewImpl->m_type = ResourceViewImpl::Type::DSV;
         viewImpl->m_dsv = dsv;
-        viewImpl->m_clearValue = resourceImpl->getDesc()->optimalClearValue.depthStencil;
+        if (resourceImpl->getDesc()->optimalClearValue)
+            viewImpl->m_clearValue = resourceImpl->getDesc()->optimalClearValue->depthStencil;
         viewImpl->m_desc = desc;
 
         returnComPtr(outView, viewImpl);

--- a/tools/gfx/gfx.slang
+++ b/tools/gfx/gfx.slang
@@ -486,7 +486,7 @@ struct TextureResourceDesc : ResourceDescBase
     GfxCount numMipLevels = 0; ///< Number of mip levels - if 0 will create all mip levels
     Format format;             ///< The resources format
     TextureResourceSampleDesc sampleDesc;     ///< How the resource is sampled
-    ClearValue optimalClearValue;
+    ClearValue* optimalClearValue;
 };
 
 /// Data for a single subresource of a texture.

--- a/tools/gfx/open-gl/render-gl.cpp
+++ b/tools/gfx/open-gl/render-gl.cpp
@@ -400,7 +400,14 @@ public:
                 renderer->glFramebufferTexture2D(
                     GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + (uint32_t)i, GL_TEXTURE_2D, rtv->m_textureID, 0);
                 m_drawBuffers.add((GLenum)(GL_COLOR_ATTACHMENT0 + i));
-                m_colorClearValues.add(rtv->m_resource->getDesc()->optimalClearValue.color);
+                if (rtv->m_resource->getDesc()->optimalClearValue)
+                {
+                    m_colorClearValues.add(rtv->m_resource->getDesc()->optimalClearValue->color);
+                }
+                else
+                {
+                    m_colorClearValues.add(ColorClearValue());
+                }
             }
             m_sameClearValues = true;
             for (Index i = 1; i < m_colorClearValues.getCount() && m_sameClearValues; i++)
@@ -423,8 +430,11 @@ public:
                     GL_TEXTURE_2D,
                     depthStencilView->m_textureID,
                     0);
-                m_depthStencilClearValue =
-                    depthStencilView->m_resource->getDesc()->optimalClearValue.depthStencil;
+                if (depthStencilView->m_resource->getDesc()->optimalClearValue)
+                {
+                    m_depthStencilClearValue =
+                        depthStencilView->m_resource->getDesc()->optimalClearValue->depthStencil;
+                }
             }
             auto error = renderer->glCheckFramebufferStatus(GL_FRAMEBUFFER);
             if (error != GL_FRAMEBUFFER_COMPLETE)

--- a/tools/gfx/vulkan/vk-framebuffer.cpp
+++ b/tools/gfx/vulkan/vk-framebuffer.cpp
@@ -164,20 +164,26 @@ Result FramebufferImpl::init(DeviceImpl* renderer, const IFramebuffer::Desc& des
         auto resourceView = static_cast<TextureResourceViewImpl*>(desc.renderTargetViews[i]);
         renderTargetViews[i] = resourceView;
         imageViews[i] = resourceView->m_view;
-        memcpy(
-            &m_clearValues[i],
-            &resourceView->m_texture->getDesc()->optimalClearValue.color,
-            sizeof(gfx::ColorClearValue));
+        if (resourceView->m_texture->getDesc()->optimalClearValue)
+        {
+            memcpy(
+                &m_clearValues[i],
+                &resourceView->m_texture->getDesc()->optimalClearValue->color,
+                sizeof(gfx::ColorClearValue));
+        }
     }
 
     if (dsv)
     {
         imageViews[desc.renderTargetCount] = dsv->m_view;
         depthStencilView = dsv;
-        memcpy(
-            &m_clearValues[desc.renderTargetCount],
-            &dsv->m_texture->getDesc()->optimalClearValue.depthStencil,
-            sizeof(gfx::DepthStencilClearValue));
+        if (dsv->m_texture->getDesc()->optimalClearValue)
+        {
+            memcpy(
+                &m_clearValues[desc.renderTargetCount],
+                &dsv->m_texture->getDesc()->optimalClearValue->depthStencil,
+                sizeof(gfx::DepthStencilClearValue));
+        }
     }
 
     // Create framebuffer.


### PR DESCRIPTION
Providing an `optimalClearValue` but then clearing the texture with a different value triggers D3D12 validation layer warning. By allowing the user to opt out of optimal clear value, we can avoid this warning.