### PR TITLE
fix(language server): return `JSONValue::Type::Null` as ""

### DIFF
--- a/source/compiler-core/slang-json-value.cpp
+++ b/source/compiler-core/slang-json-value.cpp
@@ -572,6 +572,10 @@ UnownedStringSlice JSONContainer::getString(const JSONValue& in)
         {
             return StringRepresentation::asSlice(in.stringRep);
         }
+        case JSONValue::Type::Null:
+        {
+            return UnownedStringSlice();
+        }
         default: break;
     }
    
@@ -608,6 +612,10 @@ UnownedStringSlice JSONContainer::getTransientString(const JSONValue& in)
             {
                 return unquoted;
             }
+        }
+        case JSONValue::Type::Null:
+        {
+            return UnownedStringSlice();
         }
     }
 


### PR DESCRIPTION
This allows using `slangd` with Neovim as Neovim sets some value `slangd` expects as a String to `null`.

Fixes #3322