### PR TITLE
Silent compiler warning about missing override keywords

### DIFF
--- a/source/compiler-core/slang-metal-compiler.cpp
+++ b/source/compiler-core/slang-metal-compiler.cpp
@@ -26,7 +26,7 @@ namespace Slang
 
         virtual SLANG_NO_THROW bool SLANG_MCALL isFileBased() override { return true; }
 
-        virtual SLANG_NO_THROW SlangResult SLANG_MCALL compile(const CompileOptions& options, IArtifact** outArtifact)
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL compile(const CompileOptions& options, IArtifact** outArtifact) override
         {
             // All compile requests should be routed directly to the inner compiler.
             return cppCompiler->compile(options, outArtifact);

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -9847,7 +9847,7 @@ namespace Slang
                 loc = Base::sourceLocStack.getLast();
             handleReferenceFunc(decl, decl->inferredCapabilityRequirements, loc);
         }
-        virtual void processDeclModifiers(Decl* decl)
+        virtual void processDeclModifiers(Decl* decl) override
         {
             if (decl)
                 handleReferenceFunc(decl, decl->inferredCapabilityRequirements, decl->loc);

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1346,7 +1346,7 @@ namespace Slang
             char const* name,
             SlangStage stage,
             slang::IEntryPoint** outEntryPoint,
-            ISlangBlob** outDiagnostics)
+            ISlangBlob** outDiagnostics) override
         {
             ComPtr<slang::IEntryPoint> entryPoint(findAndCheckEntryPoint(UnownedStringSlice(name), stage, outDiagnostics));
             if ((!entryPoint))


### PR DESCRIPTION
Adding "override" keywords for member functions whereever they need. The compiler warning was visible on CI build but not visible on local visual studio build.