### PR TITLE
[TreatAsDifferentiable] functions.

### DIFF
--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -998,14 +998,6 @@ class ForceInlineAttribute : public Attribute
 };
 
 
-// A `[TreatAsDifferentiableAttribute]` attribute indicates that a function or an interface
-// should be treated as differentiable in IR validation step.
-//
-class TreatAsDifferentiableAttribute : public Attribute
-{
-    SLANG_AST_CLASS(TreatAsDifferentiableAttribute)
-};
-
     /// An attribute that marks a type declaration as either allowing or
     /// disallowing the type to be inherited from in other modules.
 class InheritanceControlAttribute : public Attribute { SLANG_AST_CLASS(InheritanceControlAttribute) };
@@ -1106,6 +1098,14 @@ class RequiresNVAPIAttribute : public Attribute
 class AlwaysFoldIntoUseSiteAttribute :public Attribute
 {
     SLANG_AST_CLASS(AlwaysFoldIntoUseSiteAttribute)
+};
+
+// A `[TreatAsDifferentiableAttribute]` attribute indicates that a function or an interface
+// should be treated as differentiable in IR validation step.
+//
+class TreatAsDifferentiableAttribute : public DifferentiableAttribute
+{
+    SLANG_AST_CLASS(TreatAsDifferentiableAttribute)
 };
 
     /// The `[ForwardDifferentiable]` attribute indicates that a function can be forward-differentiated.

--- a/source/slang/slang-ir-autodiff-fwd.h
+++ b/source/slang/slang-ir-autodiff-fwd.h
@@ -88,6 +88,8 @@ struct ForwardDiffTranscriber : AutoDiffTranscriberBase
 
     virtual IRFuncType* differentiateFunctionType(IRBuilder* builder, IRInst* func, IRFuncType* funcType) override;
 
+    void generateTrivialFwdDiffFunc(IRFunc* primalFunc, IRFunc* diffFunc);
+
     // Transcribe a function definition.
     InstPair transcribeFunc(IRBuilder* inBuilder, IRFunc* primalFunc, IRFunc* diffFunc);
 

--- a/source/slang/slang-ir-autodiff-rev.cpp
+++ b/source/slang/slang-ir-autodiff-rev.cpp
@@ -295,7 +295,8 @@ namespace Slang
     // Create an empty func to represent the transcribed func of `origFunc`.
     InstPair BackwardDiffTranscriberBase::transcribeFuncHeaderImpl(IRBuilder* inBuilder, IRFunc* origFunc)
     {
-        if (!isBackwardDifferentiableFunc(origFunc))
+        if (!isBackwardDifferentiableFunc(origFunc) &&
+            !origFunc->findDecoration<IRTreatAsDifferentiableDecoration>())
             return InstPair(nullptr, nullptr);
 
         IRBuilder builder = *inBuilder;

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -8502,6 +8502,10 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             {
                 getBuilder()->addBackwardDifferentiableDecoration(irFunc);
             }
+            else if (as<TreatAsDifferentiableAttribute>(modifier))
+            {
+                getBuilder()->addDecoration(irFunc, kIROp_TreatAsDifferentiableDecoration);
+            }
         }
         // For convenience, ensure that any additional global
         // values that were emitted while outputting the function

--- a/tests/autodiff/treat-as-differentiable.slang
+++ b/tests/autodiff/treat-as-differentiable.slang
@@ -1,0 +1,37 @@
+// Tests automatic synthesis of Differential type and method requirements.
+
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+interface IFoo
+{
+    [BackwardDifferentiable]
+    float f(float v);
+}
+
+struct B : IFoo
+{
+    [TreatAsDifferentiable]
+    float f(float v)
+    {
+        return v * v;
+    }
+}
+
+[BackwardDifferentiable]
+float use(IFoo o, float x)
+{
+    return o.f(x);
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    B b;
+    var p = diffPair(1.0);
+    __bwd_diff(use)(b, p, 1.0);
+    outputBuffer[0] = p.d;
+}

--- a/tests/autodiff/treat-as-differentiable.slang.expected.txt
+++ b/tests/autodiff/treat-as-differentiable.slang.expected.txt
@@ -1,0 +1,2 @@
+type: float
+0.0


### PR DESCRIPTION
This changes adds compiler support for using `[TreatAsDifferentiable]` decoration on a function to make it being treated as backward differentiable by the compiler, and causes the compiler to generate a trivial forward and backward derivative function that always return 0.