### PR TITLE
SPIRV: debug source and debug line.

### DIFF
--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -344,6 +344,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClInclude Include="..\..\..\source\slang\slang-emit-hlsl.h" />
     <ClInclude Include="..\..\..\source\slang\slang-emit-precedence.h" />
     <ClInclude Include="..\..\..\source\slang\slang-emit-source-writer.h" />
+    <ClInclude Include="..\..\..\source\slang\slang-emit-spirv-ops-debug-info-ext.h" />
     <ClInclude Include="..\..\..\source\slang\slang-emit-spirv-ops.h" />
     <ClInclude Include="..\..\..\source\slang\slang-emit-torch.h" />
     <ClInclude Include="..\..\..\source\slang\slang-glsl-extension-tracker.h" />

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -120,6 +120,9 @@
     <ClInclude Include="..\..\..\source\slang\slang-emit-source-writer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\slang\slang-emit-spirv-ops-debug-info-ext.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-emit-spirv-ops.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -2506,7 +2506,6 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
         }
         break;
     }
-
     default:
         diagnoseUnhandledInst(inst);
         break;
@@ -2554,6 +2553,10 @@ void CLikeSourceEmitter::_emitInst(IRInst* inst)
         emitInstResultDecl(inst);
         emitInstExpr(inst, getInfo(EmitOp::General));
         m_writer->emit(";\n");
+        break;
+
+    case kIROp_DebugSource:
+    case kIROp_DebugLine:
         break;
 
         // Insts that needs to be emitted as code blocks.

