### PR TITLE
Fix pointers link in userguide

### DIFF
--- a/docs/user-guide/toc.html
+++ b/docs/user-guide/toc.html
@@ -40,7 +40,7 @@
 <li data-link="convenience-features#subscript-operator"><span>Subscript Operator</span></li>
 <li data-link="convenience-features#optionalt-type"><span>`Optional&lt;T&gt;` type</span></li>
 <li data-link="convenience-features#reinterprett-operation"><span>`reinterpret&lt;T&gt;` operation</span></li>
-<li data-link="convenience-features#pointers"><span>Pointers</span></li>
+<li data-link="convenience-features#pointers-limited"><span>Pointers (limited)</span></li>
 <li data-link="convenience-features#struct-inheritance-limited"><span>`struct` inheritance (limited)</span></li>
 <li data-link="convenience-features#extensions"><span>Extensions</span></li>
 <li data-link="convenience-features#multi-level-break"><span>Multi-level break</span></li>


### PR DESCRIPTION
Adding (limited) to the header in a previous doc change broke the link.