### PR TITLE
Add support for shared resources on vulkan/linux

### DIFF
--- a/tools/gfx/vulkan/vk-buffer.cpp
+++ b/tools/gfx/vulkan/vk-buffer.cpp
@@ -57,10 +57,12 @@ Result VKBufferHandleRAII::init(
 #if SLANG_WINDOWS_FAMILY
     VkExportMemoryWin32HandleInfoKHR exportMemoryWin32HandleInfo = {
         VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR };
+#endif
     VkExportMemoryAllocateInfoKHR exportMemoryAllocateInfo = {
         VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_KHR };
     if (isShared)
     {
+#if SLANG_WINDOWS_FAMILY
         exportMemoryWin32HandleInfo.pNext = nullptr;
         exportMemoryWin32HandleInfo.pAttributes = nullptr;
         exportMemoryWin32HandleInfo.dwAccess =
@@ -71,10 +73,10 @@ Result VKBufferHandleRAII::init(
             extMemHandleType & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR
             ? &exportMemoryWin32HandleInfo
             : nullptr;
+#endif
         exportMemoryAllocateInfo.handleTypes = extMemHandleType;
         allocateInfo.pNext = &exportMemoryAllocateInfo;
     }
-#endif
     VkMemoryAllocateFlagsInfo flagInfo = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO };
     if (usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT)
     {
@@ -151,6 +153,22 @@ Result BufferResourceImpl::getSharedHandle(InteropHandle* outHandle)
     }
     SLANG_VK_RETURN_ON_FAIL(
         vkCreateSharedHandle(api->m_device, &info, (HANDLE*)&outHandle->handleValue));
+#else
+    VkMemoryGetFdInfoKHR info = {};
+    info.sType = VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR;
+    info.pNext = nullptr;
+    info.memory = m_buffer.m_memory;
+    info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+
+    auto api = m_buffer.m_api;
+    PFN_vkGetMemoryFdKHR vkCreateSharedHandle;
+    vkCreateSharedHandle = api->vkGetMemoryFdKHR;
+    if (!vkCreateSharedHandle)
+    {
+        return SLANG_FAIL;
+    }
+    SLANG_VK_RETURN_ON_FAIL(
+        vkCreateSharedHandle(api->m_device, &info, (int*)&outHandle->handleValue));
 #endif
     outHandle->api = InteropHandleAPI::Vulkan;
     return SLANG_OK;

--- a/tools/gfx/vulkan/vk-device.cpp
+++ b/tools/gfx/vulkan/vk-device.cpp
@@ -712,6 +712,11 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             {
                 deviceExtensions.add(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
             }
+#else
+            if (extensionNames.contains("VK_KHR_external_memory_fd"))
+            {
+                deviceExtensions.add(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
+            }
 #endif
             m_features.add("external-memory");
         }
@@ -1468,16 +1473,18 @@ Result DeviceImpl::createTextureResource(
 
     VkExternalMemoryImageCreateInfo externalMemoryImageCreateInfo = {
         VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO };
-#if SLANG_WINDOWS_FAMILY
     VkExternalMemoryHandleTypeFlags extMemoryHandleType =
+#if SLANG_WINDOWS_FAMILY
         VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
+#else
+        VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+#endif
     if (descIn.isShared)
     {
         externalMemoryImageCreateInfo.pNext = nullptr;
         externalMemoryImageCreateInfo.handleTypes = extMemoryHandleType;
         imageInfo.pNext = &externalMemoryImageCreateInfo;
     }
-#endif
     SLANG_VK_RETURN_ON_FAIL(m_api.vkCreateImage(m_device, &imageInfo, nullptr, &texture->m_image));
 
     VkMemoryRequirements memRequirements;
@@ -1497,10 +1504,12 @@ Result DeviceImpl::createTextureResource(
 #if SLANG_WINDOWS_FAMILY
     VkExportMemoryWin32HandleInfoKHR exportMemoryWin32HandleInfo = {
         VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR };
+#endif
     VkExportMemoryAllocateInfoKHR exportMemoryAllocateInfo = {
         VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_KHR };
     if (descIn.isShared)
     {
+#if SLANG_WINDOWS_FAMILY
         exportMemoryWin32HandleInfo.pNext = nullptr;
         exportMemoryWin32HandleInfo.pAttributes = nullptr;
         exportMemoryWin32HandleInfo.dwAccess =
@@ -1511,10 +1520,10 @@ Result DeviceImpl::createTextureResource(
             extMemoryHandleType & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR
             ? &exportMemoryWin32HandleInfo
             : nullptr;
+#endif
         exportMemoryAllocateInfo.handleTypes = extMemoryHandleType;
         allocInfo.pNext = &exportMemoryAllocateInfo;
     }
-#endif
     SLANG_VK_RETURN_ON_FAIL(
         m_api.vkAllocateMemory(m_device, &allocInfo, nullptr, &texture->m_imageMemory));
 
@@ -1731,13 +1740,19 @@ Result DeviceImpl::createBufferResourceImpl(
     RefPtr<BufferResourceImpl> buffer(new BufferResourceImpl(desc, this));
     if (desc.isShared)
     {
+        VkExternalMemoryHandleTypeFlagsKHR extMemHandleType
+#if SLANG_WINDOWS_FAMILY
+            = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
+#else
+            = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+#endif
         SLANG_RETURN_ON_FAIL(buffer->m_buffer.init(
             m_api,
             desc.sizeInBytes,
             usage,
             reqMemoryProperties,
             desc.isShared,
-            VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT));
+            extMemHandleType));
     }
     else
     {


### PR DESCRIPTION
Uses `VK_KHR_external_memory_fd` on Linux to shared memory.