### PR TITLE
Update the GetDimension hlsl builtin for spirv path. In case of sampl…

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -957,7 +957,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
     }
 }
 
-// Texture.GetDimensions
+// Texture.GetDimensions and Sampler.GetDimensions
 ${{{{
 const char* kTextureShapeTypeNames[] = {
     "__Shape1D", "__Shape2D", "__Shape3D", "__ShapeCube"};

--- a/source/slang/slang-stdlib-textures.h
+++ b/source/slang/slang-stdlib-textures.h
@@ -66,13 +66,15 @@ public:
         const char* funcName,
         const String& glsl,
         const String& cuda,
-        const String& spirv
+        const String& spirvDefault,
+        const String& spirvCombined
     );
     void writeFuncWithSig(
         const char* funcName,
         const String& sig,
         const String& glsl = String{},
-        const String& spirv = String{},
+        const String& spirvDefault = String{},
+        const String& spirvCombined = String{},
         const String& cuda = String{},
         const ReadNoneMode readNoneMode = ReadNoneMode::Never
     );
@@ -81,7 +83,8 @@ public:
         const char* funcName,
         const String& params,
         const String& glsl = String{},
-        const String& spirv = String{},
+        const String& spirvDefault = String{},
+        const String& spirvCombined = String{},
         const String& cuda = String{},
         const ReadNoneMode readNoneMode = ReadNoneMode::Never
     );

--- a/tests/cross-compile/vk-sampler-getdimension.slang
+++ b/tests/cross-compile/vk-sampler-getdimension.slang
@@ -1,0 +1,33 @@
+// vk-sampler-getdimension.slang
+
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage fragment -emit-spirv-directly
+
+//  Input to the fragment shader.
+struct PSin
+{
+  float3 position : POSITION;
+};
+
+// Output of the fragment shader
+struct PSout
+{
+  float4 color : SV_Target;
+};
+
+[[vk::binding(1)]] Sampler3D g_Volume;
+
+// Fragment Shader
+[shader("pixel")]
+PSout main(PSin stage, bool isFrontFacing : SV_IsFrontFace)
+{
+  // CHECK: %image{{.*}} = OpImage
+  // CHECK: OpImageQuerySizeLod %{{.*}} %image{{.*}}
+  PSout output;
+  // Find normal at position
+  uint3 dim;
+  uint levels;
+  g_Volume.GetDimensions(0, dim.x, dim.y, dim.z, levels);
+  output.color = g_Volume.Sample(float3(dim));
+  
+  return output;
+}


### PR DESCRIPTION
…er, a combined sampled image needs an OpImage to be generated.

Fixes bug #3360 