### PR TITLE
Make `DifferentialPair` able to nest.

### DIFF
--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -306,6 +306,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClInclude Include="..\..\..\source\slang\slang-ast-reflect.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ast-stmt.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ast-support-types.h" />
+    <ClInclude Include="..\..\..\source\slang\slang-ast-synthesis.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ast-type.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ast-val.h" />
     <ClInclude Include="..\..\..\source\slang\slang-capability-defs.h" />
@@ -468,6 +469,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClCompile Include="..\..\..\source\slang\slang-ast-reflect.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ast-substitutions.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ast-support-types.cpp" />
+    <ClCompile Include="..\..\..\source\slang\slang-ast-synthesis.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ast-type.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ast-val.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-capability.cpp" />

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClInclude Include="..\..\..\source\slang\slang-ast-support-types.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\slang\slang-ast-synthesis.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-ast-type.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -983,6 +986,7 @@
     <ClCompile Include="..\..\..\source\slang\slang.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\source\slang\slang-ast-synthesis.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\..\source\slang\core.meta.slang">

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -536,6 +536,9 @@
     <ClCompile Include="..\..\..\source\slang\slang-ast-support-types.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\source\slang\slang-ast-synthesis.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-ast-type.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -986,7 +989,6 @@
     <ClCompile Include="..\..\..\source\slang\slang.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\source\slang\slang-ast-synthesis.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\..\source\slang\core.meta.slang">

--- a/source/core/slang-list.h
+++ b/source/core/slang-list.h
@@ -269,7 +269,7 @@ namespace Slang
 
         void insertRange(Index id, const List<T>& list) {    insertRange(id, list.m_buffer, list.m_count); }
 
-        void addRange(ArrayView<T> list) { insertRange(m_count, list.getBuffer(), list.Count()); }
+        void addRange(ArrayView<T> list) { insertRange(m_count, list.getBuffer(), list.getCount()); }
 
         void addRange(const T* vals, Index n) { insertRange(m_count, vals, n); }
 

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2434,7 +2434,7 @@ __generic<T : IComparable>
 [__unsafeForceInlineEarly]
 bool operator >=(T v0, T v1)
 {
-    return v1.lessThanOrEquals(v1);
+    return v1.lessThan(v1);
 }
 __generic<T : IComparable>
 [__unsafeForceInlineEarly]

--- a/source/slang/diff.meta.slang
+++ b/source/slang/diff.meta.slang
@@ -23,7 +23,7 @@ interface IDifferentiable
     // before anything else.
 
     [__BuiltinRequirement(_BuiltinRequirementKind.DifferentialType)]
-    associatedtype Differential;
+    associatedtype Differential : IDifferentiable;
 
     [__BuiltinRequirement(_BuiltinRequirementKind.DZeroFunc)]
     static Differential dzero();
@@ -128,21 +128,45 @@ extension vector<float, 4> : IDifferentiable
     }
 }
 
+__magic_type(DifferentialBottomType)
+__intrinsic_type($(kIROp_DifferentialBottomType))
+struct __DifferentialBottom : IDifferentiable
+{
+    typedef __DifferentialBottom Differential;
+
+    __intrinsic_op($(kIROp_DifferentialBottomValue))
+    static __DifferentialBottom dzero();
+
+    [__unsafeForceInlineEarly]
+    static __DifferentialBottom dadd(Differential a, Differential b)
+    {
+        return dzero();
+    }
+
+    [__unsafeForceInlineEarly]
+    static __DifferentialBottom dmul(This a, Differential b)
+    {
+        return dzero();
+    }
+}
+
     /// Pair type that serves to wrap the primal and
     /// differential types of an arbitrary type T.
-__generic<T : IDifferentiable>
+__generic<T : IDifferentiable, TDiff : IDifferentiable>
 __magic_type(DifferentialPairType)
 __intrinsic_type($(kIROp_DifferentialPairType))
-struct __DifferentialPair
+struct __DifferentialPair : IDifferentiable
 {
 
+    typedef __DifferentialPair<TDiff, __DifferentialBottom> Differential;
+
     __intrinsic_op($(kIROp_MakeDifferentialPair))
-    __init(T _primal, T.Differential _differential);
+    __init(T _primal, TDiff _differential);
 
     __intrinsic_op($(kIROp_DifferentialPairGetDifferential))
-    T.Differential d();
+    TDiff d();
 
-    T.Differential getDifferential()
+    TDiff getDifferential()
     {
         return d();
     }
@@ -154,7 +178,39 @@ struct __DifferentialPair
     {
         return p();
     }
+
+    // There are only two possible relationships between TDiff and T.Differnetial:
+    // 1. TDiff == T.Differential.
+    // 2. TDiff == bottom, T.Differential = someType
+    // In case 1, we can trivially cast between the two.
+    // In case 2, the result should yeild TargetType.dzero().
+    // We implement this behavior in an IRInst DifferentialEqualityTypeCast.
+
+    __intrinsic_op($(kIROp_DifferentialEqualityTypeCast))
+    static TDiff __type_equality_cast(T.Differential d);
+    __intrinsic_op($(kIROp_DifferentialEqualityTypeCast))
+    static T.Differential __type_equality_cast(TDiff d);
+
+    [__unsafeForceInlineEarly]
+    static Differential dzero()
+    {
+        return Differential(__type_equality_cast(T.dzero()), __DifferentialBottom.dzero());
+    }
+
+    [__unsafeForceInlineEarly]
+    static Differential dadd(Differential a, Differential b)
+    {
+        return Differential(__type_equality_cast(T.dadd(__type_equality_cast(a.p()), __type_equality_cast(b.p()))), __DifferentialBottom.dzero());
+    }
+
+    [__unsafeForceInlineEarly]
+    static Differential dmul(This a, Differential b)
+    {
+        return Differential(__type_equality_cast(T.dmul(a.p(), __type_equality_cast(b.p()))), __DifferentialBottom.dzero());
+    }
 };
+
+typealias DifferentialPair<T:IDifferentiable> = __DifferentialPair<T, T.Differential>;
 
 typealias IDFloat = IFloat & IDifferentiable;
 
@@ -171,9 +227,9 @@ namespace dstd
     T exp(T x);
 
     __generic<T : IDFloat>
