### PR TITLE
Fix SPIRV lowering issue.

### DIFF
--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -731,6 +731,10 @@ namespace Slang
                     // scope.
                     workList.add(fileDecl);
                 }
+                else if (auto namespaceDecl = as<NamespaceDecl>(globalDecl))
+                {
+                    workList.add(namespaceDecl);
+                }
             }
         }
     }

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -5287,6 +5287,7 @@ SlangResult emitSPIRVFromIR(
     for (auto ptrType : context.m_forwardDeclaredPointers)
     {
         auto spvPtrType = context.m_mapIRInstToSpvInst[ptrType];
+        context.ensureInst(ptrType->getValueType());
         auto parent = spvPtrType->parent;
         spvPtrType->removeFromParent();
         parent->addInst(spvPtrType);

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -5878,7 +5878,7 @@ SlangResult EndToEndCompileRequest::getEntryPointCodeBlob(int entryPointIndex, i
     SLANG_RETURN_ON_FAIL(_getEntryPointResult(this, entryPointIndex, targetIndex, artifact));
     SLANG_RETURN_ON_FAIL(artifact->loadBlob(ArtifactKeep::Yes, outBlob));
 
-    return SLANG_E_NOT_AVAILABLE;
+    return SLANG_OK;
 }
 
 SlangResult EndToEndCompileRequest::getEntryPointHostCallable(int entryPointIndex, int targetIndex, ISlangSharedLibrary** outSharedLibrary)
@@ -5887,7 +5887,7 @@ SlangResult EndToEndCompileRequest::getEntryPointHostCallable(int entryPointInde
     ComPtr<IArtifact> artifact;
     SLANG_RETURN_ON_FAIL(_getEntryPointResult(this, entryPointIndex, targetIndex, artifact));
     SLANG_RETURN_ON_FAIL(artifact->loadSharedLibrary(ArtifactKeep::Yes, outSharedLibrary));
-    return SLANG_E_NOT_AVAILABLE;
+    return SLANG_OK;
 }
 
 SlangResult EndToEndCompileRequest::getTargetCodeBlob(int targetIndex, ISlangBlob** outBlob)

--- a/tests/bugs/gh-3601.slang
+++ b/tests/bugs/gh-3601.slang
@@ -1,0 +1,56 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-directly
+struct TestStruct
+{
+    uint index;
+};
+
+[[vk::binding(2, 0)]] StructuredBuffer<uint64_t> test;
+
+struct PP
+{
+    int data;
+    int data2;
+}
+struct Data
+{
+    int data;
+    PP* pNext;
+};
+
+void funcThatTakesPointer(PP* p)
+{
+    p.data = 2;
+}
+int* funcThatReturnsPointer(PP* p)
+{
+    return &p.data;
+}
+
+// CHECK: OpEntryPoint
+
+[[vk::binding(0, 0)]] StructuredBuffer<Data> buffer;
+[[vk::binding(1, 0)]] RWStructuredBuffer<int> output;
+[shader("compute")]
+[numthreads(8, 8, 1)]
+void main(int id : SV_DispatchThreadID)
+{
+    TestStruct * ptr = (TestStruct *)(test[0]);
+    output[0] = buffer[ptr.index].pNext.data;
+    let pData = &(buffer[0].pNext.data);
+    // CHECK: OpPtrAccessChain
+    int* pData1 = pData + 1;
+    *pData1 = 3;
+    *(int2*)pData = int2(1, 2);
+    pData1[-1] = 2;
+    buffer[0].pNext[1] = {5};
+    // CHECK: OpConvertPtrToU
+    // CHECK: OpINotEqual
+    if (pData1)
+    {
+        *(funcThatReturnsPointer(buffer[0].pNext)) = 4;
+    }
+    if (pData1 > pData)
+    {
+        funcThatTakesPointer(buffer[0].pNext);
+    }
+}

--- a/tests/spirv/namespace-texture-array.slang
+++ b/tests/spirv/namespace-texture-array.slang
@@ -1,0 +1,20 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-directly
+struct ComputePush
+{
+    uint image_id;
+};
+[[vk::push_constant]] ComputePush p;
+
+namespace test_namespace
+{
+    [[vk::binding(0, 0)]] RWTexture2D<float4> textureTable[];
+}
+
+// CHECK: OpEntryPoint
+
+[shader("compute")]
+[numthreads(8, 8, 1)]
+void main(uint3 pixel_i : SV_DispatchThreadID)
+{
+    test_namespace.textureTable[p.image_id][pixel_i.xy] = float4(0,1,0,0);
+}

--- a/tests/spirv/pointer-bug.slang
+++ b/tests/spirv/pointer-bug.slang
@@ -1,0 +1,18 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-directly
+struct Foo {
+  float4 *positions;
+};
+
+struct Params {
+  Foo *foo;
+};
+
+// CHECK: %_ptr_PhysicalStorageBuffer_Foo = OpTypePointer PhysicalStorageBuffer %Foo
+
+[[vk::push_constant]] Params params;
+
+[shader("compute")]
+[numthreads(1,1,1)]
+void main() {
+  params.foo.positions[10] += float4(1, 1, 1, 1);
+}


### PR DESCRIPTION
Fix issues with pointers.

Fix an issue that causes global parameters defined in namespaces to miss layout.

Fixes #3595.
Fixes #3600.
Fixes #3601.
Fixes #3605.