### PR TITLE
Combine lookupWitness lowering with specialization.

### DIFF
--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -411,6 +411,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClInclude Include="..\..\..\source\slang\slang-ir-lower-reinterpret.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-lower-result-type.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-lower-tuple-types.h" />
+    <ClInclude Include="..\..\..\source\slang\slang-ir-lower-witness-lookup.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-marshal-native-call.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-metadata.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-missing-return.h" />
@@ -602,6 +603,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClCompile Include="..\..\..\source\slang\slang-ir-lower-reinterpret.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-lower-result-type.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-lower-tuple-types.cpp" />
+    <ClCompile Include="..\..\..\source\slang\slang-ir-lower-witness-lookup.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-marshal-native-call.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-metadata.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-missing-return.cpp" />

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -321,6 +321,9 @@
     <ClInclude Include="..\..\..\source\slang\slang-ir-lower-tuple-types.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\slang\slang-ir-lower-witness-lookup.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-ir-marshal-native-call.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -888,6 +891,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-ir-lower-tuple-types.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\source\slang\slang-ir-lower-witness-lookup.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-ir-marshal-native-call.cpp">

--- a/source/slang/slang-ast-type.cpp
+++ b/source/slang/slang-ast-type.cpp
@@ -69,8 +69,8 @@ Type* Type::getCanonicalType()
         // TODO(tfoley): worry about thread safety here?
         auto canType = et->createCanonicalType();
         et->canonicalType = canType;
-
-        SLANG_ASSERT(et->canonicalType);
+        if (!et->canonicalType)
+            return getASTBuilder()->getErrorType();
     }
     return et->canonicalType;
 }
@@ -481,7 +481,9 @@ Type* NamedExpressionType::_createCanonicalTypeOverride()
 {
     if (!innerType)
         innerType = getType(m_astBuilder, declRef);
-    return innerType->getCanonicalType();
+    if (innerType)
+        return innerType->getCanonicalType();
+    return nullptr;
 }
 
 HashCode NamedExpressionType::_getHashCodeOverride()

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -374,7 +374,9 @@ Result linkAndOptimizeIR(
 
         dumpIRIfEnabled(codeGenContext, irModule, "BEFORE-SPECIALIZE");
         if (!codeGenContext->isSpecializationDisabled())
-            changed |= specializeModule(irModule);
+            changed |= specializeModule(irModule, codeGenContext->getSink());
+        if (codeGenContext->getSink()->getErrorCount() != 0)
+            return SLANG_FAIL;
         dumpIRIfEnabled(codeGenContext, irModule, "AFTER-SPECIALIZE");
 
         eliminateDeadCode(irModule);

--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -666,6 +666,7 @@ namespace Slang
         case kIROp_IntType:
         case kIROp_FloatType:
         case kIROp_UIntType:
+        case kIROp_BoolType:
             return alignUp(offset, 4) + 4;
         case kIROp_UInt64Type:
         case kIROp_Int64Type:
@@ -753,6 +754,21 @@ namespace Slang
             auto interfaceType = cast<IRInterfaceType>(type);
             auto size = SharedGenericsLoweringContext::getInterfaceAnyValueSize(interfaceType, interfaceType->sourceLoc);
             size += kRTTIHeaderSize;
+            return alignUp(offset, 4) + alignUp((SlangInt)size, 4);
+        }
+        case kIROp_AssociatedType:
+        {
+            auto associatedType = cast<IRAssociatedType>(type);
+            SlangInt maxSize = 0;
+            for (UInt i = 0; i < associatedType->getOperandCount(); i++)
+                maxSize = Math::Max(maxSize, _getAnyValueSizeRaw((IRType*)associatedType->getOperand(i), offset));
+            return maxSize;
+        }
+        case kIROp_ThisType:
+        {
+            auto thisType = cast<IRThisType>(type);
+            auto interfaceType = thisType->getConstraintType();
+            auto size = SharedGenericsLoweringContext::getInterfaceAnyValueSize(interfaceType, interfaceType->sourceLoc);
             return alignUp(offset, 4) + alignUp((SlangInt)size, 4);
         }
         case kIROp_ExtractExistentialType:

