### PR TITLE
Fix code generation for matrix reshape.

### DIFF
--- a/prelude/slang-cpp-types.h
+++ b/prelude/slang-cpp-types.h
@@ -76,28 +76,6 @@ struct Array
     size_t count;
 };
 
-#if 0
-template<size_t N>
-struct AnyValue
-{
-    uint8_t data[N];
-};
-template<size_t N, typename T>
-AnyValue<N> packAnyValue(const T& val)
-{
-    AnyValue<N> result;
-    memcpy(&result, &val, sizeof(T));
-    return result;
-}
-template<size_t N, typename T>
-T unpackAnyValue(const AnyValue<N>& val)
-{
-    T result;
-    memcpy(&result, &val, sizeof(T));
-    return result;
-}
-#endif
-
 /* Constant buffers become a pointer to the contained type, so ConstantBuffer<T> becomes T* in C++ code.
 */
 

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -1778,7 +1778,6 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
 
     case kIROp_MakeVector:
     case kIROp_MakeMatrix:
-    case kIROp_MatrixReshape:
     case kIROp_VectorReshape:
     case kIROp_CastFloatToInt:
     case kIROp_CastIntToFloat:
@@ -1822,6 +1821,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
         m_writer->emit(")");
         break;
     case kIROp_MakeVectorFromScalar:
+    case kIROp_MatrixReshape:
     case kIROp_CastPtrToInt:
     case kIROp_CastIntToPtr:
     {

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -1178,6 +1178,7 @@ void CPPSourceEmitter::_emitInitDefinition(const UnownedStringSlice& funcName, c
     writer->emit("{ ");
 
     const Index paramCount = Index(funcType->getParamCount());
+    bool handled = false;
 
     if (IRVectorType* vecType = as<IRVectorType>(retType))
     {
@@ -1211,7 +1212,7 @@ void CPPSourceEmitter::_emitInitDefinition(const UnownedStringSlice& funcName, c
                     writer->emit(".");
                     writer->emit(elemNames[paramSubIndex]);
 
-                    paramSubIndex ++;
+                    paramSubIndex++;
 
                     if (paramSubIndex >= paramElementCount)
                     {
@@ -1226,9 +1227,51 @@ void CPPSourceEmitter::_emitInitDefinition(const UnownedStringSlice& funcName, c
                 }
             }
         }
+        handled = true;
     }
-    else
+    else if (IRMatrixType* matType = as<IRMatrixType>(retType))
     {
+        if (paramCount != 1)
+            goto fallback;
+
+        auto paramMat = as<IRMatrixType>(funcType->getParamType(0));
+        if (!paramMat)
+            goto fallback;
+
+        // We are constructing a matrix from a differently sized matrix.
+
+        Index rows = Index(getIntVal(matType->getRowCount()));
+        Index cols = Index(getIntVal(matType->getColumnCount()));
+        Index paramRows = Index(getIntVal(paramMat->getRowCount()));
+        Index paramCols = Index(getIntVal(paramMat->getColumnCount()));
+        char elementNames[] = { 'x', 'y', 'z', 'w' };
+
+        for (Index r = 0; r < rows; r++)
+        {
+            for (Index c = 0; c < cols; c++)
+            {
+                if (r != 0 || c != 0)
+                    writer->emit(", ");
+
+                if (r < paramRows && c < paramCols && c < 4)
+                {
+                    writer->emitRawText("a.rows[");
+                    writer->emit(r);
+                    writer->emitRawText("].");
+                    writer->emitChar(elementNames[c]);
+                }
+                else
+                {
+                    writer->emit("0");
+                }
+            }
+        }
+        handled = true;
+    }
+fallback:
+    if (!handled)
+    {
+        // Fallback default: just use all params to construct.
         for (Index i = 0; i < paramCount; ++i)
         {
             if (i > 0)

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -1475,6 +1475,7 @@ bool GLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
     switch (inst->getOp())
     {
         case kIROp_MakeVectorFromScalar:
+        case kIROp_MatrixReshape:
         {
             // Simple constructor call
             EmitOpInfo outerPrec = inOuterPrec;

--- a/tests/bugs/matrix-reshape.slang
+++ b/tests/bugs/matrix-reshape.slang
@@ -1,0 +1,20 @@
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+float test(float3x3 m3)
+{
+    return m3[0][0] + m3[1][1] + m3[2][2];
+}
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    float4x4 m = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    float3x3 m3 = float3x3(m);
+    outputBuffer[0] = test(m3); // Expect 18
+}

--- a/tests/bugs/matrix-reshape.slang.expected.txt
+++ b/tests/bugs/matrix-reshape.slang.expected.txt
@@ -1,0 +1,2 @@
+type: float
+18.0


### PR DESCRIPTION
This fixes a regression introduced in the `construct` opcode cleanup PR.
Also adds the implementation for C++/CUDA path for matrix reshape.