### PR TITLE
Set sharedMem argument to 0 when launching cuda kernel.

### DIFF
--- a/prelude/slang-torch-prelude.h
+++ b/prelude/slang-torch-prelude.h
@@ -114,12 +114,4 @@ TensorView make_tensor_view(torch::Tensor val, const char* name, torch::ScalarTy
     return res;
 }
 
-size_t slangGetCudaKernelSharedMemSize(const void* func)
-{
-    cudaFuncAttributes attr = {};
-    cudaFuncGetAttributes(&attr, func);
-    AT_CUDA_CHECK(cudaGetLastError());
-    return attr.sharedSizeBytes;
-}
-
 #define SLANG_PRELUDE_EXPORT

--- a/source/slang/slang-emit-torch.cpp
+++ b/source/slang/slang-emit-torch.cpp
@@ -94,9 +94,7 @@ void TorchCppSourceEmitter::emitInstStmtImpl(IRInst* inst)
             m_writer->emit(", ");
 
             // shared mem
-            m_writer->emit("slangGetCudaKernelSharedMemSize((const void*)(");
-            emitOperand(inst->getOperand(0), getInfo(EmitOp::General));
-            m_writer->emit(")), ");
+            m_writer->emit("0, ");
 
             // stream
             m_writer->emit("((cudaStream_t)");

--- a/tools/gfx/cuda/cuda-command-queue.cpp
+++ b/tools/gfx/cuda/cuda-command-queue.cpp
@@ -93,12 +93,6 @@ void CommandQueueImpl::dispatchCompute(int x, int y, int z)
     UInt threadGroupSize[3];
     programLayout->getKernelThreadGroupSize(kernelId, threadGroupSize);
 
-    int sharedSizeInBytes;
-    cuFuncGetAttribute(
-        &sharedSizeInBytes,
-        CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES,
-        currentPipeline->shaderProgram->cudaKernel);
-
     // Copy global parameter data to the `SLANG_globalParams` symbol.
     {
         CUdeviceptr globalParamsSymbol = 0;
@@ -144,7 +138,7 @@ void CommandQueueImpl::dispatchCompute(int x, int y, int z)
         int(threadGroupSize[0]),
         int(threadGroupSize[1]),
         int(threadGroupSize[2]),
-        sharedSizeInBytes,
+        0,
         stream,
         nullptr,
         extraOptions);


### PR DESCRIPTION
We used to query the shared memory size used by the kernel and use it as the argument in `cudaLaunchKernel`.
This is not the intended use of the `sharedMem` argument. It is meant to allocate additional bytes in the shared memory for dynamic allocation in the kernel. If the kernel just define shared memory objects statically, no additional bytes is required and we should always pass 0.