### PR TITLE
Improve compile time performance.

### DIFF
--- a/source/compiler-core/slang-diagnostic-sink.cpp
+++ b/source/compiler-core/slang-diagnostic-sink.cpp
@@ -592,7 +592,7 @@ Severity DiagnosticSink::getEffectiveMessageSeverity(DiagnosticInfo const& info)
         if (effectiveSeverity < Severity::Error || *pSeverityOverride >= effectiveSeverity)
             effectiveSeverity = *pSeverityOverride;
     }
-    
+
     if (isFlagSet(Flag::TreatWarningsAsErrors) && effectiveSeverity == Severity::Warning)
         effectiveSeverity = Severity::Error;
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -2153,7 +2153,7 @@ ${{{{
     {
 }}}}
     __intrinsic_op($(kIROp_CombinedTextureSamplerGetTexture))
-    __TextureImpl<T, Shape, isArray, isMS, sampleCount, 0, isShadow, 0, format> __getTexture();
+    __TextureImpl<T, Shape, isArray, 0, sampleCount, 0, isShadow, 0, format> __getTexture();
 
     __intrinsic_op($(kIROp_CombinedTextureSamplerGetSampler))
     SamplerState __getSampler();

--- a/source/slang/slang-artifact-output-util.cpp
+++ b/source/slang/slang-artifact-output-util.cpp
@@ -58,9 +58,11 @@ namespace Slang
         }
         return SLANG_FAIL;
     }
-
+    auto downstreamStartTime = std::chrono::high_resolution_clock::now();
     SLANG_RETURN_ON_FAIL(compiler->convert(artifact, assemblyDesc, outArtifact));
-
+    auto downstreamElapsedTime =
+        (std::chrono::high_resolution_clock::now() - downstreamStartTime).count() * 0.000000001;
+    session->addDownstreamCompileTime(downstreamElapsedTime);
     return SLANG_OK;
 }
 

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -551,13 +551,11 @@ namespace Slang
         SLANG_VALUE_CLASS(QualType) 
 
         Type*	type = nullptr;
-        bool	        isLeftValue;
+        bool	        isLeftValue = false;
         bool            hasReadOnlyOnTarget = false;
         bool	        isWriteOnly = false;
 
-        QualType()
-            : isLeftValue(false)
-        {}
+        QualType() = default;
 
         QualType(Type* type);
 

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -1099,7 +1099,8 @@ namespace Slang
 
         // Since the lookup and resolution of all possible implicit conversions
         // can be very costly, we use a cache to store the checking results.
-        ImplicitCastMethod* cachedMethod = getShared()->tryGetImplicitCastMethod(fromType.type, toType);
+        ImplicitCastMethodKey implicitCastKey = ImplicitCastMethodKey(fromType, toType, fromExpr);
+        ImplicitCastMethod* cachedMethod = getShared()->tryGetImplicitCastMethod(implicitCastKey);
 
         if (cachedMethod)
         {
@@ -1114,6 +1115,10 @@ namespace Slang
                 // If we are not requesting to create an expression, we can return early.
                 if (outCost)
                     *outCost = cachedMethod->cost;
+                if (cachedMethod->cost >= kConversionCost_Explicit)
+                {
+                    return false;
+                }
                 return true;
             }
         }
@@ -1139,7 +1144,7 @@ namespace Slang
             {
                 if (!cachedMethod)
                 {
-                    getShared()->cacheImplicitCastMethod(fromType.type, toType, ImplicitCastMethod{});
+                    getShared()->cacheImplicitCastMethod(implicitCastKey, ImplicitCastMethod{});
                 }
                 return _failedCoercion(toType, outToExpr, fromExpr);
             }
@@ -1188,7 +1193,7 @@ namespace Slang
             {
                 if (!cachedMethod)
                 {
-                    getShared()->cacheImplicitCastMethod(fromType.type, toType, ImplicitCastMethod{});
+                    getShared()->cacheImplicitCastMethod(implicitCastKey, ImplicitCastMethod{});
                 }
                 return _failedCoercion(toType, outToExpr, fromExpr);
             }
@@ -1301,12 +1306,12 @@ namespace Slang
                 castExpr->arguments.add(fromExpr);
             }
             if (!cachedMethod)
-                getShared()->cacheImplicitCastMethod(fromType.type, toType, ImplicitCastMethod{ *overloadContext.bestCandidate, cost });
+                getShared()->cacheImplicitCastMethod(implicitCastKey, ImplicitCastMethod{ *overloadContext.bestCandidate, cost });
             return true;
         }
         if (!cachedMethod)
         {
-            getShared()->cacheImplicitCastMethod(fromType.type, toType, ImplicitCastMethod{});
+            getShared()->cacheImplicitCastMethod(implicitCastKey, ImplicitCastMethod{});
         }
         return _failedCoercion(toType, outToExpr, fromExpr);
     }

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -8955,7 +8955,6 @@ namespace Slang
             {
                 m_mapTypePairToSubtypeWitness.remove(key);
             }
-            printf("remove %d types, %d type pairs\n", (int)keysToRemove.getCount(), (int)typePairsToRemove.getCount());
         }
 
         if (hasImplicitCastMember)

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -8918,31 +8918,33 @@ namespace Slang
             }
             m_mapTypeToInheritanceInfo = _Move(newMapTypeToInheritanceInfo);
         }
