### PR TITLE
Add diagnostic for calling non-bwd-diff func from bwd-diff func.

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -6894,38 +6894,34 @@ namespace Slang
 
     bool SharedSemanticsContext::isDifferentiableFunc(FunctionDeclBase* func)
     {
-        // A function is differentiable if it is marked as differentiable, or it
-        // has an associated derivative function.
-        if (func->findModifier<DifferentiableAttribute>())
-            return true;
-        for (auto assocDecl : getAssociatedDeclsForDecl(func))
-        {
-            switch (assocDecl.kind)
-            {
-            case DeclAssociationKind::ForwardDerivativeFunc:
-            case DeclAssociationKind::BackwardDerivativeFunc:
-                return true;
-            default:
-                break;
-            }
-        }
-        return false;
+        return getFuncDifferentiableLevel(func) != FunctionDifferentiableLevel::None;
     }
 
     bool SharedSemanticsContext::isBackwardDifferentiableFunc(FunctionDeclBase* func)
     {
-        // A function is differentiable if it is marked as differentiable, or it
-        // has an associated derivative function.
+        return getFuncDifferentiableLevel(func) == FunctionDifferentiableLevel::Backward;
+    }
+
+    FunctionDifferentiableLevel SharedSemanticsContext::getFuncDifferentiableLevel(FunctionDeclBase* func)
+    {
         if (func->findModifier<BackwardDifferentiableAttribute>())
-            return true;
+            return FunctionDifferentiableLevel::Backward;
         if (func->findModifier<BackwardDerivativeAttribute>())
-            return true;
+            return FunctionDifferentiableLevel::Backward;
+
+        FunctionDifferentiableLevel diffLevel = FunctionDifferentiableLevel::None;
+        if (func->findModifier<DifferentiableAttribute>())
+            diffLevel = FunctionDifferentiableLevel::Forward;
+
         for (auto assocDecl : getAssociatedDeclsForDecl(func))
         {
             switch (assocDecl.kind)
             {
             case DeclAssociationKind::BackwardDerivativeFunc:
-                return true;
+                return FunctionDifferentiableLevel::Backward;
+            case DeclAssociationKind::ForwardDerivativeFunc:
+                diffLevel = FunctionDifferentiableLevel::Forward;
+                break;
             default:
                 break;
             }
@@ -6937,12 +6933,12 @@ namespace Slang
             case BuiltinRequirementKind::DAddFunc:
             case BuiltinRequirementKind::DMulFunc:
             case BuiltinRequirementKind::DZeroFunc:
-                return true;
+                return FunctionDifferentiableLevel::Backward;
             default:
                 break;
             }
         }
