### PR TITLE
CUDA: Fixes for NVRTC 12.x and warp mask ambiguity; adds CC 8.x warp reduction intrinsics.

### DIFF
--- a/source/compiler-core/slang-nvrtc-compiler.cpp
+++ b/source/compiler-core/slang-nvrtc-compiler.cpp
@@ -820,15 +820,21 @@ SlangResult NVRTCDownstreamCompiler::compile(const DownstreamCompileOptions& inO
 
     {
         // The lowest supported CUDA architecture version supported
-        // by NVRTC is `compute_30`.
+        // by any version of NVRTC we support is `compute_30`.
         //
         SemanticVersion version(3);
 
-        // Newer releases of NVRTC only support `compute_35` and up
-        // (with everything before `compute_52` being deprecated).
-        //
-        if( m_desc.version.m_major >= 11 )
+        // Newer releases of NVRTC only support newer CUDA architectures.
+        if ( m_desc.version.m_major >= 12 )
         {
+            // NVRTC in CUDA 12 only supports `compute_50` and up
+            // (with everything before `compute_52` being deprecated).
+            version = SemanticVersion(5, 0);
+        }
+        if( m_desc.version.m_major == 11 )
+        {
+            // NVRTC in CUDA 11 only supports `compute_35` and up
+            // (with everything before `compute_52` being deprecated).
             version = SemanticVersion(3, 5);
         }
 

--- a/source/compiler-core/slang-nvrtc-compiler.cpp
+++ b/source/compiler-core/slang-nvrtc-compiler.cpp
@@ -831,7 +831,7 @@ SlangResult NVRTCDownstreamCompiler::compile(const DownstreamCompileOptions& inO
             // (with everything before `compute_52` being deprecated).
             version = SemanticVersion(5, 0);
         }
-        if( m_desc.version.m_major == 11 )
+        else if ( m_desc.version.m_major == 11 )
         {
             // NVRTC in CUDA 11 only supports `compute_35` and up
             // (with everything before `compute_52` being deprecated).


### PR DESCRIPTION
Hi Slang team! This merge request contains a few attempts to fix things I noticed while looking at the generated CUDA code for a `WaveActiveSum()` operation.

* Fixes mask ambiguity between the mask used for getting the lane index from `threadIdx.x` and the fast-path mask for a full mask of threads.

`SLANG_CUDA_WARP_MASK` (31) was used in two places: as the mask used in `_getLaneId()`:

```cuda
 __forceinline__ __device__ uint32_t _getLaneId()
{
    // ...
    return threadIdx.x & SLANG_CUDA_WARP_MASK;
}
```

and as the test for the fast-path in `_waveCalcPow2Offset()`:

```cuda
__inline__ __device__ int _waveCalcPow2Offset(WarpMask mask)
{
    // This should be the most common case, so fast path it
    if (mask == SLANG_CUDA_WARP_MASK)
    {
        return SLANG_CUDA_WARP_SIZE; // nbickford note: This is 32
    }
    ...
}
```

This latter case was probably incorrect: because `SLANG_CUDA_WARP_MASK` is `0x1f` instead of `0xffffffff`, `_waveCalcPow2Offset()` would return `32` when the last 5 threads were active, and the most common case (where all threads were active) would go through the slow-path logic.

I added `SLANG_CUDA_WARP_BITMASK` to try to resolve this ambiguity between two different sizes of mask.

* Adds full specializations for `_wave*()` when compute capability 8.x warp reduction intrinsics.

The fast path above uses 5 shuffles and syncs; on CC 8.x hardware, we can access the `__reduce_*_sync()` intrinsics, which can compile to a single [redux.sync](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-redux-sync) PTX instruction.

(This could probably use some testing, since it turns out NVRTC was compiling the tests for CC 5.0; more on that in the next issue! I can verify that compiling a .slang file to a .cu file and then compiling that with `nvcc -arch=sm_80` generates the intended intrinsics, but I haven't found a way to set the required `compute` version in a `.slang` file yet or to have the tests run on sm_80 other than by adding an option to the source code.)

* Fixes running NVRTC on CUDA 12

By default, Slang invokes NVRTC with an architecture of `compute_35` when the CUDA SDK version is 11.0+. However, CUDA 12 removed support for `compute_35`, so NVRTC produces an error unless the architecture version is `compute_50` or higher.

`slang-test -api cuda -category wave` seems to work now, but the full set of `slang-test -api cuda` tests still produces some errors (which appear to be unrelated to wave intrinsics, so far as I can tell).

Thank you!