### PR TITLE
Add `SourceBlobWithPathInfoArtifactRepresentation`.

### DIFF
--- a/source/compiler-core/slang-artifact-representation-impl.cpp
+++ b/source/compiler-core/slang-artifact-representation-impl.cpp
@@ -98,6 +98,12 @@ void* SourceBlobWithPathInfoArtifactRepresentation::castAs(const Guid& guid)
 
 SlangResult SourceBlobWithPathInfoArtifactRepresentation::createRepresentation(const Guid& typeGuid, ICastable** outCastable)
 {
+    // We can convert into a blob only.
+    if (typeGuid != ISlangBlob::getTypeGuid())
+    {
+        return SLANG_E_NOT_AVAILABLE;
+    }
+
     if (!m_blob)
     {
         return SLANG_E_NOT_AVAILABLE;

--- a/source/compiler-core/slang-artifact-representation-impl.cpp
+++ b/source/compiler-core/slang-artifact-representation-impl.cpp
@@ -67,6 +67,46 @@ bool ExtFileArtifactRepresentation::exists()
     return SLANG_SUCCEEDED(res) && pathType == getPathType();
 }
 
+/* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!! SourceBlobWithPathArtifactRepresentation !!!!!!!!!!!!!!!!!!!!!!!!!!! */
+
+void* SourceBlobWithPathInfoArtifactRepresentation::getInterface(const Guid& guid)
+{
+    if (guid == ISlangUnknown::getTypeGuid() ||
+        guid == ICastable::getTypeGuid() ||
+        guid == IArtifactRepresentation::getTypeGuid() ||
+        guid == IPathArtifactRepresentation::getTypeGuid())
+    {
+        return static_cast<IPathArtifactRepresentation*>(this);
+    }
+    return nullptr;
+}
+
+void* SourceBlobWithPathInfoArtifactRepresentation::getObject(const Guid& guid)
+{
+    SLANG_UNUSED(guid);
+    return nullptr;
+}
+
+void* SourceBlobWithPathInfoArtifactRepresentation::castAs(const Guid& guid)
+{
+    if (auto intf = getInterface(guid))
+    {
+        return intf;
+    }
+    return getObject(guid);
+}
+
+SlangResult SourceBlobWithPathInfoArtifactRepresentation::createRepresentation(const Guid& typeGuid, ICastable** outCastable)
+{
+    if (!m_blob)
+    {
+        return SLANG_E_NOT_AVAILABLE;
+    }
+
+    *outCastable = CastableUtil::getCastable(m_blob).detach();
+    return SLANG_OK;
+}
+
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!! FileArtifactRepresentation !!!!!!!!!!!!!!!!!!!!!!!!!!! */
 
 void* OSFileArtifactRepresentation::getInterface(const Guid& guid)

--- a/source/compiler-core/slang-artifact-representation-impl.h
+++ b/source/compiler-core/slang-artifact-representation-impl.h
@@ -123,7 +123,7 @@ public:
     SLANG_NO_THROW bool SLANG_MCALL exists() SLANG_OVERRIDE { return false; }
 
     // IPathArtifactRepresentation
-    virtual SLANG_NO_THROW const char* SLANG_MCALL getPath() SLANG_OVERRIDE { return m_pathInfo.getMostUniqueIdentity().getBuffer(); }
+    virtual SLANG_NO_THROW const char* SLANG_MCALL getPath() SLANG_OVERRIDE { return m_pathInfo.getName().getBuffer(); }
     virtual SLANG_NO_THROW SlangPathType SLANG_MCALL getPathType() SLANG_OVERRIDE { return SLANG_PATH_TYPE_FILE; }
 
     SourceBlobWithPathInfoArtifactRepresentation(const PathInfo& pathInfo, ISlangBlob* sourceBlob) :

--- a/source/compiler-core/slang-artifact-representation-impl.h
+++ b/source/compiler-core/slang-artifact-representation-impl.h
@@ -10,6 +10,8 @@
 #include "../core/slang-com-object.h"
 #include "../core/slang-memory-arena.h"
 
+#include "slang-source-loc.h"
+
 namespace Slang
 {
 
@@ -104,6 +106,43 @@ protected:
 
     String m_path;
     ComPtr<ISlangFileSystemExt> m_fileSystem;
+};
+
+class SourceBlobWithPathInfoArtifactRepresentation : public ComBaseObject, public IPathArtifactRepresentation
+{
+public:
+    typedef SourceBlobWithPathInfoArtifactRepresentation ThisType;
+
+    SLANG_COM_BASE_IUNKNOWN_ALL
+
+    // ICastable
+    SLANG_NO_THROW void* SLANG_MCALL castAs(const Guid& guid) SLANG_OVERRIDE;
+
+    // IArtifactRepresentation
+    SLANG_NO_THROW SlangResult SLANG_MCALL createRepresentation(const Guid& typeGuid, ICastable** outCastable) SLANG_OVERRIDE;
+    SLANG_NO_THROW bool SLANG_MCALL exists() SLANG_OVERRIDE { return false; }
+
+    // IPathArtifactRepresentation
+    virtual SLANG_NO_THROW const char* SLANG_MCALL getPath() SLANG_OVERRIDE { return m_pathInfo.getMostUniqueIdentity().getBuffer(); }
+    virtual SLANG_NO_THROW SlangPathType SLANG_MCALL getPathType() SLANG_OVERRIDE { return SLANG_PATH_TYPE_FILE; }
+
+    SourceBlobWithPathInfoArtifactRepresentation(const PathInfo& pathInfo, ISlangBlob* sourceBlob) :
+        m_pathInfo(pathInfo),
+        m_blob(sourceBlob)
+    {
+    }
+
+    static ComPtr<IPathArtifactRepresentation> create(const PathInfo& pathInfo, ISlangBlob* sourceBlob)
+    {
+        return ComPtr<IPathArtifactRepresentation>(new ThisType(pathInfo, sourceBlob));
+    }
+
+protected:
+    void* getInterface(const Guid& uuid);
+    void* getObject(const Guid& uuid);
+
+    PathInfo m_pathInfo;
+    ComPtr<ISlangBlob> m_blob;
 };
 
 /* This allows wrapping any object to be an artifact representation. 

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -286,7 +286,23 @@ namespace Slang
             // If ioBuilder doesn't end in a delimiter, add one
             if (!isDelimiter(ioBuilder[ioBuilder.getLength() - 1]))
             {
-                ioBuilder.append(kPathDelimiter);
+                // Determine the preferred delimiter to use based on existing path.
+                char preferedDelimiter = kOSCanonicalPathDelimiter;
+                if (kOSAlternativePathDelimiter != preferedDelimiter)
+                {
+                    // If we found the existing path uses the alternative delimiter, we will
+                    // use that instead of the canonical one.
+                    constexpr Index kMaxDelimiterSearchRange = 32;
+                    for (Index i = 0; i < Math::Min(kMaxDelimiterSearchRange, ioBuilder.getLength()); i++)
+                    {
+                        if (ioBuilder[i] == kOSAlternativePathDelimiter)
+                        {
+                            preferedDelimiter = kOSAlternativePathDelimiter;
+                            break;
+                        }
+                    }
+                }
+                ioBuilder.append(preferedDelimiter);
             }
             // Check that path doesn't start with a path delimiter
             SLANG_ASSERT(!isDelimiter(path[0]));

--- a/source/core/slang-io.h
+++ b/source/core/slang-io.h
@@ -96,8 +96,11 @@ namespace Slang
 
 #if SLANG_WINDOWS_FAMILY
         static const char kOSCanonicalPathDelimiter = '\\';
+        static const char kOSAlternativePathDelimiter = '/';
+
 #else
         static const char kOSCanonicalPathDelimiter = '/';
+        static const char kOSAlternativePathDelimiter = '/';
 #endif
 
             /// Finds all all the items in the specified directory, that matches the pattern.

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -2980,17 +2980,22 @@ RefPtr<Module> Linkage::loadModule(
     // Create an artifact for the source
     auto sourceArtifact = ArtifactUtil::createArtifact(ArtifactDesc::make(ArtifactKind::Source, ArtifactPayload::Slang, ArtifactStyle::Unknown));
 
-    // Create with the 'friendly' name
-    if (filePathInfo.type == PathInfo::Type::Normal ||
+    if (sourceBlob)
+    {
+        // If the user has already provided a source blob, use that.
+        sourceArtifact->addRepresentation(new SourceBlobWithPathInfoArtifactRepresentation(filePathInfo, sourceBlob));
+    }
+    else if (
+        filePathInfo.type == PathInfo::Type::Normal ||
         filePathInfo.type == PathInfo::Type::FoundPath)
     {
+        // Create with the 'friendly' name
         // We create that it was loaded from the file system
         sourceArtifact->addRepresentation(new ExtFileArtifactRepresentation(filePathInfo.foundPath.getUnownedSlice(), getFileSystemExt()));
     }
     else
     {
-        // Else we say we don't know and just add the blob
-        sourceArtifact->addRepresentationUnknown(sourceBlob);
+        return nullptr;
     }
 
     translationUnit->addSourceArtifact(sourceArtifact);


### PR DESCRIPTION
If the user has provided both a path and a source blob, we should use the user provided source blob instead of loading it from file. In this case we still need to preserve the path info, so we use the `SourceBlobWithPathInfoArtifactRepresentation` class to do that.