### PR TITLE
Support GL_EXT_fragment_shader_barycentric

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -2274,10 +2274,9 @@ matrix<T, N, M> fwidth(matrix<T, N, M> x)
 __generic<T : __BuiltinType>
 [__readNone]
 __target_intrinsic(hlsl)
-__target_intrinsic(glsl, "$0[$1]")
+__target_intrinsic(GL_NV_fragment_shader_barycentric, "$0[$1]")
+__target_intrinsic(GL_EXT_fragment_shader_barycentric, "$0[$1]")
 __glsl_version(450)
-__glsl_extension(GL_NV_fragment_shader_barycentric)
-__glsl_extension(GL_EXT_fragment_shader_barycentric)
 T GetAttributeAtVertex(T attribute, uint vertexIndex);
 
 /// Get the value of a vertex attribute at a specific vertex.
@@ -2297,10 +2296,9 @@ T GetAttributeAtVertex(T attribute, uint vertexIndex);
 __generic<T : __BuiltinType, let N : int>
 [__readNone]
 __target_intrinsic(hlsl)
-__target_intrinsic(glsl, "$0[$1]")
+__target_intrinsic(GL_NV_fragment_shader_barycentric, "$0[$1]")
+__target_intrinsic(GL_EXT_fragment_shader_barycentric, "$0[$1]")
 __glsl_version(450)
-__glsl_extension(GL_NV_fragment_shader_barycentric)
-__glsl_extension(GL_EXT_fragment_shader_barycentric)
 vector<T,N> GetAttributeAtVertex(vector<T,N> attribute, uint vertexIndex);
 
 /// Get the value of a vertex attribute at a specific vertex.
@@ -2320,10 +2318,9 @@ vector<T,N> GetAttributeAtVertex(vector<T,N> attribute, uint vertexIndex);
 __generic<T : __BuiltinType, let N : int, let M : int>
 [__readNone]
 __target_intrinsic(hlsl)
-__target_intrinsic(glsl, "$0[$1]")
+__target_intrinsic(GL_NV_fragment_shader_barycentric, "$0[$1]")
+__target_intrinsic(GL_EXT_fragment_shader_barycentric, "$0[$1]")
 __glsl_version(450)
-__glsl_extension(GL_NV_fragment_shader_barycentric)
-__glsl_extension(GL_EXT_fragment_shader_barycentric)
 matrix<T,N,M> GetAttributeAtVertex(matrix<T,N,M> attribute, uint vertexIndex);
 
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -2277,6 +2277,7 @@ __target_intrinsic(hlsl)
 __target_intrinsic(glsl, "$0[$1]")
 __glsl_version(450)
 __glsl_extension(GL_NV_fragment_shader_barycentric)
+__glsl_extension(GL_EXT_fragment_shader_barycentric)
 T GetAttributeAtVertex(T attribute, uint vertexIndex);
 
 /// Get the value of a vertex attribute at a specific vertex.
@@ -2299,6 +2300,7 @@ __target_intrinsic(hlsl)
 __target_intrinsic(glsl, "$0[$1]")
 __glsl_version(450)
 __glsl_extension(GL_NV_fragment_shader_barycentric)
+__glsl_extension(GL_EXT_fragment_shader_barycentric)
 vector<T,N> GetAttributeAtVertex(vector<T,N> attribute, uint vertexIndex);
 
 /// Get the value of a vertex attribute at a specific vertex.
@@ -2321,6 +2323,7 @@ __target_intrinsic(hlsl)
 __target_intrinsic(glsl, "$0[$1]")
 __glsl_version(450)
 __glsl_extension(GL_NV_fragment_shader_barycentric)
+__glsl_extension(GL_EXT_fragment_shader_barycentric)
 matrix<T,N,M> GetAttributeAtVertex(matrix<T,N,M> attribute, uint vertexIndex);
 
 

