### PR TITLE
capture/replay: interface implementation 1

### DIFF
--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -308,6 +308,10 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\slang.h" />
+    <ClInclude Include="..\..\..\source\slang-capture-replay\capture_utility.h" />
+    <ClInclude Include="..\..\..\source\slang-capture-replay\slang-filesystem.h" />
+    <ClInclude Include="..\..\..\source\slang-capture-replay\slang-global-session.h" />
+    <ClInclude Include="..\..\..\source\slang-capture-replay\slang-session.h" />
     <ClInclude Include="..\..\..\source\slang\slang-artifact-output-util.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ast-all.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ast-base.h" />
@@ -348,8 +352,6 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClInclude Include="..\..\..\source\slang\slang-emit-spirv-ops-debug-info-ext.h" />
     <ClInclude Include="..\..\..\source\slang\slang-emit-spirv-ops.h" />
     <ClInclude Include="..\..\..\source\slang\slang-emit-torch.h" />
-    <ClInclude Include="..\..\..\source\slang\slang-generated-capability-defs-impl.h" />
-    <ClInclude Include="..\..\..\source\slang\slang-generated-capability-defs.h" />
     <ClInclude Include="..\..\..\source\slang\slang-glsl-extension-tracker.h" />
     <ClInclude Include="..\..\..\source\slang\slang-hlsl-to-vulkan-layout-options.h" />
     <ClInclude Include="..\..\..\source\slang\slang-image-format-defs.h" />
@@ -539,6 +541,10 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClCompile Include="..\..\..\prelude\slang-cuda-prelude.h.cpp" />
     <ClCompile Include="..\..\..\prelude\slang-hlsl-prelude.h.cpp" />
     <ClCompile Include="..\..\..\prelude\slang-torch-prelude.h.cpp" />
+    <ClCompile Include="..\..\..\source\slang-capture-replay\capture_utility.cpp" />
+    <ClCompile Include="..\..\..\source\slang-capture-replay\slang-filesystem.cpp" />
+    <ClCompile Include="..\..\..\source\slang-capture-replay\slang-global-session.cpp" />
+    <ClCompile Include="..\..\..\source\slang-capture-replay\slang-session.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-api.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-artifact-output-util.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ast-base.cpp" />

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -12,6 +12,18 @@
     <ClInclude Include="..\..\..\slang.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\slang-capture-replay\capture_utility.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\source\slang-capture-replay\slang-filesystem.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\source\slang-capture-replay\slang-global-session.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\source\slang-capture-replay\slang-session.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-artifact-output-util.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -130,12 +142,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-emit-torch.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\source\slang\slang-generated-capability-defs-impl.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\source\slang\slang-generated-capability-defs.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-glsl-extension-tracker.h">
@@ -700,6 +706,18 @@
     </ClCompile>
     <ClCompile Include="..\..\..\prelude\slang-torch-prelude.h.cpp">
       <Filter>Header Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\source\slang-capture-replay\capture_utility.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\source\slang-capture-replay\slang-filesystem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\source\slang-capture-replay\slang-global-session.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\source\slang-capture-replay\slang-session.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-api.cpp">
       <Filter>Source Files</Filter>

--- a/premake5.lua
+++ b/premake5.lua
@@ -1609,6 +1609,8 @@ if enableEmbedStdLib then
             "source/slang/slang-lookup-glslstd450.cpp",
             "source/slang/slang-lookup-capability-defs.cpp"
         }
+        addSourceDir("source/slang-capture-replay")
+
         if not targetInfo.isWindows then
             links { "pthread" }
         end
@@ -1732,6 +1734,7 @@ standardProject("slang", "source/slang")
         "source/slang/slang-generated-capability-defs-impl.h",
     }
 
+    addSourceDir("source/slang-capture-replay")
     --
     -- The most challenging part of building `slang` is that we need
     -- to invoke generators such as slang-cpp-extractor and slang-generate

--- a/source/slang-capture-replay/capture_utility.cpp
+++ b/source/slang-capture-replay/capture_utility.cpp
@@ -1,0 +1,82 @@
+
+#include <cstring>
+#include <string>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <mutex>
+
+#include "capture_utility.h"
+
+constexpr const char* kCaptureLayerEnvVar = "SLANG_CAPTURE_LAYER";
+constexpr const char* kCaptureLayerLogLevel = "SLANG_CAPTURE_LOG_LEVEL";
+
+namespace SlangCapture
+{
+    static thread_local unsigned int g_logLevel = LogLevel::Silent;
+
+    static bool getEnvironmentVariable(const char* name, std::string& out)
+    {
+#ifdef _WIN32
+        char* envVar = nullptr;
+        size_t sz = 0;
+        if (_dupenv_s(&envVar, &sz, name) == 0 && envVar != nullptr)
+        {
+            out = envVar;
+            free(envVar);
+        }
+#else
+        if (const char* envVar = std::getenv(name))
+        {
+            out = envVar;
+        }
+#endif
+        return out.empty() == false;
+    }
+
+    bool isCaptureLayerEnabled()
+    {
+        std::string envVarStr;
+        if(getEnvironmentVariable(kCaptureLayerEnvVar, envVarStr))
+        {
+            if (envVarStr == "1")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void setLogLevel()
+    {
+        // We only want to set the log level once
+        if (g_logLevel != LogLevel::Silent)
+        {
+            return;
+        }
+
+        std::string envVarStr;
+        if (getEnvironmentVariable(kCaptureLayerLogLevel, envVarStr))
+        {
+            char* end = nullptr;
+            unsigned int logLevel = std::strtol(envVarStr.c_str(), &end, 10);
+            if (end && (*end == 0))
+            {
+                g_logLevel = std::min((unsigned int)(LogLevel::Verbose), logLevel);
+                return;
+            }
+        }
+    }
+
+    void slangCaptureLog(LogLevel logLevel, const char* fmt, ...)
+    {
+        if (logLevel > g_logLevel)
+        {
+            return;
+        }
+
+        va_list args;
+        va_start(args, fmt);
+        vfprintf(stdout, fmt, args);
+        va_end(args);
+    }
+}

--- a/source/slang-capture-replay/capture_utility.h
+++ b/source/slang-capture-replay/capture_utility.h
@@ -1,0 +1,18 @@
+#ifndef CAPTURE_UTILITY_H
+#define CAPTURE_UTILITY_H
+
+namespace SlangCapture
+{
+    enum LogLevel: unsigned int
+    {
+        Silent = 0,
+        Error = 1,
+        Debug = 2,
+        Verbose = 3,
+    };
+
+    bool isCaptureLayerEnabled();
+    void slangCaptureLog(LogLevel logLevel, const char* fmt, ...);
+    void setLogLevel();
+}
+#endif // CAPTURE_UTILITY_H

--- a/source/slang-capture-replay/slang-filesystem.cpp
+++ b/source/slang-capture-replay/slang-filesystem.cpp
@@ -7,7 +7,7 @@ namespace SlangCapture
         : m_actualFileSystem(fileSystem)
     {
         assert(m_actualFileSystem);
-        slangCaptureLog(LogLevel::Verbose, "FileSystemCapture: %p\n", m_actualFileSystem);
+        slangCaptureLog(LogLevel::Verbose, "%s: %p\n", __func__, m_actualFileSystem.get());
     }
 
     FileSystemCapture::~FileSystemCapture()
@@ -31,7 +31,7 @@ namespace SlangCapture
                 char const*     path,
                 ISlangBlob** outBlob)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s, :%s\n", m_actualFileSystem, "FileSystemCapture:loadFile", path);
+        slangCaptureLog(LogLevel::Verbose, "%p: %s, :%s\n", m_actualFileSystem.get(), __func__, path);
         SlangResult res = m_actualFileSystem->loadFile(path, outBlob);
         return res;
     }
@@ -40,7 +40,7 @@ namespace SlangCapture
         const char* path,
         ISlangBlob** outUniqueIdentity)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s :\"%s\"\n", m_actualFileSystem, "FileSystemCapture:getFileUniqueIdentity", path);
+        slangCaptureLog(LogLevel::Verbose, "%p: %s :\"%s\"\n", m_actualFileSystem.get(), __func__, path);
         SlangResult res = m_actualFileSystem->getFileUniqueIdentity(path, outUniqueIdentity);
         return res;
     }
@@ -51,7 +51,7 @@ namespace SlangCapture
         const char* path,
         ISlangBlob** pathOut)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s, :%s\n", m_actualFileSystem, "FileSystemCapture:calcCombinedPath", path);
+        slangCaptureLog(LogLevel::Verbose, "%p: %s, :%s\n", m_actualFileSystem.get(), __func__, path);
         SlangResult res = m_actualFileSystem->calcCombinedPath(fromPathType, fromPath, path, pathOut);
         return res;
     }
