### PR TITLE
Simplify Lookup and improve compiler performance.

### DIFF
--- a/source/core/core.natvis
+++ b/source/core/core.natvis
@@ -58,7 +58,7 @@
     <DisplayString>{{ size={m_count} }}</DisplayString>
     <Expand>
         <Item Name="[size]">m_count</Item>
-        <Item Name="[capacity]">m_bucketSizeMinusOne + 1</Item>
+        <Item Name="[capacity]">m_bucketCountMinusOne + 1</Item>
         <CustomListItems MaxItemsPerView="5000" ExcludeView="Test">
             <Variable Name="iBucket" InitialValue="0" />
             <Variable Name="pBucket" InitialValue="m_hashMap" />
@@ -67,12 +67,12 @@
             <Size>m_count</Size>
             <Exec>pBucket = m_hashMap</Exec>
             <Loop>
-                <If Condition="iBucket &gt;= m_bucketSizeMinusOne + 1">
+                <If Condition="iBucket &gt;= m_bucketCountMinusOne">
                     <Break/>
                 </If>
                 <Exec>
                     isDeleted = m_marks.m_buffer.m_count &gt; (iBucket*2+1)/32
-                      ? ((marks.m_buffer.m_buffer[(iBucket*2+1)/32]&amp;(1&lt;&lt;(iBucket*2+1)%32)) != 0)
+                    ? ((m_marks.m_buffer.m_buffer[(iBucket*2+1)/32]&amp;(1&lt;&lt;(iBucket*2+1)%32)) != 0)
                       : 0
                  </Exec>
                 <Exec>

--- a/source/core/core.natvis
+++ b/source/core/core.natvis
@@ -55,33 +55,33 @@
 </Type>
   
 <Type Name="Slang::Dictionary&lt;*,*&gt;">
-    <DisplayString>{{ size={_count} }}</DisplayString>
+    <DisplayString>{{ size={m_count} }}</DisplayString>
     <Expand>
-        <Item Name="[size]">_count</Item>
-        <Item Name="[capacity]">bucketSizeMinusOne + 1</Item>
+        <Item Name="[size]">m_count</Item>
+        <Item Name="[capacity]">m_bucketSizeMinusOne + 1</Item>
         <CustomListItems MaxItemsPerView="5000" ExcludeView="Test">
             <Variable Name="iBucket" InitialValue="0" />
-            <Variable Name="pBucket" InitialValue="hashMap" />
+            <Variable Name="pBucket" InitialValue="m_hashMap" />
             <Variable Name="isDeleted" InitialValue="0" />
             <Variable Name="isEmpty" InitialValue="0" />
-            <Size>_count</Size>
-            <Exec>pBucket = hashMap</Exec>
+            <Size>m_count</Size>
+            <Exec>pBucket = m_hashMap</Exec>
             <Loop>
-                <If Condition="iBucket &gt;= bucketSizeMinusOne + 1">
+                <If Condition="iBucket &gt;= m_bucketSizeMinusOne + 1">
                     <Break/>
                 </If>
                 <Exec>
-                    isDeleted = marks.m_buffer.m_count &gt; (iBucket*2+1)/32
+                    isDeleted = m_marks.m_buffer.m_count &gt; (iBucket*2+1)/32
                       ? ((marks.m_buffer.m_buffer[(iBucket*2+1)/32]&amp;(1&lt;&lt;(iBucket*2+1)%32)) != 0)
                       : 0
                  </Exec>
                 <Exec>
-                    isEmpty = marks.m_buffer.m_count &gt; (iBucket*2)/32
-                    ? ((marks.m_buffer.m_buffer[(iBucket*2)/32]&amp;(1&lt;&lt;(iBucket*2)%32)) == 0)
+                    isEmpty = m_marks.m_buffer.m_count &gt; (iBucket*2)/32
+                    ? ((m_marks.m_buffer.m_buffer[(iBucket*2)/32]&amp;(1&lt;&lt;(iBucket*2)%32)) == 0)
                     : 1
                 </Exec>
                 <If Condition="isDeleted+isEmpty==0">
-                    <Item>*(hashMap + iBucket)</Item>
+                    <Item>*(m_hashMap + iBucket)</Item>
                 </If>
                 <Exec>iBucket++</Exec>
             </Loop>
@@ -93,21 +93,21 @@
         <DisplayString>{{ size={dict._count} }}</DisplayString>
         <Expand>
             <LinkedListItems>
-                <Size>dict._count</Size>
-                <HeadPointer>dict.kvPairs.head</HeadPointer>
+                <Size>m_dict._count</Size>
+                <HeadPointer>m_dict.kvPairs.head</HeadPointer>
                 <NextPointer>next</NextPointer>
-                <ValueNode>Value</ValueNode>
+                <ValueNode>value</ValueNode>
             </LinkedListItems>
         </Expand>
     </Type>
     <Type Name="Slang::OrderedDictionary&lt;*,*&gt;">
-        <DisplayString>{{ size={_count} }}</DisplayString>
+        <DisplayString>{{ size={m_count} }}</DisplayString>
         <Expand>
             <LinkedListItems>
-                <Size>_count</Size>
-                <HeadPointer>kvPairs.head</HeadPointer>
+                <Size>m_count</Size>
+                <HeadPointer>m_kvPairs.head</HeadPointer>
                 <NextPointer>next</NextPointer>
-                <ValueNode>Value</ValueNode>
+                <ValueNode>value</ValueNode>
             </LinkedListItems>
         </Expand>
     </Type>

--- a/source/core/slang-dictionary.h
+++ b/source/core/slang-dictionary.h
@@ -191,20 +191,9 @@ namespace Slang
                 int newSize = (m_bucketCountMinusOne + 1) * 2;
                 if (newSize == 0)
                 {
-                    newSize = 16;
+                    newSize = 64;
                 }
-                Dictionary<TKey, TValue> newDict;
-                newDict.m_bucketCountMinusOne = newSize - 1;
-                newDict.m_hashMap = new KeyValuePair<TKey, TValue>[newSize];
-                newDict.m_marks.resizeAndClear(newSize * 2);
-                if (m_hashMap)
-                {
-                    for (auto& kvPair : *this)
-                    {
-                        newDict.add(_Move(kvPair));
-                    }
-                }
-                *this = _Move(newDict);
+                reserve(newSize);
             }
         }
 
@@ -342,6 +331,25 @@ namespace Slang
         {
             m_count = 0;
             m_marks.clear();
+        }
+
+        void reserve(int newSize)
+        {
+            if (newSize <= m_bucketCountMinusOne + 1)
+                return;
+
+            Dictionary<TKey, TValue> newDict;
+            newDict.m_bucketCountMinusOne = newSize - 1;
+            newDict.m_hashMap = new KeyValuePair<TKey, TValue>[newSize];
+            newDict.m_marks.resizeAndClear(newSize * 2);
+            if (m_hashMap)
+            {
+                for (auto& kvPair : *this)
+                {
+                    newDict.add(_Move(kvPair));
+                }
+            }
+            *this = _Move(newDict);
         }
 
         TValue* tryGetValueOrAdd(const TKey& key, const TValue& value)
