### PR TITLE
Use memcpy to replace strncpy_s

### DIFF
--- a/source/core/slang-performance-profiler.cpp
+++ b/source/core/slang-performance-profiler.cpp
@@ -65,7 +65,7 @@ namespace Slang
 
             if (strSize > 0)
             {
-                strncpy_s(profileEntry.funcName, strSize, func.key, strSize);
+                memcpy(profileEntry.funcName, func.key, strSize);
             }
             profileEntry.invocationCount = func.value.invocationCount;
             profileEntry.duration = func.value.duration;


### PR DESCRIPTION
Use memcpy to replace strncpy_s in SlangProfiler::SlangProfiler to fix the error in Windows.