--- a/source/slang/slang-ir-autodiff-cfg-norm.cpp
+++ b/source/slang/slang-ir-autodiff-cfg-norm.cpp
@@ -410,6 +410,7 @@ struct CFGNormalizationPass
                 }
 
                 case kIROp_loop:
+                case kIROp_Switch:
                 {
                     auto breakBlock = normalizeBreakableRegion(terminator);
 

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -877,19 +877,6 @@ InstPair ForwardDiffTranscriber::transcribeConst(IRBuilder*, IRInst* origInst)
     return InstPair(nullptr, nullptr);
 }
 
-IRInst* ForwardDiffTranscriber::findInterfaceRequirement(IRInterfaceType* type, IRInst* key)
-{
-    for (UInt i = 0; i < type->getOperandCount(); i++)
-    {
-        if (auto req = as<IRInterfaceRequirementEntry>(type->getOperand(i)))
-        {
-            if (req->getRequirementKey() == key)
-                return req->getRequirementVal();
-        }
-    }
-    return nullptr;
-}
-
 InstPair ForwardDiffTranscriber::transcribeSpecialize(IRBuilder* builder, IRSpecialize* origSpecialize)
 {
     auto primalBase = findOrTranscribePrimalInst(builder, origSpecialize->getBase());

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -1797,6 +1797,7 @@ InstPair ForwardDiffTranscriber::transcribeInstImpl(IRBuilder* builder, IRInst* 
     case kIROp_CastIntToFloat:
     case kIROp_CastFloatToInt:
     case kIROp_DetachDerivative:
+    case kIROp_GetSequentialID:
         return trascribeNonDiffInst(builder, origInst);
 
         // A call to createDynamicObject<T>(arbitraryData) cannot provide a diff value,

--- a/source/slang/slang-ir-autodiff-fwd.h
+++ b/source/slang/slang-ir-autodiff-fwd.h
@@ -62,8 +62,6 @@ struct ForwardDiffTranscriber : AutoDiffTranscriberBase
 
     InstPair transcribeConst(IRBuilder* builder, IRInst* origInst);
 
-    IRInst* findInterfaceRequirement(IRInterfaceType* type, IRInst* key);
-
     InstPair transcribeSpecialize(IRBuilder* builder, IRSpecialize* origSpecialize);
 
     InstPair transcribeFieldExtract(IRBuilder* builder, IRInst* originalInst);

--- a/source/slang/slang-ir-autodiff-primal-hoist.cpp
+++ b/source/slang/slang-ir-autodiff-primal-hoist.cpp
@@ -771,6 +771,7 @@ static bool shouldStoreInst(IRInst* inst)
     case kIROp_ExtractExistentialType:
     case kIROp_ExtractExistentialWitnessTable:
     case kIROp_undefined:
+    case kIROp_GetSequentialID:
         return false;
     case kIROp_GetElement:
     case kIROp_FieldExtract:

--- a/source/slang/slang-ir-autodiff-transcriber-base.cpp
+++ b/source/slang/slang-ir-autodiff-transcriber-base.cpp
@@ -645,19 +645,6 @@ IRType* AutoDiffTranscriberBase::tryGetDiffPairType(IRBuilder* builder, IRType* 
     return nullptr;
 }
 
-IRInst* AutoDiffTranscriberBase::findInterfaceRequirement(IRInterfaceType* type, IRInst* key)
-{
-    for (UInt i = 0; i < type->getOperandCount(); i++)
-    {
-        if (auto req = as<IRInterfaceRequirementEntry>(type->getOperand(i)))
-        {
-            if (req->getRequirementKey() == key)
-                return req->getRequirementVal();
-        }
-    }
-    return nullptr;
-}
-
 InstPair AutoDiffTranscriberBase::transcribeParam(IRBuilder* builder, IRParam* origParam)
 {
     auto primalDataType = findOrTranscribePrimalInst(builder, origParam->getDataType());

--- a/source/slang/slang-ir-autodiff-transcriber-base.h
+++ b/source/slang/slang-ir-autodiff-transcriber-base.h
@@ -111,8 +111,6 @@ struct AutoDiffTranscriberBase
 
     IRType* tryGetDiffPairType(IRBuilder* builder, IRType* primalType);
 
-    IRInst* findInterfaceRequirement(IRInterfaceType* type, IRInst* key);
-
     IRInst* getDifferentialZeroOfType(IRBuilder* builder, IRType* primalType);
 
     InstPair trascribeNonDiffInst(IRBuilder* builder, IRInst* origInst);

--- a/source/slang/slang-ir-generics-lowering-context.cpp
+++ b/source/slang/slang-ir-generics-lowering-context.cpp
@@ -339,7 +339,7 @@ namespace Slang
         }
     }
 
-    List<IRWitnessTable*> SharedGenericsLoweringContext::getWitnessTablesFromInterfaceType(IRInst* interfaceType)
+    List<IRWitnessTable*> getWitnessTablesFromInterfaceType(IRModule* module, IRInst* interfaceType)
     {
         List<IRWitnessTable*> witnessTables;
         for (auto globalInst : module->getGlobalInsts())
@@ -352,6 +352,11 @@ namespace Slang
             }
         }
         return witnessTables;
