### PR TITLE
Add slangc flag to `-ignore-capabilities`

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -842,6 +842,7 @@ extern "C"
             Language,
             MatrixLayoutColumn, // bool
             MatrixLayoutRow,    // bool
+            IgnoreCapabilities, // bool
             ModuleName,         // stringValue0: module name.
             Output,
             Profile,            // intValue0: profile

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -11,6 +11,14 @@
 
 namespace Slang
 {
+    template<typename P, typename... Args>
+    bool diagnoseCapabilityErrors(DiagnosticSink* sink, CompilerOptionSet& optionSet, P const& pos, DiagnosticInfo const& info, Args const&... args)
+    {
+        if (optionSet.getBoolOption(CompilerOptionName::IgnoreCapabilities))
+            return false;
+        return sink->diagnose(pos, info, args...);
+    }
+
         /// Should the given `decl` be treated as a static rather than instance declaration?
     bool isEffectivelyStatic(
         Decl*           decl);
@@ -793,6 +801,7 @@ namespace Slang
         {}
 
         SharedSemanticsContext* getShared() { return m_shared; }
+        CompilerOptionSet& getOptionSet() { return getShared()->getOptionSet(); }
         ASTBuilder* getASTBuilder() { return m_astBuilder; }
 
         DiagnosticSink* getSink() { return m_sink; }
@@ -2768,7 +2777,7 @@ namespace Slang
 
     DeclVisibility getDeclVisibility(Decl* decl);
 
-    void diagnoseCapabilityProvenance(DiagnosticSink* sink, Decl* decl, CapabilityAtom missingAtom);
+    void diagnoseCapabilityProvenance(CompilerOptionSet& optionSet, DiagnosticSink* sink, Decl* decl, CapabilityAtom missingAtom);
 
     void _ensureAllDeclsRec(
         SemanticsDeclVisitorBase* visitor,

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -519,7 +519,7 @@ namespace Slang
             targetCaps.join(stageCapabilitySet);
             if (targetCaps.isIncompatibleWith(entryPointFuncDecl->inferredCapabilityRequirements))
             {
-                sink->diagnose(entryPointFuncDecl, Diagnostics::entryPointUsesUnavailableCapability, entryPointFuncDecl, entryPointFuncDecl->inferredCapabilityRequirements, targetCaps);
+                diagnoseCapabilityErrors(sink, linkage->m_optionSet, entryPointFuncDecl, Diagnostics::entryPointUsesUnavailableCapability, entryPointFuncDecl, entryPointFuncDecl->inferredCapabilityRequirements, targetCaps);
                 auto& interredCapConjunctions = entryPointFuncDecl->inferredCapabilityRequirements.getExpandedAtoms();
 
                 // Find out what exactly is incompatible and print out a trace of provenance to
@@ -533,7 +533,7 @@ namespace Slang
                         {
                             if (CapabilityConjunctionSet(inferredAtom).isIncompatibleWith(atom))
                             {
-                                diagnoseCapabilityProvenance(sink, entryPointFuncDecl, inferredAtom);
+                                diagnoseCapabilityProvenance(linkage->m_optionSet, sink, entryPointFuncDecl, inferredAtom);
                                 goto breakLabel;
                             }
                         }

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -289,6 +289,7 @@ void initCommandOptions(CommandOptions& options)
         { OptionKind::Language,     "-lang", "-lang <language>", "Set the language for the following input files."},
         { OptionKind::MatrixLayoutColumn, "-matrix-layout-column-major", nullptr, "Set the default matrix layout to column-major."},
         { OptionKind::MatrixLayoutRow,"-matrix-layout-row-major", nullptr, "Set the default matrix layout to row-major."},
+        { OptionKind::IgnoreCapabilities,"-ignore-capabilities", nullptr, "Do not warn or error if capabilities are violated"},
         { OptionKind::ModuleName,     "-module-name", "-module-name <name>", 
         "Set the module name to use when compiling multiple .slang source files into a single module."},
         { OptionKind::Output, "-o", "-o <path>", 
@@ -1682,6 +1683,7 @@ SlangResult OptionsParser::_parse(
             case OptionKind::VulkanUseEntryPointName:
             case OptionKind::VulkanUseGLLayout:
             case OptionKind::VulkanEmitReflection:
+            case OptionKind::IgnoreCapabilities:
             case OptionKind::DefaultImageFormatUnknown:
             case OptionKind::Obfuscate:
             case OptionKind::OutputIncludes:

--- a/tests/language-feature/capability/capability1.slang
+++ b/tests/language-feature/capability/capability1.slang
@@ -1,4 +1,6 @@
 //TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-directly -entry main2 -stage compute
+//TEST:SIMPLE(filecheck=CHECK_IGNORE_CAPS): -target spirv -emit-spirv-directly -entry main2 -stage compute -ignore-capabilities
+// CHECK_IGNORE_CAPS-NOT: error 36104
 
 [require(spvShaderClockKHR)]
 void leafFunc1() {}

--- a/tests/language-feature/capability/capability2.slang
+++ b/tests/language-feature/capability/capability2.slang
@@ -1,4 +1,6 @@
 //TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-directly -entry main -stage compute
+//TEST:SIMPLE(filecheck=CHECK_IGNORE_CAPS): -target spirv -emit-spirv-directly -entry main -stage compute -ignore-capabilities
+// CHECK_IGNORE_CAPS-NOT: error 36104
 module test;
 
 [require(spvAtomicFloat16AddEXT)]

--- a/tests/language-feature/capability/capability3.slang
+++ b/tests/language-feature/capability/capability3.slang
@@ -1,4 +1,6 @@
 //TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-directly -entry main -stage compute
+//TEST:SIMPLE(filecheck=CHECK_IGNORE_CAPS): -target spirv -emit-spirv-directly -entry main -stage compute -ignore-capabilities
+// CHECK_IGNORE_CAPS-NOT: error 36108
 
 // Test that capabilities can be declared on module.
 

--- a/tests/language-feature/capability/capability4.slang
+++ b/tests/language-feature/capability/capability4.slang
@@ -1,4 +1,6 @@
 //TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-directly -entry main -stage compute
+//TEST:SIMPLE(filecheck=CHECK_IGNORE_CAPS): -target spirv -emit-spirv-directly -entry main -stage compute -ignore-capabilities
+// CHECK_IGNORE_CAPS-NOT: error 36108
 
 // Check that a non-static member method implictly requires capabilities
 // defined in ThisType.


### PR DESCRIPTION
`-ignore-capabilities` flag allows ignoring capability incompatibilities/discontinuity errors/warnings. We still process capabilities (needed for stdlib).

Added to capability tests to ensure everything is working as intended. More will be added in the full stdlib capabilities implementation.

(fixes #3985)

Fixes #3978.