### PR TITLE
Add warning for returning without initializing out parameter

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2649,6 +2649,15 @@ __generic<T, U>
 __intrinsic_op($(kIROp_Reinterpret))
 T reinterpret(U value);
 
+// Use an otherwise unused value
+//
+// This can be used to silence the warning about returning before initializing
+// an out paramter.
+__generic<T>
+[__readNone]
+[ForceInline]
+void unused(inout T){}
+
 // Specialized function
 
 /// Given a string returns an integer hash of that string.

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -595,7 +595,9 @@ DIAGNOSTIC(40020, Error, cannotUnrollLoop, "loop does not terminate within the l
 DIAGNOSTIC(41000, Warning, unreachableCode, "unreachable code detected")
 
 DIAGNOSTIC(41010, Warning, missingReturn, "control flow may reach end of non-'void' function")
-DIAGNOSTIC(41015, Error, usingUninitializedValue, "use of uninitialized value.")
+DIAGNOSTIC(41015, Error, usingUninitializedValue, "use of uninitialized value '$0'")
+DIAGNOSTIC(41016, Warning, returningWithUninitializedOut, "returning without initializing out parameter '$0'")
+DIAGNOSTIC(41017, Warning, returningWithPartiallyUninitializedOut, "returning without fully initializing out parameter '$0'")
 
 DIAGNOSTIC(41011, Error, typeDoesNotFitAnyValueSize, "type '$0' does not fit in the size required by its conforming interface.")
 DIAGNOSTIC(41012, Note, typeAndLimit, "sizeof($0) is $1, limit is $2")

--- a/tests/autodiff/bsdf/bsdf-auto-rev.slang
+++ b/tests/autodiff/bsdf/bsdf-auto-rev.slang
@@ -39,6 +39,7 @@ bool bsdfGGXSample(in ShadingData sd, in Auto_Bwd_BSDFParameters params, out Aut
 
     if (wiLocal.z < 1e-6)
     {
+        unused(result);
         return false;
     }
 

--- a/tests/compute/ray-tracing-inline.slang
+++ b/tests/compute/ray-tracing-inline.slang
@@ -33,6 +33,7 @@ bool traceRayClosestHit(
         //primitiveIndex = q.CommittedPrimitiveIndex();
         return true;
     }
+    unused(t);
     return false;
 }
 

--- a/tests/diagnostics/uninitialized-out.slang
+++ b/tests/diagnostics/uninitialized-out.slang
@@ -2,6 +2,31 @@
 
 float foo(out float3 v)
 {
+    // This should error as we haven't set v before we read from it
     float r = v.x + 1.0;
+    // This should warn as we haven't set v before we return
     return r;
+}
+
+// This should warn as we return without x being initialized
+float bar(out float x)
+{
+    return 0;
+}
+
+// This should also warn pointing at the implicit return
+void baz(out float x) {}
+
+// TODO: This should warn that n is potentially uninitialized
+int ok(bool b, out int n)
+{
+    if(b)
+        n = 0;
+    return n;
+}
+
+// TODO: This should warn that arr isn't fully initialized
+void partial(out float arr[2])
+{
+    arr[0] = 1;
 }

--- a/tests/diagnostics/uninitialized-out.slang
+++ b/tests/diagnostics/uninitialized-out.slang
@@ -17,6 +17,31 @@ float bar(out float x)
 // This should also warn pointing at the implicit return
 void baz(out float x) {}
 
+void twoReturns(bool b, out float y)
+{
+    if(b)
+    {
+        // Should warn
+        return;
+    }
+    y = 0;
+    // Shouldn't warn
+    return;
+}
+
+void twoOkReturns(bool b, out float y)
+{
+    if(b)
+    {
+        // Shouldn't warn
+        unused(y);
+        return;
+    }
+    y = 0;
+    // Shouldn't warn
+    return;
+}
+
 // TODO: This should warn that n is potentially uninitialized
 int ok(bool b, out int n)
 {

--- a/tests/diagnostics/uninitialized-out.slang.expected
+++ b/tests/diagnostics/uninitialized-out.slang.expected
@@ -12,6 +12,9 @@ tests/diagnostics/uninitialized-out.slang(14): warning 41016: returning without 
 tests/diagnostics/uninitialized-out.slang(18): warning 41016: returning without initializing out parameter 'x'
 void baz(out float x) {}
                        ^
+tests/diagnostics/uninitialized-out.slang(25): warning 41016: returning without initializing out parameter 'y'
+        return;
+        ^~~~~~
 }
 standard output = {
 }

--- a/tests/diagnostics/uninitialized-out.slang.expected
+++ b/tests/diagnostics/uninitialized-out.slang.expected
@@ -1,8 +1,17 @@
 result code = -1
 standard error = {
-tests/diagnostics/uninitialized-out.slang(5): error 41015: use of uninitialized value.
+tests/diagnostics/uninitialized-out.slang(6): error 41015: use of uninitialized value 'v'
     float r = v.x + 1.0;
                 ^
+tests/diagnostics/uninitialized-out.slang(8): warning 41016: returning without initializing out parameter 'v'
+    return r;
+    ^~~~~~
+tests/diagnostics/uninitialized-out.slang(14): warning 41016: returning without initializing out parameter 'x'
+    return 0;
+    ^~~~~~
+tests/diagnostics/uninitialized-out.slang(18): warning 41016: returning without initializing out parameter 'x'
+void baz(out float x) {}
+                       ^
 }
 standard output = {
 }


### PR DESCRIPTION
Also name uninitialized uses of out parameters