### PR TITLE
Fix crash in obfuscation

### DIFF
--- a/source/slang/slang-ir-obfuscate-loc.cpp
+++ b/source/slang/slang-ir-obfuscate-loc.cpp
@@ -68,6 +68,11 @@ SlangResult obfuscateModuleLocs(IRModule* module, SourceManager* sourceManager)
 
     // Find all of the instructions with source locs
     _findInstsRec(module->getModuleInst(), instWithLocs);
+    if (instWithLocs.getCount() == 0)
+    {
+        // Nothing to do
+        return SLANG_OK;
+    }
 
     // Sort them
     instWithLocs.sort();
@@ -233,8 +238,8 @@ SlangResult obfuscateModuleLocs(IRModule* module, SourceManager* sourceManager)
     }
 
     // We can now just set all the new locs in the instructions
+    if(const LocPair* curPair = locPairs.getBuffer())
     {
-        const LocPair* curPair = locPairs.getBuffer();
         LocPair pair = *curPair;
 
         for (const auto& instWithLoc : instWithLocs)


### PR DESCRIPTION
Slang crashes during obfuscation because of referencing the nullptr pointer. Add the checking.

In addition, above situation happens when user provide an empty slang shader with '-obfuscate' option, we shouldn't do anything in that case.

So add an early return in obfuscateModuleLocs if no IR code is actually generated.