### PR TITLE
Fixes incorrect profile string in hello-word example

### DIFF
--- a/examples/hello-world/main.cpp
+++ b/examples/hello-world/main.cpp
@@ -114,7 +114,7 @@ int HelloWorldExample::createComputePipelineFromShader()
     slang::SessionDesc sessionDesc = {};
     slang::TargetDesc targetDesc = {};
     targetDesc.format = SLANG_SPIRV;
-    targetDesc.profile = slangGlobalSession->findProfile("glsl440");
+    targetDesc.profile = slangGlobalSession->findProfile("glsl_440");
     targetDesc.flags = SLANG_TARGET_FLAG_GENERATE_SPIRV_DIRECTLY;
 
     sessionDesc.targets = &targetDesc;


### PR DESCRIPTION
This CL fixes a typo in the profile string for the hello-world example. Currently `"glsl440"` is passed into `findProfile()` resulting in a return value of `SLANG_UNKNOWN_PROFILE` since format of the profile name is incorrect. The correct profile name is `glsl_440`, therefore the string passed into `findProfile()` should be `"glsl_440"` which results in valid profile value.