### PR TITLE
Fix reflection-test issue (#4082)

### DIFF
--- a/tests/reflection/attribute.slang
+++ b/tests/reflection/attribute.slang
@@ -16,6 +16,12 @@ struct DefaultValueAttribute
     int iParam;
 };
 
+[__AttributeUsage(_AttributeTargets.Param)]
+struct DefaultFuncParamAttribute
+{
+    int iParam;
+};
+
 [MyStruct(0, 1.0)]
 struct A
 {
@@ -35,8 +41,11 @@ struct B
 ParameterBlock<A> param;
 ParameterBlock<B> param2;
 
+[DefaultValue(2)] int globalInt;
+
 [numthreads(1, 1, 1)]
 void main(
-    uint3 dispatchThreadID : SV_DispatchThreadID)
+    uint3 dispatchThreadID : SV_DispatchThreadID,
+    [DefaultFuncParam(3)] float a)
 {
 }

--- a/tests/reflection/attribute.slang.expected
+++ b/tests/reflection/attribute.slang.expected
@@ -6,7 +6,7 @@ standard output = {
     "parameters": [
         {
             "name": "param",
-            "binding": {"kind": "constantBuffer", "index": 0},
+            "binding": {"kind": "constantBuffer", "index": 1},
             "type": {
                 "kind": "parameterBlock",
                 "elementType": {
@@ -27,6 +27,13 @@ standard output = {
                                 "kind": "scalar",
                                 "scalarType": "float32"
                             },
+                            "userAttribs": [{
+                                "name": "DefaultValue",
+                                "arguments": [
+                                    1
+                                ]
+                            }
+                            ],
                             "binding": {"kind": "uniform", "offset": 4, "size": 4},
                             "userAttribs": [{
                                 "name": "DefaultValue",
@@ -68,6 +75,13 @@ standard output = {
                                     "kind": "scalar",
                                     "scalarType": "float32"
                                 },
+                                "userAttribs": [{
+                                    "name": "DefaultValue",
+                                    "arguments": [
+                                        1
+                                    ]
+                                }
+                                ],
                                 "binding": {"kind": "uniform", "offset": 4, "size": 4},
                                 "userAttribs": [{
                                     "name": "DefaultValue",
@@ -93,7 +107,7 @@ standard output = {
         },
         {
             "name": "param2",
-            "binding": {"kind": "constantBuffer", "index": 1},
+            "binding": {"kind": "constantBuffer", "index": 2},
             "type": {
                 "kind": "parameterBlock",
                 "elementType": {
@@ -114,6 +128,13 @@ standard output = {
                                 "kind": "scalar",
                                 "scalarType": "float32"
                             },
+                            "userAttribs": [{
+                                "name": "DefaultValue",
+                                "arguments": [
+                                    2
+                                ]
+                            }
+                            ],
                             "binding": {"kind": "uniform", "offset": 4, "size": 4},
                             "userAttribs": [{
                                 "name": "DefaultValue",
@@ -155,6 +176,13 @@ standard output = {
                                     "kind": "scalar",
                                     "scalarType": "float32"
                                 },
+                                "userAttribs": [{
+                                    "name": "DefaultValue",
+                                    "arguments": [
+                                        2
+                                    ]
+                                }
+                                ],
                                 "binding": {"kind": "uniform", "offset": 4, "size": 4},
                                 "userAttribs": [{
                                     "name": "DefaultValue",
@@ -177,6 +205,21 @@ standard output = {
                     "binding": {"kind": "uniform", "offset": 0, "size": 8}
                 }
             }
+        },
+        {
+            "name": "globalInt",
+            "userAttribs": [{
+                "name": "DefaultValue",
+                "arguments": [
+                    2
+                ]
+            }
+            ],
+            "binding": {"kind": "uniform", "offset": 0, "size": 4},
+            "type": {
+                "kind": "scalar",
+                "scalarType": "int32"
+            }
         }
     ],
     "entryPoints": [
@@ -194,6 +237,22 @@ standard output = {
                             "kind": "scalar",
                             "scalarType": "uint32"
                         }
+                    }
+                },
+                {
+                    "name": "a",
+                    "userAttribs": [{
+                        "name": "DefaultFuncParam",
+                        "arguments": [
+                            3
+                        ]
+                    }
+                    ],
+                    "stage": "compute",
+                    "binding": {"kind": "varyingInput", "index": 0},
+                    "type": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
                     }
                 }
             ],

--- a/tools/slang-reflection-test/slang-reflection-test-main.cpp
+++ b/tools/slang-reflection-test/slang-reflection-test-main.cpp
@@ -431,6 +431,8 @@ static void emitReflectionNameInfoJSON(
     writer.writeEscapedString(UnownedStringSlice(name));
 }
 
+static void emitUserAttributes(PrettyWriter& writer, slang::VariableReflection* var);
+
 static void emitReflectionModifierInfoJSON(
     PrettyWriter&               writer,
     slang::VariableReflection*  var)
@@ -440,6 +442,8 @@ static void emitReflectionModifierInfoJSON(
         writer.maybeComma();
         writer << "\"shared\": true";
     }
+
+    emitUserAttributes(writer, var);
 }
 
 static void emitUserAttributeJSON(PrettyWriter& writer, slang::UserAttribute* userAttribute)


### PR DESCRIPTION
The reflection test doesn't print the user attributes decorating for the variables, only types. Therefore, add the print for user attributes of variables.