### PR TITLE
Allow non-static const to be considered compile-time constant.

### DIFF
--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -1654,12 +1654,10 @@ namespace Slang
         if(_checkForCircularityInConstantFolding(decl, circularityInfo))
             return nullptr;
 
-        // In HLSL, `static const` is used to mark compile-time constant expressions
-        if(!decl->hasModifier<HLSLStaticModifier>())
-            return nullptr;
+        // In HLSL, `const` is used to mark compile-time constant expressions.
         if(!decl->hasModifier<ConstModifier>())
             return nullptr;
-        // Extern static const is not considered compile-time constant by the front-end.
+        // Extern const is not considered compile-time constant by the front-end.
         if (decl->hasModifier<ExternModifier>())
             return nullptr;
 

--- a/tests/bugs/gh-3643.slang
+++ b/tests/bugs/gh-3643.slang
@@ -1,0 +1,14 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -entry PSMain -stage fragment
+struct PSInput
+{
+	float4 color : COLOR;
+};
+
+// CHECK: OpEntryPoint
+
+float4 PSMain(PSInput input) : SV_TARGET
+{
+    const int nTaps = 2;
+    const float flOffsets[ nTaps ] = { 0.0, 0.1 };
+    return input.color.rgba + flOffsets[0].xxxx;
+}


### PR DESCRIPTION
Fixes #3643.