### PR TITLE
ignore spirv-tools submodule because it is always set to a commit outside of the publicly accessible repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,6 +16,7 @@
 [submodule "external/spirv-tools"]
 	path = external/spirv-tools
 	url = https://github.com/shader-slang/SPIRV-Tools.git
+	ignore = all
 [submodule "external/spirv-headers"]
 	path = external/spirv-headers
 	url = https://github.com/KhronosGroup/SPIRV-Headers.git


### PR DESCRIPTION
Git always shows the spirv-tools submodule as unstaged since the submodule points to a commit outside of the publicly accessible repository.
This makes it hard to work with the slang repo, so let's ignore all changes of the spirv-tools submodule.

Without this, `git status` always shows 
```git
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   external/spirv-tools (new commits)

no changes added to commit (use "git add" and/or "git commit -a")
```