### PR TITLE
Convert tensor types in `make_tensor_view`.

### DIFF
--- a/prelude/slang-torch-prelude.h
+++ b/prelude/slang-torch-prelude.h
@@ -68,11 +68,14 @@ struct CudaTaskMemoryAllocator
     }
 };
 
-TensorView make_tensor_view(CudaTaskMemoryAllocator* allocator, torch::Tensor val, const char* name)
+TensorView make_tensor_view(CudaTaskMemoryAllocator* allocator, torch::Tensor val, const char* name, torch::ScalarType targetScalarType)
 {
+    // Convert device and scalar types.
     if (!val.device().is_cuda())
         val = val.to(torch::kCUDA);
- 
+    if (val.dtype() != targetScalarType)
+        val = val.to(targetScalarType);
+
     TensorView res = {};
     res.dimensionCount = val.dim();
     res.strides = allocator->allocUIntArray(val.dim());


### PR DESCRIPTION
Automatically convert tensor types before calling into the cuda kernel.