### PR TITLE
Fix missing `f` suffix for float lits in CUDA backend.

### DIFF
--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -741,7 +741,7 @@ void CUDASourceEmitter::emitSimpleValueImpl(IRInst* inst)
             return;
         }
     }
-    CLikeSourceEmitter::emitSimpleValueImpl(inst);
+    Super::emitSimpleValueImpl(inst);
 }
 
 


### PR DESCRIPTION
This bug causes a performance issue due to computations are being done in double precision.