### PR TITLE
Fix lookup to prevent finding `typedef` itself.

### DIFF
--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -1421,6 +1421,9 @@ namespace Slang
         Scope*              scope       = nullptr;
         Scope*              endScope    = nullptr;
 
+        // A decl to exclude from the lookup, used to exclude the current decl being checked, such as in typedef Foo Foo;
+        // to avoid finding itself.
+        Decl* declToExclude = nullptr;
         LookupMask          mask        = LookupMask::Default;
         LookupOptions       options     = LookupOptions::None;
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -6203,7 +6203,8 @@ namespace Slang
 
     void SemanticsDeclHeaderVisitor::visitTypeDefDecl(TypeDefDecl* decl)
     {
-        decl->type = CheckProperType(decl->type);
+        SemanticsVisitor visitor(withDeclToExcludeFromLookup(decl));
+        decl->type = visitor.CheckProperType(decl->type);
         checkVisibility(decl);
     }
 

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2601,8 +2601,7 @@ namespace Slang
         }
         expr->type = QualType(m_astBuilder->getErrorType());
         auto lookupResult = lookUp(
-            m_astBuilder,
-            this, expr->name, expr->scope);
+            m_astBuilder, this, expr->name, expr->scope, LookupMask::Default, false, getDeclToExcludeFromLookup());
         
         bool diagnosed = false;
         lookupResult = filterLookupResultByVisibilityAndDiagnose(lookupResult, expr->loc, diagnosed);
@@ -3703,7 +3702,9 @@ namespace Slang
                                 this,
                                 expr->name,
                                 namespaceDecl,
-                                DeclRef(namespaceDecl));
+                                DeclRef(namespaceDecl),
+                                LookupMask::Default,
+                                getDeclToExcludeFromLookup());
                             AddToLookupResult(globalLookupResult, nsLookupResult);
                         }
                     }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -921,6 +921,15 @@ namespace Slang
             return result;
         }
 
+        SemanticsContext withDeclToExcludeFromLookup(Decl* decl)
+        {
+            SemanticsContext result(*this);
+            result.m_declToExcludeFromLookup = decl;
+            return result;
+        }
+
+        Decl* getDeclToExcludeFromLookup() { return m_declToExcludeFromLookup; }
+
     private:
         SharedSemanticsContext* m_shared = nullptr;
 
@@ -928,6 +937,7 @@ namespace Slang
 
         ExprLocalScope* m_exprLocalScope = nullptr;
 
+        Decl* m_declToExcludeFromLookup = nullptr;
 
     protected:
         // TODO: consider making more of this state `private`...

--- a/source/slang/slang-lookup.h
+++ b/source/slang/slang-lookup.h
@@ -19,7 +19,8 @@ LookupResult lookUp(
     Name*               name,
     Scope*              scope,
     LookupMask          mask = LookupMask::Default,
-    bool                considerAllLocalNamesInScope = false);
+    bool                considerAllLocalNamesInScope = false,
+    Decl*               declToExclude = nullptr);
 
 // Perform member lookup in the context of a type
 LookupResult lookUpMember(
@@ -38,7 +39,8 @@ LookupResult lookUpDirectAndTransparentMembers(
     Name*                   name,
     ContainerDecl*          containerDecl,
     DeclRef<Decl>           parentDeclRef,       // The parent of the resulting declref.
-    LookupMask              mask = LookupMask::Default);
+    LookupMask              mask = LookupMask::Default,
+    Decl*                   declToExclude = nullptr);
 
 // TODO: this belongs somewhere else
 

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -2576,11 +2576,20 @@ namespace Slang
             typeSpec.expr = parseFuncTypeExpr(parser);
             return typeSpec;
         }
+        
+        bool inGlobalScope = false;
+        if (AdvanceIf(parser, TokenType::Scope))
+        {
+            inGlobalScope = true;
+        }
 
         Token typeName = parser->ReadToken(TokenType::Identifier);
 
         auto basicType = parser->astBuilder->create<VarExpr>();
-        basicType->scope = parser->currentLookupScope;
+        if (inGlobalScope)
+            basicType->scope = parser->currentModule->ownedScope;
+        else
+            basicType->scope = parser->currentLookupScope;
         basicType->loc = typeName.loc;
         basicType->name = typeName.getNameOrNull();
 

--- a/tests/bugs/gh-3845-2.slang
+++ b/tests/bugs/gh-3845-2.slang
@@ -1,0 +1,26 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-shaderobj -vk -output-using-type
+
+struct Foo {float v;};
+
+namespace foo {
+    typedef ::Foo Foo; // unexpected '::', expected identifier; works in dxc/hlsl
+
+    float test(Foo f)
+    {
+        return f.v;
+    }
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(4, 1, 1)]
+[shader("compute")]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    Foo f;
+    f.v = 1.0;
+    // CHECK: 1.0
+    outputBuffer[0] = foo.test(f);
+}

--- a/tests/bugs/gh-3845.slang
+++ b/tests/bugs/gh-3845.slang
@@ -1,0 +1,27 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-shaderobj -vk -output-using-type
+
+
+struct Foo {float v;};
+
+namespace foo {
+    typedef Foo Foo; // cyclic reference 'Foo'; allowed in dxc/hlsl
+
+    float test(Foo f)
+    {
+        return f.v;
+    }
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(4, 1, 1)]
+[shader("compute")]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    Foo f;
+    f.v = 1.0;
+    // CHECK: 1.0
+    outputBuffer[0] = foo.test(f);
+}


### PR DESCRIPTION
Fixes #3845.

The change here is to extend decl lookup functions to take a `declToExclude` parameter that excludes the specified decl from lookup result.
Before we check the type of `typedef Foo Foo`, we will set the typedef decl itself to be excluded from lookup, so that when we check the type expr of `Foo`, we won't mistakenly use the typedef itself as its own type.