### PR TITLE
Adds functionality to dump IR to stdout

### DIFF
--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -4,6 +4,7 @@
 #include "slang-ir-util.h"
 
 #include "../core/slang-basic.h"
+#include "../core/slang-writer.h"
 
 #include "slang-ir-dominators.h"
 
@@ -8605,6 +8606,14 @@ namespace Slang
         }
     }
 
+    void IRInst::dumps()
+    {
+        StringBuilder sb;
+        IRDumpOptions options;
+        StringWriter writer(&sb, Slang::WriterFlag::AutoFlush);
+        dumpIR(this, options, nullptr, &writer);
+        std::cout << sb.toString().begin();
+    }
 } // namespace Slang
 
 #if SLANG_VC

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -8606,13 +8606,24 @@ namespace Slang
         }
     }
 
-    void IRInst::dumps()
+    void IRInst::dump()
     {
-        StringBuilder sb;
-        IRDumpOptions options;
-        StringWriter writer(&sb, Slang::WriterFlag::AutoFlush);
-        dumpIR(this, options, nullptr, &writer);
-        std::cout << sb.toString().begin();
+        if (auto intLit = as<IRIntLit>(this))
+        {
+            std::cout << intLit->getValue() << std::endl;
+        }
+        else if (auto stringLit = as<IRStringLit>(this))
+        {
+            std::cout << stringLit->getStringSlice().begin() << std::endl;
+        }
+        else
+        {
+            StringBuilder sb;
+            IRDumpOptions options;
+            StringWriter writer(&sb, Slang::WriterFlag::AutoFlush);
+            dumpIR(this, options, nullptr, &writer);
+            std::cout << sb.toString().begin() << std::endl;
+        }
     }
 } // namespace Slang
 

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -838,6 +838,8 @@ struct IRInst
         /// If both `inPrev` and `inNext` are null, then `inParent` must have no (raw) children.
         ///
     void _insertAt(IRInst* inPrev, IRInst* inNext, IRInst* inParent);
+
+   void dumps();
 };
 
 enum class IRDynamicCastBehavior

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -839,7 +839,9 @@ struct IRInst
         ///
     void _insertAt(IRInst* inPrev, IRInst* inNext, IRInst* inParent);
 
-   void dumps();
+    /// Print the IR to stdout for debugging purposes
+    ///
+    void dump();
 };
 
 enum class IRDynamicCastBehavior


### PR DESCRIPTION
Adds a member dump() to IRInst that can writes the immediate value or IR
inst value to stdout to help with debugging
