### PR TITLE
Remove target_intrinsic from `min(int,int)`

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -8389,14 +8389,32 @@ matrix<T, N, M> max(matrix<T, N, M> x, matrix<T, N, M> y)
 
 // minimum
 __generic<T : __BuiltinIntegerType>
-__target_intrinsic(hlsl)
-__target_intrinsic(glsl)
-__target_intrinsic(cuda, "$P_min($0, $1)")
-__target_intrinsic(cpp, "$P_min($0, $1)")
-__target_intrinsic(spirv, "OpExtInst resultType resultId glsl450 fus(FMin, UMin, SMin) _0 _1")
 [__readNone]
 [require(cpp_cuda_glsl_hlsl_spirv, sm_2_0_GLSL_140)]
-T min(T x, T y);
+T min(T x, T y)
+{
+    __target_switch
+    {
+    case hlsl: __intrinsic_asm "min";
+    case glsl: __intrinsic_asm "min";
+    case cuda: __intrinsic_asm "$P_min($0, $1)";
+    case cpp: __intrinsic_asm "$P_min($0, $1)";
+#if 0
+    case spirv:
+        if (__isSignedInt<T>())
+            return spirv_asm {
+                OpExtInst $$T result glsl450 SMin $x $y
+            };
+        else
+            return spirv_asm {
+                OpExtInst $$T result glsl450 UMin $x $y
+            };
+#endif
+    default:
+        return (x < y) ? x : y;
+    }
+}
+
 
 __generic<T : __BuiltinIntegerType, let N : int>
 [__readNone]


### PR DESCRIPTION
Closes #3906
Closes #4093

The last remaining function that uses `__target_intrinsic` is `min(int,int)`.

For some reason, Falcor-unit-test fails on CI when this change is applied. It can be reproduced on a local machine if you use a debug build of slang.dll