### PR TITLE
Increase CMake version requirement from 3.20 to 3.25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.25)
 
 # Our module dir, include that now so that we can get the version automatically
 # from git describe

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -94,7 +94,7 @@ Install CMake and Ninja.
 ```
 $ sudo apt-get install cmake ninja-build
 ```
-> Warning: Currently the required CMake version is 3.20 or above.
+> Warning: Currently the required CMake version is 3.25 or above.
 
 Run CMake with a following command to generate Makefile:
 ```


### PR DESCRIPTION
This commit increases the minimum CMake version from 3.20 to 3.25.

I was trying to see if I can lower it to 3.16, but I found that we are currently using CMake feature that requires a version 3.25 not 3.20.

This finding is not new. I made a similar change to CMakePresets.json a few days ago. At that time, I didn't realize that the same change had to be made for CMakeList.txt as well.