### PR TITLE
More direct-SPIRV fixes.

### DIFF
--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -1893,6 +1893,18 @@ bool GLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
 
             return true;
         }
+        case kIROp_GetVulkanRayTracingPayloadLocation:
+        {
+            auto payloadVar = inst->getOperand(0);
+            IRInst* location = getVulkanPayloadLocation(payloadVar);
+            if (!location)
+            {
+                SLANG_DIAGNOSE_UNEXPECTED(getSink(), inst, "no payload location assigned.");
+                m_writer->emit("0");
+            }
+            m_writer->emit(getIntVal(location));
+            return true;
+        }
         case kIROp_ImageLoad:
         {
             m_writer->emit("imageLoad(");

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -2274,6 +2274,20 @@ struct SPIRVEmitContext
                 registerInst(inst, inner);
                 return inner;
             }
+        case kIROp_GetVulkanRayTracingPayloadLocation:
+            {
+                IRInst* location = getVulkanPayloadLocation(inst->getOperand(0));
+                if (!location)
+                {
+                    SLANG_DIAGNOSE_UNEXPECTED(m_sink, inst, "no payload location assigned.");
+                    IRBuilder builder(inst);
+                    builder.setInsertBefore(inst);
+                    location = builder.getIntValue(builder.getIntType(), 0);
+                }
+                auto inner = ensureInst(location);
+                registerInst(inst, inner);
+                return inner;
+            }
         case kIROp_Return:
             if (as<IRReturn>(inst)->getVal()->getOp() == kIROp_VoidLit)
                 return emitOpReturn(parent, inst);

--- a/source/slang/slang-ir-array-reg-to-mem.cpp
+++ b/source/slang/slang-ir-array-reg-to-mem.cpp
@@ -33,9 +33,9 @@ namespace Slang
             if (auto arrayType = as<IRArrayTypeBase>(param->getFullType()))
             {
                 changed = true;
-                builder.setInsertBefore(param);
                 auto ptrArrayType = builder.getPtrType(arrayType);
-                auto newParam = builder.emitParam(ptrArrayType);
+                auto newParam = builder.createParam(ptrArrayType);
+                newParam->insertBefore(param);
                 setInsertAfterOrdinaryInst(&builder, param);
                 auto regVal = builder.emitLoad(newParam);
                 param->replaceUsesWith(regVal);
@@ -62,6 +62,7 @@ namespace Slang
                         for (auto paramId : arrayParamIds)
                         {
                             auto arg = call->getArg(paramId);
+                            SLANG_ASSERT(as<IRPtrTypeBase>(paramTypes[paramId]));
                             auto var = builder.emitVar(as<IRPtrTypeBase>(paramTypes[paramId])->getValueType());
                             builder.emitStore(var, arg);
                             call->setArg(paramId, var);

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -2693,18 +2693,6 @@ void assignRayPayloadHitObjectAttributeLocations(IRModule* module)
             }
         }
     end:;
-        if (location)
-        {
-            traverseUses(globalVar, [&](IRUse* use)
-                {
-                    auto user = use->getUser();
-                    if (user->getOp() == kIROp_GetVulkanRayTracingPayloadLocation)
-                    {
-                        user->replaceUsesWith(location);
-                        user->removeAndDeallocate();
-                    }
-                });
-        }
     }
 }
 

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -1516,6 +1516,10 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
 
     void processModule()
     {
+#if 0
+        eliminateArrayTypeSSARegisters(m_module);
+#endif
+
         // Process global params before anything else, so we don't generate inefficient
         // array marhalling code for array-typed global params.
         for (auto globalInst : m_module->getGlobalInsts())

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -265,7 +265,38 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         return false;
     }
 
