### PR TITLE
Implement texture functions for Metal target

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -964,14 +964,16 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,access,isShadow,0,forma
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_spirv, texture_querylod)]
+    [require(glsl_hlsl_metal_spirv, texture_querylod)]
     float CalculateLevelOfDetail(SamplerState s, TextureCoord location)
     {
         __requireComputeDerivative();
         __target_switch
         {
         case hlsl:
-            __intrinsic_asm "CalculateLevelOfDetail";
+            __intrinsic_asm ".CalculateLevelOfDetail";
+        case metal:
+            __intrinsic_asm "$0.calculate_clamped_lod($1, $2)";
         case glsl:
             __intrinsic_asm "textureQueryLod($p, $2).x";
         case spirv:
@@ -984,14 +986,16 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,access,isShadow,0,forma
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_spirv, texture_querylod)]
+    [require(glsl_hlsl_metal_spirv, texture_querylod)]
     float CalculateLevelOfDetailUnclamped(SamplerState s, TextureCoord location)
     {
         __requireComputeDerivative();
         __target_switch
         {
         case hlsl:
-            __intrinsic_asm "CalculateLevelOfDetailUnclamped";
+            __intrinsic_asm ".CalculateLevelOfDetailUnclamped";
+        case metal:
+            __intrinsic_asm "$0.calculate_unclamped_lod($1, $2)";
         case glsl:
             __intrinsic_asm "textureQueryLod($p, $2).y";
         case spirv:
@@ -1008,7 +1012,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 {
     [__readNone]
     [ForceInline]
-    [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
+    [require(cpp_cuda_glsl_hlsl_metal_spirv, texture_sm_4_1_fragment)]
     T Sample(SamplerState s, vector<float, Shape.dimensions+isArray> location)
     {
         __requireComputeDerivative();
@@ -1017,6 +1021,32 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
             case cpp:
             case hlsl:
                 __intrinsic_asm ".Sample";
+            case metal:
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_1D):
+                        __intrinsic_asm "$0.sample($1, ($2).x, uint(($2).y))";
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z))";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "$0.sample($1, ($2).xyz, uint(($2).w))";
+                    }
+                }
+                else
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_1D):
+                    case $(SLANG_TEXTURE_2D):
+                    case $(SLANG_TEXTURE_3D):
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "$0.sample($1, $2)";
+                    }
+                }
+                // TODO: This needs to be handled by the capability system
+                __intrinsic_asm "<invalid intrinsic>";
             case glsl:
                 __intrinsic_asm "$ctexture($p, $2)$z";
             case cuda:
@@ -1062,7 +1092,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_fragment)]
     T Sample(SamplerState s, vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __requireComputeDerivative();
@@ -1071,6 +1101,26 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
             case cpp:
             case hlsl:
                 __intrinsic_asm ".Sample";
+            case metal:
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z), $3)";
+                    }
+                }
+                else
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                    case $(SLANG_TEXTURE_3D):
+                        __intrinsic_asm "$0.sample($1, $2, $3)";
+                    }
+                }
+                // TODO: This needs to be handled by the capability system
+                __intrinsic_asm "<invalid intrinsic>";
             case glsl:
                 __intrinsic_asm "$ctextureOffset($p, $2, $3)$z";
             case spirv:
@@ -1086,7 +1136,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
     [__readNone]
     [ForceInline]
     __glsl_extension(GL_ARB_sparse_texture_clamp)
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_fragment)]
     T Sample(SamplerState s, vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset, float clamp)
     {
         __requireComputeDerivative();
@@ -1095,6 +1145,26 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
             case cpp:
             case hlsl:
                 __intrinsic_asm ".Sample";
+            case metal:
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z), min_lod_clamp($4), $3)";
+                    }
+                }
+                else
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                    case $(SLANG_TEXTURE_3D):
+                        __intrinsic_asm "$0.sample($1, $2, min_lod_clamp($4), $3)";
+                    }
+                }
+                // TODO: This needs to be handled by the capability system
+                __intrinsic_asm "<invalid intrinsic>";
             case glsl:
                 __intrinsic_asm "$ctextureOffsetClampARB($p, $2, $3, $4)$z";
             case spirv:
@@ -1110,7 +1180,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_fragment)]
     T Sample(SamplerState s, vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset, float clamp, out uint status)
     {
         __target_switch
@@ -1124,7 +1194,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_fragment)]
     T SampleBias(SamplerState s, vector<float, Shape.dimensions+isArray> location, float bias)
     {
         __requireComputeDerivative();
@@ -1133,6 +1203,29 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
             case cpp:
             case hlsl:
             __intrinsic_asm ".SampleBias";
+            case metal:
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z), bias($3))";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "$0.sample($1, ($2).xyz, uint(($2).w), bias($3))";
+                    }
+                }
+                else
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                    case $(SLANG_TEXTURE_3D):
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "$0.sample($1, $2, bias($3))";
+                    }
+                }
+                // TODO: This needs to be handled by the capability system
+                __intrinsic_asm "<invalid intrinsic>";
             case glsl:
             __intrinsic_asm "$ctexture($p, $2, $3)$z";
             case spirv:
@@ -1147,7 +1240,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_fragment)]
     T SampleBias(SamplerState s, vector<float, Shape.dimensions+isArray> location, float bias, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __requireComputeDerivative();
@@ -1156,6 +1249,26 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
             case cpp:
             case hlsl:
             __intrinsic_asm ".SampleBias";
+            case metal:
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z), bias($3), $4)";
+                    }
+                }
+                else
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                    case $(SLANG_TEXTURE_3D):
+                        __intrinsic_asm "$0.sample($1, $2, bias($3), $4)";
+                    }
+                }
+                // TODO: This needs to be handled by the capability system
+                __intrinsic_asm "<invalid intrinsic>";
             case glsl:
             __intrinsic_asm "$ctextureOffset($p, $2, $4, $3)$z";
             case spirv:
@@ -1170,7 +1283,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
     float SampleCmp(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue)
     {
         __target_switch
@@ -1190,6 +1303,27 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
             }
         case hlsl:
             __intrinsic_asm ".SampleCmp";
+        case metal:
+            if (isArray == 1)
+            {
+                switch (Shape.flavor)
+                {
+                case $(SLANG_TEXTURE_2D):
+                    __intrinsic_asm "$0.sample_compare($1, ($2).xy, uint(($2).z), $3)";
+                case $(SLANG_TEXTURE_CUBE):
+                    __intrinsic_asm "$0.sample_compare($1, ($2).xyz, uint(($2).w), $3)";
+                }
+            }
+            else
+            {
+                switch (Shape.flavor)
+                {
+                case $(SLANG_TEXTURE_2D):
+                case $(SLANG_TEXTURE_CUBE):
+                    __intrinsic_asm "$0.sample_compare($1, $2, $3)";
+                }
+            }
+            __intrinsic_asm "<invalid intrinsic>";
         case spirv:
             return spirv_asm
             {
@@ -1201,7 +1335,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
     float SampleCmpLevelZero(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue)
     {
         __target_switch
@@ -1217,6 +1351,27 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
             }
         case hlsl:
             __intrinsic_asm ".SampleCmpLevelZero";
+        case metal:
+            if (isArray == 1)
+            {
+                switch (Shape.flavor)
+                {
+                case $(SLANG_TEXTURE_2D):
+                    __intrinsic_asm "$0.sample_compare($1, ($2).xy, uint(($2).z), $3, level(0))";
+                case $(SLANG_TEXTURE_CUBE):
+                    __intrinsic_asm "$0.sample_compare($1, ($2).xyz, uint(($2).w), $3, level(0))";
+                }
+            }
+            else
+            {
+                switch (Shape.flavor)
+                {
+                case $(SLANG_TEXTURE_2D):
+                case $(SLANG_TEXTURE_CUBE):
+                    __intrinsic_asm "$0.sample_compare($1, $2, $3, level(0))";
+                }
+            }
+            __intrinsic_asm "<invalid intrinsic>";
         case spirv:
             const float zeroFloat = 0.0f;
             return spirv_asm
@@ -1229,7 +1384,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
     float SampleCmp(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -1245,6 +1400,24 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
             }
         case hlsl:
             __intrinsic_asm ".SampleCmp";
+        case metal:
+            if (isArray == 1)
+            {
+                switch (Shape.flavor)
+                {
+                case $(SLANG_TEXTURE_2D):
+                    __intrinsic_asm "$0.sample_compare($1, ($2).xy, uint(($2).z), $3, $4)";
+                }
+            }
+            else
+            {
+                switch (Shape.flavor)
+                {
+                case $(SLANG_TEXTURE_2D):
+                    __intrinsic_asm "$0.sample_compare($1, $2, $3, $4)";
+                }
+            }
+            __intrinsic_asm "<invalid intrinsic>";
         case spirv:
             return spirv_asm
             {
@@ -1256,7 +1429,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
     float SampleCmpLevelZero(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -1272,6 +1445,29 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
             }
         case hlsl:
             __intrinsic_asm ".SampleCmpLevelZero";
+        case metal:
+            if (isShadow == 1)
+            {
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                        // T sample_compare(sampler s, float2 coord, uint array, float compare_value, lod_options options, int2 offset = int2(0)) const
+                        __intrinsic_asm "$0.sample_compare($1, ($2).xy, uint(($2).z), $3, level(0), $4)";
+                    }
+                }
+                else
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                        // T sample_compare(sampler s, float2 coord, float compare_value, lod_options options, int2 offset = int2(0)) const
+                        __intrinsic_asm "$0.sample_compare($1, $2, $3, level(0), $4)";
+                    }
+                }
+            }
+            __intrinsic_asm "<invalid intrinsic>";
         case spirv:
             const float zeroFloat = 0.0f;
             return spirv_asm
@@ -1284,14 +1480,39 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
+    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1)]
     T SampleGrad(SamplerState s, vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY)
     {
         __target_switch
         {
             case cpp:
             case hlsl:
-            __intrinsic_asm ".SampleGrad";
+                __intrinsic_asm ".SampleGrad";
+            case metal:
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z), gradient2d($3, $4))";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "$0.sample($1, ($2).xyz, uint(($2).w), gradientcube($3, $4))";
+                    }
+                }
+                else
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "$0.sample($1, $2, gradient2d($3, $4))";
+                    case $(SLANG_TEXTURE_3D):
+                        __intrinsic_asm "$0.sample($1, $2, gradient3d($3, $4))";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "$0.sample($1, $2, gradientcube($3, $4))";
+                    }
+                }
+                // TODO: This needs to be handled by the capability system
+                __intrinsic_asm "<invalid intrinsic>";
             case glsl:
             __intrinsic_asm "$ctextureGrad($p, $2, $3, $4)$z";
             case spirv:
@@ -1306,14 +1527,35 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
+    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1)]
     T SampleGrad(SamplerState s, vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.dimensions> offset)
     {
         __target_switch
         {
             case cpp:
             case hlsl:
-            __intrinsic_asm ".SampleGrad";
+                __intrinsic_asm ".SampleGrad";
+            case metal:
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z), gradient2d($3, $4), $5)";
+                    }
+                }
+                else
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "$0.sample($1, $2, gradient2d($3, $4), $5)";
+                    case $(SLANG_TEXTURE_3D):
+                        __intrinsic_asm "$0.sample($1, $2, gradient3d($3, $4), $5)";
+                    }
+                }
+                // TODO: This needs to be handled by the capability system
+                __intrinsic_asm "<invalid intrinsic>";
             case glsl:
             __intrinsic_asm "$ctextureGradOffset($p, $2, $3, $4, $5)$z";
             case spirv:
@@ -1330,14 +1572,35 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
     [__readNone]
     [ForceInline]
     __glsl_extension(GL_ARB_sparse_texture_clamp)
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
+    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1)]
     T SampleGrad(SamplerState s, vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.dimensions> offset, float lodClamp)
     {
         __target_switch
         {
             case cpp:
             case hlsl:
-            __intrinsic_asm ".SampleGrad";
+                __intrinsic_asm ".SampleGrad";
+            case metal:
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z), gradient2d($3, $4), min_lod_clamp($6), $5)";
+                    }
+                }
+                else
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "$0.sample($1, $2, gradient2d($3, $4), min_lod_clamp($6), $5)";
+                    case $(SLANG_TEXTURE_3D):
+                        __intrinsic_asm "$0.sample($1, $2, gradient3d($3, $4), min_lod_clamp($6), $5)";
+                    }
+                }
+                // TODO: This needs to be handled by the capability system
+                __intrinsic_asm "<invalid intrinsic>";
             case glsl:
             __intrinsic_asm "$ctextureGradOffsetClampARB($p, $2, $3, $4, $5, $6)$z";
             case spirv:
@@ -1353,7 +1616,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1)]
+    [require(cpp_cuda_glsl_hlsl_metal_spirv, texture_sm_4_1)]
     T SampleLevel(SamplerState s, vector<float, Shape.dimensions+isArray> location, float level)
     {
         __target_switch
@@ -1361,6 +1624,29 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
             case cpp:
             case hlsl:
                 __intrinsic_asm ".SampleLevel";
+            case metal:
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z), level($3))";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "$0.sample($1, ($2).xyz, uint(($2).w), level($3))";
+                    }
+                }
+                else
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                    case $(SLANG_TEXTURE_3D):
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "$0.sample($1, $2, level($3))";
+                    }
+                }
+                // TODO: This needs to be handled by the capability system
+                __intrinsic_asm "<invalid intrinsic>";
             case glsl:
                 __intrinsic_asm "$ctextureLod($p, $2, $3)$z";
             case cuda:
@@ -1406,7 +1692,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
+    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1)]
     T SampleLevel(SamplerState s, vector<float, Shape.dimensions+isArray> location, float level, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -1414,6 +1700,28 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
             case cpp:
             case hlsl:
                 __intrinsic_asm ".SampleLevel";
+            case metal:
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z), level($3), $4)";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "$0.sample($1, ($2).xyz, uint(($2).w), level($3), $4)";
+                    }
+                }
+                else
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_2D):
+                    case $(SLANG_TEXTURE_3D):
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "$0.sample($1, $2, level($3), $4)";
+                    }
+                }
+                __intrinsic_asm "<invalid intrinsic>";
             case glsl:
                 __intrinsic_asm "$ctextureLodOffset($p, $2, $3, $4)$z";
             case spirv:
@@ -1439,7 +1747,7 @@ for (int isMS = 0; isMS <= 1; isMS++) {
         if (shapeIndex != kStdlibShapeIndex2D)
             continue;
     }
