### PR TITLE
Fix data-flow analysis not propagating diff property through differentiable calls

### DIFF
--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -544,7 +544,16 @@ class TreatAsDifferentiableExpr : public Expr
     
     enum Flavor 
     {
+        /// Represents a no_diff wrapper over
+        /// a non-differentiable method.
+        /// i.e. no_diff(fn(...))
+        /// 
         NoDiff,
+
+        /// Represents a call to a method that
+        /// is either marked differentiable, or has
+        /// a user-defined derivative in scope.
+        /// 
         Differentiable
     };
 

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -541,6 +541,14 @@ class TreatAsDifferentiableExpr : public Expr
 
     Expr* innerExpr;
     Scope* scope;
+    
+    enum Flavor 
+    {
+        NoDiff,
+        Differentiable
+    };
+
+    Flavor flavor;
 };
 
     /// A type expression of the form `__TaggedUnion(A, ...)`.

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2265,6 +2265,7 @@ namespace Slang
                 {
                     maybeRegisterDifferentiableType(m_astBuilder, arg->type.type);
                 }
+
                 if (auto calleeExpr = as<DeclRefExpr>(checkedInvokeExpr->functionExpr))
                 {
                     if (auto calleeDecl = as<FunctionDeclBase>(calleeExpr->declRef.getDecl()))
@@ -2279,6 +2280,7 @@ namespace Slang
                                 newFuncExpr->type = checkedInvokeExpr->type;
                                 newFuncExpr->innerExpr = checkedInvokeExpr;
                                 newFuncExpr->loc = checkedInvokeExpr->loc;
+                                newFuncExpr->flavor = TreatAsDifferentiableExpr::Flavor::Differentiable;
                                 checkedExpr = newFuncExpr;
                             }
                             else

--- a/source/slang/slang-ir-check-differentiability.cpp
+++ b/source/slang/slang-ir-check-differentiability.cpp
@@ -502,8 +502,6 @@ public:
                 auto callInst = as<IRCall>(inst);
                 if (callInst->findDecoration<IRTreatCallAsDifferentiableDecoration>())
                     continue;
-                //if (!isDifferentiableFunc(callInst->getCallee(), DifferentiableLevel::Forward))
-                //    continue;
                 auto calleeFuncType = as<IRFuncType>(callInst->getCallee()->getFullType());
                 if (!calleeFuncType) continue;
                 if (calleeFuncType->getParamCount() != callInst->getArgCount())

--- a/source/slang/slang-ir-check-differentiability.cpp
+++ b/source/slang/slang-ir-check-differentiability.cpp
@@ -71,6 +71,15 @@ public:
         return false;
     }
 
