### PR TITLE
Add `-fvk-use-dx-position-w` and fix ExecutionMode ordering for geometry shaders.

### DIFF
--- a/docs/user-guide/08-compiling.md
+++ b/docs/user-guide/08-compiling.md
@@ -660,6 +660,7 @@ meanings of their `CompilerOptionValue` encodings.
 | VulkanBindShift | Specifies the `-fvk-bind-shift` option. `intValue0` (higher 8 bits): kind, `intValue0` (lower bits): set; `intValue1`: shift. |
 | VulkanBindGlobals | Specifies the `-fvk-bind-globals` option. `intValue0`: index, `intValue`: set. |
 | VulkanInvertY | Specifies the `-fvk-invert-y` option. `intValue0` specifies a bool value for the setting. |
+| VulkanUseDxPositionW | Specifies the `-fvk-use-dx-position-w` option. `intValue0` specifies a bool value for the setting. |
 | VulkanUseEntryPointName | When set, will keep the original name of entrypoints as they are defined in the source instead of renaming them to `main`. `intValue0` specifies a bool value for the setting. |
 | VulkanUseGLLayout | When set, will use std430 layout instead of D3D buffer layout for raw buffer load/stores. `intValue0` specifies a bool value for the setting. |
 | VulkanEmitReflection | Specifies the `-fspv-reflect` option. When set will include additional reflection instructions in the output SPIRV. `intValue0` specifies a bool value for the setting. |

--- a/slang.h
+++ b/slang.h
@@ -874,6 +874,7 @@ extern "C"
             VulkanBindShift,            // intValue0 (higher 8 bits): kind; intValue0(lower bits): set; intValue1: shift
             VulkanBindGlobals,          // intValue0: index; intValue1: set
             VulkanInvertY,              // bool
+            VulkanUseDxPositionW,       // bool
             VulkanUseEntryPointName,    // bool
             VulkanUseGLLayout,          // bool
             VulkanEmitReflection,       // bool

--- a/source/slang/slang-compiler-options.cpp
+++ b/source/slang/slang-compiler-options.cpp
@@ -113,6 +113,7 @@ namespace Slang
                 case CompilerOptionName::MatrixLayoutRow:
                 case CompilerOptionName::MatrixLayoutColumn:
                 case CompilerOptionName::VulkanInvertY:
+                case CompilerOptionName::VulkanUseDxPositionW:
                 case CompilerOptionName::VulkanUseEntryPointName:
                 case CompilerOptionName::VulkanUseGLLayout:
                 case CompilerOptionName::VulkanEmitReflection:

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -3096,24 +3096,24 @@ struct SPIRVEmitContext
             break;
         case kIROp_StreamOutputTypeDecoration:
             {
-                for (auto inputDecor : decoration->parent->getDecorations())
+                for (auto inputDecor : decoration->getParent()->getDecorations())
                 {
                     switch (inputDecor->getOp())
                     {
                     case kIROp_TriangleInputPrimitiveTypeDecoration:
-                        emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), decoration, dstID, SpvExecutionModeTriangles);
+                        emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), inputDecor, dstID, SpvExecutionModeTriangles);
                         break;
                     case kIROp_LineInputPrimitiveTypeDecoration:
-                        emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), decoration, dstID, SpvExecutionModeInputLines);
+                        emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), inputDecor, dstID, SpvExecutionModeInputLines);
                         break;
                     case kIROp_LineAdjInputPrimitiveTypeDecoration:
-                        emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), decoration, dstID, SpvExecutionModeInputLinesAdjacency);
+                        emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), inputDecor, dstID, SpvExecutionModeInputLinesAdjacency);
                         break;
                     case kIROp_PointInputPrimitiveTypeDecoration:
-                        emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), decoration, dstID, SpvExecutionModeInputPoints);
+                        emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), inputDecor, dstID, SpvExecutionModeInputPoints);
                         break;
                     case kIROp_TriangleAdjInputPrimitiveTypeDecoration:
-                        emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), decoration, dstID, SpvExecutionModeInputTrianglesAdjacency);
+                        emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), inputDecor, dstID, SpvExecutionModeInputTrianglesAdjacency);
                         break;
                     }
                 }

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -3087,22 +3087,36 @@ struct SPIRVEmitContext
             }
             break;
         case kIROp_TriangleInputPrimitiveTypeDecoration:
-            emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), decoration, dstID, SpvExecutionModeTriangles);
-            break;
         case kIROp_LineInputPrimitiveTypeDecoration:
-            emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), decoration, dstID, SpvExecutionModeInputLines);
-            break;
         case kIROp_LineAdjInputPrimitiveTypeDecoration:
-            emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), decoration, dstID, SpvExecutionModeInputLinesAdjacency);
-            break;
         case kIROp_PointInputPrimitiveTypeDecoration:
-            emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), decoration, dstID, SpvExecutionModeInputPoints);
-            break;
         case kIROp_TriangleAdjInputPrimitiveTypeDecoration:
-            emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), decoration, dstID, SpvExecutionModeInputTrianglesAdjacency);
+            // Defer this until we see kIROp_StreamOutputTypeDecoration because the driver wants to see
+            // them before the output.
             break;
         case kIROp_StreamOutputTypeDecoration:
             {
+                for (auto inputDecor : decoration->parent->getDecorations())
+                {
+                    switch (inputDecor->getOp())
+                    {
+                    case kIROp_TriangleInputPrimitiveTypeDecoration:
+                        emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), decoration, dstID, SpvExecutionModeTriangles);
+                        break;
+                    case kIROp_LineInputPrimitiveTypeDecoration:
+                        emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), decoration, dstID, SpvExecutionModeInputLines);
+                        break;
+                    case kIROp_LineAdjInputPrimitiveTypeDecoration:
+                        emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), decoration, dstID, SpvExecutionModeInputLinesAdjacency);
+                        break;
+                    case kIROp_PointInputPrimitiveTypeDecoration:
+                        emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), decoration, dstID, SpvExecutionModeInputPoints);
+                        break;
+                    case kIROp_TriangleAdjInputPrimitiveTypeDecoration:
+                        emitOpExecutionMode(getSection(SpvLogicalSectionID::ExecutionModes), decoration, dstID, SpvExecutionModeInputTrianglesAdjacency);
+                        break;
+                    }
+                }
                 // SPIRV requires MaxVertexCount decoration to appear before OutputTopologyDecoration,
                 // so we emit them here.
                 if (auto maxVertexCount = decoration->getParent()->findDecoration<IRMaxVertexCountDecoration>())

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -934,6 +934,8 @@ Result linkAndOptimizeIR(
         legalizeUniformBufferLoad(irModule);
         if (targetProgram->getOptionSet().getBoolOption(CompilerOptionName::VulkanInvertY))
             invertYOfPositionOutput(irModule);
+        if (targetProgram->getOptionSet().getBoolOption(CompilerOptionName::VulkanUseDxPositionW))
+            rcpWOfPositionInput(irModule);
     }
 
     // Lower sizeof/alignof

--- a/source/slang/slang-hlsl-to-vulkan-layout-options.cpp
+++ b/source/slang/slang-hlsl-to-vulkan-layout-options.cpp
@@ -53,7 +53,6 @@ void HLSLToVulkanLayoutOptions::loadFromOptionSet(CompilerOptionSet& optionSet)
             m_globalsBinding.set = (*bindGlobals)[0].intValue2;
         }
     }
-    m_invertY = optionSet.getBoolOption(CompilerOptionName::VulkanInvertY);
     m_useGLLayout = optionSet.getBoolOption(CompilerOptionName::VulkanUseGLLayout);
     m_useOriginalEntryPointName = optionSet.getBoolOption(CompilerOptionName::VulkanUseEntryPointName);
 
@@ -123,7 +122,7 @@ Index HLSLToVulkanLayoutOptions::getShift(Kind kind, Index set) const
 
 bool HLSLToVulkanLayoutOptions::hasState() const
 {
-    return canInferBindings() || hasGlobalsBinding() || shouldInvertY() || getUseOriginalEntryPointName()
+    return canInferBindings() || hasGlobalsBinding() || getUseOriginalEntryPointName()
         || shouldUseGLLayout() || shouldEmitSPIRVReflectionInfo();
 }
 

