### PR TITLE
Allow COM based API to discover and check entrypoints without [shader] attribute.

### DIFF
--- a/build/visual-studio/slang-unit-test-tool/slang-unit-test-tool.vcxproj
+++ b/build/visual-studio/slang-unit-test-tool/slang-unit-test-tool.vcxproj
@@ -294,6 +294,7 @@
     <ClCompile Include="..\..\..\tools\slang-unit-test\unit-test-crypto.cpp" />
     <ClCompile Include="..\..\..\tools\slang-unit-test\unit-test-default-matrix-layout.cpp" />
     <ClCompile Include="..\..\..\tools\slang-unit-test\unit-test-file-system.cpp" />
+    <ClCompile Include="..\..\..\tools\slang-unit-test\unit-test-find-check-entrypoint.cpp" />
     <ClCompile Include="..\..\..\tools\slang-unit-test\unit-test-find-type-by-name.cpp" />
     <ClCompile Include="..\..\..\tools\slang-unit-test\unit-test-free-list.cpp" />
     <ClCompile Include="..\..\..\tools\slang-unit-test\unit-test-io.cpp" />

--- a/build/visual-studio/slang-unit-test-tool/slang-unit-test-tool.vcxproj.filters
+++ b/build/visual-studio/slang-unit-test-tool/slang-unit-test-tool.vcxproj.filters
@@ -38,6 +38,9 @@
     <ClCompile Include="..\..\..\tools\slang-unit-test\unit-test-file-system.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\tools\slang-unit-test\unit-test-find-check-entrypoint.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\tools\slang-unit-test\unit-test-find-type-by-name.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/slang.h
+++ b/slang.h
@@ -4949,6 +4949,13 @@ namespace slang
         /// Get the unique identity of the module.
         virtual SLANG_NO_THROW const char* SLANG_MCALL getUniqueIdentity() = 0;
 
+        /// Find and validate an entry point by name, even if the function is
+        /// not marked with the `[shader("...")]` attribute.
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL findAndCheckEntryPoint(
+            char const* name,
+            SlangStage stage,
+            IEntryPoint** outEntryPoint,
+            ISlangBlob** outDiagnostics) = 0;
     };
     
     #define SLANG_UUID_IModule IModule::getTypeGuid()

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -2773,4 +2773,7 @@ namespace Slang
         SemanticsDeclVisitorBase* visitor,
         Decl* decl,
         DeclCheckState              state);
+
+    RefPtr<EntryPoint> findAndValidateEntryPoint(
+        FrontEndEntryPointRequest* entryPointReq);
 }

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -2481,4 +2481,3 @@ namespace Slang
     }
 
 }
-

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -2481,3 +2481,4 @@ namespace Slang
     }
 
 }
+

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1338,6 +1338,20 @@ namespace Slang
             return SLANG_OK;
         }
 
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL findAndCheckEntryPoint(
+            char const* name,
+            SlangStage stage,
+            slang::IEntryPoint** outEntryPoint,
+            ISlangBlob** outDiagnostics)
+        {
+            ComPtr<slang::IEntryPoint> entryPoint(findAndCheckEntryPoint(UnownedStringSlice(name), stage, outDiagnostics));
+            if ((!entryPoint))
+                return SLANG_FAIL;
+
+            *outEntryPoint = entryPoint.detach();
+            return SLANG_OK;
+        }
+
         virtual SlangInt32 SLANG_MCALL getDefinedEntryPointCount() override
         {
             return (SlangInt32)m_entryPoints.getCount();
@@ -1481,6 +1495,7 @@ namespace Slang
         };
 
         RefPtr<EntryPoint> findEntryPointByName(UnownedStringSlice const& name);
