### PR TITLE
Remove redundant define form synchapi emulation

### DIFF
--- a/tools/gfx/d3d12/d3d12-posix-synchapi.h
+++ b/tools/gfx/d3d12/d3d12-posix-synchapi.h
@@ -32,7 +32,6 @@
 
 #define WAIT_FAILED 0xffffffff
 #define WAIT_OBJECT_0 0
-#define WAIT_TIMEOUT 258
 
 typedef struct _SECURITY_ATTRIBUTES *LPSECURITY_ATTRIBUTES;
 


### PR DESCRIPTION
This was added to the dxvk header