### PR TITLE
Simplify test file names for slang-test

### DIFF
--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -330,7 +330,14 @@ static bool _isSubCommand(const char* arg)
 
 
     // first positional argument is source shader path
-    optionsOut->testPrefixes = std::move(positionalArgs);
+    optionsOut->testPrefixes.clear();
+    optionsOut->testPrefixes.reserve(positionalArgs.getCount());
+    for (auto testPrefix : positionalArgs)
+    {
+        Slang::StringBuilder sb;
+        Slang::Path::simplify(testPrefix, Slang::Path::SimplifyStyle::NoRoot, sb);
+        optionsOut->testPrefixes.add(sb);
+    }
 
     if (optionsOut->binDir.getLength() == 0)
     {

--- a/tools/slang-test/options.h
+++ b/tools/slang-test/options.h
@@ -53,7 +53,7 @@ struct Options
     Slang::String binDir;
 
     // only run test cases with names have one of these prefixes.
-    Slang::List<const char *> testPrefixes;
+    Slang::List<Slang::String> testPrefixes;
 
     // generate extra output (notably: command lines we run)
     bool shouldBeVerbose = false;


### PR DESCRIPTION
When slang-test.exe ran with a file name doesn't exactly match character-by-character, those tests don't run.

This commit alters the file name given from the command-line and it will behave in a more expected way.
 - "./" are removed.
 - "../" gets removed along with its parent directory name.
 - Back-slash characters will be converted to slash on Windows.