### PR TITLE
Support groupshared variables for Metal.

### DIFF
--- a/source/slang/slang-emit-metal.h
+++ b/source/slang/slang-emit-metal.h
@@ -57,6 +57,8 @@ protected:
 
     void emitFuncParamLayoutImpl(IRInst* param);
 
+    virtual void _emitType(IRType* type, DeclaratorInfo* declarator) SLANG_OVERRIDE;
+
     void _emitHLSLParameterGroup(IRGlobalParam* varDecl, IRUniformParameterGroupType* type);
 
     void _emitHLSLTextureType(IRTextureTypeBase* texType);

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -3435,6 +3435,9 @@ public:
     IRConstRefType* getConstRefType(IRType* valueType);
     IRPtrTypeBase*  getPtrType(IROp op, IRType* valueType);
     IRPtrType* getPtrType(IROp op, IRType* valueType, IRIntegerValue addressSpace);
+    IRPtrType* getPtrType(IROp op, IRType* valueType, AddressSpace addressSpace) { return getPtrType(op, valueType, (IRIntegerValue)addressSpace); }
+    IRPtrType* getPtrType(IRType* valueType, AddressSpace addressSpace) { return getPtrType(kIROp_PtrType, valueType, (IRIntegerValue)addressSpace); }
+
     IRTextureTypeBase* getTextureType(
         IRType* elementType,
         IRInst* shape,

--- a/tests/metal/groupshared.slang
+++ b/tests/metal/groupshared.slang
@@ -1,0 +1,31 @@
+//TEST:SIMPLE(filecheck=CHECK): -target metal
+//TEST:SIMPLE(filecheck=CHECK-ASM): -target metallib
+
+uniform RWStructuredBuffer<float> outputBuffer;
+
+struct MyBlock
+{
+    StructuredBuffer<float> b1;
+    StructuredBuffer<float> b2;
+}
+ParameterBlock<MyBlock> block;
+
+groupshared int myArr[16];
+
+void func(float v)
+{
+    outputBuffer[0] = myArr[0];
+}
+
+// CHECK: array<int, int(16)> threadgroup* myArr{{.*}};
+// CHECK: {{\[\[}}kernel{{\]\]}} void main_kernel
+// CHECK: threadgroup array<int, int(16)> myArr{{.*}};
+// CHECK: (&kernelContext{{.*}})->myArr{{.*}} = &myArr{{.*}};
+// CHECK-ASM: define void @main_kernel
+
+[numthreads(1,1,1)]
+void main_kernel(uint3 tid: SV_DispatchThreadID)
+{
+    myArr[tid.x] = tid.x;
+    func(3.0f);
+}


### PR DESCRIPTION
This change extends the explicit context pass to handle groupshared variables differently, such that they are allocated first in the entry point as a local variable, and then its pointers are passed in the global context object.

For example,
```
groupshared int data[3];
void test()
{
   int a = data[2];
}
void main()
{
    test();
}
```

Is emitted as:
```
struct KernelContext
{
    array<int,3> threadgroup* data;
};
void test(KernelContext thread* ctx)
{
    int a =  (*ctx->data)[[2];
}
void main()
{
    threadgroup array<int,3> data;
    KernelContext ctx;
    ctx.data = &data;
    test(&ctx);
}
```

Closes #4045.