@@ -60,7 +60,7 @@ namespace SlangCapture
         const char* path,
         SlangPathType* pathTypeOut)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s, :%s\n", m_actualFileSystem, "FileSystemCapture:getPathType", path);
+        slangCaptureLog(LogLevel::Verbose, "%p: %s, :%s\n", m_actualFileSystem.get(), __func__, path);
         SlangResult res = m_actualFileSystem->getPathType(path, pathTypeOut);
         return res;
     }
@@ -70,14 +70,14 @@ namespace SlangCapture
         const char* path,
         ISlangBlob** outPath)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s, :%s\n", m_actualFileSystem, "FileSystemCapture:getPath", path);
+        slangCaptureLog(LogLevel::Verbose, "%p: %s, :%s\n", m_actualFileSystem.get(), __func__, path);
         SlangResult res = m_actualFileSystem->getPath(kind, path, outPath);
         return res;
     }
 
     SLANG_NO_THROW void FileSystemCapture::clearCache()
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualFileSystem, "FileSystemCapture:clearCache");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualFileSystem.get(), __func__);
         m_actualFileSystem->clearCache();
     }
 
@@ -86,14 +86,14 @@ namespace SlangCapture
         FileSystemContentsCallBack callback,
         void* userData)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s, :%s\n", m_actualFileSystem, "FileSystemCapture:enumeratePathContents", path);
+        slangCaptureLog(LogLevel::Verbose, "%p: %s, :%s\n", m_actualFileSystem.get(), __func__, path);
         SlangResult res = m_actualFileSystem->enumeratePathContents(path, callback, userData);
         return res;
     }
 
     SLANG_NO_THROW OSPathKind FileSystemCapture::getOSPathKind()
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualFileSystem, "FileSystemCapture:getOSPathKind");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualFileSystem.get(), __func__);
         OSPathKind pathKind = m_actualFileSystem->getOSPathKind();
         return pathKind;
     }

--- a/source/slang-capture-replay/slang-filesystem.cpp
+++ b/source/slang-capture-replay/slang-filesystem.cpp
@@ -1,0 +1,100 @@
+#include "slang-filesystem.h"
+#include "capture_utility.h"
+
+namespace SlangCapture
+{
+    FileSystemCapture::FileSystemCapture(ISlangFileSystemExt* fileSystem)
+        : m_actualFileSystem(fileSystem)
+    {
+        assert(m_actualFileSystem);
+        slangCaptureLog(LogLevel::Verbose, "FileSystemCapture: %p\n", m_actualFileSystem);
+    }
+
+    FileSystemCapture::~FileSystemCapture()
+    {
+        m_actualFileSystem->release();
+    }
+
+    void* FileSystemCapture::castAs(const Slang::Guid& guid)
+    {
+        return getInterface(guid);
+    }
+
+    ISlangUnknown* FileSystemCapture::getInterface(const Slang::Guid& guid)
+    {
+        if(guid == ISlangUnknown::getTypeGuid() || guid == ISlangFileSystem::getTypeGuid())
+            return static_cast<ISlangFileSystem*>(this);
+        return nullptr;
+    }
+
+    SLANG_NO_THROW SlangResult FileSystemCapture::loadFile(
+                char const*     path,
+                ISlangBlob** outBlob)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s, :%s\n", m_actualFileSystem, "FileSystemCapture:loadFile", path);
+        SlangResult res = m_actualFileSystem->loadFile(path, outBlob);
+        return res;
+    }
+
+    SLANG_NO_THROW SlangResult FileSystemCapture::getFileUniqueIdentity(
+        const char* path,
+        ISlangBlob** outUniqueIdentity)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s :\"%s\"\n", m_actualFileSystem, "FileSystemCapture:getFileUniqueIdentity", path);
+        SlangResult res = m_actualFileSystem->getFileUniqueIdentity(path, outUniqueIdentity);
+        return res;
+    }
+
+    SLANG_NO_THROW SlangResult FileSystemCapture::calcCombinedPath(
+        SlangPathType fromPathType,
+        const char* fromPath,
+        const char* path,
+        ISlangBlob** pathOut)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s, :%s\n", m_actualFileSystem, "FileSystemCapture:calcCombinedPath", path);
+        SlangResult res = m_actualFileSystem->calcCombinedPath(fromPathType, fromPath, path, pathOut);
+        return res;
+    }
+
+    SLANG_NO_THROW SlangResult FileSystemCapture::getPathType(
+        const char* path,
+        SlangPathType* pathTypeOut)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s, :%s\n", m_actualFileSystem, "FileSystemCapture:getPathType", path);
+        SlangResult res = m_actualFileSystem->getPathType(path, pathTypeOut);
+        return res;
+    }
+
+    SLANG_NO_THROW SlangResult FileSystemCapture::getPath(
+        PathKind kind,
+        const char* path,
+        ISlangBlob** outPath)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s, :%s\n", m_actualFileSystem, "FileSystemCapture:getPath", path);
+        SlangResult res = m_actualFileSystem->getPath(kind, path, outPath);
+        return res;
+    }
+
+    SLANG_NO_THROW void FileSystemCapture::clearCache()
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualFileSystem, "FileSystemCapture:clearCache");
+        m_actualFileSystem->clearCache();
+    }
+
+    SLANG_NO_THROW SlangResult FileSystemCapture::enumeratePathContents(
+        const char* path,
+        FileSystemContentsCallBack callback,
+        void* userData)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s, :%s\n", m_actualFileSystem, "FileSystemCapture:enumeratePathContents", path);
+        SlangResult res = m_actualFileSystem->enumeratePathContents(path, callback, userData);
+        return res;
+    }
+
+    SLANG_NO_THROW OSPathKind FileSystemCapture::getOSPathKind()
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualFileSystem, "FileSystemCapture:getOSPathKind");
+        OSPathKind pathKind = m_actualFileSystem->getOSPathKind();
+        return pathKind;
+    }
+}

--- a/source/slang-capture-replay/slang-filesystem.h
+++ b/source/slang-capture-replay/slang-filesystem.h
@@ -1,0 +1,73 @@
+#ifndef SLANG_FILE_SYSTEM_H
+#define SLANG_FILE_SYSTEM_H
+
+#include "../core/slang-com-object.h"
+#include "../../slang-com-helper.h"
+
+namespace SlangCapture
+{
+
+    using namespace Slang;
+
+    // slang always requires ISlangFileSystemExt interface, even if user only provides ISlangFileSystem,
+    // slang will still wrap it with ISlangFileSystemExt. So we have to capture ISlangFileSystemExt, even
+    // though we only need to record loadFile() function.
+    class FileSystemCapture : public RefObject, public ISlangFileSystemExt
+    {
+    public:
+        explicit FileSystemCapture(ISlangFileSystemExt* fileSystem);
+        ~FileSystemCapture();
+
+        // ISlangUnknown
+        SLANG_REF_OBJECT_IUNKNOWN_ALL
+
+        ISlangUnknown* getInterface(const Slang::Guid& guid);
+
+        // ISlangCastable
+        virtual SLANG_NO_THROW void* castAs(const Slang::Guid& guid) override;
+
+        // ISlangFileSystem
+        virtual SLANG_NO_THROW SlangResult loadFile(
+                char const*     path,
+                ISlangBlob** outBlob) override;
+
+        // ISlangFileSystemExt
+        virtual SLANG_NO_THROW SlangResult getFileUniqueIdentity(
+            const char* path,
+            ISlangBlob** outUniqueIdentity) override;
+
+        virtual SLANG_NO_THROW SlangResult calcCombinedPath(
+            SlangPathType fromPathType,
+            const char* fromPath,
+            const char* path,
+            ISlangBlob** pathOut) override;
+
+        virtual SLANG_NO_THROW SlangResult getPathType(
+            const char* path,
+            SlangPathType* pathTypeOut) override;
+
+        virtual SLANG_NO_THROW SlangResult getPath(
+            PathKind kind,
+            const char* path,
+            ISlangBlob** outPath) override;
+
+        virtual SLANG_NO_THROW void clearCache() override;
+
+        virtual SLANG_NO_THROW SlangResult enumeratePathContents(
+            const char* path,
+            FileSystemContentsCallBack callback,
+            void* userData) override;
+
+        virtual SLANG_NO_THROW OSPathKind getOSPathKind() override;
+    private:
+        // We should release the actual file system, because if 1) the file
+        // system is provided by user, we will increment the ref-count;
+        // 2) if the file system is created by slang, we will transfer the ownership
+        // from Linkage to FileSystemCapture, in both cases, we should release the
+        // 'm_actualFileSystem'.
+        ISlangFileSystemExt* m_actualFileSystem = nullptr;
+};
+
+}
+#endif
+

--- a/source/slang-capture-replay/slang-filesystem.h
+++ b/source/slang-capture-replay/slang-filesystem.h
@@ -3,6 +3,7 @@
 
 #include "../core/slang-com-object.h"
 #include "../../slang-com-helper.h"
