### PR TITLE
Fix ICE when lowering an associatedtype declref from an derived interface.

### DIFF
--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -581,6 +581,12 @@ namespace Slang
         SourceLoc loc,
         Expr* originalExpr)
     {
+        if (!item.declRef)
+        {
+            originalExpr->type = QualType(m_astBuilder->getErrorType());
+            return originalExpr;
+        }
+
         // We could be referencing a decl that will be synthesized. If so create a placeholder
         // and return a DeclRefExpr to it.
         if (auto lookupResultExpr = maybeUseSynthesizedDeclForLookupResult(item, originalExpr))

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -41,6 +41,7 @@ DIAGNOSTIC(-1, Note, seeRequirementDeclaration, "see requirement declaration")
 DIAGNOSTIC(-1, Note, doYouForgetToMakeComponentAccessible, "do you forget to make component '$0' acessible from '$1' (missing public qualifier)?")
 
 DIAGNOSTIC(-1, Note, seeDeclarationOf, "see declaration of '$0'")
+DIAGNOSTIC(-1, Note, seeDeclarationOfInterfaceRequirement, "see interface requirement declaration of '$0'")
 // An alternate wording of the above note, emphasing the position rather than content of the declaration.
 DIAGNOSTIC(-1, Note, declaredHere, "declared here")
 DIAGNOSTIC(-1, Note, seeOtherDeclarationOf, "see other declaration of '$0'")
@@ -542,6 +543,7 @@ DIAGNOSTIC(38008, Error, specializationParameterNotSpecialized, "no specializati
 DIAGNOSTIC(38009, Error, expectedValueOfTypeForSpecializationArg, "expected a constant value of type '$0' as argument for specialization parameter '$1'")
 
 DIAGNOSTIC(38100, Error, typeDoesntImplementInterfaceRequirement, "type '$0' does not provide required interface member '$1'")
+DIAGNOSTIC(38105, Error, memberDoesNotMatchRequirementSignature, "member '$0' does not match interface requirement.")
 DIAGNOSTIC(38101, Error, thisExpressionOutsideOfTypeDecl, "'this' expression can only be used in members of an aggregate type")
 DIAGNOSTIC(38102, Error, initializerNotInsideType, "an 'init' declaration is only allowed inside a type or 'extension' declaration")
 DIAGNOSTIC(38103, Error, thisTypeOutsideOfTypeDecl, "'This' type can only be used inside of an aggregate type")

--- a/source/slang/slang-emit-spirv-ops.h
+++ b/source/slang/slang-emit-spirv-ops.h
@@ -1177,6 +1177,26 @@ SpvInst* emitOpCompositeExtract(
     );
 }
 
+// https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCompositeInsert
+template<typename T1, typename T2, typename T3, Index N>
+SpvInst* emitOpCompositeInsert(
+    SpvInstParent* parent,
+    IRInst* inst,
+    const T1& idResultType,
+    const T2& object,
+    const T3& composite,
+    const Array<SpvLiteralInteger, N>& indexes
+)
+{
+    static_assert(isSingular<T1>);
+    static_assert(isSingular<T2>);
+    static_assert(isSingular<T3>);
+
+    return emitInst(
+        parent, inst, SpvOpCompositeInsert, idResultType, kResultID, object, composite, indexes
+    );
+}
+
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpVectorExtractDynamic
 template<typename T1, typename T2, typename T3>
 SpvInst* emitOpVectorExtractDynamic(

--- a/source/slang/slang-language-server-ast-lookup.cpp
+++ b/source/slang/slang-language-server-ast-lookup.cpp
@@ -363,7 +363,21 @@ public:
         return false;
     }
 
-    bool visitThisExpr(ThisExpr*) { return false; }
+    bool visitThisExpr(ThisExpr* expr)
+    {
+        static const int thisTokenLength = 4;
+        if (_isLocInRange(
+            context, expr->loc, thisTokenLength))
+        {
+            ASTLookupResult result;
+            result.path = context->nodePath;
+            result.path.add(expr);
+            context->results.add(result);
+            return true;
+        }
+        return false;
+    }
+
     bool visitThisTypeExpr(ThisTypeExpr*) { return false; }
     bool visitAndTypeExpr(AndTypeExpr* expr)
     {

--- a/source/slang/slang-language-server-semantic-tokens.cpp
+++ b/source/slang/slang-language-server-semantic-tokens.cpp
@@ -21,6 +21,8 @@ const char* kSemanticTokenTypes[] = {
     "string"
 };
 
+static const int kInitTokenLegnth = 6;
+
 static_assert(SLANG_COUNT_OF(kSemanticTokenTypes) == (int)SemanticTokenType::NormalText, "kSemanticTokenTypes must match SemanticTokenType");
 
 SemanticToken _createSemanticToken(SourceManager* manager, SourceLoc loc, Name* name)
@@ -180,6 +182,17 @@ List<SemanticToken> getSemanticTokens(Linkage* linkage, Module* module, UnownedS
                     SemanticToken token = _createSemanticToken(
                         manager, funcDecl->getNameLoc(), funcDecl->getName());
                     token.type = SemanticTokenType::Function;
+                    maybeInsertToken(token);
+                }
+            }
+            else if (auto ctorDecl = as<ConstructorDecl>(node))
+            {
+                if (ctorDecl->getName())
+                {
+                    SemanticToken token = _createSemanticToken(
+                        manager, ctorDecl->getNameLoc(), ctorDecl->getName());
+                    token.type = SemanticTokenType::Function;
+                    token.length = kInitTokenLegnth;
                     maybeInsertToken(token);
                 }
             }

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -1659,17 +1659,16 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
         // produce transitive witnesses in shapes that will cuase us
         // problems here.
         //
-
         if (!baseWitnessTable)
         {
             // If we don't have a valid baseWitnessTable,
-            // we are in a situation that `subToMid` is a `DifferentialBottomSubtypeWitness`
-            // that applies for all non-differentiable types.
-            // In this case `midToSup` will give us the `DifferentialBottom:IDifferentiable`
-            // witness table and we can just use that as the final result of
-            // this transitive witness.
-            SLANG_RELEASE_ASSERT(midToSup && as<IRWitnessTableType>(midToSup->getDataType()));
-            return LoweredValInfo::simple(midToSup);
+            // This can happen when we are looking up an associatedtype defined in the base interface from
+            // a derived interface that inherits the base interface.
+            // For now, we just emit a null witness.
+            // In the future, we may want to consider lower `ThisTypeConstraint` into IR as something like
+            // `IRThisTypeWitness`, and emit an explicit lookup through that witness instead.
+            SLANG_RELEASE_ASSERT(as<ThisType>(val->getSub()));
+            return LoweredValInfo();
         }
 
         if (auto declaredMidToSup = as<DeclaredSubtypeWitness>(val->getMidToSup()))
@@ -9837,6 +9836,23 @@ LoweredValInfo emitDeclRef(
 
         if(isInterfaceRequirement(decl))
         {
+            if (as<ThisType>(thisTypeSubst->getWitness()->getSub()))
+            {
+                // If this is a lookup from ThisType, we are looking up a decl
+                // defined in some base interface from an interface type.
+                // For now we just lower that decl as if it is referenced
+                // from the same interface directly, e.g. a reference to
+                // IBase.AssocType from IDerived:IBase will be lowered as
+                // IRAssocType(IBase).
+                // We may want to consider extend our IR representation to
+                // have a `IRThisTypeWitness` object, so we can lower this case
+                // into an explicit lookup from `IRThisTypeWitness`,
+                // just like any other cases.
+                return emitDeclRef(
+                    context,
+                    createDefaultSpecializedDeclRef(context, nullptr, decl),
+                    context->irBuilder->getTypeKind());
+            }
             // If we reach here, somebody is trying to look up an interface
             // requirement "through" some concrete type. We need to lower this
             // decl-ref as a lookup of the corresponding member in a witness

--- a/tests/autodiff/derived-interface.slang
+++ b/tests/autodiff/derived-interface.slang
@@ -6,7 +6,9 @@ RWStructuredBuffer<float> outputBuffer;
 
 interface IFoo : IDifferentiable
 {
-    __init(This.Differential)
+    [Differentiable]
+    __init<T:IFoo>(T d); 
+    
     [Differentiable]
     static This create(Differential d);
 
@@ -17,7 +19,12 @@ interface IFoo : IDifferentiable
 struct Impl : IFoo
 {
     float x;
-
+    [Differentiable]
+    __init<T : IFoo>(T d)
+    {
+        this = (Impl)d;
+    }
+    
     [Differentiable]
     static This create(Differential d)
     {

--- a/tests/autodiff/derived-interface.slang
+++ b/tests/autodiff/derived-interface.slang
@@ -1,0 +1,48 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+interface IFoo : IDifferentiable
+{
+    __init(This.Differential)
+    [Differentiable]
+    static This create(Differential d);
+
+    [Differentiable]
+    float getVal();
+}
+
+struct Impl : IFoo
+{
+    float x;
+
+    [Differentiable]
+    static This create(Differential d)
+    {
+        This v;
+        v.x = d.x * d.x;
+        return v;
+    }
+
+    [Differentiable]
+    float getVal() { return x; }
+}
+
+[Differentiable]
+float test<T:IFoo>(T.Differential d)
+{
+    return T.create(d).getVal();
+}
+
+[numthreads(1,1,1)]
+void computeMain(uint threadId: SV_DispatchThreadID)
+{
+    Impl.Differential d;
+    d.x = 3.0;
+    Impl.Differential dd;
+    dd.x = 1.0;
+    outputBuffer[0] = fwd_diff(test<Impl>)(diffPair(d, dd)).d;
+    // CHECK: 6.0
+}

--- a/tests/diagnostics/interfaces/mutating-impl-of-non-mutating-req.slang.expected
+++ b/tests/diagnostics/interfaces/mutating-impl-of-non-mutating-req.slang.expected
@@ -1,9 +1,9 @@
 result code = -1
 standard error = {
-tests/diagnostics/interfaces/mutating-impl-of-non-mutating-req.slang(10): error 38100: type 'Counter' does not provide required interface member 'processValue'
-struct Counter : IThing
-                 ^~~~~~
-tests/diagnostics/interfaces/mutating-impl-of-non-mutating-req.slang(7): note: see declaration of 'processValue'
+tests/diagnostics/interfaces/mutating-impl-of-non-mutating-req.slang(14): error 38105: member 'processValue' does not match interface requirement.
+    [mutating] int processValue(int inValue)
+                   ^~~~~~~~~~~~
+tests/diagnostics/interfaces/mutating-impl-of-non-mutating-req.slang(7): note: see interface requirement declaration of 'processValue'
     int processValue(int inValue);
         ^~~~~~~~~~~~
 }

--- a/tests/hlsl-intrinsic/image-swizzle-write.slang
+++ b/tests/hlsl-intrinsic/image-swizzle-write.slang
@@ -1,0 +1,15 @@
+//TEST:SIMPLE(filecheck=CHECK): -entry computeMain -stage compute -target spirv -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK): -entry computeMain -stage compute -target spirv
+
+layout(rgba6f)
+RWTexture2D<float4> texture;
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    half h = 1.0h;
+    // CHECK: OpImageRead
+    // CEHCK: OpCompositeInsert
+    // CHECK: OpImageWrite
+    texture[dispatchThreadID.xy].a = h;
+}


### PR DESCRIPTION
- Diagnose when a method supposed to implement an interface requirement isn't marked as differentiable when the requirement is.
- Improve diagnostics on non-matching interface implementations to point to the mismatched implementation method instead of the inheritance decl, when the potential satisfying method is non-ambiguous.
- Lower an associatedtype declref from an interface into an `IRAssocType` even if the associated type is defined in the base interface to prevent ICE.
- Fixed a regression on GLSL/SPIRV image subscript swizzle write legalization.
- Improved language server highlighting and hinting around constructors and `this` expr.
- Fixed a language server crashing issue.
- Allow simplified generics syntax on constructors: `__init<T:IFoo>(T obj);`.