### PR TITLE
Disable slang profiler in production build

### DIFF
--- a/.github/workflows/release-linux-arm64.yml
+++ b/.github/workflows/release-linux-arm64.yml
@@ -29,6 +29,7 @@ jobs:
           export CONFIGURATION=${{matrix.configuration}}
           export ARCH=${{matrix.platform}}
           export TARGETARCH=${{matrix.targetPlatform}}
+          export PRODUCTION_BUILD=1
           echo "building..."
           source ./github_build.sh
           echo "creating binary archieves..."

--- a/.github/workflows/release-linux-glibc-2-27.yml
+++ b/.github/workflows/release-linux-glibc-2-27.yml
@@ -33,6 +33,7 @@ jobs:
               export TARGETARCH=x64
               export TARGETARCH=x64
               export GLIBC_COMPATIBLE=1
+              export PRODUCTION_BUILD=1
               /bin/bash ./github_build.sh
 
       - name: CreatePackages

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -41,6 +41,7 @@ jobs:
           export CONFIGURATION=${{matrix.configuration}}
           export ARCH=${{matrix.platform}}
           export TARGETARCH=${{matrix.targetPlatform}}
+          export PRODUCTION_BUILD=1
           echo "building..."
           source ./github_build.sh
           echo "creating binary archieves..."

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -30,6 +30,7 @@ jobs:
           export CONFIGURATION=${{matrix.configuration}}
           export ARCH=${{matrix.platform}}
           export TARGETARCH=${{matrix.targetPlatform}}
+          export PRODUCTION_BUILD=1
           echo "building..."
           source ./github_macos_build.sh
       - name: "Import signing certificate"

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -34,7 +34,7 @@ jobs:
       - name: premake 
         if: ${{ matrix.platform != 'aarch64' }}
         run:
-          .\premake.bat vs2019 --enable-embed-stdlib=true --arch=${{matrix.platform}} --deps=true --no-progress=true
+          .\premake.bat vs2019 --enable-embed-stdlib=true --arch=${{matrix.platform}} --deps=true --no-progress=true --production-build=true
       - name: tag-version
         run: .\make-slang-tag-version.bat
       - name: msbuild

--- a/github_build.sh
+++ b/github_build.sh
@@ -24,6 +24,12 @@ if [[ ! -z ${GLIBC_COMPATIBLE} ]]; then
     glibcCompatible="--glibc-forward-compatible=true"
 fi
 
+productionBuildFlag=""
+if [[ ! -z ${PRODUCTION_BUILD} ]]; then
+    productionBuildFlag="--production-build=true"
+fi
+
+
 if [[ "${ARCH}" != "${TARGETARCH}" ]]; then
 
 # Create the makefile
@@ -35,11 +41,11 @@ make config=${CONFIGURATION}_${ARCH} -j`nproc`
 rm -rf ./bin
 
 # Create the makefile
-./premake5 gmake2 --cc=${CC} --enable-embed-stdlib=true --arch=${TARGETARCH} --deps=true --no-progress=true  --skip-source-generation=true --deploy-slang-llvm=false --deploy-slang-glslang=false ${glslangBuildFlag}
+./premake5 gmake2 --cc=${CC} --enable-embed-stdlib=true --arch=${TARGETARCH} --deps=true --no-progress=true  --skip-source-generation=true --deploy-slang-llvm=false --deploy-slang-glslang=false ${glslangBuildFlag} ${productionBuildFlag}
 
 else
 # Create the makefile
-./premake5 gmake2 --cc=${CC} --enable-embed-stdlib=true --arch=${TARGETARCH} --deps=true --no-progress=true ${glslangBuildFlag} ${glibcCompatible}
+./premake5 gmake2 --cc=${CC} --enable-embed-stdlib=true --arch=${TARGETARCH} --deps=true --no-progress=true ${glslangBuildFlag} ${glibcCompatible} ${productionBuildFlag}
 fi
 
 # Build the configuration

--- a/github_macos_build.sh
+++ b/github_macos_build.sh
@@ -11,6 +11,11 @@ if [[ "" == "${TARGETARCH}" ]]; then
 TARGETARCH=${ARCH}
 fi
 
+productionBuildFlag=""
+if [[ ! -z ${PRODUCTION_BUILD} ]]; then
+    productionBuildFlag="--production-build=true"
+fi
+
 if [[ "${ARCH}" != "${TARGETARCH}" ]]; then
 
 # Create the makefile
