### PR TITLE
Define `Texture::Sample` for float element types only.

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1091,12 +1091,15 @@ struct matrix : IArray<vector<T,C>>
     __subscript(int index) -> vector<T,C> { __intrinsic_op($(kIROp_GetElement)) get; }
 }
 
+__intrinsic_op($(kIROp_Eql))
+vector<bool, N> __vectorEql<T, let N:int>(vector<T, N> left, vector<T,N> right);
+
 __generic<T:__BuiltinFloatingPointType, let N : int>
 extension vector<T,N> : IFloat
 {
-    [__unsafeForceInlineEarly] bool lessThan(This other) { return this < other; }
-    [__unsafeForceInlineEarly] bool lessThanOrEquals(This other) { return this <= other; }
-    [__unsafeForceInlineEarly] bool equals(This other) { return all(this == other); }
+    [__unsafeForceInlineEarly] bool lessThan(This other) { return this[0] < other[0]; }
+    [__unsafeForceInlineEarly] bool lessThanOrEquals(This other) { return this[0] <= other[0]; }
+    [__unsafeForceInlineEarly] bool equals(This other) { return all(__vectorEql(this, other)); }
     __intrinsic_op($(kIROp_Add)) This add(This other);
     __intrinsic_op($(kIROp_Sub)) This sub(This other);
     __intrinsic_op($(kIROp_Mul)) This mul(This other);

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -167,78 +167,78 @@ public vector<T,4> texelFetch<T:__BuiltinArithmeticType, let N : int> (Sampler2D
 }
 
 [ForceInline]
-public vector<T,4> texture<T:__BuiltinArithmeticType, let N : int> (Sampler1D<vector<T,N>> sampler, float p, float bias = 0.0)
+public vector<T,4> texture<T:__BuiltinFloatingPointType, let N : int> (Sampler1D<vector<T,N>> sampler, float p, float bias = 0.0)
 {
     return __vectorReshape<4>(sampler.SampleBias(p, bias));
 }
 
 [ForceInline]
-public vector<T,4> texture<T:__BuiltinArithmeticType, let N : int> (Sampler2D<vector<T,N>> sampler, float2 p, float bias = 0.0)
+public vector<T,4> texture<T:__BuiltinFloatingPointType, let N : int> (Sampler2D<vector<T,N>> sampler, float2 p, float bias = 0.0)
 {
     return __vectorReshape<4>(sampler.SampleBias(p, bias));
 }
 
 [ForceInline]
-public vector<T,4> texture<T:__BuiltinArithmeticType, let N : int> (Sampler3D<vector<T,N>> sampler, float3 p, float bias = 0.0)
+public vector<T,4> texture<T:__BuiltinFloatingPointType, let N : int> (Sampler3D<vector<T,N>> sampler, float3 p, float bias = 0.0)
 {
     return __vectorReshape<4>(sampler.SampleBias(p, bias));
 }
 
 [ForceInline]
-public vector<T,4> texture<T:__BuiltinArithmeticType, let N : int> (SamplerCube<vector<T,N>> sampler, float3 p, float bias = 0.0)
+public vector<T,4> texture<T:__BuiltinFloatingPointType, let N : int> (SamplerCube<vector<T,N>> sampler, float3 p, float bias = 0.0)
 {
     return __vectorReshape<4>(sampler.SampleBias(p, bias));
 }
 
 [ForceInline]
-public float texture<T:__BuiltinArithmeticType, let N : int> (Sampler1DShadow<vector<T,N>> sampler, float2 p)
+public float texture<T:__BuiltinFloatingPointType, let N : int> (Sampler1DShadow<vector<T,N>> sampler, float2 p)
 {
     return sampler.SampleCmp(p.x, p.y);
 }
 
 [ForceInline]
-public float texture<T:__BuiltinArithmeticType, let N : int> (Sampler2DShadow<vector<T,N>> sampler, float3 p)
+public float texture<T:__BuiltinFloatingPointType, let N : int> (Sampler2DShadow<vector<T,N>> sampler, float3 p)
 {
     return sampler.SampleCmp(p.xy, p.z);
 }
 
 [ForceInline]
-public float texture<T:__BuiltinArithmeticType, let N : int> (SamplerCubeShadow<vector<T,N>> sampler, float4 p)
+public float texture<T:__BuiltinFloatingPointType, let N : int> (SamplerCubeShadow<vector<T,N>> sampler, float4 p)
 {
     return sampler.SampleCmp(p.xyz, p.w);
 }
 
 [ForceInline]
-public vector<T,4> texture<T:__BuiltinArithmeticType, let N : int> (Sampler1DArray<vector<T,N>> sampler, float2 p, float bias = 0.0)
+public vector<T,4> texture<T:__BuiltinFloatingPointType, let N : int> (Sampler1DArray<vector<T,N>> sampler, float2 p, float bias = 0.0)
 {
     return __vectorReshape<4>(sampler.SampleBias(p, bias));
 }
 
 [ForceInline]
-public vector<T,4> texture<T:__BuiltinArithmeticType, let N : int> (Sampler2DArray<vector<T,N>> sampler, float3 p, float bias = 0.0)
+public vector<T,4> texture<T:__BuiltinFloatingPointType, let N : int> (Sampler2DArray<vector<T,N>> sampler, float3 p, float bias = 0.0)
 {
     return __vectorReshape<4>(sampler.SampleBias(p, bias));
 }
 
 [ForceInline]
-public vector<T,4> texture<T:__BuiltinArithmeticType, let N : int> (SamplerCubeArray<vector<T,N>> sampler, float4 p, float bias = 0.0)
+public vector<T,4> texture<T:__BuiltinFloatingPointType, let N : int> (SamplerCubeArray<vector<T,N>> sampler, float4 p, float bias = 0.0)
 {
     return __vectorReshape<4>(sampler.SampleBias(p, bias));
 }
 
 [ForceInline]
-public float texture<T:__BuiltinArithmeticType, let N : int> (Sampler1DArrayShadow<vector<T,N>> sampler, float3 p)
+public float texture<T:__BuiltinFloatingPointType, let N : int> (Sampler1DArrayShadow<vector<T,N>> sampler, float3 p)
 {
     return sampler.SampleCmp(p.xy, p.z);
 }
 
 [ForceInline]
-public float texture<T:__BuiltinArithmeticType, let N : int> (Sampler2DArrayShadow<vector<T,N>> sampler, float4 p)
+public float texture<T:__BuiltinFloatingPointType, let N : int> (Sampler2DArrayShadow<vector<T,N>> sampler, float4 p)
 {
     return sampler.SampleCmp(p.xyz, p.w);
 }
 
-__generic<T:__BuiltinArithmeticType, let N : int, shape:__ITextureShape, let sampleCount: int, let isArray:int, let format:int>
+__generic<T:__BuiltinFloatingPointType, let N : int, shape:__ITextureShape, let sampleCount: int, let isArray:int, let format:int>
 public vector<T,4> textureGrad(__TextureImpl<vector<T,N>, shape, isArray, 0, sampleCount, 0, 1, 1, format> sampler, vector<float, shape.dimensions+isArray> P, vector<float,shape.planeDimensions> dPdx, vector<float,shape.planeDimensions> dPdy)
 {
     return __vectorReshape<4>(sampler.SampleGrad(P, dPdx, dPdy));

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -214,7 +214,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
             }).y;
         }
     }
