### PR TITLE
Fix for threading issues around global session & epoch ids.

### DIFF
--- a/source/slang/slang-ast-base.cpp
+++ b/source/slang/slang-ast-base.cpp
@@ -23,7 +23,7 @@ void NodeBase::_initDebug(ASTNodeType inAstNodeType, ASTBuilder* inAstBuilder)
 DeclRefBase* Decl::getDefaultDeclRef()
 {
     auto astBuilder = getCurrentASTBuilder();
-    if (astBuilder->getEpoch() != m_defaultDeclRefEpoch || !m_defaultDeclRef)
+    if (astBuilder && astBuilder->getEpoch() != m_defaultDeclRefEpoch || !m_defaultDeclRef)
     {
         m_defaultDeclRef = astBuilder->getOrCreate<DirectDeclRef>(this);
         m_defaultDeclRefEpoch = astBuilder->getEpoch();

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -221,12 +221,6 @@ Decl* SharedASTBuilder::tryFindMagicDecl(const String& name)
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! ASTBuilder !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-Index& _getGlobalASTEpochId()
-{
-    static thread_local Index epochId = 1;
-    return epochId;
-}
-
 ASTBuilder::ASTBuilder(SharedASTBuilder* sharedASTBuilder, const String& name):
     m_sharedASTBuilder(sharedASTBuilder),
     m_name(name),
@@ -260,12 +254,12 @@ ASTBuilder::~ASTBuilder()
 
 Index ASTBuilder::getEpoch()
 {
-    return _getGlobalASTEpochId();
+    return getSharedASTBuilder()->m_session->m_epochId;
 }
 
 void ASTBuilder::incrementEpoch()
 {
-    _getGlobalASTEpochId()++;
+    getSharedASTBuilder()->m_session->m_epochId++;
 }
 
 NodeBase* ASTBuilder::createByNodeType(ASTNodeType nodeType)

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -3008,7 +3008,11 @@ namespace Slang
             /// Get the downstream compiler for a transition
         IDownstreamCompiler* getDownstreamCompiler(CodeGenTarget source, CodeGenTarget target);
         
-        Index m_epochId = 1;
+        // This needs to be atomic not because of contention between threads as `Session` is
+        // *not* multithreaded, but can be used exclusively on one thread at a time.
+        // The need for atomic is purely for visibility. If the session is used on a different 
+        // thread we need to be sure any changes to m_epochId are visible to this thread.
+        std::atomic<Index> m_epochId = 1;
 
         Scope* baseLanguageScope = nullptr;
         Scope* coreLanguageScope = nullptr;

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -3008,6 +3008,8 @@ namespace Slang
             /// Get the downstream compiler for a transition
         IDownstreamCompiler* getDownstreamCompiler(CodeGenTarget source, CodeGenTarget target);
         
+        Index m_epochId = 1;
+
         Scope* baseLanguageScope = nullptr;
         Scope* coreLanguageScope = nullptr;
         Scope* hlslLanguageScope = nullptr;


### PR DESCRIPTION
Multhreading is discussed in [docs](https://github.com/shader-slang/slang/blob/master/docs/api-users-guide.md#multithreading).

The epoch id broke the behavior though because the model allowed for a global session to be used from different threads, but it could only be used exclusively by one at a time. The epoch was being held in a thread local variable, which meant if the a compilation moved to a different thread the epoch would become that which was associated with that thread, which is likely inconsistent with the epochs set.