--- a/source/slang/slang-capability-defs.h
+++ b/source/slang/slang-capability-defs.h
@@ -87,6 +87,11 @@ SLANG_CAPABILITY_ATOM1(GLSLRayTracing,      __glslRayTracing,   Abstract,None,0,
 SLANG_CAPABILITY_ATOM1(GL_NV_ray_tracing,   GL_NV_ray_tracing,  Concrete,RayTracingExtension,0,   GLSLRayTracing)
 SLANG_CAPABILITY_ATOM2(GL_EXT_ray_tracing,  GL_EXT_ray_tracing, Concrete,RayTracingExtension,1,   GLSLRayTracing, SPIRV_1_4)
 
+SLANG_CAPABILITY_ATOM1(GLSLFragmentShaderBarycentric,           __glslFragmentShaderBarycentric,         Abstract, None,                               0, GLSL)
+SLANG_CAPABILITY_ATOM1(GL_NV_fragment_shader_barycentric,       GL_NV_fragment_shader_barycentric,       Concrete, FragmentShaderBarycentricExtension, 0, GLSLFragmentShaderBarycentric)
+SLANG_CAPABILITY_ATOM1(GL_EXT_fragment_shader_barycentric,      GL_EXT_fragment_shader_barycentric,      Concrete, FragmentShaderBarycentricExtension, 1, GLSLFragmentShaderBarycentric)
+
+
 #undef SLANG_CAPABILITY_ATOM0
 #undef SLANG_CAPABILITY_ATOM1
 #undef SLANG_CAPABILITY_ATOM2

--- a/source/slang/slang-capability.cpp
+++ b/source/slang/slang-capability.cpp
@@ -67,6 +67,10 @@ enum class CapabilityAtomConflictMask : uint32_t
     // Capability atoms that represent GLSL ray tracing extensions conflict with
     // one another (we only want to use one such extension at a time).
     RayTracingExtension = 1 << 1,
+
+    // Capability atoms that represent GLSL fragment shader barycentric extensions conflict with
+    // one another (we only want to use one such extension at a time).
+    FragmentShaderBarycentricExtension = 1 << 2,
 };
 
 // For simplicity in building up our data structure representing

--- a/source/slang/slang-emit-glsl.h
+++ b/source/slang/slang-emit-glsl.h
@@ -67,6 +67,8 @@ protected:
 
     void _maybeEmitGLSLBuiltin(IRGlobalParam* var, UnownedStringSlice name);
 
+    bool _maybeEmitInterpolationModifierText(IRInterpolationMode mode, Stage stage, bool isInput);
+
     void _requireGLSLExtension(const UnownedStringSlice& name);
 
     void _requireGLSLVersion(ProfileVersion version);
@@ -107,6 +109,8 @@ protected:
     bool _tryEmitBitBinOp(IRInst* inst, const EmitOpInfo& bitOp, const EmitOpInfo& boolOp, const EmitOpInfo& inOuterPrec);
 
     void _requireRayTracing();
+
+    void _requireFragmentShaderBarycentric();
 
     void _emitSpecialFloatImpl(IRType* type, const char* valueExpr);
 

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -712,9 +712,11 @@ struct OptionsParser
             "  code accordingly.\n"
             "  Currently defined capabilities are:\n"
             "\n"
-            "    spriv_1_{0,1,2,3,4,5}   - minimum supported SPIR-V version\n"
+            "    spirv_1_{0,1,2,3,4,5}   - minimum supported SPIR-V version\n"
             "    GL_NV_ray_tracing       - enables the GL_NV_ray_tracing extension\n"
             "    GL_EXT_ray_tracing      - enables the GL_EXT_ray_tracing extension\n"
+            "    GL_NV_fragment_shader_barycentric  - enables the GL_NV_fragment_shader_barycentric extension\n"
+            "    GL_EXT_fragment_shader_barycentric - enables the GL_EXT_fragment_shader_barycentric extension\n"
             "\n";
 
 #undef EXECUTABLE_EXTENSION

--- a/tests/cross-compile/barycentrics-nv.slang
+++ b/tests/cross-compile/barycentrics-nv.slang
@@ -1,0 +1,6 @@
+//TEST:CROSS_COMPILE: -target spirv-assembly -capability GL_NV_fragment_shader_barycentric -entry main -stage fragment
+
+float4 main(float3 bary : SV_Barycentrics) : SV_Target
+{
+    return float4(bary, 0);
+}

--- a/tests/cross-compile/barycentrics-nv.slang.glsl
+++ b/tests/cross-compile/barycentrics-nv.slang.glsl
@@ -1,0 +1,12 @@
+#version 450
+
+#extension GL_NV_fragment_shader_barycentric : enable
+
+layout(location = 0)
+out vec4 _S1;
+
+void main()
+{
+    _S1 = vec4(gl_BaryCoordNV, float(0));
+    return;
+}

