### PR TITLE
Cleanup IR representation of interface member derivative.

### DIFF
--- a/source/slang/slang-ir-autodiff-fwd.h
+++ b/source/slang/slang-ir-autodiff-fwd.h
@@ -97,9 +97,9 @@ struct ForwardDiffTranscriber : AutoDiffTranscriberBase
 
     virtual InstPair transcribeInstImpl(IRBuilder* builder, IRInst* origInst) override;
 
-    virtual IROp getDifferentiableMethodDictionaryItemOp() override
+    virtual IROp getInterfaceRequirementDerivativeDecorationOp() override
     {
-        return kIROp_ForwardDifferentiableMethodRequirementDictionaryItem;
+        return kIROp_ForwardDerivativeDecoration;
     }
 
 };

--- a/source/slang/slang-ir-autodiff-rev.h
+++ b/source/slang/slang-ir-autodiff-rev.h
@@ -100,9 +100,9 @@ struct BackwardDiffTranscriberBase : AutoDiffTranscriberBase
     virtual IRInst* findExistingDiffFunc(IRInst* originalFunc) = 0;
     virtual void addExistingDiffFuncDecor(IRBuilder* builder, IRInst* inst, IRInst* diffFunc) = 0;
 
-    virtual IROp getDifferentiableMethodDictionaryItemOp() override
+    virtual IROp getInterfaceRequirementDerivativeDecorationOp() override
     {
-        return kIROp_BackwardDifferentiableMethodRequirementDictionaryItem;
+        return kIROp_BackwardDerivativeDecoration;
     }
 };
 
@@ -129,6 +129,10 @@ struct BackwardDiffPrimalTranscriber : BackwardDiffTranscriberBase
     virtual void addExistingDiffFuncDecor(IRBuilder* builder, IRInst* inst, IRInst* diffFunc) override
     {
         builder->addBackwardDerivativePrimalDecoration(inst, diffFunc);
+    }
+    virtual IROp getInterfaceRequirementDerivativeDecorationOp() override
+    {
+        return kIROp_BackwardDerivativePrimalDecoration;
     }
 };
 
@@ -163,6 +167,10 @@ struct BackwardDiffPropagateTranscriber : BackwardDiffTranscriberBase
     virtual void addExistingDiffFuncDecor(IRBuilder* builder, IRInst* inst, IRInst* diffFunc) override
     {
         builder->addBackwardDerivativePropagateDecoration(inst, diffFunc);
+    }
+    virtual IROp getInterfaceRequirementDerivativeDecorationOp() override
+    {
+        return kIROp_BackwardDerivativePropagateDecoration;
     }
 };
 

--- a/source/slang/slang-ir-autodiff-transcriber-base.h
+++ b/source/slang/slang-ir-autodiff-transcriber-base.h
@@ -147,7 +147,7 @@ struct AutoDiffTranscriberBase
 
     virtual InstPair transcribeInstImpl(IRBuilder* builder, IRInst* origInst) = 0;
 
-    virtual IROp getDifferentiableMethodDictionaryItemOp() = 0;
+    virtual IROp getInterfaceRequirementDerivativeDecorationOp() = 0;
 };
 
 }

--- a/source/slang/slang-ir-check-differentiability.cpp
+++ b/source/slang/slang-ir-check-differentiability.cpp
@@ -131,22 +131,10 @@ public:
                 return true;
             if (sharedContext.differentiableInterfaceType && interfaceType == sharedContext.differentiableInterfaceType)
                 return true;
-            auto dictDecor = interfaceType->findDecoration<IRDifferentiableMethodRequirementDictionaryDecoration>();
-            if (!dictDecor)
-                return false;
-            for (auto child : dictDecor->getChildren())
-            {
-                if (auto entry = as<IRDifferentiableMethodRequirementDictionaryItem>(child))
-                {
-                    if (entry->getOperand(0) == lookupInterfaceMethod->getRequirementKey())
-                    {
-                        if (as<IRBackwardDifferentiableMethodRequirementDictionaryItem>(child) && level == DifferentiableLevel::Backward)
-                            return true;
-                        if (as<IRForwardDifferentiableMethodRequirementDictionaryItem>(child) && level == DifferentiableLevel::Forward)
-                            return true;
-                    }
-                }
-            }
+            if (lookupInterfaceMethod->getRequirementKey()->findDecoration<IRBackwardDerivativeDecoration>())
+                return true;
+            if (lookupInterfaceMethod->getRequirementKey()->findDecoration<IRForwardDerivativeDecoration>())
+                return level == DifferentiableLevel::Forward;
         }
 
         for (; func; func = func->parent)

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -776,9 +776,6 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     /* Differentiable Type Dictionary */
     INST(DifferentiableTypeDictionaryDecoration, DifferentiableTypeDictionaryDecoration, 0, PARENT)
 
