### PR TITLE
Add support for rayQueryGetIntersectionTriangleVertexPositionsEXT

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -10208,6 +10208,42 @@ ${{{{
         auto ccTF = candidateOrCommitted == 0 ? "false" : "true";
 }}}}
 
+    __glsl_extension(GL_EXT_ray_query)
+    __glsl_extension(GL_EXT_ray_tracing_position_fetch)
+    __glsl_version(460)
+    [__NoSideEffect]
+    void __glslGetIntersectionTriangleVertexPositions$(ccName)(out float3 arr[3])
+    {
+        __intrinsic_asm "rayQueryGetIntersectionTriangleVertexPositionsEXT($0, $(ccTF), $1)";
+    };
+
+    __glsl_extension(GL_EXT_ray_query)
+    __glsl_extension(GL_EXT_ray_tracing_position_fetch)
+    __glsl_version(460)
+    [__NoSideEffect]
+    float3[3] $(ccName)GetIntersectionTriangleVertexPositions()
+    {
+        typedef float3[3] float3Arr3;
+        __target_switch
+        {
+        case glsl:
+            float3 output[3];
+            __glslGetIntersectionTriangleVertexPositions$(ccName)(output);
+            return output;
+        case spirv:
+            uint iCandidateOrCommitted = $(candidateOrCommitted);
+            return spirv_asm
+            {
+                OpCapability RayQueryKHR;
+                OpCapability RayTracingPositionFetchKHR;
+                OpCapability RayQueryPositionFetchKHR;
+                OpExtension "SPV_KHR_ray_query";
+                OpExtension "SPV_KHR_ray_tracing_position_fetch";
+                result: $$float3Arr3 = OpRayQueryGetIntersectionTriangleVertexPositionsKHR &this $iCandidateOrCommitted;
+            };
+        }
+    };
+
     // CandidateObjectToWorld3x4, CandidateWorldToObject4x3
     // CommittedObjectToWorld3x4, CommittedObjectToWorld4x3
     ${{{{

--- a/tests/vkray/rayquery-closesthit.slang
+++ b/tests/vkray/rayquery-closesthit.slang
@@ -1,0 +1,35 @@
+// rayquery-closesthit.slang
+//TEST:SIMPLE(filecheck=CHECK): -profile glsl_460+GL_EXT_ray_tracing -stage closesthit -entry main -target spirv-assembly
+//TEST:SIMPLE(filecheck=CHECK): -stage closesthit -entry main -target spirv-assembly -emit-spirv-directly
+
+struct IntersectionPayload
+{
+    float3 triangleVerticeCommitted[3];
+    float3 triangleVerticeCandidate[3];
+};
+
+RaytracingAccelerationStructure accelerationStructure;
+
+void main(
+	BuiltInTriangleIntersectionAttributes 	attributes,
+	in out IntersectionPayload 				ioPayload)
+{
+	RayQuery<RAY_FLAG_NONE> rayQuery;
+
+	uint instanceInclusionMask = 0x00;
+	RayDesc rayDesc;
+	rayQuery.TraceRayInline(accelerationStructure, RAY_FLAG_NONE, instanceInclusionMask, rayDesc);
+
+	ioPayload.triangleVerticeCommitted = rayQuery.CandidateGetIntersectionTriangleVertexPositions();
+	ioPayload.triangleVerticeCandidate = rayQuery.CommittedGetIntersectionTriangleVertexPositions();
+}
+
+// CHECK: OpCapability RayQueryKHR
+// CHECK: OpCapability RayTracingPositionFetchKHR
+// CHECK: OpCapability RayQueryPositionFetchKHR
+// CHECK: OpExtension "SPV_KHR_ray_query"
+// CHECK: OpExtension "SPV_KHR_ray_tracing_position_fetch"
+// CHECK: OpEntryPoint ClosestHitNV %main "main"
+// CHECK: OpRayQueryInitializeKHR %rayQuery{{.*}}
+// CHECK: OpRayQueryGetIntersectionTriangleVertexPositionsKHR %_arr_v3float_{{u?}}int_3{{.*}} %rayQuery{{.*}} %{{u?}}int_0
+// CHECK: OpRayQueryGetIntersectionTriangleVertexPositionsKHR %_arr_v3float_{{u?}}int_3{{.*}} %rayQuery{{.*}} %{{u?}}int_1


### PR DESCRIPTION
Add a member function to RayQuery<RAY_FLAG> class
GetIntersectionTriangleVertexPositions to support the GLSL built-int rayQueryGetIntersectionTriangleVertexPositionsEXT.

Also add new test file under tests/vkray/rayquery-closesthit.slang to test this functionality.