### PR TITLE
Apply SCCP on global scope before unrolling loops.

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -399,6 +399,9 @@ Result linkAndOptimizeIR(
         // Unroll loops.
         if (codeGenContext->getSink()->getErrorCount() == 0)
         {
+            applySparseConditionalConstantPropagationForGlobalScope(
+                irModule, codeGenContext->getSink());
+
             if (!unrollLoopsInModule(irModule, codeGenContext->getSink()))
                 return SLANG_FAIL;
         }

--- a/source/slang/slang-ir-loop-unroll.cpp
+++ b/source/slang/slang-ir-loop-unroll.cpp
@@ -99,7 +99,7 @@ static int _getLoopMaxIterationsToUnroll(IRLoop* loopInst)
     if (maxIterCount && maxIterCount->getValue() != 0)
     {
         maxIterations =
-            Math::Clamp(maxIterations, (int)maxIterCount->getValue() + 1, kMaxIterationsToAttempt);
+            Math::Min((int)maxIterCount->getValue() + 1, kMaxIterationsToAttempt);
     }
     return maxIterations;
 }

--- a/source/slang/slang-ir-loop-unroll.cpp
+++ b/source/slang/slang-ir-loop-unroll.cpp
@@ -88,7 +88,7 @@ List<IRBlock*> collectBlocksInLoop(IRGlobalValueWithCode* func,  IRLoop* loopIns
 
 static int _getLoopMaxIterationsToUnroll(IRLoop* loopInst)
 {
-    static constexpr int kMaxIterationsToAttempt = 256;
+    static constexpr int kMaxIterationsToAttempt = 4096;
 
     auto forceUnrollDecor = loopInst->findDecoration<IRForceUnrollDecoration>();
     if (!forceUnrollDecor)


### PR DESCRIPTION
If we have a loop bound on a generic integer value, the generic integer value may become an expression at global scope after specialization. We need to fold that global scope value before unrolling, otherwise we can never constant-fold the loop condition.