### PR TITLE
Split bwd_diff op into separate ops for primal and propagate func.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,15 +16,15 @@ jobs:
         compiler: ['gcc', 'clang']
         platform: ['x64'] 
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'true'
+        fetch-depth: '0'
     - uses: robinraju/release-downloader@v1.7
       with:
         latest: true
         repository: "shader-slang/swiftshader"
         fileName: "vk_swiftshader_linux_${{matrix.platform}}.zip"
-    - uses: actions/checkout@v3
-      with:
-        submodules: 'true'
-        fetch-depth: '0'
     - name: build
       run: |
         CC=${{matrix.compiler}}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,6 +16,11 @@ jobs:
         compiler: ['gcc', 'clang']
         platform: ['x64'] 
     steps:
+    - uses: robinraju/release-downloader@v1.7
+      with:
+        latest: true
+        repository: "shader-slang/swiftshader"
+        fileName: "vk_swiftshader_linux_${{matrix.platform}}.zip"
     - uses: actions/checkout@v3
       with:
         submodules: 'true'

--- a/github_test.sh
+++ b/github_test.sh
@@ -30,11 +30,7 @@ TARGET=${PLATFORM}-${ARCHITECTURE}
 OUTPUTDIR=bin/${TARGET}/${CONFIGURATION}/
 
 if [ "${ARCHITECTURE}" == "x64" -a "${PLATFORM}" != "macosx" ]; then
-    LOCATION=$(curl -s https://api.github.com/repos/shader-slang/swiftshader/releases/latest \
-    | grep "tag_name" \
-    | awk '{print "https://github.com/shader-slang/swiftshader/releases/download/" substr($2, 2, length($2)-3) "/vk_swiftshader_linux_x64.zip"}')
-    curl -L -o libswiftshader.zip $LOCATION
-    unzip libswiftshader.zip -d $OUTPUTDIR
+    unzip vk_swiftshader_linux_x64.zip -d $OUTPUTDIR
 fi
 
 SLANG_TEST=${OUTPUTDIR}slang-test

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -546,6 +546,21 @@ class BackwardDerivativeRequirementDecl : public DerivativeRequirementDecl
     SLANG_AST_CLASS(BackwardDerivativeRequirementDecl)
 };
 
+class BackwardDerivativePrimalRequirementDecl : public DerivativeRequirementDecl
+{
+    SLANG_AST_CLASS(BackwardDerivativePrimalRequirementDecl)
+};
+
+class BackwardDerivativePropagateRequirementDecl : public DerivativeRequirementDecl
+{
+    SLANG_AST_CLASS(BackwardDerivativePropagateRequirementDecl)
+};
+
+class BackwardDerivativeIntermediateTypeRequirementDecl : public DerivativeRequirementDecl
+{
+    SLANG_AST_CLASS(BackwardDerivativeIntermediateTypeRequirementDecl)
+};
+
 bool isInterfaceRequirement(Decl* decl);
 InterfaceDecl* findParentInterfaceDecl(Decl* decl);
 

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -521,4 +521,19 @@ class BackwardDifferentiateVal : public DifferentiateVal
     SLANG_AST_CLASS(BackwardDifferentiateVal)
 };
 
+class BackwardDifferentiateIntermediateTypeVal : public DifferentiateVal
+{
+    SLANG_AST_CLASS(BackwardDifferentiateIntermediateTypeVal)
+};
+
+class BackwardDifferentiatePrimalVal : public DifferentiateVal
+{
+    SLANG_AST_CLASS(BackwardDifferentiatePrimalVal)
+};
+
+class BackwardDifferentiatePropagateVal : public DifferentiateVal
+{
+    SLANG_AST_CLASS(BackwardDifferentiatePropagateVal)
+};
+
 } // namespace Slang

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2665,9 +2665,27 @@ namespace Slang
             }
             else if (auto bwdReq = as<BackwardDerivativeRequirementDecl>(reqRefDecl->referencedDecl))
             {
-                BackwardDifferentiateVal* val = m_astBuilder->create<BackwardDifferentiateVal>();
+                DifferentiateVal* val = m_astBuilder->create<BackwardDifferentiateVal>();
                 val->func = satisfyingMemberDeclRef;
                 witnessTable->add(bwdReq, RequirementWitness(val));
+            }
+            else if (auto primalReq = as<BackwardDerivativePrimalRequirementDecl>(reqRefDecl->referencedDecl))
+            {
+                DifferentiateVal* val = m_astBuilder->create<BackwardDifferentiatePrimalVal>();
+                val->func = satisfyingMemberDeclRef;
+                witnessTable->add(primalReq, RequirementWitness(val));
+            }
+            else if (auto propReq = as<BackwardDerivativePropagateRequirementDecl>(reqRefDecl->referencedDecl))
+            {
+                DifferentiateVal* val = m_astBuilder->create<BackwardDifferentiatePropagateVal>();
+                val->func = satisfyingMemberDeclRef;
+                witnessTable->add(propReq, RequirementWitness(val));
+            }
+            else if (auto itypeReq = as<BackwardDerivativeIntermediateTypeRequirementDecl>(reqRefDecl->referencedDecl))
+            {
+                DifferentiateVal* val = m_astBuilder->create<BackwardDifferentiateIntermediateTypeVal>();
+                val->func = satisfyingMemberDeclRef;
+                witnessTable->add(itypeReq, RequirementWitness(val));
             }
         }
         witnessTable->add(requiredMemberDeclRef, RequirementWitness(satisfyingMemberDeclRef));
