### PR TITLE
Validate generated SPIR-V on output

### DIFF
--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -496,6 +496,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClInclude Include="..\..\..\source\slang\slang-serialize-types.h" />
     <ClInclude Include="..\..\..\source\slang\slang-serialize-value-type-info.h" />
     <ClInclude Include="..\..\..\source\slang\slang-serialize.h" />
+    <ClInclude Include="..\..\..\source\slang\slang-spirv-val.h" />
     <ClInclude Include="..\..\..\source\slang\slang-syntax.h" />
     <ClInclude Include="..\..\..\source\slang\slang-type-layout.h" />
     <ClInclude Include="..\..\..\source\slang\slang-type-system-shared.h" />
@@ -698,6 +699,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClCompile Include="..\..\..\source\slang\slang-serialize-source-loc.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-serialize-types.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-serialize.cpp" />
+    <ClCompile Include="..\..\..\source\slang\slang-spirv-val.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-stdlib-api.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-stdlib.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-syntax.cpp" />

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -576,6 +576,9 @@
     <ClInclude Include="..\..\..\source\slang\slang-serialize.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\slang\slang-spirv-val.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-syntax.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -1176,6 +1179,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-serialize.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\source\slang\slang-spirv-val.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-stdlib-api.cpp">

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -722,5 +722,6 @@ DIAGNOSTIC(99999, Internal, internalCompilerError, "Slang internal compiler erro
 DIAGNOSTIC(99999, Error, compilationAborted, "Slang compilation aborted due to internal error")
 DIAGNOSTIC(99999, Error, compilationAbortedDueToException, "Slang compilation aborted due to an exception of $0: $1")
 DIAGNOSTIC(99999, Internal, serialDebugVerificationFailed, "Verification of serial debug information failed.")
+DIAGNOSTIC(99999, Internal, spirvValidationFailed, "Validation of generated SPIR-V failed.")
 
 #undef DIAGNOSTIC

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -8,6 +8,7 @@
 #include "slang-ir-layout.h"
 #include "slang-ir-spirv-snippet.h"
 #include "slang-ir-spirv-legalize.h"
+#include "slang-spirv-val.h"
 #include "spirv/unified1/spirv.h"
 #include "../core/slang-memory-arena.h"
 
@@ -2930,6 +2931,16 @@ SlangResult emitSPIRVFromIR(
     spirvOut.addRange(
         (uint8_t const*) context.m_words.getBuffer(),
         context.m_words.getCount() * sizeof(context.m_words[0]));
+
+    const auto validationResult = debugValidateSPIRV(spirvOut);
+    if(SLANG_FAILED(validationResult))
+    {
+        codeGenContext->getSink()->diagnoseWithoutSourceView(
+            SourceLoc{},
+            Diagnostics::spirvValidationFailed
+        );
+        return validationResult;
+    }
 
     return SLANG_OK;
 }

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -2933,7 +2933,9 @@ SlangResult emitSPIRVFromIR(
         context.m_words.getCount() * sizeof(context.m_words[0]));
 
     const auto validationResult = debugValidateSPIRV(spirvOut);
-    if(SLANG_FAILED(validationResult))
+    // If validation isn't available, don't say it failed, it's just a debug
+    // feature so we can skip
+    if(SLANG_FAILED(validationResult) && validationResult != SLANG_E_NOT_AVAILABLE)
     {
         codeGenContext->getSink()->diagnoseWithoutSourceView(
             SourceLoc{},

--- a/source/slang/slang-spirv-val.cpp
+++ b/source/slang/slang-spirv-val.cpp
@@ -1,0 +1,37 @@
+#include "slang-spirv-val.h"
+
+namespace Slang
+{
+
+SlangResult debugValidateSPIRV(const List<uint8_t>& spirv)
+{
+    // Set up our process
+    CommandLine commandLine;
+    commandLine.m_executableLocation.setName("spirv-val");
+    RefPtr<Process> p;
+    SLANG_RETURN_ON_FAIL(Process::create(commandLine, 0, p));
+    const auto in = p->getStream(StdStreamType::In);
+    const auto out = p->getStream(StdStreamType::Out);
+    const auto err = p->getStream(StdStreamType::ErrorOut);
+
+    // Write the assembly
+    SLANG_RETURN_ON_FAIL(in->write(spirv.getBuffer(), spirv.getCount()));
+    in->close();
+
+    // Wait for it to finish
+    if(!p->waitForTermination(1000))
+        return SLANG_FAIL;
+
+    // TODO: allow inheriting stderr in Process
+    List<Byte> outData;
+    SLANG_RETURN_ON_FAIL(StreamUtil::readAll(out, 0, outData));
+    fwrite(outData.getBuffer(), outData.getCount(), 1, stderr);
+    outData.clear();
+    SLANG_RETURN_ON_FAIL(StreamUtil::readAll(err, 0, outData));
+    fwrite(outData.getBuffer(), outData.getCount(), 1, stderr);
+
+    const auto ret = p->getReturnValue();
+    return ret == 0 ? SLANG_OK : SLANG_FAIL;
+}
+
+}

--- a/source/slang/slang-spirv-val.cpp
+++ b/source/slang/slang-spirv-val.cpp
@@ -9,7 +9,10 @@ SlangResult debugValidateSPIRV(const List<uint8_t>& spirv)
     CommandLine commandLine;
     commandLine.m_executableLocation.setName("spirv-val");
     RefPtr<Process> p;
-    SLANG_RETURN_ON_FAIL(Process::create(commandLine, 0, p));
+    const auto createResult = Process::create(commandLine, 0, p);
+    // If we failed to even start the process, then validation isn't available
+    if(SLANG_FAILED(createResult))
+        return SLANG_E_NOT_AVAILABLE;
     const auto in = p->getStream(StdStreamType::In);
     const auto out = p->getStream(StdStreamType::Out);
     const auto err = p->getStream(StdStreamType::ErrorOut);

--- a/source/slang/slang-spirv-val.h
+++ b/source/slang/slang-spirv-val.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstdint>
+#include "slang-compiler.h"
+
+namespace Slang
+{
+SlangResult debugValidateSPIRV(const List<uint8_t>& spirv);
+}
+


### PR DESCRIPTION
This probably won't stay in this form forever (or could at least go behind a
flag), however it's very useful in development