+
+        ShortList<DeclRef<Decl>, 16> keysToRemove;
+        for (auto& kv : m_mapDeclRefToInheritanceInfo)
+        {
+            // We can confirm the type is affected by the new extension,
+            // if the declref type points to typeDecl.
+            if (kv.first.getDecl() == typeDecl)
+            {
+                keysToRemove.add(kv.first);
+                continue;
+            }
+
+            // If we are extending interface types (and in the future any struct type
+            // if we decide to have full inheritance support),
+            // we also need to account for conformant that implements the interface.
+            if (invalidateSubtypes && isInheritanceInfoAffected(kv.second))
+            {
+                keysToRemove.add(kv.first);
+            }
+        }
+        for (auto& key : keysToRemove)
+        {
+            m_mapDeclRefToInheritanceInfo.remove(key);
+        }
+
         if (hasInheritanceMember || invalidateSubtypes)
         {
-            ShortList<DeclRef<Decl>, 16> keysToRemove;
-            for (auto& kv : m_mapDeclRefToInheritanceInfo)
-            {
-                // We can confirm the type is affected by the new extension,
-                // if the declref type points to typeDecl.
-                if (kv.first.getDecl() == typeDecl)
-                {
-                    keysToRemove.add(kv.first);
-                    continue;
-                }
-
-                // If we are extending interface types (and in the future any struct type
-                // if we decide to have full inheritance support),
-                // we also need to account for conformant that implements the interface.
-                if (invalidateSubtypes && isInheritanceInfoAffected(kv.second))
-                {
-                    keysToRemove.add(kv.first);
-                }
-            }
-            for (auto& key : keysToRemove)
-            {
-                m_mapDeclRefToInheritanceInfo.remove(key);
-            }
             ShortList<TypePair, 16> typePairsToRemove;
             for (auto& kv : m_mapTypePairToSubtypeWitness)
             {

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -8935,7 +8935,7 @@ namespace Slang
             decltype(m_mapTypePairToImplicitCastMethod) newMapTypePairToImplicitCastMethod;
             for (auto& kv : newMapTypePairToImplicitCastMethod)
             {
-                // Since implicit casts are defined a constructors on the toType,
+                // Since implicit casts are defined as constructors on the toType,
                 // we only need to check if the toType is affected by the new extension.
                 if (isTypeUpToDate(kv.first.type1))
                 {

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -554,6 +554,7 @@ namespace Slang
     {
         OverloadCandidate conversionFuncOverloadCandidate;
         ConversionCost cost = kConversionCost_Impossible;
+        bool isAmbiguous = false;
     };
 
     struct ImplicitCastMethodKey
@@ -577,7 +578,7 @@ namespace Slang
             , toType(toType)
             , constantVal(0)
             , isConstant(false)
-            , isLValue(fromExpr?fromExpr->type.isLeftValue:false)
+            , isLValue(fromType.isLeftValue)
         {
             if (auto constInt = as<IntegerLiteralExpr>(fromExpr))
             {

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -553,6 +553,7 @@ namespace Slang
     struct ImplicitCastMethod
     {
         OverloadCandidate conversionFuncOverloadCandidate;
+        ConversionCost cost = kConversionCost_Impossible;
     };
 
         /// Shared state for a semantics-checking session.
@@ -668,12 +669,10 @@ namespace Slang
             auto pair = TypePair{ fromType, toType };
             return m_mapTypePairToImplicitCastMethod.tryGetValue(pair);
         }
-        void cacheImplicitCastMethod(Type* fromType, Type* toType, const OverloadCandidate& candidate)
+        void cacheImplicitCastMethod(Type* fromType, Type* toType, ImplicitCastMethod candidate)
         {
             auto pair = TypePair{ fromType, toType };
-            ImplicitCastMethod result;
-            result.conversionFuncOverloadCandidate = candidate;
-            m_mapTypePairToImplicitCastMethod[pair] = result;
+            m_mapTypePairToImplicitCastMethod[pair] = candidate;
         }
 
     private:

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -549,6 +549,12 @@ namespace Slang
         FacetList facets;
     };
 
+        /// Cached information about how to convert between two types.
+    struct ImplicitCastMethod
+    {
+        OverloadCandidate conversionFuncOverloadCandidate;
+    };
+
         /// Shared state for a semantics-checking session.
     struct SharedSemanticsContext
     {
@@ -656,6 +662,18 @@ namespace Slang
         {
             auto pair = TypePair{ sub, sup };
             m_mapTypePairToSubtypeWitness[pair] = outWitness;
+        }
+        ImplicitCastMethod* tryGetImplicitCastMethod(Type* fromType, Type* toType)
+        {
+            auto pair = TypePair{ fromType, toType };
+            return m_mapTypePairToImplicitCastMethod.tryGetValue(pair);
+        }
+        void cacheImplicitCastMethod(Type* fromType, Type* toType, const OverloadCandidate& candidate)
+        {
+            auto pair = TypePair{ fromType, toType };
+            ImplicitCastMethod result;
+            result.conversionFuncOverloadCandidate = candidate;
+            m_mapTypePairToImplicitCastMethod[pair] = result;
         }
 
     private:
@@ -776,6 +794,7 @@ namespace Slang
         Dictionary<Type*, InheritanceInfo> m_mapTypeToInheritanceInfo;
         Dictionary<DeclRef<Decl>, InheritanceInfo> m_mapDeclRefToInheritanceInfo;
         Dictionary<TypePair, SubtypeWitness*> m_mapTypePairToSubtypeWitness;
+        Dictionary<TypePair, ImplicitCastMethod> m_mapTypePairToImplicitCastMethod;
     };
 
         /// Local/scoped state of the semantic-checking system

--- a/source/slang/slang-check-inheritance.cpp
+++ b/source/slang/slang-check-inheritance.cpp
@@ -5,11 +5,6 @@
 // related to computing linearized inheritance
 // information for types and decalrations.
 
-//#include "slang-lookup.h"
-//#include "slang-syntax.h"
-//#include "slang-ast-synthesis.h"
-//#include <limits>
-
 namespace Slang
 {
     InheritanceInfo SharedSemanticsContext::getInheritanceInfo(Type* type)
@@ -17,7 +12,12 @@ namespace Slang
         // We cache the computed inheritance information for types,
         // and re-use that information whenever possible.
 
-        if(auto found = m_mapTypeToInheritanceInfo.tryGetValue(type))
+        // DeclRefTypes will have their inheritance info cached in m_mapDeclRefToInheritanceInfo.
+        if (auto declRefType = as<DeclRefType>(type))
+            return _getInheritanceInfo(declRefType->getDeclRef(), declRefType);
+        
+        // Non ordinary types are cached on m_mapTypeToInheritanceInfo.
+        if (auto found = m_mapTypeToInheritanceInfo.tryGetValue(type))
             return *found;
 
         // Note: we install a null pointer into the dictionary to act

--- a/source/slang/slang-check-inheritance.cpp
+++ b/source/slang/slang-check-inheritance.cpp
@@ -32,9 +32,6 @@ namespace Slang
         auto info = _calcInheritanceInfo(type);
         m_mapTypeToInheritanceInfo[type] = info;
 
-        getSession()->m_typeDictionarySize = Math::Max(
-            getSession()->m_typeDictionarySize, (int)m_mapTypeToInheritanceInfo.getCount());
-
         return info;
     }
 
@@ -67,6 +64,9 @@ namespace Slang
 
         auto info = _calcInheritanceInfo(declRef, declRefType);
         m_mapDeclRefToInheritanceInfo[declRef] = info;
+
+        getSession()->m_typeDictionarySize = Math::Max(
+            getSession()->m_typeDictionarySize, (int)m_mapDeclRefToInheritanceInfo.getCount());
 
         return info;
     }

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -598,13 +598,12 @@ Result linkAndOptimizeIR(
         {
             applySparseConditionalConstantPropagation(irModule, codeGenContext->getSink());
         }
-        eliminateDeadCode(irModule, deadCodeEliminationOptions);
-
         validateIRModuleIfEnabled(codeGenContext, irModule);
     
         // Inline calls to any functions marked with [__unsafeInlineEarly] again,
         // since we may be missing out cases prevented by the functions that we just specialzied.
         performMandatoryEarlyInlining(irModule);
+        eliminateDeadCode(irModule, deadCodeEliminationOptions);
 
         // Unroll loops.
         if (!fastIRSimplificationOptions.minimalOptimization)
@@ -691,11 +690,7 @@ Result linkAndOptimizeIR(
     // do unnecessary work to lower them.
     unpinWitnessTables(irModule);
     
-    if (fastIRSimplificationOptions.minimalOptimization)
-    {
-        eliminateDeadCode(irModule, deadCodeEliminationOptions);
-    }
-    else
+    if (!fastIRSimplificationOptions.minimalOptimization)
     {
         simplifyIR(targetProgram, irModule, fastIRSimplificationOptions, sink);
     }

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -1655,7 +1655,8 @@ SlangResult ForwardDiffTranscriber::prepareFuncForForwardDiff(IRFunc* func)
     if (SLANG_SUCCEEDED(result))
     {
         disableIRValidationAtInsert();
-        simplifyFunc(autoDiffSharedContext->targetProgram, func, IRSimplificationOptions::getDefault(autoDiffSharedContext->targetProgram));
+        auto simplifyOptions = IRSimplificationOptions::getDefault(nullptr);
+        simplifyFunc(autoDiffSharedContext->targetProgram, func, simplifyOptions);
         enableIRValidationAtInsert();
     }
     return result;

--- a/source/slang/slang-ir-ssa-simplification.cpp
+++ b/source/slang/slang-ir-ssa-simplification.cpp
@@ -18,7 +18,7 @@ namespace Slang
     IRSimplificationOptions IRSimplificationOptions::getDefault(TargetProgram* targetProgram)
     {
         IRSimplificationOptions result;
-        result.minimalOptimization = targetProgram->getOptionSet().shouldPerformMinimumOptimizations();
+        result.minimalOptimization = targetProgram ? targetProgram->getOptionSet().shouldPerformMinimumOptimizations() : false;
         if (result.minimalOptimization)
             result.cfgOptions = CFGSimplificationOptions::getFast();
         else
@@ -30,7 +30,7 @@ namespace Slang
     IRSimplificationOptions IRSimplificationOptions::getFast(TargetProgram* targetProgram)
     {
         IRSimplificationOptions result;
-        result.minimalOptimization = targetProgram->getOptionSet().shouldPerformMinimumOptimizations();
+        result.minimalOptimization = targetProgram ? targetProgram->getOptionSet().shouldPerformMinimumOptimizations() : false;
         result.cfgOptions = CFGSimplificationOptions::getFast();
         result.peepholeOptions = PeepholeOptimizationOptions();
         return result;

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -2330,13 +2330,17 @@ SlangResult OptionsParser::_parse(
         SLANG_RETURN_ON_FAIL(m_session->compileStdLib(m_compileStdLibFlags));
     }
 
+    // We are going to build a mapping from target formats to the
+    // target that handles that format.
+    Dictionary<CodeGenTarget, int> mapFormatToTargetIndex;
+
     // TODO(JS): This is a restriction because of how setting of state works for load repro
     // If a repro has been loaded, then many of the following options will overwrite
     // what was set up. So for now they are ignored, and only parameters set as part
     // of the loop work if they are after -load-repro
     if (m_hasLoadedRepro)
     {
-        return SLANG_OK;
+        goto endOfOptionInference;
     }
 
     // As a compatability feature, if the user didn't list any explicit entry
@@ -2524,9 +2528,6 @@ SlangResult OptionsParser::_parse(
         rawEntryPoint.entryPointID = entryPointID;
     }
 
-    // We are going to build a mapping from target formats to the
-    // target that handles that format.
-    Dictionary<CodeGenTarget, int> mapFormatToTargetIndex;
 
     // If there was no explicit `-target` specified, then we will look
     // at the `-o` options to see what we can infer.
@@ -2861,7 +2862,7 @@ SlangResult OptionsParser::_parse(
             }
         }
     }
-
+endOfOptionInference:;
 
     // Now that we've diagnosed the output paths, we can add them
     // to the compile request at the appropriate locations.
@@ -2917,6 +2918,7 @@ SlangResult OptionsParser::_parse(
             }
         }
     }
+
 
     // Copy all settings from linkage to targets.
     for (auto target : linkage->targets)

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -2330,204 +2330,200 @@ SlangResult OptionsParser::_parse(
         SLANG_RETURN_ON_FAIL(m_session->compileStdLib(m_compileStdLibFlags));
     }
 
-    // We are going to build a mapping from target formats to the
-    // target that handles that format.
-    Dictionary<CodeGenTarget, int> mapFormatToTargetIndex;
-
     // TODO(JS): This is a restriction because of how setting of state works for load repro
     // If a repro has been loaded, then many of the following options will overwrite
     // what was set up. So for now they are ignored, and only parameters set as part
     // of the loop work if they are after -load-repro
-    if (m_hasLoadedRepro)
+    if (!m_hasLoadedRepro)
     {
-        goto endOfOptionInference;
-    }
-
-    // As a compatability feature, if the user didn't list any explicit entry
-    // point names, *and* they are compiling a single translation unit, *and* they
-    // have either specified a stage, or we can assume one from the naming
-    // of the translation unit, then we assume they wanted to compile a single
-    // entry point named `main`.
-    //
-    if (m_rawEntryPoints.getCount() == 0
-        && m_rawTranslationUnits.getCount() == 1
-        && (m_defaultEntryPoint.stage != Stage::Unknown
-            || m_rawTranslationUnits[0].impliedStage != Stage::Unknown))
-    {
-        RawEntryPoint entry;
-        entry.name = "main";
-        entry.translationUnitIndex = 0;
-        m_rawEntryPoints.add(entry);
-    }
-
-    // If the user (manually or implicitly) specified only a single entry point,
-    // then we allow the associated stage to be specified either before or after
-    // the entry point. This means that if there is a stage attached
-    // to the "default" entry point, we should copy it over to the
-    // explicit one.
-    //
-    if (m_rawEntryPoints.getCount() == 1)
-    {
-        if (m_defaultEntryPoint.stage != Stage::Unknown)
-        {
-            setStage(getCurrentEntryPoint(), m_defaultEntryPoint.stage);
-        }
-
-        if (m_defaultEntryPoint.redundantStageSet)
-            getCurrentEntryPoint()->redundantStageSet = true;
-        if (m_defaultEntryPoint.conflictingStagesSet)
-            getCurrentEntryPoint()->conflictingStagesSet = true;
-    }
-    else
-    {
-        // If the "default" entry point has had a stage (or
-        // other state, if we add other per-entry-point state)
-        // specified, but there is more than one entry point,
-        // then that state doesn't apply to anything and we
-        // should issue an error to tell the user something
-        // funky is going on.
+        // As a compatability feature, if the user didn't list any explicit entry
+        // point names, *and* they are compiling a single translation unit, *and* they
+        // have either specified a stage, or we can assume one from the naming
+        // of the translation unit, then we assume they wanted to compile a single
+        // entry point named `main`.
         //
-        if (m_defaultEntryPoint.stage != Stage::Unknown)
+        if (m_rawEntryPoints.getCount() == 0
+            && m_rawTranslationUnits.getCount() == 1
+            && (m_defaultEntryPoint.stage != Stage::Unknown
+                || m_rawTranslationUnits[0].impliedStage != Stage::Unknown))
         {
-            if (m_rawEntryPoints.getCount() == 0)
+            RawEntryPoint entry;
+            entry.name = "main";
+            entry.translationUnitIndex = 0;
+            m_rawEntryPoints.add(entry);
+        }
+
+        // If the user (manually or implicitly) specified only a single entry point,
+        // then we allow the associated stage to be specified either before or after
+        // the entry point. This means that if there is a stage attached
+        // to the "default" entry point, we should copy it over to the
+        // explicit one.
+        //
+        if (m_rawEntryPoints.getCount() == 1)
+        {
+            if (m_defaultEntryPoint.stage != Stage::Unknown)
             {
-                m_sink->diagnose(SourceLoc(), Diagnostics::stageSpecificationIgnoredBecauseNoEntryPoints);
+                setStage(getCurrentEntryPoint(), m_defaultEntryPoint.stage);
             }
-            else
+
+            if (m_defaultEntryPoint.redundantStageSet)
+                getCurrentEntryPoint()->redundantStageSet = true;
+            if (m_defaultEntryPoint.conflictingStagesSet)
+                getCurrentEntryPoint()->conflictingStagesSet = true;
+        }
+        else
+        {
+            // If the "default" entry point has had a stage (or
+            // other state, if we add other per-entry-point state)
+            // specified, but there is more than one entry point,
+            // then that state doesn't apply to anything and we
+            // should issue an error to tell the user something
+            // funky is going on.
+            //
+            if (m_defaultEntryPoint.stage != Stage::Unknown)
             {
-                m_sink->diagnose(SourceLoc(), Diagnostics::stageSpecificationIgnoredBecauseBeforeAllEntryPoints);
-            }
-        }
-    }
-
-    // Slang requires that every explicit entry point indicate the translation
-    // unit it comes from. If there is only one translation unit specified,
-    // then implicitly all entry points come from it.
-    //
-    if (m_translationUnitCount == 1)
-    {
-        for (auto& entryPoint : m_rawEntryPoints)
-        {
-            entryPoint.translationUnitIndex = 0;
-        }
-    }
-    else if (m_frontEndReq->additionalLoadedModules &&
-        m_frontEndReq->additionalLoadedModules->getCount() == 0)
-    {
-        // Otherwise, we require that all entry points be specified after
-        // the translation unit to which tye belong.
-        bool anyEntryPointWithoutTranslationUnit = false;
-        for (auto& entryPoint : m_rawEntryPoints)
-        {
-            // Skip entry points that are already associated with a translation unit...
-            if (entryPoint.translationUnitIndex != -1)
-                continue;
-
-            anyEntryPointWithoutTranslationUnit = true;
-        }
-        if (anyEntryPointWithoutTranslationUnit)
-        {
-            m_sink->diagnose(SourceLoc(), Diagnostics::entryPointsNeedToBeAssociatedWithTranslationUnits);
-            return SLANG_FAIL;
-        }
-    }
-
-    // Now that entry points are associated with translation units,
-    // we can make one additional pass where if an entry point has
-    // no specified stage, but the nameing of its translation unit
-    // implies a stage, we will use that (a manual `-stage` annotation
-    // will always win out in such a case).
-    //
-    for (auto& rawEntryPoint : m_rawEntryPoints)
-    {
-        // Skip entry points that already have a stage.
-        if (rawEntryPoint.stage != Stage::Unknown)
-            continue;
-
-        // Sanity check: don't process entry points with no associated translation unit.
-        if (rawEntryPoint.translationUnitIndex == -1)
-            continue;
-
-        auto impliedStage = m_rawTranslationUnits[rawEntryPoint.translationUnitIndex].impliedStage;
-        if (impliedStage != Stage::Unknown)
-            rawEntryPoint.stage = impliedStage;
-    }
-
-    // Note: it is possible that some entry points still won't have associated
-    // stages at this point, but we don't want to error out here, because
-    // those entry points might get stages later, as part of semantic checking,
-    // if the corresponding function has a `[shader("...")]` attribute.
-
-    // Now that we've tried to establish stages for entry points, we can
-    // issue diagnostics for cases where stages were set redundantly or
-    // in conflicting ways.
-    //
-    for (auto& rawEntryPoint : m_rawEntryPoints)
-    {
-        if (rawEntryPoint.conflictingStagesSet)
-        {
-            m_sink->diagnose(SourceLoc(), Diagnostics::conflictingStagesForEntryPoint, rawEntryPoint.name);
-        }
-        else if (rawEntryPoint.redundantStageSet)
-        {
-            m_sink->diagnose(SourceLoc(), Diagnostics::sameStageSpecifiedMoreThanOnce, rawEntryPoint.stage, rawEntryPoint.name);
-        }
-        else if (rawEntryPoint.translationUnitIndex != -1)
-        {
-            // As a quality-of-life feature, if the file name implies a particular
-            // stage, but the user manually specified something different for
-            // their entry point, give a warning in case they made a mistake.
-
-            auto& rawTranslationUnit = m_rawTranslationUnits[rawEntryPoint.translationUnitIndex];
-            if (rawTranslationUnit.impliedStage != Stage::Unknown
-                && rawEntryPoint.stage != Stage::Unknown
-                && rawTranslationUnit.impliedStage != rawEntryPoint.stage)
-            {
-                m_sink->diagnose(SourceLoc(), Diagnostics::explicitStageDoesntMatchImpliedStage, rawEntryPoint.name, rawEntryPoint.stage, rawTranslationUnit.impliedStage);
+                if (m_rawEntryPoints.getCount() == 0)
+                {
+                    m_sink->diagnose(SourceLoc(), Diagnostics::stageSpecificationIgnoredBecauseNoEntryPoints);
+                }
+                else
+                {
+                    m_sink->diagnose(SourceLoc(), Diagnostics::stageSpecificationIgnoredBecauseBeforeAllEntryPoints);
+                }
             }
         }
-    }
 
-    // If the user is requesting code generation via pass-through,
-    // then any entry points they specify need to have a stage set,
-    // because fxc/dxc/glslang don't have a facility for taking
-    // a named entry point and pulling its stage from an attribute.
-    //
-    if (_passThroughRequiresStage(m_requestImpl->m_passThrough))
-    {
+        // Slang requires that every explicit entry point indicate the translation
+        // unit it comes from. If there is only one translation unit specified,
+        // then implicitly all entry points come from it.
+        //
+        if (m_translationUnitCount == 1)
+        {
+            for (auto& entryPoint : m_rawEntryPoints)
+            {
+                entryPoint.translationUnitIndex = 0;
+            }
+        }
+        else if (m_frontEndReq->additionalLoadedModules &&
+            m_frontEndReq->additionalLoadedModules->getCount() == 0)
+        {
+            // Otherwise, we require that all entry points be specified after
+            // the translation unit to which tye belong.
+            bool anyEntryPointWithoutTranslationUnit = false;
+            for (auto& entryPoint : m_rawEntryPoints)
+            {
+                // Skip entry points that are already associated with a translation unit...
+                if (entryPoint.translationUnitIndex != -1)
+                    continue;
+
+                anyEntryPointWithoutTranslationUnit = true;
+            }
+            if (anyEntryPointWithoutTranslationUnit)
+            {
+                m_sink->diagnose(SourceLoc(), Diagnostics::entryPointsNeedToBeAssociatedWithTranslationUnits);
+                return SLANG_FAIL;
+            }
+        }
+
+        // Now that entry points are associated with translation units,
+        // we can make one additional pass where if an entry point has
+        // no specified stage, but the nameing of its translation unit
+        // implies a stage, we will use that (a manual `-stage` annotation
+        // will always win out in such a case).
+        //
         for (auto& rawEntryPoint : m_rawEntryPoints)
         {
-            if (rawEntryPoint.stage == Stage::Unknown)
+            // Skip entry points that already have a stage.
+            if (rawEntryPoint.stage != Stage::Unknown)
+                continue;
+
+            // Sanity check: don't process entry points with no associated translation unit.
+            if (rawEntryPoint.translationUnitIndex == -1)
+                continue;
+
+            auto impliedStage = m_rawTranslationUnits[rawEntryPoint.translationUnitIndex].impliedStage;
+            if (impliedStage != Stage::Unknown)
+                rawEntryPoint.stage = impliedStage;
+        }
+
+        // Note: it is possible that some entry points still won't have associated
+        // stages at this point, but we don't want to error out here, because
+        // those entry points might get stages later, as part of semantic checking,
+        // if the corresponding function has a `[shader("...")]` attribute.
+
+        // Now that we've tried to establish stages for entry points, we can
+        // issue diagnostics for cases where stages were set redundantly or
+        // in conflicting ways.
+        //
+        for (auto& rawEntryPoint : m_rawEntryPoints)
+        {
+            if (rawEntryPoint.conflictingStagesSet)
             {
-                m_sink->diagnose(SourceLoc(), Diagnostics::noStageSpecifiedInPassThroughMode, rawEntryPoint.name);
+                m_sink->diagnose(SourceLoc(), Diagnostics::conflictingStagesForEntryPoint, rawEntryPoint.name);
+            }
+            else if (rawEntryPoint.redundantStageSet)
+            {
+                m_sink->diagnose(SourceLoc(), Diagnostics::sameStageSpecifiedMoreThanOnce, rawEntryPoint.stage, rawEntryPoint.name);
+            }
+            else if (rawEntryPoint.translationUnitIndex != -1)
+            {
+                // As a quality-of-life feature, if the file name implies a particular
+                // stage, but the user manually specified something different for
+                // their entry point, give a warning in case they made a mistake.
+
+                auto& rawTranslationUnit = m_rawTranslationUnits[rawEntryPoint.translationUnitIndex];
+                if (rawTranslationUnit.impliedStage != Stage::Unknown
+                    && rawEntryPoint.stage != Stage::Unknown
+                    && rawTranslationUnit.impliedStage != rawEntryPoint.stage)
+                {
+                    m_sink->diagnose(SourceLoc(), Diagnostics::explicitStageDoesntMatchImpliedStage, rawEntryPoint.name, rawEntryPoint.stage, rawTranslationUnit.impliedStage);
+                }
             }
         }
-    }
 
-    // We now have inferred enough information to add the
-    // entry points to our compile request.
-    //
-    for (auto& rawEntryPoint : m_rawEntryPoints)
-    {
-        if (rawEntryPoint.translationUnitIndex < 0)
-            continue;
+        // If the user is requesting code generation via pass-through,
+        // then any entry points they specify need to have a stage set,
+        // because fxc/dxc/glslang don't have a facility for taking
+        // a named entry point and pulling its stage from an attribute.
+        //
+        if (_passThroughRequiresStage(m_requestImpl->m_passThrough))
+        {
+            for (auto& rawEntryPoint : m_rawEntryPoints)
+            {
+                if (rawEntryPoint.stage == Stage::Unknown)
+                {
+                    m_sink->diagnose(SourceLoc(), Diagnostics::noStageSpecifiedInPassThroughMode, rawEntryPoint.name);
+                }
+            }
+        }
 
-        auto translationUnitID = m_rawTranslationUnits[rawEntryPoint.translationUnitIndex].translationUnitID;
+        // We now have inferred enough information to add the
+        // entry points to our compile request.
+        //
+        for (auto& rawEntryPoint : m_rawEntryPoints)
+        {
+            if (rawEntryPoint.translationUnitIndex < 0)
+                continue;
 
-        List<const char*> specializationArgs;
-        for (auto& arg : rawEntryPoint.specializationArgs)
-            specializationArgs.add(arg.getBuffer());
+            auto translationUnitID = m_rawTranslationUnits[rawEntryPoint.translationUnitIndex].translationUnitID;
 
-        int entryPointID = m_compileRequest->addEntryPointEx(
-            translationUnitID,
-            rawEntryPoint.name.begin(),
-            SlangStage(rawEntryPoint.stage),
-            (int)specializationArgs.getCount(),
-            specializationArgs.getBuffer());
+            List<const char*> specializationArgs;
+            for (auto& arg : rawEntryPoint.specializationArgs)
+                specializationArgs.add(arg.getBuffer());
 
-        rawEntryPoint.entryPointID = entryPointID;
-    }
+            int entryPointID = m_compileRequest->addEntryPointEx(
+                translationUnitID,
+                rawEntryPoint.name.begin(),
+                SlangStage(rawEntryPoint.stage),
+                (int)specializationArgs.getCount(),
+                specializationArgs.getBuffer());
 
+            rawEntryPoint.entryPointID = entryPointID;
+        }
+
+        // We are going to build a mapping from target formats to the
+        // target that handles that format.
+        Dictionary<CodeGenTarget, int> mapFormatToTargetIndex;
 
     // If there was no explicit `-target` specified, then we will look
     // at the `-o` options to see what we can infer.
@@ -2548,60 +2544,60 @@ SlangResult OptionsParser::_parse(
                 if (impliedFormat == CodeGenTarget::Unknown)
                     continue;
 
-                int targetIndex = 0;
-                if (!mapFormatToTargetIndex.tryGetValue(impliedFormat, targetIndex))
-                {
-                    targetIndex = (int)m_rawTargets.getCount();
+                    int targetIndex = 0;
+                    if (!mapFormatToTargetIndex.tryGetValue(impliedFormat, targetIndex))
+                    {
+                        targetIndex = (int)m_rawTargets.getCount();
 
-                    RawTarget rawTarget;
-                    rawTarget.format = impliedFormat;
-                    m_rawTargets.add(rawTarget);
+                        RawTarget rawTarget;
+                        rawTarget.format = impliedFormat;
+                        m_rawTargets.add(rawTarget);
 
-                    mapFormatToTargetIndex[impliedFormat] = targetIndex;
+                        mapFormatToTargetIndex[impliedFormat] = targetIndex;
+                    }
+
+                    rawOutput.targetIndex = targetIndex;
                 }
-
-                rawOutput.targetIndex = targetIndex;
             }
         }
-    }
-    else
-    {
-        // If there were explicit targets, then we will use those, but still
-        // build up our mapping. We should object if the same target format
-        // is specified more than once (just because of the ambiguities
-        // it will create).
-        //
-        int targetCount = (int)m_rawTargets.getCount();
-        for (int targetIndex = 0; targetIndex < targetCount; ++targetIndex)
+        else
         {
-            auto format = m_rawTargets[targetIndex].format;
+            // If there were explicit targets, then we will use those, but still
+            // build up our mapping. We should object if the same target format
+            // is specified more than once (just because of the ambiguities
+            // it will create).
+            //
+            int targetCount = (int)m_rawTargets.getCount();
+            for (int targetIndex = 0; targetIndex < targetCount; ++targetIndex)
+            {
+                auto format = m_rawTargets[targetIndex].format;
 
-            if (mapFormatToTargetIndex.containsKey(format))
-            {
-                m_sink->diagnose(SourceLoc(), Diagnostics::duplicateTargets, format);
-            }
-            else
-            {
-                mapFormatToTargetIndex[format] = targetIndex;
+                if (mapFormatToTargetIndex.containsKey(format))
+                {
+                    m_sink->diagnose(SourceLoc(), Diagnostics::duplicateTargets, format);
+                }
+                else
+                {
+                    mapFormatToTargetIndex[format] = targetIndex;
+                }
             }
         }
-    }
 
-    // If we weren't able to infer any targets from output paths (perhaps
-    // because there were no output paths), but there was a profile specified,
-    // then we can try to infer a target from the profile.
-    //
-    if (m_rawTargets.getCount() == 0
-        && m_defaultTarget.optionSet.getProfileVersion() != ProfileVersion::Unknown
-        && !m_defaultTarget.conflictingProfilesSet)
-    {
-        // Let's see if the chosen profile allows us to infer
-        // the code gen target format that the user probably meant.
+        // If we weren't able to infer any targets from output paths (perhaps
+        // because there were no output paths), but there was a profile specified,
+        // then we can try to infer a target from the profile.
         //
-        CodeGenTarget inferredFormat = CodeGenTarget::Unknown;
-        auto profileVersion = m_defaultTarget.optionSet.getProfileVersion();
-        switch (Profile(profileVersion).getFamily())
+        if (m_rawTargets.getCount() == 0
+            && m_defaultTarget.optionSet.getProfileVersion() != ProfileVersion::Unknown
+            && !m_defaultTarget.conflictingProfilesSet)
         {
+            // Let's see if the chosen profile allows us to infer
+            // the code gen target format that the user probably meant.
+            //
+            CodeGenTarget inferredFormat = CodeGenTarget::Unknown;
+            auto profileVersion = m_defaultTarget.optionSet.getProfileVersion();
+            switch (Profile(profileVersion).getFamily())
+            {
             default:
                 break;
 
@@ -2631,128 +2627,128 @@ SlangResult OptionsParser::_parse(
                     inferredFormat = CodeGenTarget::DXBytecode;
                 }
                 break;
+            }
+
+            if (inferredFormat != CodeGenTarget::Unknown)
+            {
+                RawTarget rawTarget;
+                rawTarget.format = inferredFormat;
+                m_rawTargets.add(rawTarget);
+            }
         }
 
-        if (inferredFormat != CodeGenTarget::Unknown)
+        // Similar to the case for entry points, if there is a single target,
+        // then we allow some of its options to come from the "default"
+        // target state.
+        auto defaultTargetFloatingPointMode = m_defaultTarget.optionSet.getEnumOption<FloatingPointMode>(CompilerOptionName::FloatingPointMode);
+
+        if (m_rawTargets.getCount() == 1)
         {
-            RawTarget rawTarget;
-            rawTarget.format = inferredFormat;
-            m_rawTargets.add(rawTarget);
+            m_rawTargets[0].optionSet.overrideWith(m_defaultTarget.optionSet);
         }
-    }
+        else
+        {
+            // If the "default" target has had a profile (or other state)
+            // specified, but there is != 1 taget, then that state doesn't
+            // apply to anythign and we should give the user an error.
+            //
+            if (m_defaultTarget.optionSet.getProfileVersion() != ProfileVersion::Unknown)
+            {
+                if (m_rawTargets.getCount() == 0)
+                {
+                    // This should only happen if there were multiple `-profile` options,
+                    // so we didn't try to infer a target, or if the `-profile` option
+                    // somehow didn't imply a target.
+                    //
+                    m_sink->diagnose(SourceLoc(), Diagnostics::profileSpecificationIgnoredBecauseNoTargets);
+                }
+                else
+                {
+                    m_sink->diagnose(SourceLoc(), Diagnostics::profileSpecificationIgnoredBecauseBeforeAllTargets);
+                }
+            }
 
-    // Similar to the case for entry points, if there is a single target,
-    // then we allow some of its options to come from the "default"
-    // target state.
-    auto defaultTargetFloatingPointMode = m_defaultTarget.optionSet.getEnumOption<FloatingPointMode>(CompilerOptionName::FloatingPointMode);
+            if (defaultTargetFloatingPointMode != FloatingPointMode::Default)
+            {
+                if (m_rawTargets.getCount() == 0)
+                {
+                    m_sink->diagnose(SourceLoc(), Diagnostics::targetFlagsIgnoredBecauseNoTargets);
+                }
+                else
+                {
+                    m_sink->diagnose(SourceLoc(), Diagnostics::targetFlagsIgnoredBecauseBeforeAllTargets);
+                }
+            }
 
-    if (m_rawTargets.getCount() == 1)
-    {
-        m_rawTargets[0].optionSet.overrideWith(m_defaultTarget.optionSet);
-    }
-    else
-    {
-        // If the "default" target has had a profile (or other state)
-        // specified, but there is != 1 taget, then that state doesn't
-        // apply to anythign and we should give the user an error.
+        }
+        for (auto& rawTarget : m_rawTargets)
+        {
+            if (rawTarget.conflictingProfilesSet)
+            {
+                m_sink->diagnose(SourceLoc(), Diagnostics::conflictingProfilesSpecifiedForTarget, rawTarget.format);
+            }
+            else if (rawTarget.redundantProfileSet)
+            {
+                m_sink->diagnose(SourceLoc(), Diagnostics::sameProfileSpecifiedMoreThanOnce, rawTarget.optionSet.getProfileVersion(), rawTarget.format);
+            }
+        }
+
+        // TODO: do we need to require that a target must have a profile specified,
+        // or will we continue to allow the profile to be inferred from the target?
+
+        // We now have enough information to go ahead and declare the targets
+        // through the Slang API:
         //
-        if (m_defaultTarget.optionSet.getProfileVersion() != ProfileVersion::Unknown)
+        for (auto& rawTarget : m_rawTargets)
         {
-            if (m_rawTargets.getCount() == 0)
-            {
-                // This should only happen if there were multiple `-profile` options,
-                // so we didn't try to infer a target, or if the `-profile` option
-                // somehow didn't imply a target.
-                //
-                m_sink->diagnose(SourceLoc(), Diagnostics::profileSpecificationIgnoredBecauseNoTargets);
-            }
-            else
-            {
-                m_sink->diagnose(SourceLoc(), Diagnostics::profileSpecificationIgnoredBecauseBeforeAllTargets);
-            }
-        }
+            int targetID = m_compileRequest->addCodeGenTarget(SlangCompileTarget(rawTarget.format));
+            rawTarget.targetID = targetID;
 
-        if (defaultTargetFloatingPointMode != FloatingPointMode::Default)
-        {
-            if (m_rawTargets.getCount() == 0)
+            if (rawTarget.optionSet.getProfileVersion() != ProfileVersion::Unknown)
             {
-                m_sink->diagnose(SourceLoc(), Diagnostics::targetFlagsIgnoredBecauseNoTargets);
+                m_compileRequest->setTargetProfile(targetID, SlangProfileID(Profile(rawTarget.optionSet.getProfileVersion()).raw));
             }
-            else
+            for (auto atom : rawTarget.optionSet.getArray(CompilerOptionName::Capability))
             {
-                m_sink->diagnose(SourceLoc(), Diagnostics::targetFlagsIgnoredBecauseBeforeAllTargets);
+                m_requestImpl->addTargetCapability(targetID, SlangCapabilityID(atom.intValue));
+            }
+
+            auto floatingPointMode = rawTarget.optionSet.getEnumOption<FloatingPointMode>(CompilerOptionName::FloatingPointMode);
+            if (floatingPointMode != FloatingPointMode::Default)
+            {
+                m_compileRequest->setTargetFloatingPointMode(targetID, SlangFloatingPointMode(floatingPointMode));
+            }
+
+            if (rawTarget.optionSet.shouldUseScalarLayout())
+            {
+                m_compileRequest->setTargetForceGLSLScalarBufferLayout(targetID, true);
             }
         }
 
-    }
-    for (auto& rawTarget : m_rawTargets)
-    {
-        if (rawTarget.conflictingProfilesSet)
+        // Next we need to sort out the output files specified with `-o`, and
+        // figure out which entry point and/or target they apply to.
+        //
+        // If there is only a single entry point, then that is automatically
+        // the entry point that should be associated with all outputs.
+        //
+        if (m_rawEntryPoints.getCount() == 1)
         {
-            m_sink->diagnose(SourceLoc(), Diagnostics::conflictingProfilesSpecifiedForTarget, rawTarget.format);
+            for (auto& rawOutput : m_rawOutputs)
+            {
+                rawOutput.entryPointIndex = 0;
+            }
         }
-        else if (rawTarget.redundantProfileSet)
+        //
+        // Similarly, if there is only one target, then all outputs must
+        // implicitly appertain to that target.
+        //
+        if (m_rawTargets.getCount() == 1)
         {
-            m_sink->diagnose(SourceLoc(), Diagnostics::sameProfileSpecifiedMoreThanOnce, rawTarget.optionSet.getProfileVersion(), rawTarget.format);
+            for (auto& rawOutput : m_rawOutputs)
+            {
+                rawOutput.targetIndex = 0;
+            }
         }
-    }
-
-    // TODO: do we need to require that a target must have a profile specified,
-    // or will we continue to allow the profile to be inferred from the target?
-
-    // We now have enough information to go ahead and declare the targets
-    // through the Slang API:
-    //
-    for (auto& rawTarget : m_rawTargets)
-    {
-        int targetID = m_compileRequest->addCodeGenTarget(SlangCompileTarget(rawTarget.format));
-        rawTarget.targetID = targetID;
-
-        if (rawTarget.optionSet.getProfileVersion() != ProfileVersion::Unknown)
-        {
-            m_compileRequest->setTargetProfile(targetID, SlangProfileID(Profile(rawTarget.optionSet.getProfileVersion()).raw));
-        }
-        for (auto atom : rawTarget.optionSet.getArray(CompilerOptionName::Capability))
-        {
-            m_requestImpl->addTargetCapability(targetID, SlangCapabilityID(atom.intValue));
-        }
-
-        auto floatingPointMode = rawTarget.optionSet.getEnumOption<FloatingPointMode>(CompilerOptionName::FloatingPointMode);
-        if (floatingPointMode != FloatingPointMode::Default)
-        {
-            m_compileRequest->setTargetFloatingPointMode(targetID, SlangFloatingPointMode(floatingPointMode));
-        }
-
-        if (rawTarget.optionSet.shouldUseScalarLayout())
-        {
-            m_compileRequest->setTargetForceGLSLScalarBufferLayout(targetID, true);
-        }
-    }
-
-    // Next we need to sort out the output files specified with `-o`, and
-    // figure out which entry point and/or target they apply to.
-    //
-    // If there is only a single entry point, then that is automatically
-    // the entry point that should be associated with all outputs.
-    //
-    if (m_rawEntryPoints.getCount() == 1)
-    {
-        for (auto& rawOutput : m_rawOutputs)
-        {
-            rawOutput.entryPointIndex = 0;
-        }
-    }
-    //
-    // Similarly, if there is only one target, then all outputs must
-    // implicitly appertain to that target.
-    //
-    if (m_rawTargets.getCount() == 1)
-    {
-        for (auto& rawOutput : m_rawOutputs)
-        {
-            rawOutput.targetIndex = 0;
-        }
-    }
 
     // If we don't have any raw outputs but do have a raw target,
     // add an empty' rawOutput for certain targets where the expected behavior is obvious.
@@ -2774,55 +2770,55 @@ SlangResult OptionsParser::_parse(
         m_rawOutputs.add(rawOutput);
     }
 
-    // Consider the output files specified via `-o` and try to figure
-    // out how to deal with them.
-    //
-    for (auto& rawOutput : m_rawOutputs)
-    {
-        // For now, most output formats need to be tightly bound to
-        // both a target and an entry point.
-
-        // If an output doesn't have a target associated with
-        // it, then search for the target with the matching format.
-        if (rawOutput.targetIndex == -1)
+        // Consider the output files specified via `-o` and try to figure
+        // out how to deal with them.
+        //
+        for (auto& rawOutput : m_rawOutputs)
         {
-            auto impliedFormat = rawOutput.impliedFormat;
-            int targetIndex = -1;
+            // For now, most output formats need to be tightly bound to
+            // both a target and an entry point.
 
-            if (impliedFormat == CodeGenTarget::Unknown)
+            // If an output doesn't have a target associated with
+            // it, then search for the target with the matching format.
+            if (rawOutput.targetIndex == -1)
             {
-                
-                // If we hit this case, then it means that we need to pick the
-                // target to assocaite with this output based on its implied
-                // format, but the file path doesn't direclty imply a format
-                // (it doesn't have a suffix like `.spv` that tells us what to write).
-                //
-                m_sink->diagnose(SourceLoc(), Diagnostics::cannotDeduceOutputFormatFromPath, rawOutput.path);
-            }
-            else if (mapFormatToTargetIndex.tryGetValue(rawOutput.impliedFormat, targetIndex))
-            {
-                rawOutput.targetIndex = targetIndex;
-            }
-            else
-            {
-                m_sink->diagnose(SourceLoc(), Diagnostics::cannotMatchOutputFileToTarget, rawOutput.path, rawOutput.impliedFormat);
-            }
-        }
+                auto impliedFormat = rawOutput.impliedFormat;
+                int targetIndex = -1;
 
-        // We won't do any searching to match an output file
-        // with an entry point, since the case of a single entry
-        // point was handled above, and the user is expected to
-        // follow the ordering rules when using multiple entry points.
-        if (rawOutput.entryPointIndex == -1)
-        {
-            if (rawOutput.targetIndex != -1)
-            {
-                auto outputFormat = m_rawTargets[rawOutput.targetIndex].format;
-                // Here we check whether the given output format supports multiple entry points
-                // When we add targets with support for multiple entry points,
-                // we should update this switch with those new formats
-                switch (outputFormat)
+                if (impliedFormat == CodeGenTarget::Unknown)
                 {
+
+                    // If we hit this case, then it means that we need to pick the
+                    // target to assocaite with this output based on its implied
+                    // format, but the file path doesn't direclty imply a format
+                    // (it doesn't have a suffix like `.spv` that tells us what to write).
+                    //
+                    m_sink->diagnose(SourceLoc(), Diagnostics::cannotDeduceOutputFormatFromPath, rawOutput.path);
+                }
+                else if (mapFormatToTargetIndex.tryGetValue(rawOutput.impliedFormat, targetIndex))
+                {
+                    rawOutput.targetIndex = targetIndex;
+                }
+                else
+                {
+                    m_sink->diagnose(SourceLoc(), Diagnostics::cannotMatchOutputFileToTarget, rawOutput.path, rawOutput.impliedFormat);
+                }
+            }
+
+            // We won't do any searching to match an output file
+            // with an entry point, since the case of a single entry
+            // point was handled above, and the user is expected to
+            // follow the ordering rules when using multiple entry points.
+            if (rawOutput.entryPointIndex == -1)
+            {
+                if (rawOutput.targetIndex != -1)
+                {
+                    auto outputFormat = m_rawTargets[rawOutput.targetIndex].format;
+                    // Here we check whether the given output format supports multiple entry points
+                    // When we add targets with support for multiple entry points,
+                    // we should update this switch with those new formats
+                    switch (outputFormat)
+                    {
                     case CodeGenTarget::CPPSource:
                     case CodeGenTarget::PTX:
                     case CodeGenTarget::CUDASource:
@@ -2858,11 +2854,11 @@ SlangResult OptionsParser::_parse(
                             m_sink->diagnose(SourceLoc(), Diagnostics::cannotMatchOutputFileToEntryPoint, rawOutput.path);
                         }
                         break;
+                    }
                 }
             }
         }
     }
-endOfOptionInference:;
 
     // Now that we've diagnosed the output paths, we can add them
     // to the compile request at the appropriate locations.

--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -49,13 +49,8 @@ static SlangResult _compile(SlangCompileRequest* compileRequest, int argc, const
     try
 #endif
     {
-        auto startTime = std::chrono::high_resolution_clock::now();
-        
         // Run the compiler (this will produce any diagnostics through SLANG_WRITER_TARGET_TYPE_DIAGNOSTIC).
         res = spCompile(compileRequest);
-        auto elapsedTime =
-            (std::chrono::high_resolution_clock::now() - startTime).count() * 0.000000001;
-        printf("Elapsed time: %f\n", elapsedTime);
         // If the compilation failed, then get out of here...
         // Turn into an internal Result -> such that return code can be used to vary result to match previous behavior
         res = SLANG_FAILED(res) ? SLANG_E_INTERNAL_FAIL : res;

--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -49,8 +49,13 @@ static SlangResult _compile(SlangCompileRequest* compileRequest, int argc, const
     try
 #endif
     {
+        auto startTime = std::chrono::high_resolution_clock::now();
+        
         // Run the compiler (this will produce any diagnostics through SLANG_WRITER_TARGET_TYPE_DIAGNOSTIC).
         res = spCompile(compileRequest);
+        auto elapsedTime =
+            (std::chrono::high_resolution_clock::now() - startTime).count() * 0.000000001;
+        printf("Elapsed time: %f\n", elapsedTime);
         // If the compilation failed, then get out of here...
         // Turn into an internal Result -> such that return code can be used to vary result to match previous behavior
         res = SLANG_FAILED(res) ? SLANG_E_INTERNAL_FAIL : res;

--- a/tests/bindings/multiple-parameter-blocks.slang
+++ b/tests/bindings/multiple-parameter-blocks.slang
@@ -1,9 +1,13 @@
-//TEST:COMPARE_HLSL:-profile ps_5_1 -entry main -parameter-blocks-use-register-spaces
+//TEST:SIMPLE(filecheck=CHECK):-target hlsl -profile ps_5_1 -entry main -parameter-blocks-use-register-spaces
 
 // Confirm that Slang `ParameterBlock<T>` generates
 // parameter bindings like we expect.
 
+// CHECK: Texture2D{{.*}} p_t_0 : register(t0);
+// CHECK: Texture2D{{.*}} p_ta_0[{{.*}}] : register(t1);
 
+// CHECK: Texture2D{{.*}} p1_t_0 : register(t0, space1);
+// CHECK: SamplerState p1_s_0 : register(s0, space1);
 float4 use(float4 val) { return val; };
 float4 use(Texture2D t, SamplerState s) { return t.Sample(s, 0.0); }
 

--- a/tests/language-feature/extensions/extension-method-simple.slang
+++ b/tests/language-feature/extensions/extension-method-simple.slang
@@ -1,0 +1,30 @@
+// interface-extension.slang
+
+// Test that an `extension` applied to an interface type works as users expect
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj
+
+struct MyType
+{
+    int v;
+}
+
+extension MyType
+{
+    int foo()
+    {
+        return v;
+    }
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(4, 1, 1)]
+void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+{
+    MyType t;
+    t.v = 1;
+    // CHECK: 1
+    outputBuffer[dispatchThreadID.x] = t.foo();
+}

--- a/tests/slang-extension/atomic-float-byte-address-buffer-cross.slang
+++ b/tests/slang-extension/atomic-float-byte-address-buffer-cross.slang
@@ -34,8 +34,6 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 
     const float delta = anotherBuffer[idx & 3];
 
-    // CHECK: OpAtomicFAddEXT
-
     float previousValue = 0;
     outputBuffer.InterlockedAddF32((idx << 2), 1.0f, previousValue);
     

--- a/tests/slang-extension/atomic-float-byte-address-buffer-cross.slang
+++ b/tests/slang-extension/atomic-float-byte-address-buffer-cross.slang
@@ -33,7 +33,9 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     int idx = int((tid & 3) ^ (tid >> 2)); 
 
     const float delta = anotherBuffer[idx & 3];
-    
+
+    // CHECK: OpAtomicFAddEXT
+
     float previousValue = 0;
     outputBuffer.InterlockedAddF32((idx << 2), 1.0f, previousValue);
     


### PR DESCRIPTION
1. Add caching for implicit conversion overload resolution results.
2. Handle invalidation of type checking cache upon extension registration more gracefully.
3. Add a setting to `simplifyIR` to disable `redundancyRemoval` pass (still enabled by default).