### PR TITLE
Small fixes and cleanups on CUDA/CPP codegen.

### DIFF
--- a/source/slang/diff.meta.slang
+++ b/source/slang/diff.meta.slang
@@ -31,6 +31,7 @@ __intrinsic_type($(kIROp_TensorViewType))
 struct TensorView
 {
     __target_intrinsic(cuda, "$0.data_ptr<$G0>()")
+    [__readNone]
     Ptr<T> data_ptr();
 
     __implicit_conversion($(kConversionCost_ImplicitDereference))
@@ -38,14 +39,19 @@ struct TensorView
     __init(TorchTensor<T> t);
 
     __target_intrinsic(cuda, "$0.load<$G0>($1)")
+    [__readNone]
     T load(uint x);
     __target_intrinsic(cuda, "$0.load<$G0>($1, $2)")
+    [__readNone]
     T load(uint x, uint y);
     __target_intrinsic(cuda, "$0.load<$G0>($1, $2, $3)")
+    [__readNone]
     T load(uint x, uint y, uint z);
     __target_intrinsic(cuda, "$0.load<$G0>($1, $2, $3, $4)")
+    [__readNone]
     T load(uint x, uint y, uint z, uint w);
     __target_intrinsic(cuda, "$0.load<$G0>($1, $2, $3, $4, $5)")
+    [__readNone]
     T load(uint i0, uint i1, uint i2, uint i3, uint i4);
 
     __target_intrinsic(cuda, "$0.store<$G0>($1, $2)")
@@ -60,12 +66,15 @@ struct TensorView
     void store(uint i0, uint i1, uint i2, uint i3, uint i4, T val);
 
     __target_intrinsic(cuda, "$0.dimensionCount")
+    [__readNone]
     uint dims();
 
     __target_intrinsic(cuda, "$0.sizes[$1]")
+    [__readNone]
     uint size(uint i);
 
     __target_intrinsic(cuda, "$0.strides[$1]")
+    [__readNone]
     uint stride(uint i);
 }
 
@@ -78,18 +87,22 @@ struct TorchTensor
 
     __target_intrinsic(cuda, "$0.dims()")
     __target_intrinsic(cpp, "$0.dims()")
+    [__readNone]
     uint dims();
 
     __target_intrinsic(cuda, "$0.size($1)")
     __target_intrinsic(cpp, "$0.size($1)")
+    [__readNone]
     uint size(uint i);
 
     __target_intrinsic(cuda, "$0.stride($1)")
     __target_intrinsic(cpp, "$0.stride($1)")
+    [__readNone]
     uint stride(uint i);
 
     __target_intrinsic(cuda, "$0.data_ptr<$G0>()")
     __target_intrinsic(cpp, "$0.data_ptr<$G0>()")
+    [__readNone]
     Ptr<T> data_ptr();
 
     __intrinsic_op($(kIROp_AllocateTorchTensor))

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -6837,10 +6837,13 @@ void debugBreak();
 
 
 __target_intrinsic(cuda, "(threadIdx)")
+[__readNone]
 uint3 cudaThreadIdx();
 
 __target_intrinsic(cuda, "(blockIdx)")
+[__readNone]
 uint3 cudaBlockIdx();
 
 __target_intrinsic(cuda, "(blockDim)")
