### PR TITLE
SPIRV: Fix performance issue when handling large arrays.

### DIFF
--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -872,18 +872,21 @@ IRInst* emitLoopBlocks(IRBuilder* builder, IRInst* initVal, IRInst* finalVal, IR
     IRBuilder loopBuilder = *builder;
     auto loopHeadBlock = loopBuilder.emitBlock();
     loopBodyBlock = loopBuilder.emitBlock();
+    auto ifBreakBlock = loopBuilder.emitBlock();
     loopBreakBlock = loopBuilder.emitBlock();
     auto loopContinueBlock = loopBuilder.emitBlock();
     builder->emitLoop(loopHeadBlock, loopBreakBlock, loopHeadBlock, 1, &initVal);
     loopBuilder.setInsertInto(loopHeadBlock);
     auto loopParam = loopBuilder.emitParam(initVal->getFullType());
     auto cmpResult = loopBuilder.emitLess(loopParam, finalVal);
-    loopBuilder.emitIfElse(cmpResult, loopBodyBlock, loopBreakBlock, loopBreakBlock);
+    loopBuilder.emitIfElse(cmpResult, loopBodyBlock, ifBreakBlock, ifBreakBlock);
     loopBuilder.setInsertInto(loopBodyBlock);
     loopBuilder.emitBranch(loopContinueBlock);
     loopBuilder.setInsertInto(loopContinueBlock);
     auto newParam = loopBuilder.emitAdd(loopParam->getFullType(), loopParam, loopBuilder.getIntValue(loopBuilder.getIntType(), 1));
     loopBuilder.emitBranch(loopHeadBlock, 1, &newParam);
+    loopBuilder.setInsertInto(ifBreakBlock);
+    loopBuilder.emitBranch(loopBreakBlock);
     return loopParam;
 }
 

--- a/tests/spirv/large-struct-pack.slang
+++ b/tests/spirv/large-struct-pack.slang
@@ -1,0 +1,29 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-directly -profile glsl_460
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cpu -compute
+
+// Check that when generating spirv directly, we use a loop
+// to copy large arrays in a local variable to a buffer, instead of emitting
+// unrolled code that reads each element of the array individually.
+
+struct WorkData
+{
+    int B[1024];
+};
+
+//TEST_INPUT:set resultBuffer = out ubuffer(data=[0 0 0 0], stride=4, count=1024)
+RWStructuredBuffer<WorkData> resultBuffer;
+
+// CHECK: OpLoopMerge
+// CHECK: OpLoopMerge
+
+// BUF: 0
+// BUF: 1
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid: SV_DispatchThreadID)
+{
+    WorkData wd;
+    for (int i = 0; i < 1024; i++)
+        wd.B[i] = i;
+    resultBuffer[0] = wd;
+}

--- a/tests/spirv/large-struct-ptr.slang
+++ b/tests/spirv/large-struct-ptr.slang
@@ -1,0 +1,20 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-directly -profile glsl_460
+
+struct WorkData {
+    float A[2048 * 2048];
+    float B[2048 * 2048];
+};
+struct PushData {
+    WorkData* Input;
+    float* Dest;
+};
+
+[vk::push_constant] ConstantBuffer<PushData> cb;
+
+// CHECK: OpEntryPoint
+
+[numthreads(64, 1, 1)]
+void ComputeMain(uint tid: SV_DispatchThreadID)
+{
+    cb.Dest[tid] = cb.Input->A[tid] * cb.Input->B[tid];
+}

