### PR TITLE
ForceInline SampleLevel to allow decorations to be applied

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -618,6 +618,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     }
 
     [__readNone]
+    [ForceInline]
     T SampleLevel(vector<float, Shape.dimensions+isArray> location, float level)
     {
         __target_switch
@@ -668,6 +669,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     }
 
     [__readNone]
+    [ForceInline]
     T SampleLevel(vector<float, Shape.dimensions+isArray> location, float level, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -1045,6 +1047,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
     }
 
     [__readNone]
+    [ForceInline]
     T SampleLevel(SamplerState s, vector<float, Shape.dimensions+isArray> location, float level)
     {
         __target_switch
@@ -1096,6 +1099,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
     }
 
     [__readNone]
+    [ForceInline]
     T SampleLevel(SamplerState s, vector<float, Shape.dimensions+isArray> location, float level, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -1920,6 +1920,22 @@ InstPair ForwardDiffTranscriber::transcribeInstImpl(IRBuilder* builder, IRInst* 
     case kIROp_GetSequentialID:
     case kIROp_GetStringHash:
     case kIROp_SPIRVAsm:
+    case kIROp_SPIRVAsmOperandLiteral:
+    case kIROp_SPIRVAsmOperandInst:
+    case kIROp_SPIRVAsmOperandRayPayloadFromLocation:
+    case kIROp_SPIRVAsmOperandRayAttributeFromLocation:
+    case kIROp_SPIRVAsmOperandRayCallableFromLocation:
+    case kIROp_SPIRVAsmOperandEnum:
+    case kIROp_SPIRVAsmOperandBuiltinVar:
+    case kIROp_SPIRVAsmOperandGLSL450Set:
+    case kIROp_SPIRVAsmOperandDebugPrintfSet:
+    case kIROp_SPIRVAsmOperandId:
+    case kIROp_SPIRVAsmOperandResult:
+    case kIROp_SPIRVAsmOperandTruncate:
+    case kIROp_SPIRVAsmOperandEntryPoint:
+    case kIROp_SPIRVAsmOperandSampledType:
+    case kIROp_SPIRVAsmOperandImageType:
+    case kIROp_SPIRVAsmOperandSampledImageType:
     case kIROp_DebugLine:
     case kIROp_DebugVar:
     case kIROp_DebugValue:


### PR DESCRIPTION
Fixes #3969 

NonUniformResourceInfo instruction is applied as a Decoration on the backing resource. With the following shader, this is applied to the Function Call.
```
 vRadiance.rgb *= g_bindless_Texture2D [NonUniformResourceIndex (light.m_nCookie_nLuminaireType_nPathTraceFlags.x)].SampleLevel(g_Sampler, vUv, 0.0).rgb;
```
as shown below:
```
	{145371}	let  %1826	: Int	= nonUniformResourceIndex(%1789)
	{177146}	let  %1828	: Vec(Float, 4 : Int)	= call %SampleLevel(%1826, %gx5FCookieSampler, %1827, 0 : Float)
```

This patch ForceInlines SampleLevel intrinsic function call so that the Decoration is correctly applied on the resource.
