### PR TITLE
[Direct SPIRV]: ray tracing pipeline intrinsics.

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -7257,9 +7257,8 @@ void __executeCallable(uint shaderIndex, int payloadLocation);
 // for a type being used in a `CallShader()` call for GLSL-based targets.
 //
 __generic<Payload>
-__target_intrinsic(__glslRayTracing, "$XC")
 [__readNone]
-[__AlwaysFoldIntoUseSiteAttribute]
+__intrinsic_op($(kIROp_GetVulkanRayTracingPayloadLocation))
 int __callablePayloadLocation(__ref Payload payload);
 
 // Now we provide a hard-coded definition of `CallShader()` for GLSL-based
@@ -7313,13 +7312,13 @@ void __traceRay(
 // syntax works in a pinch.
 //
 __generic<Payload>
-__target_intrinsic(__glslRayTracing, "$XP")
 [__readNone]
-[__AlwaysFoldIntoUseSiteAttribute]
+__intrinsic_op($(kIROp_GetVulkanRayTracingPayloadLocation))
 int __rayPayloadLocation(__ref Payload payload);
 
 __generic<payload_t>
 __specialized_for_target(glsl)
+__specialized_for_target(spirv)
 void TraceRay(
     RaytracingAccelerationStructure AccelerationStructure,
     uint                            RayFlags,
@@ -7387,6 +7386,7 @@ void __traceMotionRay(
 
 __generic<payload_t>
 __specialized_for_target(glsl)
+__specialized_for_target(spirv)
 void TraceMotionRay(
     RaytracingAccelerationStructure AccelerationStructure,
     uint                            RayFlags,
@@ -7428,6 +7428,7 @@ bool __reportIntersection(float tHit, uint hitKind);
 
 __generic<A>
 __specialized_for_target(glsl)
+__specialized_for_target(spirv)
 bool ReportHit(float tHit, uint hitKind, A attributes)
 {
     [__vulkanHitAttributes]
@@ -8327,9 +8328,7 @@ Ref<T> __hitObjectAttributes<T>()
 // for GLSL-based targets.
 //
 __generic<Attributes>
-__target_intrinsic(__glslRayTracing, "$XH")
-[__readNone]
-[__AlwaysFoldIntoUseSiteAttribute]
+__intrinsic_op($(kIROp_GetVulkanRayTracingPayloadLocation))
 int __hitObjectAttributesLocation(__ref Attributes attributes);
 
     /// Immutable data type representing a ray hit or a miss. Can be used to invoke hit or miss shading,

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -7485,8 +7485,8 @@ bool __reportIntersection(float tHit, uint hitKind)
 {
     __target_switch
     {
-    case GL_NV_ray_tracing: __intrinsic_asm "reportIntersectionNV";
     case GL_EXT_ray_tracing: __intrinsic_asm "reportIntersectionEXT";
+    case GL_NV_ray_tracing: __intrinsic_asm "reportIntersectionNV";
     case spirv:
         return spirv_asm {
             result:$$bool = OpReportIntersectionKHR $tHit $hitKind;
@@ -7512,8 +7512,8 @@ void IgnoreHit()
     __target_switch
     {
     case hlsl: __intrinsic_asm "IgnoreHit";
+    case GL_EXT_ray_tracing: __intrinsic_asm "ignoreIntersectionEXT;";
     case GL_NV_ray_tracing: __intrinsic_asm "ignoreIntersectionNV";
-    case GL_EXT_ray_tracing: __intrinsic_asm "ignoreIntersectionEXT";
     case cuda: __intrinsic_asm "optixIgnoreIntersection";
     case spirv: spirv_asm { OpIgnoreIntersectionKHR; %_ = OpLabel };
     }
@@ -7525,8 +7525,8 @@ void AcceptHitAndEndSearch()
     __target_switch
     {
     case hlsl: __intrinsic_asm "AcceptHitAndEndSearch";
+    case GL_EXT_ray_tracing: __intrinsic_asm "terminateRayEXT;";
     case GL_NV_ray_tracing: __intrinsic_asm "terminateRayNV";
-    case GL_EXT_ray_tracing: __intrinsic_asm "terminateRayEXT";
     case cuda: __intrinsic_asm "optixTerminateRay";
     case spirv: spirv_asm { OpTerminateRayKHR; %_ = OpLabel };
     }
@@ -7544,8 +7544,8 @@ uint3 DispatchRaysIndex()
     __target_switch
     {
     case hlsl:  __intrinsic_asm "DispatchRaysIndex";
-    case GL_NV_ray_tracing: __intrinsic_asm "(gl_LaunchIDNV)";
     case GL_EXT_ray_tracing: __intrinsic_asm "(gl_LaunchIDEXT)";
+    case GL_NV_ray_tracing: __intrinsic_asm "(gl_LaunchIDNV)";
     case cuda: __intrinsic_asm "optixGetLaunchIndex";
     case spirv:
         return spirv_asm {
@@ -7559,8 +7559,8 @@ uint3 DispatchRaysDimensions()
     __target_switch
     {
     case hlsl:  __intrinsic_asm "DispatchRaysDimensions";
-    case GL_NV_ray_tracing: __intrinsic_asm "(gl_LaunchSizeNV)";
     case GL_EXT_ray_tracing: __intrinsic_asm "(gl_LaunchSizeEXT)";
+    case GL_NV_ray_tracing: __intrinsic_asm "(gl_LaunchSizeNV)";
     case cuda: __intrinsic_asm "optixGetLaunchDimensions";
     case spirv:
         return spirv_asm {
@@ -7576,8 +7576,8 @@ float3 WorldRayOrigin()
     __target_switch
     {
     case hlsl:  __intrinsic_asm "WorldRayOrigin";
-    case GL_NV_ray_tracing: __intrinsic_asm "(gl_WorldRayOriginNV)";
     case GL_EXT_ray_tracing: __intrinsic_asm "(gl_WorldRayOriginEXT)";
+    case GL_NV_ray_tracing: __intrinsic_asm "(gl_WorldRayOriginNV)";
     case cuda: __intrinsic_asm "optixGetWorldRayOrigin";
     case spirv:
         return spirv_asm {
@@ -7591,8 +7591,8 @@ float3 WorldRayDirection()
     __target_switch
     {
     case hlsl:  __intrinsic_asm "WorldRayDirection";
-    case GL_NV_ray_tracing: __intrinsic_asm "(gl_WorldRayDirectionNV)";
     case GL_EXT_ray_tracing: __intrinsic_asm "(gl_WorldRayDirectionEXT)";
+    case GL_NV_ray_tracing: __intrinsic_asm "(gl_WorldRayDirectionNV)";
     case cuda: __intrinsic_asm "optixGetWorldRayDirection";
     case spirv:
         return spirv_asm {
@@ -7606,8 +7606,8 @@ float RayTMin()
     __target_switch
     {
     case hlsl:  __intrinsic_asm "RayTMin";
-    case GL_NV_ray_tracing: __intrinsic_asm "(gl_RayTminNV)";
     case GL_EXT_ray_tracing: __intrinsic_asm "(gl_RayTminEXT)";
+    case GL_NV_ray_tracing: __intrinsic_asm "(gl_RayTminNV)";
     case cuda: __intrinsic_asm "optixGetRayTmin";
     case spirv:
         return spirv_asm {
@@ -7631,8 +7631,8 @@ float RayTCurrent()
     __target_switch
     {
     case hlsl:  __intrinsic_asm "RayTCurrent";
-    case GL_NV_ray_tracing: __intrinsic_asm "(gl_RayTmaxNV)";
     case GL_EXT_ray_tracing: __intrinsic_asm "(gl_RayTmaxEXT)";
+    case GL_NV_ray_tracing: __intrinsic_asm "(gl_RayTmaxNV)";
     case cuda: __intrinsic_asm "optixGetRayTmax";
     case spirv:
         return spirv_asm {
@@ -7646,8 +7646,8 @@ uint RayFlags()
     __target_switch
     {
     case hlsl:  __intrinsic_asm "RayFlags";
-    case GL_NV_ray_tracing: __intrinsic_asm "(gl_IncomingRayFlagsNV)";
     case GL_EXT_ray_tracing: __intrinsic_asm "(gl_IncomingRayFlagsEXT)";
+    case GL_NV_ray_tracing: __intrinsic_asm "(gl_IncomingRayFlagsNV)";
     case cuda: __intrinsic_asm "optixGetRayFlags";
     case spirv:
         return spirv_asm {
@@ -7677,8 +7677,8 @@ uint InstanceID()
     __target_switch
     {
     case hlsl:  __intrinsic_asm "InstanceID";
-    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_InstanceCustomIndexNV)";
     case GL_EXT_ray_tracing: __intrinsic_asm "(gl_InstanceCustomIndexEXT)";
+    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_InstanceCustomIndexNV)";
     case cuda: __intrinsic_asm "optixGetInstanceId";
     case spirv:
         return spirv_asm {
@@ -7706,8 +7706,8 @@ float3 ObjectRayOrigin()
     __target_switch
     {
     case hlsl:  __intrinsic_asm "ObjectRayOrigin";
-    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_ObjectRayOriginNV)";
     case GL_EXT_ray_tracing: __intrinsic_asm "(gl_ObjectRayOriginEXT)";
+    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_ObjectRayOriginNV)";
     case cuda: __intrinsic_asm "optixGetObjectRayOrigin";
     case spirv:
         return spirv_asm {
@@ -7721,8 +7721,8 @@ float3 ObjectRayDirection()
     __target_switch
     {
     case hlsl:  __intrinsic_asm "ObjectRayDirection";
-    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_ObjectRayDirectionNV)";
     case GL_EXT_ray_tracing: __intrinsic_asm "(gl_ObjectRayDirectionEXT)";
+    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_ObjectRayDirectionNV)";
     case cuda: __intrinsic_asm "optixGetObjectRayDirection";
     case spirv:
         return spirv_asm {
@@ -7738,8 +7738,8 @@ float3x4 ObjectToWorld3x4()
     __target_switch
     {
     case hlsl:  __intrinsic_asm "ObjectToWorld3x4";
-    case GL_NV_ray_tracing:  __intrinsic_asm "transpose(gl_ObjectToWorldNV)";
     case GL_EXT_ray_tracing: __intrinsic_asm "transpose(gl_ObjectToWorldEXT)";
+    case GL_NV_ray_tracing:  __intrinsic_asm "transpose(gl_ObjectToWorldNV)";
     case spirv:
         return spirv_asm {
             %mat = OpLoad builtin(ObjectToWorldKHR:float4x3);
@@ -7753,8 +7753,8 @@ float3x4 WorldToObject3x4()
     __target_switch
     {
     case hlsl:  __intrinsic_asm "WorldToObject3x4";
-    case GL_NV_ray_tracing:  __intrinsic_asm "transpose(gl_WorldToObjectNV)";
     case GL_EXT_ray_tracing: __intrinsic_asm "transpose(gl_WorldToObjectEXT)";
+    case GL_NV_ray_tracing:  __intrinsic_asm "transpose(gl_WorldToObjectNV)";
     case spirv:
         return spirv_asm {
             %mat = OpLoad builtin(WorldToObjectKHR:float4x3);
@@ -7768,8 +7768,8 @@ float4x3 ObjectToWorld4x3()
     __target_switch
     {
     case hlsl:  __intrinsic_asm "ObjectToWorld4x3";
-    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_ObjectToWorldNV)";
     case GL_EXT_ray_tracing: __intrinsic_asm "(gl_ObjectToWorldEXT)";
+    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_ObjectToWorldNV)";
     case spirv:
         return spirv_asm {
             result:$$float4x3 = OpLoad builtin(ObjectToWorldKHR:float4x3);
@@ -7782,8 +7782,8 @@ float4x3 WorldToObject4x3()
     __target_switch
     {
     case hlsl:  __intrinsic_asm "WorldToObject4x3";
-    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_WorldToObjectNV)";
     case GL_EXT_ray_tracing: __intrinsic_asm "(gl_WorldToObject3x4EXT)";
+    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_WorldToObjectNV)";
     case spirv:
         return spirv_asm {
             result:$$float4x3 = OpLoad builtin(WorldToObjectKHR:float4x3);
@@ -7829,8 +7829,8 @@ uint HitKind()
     __target_switch
     {
     case hlsl:  __intrinsic_asm "HitKind";
-    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_HitKindNV)";
     case GL_EXT_ray_tracing:  __intrinsic_asm "(gl_HitKindEXT)";
+    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_HitKindNV)";
     case cuda:  __intrinsic_asm "optixGetHitKind";
     case spirv:
         return spirv_asm {

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -7243,9 +7243,6 @@ struct BuiltInTriangleIntersectionAttributes
 
 // 10.3.1
 
-__target_intrinsic(hlsl)
-void CallShader<Payload>(uint shaderIndex, inout Payload payload);
-
 // `executeCallableNV` is the GLSL intrinsic that will be used to implement
 // `CallShader()` for GLSL-based targets.
 //
@@ -7266,29 +7263,35 @@ int __callablePayloadLocation(__ref Payload payload);
 // GLSL equivalent.
 //
 __generic<Payload>
-__specialized_for_target(glsl)
 void CallShader(uint shaderIndex, inout Payload payload)
 {
-    [__vulkanCallablePayload]
-    static Payload p;
+    __target_switch
+    {
+    case hlsl: __intrinsic_asm "CallShader";
+    case glsl:
+        {
+            [__vulkanCallablePayload]
+            static Payload p;
 
-    p = payload;
-    __executeCallable(shaderIndex, __callablePayloadLocation(p));
-    payload = p;
+            p = payload;
+            __executeCallable(shaderIndex, __callablePayloadLocation(p));
+            payload = p;
+        }
+    case spirv:
+        {
+            [__vulkanCallablePayload]
+            static Payload p;
+
+            p = payload;
+            spirv_asm {
+                OpExecuteCallableKHR $shaderIndex &p
+            };
+            payload = p;
+        }
+    }
 }
 
 // 10.3.2
-__target_intrinsic(hlsl)
-__target_intrinsic(cuda, "traceOptiXRay")
-void TraceRay<payload_t>(
-    RaytracingAccelerationStructure AccelerationStructure,
-    uint                            RayFlags,
-    uint                            InstanceInclusionMask,
-    uint                            RayContributionToHitGroupIndex,
-    uint                            MultiplierForGeometryContributionToHitGroupIndex,
-    uint                            MissShaderIndex,
-    RayDesc                         Ray,
-    inout payload_t                 Payload);
 
 __target_intrinsic(GL_NV_ray_tracing, "traceNV")
 __target_intrinsic(GL_EXT_ray_tracing, "traceRayEXT")
@@ -7317,8 +7320,6 @@ __intrinsic_op($(kIROp_GetVulkanRayTracingPayloadLocation))
 int __rayPayloadLocation(__ref Payload payload);
 
 __generic<payload_t>
-__specialized_for_target(glsl)
-__specialized_for_target(spirv)
 void TraceRay(
     RaytracingAccelerationStructure AccelerationStructure,
     uint                            RayFlags,
@@ -7329,42 +7330,64 @@ void TraceRay(
     RayDesc                         Ray,
     inout payload_t                 Payload)
 {
-    [__vulkanRayPayload]
-    static payload_t p;
+    __target_switch
+    {
+    case hlsl: __intrinsic_asm "TraceRay";
+    case cuda: __intrinsic_asm "traceOptiXRay";
+    case glsl:
+    {
+        [__vulkanRayPayload]
+        static payload_t p;
 
-    p = Payload;
-    __traceRay(
-        AccelerationStructure,
-        RayFlags,
-        InstanceInclusionMask,
-        RayContributionToHitGroupIndex,
-        MultiplierForGeometryContributionToHitGroupIndex,
-        MissShaderIndex,
-        Ray.Origin,
-        Ray.TMin,
-        Ray.Direction,
-        Ray.TMax,
-        __rayPayloadLocation(p));
-    Payload = p;
+        p = Payload;
+        __traceRay(
+            AccelerationStructure,
+            RayFlags,
+            InstanceInclusionMask,
+            RayContributionToHitGroupIndex,
+            MultiplierForGeometryContributionToHitGroupIndex,
+            MissShaderIndex,
+            Ray.Origin,
+            Ray.TMin,
+            Ray.Direction,
+            Ray.TMax,
+            __rayPayloadLocation(p));
+        Payload = p;
+    }
+    case spirv:
+    {
+        [__vulkanRayPayload]
+        static payload_t p;
+
+        p = Payload;
+        let origin = Ray.Origin;
+        let direction = Ray.Direction;
+        let tmin = Ray.TMin;
+        let tmax = Ray.TMax;
+        spirv_asm {
+            OpTraceRayKHR 
+                /**/ $AccelerationStructure
+                /**/ $RayFlags
+                /**/ $InstanceInclusionMask
+                /**/ $RayContributionToHitGroupIndex
+                /**/ $MultiplierForGeometryContributionToHitGroupIndex
+                /**/ $MissShaderIndex
+                /**/ $origin
+                /**/ $tmin
+                /**/ $direction
+                /**/ $tmax
+                /**/ &p;
+        };
+        Payload = p;
+    }
+    }
 }
-
 
 // NOTE!
 // The name of the following functions may change when DXR supports
 // a feature similar to the `GL_NV_ray_tracing_motion_blur` extension
 //
 // https://github.com/KhronosGroup/GLSL/blob/master/extensions/nv/GLSL_NV_ray_tracing_motion_blur.txt
-
-void TraceMotionRay<payload_t>(
-    RaytracingAccelerationStructure AccelerationStructure,
-    uint                            RayFlags,
-    uint                            InstanceInclusionMask,
-    uint                            RayContributionToHitGroupIndex,
-    uint                            MultiplierForGeometryContributionToHitGroupIndex,
-    uint                            MissShaderIndex,
-    RayDesc                         Ray,
-    float                           CurrentTime,
-    inout payload_t                 Payload);
 
 __target_intrinsic(glsl, "traceRayMotionNV")
 __glsl_version(460)
@@ -7385,8 +7408,6 @@ void __traceMotionRay(
     int                             PayloadLocation);
 
 __generic<payload_t>
-__specialized_for_target(glsl)
-__specialized_for_target(spirv)
 void TraceMotionRay(
     RaytracingAccelerationStructure AccelerationStructure,
     uint                            RayFlags,
@@ -7398,33 +7419,80 @@ void TraceMotionRay(
     float                           CurrentTime,
     inout payload_t                 Payload)
 {
-    [__vulkanRayPayload]
-    static payload_t p;
+    __target_switch
+    {
+    case hlsl: __intrinsic_asm "TraceMotionRay";
+    case glsl:
+    {
+        [__vulkanRayPayload]
+        static payload_t p;
 
-    p = Payload;
-    __traceMotionRay(
-        AccelerationStructure,
-        RayFlags,
-        InstanceInclusionMask,
-        RayContributionToHitGroupIndex,
-        MultiplierForGeometryContributionToHitGroupIndex,
-        MissShaderIndex,
-        Ray.Origin,
-        Ray.TMin,
-        Ray.Direction,
-        Ray.TMax,
-        CurrentTime,
-        __rayPayloadLocation(p));
-    Payload = p;
+        p = Payload;
+        __traceMotionRay(
+            AccelerationStructure,
+            RayFlags,
+            InstanceInclusionMask,
+            RayContributionToHitGroupIndex,
+            MultiplierForGeometryContributionToHitGroupIndex,
+            MissShaderIndex,
+            Ray.Origin,
+            Ray.TMin,
+            Ray.Direction,
+            Ray.TMax,
+            CurrentTime,
+            __rayPayloadLocation(p));
+        Payload = p;
+    }
+    case spirv:
+    {
+        [__vulkanRayPayload]
+        static payload_t p;
+        
+        let origin = Ray.Origin;
+        let direction = Ray.Direction;
+        let tmin = Ray.TMin;
+        let tmax = Ray.TMax;
+
+        p = Payload;
+        spirv_asm {
+            OpCapability RayTracingMotionBlurNV;
+            OpExtension "SPV_NV_ray_tracing_motion_blur";
+
+            OpTraceRayMotionNV
+                /**/ $AccelerationStructure
+                /**/ $RayFlags
+                /**/ $InstanceInclusionMask
+                /**/ $RayContributionToHitGroupIndex
+                /**/ $MultiplierForGeometryContributionToHitGroupIndex
+                /**/ $MissShaderIndex
+                /**/ $origin
+                /**/ $tmin
+                /**/ $direction
+                /**/ $tmax
+                /**/ $CurrentTime
+                /**/ &p;
+        };
+        Payload = p;
+    }
+    }
 }
 
 // 10.3.3
 __target_intrinsic(hlsl)
 bool ReportHit<A>(float tHit, uint hitKind, A attributes);
 
-__target_intrinsic(GL_NV_ray_tracing, "reportIntersectionNV")
-__target_intrinsic(GL_EXT_ray_tracing, "reportIntersectionEXT")
-bool __reportIntersection(float tHit, uint hitKind);
+bool __reportIntersection(float tHit, uint hitKind)
+{
+    __target_switch
+    {
+    case GL_NV_ray_tracing: __intrinsic_asm "reportIntersectionNV";
+    case GL_EXT_ray_tracing: __intrinsic_asm "reportIntersectionEXT";
+    case spirv:
+        return spirv_asm {
+            result:$$bool = OpReportIntersectionKHR $tHit $hitKind;
+        };
+    }
+}
 
 __generic<A>
 __specialized_for_target(glsl)
@@ -7439,18 +7507,30 @@ bool ReportHit(float tHit, uint hitKind, A attributes)
 }
 
 // 10.3.4
-__target_intrinsic(hlsl)
-__target_intrinsic(GL_NV_ray_tracing, ignoreIntersectionNV)
-__target_intrinsic(GL_EXT_ray_tracing, "ignoreIntersectionEXT;")
-__target_intrinsic(cuda, "optixIgnoreIntersection")
-void IgnoreHit();
+void IgnoreHit()
+{
+    __target_switch
+    {
+    case hlsl: __intrinsic_asm "IgnoreHit";
+    case GL_NV_ray_tracing: __intrinsic_asm "ignoreIntersectionNV";
+    case GL_EXT_ray_tracing: __intrinsic_asm "ignoreIntersectionEXT";
+    case cuda: __intrinsic_asm "optixIgnoreIntersection";
+    case spirv: spirv_asm { OpIgnoreIntersectionKHR; %_ = OpLabel };
+    }
+}
 
 // 10.3.5
-__target_intrinsic(hlsl)
-__target_intrinsic(GL_NV_ray_tracing, terminateRayNV)
-__target_intrinsic(GL_EXT_ray_tracing, "terminateRayEXT;")
-__target_intrinsic(cuda, "optixTerminateRay")
-void AcceptHitAndEndSearch();
+void AcceptHitAndEndSearch()
+{
+    __target_switch
+    {
+    case hlsl: __intrinsic_asm "AcceptHitAndEndSearch";
+    case GL_NV_ray_tracing: __intrinsic_asm "terminateRayNV";
+    case GL_EXT_ray_tracing: __intrinsic_asm "terminateRayEXT";
+    case cuda: __intrinsic_asm "optixTerminateRay";
+    case spirv: spirv_asm { OpTerminateRayKHR; %_ = OpLabel };
+    }
+}
 
 // 10.4 - System Values and Special Semantics
 
@@ -7459,32 +7539,82 @@ void AcceptHitAndEndSearch();
 
 // 10.4.1 - Ray Dispatch System Values
 
-__target_intrinsic(GL_NV_ray_tracing, "(gl_LaunchIDNV)")
-__target_intrinsic(GL_EXT_ray_tracing, "(gl_LaunchIDEXT)")
-__target_intrinsic(cuda, "optixGetLaunchIndex")
-uint3 DispatchRaysIndex();
+uint3 DispatchRaysIndex()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "DispatchRaysIndex";
+    case GL_NV_ray_tracing: __intrinsic_asm "(gl_LaunchIDNV)";
+    case GL_EXT_ray_tracing: __intrinsic_asm "(gl_LaunchIDEXT)";
+    case cuda: __intrinsic_asm "optixGetLaunchIndex";
+    case spirv:
+        return spirv_asm {
+            result:$$uint3 = OpLoad builtin(LaunchIdKHR:uint3);
+        };
+    }
+}
 
-__target_intrinsic(GL_NV_ray_tracing, "(gl_LaunchSizeNV)")
-__target_intrinsic(GL_EXT_ray_tracing, "(gl_LaunchSizeEXT)")
-__target_intrinsic(cuda, "optixGetLaunchDimensions")
-uint3 DispatchRaysDimensions();
+uint3 DispatchRaysDimensions()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "DispatchRaysDimensions";
+    case GL_NV_ray_tracing: __intrinsic_asm "(gl_LaunchSizeNV)";
+    case GL_EXT_ray_tracing: __intrinsic_asm "(gl_LaunchSizeEXT)";
+    case cuda: __intrinsic_asm "optixGetLaunchDimensions";
+    case spirv:
+        return spirv_asm {
+            result:$$uint3 = OpLoad builtin(LaunchSizeKHR:uint3);
+        };
+    }
+}
 
 // 10.4.2 - Ray System Values
 
-__target_intrinsic(GL_NV_ray_tracing, "(gl_WorldRayOriginNV)")
-__target_intrinsic(GL_EXT_ray_tracing, "(gl_WorldRayOriginEXT)")
-__target_intrinsic(cuda, "optixGetWorldRayOrigin")
-float3 WorldRayOrigin();
+float3 WorldRayOrigin()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "WorldRayOrigin";
+    case GL_NV_ray_tracing: __intrinsic_asm "(gl_WorldRayOriginNV)";
+    case GL_EXT_ray_tracing: __intrinsic_asm "(gl_WorldRayOriginEXT)";
+    case cuda: __intrinsic_asm "optixGetWorldRayOrigin";
+    case spirv:
+        return spirv_asm {
+            result:$$float3 = OpLoad builtin(WorldRayOriginKHR:float3);
+        };
+    }
+}
 
-__target_intrinsic(GL_NV_ray_tracing, "(gl_WorldRayDirectionNV)")
-__target_intrinsic(GL_EXT_ray_tracing, "(gl_WorldRayDirectionEXT)")
-__target_intrinsic(cuda, "optixGetWorldRayDirection")
-float3 WorldRayDirection();
+float3 WorldRayDirection()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "WorldRayDirection";
+    case GL_NV_ray_tracing: __intrinsic_asm "(gl_WorldRayDirectionNV)";
+    case GL_EXT_ray_tracing: __intrinsic_asm "(gl_WorldRayDirectionEXT)";
+    case cuda: __intrinsic_asm "optixGetWorldRayDirection";
+    case spirv:
+        return spirv_asm {
+            result:$$float3 = OpLoad builtin(WorldRayDirectionKHR:float3);
+        };
+    }
+}
 
-__target_intrinsic(GL_NV_ray_tracing, "(gl_RayTminNV)")
-__target_intrinsic(GL_EXT_ray_tracing, "(gl_RayTminEXT)")
-__target_intrinsic(cuda, "optixGetRayTmin")
-float RayTMin();
+float RayTMin()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "RayTMin";
+    case GL_NV_ray_tracing: __intrinsic_asm "(gl_RayTminNV)";
+    case GL_EXT_ray_tracing: __intrinsic_asm "(gl_RayTminEXT)";
+    case cuda: __intrinsic_asm "optixGetRayTmin";
+    case spirv:
+        return spirv_asm {
+            result:$$float = OpLoad builtin(RayTminKHR:float);
+        };
+    }
+}
 
 // Note: The `RayTCurrent()` intrinsic should translate to
 // either `gl_HitTNV` (for hit shaders) or `gl_RayTmaxNV`
@@ -7496,68 +7626,190 @@ float RayTMin();
 // we should simply provide two overloads here, specialized
 // to the appropriate Vulkan stages.
 //
-__target_intrinsic(GL_NV_ray_tracing, "(gl_RayTmaxNV)")
-__target_intrinsic(GL_EXT_ray_tracing, "(gl_RayTmaxEXT)")
-__target_intrinsic(cuda, "optixGetRayTmax")
-float RayTCurrent();
+float RayTCurrent()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "RayTCurrent";
+    case GL_NV_ray_tracing: __intrinsic_asm "(gl_RayTmaxNV)";
+    case GL_EXT_ray_tracing: __intrinsic_asm "(gl_RayTmaxEXT)";
+    case cuda: __intrinsic_asm "optixGetRayTmax";
+    case spirv:
+        return spirv_asm {
+            result:$$float = OpLoad builtin(RayTmaxKHR:float);
+        };
+    }
+}
 
-__target_intrinsic(GL_NV_ray_tracing, "(gl_IncomingRayFlagsNV)")
-__target_intrinsic(GL_EXT_ray_tracing, "(gl_IncomingRayFlagsEXT)")
-__target_intrinsic(cuda, "optixGetRayFlags")
-uint RayFlags();
+uint RayFlags()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "RayFlags";
+    case GL_NV_ray_tracing: __intrinsic_asm "(gl_IncomingRayFlagsNV)";
+    case GL_EXT_ray_tracing: __intrinsic_asm "(gl_IncomingRayFlagsEXT)";
+    case cuda: __intrinsic_asm "optixGetRayFlags";
+    case spirv:
+        return spirv_asm {
+            result:$$uint = OpLoad builtin(IncomingRayFlagsKHR:uint);
+        };
+    }
+}
 
 // 10.4.3 - Primitive/Object Space System Values
 
-__target_intrinsic(__glslRayTracing, "(gl_InstanceID)")
-__target_intrinsic(cuda, "optixGetInstanceIndex")
-uint InstanceIndex();
+uint InstanceIndex()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "InstanceIndex";
+    case __glslRayTracing: __intrinsic_asm "(gl_InstanceID)";
+    case cuda: __intrinsic_asm "optixGetInstanceIndex";
+    case spirv:
+        return spirv_asm {
+            result:$$uint = OpLoad builtin(InstanceId:uint);
+        };
+    }
+}
 
-__target_intrinsic(GL_NV_ray_tracing, "(gl_InstanceCustomIndexNV)")
-__target_intrinsic(GL_EXT_ray_tracing, "(gl_InstanceCustomIndexEXT)")
-__target_intrinsic(cuda, "optixGetInstanceId")
-uint InstanceID();
+uint InstanceID()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "InstanceID";
+    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_InstanceCustomIndexNV)";
+    case GL_EXT_ray_tracing: __intrinsic_asm "(gl_InstanceCustomIndexEXT)";
+    case cuda: __intrinsic_asm "optixGetInstanceId";
+    case spirv:
+        return spirv_asm {
+            result:$$uint = OpLoad builtin(InstanceCustomIndexKHR:uint);
+        };
+    }
+}
 
-__target_intrinsic(__glslRayTracing, "(gl_PrimitiveID)")
-__target_intrinsic(cuda, "optixGetPrimitiveIndex")
-uint PrimitiveIndex();
+uint PrimitiveIndex()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "PrimitiveIndex";
+    case __glslRayTracing:  __intrinsic_asm "(gl_PrimitiveID)";
+    case cuda: __intrinsic_asm "optixGetPrimitiveIndex";
+    case spirv:
+        return spirv_asm {
+            result:$$uint = OpLoad builtin(PrimitiveId:uint);
+        };
+    }
+}
 
-__target_intrinsic(GL_NV_ray_tracing, "(gl_ObjectRayOriginNV)")
-__target_intrinsic(GL_EXT_ray_tracing, "(gl_ObjectRayOriginEXT)")
-__target_intrinsic(cuda, "optixGetObjectRayOrigin")
-float3 ObjectRayOrigin();
+float3 ObjectRayOrigin()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "ObjectRayOrigin";
+    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_ObjectRayOriginNV)";
+    case GL_EXT_ray_tracing: __intrinsic_asm "(gl_ObjectRayOriginEXT)";
+    case cuda: __intrinsic_asm "optixGetObjectRayOrigin";
+    case spirv:
+        return spirv_asm {
+            result:$$float3 = OpLoad builtin(ObjectRayOriginKHR:float3);
+        };
+    }
+}
 
-__target_intrinsic(GL_NV_ray_tracing, "(gl_ObjectRayDirectionNV)")
-__target_intrinsic(GL_EXT_ray_tracing, "(gl_ObjectRayDirectionEXT)")
-__target_intrinsic(cuda, "optixGetObjectRayDirection")
-float3 ObjectRayDirection();
+float3 ObjectRayDirection()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "ObjectRayDirection";
+    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_ObjectRayDirectionNV)";
+    case GL_EXT_ray_tracing: __intrinsic_asm "(gl_ObjectRayDirectionEXT)";
+    case cuda: __intrinsic_asm "optixGetObjectRayDirection";
+    case spirv:
+        return spirv_asm {
+            result:$$float3 = OpLoad builtin(ObjectRayDirectionKHR:float3);
+        };
+    }
+}
 
 // TODO: optix has an optixGetObjectToWorldTransformMatrix function that returns 12
 // floats by reference.
