### PR TITLE
[gfx] specify resource view buffer range in bytes

### DIFF
--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -51,7 +51,7 @@ jobs:
         
         MSBuild.exe slang.sln -v:m -m -property:Configuration=${{matrix.configuration}} -property:Platform=${{matrix.platform}} -property:WindowsTargetPlatformVersion=10.0.19041.0 -maxcpucount:12
 
-        Copy-Item -Path '.\bin\windows-${{matrix.platform}}\${{matrix.configuration}}\*' -Destination '.\FalcorBin\build\windows-vs2022\bin\Release\' -Recurse -Exclude ("*.pdb")
+        Copy-Item -Path '.\bin\windows-${{matrix.platform}}\${{matrix.configuration}}\*' -Destination '.\FalcorBin\build\windows-vs2022\bin\Release\' -Recurse -Exclude ("*.pdb", "gfx.dll")
     - name: falcor-unit-test
       run: |
         $ErrorActionPreference = "SilentlyContinue"

--- a/examples/autodiff-texture/main.cpp
+++ b/examples/autodiff-texture/main.cpp
@@ -246,7 +246,6 @@ struct AutoDiffTexture : public WindowedAppBase
     {
         IResourceView::Desc desc = {};
         desc.type = IResourceView::Type::UnorderedAccess;
-        desc.bufferElementSize = 0;
         return gDevice->createBufferView(buffer, nullptr, desc);
     }
     ComPtr<gfx::IResourceView> createUAV(ITextureResource* texture, int level)

--- a/examples/ray-tracing-pipeline/main.cpp
+++ b/examples/ray-tracing-pipeline/main.cpp
@@ -318,6 +318,7 @@ Slang::Result initialize()
     IBufferResource::Desc primitiveBufferDesc;
     primitiveBufferDesc.type = IResource::Type::Buffer;
     primitiveBufferDesc.sizeInBytes = kPrimitiveCount * sizeof(Primitive);
+    primitiveBufferDesc.elementSize = sizeof(Primitive);
     primitiveBufferDesc.defaultState = ResourceState::ShaderResource;
     gPrimitiveBuffer = gDevice->createBufferResource(primitiveBufferDesc, &kPrimitiveData[0]);
     if (!gPrimitiveBuffer)
@@ -326,7 +327,6 @@ Slang::Result initialize()
     IResourceView::Desc primitiveSRVDesc = {};
     primitiveSRVDesc.format = Format::Unknown;
     primitiveSRVDesc.type = IResourceView::Type::ShaderResource;
-    primitiveSRVDesc.bufferElementSize = sizeof(Primitive);
     gPrimitiveBufferSRV = gDevice->createBufferView(gPrimitiveBuffer, nullptr, primitiveSRVDesc);
 
     IBufferResource::Desc transformBufferDesc;

--- a/examples/ray-tracing/main.cpp
+++ b/examples/ray-tracing/main.cpp
@@ -309,6 +309,7 @@ Slang::Result initialize()
     IBufferResource::Desc primitiveBufferDesc;
     primitiveBufferDesc.type = IResource::Type::Buffer;
     primitiveBufferDesc.sizeInBytes = kPrimitiveCount * sizeof(Primitive);
+    primitiveBufferDesc.elementSize = sizeof(Primitive);
     primitiveBufferDesc.defaultState = ResourceState::ShaderResource;
     gPrimitiveBuffer = gDevice->createBufferResource(primitiveBufferDesc, &kPrimitiveData[0]);
     if (!gPrimitiveBuffer)
@@ -317,7 +318,6 @@ Slang::Result initialize()
     IResourceView::Desc primitiveSRVDesc = {};
     primitiveSRVDesc.format = Format::Unknown;
     primitiveSRVDesc.type = IResourceView::Type::ShaderResource;
-    primitiveSRVDesc.bufferElementSize = sizeof(Primitive);
     gPrimitiveBufferSRV = gDevice->createBufferView(gPrimitiveBuffer, nullptr, primitiveSRVDesc);
 
     IBufferResource::Desc transformBufferDesc;

--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -655,9 +655,8 @@ struct ClearValue
 
 struct BufferRange
 {
-    // TODO: Change to Index and Count?
-    uint64_t firstElement;
-    uint64_t elementCount;
+    Offset offset;  ///< Offset in bytes.
+    Size size;      ///< Size in bytes.
 };
 
 enum class TextureAspect : uint32_t
