### PR TITLE
Improve Capability System

### DIFF
--- a/docs/user-guide/05-capabilities.md
+++ b/docs/user-guide/05-capabilities.md
@@ -63,17 +63,20 @@ For example, requirement `spvShaderClockKHR + fragment` and requirement `spvShad
 
 ## Requirements in Parent Scope
 
-The capability requirement of a decl is always joined with the requirements declared in its parents.
-For example:
+The capability requirement of a decl is always merged with the requirements declared in its parents. If the decl declares requirements for additional compilation targets, they are added
+to the requirement set as a separate disjunction.
+For example, given:
 ```csharp
-[require(spvShaderClockKHR)]
+[require(glsl)]
+[require(hlsl)]
 struct MyType
 {
-    [require(spvShaderClockKHR)]
-    void method() { ... }
+    [require(hlsl, hlsl_nvapi)]
+    [require(spirv)]
+    static void method() { ... }
 }
 ```
-`MyType.method` has requirement `spvShaderClockKHR + spvShaderClockKHR`.
+`MyType.method` will have requirement `glsl | hlsl + hlsl_nvapi | spirv`.
 
 The `[require]` attribute can also be used on module declarations, so that the requirement will
 apply to all decls within the module. For example:

--- a/docs/user-guide/05-capabilities.md
+++ b/docs/user-guide/05-capabilities.md
@@ -75,6 +75,20 @@ struct MyType
 ```
 `MyType.method` has requirement `spvShaderClockKHR + spvShaderClockKHR`.
 
+The `[require]` attribute can also be used on module declarations, so that the requirement will
+apply to all decls within the module. For example:
+```csharp
+[require(glsl)]
+[require(hlsl)]
+[require(spirv)]
+module myModule;
+
+// myFunc has requirement glsl|hlsl|spirv
+public void myFunc()
+{
+}
+```
+
 ## Inferrence of Capability Requirements
 
 By default, Slang will infer the capability requirements of a function given its definition, as long as the function has `internal` or `private` visibilty. For example, given:

--- a/source/compiler-core/slang-diagnostic-sink.cpp
+++ b/source/compiler-core/slang-diagnostic-sink.cpp
@@ -147,7 +147,7 @@ static void formatDiagnostic(const HumaneSourceLoc& humaneLoc, Diagnostic const&
 
     outBuilder << getSeverityName(diagnostic.severity);
 
-    if (diagnostic.ErrorID >= 0)
+    if ((flags & DiagnosticSink::Flag::LanguageServer) || diagnostic.ErrorID >= 0)
     {
         outBuilder << " ";
         outBuilder << diagnostic.ErrorID;

--- a/source/core/slang-string-util.cpp
+++ b/source/core/slang-string-util.cpp
@@ -727,6 +727,12 @@ int StringUtil::parseIntAndAdvancePos(UnownedStringSlice text, Index& pos)
         pos++;
         continue;
     }
+    bool isNeg = false;
+    if (pos < text.getLength() && text[pos] == '-')
+    {
+        pos++;
+        isNeg = true;
+    }
     while (pos < text.getLength())
     {
         if (text[pos] >= '0' && text[pos] <= '9')
@@ -740,6 +746,8 @@ int StringUtil::parseIntAndAdvancePos(UnownedStringSlice text, Index& pos)
             break;
         }
     }
+    if (isNeg)
+        result = -result;
     return result;
 }
 

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -506,7 +506,12 @@ class ImplementingDecl : public IncludeDeclBase
 
 class ModuleDeclarationDecl : public Decl
 {
-    SLANG_AST_CLASS(ModuleDeclarationDecl);
+    SLANG_AST_CLASS(ModuleDeclarationDecl)
+};
+
+class RequireCapabilityDecl : public Decl
+{
+    SLANG_AST_CLASS(RequireCapabilityDecl)
 };
 
 // A generic declaration, parameterized on types/values

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -61,6 +61,11 @@ def spirv_1_6 : spirv_1_5;
 alias spirv = spirv_1_0;
 alias spirv_latest = spirv_1_6;
 
