### PR TITLE
Allow default values for `extern` symbols.

### DIFF
--- a/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj
+++ b/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj
@@ -304,6 +304,7 @@
     <ClCompile Include="..\..\..\tools\gfx-unit-test\gfx-test-util.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\instanced-draw-tests.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\link-time-constant.cpp" />
+    <ClCompile Include="..\..\..\tools\gfx-unit-test\link-time-default.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\link-time-options.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\link-time-type.cpp" />
     <ClCompile Include="..\..\..\tools\gfx-unit-test\mutable-shader-object.cpp" />

--- a/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj.filters
+++ b/build/visual-studio/gfx-unit-test-tool/gfx-unit-test-tool.vcxproj.filters
@@ -68,6 +68,9 @@
     <ClCompile Include="..\..\..\tools\gfx-unit-test\link-time-constant.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\tools\gfx-unit-test\link-time-default.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\tools\gfx-unit-test\link-time-options.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -146,6 +146,7 @@ class AggTypeDecl : public  AggTypeDeclBase
 
     // Used if this type declaration is a wrapper, i.e. struct FooWrapper:IFoo = Foo;
     TypeExp wrappedType;
+    bool hasBody = true;
 
     void unionTagsWith(TypeTag other);
     void addTag(TypeTag tag);

--- a/source/slang/slang-check-conformance.cpp
+++ b/source/slang/slang-check-conformance.cpp
@@ -279,18 +279,16 @@ namespace Slang
     }
 
 
-    Type* SemanticsVisitor::getBufferElementType(Type* type)
+    Type* SemanticsVisitor::getConstantBufferElementType(Type* type)
     {
         if (auto arrType = as<ArrayExpressionType>(type))
-            return getBufferElementType(arrType->getElementType());
+            return getConstantBufferElementType(arrType->getElementType());
         if (auto modifiedType = as<ModifiedType>(type))
-            return getBufferElementType(modifiedType->getBase());
+            return getConstantBufferElementType(modifiedType->getBase());
         if (auto constantBuffer = as<ConstantBufferType>(type))
             return constantBuffer->getElementType();
-        if (auto structuredBuffer = as<HLSLStructuredBufferTypeBase>(type))
-            return structuredBuffer->getElementType();
-        if (auto storageBuffer = as<GLSLShaderStorageBufferType>(type))
-            return storageBuffer->getElementType();
+        if (auto parameterBlock = as<ParameterBlockType>(type))
+            return parameterBlock->getElementType();
         return nullptr;
     }
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1978,7 +1978,7 @@ namespace Slang
 
         TypeTag getTypeTags(Type* type);
 