-    if (isArray)
+    if (isArray == 1)
     {
         if (shapeIndex == kStdlibShapeIndex3D)
             continue;
@@ -1474,13 +1782,77 @@ Array<T,4> __makeArray<T>(T v0, T v1, T v2, T v3);
 // Gather for scalar textures.
 __generic<TElement, T, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let access:int, let isShadow:int, let format:int>
 [ForceInline]
-[require(glsl_spirv, GLSL_400)]
-vector<TElement,4> __glsl_gather(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 0, format> texture, SamplerState s, vector<float, Shape.dimensions+isArray> location, int component)
+[require(glsl_metal_spirv, GLSL_400)]
+vector<TElement,4> __texture_gather(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 0, format> texture, SamplerState s, vector<float, Shape.dimensions+isArray> location, int component)
 {
     __target_switch
     {
     case glsl:
         __intrinsic_asm "textureGather($p, $2, $3)";
+    case metal:
+        if (Shape.flavor == $(SLANG_TEXTURE_2D))
+        {
+            if (isArray == 1)
+            {
+                if (isShadow == 1)
+                {
+                    // Tv gather(sampler s, float2 coord, uint array, int2 offset = int2(0)) const
+                    __intrinsic_asm "$0.gather($1, ($2).xy, as_type<uint>(($2).z))";
+                }
+                else
+                {
+                    // Tv gather(sampler s, float2 coord, uint array, int2 offset = int2(0), component c = component::x) const
+                    __intrinsic_asm "$0.gather($1, ($2).xy, as_type<uint>(($2).z), int2(0), metal::component($3))";
+                }
+            }
+            else
+            {
+                if (isShadow == 1)
+                {
+                    // Tv gather(sampler s, float2 coord, int2 offset = int2(0)) const
+                    __intrinsic_asm "$0.gather($1, $2, 0)";
+                }
+                else
+                {
+                    // Tv gather(sampler s, float2 coord, int2 offset = int2(0), component c = component::x) const
+                    __intrinsic_asm "$0.gather($1, $2, int2(0), metal::component($3))";
+                }
+            }
+        }
+        else if (Shape.flavor == $(SLANG_TEXTURE_CUBE))
+        {
+            if (isArray == 1)
+            {
+                if (isShadow == 1)
+                {
+                    // Tv gather(sampler s, float3 coord, uint array) const
+                    __intrinsic_asm "$0.gather($1, ($2).xyz, as_type<uint>(($2).w))";
+                }
+                else
+                {
+                    // Tv gather(sampler s, float3 coord, uint array, component c = component::x) const
+                    __intrinsic_asm "$0.gather($1, ($2).xyz, as_type<uint>(($2).w), metal::component($3))";
+                }
+            }
+            else
+            {
+                if (isShadow == 1)
+                {
+                    // Tv gather(sampler s, float3 coord) const
+                    __intrinsic_asm "$0.gather($1, $2)";
+                }
+                else
+                {
+                    // Tv gather(sampler s, float3 coord, component c = component::x) const
+                    __intrinsic_asm "$0.gather($1, $2, metal::component($3))";
+                }
+            }
+        }
+        else
+        {
+            // TODO: This needs to be handled by the capability system
+            __intrinsic_asm "<Metal support gather only for 2D and Cube>";
+        }
     case spirv:
         return spirv_asm {
             %sampledImage : __sampledImageType(texture) = OpSampledImage $texture $s;
@@ -1491,7 +1863,7 @@ vector<TElement,4> __glsl_gather(__TextureImpl<T, Shape, isArray, 0, sampleCount
 __generic<TElement, T, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let access:int, let isShadow:int, let format:int>
 [ForceInline]
 [require(glsl_spirv, GLSL_400)]
-vector<TElement,4> __glsl_gather(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 1, format> sampler, vector<float, Shape.dimensions+isArray> location, int component)
+vector<TElement,4> __texture_gather(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 1, format> sampler, vector<float, Shape.dimensions+isArray> location, int component)
 {
     __target_switch
     {
@@ -1505,13 +1877,48 @@ vector<TElement,4> __glsl_gather(__TextureImpl<T, Shape, isArray, 0, sampleCount
 }
 __generic<TElement, T, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let access:int, let isShadow:int, let format:int>
 [ForceInline]
-[require(glsl_spirv, GLSL_400)]
-vector<TElement,4> __glsl_gather_offset(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 0, format> texture, SamplerState s, constexpr vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset, int component)
+[require(glsl_metal_spirv, GLSL_400)]
+vector<TElement,4> __texture_gather_offset(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 0, format> texture, SamplerState s, constexpr vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset, int component)
 {
     __target_switch
     {
     case glsl:
         __intrinsic_asm "textureGatherOffset($p, $2, $3, $4)";
+    case metal:
+        if (Shape.flavor == $(SLANG_TEXTURE_2D))
+        {
+            if (isArray == 1)
+            {
+                if (isShadow == 1)
+                {
+                    // Tv gather(sampler s, float2 coord, uint array, int2 offset = int2(0)) const
+                    __intrinsic_asm "$0.gather($1, ($2).xy, as_type<uint>(($2).z), $3)";
+                }
+                else
+                {
+                    // Tv gather(sampler s, float2 coord, uint array, int2 offset = int2(0), component c = component::x) const
+                    __intrinsic_asm "$0.gather($1, ($2).xy, as_type<uint>(($2).z), $3, metal::component($4))";
+                }
+            }
+            else
+            {
+                if (isShadow == 1)
+                {
+                    // Tv gather(sampler s, float2 coord, int2 offset = int2(0)) const
+                    __intrinsic_asm "$0.gather($1, $2, $3)";
+                }
+                else
+                {
+                    // Tv gather(sampler s, float2 coord, int2 offset = int2(0), component c = component::x) const
+                    __intrinsic_asm "$0.gather($1, $2, $3, metal::component($4))";
+                }
+            }
+        }
+        else
+        {
+            // TODO: This needs to be handled by the capability system
+            __intrinsic_asm "<Metal support gather with offset only for 2D>";
+        }
     case spirv:
         return spirv_asm {
             %sampledImage : __sampledImageType(texture) = OpSampledImage $texture $s;
@@ -1522,7 +1929,7 @@ vector<TElement,4> __glsl_gather_offset(__TextureImpl<T, Shape, isArray, 0, samp
 __generic<TElement, T, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let access:int, let isShadow:int, let format:int>
 [ForceInline]
 [require(glsl_spirv, GLSL_400)]
-vector<TElement,4> __glsl_gather_offset(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 1, format> sampler, vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset, int component)
+vector<TElement,4> __texture_gather_offset(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 1, format> sampler, vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset, int component)
 {
     __target_switch
     {
@@ -1537,7 +1944,7 @@ vector<TElement,4> __glsl_gather_offset(__TextureImpl<T, Shape, isArray, 0, samp
 __generic<TElement, T, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let access:int, let isShadow:int, let format:int>
 [ForceInline]
 [require(glsl_spirv, GLSL_400)]
-vector<TElement,4> __glsl_gather_offsets(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 0, format> texture, SamplerState s, vector<float, Shape.dimensions+isArray> location,
+vector<TElement,4> __texture_gather_offsets(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 0, format> texture, SamplerState s, vector<float, Shape.dimensions+isArray> location,
     constexpr vector<int, Shape.planeDimensions> offset1,
     constexpr vector<int, Shape.planeDimensions> offset2,
     constexpr vector<int, Shape.planeDimensions> offset3,
@@ -1560,7 +1967,7 @@ vector<TElement,4> __glsl_gather_offsets(__TextureImpl<T, Shape, isArray, 0, sam
 __generic<TElement, T, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let access:int, let isShadow:int, let format:int>
 [ForceInline]
 [require(glsl_spirv, GLSL_400)]
-vector<TElement,4> __glsl_gather_offsets(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 1, format> sampler, vector<float, Shape.dimensions+isArray> location,
+vector<TElement,4> __texture_gather_offsets(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 1, format> sampler, vector<float, Shape.dimensions+isArray> location,
     constexpr vector<int, Shape.planeDimensions> offset1,
     constexpr vector<int, Shape.planeDimensions> offset2,
     constexpr vector<int, Shape.planeDimensions> offset3,
@@ -1581,13 +1988,45 @@ vector<TElement,4> __glsl_gather_offsets(__TextureImpl<T, Shape, isArray, 0, sam
 }
 __generic<TElement, T, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let access:int, let isShadow:int, let format:int>
 [ForceInline]
-[require(glsl_spirv, GLSL_400)]
-vector<TElement,4> __glsl_gatherCmp(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 0, format> texture, SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, TElement compareValue)
+[require(glsl_metal_spirv, GLSL_400)]
+vector<TElement,4> __texture_gatherCmp(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 0, format> texture, SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, TElement compareValue)
 {
     __target_switch
     {
     case glsl:
         __intrinsic_asm "textureGather($p, $2, $3)";
+    case metal:
+        if (isShadow == 1)
+        {
+            if (Shape.flavor == $(SLANG_TEXTURE_2D))
+            {
+                if (isArray == 1)
+                {
+                    // Tv gather_compare(sampler s, float2 coord, uint array, float compare_value, int2 offset = int2(0)) const
+                    __intrinsic_asm "$0.gather_compare($1, ($2).xy, as_type<uint>(($2).z), $3)";
+                }
+                else
+                {
+                    // Tv gather_compare(sampler s, float2 coord, float compare_value, int2 offset = int2(0)) const
+                    __intrinsic_asm "$0.gather_compare($1, $2, $3)";
+                }
+            }
+            else if (Shape.flavor == $(SLANG_TEXTURE_CUBE))
+            {
+                if (isArray == 1)
+                {
+                    // Tv gather_compare(sampler s, float3 coord, uint array, float compare_value) const
+                    __intrinsic_asm "$0.gather_compare($1, ($2).xyz, as_type<uint>(($2).w), $3)";
+                }
+                else
+                {
+                    // Tv gather_compare(sampler s, float3 coord, float compare_value) const
+                    __intrinsic_asm "$0.gather_compare($1, $2, $3)";
+                }
+            }
+        }
+        // TODO: This needs to be handled by the capability system
+        __intrinsic_asm "<Metal support gather_compare only for 2D depth and Cube depth>";
     case spirv:
         return spirv_asm {
             %sampledImage : __sampledImageType(texture) = OpSampledImage $texture $s;
@@ -1598,7 +2037,7 @@ vector<TElement,4> __glsl_gatherCmp(__TextureImpl<T, Shape, isArray, 0, sampleCo
 __generic<TElement, T, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let access:int, let isShadow:int, let format:int>
 [ForceInline]
 [require(glsl_spirv, GLSL_400)]
-vector<TElement,4> __glsl_gatherCmp(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 1, format> sampler, vector<float, Shape.dimensions+isArray> location, TElement compareValue)
+vector<TElement,4> __texture_gatherCmp(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 1, format> sampler, vector<float, Shape.dimensions+isArray> location, TElement compareValue)
 {
     __target_switch
     {
@@ -1612,13 +2051,32 @@ vector<TElement,4> __glsl_gatherCmp(__TextureImpl<T, Shape, isArray, 0, sampleCo
 }
 __generic<TElement, T, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let access:int, let isShadow:int, let format:int>
 [ForceInline]
-[require(glsl_spirv, GLSL_400)]
-vector<TElement,4> __glsl_gatherCmp_offset(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 0, format> texture, SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, TElement compareValue, constexpr vector<int, Shape.planeDimensions> offset)
+[require(glsl_metal_spirv, GLSL_400)]
+vector<TElement,4> __texture_gatherCmp_offset(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 0, format> texture, SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, TElement compareValue, constexpr vector<int, Shape.planeDimensions> offset)
 {
     __target_switch
     {
     case glsl:
         __intrinsic_asm "textureGatherOffset($p, $2, $3, $4)";
+    case metal:
+        if (isShadow == 1)
+        {
+            if (Shape.flavor == $(SLANG_TEXTURE_2D))
+            {
+                if (isArray == 1)
+                {
+                    // Tv gather_compare(sampler s, float2 coord, uint array, float compare_value, int2 offset = int2(0)) const
+                    __intrinsic_asm "$0.gather_compare($1, ($2).xy, as_type<uint>(($2).z), $3, $4)";
+                }
+                else
+                {
+                    // Tv gather_compare(sampler s, float2 coord, float compare_value, int2 offset = int2(0)) const
+                    __intrinsic_asm "$0.gather_compare($1, $2, $3, $4)";
+                }
+            }
+        }
+        // TODO: This needs to be handled by the capability system
+        __intrinsic_asm "<Metal support gather_compare with offset only for 2D depth>";
     case spirv:
         return spirv_asm {
             %sampledImage : __sampledImageType(texture) = OpSampledImage $texture $s;
@@ -1629,7 +2087,7 @@ vector<TElement,4> __glsl_gatherCmp_offset(__TextureImpl<T, Shape, isArray, 0, s
 __generic<TElement, T, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let access:int, let isShadow:int, let format:int>
 [ForceInline]
 [require(glsl_spirv, GLSL_400)]
-vector<TElement,4> __glsl_gatherCmp_offset(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 1, format> sampler, vector<float, Shape.dimensions+isArray> location, TElement compareValue, constexpr vector<int, Shape.planeDimensions> offset)
+vector<TElement,4> __texture_gatherCmp_offset(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 1, format> sampler, vector<float, Shape.dimensions+isArray> location, TElement compareValue, constexpr vector<int, Shape.planeDimensions> offset)
 {
     __target_switch
     {
@@ -1644,7 +2102,7 @@ vector<TElement,4> __glsl_gatherCmp_offset(__TextureImpl<T, Shape, isArray, 0, s
 __generic<TElement, T, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let access:int, let isShadow:int, let format:int>
 [ForceInline]
 [require(glsl_spirv, GLSL_400)]
-vector<TElement,4> __glsl_gatherCmp_offsets(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 0, format> texture, SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, TElement compareValue,
+vector<TElement,4> __texture_gatherCmp_offsets(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 0, format> texture, SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, TElement compareValue,
     vector<int, Shape.planeDimensions> offset1,
     vector<int, Shape.planeDimensions> offset2,
     vector<int, Shape.planeDimensions> offset3,
@@ -1666,7 +2124,7 @@ vector<TElement,4> __glsl_gatherCmp_offsets(__TextureImpl<T, Shape, isArray, 0, 
 __generic<TElement, T, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let access:int, let isShadow:int, let format:int>
 [ForceInline]
 [require(glsl_spirv, GLSL_400)]
-vector<TElement,4> __glsl_gatherCmp_offsets(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 1, format> sampler, vector<float, Shape.dimensions+isArray> location, TElement compareValue,
+vector<TElement,4> __texture_gatherCmp_offsets(__TextureImpl<T, Shape, isArray, 0, sampleCount, access, isShadow, 1, format> sampler, vector<float, Shape.dimensions+isArray> location, TElement compareValue,
     vector<int, Shape.planeDimensions> offset1,
     vector<int, Shape.planeDimensions> offset2,
     vector<int, Shape.planeDimensions> offset3,
@@ -1703,7 +2161,9 @@ for (int isScalarTexture = 0; isScalarTexture <= 1; isScalarTexture++) {
 ${{{{
     // Gather component
     const char* samplerStateParam = isCombined ? "" : " s,";
-    for (int isCmp = 0; isCmp <= 1; ++isCmp) {
+    const char* metalSupport = isCombined ? "" : "metal_";
+    const char* caseMetal = isCombined ? "" : "case metal:";
+    for (int isCmp = 0; isCmp < 2; ++isCmp) {
         const char* cmp = isCmp ? "Cmp" : "";
         const char* cmpParam = isCmp ? ", T compareValue" : "";
         const char* compareArg = isCmp ? ", compareValue" : "";
@@ -1711,32 +2171,34 @@ ${{{{
         const char* componentNames[] = { "", "Red", "Green", "Blue", "Alpha"};
         const char* glslComponentNames[] = { ", 0", ", 1", ", 2", ", 3" };
 
-        for (auto componentId = 0;  componentId <= 4; componentId++) {
+        for (auto componentId = 0;  componentId < 5; componentId++) {
             auto componentName = componentNames[componentId];
             auto glslComponent = (isCmp ? "" :glslComponentNames[componentId == 0 ? 0 : componentId - 1]);
     }}}}
     [ForceInline]
-    [require(glsl_hlsl_spirv, texture_gather)]
+    [require(glsl_hlsl_$(metalSupport)spirv, texture_gather)]
     vector<T,4> Gather$(cmp)$(componentName)($(samplerStateType)$(samplerStateParam) vector<float, Shape.dimensions+isArray> location $(cmpParam))
     {
         __target_switch
         {
         case hlsl: __intrinsic_asm ".Gather$(cmp)$(componentName)";
+        $(caseMetal)
         case glsl:
         case spirv:
-            return __glsl_gather$(cmp)<T>(this,$(samplerStateParam) location $(compareArg) $(glslComponent));
+            return __texture_gather$(cmp)<T>(this,$(samplerStateParam) location $(compareArg) $(glslComponent));
         }
     }
     [ForceInline]
-    [require(glsl_hlsl_spirv, texture_gather)]
+    [require(glsl_hlsl_$(metalSupport)spirv, texture_gather)]
     vector<T,4> Gather$(cmp)$(componentName)($(samplerStateType)$(samplerStateParam) vector<float, Shape.dimensions+isArray> location $(cmpParam), constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
         {
         case hlsl: __intrinsic_asm ".Gather$(cmp)$(componentName)";
+        $(caseMetal)
         case glsl:
         case spirv:
-            return __glsl_gather$(cmp)_offset<T>(this,$(samplerStateParam) location $(compareArg), offset $(glslComponent));
+            return __texture_gather$(cmp)_offset<T>(this,$(samplerStateParam) location $(compareArg), offset $(glslComponent));
         }
     }
     [ForceInline]
@@ -1752,7 +2214,7 @@ ${{{{
         case hlsl: __intrinsic_asm ".Gather$(cmp)$(componentName)";
         case glsl:
         case spirv:
-            return __glsl_gather$(cmp)_offsets<T>(this,$(samplerStateParam) location $(compareArg), offset1,offset2,offset3,offset4 $(glslComponent));
+            return __texture_gather$(cmp)_offsets<T>(this,$(samplerStateParam) location $(compareArg), offset1,offset2,offset3,offset4 $(glslComponent));
         }
     }
     ${{{{
@@ -1785,7 +2247,7 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
     __glsl_extension(GL_EXT_samplerless_texture_functions)
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_samplerless)]
+    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_samplerless)]
     T Load(vector<int, Shape.dimensions+isArray+1> location)
     {
         __target_switch
@@ -1793,6 +2255,62 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
         case cpp:
         case hlsl:
             __intrinsic_asm ".Load";
+        case metal:
+            switch (Shape.flavor)
+            {
+            case $(SLANG_TEXTURE_1D):
+                // lod is not supported for 1D texture
+                if (isArray == 1)
+                    // Tv read(uint coord, uint array, uint lod = 0) const
+                    __intrinsic_asm "$0.read(as_type<uint>(($1).x), as_type<uint>(($1).y))";
+                else
+                    // Tv read(uint coord, uint lod = 0) const
+                    __intrinsic_asm "$0.read(as_type<uint>(($1).x))";
+            case $(SLANG_TEXTURE_2D):
+                if (isShadow == 1)
+                {
+                    if (isArray == 1)
+                        // T read(uint2 coord, uint array, uint lod = 0) const
+                        __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z), as_type<uint>(($1).w))";
+                    else
+                        // T read(uint2 coord, uint lod = 0) const
+                        __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z))";
+                }
+                else
+                {
+                    if (isArray == 1)
+                        // Tv read(uint2 coord, uint array, uint lod = 0) const
+                        __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z), as_type<uint>(($1).w))";
+                    else
+                        // Tv read(uint2 coord, uint lod = 0) const
+                        __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z))";
+                }
+            case $(SLANG_TEXTURE_3D):
+                if (isShadow == 0 && isArray == 0)
+                    // Tv read(uint3 coord, uint lod = 0) const
+                    __intrinsic_asm "$0.read(as_type<vec<uint,3>>(($1).xyz), as_type<uint>(($1).w))";
+            case $(SLANG_TEXTURE_CUBE):
+                if (isShadow == 1)
+                {
+                    if (isArray == 1)
+                        // T read(uint2 coord, uint face, uint array, uint lod = 0) const
+                        __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z), as_type<uint>(($1).w))";
+                    else
+                        // T read(uint2 coord, uint face, uint lod = 0) const
+                        __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z), as_type<uint>(($1).w))";
+                }
+                else
+                {
+                    if (isArray == 1)
+                        // Tv read(uint2 coord, uint face, uint array, uint lod = 0) const
+                        __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z), as_type<uint>(($1).w))";
+                    else
+                        // Tv read(uint2 coord, uint face, uint lod = 0) const
+                        __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z), as_type<uint>(($1).w))";
+                }
+            }
+            // TODO: This needs to be handled by the capability system
+            __intrinsic_asm "<Not supported>";
         case glsl:
             __intrinsic_asm "$ctexelFetch($0, ($1).$w1b, ($1).$w1e)$z";
         case spirv:
@@ -1919,14 +2437,39 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,form
     __glsl_extension(GL_EXT_samplerless_texture_functions)
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_samplerless)]
+    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_samplerless)]
     T Load(vector<int, Shape.dimensions+isArray> location, int sampleIndex)
     {
         __target_switch
         {
             case cpp:
             case hlsl:
-            __intrinsic_asm ".Load";
+                __intrinsic_asm ".Load";
+            case metal:
+                switch (Shape.flavor)
+                {
+                case $(SLANG_TEXTURE_2D):
+                    if (isShadow == 1)
+                    {
+                        if (isArray == 1)
+                            // Tv read(uint2 coord, uint array, uint lod = 0) const
+                            __intrinsic_asm "$0.read(($1).xy, ($1).z)";
+                        else
+                            // T read(uint2 coord, uint sample) const
+                            __intrinsic_asm "$0.read($1, uint($2))";
+                    }
+                    else
+                    {
+                        if (isArray == 1)
+                            // Tv read(uint2 coord, uint array, uint lod = 0) const
+                            __intrinsic_asm "$0.read(($1).xy, ($1).z)";
+                        else
+                            // Tv read(uint2 coord, uint sample) const
+                            __intrinsic_asm "$0.read($1, uint($2))";
+                    }
+                }
+                // TODO: This needs to be handled by the capability system
+                __intrinsic_asm "<Not supported>";
             case glsl:
                 __intrinsic_asm "$ctexelFetch($0, $1, ($2))$z";
             case spirv:
@@ -2212,7 +2755,7 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,form
 {
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_compute_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_compute_fragment)]
     T Load(vector<int, Shape.dimensions+isArray> location, int sampleIndex)
     {
         __target_switch
@@ -2220,6 +2763,33 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,form
             case cpp:
             case hlsl:
                 __intrinsic_asm ".Load";
+            case metal:
+                switch (Shape.flavor)
+                {
+                case $(SLANG_TEXTURE_2D):
+                    if (isShadow == 1)
+                    {
+                        if (isArray == 1)
+                            // The document seems to have a typo. `lod` must mean `sample`.
+                            // Tv read(uint2 coord, uint array, uint lod = 0) const
+                            __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z), $2)";
+                        else
+                            // T read(uint2 coord, uint sample) const
+                            __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), $2)";
+                    }
+                    else
+                    {
+                        if (isArray == 1)
+                            // The document seems to have a typo. `lod` must mean `sample`.
+                            // Tv read(uint2 coord, uint array, uint lod = 0) const
+                            __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z), $2)";
+                        else
+                            // Tv read(uint2 coord, uint sample) const
+                            __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), $2)";
+                    }
+                }
+                // TODO: This needs to be handled by the capability system
+                __intrinsic_asm "<Not supported>";
             case glsl:
                 __intrinsic_asm "$(glslIntrinsicMS)";
             case spirv:
@@ -14024,8 +14594,8 @@ for (int aa = 0; aa < kBaseBufferAccessLevelCount; ++aa)
     char const* glslTextureSizeFunc = (isReadOnly) ? "textureSize" : "imageSize";
     char const* glslLoadFuncName = (isReadOnly) ? "texelFetch" : "imageLoad";
     char const* spvLoadInstName = (isReadOnly) ? "OpImageFetch" : "OpImageRead";
-    char const* requireToSetQuery = (isReadOnly) ? "[require(glsl_hlsl_spirv, texture_size)]" : "[require(glsl_hlsl_spirv, image_size)]";
-    char const* requireToSet = (isReadOnly) ? "[require(glsl_hlsl_spirv, texture_sm_4_1)]" : "[require(glsl_hlsl_spirv, texture_sm_4_1_compute_fragment)]";
+    char const* requireToSetQuery = (isReadOnly) ? "[require(glsl_hlsl_metal_spirv, texture_size)]" : "[require(glsl_hlsl_metal_spirv, image_size)]";
+    char const* requireToSet = (isReadOnly) ? "[require(glsl_hlsl_metal_spirv, texture_sm_4_1)]" : "[require(glsl_hlsl_metal_spirv, texture_sm_4_1_compute_fragment)]";
 }}}}
 
 __generic<T, let format:int>
@@ -14039,6 +14609,7 @@ extension __TextureImpl<T, __ShapeBuffer, 0, 0, 0, $(aa), 0, 0, format>
         {
         case hlsl: __intrinsic_asm ".GetDimensions";
         case glsl: __intrinsic_asm "($1 = $(glslTextureSizeFunc)($0))";
+        case metal: __intrinsic_asm "(*($1) = $0.get_width())";
         case spirv:
             dim = spirv_asm {
                 OpCapability ImageQuery;
@@ -14055,6 +14626,7 @@ extension __TextureImpl<T, __ShapeBuffer, 0, 0, 0, $(aa), 0, 0, format>
         __target_switch
         {
         case hlsl: __intrinsic_asm ".Load";
+        case metal: __intrinsic_asm "$0.read(uint($1))";
         case glsl: __intrinsic_asm "$(glslLoadFuncName)($0, $1)$z";
         case spirv: return spirv_asm {
                 %sampled:__sampledType(T) = $(spvLoadInstName) $this $location;
@@ -14084,6 +14656,7 @@ ${{{{
                 {
                 case hlsl: __intrinsic_asm "($0)[$1] = $2";
                 case glsl: __intrinsic_asm "imageStore($0, int($1), $V2)";
+                case metal: __intrinsic_asm "$0.write($2, $1)";
                 case spirv: spirv_asm {
                         OpImageWrite $this $index __convertTexel(newValue);
                     };

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -1797,12 +1797,12 @@ vector<TElement,4> __texture_gather(__TextureImpl<T, Shape, isArray, 0, sampleCo
                 if (isShadow == 1)
                 {
                     // Tv gather(sampler s, float2 coord, uint array, int2 offset = int2(0)) const
-                    __intrinsic_asm "$0.gather($1, ($2).xy, as_type<uint>(($2).z))";
+                    __intrinsic_asm "$0.gather($1, ($2).xy, uint(($2).z))";
                 }
                 else
                 {
                     // Tv gather(sampler s, float2 coord, uint array, int2 offset = int2(0), component c = component::x) const
-                    __intrinsic_asm "$0.gather($1, ($2).xy, as_type<uint>(($2).z), int2(0), metal::component($3))";
+                    __intrinsic_asm "$0.gather($1, ($2).xy, uint(($2).z), int2(0), metal::component($3))";
                 }
             }
             else
@@ -1826,12 +1826,12 @@ vector<TElement,4> __texture_gather(__TextureImpl<T, Shape, isArray, 0, sampleCo
                 if (isShadow == 1)
                 {
                     // Tv gather(sampler s, float3 coord, uint array) const
-                    __intrinsic_asm "$0.gather($1, ($2).xyz, as_type<uint>(($2).w))";
+                    __intrinsic_asm "$0.gather($1, ($2).xyz, uint(($2).w))";
                 }
                 else
                 {
                     // Tv gather(sampler s, float3 coord, uint array, component c = component::x) const
-                    __intrinsic_asm "$0.gather($1, ($2).xyz, as_type<uint>(($2).w), metal::component($3))";
+                    __intrinsic_asm "$0.gather($1, ($2).xyz, uint(($2).w), metal::component($3))";
                 }
             }
             else
@@ -1892,12 +1892,12 @@ vector<TElement,4> __texture_gather_offset(__TextureImpl<T, Shape, isArray, 0, s
                 if (isShadow == 1)
                 {
                     // Tv gather(sampler s, float2 coord, uint array, int2 offset = int2(0)) const
-                    __intrinsic_asm "$0.gather($1, ($2).xy, as_type<uint>(($2).z), $3)";
+                    __intrinsic_asm "$0.gather($1, ($2).xy, uint(($2).z), $3)";
                 }
                 else
                 {
                     // Tv gather(sampler s, float2 coord, uint array, int2 offset = int2(0), component c = component::x) const
-                    __intrinsic_asm "$0.gather($1, ($2).xy, as_type<uint>(($2).z), $3, metal::component($4))";
+                    __intrinsic_asm "$0.gather($1, ($2).xy, uint(($2).z), $3, metal::component($4))";
                 }
             }
             else
@@ -2003,7 +2003,7 @@ vector<TElement,4> __texture_gatherCmp(__TextureImpl<T, Shape, isArray, 0, sampl
                 if (isArray == 1)
                 {
                     // Tv gather_compare(sampler s, float2 coord, uint array, float compare_value, int2 offset = int2(0)) const
-                    __intrinsic_asm "$0.gather_compare($1, ($2).xy, as_type<uint>(($2).z), $3)";
+                    __intrinsic_asm "$0.gather_compare($1, ($2).xy, uint(($2).z), $3)";
                 }
                 else
                 {
@@ -2016,7 +2016,7 @@ vector<TElement,4> __texture_gatherCmp(__TextureImpl<T, Shape, isArray, 0, sampl
                 if (isArray == 1)
                 {
                     // Tv gather_compare(sampler s, float3 coord, uint array, float compare_value) const
-                    __intrinsic_asm "$0.gather_compare($1, ($2).xyz, as_type<uint>(($2).w), $3)";
+                    __intrinsic_asm "$0.gather_compare($1, ($2).xyz, uint(($2).w), $3)";
                 }
                 else
                 {
@@ -2066,7 +2066,7 @@ vector<TElement,4> __texture_gatherCmp_offset(__TextureImpl<T, Shape, isArray, 0
                 if (isArray == 1)
                 {
                     // Tv gather_compare(sampler s, float2 coord, uint array, float compare_value, int2 offset = int2(0)) const
-                    __intrinsic_asm "$0.gather_compare($1, ($2).xy, as_type<uint>(($2).z), $3, $4)";
+                    __intrinsic_asm "$0.gather_compare($1, ($2).xy, uint(($2).z), $3, $4)";
                 }
                 else
                 {
@@ -2262,51 +2262,51 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
                 // lod is not supported for 1D texture
                 if (isArray == 1)
                     // Tv read(uint coord, uint array, uint lod = 0) const
-                    __intrinsic_asm "$0.read(as_type<uint>(($1).x), as_type<uint>(($1).y))";
+                    __intrinsic_asm "$0.read(uint(($1).x), uint(($1).y))";
                 else
                     // Tv read(uint coord, uint lod = 0) const
-                    __intrinsic_asm "$0.read(as_type<uint>(($1).x))";
+                    __intrinsic_asm "$0.read(uint(($1).x))";
             case $(SLANG_TEXTURE_2D):
                 if (isShadow == 1)
                 {
                     if (isArray == 1)
                         // T read(uint2 coord, uint array, uint lod = 0) const
-                        __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z), as_type<uint>(($1).w))";
+                        __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
                     else
                         // T read(uint2 coord, uint lod = 0) const
-                        __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z))";
+                        __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z))";
                 }
                 else
                 {
                     if (isArray == 1)
                         // Tv read(uint2 coord, uint array, uint lod = 0) const
-                        __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z), as_type<uint>(($1).w))";
+                        __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
                     else
                         // Tv read(uint2 coord, uint lod = 0) const
-                        __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z))";
+                        __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z))";
                 }
             case $(SLANG_TEXTURE_3D):
                 if (isShadow == 0 && isArray == 0)
                     // Tv read(uint3 coord, uint lod = 0) const
-                    __intrinsic_asm "$0.read(as_type<vec<uint,3>>(($1).xyz), as_type<uint>(($1).w))";
+                    __intrinsic_asm "$0.read(vec<uint,3>(($1).xyz), uint(($1).w))";
             case $(SLANG_TEXTURE_CUBE):
                 if (isShadow == 1)
                 {
                     if (isArray == 1)
                         // T read(uint2 coord, uint face, uint array, uint lod = 0) const
-                        __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z), as_type<uint>(($1).w))";
+                        __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
                     else
                         // T read(uint2 coord, uint face, uint lod = 0) const
-                        __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z), as_type<uint>(($1).w))";
+                        __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
                 }
                 else
                 {
                     if (isArray == 1)
                         // Tv read(uint2 coord, uint face, uint array, uint lod = 0) const
-                        __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z), as_type<uint>(($1).w))";
+                        __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
                     else
                         // Tv read(uint2 coord, uint face, uint lod = 0) const
-                        __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z), as_type<uint>(($1).w))";
+                        __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
                 }
             }
             // TODO: This needs to be handled by the capability system
@@ -2772,20 +2772,20 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,form
                         if (isArray == 1)
                             // The document seems to have a typo. `lod` must mean `sample`.
                             // Tv read(uint2 coord, uint array, uint lod = 0) const
-                            __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z), $2)";
+                            __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), $2)";
                         else
                             // T read(uint2 coord, uint sample) const
-                            __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), $2)";
+                            __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), $2)";
                     }
                     else
                     {
                         if (isArray == 1)
                             // The document seems to have a typo. `lod` must mean `sample`.
                             // Tv read(uint2 coord, uint array, uint lod = 0) const
-                            __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), as_type<uint>(($1).z), $2)";
+                            __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), $2)";
                         else
                             // Tv read(uint2 coord, uint sample) const
-                            __intrinsic_asm "$0.read(as_type<vec<uint,2>>(($1).xy), $2)";
+                            __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), $2)";
                     }
                 }
                 // TODO: This needs to be handled by the capability system

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -1448,23 +1448,20 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
         case metal:
             if (isShadow == 1)
             {
-                if (isArray == 1)
+                switch (Shape.flavor)
                 {
-                    switch (Shape.flavor)
+                case $(SLANG_TEXTURE_2D):
+                    if (isArray == 1)
                     {
-                    case $(SLANG_TEXTURE_2D):
                         // T sample_compare(sampler s, float2 coord, uint array, float compare_value, lod_options options, int2 offset = int2(0)) const
                         __intrinsic_asm "$0.sample_compare($1, ($2).xy, uint(($2).z), $3, level(0), $4)";
                     }
-                }
-                else
-                {
-                    switch (Shape.flavor)
+                    else
                     {
-                    case $(SLANG_TEXTURE_2D):
                         // T sample_compare(sampler s, float2 coord, float compare_value, lod_options options, int2 offset = int2(0)) const
                         __intrinsic_asm "$0.sample_compare($1, $2, $3, level(0), $4)";
                     }
+                    break;
                 }
             }
             __intrinsic_asm "<invalid intrinsic>";
