### PR TITLE
Disable sccache timestamps

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -21,8 +21,9 @@ runs:
     - name: Set up sccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
-        key: ${{github.job}}-${{inputs.os}}-${{inputs.compiler}}-${{inputs.platform}}-${{inputs.config}}
+        key: ${{inputs.os}}-${{inputs.compiler}}-${{inputs.platform}}-${{inputs.config}}
         variant: sccache
+        append-timestamp: false
     - shell: bash
       run: |
         # Set up system dependencies


### PR DESCRIPTION
The timestamped caches were filling up the 10GB max cache size, removing the timestamps allows older ones to be overwritten instead