### PR TITLE
CTS: do not continue on error

### DIFF
--- a/.github/workflows/debug-github-slack.yml
+++ b/.github/workflows/debug-github-slack.yml
@@ -1,0 +1,41 @@
+name: Github-Slack-Notification
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: "Import signing certificate"
+      env:
+        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+        P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+        KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+      run: |
+        echo "Hello, World!" "\"--- $BUILD_CERTIFICATE_BASE64 ---\""
+        echo "Hello, World!" "\"--- $P12_PASSWORD ---\""
+        echo "Hello, World!" "\"--- $KEYCHAIN_PASSWORD ---\""
+    - name: Run some commands
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      id: run-commands
+      run: |
+        echo "Hello, World!" "\"--- $SLACK_WEBHOOK_URL ---\""
+        exit 0
+    - name: Send custom JSON data to Slack workflow
+      id: slack
+      if : always()
+      uses: slackapi/slack-github-action@v1.26.0
+      with:
+        payload: |
+          {
+            "CTS-Nightly": "CTS nightly status: ${{ job.status }}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/vk-gl-cts-nightly.yml
+++ b/.github/workflows/vk-gl-cts-nightly.yml
@@ -1,8 +1,12 @@
 name: VK-GL-CTS Nightly
 
 on:
-  schedule:
-    - cron: '00 07 * * *'
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  # schedule:
+  #   - cron: '00 07 * * *'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -11,8 +15,8 @@ env:
 jobs:
   build:
     runs-on: [Windows, self-hosted]
-    timeout-minutes: 180
-    continue-on-error: true
+    timeout-minutes: 100
+    continue-on-error: false
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/vk-gl-cts-nightly.yml
+++ b/.github/workflows/vk-gl-cts-nightly.yml
@@ -12,11 +12,11 @@ concurrency:
   cancel-in-progress: true
 env:
   DISABLE_CTS_SLANG: 0
+  SLACK_WEBHOOK_URL: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
 jobs:
   build:
     runs-on: [Windows, self-hosted]
-    timeout-minutes: 100
-    continue-on-error: false
+    timeout-minutes: 1
     steps:
     - uses: actions/checkout@v4
       with:
@@ -58,3 +58,12 @@ jobs:
       working-directory: ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.3-win64\VK-GL-CTS_WithSlang-0.0.3-win64
       run: |
         .\deqp-vk.exe --deqp-archive-dir=${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.3-win64\VK-GL-CTS_WithSlang-0.0.3-win64 --deqp-caselist-file=${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.3-win64\VK-GL-CTS_WithSlang-0.0.3-win64\slang-passing-tests.txt
+    - name: result notification
+      id: slack-notify
+      if : always()
+      uses: slackapi/slack-github-action@v1.26.0
+      with:
+        payload: |
+          {
+            "CTS-Nightly": "CTS nightly status: ${{ job.status }}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }


### PR DESCRIPTION
The CTS nightly stops report error because of `continue-on-error` is set to true. Set it false such that we can know as soon as it fails.