+#include "../../slang-com-ptr.h"
 
 namespace SlangCapture
 {
@@ -24,48 +25,43 @@ namespace SlangCapture
         ISlangUnknown* getInterface(const Slang::Guid& guid);
 
         // ISlangCastable
-        virtual SLANG_NO_THROW void* castAs(const Slang::Guid& guid) override;
+        virtual SLANG_NO_THROW void* SLANG_MCALL castAs(const Slang::Guid& guid) override;
 
         // ISlangFileSystem
-        virtual SLANG_NO_THROW SlangResult loadFile(
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL loadFile(
                 char const*     path,
                 ISlangBlob** outBlob) override;
 
         // ISlangFileSystemExt
-        virtual SLANG_NO_THROW SlangResult getFileUniqueIdentity(
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL getFileUniqueIdentity(
             const char* path,
             ISlangBlob** outUniqueIdentity) override;
 
-        virtual SLANG_NO_THROW SlangResult calcCombinedPath(
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL calcCombinedPath(
             SlangPathType fromPathType,
             const char* fromPath,
             const char* path,
             ISlangBlob** pathOut) override;
 
-        virtual SLANG_NO_THROW SlangResult getPathType(
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL getPathType(
             const char* path,
             SlangPathType* pathTypeOut) override;
 
-        virtual SLANG_NO_THROW SlangResult getPath(
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL getPath(
             PathKind kind,
             const char* path,
             ISlangBlob** outPath) override;
 
-        virtual SLANG_NO_THROW void clearCache() override;
+        virtual SLANG_NO_THROW void SLANG_MCALL clearCache() override;
 
-        virtual SLANG_NO_THROW SlangResult enumeratePathContents(
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL enumeratePathContents(
             const char* path,
             FileSystemContentsCallBack callback,
             void* userData) override;
 
-        virtual SLANG_NO_THROW OSPathKind getOSPathKind() override;
+        virtual SLANG_NO_THROW OSPathKind SLANG_MCALL getOSPathKind() override;
     private:
-        // We should release the actual file system, because if 1) the file
-        // system is provided by user, we will increment the ref-count;
-        // 2) if the file system is created by slang, we will transfer the ownership
-        // from Linkage to FileSystemCapture, in both cases, we should release the
-        // 'm_actualFileSystem'.
-        ISlangFileSystemExt* m_actualFileSystem = nullptr;
+        Slang::ComPtr<ISlangFileSystemExt> m_actualFileSystem;
 };
 
 }

--- a/source/slang-capture-replay/slang-global-session.cpp
+++ b/source/slang-capture-replay/slang-global-session.cpp
@@ -29,10 +29,7 @@ namespace SlangCapture
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::createSession(slang::SessionDesc const&  desc, slang::ISession** outSession)
     {
         setLogLevel();
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::createSession");
-
-        FileSystemCapture * fileSystemCapture = nullptr;
-        Slang::ComPtr<FileSystemCapture> resultFileSystemCapture;
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
 
         slang::ISession* actualSession = nullptr;
         SlangResult res = m_actualGlobalSession->createSession(desc, &actualSession);
@@ -43,10 +40,7 @@ namespace SlangCapture
             // the Linkage will set to user provided file system or slang default file system.
             // We need to reset it to our capture file system
             Slang::Linkage* linkage = static_cast<Linkage*>(actualSession);
-            // add ref-count to the default file system so that when we replace it with our capture file system,
-            // the default one won't be released.
-            Slang::ComPtr<ISlangFileSystemExt> fileSystemExt(linkage->getFileSystemExt());
-            fileSystemCapture = new FileSystemCapture(fileSystemExt.detach());
+            FileSystemCapture* fileSystemCapture = new FileSystemCapture(linkage->getFileSystemExt());
 
             Slang::ComPtr<FileSystemCapture> resultFileSystemCapture(fileSystemCapture);
             linkage->setFileSystem(resultFileSystemCapture.detach());
@@ -61,152 +55,152 @@ namespace SlangCapture
 
     SLANG_NO_THROW SlangProfileID SLANG_MCALL GlobalSessionCapture::findProfile(char const* name)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::findProfile");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         SlangProfileID profileId = m_actualGlobalSession->findProfile(name);
         return profileId;
     }
 
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::setDownstreamCompilerPath(SlangPassThrough passThrough, char const* path)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::setDownstreamCompilerPath");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         m_actualGlobalSession->setDownstreamCompilerPath(passThrough, path);
     }
 
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::setDownstreamCompilerPrelude(SlangPassThrough inPassThrough, char const* prelude)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::setDownstreamCompilerPrelude");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         m_actualGlobalSession->setDownstreamCompilerPrelude(inPassThrough, prelude);
     }
 
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::getDownstreamCompilerPrelude(SlangPassThrough inPassThrough, ISlangBlob** outPrelude)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::getDownstreamCompilerPrelude");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         m_actualGlobalSession->getDownstreamCompilerPrelude(inPassThrough, outPrelude);
     }
 
     SLANG_NO_THROW const char* SLANG_MCALL GlobalSessionCapture::getBuildTagString()
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::getBuildTagString");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         const char* resStr = m_actualGlobalSession->getBuildTagString();
         return resStr;
     }
 
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::setDefaultDownstreamCompiler(SlangSourceLanguage sourceLanguage, SlangPassThrough defaultCompiler)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::setDefaultDownstreamCompiler");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         SlangResult res = m_actualGlobalSession->setDefaultDownstreamCompiler(sourceLanguage, defaultCompiler);
         return res;
     }
 
     SLANG_NO_THROW SlangPassThrough SLANG_MCALL GlobalSessionCapture::getDefaultDownstreamCompiler(SlangSourceLanguage sourceLanguage)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::getDefaultDownstreamCompiler");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         SlangPassThrough passThrough = m_actualGlobalSession->getDefaultDownstreamCompiler(sourceLanguage);
         return passThrough;
     }
 
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::setLanguagePrelude(SlangSourceLanguage inSourceLanguage, char const* prelude)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::setLanguagePrelude");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         m_actualGlobalSession->setLanguagePrelude(inSourceLanguage, prelude);
     }
 
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::getLanguagePrelude(SlangSourceLanguage inSourceLanguage, ISlangBlob** outPrelude)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::getLanguagePrelude");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         m_actualGlobalSession->getLanguagePrelude(inSourceLanguage, outPrelude);
     }
 
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::createCompileRequest(slang::ICompileRequest** outCompileRequest)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::createCompileRequest");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         SlangResult res = m_actualGlobalSession->createCompileRequest(outCompileRequest);
         return res;
     }
 
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::addBuiltins(char const* sourcePath, char const* sourceString)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::addBuiltins");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         m_actualGlobalSession->addBuiltins(sourcePath, sourceString);
     }
 
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::setSharedLibraryLoader(ISlangSharedLibraryLoader* loader)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::setSharedLibraryLoader");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         m_actualGlobalSession->setSharedLibraryLoader(loader);
     }
 
     SLANG_NO_THROW ISlangSharedLibraryLoader* SLANG_MCALL GlobalSessionCapture::getSharedLibraryLoader()
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::getSharedLibraryLoader");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         ISlangSharedLibraryLoader* loader = m_actualGlobalSession->getSharedLibraryLoader();
         return loader;
     }
 
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::checkCompileTargetSupport(SlangCompileTarget target)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::checkCompileTargetSupport");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         SlangResult res = m_actualGlobalSession->checkCompileTargetSupport(target);
         return res;
     }
 
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::checkPassThroughSupport(SlangPassThrough passThrough)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::checkPassThroughSupport");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         SlangResult res = m_actualGlobalSession->checkPassThroughSupport(passThrough);
         return res;
     }
 
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::compileStdLib(slang::CompileStdLibFlags flags)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::compileStdLib");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         SlangResult res = m_actualGlobalSession->compileStdLib(flags);
         return res;
     }
 
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::loadStdLib(const void* stdLib, size_t stdLibSizeInBytes)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::loadStdLib");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         SlangResult res = m_actualGlobalSession->loadStdLib(stdLib, stdLibSizeInBytes);
         return res;
     }
 
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::saveStdLib(SlangArchiveType archiveType, ISlangBlob** outBlob)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::saveStdLib");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         SlangResult res = m_actualGlobalSession->saveStdLib(archiveType, outBlob);
         return res;
     }
 
     SLANG_NO_THROW SlangCapabilityID SLANG_MCALL GlobalSessionCapture::findCapability(char const* name)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::findCapability");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         SlangCapabilityID capId = m_actualGlobalSession->findCapability(name);
         return capId;
     }
 
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::setDownstreamCompilerForTransition(SlangCompileTarget source, SlangCompileTarget target, SlangPassThrough compiler)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::setDownstreamCompilerForTransition");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         m_actualGlobalSession->setDownstreamCompilerForTransition(source, target, compiler);
     }
 
     SLANG_NO_THROW SlangPassThrough SLANG_MCALL GlobalSessionCapture::getDownstreamCompilerForTransition(SlangCompileTarget source, SlangCompileTarget target)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::getDownstreamCompilerForTransition");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         SlangPassThrough passThrough = m_actualGlobalSession->getDownstreamCompilerForTransition(source, target);
         return passThrough;
     }
 
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::getCompilerElapsedTime(double* outTotalTime, double* outDownstreamTime)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::getCompilerElapsedTime");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         m_actualGlobalSession->getCompilerElapsedTime(outTotalTime, outDownstreamTime);
     }
 
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::setSPIRVCoreGrammar(char const* jsonPath)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::setSPIRVCoreGrammar");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         SlangResult res = m_actualGlobalSession->setSPIRVCoreGrammar(jsonPath);
         return res;
     }
