### PR TITLE
AD: Remove the original loop condition upon inversion

### DIFF
--- a/source/slang/slang-ir-autodiff-transpose.h
+++ b/source/slang/slang-ir-autodiff-transpose.h
@@ -1064,8 +1064,6 @@ struct DiffTransposePass
 
         builder->emitStore(firstLoopCheckSkipVar, builder->getBoolValue(false));
 
-        auto loopBaseCondition = firstLoopCheckSkipVal;
-
         // Add a terminating condition based on the loop counter's initial primal value
 
         IRParam* loopCounterParam = nullptr;
@@ -1096,14 +1094,8 @@ struct DiffTransposePass
                 List<IRInst*>(
                     hoistPrimalInst(builder, loopCounterParam),
                     hoistPrimalInst(builder, loopCounterInitVal)).getBuffer());
-            
-        loopBaseCondition = builder->emitIntrinsicInst(
-            builder->getBoolType(),
-            kIROp_And,
-            2,
-            List<IRInst*>(paramBoundsCheck, loopBaseCondition).getBuffer());
 
-        as<IRIfElse>(revLoopCondBlock->getTerminator())->condition.set(loopBaseCondition);
+        as<IRIfElse>(revLoopCondBlock->getTerminator())->condition.set(paramBoundsCheck);
     }
 
     List<InvInstPair> invertInst(IRBuilder* builder, IRInst* primalInst, IRInst* invOutput)

--- a/source/slang/slang-ir-autodiff-transpose.h
+++ b/source/slang/slang-ir-autodiff-transpose.h
@@ -1050,19 +1050,6 @@ struct DiffTransposePass
 
         IRBlock* revLoopCondBlock = revBlockMap[firstLoopBlock];
         builder->setInsertBefore(revLoopCondBlock->getTerminator());
-        
-        // Convert the loop from a 'for' into a 'do-while' by skipping the first check
-
-        IRBlock* revLoopStartBlock = revBlockMap[as<IRBlock>(loopInst->getBreakBlock())];
-        builder->setInsertBefore(revLoopStartBlock->getTerminator());
-
-        auto firstLoopCheckSkipVar = builder->emitVar(builder->getBoolType());
-        builder->emitStore(firstLoopCheckSkipVar, builder->getBoolValue(true));
-
-        builder->setInsertBefore(revLoopCondBlock->getTerminator());
-        auto firstLoopCheckSkipVal = builder->emitLoad(firstLoopCheckSkipVar);
-
-        builder->emitStore(firstLoopCheckSkipVar, builder->getBoolValue(false));
 
         // Add a terminating condition based on the loop counter's initial primal value
 

--- a/source/slang/slang-ir-autodiff-transpose.h
+++ b/source/slang/slang-ir-autodiff-transpose.h
@@ -1050,8 +1050,6 @@ struct DiffTransposePass
 
         IRBlock* revLoopCondBlock = revBlockMap[firstLoopBlock];
         builder->setInsertBefore(revLoopCondBlock->getTerminator());
-
-        auto loopBaseCondition = as<IRIfElse>(revLoopCondBlock->getTerminator())->getCondition();
         
         // Convert the loop from a 'for' into a 'do-while' by skipping the first check
 
@@ -1066,11 +1064,7 @@ struct DiffTransposePass
 
         builder->emitStore(firstLoopCheckSkipVar, builder->getBoolValue(false));
 
-        loopBaseCondition = builder->emitIntrinsicInst(
-                builder->getBoolType(),
-                kIROp_Or,
-                2,
-                List<IRInst*>(firstLoopCheckSkipVal, loopBaseCondition).getBuffer());
+        auto loopBaseCondition = firstLoopCheckSkipVal;
 
         // Add a terminating condition based on the loop counter's initial primal value
 
@@ -1108,7 +1102,6 @@ struct DiffTransposePass
             kIROp_And,
             2,
             List<IRInst*>(paramBoundsCheck, loopBaseCondition).getBuffer());
-
 
         as<IRIfElse>(revLoopCondBlock->getTerminator())->condition.set(loopBaseCondition);
     }

--- a/source/slang/slang-ir-autodiff-transpose.h
+++ b/source/slang/slang-ir-autodiff-transpose.h
@@ -1059,7 +1059,7 @@ struct DiffTransposePass
         {   
             if (param->findDecoration<IRLoopCounterDecoration>())
             {
-                // There really should be two (or more) loop counter params.
+                // There really not should be two (or more) loop counter params.
                 SLANG_RELEASE_ASSERT(loopCounterParam == nullptr);
                 loopCounterParam = param;
             }


### PR DESCRIPTION
it's redundant, and causes out-of-bounds accesses. The counters are enough to ensure correctness