### PR TITLE
Link-time specialization fixes.

### DIFF
--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -95,6 +95,9 @@ class VarDeclBase : public Decl
 
     // Initializer expression (optional)
     Expr* initExpr = nullptr;
+
+    // Folded IntVal if the initializer is a constant integer.
+    IntVal* val = nullptr;
 };
 
 // Ordinary potentially-mutable variables (locals, globals, and member variables)

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -144,6 +144,8 @@ class IntVal : public Val
 
     bool isLinkTimeVal();
     bool _isLinkTimeValOverride() { return false; }
+    Val* linkTimeResolve(Dictionary<String, IntVal*>& mapMangledNameToVal);
+    Val* _linkTimeResolveOverride(Dictionary<String, IntVal*>&) { return this; }
 };
 
 // Trivial case of a value that is just a constant integer
@@ -180,6 +182,7 @@ class GenericParamIntVal : public IntVal
     }
 
     bool _isLinkTimeValOverride();
+    Val* _linkTimeResolveOverride(Dictionary<String, IntVal*>& map);
 };
 
 class TypeCastIntVal : public IntVal
@@ -204,6 +207,9 @@ class TypeCastIntVal : public IntVal
             return intBase->isLinkTimeVal();
         return false;
     }
+
+    Val* _linkTimeResolveOverride(Dictionary<String, IntVal*>& map);
+
 };
 
 // An compile time int val as result of some general computation.
@@ -238,6 +244,8 @@ class FuncCallIntVal : public IntVal
         }
         return false;
     }
+
+    Val* _linkTimeResolveOverride(Dictionary<String, IntVal*>& map);
 };
 
 class WitnessLookupIntVal : public IntVal

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -3559,24 +3559,24 @@ namespace Slang
                 auto noDiffThisAttr = m_astBuilder->create<NoDiffThisAttribute>();
                 addModifier(synFuncDecl, noDiffThisAttr);
             }
-            if (requiredMemberDeclRef.getDecl()->hasModifier<ForwardDifferentiableAttribute>())
-            {
-                auto attr = m_astBuilder->create<ForwardDifferentiableAttribute>();
-                addModifier(synFuncDecl, attr);
-            }
-            if (requiredMemberDeclRef.getDecl()->hasModifier<BackwardDifferentiableAttribute>())
-            {
-                auto attr = m_astBuilder->create<BackwardDifferentiableAttribute>();
-                addModifier(synFuncDecl, attr);
-            }
-            // The visibility of synthesized decl should be the min of the parent decl and the requirement.
-            if (requiredMemberDeclRef.getDecl()->findModifier<VisibilityModifier>())
-            {
-                auto requirementVisibility = getDeclVisibility(requiredMemberDeclRef.getDecl());
-                auto thisVisibility = getDeclVisibility(context->parentDecl);
-                auto visibility = Math::Min(thisVisibility, requirementVisibility);
-                addVisibilityModifier(m_astBuilder, synFuncDecl, visibility);
-            }
+        }
+        if (requiredMemberDeclRef.getDecl()->hasModifier<ForwardDifferentiableAttribute>())
+        {
+            auto attr = m_astBuilder->create<ForwardDifferentiableAttribute>();
+            addModifier(synFuncDecl, attr);
+        }
+        if (requiredMemberDeclRef.getDecl()->hasModifier<BackwardDifferentiableAttribute>())
+        {
+            auto attr = m_astBuilder->create<BackwardDifferentiableAttribute>();
+            addModifier(synFuncDecl, attr);
+        }
+        // The visibility of synthesized decl should be the min of the parent decl and the requirement.
+        if (requiredMemberDeclRef.getDecl()->findModifier<VisibilityModifier>())
+        {
+            auto requirementVisibility = getDeclVisibility(requiredMemberDeclRef.getDecl());
+            auto thisVisibility = getDeclVisibility(context->parentDecl);
+            auto visibility = Math::Min(thisVisibility, requirementVisibility);
+            addVisibilityModifier(m_astBuilder, synFuncDecl, visibility);
         }
 
         return synFuncDecl;

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1538,7 +1538,6 @@ namespace Slang
 
                 varDecl->initExpr = initExpr;
                 varDecl->type.type = initExpr->type;
