### PR TITLE
Add APIs to get profile of compile time

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -1574,6 +1574,16 @@ extern "C"
     
     #define SLANG_UUID_ISlangWriter ISlangWriter::getTypeGuid()
 
+    struct ISlangProfiler : public ISlangUnknown
+    {
+        SLANG_COM_INTERFACE(0x5fb632d2, 0x979d, 0x4481, { 0x9f, 0xee, 0x66, 0x3c, 0x3f, 0x14, 0x49, 0xe1 })
+        virtual SLANG_NO_THROW size_t SLANG_MCALL getEntryCount() = 0;
+        virtual SLANG_NO_THROW const char* SLANG_MCALL getEntryName(uint32_t index) = 0;
+        virtual SLANG_NO_THROW long SLANG_MCALL getEntryTimeMS(uint32_t index) = 0;
+        virtual SLANG_NO_THROW uint32_t SLANG_MCALL getEntryInvocationTimes(uint32_t index) = 0;
+    };
+    #define SLANG_UUID_ISlangProfiler ISlangProfiler::getTypeGuid()
+
     namespace slang {
     struct IGlobalSession;
     struct ICompileRequest;
@@ -2030,7 +2040,8 @@ extern "C"
     /*! @see slang::ICompileRequest::getCompileTimeProfile */
     SLANG_API SlangResult spGetCompileTimeProfile(
         SlangCompileRequest* request,
-        ISlangBlob** compileTimeProfile);
+        ISlangProfiler** compileTimeProfile,
+        bool isClear);
 
 
     /** Extract contents of a repro.
@@ -4430,7 +4441,7 @@ namespace slang
 
         virtual SLANG_NO_THROW void SLANG_MCALL setIgnoreCapabilityCheck(bool value) = 0;
 
-        virtual SLANG_NO_THROW SlangResult SLANG_MCALL getCompileTimeProfile(ISlangBlob** compileTimeProfile) = 0;
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL getCompileTimeProfile(ISlangProfiler** compileTimeProfile, bool isClear) = 0;
 
     };
 

--- a/slang.h
+++ b/slang.h
@@ -1576,7 +1576,7 @@ extern "C"
 
     struct ISlangProfiler : public ISlangUnknown
     {
-        SLANG_COM_INTERFACE(0x5fb632d2, 0x979d, 0x4481, { 0x9f, 0xee, 0x66, 0x3c, 0x3f, 0x14, 0x49, 0xe1 })
+        SLANG_COM_INTERFACE(0x197772c7, 0x0155, 0x4b91, { 0x84, 0xe8, 0x66, 0x68, 0xba, 0xff, 0x06, 0x19 })
         virtual SLANG_NO_THROW size_t SLANG_MCALL getEntryCount() = 0;
         virtual SLANG_NO_THROW const char* SLANG_MCALL getEntryName(uint32_t index) = 0;
         virtual SLANG_NO_THROW long SLANG_MCALL getEntryTimeMS(uint32_t index) = 0;
@@ -2041,7 +2041,7 @@ extern "C"
     SLANG_API SlangResult spGetCompileTimeProfile(
         SlangCompileRequest* request,
         ISlangProfiler** compileTimeProfile,
-        bool isClear);
+        bool shouldClear);
 
 
     /** Extract contents of a repro.
@@ -4441,7 +4441,8 @@ namespace slang
 
         virtual SLANG_NO_THROW void SLANG_MCALL setIgnoreCapabilityCheck(bool value) = 0;
 
-        virtual SLANG_NO_THROW SlangResult SLANG_MCALL getCompileTimeProfile(ISlangProfiler** compileTimeProfile, bool isClear) = 0;
+        // return a copy of internal profiling results, and if `shouldClear` is true, clear the internal profiling results before returning.
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL getCompileTimeProfile(ISlangProfiler** compileTimeProfile, bool shouldClear) = 0;
 
     };
 

--- a/slang.h
+++ b/slang.h
@@ -2027,6 +2027,11 @@ extern "C"
     SLANG_API SlangResult spEnableReproCapture(
         SlangCompileRequest* request);
 
+    /*! @see slang::ICompileRequest::getCompileTimeProfile */
+    SLANG_API SlangResult spGetCompileTimeProfile(
+        SlangCompileRequest* request,
+        ISlangBlob** compileTimeProfile);
+
 
     /** Extract contents of a repro.
 
@@ -4424,6 +4429,8 @@ namespace slang
         virtual SLANG_NO_THROW void SLANG_MCALL setTargetUseMinimumSlangOptimization(int targetIndex, bool value) = 0;
 
         virtual SLANG_NO_THROW void SLANG_MCALL setIgnoreCapabilityCheck(bool value) = 0;
+
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL getCompileTimeProfile(ISlangBlob** compileTimeProfile) = 0;
 
     };
 

--- a/source/core/slang-performance-profiler.cpp
+++ b/source/core/slang-performance-profiler.cpp
@@ -56,26 +56,27 @@ namespace Slang
 
             for (auto func : profilerImpl->data)
             {
-                auto milliseconds = std::chrono::duration_cast< std::chrono::milliseconds >(func.value.duration);
-                long ms = milliseconds.count();
+                std::chrono::nanoseconds ns = func.value.duration;
 
                 auto entry = m_compileTimeProfiler.find(func.key);
                 if (entry == m_compileTimeProfiler.end())
                 {
-                    m_compileTimeProfiler.emplace(std::make_pair(func.key, 0l));
+                    m_compileTimeProfiler.emplace(std::make_pair(func.key, FuncProfileInfo()));
                     entry = m_compileTimeProfiler.find(func.key);
                 }
-                entry->second += ms;
+                entry->second.invocationCount += func.value.invocationCount;
+                entry->second.duration += ns;
             }
 
             for (auto entry : m_compileTimeProfiler)
             {
-                out << entry.first.c_str() << ": \t" << entry.second << " ms\n";
+                auto milliseconds = std::chrono::duration_cast< std::chrono::milliseconds >(entry.second.duration);
+                out << entry.first.c_str() << ": \t" << entry.second.invocationCount << "\t" << milliseconds.count() << " ms\n";
             }
        }
     private:
         // Those are supposed to accumulate the time spent in each thread
-        std::unordered_map<std::string, long> m_compileTimeProfiler;
+        std::unordered_map<std::string, FuncProfileInfo> m_compileTimeProfiler;
         std::mutex m_mutex;
     };
 

--- a/source/core/slang-performance-profiler.cpp
+++ b/source/core/slang-performance-profiler.cpp
@@ -1,14 +1,8 @@
 #include "slang-performance-profiler.h"
 #include "slang-dictionary.h"
-#include <unordered_map>
 
 namespace Slang
 {
-    struct FuncProfileInfo
-    {
-        int invocationCount = 0;
-        std::chrono::nanoseconds duration = std::chrono::nanoseconds::zero();
-    };
     class PerformanceProfilerImpl : public PerformanceProfiler
     {
     public:
@@ -44,53 +38,77 @@ namespace Slang
                 out << func.value.invocationCount << "\t" << milliseconds.count() << "ms\n";
             }
         }
+        virtual void clear() override
+        {
+            data.clear();
+        }
     };
-
-    class SerialPerformaceProfilerImpl : public SerialPerformaceProfiler
-    {
-    public:
-       void accumulateResults(StringBuilder& out, PerformanceProfiler* profile)
-       {
-            PerformanceProfilerImpl* profilerImpl = static_cast<PerformanceProfilerImpl*>(profile);
-            const std::lock_guard<std::mutex> scopeLock(m_mutex);
-
-            for (auto func : profilerImpl->data)
-            {
-                std::chrono::nanoseconds ns = func.value.duration;
-
-                auto entry = m_compileTimeProfiler.find(func.key);
-                if (entry == m_compileTimeProfiler.end())
-                {
-                    m_compileTimeProfiler.emplace(std::make_pair(func.key, FuncProfileInfo()));
-                    entry = m_compileTimeProfiler.find(func.key);
-                }
-                entry->second.invocationCount += func.value.invocationCount;
-                entry->second.duration += ns;
-            }
-
-            for (auto entry : m_compileTimeProfiler)
-            {
-                auto milliseconds = std::chrono::duration_cast< std::chrono::milliseconds >(entry.second.duration);
-                out << entry.first.c_str() << ": \t" << entry.second.invocationCount << "\t" << milliseconds.count() << " ms\n";
-            }
-       }
-    private:
-        // Those are supposed to accumulate the time spent in each thread
-        std::unordered_map<std::string, FuncProfileInfo> m_compileTimeProfiler;
-        std::mutex m_mutex;
-    };
-
-    // SerialPerformaceProfilerImpl profiler is intent to be shared by all threads, it's thread safe object
-    // because the only member function is re-entrant function, all the member variables are atomic.
-    SerialPerformaceProfiler* Slang::SerialPerformaceProfiler::getProfiler()
-    {
-        static SerialPerformaceProfilerImpl profiler = SerialPerformaceProfilerImpl();
-        return &profiler;
-    }
 
     PerformanceProfiler* Slang::PerformanceProfiler::getProfiler()
     {
         thread_local static PerformanceProfilerImpl profiler = PerformanceProfilerImpl();
         return &profiler;
+    }
+
+    SlangProfiler::SlangProfiler(PerformanceProfiler* profiler)
+    {
+        PerformanceProfilerImpl* profilerImpl = static_cast<PerformanceProfilerImpl*>(profiler);
+        size_t entryCount = profilerImpl->data.getCount();
+
+        m_profilEntries.resize(entryCount);
+
+        int index = 0;
+        for (auto func : profilerImpl->data)
+        {
+            ProfileInfo profileEntry {};
+            size_t strSize = std::min(sizeof(profileEntry.funcName) - 1, strlen(func.key));
+
+            if (strSize > 0)
+            {
+                strncpy(profileEntry.funcName, func.key, strSize);
+            }
+            profileEntry.invocationCount = func.value.invocationCount;
+            profileEntry.duration = func.value.duration;
+
+            m_profilEntries[index++] = profileEntry;
+        }
+    }
+
+    ISlangUnknown* SlangProfiler::getInterface(const Guid& guid)
+    {
+        if(guid == SlangProfiler::getTypeGuid())
+            return static_cast<ISlangUnknown*>(this);
+        else
+            return nullptr;
+    }
+
+    size_t SlangProfiler::getEntryCount()
+    {
+        return m_profilEntries.size();
+    }
+
+    const char* SlangProfiler::getEntryName(uint32_t index)
+    {
+        if (index >= m_profilEntries.size())
+            return nullptr;
+
+        return m_profilEntries[index].funcName;
+    }
+
+    long SlangProfiler::getEntryTimeMS(uint32_t index)
+    {
+        if (index >= m_profilEntries.size())
+            return 0;
+
+        auto milliseconds = std::chrono::duration_cast< std::chrono::milliseconds >(m_profilEntries[index].duration);
+        return (long)milliseconds.count();
+    }
+
+    uint32_t SlangProfiler::getEntryInvocationTimes(uint32_t index)
+    {
+        if (index >= m_profilEntries.size())
+            return 0;
+
+        return m_profilEntries[index].invocationCount;
     }
 }

--- a/source/core/slang-performance-profiler.cpp
+++ b/source/core/slang-performance-profiler.cpp
@@ -55,7 +55,7 @@ namespace Slang
         PerformanceProfilerImpl* profilerImpl = static_cast<PerformanceProfilerImpl*>(profiler);
         size_t entryCount = profilerImpl->data.getCount();
 
-        m_profilEntries.resize(entryCount);
+        m_profilEntries.reserve(entryCount);
 
         int index = 0;
         for (auto func : profilerImpl->data)
@@ -65,12 +65,13 @@ namespace Slang
 
             if (strSize > 0)
             {
-                strncpy(profileEntry.funcName, func.key, strSize);
+                strncpy_s(profileEntry.funcName, strSize, func.key, strSize);
             }
             profileEntry.invocationCount = func.value.invocationCount;
             profileEntry.duration = func.value.duration;
 
-            m_profilEntries[index++] = profileEntry;
+            m_profilEntries.insert(index, profileEntry);
+            index++;
         }
     }
 
@@ -84,12 +85,12 @@ namespace Slang
 
     size_t SlangProfiler::getEntryCount()
     {
-        return m_profilEntries.size();
+        return m_profilEntries.getCount();
     }
 
     const char* SlangProfiler::getEntryName(uint32_t index)
     {
-        if (index >= m_profilEntries.size())
+        if (index >= (uint32_t)m_profilEntries.getCount())
             return nullptr;
 
         return m_profilEntries[index].funcName;
@@ -97,7 +98,7 @@ namespace Slang
 
     long SlangProfiler::getEntryTimeMS(uint32_t index)
     {
-        if (index >= m_profilEntries.size())
+        if (index >= (uint32_t)m_profilEntries.getCount())
             return 0;
 
         auto milliseconds = std::chrono::duration_cast< std::chrono::milliseconds >(m_profilEntries[index].duration);
@@ -106,7 +107,7 @@ namespace Slang
 
     uint32_t SlangProfiler::getEntryInvocationTimes(uint32_t index)
     {
-        if (index >= m_profilEntries.size())
+        if (index >= (uint32_t)m_profilEntries.getCount())
             return 0;
 
         return m_profilEntries[index].invocationCount;

--- a/source/core/slang-performance-profiler.cpp
+++ b/source/core/slang-performance-profiler.cpp
@@ -1,5 +1,6 @@
 #include "slang-performance-profiler.h"
 #include "slang-dictionary.h"
+#include <unordered_map>
 
 namespace Slang
 {
@@ -39,10 +40,52 @@ namespace Slang
             for (auto func : data)
             {
                 out << func.key << ": \t";
-                out << func.value.invocationCount << "\t" << func.value.duration.count() / 1000000.0f << "\n";
+                auto milliseconds = std::chrono::duration_cast< std::chrono::milliseconds >(func.value.duration);
+                out << func.value.invocationCount << "\t" << milliseconds.count() << "ms\n";
             }
         }
     };
+
+    class SerialPerformaceProfilerImpl : public SerialPerformaceProfiler
+    {
+    public:
+       void accumulateResults(StringBuilder& out, PerformanceProfiler* profile)
+       {
+            PerformanceProfilerImpl* profilerImpl = static_cast<PerformanceProfilerImpl*>(profile);
+            const std::lock_guard<std::mutex> scopeLock(m_mutex);
+
+            for (auto func : profilerImpl->data)
+            {
+                auto milliseconds = std::chrono::duration_cast< std::chrono::milliseconds >(func.value.duration);
+                long ms = milliseconds.count();
+
+                auto entry = m_compileTimeProfiler.find(func.key);
+                if (entry == m_compileTimeProfiler.end())
+                {
+                    m_compileTimeProfiler.emplace(std::make_pair(func.key, 0l));
+                    entry = m_compileTimeProfiler.find(func.key);
+                }
+                entry->second += ms;
+            }
+
+            for (auto entry : m_compileTimeProfiler)
+            {
+                out << entry.first.c_str() << ": \t" << entry.second << " ms\n";
+            }
+       }
+    private:
+        // Those are supposed to accumulate the time spent in each thread
+        std::unordered_map<std::string, long> m_compileTimeProfiler;
+        std::mutex m_mutex;
+    };
+
+    // SerialPerformaceProfilerImpl profiler is intent to be shared by all threads, it's thread safe object
+    // because the only member function is re-entrant function, all the member variables are atomic.
+    SerialPerformaceProfiler* Slang::SerialPerformaceProfiler::getProfiler()
+    {
+        static SerialPerformaceProfilerImpl profiler = SerialPerformaceProfilerImpl();
+        return &profiler;
+    }
 
     PerformanceProfiler* Slang::PerformanceProfiler::getProfiler()
     {

--- a/source/core/slang-performance-profiler.h
+++ b/source/core/slang-performance-profiler.h
@@ -3,9 +3,17 @@
 
 #include "slang-string.h"
 #include <chrono>
+#include <vector>
+#include "../../slang-com-helper.h"
 
 namespace Slang
 {
+
+struct FuncProfileInfo
+{
+    int invocationCount = 0;
+    std::chrono::nanoseconds duration = std::chrono::nanoseconds::zero();
+};
 
 struct FuncProfileContext
 {
@@ -19,15 +27,9 @@ public:
     virtual FuncProfileContext enterFunction(const char* funcName) = 0;
     virtual void exitFunction(FuncProfileContext context) = 0;
     virtual void getResult(StringBuilder& out) = 0;
+    virtual void clear() = 0;
 public:
     static PerformanceProfiler* getProfiler();
-};
-
-class SerialPerformaceProfiler
-{
-public:
-    virtual void accumulateResults(StringBuilder& out, PerformanceProfiler* profile) = 0;
-    static SerialPerformaceProfiler* getProfiler();
 };
 
 struct PerformanceProfilerFuncRAIIContext
@@ -41,6 +43,27 @@ struct PerformanceProfilerFuncRAIIContext
     {
         PerformanceProfiler::getProfiler()->exitFunction(context);
     }
+};
+
+struct SlangProfiler: public ISlangProfiler, public RefObject
+{
+public:
+    SLANG_REF_OBJECT_IUNKNOWN_ALL
+    struct ProfileInfo
+    {
+        char funcName[256] = {0};
+        int invocationCount = 0;
+        std::chrono::nanoseconds duration = std::chrono::nanoseconds::zero();
+    };
+    SlangProfiler(PerformanceProfiler * profiler);
+    ISlangUnknown* getInterface(const Guid& guid);
+
+    virtual SLANG_NO_THROW size_t SLANG_MCALL getEntryCount() override;
+    virtual SLANG_NO_THROW const char* SLANG_MCALL getEntryName(uint32_t index) override;
+    virtual SLANG_NO_THROW long SLANG_MCALL getEntryTimeMS(uint32_t index) override;
+    virtual SLANG_NO_THROW uint32_t SLANG_MCALL getEntryInvocationTimes(uint32_t index) override;
+private:
+    std::vector<ProfileInfo> m_profilEntries;
 };
 
 #define SLANG_PROFILE PerformanceProfilerFuncRAIIContext _profileContext(__func__)

--- a/source/core/slang-performance-profiler.h
+++ b/source/core/slang-performance-profiler.h
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <vector>
 #include "../../slang-com-helper.h"
+#include "../core/slang-list.h"
 
 namespace Slang
 {
@@ -63,7 +64,7 @@ public:
     virtual SLANG_NO_THROW long SLANG_MCALL getEntryTimeMS(uint32_t index) override;
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL getEntryInvocationTimes(uint32_t index) override;
 private:
-    std::vector<ProfileInfo> m_profilEntries;
+    List<ProfileInfo> m_profilEntries;
 };
 
 #define SLANG_PROFILE PerformanceProfilerFuncRAIIContext _profileContext(__func__)

--- a/source/core/slang-performance-profiler.h
+++ b/source/core/slang-performance-profiler.h
@@ -23,6 +23,13 @@ public:
     static PerformanceProfiler* getProfiler();
 };
 
+class SerialPerformaceProfiler
+{
+public:
+    virtual void accumulateResults(StringBuilder& out, PerformanceProfiler* profile) = 0;
+    static SerialPerformaceProfiler* getProfiler();
+};
+
 struct PerformanceProfilerFuncRAIIContext
 {
     FuncProfileContext context;

--- a/source/slang/slang-api.cpp
+++ b/source/slang/slang-api.cpp
@@ -802,10 +802,10 @@ SLANG_API SlangResult spCompileRequest_getEntryPoint(
 SLANG_API SlangResult spGetCompileTimeProfile(
     slang::ICompileRequest* request,
     ISlangProfiler** compileTimeProfile,
-    bool isClear)
+    bool shouldClear)
 {
     SLANG_ASSERT(request);
-    return request->getCompileTimeProfile(compileTimeProfile, isClear);
+    return request->getCompileTimeProfile(compileTimeProfile, shouldClear);
 }
 
 // Get the output code associated with a specific translation unit

--- a/source/slang/slang-api.cpp
+++ b/source/slang/slang-api.cpp
@@ -801,10 +801,11 @@ SLANG_API SlangResult spCompileRequest_getEntryPoint(
 /*! @see slang::ICompileRequest::getCompileTimeProfile */
 SLANG_API SlangResult spGetCompileTimeProfile(
     slang::ICompileRequest* request,
-    ISlangBlob** compileTimeProfile)
+    ISlangProfiler** compileTimeProfile,
+    bool isClear)
 {
     SLANG_ASSERT(request);
-    return request->getCompileTimeProfile(compileTimeProfile);
+    return request->getCompileTimeProfile(compileTimeProfile, isClear);
 }
 
 // Get the output code associated with a specific translation unit

