### PR TITLE
Simplify lookup.

### DIFF
--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -297,11 +297,6 @@ public:
         return getOrCreate<ConstantIntVal>(type, value);
     }
 
-    DeclRefType* getOrCreateDeclRefType(DeclRefBase* declRef)
-    {
-        return getOrCreate<DeclRefType>(declRef);
-    }
-
     GenericSubstitution* getOrCreateGenericSubstitution(GenericDecl* decl, const List<Val*>& args, Substitutions* outer)
     {
         NodeDesc desc;

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -96,6 +96,7 @@ namespace Slang
         kConversionCost_CastToInterface = 50,
 
         // Conversion that is lossless and keeps the "kind" of the value the same
+        kConversionCost_BoolToInt = 120,   // Converting bool to int has lower cost than other integer types to prevent ambiguity.
         kConversionCost_RankPromotion = 150,
         kConversionCost_NoneToOptional = 150,
         kConversionCost_ValToOptional = 150,

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1410,7 +1410,7 @@ namespace Slang
             if (auto declRefType = as<DeclRefType>(sharedTypeExpr->base))
             {
                 auto subst = createDefaultSubstitutions(m_astBuilder, this, declRefType->declRef.getDecl());
-                auto newType = m_astBuilder->getOrCreateDeclRefType(m_astBuilder->getSpecializedDeclRef(declRefType->declRef.getDecl(), subst));
+                auto newType = DeclRefType::create(m_astBuilder, m_astBuilder->getSpecializedDeclRef(declRefType->declRef.getDecl(), subst));
                 sharedTypeExpr->base.type = newType;
                 if (auto typetype = as<TypeType>(typeExp.exp->type))
                     typetype->type = newType;
@@ -1470,7 +1470,7 @@ namespace Slang
                 substSet = declRefType->declRef.getSubst();
             }
         }
-        auto satisfyingType = m_astBuilder->getOrCreateDeclRefType(m_astBuilder->getSpecializedDeclRef(aggTypeDecl, substSet));
+        auto satisfyingType = DeclRefType::create(m_astBuilder, m_astBuilder->getSpecializedDeclRef(aggTypeDecl, substSet));
 
         // Helper function to add a `diffType` field into the synthesized type for the original
         // `member`.
@@ -6533,6 +6533,10 @@ namespace Slang
         //
         m_candidateExtensionListsBuilt = false;
         m_mapTypeDeclToCandidateExtensions.clear();
+
+        // Invalidate the cached inheritanceInfo.
+        m_mapTypeToInheritanceInfo.clear();
+        m_mapDeclRefToInheritanceInfo.clear();
     }
     
     void SharedSemanticsContext::_addCandidateExtensionsFromModule(ModuleDecl* moduleDecl)

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -539,7 +539,7 @@ namespace Slang
                 auto typeDef = m_astBuilder->create<TypeAliasDecl>();
                 typeDef->nameAndLoc.name = getName("Differential");
                 auto declRef = createDefaultSubstitutionsIfNeeded(m_astBuilder, this, makeDeclRef(structDecl));
-                typeDef->type.type = m_astBuilder->getOrCreateDeclRefType(declRef);
+                typeDef->type.type = DeclRefType::create(m_astBuilder, declRef);
                 typeDef->parentDecl = structDecl;
                 structDecl->members.add(typeDef);
             }
@@ -1052,7 +1052,7 @@ namespace Slang
             {
                 foreachDirectOrExtensionMemberOfType<InheritanceDecl>(this, aggTypeDeclRef, [&](DeclRef<InheritanceDecl> member)
                     {
-                        auto subType = m_astBuilder->getOrCreateDeclRefType(member);
+                        auto subType = DeclRefType::create(m_astBuilder, member);
                         maybeRegisterDifferentiableTypeImplRecursive(m_astBuilder, subType);
                     });
                 foreachDirectOrExtensionMemberOfType<VarDeclBase>(this, aggTypeDeclRef, [&](DeclRef<VarDeclBase> member)

--- a/source/slang/slang-ir-simplify-cfg.cpp
+++ b/source/slang/slang-ir-simplify-cfg.cpp
@@ -509,7 +509,11 @@ static bool simplifyBoolPhiParams(IRBlock* block)
 
     Array<IRBlock*, 2> preds;
     for (auto pred : block->getPredecessors())
+    {
+        if (pred->getTerminator()->getOp() != kIROp_unconditionalBranch)
+            return false;
         preds.add(pred);
+    }
 
     IRBlock* ifElseBlock = nullptr;
     if (preds[0]->getPredecessors().getCount() != 1)

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -703,6 +703,12 @@ struct IRInst
     uint32_t _debugUID;
 #endif
 
+    // Reserved memory space for use by individual IR passes.
+    // This field is not supposed to be valid outside an IR pass,
+    // and each IR pass should always treat it as uninitialized
+    // upon entry.
+    UInt64 scratchData = 0;
+
     // The type of the result value of this instruction,
     // or `null` to indicate that the instruction has
     // no value.
@@ -739,12 +745,6 @@ struct IRInst
         SLANG_ASSERT(getOperands()[index].user != nullptr);
         getOperands()[index].init(this, value);
     }
-
-    // Reserved memory space for use by individual IR passes.
-    // This field is not supposed to be valid outside an IR pass,
-    // and each IR pass should always treat it as uninitialized
-    // upon entry.
-    UInt64 scratchData = 0;
 
     //
 

--- a/source/slang/slang-lookup.cpp
+++ b/source/slang/slang-lookup.cpp
@@ -200,7 +200,7 @@ static void _lookUpDirectAndTransparentMembers(
             // Skip this declaration if we are checking and this hasn't been
             // checked yet. Because we traverse block statements in order, if
             // it's unchecked or being checked then it isn't declared yet.
-            if(!request.shouldConsiderAllLocalNames() && _isUncheckedLocalVar(m))
+            if(!request.shouldConsiderAllLocalNames() && request.semantics && _isUncheckedLocalVar(m))
                 continue;
 
             if (!DeclPassesLookupMask(m, request.mask))

--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -135,6 +135,10 @@ namespace Slang
             else
                 return kConversionCost_GeneralConversion;
         }
+        else if (fromInfo.tag == BaseType::Bool && toInfo.tag == BaseType::Int)
+        {
+            return kConversionCost_BoolToInt;
+        }
 
         // If we are converting from an unsigned integer type to
         // a signed integer type that is guaranteed to be larger,

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -675,7 +675,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         }
         else
         {
-            return astBuilder->getOrCreateDeclRefType(declRef.declRefBase);
+            return astBuilder->getOrCreate<DeclRefType>(declRef.declRefBase);
         }
     }
 