-__target_intrinsic(GL_NV_ray_tracing, "transpose(gl_ObjectToWorldNV)")
-__target_intrinsic(GL_EXT_ray_tracing, "transpose(gl_ObjectToWorldEXT)")
-float3x4 ObjectToWorld3x4();
+float3x4 ObjectToWorld3x4()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "ObjectToWorld3x4";
+    case GL_NV_ray_tracing:  __intrinsic_asm "transpose(gl_ObjectToWorldNV)";
+    case GL_EXT_ray_tracing: __intrinsic_asm "transpose(gl_ObjectToWorldEXT)";
+    case spirv:
+        return spirv_asm {
+            %mat = OpLoad builtin(ObjectToWorldKHR:float4x3);
+            result:$$float3x4 = OpTranspose %mat;
+        };
+    }
+}
 
-__target_intrinsic(GL_NV_ray_tracing, "transpose(gl_WorldToObjectNV)")
-__target_intrinsic(GL_EXT_ray_tracing, "transpose(gl_WorldToObjectEXT)")
-float3x4 WorldToObject3x4();
+float3x4 WorldToObject3x4()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "WorldToObject3x4";
+    case GL_NV_ray_tracing:  __intrinsic_asm "transpose(gl_WorldToObjectNV)";
+    case GL_EXT_ray_tracing: __intrinsic_asm "transpose(gl_WorldToObjectEXT)";
+    case spirv:
+        return spirv_asm {
+            %mat = OpLoad builtin(WorldToObjectKHR:float4x3);
+            result:$$float3x4 = OpTranspose %mat;
+        };
+    }
+}
 
