### PR TITLE
Fix the issue that 'spGetDependencyFilePath' report 'unknown' (#3927)

### DIFF
--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -6102,7 +6102,7 @@ char const* EndToEndCompileRequest::getDependencyFilePath(int index)
     auto frontEndReq = getFrontEndReq();
     auto program = frontEndReq->getGlobalAndEntryPointsComponentType();
     SourceFile* sourceFile = program->getFileDependencies()[index];
-    return sourceFile->getPathInfo().hasFileFoundPath() ? sourceFile->getPathInfo().foundPath.getBuffer() : "unknown";
+    return sourceFile->getPathInfo().hasFoundPath() ? sourceFile->getPathInfo().foundPath.getBuffer() : "unknown";
 }
 
 int EndToEndCompileRequest::getTranslationUnitCount()


### PR DESCRIPTION
Fix the issue that 'spGetDependencyFilePath' will report "unknown" for the source code is from string. We only reported valid file path when the source code is file a file, so we change that to report a valid file name even when the source code is from the string.