### PR TITLE
Improve generic type argument inference.

### DIFF
--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -80,6 +80,9 @@ namespace Slang
         // No conversion at all
         kConversionCost_None = 0,
 
+        kConversionCost_GenericParamUpcast = 1,
+        kConversionCost_UnconstraintGenericParam = 20,
+
         // Convert between matrices of different layout
         kConversionCost_MatrixLayout = 5,
 

--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -286,6 +286,11 @@ Val* DeclaredSubtypeWitness::_resolveImplOverride()
     return this;
 }
 
+ConversionCost DeclaredSubtypeWitness::_getOverloadResolutionCostOverride()
+{
+    return kConversionCost_GenericParamUpcast;
+}
+
 Val* DeclaredSubtypeWitness::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int * ioDiff)
 {
     if (auto genConstraintDeclRef = getDeclRef().as<GenericTypeConstraintDecl>())
@@ -431,6 +436,11 @@ Val* TransitiveSubtypeWitness::_substituteImplOverride(ASTBuilder* astBuilder, S
     return astBuilder->getTransitiveSubtypeWitness(substSubToMid, substMidToSup);
 }
 
+ConversionCost TransitiveSubtypeWitness::_getOverloadResolutionCostOverride()
+{
+    return getSubToMid()->getOverloadResolutionCost() + getMidToSup()->getOverloadResolutionCost();
+}
+
 void TransitiveSubtypeWitness::_toTextOverride(StringBuilder& out)
 {
     // Note: we only print the constituent
@@ -469,6 +479,17 @@ Val* ExtractFromConjunctionSubtypeWitness::_substituteImplOverride(ASTBuilder* a
     //
     return astBuilder->getExtractFromConjunctionSubtypeWitness(
         substSub, substSup, substWitness, getIndexInConjunction());
+}
+
+ConversionCost ExtractFromConjunctionSubtypeWitness::_getOverloadResolutionCostOverride()
+{
+    auto witness = as<ConjunctionSubtypeWitness>(getConjunctionWitness());
+    if (!witness)
+        return kConversionCost_None;
+    auto index = getIndexInConjunction();
+    if (index < witness->getComponentCount())
+        return witness->getComponentWitness(index)->getOverloadResolutionCost();
+    return kConversionCost_None;
 }
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! ExtractExistentialSubtypeWitness !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -538,6 +559,14 @@ Val* ConjunctionSubtypeWitness::_substituteImplOverride(ASTBuilder* astBuilder, 
         substSup,
         as<SubtypeWitness>(substComponentWitnesses[0]),
         as<SubtypeWitness>(substComponentWitnesses[1]));
+    return result;
+}
+
+ConversionCost ConjunctionSubtypeWitness::_getOverloadResolutionCostOverride()
+{
+    ConversionCost result = kConversionCost_None;
+    for (Index i = 0; i < getComponentCount(); i++)
+        result += getComponentWitness(i)->getOverloadResolutionCost();
     return result;
 }
 

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -457,6 +457,9 @@ class SubtypeWitness : public Witness
 
     Type* getSub() { return as<Type>(getOperand(0)); }
     Type* getSup() { return as<Type>(getOperand(1)); }
+
+    ConversionCost _getOverloadResolutionCostOverride();
+    ConversionCost getOverloadResolutionCost();
 };
 
 class TypeEqualityWitness : public SubtypeWitness 
@@ -493,6 +496,8 @@ class DeclaredSubtypeWitness : public SubtypeWitness
     {
         setOperands(inSub, inSup, inDeclRef);
     }
+
+    ConversionCost _getOverloadResolutionCostOverride();
 };
 
 // A witness that `sub : sup` because `sub : mid` and `mid : sup`
@@ -520,6 +525,8 @@ class TransitiveSubtypeWitness : public SubtypeWitness
     {
         setOperands(subType, supType, inSubToMid, inMidToSup);
     }
+
+    ConversionCost _getOverloadResolutionCostOverride();
 };
 
 // A witness that `sub : sup` because `sub` was wrapped into
@@ -580,6 +587,8 @@ class ConjunctionSubtypeWitness : public SubtypeWitness
 
     void _toTextOverride(StringBuilder& out);
     Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+
+    ConversionCost _getOverloadResolutionCostOverride();
 };
 
     /// A witness that `T <: L` or `T <: R` because `T <: L&R`
@@ -609,6 +618,8 @@ class ExtractFromConjunctionSubtypeWitness : public SubtypeWitness
 
     void _toTextOverride(StringBuilder& out);
     Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+
+    ConversionCost _getOverloadResolutionCostOverride();
 };
 
     /// A value that represents a modifier attached to some other value

--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -358,7 +358,7 @@ namespace Slang
                         type = cType;
                         typeConstraintOptional = c.isOptional;
                     }
