### PR TITLE
Fix `isMovableInst`.

### DIFF
--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -8202,7 +8202,7 @@ namespace Slang
         case kIROp_Call:
             // Similar to the case in IRInst::mightHaveSideEffects, pure
             // calls are ok
-            return isSideEffectFreeFunctionalCall(cast<IRCall>(inst));
+            return isPureFunctionalCall(cast<IRCall>(inst));
         case kIROp_Load:
             // Load is generally not movable, an exception is loading a global constant buffer.
             if (auto load = as<IRLoad>(inst))


### PR DESCRIPTION
A `[NoSideEffect]` callee isn't movable, but it should be safe to move `[ReadNone]` callees.