### PR TITLE
Fix peephole optimization of `TypeEquals`.

### DIFF
--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -960,7 +960,8 @@ struct PeepholeContext : InstPassBase
             {
                 auto getTypeFromOperand = [](IRInst* operand) -> IRType*
                 {
-                    if (as<IRTypeType>(operand->getFullType()) || !operand->getFullType())
+                    if (as<IRTypeType>(operand->getFullType()) || !operand->getFullType() ||
+                        as<IRTypeKind>(operand->getFullType()))
                         return (IRType*)operand;
                     return operand->getFullType();
                 };

--- a/tests/language-feature/types/is-on-type.slang
+++ b/tests/language-feature/types/is-on-type.slang
@@ -1,0 +1,45 @@
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute
+
+// Test that `is` operator works on generic type param.
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+interface I
+{
+
+}
+
+struct A : I
+{
+    uint i;
+};
+
+struct B : I
+{
+    float2 f2;
+};
+
+func test<T : I>(T t) -> int
+{
+    int rs = 0;
+    if (T is A)
+    {
+        rs++;
+    }
+    if (T is B)
+    {
+        rs+=2;
+    }
+    return rs;
+}
+
+[shader("compute")]
+[numthreads(1,1, 1)]
+void computeMain()
+{
+    B b;
+    // CHECK: 2
+    outputBuffer[0] = test(b);
+}


### PR DESCRIPTION
Closes #3861.

The cause is that we are using both `kIROp_TypeType` and `kIROp_TypeKind` to represent the type of an inst that represents a type. This needs to be clean up separately so that we unify them into a single opcode.