### PR TITLE
Delete out-of-date assert.

### DIFF
--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -4456,8 +4456,6 @@ namespace Slang
         // Or add any modifiers
         if (as<NamespaceDecl>(decl) && decl->parentDecl)
         {
-            // Presumably we have no modifiers.
-            SLANG_ASSERT(modifiers.isEmpty());
             return;
         }
 


### PR DESCRIPTION
This is causing a failure of gfx-smoke test under debug configuration.

The assert is out of date and no longer needed because we already have a centralized validation check on what modifiers are allowed on what decls in `isModifierAllowedOnDecl`.

Fixes #3953.