--- a/source/slang/slang-hlsl-to-vulkan-layout-options.h
+++ b/source/slang/slang-hlsl-to-vulkan-layout-options.h
@@ -119,9 +119,6 @@ public:
         /// True if can infer a binding for a kind
     bool canInferBindingForKind(Kind kind) const { return (m_kindShiftEnabledFlags & getKindFlag(kind)) != 0; }
 
-        /// True if the compiler should invert the Y coordinate of any SV_Position output.
-    bool shouldInvertY() const { return m_invertY; }
-
     bool shouldUseGLLayout() const { return m_useGLLayout; }
 
     bool shouldEmitSPIRVReflectionInfo() const { return m_emitSPIRVReflectionInfo; }
@@ -151,8 +148,6 @@ public:
     void setGlobalsBinding(const Binding& binding);
         /// Get the globals binding
     const Binding& getGlobalsBinding() const { return m_globalsBinding; }
-
-    void setInvertY(bool value) { m_invertY = value; }
 
     void setUseOriginalEntryPointName(bool value) { m_useOriginalEntryPointName = value; }
 
@@ -185,9 +180,6 @@ protected:
 
         /// Maps a key to the amount of shift
     Dictionary<Key, Index> m_shifts;
-
-        /// Whether to invert the Y coordinate of SV_Position output.
-    bool m_invertY = false;
 
         /// If set, will use the original entry point name in the generated SPIRV instead of "main".
     bool m_useOriginalEntryPointName = false;

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -335,6 +335,7 @@ enum GLSLSystemValueKind
 {
     General,
     PositionOutput,
+    PositionInput,
 };
 
 struct GLSLSystemValueInfo
@@ -569,6 +570,7 @@ GLSLSystemValueInfo* getGLSLSystemValueInfo(
             && kind == LayoutResourceKind::VaryingInput )
         {
             name = "gl_FragCoord";
+            systemValueKind = GLSLSystemValueKind::PositionInput;
         }
         else if( stage == Stage::Geometry
             && kind == LayoutResourceKind::VaryingInput )
