### PR TITLE
Incur l-value conversion cost during overload resolution.

### DIFF
--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -140,6 +140,9 @@ namespace Slang
         // the element type of the vector)
         kConversionCost_ScalarToVector = 1,
 
+        // Additional cost when casting an LValue.
+        kConversionCost_LValueCast = 800,
+
         // Conversion is impossible
         kConversionCost_Impossible = 0xFFFFFFFF,
     };
@@ -520,6 +523,13 @@ namespace Slang
         {}
 
         QualType(Type* type);
+
+        QualType(Type* type, bool isLVal)
+            : QualType(type)
+        {
+            isLeftValue = isLVal;
+        }
+
 
         Type* Ptr() { return type; }
 

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -705,7 +705,7 @@ namespace Slang
         CoercionSite site,
         Type*    toType,
         Expr**   outToExpr,
-        Type*    fromType,
+        QualType fromType,
         Expr*    fromExpr,
         ConversionCost* outCost)
     {
@@ -1060,7 +1060,7 @@ namespace Slang
         OverloadResolveContext overloadContext;
         overloadContext.disallowNestedConversions = true;
         overloadContext.argCount = 1;
-        overloadContext.argTypes = &fromType;
+        overloadContext.argTypes = &fromType.type;
         overloadContext.args = &fromExpr;
 
         overloadContext.originalExpr = nullptr;
@@ -1191,6 +1191,11 @@ namespace Slang
                     }
                 }
             }
+            if (fromType.isLeftValue)
+            {
+                // If we are implicitly casting the type of an l-value, we need to impose additional cost.
+                cost += kConversionCost_LValueCast;
+            }
             if(outCost)
                 *outCost = cost;
 
@@ -1245,7 +1250,7 @@ namespace Slang
 
     bool SemanticsVisitor::canCoerce(
         Type*    toType,
-        Type*    fromType,
+        QualType fromType,
         Expr*    fromExpr,
         ConversionCost* outCost)
     {
@@ -1380,7 +1385,7 @@ namespace Slang
 
     bool SemanticsVisitor::canConvertImplicitly(
         Type* toType,
-        Type* fromType)
+        QualType fromType)
     {
         auto conversionCost = getConversionCost(toType, fromType);
 
@@ -1391,7 +1396,7 @@ namespace Slang
         return true;
     }
 
-    ConversionCost SemanticsVisitor::getConversionCost(Type* toType, Type* fromType)
+    ConversionCost SemanticsVisitor::getConversionCost(Type* toType, QualType fromType)
     {
         ConversionCost conversionCost = kConversionCost_Impossible;
         if (!canCoerce(toType, fromType, nullptr, &conversionCost))

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -773,7 +773,7 @@ namespace Slang
             auto toBase = toModified ? toModified->getBase() : toType;
             //
             auto fromModified = as<ModifiedType>(fromType);
-            auto fromBase = fromModified ? fromModified->getBase() : fromType;
+            auto fromBase = fromModified ? QualType(fromModified->getBase(), fromType.isLeftValue) : fromType;
 
 
             if((toModified || fromModified) && toBase->equals(fromBase))

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -441,17 +441,8 @@ namespace Slang
                 Count paramCount = funcType->getParamCount();
                 for (Index i = 0; i < paramCount; ++i)
                 {
-                    auto paramType = funcType->getParamType(i);
-                    bool isLVal = false;
-
-                    if(auto paramDirectionType = as<ParamDirectionType>(paramType))
-                    {
-                        paramType = paramDirectionType->getValueType();
-                        if (as<OutTypeBase>(paramType) || as<RefType>(paramType))
-                            isLVal = true;
-                    }
-
-                    paramTypes.add(QualType(paramType, isLVal));
+                    auto paramType = getParamQualType(funcType->getParamType(i));
+                    paramTypes.add(paramType);
                 }
             }
             break;

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -394,21 +394,44 @@ namespace Slang
         return success;
     }
 
