### PR TITLE
Fix for vk-shift-* GLSL emit issue

### DIFF
--- a/tests/bugs/vk-shift-uniform-issue.slang
+++ b/tests/bugs/vk-shift-uniform-issue.slang
@@ -1,0 +1,86 @@
+//TEST:SIMPLE(filecheck=CHECK):-target glsl -profile ps_4_0 -entry main -fvk-t-shift 10 all  -fvk-s-shift 100 all -fvk-u-shift 100 all -fvk-b-shift 1000 all
+
+// CHECK:layout(binding = 10)
+// CHECK:uniform texture2D texture0_0;
+
+// CHECK:layout(binding = 100)
+// CHECK:uniform sampler sampler0_0;
+
+// CHECK:layout(binding = 11, set = 2)
+// CHECK:uniform texture2D texture1_0;
+
+// CHECK:layout(binding = 101, set = 2)
+// CHECK:uniform sampler sampler1_0;
+
+// CHECK:layout(binding = 1004)
+// CHECK:layout(std140) uniform _S1
+
+// CHECK:layout(binding = 1003)
+// CHECK:layout(std140) uniform _S2
+
+// CHECK:layout(binding = 1002)
+// CHECK:layout(std140) uniform _S3
+
+// CHECK:layout(binding = 1001)
+// CHECK:layout(std140) uniform _S4
+
+// CHECK:layout(binding = 0)
+// CHECK:layout(std140) uniform _S5
+
+Texture2D texture0; 
+SamplerState sampler0;
+
+Texture2D texture1 : register(t1, space2); 
+SamplerState sampler1 : register(s1, space2); 
+
+float g_value;
+
+cbuffer ConstantBufferA 
+{ 
+    float constantA;
+}; 
+
+cbuffer ConstantBufferB 
+{ 
+    float constantB;
+}; 
+
+cbuffer ConstantBufferC
+{
+    float constantC; 
+}; 
+
+cbuffer ConstantBufferD
+{ 
+    float constantD;
+}; 
+
+struct StructA 
+{ 
+    float a;
+};
+ 
+[[ vk::push_constant ]] 
+StructA pushConstantA;
+  
+struct PixelInput
+{ 
+    float4 t : TEXCOORD0; 
+}; 
+
+struct PixelOutput
+{ 
+    float4 color : SV_Target0; 
+}; 
+
+float4 use(Texture2D t, SamplerState s) { return t.SampleLevel(s, 0.0, 0.0); }
+
+PixelOutput main(PixelInput i)
+{ 
+    PixelOutput o ; 
+    float4 b = use(texture0, sampler0) + use(texture1, sampler1);
+    float a = pushConstantA.a + constantD + constantC + constantB + constantA + g_value + length(b);
+    o.color = float4(1, 2, 3, 4) * a;
+    return o ; 
+} 
+


### PR DESCRIPTION
In #3000 led to situations where DescriptorSlots were not being used for binding. Specifically when a shift is enabled for HLSL resource kind, the binding remains on the HLSL kind. This leads to HLSL like LayoutResourceKind in IR being HLSL even when doing GLSL emit.

Parts of the GLSL emit assumed DescriptorSlot is the resource kind used. 

The fix here was to in cases where the distinction could happen, enable looking up for the HLSL kind also. 