### PR TITLE
Default target intrinsic should not apply to SPIR-V

### DIFF
--- a/source/slang/slang-capability-defs.h
+++ b/source/slang/slang-capability-defs.h
@@ -50,11 +50,13 @@
 // and for `glsl+spirv` or even just for `spirv`, and how should all of those impact
 // overloading).
 //
-SLANG_CAPABILITY_ATOM0(HLSL,     hlsl,      Concrete,TargetFormat,0)
-SLANG_CAPABILITY_ATOM0(GLSL,     glsl,      Concrete,TargetFormat,0)
-SLANG_CAPABILITY_ATOM0(C,        c,         Concrete,TargetFormat,0)
-SLANG_CAPABILITY_ATOM0(CPP,      cpp,       Concrete,TargetFormat,0)
-SLANG_CAPABILITY_ATOM0(CUDA,     cuda,      Concrete,TargetFormat,0)
+SLANG_CAPABILITY_ATOM0(TEXTUAL_SOURCE, textual_source, Abstract,None,0)
+SLANG_CAPABILITY_ATOM1(HLSL,     hlsl,      Concrete,TargetFormat,0,TEXTUAL_SOURCE)
+SLANG_CAPABILITY_ATOM1(GLSL,     glsl,      Concrete,TargetFormat,0,TEXTUAL_SOURCE)
+SLANG_CAPABILITY_ATOM1(C,        c,         Concrete,TargetFormat,0,TEXTUAL_SOURCE)
+SLANG_CAPABILITY_ATOM1(CPP,      cpp,       Concrete,TargetFormat,0,TEXTUAL_SOURCE)
+SLANG_CAPABILITY_ATOM1(CUDA,     cuda,      Concrete,TargetFormat,0,TEXTUAL_SOURCE)
+
 SLANG_CAPABILITY_ATOM0(SPIRV_DIRECT, spirv_direct, Concrete, TargetFormat, 0)
 
 // We have multiple capabilities for the various SPIR-V versions,

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -8276,17 +8276,19 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         definition.append(getText(declForName->getName()));
 
-        getBuilder()->addTargetIntrinsicDecoration(
-            irInst,
-            CapabilitySet({
-                CapabilityAtom::HLSL,
-                CapabilityAtom::GLSL,
-                CapabilityAtom::C,
-                CapabilityAtom::CPP,
-                CapabilityAtom::CUDA,
-            }),
-            definition.getUnownedSlice()
-        );
+        for(const auto cap : {
+            CapabilityAtom::HLSL,
+            CapabilityAtom::GLSL,
+            CapabilityAtom::C,
+            CapabilityAtom::CPP,
+            CapabilityAtom::CUDA})
+        {
+            getBuilder()->addTargetIntrinsicDecoration(
+                irInst,
+                CapabilitySet(cap),
+                definition.getUnownedSlice()
+            );
+        }
     }
 
     void addParamNameHint(IRInst* inst, IRLoweringParameterInfo const& info)

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -8276,19 +8276,11 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         definition.append(getText(declForName->getName()));
 
-        for(const auto cap : {
-            CapabilityAtom::HLSL,
-            CapabilityAtom::GLSL,
-            CapabilityAtom::C,
-            CapabilityAtom::CPP,
-            CapabilityAtom::CUDA})
-        {
-            getBuilder()->addTargetIntrinsicDecoration(
-                irInst,
-                CapabilitySet(cap),
-                definition.getUnownedSlice()
-            );
-        }
+        getBuilder()->addTargetIntrinsicDecoration(
+            irInst,
+            CapabilitySet(CapabilityAtom::TEXTUAL_SOURCE),
+            definition.getUnownedSlice()
+        );
     }
 
     void addParamNameHint(IRInst* inst, IRLoweringParameterInfo const& info)

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -8276,7 +8276,17 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         definition.append(getText(declForName->getName()));
 
-        getBuilder()->addTargetIntrinsicDecoration(irInst, CapabilitySet::makeEmpty(), definition.getUnownedSlice());
+        getBuilder()->addTargetIntrinsicDecoration(
+            irInst,
+            CapabilitySet({
+                CapabilityAtom::HLSL,
+                CapabilityAtom::GLSL,
+                CapabilityAtom::C,
+                CapabilityAtom::CPP,
+                CapabilityAtom::CUDA,
+            }),
+            definition.getUnownedSlice()
+        );
     }
 
     void addParamNameHint(IRInst* inst, IRLoweringParameterInfo const& info)


### PR DESCRIPTION
They're never appropriate as they're not SPIR-V Opcodes

We could perhaps do with a "Textual" superclass for the existing ones?