+    static QualType getParamQualType(ASTBuilder* astBuilder, DeclRef<ParamDecl> param)
+    {
+        auto paramType = getType(astBuilder, param);
+        bool isLVal = false;
+        switch (getParameterDirection(param.getDecl()))
+        {
+        case kParameterDirection_InOut:
+        case kParameterDirection_Out:
+        case kParameterDirection_Ref:
+            isLVal = true;
+            break;
+        }
+        return QualType(paramType, isLVal);
+    }
+
+    static QualType getParamQualType(Type* paramType)
+    {
+        if (auto paramDirType = as<ParamDirectionType>(paramType))
+        {
+            if (as<OutTypeBase>(paramDirType) || as<RefType>(paramDirType))
+                return QualType(paramDirType->getValueType(), true);
+        }
+        return paramType;
+    }
+
     bool SemanticsVisitor::TryCheckOverloadCandidateTypes(
         OverloadResolveContext&	context,
         OverloadCandidate&		candidate)
     {
         Index argCount = context.getArgCount();
 
-        List<Type*> paramTypes;
-//        List<DeclRef<ParamDecl>> params;
+        List<QualType> paramTypes;
         switch (candidate.flavor)
         {
         case OverloadCandidate::Flavor::Func:
             for (auto param : getParameters(m_astBuilder, candidate.item.declRef.as<CallableDecl>()))
             {
-                auto paramType = getType(m_astBuilder, param);
-                paramTypes.add(paramType);
+                paramTypes.add(getParamQualType(m_astBuilder, param));
             }
             break;
 
@@ -419,13 +442,16 @@ namespace Slang
                 for (Index i = 0; i < paramCount; ++i)
                 {
                     auto paramType = funcType->getParamType(i);
+                    bool isLVal = false;
 
                     if(auto paramDirectionType = as<ParamDirectionType>(paramType))
                     {
                         paramType = paramDirectionType->getValueType();
+                        if (as<OutTypeBase>(paramType) || as<RefType>(paramType))
+                            isLVal = true;
                     }
 
-                    paramTypes.add(paramType);
+                    paramTypes.add(QualType(paramType, isLVal));
                 }
             }
             break;
@@ -445,8 +471,8 @@ namespace Slang
         for (Index ii = 0; ii < argCount; ++ii)
         {
             auto& arg = context.getArg(ii);
-            auto argType = context.getArgType(ii);
             auto paramType = paramTypes[ii];
+            auto argType = QualType(context.getArgType(ii), paramType.isLeftValue);
             if (!paramType)
                 return false;
             if (!argType)
@@ -1318,7 +1344,7 @@ namespace Slang
         DeclRef<GenericDecl>    genericDeclRef,
         OverloadResolveContext& context,
         ArrayView<Val*>         knownGenericArgs,
-        List<Type*>             *innerParameterTypes)
+        List<QualType>          *innerParameterTypes)
     {
         // We have been asked to infer zero or more arguments to
         // `genericDeclRef`, in a context where it is being applied
@@ -1360,13 +1386,13 @@ namespace Slang
 
         if (auto funcDeclRef = as<CallableDecl>(genericDeclRef.getDecl()->inner))
         {
-            List<Type*> paramTypes;
+            List<QualType> paramTypes;
             if (!innerParameterTypes)
             {
                 auto params = getParameters(m_astBuilder, funcDeclRef).toArray();
                 for (auto param : params)
                 {
-                    paramTypes.add(getType(m_astBuilder, param));
+                    paramTypes.add(getParamQualType(m_astBuilder, param));
                 }
                 innerParameterTypes = &paramTypes;
             }
@@ -1408,11 +1434,12 @@ namespace Slang
                 //
                 // So the question is then whether a mismatch during the
                 // unification step should be taken as an immediate failure...
-
+                auto argType = context.getArgTypeForInference(aa, this);
+                auto paramType = (*innerParameterTypes)[aa];
                 TryUnifyTypes(
                     constraints,
-                    context.getArgTypeForInference(aa, this),
-                    (*innerParameterTypes)[aa]);
+                    QualType(argType, paramType.isLeftValue),
+                    paramType);
             }
         }
         else
@@ -1679,10 +1706,10 @@ namespace Slang
                 SLANG_ASSERT(diffFuncType);
 
                 // Extract parameter list from processed type.
-                List<Type*> paramTypes;
+                List<QualType> paramTypes;
 
                 for (Index ii = 0; ii < diffFuncType->getParamCount(); ii++)
-                    paramTypes.add(removeParamDirType(diffFuncType->getParamType(ii)));
+                    paramTypes.add(getParamQualType(diffFuncType->getParamType(ii)));
 
                 // Try to infer generic arguments, based on the updated context.
                 OverloadResolveContext subContext = context;

--- a/tests/language-feature/overload-resolution.slang
+++ b/tests/language-feature/overload-resolution.slang
@@ -1,0 +1,45 @@
+//TEST:SIMPLE(filecheck=CHECK): -target hlsl -stage compute -entry main
+RWStructuredBuffer<float> result;
+
+[ForceInline]
+float myF(inout int a, int b)
+{
+    return a + b;
+}
+
+[ForceInline]
+float myF(inout uint a, uint b)
+{
+    return a - b;
+}
+
+[ForceInline]
+T myGenF<T : __BuiltinIntegerType>(inout T a, T b)
+{
+    if (__isSignedInt<T>())
+    {
+        return a + b;
+    }
+    else
+    {
+        return a - b;
+    }
+}
+// CHECK: result{{.*}}[0{{U?}}] = 1
+// CHECK: result{{.*}}[1{{U?}}] = 4
+// CHECK: result{{.*}}[2{{U?}}] = 1
+// CHECK: result{{.*}}[3{{U?}}] = 4
+[numthreads(1,1,1)]
+void main()
+{
+    int ic = 1;
+    uint a = 2;
+    result[0] = myF(a, ic);
+
+    int b = 3;
+    uint uc = 1;
+    result[1] = myF(b, uc);
+
+    result[2] = myGenF(a, ic);
+    result[3] = myGenF(b, uc);
+}


### PR DESCRIPTION
Our existing overload resolution logic does not respect the l-value-ness of implicit conversions, this leads to issues such as:
```
int f(inout int a, int b) {...}
int f(inout uint a, uint b) {...}

uint a = 0;
int b =  1;
f(a, b);
```

Because it is cheaper to cast `uint` to `int`, our resolution logic will pick the first overload which leads to a surprising l-value cast.
To address this issue, we must propagate the l-value-ness of parameter types to various places of our overload resolution logic and add an extra cost whenever an implicit cast on l-value is ocurred. This will allow the compiler to pick the second overload.

Note that we need to handle the generic case as well:
```
T f<T:BuiltinIntegerType>(inout T a, T b) {...}

uint a = 0;
int b =  1;
f(a, b); // should resolve to T<uint> instead of T<int>.
```

This means that the constraints will need to carry additional bits on whether the constraint is used for a l-value.