-    void inferTextureFormat(IRInst* textureInst, IRTextureTypeBase* textureType)
+    static IRType* replaceImageElementType(IRInst* originalType, IRInst* newElementType)
+    {
+        switch(originalType->getOp())
+        {
+        case kIROp_ArrayType:
+        case kIROp_UnsizedArrayType:
+        case kIROp_PtrType:
+        case kIROp_OutType:
+        case kIROp_RefType:
+        case kIROp_ConstRefType:
+        case kIROp_InOutType:
+            {
+                auto newInnerType = replaceImageElementType(originalType->getOperand(0), newElementType);
+                if (newInnerType != originalType->getOperand(0))
+                {
+                    IRBuilder builder(originalType);
+                    builder.setInsertBefore(originalType);
+                    IRCloneEnv cloneEnv;
+                    cloneEnv.mapOldValToNew.add(originalType->getOperand(0), newInnerType);
+                    return (IRType*)cloneInst(&cloneEnv, &builder, originalType);
+                }
+                return (IRType*)originalType;
+            }
+            
+        default:
+            if (as<IRResourceTypeBase>(originalType))
+                return (IRType*)newElementType;
+            return (IRType*)originalType;
+        }
+    }
+
+    static void inferTextureFormat(IRInst* textureInst, IRTextureTypeBase* textureType)
     {
         ImageFormat format = ImageFormat::unknown;
         if (auto decor = textureInst->findDecoration<IRFormatDecoration>())
@@ -368,14 +399,52 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             args.add(builder.getIntValue(builder.getUIntType(), IRIntegerValue(format)));
 
             auto newType = (IRType*)builder.emitIntrinsicInst(builder.getTypeKind(), textureType->getOp(), 3, args.getBuffer());
-            textureInst->setFullType(newType);
+            if (textureInst->getFullType() == textureType)
+            {
+                // Simple texture typed global param.
+                textureInst->setFullType(newType);
+            }
+            else
+            {
+                // Array typed global param. We need to replace the type and the types of all getElement insts.
+                auto newInstType = (IRType*)replaceImageElementType(textureInst->getFullType(), newType);
+                textureInst->setFullType(newInstType);
+                List<IRUse*> typeReplacementWorkList;
+                HashSet<IRUse*> typeReplacementWorkListSet;
+                for (auto use = textureInst->firstUse; use; use = use->nextUse)
+                {
+                    if (typeReplacementWorkListSet.add(use))
+                        typeReplacementWorkList.add(use);
+                }
+                for (Index i = 0; i < typeReplacementWorkList.getCount(); i++)
+                {
+                    auto use = typeReplacementWorkList[i];
+                    auto user = use->getUser();
+                    switch (user->getOp())
+                    {
+                    case kIROp_GetElementPtr:
+                    case kIROp_GetElement:
+                    case kIROp_Load:
+                        {
+                            auto newUserType = (IRType*)replaceImageElementType(user->getFullType(), newType);
+                            user->setFullType(newUserType);
+                            for (auto u = user->firstUse; u; u = u->nextUse)
+                            {
+                                if (typeReplacementWorkListSet.add(u))
+                                    typeReplacementWorkList.add(u);
+                            }
+                            break;
+                        };
+                    }
+                }
+            }
         }
     }
 
     void processGlobalParam(IRGlobalParam* inst)
     {
         // If the param is a texture, infer its format.
-        if (auto textureType = as<IRTextureTypeBase>(inst->getDataType()))
+        if (auto textureType = as<IRTextureTypeBase>(unwrapArray(inst->getDataType())))
         {
             inferTextureFormat(inst, textureType);
         }

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -814,6 +814,24 @@ IRInst* findWitnessTableEntry(IRWitnessTable* table, IRInst* key)
     return nullptr;
 }
 
