### PR TITLE
Fix side effect checking around storage buffer type.

### DIFF
--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -107,6 +107,40 @@ public in uvec3 gl_WorkGroupID : SV_GroupID;
 public in uvec3 gl_LocalInvocationIndex : SV_GroupIndex;
 public in uvec3 gl_LocalInvocationID : SV_GroupThreadID;
 
+[require(glsl)]
+[require(spirv)]
+public property uint3 gl_NumWorkGroups {
+
+    get {
+        __target_switch
+        {
+        case glsl:
+            __intrinsic_asm "(gl_NumWorkGroups)";
+        case spirv:
+            return spirv_asm {
+                    result:$$uint3 = OpLoad builtin(NumWorkgroups:uint3);
+                };
+        }
+    }
+}
+
+[require(glsl)]
+[require(spirv)]
+public property uint3 gl_WorkGroupSize {
+
+    get {
+        __target_switch
+        {
+        case glsl:
+            __intrinsic_asm "(gl_WorkGroupSize)";
+        case spirv:
+            return spirv_asm {
+                    result:$$uint3 = OpLoad builtin(WorkgroupSize:uint3);
+                };
+        }
+    }
+}
+
 // TODO: define overload for tessellation control stage.
 public in int gl_InvocationID : SV_GSInstanceID;
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1755,7 +1755,7 @@ namespace Slang
                     !varDecl->findModifier<OutModifier>() &&
                     !varDecl->findModifier<GLSLBufferModifier>())
                 {
-                    if (!as<ResourceType>(varDecl->type) && !as<PointerLikeType>(varDecl->type))
+                    if (!isUniformParameterType(varDecl->type))
                     {
                         auto staticModifier = m_astBuilder->create<HLSLStaticModifier>();
                         addModifier(varDecl, staticModifier);

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -318,6 +318,8 @@ namespace Slang
             return true;
         if (as<UniformParameterGroupType>(type))
             return true;
+        if (as< GLSLShaderStorageBufferType>(type))
+            return true;
         if (as<SamplerStateType>(type))
             return true;
         return false;

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -689,6 +689,7 @@ bool isPtrLikeOrHandleType(IRInst* type)
     case kIROp_PtrType:
     case kIROp_RefType:
     case kIROp_ConstRefType:
+    case kIROp_GLSLShaderStorageBufferType:
         return true;
     }
     return false;
@@ -1175,6 +1176,11 @@ bool isGlobalOrUnknownMutableAddress(IRGlobalValueWithCode* parentFunc, IRInst* 
 
     if (root)
     {
+        if (as<IRGLSLShaderStorageBufferType>(root->getDataType()))
+        {
+            // A storage buffer is mutable, so we need to treat it as a mutable address.
+            return true;
+        }
         // If this is a global readonly resource, it is not a mutable address.
         if (as<IRParameterGroupType>(root->getDataType()))
         {

--- a/tests/glsl/storage-buffer-side-effect.slang
+++ b/tests/glsl/storage-buffer-side-effect.slang
@@ -1,0 +1,24 @@
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl
+#version 430
+precision highp float;
+precision highp int;
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
+
+buffer MyBlockName2
+{
+    uint data[1];
+} outputBuffer;
+
+layout(local_size_x = 4) in;
+
+void sideEffectInit(int val)
+{
+    outputBuffer.data[0] = val;
+}
+void computeMain()
+{
+    outputBuffer.data[0] = 1000;
+    sideEffectInit(4);
+    // BUF: 4
+}


### PR DESCRIPTION
Fixes #3746.

Fixes reflection on storage buffers.

Add gl_NumWorkGroup and gl_WorkGorupSize builtins.

Fix implicit `uniform` logic for glsl mode.