### PR TITLE
Support `constref` parameters passing.

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -679,6 +679,12 @@ struct Ref
 {};
 
 __generic<T>
+__magic_type(ConstRefType)
+__intrinsic_type($(kIROp_ConstRefType))
+struct ConstRef
+{};
+
+__generic<T>
 __magic_type(OptionalType)
 __intrinsic_type($(kIROp_OptionalType))
 struct Optional
@@ -2236,6 +2242,9 @@ attribute_syntax [mutating] : MutatingAttribute;
 
 __attributeTarget(SetterDecl)
 attribute_syntax [nonmutating] : NonmutatingAttribute;
+
+__attributeTarget(FunctionDeclBase)
+attribute_syntax [constref] : ConstRefAttribute;
 
     /// Indicates that a function computes its result as a function of its arguments without loading/storing any memory or other state.
     ///

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -311,6 +311,11 @@ RefType* ASTBuilder::getRefType(Type* valueType)
     return dynamicCast<RefType>(getPtrType(valueType, "RefType"));
 }
 
+ConstRefType* ASTBuilder::getConstRefType(Type* valueType)
+{
+    return dynamicCast<ConstRefType>(getPtrType(valueType, "ConstRefType"));
+}
+
 OptionalType* ASTBuilder::getOptionalType(Type* valueType)
 {
     auto rsType = getSpecializedBuiltinType(valueType, "OptionalType");

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -451,6 +451,9 @@ public:
         // Construct the type `Ref<valueType>`
     RefType* getRefType(Type* valueType);
 
+        // Construct the type `ConstRef<valueType>`
+    ConstRefType* getConstRefType(Type* valueType);
+
         // Construct the type `Optional<valueType>`
     OptionalType* getOptionalType(Type* valueType);
 

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -161,6 +161,11 @@ class RefModifier : public Modifier
     SLANG_AST_CLASS(RefModifier)
 };
 
+// `__ref` modifier for by-reference parameter passing
+class ConstRefModifier : public Modifier
+{
+    SLANG_AST_CLASS(ConstRefModifier)
+};
 
 // This is a special sentinel modifier that gets added
 // to the list when we have multiple variable declarations
@@ -917,6 +922,14 @@ class MutatingAttribute : public Attribute
 class NonmutatingAttribute : public Attribute
 {
     SLANG_AST_CLASS(NonmutatingAttribute)
+};
+
+// A `[constref]` attribute, which indicates that the `this` parameter of
+// a member function should be passed by reference.
+//
+class ConstRefAttribute : public Attribute
+{
+    SLANG_AST_CLASS(ConstRefAttribute)
 };
 
 

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -1550,6 +1550,7 @@ namespace Slang
         kParameterDirection_Out,    ///< Copy out
         kParameterDirection_InOut,  ///< Copy in, copy out
         kParameterDirection_Ref,    ///< By-reference
+        kParameterDirection_ConstRef, ///< By-const-reference
     };
 
     /// The kind of a builtin interface requirement that can be automatically synthesized.

--- a/source/slang/slang-ast-type.cpp
+++ b/source/slang/slang-ast-type.cpp
@@ -372,6 +372,10 @@ ParameterDirection FuncType::getParamDirection(Index index)
     {
         return kParameterDirection_Ref;
     }
+    else if (as<ConstRefType>(paramType))
+    {
+        return kParameterDirection_ConstRef;
+    }
     else if (as<InOutType>(paramType))
     {
         return kParameterDirection_InOut;

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -552,10 +552,21 @@ class InOutType : public OutTypeBase
     SLANG_AST_CLASS(InOutType)
 };
 
+class RefTypeBase : public ParamDirectionType
+{
+    SLANG_AST_CLASS(RefTypeBase)
+};
+
 // The type for an `ref` parameter, e.g., `ref T`
-class RefType : public ParamDirectionType
+class RefType : public RefTypeBase
 {
     SLANG_AST_CLASS(RefType)
+};
+
+// The type for an `constref` parameter, e.g., `constref T`
+class ConstRefType : public RefTypeBase
+{
+    SLANG_AST_CLASS(ConstRefType)
 };
 
 class OptionalType : public BuiltinType

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -991,11 +991,12 @@ namespace Slang
             return true;
         }
 
