### PR TITLE
Small type system fixes.

### DIFF
--- a/source/core/slang-string-util.cpp
+++ b/source/core/slang-string-util.cpp
@@ -392,6 +392,31 @@ ComPtr<ISlangBlob> StringUtil::createStringBlob(const String& string)
     return (fromChar == toChar || string.indexOf(fromChar) == Index(-1)) ? string : calcCharReplaced(string.getUnownedSlice(), fromChar, toChar);
 }
 
+String StringUtil::replaceAll(UnownedStringSlice text, UnownedStringSlice subStr, UnownedStringSlice replacement)
+{
+    StringBuilder builder;
+    for (Index i = 0; i < text.getLength();)
+    {
+        if (i + subStr.getLength() >= text.getLength())
+        {
+            builder.append(text.subString(i, text.getLength() - i));
+            break;
+        }
+        if (text.subString(i, subStr.getLength()) == subStr)
+        {
+            builder.append(replacement);
+            i += subStr.getLength();
+        }
+        else
+        {
+            builder.append(text[i]);
+            i++;
+        }
+    }
+    return builder.produceString();
+}
+
+
 /* static */void StringUtil::appendStandardLines(const UnownedStringSlice& text, StringBuilder& out)
 {
     const char* cur = text.begin();

--- a/source/core/slang-string-util.h
+++ b/source/core/slang-string-util.h
@@ -87,6 +87,9 @@ struct StringUtil
     static String calcCharReplaced(const UnownedStringSlice& slice, char fromChar, char toChar);
     static String calcCharReplaced(const String& string, char fromChar, char toChar);
     
+        /// Replaces all occurrances of subStr with replacement.
+    static String replaceAll(UnownedStringSlice text, UnownedStringSlice subStr, UnownedStringSlice replacement);
+
         /// Create a blob from a string
     static ComPtr<ISlangBlob> createStringBlob(const String& string);
 

--- a/source/slang/slang-ir-check-differentiability.cpp
+++ b/source/slang/slang-ir-check-differentiability.cpp
@@ -85,7 +85,12 @@ public:
         switch (func->getOp())
         {
         case kIROp_ForwardDifferentiate:
+            if (auto fwdDerivative = func->getOperand(0)->findDecoration<IRForwardDerivativeDecoration>())
+                return isDifferentiableFunc(fwdDerivative->getForwardDerivativeFunc(), level);
+            return isDifferentiableFunc(func->getOperand(0), level);
         case kIROp_BackwardDifferentiate:
+            if (auto bwdDerivative = func->getOperand(0)->findDecoration<IRUserDefinedBackwardDerivativeDecoration>())
+                return isDifferentiableFunc(bwdDerivative->getBackwardDerivativeFunc(), level);
             return isDifferentiableFunc(func->getOperand(0), level);
         default:
             break;

--- a/source/slang/slang-ir-util.h
+++ b/source/slang/slang-ir-util.h
@@ -152,9 +152,15 @@ inline bool isGenericParam(IRInst* param)
 
 inline IRInst* unwrapAttributedType(IRInst* type)
 {
-    while (auto attrType = as<IRAttributedType>(type))
-        type = attrType->getBaseType();
-    return type;
+    for (;;)
+    {
+        if (auto attrType = as<IRAttributedType>(type))
+            type = attrType->getBaseType();
+        else if (auto rateType = as<IRRateQualifiedType>(type))
+            type = rateType->getValueType();
+        else
+            return type;
+    }
 }
 
 // Remove hlsl's 'unorm' and 'snorm' modifiers

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -4848,19 +4848,20 @@ namespace Slang
     {
         IRType* type = nullptr;
         auto basePtrType = as<IRPtrTypeBase>(basePtr->getDataType());
-        if (auto arrayType = as<IRArrayType>(basePtrType->getValueType()))
+        auto valueType = unwrapAttributedType(basePtrType->getValueType());
+        if (auto arrayType = as<IRArrayType>(valueType))
         {
             type = arrayType->getElementType();
         }
-        else if (auto vectorType = as<IRVectorType>(basePtrType->getValueType()))
+        else if (auto vectorType = as<IRVectorType>(valueType))
         {
             type = vectorType->getElementType();
         }
-        else if (auto matrixType = as<IRMatrixType>(basePtrType->getValueType()))
+        else if (auto matrixType = as<IRMatrixType>(valueType))
         {
             type = getVectorType(matrixType->getElementType(), matrixType->getColumnCount());
         }
-        else if (const auto basicType = as<IRBasicType>(basePtrType->getValueType()))
+        else if (const auto basicType = as<IRBasicType>(valueType))
         {
             // HLSL support things like float.x, in which case we just return the base pointer.
             return basePtr;
@@ -4884,10 +4885,11 @@ namespace Slang
         for (auto access : accessChain)
         {
             auto basePtrType = cast<IRPtrTypeBase>(basePtr->getDataType());
+            auto valueType = unwrapAttributedType(basePtrType->getValueType());
             IRType* resultType = nullptr;
             if (auto structKey = as<IRStructKey>(access))
             {
-                auto structType = as<IRStructType>(basePtrType->getValueType());
+                auto structType = as<IRStructType>(valueType);
                 SLANG_RELEASE_ASSERT(structType);
                 for (auto field : structType->getFields())
                 {

--- a/source/slang/slang-language-server-completion.cpp
+++ b/source/slang/slang-language-server-completion.cpp
@@ -35,7 +35,7 @@ static const char* kStmtKeywords[] = {
     "__generic", "__exported",     "import",    "enum",      "break",   "continue",
     "discard",   "defer",          "cbuffer",   "tbuffer",   "func",    "is",
     "as",        "nullptr",        "none",      "true",      "false",   "functype", 
-    "sizeof",    "alignof"};
+    "sizeof",    "alignof",        "__target_switch",        "__intrinsic_asm"};
 
 static const char* hlslSemanticNames[] = {
     "register",

--- a/source/slang/slang-language-server.h
+++ b/source/slang/slang-language-server.h
@@ -152,6 +152,7 @@ private:
     void registerCapability(const char* methodName);
     void logMessage(int type, String message);
 
+    FormatOptions getFormatOptions(Workspace* workspace, FormatOptions inOptions);
     SlangResult tryGetMacroHoverInfo(
         WorkspaceVersion* version,
         DocumentVersion* doc,

--- a/tests/diagnostics/property-readonly-lvalue.slang
+++ b/tests/diagnostics/property-readonly-lvalue.slang
@@ -1,0 +1,14 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):
+// use read-only property as l-value
+
+struct MyType
+{
+    property float3 prop { get { return float3(1, 2, 3);}}
+}
+
+void test()
+{
+    MyType t;
+    // CHECK: {{.*}}error 30047: argument passed to parameter '0' must be l-value.
+    t.prop.x += 1.0;
+}


### PR DESCRIPTION
- Fix emitElementAddr() on attributed/rate types.
- Add diagnostic on using a read-only property as l-value.
- Properly recognize differentiablity of a custom provided derivative function referenced via `fwd_diff(f)` or `bwd_diff(f)`.
- Perform `${workspaceFolder}` macro replacement in clang-format-location settings in language server.