### PR TITLE
Memoize types in spirv asm blocks

### DIFF
--- a/tests/expected-failure.txt
+++ b/tests/expected-failure.txt
@@ -1,4 +1,3 @@
-tests/language-feature/constants/constexpr-loop.slang.1 (vk)
 tests/optimization/func-resource-result/func-resource-result-complex.slang.1 (vk)
 tests/type/texture-sampler/texture-sampler-2d.slang (vk)
 tests/hlsl-intrinsic/texture-lod-shadow.slang.1


### PR DESCRIPTION
Still TODO: emit a diagnostic when a use of a memoized value precedes its definition.