### PR TITLE
Add glsl intrinsics for CalculateLevelOfDetail

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1358,9 +1358,11 @@ struct TextureTypeInfo
 
         if( !isMultisample )
         {
+            sb << "__target_intrinsic(glsl, \"textureQueryLod($p, $2).x\")";
             sb << "float CalculateLevelOfDetail(" << samplerStateParam;
             sb << "float" << base.coordCount << " location);\n";
 
+            sb << "__target_intrinsic(glsl, \"textureQueryLod($p, $2).y\")";
             sb << "float CalculateLevelOfDetailUnclamped(" << samplerStateParam;
             sb << "float" << base.coordCount << " location);\n";
         }

--- a/tests/cross-compile/glsl-calculatelevelofdetail.slang
+++ b/tests/cross-compile/glsl-calculatelevelofdetail.slang
@@ -1,0 +1,11 @@
+//TEST:CROSS_COMPILE(filecheck=CHECK): -profile ps_5_0 -entry main -target glsl
+
+// CHECK: textureQueryLod(sampler2D(t_0,s_0), ({{.*}})).x
+// CHECK: textureQueryLod(sampler2D(t_0,s_0), ({{.*}})).y
+
+Texture2D t;
+SamplerState s;
+float main()
+{
+    return t.CalculateLevelOfDetail(s, float2(0,0)) + t.CalculateLevelOfDetailUnclamped(s, float2(0,0));
+}


### PR DESCRIPTION
Translates to textureQueryLod().x (with the Unclameped variant being returned in the .y component)

Closes https://github.com/shader-slang/slang/issues/3020