### PR TITLE
Parser and module finding logic fixes.

### DIFF
--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -2724,7 +2724,8 @@ namespace Slang
         {
             if(typeSpec.decl)
             {
-                if(peekToken(parser).flags & TokenFlag::AtStartOfLine)
+                if( peekToken(parser).type == TokenType::EndOfFile ||
+                    (peekToken(parser).flags & TokenFlag::AtStartOfLine))
                 {
                     // The token after the `}` is at the start of its
                     // own line, which means it can't be on the same line.
@@ -4453,7 +4454,7 @@ namespace Slang
         parser->pendingModifiers = &modifiers;
 
         auto loc = parser->tokenReader.peekLoc();
-
+        auto ptoken = parser->tokenReader.peekToken();
         switch (peekTokenType(parser))
         {
         case TokenType::Identifier:

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3444,7 +3444,7 @@ bool Linkage::isBeingImported(Module* module)
     // and then appending `.slang`.
     //
     // For example, `foo_bar` becomes `foo-bar.slang`.
-String getFileNameFromModuleName(Name* name)
+String getFileNameFromModuleName(Name* name, bool translateUnderScore)
 {
     String fileName;
     if (!getText(name).getUnownedSlice().endsWithCaseInsensitive(".slang"))
@@ -3452,7 +3452,7 @@ String getFileNameFromModuleName(Name* name)
         StringBuilder sb;
         for (auto c : getText(name))
         {
-            if (c == '_')
+            if (translateUnderScore && c == '_')
                 c = '-';
 
             sb.append(c);
@@ -3519,61 +3519,65 @@ RefPtr<Module> Linkage::findOrImportModule(
     PathInfo pathIncludedFromInfo = getSourceManager()->getPathInfo(loc, SourceLocType::Actual);
     PathInfo filePathInfo;
 
-    auto moduleSourceFileName = getFileNameFromModuleName(name);
 
     // Look for a precompiled module first, if not exist, load from source.
     for (int checkBinaryModule = 1; checkBinaryModule >= 0; checkBinaryModule--)
     {
-        String fileName;
-        if (checkBinaryModule == 1)
-            fileName = Path::replaceExt(moduleSourceFileName, "slang-module");
-        else
-            fileName = moduleSourceFileName;
-
-        ComPtr<ISlangBlob> fileContents;
-
-        // We have to load via the found path - as that is how file was originally loaded
-        if (SLANG_FAILED(includeSystem.findFile(fileName, pathIncludedFromInfo.foundPath, filePathInfo)))
+        // Try without translating `_` to `-` first, if that fails, try translating.
+        for (int translateUnderScore = 0; translateUnderScore <= 1; translateUnderScore++)
         {
-            if (name && name->text == "glsl")
-            {
-                // This is a builtin glsl module, just load it from embedded definition.
-                fileContents = getSessionImpl()->getGLSLLibraryCode();
-                filePathInfo = PathInfo::makeFromString("glsl");
-                checkBinaryModule = 0;
-            }
+            auto moduleSourceFileName = getFileNameFromModuleName(name, translateUnderScore == 1);
+            String fileName;
+            if (checkBinaryModule == 1)
+                fileName = Path::replaceExt(moduleSourceFileName, "slang-module");
             else
+                fileName = moduleSourceFileName;
+
+            ComPtr<ISlangBlob> fileContents;
+
+            // We have to load via the found path - as that is how file was originally loaded
+            if (SLANG_FAILED(includeSystem.findFile(fileName, pathIncludedFromInfo.foundPath, filePathInfo)))
+            {
+                if (name && name->text == "glsl")
+                {
+                    // This is a builtin glsl module, just load it from embedded definition.
+                    fileContents = getSessionImpl()->getGLSLLibraryCode();
+                    filePathInfo = PathInfo::makeFromString("glsl");
+                    checkBinaryModule = 0;
+                }
+                else
+                {
+                    continue;
+                }
+            }
+
+            // Maybe this was loaded previously at a different relative name?
+            if (mapPathToLoadedModule.tryGetValue(filePathInfo.getMostUniqueIdentity(), loadedModule))
+                return loadedModule;
+
+            // Try to load it
+            if (!fileContents && SLANG_FAILED(includeSystem.loadFile(filePathInfo, fileContents)))
             {
                 continue;
             }
+
+            // We've found a file that we can load for the given module, so
+            // go ahead and perform the module-load action
+            auto resultModule = loadModule(
+                name,
+                filePathInfo,
+                fileContents,
+                loc,
+                sink,
+                loadedModules,
+                (checkBinaryModule == 1 ? ModuleBlobType::IR : ModuleBlobType::Source));
+            if (resultModule)
+                return resultModule;
         }
-
-        // Maybe this was loaded previously at a different relative name?
-        if (mapPathToLoadedModule.tryGetValue(filePathInfo.getMostUniqueIdentity(), loadedModule))
-            return loadedModule;
-
-        // Try to load it
-        if (!fileContents && SLANG_FAILED(includeSystem.loadFile(filePathInfo, fileContents)))
-        {
-            continue;
-        }
-
-        // We've found a file that we can load for the given module, so
-        // go ahead and perform the module-load action
-        auto resultModule = loadModule(
-            name,
-            filePathInfo,
-            fileContents,
-            loc,
-            sink,
-            loadedModules,
-            (checkBinaryModule == 1 ? ModuleBlobType::IR : ModuleBlobType::Source));
-        if (resultModule)
-            return resultModule;
     }
 
     // Error: we cannot find the file.
-    sink->diagnose(loc, Diagnostics::cannotOpenFile, moduleSourceFileName);
+    sink->diagnose(loc, Diagnostics::cannotOpenFile, getFileNameFromModuleName(name, false));
     mapNameToLoadedModules[name] = nullptr;
     return nullptr;
 }
@@ -3643,32 +3647,38 @@ SLANG_NO_THROW bool SLANG_MCALL Linkage::isBinaryModuleUpToDate(const char* modu
 
 SourceFile* Linkage::findFile(Name* name, SourceLoc loc, IncludeSystem& outIncludeSystem)
 {
-    auto fileName = getFileNameFromModuleName(name);
-
-    // Next, try to find the file of the given name,
-    // using our ordinary include-handling logic.
-
-    auto searchDirs = getSearchDirectories();
-    outIncludeSystem = IncludeSystem(&searchDirs, getFileSystemExt(), getSourceManager());
-
-    // Get the original path info
-    PathInfo pathIncludedFromInfo = getSourceManager()->getPathInfo(loc, SourceLocType::Actual);
-    PathInfo filePathInfo;
-
-    ComPtr<ISlangBlob> fileContents;
-
-    // We have to load via the found path - as that is how file was originally loaded
-    if (SLANG_FAILED(outIncludeSystem.findFile(fileName, pathIncludedFromInfo.foundPath, filePathInfo)))
+    auto impl = [&](bool translateUnderScore)->SourceFile*
     {
-        return nullptr;
-    }
-    // Otherwise, try to load it.
-    SourceFile* sourceFile;
-    if (SLANG_FAILED(outIncludeSystem.loadFile(filePathInfo, fileContents, sourceFile)))
-    {
-        return nullptr;
-    }
-    return sourceFile;
+        auto fileName = getFileNameFromModuleName(name, translateUnderScore);
+
+        // Next, try to find the file of the given name,
+        // using our ordinary include-handling logic.
+
+        auto searchDirs = getSearchDirectories();
+        outIncludeSystem = IncludeSystem(&searchDirs, getFileSystemExt(), getSourceManager());
+
+        // Get the original path info
+        PathInfo pathIncludedFromInfo = getSourceManager()->getPathInfo(loc, SourceLocType::Actual);
+        PathInfo filePathInfo;
+
+        ComPtr<ISlangBlob> fileContents;
+
+        // We have to load via the found path - as that is how file was originally loaded
+        if (SLANG_FAILED(outIncludeSystem.findFile(fileName, pathIncludedFromInfo.foundPath, filePathInfo)))
+        {
+            return nullptr;
+        }
+        // Otherwise, try to load it.
+        SourceFile* sourceFile;
+        if (SLANG_FAILED(outIncludeSystem.loadFile(filePathInfo, fileContents, sourceFile)))
+        {
+            return nullptr;
+        }
+        return sourceFile;
+    };
+    if (auto rs = impl(false))
+        return rs;
+    return impl(true);
 }
 
 Linkage::IncludeResult Linkage::findAndIncludeFile(Module* module, TranslationUnitRequest* translationUnit, Name* name, SourceLoc const& loc, DiagnosticSink* sink)

--- a/tests/language-feature/modules/module-name-underscore/my_module.slang
+++ b/tests/language-feature/modules/module-name-underscore/my_module.slang
@@ -1,0 +1,1 @@
+int f() { return 1; }

--- a/tests/language-feature/modules/module-name-underscore/underscore.slang
+++ b/tests/language-feature/modules/module-name-underscore/underscore.slang
@@ -1,0 +1,13 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -shaderobj -output-using-type
+
+import my_module;
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=output
+RWStructuredBuffer<int> output;
+
+void computeMain()
+{
+    output[0] = f();
+    // CHECK: 1
+}

--- a/tools/gfx-unit-test/link-time-type.cpp
+++ b/tools/gfx-unit-test/link-time-type.cpp
@@ -49,8 +49,7 @@ namespace gfx_test
         )";
         const char* module1Src = R"(
             import ifoo;
-            export struct Foo : IFoo = FooImpl;
-        )";
+            export struct Foo : IFoo = FooImpl;)";
         Slang::ComPtr<slang::ISession> slangSession;
         SLANG_RETURN_ON_FAIL(device->getSlangSession(slangSession.writeRef()));
         Slang::ComPtr<slang::IBlob> diagnosticsBlob;


### PR DESCRIPTION
Fix parsing error when a `struct` type is followed immediately by `EOF` without a line break.
Closes #3716.

Fix `loadModule` translating `_` to `-`. Now trys without the translation, and only translate when that fails.
Closes #3715.