### PR TITLE
Fix `Val` deduplication bug.

### DIFF
--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -446,6 +446,10 @@ class Val : public NodeBase
             m_operands.add(ValNodeOperand(v));
     }
     List<ValNodeOperand> m_operands;
+
+    // Private use by stdlib deserialization only. Since we know the Vals serialized into stdlib is already
+    // unique, we can just use `this` pointer as the `m_resolvedVal` so we don't need to resolve them again.
+    void _setUnique();
 protected:
     Val* defaultResolveImpl();
 private:

--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -46,8 +46,6 @@ class NodeBase
         /// The actual type is set when constructed on the ASTBuilder. 
     ASTNodeType astNodeType = ASTNodeType(-1);
 
-    // Handy when debugging, shouldn't be checked in though!
-    // virtual ~NodeBase() {}
 #ifdef _DEBUG
     SLANG_UNREFLECTED int32_t _debugUID = 0;
 #endif
@@ -197,7 +195,25 @@ struct ValNodeDesc
     ASTNodeType             type;
     ShortList<ValNodeOperand, 4> operands;
 
-    bool operator==(ValNodeDesc const& that) const;
+    inline bool operator==(ValNodeDesc const& that) const
+    {
+        if (hashCode != that.hashCode) return false;
+        if (type != that.type) return false;
+        if (operands.getCount() != that.operands.getCount()) return false;
+        for (Index i = 0; i < operands.getCount(); ++i)
+        {
+            // Note: we are comparing the operands directly for identity
+            // (pointer equality) rather than doing the `Val`-level
+            // equality check.
+            //
+            // The rationale here is that nodes that will be created
+            // via a `NodeDesc` *should* all be going through the
+            // deduplication path anyway, as should their operands.
+            // 
+            if (operands[i].values.nodeOperand != that.operands[i].values.nodeOperand) return false;
+        }
+        return true;
+    }
     HashCode getHashCode() const { return hashCode; }
     void init();
 private:

--- a/source/slang/slang-ast-decl-ref.cpp
+++ b/source/slang/slang-ast-decl-ref.cpp
@@ -166,7 +166,7 @@ Val* LookupDeclRef::tryResolve(SubtypeWitness* newWitness, Type* newLookupSource
 
     case RequirementWitness::Flavor::val:
     {
-        auto satisfyingVal = requirementWitness.getVal();
+        auto satisfyingVal = requirementWitness.getVal()->resolve();
         return satisfyingVal;
     }
     break;

--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -66,31 +66,7 @@ Val* Val::resolve()
     }
     // Update epoch now to avoid infinite recursion.
     m_resolvedValEpoch = getCurrentASTBuilder()->getEpoch();
-    m_resolvedVal = this;
     m_resolvedVal = resolveImpl();
-
-#if 1
-    // Check if we are resolved to an existing Val in the AST cache.
-    ValNodeDesc newDesc;
-    newDesc.type = m_resolvedVal->astNodeType;
-    for (auto operand : m_resolvedVal->m_operands)
-    {
-        if (operand.kind == ValNodeOperandKind::ValNode)
-        {
-            auto valOperand = as<Val>(operand.values.nodeOperand);
-            if (valOperand)
-            {
-                operand.values.nodeOperand = valOperand->resolve();
-            }
-        }
-        newDesc.operands.add(operand);
-    }
-    newDesc.init();
-
-    Val* existingNode = nullptr;
-    if (astBuilder->m_cachedNodes.tryGetValue(newDesc, existingNode))
-        m_resolvedVal = existingNode;
-#endif
 #ifdef _DEBUG
     if (m_resolvedVal->_debugUID > 0 && this->_debugUID < 0)
     {

--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -110,6 +110,12 @@ ValNodeDesc Val::getDesc()
     return desc;
 }
 
+void Val::_setUnique()
+{
+    m_resolvedVal = this;
+    m_resolvedValEpoch = getCurrentASTBuilder()->getEpoch();
+}
+
 Val* Val::defaultResolveImpl()
 {
     // Default resolve implementation is to recursively resolve all operands, and lookup in deduplication cache.

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1181,7 +1181,9 @@ namespace Slang
             if (auto nodiffModifier = modifiedType->findModifier<NoDiffModifierVal>())
             {
                 varDecl->type.type = getRemovedModifierType(modifiedType, nodiffModifier);
-                addModifier(varDecl, m_astBuilder->getOrCreate<NoDiffModifier>());
+                auto noDiffModifier = m_astBuilder->create<NoDiffModifier>();
+                noDiffModifier->loc = varDecl->loc;
+                addModifier(varDecl, noDiffModifier);
             }
         }
 

