### PR TITLE
Add support for emitting cuda kernel and host functions.

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -3078,6 +3078,12 @@ attribute_syntax [DllExport] : DllExportAttribute;
 __attributeTarget(FuncDecl)
 attribute_syntax [CudaDeviceExport] : CudaDeviceExportAttribute;
 
+__attributeTarget(FuncDecl)
+attribute_syntax [CudaHost] : CudaHostAttribute;
+
+__attributeTarget(FuncDecl)
+attribute_syntax [CudaKernel] : CudaKernelAttribute;
+
 __attributeTarget(InterfaceDecl)
 attribute_syntax [COM(guid: String)] : ComInterfaceAttribute;
 

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -477,6 +477,16 @@ class BackwardDifferentiateExpr: public DifferentiateExpr
     SLANG_AST_CLASS(BackwardDifferentiateExpr)
 };
 
+    /// An expression of the form `__dispatch_kernel(fn, threadGroupSize, dispatchSize)` to
+    /// dispatch a compute kernel from host.
+    ///
+class DispatchKernelExpr : public HigherOrderInvokeExpr
+{
+    SLANG_AST_CLASS(DispatchKernelExpr)
+    Expr* threadGroupSize;
+    Expr* dispatchSize;
+};
+
     /// An express to mark its inner expression as an intended non-differential call.
 class TreatAsDifferentiableExpr : public Expr
 {

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -1068,6 +1068,16 @@ class CudaDeviceExportAttribute : public Attribute
     SLANG_AST_CLASS(CudaDeviceExportAttribute)
 };
 
