### PR TITLE
Fix pointer example

### DIFF
--- a/docs/user-guide/03-convenience-features.md
+++ b/docs/user-guide/03-convenience-features.md
@@ -411,11 +411,16 @@ float4 myPackedVector = reinterpret<float4>(myVal);
 
 Slang supports pointers when generating code for SPIRV, C++ and CUDA targets. The syntax for pointers is similar to C, with the exception that operator `.` can also be used to dereference a member from a pointer. For example:
 ```csharp
+
+struct MyType {
+    int a;
+};
+
 int test(MyType* pObj)
 {
     MyType* pNext = pObj + 1;
-    MyType* pNext = &pNext[1];
-    return pNext.a + pNext->a + (*pNext).a + pNext[0].a;
+    MyType* pNext2 = &pNext[1];
+    return pNext.a + pNext->a + (*pNext2).a + pNext2[0].a;
 }
 ```
 

--- a/docs/user-guide/03-convenience-features.md
+++ b/docs/user-guide/03-convenience-features.md
@@ -411,8 +411,8 @@ float4 myPackedVector = reinterpret<float4>(myVal);
 
 Slang supports pointers when generating code for SPIRV, C++ and CUDA targets. The syntax for pointers is similar to C, with the exception that operator `.` can also be used to dereference a member from a pointer. For example:
 ```csharp
-
-struct MyType {
+struct MyType
+{
     int a;
 };
 


### PR DESCRIPTION
Make the example shown for pointers something that would compile. Don't redefine pNext and do define MyType.