@@ -1747,7 +1744,7 @@ for (int isMS = 0; isMS <= 1; isMS++) {
         if (shapeIndex != kStdlibShapeIndex2D)
             continue;
     }
-    if (isArray == 1)
+    if (isArray)
     {
         if (shapeIndex == kStdlibShapeIndex3D)
             continue;

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -10663,13 +10663,14 @@ T NonUniformResourceIndex<T>(T value) { return value; }
 // Normalize a vector
 __generic<T : __BuiltinFloatingPointType, let N : int>
 [__readNone]
-[require(cpp_cuda_glsl_hlsl_spirv, sm_2_0_GLSL_140)]
+[require(cpp_cuda_glsl_hlsl_metal_spirv, sm_2_0_GLSL_140)]
 vector<T,N> normalize(vector<T,N> x)
 {
     __target_switch
     {
     case glsl: __intrinsic_asm "normalize";
     case hlsl: __intrinsic_asm "normalize";
+    case metal: __intrinsic_asm "normalize";
     case spirv: return spirv_asm {
         OpExtInst $$vector<T,N> result glsl450 Normalize $x
     };
@@ -10680,13 +10681,14 @@ vector<T,N> normalize(vector<T,N> x)
 
 __generic<T : __BuiltinFloatingPointType>
 [__readNone]
-[require(cpp_cuda_glsl_hlsl_spirv, sm_2_0_GLSL_140)]
+[require(cpp_cuda_glsl_hlsl_metal_spirv, sm_2_0_GLSL_140)]
 T normalize(T x)
 {
     __target_switch
     {
     case glsl: __intrinsic_asm "normalize";
     case hlsl: __intrinsic_asm "normalize";
+    case metal: __intrinsic_asm "normalize";
     case spirv: return spirv_asm {
         OpExtInst $$T result glsl450 Normalize $x
     };

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -973,7 +973,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,access,isShadow,0,forma
         case hlsl:
             __intrinsic_asm ".CalculateLevelOfDetail";
         case metal:
-            __intrinsic_asm "$0.calculate_clamped_lod($1, $2)";
+            __intrinsic_asm ".calculate_clamped_lod";
         case glsl:
             __intrinsic_asm "textureQueryLod($p, $2).x";
         case spirv:
@@ -995,7 +995,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,access,isShadow,0,forma
         case hlsl:
             __intrinsic_asm ".CalculateLevelOfDetailUnclamped";
         case metal:
-            __intrinsic_asm "$0.calculate_unclamped_lod($1, $2)";
+            __intrinsic_asm ".calculate_unclamped_lod";
         case glsl:
             __intrinsic_asm "textureQueryLod($p, $2).y";
         case spirv:
@@ -1042,7 +1042,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     case $(SLANG_TEXTURE_2D):
                     case $(SLANG_TEXTURE_3D):
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "$0.sample($1, $2)";
+                        __intrinsic_asm ".sample";
                     }
                 }
                 // TODO: This needs to be handled by the capability system
@@ -1116,7 +1116,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     {
                     case $(SLANG_TEXTURE_2D):
                     case $(SLANG_TEXTURE_3D):
-                        __intrinsic_asm "$0.sample($1, $2, $3)";
+                        __intrinsic_asm ".sample";
                     }
                 }
                 // TODO: This needs to be handled by the capability system
@@ -1320,7 +1320,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 {
                 case $(SLANG_TEXTURE_2D):
                 case $(SLANG_TEXTURE_CUBE):
-                    __intrinsic_asm "$0.sample_compare($1, $2, $3)";
+                    __intrinsic_asm ".sample_compare";
                 }
             }
             __intrinsic_asm "<invalid intrinsic>";
@@ -1414,7 +1414,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 switch (Shape.flavor)
                 {
                 case $(SLANG_TEXTURE_2D):
-                    __intrinsic_asm "$0.sample_compare($1, $2, $3, $4)";
+                    __intrinsic_asm ".sample_compare";
                 }
             }
             __intrinsic_asm "<invalid intrinsic>";
