### PR TITLE
Be lenient on same-size unsigend->signed conversion.

### DIFF
--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -97,6 +97,9 @@ namespace Slang
         // Conversions that are lossless, but change "kind"
         kConversionCost_UnsignedToSignedPromotion = 200,
 
+        // Same-size size unsigned->signed conversions are potentially lossy, but they are commonly allowed silently.
+        kConversionCost_SameSizeUnsignedToSignedConversion = 250,
+
         // Conversion from signed->unsigned integer of same or greater size
         kConversionCost_SignedToUnsignedConversion = 300,
 

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -80,6 +80,7 @@ namespace Slang
         // from one on `Foo`
         kConversionCost_GetRef = 5,
         kConversionCost_ImplicitDereference = 10,
+        kConversionCost_InRangeIntLitConversion = 20,
 
         // Conversions based on explicit sub-typing relationships are the cheapest
         //

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -80,7 +80,10 @@ namespace Slang
         // from one on `Foo`
         kConversionCost_GetRef = 5,
         kConversionCost_ImplicitDereference = 10,
-        kConversionCost_InRangeIntLitConversion = 20,
+        kConversionCost_InRangeIntLitConversion = 23,
+        kConversionCost_InRangeIntLitSignedToUnsignedConversion = 32,
+        kConversionCost_InRangeIntLitUnsignedToSignedConversion = 81,
+
 
         // Conversions based on explicit sub-typing relationships are the cheapest
         //

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -1167,7 +1167,7 @@ namespace Slang
 
         BasicTypeKeyPair cacheKey;
         cacheKey.type1 = makeBasicTypeKey(toType);