-    __DifferentialPair<T> d_exp(__DifferentialPair<T> dpx)
+    DifferentialPair<T> d_exp(DifferentialPair<T> dpx)
     {
-        return __DifferentialPair<T>(
+        return DifferentialPair<T>(
             exp(dpx.p()),
             T.dmul(exp(dpx.p()), dpx.d()));
     }
@@ -189,9 +245,9 @@ namespace dstd
     T sin(T x);
 
     __generic<T : IDFloat>
-    __DifferentialPair<T> d_sin(__DifferentialPair<T> dpx)
+    DifferentialPair<T> d_sin(DifferentialPair<T> dpx)
     {
-        return __DifferentialPair<T>(
+        return DifferentialPair<T>(
             sin(dpx.p()),
             T.dmul(cos(dpx.p()), dpx.d()));
     }
@@ -207,9 +263,9 @@ namespace dstd
     T cos(T x);
 
     __generic<T : IDFloat>
-    __DifferentialPair<T> d_cos(__DifferentialPair<T> dpx)
+    DifferentialPair<T> d_cos(DifferentialPair<T> dpx)
     {
-        return __DifferentialPair<T>(
+        return DifferentialPair<T>(
             cos(dpx.p()),
             T.dmul(-sin(dpx.p()), dpx.d()));
     }

--- a/source/slang/diff.meta.slang
+++ b/source/slang/diff.meta.slang
@@ -23,7 +23,7 @@ interface IDifferentiable
     // before anything else.
 
     [__BuiltinRequirement(_BuiltinRequirementKind.DifferentialType)]
-    associatedtype Differential : IDifferentiable;
+    associatedtype Differential;
 
     [__BuiltinRequirement(_BuiltinRequirementKind.DZeroFunc)]
     static Differential dzero();
@@ -152,21 +152,21 @@ struct __DifferentialBottom : IDifferentiable
 
     /// Pair type that serves to wrap the primal and
     /// differential types of an arbitrary type T.
-__generic<T : IDifferentiable, TDiff : IDifferentiable>
+__generic<T : IDifferentiable>
 __magic_type(DifferentialPairType)
 __intrinsic_type($(kIROp_DifferentialPairType))
-struct __DifferentialPair : IDifferentiable
+struct DifferentialPair : IDifferentiable
 {
-
-    typedef __DifferentialPair<TDiff, __DifferentialBottom> Differential;
+    typedef DifferentialPair<T.Differential> Differential;
+    typedef T.Differential DifferentialElementType;
 
     __intrinsic_op($(kIROp_MakeDifferentialPair))
-    __init(T _primal, TDiff _differential);
+    __init(T _primal, T.Differential _differential);
 
     __intrinsic_op($(kIROp_DifferentialPairGetDifferential))
-    TDiff d();
+    T.Differential d();
 
-    TDiff getDifferential()
+    T.Differential getDifferential()
     {
         return d();
     }
@@ -179,38 +179,31 @@ struct __DifferentialPair : IDifferentiable
         return p();
     }
 
-    // There are only two possible relationships between TDiff and T.Differnetial:
-    // 1. TDiff == T.Differential.
-    // 2. TDiff == bottom, T.Differential = someType
-    // In case 1, we can trivially cast between the two.
-    // In case 2, the result should yeild TargetType.dzero().
-    // We implement this behavior in an IRInst DifferentialEqualityTypeCast.
-
-    __intrinsic_op($(kIROp_DifferentialEqualityTypeCast))
-    static TDiff __type_equality_cast(T.Differential d);
-    __intrinsic_op($(kIROp_DifferentialEqualityTypeCast))
-    static T.Differential __type_equality_cast(TDiff d);
-
     [__unsafeForceInlineEarly]
     static Differential dzero()
     {
-        return Differential(__type_equality_cast(T.dzero()), __DifferentialBottom.dzero());
+        return Differential(T.dzero(), Differential.DifferentialElementType.dzero());
     }
 
     [__unsafeForceInlineEarly]
     static Differential dadd(Differential a, Differential b)
     {
-        return Differential(__type_equality_cast(T.dadd(__type_equality_cast(a.p()), __type_equality_cast(b.p()))), __DifferentialBottom.dzero());
+        return Differential(
+            T.dadd(
+                a.p(),
+                b.p()
+            ),
+            Differential.DifferentialElementType.dzero());
     }
 
     [__unsafeForceInlineEarly]
     static Differential dmul(This a, Differential b)
     {
-        return Differential(__type_equality_cast(T.dmul(a.p(), __type_equality_cast(b.p()))), __DifferentialBottom.dzero());
+        return Differential(
+             T.dmul(a.p(), b.p()),
+            Differential.DifferentialElementType.dzero());
     }
 };
-
-typealias DifferentialPair<T:IDifferentiable> = __DifferentialPair<T, T.Differential>;
 
 typealias IDFloat = IFloat & IDifferentiable;
 

--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -254,7 +254,9 @@ private:
     // The actual values of the arguments
     List<Val* > args;
 public:
+    List<Val*>& getArgs() { return args; }
     const List<Val*>& getArgs() const { return args; }
+
     // Overrides should be public so base classes can access
     Substitutions* _applySubstitutionsShallowOverride(ASTBuilder* astBuilder, SubstitutionSet substSet, Substitutions* substOuter, int* ioDiff);
     bool _equalsOverride(Substitutions* subst);
@@ -263,6 +265,12 @@ public:
     GenericSubstitution(GenericDecl* decl)
     {
         genericDecl = decl;
+    }
+
+    GenericSubstitution(GenericDecl* decl, ArrayView<Val*> argVals)
+    {
+        genericDecl = decl;
+        args.addRange(argVals);
     }
 
     template<typename... TArgs>

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -141,6 +141,16 @@ Type* SharedASTBuilder::getNoneType()
     return m_noneType;
 }
 
+Type* SharedASTBuilder::getDifferentialBottomType()
+{
+    if (!m_diffBottomType)
+    {
+        auto diffBottomTypeDecl = findMagicDecl("DifferentialBottomType");
+        m_diffBottomType = DeclRefType::create(m_astBuilder, makeDeclRef<Decl>(diffBottomTypeDecl));
+    }
+    return m_diffBottomType;
+}
+
 SharedASTBuilder::~SharedASTBuilder()
 {
     // Release built in types..
@@ -299,13 +309,22 @@ VectorExpressionType* ASTBuilder::getVectorType(
     return result;
 }
 
-DifferentialPairType* ASTBuilder::getDifferentialPairType(Type* valueType, Witness* conformanceWitness)
+DifferentialPairType* ASTBuilder::getDifferentialPairType(
+    Type* valueType,
+    Type* differentialType,
+    Witness* primalIsDifferentialWitness,
+    Witness* differentialIsDifferentiableWitness)
 {
     auto genericDecl = dynamicCast<GenericDecl>(m_sharedASTBuilder->findMagicDecl("DifferentialPairType"));
 
     auto typeDecl = genericDecl->inner;
 
-    auto substitutions = getOrCreate<GenericSubstitution>(genericDecl, valueType, conformanceWitness);
+    auto substitutions = getOrCreate<GenericSubstitution>(
+        genericDecl,
+        valueType,
+        differentialType,
+        primalIsDifferentialWitness,
+        differentialIsDifferentiableWitness);
 
     auto declRef = DeclRef<Decl>(typeDecl, substitutions);
     auto rsType = DeclRefType::create(this, declRef);

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -311,9 +311,7 @@ VectorExpressionType* ASTBuilder::getVectorType(
 
 DifferentialPairType* ASTBuilder::getDifferentialPairType(
     Type* valueType,
-    Type* differentialType,
-    Witness* primalIsDifferentialWitness,
-    Witness* differentialIsDifferentiableWitness)
+    Witness* primalIsDifferentialWitness)
 {
     auto genericDecl = dynamicCast<GenericDecl>(m_sharedASTBuilder->findMagicDecl("DifferentialPairType"));
 
@@ -322,9 +320,7 @@ DifferentialPairType* ASTBuilder::getDifferentialPairType(
     auto substitutions = getOrCreate<GenericSubstitution>(
         genericDecl,
         valueType,
-        differentialType,
-        primalIsDifferentialWitness,
-        differentialIsDifferentiableWitness);
+        primalIsDifferentialWitness);
 
     auto declRef = DeclRef<Decl>(typeDecl, substitutions);
     auto rsType = DeclRefType::create(this, declRef);

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -331,9 +331,7 @@ public:
 
     DifferentialPairType* getDifferentialPairType(
         Type* valueType,
-        Type* differentialType,
-        Witness* primalIsDifferentialWitness,
-        Witness* differentialIsDifferentiableWitness);
+        Witness* primalIsDifferentialWitness);
 
     DeclRef<InterfaceDecl> getDifferentiableInterface();
 

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -35,6 +35,8 @@ public:
     Type* getNullPtrType();
         /// Get the NullPtr type
     Type* getNoneType();
+        /// Get the DifferentialBottom type.
+    Type* getDifferentialBottomType();
 
     const ReflectClassInfo* findClassInfo(Name* name);
     SyntaxClass<NodeBase> findSyntaxClass(Name* name);
@@ -79,7 +81,7 @@ protected:
     Type* m_dynamicType = nullptr;
     Type* m_nullPtrType = nullptr;
     Type* m_noneType = nullptr;
-
+    Type* m_diffBottomType = nullptr;
     Type* m_builtinTypes[Index(BaseType::CountOf)];
 
     Dictionary<String, Decl*> m_magicDecls;
@@ -297,6 +299,7 @@ public:
     Type* getOverloadedType() { return m_sharedASTBuilder->m_overloadedType; }
     Type* getErrorType() { return m_sharedASTBuilder->m_errorType; }
     Type* getBottomType() { return m_sharedASTBuilder->m_bottomType; }
+    Type* getDifferentialBottomType() { return m_sharedASTBuilder->getDifferentialBottomType(); }
     Type* getStringType() { return m_sharedASTBuilder->getStringType(); }
     Type* getNullPtrType() { return m_sharedASTBuilder->getNullPtrType(); }
     Type* getNoneType() { return m_sharedASTBuilder->getNoneType(); }
@@ -326,7 +329,11 @@ public:
 
     VectorExpressionType* getVectorType(Type* elementType, IntVal* elementCount);
 
-    DifferentialPairType* getDifferentialPairType(Type* valueType, Witness* conformanceWitness);
+    DifferentialPairType* getDifferentialPairType(
+        Type* valueType,
+        Type* differentialType,
+        Witness* primalIsDifferentialWitness,
+        Witness* differentialIsDifferentiableWitness);
 
     DeclRef<InterfaceDecl> getDifferentiableInterface();
 

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -29,6 +29,9 @@ class ContainerDecl: public Decl
     List<Decl*> members;
     SourceLoc closingSourceLoc;
 
+    // The associated scope owned by this decl.
+    Scope* ownedScope = nullptr;
+
     template<typename T>
     FilteredMemberList<T> getMembersOfType()
     {

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -126,6 +126,12 @@ class InitializerListExpr : public Expr
     List<Expr*> args;
 };
 
+class GetArrayLengthExpr : public Expr
+{
+    SLANG_AST_CLASS(GetArrayLengthExpr)
+    Expr* arrayExpr = nullptr;
+};
+
 // A base class for expressions with arguments
 class ExprWithArgsBase : public Expr
 {

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -1016,14 +1016,14 @@ class RequiresNVAPIAttribute : public Attribute
 };
 
     /// The `[ForwardDifferentiable]` attribute indicates that a function can be forward-differentiated.
-class ForwardDifferentiableAttribute : public Attribute
+class ForwardDifferentiableAttribute : public DifferentiableAttribute
 {
     SLANG_AST_CLASS(ForwardDifferentiableAttribute)
 };
 
     /// The `[ForwardDerivative(function)]` attribute specifies a custom function that should
     /// be used as the derivative for the decorated function.
-class ForwardDerivativeAttribute : public Attribute 
+class ForwardDerivativeAttribute : public DifferentiableAttribute
 {
     SLANG_AST_CLASS(ForwardDerivativeAttribute)
 

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -384,6 +384,12 @@ namespace Slang
             ///
         ReadyForConformances,
 
+            /// Any DeclRefTypes with substitutions have been fully resolved
+            /// to concrete type. E.g. `T.X` with `T=A` should resolve to `A.X`.
+            /// We need a separate pass to resolve these types because `A.X`
+            /// maybe synthesized and made available only after conformance checking.
+        TypesFullyResolved,
+
             /// The declaration is fully checked.
             ///
             /// This step includes any validation of the declaration that is
@@ -778,6 +784,12 @@ namespace Slang
         String toString() const;
         void toText(StringBuilder& out) const;
     };
+
+    // If this is a declref to an associatedtype with a ThisTypeSubsitution,
+    // try to find the concrete decl that satisfies the associatedtype requirement from the
+    // concrete type supplied by ThisTypeSubstittution.
+    Val* _tryLookupConcreteAssociatedTypeFromThisTypeSubst(ASTBuilder* builder, DeclRef<Decl> declRef);
+
 
     template<typename T>
     struct DeclRef : DeclRefBase

--- a/source/slang/slang-ast-synthesis.cpp
+++ b/source/slang/slang-ast-synthesis.cpp
@@ -1,0 +1,175 @@
+#include "slang-ast-synthesis.h"
+
+namespace Slang
+{
+Expr* ASTSynthesizer::emitBinaryExpr(UnownedStringSlice operatorToken, Expr* left, Expr* right)
+{
+    auto infixExpr = m_builder->create<InfixExpr>();
+    infixExpr->functionExpr = emitVarExpr(m_namePool->getName(operatorToken));;
+    infixExpr->arguments.add(left);
+    infixExpr->arguments.add(right);
+    return infixExpr;
+}
+
+Expr* ASTSynthesizer::emitPrefixExpr(UnownedStringSlice operatorToken, Expr* base)
+{
+    auto prefixExpr = m_builder->create<PrefixExpr>();
+    prefixExpr->functionExpr = emitVarExpr(m_namePool->getName(operatorToken));;
+    prefixExpr->arguments.add(base);
+    return prefixExpr;
+}
+
+Expr* ASTSynthesizer::emitPostfixExpr(UnownedStringSlice operatorToken, Expr* base)
+{
+    auto postfixExpr = m_builder->create<PostfixExpr>();
+    postfixExpr->functionExpr = emitVarExpr(m_namePool->getName(operatorToken));;
+    postfixExpr->arguments.add(base);
+    return postfixExpr;
+}
+
+ForStmt* ASTSynthesizer::emitFor(Expr* initVal, Expr* finalVal, VarDecl* &outIndexVar)
+{
+    auto scopeDecl = pushVarScope()->containerDecl;
+    auto stmt = m_builder->create<ForStmt>();
+    stmt->scopeDecl = (ScopeDecl*)scopeDecl;
+    auto declStmt = emitVarDeclStmt(nullptr, m_namePool->getName("S_synth_loop_index"), initVal);
+    stmt->initialStatement = declStmt;
+    outIndexVar = (VarDecl*)declStmt->decl;
+    auto predicateExpr = emitBinaryExpr(UnownedStringSlice("<"), emitVarExpr(outIndexVar), finalVal);
+    stmt->predicateExpression = predicateExpr;
+    stmt->sideEffectExpression = emitPrefixExpr(UnownedStringSlice("++"), emitVarExpr(outIndexVar));
+    getCurrentScope().m_parentSeqStmt->stmts.add(stmt);
+    return stmt;
+}
+
+Expr* ASTSynthesizer::emitVarExpr(Name* name)
+{
+    auto scope = getCurrentScope();
+    SLANG_RELEASE_ASSERT(scope.m_scope);
+    auto varExpr = m_builder->create<VarExpr>();
+    varExpr->name = name;
+    varExpr->scope = scope.m_scope;
+    return varExpr;
+}
+
+Expr* ASTSynthesizer::emitVarExpr(VarDecl* varDecl)
+{
+    auto varExpr = m_builder->create<VarExpr>();
+    varExpr->declRef = makeDeclRef(varDecl);
+    varExpr->type = varDecl->type.type;
+    return varExpr;
+}
+
+Expr* ASTSynthesizer::emitVarExpr(VarDecl* var, Type* type)
+{
+    auto expr = m_builder->create<VarExpr>();
+    expr->declRef = DeclRef<Decl>(var, nullptr);
+    expr->type.type = type;
+    expr->type.isLeftValue = true;
+    return expr;
+}
+
+Expr* ASTSynthesizer::emitVarExpr(DeclStmt* varStmt, Type* type)
+{
+    auto expr = m_builder->create<VarExpr>();
+    expr->declRef = DeclRef<Decl>(as<Decl>(varStmt->decl), nullptr);
+    expr->type.type = type;
+    expr->type.isLeftValue = true;
+    return expr;
+}
+
+Expr* ASTSynthesizer::emitIntConst(int value)
+{
+    auto expr = m_builder->create<IntegerLiteralExpr>();
+    expr->type.type = m_builder->getIntType();
+    expr->value = value;
+    return expr;
+}
+
+Expr* ASTSynthesizer::emitGetArrayLengthExpr(Expr* arrayExpr)
+{
+    auto expr = m_builder->create<GetArrayLengthExpr>();
+    expr->arrayExpr = arrayExpr;
+    expr->type = m_builder->getIntType();
+    return expr;
+}
+
+Expr* ASTSynthesizer::emitMemberExpr(Expr* arrayExpr, Name* name)
+{
+    auto rs = m_builder->create<MemberExpr>();
+    rs->baseExpression = arrayExpr;
+    rs->name = name;
+    return rs;
+}
+
+Expr* ASTSynthesizer::emitAssignExpr(Expr* left, Expr* right)
+{
+    auto rs = m_builder->create<AssignExpr>();
+    rs->left = left;
+    rs->right = right;
+    return rs;
+}
+
+Expr* ASTSynthesizer::emitInvokeExpr(Expr* callee, List<Expr*>&& args)
+{
+    auto rs = m_builder->create<InvokeExpr>();
+    rs->functionExpr = callee;
+    rs->arguments = _Move(args);
+    return rs;
+}
+
+Expr* ASTSynthesizer::emitMemberExpr(Type* type, Name* name)
+{
+    auto rs = m_builder->create<StaticMemberExpr>();
+    auto typeExpr = m_builder->create<SharedTypeExpr>();
+    auto typetype = m_builder->create<TypeType>();
+    typetype->type = type;
+    typeExpr->type = typetype;
+    rs->baseExpression = typeExpr;
+    rs->name = name;
+    return rs;
+}
+
+Expr* ASTSynthesizer::emitIndexExpr(Expr* base, Expr* index)
+{
+    auto rs = m_builder->create<IndexExpr>();
+    rs->baseExpression = base;
+    rs->indexExprs.add(index);
+    return rs;
+}
+
+ExpressionStmt* ASTSynthesizer::emitExprStmt(Expr* expr)
+{
+    auto rs = m_builder->create<ExpressionStmt>();
+    _addStmtToScope(rs);
+    rs->expression = expr;
+    return rs;
+}
+
+ReturnStmt* ASTSynthesizer::emitReturnStmt(Expr* expr)
+{
+    auto rs = m_builder->create<ReturnStmt>();
+    rs->expression = expr;
+    _addStmtToScope(rs);
+    return rs;
+}
+
+DeclStmt* ASTSynthesizer::emitVarDeclStmt(Type* type, Name* name, Expr* initVal)
+{
+    auto scope = getCurrentScope();
+    SLANG_RELEASE_ASSERT(scope.m_parentSeqStmt);
+    SLANG_RELEASE_ASSERT(scope.m_scope);
+    SLANG_RELEASE_ASSERT(scope.m_scope->containerDecl);
+    auto varDecl = m_builder->create<VarDecl>();
+    varDecl->type.type = type;
+    varDecl->nameAndLoc.name = name;
+    varDecl->initExpr = initVal;
+    varDecl->parentDecl = scope.m_scope->containerDecl;
+    varDecl->parentDecl->members.add(varDecl);
+    auto stmt = m_builder->create<DeclStmt>();
+    stmt->decl = varDecl;
+    _addStmtToScope(stmt);
+    return stmt;
+}
+
+}

--- a/source/slang/slang-ast-synthesis.h
+++ b/source/slang/slang-ast-synthesis.h
@@ -1,0 +1,147 @@
+// slang-ast-synthesis.h
+
+#pragma once
+
+#include "slang-syntax.h"
+
+namespace Slang {
+
+struct ASTEmitScope
+{
+    ContainerDecl* m_parent = nullptr;
+    SeqStmt* m_parentSeqStmt = nullptr;
+    Scope* m_scope = nullptr;
+};
+class ASTSynthesizer
+{
+private:
+    ASTBuilder* m_builder;
+    NamePool* m_namePool;
+    List<ASTEmitScope> m_scopeStack;
+public:
+    ASTSynthesizer(ASTBuilder* builder, NamePool* namePool)
+        : m_builder(builder)
+        , m_namePool(namePool)
+    {
+    }
+
+    Scope* getScope(ContainerDecl* decl)
+    {
+        for (auto container = decl; container; container = container->parentDecl)
+        {
+            if (container->ownedScope)
+            {
+                return container->ownedScope;
+            }
+        }
+        return nullptr;
+    }
+
+    // Create a scope for `decl` and push it to scope stack
+    void pushScopeForContainer(ContainerDecl* decl)
+    {
+        if (decl->ownedScope)
+        {
+            // if decl already owns a scope, don't create a new one.
+            pushContainerScope(decl);
+            return;
+        }
+
+        auto parentScope = getScope(decl);
+        decl->ownedScope = m_builder->create<Scope>();
+        decl->ownedScope->parent = parentScope;
+        pushContainerScope(decl);
+    }
+
+    // Push `decl` and its associated scope to scope stack
+    void pushContainerScope(ContainerDecl* decl)
+    {
+        ASTEmitScope scope = getCurrentScope();
+        scope.m_parent = decl;
+        scope.m_scope = getScope(decl);
+        m_scopeStack.add(scope);
+    }
+
+    Scope* pushVarScope()
+    {
+        ASTEmitScope scope = getCurrentScope();
+        auto scopeDecl = m_builder->create<ScopeDecl>();
+        auto newScope = m_builder->create<Scope>();
+        scopeDecl->parentDecl = scope.m_parent;
+        if (scope.m_parent)
+            scope.m_parent->members.add(scopeDecl);
+        newScope->parent = scope.m_scope;
+        newScope->containerDecl = scopeDecl;
+        scope.m_scope = newScope;
+        m_scopeStack.add(scope);
+        return newScope;
+    }
+
+    void _addStmtToScope(Stmt* stmt)
+    {
+        auto scope = getCurrentScope();
+        if (scope.m_parentSeqStmt)
+        {
+            scope.m_parentSeqStmt->stmts.add(stmt);
+        }
+    }
+
+    SeqStmt* pushSeqStmtScope()
+    {
+        ASTEmitScope scope = getCurrentScope();
+        scope.m_parentSeqStmt = m_builder->create<SeqStmt>();
+        m_scopeStack.add(scope);
+        return scope.m_parentSeqStmt;
+    }
+
+    void popScope()
+    {
+        m_scopeStack.removeLast();
+    }
+
+    ASTEmitScope getCurrentScope()
+    {
+        if (m_scopeStack.getCount())
+            return m_scopeStack.getLast();
+        return ASTEmitScope();
+    }
+
+    ForStmt* emitFor(Expr* initVal, Expr* finalVal, VarDecl*& outIndexVar);
+
+    Expr* emitBinaryExpr(UnownedStringSlice operatorToken, Expr* left, Expr* right);
+
+    Expr* emitPrefixExpr(UnownedStringSlice operatorToken, Expr* base);
+
+    Expr* emitPostfixExpr(UnownedStringSlice operatorToken, Expr* base);
+
+    Expr* emitVarExpr(Name* name);
+    Expr* emitVarExpr(VarDecl* var);
+    Expr* emitVarExpr(VarDecl* var, Type* type);
+    Expr* emitVarExpr(DeclStmt* varStmt, Type* type);
+
+    Expr* emitIntConst(int value);
+
+    Expr* emitGetArrayLengthExpr(Expr* arrayExpr);
+
+    Expr* emitMemberExpr(Expr* base, Name* name);
+    Expr* emitMemberExpr(Type* base, Name* name);
+
+    Expr* emitIndexExpr(Expr* base, Expr* index);
+
+    Expr* emitAssignExpr(Expr* left, Expr* right);
+    ExpressionStmt* emitAssignStmt(Expr* left, Expr* right)
+    {
+        return emitExprStmt(emitAssignExpr(left, right));
+    }
+
+    Expr* emitInvokeExpr(Expr* callee, List<Expr*>&& args);
+
+    DeclStmt* emitVarDeclStmt(Type* type, Name* name = nullptr, Expr* initVal = nullptr);
+
+    ExpressionStmt* emitExprStmt(Expr* expr);
+
+    ReturnStmt* emitReturnStmt(Expr* expr);
+
+};
+
+} // namespace Slang

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -86,6 +86,20 @@ protected:
     {}
 };
 
+// The bottom/empty type as a result of Differentiating a Differential.
+class DifferentialBottomType : public DeclRefType
+{
+    SLANG_AST_CLASS(DifferentialBottomType)
+
+    // Overrides should be public so base classes can access
+    void _toTextOverride(StringBuilder& out);
+    Type* _createCanonicalTypeOverride();
+    bool _equalsImplOverride(Type* type);
+    HashCode _getHashCodeOverride();
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+};
+
+
 // Base class for types that can be used in arithmetic expressions
 class ArithmeticExpressionType : public DeclRefType 
 {

--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -618,6 +618,41 @@ Val* TaggedUnionSubtypeWitness::_substituteImplOverride(ASTBuilder* astBuilder, 
     return substWitness;
 }
 
+bool DifferentialBottomSubtypeWitness::_equalsValOverride(Val* val)
+{
+    auto otherDiffBottomWitness = as<DifferentialBottomSubtypeWitness>(val);
+    if (!otherDiffBottomWitness)
+        return false;
+
+    return otherDiffBottomWitness->sub && otherDiffBottomWitness->sub->equals(sub);
+}
+
+void DifferentialBottomSubtypeWitness::_toTextOverride(StringBuilder& out)
+{
+    out << "DifferentialBottomSubtypeWitness(" << sub << ")";
+}
+
+HashCode DifferentialBottomSubtypeWitness::_getHashCodeOverride()
+{
+    return combineHash(3892, sub->getHashCode());
+}
+
+Val* DifferentialBottomSubtypeWitness::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
+{
+    int diff = 0;
+
+    auto substSub = as<Type>(sub->substituteImpl(astBuilder, subst, &diff));
+    auto substSup = as<Type>(sup->substituteImpl(astBuilder, subst, &diff));
+    if (!diff)
+        return this;
+
+    *ioDiff += diff;
+
+    DifferentialBottomSubtypeWitness* substWitness =
+        astBuilder->create<DifferentialBottomSubtypeWitness>(substSub, substSup);
+    return substWitness;
+}
+
 bool ConjunctionSubtypeWitness::_equalsValOverride(Val* val)
 {
     if (auto other = as<ConjunctionSubtypeWitness>(val))

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -399,6 +399,24 @@ class DynamicSubtypeWitness : public SubtypeWitness
     SLANG_AST_CLASS(DynamicSubtypeWitness)
 };
 
+    /// A witness of the fact that any type can be viewed as a subtype of DifferentialBottom.
+class DifferentialBottomSubtypeWitness : public SubtypeWitness
+{
+    SLANG_AST_CLASS(DifferentialBottomSubtypeWitness)
+
+    DifferentialBottomSubtypeWitness(Type* inSub, Type* inSup)
+    {
+        sub = inSub;
+        sup = inSup;
+    }
+
+    // Overrides should be public so base classes can access
+    bool _equalsValOverride(Val* val);
+    void _toTextOverride(StringBuilder& out);
+    HashCode _getHashCodeOverride();
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+};
+
     /// A witness that `T : L & R` because `T : L` and `T : R`
 class ConjunctionSubtypeWitness : public SubtypeWitness
 {

--- a/source/slang/slang-check-conformance.cpp
+++ b/source/slang/slang-check-conformance.cpp
@@ -33,7 +33,6 @@ namespace Slang
                 else
                     return conjunction->rightWitness;
             }
-
             ExtractFromConjunctionSubtypeWitness* simplExtractFromConjunction = builder->create<ExtractFromConjunctionSubtypeWitness>();
             simplExtractFromConjunction->sub = extractFromConjunction->sub;
             simplExtractFromConjunction->sup = extractFromConjunction->sup;
@@ -145,7 +144,7 @@ namespace Slang
                     m_astBuilder->getOrCreate<DeclaredSubtypeWitness>(
                         bb->sub, bb->sup, bb->declRef.decl, bb->declRef.substitutions.substitutions);
 
-                TransitiveSubtypeWitness* transitiveWitness = m_astBuilder->getOrCreateWithDefaultCtor<TransitiveSubtypeWitness>(subType, bb->sup, declaredWitness);
+                TransitiveSubtypeWitness* transitiveWitness = m_astBuilder->getOrCreateWithDefaultCtor<TransitiveSubtypeWitness>();
                 transitiveWitness->sub = subType;
                 transitiveWitness->sup = bb->sup;
                 transitiveWitness->midToSup = declaredWitness;
@@ -377,6 +376,45 @@ namespace Slang
                     {
                         return true;
                     }
+                }
+            }
+
+            // If a generic type parameter does not declare itself to conform to `IDifferentiable`,
+            // we treat it as a subtype of `DifferentialBottom` to make it conform to `IDifferentiable`.
+            // Note: we only consider this option for `originalSubType` so a type that implements `IDifferential` but
+            // inherits from some other non differentiable types don't get to inherit `DifferentialBottom`.
+            if (m_astBuilder->isDifferentiableInterfaceAvailable() &&
+                subType == originalSubType &&
+                superTypeDeclRef.getDecl() == m_astBuilder->getDifferentiableInterface())
+            {
+                if (as<GenericTypeParamDecl>(declRefType->declRef.getDecl()) ||
+                    as<AssocTypeDecl>(declRefType->declRef.getDecl()))
+                {
+                    auto sup = DeclRefType::create(m_astBuilder, superTypeDeclRef);
+                    auto differentialBottomType = as<DeclRefType>(m_astBuilder->getDifferentialBottomType());
+                    auto container = differentialBottomType->declRef.as<ContainerDecl>().getDecl();
+                    SLANG_RELEASE_ASSERT(container);
+                    auto inheritanceDecl = container->getMembersOfType<InheritanceDecl>().getFirst();
+                    auto witnessDifferentialBottomIsIDifferentiable =
+                        m_astBuilder->getOrCreate<DeclaredSubtypeWitness>(
+                            m_astBuilder->getDifferentialBottomType(),
+                            sup,
+                            inheritanceDecl,
+                            nullptr);
+
+                    auto witnessSubIsDifferentialBottom =
+                        m_astBuilder->getOrCreate<DifferentialBottomSubtypeWitness>(
+                            subType, differentialBottomType);
+
+                    TransitiveSubtypeWitness* transitiveWitness =
+                        m_astBuilder->getOrCreateWithDefaultCtor<TransitiveSubtypeWitness>(
+                            witnessSubIsDifferentialBottom, witnessDifferentialBottomIsIDifferentiable);
+                    transitiveWitness->sub = subType;
+                    transitiveWitness->sup = sup;
+                    transitiveWitness->midToSup = witnessDifferentialBottomIsIDifferentiable;
+                    transitiveWitness->subToMid = witnessSubIsDifferentialBottom;
+                    *outWitness = transitiveWitness;
+                    return true;
                 }
             }
         }

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -1169,9 +1169,6 @@ namespace Slang
                 fromExpr);
         }
 
