### PR TITLE
GFX report live objects

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -2641,6 +2641,10 @@ extern "C"
     SLANG_GFX_API SlangResult SLANG_MCALL
         gfxCreateDevice(const IDevice::Desc* desc, IDevice** outDevice);
 
+    /// Reports current set of live objects in gfx.
+    /// Currently this only calls D3D's ReportLiveObjects.
+    SLANG_GFX_API SlangResult SLANG_MCALL gfxReportLiveObjects();
+
     /// Sets a callback for receiving debug messages.
     /// The layer does not hold a strong reference to the callback object.
     /// The user is responsible for holding the callback object alive.

--- a/tools/gfx/d3d/d3d-util.h
+++ b/tools/gfx/d3d/d3d-util.h
@@ -122,6 +122,8 @@ class D3DUtil
     static uint32_t getSubresourceMipLevel(uint32_t subresourceIndex, uint32_t mipLevelCount);
 
     static D3D12_RESOURCE_STATES getResourceState(ResourceState state);
+
+    static SlangResult reportLiveObjects();
 };
 
 #if SLANG_GFX_HAS_DXR_SUPPORT

--- a/tools/gfx/debug-layer/debug-swap-chain.cpp
+++ b/tools/gfx/debug-layer/debug-swap-chain.cpp
@@ -55,8 +55,10 @@ Result DebugSwapchain::resize(GfxCount width, GfxCount height)
     {
         if (image->debugGetReferenceCount() != 1)
         {
-            GFX_DIAGNOSE_ERROR("all swapchain images must be released before calling resize().");
-            return SLANG_FAIL;
+            // Only warn here because tools like NSight might keep
+            // an additional reference to swapchain images.
+            GFX_DIAGNOSE_WARNING("all swapchain images must be released before calling resize().");
+            break;
         }
     }
     m_images.clearAndDeallocate();

--- a/tools/gfx/gfx.slang
+++ b/tools/gfx/gfx.slang
@@ -1957,6 +1957,10 @@ SLANG_GFX_IMPORT Result gfxGetFormatInfo(Format format, FormatInfo *outInfo);
 /// Given a type returns a function that can construct it, or nullptr if there isn't one
 SLANG_GFX_IMPORT Result gfxCreateDevice(const DeviceDesc* desc, out Optional<IDevice> outDevice);
 
+/// Reports current set of live objects in gfx.
+/// Currently this only calls D3D's ReportLiveObjects.
+SLANG_GFX_IMPORT Result gfxReportLiveObjects();
+
 /// Sets a callback for receiving debug messages.
 /// The layer does not hold a strong reference to the callback object.
 /// The user is responsible for holding the callback object alive.

--- a/tools/gfx/render.cpp
+++ b/tools/gfx/render.cpp
@@ -21,6 +21,8 @@ Result SLANG_MCALL getD3D12Adapters(List<AdapterInfo>& outAdapters);
 Result SLANG_MCALL getVKAdapters(List<AdapterInfo>& outAdapters);
 Result SLANG_MCALL getCUDAAdapters(List<AdapterInfo>& outAdapters);
 
+Result SLANG_MCALL reportD3DLiveObjects();
+
 static bool debugLayerEnabled = false;
 bool isGfxDebugLayerEnabled() { return debugLayerEnabled; }
 
@@ -362,6 +364,15 @@ extern "C"
         debugDevice->baseObject = innerDevice;
         returnComPtr(outDevice, debugDevice);
         return resultCode;
+    }
+
+    SLANG_GFX_API SlangResult SLANG_MCALL
+        gfxReportLiveObjects()
+    {
+#if SLANG_WINDOWS_FAMILY
+        SLANG_RETURN_ON_FAIL(reportD3DLiveObjects());
+#endif
+        return SLANG_OK;
     }
 
     SLANG_GFX_API SlangResult SLANG_MCALL gfxSetDebugCallback(IDebugCallback* callback)


### PR DESCRIPTION
- Add `gfxReportLiveObjects` API call which currently just calls the D3D `ReportLiveObjects` function. In the future this could also report gfx's internal objects.
- Turn gfx swapchain validation layer message from error into warning (otherwise we crash when running with NSight attached).