### PR TITLE
WAR for ForceInline not working issue in stdlib

### DIFF
--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -905,7 +905,9 @@ LoweredValInfo emitCallToDeclRef(
     {
         if(!ctorDeclRef.getDecl()->body && isFromStdLib(ctorDeclRef.getDecl()) && !as<InterfaceDecl>(ctorDeclRef.getParent().getDecl()))
         {
+#if 0 // Workaround for an issue 3628
             SLANG_UNREACHABLE("stdlib error: __init() has no definition.");
+#endif
         }
     }
 

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -901,16 +901,6 @@ LoweredValInfo emitCallToDeclRef(
             args));
     }
 
-    if( auto ctorDeclRef = funcDeclRef.as<ConstructorDecl>() )
-    {
-        if(!ctorDeclRef.getDecl()->body && isFromStdLib(ctorDeclRef.getDecl()) && !as<InterfaceDecl>(ctorDeclRef.getParent().getDecl()))
-        {
-#if 0 // Workaround for an issue 3628
-            SLANG_UNREACHABLE("stdlib error: __init() has no definition.");
-#endif
-        }
-    }
-
     // Fallback case is to emit an actual call.
     //
     LoweredValInfo funcVal = emitDeclRef(context, funcDeclRef, funcType);


### PR DESCRIPTION
Work-around for an issue #3628

This commit allows __init() functions in stdlib to be decleared without "[__unsafeForceInlineEarly]" or "[ForceInline]".

We need to find a proper solution for the issue later.