### PR TITLE
Data flow validation pass for diagnosing derivative loss.

### DIFF
--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -335,6 +335,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClInclude Include="..\..\..\source\slang\slang-ir-augment-make-existential.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-bind-existentials.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-byte-address-legalize.h" />
+    <ClInclude Include="..\..\..\source\slang\slang-ir-check-differentiability.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-cleanup-void.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-clone.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-collect-global-uniforms.h" />
@@ -506,6 +507,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClCompile Include="..\..\..\source\slang\slang-ir-augment-make-existential.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-bind-existentials.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-byte-address-legalize.cpp" />
+    <ClCompile Include="..\..\..\source\slang\slang-ir-check-differentiability.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-cleanup-void.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-clone.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-collect-global-uniforms.cpp" />

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClInclude Include="..\..\..\source\slang\slang-ir-byte-address-legalize.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\slang\slang-ir-check-differentiability.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-ir-cleanup-void.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -645,6 +648,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-ir-byte-address-legalize.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\source\slang\slang-ir-check-differentiability.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-ir-cleanup-void.cpp">

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -391,6 +391,12 @@ class ModuleDecl : public NamespaceDeclBase
     //
     Module* module = nullptr;
 
+        /// Map a decl to the list of its associated decls.
+        ///
+        /// This mapping is filled in during semantic checking, as the decl declarations get checked or generated.
+        ///
+    OrderedDictionary<Decl*, RefPtr<DeclAssociationList>> mapDeclToAssociatedDecls;
+
     SLANG_UNREFLECTED
 
         /// Map a type to the list of extensions of that type (if any) declared in this module
@@ -398,6 +404,7 @@ class ModuleDecl : public NamespaceDeclBase
         /// This mapping is filled in during semantic checking, as `ExtensionDecl`s get checked.
         ///
     Dictionary<AggTypeDecl*, RefPtr<CandidateExtensionList>> mapTypeToCandidateExtensions;
+
 };
 
     /// A declaration that brings members of another declaration or namespace into scope

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -472,8 +472,6 @@ class TreatAsDifferentiableExpr : public Expr
 
     Expr* innerExpr;
     Scope* scope;
-
-    bool isCalleeDifferentiable = false;
 };
 
     /// A type expression of the form `__TaggedUnion(A, ...)`.

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -466,12 +466,14 @@ class BackwardDifferentiateExpr: public DifferentiateExpr
 };
 
     /// An express to mark its inner expression as an intended non-differential call.
-class NoDiffExpr : public Expr
+class DiffDecorateExpr : public Expr
 {
-    SLANG_AST_CLASS(NoDiffExpr)
+    SLANG_AST_CLASS(DiffDecorateExpr)
 
     Expr* innerExpr;
     Scope* scope;
+
+    bool isCalleeDifferentiable = false;
 };
 
     /// A type expression of the form `__TaggedUnion(A, ...)`.

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -466,9 +466,9 @@ class BackwardDifferentiateExpr: public DifferentiateExpr
 };
 
     /// An express to mark its inner expression as an intended non-differential call.
-class DiffDecorateExpr : public Expr
+class TreatAsDifferentiableExpr : public Expr
 {
-    SLANG_AST_CLASS(DiffDecorateExpr)
+    SLANG_AST_CLASS(TreatAsDifferentiableExpr)
 
     Expr* innerExpr;
     Scope* scope;

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -465,6 +465,15 @@ class BackwardDifferentiateExpr: public DifferentiateExpr
     SLANG_AST_CLASS(BackwardDifferentiateExpr)
 };
 
+    /// An express to mark its inner expression as an intended non-differential call.
+class NoDiffExpr : public Expr
+{
+    SLANG_AST_CLASS(NoDiffExpr)
+
+    Expr* innerExpr;
+    Scope* scope;
+};
+
     /// A type expression of the form `__TaggedUnion(A, ...)`.
     ///
     /// An expression of this form will resolve to a `TaggedUnionType`

--- a/source/slang/slang-ast-iterator.h
+++ b/source/slang/slang-ast-iterator.h
@@ -269,7 +269,7 @@ struct ASTIterator
             dispatchIfNotNull(expr->baseFunction);
         }
 
-        void visitNoDiffExpr(NoDiffExpr* expr)
+        void visitDiffDecorateExpr(DiffDecorateExpr* expr)
         {
             dispatchIfNotNull(expr->innerExpr);
         }

--- a/source/slang/slang-ast-iterator.h
+++ b/source/slang/slang-ast-iterator.h
@@ -268,6 +268,11 @@ struct ASTIterator
             iterator->maybeDispatchCallback(expr);
             dispatchIfNotNull(expr->baseFunction);
         }
+
+        void visitNoDiffExpr(NoDiffExpr* expr)
+        {
+            dispatchIfNotNull(expr->innerExpr);
+        }
     };
 
     struct ASTIteratorStmtVisitor : public StmtVisitor<ASTIteratorStmtVisitor>

--- a/source/slang/slang-ast-iterator.h
+++ b/source/slang/slang-ast-iterator.h
@@ -269,7 +269,7 @@ struct ASTIterator
             dispatchIfNotNull(expr->baseFunction);
         }
 
-        void visitDiffDecorateExpr(DiffDecorateExpr* expr)
+        void visitTreatAsDifferentiableExpr(TreatAsDifferentiableExpr* expr)
         {
             dispatchIfNotNull(expr->innerExpr);
         }

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -1496,6 +1496,28 @@ namespace Slang
         List<ExtensionDecl*> candidateExtensions;
     };
 
+
+    enum class DeclAssociationKind
+    {
+        ForwardDerivativeFunc, BackwardDerivativeFunc,
+    };
+
+    struct DeclAssociation
+    {
+        SLANG_VALUE_CLASS(DeclAssociation)
+        DeclAssociationKind kind;
+        Decl* decl;
+    };
+
+    /// A reference-counted object to hold a list of associated decls for a decl.
+    ///
+    struct DeclAssociationList : SerialRefObject
+    {
+        SLANG_OBJ_CLASS(DeclAssociationList)
+
+        List<DeclAssociation> associations;
+    };
+
         /// Represents the "direction" that a parameter is being passed (e.g., `in` or `out`
     enum ParameterDirection
     {

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -4635,6 +4635,7 @@ namespace Slang
                 checkDerivativeAttribute(as<FunctionDeclBase>(calleeDeclRef->declRef.getDecl()), fwdDerivativeAttr);
                 attr->backDeclRef = fwdDerivativeAttr->funcExpr;
                 fwdDerivativeAttr->funcExpr = nullptr;
+                getShared()->registerAssociatedDecl(calleeDeclRef->declRef.getDecl(), DeclAssociationKind::ForwardDerivativeFunc, funcDecl);
                 return;
             }
         }
@@ -6393,6 +6394,125 @@ namespace Slang
             auto& list = _getCandidateExtensionList(entry.Key, m_mapTypeDeclToCandidateExtensions);
             list.addRange(entry.Value->candidateExtensions);
         }