--- a/source/slang/slang-api.cpp
+++ b/source/slang/slang-api.cpp
@@ -798,6 +798,15 @@ SLANG_API SlangResult spCompileRequest_getEntryPoint(
     return request->getEntryPoint(entryPointIndex, outEntryPoint);
 }
 
+/*! @see slang::ICompileRequest::getCompileTimeProfile */
+SLANG_API SlangResult spGetCompileTimeProfile(
+    slang::ICompileRequest* request,
+    ISlangBlob** compileTimeProfile)
+{
+    SLANG_ASSERT(request);
+    return request->getCompileTimeProfile(compileTimeProfile);
+}
+
 // Get the output code associated with a specific translation unit
 SLANG_API char const* spGetTranslationUnitSource(
     slang::ICompileRequest*    /*request*/,

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -2782,6 +2782,7 @@ namespace Slang
         virtual SLANG_NO_THROW void SLANG_MCALL setSkipSPIRVValidation(bool value) SLANG_OVERRIDE;
         virtual SLANG_NO_THROW void SLANG_MCALL setTargetUseMinimumSlangOptimization(int targetIndex, bool value) SLANG_OVERRIDE;
         virtual SLANG_NO_THROW void SLANG_MCALL setIgnoreCapabilityCheck(bool value) SLANG_OVERRIDE;
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL getCompileTimeProfile(ISlangBlob** compileTimeProfile);
 
         void setTrackLiveness(bool v);
 

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -2782,7 +2782,7 @@ namespace Slang
         virtual SLANG_NO_THROW void SLANG_MCALL setSkipSPIRVValidation(bool value) SLANG_OVERRIDE;
         virtual SLANG_NO_THROW void SLANG_MCALL setTargetUseMinimumSlangOptimization(int targetIndex, bool value) SLANG_OVERRIDE;
         virtual SLANG_NO_THROW void SLANG_MCALL setIgnoreCapabilityCheck(bool value) SLANG_OVERRIDE;
-        virtual SLANG_NO_THROW SlangResult SLANG_MCALL getCompileTimeProfile(ISlangBlob** compileTimeProfile);
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL getCompileTimeProfile(ISlangProfiler** compileTimeProfile, bool isClear);
 
         void setTrackLiveness(bool v);
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -6137,7 +6137,6 @@ SlangResult EndToEndCompileRequest::compile()
         getSession()->getCompilerElapsedTime(&totalEndTime, &downstreamEndTime);
         double downstreamTime = downstreamEndTime - downstreamStartTime;
         String downstreamTimeStr = String(downstreamTime, "%.2f");
-
         getSink()->diagnose(SourceLoc(), Diagnostics::downstreamCompileTime, downstreamTimeStr);
     }
     if (getOptionSet().getBoolOption(CompilerOptionName::ReportPerfBenchmark))
