### PR TITLE
Inline all RayQuery/HitObject typed functions when targeting GLSL.

### DIFF
--- a/source/slang/slang-ir-inline.cpp
+++ b/source/slang/slang-ir-inline.cpp
@@ -861,6 +861,8 @@ struct GLSLResourceReturnFunctionInliningPass : InliningPassBase
             auto outValueType = outType->getValueType();
             if (isResourceType(outValueType))
                 return true;
+            if (isIllegalGLSLParameterType(outValueType))
+                return true;
         }
         return false;
     }

--- a/source/slang/slang-ir-specialize-resources.cpp
+++ b/source/slang/slang-ir-specialize-resources.cpp
@@ -355,11 +355,6 @@ struct ResourceOutputSpecializationPass
         if(as<IRSamplerStateTypeBase>(type))
             return true;
 
-        if(as<IRHitObjectType>(type))
-            return true;
-        if(as<IRRayQueryType>(type))
-            return true;
-
         // TODO: more cases here?
 
         return false;
@@ -1232,6 +1227,10 @@ bool isIllegalGLSLParameterType(IRType* type)
         }
     }
     if (as<IRMeshOutputType>(type))
+        return true;
+    if (as<IRRayQueryType>(type))
+        return true;
+    if (as<IRHitObjectType>(type))
         return true;
     return false;
 }

--- a/tests/bugs/ray-query-in-generic.slang
+++ b/tests/bugs/ray-query-in-generic.slang
@@ -38,8 +38,6 @@ struct Ray
 
 RaytracingAccelerationStructure sceneBVH;
 
-// TODO: remove force inline here will result in an error.
-[ForceInline]
 bool traceSceneVisibilityRayImpl<let Flags : int>(const bool useAlphaTest, inout RayQuery<Flags> q, const Ray ray, uint rayFlags, uint instanceInclusionMask)
 {
     var rayDesc = ray.toRayDesc();

--- a/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-make-hit.slang.1.expected
+++ b/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-make-hit.slang.1.expected
@@ -31,43 +31,48 @@ struct RayDesc_0
     float TMax_0;
 };
 
