### PR TITLE
AD: More legacy type handling cleanup + user-defined reverse-mode fix

### DIFF
--- a/source/slang/slang-ir-autodiff-rev.cpp
+++ b/source/slang/slang-ir-autodiff-rev.cpp
@@ -295,9 +295,6 @@ namespace Slang
     // Create an empty func to represent the transcribed func of `origFunc`.
     InstPair BackwardDiffTranscriberBase::transcribeFuncHeaderImpl(IRBuilder* inBuilder, IRFunc* origFunc)
     {
-        if (auto bwdDiffFunc = findExistingDiffFunc(origFunc))
-            return InstPair(origFunc, bwdDiffFunc);
-
         if (!isBackwardDifferentiableFunc(origFunc))
             return InstPair(nullptr, nullptr);
 
@@ -379,11 +376,15 @@ namespace Slang
 
     InstPair BackwardDiffTranscriber::transcribeFuncHeader(IRBuilder* inBuilder, IRFunc* origFunc)
     {
+        if (auto bwdDiffFunc = findExistingDiffFunc(origFunc))
+            return InstPair(origFunc, bwdDiffFunc);
+
         auto header = transcribeFuncHeaderImpl(inBuilder, origFunc);
         if (!header.differential)
             return header;
-
+            
         IRBuilder builder = *inBuilder;
+
         builder.setInsertInto(header.differential);
         builder.emitBlock();
         auto origFuncType = as<IRFuncType>(origFunc->getFullType());

--- a/source/slang/slang-ir-autodiff-transcriber-base.cpp
+++ b/source/slang/slang-ir-autodiff-transcriber-base.cpp
@@ -879,7 +879,7 @@ InstPair AutoDiffTranscriberBase::transcribeGeneric(IRBuilder* inBuilder, IRGene
 
 IRInst* AutoDiffTranscriberBase::transcribe(IRBuilder* builder, IRInst* origInst)
 {
-    // If a differential intstruction is already mapped for 
+    // If a differential instruction is already mapped for 
     // this original inst, return that.
     //
     if (auto diffInst = lookupDiffInst(origInst, nullptr))

--- a/source/slang/slang-ir-autodiff.h
+++ b/source/slang/slang-ir-autodiff.h
@@ -170,11 +170,6 @@ struct DifferentiableTypeConformanceContext
     {
         switch (origType->getOp())
         {
-        case kIROp_FloatType:
-        case kIROp_HalfType:
-        case kIROp_DoubleType:
-            return origType;
-            
         case kIROp_ArrayType:
         {
             auto diffElementType = (IRType*)getDifferentialForType(

--- a/tests/autodiff/backward-diff-check.slang
+++ b/tests/autodiff/backward-diff-check.slang
@@ -14,6 +14,7 @@ float test()
 }
 
 float noDiffFunc(float x) { return x; }
+
 [BackwardDerivativeOf(test)]
 void d_test(float dOut)
 {


### PR DESCRIPTION
 - Fixed issue with user-defined reverse-mode code still invoking AD
 - removed special cases for float, double and half from the differential types logic