+        RefPtr<EntryPoint> findAndCheckEntryPoint(UnownedStringSlice const& name, SlangStage stage, ISlangBlob** outDiagnostics);
 
         List<RefPtr<EntryPoint>>& getEntryPoints() { return m_entryPoints; }
         void _addEntryPoint(EntryPoint* entryPoint);

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -4004,9 +4004,14 @@ RefPtr<EntryPoint> Module::findAndCheckEntryPoint(
 {
     // If there is already an entrypoint marked with the [shader] attribute,
     // we should just return that.
+    //
     if (auto existingEntryPoint = findEntryPointByName(name))
         return existingEntryPoint;
 
+    // If the function hasn't been marked as [shader], then it won't be discovered
+    // by findEntryPointByName. We need to route this to the `findAndValidateEntryPoint`
+    // function. To do that we need to setup a FrontEndCompileRequest and a FrontEndEntryPointRequest.
+    //
     DiagnosticSink sink(getLinkage()->getSourceManager(), DiagnosticSink::SourceLocationLexer());
     FrontEndCompileRequest frontEndRequest(getLinkage(), StdWriters::getSingleton(), &sink);
     RefPtr<TranslationUnitRequest> tuRequest = new TranslationUnitRequest(&frontEndRequest);

--- a/tools/slang-unit-test/unit-test-find-check-entrypoint.cpp
+++ b/tools/slang-unit-test/unit-test-find-check-entrypoint.cpp
@@ -1,0 +1,65 @@
+// unit-test-translation-unit-import.cpp
+
+#include "../../slang.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "tools/unit-test/slang-unit-test.h"
+#include "../../slang-com-ptr.h"
+#include "../../source/core/slang-io.h"
+#include "../../source/core/slang-process.h"
+
+using namespace Slang;
+
+// Test that the IModule::findAndCheckEntryPoint API supports discovering 
+// entrypoints without a [shader] attribute.
+
+SLANG_UNIT_TEST(findAndCheckEntryPoint)
+{
+    // Source for a module that contains an undecorated entrypoint.
+    const char* userSourceBody = R"(
+        float4 fragMain(float4 pos:SV_Position) : SV_Position
+        {
+            return pos;
+        }
+        )";
+
+    auto moduleName = "moduleG" + String(Process::getId());
+    String userSource = "import " + moduleName + ";\n" + userSourceBody;
+    ComPtr<slang::IGlobalSession> globalSession;
+    SLANG_CHECK(slang_createGlobalSession(SLANG_API_VERSION, globalSession.writeRef()) == SLANG_OK);
+    slang::TargetDesc targetDesc = {};
+    targetDesc.format = SLANG_HLSL;
+    targetDesc.profile = globalSession->findProfile("sm_5_0");
+    slang::SessionDesc sessionDesc = {};
+    sessionDesc.targetCount = 1;
+    sessionDesc.targets = &targetDesc;
+    ComPtr<slang::ISession> session;
+    SLANG_CHECK(globalSession->createSession(sessionDesc, session.writeRef()) == SLANG_OK);
+
+    ComPtr<slang::IBlob> diagnosticBlob;
+    auto module = session->loadModuleFromSourceString("m", "m.slang", userSourceBody, diagnosticBlob.writeRef());
+    SLANG_CHECK(module != nullptr);
+
+    ComPtr<slang::IEntryPoint> entryPoint;
+    module->findAndCheckEntryPoint("fragMain", SLANG_STAGE_FRAGMENT, entryPoint.writeRef(), diagnosticBlob.writeRef());
+    SLANG_CHECK(entryPoint != nullptr);
+
+    ComPtr<slang::IComponentType> compositeProgram;
+    slang::IComponentType* components[] = { module, entryPoint.get() };
+    session->createCompositeComponentType(components, 2, compositeProgram.writeRef(), diagnosticBlob.writeRef());
+    SLANG_CHECK(compositeProgram != nullptr);
+
+    ComPtr<slang::IComponentType> linkedProgram;
+    compositeProgram->link(linkedProgram.writeRef(), diagnosticBlob.writeRef());
+    SLANG_CHECK(linkedProgram != nullptr);
+
+    ComPtr<slang::IBlob> code;
+    linkedProgram->getEntryPointCode(0, 0, code.writeRef(), diagnosticBlob.writeRef());
+    SLANG_CHECK(code != nullptr);
+
+    auto codeSrc = UnownedStringSlice((const char*)code->getBufferPointer());
+    SLANG_CHECK(codeSrc.indexOf(toSlice("fragMain")) != -1);
+}
+


### PR DESCRIPTION
Our COM based API has provided a `IModule::findEntryPointByName` method that can return
an `IEntryPoint` from an `IModule`.

However, this function only works when the entrypoint is decorated with the `[shader]` attribute.
If not, the function returns nullptr.

This changes adds `IModule::findAndCheckEntryPoint` so that if the function is not decorated
with [shader], we will call `findAndValidateEntryPoint` to find and validate the entrypoint function
on demand.

The work here is just to set up the FrontEndCompileRequest and FrontEndEntryPointRequests
so that the checking logic and be invoked.

Closes #3882.