### PR TITLE
Add more diagnostics on invalid custom derivative use.

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1201,9 +1201,9 @@ namespace Slang
             {
                 varDecl->type.type = getRemovedModifierType(modifiedType, nodiffModifier);
                 auto noDiffModifier = m_astBuilder->create<NoDiffModifier>();
-           noDiffModifier->loc = varDecl->loc;
+                noDiffModifier->loc = varDecl->loc;
                 addModifier(varDecl, noDiffModifier);
-   }
+            }
         }
 
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -2151,8 +2151,18 @@ namespace Slang
 
         // If the given declaration has generic parameters, then
         // return the corresponding `GenericDecl` that holds the
-        // parameters, etc.
+        // parameters, etc. This returns the immediate generic parent
+        // of `decl`, e.g. the generic for f<T>, and *not* any indirect
+        // generic parents, such as P<T>.f().
         GenericDecl* GetOuterGeneric(Decl* decl);
+
+        // If `decl` is inside a generic, return that outer generic,
+        // otherwise returns `decl`.
+        Decl* getOuterGenericOrSelf(Decl* decl);
+
+        // Find the next outer generic parent of `decl`, including
+        // indirect parents.
+        GenericDecl* findNextOuterGeneric(Decl* decl);
 
         // Try to find a unification for two values
         bool TryUnifyVals(

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -400,6 +400,8 @@ DIAGNOSTIC(31151, Error, cannotResolveGenericArgumentForDerivativeFunction,
     "[BackwardDerivativeOf], and [PrimalSubstituteOf] attributes are not supported when the generic arguments to the derivatives cannot be automatically deduced.")
 DIAGNOSTIC(31152, Error, cannotAssociateInterfaceRequirementWithDerivative, "cannot associate an interface requirement with a derivative.")
 DIAGNOSTIC(31153, Error, cannotUseInterfaceRequirementAsDerivative, "cannot use an interface requirement as a derivative.")
+DIAGNOSTIC(31154, Error, customDerivativeSignatureThisParamMismatch, "custom derivative does not match expected signature on `this`. Either both the original and the derivative function are static, or they must have the same `this` type.")
+DIAGNOSTIC(31155, Error, customDerivativeNotAllowedForMemberFunctionsOfDifferentiableType, "custom derivative is not allowed for non-static member functions of a differentiable type.")
 DIAGNOSTIC(31200, Warning, deprecatedUsage, "$0 has been deprecated: $1")
 
 // Enums

--- a/tests/autodiff/custom-derivative-generic.slang
+++ b/tests/autodiff/custom-derivative-generic.slang
@@ -1,0 +1,32 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+
+struct Buggy<let N : int>
+{
+    float m(float x) { return N * x; }
+
+    [BackwardDerivativeOf(m)]
+    void mDiff(inout DifferentialPair<float> x, float dResult)
+    {
+        updateDiff(x, N * dResult);
+    }
+}
+
+[Differentiable]
+float test(float x)
+{
+    Buggy<2> b;
+    return b.m(x);
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    var a = diffPair(3.0);
+    __bwd_diff(test)(a, 1.0);
+    outputBuffer[dispatchThreadID.x] = a.d;
+    // CHECK: 2.0
+}


### PR DESCRIPTION
- Add support for using `[*DerivativeOf()]` on a member function of a generic type to refer to another member function of the same type as the original function.
- Add diagnostic on trying to refer a member function of a different outer generic type in [*DerivativeOf] attribute.
- Add diagnostic on trying to use a member function of a different type as the derivative of some non-static member function.
- Add diagnostic on trying to use [*Derivative] attribute on a member function of a differentiable type. This is not allowed because there is no way to specify the transformed `this` parameter.