### PR TITLE
Fix attribute highlighting + language server crash.

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -5624,7 +5624,7 @@ T WaveMaskProduct(WaveMask mask, T expr)
             {
                 // TODO: use the correct integer width
                 OpBitcast $$uint %uvalue $expr;
-                OpGroupNonUniformIMul $$T %mulResult Subgroup 0 %uvalue;
+                OpGroupNonUniformIMul $$uint %mulResult Subgroup 0 %uvalue;
                 OpBitcast $$T result %mulResult
             };
         }
@@ -5687,7 +5687,7 @@ T WaveMaskSum(WaveMask mask, T expr)
             {
                 // TODO: use the correct integer width
                 OpBitcast $$uint %uvalue $expr;
-                OpGroupNonUniformIAdd $$T %mulResult Subgroup 0 %uvalue;
+                OpGroupNonUniformIAdd $$uint %mulResult Subgroup 0 %uvalue;
                 OpBitcast $$T result %mulResult
             };
         }
@@ -6120,21 +6120,27 @@ __generic<T : __BuiltinType> T QuadReadAcrossDiagonal(T localValue);
 __generic<T : __BuiltinType, let N : int> vector<T,N> QuadReadAcrossDiagonal(vector<T,N> localValue);
 __generic<T : __BuiltinType, let N : int, let M : int> matrix<T,N,M> QuadReadAcrossDiagonal(matrix<T,N,M> localValue);
 
+// WaveActiveBitAnd, WaveActiveBitOr, WaveActiveBitXor
+${{{{
+struct WaveActiveBitOpEntry { const char* hlslName; const char* glslName; const char* spirvName; };
+const WaveActiveBitOpEntry kWaveActiveBitOpEntries[] = {{"BitAnd", "And", "BitwiseAnd"}, {"BitOr", "Or", "BitwiseOr"}, {"BitXor", "Xor", "BitwiseXor"}};
+for (auto opName : kWaveActiveBitOpEntries) {
+}}}}wave
 
 __generic<T : __BuiltinIntegerType>
 __glsl_extension(GL_KHR_shader_subgroup_arithmetic)
 __spirv_version(1.3)
 __spirv_capability(GroupNonUniformArithmetic)
-T WaveActiveBitAnd(T expr)
+T WaveActive$(opName.hlslName)(T expr)
 {
     __target_switch
     {
-    case glsl: __intrinsic_asm "subgroupAnd($0)";
-    case hlsl: __intrinsic_asm "WaveActiveBitAnd";
+    case glsl: __intrinsic_asm "subgroup$(opName.glslName)($0)";
+    case hlsl: __intrinsic_asm "WaveActive$(opName.hlslName)";
     case spirv:
-        return spirv_asm {OpGroupNonUniformBitwiseAnd $$T result Subgroup Reduce $expr};
+        return spirv_asm {OpGroupNonUniform$(opName.spirvName) $$T result Subgroup Reduce $expr};
     default:
-        return WaveMaskBitAnd(WaveGetActiveMask(), expr);
+        return WaveMask$(opName.hlslName)(WaveGetActiveMask(), expr);
     }
 }
 
@@ -6142,127 +6148,54 @@ __generic<T : __BuiltinIntegerType, let N : int>
 __glsl_extension(GL_KHR_shader_subgroup_arithmetic)
 __spirv_version(1.3)
 __spirv_capability(GroupNonUniformArithmetic)
-vector<T, N> WaveActiveBitAnd(vector<T, N> expr)
+vector<T, N> WaveActive$(opName.hlslName)(vector<T, N> expr)
 {
     __target_switch
     {
-    case glsl: __intrinsic_asm "subgroupAnd($0)";
-    case hlsl: __intrinsic_asm "WaveActiveBitAnd";
+    case glsl: __intrinsic_asm "subgroup$(opName.glslName)($0)";
+    case hlsl: __intrinsic_asm "WaveActive$(opName.hlslName)";
     case spirv:
-        return spirv_asm {OpGroupNonUniformBitwiseAnd $$vector<T, N> result Subgroup Reduce $expr};
+        return spirv_asm {OpGroupNonUniform$(opName.spirvName) $$vector<T, N> result Subgroup Reduce $expr};
     default:
-        return WaveMaskBitAnd(WaveGetActiveMask(), expr);
+        return WaveMask$(opName.hlslName)(WaveGetActiveMask(), expr);
     }
 }
 
 __generic<T : __BuiltinIntegerType, let N : int, let M : int>
 __target_intrinsic(hlsl)
-matrix<T, N, M> WaveActiveBitAnd(matrix<T, N, M> expr)
+matrix<T, N, M> WaveActive$(opName.hlslName)(matrix<T, N, M> expr)
 {
-    return WaveMaskBitAnd(WaveGetActiveMask(), expr);
+    return WaveMask$(opName.hlslName)(WaveGetActiveMask(), expr);
 }
+${{{{
+} // WaveActiveBitAnd, WaveActiveBitOr, WaveActiveBitXor
+}}}}
 
