### PR TITLE
Direct SPIRV for RayTracing Inline.

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -7743,6 +7743,30 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     __intrinsic_op($(kIROp_AllocateOpaqueHandle))
     __init();
 
+    
+    __target_intrinsic(glsl, "rayQueryInitializeEXT($0, $1, $2, $3, $4, $5, $6, $7)")
+    __glsl_extension(GL_EXT_ray_query)
+    __glsl_version(460)
+    [mutating]
+    void __rayQueryInitializeEXT(
+        RaytracingAccelerationStructure accelerationStructure,
+        RAY_FLAG                        rayFlags,
+        uint                            instanceInclusionMask,
+        float3                          origin,
+        float                           tMin,
+        float3                          direction,
+        float                           tMax)
+    {
+        __target_switch
+        {
+        case glsl: __intrinsic_asm "rayQueryInitializeEXT($0, $1, $2, $3, $4, $5, $6, $7)";
+        case spirv:
+            spirv_asm {
+                OpRayQueryInitializeKHR &this $accelerationStructure $rayFlags $instanceInclusionMask $origin $tMin $direction $tMax;
+            };
+        }
+    }
+
     // Initialize a ray-tracing query.
     //
     // This method may be called on a "fresh" ray query, or
@@ -7755,29 +7779,7 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     // `RayQuery` to get the effective ray flags, which
     // must obey any API-imposed restrictions.
     //
-    __target_intrinsic(hlsl)
-    [mutating]
-    void TraceRayInline(
-        RaytracingAccelerationStructure accelerationStructure,
-        RAY_FLAG                        rayFlags,
-        uint                            instanceInclusionMask,
-        RayDesc                         ray);
-
-    __target_intrinsic(glsl, "rayQueryInitializeEXT($0, $1, $2, $3, $4, $5, $6, $7)")
-    __glsl_extension(GL_EXT_ray_query)
-    __glsl_version(460)
-    [mutating]
-    void __rayQueryInitializeEXT(
-        RaytracingAccelerationStructure accelerationStructure,
-        RAY_FLAG                        rayFlags,
-        uint                            instanceInclusionMask,
-        float3                          origin,
-        float                           tMin,
-        float3                          direction,
-        float                           tMax);
-
     [__unsafeForceInlineEarly]
-    __specialized_for_target(glsl)
     [mutating]
     void TraceRayInline(
         RaytracingAccelerationStructure accelerationStructure,
@@ -7785,16 +7787,22 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
         uint                            instanceInclusionMask,
         RayDesc                         ray)
     {
-        __rayQueryInitializeEXT(
-            accelerationStructure,
-            rayFlags | rayFlagsGeneric,
-            instanceInclusionMask,
-            ray.Origin,
-            ray.TMin,
-            ray.Direction,
-            ray.TMax);
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm "TraceRayInline";
+        case glsl:
+        case spirv:
+            __rayQueryInitializeEXT(
+                accelerationStructure,
+                rayFlags | rayFlagsGeneric,
+                instanceInclusionMask,
+                ray.Origin,
+                ray.TMin,
+                ray.Direction,
+                ray.TMax);
+        }
     }
-
+    
     // Resume the ray query coroutine.
     //
     // If the coroutine suspends because of encountering
@@ -7809,11 +7817,21 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     // functions to appropriately handle the closest hit (it any)
     // that was found.
     //
-    __target_intrinsic(glsl, rayQueryProceedEXT)
     __glsl_extension(GL_EXT_ray_query)
     __glsl_version(460)
     [mutating]
-    bool Proceed();
+    bool Proceed()
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm "";
+        case glsl: __intrinsic_asm "rayQueryProceedEXT";
+        case spirv: return spirv_asm
+            {
+                result:$$bool = OpRayQueryProceedKHR &this
+            };
+        }
+    }
 
     // Causes the ray query to terminate.
     //
@@ -7821,11 +7839,18 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     // traversal has terminated, so that subsequent
     // `Proceed()` calls will return `false`.
     //
-    __target_intrinsic(glsl, rayQueryTerminateEXT)
     __glsl_extension(GL_EXT_ray_query)
     __glsl_version(460)
     [mutating]