-
                 _validateCircularVarDefinition(varDecl);
             }
             
@@ -1599,6 +1598,19 @@ namespace Slang
                 varDecl->type.type = newMatrixType;
                 if (varDecl->initExpr)
                     varDecl->initExpr = coerce(CoercionSite::Initializer, varDecl->type, varDecl->initExpr);
+            }
+        }
+
+        if (varDecl->initExpr)
+        {
+            if (as<BasicExpressionType>(varDecl->type.type))
+            {
+                auto parentDecl = getParentDecl(varDecl);
+                if (varDecl->findModifier<ConstModifier>() &&
+                    (as<NamespaceDeclBase>(parentDecl) || as<FileDecl>(parentDecl) || varDecl->findModifier<HLSLStaticModifier>()))
+                {
+                    varDecl->val = tryConstantFoldExpr(varDecl->initExpr, ConstantFoldingKind::LinkTime, nullptr);
+                }
             }
         }
 

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -1305,7 +1305,7 @@ namespace Slang
             sink);
     }
 
-    Scope* ComponentType::_createScopeForLegacyLookup(ASTBuilder* astBuilder)
+    Scope* ComponentType::_getOrCreateScopeForLegacyLookup(ASTBuilder* astBuilder)
     {
         // The shape of this logic is dictated by the legacy
         // behavior for name-based lookup/parsing of types
@@ -1316,6 +1316,8 @@ namespace Slang
         // definitions (that scope is necessary because
         // it defines keywords like `true` and `false`).
         //
+        if (m_lookupScope)
+            return m_lookupScope;
 
         Scope* scope = astBuilder->create<Scope>();
         scope->parent = getLinkage()->getSessionImpl()->slangLanguageScope;
@@ -1338,7 +1340,7 @@ namespace Slang
                 scope->nextSibling = moduleScope;
             }
         }
-
+        m_lookupScope = scope;
         return scope;
     }
 
@@ -1359,7 +1361,7 @@ namespace Slang
         // We create the scopes on the linkages ASTBuilder. We might want to create a temporary ASTBuilder,
         // and let that memory get freed, but is like this because it's not clear if the scopes in ASTNode members
         // will dangle if we do.
-        Scope* scope = unspecialiedProgram->_createScopeForLegacyLookup(endToEndReq->getLinkage()->getASTBuilder());
+        Scope* scope = unspecialiedProgram->_getOrCreateScopeForLegacyLookup(endToEndReq->getLinkage()->getASTBuilder());
 
         // We are going to do some semantic checking, so we need to
         // set up a `SemanticsVistitor` that we can use.

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -404,6 +404,9 @@ namespace Slang
             String const&   typeStr,
             DiagnosticSink* sink);
 
+        Dictionary<String, IntVal*>& getMangledNameToIntValMap();
+        ConstantIntVal* tryFoldIntVal(IntVal* intVal);
+
             /// Get a list of modules that this component type depends on.
             ///
         virtual List<Module*> const& getModuleDependencies() = 0;
@@ -526,7 +529,7 @@ namespace Slang
             /// This facility is only needed to support legacy APIs for string-based lookup
             /// and parsing via Slang reflection, and is not recommended for future APIs to use.
             ///
-        Scope* _createScopeForLegacyLookup(ASTBuilder* astBuilder);
+        Scope* _getOrCreateScopeForLegacyLookup(ASTBuilder* astBuilder);
 
     protected:
         ComponentType(Linkage* linkage);
@@ -544,6 +547,9 @@ namespace Slang
         // TODO: Remove this. Type lookup should only be supported on `Module`s.
         //
         Dictionary<String, Type*> m_types;
