### PR TITLE
Fix output type detection for multi-part extensions

### DIFF
--- a/source/compiler-core/slang-artifact-desc-util.h
+++ b/source/compiler-core/slang-artifact-desc-util.h
@@ -53,9 +53,6 @@ struct ArtifactDescUtil
         /// True if artifact  appears to be linkable
     static bool isLinkable(const ArtifactDesc& desc);
 
-        /// Try to determine the desc from just a file extension (passed without .)
-    static ArtifactDesc getDescFromExtension(const UnownedStringSlice& slice);
-
         /// Try to determine the desc from a path
     static ArtifactDesc getDescFromPath(const UnownedStringSlice& slice);
 

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -264,6 +264,13 @@ namespace Slang
         }
     }
 
+    bool Path::hasExtension(const UnownedStringSlice& path, const UnownedStringSlice& ext)
+    {
+        return path.getLength() > ext.getLength()
+            && path[path.getLength() - 1 - ext.getLength()] == '.'
+            && path.endsWith(ext);
+    }
+
     String Path::getParentDirectory(const String& path)
     {
         Index pos = findLastSeparatorIndex(path);

--- a/source/core/slang-io.h
+++ b/source/core/slang-io.h
@@ -125,6 +125,10 @@ namespace Slang
 
         static String getPathExt(const String& path) { return getPathExt(path.getUnownedSlice()); }
         static UnownedStringSlice getPathExt(const UnownedStringSlice& path);
+        // hasExtension allow for dots in the matched extension, whereas comparing
+        // with the result of getPathExt will only compare against the very
+        // last extension
+        static bool hasExtension(const UnownedStringSlice& path, const UnownedStringSlice& ext);
 
         static String getParentDirectory(const String& path);
 

--- a/source/core/slang-type-text-util.cpp
+++ b/source/core/slang-type-text-util.cpp
@@ -2,6 +2,7 @@
 #include "slang-type-text-util.h"
 
 #include "slang-string-util.h"
+#include "slang-io.h"
 
 namespace Slang
 {
@@ -236,15 +237,23 @@ static const ArchiveTypeInfo s_archiveTypeInfos[] =
     return UnownedStringSlice::fromLiteral("unknown");
 }
 
-/* static */SlangCompileTarget TypeTextUtil::findCompileTargetFromExtension(const UnownedStringSlice& slice)
+/* static */SlangCompileTarget TypeTextUtil::findCompileTargetFromFilename(const UnownedStringSlice& filename)
 {
-    if (slice.getLength())
+    if (filename.getLength())
     {
         for (const auto& info : s_compileTargetInfos)
         {
-            if (StringUtil::indexOfInSplit(UnownedStringSlice(info.extensions), ',', slice) >= 0)
+            List<UnownedStringSlice> exts;
+            StringUtil::split(UnownedStringSlice(info.extensions), ',', exts);
+            for(const auto& ext : exts)
             {
-                return info.target;
+                // Ignore any empty extensions,
+                // Make sure that this is actually an extension of our filename
+                // by checking for a preceding period
+                if(ext.getLength() && Path::hasExtension(filename, ext))
+                {
+                    return info.target;
+                }
             }
         }
     }

--- a/source/core/slang-type-text-util.h
+++ b/source/core/slang-type-text-util.h
@@ -33,9 +33,9 @@ struct TypeTextUtil
         /// Get the compilers name
     static UnownedStringSlice getPassThroughName(SlangPassThrough passThru);
 
-        /// Given a file extension determines suitable target
+        /// Given a file name determines suitable target from the extension
         /// If doesn't match any target will return SLANG_TARGET_UNKNOWN
-    static SlangCompileTarget findCompileTargetFromExtension(const UnownedStringSlice& slice);
+    static SlangCompileTarget findCompileTargetFromFilename(const UnownedStringSlice& filename);
 
         /// Given a name suitable target
         /// If doesn't match any target will return SLANG_TARGET_UNKNOWN

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -338,7 +338,7 @@ struct OptionsParser
         }
         else
         {
-            const SlangCompileTarget target = TypeTextUtil::findCompileTargetFromExtension(ext.getUnownedSlice());
+            const SlangCompileTarget target = TypeTextUtil::findCompileTargetFromFilename(path.getUnownedSlice());
             // If the target is not found the value returned is Unknown. This is okay because
             // we allow an unknown-format `-o`, assuming we get a target format
             // from another argument.


### PR DESCRIPTION
For example .spv.asm or .dxil.asm