@@ -22,11 +27,11 @@ make config=${CONFIGURATION}_${ARCH} -j`sysctl -n hw.ncpu`
 rm -rf ./bin
 
 # Create the makefile
-./premake5 gmake2 --cc=${CC} --enable-xlib=false --enable-embed-stdlib=true --arch=${TARGETARCH} --deps=true --build-glslang=true --no-progress=true  --skip-source-generation=true --deploy-slang-llvm=false --deploy-slang-glslang=false
+./premake5 gmake2 --cc=${CC} --enable-xlib=false --enable-embed-stdlib=true --arch=${TARGETARCH} --deps=true --build-glslang=true --no-progress=true  --skip-source-generation=true --deploy-slang-llvm=false --deploy-slang-glslang=false ${productionBuildFlag}
 make config=${CONFIGURATION}_${TARGETARCH} -j`sysctl -n hw.ncpu`
 else
 # Create the makefile
-./premake5 gmake2 --cc=${CC} --enable-xlib=false --enable-embed-stdlib=true --arch=${TARGETARCH} --deps=true --build-glslang=true --no-progress=true --deploy-slang-glslang=false
+./premake5 gmake2 --cc=${CC} --enable-xlib=false --enable-embed-stdlib=true --arch=${TARGETARCH} --deps=true --build-glslang=true --no-progress=true --deploy-slang-glslang=false ${productionBuildFlag}
 # Build the configuration
 make config=${CONFIGURATION}_${TARGETARCH}  -j`sysctl -n hw.ncpu`
 fi

--- a/premake5.lua
+++ b/premake5.lua
@@ -244,6 +244,14 @@ newoption {
     allowed     = { { "true", "True"}, { "false", "False" } }
 }
 
+newoption {
+    trigger     = "production-build",
+    description = "(Optional) Indicates that this is a production build, and will disable profiling and other debug features",
+    value       = "bool",
+    default     = "false",
+    allowed     = { { "true", "True"}, { "false", "False" } }
+}
+
 buildLocation = _OPTIONS["build-location"]
 executeBinary = (_OPTIONS["execute-binary"] == "true")
 buildGlslang = (_OPTIONS["build-glslang"] == "true")
@@ -263,6 +271,7 @@ dxOnVk = (_OPTIONS["dx-on-vk"] == "true")
 enableAftermath = (_OPTIONS["enable-aftermath"] == "true")
 defaultSPIRVDirect = (_OPTIONS["default-spirv-direct"] == "true")
 glibcForwardCompatible = (_OPTIONS["glibc-forward-compatible"] == "true")
+productionBuild = (_OPTIONS["production-build"] == "true")
 
 -- If stdlib embedding is enabled, disable stdlib source embedding by default
 disableStdlibSource = enableEmbedStdLib
@@ -349,6 +358,7 @@ end
 function getPlatforms(targetInfo)
     return { "x86", "x64", "aarch64" }
 end
+
 
 workspace "slang"
     -- We will support debug/release configuration and x86/x64 builds.
@@ -453,6 +463,11 @@ workspace "slang"
         linkoptions{ "-Wl,-rpath,'$$ORIGIN',--no-as-needed,--no-undefined" }
         -- allow libraries to be listed in any order (do not require dependency order)
         linkgroups "On"
+
+    if not (productionBuild) then
+        buildmessage " production build"
+        defines { "SLANG_PROFILER_ENABLE" }
+    end
 
     filter {}
         -- For including windows.h in a way that minimized namespace pollution.

--- a/source/core/slang-performance-profiler.h
+++ b/source/core/slang-performance-profiler.h
@@ -36,7 +36,11 @@ struct PerformanceProfilerFuncRAIIContext
     }
 };
 
+#ifdef SLANG_PROFILE_ENABLE
 #define SLANG_PROFILE PerformanceProfilerFuncRAIIContext _profileContext(__func__)
+#else
+#define SLANG_PROFILE (void(0))
+#endif // SLANG_PROFILE_ENABLE
 }
 
 #endif


### PR DESCRIPTION
Fix issue #4167.

Add `--production-build=true` in our build system to indicate the production build which is ONLY used when publish a new release.

In production build, we will disable the SLANG_PROFILER.