### PR TITLE
Support loading serialized modules.

### DIFF
--- a/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj
+++ b/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj
@@ -330,6 +330,7 @@
     <None Include="..\..\..\tools\gfx-unit-test\mutable-shader-object.slang" />
     <None Include="..\..\..\tools\gfx-unit-test\nested-parameter-block.slang" />
     <None Include="..\..\..\tools\gfx-unit-test\precompiled-module-imported.slang" />
+    <None Include="..\..\..\tools\gfx-unit-test\precompiled-module-included.slang" />
     <None Include="..\..\..\tools\gfx-unit-test\precompiled-module.slang" />
     <None Include="..\..\..\tools\gfx-unit-test\ray-tracing-test-shaders.slang" />
     <None Include="..\..\..\tools\gfx-unit-test\resolve-resource-shader.slang" />

--- a/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj
+++ b/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj
@@ -306,6 +306,8 @@
     <ClCompile Include="..\..\..\tools\gfx-unit-test\link-time-constant.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\mutable-shader-object.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\nested-parameter-block.cpp" />
+    <ClCompile Include="..\..\..\tools\gfx-unit-test\precompiled-module-2.cpp" />
+    <ClCompile Include="..\..\..\tools\gfx-unit-test\precompiled-module.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\ray-tracing-tests.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\resolve-resource-tests.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\root-mutable-shader-object.cpp" />
@@ -327,6 +329,8 @@
     <None Include="..\..\..\tools\gfx-unit-test\link-time-constant.slang" />
     <None Include="..\..\..\tools\gfx-unit-test\mutable-shader-object.slang" />
     <None Include="..\..\..\tools\gfx-unit-test\nested-parameter-block.slang" />
+    <None Include="..\..\..\tools\gfx-unit-test\precompiled-module-imported.slang" />
+    <None Include="..\..\..\tools\gfx-unit-test\precompiled-module.slang" />
     <None Include="..\..\..\tools\gfx-unit-test\ray-tracing-test-shaders.slang" />
     <None Include="..\..\..\tools\gfx-unit-test\resolve-resource-shader.slang" />
     <None Include="..\..\..\tools\gfx-unit-test\root-shader-parameter.slang" />

--- a/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj.filters
+++ b/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj.filters
@@ -74,6 +74,12 @@
     <ClCompile Include="..\..\..\tools\gfx-unit-test\nested-parameter-block.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\tools\gfx-unit-test\precompiled-module-2.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\tools\gfx-unit-test\precompiled-module.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\tools\gfx-unit-test\ray-tracing-tests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -131,6 +137,12 @@
       <Filter>Source Files</Filter>
     </None>
     <None Include="..\..\..\tools\gfx-unit-test\nested-parameter-block.slang">
+      <Filter>Source Files</Filter>
+    </None>
+    <None Include="..\..\..\tools\gfx-unit-test\precompiled-module-imported.slang">
+      <Filter>Source Files</Filter>
+    </None>
+    <None Include="..\..\..\tools\gfx-unit-test\precompiled-module.slang">
       <Filter>Source Files</Filter>
     </None>
     <None Include="..\..\..\tools\gfx-unit-test\ray-tracing-test-shaders.slang">

--- a/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj.filters
+++ b/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj.filters
@@ -142,6 +142,9 @@
     <None Include="..\..\..\tools\gfx-unit-test\precompiled-module-imported.slang">
       <Filter>Source Files</Filter>
     </None>
+    <None Include="..\..\..\tools\gfx-unit-test\precompiled-module-included.slang">
+      <Filter>Source Files</Filter>
+    </None>
     <None Include="..\..\..\tools\gfx-unit-test\precompiled-module.slang">
       <Filter>Source Files</Filter>
     </None>

--- a/slang.h
+++ b/slang.h
@@ -4444,6 +4444,17 @@ namespace slang
             ITypeConformance** outConformance,
             SlangInt conformanceIdOverride,
             ISlangBlob** outDiagnostics) = 0;
+
+            /** Load a module from a Slang module blob.
+            */
+        virtual SLANG_NO_THROW IModule* SLANG_MCALL loadModuleFromIRBlob(
+            const char* moduleName,
+            const char* path,
+            slang::IBlob* source,
+            slang::IBlob** outDiagnostics = nullptr) = 0;
+
+        virtual SLANG_NO_THROW SlangInt SLANG_MCALL getLoadedModuleCount() = 0;
+        virtual SLANG_NO_THROW IModule* SLANG_MCALL getLoadedModule(SlangInt index) = 0;
     };
 
     #define SLANG_UUID_ISession ISession::getTypeGuid()
@@ -4691,6 +4702,22 @@ namespace slang
         /// Get the name of an entry point defined in the module.
         virtual SLANG_NO_THROW SlangResult SLANG_MCALL
             getDefinedEntryPoint(SlangInt32 index, IEntryPoint** outEntryPoint) = 0;
+
+        /// Get a serialized representation of the checked module.
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL serialize(ISlangBlob** outSerializedBlob) = 0;
+
+        /// Write the serialized representation of this module to a file.
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL writeToFile(char const* fileName) = 0;
+
+        /// Get the name of the module.
+        virtual SLANG_NO_THROW const char* SLANG_MCALL getName() = 0;
+
+        /// Get the path of the module.
+        virtual SLANG_NO_THROW const char* SLANG_MCALL getFilePath() = 0;
+
+        /// Get the unique identity of the module.
+        virtual SLANG_NO_THROW const char* SLANG_MCALL getUniqueIdentity() = 0;
+
     };
     
     #define SLANG_UUID_IModule IModule::getTypeGuid()

--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -104,10 +104,10 @@ struct Scope : public NodeBase
     // but the opposite it allowed.
     ContainerDecl*          containerDecl = nullptr;
 
-    SLANG_UNREFLECTED
     // The parent of this scope (where lookup should go if nothing is found locally)
     Scope*                  parent = nullptr;
 
+    SLANG_UNREFLECTED
     // The next sibling of this scope (a peer for lookup)
     Scope*                  nextSibling = nullptr;
 };

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -633,4 +633,9 @@ InterfaceDecl* findParentInterfaceDecl(Decl* decl);
 
 bool isLocalVar(const Decl* decl);
 
+
+// Add a sibling lookup scope for `dest` to refer to `source`.
+void addSiblingScopeForContainerDecl(ASTBuilder* builder, ContainerDecl* dest, ContainerDecl* source);
+void addSiblingScopeForContainerDecl(ASTBuilder* builder, Scope* destScope, ContainerDecl* source);
+
 } // namespace Slang

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -7302,7 +7302,7 @@ namespace Slang
     {
         // Create a new sub-scope to wire the module
         // into our lookup chain.
-        addSiblingScopeForContainerDecl(scope, fileDecl);
+        addSiblingScopeForContainerDecl(getASTBuilder(), scope, fileDecl);
     }
 
     void SemanticsVisitor::importModuleIntoScope(Scope* scope, ModuleDecl* moduleDecl)
@@ -7325,7 +7325,7 @@ namespace Slang
             if (moduleScope->containerDecl != moduleDecl && moduleScope->containerDecl->parentDecl != moduleDecl)
                 continue;
 