@@ -5652,18 +5670,70 @@ namespace Slang
             }
             if (decl->hasModifier<BackwardDifferentiableAttribute>())
             {
-                auto reqDecl = m_astBuilder->create<BackwardDerivativeRequirementDecl>();
-                cloneModifiers(reqDecl, decl);
+                // Requirement for backward derivative.
                 auto declRef = DeclRef<CallableDecl>(decl, createDefaultSubstitutions(m_astBuilder, this, decl));
-                auto diffFuncType = getBackwardDiffFuncType(getFuncType(m_astBuilder, declRef));
-                setFuncTypeIntoRequirementDecl(reqDecl, as<FuncType>(diffFuncType));
-                interfaceDecl->members.add(reqDecl);
-                reqDecl->parentDecl = interfaceDecl;
+                auto diffFuncType = as<FuncType>(getBackwardDiffFuncType(getFuncType(m_astBuilder, declRef)));
+                {
+                    auto reqDecl = m_astBuilder->create<BackwardDerivativeRequirementDecl>();
+                    cloneModifiers(reqDecl, decl);
+                    setFuncTypeIntoRequirementDecl(reqDecl, diffFuncType);
+                    interfaceDecl->members.add(reqDecl);
+                    reqDecl->parentDecl = interfaceDecl;
 
-                auto reqRef = m_astBuilder->create<DerivativeRequirementReferenceDecl>();
-                reqRef->referencedDecl = reqDecl;
-                reqRef->parentDecl = decl;
-                decl->members.add(reqRef);
+                    auto reqRef = m_astBuilder->create<DerivativeRequirementReferenceDecl>();
+                    reqRef->referencedDecl = reqDecl;
+                    reqRef->parentDecl = decl;
+                    decl->members.add(reqRef);
+                }
+                // Requirement for backward derivative intermediate type.
+                auto intermediateTypeReqDecl = m_astBuilder->create<BackwardDerivativeIntermediateTypeRequirementDecl>();
+                auto intermediateType = m_astBuilder->getOrCreateDeclRefType(
+                    intermediateTypeReqDecl, createDefaultSubstitutions(m_astBuilder, this, decl));
+                {
+                    cloneModifiers(intermediateTypeReqDecl, decl);
+                    interfaceDecl->members.add(intermediateTypeReqDecl);
+                    intermediateTypeReqDecl->parentDecl = interfaceDecl;
+
+                    auto reqRef = m_astBuilder->create<DerivativeRequirementReferenceDecl>();
+                    reqRef->referencedDecl = intermediateTypeReqDecl;
+                    reqRef->parentDecl = decl;
+                    decl->members.add(reqRef);
+                }
+                // Requirement for backward derivative primal func.
+                {
+                    auto reqDecl = m_astBuilder->create<BackwardDerivativePrimalRequirementDecl>();
+                    cloneModifiers(reqDecl, decl);
+                    FuncType* primalFuncType = m_astBuilder->create<FuncType>();
+                    primalFuncType->resultType = diffFuncType->resultType;
+                    primalFuncType->paramTypes.addRange(diffFuncType->paramTypes);
+                    auto outType = m_astBuilder->getOutType(intermediateType);
+                    primalFuncType->paramTypes.add(outType);
+                    setFuncTypeIntoRequirementDecl(reqDecl, primalFuncType);
+                    interfaceDecl->members.add(reqDecl);
+                    reqDecl->parentDecl = interfaceDecl;
+
+                    auto reqRef = m_astBuilder->create<DerivativeRequirementReferenceDecl>();
+                    reqRef->referencedDecl = reqDecl;
+                    reqRef->parentDecl = decl;
+                    decl->members.add(reqRef);
+                }
+                // Requirement for backward derivative propagate func.
+                {
+                    auto reqDecl = m_astBuilder->create<BackwardDerivativePropagateRequirementDecl>();
+                    cloneModifiers(reqDecl, decl);
+                    interfaceDecl->members.add(reqDecl);
+                    reqDecl->parentDecl = interfaceDecl;
+                    FuncType* propagateFuncType = m_astBuilder->create<FuncType>();
+                    propagateFuncType->resultType = diffFuncType->resultType;
+                    propagateFuncType->paramTypes.addRange(diffFuncType->paramTypes);
+                    propagateFuncType->paramTypes.add(intermediateType);
+                    setFuncTypeIntoRequirementDecl(reqDecl, propagateFuncType);
+                    auto reqRef = m_astBuilder->create<DerivativeRequirementReferenceDecl>();
+                    reqRef->referencedDecl = reqDecl;
+                    reqRef->parentDecl = decl;
+                    decl->members.add(reqRef);
+                }
+                
                 isDiffFunc = true;
             }
             if (isDiffFunc)

--- a/source/slang/slang-ir-autodiff-fwd.h
+++ b/source/slang/slang-ir-autodiff-fwd.h
@@ -73,7 +73,7 @@ struct ForwardDiffTranscriber : AutoDiffTranscriberBase
 
     InstPair transcribeWrapExistential(IRBuilder* builder, IRInst* origInst);
 
-    virtual IRFuncType* differentiateFunctionType(IRBuilder* builder, IRFuncType* funcType) override;
+    virtual IRFuncType* differentiateFunctionType(IRBuilder* builder, IRInst* func, IRFuncType* funcType) override;
 
     // Transcribe a function definition.
     InstPair transcribeFunc(IRBuilder* inBuilder, IRFunc* primalFunc, IRFunc* diffFunc);

