### PR TITLE
Fix parsing issue around __transparent_block.

### DIFF
--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -3572,7 +3572,7 @@ namespace Slang
         if (parser->currentScope && parser->currentScope->containerDecl)
         {
             parseDeclBody(parser, parser->currentScope->containerDecl);
-            return nullptr;
+            return parser->astBuilder->create<EmptyDecl>();
         }
         else
         {


### PR DESCRIPTION
Our decl parsing func is assumed to always return a non-null ast node upon successful parse.

The parseTransparentBlockDecl directly inserts the parsed decls in to the current parent isntead of constructing a new decl, so it was returning null. The problem with that is the calling function `ParseDeclWithModifiers` will see it as failed and continue to try fallback parsing logic, resulting wrong parsing behavior.

The fix here is to have `parseTransparentBlockDecl` return an EmptyDecl instead.