### PR TITLE
Use gmake2 as a premake target over gmake

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -69,13 +69,13 @@ Supported `--arch` options are
 For Unix like targets that might have `clang` or `gcc` compilers available you can select which one via the `-cc` option. For example...
 
 ```
-% premake5 gmake --cc=clang --deps=true --arch=x64
+% premake5 gmake2 --cc=clang --deps=true --arch=x64
 ```
 
 or 
 
 ```
-% premake5 gmake --cc=gcc --deps=true --arch=x64
+% premake5 gmake2 --cc=gcc --deps=true --arch=x64
 ```
 
 If you want to build the [`glslang`](https://github.com/KhronosGroup/glslang) library that Slang uses, add the option `--build-glslang=true`.
@@ -126,7 +126,7 @@ On Linux we need to generate Makefiles using `premake`. Please read the `premake
 In the terminal go to the root directory of the slang source tree (ie the directory containing `slang.h`). Assuming `premake5` is in your `PATH` use  
 
 ```
-% premake5 gmake --deps=true --arch=x64
+% premake5 gmake2 --deps=true --arch=x64
 ```
 
 To create a release build use
@@ -144,13 +144,13 @@ Note that OSX isn't an official target.
 On Mac OSX to generate Makefiles or an XCode project we use `premake`. Please read the `premake` section for more details. 
 
 ```
-% premake5 gmake --deps=true --arch=x64
+% premake5 gmake2 --deps=true --arch=x64
 ```
 
 If you want to build `glslang` (necessary for Slang to output SPIR-V for example), then the additional `--build-glslang` option should be used
 
 ```
-% premake5 gmake --build-glslang=true --deps=true --arch=x64
+% premake5 gmake2 --build-glslang=true --deps=true --arch=x64
 ```
 
 To build for release you can use...
@@ -171,10 +171,10 @@ Then open the `slang.xcworkspace` project inside of Xcode and build.
 
 Note that Cygwin isn't an official target. 
 
-One issue with building on [Cygwin](https://cygwin.com/), is that there isn't a binary version of `premake` currently available. It may be possible to make this work by building `premake` from source, and then just doing `premake5 gmake`. Here we use another approach - using the windows `premake` to create a Cygwin project. To do this use the command line...
+One issue with building on [Cygwin](https://cygwin.com/), is that there isn't a binary version of `premake` currently available. It may be possible to make this work by building `premake` from source, and then just doing `premake5 gmake2`. Here we use another approach - using the windows `premake` to create a Cygwin project. To do this use the command line...
 
 ```
-% premake5 --target-detail=cygwin gmake --deps=true --arch=x64
+% premake5 --target-detail=cygwin gmake2 --deps=true --arch=x64
 ```
 
 ## Testing

--- a/external/glslang-generated/README.md
+++ b/external/glslang-generated/README.md
@@ -54,7 +54,7 @@ For Visual Studio
 For gcc or clang (add -cc=clang)
 
 ```
-% premake gmake --build-glslang=true
+% premake gmake2 --build-glslang=true
 ```
 
 Then just build Slang as usual in visual studio, or from the linux command line for example

--- a/github_build.sh
+++ b/github_build.sh
@@ -14,7 +14,7 @@ fi
 if [[ "${ARCH}" != "${TARGETARCH}" ]]; then
 
 # Create the makefile
-./premake5 gmake --cc=${CC} --enable-embed-stdlib=true --arch=${ARCH} --deps=true --no-progress=true
+./premake5 gmake2 --cc=${CC} --enable-embed-stdlib=true --arch=${ARCH} --deps=true --no-progress=true
 
 # Build the configuration
 make config=${CONFIGURATION}_${ARCH} -j`nproc`
@@ -22,11 +22,11 @@ make config=${CONFIGURATION}_${ARCH} -j`nproc`
 rm -rf ./bin
 
 # Create the makefile
-./premake5 gmake --cc=${CC} --enable-embed-stdlib=true --arch=${TARGETARCH} --deps=true --no-progress=true  --skip-source-generation=true --deploy-slang-llvm=false --deploy-slang-glslang=false
+./premake5 gmake2 --cc=${CC} --enable-embed-stdlib=true --arch=${TARGETARCH} --deps=true --no-progress=true  --skip-source-generation=true --deploy-slang-llvm=false --deploy-slang-glslang=false
 
 else
 # Create the makefile
-./premake5 gmake --cc=${CC} --enable-embed-stdlib=true --arch=${TARGETARCH} --deps=true --no-progress=true
+./premake5 gmake2 --cc=${CC} --enable-embed-stdlib=true --arch=${TARGETARCH} --deps=true --no-progress=true
 fi
 
 # Build the configuration

--- a/github_macos_build.sh
+++ b/github_macos_build.sh
@@ -14,7 +14,7 @@ fi
 if [[ "${ARCH}" != "${TARGETARCH}" ]]; then
 
 # Create the makefile
-./premake5 gmake --cc=${CC} --enable-xlib=false --enable-embed-stdlib=true --arch=${ARCH} --deps=true --no-progress=true
+./premake5 gmake2 --cc=${CC} --enable-xlib=false --enable-embed-stdlib=true --arch=${ARCH} --deps=true --no-progress=true
 
 # Build the configuration
 make config=${CONFIGURATION}_${ARCH} -j`sysctl -n hw.ncpu`
@@ -23,11 +23,11 @@ rm -rf ./bin
 
 ARCH="arm64"
 # Create the makefile
-./premake5 gmake --cc=${CC} --enable-xlib=false --enable-embed-stdlib=true --arch=${TARGETARCH} --deps=true --no-progress=true  --skip-source-generation=true --deploy-slang-llvm=false --deploy-slang-glslang=false
+./premake5 gmake2 --cc=${CC} --enable-xlib=false --enable-embed-stdlib=true --arch=${TARGETARCH} --deps=true --no-progress=true  --skip-source-generation=true --deploy-slang-llvm=false --deploy-slang-glslang=false
 make config=${CONFIGURATION}_${TARGETARCH} -j`sysctl -n hw.ncpu`
 else
 # Create the makefile
-./premake5 gmake --cc=${CC} --enable-xlib=false --enable-embed-stdlib=true --arch=${TARGETARCH} --deps=true --no-progress=true
+./premake5 gmake2 --cc=${CC} --enable-xlib=false --enable-embed-stdlib=true --arch=${TARGETARCH} --deps=true --no-progress=true
 # Build the configuration
 make config=${CONFIGURATION}_${TARGETARCH}  -j`sysctl -n hw.ncpu`
 fi

--- a/premake5.lua
+++ b/premake5.lua
@@ -38,7 +38,7 @@
 --
 
 -- To output linux will output to linux
--- % premake5 --os=linux gmake --build-location="build.linux"
+-- % premake5 --os=linux gmake2 --build-location="build.linux"
 --
 -- % cd build.linux
 -- % make config=release_x64
@@ -46,7 +46,12 @@
 -- % make config=debug_x64
 --
 -- From in the build directory you can use
--- % premake5 --file=../premake5.lua --os=linux gmake
+-- % premake5 --file=../premake5.lua --os=linux gmake2
+
+-- Fail if we try to use the deprecated 'gmake' generator
+if _ACTION == "gmake" then
+    premake.error "Please use the 'gmake2' generator instead of 'gmake'"
+end
 
 --
 -- Add the package path for slang-pack/slang-util


### PR DESCRIPTION
According to the documentation, `gmake` has been deprecated by `gmake2` https://premake.github.io/docs/Using-Premake/#using-premake-to-generate-project-files

gmake2 has better dependency handling around our custom rules leading in fewer runs of slang-generate etc...

I've been using gmake2 without issue.