-            addSiblingScopeForContainerDecl(scope, moduleScope->containerDecl);
+            addSiblingScopeForContainerDecl(getASTBuilder(), scope, moduleScope->containerDecl);
         }
 
         // Also import any modules from nested `import` declarations
@@ -7547,7 +7547,7 @@ namespace Slang
                     if (addedScopes.add(s->containerDecl))
                     {
                         scopesAdded = true;
-                        addSiblingScopeForContainerDecl(scope, s->containerDecl);
+                        addSiblingScopeForContainerDecl(getASTBuilder(), scope, s->containerDecl);
                     }
                 }
             };
@@ -7608,7 +7608,7 @@ namespace Slang
                     {
                         ensureDecl(ns, DeclCheckState::ScopesWired);
                     }
-                    addSiblingScopeForContainerDecl(decl, otherNamespace);
+                    addSiblingScopeForContainerDecl(getASTBuilder(), decl, otherNamespace);
                 }
             }
             // For file decls, we need to continue searching up in the parent module scope.

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -820,6 +820,11 @@ namespace Slang
         return as<NamespaceDeclBase>(parentDecl) != nullptr || as<FileDecl>(parentDecl) != nullptr;
     }
 
+    bool isUnsafeForceInlineFunc(FunctionDeclBase* funcDecl)
+    {
+        return funcDecl->hasModifier<UnsafeForceInlineEarlyAttribute>();
+    }
+
         /// Is `decl` a global shader parameter declaration?
     bool isGlobalShaderParameter(VarDeclBase* decl)
     {

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -248,14 +248,14 @@ namespace Slang
         return SourceLoc();
     }
 
-    void SemanticsVisitor::addSiblingScopeForContainerDecl(ContainerDecl* dest, ContainerDecl* source)
+    void addSiblingScopeForContainerDecl(ASTBuilder* builder, ContainerDecl* dest, ContainerDecl* source)
     {
-        addSiblingScopeForContainerDecl(dest->ownedScope, source);
+        addSiblingScopeForContainerDecl(builder, dest->ownedScope, source);
     }
 
-    void SemanticsVisitor::addSiblingScopeForContainerDecl(Scope* destScope, ContainerDecl* source)
+    void addSiblingScopeForContainerDecl(ASTBuilder* builder, Scope* destScope, ContainerDecl* source)
     {
-        auto subScope = getASTBuilder()->create<Scope>();
+        auto subScope = builder->create<Scope>();
         subScope->containerDecl = source;
 
         subScope->nextSibling = destScope->nextSibling;

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -17,6 +17,8 @@ namespace Slang
 
     bool isGlobalDecl(Decl* decl);
 
+    bool isUnsafeForceInlineFunc(FunctionDeclBase* funcDecl);
+
     bool isUniformParameterType(Type* type);
 
     Type* checkProperType(

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1048,11 +1048,6 @@ namespace Slang
 
         Scope* getScope(SyntaxNode* node);
 
-        // Add a sibling lookup scope for `dest` to refer to `source`.
-        void addSiblingScopeForContainerDecl(ContainerDecl* dest, ContainerDecl* source);
-        void addSiblingScopeForContainerDecl(Scope* destScope, ContainerDecl* source);
-
-
         void diagnoseDeprecatedDeclRefUsage(DeclRef<Decl> declRef, SourceLoc loc, Expr* originalExpr);
 
         DeclRef<Decl> getDefaultDeclRef(Decl* decl)

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -905,58 +905,10 @@ namespace Slang
             // should work for typical HLSL code.
             //
             Index translationUnitCount = translationUnits.getCount();
-            for(Index tt = 0; tt < translationUnitCount; ++tt)
+            for (Index tt = 0; tt < translationUnitCount; ++tt)
             {
                 auto translationUnit = translationUnits[tt];
-                for( auto globalDecl : translationUnit->getModuleDecl()->members )
-                {
-                    auto maybeFuncDecl = globalDecl;
-                    if( auto genericDecl = as<GenericDecl>(maybeFuncDecl) )
-                    {
-                        maybeFuncDecl = genericDecl->inner;
-                    }
-
-                    auto funcDecl = as<FuncDecl>(maybeFuncDecl);
-                    if(!funcDecl)
-                        continue;
-
-                    auto entryPointAttr = funcDecl->findModifier<EntryPointAttribute>();
-                    if(!entryPointAttr)
-                        continue;
-
-                    // We've discovered a valid entry point. It is a function (possibly
-                    // generic) that has a `[shader(...)]` attribute to mark it as an
-                    // entry point.
-                    //
-                    // We will now register that entry point as an `EntryPoint`
-                    // with an appropriately chosen profile.
-                    //
-                    // The profile will only include a stage, so that the profile "family"
-                    // and "version" are left unspecified. Downstream code will need
-                    // to be able to handle this case.
-                    //
-                    Profile profile;
-                    profile.setStage(entryPointAttr->stage);
-
-                    RefPtr<EntryPoint> entryPoint = EntryPoint::create(
-                        linkage,
-                        makeDeclRef(funcDecl),
-                        profile);
-
-                    validateEntryPoint(entryPoint, sink);
-
-                    // Note: in the case that the user didn't explicitly
-                    // specify entry points and we are instead compiling
-                    // a shader "library," then we do not want to automatically
-                    // combine the entry points into groups in the generated
-                    // `Program`, since that would be slightly too magical.
-                    //
-                    // Instead, each entry point will end up in a singleton
-                    // group, so that its entry-point parameters lay out
-                    // independent of the others.
-                    //
-                    translationUnit->module->_addEntryPoint(entryPoint);
-                }
+                translationUnit->getModule()->_discoverEntryPoints(sink);
             }
         }
     }

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1326,10 +1326,10 @@ namespace Slang
         }
 
         /// Get a serialized representation of the checked module.
-        virtual SLANG_NO_THROW SlangResult SLANG_MCALL serialize(ISlangBlob** outSerializedBlob);
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL serialize(ISlangBlob** outSerializedBlob) override;
 
         /// Write the serialized representation of this module to a file.
-        virtual SLANG_NO_THROW SlangResult SLANG_MCALL writeToFile(char const* fileName);
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL writeToFile(char const* fileName) override;
 
         /// Get the name of the module.
         virtual SLANG_NO_THROW const char* SLANG_MCALL getName() override;

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1325,6 +1325,22 @@ namespace Slang
             return Super::getEntryPointHash(entryPointIndex, targetIndex, outHash);
         }
 
+        /// Get a serialized representation of the checked module.
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL serialize(ISlangBlob** outSerializedBlob);
+
+        /// Write the serialized representation of this module to a file.
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL writeToFile(char const* fileName);
+
+        /// Get the name of the module.
+        virtual SLANG_NO_THROW const char* SLANG_MCALL getName() override;
+
+        /// Get the path of the module.
+        virtual SLANG_NO_THROW const char* SLANG_MCALL getFilePath() override;
+
+        /// Get the unique identity of the module.
+        virtual SLANG_NO_THROW const char* SLANG_MCALL getUniqueIdentity() override;
+
+
         virtual void buildHash(DigestBuilder<SHA1>& builder) SLANG_OVERRIDE;
 
             /// Create a module (initially empty).