+    }
+
+    List<IRWitnessTable*> SharedGenericsLoweringContext::getWitnessTablesFromInterfaceType(IRInst* interfaceType)
+    {
+        return Slang::getWitnessTablesFromInterfaceType(module, interfaceType);
     }
 
     IRIntegerValue SharedGenericsLoweringContext::getInterfaceAnyValueSize(IRInst* type, SourceLoc usageLoc)

--- a/source/slang/slang-ir-generics-lowering-context.h
+++ b/source/slang/slang-ir-generics-lowering-context.h
@@ -86,19 +86,11 @@ namespace Slang
         // Get a list of all witness tables whose conformance type is `interfaceType`.
         List<IRWitnessTable*> getWitnessTablesFromInterfaceType(IRInst* interfaceType);
 
-        IRInst* findWitnessTableEntry(IRWitnessTable* table, IRInst* key)
-        {
-            for (auto entry : table->getEntries())
-            {
-                if (entry->getRequirementKey() == key)
-                    return entry->getSatisfyingVal();
-            }
-            return nullptr;
-        }
-
-            /// Does the given `concreteType` fit within the any-value size deterined by `interfaceType`?
+        /// Does the given `concreteType` fit within the any-value size deterined by `interfaceType`?
         bool doesTypeFitInAnyValue(IRType* concreteType, IRInterfaceType* interfaceType, IRIntegerValue* outTypeSize = nullptr, IRIntegerValue* outLimit = nullptr);
     };
+
+    List<IRWitnessTable*> getWitnessTablesFromInterfaceType(IRModule* module, IRInst* interfaceType);
 
     bool isPolymorphicType(IRInst* typeInst);
 

--- a/source/slang/slang-ir-generics-lowering-context.h
+++ b/source/slang/slang-ir-generics-lowering-context.h
@@ -74,7 +74,7 @@ namespace Slang
         IRInst* maybeEmitRTTIObject(IRInst* typeInst);
 
         static IRIntegerValue getInterfaceAnyValueSize(IRInst* type, SourceLoc usageLoc);
