### PR TITLE
Fix for epoch/ASTBuilder* nullptr issue

### DIFF
--- a/source/slang/slang-ast-base.cpp
+++ b/source/slang/slang-ast-base.cpp
@@ -22,11 +22,14 @@ void NodeBase::_initDebug(ASTNodeType inAstNodeType, ASTBuilder* inAstBuilder)
 }
 DeclRefBase* Decl::getDefaultDeclRef()
 {
-    auto astBuilder = getCurrentASTBuilder();
-    if (astBuilder && astBuilder->getEpoch() != m_defaultDeclRefEpoch || !m_defaultDeclRef)
+    if (auto astBuilder = getCurrentASTBuilder())
     {
-        m_defaultDeclRef = astBuilder->getOrCreate<DirectDeclRef>(this);
-        m_defaultDeclRefEpoch = astBuilder->getEpoch();
+        const Index currentEpoch = astBuilder->getEpoch();
+        if (currentEpoch != m_defaultDeclRefEpoch || !m_defaultDeclRef)
+        {
+            m_defaultDeclRef = astBuilder->getOrCreate<DirectDeclRef>(this);
+            m_defaultDeclRefEpoch = currentEpoch;
+        }
     }
     return m_defaultDeclRef;
 }

--- a/source/slang/slang-serialize-ast.cpp
+++ b/source/slang/slang-serialize-ast.cpp
@@ -86,6 +86,8 @@ struct ASTFieldAccess
 
         ASTBuilder builder(sharedASTBuilder, "Serialize Check");
 
+        SetASTBuilderContextRAII astBuilderRAII(&builder);
+
         DefaultSerialObjectFactory objectFactory(&builder);
 
         // We could now check that the loaded data matches

--- a/source/slang/slang-serialize-container.cpp
+++ b/source/slang/slang-serialize-container.cpp
@@ -390,6 +390,9 @@ static List<ExtensionDecl*>& _getCandidateExtensionList(
                         astBuilder = new ASTBuilder(options.sharedASTBuilder, buf.produceString());
                     }
 
+                    /// We need to make the current ASTBuilder available for access via thread_local global.
+                    SetASTBuilderContextRAII astBuilderRAII(astBuilder);
+
                     DefaultSerialObjectFactory objectFactory(astBuilder);
 
                     SerialReader reader(serialClasses, &objectFactory);

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -4726,6 +4726,9 @@ void Session::addBuiltinSource(
 
 Session::~Session()
 {
+    // Make sure we destroy first
+    globalAstBuilder.setNull();
+
     // destroy modules next
     stdlibModules = decltype(stdlibModules)();
 }

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -4726,7 +4726,11 @@ void Session::addBuiltinSource(
 
 Session::~Session()
 {
-    // Make sure we destroy first
+    // This is necessary because this ASTBuilder uses the SharedASTBuilder also owned by the session.
+    // If the SharedASTBuilder gets dtored before the globalASTBuilder it has a dangling pointer, which 
+    // is referenced in the ASTBuilder dtor (likely) causing a crash.
+    // 
+    // By destroying first we know it is destroyed, before the SharedASTBuilder.
     globalAstBuilder.setNull();
 
     // destroy modules next


### PR DESCRIPTION
Previously these tests were failing...

tests/serialization/serialized-module-test.slang
tests/serialization/extern/extern-test.slang

The issue is around the thread_local mechanism holding the current ASTBuilder. This wasn't being setup for a couple of scenarios that were being hit. The fix is to setup the thread_local for these scenarios using `SetASTBuilderContextRAII `

The other problem was around embed-stdlib. There the problem was that the sharedASTBuilder was being destroyed before the ASTBuilder on the Session. This led to a dangling pointer being accessed by the dtor of ASTBuilder. The fix was just to destroy the ASTBuilder before anything else.