-__generic<T : __BuiltinIntegerType>
-__glsl_extension(GL_KHR_shader_subgroup_arithmetic)
-__spirv_version(1.3)
-__spirv_capability(GroupNonUniformArithmetic)
-T WaveActiveBitOr(T expr)
-{
-    __target_switch
-    {
-    case glsl: __intrinsic_asm "subgroupOr($0)";
-    case hlsl: __intrinsic_asm "WaveActiveBitOr";
-    case spirv:
-        return spirv_asm {OpGroupNonUniformBitwiseOr $$T result Subgroup Reduce $expr};
-    default:
-        return WaveMaskBitOr(WaveGetActiveMask(), expr);
-    }
-}
-
-__generic<T : __BuiltinIntegerType, let N : int>
-__glsl_extension(GL_KHR_shader_subgroup_arithmetic)
-__spirv_version(1.3)
-__spirv_capability(GroupNonUniformArithmetic)
-vector<T,N> WaveActiveBitOr(vector<T,N> expr)
-{
-    __target_switch
-    {
-    case glsl: __intrinsic_asm "subgroupOr($0)";
-    case hlsl: __intrinsic_asm "WaveActiveBitOr";
-    case spirv:
-        return spirv_asm {OpGroupNonUniformBitwiseOr $$vector<T, N> result Subgroup Reduce $expr};
-    default:
-        return WaveMaskBitOr(WaveGetActiveMask(), expr);
-    }
-}
-
-__generic<T : __BuiltinIntegerType, let N : int, let M : int>
-__target_intrinsic(hlsl)
-matrix<T, N, M> WaveActiveBitOr(matrix<T, N, M> expr)
-{
-    return WaveMaskBitOr(WaveGetActiveMask(), expr);
-}
-
-__generic<T : __BuiltinIntegerType>
-__glsl_extension(GL_KHR_shader_subgroup_arithmetic)
-__spirv_version(1.3)
-__spirv_capability(GroupNonUniformArithmetic)
-T WaveActiveBitXor(T expr)
-{
-    __target_switch
-    {
-    case glsl: __intrinsic_asm "subgroupXor($0)";
-    case hlsl: __intrinsic_asm "WaveActiveBitXor";
-    case spirv:
-        return spirv_asm {OpGroupNonUniformBitwiseXor $$T result Subgroup Reduce $expr};
-    default:
-        return WaveMaskBitXor(WaveGetActiveMask(), expr);
-    }
-}
-
-__generic<T : __BuiltinIntegerType, let N : int>
-__glsl_extension(GL_KHR_shader_subgroup_arithmetic)
-__spirv_version(1.3)
-__spirv_capability(GroupNonUniformArithmetic)
-vector<T,N> WaveActiveBitXor(vector<T,N> expr)
-{
-    __target_switch
-    {
-    case glsl: __intrinsic_asm "subgroupXor($0)";
-    case hlsl: __intrinsic_asm "WaveActiveBitXor";
-    case spirv:
-        return spirv_asm {OpGroupNonUniformBitwiseXor $$vector<T,N> result Subgroup Reduce $expr};
-    default:
-        return WaveMaskBitXor(WaveGetActiveMask(), expr);
-    }
-}
-
-__generic<T : __BuiltinIntegerType, let N : int, let M : int>
-__target_intrinsic(hlsl)
-matrix<T, N, M> WaveActiveBitXor(matrix<T, N, M> expr)
-{
-    return WaveMaskBitXor(WaveGetActiveMask(), expr);
-}
+// WaveActiveMin/Max
+${{{{
+const char* kWaveActiveMinMaxNames[] = {"Min", "Max"};
+for (const char* opName : kWaveActiveMinMaxNames) {
+}}}}
 
 __generic<T : __BuiltinArithmeticType>
 __glsl_extension(GL_KHR_shader_subgroup_arithmetic)
 __spirv_version(1.3)
 __spirv_capability(GroupNonUniformArithmetic)
-T WaveActiveMax(T expr)
+T WaveActive$(opName)(T expr)
 {
     __target_switch
     {
-    case glsl: __intrinsic_asm "subgroupMax($0)";
-    case hlsl: __intrinsic_asm "WaveActiveMax";
+    case glsl: __intrinsic_asm "subgroup$(opName)($0)";
+    case hlsl: __intrinsic_asm "WaveActive$(opName)";
     case spirv:
         if (__isFloat<T>())
-            return spirv_asm {OpGroupNonUniformFMax $$T result Subgroup Reduce $expr};
+            return spirv_asm {OpGroupNonUniformF$(opName) $$T result Subgroup Reduce $expr};
         else if (__isUnsignedInt<T>())
-            return spirv_asm {OpGroupNonUniformUMax $$T result Subgroup Reduce $expr};
+            return spirv_asm {OpGroupNonUniformU$(opName) $$T result Subgroup Reduce $expr};
         else
-            return spirv_asm {OpGroupNonUniformSMax $$T result Subgroup Reduce $expr};
+            return spirv_asm {OpGroupNonUniformS$(opName) $$T result Subgroup Reduce $expr};
     default:
-        return WaveMaskMax(WaveGetActiveMask(), expr);
+        return WaveMask$(opName)(WaveGetActiveMask(), expr);
     }
 }
 
@@ -6270,90 +6203,77 @@ __generic<T : __BuiltinArithmeticType, let N : int>
 __glsl_extension(GL_KHR_shader_subgroup_arithmetic)
 __spirv_version(1.3)
 __spirv_capability(GroupNonUniformArithmetic)
-vector<T, N> WaveActiveMax(vector<T, N> expr)
+vector<T, N> WaveActive$(opName)(vector<T, N> expr)
 {
     __target_switch
     {
-    case glsl: __intrinsic_asm "subgroupMax($0)";
-    case hlsl: __intrinsic_asm "WaveActiveMax";
+    case glsl: __intrinsic_asm "subgroup$(opName)($0)";
+    case hlsl: __intrinsic_asm "WaveActive$(opName)";
     case spirv:
         if (__isFloat<T>())
-            return spirv_asm {OpGroupNonUniformFMax $$vector<T, N> result Subgroup Reduce $expr};
+            return spirv_asm {OpGroupNonUniformF$(opName) $$vector<T, N> result Subgroup Reduce $expr};
         else if (__isUnsignedInt<T>())
-            return spirv_asm {OpGroupNonUniformUMax $$vector<T, N> result Subgroup Reduce $expr};
+            return spirv_asm {OpGroupNonUniformU$(opName) $$vector<T, N> result Subgroup Reduce $expr};
         else
-            return spirv_asm {OpGroupNonUniformSMax $$vector<T, N> result Subgroup Reduce $expr};
+            return spirv_asm {OpGroupNonUniformS$(opName) $$vector<T, N> result Subgroup Reduce $expr};
     default:
-        return WaveMaskMax(WaveGetActiveMask(), expr);
+        return WaveMask$(opName)(WaveGetActiveMask(), expr);
     }
 }
 
 __generic<T : __BuiltinArithmeticType, let N : int, let M : int>
 __target_intrinsic(hlsl)
-matrix<T, N, M> WaveActiveMax(matrix<T, N, M> expr)
+matrix<T, N, M> WaveActive$(opName)(matrix<T, N, M> expr)
 {
-    return WaveMaskMax(WaveGetActiveMask(), expr);
+    return WaveMask$(opName)(WaveGetActiveMask(), expr);
 }
+
+${{{{
+} // WaveActiveMinMax.
+}}}}
+
+// WaveActiveProduct/Sum
+${{{{
+struct WaveActiveProductSumEntry { const char* hlslName; const char* glslName; };
+const WaveActiveProductSumEntry kWaveActivProductSumNames[] = {{"Product", "Mul"}, {"Sum", "Add"}};
+for (auto opName : kWaveActivProductSumNames) {
+}}}}
 
 __generic<T : __BuiltinArithmeticType>
 __glsl_extension(GL_KHR_shader_subgroup_arithmetic)
 __spirv_version(1.3)
-__spirv_capability(GroupNonUniformArithmetic)
-T WaveActiveMin(T expr)
+T WaveActive$(opName.hlslName)(T expr)
 {
     __target_switch
     {
-    case glsl: __intrinsic_asm "subgroupMin($0)";
-    case hlsl: __intrinsic_asm "WaveActiveMin";
+    case glsl: __intrinsic_asm "subgroup$(opName.glslName)($0)";
+    case hlsl: __intrinsic_asm "WaveActive$(opName.hlslName)";
     case spirv:
         if (__isFloat<T>())
-            return spirv_asm {OpGroupNonUniformFMin $$T result Subgroup Reduce $expr};
+            return spirv_asm {
+                OpCapability GroupNonUniformArithmetic;
+                OpGroupNonUniformF$(opName.glslName) $$T result Subgroup 0 $expr
+            };
+        else if (__isSignedInt<T>())
+        {
+            return spirv_asm
+            {
+                OpCapability GroupNonUniformArithmetic;
+                // TODO: use the correct integer width
+                OpBitcast $$uint %uvalue $expr;
+                OpGroupNonUniformI$(opName.glslName) $$uint %mulResult Subgroup 0 %uvalue;
+                OpBitcast $$T result %mulResult
+            };
+        }
         else if (__isUnsignedInt<T>())
-            return spirv_asm {OpGroupNonUniformUMin $$T result Subgroup Reduce $expr};
-        else
-            return spirv_asm {OpGroupNonUniformSMin $$T result Subgroup Reduce $expr};
+            return spirv_asm
+            {
+                OpCapability GroupNonUniformArithmetic;
+                OpGroupNonUniformI$(opName.glslName) $$T result Subgroup 0 $expr
+            };
     default:
-        return WaveMaskMin(WaveGetActiveMask(), expr);
+        return WaveMask$(opName.hlslName)(WaveGetActiveMask(), expr);
     }
-}
-
-__generic<T : __BuiltinArithmeticType, let N : int>
-__glsl_extension(GL_KHR_shader_subgroup_arithmetic)
-__spirv_version(1.3)
-__spirv_capability(GroupNonUniformArithmetic)
-vector<T, N> WaveActiveMin(vector<T, N> expr)
-{
-    __target_switch
-    {
-    case glsl: __intrinsic_asm "subgroupMin($0)";
-    case hlsl: __intrinsic_asm "WaveActiveMin";
-    case spirv:
-        if (__isFloat<T>())
-            return spirv_asm {OpGroupNonUniformFMin $$vector<T, N> result Subgroup Reduce $expr};
-        else if (__isUnsignedInt<T>())
-            return spirv_asm {OpGroupNonUniformUMin $$vector<T, N> result Subgroup Reduce $expr};
-        else
-            return spirv_asm {OpGroupNonUniformSMin $$vector<T, N> result Subgroup Reduce $expr};
-    default:
-        return WaveMaskMin(WaveGetActiveMask(), expr);
-    }
-}
-
-__generic<T : __BuiltinArithmeticType, let N : int, let M : int>
-__target_intrinsic(hlsl)
-matrix<T, N, M> WaveActiveMin(matrix<T, N, M> expr)
-{
-    return WaveMaskMin(WaveGetActiveMask(), expr);
-}
-
-__generic<T : __BuiltinArithmeticType>
-__glsl_extension(GL_KHR_shader_subgroup_arithmetic)
-__spirv_version(1.3)
-__target_intrinsic(glsl, "subgroupMul($0)")
-__target_intrinsic(hlsl)
-T WaveActiveProduct(T expr)
-{
-    return WaveMaskProduct(WaveGetActiveMask(), expr);
 }
 
 __generic<T : __BuiltinArithmeticType, let N : int>
@@ -6361,44 +6281,49 @@ __glsl_extension(GL_KHR_shader_subgroup_arithmetic)
 __spirv_version(1.3)
 __target_intrinsic(glsl, "subgroupMul($0)")
 __target_intrinsic(hlsl)
-vector<T,N> WaveActiveProduct(vector<T,N> expr)
+vector<T,N> WaveActive$(opName.hlslName)(vector<T,N> expr)
 {
-    return WaveMaskProduct(WaveGetActiveMask(), expr);
+    __target_switch
+    {
+    case glsl: __intrinsic_asm "subgroup$(opName.glslName)($0)";
+    case hlsl: __intrinsic_asm "WaveActive$(opName.hlslName)";
+    case spirv:
+        if (__isFloat<T>())
+            return spirv_asm {
+                OpCapability GroupNonUniformArithmetic;
+                OpGroupNonUniformF$(opName.glslName) $$vector<T,N> result Subgroup 0 $expr
+            };
+        else if (__isSignedInt<T>())
+        {
+            return spirv_asm
+            {
+                OpCapability GroupNonUniformArithmetic;
+                // TODO: use the correct integer width
+                OpBitcast $$vector<uint,N> %uvalue $expr;
+                OpGroupNonUniformI$(opName.glslName) $$vector<uint,N> %$(opName.glslName)Result Subgroup 0 %uvalue;
+                OpBitcast $$vector<T,N> result %$(opName.glslName)Result
+            };
+        }
+        else if (__isUnsignedInt<T>())
+            return spirv_asm
+            {
+                OpCapability GroupNonUniformArithmetic;
+                OpGroupNonUniformI$(opName.glslName) $$vector<T,N> result Subgroup 0 $expr
+            };
+    default:
+        return WaveMask$(opName.hlslName)(WaveGetActiveMask(), expr);
+    }
 }
 
 __generic<T : __BuiltinArithmeticType, let N : int, let M : int>
 __target_intrinsic(hlsl)
-matrix<T, N, M> WaveActiveProduct(matrix<T, N, M> expr)
+matrix<T, N, M> WaveActive$(opName.hlslName)(matrix<T, N, M> expr)
 {
-    return WaveMaskProduct(WaveGetActiveMask(), expr);
+    return WaveMask$(opName.hlslName)(WaveGetActiveMask(), expr);
 }
-
-__generic<T : __BuiltinArithmeticType>
-__glsl_extension(GL_KHR_shader_subgroup_arithmetic)
-__spirv_version(1.3)
-__target_intrinsic(glsl, "subgroupAdd($0)")
-__target_intrinsic(hlsl)
-T WaveActiveSum(T expr)
-{
-    return WaveMaskSum(WaveGetActiveMask(), expr);
-}
-
-__generic<T : __BuiltinArithmeticType, let N : int>
-__glsl_extension(GL_KHR_shader_subgroup_arithmetic)
-__spirv_version(1.3)
-__target_intrinsic(glsl, "subgroupAdd($0)")
-__target_intrinsic(hlsl)
-vector<T,N> WaveActiveSum(vector<T,N> expr)
-{
-    return WaveMaskSum(WaveGetActiveMask(), expr);
-}
-
-__generic<T : __BuiltinArithmeticType, let N : int, let M : int>
-__target_intrinsic(hlsl)
-matrix<T,N,M> WaveActiveSum(matrix<T,N,M> expr)
-{
-    return WaveMaskSum(WaveGetActiveMask(), expr);
-}
+${{{{
+} // WaveActiveProduct/WaveActiveProductSum.
+}}}}
 
 __generic<T : __BuiltinType>
 __glsl_extension(GL_KHR_shader_subgroup_vote)

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -6125,7 +6125,7 @@ ${{{{
 struct WaveActiveBitOpEntry { const char* hlslName; const char* glslName; const char* spirvName; };
 const WaveActiveBitOpEntry kWaveActiveBitOpEntries[] = {{"BitAnd", "And", "BitwiseAnd"}, {"BitOr", "Or", "BitwiseOr"}, {"BitXor", "Xor", "BitwiseXor"}};
 for (auto opName : kWaveActiveBitOpEntries) {
-}}}}wave
+}}}}
 
 __generic<T : __BuiltinIntegerType>
 __glsl_extension(GL_KHR_shader_subgroup_arithmetic)

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -6279,7 +6279,6 @@ T WaveActive$(opName.hlslName)(T expr)
 __generic<T : __BuiltinArithmeticType, let N : int>
 __glsl_extension(GL_KHR_shader_subgroup_arithmetic)
 __spirv_version(1.3)