-        IRType* lowerAssociatedType(IRBuilder* builder, IRInst* type);
+        static IRType* lowerAssociatedType(IRBuilder* builder, IRInst* type);
 
         IRType* lowerType(IRBuilder* builder, IRInst* paramType, const Dictionary<IRInst*, IRInst*>& typeMapping, IRType* concreteType);
 

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -740,7 +740,8 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     INST(AnyValueSizeDecoration, AnyValueSize, 1, 0)
     INST(SpecializeDecoration, SpecializeDecoration, 0, 0)
     INST(SequentialIDDecoration, SequentialIDDecoration, 1, 0)
-
+    INST(StaticRequirementDecoration, StaticRequirementDecoration, 0, 0)
+    INST(DispatchFuncDecoration, DispatchFuncDecoration, 1, 0)
     INST(TypeConstraintDecoration, TypeConstraintDecoration, 1, 0)
 
     

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -198,6 +198,14 @@ struct IRAnyValueSizeDecoration : IRDecoration
     }
 };
 
+struct IRDispatchFuncDecoration : IRDecoration
+{
+    enum { kOp = kIROp_DispatchFuncDecoration };
+    IR_LEAF_ISA(DispatchFuncDecoration)
+
+    IRInst* getFunc() { return getOperand(0); }
+};
+
 struct IRSpecializeDecoration : IRDecoration
 {
     enum { kOp = kIROp_SpecializeDecoration };
@@ -265,6 +273,7 @@ IR_SIMPLE_DECORATION(VulkanHitAttributesDecoration)
 /// to it.
 IR_SIMPLE_DECORATION(VulkanHitObjectAttributesDecoration)
 
+
 struct IRRequireGLSLVersionDecoration : IRDecoration
 {
     enum { kOp = kIROp_RequireGLSLVersionDecoration };
@@ -326,6 +335,7 @@ IR_SIMPLE_DECORATION(KeepAliveDecoration)
 IR_SIMPLE_DECORATION(RequiresNVAPIDecoration)
 IR_SIMPLE_DECORATION(NoInlineDecoration)
 IR_SIMPLE_DECORATION(AlwaysFoldIntoUseSiteDecoration)
+IR_SIMPLE_DECORATION(StaticRequirementDecoration)
 
 struct IRNVAPIMagicDecoration : IRDecoration
 {
@@ -3911,6 +3921,16 @@ public:
     void addAnyValueSizeDecoration(IRInst* inst, IRIntegerValue value)
     {
         addDecoration(inst, kIROp_AnyValueSizeDecoration, getIntValue(getIntType(), value));
+    }
+
+    void addDispatchFuncDecoration(IRInst* inst, IRInst* func)
+    {
+        addDecoration(inst, kIROp_DispatchFuncDecoration, func);
+    }
+
+    void addStaticRequirementDecoration(IRInst* inst)
+    {
+        addDecoration(inst, kIROp_StaticRequirementDecoration);
     }
 
     void addSpecializeDecoration(IRInst* inst)

--- a/source/slang/slang-ir-lower-generic-function.cpp
+++ b/source/slang/slang-ir-lower-generic-function.cpp
@@ -28,14 +28,18 @@ namespace Slang
             auto genericParent = as<IRGeneric>(genericValue);
             SLANG_ASSERT(genericParent);
             SLANG_ASSERT(genericParent->getDataType());
-            auto func = as<IRFunc>(findGenericReturnVal(genericParent));
+            auto genericRetVal = findGenericReturnVal(genericParent);
+            auto func = as<IRFunc>(genericRetVal);
             if (!func)
             {
                 // Nested generic functions are supposed to be flattened before entering
                 // this pass. The reason we are still seeing them must be that they are
                 // intrinsic functions. In this case we ignore the function.
-                SLANG_ASSERT(findInnerMostGenericReturnVal(genericParent)
-                                 ->findDecoration<IRTargetIntrinsicDecoration>() != nullptr);
+                if (as<IRGeneric>(genericRetVal))
+                {
+                    SLANG_ASSERT(findInnerMostGenericReturnVal(genericParent)
+                                     ->findDecoration<IRTargetIntrinsicDecoration>() != nullptr);
+                }
                 return genericValue;
             }
             SLANG_ASSERT(func);

--- a/source/slang/slang-ir-lower-witness-lookup.h
+++ b/source/slang/slang-ir-lower-witness-lookup.h
@@ -1,0 +1,16 @@
+// slang-ir-lower-witness-lookup.h
+#pragma once
+
+namespace Slang
+{
+    struct IRModule;
+    class DiagnosticSink;
+
+    /// Lower calls to a witness lookup into a call to a dispatch function.
+    /// For example, if we see call(witnessLookup(wt, key)), we will create a 
+    /// dispatch function that calls into different implementations based on witness table
+    /// ID. The dispatch function will be called instead of witnessLookup.
+    bool lowerWitnessLookup(IRModule* module, DiagnosticSink* sink);
+
+}
+

--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -848,7 +848,7 @@ struct PeepholeContext : InstPassBase
                     if (!intLitIndex)
                         return;
                     if (intLitIndex->getValue() < (Int)makeVector->getOperandCount())
-                        vals.add(makeVector->getOperand(intLitIndex->getValue()));
+                        vals.add(makeVector->getOperand((UInt)intLitIndex->getValue()));
                     else
                         return;
                 }

--- a/source/slang/slang-ir-specialize-dispatch.cpp
+++ b/source/slang/slang-ir-specialize-dispatch.cpp
@@ -3,6 +3,7 @@
 #include "slang-ir-generics-lowering-context.h"
 #include "slang-ir-insts.h"
 #include "slang-ir.h"
+#include "slang-ir-util.h"
 
 namespace Slang
 {
@@ -112,7 +113,7 @@ IRFunc* specializeDispatchFunction(SharedGenericsLoweringContext* sharedContext,
             builder->setInsertInto(defaultBlock);
         }
 
-        auto callee = sharedContext->findWitnessTableEntry(witnessTable, requirementKey);
+        auto callee = findWitnessTableEntry(witnessTable, requirementKey);
         SLANG_ASSERT(callee);
         auto specializedCallInst = builder->emitCallInst(callInst->getFullType(), callee, params);
         if (callInst->getDataType()->getOp() == kIROp_VoidType)

--- a/source/slang/slang-ir-specialize-dynamic-associatedtype-lookup.cpp
+++ b/source/slang/slang-ir-specialize-dynamic-associatedtype-lookup.cpp
@@ -75,7 +75,7 @@ struct AssociatedTypeLookupSpecializationContext
                 builder.setInsertInto(defaultBlock);
             }
 
-            auto resultWitnessTable = sharedContext->findWitnessTableEntry(witnessTable, key);
+            auto resultWitnessTable = findWitnessTableEntry(witnessTable, key);
             auto resultWitnessTableIDDecoration =
                 resultWitnessTable->findDecoration<IRSequentialIDDecoration>();
             SLANG_ASSERT(resultWitnessTableIDDecoration);

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -1329,7 +1329,6 @@ struct SpecializationContext
             IRInst* curInst = localWorkList.getLast();
 
             localWorkList.removeLast();
-            processedInsts.Remove(curInst);
 
             switch (curInst->getOp())
             {

--- a/source/slang/slang-ir-specialize.h
+++ b/source/slang/slang-ir-specialize.h
@@ -4,10 +4,12 @@
 namespace Slang
 {
 struct IRModule;
+class DiagnosticSink;
 
     /// Specialize generic and interface-based code to use concrete types.
 bool specializeModule(
-    IRModule*   module);
+    IRModule*   module,
+    DiagnosticSink* sink);
 
 void finalizeSpecialization(IRModule* module);
 

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -698,6 +698,29 @@ bool isPureFunctionalCall(IRCall* call)
     return false;
 }
 
+IRInst* findInterfaceRequirement(IRInterfaceType* type, IRInst* key)
+{
+    for (UInt i = 0; i < type->getOperandCount(); i++)
+    {
+        if (auto req = as<IRInterfaceRequirementEntry>(type->getOperand(i)))
+        {
+            if (req->getRequirementKey() == key)
+                return req->getRequirementVal();
+        }
+    }
+    return nullptr;
+}
+
+IRInst* findWitnessTableEntry(IRWitnessTable* table, IRInst* key)
+{
+    for (auto entry : table->getEntries())
+    {
+        if (entry->getRequirementKey() == key)
+            return entry->getSatisfyingVal();
+    }
+    return nullptr;
+}
+
 struct GenericChildrenMigrationContextImpl
 {
     IRCloneEnv cloneEnv;

--- a/source/slang/slang-ir-util.h
+++ b/source/slang/slang-ir-util.h
@@ -194,6 +194,10 @@ void sortBlocksInFunc(IRGlobalValueWithCode* func);
 
 // Remove all linkage decorations from func.
 void removeLinkageDecorations(IRGlobalValueWithCode* func);
+
+IRInst* findInterfaceRequirement(IRInterfaceType* type, IRInst* key);
+
+IRInst* findWitnessTableEntry(IRWitnessTable* table, IRInst* key);
 }
 
 #endif

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -7145,6 +7145,10 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                         entry->setRequirementVal(requirementVal);
                         break;
                     }
+                    if (requirementDecl->findModifier<HLSLStaticModifier>())
+                    {
+                        getBuilder()->addStaticRequirementDecoration(requirementKey);
+                    }
                 }
             }
             irInterface->setOperand(entryIndex, entry);