+    bool shouldTreatCallAsDifferentiable(IRInst* callInst)
+    {
+        SLANG_ASSERT(as<IRCall>(callInst));
+
+        return (
+            callInst->findDecoration<IRTreatCallAsDifferentiableDecoration>() || 
+            callInst->findDecoration<IRDifferentiableCallDecoration>());
+    }
+
     bool isDifferentiableFunc(IRInst* func, DifferentiableLevel level)
     {
         switch (func->getOp())
@@ -300,7 +309,7 @@ public:
             case kIROp_FloatLit:
                 return true;
             case kIROp_Call:
-                return inst->findDecoration<IRTreatAsDifferentiableDecoration>() ||
+                return shouldTreatCallAsDifferentiable(inst) ||
                     isDifferentiableFunc(as<IRCall>(inst)->getCallee(), requiredDiffLevel) && isDifferentiableType(diffTypeContext, inst->getFullType());
             case kIROp_Load:
                 // We don't have more knowledge on whether diff is available at the destination address.
@@ -330,7 +339,7 @@ public:
             case kIROp_DetachDerivative:
                 return false;
             case kIROp_Call:
-                if (inst->findDecoration<IRTreatAsDifferentiableDecoration>())
+                if (shouldTreatCallAsDifferentiable(inst))
                     return false;
                 return isDifferentiableFunc(as<IRCall>(inst)->getCallee(), requiredDiffLevel) &&
                        isDifferentiableType(diffTypeContext, inst->getFullType());
@@ -451,7 +460,8 @@ public:
                     // If inst's type is differentiable, and it is in expectDiffInstWorkList,
                     // then some user is expecting the result of the call to produce a derivative.
                     // In this case we need to issue a diagnostic.
-                    if (isDifferentiableType(diffTypeContext, inst->getFullType()))
+                    if (isDifferentiableType(diffTypeContext, inst->getFullType()) && 
+                        !isDifferentiableFunc(call->getCallee(), requiredDiffLevel))
                     {
                         sink->diagnose(
                             inst,
@@ -490,10 +500,10 @@ public:
             case kIROp_Call:
             {
                 auto callInst = as<IRCall>(inst);
-                if (callInst->findDecoration<IRTreatAsDifferentiableDecoration>())
+                if (callInst->findDecoration<IRTreatCallAsDifferentiableDecoration>())
                     continue;
-                if (!isDifferentiableFunc(callInst->getCallee(), DifferentiableLevel::Forward))
-                    continue;
+                //if (!isDifferentiableFunc(callInst->getCallee(), DifferentiableLevel::Forward))
+                //    continue;
                 auto calleeFuncType = as<IRFuncType>(callInst->getCallee()->getFullType());
                 if (!calleeFuncType) continue;
                 if (calleeFuncType->getParamCount() != callInst->getArgCount())

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -867,9 +867,14 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
         /// differential member of a type in its associated differential type.
     INST(DerivativeMemberDecoration, derivativeMemberDecoration, 1, 0)
 
-        /// Treat a function as differentiable function, or an IRCall as a call to a differentiable function.
+        /// Treat a function as differentiable function
     INST(TreatAsDifferentiableDecoration, treatAsDifferentiableDecoration, 0, 0)
 
+        /// Treat a call to arbitrary function as a differentiable call.
+    INST(TreatCallAsDifferentiableDecoration, treatCallAsDifferentiableDecoration, 0, 0)
+
+        /// Mark a call as explicitly calling a differentiable function.
+    INST(DifferentiableCallDecoration, differentiableCallDecoration, 0, 0)
 
         /// Hint that the result from a call to the decorated function should be stored in backward prop function.
     INST(PreferCheckpointDecoration, PreferCheckpointDecoration, 0, 0)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -899,6 +899,26 @@ struct IRTreatAsDifferentiableDecoration : IRDecoration
     IR_LEAF_ISA(TreatAsDifferentiableDecoration)
 };
 
+// Mark a call as explicitly calling a differentiable function.
+struct IRDifferentiableCallDecoration : IRDecoration
+{
+    enum
+    {
+        kOp = kIROp_DifferentiableCallDecoration
+    };
+    IR_LEAF_ISA(DifferentiableCallDecoration)
+};
+
+// Treat a call to a non-differentiable function as a differentiable call.
+struct IRTreatCallAsDifferentiableDecoration : IRDecoration
+{
+    enum
+    {
+        kOp = kIROp_TreatCallAsDifferentiableDecoration
+    };
+    IR_LEAF_ISA(TreatCallAsDifferentiableDecoration)
+};
+
 struct IRDerivativeMemberDecoration : IRDecoration
 {
     enum

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -5298,6 +5298,7 @@ namespace Slang
         auto noDiffExpr = parser->astBuilder->create<TreatAsDifferentiableExpr>();
         noDiffExpr->innerExpr = parser->ParseLeafExpression();
         noDiffExpr->scope = parser->currentScope;
+        noDiffExpr->flavor = TreatAsDifferentiableExpr::Flavor::NoDiff;
         return noDiffExpr;
     }
 

--- a/tests/diagnostics/autodiff-data-flow-4.slang
+++ b/tests/diagnostics/autodiff-data-flow-4.slang
@@ -1,0 +1,37 @@
+//DIAGNOSTIC_TEST:SIMPLE:
+
+float nonDiff(float x)
+{
+    return x;
+}
+
+[Differentiable]
+float f(float x)
+{
+    return x * x;
+}
+
+[Differentiable]
+float g(float x)
+{
+    float val = f(x + 1); // Error: f must also be backward-differentiable
+    return val;
+}
+
+[Differentiable]
+float h(float x)
+{
+    float val = 0;
+
+    // call to non-differentiable method 
+    // (should error if the data-flow propagation works properly.)
+    // 
+    float y = nonDiff(x);
+
+    // call to a differentiable method, using the
+    // result of a non-differentiable call.
+    // 
+    val = f(y);
+
+    return val;
+}

--- a/tests/diagnostics/autodiff-data-flow-4.slang
+++ b/tests/diagnostics/autodiff-data-flow-4.slang
@@ -12,13 +12,6 @@ float f(float x)
 }
 
 [Differentiable]
-float g(float x)
-{
-    float val = f(x + 1); // Error: f must also be backward-differentiable
-    return val;
-}
-
-[Differentiable]
 float h(float x)
 {
     float val = 0;

--- a/tests/diagnostics/autodiff-data-flow-4.slang.expected
+++ b/tests/diagnostics/autodiff-data-flow-4.slang.expected
@@ -1,0 +1,8 @@
+result code = -1
+standard error = {
+tests/diagnostics/autodiff-data-flow-4.slang(29): error 41020: derivative cannot be propagated through call to non-backward-differentiable function `nonDiff`, use 'no_diff' to clarify intention.
+    float y = nonDiff(x);
+                     ^
+}
+standard output = {
+}


### PR DESCRIPTION
 - Add logic & new decorations to disambiguate calls to differentiable and non-differentiable calls
         (Made `TreatAsDifferentiableDecoration` a function-definiton decoration and introduced `DifferentiableCallDecoration` & `TreatCallAsDifferentiableDecoration` for call-sites.
- Add test