### PR TITLE
Fix variable shadowing use with constructor's

### DIFF
--- a/tests/language-feature/struct-field-initializers/struct-field-initializer-shadowed-member.slang
+++ b/tests/language-feature/struct-field-initializers/struct-field-initializer-shadowed-member.slang
@@ -1,0 +1,23 @@
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain 
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -emit-spirv-directly
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-cpu -compute -entry computeMain
+//TEST(smoke,compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-dx12 -use-dxil -compute -entry computeMain
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+struct TextureHandle
+{
+    uint32_t packedData = 0;
+    __init(uint32_t packedData) { this.packedData = packedData; }
+};
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    TextureHandle texHandle = TextureHandle(1);
+    // BUF: 1
+    outputBuffer[0] = true
+        && texHandle.packedData == 1
+        ;
+}


### PR DESCRIPTION
Use memberExpr instead of varExpr, this is to allow proper resolution of a this->member with the same name as a local var to enable proper init creation when shadowing a variable name.

fixes #4007