--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -387,7 +387,11 @@ namespace Slang
             // Initialize fields to 0 to prevent downstream compiler error.
             for (uint32_t offset = 0; offset < (uint32_t)anyValInfo->fieldKeys.getCount(); offset++)
             {
-                auto fieldAddr = builder.emitFieldAddress(builder.getUIntType(), resultVar, anyValInfo->fieldKeys[offset]);
+                auto fieldAddr = builder.emitFieldAddress(
+                    builder.getPtrType(builder.getUIntType()),
+                    resultVar,
+                    anyValInfo->fieldKeys[offset]
+                );
                 builder.emitStore(fieldAddr, builder.getIntValue(builder.getUIntType(), 0));
             }
 

--- a/source/slang/slang-serialize-ast-type-info.h
+++ b/source/slang/slang-serialize-ast-type-info.h
@@ -54,14 +54,6 @@ inline void deserializeValPointerValue(SerialReader* reader, const SerialIndex* 
 {
     auto val = reader->getPointer(*(const SerialIndex*)inSerial).dynamicCast<Val>();
     *(Val**)outPtr = val;
-    if (val)
-    {
-        SLANG_ASSERT(as<Val>(val));
-        PostSerializationFixUp fixup;
-        fixup.kind = PostSerializationFixUpKind::ValPtr;
-        fixup.addressToModify = outPtr;
-        reader->getFixUps().add(fixup);
-    }
 }
 
 template<typename T>

--- a/source/slang/slang-serialize-ast-type-info.h
+++ b/source/slang/slang-serialize-ast-type-info.h
@@ -43,17 +43,15 @@ struct SerialTypeInfo<SyntaxClass<T>>
 template <>
 struct SerialTypeInfo<MatrixCoord> : SerialIdentityTypeInfo<MatrixCoord> {};
 
-inline void serializePointerValue(SerialWriter* writer, Val* ptrValue, SerialIndex* outSerial)
+inline void serializeValPointerValue(SerialWriter* writer, Val* ptrValue, SerialIndex* outSerial)
 {
     if (ptrValue)
         ptrValue = ptrValue->resolve();
     *(SerialIndex*)outSerial = writer->addPointer(ptrValue);
 }
 
-inline void deserializePointerValue(SerialReader* reader, const SerialIndex* inSerial, void* outPtr, Val* unusedForResolution)
+inline void deserializeValPointerValue(SerialReader* reader, const SerialIndex* inSerial, void* outPtr)
 {
-    SLANG_UNUSED(unusedForResolution);
-
     auto val = reader->getPointer(*(const SerialIndex*)inSerial).dynamicCast<Val>();
     *(Val**)outPtr = val;
     if (val)
@@ -65,6 +63,25 @@ inline void deserializePointerValue(SerialReader* reader, const SerialIndex* inS
         reader->getFixUps().add(fixup);
     }
 }
+
+template<typename T>
+struct PtrSerialTypeInfo<T, std::enable_if_t<std::is_base_of_v<Val, T>>>
+{
+    typedef T* NativeType;
+    typedef SerialIndex SerialType;
+    enum { SerialAlignment = SLANG_ALIGN_OF(SerialType) };
+
+    static void toSerial(SerialWriter* writer, const void* inNative, void* outSerial)
+    {
+        auto ptrValue = *(T**)inNative;
+        serializeValPointerValue(writer, ptrValue, (SerialIndex*)outSerial);
+    }
+
+    static void toNative(SerialReader* reader, const void* inSerial, void* outNative)
+    {
+        deserializeValPointerValue(reader, (SerialIndex*)inSerial, outNative);
+    }
+};
 
 template <typename T>
 struct SerialTypeInfo<DeclRef<T>> : public SerialTypeInfo<DeclRefBase*> {};
@@ -89,9 +106,9 @@ struct SerialTypeInfo<ValNodeOperand>
         if (src.kind == ValNodeOperandKind::ConstantValue)
             dst.val = src.values.intOperand;
         else if (src.kind == ValNodeOperandKind::ValNode)
-            serializePointerValue(writer, (Val*)src.values.nodeOperand, (SerialIndex*)&dst.val);
+            serializeValPointerValue(writer, (Val*)src.values.nodeOperand, (SerialIndex*)&dst.val);
         else
-            serializePointerValue(writer, src.values.nodeOperand, (SerialIndex*)&dst.val);
+            SerialTypeInfo<NodeBase*>::toSerial(writer, &src.values.nodeOperand, (SerialIndex*)&dst.val);
     }
     static void toNative(SerialReader* reader, const void* serial, void* native)
     {
@@ -104,9 +121,9 @@ struct SerialTypeInfo<ValNodeOperand>
         if (dst.kind == ValNodeOperandKind::ConstantValue)
             dst.values.intOperand = int64_t(src.val);
         else if (dst.kind == ValNodeOperandKind::ValNode)
-            deserializePointerValue(reader, (SerialIndex*)&src.val, (Val**)&dst.values.nodeOperand, (Val*)nullptr);
+            deserializeValPointerValue(reader, (SerialIndex*)&src.val, (Val**)&dst.values.nodeOperand);
         else
-            deserializePointerValue(reader, (SerialIndex*)&src.val, &dst.values.nodeOperand, (NodeBase*)nullptr);
+            SerialTypeInfo<NodeBase*>::toNative(reader, (SerialIndex*)&src.val, (NodeBase**)&dst.values.nodeOperand);
     }
 };
 

