### PR TITLE
Rename IR opcodes to unify style.

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -447,7 +447,7 @@ struct Ptr
             __store(__getElementPtr(this, index), newValue);
         }
 
-        __intrinsic_op($(kIROp_getElementPtr))
+        __intrinsic_op($(kIROp_GetElementPtr))
         ref;
     }
 };
@@ -458,10 +458,10 @@ T __load<T>(Ptr<T> ptr);
 __intrinsic_op($(kIROp_Store))
 void __store<T>(Ptr<T> ptr, T val);
 
-__intrinsic_op($(kIROp_getElementPtr))
+__intrinsic_op($(kIROp_GetElementPtr))
 Ptr<T> __getElementPtr<T>(Ptr<T> ptr, int index);
 
-__intrinsic_op($(kIROp_getElementPtr))
+__intrinsic_op($(kIROp_GetElementPtr))
 Ptr<T> __getElementPtr<T>(Ptr<T> ptr, int64_t index);
 
 __generic<T>
@@ -631,22 +631,22 @@ __intrinsic_type($(kIROp_StringType))
 struct String
 {
     __target_intrinsic(cpp)
-    __intrinsic_op($(kIROp_makeString))
+    __intrinsic_op($(kIROp_MakeString))
     __init(int val);
     __target_intrinsic(cpp)
-    __intrinsic_op($(kIROp_makeString))
+    __intrinsic_op($(kIROp_MakeString))
     __init(uint val);
     __target_intrinsic(cpp)
-    __intrinsic_op($(kIROp_makeString))
+    __intrinsic_op($(kIROp_MakeString))
     __init(int64_t val);
     __target_intrinsic(cpp)
-    __intrinsic_op($(kIROp_makeString))
+    __intrinsic_op($(kIROp_MakeString))
     __init(uint64_t val);
     __target_intrinsic(cpp)
-    __intrinsic_op($(kIROp_makeString))
+    __intrinsic_op($(kIROp_MakeString))
     __init(float val);
     __target_intrinsic(cpp)
-    __intrinsic_op($(kIROp_makeString))
+    __intrinsic_op($(kIROp_MakeString))
     __init(double val);
 
     __target_intrinsic(cpp)
@@ -762,7 +762,7 @@ struct vector
 
         /// Initialize a vector where all elements have the same scalar `value`.
     __implicit_conversion($(kConversionCost_ScalarToVector))
-    __intrinsic_op($(kIROp_constructVectorFromScalar))
+    __intrinsic_op($(kIROp_MakeVectorFromScalar))
     __init(T value);
 
         /// Initialize a vector from a value of the same type
@@ -853,7 +853,7 @@ struct Vertices
     __subscript(uint index) -> T
     {
         // TODO: Ellie make sure these remains write only
-        __intrinsic_op($(kIROp_getElementPtr))
+        __intrinsic_op($(kIROp_GetElementPtr))
         ref;
     }
 };
@@ -866,7 +866,7 @@ struct Indices
     __subscript(uint index) -> T
     {
         // TODO: Ellie: It's illegal to not write out the whole primitive at once, should we use set over ref?
-        __intrinsic_op($(kIROp_getElementPtr))
+        __intrinsic_op($(kIROp_GetElementPtr))
         ref;
     }
 };
@@ -878,7 +878,7 @@ struct Primitives
 {
     __subscript(uint index) -> T
     {
-        __intrinsic_op($(kIROp_getElementPtr))
+        __intrinsic_op($(kIROp_GetElementPtr))
         ref;
     }
 };
@@ -889,49 +889,49 @@ struct Primitives
 
 __generic<T> __extension vector<T, 2>
 {
-    __intrinsic_op($(kIROp_makeVector))
+    __intrinsic_op($(kIROp_MakeVector))
     __init(T x, T y);
 }
 __generic<T> __extension vector<T, 3>
 {
-    __intrinsic_op($(kIROp_makeVector))
+    __intrinsic_op($(kIROp_MakeVector))
     __init(T x, T y, T z);
 
     [__unsafeForceInlineEarly]
-    __intrinsic_op($(kIROp_makeVector))
+    __intrinsic_op($(kIROp_MakeVector))
     __init(vector<T,2> xy, T z);
 
     [__unsafeForceInlineEarly]
-    __intrinsic_op($(kIROp_makeVector))
+    __intrinsic_op($(kIROp_MakeVector))
     __init(T x, vector<T,2> yz);
 }
 __generic<T> __extension vector<T, 4>
 {
-    __intrinsic_op($(kIROp_makeVector))
+    __intrinsic_op($(kIROp_MakeVector))
     __init(T x, T y, T z, T w);
 
     [__unsafeForceInlineEarly]
-    __intrinsic_op($(kIROp_makeVector))
+    __intrinsic_op($(kIROp_MakeVector))
     __init(vector<T,2> xy, T z, T w);
 
     [__unsafeForceInlineEarly]
-    __intrinsic_op($(kIROp_makeVector))
+    __intrinsic_op($(kIROp_MakeVector))
     __init(T x, vector<T,2> yz, T w);
 
     [__unsafeForceInlineEarly]
-    __intrinsic_op($(kIROp_makeVector))
+    __intrinsic_op($(kIROp_MakeVector))
     __init(T x, T y, vector<T,2> zw);
 
     [__unsafeForceInlineEarly]
-    __intrinsic_op($(kIROp_makeVector))
+    __intrinsic_op($(kIROp_MakeVector))
     __init(vector<T,2> xy, vector<T,2> zw);
 
     [__unsafeForceInlineEarly]
-    __intrinsic_op($(kIROp_makeVector))
+    __intrinsic_op($(kIROp_MakeVector))
     __init(vector<T,3> xyz, T w);
 
     [__unsafeForceInlineEarly]
-    __intrinsic_op($(kIROp_makeVector))
+    __intrinsic_op($(kIROp_MakeVector))
     __init(T x, vector<T,3> yzw);
 }
 