@@ -214,14 +208,14 @@ namespace SlangCapture
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::parseCommandLineArguments(
         int argc, const char* const* argv, slang::SessionDesc* outSessionDesc, ISlangUnknown** outAllocation)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::parseCommandLineArguments");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         SlangResult res = m_actualGlobalSession->parseCommandLineArguments(argc, argv, outSessionDesc, outAllocation);
         return res;
     }
 
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::getSessionDescDigest(slang::SessionDesc* sessionDesc, ISlangBlob** outBlob)
     {
-        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::getSessionDescDigest");
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __func__);
         SlangResult res = m_actualGlobalSession->getSessionDescDigest(sessionDesc, outBlob);
         return res;
     }

--- a/source/slang-capture-replay/slang-global-session.cpp
+++ b/source/slang-capture-replay/slang-global-session.cpp
@@ -1,0 +1,228 @@
+
+#include <vector>
+#include "slang-global-session.h"
+#include "capture_utility.h"
+#include "slang-session.h"
+#include "slang-filesystem.h"
+#include "../slang/slang-compiler.h"
+
+namespace SlangCapture
+{
+    GlobalSessionCapture::GlobalSessionCapture(slang::IGlobalSession* session):
+        m_actualGlobalSession(session)
+    {
+        assert(m_actualGlobalSession != nullptr);
+    }
+
+    GlobalSessionCapture::~GlobalSessionCapture()
+    {
+        m_actualGlobalSession->release();
+    }
+
+    ISlangUnknown* GlobalSessionCapture::getInterface(const Guid& guid)
+    {
+        if(guid == ISlangUnknown::getTypeGuid() || guid == IGlobalSession::getTypeGuid())
+            return asExternal(this);
+        return nullptr;
+    }
+
+    SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::createSession(slang::SessionDesc const&  desc, slang::ISession** outSession)
+    {
+        setLogLevel();
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::createSession");
+
+        FileSystemCapture * fileSystemCapture = nullptr;
+        Slang::ComPtr<FileSystemCapture> resultFileSystemCapture;
+
+        slang::ISession* actualSession = nullptr;
+        SlangResult res = m_actualGlobalSession->createSession(desc, &actualSession);
+
+        if (actualSession != nullptr)
+        {
+            // reset the file system to our capture file system. After createSession() call,
+            // the Linkage will set to user provided file system or slang default file system.
+            // We need to reset it to our capture file system
+            Slang::Linkage* linkage = static_cast<Linkage*>(actualSession);
+            // add ref-count to the default file system so that when we replace it with our capture file system,
+            // the default one won't be released.
+            Slang::ComPtr<ISlangFileSystemExt> fileSystemExt(linkage->getFileSystemExt());
+            fileSystemCapture = new FileSystemCapture(fileSystemExt.detach());
+
+            Slang::ComPtr<FileSystemCapture> resultFileSystemCapture(fileSystemCapture);
+            linkage->setFileSystem(resultFileSystemCapture.detach());
+
+            SessionCapture* sessionCapture = new SessionCapture(actualSession);
+            Slang::ComPtr<SessionCapture> result(sessionCapture);
+            *outSession = result.detach();
+        }
+
+        return res;
+    }
+
+    SLANG_NO_THROW SlangProfileID SLANG_MCALL GlobalSessionCapture::findProfile(char const* name)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::findProfile");
+        SlangProfileID profileId = m_actualGlobalSession->findProfile(name);
+        return profileId;
+    }
+
+    SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::setDownstreamCompilerPath(SlangPassThrough passThrough, char const* path)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::setDownstreamCompilerPath");
+        m_actualGlobalSession->setDownstreamCompilerPath(passThrough, path);
+    }
+
+    SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::setDownstreamCompilerPrelude(SlangPassThrough inPassThrough, char const* prelude)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::setDownstreamCompilerPrelude");
+        m_actualGlobalSession->setDownstreamCompilerPrelude(inPassThrough, prelude);
+    }
+
+    SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::getDownstreamCompilerPrelude(SlangPassThrough inPassThrough, ISlangBlob** outPrelude)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::getDownstreamCompilerPrelude");
+        m_actualGlobalSession->getDownstreamCompilerPrelude(inPassThrough, outPrelude);
+    }
+
+    SLANG_NO_THROW const char* SLANG_MCALL GlobalSessionCapture::getBuildTagString()
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::getBuildTagString");
+        const char* resStr = m_actualGlobalSession->getBuildTagString();
+        return resStr;
+    }
+
+    SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::setDefaultDownstreamCompiler(SlangSourceLanguage sourceLanguage, SlangPassThrough defaultCompiler)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::setDefaultDownstreamCompiler");
+        SlangResult res = m_actualGlobalSession->setDefaultDownstreamCompiler(sourceLanguage, defaultCompiler);
+        return res;
+    }
+
+    SLANG_NO_THROW SlangPassThrough SLANG_MCALL GlobalSessionCapture::getDefaultDownstreamCompiler(SlangSourceLanguage sourceLanguage)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::getDefaultDownstreamCompiler");
+        SlangPassThrough passThrough = m_actualGlobalSession->getDefaultDownstreamCompiler(sourceLanguage);
+        return passThrough;
+    }
+
+    SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::setLanguagePrelude(SlangSourceLanguage inSourceLanguage, char const* prelude)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::setLanguagePrelude");
+        m_actualGlobalSession->setLanguagePrelude(inSourceLanguage, prelude);
+    }
+
+    SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::getLanguagePrelude(SlangSourceLanguage inSourceLanguage, ISlangBlob** outPrelude)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::getLanguagePrelude");
+        m_actualGlobalSession->getLanguagePrelude(inSourceLanguage, outPrelude);
+    }
+
+    SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::createCompileRequest(slang::ICompileRequest** outCompileRequest)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::createCompileRequest");
+        SlangResult res = m_actualGlobalSession->createCompileRequest(outCompileRequest);
+        return res;
+    }
+
+    SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::addBuiltins(char const* sourcePath, char const* sourceString)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::addBuiltins");
+        m_actualGlobalSession->addBuiltins(sourcePath, sourceString);
+    }
+
+    SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::setSharedLibraryLoader(ISlangSharedLibraryLoader* loader)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::setSharedLibraryLoader");
+        m_actualGlobalSession->setSharedLibraryLoader(loader);
+    }
+
+    SLANG_NO_THROW ISlangSharedLibraryLoader* SLANG_MCALL GlobalSessionCapture::getSharedLibraryLoader()
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::getSharedLibraryLoader");
+        ISlangSharedLibraryLoader* loader = m_actualGlobalSession->getSharedLibraryLoader();
+        return loader;
+    }
+
+    SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::checkCompileTargetSupport(SlangCompileTarget target)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::checkCompileTargetSupport");
+        SlangResult res = m_actualGlobalSession->checkCompileTargetSupport(target);
+        return res;
+    }
+
+    SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::checkPassThroughSupport(SlangPassThrough passThrough)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::checkPassThroughSupport");
+        SlangResult res = m_actualGlobalSession->checkPassThroughSupport(passThrough);
+        return res;
+    }
+
+    SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::compileStdLib(slang::CompileStdLibFlags flags)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::compileStdLib");
+        SlangResult res = m_actualGlobalSession->compileStdLib(flags);
+        return res;
+    }
+
+    SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::loadStdLib(const void* stdLib, size_t stdLibSizeInBytes)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::loadStdLib");
+        SlangResult res = m_actualGlobalSession->loadStdLib(stdLib, stdLibSizeInBytes);
+        return res;
+    }
+
+    SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::saveStdLib(SlangArchiveType archiveType, ISlangBlob** outBlob)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::saveStdLib");
+        SlangResult res = m_actualGlobalSession->saveStdLib(archiveType, outBlob);
+        return res;
+    }
+
+    SLANG_NO_THROW SlangCapabilityID SLANG_MCALL GlobalSessionCapture::findCapability(char const* name)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::findCapability");
+        SlangCapabilityID capId = m_actualGlobalSession->findCapability(name);
+        return capId;
+    }
+
+    SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::setDownstreamCompilerForTransition(SlangCompileTarget source, SlangCompileTarget target, SlangPassThrough compiler)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::setDownstreamCompilerForTransition");
+        m_actualGlobalSession->setDownstreamCompilerForTransition(source, target, compiler);
+    }
+
+    SLANG_NO_THROW SlangPassThrough SLANG_MCALL GlobalSessionCapture::getDownstreamCompilerForTransition(SlangCompileTarget source, SlangCompileTarget target)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::getDownstreamCompilerForTransition");
+        SlangPassThrough passThrough = m_actualGlobalSession->getDownstreamCompilerForTransition(source, target);
+        return passThrough;
+    }
+
+    SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::getCompilerElapsedTime(double* outTotalTime, double* outDownstreamTime)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::getCompilerElapsedTime");
+        m_actualGlobalSession->getCompilerElapsedTime(outTotalTime, outDownstreamTime);
+    }
+
+    SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::setSPIRVCoreGrammar(char const* jsonPath)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::setSPIRVCoreGrammar");
+        SlangResult res = m_actualGlobalSession->setSPIRVCoreGrammar(jsonPath);
+        return res;
+    }
+
+    SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::parseCommandLineArguments(
+        int argc, const char* const* argv, slang::SessionDesc* outSessionDesc, ISlangUnknown** outAllocation)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::parseCommandLineArguments");
+        SlangResult res = m_actualGlobalSession->parseCommandLineArguments(argc, argv, outSessionDesc, outAllocation);
+        return res;
+    }
+
+    SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::getSessionDescDigest(slang::SessionDesc* sessionDesc, ISlangBlob** outBlob)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession, "GlobalSession::getSessionDescDigest");
+        SlangResult res = m_actualGlobalSession->getSessionDescDigest(sessionDesc, outBlob);
+        return res;
+    }
+}

