### PR TITLE
Allow enum values to be used as generic arguments.

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2221,6 +2221,27 @@ __prefix T operator !(T v0)
     return v0.not();
 }
 
+// The operator overloads defined above already allows Enum types to be used
+// in logical operators, but we still provide overloads for __EnumTypes and map
+// them directly to intrinsic op to allow constant propagation at AST level to
+// work on enum types.
+
+__generic<T : __EnumType>
+[__unsafeForceInlineEarly]
+__intrinsic_op($(kIROp_BitAnd))
+T operator &(T v0, T v1);
+
+__generic<T : __EnumType>
+[__unsafeForceInlineEarly]
+__intrinsic_op($(kIROp_BitOr))
+T operator |(T v0, T v1);
+
+__generic<T : __EnumType>
+[__unsafeForceInlineEarly]
+__intrinsic_op($(kIROp_BitNot))
+__prefix T operator ~(T v0);
+
+
 // IR level type traits.
 
 __generic<T>

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -5946,6 +5946,11 @@ namespace Slang
         return isIntegerBaseType(baseType) || baseType == BaseType::Bool;
     }
 
+    bool SemanticsVisitor::isValidCompileTimeConstantType(Type* type)
+    {
+        return isScalarIntegerType(type) || isEnumType(type);
+    }
+
     bool SemanticsVisitor::isIntValueInRangeOfType(IntegerLiteralValue value, Type* type)
     {
         auto basicType = as<BasicExpressionType>(type);

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -1768,7 +1768,10 @@ namespace Slang
                         return nullptr;
 
                     ConstantFoldingCircularityInfo newCircularityInfo(enumCaseDecl, circularityInfo);
-                    return tryConstantFoldExpr(tagExpr, kind, &newCircularityInfo);
+                    auto intVal = as<IntVal>(tryConstantFoldExpr(tagExpr, kind, &newCircularityInfo));
+                    if (!intVal)
+                        return nullptr;
+                    return m_astBuilder->getTypeCastIntVal(enumCaseDecl->getType(), intVal);
                 }
             }
         }
@@ -1778,7 +1781,7 @@ namespace Slang
             auto substType = getType(m_astBuilder, expr);
             if (!substType)
                 return nullptr;
-            if (!isScalarIntegerType(substType))
+            if (!isValidCompileTimeConstantType(substType))
                 return nullptr;
             auto val = tryConstantFoldExpr(getArg(castExpr, 0), kind, circularityInfo);
             if (val)
@@ -1826,7 +1829,7 @@ namespace Slang
     {
         // Check if type is acceptable for an integer constant expression
         //
-        if(!isScalarIntegerType(getType(m_astBuilder, expr)))
+        if(!isValidCompileTimeConstantType(getType(m_astBuilder, expr)))
             return nullptr;
 
         // Consider operations that we might be able to constant-fold...

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -1771,7 +1771,7 @@ namespace Slang
                     auto intVal = as<IntVal>(tryConstantFoldExpr(tagExpr, kind, &newCircularityInfo));
                     if (!intVal)
                         return nullptr;
-                    return m_astBuilder->getTypeCastIntVal(enumCaseDecl->getType(), intVal);
+                    return as<IntVal>(m_astBuilder->getTypeCastIntVal(enumCaseDecl->getType(), intVal)->resolve());
                 }
             }
         }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1816,6 +1816,9 @@ namespace Slang
             /// Is `type` a scalar integer type.
         bool isScalarIntegerType(Type* type);
 
+            /// Is `type` something we allow as compile time constants, i.e. scalar integer and enum types.
+        bool isValidCompileTimeConstantType(Type* type);
+
         bool isIntValueInRangeOfType(IntegerLiteralValue value, Type* type);
 
         // Validate that `type` is a suitable type to use

--- a/tests/language-feature/enums/enum-generic-arg.slang
+++ b/tests/language-feature/enums/enum-generic-arg.slang
@@ -1,0 +1,33 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj
+
+// Test that enum values can be used as compile time constants
+// to specialize generics.
+
+[Flags]
+enum BitFlags
+{
+    One, Two, Three
+}
+
+int test<let F : BitFlags>()
+{
+    return F;
+}
+
+int testInt<let f : int>()
+{
+    return f;
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+{
+    // CHECK: 3
+    outputBuffer[0] = test<BitFlags.One | BitFlags.Two>();
+
+    // CHECK: 3
+    outputBuffer[1] = testInt<BitFlags.One | BitFlags.Two>();
+}


### PR DESCRIPTION
The main change here is to allow constant folding to preserve the enum types from enum case values, and to allow constant propagation logic to identify the binary operator overloads.