### PR TITLE
Add check for contiguous tensors

### DIFF
--- a/prelude/slang-torch-prelude.h
+++ b/prelude/slang-torch-prelude.h
@@ -87,6 +87,10 @@ TensorView make_tensor_view(torch::Tensor val, const char* name, torch::ScalarTy
     if (val.dtype() != targetScalarType)
         throw std::runtime_error(std::string(name).append(": tensor is not of the expected type.").c_str());
 
+    // Check that the tensor is contiguous
+    if (!val.is_contiguous())
+        throw std::runtime_error(std::string(name).append(": tensor is not contiguous.").c_str());
+
     TensorView res = {};
     res.dimensionCount = val.dim();
     res.data = nullptr;


### PR DESCRIPTION
Otherwise, this can lead to undetected scenarios where the strides are incorrect for non-scalar types (`float2`, `float3`, etc..)

Users must call `tensor = tensor.contiguous()` on the inputs to avoid this error.