+alias any_target = hlsl | glsl | c | cpp | cuda | spirv;
+alias any_textual_target = hlsl | glsl | c | cpp | cuda;
+alias any_gfx_target = hlsl | glsl | spirv;
+alias any_cpp_target = cpp | cuda;
+
 // Capabilities that stand for target spirv version for GLSL backend.
 // These are not compilation targets.
 def glsl_spirv_1_0 : glsl;

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -708,9 +708,12 @@ namespace Slang
 
         CapabilitySet getDeclaredCapabilitySet(Decl* decl);
 
-        void visitDecl(Decl*);
+
+        void visitDecl(Decl*) {}
         void visitDeclGroup(DeclGroup*) {}
         void checkVarDeclCommon(VarDeclBase* varDecl);
+        void visitAggTypeDeclBase(AggTypeDeclBase* decl);
+        void visitNamespaceDeclBase(NamespaceDeclBase* decl);
 
         void visitVarDecl(VarDecl* varDecl)
         {
@@ -8784,7 +8787,12 @@ namespace Slang
         return declaredCaps;
     }
 
-    void SemanticsDeclCapabilityVisitor::visitDecl(Decl* decl)
+    void SemanticsDeclCapabilityVisitor::visitAggTypeDeclBase(AggTypeDeclBase* decl)
+    {
+        decl->inferredCapabilityRequirements = getDeclaredCapabilitySet(decl);
+    }
+
+    void SemanticsDeclCapabilityVisitor::visitNamespaceDeclBase(NamespaceDeclBase* decl)
     {
         decl->inferredCapabilityRequirements = getDeclaredCapabilitySet(decl);
     }

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -370,7 +370,7 @@ DIAGNOSTIC(36005, Error, invalidVisibilityModifierOnTypeOfDecl, "visibility modi
 DIAGNOSTIC(36100, Error, conflictingCapabilityDueToUseOfDecl, "'$0' requires capability '$1' that is conflicting with the '$2''s current capability requirement '$3'.")
 DIAGNOSTIC(36101, Error, conflictingCapabilityDueToStatement, "statement requires capability '$0' that is conflicting with the '$1''s current capability requirement '$2'.")
 DIAGNOSTIC(36102, Error, conflictingCapabilityDueToStatementEnclosingFunc, "statement requires capability '$0' that is conflicting with the current function's capability requirement '$1'.")
-DIAGNOSTIC(36103, Error, missingCapabilityRequirementOnPublicDecl, "public symbol '$0' is missing capability requirement declaration.")
+DIAGNOSTIC(36103, Warning, missingCapabilityRequirementOnPublicDecl, "public symbol '$0' is missing capability requirement declaration, the symbol is assumed to require inferred capabilities '$1'.")
 DIAGNOSTIC(36104, Error, useOfUndeclaredCapability, "'$0' uses undeclared capability '$1'.")
 DIAGNOSTIC(36104, Error, useOfUndeclaredCapabilityOfInterfaceRequirement, "'$0' uses capability '$1' that is missing from the interface requirement.")
 DIAGNOSTIC(36105, Error, unknownCapability, "unknown capability name '$0'.")

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -47,6 +47,8 @@ DIAGNOSTIC(-1, Note, declaredHere, "declared here")
 DIAGNOSTIC(-1, Note, seeOtherDeclarationOf, "see other declaration of '$0'")
 DIAGNOSTIC(-1, Note, seePreviousDeclarationOf, "see previous declaration of '$0'")
 DIAGNOSTIC(-1, Note, includeOutput, "include $0")
+DIAGNOSTIC(-1, Note, genericSignatureTried, "see declaration of $0")
+DIAGNOSTIC(-1, Note, entryPointCandidate, "see candidate declaration for entry point '$0'")
 
 //
 // 0xxxx -  Command line and interaction with host platform APIs.
@@ -536,7 +538,6 @@ DIAGNOSTIC(39999, Error, defaultOutsideSwitch, "'default' not allowed outside of
 DIAGNOSTIC(39999, Error, expectedAGeneric, "expected a generic when using '<...>' (found: '$0')")
 
 DIAGNOSTIC(39999, Error, genericArgumentInferenceFailed, "could not specialize generic for arguments of type $0")
-DIAGNOSTIC(39999, Note, genericSignatureTried, "see declaration of $0")
 
 DIAGNOSTIC(39999, Error, ambiguousReference, "ambiguous reference to '$0'")
 DIAGNOSTIC(39999, Error, ambiguousExpression, "ambiguous reference")
@@ -564,7 +565,6 @@ DIAGNOSTIC(39999, Error, overloadedParameterToHigherOrderFunction, "passing over
 
 DIAGNOSTIC(38000, Error, entryPointFunctionNotFound, "no function found matching entry point name '$0'")
 DIAGNOSTIC(38001, Error, ambiguousEntryPoint, "more than one function matches entry point name '$0'")
-DIAGNOSTIC(38002, Note, entryPointCandidate, "see candidate declaration for entry point '$0'")
 DIAGNOSTIC(38003, Error, entryPointSymbolNotAFunction, "entry point '$0' must be declared as a function")
 
 DIAGNOSTIC(38004, Error, entryPointTypeParameterNotFound, "no type found matching entry-point type parameter name '$0'")

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -6945,6 +6945,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
     IGNORED_CASE(NamespaceDecl)
     IGNORED_CASE(ModuleDeclarationDecl)
     IGNORED_CASE(FileDecl)
+    IGNORED_CASE(RequireCapabilityDecl)
 
 #undef IGNORED_CASE
 

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -17,7 +17,10 @@ void printDiagnosticArg(StringBuilder& sb, Decl* decl)
 {
     if (!decl)
         return;
-    sb << getText(decl->getName());
+    if (decl->getName() && decl->getName()->text.getLength())
+        sb << getText(decl->getName());
+    else
+        printDiagnosticArg(sb, decl->astNodeType);
 }
 
 void printDiagnosticArg(StringBuilder& sb, DeclRefBase* declRefBase)
@@ -92,6 +95,7 @@ void printDiagnosticArg(StringBuilder& sb, ASTNodeType nodeType)
         case ASTNodeType::EmptyDecl: sb << "empty"; break;
         case ASTNodeType::SyntaxDecl: sb << "syntax"; break;
         case ASTNodeType::DeclGroup: sb << "decl-group"; break;
+        case ASTNodeType::RequireCapabilityDecl: sb << "__require_capability"; break;
         default: sb << "decl"; break;
     }
 }

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -866,6 +866,18 @@ Decl* getParentDecl(Decl* decl)
     return decl;
 }
 
