### PR TITLE
Add slang.natjmc.

### DIFF
--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -711,6 +711,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <None Include="..\..\..\source\slang\core.meta.slang" />
     <None Include="..\..\..\source\slang\diff.meta.slang" />
     <None Include="..\..\..\source\slang\hlsl.meta.slang" />
+    <None Include="..\..\..\source\slang\slang.natjmc" />
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="..\..\..\source\core\core.natvis" />

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -1213,6 +1213,9 @@
     <None Include="..\..\..\source\slang\hlsl.meta.slang">
       <Filter>Source Files</Filter>
     </None>
+    <None Include="..\..\..\source\slang\slang.natjmc">
+      <Filter>Source Files</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="..\..\..\source\core\core.natvis">

--- a/premake5.lua
+++ b/premake5.lua
@@ -487,6 +487,10 @@ function addSourceDir(path)
         path .. "/*.h",         -- Header files
         path .. "/*.hpp",       -- C++ style headers (for glslang)
         path .. "/*.natvis",    -- Visual Studio debugger visualization files
+        path .. "/*.natstepfilter", -- Visual Studio debugger step filter files
+        path .. "/*.natjmc", -- Visual Studio debugger step filter files
+
+
     }
     removefiles
     {
@@ -613,7 +617,7 @@ function baseSlangProject(name, sourceDir)
     --
     vpaths {
         { ["Header Files"] = { "**.h", "**.hpp"} },
-        { ["Source Files"] = { "**.cpp", "**.slang", "**.natvis" } },
+        { ["Source Files"] = { "**.cpp", "**.slang", "**.natvis", "**.natjmc" } },
     }
 
     -- Override default options for a project if necessary

--- a/source/slang/slang.natjmc
+++ b/source/slang/slang.natjmc
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<NonUserCode xmlns="http://schemas.microsoft.com/vstudio/debugger/jmc/2015">
+
+  <!-- Functions -->
+  <Function Name="Slang::Expr::accept" />
+  <Function Name="Slang::DeclBase::accept" />
+
+  <Function Name="Slang::Val::accept" />
+  <Function Name="Slang::Type::accept" />
+  <Function Name="Slang::Stmt::accept" />
+  <Function Name="Slang::NodeBase::getClassInfo" />
+  <Function Name="Slang::ASTClassInfo::getInfo" />
+
+  <Function Name="Slang::*Visitor&lt;*,*&gt;::dispatch_*" />
+  <Function Name="Slang::*Visitor&lt;*,*&gt;::dispatch" />
+  <Function Name="Slang::SemanticsVisitor::dispatch*" />
+  <Function Name="Slang::Semantics*Visitor::Semantics*Visitor" />
+
+</NonUserCode>


### PR DESCRIPTION
This allows Visual Studio debugger to skip over AST visitor dispatch functions and stop directly at the `visit*` functions when stepping into a `dispatch*` call.

Works with Visual Studio 17.6.