@@ -1790,69 +1790,38 @@ vector<TElement,4> __texture_gather(__TextureImpl<T, Shape, isArray, 0, sampleCo
     case glsl:
         __intrinsic_asm "textureGather($p, $2, $3)";
     case metal:
-        if (Shape.flavor == $(SLANG_TEXTURE_2D))
+        if (isShadow == 0)
         {
-            if (isArray == 1)
+            switch (Shape.flavor)
             {
-                if (isShadow == 1)
-                {
-                    // Tv gather(sampler s, float2 coord, uint array, int2 offset = int2(0)) const
-                    __intrinsic_asm "$0.gather($1, ($2).xy, uint(($2).z))";
-                }
-                else
+            case $(SLANG_TEXTURE_2D):
+                if (isArray == 1)
                 {
                     // Tv gather(sampler s, float2 coord, uint array, int2 offset = int2(0), component c = component::x) const
                     __intrinsic_asm "$0.gather($1, ($2).xy, uint(($2).z), int2(0), metal::component($3))";
-                }
-            }
-            else
-            {
-                if (isShadow == 1)
-                {
-                    // Tv gather(sampler s, float2 coord, int2 offset = int2(0)) const
-                    __intrinsic_asm "$0.gather($1, $2, 0)";
                 }
                 else
                 {
                     // Tv gather(sampler s, float2 coord, int2 offset = int2(0), component c = component::x) const
                     __intrinsic_asm "$0.gather($1, $2, int2(0), metal::component($3))";
                 }
-            }
-        }
-        else if (Shape.flavor == $(SLANG_TEXTURE_CUBE))
-        {
-            if (isArray == 1)
-            {
-                if (isShadow == 1)
-                {
-                    // Tv gather(sampler s, float3 coord, uint array) const
-                    __intrinsic_asm "$0.gather($1, ($2).xyz, uint(($2).w))";
-                }
-                else
+                break;
+            case $(SLANG_TEXTURE_CUBE):
+                if (isArray == 1)
                 {
                     // Tv gather(sampler s, float3 coord, uint array, component c = component::x) const
                     __intrinsic_asm "$0.gather($1, ($2).xyz, uint(($2).w), metal::component($3))";
-                }
-            }
-            else
-            {
-                if (isShadow == 1)
-                {
-                    // Tv gather(sampler s, float3 coord) const
-                    __intrinsic_asm "$0.gather($1, $2)";
                 }
                 else
                 {
                     // Tv gather(sampler s, float3 coord, component c = component::x) const
                     __intrinsic_asm "$0.gather($1, $2, metal::component($3))";
                 }
+                break;
             }
         }
-        else
-        {
-            // TODO: This needs to be handled by the capability system
-            __intrinsic_asm "<Metal support gather only for 2D and Cube>";
-        }
+        // TODO: This needs to be handled by the capability system
+        __intrinsic_asm "<invalid intrinsic>";
     case spirv:
         return spirv_asm {
             %sampledImage : __sampledImageType(texture) = OpSampledImage $texture $s;
@@ -1887,25 +1856,12 @@ vector<TElement,4> __texture_gather_offset(__TextureImpl<T, Shape, isArray, 0, s
     case metal:
         if (Shape.flavor == $(SLANG_TEXTURE_2D))
         {
-            if (isArray == 1)
+            if (isShadow == 0)
             {
-                if (isShadow == 1)
-                {
-                    // Tv gather(sampler s, float2 coord, uint array, int2 offset = int2(0)) const
-                    __intrinsic_asm "$0.gather($1, ($2).xy, uint(($2).z), $3)";
-                }
-                else
+                if (isArray == 1)
                 {
                     // Tv gather(sampler s, float2 coord, uint array, int2 offset = int2(0), component c = component::x) const
                     __intrinsic_asm "$0.gather($1, ($2).xy, uint(($2).z), $3, metal::component($4))";
-                }
-            }
-            else
-            {
-                if (isShadow == 1)
-                {
-                    // Tv gather(sampler s, float2 coord, int2 offset = int2(0)) const
-                    __intrinsic_asm "$0.gather($1, $2, $3)";
                 }
                 else
                 {
@@ -1914,11 +1870,8 @@ vector<TElement,4> __texture_gather_offset(__TextureImpl<T, Shape, isArray, 0, s
                 }
             }
         }
-        else
-        {
-            // TODO: This needs to be handled by the capability system
-            __intrinsic_asm "<Metal support gather with offset only for 2D>";
-        }
+        // TODO: This needs to be handled by the capability system
+        __intrinsic_asm "<Metal support gather with offset only for 2D>";
     case spirv:
         return spirv_asm {
             %sampledImage : __sampledImageType(texture) = OpSampledImage $texture $s;
@@ -2026,7 +1979,7 @@ vector<TElement,4> __texture_gatherCmp(__TextureImpl<T, Shape, isArray, 0, sampl
             }
         }
         // TODO: This needs to be handled by the capability system
-        __intrinsic_asm "<Metal support gather_compare only for 2D depth and Cube depth>";
+        __intrinsic_asm "<invalid intrinsics>";
     case spirv:
         return spirv_asm {
             %sampledImage : __sampledImageType(texture) = OpSampledImage $texture $s;
@@ -2076,7 +2029,7 @@ vector<TElement,4> __texture_gatherCmp_offset(__TextureImpl<T, Shape, isArray, 0
             }
         }
         // TODO: This needs to be handled by the capability system
-        __intrinsic_asm "<Metal support gather_compare with offset only for 2D depth>";
+        __intrinsic_asm "<invalid intrinsics>";
     case spirv:
         return spirv_asm {
             %sampledImage : __sampledImageType(texture) = OpSampledImage $texture $s;
@@ -2266,6 +2219,7 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
                 else
                     // Tv read(uint coord, uint lod = 0) const
                     __intrinsic_asm "$0.read(uint(($1).x))";
+                break;
             case $(SLANG_TEXTURE_2D):
                 if (isShadow == 1)
                 {
@@ -2285,10 +2239,12 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
                         // Tv read(uint2 coord, uint lod = 0) const
                         __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z))";
                 }
+                break;
             case $(SLANG_TEXTURE_3D):
                 if (isShadow == 0 && isArray == 0)
                     // Tv read(uint3 coord, uint lod = 0) const
                     __intrinsic_asm "$0.read(vec<uint,3>(($1).xyz), uint(($1).w))";
+                break;
             case $(SLANG_TEXTURE_CUBE):
                 if (isShadow == 1)
                 {
@@ -2308,9 +2264,10 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
                         // Tv read(uint2 coord, uint face, uint lod = 0) const
                         __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
                 }
+                break;
             }
             // TODO: This needs to be handled by the capability system
-            __intrinsic_asm "<Not supported>";
+            __intrinsic_asm "<invalid intrinsics>";
         case glsl:
             __intrinsic_asm "$ctexelFetch($0, ($1).$w1b, ($1).$w1e)$z";
         case spirv:
@@ -2452,8 +2409,9 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,form
                     if (isShadow == 1)
                     {
                         if (isArray == 1)
+                            // Document seems to have a typo. `lod` must be `sample`.
                             // Tv read(uint2 coord, uint array, uint lod = 0) const
-                            __intrinsic_asm "$0.read(($1).xy, ($1).z)";
+                            __intrinsic_asm "$0.read(($1).xy, ($1).z, uint($2))";
                         else
                             // T read(uint2 coord, uint sample) const
                             __intrinsic_asm "$0.read($1, uint($2))";
@@ -2461,12 +2419,14 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,form
                     else
                     {
                         if (isArray == 1)
+                            // Document seems to have a typo. `lod` must be `sample`.
                             // Tv read(uint2 coord, uint array, uint lod = 0) const
-                            __intrinsic_asm "$0.read(($1).xy, ($1).z)";
+                            __intrinsic_asm "$0.read(($1).xy, ($1).z, uint($2))";
                         else
                             // Tv read(uint2 coord, uint sample) const
                             __intrinsic_asm "$0.read($1, uint($2))";
                     }
+                    break;
                 }
                 // TODO: This needs to be handled by the capability system
                 __intrinsic_asm "<Not supported>";
@@ -2787,6 +2747,7 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,form
                             // Tv read(uint2 coord, uint sample) const
                             __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), $2)";
                     }