-        // If we coerced to a differentiable type, log it.
-        maybeRegisterDifferentiableType(m_astBuilder, expr->type);
-
         return expr;
     }
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -3235,7 +3235,7 @@ namespace Slang
     Stmt* _synthesizeMemberAssignMemberHelper(ASTSynthesizer& synth, Name* funcName, Type* leftType, Expr* leftValue, List<Expr*>&& args, int nestingLevel = 0)
     {
         if (nestingLevel > 16)
-            return false;
+            return nullptr;
 
         // If field type is an array, assign each element individually.
         if (auto arrayType = as<ArrayExpressionType>(leftType))

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -5393,7 +5393,7 @@ namespace Slang
 
     void SemanticsDeclHeaderVisitor::checkCallableDeclCommon(CallableDecl* decl)
     {
-        if (decl->findModifier<ForwardDifferentiableAttribute>())
+        if (decl->findModifier<DifferentiableAttribute>())
         {
             this->getShared()->getDiffTypeContext()->requireDifferentiableTypeDictionary();
         }

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1457,21 +1457,6 @@ namespace Slang
             synth.pushScopeForContainer(aggTypeDecl);
         }
 
-        // Make the Differential type itself conform to `IDifferential` interface.
-        auto inheritanceIDiffernetiable = m_astBuilder->create<InheritanceDecl>();
-        inheritanceIDiffernetiable->base.type =
-            DeclRefType::create(m_astBuilder, m_astBuilder->getDifferentiableInterface());
-        inheritanceIDiffernetiable->parentDecl = aggTypeDecl;
-        aggTypeDecl->members.add(inheritanceIDiffernetiable);
-
-        // The `Differential` type of a `Differential` type is always `DifferentialBottomType`.
-        auto assocTypeDef = m_astBuilder->create<TypeDefDecl>();
-        assocTypeDef->nameAndLoc.name = getName("Differential");
-        assocTypeDef->type.type = m_astBuilder->getDifferentialBottomType();
-        assocTypeDef->parentDecl = aggTypeDecl;
-        assocTypeDef->setCheckState(DeclCheckState::Checked);
-        aggTypeDecl->members.add(assocTypeDef);
-
         // Helper function to add a `diffType` field into the synthesized type for the original
         // `member`.
         auto differentialType = DeclRefType::create(m_astBuilder, makeDeclRef(aggTypeDecl));
@@ -1543,10 +1528,6 @@ namespace Slang
         }
 
         auto satisfyingType = m_astBuilder->getOrCreateDeclRefType(aggTypeDecl, substSet);