@@ -6246,18 +6245,22 @@ void const* EndToEndCompileRequest::getEntryPointCode(int entryPointIndex, size_
     return (void*)blob->getBufferPointer();
 }
 
-SlangResult EndToEndCompileRequest::getCompileTimeProfile(ISlangBlob** compileTimeProfile)
+SlangResult EndToEndCompileRequest::getCompileTimeProfile(ISlangProfiler** compileTimeProfile, bool isClear)
 {
     if (compileTimeProfile == nullptr)
     {
         return SLANG_E_INVALID_ARG;
     }
 
-    StringBuilder outString;
-    SerialPerformaceProfiler::getProfiler()->accumulateResults(outString, PerformanceProfiler::getProfiler());
+    SlangProfiler* profiler = new SlangProfiler(PerformanceProfiler::getProfiler());
 
-    ComPtr<ISlangBlob> resultBlob = StringUtil::createStringBlob(outString.produceString());
-    *compileTimeProfile = resultBlob.detach();
+    if (isClear)
+    {
+        PerformanceProfiler::getProfiler()->clear();
+    }
+
+    ComPtr<ISlangProfiler> result(profiler);
+    *compileTimeProfile = result.detach();
     return SLANG_OK;
 }
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -6245,7 +6245,7 @@ void const* EndToEndCompileRequest::getEntryPointCode(int entryPointIndex, size_
     return (void*)blob->getBufferPointer();
 }
 