@@ -1007,6 +1009,9 @@ void createVarLayoutForLegalizedGlobalParam(
         {
         case GLSLSystemValueKind::PositionOutput:
             builder->addGLPositionOutputDecoration(globalParam);
+            break;
+        case GLSLSystemValueKind::PositionInput:
+            builder->addGLPositionInputDecoration(globalParam);
             break;
         default:
             break;

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -859,6 +859,9 @@ INST(HighLevelDeclDecoration,               highLevelDecl,          1, 0)
     INST(GLSLPrimitivesRateDecoration, perprimitive, 0, 0)
         // Marks an inst that represents the gl_Position output.
     INST(GLPositionOutputDecoration, PositionOutput, 0, 0)
+        // Marks an inst that represents the gl_Position input.
+    INST(GLPositionInputDecoration, PositionInput, 0, 0)
+
 
     /* StageAccessDecoration */
         INST(StageReadAccessDecoration, stageReadAccess, 0, 0)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -1366,6 +1366,11 @@ struct IRGLPositionOutputDecoration : public IRDecoration
     IR_LEAF_ISA(GLPositionOutputDecoration)
 };
 
+struct IRGLPositionInputDecoration : public IRDecoration
+{
+    IR_LEAF_ISA(GLPositionInputDecoration)
+};
+
 struct IRMeshOutputRef : public IRInst
 {
     enum { kOp = kIROp_MeshOutputRef };
@@ -4295,6 +4300,11 @@ public:
     void addGLPositionOutputDecoration(IRInst* value)
     {
         addDecoration(value, kIROp_GLPositionOutputDecoration);
+    }
+
+    void addGLPositionInputDecoration(IRInst* value)
+    {
+        addDecoration(value, kIROp_GLPositionInputDecoration);
     }
 
     void addInterpolationModeDecoration(IRInst* value, IRInterpolationMode mode)

--- a/source/slang/slang-ir-vk-invert-y.h
+++ b/source/slang/slang-ir-vk-invert-y.h
@@ -5,6 +5,7 @@ namespace Slang
 {
     struct IRModule;
     void invertYOfPositionOutput(IRModule* module);
+    void rcpWOfPositionInput(IRModule* module);
 }
 
 #endif

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -399,6 +399,7 @@ void initCommandOptions(CommandOptions& options)
         { OptionKind::VulkanBindGlobals, "-fvk-bind-globals", "-fvk-bind-globals <N> <descriptor-set>",
         "Places the $Globals cbuffer at descriptor set <descriptor-set> and binding <N>."},
         { OptionKind::VulkanInvertY, "-fvk-invert-y", nullptr, "Negates (additively inverts) SV_Position.y before writing to stage output."},
+        { OptionKind::VulkanUseDxPositionW, "-fvk-use-dx-position-w", nullptr, "Reciprocates (multiplicatively inverts) SV_Position.w after reading from stage input. For use in fragment shaders only."},
         { OptionKind::VulkanUseEntryPointName, "-fvk-use-entrypoint-name", nullptr, "Uses the entrypoint name from the source instead of 'main' in the spirv output."},
         { OptionKind::VulkanUseGLLayout, "-fvk-use-gl-layout", nullptr, "Use std430 layout instead of D3D buffer layout for raw buffer load/stores."},
         { OptionKind::VulkanEmitReflection, "-fspv-reflect", nullptr, "Include reflection decorations in the resulting SPIRV for shader parameters."},
@@ -1681,6 +1682,7 @@ SlangResult OptionsParser::_parse(
             case OptionKind::ValidateIr:
             case OptionKind::DumpIr:
             case OptionKind::VulkanInvertY:
+            case OptionKind::VulkanUseDxPositionW:
             case OptionKind::VulkanUseEntryPointName:
             case OptionKind::VulkanUseGLLayout:
             case OptionKind::VulkanEmitReflection:

--- a/tests/cross-compile/geometry-decoration-ordering.slang
+++ b/tests/cross-compile/geometry-decoration-ordering.slang
@@ -1,0 +1,16 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -emit-spirv-directly -entry main -stage geometry
+
+// Make sure OutputTriangleStrip always appears after OutputVertices,
+// otherwise, the shader won't work correctly.
+
+// CHECK: OpExecutionMode {{.*}} OutputVertices 4
+// CHECK: OpExecutionMode {{.*}} OutputTriangleStrip
+
+[maxvertexcount(4)]
+void main( point float4 input[1], inout TriangleStream<float4> OutputStream )
+{
+    OutputStream.Append(float4(0));
+    OutputStream.Append(float4(1));
+    OutputStream.Append(float4(2));
+    OutputStream.Append(float4(3));
+}

--- a/tests/spirv/geometry-decoration-ordering.slang
+++ b/tests/spirv/geometry-decoration-ordering.slang
@@ -1,8 +1,9 @@
 //TEST:SIMPLE(filecheck=CHECK):-target spirv -emit-spirv-directly -entry main -stage geometry
 
-// Make sure OutputTriangleStrip always appears after OutputVertices,
+// Make sure InputPoints always appears before OutputVertices and OutputTriangleStrip,
 // otherwise, the shader won't work correctly.
 
+// CHECK: OpExecutionMode {{.*}} InputPoints
 // CHECK: OpExecutionMode {{.*}} OutputVertices 4
 // CHECK: OpExecutionMode {{.*}} OutputTriangleStrip
 

--- a/tests/spirv/rcp-w-fragment.slang
+++ b/tests/spirv/rcp-w-fragment.slang
@@ -1,0 +1,7 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -entry main -stage fragment -fvk-use-dx-position-w -emit-spirv-directly
+
+// CHECK: OpFDiv
+float4 main(float4 pos : SV_Position) : SV_Target
+{
+    return pos;
+}


### PR DESCRIPTION
Closes #3732.

Also it appears that 
`OpExecutionMode %main InputPoints` must appear before `OpExecutionMode %main OutputVertices 4` and `OutputTriangleStrip` in the SPIRV for the shader to work properly, despite no validation rules states so. This PR fixes the problem and always emit input execution modes before output execution modes for geometry shaders.
Fixes #3733.