+    }
+
+    /// Get a reference to the associated decl list for `decl` in the given dictionary
+    ///
+    /// Note: this function creates an empty list of candidates for the given type if
+    /// a matching entry doesn't exist already.
+    ///
+    static List<DeclAssociation>& _getDeclAssociationList(
+        Decl* decl,
+        OrderedDictionary<Decl*, RefPtr<DeclAssociationList>>& mapDeclToDeclarations)
+    {
+        RefPtr<DeclAssociationList> entry;
+        if (!mapDeclToDeclarations.TryGetValue(decl, entry))
+        {
+            entry = new DeclAssociationList();
+            mapDeclToDeclarations.Add(decl, entry);
+        }
+        return entry->associations;
+    }
+
+    void SharedSemanticsContext::_addDeclAssociationsFromModule(ModuleDecl* moduleDecl)
+    {
+        for (auto& entry : moduleDecl->mapDeclToAssociatedDecls)
+        {
+            auto& list = _getDeclAssociationList(entry.Key, m_mapDeclToAssociatedDecls);
+            list.addRange(entry.Value->associations);
+        }
+    }
+
+    void SharedSemanticsContext::registerAssociatedDecl(Decl* original, DeclAssociationKind kind, Decl* associated)
+    {
+        auto moduleDecl = getModuleDecl(associated);
+        DeclAssociation assoc = {kind, associated};
+        _getDeclAssociationList(original, moduleDecl->mapDeclToAssociatedDecls).add(assoc);
+
+        m_associatedDeclListsBuilt = false;
+        m_mapDeclToAssociatedDecls.Clear();
+    }
+
+    List<DeclAssociation> const& SharedSemanticsContext::getAssociatedDeclsForDecl(Decl* decl)
+    {
+        // This duplicates the exact same logic from `getCandidateExtensionsForTypeDecl`.
+        // Consider refactoring them into the same framework.
+        if (!m_associatedDeclListsBuilt)
+        {
+            m_associatedDeclListsBuilt = true;
+
+            for (auto module : getSession()->stdlibModules)
+            {
+                _addDeclAssociationsFromModule(module->getModuleDecl());
+            }
+
+            if (m_module)
+            {
+                _addDeclAssociationsFromModule(m_module->getModuleDecl());
+                for (auto moduleDecl : this->importedModulesList)
+                {
+                    _addDeclAssociationsFromModule(moduleDecl);
+                }
+            }
+            else
+            {
+                for (auto module : m_linkage->loadedModulesList)
+                {
+                    _addDeclAssociationsFromModule(module->getModuleDecl());
+                }
+            }
+        }
+        return _getDeclAssociationList(decl, m_mapDeclToAssociatedDecls);
+    }
+
+    bool SharedSemanticsContext::isDifferentiableFunc(FunctionDeclBase* func)
+    {
+        // A function is differentiable if it is marked as differentiable, or it
+        // has an associated derivative function.
+        if (func->findModifier<DifferentiableAttribute>())
+            return true;
+        for (auto assocDecl : getAssociatedDeclsForDecl(func))
+        {
+            switch (assocDecl.kind)
+            {
+            case DeclAssociationKind::ForwardDerivativeFunc:
+                return true;
+            default:
+                break;
+            }
+        }
+        return false;
+    }
+
+    bool SharedSemanticsContext::isBackwardDifferentiableFunc(FunctionDeclBase* func)
+    {
+        // A function is differentiable if it is marked as differentiable, or it
+        // has an associated derivative function.
+        if (func->findModifier<BackwardDifferentiableAttribute>())
+            return true;
+        for (auto assocDecl : getAssociatedDeclsForDecl(func))
+        {
+            switch (assocDecl.kind)
+            {
+            case DeclAssociationKind::BackwardDerivativeFunc:
+                return true;
+            default:
+                break;
+            }
+        }
+        if (auto builtinReq = func->findModifier<BuiltinRequirementModifier>())
+        {
+            switch (builtinReq->kind)
+            {
+            case BuiltinRequirementKind::DAddFunc:
+            case BuiltinRequirementKind::DMulFunc:
+            case BuiltinRequirementKind::DZeroFunc:
+                return true;
+            default:
+                break;
+            }
+        }
+        return false;
     }
 
     List<ExtensionDecl*> const& getCandidateExtensions(

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -6476,6 +6476,7 @@ namespace Slang
             switch (assocDecl.kind)
             {
             case DeclAssociationKind::ForwardDerivativeFunc:
+            case DeclAssociationKind::BackwardDerivativeFunc:
                 return true;
             default:
                 break;

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2227,6 +2227,23 @@ namespace Slang
         return _checkDifferentiateExpr(this, expr, &actions);
     }
 
+    Expr* SemanticsExprVisitor::visitNoDiffExpr(NoDiffExpr* expr)
+    {
+        expr->innerExpr = CheckTerm(expr->innerExpr);
+        auto innerExpr = expr->innerExpr;
+        while (auto parenExpr = as<ParenExpr>(innerExpr))
+        {
+            innerExpr = parenExpr->base;
+        }
+        if (!as<InvokeExpr>(innerExpr))
+        {
+            getSink()->diagnose(expr, Diagnostics::invalidUseOfNoDiff);
+        }
+        expr->type = expr->innerExpr->type;
+        return expr;
+    }
+
+
     Expr* SemanticsExprVisitor::visitGetArrayLengthExpr(GetArrayLengthExpr* expr)
     {
         expr->arrayExpr = CheckTerm(expr->arrayExpr);

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -724,9 +724,6 @@ namespace Slang
         ///
         void registerDifferentiableType(DeclRefType* type, SubtypeWitness* witness);
 
-        // Check and register a type if it is differentiable.
-        void maybeRegisterDifferentiableType(ASTBuilder* builder, Type* type);
-
         // Construct the differential for 'type', if it exists.
         Type* getDifferentialType(ASTBuilder* builder, Type* type, SourceLoc loc);
         Type* tryGetDifferentialType(ASTBuilder* builder, Type* type);
@@ -1060,6 +1057,9 @@ namespace Slang
 
             /// Gather differentiable members from decl.
         List<DifferentiableMemberInfo> collectDifferentiableMemberInfo(ContainerDecl* decl);
+
+        // Check and register a type if it is differentiable.
+        void maybeRegisterDifferentiableType(ASTBuilder* builder, Type* type);
 
         // Find the appropriate member of a declared type to
         // satisfy a requirement of an interface the type

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1913,6 +1913,7 @@ namespace Slang
 
         Expr* visitForwardDifferentiateExpr(ForwardDifferentiateExpr* expr);
         Expr* visitBackwardDifferentiateExpr(BackwardDifferentiateExpr* expr);
+        Expr* visitNoDiffExpr(NoDiffExpr* expr);
 
         Expr* visitGetArrayLengthExpr(GetArrayLengthExpr* expr);
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1295,8 +1295,6 @@ namespace Slang
             /// Given an immutable `expr` used as an l-value emit a special diagnostic if it was derived from `this`.
         void maybeDiagnoseThisNotLValue(Expr* expr);
 
-        void registerExtension(ExtensionDecl* decl);
-
         // Figure out what type an initializer/constructor declaration
         // is supposed to return. In most cases this is just the type
         // declaration that its declaration is nested inside.

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -401,8 +401,6 @@ namespace Slang
             return m_parentDifferentiableAttr;
         }
 
-        bool isInNoDiffEnv() { return m_noDiff; }
-
             /// A scope that is local to a particular expression, and
             /// that can be used to allocate temporary bindings that
             /// might be needed by that expression or its sub-expressions.
@@ -431,10 +429,10 @@ namespace Slang
             return result;
         }
 
-        SemanticsContext withNoDiff()
+        SemanticsContext withTreatAsDifferentiable(TreatAsDifferentiableExpr* expr)
         {
             SemanticsContext result(*this);
-            result.m_noDiff = true;
+            result.m_treatAsDifferentiableExpr = expr;
             return result;
         }
 
@@ -471,8 +469,9 @@ namespace Slang
             /// is considered valid in the current context.
         bool m_allowStaticReferenceToNonStaticMember = false;
 
-            /// Whether or not we are in a `no_diff` environment.
-        bool m_noDiff = false;
+            /// Whether or not we are in a `no_diff` environment (and therefore should treat the call to
+            /// a non-differentiable function as differentiable and not issue a diagnostic).
+        TreatAsDifferentiableExpr* m_treatAsDifferentiableExpr = nullptr;
 
         ASTBuilder* m_astBuilder = nullptr;
     };
@@ -1943,7 +1942,7 @@ namespace Slang
 
         Expr* visitForwardDifferentiateExpr(ForwardDifferentiateExpr* expr);
         Expr* visitBackwardDifferentiateExpr(BackwardDifferentiateExpr* expr);