-                    else
+                    else if (!typeConstraintOptional)
                     {
                         auto joinType = TryJoinTypes(type, cType);
                         if (!joinType)
@@ -419,7 +419,7 @@ namespace Slang
                     }
                     else
                     {
-                        if(!val->equals(cVal))
+                        if(!valOptional && !val->equals(cVal))
                         {
                             // failure!
                             return DeclRef<Decl>();

--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -343,6 +343,8 @@ namespace Slang
                 }
 
                 QualType type;
+                bool typeConstraintOptional = true;
+
                 for (auto& c : system->constraints)
                 {
                     if (c.decl != typeParam.getDecl())
@@ -351,9 +353,10 @@ namespace Slang
                     auto cType = QualType(as<Type>(c.val), c.isUsedAsLValue);
                     SLANG_RELEASE_ASSERT(cType);
 
-                    if (!type)
+                    if (!type || (typeConstraintOptional && !c.isOptional))
                     {
                         type = cType;
+                        typeConstraintOptional = c.isOptional;
                     }
                     else
                     {
@@ -400,6 +403,7 @@ namespace Slang
                 // TODO(tfoley): figure out how this needs to interact with
                 // compile-time integers that aren't just constants...
                 IntVal* val = nullptr;
+                bool valOptional = true;
                 for (auto& c : system->constraints)
                 {
                     if (c.decl != valParam.getDecl())
@@ -408,9 +412,10 @@ namespace Slang
                     auto cVal = as<IntVal>(c.val);
                     SLANG_RELEASE_ASSERT(cVal);
 
-                    if (!val)
+                    if (!val || (valOptional && !c.isOptional))
                     {
                         val = cVal;
+                        valOptional = c.isOptional;
                     }
                     else
                     {
@@ -846,6 +851,7 @@ namespace Slang
         c.decl = intParam->getDeclRef().getDecl();
         c.isUsedAsLValue = paramIsLVal;
         c.val = arg;
+        c.isOptional = true;
         constraints.constraints.add(c);
     }
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -6630,7 +6630,9 @@ namespace Slang
 
             if (!TryUnifyTypes(constraints, extDecl->targetType.Ptr(), type))
                 return DeclRef<ExtensionDecl>();
-            auto solvedDeclRef = trySolveConstraintSystem(&constraints, makeDeclRef(extGenericDecl), ArrayView<Val*>());
+
+            ConversionCost baseCost;
+            auto solvedDeclRef = trySolveConstraintSystem(&constraints, makeDeclRef(extGenericDecl), ArrayView<Val*>(), baseCost);
             if (!solvedDeclRef)
             {
                 return DeclRef<ExtensionDecl>();

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1827,6 +1827,10 @@ namespace Slang
             Val*	val = nullptr; // the value to which we are constraining it
             bool isUsedAsLValue = false;   // If this constraint is for a type parameter, is the type used in an l-value parameter?
             bool satisfied = false; // Has this constraint been met?
+
+            // Is this constraint optional? An optional constraint provides a hint value to a parameter
+            // if it is otherwise unconstrained, but doesn't take precedence over a constraint that is not optional.
+            bool isOptional = false;
         };
 
         // A collection of constraints that will need to be satisfied (solved)

--- a/source/slang/slang-check-resolve-val.cpp
+++ b/source/slang/slang-check-resolve-val.cpp
@@ -45,4 +45,14 @@ Val* SubtypeWitness::_resolveImplOverride()
     return as<SubtypeWitness>(defaultResolveImpl());
 }
 
+ConversionCost SubtypeWitness::_getOverloadResolutionCostOverride()
+{
+    return kConversionCost_None;
+}
+
+ConversionCost SubtypeWitness::getOverloadResolutionCost()
+{
+    SLANG_AST_NODE_VIRTUAL_CALL(SubtypeWitness, getOverloadResolutionCost, ());
+}
+
 }

--- a/tests/diagnostics/bad-operator-call.slang
+++ b/tests/diagnostics/bad-operator-call.slang
@@ -14,7 +14,7 @@ void test()
 {
 	int a;
     S b;
-    // CHECK:{{.*}}.slang(18): error {{.*}}: no overload for '+=' applicable to arguments of type (int, S)
+    // CHECK:{{.*}}.slang(18): error {{.*}}:
     a += b;
     // CHECK:{{.*}}.slang(20): error {{.*}}: no overload for '+' applicable to arguments of type (int, S)
     a = a + b;

--- a/tests/language-feature/generics/generic-overload-disambiguation.slang
+++ b/tests/language-feature/generics/generic-overload-disambiguation.slang
@@ -1,0 +1,42 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -shaderobj -output-using-type
+
+// Test that calls to overloaded generic functions can be resolved to prefer the
+// generic candidate with more specialized constraints.
+interface IBase
+{
+    float get();
+}
+interface IDerived : IBase
+{
+
+}
+float process<T>(T v)
+{
+    return 0.0;
+}
+float process<T : IBase>(T v)
+{
+    return v.get();
+}
+
+float process<T : IDerived>(T v)
+{
+    return v.get() + 1.0;
+}
+
+struct D : IDerived
+{
+    float get() { return 1.0; }
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    D d;
+    outputBuffer[0] = process(d);
+    // CHECK: 2.0
+}

--- a/tests/language-feature/generics/vector-generic.slang
+++ b/tests/language-feature/generics/vector-generic.slang
@@ -1,0 +1,19 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -shaderobj -output-using-type
+
+// Test that generic argument inference works when passing a scalar to a generic vector parameter.
+T process<T, let N : int>(vector<T, N> v)
+{
+    return v[0];
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    float a = 1.0;
+    outputBuffer[0] = process(a);
+    // CHECK: 1.0
+}


### PR DESCRIPTION
Allow overload resolution to prefer generics with more specialized constraints.

Allow type inference to work when passing a scalar argument to a generic vector parameter.