### PR TITLE
Legalize array return types.

### DIFF
--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -363,6 +363,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClInclude Include="..\..\..\source\slang\slang-ir-inst-pass-base.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-insts.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-layout.h" />
+    <ClInclude Include="..\..\..\source\slang\slang-ir-legalize-array-return-type.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-legalize-varying-params.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-link.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-liveness.h" />
@@ -529,6 +530,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClCompile Include="..\..\..\source\slang\slang-ir-hoist-local-types.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-inline.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-layout.cpp" />
+    <ClCompile Include="..\..\..\source\slang\slang-ir-legalize-array-return-type.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-legalize-types.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-legalize-varying-params.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-link.cpp" />

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -222,6 +222,9 @@
     <ClInclude Include="..\..\..\source\slang\slang-ir-layout.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\slang\slang-ir-legalize-array-return-type.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-ir-legalize-varying-params.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -714,6 +717,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-ir-layout.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\source\slang\slang-ir-legalize-array-return-type.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-ir-legalize-types.cpp">

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -23,6 +23,7 @@
 #include "slang-ir-glsl-legalize.h"
 #include "slang-ir-insts.h"
 #include "slang-ir-inline.h"
+#include "slang-ir-legalize-array-return-type.h"
 #include "slang-ir-legalize-varying-params.h"
 #include "slang-ir-link.h"
 #include "slang-ir-com-interface.h"
@@ -522,6 +523,10 @@ Result linkAndOptimizeIR(
         specializeArrayParameters(codeGenContext, irModule);
         simplifyIR(irModule);
     }
+
+    // Rewrite functions that return arrays to return them via `out` parameter,
+    // since our target languages doesn't allow returning arrays.
+    legalizeArrayReturnType(irModule);
 
 #if 0
     dumpIRIfEnabled(codeGenContext, irModule, "AFTER RESOURCE SPECIALIZATION");

--- a/source/slang/slang-ir-legalize-array-return-type.cpp
+++ b/source/slang/slang-ir-legalize-array-return-type.cpp
@@ -1,0 +1,99 @@
+#include "slang-ir-legalize-array-return-type.h"
+#include "slang-ir.h"
+#include "slang-ir-insts.h"
+#include "slang-ir-clone.h"
+
+namespace Slang
+{
+
+void makeFuncReturnViaOutParam(IRBuilder& builder, IRFunc* func)
+{
+    auto funcType = as<IRFuncType>(func->getFullType());
+    if (!funcType)
+        return;
+    auto arrayType = funcType->getResultType();
+    builder.setInsertBefore(funcType);
+    List<IRType*> paramTypes;
+    for (UInt i = 0; i < funcType->getParamCount(); i++)
+    {
+        paramTypes.add(funcType->getParamType(i));
+    }
+    auto outParamType = builder.getOutType(funcType->getResultType());
+    paramTypes.add(outParamType);
+
+    auto newFuncType = builder.getFuncType(paramTypes, builder.getVoidType());
+    func->setFullType(newFuncType);
+    auto firstBlock = func->getFirstBlock();
+    builder.setInsertInto(firstBlock);
+    auto outParam = builder.emitParam(outParamType);
+
+    // Collect return insts.
+    List<IRReturn*> returnInsts;
+    for (auto block : func->getBlocks())
+    {
+        for (auto inst : block->getChildren())
+        {
+            if (inst->getOp() == kIROp_Return)
+            {
+                returnInsts.add(as<IRReturn>(inst));
+            }
+        }
+    }
+
+    // Rewrite return inst into a store + return void.
+    for (auto returnInst : returnInsts)
+    {
+        builder.setInsertBefore(returnInst);
+        builder.emitStore(outParam, returnInst->getVal());
+        builder.emitReturn();
+        SLANG_RELEASE_ASSERT(!returnInst->hasUses());
+        returnInst->removeAndDeallocate();
+    }
+
+    // Rewrite call sites.
+    List<IRCall*> callSites;
+    for (auto use = func->firstUse; use; use = use->nextUse)
+    {
+        if (auto call = as<IRCall>(use->getUser()))
+        {
+            if (call->getCallee() == func)
+                callSites.add(call);
+        }
+    }
+    for (auto call : callSites)
+    {
+        builder.setInsertBefore(call);
+        auto tmpVar = builder.emitVar(arrayType);
+        List<IRInst*> args;
+        for (UInt i = 0; i < call->getArgCount(); i++)
+        {
+            args.add(call->getArg(i));
+        }
+        args.add(tmpVar);
+        builder.emitCallInst(builder.getVoidType(), func, args);
+        auto load = builder.emitLoad(tmpVar);
+        call->replaceUsesWith(load);
+        call->removeAndDeallocate();
+    }
+
+}
+
+void legalizeArrayReturnType(IRModule* module)
+{
+    SharedIRBuilder builderStorage;
+    builderStorage.init(module);
+    builderStorage.deduplicateAndRebuildGlobalNumberingMap();
+    IRBuilder builder(&builderStorage);
+
+    for (auto inst : module->getGlobalInsts())
+    {
+        if (auto func = as<IRFunc>(inst))
+        {
+            if (func->getResultType()->getOp() == kIROp_ArrayType)
+            {
+                makeFuncReturnViaOutParam(builder, func);
+            }
+        }
+    }
+}
+}

--- a/source/slang/slang-ir-legalize-array-return-type.h
+++ b/source/slang/slang-ir-legalize-array-return-type.h
@@ -1,0 +1,13 @@
+// slang-ir-legalize-array-return-type.h
+#pragma once
+
+#include "slang-ir-insts.h"
+
+namespace Slang
+{
+    struct IRModule;
+
+    // Turn array-typed return values into `out` parameters for backends that does not
+    // support arrays in return values.
+    void legalizeArrayReturnType(IRModule* module);
+}


### PR DESCRIPTION
This PR adds an IR pass to rewrite functions that return arrays to do so via `out` parameter instead.
This is because our targets does not allow array-returning functions.