-__target_intrinsic(glsl, "subgroupMul($0)")
 __target_intrinsic(hlsl)
 vector<T,N> WaveActive$(opName.hlslName)(vector<T,N> expr)
 {

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -601,6 +601,9 @@ class AttributeBase : public Modifier
     
     AttributeDecl* attributeDecl = nullptr;
 
+    // The original identifier token representing the last part of the qualified name.
+    Token originalIdentifierToken;
+
     List<Expr*> args;
 };
 

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2073,7 +2073,7 @@ namespace Slang
                                     // Replace the expression. This should make this situation easier to detect.
                                     expr->arguments[pp] = lValueImplicitCast;
                                 }
-                                else
+                                else if (!as<ErrorType>(argExpr->type))
                                 {
                                     getSink()->diagnose(
                                         argExpr,
@@ -2102,11 +2102,10 @@ namespace Slang
                                             // Fall back, in case there are other reasons...
                                             diagnostic = &Diagnostics::implicitCastUsedAsLValue;
                                         }
-
                                         getSink()->diagnoseWithoutSourceView(
                                             argExpr,
                                             *diagnostic,
-                                            implicitCastExpr->arguments[pp]->type,
+                                            implicitCastExpr->arguments[0]->type,
                                             implicitCastExpr->type);
                                     }
 

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -810,6 +810,7 @@ namespace Slang
 
         // First copy all of the state over from the original attribute.
         attr->keywordName  = uncheckedAttr->keywordName;