-SlangResult EndToEndCompileRequest::getCompileTimeProfile(ISlangProfiler** compileTimeProfile, bool isClear)
+SlangResult EndToEndCompileRequest::getCompileTimeProfile(ISlangProfiler** compileTimeProfile, bool shouldClear)
 {
     if (compileTimeProfile == nullptr)
     {
@@ -6254,7 +6254,7 @@ SlangResult EndToEndCompileRequest::getCompileTimeProfile(ISlangProfiler** compi
 
     SlangProfiler* profiler = new SlangProfiler(PerformanceProfiler::getProfiler());
 
-    if (isClear)
+    if (shouldClear)
     {
         PerformanceProfiler::getProfiler()->clear();
     }

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -6137,6 +6137,7 @@ SlangResult EndToEndCompileRequest::compile()
         getSession()->getCompilerElapsedTime(&totalEndTime, &downstreamEndTime);
         double downstreamTime = downstreamEndTime - downstreamStartTime;
         String downstreamTimeStr = String(downstreamTime, "%.2f");
+
         getSink()->diagnose(SourceLoc(), Diagnostics::downstreamCompileTime, downstreamTimeStr);
     }
     if (getOptionSet().getBoolOption(CompilerOptionName::ReportPerfBenchmark))
@@ -6243,6 +6244,21 @@ void const* EndToEndCompileRequest::getEntryPointCode(int entryPointIndex, size_
     }
 
     return (void*)blob->getBufferPointer();
+}
+
+SlangResult EndToEndCompileRequest::getCompileTimeProfile(ISlangBlob** compileTimeProfile)
+{
+    if (compileTimeProfile == nullptr)
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    StringBuilder outString;
+    SerialPerformaceProfiler::getProfiler()->accumulateResults(outString, PerformanceProfiler::getProfiler());
+
+    ComPtr<ISlangBlob> resultBlob = StringUtil::createStringBlob(outString.produceString());
+    *compileTimeProfile = resultBlob.detach();
+    return SLANG_OK;
 }
 
 static SlangResult _getEntryPointResult(


### PR DESCRIPTION
Add serial time measurement

Add profiler to measure lots of stages in slang compilation, and it can accumulate the time spent in each thread in multi-threads case and finally report a serial timing info.