### PR TITLE
If no sample is set with a `Texture(.*)MS[]` operation, set sample to 0.

### DIFF
--- a/docs/user-guide/toc.html
+++ b/docs/user-guide/toc.html
@@ -40,7 +40,7 @@
 <li data-link="convenience-features#subscript-operator"><span>Subscript Operator</span></li>
 <li data-link="convenience-features#optionalt-type"><span>`Optional&lt;T&gt;` type</span></li>
 <li data-link="convenience-features#reinterprett-operation"><span>`reinterpret&lt;T&gt;` operation</span></li>
-<li data-link="convenience-features#pointers"><span>Pointers</span></li>
+<li data-link="convenience-features#pointers-limited"><span>Pointers (limited)</span></li>
 <li data-link="convenience-features#struct-inheritance-limited"><span>`struct` inheritance (limited)</span></li>
 <li data-link="convenience-features#extensions"><span>Extensions</span></li>
 <li data-link="convenience-features#multi-level-break"><span>Multi-level break</span></li>

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -2576,7 +2576,7 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,form
             {
                 case cpp:
                 case hlsl:
-                    __intrinsic_asm "($0).sample[$1][0]";
+                    __intrinsic_asm "($0).sample[$1]";
                 case metal:
                 case glsl:
                 case spirv:

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -2564,6 +2564,26 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,form
         }
     }
 
+    __subscript(vector<uint, Shape.dimensions+isArray> location) -> T
+    {
+        __glsl_extension(GL_EXT_samplerless_texture_functions)
+        [__readNone]
+        [ForceInline]
+        [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_samplerless)]
+        get
+        {
+            __target_switch
+            {
+                case cpp:
+                case hlsl:
+                    __intrinsic_asm "($0).sample[$1][0]";
+                case metal:
+                case glsl:
+                case spirv:
+                    return Load(location, 0);
+            }
+        }
+    }
     __subscript(vector<uint, Shape.dimensions+isArray> location, int sampleIndex) -> T
     {
         __glsl_extension(GL_EXT_samplerless_texture_functions)

--- a/tests/bugs/gh-4200.slang
+++ b/tests/bugs/gh-4200.slang
@@ -1,0 +1,17 @@
+//TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv -emit-spirv-directly -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=CHECK_HLSL): -target hlsl -entry computeMain -stage compute
+
+//CHECK_SPV: OpEntryPoint
+//CHECK_HLSL: computeMain
+
+Texture2DMS<uint4> Src : register(t1);
+RWBuffer<uint4>    Dst : register(u2);
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+// CHECK_SPV: Sample %int_0
+// CHECK_HLSL: [{{.*}}int2{{.*}}][0]
+    Dst[0] = Src[int2(0)];
+}

--- a/tests/bugs/gh-4200.slang
+++ b/tests/bugs/gh-4200.slang
@@ -12,6 +12,6 @@ RWBuffer<uint4>    Dst : register(u2);
 void computeMain()
 {
 // CHECK_SPV: Sample %int_0
-// CHECK_HLSL: [{{.*}}int2{{.*}}][0]
-    Dst[0] = Src[int2(0)];
+// CHECK_HLSL: [{{.*}}1{{.*}}]
+    Dst[0] = Src[int2(1)];
 }


### PR DESCRIPTION
[docs do not talk about this behavior](https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/sm5-object-texture2dms-sampleoperatorindex), but DXC still allows it.

If no sample is set with a `Texture(.*)MS[]` operation, set sample to 0.

Fixes: #4200
