### PR TITLE
Fix assertions due to malformed switch statements

### DIFF
--- a/source/slang/slang-ast-stmt.h
+++ b/source/slang/slang-ast-stmt.h
@@ -143,6 +143,8 @@ class CaseStmt : public CaseStmtBase
     SLANG_AST_CLASS(CaseStmt)
 
     Expr* expr = nullptr;
+
+    Val* exprVal = nullptr;
 };
 
 // a `default` statement inside a `switch`

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -2741,6 +2741,9 @@ namespace Slang
         void tryInferLoopMaxIterations(ForStmt* stmt);
 
         void checkLoopInDifferentiableFunc(Stmt* stmt);
+
+    private:
+        void validateCaseStmts(SwitchStmt* stmt, DiagnosticSink* sink);
     };
 
     struct SemanticsDeclVisitorBase

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -239,6 +239,48 @@ namespace Slang
         subContext.checkStmt(stmt->body);
     }
 
+    void SemanticsStmtVisitor::validateCaseStmts(SwitchStmt* stmt, DiagnosticSink* sink)
+    {
+        auto blockStmt = as<BlockStmt>(stmt->body);
+        if (!blockStmt)
+            return;
+
+        auto seqStmt = as<SeqStmt>(blockStmt->body);
+        if (!seqStmt)
+            return;
+
+        bool hasDefaultStmt = false;
+        HashSet<Val*> caseStmtVals;
+        for (auto& sStmt : seqStmt->stmts)
+        {
+            // check that all case tags are unique
+            if (auto caseStmt = as<CaseStmt>(sStmt))
+            {
+                if (caseStmt->exprVal)
+                {
+                    // exprVal contains the constant folded expr, that is checked for
+                    // uniqueness within the scope of the switch statement.
+                    if (!caseStmtVals.add(caseStmt->exprVal))
+                    {
+                        sink->diagnose(sStmt, Diagnostics::duplicateCasesInASwitch);
+                        return;
+                    }
+                }
+            }
+
+            // check that there is at most one `default` clause
+            else if (auto defaultStmt = as<DefaultStmt>(sStmt))
+            {
+                if (hasDefaultStmt)
+                {
+                    sink->diagnose(sStmt, Diagnostics::multipleDefaultsInASwitch);
+                    return;
+                }
+                hasDefaultStmt = true;
+            }
+        }
+    }
+
     void SemanticsStmtVisitor::visitSwitchStmt(SwitchStmt* stmt)
     {
         WithOuterStmt subContext(this, stmt);
@@ -247,16 +289,16 @@ namespace Slang
         stmt->condition = CheckExpr(stmt->condition);
         subContext.checkStmt(stmt->body);
 
-        // TODO(tfoley): need to check that all case tags are unique
-
-        // TODO(tfoley): check that there is at most one `default` clause
+        // check the case value exits within the switch
+        validateCaseStmts(stmt, getSink());
     }
 
     void SemanticsStmtVisitor::visitCaseStmt(CaseStmt* stmt)
     {
-        // TODO(tfoley): Need to coerce to type being switch on,
-        // and ensure that value is a compile-time constant
         auto expr = CheckExpr(stmt->expr);
+
+        // coerce to type being switch on, and ensure that value is a compile-time constant
+        auto exprVal = tryConstantFoldExpr(expr, ConstantFoldingKind::CompileTime, nullptr);
         auto switchStmt = FindOuterStmt<SwitchStmt>();
 
         if (!switchStmt)
@@ -270,6 +312,7 @@ namespace Slang
         }
 
         stmt->expr = expr;
