### PR TITLE
Diagnose on using uninitialized `out` param.

### DIFF
--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -420,6 +420,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClInclude Include="..\..\..\source\slang\slang-ir-peephole.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-propagate-func-properties.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-pytorch-cpp-binding.h" />
+    <ClInclude Include="..\..\..\source\slang\slang-ir-reachability.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-redundancy-removal.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-remove-unused-generic-param.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-restructure-scoping.h" />
@@ -446,6 +447,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClInclude Include="..\..\..\source\slang\slang-ir-strip.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-synthesize-active-mask.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-union.h" />
+    <ClInclude Include="..\..\..\source\slang\slang-ir-use-uninitialized-out-param.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-util.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-validate.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-witness-table-wrapper.h" />
@@ -612,6 +614,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClCompile Include="..\..\..\source\slang\slang-ir-peephole.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-propagate-func-properties.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-pytorch-cpp-binding.cpp" />
+    <ClCompile Include="..\..\..\source\slang\slang-ir-reachability.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-redundancy-removal.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-remove-unused-generic-param.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-restructure-scoping.cpp" />
@@ -638,6 +641,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClCompile Include="..\..\..\source\slang\slang-ir-strip.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-synthesize-active-mask.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-union.cpp" />
+    <ClCompile Include="..\..\..\source\slang\slang-ir-use-uninitialized-out-param.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-util.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-validate.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-witness-table-wrapper.cpp" />

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -348,6 +348,9 @@
     <ClInclude Include="..\..\..\source\slang\slang-ir-pytorch-cpp-binding.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\slang\slang-ir-reachability.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-ir-redundancy-removal.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -424,6 +427,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-ir-union.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\source\slang\slang-ir-use-uninitialized-out-param.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-ir-util.h">