@@ -7807,6 +7811,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                     // to the newly construct generic value.
                     typeBuilder.setInsertBefore(parentGeneric);
                     auto typeGeneric = typeBuilder.emitGeneric();
+                    typeGeneric->setFullType(typeBuilder.getGenericKind());
                     typeBuilder.setInsertInto(typeGeneric);
                     typeBuilder.emitBlock();
                     

--- a/tests/diagnostics/no-type-conformance.slang.expected
+++ b/tests/diagnostics/no-type-conformance.slang.expected
@@ -1,8 +1,8 @@
 result code = -1
 standard error = {
-tests/diagnostics/no-type-conformance.slang(4): error 50100: No type conformances are found for interface 'IFoo'. Code generation for current target requires at least one implementation type present in the linkage.
-interface IFoo
-          ^~~~
+tests/diagnostics/no-type-conformance.slang(12): error 50100: No type conformances are found for interface 'IFoo'. Code generation for current target requires at least one implementation type present in the linkage.
+    obj.get();
+           ^
 }
 standard output = {
 }

--- a/tests/ir/dynamic-generic-method-specialize.slang
+++ b/tests/ir/dynamic-generic-method-specialize.slang
@@ -1,0 +1,48 @@
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -profile sm_5_0 -output-using-type
+
+// Test that we can specialize a generic method called through a dynamic interface.
+[anyValueSize(16)]
+interface IInterface
+{
+    float run<let N : int>(float arr[N]);
+}
+
+struct Add : IInterface
+{
+    float base;
+    float run<let N : int>(float arr[N])
+    {
+        float sum = base;
+        for (int i = 0; i < N; i++)
+            sum += arr[i];
+        return sum;
+    }
+}
+
+struct Mul : IInterface
+{
+    float base;
+
+    float run<let N : int>(float arr[N])
+    {
+        float sum = base;
+        for (int i = 0; i < N; i++)
+            sum *= arr[i];
+        return sum;
+    }
+}
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=gOutputBuffer
+RWStructuredBuffer<float> gOutputBuffer;
+
+//TEST_INPUT:type_conformance Add:IInterface=1
+//TEST_INPUT:type_conformance Mul:IInterface=2
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    var obj = createDynamicObject<IInterface>(1, 1.0); // Add.
+    float arr[3] = { 2, 3, 4 };
+    gOutputBuffer[0] = obj.run(arr);
+
+}