+IRInst* getVulkanPayloadLocation(IRInst* payloadGlobalVar)
+{
+    IRInst* location = nullptr;
+    for (auto decor : payloadGlobalVar->getDecorations())
+    {
+        switch (decor->getOp())
+        {
+        case kIROp_VulkanRayPayloadDecoration:
+        case kIROp_VulkanCallablePayloadDecoration:
+        case kIROp_VulkanHitObjectAttributesDecoration:
+            return decor->getOperand(0);
+        default:
+            continue;
+        }
+    }
+    return location;
+}
+
 void moveParams(IRBlock* dest, IRBlock* src)
 {
     for (auto param = src->getFirstChild(); param;)

--- a/source/slang/slang-ir-util.h
+++ b/source/slang/slang-ir-util.h
@@ -209,6 +209,8 @@ IRInst* findInterfaceRequirement(IRInterfaceType* type, IRInst* key);
 
 IRInst* findWitnessTableEntry(IRWitnessTable* table, IRInst* key);
 
+IRInst* getVulkanPayloadLocation(IRInst* payloadGlobalVar);
+
 void moveParams(IRBlock* dest, IRBlock* src);
 
 void removePhiArgs(IRInst* phiParam);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9903,7 +9903,13 @@ static void lowerFrontEndEntryPointToIR(
         instToDecorate = findGenericReturnVal(irGeneric);
     }
 
+    // If the entry-point decorations has already been created (because the user
+    // specified duplicate entries in the entry point list), we can stop now.
+    if (instToDecorate->findDecoration<IREntryPointDecoration>())
+        return;
+
     {
+
         Name* entryPointName = entryPoint->getFuncDecl()->getName();
         builder->addEntryPointDecoration(instToDecorate, entryPoint->getProfile(), entryPointName->text.getUnownedSlice(), moduleName.getUnownedSlice());
     }

--- a/tests/spirv/mutating-method-syn.slang
+++ b/tests/spirv/mutating-method-syn.slang
@@ -1,0 +1,38 @@
+// mutating-method-syn.slang
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute
+// Test ability to directly output SPIR-V
+
+interface IFoo
+{
+    [mutating]
+    int bar(inout int y);
+}
+
+struct Val : IFoo
+{
+    int x;
+
+    int bar(int y)
+    {
+        return x + y;
+    }
+}
+
+int test<T:IFoo>(inout T f, inout int y)
+{
+    return f.bar(y);
+}
+
+//TEST_INPUT:set result = out ubuffer(data=[0 0 0 0], stride=4)
+
+RWStructuredBuffer<int> result;
+[numthreads(1,1,1)]
+void computeMain()
+{    
+    Val v;
+    int y = 0;
+    v.x = 1;
+    
+    // CHECK: 1
+    result[0] = test(v, y);
+}

--- a/tools/gfx/vulkan/vk-api.h
+++ b/tools/gfx/vulkan/vk-api.h
@@ -261,6 +261,9 @@ struct VulkanExtendedFeatureProperties
     VkPhysicalDeviceRobustness2FeaturesEXT robustness2Features = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT};
 
+    VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV rayTracingInvocationReorderFeatures = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_NV};
+
     // Clock features
     VkPhysicalDeviceShaderClockFeaturesKHR clockFeatures = { 
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR

--- a/tools/gfx/vulkan/vk-device.cpp
+++ b/tools/gfx/vulkan/vk-device.cpp
@@ -405,6 +405,10 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
         extendedFeatures.rayTracingPipelineFeatures.pNext = deviceFeatures2.pNext;
         deviceFeatures2.pNext = &extendedFeatures.rayTracingPipelineFeatures;
 
+        // SER features.
+        extendedFeatures.rayTracingInvocationReorderFeatures.pNext = deviceFeatures2.pNext;
+        deviceFeatures2.pNext = &extendedFeatures.rayTracingInvocationReorderFeatures;
+
         // Acceleration structure features
         extendedFeatures.accelerationStructureFeatures.pNext = deviceFeatures2.pNext;
         deviceFeatures2.pNext = &extendedFeatures.accelerationStructureFeatures;
@@ -580,6 +584,16 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             deviceCreateInfo.pNext = &extendedFeatures.meshShaderFeatures;
 
             m_features.add("mesh-shader");
+        }
+
+        if (extendedFeatures.rayTracingInvocationReorderFeatures.rayTracingInvocationReorder)
+        {
+            deviceExtensions.add(VK_NV_RAY_TRACING_INVOCATION_REORDER_EXTENSION_NAME);
+
+            extendedFeatures.rayTracingInvocationReorderFeatures.pNext = (void*)deviceCreateInfo.pNext;
+            deviceCreateInfo.pNext = &extendedFeatures.rayTracingInvocationReorderFeatures;
+
+            m_features.add("shader-execution-reorder");
         }
 
         if (_hasAnySetBits(


### PR DESCRIPTION
- Properly synthesize mutating conformance methods from non-mutating implementations.
- Infer image type for arrays of images.
- Keep `GetVulkanPayloadLocation` insts instead of replacing them with the literal location in order to keep the original global variable definition alive.