### PR TITLE
Print memory leak info in Debug build of slangc.exe

### DIFF
--- a/source/core/slang-std-writers.cpp
+++ b/source/core/slang-std-writers.cpp
@@ -10,8 +10,8 @@ namespace Slang
 {
     RefPtr<StdWriters> stdWriters(new StdWriters);
 
-    RefPtr<FileWriter> stdError(new FileWriter(stderr, WriterFlag::AutoFlush));
-    RefPtr<FileWriter> stdOut(new FileWriter(stdout, WriterFlag::AutoFlush));
+    RefPtr<FileWriter> stdError(new FileWriter(stderr, WriterFlag::AutoFlush | WriterFlag::IsUnowned));
+    RefPtr<FileWriter> stdOut(new FileWriter(stdout, WriterFlag::AutoFlush | WriterFlag::IsUnowned));
 
     stdWriters->setWriter(SLANG_WRITER_CHANNEL_STD_ERROR, stdError);
     stdWriters->setWriter(SLANG_WRITER_CHANNEL_STD_OUTPUT, stdOut);

--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -139,6 +139,15 @@ int wmain(int argc, wchar_t** argv)
     }
 
 #ifdef _MSC_VER
+    // "When _DEBUG isn't defined, calls to _CrtSetReportMode are removed
+    // during preprocessing."
+    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+
     _CrtDumpMemoryLeaks();
 #endif
 


### PR DESCRIPTION
When memory leak is detected, this commit will dump the information about the memory leak. This feature is available only in Debug build on Windows platform.

Also note that the message will not be printed on the client applications that use slang.dll, because the printing happens as a part of slangc.exe not slang.dll.

I found a bug that Slang::StdWriters was closing `stdout` and `stderr` in its destructor, which prevented Crt functions to print the messages to `stdout` and `stderr`.