@@ -872,8 +871,6 @@ public:
         SubresourceRange subresourceRange;
         // Specifies the range of a buffer resource for a ShaderResource/UnorderedAccess view.
         BufferRange bufferRange;
-        // Specifies the element size in bytes of a structured buffer. Pass 0 for a raw buffer view.
-        Size bufferElementSize;
     };
     virtual SLANG_NO_THROW Desc* SLANG_MCALL getViewDesc() = 0;
 

--- a/tools/gfx-unit-test/buffer-barrier-test.cpp
+++ b/tools/gfx-unit-test/buffer-barrier-test.cpp
@@ -47,7 +47,6 @@ namespace gfx_test
         IResourceView::Desc viewDesc = {};
         viewDesc.type = unorderedAccess ? IResourceView::Type::UnorderedAccess : IResourceView::Type::ShaderResource;
         viewDesc.format = Format::Unknown;
-        viewDesc.bufferElementSize = sizeof(float);
         GFX_CHECK_CALL_ABORT(device->createBufferView(
             outBuffer.buffer, nullptr, viewDesc, outBuffer.view.writeRef()));
     }

--- a/tools/gfx-unit-test/nested-parameter-block.cpp
+++ b/tools/gfx-unit-test/nested-parameter-block.cpp
@@ -67,9 +67,8 @@ namespace gfx_test
             IResourceView::Desc srvDesc = {};
             srvDesc.type = IResourceView::Type::ShaderResource;
             srvDesc.format = Format::Unknown;
-            srvDesc.bufferElementSize = sizeof(uint32_t) * 4;
-            srvDesc.bufferRange.elementCount = 1;
-            srvDesc.bufferRange.firstElement = 0;
+            srvDesc.bufferRange.offset = 0;
+            srvDesc.bufferRange.size = sizeof(uint32_t) * 4;
             srvs.add(device->createBufferView(srvBuffers[i], nullptr, srvDesc));
         }
         Slang::ComPtr<IBufferResource> resultBuffer =
@@ -77,9 +76,8 @@ namespace gfx_test
         IResourceView::Desc resultBufferViewDesc = {};
         resultBufferViewDesc.type = IResourceView::Type::UnorderedAccess;
         resultBufferViewDesc.format = Format::Unknown;
-        resultBufferViewDesc.bufferElementSize = sizeof(uint32_t) * 4;
-        resultBufferViewDesc.bufferRange.elementCount = 1;
-        resultBufferViewDesc.bufferRange.firstElement = 0;
+        resultBufferViewDesc.bufferRange.offset = 0;
+        resultBufferViewDesc.bufferRange.size = sizeof(uint32_t) * 4;
         Slang::ComPtr<IResourceView> resultBufferView;
         SLANG_CHECK(SLANG_SUCCEEDED(device->createBufferView(
             resultBuffer, nullptr, resultBufferViewDesc, resultBufferView.writeRef())));