--- a/tests/ir/dynamic-generic-method-specialize.slang.expected.txt
+++ b/tests/ir/dynamic-generic-method-specialize.slang.expected.txt
@@ -1,0 +1,2 @@
+type: float
+10.0

--- a/tests/language-server/robustness-7.slang
+++ b/tests/language-server/robustness-7.slang
@@ -1,4 +1,5 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -profile sm_5_0 -output-using-type
+//TEST:LANG_SERVER:
+//HOVER:6,15
 
 // Test that we can specialize a generic method called through a dynamic interface.
 
@@ -23,30 +24,26 @@ interface IInterface
 struct Add : IInterface
 {
     float base;
-    typealias V = SimpleVal;
-    V run<let N : int>(float arr[N])
+    typealias V
+    float run<let N : int>(float arr[N])
     {
         float sum = base;
         for (int i = 0; i < N; i++)
             sum += arr[i];
-        V rs;
-        rs.val = sum;
-        return rs;
+        return sum;
     }
 }
 
 struct Mul : IInterface
 {
     float base;
-    typealias V = SimpleVal;
-    V run<let N : int>(float arr[N])
+
+    float run<let N : int>(float arr[N])
     {
         float sum = base;
         for (int i = 0; i < N; i++)
             sum *= arr[i];
-         V rs;
-        rs.val = sum;
-        return rs;
+        return sum;
     }
 }
 
