### PR TITLE
Frontend work for `[BackwardDerivative]` and `[BackwardDerivativeOf]`.

### DIFF
--- a/source/slang/diff.meta.slang
+++ b/source/slang/diff.meta.slang
@@ -9,10 +9,16 @@ __attributeTarget(FunctionDeclBase)
 attribute_syntax [ForwardDerivative(function)] : ForwardDerivativeAttribute;
 
 __attributeTarget(FunctionDeclBase)
+attribute_syntax [BackwardDerivative(function)] : BackwardDerivativeAttribute;
+
+__attributeTarget(FunctionDeclBase)
 attribute_syntax [BackwardDifferentiable] : BackwardDifferentiableAttribute;
 
 __attributeTarget(FunctionDeclBase)
 attribute_syntax [ForwardDerivativeOf(function)] : ForwardDerivativeOfAttribute;
+
+__attributeTarget(FunctionDeclBase)
+attribute_syntax [BackwardDerivativeOf(function)] : BackwardDerivativeOfAttribute;
 
 __attributeTarget(DeclBase)
 attribute_syntax [DerivativeMember(memberName)] : DerivativeMemberAttribute;

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -1066,26 +1066,36 @@ class ForwardDifferentiableAttribute : public DifferentiableAttribute
     SLANG_AST_CLASS(ForwardDifferentiableAttribute)
 };
 
-    /// The `[ForwardDerivative(function)]` attribute specifies a custom function that should
-    /// be used as the derivative for the decorated function.
-class ForwardDerivativeAttribute : public DifferentiableAttribute
+class UserDefinedDerivativeAttribute : public DifferentiableAttribute
 {
-    SLANG_AST_CLASS(ForwardDerivativeAttribute)
+    SLANG_AST_CLASS(UserDefinedDerivativeAttribute)
 
     Expr* funcExpr;
+};
+
+    /// The `[ForwardDerivative(function)]` attribute specifies a custom function that should
+    /// be used as the derivative for the decorated function.
+class ForwardDerivativeAttribute : public UserDefinedDerivativeAttribute
+{
+    SLANG_AST_CLASS(ForwardDerivativeAttribute)
+};
+
+class DerivativeOfAttribute : public DifferentiableAttribute
+{
+    SLANG_AST_CLASS(DerivativeOfAttribute)
+
+    Expr* funcExpr;
+
+    Expr* backDeclRef; // DeclRef to this derivative function when initiated from primalFunction.
 };
 
     /// The `[ForwardDerivativeOf(primalFunction)]` attribute marks the decorated function as custom
     /// derivative implementation for `primalFunction`.
     /// ForwardDerivativeOfAttribute inherits from DifferentiableAttribute because a derivative
     /// function itself is considered differentiable.
-class ForwardDerivativeOfAttribute : public DifferentiableAttribute
+class ForwardDerivativeOfAttribute : public DerivativeOfAttribute
 {
     SLANG_AST_CLASS(ForwardDerivativeOfAttribute)
-
-    Expr* funcExpr;
-
-    Expr* backDeclRef; // DeclRef to this derivative function when initiated from primalFunction.
 };
 
     /// The `[BackwardDifferentiable]` attribute indicates that a function can be backward-differentiated.
@@ -1096,21 +1106,16 @@ class BackwardDifferentiableAttribute : public DifferentiableAttribute
 
     /// The `[BackwardDerivative(function)]` attribute specifies a custom function that should
     /// be used as the backward-derivative for the decorated function.
-class BackwardDerivativeAttribute : public DifferentiableAttribute
+class BackwardDerivativeAttribute : public UserDefinedDerivativeAttribute
 {
     SLANG_AST_CLASS(BackwardDerivativeAttribute)
-    Expr* funcExpr;
 };
 
     /// The `[BackwardDerivativeOf(primalFunction)]` attribute marks the decorated function as custom
     /// backward-derivative implementation for `primalFunction`.