-
-        // Synthesize the rest of IDifferential method conformances by recursively checking
-        // conformance on the synthesized decl.
-        checkAggTypeConformance(aggTypeDecl);
 
         if (doesTypeSatisfyAssociatedTypeConstraintRequirement(satisfyingType, requirementDeclRef, witnessTable))
         {

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -11,9 +11,8 @@
 // and when things get checked.
 
 #include "slang-lookup.h"
-
 #include "slang-syntax.h"
-
+#include "slang-ast-synthesis.h"
 #include <limits>
 
 namespace Slang
@@ -164,6 +163,65 @@ namespace Slang
         void _validateExtensionDeclTargetType(ExtensionDecl* decl);
 
         void visitExtensionDecl(ExtensionDecl* decl);
+    };
+
+    struct SemanticsDeclTypeResolutionVisitor
+        : public SemanticsDeclVisitorBase
+        , public DeclVisitor<SemanticsDeclTypeResolutionVisitor>
+    {
+        SemanticsDeclTypeResolutionVisitor(SemanticsContext const& outer)
+            : SemanticsDeclVisitorBase(outer)
+        {}
+
+        void visitDecl(Decl*) {}
+        void visitDeclGroup(DeclGroup*) {}
+
+        Val* resolveVal(Val* val);
+        Type* resolveType(Type* type)
+        {
+            return (Type*)resolveVal(type);
+        }
+
+        void visitTypeExp(TypeExp& exp)
+        {
+            exp.type = resolveType(exp.type);
+        }
+
+        void visitVarDeclBase(VarDeclBase* varDecl)
+        {
+            visitTypeExp(varDecl->type);
+        }
+
+        void visitGenericTypeConstraintDecl(GenericTypeConstraintDecl* decl)
+        {
+            visitTypeExp(decl->sup);
+        }
+
+        void visitTypeDefDecl(TypeDefDecl* decl)
+        {
+            visitTypeExp(decl->type);
+        }
+
+        void visitGenericTypeParamDecl(GenericTypeParamDecl* paramDecl)
+        {
+            visitTypeExp(paramDecl->initType);
+        }
+
+        void visitInheritanceDecl(InheritanceDecl* inheritanceDecl)
+        {
+            visitTypeExp(inheritanceDecl->base);
+        }
+
+        void visitCallableDecl(CallableDecl* decl)
+        {
+            visitTypeExp(decl->returnType);
+            visitTypeExp(decl->errorType);
+        }
+
+        void visitPropertyDecl(PropertyDecl* decl)
+        {
+            visitTypeExp(decl->type);
+        }
     };
 
     struct SemanticsDeclBodyVisitor
@@ -1363,27 +1421,30 @@ namespace Slang
 
     bool SemanticsVisitor::trySynthesizeDifferentialAssociatedTypeRequirementWitness(
         ConformanceCheckingContext* context,
-        DeclRef<Decl> requirementDeclRef,
+        DeclRef<AssocTypeDecl> requirementDeclRef,
         RefPtr<WitnessTable> witnessTable)
     {
-        // We currently can't handle generic types.
-        if (GetOuterGeneric(context->parentDecl) != nullptr)
-        {
-            return false;
-        }
-
+        ASTSynthesizer synth(m_astBuilder, getNamePool());
         Decl* existingDecl = nullptr;
         AggTypeDecl* aggTypeDecl = nullptr;
         if (context->parentDecl->getMemberDictionary().TryGetValue(requirementDeclRef.getName(), existingDecl))
         {
+            // Remove the `ToBeSynthesizedModifier`.
+            if (as<ToBeSynthesizedModifier>(existingDecl->modifiers.first))
+            {
+                existingDecl->modifiers.first = existingDecl->modifiers.first->next;
+            }
+            else
+            {
+                // The user has defined an associatedtype explicitly but that we reach here because
+                // that type failed to satisfy the `IDifferential` requirement.
+                // We stop the synthesis and let the follow-up logic to report a diagnostic.
+                return false;
+            }
+
             aggTypeDecl = as<AggTypeDecl>(existingDecl);
             SLANG_RELEASE_ASSERT(aggTypeDecl);
-
-            // Remove the `ToBeSynthesizedModifier`.
-            if (as<ToBeSynthesizedModifier>(aggTypeDecl->modifiers.first))
-            {
-                aggTypeDecl->modifiers.first = aggTypeDecl->modifiers.first->next;
-            }
+            synth.pushContainerScope(aggTypeDecl);
         }
         else
         {
@@ -1393,15 +1454,27 @@ namespace Slang
             aggTypeDecl->nameAndLoc.name = requirementDeclRef.getName();
             aggTypeDecl->loc = context->parentDecl->nameAndLoc.loc;
             context->parentDecl->invalidateMemberDictionary();
+            synth.pushScopeForContainer(aggTypeDecl);
         }
 
-        // TODO: if we want to make the synthesized type itself to be differentiable,
-        // add an inheritance decl here. Need to be careful to avoid infinite recursion
-        // trying to synthesize the higher order differential types.
+        // Make the Differential type itself conform to `IDifferential` interface.
+        auto inheritanceIDiffernetiable = m_astBuilder->create<InheritanceDecl>();
+        inheritanceIDiffernetiable->base.type =
+            DeclRefType::create(m_astBuilder, m_astBuilder->getDifferentiableInterface());
+        inheritanceIDiffernetiable->parentDecl = aggTypeDecl;
+        aggTypeDecl->members.add(inheritanceIDiffernetiable);
+
+        // The `Differential` type of a `Differential` type is always `DifferentialBottomType`.
+        auto assocTypeDef = m_astBuilder->create<TypeDefDecl>();
+        assocTypeDef->nameAndLoc.name = getName("Differential");
+        assocTypeDef->type.type = m_astBuilder->getDifferentialBottomType();
+        assocTypeDef->parentDecl = aggTypeDecl;
+        assocTypeDef->setCheckState(DeclCheckState::Checked);
+        aggTypeDecl->members.add(assocTypeDef);
 
         // Helper function to add a `diffType` field into the synthesized type for the original
         // `member`.
-        auto differentialType = GetTypeForDeclRef(makeDeclRef(aggTypeDecl), context->parentDecl->loc);
+        auto differentialType = DeclRefType::create(m_astBuilder, makeDeclRef(aggTypeDecl));
         auto addDiffMember = [&](Decl* member, Type* diffMemberType)
         {
             // If the field is differentiable, add a corresponding field in the associated Differential type.
@@ -1452,12 +1525,39 @@ namespace Slang
             addDiffMember(member, diffType);
         }
 
-        // In the future when the Differential type itself needs to conform to some interface,
-        // this is the place to synthesize requirements for them.
         addModifier(aggTypeDecl, m_astBuilder->create<SynthesizedModifier>());
-        auto satisfyingType = m_astBuilder->getOrCreateDeclRefType(aggTypeDecl, nullptr);
-        witnessTable->add(requirementDeclRef.getDecl(), RequirementWitness(satisfyingType));
-        return true;
+
+        // If `This` is nested inside a generic, we need to form a complete declref type to the
+        // newly synthesized aggTypeDecl here. This can be done by obtaining ThisTypeSubstitution
+        // from requirementDeclRef to get the generic substitution for outer generic parameters, and
+        // apply it to the newly synthesized decl.
+        SubstitutionSet substSet;
+        if (auto thisTypeSusbt = findThisTypeSubstitution(
+                requirementDeclRef.substitutions,
+                as<InterfaceDecl>(requirementDeclRef.getDecl()->parentDecl)))
+        {
+            if (auto declRefType = as<DeclRefType>(thisTypeSusbt->witness->sub))
+            {
+                substSet = declRefType->declRef.substitutions;
+            }
+        }
+
+        auto satisfyingType = m_astBuilder->getOrCreateDeclRefType(aggTypeDecl, substSet);
+
+        // Synthesize the rest of IDifferential method conformances by recursively checking
+        // conformance on the synthesized decl.
+        checkAggTypeConformance(aggTypeDecl);
+
+        if (doesTypeSatisfyAssociatedTypeConstraintRequirement(satisfyingType, requirementDeclRef, witnessTable))
+        {
+            witnessTable->add(requirementDeclRef.getDecl(), RequirementWitness(satisfyingType));
+            return true;
+        }
+
+        // Note: the call to `doesTypeSatisfyAssociatedTypeConstraintRequirement` should always succeed.
+        // If not, there is something wrong with the code synthesis logic. For now we just return false
+        // instead of crashing so the user can work around the issues.
+        return false;
     }
 
     void SemanticsVisitor::tryAddDifferentiableConformanceToContext(Decl* decl, DifferentiableTypeSemanticContext*)
@@ -2242,6 +2342,35 @@ namespace Slang
             witnessTable);
     }
 
+    bool SemanticsVisitor::doesTypeSatisfyAssociatedTypeConstraintRequirement(Type* satisfyingType, DeclRef<AssocTypeDecl> requiredAssociatedTypeDeclRef, RefPtr<WitnessTable> witnessTable)
+    {
+        // We will enumerate the type constraints placed on the
+        // associated type and see if they can be satisfied.
+        //
+        bool conformance = true;
+        for (auto requiredConstraintDeclRef : getMembersOfType<TypeConstraintDecl>(requiredAssociatedTypeDeclRef))
+        {
+            // Grab the type we expect to conform to from the constraint.
+            auto requiredSuperType = getSup(m_astBuilder, requiredConstraintDeclRef);
+
+            // Perform a search for a witness to the subtype relationship.
+            auto witness = tryGetSubtypeWitness(satisfyingType, requiredSuperType);
+            if (witness)
+            {
+                // If a subtype witness was found, then the conformance
+                // appears to hold, and we can satisfy that requirement.
+                witnessTable->add(requiredConstraintDeclRef, RequirementWitness(witness));
+            }
+            else
+            {
+                // If a witness couldn't be found, then the conformance
+                // seems like it will fail.
+                conformance = false;
+            }
+        }
+        return conformance;
+    }
+
     bool SemanticsVisitor::doesTypeSatisfyAssociatedTypeRequirement(
         Type*            satisfyingType,
         DeclRef<AssocTypeDecl>  requiredAssociatedTypeDeclRef,
@@ -2261,27 +2390,8 @@ namespace Slang
         // We will enumerate the type constraints placed on the
         // associated type and see if they can be satisfied.
         //
-        bool conformance = true;
-        for (auto requiredConstraintDeclRef : getMembersOfType<TypeConstraintDecl>(requiredAssociatedTypeDeclRef))
-        {
-            // Grab the type we expect to conform to from the constraint.
-            auto requiredSuperType = getSup(m_astBuilder, requiredConstraintDeclRef);
-
-            // Perform a search for a witness to the subtype relationship.
-            auto witness = tryGetSubtypeWitness(satisfyingType, requiredSuperType);
-            if(witness)
-            {
-                // If a subtype witness was found, then the conformance
-                // appears to hold, and we can satisfy that requirement.
-                witnessTable->add(requiredConstraintDeclRef, RequirementWitness(witness));
-            }
-            else
-            {
-                // If a witness couldn't be found, then the conformance
-                // seems like it will fail.
-                conformance = false;
-            }
-        }
+        bool conformance = doesTypeSatisfyAssociatedTypeConstraintRequirement(
+            satisfyingType, requiredAssociatedTypeDeclRef, witnessTable);
 
         // TODO: if any conformance check failed, we should probably include
         // that in an error message produced about not satisfying the requirement.
@@ -3122,12 +3232,43 @@ namespace Slang
         return false;
     }
 