+[__readNone]
 uint3 cudaBlockDim();

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -2407,6 +2407,17 @@ void CLikeSourceEmitter::_emitInst(IRInst* inst)
         {
             auto type = inst->getDataType();
             emitType(type, getName(inst));
+
+            // On targets that support empty initializers, we will emit it.
+            switch (this->getTarget())
+            {
+            case CodeGenTarget::CPPSource:
+            case CodeGenTarget::HostCPPSource:
+            case CodeGenTarget::PyTorchCppBinding:
+            case CodeGenTarget::CUDASource:
+                m_writer->emit(" = {}");
+                break;
+            }
             m_writer->emit(";\n");
         }
         break;

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -475,7 +475,6 @@ Result linkAndOptimizeIR(
 
     // We don't need the legalize pass for C/C++ based types
     if(options.shouldLegalizeExistentialAndResourceTypes )
-//    if (!(sourceLanguage == SourceLanguage::CPP || sourceStyle == SourceLanguage::C))
     {
         // The Slang language allows interfaces to be used like
         // ordinary types (including placing them in constant
@@ -533,6 +532,14 @@ Result linkAndOptimizeIR(
         dumpIRIfEnabled(codeGenContext, irModule, "LEGALIZED");
     #endif
         validateIRModuleIfEnabled(codeGenContext, irModule);
+    }
+    else
+    {
+        // On CPU/CUDA targets, we simply elminate any empty types.
+        legalizeEmptyTypes(
+            irModule,
+            sink);
+        eliminateDeadCode(irModule);
     }
 
     // Once specialization and type legalization have been performed,

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -535,11 +535,17 @@ Result linkAndOptimizeIR(
     }
     else
     {
+#if 0
         // On CPU/CUDA targets, we simply elminate any empty types.
+        // TODO: disable for now, since the CPU compute shader
+        // trampoline is still hard coded to assume there are
+        // entrypoint and global parameters. renable when
+        // we fix that logic.
         legalizeEmptyTypes(
             irModule,
             sink);
         eliminateDeadCode(irModule);
+#endif
     }
 
     // Once specialization and type legalization have been performed,

--- a/source/slang/slang-ir-cleanup-void.cpp
+++ b/source/slang/slang-ir-cleanup-void.cpp
@@ -139,6 +139,9 @@ namespace Slang
             case kIROp_GetTupleElement:
             case kIROp_GetResultError:
             case kIROp_GetResultValue:
+            case kIROp_Call:
+            case kIROp_UpdateElement:
+            case kIROp_GetTargetTupleElement:
                 if (inst->getDataType()->getOp() == kIROp_VoidType)
                 {
                     IRBuilder builder(module);

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -3766,6 +3766,23 @@ struct IRExistentialTypeLegalizationContext : IRTypeLegalizationContext
     }
 };
 
+struct IREmptyTypeLegalizationContext : IRTypeLegalizationContext
+{
+    IREmptyTypeLegalizationContext(IRModule* module)
+        : IRTypeLegalizationContext(module)
+    {}
+
+    bool isSpecialType(IRType*) override
+    {
+        return false;
+    }
+
+    LegalType createLegalUniformBufferType(IROp, LegalType) override
+    {
+        return LegalType();
+    }
+};
+
 // The main entry points that are used when transforming IR code
 // to get it ready for lower-level codegen are then simple
 // wrappers around `legalizeTypes()` that pick an appropriately
@@ -3789,6 +3806,14 @@ void legalizeExistentialTypeLayout(
     SLANG_UNUSED(sink);
 
     IRExistentialTypeLegalizationContext context(module);
+    legalizeTypes(&context);
+}
+
+void legalizeEmptyTypes(IRModule* module, DiagnosticSink* sink)
+{
+    SLANG_UNUSED(sink);
+
+    IREmptyTypeLegalizationContext context(module);
     legalizeTypes(&context);
 }
 

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -7191,6 +7191,11 @@ namespace Slang
         case kIROp_Reinterpret:
         case kIROp_GetNativePtr:
         case kIROp_BackwardDiffIntermediateContextType:
+        case kIROp_MakeTargetTuple:
+        case kIROp_GetTargetTupleElement:
+        case kIROp_TorchGetCudaStream:
+        case kIROp_MakeTensorView:
+        case kIROp_TorchTensorGetView:
             return false;
 
         case kIROp_ForwardDifferentiate:

--- a/source/slang/slang-legalize-types.h
+++ b/source/slang/slang-legalize-types.h
@@ -695,6 +695,10 @@ void legalizeResourceTypes(
     IRModule*       module,
     DiagnosticSink* sink);
 
+void legalizeEmptyTypes(
+    IRModule* module,
+    DiagnosticSink* sink);
+
 bool isResourceType(IRType* type);
 
 


### PR DESCRIPTION
- Add [__readNone] decorations to new intrinsics.
- [Disabled] Perform type legalization to get rid of empty types for Cpp and Cuda targets.
- Add `kIROp_Call` to void type clean up op-code whitelist, this prevents generation of invalid code from `return call(f)` where `f` returns `void`.
- Emit empty initializer list for `DefaultConstruct` on c++ and cuda.