### PR TITLE
Use ankerl/unordered_dense as a hashmap implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "external/lz4"]
 	path = external/lz4
 	url = https://github.com/lz4/lz4
+[submodule "external/unordered_dense"]
+	path = external/unordered_dense
+	url = https://github.com/martinus/unordered_dense.git

--- a/build/visual-studio/core/core.vcxproj
+++ b/build/visual-studio/core/core.vcxproj
@@ -320,6 +320,7 @@
     <ClInclude Include="..\..\..\source\core\slang-short-list.h" />
     <ClInclude Include="..\..\..\source\core\slang-signal.h" />
     <ClInclude Include="..\..\..\source\core\slang-smart-pointer.h" />
+    <ClInclude Include="..\..\..\source\core\slang-stable-hash.h" />
     <ClInclude Include="..\..\..\source\core\slang-std-writers.h" />
     <ClInclude Include="..\..\..\source\core\slang-stream.h" />
     <ClInclude Include="..\..\..\source\core\slang-string-escape-util.h" />

--- a/build/visual-studio/core/core.vcxproj.filters
+++ b/build/visual-studio/core/core.vcxproj.filters
@@ -174,6 +174,9 @@
     <ClInclude Include="..\..\..\source\core\slang-smart-pointer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\core\slang-stable-hash.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\source\core\slang-std-writers.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/build/visual-studio/slang-rt/slang-rt.vcxproj
+++ b/build/visual-studio/slang-rt/slang-rt.vcxproj
@@ -332,6 +332,7 @@
     <ClInclude Include="..\..\..\source\core\slang-short-list.h" />
     <ClInclude Include="..\..\..\source\core\slang-signal.h" />
     <ClInclude Include="..\..\..\source\core\slang-smart-pointer.h" />
+    <ClInclude Include="..\..\..\source\core\slang-stable-hash.h" />
     <ClInclude Include="..\..\..\source\core\slang-std-writers.h" />
     <ClInclude Include="..\..\..\source\core\slang-stream.h" />
     <ClInclude Include="..\..\..\source\core\slang-string-escape-util.h" />

--- a/build/visual-studio/slang-rt/slang-rt.vcxproj.filters
+++ b/build/visual-studio/slang-rt/slang-rt.vcxproj.filters
@@ -174,6 +174,9 @@
     <ClInclude Include="..\..\..\source\core\slang-smart-pointer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\core\slang-stable-hash.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\source\core\slang-std-writers.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/premake5.lua
+++ b/premake5.lua
@@ -452,9 +452,6 @@ workspace "slang"
             defines { "SLANG_CONFIG_DEFAULT_SPIRV_DIRECT" }
         end
 
-        -- Includes made available to every build target
-        includedirs { "external/unordered_dense/include" }
-
 function dump(o)
     if type(o) == 'table' then
         local s = '{ '

--- a/premake5.lua
+++ b/premake5.lua
@@ -448,6 +448,9 @@ workspace "slang"
             defines { "SLANG_CONFIG_DEFAULT_SPIRV_DIRECT" }
         end
 
+        -- Includes made available to every build target
+        includedirs { "external/unordered_dense/include" }
+
 function dump(o)
     if type(o) == 'table' then
         local s = '{ '

--- a/premake5.lua
+++ b/premake5.lua
@@ -408,6 +408,10 @@ workspace "slang"
     filter { "toolset:clang or gcc*", "language:C++" }
         buildoptions { "-Wno-reorder", "-Wno-invalid-offsetof" }
 
+    -- Enable some warnings on clang/gcc which are on by default in MSVC
+    filter { "toolset:clang or gcc*", "language:C++" }
+        buildoptions { "-Wnarrowing" }
+
     -- When compiling the debug configuration, we want to turn
     -- optimization off, make sure debug symbols are output,
     -- and add the same preprocessor definition that VS

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1074,16 +1074,8 @@ struct ShaderOffset
     {
         return (uint32_t)(((bindingRangeIndex << 20) + bindingArrayIndex) ^ uniformOffset);
     }
