### PR TITLE
Add test to closesthit shader

### DIFF
--- a/tests/vkray/anyhit.slang
+++ b/tests/vkray/anyhit.slang
@@ -44,12 +44,26 @@ void main(
             IgnoreHit();
         }
     }
+
+    uint index = 0U;
+	HitTriangleVertexPosition(index);
+
+	index = 1U;
+	HitTriangleVertexPosition(index);
+
+	index = 2U;
+	HitTriangleVertexPosition(index);
 }
 
 // CHECK: OpCapability RayTracing
+// CHECK: OpCapability RayTracingPositionFetchKHR
 // CHECK: OpEntryPoint AnyHitNV %main "main"
+// CHECK: OpDecorate %{{.*}} BuiltIn HitTriangleVertexPositionsKHR
 // CHECK: %_ptr_HitAttributeNV_SphereHitAttributes_0 = OpTypePointer HitAttributeNV %SphereHitAttributes_0
 // CHECK: %_S{{.*}} = OpVariable %_ptr_HitAttributeNV_SphereHitAttributes_0 HitAttributeNV
 // CHECK: %{{.*}} = OpAccessChain %_ptr_HitAttributeNV_v3float %_S{{.*}} %int_0
 // CHECK: OpTerminateRayKHR
 // CHECK: OpIgnoreIntersectionKHR
+// CHECK: %{{.*}} = OpAccessChain %_ptr_Input_v3float %{{.*}} %{{u?}}int_0
+// CHECK: %{{.*}} = OpAccessChain %_ptr_Input_v3float %{{.*}} %{{u?}}int_1
+// CHECK: %{{.*}} = OpAccessChain %_ptr_Input_v3float %{{.*}} %{{u?}}int_2

--- a/tests/vkray/closesthit.slang
+++ b/tests/vkray/closesthit.slang
@@ -1,5 +1,5 @@
 // closesthit.slang
-//TEST:SIMPLE(filecheck=CHECK): -profile glsl_460+GL_NV_ray_tracing -stage closesthit -entry main -target spirv-assembly
+//TEST:SIMPLE(filecheck=CHECK): -profile glsl_460+GL_EXT_ray_tracing -stage closesthit -entry main -target spirv-assembly
 //TEST:SIMPLE(filecheck=CHECK): -stage closesthit -entry main -target spirv-assembly -emit-spirv-directly
 
 struct ReflectionRay
@@ -30,9 +30,19 @@ void main(
 	color *= RayTCurrent() - RayTMin();
 
 	ioPayload.color = color;
+
+	uint index = 0U;
+	HitTriangleVertexPosition(index);
+
+	index = 1U;
+	HitTriangleVertexPosition(index);
+
+	index = 2U;
+	HitTriangleVertexPosition(index);
 }
 
 // CHECK: OpCapability RayTracing
+// CHECK: OpCapability RayTracingPositionFetchKHR
 // CHECK: OpEntryPoint ClosestHitNV %main "main"
 // CHECK-DAG: OpDecorate %[[INSTANCE_ID:[A-Za-z0-9_]+]] BuiltIn InstanceId
 // CHECK-DAG: OpDecorate %[[INSTANCE_INDEX:[A-Za-z0-9_]+]] BuiltIn InstanceCustomIndexNV
@@ -40,9 +50,13 @@ void main(
 // CHECK-DAG: OpDecorate %{{.*}} BuiltIn HitKindNV
 // CHECK-DAG: OpDecorate %{{.*}} BuiltIn RayTmaxNV
 // CHECK-DAG: OpDecorate %{{.*}} BuiltIn RayTminNV
+// CHECK-DAG: OpDecorate %{{.*}} BuiltIn HitTriangleVertexPositionsKHR
 // CHECK-DAG: %ShaderRecord{{.*}} = OpVariable %_ptr_ShaderRecordBufferNV{{.*}} ShaderRecordBufferNV
 // CHECK-DAG: %{{.*}} = OpVariable %_ptr_IncomingRayPayloadNV_ReflectionRay{{.*}} IncomingRayPayloadNV
 // CHECK-DAG: %{{.*}} = OpLoad %{{u?}}int %[[INSTANCE_ID]]
 // CHECK-DAG: %{{.*}} = OpLoad %{{u?}}int %[[INSTANCE_INDEX]]
 // CHECK-DAG: %{{.*}} = OpAccessChain %_ptr_ShaderRecordBufferNV_uint %ShaderRecord{{.*}} %int_0
 // CHECK-DAG: %{{.*}} = OpAccessChain %_ptr_IncomingRayPayloadNV_v4float %{{.*}} %int_0
+// CHECK-DAG: %{{.*}} = OpAccessChain %_ptr_Input_v3float %{{.*}} %{{u?}}int_0
+// CHECK-DAG: %{{.*}} = OpAccessChain %_ptr_Input_v3float %{{.*}} %{{u?}}int_1
+// CHECK-DAG: %{{.*}} = OpAccessChain %_ptr_Input_v3float %{{.*}} %{{u?}}int_2


### PR DESCRIPTION
Add test to closesthit.slang to test the slang
stdlib API: HitTriangleVertexPosition.

The new test will add the checking for extension declaration, built-in declaration, and built-in variable access.