### PR TITLE
WIP: Fix the variable scope issue (#3838)

### DIFF
--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -479,6 +479,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClInclude Include="..\..\..\source\slang\slang-ir-user-type-hint.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-util.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-validate.h" />
+    <ClInclude Include="..\..\..\source\slang\slang-ir-variable-scope-correction.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-vk-invert-y.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-witness-table-wrapper.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-wrap-structured-buffers.h" />
@@ -705,6 +706,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClCompile Include="..\..\..\source\slang\slang-ir-user-type-hint.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-util.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-validate.cpp" />
+    <ClCompile Include="..\..\..\source\slang\slang-ir-variable-scope-correction.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-vk-invert-y.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-witness-table-wrapper.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-wrap-structured-buffers.cpp" />

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -525,6 +525,9 @@
     <ClInclude Include="..\..\..\source\slang\slang-ir-validate.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\slang\slang-ir-variable-scope-correction.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-ir-vk-invert-y.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -1197,6 +1200,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-ir-validate.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\source\slang\slang-ir-variable-scope-correction.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-ir-vk-invert-y.cpp">

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -1072,10 +1072,11 @@ Result linkAndOptimizeIR(
         // all the other optimization passes have been performed.
         //
 
+        dumpIRIfEnabled(codeGenContext, irModule, "Before var scope correction");
         applyVariableScopeCorrection(irModule);
         validateIRModuleIfEnabled(codeGenContext, irModule);
         // TODO: Debug purpose, will remove it.
-        dumpIRIfEnabled(codeGenContext, irModule, "AFTER-ALL-OPTMIZATION");
+        dumpIRIfEnabled(codeGenContext, irModule, "After var scope correction");
     }
 
     auto metadata = new ArtifactPostEmitMetadata;

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -1070,13 +1070,9 @@ Result linkAndOptimizeIR(
         //
         // This is a separate pass because it needs to run after
         // all the other optimization passes have been performed.
-        //
 
-        dumpIRIfEnabled(codeGenContext, irModule, "Before var scope correction");
-        applyVariableScopeCorrection(irModule);
+        applyVariableScopeCorrection(irModule, targetRequest);
         validateIRModuleIfEnabled(codeGenContext, irModule);
-        // TODO: Debug purpose, will remove it.
-        dumpIRIfEnabled(codeGenContext, irModule, "After var scope correction");
     }
 
     auto metadata = new ArtifactPostEmitMetadata;

--- a/source/slang/slang-ir-variable-scope-correction.cpp
+++ b/source/slang/slang-ir-variable-scope-correction.cpp
@@ -1,0 +1,139 @@
+#include "slang-ir-insts.h"
+#include "slang-ir.h"
+
+#include "slang-ir-dominators.h"
+#include "slang-ir-variable-scope-correction.h"
+
+namespace Slang
+{
+
+namespace { // anonymous
+struct VariableScopeCorrectionContext
+{
+    VariableScopeCorrectionContext(IRModule* module):
+        m_module(module), m_builder(module)
+    {
+    }
+
+    void processModule();
+
+    /// Process a function in the module
+    void _processFunction(IRFunc* funcInst);
+
+    IRModule* m_module;
+    IRBuilder m_builder;
+};
+
+void VariableScopeCorrectionContext::processModule()
+{
+    IRModuleInst* moduleInst = m_module->getModuleInst();
+    for (IRInst* child : moduleInst->getChildren())
+    {
+        // We want to find all of the functions, and process them
+        if (auto funcInst = as<IRFunc>(child))
+        {
+            _processFunction(funcInst);
+        }
+    }
+}
+
+static void debugPrint(uint32_t indent, IRInst* inst, const char* message)
+{
+    uint32_t debugid = 0;
+    for (uint32_t i = 0; i < indent; i++)
+    {
+        printf("    ");
+    }
+#ifdef SLANG_ENABLE_IR_BREAK_ALLOC
+        debugid = inst->_debugUID;
+#endif
+    printf("%s, id: %d\n", message, debugid);
+}
+
+void VariableScopeCorrectionContext::_processFunction(IRFunc* funcInst)
+{
+    IRDominatorTree* dominatorTree = m_module->findOrCreateDominatorTree(funcInst);
+
+    Dictionary<IRInst*, List<IRInst*>> workListMap;
+
+    // traverse each instruction in the function
+    for (auto block = funcInst->getFirstBlock(); block; block = block->getNextBlock())
+    {
+        for (auto inst = block->getFirstChild(); inst; inst = inst->getNextInst())
+        {
+            uint32_t indent = 1;
+            printf("process inst = %d\n", inst->getOp());
+            // traverse the dominator tree, theoretically, the variables in each of dominator should be accessible in the current block,
+            // except the loop block, so we have to find out if there is a loop block in the dominator chain.
+            auto dominatorBlock = dominatorTree->getImmediateDominator(block);
+            for (; dominatorBlock; dominatorBlock = dominatorTree->getImmediateDominator(dominatorBlock))
+            {
+                debugPrint(indent++, dominatorBlock, "dominator block");
+                if (auto loop = as<IRLoop>(dominatorBlock->getTerminator()))
+                {
+                    debugPrint(indent, loop, "loop block");
+                    // Get the break block of the loop and check if such block
+                    auto breakBlock = loop->getBreakBlock();
+                    debugPrint(indent++, breakBlock, "break block");
+
+                    // If a block is not dominated by the break block, but dominated by the loop header, then the
+                    // instructions in this block are considered to be defined in the loop. We need to search
+                    // the instruction's use sites to see if there is any uses are out of the loop.
+                    if (!dominatorTree->dominates(breakBlock, block))
+                    {
+                        debugPrint(indent++, block, "block is not dominated by break block");
+                        // traverse all uses of this instruction
+                        for (auto use = inst->firstUse; use; use=use->nextUse)
+                        {
+                            debugPrint(indent++, use->getUser()->getParent(), "inst's use block is");
+                            if (auto userBlock = as<IRBlock>(use->getUser()->getParent()))
+                            {
+                                // If the use site of this instruction is dominated by the break block, it means that the
+                                // instruction is used after the break block, so we need to make that instruction available globally.
+                                // By doing so, we record all the users of this instructions.
+                                if (dominatorTree->dominates(breakBlock, userBlock))
+                                {
+                                    debugPrint(indent, inst, "inst is defined in loop but used outside of loop");
+                                    debugPrint(indent++, use->getUser(), "The user is");
+
+                                    auto list = workListMap.tryGetValue(inst);
+                                    if (!list)
+                                    {
+                                        workListMap.add(inst, List<IRInst*>());
+                                        list = workListMap.tryGetValue(inst);
+                                    }
+                                    list->add(use->getUser());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // By duplicating the instructions right before their users, we can make the instructions available globally.
+    for(auto it = workListMap.begin(); it != workListMap.end(); it++)
+    {
+        auto inst = it->first;
+        auto list = it->second;
+        debugPrint(0, inst, "inst");
+        for(auto user : list)
+        {
+            debugPrint(1, user, "The user");
+            inst->insertAt(IRInsertLoc::before(user));
+        }
+    }
+}
+
+} // anonymous
+
+void applyVariableScopeCorrection(IRModule* module)
+{
+    VariableScopeCorrectionContext context(module);
+
+    context.processModule();
+}
+
+} // namespace Slang
+

--- a/source/slang/slang-ir-variable-scope-correction.cpp
+++ b/source/slang/slang-ir-variable-scope-correction.cpp
@@ -1,5 +1,6 @@
 #include "slang-ir-insts.h"
 #include "slang-ir.h"
+#include "slang-ir-clone.h"
 
 #include "slang-ir-dominators.h"
 #include "slang-ir-variable-scope-correction.h"
@@ -20,6 +21,11 @@ struct VariableScopeCorrectionContext
 
     /// Process a function in the module
     void _processFunction(IRFunc* funcInst);
+    void _processInstructions(IRFunc* funcInst, const Dictionary<IRInst*, List<IRInst*>>& workListMap);
+    void _processStorableInst(IRInst* insertLoc, IRInst* inst, IRInst* user);
+    void _processUnstorableInst(IRInst* funcInst, IRInst* inst, IRInst* user);
+    void _replaceOperand(IRInst* inst, IRInst* oldOperand, IRInst* newOperand);
+    bool _isStorableInst(IRInst* inst);
 
     IRModule* m_module;
     IRBuilder m_builder;
@@ -33,87 +39,106 @@ void VariableScopeCorrectionContext::processModule()
         // We want to find all of the functions, and process them
         if (auto funcInst = as<IRFunc>(child))
         {
-            _processFunction(funcInst);
+            if (funcInst->getFirstBlock())
+            {
+                _processFunction(funcInst);
+            }
         }
     }
 }
 
-static void debugPrint(uint32_t indent, IRInst* inst, const char* message)
+static void debugPrint(uint32_t indent, IRInst* inst, const char* message, bool enable)
 {
+    if (!enable)
+        return;
+
     uint32_t debugid = 0;
     for (uint32_t i = 0; i < indent; i++)
     {
         printf("    ");
     }
+
 #ifdef SLANG_ENABLE_IR_BREAK_ALLOC
+    if (inst)
         debugid = inst->_debugUID;
 #endif
-    printf("%s, id: %d\n", message, debugid);
+
+    if (debugid != 0)
+        printf("%s, id: %d\n", message, debugid);
+    else
+        printf("\n");
 }
 
 void VariableScopeCorrectionContext::_processFunction(IRFunc* funcInst)
 {
     IRDominatorTree* dominatorTree = m_module->findOrCreateDominatorTree(funcInst);
     Dictionary<IRInst*, List<IRInst*>> workListMap;
-    Dictionary<IRBlock*, IRLoop> loopHeaderMap;
+    Dictionary<IRBlock*, List<IRLoop*>> loopHeaderMap;
 
+    bool enableLog = false;
     // traverse all blocks in the function
     for (auto block = funcInst->getFirstBlock(); block; block = block->getNextBlock())
     {
         uint32_t indent = 0;
-        debugPrint(indent++, block, "processing block");
+        debugPrint(indent++, block, "processing block", enableLog);
 
         // Traverse all the dominators of a given block to check whether this given block is in a loop region.
         // Loop region blocks are the blocks that are dominated by the loop header block
         // but not dominated by the loop break block.
         auto dominatorBlock = dominatorTree->getImmediateDominator(block);
+        List<IRLoop*> loopHeaderList;
         for (; dominatorBlock; dominatorBlock = dominatorTree->getImmediateDominator(dominatorBlock))
         {
-            debugPrint(indent++, dominatorBlock, "dominator block");
+            debugPrint(indent++, dominatorBlock, "dominator block", enableLog);
 
             // Find if the block is loop header block
             if (auto loopHeader = as<IRLoop>(dominatorBlock->getTerminator()))
             {
-                debugPrint(indent, loopHeader, "loop header");
+                debugPrint(indent, loopHeader, "loop header", enableLog);
                 // Get the break block of the loop and check if such block
                 auto breakBlock = loopHeader->getBreakBlock();
-                debugPrint(indent++, breakBlock, "break block");
+                debugPrint(indent++, breakBlock, "break block", enableLog);
 
                 // Check if the current block is dominated by the break block. If so, it means that the block is in the loop region.
                 if (!dominatorTree->dominates(breakBlock, block))
                 {
-                    debugPrint(indent++, block, "block is not dominated by break block");
-                    loopHeaderMap.add(block, *loopHeader);
+                    debugPrint(indent++, block, "block is not dominated by break block", enableLog);
+                    loopHeaderList.add(loopHeader);
                 }
             }
         }
+        loopHeaderMap.add(block, loopHeaderList);
     }
 
-    printf("\n");
+    debugPrint(0, nullptr, "", enableLog);
     // Traverse all the instructions in function.
     for (auto block = funcInst->getFirstBlock(); block; block = block->getNextBlock())
     {
-        if(auto loopHeader = loopHeaderMap.tryGetValue(block))
+        if(auto loopHeaderList = loopHeaderMap.tryGetValue(block))
         {
             for (auto inst = block->getFirstChild(); inst; inst = inst->getNextInst())
             {
                 List<IRInst*> instList;
-                uint32_t indent = 0;
-                auto breakBlock = loopHeader->getBreakBlock();
                 // traverse all uses of this instruction
+                debugPrint(0, getBlock(inst), "inst is defined in block", enableLog);
                 for (auto use = inst->firstUse; use; use=use->nextUse)
                 {
-                    debugPrint(indent++, getBlock(use->getUser()), "inst's use block is");
+                    uint32_t indent = 0;
+                    debugPrint(indent++, getBlock(use->getUser()), "inst's use block is", enableLog);
                     if (auto userBlock = getBlock(use->getUser()))
                     {
                         // If the use site of this instruction is dominated by the break block, it means that the
                         // instruction is used after the break block, so we need to make that instruction available globally.
                         // By doing so, we record all the users of this instructions.
-                        if (dominatorTree->dominates(breakBlock, userBlock))
+                        for(auto loopHeader : *loopHeaderList)
                         {
-                            debugPrint(indent, inst, "inst is defined in loop but used outside of loop");
-                            debugPrint(indent++, use->getUser(), "The user is");
-                            instList.add(use->getUser());
+                            auto breakBlock = loopHeader->getBreakBlock();
+                            if (dominatorTree->dominates(breakBlock, userBlock))
+                            {
+                                debugPrint(indent, block, "inst is defined in loop but used outside of loop", enableLog);
+                                instList.add(use->getUser());
+                                break;
+                            }
                         }
                     }
                 }
@@ -125,19 +150,149 @@ void VariableScopeCorrectionContext::_processFunction(IRFunc* funcInst)
         }
     }
 
-    printf("\n");
-    // By duplicating the instructions right before their users, we can make the instructions available globally.
+    debugPrint(0, nullptr, "", enableLog);
+    _processInstructions(funcInst, workListMap);
+}
+
+void VariableScopeCorrectionContext::_processInstructions(IRFunc* funcInst, const Dictionary<IRInst*, List<IRInst*>>& workListMap)
+{
+    bool enableLog = false;
+
+    // The first instruction in the function is the parameter list, so we need to skip it.
+    auto instAfterParam = funcInst->getFirstBlock()->getFirstChild();
+    while(instAfterParam->getOp() == kIROp_Param)
+    {
+        instAfterParam = instAfterParam->getNextInst();
+    }
+
     for(auto it = workListMap.begin(); it != workListMap.end(); it++)
     {
         auto inst = it->first;
         auto list = it->second;
-        debugPrint(0, inst, "inst");
+        debugPrint(0, inst, "inst", enableLog);
+        bool isStoable = _isStorableInst(inst);
+
         for(auto user : list)
         {
-            debugPrint(1, user, "The user");
-            inst->insertAt(IRInsertLoc::before(user));
+            debugPrint(1, user, "The user", enableLog);
+            if(isStoable)
+            {
+                _processStorableInst(instAfterParam, inst, user);
+            }
+            else
+            {
+                _processUnstorableInst(instAfterParam, inst, user);
+            }
         }
     }
+}
+
+// For unstorable instructions, we need to duplicate the instruction right before the use site.
+// For the operands of the instruction, if the operand is in the same block as the instruction,
+// we need to declare a new variable at the beginning of the function
+void VariableScopeCorrectionContext::_processUnstorableInst(IRInst* insertLoc, IRInst* inst, IRInst* user)
+{
+    IRCloneEnv cloneEnv;
+    m_builder.setInsertBefore(user);
+
+    // duplicate the invisible instruction and insert it right before the use site
+    auto clonedInst = cloneInst(&cloneEnv, &m_builder, inst);
+    clonedInst->insertAt(IRInsertLoc::before(user));
+
+    // take care the operands of the duplicated instruction because they could also be invisible at use site
+    uint32_t operandCount = inst->getOperandCount();
+    for (uint32_t i = 0; i < operandCount; i++)
+    {
+        auto operand = inst->getOperand(i);
+
+        // if the operand is the same block as the instruction, we need special handling for the operand
+        // because the operand is still not available in the block where the instruction is used.
+        if (getBlock(operand) == getBlock(inst))
+        {
+            // 1. Add a store instruction after this operand, e.g.: store(dstPtr, operand)
+            // 2. Declare the dstPtr at beginning of the function, so it's globally available
+            // 3. Replace the operand with the dstPtr
+            if (auto type = operand->getDataType())
+            {
+                m_builder.setInsertBefore(insertLoc);
+                auto dstPtr = m_builder.emitVar(type);
+
+                m_builder.setInsertAfter(operand);
+                m_builder.emitStore(dstPtr, operand);
+
+                clonedInst->setOperand(i, dstPtr);
+            }
+        }
+    }
+
+    // last, because the user is still referencing the original instruction, we need to
+    // replace operands in the use site instruction with the cloned instruction
+    _replaceOperand(user, inst, clonedInst);
+}
+
+// For storable instructions, we don't want to duplicate it at use site, so we just need to store the result after the instruction
+void VariableScopeCorrectionContext::_processStorableInst(IRInst* insertLoc, IRInst* inst, IRInst* user)
+{
+    auto type = inst->getDataType();
+    // store instruction must have a result type
+    SLANG_ASSERT(type);
+
+    // declare a new variable at the beginning of the function used to store the result of the instruction
+    m_builder.setInsertBefore(insertLoc);
+    auto dstPtr = m_builder.emitVar(type);
+
+    // insert a store instruction after the instruction
+    m_builder.setInsertAfter(inst);
+    m_builder.emitStore(dstPtr, inst);
+
+    // last, replace operands in the use site instruction with the new variable
+    _replaceOperand(user, inst,  dstPtr);
+}
+
+void  VariableScopeCorrectionContext::_replaceOperand(IRInst* inst, IRInst* oldOperand, IRInst* newOperand)
+{
+    // TODO: I'd like to use "user->replaceUsesWith(clonedInst);" here, but it seems not replace the operands at all.
+    uint32_t operandCount = inst->getOperandCount();
+
+    // Traverse all the operands to find out which one is the invisible instruction, and replace it with the new one.
+    for (uint32_t i = 0; i < operandCount; i++)
+    {
+        auto operand = inst->getOperand(i);
+
+        if (operand == oldOperand)
+        {
+            // We have to special handle the store instruction. Because in C++/CUDA, pointer is a valid type,
+            // "store(dstPtr, srcVal)" could generate "dstPtr = &srcVal" if we declare srcVal at beginning of the function
+            // by using emitVar(type). So we need to insert a load instruction before the store.
+            if (inst->getOp() == kIROp_Store && operand == inst->getOperand(1))
+            {
+                m_builder.setInsertBefore(inst);
+                auto loadVar = m_builder.emitLoad(newOperand->getDataType(), newOperand);
+                inst->setOperand(i, loadVar);
+            }
+            else
+            {
+                inst->setOperand(i, newOperand);
+            }
+        }
+    }
+}
+
+bool VariableScopeCorrectionContext::_isStorableInst(IRInst* inst)
+{
+    auto type = inst->getDataType();
+
+    // If the instruction has a result, and the result is not a void type, we consider it as a storable instruction
+    if (type)
+    {
+        // Take care of pointer type, because we can't store a pointer type, so pointer type is regarded as a non-storable instruction
+        if (type->getOp() == kIROp_PtrType)
+        {
+            return false;
+        }
+        return true;
+    }
+    return false;
 }
 
 } // anonymous

--- a/source/slang/slang-ir-variable-scope-correction.h
+++ b/source/slang/slang-ir-variable-scope-correction.h
@@ -28,7 +28,7 @@ struct IRModule;
 ///    inside the loop block (block A), then check if these instructions are used after
 ///    the break block (block B). If so, we duplicate these instructions right before
 ///    their users such that we can make those instructions available globally.
-void applyVariableScopeCorrection(IRModule* module);
+void applyVariableScopeCorrection(IRModule* module, TargetRequest* targetReq);
 
 }
 

--- a/source/slang/slang-ir-variable-scope-correction.h
+++ b/source/slang/slang-ir-variable-scope-correction.h
@@ -1,0 +1,15 @@
+// slang-ir-variable-scope-correction.h
+#ifndef SLANG_IR_VARIABLE_SCOPE_CORRECTION_H
+#define SLANG_IR_VARIABLE_SCOPE_CORRECTION_H
+
+namespace Slang
+{
+
+struct IRModule;
+
+/// Correct the scope of variables in the IR module.
+void applyVariableScopeCorrection(IRModule* module);
+
+}
+
+#endif // SLANG_IR_VARIABLE_SCOPE_CORRECTION_H

--- a/source/slang/slang-ir-variable-scope-correction.h
+++ b/source/slang/slang-ir-variable-scope-correction.h
@@ -7,7 +7,27 @@ namespace Slang
 
 struct IRModule;
 
-/// Correct the scope of variables in the IR module.
+/// This pass correct the scope of variables in loop regions
+///
+/// In the IR optimization pass, we turn all the loop to do-while loop form.
+///    But in the do-while loop form, the loop body block is dominating the
+///    blocks after the loop break block. E.g.
+///
+///    do {
+///     A
+///    } while (cond);
+///    B
+///
+///    In the above example, the block A is dominating block B. This assumption
+///    is fine for SPIRV and IR code, however, it's incorrect for all the other
+///    language targets (e.g. c/c++/cuda/glsl/hlsl) because the instructions defined
+///    in the block A are not visible from block B. Therefore, when translating to
+///    other textual language, there could be issue for the variables scope.
+///
+///    To fix this issue, we first detect the instructions that are defined
+///    inside the loop block (block A), then check if these instructions are used after
+///    the break block (block B). If so, we duplicate these instructions right before
+///    their users such that we can make those instructions available globally.
 void applyVariableScopeCorrection(IRModule* module);
 
 }


### PR DESCRIPTION
In the IR optimization pass, we turn all the loop to do-while loop form. But in the do-while loop form, the loop body block is dominating the blocks after the loop break block. This assumption is fine for SPIRV and IR code, however, it's incorrect for all the other language target (e.g. c/c++/cuda/glsl/hlsl) because the instructions defined in the loop body is invisible from outside of the loop. Therefore, when translating to other textual language, there could be issue for the variables scope.

To fix this issue, we first detect the instructions that are defined inside the loop block, then check if these instructions are used after the break block. If so, we duplicate these instructions right before their users such that we can make those instructions available globally.