### PR TITLE
Add ParamDecl as the attribute target (#4055)

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2569,6 +2569,7 @@ enum _AttributeTargets
     Struct = $( (int) UserDefinedAttributeTargets::Struct),
     Var = $( (int) UserDefinedAttributeTargets::Var),
     Function = $( (int) UserDefinedAttributeTargets::Function),
+    Param = $( (int) UserDefinedAttributeTargets::Param),
 };
 __attributeTarget(StructDecl)
 attribute_syntax [__AttributeUsage(target : _AttributeTargets)] : AttributeUsageAttribute;

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -318,6 +318,11 @@ namespace Slang
             cls = m_astBuilder->findSyntaxClass(UnownedStringSlice::fromLiteral("FuncDecl"));
             return true;
         }
+        if (typeFlags == (int)UserDefinedAttributeTargets::Param)
+        {
+            cls = m_astBuilder->findSyntaxClass(UnownedStringSlice::fromLiteral("ParamDecl"));
+            return true;
+        }
         return false;
     }
 

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -322,7 +322,8 @@ namespace Slang
         Struct = 1,
         Var = 2,
         Function = 4,
-        All = 7
+        Param = 8,
+        All = 0x0F
     };
 
     const int kUnsizedArrayMagicLength = 0x7FFFFFFF;


### PR DESCRIPTION
Currently we only allow variable, struct, and function as the target for the user-defined attribute, this change adds the function parameter to the target as well.