### PR TITLE
GLSL/SPIRV Fixes.

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1894,6 +1894,12 @@ struct SPIRVEmitContext
                     emitOpDecorate(getSection(SpvLogicalSectionID::Annotations), nullptr, varInst, SpvDecorationFlat);
             }
         }
+
+        if (var->findDecorationImpl(kIROp_RequireSPIRVDescriptorIndexingExtensionDecoration))
+        {
+            ensureExtensionDeclaration(UnownedStringSlice("SPV_EXT_descriptor_indexing"));
+            requireSPIRVCapability(SpvCapabilityRuntimeDescriptorArray);
+        }
     }
 
     void maybeEmitName(SpvInst* spvInst, IRInst* irInst)

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -1420,7 +1420,7 @@ ScalarizedVal createGLSLGlobalVaryingsImpl(
                 fieldBindingIndex,
                 fieldBindingSpace,
                 declarator,
-                field->getKey());
+                field);
             if (fieldVal.flavor != ScalarizedVal::Flavor::none)
             {
                 ScalarizedTupleValImpl::Element element;

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -848,6 +848,7 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     INST(SemanticDecoration, semantic, 2, 0)
     INST(PackOffsetDecoration, packoffset, 2, 0)
 
+    INST(RequireSPIRVDescriptorIndexingExtensionDecoration, RequireSPIRVDescriptorIndexingExtensionDecoration, 0, 0)
     INST(SPIRVOpDecoration, spirvOpDecoration, 1, 0)
 
         /// Decorated function is marked for the forward-mode differentiation pass.

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -4237,6 +4237,11 @@ public:
         addDecoration(value, kIROp_SemanticDecoration, getStringValue(text), getIntValue(getIntType(), index));
     }
 
+    void addRequireSPIRVDescriptorIndexingExtensionDecoration(IRInst* value)
+    {
+        addDecoration(value, kIROp_RequireSPIRVDescriptorIndexingExtensionDecoration);
+    }
+
     void addTargetIntrinsicDecoration(IRInst* value, IRInst* caps, UnownedStringSlice const& definition, UnownedStringSlice const& predicate, IRInst* typeScrutinee)
     {
         typeScrutinee

--- a/source/slang/slang-ir-translate-glsl-global-var.cpp
+++ b/source/slang/slang-ir-translate-glsl-global-var.cpp
@@ -60,7 +60,7 @@ namespace Slang
                     {
                         builder.addNameHintDecoration(key, nameHint->getName());
                     }
-                    builder.createStructField(inputStructType, key, inputType);
+                    auto field = builder.createStructField(inputStructType, key, inputType);
                     IRTypeLayout::Builder fieldTypeLayout(&builder);
                     fieldTypeLayout.addResourceUsage(LayoutResourceKind::VaryingInput, LayoutSize(1));
                     IRVarLayout::Builder varLayoutBuilder(&builder, fieldTypeLayout.build());
@@ -86,6 +86,7 @@ namespace Slang
                         inputVarIndex++;
                     }
                     inputStructTypeLayoutBuilder.addField(key, varLayoutBuilder.build());
+                    input->transferDecorationsTo(field);
                 }
                 auto paramTypeLayout = inputStructTypeLayoutBuilder.build();
                 IRVarLayout::Builder paramVarLayoutBuilder(&builder, paramTypeLayout);

--- a/tests/glsl/flat-in-float.slang
+++ b/tests/glsl/flat-in-float.slang
@@ -1,0 +1,24 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -stage fragment -entry main -allow-glsl -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -stage fragment -entry main -allow-glsl
+
+#version 310 es
+precision highp float;
+precision highp int;
+
+layout(location = 0) out mediump vec4 dEQP_FragColor;
+
+bool isOk(float a, float b)   { return (a == b); }
+
+layout(location = 0) flat in float out0;
+layout(binding = 0, std140) uniform Reference
+{
+	uint out0;
+} ref;
+
+void main()
+{
+	bool RES = isOk(out0, ref.out0);
+    dEQP_FragColor = vec4(RES, RES, RES, 1.0);
+    // CHECK: OpDecorate {{.*}} Flat
+}
+

--- a/tests/spirv/array-resource.slang
+++ b/tests/spirv/array-resource.slang
@@ -1,0 +1,35 @@
+// array-resource.slang
+
+// Test direct SPIR-V emit on arrays of buffers.
+
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry computeMain -stage compute -emit-spirv-directly
+//TEST_INPUT:set resultBuffer = out ubuffer(data=[0 0 0 0], stride=4)
+
+// Note: we can't run this test at the moment because gfx doesn't support allocating shader objects with unsized arrays.
+//TEST_DISABLED(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -output-using-type
+
+RWStructuredBuffer<uint> inputBuffers[];
+
+RWStructuredBuffer<uint> resultBuffer;
+
+struct Data
+{
+    uint arr[4];
+}
+
+struct Data2
+{
+    uint arr[4u];
+}
+
+//TEST_INPUT: set inputBuffers = {ubuffer(data=[1 0 0 0], stride=4), ubuffer(data=[2 0 0 0], stride=4)}
+
+[numthreads(4,1,1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    uint threadId = dispatchThreadID.x;
+    resultBuffer[threadId] = inputBuffers[0][threadId] + inputBuffers[1][threadId];
+    // CHECK: OpCapability RuntimeDescriptorArray
+    // CHECK: OpExtension "SPV_EXT_descriptor_indexing"
+    // BUFFER: 3
+}

--- a/tests/spirv/array-resource.slang
+++ b/tests/spirv/array-resource.slang
@@ -12,16 +12,6 @@ RWStructuredBuffer<uint> inputBuffers[];
 
 RWStructuredBuffer<uint> resultBuffer;
 
-struct Data
-{
-    uint arr[4];
-}
-
-struct Data2
-{
-    uint arr[4u];
-}
-
 //TEST_INPUT: set inputBuffers = {ubuffer(data=[1 0 0 0], stride=4), ubuffer(data=[2 0 0 0], stride=4)}
 
 [numthreads(4,1,1)]


### PR DESCRIPTION
- Fix dropped `flat` qualifier when converting glsl global input.
- Fix spirv emit logic for unsized resource array parameters.

Fixes #3333.