### PR TITLE
Print warning when operator<< shifting too much

### DIFF
--- a/build/visual-studio/slang/slang.vcxproj
+++ b/build/visual-studio/slang/slang.vcxproj
@@ -451,6 +451,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClInclude Include="..\..\..\source\slang\slang-ir-metal-legalize.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-missing-return.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-obfuscate-loc.h" />
+    <ClInclude Include="..\..\..\source\slang\slang-ir-operator-shift-overflow.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-optix-entry-point-uniforms.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-peephole.h" />
     <ClInclude Include="..\..\..\source\slang\slang-ir-propagate-func-properties.h" />
@@ -691,6 +692,7 @@ IF EXIST ..\..\..\external\slang-glslang\bin\windows-aarch64\release\slang-glsla
     <ClCompile Include="..\..\..\source\slang\slang-ir-metal-legalize.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-missing-return.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-obfuscate-loc.cpp" />
+    <ClCompile Include="..\..\..\source\slang\slang-ir-operator-shift-overflow.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-optix-entry-point-uniforms.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-peephole.cpp" />
     <ClCompile Include="..\..\..\source\slang\slang-ir-propagate-func-properties.cpp" />

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -702,6 +702,9 @@
     <ClInclude Include="..\..\..\source\slang\slang-workspace-version.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\slang\slang-ir-operator-shift-overflow.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\prelude\slang-cpp-host-prelude.h.cpp">
@@ -1416,6 +1419,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\source\slang\slang-ir-operator-shift-overflow.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/build/visual-studio/slang/slang.vcxproj.filters
+++ b/build/visual-studio/slang/slang.vcxproj.filters
@@ -441,6 +441,9 @@
     <ClInclude Include="..\..\..\source\slang\slang-ir-obfuscate-loc.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\source\slang\slang-ir-operator-shift-overflow.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-ir-optix-entry-point-uniforms.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -700,9 +703,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\source\slang\slang-workspace-version.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\source\slang\slang-ir-operator-shift-overflow.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -1160,6 +1160,9 @@
     <ClCompile Include="..\..\..\source\slang\slang-ir-obfuscate-loc.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\source\slang\slang-ir-operator-shift-overflow.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang-ir-optix-entry-point-uniforms.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -1419,9 +1422,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\source\slang\slang.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\source\slang\slang-ir-operator-shift-overflow.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -740,7 +740,7 @@ DIAGNOSTIC(41021, Error, differentiableFuncMustHaveOutput, "a differentiable fun
 DIAGNOSTIC(41022, Error, differentiableFuncMustHaveInput, "a differentiable function must have at least one differentiable input.")
 DIAGNOSTIC(41023, Error, getStringHashMustBeOnStringLiteral, "getStringHash can only be called when argument is statically resolvable to a string literal")
 
