### PR TITLE
Fix vk-shift-* mapping issue

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -355,9 +355,15 @@ Force using scalar block layout for uniform and shader storage buffers in GLSL o
 <a id="fvk-b-shift"></a>
 ## -fvk-b-shift, -fvk-s-shift, -fvk-t-shift, -fvk-u-shift
 
-**-vk-&lt;[vulkan-shift](#vulkan-shift)&gt;-shift &lt;N&gt; &lt;space&gt;**
+**-fvk-&lt;[vulkan-shift](#vulkan-shift)&gt;-shift &lt;N&gt; &lt;space&gt;**
 
-For example '-vk-b-shift &lt;N&gt; &lt;space&gt;' shifts by N the inferred binding numbers for all resources in 'b' registers of space &lt;space&gt;. For a resource attached with :register(bX, &lt;space&gt;) but not \[vk::binding(...)\], sets its Vulkan descriptor set to &lt;space&gt; and binding number to X + N. If you need to shift the inferred binding numbers for more than one space, provide more than one such option. If more than one such option is provided for the same space, the last one takes effect. If you need to shift the inferred binding numbers for all sets, use 'all' as &lt;space&gt;. 
+For example '-fvk-b-shift &lt;N&gt; &lt;space&gt;' shifts by N the inferred binding numbers for all resources in 'b' registers of space &lt;space&gt;. For a resource attached with :register(bX, &lt;space&gt;) but not \[vk::binding(...)\], sets its Vulkan descriptor set to &lt;space&gt; and binding number to X + N. If you need to shift the inferred binding numbers for more than one space, provide more than one such option. If more than one such option is provided for the same space, the last one takes effect. If you need to shift the inferred binding numbers for all sets, use 'all' as &lt;space&gt;. 
+
+* \[DXC description\](https://github.com/Microsoft/DirectXShaderCompiler/blob/main/docs/SPIR-V.rst#implicit-binding-number-assignment) 
+
+* \[GLSL wiki\](https://github.com/KhronosGroup/glslang/wiki/HLSL-FAQ#auto-mapped-binding-numbers) 
+
+
 
 
 <a id="fvk-bind-globals"></a>
@@ -824,10 +830,10 @@ Stage
 
 Vulkan Shift 
 
-* `b` : Vulkan Buffer resource 
-* `s` : Vulkan Sampler resource 
-* `t` : Vulkan Texture resource 
-* `u` : Vulkan Uniform resource 
+* `b` : Constant buffer view 
+* `s` : Sampler 
+* `t` : Shader resource view 
+* `u` : Unorderd access view 
 
 <a id="capability"></a>
 # capability

--- a/source/slang/slang-hlsl-to-vulkan-layout-options.cpp
+++ b/source/slang/slang-hlsl-to-vulkan-layout-options.cpp
@@ -8,14 +8,16 @@ namespace { // anonymous
 
 typedef HLSLToVulkanLayoutOptions::Kind ShiftKind;
 
-/* {b|s|t|u} */
+/* {b|s|t|u} 
 
+https://github.com/KhronosGroup/glslang/wiki/HLSL-FAQ
+*/
 static NamesDescriptionValue s_vulkanShiftKinds[] =
 {
-    { ValueInt(ShiftKind::Buffer),  "b", "Vulkan Buffer resource" },
-    { ValueInt(ShiftKind::Sampler), "s", "Vulkan Sampler resource" },
-    { ValueInt(ShiftKind::Texture), "t", "Vulkan Texture resource" },
-    { ValueInt(ShiftKind::Uniform), "u", "Vulkan Uniform resource" },
+    { ValueInt(ShiftKind::ConstantBuffer),  "b", "Constant buffer view" },
+    { ValueInt(ShiftKind::Sampler),         "s", "Samplers" },
+    { ValueInt(ShiftKind::ShaderResource),  "t", "Shader resource view" },
+    { ValueInt(ShiftKind::UnorderedAccess), "u", "Unorderd access view" },
 };
 
 } // anonymous
@@ -136,10 +138,10 @@ HLSLToVulkanLayoutOptions::Binding HLSLToVulkanLayoutOptions::inferBinding(Kind 
         case ParameterCategory::Uniform:
         case ParameterCategory::ConstantBuffer: 
         {
-            return Kind::Uniform;
+            return Kind::ConstantBuffer;
         }
-        case ParameterCategory::ShaderResource:     return Kind::Texture;
-        case ParameterCategory::UnorderedAccess:    return Kind::Buffer;
+        case ParameterCategory::ShaderResource:     return Kind::ShaderResource;
+        case ParameterCategory::UnorderedAccess:    return Kind::UnorderedAccess;
         case ParameterCategory::SamplerState:       return Kind::Sampler;
         
         default:

--- a/source/slang/slang-hlsl-to-vulkan-layout-options.cpp
+++ b/source/slang/slang-hlsl-to-vulkan-layout-options.cpp
@@ -15,7 +15,7 @@ https://github.com/KhronosGroup/glslang/wiki/HLSL-FAQ
 static NamesDescriptionValue s_vulkanShiftKinds[] =
 {
     { ValueInt(ShiftKind::ConstantBuffer),  "b", "Constant buffer view" },
-    { ValueInt(ShiftKind::Sampler),         "s", "Samplers" },
+    { ValueInt(ShiftKind::Sampler),         "s", "Sampler" },
     { ValueInt(ShiftKind::ShaderResource),  "t", "Shader resource view" },
     { ValueInt(ShiftKind::UnorderedAccess), "u", "Unorderd access view" },
 };

--- a/source/slang/slang-hlsl-to-vulkan-layout-options.h
+++ b/source/slang/slang-hlsl-to-vulkan-layout-options.h
@@ -32,15 +32,36 @@ public:
         Index index = -1;
     };
 
+    // https://github.com/KhronosGroup/glslang/wiki/HLSL-FAQ
     // {b|s|t|u} 
     enum class Kind
     {
         Invalid = -1,
 
-        Buffer,             ///< Buffer 
-        Sampler,            ///< Sampler
-        Texture,            ///< Texture
-        Uniform,            ///< Uniform
+            /// Unordered access view (u) 
+            ///
+            /// RWByteAddressBuffer/RWStructuredBuffer
+            /// Append/ConsumeStructuredBuffer
+            /// RWBuffer
+            /// RWTextureXD/Array
+        UnorderedAccess,    
+
+            /// Sampler (s)
+            ///
+            /// SamplerXD
+            /// SamplerState/SamplerComparisonState
+        Sampler,
+
+            /// Shader Resource (t)
+            ///
+            /// TextureXD/Array
+            /// ByteAddressBuffer/StructuredBuffer/Buffer/TBuffer
+        ShaderResource,            
+
+            /// Constant buffer (b)
+            /// 
+            /// ConstantBufferViews, CBuffer
+        ConstantBuffer,     
 
         CountOf,
     };

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -484,13 +484,16 @@ void initCommandOptions(CommandOptions& options)
         { OptionKind::GLSLForceScalarLayout,
          "-force-glsl-scalar-layout", nullptr,
          "Force using scalar block layout for uniform and shader storage buffers in GLSL output."},
-        { OptionKind::VulkanBindShift, vkShiftNames.getBuffer(), "-vk-<vulkan-shift>-shift <N> <space>", 
-        "For example '-vk-b-shift <N> <space>' shifts by N the inferred binding numbers for all resources in 'b' registers of space <space>. "
+        { OptionKind::VulkanBindShift, vkShiftNames.getBuffer(), "-fvk-<vulkan-shift>-shift <N> <space>", 
+        "For example '-fvk-b-shift <N> <space>' shifts by N the inferred binding numbers for all resources in 'b' registers of space <space>. "
         "For a resource attached with :register(bX, <space>) but not [vk::binding(...)], "
         "sets its Vulkan descriptor set to <space> and binding number to X + N. If you need to shift the "
         "inferred binding numbers for more than one space, provide more than one such option. "
         "If more than one such option is provided for the same space, the last one takes effect. "
-        "If you need to shift the inferred binding numbers for all sets, use 'all' as <space>." },
+        "If you need to shift the inferred binding numbers for all sets, use 'all' as <space>. " 
+        "\n"
+        "* [DXC description](https://github.com/Microsoft/DirectXShaderCompiler/blob/main/docs/SPIR-V.rst#implicit-binding-number-assignment)\n" 
+        "* [GLSL wiki](https://github.com/KhronosGroup/glslang/wiki/HLSL-FAQ#auto-mapped-binding-numbers)\n" },
         { OptionKind::VulkanBindGlobals, "-fvk-bind-globals", "-fvk-bind-globals <N> <descriptor-set>",
         "Places the $Globals cbuffer at descriptor set <descriptor-set> and binding <N>."},
         { OptionKind::EnableEffectAnnotations,

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -575,7 +575,7 @@ LayoutSemanticInfo extractHLSLLayoutSemanticInfo(
     return info;
 }
 
-LayoutSemanticInfo ExtractLayoutSemanticInfo(
+static LayoutSemanticInfo _extractLayoutSemanticInfo(
     ParameterBindingContext*    context,
     HLSLLayoutSemantic*         semantic)
 {
@@ -938,7 +938,7 @@ static void addExplicitParameterBindings_HLSL(
     for (auto semantic : varDecl.getDecl()->getModifiersOfType<HLSLLayoutSemantic>())
     {
         // Need to extract the information encoded in the semantic
-        LayoutSemanticInfo semanticInfo = ExtractLayoutSemanticInfo(context, semantic);
+        LayoutSemanticInfo semanticInfo = _extractLayoutSemanticInfo(context, semantic);
         auto kind = semanticInfo.kind;
         if (kind == LayoutResourceKind::None)
             continue;
@@ -1076,7 +1076,7 @@ static void addExplicitParameterBindings_GLSL(
     }
             
     // Get the HLSL binding info
-    const auto hlslInfo = ExtractLayoutSemanticInfo(context, hlslRegSemantic);
+    const auto hlslInfo = _extractLayoutSemanticInfo(context, hlslRegSemantic);
     if (hlslInfo.kind == LayoutResourceKind::None)
     {
         // Is no hlsl resource binding

--- a/tests/bindings/hlsl-to-vulkan-shift.hlsl
+++ b/tests/bindings/hlsl-to-vulkan-shift.hlsl
@@ -1,4 +1,4 @@
-//TEST:REFLECTION:-target glsl -profile ps_4_0 -entry main -fvk-t-shift 5 all -fvk-t-shift 7 2  -fvk-s-shift -3 0 -fvk-b-shift 1 2
+//TEST:REFLECTION:-target glsl -profile ps_4_0 -entry main -fvk-t-shift 5 all -fvk-t-shift 7 2  -fvk-s-shift -3 0 -fvk-u-shift 0 all -fvk-u-shift 1 2 -fvk-b-shift 1 0
 
 struct Data
 {

--- a/tests/bindings/hlsl-to-vulkan-shift.hlsl.expected
+++ b/tests/bindings/hlsl-to-vulkan-shift.hlsl.expected
@@ -21,7 +21,7 @@ standard output = {
         },
         {
             "name": "c",
-            "binding": {"kind": "descriptorTableSlot", "index": 0},
+            "binding": {"kind": "descriptorTableSlot", "index": 3},
             "type": {
                 "kind": "constantBuffer",
                 "elementType": {
@@ -86,7 +86,7 @@ standard output = {
         },
         {
             "name": "u",
-            "binding": {"kind": "descriptorTableSlot", "index": 2},
+            "binding": {"kind": "descriptorTableSlot", "index": 11},
             "type": {
                 "kind": "resource",
                 "baseShape": "structuredBuffer",
@@ -157,7 +157,7 @@ standard output = {
                 },
                 {
                     "name": "c",
-                    "binding": {"kind": "descriptorTableSlot", "index": 0}
+                    "binding": {"kind": "descriptorTableSlot", "index": 3}
                 },
                 {
                     "name": "t2",
@@ -165,7 +165,7 @@ standard output = {
                 },
                 {
                     "name": "u",
-                    "binding": {"kind": "descriptorTableSlot", "index": 2}
+                    "binding": {"kind": "descriptorTableSlot", "index": 11}
                 },
                 {
                     "name": "u2",

--- a/tests/diagnostics/hlsl-to-vulkan-shift-diagnostic.hlsl
+++ b/tests/diagnostics/hlsl-to-vulkan-shift-diagnostic.hlsl
@@ -1,4 +1,4 @@
-//DIAGNOSTIC_TEST:SIMPLE:-target glsl -profile ps_4_0 -entry main -fvk-t-shift 5 all -fvk-t-shift 7 2  -fvk-s-shift -3 0 -fvk-b-shift 1 2 -no-codegen
+//DIAGNOSTIC_TEST:SIMPLE:-target glsl -profile ps_4_0 -entry main -fvk-t-shift 5 all -fvk-t-shift 7 2  -fvk-s-shift -3 0 -fvk-u-shift 1 2 -no-codegen
 
 struct Data
 {


### PR DESCRIPTION
Fix for #2987

Problem was due to inappropriate use of b|t|u|s interpretation as should be using the D3D resource meanings.