+class CudaKernelAttribute : public Attribute
+{
+    SLANG_AST_CLASS(CudaKernelAttribute)
+};
+
+class CudaHostAttribute : public Attribute
+{
+    SLANG_AST_CLASS(CudaHostAttribute)
+};
+
 class DerivativeMemberAttribute : public Attribute
 {
     SLANG_AST_CLASS(DerivativeMemberAttribute)

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1953,6 +1953,7 @@ namespace Slang
         Expr* visitForwardDifferentiateExpr(ForwardDifferentiateExpr* expr);
         Expr* visitBackwardDifferentiateExpr(BackwardDifferentiateExpr* expr);
         Expr* visitPrimalSubstituteExpr(PrimalSubstituteExpr* expr);
+        Expr* visitDispatchKernelExpr(DispatchKernelExpr* expr);
 
         Expr* visitTreatAsDifferentiableExpr(TreatAsDifferentiableExpr* expr);
 

--- a/source/slang/slang-emit-cpp.h
+++ b/source/slang/slang-emit-cpp.h
@@ -105,7 +105,7 @@ protected:
 
         /// Maybe emits 'export' (such that visible outside binary/dll) and `extern "C"` naming
     void _getExportStyle(IRInst* inst, bool& outIsExport, bool& outIsExternC);
-    void _maybeEmitExportLike(IRInst* inst);
+    virtual void _maybeEmitExportLike(IRInst* inst);
 
     static bool _isVariable(IROp op);
 

--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -225,7 +225,13 @@ void CUDASourceEmitter::emitFunctionPreambleImpl(IRInst* inst)
 {
     if (!inst)
         return;
-    if (inst->findDecoration<IREntryPointDecoration>() || inst->findDecoration<IRCudaKernelDecoration>())
+    if (inst->findDecoration<IREntryPointDecoration>())
+    {
+        m_writer->emit("extern \"C\" __global__ ");
+        return;
+    }
+
+    if (inst->findDecoration<IRCudaKernelDecoration>())
     {
         m_writer->emit("__global__ ");
     }

--- a/source/slang/slang-emit-cuda.h
+++ b/source/slang/slang-emit-cuda.h
@@ -79,6 +79,8 @@ protected:
     virtual void emitVarDecorationsImpl(IRInst* varDecl) SLANG_OVERRIDE;
     virtual void emitMatrixLayoutModifiersImpl(IRVarLayout* layout) SLANG_OVERRIDE;
     virtual void emitFunctionPreambleImpl(IRInst* inst) SLANG_OVERRIDE;
+    virtual void _maybeEmitExportLike(IRInst* inst) SLANG_OVERRIDE { SLANG_UNUSED(inst); }
+
     virtual String generateEntryPointNameImpl(IREntryPointDecoration* entryPointDecor) SLANG_OVERRIDE;
 
     virtual void emitGlobalRTTISymbolPrefix() SLANG_OVERRIDE;

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -667,6 +667,9 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
         /// An `[entryPoint]` decoration marks a function that represents a shader entry point
     INST(EntryPointDecoration,              entryPoint,             2, 0)
 
+    INST(CudaKernelDecoration,              CudaKernel,             0, 0)
+    INST(CudaHostDecoration,                CudaHost,               0, 0)
+
         /// Used to mark parameters that are moved from entry point parameters to global params as coming from the entry point.
     INST(EntryPointParamDecoration,         entryPointParam,        0, 0)
 
@@ -903,6 +906,8 @@ INST(BackwardDifferentiatePropagate,         BackwardDifferentiatePropagate,  1,
 INST(BackwardDifferentiate, BackwardDifferentiate, 1, 0)
 
 INST(PrimalSubstitute, PrimalSubstitute, 1, 0)
+
+INST(DispatchKernel, DispatchKernel, 3, 0)
 
 // Converts other resources (such as ByteAddressBuffer) to the equivalent StructuredBuffer
 INST(GetEquivalentStructuredBuffer,     getEquivalentStructuredBuffer, 1, 0)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -421,6 +421,9 @@ struct IREntryPointDecoration : IRDecoration
     IRStringLit* getModuleName() { return cast<IRStringLit>(getOperand(2)); }
 };
 
+IR_SIMPLE_DECORATION(CudaHostDecoration)
+IR_SIMPLE_DECORATION(CudaKernelDecoration)
+
 struct IRGeometryInputPrimitiveTypeDecoration: IRDecoration
 {
     IR_PARENT_ISA(GeometryInputPrimitiveTypeDecoration)
@@ -913,11 +916,24 @@ struct IRPrimalSubstitute : IRInst
     {
         kOp = kIROp_PrimalSubstitute
     };
-    // The base function for the call.
-    IRUse base;
     IRInst* getBaseFn() { return getOperand(0); }
 
     IR_LEAF_ISA(PrimalSubstitute)
+};
+
+struct IRDispatchKernel : IRInst
+{
+    enum
+    {
+        kOp = kIROp_DispatchKernel
+    };
+    IRInst* getBaseFn() { return getOperand(0); }
+    IRInst* getThreadGroupSize() { return getOperand(1); }
+    IRInst* getDispatchSize() { return getOperand(2); }
+    UInt getArgCount() { return getOperandCount() - 3; }
+    IRInst* getArg(UInt i) { return getOperand(3 + i); }
+
+    IR_LEAF_ISA(DispatchKernel)
 };
 
 // Dictionary item mapping a type with a corresponding 
@@ -2880,6 +2896,7 @@ public:
     IRInst* emitBackwardDifferentiatePrimalInst(IRType* type, IRInst* baseFn);
     IRInst* emitBackwardDifferentiatePropagateInst(IRType* type, IRInst* baseFn);
     IRInst* emitPrimalSubstituteInst(IRType* type, IRInst* baseFn);
+    IRInst* emitDispatchKernelInst(IRType* type, IRInst* baseFn, IRInst* threadGroupSize, IRInst* dispatchSize, Int argCount, IRInst* const* inArgs);
 
     IRInst* emitMakeDifferentialPair(IRType* type, IRInst* primal, IRInst* differential);
     IRInst* emitMakeDifferentialPairUserCode(IRType* type, IRInst* primal, IRInst* differential);
@@ -3771,6 +3788,16 @@ public:
     void addCudaDeviceExportDecoration(IRInst* value, UnownedStringSlice const& functionName)
     {
         addDecoration(value, kIROp_CudaDeviceExportDecoration, getStringValue(functionName));
+    }
+
+    void addCudaHostDecoration(IRInst* value)
+    {
+        addDecoration(value, kIROp_CudaHostDecoration);
+    }
+
+    void addCudaKernelDecoration(IRInst* value)
+    {
+        addDecoration(value, kIROp_CudaKernelDecoration);
     }
 
     void addEntryPointDecoration(IRInst* value, Profile profile, UnownedStringSlice const& name, UnownedStringSlice const& moduleName)

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3159,6 +3159,20 @@ namespace Slang
         return inst;
     }
 
+    IRInst* IRBuilder::emitDispatchKernelInst(IRType* type, IRInst* baseFn, IRInst* threadGroupSize, IRInst* dispatchSize, Int argCount, IRInst* const* inArgs)
+    {
+        List<IRInst*> args = {baseFn, threadGroupSize, dispatchSize};
+        args.addRange(inArgs, (Index)argCount);
+        auto inst = createInst<IRDispatchKernel>(
+            this,
+            kIROp_DispatchKernel,
+            type,
+            (Int)args.getCount(),
+            args.getBuffer());
+        addInst(inst);
+        return inst;
+    }
+
     IRInst* IRBuilder::emitBackwardDifferentiatePrimalInst(IRType* type, IRInst* baseFn)
     {
         auto inst = createInst<IRBackwardDifferentiatePrimal>(

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -643,8 +643,29 @@ LoweredValInfo emitCallToVal(
         switch (tryEnv.clauseType)
         {
         case TryClauseType::None:
-            return LoweredValInfo::simple(
-                builder->emitCallInst(type, getSimpleVal(context, funcVal), argCount, args));
+        {
+            auto callee = getSimpleVal(context, funcVal);
+            if (auto dispatchKernel = as<IRDispatchKernel>(callee))
+            {
+                // If callee is a dispatch kernel expr, don't emit call(dispatchKernel, ...), instead
+                // emit a dispatchKernel(high_order_args, actual_args).
+                auto result = LoweredValInfo::simple(builder->emitDispatchKernelInst(
+                    type,
+                    dispatchKernel->getBaseFn(),
+                    dispatchKernel->getThreadGroupSize(),
+                    dispatchKernel->getDispatchSize(),
+                    argCount,
+                    args));
+                SLANG_ASSERT(!dispatchKernel->hasUses());
+                dispatchKernel->removeAndDeallocate();
+                return result;
+            }
+            else
+            {
+                return LoweredValInfo::simple(
+                    builder->emitCallInst(type, getSimpleVal(context, funcVal), argCount, args));
+            }
+        }
 
         case TryClauseType::Standard:
             {
@@ -1159,6 +1180,14 @@ static void addLinkageDecoration(
     {
         builder->addCudaDeviceExportDecoration(inst, decl->getName()->text.getUnownedSlice());
         builder->addPublicDecoration(inst);
+    }
+    if (decl->findModifier<CudaHostAttribute>())
+    {
+        builder->addCudaHostDecoration(inst);
+    }
+    if (decl->findModifier<CudaKernelAttribute>())
+    {
+        builder->addCudaKernelDecoration(inst);
     }
 }
 
@@ -3202,6 +3231,23 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
             getBuilder()->emitBackwardDifferentiateInst(
                 lowerType(context, expr->type),
                 baseVal.val));
+    }
+
+    LoweredValInfo visitDispatchKernelExpr(DispatchKernelExpr* expr)
+    {
+        auto baseVal = lowerSubExpr(expr->baseFunction);
+        SLANG_ASSERT(baseVal.flavor == LoweredValInfo::Flavor::Simple);
+        auto threadSize = lowerRValueExpr(context, expr->threadGroupSize);
+        auto groupSize = lowerRValueExpr(context, expr->dispatchSize);
+        // Actual arguments to be filled in when we lower the actual call expr.
+        // This is handled in `emitCallToVal`.
+        return LoweredValInfo::simple(getBuilder()->emitDispatchKernelInst(
+            lowerType(context, expr->type),
+            baseVal.val,
+            getSimpleVal(context, threadSize),
+            getSimpleVal(context, groupSize),
+            0,
+            nullptr));
     }
 
     LoweredValInfo visitGetArrayLengthExpr(GetArrayLengthExpr* expr)

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -2189,10 +2189,12 @@ struct OptionsParser
         }
 
         // If we don't have any raw outputs but do have a raw target,
-        // and output type is callable, add an empty' rawOutput.
+        // add an empty' rawOutput for certain targets where the expected behavior is obvious.
         if (rawOutputs.getCount() == 0 &&
             rawTargets.getCount() == 1 &&
-            ArtifactDescUtil::makeDescForCompileTarget(asExternal(rawTargets[0].format)).kind == ArtifactKind::HostCallable)
+            (rawTargets[0].format == CodeGenTarget::HostCPPSource ||
+            rawTargets[0].format == CodeGenTarget::CUDASource ||
+            ArtifactDescUtil::makeDescForCompileTarget(asExternal(rawTargets[0].format)).kind == ArtifactKind::HostCallable))
         {
             RawOutput rawOutput;
             rawOutput.impliedFormat = rawTargets[0].format;

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -2158,6 +2158,27 @@ namespace Slang
         return parseBackwardDifferentiate(parser);
     }
 
+    static Expr* parseDispatchKernel(Parser* parser)
+    {
+        DispatchKernelExpr* dispatchExpr = parser->astBuilder->create<DispatchKernelExpr>();
+
+        parser->ReadToken(TokenType::LParent);
+
+        dispatchExpr->baseFunction = parser->ParseArgExpr();
+        parser->ReadToken(TokenType::Comma);
+        dispatchExpr->threadGroupSize = parser->ParseArgExpr();
+        parser->ReadToken(TokenType::Comma);
+        dispatchExpr->dispatchSize = parser->ParseArgExpr();
+        parser->ReadToken(TokenType::RParent);
+
+        return dispatchExpr;
+    }
+
+    static NodeBase* parseDispatchKernel(Parser* parser, void* /* unused */)
+    {
+        return parseDispatchKernel(parser);
+    }
+
         /// Parse a `This` type expression
     static Expr* parseThisTypeExpr(Parser* parser)
     {
@@ -6721,7 +6742,8 @@ namespace Slang
         _makeParseExpr("no_diff", parseTreatAsDifferentiableExpr),
         _makeParseExpr("__TaggedUnion", parseTaggedUnionType),
         _makeParseExpr("__fwd_diff", parseForwardDifferentiate),
-        _makeParseExpr("__bwd_diff", parseBackwardDifferentiate)
+        _makeParseExpr("__bwd_diff", parseBackwardDifferentiate),
+        _makeParseExpr("__dispatch_kernel", parseDispatchKernel)
     };
 
     ConstArrayView<SyntaxParseInfo> getSyntaxParseInfos()

--- a/tests/autodiff/cuda-kernel-export.slang
+++ b/tests/autodiff/cuda-kernel-export.slang
@@ -1,4 +1,4 @@
-//DISABLED_TEST:SIMPLE: -target cuda -line-directive-mode none
+//DISABLE_TEST:SIMPLE: -target cuda -line-directive-mode none
 
 // Verify that we can output a cuda device function with [CudaDeviceExport].
 // Disabled until we have FileCheck.
@@ -26,4 +26,16 @@ float f(MixedType m)
 void diffF(inout DifferentialPair<MixedType> m, float dout)
 {
     __bwd_diff(f)(m, dout);
+}
+
+[CudaKernel]
+void myKernel(float* inValues, float* outValues)
+{
+    outValues[0] = sin(inValues[0]);
+}
+
+[CudaHost]
+public __extern_cpp void runCompute(float *inValues, float *outValues, uint3 dispathcSize)
+{
+    __dispatch_kernel(myKernel, uint3(128, 1, 1), dispathcSize)(inValues, outValues);
 }


### PR DESCRIPTION
This change adds `[CudaHost]` and `[CudaKernel]` attributes for users to define cuda host and kernel functions.

Also adds a `__dispatch_kernel(func, thread_group_size, thread_count)(...)` syntax for dispatching kernels.