--- a/source/slang/slang-ir-autodiff-rev.h
+++ b/source/slang/slang-ir-autodiff-rev.h
@@ -99,8 +99,6 @@ struct BackwardDiffTranscriberBase : AutoDiffTranscriberBase
     {
         return kIROp_BackwardDifferentiableMethodRequirementDictionaryItem;
     }
-
-    virtual const char* getNamePrefix() = 0;
 };
 
 struct BackwardDiffPrimalTranscriber : BackwardDiffTranscriberBase
@@ -123,10 +121,6 @@ struct BackwardDiffPrimalTranscriber : BackwardDiffTranscriberBase
     {
         builder->addBackwardDerivativePrimalDecoration(inst, diffFunc);
     }
-    virtual const char* getNamePrefix() override
-    {
-        return "s_bwd_primal_";
-    }
 };
 
 struct BackwardDiffPropagateTranscriber : BackwardDiffTranscriberBase
@@ -148,10 +142,6 @@ struct BackwardDiffPropagateTranscriber : BackwardDiffTranscriberBase
     virtual void addExistingDiffFuncDecor(IRBuilder* builder, IRInst* inst, IRInst* diffFunc) override
     {
         builder->addBackwardDerivativePropagateDecoration(inst, diffFunc);
-    }
-    virtual const char* getNamePrefix() override
-    {
-        return "s_bwd_prop_";
     }
 };
 
@@ -185,11 +175,6 @@ struct BackwardDiffTranscriber : BackwardDiffTranscriberBase
     virtual void addExistingDiffFuncDecor(IRBuilder* builder, IRInst* inst, IRInst* diffFunc) override
     {
         builder->addBackwardDerivativeDecoration(inst, diffFunc);
-    }
-
-    virtual const char* getNamePrefix() override
-    {
-        return "s_bwd_";
     }
 };
 

--- a/source/slang/slang-ir-autodiff-transcriber-base.cpp
+++ b/source/slang/slang-ir-autodiff-transcriber-base.cpp
@@ -259,7 +259,7 @@ IRType* AutoDiffTranscriberBase::_differentiateTypeImpl(IRBuilder* builder, IRTy
     }
 
     case kIROp_FuncType:
-        return differentiateFunctionType(builder, as<IRFuncType>(primalType));
+        return differentiateFunctionType(builder, nullptr, as<IRFuncType>(primalType));
 
     case kIROp_OutType:
         if (auto diffValueType = differentiateType(builder, as<IROutType>(primalType)->getValueType()))
