### PR TITLE
Add `IArray`.

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -317,10 +317,27 @@ interface __FlagsEnumType : __EnumType
 {
 };
 
+interface IArray<T>
+{
+    int getCount();
+    __subscript(int index) -> T
+    {
+        get;
+    }
+}
+
 __generic<T, let N:int>
 __magic_type(ArrayExpressionType)
-struct Array
+struct Array : IArray<T>
 {
+    [ForceInline]
+    int getCount() { return N; }
+
+    __subscript(int index) -> T
+    {
+        __intrinsic_op($(kIROp_GetElement))
+        get;
+    }
 }
 
 // The "comma operator" is effectively just a generic function that returns its second
@@ -885,7 +902,7 @@ extension int16_t
     /// An `N` component vector with elements of type `T`.
 __generic<T = float, let N : int = 4>
 __magic_type(VectorExpressionType)
-struct vector
+struct vector : IArray<T>
 {
         /// The element type of the vector
     typedef T Element;
@@ -900,6 +917,11 @@ struct vector
     // TODO: we should revise semantic checking so this kind of "identity" conversion is not required
     __intrinsic_op(0)
     __init(vector<T,N> value);
+
+    [ForceInline]
+    int getCount() { return N; }
+
+    __subscript(int index) -> T { __intrinsic_op($(kIROp_GetElement)) get; }
 }
 
 const int kRowMajorMatrixLayout = $(SLANG_MATRIX_LAYOUT_ROW_MAJOR);
@@ -908,10 +930,15 @@ const int kColumnMajorMatrixLayout = $(SLANG_MATRIX_LAYOUT_COLUMN_MAJOR);
     /// A matrix with `R` rows and `C` columns, with elements of type `T`.
 __generic<T = float, let R : int = 4, let C : int = 4, let L : int = $(SLANG_MATRIX_LAYOUT_MODE_UNKNOWN)>
 __magic_type(MatrixExpressionType)