@@ -61,5 +58,6 @@ void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
 {
     var obj = createDynamicObject<IInterface>(1, 1.0); // Add.
     float arr[3] = { 2, 3, 4 };
-    gOutputBuffer[0] = obj.run(arr).getVal();
+    gOutputBuffer[0] = obj.run(arr);
+
 }

--- a/tests/language-server/robustness-7.slang.expected.txt
+++ b/tests/language-server/robustness-7.slang.expected.txt
@@ -1,0 +1,12 @@
+--------
+range: 5,10 - 5,16
+content:
+```
+interface IValue
+```
+
+Test that we can specialize a generic method called through a dynamic interface.  
+
+{REDACTED}.slang(6)
+
+


### PR DESCRIPTION
Before this change, our compiler cannot specialize a generic interface method call if that call is through a dynamic interface.
For example, this code won't compile:
```
[anyValueSize(16)]
interface IInterface
{
    float run<let N : int>(float arr[N]);
}
struct Add : IInterface
{
    float base;
    float run<let N : int>(float arr[N])
    {
        float sum = base;
        for (int i = 0; i < N; i++)
            sum += arr[i];
        return sum;
    }
}
RWStructuredBuffer<float> gOutputBuffer;

//TEST_INPUT:type_conformance Add:IInterface=1

[numthreads(1, 1, 1)]
void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
{
    var obj = createDynamicObject<IInterface>(1, 1.0); // Add.
    float arr[3] = { 2, 3, 4 };
    gOutputBuffer[0] = obj.run(arr);
}
```

Because `obj.run` is called through a dynamic `obj`, the specialization pass cannot specialize the call. 
Therefore the entire call is handled by our generic lowering pass and the `N` parameter becomes a runtime parameter.
Since HLSL does not allow defining an array using a runtime value, the resulting HLSL is malformed.

In this change, we introduce a separate `lowerWitnessLookup` pass that is run in a loop with the specialization pass.
Whenever we see a `lookupWitnessMethod` that can't be specialized, we create a dispatch function and replace calls to the `lookupWitness` with  calls to the dispatch function. If the interface method is a generic, then the dispatch function will also be a generic, and the body of the dispatch function is a switch statement calling to all available implementation types' generic methods.
After this replacement, specialization pass can continue to specialize the dispatch function and propagate the generic arguments into the implementation methods.