### PR TITLE
Fix the intrinsic expansion of ObjectToWorld3x4 in spirv_asm. Data type

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -9569,7 +9569,7 @@ float3x4 ObjectToWorld3x4()
     case GL_NV_ray_tracing:  __intrinsic_asm "transpose(gl_ObjectToWorldNV)";
     case spirv:
         return spirv_asm {
-            %mat = OpLoad builtin(ObjectToWorldKHR:float4x3);
+            %mat:$$float4x3 = OpLoad builtin(ObjectToWorldKHR:float4x3);
             result:$$float3x4 = OpTranspose %mat;
         };
     }
@@ -9584,7 +9584,7 @@ float3x4 WorldToObject3x4()
     case GL_NV_ray_tracing:  __intrinsic_asm "transpose(gl_WorldToObjectNV)";
     case spirv:
         return spirv_asm {
-            %mat = OpLoad builtin(WorldToObjectKHR:float4x3);
+            %mat:$$float4x3 = OpLoad builtin(WorldToObjectKHR:float4x3);
             result:$$float3x4 = OpTranspose %mat;
         };
     }

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -91,6 +91,7 @@
 #include "slang-emit-cuda.h"
 #include "slang-emit-torch.h"
 
+#include "slang-spirv-val.h"
 #include "../compiler-core/slang-artifact-desc-util.h"
 #include "../compiler-core/slang-artifact-util.h"
 #include "../compiler-core/slang-artifact-impl.h"
@@ -1291,6 +1292,13 @@ SlangResult emitSPIRVForEntryPointsDirectly(
 #endif
     auto artifact = ArtifactUtil::createArtifactForCompileTarget(asExternal(codeGenContext->getTargetFormat()));
     artifact->addRepresentationUnknown(ListBlob::moveCreate(spirv));
+
+#if 0
+    // Dump the unoptimized SPIRV after lowering from slang IR -> SPIRV
+    String err; String dis;
+    disassembleSPIRV(spirv, err, dis);
+    printf("%s", dis.begin());
+#endif
 
     IDownstreamCompiler* compiler = codeGenContext->getSession()->getOrLoadDownstreamCompiler(
         PassThroughMode::SpirvOpt, codeGenContext->getSink());

--- a/source/slang/slang-spirv-val.cpp
+++ b/source/slang/slang-spirv-val.cpp
@@ -3,7 +3,7 @@
 namespace Slang
 {
 
-static SlangResult disassembleSPIRV(const List<uint8_t>& spirv, String& outErr, String& outDis)
+SlangResult disassembleSPIRV(const List<uint8_t>& spirv, String& outErr, String& outDis)
 {
     // Set up our process
     CommandLine commandLine;

--- a/source/slang/slang-spirv-val.h
+++ b/source/slang/slang-spirv-val.h
@@ -6,5 +6,6 @@
 namespace Slang
 {
 SlangResult debugValidateSPIRV(const List<uint8_t>& spirv);
+SlangResult disassembleSPIRV(const List<uint8_t>& spirv, String& outErr, String& outDis);
 }
 


### PR DESCRIPTION
of result of OpLoad instruction was missing. This resulted in an incomplete OpLoad instruction getting generated causing spirv-val to report failure.
Also added dumping of spirv disassembly right after unoptimized spirv emission.

Fixes bug #3359