### PR TITLE
Add missing header in slang-glslang

### DIFF
--- a/source/slang-glslang/slang-glslang.h
+++ b/source/slang-glslang/slang-glslang.h
@@ -4,6 +4,7 @@
 
 #include <stddef.h>
 #include <memory>
+#include <cstring>
 
 typedef void (*glslang_OutputFunc)(void const* data, size_t size, void* userData);
 


### PR DESCRIPTION
Required for memcpy (not sure why this has started being important, but it is the correct thing to do)