--- a/source/slang-capture-replay/slang-global-session.h
+++ b/source/slang-capture-replay/slang-global-session.h
@@ -64,7 +64,7 @@ namespace SlangCapture
                 return static_cast<slang::IGlobalSession*>(session);
             }
 
-            slang::IGlobalSession* m_actualGlobalSession = nullptr;
+            Slang::ComPtr<slang::IGlobalSession> m_actualGlobalSession;
     };
 } // namespace Slang
 

--- a/source/slang-capture-replay/slang-global-session.h
+++ b/source/slang-capture-replay/slang-global-session.h
@@ -1,0 +1,71 @@
+#ifndef SLANG_GLOBAL_SESSION_H
+#define SLANG_GLOBAL_SESSION_H
+
+#include "../../slang-com-ptr.h"
+#include "../../slang.h"
+#include "../../slang-com-helper.h"
+#include "../core/slang-smart-pointer.h"
+
+namespace SlangCapture
+{
+    using namespace Slang;
+
+    class GlobalSessionCapture : public RefObject, public slang::IGlobalSession
+    {
+        public:
+            explicit GlobalSessionCapture(slang::IGlobalSession* session);
+            virtual ~GlobalSessionCapture();
+
+            SLANG_REF_OBJECT_IUNKNOWN_ALL
+
+            ISlangUnknown* getInterface(const Guid& guid);
+
+            // slang::IGlobalSession
+            SLANG_NO_THROW SlangResult SLANG_MCALL createSession(slang::SessionDesc const&  desc, slang::ISession** outSession) override;
+            SLANG_NO_THROW SlangProfileID SLANG_MCALL findProfile(char const* name) override;
+            SLANG_NO_THROW void SLANG_MCALL setDownstreamCompilerPath(SlangPassThrough passThrough, char const* path) override;
+            SLANG_NO_THROW void SLANG_MCALL setDownstreamCompilerPrelude(SlangPassThrough inPassThrough, char const* prelude) override;
+            SLANG_NO_THROW void SLANG_MCALL getDownstreamCompilerPrelude(SlangPassThrough inPassThrough, ISlangBlob** outPrelude) override;
+            SLANG_NO_THROW const char* SLANG_MCALL getBuildTagString() override;
+            SLANG_NO_THROW SlangResult SLANG_MCALL setDefaultDownstreamCompiler(SlangSourceLanguage sourceLanguage, SlangPassThrough defaultCompiler) override;
+            SLANG_NO_THROW SlangPassThrough SLANG_MCALL getDefaultDownstreamCompiler(SlangSourceLanguage sourceLanguage) override;
+
+            SLANG_NO_THROW void SLANG_MCALL setLanguagePrelude(SlangSourceLanguage inSourceLanguage, char const* prelude) override;
+            SLANG_NO_THROW void SLANG_MCALL getLanguagePrelude(SlangSourceLanguage inSourceLanguage, ISlangBlob** outPrelude) override;
+
+            SLANG_NO_THROW SlangResult SLANG_MCALL createCompileRequest(slang::ICompileRequest** outCompileRequest) override;
+
+            SLANG_NO_THROW void SLANG_MCALL addBuiltins(char const* sourcePath, char const* sourceString) override;
+            SLANG_NO_THROW void SLANG_MCALL setSharedLibraryLoader(ISlangSharedLibraryLoader* loader) override;
+            SLANG_NO_THROW ISlangSharedLibraryLoader* SLANG_MCALL getSharedLibraryLoader() override;
+            SLANG_NO_THROW SlangResult SLANG_MCALL checkCompileTargetSupport(SlangCompileTarget target) override;
+            SLANG_NO_THROW SlangResult SLANG_MCALL checkPassThroughSupport(SlangPassThrough passThrough) override;
+
+            SLANG_NO_THROW SlangResult SLANG_MCALL compileStdLib(slang::CompileStdLibFlags flags) override;
+            SLANG_NO_THROW SlangResult SLANG_MCALL loadStdLib(const void* stdLib, size_t stdLibSizeInBytes) override;
+            SLANG_NO_THROW SlangResult SLANG_MCALL saveStdLib(SlangArchiveType archiveType, ISlangBlob** outBlob) override;
+
+            SLANG_NO_THROW SlangCapabilityID SLANG_MCALL findCapability(char const* name) override;
+
+            SLANG_NO_THROW void SLANG_MCALL setDownstreamCompilerForTransition(SlangCompileTarget source, SlangCompileTarget target, SlangPassThrough compiler) override;
+            SLANG_NO_THROW SlangPassThrough SLANG_MCALL getDownstreamCompilerForTransition(SlangCompileTarget source, SlangCompileTarget target) override;
+            SLANG_NO_THROW void SLANG_MCALL getCompilerElapsedTime(double* outTotalTime, double* outDownstreamTime) override;
+
+            SLANG_NO_THROW SlangResult SLANG_MCALL setSPIRVCoreGrammar(char const* jsonPath) override;
+
+            SLANG_NO_THROW SlangResult SLANG_MCALL parseCommandLineArguments(
+                int argc, const char* const* argv, slang::SessionDesc* outSessionDesc, ISlangUnknown** outAllocation) override;
+
+            SLANG_NO_THROW SlangResult SLANG_MCALL getSessionDescDigest(slang::SessionDesc* sessionDesc, ISlangBlob** outBlob) override;
+
+        private:
+            SLANG_FORCE_INLINE slang::IGlobalSession* asExternal(GlobalSessionCapture* session)
+            {
+                return static_cast<slang::IGlobalSession*>(session);
+            }
+
+            slang::IGlobalSession* m_actualGlobalSession = nullptr;
+    };
+} // namespace Slang
+
+#endif

--- a/source/slang-capture-replay/slang-session.cpp
+++ b/source/slang-capture-replay/slang-session.cpp
@@ -26,7 +26,7 @@ namespace SlangCapture
 
     SLANG_NO_THROW slang::IGlobalSession* SessionCapture::getGlobalSession()
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getGlobalSession");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         slang::IGlobalSession* pGlobalSession = m_actualSession->getGlobalSession();
         return pGlobalSession;
     }
@@ -35,7 +35,7 @@ namespace SlangCapture
         const char* moduleName,
         slang::IBlob**     outDiagnostics)
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::loadModule");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         slang::IModule* pModule = m_actualSession->loadModule(moduleName, outDiagnostics);
         return pModule;
     }
@@ -46,7 +46,7 @@ namespace SlangCapture
         slang::IBlob* source,
         slang::IBlob** outDiagnostics)
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::loadModuleFromIRBlob");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         slang::IModule* pModule = m_actualSession->loadModuleFromIRBlob(moduleName, path, source, outDiagnostics);
         return pModule;
     }
