### PR TITLE
Increase MSVC warning level to 4 for Slang projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,7 +328,7 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
     slang_add_target(
         source/slang-glslang
         MODULE
-        USE_EXTRA_WARNINGS
+        USE_FEWER_WARNINGS
         LINK_WITH_PRIVATE glslang SPIRV SPIRV-Tools-opt
         INSTALL
     )

--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -75,6 +75,7 @@ add_custom_command(
 slang_add_target(
     slang-capability-defs
     OBJECT
+    USE_EXTRA_WARNINGS
     EXPLICIT_SOURCE ${SLANG_CAPABILITY_GENERATED_HEADERS}
     LINK_WITH_PRIVATE core
     INCLUDE_DIRECTORIES_PUBLIC
@@ -86,6 +87,7 @@ slang_add_target(
 slang_add_target(
     slang-capability-lookup
     OBJECT
+    USE_EXTRA_WARNINGS
     EXPLICIT_SOURCE ${SLANG_CAPABILITY_GENERATED_SOURCE}
     LINK_WITH_PRIVATE core slang-capability-defs
     EXCLUDE_FROM_ALL
@@ -177,6 +179,7 @@ add_custom_command(
 slang_add_target(
     slang-lookup-tables
     OBJECT
+    USE_EXTRA_WARNINGS
     EXPLICIT_SOURCE ${SLANG_LOOKUP_GENERATED_SOURCE}
     LINK_WITH_PRIVATE core SPIRV-Headers
     EXCLUDE_FROM_ALL
@@ -196,6 +199,7 @@ slang_add_target(
     OBJECT
     TARGET_NAME slang-no-embedded-stdlib
     EXTRA_SOURCE_DIRS ${SLANG_CAPATURE_REPLAY_SYSTEM}
+    USE_EXTRA_WARNINGS
     EXCLUDE_FROM_ALL
     EXTRA_COMPILE_DEFINITIONS_PUBLIC SLANG_STATIC
     LINK_WITH_PRIVATE
@@ -249,6 +253,7 @@ slang_add_target(
     .
     ${SLANG_LIB_TYPE}
     EXTRA_SOURCE_DIRS ${SLANG_CAPATURE_REPLAY_SYSTEM}
+    USE_EXTRA_WARNINGS
     LINK_WITH_PRIVATE
         core
         compiler-core
@@ -265,6 +270,11 @@ slang_add_target(
     INSTALL
     PUBLIC_HEADERS ${slang_SOURCE_DIR}/slang*.h
 )
+
+if(MSVC)
+    # Treat warnings as error
+    target_compile_options(slang PRIVATE /WX)
+endif()
 
 if(SLANG_EMBED_STDLIB_SOURCE)
     target_link_libraries(slang PRIVATE slang-meta-headers)


### PR DESCRIPTION
This commit increases the MSVC warning level from 2 to 4 for Slang projects.

And this commit lowers the warning level from 4 to 2 for glslang, because we are not interested in the warnings from glslang.