@@ -920,6 +926,9 @@
     <ClCompile Include="..\..\..\source\slang\slang-ir-pytorch-cpp-binding.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\source\slang\slang-ir-reachability.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-ir-redundancy-removal.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -996,6 +1005,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-ir-union.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\source\slang\slang-ir-use-uninitialized-out-param.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-ir-util.cpp">

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -593,6 +593,7 @@ DIAGNOSTIC(40020, Error, cannotUnrollLoop, "loop does not terminate within the l
 DIAGNOSTIC(41000, Warning, unreachableCode, "unreachable code detected")
 
 DIAGNOSTIC(41010, Warning, missingReturn, "control flow may reach end of non-'void' function")
+DIAGNOSTIC(41015, Error, usingUninitializedValue, "use of uninitialized value.")
 
 DIAGNOSTIC(41011, Error, typeDoesNotFitAnyValueSize, "type '$0' does not fit in the size required by its conforming interface.")
 DIAGNOSTIC(41012, Note, typeAndLimit, "sizeof($0) is $1, limit is $2")

--- a/source/slang/slang-ir-reachability.cpp
+++ b/source/slang/slang-ir-reachability.cpp
@@ -1,0 +1,39 @@
+#include "slang-ir-reachability.h"
+
+namespace Slang
+{
+// Computes whether block1 can reach block2.
+// A block is considered not reachable from itself unless there is a backedge in the CFG.
+
+bool ReachabilityContext::computeReachability(IRBlock* block1, IRBlock* block2)
+{
+    workList.clear();
+    reachableBlocks.Clear();
+    workList.add(block1);
+    for (Index i = 0; i < workList.getCount(); i++)
+    {
+        auto src = workList[i];
+        for (auto successor : src->getSuccessors())
+        {
+            if (successor == block2)
+                return true;
+            if (reachableBlocks.Add(successor))
+                workList.add(successor);
+        }
+    }
+    return false;
+}
+
+bool ReachabilityContext::isBlockReachable(IRBlock* from, IRBlock* to)
+{
+    BlockPair pair;
+    pair.first = from;
+    pair.second = to;
+    bool result = false;
+    if (reachabilityResults.TryGetValue(pair, result))
+        return result;
+    result = computeReachability(from, to);
+    reachabilityResults[pair] = result;
+    return result;
+}
+}

--- a/source/slang/slang-ir-reachability.h
+++ b/source/slang/slang-ir-reachability.h
@@ -1,0 +1,59 @@
+// slang-ir-reachability.h
+#pragma once
+
+#include "slang-ir.h"
+
+namespace Slang
+{
+
+// A context for computing and caching reachability between blocks on the CFG.
+struct ReachabilityContext
+{
+    struct BlockPair
+    {
+        IRBlock* first;
+        IRBlock* second;
+        HashCode getHashCode()
+        {
+            Hasher h;
+            h.hashValue(first);
+            h.hashValue(second);
+            return h.getResult();
+        }
+        bool operator == (const BlockPair& other)
+        {
+            return first == other.first && second == other.second;
+        }
+    };
+    Dictionary<BlockPair, bool> reachabilityResults;
+
+    List<IRBlock*> workList;
+    HashSet<IRBlock*> reachableBlocks;
+
+    // Computes whether block1 can reach block2.
+    // A block is considered not reachable from itself unless there is a backedge in the CFG.
+    bool computeReachability(IRBlock* block1, IRBlock* block2);
+
+    bool isBlockReachable(IRBlock* from, IRBlock* to);
+
+    bool isInstReachable(IRInst* inst1, IRInst* inst2)
+    {
+        if (isBlockReachable(as<IRBlock>(inst1->getParent()), as<IRBlock>(inst2->getParent())))
+            return true;
+
+        // If the parent blocks are not reachable, but inst1 and inst2 are in the same block,
+        // we test if inst2 appears after inst1.
+        if (inst1->getParent() == inst2->getParent())
+        {
+            for (auto inst = inst1->getNextInst(); inst; inst = inst->getNextInst())
+            {
+                if (inst == inst2)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+};
+
+}

--- a/source/slang/slang-ir-use-uninitialized-out-param.cpp
+++ b/source/slang/slang-ir-use-uninitialized-out-param.cpp
@@ -1,0 +1,113 @@
+#include "slang-ir-use-uninitialized-out-param.h"
+#include "slang-ir-util.h"
+#include "slang-ir-reachability.h"
+
+namespace Slang
+{
+    class DiagnosticSink;
+    struct IRModule;
+
+    struct StoreSite
+    {
+        IRInst* storeInst;
+        IRInst* address;
+    };
+
+    void checkForUsingUninitializedOutParams(IRFunc* func, DiagnosticSink* sink)
+    {
+        List<IRInst*> outParams;
+        auto firstBlock = func->getFirstBlock();
+        if (!firstBlock)
+            return;
+
+        ReachabilityContext reachability;
+
+        for (auto param : firstBlock->getParams())
+        {
+            if (!as<IROutType>(param->getFullType()))
+                continue;
+            List<IRInst*> addresses;
+            addresses.add(param);
+            List<StoreSite> stores;
+            // Collect all sub-addresses from the param.
+            for (Index i = 0; i < addresses.getCount(); i++)
+            {
+                auto addr = addresses[i];
+                for (auto use = addr->firstUse; use; use = use->nextUse)
+                {
+                    switch (use->getUser()->getOp())
+                    {
+                    case kIROp_GetElementPtr:
+                    case kIROp_FieldAddress:
+                        addresses.add(use->getUser());
+                        break;
+                    case kIROp_Store:
+                        // If we see a store of this address, add it to stores set.
+                        if (use == use->getUser()->getOperands())
+                            stores.add(StoreSite{ use->getUser(), addr });
+                        break;
+                    case kIROp_Call:
+                        // If we see a call using this address, treat it as a store.
+                        stores.add(StoreSite{ use->getUser(), addr });
+                        break;
+                    }
+                }
+            }
+            // Check all address loads.
+            List<IRLoad*> loads;
+            for (auto addr : addresses)
+            {
+                for (auto use = addr->firstUse; use; use = use->nextUse)
+                {
+                    if (auto load = as<IRLoad>(use->getUser()))
+                        loads.add(load);
+                }
+            }
+
+            for (auto store : stores)
+            {
+                // Remove insts from `loads` that is reachable from the store.
+                for (Index i = 0; i < loads.getCount();)
+                {
+                    auto load = loads[i];
+                    if (!canAddressesPotentiallyAlias(func, store.address, loads[i]->getPtr()))
+                        continue;
+                    if (reachability.isInstReachable(store.storeInst, load))
+                    {
+                        loads.fastRemoveAt(i);
+                    }
+                    else
+                    {
+                        i++;
+                    }
+                }
+            }
+            // If there are any loads left, it means they are using uninitialized out params.
+            for (auto load : loads)
+            {
+                sink->diagnose(load, Diagnostics::usingUninitializedValue);
+            }
+        }
+    }
+
+    void checkForUsingUninitializedOutParams(
+        IRModule* module,
+        DiagnosticSink* sink)
+    {
+        for (auto inst : module->getGlobalInsts())
+        {
+            if (auto func = as<IRFunc>(inst))
+            {
+                checkForUsingUninitializedOutParams(func, sink);
+            }
+            else if (auto generic = as<IRGeneric>(inst))
+            {
+                auto retVal = findGenericReturnVal(generic);
+                if (auto funcVal = as<IRFunc>(retVal))
+                {
+                    checkForUsingUninitializedOutParams(funcVal, sink);
+                }
+            }
+        }
+    }
+}

--- a/source/slang/slang-ir-use-uninitialized-out-param.h
+++ b/source/slang/slang-ir-use-uninitialized-out-param.h
@@ -1,0 +1,12 @@
+// slang-ir-use-uninitialized-out-param.h
+#pragma once
+
+namespace Slang
+{
+    class DiagnosticSink;
+    struct IRModule;
+
+    void checkForUsingUninitializedOutParams(
+        IRModule*       module,
+        DiagnosticSink* sink);
+}

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -26,6 +26,7 @@
 #include "slang-ir-clone.h"
 #include "slang-ir-lower-error-handling.h"
 #include "slang-ir-obfuscate-loc.h"
+#include "slang-ir-use-uninitialized-out-param.h"
 
 #include "slang-mangle.h"
 #include "slang-type-layout.h"
@@ -9607,6 +9608,9 @@ RefPtr<IRModule> generateIRForTranslationUnit(
 
     // TODO: give error messages if any `undefined` or
     // `unreachable` instructions remain.
+
+    // Check for using uninitialized out parameters.
+    checkForUsingUninitializedOutParams(module, compileRequest->getSink());
 
     checkForMissingReturns(module, compileRequest->getSink());
 

--- a/tests/diagnostics/uninitialized-out.slang
+++ b/tests/diagnostics/uninitialized-out.slang
@@ -1,0 +1,7 @@
+//DIAGNOSTIC_TEST:SIMPLE:
+
+float foo(out float3 v)
+{
+    float r = v.x + 1.0;
+    return r;
+}

--- a/tests/diagnostics/uninitialized-out.slang.expected
+++ b/tests/diagnostics/uninitialized-out.slang.expected
@@ -1,0 +1,8 @@
+result code = -1
+standard error = {
+tests/diagnostics/uninitialized-out.slang(5): error 41015: use of uninitialized value.
+    float r = v.x + 1.0;
+                ^
+}
+standard output = {
+}


### PR DESCRIPTION
This change adds a conservative check on using `out` parameters that are not yet initialized.

It is conservative in the sense that if a load is reachable from any stores, we will not issue an error.