+Decl* getParentAggTypeDecl(Decl* decl)
+{
+    decl = decl->parentDecl;
+    while (decl)
+    {
+        if (as<AggTypeDecl>(decl))
+            return decl;
+        decl = decl->parentDecl;
+    }
+    return nullptr;
+}
+
 Decl* getParentFunc(Decl* decl)
 {
     while (decl)

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -337,7 +337,7 @@ namespace Slang
 
         /// Get the parent decl, skipping any generic decls in between.
     Decl* getParentDecl(Decl* decl);
-
+    Decl* getParentAggTypeDecl(Decl* decl);
     Decl* getParentFunc(Decl* decl);
 
 } // namespace Slang

--- a/source/slang/slang-workspace-version.cpp
+++ b/source/slang/slang-workspace-version.cpp
@@ -194,6 +194,7 @@ void WorkspaceVersion::parseDiagnostics(String compilerOutput)
 {
     List<UnownedStringSlice> lines;
     StringUtil::calcLines(compilerOutput.getUnownedSlice(), lines);
+
     for (Index lineIndex = 0; lineIndex < lines.getCount(); lineIndex++)
     {
         auto line = lines[lineIndex];
@@ -272,7 +273,19 @@ void WorkspaceVersion::parseDiagnostics(String compilerOutput)
             diagnostic.range.end.line--;
             diagnostic.range.end.character--;
         }
-        diagnosticList.messages.add(diagnostic);
+        if (diagnostic.code == -1 && diagnosticList.messages.getCount())
+        {
+            // If this is a decoration message, add it as related information.
+            LanguageServerProtocol::DiagnosticRelatedInformation relatedInfo;
+            relatedInfo.location.range = diagnostic.range;
+            relatedInfo.location.uri = URI::fromLocalFilePath(fileName.getUnownedSlice()).uri;
+            relatedInfo.message = diagnostic.message;
+            diagnosticList.messages.getLast().relatedInformation.add(relatedInfo);
+        }
+        else
+        {
+            diagnosticList.messages.add(diagnostic);
+        }
         if (diagnosticList.messages.getCount() >= 1000)
             break;
     }

