### PR TITLE
Bug fixes for the direct spirv backend.

### DIFF
--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -451,7 +451,7 @@ DIAGNOSTIC(30510, Error, loopInDiffFuncRequireUnrollOrMaxIters, "loops inside a 
 DIAGNOSTIC(39999, Fatal, cyclicReference, "cyclic reference '$0'.")
 DIAGNOSTIC(39999, Error, localVariableUsedBeforeDeclared, "local variable '$0' is being used before its declaration.")
 DIAGNOSTIC(39999, Error, variableUsedInItsOwnDefinition, "the initial-value expression for variable '$0' depends on the value of the variable itself")
-DIAGNOSTIC(39001, Fatal , cannotProcessInclude, "internal compiler error: cannot process '__include' in the current semantic checking context.")
+DIAGNOSTIC(39901, Fatal , cannotProcessInclude, "internal compiler error: cannot process '__include' in the current semantic checking context.")
 
 // 304xx: generics
 DIAGNOSTIC(30400, Error, genericTypeNeedsArgs, "generic type '$0' used without argument")

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -1599,7 +1599,10 @@ void assign(
             auto arrayIndexInst = builder->getIntValue(builder->getIntType(), arrayIndex);
 
             // Store to the index
-            auto address = builder->emitElementAddress(right.irValue->getFullType(), left.irValue, arrayIndexInst);
+            auto address = builder->emitElementAddress(
+                builder->getPtrType(right.irValue->getFullType()),
+                left.irValue,
+                arrayIndexInst);
             builder->emitStore(address, rhs);
 
             break;
@@ -1613,7 +1616,10 @@ void assign(
                     auto address = left.irValue;
                     if(index)
                     {
-                        address = builder->emitElementAddress(right.irValue->getFullType(), left.irValue, index);
+                        address = builder->emitElementAddress(
+                            builder->getPtrType(right.irValue->getFullType()),
+                            left.irValue,
+                            index);
                     }
                     builder->emitStore(address, right.irValue);
                     break;

--- a/source/slang/slang-ir-layout.cpp
+++ b/source/slang/slang-ir-layout.cpp
@@ -461,9 +461,10 @@ struct Std140LayoutRules : IRTypeLayoutRules
     }
     virtual IRSizeAndAlignment getVectorSizeAndAlignment(IRSizeAndAlignment element, IRIntegerValue count)
     {
+        IRIntegerValue alignmentCount = count;
         if (count == 3)
-            count = 4;
-        return IRSizeAndAlignment((int)(element.size * count), (int)(element.size * count));
+            alignmentCount = 4;
+        return IRSizeAndAlignment((int)(element.size * count), (int)(element.size * alignmentCount));
     }
 };
 

--- a/tests/spirv/std140-layout.slang
+++ b/tests/spirv/std140-layout.slang
@@ -1,0 +1,17 @@
+
+//TEST:SIMPLE(filecheck=SPIRV): -stage fragment -entry main -target spirv -emit-spirv-directly
+
+// SPIRV: OpMemberDecorate %{{.*}} 0 Offset 0
+// SPIRV: OpMemberDecorate %{{.*}} 1 Offset 16
+// SPIRV: OpMemberDecorate %{{.*}} 2 Offset 28
+
+uniform float3 v0;
+uniform float3 v1;
+uniform float v2;
+
+
+
+float4 main() : SV_Target
+{
+    return float4(v2);
+}


### PR DESCRIPTION
1. Fix GLSL legalization that produces insts with wrong type (missing ptr type).
2. Fix diagnostic id conflict.
3. Fix std140 layout logic, size of `float3` should be 12.