--- a/tools/gfx/d3d12/d3d12-command-encoder.cpp
+++ b/tools/gfx/d3d12/d3d12-command-encoder.cpp
@@ -384,11 +384,14 @@ void ResourceCommandEncoderImpl::clearResourceView(
     case IResourceView::Type::UnorderedAccess:
     {
         ID3D12Resource* d3dResource = nullptr;
+        D3D12Descriptor descriptor = viewImpl->m_descriptor;
         switch (viewImpl->m_resource->getType())
         {
         case IResource::Type::Buffer:
             d3dResource = static_cast<BufferResourceImpl*>(viewImpl->m_resource.Ptr())
                 ->m_resource.getResource();
+            // D3D12 requires a UAV descriptor with zero buffer stride for calling ClearUnorderedAccessViewUint/Float.
+            viewImpl->getBufferDescriptorForBinding(m_commandBuffer->m_renderer, viewImpl, 0, descriptor);
             break;
         default:
             d3dResource = static_cast<TextureResourceImpl*>(viewImpl->m_resource.Ptr())
@@ -407,7 +410,7 @@ void ResourceCommandEncoderImpl::clearResourceView(
         this->m_commandBuffer->m_renderer->m_device->CopyDescriptorsSimple(
             1,
             m_commandBuffer->m_transientHeap->getCurrentViewHeap().getCpuHandle(gpuHandleIndex),
-            viewImpl->m_descriptor.cpuHandle,
+            descriptor.cpuHandle,
             D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
         if (flags & ClearResourceViewFlags::FloatClearValues)
@@ -415,7 +418,7 @@ void ResourceCommandEncoderImpl::clearResourceView(
             m_commandBuffer->m_cmdList->ClearUnorderedAccessViewFloat(
                 m_commandBuffer->m_transientHeap->getCurrentViewHeap().getGpuHandle(
                     gpuHandleIndex),
-                viewImpl->m_descriptor.cpuHandle,
+                descriptor.cpuHandle,
                 d3dResource,
                 clearValue->color.floatValues,
                 0,
@@ -426,7 +429,7 @@ void ResourceCommandEncoderImpl::clearResourceView(
             m_commandBuffer->m_cmdList->ClearUnorderedAccessViewUint(
                 m_commandBuffer->m_transientHeap->getCurrentViewHeap().getGpuHandle(
                     gpuHandleIndex),
-                viewImpl->m_descriptor.cpuHandle,
+                descriptor.cpuHandle,
                 d3dResource,
                 clearValue->color.uintValues,
                 0,

--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -1674,16 +1674,9 @@ Result DeviceImpl::createBufferView(
     viewImpl->m_counterResource = counterResourceImpl;
     viewImpl->m_desc = desc;
 
-    SLANG_RETURN_ON_FAIL(createD3D12BufferDescriptor(
-        resourceImpl,
-        counterResourceImpl,
-        desc,
-        resourceImpl->getDesc()->elementSize,
-        this,
-        m_cpuViewHeap.get(),
-        &viewImpl->m_descriptor));
-    if (viewImpl->m_descriptor.cpuHandle.ptr != 0)
-        viewImpl->m_allocator = m_cpuViewHeap.get();
+    // Buffer view descriptors are created on demand.
+    viewImpl->m_descriptor = {0};
+    viewImpl->m_allocator = m_cpuViewHeap.get();
  
     returnComPtr(outView, viewImpl);
     return SLANG_OK;

--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -1678,6 +1678,7 @@ Result DeviceImpl::createBufferView(
         resourceImpl,
         counterResourceImpl,
         desc,
+        resourceImpl->getDesc()->elementSize,
         this,
         m_cpuViewHeap.get(),
         &viewImpl->m_descriptor));

--- a/tools/gfx/d3d12/d3d12-resource-views.cpp
+++ b/tools/gfx/d3d12/d3d12-resource-views.cpp
@@ -115,6 +115,7 @@ SlangResult createD3D12BufferDescriptor(
             srvDesc.Buffer.FirstElement = offset / sizeInfo.blockSizeInBytes;
             srvDesc.Buffer.NumElements = UINT(size / sizeInfo.blockSizeInBytes);
         }
+
         if (size >= (1ull << 32) - 8)
         {
             // D3D12 does not support view descriptors that has size near 4GB.
@@ -141,14 +142,7 @@ SlangResult ResourceViewInternalImpl::getBufferDescriptorForBinding(
     uint32_t bufferStride,
     D3D12Descriptor& outDescriptor)
 {
-    // If stride is 0, just use the default descriptor.
-    if (bufferStride == 0)
-    {
-        outDescriptor = m_descriptor;
-        return SLANG_OK;
-    }
-
-    // Otherwise, look for an existing descriptor from the cache if it exists.
+    // Look for an existing descriptor from the cache if it exists.
     if (auto descriptor = m_mapBufferStrideToDescriptor.tryGetValue(bufferStride))
     {
         outDescriptor = *descriptor;

--- a/tools/gfx/d3d12/d3d12-resource-views.cpp
+++ b/tools/gfx/d3d12/d3d12-resource-views.cpp
@@ -23,6 +23,7 @@ SlangResult createD3D12BufferDescriptor(
     BufferResourceImpl* buffer,
     BufferResourceImpl* counterBuffer,
     IResourceView::Desc const& desc,
+    uint32_t bufferStride,
     DeviceImpl* device,
     D3D12GeneralExpandingDescriptorHeap* descriptorHeap,
     D3D12Descriptor* outDescriptor)
@@ -31,6 +32,9 @@ SlangResult createD3D12BufferDescriptor(
     auto resourceImpl = (BufferResourceImpl*)buffer;
     auto resourceDesc = *resourceImpl->getDesc();
     const auto counterResourceImpl = static_cast<BufferResourceImpl*>(counterBuffer);
+
+    uint64_t offset = desc.bufferRange.offset;
+    uint64_t size = desc.bufferRange.size == 0 ? buffer->getDesc()->sizeInBytes - offset : desc.bufferRange.size;
 
     switch (desc.type)
     {
@@ -42,39 +46,29 @@ SlangResult createD3D12BufferDescriptor(
         D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
         uavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
         uavDesc.Format = D3DUtil::getMapFormat(desc.format);
-        uavDesc.Buffer.FirstElement = desc.bufferRange.firstElement;
-        uint64_t viewSize = 0;
-        if (desc.bufferElementSize)
+        if (bufferStride)
         {
-            uavDesc.Buffer.StructureByteStride = (UINT)desc.bufferElementSize;
-            uavDesc.Buffer.NumElements =
-                desc.bufferRange.elementCount == 0
-                ? UINT(resourceDesc.sizeInBytes / desc.bufferElementSize)
-                : (UINT)desc.bufferRange.elementCount;
-            viewSize = (uint64_t)desc.bufferElementSize * uavDesc.Buffer.NumElements;
+            uavDesc.Buffer.FirstElement = offset / bufferStride;
+            uavDesc.Buffer.NumElements = UINT(size / bufferStride);
+            uavDesc.Buffer.StructureByteStride = bufferStride;
         }
         else if (desc.format == Format::Unknown)
         {
             uavDesc.Format = DXGI_FORMAT_R32_TYPELESS;
-            uavDesc.Buffer.NumElements = desc.bufferRange.elementCount == 0
-                ? UINT(resourceDesc.sizeInBytes / 4)
-                : UINT(desc.bufferRange.elementCount / 4);
+            uavDesc.Buffer.FirstElement = offset / 4;
+            uavDesc.Buffer.NumElements = UINT(size / 4);
             uavDesc.Buffer.Flags |= D3D12_BUFFER_UAV_FLAG_RAW;
-            viewSize = 4ull * uavDesc.Buffer.NumElements;
         }
         else
         {
             FormatInfo sizeInfo;
             gfxGetFormatInfo(desc.format, &sizeInfo);
             assert(sizeInfo.pixelsPerBlock == 1);
-            uavDesc.Buffer.NumElements =
-                desc.bufferRange.elementCount == 0
-                ? UINT(resourceDesc.sizeInBytes / sizeInfo.blockSizeInBytes)
-                : (UINT)desc.bufferRange.elementCount;
-            viewSize = (uint64_t)uavDesc.Buffer.NumElements * sizeInfo.blockSizeInBytes;
+            uavDesc.Buffer.FirstElement = offset / sizeInfo.blockSizeInBytes;
+            uavDesc.Buffer.NumElements = UINT(size / sizeInfo.blockSizeInBytes);
         }
 
-        if (viewSize >= (1ull << 32) - 8)
+        if (size >= (1ull << 32) - 8)
         {
             // D3D12 does not support view descriptors that has size near 4GB.
             // We will not create actual SRV/UAVs for such large buffers.
@@ -99,40 +93,29 @@ SlangResult createD3D12BufferDescriptor(
         D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
         srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
         srvDesc.Format = D3DUtil::getMapFormat(desc.format);
-        srvDesc.Buffer.StructureByteStride = 0;
-        srvDesc.Buffer.FirstElement = desc.bufferRange.firstElement;
         srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        uint64_t viewSize = 0;
-        if (desc.bufferElementSize)
+        if (bufferStride)
         {
-            srvDesc.Buffer.StructureByteStride = (UINT)desc.bufferElementSize;
-            srvDesc.Buffer.NumElements =
-                desc.bufferRange.elementCount == 0
-                ? UINT(resourceDesc.sizeInBytes / desc.bufferElementSize)
-                : (UINT)desc.bufferRange.elementCount;
-            viewSize = (uint64_t)desc.bufferElementSize * srvDesc.Buffer.NumElements;
+            srvDesc.Buffer.FirstElement = offset / bufferStride;
+            srvDesc.Buffer.NumElements = UINT(size / bufferStride);
+            srvDesc.Buffer.StructureByteStride = bufferStride;
         }
         else if (desc.format == Format::Unknown)
         {
             srvDesc.Format = DXGI_FORMAT_R32_TYPELESS;
-            srvDesc.Buffer.NumElements = desc.bufferRange.elementCount == 0
-                ? UINT(resourceDesc.sizeInBytes / 4)
-                : UINT(desc.bufferRange.elementCount / 4);
+            srvDesc.Buffer.FirstElement = offset / 4;
+            srvDesc.Buffer.NumElements = UINT(size / 4);
             srvDesc.Buffer.Flags |= D3D12_BUFFER_SRV_FLAG_RAW;
-            viewSize = 4ull * srvDesc.Buffer.NumElements;
         }
         else
         {
             FormatInfo sizeInfo;
             gfxGetFormatInfo(desc.format, &sizeInfo);
             assert(sizeInfo.pixelsPerBlock == 1);
-            srvDesc.Buffer.NumElements =
-                desc.bufferRange.elementCount == 0
-                ? UINT(resourceDesc.sizeInBytes / sizeInfo.blockSizeInBytes)
-                : (UINT)desc.bufferRange.elementCount;
-            viewSize = (uint64_t)srvDesc.Buffer.NumElements * sizeInfo.blockSizeInBytes;
+            srvDesc.Buffer.FirstElement = offset / sizeInfo.blockSizeInBytes;
+            srvDesc.Buffer.NumElements = UINT(size / sizeInfo.blockSizeInBytes);
         }
-        if (viewSize >= (1ull << 32) - 8)
+        if (size >= (1ull << 32) - 8)
         {
             // D3D12 does not support view descriptors that has size near 4GB.
             // We will not create actual SRV/UAVs for such large buffers.
@@ -176,39 +159,11 @@ SlangResult ResourceViewInternalImpl::getBufferDescriptorForBinding(
     // the given buffer stride.
     auto bufferResImpl = static_cast<BufferResourceImpl*>(view->m_resource.get());
     auto desc = view->m_desc;
-    uint64_t bufferSize = 0;
-    if (desc.bufferElementSize == 0)
-    {
-        // If buffer element size is 0, we assume the buffer range from original desc is in bytes.
-        bufferSize = desc.bufferRange.elementCount;
-        if (bufferSize == 0)
-        {
-            bufferSize = bufferResImpl->getDesc()->sizeInBytes - desc.bufferRange.firstElement;
-        }
-        desc.bufferElementSize = bufferStride;
-        desc.bufferRange.firstElement /= bufferStride;
-        desc.bufferRange.elementCount = bufferSize / bufferStride;
-    }
-    else
-    {
-        // If buffer element size is not 0, we assume the buffer range from original desc is in elements
-        // of original stride.
-        if (desc.bufferRange.elementCount == 0)
-        {
-            bufferSize = bufferResImpl->getDesc()->sizeInBytes - desc.bufferRange.firstElement * desc.bufferElementSize;
-        }
-        else
-        {
-            bufferSize = desc.bufferRange.elementCount * desc.bufferElementSize;
-        }
-        desc.bufferElementSize = bufferStride;
-        desc.bufferRange.firstElement = desc.bufferRange.firstElement * desc.bufferElementSize / bufferStride;
-        desc.bufferRange.elementCount = bufferSize / bufferStride;
-    }
     SLANG_RETURN_ON_FAIL(createD3D12BufferDescriptor(
         bufferResImpl,
         static_cast<BufferResourceImpl*>(view->m_counterResource.get()),
         desc,
+        bufferStride,
         device,
         m_allocator,
         &outDescriptor));

--- a/tools/gfx/d3d12/d3d12-resource-views.h
+++ b/tools/gfx/d3d12/d3d12-resource-views.h
@@ -39,6 +39,7 @@ SlangResult createD3D12BufferDescriptor(
     BufferResourceImpl* buffer,
     BufferResourceImpl* counterBuffer,
     IResourceView::Desc const& desc,
+    uint32_t bufferStride,
     DeviceImpl* device,
     D3D12GeneralExpandingDescriptorHeap* descriptorHeap,
     D3D12Descriptor* outDescriptor);

--- a/tools/gfx/d3d12/d3d12-shader-object.cpp
+++ b/tools/gfx/d3d12/d3d12-shader-object.cpp
@@ -965,13 +965,17 @@ Result ShaderObjectImpl::setResource(ShaderOffset const& offset, IResourceView* 
     }
 
     auto descriptorSlotIndex = bindingRange.baseIndex + (int32_t)offset.bindingArrayIndex;
-    D3D12Descriptor srcDescriptor = {};
+    D3D12Descriptor srcDescriptor = internalResourceView->m_descriptor;
 
-    SLANG_RETURN_ON_FAIL(internalResourceView->getBufferDescriptorForBinding(
-        static_cast<DeviceImpl*>(m_device.get()),
-        resourceViewImpl,
-        bindingRange.bufferElementStride,
-        srcDescriptor));
+    // Buffer descriptors are created on demand.
+    if (!srcDescriptor.cpuHandle.ptr)
+    {
+        SLANG_RETURN_ON_FAIL(internalResourceView->getBufferDescriptorForBinding(
+            static_cast<DeviceImpl*>(m_device.get()),
+            resourceViewImpl,
+            bindingRange.bufferElementStride,
+            srcDescriptor));
+    }
 
     if (srcDescriptor.cpuHandle.ptr)
     {

--- a/tools/gfx/gfx.slang
+++ b/tools/gfx/gfx.slang
@@ -446,9 +446,8 @@ public struct ClearValue
 
 public struct BufferRange
 {
-    // TODO: Change to Index and Count?
-    public uint64_t firstElement;
-    public uint64_t elementCount;
+    public Offset offset;   ///< Offset in bytes.
+    public Size size;       ///< Size in bytes.
 };
 
 public enum class TextureAspect : uint32_t
@@ -651,8 +650,6 @@ public struct ResourceViewDesc
     public SubresourceRange subresourceRange;
     // Specifies the range of a buffer resource for a ShaderResource/UnorderedAccess view.
     public BufferRange bufferRange;
-    // Specifies the element size in bytes of a structured buffer. Pass 0 for a raw buffer view.
-    public Size bufferElementSize;
 };
 
 [COM("7b6c4926-0884-408c-ad8a-50-3a-8e-23-98-a4")]

--- a/tools/gfx/vulkan/vk-device.cpp
+++ b/tools/gfx/vulkan/vk-device.cpp
@@ -2189,26 +2189,10 @@ Result DeviceImpl::createBufferView(
 {
     auto resourceImpl = (BufferResourceImpl*)buffer;
 
-    // TODO: These should come from the `ResourceView::Desc`
-    auto stride = desc.bufferElementSize;
-    if (stride == 0)
-    {
-        if (desc.format == Format::Unknown)
-        {
-            stride = 1;
-        }
-        else
-        {
-            FormatInfo info;
-            gfxGetFormatInfo(desc.format, &info);
-            stride = info.blockSizeInBytes;
-            assert(info.pixelsPerBlock == 1);
-        }
-    }
-    VkDeviceSize offset = (VkDeviceSize)desc.bufferRange.firstElement * stride;
-    VkDeviceSize size = desc.bufferRange.elementCount == 0
+    VkDeviceSize offset = (VkDeviceSize)desc.bufferRange.offset;
+    VkDeviceSize size = desc.bufferRange.size == 0
         ? (buffer ? resourceImpl->getDesc()->sizeInBytes : 0)
-        : (VkDeviceSize)desc.bufferRange.elementCount * stride;
+        : (VkDeviceSize)desc.bufferRange.size;
 
     // There are two different cases we need to think about for buffers.
     //

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -257,7 +257,6 @@ struct AssignValsFromLayoutContext
         IResourceView::Desc viewDesc = {};
         viewDesc.type = IResourceView::Type::UnorderedAccess;
         viewDesc.format = srcBuffer.format;
-        viewDesc.bufferElementSize = srcVal->bufferDesc.stride;
         auto bufferView = device->createBufferView(bufferResource, counterResource, viewDesc);
         dstCursor.setResource(bufferView);
         maybeAddOutput(dstCursor, srcVal, bufferResource);


### PR DESCRIPTION
- Change `BufferRange` to a range of bytes
- Remove `IResourceView::Desc::bufferElementSize`
- Create D3D12 buffer view descriptors on demand
- Use D3D12 buffer view descriptor with zero struct stride for `ClearUnorderedAccessViewUint/Float`
