### PR TITLE
Various fixes in GLSL emit.

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -2366,6 +2366,10 @@ __target_intrinsic(glsl, "$atomicAdd($A, $1)")
 __target_intrinsic(cuda, "atomicAdd((uint*)$0, $1)")
 void InterlockedAdd(__ref uint dest, uint value);
 
+__target_intrinsic(glsl, "$atomicAdd($A, $1)")
+__target_intrinsic(cuda, "atomicAdd((uint*)$0, $1)")
+void InterlockedAdd(__ref uint dest, int value);
+
 __target_intrinsic(glsl, "($2 = $atomicAdd($A, $1))")
 __target_intrinsic(cuda, "(*$2 = atomicAdd($0, $1))")
 void InterlockedAdd(__ref  int dest,  int value, out  int original_value);
@@ -2389,10 +2393,6 @@ void InterlockedAnd(__ref  int dest,  int value, out  int original_value);
 __target_intrinsic(glsl, "($2 = $atomicAnd($A, $1))")
 __target_intrinsic(cuda, "(*$2 = atomicAnd((int*)$0, $1))")
 void InterlockedAnd(__ref uint dest, uint value, out uint original_value);
-
-__target_intrinsic(glsl, "$atomicAnd($A, $1)")
-__target_intrinsic(cuda, "atomicAnd((int*)$0, $1)")
-void InterlockedAnd(__ref uint dest, int value);
 
 __target_intrinsic(glsl, "($3 = $atomicCompSwap($A, $1, $2))")
 __target_intrinsic(cuda, "(*$3 = atomicCAS($0, $1, $2))")

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -2390,6 +2390,10 @@ __target_intrinsic(glsl, "($2 = $atomicAnd($A, $1))")
 __target_intrinsic(cuda, "(*$2 = atomicAnd((int*)$0, $1))")
 void InterlockedAnd(__ref uint dest, uint value, out uint original_value);
 
+__target_intrinsic(glsl, "$atomicAnd($A, $1)")
+__target_intrinsic(cuda, "atomicAnd((int*)$0, $1)")
+void InterlockedAnd(__ref uint dest, int value);
+
 __target_intrinsic(glsl, "($3 = $atomicCompSwap($A, $1, $2))")
 __target_intrinsic(cuda, "(*$3 = atomicCAS($0, $1, $2))")
 void InterlockedCompareExchange(__ref  int dest,  int compare_value,  int value, out  int original_value);

--- a/source/slang/slang-mangle.cpp
+++ b/source/slang/slang-mangle.cpp
@@ -251,6 +251,15 @@ namespace Slang
             for(Index i = 0; i < n; ++i)
                 emitType(context, tupleType->getMember(i));
         }
+        else if (auto modifiedType = dynamicCast<ModifiedType>(type))
+        {
+            emitRaw(context, "Tm");
+            emitType(context, modifiedType->getBase());
+            auto n = modifiedType->getModifierCount();
+            emit(context, n);
+            for (Index i = 0; i < n; ++i)
+                emitVal(context, modifiedType->getModifier(i));
+        }
         else
         {
             SLANG_UNEXPECTED("unimplemented case in type mangling");
@@ -335,6 +344,10 @@ namespace Slang
             emitRaw(context, "KK");
             emitVal(context, typecastIntVal->getType());
             emitVal(context, typecastIntVal->getBase());
+        }
+        else if (auto modifier = as<ModifierVal>(val))
+        {
+            emitNameImpl(context, UnownedStringSlice(modifier->getClassInfo().m_name));
         }
         else
         {

--- a/tests/bugs/buffer-swizzle-store.slang
+++ b/tests/bugs/buffer-swizzle-store.slang
@@ -1,0 +1,16 @@
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -output-using-type
+
+//TEST_INPUT: RWTexture2D(format=R16G16_FLOAT, size=4, content = one, mipMaps = 1):name g_test
+[format("rg16f")]
+RWTexture2D<float2> g_test;
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1,1,1)]
+void computeMain( uint2 dispatchThreadID : SV_DispatchThreadID )
+{
+    g_test[dispatchThreadID].xy = float2(0.0, 1.0);
+    outputBuffer[dispatchThreadID.x] = g_test[dispatchThreadID].y;
+}

--- a/tests/bugs/buffer-swizzle-store.slang.expected.txt
+++ b/tests/bugs/buffer-swizzle-store.slang.expected.txt
@@ -1,0 +1,2 @@
+type: float
+1.0

--- a/tests/bugs/interlocked-add-uint-int.slang
+++ b/tests/bugs/interlocked-add-uint-int.slang
@@ -1,0 +1,19 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -profile glsl_450 -stage compute -entry MainCs -line-directive-mode none
+//CHECK: {{.*}} AtomicIAdd
+RWBuffer<uint> g_InterlockTest;
+
+[numthreads(1,1,1)]
+void MainCs( uint2 dispatchThreadID : SV_DispatchThreadID, uint2 groupThreadID : SV_GroupThreadID )
+{
+	uint nVertexCount = 41;
+	uint nVertexBufferSize = 40;
+	uint nVertex = 3;
+
+	InterlockedAdd( g_InterlockTest[ 0 ], nVertexCount, nVertex );
+
+	// Did we overflow?
+	if ( nVertex + nVertexCount > nVertexBufferSize )
+	{
+		InterlockedAdd( g_InterlockTest[ 0 ], -int(nVertexCount) );
+	}
+}


### PR DESCRIPTION
Fixes #3071 
Fixes #3072 
Fixes #3073 

- Add `InterlockedAdd(__ref uint, int)` overload.
- Fix legalization of GLSL image store where an imageLoad should always return a 4-component vector.
- Add name mangling for modified types.