### PR TITLE
Print warning when unsigned integer is promoted to signed

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1666,85 +1666,136 @@ ${{{{
 
 for (auto op : intrinsicBinaryOps)
 {
-    for (auto type : kBaseTypes)
+    for (auto firstType : kBaseTypes)
     {
-        if ((type.flags & op.flags) == 0)
+        if ((firstType.flags & op.flags) == 0)
             continue;
 
-        char const* leftType = type.name;
-        char const* rightType = leftType;
-        char const* resultType = leftType;
+        sb << "\n// Operator overloading: " << firstType.name << "\n";
 
-        if (op.flags & BOOL_RESULT) resultType = "bool";
+        for (auto secondType : kBaseTypes)
+        {
+            if ((secondType.flags & op.flags) == 0)
+                continue;
 
-        // TODO: We should handle a `SHIFT` flag on the op
-        // by changing `rightType` to `int` in order to
-        // account for the fact that the shift amount should
-        // always have a fixed type independent of the LHS.
-        //
-        // (It is unclear why this change hadn't been made
-        // already, so it is possible that such a change
-        // breaks overload resolution or other parts of
-        // the compiler)
+            // When an unsigned integer value is implicitly casted to a signed
+            // integer value, we need to warn.
+            const bool needToWarn = (op.flags & INT_MASK)
+                && (((firstType.conversionKind == kBaseTypeConversionKind_Signed
+                        && secondType.conversionKind == kBaseTypeConversionKind_Unsigned)
+                    || (firstType.conversionKind == kBaseTypeConversionKind_Unsigned
+                        && secondType.conversionKind == kBaseTypeConversionKind_Signed)));
 
-        // scalar version
-        sb << "__intrinsic_op(" << int(op.opCode) << ") " << resultType << " operator" << op.opName << "(" << leftType << " left, " << rightType << " right);\n";
-        sb << "__intrinsic_op(" << int(op.opCode) << ") " << resultType << " __" << op.funcName << "(" << leftType << " left, " << rightType << " right);\n";
+            const bool isSameType = (firstType.conversionKind == secondType.conversionKind
+                && firstType.conversionRank == secondType.conversionRank);
 
-        // vector version
-        sb << "__generic<let N : int> ";
-        sb << "__intrinsic_op(" << int(op.opCode) << ") vector<" << resultType << ",N> operator" << op.opName << "(vector<" << leftType << ",N> left, vector<" << rightType << ",N> right);\n";
+            if (!isSameType && !needToWarn)
+                continue;
 
-        // matrix version
-        sb << "__generic<let N : int, let M : int> ";
-        sb << "__intrinsic_op(" << int(op.opCode) << ") matrix<" << resultType << ",N,M> operator" << op.opName << "(matrix<" << leftType << ",N,M> left, matrix<" << rightType << ",N,M> right);\n";
+            char const* leftType = firstType.name;
+            char const* rightType = secondType.name;
+            char const* resultType = leftType;
+            const int opCode = int(needToWarn ? op.opCodeWarn : op.opCode);
 
-        // We currently synthesize addiitonal overloads
-        // for the case where one or the other operand
-        // is a scalar. This choice serves a few purposes:
-        //
-        // 1. It avoids introducing scalar-to-vector or
-        // scalar-to-matrix promotions before the operator,
-        // which might allow some back ends to produce
-        // more optimal code.
-        //
-        // 2. It avoids concerns about making overload resolution
-        // and the inference rules for `N` and `M` able to
-        // handle the mixed vector/scalar or matrix/scalar case.
-        //
-        // 3. Having explicit overloads for the matrix/scalar cases
-        // here means that we do *not* need to support a general
-        // implicit conversion from scalars to matrices, unless
-        // we decide we want to.
-        //
-        // Note: Case (2) of the motivation shouldn't really apply
-        // any more, because we end up having to support similar
-        // inteference for built-in binary math functions where
-        // vectors and scalars might be combined (and where defining
-        // additional overloads to cover all the combinations doesn't
-        // seem practical or desirable).
-        //
-        // TODO: We should consider whether dropping these extra
-        // overloads is possible and worth it. The optimization
-        // concern (1) could possibly be addressed in specific
-        // back-ends. The issue (3) about not wanting to support
-        // implicit scalar-to-matrix conversion may be moot if
-        // we end up needing to support mixed scalar/matrix input
-        // for builtin in non-operator functions anyway.
+            if (op.flags & BOOL_RESULT)
+            {
+                resultType = "bool";
+            }
+            else if (firstType.conversionRank == secondType.conversionRank)
+            {
+                // When the given types are signed and unsigned integer types,
+                // and their sizes are same, the return type is signed, because
+                // the conversion cost of "unsigned to signed" is 200, and
+                // "signed to unsigned" is 300.
+                //
+                if (secondType.conversionKind == kBaseTypeConversionKind_Signed)
+                {
+                    resultType = rightType;
+                }
+            }
+            else if (firstType.conversionRank < secondType.conversionRank)
+            {
+                resultType = rightType;
+            }
 
-        // scalar-vector and scalar-matrix
-        sb << "__generic<let N : int> ";
-        sb << "__intrinsic_op(" << int(op.opCode) << ") vector<" << resultType << ",N> operator" << op.opName << "(" << leftType << " left, vector<" << rightType << ",N> right);\n";
+            // TODO: We should handle a `SHIFT` flag on the op
+            // by changing `rightType` to `int` in order to
+            // account for the fact that the shift amount should
+            // always have a fixed type independent of the LHS.
+            //
+            // (It is unclear why this change hadn't been made
+            // already, so it is possible that such a change
+            // breaks overload resolution or other parts of
+            // the compiler)
 
-        sb << "__generic<let N : int, let M : int> ";
-        sb << "__intrinsic_op(" << int(op.opCode) << ") matrix<" << resultType << ",N,M> operator" << op.opName << "(" << leftType << " left, matrix<" << rightType << ",N,M> right);\n";
+            sb << "\n// Scalar version\n";
+            sb << "__intrinsic_op(" << opCode << ")\n";
+            sb << resultType << " operator" << op.opName << "(" << leftType << " left, " << rightType << " right);\n";
 
-        // vector-scalar and matrix-scalar
-        sb << "__generic<let N : int> ";
-        sb << "__intrinsic_op(" << int(op.opCode) << ") vector<" << resultType << ",N> operator" << op.opName << "(vector<" << leftType << ",N> left, " << rightType << " right);\n";
+            sb << "\n__intrinsic_op(" << opCode << ")\n";
+            sb << resultType << " __" << op.funcName << "(" << leftType << " left, " << rightType << " right);\n";
 
-        sb << "__generic<let N : int, let M : int> ";
-        sb << "__intrinsic_op(" << int(op.opCode) << ") matrix<" << resultType << ",N,M> operator" << op.opName << "(matrix<" << leftType << ",N,M> left, " << rightType << " right);\n";
+            sb << "\n// vector version\n";
+            sb << "__generic<let N : int>\n";
+            sb << "__intrinsic_op(" << opCode << ")\n";
+            sb << "vector<" << resultType << ",N> operator" << op.opName << "(vector<" << leftType << ",N> left, vector<" << rightType << ",N> right);\n";
+
+            sb << "\n// matrix version\n";
+            sb << "__generic<let N : int, let M : int>\n";
+            sb << "__intrinsic_op(" << opCode << ")\n";
+            sb << "matrix<" << resultType << ",N,M> operator" << op.opName << "(matrix<" << leftType << ",N,M> left, matrix<" << rightType << ",N,M> right);\n";
+
+            // We currently synthesize addiitonal overloads
+            // for the case where one or the other operand
+            // is a scalar. This choice serves a few purposes:
+            //
+            // 1. It avoids introducing scalar-to-vector or
+            // scalar-to-matrix promotions before the operator,
+            // which might allow some back ends to produce
+            // more optimal code.
+            //
+            // 2. It avoids concerns about making overload resolution
+            // and the inference rules for `N` and `M` able to
+            // handle the mixed vector/scalar or matrix/scalar case.
+            //
+            // 3. Having explicit overloads for the matrix/scalar cases
+            // here means that we do *not* need to support a general
+            // implicit conversion from scalars to matrices, unless
+            // we decide we want to.
+            //
+            // Note: Case (2) of the motivation shouldn't really apply
+            // any more, because we end up having to support similar
+            // inteference for built-in binary math functions where
+            // vectors and scalars might be combined (and where defining
+            // additional overloads to cover all the combinations doesn't
+            // seem practical or desirable).
+            //
+            // TODO: We should consider whether dropping these extra
+            // overloads is possible and worth it. The optimization
+            // concern (1) could possibly be addressed in specific
+            // back-ends. The issue (3) about not wanting to support
+            // implicit scalar-to-matrix conversion may be moot if
+            // we end up needing to support mixed scalar/matrix input
+            // for builtin in non-operator functions anyway.
+
+            sb << "\n// scalar-vector and scalar-matrix\n";
+            sb << "__generic<let N : int>\n";
+            sb << "__intrinsic_op(" << opCode << ")\n";
+            sb << "vector<" << resultType << ",N> operator" << op.opName << "(" << leftType << " left, vector<" << rightType << ",N> right);\n";
+
+            sb << "\n__generic<let N : int, let M : int>\n";
+            sb << "__intrinsic_op(" << opCode << ")\n";
+            sb << "matrix<" << resultType << ",N,M> operator" << op.opName << "(" << leftType << " left, matrix<" << rightType << ",N,M> right);\n";
+
+            sb << "\n// vector-scalar and matrix-scalar\n";
+            sb << "__generic<let N : int>\n";
+            sb << "__intrinsic_op(" << opCode << ")\n";
+            sb << "vector<" << resultType << ",N> operator" << op.opName << "(vector<" << leftType << ",N> left, " << rightType << " right);\n";
+
+            sb << "\n__generic<let N : int, let M : int>\n";
+            sb << "__intrinsic_op(" << opCode << ")\n";
+            sb << "matrix<" << resultType << ",N,M> operator" << op.opName << "(matrix<" << leftType << ",N,M> left, " << rightType << " right);\n";
+        }
     }
 
     // Synthesize generic versions

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -608,6 +608,14 @@ INST(Sub, sub, 2, 0)
 INST(Mul, mul, 2, 0)
 INST(Div, div, 2, 0)
 
+// Same as without the suffix, "_warn", but these prints warning about
+// the given input types are implicitly converted from unsigned integer
+// type to signed integer type.
+INST(Add_warn, add, 2, 0)
+INST(Sub_warn, sub, 2, 0)
+INST(Mul_warn, mul, 2, 0)
+INST(Div_warn, div, 2, 0)
+
 // Remainder of division.
 //
 // Note: this is distinct from modulus, and we should have a separate

--- a/source/slang/slang-stdlib.cpp
+++ b/source/slang/slang-stdlib.cpp
@@ -260,34 +260,42 @@ namespace Slang
         return intrinsicOpCode;
     }
 
-    struct IntrinsicOpInfo { IROp opCode; char const* funcName; char const* opName; char const* interface; unsigned flags; };
+    struct IntrinsicOpInfo
+    {
+        IROp opCode;
+        IROp opCodeWarn;
+        char const* funcName;
+        char const* opName;
+        char const* interface;
+        unsigned flags;
+    };
 
     [[maybe_unused]]
     static const IntrinsicOpInfo intrinsicUnaryOps[] = {
-        { kIROp_Neg,    "neg",              "-",    "__BuiltinArithmeticType",  ARITHMETIC_MASK },
-        { kIROp_Not,    "logicalNot",       "!",    nullptr,                    BOOL_MASK | BOOL_RESULT },
-        { kIROp_BitNot, "not",              "~",    "__BuiltinLogicalType",     INT_MASK        },
+        { kIROp_Neg,    kIROp_Neg,    "neg",              "-",    "__BuiltinArithmeticType",  ARITHMETIC_MASK },
+        { kIROp_Not,    kIROp_Not,    "logicalNot",       "!",    nullptr,                    BOOL_MASK | BOOL_RESULT },
+        { kIROp_BitNot, kIROp_BitNot, "not",              "~",    "__BuiltinLogicalType",     INT_MASK        },
     };
 
     [[maybe_unused]]
     static const IntrinsicOpInfo intrinsicBinaryOps[] = {
-        {kIROp_Add, "add", "+", "__BuiltinArithmeticType", ARITHMETIC_MASK},
-        {kIROp_Sub, "sub", "-", "__BuiltinArithmeticType", ARITHMETIC_MASK},
-        {kIROp_Mul, "mul", "*", "__BuiltinArithmeticType", ARITHMETIC_MASK},
-        {kIROp_Div, "div", "/", "__BuiltinArithmeticType", ARITHMETIC_MASK},
-        {kIROp_IRem, "irem", "%", "__BuiltinIntegerType", INT_MASK},
-        {kIROp_FRem, "frem", "%", "__BuiltinFloatingPointType", FLOAT_MASK},
-        {kIROp_And, "logicalAnd", "&&", nullptr, BOOL_MASK | BOOL_RESULT},
-        {kIROp_Or, "logicalOr", "||", nullptr, BOOL_MASK | BOOL_RESULT},
-        {kIROp_BitAnd, "and", "&", "__BuiltinLogicalType", LOGICAL_MASK},
-        {kIROp_BitOr, "or", "|", "__BuiltinLogicalType", LOGICAL_MASK},
-        {kIROp_BitXor, "xor", "^", "__BuiltinLogicalType", LOGICAL_MASK},
-        {kIROp_Eql, "eql", "==", "__BuiltinType", ANY_MASK | BOOL_RESULT},
-        {kIROp_Neq, "neq", "!=", "__BuiltinType", ANY_MASK | BOOL_RESULT},
-        {kIROp_Greater, "greater", ">", "__BuiltinArithmeticType", ARITHMETIC_MASK | BOOL_RESULT},
-        {kIROp_Less, "less", "<", "__BuiltinArithmeticType", ARITHMETIC_MASK | BOOL_RESULT},
-        {kIROp_Geq, "geq", ">=", "__BuiltinArithmeticType", ARITHMETIC_MASK | BOOL_RESULT},
-        {kIROp_Leq, "leq", "<=", "__BuiltinArithmeticType", ARITHMETIC_MASK | BOOL_RESULT},
+        {kIROp_Add, kIROp_Add_warn, "add", "+", "__BuiltinArithmeticType", ARITHMETIC_MASK},
+        {kIROp_Sub, kIROp_Sub_warn, "sub", "-", "__BuiltinArithmeticType", ARITHMETIC_MASK},
+        {kIROp_Mul, kIROp_Mul_warn, "mul", "*", "__BuiltinArithmeticType", ARITHMETIC_MASK},
+        {kIROp_Div, kIROp_Div_warn, "div", "/", "__BuiltinArithmeticType", ARITHMETIC_MASK},
+        {kIROp_IRem, kIROp_IRem, "irem", "%", "__BuiltinIntegerType", INT_MASK},
+        {kIROp_FRem, kIROp_FRem, "frem", "%", "__BuiltinFloatingPointType", FLOAT_MASK},
+        {kIROp_And, kIROp_And, "logicalAnd", "&&", nullptr, BOOL_MASK | BOOL_RESULT},
+        {kIROp_Or, kIROp_Or, "logicalOr", "||", nullptr, BOOL_MASK | BOOL_RESULT},
+        {kIROp_BitAnd, kIROp_BitAnd, "and", "&", "__BuiltinLogicalType", LOGICAL_MASK},
+        {kIROp_BitOr, kIROp_BitOr, "or", "|", "__BuiltinLogicalType", LOGICAL_MASK},
+        {kIROp_BitXor, kIROp_BitXor, "xor", "^", "__BuiltinLogicalType", LOGICAL_MASK},
+        {kIROp_Eql, kIROp_Eql, "eql", "==", "__BuiltinType", ANY_MASK | BOOL_RESULT},
+        {kIROp_Neq, kIROp_Neq, "neq", "!=", "__BuiltinType", ANY_MASK | BOOL_RESULT},
+        {kIROp_Greater, kIROp_Greater, "greater", ">", "__BuiltinArithmeticType", ARITHMETIC_MASK | BOOL_RESULT},
+        {kIROp_Less, kIROp_Less, "less", "<", "__BuiltinArithmeticType", ARITHMETIC_MASK | BOOL_RESULT},
+        {kIROp_Geq, kIROp_Geq, "geq", ">=", "__BuiltinArithmeticType", ARITHMETIC_MASK | BOOL_RESULT},
+        {kIROp_Leq, kIROp_Leq, "leq", "<=", "__BuiltinArithmeticType", ARITHMETIC_MASK | BOOL_RESULT},
     };
 
     // Integer types that can be used in atomic operations in CUDA.


### PR DESCRIPTION
** Draft: this code is still WIP.
I need to check if the approach is good before proceed.

Closes #3944

This commit is to print warning message when a given argument is unsigned and it is coerced to signed type. It applies only to the following operator overloading:
 - operator+
 - operator-
 - operator*
 - operator/
 - operator<
 - operator>
 - operator<=
 - operator>=
 - operator&
 - operator|
 - operator^
