### PR TITLE
Warn on semicolon after `if`.

### DIFF
--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -234,6 +234,8 @@ DIAGNOSTIC(20013, Error, invalidCUDASMVersion, "Expecting CUDA SM version as eit
 
 DIAGNOSTIC(20014, Error, classIsReservedKeyword, "'class' is a reserved keyword in this context; use 'struct' instead.")
 
+DIAGNOSTIC(20101, Warning, unintendedEmptyStatement, "potentially unintended empty statement at this location; use {} instead.")
+
 //
 // 3xxxx - Semantic analysis
 //

--- a/tests/diagnostics/if-empty-body.slang
+++ b/tests/diagnostics/if-empty-body.slang
@@ -1,0 +1,11 @@
+//DIAGNOSTIC_TEST(windows):SIMPLE:
+
+// Test that use of empty statement after an `if` leads to an warning.
+
+struct S {}
+
+void test()
+{
+	if (1+1==2);
+		return;
+}

--- a/tests/diagnostics/if-empty-body.slang.expected
+++ b/tests/diagnostics/if-empty-body.slang.expected
@@ -1,0 +1,8 @@
+result code = 0
+standard error = {
+tests/diagnostics/if-empty-body.slang(9): warning 20101: potentially unintended empty statement at this location; use {} instead.
+    if (1+1==2);
+               ^
+}
+standard output = {
+}


### PR DESCRIPTION
Fixes #2935.