### PR TITLE
Casting and vector/scalar correct arithmetic ops for SPIR-V

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1044,29 +1044,32 @@ struct SPIRVEmitContext
 
         // > OpTypeInt
 
-#define CASE(IROP, BITS, SIGNED) \
-        case IROP:                                                                     \
-        return emitTypeInst(inst, SpvOpTypeInt, makeArray<SpvWord>((SpvWord)BITS, (SpvWord)SIGNED).getView()); 
-
-        CASE(kIROp_IntType,     32, 1);
-        CASE(kIROp_UIntType,    32, 0);
-        CASE(kIROp_Int64Type,   64, 1);
-        CASE(kIROp_UInt64Type,  64, 0);
-
-#undef CASE
+        case kIROp_UInt8Type:
+        case kIROp_UInt16Type:
+        case kIROp_UIntType:
+        case kIROp_UInt64Type:
+        case kIROp_Int8Type:
+        case kIROp_Int16Type:
+        case kIROp_IntType:
+        case kIROp_Int64Type:
+            {
+                const IntInfo i = getIntTypeInfo(as<IRType>(inst));
+                return emitTypeInst(
+                    inst,
+                    SpvOpTypeInt,
+                    makeArray(static_cast<SpvWord>(i.width), SpvWord{i.isSigned}).getView());
+            }
 
         // > OpTypeFloat
 
-#define CASE(IROP, BITS) \
-        case IROP:                                                                \
-        return emitTypeInst(                                                      \
-            inst, SpvOpTypeFloat, makeArray<SpvWord>(BITS).getView()); \
+        case kIROp_HalfType:
+        case kIROp_FloatType:
+        case kIROp_DoubleType:
+            {
+                const FloatInfo i = getFloatingTypeInfo(as<IRType>(inst));
+                return emitTypeInst(inst, SpvOpTypeFloat, makeArray(static_cast<SpvWord>(i.width)).getView());
+            }
 
-        CASE(kIROp_HalfType,    16);
-        CASE(kIROp_FloatType,   32);
-        CASE(kIROp_DoubleType,  64);
-
-#undef CASE
         case kIROp_PtrType:
         case kIROp_RefType:
         case kIROp_OutType:

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -2673,6 +2673,25 @@ struct IRGetRegisterSpace : IRBindingQuery
     IR_LEAF_ISA(GetRegisterSpace);
 };
 
+struct IRIntCast : IRInst
+{
+    IR_LEAF_ISA(IntCast)
+};
+
+struct IRFloatCast : IRInst
+{
+    IR_LEAF_ISA(FloatCast)
+};
+
+struct IRCastIntToFloat : IRInst
+{
+    IR_LEAF_ISA(CastIntToFloat)
+};
+
+struct IRCastFloatToInt : IRInst
+{
+    IR_LEAF_ISA(CastFloatToInt)
+};
 
 struct IRBuilderSourceLocRAII;
 

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -6690,6 +6690,55 @@ namespace Slang
         return false;
     }
 
+    bool isFloatingType(IRType *t)
+    {
+        if(auto basic = as<IRBasicType>(t))
+        {
+            switch(basic->getBaseType())
+            {
+            case BaseType::Float:
+            case BaseType::Half:
+            case BaseType::Double:
+                return true;
+            default:
+                return false;
+            }
+        }
+        return false;
+    }
+
+    IntInfo getIntTypeInfo(const IRType* intType)
+    {
+        switch(intType->getOp())
+        {
+            case kIROp_UInt8Type: return {8, false};
+            case kIROp_UInt16Type: return {16, false};
+            case kIROp_UIntType: return {32, false};
+            case kIROp_UInt64Type: return {64, false};
+            case kIROp_Int8Type: return {8, true};
+            case kIROp_Int16Type: return {16, true};
+            case kIROp_IntType: return {32, true};
+            case kIROp_Int64Type: return {64, true};
+
+            case kIROp_IntPtrType: // target platform dependent
+            case kIROp_UIntPtrType: // target platform dependent
+            default:
+                SLANG_UNEXPECTED("Unhandled type passed to getIntTypeInfo");
+        }
+    }
+
+    FloatInfo getFloatingTypeInfo(const IRType* floatType)
+    {
+        switch(floatType->getOp())
+        {
+            case kIROp_HalfType: return {16};
+            case kIROp_FloatType: return {32};
+            case kIROp_DoubleType: return {64};
+            default:
+                SLANG_UNEXPECTED("Unhandled type passed to getFloatTypeInfo");
+        }
+    }
+
     bool isIntegralScalarOrCompositeType(IRType* t)
     {
         if (!t)

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1005,6 +1005,25 @@ bool isTypeEqual(IRType* a, IRType* b);
 // True if this is an integral IRBasicType, not including Char or Ptr types
 bool isIntegralType(IRType* t);
 
+bool isFloatingType(IRType* t);
+
+struct IntInfo
+{
+    Int width;
+    bool isSigned;
+    bool operator==(const IntInfo& i) const { return width == i.width && isSigned == i.isSigned; }
+};
+
+IntInfo getIntTypeInfo(const IRType* intType);
+
+struct FloatInfo
+{
+    Int width;
+    bool operator==(const FloatInfo& i) const { return width == i.width; }
+};
+
+FloatInfo getFloatingTypeInfo(const IRType* floatType);
+
 bool isIntegralScalarOrCompositeType(IRType* t);
 
 void findAllInstsBreadthFirst(IRInst* inst, List<IRInst*>& outInsts);


### PR DESCRIPTION
SPIR-V doesn't allow vector/sclar arithmetic ops so broadcast first

Also the various float/int casts