-    void Abort();
+    void Abort()
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm "";
+        case glsl: __intrinsic_asm "rayQueryTerminateEXT";
+        case spirv: spirv_asm { OpRayQueryTerminateKHR &this };
+        }
+    }
 
     // Get the type of candidate hit being considered.
     //
@@ -7840,7 +7865,19 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     __glsl_extension(GL_EXT_ray_query)
     __glsl_version(460)
     [__readNone]
-    CANDIDATE_TYPE CandidateType();
+    CANDIDATE_TYPE CandidateType()
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm "";
+        case glsl: __intrinsic_asm "rayQueryGetIntersectionTypeEXT($0, false)";
+        case spirv:
+            uint RayQueryCandidateIntersectionKHR = 0;
+            return spirv_asm {
+                result:$$CANDIDATE_TYPE = OpRayQueryGetIntersectionTypeKHR &this $RayQueryCandidateIntersectionKHR;
+            };
+        }
+    }
 
     // Access properties of a candidate hit.
 
@@ -7962,7 +7999,20 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     __glsl_extension(GL_EXT_ray_query)
     __glsl_version(460)
     [__readNone]
-    COMMITTED_STATUS CommittedStatus();
+    COMMITTED_STATUS CommittedStatus()
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm "";
+        case glsl: __intrinsic_asm "rayQueryGetIntersectionTypeEXT($0, true)";
+        case spirv:
+            uint RayQueryCommittedIntersectionKHR = 1;
+            return spirv_asm
+            {
+                result:$$COMMITTED_STATUS = OpRayQueryGetIntersectionTypeKHR &this $RayQueryCommittedIntersectionKHR;
+            };
+        }
+    }
 
     // Access properties of the committed hit.
     //
@@ -7994,7 +8044,20 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     __glsl_extension(GL_EXT_ray_query)
     __glsl_version(460)
     [__readNone]
-    float CommittedRayT();
+    float CommittedRayT()
+    {
+        __target_switch
+        {
+        case glsl: __intrinsic_asm "rayQueryGetIntersectionTEXT($0, true)";
+        case hlsl: __intrinsic_asm "";
+        case spirv:
+            uint RayQueryCommittedIntersectionKHR = 1;
+            return spirv_asm
+            {
+                result:$$float = OpRayQueryGetIntersectionTKHR &this $RayQueryCommittedIntersectionKHR
+            };
+        }
+    }
 
     __target_intrinsic(glsl, "rayQueryGetIntersectionInstanceIdEXT($0, true)")
     __glsl_extension(GL_EXT_ray_query)

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -670,6 +670,8 @@ namespace Slang
                         ThisExpr* expr = m_astBuilder->create<ThisExpr>();
                         expr->type.type = thisType;
                         expr->loc = loc;
+                        if (auto declRefExpr = as<DeclRefExpr>(originalExpr))
+                            expr->scope = declRefExpr->scope;
 
                         // Whether or not the implicit `this` is mutable depends
                         // on the context in which it is used, and the lookup

--- a/source/slang/slang-emit-spirv-ops.h
+++ b/source/slang/slang-emit-spirv-ops.h
@@ -229,6 +229,20 @@ SpvInst* emitOpTypeSampler(IRInst* inst)
     );
 }
 
+SpvInst* emitOpTypeAccelerationStructure(IRInst* inst)
+{
+    return emitInstMemoized(
+        getSection(SpvLogicalSectionID::ConstantsAndTypes), inst, SpvOpTypeAccelerationStructureKHR, kResultID
+    );
+}
+
+SpvInst* emitOpTypeRayQuery(IRInst* inst)
+{
+    return emitInstMemoized(
+        getSection(SpvLogicalSectionID::ConstantsAndTypes), inst, SpvOpTypeRayQueryKHR, kResultID
+    );
+}
+
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpTypeArray
 template<typename T1, typename T2>
 SpvInst* emitOpTypeArray(IRInst* inst, const T1& elementType, const T2& length)

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1430,11 +1430,17 @@ struct SPIRVEmitContext
                 );
             }
         case kIROp_SamplerStateType:
