### PR TITLE
Fixes running examples from generated SLN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,10 +448,10 @@ endif()
 
 if(SLANG_ENABLE_PREBUILT_BINARIES)
     if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-		file(GLOB prebuilt_binaries "${CMAKE_SOURCE_DIR}/external/slang-binaries/bin/windows-x64/*")
+        file(GLOB prebuilt_binaries "${CMAKE_SOURCE_DIR}/external/slang-binaries/bin/windows-x64/*")
         add_custom_target(
             copy-prebuilt-binaries ALL
-			COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/$<CONFIG>/${runtime_subdir}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/$<CONFIG>/${runtime_subdir}
             COMMAND ${CMAKE_COMMAND} -E copy_if_different 
                 ${prebuilt_binaries}
                 ${CMAKE_BINARY_DIR}/$<CONFIG>/${runtime_subdir}
@@ -701,10 +701,10 @@ if (SLANG_ENABLE_EXAMPLES AND SLANG_ENABLE_GFX)
     )
     set_target_properties(all-examples PROPERTIES FOLDER examples)
     function(example dir)
-		set(debug_dir ${dir})
-		if (MSVC)
-			set(debug_dir ${CMAKE_BINARY_DIR}/${dir})
-		endif()
+        set(debug_dir ${dir})
+        if (MSVC)
+            set(debug_dir ${CMAKE_BINARY_DIR}/${dir})
+        endif()
 
         slang_add_target(
             ${dir}
@@ -727,36 +727,36 @@ if (SLANG_ENABLE_EXAMPLES AND SLANG_ENABLE_GFX)
             ${ARGN}
         )
 
-		if (MSVC)
-			get_filename_component(example_target ${dir} NAME)
-			file(GLOB asset_files
-				"${CMAKE_SOURCE_DIR}/${dir}/*.slang"
-				"${CMAKE_SOURCE_DIR}/${dir}/*.jpg"
-				"${CMAKE_SOURCE_DIR}/${dir}/*.obj"
-				"${CMAKE_SOURCE_DIR}/${dir}/*.mtl"
-			)
+        if (MSVC)
+            get_filename_component(example_target ${dir} NAME)
+            file(GLOB asset_files
+                "${CMAKE_SOURCE_DIR}/${dir}/*.slang"
+                "${CMAKE_SOURCE_DIR}/${dir}/*.jpg"
+                "${CMAKE_SOURCE_DIR}/${dir}/*.obj"
+                "${CMAKE_SOURCE_DIR}/${dir}/*.mtl"
+            )
 
-			list(LENGTH asset_files asset_files_length)
-				if (asset_files_length GREATER 0)
-				set(copy_assets_target "${example_target}-copy-assets")
+            list(LENGTH asset_files asset_files_length)
+                if (asset_files_length GREATER 0)
+                set(copy_assets_target "${example_target}-copy-assets")
 
-				add_custom_target(
-					${copy_assets_target}
-					COMMAND ${CMAKE_COMMAND} -E make_directory ${debug_dir}
-					COMMAND ${CMAKE_COMMAND} -E copy_if_different ${asset_files} ${debug_dir}
-					COMMENT "Copy example assets to ${debug_dir}"
-				)
+                add_custom_target(
+                    ${copy_assets_target}
+                    COMMAND ${CMAKE_COMMAND} -E make_directory ${debug_dir}
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${asset_files} ${debug_dir}
+                    COMMENT "Copy example assets to ${debug_dir}"
+                )
 
-				set_target_properties(${copy_assets_target} PROPERTIES FOLDER "examples/copy_assets")
+                set_target_properties(${copy_assets_target} PROPERTIES FOLDER "examples/copy_assets")
 
-				add_dependencies(${example_target} ${copy_assets_target})
+                add_dependencies(${example_target} ${copy_assets_target})
 
