### PR TITLE
Do not diagnose error when a symbols is defined as 'extern' and 'export'

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -6944,6 +6944,13 @@ namespace Slang
         if (!doFunctionSignaturesMatch(newDeclRef, oldDeclRef))
             return SLANG_OK;
 
+        // If the declatation is declared by 'extern', and new definition is with 'export', then
+        // we should let overload resolution to handle it.
+        if (oldDecl->hasModifier<ExternModifier>() && newDecl->hasModifier<HLSLExportModifier>())
+        {
+            return SLANG_OK;
+        }
+
         // If we get this far, then we've got two declarations in the same
         // scope, with the same name and signature, so they appear
         // to be redeclarations.

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1141,6 +1141,15 @@ namespace Slang
         return 0;
     }
 
+    int getExportRank(DeclRef<Decl> left, DeclRef<Decl> right)
+    {
+        if (left.getDecl() && left.getDecl()->hasModifier<ExternModifier>())
+        {
+            return (right.getDecl() && right.getDecl()->hasModifier<HLSLExportModifier>()) ? -1 : 0;
+        }
+        return 0;
+    }
+
     int SemanticsVisitor::CompareOverloadCandidates(
         OverloadCandidate*	left,
         OverloadCandidate*	right)
@@ -1213,6 +1222,11 @@ namespace Slang
             auto specificityDiff = compareOverloadCandidateSpecificity(left->item, right->item);
             if(specificityDiff)
                 return specificityDiff;
+
+            // `export` function is more flavored than `extern` function. But other modifiers are not considered.
+            auto externExportDiff = getExportRank(left->item.declRef, right->item.declRef);
+            if (externExportDiff)
+                return externExportDiff;
 
             // If we reach here, we will attempt to use overload rank to break the ties.
             auto overloadRankDiff = getOverloadRank(right->item.declRef) - getOverloadRank(left->item.declRef);


### PR DESCRIPTION
Fix the issue (#3999).

For a function is defined as extern and export at the same time, don't report error, we can use the 'export' function to overload the 'extern' function.