### PR TITLE
Support for gl_HitTriangleVertexPositionsEXT (#3405)

### DIFF
--- a/docs/design/stdlib-intrinsics.md
+++ b/docs/design/stdlib-intrinsics.md
@@ -87,7 +87,7 @@ Currently `HLSL` has a special handling in that it is *assumed* if a declaration
 
 The target can also be a capability atom. The atoms are listed in "slang-capability-defs.h".
 
-What is perhaps of importance here is that for some features for a specific target can have multiple ways of achieving the same effect - for example "GL_NV_ray_tracing" or "GL_NV_ray_tracing" are two different ray tracing extensions available for Vulkan through GLSL. The `-profile` option can disambiguate which extension is actually desired, and the capability with that name on the `target_intrinsic` specifies how to implement that feature for that specific extension.
+What is perhaps of importance here is that for some features for a specific target can have multiple ways of achieving the same effect - for example "GL_NV_ray_tracing" and "GL_EXT_ray_tracing" are two different ray tracing extensions available for Vulkan through GLSL. The `-profile` option can disambiguate which extension is actually desired, and the capability with that name on the `target_intrinsic` specifies how to implement that feature for that specific extension.
 
 The expansion mechanism is implemented in "slang-intrinsic-expand.cpp" which will be most up to date.
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -9861,6 +9861,31 @@ uint GeometryIndex()
     }
 }
 
+// Get the vertex positions of the currently hit triangle in any-hit or closest-hit shader.
+// https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_ray_tracing_position_fetch.txt
+__glsl_extension(GL_EXT_ray_tracing)
+__glsl_extension(GL_EXT_ray_tracing_position_fetch)
+__glsl_version(460)
+[ForceInline]
+float3 HitTriangleVertexPositions(uint index)
+{
+    __target_switch
+    {
+        case glsl:
+            __intrinsic_asm "gl_HitTriangleVertexPositionsEXT[$0]";
+        case spirv:
+            return spirv_asm {
+                OpCapability RayTracingKHR;
+                OpCapability RayTracingPositionFetchKHR;
+                OpExtension "SPV_KHR_ray_tracing";
+                OpExtension "SPV_KHR_ray_tracing_position_fetch";
+                %_ptr_Input_v3float = OpTypePointer Input $$float3;
+                %addr = OpAccessChain %_ptr_Input_v3float builtin(HitTriangleVertexPositionsKHR:float3[3]) $index;
+                result:$$float3 = OpLoad %addr;
+            };
+    }
+}
+
 // Status of whether a (closest) hit has been committed in a `RayQuery`.
 typedef uint COMMITTED_STATUS;
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -9867,7 +9867,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_EXT_ray_tracing_position_fetch)
 __glsl_version(460)
 [ForceInline]
-float3 HitTriangleVertexPositions(uint index)
+float3 HitTriangleVertexPosition(uint index)
 {
     __target_switch
     {
@@ -9880,7 +9880,7 @@ float3 HitTriangleVertexPositions(uint index)
                 OpExtension "SPV_KHR_ray_tracing";
                 OpExtension "SPV_KHR_ray_tracing_position_fetch";
                 %_ptr_Input_v3float = OpTypePointer Input $$float3;
-                %addr = OpAccessChain %_ptr_Input_v3float builtin(HitTriangleVertexPositionsKHR:float3[3]) $index;
+                %addr : %_ptr_Input_v3float = OpAccessChain builtin(HitTriangleVertexPositionsKHR:float3[3]) $index;
                 result:$$float3 = OpLoad %addr;
             };
     }


### PR DESCRIPTION
Adding float3 HitTriangleVertexPositions(uint) to slang stdlib to support GLSL gl_HitTriangleVertexPositionsEXT builtin variable under extension of GL_EXT_ray_tracing_position_fetch.

This function support emitting GLSL code and spir-V directly.