### PR TITLE
Fix a bug on default initialization of interface typed value.

### DIFF
--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -4413,14 +4413,14 @@ struct ExprLoweringVisitorBase : public ExprVisitor<Derived, LoweredValInfo>
             {
                 return LoweredValInfo::simple(getBuilder()->getIntValue(irType, 0));
             }
+            else if (declRef.as<InterfaceDecl>())
+            {
+                return LoweredValInfo::simple(getBuilder()->emitDefaultConstruct(irType));
+            }
             else if (auto aggTypeDeclRef = declRef.as<AggTypeDecl>())
             {
-                if (aggTypeDeclRef.as<InterfaceDecl>())
-                {
-                    return LoweredValInfo::simple(getBuilder()->emitDefaultConstruct(irType));
-                }
-
                 List<IRInst*> args;
+
                 if (auto structTypeDeclRef = aggTypeDeclRef.as<StructDecl>())
                 {
                     if (auto baseStructType = findBaseStructType(getASTBuilder(), structTypeDeclRef))

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -4415,8 +4415,12 @@ struct ExprLoweringVisitorBase : public ExprVisitor<Derived, LoweredValInfo>
             }
             else if (auto aggTypeDeclRef = declRef.as<AggTypeDecl>())
             {
-                List<IRInst*> args;
+                if (aggTypeDeclRef.as<InterfaceDecl>())
+                {
+                    return LoweredValInfo::simple(getBuilder()->emitDefaultConstruct(irType));
+                }
 
+                List<IRInst*> args;
                 if (auto structTypeDeclRef = aggTypeDeclRef.as<StructDecl>())
                 {
                     if (auto baseStructType = findBaseStructType(getASTBuilder(), structTypeDeclRef))

--- a/tests/language-feature/interfaces/zero-init-interface.slang
+++ b/tests/language-feature/interfaces/zero-init-interface.slang
@@ -1,0 +1,32 @@
+// Test that we can zero-init a struct with interface typed member.
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUFFER): -shaderobj
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+interface IFoo
+{
+    int method();
+}
+
+//TEST_INPUT: type_conformance Impl1:IFoo = 0
+struct Impl1 : IFoo
+{
+    int data;
+    int method() { return data + 1; }
+}
+
+struct MyType
+{
+    IFoo foo;
+}
+
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    MyType t = {};
+    // BUFFER: 1
+    outputBuffer[0] = t.foo.method();
+}


### PR DESCRIPTION
`default(IFoo)` should lower into a `DefaultConstruct : IFoo` inst instead of `MakeStruct : IFoo` for our passes to handle it correctly to produce valid HLSL output.

Closes #3831.