### PR TITLE
Work around for NonUniformResourceIndex with non integral types.

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -3206,6 +3206,7 @@ int NonUniformResourceIndex(int index)
 /// It's effect is presumably to ignore it, which the following implementation does.
 /// We should also look to add a warning for this scenario.
 [__unsafeForceInlineEarly] 
+[deprecated("NonUniformResourceIndex on a type other than uint/int is depreciated and has no effect")]
 T NonUniformResourceIndex<T>(T value) { return value; }
 
 // Normalize a vector

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -3205,7 +3205,7 @@ int NonUniformResourceIndex(int index)
 /// HLSL allows NonUniformResourceIndex around non int/uint types. 
 /// It's effect is presumably to ignore it, which the following implementation does.
 /// We should also look to add a warning for this scenario.
-
+[__unsafeForceInlineEarly] 
 T NonUniformResourceIndex<T>(T value) { return value; }
 
 // Normalize a vector

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -3202,6 +3202,12 @@ int NonUniformResourceIndex(int index)
     return index;
 }
 
+/// HLSL allows NonUniformResourceIndex around non int/uint types. 
+/// It's effect is presumably to ignore it, which the following implementation does.
+/// We should also look to add a warning for this scenario.
+
+T NonUniformResourceIndex<T>(T value) { return value; }
+
 // Normalize a vector
 __generic<T : __BuiltinFloatingPointType, let N : int>
 __target_intrinsic(hlsl)

--- a/tests/cross-compile/non-uniform-indexing.slang
+++ b/tests/cross-compile/non-uniform-indexing.slang
@@ -1,7 +1,7 @@
 //TEST:CROSS_COMPILE:-target spirv-assembly -entry main -stage fragment
 //TEST:CROSS_COMPILE:-target spirv-assembly -entry main -stage fragment -verify-debug-serial-ir
 
-// Confirm that `NonUniformResourceIndex` translates to SPIR-V as expeted
+// Confirm that `NonUniformResourceIndex` translates to SPIR-V as expected
 
 Texture2D t[10];
 SamplerState s;


### PR DESCRIPTION
Ignores NonUniformResourceIndex for non uint/int types. Was tested with float, to make sure generic was taken over (say) coercing into integral, and that appeared to work as expected.

Should probably issue a warning when it is elided in this manner. Look to add in future PR.