+        stmt->exprVal = exprVal;
         stmt->parentStmt = switchStmt;
     }
 

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -253,27 +253,26 @@ namespace Slang
         HashSet<Val*> caseStmtVals;
         for (auto& sStmt : seqStmt->stmts)
         {
-            // check that all case tags are unique
             if (auto caseStmt = as<CaseStmt>(sStmt))
             {
+                // check that all case tags are unique
                 if (caseStmt->exprVal)
                 {
                     // exprVal contains the constant folded expr, that is checked for
                     // uniqueness within the scope of the switch statement.
                     if (!caseStmtVals.add(caseStmt->exprVal))
                     {
-                        sink->diagnose(sStmt, Diagnostics::duplicateCasesInASwitch);
+                        sink->diagnose(sStmt, Diagnostics::switchDuplicateCases);
                         return;
                     }
                 }
             }
-
-            // check that there is at most one `default` clause
             else if (auto defaultStmt = as<DefaultStmt>(sStmt))
             {
+                // check that there is at most one `default` clause
                 if (hasDefaultStmt)
                 {
-                    sink->diagnose(sStmt, Diagnostics::multipleDefaultsInASwitch);
+                    sink->diagnose(sStmt, Diagnostics::switchMultipleDefault);
                     return;
                 }
                 hasDefaultStmt = true;
@@ -298,6 +297,8 @@ namespace Slang
         auto expr = CheckExpr(stmt->expr);
 
         // coerce to type being switch on, and ensure that value is a compile-time constant
+        // The Vals in the AST are pointer-unique, making them easy to check for duplicates
+        // by addeing them to a HashSet.
         auto exprVal = tryConstantFoldExpr(expr, ConstantFoldingKind::CompileTime, nullptr);
         auto switchStmt = FindOuterStmt<SwitchStmt>();
 

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -476,6 +476,9 @@ DIAGNOSTIC(30504, Warning, forLoopTerminatesInFewerIterationsThanMaxIters, "the 
 DIAGNOSTIC(30505, Warning, loopRunsForZeroIterations, "the loop runs for 0 iterations and will be removed.")
 DIAGNOSTIC(30510, Error, loopInDiffFuncRequireUnrollOrMaxIters, "loops inside a differentiable function need to provide either '[MaxIters(n)]' or '[ForceUnroll]' attribute.")
 
+DIAGNOSTIC(30600, Error, switchMultipleDefault, "multiple 'default' cases not allowed within a 'switch' statement")
+DIAGNOSTIC(30601, Error, switchDuplicateCases, "duplicate cases not allowed within a 'switch' statement")
+
 // TODO: need to assign numbers to all these extra diagnostics...
 DIAGNOSTIC(39999, Fatal, cyclicReference, "cyclic reference '$0'.")
 DIAGNOSTIC(39999, Error, cyclicReferenceInInheritance, "cyclic reference in inheritance graph '$0'.")
@@ -556,8 +559,6 @@ DIAGNOSTIC(39999, Note, moreOverloadCandidates, "$0 more overload candidates")
 
 DIAGNOSTIC(39999, Error, caseOutsideSwitch, "'case' not allowed outside of a 'switch' statement")
 DIAGNOSTIC(39999, Error, defaultOutsideSwitch, "'default' not allowed outside of a 'switch' statement")
-DIAGNOSTIC(39999, Error, multipleDefaultsInASwitch, "multiple 'default' cases not allowed within a 'switch' statement")
-DIAGNOSTIC(39999, Error, duplicateCasesInASwitch, "duplicate cases not allowed within a 'switch' statement")
 
 DIAGNOSTIC(39999, Error, expectedAGeneric, "expected a generic when using '<...>' (found: '$0')")
 

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -476,6 +476,7 @@ DIAGNOSTIC(30504, Warning, forLoopTerminatesInFewerIterationsThanMaxIters, "the 
 DIAGNOSTIC(30505, Warning, loopRunsForZeroIterations, "the loop runs for 0 iterations and will be removed.")
 DIAGNOSTIC(30510, Error, loopInDiffFuncRequireUnrollOrMaxIters, "loops inside a differentiable function need to provide either '[MaxIters(n)]' or '[ForceUnroll]' attribute.")
 
+// Switch
 DIAGNOSTIC(30600, Error, switchMultipleDefault, "multiple 'default' cases not allowed within a 'switch' statement")
 DIAGNOSTIC(30601, Error, switchDuplicateCases, "duplicate cases not allowed within a 'switch' statement")
 

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -556,6 +556,8 @@ DIAGNOSTIC(39999, Note, moreOverloadCandidates, "$0 more overload candidates")
 
 DIAGNOSTIC(39999, Error, caseOutsideSwitch, "'case' not allowed outside of a 'switch' statement")
 DIAGNOSTIC(39999, Error, defaultOutsideSwitch, "'default' not allowed outside of a 'switch' statement")
+DIAGNOSTIC(39999, Error, multipleDefaultsInASwitch, "multiple 'default' cases not allowed within a 'switch' statement")
+DIAGNOSTIC(39999, Error, duplicateCasesInASwitch, "duplicate cases not allowed within a 'switch' statement")
 
 DIAGNOSTIC(39999, Error, expectedAGeneric, "expected a generic when using '<...>' (found: '$0')")
 

--- a/tests/diagnostics/switch-duplicate-case.slang
+++ b/tests/diagnostics/switch-duplicate-case.slang
@@ -5,8 +5,7 @@
 enum class Cases
 {
     A,
-    B,
-    C
+    B
 };
 
 void test1(Cases c)
@@ -15,7 +14,7 @@ void test1(Cases c)
     {
         case Cases::A: break;
         case Cases::B: break;
-        // CHECK: ([[# @LINE+1]]): error 39999: {{.*}}
+        // CHECK: ([[# @LINE+1]]): error 30601: {{.*}}
         case Cases::A: break;
     }
     return;
@@ -27,7 +26,7 @@ void test2()
     {
         case 1: break;
         case 2: break;
-        // CHECK: ([[# @LINE+1]]): error 39999: {{.*}}
+        // CHECK: ([[# @LINE+1]]): error 30601: {{.*}}
         case 1: break;
     }
 	return;

--- a/tests/diagnostics/switch-duplicate-case.slang
+++ b/tests/diagnostics/switch-duplicate-case.slang
@@ -1,0 +1,34 @@
+//TEST:SIMPLE(filecheck=CHECK):
+
+// Tests to evaluate the behavior of code blocks within a switch statement. A switch statement with duplicate cases with same values is not allowed and should throw an error
+
+enum class Cases
+{
+    A,
+    B,
+    C
+};
+
+void test1(Cases c)
+{
+    switch (c)
+    {
+        case Cases::A: break;
+        case Cases::B: break;
+        // CHECK: ([[# @LINE+1]]): error 39999: {{.*}}
+        case Cases::A: break;
+    }
+    return;
+}
+
+void test2()
+{
+    switch (0)
+    {
+        case 1: break;
+        case 2: break;
+        // CHECK: ([[# @LINE+1]]): error 39999: {{.*}}
+        case 1: break;
+    }
+	return;
+}

--- a/tests/diagnostics/switch-multiple-defaults.slang
+++ b/tests/diagnostics/switch-multiple-defaults.slang
@@ -7,7 +7,7 @@ void test()
     switch (0)
     {
         default: break;
-        // CHECK: ([[# @LINE+1]]): error {{.*}}
+        // CHECK: ([[# @LINE+1]]): error 30600: {{.*}}
         default: break;
     }
 	return;

--- a/tests/diagnostics/switch-multiple-defaults.slang
+++ b/tests/diagnostics/switch-multiple-defaults.slang
@@ -1,0 +1,14 @@
+//TEST:SIMPLE(filecheck=CHECK):
+
+// Test to evaluate the behavior of unreachable code blocks within a switch statement. A switch statement with multiple default cases is not allowed and should throw an error
+
+void test()
+{
+    switch (0)
+    {
+        default: break;
+        // CHECK: ([[# @LINE+1]]): error {{.*}}
+        default: break;
+    }
+	return;
+}


### PR DESCRIPTION
The change looks for duplicate default cases in a switch statement, and flag them as invalid