-RayDesc_0 HitObject_GetRayDesc_0(hitObjectNV this_0)
+void main()
 {
-    vec3 _S1 = (hitObjectGetWorldRayOriginNV((this_0)));
-    float _S2 = (hitObjectGetRayTMinNV((this_0)));
-    vec3 _S3 = (hitObjectGetObjectRayDirectionNV((this_0)));
-    float _S4 = (hitObjectGetRayTMaxNV((this_0)));
-    RayDesc_0 ray_0 = { _S1, _S2, _S3, _S4 };
-    return ray_0;
-}
-
-SomeValues_0 HitObject_GetAttributes_0(hitObjectNV this_1)
-{
-    hitObjectGetAttributesNV((this_1), ((0)));
-    return t_0;
-}
-
-uint calcValue_0(hitObjectNV hit_0)
-{
-    bool _S5 = (hitObjectIsHitNV((hit_0)));
+    uvec3 _S1 = ((gl_LaunchIDEXT));
+    ivec2 launchID_0 = ivec2(_S1.xy);
+    uvec3 _S2 = ((gl_LaunchSizeEXT));
+    int idx_0 = launchID_0.x;
+    RayDesc_0 ray_0;
+    ray_0.Origin_0 = vec3(float(idx_0), 0.0, 0.0);
+    ray_0.TMin_0 = 0.00999999977648258209;
+    ray_0.Direction_0 = vec3(0.0, 1.0, 0.0);
+    ray_0.TMax_0 = 10000.0;
+    uint _S3 = uint(idx_0);
+    uint _S4 = uint(idx_0 * 2);
+    uint _S5 = uint(idx_0 * 3);
+    RayDesc_0 _S6 = ray_0;
+    hitObjectNV hitObj_0;
+    int _S7 = int(_S3);
+    int _S8 = int(_S4);
+    int _S9 = int(_S5);
+    hitObjectRecordHitWithIndexNV(hitObj_0, scene_0, _S7, _S8, _S9, 0U, 0U, _S6.Origin_0, _S6.TMin_0, _S6.Direction_0, _S6.TMax_0, (0));
+    bool _S10 = (hitObjectIsHitNV((hitObj_0)));
     uint r_0;
-    if(_S5)
+    if(_S10)
     {
-        uint instanceIndex_0 = (hitObjectGetInstanceCustomIndexNV((hit_0)));
-        uint instanceID_0 = (hitObjectGetInstanceIdNV((hit_0)));
-        uint geometryIndex_0 = (hitObjectGetGeometryIndexNV((hit_0)));
-        uint primitiveIndex_0 = (hitObjectGetPrimitiveIndexNV((hit_0)));
-        uint hitKind_0 = (hitObjectGetHitKindNV((hit_0)));
+        uint instanceIndex_0 = (hitObjectGetInstanceCustomIndexNV((hitObj_0)));
+        uint instanceID_0 = (hitObjectGetInstanceIdNV((hitObj_0)));
+        uint geometryIndex_0 = (hitObjectGetGeometryIndexNV((hitObj_0)));
+        uint primitiveIndex_0 = (hitObjectGetPrimitiveIndexNV((hitObj_0)));
+        uint hitKind_0 = (hitObjectGetHitKindNV((hitObj_0)));
         uint r_1 = hitKind_0 + instanceIndex_0 + instanceID_0 + geometryIndex_0 + primitiveIndex_0;
-        RayDesc_0 ray_1 = HitObject_GetRayDesc_0(hit_0);
-        uint r_2 = r_1 + uint(ray_1.TMin_0 > 0.0) + uint(ray_1.TMax_0 < ray_1.TMin_0);
-        SomeValues_0 objSomeValues_0 = HitObject_GetAttributes_0(hit_0);
-        r_0 = uint(int(r_2) + objSomeValues_0.a_0);
+        vec3 _S11 = (hitObjectGetWorldRayOriginNV((hitObj_0)));
+        float _S12 = (hitObjectGetRayTMinNV((hitObj_0)));
+        vec3 _S13 = (hitObjectGetObjectRayDirectionNV((hitObj_0)));
+        float _S14 = (hitObjectGetRayTMaxNV((hitObj_0)));
+        uint r_2 = r_1 + uint(_S12 > 0.0) + uint(_S14 < _S12);
+        hitObjectGetAttributesNV((hitObj_0), ((0)));
+        r_0 = uint(int(r_2) + t_0.a_0);
     }
     else
     {
-        bool _S6 = (hitObjectIsMissNV((hit_0)));
-        if(_S6)
+        bool _S15 = (hitObjectIsMissNV((hitObj_0)));
+        if(_S15)
         {
             r_0 = 1U;
         }
@@ -76,35 +81,40 @@ uint calcValue_0(hitObjectNV hit_0)
             r_0 = 0U;
         }
     }
