### PR TITLE
Make differentiable data-flow pass recognize interface methods.

### DIFF
--- a/tests/autodiff/generic-autodiff-1.slang
+++ b/tests/autodiff/generic-autodiff-1.slang
@@ -23,7 +23,7 @@ struct A : IInterface
 [ForwardDifferentiable]
 float sqr<T:IInterface>(inout T obj, float x)
 {
-    return obj.sample() + x*x;
+    return (no_diff obj.sample()) + x*x;
 }
 
 [numthreads(1, 1, 1)]


### PR DESCRIPTION
This makes the differentiable call data-flow pass to correctly determine the differentiability of an interface method call.