### PR TITLE
Fix race-condition and visual artifacts issues

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -945,6 +945,7 @@ extern "C"
             SaveStdLib,
             SaveStdLibBinSource,
             TrackLiveness,
+            LoopInversion,              // bool, enable loop inversion optimization
 
             // Deprecated
             ParameterBlocksUseRegisterSpaces,

--- a/source/core/slang-performance-profiler.cpp
+++ b/source/core/slang-performance-profiler.cpp
@@ -46,7 +46,7 @@ namespace Slang
 
     PerformanceProfiler* Slang::PerformanceProfiler::getProfiler()
     {
-        static PerformanceProfilerImpl profiler = PerformanceProfilerImpl();
+        thread_local static PerformanceProfilerImpl profiler = PerformanceProfilerImpl();
         return &profiler;
     }
 }

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -10839,8 +10839,10 @@ RefPtr<IRModule> generateIRForTranslationUnit(
     // - If sccp is unable to eliminate the outer 'if' then we end up with
     //   duplicated code the the conditional value. Users don't tend to put
     //   huge gobs of code in the conditional expression in loops however.
-
-    invertLoops(module);
+    if (compileRequest->getLinkage()->m_optionSet.getBoolOption(CompilerOptionName::LoopInversion))
+    {
+        invertLoops(module);
+    }
 
     // Next, attempt to promote local variables to SSA
     // temporaries and do basic simplifications.

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -542,6 +542,7 @@ void initCommandOptions(CommandOptions& options)
         { OptionKind::SaveStdLibBinSource, "-save-stdlib-bin-source","-save-stdlib-bin-source <filename>", "Same as -save-stdlib but output "
         "the data as a C array.\n"},
         { OptionKind::TrackLiveness, "-track-liveness", nullptr, "Enable liveness tracking. Places SLANG_LIVE_START, and SLANG_LIVE_END in output source to indicate value liveness." },
+        { OptionKind::LoopInversion, "-loop-inversion", nullptr, "Enable loop inversion in the code-gen optimization. Default is off" },
     };
     _addOptions(makeConstArrayView(internalOpts), options);
 
@@ -1689,6 +1690,7 @@ SlangResult OptionsParser::_parse(
             case OptionKind::IncompleteLibrary:
             case OptionKind::NoHLSLBinding:
             case OptionKind::NoHLSLPackConstantBufferElements:
+            case OptionKind::LoopInversion:
                 linkage->m_optionSet.set(optionKind, true); break;
                 break;
             case OptionKind::MatrixLayoutRow:

--- a/tests/autodiff/path-tracer/pt-loop.slang
+++ b/tests/autodiff/path-tracer/pt-loop.slang
@@ -1,7 +1,7 @@
 //Tests automatic synthesis of Differential type requirement.
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj -output-using-type
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj -output-using-type -Xslang -loop-inversion
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -output-using-type -Xslang -loop-inversion
 
 //TEST_INPUT:ubuffer(data=[0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/autodiff/reverse-while-loop-2.slang
+++ b/tests/autodiff/reverse-while-loop-2.slang
@@ -1,6 +1,6 @@
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj -output-using-type
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj -output-using-type -Xslang -loop-inversion
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -output-using-type -Xslang -loop-inversion
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -output-using-type -shaderobj -Xslang -loop-inversion
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/cross-compile/loop-attribs.slang
+++ b/tests/cross-compile/loop-attribs.slang
@@ -1,7 +1,7 @@
 // loop-attribs.slang
 // Test that loop attributes are correctly emitted to the resulting HLSL.
 
-//TEST:CROSS_COMPILE:-target dxil-assembly  -entry main -stage fragment -profile sm_6_0 
+//TEST:CROSS_COMPILE:-target dxil-assembly  -entry main -stage fragment -profile sm_6_0 -loop-inversion
 
 float4 main() : SV_Target
 {

--- a/tests/ir/loop-inversion.slang
+++ b/tests/ir/loop-inversion.slang
@@ -1,4 +1,4 @@
-//TEST():SIMPLE(filecheck=CHECK):-entry computeMain -stage compute -line-directive-mode none -target hlsl
+//TEST():SIMPLE(filecheck=CHECK):-entry computeMain -stage compute -line-directive-mode none -target hlsl -loop-inversion
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=OUT):-shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=OUT):-dx12 -use-dxil -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=OUT):-cpu -shaderobj -output-using-type


### PR DESCRIPTION
In PerformanceProfiler::getProfiler() we return a static object for the profiler implementation, this is not thread-safe, so change it to thead_local.

There is still some visual artifacts when using slang as the shading language. We don't know the root cause yet, but found out it's related to our loop inversion algorithm. So stage this feature for now, and turn it into an internal option and default off. We will re-enable it after more investigation on this optimization.

File an new issue 4151 to track it.