-        /// Decorates an interface type and stores the mapping from a normal function requirement key to its derivative requirement key.
-    INST(DifferentiableMethodRequirementDictionaryDecoration, DifferentiableMethodRequirementDictionaryDecoration, 0, PARENT)
-
         /// Marks a struct type as being used as a structured buffer block.
         /// Recognized by SPIRV-emit pass so we can emit a SPIRV `BufferBlock` decoration.
     INST(SPIRVBufferBlockDecoration, spvBufferBlock, 0, 0)
@@ -898,16 +895,6 @@ INST(ExistentialTypeSpecializationDictionary, ExistentialTypeSpecializationDicti
 
 /* Differentiable Type Dictionary */
 INST(DifferentiableTypeDictionaryItem, DifferentiableTypeDictionaryItem, 0, 0)
-
-/* DifferentiableMethodRequirementDictionaryItem */
-    INST(ForwardDifferentiableMethodRequirementDictionaryItem, DifferentiableMethodRequirementDictionaryItem, 0, 0)
-    INST(BackwardDifferentiableMethodRequirementDictionaryItem, DifferentiableMethodRequirementDictionaryItem, 0, 0)
-    INST(BackwardDifferentiablePrimalMethodRequirementDictionaryItem, DifferentiablePrimalMethodRequirementDictionaryItem, 0, 0)
-    INST(BackwardDifferentiablePropagateMethodRequirementDictionaryItem, DifferentiablePropagateMethodRequirementDictionaryItem, 0, 0)
-    INST(BackwardDifferentiableIntermediateTypeRequirementDictionaryItem, DifferentiableIntermediateTypeRequirementDictionaryItem, 0, 0)
-
-
-INST_RANGE(DifferentiableMethodRequirementDictionaryItem, ForwardDifferentiableMethodRequirementDictionaryItem, BackwardDifferentiableMethodRequirementDictionaryItem)
 
 #undef PARENT
 #undef USE_OTHER

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -825,26 +825,6 @@ struct IRDifferentiableTypeDictionaryDecoration : IRDecoration
     IR_LEAF_ISA(DifferentiableTypeDictionaryDecoration)
 };
 
-struct IRDifferentiableMethodRequirementDictionaryDecoration : IRDecoration
-{
-    IR_LEAF_ISA(DifferentiableMethodRequirementDictionaryDecoration)
-};
-
-struct IRDifferentiableMethodRequirementDictionaryItem : IRInst
-{
-    IR_PARENT_ISA(DifferentiableMethodRequirementDictionaryItem)
-};
-
-struct IRForwardDifferentiableMethodRequirementDictionaryItem : IRDifferentiableMethodRequirementDictionaryItem
-{
-    IR_LEAF_ISA(ForwardDifferentiableMethodRequirementDictionaryItem)
-};
-
-struct IRBackwardDifferentiableMethodRequirementDictionaryItem : IRDifferentiableMethodRequirementDictionaryItem
-{
-    IR_LEAF_ISA(BackwardDifferentiableMethodRequirementDictionaryItem)
-};
-
 // An instruction that specializes another IR value
 // (representing a generic) to a particular set of generic arguments 
 // (instructions representing types, witness tables, etc.)


### PR DESCRIPTION
To support differentiating `LookupWitness` insts, we currently store the mapping of an interface requirement key to its derivative requirement key in an dictionary as a decoration on the interface type. This is unnecessary.

The simpler representation is to just reuse the existing `[ForwardDerivative]` decoration on the requirement key. This will make the representation consistent with how we are handling struct fields.

This change implements this cleanup and removes the `IRDifferentiableMethodRequirementDictionary` decoration.