### PR TITLE
Fix python syntax highlighting in slangpy chapter

### DIFF
--- a/docs/user-guide/a1-02-slangpy.md
+++ b/docs/user-guide/a1-02-slangpy.md
@@ -62,7 +62,7 @@ The second attribute `[AutoPyBindCUDA]` allows us to call `square` directly from
 
 You can now simply invoke this kernel from python:
 
-``` Python
+```python
 import torch
 import slangtorch
 


### PR DESCRIPTION
I guess it did not like the space between backtits and "Python"