### PR TITLE
Allow parsing some SPIR-V enums in intrinsics

### DIFF
--- a/source/core/slang-token-reader.h
+++ b/source/core/slang-token-reader.h
@@ -262,6 +262,15 @@ namespace Misc {
             }
             return false;
         }
+        bool AdvanceIf(TokenType token)
+        {
+            if( LookAhead(token) )
+            {
+                ReadToken();
+                return true;
+            }
+            return false;
+        }
         bool IsEnd()
         {
             return tokenPtr == (int)tokens.getCount();

--- a/source/slang/slang-ir-spirv-snippet.cpp
+++ b/source/slang/slang-ir-spirv-snippet.cpp
@@ -37,6 +37,10 @@ SpvSnippet::ASMType parseASMType(Slang::Misc::TokenReader& tokenReader)
     return SpvSnippet::ASMType::None;
 }
 
+// Read an unsigned integer (a SPIR-V word) or a SPIR-V enum (currently those
+// which are coded into this function).
+//
+// This also 'or's together a list of these words/enums separated by '|'
 SpvWord readWordOrWordLiteral(Misc::TokenReader& reader)
 {
     SpvWord ret = 0;


### PR DESCRIPTION
To reduce the number of magic numbers floating around.

Also parses mask sums

Eventually we should replace this with a lookup table with every enum value in