+        attr->originalIdentifierToken = uncheckedAttr->originalIdentifierToken;
         attr->args  = uncheckedAttr->args;
         attr->loc   = uncheckedAttr->loc;
         attr->attributeDecl = attrDecl;

--- a/source/slang/slang-language-server-ast-lookup.cpp
+++ b/source/slang/slang-language-server-ast-lookup.cpp
@@ -684,8 +684,8 @@ bool _findAstNodeImpl(ASTLookupContext& context, SyntaxNode* node)
                 if (attribute->getKeywordName() &&
                     _isLocInRange(
                         &context,
-                        attribute->getKeywordNameAndLoc().loc,
-                        attribute->getKeywordName()->text.getLength()))
+                        attribute->originalIdentifierToken.loc,
+                        attribute->originalIdentifierToken.getContentLength()))
                 {
                     ASTLookupResult result;
                     result.path = context.nodePath;

--- a/source/slang/slang-language-server-semantic-tokens.cpp
+++ b/source/slang/slang-language-server-semantic-tokens.cpp
@@ -199,7 +199,8 @@ List<SemanticToken> getSemanticTokens(Linkage* linkage, Module* module, UnownedS
                 if (attr->getKeywordName())
                 {
                     SemanticToken token = _createSemanticToken(
-                        manager, attr->getKeywordNameAndLoc().loc, attr->getKeywordName());
+                        manager, attr->originalIdentifierToken.loc, nullptr);
+                    token.length = (int)attr->originalIdentifierToken.getContentLength();
                     token.type = SemanticTokenType::Type;
                     maybeInsertToken(token);
                 }

--- a/source/slang/slang-language-server.cpp
+++ b/source/slang/slang-language-server.cpp
@@ -714,6 +714,7 @@ SlangResult LanguageServer::hover(
     else if (auto attr = as<Attribute>(leafNode))
     {
         fillDeclRefHoverInfo(makeDeclRef(attr->attributeDecl));
+        hover.range.end.character = hover.range.start.character + (int)attr->originalIdentifierToken.getContentLength();
     }
     if (sb.getLength() == 0)
     {

--- a/tests/diagnostics/vk-bindings.slang.expected
+++ b/tests/diagnostics/vk-bindings.slang.expected
@@ -5,7 +5,7 @@ Texture2D t : register(t0);
               ^~~~~~~~
 tests/diagnostics/vk-bindings.slang(14): error 39015: shader parameter 'b' consumes whole descriptor sets, so the binding must be in the form '[[vk::binding(0, ...)]]'; the non-zero binding '2' is not allowed
 [[vk::binding(2,1)]]
-  ^~
+      ^~~~~~~
 }
 standard output = {
 }

--- a/tests/spirv/spirv-instruction.slang
+++ b/tests/spirv/spirv-instruction.slang
@@ -4,7 +4,7 @@
 // Test using a spirv op. 128 is SpvOpIAdd
 
 [[vk::spirv_instruction(128)]]
-uint add(uint a, uint b);
+uint add(uint a, uint b); 
 
 //TEST_INPUT:set resultBuffer = out ubuffer(data=[0 0 0 0], stride=4)
 RWStructuredBuffer<uint> resultBuffer;


### PR DESCRIPTION
Fix highlighting issues around attributes that are qualified with `::`, e.g. `[[vk::attributeName]]`.

Fix a type checking crash causing https://github.com/shader-slang/slang-vscode-extension/issues/5

Fix spirv wave intrinsics.