### PR TITLE
Fix build with --enable-xlib=false

### DIFF
--- a/tools/gfx/vulkan/vk-api.h
+++ b/tools/gfx/vulkan/vk-api.h
@@ -141,9 +141,12 @@ namespace gfx {
 #   define VK_API_INSTANCE_PLATFORM_KHR_PROCS(x)          \
     x(vkCreateWin32SurfaceKHR) \
     /* */
-#else
+#elif SLANG_ENABLE_XLIB
 #   define VK_API_INSTANCE_PLATFORM_KHR_PROCS(x)          \
     x(vkCreateXlibSurfaceKHR) \
+    /* */
+#else
+#   define VK_API_INSTANCE_PLATFORM_KHR_PROCS(x)          \
     /* */
 #endif
 

--- a/tools/gfx/vulkan/vk-device.cpp
+++ b/tools/gfx/vulkan/vk-device.cpp
@@ -171,11 +171,13 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
 #if SLANG_WINDOWS_FAMILY
             instanceExtensions.add(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
 #elif defined(SLANG_ENABLE_XLIB)
+
             instanceExtensions.add(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
 #endif
+        }
+
         if (ENABLE_VALIDATION_LAYER || isGfxDebugLayerEnabled())
             instanceExtensions.add(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
-        }
 
         VkInstanceCreateInfo instanceCreateInfo = { VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO };
         instanceCreateInfo.pApplicationInfo = &applicationInfo;

--- a/tools/gfx/vulkan/vk-swap-chain.cpp
+++ b/tools/gfx/vulkan/vk-swap-chain.cpp
@@ -221,13 +221,15 @@ Result SwapchainImpl::init(DeviceImpl* renderer, const ISwapchain::Desc& desc, W
     surfaceCreateInfo.hwnd = (HWND)window.handleValues[0];
     SLANG_VK_RETURN_ON_FAIL(
         m_api->vkCreateWin32SurfaceKHR(m_api->m_instance, &surfaceCreateInfo, nullptr, &m_surface));
-#else
+#elif SLANG_ENABLE_XLIB
     VkXlibSurfaceCreateInfoKHR surfaceCreateInfo = {};
     surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
     surfaceCreateInfo.dpy = (Display*)window.handleValues[0];
     surfaceCreateInfo.window = (Window)window.handleValues[1];
     SLANG_VK_RETURN_ON_FAIL(
         m_api->vkCreateXlibSurfaceKHR(m_api->m_instance, &surfaceCreateInfo, nullptr, &m_surface));
+#else
+    return SLANG_E_NOT_AVAILABLE;
 #endif
 
     VkBool32 supported = false;


### PR DESCRIPTION
Since Jan 2022 Swiftshader no longer supports xlib (it suggests using xcb instead)