+    Stmt* _synthesizeMemberAssignMemberHelper(ASTSynthesizer& synth, Name* funcName, Type* leftType, Expr* leftValue, List<Expr*>&& args, int nestingLevel = 0)
+    {
+        if (nestingLevel > 16)
+            return false;
+
+        // If field type is an array, assign each element individually.
+        if (auto arrayType = as<ArrayExpressionType>(leftType))
+        {
+            VarDecl* indexVar = nullptr;
+            auto forStmt = synth.emitFor(synth.emitIntConst(0), synth.emitGetArrayLengthExpr(leftValue), indexVar);
+            auto innerLeft = synth.emitIndexExpr(leftValue, synth.emitVarExpr(indexVar));
+            for (auto& arg : args)
+            {
+                arg = synth.emitIndexExpr(arg, synth.emitVarExpr(indexVar));
+            }
+            auto assignStmt = _synthesizeMemberAssignMemberHelper(synth, funcName, arrayType->baseType, innerLeft, _Move(args), nestingLevel + 1);
+            synth.popScope();
+            if (!assignStmt)
+                return nullptr;
+            forStmt->statement = assignStmt;
+            return forStmt;
+        }
+
+        auto callee = synth.emitMemberExpr(leftType, funcName);
+        return synth.emitAssignStmt(leftValue, synth.emitInvokeExpr(callee, _Move(args)));
+    }
+
     bool SemanticsVisitor::trySynthesizeDifferentialMethodRequirementWitness(
         ConformanceCheckingContext* context,
         DeclRef<Decl> requirementDeclRef,
         RefPtr<WitnessTable> witnessTable)
     {
-        // This method implements a general code synthesis pattern.
+        // We support two cases of synthesis here.
+        // Case 1 is that there the associated Differential type is defined to be `DifferentialBottom`.
+        // In this case we just trivially return `DifferentialBottom` in all synthesized methods.
+        // Case 2 is that the `Differential` type contains members corresponding to each primal member.
+        // We will apply a general code synthesis pattern to reflect that structure.
         // For requirement of the form:
         // ```
         // static TResult requiredMethod(TParam1 p0, TParam2 p1, ...)
@@ -3145,104 +3286,123 @@ namespace Slang
         //     return result;
         // }
         // ```
+
+        // First we need to make sure the associated `Differential` type requirement is satisfied.
+        bool hasDifferentialAssocType = false;
+        for (auto existingEntry : witnessTable->requirementList)
+        {
+            if (auto builtinReqAttr = existingEntry.Key->findModifier<BuiltinRequirementAttribute>())
+            {
+                if (builtinReqAttr->kind == BuiltinRequirementKind::DifferentialType &&
+                    existingEntry.Value.getFlavor() != RequirementWitness::Flavor::none)
+                {
+                    hasDifferentialAssocType = true;
+                }
+            }
+        }
+        if (!hasDifferentialAssocType)
+            return false;
+
+        ASTSynthesizer synth(m_astBuilder, getNamePool());
         List<Expr*> synArgs;
         ThisExpr* synThis = nullptr;
         auto synFunc = synthesizeMethodSignatureForRequirementWitness(
             context, requirementDeclRef.as<FuncDecl>(), synArgs, synThis);
-
+        synFunc->parentDecl = context->parentDecl;
+        synth.pushContainerScope(synFunc);
         auto blockStmt = m_astBuilder->create<BlockStmt>();
         synFunc->body = blockStmt;
-        auto seqStmt = m_astBuilder->create<SeqStmt>();
+        auto seqStmt = synth.pushSeqStmtScope();
         blockStmt->body = seqStmt;
 
-        // Create a variable for return value.
-        auto scopeDecl = m_astBuilder->create<ScopeDecl>();
-        synFunc->members.add(scopeDecl);
-        scopeDecl->parentDecl = synFunc;
-        auto varStmt = m_astBuilder->create<DeclStmt>();
-        seqStmt->stmts.add(varStmt);
-
-        auto returnVar = m_astBuilder->create<VarDecl>();
-        returnVar->parentDecl = scopeDecl;
-        scopeDecl->members.add(returnVar);
-
-        returnVar->type.type = synFunc->returnType.type;
-        returnVar->nameAndLoc.name = getName("result");
-        varStmt->decl = returnVar;
-        auto resultVarExpr = m_astBuilder->create<VarExpr>();
-        resultVarExpr->declRef = makeDeclRef(returnVar);
-        resultVarExpr->type.type = synFunc->returnType.type;
-        resultVarExpr->type.isLeftValue = true;
-
-        for (auto member : context->parentDecl->members)
+        if (synFunc->returnType.type->equals(m_astBuilder->getDifferentialBottomType()))
         {
-            auto derivativeAttr = member->findModifier<DerivativeMemberAttribute>();
-            if (!derivativeAttr)
-                continue;
-            auto varMember = as<VarDeclBase>(member);
-            if (!varMember)
-                continue;
-            ensureDecl(varMember, DeclCheckState::ReadyForReference);
-            auto memberType = varMember->getType();
-            auto diffMemberType = tryGetDifferentialType(m_astBuilder, memberType);
-            if (!diffMemberType)
-                continue;
+            // Trivial case, the `Differential` type is `DifferentialBottom`.
+            // We will just return `DifferentialBottom.dzero()`.
+            auto resultExpr = m_astBuilder->create<InvokeExpr>();
+            auto dzeroMember = m_astBuilder->create<StaticMemberExpr>();
+            auto base = m_astBuilder->create<SharedTypeExpr>();
+            auto typetype = m_astBuilder->create<TypeType>();
+            typetype->type = m_astBuilder->getDifferentialBottomType();
+            base->type.type = typetype;
+            dzeroMember->baseExpression = base;
+            dzeroMember->name = getName("dzero");
+            resultExpr->functionExpr = dzeroMember;
+            auto synReturn = m_astBuilder->create<ReturnStmt>();
+            synReturn->expression = resultExpr;
+            seqStmt->stmts.add(synReturn);
+        }
+        else
+        {
+            // The general case. 
+            // Create a variable for return value.
+            synth.pushVarScope();
+            auto varStmt = synth.emitVarDeclStmt(synFunc->returnType.type, getName("result"));
+            auto resultVarExpr = synth.emitVarExpr(varStmt, synFunc->returnType.type);
 
-            // Construct reference exprs to the member's corresponding fields in each parameter.
-            List<Expr*> paramFields;
-            int paramIndex = 0;
-            for (auto arg : synArgs)
+            for (auto member : context->parentDecl->members)
             {
-                auto memberExpr = m_astBuilder->create<MemberExpr>();
-                memberExpr->baseExpression = arg;
-                // TODO: we should probably fetch the name from `[DerivativeMember]` if `arg` is
-                // Differential type.
-                memberExpr->name = varMember->getName();
-                paramFields.add(memberExpr);
-                paramIndex++;
+                auto derivativeAttr = member->findModifier<DerivativeMemberAttribute>();
+                if (!derivativeAttr)
+                    continue;
+                auto varMember = as<VarDeclBase>(member);
+                if (!varMember)
+                    continue;
+                ensureDecl(varMember, DeclCheckState::ReadyForReference);
+                auto memberType = varMember->getType();
+                auto diffMemberType = tryGetDifferentialType(m_astBuilder, memberType);
+                if (!diffMemberType)
+                    continue;
+
+                // Construct reference exprs to the member's corresponding fields in each parameter.
+                List<Expr*> paramFields;
+                int paramIndex = 0;
+                for (auto arg : synArgs)
+                {
+                    auto memberExpr = m_astBuilder->create<MemberExpr>();
+                    memberExpr->baseExpression = arg;
+                    // TODO: we should probably fetch the name from `[DerivativeMember]` if `arg` is
+                    // Differential type.
+                    memberExpr->name = varMember->getName();
+                    paramFields.add(memberExpr);
+                    paramIndex++;
+                }
+
+                // Invoke the method for the field and assign the value to resultVar.
+                // TODO: we should probably fetch the name from `[DerivativeMember]` if `resultVarExpr`
+                // is Differential type.
+                auto leftVal = synth.emitMemberExpr(resultVarExpr, varMember->getName());
+                if (!_synthesizeMemberAssignMemberHelper(synth, requirementDeclRef.getName(), memberType, leftVal, _Move(paramFields)))
+                    return false;
             }
 
-            // Invoke the method for the field.
-            auto callee = m_astBuilder->create<StaticMemberExpr>();
-            auto baseSharedType = m_astBuilder->create<SharedTypeExpr>();
-            auto baseSharedTypeType = m_astBuilder->create<TypeType>();
-            baseSharedTypeType->type = memberType;
-            baseSharedType->type = baseSharedTypeType;
-            baseSharedType->base.type = memberType;
-            callee->baseExpression = baseSharedType;
-            callee->name = requirementDeclRef.getName();
-            callee->loc = synFunc->loc;
-            auto invokeExpr = m_astBuilder->create<InvokeExpr>();
-            invokeExpr->functionExpr = callee;
-            invokeExpr->arguments = _Move(paramFields);
+            // TODO: synthesize assignments for inherited members here.
 
-            // Assign the value to resultVar.
-            auto leftVal = m_astBuilder->create<MemberExpr>();
-            leftVal->baseExpression = resultVarExpr;
-            // TODO: we should probably fetch the name from `[DerivativeMember]` if `resultVarExpr`
-            // is Differential type.
-            leftVal->name = varMember->getName();
-
-            auto assignExpr = m_astBuilder->create<AssignExpr>();
-            assignExpr->left = leftVal;
-            assignExpr->right = invokeExpr;
-            auto assignStmt = m_astBuilder->create<ExpressionStmt>();
-            assignStmt->expression = assignExpr;
-            seqStmt->stmts.add(assignStmt);
+            auto synReturn = m_astBuilder->create<ReturnStmt>();
+            synReturn->expression = resultVarExpr;
+            seqStmt->stmts.add(synReturn);
         }
-
-        // TODO: synthesize assignments for inherited members here.
         
-        auto synReturn = m_astBuilder->create<ReturnStmt>();
-        synReturn->expression = resultVarExpr;
-        seqStmt->stmts.add(synReturn);
-
-        synFunc->parentDecl = context->parentDecl;
         context->parentDecl->members.add(synFunc);
         context->parentDecl->invalidateMemberDictionary();
         addModifier(synFunc, m_astBuilder->create<SynthesizedModifier>());
 
-        witnessTable->add(requirementDeclRef, RequirementWitness(makeDeclRef(synFunc)));
+        // If `This` is nested inside a generic, we need to form a complete declref type to the
+        // newly synthesized method here in order to fill into the witness table.
+        // This can be done by obtaining ThisTypeSubstitution from requirementDeclRef to get the
+        // generic substitution for outer generic parameters, and apply it here.
+        SubstitutionSet substSet;
+        if (auto thisTypeSusbt = findThisTypeSubstitution(
+            requirementDeclRef.substitutions,
+            as<InterfaceDecl>(requirementDeclRef.getDecl()->parentDecl)))
+        {
+            if (auto declRefType = as<DeclRefType>(thisTypeSusbt->witness->sub))
+            {
+                substSet = declRefType->declRef.substitutions;
+            }
+        }
+
+        witnessTable->add(requirementDeclRef, RequirementWitness(DeclRef<Decl>(synFunc, substSet)));
         return true;
     }
 
@@ -3801,7 +3961,10 @@ namespace Slang
             // be required to implement all interface requirements,
             // just with `abstract` methods that replicate things?
             // (That's what C# does).
-            for (auto inheritanceDecl : decl->getMembersOfType<InheritanceDecl>())
+            
+            // Make a copy of inhertanceDecls firstsince `checkConformance` may modify decl->members.
+            auto inheritanceDecls = decl->getMembersOfType<InheritanceDecl>().toList();
+            for (auto inheritanceDecl : inheritanceDecls)
             {
                 checkConformance(type, inheritanceDecl, decl);
             }