-    return r_0;
-}
-
-void main()
-{
-    uvec3 _S7 = ((gl_LaunchIDEXT));
-    ivec2 launchID_0 = ivec2(_S7.xy);
-    uvec3 _S8 = ((gl_LaunchSizeEXT));
-    int idx_0 = launchID_0.x;
-    RayDesc_0 ray_2;
-    ray_2.Origin_0 = vec3(float(idx_0), 0.0, 0.0);
-    ray_2.TMin_0 = 0.00999999977648258209;
-    ray_2.Direction_0 = vec3(0.0, 1.0, 0.0);
-    ray_2.TMax_0 = 10000.0;
-    uint _S9 = uint(idx_0);
-    uint _S10 = uint(idx_0 * 2);
-    uint _S11 = uint(idx_0 * 3);
-    RayDesc_0 _S12 = ray_2;
-    hitObjectNV hitObj_0;
-    int _S13 = int(_S9);
-    int _S14 = int(_S10);
-    int _S15 = int(_S11);
-    hitObjectRecordHitWithIndexNV(hitObj_0, scene_0, _S13, _S14, _S15, 0U, 0U, _S12.Origin_0, _S12.TMin_0, _S12.Direction_0, _S12.TMax_0, (0));
-    uint r_3 = calcValue_0(hitObj_0);
-    RayDesc_0 _S16 = ray_2;
+    RayDesc_0 _S16 = ray_0;
     hitObjectNV hitObj_1;
-    hitObjectRecordHitNV(hitObj_1, scene_0, _S13, _S15, _S14, 0U, 0U, 4U, _S16.Origin_0, _S16.TMin_0, _S16.Direction_0, _S16.TMax_0, (0));
-    uint _S17 = calcValue_0(hitObj_1);
-    outputBuffer_0._data[_S9] = r_3 + _S17;
+    hitObjectRecordHitNV(hitObj_1, scene_0, _S7, _S9, _S8, 0U, 0U, 4U, _S16.Origin_0, _S16.TMin_0, _S16.Direction_0, _S16.TMax_0, (0));
+    bool _S17 = (hitObjectIsHitNV((hitObj_1)));
+    uint r_3;
+    if(_S17)
+    {
+        uint instanceIndex_1 = (hitObjectGetInstanceCustomIndexNV((hitObj_1)));
+        uint instanceID_1 = (hitObjectGetInstanceIdNV((hitObj_1)));
+        uint geometryIndex_1 = (hitObjectGetGeometryIndexNV((hitObj_1)));
+        uint primitiveIndex_1 = (hitObjectGetPrimitiveIndexNV((hitObj_1)));
+        uint hitKind_1 = (hitObjectGetHitKindNV((hitObj_1)));
+        uint r_4 = hitKind_1 + instanceIndex_1 + instanceID_1 + geometryIndex_1 + primitiveIndex_1;
+        vec3 _S18 = (hitObjectGetWorldRayOriginNV((hitObj_1)));
+        float _S19 = (hitObjectGetRayTMinNV((hitObj_1)));
+        vec3 _S20 = (hitObjectGetObjectRayDirectionNV((hitObj_1)));
+        float _S21 = (hitObjectGetRayTMaxNV((hitObj_1)));
+        uint r_5 = r_4 + uint(_S19 > 0.0) + uint(_S21 < _S19);
+        hitObjectGetAttributesNV((hitObj_1), ((0)));
+        r_3 = uint(int(r_5) + t_0.a_0);
+    }
+    else
+    {
+        bool _S22 = (hitObjectIsMissNV((hitObj_1)));
+        if(_S22)
+        {
+            r_3 = 1U;
+        }
+        else
+        {
+            r_3 = 0U;
+        }
+    }
+    outputBuffer_0._data[_S3] = r_0 + r_3;
     return;
 }
 

--- a/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-output.slang.1.expected
+++ b/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-output.slang.1.expected
@@ -49,41 +49,67 @@ RayDesc_0 makeRay_0(uint idx_0, uint variation_0)
     return ray_0;
 }
 