-        if (auto refType = as<RefType>(toType))
+        if (auto refType = as<RefTypeBase>(toType))
         {
-            if (!refType->getValueType()->equals(fromType))
+            ConversionCost cost;
+            if (!canCoerce(refType->getValueType(), fromType, fromExpr, &cost))
                 return false;
-            if (!fromExpr->type.isLeftValue)
+            if (as<RefType>(toType) && !fromExpr->type.isLeftValue)
                 return false;
             
             ConversionCost subCost = kConversionCost_GetRef;
@@ -1016,7 +1017,7 @@ namespace Slang
 
 
         // Allow implicit dereferencing a reference type.
-        if (auto fromRefType = as<RefType>(fromType))
+        if (auto fromRefType = as<RefTypeBase>(fromType))
         {
             auto fromValueType = fromRefType->getValueType();
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -5913,13 +5913,22 @@ namespace Slang
             // specialization.
             for (auto paramDecl : decl->getParameters())
             {
-                if (paramDecl->type.type && !isTypeDifferentiable(paramDecl->type.type))
+                if (!paramDecl->type.type)
+                    continue;
+                if (!isTypeDifferentiable(paramDecl->type.type))
                 {
                     if (!paramDecl->hasModifier<NoDiffModifier>())
                     {
                         auto noDiffModifier = m_astBuilder->create<NoDiffModifier>();
                         noDiffModifier->keywordName = getSession()->getNameObj("no_diff");
                         addModifier(paramDecl, noDiffModifier);
+                    }
+                }
+                if (!paramDecl->hasModifier<NoDiffModifier>())
+                {
+                    if (auto modifier = paramDecl->findModifier<ConstRefModifier>())
+                    {
+                        getSink()->diagnose(modifier, Diagnostics::cannotUseConstRefOnDifferentiableParameter);
                     }
                 }
             }

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1843,6 +1843,14 @@ namespace Slang
             return false;
         }
 
+        if (satisfyingMemberDeclRef.getDecl()->hasModifier<ConstRefAttribute>()
+            && !requiredMemberDeclRef.getDecl()->hasModifier<ConstRefAttribute>())
+        {
+            // A `[constref]` method can't satisfy a non-`[constref]` requirement,
+            // but vice-versa is okay.
+            return false;
+        }
+
         if(satisfyingMemberDeclRef.getDecl()->hasModifier<HLSLStaticModifier>()
             != requiredMemberDeclRef.getDecl()->hasModifier<HLSLStaticModifier>())
         {
@@ -2710,7 +2718,14 @@ namespace Slang
                 auto synMutatingAttr = m_astBuilder->create<MutatingAttribute>();
                 addModifier(synFuncDecl, synMutatingAttr);
             }
-
+            if (requiredMemberDeclRef.getDecl()->hasModifier<ConstRefAttribute>())
+            {
+                // If the interface requirement is `[constref]` then our
+                // synthesized method should be too.
+                //
+                auto synConstRefAttr = m_astBuilder->create<ConstRefAttribute>();
+                addModifier(synFuncDecl, synConstRefAttr);
+            }
             if (requiredMemberDeclRef.getDecl()->hasModifier<NoDiffThisAttribute>())
             {
                 auto noDiffThisAttr = m_astBuilder->create<NoDiffThisAttribute>();
@@ -5161,6 +5176,11 @@ namespace Slang
             //
             if(fstParam.getDecl()->hasModifier<RefModifier>() != sndParam.getDecl()->hasModifier<RefModifier>())
                 return false;
+
+            // If one parameter is `constref` and the other isn't, then they don't match.
+            //
+            if (fstParam.getDecl()->hasModifier<ConstRefModifier>() != sndParam.getDecl()->hasModifier<ConstRefModifier>())
+                return false;
         }
 
         // Note(tfoley): return type doesn't enter into it, because we can't take
@@ -5625,20 +5645,31 @@ namespace Slang
                 // Remove all existing direction modifiers, and replace them with a single Ref modifier.
                 List<Modifier*> newModifiers;
                 bool hasRefModifier = false;
+                bool isMutable = false;
                 for (auto modifier : paramDecl->modifiers)
                 {
-                    if (as<InModifier>(modifier) || as<InOutModifier>(modifier) || as<OutModifier>(modifier))
+                    if (as<InModifier>(modifier))
                     {
                         continue;
                     }
-                    if (as<RefModifier>(modifier))
+                    else if (as<InOutModifier>(modifier) || as<OutModifier>(modifier))
+                    {
+                        isMutable = true;
+                        continue;
+                    }
+                    if (as<RefModifier>(modifier) || as<ConstRefModifier>(modifier))
                     {
                         hasRefModifier = true;
                     }
                     newModifiers.add(modifier);
                 }
                 if (!hasRefModifier)
-                    newModifiers.add(this->getASTBuilder()->create<RefModifier>());
+                {
+                    if (isMutable)
+                        newModifiers.add(this->getASTBuilder()->create<RefModifier>());
+                    else
+                        newModifiers.add(this->getASTBuilder()->create<ConstRefModifier>());
+                }
                 paramDecl->modifiers.first = newModifiers.getFirst();
                 for (Index i = 0; i < newModifiers.getCount(); i++)
                 {
@@ -5773,6 +5804,9 @@ namespace Slang
                 break;
             case ParameterDirection::kParameterDirection_Ref:
                 addModifier(param, m_astBuilder->create<RefModifier>());
+                break;
+            case ParameterDirection::kParameterDirection_ConstRef:
+                addModifier(param, m_astBuilder->create<ConstRefModifier>());
                 break;
             default:
                 break;

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -5932,6 +5932,17 @@ namespace Slang
                     }
                 }
             }
