### PR TITLE
Fix `Ptr::__subscript` to accept any integer index.

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -694,7 +694,8 @@ struct Ptr
     __intrinsic_op($(kIROp_CastIntToPtr))
     __init(int64_t val);
 
-    __subscript(int index) -> T
+    __generic<TInt : __BuiltinIntegerType>
+    __subscript(TInt index) -> T
     {
         __intrinsic_op($(kIROp_GetOffsetPtr))
         ref;

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -10050,6 +10050,10 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         {
             return ensureDecl(context, typedefDecl);
         }
+        else if (auto subscriptDecl = as<SubscriptDecl>(genDecl->inner))
+        {
+            return ensureDecl(context, subscriptDecl);
+        }
         SLANG_RELEASE_ASSERT(false);
         UNREACHABLE_RETURN(LoweredValInfo());
     }

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -4311,6 +4311,7 @@ namespace Slang
             case ASTNodeType::TypeAliasDecl:
             case ASTNodeType::TypeDefDecl:
             case ASTNodeType::ExtensionDecl:
+            case ASTNodeType::SubscriptDecl:
                 return true;
             default:
                 return false;

--- a/tests/spirv/ptr-subscript.slang
+++ b/tests/spirv/ptr-subscript.slang
@@ -1,0 +1,12 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -entry main -stage compute -emit-spirv-directly
+
+// CHECK: OpEntryPoint
+
+ConstantBuffer<Ptr<int>> cbPtr;
+void main(int id : SV_DispatchThreadID)
+{
+    // Check that the index operand is translated directly into a 64bit integer
+    // in th resulting SPIR-V without any truncations.
+    // CHECK: OpPtrAccessChain %_ptr_PhysicalStorageBuffer_int %{{.*}} %long_123
+    cbPtr[123ll] = 4;
+}


### PR DESCRIPTION
Fixes #4029.

The main change here is to make `__subscript` a generic on `T:__BuiltinIntegerType`, and allow parser to accept generic __subscript decls.