-MyAttributes_0 HitObject_GetAttributes_0(hitObjectNV this_0)
+hitObjectNV myTraceRay_0(uint idx_1)
 {
-    hitObjectGetAttributesNV((this_0), ((0)));
-    return t_0;
-}
-
-void accumulate_0(inout uint value_2, hitObjectNV hit_0)
-{
-    value_2 = value_2 * 256U;
-    bool _S1 = (hitObjectIsHitNV((hit_0)));
-    if(_S1)
-    {
-        MyAttributes_0 _S2 = HitObject_GetAttributes_0(hit_0);
-        value_2 = value_2 + (16U + _S2.value_0);
-    }
-    return;
-}
-
-void main()
-{
-    uvec3 _S3 = ((gl_LaunchIDEXT));
-    uint idx_1 = _S3.x;
-    uint r_0 = 0U;
     RayDesc_0 ray_1 = makeRay_0(idx_1, 0U);
     hitObjectNV hitObj_0;
     p_0.value_1 = idx_1;
     hitObjectTraceRayNV(hitObj_0, scene_0, 20U, 255U, 0U, 4U, 0U, ray_1.Origin_0, ray_1.TMin_0, ray_1.Direction_0, ray_1.TMax_0, (0));
-    accumulate_0(r_0, hitObj_0);
-    accumulate_0(r_0, hitObj_0);
-    RayDesc_0 ray_2 = makeRay_0(idx_1, 1U);
+    return hitObj_0;
+}
+
+void main()
+{
+    uvec3 _S1 = ((gl_LaunchIDEXT));
+    uint idx_2 = _S1.x;
+    bool _S2 = (hitObjectIsHitNV((myTraceRay_0(idx_2))));
+    uint r_0;
+    if(_S2)
+    {
+        hitObjectGetAttributesNV((myTraceRay_0(idx_2)), ((0)));
+        r_0 = 16U + t_0.value_0;
+    }
+    else
+    {
+        r_0 = 0U;
+    }
+    uint r_1 = r_0 * 256U;
+    bool _S3 = (hitObjectIsHitNV((myTraceRay_0(idx_2))));
+    if(_S3)
+    {
+        hitObjectGetAttributesNV((myTraceRay_0(idx_2)), ((0)));
+        r_0 = r_1 + (16U + t_0.value_0);
+    }
+    else
+    {
+        r_0 = r_1;
+    }
+    RayDesc_0 ray_2 = makeRay_0(idx_2, 1U);
     hitObjectNV hitObj_1;
-    hitObjectRecordMissNV(hitObj_1, idx_1, ray_2.Origin_0, ray_2.TMin_0, ray_2.Direction_0, ray_2.TMax_0);
-    accumulate_0(r_0, hitObj_1);
-    accumulate_0(r_0, hitObj_0);
-    outputBuffer_0._data[idx_1] = r_0;
+    hitObjectRecordMissNV(hitObj_1, idx_2, ray_2.Origin_0, ray_2.TMin_0, ray_2.Direction_0, ray_2.TMax_0);
+    uint r_2 = r_0 * 256U;
+    bool _S4 = (hitObjectIsHitNV((hitObj_1)));
+    if(_S4)
+    {
+        hitObjectGetAttributesNV((hitObj_1), ((0)));
+        r_0 = r_2 + (16U + t_0.value_0);
+    }
+    else
+    {
+        r_0 = r_2;
+    }
+    uint r_3 = r_0 * 256U;
+    bool _S5 = (hitObjectIsHitNV((myTraceRay_0(idx_2))));
+    if(_S5)
+    {
+        hitObjectGetAttributesNV((myTraceRay_0(idx_2)), ((0)));
+        r_0 = r_3 + (16U + t_0.value_0);
+    }
+    else
+    {
+        r_0 = r_3;
+    }
+    outputBuffer_0._data[idx_2] = r_0;
     return;
 }
 

--- a/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-reorder-thread.slang.1.expected
+++ b/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-reorder-thread.slang.1.expected
@@ -31,40 +31,6 @@ layout(location = 1)
 rayPayloadEXT
 SomeValues_0 p_1;
 
