### PR TITLE
Allow whole program compile when using direct spirv backend.

### DIFF
--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -2945,6 +2945,8 @@ SlangResult OptionsParser::_parse(
         (m_rawTargets[0].format == CodeGenTarget::HostCPPSource ||
             m_rawTargets[0].format == CodeGenTarget::PyTorchCppBinding ||
             m_rawTargets[0].format == CodeGenTarget::CUDASource ||
+            m_rawTargets[0].format == CodeGenTarget::SPIRV ||
+            m_rawTargets[0].format == CodeGenTarget::SPIRVAssembly ||
             ArtifactDescUtil::makeDescForCompileTarget(asExternal(m_rawTargets[0].format)).kind == ArtifactKind::HostCallable))
     {
         RawOutput rawOutput;
@@ -3011,8 +3013,14 @@ SlangResult OptionsParser::_parse(
                     case CodeGenTarget::ShaderSharedLibrary:
                     case CodeGenTarget::PyTorchCppBinding:
                     case CodeGenTarget::DXIL:
-
                         rawOutput.isWholeProgram = true;
+                        break;
+                    case CodeGenTarget::SPIRV:
+                    case CodeGenTarget::SPIRVAssembly:
+                        if (getCurrentTarget()->targetFlags & SLANG_TARGET_FLAG_GENERATE_SPIRV_DIRECTLY)
+                        {
+                            rawOutput.isWholeProgram = true;
+                        }
                         break;
                     default:
                         m_sink->diagnose(SourceLoc(), Diagnostics::cannotMatchOutputFileToEntryPoint, rawOutput.path);

--- a/tests/spirv/multi-entrypoint.slang
+++ b/tests/spirv/multi-entrypoint.slang
@@ -1,0 +1,20 @@
+//TEST:SIMPLE(filecheck=CHECK1): -entry main1 -entry main2 -target spirv -fvk-use-entrypoint-name -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK2): -target spirv -fvk-use-entrypoint-name -emit-spirv-directly
+
+
+[shader("raygeneration")]
+void main1() {}
+
+[shader("raygeneration")]
+void main2() {}
+
+[shader("raygeneration")]
+void main3() {}
+
+// CHECK1: OpEntryPoint
+// CHECK1: OpEntryPoint
+// CHECK1-NOT: OpEntryPoint
+
+// CHECK2: OpEntryPoint
+// CHECK2: OpEntryPoint
+// CHECK2: OpEntryPoint


### PR DESCRIPTION
Fixes #3341.