@@ -436,7 +436,7 @@ InstPair AutoDiffTranscriberBase::transcribeParam(IRBuilder* builder, IRParam* o
 {
     auto primalDataType = findOrTranscribePrimalInst(builder, origParam->getDataType());
     // Do not differentiate generic type (and witness table) parameters
-    if (as<IRTypeType>(primalDataType) || as<IRWitnessTableType>(primalDataType))
+    if (isGenericParam(origParam))
     {
         return InstPair(
             cloneInst(&cloneEnv, builder, origParam),

--- a/source/slang/slang-ir-autodiff-transcriber-base.h
+++ b/source/slang/slang-ir-autodiff-transcriber-base.h
@@ -116,7 +116,7 @@ struct AutoDiffTranscriberBase
 
     IRType* _differentiateTypeImpl(IRBuilder* builder, IRType* origType);
 
-    virtual IRFuncType* differentiateFunctionType(IRBuilder* builder, IRFuncType* funcType) = 0;
+    virtual IRFuncType* differentiateFunctionType(IRBuilder* builder, IRInst* func, IRFuncType* funcType) = 0;
 
     // Create an empty func to represent the transcribed func of `origFunc`.
     virtual InstPair transcribeFuncHeader(IRBuilder* inBuilder, IRFunc* origFunc) = 0;

--- a/source/slang/slang-ir-autodiff-unzip.cpp
+++ b/source/slang/slang-ir-autodiff-unzip.cpp
@@ -404,7 +404,7 @@ IRFunc* DiffUnzipPass::extractPrimalFunc(
 
     if (auto nameHint = primalFunc->findDecoration<IRNameHintDecoration>())
     {
-        auto primalName = nameHint->getName() + "_primal";
+        auto primalName = String(nameHint->getName()) + "_primal";
         nameHint->setOperand(0, builder.getStringValue(primalName.getUnownedSlice()));
     }
 

--- a/source/slang/slang-ir-autodiff-unzip.cpp
+++ b/source/slang/slang-ir-autodiff-unzip.cpp
@@ -72,23 +72,11 @@ struct ExtractPrimalFuncContext
         IRFuncType* originalFuncType = nullptr;
         outIntermediateType = createIntermediateType(destFunc);
 
-        if (auto gen = as<IRGeneric>(destFunc))
-        {
-            auto func = findGenericReturnVal(gen);
-            builder.setInsertBefore(func);
-            outIntermediateType =
-                specializeWithGeneric(builder, outIntermediateType, gen);
-            SLANG_RELEASE_ASSERT(func);
-            originalFuncType = as<IRFuncType>(as<IRGeneric>(fwdFunc)->getDataType());
-        }
-        else
-        {
-            originalFuncType = as<IRFuncType>(fwdFunc->getDataType());
-        }
+        originalFuncType = as<IRFuncType>(fwdFunc->getDataType());
 
         SLANG_RELEASE_ASSERT(originalFuncType);
         List<IRType*> paramTypes;
-        for (UInt i = 0; i < originalFuncType->getParamCount(); i++)
+        for (UInt i = 0; i < originalFuncType->getParamCount() - 1; i++)
             paramTypes.add(originalFuncType->getParamType(i));
         paramTypes.add(builder.getInOutType((IRType*)outIntermediateType));
         auto newFuncType = builder.getFuncType(paramTypes, builder.getVoidType());
@@ -243,75 +231,9 @@ struct ExtractPrimalFuncContext
         return true;
     }
 
-    // Given a `genericA<Param1, Param1,...> { instX(Param1, Param2) }`,
-    // and a clone of it `genericB<ParamB_1, ParamB_2,...> { }`.
-    // `GenericChildrenMigrationContext(genericA, genericB)::getCorrespondingInst(instX)`
-    // returns a clone of `instX` in `genericB` that references the new generic params
-    // as `instX_clone` in `genericB<ParamB_1, ParamB_2,...> { instX_clone(ParamB_1, ParamB_2) }`.
-    struct GenericChildrenMigrationContext
-    {
-        IRCloneEnv cloneEnv;
-        IRGeneric* oldGeneric = nullptr;
-        IRGeneric* newGeneric = nullptr;
-        IRInst* newGenericRetVal = nullptr;
-
-        void init(IRGeneric* oldGen, IRGeneric* newGen)
-        {
-            oldGeneric = oldGen;
-            newGeneric = newGen;
-            newGenericRetVal = findGenericReturnVal(newGen);
-
-            IRInst* oldParam = oldGen->getFirstParam();
-            IRInst* newParam = newGen->getFirstParam();
-            while (oldParam)
-            {
-                oldParam = as<IRParam>(oldParam->getNextInst());
-                newParam = as<IRParam>(newParam->getNextInst());
-                if (!oldParam)
-                {
-                    SLANG_RELEASE_ASSERT(!newParam);
-                    break;
-                }
-                SLANG_RELEASE_ASSERT(newParam);
-                cloneEnv.mapOldValToNew[oldParam] = newParam;
-            }
-        }
-        IRInst* getCorrespondingInst(IRBuilder& builder, IRInst* oldChild)
-        {
-            if (!oldGeneric)
-                return oldChild;
-            auto parent = oldChild->getParent();
-            bool found = false;
-            while (parent)
-            {
-                if (parent == oldGeneric)
-                {
-                    found = true;
-                    break;
-                }
-                parent = parent->getParent();
-            }
-            if (!found)
-                return oldChild;
-            for (UInt i = 0; i < oldChild->getOperandCount(); i++)
-            {
-                auto operand = oldChild->getOperand(i);
-                if (cloneEnv.mapOldValToNew.ContainsKey(operand))
-                {}
-                else
-                {
-                    getCorrespondingInst(builder, operand);
-                }
-            }
-            auto cloned = cloneInst(&cloneEnv, &builder, oldChild);
-            return cloned;
-        }
-    };
-
     void storeInst(
         IRBuilder& builder,
         IRInst* inst,
-        GenericChildrenMigrationContext& genericContext,
         IRInst* intermediateOutput)
     {
         IRBuilder genTypeBuilder(sharedBuilder);
@@ -319,7 +241,7 @@ struct ExtractPrimalFuncContext
         SLANG_RELEASE_ASSERT(ptrStructType);
         auto structType = as<IRStructType>(ptrStructType->getValueType());
         genTypeBuilder.setInsertBefore(structType);
-        auto fieldType = genericContext.getCorrespondingInst(genTypeBuilder, inst->getDataType());
+        auto fieldType = inst->getDataType();
         SLANG_RELEASE_ASSERT(structType);
         auto structKey = genTypeBuilder.createStructKey();
         if (auto nameHint = inst->findDecoration<IRNameHintDecoration>())
@@ -333,30 +255,16 @@ struct ExtractPrimalFuncContext
             inst);
     }
 
-    IRGlobalValueWithCode* turnUnzippedFuncIntoPrimalFunc(IRGlobalValueWithCode* unzippedFunc, IRGlobalValueWithCode* fwdFunc, IRInst*& outIntermediateType)
+    IRFunc* turnUnzippedFuncIntoPrimalFunc(IRFunc* unzippedFunc, IRFunc* fwdFunc, IRInst*& outIntermediateType)
     {
         // Note: this transformation assumes the original func has only one return.
 
         IRBuilder builder(sharedBuilder);
 
-        IRFunc* func = nullptr;
+        IRFunc* func = unzippedFunc;
         IRInst* intermediateType = nullptr;
         auto newFuncType = generatePrimalFuncType(unzippedFunc, fwdFunc, intermediateType);
-        if (auto gen = as<IRGeneric>(unzippedFunc))
-        {
-            func = as<IRFunc>(findGenericReturnVal(gen));
-            SLANG_RELEASE_ASSERT(func);
-            builder.setInsertBefore(func);
-            auto spec = as<IRSpecialize>(intermediateType);
-            SLANG_RELEASE_ASSERT(spec);
-            outIntermediateType = spec->getBase();
-        }
-        else
-        {
-            func = as<IRFunc>(unzippedFunc);
-            SLANG_RELEASE_ASSERT(func);
-            outIntermediateType = intermediateType;
-        }
+        outIntermediateType = intermediateType;
         func->setFullType((IRType*)newFuncType);
 
         // Go through all the insts and preserve the primal blocks.
@@ -375,18 +283,13 @@ struct ExtractPrimalFuncContext
 
         auto paramBlock = func->getFirstBlock();
         builder.setInsertInto(paramBlock);
+        auto oldIntermediateParam = func->getLastParam();
         auto outIntermediary =
             builder.emitParam(builder.getInOutType((IRType*)intermediateType));
+        oldIntermediateParam->replaceUsesWith(outIntermediary);
+        oldIntermediateParam->removeAndDeallocate();
 
         auto firstBlock = *(paramBlock->getSuccessors().begin());
-
-        GenericChildrenMigrationContext genericMigrationContext;
-        if (auto gen = as<IRGeneric>(unzippedFunc))
-        {
-            auto spec = as<IRSpecialize>(intermediateType);
-            SLANG_RELEASE_ASSERT(spec);
-            genericMigrationContext.init(gen, as<IRGeneric>(spec->getBase()));
-        }
 
         List<IRBlock*> diffBlocksList;
         List<IRBlock*> primalBlocksList;
@@ -412,7 +315,7 @@ struct ExtractPrimalFuncContext
                 if (shouldStoreInst(inst))
                 {
                     builder.setInsertAfter(inst);
-                    storeInst(builder, inst, genericMigrationContext, outIntermediary);
+                    storeInst(builder, inst, outIntermediary);
                 }
             }
         }
@@ -482,8 +385,8 @@ static void copyPrimalValueStructKeyDecorations(IRInst* inst, IRCloneEnv& cloneE
     }
 }
 
-IRGlobalValueWithCode* DiffUnzipPass::extractPrimalFunc(
-    IRGlobalValueWithCode* func, IRGlobalValueWithCode* fwdFunc, IRInst*& intermediateType)
+IRFunc* DiffUnzipPass::extractPrimalFunc(
+    IRFunc* func, IRFunc* fwdFunc, IRInst*& intermediateType)
 {
     IRBuilder builder(this->autodiffContext->sharedBuilder);
     builder.setInsertBefore(func);
@@ -491,46 +394,31 @@ IRGlobalValueWithCode* DiffUnzipPass::extractPrimalFunc(
     IRCloneEnv subEnv;
     subEnv.squashChildrenMapping = true;
     subEnv.parent = &cloneEnv;
-    auto clonedFunc = as<IRGlobalValueWithCode>(cloneInst(&subEnv, &builder, func));
+    auto clonedFunc = as<IRFunc>(cloneInst(&subEnv, &builder, func));
 
     ExtractPrimalFuncContext context;
     context.init(autodiffContext->sharedBuilder);
 
     intermediateType = nullptr;
     auto primalFunc = context.turnUnzippedFuncIntoPrimalFunc(clonedFunc, fwdFunc, intermediateType);
-    IRInst* specializedPrimalFunc = primalFunc;
+
+    if (auto nameHint = primalFunc->findDecoration<IRNameHintDecoration>())
+    {
+        auto primalName = nameHint->getName() + "_primal";
+        nameHint->setOperand(0, builder.getStringValue(primalName.getUnownedSlice()));
+    }
 
     // Copy PrimalValueStructKey decorations from primal func.
     copyPrimalValueStructKeyDecorations(func, subEnv);
     
-    IRInst* specializedIntermediateType = intermediateType;
-    auto innerFunc = as<IRFunc>(func);
-
-    if (auto genFunc = as<IRGeneric>(func))
-    {
-        innerFunc = as<IRFunc>(findGenericReturnVal(genFunc));
-        builder.setInsertBefore(innerFunc);
-        specializedIntermediateType = specializeWithGeneric(builder, intermediateType, genFunc);
-        specializedPrimalFunc = specializeWithGeneric(builder, primalFunc, genFunc);
-    }
-    SLANG_RELEASE_ASSERT(innerFunc);
-
-    // Insert a call to primal func at start of the function.
-    auto paramBlock = innerFunc->getFirstBlock();
+    auto paramBlock = func->getFirstBlock();
     auto firstBlock = *(paramBlock->getSuccessors().begin());
     builder.setInsertBefore(firstBlock->getFirstInst());
-    auto intermediateVar = builder.emitVar((IRType*)specializedIntermediateType);
-    List<IRInst*> args;
-    for (auto param : paramBlock->getParams())
-    {
-        args.add(param);
-    }
-    args.add(intermediateVar);
-    builder.emitCallInst(innerFunc->getResultType(), specializedPrimalFunc, args);
+    auto intermediateVar = func->getLastParam();
 
     // Replace all insts that has intermediate results with a load of the intermediate.
     List<IRInst*> instsToRemove;
-    for (auto block : innerFunc->getBlocks())
+    for (auto block : func->getBlocks())
     {
         for (auto inst : block->getOrdinaryInsts())
         {
@@ -554,8 +442,8 @@ IRGlobalValueWithCode* DiffUnzipPass::extractPrimalFunc(
     }
 
     // Run simplification to DCE unnecessary insts.
-    eliminateDeadCode(innerFunc);
-    eliminateDeadCode(specializedPrimalFunc);
+    eliminateDeadCode(func);
+    eliminateDeadCode(primalFunc);
 
     return primalFunc;
 }

--- a/source/slang/slang-ir-autodiff-unzip.h
+++ b/source/slang/slang-ir-autodiff-unzip.h
@@ -132,7 +132,7 @@ struct DiffUnzipPass
         return unzippedFunc;
     }
 
-    IRGlobalValueWithCode* extractPrimalFunc(IRGlobalValueWithCode* func, IRGlobalValueWithCode* fwdFunc, IRInst*& intermediateType);
+    IRFunc* extractPrimalFunc(IRFunc* func, IRFunc* fwdFunc, IRInst*& intermediateType);
 
     bool isRelevantDifferentialPair(IRType* type)
     {

--- a/source/slang/slang-ir-autodiff.h
+++ b/source/slang/slang-ir-autodiff.h
@@ -37,7 +37,7 @@ typedef DiffInstPair<IRInst*, IRInst*> InstPair;
 
 enum class FuncBodyTranscriptionTaskType
 {
-    Forward, Backward, Primal
+    Forward, BackwardPrimal, BackwardPropagate, Backward
 };
 
 struct FuncBodyTranscriptionTask

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -60,6 +60,7 @@ INST(Nop, nop, 0, 0)
     INST(OptionalType, Optional, 1, 0)
 
     INST(DifferentialPairType, DiffPair, 1, 0)
+    INST(BackwardDiffIntermediateContextType, BwdDiffIntermediateCtxType, 1, 0)
 
     /* BindExistentialsTypeBase */
 
@@ -731,6 +732,9 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     INST(BackwardDifferentiableDecoration, backwardDifferentiable, 1, 0)
 
         /// Decorated function is marked for the reverse-mode differentiation pass.
+    INST(BackwardDerivativePrimalDecoration, backwardDiffPrimalReference, 1, 0)
+    INST(BackwardDerivativePropagateDecoration, backwardDiffPropagateReference, 1, 0)
+    INST(BackwardDerivativeIntermediateTypeDecoration, backwardDiffIntermediateTypeReference, 1, 0)
     INST(BackwardDerivativeDecoration, backwardDiffReference, 1, 0)
 
         /// Used by the auto-diff pass to mark insts that compute
@@ -815,8 +819,18 @@ INST(CastToVoid, castToVoid, 1, 0)
 
 INST(IsType, IsType, 3, 0)
 INST(ForwardDifferentiate,                   ForwardDifferentiate,            1, 0)
-INST(BackwardDifferentiate,                  BackwardDifferentiate,           1, 0)
-INST(DifferentialEqualityTypeCast, DifferentialEqualityTypeCast, 1, 0)
+
+// Produces the primal computation of backward derivatives, will return an intermediate context for
+// backward derivative func.
+INST(BackwardDifferentiatePrimal,            BackwardDifferentiatePrimal,     1, 0)
+
+// Produces the actual backward derivative propagate function, using the intermediate context returned by the
+// primal func produced from `BackwardDifferentiatePrimal`.
+INST(BackwardDifferentiatePropagate,         BackwardDifferentiatePropagate,  1, 0)
+
+// Represents the conceptual backward derivative function. Only produced by lower-to-ir and will be
+// replaced with `BackwardDifferentiatePrimal` and `BackwardDifferentiatePropagate`.
+INST(BackwardDifferentiate, BackwardDifferentiate, 1, 0)
 
 // Converts other resources (such as ByteAddressBuffer) to the equivalent StructuredBuffer
 INST(GetEquivalentStructuredBuffer,     getEquivalentStructuredBuffer, 1, 0)
@@ -875,6 +889,11 @@ INST(DifferentiableTypeDictionaryItem, DifferentiableTypeDictionaryItem, 0, 0)
 /* DifferentiableMethodRequirementDictionaryItem */
     INST(ForwardDifferentiableMethodRequirementDictionaryItem, DifferentiableMethodRequirementDictionaryItem, 0, 0)
     INST(BackwardDifferentiableMethodRequirementDictionaryItem, DifferentiableMethodRequirementDictionaryItem, 0, 0)
+    INST(BackwardDifferentiablePrimalMethodRequirementDictionaryItem, DifferentiablePrimalMethodRequirementDictionaryItem, 0, 0)
+    INST(BackwardDifferentiablePropagateMethodRequirementDictionaryItem, DifferentiablePropagateMethodRequirementDictionaryItem, 0, 0)
+    INST(BackwardDifferentiableIntermediateTypeRequirementDictionaryItem, DifferentiableIntermediateTypeRequirementDictionaryItem, 0, 0)
+
+
 INST_RANGE(DifferentiableMethodRequirementDictionaryItem, ForwardDifferentiableMethodRequirementDictionaryItem, BackwardDifferentiableMethodRequirementDictionaryItem)
 
 #undef PARENT

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -403,7 +403,7 @@ struct SpecializationContext
                     // If the base is specialized, the JVP version must be also be a specialized
                     // generic.
                     //
-                    SLANG_ASSERT(specDiffFunc);
+                    SLANG_RELEASE_ASSERT(specDiffFunc);
 
                     // Build specialization arguments from specInst.
                     // Note that if we've reached this point, we can safely assume

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -1,5 +1,6 @@
 #include "slang-ir-util.h"
 #include "slang-ir-insts.h"
+#include "slang-ir-clone.h"
 
 namespace Slang
 {
@@ -141,6 +142,79 @@ IRInst* specializeWithGeneric(IRBuilder& builder, IRInst* genericToSpecialize, I
         genericToSpecialize,
         (UInt)genArgs.getCount(),
         genArgs.getBuffer());
+}
+
+IRInst* maybeSpecializeWithGeneric(IRBuilder& builder, IRInst* genericToSpecailize, IRInst* userGeneric)
+{
+    if (auto gen = as<IRGeneric>(userGeneric))
+    {
+        if (auto toSpecialize = as<IRGeneric>(genericToSpecailize))
+        {
+            return specializeWithGeneric(builder, toSpecialize, gen);
+        }
+    }
+    return genericToSpecailize;
+}
+
+IRInst* hoistValueFromGeneric(IRBuilder& builder, IRInst* value, IRInst*& outSpecializedVal, bool replaceExistingValue)
+{
+    auto outerGeneric = as<IRGeneric>(findOuterGeneric(value));
+    if (!outerGeneric) return value;
+
+    builder.setInsertBefore(outerGeneric);
+    auto newGeneric = builder.emitGeneric();
+    builder.setInsertInto(newGeneric);
+    builder.emitBlock();
+    IRInst* newResultVal = nullptr;
+
+    // Clone insts in outerGeneric up until `value`.
+    IRCloneEnv cloneEnv;
+    for (auto inst : outerGeneric->getFirstBlock()->getChildren())
+    {
+        auto newInst = cloneInst(&cloneEnv, &builder, inst);
+        if (inst == value)
+        {
+            builder.emitReturn(newInst);
+            newResultVal = newInst;
+            break;
+        }
+    }
+    SLANG_RELEASE_ASSERT(newResultVal);
+    if (newResultVal->getOp() == kIROp_Func)
+    {
+        IRBuilder subBuilder = builder;
+        IRInst* subOutSpecialized = nullptr;
+        auto genericFuncType = hoistValueFromGeneric(subBuilder, newResultVal->getFullType(), subOutSpecialized, false);
+        newGeneric->setFullType((IRType*)genericFuncType);
+    }
+    else
+    {
+        newGeneric->setFullType(builder.getTypeKind());
+    }
+    if (replaceExistingValue)
+    {
+        builder.setInsertBefore(value);
+        outSpecializedVal = specializeWithGeneric(builder, newGeneric, outerGeneric);
+        value->replaceUsesWith(outSpecializedVal);
+        value->removeAndDeallocate();
+    }
+    return newGeneric;
+}
+
+void moveInstChildren(IRInst* dest, IRInst* src)
+{
+    for (auto child = dest->getFirstDecorationOrChild(); child; )
+    {
+        auto next = child->getNextInst();
+        child->removeAndDeallocate();
+        child = next;
+    }
+    for (auto child = src->getFirstDecorationOrChild(); child; )
+    {
+        auto next = child->getNextInst();
+        child->insertAtEnd(dest);
+        child = next;
+    }
 }
 
 }

--- a/source/slang/slang-ir-util.h
+++ b/source/slang/slang-ir-util.h
@@ -61,6 +61,40 @@ inline bool isChildInstOf(IRInst* inst, IRInst* parent)
 IRInst* specializeWithGeneric(
     IRBuilder& builder, IRInst* genericToSpecialize, IRGeneric* userGeneric);
 
+IRInst* maybeSpecializeWithGeneric(IRBuilder& builder, IRInst* genericToSpecailize, IRInst* userGeneric);
+
+    // For a value inside a generic, create a standalone generic wrapping just the value, and replace the use of
+    // the original value with a specialization of the new generic using the current generic arguments if
+    // `replaceExistingValue` is true.
+    // For example, if we have
+    // ```
+    //     generic G { param T; v = x(T); f = y(v); return f; }
+    // ```
+    // hoistValueFromGeneric(G, v) turns the code into:
+    // ```
+    //     generic G1 { param T1; v1 = x(T); return v1; }
+    //     generic G { param T; v = specialize(G1, T); f = y(v); return f; }
+    // ```
+    // This function returns newly created generic inst.
+    // if `value` is not inside any generic, this function makes no change to IR, and returns `value`.
+IRInst* hoistValueFromGeneric(
+    IRBuilder& builder,
+    IRInst* value,
+    IRInst*& outSpecializedVal,
+    bool replaceExistingValue = false);
+
+// Clear dest and move all chidlren from src to dest.
+void moveInstChildren(IRInst* dest, IRInst* src);
+
+inline bool isGenericParam(IRInst* param)
+{
+    auto parent = param->getParent();
+    if (auto block = as<IRBlock>(parent))
+        parent = block->getParent();
+    if (as<IRGeneric>(parent))
+        return true;
+    return false;
+}
 
 inline IRInst* unwrapAttributedType(IRInst* type)
 {

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -300,6 +300,11 @@ namespace Slang
         return as<IRParam>(getNextInst());
     }
 
+    IRParam* IRParam::getPrevParam()
+    {
+        return as<IRParam>(getPrevInst());
+    }
+
     // IRArrayTypeBase
 
     IRInst* IRArrayTypeBase::getElementCount()
@@ -2802,6 +2807,15 @@ namespace Slang
             operands);
     }
 
+    IRBackwardDiffIntermediateContextType* IRBuilder::getBackwardDiffIntermediateContextType(
+        IRInst* func)
+    {
+        return (IRBackwardDiffIntermediateContextType*)getType(
+            kIROp_BackwardDiffIntermediateContextType,
+            1,
+            &func);
+    }
+
     IRFuncType* IRBuilder::getFuncType(
         UInt            paramCount,
         IRType* const*  paramTypes,
@@ -3123,6 +3137,28 @@ namespace Slang
         auto inst = createInst<IRBackwardDifferentiate>(
             this,
             kIROp_BackwardDifferentiate,
+            type,
+            baseFn);
+        addInst(inst);
+        return inst;
+    }
+
+    IRInst* IRBuilder::emitBackwardDifferentiatePrimalInst(IRType* type, IRInst* baseFn)
+    {
+        auto inst = createInst<IRBackwardDifferentiatePrimal>(
+            this,
+            kIROp_BackwardDifferentiatePrimal,
+            type,
+            baseFn);
+        addInst(inst);
+        return inst;
+    }
+
+    IRInst* IRBuilder::emitBackwardDifferentiatePropagateInst(IRType* type, IRInst* baseFn)
+    {
+        auto inst = createInst<IRBackwardDifferentiatePropagate>(
+            this,
+            kIROp_BackwardDifferentiatePropagate,
             type,
             baseFn);
         addInst(inst);
@@ -6622,6 +6658,7 @@ namespace Slang
         case kIROp_UnpackAnyValue:
         case kIROp_Reinterpret:
         case kIROp_GetNativePtr:
+        case kIROp_BackwardDiffIntermediateContextType:
             return false;
 
         case kIROp_ForwardDifferentiate:
@@ -6904,6 +6941,16 @@ namespace Slang
         }
         return nullptr;
     }
