### PR TITLE
Fix NonUniformResourceIndex legalization for SPIRV.

### DIFF
--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -1215,7 +1215,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                     break;
                 case kIROp_GetElementPtr:
                     // Ignore when `NonUniformResourceIndex` is not on the index
-                    if (user->getOperand(0)->getOp() != kIROp_NonUniformResourceIndex)
+                    if (user->getOperand(1) == inst)
                     {
                         // Replace gep(pArray, nonUniformRes(x)), into nonUniformRes(gep(pArray, x))
                         newUser = builder.emitElementAddress(user->getFullType(), user->getOperand(0), inst->getOperand(0));
@@ -1282,12 +1282,10 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             {
                 IRBuilder builder(operand);
                 builder.addSPIRVNonUniformResourceDecoration(operand);
-                inst->replaceUsesWith(operand);
-                inst->removeAndDeallocate();
             }
+            inst->replaceUsesWith(operand);
+            inst->removeAndDeallocate();
         }
-        nonUniformResourceIndexInst->removeFromParent();
-        m_instsToRemove.add(nonUniformResourceIndexInst);
     }
 
     void processImageSubscript(IRImageSubscript* subscript)

--- a/tests/bugs/gh-4131.slang
+++ b/tests/bugs/gh-4131.slang
@@ -1,0 +1,29 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+
+struct TypeA {
+  float4 placeholder;
+};
+struct TypeB {
+  float4 placeholder;
+};
+
+[[vk::binding(0, 0)]]
+StructuredBuffer<TypeA> a_buffers[] : register(t0, space0);
+[[vk::binding(0, 1)]]
+StructuredBuffer<TypeB> b_buffer : register(t0, space0);
+
+struct VertexIn {
+  int32_t vert_idx : SV_VertexID;
+  [[KnownBuiltin("DrawIndex")]]
+  uint32_t draw_idx : POSITION0;
+};
+
+[shader("vertex")]
+float4 vert(VertexIn i) : SV_POSITION {
+  // Proper usage of NonUniformResourceIndex works fine
+  float4 a =
+      a_buffers[NonUniformResourceIndex(i.draw_idx)][i.vert_idx].placeholder;
+  // Incorrect usage but dxc compiles this with no warning  
+  float4 b = b_buffer[NonUniformResourceIndex(i.draw_idx)].placeholder;
+  return a + b;
+}

--- a/tests/bugs/gh-4131.slang
+++ b/tests/bugs/gh-4131.slang
@@ -1,5 +1,7 @@
 //TEST:SIMPLE(filecheck=CHECK): -target spirv
 
+//CHECK: OpEntryPoint
+
 struct TypeA {
   float4 placeholder;
 };


### PR DESCRIPTION
Fixes #4131.

The issue is that if `NonUniformResourceIndex()` is not decorating a diverging resource handle, we should ignore and remove it instead of leaving the inst in the IR module after legalization.