--- a/source/slang/slang.natvis
+++ b/source/slang/slang.natvis
@@ -10,30 +10,25 @@
     </Expand>
   </Type>
   <Type Name="Slang::DeclRef&lt;*&gt;">
-    <SmartPointer Usage="Minimal">declRefBase ? ($T1*)(declRefBase->decl) : ($T1*)0</SmartPointer>
     <DisplayString Condition="declRefBase == 0">DeclRef nullptr</DisplayString>
     <DisplayString Condition="declRefBase != 0">{*declRefBase}</DisplayString>
-    <!--
     <Expand>
-      <ExpandedItem>decl ? ($T1*)(decl) : ($T1*)0</ExpandedItem>
+      <ExpandedItem>declRefBase ? ($T1*)(declRefBase->decl) : ($T1*)0</ExpandedItem>
       <Synthetic Name="[Substitutions]">
         <Expand>
             <LinkedListItems>
-                <HeadPointer>substitutions.substitutions</HeadPointer>
+                <HeadPointer>declRefBase->substitutions</HeadPointer>
                 <NextPointer>outer</NextPointer>
                 <ValueNode>this</ValueNode>
             </LinkedListItems>
         </Expand>
       </Synthetic>
     </Expand>
-    -->
   </Type>
     <Type Name="Slang::DeclRefBase">
-      <SmartPointer Usage="Minimal">decl</SmartPointer>
       <DisplayString Condition="decl != 0 &amp;&amp; substitutions != 0">{*decl}{*substitutions}</DisplayString>
       <DisplayString Condition="decl != 0">{*decl}</DisplayString>
       <DisplayString Condition="decl == 0">DeclRefBase nullptr</DisplayString>
-      <!--
       <Expand>
           <ExpandedItem>decl</ExpandedItem>
           <Synthetic Name="[Substitutions]">
@@ -46,7 +41,6 @@
               </Expand>
           </Synthetic>
       </Expand>
-      -->
     </Type>
     <Type Name="Slang::GenericSubstitution">
         <DisplayString>GenSubst {(*genericDecl).nameAndLoc}</DisplayString>

--- a/source/slang/slang.natvis
+++ b/source/slang/slang.natvis
@@ -97,18 +97,6 @@
       </CustomListItems>
       <Item Name="[value]" Condition="m_op == kIROp_StringLit">((IRStringLit*)this)->value.stringVal.chars,[((IRStringLit*)this)->value.stringVal.numChars]s8</Item>
       <Item Name="[value]" Condition="m_op == kIROp_IntLit">((IRIntLit*)this)->value.intVal</Item>
-	  <!--
-      <Synthetic Name="[operands]">
-        <DisplayString>{{count = {operandCount}}}</DisplayString>
-        <Expand>
-          <Item Name="[count]">operandCount</Item>
-          <ArrayItems>
-            <Size>operandCount</Size>
-            <ValuePointer>(IRUse*)(&amp;(typeUse) + 1)</ValuePointer>
-          </ArrayItems>
-        </Expand>
-      </Synthetic>
-	  -->
       <CustomListItems MaxItemsPerView="10">
 	    <Variable Name="index" InitialValue="0"/>
 	    <Variable Name="nameDecoration" InitialValue="(IRInst*)nullptr"/>


### PR DESCRIPTION
This change simplifies the lookup logic in a type by scanning through the linearized inheritance list of the type instead of doing on-demand analysis of what base types and extensions can apply and recursively look into those scopes.

This avoids the repetitive work of testing sub type relationships or checking if an extension applies to a type, and therefore reduces the overall complexity of the type checking process, and drastically improves front-end performance.

With this change, the type checking time for a shader goes from 1.2s down to 0.33s. This should greatly improve application load time and speedup overall shader compilation.