+
+    IRInst* getGenericReturnVal(IRInst* inst)
+    {
+        if (auto gen = as<IRGeneric>(inst))
+        {
+            return findGenericReturnVal(gen);
+        }
+        return inst;
+    }
+
 } // namespace Slang
 
 #if SLANG_VC
@@ -6917,4 +6964,3 @@ SLANG_API const int SlangDebug__IROpStringLit = Slang::kIROp_StringLit;
 SLANG_API const int SlangDebug__IROpIntLit = Slang::kIROp_IntLit;
 #endif
 #endif
-

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1347,6 +1347,12 @@ struct IRDifferentialPairType : IRType
     IR_LEAF_ISA(DifferentialPairType)
 };
 
+struct IRBackwardDiffIntermediateContextType : IRType
+{
+    IRInst* getFunc() { return getOperand(0); }
+    IR_LEAF_ISA(BackwardDiffIntermediateContextType)
+};
+
 struct IRVectorType : IRType
 {
     IRType* getElementType() { return (IRType*)getOperand(0); }
@@ -1742,6 +1748,9 @@ struct IRGeneric : IRGlobalValueWithParams
 IRInst* findGenericReturnVal(IRGeneric* generic);
 // Recursively find the inner most generic return value.
 IRInst* findInnerMostGenericReturnVal(IRGeneric* generic);
+
+// Returns the generic return val if `inst` is a generic, otherwise returns `inst`.
+IRInst* getGenericReturnVal(IRInst* inst);
 
 // Find the generic container, if any, that this inst is contained in
 // Returns nullptr if there is no outer container.

--- a/source/slang/slang-mangle.cpp
+++ b/source/slang/slang-mangle.cpp
@@ -521,6 +521,12 @@ namespace Slang
             emitRaw(context, "FwdReq_");
         else if (as<BackwardDerivativeRequirementDecl>(decl))
             emitRaw(context, "BwdReq_");
+        else if (as<BackwardDerivativePropagateRequirementDecl>(decl))
+            emitRaw(context, "BwdReq_Prop_");
+        else if (as<BackwardDerivativePrimalRequirementDecl>(decl))
+            emitRaw(context, "BwdReq_Primal_");
+        else if (as<BackwardDerivativeIntermediateTypeRequirementDecl>(decl))
+            emitRaw(context, "BwdReq_CtxType_");
         else
         {
             // TODO: handle other cases


### PR DESCRIPTION
The purpose of this change is to introduce two distinct IR ops to initiate backward differentiation: `IRBackwardDifferentiatePrimal` and `IRBackwardDifferentiatePropagate`, where the former produces the backward derivative primal function that contains the primal computations and outputs an intermediate value, and the later consumes the intermediate value and performs the backward propagation. The reason for introducing these changes is to allow us to handle recursive context save/restore for nested calls in a backward differentiable function, so that a `IRCall(callee)` can be transcribed into a call to `IRBackwardDifferentiatePrimal(callee)` in the primal part of the backward derivative func, and into a call to the `IRBackwardDifferentiatePropagate(callee)` in the propagate part of the backward derivative func, and stores its context as a field of `IRBackwardDerivativeIntermediateContextType(callee)` type.

The existing `IRBackwardDifferentiate` opcode is perserved to produce a single backward derivative function that takes no intermediate value argument, and it first calls the primal func followed by the propagate func. Only the front-end is supposed to generate an `IRBackwardDifferentiate` inst during initial lowering.

With this change,  the `BackwardDiffTranscriber` now splits into `BackwardDiffPrimalTranscriber` and `BackwardDiffPropagateTranscriber` and share most of there logic through the common base class `BackwardDiffTranscriberBase`. The main difference between the two is in producing the transcribed function header and function type: the backward-diff-primal func produces the intermediate value through an `out` parameter, and the backward-diff-propagate func consumes the intermediate value.

We also introduce the `IRBackwardDerivativeIntermediateContextType` opcode to use as a placeholder for the to-be-generated intermediate value type. This inst is produced and then lowered into an actual struct during autodiff pass.

A `[BackwardDifferentiable]` interface requirement now correspond to five witness table entries: one for the original function, one for the simple backward derivative func (that takes no interemdiate val argument and performs both primal and propagate computations), one for the backward-diff-primal func, and one for the backward-diff-propagate-func, and one for the associated intermediate type. The front-end is modified to produce witness tables in such form so we can transcribe the `IRLookupWitness` insts.

The body of both backward-diff-primal and backward-diff-propagate functions are still generated at the same time when processing `IRBackwardDifferentiatePropagate`, although their headers are produced separately upon seeing an `IRBackwardDifferentiatePrimal` or `IRBackwardDifferentiatePropagate` insts.

