### PR TITLE
Fix static member lookup in pointer types.

### DIFF
--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -3728,7 +3728,9 @@ namespace Slang
                         this,
                         expr->name,
                         type,
-                        m_outerScope);
+                        m_outerScope,
+                        LookupMask::Default,
+                        LookupOptions::NoDeref);
 
                     // We need to confirm that whatever member we
                     // are trying to refer to is usable via static reference.

--- a/tests/language-feature/extensions/ptr-extension.slang
+++ b/tests/language-feature/extensions/ptr-extension.slang
@@ -1,0 +1,14 @@
+//TEST:EXECUTABLE:
+__generic<T> extension Ptr<T> {
+  static func FromHandle(uint64_t handle) -> Ptr<T> {
+    return (Ptr<T>)handle;
+  }
+}
+
+__extern_cpp export
+func main() -> int
+{
+    let x = Ptr<int>::FromHandle(0ull);
+    printf("%d\n", (int)x);
+    return 0;
+}

--- a/tests/language-feature/extensions/ptr-extension.slang.expected
+++ b/tests/language-feature/extensions/ptr-extension.slang.expected
@@ -1,0 +1,6 @@
+result code = 0
+standard error = {
+}
+standard output = {
+0
+}


### PR DESCRIPTION
Closes #3868.

When looking up members of a pointer type, we will automatically dereference the pointer and lookup in the pointee type instead.

However when the lookup is static, such as when the user is doing (Ptr<T>::member), we shouldn't be doing this implicit deref step, and instead need to lookup in the Ptr type itself.