### PR TITLE
Avoid classifying methods with `[numthreads]` as entry points for CUDA-related targets

### DIFF
--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -918,7 +918,7 @@ namespace Slang
             for (Index tt = 0; tt < translationUnitCount; ++tt)
             {
                 auto translationUnit = translationUnits[tt];
-                translationUnit->getModule()->_discoverEntryPoints(sink);
+                translationUnit->getModule()->_discoverEntryPoints(sink, this->getLinkage()->targets);
             }
         }
     }

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1483,7 +1483,7 @@ namespace Slang
             ///
         void _collectShaderParams();
 
-        void _discoverEntryPoints(DiagnosticSink* sink);
+        void _discoverEntryPoints(DiagnosticSink* sink, const List<RefPtr<TargetRequest>>& targets);
 
         class ModuleSpecializationInfo : public SpecializationInfo
         {

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -5335,7 +5335,7 @@ void Linkage::prepareDeserializedModule(SerialContainerData::Module& moduleEntry
     module->setPathInfo(filePathInfo);
     module->setDigest(moduleEntry.digest);
     module->_collectShaderParams();
-    module->_discoverEntryPoints(sink);
+    module->_discoverEntryPoints(sink, targets);
 
     // Hook up fileDecl's scope to module's scope.
     auto moduleDecl = module->getModuleDecl();


### PR DESCRIPTION
Fixes https://github.com/shader-slang/slang/issues/3979

We weren't able to reproduce the completely silent error with the latest top-of-tree Slang. In general, a silent error points to an internal error, and should be referred to the compiler team. Diagnostic messages from compiler errors due to incorrect input code are currently reported by `slangtorch` on stdout.

Tthis PR fixes the `[numthreads]` problem which assumed that any method with `[numthreads]` is necessarily a compute shader entry point. We no ignore that classification for CUDA-related targets ('cuda', 'ptx', and 'torch-binding').

