### PR TITLE
Changes to make UE TSR working with Slang.

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1073,7 +1073,7 @@ __magic_type(MatrixExpressionType)
 struct matrix : IArray<vector<T,C>>
 {
     __intrinsic_op($(kIROp_MakeMatrixFromScalar))
-    __implicit_conversion($(kConversionCost_ScalarToVector))
+    __implicit_conversion($(kConversionCost_ScalarToMatrix))
     [TreatAsDifferentiable]
     __init(T val);
 
@@ -1158,13 +1158,13 @@ extension matrix<T,N,M,L> : IFloat
     [OverloadRank(-1)]
     [TreatAsDifferentiable]
     [__unsafeForceInlineEarly]
-    __implicit_conversion($(kConversionCost_ScalarToVector))
+    __implicit_conversion($(kConversionCost_IntegerToFloatConversion))
     __init(int v) { this = matrix<T,N,M>(T(v)); }
 
     [OverloadRank(-1)]
     [TreatAsDifferentiable]
     [__unsafeForceInlineEarly]
-    __implicit_conversion($(kConversionCost_ScalarToVector))
+    __implicit_conversion($(kConversionCost_ScalarToMatrix))
     __init(float v) { this = matrix<T,N,M>(T(v)); }
 
     // IDifferentiable.
@@ -1259,7 +1259,7 @@ for (int tt = 0; tt < kBaseTypeCount; ++tt)
 
     sb << "extension " << tname << "\n";
     sb << "{\n";
-    sb << "    __implicit_conversion($(kConversionCost_ScalarToVector))\n";
+    sb << "    __implicit_conversion($(kConversionCost_VectorToScalar))\n";
     sb << "    __init(vector<" << tname << ",1> v) { this = v[0]; }\n";
     sb << "}\n";
 }

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1259,7 +1259,7 @@ for (int tt = 0; tt < kBaseTypeCount; ++tt)
 
     sb << "extension " << tname << "\n";
     sb << "{\n";
-    sb << "    __implicit_conversion(" << kConversionCost_VectorToScalar << ")\n";
+    sb << "    __implicit_conversion(" << kConversionCost_OneVectorToScalar << ")\n";
     sb << "    __init(vector<" << tname << ",1> v) { this = v[0]; }\n";
     sb << "}\n";
 }

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1259,7 +1259,7 @@ for (int tt = 0; tt < kBaseTypeCount; ++tt)
 
     sb << "extension " << tname << "\n";
     sb << "{\n";
-    sb << "    __implicit_conversion($(kConversionCost_VectorToScalar))\n";
+    sb << "    __implicit_conversion(" << kConversionCost_VectorToScalar << ")\n";
     sb << "    __init(vector<" << tname << ",1> v) { this = v[0]; }\n";
     sb << "}\n";
 }

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1158,7 +1158,7 @@ extension matrix<T,N,M,L> : IFloat
     [OverloadRank(-1)]
     [TreatAsDifferentiable]
     [__unsafeForceInlineEarly]