+}
 
+__generic<T:IFloat, Shape: __ITextureShape, let isArray:int, let isMS:int, let sampleCount:int, let isShadow:int, let format:int>
+extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
+{
     [__readNone]
     T Sample(vector<float, Shape.dimensions+isArray> location)
     {
@@ -586,7 +590,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,access,isShadow,0,forma
             }).y;
         }
     }
+}
 
+__generic<T:IFloat, Shape: __ITextureShape, let isArray:int, let isMS:int, let sampleCount:int, let isShadow:int, let format:int>
+extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
+{
     [__readNone]
     T Sample(SamplerState s, vector<float, Shape.dimensions+isArray> location)
     {

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -593,7 +593,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,access,isShadow,0,forma
 }
 
 __generic<T:IFloat, Shape: __ITextureShape, let isArray:int, let isMS:int, let sampleCount:int, let isShadow:int, let format:int>
-extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
+extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 {
     [__readNone]
     T Sample(SamplerState s, vector<float, Shape.dimensions+isArray> location)

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -214,6 +214,21 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
             }).y;
         }
     }
+    
+    __target_intrinsic(glsl, "texture($0, $1)")
+    float __glsl_texture(vector<float, Shape.dimensions+isArray+1> value);
+
+    __glsl_extension(GL_EXT_texture_shadow_lod)
+    __target_intrinsic(glsl, "textureOffset($0, $1, $2)")
+    float __glsl_texture_offset(vector<float, Shape.dimensions+isArray+1> value, constexpr vector<int, Shape.planeDimensions> offset);
+
+    __glsl_extension(GL_EXT_texture_shadow_lod)
+    __target_intrinsic(glsl, "textureLod($0, $1, 0)")
+    float __glsl_texture_level_zero(vector<float, Shape.dimensions+isArray+1> value);
+
+    __glsl_extension(GL_EXT_texture_shadow_lod)
+    __target_intrinsic(glsl, "textureLodOffset($0, $1, 0, $2)")
+    float __glsl_texture_offset_level_zero(vector<float, Shape.dimensions+isArray+1> value, constexpr vector<int, Shape.planeDimensions> offset);
 }
 
 __generic<T:IFloat, Shape: __ITextureShape, let isArray:int, let isMS:int, let sampleCount:int, let isShadow:int, let format:int>
