### PR TITLE
Add static for loop iteration inference.

### DIFF
--- a/source/slang/diff.meta.slang
+++ b/source/slang/diff.meta.slang
@@ -270,6 +270,7 @@ void mul(inout DifferentialPair<matrix<T, R, N>> left, inout DifferentialPair<ma
 #define VECTOR_MAP_D_UNARY(TYPE, COUNT, D_FUNC, VALUE) \
     vector<TYPE, COUNT> result; \
     vector<TYPE, COUNT>.Differential d_result; \
+    [ForceUnroll]\
     for (int i = 0; i < N; ++i) \
     { \
         DifferentialPair<TYPE> dp_elem = D_FUNC(DifferentialPair<TYPE>(VALUE.p[i], __slang_noop_cast<TYPE.Differential>(VALUE.d[i]))); \
@@ -281,6 +282,7 @@ void mul(inout DifferentialPair<matrix<T, R, N>> left, inout DifferentialPair<ma
 #define VECTOR_MAP_D_BINARY(TYPE, COUNT, D_FUNC, LEFT, RIGHT)                                                                          \
     vector<TYPE, COUNT> result;                                                                                                        \
     vector<TYPE, COUNT>.Differential d_result;                                                                                         \
+    [ForceUnroll]                                                                                                                      \
     for (int i = 0; i < N; ++i)                                                                                                        \
     {                                                                                                                                  \
         DifferentialPair<TYPE> dp_elem = D_FUNC(DifferentialPair<TYPE>(LEFT.p[i], __slang_noop_cast<TYPE.Differential>(LEFT.d[i])),    \
@@ -292,6 +294,7 @@ void mul(inout DifferentialPair<matrix<T, R, N>> left, inout DifferentialPair<ma
 
 #define VECTOR_MAP_BWD_D_UNARY(TYPE, COUNT, D_FUNC, VALUE, D_OUT)            \
     vector<TYPE, COUNT>.Differential d_result;                               \
+    [ForceUnroll]                                                            \
     for (int i = 0; i < N; ++i)                                              \
     {                                                                        \
         DifferentialPair<TYPE> dp_elem = diffPair(VALUE.p[i], TYPE.dzero()); \
@@ -302,6 +305,7 @@ void mul(inout DifferentialPair<matrix<T, R, N>> left, inout DifferentialPair<ma
 
 #define VECTOR_MAP_BWD_D_BINARY(TYPE, COUNT, D_FUNC, LEFT, RIGHT, D_OUT)           \
     vector<TYPE, COUNT>.Differential left_d_result, right_d_result;                \
+    [ForceUnroll]                                                                  \
     for (int i = 0; i < N; ++i)                                                    \
     {                                                                              \
         DifferentialPair<TYPE> left_dp = diffPair(LEFT.p[i], TYPE.dzero());        \
@@ -705,6 +709,7 @@ DifferentialPair<T> __d_dot(DifferentialPair<vector<T, N>> dpx, DifferentialPair
 {
     T result = T(0);
     T.Differential d_result = T.dzero();
+    [ForceUnroll]
     for (int i = 0; i < N; ++i)
     {
         result = result + dpx.p[i] * dpy.p[i];
@@ -719,6 +724,7 @@ __generic<T : __BuiltinFloatingPointType, let N : int>
 void __d_dot(inout DifferentialPair<vector<T, N>> dpx, inout DifferentialPair<vector<T, N>> dpy, T.Differential dOut)
 {
     vector<T, N>.Differential x_d_result, y_d_result;
+    [ForceUnroll]
     for (int i = 0; i < N; ++i)
     {
         x_d_result[i] = dpy.p[i] * __slang_noop_cast<T>(dOut);

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -635,6 +635,14 @@ class MaxItersAttribute : public Attribute
     int32_t value = 0;
 };
 
+// An inferred max iteration count on a loop.
+class InferredMaxItersAttribute : public Attribute
+{
+    SLANG_AST_CLASS(InferredMaxItersAttribute)
+    DeclRef<Decl> inductionVar;
+    int32_t value = 0;
+};
+
 class LoopAttribute : public Attribute 
 {
     SLANG_AST_CLASS(LoopAttribute)

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -2023,6 +2023,11 @@ namespace Slang
         void visitGpuForeachStmt(GpuForeachStmt *stmt);
 
         void visitExpressionStmt(ExpressionStmt *stmt);
+
+        // Try to infer the max number of iterations the loop will run.
+        void tryInferLoopMaxIterations(ForStmt* stmt);
+
+        void checkLoopInDifferentiableFunc(Stmt* stmt);
     };
 
     struct SemanticsDeclVisitorBase

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -366,6 +366,15 @@ DIAGNOSTIC(30310, Error, typeIsNotDifferentiable, "type '$0' is not differentiab
 // Interop
 DIAGNOSTIC(30400, Error, cannotDefinePtrTypeToManagedResource, "pointer to a managed resource is invalid, use `NativeRef<T>` instead")
 
+// Control flow
+DIAGNOSTIC(30500, Warning, forLoopSideEffectChangingDifferentVar, "the for loop initializes and checks variable '$0' but the side effect expression is modifying '$1'.")
+DIAGNOSTIC(30501, Warning, forLoopPredicateCheckingDifferentVar, "the for loop initializes and modifies variable '$0' but the predicate expression is checking '$1'.")
+DIAGNOSTIC(30502, Warning, forLoopChangingIterationVariableInOppsoiteDirection, "the for loop is modifiying variable '$0' in the opposite direction from loop exit condition.")
+DIAGNOSTIC(30503, Warning, forLoopNotModifyingIterationVariable, "the for loop is not modifiying variable '$0' because the step size evaluates to 0.")
+DIAGNOSTIC(30504, Warning, forLoopTerminatesInFewerIterationsThanMaxIters, "the for loop is statically determined to terminate within $0 iterations, which is less than what [MaxIters] specifies.")
+DIAGNOSTIC(30505, Warning, loopRunsForZeroIterations, "the loop runs for 0 iterations and will be removed.")
+DIAGNOSTIC(30510, Error, loopInDiffFuncRequireUnrollOrMaxIters, "loops inside a differentiable function need to provide either '[MaxIters(n)]' or '[ForceUnroll]' attribute.")
+
 // TODO: need to assign numbers to all these extra diagnostics...
 DIAGNOSTIC(39999, Fatal, cyclicReference, "cyclic reference '$0'.")
 DIAGNOSTIC(39999, Error, localVariableUsedBeforeDeclared, "local variable '$0' is being used before its declaration.")

--- a/source/slang/slang-ir-check-differentiability.cpp
+++ b/source/slang/slang-ir-check-differentiability.cpp
@@ -346,6 +346,22 @@ public:
                 }
             }
         }
+
+        // Make sure all loops are marked with either [MaxIters] or [ForceUnroll].
+        for (auto block : funcInst->getBlocks())
+        {
+            auto loop = as<IRLoop>(block->getTerminator());
+            if (!loop)
+                continue;
+            if (loop->findDecoration<IRLoopMaxItersDecoration>() || loop->findDecoration<IRForceUnrollDecoration>())
+            {
+                // We are good.
+            }
+            else
+            {
+                sink->diagnose(loop->sourceLoc, Diagnostics::loopInDiffFuncRequireUnrollOrMaxIters);
+            }
+        }
     }
 
     void processModule()

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -598,6 +598,7 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     INST(LayoutDecoration,                  layout,                 1, 0)
     INST(LoopControlDecoration,             loopControl,            1, 0)
     INST(LoopMaxItersDecoration,            loopMaxIters,           1, 0)
+    INST(LoopInferredMaxItersDecoration,    loopInferredMaxIters,   2, 0)
     INST(LoopExitPrimalValueDecoration,     loopExitPrimalValue,    2, 0)
     INST(IntrinsicOpDecoration, intrinsicOp, 1, 0)
     /* TargetSpecificDecoration */

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -466,6 +466,27 @@ IRInst* getUndefInst(IRBuilder builder, IRModule* module)
     return undefInst;
 }
 
+IROp getSwapSideComparisonOp(IROp op)
+{
+    switch (op)
+    {
+    case kIROp_Eql:
+        return kIROp_Eql;
+    case kIROp_Neq:
+        return kIROp_Neq;
+    case kIROp_Leq:
+        return kIROp_Geq;
+    case kIROp_Geq:
+        return kIROp_Leq;
+    case kIROp_Less:
+        return kIROp_Greater;
+    case kIROp_Greater:
+        return kIROp_Less;
+    default:
+        return kIROp_Nop;
+    }
+}
+
 bool isPureFunctionalCall(IRCall* call)
 {
     auto callee = getResolvedInstForDecorations(call->getCallee());

--- a/source/slang/slang-ir-util.h
+++ b/source/slang/slang-ir-util.h
@@ -170,6 +170,9 @@ bool canInstHaveSideEffectAtAddress(IRGlobalValueWithCode* func, IRInst* inst, I
 
 IRInst* getUndefInst(IRBuilder builder, IRModule* module);
 
+// The the equivalent op of (a op b) in (b op' a). For example, a > b is equivalent to b < a. So (<) ==> (>).
+IROp getSwapSideComparisonOp(IROp op);
+
 }
 
 #endif

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -4856,15 +4856,17 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
         {
             getBuilder()->addLoopControlDecoration(inst, kIRLoopControl_Loop);
         }
+
+        if( auto maxItersAttr = stmt->findModifier<MaxItersAttribute>() )
+        {
+            getBuilder()->addLoopMaxItersDecoration(inst, maxItersAttr->value);
+        }
         else if (auto inferredMaxItersAttr = stmt->findModifier<InferredMaxItersAttribute>())
         {
             getBuilder()->addLoopMaxItersDecoration(inst, inferredMaxItersAttr->value);
         }
-        else if( auto maxItersAttr = stmt->findModifier<MaxItersAttribute>() )
-        {
-            getBuilder()->addLoopMaxItersDecoration(inst, maxItersAttr->value);
-        }
-        else if (auto forceUnrollAttr = stmt->findModifier<ForceUnrollAttribute>())
+
+        if (auto forceUnrollAttr = stmt->findModifier<ForceUnrollAttribute>())
         {
             getBuilder()->addLoopForceUnrollDecoration(inst, forceUnrollAttr->maxIterations);
         }

--- a/tests/autodiff/generic-impl-jvp.slang
+++ b/tests/autodiff/generic-impl-jvp.slang
@@ -24,6 +24,7 @@ struct myvector : IDifferentiable
     
     __init(T c)
     {
+        [ForceUnroll]
         for (int i = 0; i < N; i++)
         {
             values[i] = c;
@@ -46,7 +47,7 @@ struct myvector : IDifferentiable
     static Differential dmul(This a, Differential b)
     {
         Differential output;
-        
+
         for (int i = 0; i < N; i++)
         {
             output.values[i] = T.dmul(a.values[i], b.values[i]);
@@ -73,6 +74,7 @@ __generic<T : IDFloat, let N : int>
 myvector<T, N> operator +(myvector<T, N> a, myvector<T, N> b)
 {
     myvector<T, N> output;
+    [ForceUnroll]
     for (int i = 0; i < N; i++)
     {
         output.values[i] = a.values[i] + b.values[i];
@@ -85,6 +87,7 @@ __generic<T : IDFloat, let N : int>
 myvector<T, N> operator *(myvector<T, N> a, myvector<T, N> b)
 {
     myvector<T, N> output;
+    [ForceUnroll]
     for (int i = 0; i < N; i++)
     {
         output.values[i] = a.values[i] * b.values[i];
@@ -97,6 +100,7 @@ __generic<T : IDFloat, let N : int>
 myvector<T, N> operator *(T a, myvector<T, N> b)
 {
     myvector<T, N> output;
+    [ForceUnroll]
     for (int i = 0; i < N; i++)
     {
         output.values[i] = a * b.values[i];
@@ -109,6 +113,7 @@ __generic<T : IDFloat, let N : int>
 T dot(myvector<T, N> a, myvector<T, N> b)
 {
     T curr = (T)0.0;
+    [ForceUnroll]
     for (int i = 0; i < N; i++)
     {
         curr = curr + (a.values[i] * b.values[i]);
@@ -125,6 +130,7 @@ DifferentialPair<T> dot_jvp(dpvector<T, N> a, dpvector<T, N> b)
 {
     T.Differential curr_d = (T.dzero());
     T curr_p = (T)0.0;
+    [ForceUnroll]
     for (int i = 0; i < N; i++)
     {
         curr_p = curr_p + (a.p.values[i] * b.p.values[i]);
@@ -145,6 +151,7 @@ struct lineardvector : IDifferentiable
 
     __init(vector<Real.Differential, N> a)
     {
+        [ForceUnroll]
         for (int i = 0; i < N; i++)
         {
             val.values[i] = a[i];
@@ -204,6 +211,7 @@ struct linearvector : MyLinearArithmeticType, IDifferentiable
     [ForwardDifferentiable]
     __init(vector<Real, N> a)
     {
+        [ForceUnroll]
         for (int i = 0; i < N; i++)
         {
             val.values[i] = a[i];

--- a/tests/autodiff/reverse-loop.slang
+++ b/tests/autodiff/reverse-loop.slang
@@ -13,7 +13,6 @@ float test_simple_loop(float y)
 {
     float t = y;
 
-    [MaxIters(4)]
     for (int i = 0; i < 3; i++)
     {
         t = t * t;

--- a/tests/autodiff/reverse-loop.slang
+++ b/tests/autodiff/reverse-loop.slang
@@ -13,6 +13,7 @@ float test_simple_loop(float y)
 {
     float t = y;
 
+    [MaxIters(4)]
     for (int i = 0; i < 3; i++)
     {
         t = t * t;

--- a/tests/autodiff/reverse-loop.slang
+++ b/tests/autodiff/reverse-loop.slang
@@ -13,7 +13,6 @@ float test_simple_loop(float y)
 {
     float t = y;
 
-    [MaxIters(3)]
     for (int i = 0; i < 3; i++)
     {
         t = t * t;

--- a/tests/diagnostics/autodiff-data-flow.slang
+++ b/tests/diagnostics/autodiff-data-flow.slang
@@ -24,6 +24,11 @@ void g(float x)
     float val = 0;
     if (x > 5)
         val = x + 1;
+
+    for (int i = 0; i < 5; i++) // Not ok, we can't infer the loop iterations because the body modifies induction var.
+    {
+        i = (int)x;
+    }
     return;
 }
 

--- a/tests/diagnostics/autodiff-data-flow.slang.expected
+++ b/tests/diagnostics/autodiff-data-flow.slang.expected
@@ -6,6 +6,9 @@ tests/diagnostics/autodiff-data-flow.slang(15): error 41020: derivative cannot b
 tests/diagnostics/autodiff-data-flow.slang(22): error 41021: a differentiable function must have at least one differentiable output.
 void g(float x)
      ^
+tests/diagnostics/autodiff-data-flow.slang(28): error 30510: loops inside a differentiable function need to provide either '[MaxIters(n)]' or '[ForceUnroll]' attribute.
+    for (int i = 0; i < 5; i++) // Not ok, we can't infer the loop iterations because the body modifies induction var.
+    ^~~
 }
 standard output = {
 }

--- a/tests/diagnostics/autodiff.slang
+++ b/tests/diagnostics/autodiff.slang
@@ -11,6 +11,21 @@ float f(float x)
     float val = 0;
     if (x > 5)
         val = x + 1;
+
+    // warning: dynamic loop without [MaxIters] or [ForceUnroll]
+    for (int i = 0; i < (int)x; i++) 
+    {
+    }
+
+    [MaxIters(2)]
+    for (int i = 0; i < (int)x; i++) // OK
+    {
+    }
+
+    for (int i = 0; i < 5; i++) // OK
+    {
+    }
+
     return val;
 }
 

--- a/tests/diagnostics/autodiff.slang.expected
+++ b/tests/diagnostics/autodiff.slang.expected
@@ -1,12 +1,15 @@
 result code = -1
 standard error = {
-tests/diagnostics/autodiff.slang(20): error 38031: 'no_diff' can only be used to decorate a call.
+tests/diagnostics/autodiff.slang(16): error 30510: loops inside a differentiable function need to provide either '[MaxIters(n)]' or '[ForceUnroll]' attribute.
+    for (int i = 0; i < (int)x; i++)
+    ^~~
+tests/diagnostics/autodiff.slang(35): error 38031: 'no_diff' can only be used to decorate a call.
     float x1 = no_diff x; // invalid use of no_diff here.
                ^~~~~~~
-tests/diagnostics/autodiff.slang(21): error 38032: use 'no_diff' on a call to a differentiable function has no meaning.
+tests/diagnostics/autodiff.slang(36): error 38032: use 'no_diff' on a call to a differentiable function has no meaning.
     return no_diff f(x);  // no_diff on a differentiable call has no meaning.
            ^~~~~~~
-tests/diagnostics/autodiff.slang(26): error 38033: cannot use 'no_diff' in a non-differentiable function.
+tests/diagnostics/autodiff.slang(41): error 38033: cannot use 'no_diff' in a non-differentiable function.
     return no_diff nonDiff(x); // no_diff in a non-differentiable function
            ^~~~~~~
 }

--- a/tests/diagnostics/for-loop-warning.slang
+++ b/tests/diagnostics/for-loop-warning.slang
@@ -1,0 +1,60 @@
+//DIAGNOSTIC_TEST:SIMPLE:
+
+
+float doSomething(int x)
+{
+    for (int i = 0; i < x; i--) // warn.
+    {}
+    for (int i = 0; i < 5; i-=-2) // ok.
+    {}
+    for (int j = 0; j < 3; j += 0) // warn.
+    {}
+    for (int i = 0; i < 5; i++) // ok
+    {
+        for (int j = 0; j < 3; i++) // warn.
+        {}
+    }
+    for (int i = 0; i < 5; i++) // ok
+    {
+        for (int j = 0; i < 4; j++) // warn.
+        {}
+    }
+
+    [MaxIters(6)] // warn
+    for (int i = 0; i <= 6; i+=3)
+    {
+    }
+
+    [MaxIters(6)] // warn
+    for (int i = 5; i >= 0; i -= 3)
+    {
+    }
+    [MaxIters(6)] // warn
+    for (int i = 5; i > 0; i--)
+    {
+    }
+
+    [MaxIters(5)] // ok
+    for (int i = 0; i < 5; i++) // ok
+    {
+    }
+
+    for (int i = 1; i < 0; i++) // warn
+    {
+    }
+    for (int i = 1; i >= 2; i--) // warn
+    {
+    }
+    for (int i = 1; i >= 1; i--) // ok
+    {
+    }
+    for (int i = 1; i > 1; i--) // warn
+    {
+    }
+    [MaxIters(5)] // ok, because the loop body modifies i so we can't infer the iterations.
+    for (int i = 0; i < 5; i+=2)
+    {
+        i--;
+    }
+    return 0.0;
+}

--- a/tests/diagnostics/for-loop-warning.slang.expected
+++ b/tests/diagnostics/for-loop-warning.slang.expected
@@ -1,0 +1,35 @@
+result code = 0
+standard error = {
+tests/diagnostics/for-loop-warning.slang(6): warning 30502: the for loop is modifiying variable 'i' in the opposite direction from loop exit condition.
+    for (int i = 0; i < x; i--) // warn.
+                            ^~
+tests/diagnostics/for-loop-warning.slang(10): warning 30503: the for loop is not modifiying variable 'j' because the step size evaluates to 0.
+    for (int j = 0; j < 3; j += 0) // warn.
+                             ^~
+tests/diagnostics/for-loop-warning.slang(14): warning 30500: the for loop initializes and checks variable 'j' but the side effect expression is modifying 'i'.
+        for (int j = 0; j < 3; i++) // warn.
+                               ^
+tests/diagnostics/for-loop-warning.slang(19): warning 30501: the for loop initializes and modifies variable 'j' but the predicate expression is checking 'i'.
+        for (int j = 0; i < 4; j++) // warn.
+                          ^
+tests/diagnostics/for-loop-warning.slang(42): warning 30505: the loop runs for 0 iterations and will be removed.
+    for (int i = 1; i < 0; i++) // warn
+    ^~~
+tests/diagnostics/for-loop-warning.slang(45): warning 30505: the loop runs for 0 iterations and will be removed.
+    for (int i = 1; i >= 2; i--) // warn
+    ^~~
+tests/diagnostics/for-loop-warning.slang(51): warning 30505: the loop runs for 0 iterations and will be removed.
+    for (int i = 1; i > 1; i--) // warn
+    ^~~
+tests/diagnostics/for-loop-warning.slang(23): warning 30504: the for loop is statically determined to terminate within 3 iterations, which is less than what [MaxIters] specifies.
+    [MaxIters(6)] // warn
+     ^~~~~~~~
+tests/diagnostics/for-loop-warning.slang(28): warning 30504: the for loop is statically determined to terminate within 2 iterations, which is less than what [MaxIters] specifies.
+    [MaxIters(6)] // warn
+     ^~~~~~~~
+tests/diagnostics/for-loop-warning.slang(32): warning 30504: the for loop is statically determined to terminate within 5 iterations, which is less than what [MaxIters] specifies.
+    [MaxIters(6)] // warn
+     ^~~~~~~~
+}
+standard output = {
+}


### PR DESCRIPTION
This PR adds a inference step when checking `for` loops to try to statically determine the maximum number of iterations for the loop and insert a `[MaxIters]` attribute on the loop if inference suceeds.

It also reports warnings along the way if it detects suspicious code like `for (int i = 0; i < 5; j++)`.
