### PR TITLE
Fix incorrect SPV stride for unsized array

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1415,12 +1415,18 @@ struct SPIRVEmitContext
                     if (m_decoratedSpvInsts.add(getID(resultSpvType)))
                     {
                         IRSizeAndAlignment sizeAndAlignment;
-                        getNaturalSizeAndAlignment(m_targetProgram->getOptionSet(), ptrType->getValueType(), &sizeAndAlignment);
+                        uint32_t stride;
+
+                        getNaturalSizeAndAlignment(m_targetProgram->getOptionSet(), valueType, &sizeAndAlignment);
+                        stride = sizeAndAlignment.getStride();
+                        // stride is invalid for unsized array, but we have to provide
+                        // a non-zero value to pass the spirv validator.
+                        stride = (stride == 0) ? 0xFFFF : stride;
                         emitOpDecorateArrayStride(
                             getSection(SpvLogicalSectionID::Annotations),
                             nullptr,
                             resultSpvType,
-                            SpvLiteralInteger::from32((uint32_t)sizeAndAlignment.getStride()));
+                            SpvLiteralInteger::from32(stride));
                     }
                 }
                 return resultSpvType;

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -3318,6 +3318,7 @@ public:
     IRBasicType* getVoidType();
     IRBasicType* getBoolType();
     IRBasicType* getIntType();
+    IRBasicType* getInt64Type();
     IRBasicType* getUIntType();
     IRBasicType* getUInt64Type();
     IRBasicType* getCharType();

--- a/source/slang/slang-ir-layout.cpp
+++ b/source/slang/slang-ir-layout.cpp
@@ -363,11 +363,12 @@ Result getSizeAndAlignment(CompilerOptionSet& optionSet, IRTypeLayoutRules* rule
         IRBuilder builder(module);
 
         auto intType = builder.getIntType();
+        auto int64Type = builder.getInt64Type();
         builder.addDecoration(
             type,
             kIROp_SizeAndAlignmentDecoration,
             builder.getIntValue(intType, (IRIntegerValue)rules->ruleName),
-            builder.getIntValue(intType, sizeAndAlignment.size),
+            builder.getIntValue(int64Type, sizeAndAlignment.size),
             builder.getIntValue(intType, sizeAndAlignment.alignment));
     }
 

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -2649,6 +2649,11 @@ namespace Slang
         return (IRBasicType*)getType(kIROp_IntType);
     }
 
+    IRBasicType* IRBuilder::getInt64Type()
+    {
+        return (IRBasicType*)getType(kIROp_Int64Type);
+    }
+
     IRBasicType* IRBuilder::getUIntType()
     {
         return (IRBasicType*)getType(kIROp_UIntType);

--- a/tests/bugs/gh-3825.slang
+++ b/tests/bugs/gh-3825.slang
@@ -1,0 +1,25 @@
+
+// Emit 0xFFFF as the stride value for the unsized array
+
+//TEST:SIMPLE(filecheck=CHECK): -entry fragment -stage fragment -emit-spirv-directly -target spirv-assembly -emit-spirv-directly
+struct Descriptors {
+  uint count;
+  uint array[];
+}
+
+struct Context {
+  Descriptors *descriptors;
+}
+
+[[vk::binding(0)]] ConstantBuffer<Context> context;
+
+// Dummy entry point.
+[shader("fragment")]
+float4 fragment(): SV_Target
+{
+  uint array[];
+
+  return float4(float(context.descriptors.array[0]), 1., 1., 1.);
+}
+
+// CHECK: OpDecorate %_ptr_PhysicalStorageBuffer__runtimearr_uint ArrayStride 65535

--- a/tests/bugs/gh-3825.slang
+++ b/tests/bugs/gh-3825.slang
@@ -17,9 +17,7 @@ struct Context {
 [shader("fragment")]
 float4 fragment(): SV_Target
 {
-  uint array[];
-
-  return float4(float(context.descriptors.array[0]), 1., 1., 1.);
+  return float4(float(context.descriptors[0].array[0]), 1., 1., 1.);
 }
 
 // CHECK: OpDecorate %_ptr_PhysicalStorageBuffer__runtimearr_uint ArrayStride 65535


### PR DESCRIPTION
In '-emit-spirv-directly' mode, slang generates the incorrect stride for unsized array in `OpDecorate` instructions.

The root cause of this issue is that `emitOpDecorateArrayStride` will only take a 32-bit integer as the stride value, however, we define the IRSizeAndAlignment::kIndeterminateSize as the size for the unsized array, which is a 64-bit integer. So it will be 0 when converted to 32-bit.

The easiest fix for this issue is to change
IRSizeAndAlignment::kIndeterminateSize to a 32-bit integer.