### PR TITLE
Propagate warning settings on `Linkage` to IR passes.

### DIFF
--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -4309,6 +4309,7 @@ SLANG_NO_THROW SlangResult SLANG_MCALL ComponentType::getEntryPointCode(
     auto targetProgram = getTargetProgram(target);
 
     DiagnosticSink sink(linkage->getSourceManager(), Lexer::sourceLocationLexer);
+    applySettingsToDiagnosticSink(&sink, &sink, linkage->m_optionSet);
     applySettingsToDiagnosticSink(&sink, &sink, m_optionSet);
 
     IArtifact* artifact = targetProgram->getOrCreateEntryPointResult(entryPointIndex, &sink);


### PR DESCRIPTION
Fixes #4155.