+            if (!isEffectivelyStatic(decl))
+            {
+                auto constrefAttr = decl->findModifier<ConstRefAttribute>();
+                if (constrefAttr)
+                {
+                    if (isTypeDifferentiable(calcThisType(getParentDecl(decl))))
+                    {
+                        getSink()->diagnose(constrefAttr, Diagnostics::cannotUseConstRefOnDifferentiableMemberMethod);
+                    }
+                }
+            }
         }
     }
 

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -214,11 +214,11 @@ namespace Slang
     {
         auto exprType = expr->type.type;
 
-        if (auto refType = as<RefType>(exprType))
+        if (auto refType = as<RefTypeBase>(exprType))
         {
             auto openRef = m_astBuilder->create<OpenRefExpr>();
             openRef->innerExpr = expr;
-            openRef->type.isLeftValue = true;
+            openRef->type.isLeftValue = (as<RefType>(exprType) != nullptr);
             openRef->type.type = refType->getValueType();
             return openRef;
         }

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -561,6 +561,8 @@ DIAGNOSTIC(38031, Error, invalidUseOfNoDiff, "'no_diff' can only be used to deco
 DIAGNOSTIC(38032, Error, useOfNoDiffOnDifferentiableFunc, "use 'no_diff' on a call to a differentiable function has no meaning.")
 DIAGNOSTIC(38033, Error, cannotUseNoDiffInNonDifferentiableFunc, "cannot use 'no_diff' in a non-differentiable function.")
 DIAGNOSTIC(38034, Error, cannotUseConstRefOnDifferentiableParameter, "cannot use '__constref' on a differentiable parameter.")
+DIAGNOSTIC(38034, Error, cannotUseConstRefOnDifferentiableMemberMethod, "cannot use '[constref]' on a differentiable member method of a differentiable type.")
+
 DIAGNOSTIC(38200, Error, recursiveModuleImport, "module `$0` recursively imports itself")
 DIAGNOSTIC(39999, Error, errorInImportedModule, "import of module '$0' failed because of a compilation error")
 DIAGNOSTIC(39999, Fatal, complationCeased, "compilation ceased")

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -560,7 +560,7 @@ DIAGNOSTIC(38029, Error, typeArgumentDoesNotConformToInterface, "type argument '
 DIAGNOSTIC(38031, Error, invalidUseOfNoDiff, "'no_diff' can only be used to decorate a call or a subscript operation")
 DIAGNOSTIC(38032, Error, useOfNoDiffOnDifferentiableFunc, "use 'no_diff' on a call to a differentiable function has no meaning.")
 DIAGNOSTIC(38033, Error, cannotUseNoDiffInNonDifferentiableFunc, "cannot use 'no_diff' in a non-differentiable function.")
-
+DIAGNOSTIC(38034, Error, cannotUseConstRefOnDifferentiableParameter, "cannot use '__constref' on a differentiable parameter.")
 DIAGNOSTIC(38200, Error, recursiveModuleImport, "module `$0` recursively imports itself")
 DIAGNOSTIC(39999, Error, errorInImportedModule, "import of module '$0' failed because of a compilation error")
 DIAGNOSTIC(39999, Fatal, complationCeased, "compilation ceased")

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -3235,6 +3235,10 @@ void CLikeSourceEmitter::emitParamTypeImpl(IRType* type, String const& name)
         m_writer->emit("inout ");
         type = refType->getValueType();
     }
+    else if (auto constRefType = as<IRConstRefType>(type))
+    {
+        type = constRefType->getValueType();
+    }
 
     emitType(type, name);
 }

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -403,8 +403,9 @@ void CPPSourceEmitter::useType(IRType* type)
             break;
         }
         case kIROp_RefType:
+        case kIROp_ConstRefType:
         {
-            type = static_cast<IRRefType*>(type)->getValueType();
+            type = static_cast<IRPtrTypeBase*>(type)->getValueType();
             break;
         }
         default: break;
@@ -1039,6 +1040,7 @@ void CPPSourceEmitter::_emitType(IRType* type, DeclaratorInfo* declarator)
         }
         break;
     case kIROp_RefType:
+    case kIROp_ConstRefType:
         {
             auto ptrType = cast<IRPtrTypeBase>(type);
             PtrDeclaratorInfo refDeclarator(declarator);

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1277,6 +1277,7 @@ struct SPIRVEmitContext
             }
         case kIROp_PtrType:
         case kIROp_RefType:
+        case kIROp_ConstRefType:
         case kIROp_OutType:
         case kIROp_InOutType:
             {

--- a/source/slang/slang-ir-addr-inst-elimination.cpp
+++ b/source/slang/slang-ir-addr-inst-elimination.cpp
@@ -97,6 +97,12 @@ struct AddressInstEliminationContext
         auto addr = use->get();
         auto call = as<IRCall>(use->getUser());
 
+        // Don't change the use if addr is a non mutable address.
+        if (auto refType = as<IRConstRefType>(addr->getDataType()))
+        {
+            return;
+        }
+
         IRBuilder builder(module);
         builder.setInsertBefore(call);
         auto tempVar = builder.emitVar(cast<IRPtrTypeBase>(addr->getFullType())->getValueType());
@@ -123,6 +129,8 @@ struct AddressInstEliminationContext
         {
             for (auto inst : block->getChildren())
             {
+                if (as<IRConstRefType>(getRootAddr(inst)->getDataType()))
+                    continue;
                 if (auto ptrType = as<IRPtrTypeBase>(inst->getDataType()))
                 {
                     auto valType = unwrapAttributedType(ptrType->getValueType());

--- a/source/slang/slang-ir-addr-inst-elimination.cpp
+++ b/source/slang/slang-ir-addr-inst-elimination.cpp
@@ -98,7 +98,7 @@ struct AddressInstEliminationContext
         auto call = as<IRCall>(use->getUser());
 
         // Don't change the use if addr is a non mutable address.
-        if (auto refType = as<IRConstRefType>(addr->getDataType()))
+        if (auto refType = as<IRConstRefType>(getRootAddr(addr)->getDataType()))
         {
             return;
         }

--- a/source/slang/slang-ir-autodiff-primal-hoist.cpp
+++ b/source/slang/slang-ir-autodiff-primal-hoist.cpp
@@ -1478,9 +1478,8 @@ RefPtr<HoistedPrimalsInfo> ensurePrimalAvailability(
                 continue;
 
             IRBlock* defBlock = nullptr;
-            if (const auto ptrInst = as<IRPtrTypeBase>(instToStore->getDataType()))
+            if (auto varInst = as<IRVar>(instToStore))
             {
-                auto varInst = as<IRVar>(instToStore);
                 auto storeUse = findEarliestUniqueWriteUse(varInst);
 
                 defBlock = getBlock(storeUse->getUser());
@@ -2126,6 +2125,10 @@ bool DefaultCheckpointPolicy::canRecompute(UseOrPseudoUse use)
         // We can't recompute a 'load' from a mutable function parameter.
         if (as<IRParam>(ptr) || as<IRVar>(ptr))
         {
+            // An exception is a load of a constref parameter, which should
+            // remain constant throughout the function.
+            if (as<IRConstRefType>(getRootAddr(ptr)->getDataType()))
+                return true;
             if (isInstInPrimalOrTransposedParameterBlocks(ptr))
                 return false;
         }

--- a/source/slang/slang-ir-autodiff-rev.cpp
+++ b/source/slang/slang-ir-autodiff-rev.cpp
@@ -415,9 +415,9 @@ namespace Slang
 
                 // Fetch primal values to use as arguments in primal func call.
                 IRInst* primalArg = param;
-                if (!as<IROutType>(primalParamType))
+                if (!as<IROutType>(primalParamType) && !as<IRConstRefType>(primalParamType))
                 {
-                    // As long as the primal parameter is not an out type,
+                    // As long as the primal parameter is not an out or constref type,
                     // we need to fetch the primal value from the parameter.
                     if (as<IRPtrTypeBase>(propagateParamType))
                     {
@@ -428,7 +428,7 @@ namespace Slang
                         primalArg = builder.emitDifferentialPairGetPrimal(primalArg);
                     }
                 }
-                if (auto primalParamPtrType = as<IRPtrTypeBase>(primalParamType))
+                if (auto primalParamPtrType = isMutablePointerType(primalParamType))
                 {
                     // If primal parameter is mutable, we need to pass in a temp var.
                     auto tempVar = builder.emitVar(primalParamPtrType->getValueType());

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -108,6 +108,7 @@ INST(Nop, nop, 0, 0)
     /* PtrTypeBase */
         INST(PtrType, Ptr, 1, HOISTABLE)
         INST(RefType, Ref, 1, HOISTABLE)
+        INST(ConstRefType, ConstRef, 1, HOISTABLE)
         // A `PsuedoPtr<T>` logically represents a pointer to a value of type
         // `T` on a platform that cannot support pointers. The expectation
         // is that the "pointer" will be legalized away by storing a value

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -3246,6 +3246,7 @@ public:
     IROutType*  getOutType(IRType* valueType);
     IRInOutType*  getInOutType(IRType* valueType);
     IRRefType*  getRefType(IRType* valueType);
+    IRConstRefType* getConstRefType(IRType* valueType);
     IRPtrTypeBase*  getPtrType(IROp op, IRType* valueType);
     IRPtrType* getPtrType(IROp op, IRType* valueType, IRIntegerValue addressSpace);
 

--- a/source/slang/slang-ir-layout.cpp
+++ b/source/slang/slang-ir-layout.cpp
@@ -287,6 +287,7 @@ case kIROp_##TYPE##Type:                                        \
     case kIROp_OutType:
     case kIROp_InOutType:
     case kIROp_RefType:
+    case kIROp_ConstRefType:
     case kIROp_RawPointerType:
     case kIROp_PtrType:
     case kIROp_NativePtrType:

--- a/source/slang/slang-ir-marshal-native-call.cpp
+++ b/source/slang/slang-ir-marshal-native-call.cpp
@@ -18,6 +18,7 @@ namespace Slang
             return builder.getNativePtrType((IRType*)as<IRComPtrType>(type)->getOperand(0));
         case kIROp_InOutType:
         case kIROp_RefType:
+        case kIROp_ConstRefType:
         case kIROp_OutType:
             return builder.getPtrType(getNativeType(builder, (IRType*)type->getOperand(0)));
         default:
@@ -76,6 +77,7 @@ namespace Slang
         {
         case kIROp_InOutType:
         case kIROp_RefType:
+        case kIROp_ConstRefType:
         case kIROp_OutType:
             return marshalRefManagedValueToNativeValue(
                 builder, originalArg, args);
@@ -135,6 +137,7 @@ namespace Slang
         {
         case kIROp_InOutType:
         case kIROp_RefType:
+        case kIROp_ConstRefType:
             SLANG_UNREACHABLE("out and ref types should be handled before reaching here.");
             break;
         case kIROp_StringType:

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -418,6 +418,7 @@ bool isPtrLikeOrHandleType(IRInst* type)
     case kIROp_InOutType:
     case kIROp_PtrType:
     case kIROp_RefType:
+    case kIROp_ConstRefType:
         return true;
     }
     return false;
@@ -967,6 +968,17 @@ bool isOne(IRInst* inst)
         return isOne(inst->getOperand(0));
     default:
         return false;
+    }
+}
+
+IRPtrTypeBase* isMutablePointerType(IRInst* inst)
+{
+    switch (inst->getOp())
+    {
+    case kIROp_ConstRefType:
+        return nullptr;
+    default:
+        return as<IRPtrTypeBase>(inst);
     }
 }
 

--- a/source/slang/slang-ir-util.h
+++ b/source/slang/slang-ir-util.h
@@ -221,6 +221,8 @@ bool isZero(IRInst* inst);
 
 bool isOne(IRInst* inst);
 
+IRPtrTypeBase* isMutablePointerType(IRInst* inst);
+
 void initializeScratchData(IRInst* inst);
 void resetScratchDataBit(IRInst* inst, int bitIndex);
 

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -2755,6 +2755,11 @@ namespace Slang
         return (IRRefType*) getPtrType(kIROp_RefType, valueType);
     }
 
+    IRConstRefType* IRBuilder::getConstRefType(IRType* valueType)
+    {
+        return (IRConstRefType*)getPtrType(kIROp_ConstRefType, valueType);
+    }
+
     IRSPIRVLiteralType* IRBuilder::getSPIRVLiteralType(IRType* type)
     {
         IRInst* operands[] = { type };
@@ -3588,6 +3593,7 @@ namespace Slang
         case kIROp_OutType:
         case kIROp_RawPointerType:
         case kIROp_RefType:
+        case kIROp_ConstRefType:
         case kIROp_ComPtrType:
         case kIROp_NativePtrType:
         case kIROp_NativeStringType:
@@ -3697,6 +3703,7 @@ namespace Slang
         case kIROp_OutType:
         case kIROp_RawPointerType:
         case kIROp_RefType:
+        case kIROp_ConstRefType:
             return 3;
         case kIROp_VoidType:
             return 4;

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1637,6 +1637,7 @@ struct IRPtrTypeBase : IRType
 
 SIMPLE_IR_TYPE(PtrType, PtrTypeBase)
 SIMPLE_IR_TYPE(RefType, PtrTypeBase)
+SIMPLE_IR_TYPE(ConstRefType, PtrTypeBase)
 SIMPLE_IR_PARENT_TYPE(OutTypeBase, PtrTypeBase)
 SIMPLE_IR_TYPE(OutType, OutTypeBase)
 SIMPLE_IR_TYPE(InOutType, OutTypeBase)

--- a/source/slang/slang-language-server-inlay-hints.cpp
+++ b/source/slang/slang-language-server-inlay-hints.cpp
@@ -63,6 +63,7 @@ List<LanguageServerProtocol::InlayHint> getInlayHints(
                         if (param->hasModifier<OutModifier>()) lblSb << "out ";
                         else if (param->hasModifier<InOutModifier>()) lblSb << "inout ";
                         else if (param->hasModifier<RefModifier>()) lblSb << "ref ";
+                        else if (param->hasModifier<ConstRefModifier>()) lblSb << "constref ";
                         lblSb << name->text;
                         lblSb << ":";
                         hint.label = lblSb.produceString();

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -2414,6 +2414,7 @@ void addArg(
 
     case kParameterDirection_Out:
     case kParameterDirection_InOut:
+    case kParameterDirection_ConstRef:
         {
             // According to our "calling convention" we need to
             // pass a pointer into the callee.
@@ -2434,6 +2435,12 @@ void addArg(
                 // If the value is not one that could yield a simple l-value
                 // then we need to convert it into a temporary
                 //
+                if (auto refType = as<IRConstRefType>(paramType))
+                {
+                    paramType = refType->getValueType();
+                    argVal = LoweredValInfo::simple(context->irBuilder->emitLoad(getSimpleVal(context, argPtr)));
+                }
+
                 LoweredValInfo tempVar = createVar(context, paramType);
 
                 // If the parameter is `in out` or `inout`, then we need
@@ -2441,7 +2448,8 @@ void addArg(
                 // in the argument, which we accomplish by assigning
                 // from the l-value to our temp.
                 //
-                if (paramDirection == kParameterDirection_InOut)
+                if (paramDirection == kParameterDirection_InOut ||
+                    paramDirection == kParameterDirection_ConstRef)
                 {
                     assign(context, tempVar, argVal);
                 }
@@ -2455,11 +2463,14 @@ void addArg(
                 // Finally, after the call we will need
                 // to copy in the other direction: from our
                 // temp back to the original l-value.
-                OutArgumentFixup fixup;
-                fixup.src = tempVar;
-                fixup.dst = argVal;
+                if (paramDirection != kParameterDirection_ConstRef)
+                {
+                    OutArgumentFixup fixup;
+                    fixup.src = tempVar;
+                    fixup.dst = argVal;
 
-                (*ioFixups).add(fixup);
+                    (*ioFixups).add(fixup);
+                }
             }
         }
         break;
@@ -2492,6 +2503,7 @@ void addCallArgsForParam(
     switch(paramDirection)
     {
     case kParameterDirection_Ref:
+    case kParameterDirection_ConstRef:
     case kParameterDirection_Out:
     case kParameterDirection_InOut:
         {
@@ -2525,6 +2537,10 @@ ParameterDirection getParameterDirection(VarDeclBase* paramDecl)
         // where this matters, so treat them as by-reference here.
 
         return kParameterDirection_Ref;
+    }
+    if (paramDecl->hasModifier<ConstRefModifier>())
+    {
+        return kParameterDirection_ConstRef;
     }
     if( paramDecl->hasModifier<InOutModifier>() )
     {
@@ -2563,7 +2579,10 @@ ParameterDirection getThisParamDirection(Decl* parentDecl, ParameterDirection de
 
     if (parentParent->findModifier<NonCopyableTypeAttribute>())
     {
-        return kParameterDirection_Ref;
+        if (parentDecl->hasModifier<MutatingAttribute>())
+            return kParameterDirection_Ref;
+        else
+            return kParameterDirection_ConstRef;
     }
 
     // Applications can opt in to a mutable `this` parameter,
@@ -2573,6 +2592,10 @@ ParameterDirection getThisParamDirection(Decl* parentDecl, ParameterDirection de
     if( parentDecl->hasModifier<MutatingAttribute>() )
     {
         return kParameterDirection_InOut;
+    }
+    else if (parentDecl->hasModifier<ConstRefAttribute>())
+    {
+        return kParameterDirection_ConstRef;
     }
 
     // A `set` accessor on a property or subscript declaration
@@ -2988,7 +3011,9 @@ void _lowerFuncDeclBaseTypeInfo(
         case kParameterDirection_Ref:
             irParamType = builder->getRefType(irParamType);
             break;
-
+        case kParameterDirection_ConstRef:
+            irParamType = builder->getConstRefType(irParamType);
+            break;
         default:
             SLANG_UNEXPECTED("unknown parameter direction");
             break;

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -7263,6 +7263,7 @@ namespace Slang
         _makeParseModifier("out",           OutModifier::kReflectClassInfo),
         _makeParseModifier("inout",         InOutModifier::kReflectClassInfo),
         _makeParseModifier("__ref",         RefModifier::kReflectClassInfo),
+        _makeParseModifier("__constref",    ConstRefModifier::kReflectClassInfo),
         _makeParseModifier("const",         ConstModifier::kReflectClassInfo),
         _makeParseModifier("instance",      InstanceModifier::kReflectClassInfo),
         _makeParseModifier("__builtin",     BuiltinModifier::kReflectClassInfo),

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -603,6 +603,10 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
             {
                 paramType = astBuilder->getRefType(paramType);
             }
+            else if (paramDecl->findModifier<ConstRefModifier>())
+            {
+                paramType = astBuilder->getConstRefType(paramType);
+            }
             else if( paramDecl->findModifier<OutModifier>() )
             {
                 if(paramDecl->findModifier<InOutModifier>() || paramDecl->findModifier<InModifier>())

--- a/tests/autodiff/constref-param.slang
+++ b/tests/autodiff/constref-param.slang
@@ -1,0 +1,41 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cpu -compute -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+struct NonDiff
+{
+    float a;
+}
+
+[Differentiable]
+float myFunc(__constref NonDiff fIn, float x, __constref no_diff float y)
+{
+    return x * fIn.a + y;
+}
+
+// test that the ordering of no_diff and __constref doesn't matter.
+[Differentiable]
+float myFunc2(__constref NonDiff fIn, float x, no_diff __constref float y)
+{
+    return x * fIn.a + y;
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    float a = 10.0;
+    NonDiff fIn = { a };
+    DifferentialPair<float> dpx = DifferentialPair<float>(4.f, 1.f);
+    float rs = __fwd_diff(myFunc)(fIn, dpx, 1.0).d;
+    float rs2 = __fwd_diff(myFunc2)(fIn, dpx, 1.0).d;
+
+    // CHECK: 10.0
+    // CHECK: 10.0
+
+    outputBuffer[0] = rs;
+    outputBuffer[1] = rs2;
+}

--- a/tests/diagnostics/const-ref-differentiable-param.slang
+++ b/tests/diagnostics/const-ref-differentiable-param.slang
@@ -1,0 +1,9 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):
+
+[Differentiable]
+float f(__constref float3 val)
+{
+    return val.x;
+}
+
+// CHECK: {{.*}}error {{.*}}: cannot use '{{(__)?}}constref' on a differentiable parameter.

--- a/tests/diagnostics/const-ref-differentiable-param.slang
+++ b/tests/diagnostics/const-ref-differentiable-param.slang
@@ -1,9 +1,38 @@
 //DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):
 
+
 [Differentiable]
 float f(__constref float3 val)
 {
     return val.x;
 }
 
-// CHECK: {{.*}}error {{.*}}: cannot use '{{(__)?}}constref' on a differentiable parameter.
+struct MyType : IDifferentiable
+{
+    // Error: cannot use constref on a differentiable member method of a differentiable type.
+    [Differentiable]
+    [constref] float compute(float x) { return 0; }
+
+    // OK
+    [Differentiable]
+    float compute1(float x) { return 0; }
+
+    // OK
+    [constref] float compute2(float x) { return 0;}
+}
+
+struct MyType2
+{
+    // OK.
+    [Differentiable]
+    [constref] float compute(float x) { return 0; }
+
+    // OK
+    [constref]
+    float compute1(float x) { return 0; }
+}
+
+// CHECK-DAG: {{.*}}(5): error 38034: cannot use '__constref' on a differentiable parameter.
+// CHECK-NOT {{.*}}error
+// CHECK-DAG: {{.*}}(14): error 38034: cannot use '[constref]' on a differentiable member method of a differentiable type.
+// CHECK-NOT {{.*}}error

--- a/tests/diagnostics/param-mutation.slang
+++ b/tests/diagnostics/param-mutation.slang
@@ -20,8 +20,6 @@ int doThing(MutatingStruct s, int v)
 
 // For non-copyable types (such as HitObject or NonCopyableStruct declared below), if passed as as `in`
 // should produce an error.
-// NOTE! This *doesn't* produce an error (or warning) because NonCopyable types are *implicitly* 
-// made *ref* when parsed as arguments. 
 
 [__NonCopyableType]
 struct NonCopyableStruct
@@ -32,7 +30,6 @@ struct NonCopyableStruct
 
 int doThing2(NonCopyableStruct s, int v)
 {
-    // Currently doesn't produce an error/warning because NonCopyableStruct is passed as *ref* implicitly.
     s.setValue(v + 1);
     return s.m_value;
 }

--- a/tests/diagnostics/param-mutation.slang.expected
+++ b/tests/diagnostics/param-mutation.slang.expected
@@ -1,6 +1,9 @@
-result code = 0
+result code = -1
 standard error = {
 tests/diagnostics/param-mutation.slang(17): warning 30068: mutating method 'setValue' called on `in` parameter 's'; changes will not be visible to caller. copy the parameter into a local variable if this behavior is intended
+    s.setValue(v + 1);
+              ^
+tests/diagnostics/param-mutation.slang(36): error 30067: mutating method 'setValue' called on `in` parameter 's'; changes will not be visible to caller. copy the parameter into a local variable if this behavior is intended
     s.setValue(v + 1);
               ^
 }

--- a/tests/language-feature/pointer/const-ref.slang
+++ b/tests/language-feature/pointer/const-ref.slang
@@ -1,0 +1,64 @@
+// pointer-self-reference.slang
+
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER): -slang -compute -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER): -vk -compute -output-using-type -shaderobj
+
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+struct Thing
+{
+    int value;
+    int bigArray[128];
+
+    // Check that we are not inserting local variables that are copies of `this` parameter.
+    
+    // CHECK: __device__ int Thing_getSum{{.*}}(Thing{{.*}} * this{{.*}})
+    // CHECK-NOT: Thing{{[a-zA-Z0-9_]*}} {{[a-zA-Z0-9_]+}}
+    // CHECK: }
+    [constref]
+    int getSum()
+    {
+        int result = 0;
+        for (int i = 0; i < 128; i++)
+        {
+            result += bigArray[i];
+        }
+        return result;
+    }
+};
+
+// Check that we are not inserting local variables that are copies of `thing` parameter.
+
+// CHECK: __device__ int test{{.*}}(Thing{{.*}} * thing{{.*}})
+// CHECK-NOT: Thing{{[a-zA-Z0-9_]*}} {{[a-zA-Z0-9_]+}}
+// CHECK: }
+
+int test(__constref Thing thing)
+{
+    int sum0 = thing.getSum();
+    AllMemoryBarrier();
+    int sum1 = thing.getSum();
+    return sum0 + sum1;
+}
+
+int caller(Thing thing)
+{
+    return test(thing);
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID: SV_DispatchThreadID)
+{
+    int idx = dispatchThreadID.x;
+
+    Thing thing = {};
+
+    thing.bigArray[0] = 100;
+    thing.bigArray[99] = 1;
+
+    // BUFFER: 202
+    outputBuffer[idx] = caller(thing);
+}


### PR DESCRIPTION
This PR adds support for `__constref` parameter modifier to specify that a parameter should be passed by const reference.
A `constref` parameter is treated as an immutable value.
Adds `[constref]` attribute that can be used to mark a function to make `this` parameter passed by const reference.

Make NonCopyable type passed by constref by default.
Also makes sure constref parameters doesn't lead to redundant load/stores in auto-diffed functions.

Add tests for mixing use of `__constref` and `no_diff` in a differentiable function.