-				# Copy DirectX shader binaries so signing doesn't fail when running from Visual Studio
-				if (SLANG_ENABLE_PREBUILT_BINARIES)
-					add_dependencies(${example_target} copy-prebuilt-binaries)
-				endif()
-			endif()
-		endif()
+                # Copy DirectX shader binaries so signing doesn't fail when running from Visual Studio
+                if (SLANG_ENABLE_PREBUILT_BINARIES)
+                    add_dependencies(${example_target} copy-prebuilt-binaries)
+                endif()
+            endif()
+        endif()
     endfunction()
 
     example(examples/autodiff-texture WIN32_EXECUTABLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,10 +448,12 @@ endif()
 
 if(SLANG_ENABLE_PREBUILT_BINARIES)
     if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+		file(GLOB prebuilt_binaries "${CMAKE_SOURCE_DIR}/external/slang-binaries/bin/windows-x64/*")
         add_custom_target(
             copy-prebuilt-binaries ALL
-            COMMAND ${CMAKE_COMMAND} -E copy_directory
-                ${CMAKE_SOURCE_DIR}/external/slang-binaries/bin/windows-x64
+			COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/$<CONFIG>/${runtime_subdir}
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different 
+                ${prebuilt_binaries}
                 ${CMAKE_BINARY_DIR}/$<CONFIG>/${runtime_subdir}
             VERBATIM
         )
@@ -699,6 +701,11 @@ if (SLANG_ENABLE_EXAMPLES AND SLANG_ENABLE_GFX)
     )
     set_target_properties(all-examples PROPERTIES FOLDER examples)
     function(example dir)
+		set(debug_dir ${dir})
+		if (MSVC)
+			set(debug_dir ${CMAKE_BINARY_DIR}/${dir})
+		endif()
+
         slang_add_target(
             ${dir}
             EXECUTABLE
@@ -716,9 +723,40 @@ if (SLANG_ENABLE_EXAMPLES AND SLANG_ENABLE_GFX)
                 $<$<BOOL:${SLANG_ENABLE_XLIB}>:SLANG_ENABLE_XLIB>
             REQUIRED_BY all-examples
             FOLDER examples
-            DEBUG_DIR ${dir}
+            DEBUG_DIR ${debug_dir}
             ${ARGN}
         )
+
+		if (MSVC)
+			get_filename_component(example_target ${dir} NAME)
+			file(GLOB asset_files
+				"${CMAKE_SOURCE_DIR}/${dir}/*.slang"
+				"${CMAKE_SOURCE_DIR}/${dir}/*.jpg"
+				"${CMAKE_SOURCE_DIR}/${dir}/*.obj"
+				"${CMAKE_SOURCE_DIR}/${dir}/*.mtl"
+			)
+
+			list(LENGTH asset_files asset_files_length)
+				if (asset_files_length GREATER 0)
+				set(copy_assets_target "${example_target}-copy-assets")
+
+				add_custom_target(
+					${copy_assets_target}
+					COMMAND ${CMAKE_COMMAND} -E make_directory ${debug_dir}
+					COMMAND ${CMAKE_COMMAND} -E copy_if_different ${asset_files} ${debug_dir}
+					COMMENT "Copy example assets to ${debug_dir}"
+				)
+
+				set_target_properties(${copy_assets_target} PROPERTIES FOLDER "examples/copy_assets")
+
+				add_dependencies(${example_target} ${copy_assets_target})
+
+				# Copy DirectX shader binaries so signing doesn't fail when running from Visual Studio
+				if (SLANG_ENABLE_PREBUILT_BINARIES)
+					add_dependencies(${example_target} copy-prebuilt-binaries)
+				endif()
+			endif()
+		endif()
     endfunction()
 
     example(examples/autodiff-texture WIN32_EXECUTABLE)


### PR DESCRIPTION
This CL contains changes to CMakeLists.txt that enables the examples to run from within Visual Studio when using CMake generated solution. Previously the working directory was set to examples/<example name> and which resulted in an invalid path in the generated project files. Additionally, the assets (shaders, images, models) were not in location that was accessible to the executable when ran from within Visual Studio.

- Changed examples to use ${CMAKE_BINARY_DIR}/${dir} instead of ${dir} if generator is MSVC.
- Add custom target to assets (shaders, images, models, etc) to example subdir under ${CMAKE_BINARY_DIR}
- Add dependency to copy prebuilt binaries if building examples in MSVC so DirectX shader signing doesn't fail
- Changed copy-prebuilt-binaries to use copy_if_different to avoid redundant copies