### PR TITLE
Proper lowering of functiosn that returns NonCopyable values.

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -8401,7 +8401,8 @@ struct HitObject
 
         attr = attributes;
 
-        return __glslMakeHit(
+        __glslMakeHit(
+            __return_val,
             AccelerationStructure,
             InstanceIndex,
             PrimitiveIndex,
@@ -8437,7 +8438,8 @@ struct HitObject
 
         attr = attributes;
 
-        return __glslMakeMotionHit(
+        __glslMakeMotionHit(
+            __return_val,
             AccelerationStructure,
             InstanceIndex,
             PrimitiveIndex,
@@ -8501,7 +8503,8 @@ struct HitObject
         __ref attr_t attr = __hitObjectAttributes<attr_t>();
         attr = attributes;
 
-        return __glslMakeHitWithIndex(
+        __glslMakeHitWithIndex(
+            __return_val,
             AccelerationStructure, 
             InstanceIndex,              ///? Same as instanceid ?
             GeometryIndex, 
@@ -8536,7 +8539,8 @@ struct HitObject
         __ref attr_t attr = __hitObjectAttributes<attr_t>();
         attr = attributes;
 
-        return __glslMakeMotionHitWithIndex(
+        __glslMakeMotionHitWithIndex(
+            __return_val,
             AccelerationStructure, 
             InstanceIndex,              ///? Same as instanceid ?
             GeometryIndex, 
@@ -8566,7 +8570,7 @@ struct HitObject
         uint MissShaderIndex, 
         RayDesc Ray)
     {
-        return __glslMakeMiss(MissShaderIndex, Ray.Origin, Ray.TMin, Ray.Direction, Ray.TMax);
+        __glslMakeMiss(__return_val, MissShaderIndex, Ray.Origin, Ray.TMin, Ray.Direction, Ray.TMax);
     }
 
         /// See MakeMiss but handles Motion 
@@ -8578,7 +8582,7 @@ struct HitObject
         RayDesc Ray,
         float CurrentTime)
     {
-        return __glslMakeMotionMiss(MissShaderIndex, Ray.Origin, Ray.TMin, Ray.Direction, Ray.TMax, CurrentTime);
+        __glslMakeMotionMiss(__return_val, MissShaderIndex, Ray.Origin, Ray.TMin, Ray.Direction, Ray.TMax, CurrentTime);
     }
 
         /// Creates a HitObject representing “NOP” (no operation) which is neither a hit nor a miss. Invoking a
@@ -8594,7 +8598,7 @@ struct HitObject
     __specialized_for_target(glsl)
     static HitObject MakeNop()
     {
-        return __glslMakeNop();
+        __glslMakeNop(__return_val);
     }
 
         /// Invokes closesthit or miss shading for the specified hit object. In case of a NOP HitObject, no
@@ -8628,18 +8632,21 @@ struct HitObject
     [__requiresNVAPI]
     __target_intrinsic(hlsl)
     __target_intrinsic(glsl, "hitObjectIsMissNV($0)")
+    __glsl_extension(GL_EXT_ray_tracing)
     bool IsMiss();
 
         /// Returns true if the HitObject encodes a hit, otherwise returns false.
     [__requiresNVAPI]
     __target_intrinsic(hlsl)
     __target_intrinsic(glsl, "hitObjectIsHitNV($0)")
+    __glsl_extension(GL_EXT_ray_tracing)
     bool IsHit();
 
         /// Returns true if the HitObject encodes a nop, otherwise returns false.
     [__requiresNVAPI]
     __target_intrinsic(hlsl)
     __target_intrinsic(glsl, "hitObjectIsEmptyNV($0)")
+    __glsl_extension(GL_EXT_ray_tracing)
     bool IsNop();
 
         /// Queries ray properties from HitObject. Valid if the hit object represents a hit or a miss.
@@ -8658,36 +8665,42 @@ struct HitObject
     [__requiresNVAPI]
     __target_intrinsic(hlsl)
     __target_intrinsic(glsl, "hitObjectGetShaderBindingTableRecordIndexNV($0)")
+    __glsl_extension(GL_EXT_ray_tracing)
     uint GetShaderTableIndex();
 
         /// Returns the instance index of a hit. Valid if the hit object represents a hit.
     [__requiresNVAPI]
     __target_intrinsic(hlsl)
     __target_intrinsic(glsl, "hitObjectGetInstanceCustomIndexNV($0)")
+    __glsl_extension(GL_EXT_ray_tracing)
     uint GetInstanceIndex();
 
         /// Returns the instance ID of a hit. Valid if the hit object represents a hit.
     [__requiresNVAPI]
     __target_intrinsic(hlsl)
     __target_intrinsic(glsl, "hitObjectGetInstanceIdNV($0)")
+    __glsl_extension(GL_EXT_ray_tracing)
     uint GetInstanceID();
 
         /// Returns the geometry index of a hit. Valid if the hit object represents a hit.
     [__requiresNVAPI]
     __target_intrinsic(hlsl)
     __target_intrinsic(glsl, "hitObjectGetGeometryIndexNV($0)")
+    __glsl_extension(GL_EXT_ray_tracing)
     uint GetGeometryIndex();
 
         /// Returns the primitive index of a hit. Valid if the hit object represents a hit.
     [__requiresNVAPI]
     __target_intrinsic(hlsl)
     __target_intrinsic(glsl, "hitObjectGetPrimitiveIndexNV($0)")
+    __glsl_extension(GL_EXT_ray_tracing)
     uint GetPrimitiveIndex();
 
         /// Returns the hit kind. Valid if the hit object represents a hit.
     [__requiresNVAPI]
     __target_intrinsic(hlsl)
     __target_intrinsic(glsl, "hitObjectGetHitKindNV($0)")
+    __glsl_extension(GL_EXT_ray_tracing)
     uint GetHitKind();
 
         /// Returns the attributes of a hit. Valid if the hit object represents a hit or a miss.
@@ -8769,8 +8782,10 @@ struct HitObject
 
     __glsl_extension(GL_NV_shader_invocation_reorder)
     __glsl_extension(GL_EXT_ray_tracing)
-    __target_intrinsic(glsl, "hitObjectRecordMissNV($5, $0, $1, $2, $3, $4)")
-    static HitObject __glslMakeMiss(
+    __glsl_version(460)
+    __target_intrinsic(glsl, "hitObjectRecordMissNV")
+    static void __glslMakeMiss(
+        out HitObject hitObj,
         uint MissShaderIndex,
         float3 Origin,
         float TMin,
@@ -8781,8 +8796,10 @@ struct HitObject
     __glsl_extension(GL_NV_shader_invocation_reorder)
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
-    __target_intrinsic(glsl, "hitObjectRecordMissNV($6, $0, $1, $2, $3, $4, $5)")
-    static HitObject __glslMakeMotionMiss(
+    __glsl_version(460)
+    __target_intrinsic(glsl, "hitObjectRecordMissMotionNV")
+    static void __glslMakeMotionMiss(
+        out HitObject hitObj,
         uint MissShaderIndex,
         float3 Origin,
         float TMin,
@@ -8792,8 +8809,8 @@ struct HitObject
 
     __glsl_extension(GL_NV_shader_invocation_reorder)
     __glsl_extension(GL_EXT_ray_tracing)
-    __target_intrinsic(glsl, "hitObjectRecordEmptyNV($0)")
-    static HitObject __glslMakeNop();
+    __target_intrinsic(glsl, "hitObjectRecordEmptyNV")
+    static void __glslMakeNop(out HitObject hitObj);
 
     __glsl_extension(GL_NV_shader_invocation_reorder)
     __target_intrinsic(glsl, "hitObjectGetObjectRayDirectionNV($0)")
@@ -8814,8 +8831,10 @@ struct HitObject
     // "void hitObjectRecordHitWithIndexNV(hitObjectNV, accelerationStructureEXT,int,int,int,uint,uint,vec3,float,vec3,float,int);"
     __glsl_extension(GL_NV_shader_invocation_reorder)
     __glsl_extension(GL_EXT_ray_tracing)
-    __target_intrinsic(glsl, "hitObjectRecordHitWithIndexNV($11, $0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10)")
-    static HitObject __glslMakeHitWithIndex(
+    __glsl_version(460)
+    __target_intrinsic(glsl, "hitObjectRecordHitWithIndexNV")
+    static void __glslMakeHitWithIndex(
+        out HitObject hitObj,
         RaytracingAccelerationStructure accelerationStructure,
         int instanceid,
         int primitiveid,
@@ -8832,8 +8851,9 @@ struct HitObject
     __glsl_extension(GL_NV_shader_invocation_reorder)
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
-    __target_intrinsic(glsl, "hitObjectRecordHitWithIndexMotionNV($12, $0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)")
-    static HitObject __glslMakeMotionHitWithIndex(
+    __target_intrinsic(glsl, "hitObjectRecordHitWithIndexMotionNV")
+    static void __glslMakeMotionHitWithIndex(
+        out HitObject hitObj,
         RaytracingAccelerationStructure accelerationStructure,
         int instanceid,
         int primitiveid,
@@ -8850,8 +8870,9 @@ struct HitObject
     // "void hitObjectRecordHitNV(hitObjectNV,accelerationStructureEXT,int,int,int,uint,uint,uint,vec3,float,vec3,float,int);"
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_shader_invocation_reorder)
-    __target_intrinsic(glsl, "hitObjectRecordHitNV($12, $0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)")
-    static HitObject __glslMakeHit(
+    __target_intrinsic(glsl, "hitObjectRecordHitNV")
+    static void __glslMakeHit(
+        out HitObject hitObj,
         RaytracingAccelerationStructure accelerationStructure,
         int instanceid,
         int primitiveid,
@@ -8869,8 +8890,9 @@ struct HitObject
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_shader_invocation_reorder)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
-    __target_intrinsic(glsl, "hitObjectRecordHitMotionNV($13, $0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)")
-    static HitObject __glslMakeMotionHit(
+    __target_intrinsic(glsl, "hitObjectRecordHitMotionNV")
+    static void __glslMakeMotionHit(
+        out HitObject hitObj,
         RaytracingAccelerationStructure accelerationStructure,
         int instanceid,
         int primitiveid,

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -8286,8 +8286,6 @@ struct HitObject
         RayDesc Ray, 
         inout payload_t Payload)
     {
-        HitObject hitObj;
-
         [__vulkanRayPayload]
         static payload_t p;
 
@@ -8295,7 +8293,7 @@ struct HitObject
         p = Payload;
 
         __glslTraceRay(
-            hitObj,
+            __return_val,
             AccelerationStructure,
             RayFlags,                                           // Assumes D3D/VK have some RayFlags values
             InstanceInclusionMask,                              // cullMask
@@ -8310,8 +8308,6 @@ struct HitObject
         
         // Write the payload out
         Payload = p;
-
-        return hitObj;
     }
 
         /// Executes motion ray traversal (including anyhit and intersection shaders) like TraceRay, but returns the
@@ -8329,8 +8325,6 @@ struct HitObject
         float CurrentTime,
         inout payload_t Payload)
     {
-        HitObject hitObj;
-
         [__vulkanRayPayload]
         static payload_t p;
 
@@ -8338,7 +8332,7 @@ struct HitObject
         p = Payload;
 
         __glslTraceMotionRay(
-            hitObj,
+            __return_val,
             AccelerationStructure,
             RayFlags,                                           // Assumes D3D/VK have some RayFlags values
             InstanceInclusionMask,                              // cullMask
@@ -8354,8 +8348,6 @@ struct HitObject
         
         // Write the payload out
         Payload = p;
-
-        return hitObj;
     }
 
         /// Creates a HitObject representing a hit based on values explicitly passed as arguments, without
@@ -8404,14 +8396,12 @@ struct HitObject
         RayDesc Ray, 
         attr_t attributes)
     {
-        HitObject hitObj;
-
         // Save the attributes
         __ref attr_t attr = __hitObjectAttributes<attr_t>();
 
         attr = attributes;
 
-        __glslMakeHit(hitObj,
+        return __glslMakeHit(
             AccelerationStructure,
             InstanceIndex,
             PrimitiveIndex,
@@ -8424,8 +8414,6 @@ struct HitObject
             Ray.Direction, 
             Ray.TMax,
             __hitObjectAttributesLocation(__hitObjectAttributes<attr_t>()));
-
-        return hitObj;
     }
 
         /// See MakeHit but handles Motion 
@@ -8444,14 +8432,12 @@ struct HitObject
         float CurrentTime,
         attr_t attributes)
     {
-        HitObject hitObj;
-
         // Save the attributes
         __ref attr_t attr = __hitObjectAttributes<attr_t>();
 
         attr = attributes;
 
-        __glslMakeMotionHit(hitObj,
+        return __glslMakeMotionHit(
             AccelerationStructure,
             InstanceIndex,
             PrimitiveIndex,
@@ -8465,8 +8451,6 @@ struct HitObject
             Ray.TMax,
             CurrentTime,
             __hitObjectAttributesLocation(__hitObjectAttributes<attr_t>()));
-
-        return hitObj;
     }
 
         /// Creates a HitObject representing a hit based on values explicitly passed as arguments, without
@@ -8513,13 +8497,11 @@ struct HitObject
         RayDesc Ray, 
         attr_t attributes)
     {
-        HitObject hitObj;
-
         // Save the attributes
         __ref attr_t attr = __hitObjectAttributes<attr_t>();
         attr = attributes;
 
-        __glslMakeHitWithIndex(hitObj,
+        return __glslMakeHitWithIndex(
             AccelerationStructure, 
             InstanceIndex,              ///? Same as instanceid ?
             GeometryIndex, 
@@ -8531,8 +8513,6 @@ struct HitObject
             Ray.Direction, 
             Ray.TMax,
             __hitObjectAttributesLocation(__hitObjectAttributes<attr_t>()));
-
-        return hitObj;
     }
 
         /// See MakeHit but handles Motion 
@@ -8556,7 +8536,7 @@ struct HitObject
         __ref attr_t attr = __hitObjectAttributes<attr_t>();
         attr = attributes;
 
-        __glslMakeMotionHitWithIndex(hitObj,
+        return __glslMakeMotionHitWithIndex(
             AccelerationStructure, 
             InstanceIndex,              ///? Same as instanceid ?
             GeometryIndex, 
@@ -8569,8 +8549,6 @@ struct HitObject
             Ray.TMax,
             CurrentTime,
             __hitObjectAttributesLocation(__hitObjectAttributes<attr_t>()));
-
-        return hitObj;
     }
 
         /// Creates a HitObject representing a miss based on values explicitly passed as arguments, without
@@ -8588,9 +8566,7 @@ struct HitObject
         uint MissShaderIndex, 
         RayDesc Ray)
     {
-        HitObject hitObj;
-        __glslMakeMiss(hitObj, MissShaderIndex, Ray.Origin, Ray.TMin, Ray.Direction, Ray.TMax);
-        return hitObj;
+        return __glslMakeMiss(MissShaderIndex, Ray.Origin, Ray.TMin, Ray.Direction, Ray.TMax);
     }
 
         /// See MakeMiss but handles Motion 
@@ -8602,9 +8578,7 @@ struct HitObject
         RayDesc Ray,
         float CurrentTime)
     {
-        HitObject hitObj;
-        __glslMakeMotionMiss(hitObj, MissShaderIndex, Ray.Origin, Ray.TMin, Ray.Direction, Ray.TMax, CurrentTime);
-        return hitObj;
+        return __glslMakeMotionMiss(MissShaderIndex, Ray.Origin, Ray.TMin, Ray.Direction, Ray.TMax, CurrentTime);
     }
 
         /// Creates a HitObject representing “NOP” (no operation) which is neither a hit nor a miss. Invoking a
@@ -8620,9 +8594,7 @@ struct HitObject
     __specialized_for_target(glsl)
     static HitObject MakeNop()
     {
-        HitObject hitObj;
-        __glslMakeNop(hitObj);
-        return hitObj;
+        return __glslMakeNop();
     }
 
         /// Invokes closesthit or miss shading for the specified hit object. In case of a NOP HitObject, no
@@ -8797,9 +8769,8 @@ struct HitObject
 
     __glsl_extension(GL_NV_shader_invocation_reorder)
     __glsl_extension(GL_EXT_ray_tracing)
-    __target_intrinsic(glsl, "hitObjectRecordMissNV")
-    static void __glslMakeMiss(
-        out HitObject hitObj,
+    __target_intrinsic(glsl, "hitObjectRecordMissNV($5, $0, $1, $2, $3, $4)")
+    static HitObject __glslMakeMiss(
         uint MissShaderIndex,
         float3 Origin,
         float TMin,
@@ -8810,9 +8781,8 @@ struct HitObject
     __glsl_extension(GL_NV_shader_invocation_reorder)
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
-    __target_intrinsic(glsl, "hitObjectRecordMissNV")
-    static void __glslMakeMotionMiss(
-        out HitObject hitObj,
+    __target_intrinsic(glsl, "hitObjectRecordMissNV($6, $0, $1, $2, $3, $4, $5)")
+    static HitObject __glslMakeMotionMiss(
         uint MissShaderIndex,
         float3 Origin,
         float TMin,
@@ -8823,7 +8793,7 @@ struct HitObject
     __glsl_extension(GL_NV_shader_invocation_reorder)
     __glsl_extension(GL_EXT_ray_tracing)
     __target_intrinsic(glsl, "hitObjectRecordEmptyNV($0)")
-    static void __glslMakeNop(out HitObject hitObj);
+    static HitObject __glslMakeNop();
 
     __glsl_extension(GL_NV_shader_invocation_reorder)
     __target_intrinsic(glsl, "hitObjectGetObjectRayDirectionNV($0)")
@@ -8844,9 +8814,8 @@ struct HitObject
     // "void hitObjectRecordHitWithIndexNV(hitObjectNV, accelerationStructureEXT,int,int,int,uint,uint,vec3,float,vec3,float,int);"
     __glsl_extension(GL_NV_shader_invocation_reorder)
     __glsl_extension(GL_EXT_ray_tracing)
-    __target_intrinsic(glsl, "hitObjectRecordHitWithIndexNV")
-    static void __glslMakeHitWithIndex(
-        out HitObject hitObj,
+    __target_intrinsic(glsl, "hitObjectRecordHitWithIndexNV($11, $0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10)")
+    static HitObject __glslMakeHitWithIndex(
         RaytracingAccelerationStructure accelerationStructure,
         int instanceid,
         int primitiveid,
@@ -8863,9 +8832,8 @@ struct HitObject
     __glsl_extension(GL_NV_shader_invocation_reorder)
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
-    __target_intrinsic(glsl, "hitObjectRecordHitWithIndexMotionNV")
-    static void __glslMakeMotionHitWithIndex(
-        out HitObject hitObj,
+    __target_intrinsic(glsl, "hitObjectRecordHitWithIndexMotionNV($12, $0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)")
+    static HitObject __glslMakeMotionHitWithIndex(
         RaytracingAccelerationStructure accelerationStructure,
         int instanceid,
         int primitiveid,
@@ -8882,9 +8850,8 @@ struct HitObject
     // "void hitObjectRecordHitNV(hitObjectNV,accelerationStructureEXT,int,int,int,uint,uint,uint,vec3,float,vec3,float,int);"
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_shader_invocation_reorder)
-    __target_intrinsic(glsl, "hitObjectRecordHitNV")
-    static void __glslMakeHit(
-        out HitObject hitObj,
+    __target_intrinsic(glsl, "hitObjectRecordHitNV($12, $0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)")
+    static HitObject __glslMakeHit(
         RaytracingAccelerationStructure accelerationStructure,
         int instanceid,
         int primitiveid,
@@ -8902,9 +8869,8 @@ struct HitObject
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_shader_invocation_reorder)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
-    __target_intrinsic(glsl, "hitObjectRecordHitMotionNV")
-    static void __glslMakeMotionHit(
-        out HitObject hitObj,
+    __target_intrinsic(glsl, "hitObjectRecordHitMotionNV($13, $0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)")
+    static HitObject __glslMakeMotionHit(
         RaytracingAccelerationStructure accelerationStructure,
         int instanceid,
         int primitiveid,
@@ -8929,7 +8895,7 @@ struct HitObject
     __glsl_extension(GL_NV_shader_invocation_reorder)
     __target_intrinsic(glsl, "hitObjectTraceRayNV")
     static void __glslTraceRay(
-        out HitObject hitObj,
+        out HitObject hitObject,
         RaytracingAccelerationStructure accelerationStructure,
         uint rayFlags,
         uint cullMask,
@@ -8947,7 +8913,7 @@ struct HitObject
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
     __target_intrinsic(glsl, "hitObjectTraceRayMotionNV")
     static void __glslTraceMotionRay(
-        out HitObject hitObj,
+        out HitObject hitObject,
         RaytracingAccelerationStructure accelerationStructure,
         uint rayFlags,
         uint cullMask,

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -469,6 +469,16 @@ class ThisExpr: public Expr
     Scope* scope = nullptr;
 };
 
+// Represent a reference to the virtual __return_val object holding the return value of
+// functions whose result type is non-copyable.
+class ReturnValExpr : public Expr
+{
+    SLANG_AST_CLASS(ReturnValExpr)
+
+    SLANG_UNREFLECTED
+    Scope* scope = nullptr;
+};
+
 // An expression that binds a temporary variable in a local expression context
 class LetExpr: public Expr
 {

--- a/source/slang/slang-ast-iterator.h
+++ b/source/slang/slang-ast-iterator.h
@@ -220,6 +220,8 @@ struct ASTIterator
 
         void visitThisExpr(ThisExpr* expr) { iterator->maybeDispatchCallback(expr); }
         void visitThisTypeExpr(ThisTypeExpr* expr) { iterator->maybeDispatchCallback(expr); }
+        void visitReturnValExpr(ReturnValExpr* expr) { iterator->maybeDispatchCallback(expr); }
+
         void visitAndTypeExpr(AndTypeExpr* expr)
         {
             iterator->maybeDispatchCallback(expr);

--- a/source/slang/slang-ast-type.cpp
+++ b/source/slang/slang-ast-type.cpp
@@ -796,4 +796,14 @@ Type* removeParamDirType(Type* type)
     return type;
 }
 
+bool isNonCopyableType(Type* type)
+{
+    auto declRefType = as<DeclRefType>(type);
+    if (!declRefType)
+        return false;
+    if (declRefType->getDeclRef().getDecl()->findModifier<NonCopyableTypeAttribute>())
+        return true;
+    return false;
+}
+
 } // namespace Slang

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -834,5 +834,6 @@ class ModifiedType : public Type
 };
 
 Type* removeParamDirType(Type* type);
+bool isNonCopyableType(Type* type);
 
 } // namespace Slang

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -2409,6 +2409,7 @@ namespace Slang
 
         Expr* visitThisExpr(ThisExpr* expr);
         Expr* visitThisTypeExpr(ThisTypeExpr* expr);
+        Expr* visitReturnValExpr(ReturnValExpr* expr);
         Expr* visitAndTypeExpr(AndTypeExpr* expr);
         Expr* visitPointerTypeExpr(PointerTypeExpr* expr);
         Expr* visitModifiedTypeExpr(ModifiedTypeExpr* expr);

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -536,7 +536,7 @@ DIAGNOSTIC(38100, Error, typeDoesntImplementInterfaceRequirement, "type '$0' doe
 DIAGNOSTIC(38101, Error, thisExpressionOutsideOfTypeDecl, "'this' expression can only be used in members of an aggregate type")
 DIAGNOSTIC(38102, Error, initializerNotInsideType, "an 'init' declaration is only allowed inside a type or 'extension' declaration")
 DIAGNOSTIC(38103, Error, thisTypeOutsideOfTypeDecl, "'This' type can only be used inside of an aggregate type")
-
+DIAGNOSTIC(38104, Error, returnValNotAvailable, "cannot use '__return_val' here. '__return_val' is defined only in functions that return a non-copyable value.")
 DIAGNOSTIC(38020, Error, mismatchEntryPointTypeArgument, "expecting $0 entry-point type arguments, provided $1.")
 DIAGNOSTIC(38021, Error, typeArgumentForGenericParameterDoesNotConformToInterface, "type argument `$0` for generic parameter `$1` does not conform to interface `$2`.")
 

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -309,9 +309,8 @@ public:
 
     void emitStore(IRStore* store);
     virtual void _emitStoreImpl(IRStore* store);
-    virtual void _emitInstAsVarInitializerImpl(IRInst* inst);
     void _emitInstAsDefaultInitializedVar(IRInst* inst, IRType* type);
-    virtual void _emitAllocateOpaqueHandleImpl(IRInst* allocateInst);
+    void _emitInstAsVarInitializerImpl(IRInst* inst);
 
     UInt getBindingOffset(EmitVarChain* chain, LayoutResourceKind kind);
     UInt getBindingSpace(EmitVarChain* chain, LayoutResourceKind kind);

--- a/source/slang/slang-emit-glsl.h
+++ b/source/slang/slang-emit-glsl.h
@@ -56,9 +56,6 @@ protected:
     virtual void emitSimpleValueImpl(IRInst* inst) SLANG_OVERRIDE;
     virtual void emitLoopControlDecorationImpl(IRLoopControlDecoration* decl) SLANG_OVERRIDE;
 
-    virtual void _emitInstAsVarInitializerImpl(IRInst* inst) SLANG_OVERRIDE;
-    virtual void _emitStoreImpl(IRStore* store) SLANG_OVERRIDE;
-
     void _emitGLSLTextureOrTextureSamplerType(IRTextureTypeBase* type, char const* baseName);
     void _emitGLSLStructuredBuffer(IRGlobalParam* varDecl, IRHLSLStructuredBufferTypeBase* structuredBufferType);
 

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -1136,31 +1136,6 @@ void HLSLSourceEmitter::_emitPrefixTypeAttr(IRAttr* attr)
     }
 }
 
-void HLSLSourceEmitter::_emitInstAsVarInitializerImpl(IRInst* inst)
-{
-    // Some opcodes can be folded into a variable initialization
-    // by allowing the variable to be "default-constructed."
-    //
-    switch (inst->getOp())
-    {
-    case kIROp_AllocateOpaqueHandle:
-        if (shouldFoldInstIntoUseSites(inst))
-        {
-            return;
-        }
-        break;
-
-    default:
-        break;
-    }
-
-    // We fall back to the default behavior for all targets,
-    // which is to emit `inst` as an initial-value expression
-    // after an `=`.
-    //
-    Super::_emitInstAsVarInitializerImpl(inst);
-}
-
 void HLSLSourceEmitter::emitSimpleFuncParamImpl(IRParam* param)
 {
     emitRateQualifiers(param);

--- a/source/slang/slang-emit-hlsl.h
+++ b/source/slang/slang-emit-hlsl.h
@@ -64,8 +64,6 @@ protected:
 
     void _emitPrefixTypeAttr(IRAttr* attr) SLANG_OVERRIDE;
 
-    virtual void _emitInstAsVarInitializerImpl(IRInst* inst) SLANG_OVERRIDE;
-
         // Emit a single `register` semantic, as appropriate for a given resource-type-specific layout info
         // Keyword to use in the uniform case (`register` for globals, `packoffset` inside a `cbuffer`)
     void _emitHLSLRegisterSemantic(LayoutResourceKind kind, EmitVarChain* chain, char const* uniformSemanticSpelling = "register");

--- a/source/slang/slang-ir-specialize-resources.cpp
+++ b/source/slang/slang-ir-specialize-resources.cpp
@@ -355,6 +355,12 @@ struct ResourceOutputSpecializationPass
         if(as<IRSamplerStateTypeBase>(type))
             return true;
 
+        if (as<IRRayQueryType>(type))
+            return true;
+
+        if (as<IRHitObjectType>(type))
+            return true;
+
         // TODO: more cases here?
 
         return false;

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -1239,6 +1239,12 @@ void assign(
     LoweredValInfo const&   left,
     LoweredValInfo const&   right);
 
+void assignExpr(
+    IRGenContext* context,
+    const LoweredValInfo& inLeft,
+    Expr* rightExpr,
+    SourceLoc assignmentLoc);
+
 IRInst* getAddress(
     IRGenContext*           context,
     LoweredValInfo const&   inVal,

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -563,6 +563,10 @@ struct IRGenContext
     // The IR witness value to use for `ThisType`
     IRInst* thisTypeWitness = nullptr;
 
+    // The return destination parameter to write to at return sites.
+    // (For use by functions that returns non-copyable types)
+    LoweredValInfo returnDestination;
+
     bool includeDebugInfo = false;
 
     explicit IRGenContext(SharedIRGenContext* inShared, ASTBuilder* inAstBuilder)
@@ -804,6 +808,11 @@ LoweredValInfo lowerRValueExpr(
     IRGenContext*   context,
     Expr*           expr);
 
+void lowerRValueExprWithDestination(
+    IRGenContext* context,
+    LoweredValInfo destination,
+    Expr* expr);
+
 IRType* lowerType(
     IRGenContext*   context,
     Type*           type);
@@ -1037,8 +1046,6 @@ LoweredValInfo extractField(
         break;
     }
 }
-
-
 
 LoweredValInfo materialize(
     IRGenContext*   context,
@@ -2703,6 +2710,9 @@ struct IRLoweringParameterInfo
 
     // Is this the representation of a `this` parameter?
     bool                isThisParam = false;
+
+    // Is this the destination of address for non-copyable return val?
+    bool                isReturnDestination = false;
 };
 //
 // We need a way to be able to create a `IRLoweringParameterInfo` given the declaration
@@ -2771,6 +2781,19 @@ void addThisParameter(
     info.isThisParam = true;
 
     ioParameterLists->params.add(info);
+}
+
+void maybeAddReturnDestinationParam(ParameterLists* ioParameterLists, Type* resultType)
+{
+    if (isNonCopyableType(resultType))
+    {
+        IRLoweringParameterInfo info;
+        info.type = resultType;
+        info.decl = nullptr;
+        info.direction = kParameterDirection_Ref;
+        info.isReturnDestination = true;
+        ioParameterLists->params.add(info);
+    }
 }
 //
 // And here is our function that will do the recursive walk:
@@ -2842,6 +2865,7 @@ void collectParameterLists(
             {
                 ioParameterLists->params.add(getParameterInfo(context, paramDeclRef));
             }
+            maybeAddReturnDestinationParam(ioParameterLists, getResultType(context->astBuilder, callableDeclRef));
         }
     }
 }
@@ -2883,6 +2907,10 @@ struct FuncDeclBaseTypeInfo
     IRType*         resultType;
     ParameterLists  parameterLists;
     List<IRType*>   paramTypes;
+    // If the function returns a non-copyable value, this
+    // flag is set to indicate that the result should be
+    // returned via the last ref parameter.
+    bool            returnViaLastRefParam = false;
 };
 
 void _lowerFuncDeclBaseTypeInfo(
@@ -2947,24 +2975,34 @@ void _lowerFuncDeclBaseTypeInfo(
     }
 
     auto& irResultType = outInfo.resultType;
-    irResultType = lowerType(context, getResultType(context->astBuilder, declRef));
-
-    if (auto setterDeclRef = declRef.as<SetterDecl>())
+    
+    if (parameterLists.params.getCount() && parameterLists.params.getLast().isReturnDestination)
     {
-        // A `set` accessor always returns `void`
-        //
-        // TODO: We should handle this by making the result
-        // type of a `set` accessor be represented accurately
-        // at the AST level (ditto for the `ref` case below).
-        //
-        irResultType = builder->getVoidType();
+        irResultType = context->irBuilder->getVoidType();
+        outInfo.returnViaLastRefParam = true;
     }
-
-    if( auto refAccessorDeclRef = declRef.as<RefAccessorDecl>() )
+    else
     {
-        // A `ref` accessor needs to return a *pointer* to the value
-        // being accessed, rather than a simple value.
-        irResultType = builder->getPtrType(irResultType);
+        irResultType = lowerType(context, getResultType(context->astBuilder, declRef));
+
+
+        if (auto setterDeclRef = declRef.as<SetterDecl>())
+        {
+            // A `set` accessor always returns `void`
+            //
+            // TODO: We should handle this by making the result
+            // type of a `set` accessor be represented accurately
+            // at the AST level (ditto for the `ref` case below).
+            //
+            irResultType = builder->getVoidType();
+        }
+
+        if (auto refAccessorDeclRef = declRef.as<RefAccessorDecl>())
+        {
+            // A `ref` accessor needs to return a *pointer* to the value
+            // being accessed, rather than a simple value.
+            irResultType = builder->getPtrType(irResultType);
+        }
     }
   
     if (!getErrorCodeType(context->astBuilder, declRef)->equals(context->astBuilder->getBottomType()))
@@ -3023,10 +3061,8 @@ static LoweredValInfo _emitCallToAccessor(
     return result;
 }
 
-//
-
 template<typename Derived>
-struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
+struct ExprLoweringContext
 {
     static bool isLValueContext() { return Derived::_isLValueContext(); }
 
@@ -3035,15 +3071,480 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
     IRBuilder* getBuilder() { return context->irBuilder; }
     ASTBuilder* getASTBuilder() { return context->astBuilder; }
 
+
+    struct ResolvedCallInfo
+    {
+        DeclRef<Decl>   funcDeclRef;
+        Expr* baseExpr = nullptr;
+    };
+
+    // Try to resolve a the function expression for a call
+    // into a reference to a specific declaration, along
+    // with some contextual information about the declaration
+    // we are calling.
+    bool tryResolveDeclRefForCall(
+        Expr* funcExpr,
+        ResolvedCallInfo* outInfo)
+    {
+        // TODO: unwrap any "identity" expressions that might
+        // be wrapping the callee.
+
+        // First look to see if the expression references a
+        // declaration at all.
+        auto declRefExpr = as<DeclRefExpr>(funcExpr);
+        if (!declRefExpr)
+            return false;
+
+        // A little bit of future proofing here: if we ever
+        // allow higher-order functions, then we might be
+        // calling through a variable/field that has a function
+        // type, but is not itself a function.
+        // In such a case we should be careful to not statically
+        // resolve things.
+        //
+        if (auto callableDecl = as<CallableDecl>(declRefExpr->declRef.getDecl()))
+        {
+            // Okay, the declaration is directly callable, so we can continue.
+        }
+        else
+        {
+            // The callee declaration isn't itself a callable (it must have
+            // a function type, though).
+            return false;
+        }
+
+        // Now we can look at the specific kinds of declaration references,
+        // and try to tease them apart.
+        if (auto memberFuncExpr = as<MemberExpr>(funcExpr))
+        {
+            outInfo->funcDeclRef = memberFuncExpr->declRef;
+            outInfo->baseExpr = memberFuncExpr->baseExpression;
+            return true;
+        }
+        else if (auto staticMemberFuncExpr = as<StaticMemberExpr>(funcExpr))
+        {
+            outInfo->funcDeclRef = staticMemberFuncExpr->declRef;
+            return true;
+        }
+        else if (auto varExpr = as<VarExpr>(funcExpr))
+        {
+            outInfo->funcDeclRef = varExpr->declRef;
+            return true;
+        }
+        else
+        {
+            // Seems to be a case of declaration-reference we don't know about.
+            SLANG_UNEXPECTED("unknown declaration reference kind");
+            //return false;
+        }
+    }
+
+    /// Return `expr` with any outer casts to interface types stripped away
+    Expr* maybeIgnoreCastToInterface(Expr* expr)
+    {
+        auto e = expr;
+        while (auto castExpr = as<CastToSuperTypeExpr>(e))
+        {
+            if (auto declRefType = as<DeclRefType>(e->type))
+            {
+                if (declRefType->getDeclRef().as<InterfaceDecl>())
+                {
+                    e = castExpr->valueArg;
+                    continue;
+                }
+            }
+            else if (auto andType = as<AndType>(e->type))
+            {
+                // TODO: We might eventually need to tell the difference
+                // between conjunctions of interfaces and conjunctions
+                // that might include non-interface types.
+                //
+                // For now we assume that any case to a conjunction
+                // is effectively a cast to an interface type.
+                //
+                e = castExpr->valueArg;
+                continue;
+            }
+            break;
+        }
+        return e;
+    }
+
+
     // Lower an expression that should have the same l-value-ness
     // as the visitor itself.
     LoweredValInfo lowerSubExpr(Expr* expr)
     {
         IRBuilderSourceLocRAII sourceLocInfo(getBuilder(), expr->loc);
-        return this->dispatch(expr);
+        if (isLValueContext())
+            return lowerLValueExpr(context, expr);
+        return lowerRValueExpr(context, expr);
     }
 
-    LoweredValInfo lowerSubExpr(Expr* expr, IRGenContext* subContext)
+    /// Create IR instructions for an argument at a call site, based on
+    /// AST-level expressions plus function signature information.
+    ///
+    /// The `funcType` parameter is always required, and specifies the types
+    /// of all the parameters. The `funcDeclRef` parameter is only required
+    /// if there are parameter positions for which the matching argument is
+    /// absent.
+    ///
+    void addDirectCallArgs(
+        InvokeExpr* expr,
+        Index                   argIndex,
+        IRType* paramType,
+        ParameterDirection      paramDirection,
+        DeclRef<ParamDecl>      paramDeclRef,
+        List<IRInst*>* ioArgs,
+        List<OutArgumentFixup>* ioFixups)
+    {
+        Count argCount = expr->arguments.getCount();
+        if (argIndex < argCount)
+        {
+            auto argExpr = expr->arguments[argIndex];
+            addCallArgsForParam(context, paramType, paramDirection, argExpr, ioArgs, ioFixups);
+        }
+        else
+        {
+            // We have run out of arguments supplied at the call site,
+            // but there are still parameters remaining. This must mean
+            // that these parameters have default argument expressions
+            // associated with them.
+            //
+            // Currently we simply extract the initial-value expression
+            // from the parameter declaration and then lower it in
+            // the context of the caller.
+            //
+            // Note that the expression could involve subsitutions because
+            // in the general case it could depend on the generic parameters
+            // used the specialize the callee. For now we do not handle that
+            // case, and simply ignore generic arguments.
+            //
+            SubstExpr<Expr> argExpr = getInitExpr(getASTBuilder(), paramDeclRef);
+            SLANG_ASSERT(argExpr);
+
+            IRGenEnv subEnvStorage;
+            IRGenEnv* subEnv = &subEnvStorage;
+            subEnv->outer = context->env;
+
+            IRGenContext subContextStorage = *context;
+            IRGenContext* subContext = &subContextStorage;
+            subContext->env = subEnv;
+
+            _lowerSubstitutionEnv(subContext, argExpr.getSubsts() ? argExpr.getSubsts().declRef : nullptr);
+
+            addCallArgsForParam(subContext, paramType, paramDirection, argExpr.getExpr(), ioArgs, ioFixups);
+
+            // TODO: The approach we are taking here to default arguments
+            // is simplistic, and has consequences for the front-end as
+            // well as binary serialization of modules.
+            //
+            // We could consider some more refined approaches where, e.g.,
+            // functions with default arguments generate multiple IR-level
+            // functions, that compute and provide the default values.
+            //
+            // Alternatively, each parameter with defaults could be generated
+            // into its own callable function that provides the default value,
+            // so that calling modules can call into a pre-generated function.
+            //
+            // Each of these options involves trade-offs, and we need to
+            // make a conscious decision at some point.
+
+            // Assert that such an expression must have been present.
+        }
+    }
+
+    void addDirectCallArgs(
+        InvokeExpr* expr,
+        FuncType* funcType,
+        List<IRInst*>* ioArgs,
+        List<OutArgumentFixup>* ioFixups)
+    {
+        Count argCount = expr->arguments.getCount();
+        SLANG_ASSERT(argCount == funcType->getParamCount());
+
+        for (Index i = 0; i < argCount; ++i)
+        {
+            IRType* paramType = lowerType(context, funcType->getParamType(i));
+            ParameterDirection paramDirection = funcType->getParamDirection(i);
+            addDirectCallArgs(expr, i, paramType, paramDirection, DeclRef<ParamDecl>(), ioArgs, ioFixups);
+        }
+    }
+
+    void addDirectCallArgs(
+        InvokeExpr* expr,
+        DeclRef<CallableDecl>   funcDeclRef,
+        List<IRInst*>* ioArgs,
+        List<OutArgumentFixup>* ioFixups)
+    {
+        Count argCounter = 0;
+        for (auto paramDeclRef : getMembersOfType<ParamDecl>(getASTBuilder(), funcDeclRef))
+        {
+            auto paramDecl = paramDeclRef.getDecl();
+            IRType* paramType = lowerType(context, getType(getASTBuilder(), paramDeclRef));
+            auto paramDirection = getParameterDirection(paramDecl);
+
+            Index argIndex = argCounter++;
+            addDirectCallArgs(expr, argIndex, paramType, paramDirection, paramDeclRef, ioArgs, ioFixups);
+        }
+    }
+
+    // Add arguments that appeared directly in an argument list
+    // to the list of argument values for a call.
+    void addDirectCallArgs(
+        InvokeExpr* expr,
+        DeclRef<Decl>           funcDeclRef,
+        List<IRInst*>* ioArgs,
+        List<OutArgumentFixup>* ioFixups)
+    {
+        if (auto callableDeclRef = funcDeclRef.as<CallableDecl>())
+        {
+            addDirectCallArgs(expr, callableDeclRef, ioArgs, ioFixups);
+        }
+        else
+        {
+            SLANG_UNEXPECTED("callee was not a callable decl");
+        }
+    }
+
+    void addFuncBaseArgs(
+        LoweredValInfo funcVal,
+        List<IRInst*>* /*ioArgs*/)
+    {
+        switch (funcVal.flavor)
+        {
+        default:
+            return;
+        }
+    }
+
+
+    void _lowerSubstitutionArg(IRGenContext* subContext, GenericAppDeclRef* subst, Decl* paramDecl, Index argIndex)
+    {
+        SLANG_ASSERT(argIndex < subst->getArgs().getCount());
+        auto argVal = lowerVal(subContext, subst->getArgs()[argIndex]);
+        subContext->setValue(paramDecl, argVal);
+    }
+
+    void _lowerSubstitutionEnv(IRGenContext* subContext, DeclRefBase* subst)
+    {
+        if (!subst) return;
+        _lowerSubstitutionEnv(subContext, subst->getBase());
+
+        if (auto genSubst = as<GenericAppDeclRef>(subst))
+        {
+            auto genDecl = genSubst->getGenericDecl();
+
+            Index argCounter = 0;
+            for (auto memberDecl : genDecl->members)
+            {
+                if (auto typeParamDecl = as<GenericTypeParamDecl>(memberDecl))
+                {
+                    _lowerSubstitutionArg(subContext, genSubst, typeParamDecl, argCounter++);
+                }
+                else if (auto valParamDecl = as<GenericValueParamDecl>(memberDecl))
+                {
+                    _lowerSubstitutionArg(subContext, genSubst, valParamDecl, argCounter++);
+                }
+            }
+            for (auto memberDecl : genDecl->members)
+            {
+                if (auto constraintDecl = as<GenericTypeConstraintDecl>(memberDecl))
+                {
+                    _lowerSubstitutionArg(subContext, genSubst, constraintDecl, argCounter++);
+                }
+            }
+        }
+        // TODO: also need to handle this-type substitution here?
+    }
+
+    /// Lower an invoke expr, and attempt to fuse a store of the expr's result into destination.
+    /// If the store is fused, returns LoweredValInfo::None. Otherwise, returns the IR val representing the RValue.
+    LoweredValInfo visitInvokeExprImpl(InvokeExpr* expr, LoweredValInfo destination, const TryClauseEnvironment& tryEnv)
+    {
+        auto type = lowerType(context, expr->type);
+
+        // We are going to look at the syntactic form of
+        // the "function" expression, so that we can avoid
+        // a lot of complexity that would come from lowering
+        // it as a general expression first, and then trying
+        // to apply it. For example, given `obj.f(a,b)` we
+        // will try to detect that we are trying to compute
+        // something like `ObjType::f(obj, a, b)` (in pseudo-code),
+        // rather than trying to construct a meaningful
+        // intermediate value for `obj.f` first.
+        //
+        // Note that this doe not preclude having support
+        // for directly generating code from `obj.f` - it
+        // just may be that such usage is more complicated.
+
+        // Along the way, we may end up collecting additional
+        // arguments that will be part of the call.
+        List<IRInst*> irArgs;
+
+        // We will also collect "fixup" actions that need
+        // to be performed after the call, in order to
+        // copy the final values for `out` parameters
+        // back to their arguments.
+        List<OutArgumentFixup> argFixups;
+
+        auto funcExpr = expr->functionExpr;
+        ResolvedCallInfo resolvedInfo;
+        if (tryResolveDeclRefForCall(funcExpr, &resolvedInfo))
+        {
+            // In this case we know exactly what declaration we
+            // are going to call, and so we can resolve things
+            // appropriately.
+            auto funcDeclRef = resolvedInfo.funcDeclRef;
+            auto baseExpr = resolvedInfo.baseExpr;
+
+            // If the thing being invoked is a subscript operation,
+            // then we need to handle multiple extra details
+            // that don't arise for other kinds of calls.
+            //
+            // TODO: subscript operations probably deserve to
+            // be handled on their own path for this reason...
+            //
+            if (auto subscriptDeclRef = funcDeclRef.template as<SubscriptDecl>())
+            {
+                // A reference to a subscript declaration is a special case,
+                // because it is not possible to call a subscript directly;
+                // we must call one of its accessors.
+                //
+                auto loweredBase = lowerSubExpr(baseExpr);
+                addDirectCallArgs(expr, funcDeclRef, &irArgs, &argFixups);
+                auto result = lowerStorageReference(context, type, subscriptDeclRef, loweredBase, irArgs.getCount(), irArgs.getBuffer());
+
+                // TODO: Applying the fixups for arguments to the subscript at this point
+                // won't technically be correct, since the call to the subscript may
+                // not have occured at this point.
+                //
+                // It seems like we need to either:
+                //
+                // * Capture the arguments to the subscript as `LoweredValInfo` instead of `IRInst*`
+                //   so that we can deal with everything related to fixups around the actual call
+                //   site.
+                //
+                // OR
+                //
+                // * Handle everything to do with "fixups" differently, by treating them as deferred
+                // actions that gert queued up on the context itself and then flushed at certain
+                // well-defined points, so that we don't have to be as careful around them.
+                //
+                // OR
+                //
+                // * Switch to a more "destination-driven" approach to code generation, where we
+                // can determine on entry to the lowering of a sub-expression whether it will be
+                // used for read, write, or read/write, and resolve things like the choice of
+                // accessor at that point instead.
+                //
+                applyOutArgumentFixups(context, argFixups);
+                return result;
+            }
+
+            // First comes the `this` argument if we are calling
+            // a member function:
+            if (baseExpr)
+            {
+                // The base expression might be an "upcast" to a base interface, in
+                // which case we don't want to emit the result of the cast, but instead
+                // the source.
+                //
+                baseExpr = maybeIgnoreCastToInterface(baseExpr);
+
+                auto thisType = getThisParamTypeForCallable(context, funcDeclRef);
+                auto irThisType = lowerType(context, thisType);
+                addCallArgsForParam(
+                    context,
+                    irThisType,
+                    getThisParamDirection(funcDeclRef.getDecl(), kParameterDirection_In),
+                    baseExpr,
+                    &irArgs,
+                    &argFixups);
+            }
+
+            // Then we have the "direct" arguments to the call.
+            // These may include `out` and `inout` arguments that
+            // require "fixup" work on the other side.
+            //
+            FuncDeclBaseTypeInfo funcTypeInfo;
+            _lowerFuncDeclBaseTypeInfo(context, funcDeclRef.template as<FunctionDeclBase>(), funcTypeInfo);
+
+            auto funcType = funcTypeInfo.type;
+            addDirectCallArgs(expr, funcDeclRef, &irArgs, &argFixups);
+
+            LoweredValInfo result;
+            if (funcTypeInfo.returnViaLastRefParam)
+            {
+                // If the function returns a non-copyable type, then we need to
+                // pass in the destination that receives the result value as an `__ref` parameter.
+                //
+                if (destination.flavor != LoweredValInfo::Flavor::None)
+                {
+                    // If we have a known destination, we can use it directly as argument to the call.
+                    irArgs.add(destination.val);
+                    result = LoweredValInfo();
+                }
+                else
+                {
+                    // Otherwise, we need to create a temporary variable to hold the result.
+                    //
+                    auto tempVar = context->irBuilder->emitVar(tryGetPointedToType(context->irBuilder, funcTypeInfo.paramTypes.getLast()));
+                    irArgs.add(tempVar);
+                    result = LoweredValInfo::ptr(tempVar);
+                }
+            }
+
+            auto callResult = emitCallToDeclRef(
+                context,
+                type,
+                funcDeclRef,
+                funcType,
+                irArgs,
+                tryEnv);
+            applyOutArgumentFixups(context, argFixups);
+            
+            if (funcTypeInfo.returnViaLastRefParam)
+                return result;
+            return callResult;
+        }
+        else if (auto funcType = as<FuncType>(expr->functionExpr->type))
+        {
+            auto funcVal = lowerRValueExpr(context, expr->functionExpr);
+            addDirectCallArgs(expr, funcType, &irArgs, &argFixups);
+
+            auto result = emitCallToVal(context, type, funcVal, irArgs.getCount(), irArgs.getBuffer(), tryEnv);
+
+            applyOutArgumentFixups(context, argFixups);
+            return result;
+        }
+
+
+        // TODO: In this case we should be emitting code for the callee as
+        // an ordinary expression, then emitting the arguments according
+        // to the type information on the callee (e.g., which parameters
+        // are `out` or `inout`, and then finally emitting the `call`
+        // instruction.
+        //
+        // We don't currently have the case of emitting arguments according
+        // to function type info (instead of declaration info), and really
+        // this case can't occur unless we start adding first-class functions
+        // to the source language.
+        //
+        // For now we just bail out with an error.
+        //
+        SLANG_UNEXPECTED("could not resolve target declaration for call");
+        UNREACHABLE_RETURN(LoweredValInfo());
+    }
+
+};
+
+template<typename Derived>
+struct ExprLoweringVisitorBase : public ExprVisitor<Derived, LoweredValInfo>, public ExprLoweringContext<Derived>
+{
+    static bool isLValueContext() { return Derived::_isLValueContext(); }
+
+    LoweredValInfo lowerSubExprWithSubContext(Expr* expr, IRGenContext* subContext)
     {
         IRBuilderSourceLocRAII sourceLocInfo(getBuilder(), expr->loc);
         Derived d;
@@ -3378,6 +3879,11 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
     LoweredValInfo visitThisExpr(ThisExpr* /*expr*/)
     {
         return context->thisVal;
+    }
+
+    LoweredValInfo visitReturnValExpr(ReturnValExpr*)
+    {
+        return context->returnDestination;
     }
 
     LoweredValInfo visitMemberExpr(MemberExpr* expr)
@@ -3812,281 +4318,6 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         UNREACHABLE_RETURN(LoweredValInfo());
     }
 
-    void _lowerSubstitutionArg(IRGenContext* subContext, GenericAppDeclRef* subst, Decl* paramDecl, Index argIndex)
-    {
-        SLANG_ASSERT(argIndex < subst->getArgs().getCount());
-        auto argVal = lowerVal(subContext, subst->getArgs()[argIndex]);
-        subContext->setValue(paramDecl, argVal);
-    }
-
-    void _lowerSubstitutionEnv(IRGenContext* subContext, DeclRefBase* subst)
-    {
-        if(!subst) return;
-        _lowerSubstitutionEnv(subContext, subst->getBase());
-
-        if (auto genSubst = as<GenericAppDeclRef>(subst))
-        {
-            auto genDecl = genSubst->getGenericDecl();
-
-            Index argCounter = 0;
-            for( auto memberDecl: genDecl->members )
-            {
-                if(auto typeParamDecl = as<GenericTypeParamDecl>(memberDecl) )
-                {
-                    _lowerSubstitutionArg(subContext, genSubst, typeParamDecl, argCounter++);
-                }
-                else if( auto valParamDecl = as<GenericValueParamDecl>(memberDecl) )
-                {
-                    _lowerSubstitutionArg(subContext, genSubst, valParamDecl, argCounter++);
-                }
-            }
-            for( auto memberDecl: genDecl->members )
-            {
-                if(auto constraintDecl = as<GenericTypeConstraintDecl>(memberDecl) )
-                {
-                    _lowerSubstitutionArg(subContext, genSubst, constraintDecl, argCounter++);
-                }
-            }
-        }
-        // TODO: also need to handle this-type substitution here?
-    }
-
-        /// Create IR instructions for an argument at a call site, based on
-        /// AST-level expressions plus function signature information.
-        ///
-        /// The `funcType` parameter is always required, and specifies the types
-        /// of all the parameters. The `funcDeclRef` parameter is only required
-        /// if there are parameter positions for which the matching argument is
-        /// absent.
-        ///
-    void addDirectCallArgs(
-        InvokeExpr*             expr,
-        Index                   argIndex,
-        IRType*                 paramType,
-        ParameterDirection      paramDirection,
-        DeclRef<ParamDecl>      paramDeclRef,
-        List<IRInst*>*          ioArgs,
-        List<OutArgumentFixup>* ioFixups)
-    {
-        Count argCount = expr->arguments.getCount();
-        if (argIndex < argCount)
-        {
-            auto argExpr = expr->arguments[argIndex];
-            addCallArgsForParam(context, paramType, paramDirection, argExpr, ioArgs, ioFixups);
-        }
-        else
-        {
-            // We have run out of arguments supplied at the call site,
-            // but there are still parameters remaining. This must mean
-            // that these parameters have default argument expressions
-            // associated with them.
-            //
-            // Currently we simply extract the initial-value expression
-            // from the parameter declaration and then lower it in
-            // the context of the caller.
-            //
-            // Note that the expression could involve subsitutions because
-            // in the general case it could depend on the generic parameters
-            // used the specialize the callee. For now we do not handle that
-            // case, and simply ignore generic arguments.
-            //
-            SubstExpr<Expr> argExpr = getInitExpr(getASTBuilder(), paramDeclRef);
-            SLANG_ASSERT(argExpr);
-
-            IRGenEnv subEnvStorage;
-            IRGenEnv* subEnv = &subEnvStorage;
-            subEnv->outer = context->env;
-
-            IRGenContext subContextStorage = *context;
-            IRGenContext* subContext = &subContextStorage;
-            subContext->env = subEnv;
-
-            _lowerSubstitutionEnv(subContext, argExpr.getSubsts() ? argExpr.getSubsts().declRef : nullptr);
-
-            addCallArgsForParam(subContext, paramType, paramDirection, argExpr.getExpr(), ioArgs, ioFixups);
-
-            // TODO: The approach we are taking here to default arguments
-            // is simplistic, and has consequences for the front-end as
-            // well as binary serialization of modules.
-            //
-            // We could consider some more refined approaches where, e.g.,
-            // functions with default arguments generate multiple IR-level
-            // functions, that compute and provide the default values.
-            //
-            // Alternatively, each parameter with defaults could be generated
-            // into its own callable function that provides the default value,
-            // so that calling modules can call into a pre-generated function.
-            //
-            // Each of these options involves trade-offs, and we need to
-            // make a conscious decision at some point.
-
-            // Assert that such an expression must have been present.
-        }
-    }
-
-    void addDirectCallArgs(
-        InvokeExpr*             expr,
-        FuncType*               funcType,
-        List<IRInst*>*          ioArgs,
-        List<OutArgumentFixup>* ioFixups)
-    {
-        Count argCount = expr->arguments.getCount();
-        SLANG_ASSERT(argCount == funcType->getParamCount());
-
-        for(Index i = 0; i < argCount; ++i)
-        {
-            IRType* paramType = lowerType(context, funcType->getParamType(i));
-            ParameterDirection paramDirection = funcType->getParamDirection(i);
-            addDirectCallArgs(expr, i, paramType, paramDirection, DeclRef<ParamDecl>(), ioArgs, ioFixups);
-        }
-    }
-
-
-    void addDirectCallArgs(
-        InvokeExpr*             expr,
-        DeclRef<CallableDecl>   funcDeclRef,
-        List<IRInst*>*          ioArgs,
-        List<OutArgumentFixup>* ioFixups)
-    {
-        Count argCounter = 0;
-        for (auto paramDeclRef : getMembersOfType<ParamDecl>(getASTBuilder(), funcDeclRef))
-        {
-            auto paramDecl = paramDeclRef.getDecl();
-            IRType* paramType = lowerType(context, getType(getASTBuilder(), paramDeclRef));
-            auto paramDirection = getParameterDirection(paramDecl);
-
-            Index argIndex = argCounter++;
-            addDirectCallArgs(expr, argIndex, paramType, paramDirection, paramDeclRef, ioArgs, ioFixups);
-        }
-    }
-
-    // Add arguments that appeared directly in an argument list
-    // to the list of argument values for a call.
-    void addDirectCallArgs(
-        InvokeExpr*             expr,
-        DeclRef<Decl>           funcDeclRef,
-        List<IRInst*>*         ioArgs,
-        List<OutArgumentFixup>* ioFixups)
-    {
-        if (auto callableDeclRef = funcDeclRef.as<CallableDecl>())
-        {
-            addDirectCallArgs(expr, callableDeclRef, ioArgs, ioFixups);
-        }
-        else
-        {
-            SLANG_UNEXPECTED("callee was not a callable decl");
-        }
-    }
-
-    void addFuncBaseArgs(
-        LoweredValInfo funcVal,
-        List<IRInst*>* /*ioArgs*/)
-    {
-        switch (funcVal.flavor)
-        {
-        default:
-            return;
-        }
-    }
-
-    struct ResolvedCallInfo
-    {
-        DeclRef<Decl>   funcDeclRef;
-        Expr*           baseExpr = nullptr;
-    };
-
-    // Try to resolve a the function expression for a call
-    // into a reference to a specific declaration, along
-    // with some contextual information about the declaration
-    // we are calling.
-    bool tryResolveDeclRefForCall(
-        Expr*        funcExpr,
-        ResolvedCallInfo*   outInfo)
-    {
-        // TODO: unwrap any "identity" expressions that might
-        // be wrapping the callee.
-
-        // First look to see if the expression references a
-        // declaration at all.
-        auto declRefExpr = as<DeclRefExpr>(funcExpr);
-        if(!declRefExpr)
-            return false;
-
-        // A little bit of future proofing here: if we ever
-        // allow higher-order functions, then we might be
-        // calling through a variable/field that has a function
-        // type, but is not itself a function.
-        // In such a case we should be careful to not statically
-        // resolve things.
-        //
-        if(auto callableDecl = as<CallableDecl>(declRefExpr->declRef.getDecl()))
-        {
-            // Okay, the declaration is directly callable, so we can continue.
-        }
-        else
-        {
-            // The callee declaration isn't itself a callable (it must have
-            // a function type, though).
-            return false;
-        }
-
-        // Now we can look at the specific kinds of declaration references,
-        // and try to tease them apart.
-        if (auto memberFuncExpr = as<MemberExpr>(funcExpr))
-        {
-            outInfo->funcDeclRef = memberFuncExpr->declRef;
-            outInfo->baseExpr = memberFuncExpr->baseExpression;
-            return true;
-        }
-        else if (auto staticMemberFuncExpr = as<StaticMemberExpr>(funcExpr))
-        {
-            outInfo->funcDeclRef = staticMemberFuncExpr->declRef;
-            return true;
-        }
-        else if (auto varExpr = as<VarExpr>(funcExpr))
-        {
-            outInfo->funcDeclRef = varExpr->declRef;
-            return true;
-        }
-        else
-        {
-            // Seems to be a case of declaration-reference we don't know about.
-            SLANG_UNEXPECTED("unknown declaration reference kind");
-            //return false;
-        }
-    }
-
-        /// Return `expr` with any outer casts to interface types stripped away
-    Expr* maybeIgnoreCastToInterface(Expr* expr)
-    {
-        auto e = expr;
-        while( auto castExpr = as<CastToSuperTypeExpr>(e) )
-        {
-            if(auto declRefType = as<DeclRefType>(e->type))
-            {
-                if(declRefType->getDeclRef().as<InterfaceDecl>())
-                {
-                    e = castExpr->valueArg;
-                    continue;
-                }
-            }
-            else if( auto andType = as<AndType>(e->type) )
-            {
-                // TODO: We might eventually need to tell the difference
-                // between conjunctions of interfaces and conjunctions
-                // that might include non-interface types.
-                //
-                // For now we assume that any case to a conjunction
-                // is effectively a cast to an interface type.
-                //
-                e = castExpr->valueArg;
-                continue;
-            }
-            break;
-        }
-        return e;
-    }
-
     LoweredValInfo visitSelectExpr(SelectExpr* expr)
     {
         // A vector typed `select` expr will turn into a normal `select` op.
@@ -4126,158 +4357,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
 
     LoweredValInfo visitInvokeExpr(InvokeExpr* expr)
     {
-        return visitInvokeExprImpl(expr, TryClauseEnvironment());
-    }
-
-    LoweredValInfo visitInvokeExprImpl(InvokeExpr* expr, const TryClauseEnvironment& tryEnv)
-    {
-        auto type = lowerType(context, expr->type);
-
-        // We are going to look at the syntactic form of
-        // the "function" expression, so that we can avoid
-        // a lot of complexity that would come from lowering
-        // it as a general expression first, and then trying
-        // to apply it. For example, given `obj.f(a,b)` we
-        // will try to detect that we are trying to compute
-        // something like `ObjType::f(obj, a, b)` (in pseudo-code),
-        // rather than trying to construct a meaningful
-        // intermediate value for `obj.f` first.
-        //
-        // Note that this doe not preclude having support
-        // for directly generating code from `obj.f` - it
-        // just may be that such usage is more complicated.
-
-        // Along the way, we may end up collecting additional
-        // arguments that will be part of the call.
-        List<IRInst*> irArgs;
-
-        // We will also collect "fixup" actions that need
-        // to be performed after the call, in order to
-        // copy the final values for `out` parameters
-        // back to their arguments.
-        List<OutArgumentFixup> argFixups;
-
-        auto funcExpr = expr->functionExpr;
-        ResolvedCallInfo resolvedInfo;
-        if (tryResolveDeclRefForCall(funcExpr, &resolvedInfo))
-        {
-            // In this case we know exactly what declaration we
-            // are going to call, and so we can resolve things
-            // appropriately.
-            auto funcDeclRef = resolvedInfo.funcDeclRef;
-            auto baseExpr = resolvedInfo.baseExpr;
-
-            // If the thing being invoked is a subscript operation,
-            // then we need to handle multiple extra details
-            // that don't arise for other kinds of calls.
-            //
-            // TODO: subscript operations probably deserve to
-            // be handled on their own path for this reason...
-            //
-            if (auto subscriptDeclRef = funcDeclRef.template as<SubscriptDecl>())
-            {
-                // A reference to a subscript declaration is a special case,
-                // because it is not possible to call a subscript directly;
-                // we must call one of its accessors.
-                //
-                auto loweredBase = lowerSubExpr(baseExpr);
-                addDirectCallArgs(expr, funcDeclRef, &irArgs, &argFixups);
-                auto result = lowerStorageReference(context, type, subscriptDeclRef, loweredBase, irArgs.getCount(), irArgs.getBuffer());
-
-                // TODO: Applying the fixups for arguments to the subscript at this point
-                // won't technically be correct, since the call to the subscript may
-                // not have occured at this point.
-                //
-                // It seems like we need to either:
-                //
-                // * Capture the arguments to the subscript as `LoweredValInfo` instead of `IRInst*`
-                //   so that we can deal with everything related to fixups around the actual call
-                //   site.
-                //
-                // OR
-                //
-                // * Handle everything to do with "fixups" differently, by treating them as deferred
-                // actions that gert queued up on the context itself and then flushed at certain
-                // well-defined points, so that we don't have to be as careful around them.
-                //
-                // OR
-                //
-                // * Switch to a more "destination-driven" approach to code generation, where we
-                // can determine on entry to the lowering of a sub-expression whether it will be
-                // used for read, write, or read/write, and resolve things like the choice of
-                // accessor at that point instead.
-                //
-                applyOutArgumentFixups(context, argFixups);
-                return result;
-            }
-
-            // First comes the `this` argument if we are calling
-            // a member function:
-            if (baseExpr)
-            {
-                // The base expression might be an "upcast" to a base interface, in
-                // which case we don't want to emit the result of the cast, but instead
-                // the source.
-                //
-                baseExpr = maybeIgnoreCastToInterface(baseExpr);
-
-                auto thisType = getThisParamTypeForCallable(context, funcDeclRef);
-                auto irThisType = lowerType(context, thisType);
-                addCallArgsForParam(
-                    context,
-                    irThisType,
-                    getThisParamDirection(funcDeclRef.getDecl(), kParameterDirection_In),
-                    baseExpr,
-                    &irArgs,
-                    &argFixups);
-            }
-
-            // Then we have the "direct" arguments to the call.
-            // These may include `out` and `inout` arguments that
-            // require "fixup" work on the other side.
-            //
-            FuncDeclBaseTypeInfo funcTypeInfo;
-            _lowerFuncDeclBaseTypeInfo(context, funcDeclRef.template as<FunctionDeclBase>(), funcTypeInfo);
-
-            auto funcType = funcTypeInfo.type;
-            addDirectCallArgs(expr, funcDeclRef, &irArgs, &argFixups);
-            auto result = emitCallToDeclRef(
-                context,
-                type,
-                funcDeclRef,
-                funcType,
-                irArgs,
-                tryEnv);
-            applyOutArgumentFixups(context, argFixups);
-            return result;
-        }
-        else if(auto funcType = as<FuncType>(expr->functionExpr->type))
-        {
-            auto funcVal = lowerRValueExpr(context, expr->functionExpr);
-            addDirectCallArgs(expr, funcType, &irArgs, &argFixups);
-
-            auto result = emitCallToVal(context, type, funcVal, irArgs.getCount(), irArgs.getBuffer(), tryEnv);
-
-            applyOutArgumentFixups(context, argFixups);
-            return result;
-        }
-        
-
-        // TODO: In this case we should be emitting code for the callee as
-        // an ordinary expression, then emitting the arguments according
-        // to the type information on the callee (e.g., which parameters
-        // are `out` or `inout`, and then finally emitting the `call`
-        // instruction.
-        //
-        // We don't currently have the case of emitting arguments according
-        // to function type info (instead of declaration info), and really
-        // this case can't occur unless we start adding first-class functions
-        // to the source language.
-        //
-        // For now we just bail out with an error.
-        //
-        SLANG_UNEXPECTED("could not resolve target declaration for call");
-        UNREACHABLE_RETURN(LoweredValInfo());
+        return visitInvokeExprImpl(expr, LoweredValInfo(), TryClauseEnvironment());
     }
 
         /// Emit code for a `try` invoke.
@@ -4287,7 +4367,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         assert(invokeExpr);
         TryClauseEnvironment tryEnv;
         tryEnv.clauseType = expr->tryClauseType;
-        return visitInvokeExprImpl(invokeExpr, tryEnv);
+        return visitInvokeExprImpl(invokeExpr, LoweredValInfo(), tryEnv);
     }
 
         /// Emit code to cast `value` to a concrete `superType` (e.g., a `struct`).
@@ -4540,8 +4620,7 @@ struct ExprLoweringVisitorBase : ExprVisitor<Derived, LoweredValInfo>
         // based on the resulting values.
         //
         auto leftVal = lowerLValueExpr(context, expr->left);
-        auto rightVal = lowerRValueExpr(context, expr->right);
-        assign(context, leftVal, rightVal);
+        assignExpr(context, leftVal, expr->right);
 
         // The result value of the assignment expression is
         // the value of the left-hand side (and it is expected
@@ -4780,7 +4859,7 @@ struct LValueExprLoweringVisitor : ExprLoweringVisitorBase<LValueExprLoweringVis
     }
 };
 
-struct RValueExprLoweringVisitor : ExprLoweringVisitorBase<RValueExprLoweringVisitor>
+struct RValueExprLoweringVisitor : public ExprLoweringVisitorBase<RValueExprLoweringVisitor>
 {
     static bool _isLValueContext() { return false; }
 
@@ -4868,6 +4947,46 @@ struct RValueExprLoweringVisitor : ExprLoweringVisitorBase<RValueExprLoweringVis
     }
 };
 
+// ExprLoweringVisitor that fuses the destination assignment.
+//
+struct DestinationDrivenRValueExprLoweringVisitor 
+    : ExprVisitor<DestinationDrivenRValueExprLoweringVisitor>
+    , ExprLoweringContext<DestinationDrivenRValueExprLoweringVisitor>
+{
+    LoweredValInfo destination;
+
+    static bool _isLValueContext() { return false; }
+
+    // The default case is lower the rvalue expr independently and then assign to destination.
+    void visitExpr(Expr* expr)
+    {
+        auto rValue = lowerRValueExpr(context, expr);
+        assign(context, destination, rValue);
+    }
+
+    void visitInvokeExpr(InvokeExpr* expr)
+    {
+        auto resultRVal = visitInvokeExprImpl(expr, destination, TryClauseEnvironment{});
+        if (resultRVal.flavor != LoweredValInfo::Flavor::None)
+        {
+            // If we weren't able to fuse the destination write during lowering rvalue,
+            // we should insert the assign operation now.
+            assign(context, destination, resultRVal);
+        }
+    }
+
+    /// Emit code for a `try` invoke.
+    LoweredValInfo visitTryExpr(TryExpr* expr)
+    {
+        auto invokeExpr = as<InvokeExpr>(expr->base);
+        assert(invokeExpr);
+        TryClauseEnvironment tryEnv;
+        tryEnv.clauseType = expr->tryClauseType;
+        return visitInvokeExprImpl(invokeExpr, destination, tryEnv);
+    }
+
+};
+
 LoweredValInfo lowerLValueExpr(
     IRGenContext*   context,
     Expr*           expr)
@@ -4890,6 +5009,19 @@ LoweredValInfo lowerRValueExpr(
     visitor.context = context;
     auto info = visitor.dispatch(expr);
     return info;
+}
+
+void lowerRValueExprWithDestination(
+    IRGenContext* context,
+    LoweredValInfo destination,
+    Expr* expr)
+{
+    IRBuilderSourceLocRAII sourceLocInfo(context->irBuilder, expr->loc);
+
+    DestinationDrivenRValueExprLoweringVisitor visitor;
+    visitor.context = context;
+    visitor.destination = destination;
+    visitor.dispatch(expr);
 }
 
 struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
@@ -5464,6 +5596,14 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
         //
         if( auto expr = stmt->expression )
         {
+            if (context->returnDestination.flavor != LoweredValInfo::Flavor::None)
+            {
+                // If this function should return via a __ref parameter, do that and return void.
+                lowerRValueExprWithDestination(context, context->returnDestination, expr);
+                getBuilder()->emitReturn();
+                return;
+            }
+
             // If the AST `return` statement had an expression, then we
             // need to lower it to the IR at this point, both to
             // compute its value and (in case we are returning a
@@ -6123,6 +6263,28 @@ IRInst* getAddress(
 
     context->getSink()->diagnose(diagnosticLocation, Diagnostics::invalidLValueForRefParameter);
     return nullptr;
+}
+
+void assignExpr(
+    IRGenContext* context,
+    const LoweredValInfo& inLeft,
+    Expr* rightExpr)
+{
+    auto left = tryGetAddress(context, inLeft, TryGetAddressMode::Default);
+    switch (left.flavor)
+    {
+    case LoweredValInfo::Flavor::Ptr:
+        {
+            lowerRValueExprWithDestination(context, left, rightExpr);
+        }
+        break;
+    default:
+        {
+            auto right = lowerRValueExpr(context, rightExpr);
+            assign(context, inLeft, right);
+        }
+        break;
+    }
 }
 
 void assign(
@@ -7228,6 +7390,8 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
             subContextStorage.thisType = outerContext->thisType;
             subContextStorage.thisTypeWitness = outerContext->thisTypeWitness;
+
+            subContextStorage.returnDestination = LoweredValInfo();
         }
 
         IRBuilder* getBuilder() { return &subBuilderStorage; }
@@ -7381,9 +7545,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         if( auto initExpr = decl->initExpr )
         {
-            auto initVal = lowerRValueExpr(context, initExpr);
-
-            assign(context, varVal, initVal);
+            assignExpr(context, varVal, initExpr);
         }
 
         context->setGlobalValue(decl, varVal);
@@ -8700,6 +8862,9 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
                     paramVal = LoweredValInfo::ptr(irParam);
 
+                    if (paramInfo.isReturnDestination)
+                        subContext->returnDestination = paramVal;
+
                     // TODO: We might want to copy the pointed-to value into
                     // a temporary at the start of the function, and then copy
                     // back out at the end, so that we don't have to worry
@@ -8815,14 +8980,19 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             auto constructorDecl = as<ConstructorDecl>(decl);
             if (constructorDecl)
             {
-                auto thisVar = subContext->irBuilder->emitVar(irResultType);
-                subContext->thisVal = LoweredValInfo::ptr(thisVar);
-
-                // For class-typed objects, we need to allocate it from heap.
-                if (isClassType(irResultType))
+                if (subContext->returnDestination.flavor != LoweredValInfo::Flavor::None)
+                    subContext->thisVal = subContext->returnDestination;
+                else
                 {
-                    auto allocatedObj = subContext->irBuilder->emitAllocObj(irResultType);
-                    subContext->irBuilder->emitStore(thisVar, allocatedObj);
+                    auto thisVar = subContext->irBuilder->emitVar(irResultType);
+                    subContext->thisVal = LoweredValInfo::ptr(thisVar);
+
+                    // For class-typed objects, we need to allocate it from heap.
+                    if (isClassType(irResultType))
+                    {
+                        auto allocatedObj = subContext->irBuilder->emitAllocObj(irResultType);
+                        subContext->irBuilder->emitStore(thisVar, allocatedObj);
+                    }
                 }
             }
 
@@ -8846,8 +9016,13 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                     // path in an initializer/constructor attempts
                     // to do an early `return;`.
                     //
-                    subContext->irBuilder->emitReturn(
-                        getSimpleVal(subContext, subContext->thisVal));
+                    if (subContext->returnDestination.flavor != LoweredValInfo::Flavor::None)
+                        subContext->irBuilder->emitReturn();
+                    else
+                    {
+                        subContext->irBuilder->emitReturn(
+                            getSimpleVal(subContext, subContext->thisVal));
+                    }
                 }
                 else if (as<IRVoidType>(irResultType))
                 {

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -5299,6 +5299,13 @@ namespace Slang
         return expr;
     }
 
+    static NodeBase* parseReturnValExpr(Parser* parser, void* /*userData*/)
+    {
+        ReturnValExpr* expr = parser->astBuilder->create<ReturnValExpr>();
+        expr->scope = parser->currentScope;
+        return expr;
+    }
+
     static Expr* parseBoolLitExpr(Parser* parser, bool value)
     {
         BoolLiteralExpr* expr = parser->astBuilder->create<BoolLiteralExpr>();
@@ -7314,6 +7321,7 @@ namespace Slang
         _makeParseExpr("this",  parseThisExpr),
         _makeParseExpr("true",  parseTrueExpr),
         _makeParseExpr("false", parseFalseExpr),
+        _makeParseExpr("__return_val", parseReturnValExpr),
         _makeParseExpr("nullptr", parseNullPtrExpr),
         _makeParseExpr("none", parseNoneExpr),
         _makeParseExpr("try",     parseTryExpr),

--- a/tests/bindings/hlsl-to-vulkan-shift-rw-structured.hlsl
+++ b/tests/bindings/hlsl-to-vulkan-shift-rw-structured.hlsl
@@ -1,10 +1,10 @@
 //TEST:SIMPLE(filecheck=CHECK):-target glsl -profile glsl_450 -entry MainCs -stage compute  -fvk-b-shift 0 0 -fvk-s-shift 14 0 -fvk-t-shift 30 0 -fvk-u-shift 158 0
 
 
-// CHECK: layout(std430, binding = 159) buffer  
-// CHECK: } g_ByteBuffer
+// CHECK-DAG: layout(std430, binding = 159) buffer  
+// CHECK-DAG: } g_ByteBuffer
 
-// CHECK: layout(std430, binding = 158) buffer  
+// CHECK-DAG: layout(std430, binding = 158) buffer  
 
 RWStructuredBuffer<uint> g_OutputCullBits;
 RWByteAddressBuffer g_ByteBuffer;

--- a/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-assign.slang
+++ b/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-assign.slang
@@ -1,7 +1,7 @@
 // hit-object-assign.slang
 
 //TEST:SIMPLE: -target dxil -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -DNV_SHADER_EXTN_SLOT=u0 
-//TEST:SIMPLE: -target glsl -entry rayGenerationMain -stage raygeneration -profile glsl_460+GL_EXT_ray_tracing -O0 -line-directive-mode none 
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -entry rayGenerationMain -stage raygeneration -profile glsl_460+GL_EXT_ray_tracing -O0 -line-directive-mode none 
 
 //DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -output-using-type -profile sm_6_5 -nvapi-slot u0 
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-d3d12 -output-using-type -use-dxil -profile sm_6_5 -render-feature ray-query
@@ -9,6 +9,9 @@
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
+
+// SPIRV: OpHitObjectRecordMissNV
+// SPIRV: OpHitObjectIsMissNV
 
 void rayGenerationMain()
 {    

--- a/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-make-hit.slang
+++ b/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-make-hit.slang
@@ -1,7 +1,7 @@
 // hit-object-make-hit.slang
 
 //TEST:SIMPLE: -target dxil -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -DNV_SHADER_EXTN_SLOT=u0 
-//TEST:SIMPLE: -target glsl -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -line-directive-mode none 
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -line-directive-mode none 
 
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-d3d12 -output-using-type -use-dxil -profile sm_6_5 -render-feature ray-query
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-vk -output-using-type -render-feature ray-query
@@ -18,8 +18,16 @@ struct SomeValues
     float b;
 };
 
+
 uint calcValue(HitObject hit)
 {
+    // SPIRV-DAG: OpHitObjectIsHitNV
+    // SPIRV: OpHitObjectGetInstanceCustomIndexNV
+    // SPIRV: OpHitObjectGetInstanceIdNV
+    // SPIRV: OpHitObjectGetGeometryIndexNV
+    // SPIRV: OpHitObjectGetPrimitiveIndexNV
+    // SPIRV: OpHitObjectGetHitKindNV
+    // SPIRV: OpHitObjectIsMissNV
     uint r = 0;
     
     if (hit.IsHit())
@@ -72,6 +80,7 @@ void rayGenerationMain()
 
     uint r = 0;
     {
+        // SPIRV-DAG: OpHitObjectRecordHitNV
         HitObject hit = HitObject::MakeHit(0, scene, idx, idx * 2, idx * 3, hitKind, ray, someValues);
         
         r = calcValue(hit);

--- a/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-make-miss.slang
+++ b/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-make-miss.slang
@@ -1,7 +1,7 @@
 // hit-object-make-miss.slang
 
-//TEST:SIMPLE: -target dxil -entry computeMain -stage compute -profile sm_6_5 -DNV_SHADER_EXTN_SLOT=u0 
-//TEST:SIMPLE: -target glsl -entry computeMain -stage compute -profile sm_6_5 -line-directive-mode none 
+//TEST:SIMPLE: -target dxil -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -DNV_SHADER_EXTN_SLOT=u0
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -line-directive-mode none 
 
 //DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -output-using-type -profile sm_6_5 -nvapi-slot u0 
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-d3d12 -output-using-type -use-dxil -profile sm_6_5 -render-feature ray-query
@@ -10,19 +10,19 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
 
-[numthreads(4, 1, 1)]
-void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
-{    
-    int idx = int(dispatchThreadID.x);
+void rayGenerationMain()
+{
+    int idx = DispatchRaysIndex().x;
 
     RayDesc ray;  
     ray.Origin = float3(idx, 0, 0);
     ray.TMin = 0.01f;
     ray.Direction = float3(0, 1, 0);
     ray.TMax = 1e4f;
-    
+    // SPIRV: OpHitObjectRecordMissNV
     HitObject hit = HitObject::MakeMiss(idx, ray);
-    
+
+    // SPIRV: OpHitObjectIsMissNV
     int r = int(hit.IsMiss());
     
     outputBuffer[idx] = r;

--- a/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-make-nop.slang
+++ b/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-make-nop.slang
@@ -1,7 +1,7 @@
 // hit-object-make-nop.slang
 
 //TEST:SIMPLE: -target dxil -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -DNV_SHADER_EXTN_SLOT=u0 
-//TEST:SIMPLE: -target glsl -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -line-directive-mode none 
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -line-directive-mode none 
 
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-d3d12 -output-using-type -use-dxil -profile sm_6_5 -render-feature ray-query
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-vk -output-using-type -render-feature ray-query
@@ -16,6 +16,7 @@ void rayGenerationMain()
 
     int idx = launchID.x;
 
+    // SPIRV: OpHitObjectRecordEmptyNV
     HitObject hit = HitObject::MakeNop();
     
     outputBuffer[idx] = uint(hit.IsNop());

--- a/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-output.slang
+++ b/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-output.slang
@@ -4,7 +4,7 @@
 // as function results (including `out` parameters)
 
 //TEST:SIMPLE: -target dxil -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -DNV_SHADER_EXTN_SLOT=u0
-//TEST:SIMPLE: -target glsl -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -line-directive-mode none 
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -line-directive-mode none 
 
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-d3d12 -output-using-type -use-dxil -profile sm_6_5 -render-feature ray-query
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-vk -output-using-type -render-feature ray-query
@@ -57,7 +57,8 @@ HitObject myTraceRay(uint idx)
     uint multiplierForGeometryContributionToHitGroupIndex = 4;
     uint missShaderIndex = 0;
 
-    HitObject hit = HitObject::TraceRay(scene,
+    // SPIRV-DAG: OpHitObjectTraceRayNV
+    return HitObject::TraceRay(scene,
         rayFlags, 
         instanceInclusionMask, 
         rayContributionToHitGroupIndex, 
@@ -65,8 +66,6 @@ HitObject myTraceRay(uint idx)
         missShaderIndex, 
         ray, 
         payload);
-
-    return hit;
 }
 
 void copyHitObjectHandle(
@@ -94,16 +93,20 @@ void rayGenerationMain()
 
     accumulate(r, hit);
 
+#if 0 // cannot support this right now
     HitObject hit2;
     copyHitObjectHandle(hit2, hit);
 
     accumulate(r, hit2);
+#else
+    accumulate(r, hit);
 
-    HitObject hitBackup = hit;
+#endif
+
     myMakeMiss(idx, hit);
 
     accumulate(r, hit);
-    accumulate(r, hitBackup);
+    accumulate(r, hit);
 
     outputBuffer[idx] = r;
 }

--- a/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-reorder-thread.slang
+++ b/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-reorder-thread.slang
@@ -1,7 +1,7 @@
 // hit-object-reorder-thread.slang
 
 //TEST:SIMPLE: -target dxil -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -DNV_SHADER_EXTN_SLOT=u0
-//TEST:SIMPLE: -target glsl -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -line-directive-mode none 
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -line-directive-mode none 
 
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-d3d12 -output-using-type -use-dxil -profile sm_6_5 -render-feature ray-query
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-vk -output-using-type -render-feature ray-query
@@ -62,6 +62,7 @@ void rayGenerationMain()
     uint multiplierForGeometryContributionToHitGroupIndex = 4;
     uint missShaderIndex = 0;
 
+    // SPIRV: OpHitObjectTraceRayNV
     HitObject hit = HitObject::TraceRay(scene, 
         rayFlags, 
         instanceInclusionMask, 
@@ -70,42 +71,47 @@ void rayGenerationMain()
         missShaderIndex, 
         ray, 
         someValues);
-    
+
     uint r = calcValue(hit);
-    
+    // SPIRV: OpReorderThreadWithHitObjectNV
     ReorderThread( hit );
     
     // Change the payload
     SomeValues otherValues = { idx * -1, idx * 4.0f };
-    
+
     // Now Invoke to cast another ray, with the new payload
+    // SPIRV: OpHitObjectExecuteShaderNV
     HitObject::Invoke( scene, hit, otherValues );
     
     r += calcValue(hit);
   
     // !!! TODO(JS) !!!
     // NOTE! If I enable this I end up with a recursive failure in AST traversal, if 
-    // otherValues is redefined. 
-    
-    // Reorder 
+    // otherValues is redefined.
+
+    // Reorder
+    // SPIRV: OpReorderThreadWithHitObjectNV
     ReorderThread(hit, uint(idx & 3), 2);
 
     
     // Change the payload
     otherValues = { idx * -2, idx * 8.0f };
-    
+
     // Now Invoke to cast another ray, with the new payload
+    // SPIRV: OpHitObjectExecuteShaderNV
     HitObject::Invoke( scene, hit, otherValues );
     
     r += calcValue(hit);
 
-    // Reorder 
+    // Reorder
+    // SPIRV: OpReorderThreadWithHintNV
     ReorderThread(uint(idx & 1), 1);
     
     // Change the payload
     otherValues = { idx * -4, idx * 16.0f };
-    
+
     // Now Invoke to cast another ray, with the new payload
+    // SPIRV: OpHitObjectExecuteShaderNV
     HitObject::Invoke( scene, hit, otherValues );
     
     r += calcValue(hit);

--- a/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-trace-motion-ray.slang
+++ b/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-trace-motion-ray.slang
@@ -2,7 +2,7 @@
 
 // Motion rays not supported on HLSL impl currently
 //DISABLE_TEST:SIMPLE: -target dxil -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -DNV_SHADER_EXTN_SLOT=u0 
-//TEST:SIMPLE: -target glsl -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -line-directive-mode none 
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -line-directive-mode none 
 
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-d3d12 -output-using-type -use-dxil -profile sm_6_6 -render-feature ray-query
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-vk -output-using-type -render-feature ray-query
@@ -64,7 +64,7 @@ void rayGenerationMain()
     uint rayContributionToHitGroupIndex = 0;
     uint multiplierForGeometryContributionToHitGroupIndex = 4;
     uint missShaderIndex = 0;
-
+    // SPIRV: OpHitObjectTraceRayMotionNV
     HitObject hit = HitObject::TraceMotionRay(scene, 
         rayFlags, 
         instanceInclusionMask, 

--- a/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-trace-ray.slang
+++ b/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-trace-ray.slang
@@ -1,7 +1,7 @@
 // hit-object-trace-ray.slang
 
 //TEST:SIMPLE: -target dxil -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -DNV_SHADER_EXTN_SLOT=u0 
-//TEST:SIMPLE: -target glsl -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -line-directive-mode none 
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -entry rayGenerationMain -stage raygeneration -profile sm_6_5 -line-directive-mode none 
 
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-d3d12 -output-using-type -use-dxil -profile sm_6_6 -render-feature ray-query
 //DISABLE_TEST(compute):COMPARE_COMPUTE:-vk -output-using-type -render-feature ray-query
@@ -61,7 +61,7 @@ void rayGenerationMain()
     uint rayContributionToHitGroupIndex = 0;
     uint multiplierForGeometryContributionToHitGroupIndex = 4;
     uint missShaderIndex = 0;
-
+    // SPIRV: OpHitObjectTraceRayNV
     HitObject hit = HitObject::TraceRay(scene, 
         rayFlags, 
         instanceInclusionMask, 

--- a/tests/language-feature/non-copyable-return.slang
+++ b/tests/language-feature/non-copyable-return.slang
@@ -1,0 +1,37 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj -output-using-type
+//TEST(compute):SIMPLE(filecheck=GLSL): -stage compute -entry computeMain -target glsl
+
+// Note: spirv_by_reference is only supported for passing opaque types, so this test won't produce
+// expected result on vulkan.
+//DISABLED_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -shaderobj -output-using-type
+
+[__NonCopyableType]
+struct MyType
+{
+    float x;
+    __init() { x = 1.0; }
+}
+
+MyType myFunc1(float y)
+{
+    __return_val = MyType();
+    __return_val.x += y;
+}
+
+MyType myFunc0(float x)
+{
+    return myFunc1(x + 1.0);
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID: SV_DispatchThreadID)
+{
+    let f = myFunc0(2.0);
+    // CHECK: 4.0
+    // GLSL: void myFunc1_0(float y{{.*}}, spirv_by_reference MyType_0 {{.*}})
+    // GLSL: void myFunc0_0(float x{{.*}}, spirv_by_reference MyType_0 {{.*}})
+    outputBuffer[0] = f.x;
+}

--- a/tests/pipeline/ray-tracing/trace-ray-inline.slang.hlsl
+++ b/tests/pipeline/ray-tracing/trace-ray-inline.slang.hlsl
@@ -1,4 +1,8 @@
 #pragma pack_matrix(column_major)
+#ifdef SLANG_HLSL_ENABLE_NVAPI
+#include "nvHLSLExtns.h"
+#endif
+#pragma warning(disable: 3557)
 
 struct SLANG_ParameterGroup_C_0
 {
@@ -15,7 +19,6 @@ cbuffer C_0 : register(b0)
 {
     SLANG_ParameterGroup_C_0 C_0;
 }
-
 RaytracingAccelerationStructure myAccelerationStructure_0 : register(t0);
 
 RWStructuredBuffer<int > resultBuffer_0 : register(u0);
@@ -67,53 +70,41 @@ void myMiss_0(inout MyRayPayload_0 payload_4)
 void main(uint3 tid_0 : SV_DISPATCHTHREADID)
 {
     uint index_0 = tid_0.x;
-    RayQuery<int(512) > query_0;
-
     MyRayPayload_0 payload_5;
     payload_5.value_1 = int(-1);
-
     RayDesc ray_0 = { C_0.origin_0, C_0.tMin_0, C_0.direction_0, C_0.tMax_0 };
-
+    RayQuery<512U > query_0;
     query_0.TraceRayInline(myAccelerationStructure_0, C_0.rayFlags_0, C_0.instanceMask_0, ray_0);
-
     MyProceduralHitAttrs_0 committedProceduralAttrs_0;
-
     for(;;)
     {
-
         bool _S1 = query_0.Proceed();
-
         if(!_S1)
         {
-
             break;
         }
-
+        uint _S2 = query_0.CandidateType();
         MyProceduralHitAttrs_0 committedProceduralAttrs_1;
-        switch(query_0.CandidateType())
+        switch(_S2)
         {
         case 1U:
             {
                 MyProceduralHitAttrs_0 candidateProceduralAttrs_0;
                 candidateProceduralAttrs_0.value_0 = int(0);
-
                 float tHit_1 = 0.0;
-                bool _S2 = myProceduralIntersection_0(tHit_1, candidateProceduralAttrs_0);
-                if(_S2)
+                bool _S3 = myProceduralIntersection_0(tHit_1, candidateProceduralAttrs_0);
+                if(_S3)
                 {
-                    bool _S3 = myProceduralAnyHit_0(payload_5);
-                    if(_S3)
+                    bool _S4 = myProceduralAnyHit_0(payload_5);
+                    if(_S4)
                     {
                         query_0.CommitProceduralPrimitiveHit(tHit_1);
-                        MyProceduralHitAttrs_0 _S4 = candidateProceduralAttrs_0;
+                        MyProceduralHitAttrs_0 _S5 = candidateProceduralAttrs_0;
                         if(C_0.shouldStopAtFirstHit_0 != 0U)
                         {
                             query_0.Abort();
                         }
-                        else
-                        {}
-
-                        committedProceduralAttrs_1 = _S4;
+                        committedProceduralAttrs_1 = _S5;
                     }
                     else
                     {
@@ -128,20 +119,15 @@ void main(uint3 tid_0 : SV_DISPATCHTHREADID)
             }
         case 0U:
             {
-                bool _S5 = myTriangleAnyHit_0(payload_5);
-                if(_S5)
+                bool _S6 = myTriangleAnyHit_0(payload_5);
+                if(_S6)
                 {
                     query_0.CommitNonOpaqueTriangleHit();
                     if(C_0.shouldStopAtFirstHit_0 != 0U)
                     {
                         query_0.Abort();
                     }
-                    else
-                    {}
                 }
-                else
-                {}
-
                 committedProceduralAttrs_1 = committedProceduralAttrs_0;
                 break;
             }
@@ -151,11 +137,10 @@ void main(uint3 tid_0 : SV_DISPATCHTHREADID)
                 break;
             }
         }
-
         committedProceduralAttrs_0 = committedProceduralAttrs_1;
     }
-
-    switch(query_0.CommittedStatus())
+    uint _S7 = query_0.CommittedStatus();
+    switch(_S7)
     {
     case 1U:
         {


### PR DESCRIPTION
Use destination driven lowering to get rid of temp var copies when working with functions that returns a non-copyable object.

Fixes HitObject API issues on Vulkan.

Added lowering logic for functions that return non-copyable objects:
```
NonCopyable myFunc(T x, U y);
```
Lowers into
```
void myFunc(T x, U y, __ref NonCopyable __return_val);
```

Assignments and initializations are handled accordingly to generate callsites that match this function signature.
Returns are lowered into writes into the `__return_val` parameter.
The `__return_val` parameter is also made available for functions that return non-copyable objects in user code, so it is valid to write:
```
NonCopyable myFunc()
{
    __return_val = otherFunc();
    // do some other things before returning
    ...
}
```

With this changes, we can define the `HitObject` API as:
```
    __glsl_extension(GL_EXT_ray_tracing)
    __glsl_extension(GL_NV_shader_invocation_reorder)
    __target_intrinsic(glsl, "hitObjectRecordHitNV")
    static void __glslMakeHit(
        out HitObject hitObj,
        RaytracingAccelerationStructure accelerationStructure,
        int instanceid,
        int primitiveid,
        int geometryindex,
        uint hitKind,
        uint sbtRecordOffset,
        uint sbtRecordStride,
        float3 origin,
        float Tmin,
        float3 direction,
        float Tmax,
        int attributeLocation);

    [ForceInline]
    __specialized_for_target(glsl)
    static HitObject MakeHit<attr_t>( 
        RaytracingAccelerationStructure AccelerationStructure, 
        uint InstanceIndex, 
        uint GeometryIndex, 
        uint PrimitiveIndex, 
        uint HitKind, 
        uint RayContributionToHitGroupIndex, 
        uint MultiplierForGeometryContributionToHitGroupIndex, 
        RayDesc Ray, 
        attr_t attributes)
    {
        // Save the attributes
        __ref attr_t attr = __hitObjectAttributes<attr_t>();

        attr = attributes;

        __glslMakeHit(
            __return_val,
            AccelerationStructure,
            InstanceIndex,
            PrimitiveIndex,
            GeometryIndex,
            HitKind,
            RayContributionToHitGroupIndex,                         /// sbtRecordOffset?
            MultiplierForGeometryContributionToHitGroupIndex,       /// sbtRecordStride?
            Ray.Origin,
            Ray.TMin,
            Ray.Direction, 
            Ray.TMax,
            __hitObjectAttributesLocation(__hitObjectAttributes<attr_t>()));
    }
```

With this, this user code:
```
HitObject hit = HitObject.MakeHit(...);
```
will translate into
```
hitObjectNV hit;
hitObjectRecordHitNV(hit, ...);
```
with no explicit copies.

However if the user writes anything like:
```
HitObject h1 = h0;
```
We still can't eliminate the copy, but this isn't the code that users are likely going to write, and we should consider adding semantic checking rules for NonCopyable values to prevent against this kind of code.