### PR TITLE
Add AdapterLUID to identify GPU adapters

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -2071,11 +2071,36 @@ public:
           0x8eccc8ec, 0x5c04, 0x4a51, { 0x99, 0x75, 0x13, 0xf8, 0xfe, 0xa1, 0x59, 0xf3 } \
     }
 
+struct AdapterLUID
+{
+    uint8_t luid[16];
+
+    bool operator==(const AdapterLUID& other) const
+    {
+        for (int i = 0; i < sizeof(AdapterLUID::luid); ++i)
+            if (luid[i] != other.luid[i])
+                return false;
+        return true;
+    }
+    bool operator!=(const AdapterLUID& other) const
+    {
+        return !this->operator==(other);
+    }
+};
+
 struct AdapterInfo
 {
+    // Descriptive name of the adapter.
     char name[128];
+
+    // Unique identifier for the vendor (only available for D3D and Vulkan).
     uint32_t vendorID;
+
+    // Unique identifier for the physical device among devices from the vendor (only available for D3D and Vulkan)
     uint32_t deviceID;
+
+    // Logically unique identifier of the adapter.
+    AdapterLUID luid;
 };
 
 class AdapterList
@@ -2182,8 +2207,8 @@ public:
         // for the ID3D12Device. For Vulkan, the first InteropHandle is the VkInstance, the second is the VkPhysicalDevice,
         // and the third is the VkDevice. For CUDA, this only contains a single value for the CUDADevice.
         InteropHandles existingDeviceHandles;
-        // Name to identify the adapter to use
-        const char* adapter = nullptr;
+        // LUID of the adapter to use. Use getGfxAdapters() to get a list of available adapters.
+        AdapterLUID* adapterLUID = nullptr;
         // Number of required features.
         GfxCount requiredFeatureCount = 0;
         // Array of required feature names, whose size is `requiredFeatureCount`.

--- a/tools/gfx/cuda/cuda-helper-functions.cpp
+++ b/tools/gfx/cuda/cuda-helper-functions.cpp
@@ -70,18 +70,36 @@ void _optixLogCallback(unsigned int level, const char* tag, const char* message,
 }
 #       endif
 #    endif
