### PR TITLE
Add mesh and amplification shaders to slang-glslang

### DIFF
--- a/source/slang-glslang/slang-glslang.cpp
+++ b/source/slang-glslang/slang-glslang.cpp
@@ -532,6 +532,8 @@ static int glslang_compileGLSLToSPIRV(const glslang_CompileRequest_1_1& request)
     CASE(MISS,              MissNV);
     CASE(CALLABLE,          CallableNV);
 
+    CASE(MESH,          Mesh);
+    CASE(AMPLIFICATION, Task);
 #undef CASE
 
     default:


### PR DESCRIPTION
As a separate PR to make the update slang-glslang dance work