@@ -57,7 +57,7 @@ namespace SlangCapture
         slang::IBlob* source,
         slang::IBlob** outDiagnostics)
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::loadModuleFromSource");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         slang::IModule* pModule = m_actualSession->loadModuleFromSource(moduleName, path, source, outDiagnostics);
         return pModule;
     }
@@ -68,7 +68,7 @@ namespace SlangCapture
         const char* string,
         slang::IBlob** outDiagnostics)
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::loadModuleFromSourceString");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         slang::IModule* pModule = m_actualSession->loadModuleFromSourceString(moduleName, path, string, outDiagnostics);
         return pModule;
     }
@@ -79,7 +79,7 @@ namespace SlangCapture
         slang::IComponentType**         outCompositeComponentType,
         ISlangBlob**                    outDiagnostics)
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::createCompositeComponentType");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         SlangResult result = m_actualSession->createCompositeComponentType(componentTypes, componentTypeCount, outCompositeComponentType, outDiagnostics);
         return result;
     }
@@ -90,7 +90,7 @@ namespace SlangCapture
         SlangInt                        specializationArgCount,
         ISlangBlob**                    outDiagnostics)
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::specializeType");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         slang::TypeReflection* pTypeReflection = m_actualSession->specializeType(type, specializationArgs, specializationArgCount, outDiagnostics);
         return pTypeReflection;
     }
@@ -101,7 +101,7 @@ namespace SlangCapture
         slang::LayoutRules     rules,
         ISlangBlob**    outDiagnostics)
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getTypeLayout");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         slang::TypeLayoutReflection* pTypeLayoutReflection = m_actualSession->getTypeLayout(type, targetIndex, rules, outDiagnostics);
         return pTypeLayoutReflection;
     }
@@ -111,14 +111,14 @@ namespace SlangCapture
         slang::ContainerType containerType,
         ISlangBlob** outDiagnostics)
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getContainerType");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         slang::TypeReflection* pTypeReflection = m_actualSession->getContainerType(elementType, containerType, outDiagnostics);
         return pTypeReflection;
     }
 
     SLANG_NO_THROW slang::TypeReflection* SessionCapture::getDynamicType()
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getDynamicType");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         slang::TypeReflection* pTypeReflection = m_actualSession->getDynamicType();
         return pTypeReflection;
     }
@@ -127,7 +127,7 @@ namespace SlangCapture
         slang::TypeReflection* type,
         ISlangBlob** outNameBlob)
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getTypeRTTIMangledName");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         SlangResult result = m_actualSession->getTypeRTTIMangledName(type, outNameBlob);
         return result;
     }
@@ -137,7 +137,7 @@ namespace SlangCapture
         slang::TypeReflection* interfaceType,
         ISlangBlob** outNameBlob)
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getTypeConformanceWitnessMangledName");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         SlangResult result = m_actualSession->getTypeConformanceWitnessMangledName(type, interfaceType, outNameBlob);
         return result;
     }
@@ -147,7 +147,7 @@ namespace SlangCapture
         slang::TypeReflection* interfaceType,
         uint32_t*              outId)
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getTypeConformanceWitnessSequentialID");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         SlangResult result = m_actualSession->getTypeConformanceWitnessSequentialID(type, interfaceType, outId);
         return result;
     }
@@ -159,7 +159,7 @@ namespace SlangCapture
         SlangInt conformanceIdOverride,
         ISlangBlob** outDiagnostics)
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::createTypeConformanceComponentType");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         SlangResult result = m_actualSession->createTypeConformanceComponentType(type, interfaceType, outConformance, conformanceIdOverride, outDiagnostics);
         return result;
     }
@@ -167,28 +167,28 @@ namespace SlangCapture
     SLANG_NO_THROW SlangResult SessionCapture::createCompileRequest(
         SlangCompileRequest**   outCompileRequest)
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::createCompileRequest");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         SlangResult result = m_actualSession->createCompileRequest(outCompileRequest);
         return result;
     }
 
     SLANG_NO_THROW SlangInt SessionCapture::getLoadedModuleCount()
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getLoadedModuleCount");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         SlangInt count = m_actualSession->getLoadedModuleCount();
         return count;
     }
 
     SLANG_NO_THROW slang::IModule* SessionCapture::getLoadedModule(SlangInt index)
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getLoadedModule");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         slang::IModule* pModule = m_actualSession->getLoadedModule(index);
         return pModule;
     }
 
     SLANG_NO_THROW bool SessionCapture::isBinaryModuleUpToDate(const char* modulePath, slang::IBlob* binaryModuleBlob)
     {
-        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::isBinaryModuleUpToDate");
+        slangCaptureLog(LogLevel::Verbose, "%s\n", __func__);
         bool result = m_actualSession->isBinaryModuleUpToDate(modulePath, binaryModuleBlob);
         return result;
     }

--- a/source/slang-capture-replay/slang-session.cpp
+++ b/source/slang-capture-replay/slang-session.cpp
@@ -1,0 +1,196 @@
+#include "capture_utility.h"
+#include "slang-session.h"
+
+namespace SlangCapture
+{
+
+    SessionCapture::SessionCapture(slang::ISession* session)
+        : m_actualSession(session)
+    {
+        assert(m_actualSession);
+        slangCaptureLog(LogLevel::Verbose, "%s: %p\n", "Session", session);
+    }
+
+    SessionCapture::~SessionCapture()
+    {
+        m_actualSession->release();
+    }
+
+    ISlangUnknown* SessionCapture::getInterface(const Guid& guid)
+    {
+        if(guid == ISlangUnknown::getTypeGuid() || guid == ISession::getTypeGuid())
+            return asExternal(this);
+
+        return nullptr;
+    }
+
+    SLANG_NO_THROW slang::IGlobalSession* SessionCapture::getGlobalSession()
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getGlobalSession");
+        slang::IGlobalSession* pGlobalSession = m_actualSession->getGlobalSession();
+        return pGlobalSession;
+    }
+
+    SLANG_NO_THROW slang::IModule* SessionCapture::loadModule(
+        const char* moduleName,
+        slang::IBlob**     outDiagnostics)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::loadModule");
+        slang::IModule* pModule = m_actualSession->loadModule(moduleName, outDiagnostics);
+        return pModule;
+    }
+
+    SLANG_NO_THROW slang::IModule* SessionCapture::loadModuleFromIRBlob(
+        const char* moduleName,
+        const char* path,
+        slang::IBlob* source,
+        slang::IBlob** outDiagnostics)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::loadModuleFromIRBlob");
+        slang::IModule* pModule = m_actualSession->loadModuleFromIRBlob(moduleName, path, source, outDiagnostics);
+        return pModule;
+    }
+
+    SLANG_NO_THROW slang::IModule* SessionCapture::loadModuleFromSource(
+        const char* moduleName,
+        const char* path,
+        slang::IBlob* source,
+        slang::IBlob** outDiagnostics)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::loadModuleFromSource");
+        slang::IModule* pModule = m_actualSession->loadModuleFromSource(moduleName, path, source, outDiagnostics);
+        return pModule;
+    }
+
+    SLANG_NO_THROW slang::IModule* SessionCapture::loadModuleFromSourceString(
+        const char* moduleName,
+        const char* path,
+        const char* string,
+        slang::IBlob** outDiagnostics)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::loadModuleFromSourceString");
+        slang::IModule* pModule = m_actualSession->loadModuleFromSourceString(moduleName, path, string, outDiagnostics);
+        return pModule;
+    }
+
+    SLANG_NO_THROW SlangResult SessionCapture::createCompositeComponentType(
+        slang::IComponentType* const*   componentTypes,
+        SlangInt                        componentTypeCount,
+        slang::IComponentType**         outCompositeComponentType,
+        ISlangBlob**                    outDiagnostics)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::createCompositeComponentType");
+        SlangResult result = m_actualSession->createCompositeComponentType(componentTypes, componentTypeCount, outCompositeComponentType, outDiagnostics);
+        return result;
+    }
+
+    SLANG_NO_THROW slang::TypeReflection* SessionCapture::specializeType(
+        slang::TypeReflection*          type,
+        slang::SpecializationArg const* specializationArgs,
+        SlangInt                        specializationArgCount,
+        ISlangBlob**                    outDiagnostics)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::specializeType");
+        slang::TypeReflection* pTypeReflection = m_actualSession->specializeType(type, specializationArgs, specializationArgCount, outDiagnostics);
+        return pTypeReflection;
+    }
+
+    SLANG_NO_THROW slang::TypeLayoutReflection* SessionCapture::getTypeLayout(
+        slang::TypeReflection* type,
+        SlangInt               targetIndex,
+        slang::LayoutRules     rules,
+        ISlangBlob**    outDiagnostics)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getTypeLayout");
+        slang::TypeLayoutReflection* pTypeLayoutReflection = m_actualSession->getTypeLayout(type, targetIndex, rules, outDiagnostics);
+        return pTypeLayoutReflection;
+    }
+
+    SLANG_NO_THROW slang::TypeReflection* SessionCapture::getContainerType(
+        slang::TypeReflection* elementType,
+        slang::ContainerType containerType,
+        ISlangBlob** outDiagnostics)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getContainerType");
+        slang::TypeReflection* pTypeReflection = m_actualSession->getContainerType(elementType, containerType, outDiagnostics);
+        return pTypeReflection;
+    }
+
+    SLANG_NO_THROW slang::TypeReflection* SessionCapture::getDynamicType()
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getDynamicType");
+        slang::TypeReflection* pTypeReflection = m_actualSession->getDynamicType();
+        return pTypeReflection;
+    }
+
+    SLANG_NO_THROW SlangResult SessionCapture::getTypeRTTIMangledName(
+        slang::TypeReflection* type,
+        ISlangBlob** outNameBlob)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getTypeRTTIMangledName");
+        SlangResult result = m_actualSession->getTypeRTTIMangledName(type, outNameBlob);
+        return result;
+    }
+
+    SLANG_NO_THROW SlangResult SessionCapture::getTypeConformanceWitnessMangledName(
+        slang::TypeReflection* type,
+        slang::TypeReflection* interfaceType,
+        ISlangBlob** outNameBlob)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getTypeConformanceWitnessMangledName");
+        SlangResult result = m_actualSession->getTypeConformanceWitnessMangledName(type, interfaceType, outNameBlob);
+        return result;
+    }
+
+    SLANG_NO_THROW SlangResult SessionCapture::getTypeConformanceWitnessSequentialID(
+        slang::TypeReflection* type,
+        slang::TypeReflection* interfaceType,
+        uint32_t*              outId)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getTypeConformanceWitnessSequentialID");
+        SlangResult result = m_actualSession->getTypeConformanceWitnessSequentialID(type, interfaceType, outId);
+        return result;
+    }
+
+    SLANG_NO_THROW SlangResult SessionCapture::createTypeConformanceComponentType(
+        slang::TypeReflection* type,
+        slang::TypeReflection* interfaceType,
+        slang::ITypeConformance** outConformance,
+        SlangInt conformanceIdOverride,
+        ISlangBlob** outDiagnostics)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::createTypeConformanceComponentType");
+        SlangResult result = m_actualSession->createTypeConformanceComponentType(type, interfaceType, outConformance, conformanceIdOverride, outDiagnostics);
+        return result;
+    }
+
+    SLANG_NO_THROW SlangResult SessionCapture::createCompileRequest(
+        SlangCompileRequest**   outCompileRequest)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::createCompileRequest");
+        SlangResult result = m_actualSession->createCompileRequest(outCompileRequest);
+        return result;
+    }
+
+    SLANG_NO_THROW SlangInt SessionCapture::getLoadedModuleCount()
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getLoadedModuleCount");
+        SlangInt count = m_actualSession->getLoadedModuleCount();
+        return count;
+    }
+
+    SLANG_NO_THROW slang::IModule* SessionCapture::getLoadedModule(SlangInt index)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::getLoadedModule");
+        slang::IModule* pModule = m_actualSession->getLoadedModule(index);
+        return pModule;
+    }
+
+    SLANG_NO_THROW bool SessionCapture::isBinaryModuleUpToDate(const char* modulePath, slang::IBlob* binaryModuleBlob)
+    {
+        slangCaptureLog(LogLevel::Verbose, "%s\n", "SessionCapture::isBinaryModuleUpToDate");
+        bool result = m_actualSession->isBinaryModuleUpToDate(modulePath, binaryModuleBlob);
+        return result;
+    }
+
+} // namespace SlangCapture