+                    break;
                 }
                 // TODO: This needs to be handled by the capability system
                 __intrinsic_asm "<Not supported>";

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -75,6 +75,7 @@ alias cpp_cuda_glsl_hlsl_metal_spirv = cpp | cuda | glsl | hlsl | metal | spirv_
 alias cpp_cuda_hlsl = cpp | cuda | hlsl;
 alias cpp_glsl = cpp | glsl;
 alias cpp_glsl_hlsl_spirv = cpp | glsl | hlsl | spirv_1_0;
+alias cpp_glsl_hlsl_metal_spirv = cpp | glsl | hlsl | metal | spirv_1_0;
 alias cpp_hlsl = cpp | hlsl;
 alias cuda_glsl_hlsl = cuda | glsl | hlsl;
 alias cuda_glsl_hlsl_spirv = cuda | glsl | hlsl | spirv_1_0;
@@ -84,6 +85,7 @@ alias cuda_hlsl = cuda | hlsl;
 alias cuda_hlsl_spirv = cuda | hlsl | spirv;
 alias glsl_hlsl_spirv = glsl | hlsl | spirv;
 alias glsl_hlsl_metal_spirv = glsl | hlsl | metal | spirv;
+alias glsl_metal_spirv = glsl | metal | spirv;
 alias glsl_spirv = glsl | spirv;
 alias hlsl_spirv = hlsl | spirv;
 

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -62,9 +62,9 @@ def spirv_1_6 : spirv_1_5;
 alias spirv = spirv_1_0;
 alias spirv_latest = spirv_1_6;
 
-alias any_target = hlsl | glsl | c | cpp | cuda | spirv;
-alias any_textual_target = hlsl | glsl | c | cpp | cuda;
-alias any_gfx_target = hlsl | glsl | spirv;
+alias any_target = hlsl | metal | glsl | c | cpp | cuda | spirv;
+alias any_textual_target = hlsl | metal | glsl | c | cpp | cuda;
+alias any_gfx_target = hlsl | metal | glsl | spirv;
 alias any_cpp_target = cpp | cuda;
 
 alias cpp_cuda = cpp | cuda;

--- a/source/slang/slang-emit-metal.cpp
+++ b/source/slang/slang-emit-metal.cpp
@@ -963,6 +963,7 @@ void MetalSourceEmitter::emitFrontMatterImpl(TargetRequest*)
 {
     m_writer->emit("#include <metal_stdlib>\n");
     m_writer->emit("#include <metal_math>\n");
+    m_writer->emit("#include <metal_texture>\n");
     m_writer->emit("using namespace metal;\n");
 }
 

--- a/source/slang/slang-stdlib-textures.cpp
+++ b/source/slang/slang-stdlib-textures.cpp
@@ -192,7 +192,7 @@ void TextureTypeInfo::writeGetDimensionFunctions()
 
             int sizeDimCount = 0;
             StringBuilder params;
-            size_t paramCount = 0;
+            int paramCount = 0;
 
             StringBuilder metal;
             const char* metalMipLevel = "0";

--- a/source/slang/slang-stdlib-textures.cpp
+++ b/source/slang/slang-stdlib-textures.cpp
@@ -211,7 +211,7 @@ void TextureTypeInfo::writeGetDimensionFunctions()
             case SLANG_TEXTURE_1D:
                 ++paramCount;
                 params << t << "width";
-                metal << "(*($" << paramCount << ") = $0.get_width(" << metalMipLevel << ")),";
+                metal << "(*($" << String(paramCount) << ") = $0.get_width(" << String(metalMipLevel) << ")),";
 
                 sizeDimCount = 1;
                 break;
@@ -220,11 +220,11 @@ void TextureTypeInfo::writeGetDimensionFunctions()
             case SLANG_TEXTURE_CUBE:
                 ++paramCount;
                 params << t << "width,";
-                metal << "(*($" << paramCount << ") = $0.get_width(" << metalMipLevel << ")),";
+                metal << "(*($" << String(paramCount) << ") = $0.get_width(" << String(metalMipLevel) << ")),";
 
                 ++paramCount;
                 params << t << "height";
-                metal << "(*($" << paramCount << ") = $0.get_height(" << metalMipLevel << ")),";
+                metal << "(*($" << String(paramCount) << ") = $0.get_height(" << String(metalMipLevel) << ")),";
 
                 sizeDimCount = 2;
                 break;
@@ -232,15 +232,15 @@ void TextureTypeInfo::writeGetDimensionFunctions()
             case SLANG_TEXTURE_3D:
                 ++paramCount;
                 params << t << "width,";
-                metal << "(*($" << paramCount << ") = $0.get_width(" << metalMipLevel << ")),";
+                metal << "(*($" << String(paramCount) << ") = $0.get_width(" << String(metalMipLevel) << ")),";
 
                 ++paramCount;
                 params << t << "height,";
-                metal << "(*($" << paramCount << ") = $0.get_height(" << metalMipLevel << ")),";
+                metal << "(*($" << String(paramCount) << ") = $0.get_height(" << String(metalMipLevel) << ")),";
 
                 ++paramCount;
                 params << t << "depth";
-                metal << "(*($" << paramCount << ") = $0.get_depth(" << metalMipLevel << ")),";
+                metal << "(*($" << String(paramCount) << ") = $0.get_depth(" << String(metalMipLevel) << ")),";
 
                 sizeDimCount = 3;
                 break;
@@ -255,21 +255,21 @@ void TextureTypeInfo::writeGetDimensionFunctions()
                 ++sizeDimCount;
                 ++paramCount;
                 params << ", " << t << "elements";
-                metal << "(*($" << paramCount << ") = $0.get_array_size()),";
+                metal << "(*($" << String(paramCount) << ") = $0.get_array_size()),";
             }
 
             if (isMultisample)
             {
                 ++paramCount;
                 params << ", " << t << "sampleCount";
-                metal << "(*($" << paramCount << ") = $0.get_num_samples()),";
+                metal << "(*($" << String(paramCount) << ") = $0.get_num_samples()),";
             }
 
             if (includeMipInfo)
             {
                 ++paramCount;
                 params << ", " << t << "numberOfLevels";
-                metal << "(*($" << paramCount << ") = $0.get_num_mip_levels()),";
+                metal << "(*($" << String(paramCount) << ") = $0.get_num_mip_levels()),";
             }
 
             metal.reduceLength(metal.getLength() - 1); // drop the last comma

--- a/source/slang/slang-stdlib-textures.cpp
+++ b/source/slang/slang-stdlib-textures.cpp
@@ -200,7 +200,7 @@ void TextureTypeInfo::writeGetDimensionFunctions()
             if (includeMipInfo)
             {
                 ++paramCount;
-                params << "uint mipLevel, ";
+                params << "uint mipLevel,";
 
                 if (baseShape != SLANG_TEXTURE_1D)
                     metalMipLevel = "$1";

--- a/source/slang/slang-stdlib-textures.cpp
+++ b/source/slang/slang-stdlib-textures.cpp
@@ -68,7 +68,8 @@ void TextureTypeInfo::writeFuncBody(
     const String& cuda,
     const String& spirvDefault,
     const String& spirvRWDefault,
-    const String& spirvCombined)
+    const String& spirvCombined,
+    const String& metal)
 {
     BraceScope funcScope{i, sb};
     {
@@ -89,6 +90,11 @@ void TextureTypeInfo::writeFuncBody(
         {
             sb << i << "case cuda:\n";
             sb << i << "__intrinsic_asm \"" << cuda << "\";\n";
+        }
+        if (metal.getLength())
+        {
+            sb << i << "case metal:\n";
+            sb << i << "__intrinsic_asm \"" << metal << "\";\n";
         }
         if(spirvDefault.getLength() && spirvCombined.getLength())
         {
@@ -127,14 +133,14 @@ void TextureTypeInfo::writeFuncWithSig(
     const String& spirvRWDefault,
     const String& spirvCombined,
     const String& cuda,
+    const String& metal,
     const ReadNoneMode readNoneMode)
 {
     if (readNoneMode == ReadNoneMode::Always)
         sb << i << "[__readNone]\n";
-    sb << i << "[__readNone]\n";
     sb << i << "[ForceInline]\n";
     sb << i << sig << "\n";
-    writeFuncBody(funcName, glsl, cuda, spirvDefault, spirvRWDefault, spirvCombined);
+    writeFuncBody(funcName, glsl, cuda, spirvDefault, spirvRWDefault, spirvCombined, metal);
     sb << "\n";
 }
 
@@ -147,6 +153,7 @@ void TextureTypeInfo::writeFunc(
     const String& spirvRWDefault,
     const String& spirvCombined,
     const String& cuda,
+    const String& metal,
     const ReadNoneMode readNoneMode)
 {
     writeFuncWithSig(
@@ -157,6 +164,7 @@ void TextureTypeInfo::writeFunc(
         spirvRWDefault,
         spirvCombined,
         cuda,
+        metal,
         readNoneMode
     );
 }
@@ -184,27 +192,56 @@ void TextureTypeInfo::writeGetDimensionFunctions()
 
             int sizeDimCount = 0;
             StringBuilder params;
+            size_t paramCount = 0;
+
+            StringBuilder metal;
+            const char* metalMipLevel = "0";
+
             if (includeMipInfo)
+            {
+                ++paramCount;
                 params << "uint mipLevel, ";
+
+                if (baseShape != SLANG_TEXTURE_1D);
+                    metalMipLevel = "$1";
+            }
 
             switch (baseShape)
             {
             case SLANG_TEXTURE_1D:
+                ++paramCount;
                 params << t << "width";
+                metal << "(*($" << paramCount << ") = $0.get_width(" << metalMipLevel << ")),";
+
                 sizeDimCount = 1;
                 break;
 
             case SLANG_TEXTURE_2D:
             case SLANG_TEXTURE_CUBE:
+                ++paramCount;
                 params << t << "width,";
+                metal << "(*($" << paramCount << ") = $0.get_width(" << metalMipLevel << ")),";
+
+                ++paramCount;
                 params << t << "height";
+                metal << "(*($" << paramCount << ") = $0.get_height(" << metalMipLevel << ")),";
+
                 sizeDimCount = 2;
                 break;
 
             case SLANG_TEXTURE_3D:
+                ++paramCount;
                 params << t << "width,";
+                metal << "(*($" << paramCount << ") = $0.get_width(" << metalMipLevel << ")),";
+
+                ++paramCount;
                 params << t << "height,";
+                metal << "(*($" << paramCount << ") = $0.get_height(" << metalMipLevel << ")),";
+
+                ++paramCount;
                 params << t << "depth";
+                metal << "(*($" << paramCount << ") = $0.get_depth(" << metalMipLevel << ")),";
+
                 sizeDimCount = 3;
                 break;
 
@@ -215,18 +252,27 @@ void TextureTypeInfo::writeGetDimensionFunctions()
 
             if (isArray)
             {
+                ++sizeDimCount;
+                ++paramCount;
                 params << ", " << t << "elements";
-                sizeDimCount++;
+                metal << "(*($" << paramCount << ") = $0.get_array_size()),";
             }
 
             if (isMultisample)
             {
+                ++paramCount;
                 params << ", " << t << "sampleCount";
+                metal << "(*($" << paramCount << ") = $0.get_num_samples()),";
             }
 
             if (includeMipInfo)
+            {
+                ++paramCount;
                 params << ", " << t << "numberOfLevels";
+                metal << "(*($" << paramCount << ") = $0.get_num_mip_levels()),";
+            }
 
+            metal.reduceLength(metal.getLength() - 1); // drop the last comma
 
             StringBuilder glsl;
             {
@@ -407,7 +453,7 @@ void TextureTypeInfo::writeGetDimensionFunctions()
 
             sb << "    __glsl_version(450)\n";
             sb << "    __glsl_extension(GL_EXT_samplerless_texture_functions)\n";
-            sb << "    [require(glsl_spirv, texture_sm_4_1)]\n";
+            sb << "    [require(glsl_hlsl_metal_spirv, texture_sm_4_1)]\n";
             writeFunc(
                 "void",
                 "GetDimensions",
@@ -417,6 +463,7 @@ void TextureTypeInfo::writeGetDimensionFunctions()
                 spirvRWDefault,
                 spirvCombined,
                 "",
+                metal,
                 ReadNoneMode::Always);
         }
     }

--- a/source/slang/slang-stdlib-textures.cpp
+++ b/source/slang/slang-stdlib-textures.cpp
@@ -202,7 +202,7 @@ void TextureTypeInfo::writeGetDimensionFunctions()
                 ++paramCount;
                 params << "uint mipLevel, ";
 
-                if (baseShape != SLANG_TEXTURE_1D);
+                if (baseShape != SLANG_TEXTURE_1D)
                     metalMipLevel = "$1";
             }
 

--- a/source/slang/slang-stdlib-textures.h
+++ b/source/slang/slang-stdlib-textures.h
@@ -68,8 +68,9 @@ public:
         const String& cuda,
         const String& spirvDefault,
         const String& spirvRWDefault,
-        const String& spirvCombined
-    );
+        const String& spirvCombined,
+        const String& metal
+        );
     void writeFuncWithSig(
         const char* funcName,
         const String& sig,
@@ -78,6 +79,7 @@ public:
         const String& spirvRWDefault = String{},
         const String& spirvCombined = String{},
         const String& cuda = String{},
+        const String& metal = String{},
         const ReadNoneMode readNoneMode = ReadNoneMode::Never
     );
     void writeFunc(
@@ -89,6 +91,7 @@ public:
         const String& spirvRWDefault = String{},
         const String& spirvCombined = String{},
         const String& cuda = String{},
+        const String& metal = String{},
         const ReadNoneMode readNoneMode = ReadNoneMode::Never
     );
 

--- a/tests/bindings/multi-file-shared.slang
+++ b/tests/bindings/multi-file-shared.slang
@@ -7,10 +7,6 @@ PUBLIC float4 use(float  val) { return val; };
 PUBLIC float4 use(float2 val) { return float4(val,0.0,0.0); };
 PUBLIC float4 use(float3 val) { return float4(val,0.0); };
 PUBLIC float4 use(float4 val) { return val; };
-
-#ifdef __SLANG__
-[require(hlsl)]
-#endif
 PUBLIC float4 use(Texture2D t, SamplerState s) { return t.SampleLevel(s, 0.0, 0.0); }
 
 PUBLIC Texture2D sharedT R(: register(t2));

--- a/tests/bindings/multi-file-shared.slang
+++ b/tests/bindings/multi-file-shared.slang
@@ -7,6 +7,10 @@ PUBLIC float4 use(float  val) { return val; };
 PUBLIC float4 use(float2 val) { return float4(val,0.0,0.0); };
 PUBLIC float4 use(float3 val) { return float4(val,0.0); };
 PUBLIC float4 use(float4 val) { return val; };
+
+#ifdef __SLANG__
+[require(hlsl)]
+#endif
 PUBLIC float4 use(Texture2D t, SamplerState s) { return t.SampleLevel(s, 0.0, 0.0); }
 
 PUBLIC Texture2D sharedT R(: register(t2));

--- a/tests/metal/texture.slang
+++ b/tests/metal/texture.slang
@@ -18,10 +18,6 @@
     #define TEST_WHEN_DEPTH_CUBE_WORKS
 #endif
 
-// There is an unknown issue with cabability system that causes an error
-// when Cube, CubeArray and 2DArray are used.
-//#define TEST_AFTER_FIXING_CAPABILITY_PROBLEM
-
 //TEST_INPUT: ubuffer(data=[0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
@@ -281,7 +277,7 @@ bool TEST_texture_float()
 
         // METAL: tCube{{.*}}.calculate_unclamped_lod({{.*}}
         // METALLIB: call {{.*}}.calculate_unclamped_lod_texture_cube(
-        && float(0) >= tCube.CalculateLevelOfDetailUnclamped(samplerState, float3(u, u, u))
+        && float(0) >= tCube.CalculateLevelOfDetailUnclamped(samplerState, normalize(float3(u, 1 - u, u)))
 
         // METAL: t2DArray{{.*}}.calculate_unclamped_lod({{.*}}
         // METALLIB: call {{.*}}.calculate_unclamped_lod_texture_2d_array(
@@ -289,7 +285,7 @@ bool TEST_texture_float()
 
         // METAL: tCubeArray{{.*}}.calculate_unclamped_lod({{.*}}
         // METALLIB: call {{.*}}.calculate_unclamped_lod_texture_cube_array(
-        && float(0) >= tCubeArray.CalculateLevelOfDetailUnclamped(samplerState, float3(u, u, u))
+        && float(0) >= tCubeArray.CalculateLevelOfDetailUnclamped(samplerState, normalize(float3(u, 1 - u, u)))
 
         // ===========
         // T Sample()
@@ -307,11 +303,9 @@ bool TEST_texture_float()
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
         && all(Tv(1) == t3D.Sample(samplerState, float3(u, u, u)))
 
-#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
-        // M-ETAL: tCube{{.*}}.sample({{.*}}
-        // M-ETALLIB: call {{.*}}.sample_texture_cube.v4f32(
+        // METAL: tCube{{.*}}.sample({{.*}}
+        // METALLIB: call {{.*}}.sample_texture_cube.v4f32(
         && all(Tv(1) == tCube.Sample(samplerState, normalize(float3(u, 1 - u, u))))
-#endif
 
         // METAL: t1DArray{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_1d_array.v4f32(
@@ -321,11 +315,9 @@ bool TEST_texture_float()
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
         && all(Tv(1) == t2DArray.Sample(samplerState, float3(u, u, 0)))
 
-#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
-        // M-ETAL: tCubeArray{{.*}}.sample({{.*}}
-        // M-ETALLIB: call {{.*}}.sample_texture_cube_array.v4f32(
+        // METAL: tCubeArray{{.*}}.sample({{.*}}
+        // METALLIB: call {{.*}}.sample_texture_cube_array.v4f32(
         && all(Tv(1) == tCubeArray.Sample(samplerState, normalize(float4(u, 1 - u, u, 0))))
-#endif
 
         // Offset variant
 
@@ -385,21 +377,17 @@ bool TEST_texture_float()
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
         && all(Tv(1) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1)))
 
