### PR TITLE
Make a warning if a [mutating] method is called on an in param.

### DIFF
--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -586,9 +586,16 @@ namespace Slang
                 {
                     if(auto paramDecl = isReferenceIntoFunctionInputParameter(context.baseExpr))
                     {
-                        getSink()->diagnose(context.loc, Diagnostics::mutatingMethodOnFunctionInputParameter,
+                        const bool isNonCopyable = isNonCopyableType(paramDecl->getType());
+
+                        const auto& diagnotic = isNonCopyable ?
+                            Diagnostics::mutatingMethodOnFunctionInputParameterError :
+                            Diagnostics::mutatingMethodOnFunctionInputParameterWarning;
+
+                        getSink()->diagnose(context.loc, diagnotic,
                             funcDeclRef.getName(),
                             paramDecl->getName());
+
                     }
                 }
             }

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -595,7 +595,6 @@ namespace Slang
                         getSink()->diagnose(context.loc, diagnotic,
                             funcDeclRef.getName(),
                             paramDecl->getName());
-
                     }
                 }
             }

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -316,7 +316,8 @@ DIAGNOSTIC(30064, Note,  implicitCastUsedAsLValue, "argument was implicitly cast
 DIAGNOSTIC(30065, Error, newCanOnlyBeUsedToInitializeAClass, "`new` can only be used to initialize a class")
 DIAGNOSTIC(30066, Error, classCanOnlyBeInitializedWithNew, "a class can only be initialized by a `new` clause")
 
-DIAGNOSTIC(30067, Error, mutatingMethodOnFunctionInputParameter, "mutating method '$0' called on `in` parameter '$1'; changes will not be visible to caller. copy the parameter into a local variable if this behavior is intended")
+DIAGNOSTIC(30067, Error, mutatingMethodOnFunctionInputParameterError, "mutating method '$0' called on `in` parameter '$1'; changes will not be visible to caller. copy the parameter into a local variable if this behavior is intended")
+DIAGNOSTIC(30068, Warning, mutatingMethodOnFunctionInputParameterWarning, "mutating method '$0' called on `in` parameter '$1'; changes will not be visible to caller. copy the parameter into a local variable if this behavior is intended")
 
 DIAGNOSTIC(30100, Error, staticRefToNonStaticMember, "type '$0' cannot be used to refer to non-static member '$1'")
 

--- a/tests/diagnostics/param-mutation.slang
+++ b/tests/diagnostics/param-mutation.slang
@@ -1,0 +1,39 @@
+// param-mutation.slang
+
+// When a parameter is passed to `in`, it is mutable but generates a warning as it probably (?)
+// isn't what the programmer intended.
+
+//DIAGNOSTIC_TEST:SIMPLE:
+
+struct MutatingStruct
+{
+    [mutating] void setValue(int value) { m_value = value; }
+    int m_value;
+};
+
+int doThing(MutatingStruct s, int v)
+{
+    // Should generate a warning. 
+    s.setValue(v + 1);
+    return s.m_value;
+}
+
+// For non-copyable types (such as HitObject or NonCopyableStruct declared below), if passed as as `in`
+// should produce an error.
+// NOTE! This *doesn't* produce an error (or warning) because NonCopyable types are *implicitly* 
+// made *ref* when parsed as arguments. 
+
+[__NonCopyableType]
+struct NonCopyableStruct
+{
+    [mutating] void setValue(int value) { m_value = value; }
+    int m_value;
+};
+
+int doThing2(NonCopyableStruct s, int v)
+{
+    // Currently doesn't produce an error/warning because NonCopyableStruct is passed as *ref* implicitly.
+    s.setValue(v + 1);
+    return s.m_value;
+}
+

--- a/tests/diagnostics/param-mutation.slang.expected
+++ b/tests/diagnostics/param-mutation.slang.expected
@@ -1,0 +1,8 @@
+result code = 0
+standard error = {
+tests/diagnostics/param-mutation.slang(17): warning 30068: mutating method 'setValue' called on `in` parameter 's'; changes will not be visible to caller. copy the parameter into a local variable if this behavior is intended
+    s.setValue(v + 1);
+              ^
+}
+standard output = {
+}


### PR DESCRIPTION
#3067 added checking such that an error is produced if a [mutating] method is called on an `in` parameter.

The change was added to make it an error on 'NonCopyable' types, but was also an error on copyable types too. This change makes it an error on NonCopyable type as was the original intention, and a warning otherwise. The NonCopyable scenario is not triggerable currently as NonCopyable types are also implicitly passed as `ref`. The support for emitting an error is left here though as that behavior might change. 