-    __implicit_conversion($(kConversionCost_IntegerToFloatConversion))
+    __implicit_conversion($(kConversionCost_ScalarIntegerToFloatMatrix))
     __init(int v) { this = matrix<T,N,M>(T(v)); }
 
     [OverloadRank(-1)]

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1073,6 +1073,7 @@ __magic_type(MatrixExpressionType)
 struct matrix : IArray<vector<T,C>>
 {
     __intrinsic_op($(kIROp_MakeMatrixFromScalar))
+    __implicit_conversion($(kConversionCost_ScalarToVector))
     [TreatAsDifferentiable]
     __init(T val);
 
@@ -1107,9 +1108,9 @@ extension vector<T,N> : IFloat
     [__unsafeForceInlineEarly] float toFloat() { return __realCast<float>(this[0]); }
 
     [OverloadRank(-1)]
-    [__unsafeForceInlineEarly] __init(int v) { return vector<T,N>(T(v)); }
+    [__unsafeForceInlineEarly] __init(int v) { this = vector<T,N>(T(v)); }
     [OverloadRank(-1)]
-    [__unsafeForceInlineEarly] __init(float v) { return vector<T,N>(T(v)); }
+    [__unsafeForceInlineEarly] __init(float v) { this = vector<T,N>(T(v)); }
 
     // IDifferentiable
 
@@ -1155,9 +1156,16 @@ extension matrix<T,N,M,L> : IFloat
     [TreatAsDifferentiable][__unsafeForceInlineEarly] float toFloat() { return __realCast<float>(this[0][0]); }
 
     [OverloadRank(-1)]
-    [TreatAsDifferentiable][__unsafeForceInlineEarly] __init(int v) { return matrix<T,N,M>(T(v)); }
+    [TreatAsDifferentiable]
+    [__unsafeForceInlineEarly]
+    __implicit_conversion($(kConversionCost_ScalarToVector))
+    __init(int v) { this = matrix<T,N,M>(T(v)); }
+
     [OverloadRank(-1)]
-    [TreatAsDifferentiable][__unsafeForceInlineEarly] __init(float v) { return matrix<T,N,M>(T(v)); }
+    [TreatAsDifferentiable]
+    [__unsafeForceInlineEarly]
+    __implicit_conversion($(kConversionCost_ScalarToVector))
+    __init(float v) { this = matrix<T,N,M>(T(v)); }
 
     // IDifferentiable.
     typedef matrix<T, N,M,L> Differential;
@@ -1183,6 +1191,14 @@ extension matrix<T,N,M,L> : IFloat
     {
         return __realCast<T, U>(a) * b;
     }
+}
+
+__generic<let R : int, let C : int, let L : int>
+extension matrix<int16_t,R,C,L>
+{
+    typealias T = int16_t;
+    __implicit_conversion($(kConversionCost_IntegerToShort))
+    __init(int value) { this = matrix<T,R,C,L>(T(value)); }
 }
 
 ${{{{
@@ -1230,6 +1246,22 @@ for (int tt = 0; tt < kTypeCount; ++tt)
     {
         sb << "typedef matrix<" << kTypes[tt].name << "," << rr << "," << cc << "> " << kTypes[tt].name << rr << "x" << cc << ";\n";
     }
+}
+
+sb << "\n\n";
+sb << "// Cast from vector<T,1> to T, which is a scalar type\n";
+
+for (int tt = 0; tt < kBaseTypeCount; ++tt)
+{
+    if(kBaseTypes[tt].tag == BaseType::Void) continue;
+
+    const char* tname = kBaseTypes[tt].name;
+
+    sb << "extension " << tname << "\n";
+    sb << "{\n";
+    sb << "    __implicit_conversion($(kConversionCost_ScalarToVector))\n";
+    sb << "    __init(vector<" << tname << ",1> v) { this = v[0]; }\n";
+    sb << "}\n";
 }
 
 // Declare additional built-in generic types
@@ -1426,6 +1458,19 @@ for( int C = 2; C <= 4; ++C )
         if(rr == R && cc == C) continue;
         sb << "__intrinsic_op(" << int(kIROp_MatrixReshape) << ") __init(matrix<T," << rr << "," << cc << ", L> value);\n";
     }
+
+    // Initialize from matrix and vector
+    if (R > 2)
+    {
+        sb << "__init(matrix<T," << (R - 1) << "," << C << "> m, vector<T," << C << "> row" << (R - 1) << ") ";
+        sb << "{ this = This(";
+        for (int ii = 0; ii < R - 1; ++ii)
+        {
+            sb << "m[" << ii << "], ";
+        }
+        sb << "row" << (R - 1) << "); }\n";
+    }
+
     sb << "}\n";
 }
 

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1197,7 +1197,7 @@ __generic<let R : int, let C : int, let L : int>
 extension matrix<int16_t,R,C,L>
 {
     typealias T = int16_t;
-    __implicit_conversion($(kConversionCost_IntegerToShort))
+    __implicit_conversion($(kConversionCost_IntegerTruncate))
     __init(int value) { this = matrix<T,R,C,L>(T(value)); }
 }
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -7172,6 +7172,7 @@ __target_intrinsic(glsl)
 __target_intrinsic(spirv, "OpTranspose resultType resultId _0")
 [__readNone]
 [PreferRecompute]
+[OverloadRank(-1)]
 matrix<T, M, N> transpose(matrix<T, N, M> x)
 {
     matrix<T, M, N> result;

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -143,8 +143,8 @@ namespace Slang
         // Default case (usable for user-defined conversions)
         kConversionCost_Default = 500,
 
-	// Cost of converting an integer to int16_t
-        kConversionCost_IntegerToShort = 700,
+        // Cost of converting an integer to int16_t
+        kConversionCost_IntegerTruncate = 700,
 
         // Catch-all for conversions that should be discouraged
         // (i.e., that really shouldn't be made implicitly)
@@ -161,7 +161,7 @@ namespace Slang
         // the element type of the vector)
         kConversionCost_ScalarToVector = 1,
         kConversionCost_VectorToScalar = 1,
-        kConversionCost_ScalarToMatrix = 1,
+        kConversionCost_ScalarToMatrix = 10,
 
         // Additional cost when casting an LValue.
         kConversionCost_LValueCast = 800,

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -143,6 +143,9 @@ namespace Slang
         // Default case (usable for user-defined conversions)
         kConversionCost_Default = 500,
 
+	// Cost of converting an integer to int16_t
+        kConversionCost_IntegerToShort = 700,
+
         // Catch-all for conversions that should be discouraged
         // (i.e., that really shouldn't be made implicitly)
         //

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -162,6 +162,7 @@ namespace Slang
         kConversionCost_ScalarToVector = 1,
         kConversionCost_VectorToScalar = 1,
         kConversionCost_ScalarToMatrix = 10,
+        kConversionCost_ScalarIntegerToFloatMatrix = kConversionCost_IntegerToFloatConversion + kConversionCost_ScalarToMatrix,
 
         // Additional cost when casting an LValue.
         kConversionCost_LValueCast = 800,

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -159,8 +159,8 @@ namespace Slang
         // Additional conversion cost to add when promoting from a scalar to
         // a vector (this will be added to the cost, if any, of converting
         // the element type of the vector)
-        kConversionCost_ScalarToVector = 1,
-        kConversionCost_VectorToScalar = 1,
+        kConversionCost_OneVectorToScalar = 1,
+        kConversionCost_ScalarToVector = 2,
         kConversionCost_ScalarToMatrix = 10,
         kConversionCost_ScalarIntegerToFloatMatrix = kConversionCost_IntegerToFloatConversion + kConversionCost_ScalarToMatrix,
 

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -160,6 +160,8 @@ namespace Slang
         // a vector (this will be added to the cost, if any, of converting
         // the element type of the vector)
         kConversionCost_ScalarToVector = 1,
+        kConversionCost_VectorToScalar = 1,
+        kConversionCost_ScalarToMatrix = 1,
 
         // Additional cost when casting an LValue.
         kConversionCost_LValueCast = 800,


### PR DESCRIPTION
Adding constructor for matrix that takes a partial matrix and a vector.
For example, "mat4x4 var = mat4x4(mat3x4, vec4)".

Adding implicit cast from vector<T,1> to T.

transpose(matrix<T,R,C>) had ambigous calls when T is int, because there
are definition for __BuiltinIntegerType and __BuiltinLogicalType. "int"
couldn't be resolved properly. In order to resolve the issue,
__BuiltinLogicalType got [OverloadRank(-1)], which gives
__BuiltinIntegerType a higher chance to be used.