### PR TITLE
Add support for ConstBufferPointer on Vulkan.

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -7775,3 +7775,18 @@ ${{{{
 ${{{{
 }
 }}}}
+
+// Buffer Pointer
+
+__generic<T, let Alignment : int = 16>
+__intrinsic_type($(kIROp_HLSLConstBufferPointerType))
+__glsl_extension(GL_EXT_buffer_reference)
+__magic_type(ConstBufferPointerType)
+struct ConstBufferPointer
+{
+    __glsl_version(450)
+    __glsl_extension(GL_EXT_buffer_reference)
+    __target_intrinsic(glsl, "$0._data")
+    [__NoSideEffect]
+    T get();
+}

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -519,6 +519,12 @@ class PtrType : public PtrTypeBase
     SLANG_AST_CLASS(PtrType)
 };
 
+// A GPU pointer type that for general readonly memory access.
+class ConstBufferPointerType : public PtrTypeBase
+{
+    SLANG_AST_CLASS(ConstBufferPointerType)
+};
+
 /// A pointer-like type used to represent a parameter "direction"
 class ParamDirectionType : public PtrTypeBase
 {

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -966,6 +966,19 @@ String CLikeSourceEmitter::generateName(IRInst* inst)
         return linkageDecoration->getMangledName();
     }
 
+    switch (inst->getOp())
+    {
+    case kIROp_HLSLConstBufferPointerType:
+        {
+            StringBuilder sb;
+            sb << "BufferPointer_";
+            sb << getName(inst->getOperand(0));
+            sb << "_" << Int32(getID(inst));
+            return sb.produceString();
+        }
+    default:
+        break;
+    }
     // Otherwise fall back to a construct temporary name
     // for the instruction.
     StringBuilder sb;
@@ -3743,7 +3756,6 @@ void CLikeSourceEmitter::emitGlobalInstImpl(IRInst* inst)
     case kIROp_InterfaceType:
         emitInterface(cast<IRInterfaceType>(inst));
         break;
-
     case kIROp_WitnessTable:
         emitWitnessTable(cast<IRWitnessTable>(inst));
         break;

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -1619,6 +1619,8 @@ bool GLSLSourceEmitter::_tryEmitBitBinOp(IRInst* inst, const EmitOpInfo& bitOp, 
 
 void GLSLSourceEmitter::emitBufferPointerTypeDefinition(IRInst* ptrType)
 {
+    _requireGLSLExtension(UnownedStringSlice("GL_EXT_buffer_reference"));
+
     auto constPtrType = as<IRHLSLConstBufferPointerType>(ptrType);
     auto ptrTypeName = getName(ptrType);
     auto alignment = getIntVal(constPtrType->getAlignment());

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -1623,7 +1623,7 @@ void GLSLSourceEmitter::emitBufferPointerTypeDefinition(IRInst* ptrType)
 
     auto constPtrType = as<IRHLSLConstBufferPointerType>(ptrType);
     auto ptrTypeName = getName(ptrType);
-    auto alignment = getIntVal(constPtrType->getAlignment());
+    auto alignment = getIntVal(constPtrType->getBaseAlignment());
     m_writer->emit("layout(buffer_reference, std430, buffer_reference_align = ");
     m_writer->emitInt64(alignment);
     m_writer->emit(") readonly buffer ");
@@ -1631,7 +1631,7 @@ void GLSLSourceEmitter::emitBufferPointerTypeDefinition(IRInst* ptrType)
     m_writer->emit("\n");
     m_writer->emit("{\n");
     m_writer->indent();
-    emitType((IRType*)constPtrType->getElementType(), "_data");
+    emitType((IRType*)constPtrType->getValueType(), "_data");
     m_writer->emit(";\n");
     m_writer->dedent();
     m_writer->emit("};\n");

--- a/source/slang/slang-emit-glsl.h
+++ b/source/slang/slang-emit-glsl.h
@@ -48,6 +48,8 @@ protected:
 
     virtual bool tryEmitGlobalParamImpl(IRGlobalParam* varDecl, IRType* varType) SLANG_OVERRIDE;
     virtual bool tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;
+    virtual void emitGlobalInstImpl(IRInst* inst) override;
+    void emitBufferPointerTypeDefinition(IRInst* ptrType);
 
     virtual void emitSimpleValueImpl(IRInst* inst) SLANG_OVERRIDE;
     virtual void emitLoopControlDecorationImpl(IRLoopControlDecoration* decl) SLANG_OVERRIDE;

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -119,6 +119,7 @@ INST(Nop, nop, 0, 0)
             INST(OutType, Out, 1, HOISTABLE)
             INST(InOutType, InOut, 1, HOISTABLE)
         INST_RANGE(OutTypeBase, OutType, InOutType)
+        INST(HLSLConstBufferPointerType, ConstBufferPointerType, 2, HOISTABLE)
     INST_RANGE(PtrTypeBase, PtrType, InOutType)
 
     // A ComPtr<T> type is treated as a opaque type that represents a reference-counted handle to a COM object.

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1641,6 +1641,13 @@ struct IRRTTIPointerType : IRRawPointerTypeBase
     IR_LEAF_ISA(RTTIPointerType)
 };
 
+struct IRHLSLConstBufferPointerType : IRPtrTypeBase
+{
+    IR_LEAF_ISA(HLSLConstBufferPointerType)
+    IRInst* getElementType() { return getOperand(0); }
+    IRInst* getAlignment() { return getOperand(1); }
+};
+
 struct IRGlobalHashedStringLiterals : IRInst
 {
     IR_LEAF_ISA(GlobalHashedStringLiterals)

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1644,8 +1644,7 @@ struct IRRTTIPointerType : IRRawPointerTypeBase
 struct IRHLSLConstBufferPointerType : IRPtrTypeBase
 {
     IR_LEAF_ISA(HLSLConstBufferPointerType)
-    IRInst* getElementType() { return getOperand(0); }
-    IRInst* getAlignment() { return getOperand(1); }
+    IRInst* getBaseAlignment() { return getOperand(1); }
 };
 
 struct IRGlobalHashedStringLiterals : IRInst

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -3928,7 +3928,7 @@ static TypeLayoutResult _createTypeLayout(
     {
         return createArrayLikeTypeLayout(context, arrayType, arrayType->getElementType(), arrayType->getElementCount());
     }
-    else if (auto ptrType = as<PtrType>(type))
+    else if (auto ptrType = as<PtrTypeBase>(type))
     {
         RefPtr<PointerTypeLayout> ptrLayout = new PointerTypeLayout();
 

--- a/tests/hlsl-intrinsic/const-buffer-pointer.slang
+++ b/tests/hlsl-intrinsic/const-buffer-pointer.slang
@@ -1,0 +1,36 @@
+//TEST:SIMPLE(filecheck=CHECK):-target glsl -profile glsl_450 -entry main -stage compute
+
+struct MyStruct
+{
+    float4 position;
+    float4x4 transform;
+}
+
+// CHECK: layout(buffer_reference, std430, buffer_reference_align = 16) readonly buffer BufferPointer_MyStruct
+// CHECK-NEXT: {
+// CHECK-NEXT: MyStruct{{.*}} _data;
+// CHECK-NEXT: }
+
+// CHECK: struct Globals
+// CHECK-NEXT: {
+// CHECK-NEXT: BufferPointer_MyStruct{{.*}} pStruct
+// CHECK-NEXT: }
+
+// CHECK: void main
+// CHECK: MyStruct{{.*}} s{{.*}} = ((gGlobals{{.*}}.pStruct{{.*}})._data);
+
+struct Globals
+{
+    ConstBufferPointer<MyStruct> pStruct;
+}
+
+ConstantBuffer<Globals> gGlobals;
+
+RWStructuredBuffer<uint> outputBuffer;
+
+[numthreads(1,1,1)]
+void main(int3 tid: SV_DispatchThreadID)
+{
+    MyStruct s = gGlobals.pStruct.get();
+    outputBuffer[tid.x] = uint(s.position.x);
+}

--- a/tests/hlsl-intrinsic/const-buffer-pointer.slang
+++ b/tests/hlsl-intrinsic/const-buffer-pointer.slang
@@ -1,4 +1,7 @@
 //TEST:SIMPLE(filecheck=CHECK):-target glsl -profile glsl_450 -entry main -stage compute
+//TEST:SIMPLE(filecheck=SPV):-target spirv -profile glsl_450 -entry main -stage compute
+
+// SPV: EntryPoint GLCompute {{.*}} "main" {{.*}}
 
 struct MyStruct
 {


### PR DESCRIPTION
This change adds a `ConstBufferPointer` type that maps to a `buffer_reference` on Vulkan.

Usage:
```
struct MyStruct
{
    float4 position;
    float4x4 transform;
}

struct Globals
{
    ConstBufferPointer<MyStruct> pStruct;
}

ConstantBuffer<Globals> gGlobals;

RWStructuredBuffer<uint> outputBuffer;

[numthreads(1,1,1)]
void main(int3 tid: SV_DispatchThreadID)
{
    MyStruct s = gGlobals.pStruct.get();
    outputBuffer[tid.x] = uint(s.position.x);
}
```