-class BackwardDerivativeOfAttribute : public DifferentiableAttribute
+class BackwardDerivativeOfAttribute : public DerivativeOfAttribute
 {
     SLANG_AST_CLASS(BackwardDerivativeOfAttribute)
-
-    Expr* funcExpr;
-
-    Expr* backDeclRef; // DeclRef to this derivative function when initiated from primalFunction.
 };
 
     /// The `[NoDiffThis]` attribute is used to specify that the `this` parameter should not be

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -4796,14 +4796,21 @@ namespace Slang
         return imaginaryArguments;
     }
 
+    // This helper function is needed to workaround a gcc bug.
+    // Remove when we upgrade to a newer version of gcc.
+    template <typename T>
+    static T* _findModifier(Decl* decl)
+    {
+        return decl->findModifier<T>();
+    }
 
-    template<typename TDerivativeAttr, typename TDerivativeOfAttr>
+    template <typename TDerivativeAttr, typename TDerivativeOfAttr>
     void checkDerivativeOfAttributeImpl(
-        SemanticsVisitor* visitor,
-        FunctionDeclBase* funcDecl,
-        TDerivativeOfAttr* derivativeOfAttr,
+        SemanticsVisitor *visitor,
+        FunctionDeclBase *funcDecl,
+        TDerivativeOfAttr *derivativeOfAttr,
         DeclAssociationKind assocKind,
-        const List<Expr*>& imaginaryArgsToOriginal)
+        const List<Expr *> &imaginaryArgsToOriginal)
     {
         auto invokeExpr = visitor->constructUncheckedInvokeExpr(derivativeOfAttr->funcExpr, imaginaryArgsToOriginal);
         auto resolved = visitor->ResolveInvoke(invokeExpr);
@@ -4811,7 +4818,8 @@ namespace Slang
         {
             if (auto calleeDeclRef = as<DeclRefExpr>(resolvedInvoke->functionExpr))
             {
-                if (auto existingModifier = calleeDeclRef->declRef.getDecl()->findModifier<TDerivativeAttr>())
+                auto calleeDecl = calleeDeclRef->declRef.getDecl();
+                if (auto existingModifier = _findModifier<TDerivativeAttr>(calleeDecl))
                 {
                     // The primal function already has a `[*Derivative]` attribute, this is invalid.
                     visitor->getSink()->diagnose(

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -259,10 +259,9 @@ namespace Slang
 
         void visitParamDecl(ParamDecl* paramDecl);
 
-        void checkDerivativeOfAttribute(FunctionDeclBase* funcDecl);
+        void checkForwardDerivativeOfAttribute(FunctionDeclBase* funcDecl);
 
-        void checkDerivativeAttribute(FunctionDeclBase* funcDecl, ForwardDerivativeAttribute* attr);
-
+        void checkBackwardDerivativeOfAttribute(FunctionDeclBase* funcDecl);
     };
 
         /// Should the given `decl` nested in `parentDecl` be treated as a static rather than instance declaration?
@@ -4668,90 +4667,265 @@ namespace Slang
             getSink()->diagnose(decl, Slang::Diagnostics::assocTypeInInterfaceOnly);
     }
 
-    void SemanticsDeclBodyVisitor::checkDerivativeOfAttribute(FunctionDeclBase* funcDecl)
+    template<typename TDerivativeAttr>
+    void checkDerivativeAttributeImpl(
+        SemanticsVisitor* visitor,
+        TDerivativeAttr* attr,
+        const List<Expr*>& imaginaryArguments)
     {
-        auto attr = funcDecl->findModifier<ForwardDerivativeOfAttribute>();
-        if (!attr)
-            return;
-
-        List<Expr*> imaginaryArguments;
-        for (auto param : funcDecl->getParameters())
+        auto invokeExpr = visitor->constructUncheckedInvokeExpr(attr->funcExpr, imaginaryArguments);
+        auto resolved = visitor->ResolveInvoke(invokeExpr);
+        if (auto resolvedInvoke = as<InvokeExpr>(resolved))
         {
-            auto arg = m_astBuilder->create<VarExpr>();
+            if (auto calleeDeclRef = as<DeclRefExpr>(resolvedInvoke->functionExpr))
+            {
+                attr->funcExpr = calleeDeclRef;
+                return;
+            }
+        }
+        visitor->getSink()->diagnose(attr, Diagnostics::invalidCustomDerivative);
+    }
+
+    template<typename TDerivativeAttr>
+    const char* getDerivativeAttrName() { SLANG_UNREACHABLE(""); }
+
+    template<>
+    const char* getDerivativeAttrName<ForwardDerivativeAttribute>()
+    {
+        return "ForwardDerivative";
+    }
+    template<>
+    const char* getDerivativeAttrName<BackwardDerivativeAttribute>()
+    {
+        return "BackwardDerivative";
+    }
+
+    List<Expr*> getImaginaryArgsToForwardDerivative(SemanticsVisitor* visitor, FunctionDeclBase* originalFuncDecl, SourceLoc loc)
+    {
+        List<Expr*> imaginaryArguments;
+        for (auto param : originalFuncDecl->getParameters())
+        {
+            auto arg = visitor->getASTBuilder()->create<VarExpr>();
             arg->declRef.decl = param;
             arg->type.isLeftValue = param->findModifier<OutModifier>() ? true : false;
             arg->type.type = param->getType();
-            arg->loc = attr->loc;
+            arg->loc = loc;
+            if (auto pairType = visitor->getDifferentialPairType(param->getType()))
+            {
+                arg->type.type = pairType;
+            }
+            imaginaryArguments.add(arg);
+        }
+        return imaginaryArguments;
+    }
+
+    List<Expr*> getImaginaryArgsToOriginalFuncFromForwardDerivativeFunc(ASTBuilder* astBuilder, FunctionDeclBase* fwdDiffFunc, SourceLoc loc)
+    {
+        List<Expr*> imaginaryArguments;
+        for (auto param : fwdDiffFunc->getParameters())
+        {
+            auto arg = astBuilder->create<VarExpr>();
+            arg->declRef.decl = param;
+            arg->type.isLeftValue = param->findModifier<OutModifier>() ? true : false;
+            arg->type.type = param->getType();
+            arg->loc = loc;
             if (auto pairType = as<DifferentialPairType>(param->getType()))
             {
                 arg->type.type = pairType->getPrimalType();
             }
             imaginaryArguments.add(arg);
         }
-        auto invokeExpr = constructUncheckedInvokeExpr(attr->funcExpr, imaginaryArguments);
-        auto resolved = ResolveInvoke(invokeExpr);
+        return imaginaryArguments;
+    }
+
+    List<Expr*> getImaginaryArgsToBackwardDerivative(SemanticsVisitor* visitor, FunctionDeclBase* originalFuncDecl, SourceLoc loc)
+    {
+        List<Expr*> imaginaryArguments;
+        for (auto param : originalFuncDecl->getParameters())
+        {
+            auto arg = visitor->getASTBuilder()->create<VarExpr>();
+            arg->declRef.decl = param;
+            arg->type.isLeftValue = param->findModifier<OutModifier>() ? true : false;
+            arg->type.type = param->getType();
+            arg->loc = loc;
+            if (auto pairType = visitor->getDifferentialPairType(param->getType()))
+            {
+                arg->type.type = pairType;
+                if (auto diffPairType = as<DifferentialPairType>(pairType))
+                {
+                    if (param->findModifier<OutModifier>() != nullptr && param->findModifier<InModifier>() == nullptr)
+                    {
+                        arg->type.isLeftValue = false;
+                        arg->type.type = diffPairType->getPrimalType();
+                    }
+                }
+            }
+            imaginaryArguments.add(arg);
+        }
+        if (auto diffReturnType = visitor->tryGetDifferentialType(visitor->getASTBuilder(), originalFuncDecl->returnType.type))
+        {
+            auto arg = visitor->getASTBuilder()->create<InitializerListExpr>();
+            arg->type.isLeftValue = false;
+            arg->type.type = diffReturnType;
+            arg->loc = loc;
+            imaginaryArguments.add(arg);
+        }
+        return imaginaryArguments;
+    }
+
+    List<Expr*> getImaginaryArgsToOriginalFuncFromBackwardDerivativeFunc(ASTBuilder* astBuilder, FunctionDeclBase* bwdDiffFunc, SourceLoc loc)
+    {
+        List<Expr*> imaginaryArguments;
+        for (auto param : bwdDiffFunc->getParameters())
+        {
+            auto arg = astBuilder->create<VarExpr>();
+            arg->declRef.decl = param;
+            arg->type.isLeftValue = param->findModifier<OutModifier>() ? true : false;
+            arg->type.type = param->getType();
+            arg->loc = loc;
+            if (auto pairType = as<DifferentialPairType>(param->getType()))
+            {
+                if (param->findModifier<OutModifier>() != nullptr && param->findModifier<InModifier>() == nullptr)
+                {
+                    arg->type.isLeftValue = false;
+                }
+                arg->type.type = pairType->getPrimalType();
+            }
+            imaginaryArguments.add(arg);
+        }
+        return imaginaryArguments;
+    }
+
+
+    template<typename TDerivativeAttr, typename TDerivativeOfAttr>
+    void checkDerivativeOfAttributeImpl(
+        SemanticsVisitor* visitor,
+        FunctionDeclBase* funcDecl,
+        TDerivativeOfAttr* derivativeOfAttr,
+        DeclAssociationKind assocKind,
+        const List<Expr*>& imaginaryArgsToOriginal)
+    {
+        auto invokeExpr = visitor->constructUncheckedInvokeExpr(derivativeOfAttr->funcExpr, imaginaryArgsToOriginal);
+        auto resolved = visitor->ResolveInvoke(invokeExpr);
         if (auto resolvedInvoke = as<InvokeExpr>(resolved))
         {
             if (auto calleeDeclRef = as<DeclRefExpr>(resolvedInvoke->functionExpr))
             {
-                if (auto existingModifier = calleeDeclRef->declRef.getDecl()->findModifier<ForwardDerivativeAttribute>())
+                if (auto existingModifier = calleeDeclRef->declRef.getDecl()->findModifier<TDerivativeAttr>())
                 {
-                    // The primal function already has a `[ForwardDerivative]` attribute, this is invalid.
-                    getSink()->diagnose(attr, Diagnostics::declAlreadyHasAttribute, calleeDeclRef->declRef, "[ForwardDerivative]");
-                    getSink()->diagnose(existingModifier->loc, Diagnostics::seeDeclarationOf, calleeDeclRef->declRef.getDecl());
+                    // The primal function already has a `[*Derivative]` attribute, this is invalid.
+                    visitor->getSink()->diagnose(
+                        derivativeOfAttr,
+                        Diagnostics::declAlreadyHasAttribute,
+                        calleeDeclRef->declRef,
+                        getDerivativeAttrName<TDerivativeAttr>());
+                    visitor->getSink()->diagnose(existingModifier->loc, Diagnostics::seeDeclarationOf, calleeDeclRef->declRef.getDecl());
                 }
-                attr->funcExpr = calleeDeclRef;
-                auto fwdDerivativeAttr = m_astBuilder->create<ForwardDerivativeAttribute>();
-                fwdDerivativeAttr->loc = attr->loc;
-                auto outterGeneric = GetOuterGeneric(funcDecl);
+                derivativeOfAttr->funcExpr = calleeDeclRef;
+                auto derivativeAttr = visitor->getASTBuilder()->create<TDerivativeAttr>();
+                derivativeAttr->loc = derivativeOfAttr->loc;
+                auto outterGeneric = visitor->GetOuterGeneric(funcDecl);
                 auto declRef =
                     DeclRef<Decl>((outterGeneric ? (Decl*)outterGeneric : funcDecl), nullptr);
-                auto declRefExpr = ConstructDeclRefExpr(declRef, nullptr, attr->loc, nullptr);
+                auto declRefExpr = visitor->ConstructDeclRefExpr(declRef, nullptr, derivativeOfAttr->loc, nullptr);
                 declRefExpr->type.type = nullptr;
-                fwdDerivativeAttr->args.add(declRefExpr);
-                fwdDerivativeAttr->funcExpr = declRefExpr;
-                checkDerivativeAttribute(as<FunctionDeclBase>(calleeDeclRef->declRef.getDecl()), fwdDerivativeAttr);
-                attr->backDeclRef = fwdDerivativeAttr->funcExpr;
-                fwdDerivativeAttr->funcExpr = nullptr;
-                getShared()->registerAssociatedDecl(calleeDeclRef->declRef.getDecl(), DeclAssociationKind::ForwardDerivativeFunc, funcDecl);
+                derivativeAttr->args.add(declRefExpr);
+                derivativeAttr->funcExpr = declRefExpr;
+                checkDerivativeAttribute(visitor, as<FunctionDeclBase>(calleeDeclRef->declRef.getDecl()), derivativeAttr);
+                derivativeOfAttr->backDeclRef = derivativeAttr->funcExpr;
+                derivativeAttr->funcExpr = nullptr;
+                visitor->getShared()->registerAssociatedDecl(calleeDeclRef->declRef.getDecl(), assocKind, funcDecl);
                 return;
             }
         }
-        getSink()->diagnose(attr, Diagnostics::invalidCustomDerivative);
+        visitor->getSink()->diagnose(derivativeOfAttr, Diagnostics::invalidCustomDerivative);
     }
 
-    void SemanticsDeclBodyVisitor::checkDerivativeAttribute(FunctionDeclBase* funcDecl, ForwardDerivativeAttribute* attr)
+    static void checkDerivativeAttribute(SemanticsVisitor* visitor, FunctionDeclBase* funcDecl, ForwardDerivativeAttribute* attr)
     {
         if (!attr->funcExpr)
             return;
         if (attr->funcExpr->type.type)
             return;
 
-        List<Expr*> imaginaryArguments;
-        for (auto param : funcDecl->getParameters())
+        List<Expr*> imaginaryArguments = getImaginaryArgsToForwardDerivative(visitor, funcDecl, attr->loc);
+        checkDerivativeAttributeImpl(visitor, attr, imaginaryArguments);
+    }
+
+    static void checkDerivativeAttribute(SemanticsVisitor* visitor, FunctionDeclBase* funcDecl, BackwardDerivativeAttribute* attr)
+    {
+        if (!attr->funcExpr)
+            return;
+        if (attr->funcExpr->type.type)
+            return;
+
+        List<Expr*> imaginaryArguments = getImaginaryArgsToBackwardDerivative(visitor, funcDecl, attr->loc);
+        checkDerivativeAttributeImpl(visitor, attr, imaginaryArguments);
+    }
+
+    template<typename TDerivativeAttr, typename TDerivativeOfAttr>
+    bool tryCheckDerivativeOfAttributeImpl(
+        SemanticsVisitor* visitor,
+        FunctionDeclBase* funcDecl,
+        TDerivativeOfAttr* derivativeOfAttr,
+        DeclAssociationKind assocKind,
+        const List<Expr*>& imaginaryArgsToOriginal)
+    {
+        DiagnosticSink tempSink(visitor->getSourceManager(), nullptr);
+        SemanticsVisitor subVisitor(visitor->withSink(&tempSink));
+        checkDerivativeOfAttributeImpl<TDerivativeAttr>(
+            &subVisitor,
+            funcDecl,
+            derivativeOfAttr,
+            assocKind,
+            imaginaryArgsToOriginal);
+        return tempSink.getErrorCount() == 0;
+    }
+
+    void SemanticsDeclBodyVisitor::checkForwardDerivativeOfAttribute(FunctionDeclBase* funcDecl)
+    {
+        auto attr = funcDecl->findModifier<ForwardDerivativeOfAttribute>();
+        if (!attr)
+            return;
+
+        List<Expr*> imaginaryArgsToOriginal = getImaginaryArgsToOriginalFuncFromForwardDerivativeFunc(m_astBuilder, funcDecl, attr->loc);
+        checkDerivativeOfAttributeImpl<ForwardDerivativeAttribute>(
+            this, funcDecl, attr, DeclAssociationKind::ForwardDerivativeFunc, imaginaryArgsToOriginal);
+    }
+
+    void SemanticsDeclBodyVisitor::checkBackwardDerivativeOfAttribute(FunctionDeclBase* funcDecl)
+    {
+        auto attr = funcDecl->findModifier<BackwardDerivativeOfAttribute>();
+        if (!attr)
+            return;
+
+        List<Expr*> imaginaryArguments = getImaginaryArgsToOriginalFuncFromBackwardDerivativeFunc(m_astBuilder, funcDecl, attr->loc);
+
+        // The tricky part here is that we can't easily derive the arguments to original func just
+        // from the definition of a backward derivative function, because we don't know if the last
+        // parameter is just a normal parameter of the original func, or if it is the additional
+        // derivative of the return value. The solution here is to try to resolve the original
+        // function with or without the last argument. However if the type of the last argument
+        // isn't differentiable, we know that it can't possibly be the result derivative.
+
+        if (imaginaryArguments.getCount() == 0 ||
+            !tryGetDifferentialType(m_astBuilder, imaginaryArguments.getLast()->type.type))
         {
-            auto arg = m_astBuilder->create<VarExpr>();
-            arg->declRef.decl = param;
-            arg->type.isLeftValue = param->findModifier<OutModifier>() ? true : false;
-            arg->type.type = param->getType();
-            arg->loc = attr->loc;
-            if (auto pairType = getDifferentialPairType(param->getType()))
-            {
-                arg->type.type = pairType;
-            }
-            imaginaryArguments.add(arg);
+            checkDerivativeOfAttributeImpl<BackwardDerivativeAttribute>(
+                this, funcDecl, attr, DeclAssociationKind::BackwardDerivativeFunc, imaginaryArguments);
+            return;
         }
-        auto invokeExpr = constructUncheckedInvokeExpr(attr->funcExpr, imaginaryArguments);
-        auto resolved = ResolveInvoke(invokeExpr);
-        if (auto resolvedInvoke = as<InvokeExpr>(resolved))
+
+        // Otherwise, try resolve with all the arguments, if failed, resolve without the last
+        // argument.
+        if (tryCheckDerivativeOfAttributeImpl<BackwardDerivativeAttribute>(this, funcDecl, attr, DeclAssociationKind::BackwardDerivativeFunc, imaginaryArguments))
         {
-            if (auto calleeDeclRef = as<DeclRefExpr>(resolvedInvoke->functionExpr))
-            {
-                attr->funcExpr = calleeDeclRef;
-                return;
-            }
+            return;
         }
-        getSink()->diagnose(attr, Diagnostics::invalidCustomDerivative);
+
+        imaginaryArguments.removeLast();
+        checkDerivativeOfAttributeImpl<BackwardDerivativeAttribute>(
+            this, funcDecl, attr, DeclAssociationKind::BackwardDerivativeFunc, imaginaryArguments);
     }
 
     void SemanticsDeclBodyVisitor::visitFunctionDeclBase(FunctionDeclBase* decl)
@@ -4759,9 +4933,12 @@ namespace Slang
         auto newContext = withParentFunc(decl);
 
         // Run checking on attributes that can't be fully checked in header checking stage.
-        checkDerivativeOfAttribute(decl);
+        checkForwardDerivativeOfAttribute(decl);
         if (auto derivativeAttr = decl->findModifier<ForwardDerivativeAttribute>())
-            checkDerivativeAttribute(decl, derivativeAttr);
+            checkDerivativeAttribute(this, decl, derivativeAttr);
+        checkBackwardDerivativeOfAttribute(decl);
+        if (auto derivativeAttr = decl->findModifier<BackwardDerivativeAttribute>())
+            checkDerivativeAttribute(this, decl, derivativeAttr);
 
         if (newContext.getParentDifferentiableAttribute())
         {

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -4806,11 +4806,11 @@ namespace Slang
 
     template <typename TDerivativeAttr, typename TDerivativeOfAttr>
     void checkDerivativeOfAttributeImpl(
-        SemanticsVisitor *visitor,
-        FunctionDeclBase *funcDecl,
-        TDerivativeOfAttr *derivativeOfAttr,
+        SemanticsVisitor* visitor,
+        FunctionDeclBase* funcDecl,
+        TDerivativeOfAttr* derivativeOfAttr,
         DeclAssociationKind assocKind,
-        const List<Expr *> &imaginaryArgsToOriginal)
+        const List<Expr*>& imaginaryArgsToOriginal)
     {
         auto invokeExpr = visitor->constructUncheckedInvokeExpr(derivativeOfAttr->funcExpr, imaginaryArgsToOriginal);
         auto resolved = visitor->ResolveInvoke(invokeExpr);

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -4811,18 +4811,18 @@ namespace Slang
         {
             if (auto calleeDeclRef = as<DeclRefExpr>(resolvedInvoke->functionExpr))
             {
-                if (auto existingModifier = calleeDeclRef->declRef.getDecl()->findModifier<TDerivativeAttr>())
+                if (auto existingModifier = calleeDeclRef->declRef.getDecl()->findModifier<typename TDerivativeAttr>())
                 {
                     // The primal function already has a `[*Derivative]` attribute, this is invalid.
                     visitor->getSink()->diagnose(
                         derivativeOfAttr,
                         Diagnostics::declAlreadyHasAttribute,
                         calleeDeclRef->declRef,
-                        getDerivativeAttrName<TDerivativeAttr>());
+                        getDerivativeAttrName<typename TDerivativeAttr>());
                     visitor->getSink()->diagnose(existingModifier->loc, Diagnostics::seeDeclarationOf, calleeDeclRef->declRef.getDecl());
                 }
                 derivativeOfAttr->funcExpr = calleeDeclRef;
-                auto derivativeAttr = visitor->getASTBuilder()->create<TDerivativeAttr>();
+                auto derivativeAttr = visitor->getASTBuilder()->create<typename TDerivativeAttr>();
                 derivativeAttr->loc = derivativeOfAttr->loc;
                 auto outterGeneric = visitor->GetOuterGeneric(funcDecl);
                 auto declRef =

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -4811,18 +4811,18 @@ namespace Slang
         {
             if (auto calleeDeclRef = as<DeclRefExpr>(resolvedInvoke->functionExpr))
             {
-                if (auto existingModifier = calleeDeclRef->declRef.getDecl()->findModifier<typename TDerivativeAttr>())
+                if (auto existingModifier = calleeDeclRef->declRef.getDecl()->findModifier<TDerivativeAttr>())
                 {
                     // The primal function already has a `[*Derivative]` attribute, this is invalid.
                     visitor->getSink()->diagnose(
                         derivativeOfAttr,
                         Diagnostics::declAlreadyHasAttribute,
                         calleeDeclRef->declRef,
-                        getDerivativeAttrName<typename TDerivativeAttr>());
+                        getDerivativeAttrName<TDerivativeAttr>());
                     visitor->getSink()->diagnose(existingModifier->loc, Diagnostics::seeDeclarationOf, calleeDeclRef->declRef.getDecl());
                 }
                 derivativeOfAttr->funcExpr = calleeDeclRef;
-                auto derivativeAttr = visitor->getASTBuilder()->create<typename TDerivativeAttr>();
+                auto derivativeAttr = visitor->getASTBuilder()->create<TDerivativeAttr>();
                 derivativeAttr->loc = derivativeOfAttr->loc;
                 auto outterGeneric = visitor->GetOuterGeneric(funcDecl);
                 auto declRef =

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -635,7 +635,7 @@ namespace Slang
             diffExpr->type.type = nullptr;
             forwardDerivativeAttr->funcExpr = diffExpr;
         }
-        else if (auto forwardDerivativeOfAttr = as<ForwardDerivativeOfAttribute>(attr))
+        else if (auto derivativeOfAttr = as<DerivativeOfAttribute>(attr))
         {
             SLANG_ASSERT(attr->args.getCount() == 1);
             SLANG_ASSERT(as<Decl>(attrTarget));
@@ -648,7 +648,7 @@ namespace Slang
                 getSink()->diagnose(primalFunc, Slang::Diagnostics::invalidCustomDerivative, as<Decl>(attrTarget));
                 return false;
             }
-            forwardDerivativeOfAttr->funcExpr = primalFunc;
+            derivativeOfAttr->funcExpr = primalFunc;
         }
         else if (auto comInterfaceAttr = as<ComInterfaceAttribute>(attr))
         {

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -345,7 +345,7 @@ DIAGNOSTIC(31142, Error, ambiguousOriginalDefintionOfExternDecl, "`extern` decl 
 DIAGNOSTIC(31143, Error, missingOriginalDefintionOfExternDecl, "no original definition found for `extern` decl '$0'.")
 
 DIAGNOSTIC(31145, Error, invalidCustomDerivative, "invalid custom derivative attribute.")
-DIAGNOSTIC(31146, Error, declAlreadyHasAttribute, "'$0' already has attribute '$1'.")
+DIAGNOSTIC(31146, Error, declAlreadyHasAttribute, "'$0' already has attribute '[$1]'.")
 
 // Enums
 

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -734,12 +734,13 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
         /// generated derivative function.
     INST(BackwardDifferentiableDecoration, backwardDifferentiable, 1, 0)
 
-        /// Decorated function is marked for the reverse-mode differentiation pass.
+        /// Decorations to associate an original function with compiler generated backward derivative functions.
     INST(BackwardDerivativePrimalDecoration, backwardDiffPrimalReference, 1, 0)
     INST(BackwardDerivativePropagateDecoration, backwardDiffPropagateReference, 1, 0)
     INST(BackwardDerivativeIntermediateTypeDecoration, backwardDiffIntermediateTypeReference, 1, 0)
     INST(BackwardDerivativeDecoration, backwardDiffReference, 1, 0)
 
+    INST(UserDefinedBackwardDerivativeDecoration, userDefinedBackwardDiffReference, 1, 0)
     INST(BackwardDerivativePrimalContextDecoration, BackwardDerivativePrimalContextDecoration, 1, 0)
     INST(BackwardDerivativePrimalReturnDecoration, BackwardDerivativePrimalReturnDecoration, 1, 0)
 

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -701,6 +701,15 @@ struct IRBackwardDifferentiableDecoration : IRDecoration
     IR_LEAF_ISA(BackwardDifferentiableDecoration)
 };
 
+struct IRUserDefinedBackwardDerivativeDecoration : IRDecoration
+{
+    enum
+    {
+        kOp = kIROp_UserDefinedBackwardDerivativeDecoration
+    };
+    IR_LEAF_ISA(UserDefinedBackwardDerivativeDecoration)
+};
+
 struct IRTreatAsDifferentiableDecoration : IRDecoration
 {
     enum
@@ -3495,6 +3504,11 @@ public:
     void addForwardDerivativeDecoration(IRInst* value, IRInst* fwdFunc)
     {
         addDecoration(value, kIROp_ForwardDerivativeDecoration, fwdFunc);
+    }
+
+    void addUserDefinedBackwardDerivativeDecoration(IRInst* value, IRInst* fwdFunc)
+    {
+        addDecoration(value, kIROp_UserDefinedBackwardDerivativeDecoration, fwdFunc);
     }
 
     void addBackwardDerivativePrimalDecoration(IRInst* value, IRInst* jvpFn)


### PR DESCRIPTION
This PR completes the front-end logic to allow user-provided backward derivative functions through `[BackwardDerivative]` and `[BackwardDerivativeOf]` attributes.

We currently only allow user defined full backward derivative functions instead of separate primal and propagate functions to simplify things. For now, we will automatically generate the trivial primal func (by calling the original func and writes nothing to intermediates) and the propagate func (by calling user provided derivative function). This is fine for most stdlib functions since they don't need to preserve context.

With these changes, the emitted IR will contain `[IRUserDefinedBackwardDerivativeDecoration]` on functions that has a user defined backward derivative implementation. Note that we are not reusing the existing `[IRBackwardDerivativeDecoration]` since we need a way to tell if the function has user provided backward derivative and do slight different things, unlike in forward derivative where this shouldn't matter.

Changes to the IR passes to handle user provided backward derivatives will come in a separate PR.