+
+        Scope* m_lookupScope = nullptr;
+        std::unique_ptr<Dictionary<String, IntVal*>> m_mapMangledNameToIntVal;
     };
 
         /// A component type built up from other component types.

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -2718,6 +2718,7 @@ static RefPtr<EntryPointLayout> collectEntryPointParameters(
     auto entryPointType = DeclRefType::create(astBuilder, entryPointFuncDeclRef);
 
     entryPointLayout->entryPoint = entryPointFuncDeclRef;
+    entryPointLayout->program = context->getTargetProgram()->getProgram();
 
     // For the duration of our parameter collection work we will
     // establish this entry point as the current one in the context.

--- a/source/slang/slang-reflection-api.cpp
+++ b/source/slang/slang-reflection-api.cpp
@@ -2811,12 +2811,18 @@ SLANG_API void spReflectionEntryPoint_getComputeThreadGroupSize(
     auto numThreadsAttribute = entryPointFunc.getDecl()->findModifier<NumThreadsAttribute>();
     if (numThreadsAttribute)
     {
-        if (auto cint = as<ConstantIntVal>(numThreadsAttribute->x))
+        if (auto cint = entryPointLayout->program->tryFoldIntVal(numThreadsAttribute->x))
             sizeAlongAxis[0] = (SlangUInt)cint->getValue();
-        if (auto cint = as<ConstantIntVal>(numThreadsAttribute->y))
+        else if (numThreadsAttribute->x)
+            sizeAlongAxis[0] = 0;
+        if (auto cint = entryPointLayout->program->tryFoldIntVal(numThreadsAttribute->y))
             sizeAlongAxis[1] = (SlangUInt)cint->getValue();
-        if (auto cint = as<ConstantIntVal>(numThreadsAttribute->z))
+        else if (numThreadsAttribute->y)
+            sizeAlongAxis[1] = 0;
+        if (auto cint = entryPointLayout->program->tryFoldIntVal(numThreadsAttribute->z))
             sizeAlongAxis[2] = (SlangUInt)cint->getValue();
+        else if (numThreadsAttribute->z)
+            sizeAlongAxis[2] = 0;
     }
 
     //

--- a/source/slang/slang-type-layout.h
+++ b/source/slang/slang-type-layout.h
@@ -793,6 +793,8 @@ public:
     // The corresponding function declaration
     DeclRef<FuncDecl> entryPoint;
 
+    ComponentType* program = nullptr;
+
     DeclRef<FuncDecl> getFuncDeclRef() { return entryPoint; }
     FuncDecl* getFuncDecl() { return entryPoint.getDecl(); }
 

--- a/tools/gfx-unit-test/link-time-constant.cpp
+++ b/tools/gfx-unit-test/link-time-constant.cpp
@@ -79,9 +79,13 @@ namespace gfx_test
             R"(
                 export static const bool turnOnFeature = true;
                 export static const float constValue = 2.0;
-                export static const int numthread = 1;
+                export static const int numthread = 2;
                 export static const int arraySize = 4;
             )"));
+        
+        SlangUInt threadGroupSizes[3];
+        slangReflection->findEntryPointByName("computeMain")->getComputeThreadGroupSize(3, threadGroupSizes);
+        SLANG_CHECK(threadGroupSizes[0] == 2 && threadGroupSizes[1] == 1 && threadGroupSizes[2] == 1);
 
         ComputePipelineStateDesc pipelineDesc = {};
         pipelineDesc.program = shaderProgram.get();

--- a/tools/gfx-unit-test/link-time-type.cpp
+++ b/tools/gfx-unit-test/link-time-type.cpp
@@ -20,6 +20,8 @@ namespace gfx_test
             {
                 [Differentiable]
                 float getBaseValue();
+                [Differentiable]
+                static float getBaseValueS();
             }
             interface IFoo : IBase
             {
@@ -36,6 +38,8 @@ namespace gfx_test
                 float getValue() { return val + 1.0; }
                 [Differentiable]
                 float getBaseValue() { return val; }
+                [Differentiable]
+                static float getBaseValueS() { return 0.0; }
                 property float val2 {
                     get { return val + 2.0; }
                     set { val = newValue; }


### PR DESCRIPTION
- Fix method synthesis logic for static differentiable methods.
- Support link-time constants in thread group size reflection.

Closes #3735.
Closes #3736.