-struct matrix
+struct matrix : IArray<vector<T,C>>
 {
     __intrinsic_op($(kIROp_MakeMatrixFromScalar))
     __init(T val);
+
+    [ForceInline]
+    int getCount() { return R; }
+
+    __subscript(int index) -> vector<T,C> { __intrinsic_op($(kIROp_GetElement)) get; }
 }
 
 ${{{{

--- a/source/slang/slang-ast-base.cpp
+++ b/source/slang/slang-ast-base.cpp
@@ -3,34 +3,43 @@
 
 namespace Slang
 {
-void NodeBase::_initDebug(ASTNodeType inAstNodeType, ASTBuilder* inAstBuilder)
-{
-#ifdef _DEBUG
-    SLANG_UNUSED(inAstNodeType);
-    static int32_t uidCounter = 0;
-    static int32_t breakValue = 0;
-    uidCounter++;
-    _debugUID = uidCounter;
-    if (inAstBuilder->getId() == -1)
-        _debugUID = -_debugUID;
-    if (breakValue != 0 && _debugUID == breakValue)
-        SLANG_BREAKPOINT(0)
-#else
-    SLANG_UNUSED(inAstNodeType);
-    SLANG_UNUSED(inAstBuilder);
-#endif
-}
-DeclRefBase* Decl::getDefaultDeclRef()
-{
-    if (auto astBuilder = getCurrentASTBuilder())
+    void NodeBase::_initDebug(ASTNodeType inAstNodeType, ASTBuilder* inAstBuilder)
     {
-        const Index currentEpoch = astBuilder->getEpoch();
-        if (currentEpoch != m_defaultDeclRefEpoch || !m_defaultDeclRef)
-        {
-            m_defaultDeclRef = astBuilder->getOrCreate<DirectDeclRef>(this);
-            m_defaultDeclRefEpoch = currentEpoch;
-        }
+#ifdef _DEBUG
+        SLANG_UNUSED(inAstNodeType);
+        static int32_t uidCounter = 0;
+        static int32_t breakValue = 0;
+        uidCounter++;
+        _debugUID = uidCounter;
+        if (inAstBuilder->getId() == -1)
+            _debugUID = -_debugUID;
+        if (breakValue != 0 && _debugUID == breakValue)
+            SLANG_BREAKPOINT(0)
+#else
+        SLANG_UNUSED(inAstNodeType);
+        SLANG_UNUSED(inAstBuilder);
+#endif
     }
-    return m_defaultDeclRef;
-}
+    DeclRefBase* Decl::getDefaultDeclRef()
+    {
+        if (auto astBuilder = getCurrentASTBuilder())
+        {
+            const Index currentEpoch = astBuilder->getEpoch();
+            if (currentEpoch != m_defaultDeclRefEpoch || !m_defaultDeclRef)
+            {
+                m_defaultDeclRef = astBuilder->getOrCreate<DirectDeclRef>(this);
+                m_defaultDeclRefEpoch = currentEpoch;
+            }
+        }
+        return m_defaultDeclRef;
+    }
+
+    bool Decl::isChildOf(Decl* other) const
+    {
+        for (auto parent = parentDecl; parent; parent = parent->parentDecl)
+            if (parent == other)
+                return true;
+        return false;
+    }
+
 }

--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -734,6 +734,7 @@ public:
         SLANG_RELEASE_ASSERT(state >= checkState.getState());
         checkState.setState(state);
     }
+    bool isChildOf(Decl* other) const;
 
 private:
     SLANG_UNREFLECTED DeclRefBase* m_defaultDeclRef = nullptr;

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -294,7 +294,6 @@ public:
         interfaceDecl->addMember(thisDecl);
         auto thisConstraint = create<ThisTypeConstraintDecl>();
         thisConstraint->loc = loc;
-        thisConstraint->base.type = DeclRefType::create(this, getDirectDeclRef(interfaceDecl));
         thisDecl->addMember(thisConstraint);
         return interfaceDecl;
     }

--- a/source/slang/slang-ast-type.cpp
+++ b/source/slang/slang-ast-type.cpp
@@ -636,9 +636,9 @@ Val* ExistentialSpecializedType::_substituteImplOverride(ASTBuilder* astBuilder,
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! ThisType !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-InterfaceDecl* ThisType::getInterfaceDecl()
+DeclRef<InterfaceDecl> ThisType::getInterfaceDeclRef()
 {
-    return dynamicCast<InterfaceDecl>(getDeclRefBase()->getDecl()->parentDecl);
+    return DeclRef<Decl>(getDeclRefBase()->getParent()).template as<InterfaceDecl>();
 }
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! AndType !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -55,7 +55,7 @@ class DeclRefType : public Type
 {
     SLANG_AST_CLASS(DeclRefType)
 
-    static DeclRefType* create(ASTBuilder* astBuilder, DeclRef<Decl> declRef);
+    static Type* create(ASTBuilder* astBuilder, DeclRef<Decl> declRef);
 
     DeclRef<Decl> getDeclRef() const { return DeclRef<Decl>(as<DeclRefBase>(getOperand(0))); }
     DeclRefBase* getDeclRefBase() const { return as<DeclRefBase>(getOperand(0)); }
@@ -786,7 +786,7 @@ class ThisType : public DeclRefType
 
     ThisType(DeclRefBase* declRef) : DeclRefType(declRef) {}
 
-    InterfaceDecl* getInterfaceDecl();
+    DeclRef<InterfaceDecl> getInterfaceDeclRef();
 };
 
     /// The type of `A & B` where `A` and `B` are types

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1604,6 +1604,8 @@ namespace Slang
 
     void SemanticsDeclBasesVisitor::visitThisTypeConstraintDecl(ThisTypeConstraintDecl* thisTypeConstraintDecl)
     {
+        // Make sure IFoo<T>.This.ThisIsIFooConstraint.base.type is properly set
+        // to DeclRefType(IFoo<T>) with default generic arguments.
         if (!thisTypeConstraintDecl->base.type)
         {
             auto parentTypeDecl = getParentDecl(getParentDecl(thisTypeConstraintDecl));
@@ -4320,21 +4322,6 @@ namespace Slang
 
     void SemanticsDeclBasesVisitor::visitInterfaceDecl(InterfaceDecl* decl)
     {
-        // Make sure IFoo<T>.This.ThisIsIFooConstraint.base.type is properly set
-        // to DeclRefType(IFoo<T>) with default generic arguments.
-        for (auto thisTypeDecl : decl->getMembersOfType<ThisTypeDecl>())
-        {
-            for (auto thisTypeConstraintDecl : thisTypeDecl->getMembersOfType<ThisTypeConstraintDecl>())
-            {
-                if (!thisTypeConstraintDecl->base.type)
-                {
-                    thisTypeConstraintDecl->base.type = DeclRefType::create(
-                        m_astBuilder,
-                        createDefaultSubstitutionsIfNeeded(m_astBuilder, this, getDefaultDeclRef(decl)));
-                }
-            }
-        }
-
         for( auto inheritanceDecl : decl->getMembersOfType<InheritanceDecl>() )
         {
             ensureDecl(inheritanceDecl, DeclCheckState::CanUseBaseOfInheritanceDecl);

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -1752,8 +1752,7 @@ namespace Slang
 
     Expr* SemanticsExprVisitor::visitIndexExpr(IndexExpr* subscriptExpr)
     {
-        auto baseExpr = subscriptExpr->baseExpression;
-        baseExpr = CheckExpr(baseExpr);
+        auto baseExpr = CheckTerm(subscriptExpr->baseExpression);
 
         for (auto& arg : subscriptExpr->indexExprs)
         {
@@ -1822,43 +1821,23 @@ namespace Slang
         // Default behavior is to look at all available `__subscript`
         // declarations on the type and try to call one of them.
 
+        auto baseMemberExpr = m_astBuilder->create<MemberExpr>();
+        baseMemberExpr->baseExpression = subscriptExpr->baseExpression;
+        baseMemberExpr->name = getName("operator[]");
+        baseMemberExpr->loc = subscriptExpr->loc;
+        auto checkedBaseMemberExpr = CheckTerm(baseMemberExpr);
+
+        if (checkedBaseMemberExpr)
         {
-            Name* name = getName("operator[]");
-            LookupResult lookupResult = lookUpMember(
-                m_astBuilder,
-                this,
-                name,
-                baseType,
-                LookupMask::Default,
-                LookupOptions::NoDeref);
-            if (!lookupResult.isValid())
-            {
-                goto fail;
-            }
-
-            // Now that we know there is at least one subscript member,
-            // we will construct a reference to it and try to call it.
-            //
-            // Note: the expression may be an `OverloadedExpr`, in which
-            // case the attempt to call it will trigger overload
-            // resolution.
-            Expr* subscriptFuncExpr = createLookupResultExpr(
-                name,
-                lookupResult,
-                subscriptExpr->baseExpression,
-                subscriptExpr->loc,
-                subscriptExpr);
-
             InvokeExpr* subscriptCallExpr = m_astBuilder->create<InvokeExpr>();
             subscriptCallExpr->loc = subscriptExpr->loc;
-            subscriptCallExpr->functionExpr = subscriptFuncExpr;
+            subscriptCallExpr->functionExpr = checkedBaseMemberExpr;
             subscriptCallExpr->arguments.addRange(subscriptExpr->indexExprs);
             subscriptCallExpr->argumentDelimeterLocs.addRange(subscriptExpr->argumentDelimeterLocs);
 
             return CheckInvokeExprWithCheckedOperands(subscriptCallExpr);
         }
-
-    fail:
+        else
         {
             getSink()->diagnose(subscriptExpr, Diagnostics::subscriptNonArray, baseType);
             return CreateErrorExpr(subscriptExpr);
@@ -2306,7 +2285,6 @@ namespace Slang
                 expr->type = GetTypeForDeclRef(expr->declRef, expr->loc);
             return expr;
         }
-
         expr->type = QualType(m_astBuilder->getErrorType());
         auto lookupResult = lookUp(
             m_astBuilder,

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -1827,7 +1827,9 @@ namespace Slang
             m_astBuilder,
             this,
             operatorName,
-            baseType);
+            baseType,
+            LookupMask::Default,
+            LookupOptions::NoDeref);
         if (!lookupResult.isValid())
         {
             getSink()->diagnose(subscriptExpr, Diagnostics::subscriptNonArray, baseType);

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1445,6 +1445,12 @@ namespace Slang
             DeclRef<PropertyDecl>   satisfyingMemberDeclRef,
             DeclRef<PropertyDecl>   requiredMemberDeclRef,
             RefPtr<WitnessTable>    witnessTable);
+
+        bool doesSubscriptMatchRequirement(
+            DeclRef<SubscriptDecl>  satisfyingMemberDeclRef,
+            DeclRef<SubscriptDecl>  requiredMemberDeclRef,
+            RefPtr<WitnessTable>    witnessTable);
+
         bool doesVarMatchRequirement(
             DeclRef<VarDeclBase>   satisfyingMemberDeclRef,
             DeclRef<VarDeclBase>   requiredMemberDeclRef,

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -274,7 +274,7 @@ DIAGNOSTIC(30010, Error, whilePredicateTypeError2, "'while': expression must eva
 DIAGNOSTIC(30011, Error, assignNonLValue, "left of '=' is not an l-value.")
 DIAGNOSTIC(30012, Error, noApplicationUnaryOperator, "no overload found for operator $0 ($1).")
 DIAGNOSTIC(30012, Error, noOverloadFoundForBinOperatorOnTypes, "no overload found for operator $0  ($1, $2).")
-DIAGNOSTIC(30013, Error, subscriptNonArray, "no subscript operation found for  type '$0'")
+DIAGNOSTIC(30013, Error, subscriptNonArray, "no subscript operation found for type '$0'")
 DIAGNOSTIC(30014, Error, subscriptIndexNonInteger, "index expression must evaluate to int.")
 DIAGNOSTIC(30015, Error, undefinedIdentifier2, "undefined identifier '$0'.")
 DIAGNOSTIC(30018, Error, typeNotInTheSameHierarchy, "invalid use of 'as' operator: expression evaluates to '$0', which is not in the same type hierarchy as target type '$1'.")

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1397,7 +1397,7 @@ struct SPIRVEmitContext
 
         case kIROp_RateQualifiedType:
             {
-                auto result = emitGlobalInst(as<IRRateQualifiedType>(inst)->getValueType());
+                auto result = ensureInst(as<IRRateQualifiedType>(inst)->getValueType());
                 registerInst(inst, result);
                 return result;
             }

--- a/source/slang/slang-ir-inst-pass-base.h
+++ b/source/slang/slang-ir-inst-pass-base.h
@@ -17,6 +17,7 @@ namespace Slang
         InstHashSet workListSet;
         void addToWorkList(IRInst* inst)
         {
+            SLANG_ASSERT(inst);
             if (workListSet.contains(inst))
                 return;
 
@@ -139,6 +140,7 @@ namespace Slang
                     default:
                         break;
                     }
+                    SLANG_ASSERT(child);
                     if (shouldInstBeLiveIfParentIsLive(child, IRDeadCodeEliminationOptions()))
                         addToWorkList(child);
                 }

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -3226,7 +3226,7 @@ public:
     IRType* getCapabilitySetType();
 
     IRAssociatedType* getAssociatedType(ArrayView<IRInterfaceType*> constraintTypes);
-    IRThisType* getThisType(IRInterfaceType* interfaceType);
+    IRThisType* getThisType(IRType* interfaceType);
     IRRawPointerType* getRawPointerType();
     IRRTTIPointerType* getRTTIPointerType(IRInst* rttiPtr);
     IRRTTIType* getRTTIType();

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -2653,7 +2653,7 @@ namespace Slang
             (IRInst**)constraintTypes.getBuffer());
     }
 
-    IRThisType* IRBuilder::getThisType(IRInterfaceType* interfaceType)
+    IRThisType* IRBuilder::getThisType(IRType* interfaceType)
     {
         return (IRThisType*)getType(kIROp_ThisType, interfaceType);
     }

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -535,6 +535,22 @@ struct SharedIRGenContext
     List<IRInst*> m_stringLiterals;
 };
 
+struct IRGenContext;
+
+struct AstOrIRType
+{
+    Type* astType = nullptr;
+    IRInst* irType = nullptr;
+    IRInst* getIRType(IRGenContext* context);
+
+    AstOrIRType& operator=(Type* t) { astType = t; irType = nullptr; return *this; }
+    AstOrIRType& operator=(IRInst* t) { astType = nullptr; irType = t; return *this; }
+    explicit operator bool()
+    {
+        return astType || irType;
+    }
+};
+
 struct IRGenContext
 {
     ASTBuilder* astBuilder;
@@ -558,7 +574,7 @@ struct IRGenContext
     LoweredValInfo thisVal;
 
     // The IRType value to lower into for `ThisType`.
-    IRInst* thisType = nullptr;
+    AstOrIRType thisType;
 
     // The IR witness value to use for `ThisType`
     IRInst* thisTypeWitness = nullptr;
@@ -822,6 +838,14 @@ static IRType* lowerType(
     QualType const& type)
 {
     return lowerType(context, type.type);
+}
+
+IRInst* AstOrIRType::getIRType(IRGenContext* context)
+{
+    if (irType)
+        return irType;
+    irType = lowerType(context, astType);
+    return irType;
 }
 
 // Given a `DeclRef` for something callable, along with a bunch of
@@ -1984,9 +2008,17 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
         // Therefore, `context->thisType` should have been set to `IRThisType`
         // in `visitInterfaceDecl`, and we can just use that value here.
         //
-        if (context->thisType != nullptr)
-            return LoweredValInfo::simple(context->thisType);
-        return emitDeclRef(context, makeDeclRef(type->getInterfaceDecl()), getBuilder()->getTypeKind());
+        if (context->thisType.irType)
+        {
+            return LoweredValInfo::simple(context->thisType.irType);
+        }
+        auto interfaceType = emitDeclRef(context, type->getInterfaceDeclRef(), getBuilder()->getTypeKind());
+        auto result = LoweredValInfo::simple(getBuilder()->getThisType((IRType*)getSimpleVal(context, interfaceType)));
+        if (context->thisType.astType == type)
+        {
+            context->thisType = getSimpleVal(context, result);
+        }
+        return result;
     }
 
     LoweredValInfo visitAndType(AndType* type)
@@ -2668,7 +2700,9 @@ static Type* _findReplacementThisParamType(
 
     if (auto interfaceDeclRef = parentDeclRef.as<InterfaceDecl>())
     {
-        auto thisType = DeclRefType::create(context->astBuilder, interfaceDeclRef.getDecl()->getThisTypeDecl());
+        auto thisType = DeclRefType::create(
+            context->astBuilder,
+            context->astBuilder->getMemberDeclRef(interfaceDeclRef, interfaceDeclRef.getDecl()->getThisTypeDecl()));
         return thisType;
     }
 
@@ -2704,6 +2738,11 @@ Type* getThisParamTypeForCallable(
     IRGenContext*   context,
     DeclRef<Decl>   callableDeclRef)
 {
+    if (auto lookup = as<LookupDeclRef>((callableDeclRef.declRefBase)))
+    {
+        return lookup->getLookupSource();
+    }
+
     auto parentDeclRef = callableDeclRef.getParent();
 
     if(auto subscriptDeclRef = parentDeclRef.as<SubscriptDecl>())
@@ -7751,13 +7790,19 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         // Allocate an IRInterfaceType with the `operandCount` operands.
         IRInterfaceType* irInterface = subBuilder->createInterfaceType(operandCount, nullptr);
+        auto finalVal = finishOuterGenerics(subBuilder, irInterface, outerGeneric);
 
         // Add `irInterface` to decl mapping now to prevent cyclic lowering.
-        context->setValue(decl, LoweredValInfo::simple(irInterface));
+        context->setValue(decl, LoweredValInfo::simple(finalVal));
+
+        subBuilder->setInsertBefore(irInterface);
 
         // Setup subContext for proper lowering `ThisType`, associated types and
         // the interface decl's self reference.
-        auto thisType = getBuilder()->getThisType(irInterface);
+        
+        auto thisType = DeclRefType::create(
+            context->astBuilder,
+            createDefaultSpecializedDeclRef(subContext, nullptr, decl->getThisTypeDecl()));
         subContext->thisType = thisType;
 
         // TODO: Need to add an appropriate stand-in witness here.
@@ -7880,14 +7925,9 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         }
 
         subBuilder->setInsertInto(irInterface);
-        // TODO: are there any interface members that should be
-        // nested inside the interface type itself?
-
-        irInterface->moveToEnd();
 
         addTargetIntrinsicDecorations(subContext, irInterface, decl);
 
-        auto finalVal = finishOuterGenerics(subBuilder, irInterface, outerGeneric);
         return LoweredValInfo::simple(finalVal);
     }
 
@@ -7939,8 +7979,8 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
     LoweredValInfo visitThisTypeDecl(ThisTypeDecl* decl)
     {
-        auto interfaceType = ensureDecl(context, decl->parentDecl).val;
-        return LoweredValInfo::simple(context->irBuilder->getThisType(as<IRInterfaceType>(interfaceType)));
+        SLANG_UNUSED(decl);
+        return LoweredValInfo();
     }
 
     LoweredValInfo visitThisTypeConstraintDecl(ThisTypeConstraintDecl* decl)
@@ -7968,14 +8008,6 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
         const bool isPublicType = decl->findModifier<PublicModifier>() != nullptr;
 
-        // Given a declaration of a type, we need to make sure
-        // to output "witness tables" for any interfaces this
-        // type has declared conformance to.
-        for( auto inheritanceDecl : decl->getMembersOfType<InheritanceDecl>() )
-        {
-            ensureDecl(context, inheritanceDecl);
-        }
-
         // We are going to create nested IR building state
         // to use when emitting the members of the type.
         //
@@ -8001,11 +8033,21 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             return LoweredValInfo::simple(subBuilder->getVoidType());
         }
 
-        const auto finishedVal = _getFinishOuterGenericsReturnValue(irAggType, outerGeneric);
+        auto finalFinishedVal = finishOuterGenerics(subBuilder, irAggType, outerGeneric);
 
         // We add the decl now such that if there are Ptr or other references 
         // to this type they can still complete
-        context->setValue(decl, LoweredValInfo::simple(finishedVal));
+        context->setValue(decl, LoweredValInfo::simple(finalFinishedVal));
+
+        subBuilder->setInsertBefore(irAggType);
+
+        // Given a declaration of a type, we need to make sure
+        // to output "witness tables" for any interfaces this
+        // type has declared conformance to.
+        for (auto inheritanceDecl : decl->getMembersOfType<InheritanceDecl>())
+        {
+            ensureDecl(subContext, inheritanceDecl);
+        }
 
         addNameHint(context, irAggType, decl);
         addLinkageDecoration(context, irAggType, decl);
@@ -8022,8 +8064,6 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         //
         for( auto inheritanceDecl : decl->getMembersOfType<InheritanceDecl>() )
         {
-            if (isPublicType)
-                ensureDecl(context, inheritanceDecl);
             auto superType = inheritanceDecl->base;
             if(auto superDeclRefType = as<DeclRefType>(superType))
             {
@@ -8031,7 +8071,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                     superDeclRefType->getDeclRef().as<ClassDecl>())
                 {
                     auto superKey = (IRStructKey*) getSimpleVal(context, ensureDecl(context, inheritanceDecl));
-                    auto irSuperType = lowerType(context, superType.type);
+                    auto irSuperType = lowerType(subContext, superType.type);
                     subBuilder->createStructField(
                         irAggType,
                         superKey,
@@ -8053,8 +8093,8 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
             // Each ordinary field will need to turn into a struct "key"
             // that is used for fetching the field.
-            IRInst* fieldKeyInst = getSimpleVal(context,
-                ensureDecl(context, fieldDecl));
+            IRInst* fieldKeyInst = getSimpleVal(subContext,
+                ensureDecl(subContext, fieldDecl));
             auto fieldKey = as<IRStructKey>(fieldKeyInst);
             SLANG_ASSERT(fieldKey);
 
@@ -8085,7 +8125,6 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // Instead we will force emission of all children of aggregate
         // type declarations later, from the top-level emit logic.
 
-        irAggType->moveToEnd();
         addTargetIntrinsicDecorations(subContext, irAggType, decl);
         for (auto modifier : decl->modifiers)
         {
@@ -8093,9 +8132,6 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                 subBuilder->addNonCopyableTypeDecoration(irAggType);
         }
      
-        auto finalFinishedVal = finishOuterGenerics(subBuilder, irAggType, outerGeneric);
-        // Confirm that _getFinishOuterGenericsReturnValue above returned the same result
-        SLANG_ASSERT(finalFinishedVal == finishedVal);
 
         return LoweredValInfo::simple(finalFinishedVal);
     }
@@ -8611,27 +8647,6 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         return v;
     }
 
-    // This function matches the return value from finishOuterGenerics
-    // so that we can create the target value without finishOuterGenerics having to be called. 
-    IRInst* _getFinishOuterGenericsReturnValue(
-        IRInst* val,
-        IRGeneric* parentGeneric)
-    {
-        IRInst* v = val;
-        while (parentGeneric)
-        {
-            // There might be more outer generics,
-            // so we need to loop until we run out.
-            v = parentGeneric;
-            auto parentBlock = as<IRBlock>(v->getParent());
-            if (!parentBlock) break;
-
-            parentGeneric = as<IRGeneric>(parentBlock->getParent());
-            if (!parentGeneric) break;
-
-        }
-        return v;
-    }
 
     void addSpecializedForTargetDecorations(IRInst* inst, Decl* decl)
     {
@@ -9699,6 +9714,26 @@ LoweredValInfo emitDeclRef(
 {
     const auto initialSubst = subst;
     SLANG_UNUSED(initialSubst);
+
+
+    if (auto thisTypeDecl = as<ThisTypeDecl>(decl))
+    {
+        // A declref to ThisType decl should be lowered differently
+        // from other decls. In general, IFoo<T>.ThisType should lower to
+        // ThisType(specialize(IFoo,T)) instead of specialize(IFoo.ThisType, T).
+        SLANG_ASSERT(subst->getDecl() == decl);
+        IRType* parentInterfaceType = nullptr;
+        if (auto lookupDeclRef = as<LookupDeclRef>(subst))
+        {
+            parentInterfaceType = lowerType(context, lookupDeclRef->getWitness()->getSup());
+        }
+        else
+        {
+            parentInterfaceType = lowerType(context, DeclRefType::create(context->astBuilder, subst->getParent()));
+        }
+        auto thisType = context->irBuilder->getThisType(parentInterfaceType);
+        return LoweredValInfo::simple(thisType);
+    }
 
     // We need to proceed by considering the specializations that
     // have been put in place.

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -3024,6 +3024,7 @@ void _lowerFuncDeclBaseTypeInfo(
     auto& parameterLists = outInfo.parameterLists;
     collectParameterLists(
         context,
+
         declRef,
         &parameterLists, kParameterListCollectMode_Default, kParameterDirection_In);
 

--- a/source/slang/slang-mangle.cpp
+++ b/source/slang/slang-mangle.cpp
@@ -223,7 +223,7 @@ namespace Slang
         else if( auto thisType = dynamicCast<ThisType>(type) )
         {
             emitRaw(context, "t");
-            emitQualifiedName(context, thisType->getInterfaceDecl());
+            emitQualifiedName(context, thisType->getInterfaceDeclRef());
         }
         else if (const auto errorType = dynamicCast<ErrorType>(type))
         {

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -3061,7 +3061,7 @@ namespace Slang
                 parser->FillPosition(paramConstraint);
 
                 // substitution needs to be filled during check
-                DeclRefType* paramType = DeclRefType::create(parser->astBuilder, DeclRef<Decl>(decl));
+                Type* paramType = DeclRefType::create(parser->astBuilder, DeclRef<Decl>(decl));
 
                 SharedTypeExpr* paramTypeExpr = parser->astBuilder->create<SharedTypeExpr>();
                 paramTypeExpr->loc = decl->loc;

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -3128,12 +3128,14 @@ namespace Slang
         AdvanceIf(parser, TokenType::CompletionRequest);
 
         decl->nameAndLoc = NameLoc(parser->ReadToken(TokenType::Identifier));
-
-        parseOptionalInheritanceClause(parser, decl);
-
-        parseDeclBody(parser, decl);
-
-        return decl;
+        return parseOptGenericDecl(parser, [&](GenericDecl*)
+            {
+                // We allow for an inheritance clause on a `struct`
+                // so that it can conform to interfaces.
+                parseOptionalInheritanceClause(parser, decl);
+                parseDeclBody(parser, decl);
+                return decl;
+            });
     }
 
     static NodeBase* parseNamespaceDecl(Parser* parser, void* /*userData*/)

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -407,7 +407,7 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
 
     // TODO: need to figure out how to unify this with the logic
     // in the generic case...
-    DeclRefType* DeclRefType::create(
+    Type* DeclRefType::create(
         ASTBuilder*     astBuilder,
         DeclRef<Decl>   declRef)
     {

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -133,6 +133,11 @@ namespace Slang
         return declRef.substitute(astBuilder, declRef.getDecl()->type.Ptr());
     }
 
+    inline Type* getType(ASTBuilder* astBuilder, DeclRef<SubscriptDecl> declRef)
+    {
+        return declRef.substitute(astBuilder, declRef.getDecl()->returnType.Ptr());
+    }
+
     inline Type* getType(ASTBuilder* astBuilder, DeclRef<EnumCaseDecl> declRef)
     {
         return declRef.substitute(astBuilder, declRef.getDecl()->type.Ptr());

--- a/tests/language-feature/generics/generic-interface-1.slang
+++ b/tests/language-feature/generics/generic-interface-1.slang
@@ -1,0 +1,38 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -shaderobj -output-using-type
+
+__generic<T>
+interface IEqlTestable
+{
+    bool testEql(T v1);
+}
+
+bool test<T>(IEqlTestable<T> v0, T v1)
+{
+    return v0.testEql(v1);
+}
+
+struct MyType : IEqlTestable<MyType>
+{
+    int val;
+    bool testEql(MyType v1)
+    {
+        return val == v1.val;
+    }
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(2, 1, 1)]
+void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+{
+    int tid = dispatchThreadID.x;
+    MyType obj1, obj2;
+    obj1.val = tid;
+    obj2.val = 1;
+    let result = test(obj1, obj2);
+    outputBuffer[tid] = result ? 1 : 0;
+    // CHECK: 0
+    // CHECK: 1
+}

--- a/tests/language-feature/generics/generic-interface-1.slang
+++ b/tests/language-feature/generics/generic-interface-1.slang
@@ -1,8 +1,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -shaderobj -output-using-type
 
-__generic<T>
-interface IEqlTestable
+interface IEqlTestable<T>
 {
     bool testEql(T v1);
 }

--- a/tests/language-feature/generics/iarray.slang
+++ b/tests/language-feature/generics/iarray.slang
@@ -1,0 +1,37 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -shaderobj -output-using-type
+
+T sum<T:__BuiltinArithmeticType>(IArray<T> array)
+{
+    T result = T(0);
+    for (int i = 0; i < array.getCount(); i++)
+    {
+        result = result + array[i];
+    }
+    return result;
+}
+vector<T,N> sum<T:__BuiltinArithmeticType, let N:int>(IArray<vector<T,N>> array)
+{
+    vector<T,N> result = vector<T,N>(T(0));
+    for (int i = 0; i < array.getCount(); i++)
+    {
+        result = result + array[i];
+    }
+    return result;
+}
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+{
+    float arr[3] = { 1.0, 2.0, 3.0 };
+    float4 v = float4(1.0, 2.0, 3.0, 4.0);
+    float2x2 m = float2x2(1.0, 2.0, 3.0, 4.0);
+    outputBuffer[0] = sum(arr);
+    outputBuffer[1] = sum(v);
+    outputBuffer[2] = sum(sum(m));
+    // CHECK: 6.0
+    // CHECK: 10.0
+    // CHECK: 10.0
+}


### PR DESCRIPTION
Add the `IArray<T>` interface to stdlib to allow writing generic functions on array-like types.

`Array`, `vector` and `matrix` types are modified to implement `IArray`.

Major changes in this PR are:
- Enabling `subscript` operators in interfaces
- Allow generic type argument inference to structurally match base types, so that functions like `void test<T>(IArray<T> array)` can be called with `test(Array<float,3>())`, although `Array<float,3>` can't structurally match `IArray<T>`, we should still be able to infer `T` because `Array<float,3>:IArray<float>`.