### PR TITLE
Various slangpy fixes.

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2290,6 +2290,15 @@ __attributeTarget(FuncDecl)
 attribute_syntax [CudaKernel] : CudaKernelAttribute;
 
 __attributeTarget(FuncDecl)
+attribute_syntax [CUDADeviceExport] : CudaDeviceExportAttribute;
+
+__attributeTarget(FuncDecl)
+attribute_syntax [CUDAHost] : CudaHostAttribute;
+
+__attributeTarget(FuncDecl)
+attribute_syntax [CUDAKernel] : CudaKernelAttribute;
+
+__attributeTarget(FuncDecl)
 attribute_syntax[AutoPyBindCUDA] : AutoPyBindCudaAttribute;
 
 __attributeTarget(AggTypeDecl)

--- a/source/slang/slang-ir-address-analysis.cpp
+++ b/source/slang/slang-ir-address-analysis.cpp
@@ -64,7 +64,7 @@ namespace Slang
             }
         }
 
-        if (!latestOperand || as<IRParam>(latestOperand))
+        if (!latestOperand || as<IRParam, IRDynamicCastBehavior::NoUnwrap>(latestOperand))
             inst->insertBefore(earliestBlock->getFirstOrdinaryInst());
         else
             inst->insertAfter(latestOperand);

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -1647,7 +1647,7 @@ bool isLocalPointer(IRInst* ptrInst)
     // referencing something outside the function scope.
     // 
     auto addr = getRootAddr(ptrInst);
-    return as<IRVar>(addr) || as<IRParam>(addr);
+    return as<IRVar>(addr) || as<IRParam, IRDynamicCastBehavior::NoUnwrap>(addr);
 }
 
 void lowerSwizzledStores(IRModule* module, IRFunc* func)
@@ -2067,7 +2067,7 @@ InstPair ForwardDiffTranscriber::transcribeFuncParam(IRBuilder* builder, IRParam
     }
 
     auto primalInst = cloneInst(&cloneEnv, builder, origParam);