@@ -6274,6 +6437,10 @@ namespace Slang
             SemanticsDeclConformancesVisitor(shared).dispatch(decl);
             break;
 
+        case DeclCheckState::TypesFullyResolved:
+            SemanticsDeclTypeResolutionVisitor(shared).dispatch(decl);
+            break;
+
         case DeclCheckState::Checked:
             SemanticsDeclBodyVisitor(shared).dispatch(decl);
             break;
@@ -6323,6 +6490,42 @@ namespace Slang
             result[constraints.Key] = typeList;
         }
         return result;
+    }
+
+    Val* SemanticsDeclTypeResolutionVisitor::resolveVal(Val* val)
+    {
+        if (auto declRefType = as<DeclRefType>(val))
+        {
+            if (auto concreteType = _tryLookupConcreteAssociatedTypeFromThisTypeSubst(m_astBuilder, declRefType->declRef))
+                return as<Type>(concreteType);
+            for (auto subst = declRefType->declRef.substitutions.substitutions; subst; subst=subst->outer)
+            {
+                if (auto genericSubst = as<GenericSubstitution>(subst))
+                {
+                    ShortList<Val*> newArgs;
+                    for (auto& arg : genericSubst->getArgs())
+                    {
+                        arg = resolveVal(arg);
+                        SLANG_RELEASE_ASSERT(arg);
+                    }
+                }
+            }
+        }
+        else if (auto subtypeWitness = as<SubtypeWitness>(val))
+        {
+            auto sub = as<Type>(resolveVal(subtypeWitness->sub));
+            auto sup = as<Type>(resolveVal(subtypeWitness->sup));
+            if (sub && sup)
+            {
+                if (sub != subtypeWitness->sub || sup != subtypeWitness->sup)
+                {
+                    auto newVal = tryGetSubtypeWitness(as<Type>(sub), as<Type>(sup));
+                    if (newVal)
+                        val = newVal;
+                }
+            }
+        }
+        return val;
     }
 
 }

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -1946,17 +1946,11 @@ namespace Slang
         // Get a reference to the builtin 'IDifferentiable' interface
         auto differentiableInterface = m_astBuilder->getDifferentiableInterface();
 
-        auto differentialType = tryGetDifferentialType(m_astBuilder, primalType);
-        if (!differentialType)
-            differentialType = m_astBuilder->getDifferentialBottomType();
-        auto differentialConformanceWitness = as<Witness>(
-            tryGetInterfaceConformanceWitness(differentialType, differentiableInterface));
         auto conformanceWitness = as<Witness>(tryGetInterfaceConformanceWitness(primalType, differentiableInterface));
         // Check if the provided type inherits from IDifferentiable.
         // If not, return the original type.
-        if (conformanceWitness && differentialConformanceWitness)
-            return m_astBuilder->getDifferentialPairType(
-                primalType, differentialType, conformanceWitness, differentialConformanceWitness);
+        if (conformanceWitness)
+            return m_astBuilder->getDifferentialPairType(primalType, conformanceWitness);
         else
             return primalType;
     }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -794,15 +794,12 @@ namespace Slang
         bool shouldSkipChecking(Decl* decl, DeclCheckState state);
 
         // Auto-diff convenience functions for translating primal types to differential types.
-        Type* _toDifferentialParamType(ASTBuilder* builder, Type* primalType);
+        Type* _toDifferentialParamType(Type* primalType);
 
-        // Translate a return type to the return type of a forward-mode differentiated
-        // function.
-        //
-        Type* _toJVPReturnType(ASTBuilder* builder, Type* primalType);
-        
+        Type* getDifferentialPairType(Type* primalType);
+
         // Convert a function's original type to it's JVP type.
-        Type* processJVPFuncType(ASTBuilder* builder, FuncType* originalType);
+        Type* processJVPFuncType(FuncType* originalType);
 
         // Check and register a type if it is differentiable.
         void maybeRegisterDifferentiableType(ASTBuilder* builder, Type* type);
@@ -1038,6 +1035,11 @@ namespace Slang
             DeclRef<GenericDecl>        requirementGenDecl,
             RefPtr<WitnessTable>        witnessTable);
 
+        bool doesTypeSatisfyAssociatedTypeConstraintRequirement(
+            Type* satisfyingType,
+            DeclRef<AssocTypeDecl>  requiredAssociatedTypeDeclRef,
+            RefPtr<WitnessTable>    witnessTable);
+
         bool doesTypeSatisfyAssociatedTypeRequirement(
             Type*            satisfyingType,
             DeclRef<AssocTypeDecl>  requiredAssociatedTypeDeclRef,
@@ -1124,7 +1126,7 @@ namespace Slang
             /// Otherwise, returns `false`.
         bool trySynthesizeDifferentialAssociatedTypeRequirementWitness(
             ConformanceCheckingContext* context,
-            DeclRef<Decl> requirementDeclRef,
+            DeclRef<AssocTypeDecl> requirementDeclRef,
             RefPtr<WitnessTable> witnessTable);
 
             /// Registers a type as differentiable in the currrent semantic context, if the declaration represents
@@ -1988,6 +1990,8 @@ namespace Slang
         Expr* visitModifiedTypeExpr(ModifiedTypeExpr* expr);
 
         Expr* visitForwardDifferentiateExpr(ForwardDifferentiateExpr* expr);
+
+        Expr* visitGetArrayLengthExpr(GetArrayLengthExpr* expr);
 
             /// Perform semantic checking on a `modifier` that is being applied to the given `type`
         Val* checkTypeModifier(Modifier* modifier, Type* type);

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1559,7 +1559,7 @@ namespace Slang
 
                 OverloadCandidate candidate;
                 candidate.flavor = OverloadCandidate::Flavor::Expr;
-                candidate.funcType = as<FuncType>(processJVPFuncType(this->getASTBuilder(), origFuncType));
+                candidate.funcType = as<FuncType>(processJVPFuncType(origFuncType));
                 candidate.resultType = candidate.funcType->getResultType();
                 candidate.item = LookupResultItem(baseFuncDeclRef);
 
@@ -1576,7 +1576,6 @@ namespace Slang
                         OverloadCandidate candidate;
                         candidate.flavor = OverloadCandidate::Flavor::Expr;
                         candidate.funcType = as<FuncType>(processJVPFuncType(
-                            this->getASTBuilder(),
                             as<FuncType>(GetTypeForDeclRef(item.declRef, item.declRef.decl->loc))));
                         candidate.resultType = candidate.funcType->getResultType();
                         candidate.item = LookupResultItem(item.declRef);
@@ -1606,7 +1605,7 @@ namespace Slang
                 auto funcType = getFuncType(this->getASTBuilder(), unspecializedInnerRef.as<CallableDecl>());
 
                 // Process func type to generate JVP func type.
-                auto jvpFuncType = as<FuncType>(processJVPFuncType(this->getASTBuilder(), funcType));
+                auto jvpFuncType = as<FuncType>(processJVPFuncType(funcType));
 
                 // Extract parameter list from processed type.
                 List<Type*> paramTypes;
@@ -1631,7 +1630,6 @@ namespace Slang
                     // This could potentially be a declRef.substitute(jvpFuncType)
                     //
                     candidate.funcType = as<FuncType>(processJVPFuncType(
-                        this->getASTBuilder(),
                         getFuncType(this->getASTBuilder(), innerRef.as<CallableDecl>())));
                         
                     candidate.resultType = candidate.funcType->getResultType();

--- a/source/slang/slang-ir-diff-jvp.cpp
+++ b/source/slang/slang-ir-diff-jvp.cpp
@@ -1333,22 +1333,10 @@ struct JVPTranscriber
         }
         else
         {
-            // We special case a few non-differentiable types that sometimes appear in places
-            // where we're forced to provide a differential zero value. For instance, 
-            // float3(float, float, int) is accepted by the compiler, but is tricky in the context
-            // of differentiation since int is non-differentiable, and should be cast to float first.
-            // In the absence of such casts, this piece of code generates appropriate zero values.
-            // 
-            switch (primalType->getOp())
-            {
-                case kIROp_IntType:
-                    return builder->getIntValue(primalType, 0);
-                default:
-                    getSink()->diagnose(primalType->sourceLoc,
-                        Diagnostics::internalCompilerError,
-                        "could not generate zero value for given type");
-                    return nullptr;
-            }
+            getSink()->diagnose(primalType->sourceLoc,
+                Diagnostics::internalCompilerError,
+                "could not generate zero value for given type");
+            return nullptr;
         }
     }
 

--- a/source/slang/slang-ir-diff-jvp.cpp
+++ b/source/slang/slang-ir-diff-jvp.cpp
@@ -193,20 +193,20 @@ struct DifferentiableTypeConformanceContext
 
     IRStructKey* findZeroMethodStructKey()
     {
-        return getIDifferentiableStructKeyAtIndex(1);
+        return getIDifferentiableStructKeyAtIndex(2);
     }
 
     IRStructKey* findAddMethodStructKey()
     {
-        return getIDifferentiableStructKeyAtIndex(2);
+        return getIDifferentiableStructKeyAtIndex(3);
     }
 
     IRStructKey* getIDifferentiableStructKeyAtIndex(UInt index)
     {
         if (as<IRModuleInst>(inst) && differentiableInterfaceType)
         {
-            // Assume for now that IDifferentiable has exactly three fields.
-            SLANG_ASSERT(differentiableInterfaceType->getOperandCount() == 4);
+            // Assume for now that IDifferentiable has exactly five fields.
+            SLANG_ASSERT(differentiableInterfaceType->getOperandCount() == 5);
             if (auto entry = as<IRInterfaceRequirementEntry>(differentiableInterfaceType->getOperand(index)))
                 return as<IRStructKey>(entry->getRequirementKey());
             else

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -278,7 +278,6 @@ INST(lookup_interface_method, lookup_interface_method, 2, 0)
 INST(GetSequentialID, GetSequentialID, 1, 0)
 INST(lookup_witness_table, lookup_witness_table, 2, 0)
 INST(BindGlobalGenericParam, bind_global_generic_param, 2, 0)
-
 INST(Construct, construct, 0, 0)
 INST(AllocObj, allocObj, 0, 0)
 

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -60,6 +60,7 @@ INST(Nop, nop, 0, 0)
     INST(OptionalType, Optional, 1, 0)
 
     INST(DifferentialPairType, DiffPair, 1, 0)
+    INST(DifferentialBottomType, DiffBottomType, 0, 0)
 
     /* BindExistentialsTypeBase */
 
@@ -297,6 +298,7 @@ INST(GetOptionalValue, getOptionalValue, 1, 0)
 INST(OptionalHasValue, optionalHasValue, 1, 0)
 INST(MakeOptionalValue, makeOptionalValue, 1, 0)
 INST(MakeOptionalNone, makeOptionalNone, 1, 0)
+INST(DifferentialBottomValue, differentialBottomVal, 0, 0)
 INST(Call, call, 1, 0)
 
 INST(RTTIObject, rtti_object, 0, 0)
@@ -759,6 +761,7 @@ INST(Reinterpret,                       reinterpret,                1, 0)
 INST(CastPtrToBool, CastPtrToBool, 1, 0)
 INST(IsType, IsType, 3, 0)
 INST(ForwardDifferentiate,                   ForwardDifferentiate,            1, 0)
+INST(DifferentialEqualityTypeCast, DifferentialEqualityTypeCast, 1, 0)
 
 // Converts other resources (such as ByteAddressBuffer) to the equivalent StructuredBuffer
 INST(GetEquivalentStructuredBuffer,     getEquivalentStructuredBuffer, 1, 0)

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -6282,6 +6282,8 @@ namespace Slang
         case kIROp_MakeOptionalNone:
         case kIROp_OptionalHasValue:
         case kIROp_GetOptionalValue:
+        case kIROp_MakeTuple:
+        case kIROp_GetTupleElement:
         case kIROp_Load:    // We are ignoring the possibility of loads from bad addresses, or `volatile` loads
         case kIROp_ImageSubscript:
         case kIROp_FieldExtract:

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -132,8 +132,8 @@ namespace Slang
             Scope* newScope = astBuilder->create<Scope>();
             newScope->containerDecl = containerDecl;
             newScope->parent = currentScope;
-
             currentScope = newScope;
+            containerDecl->ownedScope = newScope;
         }
 
         void pushScopeAndSetParent(ContainerDecl* containerDecl)

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -915,7 +915,14 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         DeclRefBase substDeclRef;
         substDeclRef.decl = decl;
         substDeclRef.substitutions = substSubst;
-                
+
+        // TODO: The old code here used to try to translate a decl-ref
+        // to an associated type in a decl-ref for the concrete type
+        // in a particular implementation.
+        //
+        // I have only kept that logic in `DeclRefType::SubstituteImpl`,
+        // but it may turn out it is needed here too.
+
         return substDeclRef;
     }
 

