### PR TITLE
Change stdlib to not depend on short-circuit

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -572,7 +572,7 @@ ${{{{
         __intrinsic_op($(kIROp_Rsh)) This shr(int other);
         __intrinsic_op($(kIROp_BitAnd)) This bitAnd(This other);
         __intrinsic_op($(kIROp_BitOr)) This bitOr(This other);
-        [__unsafeForceInlineEarly] This and(This other) {return __intCast<This>(__intCast<bool>(this) && __intCast<bool>(other)); }
+        [__unsafeForceInlineEarly] This and(This other) {return __intCast<This>(and(__intCast<bool>(this), __intCast<bool>(other))); }
         [__unsafeForceInlineEarly] This or(This other) {return __intCast<This>(__intCast<bool>(this) || __intCast<bool>(other)); }
         __intrinsic_op($(kIROp_BitXor)) This bitXor(This other);
         __intrinsic_op($(kIROp_BitNot)) This bitNot();
@@ -2228,6 +2228,14 @@ T operator &&(T v0, T v1)
 {
     return v0.and(v1);
 }
+
+[__unsafeForceInlineEarly]
+[OverloadRank(-10)]
+bool and(bool v0, bool v1)
+{
+    return __and(v0, v1);
+}
+
 __generic<T : ILogical>
 [__unsafeForceInlineEarly]
 [OverloadRank(-10)]

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -170,7 +170,6 @@ void Session::init()
     // Built in linkage uses the built in builder
     m_builtinLinkage = new Linkage(this, builtinAstBuilder, nullptr);
     m_builtinLinkage->m_optionSet.set(CompilerOptionName::DebugInformation, DebugInfoLevel::None);
-    m_builtinLinkage->m_optionSet.set(CompilerOptionName::DisableShortCircuit, true);
 
     // Because the `Session` retains the builtin `Linkage`,
     // we need to make sure that the parent pointer inside


### PR DESCRIPTION
Do not use "&&" to implement the intrinsic kIROp_And, instead define a 'and' function in stdlib. So it will be up to us to determine whether we want to use 'short-circuit' behavior in stdlib.