### PR TITLE
Fix `Texture2D.Load()` with offset.

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1641,7 +1641,9 @@ struct TextureTypeInfo
             }
             sb << ");\n";
 
+
             // GLSL
+            glslFuncName = (access == SLANG_RESOURCE_ACCESS_READ) ? "texelFetchOffset" : "imageLoad";
             if (isMultisample)
             {
                 sb << "__glsl_extension(GL_EXT_samplerless_texture_functions)";
@@ -1654,12 +1656,12 @@ struct TextureTypeInfo
                 if( needsMipLevel )
                 {
                     sb << "($1)." << kGLSLLoadCoordsSwizzle[loadCoordCount] << ", ($1)." << kGLSLLoadLODSwizzle[loadCoordCount];
+                    sb << ", $2)$z\")\n";
                 }
                 else
                 {
-                    sb << "$1, 0";
+                    sb << "$1, 0, $2)$z\")\n";
                 }
-                sb << ", $2)$z\")\n";
             }
 
             if (isReadOnly)

--- a/tests/bugs/gh-3085.slang
+++ b/tests/bugs/gh-3085.slang
@@ -1,0 +1,29 @@
+//TEST:SIMPLE(filecheck=CHECK): -entry MainCs -stage compute -profile glsl_450 -target spirv
+//CHECK: EntryPoint
+
+RWTexture2D<float4> g_Test;
+
+Texture2D<float4> g_inoutColorReadonly;
+
+[ForceInline] float3 LoadSourceColor(uint2 pixelPos, constexpr int2 offset, int sampleIndex)
+{
+    float3 color = g_inoutColorReadonly.Load(int3(pixelPos, 0), offset).rgb;
+
+    return color;
+}
+
+[numthreads(16, 16, 1)]
+void MainCs(uint3 groupID: SV_GroupID, uint3 groupThreadID: SV_GroupThreadID)
+{
+
+    uint2 pixelPos = groupID.xy * int2((16 - 2), (16 - 2)) + groupThreadID.xy - int2(1, 1);
+    float3 color = LoadSourceColor(pixelPos, int2(0, 0), 0).rgb;
+
+    // Note this also doesn't work
+    //[unroll]
+    // for ( int i = 0; i < 3; i++ )
+    //{
+    // color+= LoadSourceColor ( pixelPos , int2 ( i%3 , i/3 ) , msaaSampleIndex ) . rgb ;
+    //}
+    g_Test[int2(pixelPos.x / 2, pixelPos.y + 0)] = float4(color, 1.0);
+} 

--- a/tests/bugs/texture-array-samplecmplevelzero.slang
+++ b/tests/bugs/texture-array-samplecmplevelzero.slang
@@ -1,0 +1,23 @@
+//TEST_DISABLED:SIMPLE(filecheck=CHECK): -entry MainPs -stage fragment -profile glsl_450 -target spirv
+//CHECK: EntryPoint
+
+SamplerComparisonState g_tSFMShadowDepthTexture_sampler; 
+Texture2DArray g_tSFMShadowDepthTexture; 
+
+struct PS_INPUT
+{
+  float3 vTexCoord : TEXCOORD0;
+};
+
+struct PS_OUTPUT
+{
+  float4 vColor : SV_Target0;
+};
+
+PS_OUTPUT MainPs ( PS_INPUT i ) 
+{ 
+  PS_OUTPUT o;
+  float flDepth = 0.5;
+  o.vColor = g_tSFMShadowDepthTexture.SampleCmpLevelZero ( g_tSFMShadowDepthTexture_sampler, i.vTexCoord.xyz, flDepth ).rrrr;
+  return o;
+} 


### PR DESCRIPTION
Fixes #3085.