--- a/source/slang/slang-emit-spirv-ops-debug-info-ext.h
+++ b/source/slang/slang-emit-spirv-ops-debug-info-ext.h
@@ -1,0 +1,28 @@
+#ifdef SLANG_IN_SPIRV_EMIT_CONTEXT
+
+// https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc#DebugCompilationUnit
+template<typename T>
+SpvInst* emitOpDebugCompilationUnit(SpvInstParent* parent, IRInst* inst, const T& idResultType, SpvInst* set, SpvInst* version, SpvInst* dwarfVersion, SpvInst* source, SpvInst* language)
+{
+    static_assert(isSingular<T>);
+    return emitInst(parent, inst, SpvOpExtInst, idResultType, kResultID, set, SpvWord(1), version, dwarfVersion, source, language);
+}
+
+// https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc#DebugSource
+template<typename T>
+SpvInst* emitOpDebugSource(SpvInstParent* parent, IRInst* inst, const T& idResultType, SpvInst* set, IRInst* file, IRInst* text)
+{
+    static_assert(isSingular<T>);
+    return emitInst(parent, inst, SpvOpExtInst, idResultType, kResultID, set, SpvWord(35), file, text);
+}
+
+// https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc#DebugLine
+template<typename T>
+SpvInst* emitOpDebugLine(SpvInstParent* parent, IRInst* inst, const T& idResultType, SpvInst* set, IRInst* source, IRInst* lineStart, IRInst* lineEnd, IRInst* colStart, IRInst* colEnd)
+{
+    static_assert(isSingular<T>);
+    return emitInst(parent, inst, SpvOpExtInst, idResultType, kResultID, set, SpvWord(103), source, lineStart, lineEnd, colStart, colEnd);
+}
+
+
+#endif        // SLANG_IN_SPIRV_EMIT_CONTEXT

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -547,7 +547,7 @@ struct SPIRVEmitContext
         for (auto parent = inst; parent; parent = parent->getParent())
         {
             SpvInst* spvInst = nullptr;
-            if (m_mapIRInstToSpvDebugInst.tryGetValue(inst, spvInst))
+            if (m_mapIRInstToSpvDebugInst.tryGetValue(parent, spvInst))
                 return spvInst;
         }
         return nullptr;

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -1042,7 +1042,7 @@ INST(ExistentialTypeSpecializationDictionary, ExistentialTypeSpecializationDicti
 INST(DifferentiableTypeDictionaryItem, DifferentiableTypeDictionaryItem, 0, 0)
 
 /* DebugInfo */
-INST(DebugSource, DebugSource, 2, 0)
+INST(DebugSource, DebugSource, 2, HOISTABLE)
 INST(DebugLine, DebugLine, 5, 0)
 
 #undef PARENT

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -1041,6 +1041,10 @@ INST(ExistentialTypeSpecializationDictionary, ExistentialTypeSpecializationDicti
 /* Differentiable Type Dictionary */
 INST(DifferentiableTypeDictionaryItem, DifferentiableTypeDictionaryItem, 0, 0)
 
+/* DebugInfo */
+INST(DebugSource, DebugSource, 2, 0)
+INST(DebugLine, DebugLine, 5, 0)
+
 #undef PARENT
 #undef USE_OTHER
 #undef INST_RANGE

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -2864,7 +2864,7 @@ struct IRDebugSource : IRInst
 
 struct IRDebugLine : IRInst
 {
-    IR_LEAF_ISA(DebugSource)
+    IR_LEAF_ISA(DebugLine)
     IRInst* getSource() { return getOperand(0); }
     IRInst* getLineStart() { return getOperand(1); }
     IRInst* getLineEnd() { return getOperand(2); }

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -2855,6 +2855,24 @@ struct IRCastFloatToInt : IRInst
     IR_LEAF_ISA(CastFloatToInt)
 };
 
+struct IRDebugSource : IRInst
+{
+    IR_LEAF_ISA(DebugSource)
+    IRInst* getFileName() { return getOperand(0); }
+    IRInst* getSource() { return getOperand(1); }
+};
+
+struct IRDebugLine : IRInst
+{
+    IR_LEAF_ISA(DebugSource)
+    IRInst* getSource() { return getOperand(0); }
+    IRInst* getLineStart() { return getOperand(1); }
+    IRInst* getLineEnd() { return getOperand(2); }
+    IRInst* getColStart() { return getOperand(3); }
+    IRInst* getColEnd() { return getOperand(4); }
+};
+
+
 struct IRBuilderSourceLocRAII;
 
 struct IRBuilder
@@ -3183,6 +3201,9 @@ public:
     {
         return getAttributedType(baseType, attributes.getCount(), attributes.getBuffer());
     }
+
+    IRInst* emitDebugSource(UnownedStringSlice fileName, UnownedStringSlice source);
+    IRInst* emitDebugLine(IRInst* source, IRIntegerValue lineStart, IRIntegerValue lineEnd, IRIntegerValue colStart, IRIntegerValue colEnd);
 
         /// Emit an LiveRangeStart instruction indicating the referenced item is live following this instruction
     IRLiveRangeStart* emitLiveRangeStart(IRInst* referenced);

--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -1417,7 +1417,8 @@ static bool _isPublicOrHLSLExported(IRInst* inst)
     {
         const auto op = decoration->getOp();
         if (op == kIROp_PublicDecoration ||
-            op == kIROp_HLSLExportDecoration)
+            op == kIROp_HLSLExportDecoration ||
+            op == kIROp_DebugSource)
         {
             return true;
         }

--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -1417,8 +1417,7 @@ static bool _isPublicOrHLSLExported(IRInst* inst)
     {
         const auto op = decoration->getOp();
         if (op == kIROp_PublicDecoration ||
-            op == kIROp_HLSLExportDecoration ||
-            op == kIROp_DebugSource)
+            op == kIROp_HLSLExportDecoration)
         {
             return true;
         }

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3123,6 +3123,23 @@ namespace Slang
     {
         return emitIntrinsicInst((IRType*)type, kIROp_OutImplicitCast, 1, &value);
     }
+    IRInst* IRBuilder::emitDebugSource(UnownedStringSlice fileName, UnownedStringSlice source)
+    {
+        IRInst* args[] = { getStringValue(fileName), getStringValue(source) };
+        return emitIntrinsicInst(getVoidType(), kIROp_DebugSource, 2, args);
+    }
+    IRInst* IRBuilder::emitDebugLine(IRInst* source, IRIntegerValue lineStart, IRIntegerValue lineEnd, IRIntegerValue colStart, IRIntegerValue colEnd)
+    {
+        IRInst* args[] = 
+        {
+            source,
+            getIntValue(getIntType(), lineStart),
+            getIntValue(getIntType(), lineEnd),
+            getIntValue(getIntType(), colStart),
+            getIntValue(getIntType(), colEnd)
+        };
+        return emitIntrinsicInst(getVoidType(), kIROp_DebugLine, 5, args);
+    }
     IRLiveRangeStart* IRBuilder::emitLiveRangeStart(IRInst* referenced)
     {
         // This instruction doesn't produce any result, 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -2430,8 +2430,6 @@ void FrontEndCompileRequest::generateIR()
         // * it can generate diagnostics
 
         /// Generate IR for translation unit.
-        /// TODO(JS): Use the linkage ASTBuilder, because it seems possible that cross module constructs are possible in
-        /// ir lowering.
         RefPtr<IRModule> irModule(generateIRForTranslationUnit(getLinkage()->getASTBuilder(), translationUnit));
 
         if (verifyDebugSerialization)

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -170,6 +170,7 @@ void Session::init()
 
     // Built in linkage uses the built in builder
     m_builtinLinkage = new Linkage(this, builtinAstBuilder, nullptr);
+    m_builtinLinkage->debugInfoLevel = DebugInfoLevel::None;
 
     // Because the `Session` retains the builtin `Linkage`,
     // we need to make sure that the parent pointer inside

--- a/tests/bugs/spirv-debug-info.slang
+++ b/tests/bugs/spirv-debug-info.slang
@@ -1,15 +1,14 @@
 //TEST:SIMPLE(filecheck=CHECK):-target spirv -entry MainPs -stage fragment -profile glsl_450 -g3 -line-directive-mode none
-//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry MainPs -stage fragment -profile glsl_450 -g3 -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK-SPIRV):-target spirv -entry MainPs -stage fragment -profile glsl_450 -g3 -emit-spirv-directly
 
 // make sure that the generated spirv has glsl source in it.
-//CHECK: #version 450
+// CHECK: #version 450
 
-/*
-This is to allow spirv-direct test to pass because this source should be
-included in the generated spirv module:
-
-#version 450
-*/
+// CHECK-SPIRV: struct PS_OUTPUT
+// CHECK-SPIRV:  {{.*}} = OpExtInst %void {{.*}} DebugSource
+// CHECK-SPIRV:  {{.*}} = OpExtInst %void {{.*}} DebugCompilationUnit
+// CHECK-SPIRV:  {{.*}} OpFunction
+// CHECK-SPIRV:  {{.*}} = OpExtInst %void {{.*}} DebugLine
 
 struct PS_OUTPUT 
 { 

--- a/tests/bugs/spirv-debug-info.slang
+++ b/tests/bugs/spirv-debug-info.slang
@@ -1,7 +1,16 @@
 //TEST:SIMPLE(filecheck=CHECK):-target spirv -entry MainPs -stage fragment -profile glsl_450 -g3 -line-directive-mode none
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry MainPs -stage fragment -profile glsl_450 -g3 -emit-spirv-directly
 
 // make sure that the generated spirv has glsl source in it.
 //CHECK: #version 450
+
+/*
+This is to allow spirv-direct test to pass because this source should be
+included in the generated spirv module:
+
+#version 450
+*/
+
 struct PS_OUTPUT 
 { 
     float4 vColor : SV_Target0 ; 

--- a/tests/serialization/obfuscated-module-check-loc.slang
+++ b/tests/serialization/obfuscated-module-check-loc.slang
@@ -1,10 +1,11 @@
 //TEST:COMPILE: tests/serialization/obfuscated-loc-module.slang -o tests/serialization/obfuscated-loc-module.zip -g -obfuscate 
-//TEST:SIMPLE:-target hlsl -stage compute -entry computeMain -obfuscate -r tests/serialization/obfuscated-loc-module.zip 
+//TEST:SIMPLE(filecheck=CHECK):-target hlsl -stage compute -entry computeMain -obfuscate -r tests/serialization/obfuscated-loc-module.zip 
 //TEST:COMPILE: tests/serialization/obfuscated-loc-module.slang -o tests/serialization/obfuscated-loc-module.slang-module -g -obfuscate 
-//TEST:SIMPLE:-target hlsl -stage compute -entry computeMain -obfuscate -r tests/serialization/obfuscated-loc-module.slang-module
-
+//TEST:SIMPLE(filecheck=CHECK):-target hlsl -stage compute -entry computeMain -obfuscate -r tests/serialization/obfuscated-loc-module.slang-module
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
+
+// CHECK: {{.*}}: error 40020: loop does not terminate within the limited number of iterations, unrolling is aborted.
 
 // This test checks obfuscated source map loc tracking through a round trip, and producing a location correctly from slang-module that has a source map
 

--- a/tests/serialization/obfuscated-module-check-loc.slang.1.expected
+++ b/tests/serialization/obfuscated-module-check-loc.slang.1.expected
@@ -1,6 +1,0 @@
-result code = -1
-standard error = {
-tests/serialization/obfuscated-loc-module.slang(16): error 40020: loop does not terminate within the limited number of iterations, unrolling is aborted.
-}
-standard output = {
-}

--- a/tests/serialization/obfuscated-module-check-loc.slang.3.expected
+++ b/tests/serialization/obfuscated-module-check-loc.slang.3.expected
@@ -1,6 +1,0 @@
-result code = -1
-standard error = {
-cae4a81b-obfuscated(2): error 40020: loop does not terminate within the limited number of iterations, unrolling is aborted.
-}
-standard output = {
-}


### PR DESCRIPTION
Add logic to emit OpDebugSource, OpDebugCompilationUnit, OpDebug and OpDebugLine in spirv-direct backend.