-#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
-        // M-ETAL: tCube{{.*}}.sample({{.*}}
-        // M-ETALLIB: call {{.*}}.sample_texture_cube.v4f32(
+        // METAL: tCube{{.*}}.sample({{.*}}
+        // METALLIB: call {{.*}}.sample_texture_cube.v4f32(
         && all(Tv(1) == tCube.SampleBias(samplerState, normalize(float3(u, 1 - u, u)), float(-1)))
-#endif
 
         // METAL: t2DArray{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
         && all(Tv(1) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1)))
 
-#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
-        // M-ETAL: tCubeArray{{.*}}.sample({{.*}}
-        // M-ETALLIB: call {{.*}}.sample_texture_cube_array.v4f32(
+        // METAL: tCubeArray{{.*}}.sample({{.*}}
+        // METALLIB: call {{.*}}.sample_texture_cube_array.v4f32(
         && all(Tv(1) == tCubeArray.SampleBias(samplerState, normalize(float4(u, 1 - u, u, 0)), float(-1)))
-#endif
 
         // Offset variant
 
@@ -439,11 +427,9 @@ bool TEST_texture_float()
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
         && all(Tv(1) == t3D.SampleLevel(samplerState, float3(u, u, u), 0))
 
-#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
-        // M-ETAL: tCube{{.*}}.sample({{.*}} level(
-        // M-ETALLIB: call {{.*}}.sample_texture_cube.v4f32(
+        // METAL: tCube{{.*}}.sample({{.*}} level(
+        // METALLIB: call {{.*}}.sample_texture_cube.v4f32(
         && all(Tv(1) == tCube.SampleLevel(samplerState, normalize(float3(u, 1 - u, u)), 0))
-#endif
 
         // METAL: t2DArray{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
@@ -451,7 +437,7 @@ bool TEST_texture_float()
 
         // METAL: tCubeArray{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_cube_array.v4f32(
-        && all(Tv(1) == tCubeArray.SampleLevel(samplerState, float4(u, u, u, 0), 0))
+        && all(Tv(1) == tCubeArray.SampleLevel(samplerState, float4(normalize(float3(u, 1 - u, u)), 0), 0))
 
         // Offset variant
 
@@ -481,22 +467,18 @@ bool TEST_texture_float()
         // METALLIB: call {{.*}}.sample_compare_depth_2d.f32(
         && float(1) == d2D.SampleCmp(shadowSampler, float2(u, u), 0)
 
