### PR TITLE
Copy default target's optionSet to code-gen target's optionSet

### DIFF
--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -2835,6 +2835,8 @@ namespace Slang
         };
         Dictionary<TargetRequest*, RefPtr<TargetInfo>> m_targetInfos;
 
+        CompilerOptionSet m_optionSetForDefaultTarget;
+
         CompilerOptionSet& getTargetOptionSet(TargetRequest* req);
 
         CompilerOptionSet& getTargetOptionSet(Index targetIndex);

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -2909,7 +2909,23 @@ SlangResult OptionsParser::_parse(
 
     // Copy all settings from linkage to targets.
     for (auto target : linkage->targets)
+    {
         target->getOptionSet().inheritFrom(linkage->m_optionSet);
+
+        // If there is no target specified in command line, we should inherit the default target options.
+        if(m_rawTargets.getCount() == 0)
+        {
+            target->getOptionSet().inheritFrom(m_defaultTarget.optionSet);
+        }
+    }
+
+    // If there are no targets specified in command line, and addCodeGenTarget() is not called
+    // yet, the options for the default target will be gone after option parsing. We
+    // should save the option for the future use when addCodeGenTarget() is called.
+    if ((linkage->targets.getCount() == 0) && (m_rawTargets.getCount() == 0))
+    {
+        m_requestImpl->m_optionSetForDefaultTarget = m_defaultTarget.optionSet;
+    }
     
     applySettingsToDiagnosticSink(m_requestImpl->getSink(), m_sink, linkage->m_optionSet);
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -5530,6 +5530,7 @@ void EndToEndCompileRequest::_completeTargetRequest(UInt targetIndex)
     TargetRequest* targetRequest = linkage->targets[Index(targetIndex)];
 
     targetRequest->getOptionSet().inheritFrom(getLinkage()->m_optionSet);
+    targetRequest->getOptionSet().inheritFrom(m_optionSetForDefaultTarget);
 }
 
 void EndToEndCompileRequest::setCodeGenTarget(SlangCompileTarget target)


### PR DESCRIPTION
In current implementation, the some options will be to added to the target that is only specified by command line "-target". But if user specifies the target by just using slang API, e.g. 'spAddCodeGenTarget', those options will be missed.

To fix the problem, we copy the default target's options to the code-gen target's option set. The default target will only be useful when there is no target specified in the command line.