### PR TITLE
Rework differential conformance dictionary checking.

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2737,9 +2737,6 @@ __attributeTarget(InterfaceDecl)
 attribute_syntax [Specialize] : SpecializeAttribute;
 
 __attributeTarget(DeclBase)
-attribute_syntax [Differentiable] : DifferentiableAttribute;
-
-__attributeTarget(DeclBase)
 attribute_syntax [DerivativeMember(memberName)] : DerivativeMemberAttribute;
 
 enum _BuiltinRequirementKind

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -511,36 +511,6 @@ class AttributeDecl : public ContainerDecl
     SyntaxClass<NodeBase> syntaxClass;
 };
 
-// A declaration to hold differentiable type conformances generated during
-// the semantic checking phase.
-// 
-class DifferentiableTypeDictionary : public ContainerDecl
-{
-    SLANG_AST_CLASS(DifferentiableTypeDictionary);
-};
-
-// A declaration to hold differentiable type conformances generated during
-// the semantic checking phase.
-// 
-class DifferentiableTypeDictionaryItem : public Decl
-{
-    SLANG_AST_CLASS(DifferentiableTypeDictionaryItem);
-
-    DeclRefType* baseType;
-    SubtypeWitness* confWitness;
-};
-
-// A declaration that references another dictionary (generally from another module)
-// Used to tell the IR lowering pass to process the referenced dictionary.
-// 
-class DifferentiableTypeDictionaryImportItem : public Decl
-{
-    SLANG_AST_CLASS(DifferentiableTypeDictionaryImportItem);
-
-    DeclRef<DifferentiableTypeDictionary> dictionaryRef;
-};
-
-
 bool isInterfaceRequirement(Decl* decl);
 
 } // namespace Slang

--- a/source/slang/slang-ast-dump.cpp
+++ b/source/slang/slang-ast-dump.cpp
@@ -408,6 +408,35 @@ struct ASTDumpContext
         m_writer->emit("}");
     }
 
+    template <typename KEY, typename VALUE>
+    void dump(const OrderedDictionary<KEY, VALUE>& dict)
+    {
+        m_writer->emit(" { \n");
+        m_writer->indent();
+
+        for (auto iter : dict)
+        {
+            const auto& key = iter.Key;
+            const auto& value = iter.Value;
+
+            dump(key);
+            m_writer->emit(" : ");
+            dump(value);
+
+            m_writer->emit("\n");
+        }
+
+        m_writer->dedent();
+        m_writer->emit("}");
+    }
+
+    void dump(DeclRefBase declRef)
+    {
+        StringBuilder sb;
+        sb << declRef;
+        m_writer->emit(sb.ToString());
+    }
+
     void dump(const DeclCheckStateExt& extState)
     {
         auto state = extState.getState();

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -977,6 +977,9 @@ class SpecializeAttribute : public Attribute
 class DifferentiableAttribute : public Attribute
 {
     SLANG_AST_CLASS(DifferentiableAttribute)
+
+    /// Mapping from types to subtype witnesses for conformance to IDifferentiable.
+    OrderedDictionary<DeclRefBase, SubtypeWitness*>   m_mapTypeToIDifferentiableWitness;
 };
 
 class DllImportAttribute : public Attribute

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -1510,7 +1510,6 @@ namespace Slang
         DAddFunc, ///< The `IDifferentiable.dadd` function requirement 
         DMulFunc, ///< The `IDifferentiable.dmul` function requirement 
     };
-
 } // namespace Slang
 
 #endif

--- a/source/slang/slang-check-type.cpp
+++ b/source/slang/slang-check-type.cpp
@@ -320,19 +320,6 @@ namespace Slang
                 getSink()->diagnose(typeExp.exp, Diagnostics::cannotDefinePtrTypeToManagedResource);
             }
         }
-        
-        // Differentiable type checking.
-        // TODO: This can be super slow. Switch to caching the result asap.
-        if (this->m_parentFunc && 
-            this->m_parentFunc->findModifier<ForwardDifferentiableAttribute>())
-        {
-            auto diffTypeContext = this->getShared()->innermostDiffTypeContext();
-            if (auto subtypeWitness = as<SubtypeWitness>(
-                tryGetInterfaceConformanceWitness(result, getASTBuilder()->getDifferentiableInterface())))
-            {
-                diffTypeContext->registerDifferentiableType((DeclRefType*)result, subtypeWitness);
-            }
-        }
 
         *outProperType = result;
         return true;

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -7,6 +7,7 @@
 #include "slang-mangled-lexer.h"
 
 #include "slang-ir-clone.h"
+#include "slang-ir-util.h"
 
 #include "../compiler-core/slang-artifact-desc-util.h"
 
@@ -80,39 +81,6 @@ static UnownedStringSlice _getTypePrefix(IROp op)
     }
 }
 
