### PR TITLE
Delete out-of-date notes from user guide.

### DIFF
--- a/docs/user-guide/06-interfaces-generics.md
+++ b/docs/user-guide/06-interfaces-generics.md
@@ -68,28 +68,6 @@ int b = myGenericMethod(obj); // OK, automatic type deduction
 
 You may explicitly specify the concrete type to used for the generic type argument, by providing the types in angular brackets after the method name, or leave it to the compiler to automatically deduce the type from the argument list.
 
-> #### Note ####
-> Slang currently does not support partial type argument list deduction.
-> For example if you have a generic method that accepts two type arguments:
-> ```
-> void g<T:IFoo, U:IBar>(T a, U b) {...}
-> ```
-> You may either call this method with no explicit type arguments:
-> ```
-> MyType a, b;
-> g(a, b);
-> ```
-> Or with explicit arguments for both generic type parameters:
-> ```
-> g<MyType, MyType>(a,b);
-> ```
-> If you only provide first type argument, Slang will generate an error:
-> ```
-> g<MyType>(a,b); // error, does not work today.
-> ```
-> We plan to support such use in a future version.
-
-
 Note that it is important to associate a generic type parameter with a type constraint. In the above example, although the definition of `myGenericMethod` is agnostic of the concrete type `T` will stand for, knowing that `T` conforms to `IFoo` allows the compiler to type-check and pre-compile `myGenericMethod` without needing to substitute `T` with any concrete types first. Similar to languages like C#, Rust, Swift and Java, leaving out the type constraint declaration on type parameter `T` will result in a compile error at the line calling `arg.myMethod` since the compiler cannot verify that `arg` has a member named `myMethod` without any knowledge on `T`. This is a major difference of Slang's generics compared to _templates_ in C++. 
 
 While C++ templates are a powerful language mechanism, Slang has followed the path of many other modern programming languages to adopt the more structural and restricted generics feature instead. This enables the Slang compiler to perform type checking early to give more readable error messages, and to speed-up compilation by reusing a lot of work for different instantiations of `myGenericMethod`.


### PR DESCRIPTION
We support partial generic parameter inference today.