--- a/source/slang/slang-serialize-container.cpp
+++ b/source/slang/slang-serialize-container.cpp
@@ -602,8 +602,7 @@ static List<ExtensionDecl*>& _getCandidateExtensionList(
                                 astBuilder->m_cachedNodes[val->getDesc()] = newVal;
                                 for (auto use : valUseList.value)
                                 {
-                                    if (*use != newVal)
-                                        *use = newVal;
+                                    *use = newVal;
                                 }
                             }
                         }

--- a/source/slang/slang-serialize.h
+++ b/source/slang/slang-serialize.h
@@ -216,12 +216,6 @@ enum class PostSerializationFixUpKind
     ValPtr,
 };
 
-struct PostSerializationFixUp
-{
-    PostSerializationFixUpKind kind;
-    void* addressToModify;
-};
-
 /* This class is the interface used by toNative implementations to recreate a type. */
 class SerialReader : public RefObject
 {
@@ -250,8 +244,6 @@ public:
 
         /// Get the entries list
     const List<const Entry*>& getEntries() const { return m_entries; }
-
-    List<PostSerializationFixUp>& getFixUps() { return m_fixUps; }
 
         /// Access the objects list
         /// NOTE that if a SerialObject holding a RefObject and needs to be kept in scope, add the RefObject* via addScope
@@ -289,9 +281,7 @@ protected:
     SerialExtraObjects m_extraObjects;
 
     SerialObjectFactory* m_objectFactory;
-    SerialClasses* m_classes;           ///< Information used to deserialize 
-
-    List<PostSerializationFixUp> m_fixUps;
+    SerialClasses* m_classes;           ///< Information used to deserialize
 };
 
 // ---------------------------------------------------------------------------

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -437,12 +437,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
             nodeDesc.type = (ASTNodeType)classInfo.classInfo->m_classId;
             nodeDesc.operands.add(ValNodeOperand(declRef));
             nodeDesc.init();
-            NodeBase* type = astBuilder->_getOrCreateImpl(nodeDesc, [&]()
-                {
-                    auto resultNode = as<DeclRefType>(classInfo.createInstance(astBuilder));
-                    resultNode->setOperands(declRef);
-                    return resultNode;
-                });
+            NodeBase* type = astBuilder->_getOrCreateImpl(nodeDesc);
             if (!type)
             {
                 SLANG_UNEXPECTED("constructor failure");


### PR DESCRIPTION
- Use SFINAE to override `SerializeTypeInfo<T*>` for certain derived types that works more robustly for value type members.
- Fix several missing calls to `resolve`.
- Concatenate all stdlib sources into a single module before compiling and serializing it so we don't have to deduplicate Vals within stdlibs upon deserialization.