-        Type* getBufferElementType(Type* type);
+        Type* getConstantBufferElementType(Type* type);
 
             /// Check whether `subType` is a sub-type of `superTypeDeclRef`,
             /// and return a witness to the sub-type relationship if it holds

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -484,7 +484,6 @@ DIAGNOSTIC(30504, Error, cannotUseInitializerListForType, "cannot use initialize
 
 // 3062x: variables
 DIAGNOSTIC(30620, Error, varWithoutTypeMustHaveInitializer, "a variable declaration without an initial-value expression must be given an explicit type")
-DIAGNOSTIC(30621, Error, externValueCannotHaveInitializer, "an 'extern' variable declaration cannot have a value.")
 DIAGNOSTIC(30622, Error, ambiguousDefaultInitializerForType, "more than one default initializer was found for type '$0'")
 
 // 307xx: parameters
@@ -713,6 +712,7 @@ DIAGNOSTIC(41904, Error, unableToAlignOf, "alignof could not be performed for ty
 
 DIAGNOSTIC(42001, Error, invalidUseOfTorchTensorTypeInDeviceFunc, "invalid use of TorchTensor type in device/kernel functions. use `TensorView` instead.")
 
+DIAGNOSTIC(45001, Error, unresolvedSymbol, "unresolved external symbol '$0'.")
 //
 // 5xxxx - Target code generation.
 //

--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -17,6 +17,7 @@ struct PeepholeContext : InstPassBase
     FloatingPointMode floatingPointMode = FloatingPointMode::Precise;
     bool removeOldInst = true;
     bool isInGeneric = false;
+    bool isPrelinking = false;
 
     TargetProgram* targetProgram;
 
@@ -695,6 +696,13 @@ struct PeepholeContext : InstPassBase
             {
                 if (inst->getOperand(0)->getOp() == kIROp_WitnessTable)
                 {
+                    // Don't fold witness lookups prelinking if the witness table is `extern`.
+                    // These witness tables provides `default`s in case they are not
+                    // explicitly specialized via other linked modules, therefore we don't want
+                    // to resolve them too soon before linking.
+                    if (isPrelinking && inst->getOperand(0)->findDecoration<IRImportDecoration>())
+                        break;
+
                     auto wt = as<IRWitnessTable>(inst->getOperand(0));
                     auto key = inst->getOperand(1);
                     for (auto item : wt->getChildren())
@@ -1069,10 +1077,11 @@ struct PeepholeContext : InstPassBase
     }
 };
 
-bool peepholeOptimize(TargetProgram* target, IRModule* module)
+bool peepholeOptimize(TargetProgram* target, IRModule* module, PeepholeOptimizationOptions options)
 {
     PeepholeContext context = PeepholeContext(module);
     context.targetProgram = target;
+    context.isPrelinking = options.isPrelinking;
     return context.processModule();
 }
 

--- a/source/slang/slang-ir-peephole.h
+++ b/source/slang/slang-ir-peephole.h
@@ -8,8 +8,19 @@ namespace Slang
     struct IRInst;
     class TargetProgram;
 
+    struct PeepholeOptimizationOptions
+    {
+        bool isPrelinking = false;
+        static PeepholeOptimizationOptions getPrelinking()
+        {
+            PeepholeOptimizationOptions result;
+            result.isPrelinking = true;
+            return result;
+        }
+    };
+
         /// Apply peephole optimizations.
-    bool peepholeOptimize(TargetProgram* target, IRModule* module);
+    bool peepholeOptimize(TargetProgram* target, IRModule* module, PeepholeOptimizationOptions options);
     bool peepholeOptimize(TargetProgram* target, IRInst* func);
     bool peepholeOptimizeGlobalScope(TargetProgram* target, IRModule* module);
     bool tryReplaceInstUsesWithSimplifiedValue(TargetProgram* target, IRModule* module, IRInst* inst);

--- a/source/slang/slang-ir-ssa-simplification.cpp
+++ b/source/slang/slang-ir-ssa-simplification.cpp
@@ -76,7 +76,7 @@ namespace Slang
         while (changed && iterationCounter < kMaxIterations)
         {
             changed = false;
-            changed |= peepholeOptimize(target, module);
+            changed |= peepholeOptimize(target, module, options.peepholeOptions);
 
             changed |= removeRedundancy(module);
             changed |= simplifyCFG(module, options.cfgOptions);

--- a/source/slang/slang-ir-ssa-simplification.h
+++ b/source/slang/slang-ir-ssa-simplification.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "slang-ir-simplify-cfg.h"
+#include "slang-ir-peephole.h"
 
 namespace Slang
 {
@@ -13,6 +14,8 @@ namespace Slang
     struct IRSimplificationOptions
     {
         CFGSimplificationOptions cfgOptions;
+        PeepholeOptimizationOptions peepholeOptions;
+
         static IRSimplificationOptions getDefault()
         {
             IRSimplificationOptions result;

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -32,7 +32,15 @@ namespace Slang
         if (!irObject)
             return;
         if (auto nameHint = irObject->findDecoration<IRNameHintDecoration>())
+        {
             sb << nameHint->getName();
+            return;
+        }
+        if (auto linkage = irObject->findDecoration<IRLinkageDecoration>())
+        {
+            sb << linkage->getMangledName();
+            return;
+        }
     }
 
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1878,6 +1878,8 @@ struct IRInterfaceRequirementEntry : IRInst
 struct IRInterfaceType : IRType
 {
     IR_LEAF_ISA(InterfaceType)
+
+    UInt getRequirementCount() { return getOperandCount(); }
 };
 
 struct IRConjunctionType : IRType

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -666,35 +666,13 @@ bool isImportedDecl(IRGenContext* context, Decl* decl)
         return true;
     }
 
-    ModuleDecl* moduleDecl = findModuleDecl(decl);
-    if (!moduleDecl)
-        return false;
-
-#if 0
-    // HACK: don't treat standard library code as
-    // being imported for right now, just because
-    // we don't load its IR in the same way as
-    // for other imports.
-    //
-    // TODO: Fix this the right way, by having standard
-    // library declarations have IR modules that we link
-    // in via the normal means.
-    if (isFromStdLib(decl))
-        return false;
-#endif
-
-    if (moduleDecl != context->getMainModuleDecl())
-        return true;
-
-    return false;
-}
-
-    /// Is `decl` a function that should be force-inlined early in compilation (before linking)?
-static bool isForceInlineEarly(Decl* decl)
-{
-    if(decl->hasModifier<UnsafeForceInlineEarlyAttribute>())
-        return true;
-
+    for (auto parent = decl; parent; parent = parent->parentDecl)
+    {
+        if (as<ModuleDecl>(parent) && parent != context->getMainModuleDecl())
+            return true;
+        if (parent->findModifier<ExternAttribute>() || parent->findModifier<ExternModifier>())
+            return true;
+    }
     return false;
 }
 
@@ -7596,12 +7574,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // the underlying storage.
         context->setGlobalValue(decl, globalVal);
 
-        if (isImportedDecl(decl))
-        {
-            // Always emit imported declarations as declarations,
-            // and not definitions.
-        }
-        else if( auto initExpr = decl->initExpr )
+        if( auto initExpr = decl->initExpr )
         {
             IRBuilder subBuilderStorage = *getBuilder();
             IRBuilder* subBuilder = &subBuilderStorage;
@@ -9104,12 +9077,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // pre-generated IR for the module that defines it (or do some kind
         // of minimal linking to bring in the inline functions).
         //
-        if (isImportedDecl(decl) && !isForceInlineEarly(decl))
-        {
-            // Always emit imported declarations as declarations,
-            // and not definitions.
-        }
-        else if (!decl->body)
+        if (!decl->body)
         {
             // This is a function declaration without a body.
             // In Slang we currently try not to support forward declarations
@@ -10373,7 +10341,7 @@ RefPtr<IRModule> generateIRForTranslationUnit(
     constructSSA(module);
     simplifyCFG(module, CFGSimplificationOptions::getDefault());
     applySparseConditionalConstantPropagation(module, compileRequest->getSink());
-    peepholeOptimize(nullptr, module);
+    peepholeOptimize(nullptr, module, PeepholeOptimizationOptions::getPrelinking());
 
     for (auto inst : module->getGlobalInsts())
     {
@@ -10422,7 +10390,7 @@ RefPtr<IRModule> generateIRForTranslationUnit(
         changed |= constructSSA(module);
         simplifyCFG(module, CFGSimplificationOptions::getDefault());
         changed |= applySparseConditionalConstantPropagation(module, compileRequest->getSink());
-        changed |= peepholeOptimize(nullptr, module);
+        changed |= peepholeOptimize(nullptr, module, PeepholeOptimizationOptions::getPrelinking());
         for (auto inst : module->getGlobalInsts())
         {
             if (auto func = as<IRGlobalValueWithCode>(inst))

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -4744,7 +4744,10 @@ namespace Slang
                 return rs;
             }
             if (AdvanceIf(this, TokenType::Semicolon))
+            {
+                rs->hasBody = false;
                 return rs;
+            }
             parseDeclBody(this, rs);
             return rs;
         });

--- a/source/slang/slang-serialize-container.cpp
+++ b/source/slang/slang-serialize-container.cpp
@@ -81,6 +81,8 @@ namespace Slang {
             SLANG_ASSERT(dstModule.irModule);
         }
         DigestBuilder<SHA1> digestBuilder;
+        auto version = String(getBuildTagString());
+        digestBuilder.append(version);
         module->getOptionSet().buildHash(digestBuilder);
         auto fileDependencies = module->getFileDependencies();
         String canonicalModulePath, moduleDir;

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3559,6 +3559,8 @@ bool Linkage::isBinaryModuleUpToDate(String fromPath, RiffContainer* container)
     
     auto& moduleHeader = containerData.modules[0];
     DigestBuilder<SHA1> digestBuilder;
+    auto version = String(getBuildTagString());
+    digestBuilder.append(version);
     m_optionSet.buildHash(digestBuilder);
     for (auto file : moduleHeader.dependentFiles)
     {

--- a/tests/diagnostics/unresolved-symbol.slang
+++ b/tests/diagnostics/unresolved-symbol.slang
@@ -1,0 +1,18 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target hlsl -entry main -profile cs_6_0
+interface IFoo
+{
+    int doThing();
+}
+
+// CHECK: ([[#@LINE+1]]): error 45001:
+extern struct Foo : IFoo;
+// CHECK: ([[#@LINE+1]]): error 45001:
+extern static const int c;
+
+RWStructuredBuffer<int> output;
+
+void main()
+{
+    Foo f;
+    output[0] = c + f.doThing();
+}

--- a/tools/gfx-unit-test/link-time-default.cpp
+++ b/tools/gfx-unit-test/link-time-default.cpp
@@ -1,0 +1,237 @@
+#include "tools/unit-test/slang-unit-test.h"
+
+#include "slang-gfx.h"
+#include "gfx-test-util.h"
+#include "tools/gfx-util/shader-cursor.h"
+#include "source/core/slang-basic.h"
+#include "source/core/slang-blob.h"
+
+using namespace gfx;
+
+namespace gfx_test
+{
+    static Slang::Result loadProgram(
+        gfx::IDevice* device,
+        Slang::ComPtr<gfx::IShaderProgram>& outShaderProgram,
+        slang::ProgramLayout*& slangReflection,
+        bool linkSpecialization = false)
+    {
+        const char* moduleInterfaceSrc = R"(
+            interface IFoo
+            {
+                static const int offset;
+                [mutating] void setValue(float v);
+                float getValue();
+                property float val2{get;set;}
+            }
+            struct FooImpl : IFoo
+            {
+                float val;
+                static const int offset = -1;
+                [mutating] void setValue(float v) { val = v; }
+                float getValue() { return val + 1.0; }
+                property float val2 {
+                    get { return val + 2.0; }
+                    set { val = newValue; }
+                }
+            };
+            struct BarImpl : IFoo
+            {
+                float val;
+                static const int offset = 2;
+                [mutating] void setValue(float v) { val = v; }
+                float getValue() { return val + 1.0; }
+                property float val2 {
+                    get { return val; }
+                    set { val = newValue; }
+                }
+            };
+        )";
+        const char* module0Src = R"(
+            import ifoo;
+            extern struct Foo : IFoo = FooImpl;
+            extern static const float c = 0.0;
+            [numthreads(1,1,1)]
+            void computeMain(uniform RWStructuredBuffer<float> buffer)
+            {
+                Foo foo;
+                foo.setValue(3.0);
+                buffer[0] = foo.getValue() + foo.val2 + Foo.offset + c;
+            }
+        )";
+        const char* module1Src = R"(
+            import ifoo;
+            export struct Foo : IFoo = BarImpl;
+            export static const float c = 1.0;
+        )";
+        Slang::ComPtr<slang::ISession> slangSession;
+        SLANG_RETURN_ON_FAIL(device->getSlangSession(slangSession.writeRef()));
+        Slang::ComPtr<slang::IBlob> diagnosticsBlob;
+        auto moduleInterfaceBlob = Slang::UnownedRawBlob::create(moduleInterfaceSrc, strlen(moduleInterfaceSrc));
+        auto module0Blob = Slang::UnownedRawBlob::create(module0Src, strlen(module0Src));
+        auto module1Blob = Slang::UnownedRawBlob::create(module1Src, strlen(module1Src));
+        slang::IModule* moduleInterface = slangSession->loadModuleFromSource("ifoo", "ifoo.slang",
+            moduleInterfaceBlob);
+        slang::IModule* module0 = slangSession->loadModuleFromSource("module0", "path0",
+            module0Blob);
+        slang::IModule* module1 = slangSession->loadModuleFromSource("module1", "path1",
+            module1Blob);
+        ComPtr<slang::IEntryPoint> computeEntryPoint;
+        SLANG_RETURN_ON_FAIL(
+            module0->findEntryPointByName("computeMain", computeEntryPoint.writeRef()));
+
+        Slang::List<slang::IComponentType*> componentTypes;
+        componentTypes.add(moduleInterface);
+        componentTypes.add(module0);
+        if (linkSpecialization)
+            componentTypes.add(module1);
+        componentTypes.add(computeEntryPoint);
+
+        Slang::ComPtr<slang::IComponentType> composedProgram;
+        SlangResult result = slangSession->createCompositeComponentType(
+            componentTypes.getBuffer(),
+            componentTypes.getCount(),
+            composedProgram.writeRef(),
+            diagnosticsBlob.writeRef());
+        diagnoseIfNeeded(diagnosticsBlob);
+        SLANG_RETURN_ON_FAIL(result);
+
+        ComPtr<slang::IComponentType> linkedProgram;
+        result = composedProgram->link(linkedProgram.writeRef(), diagnosticsBlob.writeRef());
+        diagnoseIfNeeded(diagnosticsBlob);
+        SLANG_RETURN_ON_FAIL(result);
+
+        composedProgram = linkedProgram;
+        slangReflection = composedProgram->getLayout();
+
+        gfx::IShaderProgram::Desc programDesc = {};
+        programDesc.slangGlobalScope = composedProgram.get();
+
+        auto shaderProgram = device->createProgram(programDesc);
+
+        outShaderProgram = shaderProgram;
+        return SLANG_OK;
+    }
+
+    void linkTimeDefaultTestImpl(IDevice* device, UnitTestContext* context)
+    {
+        Slang::ComPtr<ITransientResourceHeap> transientHeap;
+        ITransientResourceHeap::Desc transientHeapDesc = {};
+        transientHeapDesc.constantBufferSize = 4096;
+        GFX_CHECK_CALL_ABORT(
+            device->createTransientResourceHeap(transientHeapDesc, transientHeap.writeRef()));
+
+        // Create pipeline without linking a specialization override module, so we should
+        // see the default value of `extern Foo`.
+        ComPtr<IShaderProgram> shaderProgram;
+        slang::ProgramLayout* slangReflection;
+        GFX_CHECK_CALL_ABORT(loadProgram(device, shaderProgram, slangReflection, false));
+
+        ComputePipelineStateDesc pipelineDesc = {};
+        pipelineDesc.program = shaderProgram.get();
+        ComPtr<gfx::IPipelineState> pipelineState;
+        GFX_CHECK_CALL_ABORT(
+            device->createComputePipelineState(pipelineDesc, pipelineState.writeRef()));
+
+        // Create pipeline with a specialization override module linked in, so we should
+        // see the result of using `Bar` for `extern Foo`.
+        ComPtr<IShaderProgram> shaderProgram1;
+        GFX_CHECK_CALL_ABORT(loadProgram(device, shaderProgram1, slangReflection, true));
+
+        ComputePipelineStateDesc pipelineDesc1 = {};
+        pipelineDesc1.program = shaderProgram1.get();
+        ComPtr<gfx::IPipelineState> pipelineState1;
+        GFX_CHECK_CALL_ABORT(
+            device->createComputePipelineState(pipelineDesc1, pipelineState1.writeRef()));
+
+        const int numberCount = 4;
+        float initialData[] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        IBufferResource::Desc bufferDesc = {};
+        bufferDesc.sizeInBytes = numberCount * sizeof(float);
+        bufferDesc.format = gfx::Format::Unknown;
+        bufferDesc.elementSize = sizeof(float);
+        bufferDesc.allowedStates = ResourceStateSet(
+            ResourceState::ShaderResource,
+            ResourceState::UnorderedAccess,
+            ResourceState::CopyDestination,
+            ResourceState::CopySource);
+        bufferDesc.defaultState = ResourceState::UnorderedAccess;
+        bufferDesc.memoryType = MemoryType::DeviceLocal;
+
+        ComPtr<IBufferResource> numbersBuffer;
+        GFX_CHECK_CALL_ABORT(device->createBufferResource(
+            bufferDesc,
+            (void*)initialData,
+            numbersBuffer.writeRef()));
+
+        ComPtr<IResourceView> bufferView;
+        IResourceView::Desc viewDesc = {};
+        viewDesc.type = IResourceView::Type::UnorderedAccess;
+        viewDesc.format = Format::Unknown;
+        GFX_CHECK_CALL_ABORT(
+            device->createBufferView(numbersBuffer, nullptr, viewDesc, bufferView.writeRef()));
+
+        ICommandQueue::Desc queueDesc = { ICommandQueue::QueueType::Graphics };
+        auto queue = device->createCommandQueue(queueDesc);
+
+        // We have done all the set up work, now it is time to start recording a command buffer for
+        // GPU execution.
+        {
+            auto commandBuffer = transientHeap->createCommandBuffer();
+            auto encoder = commandBuffer->encodeComputeCommands();
+
+            auto rootObject = encoder->bindPipeline(pipelineState);
+
+            ShaderCursor entryPointCursor(
+                rootObject->getEntryPoint(0)); // get a cursor the the first entry-point.
+            // Bind buffer view to the entry point.
+            entryPointCursor.getPath("buffer").setResource(bufferView);
+
+            encoder->dispatchCompute(1, 1, 1);
+            encoder->endEncoding();
+            commandBuffer->close();
+            queue->executeCommandBuffer(commandBuffer);
+            queue->waitOnHost();
+        }
+
+        compareComputeResult(
+            device,
+            numbersBuffer,
+            Slang::makeArray<float>(8.0));
+
+        // Now run again with the overrided program.
+        {
+            auto commandBuffer = transientHeap->createCommandBuffer();
+            auto encoder = commandBuffer->encodeComputeCommands();
+
+            auto rootObject = encoder->bindPipeline(pipelineState1);
+
+            ShaderCursor entryPointCursor(
+                rootObject->getEntryPoint(0)); // get a cursor the the first entry-point.
+            // Bind buffer view to the entry point.
+            entryPointCursor.getPath("buffer").setResource(bufferView);
+
+            encoder->dispatchCompute(1, 1, 1);
+            encoder->endEncoding();
+            commandBuffer->close();
+            queue->executeCommandBuffer(commandBuffer);
+            queue->waitOnHost();
+        }
+
+        compareComputeResult(
+            device,
+            numbersBuffer,
+            Slang::makeArray<float>(10.0));
+    }
+
+    SLANG_UNIT_TEST(linkTimeDefaultD3D12)
+    {
+        runTestImpl(linkTimeDefaultTestImpl, unitTestContext, Slang::RenderApiFlag::D3D12);
+    }
+
+    SLANG_UNIT_TEST(linkTimeDefaultVulkan)
+    {
+        runTestImpl(linkTimeDefaultTestImpl, unitTestContext, Slang::RenderApiFlag::Vulkan);
+    }
+
+}


### PR DESCRIPTION
This changes enables `extern` types and constants to have default values that will be used when no other symbols of the same name are linked in.

Also allows incomplete `extern` types to be used as `StructuredBuffer` element types.

Includes the Slang compiler version in serialized module's digest.