-        return false;
+        return diffLevel;
     }
 
     List<ExtensionDecl*> const& getCandidateExtensions(

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -1967,6 +1967,10 @@ namespace Slang
 
         if (m_parentDifferentiableAttr)
         {
+            FunctionDifferentiableLevel callerDiffLevel = FunctionDifferentiableLevel::None;
+            if (m_parentFunc)
+                callerDiffLevel = getShared()->getFuncDifferentiableLevel(m_parentFunc);
+
             if (auto checkedInvokeExpr = as<InvokeExpr>(checkedExpr))
             {
                 // Register types for final resolved invoke arguments again.
@@ -1978,7 +1982,8 @@ namespace Slang
                 {
                     if (auto calleeDecl = as<FunctionDeclBase>(calleeExpr->declRef.getDecl()))
                     {
-                        if (getShared()->isDifferentiableFunc(calleeDecl))
+                        auto calleeDiffLevel = getShared()->getFuncDifferentiableLevel(calleeDecl);
+                        if (calleeDiffLevel >= callerDiffLevel)
                         {
                             if (!m_treatAsDifferentiableExpr)
                             {

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -11,7 +11,12 @@
 
 namespace Slang
 {
-    
+    enum class FunctionDifferentiableLevel
+    {
+        None,
+        Forward,
+        Backward
+    };
         /// Should the given `decl` be treated as a static rather than instance declaration?
     bool isEffectivelyStatic(
         Decl*           decl);
@@ -292,6 +297,7 @@ namespace Slang
 
         bool isDifferentiableFunc(FunctionDeclBase* func);
         bool isBackwardDifferentiableFunc(FunctionDeclBase* func);
+        FunctionDifferentiableLevel getFuncDifferentiableLevel(FunctionDeclBase* func);
 
     private:
             /// Mapping from type declarations to the known extensiosn that apply to them

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -576,7 +576,7 @@ DIAGNOSTIC(41010, Warning, missingReturn, "control flow may reach end of non-'vo
 DIAGNOSTIC(41011, Error, typeDoesNotFitAnyValueSize, "type '$0' does not fit in the size required by its conforming interface.")
 DIAGNOSTIC(41012, Note, typeAndLimit, "sizeof($0) is $1, limit is $2")
 DIAGNOSTIC(41012, Error, typeCannotBePackedIntoAnyValue, "type '$0' contains fields that cannot be packed into an AnyValue.")
-DIAGNOSTIC(41020, Error, lossOfDerivativeDueToCallOfNonDifferentiableFunction, "derivative cannot be propagated through call to non-differentiable function `$0`, use 'no_diff' to clarify intention.")
+DIAGNOSTIC(41020, Error, lossOfDerivativeDueToCallOfNonDifferentiableFunction, "derivative cannot be propagated through call to non-$1-differentiable function `$0`, use 'no_diff' to clarify intention.")
 DIAGNOSTIC(41021, Error, differentiableFuncMustHaveOutput, "a differentiable function must have at least one differentiable output.")
 DIAGNOSTIC(41022, Error, differentiableFuncMustHaveInput, "a differentiable function must have at least one differentiable input.")
 DIAGNOSTIC(41023, Error, getStringHashMustBeOnStringLiteral, "getStringHash can only be called when argument is statically resolvable to a string literal")

--- a/tests/diagnostics/autodiff-data-flow-2.slang
+++ b/tests/diagnostics/autodiff-data-flow-2.slang
@@ -1,0 +1,30 @@
+//DIAGNOSTIC_TEST:SIMPLE:
+
+float nonDiff(float x)
+{
+    return x;
+}
+
+[ForwardDifferentiable]
+float f(float x)
+{
+    return x * x;
+}
+
+// error: function does not return a differentiable value.
+[BackwardDifferentiable]
+float g(float x)
+{
+    float val = f(x + 1); // Error: f must also be backward-differentiable
+    return val;
+}
+/*
+[BackwardDifferentiable]
+float h(float x)
+{
+    float val = 0;
+    // no diagnostic by clarifying intention.
+    val = no_diff(f(x + 1));
+    return val;
+}
+*/

--- a/tests/diagnostics/autodiff-data-flow-2.slang
+++ b/tests/diagnostics/autodiff-data-flow-2.slang
@@ -11,7 +11,6 @@ float f(float x)
     return x * x;
 }
 
-// error: function does not return a differentiable value.
 [BackwardDifferentiable]
 float g(float x)
 {

--- a/tests/diagnostics/autodiff-data-flow-2.slang
+++ b/tests/diagnostics/autodiff-data-flow-2.slang
@@ -18,7 +18,7 @@ float g(float x)
     float val = f(x + 1); // Error: f must also be backward-differentiable
     return val;
 }
-/*
+
 [BackwardDifferentiable]
 float h(float x)
 {
@@ -27,4 +27,3 @@ float h(float x)
     val = no_diff(f(x + 1));
     return val;
 }
-*/

--- a/tests/diagnostics/autodiff-data-flow-2.slang.expected
+++ b/tests/diagnostics/autodiff-data-flow-2.slang.expected
@@ -1,0 +1,8 @@
+result code = -1
+standard error = {
+tests/diagnostics/autodiff-data-flow-2.slang(18): error 41020: derivative cannot be propagated through call to non-backward-differentiable function `f`, use 'no_diff' to clarify intention.
+    float val = f(x + 1); // Error: f must also be backward-differentiable
+                 ^
+}
+standard output = {
+}

--- a/tests/diagnostics/autodiff-data-flow.slang.expected
+++ b/tests/diagnostics/autodiff-data-flow.slang.expected
@@ -1,6 +1,6 @@
 result code = -1
 standard error = {
-tests/diagnostics/autodiff-data-flow.slang(15): error 41020: derivative cannot be propagated through call to non-differentiable function `nonDiff`, use 'no_diff' to clarify intention.
+tests/diagnostics/autodiff-data-flow.slang(15): error 41020: derivative cannot be propagated through call to non-forward-differentiable function `nonDiff`, use 'no_diff' to clarify intention.
         val = nonDiff(x * 2.0f);
                      ^
 tests/diagnostics/autodiff-data-flow.slang(22): error 41021: a differentiable function must have at least one differentiable output.


### PR DESCRIPTION
This change adds a diagnostic when the user attempts to call a forward-differentiable function (but not backward differentiable) from a backward-differentiable function.