--- a/tests/cross-compile/barycentrics.slang.glsl
+++ b/tests/cross-compile/barycentrics.slang.glsl
@@ -1,12 +1,12 @@
 #version 450
 
-#extension GL_NV_fragment_shader_barycentric : enable
+#extension GL_EXT_fragment_shader_barycentric : enable
 
 layout(location = 0)
 out vec4 _S1;
 
 void main()
 {
-    _S1 = vec4(gl_BaryCoordNV, float(0));
+    _S1 = vec4(gl_BaryCoordEXT, float(0));
     return;
 }

--- a/tests/pipeline/rasterization/get-attribute-at-vertex-nv.slang
+++ b/tests/pipeline/rasterization/get-attribute-at-vertex-nv.slang
@@ -1,0 +1,17 @@
+// get-attribute-at-vertex.slang
+
+// Basic test for `GetAttributeAtVertex` function
+
+//TEST:CROSS_COMPILE:-target dxil -capability GL_NV_fragment_shader_barycentric -entry main -stage fragment -profile sm_6_1
+//TEST:CROSS_COMPILE:-target spirv -capability GL_NV_fragment_shader_barycentric -entry main -stage fragment -profile glsl_450
+
+[shader("fragment")]
+void main(
+    pervertex float4 color : COLOR,
+    float3 bary : SV_Barycentrics,
+    out float4 result : SV_Target)
+{
+    result = bary.x * GetAttributeAtVertex(color, 0)
+           + bary.y * GetAttributeAtVertex(color, 1)
+           + bary.z * GetAttributeAtVertex(color, 2);
+}

--- a/tests/pipeline/rasterization/get-attribute-at-vertex-nv.slang.glsl
+++ b/tests/pipeline/rasterization/get-attribute-at-vertex-nv.slang.glsl
@@ -2,11 +2,11 @@
 //TEST_IGNORE_FILE:
 
 #version 450
-#extension GL_EXT_fragment_shader_barycentric : require
+#extension GL_NV_fragment_shader_barycentric : require
 layout(row_major) uniform;
 layout(row_major) buffer;
 
-pervertexEXT layout(location = 0)
+pervertexNV layout(location = 0)
 in vec4  _S1[3];
 
 layout(location = 0)
@@ -14,6 +14,6 @@ out vec4 _S2;
 
 void main()
 {
-    _S2 = gl_BaryCoordEXT.x * ((_S1)[(0U)]) + gl_BaryCoordEXT.y * ((_S1)[(1U)]) + gl_BaryCoordEXT.z * ((_S1)[(2U)]);
+    _S2 = gl_BaryCoordNV.x * ((_S1)[(0U)]) + gl_BaryCoordNV.y * ((_S1)[(1U)]) + gl_BaryCoordNV.z * ((_S1)[(2U)]);
     return;
 }

--- a/tests/pipeline/rasterization/get-attribute-at-vertex-nv.slang.hlsl
+++ b/tests/pipeline/rasterization/get-attribute-at-vertex-nv.slang.hlsl
@@ -1,0 +1,14 @@
+// get-attribute-at-vertex.slang.hlsl
+
+//TEST_IGNORE_FILE:
+
+[shader("pixel")]
+void main(
+    nointerpolation vector<float,4> color_0 : COLOR,
+    vector<float,3> bary_0 : SV_BARYCENTRICS,
+    out vector<float,4> result_0 : SV_TARGET)
+{
+    result_0 = bary_0.x * GetAttributeAtVertex(color_0, 0U)
+             + bary_0.y * GetAttributeAtVertex(color_0, 1U)
+             + bary_0.z * GetAttributeAtVertex(color_0, 2U);
+}


### PR DESCRIPTION
Hey,

this is my first PR in here. I tried to follow conventions and change as little as possible. 

Using the capability system, you can keep the old behavior, but the default is to use the vendor-neutral GL_EXT_fragment_shader_barycentric extension.

I had to forward the `CodeGenContext` to the GLSL emitting functions in glsl-legalize, which is why there are more changes than I necessarily wanted.

Let me know what you think!