@@ -785,7 +793,7 @@ namespace Slang
                 int newSize = (m_bucketCountMinusOne + 1) * 2;
                 if (newSize == 0)
                 {
-                    newSize = 16;
+                    newSize = 128;
                 }
                 OrderedDictionary<TKey, TValue> newDict;
                 newDict.m_bucketCountMinusOne = newSize - 1;

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -298,7 +298,7 @@ ArrayExpressionType* ASTBuilder::getArrayType(Type* elementType, IntVal* element
     {
         auto arrayGenericDecl = as<GenericDecl>(m_sharedASTBuilder->findMagicDecl("ArrayType"));
         auto arrayTypeDecl = arrayGenericDecl->inner;
-        auto substitutions = getOrCreate<GenericSubstitution>(arrayGenericDecl, elementType, elementCount);
+        auto substitutions = getOrCreateGenericSubstitution(nullptr, arrayGenericDecl, elementType, elementCount);
         result->declRef = getSpecializedDeclRef<Decl>(arrayTypeDecl, substitutions);
     }
     return result;
@@ -313,7 +313,7 @@ VectorExpressionType* ASTBuilder::getVectorType(
     {
         auto vectorGenericDecl = as<GenericDecl>(m_sharedASTBuilder->findMagicDecl("Vector"));
         auto vectorTypeDecl = vectorGenericDecl->inner;
-        auto substitutions = getOrCreate<GenericSubstitution>(vectorGenericDecl, elementType, elementCount);
+        auto substitutions = getOrCreateGenericSubstitution(nullptr, vectorGenericDecl, elementType, elementCount);
         result->declRef = getSpecializedDeclRef<Decl>(vectorTypeDecl, substitutions);
     }
     return result;
@@ -327,7 +327,8 @@ DifferentialPairType* ASTBuilder::getDifferentialPairType(
 
     auto typeDecl = genericDecl->inner;
 
-    auto substitutions = getOrCreate<GenericSubstitution>(
+    auto substitutions = getOrCreateGenericSubstitution(
+        nullptr,
         genericDecl,
         valueType,
         primalIsDifferentialWitness);
@@ -367,7 +368,8 @@ MeshOutputType* ASTBuilder::getMeshOutputTypeFromModifier(
 
     auto typeDecl = genericDecl->inner;
 
-    auto substitutions = getOrCreate<GenericSubstitution>(
+    auto substitutions = getOrCreateGenericSubstitution(
+        nullptr,
         genericDecl,
         elementType,
         maxElementCount);
@@ -392,7 +394,7 @@ DeclRef<Decl> ASTBuilder::getBuiltinDeclRef(const char* builtinMagicTypeName, Va
         Substitutions* subst = nullptr;
         if (genericArg)
         {
-            subst = getOrCreate<GenericSubstitution>(genericDecl, genericArg);
+            subst = getOrCreateGenericSubstitution(nullptr, genericDecl, genericArg);
         }
         return getSpecializedDeclRef(decl, subst);
     }
@@ -587,6 +589,11 @@ top:
     transitiveWitness->midToSup = bIsSubtypeOfCWitness;
 
     return transitiveWitness;
+}
+
+ThisTypeSubtypeWitness* ASTBuilder::getThisTypeSubtypeWitness(Type* subType, Type* superType)
+{
+    return getOrCreate<ThisTypeSubtypeWitness>(subType, superType);
 }
 
 SubtypeWitness* ASTBuilder::getExtractFromConjunctionSubtypeWitness(

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -297,11 +297,6 @@ public:
         return getOrCreate<ConstantIntVal>(type, value);
     }
 
-    DeclRefType* getOrCreateDeclRefType(DeclRefBase* declRef)
-    {
-        return getOrCreate<DeclRefType>(declRef);
-    }
-
     GenericSubstitution* getOrCreateGenericSubstitution(GenericDecl* decl, const List<Val*>& args, Substitutions* outer)
     {
         NodeDesc desc;

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -297,7 +297,7 @@ public:
         return getOrCreate<ConstantIntVal>(type, value);
     }
 
-    GenericSubstitution* getOrCreateGenericSubstitution(GenericDecl* decl, const List<Val*>& args, Substitutions* outer)
+    GenericSubstitution* getOrCreateGenericSubstitution(Substitutions* outer, GenericDecl* decl, ArrayView<Val*> args)
     {
         NodeDesc desc;
         desc.type = GenericSubstitution::kType;
@@ -319,6 +319,20 @@ public:
         }
         return result;
     }
+
+    GenericSubstitution* getOrCreateGenericSubstitution(Substitutions* outer, GenericDecl* decl, const List<Val*>& args)
+    {
+        return getOrCreateGenericSubstitution(outer, decl, args.getArrayView());
+    }
+
+    template<typename... Args>
+    GenericSubstitution* getOrCreateGenericSubstitution(Substitutions* outer, GenericDecl* decl, Args... args)
+    {
+        List<Val*> vals;
+        addToList(vals, args...);
+        return getOrCreateGenericSubstitution(outer, decl, vals.getArrayView());
+    }
+
 
     ThisTypeSubstitution* getOrCreateThisTypeSubstitution(InterfaceDecl* interfaceDecl, SubtypeWitness* subtypeWitness, Substitutions* outer)
     {
@@ -438,6 +452,9 @@ public:
     SubtypeWitness* getTransitiveSubtypeWitness(
         SubtypeWitness*    aIsSubtypeOfBWitness,
         SubtypeWitness*    bIsSubtypeOfCWitness);
+
+        /// Produce a witness that `ThisType(IFoo) <: IFoo`.
+    ThisTypeSubtypeWitness* getThisTypeSubtypeWitness(Type* subType, Type* superType);
 
         /// Produce a witness that `T <: L` or `T <: R` given `T <: L&R`
     SubtypeWitness* getExtractFromConjunctionSubtypeWitness(

--- a/source/slang/slang-ast-print.cpp
+++ b/source/slang/slang-ast-print.cpp
@@ -176,7 +176,7 @@ void ASTPrinter::_addDeclPathRec(const DeclRef<Decl>& declRef, Index depth)
         if (genSubst)
         {
             SLANG_RELEASE_ASSERT(genSubst);
-            SLANG_RELEASE_ASSERT(genSubst->genericDecl == parentGenericDeclRef.getDecl());
+            SLANG_RELEASE_ASSERT(genSubst->getGenericDecl() == parentGenericDeclRef.getDecl());
 
             // If the name we printed previously was an operator
             // that ends with `<`, then immediately printing the

--- a/source/slang/slang-ast-substitutions.cpp
+++ b/source/slang/slang-ast-substitutions.cpp
@@ -64,7 +64,7 @@ Substitutions* GenericSubstitution::_applySubstitutionsShallowOverride(ASTBuilde
 
     (*ioDiff)++;
 
-    auto substSubst = astBuilder->getOrCreateGenericSubstitution(genericDecl, substArgs, substOuter);
+    auto substSubst = astBuilder->getOrCreateGenericSubstitution(substOuter, genericDecl, substArgs);
     return substSubst;
 }
 

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -96,6 +96,7 @@ namespace Slang
         kConversionCost_CastToInterface = 50,
 
         // Conversion that is lossless and keeps the "kind" of the value the same
+        kConversionCost_BoolToInt = 120,   // Converting bool to int has lower cost than other integer types to prevent ambiguity.
         kConversionCost_RankPromotion = 150,
         kConversionCost_NoneToOptional = 150,
         kConversionCost_ValToOptional = 150,

--- a/source/slang/slang-ast-type.cpp
+++ b/source/slang/slang-ast-type.cpp
@@ -772,10 +772,8 @@ DeclRef<InterfaceDecl> ExtractExistentialType::getSpecializedInterfaceDeclRef()
 
     SubtypeWitness* openedWitness = getSubtypeWitness();
 
-    ThisTypeSubstitution* openedThisType = m_astBuilder->create<ThisTypeSubstitution>();
-    openedThisType->outer = originalInterfaceDeclRef.getSubst();
-    openedThisType->interfaceDecl = interfaceDecl;
-    openedThisType->witness = openedWitness;
+    ThisTypeSubstitution* openedThisType = m_astBuilder->getOrCreateThisTypeSubstitution(
+        interfaceDecl, openedWitness, originalInterfaceDeclRef.getSubst());
 
     DeclRef<InterfaceDecl> specialiedInterfaceDeclRef = m_astBuilder->getSpecializedDeclRef<InterfaceDecl>(interfaceDecl, openedThisType);
 

--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -118,7 +118,7 @@ HashCode GenericParamIntVal::_getHashCodeOverride()
 Val* maybeSubstituteGenericParam(Val* paramVal, Decl* paramDecl, SubstitutionSet subst, int* ioDiff)
 {
     // search for a substitution that might apply to us
-    for (auto s = subst.substitutions; s; s = s->outer)
+    for (auto s = subst.substitutions; s; s = s->getOuter())
     {
         auto genSubst = as<GenericSubstitution>(s);
         if (!genSubst)
@@ -126,7 +126,7 @@ Val* maybeSubstituteGenericParam(Val* paramVal, Decl* paramDecl, SubstitutionSet
 
         // the generic decl associated with the substitution list must be
         // the generic decl that declared this parameter
-        auto genericDecl = genSubst->genericDecl;
+        auto genericDecl = genSubst->getGenericDecl();
         if (genericDecl != paramDecl->parentDecl)
             continue;
 
@@ -261,13 +261,13 @@ Val* DeclaredSubtypeWitness::_substituteImplOverride(ASTBuilder* astBuilder, Sub
         auto genConstraintDecl = genConstraintDeclRef.getDecl();
 
         // search for a substitution that might apply to us
-        for (auto s = subst.substitutions; s; s = s->outer)
+        for (auto s = subst.substitutions; s; s = s->getOuter())
         {
             if (auto genericSubst = as<GenericSubstitution>(s))
             {
                 // the generic decl associated with the substitution list must be
                 // the generic decl that declared this parameter
-                auto genericDecl = genericSubst->genericDecl;
+                auto genericDecl = genericSubst->getGenericDecl();
                 if (genericDecl != genConstraintDecl->parentDecl)
                     continue;
 

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -407,6 +407,12 @@ class TaggedUnionSubtypeWitness : public SubtypeWitness
 class ThisTypeSubtypeWitness : public SubtypeWitness
 {
     SLANG_AST_CLASS(ThisTypeSubtypeWitness)
+
+    ThisTypeSubtypeWitness(Type* subType, Type* supType)
+    {
+        sub = subType;
+        sup = supType;
+    }
 };
 
     /// A witness of the fact that a user provided "__Dynamic" type argument is a

--- a/source/slang/slang-check-conformance.cpp
+++ b/source/slang/slang-check-conformance.cpp
@@ -50,6 +50,18 @@ namespace Slang
     }
 
     SubtypeWitness* SemanticsVisitor::isSubtype(
+        Type* subType,
+        Type* superType)
+    {
+        SubtypeWitness* result = nullptr;
+        if (getShared()->tryGetSubtypeWitness(subType, superType, result))
+            return result;
+        result = checkAndConstructSubtypeWitness(subType, superType);
+        getShared()->cacheSubtypeWitness(subType, superType, result);
+        return result;
+    }
+
+    SubtypeWitness* SemanticsVisitor::checkAndConstructSubtypeWitness(
         Type*                   subType,
         Type*                   superType)
     {
@@ -92,8 +104,9 @@ namespace Slang
         // For now we are continuing to conflate all the subtype-ish relationships but not
         // tangling convertibility into it.
 
-        // TODO: Evaluate whether it is beneficial to memo-cache
-        // the results of subtype tests on the `SharedSemanticsContext`.
+        SubtypeWitness* result = nullptr;
+        if (getShared()->tryGetSubtypeWitness(subType, superType, result))
+            return result;
 
         // In the common case, we can use the pre-computed inheritance information for `subType`
         // to enumerate all the types it transitively inherits from.

--- a/source/slang/slang-check-conformance.cpp
+++ b/source/slang/slang-check-conformance.cpp
@@ -104,10 +104,6 @@ namespace Slang
         // For now we are continuing to conflate all the subtype-ish relationships but not
         // tangling convertibility into it.
 
-        SubtypeWitness* result = nullptr;
-        if (getShared()->tryGetSubtypeWitness(subType, superType, result))
-            return result;
-
         // In the common case, we can use the pre-computed inheritance information for `subType`
         // to enumerate all the types it transitively inherits from.
         //

--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -457,7 +457,7 @@ namespace Slang
         // apply the substitutions we already know...
 
         GenericSubstitution* solvedSubst = m_astBuilder->getOrCreateGenericSubstitution(
-            genericDeclRef.getDecl(), args, genericDeclRef.getSubst());
+            genericDeclRef.getSubst(), genericDeclRef.getDecl(), args.getArrayView());
 
         for( auto constraintDecl : genericDeclRef.getDecl()->getMembersOfType<GenericTypeConstraintDecl>() )
         {
@@ -510,7 +510,7 @@ namespace Slang
         }
 
         resultSubst = m_astBuilder->getOrCreateGenericSubstitution(
-            genericDeclRef.getDecl(), args, genericDeclRef.getSubst());
+            genericDeclRef.getSubst(), genericDeclRef.getDecl(), args);
         return resultSubst;
     }
 
@@ -633,7 +633,7 @@ namespace Slang
         auto fstGen = fst;
         auto sndGen = snd;
         // They must be specializing the same generic
-        if (fstGen->genericDecl != sndGen->genericDecl)
+        if (fstGen->getGenericDecl() != sndGen->getGenericDecl())
             return false;
 
         // Their arguments must unify
@@ -649,7 +649,7 @@ namespace Slang
         }
 
         // Their "base" specializations must unify
-        if (!tryUnifySubstitutions(constraints, fstGen->outer, sndGen->outer))
+        if (!tryUnifySubstitutions(constraints, fstGen->getOuter(), sndGen->getOuter()))
         {
             okay = false;
         }

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -6535,6 +6535,7 @@ namespace Slang
         // Invalidate the cached inheritanceInfo.
         m_mapTypeToInheritanceInfo.clear();
         m_mapDeclRefToInheritanceInfo.clear();
+        m_mapTypePairToSubtypeWitness.clear();
     }
     
     void SharedSemanticsContext::_addCandidateExtensionsFromModule(ModuleDecl* moduleDecl)

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1410,7 +1410,7 @@ namespace Slang
             if (auto declRefType = as<DeclRefType>(sharedTypeExpr->base))
             {
                 auto subst = createDefaultSubstitutions(m_astBuilder, this, declRefType->declRef.getDecl());
-                auto newType = m_astBuilder->getOrCreateDeclRefType(m_astBuilder->getSpecializedDeclRef(declRefType->declRef.getDecl(), subst));
+                auto newType = DeclRefType::create(m_astBuilder, m_astBuilder->getSpecializedDeclRef(declRefType->declRef.getDecl(), subst));
                 sharedTypeExpr->base.type = newType;
                 if (auto typetype = as<TypeType>(typeExp.exp->type))
                     typetype->type = newType;
@@ -1470,7 +1470,7 @@ namespace Slang
                 substSet = declRefType->declRef.getSubst();
             }
         }
-        auto satisfyingType = m_astBuilder->getOrCreateDeclRefType(m_astBuilder->getSpecializedDeclRef(aggTypeDecl, substSet));
+        auto satisfyingType = DeclRefType::create(m_astBuilder, m_astBuilder->getSpecializedDeclRef(aggTypeDecl, substSet));
 
         // Helper function to add a `diffType` field into the synthesized type for the original
         // `member`.
@@ -6533,6 +6533,10 @@ namespace Slang
         //
         m_candidateExtensionListsBuilt = false;
         m_mapTypeDeclToCandidateExtensions.clear();
+
+        // Invalidate the cached inheritanceInfo.
+        m_mapTypeToInheritanceInfo.clear();
+        m_mapDeclRefToInheritanceInfo.clear();
     }
     
     void SharedSemanticsContext::_addCandidateExtensionsFromModule(ModuleDecl* moduleDecl)

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -539,7 +539,7 @@ namespace Slang
                 auto typeDef = m_astBuilder->create<TypeAliasDecl>();
                 typeDef->nameAndLoc.name = getName("Differential");
                 auto declRef = createDefaultSubstitutionsIfNeeded(m_astBuilder, this, makeDeclRef(structDecl));
-                typeDef->type.type = m_astBuilder->getOrCreateDeclRefType(declRef);
+                typeDef->type.type = DeclRefType::create(m_astBuilder, declRef);
                 typeDef->parentDecl = structDecl;
                 structDecl->members.add(typeDef);
             }
@@ -1052,7 +1052,7 @@ namespace Slang
             {
                 foreachDirectOrExtensionMemberOfType<InheritanceDecl>(this, aggTypeDeclRef, [&](DeclRef<InheritanceDecl> member)
                     {
-                        auto subType = m_astBuilder->getOrCreateDeclRefType(member);
+                        auto subType = DeclRefType::create(m_astBuilder, member);
                         maybeRegisterDifferentiableTypeImplRecursive(m_astBuilder, subType);
                     });
                 foreachDirectOrExtensionMemberOfType<VarDeclBase>(this, aggTypeDeclRef, [&](DeclRef<VarDeclBase> member)

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -1061,7 +1061,7 @@ namespace Slang
                         maybeRegisterDifferentiableTypeImplRecursive(m_astBuilder, fieldType);
                     });
             }
-            for (auto subst = declRefType->declRef.getSubst(); subst; subst = subst->outer)
+            for (auto subst = declRefType->declRef.getSubst(); subst; subst = subst->getOuter())
             {
                 if (auto genSubst = as<GenericSubstitution>(subst))
                 {
@@ -1507,7 +1507,7 @@ namespace Slang
 
         if (isInterfaceRequirement(decl))
         {
-            for (auto subst = declRef.getSubst(); subst; subst = subst->outer)
+            for (auto subst = declRef.getSubst(); subst; subst = subst->getOuter())
             {
                 if (auto thisTypeSubst = as<ThisTypeSubstitution>(subst))
                 {

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1613,7 +1613,7 @@ namespace Slang
             DeclRef<FuncDecl> fst,
             DeclRef<FuncDecl> snd);
 
-        GenericSubstitution* createDummySubstitutions(
+        List<Val*> getDefaultSubstitutionArgs(
             GenericDecl* genericDecl);
 
         Result checkRedeclaration(Decl* newDecl, Decl* oldDecl);

--- a/source/slang/slang-check-inheritance.cpp
+++ b/source/slang/slang-check-inheritance.cpp
@@ -32,6 +32,9 @@ namespace Slang
         auto info = _calcInheritanceInfo(type);
         m_mapTypeToInheritanceInfo[type] = info;
 
+        getSession()->m_typeDictionarySize = Math::Max(
+            getSession()->m_typeDictionarySize, (int)m_mapTypeToInheritanceInfo.getCount());
+
         return info;
     }
 

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -1205,9 +1205,9 @@ namespace Slang
             }
             GenericSubstitution* genericSubst =
                 getLinkage()->getASTBuilder()->getOrCreateGenericSubstitution(
+                    genericDeclRef.getSubst(),
                     genericDeclRef.getDecl(),
-                    genericArgs,
-                    genericDeclRef.getSubst());
+                    genericArgs.getArrayView());
             ASTBuilder* astBuilder = getLinkage()->getASTBuilder();
 
             for (auto constraintDecl : getMembersOfType<GenericTypeConstraintDecl>(
@@ -1235,9 +1235,9 @@ namespace Slang
 
             genericSubst =
                 getLinkage()->getASTBuilder()->getOrCreateGenericSubstitution(
+                    genericDeclRef.getSubst(),
                     genericDeclRef.getDecl(),
-                    genericArgs,
-                    genericDeclRef.getSubst());
+                    genericArgs);
             specializedFuncDeclRef = astBuilder->getSpecializedDeclRef(specializedFuncDeclRef.getDecl(), genericSubst);
         }
 

--- a/source/slang/slang-check-type.cpp
+++ b/source/slang/slang-check-type.cpp
@@ -188,7 +188,7 @@ namespace Slang
         }
 
         GenericSubstitution* subst = m_astBuilder->getOrCreateGenericSubstitution(
-            genericDeclRef.getDecl(), evaledArgs, genericDeclRef.getSubst());
+            genericDeclRef.getSubst(), genericDeclRef.getDecl(), evaledArgs);
 
         DeclRef<Decl> innerDeclRef = m_astBuilder->getSpecializedDeclRef(getInner(genericDeclRef), subst);
         return DeclRefType::create(m_astBuilder, innerDeclRef);

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -3062,6 +3062,7 @@ namespace Slang
             /// For parsing command line options
         CommandOptions m_commandOptions;
 
+        int m_typeDictionarySize = 0;
     private:
 
         void _initCodeGenTransitionMap();

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -3593,8 +3593,7 @@ struct IRTypeLegalizationPass
                 // at each step, and swap in an empty work list to be added
                 // to with any new instructions.
                 //
-                List<IRInst*> workListCopy;
-                Swap(workListCopy, workList);
+                List<IRInst*> workListCopy = _Move(workList);
 
                 resetScratchDataBit(module->getModuleInst(), kHasBeenAddedScratchBitIndex);
 

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -3574,42 +3574,32 @@ struct IRTypeLegalizationPass
         // In order to process an entire module, we start by adding the
         // root module insturction to our work list, and then we will
         // proceed to process instructions until the work list goes dry.
-        // The entire process is repeated until no more changes can be
-        // made to the module.
-        //
-        for (;;)
+
+        addToWorkList(module->getModuleInst());
+        while( workList.getCount() != 0 )
         {
-            auto lastReplacedInstCount = context->replacedInstructions.getCount();
-            addToWorkList(module->getModuleInst());
-            while( workList.getCount() != 0 )
+            // The order of items in the work list is signficiant;
+            // later entries could depend on earlier ones. As such, we
+            // cannot just do something like the `fastRemoveAt(...)`
+            // operation that could potentially lead to instructions
+            // being processed in a different order than they were added.
+            //
+            // Instead, we will make a copy of the current work list
+            // at each step, and swap in an empty work list to be added
+            // to with any new instructions.
+            //
+            List<IRInst*> workListCopy = _Move(workList);
+
+            resetScratchDataBit(module->getModuleInst(), kHasBeenAddedScratchBitIndex);
+
+            // Now we simply process each instruction on the copy of
+            // the work list, knowing that `processInst` may add additional
+            // instructions to the original work list.
+            //
+            for( auto inst : workListCopy )
             {
-                // The order of items in the work list is signficiant;
-                // later entries could depend on earlier ones. As such, we
-                // cannot just do something like the `fastRemoveAt(...)`
-                // operation that could potentially lead to instructions
-                // being processed in a different order than they were added.
-                //
-                // Instead, we will make a copy of the current work list
-                // at each step, and swap in an empty work list to be added
-                // to with any new instructions.
-                //
-                List<IRInst*> workListCopy = _Move(workList);
-
-                resetScratchDataBit(module->getModuleInst(), kHasBeenAddedScratchBitIndex);
-
-                // Now we simply process each instruction on the copy of
-                // the work list, knowing that `processInst` may add additional
-                // instructions to the original work list.
-                //
-                for( auto inst : workListCopy )
-                {
-                    processInst(inst);
-                }
+                processInst(inst);
             }
-            
-            // Any changes made? Run the process again.
-            if (lastReplacedInstCount == context->replacedInstructions.getCount())
-                break;
         }
 
         // After we are done, there might be various instructions that

--- a/source/slang/slang-ir-lower-generic-function.cpp
+++ b/source/slang/slang-ir-lower-generic-function.cpp
@@ -175,6 +175,7 @@ namespace Slang
             {
                 auto paramType = funcType->getOperand(i);
                 auto loweredParamType = sharedContext->lowerType(builder, paramType, typeMapping, nullptr);
+                SLANG_ASSERT(loweredParamType);
                 translated = translated || (loweredParamType != paramType);
                 newOperands.add(loweredParamType);
             }

--- a/source/slang/slang-ir-redundancy-removal.cpp
+++ b/source/slang/slang-ir-redundancy-removal.cpp
@@ -10,6 +10,10 @@ struct RedundancyRemovalContext
     RefPtr<IRDominatorTree> dom;
     bool isMovableInst(IRInst* inst)
     {
+        // Don't try to modify hoistable insts, they are already globally deduplicated.
+        if (getIROpInfo(inst->getOp()).isHoistable())
+            return false;
+
         switch (inst->getOp())
         {
         case kIROp_Add:
@@ -73,11 +77,6 @@ struct RedundancyRemovalContext
         case kIROp_ExtractExistentialType:
         case kIROp_ExtractExistentialValue:
         case kIROp_ExtractExistentialWitnessTable:
-        case kIROp_PtrType:
-        case kIROp_ArrayType:
-        case kIROp_FuncType:
-        case kIROp_InOutType:
-        case kIROp_OutType:
             return true;
         case kIROp_Call:
             return isPureFunctionalCall(as<IRCall>(inst));

--- a/source/slang/slang-ir-simplify-cfg.cpp
+++ b/source/slang/slang-ir-simplify-cfg.cpp
@@ -509,7 +509,11 @@ static bool simplifyBoolPhiParams(IRBlock* block)
 
     Array<IRBlock*, 2> preds;
     for (auto pred : block->getPredecessors())
+    {
+        if (pred->getTerminator()->getOp() != kIROp_unconditionalBranch)
+            return false;
         preds.add(pred);
+    }
 
     IRBlock* ifElseBlock = nullptr;
     if (preds[0]->getPredecessors().getCount() != 1)

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -51,6 +51,14 @@ struct SpecializationContext
 
     bool changed = false;
 
+    SpecializationContext(IRModule* inModule)
+        : module(inModule)
+    {
+        genericSpecializations.reserve(16384);
+        existentialSpecializedFuncs.reserve(16384);
+        existentialSpecializedStructs.reserve(16384);
+    }
+
     // We know that we can only perform generic specialization when all
     // of the arguments to a generic are also fully specialized.
     // The "is fully specialized" condition is something we
@@ -2360,8 +2368,7 @@ bool specializeModule(
     DiagnosticSink* sink)
 {
     SLANG_PROFILE;
-    SpecializationContext context;
-    context.module = module;
+    SpecializationContext context(module);
     context.sink = sink;
     context.processModule();
     return context.changed;

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -7,7 +7,6 @@
 #include "slang-ir-ssa-simplification.h"
 #include "slang-ir-lower-witness-lookup.h"
 #include "slang-ir-dce.h"
-#include "slang-ir-util.h"
 #include "../core/slang-performance-profiler.h"
 
 namespace Slang
@@ -37,10 +36,10 @@ namespace Slang
 struct SpecializationContext;
 
 IRInst* specializeGenericImpl(
-    IRGeneric*              genericVal,
-    IRSpecialize*           specializeInst,
-    IRModule*               module,
-    SpecializationContext*  context);
+    IRGeneric* genericVal,
+    IRSpecialize* specializeInst,
+    IRModule* module,
+    SpecializationContext* context);
 
 struct SpecializationContext
 {
@@ -51,14 +50,6 @@ struct SpecializationContext
 
     bool changed = false;
 
-    SpecializationContext(IRModule* inModule)
-        : module(inModule)
-    {
-        genericSpecializations.reserve(16384);
-        existentialSpecializedFuncs.reserve(16384);
-        existentialSpecializedStructs.reserve(16384);
-    }
-
     // We know that we can only perform generic specialization when all
     // of the arguments to a generic are also fully specialized.
     // The "is fully specialized" condition is something we
@@ -66,29 +57,21 @@ struct SpecializationContext
     // specialized-ness of an instruction depends on the
     // fully-specialized-ness of its operands.
     //
-    // We will use an inst's scratchData to represent whether or not
-    // the inst is considered as fully specialized.
+    // We will build an explicit hash set to encode those
+    // instructions that are fully specialized.
     //
-    void setFullySpecializedBit(IRInst* inst)
+    HashSet<IRInst*>& fullySpecializedInsts;
+
+    SpecializationContext(IRModule* inModule)
+        : fullySpecializedInsts(*module->getContainerPool().getHashSet<IRInst>())
+        , cleanInsts(*module->getContainerPool().getHashSet<IRInst>())
+        , module(inModule)
     {
-        inst->scratchData |= 1;
     }
-    bool getFullySpecializedBit(IRInst* inst)
-    {
-        return (inst->scratchData & 1) != 0;
-    }
-    void setCleanBit(IRInst* inst)
-    {
-        inst->scratchData |= 2;
-    }
-    void resetCleanBit(IRInst* inst)
-    {
-        inst->scratchData &= (~2);
-    }
-    bool getCleanBit(IRInst* inst)
-    {
-        return (inst->scratchData & 2) != 0;
-    }
+
+    // An instruction is then fully specialized if and only
+    // if it is in our set.
+    //
     bool isInstFullySpecialized(
         IRInst* inst)
     {
@@ -135,7 +118,7 @@ struct SpecializationContext
             }
         }
 
-        return getFullySpecializedBit(inst);
+        return fullySpecializedInsts.contains(inst);
     }
 
     // When an instruction isn't fully specialized, but its operands *are*
@@ -143,16 +126,16 @@ struct SpecializationContext
     // a query to check for the "all operands fully specialized" case.
     //
     bool areAllOperandsFullySpecialized(
-        IRInst*                     inst)
+        IRInst* inst)
     {
-        if(!isInstFullySpecialized(inst->getFullType()))
+        if (!isInstFullySpecialized(inst->getFullType()))
             return false;
 
         UInt operandCount = inst->getOperandCount();
-        for(UInt ii = 0; ii < operandCount; ++ii)
+        for (UInt ii = 0; ii < operandCount; ++ii)
         {
             IRInst* operand = inst->getOperand(ii);
-            if(!isInstFullySpecialized(operand))
+            if (!isInstFullySpecialized(operand))
                 return false;
         }
 
@@ -164,6 +147,7 @@ struct SpecializationContext
     // whether generic, existential, etc.
     //
     OrderedHashSet<IRInst*> workList;
+    HashSet<IRInst*>& cleanInsts;
 
     void addToWorkList(
         IRInst* inst)
@@ -180,16 +164,16 @@ struct SpecializationContext
         // because it doesn't make sense to perform specialization
         // on such code.
         //
-        for( auto ii = inst->getParent(); ii; ii = ii->getParent() )
+        for (auto ii = inst->getParent(); ii; ii = ii->getParent())
         {
-            if(as<IRGeneric>(ii))
+            if (as<IRGeneric>(ii))
                 return;
         }
 #endif
 
         if (workList.add(inst))
         {
-            resetCleanBit(inst);
+            cleanInsts.remove(inst);
 
             addUsersToWorkList(inst);
         }
@@ -203,10 +187,10 @@ struct SpecializationContext
     void addUsersToWorkList(
         IRInst* inst)
     {
-        for( auto use = inst->firstUse; use; use = use->nextUse )
+        for (auto use = inst->firstUse; use; use = use->nextUse)
         {
             auto user = use->getUser();
-            
+
             addToWorkList(user);
         }
     }
@@ -217,9 +201,9 @@ struct SpecializationContext
     void markInstAsFullySpecialized(
         IRInst* inst)
     {
-        if(getFullySpecializedBit(inst))
+        if (fullySpecializedInsts.contains(inst))
             return;
-        setFullySpecializedBit(inst);
+        fullySpecializedInsts.add(inst);
 
         // If we know that an instruction is fully specialized,
         // then we should start to consider its uses and children
@@ -255,8 +239,8 @@ struct SpecializationContext
     // instruction.
     //
     IRInst* specializeGeneric(
-        IRGeneric*      genericVal,
-        IRSpecialize*   specializeInst)
+        IRGeneric* genericVal,
+        IRSpecialize* specializeInst)
     {
         // First, we want to see if an existing specialization
         // has already been made. To do that we will construct a key
@@ -271,7 +255,7 @@ struct SpecializationContext
         Key key;
         key.vals.add(specializeInst->getBase());
         UInt argCount = specializeInst->getArgCount();
-        for( UInt ii = 0; ii < argCount; ++ii )
+        for (UInt ii = 0; ii < argCount; ++ii)
         {
             key.vals.add(specializeInst->getArg(ii));
         }
@@ -282,7 +266,7 @@ struct SpecializationContext
             // If one is found, our work is done.
             //
             IRInst* specializedVal = nullptr;
-            if(genericSpecializations.tryGetValue(key, specializedVal))
+            if (genericSpecializations.tryGetValue(key, specializedVal))
                 return specializedVal;
         }
 
@@ -326,7 +310,7 @@ struct SpecializationContext
     // by looking at whether it is a definition or a declaration.
     //
     bool canSpecializeGeneric(
-        IRGeneric*  generic)
+        IRGeneric* generic)
     {
         // It is possible to have multiple "layers" of generics
         // (e.g., when a generic function is nested in a generic
@@ -335,20 +319,20 @@ struct SpecializationContext
         // something that looks like a definition.
         //
         IRGeneric* g = generic;
-        for(;;)
+        for (;;)
         {
             // We can't specialize a generic if it is marked as
             // being imported from an external module (in which
             // case its definition is not available to us).
             //
-            if(!isDefinition(g))
+            if (!isDefinition(g))
                 return false;
 
             // Given the generic `g`, we will find the value
             // it appears to return in its body.
             //
             auto val = findGenericReturnVal(g);
-            if(!val)
+            if (!val)
                 return false;
 
             // If `g` returns an inner generic, then we need
@@ -369,7 +353,7 @@ struct SpecializationContext
             // by having the linking step strip/skip decorations
             // that aren't applicable to the chosen target at link time.
             //
-            if(as<IRStructType>(val) && val->findDecoration<IRTargetIntrinsicDecoration>())
+            if (as<IRStructType>(val) && val->findDecoration<IRTargetIntrinsicDecoration>())
                 return false;
 
             // Once we've found the leaf value that will be produced
@@ -392,7 +376,7 @@ struct SpecializationContext
         // operands to the `speicalize(...)` instruction are
         // themselves fully specialized.
         //
-        if(!areAllOperandsFullySpecialized(specInst))
+        if (!areAllOperandsFullySpecialized(specInst))
             return false;
 
         // The invariant that the arguments are fully specialized
@@ -405,13 +389,13 @@ struct SpecializationContext
         //
         auto baseVal = specInst->getBase();
         auto genericVal = as<IRGeneric>(baseVal);
-        if(!genericVal)
+        if (!genericVal)
             return false;
 
         // We can also only specialize a generic if it
         // represents a definition rather than a declaration.
         //
-        if(!canSpecializeGeneric(genericVal))
+        if (!canSpecializeGeneric(genericVal))
         {
             // We have to consider a special case here if baseVal is
             // an intrinsic, and contains a custom differential. 
@@ -538,7 +522,7 @@ struct SpecializationContext
         // since values are an important class of instruction we want
         // to deduplicate.
 
-        switch(inst->getOp())
+        switch (inst->getOp())
         {
         default:
             // The default case is that an instruction can
@@ -574,37 +558,37 @@ struct SpecializationContext
             // case where this code path first showed up
             // as necessary was `RayQuery<>`)
             //
+        {
+            auto specialize = cast<IRSpecialize>(inst);
+            auto base = specialize->getBase();
+            if (auto generic = as<IRGeneric>(base))
             {
-                auto specialize = cast<IRSpecialize>(inst);
-                auto base = specialize->getBase();
-                if( auto generic = as<IRGeneric>(base) )
+                // If the thing being specialized can be resolved,
+                // *and* it is a target intrinsic, ...
+                //
+                if (auto result = findGenericReturnVal(generic))
                 {
-                    // If the thing being specialized can be resolved,
-                    // *and* it is a target intrinsic, ...
-                    //
-                    if( auto result = findGenericReturnVal(generic) )
+                    if (result->findDecoration<IRTargetIntrinsicDecoration>())
                     {
-                        if( result->findDecoration<IRTargetIntrinsicDecoration>() )
-                        {
-                            // ... then we should consider the instruction as
-                            // "fully specialized" in the same cases as for
-                            // any ordinary instruciton.
-                            //
+                        // ... then we should consider the instruction as
+                        // "fully specialized" in the same cases as for
+                        // any ordinary instruciton.
+                        //
 
-                            if( areAllOperandsFullySpecialized(inst) )
-                            {
-                                markInstAsFullySpecialized(inst);
-                            }
-                            return;
+                        if (areAllOperandsFullySpecialized(inst))
+                        {
+                            markInstAsFullySpecialized(inst);
                         }
+                        return;
                     }
                 }
-
-                // Otherwise, a `specialize` instruction falls into
-                // the case of instructions that should never be
-                // considered to be fully specialized.
             }
-            break;
+
+            // Otherwise, a `specialize` instruction falls into
+            // the case of instructions that should never be
+            // considered to be fully specialized.
+        }
+        break;
         }
     }
 
@@ -613,9 +597,9 @@ struct SpecializationContext
     // is appropriate based on its opcode.
     //
     bool maybeSpecializeInst(
-        IRInst*                     inst)
+        IRInst* inst)
     {
-        switch(inst->getOp())
+        switch (inst->getOp())
         {
         default:
             // By default we assume that specialization is
@@ -696,7 +680,7 @@ struct SpecializationContext
         // operation that will yield such a table.
         //
         auto witnessTable = as<IRWitnessTable>(lookupInst->getWitnessTable());
-        if(!witnessTable)
+        if (!witnessTable)
             return false;
 
         // Because we have a concrete witness table, we can
@@ -711,7 +695,7 @@ struct SpecializationContext
         // we leave "correct" but unspecialized code if
         // we cannot find a concrete value to use.
         //
-        if(!satisfyingVal)
+        if (!satisfyingVal)
             return false;
 
         // At this point, we know that `satisfyingVal` is what
@@ -737,13 +721,13 @@ struct SpecializationContext
     //
     IRInst* findWitnessVal(
         IRWitnessTable* witnessTable,
-        IRInst*         requirementKey)
+        IRInst* requirementKey)
     {
         // A witness table is basically just a container
         // for key-value pairs, and so the best we can
         // do for now is a naive linear search.
         //
-        for( auto entry : witnessTable->getEntries() )
+        for (auto entry : witnessTable->getEntries())
         {
             if (requirementKey == entry->getRequirementKey())
             {
@@ -897,9 +881,6 @@ struct SpecializationContext
         for (;;)
         {
             bool iterChanged = false;
-
-            initializeScratchData(module->getModuleInst());
-
             addToWorkList(module->getModuleInst());
 
             while (workList.getCount() != 0)
@@ -912,7 +893,7 @@ struct SpecializationContext
 
                     workList.removeLast();
 
-                    setCleanBit(inst);
+                    cleanInsts.add(inst);
 
                     // For each instruction we process, we want to perform
                     // a few steps.
@@ -985,12 +966,12 @@ struct SpecializationContext
 
     void addDirtyInstsToWorkListRec(IRInst* inst)
     {
-        if( !getCleanBit(inst) )
+        if (!cleanInsts.contains(inst))
         {
             addToWorkList(inst);
         }
 
-        for(auto child = inst->getLastChild(); child; child = child->getPrevInst())
+        for (auto child = inst->getLastChild(); child; child = child->getPrevInst())
         {
             addDirtyInstsToWorkListRec(child);
         }
@@ -1050,7 +1031,7 @@ struct SpecializationContext
             if (auto wrapExistential = as<IRWrapExistential>(inst->getArg(0)))
             {
                 if (auto sbType = as<IRHLSLStructuredBufferTypeBase>(
-                        wrapExistential->getWrappedValue()->getDataType()))
+                    wrapExistential->getWrappedValue()->getDataType()))
                 {
                     // We are seeing the instruction sequence in the form of
                     // .operator[](wrapExistential(structuredBuffer), idx).
@@ -1118,7 +1099,7 @@ struct SpecializationContext
         // We can only specialize a call when the callee function is known.
         //
         auto calleeFunc = as<IRFunc>(inst->getCallee());
-        if(!calleeFunc)
+        if (!calleeFunc)
             return false;
 
         // Update result type since the callee may have been changed.
@@ -1129,7 +1110,7 @@ struct SpecializationContext
 
         // We can only specialize if we have access to a body for the callee.
         //
-        if(!calleeFunc->isDefinition())
+        if (!calleeFunc->isDefinition())
             return false;
 
         // We shouldn't bother specializing unless the callee has at least
@@ -1137,10 +1118,10 @@ struct SpecializationContext
         //
         bool shouldSpecialize = false;
         UInt argCounter = 0;
-        for( auto param : calleeFunc->getParams() )
+        for (auto param : calleeFunc->getParams())
         {
             auto arg = inst->getArg(argCounter++);
-            if( !isExistentialType(param->getDataType()) )
+            if (!isExistentialType(param->getDataType()))
                 continue;
 
             shouldSpecialize = true;
@@ -1148,13 +1129,13 @@ struct SpecializationContext
             // We *cannot* specialize unless the argument value corresponding
             // to such a parameter is one we can specialize.
             //
-            if( !canSpecializeExistentialArg(arg))
+            if (!canSpecializeExistentialArg(arg))
                 return false;
 
         }
         // If we never found a parameter worth specializing, we should bail out.
         //
-        if(!shouldSpecialize)
+        if (!shouldSpecialize)
             return false;
 
         // At this point, we believe we *should* and *can* specialize.
@@ -1181,13 +1162,13 @@ struct SpecializationContext
         // argument.
         //
         argCounter = 0;
-        for( auto param : calleeFunc->getParams() )
+        for (auto param : calleeFunc->getParams())
         {
             auto arg = inst->getArg(argCounter++);
-            if( !isExistentialType(param->getDataType()) )
+            if (!isExistentialType(param->getDataType()))
                 continue;
 
-            if( auto makeExistential = as<IRMakeExistential>(arg) )
+            if (auto makeExistential = as<IRMakeExistential>(arg))
             {
                 // Note that we use the *type* stored in the
                 // existential-type argument, but not anything to
@@ -1216,14 +1197,14 @@ struct SpecializationContext
                 auto witnessTable = makeExistential->getWitnessTable();
                 key.vals.add(witnessTable);
             }
-            else if( auto wrapExistential = as<IRWrapExistential>(arg) )
+            else if (auto wrapExistential = as<IRWrapExistential>(arg))
             {
                 auto val = wrapExistential->getWrappedValue();
                 auto valType = val->getFullType();
                 key.vals.add(valType);
 
                 UInt slotOperandCount = wrapExistential->getSlotOperandCount();
-                for( UInt ii = 0; ii < slotOperandCount; ++ii )
+                for (UInt ii = 0; ii < slotOperandCount; ++ii)
                 {
                     auto slotOperand = wrapExistential->getSlotOperand(ii);
                     key.vals.add(slotOperand);
@@ -1239,7 +1220,7 @@ struct SpecializationContext
         // existing specialization of the callee that we can use.
         //
         IRFunc* specializedCallee = nullptr;
-        if( !existentialSpecializedFuncs.tryGetValue(key, specializedCallee) )
+        if (!existentialSpecializedFuncs.tryGetValue(key, specializedCallee))
         {
             // If we didn't find a specialized callee already made, then we
             // will go ahead and create one, and then register it in our cache.
@@ -1255,14 +1236,14 @@ struct SpecializationContext
         //
         argCounter = 0;
         List<IRInst*> newArgs;
-        for( auto param : calleeFunc->getParams() )
+        for (auto param : calleeFunc->getParams())
         {
             auto arg = inst->getArg(argCounter++);
 
             // How we handle each argument depends on whether the corresponding
             // parameter has an existential type or not.
             //
-            if( !isExistentialType(param->getDataType()) )
+            if (!isExistentialType(param->getDataType()))
             {
                 // If the parameter doesn't have an existential type, then we
                 // don't want to change up the argument we pass at all.
@@ -1275,12 +1256,12 @@ struct SpecializationContext
                 // existential type, we will now be passing in the concrete
                 // argument value instead of an existential wrapper.
                 //
-                if( auto makeExistential = as<IRMakeExistential>(arg) )
+                if (auto makeExistential = as<IRMakeExistential>(arg))
                 {
                     auto val = makeExistential->getWrappedValue();
                     newArgs.add(val);
                 }
-                else if( auto wrapExistential = as<IRWrapExistential>(arg) )
+                else if (auto wrapExistential = as<IRWrapExistential>(arg))
                 {
                     auto val = wrapExistential->getWrappedValue();
                     newArgs.add(val);
@@ -1330,7 +1311,7 @@ struct SpecializationContext
     {
         // An IR-level interface type is always an existential.
         //
-        if(as<IRInterfaceType>(type))
+        if (as<IRInterfaceType>(type))
             return true;
         if (calcExistentialTypeParamSlotCount(type) != 0)
             return true;
@@ -1347,8 +1328,8 @@ struct SpecializationContext
         // TODO: We probably need/want a more robust test here.
         // For now we are just look into the dependency graph of the inst and
         // see if there are any opcodes that are causing problems.
-        InstWorkList localWorkList(inst->getModule());
-        InstHashSet processedInsts(inst->getModule());
+        List<IRInst*> localWorkList;
+        HashSet<IRInst*> processedInsts;
         localWorkList.add(inst);
         processedInsts.add(inst);
 
@@ -1393,7 +1374,7 @@ struct SpecializationContext
         // (which implicitly determines the concrete type), and
         // the witness table `w.
         //
-        if( auto makeExistential = as<IRMakeExistential>(inst) )
+        if (auto makeExistential = as<IRMakeExistential>(inst))
         {
             // We need to be careful about the type that we'd be specializing
             // to, since it needs to be visible to both the caller and calee.
@@ -1414,7 +1395,7 @@ struct SpecializationContext
         // is just a generalization of `makeExistential`, so it
         // can apply in the same cases.
         //
-        if(as<IRWrapExistential>(inst))
+        if (as<IRWrapExistential>(inst))
             return true;
 
         // If we start to specialize functions that take arrays
@@ -1471,7 +1452,7 @@ struct SpecializationContext
         List<IRParam*> newParams;
         List<IRInst*> newBodyInsts;
         UInt argCounter = 0;
-        for( auto oldParam : oldFunc->getParams() )
+        for (auto oldParam : oldFunc->getParams())
         {
             auto arg = oldCall->getArg(argCounter++);
 
@@ -1486,7 +1467,7 @@ struct SpecializationContext
             // parameter, because we need to extract out the concrete
             // type that is coming from the call site.
             //
-            if( auto oldMakeExistential = as<IRMakeExistential>(arg) )
+            if (auto oldMakeExistential = as<IRMakeExistential>(arg))
             {
                 // In this case, the `arg` is `makeExistential(val, witnessTable)`
                 // and we know that the specialized call site will just be
@@ -1516,7 +1497,7 @@ struct SpecializationContext
                 newBodyInsts.add(newMakeExistential);
                 replacementVal = newMakeExistential;
             }
-            else if( auto oldWrapExistential = as<IRWrapExistential>(arg) )
+            else if (auto oldWrapExistential = as<IRWrapExistential>(arg))
             {
                 auto val = oldWrapExistential->getWrappedValue();
                 auto valType = val->getFullType();
@@ -1566,7 +1547,7 @@ struct SpecializationContext
         // need to extract the types of all its parameters.
         //
         List<IRType*> newParamTypes;
-        for( auto newParam : newParams )
+        for (auto newParam : newParams)
         {
             newParamTypes.add(newParam->getFullType());
         }
@@ -1581,7 +1562,7 @@ struct SpecializationContext
         // "fully specialized" by the rules used for doing
         // generic specialization elsewhere in this pass.
         //
-        setFullySpecializedBit(newFuncType);
+        fullySpecializedInsts.add(newFuncType);
 
         // The above steps have accomplished the "first phase"
         // of cloning the function (since `IRFunc`s have no
@@ -1620,7 +1601,7 @@ struct SpecializationContext
         // the first ordinary instruction (since the function parameters
         // should come at the start of the first block).
         //
-        for( auto newParam : newParams )
+        for (auto newParam : newParams)
         {
             newParam->insertBefore(newFirstOrdinary);
         }
@@ -1629,7 +1610,7 @@ struct SpecializationContext
         // before the first ordinary instruction (but will come
         // *after* the parameters by the order of these two loops).
         //
-        for( auto newBodyInst : newBodyInsts )
+        for (auto newBodyInst : newBodyInsts)
         {
             newBodyInst->insertBefore(newFirstOrdinary);
         }
@@ -1678,7 +1659,7 @@ struct SpecializationContext
         //
         auto existentialArg = inst->getOperand(0);
 
-        if( auto makeExistential = as<IRMakeExistential>(existentialArg) )
+        if (auto makeExistential = as<IRMakeExistential>(existentialArg))
         {
             // In this case we know `inst` is:
             //
@@ -1710,7 +1691,7 @@ struct SpecializationContext
         // We know `inst` is `extractExistentialValue(existentialArg)`.
         //
         auto existentialArg = inst->getOperand(0);
-        if( auto makeExistential = as<IRMakeExistential>(existentialArg) )
+        if (auto makeExistential = as<IRMakeExistential>(existentialArg))
         {
             // Now we know `inst` is:
             //
@@ -1737,7 +1718,7 @@ struct SpecializationContext
         // We know `inst` is `extractExistentialValue(existentialArg)`.
         //
         auto existentialArg = inst->getOperand(0);
-        if( auto makeExistential = as<IRMakeExistential>(existentialArg) )
+        if (auto makeExistential = as<IRMakeExistential>(existentialArg))
         {
             // Now we know `inst` is:
             //
@@ -1761,7 +1742,7 @@ struct SpecializationContext
     {
         auto ptrArg = inst->ptr.get();
 
-        if( auto wrapInst = as<IRWrapExistential>(ptrArg) )
+        if (auto wrapInst = as<IRWrapExistential>(ptrArg))
         {
             // We have an instruction of the form `load(wrapExistential(val, ...))`
             //
@@ -1785,13 +1766,13 @@ struct SpecializationContext
             // the type that `load(val)` should return.
             //
             auto elementType = tryGetPointedToType(&builder, val->getDataType());
-            if(!elementType)
+            if (!elementType)
                 return false;
 
 
             List<IRInst*> slotOperands;
             UInt slotOperandCount = wrapInst->getSlotOperandCount();
-            for( UInt ii = 0; ii < slotOperandCount; ++ii )
+            for (UInt ii = 0; ii < slotOperandCount; ++ii)
             {
                 slotOperands.add(wrapInst->getSlotOperand(ii));
             }
@@ -1815,20 +1796,20 @@ struct SpecializationContext
     UInt calcExistentialBoxSlotCount(IRType* type)
     {
     top:
-        if( as<IRBoundInterfaceType>(type) )
+        if (as<IRBoundInterfaceType>(type))
         {
             return 2;
         }
-        else if( as<IRInterfaceType>(type) )
+        else if (as<IRInterfaceType>(type))
         {
             return 2;
         }
-        else if( auto ptrType = as<IRPtrTypeBase>(type) )
+        else if (auto ptrType = as<IRPtrTypeBase>(type))
         {
             type = ptrType->getValueType();
             goto top;
         }
-        else if( auto ptrLikeType = as<IRPointerLikeType>(type) )
+        else if (auto ptrLikeType = as<IRPointerLikeType>(type))
         {
             type = ptrLikeType->getElementType();
             goto top;
@@ -1848,10 +1829,10 @@ struct SpecializationContext
             type = attributedType->getBaseType();
             goto top;
         }
-        else if( auto structType = as<IRStructType>(type) )
+        else if (auto structType = as<IRStructType>(type))
         {
             UInt count = 0;
-            for( auto field : structType->getFields() )
+            for (auto field : structType->getFields())
             {
                 count += calcExistentialBoxSlotCount(field->getFieldType());
             }
@@ -1868,7 +1849,7 @@ struct SpecializationContext
         auto baseArg = inst->getBase();
         auto fieldKey = inst->getField();
 
-        if( auto wrapInst = as<IRWrapExistential>(baseArg) )
+        if (auto wrapInst = as<IRWrapExistential>(baseArg))
         {
             // We have `getField(wrapExistential(val, ...), fieldKey)`
             //
@@ -1900,15 +1881,15 @@ struct SpecializationContext
             //
             auto valType = val->getDataType();
             auto valStructType = as<IRStructType>(valType);
-            if(!valStructType)
+            if (!valStructType)
                 return false;
 
             UInt slotOperandOffset = 0;
 
             IRStructField* foundField = nullptr;
-            for( auto valField : valStructType->getFields() )
+            for (auto valField : valStructType->getFields())
             {
-                if( valField->getKey() == fieldKey )
+                if (valField->getKey() == fieldKey)
                 {
                     foundField = valField;
                     break;
@@ -1917,7 +1898,7 @@ struct SpecializationContext
                 slotOperandOffset += calcExistentialBoxSlotCount(valField->getFieldType());
             }
 
-            if(!foundField)
+            if (!foundField)
                 return false;
 
             auto foundFieldType = foundField->getFieldType();
@@ -1925,7 +1906,7 @@ struct SpecializationContext
             List<IRInst*> slotOperands;
             UInt slotOperandCount = calcExistentialBoxSlotCount(foundFieldType);
 
-            for( UInt ii = 0; ii < slotOperandCount; ++ii )
+            for (UInt ii = 0; ii < slotOperandCount; ++ii)
             {
                 slotOperands.add(wrapInst->getSlotOperand(slotOperandOffset + ii));
             }
@@ -1955,7 +1936,7 @@ struct SpecializationContext
         auto baseArg = inst->getBase();
         auto fieldKey = inst->getField();
 
-        if( auto wrapInst = as<IRWrapExistential>(baseArg) )
+        if (auto wrapInst = as<IRWrapExistential>(baseArg))
         {
             // We have `getFieldAddr(wrapExistential(val, ...), fieldKey)`
             //
@@ -1986,19 +1967,19 @@ struct SpecializationContext
             // up the field corresponding to `fieldKey`.
             //
             auto valType = tryGetPointedToType(&builder, val->getDataType());
-            if(!valType)
+            if (!valType)
                 return false;
 
             auto valStructType = as<IRStructType>(valType);
-            if(!valStructType)
+            if (!valStructType)
                 return false;
 
             UInt slotOperandOffset = 0;
 
             IRStructField* foundField = nullptr;
-            for( auto valField : valStructType->getFields() )
+            for (auto valField : valStructType->getFields())
             {
-                if( valField->getKey() == fieldKey )
+                if (valField->getKey() == fieldKey)
                 {
                     foundField = valField;
                     break;
@@ -2007,7 +1988,7 @@ struct SpecializationContext
                 slotOperandOffset += calcExistentialBoxSlotCount(valField->getFieldType());
             }
 
-            if(!foundField)
+            if (!foundField)
                 return false;
 
             auto foundFieldType = foundField->getFieldType();
@@ -2015,7 +1996,7 @@ struct SpecializationContext
             List<IRInst*> slotOperands;
             UInt slotOperandCount = calcExistentialBoxSlotCount(foundFieldType);
 
-            for( UInt ii = 0; ii < slotOperandCount; ++ii )
+            for (UInt ii = 0; ii < slotOperandCount; ++ii)
             {
                 slotOperands.add(wrapInst->getSlotOperand(slotOperandOffset + ii));
             }
@@ -2123,16 +2104,16 @@ struct SpecializationContext
     UInt calcExistentialTypeParamSlotCount(IRType* type)
     {
     top:
-        if( as<IRInterfaceType>(type) )
+        if (as<IRInterfaceType>(type))
         {
             return 2;
         }
-        else if( auto ptrType = as<IRPtrTypeBase>(type) )
+        else if (auto ptrType = as<IRPtrTypeBase>(type))
         {
             type = ptrType->getValueType();
             goto top;
         }
-        else if( auto ptrLikeType = as<IRPointerLikeType>(type) )
+        else if (auto ptrLikeType = as<IRPointerLikeType>(type))
         {
             type = ptrLikeType->getElementType();
             goto top;
@@ -2147,10 +2128,10 @@ struct SpecializationContext
             type = attributedType->getBaseType();
             goto top;
         }
-        else if( auto structType = as<IRStructType>(type) )
+        else if (auto structType = as<IRStructType>(type))
         {
             UInt count = 0;
-            for( auto field : structType->getFields() )
+            for (auto field : structType->getFields())
             {
                 count += calcExistentialTypeParamSlotCount(field->getFieldType());
             }
@@ -2172,15 +2153,15 @@ struct SpecializationContext
         IRBuilder builder(module);
         builder.setInsertBefore(type);
 
-        if( auto baseInterfaceType = as<IRInterfaceType>(baseType) )
+        if (auto baseInterfaceType = as<IRInterfaceType>(baseType))
         {
             // We always expect two slot operands, one for the concrete type
             // and one for the witness table.
             //
             SLANG_ASSERT(slotOperandCount == 2);
-            if(slotOperandCount < 2) return false;
+            if (slotOperandCount < 2) return false;
 
-            auto concreteType = (IRType*) type->getExistentialArg(0);
+            auto concreteType = (IRType*)type->getExistentialArg(0);
             auto witnessTable = type->getExistentialArg(1);
             auto newVal = builder.getBoundInterfaceType(baseInterfaceType, concreteType, witnessTable);
 
@@ -2189,10 +2170,10 @@ struct SpecializationContext
             type->removeAndDeallocate();
             return true;
         }
-        else if( as<IRPointerLikeType>(baseType) ||
-                 as<IRHLSLStructuredBufferTypeBase>(baseType) ||
-                 as<IRArrayTypeBase>(baseType) ||
-                 as<IRAttributedType>(baseType) )
+        else if (as<IRPointerLikeType>(baseType) ||
+            as<IRHLSLStructuredBufferTypeBase>(baseType) ||
+            as<IRArrayTypeBase>(baseType) ||
+            as<IRAttributedType>(baseType))
         {
             // A `BindExistentials<P<T>, ...>` can be simplified to
             // `P<BindExistentials<T, ...>>` when `P` is a pointer-like
@@ -2225,7 +2206,7 @@ struct SpecializationContext
             type->removeAndDeallocate();
             return true;
         }
-        else if( auto baseStructType = as<IRStructType>(baseType) )
+        else if (auto baseStructType = as<IRStructType>(baseType))
         {
             // In order to bind a `struct` type we will generate
             // a new specialized `struct` type on demand and then
@@ -2237,7 +2218,7 @@ struct SpecializationContext
             // specialized, so that we can be sure that we
             // have a unique type.
             //
-            if( !areAllOperandsFullySpecialized(type) )
+            if (!areAllOperandsFullySpecialized(type))
                 return false;
 
             // Now we we check to see if we've already created
@@ -2245,7 +2226,7 @@ struct SpecializationContext
             //
             IRSimpleSpecializationKey key;
             key.vals.add(baseStructType);
-            for( UInt ii = 0; ii < slotOperandCount; ++ii )
+            for (UInt ii = 0; ii < slotOperandCount; ++ii)
             {
                 key.vals.add(type->getExistentialArg(ii));
             }
@@ -2253,7 +2234,7 @@ struct SpecializationContext
             IRStructType* newStructType = nullptr;
             addUsersToWorkList(type);
 
-            if( !existentialSpecializedStructs.tryGetValue(key, newStructType) )
+            if (!existentialSpecializedStructs.tryGetValue(key, newStructType))
             {
                 builder.setInsertBefore(baseStructType);
                 newStructType = builder.createStructType();
@@ -2261,7 +2242,7 @@ struct SpecializationContext
 
                 auto fieldSlotArgs = type->getExistentialArgs();
 
-                for( auto oldField : baseStructType->getFields() )
+                for (auto oldField : baseStructType->getFields())
                 {
                     // TODO: we need to figure out which of the specialization arguments
                     // apply to this field...
@@ -2299,13 +2280,13 @@ struct SpecializationContext
     void specializeGlobalGenericParameters()
     {
         auto moduleInst = module->getModuleInst();
-        for(auto inst : moduleInst->getChildren())
+        for (auto inst : moduleInst->getChildren())
         {
             // We only want to consider the `bind_global_generic_param`
             // instructions, and ignore everything else.
             //
             auto bindInst = as<IRBindGlobalGenericParam>(inst);
-            if(!bindInst)
+            if (!bindInst)
                 continue;
 
             // HACK: Our current front-end emit logic can end up emitting multiple
@@ -2316,7 +2297,7 @@ struct SpecializationContext
             // For now we will do a sanity check to detect parameters that
             // have already been specialized.
             //
-            if( !as<IRGlobalGenericParam>(bindInst->getOperand(0)) )
+            if (!as<IRGlobalGenericParam>(bindInst->getOperand(0)))
             {
                 // The "parameter" operand is no longer a parameter, so it
                 // seems things must have been specialized already.
@@ -2339,11 +2320,11 @@ struct SpecializationContext
             // instructions, since both should be dead/unused.
             //
             IRInst* next = nullptr;
-            for(auto inst = moduleInst->getFirstChild(); inst; inst = next)
+            for (auto inst = moduleInst->getFirstChild(); inst; inst = next)
             {
                 next = inst->getNextInst();
 
-                switch(inst->getOp())
+                switch (inst->getOp())
                 {
                 default:
                     break;
@@ -2364,7 +2345,7 @@ struct SpecializationContext
 };
 
 bool specializeModule(
-    IRModule*   module,
+    IRModule* module,
     DiagnosticSink* sink)
 {
     SLANG_PROFILE;
@@ -2382,11 +2363,11 @@ void finalizeSpecialization(IRModule* module)
 
     auto moduleInst = module->getModuleInst();
     IRInst* next = nullptr;
-    for(auto inst = moduleInst->getFirstChild(); inst; inst = next)
+    for (auto inst = moduleInst->getFirstChild(); inst; inst = next)
     {
         next = inst->getNextInst();
 
-        switch(inst->getOp())
+        switch (inst->getOp())
         {
         default:
             break;
@@ -2417,10 +2398,10 @@ void finalizeSpecialization(IRModule* module)
 }
 
 IRInst* specializeGenericImpl(
-    IRGeneric*              genericVal,
-    IRSpecialize*           specializeInst,
-    IRModule*               module,
-    SpecializationContext*  context)
+    IRGeneric* genericVal,
+    IRSpecialize* specializeInst,
+    IRModule* module,
+    SpecializationContext* context)
 {
     // Effectively, specializing a generic amounts to "calling" the generic
     // on its concrete argument values and computing the
@@ -2447,7 +2428,7 @@ IRInst* specializeGenericImpl(
     // and `V -> c`.
     //
     UInt argCounter = 0;
-    for( auto param : genericVal->getParams() )
+    for (auto param : genericVal->getParams())
     {
         UInt argIndex = argCounter++;
         SLANG_ASSERT(argIndex < specializeInst->getArgCount());
@@ -2469,7 +2450,7 @@ IRInst* specializeGenericImpl(
     // clone each of its instructions into the global scope,
     // until we reach a `return` instruction.
     //
-    for( auto bb : genericVal->getBlocks() )
+    for (auto bb : genericVal->getBlocks())
     {
         // We expect a generic to only ever contain a single block.
         //
@@ -2479,7 +2460,7 @@ IRInst* specializeGenericImpl(
         // instructions only, because parameters were dealt
         // with explictly at an earlier point.
         //
-        for( auto ii : bb->getOrdinaryInsts() )
+        for (auto ii : bb->getOrdinaryInsts())
         {
             // The last block of the generic is expected to end with
             // a `return` instruction for the specialized value that
@@ -2488,7 +2469,7 @@ IRInst* specializeGenericImpl(
             // We thus use that cloned value as the result of the
             // specialization step.
             //
-            if( auto returnValInst = as<IRReturn>(ii) )
+            if (auto returnValInst = as<IRReturn>(ii))
             {
                 auto specializedVal = findCloneForOperand(&env, returnValInst->getVal());
 
@@ -2523,7 +2504,7 @@ IRInst* specializeGenericImpl(
             // operations nested inside the first generic that refer
             // to the second.
             //
-            if( context )
+            if (context)
             {
                 context->addToWorkList(clonedInst);
             }
@@ -2538,15 +2519,15 @@ IRInst* specializeGenericImpl(
 }
 
 IRInst* specializeGeneric(
-    IRSpecialize*   specializeInst)
+    IRSpecialize* specializeInst)
 {
     auto baseGeneric = as<IRGeneric>(specializeInst->getBase());
     SLANG_ASSERT(baseGeneric);
-    if(!baseGeneric) return specializeInst;
+    if (!baseGeneric) return specializeInst;
 
     auto module = specializeInst->getModule();
     SLANG_ASSERT(module);
-    if(!module) return specializeInst;
+    if (!module) return specializeInst;
 
     return specializeGenericImpl(baseGeneric, specializeInst, module, nullptr);
 }

--- a/source/slang/slang-ir-util.h
+++ b/source/slang/slang-ir-util.h
@@ -53,9 +53,6 @@ struct DeduplicateContext
             if (deduplicatedOperand != value->getOperand(i))
                 value->unsafeSetOperand(i, deduplicatedOperand);
         }
-        auto deduplicatedType = (IRType*)deduplicate(value->getFullType(), shouldDeduplicate);
-        if (deduplicatedType != value->getFullType())
-            value->setFullType(deduplicatedType);
         if (auto newValue = deduplicateMap.tryGetValue(key))
             return *newValue;
         deduplicateMap[key] = value;

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -6849,6 +6849,18 @@ namespace Slang
             thisInst = workItem.thisInst;
             other = workItem.otherInst;
 
+            // If `other` has been replaced by something else, use that.
+            if (getIROpInfo(thisInst->getOp()).isHoistable())
+            {
+                if (!dedupContext)
+                {
+                    SLANG_ASSERT(thisInst->getModule());
+                    dedupContext = thisInst->getModule()->getDeduplicationContext();
+                }
+                dedupContext->getInstReplacementMap().tryGetValue(other, other);
+            }
+            SLANG_ASSERT(other);
+
             // Safety check: don't try to replace something with itself.
             if (other == thisInst)
                 continue;
@@ -6861,10 +6873,6 @@ namespace Slang
                     dedupContext = thisInst->getModule()->getDeduplicationContext();
                 }
                 dedupContext->getInstReplacementMap()[thisInst] = other;
-                
-                // If thisInst is hoistable, remove it from global dedup map now since
-                // we don't want to other insts to be replaced with thisInst.
-                dedupContext->getGlobalValueNumberingMap().remove(thisInst);
             }
 
      

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -6861,8 +6861,13 @@ namespace Slang
                     dedupContext = thisInst->getModule()->getDeduplicationContext();
                 }
                 dedupContext->getInstReplacementMap()[thisInst] = other;
+                
+                // If thisInst is hoistable, remove it from global dedup map now since
+                // we don't want to other insts to be replaced with thisInst.
+                dedupContext->getGlobalValueNumberingMap().remove(thisInst);
             }
 
+     
             // We will walk through the list of uses for the current
             // instruction, and make them point to the other inst.
             IRUse* ff = thisInst->firstUse;

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -6849,16 +6849,6 @@ namespace Slang
             thisInst = workItem.thisInst;
             other = workItem.otherInst;
 
-            // If `other` has been replaced by something else, use that.
-            if (getIROpInfo(thisInst->getOp()).isHoistable())
-            {
-                if (!dedupContext)
-                {
-                    SLANG_ASSERT(thisInst->getModule());
-                    dedupContext = thisInst->getModule()->getDeduplicationContext();
-                }
-                dedupContext->getInstReplacementMap().tryGetValue(other, other);
-            }
             SLANG_ASSERT(other);
 
             // Safety check: don't try to replace something with itself.
@@ -6875,7 +6865,6 @@ namespace Slang
                 dedupContext->getInstReplacementMap()[thisInst] = other;
             }
 
-     
             // We will walk through the list of uses for the current
             // instruction, and make them point to the other inst.
             IRUse* ff = thisInst->firstUse;
@@ -6915,6 +6904,8 @@ namespace Slang
                     IRInst* existingVal = nullptr;
                     if (dedupContext->getGlobalValueNumberingMap().tryGetValue(IRInstKey{ user }, existingVal))
                     {
+                        // If existingVal has been replaced by something else, use that.
+                        dedupContext->getInstReplacementMap().tryGetValue(existingVal, existingVal);
                         addToWorkList(user, existingVal);
                     }
                     else

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -703,6 +703,12 @@ struct IRInst
     uint32_t _debugUID;
 #endif
 
+    // Reserved memory space for use by individual IR passes.
+    // This field is not supposed to be valid outside an IR pass,
+    // and each IR pass should always treat it as uninitialized
+    // upon entry.
+    UInt64 scratchData = 0;
+
     // The type of the result value of this instruction,
     // or `null` to indicate that the instruction has
     // no value.
@@ -739,12 +745,6 @@ struct IRInst
         SLANG_ASSERT(getOperands()[index].user != nullptr);
         getOperands()[index].init(this, value);
     }
-
-    // Reserved memory space for use by individual IR passes.
-    // This field is not supposed to be valid outside an IR pass,
-    // and each IR pass should always treat it as uninitialized
-    // upon entry.
-    UInt64 scratchData = 0;
 
     //
 

--- a/source/slang/slang-lookup.cpp
+++ b/source/slang/slang-lookup.cpp
@@ -200,7 +200,7 @@ static void _lookUpDirectAndTransparentMembers(
             // Skip this declaration if we are checking and this hasn't been
             // checked yet. Because we traverse block statements in order, if
             // it's unchecked or being checked then it isn't declared yet.
-            if(!request.shouldConsiderAllLocalNames() && _isUncheckedLocalVar(m))
+            if(!request.shouldConsiderAllLocalNames() && request.semantics && _isUncheckedLocalVar(m))
                 continue;
 
             if (!DeclPassesLookupMask(m, request.mask))

--- a/source/slang/slang-lookup.cpp
+++ b/source/slang/slang-lookup.cpp
@@ -311,10 +311,10 @@ DeclRef<Decl> _maybeSpecializeSuperTypeDeclRef(
     {
         if (auto superInterfaceDeclRef = superDeclRefType->declRef.as<InterfaceDecl>())
         {
-            ThisTypeSubstitution* thisTypeSubst = astBuilder->create<ThisTypeSubstitution>();
-            thisTypeSubst->interfaceDecl = superInterfaceDeclRef.getDecl();
-            thisTypeSubst->witness = subIsSuperWitness;
-            thisTypeSubst->outer = declRefToSpecialize.getSubst();
+            ThisTypeSubstitution* thisTypeSubst = astBuilder->getOrCreateThisTypeSubstitution(
+                superInterfaceDeclRef.getDecl(),
+                subIsSuperWitness,
+                declRefToSpecialize.getSubst());
 
             auto specializedDeclRef = astBuilder->getSpecializedDeclRef<Decl>(declRefToSpecialize.getDecl(), thisTypeSubst);
 
@@ -563,9 +563,7 @@ static void _lookUpMembersInSuperTypeImpl(
         //
         auto interfaceType = DeclRefType::create(astBuilder, thisType->interfaceDeclRef);
 
-        auto superIsInterfaceWitness = astBuilder->create<ThisTypeSubtypeWitness>();
-        superIsInterfaceWitness->sub = superType;
-        superIsInterfaceWitness->sup = interfaceType;
+        auto superIsInterfaceWitness = astBuilder->getThisTypeSubtypeWitness(superType, interfaceType);
 
         auto leafIsInterfaceWitness = _makeSubtypeWitness(
             astBuilder,

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -2034,7 +2034,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
     void _collectSubstitutionArgs(List<IRInst*>& operands, Substitutions* subst)
     {
         if (!subst) return;
-        _collectSubstitutionArgs(operands, subst->outer);
+        _collectSubstitutionArgs(operands, subst->getOuter());
         if (auto genSubst = as<GenericSubstitution>(subst))
         {
             for (auto arg : genSubst->getArgs())
@@ -3931,11 +3931,11 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
     void _lowerSubstitutionEnv(IRGenContext* subContext, Substitutions* subst)
     {
         if(!subst) return;
-        _lowerSubstitutionEnv(subContext, subst->outer);
+        _lowerSubstitutionEnv(subContext, subst->getOuter());
 
         if (auto genSubst = as<GenericSubstitution>(subst))
         {
-            auto genDecl = genSubst->genericDecl;
+            auto genDecl = genSubst->getGenericDecl();
 
             Index argCounter = 0;
             for( auto memberDecl: genDecl->members )
@@ -9415,7 +9415,7 @@ LoweredValInfo emitDeclRef(
     if(!canDeclLowerToAGeneric(decl))
     {
         while(auto genericSubst = as<GenericSubstitution>(subst))
-            subst = genericSubst->outer;
+            subst = genericSubst->getOuter();
     }
 
     // In the simplest case, there is no specialization going
@@ -9444,7 +9444,7 @@ LoweredValInfo emitDeclRef(
         LoweredValInfo genericVal = emitDeclRef(
             context,
             decl,
-            genericSubst->outer,
+            genericSubst->getOuter(),
             context->irBuilder->getGenericKind());
 
         // There's no reason to specialize something that maps to a NULL pointer.
@@ -9542,7 +9542,7 @@ LoweredValInfo emitDeclRef(
             // are lowered as generics, where the generic parameter represents
             // the `ThisType`.
             //
-            auto genericVal = emitDeclRef(context, decl, thisTypeSubst->outer, context->irBuilder->getGenericKind());
+            auto genericVal = emitDeclRef(context, decl, thisTypeSubst->getOuter(), context->irBuilder->getGenericKind());
             auto irGenericVal = getSimpleVal(context, genericVal);
 
             // In order to reference the member for a particular type, we

--- a/source/slang/slang-mangle.cpp
+++ b/source/slang/slang-mangle.cpp
@@ -424,7 +424,7 @@ namespace Slang
             // in place for the parent generic declaration, or we don't.
 
             auto subst = findInnerMostGenericSubstitution(declRef.getSubst());
-            if( subst && subst->genericDecl == parentGenericDeclRef.getDecl() )
+            if( subst && subst->getGenericDecl() == parentGenericDeclRef.getDecl())
             {
                 // This is the case where we *do* have substitutions.
                 emitRaw(context, "G");

--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -135,6 +135,10 @@ namespace Slang
             else
                 return kConversionCost_GeneralConversion;
         }
+        else if (fromInfo.tag == BaseType::Bool && toInfo.tag == BaseType::Int)
+        {
+            return kConversionCost_BoolToInt;
+        }
 
         // If we are converting from an unsigned integer type to
         // a signed integer type that is guaranteed to be larger,

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -675,7 +675,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
         }
         else
         {
-            return astBuilder->getOrCreateDeclRefType(declRef.declRefBase);
+            return astBuilder->getOrCreate<DeclRefType>(declRef.declRefBase);
         }
     }
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -4004,7 +4004,7 @@ struct SpecializationArgModuleCollector : ComponentTypeVisitor
 
     void collectReferencedModules(SubstitutionSet const& substitutions)
     {
-        for(auto subst = substitutions.substitutions; subst; subst = subst->outer)
+        for(auto subst = substitutions.substitutions; subst; subst = subst->getOuter())
         {
             collectReferencedModules(subst);
         }

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -5210,6 +5210,7 @@ SlangResult EndToEndCompileRequest::EndToEndCompileRequest::compile()
     {
         StringBuilder perfResult;
         PerformanceProfiler::getProfiler()->getResult(perfResult);
+        perfResult << "\nType Dictionary Size: " << getSession()->m_typeDictionarySize << "\n";
         getSink()->diagnose(SourceLoc(), Diagnostics::performanceBenchmarkResult, perfResult.produceString());
     }
 

--- a/source/slang/slang.natvis
+++ b/source/slang/slang.natvis
@@ -10,30 +10,25 @@
     </Expand>
   </Type>
   <Type Name="Slang::DeclRef&lt;*&gt;">
-    <SmartPointer Usage="Minimal">declRefBase ? ($T1*)(declRefBase->decl) : ($T1*)0</SmartPointer>
     <DisplayString Condition="declRefBase == 0">DeclRef nullptr</DisplayString>
     <DisplayString Condition="declRefBase != 0">{*declRefBase}</DisplayString>
-    <!--
     <Expand>
-      <ExpandedItem>decl ? ($T1*)(decl) : ($T1*)0</ExpandedItem>
+      <ExpandedItem>declRefBase ? ($T1*)(declRefBase->decl) : ($T1*)0</ExpandedItem>
       <Synthetic Name="[Substitutions]">
         <Expand>
             <LinkedListItems>
-                <HeadPointer>substitutions.substitutions</HeadPointer>
+                <HeadPointer>declRefBase->substitutions</HeadPointer>
                 <NextPointer>outer</NextPointer>
                 <ValueNode>this</ValueNode>
             </LinkedListItems>
         </Expand>
       </Synthetic>
     </Expand>
-    -->
   </Type>
     <Type Name="Slang::DeclRefBase">
-      <SmartPointer Usage="Minimal">decl</SmartPointer>
       <DisplayString Condition="decl != 0 &amp;&amp; substitutions != 0">{*decl}{*substitutions}</DisplayString>
       <DisplayString Condition="decl != 0">{*decl}</DisplayString>
       <DisplayString Condition="decl == 0">DeclRefBase nullptr</DisplayString>
-      <!--
       <Expand>
           <ExpandedItem>decl</ExpandedItem>
           <Synthetic Name="[Substitutions]">
@@ -46,7 +41,6 @@
               </Expand>
           </Synthetic>
       </Expand>
-      -->
     </Type>
     <Type Name="Slang::GenericSubstitution">
         <DisplayString>GenSubst {(*genericDecl).nameAndLoc}</DisplayString>

--- a/source/slang/slang.natvis
+++ b/source/slang/slang.natvis
@@ -97,18 +97,6 @@
       </CustomListItems>
       <Item Name="[value]" Condition="m_op == kIROp_StringLit">((IRStringLit*)this)->value.stringVal.chars,[((IRStringLit*)this)->value.stringVal.numChars]s8</Item>
       <Item Name="[value]" Condition="m_op == kIROp_IntLit">((IRIntLit*)this)->value.intVal</Item>
-	  <!--
-      <Synthetic Name="[operands]">
-        <DisplayString>{{count = {operandCount}}}</DisplayString>
-        <Expand>
-          <Item Name="[count]">operandCount</Item>
-          <ArrayItems>
-            <Size>operandCount</Size>
-            <ValuePointer>(IRUse*)(&amp;(typeUse) + 1)</ValuePointer>
-          </ArrayItems>
-        </Expand>
-      </Synthetic>
-	  -->
       <CustomListItems MaxItemsPerView="10">
 	    <Variable Name="index" InitialValue="0"/>
 	    <Variable Name="nameDecoration" InitialValue="(IRInst*)nullptr"/>


### PR DESCRIPTION
This change simplifies the lookup logic in a type by scanning through the linearized inheritance list of the type instead of doing on-demand analysis of what base types and extensions can apply and recursively look into those scopes.

This avoids the repetitive work of testing sub type relationships or checking if an extension applies to a type, and therefore reduces the overall complexity of the type checking process, and drastically improves front-end performance.

This PR also includes the following performance optimizations:
- Cache subtype witnesses.
- Avoid creating duplicate type objects.
- Make substitutions immutable for better deduplication.
- Increase initial dictionary sizes to reduce rehashing.
- Revert #2768, fixed a bug in `replaceUsesWith` that seemed to cause the legalization issue that this PR attempted to fix and now we should no longer need to run legalization in a loop, this is to be verified since we weren't able to come up with an repro for the original problem.

These changes combined results in an up to 50% reduction in Slang compilation time (excluding downstream compilation).