-__target_intrinsic(GL_NV_ray_tracing, "transpose(gl_ObjectToWorldNV)")
-__target_intrinsic(GL_EXT_ray_tracing, "transpose(gl_ObjectToWorld3x4EXT)")
-float4x3 ObjectToWorld4x3();
+float4x3 ObjectToWorld4x3()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "ObjectToWorld4x3";
+    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_ObjectToWorldNV)";
+    case GL_EXT_ray_tracing: __intrinsic_asm "(gl_ObjectToWorldEXT)";
+    case spirv:
+        return spirv_asm {
+            result:$$float4x3 = OpLoad builtin(ObjectToWorldKHR:float4x3);
+        };
+    }
+}
 
-__target_intrinsic(GL_NV_ray_tracing, "transpose(gl_WorldToObjectNV)")
-__target_intrinsic(GL_EXT_ray_tracing, "transpose(gl_WorldToObject3x4EXT)")
-float4x3 WorldToObject4x3();
+float4x3 WorldToObject4x3()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "WorldToObject4x3";
+    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_WorldToObjectNV)";
+    case GL_EXT_ray_tracing: __intrinsic_asm "(gl_WorldToObject3x4EXT)";
+    case spirv:
+        return spirv_asm {
+            result:$$float4x3 = OpLoad builtin(WorldToObjectKHR:float4x3);
+        };
+    }
+}
 
 // NOTE!
 // The name of the following functions may change when DXR supports
 // a feature similar to the `GL_NV_ray_tracing_motion_blur` extension
 
