### PR TITLE
Correctly emit `SPV_EXT_mesh_shader` for when `CullPrimitiveEXT` is used - resolves #3863

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -3815,7 +3815,7 @@ struct SPIRVEmitContext
                 else if (semanticName == "sv_cullprimitive")
                 {
                     requireSPIRVCapability(SpvCapabilityMeshShadingEXT);
-                    ensureExtensionDeclaration(UnownedStringSlice("SPV_NV_mesh_shader"));
+                    ensureExtensionDeclaration(UnownedStringSlice("SPV_EXT_mesh_shader"));
                     return getBuiltinGlobalVar(inst->getFullType(), SpvBuiltInCullPrimitiveEXT);
                 }
                 else if (semanticName == "sv_shadingrate")

--- a/tests/pipeline/rasterization/mesh/primitive-output.slang
+++ b/tests/pipeline/rasterization/mesh/primitive-output.slang
@@ -3,6 +3,11 @@
 // Test that a simple mesh shader compiles
 
 //TEST:CROSS_COMPILE:-target spirv -profile glsl_450+spirv_1_4 -entry main -stage mesh
+//TEST:SIMPLE(filecheck=SPV_CHECK):-target spirv -profile glsl_450+spirv_1_4 -entry main -stage mesh
+
+//SPV_CHECK-NOT: SPV_NV_mesh_shader
+//SPV_CHECK: SPV_EXT_mesh_shader
+//SPV_CHECK: CullPrimitiveEXT
 
 const static float2 positions[3] = {
     float2(0.0, -0.5),


### PR DESCRIPTION
[Follow capabilities as per SPIR-V specification](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_capability) CullPrimitiveEXT should require `SPV_EXT_mesh_shader`, currently the code requires `SPV_NV_mesh_shader`.

Addresses https://github.com/shader-slang/slang/issues/3863