### PR TITLE
Add `IRAttributedOperand` to allow decorating operands with attributes.

### DIFF
--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -1364,7 +1364,7 @@ void CPPSourceEmitter::emitSpecializedOperationDefinition(const HLSLIntrinsic* s
     SLANG_ASSERT(!"Unhandled");
 }
 
-void CPPSourceEmitter::emitCall(const HLSLIntrinsic* specOp, IRInst* inst, const IRUse* operands, int numOperands, const EmitOpInfo& inOuterPrec)
+void CPPSourceEmitter::emitCall(const HLSLIntrinsic* specOp, IRInst* inst, IROperandListBase operands, int numOperands, const EmitOpInfo& inOuterPrec)
 {
     typedef HLSLIntrinsic::Op Op;
 
@@ -1383,7 +1383,7 @@ void CPPSourceEmitter::emitCall(const HLSLIntrinsic* specOp, IRInst* inst, const
                 writer->emit(_getTypeName(retType));
                 writer->emitChar('(');
 
-                emitOperand(operands[0].get(), getInfo(EmitOp::General));
+                emitOperand(operands[0], getInfo(EmitOp::General));
 
                 writer->emitChar(')');
                 return;
@@ -1476,7 +1476,7 @@ void CPPSourceEmitter::emitCall(const HLSLIntrinsic* specOp, IRInst* inst, const
                 {
                     writer->emit(", ");
                 }
-                emitOperand(operands[i].get(), getInfo(EmitOp::General));
+                emitOperand(operands[i], getInfo(EmitOp::General));
             }
 
             writer->emitChar(')');
@@ -2207,7 +2207,7 @@ void CPPSourceEmitter::emitIntrinsicCallExprImpl(
         SLANG_ASSERT(argCount == 2 || argCount == 3);
 
         // If the first item is either a matrix or a vector, we use 'getAt' logic
-        IRType* targetType = args[0].get()->getDataType();
+        IRType* targetType = args[0]->getDataType();
         if (targetType->getOp() == kIROp_VectorType || targetType->getOp() == kIROp_MatrixType)
         {
             // Work out the intrinsic used
@@ -2249,9 +2249,9 @@ void CPPSourceEmitter::emitIntrinsicCallExprImpl(
             {
                 auto prec = getInfo(EmitOp::Postfix);
                 bool needCloseSubscript = maybeEmitParens(_outerPrec, prec);
-                emitOperand(args[0].get(), leftSide(_outerPrec, prec));
+                emitOperand(args[0], leftSide(_outerPrec, prec));
                 m_writer->emit("[");
-                emitOperand(args[1].get(), getInfo(EmitOp::General));
+                emitOperand(args[1], getInfo(EmitOp::General));
                 m_writer->emit("]");
                 maybeCloseParens(needCloseSubscript);
             };
@@ -2268,7 +2268,7 @@ void CPPSourceEmitter::emitIntrinsicCallExprImpl(
             if (argCount == 3)
             {
                 m_writer->emit(" = ");
-                emitOperand(args[2].get(), getInfo(EmitOp::General));
+                emitOperand(args[2], getInfo(EmitOp::General));
             }
         }
 

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -39,7 +39,7 @@ public:
     };
 
     virtual void useType(IRType* type);
-    virtual void emitCall(const HLSLIntrinsic* specOp, IRInst* inst, const IRUse* operands, int numOperands, const EmitOpInfo& inOuterPrec);
+    virtual void emitCall(const HLSLIntrinsic* specOp, IRInst* inst, IROperandListBase operands, int numOperands, const EmitOpInfo& inOuterPrec);
     virtual void emitTypeDefinition(IRType* type);
     virtual void emitSpecializedOperationDefinition(const HLSLIntrinsic* specOp);
     

--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -436,7 +436,7 @@ void CUDASourceEmitter::emitGlobalRTTISymbolPrefix()
     m_writer->emit("__constant__ ");
 }
 
-void CUDASourceEmitter::emitCall(const HLSLIntrinsic* specOp, IRInst* inst, const IRUse* operands, int numOperands, const EmitOpInfo& inOuterPrec)
+void CUDASourceEmitter::emitCall(const HLSLIntrinsic* specOp, IRInst* inst, IROperandListBase operands, int numOperands, const EmitOpInfo& inOuterPrec)
 {
     switch (specOp->op)
     {
@@ -463,7 +463,7 @@ void CUDASourceEmitter::emitCall(const HLSLIntrinsic* specOp, IRInst* inst, cons
                         {
                             writer->emit(", ");
                         }
-                        emitOperand(operands[i].get(), getInfo(EmitOp::General));
+                        emitOperand(operands[i], getInfo(EmitOp::General));
                     }
 
                     writer->emitChar(')');
@@ -573,7 +573,7 @@ void CUDASourceEmitter::_emitInitializerListValue(IRType* dstType, IRInst* value
                     {
                         // Handle if all are explicitly defined
                         IRType* elementType = matType->getElementType();                                        
-                        IRUse* operands = value->getOperands();
+                        auto operands = value->getOperands();
 
                         // Emit the braces for the Matrix struct, and the array of rows
                         m_writer->emit("{\n");
@@ -584,7 +584,7 @@ void CUDASourceEmitter::_emitInitializerListValue(IRType* dstType, IRInst* value
                         {
                             if (i != 0) m_writer->emit(", ");
                             _emitInitializerList(elementType, operands, colCount);
-                            operands += colCount;
+                            operands = operands + colCount;
                         }
                         m_writer->dedent();
                         m_writer->emit("\n}");
@@ -603,7 +603,7 @@ void CUDASourceEmitter::_emitInitializerListValue(IRType* dstType, IRInst* value
     emitOperand(value, getInfo(EmitOp::General));
 }
 
-void CUDASourceEmitter::_emitInitializerList(IRType* elementType, IRUse* operands, Index operandCount)
+void CUDASourceEmitter::_emitInitializerList(IRType* elementType, IROperandListBase operands, Index operandCount)
 {
     m_writer->emit("{\n");
     m_writer->indent();
@@ -611,7 +611,7 @@ void CUDASourceEmitter::_emitInitializerList(IRType* elementType, IRUse* operand
     for (Index i = 0; i < operandCount; ++i)
     {
         if (i != 0) m_writer->emit(", ");
-        _emitInitializerListValue(elementType, operands[i].get());
+        _emitInitializerListValue(elementType, operands[i]);
     }
 
     m_writer->dedent();

--- a/source/slang/slang-emit-cuda.h
+++ b/source/slang/slang-emit-cuda.h
@@ -78,7 +78,7 @@ protected:
     virtual void emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount) SLANG_OVERRIDE;
     virtual void emitVarDecorationsImpl(IRInst* varDecl) SLANG_OVERRIDE;
     virtual void emitMatrixLayoutModifiersImpl(IRVarLayout* layout) SLANG_OVERRIDE;
-    virtual void emitCall(const HLSLIntrinsic* specOp, IRInst* inst, const IRUse* operands, int numOperands, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;
+    virtual void emitCall(const HLSLIntrinsic* specOp, IRInst* inst, IROperandListBase operands, int numOperands, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;
     virtual void emitFunctionPreambleImpl(IRInst* inst) SLANG_OVERRIDE;
     virtual String generateEntryPointNameImpl(IREntryPointDecoration* entryPointDecor) SLANG_OVERRIDE;
 
@@ -104,7 +104,7 @@ protected:
 
     SlangResult _calcCUDATextureTypeName(IRTextureTypeBase* texType, StringBuilder& outName);
 
-    void _emitInitializerList(IRType* elementType, IRUse* operands, Index operandCount);
+    void _emitInitializerList(IRType* elementType, IROperandListBase operands, Index operandCount);
     void _emitInitializerListValue(IRType* elementType, IRInst* value);
 
     void _emitGetHalfVectorElement(IRInst* baseInst, Index index, Index vecSize, const EmitOpInfo& inOuterPrec);

--- a/source/slang/slang-hlsl-intrinsic-set.cpp
+++ b/source/slang/slang-hlsl-intrinsic-set.cpp
@@ -164,7 +164,7 @@ void HLSLIntrinsicSet::calcIntrinsic(HLSLIntrinsic::Op op, IRInst* inst, Index o
     }
 }
 
-void HLSLIntrinsicSet::calcIntrinsic(HLSLIntrinsic::Op op, IRType* returnType, IRUse* inArgs, Index argCount, HLSLIntrinsic& out)
+void HLSLIntrinsicSet::calcIntrinsic(HLSLIntrinsic::Op op, IRType* returnType, IROperandListBase inArgs, Index argCount, HLSLIntrinsic& out)
 {
     returnType = m_typeSet->getType(returnType);
 
@@ -174,7 +174,7 @@ void HLSLIntrinsicSet::calcIntrinsic(HLSLIntrinsic::Op op, IRType* returnType, I
 
         for (Index i = 0; i < argCount; ++i)
         {
-            auto operand = inArgs[i].get();
+            auto operand = inArgs[i];
             argTypes[i] = m_typeSet->getType(operand->getDataType());
         }
         _calcIntrinsic(op, returnType, argTypes, argCount, out);
@@ -186,7 +186,7 @@ void HLSLIntrinsicSet::calcIntrinsic(HLSLIntrinsic::Op op, IRType* returnType, I
 
         for (Index i = 0; i < argCount; ++i)
         {
-            auto operand = inArgs[i].get();
+            auto operand = inArgs[i];
             argTypes[i] = m_typeSet->getType(operand->getDataType());
         }
         _calcIntrinsic(op, returnType, argTypes.getBuffer(), argCount, out);

--- a/source/slang/slang-hlsl-intrinsic-set.h
+++ b/source/slang/slang-hlsl-intrinsic-set.h
@@ -196,7 +196,7 @@ public:
 
     void calcIntrinsic(Op op, IRType* returnType, IRType*const* args, Index argsCount, HLSLIntrinsic& out);
     void calcIntrinsic(Op op, IRInst* inst, Index argsCount, HLSLIntrinsic& out);
-    void calcIntrinsic(Op op, IRType* returnType, IRUse* args, Index argCount, HLSLIntrinsic& out);
+    void calcIntrinsic(Op op, IRType* returnType, IROperandListBase args, Index argCount, HLSLIntrinsic& out);
     void  calcIntrinsic(Op op, IRInst* inst, HLSLIntrinsic& out) { calcIntrinsic(op, inst, Index(inst->getOperandCount()), out); }
 
     SlangResult makeIntrinsic(IRInst* inst, HLSLIntrinsic& out);

--- a/source/slang/slang-intrinsic-expand.cpp
+++ b/source/slang/slang-intrinsic-expand.cpp
@@ -5,7 +5,7 @@
 
 namespace Slang {
 
-void IntrinsicExpandContext::emit(IRCall* inst, IRUse* args, Int argCount, const UnownedStringSlice& intrinsicText)
+void IntrinsicExpandContext::emit(IRCall* inst, IROperandListBase args, Int argCount, const UnownedStringSlice& intrinsicText)
 {
     m_args = args;
     m_argCount = argCount;
@@ -233,7 +233,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
             Index argIndex = d - '0' + m_argIndexOffset;
             SLANG_RELEASE_ASSERT((0 <= argIndex) && (argIndex < m_argCount));
             m_writer->emit("(");
-            m_emitter->emitOperand(m_args[argIndex].get(), getInfo(EmitOp::General));
+            m_emitter->emitOperand(m_args[argIndex], getInfo(EmitOp::General));
             m_writer->emit(")");
         }
         break;
@@ -274,7 +274,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
             Index argIndex = (*cursor++) - '0' + m_argIndexOffset;
             SLANG_RELEASE_ASSERT(m_argCount > argIndex);
 
-            IRType* type = m_args[argIndex].get()->getDataType();
+            IRType* type = m_args[argIndex]->getDataType();
             if (auto baseTextureType = as<IRTextureType>(type))
             {
                 type = baseTextureType->getElementType();
@@ -290,7 +290,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
             Index argIndex = (*cursor++) - '0' + m_argIndexOffset;
             SLANG_RELEASE_ASSERT(m_argCount > argIndex);
 
-            IRType* type = m_args[argIndex].get()->getDataType();
+            IRType* type = m_args[argIndex]->getDataType();
             if (auto baseTextureType = as<IRTextureType>(type))
             {
                 type = baseTextureType->getElementType();
@@ -322,7 +322,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
             // texturing operation.
             SLANG_RELEASE_ASSERT(m_argCount >= 1);
 
-            auto textureArg = m_args[0].get();
+            auto textureArg = m_args[0];
 
             if (auto baseTextureSamplerType = as<IRTextureSamplerType>(textureArg->getDataType()))
             {
@@ -345,7 +345,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
                 // the next argument to be a sampler to pair with it.
                 //
                 SLANG_RELEASE_ASSERT(m_argCount >= 2);
-                auto samplerArg = m_args[1].get();
+                auto samplerArg = m_args[1];
 
                 // We will emit GLSL code to construct the corresponding combined texture/sampler
                 // type from the separate pieces.
@@ -452,7 +452,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
             // we don't need to do any casting there as half is coerced to float without a problem.
             SLANG_RELEASE_ASSERT(m_argCount >= 1);
 
-            auto textureArg = m_args[0].get();
+            auto textureArg = m_args[0];
             if (auto baseTextureType = as<IRTextureType>(textureArg->getDataType()))
             {
                 auto elementType = baseTextureType->getElementType();
@@ -485,7 +485,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
             // shape.
             SLANG_RELEASE_ASSERT(m_argCount >= 1);
 
-            auto textureArg = m_args[0].get();
+            auto textureArg = m_args[0];
             IRType* elementType  = nullptr;
 
             if (auto baseTextureType = as<IRTextureType>(textureArg->getDataType()))
@@ -535,7 +535,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
             Index argIndex = (*cursor++) - '0' + m_argIndexOffset;
             SLANG_RELEASE_ASSERT(m_argCount > argIndex);
 
-            auto vectorArg = m_args[argIndex].get();
+            auto vectorArg = m_args[argIndex];
             if (auto vectorType = as<IRVectorType>(vectorArg->getDataType()))
             {
                 auto elementCount = getIntVal(vectorType->getElementCount());
@@ -558,7 +558,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
             Index argIndex = (*cursor++) - '0' + m_argIndexOffset;
             SLANG_RELEASE_ASSERT(m_argCount > argIndex);
 
-            auto arg = m_args[argIndex].get();
+            auto arg = m_args[argIndex];
             IRIntegerValue elementCount = 1;
             IRType* elementType = arg->getDataType();
             if (auto vectorType = as<IRVectorType>(elementType))
@@ -615,7 +615,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
             Index argIndex = 0;
             SLANG_RELEASE_ASSERT(m_argCount > argIndex);
 
-            auto arg = m_args[argIndex].get();
+            auto arg = m_args[argIndex];
             if (arg->getOp() == kIROp_ImageSubscript)
             {
                 m_writer->emit("imageA");
@@ -640,7 +640,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
             Index argIndex = 0;
             SLANG_RELEASE_ASSERT(m_argCount > argIndex);
 
-            auto arg = m_args[argIndex].get();
+            auto arg = m_args[argIndex];
             if (arg->getOp() == kIROp_ImageSubscript)
             {
                 if (m_emitter->getSourceLanguage() == SourceLanguage::GLSL)
@@ -734,7 +734,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
             {
                 Index argIndex = 0;
                 SLANG_RELEASE_ASSERT(m_argCount > argIndex);
-                auto arg = m_args[argIndex].get();
+                auto arg = m_args[argIndex];
                 auto argLoad = as<IRLoad>(arg);
                 SLANG_RELEASE_ASSERT(argLoad);
 
@@ -766,7 +766,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
         {
             Index argIndex = 0;
             SLANG_RELEASE_ASSERT(m_argCount > argIndex);
-            auto arg = m_args[argIndex].get();
+            auto arg = m_args[argIndex];
             auto argType = arg->getDataType();
 
             const char* str = "";

--- a/source/slang/slang-intrinsic-expand.h
+++ b/source/slang/slang-intrinsic-expand.h
@@ -17,7 +17,7 @@ struct IntrinsicExpandContext
     {
     }
 
-    void emit(IRCall* inst, IRUse* args, Int argCount, const UnownedStringSlice& intrinsicText);
+    void emit(IRCall* inst, IROperandListBase args, Int argCount, const UnownedStringSlice& intrinsicText);
     
 protected:
     const char* _emitSpecial(const char* cursor);
@@ -25,7 +25,7 @@ protected:
     SourceWriter* m_writer;
     UnownedStringSlice m_text;
     IRCall* m_callInst;
-    IRUse* m_args = nullptr;
+    IROperandListBase m_args;
     Int m_argCount = 0;
     Index m_openParenCount = 0;
     CLikeSourceEmitter* m_emitter;

--- a/source/slang/slang-ir-bind-existentials.cpp
+++ b/source/slang/slang-ir-bind-existentials.cpp
@@ -267,7 +267,7 @@ struct BindExistentialSlots
     void replaceTypeUsingExistentialSlots(
         IRInst*         inst,
         UInt            slotOperandCount,
-        IRUse const*    slotArgs)
+        IROperandListBase slotArgs)
     {
         // We are going to alter the type of the
         // given `inst` based on information in
@@ -285,7 +285,7 @@ struct BindExistentialSlots
         //
         List<IRInst*> slotOperands;
         for(UInt ii = 0; ii < slotOperandCount; ++ii)
-            slotOperands.add(slotArgs[ii].get());
+            slotOperands.add(slotArgs[ii]);
 
         // We are going to create a proxy type that represents
         // the results of plugging all the information

--- a/source/slang/slang-ir-clone.cpp
+++ b/source/slang/slang-ir-clone.cpp
@@ -89,10 +89,10 @@ IRInst* cloneInstAndOperands(
     //
     for(UInt ii = 0; ii < operandCount; ++ii)
     {
-        auto oldOperand = oldInst->getOperand(ii);
+        auto oldOperand = oldInst->getRawOperand(ii);
         auto newOperand = findCloneForOperand(env, oldOperand);
 
-        newInst->getOperands()[ii].init(newInst, newOperand);
+        newInst->getRawOperands()[ii].init(newInst, newOperand);
     }
 
     newInst->sourceLoc = oldInst->sourceLoc;

--- a/source/slang/slang-ir-deduplicate.cpp
+++ b/source/slang/slang-ir-deduplicate.cpp
@@ -96,7 +96,7 @@ namespace Slang
             use->set(newInst);
             // depending on the type of the user inst, we may need to rebuild and update the global
             // numbering cache.
-            if (isGloballyNumberedInst(use->getUser()))
+            if (isGloballyNumberedInst(use->getRawUser()))
             {
                 shouldUpdateGlobalNumberedCache = true;
             }

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -29,6 +29,8 @@ INST(Nop, nop, 0, 0)
         INST(NativeStringType, NativeString, 0, 0)
     INST_RANGE(StringTypeBase, StringType, NativeStringType)
 
+    INST(AttributedOperand, AttributedOperand, 0, 0)
+
     INST(CapabilitySetType, CapabilitySet, 0, 0)
 
     INST(DynamicType, DynamicType, 0, 0)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -1571,7 +1571,7 @@ struct IRCall : IRInst
     IRInst* getCallee() { return getOperand(0); }
 
     UInt getArgCount() { return getOperandCount() - 1; }
-    IRUse* getArgs() { return getOperands() + 1; }
+    IROperandListBase getArgs() { return getOperands() + 1; }
     IRInst* getArg(UInt index) { return getOperand(index + 1); }
 };
 
@@ -1702,7 +1702,7 @@ struct IRUnconditionalBranch : IRTerminatorInst
     IRBlock* getTargetBlock() { return (IRBlock*)block.get(); }
 
     UInt getArgCount();
-    IRUse* getArgs();
+    IROperandListBase getArgs();
     IRInst* getArg(UInt index);
 
     IR_PARENT_ISA(UnconditionalBranch);
@@ -1809,7 +1809,7 @@ struct IRTryCall : IRTerminatorInst
     IRBlock* getFailureBlock() { return cast<IRBlock>(getOperand(1)); }
     IRInst* getCallee() { return getOperand(2); }
     UInt getArgCount() { return getOperandCount() - 3; }
-    IRUse* getArgs() { return getOperands() + 3; }
+    IROperandListBase getArgs() { return getOperands() + 3; }
     IRInst* getArg(UInt index) { return getOperand(index + 3); }
 };
 
@@ -2146,7 +2146,7 @@ struct IRWrapExistential : IRInst
 
     UInt getSlotOperandCount() { return getOperandCount() - 1; }
     IRInst* getSlotOperand(UInt index) { return getOperand(index + 1); }
-    IRUse* getSlotOperands() { return getOperands() + 1; }
+    IROperandListBase getSlotOperands() { return getOperands() + 1; }
 
     IR_LEAF_ISA(WrapExistential)
 };

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -1836,7 +1836,7 @@ static LegalVal legalizeInst(
     bool anyComplex = false;
     for (UInt aa = 0; aa < argCount; ++aa)
     {
-        auto oldArg = inst->getOperand(aa);
+        auto oldArg = inst->getRawOperand(aa);
         auto legalArg = legalizeOperand(context, oldArg);
         legalArgs.add(legalArg);
 
@@ -3337,7 +3337,7 @@ struct IRTypeLegalizationPass
         Index operandCount = (Index) inst->getOperandCount();
         for( Index i = 0; i < operandCount; ++i )
         {
-            auto operand = inst->getOperand(i);
+            auto operand = inst->getRawOperand(i);
             if(!hasBeenAddedToWorkList(operand))
                 return;
         }

--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -290,9 +290,9 @@ IRInst* IRSpecContext::maybeCloneValue(IRInst* originalValue)
             registerClonedValue(this, clonedValue, originalValue);
             for (UInt aa = 0; aa < argCount; ++aa)
             {
-                IRInst* originalArg = originalValue->getOperand(aa);
+                IRInst* originalArg = originalValue->getRawOperand(aa);
                 IRInst* clonedArg = cloneValue(this, originalArg);
-                clonedValue->getOperands()[aa].init(clonedValue, clonedArg);
+                clonedValue->getRawOperands()[aa].init(clonedValue, clonedArg);
             }
             cloneDecorationsAndChildren(this, clonedValue, originalValue);
 
@@ -671,7 +671,7 @@ IRInterfaceType* cloneInterfaceTypeImpl(
 
     for (UInt i = 0; i < originalInterface->getOperandCount(); i++)
     {
-        auto clonedKey = cloneValue(context, originalInterface->getOperand(i));
+        auto clonedKey = cloneValue(context, originalInterface->getRawOperand(i));
         clonedInterface->setOperand(i, clonedKey);
     }
     cloneSimpleGlobalValueImpl(context, originalInterface, originalValues, clonedInterface, false);
@@ -1182,9 +1182,9 @@ IRInst* cloneInst(
     context->builder = builder;
     for (UInt aa = 0; aa < argCount; ++aa)
     {
-        IRInst* originalArg = originalInst->getOperand(aa);
+        IRInst* originalArg = originalInst->getRawOperand(aa);
         IRInst* clonedArg = cloneValue(context, originalArg);
-        clonedInst->getOperands()[aa].init(clonedInst, clonedArg);
+        clonedInst->getRawOperands()[aa].init(clonedInst, clonedArg);
     }
     builder->addInst(clonedInst);
     context->builder = oldBuilder;

--- a/source/slang/slang-ir-lower-generic-function.cpp
+++ b/source/slang/slang-ir-lower-generic-function.cpp
@@ -122,7 +122,7 @@ namespace Slang
             bool translated = false;
             for (UInt i = 0; i < funcType->getOperandCount(); i++)
             {
-                auto paramType = funcType->getOperand(i);
+                auto paramType = funcType->getRawOperand(i);
                 auto loweredParamType = sharedContext->lowerType(builder, paramType, typeMapping, nullptr);
                 translated = translated || (loweredParamType != paramType);
                 newOperands.add(loweredParamType);

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -109,7 +109,7 @@ struct SpecializationContext
         UInt operandCount = inst->getOperandCount();
         for(UInt ii = 0; ii < operandCount; ++ii)
         {
-            IRInst* operand = inst->getOperand(ii);
+            IRInst* operand = inst->getRawOperand(ii);
             if(!isInstFullySpecialized(operand))
                 return false;
         }
@@ -164,7 +164,7 @@ struct SpecializationContext
     {
         for( auto use = inst->firstUse; use; use = use->nextUse )
         {
-            auto user = use->getUser();
+            auto user = use->getRawUser();
             
             addToWorkList(user);
         }
@@ -722,16 +722,16 @@ struct SpecializationContext
             bool shouldSkip = false;
             for (UInt i = 1; i < item->getOperandCount(); i++)
             {
-                if (item->getOperand(i) == nullptr)
+                if (item->getRawOperand(i) == nullptr)
                 {
                     shouldSkip = true;
                     break;
                 }
-                key.vals.add(item->getOperand(i));
+                key.vals.add(item->getRawOperand(i));
             }
             if (shouldSkip)
                 continue;
-            auto value = as<typename std::remove_pointer<typename TDict::ValueType>::type>(item->getOperand(0));
+            auto value = as<typename std::remove_pointer<typename TDict::ValueType>::type>(item->getRawOperand(0));
             SLANG_ASSERT(value);
             dict[key] = value;
         }
@@ -1314,7 +1314,7 @@ struct SpecializationContext
 
             for (UInt i = 0; i < curInst->getOperandCount(); ++i)
             {
-                auto operand = curInst->getOperand(i);
+                auto operand = curInst->getRawOperand(i);
                 if (processedInsts.Add(operand))
                 {
                     localWorkList.add(operand);
@@ -1479,7 +1479,7 @@ struct SpecializationContext
                     oldParam->getFullType(),
                     newParam,
                     oldWrapExistential->getSlotOperandCount(),
-                    oldWrapExistential->getSlotOperands());
+                    oldWrapExistential->getSlotOperands().begin().getCursor());
                 newBodyInsts.add(newWrapExistential);
                 replacementVal = newWrapExistential;
             }
@@ -2151,7 +2151,7 @@ struct SpecializationContext
             IRInst* wrappedElementType = builder.getBindExistentialsType(
                 baseElementType,
                 slotOperandCount,
-                type->getExistentialArgs());
+                type->getExistentialArgs().begin().getCursor());
 
             auto newPtrLikeType = builder.getType(
                 baseType->getOp(),
@@ -2212,7 +2212,7 @@ struct SpecializationContext
                     auto newFieldType = builder.getBindExistentialsType(
                         oldFieldType,
                         fieldSlotArgCount,
-                        fieldSlotArgs);
+                        fieldSlotArgs.begin().getCursor());
 
                     addToWorkList(newFieldType);
 

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -38,7 +38,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
     {
         for (auto use = inst->firstUse; use; use = use->nextUse)
         {
-            auto user = use->getUser();
+            auto user = use->getRawUser();
 
             addToWorkList(user);
         }
@@ -170,7 +170,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 List<IRInst*> args;
                 for (UInt i = 0; i < inst->getArgCount(); i++)
                     args.add(inst->getArg(i));
-                auto newCall = builder.emitCallInst(qualPtrType, funcValue, args);
+                auto newCall = builder.emitCallInst(qualPtrType, inst->getRawOperand(0), args);
                 inst->replaceUsesWith(newCall);
                 inst->removeAndDeallocate();
                 addUsersToWorkList(newCall);

--- a/source/slang/slang-ir-ssa.cpp
+++ b/source/slang/slang-ir-ssa.cpp
@@ -111,7 +111,7 @@ bool allUsesLeadToLoads(IRInst* inst)
 {
     for (auto u = inst->firstUse; u; u = u->nextUse)
     {
-        auto user = u->getUser();
+        auto user = u->getRawUser();
         switch (user->getOp())
         {
         default:
@@ -122,11 +122,12 @@ bool allUsesLeadToLoads(IRInst* inst)
 
         case kIROp_GetElementPtr:
         case kIROp_FieldAddress:
+        case kIROp_AttributedOperand:
             {
                 // Sanity check: the address being used should
                 // be the base-address operand, and not the field
                 // key or index (this should never be a problem).
-                if (u != &user->getOperands()[0])
+                if (u != &user->getRawOperands()[0])
                     return false;
 
                 if (!allUsesLeadToLoads(user))
@@ -177,7 +178,7 @@ bool isPromotableVar(
 
     for (auto u = var->firstUse; u; u = u->nextUse)
     {
-        auto user = u->getUser();
+        auto user = u->getRawUser();
         switch (user->getOp())
         {
         default:
@@ -213,11 +214,12 @@ bool isPromotableVar(
 
         case kIROp_GetElementPtr:
         case kIROp_FieldAddress:
+        case kIROp_AttributedOperand:
             {
                 // Sanity check: the address being used should
                 // be the base-address operand, and not the field
                 // key or index (this should never be a problem).
-                if (u != &user->getOperands()[0])
+                if (u != &user->getRawOperands()[0])
                     return false;
 
                 if (!allUsesLeadToLoads(user))

--- a/source/slang/slang-ir-string-hash.cpp
+++ b/source/slang/slang-ir-string-hash.cpp
@@ -71,7 +71,7 @@ void addGlobalHashedStringLiterals(const StringSlicePool& pool, SharedIRBuilder&
     IRInst* globalHashedInst = module->_allocateInst(kIROp_GlobalHashedStringLiterals, int(slicesCount));
     builder.addInst(globalHashedInst);
 
-    auto operands = globalHashedInst->getOperands();
+    auto operands = globalHashedInst->getRawOperands();
 
     for (Index i = 0; i < slicesCount; ++i)
     {

--- a/source/slang/slang-ir-type-set.cpp
+++ b/source/slang/slang-ir-type-set.cpp
@@ -159,7 +159,7 @@ IRInst* IRTypeSet::cloneInst(IRInst* inst)
 
                 for (Index i = 0; i < operandCount; ++i)
                 {
-                    cloneOperands[i] = cloneInst(inst->getOperand(i));
+                    cloneOperands[i] = cloneInst(inst->getRawOperand(i));
                 }
 
                 //clone = m_irBuilder.findOrEmitHoistableInst(cloneType, inst->op, operandCount, cloneOperands.getBuffer());
@@ -178,8 +178,8 @@ IRInst* IRTypeSet::cloneInst(IRInst* inst)
                 clone = m_builder.emitIntrinsicInst(clonedType, inst->getOp(), operandCount, nullptr);
                 for (Index i = 0; i < operandCount; ++i)
                 {
-                    auto cloneOperand = cloneInst(inst->getOperand(i));
-                    clone->getOperands()[i].init(clone, cloneOperand);
+                    auto cloneOperand = cloneInst(inst->getRawOperand(i));
+                    clone->getRawOperands()[i].init(clone, cloneOperand);
                 }
             }
         }
@@ -276,7 +276,7 @@ static bool _hasNominalOperand(IRInst* inst)
 
     for (Index i = 0; i < operandCount; ++i)
     {
-        IRInst* operand = operands[i].get();
+        IRInst* operand = operands[i];
         if (isNominalOp(operand->getOp()))
         {
             return true;

--- a/source/slang/slang-ir-validate.cpp
+++ b/source/slang/slang-ir-validate.cpp
@@ -192,7 +192,7 @@ namespace Slang
         UInt operandCount = inst->getOperandCount();
         for (UInt ii = 0; ii < operandCount; ++ii)
         {
-            validateIRInstOperand(context, inst, inst->getOperands() + ii);
+            validateIRInstOperand(context, inst, inst->getRawOperands() + ii);
         }
     }
 

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -719,7 +719,7 @@ namespace Slang
 
         default:
             SLANG_UNEXPECTED("unhandled unconditional branch opcode");
-            UNREACHABLE_RETURN(0);
+            UNREACHABLE_RETURN(IROperandListBase());
         }
     }
 

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -690,8 +690,8 @@ struct IRInst
 
     void setOperand(UInt index, IRInst* value)
     {
-        SLANG_ASSERT(getOperands()[index].user != nullptr);
-        getOperands().getRawUse(index)->set(value);
+        SLANG_ASSERT(getRawOperands()[index].user != nullptr);
+        getRawOperands()[index].set(value);
     }
 
     IRAttr* findOperandAttribute(UInt operandIndex, IROp attrOp);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -1603,7 +1603,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
                     // The `this` argument to the call will need to represent the
                     // appropriate field of our tagged union.
                     //
-                    IRType* caseThisType = (IRType*) irTaggedUnionType->getOperand(ii);
+                    IRType* caseThisType = (IRType*) irTaggedUnionType->getRawOperand(ii);
                     auto caseThisArg = subBuilder->emitExtractTaggedUnionPayload(
                         caseThisType,
                         irThisParam, caseTag);
@@ -1721,7 +1721,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
         // TODO: `IRTupleType` should really have `getElementCount()` and
         // `getElementType(index)` accessors.
         //
-        auto elementType = (IRType*) conjunctionTupleType->getOperand(indexInConjunction);
+        auto elementType = (IRType*) conjunctionTupleType->getRawOperand(indexInConjunction);
 
         // With the information we've extracted above, we now just need to
         // extract the appropriate element from the `(w_l, w_r)` tuple of
@@ -4147,7 +4147,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         auto existentialInfo = value.getExtractedExistentialValInfo();
         auto optType = lowerType(context, expr->type);
         SLANG_RELEASE_ASSERT(optType->getOp() == kIROp_OptionalType);
-        auto targetType = optType->getOperand(0);
+        auto targetType = optType->getRawOperand(0);
         auto witness = lowerSimpleVal(context, expr->witnessArg);
         auto builder = getBuilder();
         auto var = builder->emitVar(optType);
@@ -7497,7 +7497,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         {
             for (UInt i = 0; i < value->getOperandCount(); i++)
             {
-                auto operand = value->getOperand(i);
+                auto operand = value->getRawOperand(i);
                 markInstsToClone(valuesToClone, parentBlock, operand);
             }
         }
@@ -8581,7 +8581,7 @@ static void _addFlattenedTupleArgs(
         auto elementCount = tupleVal->getOperandCount();
         for( UInt i = 0; i < elementCount; ++i )
         {
-            _addFlattenedTupleArgs(ioArgs, tupleVal->getOperand(i));
+            _addFlattenedTupleArgs(ioArgs, tupleVal->getRawOperand(i));
         }
     }
     //

--- a/source/slang/slang-serialize-ir.cpp
+++ b/source/slang/slang-serialize-ir.cpp
@@ -285,7 +285,7 @@ Result IRSerialWriter::write(IRModule* module, SerialSourceLocWriter* sourceLocW
 
             for (int j = 0; j < numOperands; ++j)
             {
-                const Ser::InstIndex dstInstIndex = getInstIndex(srcInst->getOperand(j));
+                const Ser::InstIndex dstInstIndex = getInstIndex(srcInst->getRawOperand(j));
                 dstOperands[j] = dstInstIndex;
             }
         }
@@ -884,7 +884,7 @@ Result IRSerialReader::read(const IRSerialData& data, Session* session, SerialSo
             const Ser::InstIndex* srcOperandIndices;
             const int numOperands = data.getOperands(srcInst, &srcOperandIndices);
 
-            auto dstOperands = dstInst->getOperands();
+            auto dstOperands = dstInst->getRawOperands();
 
             for (int j = 0; j < numOperands; j++)
             {


### PR DESCRIPTION
This allows us to decorate an operand.

For example, `FuncType([no_diff]int)` can now be represented as:
```
%0 = IRIntType;
%1 = IRAttributedOperand(%0, no_diff_attr)
%2 = IRFuncType(%1)
```

To allow most of existing code to work transparently with `IRAttributedOperand`, this change bottlenecks all operand access through `getOperand()`, `getRawOperand()` accessors, and make `getOperands()` return an `IROperandListBase` where we provide further accessors to return either the actual inner operand or the raw `IRAttributedOperand`.

The potential problematic case with this approach is if the code calls the `getOperand()` accessor to get an inner operand without the attributes, and later use it to create a new replacement inst or set it back with `setOperand()`, the attributes would be lost. We will have to examine all such use cases and make sure their behavior is desirable.