### PR TITLE
added D32_S8 format

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -270,6 +270,7 @@ public:
     \
     x(D32_FLOAT, 4, 1) \
     x(D16_UNORM, 2, 1) \
+    x(D32_FLOAT_S8_UINT, 8, 1) \
     \
     x(B4G4R4A4_UNORM, 2, 1) \
     x(B5G6R5_UNORM, 2, 1) \
@@ -379,6 +380,7 @@ enum class Format
 
     D32_FLOAT,
     D16_UNORM,
+    D32_FLOAT_S8_UINT,
 
     B4G4R4A4_UNORM,
     B5G6R5_UNORM,

--- a/tools/gfx/d3d/d3d-util.cpp
+++ b/tools/gfx/d3d/d3d-util.cpp
@@ -208,6 +208,7 @@ D3D12_DEPTH_STENCILOP_DESC D3DUtil::translateStencilOpDesc(DepthStencilOpDesc de
 
         case Format::D32_FLOAT:                 return DXGI_FORMAT_D32_FLOAT;
         case Format::D16_UNORM:                 return DXGI_FORMAT_D16_UNORM;
+        case Format::D32_FLOAT_S8_UINT:         return DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
 
         case Format::B4G4R4A4_UNORM:            return DXGI_FORMAT_B4G4R4A4_UNORM;
         case Format::B5G6R5_UNORM:              return DXGI_FORMAT_B5G6R5_UNORM;

--- a/tools/gfx/d3d12/d3d12-helper-functions.cpp
+++ b/tools/gfx/d3d12/d3d12-helper-functions.cpp
@@ -95,6 +95,8 @@ DXGI_FORMAT getTypelessFormatFromDepthFormat(Format format)
         return DXGI_FORMAT_R16_TYPELESS;
     case Format::D32_FLOAT:
         return DXGI_FORMAT_R32_TYPELESS;
+    case Format::D32_FLOAT_S8_UINT:
+        return DXGI_FORMAT_R32G8X24_TYPELESS;
     default:
         return D3DUtil::getMapFormat(format);
     }

--- a/tools/gfx/open-gl/render-gl.cpp
+++ b/tools/gfx/open-gl/render-gl.cpp
@@ -1594,6 +1594,7 @@ public:
         R8G8B8A8_UNORM,
         D32_FLOAT,
         D_Unorm24_S8,
+        D32_FLOAT_S8,
         CountOf,
     };
 
@@ -1660,6 +1661,8 @@ public:
     {
         case Format::R8G8B8A8_UNORM:        return GlPixelFormat::R8G8B8A8_UNORM;
         case Format::D32_FLOAT:             return GlPixelFormat::D32_FLOAT;
+        //case Format::D24_UNORM_S8_UINT:     return GlPixelFormat::D_Unorm24_S8;
+        case Format::D32_FLOAT_S8_UINT:     return GlPixelFormat::D32_FLOAT_S8;
 
         default:                            return GlPixelFormat::Unknown;
     }
@@ -1672,6 +1675,7 @@ public:
     { GL_RGBA8,         GL_RGBA,    GL_UNSIGNED_BYTE },         // GlPixelFormat::R8G8B8A8_UNORM
     { GL_DEPTH_COMPONENT32F, GL_DEPTH_COMPONENT, GL_UNSIGNED_BYTE}, // GlPixelFormat::D32_FLOAT
     { GL_DEPTH24_STENCIL8, GL_DEPTH_STENCIL, GL_UNSIGNED_BYTE}, // GlPixelFormat::D_Unorm24_S8
+    { GL_DEPTH32F_STENCIL8, GL_DEPTH_STENCIL, GL_FLOAT_32_UNSIGNED_INT_24_8_REV}, // GlPixelFormat::D32_FLOAT_S8
 
 };
 

--- a/tools/gfx/render.cpp
+++ b/tools/gfx/render.cpp
@@ -135,6 +135,7 @@ struct FormatInfoMap
 
         set(Format::D32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 1);
         set(Format::D16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
+        set(Format::D32_FLOAT_S8_UINT, SLANG_SCALAR_TYPE_FLOAT32, 2);
 
         set(Format::B4G4R4A4_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
         set(Format::B5G6R5_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 3);

--- a/tools/gfx/renderer-shared.cpp
+++ b/tools/gfx/renderer-shared.cpp
@@ -1259,6 +1259,18 @@ bool isDepthFormat(Format format)
     {
     case Format::D16_UNORM:
     case Format::D32_FLOAT:
+    case Format::D32_FLOAT_S8_UINT:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool isStencilFormat(Format format)
+{
+    switch (format)
+    {
+    case Format::D32_FLOAT_S8_UINT:
         return true;
     default:
         return false;

--- a/tools/gfx/vulkan/vk-util.cpp
+++ b/tools/gfx/vulkan/vk-util.cpp
@@ -83,6 +83,7 @@ namespace gfx {
 
         case Format::D32_FLOAT:                 return VK_FORMAT_D32_SFLOAT;
         case Format::D16_UNORM:                 return VK_FORMAT_D16_UNORM;
+        case Format::D32_FLOAT_S8_UINT:         return VK_FORMAT_D32_SFLOAT_S8_UINT;
 
         case Format::B4G4R4A4_UNORM:            return VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT;
         case Format::B5G6R5_UNORM:              return VK_FORMAT_R5G6B5_UNORM_PACK16;


### PR DESCRIPTION
related to #2884 

I prepared a pull request that includes the D32_S8 format.
It appears to be working for my program without breaking anything.
However, I am unsure about the change in the render.cpp where I set the channel count to 2 and kept the type at Float32 (since it is technically Float32_Uint8_X24).