### PR TITLE
Don't touch output file if content did not change.

### DIFF
--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -993,6 +993,17 @@ namespace Slang
         return SLANG_OK;
     }
 
+    SlangResult File::writeAllTextIfChanged(const String& fileName, UnownedStringSlice text)
+    {
+        String existingContent;
+        auto result = File::readAllText(fileName, existingContent);
+        if (SLANG_FAILED(result) || existingContent != text)
+        {
+            return File::writeNativeText(fileName, text.begin(), text.getLength());
+        }
+        return SLANG_OK;
+    }
+
     /* static */SlangResult File::writeNativeText(const String& path, const void* data, size_t size)
     {
         FILE* file = fopen(path.getBuffer(), "w");

--- a/source/core/slang-io.h
+++ b/source/core/slang-io.h
@@ -21,6 +21,8 @@ namespace Slang
 
         static SlangResult writeAllText(const String& fileName, const String& text);
 
+        static SlangResult writeAllTextIfChanged(const String& fileName, UnownedStringSlice text);
+
             /// Write as text in native form for the target (so typically may change line endings )
         static SlangResult writeNativeText(const String& filename, const void* data, size_t size);
 

--- a/source/slang/slang-artifact-output-util.cpp
+++ b/source/slang/slang-artifact-output-util.cpp
@@ -176,7 +176,7 @@ static SlangResult _requireBlob(IArtifact* artifact, DiagnosticSink* sink, ComPt
 {
     if (ArtifactDescUtil::isText(desc))
     {
-        return File::writeNativeText(path, data, size);
+        return File::writeAllTextIfChanged(path, UnownedStringSlice((const char*)data, size));
     }
     else
     {

--- a/tools/slang-lookup-generator/lookup-generator-main.cpp
+++ b/tools/slang-lookup-generator/lookup-generator-main.cpp
@@ -210,13 +210,8 @@ void writeHashFile(
     const List<String> includes,
     const HashParams&  hashParams)
 {
-    FILE* f = nullptr;
-    fopen_s(&f, outCppPath, "wb");
-    if (!f)
-    {
-        return;
-    }
-    FileWriter   writer(f, WriterFlags(0));
+    StringBuilder sb;
+    StringWriter writer(&sb, WriterFlags(0));
     WriterHelper w(&writer);
 
     w.print("// Hash function for %s\n", valueType);
@@ -299,6 +294,8 @@ void writeHashFile(
     w.print("\n");
 
     w.print("}\n");
+
+    File::writeAllTextIfChanged(outCppPath, sb.getUnownedSlice());
 }
 
 int main(int argc, const char* const* argv)


### PR DESCRIPTION
This change makes slangc tool and lookup-generator tool to not write the output file if the content of it does not change.
This avoid unnecessary rebuilds and trivial git diffs from showing up.