-        cacheKey.type2 = makeBasicTypeKey(fromType);
+        cacheKey.type2 = makeBasicTypeKey(fromType, fromExpr);
     
         if( cacheKey.isValid())
         {

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -26,6 +26,17 @@ namespace Slang
         /// Note: this currently does not include PtrTypeBase.
     Type* getPointedToTypeIfCanImplicitDeref(Type* type);
 
+    inline int getIntValueBitSize(IntegerLiteralValue val)
+    {
+        uint64_t v = val > 0 ? (uint64_t)val : (uint64_t)-val;
+        int result = 1;
+        while (v >>= 1)
+        {
+            result++;
+        }
+        return result;
+    }
+
     // A flat representation of basic types (scalars, vectors and matrices)
     // that can be used as lookup key in caches
     struct BasicTypeKey
@@ -62,15 +73,11 @@ namespace Slang
             auto rs = makeBasicTypeKey(basicType->baseType);
             if (auto constInt = as<IntegerLiteralExpr>(exprIn))
             {
-                auto value = constInt->value;
-                if (value < 0)
+                if (constInt->value < 0)
                 {
                     rs.knownNegative = 1;
-                    value = -value;
                 }
-                rs.knownConstantBitCount = 1;
-                while (value >>= 1)
-                    rs.knownConstantBitCount++;
+                rs.knownConstantBitCount = getIntValueBitSize(constInt->value);
             }
             return rs;
         }

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1043,6 +1043,18 @@ namespace Slang
         }
         else if(context.bestCandidate)
         {
+            if (as<ContainerDecl>(candidate.item.declRef.decl)->members.getCount())
+            {
+                auto param = as<ParamDecl>( as<ContainerDecl>(candidate.item.declRef.decl)->members.getFirst());
+                if (param)
+                    if (auto t = as<BasicExpressionType>(param->type))
+                    {
+                        if (t->baseType == BaseType::UInt)
+                        {
+                            printf("break");
+                        }
+                    }
+            }
             // There's only one candidate so far
             int cmp = CompareOverloadCandidates(&candidate, context.bestCandidate);
             if(cmp < 0)

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1043,18 +1043,6 @@ namespace Slang
         }
         else if(context.bestCandidate)
         {
-            if (as<ContainerDecl>(candidate.item.declRef.decl)->members.getCount())
-            {
-                auto param = as<ParamDecl>( as<ContainerDecl>(candidate.item.declRef.decl)->members.getFirst());
-                if (param)
-                    if (auto t = as<BasicExpressionType>(param->type))
-                    {
-                        if (t->baseType == BaseType::UInt)
-                        {
-                            printf("break");
-                        }
-                    }
-            }
             // There's only one candidate so far
             int cmp = CompareOverloadCandidates(&candidate, context.bestCandidate);
             if(cmp < 0)

--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -150,11 +150,20 @@ namespace Slang
         // *from* a pointer-sized unsigned integer.
         else if(toInfo.conversionKind == kBaseTypeConversionKind_Signed
             && fromInfo.conversionKind == kBaseTypeConversionKind_Unsigned
-            && toInfo.conversionRank >= fromInfo.conversionRank
+            && toInfo.conversionRank > fromInfo.conversionRank
             && toInfo.conversionRank != kBaseTypeConversionRank_IntPtr
             && fromInfo.conversionRank != kBaseTypeConversionRank_IntPtr)
         {
             return kConversionCost_UnsignedToSignedPromotion;
+        }
+        // Same-size unsigned to signed integer conversion.
+        else if (toInfo.conversionKind == kBaseTypeConversionKind_Signed
+            && fromInfo.conversionKind == kBaseTypeConversionKind_Unsigned
+            && toInfo.conversionRank == fromInfo.conversionRank
+            && toInfo.conversionRank != kBaseTypeConversionRank_IntPtr
+            && fromInfo.conversionRank != kBaseTypeConversionRank_IntPtr)
+        {
+            return kConversionCost_SameSizeUnsignedToSignedConversion;
         }
 
         // Conversion from signed to unsigned is always lossy,

--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -150,7 +150,7 @@ namespace Slang
         // *from* a pointer-sized unsigned integer.
         else if(toInfo.conversionKind == kBaseTypeConversionKind_Signed
             && fromInfo.conversionKind == kBaseTypeConversionKind_Unsigned
-            && toInfo.conversionRank > fromInfo.conversionRank
+            && toInfo.conversionRank >= fromInfo.conversionRank
             && toInfo.conversionRank != kBaseTypeConversionRank_IntPtr
             && fromInfo.conversionRank != kBaseTypeConversionRank_IntPtr)
         {

--- a/tests/compute/unbounded-array-of-array-syntax.slang.glsl
+++ b/tests/compute/unbounded-array-of-array-syntax.slang.glsl
@@ -24,7 +24,7 @@ void main()
     (bufferCount_0) = (g_aoa_0[_S3])._data.length(); (bufferStride_0) = 0;
 
     int innerIndex_1;
-    if(uint(innerIndex_0) >= bufferCount_0)
+    if(innerIndex_0 >= int(bufferCount_0))
     {
         innerIndex_1 = int(bufferCount_0 - 1U);
     }

--- a/tests/compute/unbounded-array-of-array-syntax.slang.hlsl
+++ b/tests/compute/unbounded-array-of-array-syntax.slang.hlsl
@@ -24,7 +24,7 @@ void computeMain(vector<uint,3> dispatchThreadID_0 : SV_DISPATCHTHREADID)
 
     uint bufferCount_0 = _S1;
 
-    if((uint) innerIndex_1 >= bufferCount_0)
+    if(innerIndex_1 >= (int)bufferCount_0)
     {
         innerIndex_0 = (int) (bufferCount_0 - (uint) 1);
     }

--- a/tests/diagnostics/constexpr-error.slang.expected
+++ b/tests/diagnostics/constexpr-error.slang.expected
@@ -1,8 +1,5 @@
 result code = -1
 standard error = {
-tests/diagnostics/constexpr-error.slang(27): warning 30081: implicit conversion from 'vector<uint,2>' to 'vector<int,2>' is not recommended
-    result += t.Sample(s, uv, offset);
-                              ^~~~~~
 tests/diagnostics/constexpr-error.slang(27): error 40006: expected a compile-time constant
     result += t.Sample(s, uv, offset);
                               ^~~~~~

--- a/tests/diagnostics/enum-implicit-conversion.slang.expected
+++ b/tests/diagnostics/enum-implicit-conversion.slang.expected
@@ -1,11 +1,5 @@
 result code = -1
 standard error = {
-tests/diagnostics/enum-implicit-conversion.slang(18): warning 30081: implicit conversion from 'uint' to 'int' is not recommended
-int foo(uint x) { return x * 256 * 16; }
-                                 ^
-tests/diagnostics/enum-implicit-conversion.slang(22): warning 30081: implicit conversion from 'uint' to 'int' is not recommended
-int bar(uint  x) { return x * 256 * 256 * 16; }
-                                        ^
 tests/diagnostics/enum-implicit-conversion.slang(27): error 30019: expected an expression of type 'Color', got 'int'
     Color c = val;
               ^~~
@@ -23,9 +17,6 @@ tests/diagnostics/enum-implicit-conversion.slang(42): error 39999: ambiguous cal
                ^
 tests/diagnostics/enum-implicit-conversion.slang(18): note 39999: candidate: func foo(uint) -> int
 tests/diagnostics/enum-implicit-conversion.slang(17): note 39999: candidate: func foo(int) -> int
-tests/diagnostics/enum-implicit-conversion.slang(47): warning 30081: implicit conversion from 'uint' to 'int' is not recommended
-    return x + y + z;
-                 ^
 }
 standard output = {
 }

--- a/tests/diagnostics/generic-invalid-type-specialization.slang.expected
+++ b/tests/diagnostics/generic-invalid-type-specialization.slang.expected
@@ -1,8 +1,5 @@
 result code = -1
 standard error = {
-tests/diagnostics/generic-invalid-type-specialization.slang(14): warning 30081: implicit conversion from 'uint' to 'int' is not recommended
-    int index = dispatchThreadID.x;
-                                 ^
 tests/diagnostics/generic-invalid-type-specialization.slang(17): error 30060: expected a type, got a 'int'
     Check<2 + 2> v;
             ^

--- a/tests/experimental/liveness/liveness.slang.expected
+++ b/tests/experimental/liveness/liveness.slang.expected
@@ -47,7 +47,7 @@ int someSlowFunc_0(int a_0)
         uint _S5 = v_0 >> 1;
         uint _S6 = v_0;
         livenessEnd_1(v_0, 0);
-        uint _S7 = (_S5 | _S6 << 31) * uint(i_0);
+        uint _S7 = uint(int(_S5 | _S6 << 31) * i_0);
         int i_1 = i_0 + 1;
         livenessStart_0(v_0, 0);
         v_0 = _S7;


### PR DESCRIPTION
With this change, uint->int will have cost `kConversionCost_SameSizeUnsignedToSignedConversion` (250) instead of `kConversionCost_General` (900) so we no longer report warnings on them. This has been more annoying then helpful.

Our current logic does not report warnings on int->uint, which is even worse. So there is no reason to report warnings uint->int.

If we have
```
int f(int, int);
int f(uint, uint);
```
After this change, the compiler now prefers the `f(int, int)` overload if the argument types are `(uint, int)`, previously we will choose `f(uint, uint)`.

We need to make sure that a call to `f(uint, 3)` still picks the `uint` overload. To do this, we special case the coercion cost computation if the argument is an `IntLiterialExpr`. We also need to fix the cache for overload resolution and candidate costs to factor in the int constant info in the cache key.