### PR TITLE
Add option -disable-short-circuit

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -860,6 +860,7 @@ extern "C"
             SourceEmbedStyle,
             SourceEmbedName,
             SourceEmbedLanguage,
+            DisableShortCircuit,   // bool
 
             // Target
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -798,7 +798,13 @@ namespace Slang
             : m_shared(shared)
             , m_sink(shared->getSink())
             , m_astBuilder(shared->getLinkage()->getASTBuilder())
-        {}
+        {
+            if (shared->getLinkage()->m_optionSet.hasOption(CompilerOptionName::DisableShortCircuit))
+            {
+                m_shouldShortCircuitLogicExpr =
+                    !shared->getLinkage()->m_optionSet.getBoolOption(CompilerOptionName::DisableShortCircuit);
+            }
+        }
 
         SharedSemanticsContext* getShared() { return m_shared; }
         CompilerOptionSet& getOptionSet() { return getShared()->getOptionSet(); }

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -343,6 +343,7 @@ void initCommandOptions(CommandOptions& options)
         "The name used as the basis for variables output for source embedding."},
         { OptionKind::SourceEmbedLanguage, "-source-embed-language", "-source-embed-language <language>",
         "The language to be used for source embedding. Defaults to C/C++. Currently only C/C++ are supported"},
+        { OptionKind::DisableShortCircuit, "-disable-short-circuit", nullptr, "Disable short-circuiting for \"&&\" and \"||\" operations" },
     };
 
     _addOptions(makeConstArrayView(generalOpts), options);
@@ -2296,6 +2297,11 @@ SlangResult OptionsParser::_parse(
                     return SLANG_FAIL;
                 }
 
+                break;
+            }
+            case OptionKind::DisableShortCircuit:
+            {
+                linkage->m_optionSet.add(OptionKind::DisableShortCircuit, true);
                 break;
             }
             default:

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -170,6 +170,7 @@ void Session::init()
     // Built in linkage uses the built in builder
     m_builtinLinkage = new Linkage(this, builtinAstBuilder, nullptr);
     m_builtinLinkage->m_optionSet.set(CompilerOptionName::DebugInformation, DebugInfoLevel::None);
+    m_builtinLinkage->m_optionSet.set(CompilerOptionName::DisableShortCircuit, true);
 
     // Because the `Session` retains the builtin `Linkage`,
     // we need to make sure that the parent pointer inside


### PR DESCRIPTION
Add option -disable-short-circuit to disable short circuit for logic operators && and ||. Also, disable the short circuit by default in the stdlib.