-        Expr* visitDiffDecorateExpr(DiffDecorateExpr* expr);
+        Expr* visitTreatAsDifferentiableExpr(TreatAsDifferentiableExpr* expr);
 
         Expr* visitGetArrayLengthExpr(GetArrayLengthExpr* expr);
 

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -494,8 +494,6 @@ DIAGNOSTIC(38026, Error, globalTypeArgumentDoesNotConformToInterface, "type argu
 DIAGNOSTIC(38027, Error, mismatchExistentialSlotArgCount, "expected $0 existential slot arguments ($1 provided)")
 DIAGNOSTIC(38029, Error, typeArgumentDoesNotConformToInterface, "type argument '$0' does not conform to the required interface '$1'")
 
-DIAGNOSTIC(30830, Error, functionNotMarkedAsDifferentiable, "function '$0' is not marked as $1-differentiable.")
-
 DIAGNOSTIC(38200, Error, recursiveModuleImport, "module `$0` recursively imports itself")
 DIAGNOSTIC(39999, Error, errorInImportedModule, "import of module '$0' failed because of a compilation error")
 DIAGNOSTIC(39999, Fatal, complationCeased, "compilation ceased")
@@ -568,6 +566,10 @@ DIAGNOSTIC(41010, Warning, missingReturn, "control flow may reach end of non-'vo
 DIAGNOSTIC(41011, Error, typeDoesNotFitAnyValueSize, "type '$0' does not fit in the size required by its conforming interface.")
 DIAGNOSTIC(41012, Note, typeAndLimit, "sizeof($0) is $1, limit is $2")
 DIAGNOSTIC(41012, Error, typeCannotBePackedIntoAnyValue, "type '$0' contains fields that cannot be packed into an AnyValue.")
+DIAGNOSTIC(41020, Error, lossOfDerivativeDueToCallOfNonDifferentiableFunction, "derivative cannot be propagated through call to non-differnetiable function `$0`, use 'no_diff' to clarify intention.")
+DIAGNOSTIC(41021, Error, differentiableFuncMustHaveOutput, "a differentiable function must have at least one differentiable output.")
+DIAGNOSTIC(41022, Error, differentiableFuncMustHaveInput, "a differentiable function must have at least one differentiable input.")
+DIAGNOSTIC(41023, Error, functionNotMarkedAsDifferentiable, "function '$0' is not marked as $1-differentiable.")
 
 //
 // 5xxxx - Target code generation.

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -494,6 +494,8 @@ DIAGNOSTIC(38026, Error, globalTypeArgumentDoesNotConformToInterface, "type argu
 DIAGNOSTIC(38027, Error, mismatchExistentialSlotArgCount, "expected $0 existential slot arguments ($1 provided)")
 DIAGNOSTIC(38029, Error, typeArgumentDoesNotConformToInterface, "type argument '$0' does not conform to the required interface '$1'")
 
+DIAGNOSTIC(38030, Error, invalidUseOfNoDiff, "'no_diff' can only be used to decorate a call.")
+
 DIAGNOSTIC(38200, Error, recursiveModuleImport, "module `$0` recursively imports itself")
 DIAGNOSTIC(39999, Error, errorInImportedModule, "import of module '$0' failed because of a compilation error")
 DIAGNOSTIC(39999, Fatal, complationCeased, "compilation ceased")

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -497,6 +497,8 @@ DIAGNOSTIC(38027, Error, mismatchExistentialSlotArgCount, "expected $0 existenti
 DIAGNOSTIC(38029, Error, typeArgumentDoesNotConformToInterface, "type argument '$0' does not conform to the required interface '$1'")
 
 DIAGNOSTIC(38031, Error, invalidUseOfNoDiff, "'no_diff' can only be used to decorate a call.")
+DIAGNOSTIC(38032, Error, useOfNoDiffOnDifferentiableFunc, "use 'no_diff' on a call to a differentiable function has no meaning.")
+DIAGNOSTIC(38033, Error, cannotUseNoDiffInNonDifferentiableFunc, "cannot use 'no_diff' in a non-differentiable function.")
 
 DIAGNOSTIC(38200, Error, recursiveModuleImport, "module `$0` recursively imports itself")
 DIAGNOSTIC(39999, Error, errorInImportedModule, "import of module '$0' failed because of a compilation error")

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -304,6 +304,8 @@ DIAGNOSTIC(30094, Error, mustUseTryClauseToCallAThrowFunc, "the callee may throw
 DIAGNOSTIC(30095, Error, errorTypeOfCalleeIncompatibleWithCaller, "the error type `$1` of callee `$0` is not compatible with the caller's error type `$2`.")
 
 DIAGNOSTIC(30096, Error, differentialTypeShouldServeAsItsOwnDifferentialType, "type '$0' is used as a `Differential` type, therefore it must serve as its own `Differential` type.")
+DIAGNOSTIC(30097, Error, functionNotMarkedAsDifferentiable, "function '$0' is not marked as $1-differentiable.")
+
 DIAGNOSTIC(-1, Note, noteSeeUseOfDifferentialType, "see use of '$0' as Differential of '$1'.")
 
 // Attributes
@@ -494,7 +496,7 @@ DIAGNOSTIC(38026, Error, globalTypeArgumentDoesNotConformToInterface, "type argu
 DIAGNOSTIC(38027, Error, mismatchExistentialSlotArgCount, "expected $0 existential slot arguments ($1 provided)")
 DIAGNOSTIC(38029, Error, typeArgumentDoesNotConformToInterface, "type argument '$0' does not conform to the required interface '$1'")
 
-DIAGNOSTIC(38030, Error, invalidUseOfNoDiff, "'no_diff' can only be used to decorate a call.")
+DIAGNOSTIC(38031, Error, invalidUseOfNoDiff, "'no_diff' can only be used to decorate a call.")
 
 DIAGNOSTIC(38200, Error, recursiveModuleImport, "module `$0` recursively imports itself")
 DIAGNOSTIC(39999, Error, errorInImportedModule, "import of module '$0' failed because of a compilation error")
@@ -568,10 +570,9 @@ DIAGNOSTIC(41010, Warning, missingReturn, "control flow may reach end of non-'vo
 DIAGNOSTIC(41011, Error, typeDoesNotFitAnyValueSize, "type '$0' does not fit in the size required by its conforming interface.")
 DIAGNOSTIC(41012, Note, typeAndLimit, "sizeof($0) is $1, limit is $2")
 DIAGNOSTIC(41012, Error, typeCannotBePackedIntoAnyValue, "type '$0' contains fields that cannot be packed into an AnyValue.")
-DIAGNOSTIC(41020, Error, lossOfDerivativeDueToCallOfNonDifferentiableFunction, "derivative cannot be propagated through call to non-differnetiable function `$0`, use 'no_diff' to clarify intention.")
+DIAGNOSTIC(41020, Error, lossOfDerivativeDueToCallOfNonDifferentiableFunction, "derivative cannot be propagated through call to non-differentiable function `$0`, use 'no_diff' to clarify intention.")
 DIAGNOSTIC(41021, Error, differentiableFuncMustHaveOutput, "a differentiable function must have at least one differentiable output.")
 DIAGNOSTIC(41022, Error, differentiableFuncMustHaveInput, "a differentiable function must have at least one differentiable input.")
-DIAGNOSTIC(41023, Error, functionNotMarkedAsDifferentiable, "function '$0' is not marked as $1-differentiable.")
 
 //
 // 5xxxx - Target code generation.

--- a/source/slang/slang-ir-check-differentiability.cpp
+++ b/source/slang/slang-ir-check-differentiability.cpp
@@ -226,6 +226,7 @@ public:
             case kIROp_Load:
                 // We don't have more knowledge on whether diff is available at the destination address.
                 // Just assume it is producing diff.
+                //TODO: propagate the info if this is a load of a temporary variable intended to receive result from an `out` parameter.
                 return isDifferentiableType(diffTypeContext, inst->getDataType());
             default:
                 // default case is to assume the inst produces a diff value if any

--- a/source/slang/slang-ir-check-differentiability.cpp
+++ b/source/slang/slang-ir-check-differentiability.cpp
@@ -1,0 +1,420 @@
+#include "slang-ir-check-differentiability.h"
+
+#include "slang-ir-diff-jvp.h"
+#include "slang-ir-inst-pass-base.h"
+
+namespace Slang
+{
+
+struct CheckDifferentiabilityPassContext : public InstPassBase
+{
+public:
+    DiagnosticSink* sink;
+    AutoDiffSharedContext sharedContext;
+
+    HashSet<IRInst*> differentiableFunctions;
+
+    CheckDifferentiabilityPassContext(IRModule* inModule, DiagnosticSink* inSink)
+        : InstPassBase(inModule), sink(inSink), sharedContext(inModule->getModuleInst())
+    {}
+
+    IRInst* getSpecializedVal(IRInst* inst)
+    {
+        int loopLimit = 1024;
+        while (inst && inst->getOp() == kIROp_Specialize)
+        {
+            inst = as<IRSpecialize>(inst)->getBase();
+            loopLimit--;
+            if (loopLimit == 0)
+                return inst;
+        }
+        return inst;
+    }
+
+    IRInst* getLeafFunc(IRInst* func)
+    {
+        func = getSpecializedVal(func);
+        if (!func)
+            return nullptr;
+        if (auto genericFunc = as<IRGeneric>(func))
+            return findInnerMostGenericReturnVal(genericFunc);
+        return func;
+    }
+
+    bool _isFuncMarkedForAutoDiff(IRInst* func)
+    {
+        func = getLeafFunc(func);
+        if (!func)
+            return false;
+        for (auto decorations : func->getDecorations())
+        {
+            switch (decorations->getOp())
+            {
+            case kIROp_ForwardDifferentiableDecoration:
+            case kIROp_BackwardDifferentiableDecoration:
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    bool _isDifferentiableFuncImpl(IRInst* func)
+    {
+        func = getLeafFunc(func);
+        if (!func)
+            return false;
+
+        for (auto decorations : func->getDecorations())
+        {
+            switch (decorations->getOp())
+            {
+            case kIROp_ForwardDerivativeDecoration:
+            case kIROp_ForwardDifferentiableDecoration:
+            case kIROp_BackwardDerivativeDecoration:
+            case kIROp_BackwardDifferentiableDecoration:
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool isDifferentiableFunc(IRInst* func)
+    {
+        switch (func->getOp())
+        {
+        case kIROp_ForwardDifferentiate:
+        case kIROp_BackwardDifferentiate:
+            return true;
+        default:
+            break;
+        }
+
+        func = getSpecializedVal(func);
+        if (!func)
+            return false;
+
+        if (differentiableFunctions.Contains(func))
+            return true;
+
+        for (; func; func = func->parent)
+        {
+            if (as<IRGeneric>(func))
+            {
+                return differentiableFunctions.Contains(func);
+            }
+        }
+        return false;
+    }
+
+    bool isBackwardDifferentiableFunc(IRInst* func)
+    {
+        for (auto decorations : func->getDecorations())
+        {
+            switch (decorations->getOp())
+            {
+            case kIROp_BackwardDerivativeDecoration:
+            case kIROp_BackwardDifferentiableDecoration:
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool isDifferentiableType(DifferentiableTypeConformanceContext& context, IRInst* typeInst)
+    {
+        HashSet<IRInst*> processedSet;
+        while (auto ptrType = as<IRPtrTypeBase>(typeInst))
+        {
+            typeInst = ptrType->getValueType();
+            if (!processedSet.Add(typeInst))
+                return false;
+        }
+        if (!typeInst)
+            return false;
+        switch (typeInst->getOp())
+        {
+        case kIROp_FloatType:
+        case kIROp_DifferentialPairType:
+            return true;
+        default:
+            break;
+        }
+        if (context.lookUpConformanceForType(typeInst))
+            return true;
+        // Look for equivalent types.
+        for (auto type : context.differentiableWitnessDictionary)
+        {
+            if (isTypeEqual(type.Key, (IRType*)typeInst))
+            {
+                context.differentiableWitnessDictionary[(IRType*)typeInst] = type.Value;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    int getParamIndexInBlock(IRParam* paramInst)
+    {
+        auto block = as<IRBlock>(paramInst->getParent());
+        if (!block)
+            return -1;
+        int paramIndex = 0;
+        for (auto param : block->getParams())
+        {
+            if (param == paramInst)
+                return paramIndex;
+            paramIndex++;
+        }
+        return -1;
+    }
+
+    bool isInstInFunc(IRInst* inst, IRInst* func)
+    {
+        while (inst)
+        {
+            if (inst == func)
+                return true;
+            inst = inst->parent;
+        }
+        return false;
+    }
+    void processFunc(IRGlobalValueWithCode* funcInst)
+    {
+        if (!_isFuncMarkedForAutoDiff(funcInst))
+            return;
+        if (!funcInst->getFirstBlock())
+            return;
+
+        DifferentiableTypeConformanceContext diffTypeContext(&sharedContext);
+        diffTypeContext.setFunc(funcInst);
+
+        HashSet<IRInst*> produceDiffSet;
+        HashSet<IRInst*> expectDiffSet;
+        int differentiableInputs = 0;
+        int differentiableOutputs = 0;
+        for (auto param : funcInst->getFirstBlock()->getParams())
+        {
+            if (isDifferentiableType(diffTypeContext, param->getFullType()))
+            {
+                if (as<IROutTypeBase>(param->getFullType()))
+                    differentiableOutputs++;
+                if (!as<IROutType>(param->getFullType()))
+                    differentiableInputs++;
+                produceDiffSet.Add(param);
+            }
+        }
+        if (auto funcType = as<IRFuncType>(funcInst->getDataType()))
+        {
+            if (isDifferentiableType(diffTypeContext, funcType->getResultType()))
+                differentiableOutputs++;
+        }
+
+        if (differentiableOutputs == 0)
+            sink->diagnose(funcInst, Diagnostics::differentiableFuncMustHaveOutput);
+        if (differentiableInputs == 0)
+            sink->diagnose(funcInst, Diagnostics::differentiableFuncMustHaveInput);
+
+        auto isInstProducingDiff = [&](IRInst* inst) -> bool
+        {
+            switch (inst->getOp())
+            {
+            case kIROp_FloatLit:
+                return true;
+            case kIROp_Call:
+                return inst->findDecoration<IRNonDifferentiableCallDecoration>() || isDifferentiableFunc(as<IRCall>(inst)->getCallee());
+            case kIROp_Load:
+                // We don't have more knowledge on whether diff is available at the destination address.
+                // Just assume it is producing diff.
+                return isDifferentiableType(diffTypeContext, inst->getDataType());
+            default:
+                // default case is to assume the inst produces a diff value if any
+                // of its operands produces a diff value.
+                for (UInt i = 0; i < inst->getOperandCount(); i++)
+                {
+                    if (produceDiffSet.Contains(inst->getOperand(i)))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        };
+
+        List<IRInst*> expectDiffInstWorkList;
+        OrderedHashSet<IRInst*> expectDiffInstWorkListSet;
+        auto addToExpectDiffWorkList = [&](IRInst* inst)
+        {
+            if (isInstInFunc(inst, funcInst))
+            {
+                if (expectDiffInstWorkListSet.Add(inst))
+                    expectDiffInstWorkList.add(inst);
+            }
+        };
+        // Run data flow analysis and generate `produceDiffSet` and an intial `expectDiffSet`.
+        Index lastProduceDiffCount = 0;
+        do
+        {
+            lastProduceDiffCount = produceDiffSet.Count();
+            for (auto block : funcInst->getBlocks())
+            {
+                if (block != funcInst->getFirstBlock())
+                {
+                    UInt paramIndex = 0;
+                    for (auto param : block->getParams())
+                    {
+                        for (auto p : block->getPredecessors())
+                        {
+                            // A Phi Node is producing diff if any of its candidate values are producing diff.
+                            if (auto branch = as<IRUnconditionalBranch>(p->getTerminator()))
+                            {
+                                if (branch->getArgCount() > paramIndex)
+                                {
+                                    auto arg = branch->getArg(paramIndex);
+                                    if (produceDiffSet.Contains(arg))
+                                    {
+                                        produceDiffSet.Add(param);
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        paramIndex++;
+                    }
+                }
+                for (auto inst : block->getChildren())
+                {
+                    if (isInstProducingDiff(inst))
+                        produceDiffSet.Add(inst);
+                    switch (inst->getOp())
+                    {
+                    case kIROp_Call:
+                        if (isDifferentiableFunc(as<IRCall>(inst)->getCallee()))
+                        {
+                            addToExpectDiffWorkList(inst);
+                        }
+                        break;
+                    case kIROp_Store:
+                    {
+                        auto storeInst = as<IRStore>(inst);
+                        if (isDifferentiableType(diffTypeContext, as<IRStore>(inst)->getPtr()->getDataType()))
+                        {
+                            addToExpectDiffWorkList(storeInst->getVal());
+                        }
+                    }
+                    break;
+                    case kIROp_Return:
+                        if (auto returnVal = as<IRReturn>(inst)->getVal())
+                        {
+                            if (isDifferentiableType(diffTypeContext, returnVal->getDataType()))
+                            {
+                                addToExpectDiffWorkList(inst);
+                            }
+                        }
+                        break;
+                    default:
+                        break;
+                    }
+                }
+            }
+        } while (produceDiffSet.Count() != lastProduceDiffCount);
+
+        // Reverse propagate `expectDiffSet`.
+        for (int i = 0; i < expectDiffInstWorkList.getCount(); i++)
+        {
+            auto inst = expectDiffInstWorkList[i];
+            // Is inst in produceDiffSet?
+            if (!produceDiffSet.Contains(inst))
+            {
+                if (auto call = as<IRCall>(inst))
+                {
+                    sink->diagnose(inst, Diagnostics::lossOfDerivativeDueToCallOfNonDifferentiableFunction, getLeafFunc(call->getCallee()));
+                }
+            }
+            switch (inst->getOp())
+            {
+            case kIROp_Param:
+            {
+                auto block = as<IRBlock>(inst->getParent());
+                if (block != funcInst->getFirstBlock())
+                {
+                    auto paramIndex = getParamIndexInBlock(as<IRParam>(inst));
+                    if (paramIndex != -1)
+                    {
+                        for (auto p : block->getPredecessors())
+                        {
+                            // A Phi Node is producing diff if any of its candidate values are producing diff.
+                            if (auto branch = as<IRUnconditionalBranch>(p->getTerminator()))
+                            {
+                                if (branch->getArgCount() > paramIndex)
+                                {
+                                    auto arg = branch->getArg(paramIndex);
+                                    addToExpectDiffWorkList(arg);
+                                }
+                            }
+                        }
+                    }
+                }
+                break;
+            }
+            default:
+                // Default behavior is to request all differentiable operands to provide differential.
+                for (UInt opIndex = 0; opIndex < inst->getOperandCount(); opIndex++)
+                {
+                    auto operand = inst->getOperand(opIndex);
+                    if (isDifferentiableType(diffTypeContext, operand->getFullType()))
+                    {
+                        addToExpectDiffWorkList(operand);
+                    }
+                }
+            }
+        }
+    }
+
+    void processModule()
+    {
+        // Collect set of differentiable functions.
+        HashSet<UnownedStringSlice> differentiableSymbolNames;
+        for (auto inst : module->getGlobalInsts())
+        {
+            if (_isDifferentiableFuncImpl(inst))
+            {
+                if (auto linkageDecor = inst->findDecoration<IRLinkageDecoration>())
+                    differentiableSymbolNames.Add(linkageDecor->getMangledName());
+                differentiableFunctions.Add(inst);
+            }
+        }
+        for (auto inst : module->getGlobalInsts())
+        {
+            if (auto linkageDecor = inst->findDecoration<IRLinkageDecoration>())
+            {
+                if (differentiableSymbolNames.Contains(linkageDecor->getMangledName()))
+                    differentiableFunctions.Add(inst);
+            }
+        }
+
+        if (!sharedContext.isInterfaceAvailable)
+            return;
+
+        for (auto inst : module->getGlobalInsts())
+        {
+            if (auto genericInst = as<IRGeneric>(inst))
+            {
+                if (auto innerFunc = as<IRGlobalValueWithCode>(findGenericReturnVal(genericInst)))
+                    processFunc(innerFunc);
+            }
+            else if (auto funcInst = as<IRGlobalValueWithCode>(inst))
+            {
+                processFunc(funcInst);
+            }
+        }
+    }
+};
+
+void checkAutoDiffUsages(IRModule* module, DiagnosticSink* sink)
+{
+    CheckDifferentiabilityPassContext context(module, sink);
+    context.processModule();
+}
+
+} // namespace Slang

--- a/source/slang/slang-ir-check-differentiability.cpp
+++ b/source/slang/slang-ir-check-differentiability.cpp
@@ -347,7 +347,7 @@ public:
                             // A Phi Node is producing diff if any of its candidate values are producing diff.
                             if (auto branch = as<IRUnconditionalBranch>(p->getTerminator()))
                             {
-                                if (branch->getArgCount() > paramIndex)
+                                if (branch->getArgCount() > (UInt)paramIndex)
                                 {
                                     auto arg = branch->getArg(paramIndex);
                                     addToExpectDiffWorkList(arg);

--- a/source/slang/slang-ir-check-differentiability.cpp
+++ b/source/slang/slang-ir-check-differentiability.cpp
@@ -222,7 +222,7 @@ public:
             case kIROp_FloatLit:
                 return true;
             case kIROp_Call:
-                return inst->findDecoration<IRNonDifferentiableCallDecoration>() || isDifferentiableFunc(as<IRCall>(inst)->getCallee());
+                return inst->findDecoration<IRTreatAsDifferentiableCallDecoration>() || isDifferentiableFunc(as<IRCall>(inst)->getCallee());
             case kIROp_Load:
                 // We don't have more knowledge on whether diff is available at the destination address.
                 // Just assume it is producing diff.

--- a/source/slang/slang-ir-check-differentiability.h
+++ b/source/slang/slang-ir-check-differentiability.h
@@ -1,0 +1,14 @@
+// slang-ir-check-differentiability.h
+#pragma once
+
+#include "slang-ir.h"
+
+namespace Slang
+{
+struct IRModule;
+class DiagnosticSink;
+
+// Check all auto diff usages are valid.
+void checkAutoDiffUsages(IRModule* module, DiagnosticSink* sink);
+
+} // namespace Slang

--- a/source/slang/slang-ir-diff-jvp.h
+++ b/source/slang/slang-ir-diff-jvp.h
@@ -2,11 +2,162 @@
 #pragma once
 
 #include "slang-ir.h"
+#include "slang-ir-insts.h"
 #include "slang-compiler.h"
 
 namespace Slang
 {
-    struct IRModule;
+    template<typename P, typename D>
+    struct DiffInstPair
+    {
+        P primal;
+        D differential;
+        DiffInstPair() = default;
+        DiffInstPair(P primal, D differential) : primal(primal), differential(differential)
+        {}
+        HashCode getHashCode() const
+        {
+            Hasher hasher;
+            hasher << primal << differential;
+            return hasher.getResult();
+        }
+        bool operator ==(const DiffInstPair& other) const
+        {
+            return primal == other.primal && differential == other.differential;
+        }
+    };
+
+    typedef DiffInstPair<IRInst*, IRInst*> InstPair;
+
+    struct AutoDiffSharedContext
+    {
+        IRModuleInst* moduleInst = nullptr;
+
+        SharedIRBuilder* sharedBuilder = nullptr;
+
+        // A reference to the builtin IDifferentiable interface type.
+        // We use this to look up all the other types (and type exprs)
+        // that conform to a base type.
+        // 
+        IRInterfaceType* differentiableInterfaceType = nullptr;
+
+        // The struct key for the 'Differential' associated type
+        // defined inside IDifferential. We use this to lookup the differential
+        // type in the conformance table associated with the concrete type.
+        // 
+        IRStructKey* differentialAssocTypeStructKey = nullptr;
+
+        // The struct key for the witness that `Differential` associated type conforms to
+        // `IDifferential`.
+        IRStructKey* differentialAssocTypeWitnessStructKey = nullptr;
+
+
+        // The struct key for the 'zero()' associated type
+        // defined inside IDifferential. We use this to lookup the 
+        // implementation of zero() for a given type.
+        // 
+        IRStructKey* zeroMethodStructKey = nullptr;
+
+        // The struct key for the 'add()' associated type
+        // defined inside IDifferential. We use this to lookup the 
+        // implementation of add() for a given type.
+        // 
+        IRStructKey* addMethodStructKey = nullptr;
+
+        IRStructKey* mulMethodStructKey = nullptr;
+
+
+        // Modules that don't use differentiable types
+        // won't have the IDifferentiable interface type available. 
+        // Set to false to indicate that we are uninitialized.
+        // 
+        bool                                    isInterfaceAvailable = false;
+
+
+        AutoDiffSharedContext(IRModuleInst* inModuleInst);
+
+    private:
+
+        IRInst* findDifferentiableInterface();
+
+        IRStructKey* findDifferentialTypeStructKey()
+        {
+            return getIDifferentiableStructKeyAtIndex(0);
+        }
+
+        IRStructKey* findDifferentialTypeWitnessStructKey()
+        {
+            return getIDifferentiableStructKeyAtIndex(1);
+        }
+
+        IRStructKey* findZeroMethodStructKey()
+        {
+            return getIDifferentiableStructKeyAtIndex(2);
+        }
+
+        IRStructKey* findAddMethodStructKey()
+        {
+            return getIDifferentiableStructKeyAtIndex(3);
+        }
+
+        IRStructKey* findMulMethodStructKey()
+        {
+            return getIDifferentiableStructKeyAtIndex(4);
+        }
+
+        IRStructKey* getIDifferentiableStructKeyAtIndex(UInt index);
+    };
+
+    struct DifferentiableTypeConformanceContext
+    {
+        AutoDiffSharedContext* sharedContext;
+
+        IRGlobalValueWithCode* parentFunc = nullptr;
+        OrderedDictionary<IRType*, IRInst*> differentiableWitnessDictionary;
+
+        DifferentiableTypeConformanceContext(AutoDiffSharedContext* shared)
+            : sharedContext(shared)
+        {}
+
+        void setFunc(IRGlobalValueWithCode* func);
+
+
+        // Lookup a witness table for the concreteType. One should exist if concreteType
+        // inherits (successfully) from IDifferentiable.
+        // 
+        IRInst* lookUpConformanceForType(IRInst* type);
+
+        IRInst* lookUpInterfaceMethod(IRBuilder* builder, IRType* origType, IRStructKey* key);
+
+        // Lookup and return the 'Differential' type declared in the concrete type
+        // in order to conform to the IDifferentiable interface.
+        // Note that inside a generic block, this will be a witness table lookup instruction
+        // that gets resolved during the specialization pass.
+        // 
+        IRInst* getDifferentialForType(IRBuilder* builder, IRType* origType)
+        {
+            switch (origType->getOp())
+            {
+            case kIROp_FloatType:
+            case kIROp_HalfType:
+            case kIROp_DoubleType:
+            case kIROp_VectorType:
+                return origType;
+            }
+            return lookUpInterfaceMethod(builder, origType, sharedContext->differentialAssocTypeStructKey);
+        }
+
+        IRInst* getZeroMethodForType(IRBuilder* builder, IRType* origType)
+        {
+            return lookUpInterfaceMethod(builder, origType, sharedContext->zeroMethodStructKey);
+        }
+
+        IRInst* getAddMethodForType(IRBuilder* builder, IRType* origType)
+        {
+            return lookUpInterfaceMethod(builder, origType, sharedContext->addMethodStructKey);
+        }
+
+    };
 
     struct IRJVPDerivativePassOptions
     {

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -736,6 +736,9 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
         /// differential member of a type in its associated differential type.
     INST(DerivativeMemberDecoration, derivativeMemberDecoration, 1, 0)
 
+        /// Marks a call as an intended non differentiable call.
+    INST(NonDifferentiableCallDecoration, nonDifferentiableCallDecoration, 0, 0)
+
         /// Marks a class type as a COM interface implementation, which enables
         /// the witness table to be easily picked up by emit.
     INST(COMWitnessDecoration, COMWitnessDecoration, 1, 0)

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -736,8 +736,8 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
         /// differential member of a type in its associated differential type.
     INST(DerivativeMemberDecoration, derivativeMemberDecoration, 1, 0)
 
-        /// Marks a call as an intended non differentiable call.
-    INST(NonDifferentiableCallDecoration, nonDifferentiableCallDecoration, 0, 0)
+        /// Treat the IRCall as a call to a differentiable function.
+    INST(TreatAsDifferentiableCallDecoration, treatAsDifferentiableCallDecoration, 0, 0)
 
         /// Marks a class type as a COM interface implementation, which enables
         /// the witness table to be easily picked up by emit.

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -572,6 +572,18 @@ struct IRForwardDerivativeDecoration : IRDecoration
     IRInst* getForwardDerivativeFunc() { return getOperand(0); }
 };
 
+
+struct IRBackwardDerivativeDecoration : IRDecoration
+{
+    enum
+    {
+        kOp = kIROp_BackwardDerivativeDecoration
+    };
+    IR_LEAF_ISA(BackwardDerivativeDecoration)
+
+    IRInst* getBackwardDerivativeFunc() { return getOperand(0); }
+};
+
 struct IRBackwardDifferentiableDecoration : IRDecoration
 {
     enum
@@ -581,6 +593,14 @@ struct IRBackwardDifferentiableDecoration : IRDecoration
     IR_LEAF_ISA(BackwardDifferentiableDecoration)
 };
 
+struct IRNonDifferentiableCallDecoration : IRDecoration
+{
+    enum
+    {
+        kOp = kIROp_NonDifferentiableCallDecoration
+    };
+    IR_LEAF_ISA(NonDifferentiableCallDecoration)
+};
 
 struct IRDerivativeMemberDecoration : IRDecoration
 {

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -593,13 +593,13 @@ struct IRBackwardDifferentiableDecoration : IRDecoration
     IR_LEAF_ISA(BackwardDifferentiableDecoration)
 };
 
-struct IRNonDifferentiableCallDecoration : IRDecoration
+struct IRTreatAsDifferentiableCallDecoration : IRDecoration
 {
     enum
     {
-        kOp = kIROp_NonDifferentiableCallDecoration
+        kOp = kIROp_TreatAsDifferentiableCallDecoration
     };
-    IR_LEAF_ISA(NonDifferentiableCallDecoration)
+    IR_LEAF_ISA(TreatAsDifferentiableCallDecoration)
 };
 
 struct IRDerivativeMemberDecoration : IRDecoration

--- a/source/slang/slang-ir-lower-error-handling.cpp
+++ b/source/slang/slang-ir-lower-error-handling.cpp
@@ -90,6 +90,8 @@ struct ErrorHandlingLoweringContext
             args.add(tryCall->getArg(i));
         }
         auto call = builder.emitCallInst(resultType, tryCall->getCallee(), args);
+        tryCall->transferDecorationsTo(call);
+
         auto isFail = builder.emitIsResultError(call);
         auto failBlock = tryCall->getFailureBlock();
         auto successBlock = tryCall->getSuccessBlock();

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -5848,7 +5848,10 @@ namespace Slang
             return static_cast<IRConstant*>(a)->isValueEqual(static_cast<IRConstant*>(b)) &&
                 isTypeEqual(a->getFullType(), b->getFullType());
         }
-
+        if (IRSpecialize::isaImpl(opA) || opA == kIROp_lookup_interface_method)
+        {
+            return _areTypeOperandsEqual(a, b);
+        }
         SLANG_ASSERT(!"Unhandled comparison");
 
         // We can't equate any other type..

--- a/source/slang/slang-language-server-ast-lookup.cpp
+++ b/source/slang/slang-language-server-ast-lookup.cpp
@@ -426,7 +426,7 @@ public:
         }
         return dispatchIfNotNull(expr->baseFunction);
     }
-    bool visitNoDiffExpr(NoDiffExpr* expr)
+    bool visitDiffDecorateExpr(DiffDecorateExpr* expr)
     {
         return dispatchIfNotNull(expr->innerExpr);
     }

--- a/source/slang/slang-language-server-ast-lookup.cpp
+++ b/source/slang/slang-language-server-ast-lookup.cpp
@@ -426,7 +426,7 @@ public:
         }
         return dispatchIfNotNull(expr->baseFunction);
     }
-    bool visitDiffDecorateExpr(DiffDecorateExpr* expr)
+    bool visitTreatAsDifferentiableExpr(TreatAsDifferentiableExpr* expr)
     {
         return dispatchIfNotNull(expr->innerExpr);
     }

--- a/source/slang/slang-language-server-ast-lookup.cpp
+++ b/source/slang/slang-language-server-ast-lookup.cpp
@@ -426,6 +426,10 @@ public:
         }
         return dispatchIfNotNull(expr->baseFunction);
     }
+    bool visitNoDiffExpr(NoDiffExpr* expr)
+    {
+        return dispatchIfNotNull(expr->innerExpr);
+    }
 };
 
 struct ASTLookupStmtVisitor : public StmtVisitor<ASTLookupStmtVisitor, bool>

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -11,6 +11,7 @@
 #include "slang-ir-diff-jvp.h"
 #include "slang-ir-inline.h"
 #include "slang-ir-insts.h"
+#include "slang-ir-check-differentiability.h"
 #include "slang-ir-missing-return.h"
 #include "slang-ir-sccp.h"
 #include "slang-ir-ssa.h"
@@ -8997,6 +8998,9 @@ RefPtr<IRModule> generateIRForTranslationUnit(
     // `unreachable` instructions remain.
 
     checkForMissingReturns(module, compileRequest->getSink());
+
+    // Check for invalid differentiable function body.
+    checkAutoDiffUsages(module, compileRequest->getSink());
 
     // The "mandatory" optimization passes may make use of the
     // `IRHighLevelDeclDecoration` type to relate IR instructions

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -3114,7 +3114,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
                 baseVal.val));
     }
 
-    LoweredValInfo visitNoDiffExpr(NoDiffExpr* expr)
+    LoweredValInfo visitDiffDecorateExpr(DiffDecorateExpr* expr)
     {
         auto baseVal = lowerSubExpr(expr->innerExpr);
         SLANG_ASSERT(baseVal.flavor == LoweredValInfo::Flavor::Simple);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -3114,6 +3114,17 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
                 baseVal.val));
     }
 
+    LoweredValInfo visitNoDiffExpr(NoDiffExpr* expr)
+    {
+        auto baseVal = lowerSubExpr(expr->innerExpr);
+        SLANG_ASSERT(baseVal.flavor == LoweredValInfo::Flavor::Simple);
+        if (auto call = as<IRCall>(baseVal.val))
+        {
+            getBuilder()->addDecoration(call, kIROp_NonDifferentiableCallDecoration);
+        }
+        return baseVal;
+    }
+
     // Emit IR to denote the forward-mode derivative
     // of the inner func-expr. This will be resolved 
     // to a concrete function during the derivative 

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -3114,14 +3114,11 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
                 baseVal.val));
     }
 
-    LoweredValInfo visitDiffDecorateExpr(DiffDecorateExpr* expr)
+    LoweredValInfo visitTreatAsDifferentiableExpr(TreatAsDifferentiableExpr* expr)
     {
         auto baseVal = lowerSubExpr(expr->innerExpr);
         SLANG_ASSERT(baseVal.flavor == LoweredValInfo::Flavor::Simple);
-        if (auto call = as<IRCall>(baseVal.val))
-        {
-            getBuilder()->addDecoration(call, kIROp_NonDifferentiableCallDecoration);
-        }
+        getBuilder()->addDecoration(baseVal.val, kIROp_TreatAsDifferentiableCallDecoration);
         return baseVal;
     }
 

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -5086,9 +5086,9 @@ namespace Slang
         return tryExpr;
     }
 
-    static NodeBase* parseDiffDecorateExpr(Parser* parser, void* /*userData*/)
+    static NodeBase* parseTreatAsDifferentiableExpr(Parser* parser, void* /*userData*/)
     {
-        auto noDiffExpr = parser->astBuilder->create<DiffDecorateExpr>();
+        auto noDiffExpr = parser->astBuilder->create<TreatAsDifferentiableExpr>();
         noDiffExpr->innerExpr = parser->ParseLeafExpression();
         noDiffExpr->scope = parser->currentScope;
         return noDiffExpr;
@@ -6678,7 +6678,7 @@ namespace Slang
         _makeParseExpr("nullptr", parseNullPtrExpr),
         _makeParseExpr("none", parseNoneExpr),
         _makeParseExpr("try",     parseTryExpr),
-        _makeParseExpr("no_diff", parseDiffDecorateExpr),
+        _makeParseExpr("no_diff", parseTreatAsDifferentiableExpr),
         _makeParseExpr("__TaggedUnion", parseTaggedUnionType),
         _makeParseExpr("__fwd_diff", parseForwardDifferentiate),
         _makeParseExpr("__bwd_diff", parseBackwardDifferentiate)

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -5086,9 +5086,9 @@ namespace Slang
         return tryExpr;
     }
 
-    static NodeBase* parseNoDiffExpr(Parser* parser, void* /*userData*/)
+    static NodeBase* parseDiffDecorateExpr(Parser* parser, void* /*userData*/)
     {
-        auto noDiffExpr = parser->astBuilder->create<NoDiffExpr>();
+        auto noDiffExpr = parser->astBuilder->create<DiffDecorateExpr>();
         noDiffExpr->innerExpr = parser->ParseLeafExpression();
         noDiffExpr->scope = parser->currentScope;
         return noDiffExpr;
@@ -6678,7 +6678,7 @@ namespace Slang
         _makeParseExpr("nullptr", parseNullPtrExpr),
         _makeParseExpr("none", parseNoneExpr),
         _makeParseExpr("try",     parseTryExpr),
-        _makeParseExpr("no_diff", parseNoDiffExpr),
+        _makeParseExpr("no_diff", parseDiffDecorateExpr),
         _makeParseExpr("__TaggedUnion", parseTaggedUnionType),
         _makeParseExpr("__fwd_diff", parseForwardDifferentiate),
         _makeParseExpr("__bwd_diff", parseBackwardDifferentiate)

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -5086,6 +5086,14 @@ namespace Slang
         return tryExpr;
     }
 
+    static NodeBase* parseNoDiffExpr(Parser* parser, void* /*userData*/)
+    {
+        auto noDiffExpr = parser->astBuilder->create<NoDiffExpr>();
+        noDiffExpr->innerExpr = parser->ParseLeafExpression();
+        noDiffExpr->scope = parser->currentScope;
+        return noDiffExpr;
+    }
+
     static bool _isFinite(double value)
     {
         // Lets type pun double to uint64_t, so we can detect special double values
@@ -6670,6 +6678,7 @@ namespace Slang
         _makeParseExpr("nullptr", parseNullPtrExpr),
         _makeParseExpr("none", parseNoneExpr),
         _makeParseExpr("try",     parseTryExpr),
+        _makeParseExpr("no_diff", parseNoDiffExpr),
         _makeParseExpr("__TaggedUnion", parseTaggedUnionType),
         _makeParseExpr("__fwd_diff", parseForwardDifferentiate),
         _makeParseExpr("__bwd_diff", parseBackwardDifferentiate)

--- a/source/slang/slang-serialize-misc-type-info.h
+++ b/source/slang/slang-serialize-misc-type-info.h
@@ -188,7 +188,11 @@ struct SerialTypeInfo<const DiagnosticInfo*>
     }
 };
 
-
+// DeclAssociation
+template <>
+struct SerialTypeInfo<DeclAssociation> : SerialIdentityTypeInfo<DeclAssociation> {};
+template <>
+struct SerialTypeInfo<DeclAssociationKind> : public SerialConvertTypeInfo<DeclAssociationKind, uint8_t> {};
 
 } // namespace Slang
 

--- a/tests/autodiff/differential-method-synthesis.slang
+++ b/tests/autodiff/differential-method-synthesis.slang
@@ -31,7 +31,7 @@ A f(A a)
     aout.y = 2 * a.b.x;
     aout.b.x = 5 * a.b.x;
 
-    return nonDiff(aout);
+    return no_diff(nonDiff(aout));
 }
 
 [numthreads(1, 1, 1)]

--- a/tests/diagnostics/autodiff-data-flow.slang
+++ b/tests/diagnostics/autodiff-data-flow.slang
@@ -1,0 +1,38 @@
+//DIAGNOSTIC_TEST:SIMPLE:
+
+float nonDiff(float x)
+{
+    return x;
+}
+
+[ForwardDifferentiable]
+float f(float x)
+{
+    float val = 0;
+    if (x > 5)
+        val = x + 1;
+    else
+        val = nonDiff(x * 2.0f);
+    // Not all path propagates derivatives through.
+    return val;
+}
+
+// error: function does not return a differentiable value.
+[ForwardDifferentiable]
+void g(float x)
+{
+    float val = 0;
+    if (x > 5)
+        val = x + 1;
+    return;
+}
+
+
+[ForwardDifferentiable]
+float h(float x)
+{
+    float val = 0;
+    // no diagnostic by clarifying intention.
+    val = no_diff(nonDiff(x * 2.0f));
+    return val;
+}

--- a/tests/diagnostics/autodiff-data-flow.slang.expected
+++ b/tests/diagnostics/autodiff-data-flow.slang.expected
@@ -1,0 +1,11 @@
+result code = -1
+standard error = {
+tests/diagnostics/autodiff-data-flow.slang(15): error 41020: derivative cannot be propagated through call to non-differentiable function `nonDiff`, use 'no_diff' to clarify intention.
+        val = nonDiff(x * 2.0f);
+                     ^
+tests/diagnostics/autodiff-data-flow.slang(22): error 41021: a differentiable function must have at least one differentiable output.
+void g(float x)
+     ^
+}
+standard output = {
+}

--- a/tests/diagnostics/autodiff.slang
+++ b/tests/diagnostics/autodiff.slang
@@ -24,7 +24,15 @@ void g(float x)
     float val = 0;
     if (x > 5)
         val = x + 1;
-    else
-        val = nonDiff(x * 2.0f);
     return;
+}
+
+
+[ForwardDifferentiable]
+float h(float x)
+{
+    float val = 0;
+    // no diagnostic by clarifying intention.
+    val = no_diff(nonDiff(x * 2.0f));
+    return val;
 }

--- a/tests/diagnostics/autodiff.slang
+++ b/tests/diagnostics/autodiff.slang
@@ -1,0 +1,30 @@
+//DIAGNOSTIC_TEST:SIMPLE:
+
+float nonDiff(float x)
+{
+    return x;
+}
+
+[ForwardDifferentiable]
+float f(float x)
+{
+    float val = 0;
+    if (x > 5)
+        val = x + 1;
+    else
+        val = nonDiff(x * 2.0f);
+    // Not all path propagates derivatives through.
+    return val;
+}
+
+// error: function does not return a differentiable value.
+[ForwardDifferentiable]
+void g(float x)
+{
+    float val = 0;
+    if (x > 5)
+        val = x + 1;
+    else
+        val = nonDiff(x * 2.0f);
+    return;
+}

--- a/tests/diagnostics/autodiff.slang
+++ b/tests/diagnostics/autodiff.slang
@@ -11,28 +11,17 @@ float f(float x)
     float val = 0;
     if (x > 5)
         val = x + 1;
-    else
-        val = nonDiff(x * 2.0f);
-    // Not all path propagates derivatives through.
     return val;
 }
 
-// error: function does not return a differentiable value.
 [ForwardDifferentiable]
-void g(float x)
+float m(float x)
 {
-    float val = 0;
-    if (x > 5)
-        val = x + 1;
-    return;
+    float x1 = no_diff x; // invalid use of no_diff here.
+    return no_diff f(x);  // no_diff on a differentiable call has no meaning.
 }
 
-
-[ForwardDifferentiable]
-float h(float x)
+float n(float x)
 {
-    float val = 0;
-    // no diagnostic by clarifying intention.
-    val = no_diff(nonDiff(x * 2.0f));
-    return val;
+    return no_diff nonDiff(x); // no_diff in a non-differentiable function
 }

--- a/tests/diagnostics/autodiff.slang.expected
+++ b/tests/diagnostics/autodiff.slang.expected
@@ -1,6 +1,6 @@
 result code = -1
 standard error = {
-tests/diagnostics/autodiff.slang(15): error 41020: derivative cannot be propagated through call to non-differnetiable function `nonDiff`, use 'no_diff' to clarify intention.
+tests/diagnostics/autodiff.slang(15): error 41020: derivative cannot be propagated through call to non-differentiable function `nonDiff`, use 'no_diff' to clarify intention.
         val = nonDiff(x * 2.0f);
                      ^
 tests/diagnostics/autodiff.slang(22): error 41021: a differentiable function must have at least one differentiable output.

--- a/tests/diagnostics/autodiff.slang.expected
+++ b/tests/diagnostics/autodiff.slang.expected
@@ -1,11 +1,14 @@
 result code = -1
 standard error = {
-tests/diagnostics/autodiff.slang(15): error 41020: derivative cannot be propagated through call to non-differentiable function `nonDiff`, use 'no_diff' to clarify intention.
-        val = nonDiff(x * 2.0f);
-                     ^
-tests/diagnostics/autodiff.slang(22): error 41021: a differentiable function must have at least one differentiable output.
-void g(float x)
-     ^
+tests/diagnostics/autodiff.slang(20): error 38031: 'no_diff' can only be used to decorate a call.
+    float x1 = no_diff x; // invalid use of no_diff here.
+               ^~~~~~~
+tests/diagnostics/autodiff.slang(21): error 38032: use 'no_diff' on a call to a differentiable function has no meaning.
+    return no_diff f(x);  // no_diff on a differentiable call has no meaning.
+           ^~~~~~~
+tests/diagnostics/autodiff.slang(26): error 38033: cannot use 'no_diff' in a non-differentiable function.
+    return no_diff nonDiff(x); // no_diff in a non-differentiable function
+           ^~~~~~~
 }
 standard output = {
 }

--- a/tests/diagnostics/autodiff.slang.expected
+++ b/tests/diagnostics/autodiff.slang.expected
@@ -1,0 +1,11 @@
+result code = -1
+standard error = {
+tests/diagnostics/autodiff.slang(15): error 41020: derivative cannot be propagated through call to non-differnetiable function `nonDiff`, use 'no_diff' to clarify intention.
+        val = nonDiff(x * 2.0f);
+                     ^
+tests/diagnostics/autodiff.slang(22): error 41021: a differentiable function must have at least one differentiable output.
+void g(float x)
+     ^
+}
+standard output = {
+}


### PR DESCRIPTION
- Add an IR validation pass to check for unintended call to non-differential functions (and losing derivatives).
- Add `no_diff` keyword to allow the user to clarify the intention and silence the diagnostic.