### PR TITLE
Allow var/param names to be the same as type name.

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1547,7 +1547,8 @@ namespace Slang
             }
             else
             {
-                initExpr = CheckExpr(initExpr);
+                SemanticsVisitor subVisitor(withDeclToExcludeFromLookup(varDecl));
+                initExpr = subVisitor.CheckExpr(initExpr);
 
                 // TODO: We might need some additional steps here to ensure
                 // that the type of the expression is one we are okay with
@@ -1568,7 +1569,8 @@ namespace Slang
         {
             // A variable with an explicit type is simpler, for the
             // most part.
-            TypeExp typeExp = CheckUsableType(varDecl->type);
+            SemanticsVisitor subVisitor(withDeclToExcludeFromLookup(varDecl));
+            TypeExp typeExp = subVisitor.CheckUsableType(varDecl->type);
             varDecl->type = typeExp;
             if (varDecl->type.equals(m_astBuilder->getVoidType()))
             {
@@ -6998,7 +7000,8 @@ namespace Slang
         auto typeExpr = paramDecl->type;
         if(typeExpr.exp)
         {
-            typeExpr = CheckUsableType(typeExpr);
+            SemanticsVisitor subVisitor(withDeclToExcludeFromLookup(paramDecl));
+            typeExpr = subVisitor.CheckUsableType(typeExpr);
             paramDecl->type = typeExpr;
             checkMeshOutputDecl(paramDecl);
         }
@@ -7640,7 +7643,8 @@ namespace Slang
 
     void SemanticsDeclHeaderVisitor::visitPropertyDecl(PropertyDecl* decl)
     {
-        decl->type = CheckUsableType(decl->type);
+        SemanticsVisitor subVisitor(withDeclToExcludeFromLookup(decl));
+        decl->type = subVisitor.CheckUsableType(decl->type);
         visitAbstractStorageDeclCommon(decl);
         checkVisibility(decl);
     }

--- a/tests/bugs/gh-3824.slang
+++ b/tests/bugs/gh-3824.slang
@@ -1,0 +1,20 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -emit-spirv-directly
+
+// CHECK: OpEntryPoint
+
+namespace example {
+  struct Example {}
+}
+
+struct Struct {
+  example::Example example;
+}
+
+void func(Struct Struct)
+{
+    // Test parameter name to be the same as type name.
+}
+
+[numthreads(1,1,1)]
+void main()
+{}


### PR DESCRIPTION
Expand on #3848 to allow the variables, struct fields and function parameters to be named the same as their types.
The fix is the same: exclude the current var/param decl from the lookup when checking its type.

Fixes #3824.