### PR TITLE
Allow multiple _AttributeTargets for attribute declaration

### DIFF
--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -212,10 +212,14 @@ namespace Slang
         attrDecl->nameAndLoc.loc = structDecl->nameAndLoc.loc;
         attrDecl->loc = structDecl->loc;
 
-        AttributeTargetModifier* targetModifier = m_astBuilder->create<AttributeTargetModifier>();
-        targetModifier->syntaxClass = attrUsageAttr->targetSyntaxClass;
-        targetModifier->loc = attrUsageAttr->loc;
-        addModifier(attrDecl, targetModifier);
+        while(attrUsageAttr)
+        {
+            AttributeTargetModifier* targetModifier = m_astBuilder->create<AttributeTargetModifier>();
+            targetModifier->syntaxClass = attrUsageAttr->targetSyntaxClass;
+            targetModifier->loc = attrUsageAttr->loc;
+            addModifier(attrDecl, targetModifier);
+            attrUsageAttr = as<AttributeUsageAttribute>(attrUsageAttr->next);
+        }
 
         // Every attribute declaration is associated with the type
         // of syntax nodes it constructs (via reflection/RTTI).

--- a/tests/reflection/attribute.slang
+++ b/tests/reflection/attribute.slang
@@ -10,14 +10,10 @@ struct MyStructAttribute
     int iParam;
     float fParam;
 };
-[__AttributeUsage(_AttributeTargets.Var)]
-struct DefaultValueAttribute
-{
-    int iParam;
-};
 
+[__AttributeUsage(_AttributeTargets.Var)]
 [__AttributeUsage(_AttributeTargets.Param)]
-struct DefaultFuncParamAttribute
+struct DefaultValueAttribute
 {
     int iParam;
 };
@@ -43,9 +39,29 @@ ParameterBlock<B> param2;
 
 [DefaultValue(2)] int globalInt;
 
+[__AttributeUsage(_AttributeTargets.Struct)]
+[__AttributeUsage(_AttributeTargets.Var)]
+[__AttributeUsage(_AttributeTargets.Param)]
+struct StructVarParamAttribute
+{
+    int iParam;
+};
+
+[StructVarParam(0)]
+struct D
+{
+    int a;
+};
+
+D param3;
+
+[StructVarParam(1)] int globalInt2;
+
+
 [numthreads(1, 1, 1)]
 void main(
     uint3 dispatchThreadID : SV_DispatchThreadID,
-    [DefaultFuncParam(3)] float a)
+    [DefaultValue(3)] float a,
+    [StructVarParam(2)] float b)
 {
 }

--- a/tests/reflection/attribute.slang.expected
+++ b/tests/reflection/attribute.slang.expected
@@ -220,6 +220,46 @@ standard output = {
                 "kind": "scalar",
                 "scalarType": "int32"
             }
+        },
+        {
+            "name": "param3",
+            "binding": {"kind": "uniform", "offset": 16, "size": 4},
+            "type": {
+                "kind": "struct",
+                "name": "D",
+                "fields": [
+                    {
+                        "name": "a",
+                        "type": {
+                            "kind": "scalar",
+                            "scalarType": "int32"
+                        },
+                        "binding": {"kind": "uniform", "offset": 0, "size": 4}
+                    }
+                ],
+                "userAttribs": [{
+                    "name": "StructVarParam",
+                    "arguments": [
+                        0
+                    ]
+                }
+                ]
+            }
+        },
+        {
+            "name": "globalInt2",
+            "userAttribs": [{
+                "name": "StructVarParam",
+                "arguments": [
+                    1
+                ]
+            }
+            ],
+            "binding": {"kind": "uniform", "offset": 20, "size": 4},
+            "type": {
+                "kind": "scalar",
+                "scalarType": "int32"
+            }
         }
     ],
     "entryPoints": [
@@ -242,7 +282,7 @@ standard output = {
                 {
                     "name": "a",
                     "userAttribs": [{
-                        "name": "DefaultFuncParam",
+                        "name": "DefaultValue",
                         "arguments": [
                             3
                         ]
@@ -250,6 +290,22 @@ standard output = {
                     ],
                     "stage": "compute",
                     "binding": {"kind": "varyingInput", "index": 0},
+                    "type": {
+                        "kind": "scalar",
+                        "scalarType": "float32"
+                    }
+                },
+                {
+                    "name": "b",
+                    "userAttribs": [{
+                        "name": "StructVarParam",
+                        "arguments": [
+                            2
+                        ]
+                    }
+                    ],
+                    "stage": "compute",
+                    "binding": {"kind": "varyingInput", "index": 1},
                     "type": {
                         "kind": "scalar",
                         "scalarType": "float32"


### PR DESCRIPTION
The syntax like:
[__AttributeUsage(_AttributeTargets.Var)]
[__AttributeUsage(_AttributeTargets.Param)]
struct DefaultValueAttribute
{
    int iParam;
};

is allowed.

For user-defined attribute, we can specify more attribute targets on the attribute declaration. So one attribute can be used in more than one situations.