### PR TITLE
Patch transcription of `inout` non differentiable params.

### DIFF
--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2232,8 +2232,17 @@ namespace Slang
             {
                 if (as<DifferentialPairType>(derivType))
                 {
-                    // Using inout type on all the derivative parameters
+                    // An `in` differentiable parameter becomes an `inout` parameter.
                     derivType = m_astBuilder->getInOutType(derivType);
+                }
+                else if (auto inoutType = as<InOutType>(derivType))
+                {
+                    if (!as<DifferentialPairType>(inoutType->getValueType()))
+                    {
+                        // An `inout` non differentiable parameter becomes an `in` parameter
+                        // (removing `out`).
+                        derivType = inoutType->getValueType();
+                    }
                 }
                 type->paramTypes.add(derivType);
             }

--- a/source/slang/slang-ir-autodiff-transpose.h
+++ b/source/slang/slang-ir-autodiff-transpose.h
@@ -1040,6 +1040,13 @@ struct DiffTransposePass
                     args.add(nullptr);
                     argRequiresLoad.add(false);
                 }
+                else if (as<IRInOutType>(paramType))
+                {
+                    arg = builder->emitLoad(arg);
+                    args.add(arg);
+                    argTypes.add(arg->getDataType());
+                    argRequiresLoad.add(false);
+                }
                 else
                 {
                     args.add(arg);

--- a/tests/autodiff/reverse-inout-param-2.slang
+++ b/tests/autodiff/reverse-inout-param-2.slang
@@ -56,14 +56,13 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     p.m = 1.0;
     p.n = 2.0;
 
-    ND v2 = { 1.0 };
+    let v2 : ND = { 1.0 };
 
     var x = diffPair(5.0);
     float yDiffOut = 1.0;
 
     __bwd_diff(f)(p, v2, x, yDiffOut);
 
-    // (3+((3+x)*x))*((3+x)*x) = (3+3x+x^2)*(3x+x^2)
     outputBuffer[0] = x.p; // should be 5, since bwd_diff does not write back new primal val.
     outputBuffer[1] = x.d; // 14
     outputBuffer[2] = p.m; // 1.0


### PR DESCRIPTION
This PR adds handling for `inout` non differential parameters so they be come an `in` parameter after backward diff.
This makes the semantics consistent with `out` non differential parameters, which are removed after transcription.