@@ -332,21 +347,6 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
             };
         }
     }
-
-    __target_intrinsic(glsl, "texture($0, $1)")
-    float __glsl_texture(vector<float, Shape.dimensions+isArray+1> value);
-
-    __glsl_extension(GL_EXT_texture_shadow_lod)
-    __target_intrinsic(glsl, "textureOffset($0, $1, $2)")
-    float __glsl_texture_offset(vector<float, Shape.dimensions+isArray+1> value, constexpr vector<int, Shape.planeDimensions> offset);
-
-    __glsl_extension(GL_EXT_texture_shadow_lod)
-    __target_intrinsic(glsl, "textureLod($0, $1, 0)")
-    float __glsl_texture_level_zero(vector<float, Shape.dimensions+isArray+1> value);
-
-    __glsl_extension(GL_EXT_texture_shadow_lod)
-    __target_intrinsic(glsl, "textureLodOffset($0, $1, 0, $2)")
-    float __glsl_texture_offset_level_zero(vector<float, Shape.dimensions+isArray+1> value, constexpr vector<int, Shape.planeDimensions> offset);
 
     [__readNone]
     [ForceInline]
@@ -590,6 +590,22 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,access,isShadow,0,forma
             }).y;
         }
     }
+    
+    __target_intrinsic(glsl, "texture($p, $2)")
+    float __glsl_texture(SamplerComparisonState s, vector<float, Shape.dimensions+isArray+1> value);
+
+    __glsl_extension(GL_EXT_texture_shadow_lod)
+    __target_intrinsic(glsl, "textureOffset($p, $2, $3)")
+    float __glsl_texture_offset(SamplerComparisonState s, vector<float, Shape.dimensions+isArray+1> value, constexpr vector<int, Shape.planeDimensions> offset);
+
+    __glsl_extension(GL_EXT_texture_shadow_lod)
+    __target_intrinsic(glsl, "textureLod($p, $2, 0)")
+    float __glsl_texture_level_zero(SamplerComparisonState s, vector<float, Shape.dimensions+isArray+1> value);
+
+    __glsl_extension(GL_EXT_texture_shadow_lod)
+    __target_intrinsic(glsl, "textureLodOffset($p, $2, 0, $3)")
+    float __glsl_texture_offset_level_zero(SamplerComparisonState s, vector<float, Shape.dimensions+isArray+1> value, constexpr vector<int, Shape.planeDimensions> offset);
+
 }
 
 __generic<T:IFloat, Shape: __ITextureShape, let isArray:int, let isMS:int, let sampleCount:int, let isShadow:int, let format:int>
@@ -733,21 +749,6 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
             };
         }
     }
