### PR TITLE
Update the dependency file

### DIFF
--- a/deps/target-deps.json
+++ b/deps/target-deps.json
@@ -4,19 +4,20 @@
         "dependencies" : [
             {
                 "name" : "slang-llvm",
-                "baseUrl" : "https://github.com/shader-slang/slang-llvm/releases/download/v13.x-42/",
+                "baseUrl" : "https://github.com/shader-slang/slang-llvm/releases/download/v13.x-43/",
                 "optional" : true,
                 "packages" : 
                 {
-                    "windows-x86_64" : { "type" : "url", "path" : "slang-llvm-13.x-42-win64.zip" },
-                    "windows-x86" : { "type": "url", "path" : "slang-llvm-13.x-42-win32.zip" },
-                    "linux-x86_64" : { "type": "url", "path" : "slang-llvm-v13.x-42-linux-x86_64-release.zip" },
-                    "macosx-x86_64" : { "type": "url", "path" : "slang-llvm-v13.x-42-macosx-x86_64-release.zip" }
+                    "windows-x86_64" : { "type" : "url", "path" : "slang-llvm-13.x-43-win64.zip" },
+                    "windows-x86" : { "type": "url", "path" : "slang-llvm-13.x-43-win32.zip" },
+                    "linux-x86_64" : { "type": "url", "path" : "slang-llvm-v13.x-43-linux-x86_64-release.zip" },
+                    "linux-x86_64-glibc-2.27" : { "type": "url", "path" : "slang-llvm-v13.x-43-linux-x86_64-release-glibc-2.27.zip" },
+                    "macosx-x86_64" : { "type": "url", "path" : "slang-llvm-v13.x-43-macosx-x86_64-release.zip" }
                 } 
             },
             {
                 "name" : "slang-glslang",
-                "baseUrl" : "https://github.com/shader-slang/slang-glslang/releases/download/v13.0.0.x-i/slang-glslang-13.0.0.x-i-",
+                "baseUrl" : "https://github.com/shader-slang/slang-glslang/releases/download/v13.0.0.x-j/slang-glslang-13.0.0.x-j-",
                 "optional" : true,
                 "packages" : 
                 {

--- a/github_build.sh
+++ b/github_build.sh
@@ -21,7 +21,7 @@ if [[ "aarch64" == "${TARGETARCH}"  && "release" == "${CONFIGURATION}" ]]; then
 fi
 
 if [[ ! -z ${GLIBC_COMPATIBLE} ]]; then
-    glibcCompatible="--glibcForwardCompatible=true"
+    glibcCompatible="--glibc-forward-compatible=true"
 fi
 
 if [[ "${ARCH}" != "${TARGETARCH}" ]]; then


### PR DESCRIPTION
Update the dependency file to use the latest release version for slang-llvm and slang-glslang where we added a new Linux release to support the older version of Glibc-2.27.

Fix a type in github.sh for the glibc compatible option input for premake5.lua.