-                return emitOpTypeSampler(inst);
-        // > OpTypeArray
-        // > OpTypeRuntimeArray
-        // > OpTypeOpaque
-        // > OpTypePointer
+            return emitOpTypeSampler(inst);
+
+        case kIROp_RaytracingAccelerationStructureType:
+            requireSPIRVCapability(SpvCapabilityRayTracingKHR);
+            ensureExtensionDeclaration(UnownedStringSlice("SPV_KHR_ray_tracing"));
+            return emitOpTypeAccelerationStructure(inst);
+
+        case kIROp_RayQueryType:
+            ensureExtensionDeclaration(UnownedStringSlice("SPV_KHR_ray_query"));
+            requireSPIRVCapability(SpvCapabilityRayQueryKHR);
+            return emitOpTypeRayQuery(inst);
 
         case kIROp_FuncType:
             // > OpTypeFunction
@@ -1544,6 +1550,8 @@ struct SPIRVEmitContext
             }
         case kIROp_GetStringHash:
             return emitGetStringHash(inst);
+        case kIROp_AllocateOpaqueHandle:
+            return nullptr;
         default:
             {
                 if (as<IRSPIRVAsmOperand>(inst))

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -202,6 +202,20 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 i->removeAndDeallocate();
     }
 
+    bool isSpirvUniformConstantType(IRType* type)
+    {
+        if (as<IRTextureTypeBase>(type))
+            return true;
+        if (as<IRSamplerStateTypeBase>(type))
+            return true;
+        switch (type->getOp())
+        {
+        case kIROp_RaytracingAccelerationStructureType:
+        case kIROp_RayQueryType:
+            return true;
+        }
+    }
+
     void processGlobalParam(IRGlobalParam* inst)
     {
         // If the global param is not a pointer type, make it so and insert explicit load insts.
@@ -237,8 +251,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             // Textures and Samplers can't be in Uniform for Vulkan, if they are
             // placed here then put them in UniformConstant instead
             if (storageClass == SpvStorageClassUniform
-                && (as<IRTextureTypeBase>(inst->getDataType())
-                    || as<IRSamplerStateTypeBase>(inst->getDataType())))
+                && isSpirvUniformConstantType(inst->getDataType()))
             {
                 storageClass = SpvStorageClassUniformConstant;
             }

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -2530,10 +2530,16 @@ ParameterDirection getParameterDirection(VarDeclBase* paramDecl)
     ///
 ParameterDirection getThisParamDirection(Decl* parentDecl, ParameterDirection defaultDirection)
 {
+    auto parentParent = getParentDecl(parentDecl);
     // The `this` parameter for a `class` is always `in`.
-    if (as<ClassDecl>(parentDecl->parentDecl))
+    if (as<ClassDecl>(parentParent))
     {
         return kParameterDirection_In;
+    }
+
+    if (parentParent->findModifier<NonCopyableTypeAttribute>())
+    {
+        return kParameterDirection_Ref;
     }
 
     // Applications can opt in to a mutable `this` parameter,

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -6294,13 +6294,8 @@ namespace Slang
     static std::optional<SPIRVAsmOperand> parseSPIRVAsmOperand(Parser* parser)
     {
         const auto slangIdentOperand = [&](auto flavor){
-            const auto tok = parser->ReadToken(TokenType::Identifier);
-
-            VarExpr* varExpr = parser->astBuilder->create<VarExpr>();
-            varExpr->scope = parser->currentScope;
-            varExpr->loc = tok.getLoc();
-            varExpr->name = tok.getName();
-            return SPIRVAsmOperand{flavor, tok, varExpr};
+            auto token = parser->tokenReader.peekToken();
+            return SPIRVAsmOperand{flavor, token, parseAtomicExpr(parser)};
         };
 
         const auto slangTypeExprOperand = [&](auto flavor) {

--- a/tests/expected-failure.txt
+++ b/tests/expected-failure.txt
@@ -1,8 +1,6 @@
 tests/autodiff/global-param-hoisting.slang.1 (vk)
 tests/bugs/buffer-swizzle-store.slang.1 (vk)
-tests/bugs/gh-3075.slang.2 (vk)
 tests/bugs/ray-query-in-generic.slang.1 (vk)
-tests/compute/ray-tracing-inline.slang.1 (vk)
 tests/language-feature/constants/constexpr-loop.slang.1 (vk)
 tests/optimization/func-resource-result/func-resource-result-complex.slang.1 (vk)
 tests/type/texture-sampler/texture-sampler-2d.slang (vk)


### PR DESCRIPTION
Add intrinsics to get ray-trace-inline test to work.