### PR TITLE
Avoid duplicating entry points in library

### DIFF
--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -2444,6 +2444,9 @@ namespace Slang
 
     void Module::_discoverEntryPoints(DiagnosticSink* sink, const List<RefPtr<TargetRequest>>& targets)
     {
+        if (m_entryPoints.getCount() > 0)
+            return;
+
         for (auto globalDecl : m_moduleDecl->members)
         {
             auto maybeFuncDecl = globalDecl;


### PR DESCRIPTION
When compile a library module with other slang module together, if that library module already contains entry points, during the front-end process, we could add the entry points in library module again when scanning all the translation units. This will cause an issue that we will call linkIR twice on the exactly same entry point, and it will downgrade our performance heavily.

So, we will add a check in _discoverEntryPoints(), where if the entry points were added before, don't discover them again.