@@ -2119,7 +2119,7 @@ __intrinsic_op(0)
 __prefix Ptr<T> operator&(__ref T value);
 
 __generic<T>
-__intrinsic_op($(kIROp_getElementPtr))
+__intrinsic_op($(kIROp_GetElementPtr))
 Ptr<T> operator+(Ptr<T> value, int64_t offset);
 
 __generic<T>

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -1107,9 +1107,9 @@ bool CLikeSourceEmitter::shouldFoldInstIntoUseSites(IRInst* inst)
     // in pointers directly.
     //
     case kIROp_FieldAddress:
-    case kIROp_getElementPtr:
+    case kIROp_GetElementPtr:
     case kIROp_Specialize:
-    case kIROp_lookup_interface_method:
+    case kIROp_LookupWitness:
     case kIROp_GetValueFromBoundInterface:
         return true;
     }
@@ -1132,8 +1132,8 @@ bool CLikeSourceEmitter::shouldFoldInstIntoUseSites(IRInst* inst)
     // them to initializer lists, which aren't allowed in
     // general expression contexts.
     //
-    case kIROp_makeStruct:
-    case kIROp_makeArray:
+    case kIROp_MakeStruct:
+    case kIROp_MakeArray:
     case kIROp_swizzleSet:
         return false;
 
@@ -1697,7 +1697,7 @@ void CLikeSourceEmitter::emitCallExpr(IRCall* inst, EmitOpInfo outerPrec)
     handleRequiredCapabilities(funcValue);
 
     // Detect if this is a call into a COM interface method.
