### PR TITLE
IRSPIRVAsmOperandInst instructions may not have IRBlock as the immedi…

### DIFF
--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -2109,27 +2109,6 @@ bool finalizeAutoDiffPass(TargetRequest* target, IRModule* module)
     return modified;
 }
 
-IRBlock* getBlock(IRInst* inst)
-{
-    if (!inst)
-        return nullptr;
-
-    if (auto block = as<IRBlock>(inst))
-        return block;
-
-    return getBlock(inst->getParent());
-}
-
-IRInst* getInstInBlock(IRInst* inst)
-{
-    SLANG_RELEASE_ASSERT(inst);
-
-    if (const auto block = as<IRBlock>(inst->getParent()))
-        return inst;
-
-    return getInstInBlock(inst->getParent());
-}
-
 UIndex addPhiOutputArg(IRBuilder* builder, IRBlock* block, IRInst*& inoutTerminatorInst, IRInst* arg)
 {
     SLANG_RELEASE_ASSERT(as<IRUnconditionalBranch>(block->getTerminator()));

--- a/source/slang/slang-ir-autodiff.h
+++ b/source/slang/slang-ir-autodiff.h
@@ -394,10 +394,6 @@ inline bool isRelevantDifferentialPair(IRType* type)
     return false;
 }
 
-IRBlock* getBlock(IRInst* inst);
-
-IRInst* getInstInBlock(IRInst* inst);
-
 UIndex addPhiOutputArg(IRBuilder* builder, IRBlock* block, IRInst*& inoutTerminatorInst, IRInst* arg);
 
 IRUse* findUniqueStoredVal(IRVar* var);

--- a/source/slang/slang-ir-util.h
+++ b/source/slang/slang-ir-util.h
@@ -217,7 +217,7 @@ IRInst* findWitnessTableEntry(IRWitnessTable* table, IRInst* key);
 
 IRInst* getVulkanPayloadLocation(IRInst* payloadGlobalVar);
 
-void moveParams(IRBlock* dest, IRBlock* src);
+IRInst* getInstInBlock(IRInst* inst);
 
 void removePhiArgs(IRInst* phiParam);
 
@@ -233,6 +233,10 @@ IRPtrTypeBase* isMutablePointerType(IRInst* inst);
 
 void initializeScratchData(IRInst* inst);
 void resetScratchDataBit(IRInst* inst, int bitIndex);
+///
+/// IRBlock related common helper methods 
+///
+void moveParams(IRBlock* dest, IRBlock* src);
 
 List<IRBlock*> collectBlocksInRegion(
     IRDominatorTree* dom,
@@ -264,6 +268,12 @@ List<IRBlock*> collectBlocksInRegion(IRGlobalValueWithCode* func,  IRLoop* loopI
 List<IRBlock*> collectBlocksInRegion(IRGlobalValueWithCode* func,  IRLoop* loopInst);
 
 HashSet<IRBlock*> getParentBreakBlockSet(IRDominatorTree* dom, IRBlock* block);
+
+IRBlock* getBlock(IRInst* inst);
+
+///
+/// End of IRBlock utility methods
+///
 
 IRVarLayout* findVarLayout(IRInst* value);
 

--- a/source/slang/slang-ir-validate.cpp
+++ b/source/slang/slang-ir-validate.cpp
@@ -4,6 +4,7 @@
 #include "slang-ir.h"
 #include "slang-ir-insts.h"
 #include "slang-ir-dominators.h"
+#include "slang-ir-util.h"
 
 namespace Slang
 {
@@ -144,13 +145,7 @@ namespace Slang
 
         auto operandParent = operandValue->getParent();
 
-        auto instParentBlock = as<IRBlock>(instParent);
-        if (!instParentBlock && as<IRDecoration>(inst))
-        {
-            instParent = instParent->getParent();
-            instParentBlock = as<IRBlock>(instParent);
-        }
-
+        auto instParentBlock = getBlock(inst);
         if (instParentBlock)
         {
             if (auto operandParentBlock = as<IRBlock>(operandParent))


### PR DESCRIPTION
…ate parent. Previously special case was added to handle IRDecoration similarly. Replace this with a common method getBlock that traverses the parent chain till it gets to the Block

Fixes bug #3432