### PR TITLE
Add ASAN support + fixes

### DIFF
--- a/build/visual-studio/gfx/gfx.vcxproj
+++ b/build/visual-studio/gfx/gfx.vcxproj
@@ -164,7 +164,6 @@
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>_DEBUG;SLANG_GFX_DYNAMIC;SLANG_GFX_DYNAMIC_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..;..\..\..\external;..\..\..\source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -177,7 +176,6 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ImportLibrary>..\..\..\bin\windows-x86\debug\gfx.lib</ImportLibrary>
-      <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
     <PostBuildEvent>
       <Command>IF EXIST "$(SolutionDir)tools\gfx\gfx.slang"\ (xcopy /Q /E /Y /I "$(SolutionDir)tools\gfx\gfx.slang" "..\..\..\bin\windows-x86\debug" &gt; nul) ELSE (xcopy /Q /Y /I "$(SolutionDir)tools\gfx\gfx.slang" "..\..\..\bin\windows-x86\debug" &gt; nul)
@@ -189,7 +187,6 @@ IF EXIST "$(SolutionDir)tools\gfx\slang.slang"\ (xcopy /Q /E /Y /I "$(SolutionDi
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>_DEBUG;SLANG_GFX_DYNAMIC;SLANG_GFX_DYNAMIC_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..;..\..\..\external;..\..\..\source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -202,7 +199,6 @@ IF EXIST "$(SolutionDir)tools\gfx\slang.slang"\ (xcopy /Q /E /Y /I "$(SolutionDi
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ImportLibrary>..\..\..\bin\windows-x64\debug\gfx.lib</ImportLibrary>
-      <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
     <PostBuildEvent>
       <Command>IF EXIST "$(SolutionDir)tools\gfx\gfx.slang"\ (xcopy /Q /E /Y /I "$(SolutionDir)tools\gfx\gfx.slang" "..\..\..\bin\windows-x64\debug" &gt; nul) ELSE (xcopy /Q /Y /I "$(SolutionDir)tools\gfx\gfx.slang" "..\..\..\bin\windows-x64\debug" &gt; nul)
@@ -214,7 +210,6 @@ IF EXIST "$(SolutionDir)tools\gfx\slang.slang"\ (xcopy /Q /E /Y /I "$(SolutionDi
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>_DEBUG;SLANG_GFX_DYNAMIC;SLANG_GFX_DYNAMIC_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..;..\..\..\external;..\..\..\source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -227,7 +222,6 @@ IF EXIST "$(SolutionDir)tools\gfx\slang.slang"\ (xcopy /Q /E /Y /I "$(SolutionDi
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ImportLibrary>..\..\..\bin\windows-aarch64\debug\gfx.lib</ImportLibrary>
-      <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
     <PostBuildEvent>
       <Command>IF EXIST "$(SolutionDir)tools\gfx\gfx.slang"\ (xcopy /Q /E /Y /I "$(SolutionDir)tools\gfx\gfx.slang" "..\..\..\bin\windows-aarch64\debug" &gt; nul) ELSE (xcopy /Q /Y /I "$(SolutionDir)tools\gfx\gfx.slang" "..\..\..\bin\windows-aarch64\debug" &gt; nul)
@@ -239,7 +233,6 @@ IF EXIST "$(SolutionDir)tools\gfx\slang.slang"\ (xcopy /Q /E /Y /I "$(SolutionDi
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>NDEBUG;SLANG_GFX_DYNAMIC;SLANG_GFX_DYNAMIC_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..;..\..\..\external;..\..\..\source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Full</Optimization>
@@ -255,7 +248,6 @@ IF EXIST "$(SolutionDir)tools\gfx\slang.slang"\ (xcopy /Q /E /Y /I "$(SolutionDi
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ImportLibrary>..\..\..\bin\windows-x86\release\gfx.lib</ImportLibrary>
-      <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
     <PostBuildEvent>
       <Command>IF EXIST "$(SolutionDir)tools\gfx\gfx.slang"\ (xcopy /Q /E /Y /I "$(SolutionDir)tools\gfx\gfx.slang" "..\..\..\bin\windows-x86\release" &gt; nul) ELSE (xcopy /Q /Y /I "$(SolutionDir)tools\gfx\gfx.slang" "..\..\..\bin\windows-x86\release" &gt; nul)
@@ -267,7 +259,6 @@ IF EXIST "$(SolutionDir)tools\gfx\slang.slang"\ (xcopy /Q /E /Y /I "$(SolutionDi
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>NDEBUG;SLANG_GFX_DYNAMIC;SLANG_GFX_DYNAMIC_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..;..\..\..\external;..\..\..\source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Full</Optimization>
@@ -283,7 +274,6 @@ IF EXIST "$(SolutionDir)tools\gfx\slang.slang"\ (xcopy /Q /E /Y /I "$(SolutionDi
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ImportLibrary>..\..\..\bin\windows-x64\release\gfx.lib</ImportLibrary>
-      <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
     <PostBuildEvent>
       <Command>IF EXIST "$(SolutionDir)tools\gfx\gfx.slang"\ (xcopy /Q /E /Y /I "$(SolutionDir)tools\gfx\gfx.slang" "..\..\..\bin\windows-x64\release" &gt; nul) ELSE (xcopy /Q /Y /I "$(SolutionDir)tools\gfx\gfx.slang" "..\..\..\bin\windows-x64\release" &gt; nul)
@@ -295,7 +285,6 @@ IF EXIST "$(SolutionDir)tools\gfx\slang.slang"\ (xcopy /Q /E /Y /I "$(SolutionDi
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>NDEBUG;SLANG_GFX_DYNAMIC;SLANG_GFX_DYNAMIC_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..;..\..\..\external;..\..\..\source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Full</Optimization>
@@ -311,7 +300,6 @@ IF EXIST "$(SolutionDir)tools\gfx\slang.slang"\ (xcopy /Q /E /Y /I "$(SolutionDi
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ImportLibrary>..\..\..\bin\windows-aarch64\release\gfx.lib</ImportLibrary>
-      <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
     <PostBuildEvent>
       <Command>IF EXIST "$(SolutionDir)tools\gfx\gfx.slang"\ (xcopy /Q /E /Y /I "$(SolutionDir)tools\gfx\gfx.slang" "..\..\..\bin\windows-aarch64\release" &gt; nul) ELSE (xcopy /Q /Y /I "$(SolutionDir)tools\gfx\gfx.slang" "..\..\..\bin\windows-aarch64\release" &gt; nul)

--- a/examples/gpu-printing/kernels.slang
+++ b/examples/gpu-printing/kernels.slang
@@ -34,5 +34,5 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
     // The second facility supported by `printing.slang` is a C-style
     // `printf()` function.
     //
-    printf("printf from thread 0x%x\n", tid.x);
+    printf_("printf from thread 0x%x\n", tid.x);
 }

--- a/examples/gpu-printing/printing.slang
+++ b/examples/gpu-printing/printing.slang
@@ -284,6 +284,9 @@ void println<A : IPrintable, B : IPrintable, C : IPrintable>(
 // starts with an allocation function that does the behind-the-scenes
 // work.
 //
+// Note: We use the name `printf_` here because `printf` clashes with
+// HLSL's printf.
+//
 
 uint _beginPrintf(String format, uint wordCount)
 {
@@ -340,14 +343,14 @@ extension String : IPrintf
 
 
 // A `printf()` with no format arguments can just call back to `_beginPrintf()`
-void printf(String format)
+void printf_(String format)
 {
     _beginPrintf(format, 0);
 }
 
 // The `printf()` cases with one or more format arguments are all quite similar.
 
-void printf<A : IPrintf>(String format, A a)
+void printf_<A : IPrintf>(String format, A a)
 {
     // We need to compute the words required by each format argument
     // and sum them up.
@@ -366,7 +369,7 @@ void printf<A : IPrintf>(String format, A a)
     a.writePrintfWords(gPrintBuffer, wordOffset); wordOffset += aCount;
 }
 
-void printf<A : IPrintf, B : IPrintf>(String format, A a, B b)
+void printf_<A : IPrintf, B : IPrintf>(String format, A a, B b)
 {
     uint wordCount = 0;
     uint aCount = a.getPrintfWordCount(); wordCount += aCount;

--- a/examples/hello-world/vulkan-api.cpp
+++ b/examples/hello-world/vulkan-api.cpp
@@ -51,6 +51,24 @@ int initializeVulkanDevice(VulkanAPI& api)
     if (!api.vkCreateInstance)
         return -1;
 
+    // Enable validation layer if available.
+    std::vector<const char*> layers;
+#ifdef ENABLE_VALIDATION_LAYER
+    uint32_t propertyCount;
+    if (api.vkEnumerateInstanceLayerProperties(&propertyCount, nullptr) != 0)
+        return -1;
+    std::vector< VkLayerProperties> properties(propertyCount);
+    if (api.vkEnumerateInstanceLayerProperties(&propertyCount, properties.data()) != 0)
+        return -1;
+    for (const auto& p : properties)
+    {
+        if (strcmp(p.layerName, "VK_LAYER_KHRONOS_validation") == 0)
+        {
+            layers.push_back("VK_LAYER_KHRONOS_validation");
+        }
+    }
+#endif
+
     // Create Vulkan Instance.
     VkApplicationInfo applicationInfo = {VK_STRUCTURE_TYPE_APPLICATION_INFO};
     applicationInfo.pApplicationName = "slang-hello-world";
@@ -66,10 +84,6 @@ int initializeVulkanDevice(VulkanAPI& api)
     instanceCreateInfo.pApplicationInfo = &applicationInfo;
     instanceCreateInfo.enabledExtensionCount = SLANG_COUNT_OF(instanceExtensions);
     instanceCreateInfo.ppEnabledExtensionNames = &instanceExtensions[0];
-    std::vector<const char*> layers;
-#ifdef ENABLE_VALIDATION_LAYER
-    layers.push_back("VK_LAYER_KHRONOS_validation");
-#endif
     if (layers.size())
     {
         instanceCreateInfo.ppEnabledLayerNames = &layers[0];

--- a/examples/hello-world/vulkan-api.cpp
+++ b/examples/hello-world/vulkan-api.cpp
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
+#include <string.h>
 #include <vector>
 
 #if SLANG_WINDOWS_FAMILY

--- a/premake5.lua
+++ b/premake5.lua
@@ -192,10 +192,18 @@ newoption {
 }
 
 newoption {
-    trigger = "full-debug-validation",
+    trigger     = "full-debug-validation",
     description = "(Optional) If true will enable full IR validation in debug build. (SLOW!)",
-    value = "bool",
-    default = "false",
+    value       = "bool",
+    default     = "false",
+    allowed     = { { "true", "True"}, { "false", "False" } }
+}
+
+newoption {
+    trigger     = "enable-asan",
+    description = "(Optional) If true will enable ASAN (address santizier).",
+    value       = "bool",
+    default     = "false",
     allowed     = { { "true", "True"}, { "false", "False" } }
 }
 
@@ -213,6 +221,7 @@ skipSourceGeneration = (_OPTIONS["skip-source-generation"] == "true")
 deployLLVM = (_OPTIONS["deploy-slang-llvm"] == "true")
 deployGLSLang = (_OPTIONS["deploy-slang-glslang"] == "true")
 fullDebugValidation = (_OPTIONS["full-debug-validation"] == "true")
+enableAsan = (_OPTIONS["enable-asan"] == "true")
 
 -- If stdlib embedding is enabled, disable stdlib source embedding by default
 disableStdlibSource = enableEmbedStdLib
@@ -571,6 +580,18 @@ function baseSlangProject(name, sourceDir)
     if not not sourceDir then
         addSourceDir(sourceDir)
     end
+
+    --
+    -- Enable ASAN (address sanitizer) if requested.
+    --
+
+    if enableAsan then
+        if (targetInfo.isWindows) then
+            buildoptions { "/fsanitize=address" }
+            flags { "NoIncrementalLink" }
+        end
+    end
+
 end
 
 
@@ -992,7 +1013,6 @@ tool "gfx"
         addSourceDir "tools/gfx/d3d"
         addSourceDir "tools/gfx/d3d11"
         addSourceDir "tools/gfx/d3d12"
-        flags { "FatalWarnings" }
     elseif targetInfo.os == "mingw" or targetInfo.os == "cygwin" then
         -- Don't support any render techs...
     elseif os.target() == "macosx" then

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -321,7 +321,9 @@ namespace Slang
             /// does not match deallocation size (due variable sized string payload).
         void operator delete(void* p)
         {
-            delete(p);
+            if (!p) return;
+            StringRepresentation* str = (StringRepresentation*) p;
+            ::operator delete(p, sizeof(StringRepresentation) + str->capacity + 1);
         }        
     };
 

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -321,9 +321,8 @@ namespace Slang
             /// does not match deallocation size (due variable sized string payload).
         void operator delete(void* p)
         {
-            if (!p) return;
             StringRepresentation* str = (StringRepresentation*) p;
-            ::operator delete(p, sizeof(StringRepresentation) + str->capacity + 1);
+            ::operator delete(str);
         }        
     };
 

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -315,6 +315,14 @@ namespace Slang
 
             return cloneWithCapacity(newCapacity);
         }
+
+            /// Overload delete to silence ASAN new-delete-type-mismatch errors.
+            /// These occur because the allocation size of StringRepresentation
+            /// does not match deallocation size (due variable sized string payload).
+        void operator delete(void* p)
+        {
+            delete(p);
+        }        
     };
 
     class String;

--- a/tools/slang-generate/main.cpp
+++ b/tools/slang-generate/main.cpp
@@ -56,8 +56,16 @@ struct SourceFile : public RefObject
     {
         if (text.begin())
             free((void*)text.begin());
-        if (node)
+
+        // To avoid deep recursion in the Node destructor,
+        // we delete the first level of the node tree iteratively.
+        while (node)
+        {
+            Node* next = node->next;
+            node->next = nullptr;
             delete node;
+            node = next;
+        }
     }
 };
 


### PR DESCRIPTION
- Add support for ASAN (MSVC for now)
- Enable using `--enable-asan` option in premake
- Fix ASAN false positives when deleting `StringRepresentation` objects.
- Fix deep recursion in `slang-generate`.
- Fix `hello-world` and `gpu-printing` examples.

With this, all the examples pass when running debug build with ASAN enabled. Unfortunately when switching examples to use Vulkan, ASAN seems to break the loader. Needs more investigation.