### PR TITLE
Add CTS status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Slang
 ![Linux Build Status](https://github.com/shader-slang/slang/actions/workflows/linux.yml/badge.svg)
 ![Windows Build Status](https://github.com/shader-slang/slang/actions/workflows/windows.yml/badge.svg)
 ![macOS Build Status](https://github.com/shader-slang/slang/actions/workflows/macos.yml/badge.svg)
+![CTS Status](https://github.com/shader-slang/slang/actions/workflows/vk-gl-cts-nightly.yml/badge.svg)
 
 Slang is a shading language that makes it easier to build and maintain large shader codebases in a modular and extensible fashion, while also maintaining the highest possible performance on modern GPUs and graphics APIs.
 Slang is based on years of collaboration between researchers at NVIDIA, Carnegie Mellon University, Stanford, MIT, UCSD and the University of Washington.


### PR DESCRIPTION
Add CTS status badge to README.

Our CTS is schedule as nightly run, and currently there is no passive notification for developers about the status, for now we just add the status to our README badge as a notification.