-#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
-        // M-ETAL: d2DArray{{.*}}.sample_compare(
-        // M-ETALLIB: call {{.*}}.sample_compare_depth_2d_array.f32(
+        // METAL: d2DArray{{.*}}.sample_compare(
+        // METALLIB: call {{.*}}.sample_compare_depth_2d_array.f32(
         && float(1) == d2DArray.SampleCmp(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
-#endif
 
 #if defined(TEST_WHEN_DEPTH_CUBE_WORKS)
-#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
-        // M-ETAL: dCube{{.*}}.sample_compare(
-        // M-ETALLIB: call {{.*}}.sample_compare_depth_cube.f32(
+        // METAL: dCube{{.*}}.sample_compare(
+        // METALLIB: call {{.*}}.sample_compare_depth_cube.f32(
         && float(1) == dCube.SampleCmp(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
 
-        // M-ETAL: dCubeArray{{.*}}.sample_compare(
-        // M-ETALLIB: call {{.*}}.sample_compare_depth_cube_array.f32(
+        // METAL: dCubeArray{{.*}}.sample_compare(
+        // METALLIB: call {{.*}}.sample_compare_depth_cube_array.f32(
         && float(1) == dCubeArray.SampleCmp(shadowSampler, normalize(float4(u, 1-u, u, u)), 0)
-#endif
 #endif
 
         // Offset variant
@@ -513,22 +495,18 @@ bool TEST_texture_float()
         // METALLIB: call {{.*}}.sample_compare_depth_2d.f32(
         && float(1) == d2D.SampleCmpLevelZero(shadowSampler, float2(u, u), 0)
 
-#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
-        // M-ETAL: d2DArray{{.*}}.sample_compare(
-        // M-ETALLIB: call {{.*}}.sample_compare_depth_2d_array.f32(
+        // METAL: d2DArray{{.*}}.sample_compare(
+        // METALLIB: call {{.*}}.sample_compare_depth_2d_array.f32(
         && float(1) == d2DArray.SampleCmpLevelZero(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
-#endif
 
 #if defined(TEST_WHEN_DEPTH_CUBE_WORKS)
-#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
-        // M-ETAL: dCube{{.*}}.sample_compare(
-        // M-ETALLIB: call {{.*}}.sample_compare_depth_cube.f32(
+        // METAL: dCube{{.*}}.sample_compare(
+        // METALLIB: call {{.*}}.sample_compare_depth_cube.f32(
         && float(1) == dCube.SampleCmpLevelZero(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
 
-        // M-ETAL: dCubeArray{{.*}}.sample_compare(
-        // M-ETALLIB: call {{.*}}.sample_compare_depth_cube_array.f32(
+        // METAL: dCubeArray{{.*}}.sample_compare(
+        // METALLIB: call {{.*}}.sample_compare_depth_cube_array.f32(
         && float(1) == dCubeArray.SampleCmpLevelZero(shadowSampler, normalize(float4(u, 1-u, u, u)), 0)
-#endif
 #endif
 
         // Offset variant
@@ -545,21 +523,17 @@ bool TEST_texture_float()
         // METALLIB: call {{.*}}.gather_texture_2d.v4f32(
         && all(Tv(1) == t2D.Gather(samplerState, float2(u, u)))
 
-#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
-        // M-ETAL: tCube{{.*}}.gather(
-        // M-ETALLIB: call {{.*}}.gather_texture_cube.v4f32(
+        // METAL: tCube{{.*}}.gather(
+        // METALLIB: call {{.*}}.gather_texture_cube.v4f32(
         && all(Tv(1) == tCube.Gather(samplerState, normalize(float3(u, 1 - u, u))))
-#endif
 
         // METAL: t2DArray{{.*}}.gather(
         // METALLIB: call {{.*}}.gather_texture_2d_array.v4f32(
         && all(Tv(1) == t2DArray.Gather(samplerState, float3(u, u, 0)))
 
-#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
-        // M-ETAL: tCubeArray{{.*}}.gather(
-        // M-ETALLIB: call {{.*}}.gather_texture_cube_array.v4f32(
+        // METAL: tCubeArray{{.*}}.gather(
+        // METALLIB: call {{.*}}.gather_texture_cube_array.v4f32(
         && all(Tv(1) == tCubeArray.Gather(samplerState, float4(normalize(float3(u, 1 - u, u)), 0)))
-#endif
 
         // Offset variant
 
@@ -591,11 +565,9 @@ bool TEST_texture_float()
         // METALLIB: call {{.*}}.sample_texture_3d_grad.v4f32(
         && all(Tv(1) == t3D.SampleGrad(samplerState, float3(u, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
 
-#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
-        // M-ETAL: tCube{{.*}}.sample(
-        // M-ETALLIB: call {{.*}}.sample_texture_cube_grad.v4f32(
+        // METAL: tCube{{.*}}.sample(
+        // METALLIB: call {{.*}}.sample_texture_cube_grad.v4f32(
         && all(Tv(1) == tCube.SampleGrad(samplerState, normalize(float3(u, 1 - u, u)), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
-#endif
 
         // METAL: t2DArray{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_2d_array_grad.v4f32(

--- a/tests/metal/texture.slang
+++ b/tests/metal/texture.slang
@@ -96,7 +96,7 @@ depth2d<float> d2D;
 depthcube<float> dCube;
 //TEST_INPUT: Texture2D(size=4, content = one, arrayLength=2):name d2DArray
 depth2d_array<float> d2DArray;
-//TEST_INPUT: Texture2D(size=4, content = one, arrayLength=2):name dCubeArray
+//TEST_INPUT: TextureCube(size=4, content = one, arrayLength=2):name dCubeArray
 depthcube_array<float> dCubeArray;
 
 //TEST_INPUT: Sampler:name samplerState

--- a/tests/metal/texture.slang
+++ b/tests/metal/texture.slang
@@ -1,0 +1,672 @@
+//TEST:SIMPLE(filecheck=METAL): -stage compute -entry computeMain -target metal -DEMIT_SOURCE
+//TEST:SIMPLE(filecheck=METALLIB): -stage compute -entry computeMain -target metallib -DEMIT_SOURCE -DMETALLIB
+//TEST:SIMPLE(filecheck=HLSL): -stage compute -entry computeMain -target hlsl -DEMIT_SOURCE
+//TEST:SIMPLE(filecheck=SPIR): -stage compute -entry computeMain -target spirv -emit-spirv-directly -DEMIT_SOURCE
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=FUNCTIONAL):-slang -compute -dx12 -profile cs_6_6 -use-dxil -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=FUNCTIONAL):-vk -emit-spirv-directly -compute -shaderobj -output-using-type -render-feature hardware-device
+
+#if !defined(METALLIB)
+    // Metal doesn't support some features, and we need a new test that
+    // can check if the capability system can error them out properly.
+    #define NEED_TO_TEST_FOR_METAL_CAPABILITY 1
+#endif
+
+#if defined(EMIT_SOURCE)
+    // It appears that Slang-test doesn't initialize the depth cube texture
+    // properly.
+    #define TEST_WHEN_DEPTH_CUBE_WORKS
+#endif
+
+// There is an unknown issue with cabability system that causes an error
+// when Cube, CubeArray and 2DArray are used.
+//#define TEST_AFTER_FIXING_CAPABILITY_PROBLEM
+
+//TEST_INPUT: ubuffer(data=[0], stride=4):out,name outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+//TEST_INPUT: Texture1D(size=4, content = one):name t1D
+Texture1D<float> t1D;
+//TEST_INPUT: Texture2D(size=4, content = one):name t2D
+Texture2D<float> t2D;
+//TEST_INPUT: Texture3D(size=4, content = one):name t3D
+Texture3D<float> t3D;
+//TEST_INPUT: TextureCube(size=4, content = one):name tCube
+TextureCube<float> tCube;
+
+//TEST_INPUT: Texture1D(size=4, content = one, arrayLength=2):name t1DArray
+Texture1DArray<float> t1DArray;
+//TEST_INPUT: Texture2D(size=4, content = one, arrayLength=2):name t2DArray
+Texture2DArray<float> t2DArray;
+//TEST_INPUT: TextureCube(size=4, content = one, arrayLength=2):name tCubeArray
+TextureCubeArray<float> tCubeArray;
+
+// Metal doc says "For depth texture types, T must be float."
+__generic<T : __BuiltinType, let sampleCount:int=0, let format:int=0>
+typealias depth2d = __TextureImpl<
+    T,
+    __Shape2D,
+    0, // isArray
+    0, // isMS
+    sampleCount,
+    0, // access
+    1, // isShadow
+    0, // isCombined
+    format
+>;
+
+__generic<T : __BuiltinType, let sampleCount:int=0, let format:int=0>
+typealias depth2d_array = __TextureImpl<
+    T,
+    __Shape2D,
+    1, // isArray
+    0, // isMS
+    sampleCount,
+    0, // access
+    1, // isShadow
+    0, // isCombined
+    format
+>;
+
+__generic<T : __BuiltinType, let sampleCount:int=0, let format:int=0>
+typealias depthcube = __TextureImpl<
+    T,
+    __ShapeCube,
+    0, // isArray
+    0, // isMS
+    sampleCount,
+    0, // access
+    1, // isShadow
+    0, // isCombined
+    format
+>;
+
+__generic<T : __BuiltinType, let sampleCount:int=0, let format:int=0>
+typealias depthcube_array = __TextureImpl<
+    T,
+    __ShapeCube,
+    1, // isArray
+    0, // isMS
+    sampleCount,
+    0, // access
+    1, // isShadow
+    0, // isCombined
+    format
+>;
+
+//TEST_INPUT: Texture2D(size=4, content = one):name d2D
+depth2d<float> d2D;
+//TEST_INPUT: Texture2D(size=4, content = one):name dCube
+depthcube<float> dCube;
+//TEST_INPUT: Texture2D(size=4, content = one, arrayLength=2):name d2DArray
+depth2d_array<float> d2DArray;
+//TEST_INPUT: Texture2D(size=4, content = one, arrayLength=2):name dCubeArray
+depthcube_array<float> dCubeArray;
+
+//TEST_INPUT: Sampler:name samplerState
+SamplerState samplerState;
+//TEST_INPUT: Sampler:name shadowSampler
+SamplerComparisonState shadowSampler;
+
+
+bool TEST_texture_float()
+{
+    // Metal textures support `Tv` types, which "denotes a 4-component vector
+    // type based on the templated type <T> for declaring the texture type:
+    //  - If T is float, Tv is float4.
+    //  - If T is half, Tv is half4.
+    //  - If T is int, Tv is int4.
+    //  - If T is uint, Tv is uint4.
+    //  - If T is short, Tv is short4.
+    //  - If T is ushort, Tv is ushort4."
+    typealias Tv = vector<float,4>;
+
+    float u = 0;
+    float u2 = 0.5;
+    constexpr const float ddx = 0.0f;
+    constexpr const float ddy = 0.0f;
+
+    uint width = 0, height = 0, depth = 0;
+    float fwidth = 0.0f, fheight = 0.0f, fdepth = 0.0f;
+    uint numLevels = 0, elements = 0, sampleCount = 0;
+    float fnumLevels = 0.0f, felements = 0.0f;
+
+    bool voidResult = true;
+
+    // ======================
+    //  void GetDimensions()
+    // ======================
+
+    // METAL: .get_width(
+    // METALLIB: call {{.*}}.get_width_texture_1d(
+    t1D.GetDimensions(width);
+    voidResult = voidResult && (uint(4) == width);
+
+    // METAL: .get_width({{.*}}.get_num_mip_levels()
+    // METALLIB: call {{.*}}.get_num_mip_levels_texture_1d(
+    t1D.GetDimensions(0, width, numLevels);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(3) == numLevels);
+
+    // METAL: .get_width({{.*}}.get_height(
+    // METALLIB: call {{.*}}.get_height_texture_2d(
+    t2D.GetDimensions(width, height);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}.get_num_mip_levels()
+    // METALLIB: call {{.*}}.get_num_mip_levels_texture_2d(
+    t2D.GetDimensions(0, width, height, numLevels);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+    voidResult = voidResult && (uint(3) == numLevels);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}.get_depth(
+    // METALLIB: call {{.*}}.get_depth_texture_3d(
+    t3D.GetDimensions(width, height, depth);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+    voidResult = voidResult && (uint(4) == depth);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}.get_depth({{.*}}.get_num_mip_levels()
+    // METALLIB: call {{.*}}.get_num_mip_levels_texture_3d(
+    t3D.GetDimensions(0, width, height, depth, numLevels);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+    voidResult = voidResult && (uint(4) == depth);
+    voidResult = voidResult && (uint(3) == numLevels);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}
+    // METALLIB: call {{.*}}.get_height_texture_cube(
+    tCube.GetDimensions(width, height);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}.get_num_mip_levels()
+    // METALLIB: call {{.*}}.get_num_mip_levels_texture_cube(
+    tCube.GetDimensions(0, width, height, numLevels);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+    voidResult = voidResult && (uint(3) == numLevels);
+
+    // METAL: .get_width({{.*}}.get_array_size(
+    // METALLIB: call {{.*}}.get_array_size_texture_1d_array(
+    t1DArray.GetDimensions(width, elements);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(2) == elements);
+
+    // METAL: .get_width({{.*}}.get_num_mip_levels(
+    // METALLIB: call {{.*}}.get_num_mip_levels_texture_1d_array(
+    t1DArray.GetDimensions(0, width, elements, numLevels);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(2) == elements);
+    voidResult = voidResult && (uint(3) == numLevels);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}.get_array_size(
+    // METALLIB: call {{.*}}.get_array_size_texture_2d_array(
+    t2DArray.GetDimensions(width, height, elements);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+    voidResult = voidResult && (uint(2) == elements);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}.get_num_mip_levels(
+    // METALLIB: call {{.*}}.get_num_mip_levels_texture_2d_array(
+    t2DArray.GetDimensions(0, width, height, elements, numLevels);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+    voidResult = voidResult && (uint(2) == elements);
+    voidResult = voidResult && (uint(3) == numLevels);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}.get_array_size(
+    // METALLIB: call {{.*}}.get_array_size_texture_cube_array(
+    tCubeArray.GetDimensions(width, height, elements);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+    voidResult = voidResult && (uint(2) == elements);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}.get_num_mip_levels(
+    // METALLIB: call {{.*}}.get_num_mip_levels_texture_cube_array(
+    tCubeArray.GetDimensions(0, width, height, elements, numLevels);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+    voidResult = voidResult && (uint(2) == elements);
+    voidResult = voidResult && (uint(3) == numLevels);
+
+    bool result = voidResult
+        // ===============================
+        // float CalculateLevelOfDetail()
+        // ===============================
+
+#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
+        // Metal doesn't support LOD for 1D texture
+        && float(0) == t1D.CalculateLevelOfDetail(samplerState, u)
+#endif
+
+        // METAL: t2D{{.*}}.calculate_clamped_lod({{.*}}
+        // METALLIB: call {{.*}}.calculate_clamped_lod_texture_2d(
+        && float(0) == t2D.CalculateLevelOfDetail(samplerState, float2(u, u))
+
+        // METAL: t3D{{.*}}.calculate_clamped_lod({{.*}}
+        // METALLIB: call {{.*}}.calculate_clamped_lod_texture_3d(
+        && float(0) == t3D.CalculateLevelOfDetail(samplerState, float3(u, u, u))
+
+        // METAL: tCube{{.*}}.calculate_clamped_lod({{.*}}
+        // METALLIB: call {{.*}}.calculate_clamped_lod_texture_cube(
+        && float(0) == tCube.CalculateLevelOfDetail(samplerState, float3(u, u, u))
+
+        // METAL: t2DArray{{.*}}.calculate_clamped_lod({{.*}}
+        // METALLIB: call {{.*}}.calculate_clamped_lod_texture_2d_array(
+        && float(0) == t2DArray.CalculateLevelOfDetail(samplerState, float2(u, u))
+
+        // METAL: tCubeArray{{.*}}.calculate_clamped_lod({{.*}}
+        // METALLIB: call {{.*}}.calculate_clamped_lod_texture_cube_array(
+        && float(0) == tCubeArray.CalculateLevelOfDetail(samplerState, float3(u, u, u))
+
+        // ========================================
+        // float CalculateLevelOfDetailUnclamped()
+        // ========================================
+
+#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
+        // Metal doesn't support LOD for 1D texture
+        && float(0) >= t1D.CalculateLevelOfDetailUnclamped(samplerState, u)
+#endif
+
+        // METAL: t2D{{.*}}.calculate_unclamped_lod({{.*}}
+        // METALLIB: call {{.*}}.calculate_unclamped_lod_texture_2d(
+        && float(0) >= t2D.CalculateLevelOfDetailUnclamped(samplerState, float2(u, u))
+
+        // METAL: t3D{{.*}}.calculate_unclamped_lod({{.*}}
+        // METALLIB: call {{.*}}.calculate_unclamped_lod_texture_3d(
+        && float(0) >= t3D.CalculateLevelOfDetailUnclamped(samplerState, float3(u, u, u))
+
+        // METAL: tCube{{.*}}.calculate_unclamped_lod({{.*}}
+        // METALLIB: call {{.*}}.calculate_unclamped_lod_texture_cube(
+        && float(0) >= tCube.CalculateLevelOfDetailUnclamped(samplerState, float3(u, u, u))
+
+        // METAL: t2DArray{{.*}}.calculate_unclamped_lod({{.*}}
+        // METALLIB: call {{.*}}.calculate_unclamped_lod_texture_2d_array(
+        && float(0) >= t2DArray.CalculateLevelOfDetailUnclamped(samplerState, float2(u, u))
+
+        // METAL: tCubeArray{{.*}}.calculate_unclamped_lod({{.*}}
+        // METALLIB: call {{.*}}.calculate_unclamped_lod_texture_cube_array(
+        && float(0) >= tCubeArray.CalculateLevelOfDetailUnclamped(samplerState, float3(u, u, u))
+
+        // ===========
+        // T Sample()
+        // ===========
+
+        // METAL: t1D{{.*}}.sample(
+        // METALLIB: call {{.*}}.sample_texture_1d.v4f32(
+        && all(Tv(1) == t1D.Sample(samplerState, u))
+
+        // METAL: t2D{{.*}}.sample({{.*}}
+        // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
+        && all(Tv(1) == t2D.Sample(samplerState, float2(u, u)))
+
+        // METAL: t3D{{.*}}.sample({{.*}}
+        // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
+        && all(Tv(1) == t3D.Sample(samplerState, float3(u, u, u)))
+
+#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
+        // M-ETAL: tCube{{.*}}.sample({{.*}}
+        // M-ETALLIB: call {{.*}}.sample_texture_cube.v4f32(
+        && all(Tv(1) == tCube.Sample(samplerState, normalize(float3(u, 1 - u, u))))
+#endif
+
+        // METAL: t1DArray{{.*}}.sample(
+        // METALLIB: call {{.*}}.sample_texture_1d_array.v4f32(
+        && all(Tv(1) == t1DArray.Sample(samplerState, float2(u, 0)))
+
+        // METAL: t2DArray{{.*}}.sample({{.*}}
+        // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
+        && all(Tv(1) == t2DArray.Sample(samplerState, float3(u, u, 0)))
+
+#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
+        // M-ETAL: tCubeArray{{.*}}.sample({{.*}}
+        // M-ETALLIB: call {{.*}}.sample_texture_cube_array.v4f32(
+        && all(Tv(1) == tCubeArray.Sample(samplerState, normalize(float4(u, 1 - u, u, 0))))
+#endif
+
+        // Offset variant
+
+#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
+        // Metal doesn't support Offset for 1D and Cube texture
+        && all(Tv(1) == t1D.Sample(samplerState, u2, 1))
+        && all(Tv(1) == t1DArray.Sample(samplerState, float2(u2, 0), 1))
+#endif
+
+        // METAL: t2D{{.*}}.sample({{.*}}
+        // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
+        && all(Tv(1) == t2D.Sample(samplerState, float2(u, u), int2(1, 1)))
+
+        // METAL: t3D{{.*}}.sample({{.*}}
+        // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
+        && all(Tv(1) == t3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1)))
+
+        // METAL: t2DArray{{.*}}.sample({{.*}}
+        // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
+        && all(Tv(1) == t2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1)))
+
+        // Clamp variant
+
+#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
+        // Metal doesn't support Offset for 1D and Cube texture
+        && all(Tv(1) == t1D.Sample(samplerState, u2, 1, float(1)))
+        && all(Tv(1) == t1DArray.Sample(samplerState, float2(u2, 0), 1, float(1)))
+#endif
+
+        // METAL: t2D{{.*}}.sample({{.*}} min_lod_clamp(
+        // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
+        && all(Tv(1) == t2D.Sample(samplerState, float2(u, u), int2(1, 1), float(1)))
+
+        // METAL: t3D{{.*}}.sample({{.*}} min_lod_clamp(
+        // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
+        && all(Tv(1) == t3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1), float(1)))
+
+        // METAL: t2DArray{{.*}}.sample({{.*}} min_lod_clamp(
+        // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
+        && all(Tv(1) == t2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1), float(1)))
+
+        // ===============
+        // T SampleBias()
+        // ===============
+
+#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
+        // Metal doesn't support Bias for 1D texture
+        && all(Tv(1) == t1D.SampleBias(samplerState, u, float(-1)))
+        && all(Tv(1) == t1DArray.SampleBias(samplerState, float2(u, 0), float(-1)))
+#endif
+
+        // METAL: t2D{{.*}}.sample({{.*}}
+        // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
+        && all(Tv(1) == t2D.SampleBias(samplerState, float2(u, u), float(-1)))
+
+        // METAL: t3D{{.*}}.sample({{.*}}
+        // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
+        && all(Tv(1) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1)))
+
+#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
+        // M-ETAL: tCube{{.*}}.sample({{.*}}
+        // M-ETALLIB: call {{.*}}.sample_texture_cube.v4f32(
+        && all(Tv(1) == tCube.SampleBias(samplerState, normalize(float3(u, 1 - u, u)), float(-1)))
+#endif
+
+        // METAL: t2DArray{{.*}}.sample({{.*}}
+        // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
+        && all(Tv(1) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1)))
+
+#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
+        // M-ETAL: tCubeArray{{.*}}.sample({{.*}}
+        // M-ETALLIB: call {{.*}}.sample_texture_cube_array.v4f32(
+        && all(Tv(1) == tCubeArray.SampleBias(samplerState, normalize(float4(u, 1 - u, u, 0)), float(-1)))
+#endif
+
+        // Offset variant
+
+#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
+        // Metal doesn't support Offset for 1D and Cube texture
+        && all(Tv(1) == t1D.SampleBias(samplerState, u2, float(-1), 1))
+        && all(Tv(1) == t1DArray.SampleBias(samplerState, float2(u2, 0), float(-1), 1))
+#endif
+
+        // METAL: t2D{{.*}}.sample({{.*}}
+        // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
+        && all(Tv(1) == t2D.SampleBias(samplerState, float2(u, u), float(-1), int2(1, 1)))
+
+        // METAL: t3D{{.*}}.sample({{.*}}
+        // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
+        && all(Tv(1) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1), int3(1, 1, 1)))
+
+        // METAL: t2DArray{{.*}}.sample({{.*}}
+        // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
+        && all(Tv(1) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1), int2(1, 1)))
+
+        // ===================================
+        //  T SampleLevel()
+        // ===================================
+
+#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
+        // Metal doesn't support LOD for 1D texture
+        && all(Tv(1) == t1D.SampleLevel(samplerState, u, 0))
+        && all(Tv(1) == t1DArray.SampleLevel(samplerState, float2(u, 0), 0))
+#endif
+
+        // METAL: t2D{{.*}}.sample({{.*}} level(
+        // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
+        && all(Tv(1) == t2D.SampleLevel(samplerState, float2(u, u), 0))
+
+        // METAL: t3D{{.*}}.sample({{.*}} level(
+        // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
+        && all(Tv(1) == t3D.SampleLevel(samplerState, float3(u, u, u), 0))
+
+#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
+        // M-ETAL: tCube{{.*}}.sample({{.*}} level(
+        // M-ETALLIB: call {{.*}}.sample_texture_cube.v4f32(
+        && all(Tv(1) == tCube.SampleLevel(samplerState, normalize(float3(u, 1 - u, u)), 0))
+#endif
+
+        // METAL: t2DArray{{.*}}.sample({{.*}} level(
+        // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
+        && all(Tv(1) == t2DArray.SampleLevel(samplerState, float3(u, u, 0), 0))
+
+        // METAL: tCubeArray{{.*}}.sample({{.*}} level(
+        // METALLIB: call {{.*}}.sample_texture_cube_array.v4f32(
+        && all(Tv(1) == tCubeArray.SampleLevel(samplerState, float4(u, u, u, 0), 0))
+
+        // Offset variant
+
+#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
+        // Metal doesn't support LOD for 1D texture
+        && all(Tv(1) == t1D.SampleLevel(samplerState, u2, 0, 1))
+        && all(Tv(1) == t1DArray.SampleLevel(samplerState, float2(u2, 0), 0, 1))
+#endif
+
+        // METAL: t2D{{.*}}.sample({{.*}} level(
+        // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
+        && all(Tv(1) == t2D.SampleLevel(samplerState, float2(u, u), 0, int2(1, 1)))
+
+        // METAL: t3D{{.*}}.sample({{.*}} level(
+        // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
+        && all(Tv(1) == t3D.SampleLevel(samplerState, float3(u, u, u), 0, int3(1, 1, 1)))
+
+        // METAL: t2DArray{{.*}}.sample({{.*}} level(
+        // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
+        && all(Tv(1) == t2DArray.SampleLevel(samplerState, float3(u, u, 0), 0, int2(1, 1)))
+
+        // ==================
+        // float SampleCmp()
+        // ==================
+
+        // METAL: d2D{{.*}}.sample_compare(
+        // METALLIB: call {{.*}}.sample_compare_depth_2d.f32(
+        && float(1) == d2D.SampleCmp(shadowSampler, float2(u, u), 0)
+
+#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
+        // M-ETAL: d2DArray{{.*}}.sample_compare(
+        // M-ETALLIB: call {{.*}}.sample_compare_depth_2d_array.f32(
+        && float(1) == d2DArray.SampleCmp(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
+#endif
+
+#if defined(TEST_WHEN_DEPTH_CUBE_WORKS)
+#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
+        // M-ETAL: dCube{{.*}}.sample_compare(
+        // M-ETALLIB: call {{.*}}.sample_compare_depth_cube.f32(
+        && float(1) == dCube.SampleCmp(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
+
+        // M-ETAL: dCubeArray{{.*}}.sample_compare(
+        // M-ETALLIB: call {{.*}}.sample_compare_depth_cube_array.f32(
+        && float(1) == dCubeArray.SampleCmp(shadowSampler, normalize(float4(u, 1-u, u, u)), 0)
+#endif
+#endif
+
+        // Offset variant
+
+        // METAL: d2D{{.*}}.sample_compare(
+        // METALLIB: call {{.*}}.sample_compare_depth_2d.f32(
+        && float(1) == d2D.SampleCmp(shadowSampler, float2(u2, u), 0, int2(0, 0))
+
+        // ===================================
+        //  float SampleCmpLevelZero()
+        // ===================================
+
+        // METAL: d2D{{.*}}.sample_compare(
+        // METALLIB: call {{.*}}.sample_compare_depth_2d.f32(
+        && float(1) == d2D.SampleCmpLevelZero(shadowSampler, float2(u, u), 0)
+
+#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
+        // M-ETAL: d2DArray{{.*}}.sample_compare(
+        // M-ETALLIB: call {{.*}}.sample_compare_depth_2d_array.f32(
+        && float(1) == d2DArray.SampleCmpLevelZero(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
+#endif
+
+#if defined(TEST_WHEN_DEPTH_CUBE_WORKS)
+#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
+        // M-ETAL: dCube{{.*}}.sample_compare(
+        // M-ETALLIB: call {{.*}}.sample_compare_depth_cube.f32(
+        && float(1) == dCube.SampleCmpLevelZero(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
+
+        // M-ETAL: dCubeArray{{.*}}.sample_compare(
+        // M-ETALLIB: call {{.*}}.sample_compare_depth_cube_array.f32(
+        && float(1) == dCubeArray.SampleCmpLevelZero(shadowSampler, normalize(float4(u, 1-u, u, u)), 0)
+#endif
+#endif
+
+        // Offset variant
+
+        // METAL: d2D{{.*}}.sample_compare(
+        // METALLIB: call {{.*}}.sample_compare_depth_2d.f32(
+        && float(1) == d2D.SampleCmpLevelZero(shadowSampler, float2(u2, u), 0, int2(0, 0))
+
+        // ==================================
+        //  vector<T,4> Gather()
+        // ==================================
+
+        // METAL: t2D{{.*}}.gather(
+        // METALLIB: call {{.*}}.gather_texture_2d.v4f32(
+        && all(Tv(1) == t2D.Gather(samplerState, float2(u, u)))
+
+#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
+        // M-ETAL: tCube{{.*}}.gather(
+        // M-ETALLIB: call {{.*}}.gather_texture_cube.v4f32(
+        && all(Tv(1) == tCube.Gather(samplerState, normalize(float3(u, 1 - u, u))))
+#endif
+
+        // METAL: t2DArray{{.*}}.gather(
+        // METALLIB: call {{.*}}.gather_texture_2d_array.v4f32(
+        && all(Tv(1) == t2DArray.Gather(samplerState, float3(u, u, 0)))
+
+#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
+        // M-ETAL: tCubeArray{{.*}}.gather(
+        // M-ETALLIB: call {{.*}}.gather_texture_cube_array.v4f32(
+        && all(Tv(1) == tCubeArray.Gather(samplerState, float4(normalize(float3(u, 1 - u, u)), 0)))
+#endif
+
+        // Offset variant
+
+        // METAL: t2D{{.*}}.gather(
+        // METALLIB: call {{.*}}.gather_texture_2d.v4f32(
+        && all(Tv(1) == t2D.Gather(samplerState, float2(u2, u), int2(0, 0)))
+
+        // METAL: t2DArray{{.*}}.gather(
+        // METALLIB: call {{.*}}.gather_texture_2d_array.v4f32(
+        && all(Tv(1) == t2DArray.Gather(samplerState, float3(u2, u, 0), int2(0, 0)))
+
+        // =====================================
+        //  T SampleGrad()
+        // =====================================
+
+#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
+        // Metal doesn't support LOD for 1D texture
+        && all(Tv(1) == t1D.SampleGrad(samplerState, 0.0f, ddx, ddy))
+        && all(Tv(1) == t1DArray.SampleGrad(samplerState, float2(0.0f, 0.0f), ddx, ddy))
+        && all(Tv(1) == t1D.SampleGrad(samplerState, 0.0f, ddx, ddy, 0))
+        && all(Tv(1) == t1DArray.SampleGrad(samplerState, float2(0.0f, 0.0f), ddx, ddy, 0))
+#endif
+
+        // METAL: t2D{{.*}}.sample(
+        // METALLIB: call {{.*}}.sample_texture_2d_grad.v4f32(
+        && all(Tv(1) == t2D.SampleGrad(samplerState, float2(u, u), float2(ddx, ddx), float2(ddy, ddy)))
+
+        // METAL: t3D{{.*}}.sample(
+        // METALLIB: call {{.*}}.sample_texture_3d_grad.v4f32(
+        && all(Tv(1) == t3D.SampleGrad(samplerState, float3(u, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
+
+#if defined(TEST_AFTER_FIXING_CAPABILITY_PROBLEM)
+        // M-ETAL: tCube{{.*}}.sample(
+        // M-ETALLIB: call {{.*}}.sample_texture_cube_grad.v4f32(
+        && all(Tv(1) == tCube.SampleGrad(samplerState, normalize(float3(u, 1 - u, u)), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
+#endif
+
+        // METAL: t2DArray{{.*}}.sample(
+        // METALLIB: call {{.*}}.sample_texture_2d_array_grad.v4f32(
+        && all(Tv(1) == t2DArray.SampleGrad(samplerState, float3(u, u, 0.0f), float2(ddx, ddx), float2(ddy, ddy)))
+
+        // Offset variant
+
+        // METAL: t2D{{.*}}.sample(
+        // METALLIB: call {{.*}}.sample_texture_2d_grad.v4f32(
+        && all(Tv(1) == t2D.SampleGrad(samplerState, float2(u2, u), float2(ddx, ddx), float2(ddy, ddy), int2(0, 0)))
+
+        // METAL: t3D{{.*}}.sample(
+        // METALLIB: call {{.*}}.sample_texture_3d_grad.v4f32(
+        && all(Tv(1) == t3D.SampleGrad(samplerState, float3(u2, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy), int3(0, 0, 0)))
+
+        // METAL: t2DArray{{.*}}.sample(
+        // METALLIB: call {{.*}}.sample_texture_2d_array_grad.v4f32(
+        && all(Tv(1) == t2DArray.SampleGrad(samplerState, float3(u2, u, 0.0f), float2(ddx, ddx), float2(ddy, ddy), int2(0, 0)))
+
+        // ===================
+        //  T Load()
+        // ===================
+        // T Load(vector<int, Shape.dimensions+isArray> location)
+        // T Load(vector<int, Shape.dimensions+isArray> location, int sampleIndex)
+
+        // METAL: t1D{{.*}}.read(
+        // METALLIB: call {{.*}}.read_texture_1d.v4f32(
+        && all(Tv(1) == t1D.Load(int2(0, 0)))
+
+        // METAL: t2D{{.*}}.read(
+        // METALLIB: call {{.*}}.read_texture_2d.v4f32(
+        && all(Tv(1) == t2D.Load(int3(0, 0, 0)))
+
+        // METAL: t3D{{.*}}.read(
+        // METALLIB: call {{.*}}.read_texture_3d.v4f32(
+        && all(Tv(1) == t3D.Load(int4(0, 0, 0, 0)))
+
+        // METAL: t1DArray{{.*}}.read(
+        // METALLIB: call {{.*}}.read_texture_1d_array.v4f32(
+        && all(Tv(1) == t1DArray.Load(int3(0, 0, 0)))
+
+        // METAL: t2DArray{{.*}}.read(
+        // METALLIB: call {{.*}}.read_texture_2d_array.v4f32(
+        && all(Tv(1) == t2DArray.Load(int4(0, 0, 0, 0)))
+
+        // Offset variant
+
+#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
+        // Metal doesn't support offset variants for Load
+        && all(Tv(1) == t1D.Load(int2(0, 0), 0))
+        && all(Tv(1) == t2D.Load(int3(0, 0, 0), int2(0,0)))
+        && all(Tv(1) == t3D.Load(int4(0, 0, 0, 0), int3(0, 0, 0)))
+        && all(Tv(1) == t1DArray.Load(int3(0, 0, 0), 0))
+        && all(Tv(1) == t2DArray.Load(int4(0, 0, 0, 0), int2(0, 0)))
+#endif
+        ;
+
+    return result;
+}
+
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // SPIR: OpEntryPoint
+    // HLSL: void computeMain(
+
+    bool result = true
+        && TEST_texture_float()
+        ;
+
+    // FUNCTIONAL: 1
+    outputBuffer[0] = int(result);
+}

--- a/tests/metal/texture.slang
+++ b/tests/metal/texture.slang
@@ -618,8 +618,6 @@ bool TEST_texture_float()
         // ===================
         //  T Load()
         // ===================
-        // T Load(vector<int, Shape.dimensions+isArray> location)
-        // T Load(vector<int, Shape.dimensions+isArray> location, int sampleIndex)
 
         // METAL: t1D{{.*}}.read(
         // METALLIB: call {{.*}}.read_texture_1d.v4f32(


### PR DESCRIPTION
This commit is to implement texture functions for Metal target.

The following functions are implemented and tested.
 - GetDimensions()
 - CalculateLevelOfDetail()
 - CalculateLevelOfDetailUnclamped()
 - Sample()
 - SampleBias()
 - SampleLevel()
 - SampleCmp()
 - SampleCmpLevelZero()
 - Gather()
 - SampleGrad()
 - Load()

Metal has limited support for the texture functions compared to HLSL.
 - LOD is not supported for 1D texture,
 - Depth textures are limited to 2D, 2DArray, Cube and CubeArray textures.
 - "Offset" variants are limited to 2D, 2DArray, 2D-Depth, 2DArray-Depth and 3D textures.

The functions that cannot be implemented for Metal should properly be handled by the capability system later.