### PR TITLE
Fix missing PerPrimitive decoration in mesh shader output.

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -2141,10 +2141,18 @@ struct SPIRVEmitContext
             }
         }
 
-        if (var->findDecorationImpl(kIROp_RequireSPIRVDescriptorIndexingExtensionDecoration))
+        for (auto decor : var->getDecorations())
         {
-            ensureExtensionDeclaration(UnownedStringSlice("SPV_EXT_descriptor_indexing"));
-            requireSPIRVCapability(SpvCapabilityRuntimeDescriptorArray);
+            switch (decor->getOp())
+            {
+            case kIROp_GLSLPrimitivesRateDecoration:
+                emitOpDecorate(getSection(SpvLogicalSectionID::Annotations), decor, varInst, SpvDecorationPerPrimitiveEXT);
+                break;
+            case kIROp_RequireSPIRVDescriptorIndexingExtensionDecoration:
+                ensureExtensionDeclaration(UnownedStringSlice("SPV_EXT_descriptor_indexing"));
+                requireSPIRVCapability(SpvCapabilityRuntimeDescriptorArray);
+                break;
+            }
         }
     }
 

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -988,8 +988,9 @@ void createVarLayoutForLegalizedGlobalParam(
     IRVarLayout* varLayout = varLayoutBuilder.build();
     builder->addLayoutDecoration(globalParam, varLayout);
 
-    for (auto paramInfo = outerParamInfo->outerParam; outerParamInfo; outerParamInfo = outerParamInfo->next)
+    for (; outerParamInfo; outerParamInfo = outerParamInfo->next)
     {
+        auto paramInfo = outerParamInfo->outerParam;
         auto decorParent = paramInfo;
         if (auto field = as<IRStructField>(decorParent))
             decorParent = field->getKey();
@@ -1404,7 +1405,6 @@ ScalarizedVal createGLSLGlobalVaryingsImpl(
 
         OuterParamInfoLink fieldParentInfo;
         fieldParentInfo.next = outerParamInfo;
-        fieldParentInfo.outerParam = leafVar;
 
         // Construct the actual type for the tuple (including any outer arrays)
         IRType* fullType = type;
@@ -1452,6 +1452,7 @@ ScalarizedVal createGLSLGlobalVaryingsImpl(
                     nameHintSB << ".";
                 nameHintSB << fieldNameHint->getName();
             }
+            fieldParentInfo.outerParam = field;
             auto fieldVal = createGLSLGlobalVaryingsImpl(
                 context,
                 codeGenContext,

--- a/source/slang/slang-ir-translate-glsl-global-var.cpp
+++ b/source/slang/slang-ir-translate-glsl-global-var.cpp
@@ -79,7 +79,7 @@ namespace Slang
                     {
                         builder.addNameHintDecoration(key, nameHint->getName());
                     }
-                    auto field = builder.createStructField(inputStructType, key, inputType);
+                    builder.createStructField(inputStructType, key, inputType);
                     IRTypeLayout::Builder fieldTypeLayout(&builder);
                     IRVarLayout::Builder varLayoutBuilder(&builder, fieldTypeLayout.build());
                     varLayoutBuilder.setStage(entryPointDecor->getProfile().getStage());
@@ -105,7 +105,7 @@ namespace Slang
                         inputVarIndex++;
                     }
                     inputStructTypeLayoutBuilder.addField(key, varLayoutBuilder.build());
-                    input->transferDecorationsTo(field);
+                    input->transferDecorationsTo(key);
                 }
                 auto paramTypeLayout = inputStructTypeLayoutBuilder.build();
                 IRVarLayout::Builder paramVarLayoutBuilder(&builder, paramTypeLayout);

--- a/tests/spirv/mesh-primitive.slang
+++ b/tests/spirv/mesh-primitive.slang
@@ -1,0 +1,64 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-directly
+
+// CHECK: OpDecorate %primitives_color Location 0
+// CHECK: OpDecorate %primitives_color PerPrimitive
+// CHECK: OpDecorate %prim_color Location 0
+// CHECK: OpDecorate %prim_color Flat
+
+const static uint MAX_VERTS = 6;
+const static uint MAX_PRIMS = 2;
+
+const static float2 positions[MAX_VERTS] = {
+  float2(0.0, -0.5),
+  float2(0.5, 0),
+  float2(-0.5, 0),
+  float2(0.0, 0.5),
+  float2(0.5, 0),
+  float2(-0.5, 0),
+};
+
+struct Vertex
+{
+  float4 pos : SV_Position;
+};
+
+struct Primitive
+{
+  [[vk::location(0)]] float3 color;
+}
+
+[outputtopology("triangle")]
+[numthreads(MAX_VERTS, 1, 1)]
+[shader("mesh")]
+void entry_mesh(
+    in uint tig : SV_GroupThreadID,
+    OutputVertices<Vertex, MAX_VERTS> verts,
+    OutputIndices<uint3, MAX_PRIMS> triangles,
+    OutputPrimitives<Primitive, MAX_PRIMS> primitives)
+{
+    const uint numVertices = MAX_VERTS;
+    const uint numPrimitives = MAX_PRIMS;
+    SetMeshOutputCounts(numVertices, numPrimitives);
+
+    if(tig < numVertices) {
+        verts[tig] = {float4(positions[tig], 0, 1)};
+    }
+
+    if(tig < numPrimitives) {
+        triangles[tig] = uint3(0,1,2) + tig * 3;
+        primitives[tig] = { float3(1,0,0) };
+    }
+}
+
+struct FragmentOut
+{
+    [[vk::location(0)]] float3 color;
+};
+
+[shader("fragment")]
+FragmentOut entry_fragment(in nointerpolation Primitive prim)
+{
+    FragmentOut frag_out;
+    frag_out.color = prim.color;
+    return frag_out;
+}


### PR DESCRIPTION
Fixes #3826.

Also fixes a problem where `Flat` decoration is missing when a struct field or input parameter is declared as `nointerpolation`.