-__target_intrinsic(glsl, "(gl_CurrentRayTimeNV)")
 __glsl_version(460)
 __glsl_extension(GL_NV_ray_tracing_motion_blur)
 __glsl_extension(GL_EXT_ray_tracing)
-float RayCurrentTime();
+float RayCurrentTime()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "RayCurrentTime";
+    case glsl:  __intrinsic_asm "(gl_CurrentRayTimeNV)";
+    case spirv:
+        return spirv_asm {
+            result:$$float = OpLoad builtin(CurrentRayTimeNV:float);
+        };
+    }
+}
 
 // Note: The provisional DXR spec included these unadorned
 // `ObjectToWorld()` and `WorldToObject()` functions, so
@@ -7572,10 +7824,20 @@ float3x4 ObjectToWorld() { return ObjectToWorld3x4(); }
 float3x4 WorldToObject() { return WorldToObject3x4(); }
 
 // 10.4.4 - Hit Specific System values
-__target_intrinsic(GL_NV_ray_tracing, "(gl_HitKindNV)")
-__target_intrinsic(GL_EXT_ray_tracing, "(gl_HitKindEXT)")
-__target_intrinsic(cuda, "optixGetHitKind")
-uint HitKind();
+uint HitKind()
+{
+    __target_switch
+    {
+    case hlsl:  __intrinsic_asm "HitKind";
+    case GL_NV_ray_tracing:  __intrinsic_asm "(gl_HitKindNV)";
+    case GL_EXT_ray_tracing:  __intrinsic_asm "(gl_HitKindEXT)";
+    case cuda:  __intrinsic_asm "optixGetHitKind";
+    case spirv:
+        return spirv_asm {
+            result:$$uint = OpLoad builtin(HitKindKHR:uint);
+        };
+    }
+}
 
 // Pre-defined hit kinds (not documented explicitly)
 static const uint HIT_KIND_TRIANGLE_FRONT_FACE  = 254;