-    if (auto primalParam = as<IRParam>(primalInst))
+    if (auto primalParam = as<IRParam, IRDynamicCastBehavior::NoUnwrap>(primalInst))
     {
         SLANG_RELEASE_ASSERT(builder->getInsertLoc().getBlock());
         primalParam->removeFromParent();

--- a/source/slang/slang-ir-autodiff-unzip.cpp
+++ b/source/slang/slang-ir-autodiff-unzip.cpp
@@ -228,7 +228,7 @@ struct ExtractPrimalFuncContext
                     }
                     else
                     {
-                        if (as<IRParam>(inst))
+                        if (as<IRParam, IRDynamicCastBehavior::NoUnwrap>(inst))
                             builder.setInsertBefore(block->getFirstOrdinaryInst());
                         else
                             builder.setInsertAfter(inst);
@@ -427,7 +427,7 @@ IRFunc* DiffUnzipPass::extractPrimalFunc(
 
     for (auto inst : instsToRemove)
     {
-        if (as<IRParam>(inst))
+        if (as<IRParam, IRDynamicCastBehavior::NoUnwrap>(inst))
             removePhiArgs(inst);
         inst->removeAndDeallocate();
     }

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -324,7 +324,7 @@ IRInst* DifferentialPairTypeBuilder::lowerDiffPairType(
         result = originalPairType;
         return result;
     }
-    if (as<IRParam>(primalType))
+    if (as<IRParam, IRDynamicCastBehavior::NoUnwrap>(primalType))
     {
         result = nullptr;
         return result;

--- a/source/slang/slang-ir-check-differentiability.cpp
+++ b/source/slang/slang-ir-check-differentiability.cpp
@@ -471,7 +471,7 @@ public:
                 auto block = as<IRBlock>(inst->getParent());
                 if (block != funcInst->getFirstBlock())
                 {
-                    auto paramIndex = getParamIndexInBlock(as<IRParam>(inst));
+                    auto paramIndex = getParamIndexInBlock(as<IRParam, IRDynamicCastBehavior::NoUnwrap>(inst));
                     if (paramIndex != -1)
                     {
                         for (auto p : block->getPredecessors())

--- a/source/slang/slang-ir-constexpr.cpp
+++ b/source/slang/slang-ir-constexpr.cpp
@@ -172,7 +172,7 @@ IRLoop* isLoopPhi(IRParam* param)
 bool opCanBeConstExprByBackwardPass(IRInst* value)
 {
     if (value->getOp() == kIROp_Param)
-        return isLoopPhi(as<IRParam>(value));
+        return isLoopPhi(as<IRParam, IRDynamicCastBehavior::NoUnwrap>(value));
     return opCanBeConstExpr(value->getOp());
 }
 

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -766,6 +766,9 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
         /// An extern_cpp decoration marks the inst to emit its name without mangling for C++ interop.
     INST(ExternCppDecoration, externCpp, 1, 0)
 
+        // An externC decoration marks a function should be emitted inside an extern "C" block.
+    INST(ExternCDecoration, externC, 0, 0)
+
         /// An dllImport decoration marks a function as imported from a DLL. Slang will generate dynamic function loading logic to use this function at runtime.
     INST(DllImportDecoration, dllImport, 2, 0)
         /// An dllExport decoration marks a function as an export symbol. Slang will generate a native wrapper function that is exported to DLL.

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -543,6 +543,15 @@ struct IRExternCppDecoration : IRDecoration
     UnownedStringSlice getName() { return getNameOperand()->getStringSlice(); }
 };
 
+struct IRExternCDecoration : IRDecoration
+{
+    enum
+    {
+        kOp = kIROp_ExternCDecoration
+    };
+    IR_LEAF_ISA(ExternCDecoration)
+};
+
 struct IRDllImportDecoration : IRDecoration
 {
     enum
@@ -4274,6 +4283,11 @@ public:
     void addExternCppDecoration(IRInst* value, UnownedStringSlice const& mangledName)
     {
         addDecoration(value, kIROp_ExternCppDecoration, getStringValue(mangledName));
+    }
+
+    void addExternCDecoration(IRInst* value)
+    {
+        addDecoration(value, kIROp_ExternCDecoration);
     }
 
     void addForceInlineDecoration(IRInst* value)

--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -589,7 +589,9 @@ IRGeneric* cloneGenericImpl(
         auto originalParam = originalGeneric->getFirstParam();
 
         ShortList<KeyValuePair<IRInst*, IRInst*>> paramMapping;
-        for (; clonedParam && originalParam; (clonedParam = as<IRParam>(clonedParam->next)), (originalParam = as<IRParam>(originalParam->next)))
+        for (; clonedParam && originalParam;
+            (clonedParam = as<IRParam, IRDynamicCastBehavior::NoUnwrap>(clonedParam->next)),
+            (originalParam = as<IRParam, IRDynamicCastBehavior::NoUnwrap>(originalParam->next)))
         {
             paramMapping.add(KeyValuePair<IRInst*, IRInst*>(clonedParam, originalParam));
         }

--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -776,7 +776,7 @@ struct PeepholeContext : InstPassBase
                     break;
                 UInt paramIndex = 0;
                 auto prevParam = inst->getPrevInst();
-                while (as<IRParam>(prevParam))
+                while (as<IRParam, IRDynamicCastBehavior::NoUnwrap>(prevParam))
                 {
                     prevParam = prevParam->getPrevInst();
                     paramIndex++;

--- a/source/slang/slang-ir-pytorch-cpp-binding.cpp
+++ b/source/slang/slang-ir-pytorch-cpp-binding.cpp
@@ -193,7 +193,7 @@ static IRInst* makeValueFromTargetTuple(IRBuilder& builder, IRType* type, IRInst
         IRIntegerValue i = 0;
         for (auto field : structType->getFields())
         {
-            auto tupleElement = builder.emitTargetTupleGetElement(field->getFieldType(), val, builder.getIntValue(builder.getIntType(), i));
+            auto tupleElement = builder.emitTargetTupleGetElement(translateToTupleType(builder, field->getFieldType()), val, builder.getIntValue(builder.getIntType(), i));
             auto convertedElement = makeValueFromTargetTuple(builder, field->getFieldType(), tupleElement);
             if (!convertedElement)
                 return nullptr;
@@ -317,16 +317,29 @@ static void generateCppBindingForFunc(IRFunc* func, DiagnosticSink* sink)
 
 IRType* translateToHostType(IRBuilder* builder, IRType* type, IRInst* func, DiagnosticSink* sink = nullptr)
 {
-    if (as<IRBasicType>(type))
-        return type;
-    if (as<IRVectorType>(type))
+    if (as<IRBasicType>(type) || as<IRVectorType>(type))
         return type;
 
     switch (type->getOp())
     {
     case kIROp_TensorViewType:
         return builder->getTorchTensorType(as<IRTensorViewType>(type)->getElementType());
-    
+#if 0
+    case kIROp_VectorType:
+    {
+        // Create a new struct type representing the vector.
+        auto hostStructType = builder->createStructType();
+        const char* names[4] = { "x", "y", "z", "w" };
+        for (IRIntegerValue i = 0; i < getIntVal(as<IRVectorType>(type)->getElementCount()); i++)
+        {
+            auto key = builder->createStructKey();
+            if (i < 4)
+                builder->addNameHintDecoration(key, UnownedStringSlice(names[i]));
+            builder->createStructField(hostStructType, key, as<IRVectorType>(type)->getElementType());
+        }
+        return hostStructType;
+    }
+#endif
     case kIROp_StructType:
     {
         // Create a new struct type with translated fields.
@@ -365,7 +378,18 @@ IRInst* castHostToCUDAType(IRBuilder* builder, IRType* hostType, IRType* cudaTyp
     {
     case kIROp_TensorViewType:
         return builder->emitMakeTensorView(cudaType, inst);
-    
+#if 0
+    case kIROp_VectorType:
+    {
+        List<IRInst*> args;
+        auto hostStructType = cast<IRStructType>(hostType);
+        for (auto field : hostStructType->getFields())
+        {
+            args.add(builder->emitFieldExtract(field->getFieldType(), inst, field->getKey()));
+        }
+        return builder->emitMakeVector(cudaType, args);
+    }
+#endif
     case kIROp_StructType:
     {
         auto cudaStructType = cast<IRStructType>(cudaType);
@@ -863,6 +887,7 @@ void handleAutoBindNames(IRModule* module)
                 nameBuilder << "__kernel__" << externCppHint->getName();
                 externCppHint->removeAndDeallocate();
                 builder.addExternCppDecoration(globalInst, nameBuilder.getUnownedSlice());
+                builder.addExternCDecoration(globalInst);
             }
         }
     }
@@ -919,7 +944,10 @@ void generateDerivativeWrappers(IRModule* module, DiagnosticSink* sink)
 
                 // If the original func is a CUDA kernel, mark the wrapper as a CUDA kernel as well.
                 if (func->findDecoration<IRCudaKernelDecoration>())
+                {
                     builder.addCudaKernelDecoration(wrapperFunc);
+                    builder.addExternCDecoration(wrapperFunc);
+                }
 
                 // Add an auto-pybind-cuda decoration to the wrapper function to further generate the 
                 // host-side binding for the derivative kernel.
@@ -975,7 +1003,10 @@ void generateDerivativeWrappers(IRModule* module, DiagnosticSink* sink)
 
                 // If the original func is a CUDA kernel, mark the wrapper as a CUDA kernel as well.
                 if (func->findDecoration<IRCudaKernelDecoration>())
+                {
                     builder.addCudaKernelDecoration(wrapperFunc);
+                    builder.addExternCDecoration(wrapperFunc);
+                }
 
                 // Add an auto-pybind-cuda decoration to the wrapper function to further generate the 
                 // host-side binding for the derivative kernel.

--- a/source/slang/slang-ir-sccp.cpp
+++ b/source/slang/slang-ir-sccp.cpp
@@ -1022,7 +1022,7 @@ struct SCCPContext
         // that provide arguments. We will see that logic shortly, when
         // handling `IRUnconditionalBranch`.
         //
-        if(as<IRParam>(inst))
+        if(as<IRParam, IRDynamicCastBehavior::NoUnwrap>(inst))
             return;
 
         // We want to special-case terminator instructions here,

--- a/source/slang/slang-ir-simplify-cfg.cpp
+++ b/source/slang/slang-ir-simplify-cfg.cpp
@@ -205,7 +205,7 @@ static bool doesLoopHasSideEffect(IRGlobalValueWithCode* func, IRLoop* loopInst)
         auto rootAddr = getRootAddr(addr);
         if (isGlobalOrUnknownMutableAddress(func, rootAddr))
             return true;
-        if (as<IRParam>(rootAddr))
+        if (as<IRParam, IRDynamicCastBehavior::NoUnwrap>(rootAddr))
             return true;
 
         // If we can't find the address from our map, we conservatively assume it is an unknown address.

--- a/source/slang/slang-ir-ssa-register-allocate.cpp
+++ b/source/slang/slang-ir-ssa-register-allocate.cpp
@@ -103,7 +103,7 @@ struct RegisterAllocateContext
 
     bool isUseOfParamAfterPhiAssignment(IRDominatorTree* dom, IRUse* useToTest, IRInst* phiParam, IRInst* phiArg)
     {
-        IRParam* param = as<IRParam>(phiParam);
+        IRParam* param = as<IRParam, IRDynamicCastBehavior::NoUnwrap>(phiParam);
         if (!param)
             return false;
         IRUse* branchUse = nullptr;

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -617,7 +617,7 @@ void removeLinkageDecorations(IRGlobalValueWithCode* func)
 
 void setInsertBeforeOrdinaryInst(IRBuilder* builder, IRInst* inst)
 {
-    if (as<IRParam>(inst))
+    if (as<IRParam, IRDynamicCastBehavior::NoUnwrap>(inst))
     {
         SLANG_RELEASE_ASSERT(as<IRBlock>(inst->getParent()));
         auto lastParam = as<IRBlock>(inst->getParent())->getLastParam();
@@ -631,7 +631,7 @@ void setInsertBeforeOrdinaryInst(IRBuilder* builder, IRInst* inst)
 
 void setInsertAfterOrdinaryInst(IRBuilder* builder, IRInst* inst)
 {
-    if (as<IRParam>(inst))
+    if (as<IRParam, IRDynamicCastBehavior::NoUnwrap>(inst))
     {
         SLANG_RELEASE_ASSERT(as<IRBlock>(inst->getParent()));
         auto lastParam = as<IRBlock>(inst->getParent())->getLastParam();
@@ -818,7 +818,7 @@ void moveParams(IRBlock* dest, IRBlock* src)
     for (auto param = src->getFirstChild(); param;)
     {
         auto nextInst = param->getNextInst();
-        if (as<IRDecoration>(param) || as<IRParam>(param))
+        if (as<IRDecoration>(param) || as<IRParam, IRDynamicCastBehavior::NoUnwrap>(param))
         {
             param->insertAtEnd(dest);
         }

--- a/source/slang/slang-ir-validate.cpp
+++ b/source/slang/slang-ir-validate.cpp
@@ -80,7 +80,7 @@ namespace Slang
                 validate(context, state <= kState_AfterDecoration, child, "decorations must come before other child instructions");
                 state = kState_AfterDecoration;
             }
-            else if( as<IRParam>(child) )
+            else if( as<IRParam, IRDynamicCastBehavior::NoUnwrap>(child) )
             {
                 validate(context, state <= kState_AfterParam, child, "parameters must come before ordinary instructions");
                 state = kState_AfterParam;

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -304,12 +304,12 @@ namespace Slang
 
     IRParam* IRParam::getNextParam()
     {
-        return as<IRParam>(getNextInst());
+        return as<IRParam, IRDynamicCastBehavior::NoUnwrap>(getNextInst());
     }
 
     IRParam* IRParam::getPrevParam()
     {
-        return as<IRParam>(getPrevInst());
+        return as<IRParam, IRDynamicCastBehavior::NoUnwrap>(getPrevInst());
     }
 
     // IRArrayTypeBase
@@ -472,7 +472,7 @@ namespace Slang
         // If the last instruction is a parameter, then
         // there are no ordinary instructions, so the last
         // one is a null pointer.
-        if (as<IRParam>(inst))
+        if (as<IRParam, IRDynamicCastBehavior::NoUnwrap>(inst))
             return nullptr;
 
         // Otherwise the last instruction is the last "ordinary"
@@ -1643,8 +1643,8 @@ namespace Slang
         // instructions, so they need to come after
         // any parameters of the parent.
         //
-        while(auto param = as<IRParam>(insertBeforeInst))
-            insertBeforeInst = param->getNextInst();
+        while (insertBeforeInst && insertBeforeInst->getOp() == kIROp_Param)
+            insertBeforeInst = insertBeforeInst->getNextInst();
 
         // For instructions that will be placed at module scope,
         // we don't care about relative ordering, but for everything
@@ -6425,14 +6425,14 @@ namespace Slang
 
         // First walk through any `param` instructions,
         // so that we can format them nicely
-        if (auto firstParam = as<IRParam>(inst))
+        if (auto firstParam = as<IRParam, IRDynamicCastBehavior::NoUnwrap>(inst))
         {
             dump(context, "(\n");
             context->indent += 2;
 
             for(;;)
             {
-                auto param = as<IRParam>(inst);
+                auto param = as<IRParam, IRDynamicCastBehavior::NoUnwrap>(inst);
                 if (!param)
                     break;
 

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -828,31 +828,42 @@ struct IRInst
     void _insertAt(IRInst* inPrev, IRInst* inNext, IRInst* inParent);
 };
 
-template<typename T>
+enum class IRDynamicCastBehavior
+{
+    Unwrap, NoUnwrap
+};
+
+template<typename T, IRDynamicCastBehavior behavior = IRDynamicCastBehavior::Unwrap>
 T* dynamicCast(IRInst* inst)
 {
-    if (inst && T::isaImpl(inst->getOp()))
+    if (!inst) return nullptr;
+    if (T::isaImpl(inst->getOp()))
         return static_cast<T*>(inst);
+    if constexpr(behavior == IRDynamicCastBehavior::Unwrap)
+    {
+        if (inst->getOp() == kIROp_AttributedType)
+            return dynamicCast<T>(inst->getOperand(0));
+    }
     return nullptr;
 }
 
-template<typename T>
+template<typename T, IRDynamicCastBehavior behavior = IRDynamicCastBehavior::Unwrap>
 const T* dynamicCast(const IRInst* inst)
 {
-    return dynamicCast<T>(const_cast<IRInst*>(inst));
+    return dynamicCast<T, behavior>(const_cast<IRInst*>(inst));
 }
 
 // `dynamic_cast` equivalent (we just use dynamicCast)
-template<typename T>
+template<typename T, IRDynamicCastBehavior behavior = IRDynamicCastBehavior::Unwrap>
 T* as(IRInst* inst)
 {
-    return dynamicCast<T>(inst);
+    return dynamicCast<T, behavior>(inst);
 }
 
-template<typename T>
+template<typename T, IRDynamicCastBehavior behavior = IRDynamicCastBehavior::Unwrap>
 const T* as(const IRInst* inst)
 {
-    return dynamicCast<T>(inst);
+    return dynamicCast<T, behavior>(inst);
 }
 
 // `static_cast` equivalent, with debug validation
@@ -1228,7 +1239,7 @@ struct IRBlock : IRInst
     // instructions at the start of the block. These play
     // the role of function parameters for the entry block
     // of a function, and of phi nodes in other blocks.
-    IRParam* getFirstParam() { return as<IRParam>(getFirstInst()); }
+    IRParam* getFirstParam() { return as<IRParam, IRDynamicCastBehavior::NoUnwrap>(getFirstInst()); }
     IRParam* getLastParam();
     IRInstList<IRParam> getParams()
     {

--- a/tests/autodiff/modify-vector-param.slang
+++ b/tests/autodiff/modify-vector-param.slang
@@ -6,10 +6,16 @@ RWStructuredBuffer<float> outputBuffer;
 
 typedef float.Differential dfloat;
 
-[Differentiable]
-float3 f(float3 x, uint2 v)
+struct Params
 {
-    v.x = 1;
+    float vv;
+}
+
+[Differentiable]
+float3 f(float3 x, uint2 v, Params p)
+{
+    v.x = 1 + int(p.vv);
+
     x.y = x.x * x.x;
     return x;
 }
@@ -18,9 +24,10 @@ float3 f(float3 x, uint2 v)
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     {
-        var dpa = diffPair(float3(4.0,2.0,3.0));
-
-        __bwd_diff(f)(dpa, uint2(1,2), float3(1.0,1.0,1.0));
+        var dpa = diffPair(float3(4.0, 2.0, 3.0));
+        Params p;
+        p.vv = 0.0;
+        __bwd_diff(f)(dpa, uint2(1,2), p, float3(1.0,1.0,1.0));
 
         // CHECK: 9.0
         outputBuffer[0] = dpa.d.x; // Expect: 9.0

--- a/tests/autodiff/modify-vector-param.slang
+++ b/tests/autodiff/modify-vector-param.slang
@@ -1,0 +1,28 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+typedef float.Differential dfloat;
+
+[Differentiable]
+float3 f(float3 x, uint2 v)
+{
+    v.x = 1;
+    x.y = x.x * x.x;
+    return x;
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    {
+        var dpa = diffPair(float3(4.0,2.0,3.0));
+
+        __bwd_diff(f)(dpa, uint2(1,2), float3(1.0,1.0,1.0));
+
+        // CHECK: 9.0
+        outputBuffer[0] = dpa.d.x; // Expect: 9.0
+    }
+}


### PR DESCRIPTION
- Make dynamic cast transparent through `IRAttributedType`.
- Handle vector type in `castHostToCUDAType`.
- Fix bug in tuple type marshaling.
- Place cuda kernels in `extern "C"` block to get rid of CUDA<->C++ linkage issue.