### PR TITLE
Do not mangle the name of identifiers when __extern_cpp is added

### DIFF
--- a/source/slang/slang-mangle.cpp
+++ b/source/slang/slang-mangle.cpp
@@ -383,6 +383,12 @@ namespace Slang
             }
         }
 
+        if (declRef.getDecl()->hasModifier<ExternCppModifier>())
+        {
+            emit(context, declRef.getDecl()->getName()->text);
+            return;
+        }
+
         auto parentDeclRef = declRef.getParent();
         if (as<FileDecl>(parentDeclRef))
             parentDeclRef = parentDeclRef.getParent();


### PR DESCRIPTION
Do not mange the name of identifiers decorated by "__extern_cpp".

For a slang files that are included by the library module and entry point module, slang could generated two different mangled names for the same functions, because the function with a struct parameter will make the mangled function name contains the file name. Therefore, we allow using "__extern_cpp" on such struct, such that no file name is associated in the mangled name.