@@ -7795,7 +8057,17 @@ struct FeedbackTexture2DArray<T : __BuiltinSamplerFeedbackType>
 
 // Get the index of the geometry that was hit in an intersection, any-hit, or closest-hit shader
 __target_intrinsic(GL_EXT_ray_tracing, "(gl_GeometryIndexEXT)")
-uint GeometryIndex();
+uint GeometryIndex()
+{
+    __target_switch
+    {
+    case hlsl: __intrinsic_asm "GeometryIndex";
+    case glsl: __intrinsic_asm "(gl_GeometryIndexEXT)";
+    case spirv: return spirv_asm {
+            result:$$uint = OpLoad builtin(RayGeometryIndexKHR:uint);
+        };
+    }
+}
 
 // Status of whether a (closest) hit has been committed in a `RayQuery`.
 typedef uint COMMITTED_STATUS;

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -41,56 +41,6 @@ struct CLikeSourceEmitter::ComputeEmitActionsContext
     List<EmitAction>*   actions;
 };
 
-/* !!!!!!!!!!!!!!!!!!!!!!!!!!!! LocationTracker !!!!!!!!!!!!!!!!!!!!!!!!!! */
-
-/* static */LocationTracker::Kind LocationTracker::getKindFromDecoration(IRDecoration* decoration)
-{
-    switch (decoration->getOp())
-    {
-        case kIROp_VulkanRayPayloadDecoration:          return Kind::RayPayload;
-        case kIROp_VulkanCallablePayloadDecoration:     return Kind::CallablePayload;
-        case kIROp_VulkanHitObjectAttributesDecoration: return Kind::HitObjectAttribute;
-        default: break;
-    }
-    return Kind::Invalid;
-}
-
-Index LocationTracker::getValue(IRInst* inst, IRDecoration* decoration)
-{
-    const Kind kind = getKindFromDecoration(decoration);
-    SLANG_RELEASE_ASSERT(kind != Kind::Invalid);
-    if (kind == Kind::Invalid)
-    {
-        return -1;
-    }
-
-    return getValue(kind, inst, decoration);
-}
-
-Index LocationTracker::getValue(Kind kind, IRInst* inst, IRDecoration* decoration)
-{
-    if (decoration->getOperandCount() > 0)
-    {
-        // TODO(JS):
-        // There could be a clash with the auto generated location, and the user set value/ 
-        // Perhaps the implication in practice is that either all are marked or none.
-        const int explicitLocation = int(getIntVal(decoration->getOperand(0)));
-        if (explicitLocation >= 0)
-            return UInt(explicitLocation);
-    }
-
-    auto& nextValue = m_nextValueForKind[Index(kind)];
-
-    const Location defaultLocation{kind, nextValue};
-    const Location foundLocation = m_mapIRToLocations.getOrAddValue(inst, defaultLocation);
-
-    // Increase if it was the default
-    nextValue += Index(defaultLocation == foundLocation);
-
-    // Has to match the kind
-    return (foundLocation.kind == kind) ? foundLocation.value : -1;
-}
-
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!!! CLikeSourceEmitter !!!!!!!!!!!!!!!!!!!!!!!!!! */
 
 /* static */SourceLanguage CLikeSourceEmitter::getSourceLanguage(CodeGenTarget target)
