### PR TITLE
Better handling of bindings with multiple resource kind "aliases" for GLSL emit

### DIFF
--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -605,6 +605,48 @@ void CLikeSourceEmitter::emitVal(IRInst* val, EmitOpInfo const& outerPrec)
     }
 }
 
+UInt CLikeSourceEmitter::getBindingOffsetForKinds(EmitVarChain* chain, LayoutResourceKindFlags kindFlags)
+{
+    UInt offset = 0;
+    for (auto cc = chain; cc; cc = cc->next)
+    {
+        for (auto offsetAttr : cc->varLayout->getOffsetAttrs())
+        {
+            // Accumulate offset for all matching kind
+            if (LayoutResourceKindFlag::make(offsetAttr->getResourceKind()) & kindFlags)
+            {
+                offset += offsetAttr->getOffset();
+            }
+        }
+    }
+
+    return offset;
+}
+
+UInt CLikeSourceEmitter::getBindingSpaceForKinds(EmitVarChain* chain, LayoutResourceKindFlags kindFlags)
+{
+    UInt space = 0;
+    for (auto cc = chain; cc; cc = cc->next)
+    {
+        auto varLayout = cc->varLayout;
+
+        for (auto offsetAttr : cc->varLayout->getOffsetAttrs())
+        {
+            // Accumulate offset for all matching kinds
+            if (LayoutResourceKindFlag::make(offsetAttr->getResourceKind()) & kindFlags)
+            {
+                space += offsetAttr->getSpace();
+            }
+        }
+
+        if (auto resInfo = varLayout->findOffsetAttr(LayoutResourceKind::RegisterSpace))
+        {
+            space += resInfo->getOffset();
+        }
+    }
+    return space;
+}
+
 UInt CLikeSourceEmitter::getBindingOffset(EmitVarChain* chain, LayoutResourceKind kind)
 {
     UInt offset = 0;

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -316,6 +316,9 @@ public:
     UInt getBindingOffset(EmitVarChain* chain, LayoutResourceKind kind);
     UInt getBindingSpace(EmitVarChain* chain, LayoutResourceKind kind);
 
+    UInt getBindingOffsetForKinds(EmitVarChain* chain, LayoutResourceKindFlags kindFlags);   
+    UInt getBindingSpaceForKinds(EmitVarChain* chain, LayoutResourceKindFlags kindFlags);
+    
         // Utility code for generating unique IDs as needed
         // during the emit process (e.g., for declarations
         // that didn't originally have names, but now need to).

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -316,6 +316,10 @@ public:
     UInt getBindingOffset(EmitVarChain* chain, LayoutResourceKind kind);
     UInt getBindingSpace(EmitVarChain* chain, LayoutResourceKind kind);
 
+        /// Finds the binding offset for *all* the kinds that match the kindFlags
+        /// Thus only meaningful if multiple kinds can be treated as the same as far as binding is concerned.
+        /// In particular is useful for GLSL binding emit, where some HLSL resource kinds can appear but are in effect the 
+        /// same as DescriptorSlot
     UInt getBindingOffsetForKinds(EmitVarChain* chain, LayoutResourceKindFlags kindFlags);   
     UInt getBindingSpaceForKinds(EmitVarChain* chain, LayoutResourceKindFlags kindFlags);
     

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -320,7 +320,7 @@ void GLSLSourceEmitter::_emitGLSLParameterGroup(IRGlobalParam* varDecl, IRUnifor
 
     {
         const LayoutResourceKindFlags kinds = LayoutResourceKindFlag::ConstantBuffer | LayoutResourceKindFlag::DescriptorTableSlot;
-        _emitGLSLLayoutQualifier(LayoutResourceKind::DescriptorTableSlot, kinds, &containerChain);
+        _emitGLSLLayoutQualifierWithBindingKinds(LayoutResourceKind::DescriptorTableSlot, &containerChain, kinds);
     }
 
     _emitGLSLLayoutQualifier(LayoutResourceKind::PushConstantBuffer, &containerChain);
@@ -546,7 +546,7 @@ void GLSLSourceEmitter::_emitGLSLImageFormatModifier(IRInst* var, IRTextureType*
     }
 }
 
-bool GLSLSourceEmitter::_emitGLSLLayoutQualifier(LayoutResourceKind kind, LayoutResourceKindFlags kindFlags, EmitVarChain* chain)
+bool GLSLSourceEmitter::_emitGLSLLayoutQualifierWithBindingKinds(LayoutResourceKind kind, EmitVarChain* chain, LayoutResourceKindFlags bindingKinds)
 {
     if (!chain)
         return false;
@@ -554,16 +554,16 @@ bool GLSLSourceEmitter::_emitGLSLLayoutQualifier(LayoutResourceKind kind, Layout
     UInt index, space; 
     auto varLayout = chain->varLayout;
 
-    // If kindFlags are set, we use that for binding lookup
-    if (kindFlags != 0)
+    // If bindingKinds are set, we use that for binding lookup
+    if (bindingKinds != 0)
     {
-        if (!varLayout->usesResourceFromKinds(kindFlags))
+        if (!varLayout->usesResourceFromKinds(bindingKinds))
         {
             return false;
         }
 
-        index = getBindingOffsetForKinds(chain, kindFlags);
-        space = getBindingSpaceForKinds(chain, kindFlags);
+        index = getBindingOffsetForKinds(chain, bindingKinds);
+        space = getBindingSpaceForKinds(chain, bindingKinds);
     }
     else
     {

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -568,9 +568,11 @@ bool GLSLSourceEmitter::_emitGLSLLayoutQualifierWithBindingKinds(LayoutResourceK
     else
     {
         // Otherwise we just use kind
-        if (!varLayout->findOffsetAttr(kind))
+        if (!varLayout->usesResourceKind(kind))
+        {
             return false;
-
+        }
+        
         index = getBindingOffset(chain, kind);
         space = getBindingSpace(chain, kind);
     }

--- a/source/slang/slang-emit-glsl.h
+++ b/source/slang/slang-emit-glsl.h
@@ -67,9 +67,9 @@ protected:
 
     void _emitGLSLLayoutQualifiers(IRVarLayout* layout, EmitVarChain* inChain, LayoutResourceKind filter = LayoutResourceKind::None);
 
-        /// If kindFlags is set, it is used for binding lookup
-    bool _emitGLSLLayoutQualifier(LayoutResourceKind kind, LayoutResourceKindFlags kindFlags, EmitVarChain* chain);
-    bool _emitGLSLLayoutQualifier(LayoutResourceKind kind, EmitVarChain* chain) { return _emitGLSLLayoutQualifier(kind, 0, chain); }
+        /// If bindingKinds is set, it is used for binding index/set lookup. Passing in 0 is equivalent to using the kind only.
+    bool _emitGLSLLayoutQualifierWithBindingKinds(LayoutResourceKind kind, EmitVarChain* chain, LayoutResourceKindFlags bindingKinds);
+    bool _emitGLSLLayoutQualifier(LayoutResourceKind kind, EmitVarChain* chain) { return _emitGLSLLayoutQualifierWithBindingKinds(kind, chain, 0); }
 
     void _emitGLSLTypePrefix(IRType* type, bool promoteHalfToFloat = false);
 

--- a/source/slang/slang-emit-glsl.h
+++ b/source/slang/slang-emit-glsl.h
@@ -66,7 +66,10 @@ protected:
     void _emitGLSLImageFormatModifier(IRInst* var, IRTextureType* resourceType);
 
     void _emitGLSLLayoutQualifiers(IRVarLayout* layout, EmitVarChain* inChain, LayoutResourceKind filter = LayoutResourceKind::None);
-    bool _emitGLSLLayoutQualifier(LayoutResourceKind kind, EmitVarChain* chain);
+
+        /// If kindFlags is set, it is used for binding lookup
+    bool _emitGLSLLayoutQualifier(LayoutResourceKind kind, LayoutResourceKindFlags kindFlags, EmitVarChain* chain);
+    bool _emitGLSLLayoutQualifier(LayoutResourceKind kind, EmitVarChain* chain) { return _emitGLSLLayoutQualifier(kind, 0, chain); }
 
     void _emitGLSLTypePrefix(IRType* type, bool promoteHalfToFloat = false);
 

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -1851,6 +1851,8 @@ struct IRVarLayout : IRLayout
 
         /// Does this variable use any resources of the given `kind`?
     bool usesResourceKind(LayoutResourceKind kind);
+        /// Returns true if there is use of one or more of the kinds
+    bool usesResourceFromKinds(LayoutResourceKindFlags kindFlags);
 
         /// Get the fixed/known stage that this variable is associated with.
         ///

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -1047,6 +1047,20 @@ namespace Slang
         return findOffsetAttr(kind) != nullptr;
     }
 
+    bool IRVarLayout::usesResourceFromKinds(LayoutResourceKindFlags kindFlags)
+    {
+        // Like usesResourceKind this works because there is an offset stored even if it's 0.
+        if (kindFlags)
+        {
+            for (auto offsetAttr : getOffsetAttrs())
+            {
+                if (LayoutResourceKindFlag::make(offsetAttr->getResourceKind()) & kindFlags )
+                    return true;
+            }
+        }
+        return false;
+    }
+
     IRSystemValueSemanticAttr* IRVarLayout::findSystemValueSemanticAttr()
     {
         return findAttr<IRSystemValueSemanticAttr>();

--- a/source/slang/slang-type-layout.h
+++ b/source/slang/slang-type-layout.h
@@ -243,6 +243,52 @@ struct UniformArrayLayoutInfo : UniformLayoutInfo
 
 typedef slang::ParameterCategory LayoutResourceKind;
 
+// Any change to slang::ParameterCategory, requires a change to this macro.
+#define SLANG_PARAMETER_CATEGORIES(x) \
+    x(None) \
+    x(Mixed) \
+    x(ConstantBuffer) \
+    x(ShaderResource) \
+    x(UnorderedAccess) \
+    x(VaryingInput) \
+    x(VaryingOutput) \
+    x(SamplerState) \
+    x(Uniform) \
+    x(DescriptorTableSlot) \
+    x(SpecializationConstant) \
+    x(PushConstantBuffer) \
+    x(RegisterSpace) \
+    x(GenericResource) \
+    \
+    x(RayPayload) \
+    x(HitAttributes) \
+    x(CallablePayload) \
+    \
+    x(ShaderRecord) \
+    \
+    x(ExistentialTypeParam) \
+    x(ExistentialObjectParam) \
+    \
+    x(VertexInput) \
+    x(FragmentOutput)
+
+#define SLANG_PARAMETER_CATEGORY_FLAG(x) x = ParameterCategoryFlags(1) << int(slang::x), 
+
+typedef uint32_t ParameterCategoryFlags;
+struct ParameterCategoryFlag
+{
+    enum Enum : ParameterCategoryFlags
+    {
+        SLANG_PARAMETER_CATEGORIES(SLANG_PARAMETER_CATEGORY_FLAG)
+    };
+
+        /// Make a flag from a category
+    SLANG_FORCE_INLINE static Enum make(slang::ParameterCategory cat) { return Enum(ParameterCategoryFlags(1) << int(cat)); }
+};
+
+typedef ParameterCategoryFlags LayoutResourceKindFlags;
+typedef ParameterCategoryFlag LayoutResourceKindFlag;
+
 // Layout information for a value that only consumes
 // a single resource kind.
 struct SimpleLayoutInfo


### PR DESCRIPTION
In #3004 tries to fix an issue that came up with vk-shift-* can make GLSL emit see HLSL binding types. Moreover there can be a mixture of automatic 'vulkan' layout and shifted types. The change allows for treating multiple LayoutResourceKinds that are in effect the same, to be handled in a robust way.