--- a/tests/diagnostics/extension-visibility.slang.expected
+++ b/tests/diagnostics/extension-visibility.slang.expected
@@ -3,7 +3,7 @@ standard error = {
 tests/diagnostics/extension-visibility.slang(17): error 39999: could not specialize generic for arguments of type (MyThing)
     return helper(thing);
                  ^
-tests/diagnostics/extension-visibility-a.slang(14): note 39999: see declaration of public func helper<T>(T) -> int
+tests/diagnostics/extension-visibility-a.slang(14): note: see declaration of public func helper<T>(T) -> int
 public int helper<T : IThing>(T thing)
            ^~~~~~
 }

--- a/tests/diagnostics/generic-type-inference-fail.slang.expected
+++ b/tests/diagnostics/generic-type-inference-fail.slang.expected
@@ -3,7 +3,7 @@ standard error = {
 tests/diagnostics/generic-type-inference-fail.slang(66): error 39999: could not specialize generic for arguments of type (int)
     var obj3 = CreateT_Assoc_Inner(1); // ERROR.
                                   ^
-tests/diagnostics/generic-type-inference-fail.slang(18): note 39999: see declaration of func CreateT_Assoc_Inner<T>(int) -> T.TAssoc
+tests/diagnostics/generic-type-inference-fail.slang(18): note: see declaration of func CreateT_Assoc_Inner<T>(int) -> T.TAssoc
 T.TAssoc CreateT_Assoc_Inner<T:IInterface>(int inVal)
          ^~~~~~~~~~~~~~~~~~~
 }

--- a/tests/language-feature/capability/capability3.slang
+++ b/tests/language-feature/capability/capability3.slang
@@ -1,0 +1,47 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-directly -entry main -stage compute
+
+// Test that capabilities can be declared on module.
+
+[require(glsl)]
+[require(spirv)]
+module test;
+
+void f()
+{
+    __require_capability glsl;
+}
+
+// CHECK: ([[# @LINE+1]]): error 36108
+public void g()
+{
+    __require_capability spvAtomicFloat16AddEXT;
+}
+
+void l()
+{
+    __target_switch
+    {
+    case glsl:
+        f();
+        return;
+    case spirv:
+        __require_capability spvAtomicFloat16AddEXT;
+        return;
+    }
+}
+
+// CHECK: ([[# @LINE+1]]): error 36104: {{.*}}
+public void use()
+{
+    l(); // Error
+}
+
+// CHECK-NOT: ([[# @LINE+1]]): error
+[require(spirv, spvAtomicFloat16AddEXT)]
+public void use1()
+{
+    l(); // Error
+}
+
+void main()
+{}

--- a/tests/language-feature/capability/capability4.slang
+++ b/tests/language-feature/capability/capability4.slang
@@ -1,0 +1,25 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-directly -entry main -stage compute
+
+// Check that a non-static member method implictly requires capabilities
+// defined in ThisType.
+
+[require(hlsl)]
+struct Type
+{
+    int member;
+    [require(glsl)]
+    [mutating]
+    // CHECK: ([[# @LINE+1]]): error 36108:
+    void f()
+    {
+    }
+
+    [require(glsl)]
+    // CHECK-NOT: ([[# @LINE+1]]): error 36108:
+    static void f1()
+    {
+    }
+}
+
+void main()
+{}


### PR DESCRIPTION
- Allow adding `[require]` attributes to module declarations.
- Add `__require_capability` decl that can be placed inside functions to introduce additional requirements for inference.
- Include requirements from `this` parameter in inference.