### PR TITLE
Fixes building slang-bootstrap by linking with slang-lookup-tables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,7 +285,7 @@ generator(
     source/slangc
     TARGET_NAME slang-bootstrap
     USE_FEWER_WARNINGS
-    LINK_WITH_PRIVATE prelude slang-no-embedded-stdlib slang-capability-lookup Threads::Threads
+    LINK_WITH_PRIVATE prelude slang-no-embedded-stdlib slang-capability-lookup slang-lookup-tables Threads::Threads
 )
 
 #


### PR DESCRIPTION
Hi Slang team!

At the moment, ToT generates the following when running `cmake --preset vs2022; cmake --build --preset release --target slang-bootstrap` to build the slang-bootstrap target using CMake on Windows:

```output
slang-check-expr.obj : error LNK2019: unresolved external symbol "bool __cdecl Slang::lookupGLSLstd450(struct Slang::Un
ownedStringSlice const &,enum GLSLstd450 &)" (?lookupGLSLstd450@Slang@@YA_NAEBUUnownedStringSlice@1@AEAW4GLSLstd450@@@Z
) referenced in function "public: void __cdecl <lambda_95ea3229cd43cabe2973e50266723bf3>::operator()<class <lambda_95ea
3229cd43cabe2973e50266723bf3>,class Slang::SPIRVAsmOperand>(class <lambda_95ea3229cd43cabe2973e50266723bf3> const &,cla
ss Slang::SPIRVAsmOperand &)const " (??$?RV<lambda_95ea3229cd43cabe2973e50266723bf3>@@VSPIRVAsmOperand@Slang@@@<lambda_
95ea3229cd43cabe2973e50266723bf3>@@QEBAXAEBV0@AEAVSPIRVAsmOperand@Slang@@@Z) [C:\Users\nbickford\Documents\GitHub\slang
\build\slang-bootstrap.vcxproj]
slang-ir-spirv-snippet.obj : error LNK2001: unresolved external symbol "bool __cdecl Slang::lookupGLSLstd450(struct Sla
ng::UnownedStringSlice const &,enum GLSLstd450 &)" (?lookupGLSLstd450@Slang@@YA_NAEBUUnownedStringSlice@1@AEAW4GLSLstd4
50@@@Z) [C:\Users\nbickford\Documents\GitHub\slang\build\slang-bootstrap.vcxproj]
C:\Users\nbickford\Documents\GitHub\slang\build\generators\Release\bin\slang-bootstrap.exe : fatal error LNK1120: 1 unr
esolved externals [C:\Users\nbickford\Documents\GitHub\slang\build\slang-bootstrap.vcxproj]
```

This MR fixes it by linking slang-bootstrap with slang-lookup-tables, which provides `lookupGLSLstd450`. (`slang` itself links with `slang-lookup-tables` in `source/slang/CMakeLists.txt`. `slang-bootstrap` links with `slang-no-embedded-stdlib` which privately links with `slang-lookup-tables`; I believe the link isn't propagated to `slang-bootstrap` because it's private.)

Thanks!