-DIAGNOSTIC(41030, Warning, operatorShiftLeftOverflow, "left shift amount, `$1`, is bigger than the bit count of type, `$0`.")
+DIAGNOSTIC(41030, Warning, operatorShiftLeftOverflow, "left shift amount exceeds the number of bits, (`$0` << `$1`).")
 
 DIAGNOSTIC(41901, Error, unsupportedUseOfLValueForAutoDiff, "unsupported use of L-value for auto differentiation.")
 DIAGNOSTIC(41902, Error, cannotDifferentiateDynamicallyIndexedData, "cannot auto-differentiate mixed read/write access to dynamically indexed data in '$0'.")

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -740,7 +740,7 @@ DIAGNOSTIC(41021, Error, differentiableFuncMustHaveOutput, "a differentiable fun
 DIAGNOSTIC(41022, Error, differentiableFuncMustHaveInput, "a differentiable function must have at least one differentiable input.")
 DIAGNOSTIC(41023, Error, getStringHashMustBeOnStringLiteral, "getStringHash can only be called when argument is statically resolvable to a string literal")
 
-DIAGNOSTIC(41030, Warning, operatorShiftLeftOverflow, "the type of left hand side operand, `$0`, for operatnr<< is not big enough for the shifting amount, `$1`.")
+DIAGNOSTIC(41030, Warning, operatorShiftLeftOverflow, "left shift amount, `$1`, is bigger than the bit count of type, `$0`.")
 
 DIAGNOSTIC(41901, Error, unsupportedUseOfLValueForAutoDiff, "unsupported use of L-value for auto differentiation.")
 DIAGNOSTIC(41902, Error, cannotDifferentiateDynamicallyIndexedData, "cannot auto-differentiate mixed read/write access to dynamically indexed data in '$0'.")

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -740,7 +740,7 @@ DIAGNOSTIC(41021, Error, differentiableFuncMustHaveOutput, "a differentiable fun
 DIAGNOSTIC(41022, Error, differentiableFuncMustHaveInput, "a differentiable function must have at least one differentiable input.")
 DIAGNOSTIC(41023, Error, getStringHashMustBeOnStringLiteral, "getStringHash can only be called when argument is statically resolvable to a string literal")
 
-DIAGNOSTIC(41030, Warning, operatorShiftLeftOverflow, "left shift amount exceeds the number of bits, (`$0` << `$1`).")
+DIAGNOSTIC(41030, Warning, operatorShiftLeftOverflow, "left shift amount exceeds the number of bits and the result will be always zero, (`$0` << `$1`).")
 
 DIAGNOSTIC(41901, Error, unsupportedUseOfLValueForAutoDiff, "unsupported use of L-value for auto differentiation.")
 DIAGNOSTIC(41902, Error, cannotDifferentiateDynamicallyIndexedData, "cannot auto-differentiate mixed read/write access to dynamically indexed data in '$0'.")

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -740,6 +740,8 @@ DIAGNOSTIC(41021, Error, differentiableFuncMustHaveOutput, "a differentiable fun
 DIAGNOSTIC(41022, Error, differentiableFuncMustHaveInput, "a differentiable function must have at least one differentiable input.")
 DIAGNOSTIC(41023, Error, getStringHashMustBeOnStringLiteral, "getStringHash can only be called when argument is statically resolvable to a string literal")
 
+DIAGNOSTIC(41030, Warning, operatorShiftLeftOverflow, "the type of left hand side operand, `$0`, for operatnr<< is not big enough for the shifting amount, `$1`.")
+
 DIAGNOSTIC(41901, Error, unsupportedUseOfLValueForAutoDiff, "unsupported use of L-value for auto differentiation.")
 DIAGNOSTIC(41902, Error, cannotDifferentiateDynamicallyIndexedData, "cannot auto-differentiate mixed read/write access to dynamically indexed data in '$0'.")
 

--- a/source/slang/slang-ir-operator-shift-overflow.cpp
+++ b/source/slang/slang-ir-operator-shift-overflow.cpp
@@ -35,7 +35,7 @@ namespace Slang {
                     IRInst* lhs = opShiftLeft->getOperand(0);
                     IRType* lhsType = lhs->getDataType();
 
-                    IRIntegerValue sizeofLhs = 1;
+                    IRIntegerValue sizeofLhs;
                     switch (lhsType->getOp())
                     {
                     case kIROp_BoolType:
@@ -64,6 +64,9 @@ namespace Slang {
                     case kIROp_UIntPtrType:
                         sizeofLhs = 8;
                         break;
+
+                    default:
+                        continue;
                     }
 
                     if (sizeofLhs * 8 <= shiftAmount)

--- a/source/slang/slang-ir-operator-shift-overflow.cpp
+++ b/source/slang/slang-ir-operator-shift-overflow.cpp
@@ -1,0 +1,62 @@
+// slang-ir-operator-shift-overflow.cpp
+#include "slang-ir-operator-shift-overflow.h"
+
+#include "slang-ir.h"
+#include "slang-ir-insts.h"
+
+namespace Slang {
+
+    class DiagnosticSink;
+    struct IRModule;
+
+    void checkForOperatorShiftOverflowRecursive(
+        IRInst* inst,
+        DiagnosticSink* sink)
+    {
+        if (auto code = as<IRGlobalValueWithCode>(inst))
+        {
+            for (auto block : code->getBlocks())
+            {
+                for (auto opShiftLeft : block->getChildren())
+                {
+                    if (opShiftLeft->getOp() != kIROp_Lsh)
+                        continue;
+
+                    SLANG_ASSERT(opShiftLeft->getOperandCount() == 2);
+
+                    IRInst* rhs = opShiftLeft->getOperand(1);
+                    auto rhsLit = as<IRIntLit>(rhs);
+                    if (!rhsLit)
+                        continue;
+
+                    IRIntegerValue shiftAmount = rhsLit->getValue();
+
+                    IRInst* lhs = opShiftLeft->getOperand(0);
+                    IRUse lhsType = lhs->typeUse;
+
+                    // TODO: Not sure how to get the size of the type.
+                    {
+                        (void)lhsType;
+                        printf("JKWAK found 'operator<<' shifting by %" PRId64 "\n", shiftAmount);
+                        //sink->diagnose(child, Diagnostics::operatorShiftLeftOverflow);
+                    }
+                }
+            }
+        }
+
+        // TODO: Need to figure out if this can be just "inst->getChildren()"
+        for (auto childInst : inst->getDecorationsAndChildren())
+        {
+            checkForOperatorShiftOverflowRecursive(childInst, sink);
+        }
+    }
+
+    void checkForOperatorShiftOverflow(
+        IRModule* module,
+        DiagnosticSink* sink)
+    {
+        // Look for `operator<<` instructions
+        checkForOperatorShiftOverflowRecursive(module->getModuleInst(), sink);
+    }
+
+}

--- a/source/slang/slang-ir-operator-shift-overflow.cpp
+++ b/source/slang/slang-ir-operator-shift-overflow.cpp
@@ -11,7 +11,6 @@ namespace Slang {
     class DiagnosticSink;
     struct IRModule;
 
-    //struct 
     void checkForOperatorShiftOverflowRecursive(
         IRInst* inst,
         DiagnosticSink* sink)
@@ -70,7 +69,6 @@ namespace Slang {
                     if (sizeofLhs * 8 <= shiftAmount)
                     {
                         (void)lhsType;
-                        printf("JKWAK found 'operator<<' shifting by %" PRId64 "\n", shiftAmount);
                         sink->diagnose(opShiftLeft, Diagnostics::operatorShiftLeftOverflow, lhsType, shiftAmount);
                     }
                 }

--- a/source/slang/slang-ir-operator-shift-overflow.cpp
+++ b/source/slang/slang-ir-operator-shift-overflow.cpp
@@ -13,6 +13,7 @@ namespace Slang {
 
     void checkForOperatorShiftOverflowRecursive(
         IRInst* inst,
+        CompilerOptionSet& optionSet,
         DiagnosticSink* sink)
     {
         if (auto code = as<IRGlobalValueWithCode>(inst))
@@ -31,47 +32,16 @@ namespace Slang {
                     if (!rhsLit)
                         continue;
 
-                    IRIntegerValue shiftAmount = rhsLit->getValue();
                     IRInst* lhs = opShiftLeft->getOperand(0);
                     IRType* lhsType = lhs->getDataType();
 
-                    IRIntegerValue sizeofLhs;
-                    switch (lhsType->getOp())
-                    {
-                    case kIROp_BoolType:
-                    case kIROp_Int8Type:
-                    case kIROp_UInt8Type:
-                    case kIROp_CharType:
-                        sizeofLhs = 1;
-                        break;
-
-                    case kIROp_Int16Type:
-                    case kIROp_UInt16Type:
-                        sizeofLhs = 2;
-                        break;
-
-                    case kIROp_IntType:
-                    case kIROp_UIntType:
-                        sizeofLhs = 4;
-                        break;
-
-                    case kIROp_Int64Type:
-                    case kIROp_UInt64Type:
-                        sizeofLhs = 8;
-                        break;
-
-                    case kIROp_IntPtrType:
-                    case kIROp_UIntPtrType:
-                        sizeofLhs = 8;
-                        break;
-
-                    default:
+                    IRSizeAndAlignment sizeAlignment;
+                    if (SLANG_FAILED(getNaturalSizeAndAlignment(optionSet, lhsType, &sizeAlignment)))
                         continue;
-                    }
 
-                    if (sizeofLhs * 8 <= shiftAmount)
+                    IRIntegerValue shiftAmount = rhsLit->getValue();
+                    if (sizeAlignment.size * 8 <= shiftAmount)
                     {
-                        (void)lhsType;
                         sink->diagnose(opShiftLeft, Diagnostics::operatorShiftLeftOverflow, lhsType, shiftAmount);
                     }
                 }
@@ -80,16 +50,17 @@ namespace Slang {
 
         for (auto childInst : inst->getChildren())
         {
-            checkForOperatorShiftOverflowRecursive(childInst, sink);
+            checkForOperatorShiftOverflowRecursive(childInst, optionSet, sink);
         }
     }
 
     void checkForOperatorShiftOverflow(
         IRModule* module,
+        CompilerOptionSet& optionSet,
         DiagnosticSink* sink)
     {
         // Look for `operator<<` instructions
-        checkForOperatorShiftOverflowRecursive(module->getModuleInst(), sink);
+        checkForOperatorShiftOverflowRecursive(module->getModuleInst(), optionSet, sink);
     }
 
 }

--- a/source/slang/slang-ir-operator-shift-overflow.h
+++ b/source/slang/slang-ir-operator-shift-overflow.h
@@ -1,0 +1,12 @@
+// slang-ir-operator-shift-overflow.h
+#pragma once
+
+namespace Slang
+{
+    class DiagnosticSink;
+    struct IRModule;
+
+    void checkForOperatorShiftOverflow(
+        IRModule* module,
+        DiagnosticSink* sink);
+}

--- a/source/slang/slang-ir-operator-shift-overflow.h
+++ b/source/slang/slang-ir-operator-shift-overflow.h
@@ -1,6 +1,8 @@
 // slang-ir-operator-shift-overflow.h
 #pragma once
 
+#include "slang-compiler-options.h"
+
 namespace Slang
 {
     class DiagnosticSink;
@@ -8,5 +10,6 @@ namespace Slang
 
     void checkForOperatorShiftOverflow(
         IRModule* module,
+        CompilerOptionSet& optionSet,
         DiagnosticSink* sink);
 }

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -10938,7 +10938,7 @@ RefPtr<IRModule> generateIRForTranslationUnit(
         // Check for invalid differentiable function body.
         checkAutoDiffUsages(module, compileRequest->getSink());
 
-        checkForOperatorShiftOverflow(module, compileRequest->getSink());
+        checkForOperatorShiftOverflow(module, linkage->m_optionSet, compileRequest->getSink());
     }
 
     // The "mandatory" optimization passes may make use of the

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -23,6 +23,7 @@
 #include "slang-ir-check-differentiability.h"
 #include "slang-ir-check-recursive-type.h"
 #include "slang-ir-missing-return.h"
+#include "slang-ir-operator-shift-overflow.h"
 #include "slang-ir-sccp.h"
 #include "slang-ir-ssa.h"
 #include "slang-ir-strip.h"
@@ -10917,13 +10918,13 @@ RefPtr<IRModule> generateIRForTranslationUnit(
             break;
     }
 
-    // Check for using uninitialized out parameters.
     if (compileRequest->getLinkage()->m_optionSet.shouldRunNonEssentialValidation())
     {
         // Propagate `constexpr`-ness through the dataflow graph (and the
         // call graph) based on constraints imposed by different instructions.
         propagateConstExpr(module, compileRequest->getSink());
 
+        // Check for using uninitialized out parameters.
         checkForUsingUninitializedOutParams(module, compileRequest->getSink());
         
         // TODO: give error messages if any `undefined` or
@@ -10936,6 +10937,8 @@ RefPtr<IRModule> generateIRForTranslationUnit(
 
         // Check for invalid differentiable function body.
         checkAutoDiffUsages(module, compileRequest->getSink());
+
+        checkForOperatorShiftOverflow(module, compileRequest->getSink());
     }
 
     // The "mandatory" optimization passes may make use of the

--- a/tests/diagnostics/warning_operator_left_shift_overflow.slang
+++ b/tests/diagnostics/warning_operator_left_shift_overflow.slang
@@ -17,9 +17,9 @@ void computeMain(int3 dispatchThreadID: SV_DispatchThreadID)
         + (u8 << 6)
         + (u8 << 7)
         // CHECK-NOT: warning 41030:
-        // CHECK: ([[#@LINE+1]]): warning 41030: {{.*}}8{{.*}}uint8
+        // CHECK: ([[#@LINE+1]]): warning 41030: {{.*}}uint8{{.*}}8
         + (u8 << 8)
-        // CHECK: ([[#@LINE+1]]): warning 41030: {{.*}}9{{.*}}uint8
+        // CHECK: ([[#@LINE+1]]): warning 41030: {{.*}}uint8{{.*}}9
         + (u8 << 9)
         ;
 

--- a/tests/diagnostics/warning_operator_left_shift_overflow.slang
+++ b/tests/diagnostics/warning_operator_left_shift_overflow.slang
@@ -1,0 +1,27 @@
+//TEST:SIMPLE(filecheck=CHECK): -stage compute -entry computeMain -target hlsl
+
+RWStructuredBuffer<int> inputBuffer;
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(4, 1, 1)]
+void computeMain(int3 dispatchThreadID: SV_DispatchThreadID)
+{
+    uint8_t u8 = uint8_t(inputBuffer[0]);
+
+    uint result = (u8 << 0)
+        + (u8 << 1)
+        + (u8 << 2)
+        + (u8 << 3)
+        + (u8 << 4)
+        + (u8 << 5)
+        + (u8 << 6)
+        + (u8 << 7)
+        // CHECK-NOT: warning 41030:
+        // CHECK: ([[#@LINE+1]]): warning 41030: {{.*}}8{{.*}}uint8
+        + (u8 << 8)
+        // CHECK: ([[#@LINE+1]]): warning 41030: {{.*}}9{{.*}}uint8
+        + (u8 << 9)
+        ;
+
+    outputBuffer[0] = int(result);
+}


### PR DESCRIPTION
Closes #3944

For the given type of the left side operand to `operator<<` is not big enough for the right side operand, print a warning that the result will be always zero.