@@ -1353,6 +1369,10 @@ namespace Slang
             /// This should only be called once, during creation of the module.
             ///
         void setModuleDecl(ModuleDecl* moduleDecl);// { m_moduleDecl = moduleDecl; }
+
+        void setName(String name);
+        void setName(Name* name) { m_name = name; }
+        void setPathInfo(PathInfo pathInfo) { m_pathInfo = pathInfo; }
 
             /// Set the IR for this module.
             ///
@@ -1395,6 +1415,8 @@ namespace Slang
             ///
         void _collectShaderParams();
 
+        void _discoverEntryPoints(DiagnosticSink* sink);
+
         class ModuleSpecializationInfo : public SpecializationInfo
         {
         public:
@@ -1426,6 +1448,9 @@ namespace Slang
             DiagnosticSink*             sink) SLANG_OVERRIDE;
 
     private:
+        Name* m_name = nullptr;
+        PathInfo m_pathInfo;
+
         // The AST for the module
         ModuleDecl*  m_moduleDecl = nullptr;
 
@@ -1538,6 +1563,13 @@ namespace Slang
         Scope* getLanguageScope();
 
         Dictionary<String, String> getCombinedPreprocessorDefinitions();
+
+        void setModuleName(Name* name)
+        {
+            moduleName = name;
+            if (module)
+                module->setName(name);
+        }
 
     protected:
         void _addSourceFile(SourceFile* sourceFile);
@@ -1730,6 +1762,11 @@ namespace Slang
         /// lookup additional loaded modules.
     typedef Dictionary<Name*, Module*> LoadedModuleDictionary;
 
+    enum ModuleBlobType
+    {
+        Source, IR
+    };
+
         /// A context for loading and re-using code modules.
     class Linkage : public RefObject, public slang::ISession
     {
@@ -1742,6 +1779,17 @@ namespace Slang
         SLANG_NO_THROW slang::IModule* SLANG_MCALL loadModule(
             const char* moduleName,
             slang::IBlob**     outDiagnostics = nullptr) override;
+        slang::IModule* loadModuleFromBlob(
+            const char* moduleName,
+            const char* path,
+            slang::IBlob* source,
+            ModuleBlobType blobType,
+            slang::IBlob** outDiagnostics = nullptr);
+        SLANG_NO_THROW slang::IModule* SLANG_MCALL loadModuleFromIRBlob(
+            const char* moduleName,
+            const char* path,
+            slang::IBlob* source,
+            slang::IBlob** outDiagnostics = nullptr) override;
         SLANG_NO_THROW slang::IModule* SLANG_MCALL loadModuleFromSource(
             const char* moduleName,
             const char* path,
@@ -1786,6 +1834,8 @@ namespace Slang
             ISlangBlob** outDiagnostics) override;
         SLANG_NO_THROW SlangResult SLANG_MCALL createCompileRequest(
             SlangCompileRequest**   outCompileRequest) override;
+        virtual SLANG_NO_THROW SlangInt SLANG_MCALL getLoadedModuleCount() override;
+        virtual SLANG_NO_THROW slang::IModule* SLANG_MCALL getLoadedModule(SlangInt index) override;
 
         // Updates the supplied builder with linkage-related information, which includes preprocessor
         // defines, the compiler version, and other compiler options. This is then merged with the hash
@@ -1935,6 +1985,15 @@ namespace Slang
             ISlangBlob*         fileContentsBlob,
             SourceLoc const&    loc,
             DiagnosticSink*     sink,
+            const LoadedModuleDictionary* additionalLoadedModules,
+            ModuleBlobType      blobType);
+
+        RefPtr<Module> loadModuleFromIRBlobImpl(
+            Name* name,
+            const PathInfo& filePathInfo,
+            ISlangBlob* fileContentsBlob,
+            SourceLoc const& loc,
+            DiagnosticSink* sink,
             const LoadedModuleDictionary* additionalLoadedModules);
 
         void loadParsedModule(
@@ -1951,6 +2010,8 @@ namespace Slang
             SourceLoc const&    loc,
             DiagnosticSink*     sink,
             const LoadedModuleDictionary* loadedModules = nullptr);
+
+        void prepareDeserializedModule(Module* module, DiagnosticSink* sink);
 
         SourceFile* findFile(Name* name, SourceLoc loc, IncludeSystem& outIncludeSystem);
         struct IncludeResult

