### PR TITLE
Add -repro-fallback-directory option

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -16,6 +16,7 @@ slangc -help-style markdown -h
 * [Target](#Target)
 * [Downstream](#Downstream)
 * [Debugging](#Debugging)
+* [Repro](#Repro)
 * [Experimental](#Experimental)
 * [Internal](#Internal)
 * [Deprecated](#Deprecated)
@@ -379,9 +380,34 @@ Places the $Globals cbuffer at descriptor set &lt;descriptor-set&gt; and binding
 Negates (additively inverts) SV_Position.y before writing to stage output. 
 
 
+<a id="fvk-use-entrypoint-name"></a>
+## -fvk-use-entrypoint-name
+Uses the entrypoint name from the source instead of 'main' in the spirv output. 
+
+
+<a id="fvk-use-gl-layout"></a>
+## -fvk-use-gl-layout
+Use std430 layout instead of D3D buffer layout for raw buffer load/stores. 
+
+
 <a id="enable-effect-annotations"></a>
 ## -enable-effect-annotations
 Enables support for legacy effect annotation syntax. 
+
+
+<a id="emit-spirv-via-glsl"></a>
+## -emit-spirv-via-glsl
+Generate SPIR-V output by compiling generated GLSL with glslang (default) 
+
+
+<a id="emit-spirv-directly"></a>
+## -emit-spirv-directly
+Generate SPIR-V output direclty rather than by compiling generated GLSL with glslang 
+
+
+<a id="spirv-core-grammar"></a>
+## -spirv-core-grammar
+A path to a specific spirv.core.grammar.json to use when generating SPIR-V output 
 
 
 
@@ -391,7 +417,7 @@ Enables support for legacy effect annotation syntax.
 Downstream compiler options 
 
 <a id="none-path"></a>
-## -none-path, -fxc-path, -dxc-path, -glslang-path, -visualstudio-path, -clang-path, -gcc-path, -genericcpp-path, -nvrtc-path, -llvm-path
+## -none-path, -fxc-path, -dxc-path, -glslang-path, -spirv-dis-path, -visualstudio-path, -clang-path, -gcc-path, -genericcpp-path, -nvrtc-path, -llvm-path
 
 **-&lt;[compiler](#compiler)&gt;-path &lt;path&gt;**
 
@@ -460,45 +486,9 @@ Dump the IR for debugging.
 Dump the IDs with [-dump-ir](#dump-ir) (debug builds only) 
 
 
-<a id="dump-repro"></a>
-## -dump-repro
-Dump a `.slang-repro` file that can be used to reproduce a compilation on another machine. 
-
-
-
-
-<a id="dump-repro-on-error"></a>
-## -dump-repro-on-error
-Dump `.slang-repro` file on any compilation error. 
-
-
 <a id="E"></a>
 ## -E, -output-preprocessor
 Output the preprocessing result and exit. 
-
-
-<a id="extract-repro"></a>
-## -extract-repro
-
-**-extract-repro &lt;name&gt;**
-
-Extract the repro files into a folder. 
-
-
-<a id="load-repro-directory"></a>
-## -load-repro-directory
-
-**-load-repro-directory &lt;path&gt;**
-
-Use repro along specified path 
-
-
-<a id="load-repro"></a>
-## -load-repro
-
-**-load-repro &lt;name&gt;**
-
-Load repro 
 
 
 <a id="no-codegen"></a>
@@ -509,14 +499,6 @@ Skip the code generation step, just check the code and generate layout.
 <a id="output-includes"></a>
 ## -output-includes
 Print the hierarchy of the processed source files. 
-
-
-<a id="repro-file-system"></a>
-## -repro-file-system
-
-**-repro-file-system &lt;name&gt;**
-
-Use a repro as a file system 
 
 
 <a id="serial-ir"></a>
@@ -545,15 +527,76 @@ Verify IR in the front-end.
 
 
 
+<a id="Repro"></a>
+# Repro
+
+Slang repro system related 
+
+<a id="dump-repro-on-error"></a>
+## -dump-repro-on-error
+Dump `.slang-repro` file on any compilation error. 
+
+
+<a id="extract-repro"></a>
+## -extract-repro
+
+**-extract-repro &lt;name&gt;**
+
+Extract the repro files into a folder. 
+
+
+<a id="load-repro-directory"></a>
+## -load-repro-directory
+
+**-load-repro-directory &lt;path&gt;**
+
+Use repro along specified path 
+
+
+<a id="load-repro"></a>
+## -load-repro
+
+**-load-repro &lt;name&gt;**
+
+Load repro 
+
+
+<a id="repro-file-system"></a>
+## -repro-file-system
+
+**-repro-file-system &lt;name&gt;**
+
+Use a repro as a file system 
+
+
+<a id="dump-repro"></a>
+## -dump-repro
+Dump a `.slang-repro` file that can be used to reproduce a compilation on another machine. 
+
+
+
+
+<a id="repro-fallback-directory"></a>
+## -repro-fallback-directory
+
+**-repro-fallback-directory &lt;path&gt;**
+
+Specify a directory to use if a file isn't found in a repro. Should be specified *before* any repro usage such as `load-repro`. 
+
+There are two *special* &lt;path&gt;s: 
+
+
+
+* 'none:' indicates no fallback, so if the file isn't found in the repro compliation will fail 
+
+* 'default:' is the default (which is the OS file system) 
+
+
+
 <a id="Experimental"></a>
 # Experimental
 
 Experimental options (use at your own risk) 
-
-<a id="emit-spirv-via-glsl"></a>
-## -emit-spirv-via-glsl
-Generate SPIR-V output by generating and compiling GLSL using glslang
-
 
 <a id="file-system"></a>
 ## -file-system
@@ -667,6 +710,7 @@ Downstream Compilers (aka Pass through)
 * `fxc` : FXC HLSL compiler 
 * `dxc` : DXC HLSL compiler 
 * `glslang` : GLSLANG GLSL compiler 
+* `spirv-dis` : spirv-tools SPIRV disassembler 
 * `visualstudio`, `vs` : Visual Studio C/C++ compiler 
 * `clang` : Clang C/C++ compiler 
 * `gcc` : GCC C/C++ compiler 
@@ -847,12 +891,13 @@ A capability describes an optional feature that a target may or may not support.
 
 * `spirv_1_{ 0`, `1`, `2`, `3`, `4`, `5 }` : minimum supported SPIR - V version 
 * `invalid` 
+* `textual_source` 
 * `hlsl` 
 * `glsl` 
 * `c` 
 * `cpp` 
 * `cuda` 
-* `spirv`
+* `spirv` 
 * `GL_NV_ray_tracing` : enables the GL_NV_ray_tracing extension 
 * `GL_EXT_ray_tracing` : enables the GL_EXT_ray_tracing extension 
 * `GL_NV_fragment_shader_barycentric` : enables the GL_NV_fragment_shader_barycentric extension 

--- a/source/compiler-core/slang-dxc-compiler.cpp
+++ b/source/compiler-core/slang-dxc-compiler.cpp
@@ -133,8 +133,8 @@ public:
         // If it starts with ./ then attempt to strip it
         if (filePath.startsWith("./"))
         {
-            String remaining(filePath.subString(2, filePath.getLength() - 2));
-
+            const String remaining = filePath.getUnownedSlice().tail(2);
+            
             // Okay if we strip ./ and what we have is absolute, then it's the absolute path that we care about,
             // otherwise we just leave as is.
             if (Path::isAbsolute(remaining))

--- a/source/core/slang-file-system.h
+++ b/source/core/slang-file-system.h
@@ -172,7 +172,7 @@ class CacheFileSystem: public ISlangFileSystemExt, public ComBaseObject
     void setInnerFileSystem(ISlangFileSystem* fileSystem, UniqueIdentityMode uniqueIdentityMode = UniqueIdentityMode::Default, PathStyle pathStyle = PathStyle::Default);
 
         /// Ctor
-    CacheFileSystem(ISlangFileSystem* fileSystem, UniqueIdentityMode uniqueIdentityMode = UniqueIdentityMode::Default, PathStyle pathStyle = PathStyle::Default);
+    explicit CacheFileSystem(ISlangFileSystem* fileSystem, UniqueIdentityMode uniqueIdentityMode = UniqueIdentityMode::Default, PathStyle pathStyle = PathStyle::Default);
         /// Dtor
     virtual ~CacheFileSystem();
 

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -1412,7 +1412,7 @@ namespace Slang
         options.requiredCapabilityVersions = SliceUtil::asSlice(requiredCapabilityVersions);
         options.libraries = SliceUtil::asSlice(libraries);
         options.libraryPaths = allocator.allocate(libraryPaths);
-
+        
         // Compile
         ComPtr<IArtifact> artifact;
         auto downstreamStartTime = std::chrono::high_resolution_clock::now();

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -19,6 +19,8 @@
 #include "../core/slang-std-writers.h"
 #include "../core/slang-command-options.h"
 
+#include "../core/slang-file-system.h"
+
 #include "../../slang-com-ptr.h"
 
 #include "slang-capability.h"
@@ -2696,6 +2698,9 @@ namespace Slang
         ComPtr<IArtifact> m_containerArtifact;
             /// Holds the container as a file system
         ComPtr<ISlangMutableFileSystem> m_containerFileSystem;
+
+            /// File system used by repro system if a file couldn't be found within the repro (or associated directory)
+        ComPtr<ISlangFileSystem> m_reproFallbackFileSystem = ComPtr<ISlangFileSystem>(OSFileSystem::getExtSingleton());
 
             // Path to output container to
         String m_containerOutputPath;

--- a/source/slang/slang-repro.cpp
+++ b/source/slang/slang-repro.cpp
@@ -888,7 +888,7 @@ struct LoadContext
     return SLANG_OK;
 }
 
-/* static */SlangResult ReproUtil::load(OffsetBase& base, RequestState* requestState, ISlangFileSystem* fileSystem, EndToEndCompileRequest* request)
+/* static */SlangResult ReproUtil::load(OffsetBase& base, RequestState* requestState, ISlangFileSystem* optionalFileSystem, EndToEndCompileRequest* request)
 {
     auto externalRequest = asExternal(request);
 
@@ -902,7 +902,7 @@ struct LoadContext
         linkage->targets.clear();
     }
 
-    LoadContext context(linkage->getSourceManager(), fileSystem, &base);
+    LoadContext context(linkage->getSourceManager(), optionalFileSystem, &base);
 
     // Try to set state through API - as doing so means if state stored in multiple places it will be ok
 
@@ -1046,7 +1046,7 @@ struct LoadContext
     }
 
     {
-        auto cacheFileSystem = new CacheFileSystem(nullptr);
+        auto cacheFileSystem = new CacheFileSystem(request->m_reproFallbackFileSystem);
         ComPtr<ISlangFileSystemExt> fileSystemExt(cacheFileSystem);
         auto& dstUniqueMap = cacheFileSystem->getUniqueMap();
         auto& dstPathMap = cacheFileSystem->getPathMap();

--- a/source/slang/slang-repro.h
+++ b/source/slang/slang-repro.h
@@ -174,9 +174,9 @@ struct ReproUtil
     static SlangResult loadFileSystem(OffsetBase& base, RequestState* requestState, ISlangFileSystem* fileSystem, ComPtr<ISlangFileSystemExt>& outFileSystem);
 
         /// Load the requestState into request
-        /// The fileSystem is optional and can be passed as nullptr. If set, as each file is loaded
+        /// The overrideFileSystem is optional and can be passed as nullptr. If set, as each file is loaded
         /// it will attempt to load from fileSystem the *uniqueName*
-    static SlangResult load(OffsetBase& base, RequestState* requestState, ISlangFileSystem* fileSystem, EndToEndCompileRequest* request);
+    static SlangResult load(OffsetBase& base, RequestState* requestState, ISlangFileSystem* overrideFileSystem, EndToEndCompileRequest* request);
 
     static SlangResult loadState(const String& filename, DiagnosticSink* sink, List<uint8_t>& outBuffer);
     static SlangResult loadState(Stream* stream, DiagnosticSink* sink, List<uint8_t>& outBuffer);


### PR DESCRIPTION
The motivation here is when using a repro which requires access to includes to complete, which weren't captured. For example if using implicit `NVAPI`, the NVAPI header includes are inserted into downstream output. The option allows specifying a falback directory or disabling (if fallback isn't required). This could also allow splitting a repro.

* Put repro options into repro category
* Added `-repro-fallback-directory` option
* Support `none:` and `default:` special directories