### PR TITLE
Make `__BuiltinFloatingPointType` conform to `IDifferentiable`.

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -162,7 +162,7 @@ interface __BuiltinRealType : __BuiltinSignedArithmeticType {}
 /// A type that uses a floating-point representation
 [sealed]
 [builtin]
-interface __BuiltinFloatingPointType : __BuiltinRealType
+interface __BuiltinFloatingPointType : __BuiltinRealType, IDifferentiable
 {
         /// Initialize from a 32-bit floating-point value.
     __init(float value);
@@ -369,6 +369,26 @@ ${{{{
     case BaseType::Double:
 }}}}
         static $(kBaseTypes[tt].name) getPi() { return $(kBaseTypes[tt].name)(3.14159265358979323846264338328); }
+
+        typedef $(kBaseTypes[tt].name) Differential;
+    
+        [__unsafeForceInlineEarly]
+        static Differential dzero()
+        {
+            return Differential(0);
+        }
+
+        [__unsafeForceInlineEarly]
+        static Differential dadd(Differential a, Differential b)
+        {
+            return a + b;
+        }
+
+        [__unsafeForceInlineEarly]
+        static Differential dmul(Differential a, Differential b)
+        {
+            return a * b;
+        }
 ${{{{
         break;
     }
@@ -891,7 +911,6 @@ for (int tt = 0; tt < kBaseTypeCount; ++tt)
             sb << "    __init(" << kBaseTypes[ff].name << " value);\n";
         }
     }
-
     sb << "}\n";
 }
 
@@ -926,7 +945,6 @@ for( int C = 2; C <= 4; ++C )
         if(rr == R && cc == C) continue;
         sb << "__init(matrix<T," << rr << "," << cc << "> value);\n";
     }
-
     sb << "}\n";
 }
 
@@ -935,6 +953,7 @@ for (int tt = 0; tt < kBaseTypeCount; ++tt)
     if(kBaseTypes[tt].tag == BaseType::Void) continue;
     auto toType = kBaseTypes[tt].name;
 }}}}
