### PR TITLE
Fixed hoisting of intermediate array & context vars

### DIFF
--- a/source/slang/slang-ir-autodiff-cfg-norm.cpp
+++ b/source/slang/slang-ir-autodiff-cfg-norm.cpp
@@ -409,6 +409,7 @@ struct CFGNormalizationPass
                 // false -> atleast one break statement hit.
                 //
                 info.breakVar = builder.emitVar(builder.getBoolType());
+                builder.addNameHintDecoration(info.breakVar, UnownedStringSlice("_bflag"));
                 builder.emitStore(info.breakVar, builder.getBoolValue(true));
 
                 // If the loop is trivial (i.e. single iteration, with no

--- a/source/slang/slang-ir-autodiff-rev.h
+++ b/source/slang/slang-ir-autodiff-rev.h
@@ -32,8 +32,8 @@ struct ParameterBlockTransposeInfo
 
     // The value with which a primal specific parameter should be replaced in propagate func.
     OrderedDictionary<IRInst*, IRInst*> mapPrimalSpecificParamToReplacementInPropFunc;
-
     // The insts added that is specific for propagate functions and should be removed
+
     // from the future primal func.
     List<IRInst*> propagateFuncSpecificPrimalInsts;
 

--- a/source/slang/slang-ir-autodiff-transpose.h
+++ b/source/slang/slang-ir-autodiff-transpose.h
@@ -1138,7 +1138,11 @@ struct DiffTransposePass
 
     IRInst* hoistPrimalInst(IRBuilder* revBuilder, IRInst* inst)
     {
-        SLANG_RELEASE_ASSERT(isPrimalInst(inst));
+        if (as<IRBlock>(inst->getParent()) && 
+            isDifferentialInst(as<IRBlock>(inst->getParent())))
+        {
+            SLANG_RELEASE_ASSERT(isPrimalInst(inst));
+        }
 
         // Are the operands of this primal inst also available in the reverse-mode context?
         // If not, move/load them.
@@ -1379,7 +1383,7 @@ struct DiffTransposePass
                 // In order to perform the call, we need a temporary var to store the DiffPair.
                 auto pairType = as<IRPtrTypeBase>(arg->getDataType())->getValueType();
                 auto tempVar = builder->emitVar(pairType);
-                auto primalVal = builder->emitLoad(instPair->getPrimal());
+                auto primalVal = builder->emitLoad(hoistPrimalInst(builder, instPair->getPrimal()));
                 auto diffVal = builder->emitLoad(instPair->getDiff());
                 auto pairVal = builder->emitMakeDifferentialPair(pairType, primalVal, diffVal);
                 builder->emitStore(tempVar, pairVal);

--- a/tests/autodiff/reverse-control-flow-3.slang
+++ b/tests/autodiff/reverse-control-flow-3.slang
@@ -65,7 +65,7 @@ DifferentialPair<MaterialParam> d_getParam(uint id)
     MaterialParam p;
     p.roughness = 0.5f;
     MaterialParam.Differential d;
-    d.roughness = 0.0f;
+    d.roughness = 1.0f;
     return diffPair(p, d);
 }
 
@@ -140,7 +140,7 @@ void handleHit(inout PathState path, inout PathResult rs, inout VisibilityQuery 
         path.terminated = true;
         return;
     }
-    
+     
     generateScatterRay(param, path, rs);
 
     rs.L = rs.thp * lightEval(path.depth);
@@ -179,7 +179,6 @@ bool tracePath(uint pathID, out PathState path, inout PathResult pathRes)
     float thp = pathRes.thp;
     float L = pathRes.L;
 
-    [ForceUnroll]
     for (int i = 0; i < 3; ++i)
     {
         if (path.isHit())


### PR DESCRIPTION
Added logic to store most arbitrary temporary variables

The hoisting code is fairly messy now with all these cases. 
Next step is to restructure this and merge with the dominator tree approach.