-    if (funcValue->getOp() == kIROp_lookup_interface_method)
+    if (funcValue->getOp() == kIROp_LookupWitness)
     {
         auto operand0Type = funcValue->getOperand(0)->getDataType();
         switch (operand0Type->getOp())
@@ -1776,7 +1776,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
         emitSimpleValue(inst);
         break;
 
-    case kIROp_makeVector:
+    case kIROp_MakeVector:
     case kIROp_MakeMatrix:
     case kIROp_MakeMatrixFromScalar:
     case kIROp_MatrixReshape:
@@ -1794,7 +1794,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
         m_writer->emit(getName(inst->getDataType()));
         m_writer->emit("()");
         break;
-    case kIROp_makeUInt64:
+    case kIROp_MakeUInt64:
         m_writer->emit("((");
         emitType(inst->getDataType());
         m_writer->emit("(");
@@ -1803,7 +1803,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
         emitOperand(inst->getOperand(0), getInfo(EmitOp::General));
         m_writer->emit(")");
         break;
-    case kIROp_constructVectorFromScalar:
+    case kIROp_MakeVectorFromScalar:
     case kIROp_CastPtrToInt:
     case kIROp_CastIntToPtr:
     {
@@ -2006,7 +2006,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
             m_writer->emit("->getBuffer()");
             break;
         }
-    case kIROp_makeString:
+    case kIROp_MakeString:
         {
             m_writer->emit("String(");
             emitOperand(inst->getOperand(0), EmitOpInfo());
@@ -2047,8 +2047,8 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
         m_writer->emit(".detach()");
         break;
     }
-    case kIROp_getElement:
-    case kIROp_getElementPtr:
+    case kIROp_GetElement:
+    case kIROp_GetElementPtr:
     case kIROp_ImageSubscript:
         // HACK: deal with translation of GLSL geometry shader input arrays.
         if(auto decoration = inst->getOperand(0)->findDecoration<IRGLSLOuterArrayDecoration>())
@@ -2065,7 +2065,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
         }
         else
         {
-            if (inst->getOp() == kIROp_getElementPtr && doesTargetSupportPtrTypes())
+            if (inst->getOp() == kIROp_GetElementPtr && doesTargetSupportPtrTypes())
             {
                 const auto info = getInfo(EmitOp::Prefix);
                 needClose = maybeEmitParens(outerPrec, info);
@@ -2155,8 +2155,8 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
         m_writer->emit(getName(inst));
         break;
 
-    case kIROp_makeArray:
-    case kIROp_makeStruct:
+    case kIROp_MakeArray:
+    case kIROp_MakeStruct:
         {
             // TODO: initializer-list syntax may not always
             // be appropriate, depending on the context
@@ -3484,7 +3484,7 @@ void CLikeSourceEmitter::ensureInstOperandsRec(ComputeEmitActionsContext* ctx, I
     case kIROp_NativePtrType:
         requiredLevel = EmitAction::ForwardDeclaration;
         break;
-    case kIROp_lookup_interface_method:
+    case kIROp_LookupWitness:
     case kIROp_FieldExtract:
     case kIROp_FieldAddress:
     {

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -2400,7 +2400,7 @@ bool CPPSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOut
             // try doing automatically
             return _tryEmitInstExprAsIntrinsic(inst, inOuterPrec);
         }
-        case kIROp_lookup_interface_method:
+        case kIROp_LookupWitness:
         {
             emitInstExpr(inst->getOperand(0), inOuterPrec);
             m_writer->emit("->");
@@ -2420,7 +2420,7 @@ bool CPPSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOut
             m_writer->emit(")");
             return true;
         }
-        case kIROp_getAddr:
+        case kIROp_GetAddr:
         {
             // Once we clean up the pointer emitting logic, we can
             // just use GetElementAddress instruction in place of

--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -529,7 +529,7 @@ void CUDASourceEmitter::_emitInitializerListValue(IRType* dstType, IRInst* value
     switch (value->getOp())
     {
         case kIROp_MakeMatrix:
-        case kIROp_makeVector:
+        case kIROp_MakeVector:
         {
             IRType* type = value->getDataType();
 
@@ -714,7 +714,7 @@ bool CUDASourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
             }
             break;
         }
-        case kIROp_makeArray:
+        case kIROp_MakeArray:
         {
             IRType* dataType = inst->getDataType();
             IRArrayType* arrayType = as<IRArrayType>(dataType);

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -1474,7 +1474,7 @@ bool GLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
 {
     switch (inst->getOp())
     {
-        case kIROp_constructVectorFromScalar:
+        case kIROp_MakeVectorFromScalar:
         {
             // Simple constructor call
             EmitOpInfo outerPrec = inOuterPrec;

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -433,7 +433,7 @@ bool HLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
 {
     switch (inst->getOp())
     {
-        case kIROp_makeVector:
+        case kIROp_MakeVector:
         case kIROp_MakeMatrix:
         {
             if (inst->getOperandCount() == 1)

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1591,9 +1591,9 @@ struct SPIRVEmitContext
             return emitFieldAddress(parent, as<IRFieldAddress>(inst));
         case kIROp_FieldExtract:
             return emitFieldExtract(parent, as<IRFieldExtract>(inst));
-        case kIROp_getElementPtr:
+        case kIROp_GetElementPtr:
             return emitGetElementPtr(parent, as<IRGetElementPtr>(inst));
-        case kIROp_getElement:
+        case kIROp_GetElement:
             return emitGetElement(parent, as<IRGetElement>(inst));
         case kIROp_Load:
             return emitLoad(parent, as<IRLoad>(inst));

--- a/source/slang/slang-hlsl-intrinsic-set.cpp
+++ b/source/slang/slang-hlsl-intrinsic-set.cpp
@@ -255,7 +255,7 @@ SlangResult HLSLIntrinsicSet::makeIntrinsic(IRInst* inst, HLSLIntrinsic& out)
     // All the special cases
     switch (inst->getOp())
     {
-        case kIROp_constructVectorFromScalar:
+        case kIROp_MakeVectorFromScalar:
         case kIROp_MakeMatrixFromScalar:
         {
             SLANG_ASSERT(inst->getOperandCount() == 1);
@@ -297,7 +297,7 @@ SlangResult HLSLIntrinsicSet::makeIntrinsic(IRInst* inst, HLSLIntrinsic& out)
             }
             return SLANG_FAIL;
         }
-        case kIROp_makeVector:
+        case kIROp_MakeVector:
         case kIROp_VectorReshape:
         {
             if (inst->getOperandCount() == 1 && as<IRBasicType>(inst->getOperand(0)->getDataType()))
@@ -355,7 +355,7 @@ SlangResult HLSLIntrinsicSet::makeIntrinsic(IRInst* inst, HLSLIntrinsic& out)
             }
             break;
         }
-        case kIROp_getElement:
+        case kIROp_GetElement:
         {
             IRInst* target = inst->getOperand(0);
             IRType* targetType = target->getDataType();
@@ -367,7 +367,7 @@ SlangResult HLSLIntrinsicSet::makeIntrinsic(IRInst* inst, HLSLIntrinsic& out)
             }
             break;
         }
-        case kIROp_getElementPtr:
+        case kIROp_GetElementPtr:
         {
             IRInst* target = inst->getOperand(0);
             IRType* targetType = target->getDataType();
@@ -581,7 +581,7 @@ HLSLIntrinsic::Op HLSLIntrinsicOpLookup::getOpForIROp(IRInst* inst)
         case kIROp_Not:     return Op::Not;
         case kIROp_BitNot:  return Op::BitNot;
 
-        case kIROp_constructVectorFromScalar: return Op::ConstructFromScalar;
+        case kIROp_MakeVectorFromScalar: return Op::ConstructFromScalar;
 
         default:            return Op::Invalid;
     }

--- a/source/slang/slang-hlsl-intrinsic-set.h
+++ b/source/slang/slang-hlsl-intrinsic-set.h
@@ -17,7 +17,7 @@ generic 'construction' for built in types including vectors and matrices.
 For the moment the cpp emit code, determines what kind of construct is needed, and has special handling for ConstructConvert and
 ConstructFromScalar.
 
-That currently we do not see constructVectorFromScalar - for example when we do...
+That currently we do not see MakeVectorFromScalar - for example when we do...
 
 int2 fromScalar = 1;
 
@@ -25,7 +25,7 @@ This appears as a construction from an int.
 
 That the better thing to do would be that there were IR instructions for the specific types of construction. I suppose there is a question
 about whether there should be separate instructions for vector/matrix, or emit code should just use the destination type. In practice I think
-it's fine that there isn't an instruction separating vector/matrix. That being the case I guess we arguably don't need constructVectorFromScalar,
+it's fine that there isn't an instruction separating vector/matrix. That being the case I guess we arguably don't need MakeVectorFromScalar,
 just constructXXXFromScalar. Would be good if there was a suitable name to encompass vector/matrix.
 */
 #define SLANG_HLSL_INTRINSIC_OP(x) \

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -1584,7 +1584,7 @@ InstPair ForwardDerivativeTranscriber::transcribeInst(IRBuilder* builder, IRInst
 
     case kIROp_CastIntToFloat:
     case kIROp_CastFloatToInt:
-    case kIROp_makeVector:
+    case kIROp_MakeVector:
     case kIROp_MakeMatrix:
     case kIROp_MakeMatrixFromScalar:
     case kIROp_MatrixReshape:
@@ -1593,7 +1593,7 @@ InstPair ForwardDerivativeTranscriber::transcribeInst(IRBuilder* builder, IRInst
     case kIROp_FloatCast:
         return transcribeConstruct(builder, origInst);
 
-    case kIROp_lookup_interface_method:
+    case kIROp_LookupWitness:
         return transcribeLookupInterfaceMethod(builder, as<IRLookupWitnessMethod>(origInst));
 
     case kIROp_Call:
@@ -1602,7 +1602,7 @@ InstPair ForwardDerivativeTranscriber::transcribeInst(IRBuilder* builder, IRInst
     case kIROp_swizzle:
         return transcribeSwizzle(builder, as<IRSwizzle>(origInst));
     
-    case kIROp_constructVectorFromScalar:
+    case kIROp_MakeVectorFromScalar:
     case kIROp_MakeTuple:
         return transcribeByPassthrough(builder, origInst);
 
@@ -1620,8 +1620,8 @@ InstPair ForwardDerivativeTranscriber::transcribeInst(IRBuilder* builder, IRInst
     case kIROp_FieldExtract:
     case kIROp_FieldAddress:
         return transcribeFieldExtract(builder, origInst);
-    case kIROp_getElement:
-    case kIROp_getElementPtr:
+    case kIROp_GetElement:
+    case kIROp_GetElementPtr:
         return transcribeGetElement(builder, origInst);
     
     case kIROp_loop:
@@ -1750,7 +1750,7 @@ struct ForwardDerivativePass : public InstPassBase
                         {
                         case kIROp_Func:
                         case kIROp_Specialize:
-                        case kIROp_lookup_interface_method:
+                        case kIROp_LookupWitness:
                             autoDiffWorkList.add(inst);
                             break;
                         default:

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -220,7 +220,7 @@ IRInst* DifferentialPairTypeBuilder::_createDiffPairType(IRType* origBaseType, I
 {
     switch (origBaseType->getOp())
     {
-    case kIROp_lookup_interface_method:
+    case kIROp_LookupWitness:
     case kIROp_Specialize:
     case kIROp_Param:
         return nullptr;

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -297,7 +297,7 @@ struct ByteAddressBufferLegalizationContext
             auto elementCountInst = as<IRIntLit>(arrayType->getElementCount());
             if( elementCountInst )
             {
-                return emitLegalSequenceLoad(type, buffer, baseOffset, immediateOffset, kIROp_makeArray, arrayType->getElementType(), elementCountInst->getValue());
+                return emitLegalSequenceLoad(type, buffer, baseOffset, immediateOffset, kIROp_MakeArray, arrayType->getElementType(), elementCountInst->getValue());
             }
         }
         else if( auto matType = as<IRMatrixType>(type) )
@@ -335,7 +335,7 @@ struct ByteAddressBufferLegalizationContext
             auto elementCountInst = as<IRIntLit>(vecType->getElementCount());
             if( m_options.scalarizeVectorLoadStore && elementCountInst)
             {
-                return emitLegalSequenceLoad(type, buffer, baseOffset, immediateOffset, kIROp_makeVector, vecType->getElementType(), elementCountInst->getValue());
+                return emitLegalSequenceLoad(type, buffer, baseOffset, immediateOffset, kIROp_MakeVector, vecType->getElementType(), elementCountInst->getValue());
             }
 
             // If we aren't scalarizing a vetor load then we next need
@@ -621,7 +621,7 @@ struct ByteAddressBufferLegalizationContext
             return getEquivalentStructuredBufferParam(elementType, byteAddressBufferParam);
         }
 
-        if( byteAddressBuffer->getOp() == kIROp_getElement )
+        if( byteAddressBuffer->getOp() == kIROp_GetElement )
         {
             // If the code is fetching the byte-address buffer from an
             // array, then we need to create an "equivalent" structured

--- a/source/slang/slang-ir-cleanup-void.cpp
+++ b/source/slang/slang-ir-cleanup-void.cpp
@@ -36,7 +36,7 @@ namespace Slang
             switch (inst->getOp())
             {
             case kIROp_Call:
-            case kIROp_makeStruct:
+            case kIROp_MakeStruct:
                 {
                     // Remove void argument.
                     List<IRInst*> newArgs;
@@ -135,7 +135,7 @@ namespace Slang
             switch(inst->getOp())
             {
             case kIROp_Load:
-            case kIROp_getElement:
+            case kIROp_GetElement:
             case kIROp_GetOptionalValue:
             case kIROp_FieldExtract:
             case kIROp_GetTupleElement:

--- a/source/slang/slang-ir-constexpr.cpp
+++ b/source/slang/slang-ir-constexpr.cpp
@@ -89,8 +89,8 @@ bool opCanBeConstExpr(IROp op)
     case kIROp_Lsh:
     case kIROp_Rsh:
     case kIROp_Select:
-    case kIROp_constructVectorFromScalar:
-    case kIROp_makeVector:
+    case kIROp_MakeVectorFromScalar:
+    case kIROp_MakeVector:
     case kIROp_MakeMatrix:
     case kIROp_MakeMatrixFromScalar:
     case kIROp_MatrixReshape:
@@ -112,11 +112,11 @@ bool opCanBeConstExpr(IROp op)
     case kIROp_MakeOptionalValue:
     case kIROp_MakeResultError:
     case kIROp_MakeResultValue:
-    case kIROp_makeString:
-    case kIROp_makeUInt64:
-    case kIROp_makeArray:
+    case kIROp_MakeString:
+    case kIROp_MakeUInt64:
+    case kIROp_MakeArray:
     case kIROp_swizzle:
-    case kIROp_getElement:
+    case kIROp_GetElement:
     case kIROp_FieldExtract:
     case kIROp_ExtractExistentialType:
     case kIROp_ExtractExistentialValue:

--- a/source/slang/slang-ir-generics-lowering-context.cpp
+++ b/source/slang/slang-ir-generics-lowering-context.cpp
@@ -16,7 +16,7 @@ namespace Slang
         case kIROp_ThisType:
         case kIROp_AssociatedType:
         case kIROp_InterfaceType:
-        case kIROp_lookup_interface_method:
+        case kIROp_LookupWitness:
             return true;
         case kIROp_Specialize:
         {
@@ -288,7 +288,7 @@ namespace Slang
 
             return tupleType;
         }
-        case kIROp_lookup_interface_method:
+        case kIROp_LookupWitness:
         {
             auto lookupInterface = static_cast<IRLookupWitnessMethod*>(paramType);
             auto witnessTableType = as<IRWitnessTableType>(

--- a/source/slang/slang-ir-hoist-constants.cpp
+++ b/source/slang/slang-ir-hoist-constants.cpp
@@ -62,10 +62,10 @@ struct HoistConstantPass : InstPassBase
                 case kIROp_Rsh:
                 case kIROp_MatrixReshape:
                 case kIROp_VectorReshape:
-                case kIROp_makeVector:
+                case kIROp_MakeVector:
                 case kIROp_MakeMatrix:
                 case kIROp_MakeMatrixFromScalar:
-                case kIROp_constructVectorFromScalar:
+                case kIROp_MakeVectorFromScalar:
                 case kIROp_MakeOptionalNone:
                 case kIROp_MakeOptionalValue:
                 case kIROp_MakeDifferentialPair:

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -279,20 +279,20 @@ INST(DifferentialPairGetDifferential, GetDifferential, 1, 0)
 INST(DifferentialPairGetPrimal, GetPrimal, 1, 0)
 
 INST(Specialize, specialize, 2, 0)
-INST(lookup_interface_method, lookup_interface_method, 2, 0)
+INST(LookupWitness, lookupWitness, 2, 0)
 INST(GetSequentialID, GetSequentialID, 1, 0)
 INST(lookup_witness_table, lookup_witness_table, 2, 0)
 INST(BindGlobalGenericParam, bind_global_generic_param, 2, 0)
 INST(AllocObj, allocObj, 0, 0)
 
-INST(makeUInt64, makeUInt64, 2, 0)
-INST(makeVector, makeVector, 0, 0)
+INST(MakeUInt64, makeUInt64, 2, 0)
+INST(MakeVector, makeVector, 0, 0)
 INST(MakeMatrix, makeMatrix, 0, 0)
 INST(MakeMatrixFromScalar, makeMatrixFromScalar, 1, 0)
 INST(MatrixReshape, matrixReshape, 1, 0)
 INST(VectorReshape, vectorReshape, 1, 0)
-INST(makeArray, makeArray, 0, 0)
-INST(makeStruct, makeStruct, 0, 0)
+INST(MakeArray, makeArray, 0, 0)
+INST(MakeStruct, makeStruct, 0, 0)
 INST(MakeTuple, makeTuple, 0, 0)
 INST(GetTupleElement, getTupleElement, 2, 0)
 INST(MakeResultValue, makeResultValue, 1, 0)
@@ -326,15 +326,15 @@ INST(Store, store, 2, 0)
 INST(FieldExtract, get_field, 2, 0)
 INST(FieldAddress, get_field_addr, 2, 0)
 
-INST(getElement, getElement, 2, 0)
-INST(getElementPtr, getElementPtr, 2, 0)
-INST(getAddr, getAddr, 1, 0)
+INST(GetElement, getElement, 2, 0)
+INST(GetElementPtr, getElementPtr, 2, 0)
+INST(GetAddr, getAddr, 1, 0)
 
 // Get an unowned NativeString from a String.
 INST(getNativeStr, getNativeStr, 1, 0)
 
 // Make String from a NativeString.
-INST(makeString, makeString, 1, 0)
+INST(MakeString, makeString, 1, 0)
 
 // Get a native ptr from a ComPtr or RefPtr
 INST(GetNativePtr, getNativePtr, 1, 0)
@@ -404,7 +404,7 @@ INST(MeshOutputRef, meshOutputRef, 2, 0)
 
 // Construct a vector from a scalar
 //
-// %dst = constructVectorFromScalar %T %N %val
+// %dst = MakeVectorFromScalar %T %N %val
 //
 // where
 // - `T` is a `Type`
@@ -412,7 +412,7 @@ INST(MeshOutputRef, meshOutputRef, 2, 0)
 // - `val` is a `T`
 // - dst is a `Vec<T,N>`
 //
-INST(constructVectorFromScalar, constructVectorFromScalar, 3, 0)
+INST(MakeVectorFromScalar, MakeVectorFromScalar, 3, 0)
 
 // A swizzle of a vector:
 //

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -729,7 +729,7 @@ struct IRLookupWitnessMethod : IRInst
     IRInst* getWitnessTable() { return witnessTable.get(); }
     IRInst* getRequirementKey() { return requirementKey.get(); }
 
-    IR_LEAF_ISA(lookup_interface_method)
+    IR_LEAF_ISA(LookupWitness)
 };
 
 // Returns the sequential ID of an RTTI object.
@@ -1613,14 +1613,14 @@ struct IRFieldAddress : IRInst
 
 struct IRGetElement : IRInst
 {
-    IR_LEAF_ISA(getElement);
+    IR_LEAF_ISA(GetElement);
     IRInst* getBase() { return getOperand(0); }
     IRInst* getIndex() { return getOperand(1); }
 };
 
 struct IRGetElementPtr : IRInst
 {
-    IR_LEAF_ISA(getElementPtr);
+    IR_LEAF_ISA(GetElementPtr);
     IRInst* getBase() { return getOperand(0); }
     IRInst* getIndex() { return getOperand(1); }
 };
@@ -1639,7 +1639,7 @@ struct IRGetManagedPtrWriteRef : IRInst
 
 struct IRGetAddress : IRInst
 {
-    IR_LEAF_ISA(getAddr);
+    IR_LEAF_ISA(GetAddr);
 };
 
 struct IRImageSubscript : IRInst

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -1629,10 +1629,10 @@ static LegalVal legalizeInst(
     case kIROp_FieldExtract:
         return legalizeFieldExtract(context, type, args[0], args[1]);
 
-    case kIROp_getElement:
+    case kIROp_GetElement:
         return legalizeGetElement(context, type, args[0], args[1]);
 
-    case kIROp_getElementPtr:
+    case kIROp_GetElementPtr:
         return legalizeGetElementPtr(context, type, args[0], args[1]);
 
     case kIROp_Store:
@@ -1642,7 +1642,7 @@ static LegalVal legalizeInst(
         return legalizeCall(context, (IRCall*)inst);
     case kIROp_Return:
         return legalizeRetVal(context, args[0], (IRReturn*)inst);
-    case kIROp_makeStruct:
+    case kIROp_MakeStruct:
         return legalizeMakeStruct(
             context,
             type,

--- a/source/slang/slang-ir-liveness.cpp
+++ b/source/slang/slang-ir-liveness.cpp
@@ -829,7 +829,7 @@ void LivenessContext::_findAliasesAndAccesses(IRInst* root)
             // We want to find instructions that access the root
             switch (cur->getOp())
             {
-                case kIROp_getElementPtr:
+                case kIROp_GetElementPtr:
                 {
                     base = static_cast<IRGetElementPtr*>(cur)->getBase();
                     accessType = AccessType::Alias;
@@ -841,7 +841,7 @@ void LivenessContext::_findAliasesAndAccesses(IRInst* root)
                     accessType = AccessType::Alias;
                     break;
                 }
-                case kIROp_getAddr:
+                case kIROp_GetAddr:
                 {
                     IRGetAddress* getAddr = static_cast<IRGetAddress*>(cur);
                     base = getAddr->getOperand(0);
@@ -882,7 +882,7 @@ void LivenessContext::_findAliasesAndAccesses(IRInst* root)
                     accessType = AccessType::Access;
                     break;
                 }
-                case kIROp_getElement:
+                case kIROp_GetElement:
                 case kIROp_FieldExtract:
                 {
                     // These will never take place on the var which is accessed through a pointer, so can be ignored

--- a/source/slang/slang-ir-lower-com-methods.cpp
+++ b/source/slang/slang-ir-lower-com-methods.cpp
@@ -31,7 +31,7 @@ struct ComMethodLoweringContext : public InstPassBase
         SLANG_ASSERT(callee);
 
         IRLookupWitnessMethod* innerMostCallee = callee;
-        while (innerMostCallee->getOperand(0)->getOp() == kIROp_lookup_interface_method)
+        while (innerMostCallee->getOperand(0)->getOp() == kIROp_LookupWitness)
         {
             innerMostCallee = as<IRLookupWitnessMethod>(innerMostCallee->getOperand(0));
         }
@@ -83,7 +83,7 @@ struct ComMethodLoweringContext : public InstPassBase
         auto funcValue = inst->getOperand(0);
 
         // Detect if this is a call into a COM interface method.
-        if (funcValue->getOp() == kIROp_lookup_interface_method)
+        if (funcValue->getOp() == kIROp_LookupWitness)
         {
             const auto operand0TypeOp = funcValue->getOperand(0)->getDataType();
             if (auto tableType = as<IRWitnessTableTypeBase>(operand0TypeOp))

--- a/source/slang/slang-ir-lower-generic-call.cpp
+++ b/source/slang/slang-ir-lower-generic-call.cpp
@@ -261,7 +261,7 @@ namespace Slang
                     return;
                 SLANG_UNEXPECTED("Nested generics specialization.");
             }
-            else if (loweredFunc->getOp() == kIROp_lookup_interface_method)
+            else if (loweredFunc->getOp() == kIROp_LookupWitness)
             {
                 lowerCallToInterfaceMethod(
                     callInst, cast<IRLookupWitnessMethod>(loweredFunc), specializeInst);

--- a/source/slang/slang-ir-lower-generics.cpp
+++ b/source/slang/slang-ir-lower-generics.cpp
@@ -39,7 +39,7 @@ namespace Slang
             for (auto use = rtti.Value->firstUse; use; use = nextUse)
             {
                 nextUse = use->nextUse;
-                if (use->getUser()->getOp() == kIROp_getAddr)
+                if (use->getUser()->getOp() == kIROp_GetAddr)
                 {
                     use->getUser()->replaceUsesWith(idOperand);
                 }

--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -59,7 +59,7 @@ struct PeepholeContext : InstPassBase
             }
             break;
         case kIROp_FieldExtract:
-            if (inst->getOperand(0)->getOp() == kIROp_makeStruct)
+            if (inst->getOperand(0)->getOp() == kIROp_MakeStruct)
             {
                 auto field = as<IRFieldExtract>(inst)->field.get();
                 Index fieldIndex = -1;
@@ -200,7 +200,7 @@ struct PeepholeContext : InstPassBase
                 }
             }
             break;
-        case kIROp_lookup_interface_method:
+        case kIROp_LookupWitness:
             {
                 if (inst->getOperand(0)->getOp() == kIROp_WitnessTable)
                 {

--- a/source/slang/slang-ir-specialize-dispatch.cpp
+++ b/source/slang/slang-ir-specialize-dispatch.cpp
@@ -29,7 +29,7 @@ IRFunc* specializeDispatchFunction(SharedGenericsLoweringContext* sharedContext,
         case kIROp_Call:
             callInst = cast<IRCall>(inst);
             break;
-        case kIROp_lookup_interface_method:
+        case kIROp_LookupWitness:
             lookupInst = cast<IRLookupWitnessMethod>(inst);
             break;
         case kIROp_Return:

--- a/source/slang/slang-ir-specialize-dynamic-associatedtype-lookup.cpp
+++ b/source/slang/slang-ir-specialize-dynamic-associatedtype-lookup.cpp
@@ -185,7 +185,7 @@ struct AssociatedTypeLookupSpecializationContext
         // Replace all `lookup_interface_method():IRWitnessTable` with call to specialized functions.
         workOnModule(sharedContext, [this](IRInst* inst)
         {
-            if (inst->getOp() == kIROp_lookup_interface_method)
+            if (inst->getOp() == kIROp_LookupWitness)
             {
                 processLookupInterfaceMethodInst(cast<IRLookupWitnessMethod>(inst));
             }

--- a/source/slang/slang-ir-specialize-function-call.cpp
+++ b/source/slang/slang-ir-specialize-function-call.cpp
@@ -38,7 +38,7 @@ bool FunctionCallSpecializeCondition::isParamSuitableForSpecialization(IRParam* 
         // of the indexing operation is also
         // suitable for specialization.
         //
-        if (arg->getOp() == kIROp_getElement || arg->getOp() == kIROp_Load)
+        if (arg->getOp() == kIROp_GetElement || arg->getOp() == kIROp_Load)
         {
             auto base = arg->getOperand(0);
 
@@ -511,7 +511,7 @@ struct FunctionParameterSpecializationContext
             //
             ioInfo.key.vals.add(oldGlobalParam);
         }
-        else if( oldArg->getOp() == kIROp_getElement )
+        else if( oldArg->getOp() == kIROp_GetElement )
         {
             // This is the case where the `oldArg` is
             // in the form `oldBase[oldIndex]`
@@ -632,7 +632,7 @@ struct FunctionParameterSpecializationContext
             //
             return globalParam;
         }
-        else if( oldArg->getOp() == kIROp_getElement )
+        else if( oldArg->getOp() == kIROp_GetElement )
         {
             // This is the case where the argument is
             // in the form `oldBase[oldIndex]`.

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -515,7 +515,7 @@ struct SpecializationContext
             // Certain instructions cannot ever be considered
             // fully specialized because they should never
             // be substituted into a generic as its arguments.
-        case kIROp_lookup_interface_method:
+        case kIROp_LookupWitness:
         case kIROp_ExtractExistentialType:
         case kIROp_BindExistentialsType:
             break;
@@ -588,7 +588,7 @@ struct SpecializationContext
             //
             return maybeSpecializeGeneric(cast<IRSpecialize>(inst));
 
-        case kIROp_lookup_interface_method:
+        case kIROp_LookupWitness:
             // The remaining case we need to consider here for generics
             // is when we have a `lookup_witness_method` instruction
             // that is being applied to a concrete witness table,
@@ -625,9 +625,9 @@ struct SpecializationContext
         case kIROp_FieldAddress:
             return maybeSpecializeFieldAddress(as<IRFieldAddress>(inst));
 
-        case kIROp_getElement:
+        case kIROp_GetElement:
             return maybeSpecializeGetElement(as<IRGetElement>(inst));
-        case kIROp_getElementPtr:
+        case kIROp_GetElementPtr:
             return maybeSpecializeGetElementAddress(as<IRGetElementPtr>(inst));
 
         case kIROp_BindExistentialsType:

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -276,7 +276,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             case kIROp_Call:
                 processCall(as<IRCall>(inst));
                 break;
-            case kIROp_getElementPtr:
+            case kIROp_GetElementPtr:
                 processGetElementPtr(as<IRGetElementPtr>(inst));
                 break;
             case kIROp_FieldAddress:

--- a/source/slang/slang-ir-ssa.cpp
+++ b/source/slang/slang-ir-ssa.cpp
@@ -120,7 +120,7 @@ bool allUsesLeadToLoads(IRInst* inst)
         case kIROp_Load:
             break;
 
-        case kIROp_getElementPtr:
+        case kIROp_GetElementPtr:
         case kIROp_FieldAddress:
             {
                 // Sanity check: the address being used should
@@ -211,7 +211,7 @@ bool isPromotableVar(
             }
             break;
 
-        case kIROp_getElementPtr:
+        case kIROp_GetElementPtr:
         case kIROp_FieldAddress:
             {
                 // Sanity check: the address being used should
@@ -280,7 +280,7 @@ IRVar* asPromotableVarAccessChain(
         return asPromotableVar(context, value);
 
     case kIROp_FieldAddress:
-    case kIROp_getElementPtr:
+    case kIROp_GetElementPtr:
         return asPromotableVarAccessChain(context, value->getOperand(0));
 
     default:
@@ -331,7 +331,7 @@ IRInst* applyAccessChain(
             return extractInst;
         }
 
-    case kIROp_getElementPtr:
+    case kIROp_GetElementPtr:
         {
             SLANG_ASSERT(context->instsToRemove.contains(accessChain));
 
@@ -878,7 +878,7 @@ void processBlock(
             }
             break;
 
-        case kIROp_getElementPtr:
+        case kIROp_GetElementPtr:
         case kIROp_FieldAddress:
             {
                 auto  ptrArg = ii->getOperand(0);

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3189,7 +3189,7 @@ namespace Slang
 
         return findOrEmitHoistableInst(
             type,
-            kIROp_lookup_interface_method,
+            kIROp_LookupWitness,
             2,
             args);
     }
@@ -3408,7 +3408,7 @@ namespace Slang
             auto inner = emitDefaultConstruct(as<IRVectorType>(actualType)->getElementType(), fallback);
             if (!inner)
                 return nullptr;
-            return emitIntrinsicInst(type, kIROp_constructVectorFromScalar, 1, &inner);
+            return emitIntrinsicInst(type, kIROp_MakeVectorFromScalar, 1, &inner);
         }
         case kIROp_MatrixType:
         {
@@ -3544,7 +3544,7 @@ namespace Slang
     IRInst* IRBuilder::emitMakeUInt64(IRInst* low, IRInst* high)
     {
         IRInst* args[2] = {low, high};
-        return emitIntrinsicInst(getUInt64Type(), kIROp_makeUInt64, 2, args);
+        return emitIntrinsicInst(getUInt64Type(), kIROp_MakeUInt64, 2, args);
     }
 
     IRInst* IRBuilder::emitMakeRTTIObject(IRInst* typeInst)
@@ -3575,7 +3575,7 @@ namespace Slang
 
     IRInst* IRBuilder::emitMakeString(IRInst* nativeStr)
     {
-        return emitIntrinsicInst(getStringType(), kIROp_makeString, 1, &nativeStr);
+        return emitIntrinsicInst(getStringType(), kIROp_MakeString, 1, &nativeStr);
     }
 
     IRInst* IRBuilder::emitGetNativeString(IRInst* str)
@@ -3677,7 +3677,7 @@ namespace Slang
         UInt            argCount,
         IRInst* const* args)
     {
-        return emitIntrinsicInst(type, kIROp_makeVector, argCount, args);
+        return emitIntrinsicInst(type, kIROp_MakeVector, argCount, args);
     }
 
     IRInst* IRBuilder::emitDifferentialPairGetDifferential(IRType* diffType, IRInst* diffPair)
@@ -3732,7 +3732,7 @@ namespace Slang
         UInt            argCount,
         IRInst* const* args)
     {
-        return emitIntrinsicInst(type, kIROp_makeArray, argCount, args);
+        return emitIntrinsicInst(type, kIROp_MakeArray, argCount, args);
     }
 
     IRInst* IRBuilder::emitMakeStruct(
@@ -3740,7 +3740,7 @@ namespace Slang
         UInt            argCount,
         IRInst* const* args)
     {
-        return emitIntrinsicInst(type, kIROp_makeStruct, argCount, args);
+        return emitIntrinsicInst(type, kIROp_MakeStruct, argCount, args);
     }
 
     IRInst* IRBuilder::emitMakeExistential(
@@ -4283,7 +4283,7 @@ namespace Slang
     {
         auto inst = createInst<IRFieldAddress>(
             this,
-            kIROp_getElement,
+            kIROp_GetElement,
             type,
             base,
             index);
@@ -4299,7 +4299,7 @@ namespace Slang
     {
         auto inst = createInst<IRFieldAddress>(
             this,
-            kIROp_getElementPtr,
+            kIROp_GetElementPtr,
             type,
             basePtr,
             index);
@@ -4314,7 +4314,7 @@ namespace Slang
     {
         auto inst = createInst<IRGetAddress>(
             this,
-            kIROp_getAddr,
+            kIROp_GetAddr,
             type,
             value);
 
@@ -6090,7 +6090,7 @@ namespace Slang
             return static_cast<IRConstant*>(a)->isValueEqual(static_cast<IRConstant*>(b)) &&
                 isTypeEqual(a->getFullType(), b->getFullType());
         }
-        if (IRSpecialize::isaImpl(opA) || opA == kIROp_lookup_interface_method)
+        if (IRSpecialize::isaImpl(opA) || opA == kIROp_LookupWitness)
         {
             return _areTypeOperandsEqual(a, b);
         }
@@ -6537,19 +6537,19 @@ namespace Slang
         case kIROp_undefined:
         case kIROp_DefaultConstruct:
         case kIROp_Specialize:
-        case kIROp_lookup_interface_method:
+        case kIROp_LookupWitness:
         case kIROp_GetSequentialID:
-        case kIROp_getAddr:
+        case kIROp_GetAddr:
         case kIROp_GetValueFromBoundInterface:
-        case kIROp_makeUInt64:
-        case kIROp_makeVector:
+        case kIROp_MakeUInt64:
+        case kIROp_MakeVector:
         case kIROp_MakeMatrix:
         case kIROp_MakeMatrixFromScalar:
         case kIROp_MatrixReshape:
         case kIROp_VectorReshape:
-        case kIROp_makeArray:
-        case kIROp_makeStruct:
-        case kIROp_makeString:
+        case kIROp_MakeArray:
+        case kIROp_MakeStruct:
+        case kIROp_MakeString:
         case kIROp_getNativeStr:
         case kIROp_MakeResultError:
         case kIROp_MakeResultValue:
@@ -6566,10 +6566,10 @@ namespace Slang
         case kIROp_ImageSubscript:
         case kIROp_FieldExtract:
         case kIROp_FieldAddress:
-        case kIROp_getElement:
-        case kIROp_getElementPtr:
+        case kIROp_GetElement:
+        case kIROp_GetElementPtr:
         case kIROp_MeshOutputRef:
-        case kIROp_constructVectorFromScalar:
+        case kIROp_MakeVectorFromScalar:
         case kIROp_swizzle:
         case kIROp_swizzleSet:  // Doesn't actually "set" anything - just returns the resulting vector
         case kIROp_Add:


### PR DESCRIPTION
 - `constructVectorFromScalar` -> `MakeVectorFromScalar`
 - `makeXXX` -> `MakeXXX`
 - `lookup_interface_method` -> `LookupWitness`
 - `getElementPtr` -> `GetElementPtr`
 - `getElement` -> `GetElement`