--- a/tests/spirv/large-struct.slang
+++ b/tests/spirv/large-struct.slang
@@ -1,0 +1,32 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-directly -profile glsl_460
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-d3d12 -compute -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cpu -compute -output-using-type
+
+// Check that when generating spirv directly, we use a loop
+// to copy large arrays in input data out into a local variable, instead of emitting
+// unrolled code that reads each element of the array individually.
+
+struct WorkData
+{
+    float A[2*2];
+    float B[1024];
+    
+    float Foo(uint i) { return A[i] * B[i]; }
+};
+
+//TEST_INPUT:set input = new WorkData{[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]}
+ConstantBuffer<WorkData> input;
+
+//TEST_INPUT:set resultBuffer = out ubuffer(data=[0 0 0 0], stride=4)
+RWStructuredBuffer<float> resultBuffer;
+
+// CHECK: OpLoopMerge
+
+[numthreads(2, 1, 1)]
+void computeMain(uint3 tid: SV_DispatchThreadID)
+{
+    // BUF: 10.0
+    // BUF: 40.0
+    resultBuffer[tid.x] = input.Foo(tid.x);
+}

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -207,7 +207,7 @@ struct AssignValsFromLayoutContext
     {
         const InputBufferDesc& srcBuffer = srcVal->bufferDesc;
         auto& bufferData = srcVal->bufferData;
-        const size_t bufferSize = Math::Max(bufferData.getCount() * sizeof(uint32_t), (size_t)(srcBuffer.elementCount * srcBuffer.stride));
+        const size_t bufferSize = Math::Max((size_t)bufferData.getCount() * sizeof(uint32_t), (size_t)(srcBuffer.elementCount * srcBuffer.stride));
         bufferData.reserve(bufferSize / sizeof(uint32_t));
         for (size_t i = bufferData.getCount(); i < bufferSize / sizeof(uint32_t); i++)
             bufferData.add(0);

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -207,7 +207,10 @@ struct AssignValsFromLayoutContext
     {
         const InputBufferDesc& srcBuffer = srcVal->bufferDesc;
         auto& bufferData = srcVal->bufferData;
-        const size_t bufferSize = bufferData.getCount() * sizeof(uint32_t);
+        const size_t bufferSize = Math::Max(bufferData.getCount() * sizeof(uint32_t), (size_t)(srcBuffer.elementCount * srcBuffer.stride));
+        bufferData.reserve(bufferSize / sizeof(uint32_t));
+        for (size_t i = bufferData.getCount(); i < bufferSize / sizeof(uint32_t); i++)
+            bufferData.add(0);
 
         ComPtr<IBufferResource> bufferResource;
         SLANG_RETURN_ON_FAIL(ShaderRendererUtil::createBufferResource(srcBuffer, /*entry.isOutput,*/ bufferSize, bufferData.getBuffer(), device, bufferResource));
@@ -232,6 +235,7 @@ struct AssignValsFromLayoutContext
                 const InputBufferDesc& counterBufferDesc{
                     InputBufferType::StorageBuffer,
                     sizeof(uint32_t),
+                    1,
                     Format::Unknown,
                 };
                 SLANG_RETURN_ON_FAIL(ShaderRendererUtil::createBufferResource(

--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -222,6 +222,11 @@ namespace renderer_test
                 parser.Read("=");
                 val->bufferDesc.stride = parser.ReadInt();
             }
+            else if (word == "count")
+            {
+                parser.Read("=");
+                val->bufferDesc.elementCount = parser.ReadInt();
+            }
             else if (word == "counter")
             {
                 parser.Read("=");

--- a/tools/render-test/shader-input-layout.h
+++ b/tools/render-test/shader-input-layout.h
@@ -68,6 +68,7 @@ struct InputBufferDesc
 {
     InputBufferType type = InputBufferType::StorageBuffer;
     int stride = 0; // stride == 0 indicates an unstructured buffer.
+    int elementCount = 1;
     Format format = Format::Unknown;
     // For RWStructuredBuffer, AppendStructuredBuffer, ConsumeStructuredBuffer
     // the default value of 0xffffffff indicates that a counter buffer should


### PR DESCRIPTION
The problem of long compile time is due to our `lower-buffer-element-type` pass is emitting expanded/unrolled instructions to pack/unpack each element in an array.

We fix this problem by emitting a loop to copy the array when the array is bigger than a threshold, instead of just emit raw insts that processes each element.

Fixes #4038.