--- a/source/slang-capture-replay/slang-session.h
+++ b/source/slang-capture-replay/slang-session.h
@@ -1,0 +1,99 @@
+#ifndef SLANG_SESSION_H
+#define SLANG_SESSION_H
+
+#include "../../slang-com-ptr.h"
+#include "../../slang.h"
+#include "../../slang-com-helper.h"
+#include "../core/slang-smart-pointer.h"
+#include "../slang/slang-compiler.h"
+
+namespace SlangCapture
+{
+    using namespace Slang;
+    class SessionCapture: public RefObject, public slang::ISession
+    {
+    public:
+        SLANG_REF_OBJECT_IUNKNOWN_ALL
+        ISlangUnknown* getInterface(const Guid& guid);
+
+        explicit SessionCapture(slang::ISession* session);
+        ~SessionCapture();
+
+        SLANG_NO_THROW slang::IGlobalSession* getGlobalSession() override;
+        SLANG_NO_THROW slang::IModule* loadModule(
+            const char* moduleName,
+            slang::IBlob**     outDiagnostics = nullptr) override;
+        slang::IModule* loadModuleFromBlob(
+            const char* moduleName,
+            const char* path,
+            slang::IBlob* source,
+            ModuleBlobType blobType,
+            slang::IBlob** outDiagnostics = nullptr);
+        SLANG_NO_THROW slang::IModule* loadModuleFromIRBlob(
+            const char* moduleName,
+            const char* path,
+            slang::IBlob* source,
+            slang::IBlob** outDiagnostics = nullptr) override;
+        SLANG_NO_THROW slang::IModule* loadModuleFromSource(
+            const char* moduleName,
+            const char* path,
+            slang::IBlob* source,
+            slang::IBlob** outDiagnostics = nullptr) override;
+        SLANG_NO_THROW slang::IModule* loadModuleFromSourceString(
+            const char* moduleName,
+            const char* path,
+            const char* string,
+            slang::IBlob** outDiagnostics = nullptr) override;
+        SLANG_NO_THROW SlangResult createCompositeComponentType(
+            slang::IComponentType* const*   componentTypes,
+            SlangInt                        componentTypeCount,
+            slang::IComponentType**         outCompositeComponentType,
+            ISlangBlob**                    outDiagnostics = nullptr) override;
+        SLANG_NO_THROW slang::TypeReflection* specializeType(
+            slang::TypeReflection*          type,
+            slang::SpecializationArg const* specializationArgs,
+            SlangInt                        specializationArgCount,
+            ISlangBlob**                    outDiagnostics = nullptr) override;
+        SLANG_NO_THROW slang::TypeLayoutReflection* getTypeLayout(
+            slang::TypeReflection* type,
+            SlangInt               targetIndex = 0,
+            slang::LayoutRules     rules = slang::LayoutRules::Default,
+            ISlangBlob**    outDiagnostics = nullptr) override;
+        SLANG_NO_THROW slang::TypeReflection* getContainerType(
+            slang::TypeReflection* elementType,
+            slang::ContainerType containerType,
+            ISlangBlob** outDiagnostics = nullptr) override;
+        SLANG_NO_THROW slang::TypeReflection* getDynamicType() override;
+        SLANG_NO_THROW SlangResult getTypeRTTIMangledName(
+            slang::TypeReflection* type,
+            ISlangBlob** outNameBlob) override;
+        SLANG_NO_THROW SlangResult getTypeConformanceWitnessMangledName(
+            slang::TypeReflection* type,
+            slang::TypeReflection* interfaceType,
+            ISlangBlob** outNameBlob) override;
+        SLANG_NO_THROW SlangResult getTypeConformanceWitnessSequentialID(
+            slang::TypeReflection* type,
+            slang::TypeReflection* interfaceType,
+            uint32_t*              outId) override;
+        SLANG_NO_THROW SlangResult createTypeConformanceComponentType(
+            slang::TypeReflection* type,
+            slang::TypeReflection* interfaceType,
+            slang::ITypeConformance** outConformance,
+            SlangInt conformanceIdOverride,
+            ISlangBlob** outDiagnostics) override;
+        SLANG_NO_THROW SlangResult createCompileRequest(
+            SlangCompileRequest**   outCompileRequest) override;
+        SLANG_NO_THROW SlangInt getLoadedModuleCount() override;
+        SLANG_NO_THROW slang::IModule* getLoadedModule(SlangInt index) override;
+        SLANG_NO_THROW bool isBinaryModuleUpToDate(const char* modulePath, slang::IBlob* binaryModuleBlob) override;
+
+    private:
+        SLANG_FORCE_INLINE slang::ISession* asExternal(SessionCapture* session)
+        {
+            return static_cast<slang::ISession*>(session);
+        }
+        slang::ISession* m_actualSession = nullptr;
+    };
+}
+
+#endif // SLANG_SESSION_H

--- a/source/slang-capture-replay/slang-session.h
+++ b/source/slang-capture-replay/slang-session.h
@@ -19,80 +19,80 @@ namespace SlangCapture
         explicit SessionCapture(slang::ISession* session);
         ~SessionCapture();
 
