### PR TITLE
Revert inlining change in #3217.

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -413,8 +413,6 @@ Result linkAndOptimizeIR(
         // since we may be missing out cases prevented by the functions that we just specialzied.
         performMandatoryEarlyInlining(irModule);
 
-        performPreAutoDiffForceInlining(irModule);
-
         // Unroll loops.
         if (codeGenContext->getSink()->getErrorCount() == 0)
         {

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -1691,6 +1691,8 @@ SlangResult ForwardDiffTranscriber::prepareFuncForForwardDiff(IRFunc* func)
     insertTempVarForMutableParams(autoDiffSharedContext->moduleInst->getModule(), func);
     removeLinkageDecorations(func);
     
+    performPreAutoDiffForceInlining(func);
+
     initializeLocalVariables(autoDiffSharedContext->moduleInst->getModule(), func);
 
     lowerSwizzledStores(autoDiffSharedContext->moduleInst->getModule(), func);

--- a/source/slang/slang-ir-autodiff-rev.cpp
+++ b/source/slang/slang-ir-autodiff-rev.cpp
@@ -533,6 +533,8 @@ namespace Slang
     {
         removeLinkageDecorations(func);
 
+        performPreAutoDiffForceInlining(func);
+
         DifferentiableTypeConformanceContext diffTypeContext(autoDiffSharedContext);
         diffTypeContext.setFunc(func);
 


### PR DESCRIPTION
#3217 causes a performance regression.

This change reverts the change to do pervasive inlining, instead it checks if the callee has fwd_diff and bwd_diff insts and don't inline if they have those insts during `performPreAutoDiffInlining` to avoid the problem that the autodiff pass cannot handle a function  that has unprocessed fwd_diff or bwd_diff insts.