-
-    __target_intrinsic(glsl, "texture($p, $2)")
-    float __glsl_texture(SamplerComparisonState s, vector<float, Shape.dimensions+isArray+1> value);
-
-    __glsl_extension(GL_EXT_texture_shadow_lod)
-    __target_intrinsic(glsl, "textureOffset($p, $2, $3)")
-    float __glsl_texture_offset(SamplerComparisonState s, vector<float, Shape.dimensions+isArray+1> value, constexpr vector<int, Shape.planeDimensions> offset);
-
-    __glsl_extension(GL_EXT_texture_shadow_lod)
-    __target_intrinsic(glsl, "textureLod($p, $2, 0)")
-    float __glsl_texture_level_zero(SamplerComparisonState s, vector<float, Shape.dimensions+isArray+1> value);
-
-    __glsl_extension(GL_EXT_texture_shadow_lod)
-    __target_intrinsic(glsl, "textureLodOffset($p, $2, 0, $3)")
-    float __glsl_texture_offset_level_zero(SamplerComparisonState s, vector<float, Shape.dimensions+isArray+1> value, constexpr vector<int, Shape.planeDimensions> offset);
 
     [__readNone] [ForceInline]
     float SampleCmp(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue)

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -966,9 +966,9 @@ namespace Slang
         case ASTNodeType::HLSLColumnMajorLayoutModifier:
         case ASTNodeType::GLSLRowMajorLayoutModifier:
         case ASTNodeType::HLSLEffectSharedModifier:
-        case ASTNodeType::HLSLGroupSharedModifier:
         case ASTNodeType::HLSLVolatileModifier:
         case ASTNodeType::GLSLPrecisionModifier:
+        case ASTNodeType::HLSLGroupSharedModifier:
             return modifierType;
 
         case ASTNodeType::HLSLStaticModifier:
@@ -1025,7 +1025,6 @@ namespace Slang
         case ASTNodeType::RayPayloadReadSemantic:
         case ASTNodeType::RayPayloadWriteSemantic:
         case ASTNodeType::GloballyCoherentModifier:
-        case ASTNodeType::HLSLGroupSharedModifier:
             return (as<VarDeclBase>(decl) && isGlobalDecl(decl)) || as<ParamDecl>(decl) || as<GLSLInterfaceBlockDecl>(decl);
 
             // Allowed only on parameters, struct fields and global variables.
@@ -1087,6 +1086,11 @@ namespace Slang
 
         case ASTNodeType::GLSLPrecisionModifier:
             return as<VarDeclBase>(decl) || as<GLSLInterfaceBlockDecl>(decl) || as<CallableDecl>(decl);
+        case ASTNodeType::HLSLGroupSharedModifier:
+            // groupshared must be global or static.
+            if (!as<VarDeclBase>(decl))
+                return false;
+            return isGlobalDecl(decl) || isEffectivelyStatic(decl);
         default:
             return true;
         }

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -1025,6 +1025,7 @@ namespace Slang
         case ASTNodeType::RayPayloadReadSemantic:
         case ASTNodeType::RayPayloadWriteSemantic:
         case ASTNodeType::GloballyCoherentModifier:
+        case ASTNodeType::HLSLGroupSharedModifier:
             return (as<VarDeclBase>(decl) && isGlobalDecl(decl)) || as<ParamDecl>(decl) || as<GLSLInterfaceBlockDecl>(decl);
 
             // Allowed only on parameters, struct fields and global variables.
@@ -1081,7 +1082,6 @@ namespace Slang
         case ASTNodeType::HLSLColumnMajorLayoutModifier:
         case ASTNodeType::GLSLRowMajorLayoutModifier:
         case ASTNodeType::HLSLEffectSharedModifier:
-        case ASTNodeType::HLSLGroupSharedModifier:
         case ASTNodeType::HLSLVolatileModifier:
             return as<VarDeclBase>(decl) || as<GLSLInterfaceBlockDecl>(decl);
 

--- a/tests/diagnostics/groupshared-local.slang
+++ b/tests/diagnostics/groupshared-local.slang
@@ -1,0 +1,10 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):
+
+// CHECK-NOT: ([[# @LINE+1]]): error 31201
+groupshared int b;
+
+int test()
+{
+    // CHECK: ([[# @LINE+1]]): error 31201
+    groupshared int a;
+}

--- a/tests/diagnostics/int-texture-sample.slang
+++ b/tests/diagnostics/int-texture-sample.slang
@@ -1,0 +1,7 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):
+
+void test(Texture2D<int4> itex, SamplerState s)
+{
+    // CHECK: ([[# @LINE+1]]): error
+    itex.Sample(s, float2(0.0, 0.0));
+}


### PR DESCRIPTION
Fixes #3387.

Fixes #490.