-static IROp _getTypeStyle(IROp op)
-{
-    switch (op)
-    {
-        case kIROp_VoidType:    
-        case kIROp_BoolType:
-        {
-            return op;
-        }
-        case kIROp_Int8Type:
-        case kIROp_Int16Type:
-        case kIROp_IntType:
-        case kIROp_UInt8Type:
-        case kIROp_UInt16Type:
-        case kIROp_UIntType:
-        case kIROp_Int64Type:
-        case kIROp_UInt64Type:
-        case kIROp_IntPtrType:
-        case kIROp_UIntPtrType:
-        {
-            // All int like 
-            return kIROp_IntType;
-        }
-        case kIROp_HalfType:
-        case kIROp_FloatType:
-        case kIROp_DoubleType:
-        {
-            // All float like
-            return kIROp_FloatType;
-        }
-        default: return kIROp_Invalid;
-    }
-}
 
 static IROp _getCType(IROp op)
 {
@@ -912,7 +880,7 @@ void CPPSourceEmitter::_emitAnyAllDefinition(const UnownedStringSlice& funcName,
     IRType* retType = specOp->returnType;
     auto retTypeName = _getTypeName(retType);
 
-    IROp style = _getTypeStyle(elementType->getOp());
+    IROp style = getTypeStyle(elementType->getOp());
 
     const TypeDimension dim = _getTypeDimension(paramType0, false);
 

--- a/source/slang/slang-ir-dce.cpp
+++ b/source/slang/slang-ir-dce.cpp
@@ -361,13 +361,6 @@ bool shouldInstBeLiveIfParentIsLive(IRInst* inst, IRDeadCodeEliminationOptions o
     case kIROp_WitnessTableEntry:
         return true;
 
-        // Special dictionaries used for differentiable type tracking 
-        // should be kept alive. These are removed by the auto-diff pass,
-        // once they are used.
-    case kIROp_DifferentiableTypeDictionaryItem:
-    case kIROp_DifferentiableTypeDictionary:
-        return true;
-
     default:
         break;
     }

--- a/source/slang/slang-ir-diff-jvp.cpp
+++ b/source/slang/slang-ir-diff-jvp.cpp
@@ -6,6 +6,7 @@
 #include "slang-ir-clone.h"
 #include "slang-ir-dce.h"
 #include "slang-ir-eliminate-phis.h"
+#include "slang-ir-util.h"
 
 // origX, primalX, diffX
 // origX -> primalX (cloneEnv)
@@ -26,11 +27,9 @@ struct Pair
 
 typedef Pair<IRInst*, IRInst*> InstPair;
 
-struct DifferentiableTypeConformanceContext
+struct AutoDiffSharedContext
 {
-    Dictionary<IRInst*, IRInst*>            witnessTableMap;
-
-    IRInst*                                 inst = nullptr;
+    IRModuleInst*                          moduleInst = nullptr;
 
     // A reference to the builtin IDifferentiable interface type.
     // We use this to look up all the other types (and type exprs)
@@ -62,114 +61,27 @@ struct DifferentiableTypeConformanceContext
     // 
     bool                                    isInterfaceAvailable = false;
 
-    // For handling generic blocks, we use a parent pointer to allow
-    // looking up types in all relevant scopes.
-    DifferentiableTypeConformanceContext*   parent = nullptr;
 
-    DifferentiableTypeConformanceContext(DifferentiableTypeConformanceContext* parent, IRInst* inst) : parent(parent), inst(inst)
+    AutoDiffSharedContext(IRModuleInst* inModuleInst)
+        : moduleInst(inModuleInst)
     {
-        if (parent)
+        differentiableInterfaceType = as<IRInterfaceType>(findDifferentiableInterface());
+        if (differentiableInterfaceType)
         {
-            differentiableInterfaceType = parent->differentiableInterfaceType;
-            differentialAssocTypeStructKey = parent->differentialAssocTypeStructKey;
-            zeroMethodStructKey = parent->zeroMethodStructKey;
-            addMethodStructKey = parent->addMethodStructKey;
+            differentialAssocTypeStructKey = findDifferentialTypeStructKey();
+            zeroMethodStructKey = findZeroMethodStructKey();
+            addMethodStructKey = findAddMethodStructKey();
 
-            isInterfaceAvailable = parent->isInterfaceAvailable;
+            if (differentialAssocTypeStructKey)
+                isInterfaceAvailable = true;
         }
-        else
-        {
-            differentiableInterfaceType = as<IRInterfaceType>(findDifferentiableInterface());
-            if (differentiableInterfaceType)
-            {
-                differentialAssocTypeStructKey = findDifferentialTypeStructKey();
-                zeroMethodStructKey = findZeroMethodStructKey();
-                addMethodStructKey = findAddMethodStructKey();
-
-                if (differentialAssocTypeStructKey)
-                    isInterfaceAvailable = true;
-            }
-        }
-    }
-
-    DifferentiableTypeConformanceContext(IRInst* inst) :
-        DifferentiableTypeConformanceContext(nullptr, inst)
-    {}
-
-    // Lookup a witness table for the concreteType. One should exist if concreteType
-    // inherits (successfully) from IDifferentiable.
-    // 
-    IRInst* lookUpConformanceForType(IRBuilder* builder, IRInst* type)
-    {
-        SLANG_ASSERT(isInterfaceAvailable);
-        // TODO: Cache the returned value to avoid repeatedly scanning through
-        // blocks looking for the type entries.
-        // 
-        if (auto irWitness = builder->findDifferentiableTypeEntry(type, type->getParent()))
-        {
-            return irWitness;
-        }
-
-        return nullptr;
-    }
-
-    IRInst* lookUpInterfaceMethod(IRBuilder* builder, IRType* origType, IRStructKey* key)
-    {
-        if (auto conformance = lookUpConformanceForType(builder, origType))
-        {
-            if (auto witnessTable = as<IRWitnessTable>(conformance))
-            {
-                for (auto entry : witnessTable->getEntries())
-                {
-                    if (entry->getRequirementKey() == key)
-                        return entry->getSatisfyingVal();
-                }
-            }
-            else if (auto witnessTableParam = as<IRParam>(conformance))
-            {
-                return builder->emitLookupInterfaceMethodInst(
-                    builder->getTypeKind(),
-                    witnessTableParam,
-                    key);
-            }
-        }
-
-        return nullptr;
-    }
-    
-    // Lookup and return the 'Differential' type declared in the concrete type
-    // in order to conform to the IDifferentiable interface.
-    // Note that inside a generic block, this will be a witness table lookup instruction
-    // that gets resolved during the specialization pass.
-    // 
-    IRInst* getDifferentialForType(IRBuilder* builder, IRType* origType)
-    {
-        switch (origType->getOp())
-        {
-        case kIROp_FloatType:
-        case kIROp_HalfType:
-        case kIROp_DoubleType:
-        case kIROp_VectorType:
-            return origType;
-        }
-        return lookUpInterfaceMethod(builder, origType, differentialAssocTypeStructKey);
-    }
-
-    IRInst* getZeroMethodForType(IRBuilder* builder, IRType* origType)
-    {
-        return lookUpInterfaceMethod(builder, origType, zeroMethodStructKey);
-    }
-
-    IRInst* getAddMethodForType(IRBuilder* builder, IRType* origType)
-    {
-        return lookUpInterfaceMethod(builder, origType, addMethodStructKey);
     }
 
     private:
 
     IRInst* findDifferentiableInterface()
     {
-        if (auto module = as<IRModuleInst>(inst))
+        if (auto module = as<IRModuleInst>(moduleInst))
         {
             for (auto globalInst : module->getGlobalInsts())
             {
@@ -203,7 +115,7 @@ struct DifferentiableTypeConformanceContext
 
     IRStructKey* getIDifferentiableStructKeyAtIndex(UInt index)
     {
-        if (as<IRModuleInst>(inst) && differentiableInterfaceType)
+        if (as<IRModuleInst>(moduleInst) && differentiableInterfaceType)
         {
             // Assume for now that IDifferentiable has exactly four fields.
             SLANG_ASSERT(differentiableInterfaceType->getOperandCount() == 4);
@@ -217,110 +129,126 @@ struct DifferentiableTypeConformanceContext
 
         return nullptr;
     }
+};
 
-    void loadWitnessTablesForInterface(IRInst* interfaceType)
+namespace
+{
+
+IRInst* _lookupWitness(IRBuilder* builder, IRInst* witness, IRInst* requirementKey)
+{
+    if (auto witnessTable = as<IRWitnessTable>(witness))
     {
-        
-        if (auto module = as<IRModuleInst>(inst))
+        for (auto entry : witnessTable->getEntries())
         {
-            for (auto globalInst : module->getGlobalInsts())
+            if (entry->getRequirementKey() == requirementKey)
+                return entry->getSatisfyingVal();
+        }
+    }
+    else if (auto witnessTableParam = as<IRParam>(witness))
+    {
+        return builder->emitLookupInterfaceMethodInst(
+            builder->getTypeKind(),
+            witnessTableParam,
+            requirementKey);
+    }
+    return nullptr;
+}
+
+}
+
+struct DifferentiableTypeConformanceContext
+{
+    AutoDiffSharedContext* sharedContext;
+
+    IRGlobalValueWithCode* parentFunc = nullptr;
+    Dictionary<IRType*, IRInst*> differentiableWitnessDictionary;
+
+    DifferentiableTypeConformanceContext(AutoDiffSharedContext* shared)
+        : sharedContext(shared)
+    {}
+
+    void setFunc(IRGlobalValueWithCode* func)
+    {
+        parentFunc = func;
+
+        auto decor = func->findDecoration<IRDifferentiableTypeDictionaryDecoration>();
+        SLANG_RELEASE_ASSERT(decor);
+
+        // Build lookup dictionary for type witnesses.
+        for (auto child = decor->getFirstChild(); child; child = child->next)
+        {
+            if (auto item = as<IRDifferentiableTypeDictionaryItem>(child))
             {
-                if (globalInst->getOp() == kIROp_WitnessTable &&
-                    cast<IRWitnessTableType>(globalInst->getDataType())->getConformanceType() ==
-                        interfaceType)
+                auto existingItem = differentiableWitnessDictionary.TryGetValue(item->getConcreteType());
+                if (existingItem)
                 {
-                    // TODO: Can we have multiple conformances for the same pair of types?
-                    // TODO: Can type instrs be duplicated (i.e. two different float types)? And if they are duplicated, can
-                    // we supply the dictionary with a custom equality rule that uses 'type1->equals(type2)'
-                    witnessTableMap.Add(as<IRWitnessTable>(globalInst)->getConcreteType(), globalInst);
+                    if (auto witness = as<IRWitnessTable>(item->getWitness()))
+                    {
+                        if (witness->getConcreteType()->getOp() == kIROp_DifferentialBottomType)
+                            continue;
+                    }
+                    *existingItem = item->getWitness();
+                }
+                else
+                {
+                    differentiableWitnessDictionary.Add((IRType*)item->getConcreteType(), item->getWitness());
                 }
             }
         }
-        else if (auto generic = as<IRGeneric>(inst))
+    }
+
+
+    // Lookup a witness table for the concreteType. One should exist if concreteType
+    // inherits (successfully) from IDifferentiable.
+    // 
+    IRInst* lookUpConformanceForType(IRInst* type)
+    {
+        IRInst* foundResult = nullptr;
+        differentiableWitnessDictionary.TryGetValue(type, foundResult);
+        return foundResult;
+    }
+
+    IRInst* lookUpInterfaceMethod(IRBuilder* builder, IRType* origType, IRStructKey* key)
+    {
+        if (auto conformance = lookUpConformanceForType(origType))
         {
-            List<IRParam*> typeParams;
-
-            auto genericParam = generic->getFirstParam();
-            while (genericParam)
-            {
-                if (as<IRTypeType>(genericParam->getDataType()))
-                {
-                    typeParams.add(genericParam);
-                }
-                else
-                    break;
-                
-                genericParam = genericParam->getNextParam();
-            }
-            
-            Count tableIndex = 0;
-            while (genericParam)
-            {
-                SLANG_ASSERT(!as<IRTypeType>(genericParam->getDataType()));
-
-                if (tableIndex >= typeParams.getCount())
-                    break;
-
-                if (auto witnessTableType = as<IRWitnessTableType>(genericParam->getDataType()))
-                {
-                    // TODO(sai): Heavily flawed way to find the right witness table.
-                    // Rewrite this part
-                    if (witnessTableType->getConformanceType() == differentiableInterfaceType)
-                        witnessTableMap.Add(typeParams[tableIndex], genericParam);
-                }
-                else
-                    break;
-
-                tableIndex += 1;
-                genericParam = genericParam->getNextParam();
-            }
-            
+            return _lookupWitness(builder, conformance, key);
         }
+        return nullptr;
+    }
 
+    // Lookup and return the 'Differential' type declared in the concrete type
+    // in order to conform to the IDifferentiable interface.
+    // Note that inside a generic block, this will be a witness table lookup instruction
+    // that gets resolved during the specialization pass.
+    // 
+    IRInst* getDifferentialForType(IRBuilder* builder, IRType* origType)
+    {
+        switch (origType->getOp())
+        {
+        case kIROp_FloatType:
+        case kIROp_HalfType:
+        case kIROp_DoubleType:
+        case kIROp_VectorType:
+            return origType;
+        }
+        return lookUpInterfaceMethod(builder, origType, sharedContext->differentialAssocTypeStructKey);
+    }
+
+    IRInst* getZeroMethodForType(IRBuilder* builder, IRType* origType)
+    {
+        return lookUpInterfaceMethod(builder, origType, sharedContext->zeroMethodStructKey);
+    }
+
+    IRInst* getAddMethodForType(IRBuilder* builder, IRType* origType)
+    {
+        return lookUpInterfaceMethod(builder, origType, sharedContext->addMethodStructKey);
     }
 
 };
 
-
-IRInst* findGlobal(IRInst* inst)
-{
-    if (inst->getParent() != inst->getModule()->getModuleInst())
-    {
-        return findGlobal(inst->getParent());
-    }
-
-    return inst;
-}
-
-void moveGlobalToBeforeUses(IRBuilder*, IRInst* globalInst)
-{
-    HashSet<IRInst*> globalsOfUses;
-    for (auto use = globalInst->firstUse; use; use = use->nextUse)
-    {
-        globalsOfUses.Add(findGlobal(use->getUser()));
-    }
-
-    IRInst* earliestUse = nullptr;
-    for (auto cursor = globalInst; cursor; cursor = cursor->getPrevInst())
-    {   
-        if (globalsOfUses.Contains(cursor))
-        {
-            earliestUse = cursor;
-        }
-    }
-
-    if (earliestUse)
-    {
-        globalInst->insertBefore(earliestUse);
-    }
-}
-
 struct DifferentialPairTypeBuilder
 {
-    
-    DifferentialPairTypeBuilder(DifferentiableTypeConformanceContext* diffConformanceContext) :
-        diffConformanceContext(diffConformanceContext)
-    {}
 
     IRStructField* findField(IRInst* type, IRStructKey* key)
     {
@@ -454,14 +382,6 @@ struct DifferentialPairTypeBuilder
         return emitFieldAccessor(builder, baseInst, this->globalDiffKey);
     }
 
-    void relocateNewTypes(IRBuilder* builder)
-    {
-        for (auto typeInst : generatedTypeList)
-        {
-            moveGlobalToBeforeUses(builder, typeInst);
-        }
-    }
-
     IRStructKey* _getOrCreateDiffStructKey(IRBuilder* builder)
     {
         if (!this->globalDiffKey)
@@ -496,27 +416,23 @@ struct DifferentialPairTypeBuilder
         return this->globalPrimalKey;
     }
 
-    IRInst* _createDiffPairType(IRBuilder* builder, IRType* origBaseType)
+    IRInst* _createDiffPairType(IRBuilder* builder, IRType* origBaseType, IRType* diffType)
     {
-        if (auto diffBaseType = diffConformanceContext->getDifferentialForType(builder, origBaseType))
-        {
-            SLANG_ASSERT(!as<IRParam>(origBaseType));
+        SLANG_ASSERT(!as<IRParam>(origBaseType));
+        SLANG_ASSERT(diffType);
+        auto pairStructType = builder->createStructType();
+        builder->createStructField(pairStructType, _getOrCreatePrimalStructKey(builder), origBaseType);
+        builder->createStructField(pairStructType, _getOrCreateDiffStructKey(builder), (IRType*)diffType);
 
-            auto pairStructType = builder->createStructType();
-            builder->createStructField(pairStructType, _getOrCreatePrimalStructKey(builder), origBaseType);
-            builder->createStructField(pairStructType, _getOrCreateDiffStructKey(builder), (IRType*) diffBaseType);
-
-            return pairStructType;
-        }
-        return nullptr;
+        return pairStructType;
     }
 
-    IRInst* getOrCreateDiffPairType(IRBuilder* builder, IRType* origBaseType)
+    IRInst* getOrCreateDiffPairType(IRBuilder* builder, IRType* origBaseType, IRType* diffType)
     {
         if (pairTypeCache.ContainsKey(origBaseType))
             return pairTypeCache[origBaseType];
 
-        auto pairType = _createDiffPairType(builder, origBaseType);
+        auto pairType = _createDiffPairType(builder, origBaseType, diffType);
         pairTypeCache.Add(origBaseType, pairType);
 
         return pairType;
@@ -524,8 +440,6 @@ struct DifferentialPairTypeBuilder
 
     Dictionary<IRInst*, IRInst*> pairTypeCache;
 
-    DifferentiableTypeConformanceContext* diffConformanceContext;
-    
     IRStructKey* globalPrimalKey = nullptr;
 
     IRStructKey* globalDiffKey = nullptr;
@@ -553,10 +467,16 @@ struct JVPTranscriber
     DiagnosticSink*                         sink;
 
     // Type conformance information.
-    DifferentiableTypeConformanceContext*   diffConformanceContext;
+    AutoDiffSharedContext*                  autoDiffSharedContext;
 
     // Builder to help with creating and accessing the 'DifferentiablePair<T>' struct
     DifferentialPairTypeBuilder*            pairBuilder;
+
+    DifferentiableTypeConformanceContext    differentiableTypeConformanceContext;
+
+    JVPTranscriber(AutoDiffSharedContext* shared)
+        : differentiableTypeConformanceContext(shared)
+    {}
 
     DiagnosticSink* getSink()
     {
@@ -692,7 +612,7 @@ struct JVPTranscriber
         {
         case kIROp_Param:
             if (as<IRTypeType>(primalType->getDataType()))
-                return (IRType*)(diffConformanceContext->getDifferentialForType(
+                return (IRType*)(differentiableTypeConformanceContext.getDifferentialForType(
                     builder,
                     (IRType*)primalType));
             else if (as<IRWitnessTableType>(primalType->getDataType()))
@@ -737,7 +657,7 @@ struct JVPTranscriber
             }
 
         default:
-            return (IRType*)(diffConformanceContext->getDifferentialForType(builder, (IRType*)primalType));
+            return (IRType*)(differentiableTypeConformanceContext.getDifferentialForType(builder, (IRType*)primalType));
         }
     }
     
@@ -753,8 +673,10 @@ struct JVPTranscriber
             else 
                 return nullptr;
         }
-
-        return (IRType*)pairBuilder->getOrCreateDiffPairType(builder, primalType);
+        auto diffType = differentiateType(builder, primalType);
+        if (diffType)
+            return (IRType*)pairBuilder->getOrCreateDiffPairType(builder, primalType, diffType);
+        return nullptr;
     }
 
     InstPair transcribeParam(IRBuilder* builder, IRParam* origParam)
@@ -1325,7 +1247,7 @@ struct JVPTranscriber
         {
             // Since primalType has a corresponding differential type, we can lookup the 
             // definition for zero().
-            auto zeroMethod = this->diffConformanceContext->getZeroMethodForType(builder, primalType);
+            auto zeroMethod = differentiableTypeConformanceContext.getZeroMethodForType(builder, primalType);
             SLANG_ASSERT(zeroMethod);
 
             auto emptyArgList = List<IRInst*>();
@@ -1333,6 +1255,11 @@ struct JVPTranscriber
         }
         else
         {
+            if (isScalarIntegerType(primalType))
+            {
+                return builder->getIntValue(primalType, 0);
+            }
+
             getSink()->diagnose(primalType->sourceLoc,
                 Diagnostics::internalCompilerError,
                 "could not generate zero value for given type");
@@ -1358,17 +1285,6 @@ struct JVPTranscriber
         // First transcribe every parameter in the block.
         for (auto param = origBlock->getFirstParam(); param; param = param->getNextParam())
             this->transcribe(builder, param);
-
-        // Look for the differentiable type dictionary and clone it (and anything else we might need).
-        // TODO: This logic might have issues if there are additional instructions (say lookup_interface_requirement) 
-        // that are operands.
-        // TODO: This is currently cloning the global dictionary. Should only clone dictionaries in generic blocks.
-        if (auto origDict = builder->findDifferentiableTypeDictionary(origBlock))
-        {
-            auto clonedDict = cloneInst(&cloneEnv, builder, origDict);
-            mapPrimalInst(origDict, clonedDict);
-            mapDifferentialInst(origDict, clonedDict);
-        }
 
         // Then, run through every instruction and use the transcriber to generate the appropriate
         // derivative code.
@@ -1547,6 +1463,8 @@ struct JVPTranscriber
     {
         IRFunc* primalFunc = nullptr;
 
+        differentiableTypeConformanceContext.setFunc(origFunc);
+
         auto oldLoc = builder->getInsertLoc();
 
         // If this is a top-level function, there is no need to clone it
@@ -1602,6 +1520,16 @@ struct JVPTranscriber
     // Transcribe a generic definition
     InstPair transcribeGeneric(IRBuilder* builder, IRGeneric* origGeneric)
     {
+        auto innerVal = findInnerMostGenericReturnVal(origGeneric);
+        if (auto innerFunc = as<IRFunc>(innerVal))
+        {
+            differentiableTypeConformanceContext.setFunc(innerFunc);
+        }
+        else
+        {
+            return InstPair(origGeneric, nullptr);
+        }
+
         // For now, we assume there's only one generic layer. So this inst must be top level
         bool isTopLevel = (as<IRModuleInst>(origGeneric->getParent()) != nullptr);
         SLANG_RELEASE_ASSERT(isTopLevel);
@@ -1757,10 +1685,6 @@ struct JVPTranscriber
         case kIROp_ifElse:
             return transcribeIfElse(builder, as<IRIfElse>(origInst));
 
-        case kIROp_DifferentiableTypeDictionary:
-            // Ignore dictionary insts.
-            return InstPair(nullptr, nullptr);
-
         }
     
         // If none of the cases have been hit, check if the instruction is a
@@ -1885,11 +1809,8 @@ struct JVPDerivativeContext
         // IRDifferentialPairGetPrimal with 'primal' field access, and
         // IRMakeDifferentialPair with an IRMakeStruct.
         // 
-        modified |= processPairTypes(builder, module->getModuleInst(), (&diffConformanceContextStorage));
+        modified |= processPairTypes(builder, module->getModuleInst());
         
-        // Temporary fix: Move generated types, if any, to before their use locations.
-        (&pairBuilderStorage)->relocateNewTypes(builder);
-
         return modified;
     }
 
@@ -1981,7 +1902,7 @@ struct JVPDerivativeContext
         return true;
     }
 
-    IRInst* lowerPairType(IRBuilder* builder, IRType* type, DifferentiableTypeConformanceContext*)
+    IRInst* lowerPairType(IRBuilder* builder, IRType* type)
     {
         
         if (auto pairType = as<IRDifferentialPairType>(type))
@@ -1990,13 +1911,18 @@ struct JVPDerivativeContext
 
             if (!as<IRType>(pairType->getValueType()))
             {
-                // Do not handle non-concrete types.
                 return nullptr;
             }
-
+            auto witness = pairType->getWitness();
+            auto diffType = _lookupWitness(builder, witness, autoDiffSharedContextStorage.differentialAssocTypeStructKey);
+            if (!diffType)
+            {
+                return nullptr;
+            }
             auto diffPairStructType = (&pairBuilderStorage)->getOrCreateDiffPairType(
                 builder,
-                pairType->getValueType());
+                pairType->getValueType(),
+                (IRType*)(diffType));
 
             pairType->replaceUsesWith(diffPairStructType);
             pairType->removeAndDeallocate();
@@ -2017,12 +1943,12 @@ struct JVPDerivativeContext
         return nullptr;
     }
 
-    IRInst* lowerMakePair(IRBuilder* builder, IRInst* inst, DifferentiableTypeConformanceContext* diffContext)
+    IRInst* lowerMakePair(IRBuilder* builder, IRInst* inst)
     {
         
         if (auto makePairInst = as<IRMakeDifferentialPair>(inst))
         {
-            if (auto diffPairStructType = lowerPairType(builder, makePairInst->getDataType(), diffContext))
+            if (auto diffPairStructType = lowerPairType(builder, makePairInst->getDataType()))
             {
                 builder->setInsertBefore(makePairInst);
                 
@@ -2041,11 +1967,11 @@ struct JVPDerivativeContext
         return nullptr;
     }
 
-    IRInst* lowerPairAccess(IRBuilder* builder, IRInst* inst, DifferentiableTypeConformanceContext* diffContext)
+    IRInst* lowerPairAccess(IRBuilder* builder, IRInst* inst)
     {
         if (auto getDiffInst = as<IRDifferentialPairGetDifferential>(inst))
         {
-            if (lowerPairType(builder, getDiffInst->getBase()->getDataType(), diffContext))
+            if (lowerPairType(builder, getDiffInst->getBase()->getDataType()))
             {
                 builder->setInsertBefore(getDiffInst);
                 
@@ -2057,7 +1983,7 @@ struct JVPDerivativeContext
         }
         else if (auto getPrimalInst = as<IRDifferentialPairGetPrimal>(inst))
         {
-            if (lowerPairType(builder, getPrimalInst->getBase()->getDataType(), diffContext))
+            if (lowerPairType(builder, getPrimalInst->getBase()->getDataType()))
             {
                 builder->setInsertBefore(getPrimalInst);
 
@@ -2072,15 +1998,9 @@ struct JVPDerivativeContext
         return nullptr;
     }
 
-    bool processPairTypes(IRBuilder* builder, IRInst* instWithChildren, DifferentiableTypeConformanceContext* diffContext)
+    bool processPairTypes(IRBuilder* builder, IRInst* instWithChildren)
     {
         bool modified = false;
-
-        // Create a new sub-context to scan witness tables inside workItem 
-        // (mainly relevant if instWithChildren is a generic scope)
-        // 
-        auto subContext = DifferentiableTypeConformanceContext(diffContext, instWithChildren);
-        (&pairBuilderStorage)->diffConformanceContext = (&subContext);
 
         for (auto child = instWithChildren->getFirstChild(); child; )
         {
@@ -2092,53 +2012,21 @@ struct JVPDerivativeContext
             switch (child->getOp())
             {
                 case kIROp_DifferentialPairType:
-                    lowerPairType(builder, as<IRType>(child), &subContext);
+                    lowerPairType(builder, as<IRType>(child));
                     break;
                 
                 case kIROp_DifferentialPairGetDifferential:
                 case kIROp_DifferentialPairGetPrimal:
-                    lowerPairAccess(builder, child, &subContext);
+                    lowerPairAccess(builder, child);
                     break;
                 
                 case kIROp_MakeDifferentialPair:
-                    lowerMakePair(builder, child, &subContext);
+                    lowerMakePair(builder, child);
                     break;
                 
                 default:
                     if (child->getFirstChild())
-                        modified = processPairTypes(builder, child, (&subContext)) | modified;
-            }
-
-            child = nextChild;
-        }
-
-        // Reset the context back to the parent.
-        (&pairBuilderStorage)->diffConformanceContext = diffContext;
-
-        return modified;
-    }
-
-    bool stripDiffTypeInformation(IRInst* parent)
-    {
-        bool modified = false;
-
-        auto child = parent->getFirstChild();
-        while (child)
-        {
-            auto nextChild = child->getNextInst();
-            
-            switch (child->getOp())
-            {
-            case kIROp_DifferentiableTypeDictionary:
-                child->removeAndDeallocate();
-                child = nextChild;
-                modified = true;
-                continue;
-            }
-
-            if (child->getFirstChild() != nullptr)
-            {
-                modified |= stripDiffTypeInformation(child);
+                        modified = processPairTypes(builder, child) | modified;
             }
 
             child = nextChild;
@@ -2186,12 +2074,13 @@ struct JVPDerivativeContext
     }
 
     JVPDerivativeContext(IRModule* module, DiagnosticSink* sink) :
-        module(module), sink(sink),
-        diffConformanceContextStorage(module->getModuleInst()),
-        pairBuilderStorage(&diffConformanceContextStorage)
+        module(module),
+        sink(sink),
+        autoDiffSharedContextStorage(module->getModuleInst()),
+        transcriberStorage(&autoDiffSharedContextStorage)
     {
         transcriberStorage.sink = sink;
-        transcriberStorage.diffConformanceContext = &(diffConformanceContextStorage);
+        transcriberStorage.autoDiffSharedContext = &(autoDiffSharedContextStorage);
         transcriberStorage.pairBuilder = &(pairBuilderStorage);
     }
 
@@ -2221,7 +2110,7 @@ struct JVPDerivativeContext
 
     // Context to find and manage the witness tables for types 
     // implementing `IDifferentiable`
-    DifferentiableTypeConformanceContext diffConformanceContextStorage;
+    AutoDiffSharedContext           autoDiffSharedContextStorage;
 
     // Builder for dealing with differential pair types.
     DifferentialPairTypeBuilder     pairBuilderStorage;
@@ -2243,7 +2132,6 @@ bool processForwardDifferentiableFuncs(
 
     JVPDerivativeContext context(module, sink);
     bool changed = context.processModule();
-    changed |= context.stripDiffTypeInformation(module->getModuleInst());
     return changed;
 }
 
@@ -2258,6 +2146,7 @@ void stripAutoDiffDecorationsFromChildren(IRInst* parent)
             {
             case kIROp_ForwardDerivativeDecoration:
             case kIROp_DerivativeMemberDecoration:
+            case kIROp_DifferentiableTypeDictionaryDecoration:
                 decor->removeAndDeallocate();
                 break;
             default:

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -715,6 +715,9 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
         /// the witness table to be easily picked up by emit.
     INST(COMWitnessDecoration, COMWitnessDecoration, 1, 0)
 
+    /* Differentiable Type Dictionary */
+    INST(DifferentiableTypeDictionaryDecoration, DifferentiableTypeDictionaryDecoration, 0, PARENT)
+
         /// Marks a struct type as being used as a structured buffer block.
         /// Recognized by SPIRV-emit pass so we can emit a SPIRV `BufferBlock` decoration.
     INST(SPIRVBufferBlockDecoration, spvBufferBlock, 0, 0)
@@ -812,7 +815,6 @@ INST(ExistentialFuncSpecializationDictionary, ExistentialFuncSpecializationDicti
 INST(ExistentialTypeSpecializationDictionary, ExistentialTypeSpecializationDictionary, 0, PARENT)
 
 /* Differentiable Type Dictionary */
-INST(DifferentiableTypeDictionary, DifferentiableTypeDictionary, 0, PARENT)
 INST(DifferentiableTypeDictionaryItem, DifferentiableTypeDictionaryItem, 0, 0)
 
 #undef PARENT

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -598,6 +598,14 @@ struct IRForwardDifferentiate : IRInst
 struct IRDifferentiableTypeDictionaryItem : IRInst
 {
     IR_LEAF_ISA(DifferentiableTypeDictionaryItem)
+
+    IRInst* getConcreteType() { return getOperand(0); }
+    IRInst* getWitness() { return getOperand(1); }
+};
+
+struct IRDifferentiableTypeDictionaryDecoration : IRInst
+{
+    IR_LEAF_ISA(DifferentiableTypeDictionaryDecoration)
 };
 
 
@@ -2490,26 +2498,10 @@ public:
 
     IRInst* emitMakeDifferentialPair(IRType* type, IRInst* primal, IRInst* differential);
 
-    // Emit and return a dictionary instruction to the global or generic scope.
-    IRInst* emitDifferentiableTypeDictionary();
-
-    // Emit and return a dictionary instruction to the global or generic scope,
-    // if one is not already present.
-    // 
-    IRInst* findOrEmitDifferentiableTypeDictionary();
-
-    // Returns the IRDifferentiableTypeDictionary in the scope of inst.
-    IRInst* findDifferentiableTypeDictionary(IRInst* inst);
+    IRInst* addDifferentiableTypeDictionaryDecoration(IRInst* target);
 
     // Add a differentiable type entry to the appropriate dictionary.
-    IRInst* addDifferentiableTypeEntry(IRInst* irType, IRInst* conformanceWitness);
-    
-    // Lookup a differentiable type entry in the appropriate dictionary.
-    // This recursively looks up in upper contexts.
-    // 
-    IRInst* findDifferentiableTypeEntry(IRInst* irType);
-
-    IRInst* findDifferentiableTypeEntry(IRInst* irType, IRInst* scope);
+    IRInst* addDifferentiableTypeEntry(IRInst* dictDecoration, IRInst* irType, IRInst* conformanceWitness);
 
     IRInst* emitSpecializeInst(
         IRType*         type,

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -66,5 +66,38 @@ bool isComInterfaceType(IRType* type)
     return false;
 }
 
+IROp getTypeStyle(IROp op)
+{
+    switch (op)
+    {
+    case kIROp_VoidType:
+    case kIROp_BoolType:
+    {
+        return op;
+    }
+    case kIROp_Int8Type:
+    case kIROp_Int16Type:
+    case kIROp_IntType:
+    case kIROp_UInt8Type:
+    case kIROp_UInt16Type:
+    case kIROp_UIntType:
+    case kIROp_Int64Type:
+    case kIROp_UInt64Type:
+    case kIROp_IntPtrType:
+    case kIROp_UIntPtrType:
+    {
+        // All int like 
+        return kIROp_IntType;
+    }
+    case kIROp_HalfType:
+    case kIROp_FloatType:
+    case kIROp_DoubleType:
+    {
+        // All float like
+        return kIROp_FloatType;
+    }
+    default: return kIROp_Invalid;
+    }
+}
 
 }

--- a/source/slang/slang-ir-util.h
+++ b/source/slang/slang-ir-util.h
@@ -24,6 +24,14 @@ Dictionary<IRInst*, IRInst*> buildInterfaceRequirementDict(IRInterfaceType* inte
 
 bool isComInterfaceType(IRType* type);
 
+
+IROp getTypeStyle(IROp op);
+
+inline bool isScalarIntegerType(IRType* type)
+{
+    return getTypeStyle(type->getOp()) == kIROp_IntType;
+}
+
 }
 
 #endif

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3546,131 +3546,33 @@ namespace Slang
             value->insertAtEnd(parent);
         }
     }
-
     
-    IRInst* IRBuilder::emitDifferentiableTypeDictionary()
+    IRInst* IRBuilder::addDifferentiableTypeDictionaryDecoration(IRInst* target)
     {
-        auto inst = createInst<IRInst>(
-            this,
-            kIROp_DifferentiableTypeDictionary,
-            nullptr);
-
-        addGlobalValue(this, inst);
-        return inst;
+        return addDecoration(target, kIROp_DifferentiableTypeDictionaryDecoration);
     }
 
-    IRInst* IRBuilder::findOrEmitDifferentiableTypeDictionary()
-    {
-        auto currentLoc = this->getInsertLoc();
-        auto currentInst = currentLoc.getInst();
-        
-        if (auto diffTypeDictionary = findDifferentiableTypeDictionary(currentInst))
-            return diffTypeDictionary;
-
-        return emitDifferentiableTypeDictionary();
-    }
-
-    IRInst* IRBuilder::findDifferentiableTypeDictionary(IRInst* parent)
-    {
-        //auto parent = inst->getParent();
-        while (parent)
-        {
-            // Inserting into the top level of a module?
-            // That is fine, and we can stop searching.
-            if (as<IRModuleInst>(parent))
-                break;
-
-            // Inserting into a basic block inside of
-            // a generic? That is okay too.
-            if (auto block = as<IRBlock>(parent))
-            {
-                if (as<IRGeneric>(block->parent))
-                    break;
-            }
-
-            // Otherwise, move up the chain.
-            parent = parent->parent;
-        }
-
-        for (auto child = parent->getFirstChild(); child; child = child->getNextInst())
-        {
-            if (child->getOp() == kIROp_DifferentiableTypeDictionary)
-                return child;
-        }
-
-        return nullptr;
-    }
-
-    IRInst* IRBuilder::addDifferentiableTypeEntry(IRInst* irType, IRInst* conformanceWitness)
+    IRInst* IRBuilder::addDifferentiableTypeEntry(IRInst* dictDecoration, IRInst* irType, IRInst* conformanceWitness)
     {
         auto oldLoc = this->getInsertLoc();
 
         IRDifferentiableTypeDictionaryItem* item = nullptr;
 
-        if (auto diffTypeDictionary = findOrEmitDifferentiableTypeDictionary())
-        {
-            this->setInsertInto(diffTypeDictionary);
+        this->setInsertInto(dictDecoration);
 
-            IRInst* args[2] = {irType, conformanceWitness};
-            item = createInstWithTrailingArgs<IRDifferentiableTypeDictionaryItem>(
-                this,
-                kIROp_DifferentiableTypeDictionaryItem,
-                nullptr,
-                2,
-                args);
+        IRInst* args[2] = {irType, conformanceWitness};
+        item = createInstWithTrailingArgs<IRDifferentiableTypeDictionaryItem>(
+            this,
+            kIROp_DifferentiableTypeDictionaryItem,
+            nullptr,
+            2,
+            args);
                 
-            addInst(item);
-        }
+        addInst(item);
 
         this->setInsertLoc(oldLoc);
 
         return item;
-    }
-
-    IRInst* IRBuilder::findDifferentiableTypeEntry(IRInst* irType, IRInst* scope)
-    {
-        IRInst* foundResult = nullptr;
-        for (auto child = scope->getFirstChild(); child; child = child->getNextInst()) 
-        {
-            if (child->getOp() == kIROp_DifferentiableTypeDictionary)
-            {
-                for (auto entry = child->getFirstChild(); entry; entry = entry->getNextInst())
-                {
-                    IRInst* entryType = entry->getOperand(0);
-                    IRInst* entryConformanceWitness = entry->getOperand(1);
-
-                    if (irType == entryType)
-                    {
-                        foundResult = entryConformanceWitness;
-                        // If the found witness table is not a trivial one (i.e. DifferentialBottom:IDifferential),
-                        // return immediately. Otherwise, continue the search to see if we can find a better one.
-                        if (auto witness = as<IRWitnessTable>(foundResult))
-                        {
-                            if (witness->getConcreteType()->getOp() != kIROp_DifferentialBottomType)
-                                return foundResult;
-                        }
-                    }
-                }
-            }
-        }
-
-        return foundResult;
-    }
-
-    IRInst* IRBuilder::findDifferentiableTypeEntry(IRInst* irType)
-    {
-        auto instScope = this->getInsertLoc().getInst();
-
-        while (instScope)
-        {
-            if (auto witness = findDifferentiableTypeEntry(irType, instScope))
-            {
-                return witness;
-            }
-            instScope = instScope->getParent();
-        }
-
-        return nullptr;
     }
 
 

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1323,6 +1323,7 @@ SIMPLE_IR_TYPE(GenericKind, Kind)
 struct IRDifferentialPairType : IRType
 {
     IRType* getValueType() { return (IRType*)getOperand(0); }
+    IRInst* getWitness() { return (IRInst*)getOperand(1); }
 
     IR_LEAF_ISA(DifferentialPairType)
 };

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -7143,7 +7143,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         {
             lowerDerivativeMemberModifier(irFieldKey, derivativeMemberModifier);
         }
-        
+
         // We allow a field to be marked as a target intrinsic,
         // so that we can override its mangled name in the
         // output for the chosen target.
@@ -7151,10 +7151,6 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         return LoweredValInfo::simple(irFieldKey);
     }
-
-
-
-
 
     bool isImportedDecl(Decl* decl)
     {
@@ -7174,6 +7170,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         GenericTypeConstraintDecl*  constraintDecl,
         IRType*                     supType)
     {
+
         auto subBuilder = subContext->irBuilder;
 
         // There are two cases we care about here.

--- a/source/slang/slang-serialize-ast-type-info.h
+++ b/source/slang/slang-serialize-ast-type-info.h
@@ -83,6 +83,9 @@ struct SerialGetFieldType<DeclRef<T>>
 template <typename T>
 struct SerialTypeInfo<DeclRef<T>> : public SerialDeclRefBaseTypeInfo {};
 
+template<>
+struct SerialTypeInfo<DeclRefBase> : public SerialDeclRefBaseTypeInfo {};
+
 // MatrixCoord can just go as is
 template <>
 struct SerialTypeInfo<MatrixCoord> : SerialIdentityTypeInfo<MatrixCoord> {};


### PR DESCRIPTION
This PR redesigns the checking logic around differential type conformances.

Previously, AST checking forms a `DifferentialTypeConformanceDictionary` node for each level of generic decl, including the top-level `Module`, and places differentiable types inside this dictionary node, which later lowers into an `IRDifferentiableTypeConformanceDictionary` inst so the auto diff pass can pick it up and lookup the differential type of a primal type.

Note that functions that are differentiable has either a `[ForwardDifferentiable]` or a `[ForwardDerivative]` attribute. We make them both subtypes of `DifferentialAttribute`. A `DifferentialAttribute` AST node provides us a natural place to hold differential witnesses needed by the differentiable function. When we check the body of an differential function, we just add all differential type witnesses to the `DifferentialAttribute` node associated with the function.

Then when we get to lower the function to IR, the `DifferentialAttribute` will become an `IRDifferentialTypeConformanceDictionaryDecoration` that is attached to the resulting IR function. The auto diff pass can then grab the dictionary from this decoration and it will contain all type info required by the auto diff pass.

This design avoids global dictionaries, and we no longer need to deal with importing modules or recursively looking up for conformance info in parent nodes.

This also speeds up our type checking by not running differential conformance check at every `coerce`, and only do the checks for exprs inside a differentiable function.