@@ -1241,6 +1191,9 @@ bool CLikeSourceEmitter::shouldFoldInstIntoUseSites(IRInst* inst)
     case kIROp_Specialize:
     case kIROp_LookupWitness:
     case kIROp_GetValueFromBoundInterface:
+        return true;
+
+    case kIROp_GetVulkanRayTracingPayloadLocation:
         return true;
     }
 

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -17,48 +17,6 @@
 namespace Slang
 {
 
-class LocationTracker
-{
-public:
-    enum class Kind
-    {
-        Invalid = -1,
-        RayPayload,                 ///< GLSL rayPayload
-        CallablePayload,            ///< GLSL callableData
-        HitObjectAttribute,         ///< GLSL hitObjectAttribute
-        CountOf,
-    };
-
-        /// Given a decoration returns the Kind, or Kind::Invalid if that is not appropriate
-    static Kind getKindFromDecoration(IRDecoration* decoration);
-
-        /// Get the location value associated with inst (and decoration).
-        /// Will return -1, if no location is associated
-    Index getValue(IRInst* inst, IRDecoration* decoration);
-
-        /// Get the location value associated with inst (and decoration).
-        /// The kind must match that for the decoration.
-        /// Will return -1, if no location is associated
-    Index getValue(Kind kind, IRInst* inst, IRDecoration* decoration);
-
-protected:
-    struct Location
-    {
-        typedef Location ThisType;
-
-        bool operator==(const ThisType& rhs) const { return kind == rhs.kind && value == rhs.value; }
-        bool operator!=(const ThisType& rhs) const { return !(*this == rhs); }
-
-        Kind kind;          ///< The kind of location
-        Index value;          ///< The value of the location. Must be >= 0
-    };
-
-    Index m_nextValueForKind[Count(Kind::CountOf)] = { 0, };
-
-    Dictionary<IRInst*, Location> m_mapIRToLocations;
-};
-
-
 class CLikeSourceEmitter: public SourceEmitterBase
 {
 public:
@@ -277,8 +235,6 @@ public:
     Linkage* getLinkage() { return m_codeGenContext->getLinkage(); }
     ComponentType* getProgram() { return m_codeGenContext->getProgram(); }
     TargetProgram* getTargetProgram() { return m_codeGenContext->getTargetProgram(); }
-
-    LocationTracker& getLocationTracker() { return m_locationTracker; }
 
     //
     // Types
@@ -614,10 +570,6 @@ public:
     // Map an IR instruction to the name that we've decided
     // to use for it when emitting code.
     Dictionary<IRInst*, String> m_mapInstToName;
-
-    // Maps instructions to locations. Used for GLSL output for locations, but could potentially
-    // be used for other kinds of location.
-    LocationTracker m_locationTracker;
 };
 
 }

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -2594,9 +2594,6 @@ void GLSLSourceEmitter::emitVarDecorationsImpl(IRInst* varDecl)
 
     for (auto decoration : varDecl->getDecorations())
     {
-        typedef LocationTracker::Kind LocationKind;
-
-        LocationKind locationKind = LocationKind::Invalid;
         UnownedStringSlice prefix;
         if (as<IRVulkanHitAttributesDecoration>(decoration))
         {
@@ -2604,37 +2601,34 @@ void GLSLSourceEmitter::emitVarDecorationsImpl(IRInst* varDecl)
         }
         else
         {
-            // Handle attributes that have location
-            const LocationKind decorationLocationKind = LocationTracker::getKindFromDecoration(decoration);
-            if (decorationLocationKind == LocationKind::Invalid)
+            IRIntegerValue locationValue = -1;
+            switch (decoration->getOp())
             {
-                // Next decoration
+            case kIROp_VulkanCallablePayloadDecoration:
+                prefix = toSlice("callableData");
+                locationValue = getIntVal(decoration->getOperand(0));
+                break;
+            case kIROp_VulkanRayPayloadDecoration:
+                prefix = toSlice("rayPayload");
+                locationValue = getIntVal(decoration->getOperand(0));
+                break;
+            case kIROp_VulkanHitObjectAttributesDecoration:
+                prefix = toSlice("hitObjectAttribute");
+                locationValue = getIntVal(decoration->getOperand(0));
+                break;
+            default:
                 continue;
             }
-
-            locationKind = decorationLocationKind;
-
-            // Get the location value
-            const auto locationValue = m_locationTracker.getValue(locationKind, varDecl, decoration);
-
             m_writer->emit(toSlice("layout(location = "));
             m_writer->emit(locationValue);
             m_writer->emit(toSlice(")\n"));
-
-            switch (locationKind)
-            {
-                case LocationKind::CallablePayload:             prefix = toSlice("callableData"); break;
-                case LocationKind::HitObjectAttribute:          prefix = toSlice("hitObjectAttribute"); break;
-                case LocationKind::RayPayload:                  prefix = toSlice("rayPayload"); break;
-                default: break;
-            }
         }
 
         SLANG_ASSERT(prefix.getLength());
         m_writer->emit(prefix);
 
         // Special case  hitObjectAttribute as is only NV currently 
-        if (locationKind == LocationKind::HitObjectAttribute ||
+        if (decoration->getOp() == kIROp_VulkanHitObjectAttributesDecoration ||
             getTargetCaps().implies(CapabilityAtom::GL_NV_ray_tracing))
         {
             m_writer->emit(toSlice("NV"));

--- a/source/slang/slang-intrinsic-expand.cpp
+++ b/source/slang/slang-intrinsic-expand.cpp
@@ -739,58 +739,6 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
         }
         break;
 
-        // We will use the `$X` case as a prefix for
-        // special logic needed when cross-compiling ray-tracing
-        // shaders.
-        case 'X':
-        {
-            typedef LocationTracker::Kind LocationKind;
-
-            SLANG_RELEASE_ASSERT(*cursor);
-            const auto kindChar = *cursor++;
-
-            LocationKind kind = LocationKind::Invalid;
-
-            // The `$XP`/`$XC`/`$XH` case handles looking up
-            // the associated `location` for a variable
-            // used as the argument.
-            switch (kindChar)
-            {
-                case 'P':       kind = LocationKind::RayPayload; break;
-                case 'C':       kind = LocationKind::CallablePayload; break;
-                case 'H':       kind = LocationKind::HitObjectAttribute; break;
-                default:        break;
-            }
-
-            SLANG_ASSERT(kind != LocationKind::Invalid);
-
-            if (kind != LocationKind::Invalid)
-            {
-                Index argIndex = 0;
-                SLANG_RELEASE_ASSERT(m_argCount > argIndex);
-                auto arg = m_args[argIndex].get();
-
-                // Find the associated decoration
-                IRDecoration* foundDecoration = nullptr;
-                for (auto decoration : arg->getDecorations())
-                {
-                    const auto curKind = LocationTracker::getKindFromDecoration(decoration);
-                    if (curKind == kind)
-                    {
-                        foundDecoration = decoration;
-                        break;
-                    }
-                }
-
-                // Must have found the decoration
-                SLANG_ASSERT(foundDecoration);
-
-                const auto location = m_emitter->getLocationTracker().getValue(kind, arg, foundDecoration);
-                m_writer->emit(location);
-            }
-        }
-        break;
-
         case 'P':
             // Type-based prefix as used for CUDA and C++ targets
         {

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -632,6 +632,8 @@ INST(GetOptiXHitAttribute, getOptiXHitAttribute, 2, 0)
 // using a pointer. 
 INST(GetOptiXSbtDataPtr, getOptiXSbtDataPointer, 0, 0)
 
+INST(GetVulkanRayTracingPayloadLocation, GetVulkanRayTracingPayloadLocation, 1, 0)
+
 INST(MakeArrayList, makeArrayList, 0, 0)
 INST(MakeTensorView, makeTensorView, 0, 0)
 INST(AllocateTorchTensor, allocTorchTensor, 0, 0)

--- a/source/slang/slang-ir-lower-buffer-element-type.cpp
+++ b/source/slang/slang-ir-lower-buffer-element-type.cpp
@@ -560,6 +560,8 @@ namespace Slang
                     traverseUses(ptrVal, [&](IRUse* use)
                         {
                             auto user = use->getUser();
+                            if (as<IRDecoration>(user))
+                                return;
                             switch (user->getOp())
                             {
                             case kIROp_Load:

--- a/source/slang/slang-ir-specialize-target-switch.cpp
+++ b/source/slang/slang-ir-specialize-target-switch.cpp
@@ -19,17 +19,14 @@ namespace Slang
                 for (UInt i = 0; i < targetSwitch->getCaseCount(); i++)
                 {
                     auto cap = (CapabilityAtom)getIntVal(targetSwitch->getCaseValue(i));
+                    if (target->getTargetCaps().isIncompatibleWith(cap))
+                        continue;
                     CapabilitySet capSet;
                     if (cap == CapabilityAtom::Invalid)
                         capSet = CapabilitySet::makeEmpty();
                     else
                         capSet = CapabilitySet(cap);
                     if (capSet.isBetterForTarget(bestCapSet, target->getTargetCaps()))
-                    {
-                        targetBlock = targetSwitch->getCaseBlock(i);
-                        bestCapSet = capSet;
-                    }
-                    else if (bestCapSet.isInvalid() && !target->getTargetCaps().isIncompatibleWith(capSet))
                     {
                         targetBlock = targetSwitch->getCaseBlock(i);
                         bestCapSet = capSet;

--- a/source/slang/slang-ir-specialize-target-switch.cpp
+++ b/source/slang/slang-ir-specialize-target-switch.cpp
@@ -29,6 +29,11 @@ namespace Slang
                         targetBlock = targetSwitch->getCaseBlock(i);
                         bestCapSet = capSet;
                     }
+                    else if (bestCapSet.isInvalid() && !target->getTargetCaps().isIncompatibleWith(capSet))
+                    {
+                        targetBlock = targetSwitch->getCaseBlock(i);
+                        bestCapSet = capSet;
+                    }
                 }
                 IRBuilder builder(targetSwitch);
                 builder.setInsertBefore(targetSwitch);

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -447,7 +447,7 @@ bool canInstHaveSideEffectAtAddress(IRGlobalValueWithCode* func, IRInst* inst, I
             {
                 auto callee = call->getCallee();
                 if (callee &&
-                    doesCalleeHaveSideEffect(callee))
+                    !doesCalleeHaveSideEffect(callee))
                 {
                     // An exception is if the callee is side-effect free and is not reading from
                     // memory.

--- a/tests/vkray/closesthit.slang
+++ b/tests/vkray/closesthit.slang
@@ -1,5 +1,6 @@
 // closesthit.slang
 //TEST:SIMPLE(filecheck=CHECK): -profile glsl_460+GL_NV_ray_tracing -stage closesthit -entry main -target spirv-assembly
+//TEST:SIMPLE(filecheck=CHECK): -stage closesthit -entry main -target spirv-assembly -emit-spirv-directly
 
 struct ReflectionRay
 {
@@ -33,15 +34,15 @@ void main(
 
 // CHECK: OpCapability RayTracing
 // CHECK: OpEntryPoint ClosestHitNV %main "main"
-// CHECK: OpDecorate %gl_InstanceID BuiltIn InstanceId
-// CHECK: OpDecorate %gl_InstanceCustomIndexNV BuiltIn InstanceCustomIndexNV
-// CHECK: OpDecorate %gl_PrimitiveID BuiltIn PrimitiveId
-// CHECK: OpDecorate %gl_HitKindNV BuiltIn HitKindNV
-// CHECK: OpDecorate %gl_RayTmaxNV BuiltIn RayTmaxNV
-// CHECK: OpDecorate %gl_RayTminNV BuiltIn RayTminNV
-// CHECK: %ShaderRecord_0 = OpVariable %_ptr_ShaderRecordBufferNV__S{{.*}} ShaderRecordBufferNV
-// CHECK: %{{.*}} = OpVariable %_ptr_IncomingRayPayloadNV_ReflectionRay_0 IncomingRayPayloadNV
-// CHECK: %{{.*}} = OpLoad %int %gl_InstanceID
-// CHECK: %{{.*}} = OpLoad %int %gl_InstanceCustomIndexNV
-// CHECK: %{{.*}} = OpAccessChain %_ptr_ShaderRecordBufferNV_uint %ShaderRecord_0 %int_0
-// CHECK: %{{.*}} = OpAccessChain %_ptr_IncomingRayPayloadNV_v4float %_S{{.*}} %int_0
+// CHECK-DAG: OpDecorate %[[INSTANCE_ID:[A-Za-z0-9_]+]] BuiltIn InstanceId
+// CHECK-DAG: OpDecorate %[[INSTANCE_INDEX:[A-Za-z0-9_]+]] BuiltIn InstanceCustomIndexNV
+// CHECK-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
+// CHECK-DAG: OpDecorate %{{.*}} BuiltIn HitKindNV
+// CHECK-DAG: OpDecorate %{{.*}} BuiltIn RayTmaxNV
+// CHECK-DAG: OpDecorate %{{.*}} BuiltIn RayTminNV
+// CHECK-DAG: %ShaderRecord{{.*}} = OpVariable %_ptr_ShaderRecordBufferNV{{.*}} ShaderRecordBufferNV
+// CHECK-DAG: %{{.*}} = OpVariable %_ptr_IncomingRayPayloadNV_ReflectionRay{{.*}} IncomingRayPayloadNV
+// CHECK-DAG: %{{.*}} = OpLoad %{{u?}}int %[[INSTANCE_ID]]
+// CHECK-DAG: %{{.*}} = OpLoad %{{u?}}int %[[INSTANCE_INDEX]]
+// CHECK-DAG: %{{.*}} = OpAccessChain %_ptr_ShaderRecordBufferNV_uint %ShaderRecord{{.*}} %int_0
+// CHECK-DAG: %{{.*}} = OpAccessChain %_ptr_IncomingRayPayloadNV_v4float %{{.*}} %int_0

--- a/tests/vkray/entry-point-params.slang
+++ b/tests/vkray/entry-point-params.slang
@@ -4,6 +4,7 @@
 // shaders properly map to the "shader record" in SPIR-V output.
 
 //TEST:SIMPLE(filecheck=CHECK): -profile glsl_460+spirv_1_4 -stage raygeneration -entry main -target spirv-assembly
+//TEST:SIMPLE(filecheck=CHECK): -stage raygeneration -entry main -target spirv-assembly -emit-spirv-directly
 
 RWStructuredBuffer<float> buffer;
 
@@ -16,7 +17,7 @@ void main(
 // CHECK: OpCapability RayTracingKHR
 // CHECK: OpExtension "SPV_KHR_ray_tracing"
 // CHECK: OpEntryPoint RayGenerationNV %main
-// CHECK: OpDecorate %gl_LaunchIDEXT BuiltIn LaunchIdNV
-// CHECK: %gl_LaunchIDEXT = OpVariable %_ptr_Input_v3uint Input
-// CHECK: %{{.*}} = OpLoad %v3uint %gl_LaunchIDEXT
-// CHECK: %{{.*}} = OpAccessChain %_ptr_ShaderRecordBufferNV_float %_S2 %int_0
+// CHECK-DAG: OpDecorate %[[LaunchID:[A-Za-z0-9_]+]] BuiltIn LaunchIdNV
+// CHECK-DAG: %[[LaunchID]] = OpVariable %_ptr_Input_v3uint Input
+// CHECK-DAG: %{{.*}} = OpLoad %v3uint %[[LaunchID]]
+// CHECK-DAG: %{{.*}} = OpAccessChain %_ptr_ShaderRecordBufferNV_float %{{.*}} %int_0

--- a/tests/vkray/intersection.slang
+++ b/tests/vkray/intersection.slang
@@ -1,6 +1,6 @@
 // intersection.slang
-//TEST:CROSS_COMPILE: -profile glsl_460+GL_NV_ray_tracing -stage intersection -entry main -target spirv-assembly
-
+//TEST:SIMPLE(filecheck=CHECK): -profile glsl_460+GL_NV_ray_tracing -stage intersection -entry main -target spirv-assembly
+//TEST:SIMPLE(filecheck=CHECK): -emit-spirv-directly -stage intersection -entry main -target spirv-assembly
 struct Sphere
 {
 	float3 position;
@@ -45,3 +45,12 @@ void main()
 		ReportHit(tHit, 0, attrs);
 	}
 }
+
+// CHECK: OpEntryPoint IntersectionNV %main "main"
+// CHECK: OpDecorate %[[rayTMin:[a-zA-Z0-9_]+]] BuiltIn RayTminNV
+
+// CHECK-DAG: %[[ATTR:[A-Za-z0-9_]+]] = OpVariable %_ptr_HitAttributeNV_SphereHitAttributes{{.*}} HitAttributeNV
+// CHECK-DAG: %[[VAL:[A-Za-z0-9_]+]] = Op{{.+}} %SphereHitAttributes{{.*}} {{.*}}
+// CHECK-DAG: OpStore %[[ATTR]] %[[VAL]]
+
+// CHECK-DAG: OpReportIntersectionKHR

--- a/tests/vkray/raygen.slang
+++ b/tests/vkray/raygen.slang
@@ -1,4 +1,5 @@
 //TEST:CROSS_COMPILE: -profile glsl_460+GL_EXT_ray_tracing -stage raygeneration -entry main -target spirv-assembly
+//TEST:SIMPLE(filecheck=CHECK): -emit-spirv-directly -stage raygeneration -entry main -target spirv-assembly
 
 #define TRACING_EPSILON 1e-6
 
@@ -46,8 +47,8 @@ void main()
         (float(gl_LaunchIDNV.y) + 0.5f) / float(gl_LaunchSizeNV.y)
     );
 
-    float3 P = samplerPosition.Sample(sampler, inUV).rgb;
-    float3 N = samplerNormal.Sample(sampler, inUV).rgb * 2.0 - 1.0;
+    float3 P = samplerPosition.SampleLevel(sampler, inUV, 0).rgb;
+    float3 N = samplerNormal.SampleLevel(sampler, inUV, 0).rgb * 2.0 - 1.0;
 
     float3 lightPos = ubo.light.position.xyz;
     float3 lightDelta = lightPos - P;
@@ -114,3 +115,6 @@ void main()
 
     outputImage[int2(gl_LaunchIDNV.xy)] = float4(color, 1.0);
 }
+
+// CHECK: %{{.*}} = OpVariable %_ptr_RayPayload{{(NV)?}}_ReflectionRay{{.*}} RayPayload
+// CHECK: OpTraceRayKHR


### PR DESCRIPTION
Add intrinsics for ray tracing API.

Translate StorageClass for ray payload, callable payload, shader record and hit object atttributes.

Replace the target_intrinsic expansion logic of "XC", "XP" and "XH" with an actual `IROp_GetVulkanRayTracingPayloadLocation` instruction and handle it during legalization passes.