--- a/source/slang/slang.natvis
+++ b/source/slang/slang.natvis
@@ -233,7 +233,7 @@
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::LetExpr">(Slang::LetExpr*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ExtractExistentialValueExpr">(Slang::ExtractExistentialValueExpr*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::OpenRefExpr">(Slang::OpenRefExpr*)&amp;astNodeType</ExpandedItem>
-            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::JVPDifferentiateExpr">(Slang::JVPDifferentiateExpr*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ForwardDifferentiateExpr">(Slang::ForwardDifferentiateExpr*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::TaggedUnionTypeExpr">(Slang::TaggedUnionTypeExpr*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ThisTypeExpr">(Slang::ThisTypeExpr*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::AndTypeExpr">(Slang::AndTypeExpr*)&amp;astNodeType</ExpandedItem>
@@ -384,6 +384,7 @@
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ErrorType">(Slang::ErrorType*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::BottomType">(Slang::BottomType*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::DeclRefType">(Slang::DeclRefType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::DifferentialPairType">(Slang::DeclRefType*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ArithmeticExpressionType">(Slang::ArithmeticExpressionType*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::BasicExpressionType">(Slang::BasicExpressionType*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::VectorExpressionType">(Slang::VectorExpressionType*)&amp;astNodeType</ExpandedItem>
@@ -456,7 +457,7 @@
         </Expand>
     </Type>
 
-    <Type Name="Slang::Substitutions">
+    <Type Name="Slang::Substitutions" Inheritable="false">
         <DisplayString>{astNodeType}</DisplayString>
         <Expand>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::GenericSubstitution">(Slang::GenericSubstitution*)&amp;astNodeType</ExpandedItem>
@@ -469,7 +470,7 @@
             <LinkedListItems>
                 <HeadPointer>substitutions</HeadPointer>
                 <NextPointer>outer</NextPointer>
-                <ValueNode>this</ValueNode>
+                <ValueNode>(Slang::Substitutions*)this</ValueNode>
             </LinkedListItems>
         </Expand>
     </Type>
@@ -487,6 +488,79 @@
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::GenericParamIntVal">(Slang::GenericParamIntVal*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::DeclaredSubtypeWitness">(Slang::DeclaredSubtypeWitness*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::TransitiveSubtypeWitness">(Slang::TransitiveSubtypeWitness*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::OverloadGroupType">(Slang::OverloadGroupType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::InitializerListType">(Slang::InitializerListType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ErrorType">(Slang::ErrorType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::BottomType">(Slang::BottomType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::DeclRefType">(Slang::DeclRefType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::DifferentialPairType">(Slang::DeclRefType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ArithmeticExpressionType">(Slang::ArithmeticExpressionType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::BasicExpressionType">(Slang::BasicExpressionType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::VectorExpressionType">(Slang::VectorExpressionType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::MatrixExpressionType">(Slang::MatrixExpressionType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::BuiltinType">(Slang::BuiltinType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::FeedbackType">(Slang::FeedbackType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ResourceType">(Slang::ResourceType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::TextureTypeBase">(Slang::TextureTypeBase*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::TextureType">(Slang::TextureType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::TextureSamplerType">(Slang::TextureSamplerType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::GLSLImageType">(Slang::GLSLImageType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::SamplerStateType">(Slang::SamplerStateType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::BuiltinGenericType">(Slang::BuiltinGenericType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::PointerLikeType">(Slang::PointerLikeType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ParameterGroupType">(Slang::ParameterGroupType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::UniformParameterGroupType">(Slang::UniformParameterGroupType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ConstantBufferType">(Slang::ConstantBufferType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::TextureBufferType">(Slang::TextureBufferType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::GLSLShaderStorageBufferType">(Slang::GLSLShaderStorageBufferType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ParameterBlockType">(Slang::ParameterBlockType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::VaryingParameterGroupType">(Slang::VaryingParameterGroupType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::GLSLInputParameterGroupType">(Slang::GLSLInputParameterGroupType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::GLSLOutputParameterGroupType">(Slang::GLSLOutputParameterGroupType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::HLSLStructuredBufferTypeBase">(Slang::HLSLStructuredBufferTypeBase*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::HLSLStructuredBufferType">(Slang::HLSLStructuredBufferType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::HLSLRWStructuredBufferType">(Slang::HLSLRWStructuredBufferType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::HLSLRasterizerOrderedStructuredBufferType">(Slang::HLSLRasterizerOrderedStructuredBufferType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::HLSLAppendStructuredBufferType">(Slang::HLSLAppendStructuredBufferType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::HLSLConsumeStructuredBufferType">(Slang::HLSLConsumeStructuredBufferType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::HLSLStreamOutputType">(Slang::HLSLStreamOutputType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::HLSLPointStreamType">(Slang::HLSLPointStreamType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::HLSLLineStreamType">(Slang::HLSLLineStreamType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::HLSLTriangleStreamType">(Slang::HLSLTriangleStreamType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::UntypedBufferResourceType">(Slang::UntypedBufferResourceType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::HLSLByteAddressBufferType">(Slang::HLSLByteAddressBufferType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::HLSLRWByteAddressBufferType">(Slang::HLSLRWByteAddressBufferType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::HLSLRasterizerOrderedByteAddressBufferType">(Slang::HLSLRasterizerOrderedByteAddressBufferType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::RaytracingAccelerationStructureType">(Slang::RaytracingAccelerationStructureType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::HLSLPatchType">(Slang::HLSLPatchType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::HLSLInputPatchType">(Slang::HLSLInputPatchType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::HLSLOutputPatchType">(Slang::HLSLOutputPatchType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::GLSLInputAttachmentType">(Slang::GLSLInputAttachmentType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::StringTypeBase">(Slang::StringTypeBase*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::StringType">(Slang::StringType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::NativeStringType">(Slang::NativeStringType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::DynamicType">(Slang::DynamicType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::EnumTypeType">(Slang::EnumTypeType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::PtrTypeBase">(Slang::PtrTypeBase*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::PtrType">(Slang::PtrType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ParamDirectionType">(Slang::ParamDirectionType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::OutTypeBase">(Slang::OutTypeBase*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::OutType">(Slang::OutType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::InOutType">(Slang::InOutType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::RefType">(Slang::RefType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::NullPtrType">(Slang::NullPtrType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ArrayExpressionType">(Slang::ArrayExpressionType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::TypeType">(Slang::TypeType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::NamedExpressionType">(Slang::NamedExpressionType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::FuncType">(Slang::FuncType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::GenericDeclRefType">(Slang::GenericDeclRefType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::NamespaceType">(Slang::NamespaceType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ExtractExistentialType">(Slang::ExtractExistentialType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::TaggedUnionType">(Slang::TaggedUnionType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ExistentialSpecializedType">(Slang::ExistentialSpecializedType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ThisType">(Slang::ThisType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::AndType">(Slang::AndType*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::ModifiedType">(Slang::ModifiedType*)&amp;astNodeType</ExpandedItem>
         </Expand>
     </Type>
 </AutoVisualizer>

--- a/tests/autodiff/arithmetic-jvp.slang
+++ b/tests/autodiff/arithmetic-jvp.slang
@@ -4,7 +4,7 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-typedef __DifferentialPair<float> dpfloat;
+typedef DifferentialPair<float> dpfloat;
 typedef float.Differential dfloat;
 
 [ForwardDifferentiable]

--- a/tests/autodiff/auto-differential-type.slang
+++ b/tests/autodiff/auto-differential-type.slang
@@ -33,7 +33,7 @@ struct A : IDifferentiable
     }
 };
 
-typedef __DifferentialPair<A> dpA;
+typedef DifferentialPair<A> dpA;
 
 [ForwardDifferentiable]
 A f(A a)

--- a/tests/autodiff/custom-intrinsic.slang
+++ b/tests/autodiff/custom-intrinsic.slang
@@ -4,7 +4,7 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-typedef __DifferentialPair<float> dpfloat;
+typedef DifferentialPair<float> dpfloat;
 
 typealias IDFloat = IFloat & IDifferentiable;
 
@@ -20,9 +20,9 @@ namespace myintrinsiclib
     T exp(T x);
 
     __generic<T : IDFloat>
-    __DifferentialPair<T> d_exp(__DifferentialPair<T> dpx)
+    DifferentialPair<T> d_exp(DifferentialPair<T> dpx)
     {
-        return __DifferentialPair<T>(
+        return DifferentialPair<T>(
             exp(dpx.p()),
             T.dmul(exp(dpx.p()), dpx.d()));
     }
@@ -39,9 +39,9 @@ namespace myintrinsiclib
     T sin(T x);
 
     __generic<T : IDFloat>
-    __DifferentialPair<T> d_sin(__DifferentialPair<T> dpx)
+    DifferentialPair<T> d_sin(DifferentialPair<T> dpx)
     {
-        return __DifferentialPair<T>(
+        return DifferentialPair<T>(
             sin(dpx.p()),
             T.dmul(cos(dpx.p()), dpx.d()));
     }
@@ -57,9 +57,9 @@ namespace myintrinsiclib
     T cos(T x);
 
     __generic<T : IDFloat>
-    __DifferentialPair<T> d_cos(__DifferentialPair<T> dpx)
+    DifferentialPair<T> d_cos(DifferentialPair<T> dpx)
     {
-        return __DifferentialPair<T>(
+        return DifferentialPair<T>(
             cos(dpx.p()),
             T.dmul(-sin(dpx.p()), dpx.d()));
     }
@@ -76,14 +76,14 @@ namespace myintrinsiclib
     }
 
     __generic<T : IDFloat>
-    void d_sincos(__DifferentialPair<T> x, out __DifferentialPair<T> s, out __DifferentialPair<T> c)
+    void d_sincos(DifferentialPair<T> x, out DifferentialPair<T> s, out DifferentialPair<T> c)
     {
         T _s;
         T _c;
         sincos(x.p(), _s, _c);
 
-        s = __DifferentialPair<T>(_s, T.dmul(_c, x.d()));
-        c = __DifferentialPair<T>(_c, T.dmul(-_s, x.d()));
+        s = DifferentialPair<T>(_s, T.dmul(_c, x.d()));
+        c = DifferentialPair<T>(_c, T.dmul(-_s, x.d()));
     }
 };
 

--- a/tests/autodiff/differential-method-synthesis.slang
+++ b/tests/autodiff/differential-method-synthesis.slang
@@ -17,7 +17,7 @@ struct A : IDifferentiable
     float y;
 };
 
-typedef __DifferentialPair<A> dpA;
+typedef DifferentialPair<A> dpA;
 
 A nonDiff(A a)
 {

--- a/tests/autodiff/dstdlib.slang
+++ b/tests/autodiff/dstdlib.slang
@@ -4,7 +4,7 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-typedef __DifferentialPair<float> dpfloat;
+typedef DifferentialPair<float> dpfloat;
 
 [ForwardDifferentiable]
 float f(float x)

--- a/tests/autodiff/generic-custom-jvp.slang
+++ b/tests/autodiff/generic-custom-jvp.slang
@@ -6,7 +6,7 @@ RWStructuredBuffer<float> outputBuffer;
 typealias IDFloat = IFloat & IDifferentiable;
 
 __generic<T : IDFloat>
-typedef __DifferentialPair<T> dfloat;
+typedef DifferentialPair<T> dfloat;
 
 import test_intrinsics;
 

--- a/tests/autodiff/generic-impl-jvp.slang
+++ b/tests/autodiff/generic-impl-jvp.slang
@@ -8,8 +8,8 @@ typedef float Real;
 
 typealias IDFloat = IFloat & IDifferentiable;
 
-__generic<T, let N : int>
-struct dvector
+__generic<T : IDifferentiable, let N : int>
+struct dvector : IDifferentiable
 {
     T values[N];
 };
@@ -118,10 +118,10 @@ T dot(myvector<T, N> a, myvector<T, N> b)
 }
 
 __generic<T : IDFloat, let N : int>
-typedef __DifferentialPair<myvector<T, N>> dpvector;
+typedef DifferentialPair<myvector<T, N>> dpvector;
 
 __generic<T : IDFloat, let N : int>
-__DifferentialPair<T> dot_jvp(dpvector<T, N> a, dpvector<T, N> b)
+DifferentialPair<T> dot_jvp(dpvector<T, N> a, dpvector<T, N> b)
 {
     T.Differential curr_d = (T.dzero());
     T curr_p = (T)0.0;
@@ -135,11 +135,11 @@ __DifferentialPair<T> dot_jvp(dpvector<T, N> a, dpvector<T, N> b)
                         T.dmul(b.p().values[i], a.d().values[i])));
     }
 
-    return __DifferentialPair<T>(curr_p, curr_d);
+    return DifferentialPair<T>(curr_p, curr_d);
 }
 
 __generic<let N : int>
-struct lineardvector
+struct lineardvector : IDifferentiable
 {
     myvector<Real, N>.Differential val;
 
@@ -223,7 +223,7 @@ typedef linearvector<4> myfloat4;
 typedef lineardvector<3> mydfloat3;
 typedef lineardvector<4> mydfloat4;
 
-typedef __DifferentialPair<Real> dpfloat;
+typedef DifferentialPair<Real> dpfloat;
 
 interface MyLinearArithmeticType
 {
@@ -233,8 +233,8 @@ interface MyLinearArithmeticType
     static Real ldot(This a, This b);
 };
 
-typedef __DifferentialPair<myfloat4> dpfloat4;
-typedef __DifferentialPair<myfloat3> dpfloat3;
+typedef DifferentialPair<myfloat4> dpfloat4;
+typedef DifferentialPair<myfloat3> dpfloat3;
 
 extension float : MyLinearArithmeticType
 {

--- a/tests/autodiff/generic-jvp.slang
+++ b/tests/autodiff/generic-jvp.slang
@@ -39,7 +39,7 @@ extension myvector<3> : MyLinearArithmeticType
     }
 
     [ForwardDifferentiable]
-__init(vector<Real, 3> a)
+    __init(vector<Real, 3> a)
     {
         val = a;
     }
@@ -83,7 +83,7 @@ extension myvector<4> : MyLinearArithmeticType
 typedef myvector<3> myfloat3;
 typedef myvector<4> myfloat4;
 
-typedef __DifferentialPair<Real> dpfloat;
+typedef DifferentialPair<Real> dpfloat;
 
 interface MyLinearArithmeticType
 {
@@ -144,8 +144,8 @@ extension myfloat4 : IDifferentiable
     }
 };
 
-typedef __DifferentialPair<myfloat4> dpfloat4;
-typedef __DifferentialPair<myfloat3> dpfloat3;
+typedef DifferentialPair<myfloat4> dpfloat4;
+typedef DifferentialPair<myfloat3> dpfloat3;
 
 extension float : MyLinearArithmeticType
 {

--- a/tests/autodiff/getter-setter-multi.slang
+++ b/tests/autodiff/getter-setter-multi.slang
@@ -4,7 +4,7 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-struct B
+struct B : IDifferentiable
 {
     float3 z;
     float.Differential k[10];
@@ -41,7 +41,7 @@ struct A : IDifferentiable
     }
 };
 
-typedef __DifferentialPair<A> dpA;
+typedef DifferentialPair<A> dpA;
 
 [ForwardDifferentiable]
 A f(A a)

--- a/tests/autodiff/getter-setter.slang
+++ b/tests/autodiff/getter-setter.slang
@@ -4,7 +4,7 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-struct B
+struct B : IDifferentiable
 {
     float z;
 };
@@ -39,7 +39,7 @@ struct A : IDifferentiable
     }
 };
 
-typedef __DifferentialPair<A> dpA;
+typedef DifferentialPair<A> dpA;
 
 [ForwardDifferentiable]
 A f(A a)

--- a/tests/autodiff/high-order-forward-diff.slang
+++ b/tests/autodiff/high-order-forward-diff.slang
@@ -1,0 +1,23 @@
+//DTEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj -output-using-type
+//DTEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+[ForwardDifferentiable]
+float f(float x)
+{
+    return x * x;
+}
+
+[ForwardDifferentiable]
+float df(float x)
+{
+    return __fwd_diff(f)(DifferentialPair<float>(x, 1.0)).d();
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    outputBuffer[0] = __fwd_diff(df)(DifferentialPair<float>(1.0, 1.0)).d(); // Expect: 2.0
+}

--- a/tests/autodiff/imported-custom-jvp.slang
+++ b/tests/autodiff/imported-custom-jvp.slang
@@ -5,7 +5,7 @@ RWStructuredBuffer<float> outputBuffer;
 
 import test_intrinsics_jvp;
 
-typedef __DifferentialPair<float> dpfloat;
+typedef DifferentialPair<float> dpfloat;
 typedef float.Differential dfloat;
 
 [ForwardDifferentiable]

--- a/tests/autodiff/inout-parameters-jvp.slang
+++ b/tests/autodiff/inout-parameters-jvp.slang
@@ -4,7 +4,7 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-typedef __DifferentialPair<float> dpfloat;
+typedef DifferentialPair<float> dpfloat;
 
 [ForwardDifferentiable]
 void g(float x, float y, inout float z)

--- a/tests/autodiff/local-redecl-custom-jvp.slang
+++ b/tests/autodiff/local-redecl-custom-jvp.slang
@@ -3,7 +3,7 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-typedef __DifferentialPair<float> dpfloat;
+typedef DifferentialPair<float> dpfloat;
 typedef float.Differential dfloat;
 
 import test_intrinsics;

--- a/tests/autodiff/nested-jvp.slang
+++ b/tests/autodiff/nested-jvp.slang
@@ -4,8 +4,8 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-typedef __DifferentialPair<float> dpfloat;
-typedef __DifferentialPair<float3> dpfloat3;
+typedef DifferentialPair<float> dpfloat;
+typedef DifferentialPair<float3> dpfloat3;
 
 [ForwardDerivative(pow_jvp)]
 float pow_(float x, float n)

--- a/tests/autodiff/out-parameters-jvp.slang
+++ b/tests/autodiff/out-parameters-jvp.slang
@@ -4,7 +4,7 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-typedef __DifferentialPair<float> dpfloat;
+typedef DifferentialPair<float> dpfloat;
 
 [ForwardDifferentiable]
 void h(float x, float y, out float result)

--- a/tests/autodiff/overloads-jvp.slang
+++ b/tests/autodiff/overloads-jvp.slang
@@ -4,8 +4,8 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-typedef __DifferentialPair<float> dpfloat;
-typedef __DifferentialPair<float3> dpfloat3;
+typedef DifferentialPair<float> dpfloat;
+typedef DifferentialPair<float3> dpfloat3;
 
 [ForwardDifferentiable]
 float f(float a)

--- a/tests/autodiff/vector-arithmetic-jvp.slang
+++ b/tests/autodiff/vector-arithmetic-jvp.slang
@@ -4,9 +4,9 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-typedef __DifferentialPair<float2> dpfloat2;
-typedef __DifferentialPair<float3> dpfloat3;
-typedef __DifferentialPair<float4> dpfloat4;
+typedef DifferentialPair<float2> dpfloat2;
+typedef DifferentialPair<float3> dpfloat3;
+typedef DifferentialPair<float4> dpfloat4;
 
 [ForwardDifferentiable]
 float3 f(float3 x)

--- a/tests/autodiff/vector-swizzle-jvp.slang
+++ b/tests/autodiff/vector-swizzle-jvp.slang
@@ -4,9 +4,9 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-typedef __DifferentialPair<float2> dpfloat2;
-typedef __DifferentialPair<float3> dpfloat3;
-typedef __DifferentialPair<float4> dpfloat4;
+typedef DifferentialPair<float2> dpfloat2;
+typedef DifferentialPair<float3> dpfloat3;
+typedef DifferentialPair<float4> dpfloat4;
 
 [ForwardDifferentiable]
 float2 f(float3 x)

--- a/tests/language-server/high-order-expr.slang
+++ b/tests/language-server/high-order-expr.slang
@@ -17,5 +17,5 @@ float df(float x)
 [numthreads(1, 1, 1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
-    outputBuffer[0] = __fwd_diff(df)(__DifferentialPair<float>(x, 1.0)).d(); // Expect: 2.0
+    outputBuffer[0] = __fwd_diff(df)(DifferentialPair<float>(x, 1.0)).d(); // Expect: 2.0
 }

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -510,10 +510,6 @@ SlangResult RenderTestApp::initialize(
     //
     ComPtr<ISlangBlob> outDiagnostics;
     auto result = device->createProgram(m_compilationOutput.output.desc, m_shaderProgram.writeRef(), outDiagnostics.writeRef());
-    if (outDiagnostics)
-    {
-        printf("Slang compilation diagnostic:\n%s\n", (const char*)outDiagnostics->getBufferPointer());
-    }
     SLANG_RETURN_ON_FAIL(result);
 
 	m_device = device;

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -512,7 +512,7 @@ SlangResult RenderTestApp::initialize(
     auto result = device->createProgram(m_compilationOutput.output.desc, m_shaderProgram.writeRef(), outDiagnostics.writeRef());
     if (outDiagnostics)
     {
-        printf("Slang compilation error:\n%s\n", (const char*)outDiagnostics->getBufferPointer());
+        printf("Slang compilation diagnostic:\n%s\n", (const char*)outDiagnostics->getBufferPointer());
     }
     SLANG_RETURN_ON_FAIL(result);
 

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -508,8 +508,13 @@ SlangResult RenderTestApp::initialize(
 
     // Once the shaders have been compiled we load them via the underlying API.
     //
-    SLANG_RETURN_ON_FAIL(
-        device->createProgram(m_compilationOutput.output.desc, m_shaderProgram.writeRef()));
+    ComPtr<ISlangBlob> outDiagnostics;
+    auto result = device->createProgram(m_compilationOutput.output.desc, m_shaderProgram.writeRef(), outDiagnostics.writeRef());
+    if (outDiagnostics)
+    {
+        printf("Slang compilation error:\n%s\n", (const char*)outDiagnostics->getBufferPointer());
+    }
+    SLANG_RETURN_ON_FAIL(result);
 
 	m_device = device;
 


### PR DESCRIPTION
This change makes the `DifferentialPair` type nest-able, so we can form `DifferentialPair<DifferentialPair<T>>` types.
This is a prerequisite to support nested/higher-order differentiation.

The challenge here is to define the `DifferentialPair` type so that the Differential of Differential should always evaluates to `DifferentialBottom`, which is a builtin type for representing non-existent/not-well-defined differential. This means that we need to make `DifferentialPair<DifferentialPair<T>>` to effectively form a tripple `(p.p.p, p.p.d p.d.p)`, leaving out the `p.d.d` term that has no mathematical meaning.

To allow such definition, this work starts by modifying the existing `DifferentialPair<T:IDifferentiable>` .
The new definition of `DifferentialPair` type is as follows:
```
__generic<T : IDifferentiable>
__magic_type(DifferentialPairType)
__intrinsic_type($(kIROp_DifferentialPairType))
struct DifferentialPair : IDifferentiable
{
    typedef DifferentialPair<T.Differential> Differential;
    typedef T.Differential DifferentialElementType;

    __intrinsic_op($(kIROp_MakeDifferentialPair))
    __init(T _primal, T.Differential _differential);

    __intrinsic_op($(kIROp_DifferentialPairGetDifferential))
    T.Differential d();

    T.Differential getDifferential()
    {
        return d();
    }

    __intrinsic_op($(kIROp_DifferentialPairGetPrimal))
    T p();

    T getPrimal()
    {
        return p();
    }

    [__unsafeForceInlineEarly]
    static Differential dzero()
    {
        return Differential(T.dzero(), Differential.DifferentialElementType.dzero());
    }

    [__unsafeForceInlineEarly]
    static Differential dadd(Differential a, Differential b)
    {
        return Differential(
            T.dadd(
                a.p(),
                b.p()
            ),
            Differential.DifferentialElementType.dzero());
    }

    [__unsafeForceInlineEarly]
    static Differential dmul(This a, Differential b)
    {
        return Differential(
             T.dmul(a.p(), b.p()),
            Differential.DifferentialElementType.dzero());
    }
};
```

There is one tricky bit when defining `DifferentialPair` this way. Notice the definition of `Differential`:
```
 typedef DifferentialPair<T.Differential> Differential;
```

This line has a type mismatch issue because `T.Differential` is unconstrained and using it to fill in type parameter that requires `IDifferential` conformance is not valid.

To solve this issue, we introduce a new sub-typing rule that if a generic type `T` is unconstraint, we treat it as a subtype of `DifferentialBottom`. This rule allowed us to form the `Differential` type for `DifferentialPair`, and that the `Differential.Differential` will resolve to `DifferentialPair<T.Differential, DifferentialBottom>`, which is exactly what we want.

The rest of this PR is all about dealing with the consequences of changing the stdlib definition of `DifferentialPair`.

Most of the work done here is to get `generic-impl-jvp` test to pass. First, we need to modify `dvector` type to conform to `IDifferentiable`  since it is used as `Differential` type for `myvector`. We will just rely on automatic synthesis to implement the conformances. However, `dvector` is a generic type, so the first part of the work is to extend our synthesis logic to work with generic parent types. The next obstacle is that `values` field is an array, and we need our synthesis logic to be smart enough to synthesize a loop to compute each element of the array. This required us to synthesize significantly more complex code, so I've added the `ASTSynthesizer` class to simplify the synthesis code.

Another major challenge addressed in this PR is to register type conformances only within a differentiable function at each expression site instead of doing it globally at `coerce`. This allows us to avoid running the differentiation logic for programs that don't need it.