### PR TITLE
[SPIRV] Support `globallycoherent` and `[vk::index()]`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ tools/gfx-unit-test/test-tmp-*
 
 # Intermediate source files generated during build process
 /source/slang/slang-generated-*.h
-/source/slang/slang-lookup-capability-defs.cpp
+/source/slang/slang-lookup-*.cpp
 /source/slang/*.meta.slang.h
 prelude/*.h.cpp
 /source/slang/cpp.hint

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -1037,7 +1037,7 @@ namespace Slang
 
         case ASTNodeType::GloballyCoherentModifier:
         case ASTNodeType::HLSLVolatileModifier:
-            return as<VarDecl>(decl) && (as<StructDecl>(getParentDecl(decl)) || as<GLSLInterfaceBlockDecl>(decl));
+            return as<VarDecl>(decl) && (isGlobalDecl(decl) || as<StructDecl>(getParentDecl(decl)) || as<GLSLInterfaceBlockDecl>(decl));
 
             // Allowed only on parameters, struct fields and global variables.
         case ASTNodeType::InterpolationModeModifier:

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -1033,8 +1033,11 @@ namespace Slang
         case ASTNodeType::RayPayloadAccessSemantic:
         case ASTNodeType::RayPayloadReadSemantic:
         case ASTNodeType::RayPayloadWriteSemantic:
-        case ASTNodeType::GloballyCoherentModifier:
             return (as<VarDeclBase>(decl) && isGlobalDecl(decl)) || as<ParamDecl>(decl) || as<GLSLInterfaceBlockDecl>(decl);
+
+        case ASTNodeType::GloballyCoherentModifier:
+        case ASTNodeType::HLSLVolatileModifier:
+            return as<VarDecl>(decl) && (as<StructDecl>(getParentDecl(decl)) || as<GLSLInterfaceBlockDecl>(decl));
 
             // Allowed only on parameters, struct fields and global variables.
         case ASTNodeType::InterpolationModeModifier:
@@ -1090,7 +1093,6 @@ namespace Slang
         case ASTNodeType::HLSLColumnMajorLayoutModifier:
         case ASTNodeType::GLSLRowMajorLayoutModifier:
         case ASTNodeType::HLSLEffectSharedModifier:
-        case ASTNodeType::HLSLVolatileModifier:
             return as<VarDeclBase>(decl) || as<GLSLInterfaceBlockDecl>(decl);
 
         case ASTNodeType::GLSLPrecisionModifier:

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -179,7 +179,7 @@ void GLSLSourceEmitter::_emitGLSLStructuredBuffer(IRGlobalParam* varDecl, IRHLSL
             m_writer->emit(space);
         }
     }
-
+    
     m_writer->emit(") ");
 
     /*
@@ -194,7 +194,10 @@ void GLSLSourceEmitter::_emitGLSLStructuredBuffer(IRGlobalParam* varDecl, IRHLSL
     HLSLAppendStructuredBufferType                  - Write
     HLSLConsumeStructuredBufferType                 - TODO (JS): Its possible that this can be readonly, but we currently don't support on GLSL
     */
-
+    if (varDecl->findDecoration<IRGloballyCoherentDecoration>())
+    {
+        m_writer->emit("coherent ");
+    }
     if (as<IRHLSLStructuredBufferType>(structuredBufferType))
     {
         m_writer->emit("readonly ");
@@ -264,8 +267,12 @@ void GLSLSourceEmitter::_emitGLSLByteAddressBuffer(IRGlobalParam* varDecl, IRByt
             m_writer->emit(space);
         }
     }
-
     m_writer->emit(") ");