+
 __generic<let R : int, let C : int> extension matrix<$(toType),R,C>
 {
 ${{{{
@@ -957,6 +976,60 @@ ${{{{
 ${{{{
 }
 }}}}
+
+__generic<T, U>
+__intrinsic_op(0)
+T __slang_noop_cast(U u);
+
+__generic<T:__BuiltinFloatingPointType, let N: int>
+extension vector<T, N> : IDifferentiable
+{
+    typedef vector<T, N> Differential;
+
+    [__unsafeForceInlineEarly]
+    static Differential dzero()
+    {
+        return Differential(__slang_noop_cast<T>(T.dzero()));
+    }
+
+    [__unsafeForceInlineEarly]
+    static Differential dadd(Differential a, Differential b)
+    {
+        return a + b;
+    }
+
+    [__unsafeForceInlineEarly]
+    static Differential dmul(This a, Differential b)
+    {
+        return a * b;
+    }
+}
+
+__generic<T:__BuiltinFloatingPointType, let R: int, let C: int>
+extension matrix<T, R, C> : IDifferentiable
+{
+    typedef matrix<T, R, C> Differential;
+
+    __init(T val);
+
+    [__unsafeForceInlineEarly]
+    static Differential dzero()
+    {
+        return matrix<T, R, C>(__slang_noop_cast<T>(T.dzero()));
+    }
+
+    [__unsafeForceInlineEarly]
+    static Differential dadd(Differential a, Differential b)
+    {
+        return a + b;
+    }
+
+    [__unsafeForceInlineEarly]
+    static Differential dmul(This a, Differential b)
+    {
+        return a * b;
+    }
+}
 
 //@ public:
 

--- a/source/slang/diff.meta.slang
+++ b/source/slang/diff.meta.slang
@@ -9,56 +9,10 @@ attribute_syntax [ForwardDifferentiable] : ForwardDifferentiableAttribute;
 __attributeTarget(FunctionDeclBase)
 attribute_syntax [ForwardDerivative(function)]   : ForwardDerivativeAttribute;
 
-// Add extensions for the standard types
-extension float : IDifferentiable
-{
-    typedef float Differential;
-    
-    [__unsafeForceInlineEarly]
-    static Differential dzero()
-    {
-        return float(0.f);
-    }
 
-    [__unsafeForceInlineEarly]
-    static Differential dadd(Differential a, Differential b)
-    {
-        return a + b;
-    }
+/// Pair type that serves to wrap the primal and
+/// differential types of an arbitrary type T.
 
-    [__unsafeForceInlineEarly]
-    static Differential dmul(This a, Differential b)
-    {
-        return a * b;
-    }
-}
-
-__generic<let N:int>
-extension vector<float, N> : IDifferentiable
-{
-    typedef vector<float, N> Differential;
-
-    [__unsafeForceInlineEarly]
-    static Differential dzero()
-    {
-        return vector<float, N>(0.f);
-    }
-
-    [__unsafeForceInlineEarly]
-    static Differential dadd(Differential a, Differential b)
-    {
-        return a + b;
-    }
-
-    [__unsafeForceInlineEarly]
-    static Differential dmul(This a, Differential b)
-    {
-        return a * b;
-    }
-}
-
-    /// Pair type that serves to wrap the primal and
-    /// differential types of an arbitrary type T.
 __generic<T : IDifferentiable>
 __magic_type(DifferentialPairType)
 __intrinsic_type($(kIROp_DifferentialPairType))
@@ -126,15 +80,13 @@ struct DifferentialPair : IDifferentiable
     }
 };
 
-typealias IDFloat = IFloat & IDifferentiable;
-
 #define VECTOR_MAP_UNARY(TYPE, COUNT, FUNC, VALUE) \
     vector<TYPE,COUNT> result; for(int i = 0; i < COUNT; ++i) { result[i] = FUNC(VALUE[i]); } return result
 
 namespace dstd
 {
     // Natural Exponent
-    __generic<T : IDFloat>
+    __generic<T : __BuiltinFloatingPointType>
     __target_intrinsic(hlsl)
     __target_intrinsic(glsl)
     __target_intrinsic(cuda, "$P_exp($0)")
@@ -143,16 +95,16 @@ namespace dstd
     [ForwardDerivative(d_exp<T>)]
     T exp(T x);
 
-    __generic<T : IDFloat>
+    __generic<T : __BuiltinFloatingPointType>
     DifferentialPair<T> d_exp(DifferentialPair<T> dpx)
     {
         return DifferentialPair<T>(
-            exp(dpx.p),
-            T.dmul(exp(dpx.p), dpx.d));
+            dstd.exp(dpx.p),
+            T.dmul(dstd.exp(dpx.p), dpx.d));
     }
 
     // Sine
-    __generic<T : IDFloat>
+    __generic<T : __BuiltinFloatingPointType>
     __target_intrinsic(hlsl)
     __target_intrinsic(glsl)
     __target_intrinsic(cuda, "$P_sin($0)")
@@ -161,16 +113,16 @@ namespace dstd
     [ForwardDerivative(d_sin<T>)]
     T sin(T x);
 
-    __generic<T : IDFloat>
+    __generic<T : __BuiltinFloatingPointType>
     DifferentialPair<T> d_sin(DifferentialPair<T> dpx)
     {
         return DifferentialPair<T>(
-            sin(dpx.p),
-            T.dmul(cos(dpx.p), dpx.d));
+            dstd.sin(dpx.p),
+            T.dmul(dstd.cos(dpx.p), dpx.d));
     }
 
     // Cosine
-    __generic<T : IDFloat>
+    __generic<T : __BuiltinFloatingPointType>
     __target_intrinsic(hlsl)
     __target_intrinsic(glsl)
     __target_intrinsic(cuda, "$P_cos($0)")
@@ -179,12 +131,12 @@ namespace dstd
     [ForwardDerivative(d_cos<T>)]
     T cos(T x);
 
-    __generic<T : IDFloat>
+    __generic<T : __BuiltinFloatingPointType>
     DifferentialPair<T> d_cos(DifferentialPair<T> dpx)
     {
         return DifferentialPair<T>(
-            cos(dpx.p),
-            T.dmul(-sin(dpx.p), dpx.d));
+            dstd.cos(dpx.p),
+            T.dmul(-dstd.sin(dpx.p), dpx.d));
     }
 
     __generic<let N : int>

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1573,10 +1573,15 @@ namespace Slang
                 {
                     for (auto item : overloadExpr->lookupResult2.items)
                     {
+                        auto funcType = as<FuncType>(GetTypeForDeclRef(item.declRef, item.declRef.decl->loc));
+                        if (!funcType)
+                            continue;
+                        funcType = as<FuncType>(processJVPFuncType(funcType));
+                        if (!funcType)
+                            continue;
                         OverloadCandidate candidate;
                         candidate.flavor = OverloadCandidate::Flavor::Expr;
-                        candidate.funcType = as<FuncType>(processJVPFuncType(
-                            as<FuncType>(GetTypeForDeclRef(item.declRef, item.declRef.decl->loc))));
+                        candidate.funcType = funcType;
                         candidate.resultType = candidate.funcType->getResultType();
                         candidate.item = LookupResultItem(item.declRef);
 

--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -197,6 +197,29 @@ struct PeepholeContext : InstPassBase
                 }
             }
             break;
+        case kIROp_lookup_interface_method:
+            {
+                if (inst->getOperand(0)->getOp() == kIROp_WitnessTable)
+                {
+                    auto wt = as<IRWitnessTable>(inst->getOperand(0));
+                    auto key = inst->getOperand(1);
+                    for (auto item : wt->getChildren())
+                    {
+                        if (auto entry = as<IRWitnessTableEntry>(item))
+                        {
+                            if (entry->getRequirementKey() == key)
+                            {
+                                auto value = entry->getSatisfyingVal();
+                                inst->replaceUsesWith(value);
+                                inst->removeAndDeallocate();
+                                changed = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            break;
         default:
             break;
         }


### PR DESCRIPTION
Also moves the `float:IDifferentiable` and `vector:IDifferentiable` to `core`.

Defines `matrix` to be differentiable, but its operations hasn't been implemented yet.