### PR TITLE
cmake: option to build a static library version of slang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ option(SLANG_ENABLE_TESTS "Enable test targets, requires SLANG_ENABLE_GFX, SLANG
 option(SLANG_ENABLE_EXAMPLES "Enable example targets, requires SLANG_ENABLE_GFX" ON)
 
 enum_option(
-    SLANG_BUILD_LIB_TYPE
+    SLANG_LIB_TYPE 
     # Default
     SHARED
     "How to build the slang lib:"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,18 @@ option(SLANG_EMBED_STDLIB "Build slang with an embedded version of the stdlib")
 option(SLANG_ENABLE_FULL_IR_VALIDATION "Enable full IR validation (SLOW!)")
 option(SLANG_ENABLE_ASAN "Enable ASAN (address sanitizer)")
 
+enum_option(
+    SLANG_BUILD_LIB_TYPE
+    # Default
+    SHARED
+    "How to build the slang lib:"
+    # Options
+    SHARED
+    "Build slang as a shared library (default)"
+    STATIC
+    "Build slang as a static library"
+)
+
 set(SLANG_GENERATORS_PATH
     ""
     CACHE PATH

--- a/cmake/SlangTarget.cmake
+++ b/cmake/SlangTarget.cmake
@@ -241,6 +241,13 @@ function(slang_add_target dir type)
                 PUBLIC "${ARG_EXPORT_MACRO_PREFIX}_DYNAMIC"
                 PRIVATE "${ARG_EXPORT_MACRO_PREFIX}_DYNAMIC_EXPORT"
             )
+        elseif(
+            target_type STREQUAL STATIC_LIBRARY
+        )
+            target_compile_definitions(
+                ${target}
+                PUBLIC "${ARG_EXPORT_MACRO_PREFIX}_STATIC"
+            )
         endif()
     endif()
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -253,6 +253,7 @@ See the [documentation on testing](../tools/slang-test/README.md) for more infor
 | `SLANG_EMBED_STDLIB_SOURCE`       | `TRUE`           | Embed stdlib source in the binary                                  |
 | `SLANG_ENABLE_ASAN`               | `FALSE`          | Enable ASAN (address sanitizer)                                    |
 | `SLANG_ENABLE_FULL_IR_VALIDATION` | `FALSE`          | Enable full IR validation (SLOW!)                                  |
+| `SLANG_BUILD_LIB_TYPE`            | `SHARED`         | How to build the slang library                                     |
 | `SLANG_SLANG_LLVM_FLAVOR`         | `FETCH_BINARY`   | How to set up llvm support                                         |
 | `SLANG_SLANG_LLVM_BINARY_URL`     | System dependent | URL specifying the location of the slang-llvm prebuilt library     |
 | `SLANG_GENERATORS_PATH`           | ``               | Path to an installed `all-generators` target for cross compilation |

--- a/docs/building.md
+++ b/docs/building.md
@@ -260,7 +260,7 @@ See the [documentation on testing](../tools/slang-test/README.md) for more infor
 | `SLANG_ENABLE_SLANG_GLSLANG`      | `TRUE`           | Enable glslang dependency and slang-glslang wrapper target         |
 | `SLANG_ENABLE_TESTS`              | `TRUE`           | Enable test targets, requires SLANG_ENABLE_GFX, SLANG_ENABLE_SLANGD and SLANG_ENABLE_SLANGRT |
 | `SLANG_ENABLE_EXAMPLES`           | `TRUE`           | Enable example targets, requires SLANG_ENABLE_GFX                  |
-| `SLANG_BUILD_LIB_TYPE`            | `SHARED`         | How to build the slang library                                     |
+| `SLANG_LIB_TYPE`                  | `SHARED`         | How to build the slang library                                     |
 | `SLANG_SLANG_LLVM_FLAVOR`         | `FETCH_BINARY`   | How to set up llvm support                                         |
 | `SLANG_SLANG_LLVM_BINARY_URL`     | System dependent | URL specifying the location of the slang-llvm prebuilt library     |
 | `SLANG_GENERATORS_PATH`           | ``               | Path to an installed `all-generators` target for cross compilation |

--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -243,7 +243,7 @@ target_include_directories(
 #
 slang_add_target(
     .
-    SHARED
+    ${SLANG_BUILD_LIB_TYPE}
     LINK_WITH_PRIVATE
         core
         compiler-core

--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -243,7 +243,7 @@ target_include_directories(
 #
 slang_add_target(
     .
-    ${SLANG_BUILD_LIB_TYPE}
+    ${SLANG_LIB_TYPE}
     LINK_WITH_PRIVATE
         core
         compiler-core


### PR DESCRIPTION
This adds an option to cmake that allows to build and link a static version of the slang library.
The resulting `slang.lib` is about 1 GB in size in debug, which is a bit on the larger side but I don't know why.