### PR TITLE
Flag to prevent packing of cbuffer elements in HLSL backend.

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -932,6 +932,7 @@ extern "C"
             Heterogeneous,
             NoMangle,
             NoHLSLBinding,
+            NoHLSLPackConstantBufferElements,
             ValidateUniformity,
             AllowGLSL,
 

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -251,6 +251,7 @@ public:
     void emitType(IRType* type, NameLoc const& nameAndLoc);
     bool hasExplicitConstantBufferOffset(IRInst* cbufferType);
     bool isSingleElementConstantBuffer(IRInst* cbufferType);
+    bool shouldForceUnpackConstantBufferElements(IRInst* cbufferType);
 
     //
     // Expressions

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -221,9 +221,10 @@ void HLSLSourceEmitter::_emitHLSLParameterGroup(IRGlobalParam* varDecl, IRUnifor
     _emitHLSLRegisterSemantic(LayoutResourceKind::ConstantBuffer, &containerChain, varDecl);
 
     auto elementType = type->getElementType();
-    if (hasExplicitConstantBufferOffset(type))
+    if (shouldForceUnpackConstantBufferElements(type) || hasExplicitConstantBufferOffset(type))
     {
         // If the user has provided any explicit `packoffset` modifiers,
+        // or the user has explicitly requested for cbuffer fields to be packed,
         // we have to unwrap the struct and emit the fields directly.
         emitStructDeclarationsBlock(as<IRStructType>(elementType), true);
         m_writer->emit("\n");

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -224,7 +224,7 @@ void HLSLSourceEmitter::_emitHLSLParameterGroup(IRGlobalParam* varDecl, IRUnifor
     if (shouldForceUnpackConstantBufferElements(type) || hasExplicitConstantBufferOffset(type))
     {
         // If the user has provided any explicit `packoffset` modifiers,
-        // or the user has explicitly requested for cbuffer fields to be packed,
+        // or the user has explicitly requested for cbuffer fields to be unpacked,
         // we have to unwrap the struct and emit the fields directly.
         emitStructDeclarationsBlock(as<IRStructType>(elementType), true);
         m_writer->emit("\n");

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -520,6 +520,8 @@ void initCommandOptions(CommandOptions& options)
         { OptionKind::NoMangle, "-no-mangle", nullptr, "Do as little mangling of names as possible." },
         { OptionKind::NoHLSLBinding, "-no-hlsl-binding", nullptr, "Do not include explicit parameter binding semantics in the output HLSL code,"
                                                                   "except for parameters that has explicit bindings in the input source." },
+        { OptionKind::NoHLSLPackConstantBufferElements, "-no-hlsl-pack-constant-buffer-elements", nullptr,
+        "Do not pack elements of constant buffers into structs in the output HLSL code." },
         { OptionKind::ValidateUniformity, "-validate-uniformity", nullptr, "Perform uniformity validation analysis." },
         { OptionKind::AllowGLSL, "-allow-glsl", nullptr, "Enable GLSL as an input language." },
     };
@@ -1691,6 +1693,7 @@ SlangResult OptionsParser::_parse(
             case OptionKind::DumpAst:
             case OptionKind::IncompleteLibrary:
             case OptionKind::NoHLSLBinding:
+            case OptionKind::NoHLSLPackConstantBufferElements:
                 linkage->m_optionSet.set(optionKind, true); break;
                 break;
             case OptionKind::MatrixLayoutRow:

--- a/tests/language-feature/no-hlsl-pack-constant-buffer-elements.slang
+++ b/tests/language-feature/no-hlsl-pack-constant-buffer-elements.slang
@@ -1,0 +1,17 @@
+//TEST:SIMPLE(filecheck=CHECK):-target hlsl -entry main -profile cs_6_0 -no-hlsl-pack-constant-buffer-elements
+
+// Test that -no-hlsl-pack-constant-buffer-elements prevents packing of elements in the output HLSL code.
+
+// CHECK-DAG: cbuffer {{.*}} :
+cbuffer MyCB
+{
+    float member0;
+    float member1;
+}
+
+// CHECK-DAG: return member0{{.*}} + member1{{.*}};
+[numthreads(1,1,1)]
+float main()
+{
+    return member0 + member1;
+}

--- a/tests/language-feature/no-hlsl-pack-constant-buffer-elements.slang
+++ b/tests/language-feature/no-hlsl-pack-constant-buffer-elements.slang
@@ -1,4 +1,7 @@
 //TEST:SIMPLE(filecheck=CHECK):-target hlsl -entry main -profile cs_6_0 -no-hlsl-pack-constant-buffer-elements
+//TEST:SIMPLE(filecheck=DXIL): -target dxil -entry main -profile cs_6_0 -no-hlsl-pack-constant-buffer-elements
+
+// DXIL: define void @main()
 
 // Test that -no-hlsl-pack-constant-buffer-elements prevents packing of elements in the output HLSL code.
 
@@ -9,9 +12,11 @@ cbuffer MyCB
     float member1;
 }
 
-// CHECK-DAG: return member0{{.*}} + member1{{.*}};
+RWStructuredBuffer<float> MyBuffer;
+
+// CHECK-DAG: {{.*}} = member0{{.*}} + member1{{.*}};
 [numthreads(1,1,1)]
-float main()
+void main()
 {
-    return member0 + member1;
+    MyBuffer[0] = member0 + member1;
 }


### PR DESCRIPTION
Added a flag that prevents packing of elements in cbuffers into ParameterGroup structs, and instead emits them directly into the resulting cbuffer. Addresses #3992.

Also added a small test verifying the flag. All tests pass locally.