-SomeValues_0 HitObject_GetAttributes_0(hitObjectNV this_0)
-{
-    hitObjectGetAttributesNV((this_0), ((0)));
-    return t_0;
-}
-
-uint calcValue_0(hitObjectNV hit_0)
-{
-    bool _S1 = (hitObjectIsHitNV((hit_0)));
-    uint r_0;
-    if(_S1)
-    {
-        uint instanceIndex_0 = (hitObjectGetInstanceCustomIndexNV((hit_0)));
-        uint instanceID_0 = (hitObjectGetInstanceIdNV((hit_0)));
-        uint geometryIndex_0 = (hitObjectGetGeometryIndexNV((hit_0)));
-        uint primitiveIndex_0 = (hitObjectGetPrimitiveIndexNV((hit_0)));
-        SomeValues_0 objSomeValues_0 = HitObject_GetAttributes_0(hit_0);
-        r_0 = uint(int(instanceIndex_0 + instanceID_0 + geometryIndex_0 + primitiveIndex_0) + objSomeValues_0.a_0);
-    }
-    else
-    {
-        r_0 = 0U;
-    }
-    return r_0;
-}
-
-void HitObject_Invoke_0(accelerationStructureEXT AccelerationStructure_0, hitObjectNV HitOrMiss_0, inout SomeValues_0 Payload_0)
-{
-    p_0 = Payload_0;
-    hitObjectExecuteShaderNV(HitOrMiss_0, (0));
-    Payload_0 = p_0;
-    return;
-}
-
 struct RayDesc_0
 {
     vec3 Origin_0;
@@ -75,45 +41,104 @@ struct RayDesc_0
 
 void main()
 {
-    uvec3 _S2 = ((gl_LaunchIDEXT));
-    ivec2 launchID_0 = ivec2(_S2.xy);
-    uvec3 _S3 = ((gl_LaunchSizeEXT));
+    uvec3 _S1 = ((gl_LaunchIDEXT));
+    ivec2 launchID_0 = ivec2(_S1.xy);
+    uvec3 _S2 = ((gl_LaunchSizeEXT));
     int idx_0 = launchID_0.x;
-    float _S4 = float(idx_0);
-    float _S5 = _S4 * 2.0;
+    float _S3 = float(idx_0);
+    float _S4 = _S3 * 2.0;
     RayDesc_0 ray_0;
-    ray_0.Origin_0 = vec3(_S4, 0.0, 0.0);
+    ray_0.Origin_0 = vec3(_S3, 0.0, 0.0);
     ray_0.TMin_0 = 0.00999999977648258209;
     ray_0.Direction_0 = vec3(0.0, 1.0, 0.0);
     ray_0.TMax_0 = 10000.0;
-    RayDesc_0 _S6 = ray_0;
+    RayDesc_0 _S5 = ray_0;
     hitObjectNV hitObj_0;
     p_1.a_0 = idx_0;
-    p_1.b_0 = _S5;
-    hitObjectTraceRayNV(hitObj_0, scene_0, 20U, 255U, 0U, 4U, 0U, _S6.Origin_0, _S6.TMin_0, _S6.Direction_0, _S6.TMax_0, (1));
-    uint r_1 = calcValue_0(hitObj_0);
+    p_1.b_0 = _S4;
+    hitObjectTraceRayNV(hitObj_0, scene_0, 20U, 255U, 0U, 4U, 0U, _S5.Origin_0, _S5.TMin_0, _S5.Direction_0, _S5.TMax_0, (1));
+    int _S6 = idx_0 * -1;
+    float _S7 = _S3 * 4.0;
+    uint _S8 = uint(idx_0 & 3);
+    int _S9 = idx_0 * -2;
+    float _S10 = _S3 * 8.0;
+    uint _S11 = uint(idx_0 & 1);
+    int _S12 = idx_0 * -4;
+    float _S13 = _S3 * 16.0;
+    uint _S14 = uint(idx_0);
+    bool _S15 = (hitObjectIsHitNV((hitObj_0)));
+    uint r_0;
+    if(_S15)
+    {
+        uint instanceIndex_0 = (hitObjectGetInstanceCustomIndexNV((hitObj_0)));
+        uint instanceID_0 = (hitObjectGetInstanceIdNV((hitObj_0)));
+        uint geometryIndex_0 = (hitObjectGetGeometryIndexNV((hitObj_0)));
+        uint primitiveIndex_0 = (hitObjectGetPrimitiveIndexNV((hitObj_0)));
+        hitObjectGetAttributesNV((hitObj_0), ((0)));
+        r_0 = uint(int(instanceIndex_0 + instanceID_0 + geometryIndex_0 + primitiveIndex_0) + t_0.a_0);
+    }
+    else
+    {
+        r_0 = 0U;
+    }
     reorderThreadNV(hitObj_0);
-    float _S7 = _S4 * 4.0;
-    SomeValues_0 otherValues_0;
-    otherValues_0.a_0 = idx_0 * -1;
-    otherValues_0.b_0 = _S7;
-    HitObject_Invoke_0(scene_0, hitObj_0, otherValues_0);
-    uint _S8 = calcValue_0(hitObj_0);
-    uint r_2 = r_1 + _S8;
-    reorderThreadNV(hitObj_0, uint(idx_0 & 3), 2U);
-    float _S9 = _S4 * 8.0;
-    otherValues_0.a_0 = idx_0 * -2;
-    otherValues_0.b_0 = _S9;
-    HitObject_Invoke_0(scene_0, hitObj_0, otherValues_0);
-    uint _S10 = calcValue_0(hitObj_0);
-    uint r_3 = r_2 + _S10;
-    reorderThreadNV(uint(idx_0 & 1), 1U);
-    float _S11 = _S4 * 16.0;
-    otherValues_0.a_0 = idx_0 * -4;
-    otherValues_0.b_0 = _S11;
-    HitObject_Invoke_0(scene_0, hitObj_0, otherValues_0);
-    uint _S12 = calcValue_0(hitObj_0);
-    outputBuffer_0._data[uint(idx_0)] = r_3 + _S12;
+    p_0.a_0 = _S6;
+    p_0.b_0 = _S7;
+    hitObjectExecuteShaderNV(hitObj_0, (0));
+    bool _S16 = (hitObjectIsHitNV((hitObj_0)));
+    uint r_1;
+    if(_S16)
+    {
+        uint instanceIndex_1 = (hitObjectGetInstanceCustomIndexNV((hitObj_0)));
+        uint instanceID_1 = (hitObjectGetInstanceIdNV((hitObj_0)));
+        uint geometryIndex_1 = (hitObjectGetGeometryIndexNV((hitObj_0)));
+        uint primitiveIndex_1 = (hitObjectGetPrimitiveIndexNV((hitObj_0)));
+        hitObjectGetAttributesNV((hitObj_0), ((0)));
+        r_1 = uint(int(instanceIndex_1 + instanceID_1 + geometryIndex_1 + primitiveIndex_1) + t_0.a_0);
+    }
+    else
+    {
+        r_1 = 0U;
+    }
+    uint r_2 = r_0 + r_1;
+    reorderThreadNV(hitObj_0, _S8, 2U);
+    p_0.a_0 = _S9;
+    p_0.b_0 = _S10;
+    hitObjectExecuteShaderNV(hitObj_0, (0));
+    bool _S17 = (hitObjectIsHitNV((hitObj_0)));
+    if(_S17)
+    {
+        uint instanceIndex_2 = (hitObjectGetInstanceCustomIndexNV((hitObj_0)));
+        uint instanceID_2 = (hitObjectGetInstanceIdNV((hitObj_0)));
+        uint geometryIndex_2 = (hitObjectGetGeometryIndexNV((hitObj_0)));
+        uint primitiveIndex_2 = (hitObjectGetPrimitiveIndexNV((hitObj_0)));
+        hitObjectGetAttributesNV((hitObj_0), ((0)));
+        r_0 = uint(int(instanceIndex_2 + instanceID_2 + geometryIndex_2 + primitiveIndex_2) + t_0.a_0);
+    }
+    else
+    {
+        r_0 = 0U;
+    }
+    uint r_3 = r_2 + r_0;
+    reorderThreadNV(_S11, 1U);
+    p_0.a_0 = _S12;
+    p_0.b_0 = _S13;
+    hitObjectExecuteShaderNV(hitObj_0, (0));
+    bool _S18 = (hitObjectIsHitNV((hitObj_0)));
+    if(_S18)
+    {
+        uint instanceIndex_3 = (hitObjectGetInstanceCustomIndexNV((hitObj_0)));
+        uint instanceID_3 = (hitObjectGetInstanceIdNV((hitObj_0)));
+        uint geometryIndex_3 = (hitObjectGetGeometryIndexNV((hitObj_0)));
+        uint primitiveIndex_3 = (hitObjectGetPrimitiveIndexNV((hitObj_0)));
+        hitObjectGetAttributesNV((hitObj_0), ((0)));
+        r_0 = uint(int(instanceIndex_3 + instanceID_3 + geometryIndex_3 + primitiveIndex_3) + t_0.a_0);
+    }
+    else
+    {
+        r_0 = 0U;
+    }
+    outputBuffer_0._data[_S14] = r_3 + r_0;
     return;
 }
 

--- a/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-trace-motion-ray.slang.1.expected
+++ b/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-trace-motion-ray.slang.1.expected
@@ -4,8 +4,8 @@ standard error = {
 standard output = {
 #version 460
 #extension GL_EXT_ray_tracing : require
-#extension GL_NV_shader_invocation_reorder : require
 #extension GL_NV_ray_tracing_motion_blur : require
+#extension GL_NV_shader_invocation_reorder : require
 layout(row_major) uniform;
 layout(row_major) buffer;
 layout(binding = 0)
@@ -28,32 +28,6 @@ layout(location = 0)
 rayPayloadEXT
 SomeValues_0 p_0;
 
-SomeValues_0 HitObject_GetAttributes_0(hitObjectNV this_0)
-{
-    hitObjectGetAttributesNV((this_0), ((0)));
-    return t_0;
-}
-
-uint calcValue_0(hitObjectNV hit_0)
-{
-    bool _S1 = (hitObjectIsHitNV((hit_0)));
-    uint r_0;
-    if(_S1)
-    {
-        uint instanceIndex_0 = (hitObjectGetInstanceCustomIndexNV((hit_0)));
-        uint instanceID_0 = (hitObjectGetInstanceIdNV((hit_0)));
-        uint geometryIndex_0 = (hitObjectGetGeometryIndexNV((hit_0)));
-        uint primitiveIndex_0 = (hitObjectGetPrimitiveIndexNV((hit_0)));
-        SomeValues_0 objSomeValues_0 = HitObject_GetAttributes_0(hit_0);
-        r_0 = uint(int(instanceIndex_0 + instanceID_0 + geometryIndex_0 + primitiveIndex_0) + objSomeValues_0.a_0);
-    }
-    else
-    {
-        r_0 = 0U;
-    }
-    return r_0;
-}
-
 struct RayDesc_0
 {
     vec3 Origin_0;
@@ -64,26 +38,40 @@ struct RayDesc_0
 
 void main()
 {
-    uvec3 _S2 = ((gl_LaunchIDEXT));
-    ivec2 launchID_0 = ivec2(_S2.xy);
-    uvec3 _S3 = ((gl_LaunchSizeEXT));
+    uvec3 _S1 = ((gl_LaunchIDEXT));
+    ivec2 launchID_0 = ivec2(_S1.xy);
+    uvec3 _S2 = ((gl_LaunchSizeEXT));
     int idx_0 = launchID_0.x;
     float currentTime_0 = float(idx_0 / 4);
-    float _S4 = float(idx_0);
-    float _S5 = _S4 * 2.0;
+    float _S3 = float(idx_0);
+    float _S4 = _S3 * 2.0;
     RayDesc_0 ray_0;
-    ray_0.Origin_0 = vec3(_S4, 0.0, 0.0);
+    ray_0.Origin_0 = vec3(_S3, 0.0, 0.0);
     ray_0.TMin_0 = 0.00999999977648258209;
     ray_0.Direction_0 = vec3(0.0, 1.0, 0.0);
     ray_0.TMax_0 = 10000.0;
-    RayDesc_0 _S6 = ray_0;
+    RayDesc_0 _S5 = ray_0;
     hitObjectNV hitObj_0;
     p_0.a_0 = idx_0;
-    p_0.b_0 = _S5;
-    hitObjectTraceRayMotionNV(hitObj_0, scene_0, 20U, 255U, 0U, 4U, 0U, _S6.Origin_0, _S6.TMin_0, _S6.Direction_0, _S6.TMax_0, currentTime_0, (0));
-    uint _S7 = uint(idx_0);
-    uint _S8 = calcValue_0(hitObj_0);
-    outputBuffer_0._data[_S7] = _S8;
+    p_0.b_0 = _S4;
+    hitObjectTraceRayMotionNV(hitObj_0, scene_0, 20U, 255U, 0U, 4U, 0U, _S5.Origin_0, _S5.TMin_0, _S5.Direction_0, _S5.TMax_0, currentTime_0, (0));
+    uint _S6 = uint(idx_0);
+    bool _S7 = (hitObjectIsHitNV((hitObj_0)));
+    uint r_0;
+    if(_S7)
+    {
+        uint instanceIndex_0 = (hitObjectGetInstanceCustomIndexNV((hitObj_0)));
+        uint instanceID_0 = (hitObjectGetInstanceIdNV((hitObj_0)));
+        uint geometryIndex_0 = (hitObjectGetGeometryIndexNV((hitObj_0)));
+        uint primitiveIndex_0 = (hitObjectGetPrimitiveIndexNV((hitObj_0)));
+        hitObjectGetAttributesNV((hitObj_0), ((0)));
+        r_0 = uint(int(instanceIndex_0 + instanceID_0 + geometryIndex_0 + primitiveIndex_0) + t_0.a_0);
+    }
+    else
+    {
+        r_0 = 0U;
+    }
+    outputBuffer_0._data[_S6] = r_0;
     return;
 }
 

--- a/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-trace-ray.slang.1.expected
+++ b/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-trace-ray.slang.1.expected
@@ -27,32 +27,6 @@ layout(location = 0)
 rayPayloadEXT
 SomeValues_0 p_0;
 
-SomeValues_0 HitObject_GetAttributes_0(hitObjectNV this_0)
-{
-    hitObjectGetAttributesNV((this_0), ((0)));
-    return t_0;
-}
-
-uint calcValue_0(hitObjectNV hit_0)
-{
-    bool _S1 = (hitObjectIsHitNV((hit_0)));
-    uint r_0;
-    if(_S1)
-    {
-        uint instanceIndex_0 = (hitObjectGetInstanceCustomIndexNV((hit_0)));
-        uint instanceID_0 = (hitObjectGetInstanceIdNV((hit_0)));
-        uint geometryIndex_0 = (hitObjectGetGeometryIndexNV((hit_0)));
-        uint primitiveIndex_0 = (hitObjectGetPrimitiveIndexNV((hit_0)));
-        SomeValues_0 objSomeValues_0 = HitObject_GetAttributes_0(hit_0);
-        r_0 = uint(int(instanceIndex_0 + instanceID_0 + geometryIndex_0 + primitiveIndex_0) + objSomeValues_0.a_0);
-    }
-    else
-    {
-        r_0 = 0U;
-    }
-    return r_0;
-}
-
 struct RayDesc_0
 {
     vec3 Origin_0;
@@ -63,25 +37,39 @@ struct RayDesc_0
 
 void main()
 {
-    uvec3 _S2 = ((gl_LaunchIDEXT));
-    ivec2 launchID_0 = ivec2(_S2.xy);
-    uvec3 _S3 = ((gl_LaunchSizeEXT));
+    uvec3 _S1 = ((gl_LaunchIDEXT));
+    ivec2 launchID_0 = ivec2(_S1.xy);
+    uvec3 _S2 = ((gl_LaunchSizeEXT));
     int idx_0 = launchID_0.x;
-    float _S4 = float(idx_0);
-    float _S5 = _S4 * 2.0;
+    float _S3 = float(idx_0);
+    float _S4 = _S3 * 2.0;
     RayDesc_0 ray_0;
-    ray_0.Origin_0 = vec3(_S4, 0.0, 0.0);
+    ray_0.Origin_0 = vec3(_S3, 0.0, 0.0);
     ray_0.TMin_0 = 0.00999999977648258209;
     ray_0.Direction_0 = vec3(0.0, 1.0, 0.0);
     ray_0.TMax_0 = 10000.0;
-    RayDesc_0 _S6 = ray_0;
+    RayDesc_0 _S5 = ray_0;
     hitObjectNV hitObj_0;
     p_0.a_0 = idx_0;
-    p_0.b_0 = _S5;
-    hitObjectTraceRayNV(hitObj_0, scene_0, 20U, 255U, 0U, 4U, 0U, _S6.Origin_0, _S6.TMin_0, _S6.Direction_0, _S6.TMax_0, (0));
-    uint _S7 = uint(idx_0);
-    uint _S8 = calcValue_0(hitObj_0);
-    outputBuffer_0._data[_S7] = _S8;
+    p_0.b_0 = _S4;
+    hitObjectTraceRayNV(hitObj_0, scene_0, 20U, 255U, 0U, 4U, 0U, _S5.Origin_0, _S5.TMin_0, _S5.Direction_0, _S5.TMax_0, (0));
+    uint _S6 = uint(idx_0);
+    bool _S7 = (hitObjectIsHitNV((hitObj_0)));
+    uint r_0;
+    if(_S7)
+    {
+        uint instanceIndex_0 = (hitObjectGetInstanceCustomIndexNV((hitObj_0)));
+        uint instanceID_0 = (hitObjectGetInstanceIdNV((hitObj_0)));
+        uint geometryIndex_0 = (hitObjectGetGeometryIndexNV((hitObj_0)));
+        uint primitiveIndex_0 = (hitObjectGetPrimitiveIndexNV((hitObj_0)));
+        hitObjectGetAttributesNV((hitObj_0), ((0)));
+        r_0 = uint(int(instanceIndex_0 + instanceID_0 + geometryIndex_0 + primitiveIndex_0) + t_0.a_0);
+    }
+    else
+    {
+        r_0 = 0U;
+    }
+    outputBuffer_0._data[_S6] = r_0;
     return;
 }
 


### PR DESCRIPTION
Fixes #3141.

Reverts the attempt to specialize functions with RayQuery/HitObject parameters in PR #2929, because specialization introduces new copies of these objects that can't be eliminated. 

We have to resort to inlining them for now.