### PR TITLE
Update README.md with tables for platform & target support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,20 @@ The following guidelines should be observed by contributors:
 
 [Contribution guide](CONTRIBUTION.md) describes the workflow for contributors at more detail.
 
-Limitations
------------
+Limitations and Support
+-----------------------
+
+### Platform support
+|   Windows       |     Linux      |    MacOS     |
+|:---------------:|:--------------:|:------------:|
+|   supported     |   supported    | unofficial   |
+
+### Target support
+|   Direct3D 11   |  Direct3D 12   |     Vulkan      |         CUDA        |    OptiX    |      CPU Compute      |
+|:---------------:|:--------------:|:---------------:|:-------------------:|:-----------:|:---------------------:|
+|     HLSL        |    HLSL        |  GLSL & SPIR-V  |  C++ (compute-only) |  C++ (WIP)  |  C++ (compute-only)   |
+
+*for greater detail, see the [Supported Compilation Targets](https://shader-slang.com/slang/user-guide/targets.html) section of the [User Guide](https://shader-slang.github.io/slang/user-guide/)
 
 The Slang project has been used for production applications and large shader codebases, but it is still under active development.
 Support is currently focused on the platforms (Windows, Linux) and target APIs (Direct3D 12, Vulkan) where Slang is used most heavily.


### PR DESCRIPTION
Adds tables to README.md for quick reference of which platforms and targets are supported. Links to detailed information in user guide.

Bug Id: shader-slang/slang #3667