### PR TITLE
Remove multiple back-edges from loops for SPIR-V

### DIFF
--- a/source/slang/slang-ir-loop-unroll.cpp
+++ b/source/slang/slang-ir-loop-unroll.cpp
@@ -554,11 +554,12 @@ void eliminateContinueBlocks(IRModule* module, IRLoop* loopInst)
     //  where a continue is replaced with a "break" into breakableRegionBreakBlock.
     //
 
-    if (loopInst->getContinueBlock() == loopInst->getTargetBlock())
+    auto continueBlock = loopInst->getContinueBlock();
+
+    if (continueBlock == loopInst->getTargetBlock())
         return;
 
     // If the continue block is not reachable, remove it.
-    auto continueBlock = loopInst->getContinueBlock();
     if (continueBlock && !continueBlock->hasMoreThanOneUse())
     {
         loopInst->continueBlock.set(loopInst->getTargetBlock());

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -3,6 +3,7 @@
 
 #include "slang-ir-glsl-legalize.h"
 
+#include "slang-ir-clone.h"
 #include "slang-ir.h"
 #include "slang-ir-insts.h"
 #include "slang-emit-base.h"
@@ -372,6 +373,107 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         addUsersToWorkList(ptrType);
     }
 
+    void processLoop(IRLoop* loop)
+    {
+
+        // 2.11.1. Rules for Structured Control-flow Declarations
+        // Structured control flow declarations must satisfy the following
+        // rules:
+        //   - the merge block declared by a header block must not be a merge
+        //     block declared by any other header block
+        //   - each header block must strictly structurally dominate its merge
+        //     block
+        //   - all back edges must branch to a loop header, with each loop
+        //     header having exactly one back edge branching to it
+        //   - for a given loop header, its merge block, OpLoopMerge Continue
+        //     Target, and corresponding back-edge block:
+        //       - the Continue Target and merge block must be different blocks
+        //       - the loop header must structurally dominate the Continue
+        //         Target
+        //       - the Continue Target must structurally dominate the back-edge
+        //         block
+        //       - the back-edge block must structurally post dominate the
+        //         Continue Target
+
+        // Our IR allows multiple back-edges to a loop header if this is also
+        // the loop continue block. SPIR-V does not so replace them with a
+        // single intermediate block
+        const auto t = loop->getTargetBlock();
+        const auto c = loop->getContinueBlock();
+        if(c == t)
+        {
+            // Subtract one predecessor for the loop entry
+            const auto numBackEdges = c->getPredecessors().getCount() - 1;
+
+            // If we have multiple back-edges, make a new block at the end of
+            // the loop to be the new continue block which jumps straight to
+            // the loop header.
+            //
+            // If we have a single back-edge, we still may need to perform this
+            // transformation to make sure that the back-edge block
+            // structurally post-dominates the continue target. For example
+            // consider the loop:
+            //
+            // int i = 0;
+            // while(true)
+            //     if(foo()) break;
+            //
+            // If we translate this to
+            // loop target=t break=b, continue=t
+            // t: if foo goto x else goto y
+            // x: goto b -- break
+            // y: goto t
+            // b: ...
+            //
+            // The back edge block, y, does not post-dominate the continue target, t.
+            //
+            // So we transform this to:
+            //
+            // loop target=t break=b, continue=c
+            // t: if foo goto x else goto y
+            // x: goto b -- break
+            // y: goto c
+            // c: goto t
+            // b: ...
+            //
+            // Now the back edge block and the continue target are one and the
+            // same, so the condition trivially holds.
+            //
+            // TODO: We don't need to always perform this, we could replace the
+            // below condition with `numBackEdges > 1 ||
+            //     !postDominates(backJumpingBlock, c)`
+            if(numBackEdges > 0)
+            {
+                IRBuilder builder(m_sharedContext->m_irModule);
+                builder.setInsertInto(loop->getParent());
+                IRCloneEnv cloneEnv;
+                cloneEnv.squashChildrenMapping = true;
+
+                // Insert a new continue block at the end of the loop
+                const auto newContinueBlock = builder.emitBlock();
+                newContinueBlock->insertBefore(loop->getBreakBlock());
+
+                // This block simply branches to the loop header, forwarding
+                // any params
+                List<IRInst*> ps;
+                for(const auto p : c->getParams())
+                {
+                    const auto q = cast<IRParam>(cloneInst(&cloneEnv, &builder, p));
+                    newContinueBlock->addParam(q);
+                    ps.add(q);
+                }
+                // Replace all jumps to our loop header/old continue block
+                c->replaceUsesWith(newContinueBlock);
+
+                // Restore the target block
+                loop->block.set(t);
+
+                // Branch to the target in our new continue block
+                builder.emitBranch(t, ps.getCount(), ps.getBuffer());
+            }
+        }
+    }
+
     void processModule()
     {
         addToWorkList(m_module->getModuleInst());
@@ -414,6 +516,9 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             case kIROp_HLSLStructuredBufferType:
             case kIROp_HLSLRWStructuredBufferType:
                 processStructuredBufferType(as<IRHLSLStructuredBufferTypeBase>(inst));
+                break;
+            case kIROp_loop:
+                processLoop(as<IRLoop>(inst));
                 break;
             default:
                 for (auto child = inst->getLastChild(); child; child = child->getPrevInst())

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -5124,13 +5124,11 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
         // by `continue` or `break` statements.
         auto loopHead = createBlock();
         auto bodyLabel = createBlock();
-        // A `continue` inside a `while` loop jumps to the end of the loop, to
-        // then immediately follow the back edge to the top
-        // While we could jump to the loop head directly, this would mean more
-        // than one back-edge which complicated the SPIR-V backend (TODO: we
-        // should add this check to our IR validate machinery)
-        auto continueLabel = createBlock();
         auto breakLabel = createBlock();
+
+        // A `continue` inside a `while` loop always
+        // jumps to the head of hte loop.
+        auto continueLabel = loopHead;
 
         // Register the `break` and `continue` labels so
         // that we can find them for nested statements.
@@ -5166,9 +5164,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
         // Emit the body of the loop
         insertBlock(bodyLabel);
         lowerStmt(context, stmt->statement);
-        emitBranchIfNeeded(continueLabel);
 
-        insertBlock(continueLabel);
         // At the end of the body we need to jump back to the top.
         emitBranchIfNeeded(loopHead);
 

--- a/tests/cross-compile/geometry-shader.slang.glsl
+++ b/tests/cross-compile/geometry-shader.slang.glsl
@@ -80,12 +80,12 @@ void main()
         int ii_1 = ii_0 + 1;
         if(ii_1 < 3)
         {
-            ii_0 = ii_1;
         }
         else
         {
             break;
         }
+        ii_0 = ii_1;
     }
     return;
 }


### PR DESCRIPTION
Make loop-inversion assign better continue/merge blocks also to help the SPIR-V
backend