-    bool operator==(const ShaderOffset& other) const
-    {
-        return uniformOffset == other.uniformOffset
-            && bindingRangeIndex == other.bindingRangeIndex
-            && bindingArrayIndex == other.bindingArrayIndex;
-    }
-    bool operator!=(const ShaderOffset& other) const
-    {
-        return !this->operator==(other);
-    }
+    bool operator==(const ShaderOffset&) const = default;
+    bool operator!=(const ShaderOffset&) const = default;
     bool operator<(const ShaderOffset& other) const
     {
         if (bindingRangeIndex < other.bindingRangeIndex)

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1074,8 +1074,16 @@ struct ShaderOffset
     {
         return (uint32_t)(((bindingRangeIndex << 20) + bindingArrayIndex) ^ uniformOffset);
     }
-    bool operator==(const ShaderOffset&) const = default;
-    bool operator!=(const ShaderOffset&) const = default;
+    bool operator==(const ShaderOffset& other) const
+    {
+        return uniformOffset == other.uniformOffset
+            && bindingRangeIndex == other.bindingRangeIndex
+            && bindingArrayIndex == other.bindingArrayIndex;
+    }
+    bool operator!=(const ShaderOffset& other) const
+    {
+        return !this->operator==(other);
+    }
     bool operator<(const ShaderOffset& other) const
     {
         if (bindingRangeIndex < other.bindingRangeIndex)

--- a/slang.h
+++ b/slang.h
@@ -287,8 +287,7 @@ convention for interface methods.
 #endif
 
 #ifndef SLANG_COMPILE_TIME_ASSERT
-//  TODO(C++17), can use terse static_assert
-#   define SLANG_COMPILE_TIME_ASSERT(x) static_assert(x, #x)
+#   define SLANG_COMPILE_TIME_ASSERT(x) static_assert(x)
 #endif
 
 #ifndef SLANG_OFFSET_OF

--- a/slang.h
+++ b/slang.h
@@ -2412,7 +2412,7 @@ extern "C"
 
         /// Compute a string hash.
         /// Count should *NOT* include terminating zero.
-    SLANG_API int spComputeStringHash(const char* chars, size_t count);
+    SLANG_API SlangUInt32 spComputeStringHash(const char* chars, size_t count);
 
         /// Get a type layout representing reflection information for the global-scope prameters.
     SLANG_API SlangReflectionTypeLayout* spReflection_getGlobalParamsTypeLayout(

--- a/source/compiler-core/slang-source-loc.cpp
+++ b/source/compiler-core/slang-source-loc.cpp
@@ -318,7 +318,6 @@ SlangResult SourceView::_findSourceMapLoc(SourceLoc loc, SourceLocType type, Han
     // view, which may be a parent to the current one. 
     auto lookupSourceManager = m_sourceFile->getSourceManager();
 
-    HandleSourceLoc handleLoc;
     SLANG_RETURN_ON_FAIL(_findLocWithSourceMap(lookupSourceManager, this, loc, type, outLoc));
 
     return SLANG_OK;

--- a/source/compiler-core/slang-visual-studio-compiler-util.cpp
+++ b/source/compiler-core/slang-visual-studio-compiler-util.cpp
@@ -83,14 +83,17 @@ static void _addFile(const String& path, const ArtifactDesc& desc, IOSFileArtifa
     // Display full path of source files in diagnostics
     cmdLine.addArg("/FC");
 
-    if (options.flags & CompileOptions::Flag::EnableExceptionHandling)
+    if (options.sourceLanguage == SLANG_SOURCE_LANGUAGE_CPP)
     {
-        if (options.sourceLanguage == SLANG_SOURCE_LANGUAGE_CPP)
+        if (options.flags & CompileOptions::Flag::EnableExceptionHandling)
         {
             // https://docs.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=vs-2019
             // Assumes c functions cannot throw
             cmdLine.addArg("/EHsc");
         }
+
+        // To maintain parity with the slang compiler headers which are shared
+        cmdLine.addArg("/std:c++17");
     }
 
     if (options.flags & CompileOptions::Flag::Verbose)

--- a/source/core/slang-dictionary.h
+++ b/source/core/slang-dictionary.h
@@ -76,14 +76,15 @@ namespace Slang
 
     const float kMaxLoadFactor = 0.7f;
 
-    template<typename TKey, typename TValue>
+    template<typename TKey, typename TValue, typename Hash = Slang::Hash<TKey>, typename KeyEqual = std::equal_to<TKey>>
     class Dictionary
     {
         using InnerMap = ankerl::unordered_dense::map<
             TKey,
             TValue,
-            Hash<TKey>>;
-        using ThisType = Dictionary<TKey, TValue>;
+            Hash,
+            KeyEqual>;
+        using ThisType = Dictionary<TKey, TValue, Hash, KeyEqual>;
         InnerMap map;
     public:
         //

--- a/source/core/slang-dictionary.h
+++ b/source/core/slang-dictionary.h
@@ -8,6 +8,7 @@
 #include "slang-exception.h"
 #include "slang-math.h"
 #include "slang-hash.h"
+#include "ankerl/unordered_dense.h"
 
 namespace Slang
 {
@@ -78,492 +79,185 @@ namespace Slang
     template<typename TKey, typename TValue>
     class Dictionary
     {
-        friend class Iterator;
-        friend class ItemProxy;
+        using InnerMap = ankerl::unordered_dense::map<
+            TKey,
+            TValue,
+            Hash<TKey>>;
+        using ThisType = Dictionary<TKey, TValue>;
+        InnerMap map;
     public:
-        typedef TValue ValueType;
-        typedef TKey KeyType;
-        typedef Dictionary ThisType;
-    private:
-        inline int getProbeOffset(int /*probeId*/) const
-        {
-            // linear probing
-            return 1;
-        }
-    private:
-        int m_bucketCountMinusOne;
-        int m_count;
-        UIntSet m_marks;
-        KeyValuePair<TKey, TValue>* m_hashMap;
-        void deallocateAll()
-        {
-            if (m_hashMap)
-                delete[] m_hashMap;
-            m_hashMap = nullptr;
-        }
-        inline bool isDeleted(int pos) const
-        {
-            return m_marks.contains((pos << 1) + 1);
-        }
-        inline bool isEmpty(int pos) const
-        {
-            return !m_marks.contains((pos << 1));
-        }
-        inline void setDeleted(int pos, bool val)
-        {
-            if (val)
-                m_marks.add((pos << 1) + 1);
-            else
-                m_marks.remove((pos << 1) + 1);
-        }
-        inline void setEmpty(int pos, bool val)
-        {
-            if (val)
-                m_marks.remove((pos << 1));
-            else
-                m_marks.add((pos << 1));
-        }
-        struct FindPositionResult
-        {
-            int objectPosition;
-            int insertionPosition;
+        //
+        // Types
+        //
+        using Iterator = InnerMap::iterator;
+        using ConstIterator = InnerMap::const_iterator;
+        using KeyType = TKey;
+        using ValueType = TValue;
 
-            FindPositionResult()
-            {
-                objectPosition = -1;
-                insertionPosition = -1;
-            }
-            FindPositionResult(int objPos, int insertPos)
-            {
-                objectPosition = objPos;
-                insertionPosition = insertPos;
-            }
-        };
-        template<typename KeyType>
-        inline int getHashPos(KeyType& key) const
+        //
+        // Iterators
+        //
+
+        auto begin() { return map.begin(); }
+        auto begin() const { return map.begin(); }
+        auto end() { return map.end(); }
+        auto end() const { return map.end(); }
+
+        //
+        // Modifiers
+        //
+
+        // Removes all values from the map
+        void clear() { map.clear(); }
+
+        // Erases the value at the specified key if it exists
+        void remove(const TKey& key) { map.erase(key); }
+
+        // Reserves enough space for the specified number of values
+        void reserve(std::size_t size) { map.reserve(size); };
+
+        // Swap with another map
+        void swapWith(ThisType& rhs) { std::swap(*this, rhs); }
+
+        //
+        // Query capacity
+        //
+
+        // TODO: too small return type
+        std::size_t getCount() const { return map.size(); }
+
+        //
+        // Lookup
+        //
+
+        // Returns true if the map contains an equivalent key
+        template<typename K>
+        bool containsKey(const K& k) const { return map.contains(k); }
+
+        // Returns a valid pointer to the requested element, or nullptr if it
+        // doesn't exist
+        template<typename K>
+        const TValue* tryGetValue(const K& key) const
         {
-            SLANG_ASSERT(m_bucketCountMinusOne > 0);
-            const unsigned int hash = (unsigned int)getHashCode(key);
-            return (hash * 2654435761u) % (unsigned int)(m_bucketCountMinusOne);
+            auto i = map.find(key);
+            return i == map.end() ? nullptr : &(i->second);
         }
-        template<typename KeyType>
-        FindPositionResult findPosition(const KeyType& key) const
+        // Returns a valid pointer to the requested element, or nullptr if it
+        // doesn't exist
+        template<typename K>
+        TValue* tryGetValue(const K& key)
         {
-            int hashPos = getHashPos(const_cast<KeyType&>(key));
-            int insertPos = -1;
-            int numProbes = 0;
-            while (numProbes <= m_bucketCountMinusOne)
-            {
-                if (isEmpty(hashPos))
-                {
-                    if (insertPos == -1)
-                        return FindPositionResult(-1, hashPos);
-                    else
-                        return FindPositionResult(-1, insertPos);
-                }
-                else if (isDeleted(hashPos))
-                {
-                    if (insertPos == -1)
-                        insertPos = hashPos;
-                }
-                else if (m_hashMap[hashPos].key == key)
-                {
-                    return FindPositionResult(hashPos, -1);
-                }
-                numProbes++;
-                hashPos = (hashPos + getProbeOffset(numProbes)) & m_bucketCountMinusOne;
-            }
-            if (insertPos != -1)
-                return FindPositionResult(-1, insertPos);
-            SLANG_ASSERT_FAILURE("Hash map is full. This indicates an error in Key::Equal or Key::getHashCode.");
-        }
-        TValue& _insert(KeyValuePair<TKey, TValue>&& kvPair, int pos)
-        {
-            m_hashMap[pos] = _Move(kvPair);
-            setEmpty(pos, false);
-            setDeleted(pos, false);
-            return m_hashMap[pos].value;
-        }
-        void maybeRehash()
-        {
-            if (m_bucketCountMinusOne == -1 || m_count >= int(kMaxLoadFactor * m_bucketCountMinusOne))
-            {
-                int newSize = (m_bucketCountMinusOne + 1) * 2;
-                if (newSize == 0)
-                {
-                    newSize = 64;
-                }
-                reserve(newSize);
-            }
+            auto i = map.find(key);
+            return i == map.end() ? nullptr : std::addressof(i->second);
         }
 
-        bool addIfNotExists(KeyValuePair<TKey, TValue>&& kvPair)
+        // Returns true and copies the element into 'value' if present.
+        // Otherwise returns false and value unmodified.
+        template<typename K>
+        bool tryGetValue(const K& key, TValue& value) const
         {
-            maybeRehash();
-            auto pos = findPosition(kvPair.key);
-            if (pos.objectPosition != -1)
+            auto i = map.find(key);
+            if(i == map.end())
                 return false;
-            else if (pos.insertionPosition != -1)
-            {
-                m_count++;
-                _insert(_Move(kvPair), pos.insertionPosition);
-                return true;
-            }
-            else
-                SLANG_ASSERT_FAILURE("Inconsistent find result returned. This is a bug in Dictionary implementation.");
-        }
-        void add(KeyValuePair<TKey, TValue>&& kvPair)
-        {
-            if (!addIfNotExists(_Move(kvPair)))
-                SLANG_ASSERT_FAILURE("The key already exists in Dictionary.");
-        }
-        TValue& set(KeyValuePair<TKey, TValue>&& kvPair)
-        {
-            maybeRehash();
-            auto pos = findPosition(kvPair.key);
-            if (pos.objectPosition != -1)
-                return _insert(_Move(kvPair), pos.objectPosition);
-            else if (pos.insertionPosition != -1)
-            {
-                m_count++;
-                return _insert(_Move(kvPair), pos.insertionPosition);
-            }
-            else
-                SLANG_ASSERT_FAILURE("Inconsistent find result returned. This is a bug in Dictionary implementation.");
-        }
-    public:
-        class Iterator
-        {
-        private:
-            const Dictionary<TKey, TValue>* dict;
-            int pos;
-        public:
-            KeyValuePair<TKey, TValue>& operator*() const
-            {
-                return dict->m_hashMap[pos];
-            }
-            KeyValuePair<TKey, TValue>* operator->() const
-            {
-                return dict->m_hashMap + pos;
-            }
-            Iterator& operator++()
-            {
-                if (pos > dict->m_bucketCountMinusOne)
-                    return *this;
-                pos++;
-                while (pos <= dict->m_bucketCountMinusOne && (dict->isDeleted(pos) || dict->isEmpty(pos)))
-                {
-                    pos++;
-                }
-                return *this;
-            }
-            Iterator operator++(int)
-            {
-                Iterator rs = *this;
-                operator++();
-                return rs;
-            }
-            bool operator!=(const Iterator& that) const
-            {
-                return pos != that.pos || dict != that.dict;
-            }
-            bool operator==(const Iterator& that) const
-            {
-                return pos == that.pos && dict == that.dict;
-            }
-            Iterator(const Dictionary<TKey, TValue>* inDict, int inPos)
-            {
-                this->dict = inDict;
-                this->pos = inPos;
-            }
-            Iterator()
-            {
-                this->dict = nullptr;
-                this->pos = 0;
-            }
-        };
-
-        Iterator begin() const
-        {
-            int pos = 0;
-            while (pos < m_bucketCountMinusOne + 1)
-            {
-                if (isEmpty(pos) || isDeleted(pos))
-                    pos++;
-                else
-                    break;
-            }
-            return Iterator(this, pos);
-        }
-        Iterator end() const
-        {
-            return Iterator(this, m_bucketCountMinusOne + 1);
-        }
-    public:
-        void add(const TKey& key, const TValue& value)
-        {
-            add(KeyValuePair<TKey, TValue>(key, value));
-        }
-        void add(TKey&& key, TValue&& value)
-        {
-            add(KeyValuePair<TKey, TValue>(_Move(key), _Move(value)));
-        }
-        bool addIfNotExists(const TKey& key, const TValue& value)
-        {
-            return addIfNotExists(KeyValuePair<TKey, TValue>(key, value));
-        }
-        bool addIfNotExists(TKey&& key, TValue&& value)
-        {
-            return addIfNotExists(KeyValuePair<TKey, TValue>(_Move(key), _Move(value)));
-        }
-        void remove(const TKey& key)
-        {
-            if (m_count == 0)
-                return;
-            auto pos = findPosition(key);
-            if (pos.objectPosition != -1)
-            {
-                setDeleted(pos.objectPosition, true);
-                m_count--;
-            }
-        }
-        void clear()
-        {
-            m_count = 0;
-            m_marks.clear();
+            value = i->second;
+            return true;
         }
 
-        void reserve(int newSize)
+        // Returns a const reference to the value at the given key. Asserts if
+        // the value doesn't exist
+        const TValue& at(const TKey& key) const
         {
-            if (newSize <= m_bucketCountMinusOne + 1)
-                return;
-
-            Dictionary<TKey, TValue> newDict;
-            newDict.m_bucketCountMinusOne = newSize - 1;
-            newDict.m_hashMap = new KeyValuePair<TKey, TValue>[newSize];
-            newDict.m_marks.resizeAndClear(newSize * 2);
-            if (m_hashMap)
-            {
-                for (auto& kvPair : *this)
-                {
-                    newDict.add(_Move(kvPair));
-                }
-            }
-            *this = _Move(newDict);
+            if(const auto x = tryGetValue(key))
+                return *x;
+            SLANG_ASSERT_FAILURE("The key does not exist in dictionary.");
         }
 
-        TValue* tryGetValueOrAdd(const TKey& key, const TValue& value)
+        // Returns a reference to the value at the given key. Asserts if the
+        // value doesn't exist
+        TValue& at(const TKey& key)
         {
-            maybeRehash();
-            auto pos = findPosition(key);
-            if (pos.objectPosition != -1)
-            {
-                return &m_hashMap[pos.objectPosition].value;
-            }
-            else if (pos.insertionPosition != -1)
-            {
-                // Make pair
-                KeyValuePair<TKey, TValue> kvPair(_Move(key), _Move(value));
-                m_count++;
-                _insert(_Move(kvPair), pos.insertionPosition);
-                return nullptr;
-            }
-            else
-                SLANG_ASSERT_FAILURE("Inconsistent find result returned. This is a bug in Dictionary implementation.");
+            if(const auto x = tryGetValue(key))
+                return *x;
+            SLANG_ASSERT_FAILURE("The key does not exist in dictionary.");
         }
 
-            /// This differs from tryGetValueOrAdd, in that it always returns the Value held in the Dictionary.
-            /// If there isn't already an entry for 'key', a value is added with defaultValue. 
+        //
+        // Combined Lookup and Insertion
+        //
+
+        // Tries to insert the given element, if a value was already present at
+        // the given key then returns a pointer to that element instead.
+        // Returns nullptr if insertion was successful.
+        TValue* tryGetValueOrAdd(const InnerMap::value_type& kvPair)
+        {
+            const auto& [iterator, inserted] = map.insert(kvPair);
+            return inserted ? nullptr : std::addressof(iterator->second);
+        }
+        // Tries to insert the given element, if a value was already present at
+        // the given key then returns a pointer to that element instead.
+        // Returns nullptr if insertion was successful.
+        TValue* tryGetValueOrAdd(InnerMap::value_type&& kvPair)
+        {
+            const auto& [iterator, inserted] = map.insert(std::move(kvPair));
+            return inserted ? nullptr : std::addressof(iterator->second);
+        }
+        // Tries to insert the given element, if a value was already present at
+        // the given key then returns a pointer to that element instead.
+        // Returns nullptr if insertion was successful.
+        TValue* tryGetValueOrAdd(const TKey& key, const TValue& value) { return tryGetValueOrAdd({key, value}); }
+
+        // Inserts the given value if it doesn't exist already
+        // Return a reference to the (possibly new) value in the map
         TValue& getOrAddValue(const TKey& key, const TValue& defaultValue)
         {
-            maybeRehash();
-            auto pos = findPosition(key);
-            if (pos.objectPosition != -1)
-            {
-                return m_hashMap[pos.objectPosition].value;
-            }
-            else if (pos.insertionPosition != -1)
-            {
-                // Make pair
-                KeyValuePair<TKey, TValue> kvPair(_Move(key), _Move(defaultValue));
-                m_count++;
-                return _insert(_Move(kvPair), pos.insertionPosition);
-            }
-            else
-                SLANG_ASSERT_FAILURE("Inconsistent find result returned. This is a bug in Dictionary implementation.");
-        }
-        void set(const TKey& key, const TValue& value)
-        {
-            if (auto ptr = tryGetValueOrAdd(key, value))
-            {
-                *ptr = value;
-            }
+            auto [iterator, inserted] = map.insert({key, defaultValue});
+            return iterator->second;
         }
 
-        template<typename KeyType>
-        bool containsKey(const KeyType& key) const
-        {
-            if (m_bucketCountMinusOne == -1)
-                return false;
-            auto pos = findPosition(key);
-            return pos.objectPosition != -1;
-        }
-        template<typename KeyType>
-        bool tryGetValue(const KeyType& key, TValue& value) const
-        {
-            if (m_bucketCountMinusOne == -1)
-                return false;
-            auto pos = findPosition(key);
-            if (pos.objectPosition != -1)
-            {
-                value = m_hashMap[pos.objectPosition].value;
-                return true;
-            }
-            return false;
-        }
-        template<typename KeyType>
-        TValue* tryGetValue(const KeyType& key) const
-        {
-            if (m_bucketCountMinusOne == -1)
-                return nullptr;
-            auto pos = findPosition(key);
-            if (pos.objectPosition != -1)
-            {
-                return &m_hashMap[pos.objectPosition].value;
-            }
-            return nullptr;
-        }
+        // Returns a reference to the value at the specified key, default
+        // initializing it if it doesn't already exist
+        TValue& operator[]( const TKey& key ) { return map[key]; }
+        // Returns a reference to the value at the specified key, default
+        // initializing it if it doesn't already exist
+        TValue& operator[]( TKey&& key ) { return map[std::move(key)]; }
 
-        class ItemProxy
-        {
-        private:
-            const Dictionary<TKey, TValue>* dict;
-            TKey key;
-        public:
-            ItemProxy(const TKey& _key, const Dictionary<TKey, TValue>* _dict)
-            {
-                this->dict = _dict;
-                this->key = _key;
-            }
-            ItemProxy(TKey&& _key, const Dictionary<TKey, TValue>* _dict)
-            {
-                this->dict = _dict;
-                this->key = _Move(_key);
-            }
-            TValue& getValue() const
-            {
-                auto pos = dict->findPosition(key);
-                if (pos.objectPosition != -1)
-                {
-                    return dict->m_hashMap[pos.objectPosition].value;
-                }
-                else
-                    SLANG_ASSERT_FAILURE("The key does not exist in dictionary.");
-            }
-            inline TValue& operator()() const
-            {
-                return getValue();
-            }
-            operator TValue&() const
-            {
-                return getValue();
-            }
-            TValue& operator=(const TValue& val) const
-            {
-                return ((Dictionary<TKey, TValue>*)dict)->set(KeyValuePair<TKey, TValue>(_Move(key), val));
-            }
-            TValue& operator=(TValue&& val) const
-            {
-                return ((Dictionary<TKey, TValue>*)dict)->set(KeyValuePair<TKey, TValue>(_Move(key), _Move(val)));
-            }
-        };
-        ItemProxy operator[](const TKey& key) const
-        {
-            return ItemProxy(key, this);
-        }
-        ItemProxy operator[](TKey&& key) const
-        {
-            return ItemProxy(_Move(key), this);
-        }
-        int getCount() const
-        {
-            return m_count;
-        }
+        //
+        // Insertion
+        //
 
-            /// Swap this with rhs
-        void swapWith(ThisType& rhs);
+        // Returns true if the value was inserted, returns false if the map
+        // already has a value associated with this key
+        bool addIfNotExists(InnerMap::value_type&& kvPair) { return !tryGetValueOrAdd(std::move(kvPair)); }
+        // Returns true if the value was inserted, returns false if the map
+        // already has a value associated with this key
+        bool addIfNotExists(const InnerMap::value_type& kvPair) { return !tryGetValueOrAdd(kvPair); }
+        // Returns true if the value was inserted, returns false if the map
+        // already has a value associated with this key
+        bool addIfNotExists(const TKey& k, const TValue& v) { return addIfNotExists({k, v}); }
+        // Returns true if the value was inserted, returns false if the map
+        // already has a value associated with this key
+        bool addIfNotExists(TKey&& k, TValue&& v) { return addIfNotExists({std::move(k), std::move(v)}); }
 
-    private:
-        template<typename... Args>
-        void init(const KeyValuePair<TKey, TValue>& kvPair, Args... args)
+        // Asserts if the key already exists in the dictionary
+        void add(InnerMap::value_type&& kvPair)
         {
-            add(kvPair);
-            init(args...);
+            if (!addIfNotExists(std::move(kvPair)))
+                SLANG_ASSERT_FAILURE("The key already exists in Dictionary.");
         }
-    public:
-        Dictionary()
+        // Asserts if the key already exists in the dictionary
+        void add(const InnerMap::value_type& kvPair)
         {
-            m_bucketCountMinusOne = -1;
-            m_count = 0;
-            m_hashMap = nullptr;
+            if (!addIfNotExists(kvPair))
+                SLANG_ASSERT_FAILURE("The key already exists in Dictionary.");
         }
-        template<typename Arg, typename... Args>
-        Dictionary(Arg arg, Args... args)
-        {
-            init(arg, args...);
-        }
-        Dictionary(const Dictionary<TKey, TValue>& other)
-            : m_bucketCountMinusOne(-1), m_count(0), m_hashMap(nullptr)
-        {
-            *this = other;
-        }
-        Dictionary(Dictionary<TKey, TValue>&& other)
-            : m_bucketCountMinusOne(-1), m_count(0), m_hashMap(nullptr)
-        {
-            *this = (_Move(other));
-        }
-        Dictionary<TKey, TValue>& operator=(const Dictionary<TKey, TValue>& other)
-        {
-            if (this == &other)
-                return *this;
-            deallocateAll();
-            m_bucketCountMinusOne = other.m_bucketCountMinusOne;
-            m_count = other.m_count;
-            m_hashMap = new KeyValuePair<TKey, TValue>[other.m_bucketCountMinusOne + 1];
-            m_marks = other.m_marks;
-            for (int i = 0; i <= m_bucketCountMinusOne; i++)
-                m_hashMap[i] = other.m_hashMap[i];
-            return *this;
-        }
-        Dictionary<TKey, TValue>& operator=(Dictionary<TKey, TValue>&& other)
-        {
-            if (this == &other)
-                return *this;
-            deallocateAll();
-            m_bucketCountMinusOne = other.m_bucketCountMinusOne;
-            m_count = other.m_count;
-            m_hashMap = other.m_hashMap;
-            m_marks = _Move(other.m_marks);
-            other.m_hashMap = nullptr;
-            other.m_count = 0;
-            other.m_bucketCountMinusOne = -1;
-            return *this;
-        }
-        ~Dictionary()
-        {
-            deallocateAll();
-        }
+        // Asserts if the key already exists in the dictionary
+        void add(const TKey& key, const TValue& value) { add({key, value}); }
+        // Asserts if the key already exists in the dictionary
+        void add(TKey&& key, TValue&& value) { add({std::move(key), std::move(value)}); }
+
+        // Inserts into the dictionary or assigns if the key already exists
+        void set(const TKey& key, const TValue& value) { map.insert_or_assign(key, value); }
     };
-
-    // ---------------------------------------------------------
-    template<typename TKey, typename TValue>
-    void Dictionary<TKey, TValue>::swapWith(ThisType& rhs)
-    {
-        Swap(m_bucketCountMinusOne, rhs.m_bucketCountMinusOne);
-        Swap(m_count, rhs.m_count);
-        m_marks.swapWith(rhs.m_marks);
-        Swap(m_hashMap, rhs.m_hashMap);
-    }
 
     /* We may want to rename this, as strictly speaking _Caps names are reserved */
     class _DummyClass
@@ -611,16 +305,18 @@ namespace Slang
         class Iterator
         {
         private:
-            typename DictionaryType::Iterator iter;
+            DictionaryType::ConstIterator iter;
         public:
             Iterator() = default;
-            T& operator*() const
+            const T& operator*() const
             {
-                return (*iter).key;
+                const auto& [k, v] = *iter;
+                return k;
             }
-            T* operator->() const
+            const T* operator->() const
             {
-                return &(*iter).key;
+                const auto& [k, v] = *iter;
+                return &k;
             }
             Iterator& operator++()
             {
@@ -641,7 +337,7 @@ namespace Slang
             {
                 return iter == that.iter;
             }
-            Iterator(const typename DictionaryType::Iterator& _iter)
+            Iterator(const DictionaryType::ConstIterator& _iter)
             {
                 this->iter = _iter;
             }
@@ -849,16 +545,13 @@ namespace Slang
         }
 
     public:
-        typedef typename LinkedList<KeyValuePair<TKey, TValue>>::Iterator Iterator;
+        using Iterator = LinkedList<KeyValuePair<TKey, TValue>>::Iterator;
+        using ConstIterator = LinkedList<KeyValuePair<TKey, TValue>>::ConstIterator;
 
-        typename LinkedList<KeyValuePair<TKey, TValue>>::Iterator begin() const
-        {
-            return m_kvPairs.begin();
-        }
-        typename LinkedList<KeyValuePair<TKey, TValue>>::Iterator end() const
-        {
-            return m_kvPairs.end();
-        }
+        Iterator begin() { return m_kvPairs.begin(); }
+        Iterator end() { return m_kvPairs.end(); }
+        ConstIterator begin() const { return m_kvPairs.begin(); }
+        ConstIterator end() const { return m_kvPairs.end(); }
 
     public:
         void add(const TKey& key, const TValue& value)

--- a/source/core/slang-dictionary.h
+++ b/source/core/slang-dictionary.h
@@ -55,7 +55,7 @@ namespace Slang
             value = that.value;
             return *this;
         }
-        HashCode getHashCode()
+        HashCode getHashCode() const
         {
             return combineHash(
                 Slang::getHashCode(key),

--- a/source/core/slang-dictionary.h
+++ b/source/core/slang-dictionary.h
@@ -165,7 +165,7 @@ namespace Slang
 
         // Returns a const reference to the value at the given key. Asserts if
         // the value doesn't exist
-        const TValue& at(const TKey& key) const
+        const TValue& getValue(const TKey& key) const
         {
             if(const auto x = tryGetValue(key))
                 return *x;
@@ -174,7 +174,7 @@ namespace Slang
 
         // Returns a reference to the value at the given key. Asserts if the
         // value doesn't exist
-        TValue& at(const TKey& key)
+        TValue& getValue(const TKey& key)
         {
             if(const auto x = tryGetValue(key))
                 return *x;

--- a/source/core/slang-dictionary.h
+++ b/source/core/slang-dictionary.h
@@ -114,7 +114,7 @@ namespace Slang
         void remove(const TKey& key) { map.erase(key); }
 
         // Reserves enough space for the specified number of values
-        void reserve(std::size_t size) { map.reserve(size); };
+        void reserve(Index size) { map.reserve(std::size_t(size)); };
 
         // Swap with another map
         void swapWith(ThisType& rhs) { std::swap(*this, rhs); }

--- a/source/core/slang-dictionary.h
+++ b/source/core/slang-dictionary.h
@@ -8,7 +8,7 @@
 #include "slang-exception.h"
 #include "slang-math.h"
 #include "slang-hash.h"
-#include "ankerl/unordered_dense.h"
+#include "../../external/unordered_dense/include/ankerl/unordered_dense.h"
 
 namespace Slang
 {

--- a/source/core/slang-dictionary.h
+++ b/source/core/slang-dictionary.h
@@ -123,7 +123,6 @@ namespace Slang
         // Query capacity
         //
 
-        // TODO: too small return type
         std::size_t getCount() const { return map.size(); }
 
         //
@@ -351,7 +350,7 @@ namespace Slang
             return Iterator(dict.end());
         }
     public:
-        int getCount() const
+        auto getCount() const
         {
             return dict.getCount();
         }

--- a/source/core/slang-dictionary.h
+++ b/source/core/slang-dictionary.h
@@ -89,8 +89,8 @@ namespace Slang
         //
         // Types
         //
-        using Iterator = InnerMap::iterator;
-        using ConstIterator = InnerMap::const_iterator;
+        using Iterator = typename InnerMap::iterator;
+        using ConstIterator = typename InnerMap::const_iterator;
         using KeyType = TKey;
         using ValueType = TValue;
 
@@ -188,7 +188,7 @@ namespace Slang
         // Tries to insert the given element, if a value was already present at
         // the given key then returns a pointer to that element instead.
         // Returns nullptr if insertion was successful.
-        TValue* tryGetValueOrAdd(const InnerMap::value_type& kvPair)
+        TValue* tryGetValueOrAdd(const typename InnerMap::value_type& kvPair)
         {
             const auto& [iterator, inserted] = map.insert(kvPair);
             return inserted ? nullptr : std::addressof(iterator->second);
@@ -196,7 +196,7 @@ namespace Slang
         // Tries to insert the given element, if a value was already present at
         // the given key then returns a pointer to that element instead.
         // Returns nullptr if insertion was successful.
-        TValue* tryGetValueOrAdd(InnerMap::value_type&& kvPair)
+        TValue* tryGetValueOrAdd(typename InnerMap::value_type&& kvPair)
         {
             const auto& [iterator, inserted] = map.insert(std::move(kvPair));
             return inserted ? nullptr : std::addressof(iterator->second);
@@ -227,10 +227,10 @@ namespace Slang
 
         // Returns true if the value was inserted, returns false if the map
         // already has a value associated with this key
-        bool addIfNotExists(InnerMap::value_type&& kvPair) { return !tryGetValueOrAdd(std::move(kvPair)); }
+        bool addIfNotExists(typename InnerMap::value_type&& kvPair) { return !tryGetValueOrAdd(std::move(kvPair)); }
         // Returns true if the value was inserted, returns false if the map
         // already has a value associated with this key
-        bool addIfNotExists(const InnerMap::value_type& kvPair) { return !tryGetValueOrAdd(kvPair); }
+        bool addIfNotExists(const typename InnerMap::value_type& kvPair) { return !tryGetValueOrAdd(kvPair); }
         // Returns true if the value was inserted, returns false if the map
         // already has a value associated with this key
         bool addIfNotExists(const TKey& k, const TValue& v) { return addIfNotExists({k, v}); }
@@ -239,13 +239,13 @@ namespace Slang
         bool addIfNotExists(TKey&& k, TValue&& v) { return addIfNotExists({std::move(k), std::move(v)}); }
 
         // Asserts if the key already exists in the dictionary
-        void add(InnerMap::value_type&& kvPair)
+        void add(typename InnerMap::value_type&& kvPair)
         {
             if (!addIfNotExists(std::move(kvPair)))
                 SLANG_ASSERT_FAILURE("The key already exists in Dictionary.");
         }
         // Asserts if the key already exists in the dictionary
-        void add(const InnerMap::value_type& kvPair)
+        void add(const typename InnerMap::value_type& kvPair)
         {
             if (!addIfNotExists(kvPair))
                 SLANG_ASSERT_FAILURE("The key already exists in Dictionary.");
@@ -305,7 +305,7 @@ namespace Slang
         class Iterator
         {
         private:
-            DictionaryType::ConstIterator iter;
+            typename DictionaryType::ConstIterator iter;
         public:
             Iterator() = default;
             const T& operator*() const
@@ -337,7 +337,7 @@ namespace Slang
             {
                 return iter == that.iter;
             }
-            Iterator(const DictionaryType::ConstIterator& _iter)
+            Iterator(const typename DictionaryType::ConstIterator& _iter)
             {
                 this->iter = _iter;
             }
@@ -545,8 +545,8 @@ namespace Slang
         }
 
     public:
-        using Iterator = LinkedList<KeyValuePair<TKey, TValue>>::Iterator;
-        using ConstIterator = LinkedList<KeyValuePair<TKey, TValue>>::ConstIterator;
+        using Iterator = typename LinkedList<KeyValuePair<TKey, TValue>>::Iterator;
+        using ConstIterator = typename LinkedList<KeyValuePair<TKey, TValue>>::ConstIterator;
 
         Iterator begin() { return m_kvPairs.begin(); }
         Iterator end() { return m_kvPairs.end(); }

--- a/source/core/slang-file-system.cpp
+++ b/source/core/slang-file-system.cpp
@@ -548,7 +548,7 @@ SlangResult CacheFileSystem::_calcUniqueIdentity(const String& path, String& out
             }
  
             // Calculate the hash on the contents
-            const uint64_t hash = getHashCode64((const char*)outFileContents->getBufferPointer(), outFileContents->getBufferSize());
+            const uint64_t hash = getStableHashCode64((const char*)outFileContents->getBufferPointer(), outFileContents->getBufferSize());
 
             String hashString = Path::getFileName(path);
             hashString = hashString.toLower();

--- a/source/core/slang-file-system.cpp
+++ b/source/core/slang-file-system.cpp
@@ -539,7 +539,7 @@ SlangResult CacheFileSystem::_calcUniqueIdentity(const String& path, String& out
             }
  
             // Calculate the hash on the contents
-            const uint64_t hash = getStableHashCode64((const char*)outFileContents->getBufferPointer(), outFileContents->getBufferSize());
+            const StableHashCode64 hash = getStableHashCode64((const char*)outFileContents->getBufferPointer(), outFileContents->getBufferSize());
 
             String hashString = Path::getFileName(path);
             hashString = hashString.toLower();
@@ -547,7 +547,7 @@ SlangResult CacheFileSystem::_calcUniqueIdentity(const String& path, String& out
             hashString.append(':');
 
             // The uniqueIdentity is a combination of name and hash
-            hashString.append(hash, 16);
+            hashString.append(hash);
 
             outUniqueIdentity = hashString;
             return SLANG_OK;

--- a/source/core/slang-file-system.cpp
+++ b/source/core/slang-file-system.cpp
@@ -319,11 +319,8 @@ CacheFileSystem::CacheFileSystem(ISlangFileSystem* fileSystem, UniqueIdentityMod
 
 CacheFileSystem::~CacheFileSystem()
 {
-    for (const auto& pair : m_uniqueIdentityMap)
-    {
-        PathInfo* pathInfo = pair.value;
+    for (const auto& [_, pathInfo] : m_uniqueIdentityMap)
         delete pathInfo;
-    }
 }
 
 void CacheFileSystem::setInnerFileSystem(ISlangFileSystem* fileSystem, UniqueIdentityMode uniqueIdentityMode, PathStyle pathStyle)
@@ -374,11 +371,8 @@ void CacheFileSystem::setInnerFileSystem(ISlangFileSystem* fileSystem, UniqueIde
 
 void CacheFileSystem::clearCache()
 {
-    for (const auto& pair : m_uniqueIdentityMap)
-    {
-        PathInfo* pathInfo = pair.value;
+    for (const auto& [_, pathInfo] : m_uniqueIdentityMap)
         delete pathInfo;
-    }
 
     m_uniqueIdentityMap.clear();
     m_pathMap.clear();
@@ -434,11 +428,10 @@ SlangResult CacheFileSystem::enumeratePathContents(const char* path, FileSystemC
         simplifiedPath = "";
     }
 
-    for (auto& pair : m_pathMap)
+    for (const auto& [currentPath, pathInfo] : m_pathMap)
     {
         // NOTE! The currentPath can be a *non* simplified path (the m_pathMap is the cache of paths simplified and other to a file/directory)
         // Also note that there will always be the simplified version of the path in cache.
-        const String& currentPath = pair.key;
 
         // If it doesn't start with simplified path, then it can't be a hit
         if (!currentPath.startsWith(simplifiedPath))
@@ -467,8 +460,6 @@ SlangResult CacheFileSystem::enumeratePathContents(const char* path, FileSystemC
         const char* foundPath = remaining.begin();
         // Let's check that fact...
         SLANG_ASSERT(foundPath[remaining.getLength()] == 0);
-
-        PathInfo* pathInfo = pair.value;
 
         SlangPathType pathType;
         if (SLANG_FAILED(_getPathType(pathInfo, currentPath.getBuffer(), &pathType)))

--- a/source/core/slang-hash.h
+++ b/source/core/slang-hash.h
@@ -3,7 +3,7 @@
 
 #include "../../slang.h"
 #include "slang-math.h"
-#include "ankerl/unordered_dense.h"
+#include "../../external/unordered_dense/include/ankerl/unordered_dense.h"
 #include <bit>
 #include <concepts>
 #include <cstring>

--- a/source/core/slang-hash.h
+++ b/source/core/slang-hash.h
@@ -113,7 +113,7 @@ namespace Slang
 	{
 	public:
 		template<typename TKey>
-		static HashCode getHashCode(TKey& key)
+		static HashCode getHashCode(const TKey& key)
 		{
 			return (HashCode)key;
 		}
@@ -123,7 +123,7 @@ namespace Slang
 	{
 	public:
 		template<typename TKey>
-		static HashCode getHashCode(TKey& key)
+		static HashCode getHashCode(const TKey& key)
 		{
 			return HashCode(key.getHashCode());
 		}
@@ -146,7 +146,7 @@ namespace Slang
 	{
 	public:
 		template<typename TKey>
-		static HashCode getHashCode(TKey& key)
+		static HashCode getHashCode(const TKey& key)
 		{
 			return Hash<std::is_integral<TKey>::value || std::is_enum<TKey>::value>::getHashCode(key);
 		}

--- a/source/core/slang-hash.h
+++ b/source/core/slang-hash.h
@@ -114,7 +114,7 @@ namespace Slang
         return Hash<TKey>{}(key);
 	}
 
-	inline auto getHashCode(const char* buffer, std::size_t len)
+	inline HashCode64 getHashCode(const char* buffer, std::size_t len)
 	{
         return ankerl::unordered_dense::detail::wyhash::hash(buffer, len);
 	}

--- a/source/core/slang-hash.h
+++ b/source/core/slang-hash.h
@@ -15,9 +15,9 @@ namespace Slang
 
     // A fixed 64bit wide hash on all targets.
     typedef uint64_t HashCode64;
+    typedef HashCode64 HashCode;
     // A fixed 32bit wide hash on all targets.
     typedef uint32_t HashCode32;
-    typedef HashCode32 HashCode;
 
     //
     // Some helpers to determine which hash to use for a type

--- a/source/core/slang-hex-dump-util.cpp
+++ b/source/core/slang-hex-dump-util.cpp
@@ -28,8 +28,8 @@ static const char s_hex[] = "0123456789abcdef";
     SLANG_RETURN_ON_FAIL(helper.write(s_start.begin(), s_start.getLength()));
     SLANG_RETURN_ON_FAIL(helper.print(" %zu", dataCount));
 
-    const HashCode32 hash = getStableHashCode32((const char*)data, dataCount);
-    SLANG_RETURN_ON_FAIL(helper.print(" %d\n", int(hash) ));
+    const StableHashCode32 hash = getStableHashCode32((const char*)data, dataCount);
+    SLANG_RETURN_ON_FAIL(helper.print(" %d\n", hash.hash ));
 
     SLANG_RETURN_ON_FAIL(dump(data, dataCount, maxBytesPerLine, writer));
 
@@ -216,7 +216,7 @@ static SlangResult _findLine(const UnownedStringSlice& find, UnownedStringSlice&
     UnownedStringSlice startLine, endLine;
     SLANG_RETURN_ON_FAIL(findStartAndEndLines(lines, startLine, endLine));
 
-    HashCode32 hash;
+    StableHashCode32 hash;
     size_t size;
     {
         // Get the size and the hash
@@ -228,13 +228,13 @@ static SlangResult _findLine(const UnownedStringSlice& find, UnownedStringSlice&
         }
         // Extract the size
         size = stringToInt(String(slices[1]));
-        hash = HashCode32(stringToInt(String(slices[2])));
+        hash = StableHashCode32{stringToUInt(String(slices[2]))};
     }
 
     SLANG_RETURN_ON_FAIL(parse(UnownedStringSlice(startLine.end(), endLine.begin()), outBytes));
 
     // Calc the hash
-    const HashCode32 readHash = getStableHashCode32((const char*)outBytes.begin(), outBytes.getCount());
+    const StableHashCode32 readHash = getStableHashCode32((const char*)outBytes.begin(), outBytes.getCount());
 
     if (readHash != hash || size_t(outBytes.getCount()) != size)
     {

--- a/source/core/slang-linked-list.h
+++ b/source/core/slang-linked-list.h
@@ -106,8 +106,8 @@ public:
         }
         GenIterator() { current = next = nullptr; }
         GenIterator(Node* cur) { setCurrent(cur); }
-        const T& operator*() const requires Const { return current->value; }
-        T& operator*() const requires (!Const) { return current->value; }
+        std::conditional_t<Const, const T&, T&>
+            operator*() const { return current->value; }
         GenIterator& operator++()
         {
             setCurrent(next);

--- a/source/core/slang-linked-list.h
+++ b/source/core/slang-linked-list.h
@@ -4,6 +4,7 @@
 #include "../../slang.h"
 
 #include "slang-allocator.h"
+#include <type_traits>
 
 namespace Slang
 {
@@ -28,6 +29,7 @@ public:
     };
     LinkedNode<T>* getPrevious() { return prev; };
     LinkedNode<T>* getNext() { return next; };
+    const LinkedNode<T>* getNext() const { return next; };
     LinkedNode<T>* insertAfter(const T& nData)
     {
         LinkedNode<T>* n = new LinkedNode<T>(list);
@@ -88,37 +90,46 @@ private:
     int count;
 
 public:
-    class Iterator
+    template<bool Const>
+    class GenIterator
     {
     public:
-        LinkedNode<T>* current, *next;
-        void setCurrent(LinkedNode<T>* cur)
+        using Node = std::conditional_t<Const, const LinkedNode<T>, LinkedNode<T>>;
+        Node* current, *next;
+        void setCurrent(Node* cur)
         {
             current = cur;
             if (current)
                 next = current->getNext();
             else
-                next = 0;
+                next = nullptr;
         }
-        Iterator() { current = next = nullptr; }
-        Iterator(LinkedNode<T>* cur) { setCurrent(cur); }
-        T& operator*() const { return current->value; }
-        Iterator& operator++()
+        GenIterator() { current = next = nullptr; }
+        GenIterator(Node* cur) { setCurrent(cur); }
+        const T& operator*() const requires Const { return current->value; }
+        T& operator*() const requires (!Const) { return current->value; }
+        GenIterator& operator++()
         {
             setCurrent(next);
             return *this;
         }
-        Iterator operator++(int)
+        GenIterator operator++(int)
         {
-            Iterator rs = *this;
+            GenIterator rs = *this;
             setCurrent(next);
             return rs;
         }
-        bool operator!=(const Iterator& iter) const { return current != iter.current; }
-        bool operator==(const Iterator& iter) const { return current == iter.current; }
+        bool operator!=(const GenIterator& iter) const { return current != iter.current; }
+        bool operator==(const GenIterator& iter) const { return current == iter.current; }
     };
-    Iterator begin() const { return Iterator(head); }
-    Iterator end() const { return Iterator(0); }
+
+    using Iterator = GenIterator<false>;
+    Iterator begin() { return Iterator(head); }
+    Iterator end() { return Iterator(0); }
+
+    using ConstIterator = GenIterator<true>;
+    ConstIterator begin() const { return ConstIterator(head); }
+    ConstIterator end() const { return ConstIterator(0); }
 
 public:
     LinkedList()

--- a/source/core/slang-memory-file-system.cpp
+++ b/source/core/slang-memory-file-system.cpp
@@ -171,10 +171,9 @@ SlangResult MemoryFileSystem::enumeratePathContents(const char* path, FileSystem
     ImplicitDirectoryCollector collector(canonicalPath, true);
 
     // If it is a directory, we need to see if there is anything in it
-    for (const auto& pair : m_entries)
+    for (const auto& [_, childEntry] : m_entries)
     {
-        const Entry* childEntry = &pair.value;
-        collector.addPath(childEntry->m_type, childEntry->m_canonicalPath.getUnownedSlice());
+        collector.addPath(childEntry.m_type, childEntry.m_canonicalPath.getUnownedSlice());
     }
 
     return collector.enumerate(callback, userData);
@@ -275,10 +274,9 @@ SlangResult MemoryFileSystem::remove(const char* path)
             ImplicitDirectoryCollector collector(canonicalPath);
 
             // If it is a directory, we need to see if there is anything in it
-            for (const auto& pair : m_entries)
+            for (const auto& [_, childEntry] : m_entries)
             {
-                const Entry* childEntry = &pair.value;
-                collector.addPath(childEntry->m_type, childEntry->m_canonicalPath.getUnownedSlice());
+                collector.addPath(childEntry.m_type, childEntry.m_canonicalPath.getUnownedSlice());
                 if (collector.hasContent())
                 {
                     // Directory is not empty

--- a/source/core/slang-riff-file-system.cpp
+++ b/source/core/slang-riff-file-system.cpp
@@ -235,12 +235,10 @@ SlangResult RiffFileSystem::storeArchive(bool blobOwnsContent, ISlangBlob** outB
         container.addDataChunk(RiffFileSystemBinary::kHeaderFourCC, &header, sizeof(header));
     }
 
-    for (const auto& pair : m_entries)
+    for (const auto& [_, srcEntry] : m_entries)
     {
-        const Entry* srcEntry = &pair.value;
-
         // Ignore the root entry
-        if (srcEntry->m_canonicalPath == toSlice("."))
+        if (srcEntry.m_canonicalPath == toSlice("."))
         {
             continue;
         }
@@ -250,22 +248,22 @@ SlangResult RiffFileSystem::storeArchive(bool blobOwnsContent, ISlangBlob** outB
         RiffFileSystemBinary::Entry dstEntry;
         dstEntry.uncompressedSize = 0;
         dstEntry.compressedSize = 0;
-        dstEntry.pathSize = uint32_t(srcEntry->m_canonicalPath.getLength() + 1);
-        dstEntry.pathType = srcEntry->m_type;
+        dstEntry.pathSize = uint32_t(srcEntry.m_canonicalPath.getLength() + 1);
+        dstEntry.pathType = srcEntry.m_type;
 
-        ISlangBlob* blob = srcEntry->m_contents;
+        ISlangBlob* blob = srcEntry.m_contents;
 
-        if (srcEntry->m_type == SLANG_PATH_TYPE_FILE)
+        if (srcEntry.m_type == SLANG_PATH_TYPE_FILE)
         {
             dstEntry.compressedSize = uint32_t(blob->getBufferSize());
-            dstEntry.uncompressedSize = uint32_t(srcEntry->m_uncompressedSizeInBytes);
+            dstEntry.uncompressedSize = uint32_t(srcEntry.m_uncompressedSizeInBytes);
         }
 
         // Entry header
         container.write(&dstEntry, sizeof(dstEntry));
 
         // Path
-        container.write(srcEntry->m_canonicalPath.getBuffer(), srcEntry->m_canonicalPath.getLength() + 1);
+        container.write(srcEntry.m_canonicalPath.getBuffer(), srcEntry.m_canonicalPath.getLength() + 1);
 
         // Add the contained data without copying
         if (blob)

--- a/source/core/slang-smart-pointer.h
+++ b/source/core/slang-smart-pointer.h
@@ -153,7 +153,7 @@ namespace Slang
             releaseReference(old);
         }
 
-        HashCode getHashCode()
+        HashCode getHashCode() const
         {
             // Note: We need a `RefPtr<T>` to hash the same as a `T*`,
             // so that a `T*` can be used as a key in a dictionary with

--- a/source/core/slang-stable-hash.h
+++ b/source/core/slang-stable-hash.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+
+namespace Slang
+{
+    //
+    // Types
+    //
+
+    struct StableHashCode64
+    {
+        uint64_t hash;
+        explicit operator uint64_t() const { return hash; }
+        bool operator==(StableHashCode64 other) const { return other.hash == hash; };
+        bool operator!=(StableHashCode64 other) const { return other.hash != hash; };
+    };
+
+    struct StableHashCode32
+    {
+        uint32_t hash;
+        explicit operator uint32_t() const { return hash; }
+        bool operator==(StableHashCode32 other) const { return other.hash == hash; };
+        bool operator!=(StableHashCode32 other) const { return other.hash != hash; };
+    };
+
+    /* The 'Stable' hash code functions produce hashes that must be
+
+    * The same result for the same inputs on all targets
+    * Rarely change - as their values can change the output of the Slang API/Serialization
+
+    Hash value used from the 'Stable' functions can also be used as part of serialization -
+    so it is in effect part of the API.
+
+    In effect this means changing a 'Stable' algorithm will typically require doing a new release.
+    */
+    inline StableHashCode64 getStableHashCode64(const char* buffer, size_t numChars)
+    {
+        uint64_t hash = 0;
+        for (size_t i = 0; i < numChars; ++i)
+        {
+            hash = uint64_t(buffer[i]) + (hash << 6) + (hash << 16) - hash;
+        }
+        return StableHashCode64{hash};
+    }
+
+    template<typename T>
+    inline StableHashCode64 getStableHashCode64(const T& t)
+    {
+        static_assert(std::has_unique_object_representations_v<T>);
+        return getStableHashCode64(reinterpret_cast<const char*>(&t), sizeof(T));
+    }
+
+    inline StableHashCode32 getStableHashCode32(const char* buffer, size_t numChars)
+    {
+        uint32_t hash = 0;
+        for (size_t i = 0; i < numChars; ++i)
+        {
+            hash = uint32_t(buffer[i]) + (hash << 6) + (hash << 16) - hash;
+        }
+        return StableHashCode32{hash};
+    }
+
+    template<typename T>
+    inline StableHashCode32 getStableHashCode32(const T& t)
+    {
+        static_assert(std::has_unique_object_representations_v<T>);
+        return getStableHashCode32(reinterpret_cast<const char*>(&t), sizeof(T));
+    }
+
+    inline StableHashCode64 combineStableHash(StableHashCode64 h)
+    {
+        return h;
+    }
+
+    inline StableHashCode32 combineStableHash(StableHashCode32 h)
+    {
+        return h;
+    }
+
+    // A left fold with a mixing operation
+    template<typename H, typename... Hs>
+    H combineStableHash(H n, H m, Hs... args)
+    {
+        return combineStableHash(H{(n.hash * 16777619) ^ m.hash}, args...);
+    }
+}
+
+// > Please draw a small horse in ASCII art:
+//
+//           ,~~.
+//          (  9 )-_,
+//  (\___ )=='-' )
+//   \ .   ) )  /
+//    \ `-' /  /
+// ~'`~'`~'`~'`~
+//

--- a/source/core/slang-string.cpp
+++ b/source/core/slang-string.cpp
@@ -612,6 +612,24 @@ namespace Slang
         m_buffer->length += strnlen_s(data, kCount);
     }
 
+    void String::append(StableHashCode32 value)
+    {
+        const Index digits = 8;
+        // + null terminator
+        char* data = prepareForAppend(digits + 1);
+        auto count = intToAscii(data, value.hash, 16, digits);
+        m_buffer->length += count;
+    }
+
+    void String::append(StableHashCode64 value)
+    {
+        const Index digits = 16;
+        // + null terminator
+        char* data = prepareForAppend(digits + 1);
+        auto count = intToAscii(data, value.hash, 16, digits);
+        m_buffer->length += count;
+    }
+
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! UnownedStringSlice !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     Index UnownedStringSlice::indexOf(char c) const

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -189,7 +189,8 @@ namespace Slang
             /// Trims any horizonatl whitespace from start and returns as a substring
         UnownedStringSlice trimStart() const;
 
-        HashCode getHashCode() const
+        static constexpr bool kHasUniformHash = true;
+        HashCode64 getHashCode() const
         {
             return Slang::getHashCode(m_begin, size_t(m_end - m_begin)); 
         }
@@ -869,7 +870,8 @@ namespace Slang
             return contains(str.begin());
         }
 
-        HashCode getHashCode() const
+        static constexpr bool kHasUniformHash = true;
+        HashCode64 getHashCode() const
         {
             return Slang::getHashCode(StringRepresentation::asSlice(m_buffer));
         }

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -10,8 +10,10 @@
 #include "slang-common.h"
 #include "slang-hash.h"
 #include "slang-secure-crt.h"
+#include "slang-stable-hash.h"
 
 #include <new>
+#include <type_traits>
 
 namespace Slang
 {
@@ -32,8 +34,10 @@ namespace Slang
         }
     }
     template<typename IntType>
-    inline int intToAscii(char* buffer, IntType val, int radix)
+    inline int intToAscii(char* buffer, IntType val, int radix, int padTo = 0)
     {
+        static_assert(std::is_integral_v<IntType>);
+
         int i = 0;
         IntType sign;
         
@@ -51,6 +55,9 @@ namespace Slang
             else
                 buffer[i++] = (char)(digit - 10 + 'A');
         } while ((val /= radix) > 0);
+
+        while(i < padTo)
+            buffer[i++] = '0';
 
         if (sign < 0)
             buffer[i++] = '-';
@@ -509,6 +516,10 @@ namespace Slang
         void append(float val, const char* format = "%g");
         void append(double val, const char* format = "%g");
 
+        // Padded hex representations
+        void append(StableHashCode32 val);
+        void append(StableHashCode64 val);
+
         void append(char const* str);
         void append(char const* str, size_t len);
         void append(const char* textBegin, char const* textEnd);
@@ -549,6 +560,14 @@ namespace Slang
         explicit String(uint64_t val, int radix = 10)
         {
             append(val, radix);
+        }
+        explicit String(StableHashCode32 val)
+        {
+            append(val);
+        }
+        explicit String(StableHashCode64 val)
+        {
+            append(val);
         }
         explicit String(float val, const char* format = "%g")
         {

--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -484,11 +484,11 @@ struct ValSet
         ValItem() = default;
         ValItem(Val* v) : val(v) {}
 
-        HashCode getHashCode()
+        HashCode getHashCode() const
         {
             return val ? val->getHashCode() : 0;
         }
-        bool operator==(ValItem other)
+        bool operator==(const ValItem other) const
         {
             if (val == other.val)
                 return true;

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -210,19 +210,13 @@ void SharedASTBuilder::registerMagicDecl(Decl* decl, MagicTypeModifier* modifier
 
 Decl* SharedASTBuilder::findMagicDecl(const String& name)
 {
-    return m_magicDecls[name].getValue();
+    return m_magicDecls.at(name);
 }
 
 Decl* SharedASTBuilder::tryFindMagicDecl(const String& name)
 {
-    if (m_magicDecls.containsKey(name))
-    {
-        return m_magicDecls[name].getValue();
-    }
-    else
-    {
-        return nullptr;
-    }
+    auto d = m_magicDecls.tryGetValue(name);
+    return d ? *d : nullptr;
 }
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! ASTBuilder !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -210,7 +210,7 @@ void SharedASTBuilder::registerMagicDecl(Decl* decl, MagicTypeModifier* modifier
 
 Decl* SharedASTBuilder::findMagicDecl(const String& name)
 {
-    return m_magicDecls.at(name);
+    return m_magicDecls.getValue(name);
 }
 
 Decl* SharedASTBuilder::tryFindMagicDecl(const String& name)

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -154,6 +154,35 @@ struct ValKey
     HashCode getHashCode() const { return hashCode; }
 };
 
+// Add a specialization which can hash both ValKey and ValNodeDesc
+template<>
+struct Hash<ValKey>
+{
+    using is_transparent = void;
+    auto operator()(const ValKey& k) const
+    {
+        return k.getHashCode();
+    }
+    auto operator()(const ValNodeDesc& k) const
+    {
+        return Hash<ValNodeDesc>{}(k);
+    }
+};
+
+// A functor which can compare ValKey for equality with ValNodeDesc
+struct ValKeyEqual
+{
+    using is_transparent = void;
+    bool operator()(const Slang::ValKey& a, const Slang::ValKey& b) const
+    {
+        return a == b;
+    }
+    bool operator()(const Slang::ValNodeDesc& a, const Slang::ValKey& b) const
+    {
+        return b == a;
+    }
+};
+
 class ASTBuilder : public RefObject
 {
     friend class SharedASTBuilder;
@@ -176,7 +205,7 @@ public:
 
     /// A cache for AST nodes that are entirely defined by their node type, with
     /// no need for additional state.
-    Dictionary<ValKey, Val*> m_cachedNodes;
+    Dictionary<ValKey, Val*, Hash<ValKey>, ValKeyEqual> m_cachedNodes;
 
     Dictionary<GenericDecl*, List<Val*>> m_cachedGenericDefaultArgs;
 

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -57,7 +57,7 @@ public:
 
     Decl* findBuiltinRequirementDecl(BuiltinRequirementKind kind)
     {
-        return m_builtinRequirementDecls[kind].getValue();
+        return m_builtinRequirementDecls.at(kind);
     }
 
         /// A name pool that can be used for lookup for findClassInfo etc. It is the same pool as the Session.

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -57,7 +57,7 @@ public:
 
     Decl* findBuiltinRequirementDecl(BuiltinRequirementKind kind)
     {
-        return m_builtinRequirementDecls.at(kind);
+        return m_builtinRequirementDecls.getValue(kind);
     }
 
         /// A name pool that can be used for lookup for findClassInfo etc. It is the same pool as the Session.

--- a/source/slang/slang-ast-dump.cpp
+++ b/source/slang/slang-ast-dump.cpp
@@ -386,11 +386,8 @@ struct ASTDumpContext
         m_writer->emit(" { \n");
         m_writer->indent();
 
-        for (auto iter : dict)
+        for (const auto& [key, value] : dict)
         {
-            const auto& key = iter.key;
-            const auto& value = iter.value;
-
             dump(key);
             m_writer->emit(" : ");
             dump(value);

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -1413,7 +1413,7 @@ namespace Slang
             witnessTable,
         };
 
-        Flavor getFlavor()
+        Flavor getFlavor() const
         {
             return m_flavor;
         }

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2006,11 +2006,11 @@ namespace Slang
         // Once things are done, we will install the satisfying values
         // into the witness table for the requirements.
         //
-        for( auto p : mapRequiredToSatisfyingAccessorDeclRef )
+        for( const auto& [key, value] : mapRequiredToSatisfyingAccessorDeclRef )
         {
             witnessTable->add(
-                p.key.getDecl(),
-                RequirementWitness(p.value));
+                key.getDecl(),
+                RequirementWitness(value));
         }
         //
         // Note: the property declaration itself isn't something that
@@ -3262,9 +3262,9 @@ namespace Slang
         // difference between our synthetic property and a hand-written
         // one with the same behavior.
         //
-        for(auto p : mapRequiredAccessorToSynAccessor)
+        for(auto& [key, value] : mapRequiredAccessorToSynAccessor)
         {
-            witnessTable->add(p.key.getDecl(), RequirementWitness(makeDeclRef(p.value)));
+            witnessTable->add(key.getDecl(), RequirementWitness(makeDeclRef(value)));
         }
         witnessTable->add(requiredMemberDeclRef.getDecl(),
             RequirementWitness(makeDeclRef(synPropertyDecl)));
@@ -5457,9 +5457,8 @@ namespace Slang
             _addTargetModifiers(newDecl, newTargets);
 
             bool hasConflict = false;
-            for (auto& pair : newTargets)
+            for (auto& [target, value] : newTargets)
             {
-                Name* target = pair.key;
                 auto found = currentTargets.tryGetValue(target);
                 if (found)
                 {
@@ -6663,10 +6662,10 @@ namespace Slang
     
     void SharedSemanticsContext::_addCandidateExtensionsFromModule(ModuleDecl* moduleDecl)
     {
-        for( auto& entry : moduleDecl->mapTypeToCandidateExtensions )
+        for( auto& [entryKey, entryValue] : moduleDecl->mapTypeToCandidateExtensions )
         {
-            auto& list = _getCandidateExtensionList(entry.key, m_mapTypeDeclToCandidateExtensions);
-            list.addRange(entry.value->candidateExtensions);
+            auto& list = _getCandidateExtensionList(entryKey, m_mapTypeDeclToCandidateExtensions);
+            list.addRange(entryValue->candidateExtensions);
         }
     }
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2559,7 +2559,7 @@ namespace Slang
                 // 
                 if (auto typeParamDecl = as<DeclRefType>(constraintDecl->sub.type)->getDeclRef().as<GenericTypeParamDecl>().getDecl())
                 {  
-                    auto synTypeParamDecl = mapOrigToSynTypeParams.at(typeParamDecl);
+                    auto synTypeParamDecl = mapOrigToSynTypeParams.getValue(typeParamDecl);
 
                     // Construct a DeclRefExpr from the type parameter.
                     auto synTypeParamDeclRef = makeDeclRef(synTypeParamDecl);

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2559,10 +2559,10 @@ namespace Slang
                 // 
                 if (auto typeParamDecl = as<DeclRefType>(constraintDecl->sub.type)->getDeclRef().as<GenericTypeParamDecl>().getDecl())
                 {  
-                    auto synTypeParamDecl = mapOrigToSynTypeParams[typeParamDecl];
+                    auto synTypeParamDecl = mapOrigToSynTypeParams.at(typeParamDecl);
 
                     // Construct a DeclRefExpr from the type parameter.
-                    auto synTypeParamDeclRef = makeDeclRef(synTypeParamDecl.getValue());
+                    auto synTypeParamDeclRef = makeDeclRef(synTypeParamDecl);
 
                     auto synTypeParamDeclRefExpr = m_astBuilder->create<VarExpr>();
                     synTypeParamDeclRefExpr->declRef = synTypeParamDeclRef;

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -3531,7 +3531,6 @@ namespace Slang
             {
                 case SynthesisPattern::AllInductive:
                 {
-                    int paramIndex = 0;
                     for (auto arg : synArgs)
                     {
                         auto memberExpr = m_astBuilder->create<MemberExpr>();
@@ -3541,8 +3540,6 @@ namespace Slang
                         memberExpr->name = varMember->getName();
                         paramFields.add(memberExpr);
                         inductiveArgMask.add(true);
-
-                        paramIndex++;
                     }
                     break;
                 }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -115,7 +115,7 @@ namespace Slang
 
         bool isValid() const { return type1.getRaw() != BasicTypeKey::invalid().getRaw() && type2.getRaw() != BasicTypeKey::invalid().getRaw(); }
 
-        HashCode getHashCode()
+        HashCode getHashCode() const
         {
             return combineHash(type1.getRaw(), type2.getRaw());
         }
@@ -125,11 +125,8 @@ namespace Slang
     {
         intptr_t operatorName;
         BasicTypeKey args[2];
-        bool operator == (OperatorOverloadCacheKey key)
-        {
-            return operatorName == key.operatorName && args[0] == key.args[0] && args[1] == key.args[1];
-        }
-        HashCode getHashCode()
+        bool operator==(const OperatorOverloadCacheKey&) const = default;
+        HashCode getHashCode() const
         {
             return combineHash((int)(UInt64)(void*)(operatorName), args[0].getRaw(), args[1].getRaw());
         }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -125,7 +125,10 @@ namespace Slang
     {
         intptr_t operatorName;
         BasicTypeKey args[2];
-        bool operator==(const OperatorOverloadCacheKey&) const = default;
+        bool operator == (OperatorOverloadCacheKey key) const
+        {
+            return operatorName == key.operatorName && args[0] == key.args[0] && args[1] == key.args[1];
+        }
         HashCode getHashCode() const
         {
             return combineHash((int)(UInt64)(void*)(operatorName), args[0].getRaw(), args[1].getRaw());

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -1063,14 +1063,10 @@ namespace Slang
             sourceTarget = CodeGenTarget(TypeConvertUtil::getCompileTargetFromSourceLanguage((SlangSourceLanguage)sourceLanguage));
 
             // If it's pass through we accumulate the preprocessor definitions. 
-            for (auto& define : translationUnit->compileRequest->preprocessorDefinitions)
-            {
-                preprocessorDefinitions.add(define.key, define.value);
-            }
-            for (auto& define : translationUnit->preprocessorDefinitions)
-            {
-                preprocessorDefinitions.add(define.key, define.value);
-            }
+            for (const auto& define : translationUnit->compileRequest->preprocessorDefinitions)
+                preprocessorDefinitions.add(define);
+            for (const auto& define : translationUnit->preprocessorDefinitions)
+                preprocessorDefinitions.add(define);
             
             {
                 /* TODO(JS): Not totally clear what options should be set here. If we are using the pass through - then using say the defines/includes
@@ -1148,10 +1144,8 @@ namespace Slang
             // of downstream compilation. 
             
             auto linkage = getLinkage();
-            for (auto& define : linkage->preprocessorDefinitions)
-            {
-                preprocessorDefinitions.add(define.key, define.value);
-            }
+            for (const auto& define : linkage->preprocessorDefinitions)
+                preprocessorDefinitions.add(define);
         }
 
         
@@ -1398,12 +1392,12 @@ namespace Slang
 
                 Index i = 0;
 
-                for(auto& def : preprocessorDefinitions)
+                for(const auto& [defKey, defValue] : preprocessorDefinitions)
                 {
                     auto& define = dst[i];
                     
-                    define.nameWithSig = allocator.allocate(def.key);
-                    define.value = allocator.allocate(def.value);
+                    define.nameWithSig = allocator.allocate(defKey);
+                    define.value = allocator.allocate(defValue);
 
                     ++i;
                 }

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1697,7 +1697,10 @@ namespace Slang
     {
         slang::TypeReflection* elementType;
         slang::ContainerType containerType;
-        bool operator==(const ContainerTypeKey&) const = default;
+        bool operator==(ContainerTypeKey other) const
+        {
+            return elementType == other.elementType && containerType == other.containerType;
+        }
         Slang::HashCode getHashCode() const
         {
             return Slang::combineHash(

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1697,11 +1697,8 @@ namespace Slang
     {
         slang::TypeReflection* elementType;
         slang::ContainerType containerType;
-        bool operator==(ContainerTypeKey other)
-        {
-            return elementType == other.elementType && containerType == other.containerType;
-        }
-        Slang::HashCode getHashCode()
+        bool operator==(const ContainerTypeKey&) const = default;
+        Slang::HashCode getHashCode() const
         {
             return Slang::combineHash(
                 Slang::getHashCode(elementType), Slang::getHashCode(containerType));

--- a/source/slang/slang-doc-markdown-writer.cpp
+++ b/source/slang/slang-doc-markdown-writer.cpp
@@ -1064,9 +1064,9 @@ void DocMarkdownWriter::writeAggType(const ASTMarkup::Entry& entry, AggTypeDeclB
         auto& memberDict = aggTypeDecl->getMemberDictionary();
 
         List<Decl*> uniqueMethods;
-        for (const auto& pair : memberDict)
+        for (const auto& [_, decl] : memberDict)
         {
-            CallableDecl* callableDecl = as<CallableDecl>(pair.value);
+            CallableDecl* callableDecl = as<CallableDecl>(decl);
             if (callableDecl && isVisible(callableDecl))
             {
                 uniqueMethods.add(callableDecl);

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -3,6 +3,7 @@
 
 #include "../core/slang-writer.h"
 #include "../compiler-core/slang-name.h"
+#include "../core/slang-stable-hash.h"
 
 #include "slang-ir-bind-existentials.h"
 #include "slang-ir-dce.h"
@@ -833,7 +834,7 @@ void CLikeSourceEmitter::appendScrubbedName(const UnownedStringSlice& name, Stri
         if (length > maxTokenLength)
         {
             // We are going to output with a prefix and a hash of the full name
-            const HashCode64 hash = getStableHashCode64(out.getBuffer(), length);
+            const auto hash = getStableHashCode64(out.getBuffer(), length);
             // Two hex chars per byte
             const Index hashSize = sizeof(hash) * 2; 
 
@@ -848,7 +849,7 @@ void CLikeSourceEmitter::appendScrubbedName(const UnownedStringSlice& name, Stri
             // Let's add a _ to separate from the rest of the name
             out.appendChar('_');
             // Append the hash in hex
-            out.append(uint64_t(hash), 16);
+            out.append(hash);
 
             SLANG_ASSERT(out.getLength() <= maxTokenLength);
         }
@@ -2497,7 +2498,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
         if (stringLit)
         {
             auto slice = stringLit->getStringSlice();
-            m_writer->emit(static_cast<int32_t>(getStableHashCode32(slice.begin(), slice.getLength())));
+            m_writer->emit(getStableHashCode32(slice.begin(), slice.getLength()).hash);
         }
         else
         {

--- a/source/slang/slang-emit-source-writer.cpp
+++ b/source/slang/slang-emit-source-writer.cpp
@@ -186,38 +186,41 @@ void SourceWriter::emitName(Name* name)
     emitName(name, SourceLoc());
 }
 
-void SourceWriter::emit(IntegerLiteralValue value)
-{
-    char buffer[32];
-    sprintf(buffer, "%lld", (long long int)value);
-    emit(buffer);
-}
-
-void SourceWriter::emit(UInt value)
-{
-    char buffer[32];
-    sprintf(buffer, "%llu", (unsigned long long)(value));
-    emit(buffer);
-}
-
 void SourceWriter::emitUInt64(uint64_t value)
 {
-    char buffer[32];
-    sprintf(buffer, "%llu", (unsigned long long)(value));
-    emit(buffer);
+    emit(value);
 }
 
 void SourceWriter::emitInt64(int64_t value)
 {
-    char buffer[32];
-    sprintf(buffer, "%lld", (long long int)value);
+    emit(value);
+}
+
+void SourceWriter::emit(Int32 value)
+{
+    char buffer[16];
+    sprintf(buffer, "%" PRId32, value);
     emit(buffer);
 }
 
-void SourceWriter::emit(int value)
+void SourceWriter::emit(Int64 value)
 {
-    char buffer[16];
-    sprintf(buffer, "%d", value);
+    char buffer[32];
+    sprintf(buffer, "%" PRId64, value);
+    emit(buffer);
+}
+
+void SourceWriter::emit(UInt32 value)
+{
+    char buffer[32];
+    sprintf(buffer, "%" PRIu32, value);
+    emit(buffer);
+}
+
+void SourceWriter::emit(UInt64 value)
+{
+    char buffer[32];
+    sprintf(buffer, "%" PRIu64, value);
     emit(buffer);
 }
 

--- a/source/slang/slang-emit-source-writer.h
+++ b/source/slang/slang-emit-source-writer.h
@@ -32,13 +32,15 @@ public:
     void emit(Name* name);
     void emit(const NameLoc& nameAndLoc);
     void emit(const StringSliceLoc& nameAndLoc);
-    void emit(IntegerLiteralValue value);
 
     void emitUInt64(uint64_t value);
     void emitInt64(int64_t value);
 
-    void emit(UInt value);
-    void emit(int value);
+    void emit(Int32 value);
+    void emit(UInt32 value);
+    void emit(Int64 value);
+    void emit(UInt64 value);
+
     void emit(double value);
 
     void emitChar(char c);

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -2533,8 +2533,7 @@ struct SPIRVEmitContext
                 case SpvSnippet::ASMOperandType::ResultTypeId:
                     if (operand.content != 0xFFFFFFFF)
                     {
-                        emitOperand(context.qualifiedResultTypes[(SpvStorageClass)operand.content]
-                                        .getValue());
+                        emitOperand(context.qualifiedResultTypes.at((SpvStorageClass)operand.content));
                     }
                     else
                     {

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -2533,7 +2533,7 @@ struct SPIRVEmitContext
                 case SpvSnippet::ASMOperandType::ResultTypeId:
                     if (operand.content != 0xFFFFFFFF)
                     {
-                        emitOperand(context.qualifiedResultTypes.at((SpvStorageClass)operand.content));
+                        emitOperand(context.qualifiedResultTypes.getValue((SpvStorageClass)operand.content));
                     }
                     else
                     {

--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -27,10 +27,7 @@ namespace Slang
         {
             IRType* originalType;
             IRIntegerValue anyValueSize;
-            bool operator ==(MarshallingFunctionKey other)
-            {
-                return originalType == other.originalType && anyValueSize == other.anyValueSize;
-            }
+            bool operator==(const MarshallingFunctionKey&) const = default;
             HashCode getHashCode() const
             {
                 return combineHash(Slang::getHashCode(originalType), Slang::getHashCode(anyValueSize));

--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -27,7 +27,10 @@ namespace Slang
         {
             IRType* originalType;
             IRIntegerValue anyValueSize;
-            bool operator==(const MarshallingFunctionKey&) const = default;
+            bool operator ==(MarshallingFunctionKey other) const
+            {
+                return originalType == other.originalType && anyValueSize == other.anyValueSize;
+            }
             HashCode getHashCode() const
             {
                 return combineHash(Slang::getHashCode(originalType), Slang::getHashCode(anyValueSize));

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -1608,10 +1608,8 @@ void insertTempVarForMutableParams(IRModule* module, IRFunc* func)
             if (inst->getOp() == kIROp_Return)
             {
                 builder.setInsertBefore(inst);
-                for (auto& kv : mapParamToTempVar)
-                {
-                    builder.emitStore(kv.key, builder.emitLoad(kv.value));
-                }
+                for (const auto& [param, var] : mapParamToTempVar)
+                    builder.emitStore(param, builder.emitLoad(var));
             }
         }
     }

--- a/source/slang/slang-ir-autodiff-primal-hoist.cpp
+++ b/source/slang/slang-ir-autodiff-primal-hoist.cpp
@@ -108,7 +108,7 @@ static Dictionary<IRBlock*, IRBlock*> createPrimalRecomputeBlocks(
         recomputeBlock->insertAtEnd(func);
         builder.addDecoration(recomputeBlock, kIROp_RecomputeBlockDecoration);
         recomputeBlockMap.add(primalBlock, recomputeBlock);
-        indexedBlockInfo[recomputeBlock] = indexedBlockInfo.at(primalBlock);
+        indexedBlockInfo.set(recomputeBlock, indexedBlockInfo.at(primalBlock));
         return recomputeBlock;
     };
     

--- a/source/slang/slang-ir-autodiff-primal-hoist.cpp
+++ b/source/slang/slang-ir-autodiff-primal-hoist.cpp
@@ -108,7 +108,7 @@ static Dictionary<IRBlock*, IRBlock*> createPrimalRecomputeBlocks(
         recomputeBlock->insertAtEnd(func);
         builder.addDecoration(recomputeBlock, kIROp_RecomputeBlockDecoration);
         recomputeBlockMap.add(primalBlock, recomputeBlock);
-        indexedBlockInfo[recomputeBlock] = indexedBlockInfo[primalBlock].getValue();
+        indexedBlockInfo[recomputeBlock] = indexedBlockInfo.at(primalBlock);
         return recomputeBlock;
     };
     
@@ -188,7 +188,7 @@ static Dictionary<IRBlock*, IRBlock*> createPrimalRecomputeBlocks(
             // Queue work for the subregion.
             auto loop = as<IRLoop>(primalBlock->getTerminator());
             auto bodyBlock = getLoopRegionBodyBlock(loop);
-            auto diffLoop = mapPrimalLoopToDiffLoop[loop].getValue();
+            auto diffLoop = mapPrimalLoopToDiffLoop.at(loop);
             auto diffBodyBlock = getLoopRegionBodyBlock(diffLoop);
             auto bodyRecomputeBlock = createRecomputeBlock(bodyBlock);
             bodyRecomputeBlock->insertBefore(diffBodyBlock);
@@ -993,7 +993,7 @@ void applyCheckpointSet(
                 predecessorSet.add(predecessor);
                 
                 auto primalPhiArg = as<IRUnconditionalBranch>(predecessor->getTerminator())->getArg(ii);
-                auto recomputePredecessor = mapPrimalBlockToRecomputeBlock[predecessor].getValue();
+                auto recomputePredecessor = mapPrimalBlockToRecomputeBlock.at(predecessor);
 
                 // For now, find the primal phi argument in this predecessor,
                 // and stick it into the recompute predecessor's branch inst. We
@@ -1236,7 +1236,7 @@ static int getInstRegionNestLevel(
     IRBlock* defBlock,
     IRInst* inst)
 {
-    auto result = indexedBlockInfo[defBlock].getValue().getCount();
+    auto result = indexedBlockInfo.at(defBlock).getCount();
     // Loop counters are considered to not belong to the region started by the its loop.
     if (result > 0 && inst->findDecoration<IRLoopCounterDecoration>())
         result--;
@@ -1261,7 +1261,7 @@ static List<IndexTrackingInfo> maybeTrimIndices(
         {
             auto useInst = use->getUser();
             auto useBlock = useInst->getParent();
-            auto useBlockIndices = indexedBlockInfo[as<IRBlock>(useBlock)].getValue();
+            auto useBlockIndices = indexedBlockInfo.at(as<IRBlock>(useBlock));
             if (useBlockIndices.contains(index))
             {
                 found = true;
@@ -1410,7 +1410,7 @@ RefPtr<HoistedPrimalsInfo> ensurePrimalAvailability(
                 continue;
             }
 
-            auto defBlockIndices = indexedBlockInfo[defBlock].getValue();
+            auto defBlockIndices = indexedBlockInfo.at(defBlock);
             IRBlock* varBlock = defaultVarBlock;
             if (isRecomputeInst)
             {

--- a/source/slang/slang-ir-autodiff-primal-hoist.cpp
+++ b/source/slang/slang-ir-autodiff-primal-hoist.cpp
@@ -108,7 +108,7 @@ static Dictionary<IRBlock*, IRBlock*> createPrimalRecomputeBlocks(
         recomputeBlock->insertAtEnd(func);
         builder.addDecoration(recomputeBlock, kIROp_RecomputeBlockDecoration);
         recomputeBlockMap.add(primalBlock, recomputeBlock);
-        indexedBlockInfo.set(recomputeBlock, indexedBlockInfo.at(primalBlock));
+        indexedBlockInfo.set(recomputeBlock, indexedBlockInfo.getValue(primalBlock));
         return recomputeBlock;
     };
     
@@ -188,7 +188,7 @@ static Dictionary<IRBlock*, IRBlock*> createPrimalRecomputeBlocks(
             // Queue work for the subregion.
             auto loop = as<IRLoop>(primalBlock->getTerminator());
             auto bodyBlock = getLoopRegionBodyBlock(loop);
-            auto diffLoop = mapPrimalLoopToDiffLoop.at(loop);
+            auto diffLoop = mapPrimalLoopToDiffLoop.getValue(loop);
             auto diffBodyBlock = getLoopRegionBodyBlock(diffLoop);
             auto bodyRecomputeBlock = createRecomputeBlock(bodyBlock);
             bodyRecomputeBlock->insertBefore(diffBodyBlock);
@@ -992,7 +992,7 @@ void applyCheckpointSet(
                 predecessorSet.add(predecessor);
                 
                 auto primalPhiArg = as<IRUnconditionalBranch>(predecessor->getTerminator())->getArg(ii);
-                auto recomputePredecessor = mapPrimalBlockToRecomputeBlock.at(predecessor);
+                auto recomputePredecessor = mapPrimalBlockToRecomputeBlock.getValue(predecessor);
 
                 // For now, find the primal phi argument in this predecessor,
                 // and stick it into the recompute predecessor's branch inst. We
@@ -1235,7 +1235,7 @@ static int getInstRegionNestLevel(
     IRBlock* defBlock,
     IRInst* inst)
 {
-    auto result = indexedBlockInfo.at(defBlock).getCount();
+    auto result = indexedBlockInfo.getValue(defBlock).getCount();
     // Loop counters are considered to not belong to the region started by the its loop.
     if (result > 0 && inst->findDecoration<IRLoopCounterDecoration>())
         result--;
@@ -1260,7 +1260,7 @@ static List<IndexTrackingInfo> maybeTrimIndices(
         {
             auto useInst = use->getUser();
             auto useBlock = useInst->getParent();
-            auto useBlockIndices = indexedBlockInfo.at(as<IRBlock>(useBlock));
+            auto useBlockIndices = indexedBlockInfo.getValue(as<IRBlock>(useBlock));
             if (useBlockIndices.contains(index))
             {
                 found = true;
@@ -1409,7 +1409,7 @@ RefPtr<HoistedPrimalsInfo> ensurePrimalAvailability(
                 continue;
             }
 
-            auto defBlockIndices = indexedBlockInfo.at(defBlock);
+            auto defBlockIndices = indexedBlockInfo.getValue(defBlock);
             IRBlock* varBlock = defaultVarBlock;
             if (isRecomputeInst)
             {

--- a/source/slang/slang-ir-autodiff-primal-hoist.cpp
+++ b/source/slang/slang-ir-autodiff-primal-hoist.cpp
@@ -499,11 +499,10 @@ RefPtr<HoistedPrimalsInfo> AutodiffCheckpointPolicyBase::processFunc(
 struct ImplicationParams
 {
     IRInst *condition, *induction, *block;
-    HashCode getHashCode() const { return getHashCodeBytewise(*this); }
-    // C++20: friend auto operator<=>(const ImplicationParams&, const ImplicationParams&) = default;
-    friend bool operator==(const ImplicationParams& x, const ImplicationParams& y)
+    SLANG_BYTEWISE_HASHABLE;
+    bool operator==(const ImplicationParams& other) const
     {
-        return x.condition == y.condition && x.induction == y.induction && x.block == y.block;
+        return condition == other.condition && induction == other.induction && block == other.block;
     }
 };
 

--- a/source/slang/slang-ir-autodiff-primal-hoist.h
+++ b/source/slang/slang-ir-autodiff-primal-hoist.h
@@ -120,9 +120,9 @@ namespace Slang
                 if (env->mapOldValToNew.containsKey(inst))
                     newPrimalsInfo->instsToInvert.add(env->mapOldValToNew[inst]);
 
-            for (auto kvpair : this->invertInfoMap)
-                if (env->mapOldValToNew.containsKey(kvpair.key))
-                    newPrimalsInfo->invertInfoMap[env->mapOldValToNew[kvpair.key]] = kvpair.value.applyMap(env);
+            for (auto [key, value] : this->invertInfoMap)
+                if (env->mapOldValToNew.containsKey(key))
+                    newPrimalsInfo->invertInfoMap[env->mapOldValToNew[key]] = value.applyMap(env);
             
             return newPrimalsInfo;
         }
@@ -141,8 +141,8 @@ namespace Slang
             for (auto inst : info->instsToInvert)
                 instsToInvert.add(inst);
 
-            for (auto kvpair : info->invertInfoMap)
-                invertInfoMap[kvpair.key] = kvpair.value;
+            for (auto [key, value] : info->invertInfoMap)
+                invertInfoMap[key] = value;
         }
     };
 

--- a/source/slang/slang-ir-autodiff-primal-hoist.h
+++ b/source/slang/slang-ir-autodiff-primal-hoist.h
@@ -136,8 +136,8 @@ namespace Slang
             for (auto inst : info->instsToInvert)
                 instsToInvert.add(inst);
 
-            for (auto info : info->invertInfoMap)
-                invertInfoMap.add(info);
+            for (auto invertInfo : info->invertInfoMap)
+                invertInfoMap.add(invertInfo);
         }
     };
 

--- a/source/slang/slang-ir-autodiff-primal-hoist.h
+++ b/source/slang/slang-ir-autodiff-primal-hoist.h
@@ -103,26 +103,21 @@ namespace Slang
         RefPtr<HoistedPrimalsInfo> applyMap(IRCloneEnv* env)
         {
             RefPtr<HoistedPrimalsInfo> newPrimalsInfo = new HoistedPrimalsInfo();
+
+            const auto goSet = [&env](const auto& inSet, auto& outSet){
+                for (auto inst : inSet)
+                    if (const auto newKey = env->mapOldValToNew.tryGetValue(inst))
+                        outSet.add(*newKey);
+            };
             
-            for (auto inst : this->storeSet)
-                if (env->mapOldValToNew.containsKey(inst))
-                    newPrimalsInfo->storeSet.add(env->mapOldValToNew[inst]);
-            
-            for (auto inst : this->recomputeSet)
-                if (env->mapOldValToNew.containsKey(inst))
-                    newPrimalsInfo->recomputeSet.add(env->mapOldValToNew[inst]);
-                
-            for (auto inst : this->invertSet)
-                if (env->mapOldValToNew.containsKey(inst))
-                    newPrimalsInfo->invertSet.add(env->mapOldValToNew[inst]);
-            
-            for (auto inst : this->instsToInvert)
-                if (env->mapOldValToNew.containsKey(inst))
-                    newPrimalsInfo->instsToInvert.add(env->mapOldValToNew[inst]);
+            goSet(this->storeSet, newPrimalsInfo->storeSet);
+            goSet(this->recomputeSet, newPrimalsInfo->recomputeSet);
+            goSet(this->invertSet, newPrimalsInfo->invertSet);
+            goSet(this->instsToInvert, newPrimalsInfo->instsToInvert);
 
             for (auto [key, value] : this->invertInfoMap)
-                if (env->mapOldValToNew.containsKey(key))
-                    newPrimalsInfo->invertInfoMap[env->mapOldValToNew[key]] = value.applyMap(env);
+                if (const auto newKey = env->mapOldValToNew.tryGetValue(key))
+                    newPrimalsInfo->invertInfoMap.set(*newKey, value.applyMap(env));
             
             return newPrimalsInfo;
         }
@@ -141,8 +136,8 @@ namespace Slang
             for (auto inst : info->instsToInvert)
                 instsToInvert.add(inst);
 
-            for (auto [key, value] : info->invertInfoMap)
-                invertInfoMap[key] = value;
+            for (auto info : info->invertInfoMap)
+                invertInfoMap.add(info);
         }
     };
 

--- a/source/slang/slang-ir-autodiff-rev.cpp
+++ b/source/slang/slang-ir-autodiff-rev.cpp
@@ -658,8 +658,8 @@ namespace Slang
     // Remove [KeepAlive] decorations for primal param replacement insts.
     static void _unlockPrimalParamReplacementInsts(ParameterBlockTransposeInfo& paramInfo)
     {
-        for (auto& kv : paramInfo.mapPrimalSpecificParamToReplacementInPropFunc)
-            kv.value->findDecoration<IRKeepAliveDecoration>()->removeAndDeallocate();
+        for (const auto& [_, value] : paramInfo.mapPrimalSpecificParamToReplacementInPropFunc)
+            value->findDecoration<IRKeepAliveDecoration>()->removeAndDeallocate();
     }
 
     // Transcribe a function definition.

--- a/source/slang/slang-ir-autodiff-transpose.h
+++ b/source/slang/slang-ir-autodiff-transpose.h
@@ -1360,7 +1360,7 @@ struct DiffTransposePass
                 SLANG_ASSERT(!(afterBlockMap.containsKey(afterBlock) && \
                     afterBlockMap[afterBlock] != block->getTerminator()));
 
-                afterBlockMap[afterBlock] = block->getTerminator();
+                afterBlockMap.set(afterBlock, block->getTerminator());
             }
         }
     }

--- a/source/slang/slang-ir-autodiff-transpose.h
+++ b/source/slang/slang-ir-autodiff-transpose.h
@@ -571,7 +571,7 @@ struct DiffTransposePass
         // Keep track of first diff block, since this is where 
         // we'll emit temporary vars to hold per-block derivatives.
         // 
-        auto firstRevDiffBlock = revBlockMap.at(terminalDiffBlocks[0]);
+        auto firstRevDiffBlock = revBlockMap.getValue(terminalDiffBlocks[0]);
         firstRevDiffBlockMap[revDiffFunc] = firstRevDiffBlock;
 
         // Move all diff vars to first block, and initialize them with zero.
@@ -2782,7 +2782,7 @@ struct DiffTransposePass
         {
             gradientsMap[fwdInst] = List<RevGradient>();
         }
-        gradientsMap.at(fwdInst).add(assignment);
+        gradientsMap.getValue(fwdInst).add(assignment);
     }
 
     List<RevGradient> getRevGradients(IRInst* fwdInst)
@@ -2792,7 +2792,7 @@ struct DiffTransposePass
 
     List<RevGradient> popRevGradients(IRInst* fwdInst)
     {
-        List<RevGradient> val = gradientsMap.at(fwdInst);
+        List<RevGradient> val = gradientsMap.getValue(fwdInst);
         gradientsMap.remove(fwdInst);
         return val;
     }

--- a/source/slang/slang-ir-autodiff-transpose.h
+++ b/source/slang/slang-ir-autodiff-transpose.h
@@ -855,11 +855,14 @@ struct DiffTransposePass
         // function scope variable, since control flow can affect what blocks contribute to
         // for a specific inst.
         // 
-        for (auto pair : gradientsMap)
+        List<IRLoad*> loads;
+        for (const auto& [key, _] : gradientsMap)
         {
-            if (auto loadInst = as<IRLoad>(pair.key))
-                accumulateGradientsForLoad(&builder, loadInst);
+            if (auto load = as<IRLoad>(key))
+                loads.add(load);
         }
+        for(const auto& load : loads)
+                accumulateGradientsForLoad(&builder, load);
 
         // Do the same thing with the phi parameters if the block.
         List<IRInst*> phiParamRevGradInsts;

--- a/source/slang/slang-ir-autodiff-transpose.h
+++ b/source/slang/slang-ir-autodiff-transpose.h
@@ -903,16 +903,16 @@ struct DiffTransposePass
         // Also handle any remaining gradients for insts that appear in prior blocks.
         List<IRInst*> externInsts; // Holds insts in a different block, same function.
         List<IRInst*> globalInsts; // Holds insts in the global scope.
-        for (auto pair : gradientsMap)
+        for (const auto& [inst, _] : gradientsMap)
         {
-            auto instParent = pair.key->getParent();
+            auto instParent = inst->getParent();
             if (instParent != fwdBlock)
             {
                 if (instParent->getParent() == fwdBlock->getParent())
-                    externInsts.add(pair.key);
+                    externInsts.add(inst);
                 
                 if (as<IRModuleInst>(instParent))
-                    globalInsts.add(pair.key);
+                    globalInsts.add(inst);
             }
         }
 

--- a/source/slang/slang-ir-autodiff-transpose.h
+++ b/source/slang/slang-ir-autodiff-transpose.h
@@ -571,7 +571,7 @@ struct DiffTransposePass
         // Keep track of first diff block, since this is where 
         // we'll emit temporary vars to hold per-block derivatives.
         // 
-        auto firstRevDiffBlock = revBlockMap[terminalDiffBlocks[0]].getValue();
+        auto firstRevDiffBlock = revBlockMap.at(terminalDiffBlocks[0]);
         firstRevDiffBlockMap[revDiffFunc] = firstRevDiffBlock;
 
         // Move all diff vars to first block, and initialize them with zero.
@@ -2779,7 +2779,7 @@ struct DiffTransposePass
         {
             gradientsMap[fwdInst] = List<RevGradient>();
         }
-        gradientsMap[fwdInst].getValue().add(assignment);
+        gradientsMap.at(fwdInst).add(assignment);
     }
 
     List<RevGradient> getRevGradients(IRInst* fwdInst)
@@ -2789,7 +2789,7 @@ struct DiffTransposePass
 
     List<RevGradient> popRevGradients(IRInst* fwdInst)
     {
-        List<RevGradient> val = gradientsMap[fwdInst].getValue();
+        List<RevGradient> val = gradientsMap.at(fwdInst);
         gradientsMap.remove(fwdInst);
         return val;
     }

--- a/source/slang/slang-ir-autodiff-unzip.cpp
+++ b/source/slang/slang-ir-autodiff-unzip.cpp
@@ -331,7 +331,7 @@ IRFunc* DiffUnzipPass::extractPrimalFunc(
     for (auto param : func->getParams())
     {
         if (paramInfo.primalFuncParams.contains(param))
-            newPrimalParams.add(subEnv.mapOldValToNew[param].getValue());
+            newPrimalParams.add(subEnv.mapOldValToNew.at(param));
     }
 
     ExtractPrimalFuncContext context;

--- a/source/slang/slang-ir-autodiff-unzip.cpp
+++ b/source/slang/slang-ir-autodiff-unzip.cpp
@@ -331,7 +331,7 @@ IRFunc* DiffUnzipPass::extractPrimalFunc(
     for (auto param : func->getParams())
     {
         if (paramInfo.primalFuncParams.contains(param))
-            newPrimalParams.add(subEnv.mapOldValToNew.at(param));
+            newPrimalParams.add(subEnv.mapOldValToNew.getValue(param));
     }
 
     ExtractPrimalFuncContext context;

--- a/source/slang/slang-ir-autodiff-unzip.h
+++ b/source/slang/slang-ir-autodiff-unzip.h
@@ -159,11 +159,8 @@ struct DiffUnzipPass
         //
         {
             List<IRBlock*> workList;
-            for (auto blockRegionPair : indexRegionMap->map)
-            {
-                IRBlock* block = blockRegionPair.key;
+            for (auto [block, _] : indexRegionMap->map)
                 workList.add(block);
-            }
 
             for (auto block : workList)
             {

--- a/source/slang/slang-ir-autodiff-unzip.h
+++ b/source/slang/slang-ir-autodiff-unzip.h
@@ -168,7 +168,7 @@ struct DiffUnzipPass
                     indexRegionMap->map[as<IRBlock>(primalMap[block])] = (IndexedRegion*)indexRegionMap->map[block];
                 
                 if (diffMap.containsKey(block))
-                    indexRegionMap->map[as<IRBlock>(diffMap[block])] = (IndexedRegion*)indexRegionMap->map[block];
+                    indexRegionMap->map.set(as<IRBlock>(diffMap[block]), (IndexedRegion*)indexRegionMap->map[block]);
             }
         }
         

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -1782,7 +1782,7 @@ bool finalizeAutoDiffPass(IRModule* module)
     // Remove auto-diff related decorations.
     stripAutoDiffDecorations(module);
 
-    return false;
+    return modified;
 }
 
 IRBlock* getBlock(IRInst* inst)

--- a/source/slang/slang-ir-eliminate-multilevel-break.cpp
+++ b/source/slang/slang-ir-eliminate-multilevel-break.cpp
@@ -338,10 +338,8 @@ struct EliminateMultiLevelBreakContext
         // Once we have rewritten regions' break blocks with additional targetLevel parameter, all
         // original branches into that block without a parameter will now need to provide a default
         // value equal to the level of its corresponding region.
-        for (auto breakBlockKV : mapNewBreakBlockToRegionLevel)
+        for (auto [breakBlock, level] : mapNewBreakBlockToRegionLevel)
         {
-            auto breakBlock = breakBlockKV.key;
-            auto level = breakBlockKV.value;
             IRInst* levelInst = nullptr;
             List<IRUse*> uses;
             for (auto use = breakBlock->firstUse; use; use = use->nextUse)

--- a/source/slang/slang-ir-eliminate-phis.cpp
+++ b/source/slang/slang-ir-eliminate-phis.cpp
@@ -140,11 +140,10 @@ struct PhiEliminationContext
     {
         IRBuilder builder(m_module);
 
-        for (auto instAlloc : m_registerAllocation.mapInstToRegister)
+        for (const auto& [inst, reg] : m_registerAllocation.mapInstToRegister)
         {
-            auto inst = instAlloc.key;
             IRInst* registerVar = nullptr;
-            m_mapRegToTempVar.tryGetValue(instAlloc.value, registerVar);
+            m_mapRegToTempVar.tryGetValue(reg, registerVar);
             SLANG_RELEASE_ASSERT(registerVar);
 
             switch (inst->getOp())
@@ -159,7 +158,7 @@ struct PhiEliminationContext
                     m_registerAllocation.mapInstToRegister.tryGetValue(updateInst->getOldValue(), oldReg);
                     // If the original value is not assigned to the same register as this inst,
                     // we need to insert a copy.
-                    if (instAlloc.value != oldReg)
+                    if (reg != oldReg)
                     {
                         builder.emitStore(registerVar, updateInst->getOldValue());
                     }
@@ -178,11 +177,10 @@ struct PhiEliminationContext
     {
         IRBuilder builder(m_module);
 
-        for (auto instAlloc : m_registerAllocation.mapInstToRegister)
+        for (const auto& [inst, reg] : m_registerAllocation.mapInstToRegister)
         {
-            auto inst = instAlloc.key;
             IRInst* registerVar = nullptr;
-            m_mapRegToTempVar.tryGetValue(instAlloc.value, registerVar);
+            m_mapRegToTempVar.tryGetValue(reg, registerVar);
             SLANG_RELEASE_ASSERT(registerVar);
             while (auto use = inst->firstUse)
             {

--- a/source/slang/slang-ir-generics-lowering-context.cpp
+++ b/source/slang/slang-ir-generics-lowering-context.cpp
@@ -88,7 +88,7 @@ namespace Slang
     IRInst* SharedGenericsLoweringContext::findInterfaceRequirementVal(IRInterfaceType* interfaceType, IRInst* requirementKey)
     {
         if (auto dict = mapInterfaceRequirementKeyValue.tryGetValue(interfaceType))
-            return dict->at(requirementKey);
+            return dict->getValue(requirementKey);
         _builldInterfaceRequirementMap(interfaceType);
         return findInterfaceRequirementVal(interfaceType, requirementKey);
     }

--- a/source/slang/slang-ir-generics-lowering-context.cpp
+++ b/source/slang/slang-ir-generics-lowering-context.cpp
@@ -88,7 +88,7 @@ namespace Slang
     IRInst* SharedGenericsLoweringContext::findInterfaceRequirementVal(IRInterfaceType* interfaceType, IRInst* requirementKey)
     {
         if (auto dict = mapInterfaceRequirementKeyValue.tryGetValue(interfaceType))
-            return (*dict)[requirementKey].getValue();
+            return dict->at(requirementKey);
         _builldInterfaceRequirementMap(interfaceType);
         return findInterfaceRequirementVal(interfaceType, requirementKey);
     }

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -2744,10 +2744,8 @@ void legalizeEntryPointForGLSL(
 
     // Let's fix the size array type globals now that we know the maximum index
     {
-        for (const auto& a : context.systemNameToGlobalMap)
+        for (const auto& [_, value] : context.systemNameToGlobalMap)
         {
-            const auto& value = a.value;
-
             auto type = value.globalParam->getDataType();
 
             // Strip out if there is one

--- a/source/slang/slang-ir-inline.cpp
+++ b/source/slang/slang-ir-inline.cpp
@@ -573,7 +573,7 @@ struct InliningPassBase
 
         // Insert a branch into the cloned first block at the end of `callerBlock`.
         builder->setInsertInto(callerBlock);
-        auto mainBlock = as<IRBlock>(env->mapOldValToNew[callee->getFirstBlock()].getValue());
+        auto mainBlock = as<IRBlock>(env->mapOldValToNew.at(callee->getFirstBlock()));
         auto newBranch = builder->emitLoop(mainBlock, afterBlock, mainBlock);
         _setSourceLoc(newBranch, call, callSite);
 
@@ -581,7 +581,7 @@ struct InliningPassBase
         bool isFirstBlock = true;
         for (auto calleeBlock : callee->getBlocks())
         {
-            auto clonedBlock = env->mapOldValToNew[calleeBlock].getValue();
+            auto clonedBlock = env->mapOldValToNew.at(calleeBlock);
             builder->setInsertInto(clonedBlock);
             // We will loop over the instructions of the each block,
             // and clone each of them appropriately.

--- a/source/slang/slang-ir-inline.cpp
+++ b/source/slang/slang-ir-inline.cpp
@@ -573,7 +573,7 @@ struct InliningPassBase
 
         // Insert a branch into the cloned first block at the end of `callerBlock`.
         builder->setInsertInto(callerBlock);
-        auto mainBlock = as<IRBlock>(env->mapOldValToNew.at(callee->getFirstBlock()));
+        auto mainBlock = as<IRBlock>(env->mapOldValToNew.getValue(callee->getFirstBlock()));
         auto newBranch = builder->emitLoop(mainBlock, afterBlock, mainBlock);
         _setSourceLoc(newBranch, call, callSite);
 
@@ -581,7 +581,7 @@ struct InliningPassBase
         bool isFirstBlock = true;
         for (auto calleeBlock : callee->getBlocks())
         {
-            auto clonedBlock = env->mapOldValToNew.at(calleeBlock);
+            auto clonedBlock = env->mapOldValToNew.getValue(calleeBlock);
             builder->setInsertInto(clonedBlock);
             // We will loop over the instructions of the each block,
             // and clone each of them appropriately.

--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -595,10 +595,8 @@ IRGeneric* cloneGenericImpl(
         // Generic parameter list does not match, bail.
         if (clonedParam || originalParam)
             continue;
-        for (auto kv : paramMapping)
-        {
-            registerClonedValue(context, kv.key, kv.value);
-        }
+        for (const auto& [key, value] : paramMapping)
+            registerClonedValue(context, key, value);
 
         IRBuilder builderStorage = *builder;
         IRBuilder* decorBuilder = &builderStorage;

--- a/source/slang/slang-ir-lower-generic-function.cpp
+++ b/source/slang/slang-ir-lower-generic-function.cpp
@@ -370,10 +370,8 @@ namespace Slang
 
         void replaceLoweredInterfaceTypes()
         {
-            for (auto lowered : sharedContext->loweredInterfaceTypes)
-            {
-                 lowered.key->replaceUsesWith(lowered.value);
-            }
+            for (const auto& [loweredKey, loweredValue] : sharedContext->loweredInterfaceTypes)
+                 loweredKey->replaceUsesWith(loweredValue);
             sharedContext->mapInterfaceRequirementKeyValue.clear();
         }
 

--- a/source/slang/slang-ir-lower-optional-type.cpp
+++ b/source/slang/slang-ir-lower-optional-type.cpp
@@ -270,10 +270,8 @@ namespace Slang
             }
 
             // Replace all optional types with lowered struct types.
-            for (auto kv : loweredOptionalTypes)
-            {
-                kv.key->replaceUsesWith(kv.value->loweredType);
-            }
+            for (const auto& [key, value] : loweredOptionalTypes)
+                key->replaceUsesWith(value->loweredType);
         }
     };
     

--- a/source/slang/slang-ir-lower-result-type.cpp
+++ b/source/slang/slang-ir-lower-result-type.cpp
@@ -291,10 +291,8 @@ namespace Slang
             }
 
             // Replace all result types with lowered struct types.
-            for (auto kv : loweredResultTypes)
-            {
-                kv.key->replaceUsesWith(kv.value->loweredType);
-            }
+            for (const auto& [key, value] : loweredResultTypes)
+                key->replaceUsesWith(value->loweredType);
         }
     };
     

--- a/source/slang/slang-ir-lower-tuple-types.cpp
+++ b/source/slang/slang-ir-lower-tuple-types.cpp
@@ -170,10 +170,8 @@ namespace Slang
             }
 
             // Replace all tuple types with lowered struct types.
-            for (auto kv : loweredTuples)
-            {
-                kv.key->replaceUsesWith(kv.value->structType);
-            }
+            for (const auto& [key, value] : loweredTuples)
+                key->replaceUsesWith(value->structType);
         }
     };
     

--- a/source/slang/slang-ir-obfuscate-loc.cpp
+++ b/source/slang/slang-ir-obfuscate-loc.cpp
@@ -4,7 +4,7 @@
 #include "../../slang.h"
 
 #include "../core/slang-random-generator.h"
-#include "../core/slang-hash.h"
+#include "../core/slang-stable-hash.h"
 #include "../core/slang-char-util.h"
 
 #include "../core/slang-castable.h"
@@ -81,7 +81,7 @@ SlangResult obfuscateModuleLocs(IRModule* module, SourceManager* sourceManager)
     // Doing so would mean that we could use the obfuscated location ouput to output 
     // the origin.
 
-    HashCode hash = 0;
+    StableHashCode32 hash{0};
 
     List<LocPair> locPairs;
 
@@ -124,10 +124,10 @@ SlangResult obfuscateModuleLocs(IRModule* module, SourceManager* sourceManager)
 
                     const auto pathInfo = sourceView->getViewPathInfo();
                     const auto name = pathInfo.getName();
-                    const auto nameHash = getHashCode(pathInfo.getName().getUnownedSlice());
+                    const auto nameHash = getStableHashCode32(name.getBuffer(), name.getLength());
                     
                     // Combine the name
-                    hash = combineHash(hash, nameHash);
+                    hash = combineStableHash(hash, nameHash);
                 }
 
                 // We *can't* just use the offset to produce the hash, because the source might have
@@ -140,8 +140,7 @@ SlangResult obfuscateModuleLocs(IRModule* module, SourceManager* sourceManager)
                 const auto lineIndex = sourceFile->calcLineIndexFromOffset(offset);
                 const auto lineOffset = sourceFile->calcColumnOffset(lineIndex, offset);
 
-                hash = combineHash(hash, getHashCode(lineIndex));
-                hash = combineHash(hash, getHashCode(lineOffset));
+                hash = combineStableHash(hash, getStableHashCode32(lineIndex), getStableHashCode32(lineOffset));
             }    
         }
     }

--- a/source/slang/slang-ir-reachability.h
+++ b/source/slang/slang-ir-reachability.h
@@ -13,16 +13,13 @@ struct ReachabilityContext
     {
         IRBlock* first;
         IRBlock* second;
-        HashCode getHashCode()
+        bool operator==(const BlockPair&) const = default;
+        HashCode getHashCode() const
         {
             Hasher h;
             h.hashValue(first);
             h.hashValue(second);
             return h.getResult();
-        }
-        bool operator == (const BlockPair& other)
-        {
-            return first == other.first && second == other.second;
         }
     };
     Dictionary<BlockPair, bool> reachabilityResults;

--- a/source/slang/slang-ir-reachability.h
+++ b/source/slang/slang-ir-reachability.h
@@ -13,7 +13,10 @@ struct ReachabilityContext
     {
         IRBlock* first;
         IRBlock* second;
-        bool operator==(const BlockPair&) const = default;
+        bool operator == (const BlockPair& other) const
+        {
+            return first == other.first && second == other.second;
+        }
         HashCode getHashCode() const
         {
             Hasher h;

--- a/source/slang/slang-ir-specialize-dispatch.cpp
+++ b/source/slang/slang-ir-specialize-dispatch.cpp
@@ -333,10 +333,8 @@ void specializeDispatchFunctions(SharedGenericsLoweringContext* sharedContext)
     ensureWitnessTableSequentialIDs(sharedContext);
 
     // Generate specialized dispatch functions and fixup call sites.
-    for (auto kv : sharedContext->mapInterfaceRequirementKeyToDispatchMethods)
+    for (const auto& [_, dispatchFunc] : sharedContext->mapInterfaceRequirementKeyToDispatchMethods)
     {
-        auto dispatchFunc = kv.value;
-
         // Generate a specialized `switch` statement based dispatch func,
         // from the witness tables present in the module.
         auto newDispatchFunc = specializeDispatchFunction(sharedContext, dispatchFunc);

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -629,7 +629,7 @@ struct SpecializationContext
     template<typename TDict>
     void _readSpecializationDictionaryImpl(TDict& dict, IRInst* dictInst)
     {
-        int childrenCount = 0;
+        Int childrenCount = 0;
         for (auto child = dictInst->getFirstChild(); child; child = child->next)
             childrenCount++;
         dict.reserve(1 << Math::Log2Ceil(childrenCount * 2));

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -629,10 +629,10 @@ struct SpecializationContext
     template<typename TDict>
     void _readSpecializationDictionaryImpl(TDict& dict, IRInst* dictInst)
     {
-        Int childrenCount = 0;
+        int childrenCount = 0;
         for (auto child = dictInst->getFirstChild(); child; child = child->next)
             childrenCount++;
-        dict.reserve(1 << Math::Log2Ceil(childrenCount * 2));
+        dict.reserve(Index{1} << Math::Log2Ceil(childrenCount * 2));
         for (auto child : dictInst->getChildren())
         {
             auto item = as<IRSpecializationDictionaryItem>(child);

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -698,18 +698,18 @@ struct SpecializationContext
         builder.setInsertInto(moduleInst);
         auto dictInst = builder.emitIntrinsicInst(nullptr, dictOp, 0, nullptr);
         builder.setInsertInto(dictInst);
-        for (auto kv : dict)
+        for (const auto& [key, value] : dict)
         {
-            if (!kv.value->parent)
+            if (!value->parent)
                 continue;
-            for (auto keyVal : kv.key.vals)
+            for (auto keyVal : key.vals)
             {
                 if (!keyVal->parent) goto next;
             }
             {
                 List<IRInst*> args;
-                args.add(kv.value);
-                args.addRange(kv.key.vals);
+                args.add(value);
+                args.addRange(key.vals);
                 builder.emitIntrinsicInst(nullptr, kIROp_SpecializationDictionaryItem, args.getCount(), args.getBuffer());
             }
         next:;

--- a/source/slang/slang-ir-spirv-snippet.cpp
+++ b/source/slang/slang-ir-spirv-snippet.cpp
@@ -102,7 +102,7 @@ RefPtr<SpvSnippet> SpvSnippet::parse(UnownedStringSlice definition)
             if (tokenReader.AdvanceIf("%"))
             {
                 String instName = tokenReader.ReadToken().Content;
-                mapInstNameToIndex[instName] = (int)snippet->instructions.getCount();
+                mapInstNameToIndex.set(instName, (int)snippet->instructions.getCount());
                 tokenReader.Read(Slang::Misc::TokenType::OpAssign);
             }
             SpvOp opCode;

--- a/source/slang/slang-ir-spirv-snippet.h
+++ b/source/slang/slang-ir-spirv-snippet.h
@@ -76,7 +76,7 @@ struct SpvSnippet : public RefObject
         ASMType type;
         SpvWord intValues[4];
         float floatValues[4];
-        HashCode getHashCode()
+        HashCode getHashCode() const
         {
             HashCode result = (HashCode)type;
             for (int i = 0; i < 4; i++)
@@ -96,7 +96,7 @@ struct SpvSnippet : public RefObject
             }
             return result;
         }
-        bool operator==(const ASMConstant& other)
+        bool operator==(const ASMConstant& other) const
         {
             if (type != other.type)
                 return false;

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -2034,6 +2034,7 @@ public:
     {
         hashCode = _getHashCode();
     }
+    IRInstKey& operator=(const IRInstKey&) = default;
     HashCode getHashCode() const { return hashCode; }
     IRInst* getInst() const { return inst; }
 

--- a/source/slang/slang-mangle.cpp
+++ b/source/slang/slang-mangle.cpp
@@ -681,7 +681,7 @@ namespace Slang
 
     String getHashedName(const UnownedStringSlice& mangledName)
     {
-        HashCode64 hash = getStableHashCode64(mangledName.begin(), mangledName.getLength());
+        StableHashCode64 hash = getStableHashCode64(mangledName.begin(), mangledName.getLength());
 
         StringBuilder builder;
         builder << "_Sh";

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -676,8 +676,9 @@ RefPtr<TypeLayout> getTypeLayoutForGlobalShaderParameter(
 
     if(varDecl->hasModifier<ShaderRecordAttribute>() && as<ConstantBufferType>(type))
     {
-        return createTypeLayout(
-            layoutContext.with(rules->getShaderRecordConstantBufferRules()),
+        return createTypeLayoutWith(
+            layoutContext,
+            rules->getShaderRecordConstantBufferRules(),
             type);
     }
 
@@ -686,8 +687,9 @@ RefPtr<TypeLayout> getTypeLayoutForGlobalShaderParameter(
     // qualifier before we move on to anything else.
     if( varDecl->hasModifier<PushConstantAttribute>() && as<ConstantBufferType>(type) )
     {
-        return createTypeLayout(
-            layoutContext.with(rules->getPushConstantBufferRules()),
+        return createTypeLayoutWith(
+            layoutContext,
+            rules->getPushConstantBufferRules(),
             type);
     }
 
@@ -710,8 +712,9 @@ RefPtr<TypeLayout> getTypeLayoutForGlobalShaderParameter(
 
     // An "ordinary" global variable is implicitly a uniform
     // shader parameter.
-    return createTypeLayout(
-        layoutContext.with(rules->getConstantBufferRules(context->getTargetRequest())),
+    return createTypeLayoutWith(
+        layoutContext,
+        rules->getConstantBufferRules(context->getTargetRequest()),
         type);
 }
 
@@ -1910,15 +1913,19 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
         case Stage::ClosestHit:
         case Stage::Miss:
             // `in out` or `out` parameter is payload
-            return createTypeLayout(context->layoutContext.with(
-                context->getRulesFamily()->getRayPayloadParameterRules()),
-                type);
+            return createTypeLayoutWith(
+                context->layoutContext,
+                context->getRulesFamily()->getRayPayloadParameterRules(),
+                type
+            );
 
         case Stage::Callable:
             // `in out` or `out` parameter is payload
-            return createTypeLayout(context->layoutContext.with(
-                context->getRulesFamily()->getCallablePayloadParameterRules()),
-                type);
+            return createTypeLayoutWith(
+                context->layoutContext,
+                context->getRulesFamily()->getCallablePayloadParameterRules(),
+                type
+            );
 
         }
     }
@@ -1946,9 +1953,11 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
         case Stage::AnyHit:
         case Stage::ClosestHit:
             // `in` parameter is hit attributes
-            return createTypeLayout(context->layoutContext.with(
-                context->getRulesFamily()->getHitAttributesParameterRules()),
-                type);
+            return createTypeLayoutWith(
+                context->layoutContext,
+                context->getRulesFamily()->getHitAttributesParameterRules(),
+                type
+            );
         }
     }
 
@@ -2226,9 +2235,9 @@ static RefPtr<TypeLayout> computeEntryPointParameterTypeLayout(
         // a uniform shader parameter passed via the implicitly-defined
         // constant buffer (e.g., the `$Params` constant buffer seen in fxc/dxc output).
         //
-        return createTypeLayout(
-            context->layoutContext.with(
-                context->getRulesFamily()->getConstantBufferRules(context->getTargetRequest())),
+        return createTypeLayoutWith(
+            context->layoutContext,
+            context->getRulesFamily()->getConstantBufferRules(context->getTargetRequest()),
             paramType);
     }
     else

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -3171,9 +3171,8 @@ void diagnoseGlobalUniform(
 static int _calcTotalNumUsedRegistersForLayoutResourceKind(ParameterBindingContext* bindingContext, LayoutResourceKind kind)
 {
     int numUsed = 0;
-    for (auto& pair : bindingContext->shared->globalSpaceUsedRangeSets)
+    for (auto& [_, rangeSet] : bindingContext->shared->globalSpaceUsedRangeSets)
     {
-        UsedRangeSet* rangeSet = pair.value;
         const auto& usedRanges = rangeSet->usedResourceRanges[kind];
         for (const auto& usedRange : usedRanges.ranges)
         {

--- a/source/slang/slang-preprocessor.cpp
+++ b/source/slang/slang-preprocessor.cpp
@@ -3864,11 +3864,8 @@ static Token ReadToken(Preprocessor* preprocessor)
 // clean up after an environment
 Environment::~Environment()
 {
-    for (auto pair : this->macros)
-    {
-        auto macro = pair.value;
+    for (const auto& [_, macro] : this->macros)
         delete macro;
-    }
 }
 
 // Add a simple macro definition from a string (e.g., for a
@@ -4066,10 +4063,8 @@ TokenList preprocessSource(
 
     if(desc.defines)
     {
-        for (auto p : *desc.defines)
-        {
-            DefineMacro(&preprocessor, p.key, p.value);
-        }
+        for (const auto& [key, value] : *desc.defines)
+            DefineMacro(&preprocessor, key, value);
     }
 
     {

--- a/source/slang/slang-reflection-api.cpp
+++ b/source/slang/slang-reflection-api.cpp
@@ -2962,9 +2962,9 @@ SLANG_API const char* spReflection_getHashedString(
     return slice.begin();
 }
 
-SLANG_API int spComputeStringHash(const char* chars, size_t count)
+SLANG_API SlangUInt32 spComputeStringHash(const char* chars, size_t count)
 {
-    return (int)getStableHashCode32(chars, count);
+    return SlangUInt32(getStableHashCode32(chars, count));
 }
 
 SLANG_API SlangReflectionTypeLayout* spReflection_getGlobalParamsTypeLayout(

--- a/source/slang/slang-repro.cpp
+++ b/source/slang/slang-repro.cpp
@@ -57,7 +57,7 @@ namespace Slang {
 #define SLANG_STATE_TYPE_SIZE(x) uint32_t(sizeof(x)), 
 
 // A function to calculate the hash related in list in part to how the types used are sized. Can catch crude breaking binary differences.
-static HashCode32 _calcTypeHash()
+static StableHashCode32 _calcTypeHash()
 {
     typedef ReproUtil Util;
     const uint32_t sizes[] =
@@ -67,9 +67,9 @@ static HashCode32 _calcTypeHash()
     return getStableHashCode32((const char*)&sizes, sizeof(sizes));
 }
 
-static HashCode32 _getTypeHash()
+static StableHashCode32 _getTypeHash()
 {
-    static HashCode32 s_hash = _calcTypeHash();
+    static StableHashCode32 s_hash = _calcTypeHash();
     return s_hash;
 }
 
@@ -1098,7 +1098,7 @@ struct LoadContext
     Header header;
     header.m_chunk.type = kSlangStateFourCC;
     header.m_semanticVersion = g_semanticVersion;
-    header.m_typeHash = uint32_t(_getTypeHash());
+    header.m_typeHash = _getTypeHash();
 
     return RiffUtil::writeData(&header.m_chunk, sizeof(header),container.getData(), container.getDataCount(), stream);
 }
@@ -1145,7 +1145,7 @@ struct LoadContext
         return SLANG_FAIL;
     }
 
-    if (header.m_typeHash != uint32_t(_getTypeHash()))
+    if (header.m_typeHash != _getTypeHash())
     {
         sink->diagnose(SourceLoc(), Diagnostics::riffHashMismatch);
         return SLANG_FAIL;

--- a/source/slang/slang-repro.cpp
+++ b/source/slang/slang-repro.cpp
@@ -443,7 +443,7 @@ static String _scrubName(const String& in)
             {
                 const auto& srcTargetInfos = request->m_targetInfos;
 
-                if (RefPtr<EndToEndCompileRequest::TargetInfo>* infosPtr = srcTargetInfos.tryGetValue(srcTargetRequest))
+                if (const RefPtr<EndToEndCompileRequest::TargetInfo>* infosPtr = srcTargetInfos.tryGetValue(srcTargetRequest))
                 {
                     EndToEndCompileRequest::TargetInfo* infos = *infosPtr;
 

--- a/source/slang/slang-repro.cpp
+++ b/source/slang/slang-repro.cpp
@@ -278,15 +278,11 @@ struct StoreContext
         OffsetBase& base = m_container->asBase();
 
         Index index = 0;
-        for (const auto& srcDefine : srcDefines)
+        for (const auto& [srcDefineName, srcDefineVal] : srcDefines)
         {
-            // Do allocation before setting
-            const auto key = fromString(srcDefine.key);
-            const auto value = fromString(srcDefine.value);
-
             auto& dstDefine = base[dstDefines[index]];
-            dstDefine.first = key;
-            dstDefine.second = value;
+            dstDefine.first = fromString(srcDefineName);
+            dstDefine.second = fromString(srcDefineVal);
 
             index++;
         }
@@ -456,13 +452,13 @@ static String _scrubName(const String& in)
                     Offset32Array<OutputState> dstOutputStates = inOutContainer.newArray<OutputState>(entryPointOutputPaths.getCount());
 
                     Index index = 0;
-                    for (const auto& pair : entryPointOutputPaths)
+                    for (const auto& [key, value] : entryPointOutputPaths)
                     {
-                        Offset32Ptr<OffsetString> outputPath = inOutContainer.newString(pair.value.getUnownedSlice());
+                        Offset32Ptr<OffsetString> outputPath = inOutContainer.newString(value.getUnownedSlice());
 
                         auto& dstOutputState = base[dstOutputStates[index]];
 
-                        dstOutputState.entryPointIndex = int32_t(pair.key);
+                        dstOutputState.entryPointIndex = int32_t(key);
                         dstOutputState.outputPath = outputPath;
 
                         index++;
@@ -545,10 +541,10 @@ static String _scrubName(const String& in)
             Offset32Array<PathAndPathInfo> pathMap = inOutContainer.newArray<PathAndPathInfo>(srcFiles.getCount());
 
             Index index = 0;
-            for (const auto& pair : srcFiles)
+            for (const auto& [key, value] : srcFiles)
             {
-                const auto path = context.fromString(pair.key);
-                const auto pathInfo = context.addPathInfo(pair.value);
+                const auto path = context.fromString(key);
+                const auto pathInfo = context.addPathInfo(value);
 
                 PathAndPathInfo& dstInfo = base[pathMap[index]];
                 dstInfo.path = path;
@@ -637,9 +633,9 @@ static String _scrubName(const String& in)
         auto dstSourceFiles = inOutContainer.newArray<Offset32Ptr<SourceFileState>>(srcSourceFiles.getCount());
 
         Index index = 0;
-        for (const auto& pair : srcSourceFiles)
+        for (const auto& [_, value] : srcSourceFiles)
         {
-            base[dstSourceFiles[index]] = pair.value; 
+            base[dstSourceFiles[index]] = value;
             index++;
         }
         base[requestState]->sourceFiles = dstSourceFiles;
@@ -873,9 +869,8 @@ struct LoadContext
 
     // Put all the path infos in the cache system
     {
-        for (const auto& pair : context.m_fileToPathInfoMap)
+        for (const auto& [_, pathInfo] : context.m_fileToPathInfoMap)
         {
-            CacheFileSystem::PathInfo* pathInfo = pair.value;
             SLANG_ASSERT(pathInfo->m_uniqueIdentity.getLength());
             dstUniqueMap.add(pathInfo->m_uniqueIdentity, pathInfo);
 
@@ -1069,10 +1064,8 @@ struct LoadContext
         }
         // Put all the path infos in the cache system
         {
-            for (const auto& pair : context.m_fileToPathInfoMap)
+            for (const auto& [_, pathInfo] : context.m_fileToPathInfoMap)
             {
-                CacheFileSystem::PathInfo* pathInfo = pair.value;
-
                 // TODO(JS): It's not 100% clear why we are ending up 
                 // with entries that don't have a unique identity.
                 // For now we ignore adding to the unique map, because 

--- a/source/slang/slang-repro.h
+++ b/source/slang/slang-repro.h
@@ -4,6 +4,7 @@
 
 #include "../core/slang-riff.h"
 #include "../core/slang-string.h"
+#include "../core/slang-stable-hash.h"
 
 // For TranslationUnitRequest
 #include "slang-compiler.h"
@@ -35,7 +36,7 @@ struct ReproUtil
     {
         RiffHeader m_chunk;                              ///< The chunk 
         RiffSemanticVersion m_semanticVersion;          ///< The semantic version
-        uint32_t m_typeHash;                            ///< A hash based on the binary representation. If doesn't match then not binary compatible (extra check over semantic versioning)
+        StableHashCode32 m_typeHash;                   ///< A hash based on the binary representation. If doesn't match then not binary compatible (extra check over semantic versioning)
     };
 
     struct FileState

--- a/source/slang/slang-serialize-ir.h
+++ b/source/slang/slang-serialize-ir.h
@@ -26,7 +26,7 @@ struct IRSerialWriter
     static Result writeContainer(const IRSerialData& data, SerialCompressionType compressionType, RiffContainer* container);
     
     /// Get an instruction index from an instruction
-    Ser::InstIndex getInstIndex(IRInst* inst) const { return inst ? Ser::InstIndex(m_instMap[inst]) : Ser::InstIndex(0); }
+    Ser::InstIndex getInstIndex(IRInst* inst) const { return inst ? Ser::InstIndex(m_instMap.at(inst)) : Ser::InstIndex(0); }
 
         /// Get a slice from an index
     UnownedStringSlice getStringSlice(Ser::StringIndex index) const { return m_stringSlicePool.getSlice(StringSlicePool::Handle(index)); }

--- a/source/slang/slang-serialize-ir.h
+++ b/source/slang/slang-serialize-ir.h
@@ -26,7 +26,7 @@ struct IRSerialWriter
     static Result writeContainer(const IRSerialData& data, SerialCompressionType compressionType, RiffContainer* container);
     
     /// Get an instruction index from an instruction
-    Ser::InstIndex getInstIndex(IRInst* inst) const { return inst ? Ser::InstIndex(m_instMap.at(inst)) : Ser::InstIndex(0); }
+    Ser::InstIndex getInstIndex(IRInst* inst) const { return inst ? Ser::InstIndex(m_instMap.getValue(inst)) : Ser::InstIndex(0); }
 
         /// Get a slice from an index
     UnownedStringSlice getStringSlice(Ser::StringIndex index) const { return m_stringSlicePool.getSlice(StringSlicePool::Handle(index)); }

--- a/source/slang/slang-serialize-source-loc.cpp
+++ b/source/slang/slang-serialize-source-loc.cpp
@@ -124,9 +124,8 @@ void SerialSourceLocWriter::write(SerialSourceLocData* outSourceLocData)
 
     // Okay we can now calculate the final source information
 
-    for (auto& pair : m_sourceFileMap)
+    for (const auto& [_, debugSourceFile] : m_sourceFileMap)
     {
-        Source* debugSourceFile = pair.value;
         SourceFile* sourceFile = debugSourceFile->m_sourceFile;
 
         SerialSourceLocData::SourceInfo sourceInfo;

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -1986,12 +1986,12 @@ RefPtr<TypeLayout> applyOffsetToTypeLayout(
             mapOldFieldToNew.add(oldField.Ptr(), newField.Ptr());
         }
 
-        for (auto entry : oldStructTypeLayout->mapVarToLayout)
+        for (const auto& [entryKey, entryValue] : oldStructTypeLayout->mapVarToLayout)
         {
             VarLayout* newFieldLayout = nullptr;
-            if (mapOldFieldToNew.tryGetValue(entry.value.Ptr(), newFieldLayout))
+            if (mapOldFieldToNew.tryGetValue(entryValue.Ptr(), newFieldLayout))
             {
-                newStructTypeLayout->mapVarToLayout.add(entry.key, newFieldLayout);
+                newStructTypeLayout->mapVarToLayout.add(entryKey, newFieldLayout);
             }
         }
 
@@ -3131,10 +3131,8 @@ static RefPtr<TypeLayout> maybeAdjustLayoutForArrayElementType(
             mapOriginalFieldToAdjusted.add(originalField, adjustedField);
         }
 
-        for( auto p : originalStructTypeLayout->mapVarToLayout )
+        for( auto [key, originalVal] : originalStructTypeLayout->mapVarToLayout )
         {
-            VarDeclBase* key = p.key;
-            RefPtr<VarLayout> originalVal = p.value;
             RefPtr<VarLayout> adjustedVal;
             if( mapOriginalFieldToAdjusted.tryGetValue(originalVal, adjustedVal) )
             {

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -3613,7 +3613,7 @@ static void _addLayout(TypeLayoutContext& context,
 {
     // Add it *without info*.
     // The info can be added with _updateLayout
-    context.layoutMap[type] = TypeLayoutResult(layout, SimpleLayoutInfo());
+    context.layoutMap.set(type, TypeLayoutResult(layout, SimpleLayoutInfo()));
 }
 
 static void _addLayout(TypeLayoutContext& context,

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -3625,24 +3625,6 @@ static void _addLayout(TypeLayoutContext& context,
 
 static TypeLayoutResult _updateLayout(TypeLayoutContext& context,
     Type* type,
-    TypeLayout* layout,
-    const SimpleLayoutInfo& info)
-{
-    auto layoutResultPtr = context.layoutMap.tryGetValue(type);
-    SLANG_ASSERT(layoutResultPtr);
-    if (layoutResultPtr)
-    {
-        // Check the layout is the same!
-        SLANG_ASSERT(layoutResultPtr->layout.get() == layout);
-        // Update the info
-        layoutResultPtr->info = info;
-    }
-
-    return TypeLayoutResult(layout, info);
-}
-
-static TypeLayoutResult _updateLayout(TypeLayoutContext& context,
-    Type* type,
     const TypeLayoutResult& result)
 {
     auto layoutResultPtr = context.layoutMap.tryGetValue(type);

--- a/source/slang/slang-type-layout.h
+++ b/source/slang/slang-type-layout.h
@@ -1264,7 +1264,14 @@ RefPtr<TypeLayout> getSimpleVaryingParameterTypeLayout(
 // Create a full type-layout object for a type,
 // according to the layout rules in `context`.
 RefPtr<TypeLayout> createTypeLayout(
-    TypeLayoutContext const&    context,
+    TypeLayoutContext&          context,
+    Type*                       type);
+
+// A wrapper for createTypeLayout which copies the context applying the
+// provided rules with TypeLayoutContext::with
+RefPtr<TypeLayout> createTypeLayoutWith(
+    const TypeLayoutContext&    context,
+    LayoutRulesImpl*            rules,
     Type*                       type);
 
 //

--- a/source/slang/slang-workspace-version.cpp
+++ b/source/slang/slang-workspace-version.cpp
@@ -299,9 +299,9 @@ RefPtr<WorkspaceVersion> Workspace::createWorkspaceVersion()
     else
     {
         HashSet<String> set;
-        for (auto& p : openedDocuments)
+        for (const auto& [docPath, _] : openedDocuments)
         {
-            auto dir = Path::getParentDirectory(p.key.getBuffer());
+            auto dir = Path::getParentDirectory(docPath.getBuffer());
             if (set.add(dir))
                 searchPathsRaw.add(dir.getBuffer());
         }

--- a/tests/serialization/obfuscated-module-check-loc.slang.3.expected
+++ b/tests/serialization/obfuscated-module-check-loc.slang.3.expected
@@ -1,6 +1,6 @@
 result code = -1
 standard error = {
-cae4a81b-obfuscated(2): error 40020: loop does not terminate within the limited number of iterations, unrolling is aborted.
+d1fec486-obfuscated(11): error 40020: loop does not terminate within the limited number of iterations, unrolling is aborted.
 }
 standard output = {
 }

--- a/tools/gfx/debug-layer/debug-shader-object.h
+++ b/tools/gfx/debug-layer/debug-shader-object.h
@@ -12,13 +12,13 @@ namespace debug
 struct ShaderOffsetKey
 {
     ShaderOffset offset;
-    bool operator==(ShaderOffsetKey other)
+    bool operator==(ShaderOffsetKey other) const
     {
         return offset.bindingArrayIndex == other.offset.bindingArrayIndex &&
             offset.bindingRangeIndex == other.offset.bindingRangeIndex &&
             offset.uniformOffset == other.offset.uniformOffset;
     }
-    Slang::HashCode getHashCode()
+    Slang::HashCode getHashCode() const
     {
         return Slang::combineHash(
             (Slang::HashCode)offset.uniformOffset,

--- a/tools/gfx/renderer-shared.cpp
+++ b/tools/gfx/renderer-shared.cpp
@@ -3,6 +3,7 @@
 #include "core/slang-io.h"
 #include "core/slang-token-reader.h"
 
+#include "../../source/core/slang-stable-hash.h"
 #include "../../source/core/slang-file-system.h"
 
 #include "../../slang.h"

--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -1043,7 +1043,7 @@ struct ComponentKey
     Slang::UnownedStringSlice typeName;
     Slang::ShortList<ShaderComponentID> specializationArgs;
     Slang::HashCode hash;
-    Slang::HashCode getHashCode()
+    Slang::HashCode getHashCode() const
     {
         return hash;
     }
@@ -1060,7 +1060,7 @@ struct PipelineKey
     PipelineStateBase* pipeline;
     Slang::ShortList<ShaderComponentID> specializationArgs;
     Slang::HashCode hash;
-    Slang::HashCode getHashCode()
+    Slang::HashCode getHashCode() const
     {
         return hash;
     }
@@ -1070,7 +1070,7 @@ struct PipelineKey
         for (auto& arg : specializationArgs)
             hash = Slang::combineHash(hash, arg);
     }
-    bool operator==(const PipelineKey& other)
+    bool operator==(const PipelineKey& other) const
     {
         if (pipeline != other.pipeline)
             return false;
@@ -1090,12 +1090,12 @@ struct OwningComponentKey
     Slang::String typeName;
     Slang::ShortList<ShaderComponentID> specializationArgs;
     Slang::HashCode hash;
-    Slang::HashCode getHashCode()
+    Slang::HashCode getHashCode() const
     {
         return hash;
     }
     template<typename KeyType>
-    bool operator==(const KeyType& other)
+    bool operator==(const KeyType& other) const
     {
         if (typeName != other.typeName)
             return false;

--- a/tools/slang-cpp-extractor/node.cpp
+++ b/tools/slang-cpp-extractor/node.cpp
@@ -316,7 +316,7 @@ void ScopeNode::addChild(Node* child)
 
 Node* ScopeNode::findChild(const UnownedStringSlice& name) const
 {
-    Node** nodePtr = m_childMap.tryGetValue(name);
+    Node* const* nodePtr = m_childMap.tryGetValue(name);
     if (nodePtr)
     {
         return *nodePtr;

--- a/tools/slang-lookup-generator/lookup-generator-main.cpp
+++ b/tools/slang-lookup-generator/lookup-generator-main.cpp
@@ -103,12 +103,11 @@ static HashFindResult minimalPerfectHash(const List<String>& ss, HashParams& has
     const auto hash = [&](const String& s, const HashCode64 salt = 0) -> UInt32
     {
         //
-        // The current getStableHashCode32 is susceptible to patterns of
-        // collisions causing the search to fail for the SPIR-V opnames
-        //
-        // getStableHashCode64 is better, although it still performs poorly on
-        // short strings, taking over 300000 iterations to diverge on "Ceil"
-        // and "FMix" (and place them in already unoccupied slots)!
+        // The current getStableHashCode is susceptible to patterns of
+        // collisions causing the search to fail for the SPIR-V opnames; it
+        // performs poorly on short strings, taking over 300000 iterations to
+        // diverge on "Ceil" and "FMix" (and place them in already unoccupied
+        // slots)!
         //
         // Use FNV Hash here which seem perform much better on these short inputs
         // https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function

--- a/tools/slang-profile/slang-profile-main.cpp
+++ b/tools/slang-profile/slang-profile-main.cpp
@@ -17,7 +17,7 @@ SlangResult innerMain(int argc, char** argv)
 
     // Time the creation of the session
     {
-        const auto startTick = ProcessUtil::getClockTick();
+        const auto startTick = Process::getClockTick();
 
         for (Int i = 0; i < 32; ++i)
         {
@@ -25,9 +25,9 @@ SlangResult innerMain(int argc, char** argv)
             slangSession.attach(spCreateSession(nullptr));
         }
 
-        const auto endTick = ProcessUtil::getClockTick();
+        const auto endTick = Process::getClockTick();
 
-        printf("Ticks %f\n", double(endTick - startTick) / ProcessUtil::getClockFrequency());
+        printf("Ticks %f\n", double(endTick - startTick) / Process::getClockFrequency());
         return SLANG_OK;
     }
 

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -3661,9 +3661,9 @@ bool testCategoryMatches(
     TestCategory*                           categoryToMatch,
     const Dictionary<TestCategory*, TestCategory*>& categorySet)
 {
-    for( auto item : categorySet )
+    for( const auto& [_, category] : categorySet )
     {
-        if(testCategoryMatches(categoryToMatch, item.value))
+        if(testCategoryMatches(categoryToMatch, category))
             return true;
     }
     return false;

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -185,10 +185,8 @@ SlangResult TestServer::init(int argc, const char* const* argv)
 
 TestServer::~TestServer()
 {
-    for (auto& pair : m_unitTestModules)
-    {
-        pair.value->destroy();
-    }
+    for (auto& [_, value] : m_unitTestModules)
+        value->destroy();
 }
 
 slang::IGlobalSession* TestServer::getOrCreateGlobalSession()


### PR DESCRIPTION
Notable changes to Dictionary:
- The subscript operator returns a reference directly to the value,
rather than a lazy ItemProxy (pair of dict pointer and key). The most important consequence is that the idiom `myMap[foo] = myMap.at(bar)` is no longer safe if `foo` doesn't exist in the map already. Consider that the construction of the value at `foo` caused the map to invalidate references, then the reference returned by `bar` is now no longer value; these can be safely replaced with the (more efficient) `myMap.set(foo, myMap.at(bar))`.

Notable changes to Hash:
- We no longer specialize `getHashCode` for `const char*` and `char*`, they are treated as regular pointers now (we were't using this specialization anyway. If desired we can add a static assert in slang-hash.h for this case).
- If we implement a "uniform hash" for a class's `getHashCode` member, then we can set `kHasUniformHash = true` to avoid the map library rehashing to regain uniformity.
- Default to 64 bit hash, which is what the map implementation expects (and hence doesn't require an expansion to 64 bits)

Other:
- The comments for obfuscated module names indicated that a stable hash was desirable, however the non-stable hashing functions were being used in the computation. I've corrected this to use the stable hashing functions, however this has necessarily introduced a change to the output module names. I've made the stable hashing functions operate on distinct types to the regular hashing functions to help prevent this happening again.

We still hash `0.f` and `-0.f` to distinct values, however this warrants reconsideration as it means our hash function is not equality preserving!

slang-profile time (95% over 10 runs):

- Before: 6.3913906 (±0.0746)
- After:  5.9276123 (±0.0964)

~~For a bunch of convenience features also bump to c++20~~