--- a/source/slang/slang-module-library.cpp
+++ b/source/slang/slang-module-library.cpp
@@ -66,7 +66,7 @@ SlangResult loadModuleLibrary(const Byte* inBytes, size_t bytesCount, EndToEndCo
         options.linkage = req->getLinkage();
         options.sink = req->getSink();
 
-        SLANG_RETURN_ON_FAIL(SerialContainerUtil::read(&riffContainer, options, containerData));
+        SLANG_RETURN_ON_FAIL(SerialContainerUtil::read(&riffContainer, options, nullptr, containerData));
 
         for (const auto& module : containerData.modules)
         {

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -1280,21 +1280,24 @@ namespace Slang
         Parser* parser, void* /*userData*/)
     {
         auto decl = parser->astBuilder->create<ModuleDeclarationDecl>();
+        auto moduleDecl = parser->getCurrentModuleDecl();
         if (parser->LookAheadToken(TokenType::Identifier))
         {
             auto nameToken = parser->ReadToken(TokenType::Identifier);
             decl->nameAndLoc.name = parser->getNamePool()->getName(nameToken.getContent());
             decl->nameAndLoc.loc = nameToken.loc;
+            if (moduleDecl) moduleDecl->nameAndLoc = decl->nameAndLoc;
         }
         else if (parser->LookAheadToken(TokenType::StringLiteral))
         {
             auto nameToken = parser->ReadToken(TokenType::StringLiteral);
             decl->nameAndLoc.name = parser->getNamePool()->getName(getStringLiteralTokenValue(nameToken));
             decl->nameAndLoc.loc = nameToken.loc;
+            if (moduleDecl) moduleDecl->nameAndLoc = decl->nameAndLoc;
         }
         else
         {
-            if (auto moduleDecl = parser->getCurrentModuleDecl())
+            if (moduleDecl)
                 decl->nameAndLoc.name = moduleDecl->getName();
             decl->nameAndLoc.loc = parser->tokenReader.peekLoc();
         }

--- a/source/slang/slang-serialize-ast-type-info.h
+++ b/source/slang/slang-serialize-ast-type-info.h
@@ -52,8 +52,8 @@ inline void serializeValPointerValue(SerialWriter* writer, Val* ptrValue, Serial
 
 inline void deserializeValPointerValue(SerialReader* reader, const SerialIndex* inSerial, void* outPtr)
 {
-    auto val = reader->getPointer(*(const SerialIndex*)inSerial).dynamicCast<Val>();
-    *(Val**)outPtr = val;
+    auto val = reader->getValPointer(*(const SerialIndex*)inSerial);
+    *(void**)outPtr = val.m_ptr;
 }
 
 template<typename T>

--- a/source/slang/slang-serialize-container.h
+++ b/source/slang/slang-serialize-container.h
@@ -107,7 +107,7 @@ struct SerialContainerUtil
     static SlangResult write(const SerialContainerData& data, const WriteOptions& options, RiffContainer* container);
 
         /// Read the container into outData
-    static SlangResult read(RiffContainer* container, const ReadOptions& options, SerialContainerData& outData);
+    static SlangResult read(RiffContainer* container, const ReadOptions& options, const LoadedModuleDictionary* additionalLoadedModules, SerialContainerData& outData);
 
         /// Verify IR serialization
     static SlangResult verifyIRSerialize(IRModule* module, Session* session, const WriteOptions& options);

--- a/source/slang/slang-serialize-factory.cpp
+++ b/source/slang/slang-serialize-factory.cpp
@@ -45,6 +45,11 @@ void* DefaultSerialObjectFactory::create(SerialTypeKind typeKind, SerialSubType 
     return nullptr;
 }
 
+void* DefaultSerialObjectFactory::getOrCreateVal(ValNodeDesc&& desc)
+{
+    return m_astBuilder->_getOrCreateImpl(_Move(desc));
+}
+
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! ModuleSerialFilter  !!!!!!!!!!!!!!!!!!!!!!!!
 
 SerialIndex ModuleSerialFilter::writePointer(SerialWriter* writer, const RefObject* inPtr)
@@ -65,12 +70,6 @@ SerialIndex ModuleSerialFilter::writePointer(SerialWriter* writer, const NodeBas
     NodeBase* ptr = const_cast<NodeBase*>(inPtr);
     SLANG_ASSERT(ptr);
 
-    // We don't serialize Scope
-    if (as<Scope>(ptr))
-    {
-        writer->setPointerIndex(inPtr, SerialIndex(0));
-        return SerialIndex(0);
-    }
 
     if (Decl* decl = as<Decl>(ptr))
     {

--- a/source/slang/slang-serialize-factory.h
+++ b/source/slang/slang-serialize-factory.h
@@ -15,6 +15,7 @@ class DefaultSerialObjectFactory : public SerialObjectFactory
 public:
 
     virtual void* create(SerialTypeKind typeKind, SerialSubType subType) SLANG_OVERRIDE;
+    virtual void* getOrCreateVal(ValNodeDesc&& desc) SLANG_OVERRIDE;
 
     DefaultSerialObjectFactory(ASTBuilder* astBuilder) :
         m_astBuilder(astBuilder)

--- a/source/slang/slang-serialize-types.h
+++ b/source/slang/slang-serialize-types.h
@@ -30,6 +30,7 @@ struct SerialOptionFlag
         SourceLocation      = 0x02,     ///< If set will output SourceLoc information, that can be reconstructed when read after being stored.
         ASTModule           = 0x04,     ///< If set will output AST modules - typically required, but potentially not desired (for example with obsfucation)
         IRModule            = 0x08,     ///< If set will output IR modules - typically required
+        ASTFunctionBody     = 0x10,     ///< If set will serialize AST function bodies.
     };
 };
 typedef SerialOptionFlag::Type SerialOptionFlags;

--- a/source/slang/slang-serialize.cpp
+++ b/source/slang/slang-serialize.cpp
@@ -224,10 +224,57 @@ SerialWriter::SerialWriter(SerialClasses* classes, SerialFilter* filter, Flags f
 
 SerialIndex SerialWriter::writeObject(const SerialClass* serialCls, const void* ptr)
 {
+    struct SkipFunctionBodyRAII
+    {
+        FunctionDeclBase* funcDecl = nullptr;
+        Stmt* oldBody;
+        SkipFunctionBodyRAII(SerialWriter::Flags flags, const SerialClass* serialCls, const void* ptr)
+        {
+            if ((flags & SerialWriter::Flag::SkipFunctionBody) == 0)
+                return;
+
+            if (serialCls->typeKind != SerialTypeKind::NodeBase)
+                return;
+            auto cls = serialCls;
+            while (cls)
+            {
+                auto astNodeType = (ASTNodeType)cls->subType;
+                if (astNodeType == ASTNodeType::FunctionDeclBase)
+                {
+                    funcDecl = (FunctionDeclBase*)ptr;
+                    break;
+                }
+                cls = cls->super;
+            }
+            if (funcDecl)
+            {
+                oldBody = funcDecl->body;
+                funcDecl->body = nullptr;
+            }
+
+        }
+        ~SkipFunctionBodyRAII()
+        {
+            if (funcDecl)
+            {
+                funcDecl->body = oldBody;
+            }
+        }
+    };
     if (serialCls->flags & SerialClassFlag::DontSerialize)
     {
         return SerialIndex(0);
     }
+
+    if (serialCls->typeKind == SerialTypeKind::NodeBase &&
+        ReflectClassInfo::isSubClassOf(serialCls->subType, Val::kReflectClassInfo))
+    {
+        return writeValObject((Val*)ptr);
+    }
+
+    // If we are skipping function bodies, set the body field to nullptr, and
+    // restore it after serialization.
+    SkipFunctionBodyRAII clearFunctionBodyRAII(m_flags, serialCls, ptr);
 
     // This pointer cannot be in the map
     SLANG_ASSERT(m_ptrMap.tryGetValue(ptr) == nullptr);
@@ -277,6 +324,62 @@ SerialIndex SerialWriter::writeObject(const NodeBase* node)
 {
     const SerialClass* serialClass = m_classes->getSerialClass(SerialTypeKind::NodeBase, SerialSubType(node->astNodeType));
     return writeObject(serialClass, (const void*)node);
+}
+
+SerialIndex SerialWriter::writeValObject(const Val* node)
+{
+    typedef SerialInfo::ValEntry ValEntry;
+
+    size_t size = node->getOperandCount() * sizeof(SerialInfo::SerialValOperand);
+    ValEntry* nodeEntry = (ValEntry*)m_arena.allocateAligned(sizeof(ValEntry) + size, SerialInfo::MAX_ALIGNMENT);
+
+    nodeEntry->typeKind = SerialTypeKind::NodeBase;
+    nodeEntry->subType = (SerialSubType)node->astNodeType;
+    nodeEntry->operandCount = (uint32_t)node->getOperandCount();
+    nodeEntry->info = SerialInfo::makeEntryInfo(SerialInfo::MAX_ALIGNMENT);
+
+    // We add before adding fields, so if the fields point to this, the entry will be set
+    auto index = _add(node, nodeEntry);
+
+    ShortList<SerialIndex, 4> serializedOperands;
+
+    for (Index i = 0; i < node->getOperandCount(); i++)
+    {
+        auto operand = node->m_operands[i];
+        switch (operand.kind)
+        {
+        case ValNodeOperandKind::ConstantValue:
+            serializedOperands.add((SerialIndex)0);
+            break;
+        case ValNodeOperandKind::ValNode:
+        case ValNodeOperandKind::ASTNode:
+            serializedOperands.add(addPointer(operand.values.nodeOperand));
+            break;
+        }
+    }
+
+    SLANG_ASSERT(serializedOperands.getCount() == node->getOperandCount());
+
+    auto serialOperands = (SerialInfo::SerialValOperand*)(nodeEntry + 1);
+    for (Index i = 0; i < node->getOperandCount(); i++)
+    {
+        auto serialOperand = serialOperands + i;
+        auto operand = node->m_operands[i];
+        serialOperand->type = (int)operand.kind;
+        switch (operand.kind)
+        {
+        case ValNodeOperandKind::ConstantValue:
+            serialOperand->payload = operand.values.intOperand;
+            break;
+        case ValNodeOperandKind::ValNode:
+            serialOperand->payload = (uint64_t)serializedOperands[i];
+            break;
+        case ValNodeOperandKind::ASTNode:
+            serialOperand->payload = (uint64_t)serializedOperands[i];
+            break;
+        }
+    }
+    return index;
 }
 
 SerialIndex SerialWriter::writeObject(const RefObject* obj)
@@ -633,6 +736,9 @@ size_t SerialInfo::Entry::calcSize(SerialClasses* serialClasses) const
 
             auto serialClass = serialClasses->getSerialClass(typeKind, entry->subType);
 
+            if (ReflectClassInfo::isSubClassOf(entry->subType, Val::kReflectClassInfo))
+                return sizeof(ValEntry) + static_cast<const ValEntry*>(this)->operandCount * sizeof(SerialValOperand);
+
             // Align by the alignment of the entry 
             size_t alignment = getAlignment(entry->info);
             size_t size = sizeof(ObjectEntry) + serialClass->size;
@@ -719,6 +825,49 @@ SerialPointer SerialReader::getPointer(SerialIndex index)
         default: break;
     }
 
+    return ptr;
+}
+
+SerialPointer SerialReader::getValPointer(SerialIndex index)
+{
+    if (index == SerialIndex(0))
+    {
+        return SerialPointer();
+    }
+
+    SLANG_ASSERT(SerialIndexRaw(index) < SerialIndexRaw(m_entries.getCount()));
+
+    SerialPointer& ptr = m_objects[Index(index)];
+
+    if (ptr.m_ptr)
+        return ptr;
+
+    const SerialInfo::ValEntry* entry = (SerialInfo::ValEntry*)m_entries[Index(index)];
+    ValNodeDesc desc;
+    desc.type = (ASTNodeType)entry->subType;
+    auto readPtr = (SerialInfo::SerialValOperand*)(entry + 1);
+    for (Index i = 0; i < entry->operandCount; i++)
+    {
+        auto serialOperand = readPtr[i];
+        ValNodeOperand operand;
+        operand.kind = (ValNodeOperandKind)(serialOperand.type);
+        switch (operand.kind)
+        {
+        case ValNodeOperandKind::ConstantValue:
+            operand.values.intOperand = serialOperand.payload;
+            break;
+        case ValNodeOperandKind::ASTNode:
+            operand.values.nodeOperand = getPointer((SerialIndex)serialOperand.payload).dynamicCast<NodeBase>();
+            break;
+        case ValNodeOperandKind::ValNode:
+            operand.values.nodeOperand = getValPointer((SerialIndex)serialOperand.payload).dynamicCast<Val>();
+            break;
+        }
+        desc.operands.add(operand);
+    }
+    desc.init();
+    ptr.m_kind = SerialTypeKind::NodeBase;
+    ptr.m_ptr = this->m_objectFactory->getOrCreateVal(_Move(desc));
     return ptr;
 }
 
@@ -902,6 +1051,12 @@ SlangResult SerialReader::constructObjects(NamePool* namePool)
             case SerialTypeKind::NodeBase:
             {
                 auto objectEntry = static_cast<const SerialInfo::ObjectEntry*>(entry);
+
+                // Don't create object for Vals.
+                if (objectEntry->typeKind == SerialTypeKind::NodeBase &&
+                    ReflectClassInfo::isSubClassOf(objectEntry->subType, Val::kReflectClassInfo))
+                    break;
+
                 void* obj = m_objectFactory->create(objectEntry->typeKind, objectEntry->subType);
                 if (!obj)
                 {
@@ -912,7 +1067,7 @@ SlangResult SerialReader::constructObjects(NamePool* namePool)
             }
             case SerialTypeKind::Array:
             {
-                // Don't need to construct an object, as will be accessed an interpreted by the object that holds it
+                // Don't need to construct an object, as will be accessed and interpreted by the object that holds it
                 break;
             }
         }
@@ -944,6 +1099,8 @@ SlangResult SerialReader::deserializeObjects()
                 {
                     return SLANG_FAIL;
                 }
+                if (ReflectClassInfo::isSubClassOf(objectEntry->subType, Val::kReflectClassInfo))
+                    continue;
 
                 const uint8_t* src = (const uint8_t*)(objectEntry + 1);
                 uint8_t* dst = (uint8_t*)dstPtr.m_ptr;

--- a/source/slang/slang-serialize.cpp
+++ b/source/slang/slang-serialize.cpp
@@ -863,10 +863,10 @@ SerialPointer SerialReader::getValPointer(SerialIndex index)
             operand.values.intOperand = serialOperand.payload;
             break;
         case ValNodeOperandKind::ASTNode:
-            operand.values.nodeOperand = getPointer((SerialIndex)serialOperand.payload).dynamicCast<NodeBase>();
+            operand.values.nodeOperand = (NodeBase*)getPointer((SerialIndex)serialOperand.payload).m_ptr;
             break;
         case ValNodeOperandKind::ValNode:
-            operand.values.nodeOperand = getValPointer((SerialIndex)serialOperand.payload).dynamicCast<Val>();
+            operand.values.nodeOperand = (Val*)getValPointer((SerialIndex)serialOperand.payload).m_ptr;
             break;
         }
         desc.operands.add(operand);

--- a/source/slang/slang-serialize.cpp
+++ b/source/slang/slang-serialize.cpp
@@ -3,6 +3,7 @@
 
 #include "slang-ast-base.h"
 #include "slang-ast-builder.h"
+#include "slang-check-impl.h"
 
 namespace Slang {
 
@@ -250,7 +251,7 @@ struct SkipFunctionBodyRAII
             // We always need to include body of unsafeForceInlineEarly functions
             // since they will need to be available at IR lowering time of the
             // user module for pre-linking inling.
-            if (!funcDecl->hasModifier<UnsafeForceInlineEarlyAttribute>())
+            if (!isUnsafeForceInlineFunc(funcDecl))
             {
                 funcDecl->body = nullptr;
             }

--- a/source/slang/slang-serialize.cpp
+++ b/source/slang/slang-serialize.cpp
@@ -249,7 +249,13 @@ SerialIndex SerialWriter::writeObject(const SerialClass* serialCls, const void* 
             if (funcDecl)
             {
                 oldBody = funcDecl->body;
-                funcDecl->body = nullptr;
+                // We always need to include body of unsafeForceInlineEarly functions
+                // since they will need to be available at IR lowering time of the
+                // user module for pre-linking inling.
+                if (!funcDecl->hasModifier<UnsafeForceInlineEarlyAttribute>())
+                {
+                    funcDecl->body = nullptr;
+                }
             }
 
         }

--- a/source/slang/slang-serialize.cpp
+++ b/source/slang/slang-serialize.cpp
@@ -852,7 +852,7 @@ SerialPointer SerialReader::getValPointer(SerialIndex index)
     ValNodeDesc desc;
     desc.type = (ASTNodeType)entry->subType;
     auto readPtr = (SerialInfo::SerialValOperand*)(entry + 1);
-    for (Index i = 0; i < entry->operandCount; i++)
+    for (uint32_t i = 0; i < entry->operandCount; i++)
     {
         auto serialOperand = readPtr[i];
         ValNodeOperand operand;

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -295,13 +295,7 @@ namespace Slang
     // being in templates, because gcc/clang get angry.
     //
     template<typename T>
-    void FilteredModifierList<T>::Iterator::operator++()
-    {
-        current = adjust(current->next);
-    }
-    //
-    template<typename T>
-    Modifier* FilteredModifierList<T>::adjust(Modifier* modifier)
+    inline Modifier* FilteredModifierList<T>::adjust(Modifier* modifier)
     {
         Modifier* m = modifier;
         for (;;)
@@ -315,6 +309,11 @@ namespace Slang
         }        
     }
 
+    template<typename T>
+    inline void FilteredModifierList<T>::Iterator::operator++()
+    {
+        current = adjust(current->next);
+    }
     //
 
     enum class UserDefinedAttributeTargets

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -295,7 +295,7 @@ namespace Slang
     // being in templates, because gcc/clang get angry.
     //
     template<typename T>
-    inline Modifier* FilteredModifierList<T>::adjust(Modifier* modifier)
+    Modifier* FilteredModifierList<T>::adjust(Modifier* modifier)
     {
         Modifier* m = modifier;
         for (;;)
@@ -310,9 +310,9 @@ namespace Slang
     }
 
     template<typename T>
-    inline void FilteredModifierList<T>::Iterator::operator++()
+    void FilteredModifierList<T>::Iterator::operator++()
     {
-        current = adjust(current->next);
+        current = FilteredModifierList<T>::adjust(current->next);
     }
     //
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -1087,7 +1087,7 @@ SLANG_NO_THROW slang::IModule* SLANG_MCALL Linkage::loadModule(
     }
 }
 
-SLANG_NO_THROW slang::IModule* SLANG_MCALL Linkage::loadModuleFromBlob(
+slang::IModule* Linkage::loadModuleFromBlob(
     const char* moduleName,
     const char* path,
     slang::IBlob* source,

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3415,6 +3415,7 @@ RefPtr<Module> Linkage::findOrImportModule(
                 // This is a builtin glsl module, just load it from embedded definition.
                 fileContents = getSessionImpl()->getGLSLLibraryCode();
                 filePathInfo = PathInfo::makeFromString("glsl");
+                checkBinaryModule = 0;
             }
             else
             {

--- a/tools/gfx-unit-test/gfx-test-util.h
+++ b/tools/gfx-unit-test/gfx-test-util.h
@@ -18,6 +18,14 @@ namespace gfx_test
         const char* entryPointName,
         slang::ProgramLayout*& slangReflection);
 
+    Slang::Result loadComputeProgram(
+        gfx::IDevice* device,
+        slang::ISession* slangSession,
+        Slang::ComPtr<gfx::IShaderProgram>& outShaderProgram,
+        const char* shaderModuleName,
+        const char* entryPointName,
+        slang::ProgramLayout*& slangReflection);
+
     Slang::Result loadComputeProgramFromSource(
         gfx::IDevice* device,
         Slang::ComPtr<gfx::IShaderProgram>& outShaderProgram,
@@ -79,6 +87,8 @@ namespace gfx_test
         Slang::RenderApiFlag::Enum api,
         Slang::List<const char*> additionalSearchPaths = {},
         gfx::IDevice::ShaderCacheDesc shaderCache = {});
+    
+    Slang::List<const char*> getSlangSearchPaths();
 
     void initializeRenderDoc();
     void renderDocBeginFrame();

--- a/tools/gfx-unit-test/precompiled-module-2.cpp
+++ b/tools/gfx-unit-test/precompiled-module-2.cpp
@@ -1,0 +1,181 @@
+#include "tools/unit-test/slang-unit-test.h"
+
+#include "slang-gfx.h"
+#include "gfx-test-util.h"
+#include "tools/gfx-util/shader-cursor.h"
+#include "source/core/slang-basic.h"
+#include "source/core/slang-blob.h"
+#include "source/core/slang-memory-file-system.h"
+#include "source/core/slang-io.h"
+
+using namespace gfx;
+
+namespace gfx_test
+{
+    // Test that mixing precompiled and non-precompiled modules is working.
+
+    static Slang::Result precompileProgram(
+        gfx::IDevice* device,
+        ISlangMutableFileSystem* fileSys,
+        const char* shaderModuleName)
+    {
+        Slang::ComPtr<slang::ISession> slangSession;
+        SLANG_RETURN_ON_FAIL(device->getSlangSession(slangSession.writeRef()));
+        slang::SessionDesc sessionDesc = {};
+        auto searchPaths = getSlangSearchPaths();
+        sessionDesc.searchPathCount = searchPaths.getCount();
+        sessionDesc.searchPaths = searchPaths.getBuffer();
+        auto globalSession = slangSession->getGlobalSession();
+        globalSession->createSession(sessionDesc, slangSession.writeRef());
+
+        Slang::ComPtr<slang::IBlob> diagnosticsBlob;
+        slang::IModule* module = slangSession->loadModule(shaderModuleName, diagnosticsBlob.writeRef());
+        diagnoseIfNeeded(diagnosticsBlob);
+        if (!module)
+            return SLANG_FAIL;
+
+        // Write loaded modules to memory file system.
+        for (SlangInt i = 0; i < slangSession->getLoadedModuleCount(); i++)
+        {
+            auto module = slangSession->getLoadedModule(i);
+            auto path = module->getFilePath();
+            if (path)
+            {
+                auto name = module->getName();
+                ComPtr<ISlangBlob> outBlob;
+                module->serialize(outBlob.writeRef());
+                fileSys->saveFileBlob((Slang::String(name) + ".slang-module").getBuffer(), outBlob);
+            }
+        }
+        return SLANG_OK;
+    }
+
+    void precompiledModule2TestImpl(IDevice* device, UnitTestContext* context)
+    {
+        Slang::ComPtr<ITransientResourceHeap> transientHeap;
+        ITransientResourceHeap::Desc transientHeapDesc = {};
+        transientHeapDesc.constantBufferSize = 4096;
+        GFX_CHECK_CALL_ABORT(
+            device->createTransientResourceHeap(transientHeapDesc, transientHeap.writeRef()));
+
+        // First, load and compile the slang source.
+        ComPtr<ISlangMutableFileSystem> memoryFileSystem = ComPtr<ISlangMutableFileSystem>(new Slang::MemoryFileSystem());
+
+        ComPtr<IShaderProgram> shaderProgram;
+        slang::ProgramLayout* slangReflection;
+        GFX_CHECK_CALL_ABORT(precompileProgram(device, memoryFileSystem.get(), "precompiled-module-imported"));
+
+        // Next, load the precompiled slang program.
+        Slang::ComPtr<slang::ISession> slangSession;
+        device->getSlangSession(slangSession.writeRef());
+        slang::SessionDesc sessionDesc = {};
+        sessionDesc.targetCount = 1;
+        slang::TargetDesc targetDesc = {};
+        switch (device->getDeviceInfo().deviceType)
+        {
+        case gfx::DeviceType::DirectX12:
+            targetDesc.format = SLANG_DXIL;
+            targetDesc.profile = device->getSlangSession()->getGlobalSession()->findProfile("sm_6_1");
+            break;
+        case gfx::DeviceType::Vulkan:
+            targetDesc.format = SLANG_SPIRV;
+            targetDesc.profile = device->getSlangSession()->getGlobalSession()->findProfile("GLSL_460");
+            break;
+        }
+        sessionDesc.targets = &targetDesc;
+        sessionDesc.fileSystem = memoryFileSystem.get();
+        auto globalSession = slangSession->getGlobalSession();
+        globalSession->createSession(sessionDesc, slangSession.writeRef());
+
+        const char* moduleSrc = R"(
+            import "precompiled-module-imported";
+
+            // Main entry-point. 
+
+            using namespace ns;
+
+            [shader("compute")]
+            [numthreads(4, 1, 1)]
+            void computeMain(
+                uint3 sv_dispatchThreadID : SV_DispatchThreadID,
+                uniform RWStructuredBuffer <float> buffer)
+            {
+                buffer[sv_dispatchThreadID.x] = helperFunc() + helperFunc1();
+            }
+        )";
+        memoryFileSystem->saveFile("precompiled-module.slang", moduleSrc, strlen(moduleSrc));
+        GFX_CHECK_CALL_ABORT(loadComputeProgram(device, slangSession, shaderProgram, "precompiled-module", "computeMain", slangReflection));
+
+        ComputePipelineStateDesc pipelineDesc = {};
+        pipelineDesc.program = shaderProgram.get();
+        ComPtr<gfx::IPipelineState> pipelineState;
+        GFX_CHECK_CALL_ABORT(
+            device->createComputePipelineState(pipelineDesc, pipelineState.writeRef()));
+
+        const int numberCount = 4;
+        float initialData[] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        IBufferResource::Desc bufferDesc = {};
+        bufferDesc.sizeInBytes = numberCount * sizeof(float);
+        bufferDesc.format = gfx::Format::Unknown;
+        bufferDesc.elementSize = sizeof(float);
+        bufferDesc.allowedStates = ResourceStateSet(
+            ResourceState::ShaderResource,
+            ResourceState::UnorderedAccess,
+            ResourceState::CopyDestination,
+            ResourceState::CopySource);
+        bufferDesc.defaultState = ResourceState::UnorderedAccess;
+        bufferDesc.memoryType = MemoryType::DeviceLocal;
+
+        ComPtr<IBufferResource> numbersBuffer;
+        GFX_CHECK_CALL_ABORT(device->createBufferResource(
+            bufferDesc,
+            (void*)initialData,
+            numbersBuffer.writeRef()));
+
+        ComPtr<IResourceView> bufferView;
+        IResourceView::Desc viewDesc = {};
+        viewDesc.type = IResourceView::Type::UnorderedAccess;
+        viewDesc.format = Format::Unknown;
+        GFX_CHECK_CALL_ABORT(
+            device->createBufferView(numbersBuffer, nullptr, viewDesc, bufferView.writeRef()));
+
+        // We have done all the set up work, now it is time to start recording a command buffer for
+        // GPU execution.
+        {
+            ICommandQueue::Desc queueDesc = { ICommandQueue::QueueType::Graphics };
+            auto queue = device->createCommandQueue(queueDesc);
+
+            auto commandBuffer = transientHeap->createCommandBuffer();
+            auto encoder = commandBuffer->encodeComputeCommands();
+
+            auto rootObject = encoder->bindPipeline(pipelineState);
+
+            ShaderCursor entryPointCursor(
+                rootObject->getEntryPoint(0)); // get a cursor the the first entry-point.
+            // Bind buffer view to the entry point.
+            entryPointCursor.getPath("buffer").setResource(bufferView);
+
+            encoder->dispatchCompute(1, 1, 1);
+            encoder->endEncoding();
+            commandBuffer->close();
+            queue->executeCommandBuffer(commandBuffer);
+            queue->waitOnHost();
+        }
+
+        compareComputeResult(
+            device,
+            numbersBuffer,
+            Slang::makeArray<float>(3.0f, 3.0f, 3.0f, 3.0f));
+    }
+
+    SLANG_UNIT_TEST(precompiledModule2D3D12)
+    {
+        runTestImpl(precompiledModule2TestImpl, unitTestContext, Slang::RenderApiFlag::D3D12);
+    }
+
+    SLANG_UNIT_TEST(precompiledModule2Vulkan)
+    {
+        runTestImpl(precompiledModule2TestImpl, unitTestContext, Slang::RenderApiFlag::Vulkan);
+    }
+
+}

--- a/tools/gfx-unit-test/precompiled-module-imported.slang
+++ b/tools/gfx-unit-test/precompiled-module-imported.slang
@@ -1,0 +1,11 @@
+module "precompiled-module-imported";
+
+__include "precompiled-module-included.slang";
+
+namespace ns
+{
+    public int helperFunc()
+    {
+        return 1;
+    }
+}

--- a/tools/gfx-unit-test/precompiled-module-included.slang
+++ b/tools/gfx-unit-test/precompiled-module-included.slang
@@ -1,0 +1,9 @@
+implementing "precompiled-module-imported";
+
+namespace ns
+{
+    public int helperFunc1()
+    {
+        return 2;
+    }
+}

--- a/tools/gfx-unit-test/precompiled-module.cpp
+++ b/tools/gfx-unit-test/precompiled-module.cpp
@@ -1,0 +1,160 @@
+#include "tools/unit-test/slang-unit-test.h"
+
+#include "slang-gfx.h"
+#include "gfx-test-util.h"
+#include "tools/gfx-util/shader-cursor.h"
+#include "source/core/slang-basic.h"
+#include "source/core/slang-blob.h"
+#include "source/core/slang-memory-file-system.h"
+
+using namespace gfx;
+
+namespace gfx_test
+{
+    static Slang::Result precompileProgram(
+        gfx::IDevice* device,
+        ISlangMutableFileSystem* fileSys,
+        const char* shaderModuleName)
+    {
+        Slang::ComPtr<slang::ISession> slangSession;
+        SLANG_RETURN_ON_FAIL(device->getSlangSession(slangSession.writeRef()));
+        slang::SessionDesc sessionDesc = {};
+        auto searchPaths = getSlangSearchPaths();
+        sessionDesc.searchPathCount = searchPaths.getCount();
+        sessionDesc.searchPaths = searchPaths.getBuffer();
+        auto globalSession = slangSession->getGlobalSession();
+        globalSession->createSession(sessionDesc, slangSession.writeRef());
+
+        Slang::ComPtr<slang::IBlob> diagnosticsBlob;
+        slang::IModule* module = slangSession->loadModule(shaderModuleName, diagnosticsBlob.writeRef());
+        diagnoseIfNeeded(diagnosticsBlob);
+        if (!module)
+            return SLANG_FAIL;
+
+        // Write loaded modules to memory file system.
+        for (SlangInt i = 0; i < slangSession->getLoadedModuleCount(); i++)
+        {
+            auto module = slangSession->getLoadedModule(i);
+            auto path = module->getFilePath();
+            if (path)
+            {
+                auto name = module->getName();
+                ComPtr<ISlangBlob> outBlob;
+                module->serialize(outBlob.writeRef());
+                fileSys->saveFileBlob((Slang::String(name) + ".slang-module").getBuffer(), outBlob);
+            }
+        }
+        return SLANG_OK;
+    }
+
+    void precompiledModuleTestImpl(IDevice* device, UnitTestContext* context)
+    {
+        Slang::ComPtr<ITransientResourceHeap> transientHeap;
+        ITransientResourceHeap::Desc transientHeapDesc = {};
+        transientHeapDesc.constantBufferSize = 4096;
+        GFX_CHECK_CALL_ABORT(
+            device->createTransientResourceHeap(transientHeapDesc, transientHeap.writeRef()));
+
+        // First, load and compile the slang source.
+        ComPtr<ISlangMutableFileSystem> memoryFileSystem = ComPtr<ISlangMutableFileSystem>(new Slang::MemoryFileSystem());
+
+        ComPtr<IShaderProgram> shaderProgram;
+        slang::ProgramLayout* slangReflection;
+        GFX_CHECK_CALL_ABORT(precompileProgram(device, memoryFileSystem.get(), "precompiled-module"));
+
+        // Next, load the precompiled slang program.
+        Slang::ComPtr<slang::ISession> slangSession;
+        device->getSlangSession(slangSession.writeRef());
+        slang::SessionDesc sessionDesc = {};
+        sessionDesc.targetCount = 1;
+        slang::TargetDesc targetDesc = {};
+        switch (device->getDeviceInfo().deviceType)
+        {
+        case gfx::DeviceType::DirectX12:
+            targetDesc.format = SLANG_DXIL;
+            targetDesc.profile = device->getSlangSession()->getGlobalSession()->findProfile("sm_6_1");
+            break;
+        case gfx::DeviceType::Vulkan:
+            targetDesc.format = SLANG_SPIRV;
+            targetDesc.profile = device->getSlangSession()->getGlobalSession()->findProfile("GLSL_460");
+            break;
+        }
+        sessionDesc.targets = &targetDesc;
+        sessionDesc.fileSystem = memoryFileSystem.get();
+        auto globalSession = slangSession->getGlobalSession();
+        globalSession->createSession(sessionDesc, slangSession.writeRef());
+        GFX_CHECK_CALL_ABORT(loadComputeProgram(device, slangSession, shaderProgram, "precompiled-module", "computeMain", slangReflection));
+
+        ComputePipelineStateDesc pipelineDesc = {};
+        pipelineDesc.program = shaderProgram.get();
+        ComPtr<gfx::IPipelineState> pipelineState;
+        GFX_CHECK_CALL_ABORT(
+            device->createComputePipelineState(pipelineDesc, pipelineState.writeRef()));
+
+        const int numberCount = 4;
+        float initialData[] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        IBufferResource::Desc bufferDesc = {};
+        bufferDesc.sizeInBytes = numberCount * sizeof(float);
+        bufferDesc.format = gfx::Format::Unknown;
+        bufferDesc.elementSize = sizeof(float);
+        bufferDesc.allowedStates = ResourceStateSet(
+            ResourceState::ShaderResource,
+            ResourceState::UnorderedAccess,
+            ResourceState::CopyDestination,
+            ResourceState::CopySource);
+        bufferDesc.defaultState = ResourceState::UnorderedAccess;
+        bufferDesc.memoryType = MemoryType::DeviceLocal;
+
+        ComPtr<IBufferResource> numbersBuffer;
+        GFX_CHECK_CALL_ABORT(device->createBufferResource(
+            bufferDesc,
+            (void*)initialData,
+            numbersBuffer.writeRef()));
+
+        ComPtr<IResourceView> bufferView;
+        IResourceView::Desc viewDesc = {};
+        viewDesc.type = IResourceView::Type::UnorderedAccess;
+        viewDesc.format = Format::Unknown;
+        GFX_CHECK_CALL_ABORT(
+            device->createBufferView(numbersBuffer, nullptr, viewDesc, bufferView.writeRef()));
+
+        // We have done all the set up work, now it is time to start recording a command buffer for
+        // GPU execution.
+        {
+            ICommandQueue::Desc queueDesc = { ICommandQueue::QueueType::Graphics };
+            auto queue = device->createCommandQueue(queueDesc);
+
+            auto commandBuffer = transientHeap->createCommandBuffer();
+            auto encoder = commandBuffer->encodeComputeCommands();
+
+            auto rootObject = encoder->bindPipeline(pipelineState);
+
+            ShaderCursor entryPointCursor(
+                rootObject->getEntryPoint(0)); // get a cursor the the first entry-point.
+            // Bind buffer view to the entry point.
+            entryPointCursor.getPath("buffer").setResource(bufferView);
+
+            encoder->dispatchCompute(1, 1, 1);
+            encoder->endEncoding();
+            commandBuffer->close();
+            queue->executeCommandBuffer(commandBuffer);
+            queue->waitOnHost();
+        }
+
+        compareComputeResult(
+            device,
+            numbersBuffer,
+            Slang::makeArray<float>(3.0f, 3.0f, 3.0f, 3.0f));
+    }
+
+    SLANG_UNIT_TEST(precompiledModuleD3D12)
+    {
+        runTestImpl(precompiledModuleTestImpl, unitTestContext, Slang::RenderApiFlag::D3D12);
+    }
+
+    SLANG_UNIT_TEST(precompiledModuleVulkan)
+    {
+        runTestImpl(precompiledModuleTestImpl, unitTestContext, Slang::RenderApiFlag::Vulkan);
+    }
+
+}

--- a/tools/gfx-unit-test/precompiled-module.slang
+++ b/tools/gfx-unit-test/precompiled-module.slang
@@ -1,0 +1,14 @@
+import "precompiled-module-imported";
+
+using namespace ns;
+
+// Main entry-point. 
+
+[shader("compute")]
+[numthreads(4, 1, 1)]
+void computeMain(
+    uint3 sv_dispatchThreadID : SV_DispatchThreadID,
+    uniform RWStructuredBuffer <float> buffer)
+{
+    buffer[sv_dispatchThreadID.x] = helperFunc() + helperFunc1();
+}


### PR DESCRIPTION
This PR addes support for serializing/deserializing checked modules (that contains AST+IR) from the `ISession` API, and allows `import` to find and load serialized modules.

This will allow our users to get rid of run-time Slang type checking cost by moving them to an offline build process.

The key change here is that we need a better handling of `Val` deserialization so the deserialized  module can have globally deduplicated `Val` objects that shares the deduplication dictionary with the currently loaded modules. To implement this, we separated out the logic of `Val` serialization/deserialization to be lazy/on-demand and bottleneck Val deserialization through `ASTBuilder::getOrCreateImpl`.