### PR TITLE
Fix for preludes being always embedded for cpp and cuda targets

### DIFF
--- a/source/core/slang-test-tool-util.cpp
+++ b/source/core/slang-test-tool-util.cpp
@@ -71,7 +71,12 @@ namespace Slang
 static SlangResult _addCPPPrelude(const String& rootPath, slang::IGlobalSession* session)
 {
     String includePath;
-    SLANG_RETURN_ON_FAIL(TestToolUtil::getIncludePath(rootPath, "prelude/slang-cpp-prelude.h", includePath));
+    SlangResult res = SLANG_FAIL;
+    if (SLANG_FAILED(res))
+        res = TestToolUtil::getIncludePath(Path::combine(rootPath, "include"), "slang-cpp-prelude.h", includePath);
+    if (SLANG_FAILED(res))
+        res = TestToolUtil::getIncludePath(rootPath, "prelude/slang-cpp-prelude.h", includePath);
+    SLANG_RETURN_ON_FAIL(res);
     StringBuilder prelude;
     prelude << "#include \"" << includePath << "\"\n\n";
     session->setLanguagePrelude(SLANG_SOURCE_LANGUAGE_CPP, prelude.getBuffer());
@@ -81,7 +86,12 @@ static SlangResult _addCPPPrelude(const String& rootPath, slang::IGlobalSession*
 static SlangResult _addCUDAPrelude(const String& rootPath, slang::IGlobalSession* session)
 {
     String includePath;
-    SLANG_RETURN_ON_FAIL(TestToolUtil::getIncludePath(rootPath, "prelude/slang-cuda-prelude.h", includePath));
+    SlangResult res = SLANG_FAIL;
+    if (SLANG_FAILED(res))
+        res = TestToolUtil::getIncludePath(Path::combine(rootPath, "include"), "slang-cuda-prelude.h", includePath);
+    if (SLANG_FAILED(res))
+        res = TestToolUtil::getIncludePath(rootPath, "prelude/slang-cuda-prelude.h", includePath);
+    SLANG_RETURN_ON_FAIL(res);
     StringBuilder prelude;
     prelude << "#include \"" << includePath << "\"\n\n";
     session->setLanguagePrelude(SLANG_SOURCE_LANGUAGE_CUDA, prelude.getBuffer());
@@ -109,6 +119,8 @@ static SlangResult _addCUDAPrelude(const String& rootPath, slang::IGlobalSession
     SLANG_RETURN_ON_FAIL(Path::getCanonical(parentPath, rootRelPath));
     do
     {
+        if(File::exists(Path::combine(rootRelPath, "include/slang-cpp-prelude.h")))
+            break;
         if(File::exists(Path::combine(rootRelPath, "prelude/slang-cpp-prelude.h")))
             break;
 


### PR DESCRIPTION
If Slang is installed using CMake install command, preludes are no longer in `... /prelude` (arbitrary depth), but in `../include` relative to the `slangc` executable.

This fix add search for preludes in `../include` relative to the `slangc` executable.