### PR TITLE
Fix IR lowering bug of do-while loops.

### DIFF
--- a/source/slang/slang-ir-validate.cpp
+++ b/source/slang/slang-ir-validate.cpp
@@ -66,6 +66,7 @@ namespace Slang
         State state = kState_Initial;
 
         IRInst* prevChild = nullptr;
+        bool hasSeenTerminatorInst = false;
         for(auto child : parent->getDecorationsAndChildren() )
         {
             // We need to check the integrity of the parent/next/prev links of
@@ -105,7 +106,11 @@ namespace Slang
                 validate(context, !as<IRTerminatorInst>(child), child, "terminator must be last instruction in a block");
             }
 
-
+            if (as<IRTerminatorInst>(child))
+            {
+                validate(context, !hasSeenTerminatorInst, child, "block must not contain more than one terminator");
+                hasSeenTerminatorInst = true;
+            }
             prevChild = child;
         }
     }

--- a/tests/bugs/gh-3930.slang
+++ b/tests/bugs/gh-3930.slang
@@ -1,0 +1,26 @@
+// A regression: the do-while loop ir lowering logic is making incorrect assumptions and is
+// broken after short circuiting expr change, leading to invalid IR being generated from lowering
+// (a block has two terminator insts).
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-directly
+
+// CHECK: OpEntryPoint
+
+struct Constants {
+  uint *buffer;
+}
+[[vk::push_constant]] Constants push_constants;
+
+[shader("compute")] [numthreads(1, 1, 1)] void compute(void) {
+  uint index = push_constants.buffer[0];
+
+  [[unroll]] for (uint i = 0; i < 2; i++) {
+    GroupMemoryBarrierWithWaveSync();
+
+    if (index > 0 && i < push_constants.buffer[index - 1]) {
+      do {
+        index--;
+      } while (index > 0 && i < push_constants.buffer[index - 1]);
+    }
+  }
+}


### PR DESCRIPTION
The lowering logic for do-while loops is making an incorrect assumption that the current insert location is still the same block after lowering an expression. However this is not true with the recent short circuiting operator work. Lowering exprs can lead to new block being created, and the insert loc can be changed to a different loc.

This change fixes the logic to not make this assumption, and adds an IR validation logic to guard against this type of IR error.

This fixes a reported crash.

Closes #3930.