### PR TITLE
CUDA prelude: Fixes compilation when using `SLANG_CUDA_ENABLE_HALF` without NVRTC

### DIFF
--- a/prelude/slang-cuda-prelude.h
+++ b/prelude/slang-cuda-prelude.h
@@ -363,11 +363,14 @@ SLANG_CUDA_VECTOR_FLOAT_OPS(__half)
 SLANG_CUDA_FLOAT_VECTOR_MOD(float)
 SLANG_CUDA_FLOAT_VECTOR_MOD(double)
 
-#if SLANG_CUDA_RTC
+#if SLANG_CUDA_RTC || SLANG_CUDA_ENABLE_HALF
 #define SLANG_MAKE_VECTOR(T) \
     SLANG_FORCE_INLINE SLANG_CUDA_CALL T##2 make_##T##2(T x, T y) { return T##2{x, y}; }\
     SLANG_FORCE_INLINE SLANG_CUDA_CALL T##3 make_##T##3(T x, T y, T z) { return T##3{ x, y, z }; }\
     SLANG_FORCE_INLINE SLANG_CUDA_CALL T##4 make_##T##4(T x, T y, T z, T w) { return T##4{ x, y, z, w }; }
+#endif
+
+#if SLANG_CUDA_RTC
 SLANG_MAKE_VECTOR(int)
 SLANG_MAKE_VECTOR(uint)
 SLANG_MAKE_VECTOR(short)
@@ -413,6 +416,9 @@ SLANG_MAKE_VECTOR_FROM_SCALAR(float)
 SLANG_MAKE_VECTOR_FROM_SCALAR(double)
 #if SLANG_CUDA_ENABLE_HALF
 SLANG_MAKE_VECTOR_FROM_SCALAR(__half)
+#if !SLANG_CUDA_RTC
+SLANG_FORCE_INLINE SLANG_CUDA_CALL __half1 make___half1(__half x) { return __half1{x}; }
+#endif
 #endif
 
 #define SLANG_CUDA_VECTOR_ATOMIC_BINARY_IMPL(Fn,T,N) \


### PR DESCRIPTION
Hi Slang team! This merge request modifies the CUDA prelude so that `nvcc` can compile code that uses it when `SLANG_CUDA_ENABLE_HALF` is defined and set to 1.

I've attached a repro case; `test-half-vector-calc.bat` transpiles `tests/compute/half-vector-calc.slang` to a CUDA source file using

```
slangc -target cuda ../../../tests/compute/half-vector-calc.slang -o half-vector-calc.slang.cuh
```

and then compiles the result to a `.cubin` using the following support file:

```cuda
// half-vector-calc.cu
#define SLANG_CUDA_ENABLE_HALF 1
#include "half-vector-calc.slang.cuh"

```

and the command line

```
nvcc half-vector-calc.cu --cubin --output-file half-vector-calc.cubin
```

Currently, this generates a lot of errors, originating in two places:
* `SLANG_MAKE_VECTOR()` is only defined if `SLANG_CUDA_RTC` is enabled, but is used if `SLANG_CUDA_ENABLE_HALF` is enabled.
* `SLANG_MAKE_VECTOR_FROM_SCALAR()` creates functions for `__half2`, `__half3`, and `__half4`. `GET_VECTOR_TYPE_IMPL_N(__half)`, later in the prelude, attempts to use `make___half1()`, which doesn't exist. (Adding the motivation here in case I forget: `__half1` is its own struct instead of a typedef of `__half` to match how CUDA's `vector_types.h` defines other 1-element vector types as their own structs.)

Thanks!

[test-half-vector-calc.zip](https://github.com/shader-slang/slang/files/14392279/test-half-vector-calc.zip)