+
+    if (varDecl->findDecoration<IRGloballyCoherentDecoration>())
+    {
+        m_writer->emit("coherent ");
+    }
 
     /*
     If the output type is a buffer, and we can determine it is only readonly we can prefix before

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1836,6 +1836,14 @@ struct SPIRVEmitContext
                     varInst,
                     SpvLiteralInteger::from32(int32_t(index))
                 );
+                if (space != 0)
+                {
+                    emitOpDecorateIndex(
+                        getSection(SpvLogicalSectionID::Annotations),
+                        nullptr,
+                        varInst,
+                        SpvLiteralInteger::from32(int32_t(space)));
+                }
                 break;
             case LayoutResourceKind::VaryingOutput:
                 emitOpDecorateLocation(
@@ -1844,6 +1852,14 @@ struct SPIRVEmitContext
                     varInst,
                     SpvLiteralInteger::from32(int32_t(index))
                 );
+                if (space != 0)
+                {
+                    emitOpDecorateIndex(
+                        getSection(SpvLogicalSectionID::Annotations),
+                        nullptr,
+                        varInst,
+                        SpvLiteralInteger::from32(int32_t(space)));
+                }
                 break;
 
             case LayoutResourceKind::SpecializationConstant:
@@ -2744,10 +2760,10 @@ struct SPIRVEmitContext
                     default:
                         break;
                     }
-                    if (entryPointDecor->getProfile().getStage() == Stage::Fragment)
-                    {
-                        maybeEmitEntryPointDepthReplacingExecutionMode(entryPoint, referencedBuiltinIRVars);
-                    }
+                }
+                if (entryPointDecor->getProfile().getStage() == Stage::Fragment)
+                {
+                    maybeEmitEntryPointDepthReplacingExecutionMode(entryPoint, referencedBuiltinIRVars);
                 }
                 // Add remaining builtin variables that does not have a corresponding IR global var/param.
                 // These variables could be added from SPIRV ASM blocks.

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -717,6 +717,21 @@ struct ByteAddressBufferLegalizationContext
         return structuredBufferParam;
     }
 
+    void cloneBufferDecorations(IRBuilder& builder, IRInst* dest, IRInst* src)
+    {
+        for (auto decoration : src->getDecorations())
+        {
+            switch (decoration->getOp())
+            {
+            case kIROp_GloballyCoherentDecoration:
+                builder.addDecoration(dest, decoration->getOp());
+                break;
+            default:
+                break;
+            }
+        }
+    }
+
     IRGlobalParam* createEquivalentStructuredBufferParam(IRType* elementType, IRGlobalParam* byteAddressBufferParam)
     {
         // When we need to create a new structured buffer to stand in for
@@ -751,7 +766,7 @@ struct ByteAddressBufferLegalizationContext
         {
             paramBuilder.addLayoutDecoration(structuredBufferParam, layoutDecoration->getLayout());
         }
-
+        cloneBufferDecorations(paramBuilder, structuredBufferParam, byteAddressBufferParam);
         return structuredBufferParam;
     }
 

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -1200,10 +1200,6 @@ ScalarizedVal createSimpleGLSLGlobalVarying(
 
     auto globalParam = addGlobalParam(builder->getModule(), paramType);
     moveValueBefore(globalParam, builder->getFunc());
-    if (nameHintSB.getLength())
-    {
-        builder->addNameHintDecoration(globalParam, nameHintSB.getUnownedSlice());
-    }
 
     ScalarizedVal val = isOutput ? ScalarizedVal::address(globalParam) : ScalarizedVal::value(globalParam);
 
@@ -1224,6 +1220,13 @@ ScalarizedVal createSimpleGLSLGlobalVarying(
 
                 val = ScalarizedVal::typeAdapter(typeAdapter);
             }
+        }
+    }
+    else
+    {
+        if (nameHintSB.getLength())
+        {
+            builder->addNameHintDecoration(globalParam, nameHintSB.getUnownedSlice());
         }
     }
 

--- a/source/slang/slang-ir-lower-buffer-element-type.cpp
+++ b/source/slang/slang-ir-lower-buffer-element-type.cpp
@@ -515,7 +515,7 @@ namespace Slang
                     elementType = constBuffer->getElementType();
                 if (as<IRTextureBufferType>(globalInst))
                     continue;
-                if (!as<IRStructType>(elementType) && !as<IRMatrixType>(elementType) && !as<IRArrayType>(elementType))
+                if (!as<IRStructType>(elementType) && !as<IRMatrixType>(elementType) && !as<IRArrayType>(elementType) && !as<IRBoolType>(elementType))
                     continue;
                 bufferTypeInsts.add(BufferTypeInfo{ (IRType*)globalInst, elementType });
             }

--- a/tests/bindings/glsl-parameter-blocks.slang.glsl
+++ b/tests/bindings/glsl-parameter-blocks.slang.glsl
@@ -18,14 +18,14 @@ layout(binding = 2)
 uniform sampler gTest_s_0;
 
 layout(location = 0)
-out vec4 _S2;
+out vec4 main_0;
 
 layout(location = 0)
-in vec2 _S3;
+in vec2 uv_0;
 
 void main()
 {
-    _S2 = gTest_0.a_0 + (texture(sampler2D(gTest_t_0,gTest_s_0), (_S3)));
+    main_0 = gTest_0.a_0 + (texture(sampler2D(gTest_t_0,gTest_s_0), (uv_0)));
     return;
 }
 

--- a/tests/bugs/gh-841.slang
+++ b/tests/bugs/gh-841.slang
@@ -1,6 +1,5 @@
 // gh-841.slang
 
-//TEST:CROSS_COMPILE: -profile ps_5_0 -entry main -target spirv-assembly
 //TEST:CROSS_COMPILE(filecheck=SPV): -profile ps_5_0 -entry main -target spirv-assembly
 //TEST:CROSS_COMPILE(filecheck=GLSL): -profile ps_5_0 -entry main -target glsl
 

--- a/tests/bugs/gh-941.slang.glsl
+++ b/tests/bugs/gh-941.slang.glsl
@@ -21,11 +21,11 @@ layout(binding = 1)
 uniform sampler s_0;
 
 layout(location = 0)
-out vec4 _S2;
+out vec4 main_0;
 
 void main()
 {
-    _S2 = (texture(sampler2D(t_0[C_0.index_0],s_0), (C_0.uv_0)));
+    main_0 = (texture(sampler2D(t_0[C_0.index_0],s_0), (C_0.uv_0)));
     return;
 }
 

--- a/tests/bugs/vk-image-atomics.slang.glsl
+++ b/tests/bugs/vk-image-atomics.slang.glsl
@@ -5,12 +5,12 @@ layout(binding = 0)
 uniform uimage2D t_0;
 
 layout(location = 0)
-out vec4 _S1;
+out vec4 main_0;
 
 void main()
 {
     uint u_0;
     u_0 = imageAtomicAdd(t_0, ivec2(uvec2(0)), 1);
-    _S1 = vec4(u_0);
+    main_0 = vec4(u_0);
     return;
 }

--- a/tests/bugs/vk-structured-buffer-binding.hlsl.glsl
+++ b/tests/bugs/vk-structured-buffer-binding.hlsl.glsl
@@ -10,14 +10,14 @@ layout(std430, binding = 3, set = 4) buffer StructuredBuffer_uint_t_0 {
 } gDoneGroups_0;
 
 layout(location = 0)
-out vec4 _S1;
+out vec4 main_0;
 
 layout(location = 0)
-in vec3 _S2;
+in vec3 uv_0;
 
 void main()
 {
-    _S1 = vec4(float(gDoneGroups_0._data[uint(int(_S2.z))]));
+    main_0 = vec4(float(gDoneGroups_0._data[uint(int(uv_0.z))]));
     return;
 }
 

--- a/tests/compute/half-texture.slang
+++ b/tests/compute/half-texture.slang
@@ -26,14 +26,14 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     half2 h2 = halfTexture2.Sample(s, uv);
     half4 h4 = halfTexture4.Sample(s, uv);
 #else
-    // CHECK: OpImageRead
-    // CHECK: OpFConvert %half
+    // CHECK: {{.*}} = OpImageRead
+    // CHECK: {{.*}} = OpFConvert %half
     half h = halfTexture[pos2];
-    // CHECK: OpImageRead
-    // CHECK: OpFConvert %half
+    // CHECK: {{.*}} = OpImageRead
+    // CHECK: {{.*}} = OpFConvert %v2half
     half2 h2 = halfTexture2[pos2];
-    // CHECK: OpImageRead
-    // CHECK: OpFConvert %half
+    // CHECK: {{.*}} = OpImageRead
+    // CHECK: {{.*}} = OpFConvert %v4half
     half4 h4 = halfTexture4[pos2];
 #endif
     // Store a results

--- a/tests/compute/half-texture.slang
+++ b/tests/compute/half-texture.slang
@@ -1,4 +1,4 @@
-//TEST:CROSS_COMPILE: -target spirv -entry computeMain -profile cs_6_2
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -entry computeMain -profile cs_6_2
 //TEST:CROSS_COMPILE: -target dxil-assembly -entry computeMain -profile cs_6_2
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=16):out
@@ -26,8 +26,14 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     half2 h2 = halfTexture2.Sample(s, uv);
     half4 h4 = halfTexture4.Sample(s, uv);
 #else
-    half  h = halfTexture[pos2];
+    // CHECK: OpImageRead
+    // CHECK: OpFConvert %half
+    half h = halfTexture[pos2];
+    // CHECK: OpImageRead
+    // CHECK: OpFConvert %half
     half2 h2 = halfTexture2[pos2];
+    // CHECK: OpImageRead
+    // CHECK: OpFConvert %half
     half4 h4 = halfTexture4[pos2];
 #endif
     // Store a results

--- a/tests/cross-compile/array-of-buffers.slang.glsl
+++ b/tests/cross-compile/array-of-buffers.slang.glsl
@@ -30,10 +30,10 @@ layout(std430, binding = 4) readonly buffer StructuredBuffer_uint_t_0 {
     uint _data[];
 } bb_0[6];
 layout(location = 0)
-out vec4 _S3;
+out vec4 main_0;
 
 void main()
 {
-    _S3 = cb_0[C_0.index_0].f_0 + sb1_0[C_0.index_0]._data[C_0.index_0].f_0 + sb2_0[C_0.index_0]._data[C_0.index_0] + vec4(float(bb_0[C_0.index_0]._data[int(C_0.index_0 * 4U) / 4]));
+    main_0 = cb_0[C_0.index_0].f_0 + sb1_0[C_0.index_0]._data[C_0.index_0].f_0 + sb2_0[C_0.index_0]._data[C_0.index_0] + vec4(float(bb_0[C_0.index_0]._data[int(C_0.index_0 * 4U) / 4]));
     return;
 }

--- a/tests/cross-compile/barycentrics-nv.slang.glsl
+++ b/tests/cross-compile/barycentrics-nv.slang.glsl
@@ -3,10 +3,10 @@
 #extension GL_NV_fragment_shader_barycentric : enable
 
 layout(location = 0)
-out vec4 _S1;
+out vec4 main_0;
 
 void main()
 {
-    _S1 = vec4(gl_BaryCoordNV, float(0));
+    main_0 = vec4(gl_BaryCoordNV, float(0));
     return;
 }

--- a/tests/cross-compile/barycentrics.slang.glsl
+++ b/tests/cross-compile/barycentrics.slang.glsl
@@ -3,10 +3,10 @@
 #extension GL_EXT_fragment_shader_barycentric : enable
 
 layout(location = 0)
-out vec4 _S1;
+out vec4 main_0;
 
 void main()
 {
-    _S1 = vec4(gl_BaryCoordEXT, float(0));
+    main_0 = vec4(gl_BaryCoordEXT, float(0));
     return;
 }

--- a/tests/cross-compile/dual-source-blending.slang.glsl
+++ b/tests/cross-compile/dual-source-blending.slang.glsl
@@ -5,13 +5,13 @@ layout(row_major) uniform;
 layout(row_major) buffer;
 
 layout(location = 0)
-out vec4 _S1;
+out vec4 main_a_0;
 
 layout(location = 0, index = 1)
-out vec4 _S2;
+out vec4 main_b_0;
 
 layout(location = 0)
-in vec4 _S3;
+in vec4 v_0;
 
 struct FragmentOutput_0
 {
@@ -21,17 +21,17 @@ struct FragmentOutput_0
 
 void main()
 {
-    const vec4 _S4 = vec4(0.0, 0.0, 0.0, 0.0);
+    const vec4 _S1 = vec4(0.0, 0.0, 0.0, 0.0);
     FragmentOutput_0 f_0;
 
-    f_0.a_0 = _S4;
+    f_0.a_0 = _S1;
 
-    f_0.b_0 = _S4;
-    f_0.a_0 = _S3;
-    f_0.b_0 = _S3;
-    FragmentOutput_0 _S5 = f_0;
-    _S1 = f_0.a_0;
-    _S2 = _S5.b_0;
+    f_0.b_0 = _S1;
+    f_0.a_0 = v_0;
+    f_0.b_0 = v_0;
+    FragmentOutput_0 _S2 = f_0;
+    main_a_0 = f_0.a_0;
+    main_b_0 = _S2.b_0;
 
     return;
 }

--- a/tests/cross-compile/early-depth-stencil.hlsl.glsl
+++ b/tests/cross-compile/early-depth-stencil.hlsl.glsl
@@ -5,12 +5,12 @@ layout(row_major) buffer;
 
 #line 5 0
 layout(location = 0)
-out vec4 _S1;
+out vec4 main_0;
 
 #line 5
 layout(early_fragment_tests) in;
 void main()
 {
-    _S1 = vec4(float(1), float(0), float(0), float(1));
+    main_0 = vec4(float(1), float(0), float(0), float(1));
     return;
 }

--- a/tests/cross-compile/geometry-shader.slang
+++ b/tests/cross-compile/geometry-shader.slang
@@ -1,6 +1,7 @@
 // geometry-shader.slang
 
-//TEST:CROSS_COMPILE: -profile sm_5_0 -stage geometry -entry main -target spirv-assembly
+//TEST:SIMPLE(filecheck=CHECK): -profile sm_5_0 -stage geometry -entry main -target glsl
+//TEST:SIMPLE(filecheck=SPIRV): -profile sm_5_0 -stage geometry -entry main -target spirv
 
 struct CoarseVertex
 {
@@ -15,6 +16,11 @@ struct RasterVertex
     float3 color    : COLOR;
     uint   id       : SV_RenderTargetArrayIndex;
 }
+
+// SPIRV: OpEntryPoint
+// CHECK: void main()
+// CHECK: gl_Layer =
+// CHECK: EmitVertex();
 
 [maxvertexcount(3)]
 void main(

--- a/tests/cross-compile/geometry-shader.slang.glsl
+++ b/tests/cross-compile/geometry-shader.slang.glsl
@@ -5,11 +5,11 @@
 #define RasterVertex RasterVertex_0
 #define CoarseVertex CoarseVertex_0
 
-#define input_position  _S1
-#define input_color     _S2
-#define input_id        _S3
-#define output_position _S4
-#define output_color    _S5
+#define input_position  coarseVertices_position_0
+#define input_color     coarseVertices_color_0
+#define input_id        coarseVertices_id_0
+#define output_position outputStream_position_0
+#define output_color    outputStream_color_0
 
 layout(row_major) uniform;
 layout(row_major) buffer;

--- a/tests/cross-compile/glsl-empty-struct-param-field.slang.glsl
+++ b/tests/cross-compile/glsl-empty-struct-param-field.slang.glsl
@@ -14,10 +14,10 @@ layout(std140) uniform _S1
     vec4 param_0;
 } pblock_0;
 layout(location = 0)
-out vec4 _S2;
+out vec4 main_0;
 
 void main()
 {
-    _S2 = pblock_0.param_0;
+    main_0 = pblock_0.param_0;
     return;
 }

--- a/tests/cross-compile/glsl-generic-in.slang
+++ b/tests/cross-compile/glsl-generic-in.slang
@@ -1,4 +1,7 @@
-//TEST:CROSS_COMPILE:-target spirv-assembly -entry main -profile vs_5_0
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-assembly -entry main -profile vs_5_0
+// CHECK: vIn_field_v0_0 = OpVariable %_ptr_Input_v4float Input
+// CHECK: %vIn_field_v1_0 = OpVariable %_ptr_Input_v2float Input
+// CHECK: %vIn_p0_0 = OpVariable %_ptr_Input_v3float Input
 interface IField
 {
 	float get();

--- a/tests/cross-compile/glsl-generic-in.slang.glsl
+++ b/tests/cross-compile/glsl-generic-in.slang.glsl
@@ -18,10 +18,10 @@ float E_get_0()
 }
 
 layout(location = 0)
-in vec3 _S1;
+in vec3 vIn_p0_0;
 
 layout(location = 1)
-in vec4 _S2;
+in vec4 vIn_field_v0_0;
 
 layout(location = 2)
 in vec2 _S3;
@@ -32,9 +32,9 @@ struct VOut_0
 };
 void main()
 {
-    F_0 _S4 = { _S2, _S3 };
+    F_0 _S4 = { vIn_field_v0_0, _S3 };
     VOut_0 vout_0;
-    vout_0.projPos_0 = vec4(_S1, F_get_0(_S4) + E_get_0());
+    vout_0.projPos_0 = vec4(vIn_p0_0, F_get_0(_S4) + E_get_0());
     gl_Position = vout_0.projPos_0;
     return;
 }

--- a/tests/cross-compile/glsl-samplecmplevelzero.slang
+++ b/tests/cross-compile/glsl-samplecmplevelzero.slang
@@ -1,7 +1,7 @@
 //TEST:CROSS_COMPILE(filecheck=CHECK): -profile ps_5_0 -entry main -target glsl
 
-// CHECK: float _S3 = (textureLod(sampler2DShadow(shadowMap_0,sampler_0), (_S2), 0));
-// CHECK: float _S4 = (textureLodOffset(sampler2DShadow(shadowMap_0,sampler_0), (_S2), 0, (ivec2(1, 1))));
+// CHECK: float {{.*}} = (textureLod(sampler2DShadow(shadowMap_0,sampler_0), ({{.*}}), 0));
+// CHECK: float {{.*}} = (textureLodOffset(sampler2DShadow(shadowMap_0,sampler_0), ({{.*}}), 0, (ivec2(1, 1))));
 
 Texture2D shadowMap;
 SamplerComparisonState sampler;

--- a/tests/cross-compile/half-conversion.slang.glsl
+++ b/tests/cross-compile/half-conversion.slang.glsl
@@ -31,10 +31,10 @@ vec4 f16tof32_0(uvec4 value_0)
 }
 
 layout(location = 0)
-out vec4 _S2;
+out vec4 main_0;
 
 void main()
 {
-    _S2 = f16tof32_0(C_0.u_0);
+    main_0 = f16tof32_0(C_0.u_0);
     return;
 }

--- a/tests/cross-compile/non-uniform-indexing.slang.glsl
+++ b/tests/cross-compile/non-uniform-indexing.slang.glsl
@@ -9,14 +9,14 @@ layout(binding = 1)
 uniform sampler s_0;
 
 layout(location = 0)
-out vec4 _S1;
+out vec4 main_0;
 
 layout(location = 0)
-in vec3 _S2;
+in vec3 uv_0;
 
 void main()
 {
-    _S1 = (texture(sampler2D(t_0[nonuniformEXT(int(_S2.z))],s_0), (_S2.xy)));
+    main_0 = (texture(sampler2D(t_0[nonuniformEXT(int(uv_0.z))],s_0), (uv_0.xy)));
     return;
 }
 

--- a/tests/cross-compile/precise-keyword.slang
+++ b/tests/cross-compile/precise-keyword.slang
@@ -1,10 +1,12 @@
 // precise-keyword.slang
 
-//TEST:CROSS_COMPILE:-target spirv-assembly -entry main -stage fragment
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv-assembly -entry main -stage fragment
 //TEST:CROSS_COMPILE:-target dxbc-assembly  -entry main -stage fragment
 //TEST:CROSS_COMPILE:-target dxil-assembly  -entry main -stage fragment -profile sm_6_0
 
 // Test handling of the `precise` keyword
+
+// SPIRV: OpEntryPoint
 
 float4 main(float2 v : V) : SV_Target
 {

--- a/tests/cross-compile/sign.slang.glsl
+++ b/tests/cross-compile/sign.slang.glsl
@@ -3,10 +3,10 @@ layout(row_major) uniform;
 layout(row_major) buffer;
 
 layout(location = 0)
-out vec4 _S1;
+out vec4 main_0;
 
 void main()
 {
-    _S1 = vec4((ivec4(sign((vec4(1.5, 1.0, -1.5, -1.0))))));
+    main_0 = vec4((ivec4(sign((vec4(1.5, 1.0, -1.5, -1.0))))));
     return;
 }

--- a/tests/cross-compile/sv-coverage.slang.glsl
+++ b/tests/cross-compile/sv-coverage.slang.glsl
@@ -2,15 +2,15 @@
 #version 450
 
 layout(location = 0)
-out vec4 _S1;
+out vec4 main_0;
 
 layout(location = 0)
-in vec4 _S2;
+in vec4 color_0;
 
 void main()
 {
-    uint _S3 = uint(gl_SampleMaskIn[0]) ^ uint(1);
-    _S1 = _S2;
-    gl_SampleMask[0] = int(_S3);
+    uint _S1 = uint(gl_SampleMaskIn[0]) ^ uint(1);
+    main_0 = color_0;
+    gl_SampleMask[0] = int(_S1);
     return;
 }

--- a/tests/cross-compile/unknown-image-format.slang.glsl
+++ b/tests/cross-compile/unknown-image-format.slang.glsl
@@ -39,7 +39,7 @@ layout(binding = 4)
 uniform image2D entryPointParams_explicitFormat_0;
 
 layout(location = 0)
-out vec4 _S2;
+out vec4 main_0;
 
 void main()
 {
@@ -60,7 +60,7 @@ void main()
     vec4 result_3 = result_2 + _S8;
 
     vec4 _S9 = (imageLoad((entryPointParams_explicitFormat_0), ivec2((C_0.index_0))));
-    _S2 = result_3 + _S9;
+    main_0 = result_3 + _S9;
 
     return;
 }

--- a/tests/cross-compile/vector-comparison.slang.glsl
+++ b/tests/cross-compile/vector-comparison.slang.glsl
@@ -14,13 +14,13 @@ layout(std140) uniform _S1
     vec4 b_0;
 } params_0;
 layout(location = 0)
-out vec4 _S2;
+out vec4 main_0;
 
 void main()
 {
 
     const vec4 _S3 = vec4(2.0);
     const vec4 _S4 = vec4(3.0);
-    _S2 = mix(_S4, _S3, (equal(params_0.a_0,params_0.b_0))) + mix(_S4, _S3, (lessThan(params_0.a_0,params_0.b_0))) + mix(_S4, _S3, (greaterThan(params_0.a_0,params_0.b_0))) + mix(_S4, _S3, (lessThanEqual(params_0.a_0,params_0.b_0))) + mix(_S4, _S3, (greaterThanEqual(params_0.a_0,params_0.b_0))) + mix(_S4, _S3, (notEqual(params_0.a_0,params_0.b_0)));
+    main_0 = mix(_S4, _S3, (equal(params_0.a_0,params_0.b_0))) + mix(_S4, _S3, (lessThan(params_0.a_0,params_0.b_0))) + mix(_S4, _S3, (greaterThan(params_0.a_0,params_0.b_0))) + mix(_S4, _S3, (lessThanEqual(params_0.a_0,params_0.b_0))) + mix(_S4, _S3, (greaterThanEqual(params_0.a_0,params_0.b_0))) + mix(_S4, _S3, (notEqual(params_0.a_0,params_0.b_0)));
     return;
 }

--- a/tests/cross-compile/vk-push-constant-set.slang.glsl
+++ b/tests/cross-compile/vk-push-constant-set.slang.glsl
@@ -19,10 +19,10 @@ layout(std140) uniform _S2
 } y_0;
 
 layout(location = 0)
-out vec4 _S3;
+out vec4 main_0;
 
 void main()
 {
-    _S3 = x_0.v_0 + y_0.v_0;
+    main_0 = x_0.v_0 + y_0.v_0;
     return;
 }

--- a/tests/expected-failure.txt
+++ b/tests/expected-failure.txt
@@ -1,0 +1,6 @@
+tests/language-feature/saturated-cooperation/simple.slang (vk)
+tests/language-feature/saturated-cooperation/fuse3.slang (vk)
+tests/language-feature/saturated-cooperation/fuse-product.slang (vk)
+tests/language-feature/saturated-cooperation/fuse.slang (vk)
+tests/bugs/byte-address-buffer-interlocked-add-f32.slang (vk)
+tests/ir/loop-unroll-0.slang.1 (vk)

--- a/tests/language-feature/saturated-cooperation/fuse-product.slang
+++ b/tests/language-feature/saturated-cooperation/fuse-product.slang
@@ -1,5 +1,5 @@
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX():-vk -compute -shaderobj -output-using-type -render-features wave-ops
-//TEST(compute):COMPARE_COMPUTE_EX():-dx12 -profile sm_6_5 -use-dxil -compute -shaderobj -output-using-type -render-features wave-ops
+//DISABLED_TEST(compute, vulkan):COMPARE_COMPUTE_EX():-vk -compute -shaderobj -output-using-type -render-features wave-ops
+//DISABLED_TEST(compute):COMPARE_COMPUTE_EX():-dx12 -profile sm_6_5 -use-dxil -compute -shaderobj -output-using-type -render-features wave-ops
 //TEST:SIMPLE(filecheck=CHECK):-target hlsl -profile cs_6_5 -entry computeMain -line-directive-mode none
 //TEST:SIMPLE(filecheck=CHECK):-target glsl -profile cs_6_5 -entry computeMain -line-directive-mode none
 

--- a/tests/language-feature/saturated-cooperation/fuse.slang
+++ b/tests/language-feature/saturated-cooperation/fuse.slang
@@ -1,5 +1,5 @@
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX():-vk -compute -shaderobj -output-using-type -render-features wave-ops
-//TEST(compute):COMPARE_COMPUTE_EX():-dx12 -profile sm_6_5 -use-dxil -compute -shaderobj -output-using-type -render-features wave-ops
+//DISABLED_TEST(compute, vulkan):COMPARE_COMPUTE_EX():-vk -compute -shaderobj -output-using-type -render-features wave-ops
+//DISABLED_TEST(compute):COMPARE_COMPUTE_EX():-dx12 -profile sm_6_5 -use-dxil -compute -shaderobj -output-using-type -render-features wave-ops
 
 //
 // This test checks whether adjacent calls to saturated_cooperation are fused

--- a/tests/language-feature/saturated-cooperation/fuse3.slang
+++ b/tests/language-feature/saturated-cooperation/fuse3.slang
@@ -1,5 +1,5 @@
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX():-vk -compute -shaderobj -output-using-type -render-features wave-ops
-//TEST(compute):COMPARE_COMPUTE_EX():-dx12 -profile sm_6_5 -use-dxil -compute -shaderobj -output-using-type -render-features wave-ops
+//DISABLED_TEST(compute, vulkan):COMPARE_COMPUTE_EX():-vk -compute -shaderobj -output-using-type -render-features wave-ops
+//DISABLED_TEST(compute):COMPARE_COMPUTE_EX():-dx12 -profile sm_6_5 -use-dxil -compute -shaderobj -output-using-type -render-features wave-ops
 
 //
 // This test checks whether more than 2 adjacent calls to saturated_cooperation

--- a/tests/language-feature/saturated-cooperation/simple.slang
+++ b/tests/language-feature/saturated-cooperation/simple.slang
@@ -1,5 +1,5 @@
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX():-vk -compute -shaderobj -output-using-type -render-features wave-ops
-//TEST(compute):COMPARE_COMPUTE_EX():-dx12 -profile sm_6_5 -use-dxil -compute -shaderobj -output-using-type -render-features wave-ops
+//DISABLED_TEST(compute, vulkan):COMPARE_COMPUTE_EX():-vk -compute -shaderobj -output-using-type -render-features wave-ops
+//DISABLED_TEST(compute):COMPARE_COMPUTE_EX():-dx12 -profile sm_6_5 -use-dxil -compute -shaderobj -output-using-type -render-features wave-ops
 
 //TEST_INPUT:ubuffer(data=[0 3 2 2], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;

--- a/tests/pipeline/rasterization/get-attribute-at-vertex-nv.slang.glsl
+++ b/tests/pipeline/rasterization/get-attribute-at-vertex-nv.slang.glsl
@@ -7,13 +7,13 @@ layout(row_major) uniform;
 layout(row_major) buffer;
 
 pervertexNV layout(location = 0)
-in vec4  _S1[3];
+in vec4  color_0[3];
 
 layout(location = 0)
-out vec4 _S2;
+out vec4 result_0;
 
 void main()
 {
-    _S2 = gl_BaryCoordNV.x * ((_S1)[(0U)]) + gl_BaryCoordNV.y * ((_S1)[(1U)]) + gl_BaryCoordNV.z * ((_S1)[(2U)]);
+    result_0 = gl_BaryCoordNV.x * ((color_0)[(0U)]) + gl_BaryCoordNV.y * ((color_0)[(1U)]) + gl_BaryCoordNV.z * ((color_0)[(2U)]);
     return;
 }

--- a/tests/pipeline/rasterization/get-attribute-at-vertex.slang.glsl
+++ b/tests/pipeline/rasterization/get-attribute-at-vertex.slang.glsl
@@ -7,13 +7,13 @@ layout(row_major) uniform;
 layout(row_major) buffer;
 
 pervertexEXT layout(location = 0)
-in vec4  _S1[3];
+in vec4  color_0[3];
 
 layout(location = 0)
-out vec4 _S2;
+out vec4 result_0;
 
 void main()
 {
-    _S2 = gl_BaryCoordEXT.x * ((_S1)[(0U)]) + gl_BaryCoordEXT.y * ((_S1)[(1U)]) + gl_BaryCoordEXT.z * ((_S1)[(2U)]);
+    result_0 = gl_BaryCoordEXT.x * ((color_0)[(0U)]) + gl_BaryCoordEXT.y * ((color_0)[(1U)]) + gl_BaryCoordEXT.z * ((color_0)[(2U)]);
     return;
 }

--- a/tests/pipeline/rasterization/mesh/component-write.slang.glsl
+++ b/tests/pipeline/rasterization/mesh/component-write.slang.glsl
@@ -5,7 +5,7 @@ layout(row_major) buffer;
 const vec2  positions_0[3] = { vec2(0.0, -0.5), vec2(0.5, 0.5), vec2(-0.5, 0.5) };
 const vec3  colors_0[3] = { vec3(1.0, 1.0, 0.0), vec3(0.0, 1.0, 1.0), vec3(1.0, 0.0, 1.0) };
 layout(location = 0)
-out vec3  _S1[3];
+out vec3  verts_color_0[3];
 
 
 out gl_MeshPerVertexEXT
@@ -26,7 +26,7 @@ void main()
     if(gl_LocalInvocationIndex < 3U)
     {
         gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = vec4(positions_0[gl_LocalInvocationIndex], 0.0, 1.0);
-        _S1[gl_LocalInvocationIndex] = colors_0[gl_LocalInvocationIndex];
+        verts_color_0[gl_LocalInvocationIndex] = colors_0[gl_LocalInvocationIndex];
     }
     else
     {

--- a/tests/pipeline/rasterization/mesh/hlsl-syntax.slang.glsl
+++ b/tests/pipeline/rasterization/mesh/hlsl-syntax.slang.glsl
@@ -5,7 +5,7 @@ layout(row_major) buffer;
 const vec3  colors_0[3] = { vec3(1.0, 1.0, 0.0), vec3(0.0, 1.0, 1.0), vec3(1.0, 0.0, 1.0) };
 const vec2  positions_0[3] = { vec2(0.0, -0.5), vec2(0.5, 0.5), vec2(-0.5, 0.5) };
 layout(location = 0)
-out vec3  _S1[3];
+out vec3  verts_color_0[3];
 
 out gl_MeshPerVertexEXT
 {
@@ -19,7 +19,7 @@ void foo_0(uint _S2)
     if(_S2 < 3U)
     {
         gl_MeshVerticesEXT[_S2].gl_Position = vec4(positions_0[_S2], 0.0, 1.0);
-        _S1[_S2] = colors_0[_S2];
+        verts_color_0[_S2] = colors_0[_S2];
     }
     else
     {

--- a/tests/pipeline/rasterization/mesh/nested-component-write.slang.glsl
+++ b/tests/pipeline/rasterization/mesh/nested-component-write.slang.glsl
@@ -3,7 +3,7 @@
 layout(row_major) uniform;
 layout(row_major) buffer;
 layout(location = 0)
-out vec3  _S1[3];
+out vec3  verts_foo_bar_baz_color_0[3];
 
 out gl_MeshPerVertexEXT
 {
@@ -20,7 +20,7 @@ void main()
     if(gl_LocalInvocationIndex < 3U)
     {
         gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = vec4(0.00000000000000000000, 0.00000000000000000000, 0.00000000000000000000, 1.00000000000000000000);
-        _S1[gl_LocalInvocationIndex] = vec3(1.00000000000000000000, 2.00000000000000000000, 3.00000000000000000000);
+        verts_foo_bar_baz_color_0[gl_LocalInvocationIndex] = vec3(1.00000000000000000000, 2.00000000000000000000, 3.00000000000000000000);
     }
     else
     {

--- a/tests/pipeline/rasterization/mesh/passing-outputs.slang
+++ b/tests/pipeline/rasterization/mesh/passing-outputs.slang
@@ -2,13 +2,15 @@
 
 // This tests that writing to individual components of the output struct works
 
-//TEST:CROSS_COMPILE:-target spirv-assembly -entry main -stage mesh -profile glsl_450+spirv_1_4
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv-assembly -entry main -stage mesh -profile glsl_450+spirv_1_4
 
 // DXC is stricter than we are about passing references to individual mesh shader outputs
 // We could get around this by doing what we do for GLSL, i.e. use a temporary
 // variable to pass as the out parameter, and then copy that into the array
 // after the function call.
 //TEST_DISABLED:CROSS_COMPILE:-target dxil-assembly  -entry main -stage mesh -profile sm_6_6
+
+// SPIRV: OpEntryPoint MeshEXT %main
 
 const static uint MAX_VERTS = 3;
 const static uint MAX_PRIMS = 1;

--- a/tests/pipeline/rasterization/mesh/primitive-output.slang.glsl
+++ b/tests/pipeline/rasterization/mesh/primitive-output.slang.glsl
@@ -7,7 +7,7 @@ const vec3  colors_0[3] = { vec3(1.0, 1.0, 0.0), vec3(0.0, 1.0, 1.0), vec3(1.0, 
 out uvec3  gl_PrimitiveTriangleIndicesEXT[1];
 
 layout(location = 0)
-out vec3  _S1[3];
+out vec3  verts_color_0[3];
 
 out gl_MeshPerVertexEXT
 {
@@ -15,7 +15,7 @@ out gl_MeshPerVertexEXT
 } gl_MeshVerticesEXT[3];
 
 perprimitiveEXT layout(location = 1)
-out vec3  _S2[1];
+out vec3  primitives_triangleNormal_0[1];
 
 perprimitiveEXT out gl_MeshPerPrimitiveEXT
 {
@@ -34,7 +34,7 @@ void main()
     if(gl_LocalInvocationIndex < 3U)
     {
         gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = vec4(positions_0[gl_LocalInvocationIndex], 0.0, 1.0);
-        _S1[gl_LocalInvocationIndex] = colors_0[gl_LocalInvocationIndex];
+        verts_color_0[gl_LocalInvocationIndex] = colors_0[gl_LocalInvocationIndex];
     }
     else
     {
@@ -43,7 +43,7 @@ void main()
     if(gl_LocalInvocationIndex < 1U)
     {
         gl_PrimitiveTriangleIndicesEXT[gl_LocalInvocationIndex] = uvec3(0U, 1U, 2U);
-        _S2[gl_LocalInvocationIndex] = vec3(0.0, 0.0, 1.0);
+        primitives_triangleNormal_0[gl_LocalInvocationIndex] = vec3(0.0, 0.0, 1.0);
         gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveID = int(gl_LocalInvocationIndex);
         gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_CullPrimitiveEXT = false;
     }

--- a/tests/spirv/coherent-2.slang
+++ b/tests/spirv/coherent-2.slang
@@ -1,0 +1,15 @@
+// Test that globallycoherent works on arrays of uavs.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -stage compute -entry main -emit-spirv-directly
+
+globallycoherent RWByteAddressBuffer buffer[];
+
+RWStructuredBuffer<float> output;
+[numthreads(4,1,1)]
+void main(int tid : SV_DispatchThreadID)
+{
+    buffer[NonUniformResourceIndex(0)].InterlockedAdd(0, 1);
+    AllMemoryBarrier();
+    output[tid] = buffer[0].Load(0);
+    // CHECK-DAG: OpDecorate %buffer Coherent
+}

--- a/tests/spirv/coherent.slang
+++ b/tests/spirv/coherent.slang
@@ -6,7 +6,7 @@ struct S
 {
     globallycoherent int member;
 }
-RWStructuredBuffer<S> buffer;
+globallycoherent RWStructuredBuffer<S> buffer;
 
 RWStructuredBuffer<float> output;
 [numthreads(4,1,1)]
@@ -15,5 +15,6 @@ void main(int tid : SV_DispatchThreadID)
     InterlockedAdd(buffer[0].member, 1);
     AllMemoryBarrier();
     output[tid] = buffer[0].member;
-    // CHECK: OpMemberDecorate {{.*}} 0 Coherent
+    // CHECK-DAG: OpMemberDecorate {{.*}} 0 Coherent
+    // CHECK-DAG: OpDecorate %buffer Coherent
 }

--- a/tests/spirv/coherent.slang
+++ b/tests/spirv/coherent.slang
@@ -1,0 +1,19 @@
+// Test that globallycoherent works.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -stage compute -entry main -emit-spirv-directly
+
+struct S
+{
+    globallycoherent int member;
+}
+RWStructuredBuffer<S> buffer;
+
+RWStructuredBuffer<float> output;
+[numthreads(4,1,1)]
+void main(int tid : SV_DispatchThreadID)
+{
+    InterlockedAdd(buffer[0].member, 1);
+    AllMemoryBarrier();
+    output[tid] = buffer[0].member;
+    // CHECK: OpMemberDecorate {{.*}} 0 Coherent
+}

--- a/tests/spirv/varying-out-index.slang
+++ b/tests/spirv/varying-out-index.slang
@@ -1,0 +1,25 @@
+// Test that explicit binding of varying output works.
+
+//TEST:SIMPLE(filecheck=CHECK): -stage fragment -entry MainPS -target spirv -emit-spirv-directly
+
+struct PS_OUTPUT 
+{
+    [[vk::location(0) vk::index(0)]]    
+    float4 vColor : SV_Target0 ; 
+    
+    [[vk::location(0) vk::index(1)]] 
+    float4 vColor2 : SV_Target1 ; 
+    
+};
+
+// CHECK: OpDecorate %MainPS_vColor Location 0
+// CHECK: OpDecorate %MainPS_vColor2 Location 0
+// CHECK: OpDecorate %MainPS_vColor2 Index 1
+
+PS_OUTPUT MainPS()
+{
+    PS_OUTPUT output;
+    output.vColor = float4(1.0f, 0.0f, 0.0f, 1.0f);
+    output.vColor2 = float4(0.0f, 1.0f, 0.0f, 1.0f);
+    return output;
+}


### PR DESCRIPTION
Fixes #3482.

Also implements `[earlydepthstencil]`.

Fixing `StructuredBuffer<bool>`.