### PR TITLE
fixed incorrect handling of D3D12_RENDER_TARGET_VIEW_DESC.ViewDimensi…

### DIFF
--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -1308,7 +1308,7 @@ Result DeviceImpl::createTextureView(
     RefPtr<ResourceViewImpl> viewImpl = new ResourceViewImpl();
     viewImpl->m_resource = resourceImpl;
     viewImpl->m_desc = desc;
-    bool isArray = resourceImpl ? resourceImpl->getDesc()->arraySize != 0 : false;
+    bool isArray = resourceImpl ? resourceImpl->getDesc()->arraySize > 1 : false;
     bool isMultiSample = resourceImpl ? resourceImpl->getDesc()->sampleDesc.numSamples > 1 : false;
     switch (desc.type)
     {
@@ -1396,7 +1396,6 @@ Result DeviceImpl::createTextureView(
         viewImpl->m_allocator = m_dsvAllocator;
         D3D12_DEPTH_STENCIL_VIEW_DESC dsvDesc = {};
         dsvDesc.Format = D3DUtil::getMapFormat(desc.format);
-        isArray = desc.subresourceRange.layerCount > 1;
         switch (desc.renderTarget.shape)
         {
         case IResource::Type::Texture1D:


### PR DESCRIPTION
fixed #2896 

It looks like the ViewDimension member was not set properly for the RTV and also UAV.
The documentation states that: "ViewDimension: This member also determines which _RTV to use in the following union" (https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_render_target_view_desc)
Therefore the type should be set if the underlying resource is an array and NOT if the requested view is an array. Otherwise, members like the first array slice would be ignored (Which is relevant if one wants to bind a specific slice).

An alternative fix would be to always use the TEXTUREXDARRAY enum, since appears to work fine with array sizes of 1 regardless. This would result in less nesting statements and overall be more readable. Let me know if you prefer that instead.