+
+AdapterLUID getAdapterLUID(int device)
+{
+    AdapterLUID luid = {};
+#if SLANG_WIN32 || SLANG_WIN64
+    // LUID reported by CUDA is undefined i not on windows platform.
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, device);
+    SLANG_ASSERT(sizeof(AdapterLUID) >= sizeof(cudaDeviceProp::luid));
+    memcpy(&luid, prop.luid, sizeof(cudaDeviceProp::luid));
+#else
+    SLANG_ASSERT(sizeof(AdapterLUID) >= sizeof(int));
+    memcpy(&luid, &device, sizeof(int));
+#endif
+    return luid;
+}
+
 } // namespace cuda
 
 Result SLANG_MCALL getCUDAAdapters(List<AdapterInfo>& outAdapters)
 {
-    int count;
-    cudaGetDeviceCount(&count);
-    for (int i = 0; i < count; i++)
+    int deviceCount;
+    cudaGetDeviceCount(&deviceCount);
+    for (int device = 0; device < deviceCount; device++)
     {
         cudaDeviceProp prop;
-        cudaGetDeviceProperties(&prop, i);
+        cudaGetDeviceProperties(&prop, device);
         AdapterInfo info = {};
         memcpy(info.name, prop.name, Math::Min(strlen(prop.name), sizeof(AdapterInfo::name) - 1));
+        info.luid = cuda::getAdapterLUID(device);
         outAdapters.add(info);
     }
 
@@ -90,10 +108,10 @@ Result SLANG_MCALL getCUDAAdapters(List<AdapterInfo>& outAdapters)
 
 Result SLANG_MCALL createCUDADevice(const IDevice::Desc* desc, IDevice** outDevice)
 {
-RefPtr<cuda::DeviceImpl> result = new cuda::DeviceImpl();
-SLANG_RETURN_ON_FAIL(result->initialize(*desc));
-returnComPtr(outDevice, result);
-return SLANG_OK;
+    RefPtr<cuda::DeviceImpl> result = new cuda::DeviceImpl();
+    SLANG_RETURN_ON_FAIL(result->initialize(*desc));
+    returnComPtr(outDevice, result);
+    return SLANG_OK;
 }
 #else
 
@@ -105,9 +123,9 @@ Result SLANG_MCALL getCUDAAdapters(List<AdapterInfo>& outAdapters)
 
 Result SLANG_MCALL createCUDADevice(const IDevice::Desc* desc, IDevice** outDevice)
 {
-SLANG_UNUSED(desc);
-*outDevice = nullptr;
-return SLANG_FAIL;
+    SLANG_UNUSED(desc);
+    *outDevice = nullptr;
+    return SLANG_FAIL;
 }
 #endif
 

--- a/tools/gfx/cuda/cuda-helper-functions.h
+++ b/tools/gfx/cuda/cuda-helper-functions.h
@@ -99,6 +99,8 @@ void _optixLogCallback(unsigned int level, const char* tag, const char* message,
 
 #    endif
 
+AdapterLUID getAdapterLUID(int device);
+
 } // namespace cuda
 #endif
 

--- a/tools/gfx/d3d/d3d-util.h
+++ b/tools/gfx/d3d/d3d-util.h
@@ -78,16 +78,18 @@ class D3DUtil
         /// Append text in in, into wide char array
     static void appendWideChars(const char* in, Slang::List<wchar_t>& out);
 
-    
+
     static SlangResult createFactory(DeviceCheckFlags flags, Slang::ComPtr<IDXGIFactory>& outFactory);
 
         /// Get the dxgiModule
     static HMODULE getDxgiModule();
 
         /// Find adapters
-    static SlangResult findAdapters(DeviceCheckFlags flags, const Slang::UnownedStringSlice& adapaterName, IDXGIFactory* dxgiFactory, Slang::List<Slang::ComPtr<IDXGIAdapter>>& dxgiAdapters);
+    static SlangResult findAdapters(DeviceCheckFlags flags, const AdapterLUID* adapterLUID, IDXGIFactory* dxgiFactory, Slang::List<Slang::ComPtr<IDXGIAdapter>>& dxgiAdapters);
         /// Find adapters
-    static SlangResult findAdapters(DeviceCheckFlags flags, const Slang::UnownedStringSlice& adapaterName, Slang::List<Slang::ComPtr<IDXGIAdapter>>& dxgiAdapters);
+    static SlangResult findAdapters(DeviceCheckFlags flags, const AdapterLUID* adapterLUID, Slang::List<Slang::ComPtr<IDXGIAdapter>>& dxgiAdapters);
+
+    static AdapterLUID getAdapterLUID(IDXGIAdapter* dxgiAdapter);
 
         /// True if the adapter is warp
     static bool isWarp(IDXGIFactory* dxgiFactory, IDXGIAdapter* adapter);

--- a/tools/gfx/d3d11/d3d11-device.cpp
+++ b/tools/gfx/d3d11/d3d11-device.cpp
@@ -112,12 +112,12 @@ SlangResult DeviceImpl::initialize(const Desc& desc)
             const auto deviceCheckFlags = combiner.getCombination(i);
             D3DUtil::createFactory(deviceCheckFlags, m_dxgiFactory);
 
-            // If we have an adapter set on the desc, look it up. We only need to do so for hardware
+            // If we have an adapter set on the desc, look it up.
             ComPtr<IDXGIAdapter> adapter;
-            if (desc.adapter && (deviceCheckFlags & DeviceCheckFlag::UseHardwareDevice))
+            if (desc.adapterLUID)
             {
                 List<ComPtr<IDXGIAdapter>> dxgiAdapters;
-                D3DUtil::findAdapters(deviceCheckFlags, Slang::UnownedStringSlice(desc.adapter), dxgiAdapters);
+                D3DUtil::findAdapters(deviceCheckFlags, desc.adapterLUID, m_dxgiFactory, dxgiAdapters);
                 if (dxgiAdapters.getCount() == 0)
                 {
                     continue;
@@ -147,7 +147,7 @@ SlangResult DeviceImpl::initialize(const Desc& desc)
                 m_device.writeRef(),
                 &featureLevel,
                 m_immediateContext.writeRef());
-            // Check if successfully constructed - if so we are done. 
+            // Check if successfully constructed - if so we are done.
             if (SLANG_SUCCEEDED(res))
             {
                 break;
@@ -882,7 +882,7 @@ Result DeviceImpl::createInputLayout(IInputLayout::Desc const& desc, IInputLayou
         default:
             return SLANG_FAIL;
         }
-            
+
         hlslCursor += sprintf(hlslCursor, "%s a%d : %s%d",
             typeName,
             (int)ii,

--- a/tools/gfx/d3d11/d3d11-helper-functions.cpp
+++ b/tools/gfx/d3d11/d3d11-helper-functions.cpp
@@ -348,8 +348,7 @@ namespace d3d11
 Result SLANG_MCALL getD3D11Adapters(List<AdapterInfo>& outAdapters)
 {
     List<ComPtr<IDXGIAdapter>> dxgiAdapters;
-    DeviceCheckFlags flags = DeviceCheckFlag::UseHardwareDevice;
-    SLANG_RETURN_ON_FAIL(D3DUtil::findAdapters(flags, UnownedStringSlice(), dxgiAdapters));
+    SLANG_RETURN_ON_FAIL(D3DUtil::findAdapters(DeviceCheckFlag::UseHardwareDevice, nullptr, dxgiAdapters));
 
     outAdapters.clear();
     for (const auto& dxgiAdapter : dxgiAdapters)
@@ -361,6 +360,7 @@ Result SLANG_MCALL getD3D11Adapters(List<AdapterInfo>& outAdapters)
         memcpy(info.name, name.getBuffer(), Math::Min(name.getLength(), (Index)sizeof(AdapterInfo::name) - 1));
         info.vendorID = desc.VendorId;
         info.deviceID = desc.DeviceId;
+        info.luid = D3DUtil::getAdapterLUID(dxgiAdapter);
         outAdapters.add(info);
     }
     return SLANG_OK;

--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -277,7 +277,7 @@ Result DeviceImpl::getNativeDeviceHandles(InteropHandles* outHandles)
 
 Result DeviceImpl::_createDevice(
     DeviceCheckFlags deviceCheckFlags,
-    const UnownedStringSlice& nameMatch,
+    const AdapterLUID* adapterLUID,
     D3D_FEATURE_LEVEL featureLevel,
     D3D12DeviceInfo& outDeviceInfo)
 {
@@ -293,7 +293,7 @@ Result DeviceImpl::_createDevice(
 
     List<ComPtr<IDXGIAdapter>> dxgiAdapters;
     SLANG_RETURN_ON_FAIL(
-        D3DUtil::findAdapters(deviceCheckFlags, nameMatch, dxgiFactory, dxgiAdapters));
+        D3DUtil::findAdapters(deviceCheckFlags, adapterLUID, dxgiFactory, dxgiAdapters));
 
     ComPtr<ID3D12Device> device;
     ComPtr<IDXGIAdapter> adapter;
@@ -471,7 +471,7 @@ Result DeviceImpl::initialize(const Desc& desc)
             if (SLANG_SUCCEEDED(m_D3D12GetDebugInterface(IID_PPV_ARGS(m_dxDebug.writeRef()))))
             {
 #    if 0
-                // Can enable for extra validation. NOTE! That d3d12 warns if you do.... 
+                // Can enable for extra validation. NOTE! That d3d12 warns if you do....
                 // D3D12 MESSAGE : Device Debug Layer Startup Options : GPU - Based Validation is enabled(disabled by default).
                 // This results in new validation not possible during API calls on the CPU, by creating patched shaders that have validation
                 // added directly to the shader. However, it can slow things down a lot, especially for applications with numerous
@@ -534,7 +534,7 @@ Result DeviceImpl::initialize(const Desc& desc)
             {
                 if (SLANG_SUCCEEDED(_createDevice(
                     combiner.getCombination(i),
-                    UnownedStringSlice(desc.adapter),
+                    desc.adapterLUID,
                     featureLevel,
                     m_deviceInfo)))
                 {

--- a/tools/gfx/d3d12/d3d12-device.h
+++ b/tools/gfx/d3d12/d3d12-device.h
@@ -236,7 +236,7 @@ public:
 
     Result _createDevice(
         DeviceCheckFlags deviceCheckFlags,
-        const UnownedStringSlice& nameMatch,
+        const AdapterLUID* adapterLUID,
         D3D_FEATURE_LEVEL featureLevel,
         D3D12DeviceInfo& outDeviceInfo);
 

--- a/tools/gfx/d3d12/d3d12-helper-functions.cpp
+++ b/tools/gfx/d3d12/d3d12-helper-functions.cpp
@@ -616,8 +616,7 @@ void translatePostBuildInfoDescs(
 Result SLANG_MCALL getD3D12Adapters(List<AdapterInfo>& outAdapters)
 {
     List<ComPtr<IDXGIAdapter>> dxgiAdapters;
-    DeviceCheckFlags flags = DeviceCheckFlag::UseHardwareDevice;
-    SLANG_RETURN_ON_FAIL(D3DUtil::findAdapters(flags, UnownedStringSlice(), dxgiAdapters));
+    SLANG_RETURN_ON_FAIL(D3DUtil::findAdapters(DeviceCheckFlag::UseHardwareDevice, nullptr, dxgiAdapters));
 
     outAdapters.clear();
     for (const auto& dxgiAdapter : dxgiAdapters)
@@ -629,6 +628,7 @@ Result SLANG_MCALL getD3D12Adapters(List<AdapterInfo>& outAdapters)
         memcpy(info.name, name.getBuffer(), Math::Min(name.getLength(), (Index)sizeof(AdapterInfo::name) - 1));
         info.vendorID = desc.VendorId;
         info.deviceID = desc.DeviceId;
+        info.luid = D3DUtil::getAdapterLUID(dxgiAdapter);
         outAdapters.add(info);
     }
     return SLANG_OK;

--- a/tools/gfx/open-gl/render-gl.cpp
+++ b/tools/gfx/open-gl/render-gl.cpp
@@ -1367,7 +1367,7 @@ public:
                 auto subObjectLayout = subObjectRange.layout;
                 auto const& bindingRange =
                     layout->getBindingRange(subObjectRange.bindingRangeIndex);
-                
+
                 switch (bindingRange.bindingType)
                 {
                 case slang::BindingType::ConstantBuffer:
@@ -2039,16 +2039,9 @@ SLANG_NO_THROW Result SLANG_MCALL GLDevice::initialize(const Desc& desc)
     auto renderer = glGetString(GL_RENDERER);
     m_info.adapterName = (char*)renderer;
 
-    if (renderer && desc.adapter)
+    if (desc.adapterLUID)
     {
-        String lowerAdapter = String(desc.adapter).toLower();
-        String lowerRenderer = String((const char*)renderer).toLower();
-
-        // The adapter is not available
-        if (lowerRenderer.indexOf(lowerAdapter) == Index(-1))
-        {
-            return SLANG_E_NOT_AVAILABLE;
-        }
+        return SLANG_E_INVALID_ARG;
     }
 
     if (m_desc.nvapiExtnSlot >= 0)

--- a/tools/gfx/vulkan/vk-device.cpp
+++ b/tools/gfx/vulkan/vk-device.cpp
@@ -168,7 +168,7 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
         instanceCreateInfo.ppEnabledExtensionNames = &instanceExtensions[0];
 
         const char* layerNames[] = { nullptr };
-        
+
         if (useValidationLayer)
         {
             // Depending on driver version, validation layer may or may not exist.
@@ -250,7 +250,6 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
     }
 
     VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
-    Index selectedDeviceIndex = 0;
     if (handles[1].handleValue == 0)
     {
         uint32_t numPhysicalDevices = 0;
@@ -262,33 +261,27 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
         SLANG_VK_RETURN_ON_FAIL(m_api.vkEnumeratePhysicalDevices(
             instance, &numPhysicalDevices, physicalDevices.getBuffer()));
 
-        if (m_desc.adapter)
+        // Use first physical device by default.
+        Index selectedDeviceIndex = 0;
+
+        // Search for requested adapter.
+        if (m_desc.adapterLUID)
         {
             selectedDeviceIndex = -1;
-
-            String lowerAdapter = String(m_desc.adapter).toLower();
-
             for (Index i = 0; i < physicalDevices.getCount(); ++i)
             {
-                auto physicalDevice = physicalDevices[i];
-
-                VkPhysicalDeviceProperties basicProps = {};
-                m_api.vkGetPhysicalDeviceProperties(physicalDevice, &basicProps);
-
-                String lowerName = String(basicProps.deviceName).toLower();
-
-                if (lowerName.indexOf(lowerAdapter) != Index(-1))
+                if (vk::getAdapterLUID(m_api, physicalDevices[i]) == *m_desc.adapterLUID)
                 {
                     selectedDeviceIndex = i;
                     break;
                 }
             }
             if (selectedDeviceIndex < 0)
-            {
-                // Device not found
-                return SLANG_FAIL;
-            }
+                return SLANG_E_NOT_FOUND;
         }
+
+        if (selectedDeviceIndex >= physicalDevices.getCount())
+            return SLANG_FAIL;
 
         physicalDevice = physicalDevices[selectedDeviceIndex];
     }
@@ -798,7 +791,7 @@ SlangResult DeviceImpl::readTextureResource(
     auto textureImpl = static_cast<TextureResourceImpl*>(texture);
 
     List<uint8_t> blobData;
-    
+
     auto desc = textureImpl->getDesc();
     auto width = desc->size.width;
     auto height = desc->size.height;

--- a/tools/gfx/vulkan/vk-helper-functions.h
+++ b/tools/gfx/vulkan/vk-helper-functions.h
@@ -175,6 +175,8 @@ VkPipelineStageFlags calcPipelineStageFlagsFromImageLayout(VkImageLayout layout)
 
 VkImageAspectFlags getAspectMaskFromFormat(VkFormat format);
 
+AdapterLUID getAdapterLUID(VulkanApi api, VkPhysicalDevice physicaDevice);
+
 } // namespace vk
 
 Result SLANG_MCALL getVKAdapters(List<AdapterInfo>& outAdapters);

--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -153,10 +153,6 @@ static gfx::DeviceType _toRenderType(Slang::RenderApiType apiType)
         {
             outOptions.performanceProfile = true;
         }
-        else if (argValue == "-adapter")
-        {
-            SLANG_RETURN_ON_FAIL(reader.expectArg(outOptions.adapter));
-        }
         else if (argValue == "-output-using-type")
         {
             outOptions.outputUsingType = true;

--- a/tools/render-test/options.h
+++ b/tools/render-test/options.h
@@ -65,8 +65,6 @@ struct Options
 
     Slang::List<Slang::String> renderFeatures;          /// Required render features for this test to run
 
-    Slang::String adapter;                              ///< The adapter to use either name or index
-
     uint32_t computeDispatchSize[3] = { 1, 1, 1 };
 
     Slang::String nvapiExtnSlot;                               ///< The nvapiRegister to use.

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -1266,10 +1266,6 @@ static SlangResult _innerMain(Slang::StdWriters* stdWriters, SlangSession* sessi
     StringBuilder rendererName;
     auto info = 
     rendererName << "[" << gfxGetDeviceTypeName(options.deviceType) << "] ";
-    if (options.adapter.getLength())
-    {
-        rendererName << "'" << options.adapter << "'";
-    }
 
     if (options.onlyStartup)
     {
@@ -1318,7 +1314,6 @@ static SlangResult _innerMain(Slang::StdWriters* stdWriters, SlangSession* sessi
     {
         IDevice::Desc desc = {};
         desc.deviceType = options.deviceType;
-        desc.adapter = options.adapter.getBuffer();
 
         desc.slang.lineDirectiveMode = SLANG_LINE_DIRECTIVE_MODE_NONE;
         if (options.generateSPIRVDirectly)


### PR DESCRIPTION
- Add `AdapterLUID` to hold locally unique identifier of GPU adapters.
- Return LUIDs when enumerating GPU adapters using `gfxGetAdapters()`.
- Allow specifying an LUID when creating a GPU device.
- Remove functionality to match adapter by name.
- Remove `adapter` option in `render-test`.