-        SLANG_NO_THROW slang::IGlobalSession* getGlobalSession() override;
-        SLANG_NO_THROW slang::IModule* loadModule(
+        SLANG_NO_THROW slang::IGlobalSession* SLANG_MCALL getGlobalSession() override;
+        SLANG_NO_THROW slang::IModule* SLANG_MCALL loadModule(
             const char* moduleName,
             slang::IBlob**     outDiagnostics = nullptr) override;
-        slang::IModule* loadModuleFromBlob(
+        slang::IModule* SLANG_MCALL loadModuleFromBlob(
             const char* moduleName,
             const char* path,
             slang::IBlob* source,
             ModuleBlobType blobType,
             slang::IBlob** outDiagnostics = nullptr);
-        SLANG_NO_THROW slang::IModule* loadModuleFromIRBlob(
+        SLANG_NO_THROW slang::IModule* SLANG_MCALL loadModuleFromIRBlob(
             const char* moduleName,
             const char* path,
             slang::IBlob* source,
             slang::IBlob** outDiagnostics = nullptr) override;
-        SLANG_NO_THROW slang::IModule* loadModuleFromSource(
+        SLANG_NO_THROW slang::IModule* SLANG_MCALL loadModuleFromSource(
             const char* moduleName,
             const char* path,
             slang::IBlob* source,
             slang::IBlob** outDiagnostics = nullptr) override;
-        SLANG_NO_THROW slang::IModule* loadModuleFromSourceString(
+        SLANG_NO_THROW slang::IModule* SLANG_MCALL loadModuleFromSourceString(
             const char* moduleName,
             const char* path,
             const char* string,
             slang::IBlob** outDiagnostics = nullptr) override;
-        SLANG_NO_THROW SlangResult createCompositeComponentType(
+        SLANG_NO_THROW SlangResult SLANG_MCALL createCompositeComponentType(
             slang::IComponentType* const*   componentTypes,
             SlangInt                        componentTypeCount,
             slang::IComponentType**         outCompositeComponentType,
             ISlangBlob**                    outDiagnostics = nullptr) override;
-        SLANG_NO_THROW slang::TypeReflection* specializeType(
+        SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL specializeType(
             slang::TypeReflection*          type,
             slang::SpecializationArg const* specializationArgs,
             SlangInt                        specializationArgCount,
             ISlangBlob**                    outDiagnostics = nullptr) override;
-        SLANG_NO_THROW slang::TypeLayoutReflection* getTypeLayout(
+        SLANG_NO_THROW slang::TypeLayoutReflection* SLANG_MCALL getTypeLayout(
             slang::TypeReflection* type,
             SlangInt               targetIndex = 0,
             slang::LayoutRules     rules = slang::LayoutRules::Default,
             ISlangBlob**    outDiagnostics = nullptr) override;
-        SLANG_NO_THROW slang::TypeReflection* getContainerType(
+        SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL getContainerType(
             slang::TypeReflection* elementType,
             slang::ContainerType containerType,
             ISlangBlob** outDiagnostics = nullptr) override;
-        SLANG_NO_THROW slang::TypeReflection* getDynamicType() override;
-        SLANG_NO_THROW SlangResult getTypeRTTIMangledName(
+        SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL getDynamicType() override;
+        SLANG_NO_THROW SlangResult SLANG_MCALL getTypeRTTIMangledName(
             slang::TypeReflection* type,
             ISlangBlob** outNameBlob) override;
-        SLANG_NO_THROW SlangResult getTypeConformanceWitnessMangledName(
+        SLANG_NO_THROW SlangResult SLANG_MCALL getTypeConformanceWitnessMangledName(
             slang::TypeReflection* type,
             slang::TypeReflection* interfaceType,
             ISlangBlob** outNameBlob) override;
-        SLANG_NO_THROW SlangResult getTypeConformanceWitnessSequentialID(
+        SLANG_NO_THROW SlangResult SLANG_MCALL getTypeConformanceWitnessSequentialID(
             slang::TypeReflection* type,
             slang::TypeReflection* interfaceType,
             uint32_t*              outId) override;
-        SLANG_NO_THROW SlangResult createTypeConformanceComponentType(
+        SLANG_NO_THROW SlangResult SLANG_MCALL createTypeConformanceComponentType(
             slang::TypeReflection* type,
             slang::TypeReflection* interfaceType,
             slang::ITypeConformance** outConformance,
             SlangInt conformanceIdOverride,
             ISlangBlob** outDiagnostics) override;
-        SLANG_NO_THROW SlangResult createCompileRequest(
+        SLANG_NO_THROW SlangResult SLANG_MCALL createCompileRequest(
             SlangCompileRequest**   outCompileRequest) override;
-        SLANG_NO_THROW SlangInt getLoadedModuleCount() override;
-        SLANG_NO_THROW slang::IModule* getLoadedModule(SlangInt index) override;
-        SLANG_NO_THROW bool isBinaryModuleUpToDate(const char* modulePath, slang::IBlob* binaryModuleBlob) override;
+        SLANG_NO_THROW SlangInt SLANG_MCALL getLoadedModuleCount() override;
+        SLANG_NO_THROW slang::IModule* SLANG_MCALL getLoadedModule(SlangInt index) override;
+        SLANG_NO_THROW bool SLANG_MCALL isBinaryModuleUpToDate(const char* modulePath, slang::IBlob* binaryModuleBlob) override;
 
     private:
         SLANG_FORCE_INLINE slang::ISession* asExternal(SessionCapture* session)
         {
             return static_cast<slang::ISession*>(session);
         }
-        slang::ISession* m_actualSession = nullptr;
+        Slang::ComPtr<slang::ISession> m_actualSession;
     };
 }
 

--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -159,6 +159,9 @@ set(SLANG_LOOKUP_GENERATOR_OUTPUT_DIR
 set(SLANG_LOOKUP_GENERATED_SOURCE
     "${SLANG_LOOKUP_GENERATOR_OUTPUT_DIR}/slang-lookup-GLSLstd450.cpp"
 )
+set(SLANG_CAPATURE_REPLAY_SYSTEM
+    "${slang_SOURCE_DIR}/source/slang-capture-replay"
+)
 add_custom_command(
     OUTPUT ${SLANG_LOOKUP_GENERATED_SOURCE}
     COMMAND
@@ -192,6 +195,7 @@ slang_add_target(
     .
     OBJECT
     TARGET_NAME slang-no-embedded-stdlib
+    EXTRA_SOURCE_DIRS ${SLANG_CAPATURE_REPLAY_SYSTEM}
     EXCLUDE_FROM_ALL
     EXTRA_COMPILE_DEFINITIONS_PUBLIC SLANG_STATIC
     LINK_WITH_PRIVATE
@@ -244,6 +248,7 @@ target_include_directories(
 slang_add_target(
     .
     ${SLANG_LIB_TYPE}
+    EXTRA_SOURCE_DIRS ${SLANG_CAPATURE_REPLAY_SYSTEM}
     LINK_WITH_PRIVATE
         core
         compiler-core

--- a/source/slang/slang-api.cpp
+++ b/source/slang/slang-api.cpp
@@ -5,6 +5,8 @@
 #include "slang-repro.h"
 
 #include "../core/slang-shared-library.h"
+#include "../slang-capture-replay/slang-global-session.h"
+#include "../slang-capture-replay/capture_utility.h"
 
 // implementation of C interface
 
@@ -116,7 +118,18 @@ SLANG_API SlangResult slang_createGlobalSession(
         }
     }
 
-    *outGlobalSession = globalSession.detach();
+    // Check if the SLANG_CAPTURE_ENABLE_ENV is enabled
+    if (SlangCapture::isCaptureLayerEnabled())
+    {
+        SlangCapture::GlobalSessionCapture* globalSessionCapture =
+            new SlangCapture::GlobalSessionCapture(globalSession.detach());
+        Slang::ComPtr<SlangCapture::GlobalSessionCapture> result(globalSessionCapture);
+        *outGlobalSession = result.detach();
+    }
+    else
+    {
+        *outGlobalSession = globalSession.detach();
+    }
 
 #ifdef SLANG_ENABLE_IR_BREAK_ALLOC
     // Reset inst debug alloc counter to 0 so IRInsts for user code always starts from 0.


### PR DESCRIPTION
- Add global session, filesystem, and session capture interface classes: GlobalSessionCapture for IGlobalSession FileSystemCapture for ISlangFileSystemExt SessionCapture for ISession

- Add environment variables to enable it The 2 variables are SLANG_CAPTURE_LAYER and SLANG_CAPTURE_LOG_LEVEL

    SLANG_CAPTURE_LAYER:

    In slang_createGlobalSession(), after the compiling/loading stdlib,
    we will check the capture environment variable, if it's set to 1,
    we will create a GlobalSessionCapture object and return to user
    code.

    SLANG_CAPTURE_LOG_LEVEL: This is to set the log level, user can
    choose the loglevel to debug. (We can remove this when the feature
    is fully implemented).

- Update premake file to add the capture/replay source folder