### PR TITLE
[slangc] generate an error when `-entry` is not specified for targets that require them.

### DIFF
--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -2822,8 +2822,9 @@ SlangResult OptionsParser::_parse(
                         if (getCurrentTarget()->optionSet.shouldEmitSPIRVDirectly())
                         {
                             rawOutput.isWholeProgram = true;
+                            break;
                         }
-                        break;
+                        [[fallthrough]];
                     default:
                         m_sink->diagnose(SourceLoc(), Diagnostics::cannotMatchOutputFileToEntryPoint, rawOutput.path);
                         break;

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -2824,6 +2824,11 @@ SlangResult OptionsParser::_parse(
                             rawOutput.isWholeProgram = true;
                             break;
                         }
+                        else if (m_rawEntryPoints.getCount() != 0)
+                        {
+                            rawOutput.entryPointIndex = (int)m_rawEntryPoints.getCount() - 1;
+                            break;
+                        }
                         [[fallthrough]];
                     default:
                         m_sink->diagnose(SourceLoc(), Diagnostics::cannotMatchOutputFileToEntryPoint, rawOutput.path);

--- a/tests/diagnostics/vk-bindings.slang
+++ b/tests/diagnostics/vk-bindings.slang
@@ -1,6 +1,6 @@
 // vk-bindings.slang
 
-//DIAGNOSTIC_TEST:SIMPLE:-target spirv
+//DIAGNOSTIC_TEST:SIMPLE:-entry main -target spirv
 
 // D3D `register` without VK binding
 Texture2D t : register(t0);


### PR DESCRIPTION
Fixes #3676.