### PR TITLE
Limit the supported texture types for GLSL

### DIFF
--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -1682,10 +1682,10 @@ public typealias usamplerBuffer = SamplerBuffer<uint4>;
 // textureSize
 // -------------------
 
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_size)]
-public int textureSize(Sampler1D<vector<T,N>> sampler, int lod)
+public int textureSize(Sampler1D<vector<T,4>> sampler, int lod)
 {
     int result;
     int numberOfLevels;
@@ -1693,10 +1693,10 @@ public int textureSize(Sampler1D<vector<T,N>> sampler, int lod)
     return result;
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_size)]
-public ivec2 textureSize(Sampler2D<vector<T,N>> sampler, int lod)
+public ivec2 textureSize(Sampler2D<vector<T,4>> sampler, int lod)
 {
     vector<int,2> result;
     int numberOfLevels;
@@ -1704,10 +1704,10 @@ public ivec2 textureSize(Sampler2D<vector<T,N>> sampler, int lod)
     return result;
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_size)]
-public ivec3 textureSize(Sampler3D<vector<T,N>> sampler, int lod)
+public ivec3 textureSize(Sampler3D<vector<T,4>> sampler, int lod)
 {
     vector<int,3> result;
     int numberOfLevels;
@@ -1715,10 +1715,10 @@ public ivec3 textureSize(Sampler3D<vector<T,N>> sampler, int lod)
     return result;
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_size)]
-public ivec2 textureSize(SamplerCube<vector<T,N>> sampler, int lod)
+public ivec2 textureSize(SamplerCube<vector<T,4>> sampler, int lod)
 {
     vector<int,2> result;
     int numberOfLevels;
@@ -1757,9 +1757,9 @@ public ivec2 textureSize(samplerCubeShadow sampler, int lod)
 }
 
 [require(glsl_hlsl_spirv, texture_size)]
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
-public ivec3 textureSize(SamplerCubeArray<vector<T,N>> sampler, int lod)
+public ivec3 textureSize(SamplerCubeArray<vector<T,4>> sampler, int lod)
 {
     vector<int,3> result;
     int numberOfLevels;
@@ -1778,9 +1778,9 @@ public ivec3 textureSize(samplerCubeArrayShadow sampler, int lod)
 }
 
 [require(glsl_hlsl_spirv, texture_size)]
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
-public ivec2 textureSize(Sampler2DRect<vector<T,N>> sampler)
+public ivec2 textureSize(Sampler2DRect<vector<T,4>> sampler)
 {
     vector<int,2> result;
     int numberOfLevels;
@@ -1799,9 +1799,9 @@ public ivec2 textureSize(sampler2DRectShadow sampler)
 }
 
 [require(glsl_hlsl_spirv, texture_size)]
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
-public ivec2 textureSize(Sampler1DArray<vector<T,N>> sampler, int lod)
+public ivec2 textureSize(Sampler1DArray<vector<T,4>> sampler, int lod)
 {
     vector<int,2> result;
     int numberOfLevels;
@@ -1820,9 +1820,9 @@ public ivec2 textureSize(sampler1DArrayShadow sampler, int lod)
 }
 
 [require(glsl_hlsl_spirv, texture_size)]
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
-public ivec3 textureSize(Sampler2DArray<vector<T,N>> sampler, int lod)
+public ivec3 textureSize(Sampler2DArray<vector<T,4>> sampler, int lod)
 {
     vector<int,3> result;
     int numberOfLevels;
@@ -1841,9 +1841,9 @@ public ivec3 textureSize(sampler2DArrayShadow sampler, int lod)
 }
 
 [require(glsl_hlsl_spirv, texture_size)]
-__generic<T:__BuiltinArithmeticType, let N:int, let format:int>
+__generic<T:__BuiltinArithmeticType, let format:int>
 [ForceInline]
-public int textureSize(SamplerBuffer<vector<T,N>,format> sampler)
+public int textureSize(SamplerBuffer<vector<T,4>,format> sampler)
 {
     uint result;
     sampler.GetDimensions(result);
@@ -1851,9 +1851,9 @@ public int textureSize(SamplerBuffer<vector<T,N>,format> sampler)
 }
 
 [require(glsl_hlsl_spirv, texture_size)]
-__generic<T:__BuiltinArithmeticType, let N:int, let sampleCount:int>
+__generic<T:__BuiltinArithmeticType, let sampleCount:int>
 [ForceInline]
-public ivec2 textureSize(Sampler2DMS<vector<T,N>,sampleCount> sampler)
+public ivec2 textureSize(Sampler2DMS<vector<T,4>,sampleCount> sampler)
 {
     vector<int,2> result;
     int sampleCount;
@@ -1863,9 +1863,9 @@ public ivec2 textureSize(Sampler2DMS<vector<T,N>,sampleCount> sampler)
 }
 
 [require(glsl_hlsl_spirv, texture_size)]
-__generic<T:__BuiltinArithmeticType, let N:int, let sampleCount:int>
+__generic<T:__BuiltinArithmeticType, let sampleCount:int>
 [ForceInline]
-public ivec3 textureSize(Sampler2DMSArray<vector<T,N>,sampleCount> sampler)
+public ivec3 textureSize(Sampler2DMSArray<vector<T,4>,sampleCount> sampler)
 {
     vector<int,3> result;
     int sampleCount;
@@ -1945,10 +1945,10 @@ public vec2 textureQueryLod(__TextureImpl<T,
 // textureQueryLevels
 // -------------------
 
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_querylevels)]
-public int textureQueryLevels(Sampler1D<vector<T,N>> sampler)
+public int textureQueryLevels(Sampler1D<vector<T,4>> sampler)
 {
     int width;
     int numberOfLevels;
@@ -1956,10 +1956,10 @@ public int textureQueryLevels(Sampler1D<vector<T,N>> sampler)
     return numberOfLevels;
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_querylevels)]
-public int textureQueryLevels(Sampler2D<vector<T,N>> sampler)
+public int textureQueryLevels(Sampler2D<vector<T,4>> sampler)
 {
     vector<int,2> dim;
     int numberOfLevels;
@@ -1967,10 +1967,10 @@ public int textureQueryLevels(Sampler2D<vector<T,N>> sampler)
     return numberOfLevels;
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_querylevels)]
-public int textureQueryLevels(Sampler3D<vector<T,N>> sampler)
+public int textureQueryLevels(Sampler3D<vector<T,4>> sampler)
 {
     vector<int,3> dim;
     int numberOfLevels;
@@ -1978,10 +1978,10 @@ public int textureQueryLevels(Sampler3D<vector<T,N>> sampler)
     return numberOfLevels;
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_querylevels)]
-public int textureQueryLevels(SamplerCube<vector<T,N>> sampler)
+public int textureQueryLevels(SamplerCube<vector<T,4>> sampler)
 {
     vector<int,2> dim;
     int numberOfLevels;
@@ -1989,10 +1989,10 @@ public int textureQueryLevels(SamplerCube<vector<T,N>> sampler)
     return numberOfLevels;
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_querylevels)]
-public int textureQueryLevels(Sampler1DArray<vector<T,N>> sampler)
+public int textureQueryLevels(Sampler1DArray<vector<T,4>> sampler)
 {
     vector<int,2> dim;
     int numberOfLevels;
@@ -2000,10 +2000,10 @@ public int textureQueryLevels(Sampler1DArray<vector<T,N>> sampler)
     return numberOfLevels;
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_querylevels)]
-public int textureQueryLevels(Sampler2DArray<vector<T,N>> sampler)
+public int textureQueryLevels(Sampler2DArray<vector<T,4>> sampler)
 {
     vector<int,3> dim;
     int numberOfLevels;
@@ -2011,10 +2011,10 @@ public int textureQueryLevels(Sampler2DArray<vector<T,N>> sampler)
     return numberOfLevels;
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_querylevels)]
-public int textureQueryLevels(SamplerCubeArray<vector<T,N>> sampler)
+public int textureQueryLevels(SamplerCubeArray<vector<T,4>> sampler)
 {
     vector<int,3> dim;
     int numberOfLevels;
@@ -2086,10 +2086,10 @@ public int textureQueryLevels(samplerCubeArrayShadow sampler)
 // textureSamples
 // -------------------
 
-__generic<T:__BuiltinArithmeticType, let N:int, let sampleCount:int>
+__generic<T:__BuiltinArithmeticType, let sampleCount:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, image_samples)]
-public int textureSamples(Sampler2DMS<vector<T,N>,sampleCount> sampler)
+public int textureSamples(Sampler2DMS<vector<T,4>,sampleCount> sampler)
 {
     vector<int,2> dim;
     int sampleCount;
@@ -2098,10 +2098,10 @@ public int textureSamples(Sampler2DMS<vector<T,N>,sampleCount> sampler)
     return sampleCount;
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int, let sampleCount:int>
+__generic<T:__BuiltinArithmeticType, let sampleCount:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, image_samples)]
-public int textureSamples(Sampler2DMSArray<vector<T,N>,sampleCount> sampler)
+public int textureSamples(Sampler2DMSArray<vector<T,4>,sampleCount> sampler)
 {
     vector<int,3> dim;
     int sampleCount;
@@ -2118,27 +2118,27 @@ public int textureSamples(Sampler2DMSArray<vector<T,N>,sampleCount> sampler)
 // texture
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> texture(Sampler1D<vector<T,N>> sampler, float p)
+public vector<T,4> texture(Sampler1D<vector<T,4>> sampler, float p)
 {
     return __vectorReshape<4>(sampler.Sample(p));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> texture(Sampler1D<vector<T,N>> sampler, float p, constexpr float bias)
+public vector<T,4> texture(Sampler1D<vector<T,4>> sampler, float p, constexpr float bias)
 {
     return __vectorReshape<4>(sampler.SampleBias(p, bias));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinFloatingPointType, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let format:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> texture(__TextureImpl<
-        vector<T,N>,
+        vector<T,4>,
         Shape,
         isArray,
         0, // isMS
@@ -2152,11 +2152,11 @@ public vector<T,4> texture(__TextureImpl<
     return __vectorReshape<4>(sampler.Sample(p));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinFloatingPointType, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let format:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> texture(__TextureImpl<
-        vector<T,N>,
+        vector<T,4>,
         Shape,
         isArray,
         0, // isMS
@@ -2304,10 +2304,10 @@ public float texture(samplerCubeArrayShadow sampler, vec4 p, float compare)
 // textureProj
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProj(Sampler1D<vector<T,N>> sampler, vec2 p)
+public vector<T,4> textureProj(Sampler1D<vector<T,4>> sampler, vec2 p)
 {
     __requireComputeDerivative();
     __target_switch
@@ -2321,10 +2321,10 @@ public vector<T,4> textureProj(Sampler1D<vector<T,N>> sampler, vec2 p)
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProj(Sampler1D<vector<T,N>> sampler, vec2 p, float bias)
+public vector<T,4> textureProj(Sampler1D<vector<T,4>> sampler, vec2 p, float bias)
 {
     __requireComputeDerivative();
     __target_switch
@@ -2338,10 +2338,10 @@ public vector<T,4> textureProj(Sampler1D<vector<T,N>> sampler, vec2 p, float bia
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProj(Sampler1D<vector<T,N>> sampler, vec4 p)
+public vector<T,4> textureProj(Sampler1D<vector<T,4>> sampler, vec4 p)
 {
     __requireComputeDerivative();
     __target_switch
@@ -2355,10 +2355,10 @@ public vector<T,4> textureProj(Sampler1D<vector<T,N>> sampler, vec4 p)
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProj(Sampler1D<vector<T,N>> sampler, vec4 p, float bias)
+public vector<T,4> textureProj(Sampler1D<vector<T,4>> sampler, vec4 p, float bias)
 {
     __requireComputeDerivative();
     __target_switch
@@ -2372,10 +2372,10 @@ public vector<T,4> textureProj(Sampler1D<vector<T,N>> sampler, vec4 p, float bia
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProj(Sampler2D<vector<T,N>> sampler, vec3 p)
+public vector<T,4> textureProj(Sampler2D<vector<T,4>> sampler, vec3 p)
 {
     __requireComputeDerivative();
     __target_switch
@@ -2389,10 +2389,10 @@ public vector<T,4> textureProj(Sampler2D<vector<T,N>> sampler, vec3 p)
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProj(Sampler2D<vector<T,N>> sampler, vec3 p, float bias)
+public vector<T,4> textureProj(Sampler2D<vector<T,4>> sampler, vec3 p, float bias)
 {
     __requireComputeDerivative();
     __target_switch
@@ -2406,10 +2406,10 @@ public vector<T,4> textureProj(Sampler2D<vector<T,N>> sampler, vec3 p, float bia
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProj(Sampler2D<vector<T,N>> sampler, vec4 p)
+public vector<T,4> textureProj(Sampler2D<vector<T,4>> sampler, vec4 p)
 {
     __requireComputeDerivative();
     __target_switch
@@ -2423,10 +2423,10 @@ public vector<T,4> textureProj(Sampler2D<vector<T,N>> sampler, vec4 p)
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProj(Sampler2D<vector<T,N>> sampler, vec4 p, float bias)
+public vector<T,4> textureProj(Sampler2D<vector<T,4>> sampler, vec4 p, float bias)
 {
     __requireComputeDerivative();
     __target_switch
@@ -2440,10 +2440,10 @@ public vector<T,4> textureProj(Sampler2D<vector<T,N>> sampler, vec4 p, float bia
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProj(Sampler3D<vector<T,N>> sampler, vec4 p)
+public vector<T,4> textureProj(Sampler3D<vector<T,4>> sampler, vec4 p)
 {
     __requireComputeDerivative();
     __target_switch
@@ -2457,10 +2457,10 @@ public vector<T,4> textureProj(Sampler3D<vector<T,N>> sampler, vec4 p)
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProj(Sampler3D<vector<T,N>> sampler, vec4 p, float bias)
+public vector<T,4> textureProj(Sampler3D<vector<T,4>> sampler, vec4 p, float bias)
 {
     __requireComputeDerivative();
     __target_switch
@@ -2562,19 +2562,19 @@ public float textureProj(sampler2DShadow sampler, vec4 p, float bias)
 // textureLod
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureLod(Sampler1D<vector<T,N>> sampler, float p, float lod)
+public vector<T,4> textureLod(Sampler1D<vector<T,4>> sampler, float p, float lod)
 {
     return __vectorReshape<4>(sampler.SampleLevel(p, lod));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinFloatingPointType, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let format:int>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureLod(__TextureImpl<
-        vector<T,N>,
+        vector<T,4>,
         Shape,
         isArray,
         0, // isMS
@@ -2652,26 +2652,26 @@ public float textureLod(sampler1DArrayShadow sampler, vec3 p, float lod)
 // textureOffset
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureOffset(Sampler1D<vector<T,N>> sampler, float p, constexpr int offset, float bias = 0.0)
+public vector<T,4> textureOffset(Sampler1D<vector<T,4>> sampler, float p, constexpr int offset, float bias = 0.0)
 {
     return __vectorReshape<4>(sampler.SampleBias(p, bias, offset));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureOffset(Sampler2D<vector<T,N>> sampler, vec2 p, constexpr ivec2 offset, float bias = 0.0)
+public vector<T,4> textureOffset(Sampler2D<vector<T,4>> sampler, vec2 p, constexpr ivec2 offset, float bias = 0.0)
 {
     return __vectorReshape<4>(sampler.SampleBias(p, bias, offset));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureOffset(Sampler3D<vector<T,N>> sampler, vec3 p, constexpr ivec3 offset, float bias = 0.0)
+public vector<T,4> textureOffset(Sampler3D<vector<T,4>> sampler, vec3 p, constexpr ivec3 offset, float bias = 0.0)
 {
     return __vectorReshape<4>(sampler.SampleBias(p, bias, offset));
 }
@@ -2742,18 +2742,18 @@ public float textureOffset(sampler1DShadow sampler, vec3 p, constexpr int offset
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureOffset(Sampler1DArray<vector<T,N>> sampler, vec2 p, constexpr int offset, float bias = 0.0)
+public vector<T,4> textureOffset(Sampler1DArray<vector<T,4>> sampler, vec2 p, constexpr int offset, float bias = 0.0)
 {
     return __vectorReshape<4>(sampler.SampleBias(p, bias, offset));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureOffset(Sampler2DArray<vector<T,N>> sampler, vec3 p, constexpr ivec2 offset, float bias = 0.0)
+public vector<T,4> textureOffset(Sampler2DArray<vector<T,4>> sampler, vec3 p, constexpr ivec2 offset, float bias = 0.0)
 {
     return __vectorReshape<4>(sampler.SampleBias(p, bias, offset));
 }
@@ -2813,19 +2813,19 @@ public float textureOffset(sampler2DArrayShadow sampler, vec4 p, constexpr ivec2
 // texelFetch
 // -------------------
 
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_samplerless)]
-public vector<T,4> texelFetch(Sampler1D<vector<T,N>> sampler, int p, int lod)
+public vector<T,4> texelFetch(Sampler1D<vector<T,4>> sampler, int p, int lod)
 {
     return __vectorReshape<4>(sampler.Load(int2(p, lod)));
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinArithmeticType, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_samplerless)]
 public vector<T,4> texelFetch(__TextureImpl<
-        vector<T,N>,
+        vector<T,4>,
         Shape,
         isArray,
         0, // isMS
@@ -2839,27 +2839,27 @@ public vector<T,4> texelFetch(__TextureImpl<
     return __vectorReshape<4>(sampler.Load(__makeVector(p,lod)));
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_samplerless)]
-public vector<T,4> texelFetch(Sampler2DRect<vector<T,N>> sampler, ivec2 p)
+public vector<T,4> texelFetch(Sampler2DRect<vector<T,4>> sampler, ivec2 p)
 {
     return __vectorReshape<4>(sampler.Load(int3(p.xy,0)));
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int, let format:int>
+__generic<T:__BuiltinArithmeticType, let format:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_samplerless)]
-public vector<T,4> texelFetch(SamplerBuffer<vector<T,N>,format> sampler, int p)
+public vector<T,4> texelFetch(SamplerBuffer<vector<T,4>,format> sampler, int p)
 {
     return __vectorReshape<4>(sampler.Load(p));
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinArithmeticType, let isArray:int, let sampleCount:int, let format:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_samplerless)]
 public vector<T,4> texelFetch(__TextureImpl<
-        vector<T,N>,
+        vector<T,4>,
         __Shape2D,
         isArray,
         1, // isMS
@@ -2883,19 +2883,19 @@ public vector<T,4> texelFetch(__TextureImpl<
 // texelFetchOffset
 // -------------------
 
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_samplerless)]
-public vector<T,4> texelFetchOffset(Sampler1D<vector<T,N>> sampler, int p, int lod, constexpr int offset)
+public vector<T,4> texelFetchOffset(Sampler1D<vector<T,4>> sampler, int p, int lod, constexpr int offset)
 {
     return __vectorReshape<4>(sampler.Load(int2(p, lod), offset));
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinArithmeticType, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_samplerless)]
 public vector<T,4> texelFetchOffset(__TextureImpl<
-        vector<T,N>,
+        vector<T,4>,
         Shape,
         isArray,
         0, // isMS
@@ -2909,10 +2909,10 @@ public vector<T,4> texelFetchOffset(__TextureImpl<
     return __vectorReshape<4>(sampler.Load(__makeVector(p,lod), offset));
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int>
+__generic<T:__BuiltinArithmeticType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_samplerless)]
-public vector<T,4> texelFetchOffset(Sampler2DRect<vector<T,N>> sampler, ivec2 p, constexpr ivec2 offset)
+public vector<T,4> texelFetchOffset(Sampler2DRect<vector<T,4>> sampler, ivec2 p, constexpr ivec2 offset)
 {
     return __vectorReshape<4>(sampler.Load(__makeVector(p, 0), offset));
 }
@@ -2921,10 +2921,10 @@ public vector<T,4> texelFetchOffset(Sampler2DRect<vector<T,N>> sampler, ivec2 p,
 // textureProjOffset
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjOffset(Sampler1D<vector<T,N>> sampler, vec2 p, constexpr int offset)
+public vector<T,4> textureProjOffset(Sampler1D<vector<T,4>> sampler, vec2 p, constexpr int offset)
 {
     __requireComputeDerivative();
     __target_switch
@@ -2938,10 +2938,10 @@ public vector<T,4> textureProjOffset(Sampler1D<vector<T,N>> sampler, vec2 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjOffset(Sampler1D<vector<T,N>> sampler, vec2 p, constexpr int offset, float bias)
+public vector<T,4> textureProjOffset(Sampler1D<vector<T,4>> sampler, vec2 p, constexpr int offset, float bias)
 {
     __requireComputeDerivative();
     __target_switch
@@ -2955,10 +2955,10 @@ public vector<T,4> textureProjOffset(Sampler1D<vector<T,N>> sampler, vec2 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjOffset(Sampler1D<vector<T,N>> sampler, vec4 p, constexpr int offset)
+public vector<T,4> textureProjOffset(Sampler1D<vector<T,4>> sampler, vec4 p, constexpr int offset)
 {
     __requireComputeDerivative();
     __target_switch
@@ -2976,10 +2976,10 @@ public vector<T,4> textureProjOffset(Sampler1D<vector<T,N>> sampler, vec4 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjOffset(Sampler1D<vector<T,N>> sampler, vec4 p, constexpr int offset, float bias)
+public vector<T,4> textureProjOffset(Sampler1D<vector<T,4>> sampler, vec4 p, constexpr int offset, float bias)
 {
     __requireComputeDerivative();
     __target_switch
@@ -2997,10 +2997,10 @@ public vector<T,4> textureProjOffset(Sampler1D<vector<T,N>> sampler, vec4 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjOffset(Sampler2D<vector<T,N>> sampler, vec3 p, constexpr ivec2 offset)
+public vector<T,4> textureProjOffset(Sampler2D<vector<T,4>> sampler, vec3 p, constexpr ivec2 offset)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3014,10 +3014,10 @@ public vector<T,4> textureProjOffset(Sampler2D<vector<T,N>> sampler, vec3 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjOffset(Sampler2D<vector<T,N>> sampler, vec3 p, constexpr ivec2 offset, float bias)
+public vector<T,4> textureProjOffset(Sampler2D<vector<T,4>> sampler, vec3 p, constexpr ivec2 offset, float bias)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3031,10 +3031,10 @@ public vector<T,4> textureProjOffset(Sampler2D<vector<T,N>> sampler, vec3 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjOffset(Sampler2D<vector<T,N>> sampler, vec4 p, constexpr ivec2 offset)
+public vector<T,4> textureProjOffset(Sampler2D<vector<T,4>> sampler, vec4 p, constexpr ivec2 offset)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3052,10 +3052,10 @@ public vector<T,4> textureProjOffset(Sampler2D<vector<T,N>> sampler, vec4 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjOffset(Sampler2D<vector<T,N>> sampler, vec4 p, constexpr ivec2 offset, float bias)
+public vector<T,4> textureProjOffset(Sampler2D<vector<T,4>> sampler, vec4 p, constexpr ivec2 offset, float bias)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3073,10 +3073,10 @@ public vector<T,4> textureProjOffset(Sampler2D<vector<T,N>> sampler, vec4 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjOffset(Sampler3D<vector<T,N>> sampler, vec4 p, constexpr ivec3 offset)
+public vector<T,4> textureProjOffset(Sampler3D<vector<T,4>> sampler, vec4 p, constexpr ivec3 offset)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3090,10 +3090,10 @@ public vector<T,4> textureProjOffset(Sampler3D<vector<T,N>> sampler, vec4 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjOffset(Sampler3D<vector<T,N>> sampler, vec4 p, constexpr ivec3 offset, float bias)
+public vector<T,4> textureProjOffset(Sampler3D<vector<T,4>> sampler, vec4 p, constexpr ivec3 offset, float bias)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3195,19 +3195,19 @@ public float textureProjOffset(sampler2DShadow sampler, vec4 p, constexpr ivec2 
 // textureLodOffset
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
-public vector<T,4> textureLodOffset(Sampler1D<vector<T,N>> sampler, float p, float lod, constexpr int offset)
+public vector<T,4> textureLodOffset(Sampler1D<vector<T,4>> sampler, float p, float lod, constexpr int offset)
 {
     return __vectorReshape<4>(sampler.SampleLevel(p, lod, offset));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinFloatingPointType, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureLodOffset(__TextureImpl<
-        vector<T,N>,
+        vector<T,4>,
         Shape,
         isArray,
         0, // isMS
@@ -3288,10 +3288,10 @@ public float textureLodOffset(sampler1DArrayShadow sampler, vec3 p, float lod, c
 // textureProjLod
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjLod(Sampler1D<vector<T,N>> sampler, vec2 p, float lod)
+public vector<T,4> textureProjLod(Sampler1D<vector<T,4>> sampler, vec2 p, float lod)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3305,10 +3305,10 @@ public vector<T,4> textureProjLod(Sampler1D<vector<T,N>> sampler, vec2 p, float 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjLod(Sampler1D<vector<T,N>> sampler, vec4 p, float lod)
+public vector<T,4> textureProjLod(Sampler1D<vector<T,4>> sampler, vec4 p, float lod)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3326,10 +3326,10 @@ public vector<T,4> textureProjLod(Sampler1D<vector<T,N>> sampler, vec4 p, float 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjLod(Sampler2D<vector<T,N>> sampler, vec3 p, float lod)
+public vector<T,4> textureProjLod(Sampler2D<vector<T,4>> sampler, vec3 p, float lod)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3343,10 +3343,10 @@ public vector<T,4> textureProjLod(Sampler2D<vector<T,N>> sampler, vec3 p, float 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjLod(Sampler2D<vector<T,N>> sampler, vec4 p, float lod)
+public vector<T,4> textureProjLod(Sampler2D<vector<T,4>> sampler, vec4 p, float lod)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3364,10 +3364,10 @@ public vector<T,4> textureProjLod(Sampler2D<vector<T,N>> sampler, vec4 p, float 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjLod(Sampler3D<vector<T,N>> sampler, vec4 p, float lod)
+public vector<T,4> textureProjLod(Sampler3D<vector<T,4>> sampler, vec4 p, float lod)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3427,10 +3427,10 @@ public float textureProjLod(sampler2DShadow sampler, vec4 p, float lod)
 // textureProjLodOffset
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjLodOffset(Sampler1D<vector<T,N>> sampler, vec2 p, float lod, constexpr int offset)
+public vector<T,4> textureProjLodOffset(Sampler1D<vector<T,4>> sampler, vec2 p, float lod, constexpr int offset)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3444,10 +3444,10 @@ public vector<T,4> textureProjLodOffset(Sampler1D<vector<T,N>> sampler, vec2 p, 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjLodOffset(Sampler1D<vector<T,N>> sampler, vec4 p, float lod, constexpr int offset)
+public vector<T,4> textureProjLodOffset(Sampler1D<vector<T,4>> sampler, vec4 p, float lod, constexpr int offset)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3465,10 +3465,10 @@ public vector<T,4> textureProjLodOffset(Sampler1D<vector<T,N>> sampler, vec4 p, 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjLodOffset(Sampler2D<vector<T,N>> sampler, vec3 p, float lod, constexpr ivec2 offset)
+public vector<T,4> textureProjLodOffset(Sampler2D<vector<T,4>> sampler, vec3 p, float lod, constexpr ivec2 offset)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3482,10 +3482,10 @@ public vector<T,4> textureProjLodOffset(Sampler2D<vector<T,N>> sampler, vec3 p, 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjLodOffset(Sampler2D<vector<T,N>> sampler, vec4 p, float lod, constexpr ivec2 offset)
+public vector<T,4> textureProjLodOffset(Sampler2D<vector<T,4>> sampler, vec4 p, float lod, constexpr ivec2 offset)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3503,10 +3503,10 @@ public vector<T,4> textureProjLodOffset(Sampler2D<vector<T,N>> sampler, vec4 p, 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
-public vector<T,4> textureProjLodOffset(Sampler3D<vector<T,N>> sampler, vec4 p, float lod, constexpr ivec3 offset)
+public vector<T,4> textureProjLodOffset(Sampler3D<vector<T,4>> sampler, vec4 p, float lod, constexpr ivec3 offset)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3567,19 +3567,19 @@ public float textureProjLodOffset(sampler2DShadow sampler, vec4 p, float lod, co
 // -------------------
 
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
-public vector<T,4> textureGrad(Sampler1D<vector<T,N>> sampler, float p, float dPdx, float dPdy)
+public vector<T,4> textureGrad(Sampler1D<vector<T,4>> sampler, float p, float dPdx, float dPdy)
 {
     return __vectorReshape<4>(sampler.SampleGrad(p, dPdx, dPdy));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinFloatingPointType, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureGrad(__TextureImpl<
-        vector<T,N>,
+        vector<T,4>,
         Shape,
         isArray,
         0, // isMS
@@ -3687,19 +3687,19 @@ public float textureGrad(sampler2DArrayShadow sampler, vec4 p, vec2 dPdx, vec2 d
 // textureGradOffset
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
-public vector<T,4> textureGradOffset(Sampler1D<vector<T,N>> sampler, float p, float dPdx, float dPdy, constexpr int offset)
+public vector<T,4> textureGradOffset(Sampler1D<vector<T,4>> sampler, float p, float dPdx, float dPdy, constexpr int offset)
 {
     return __vectorReshape<4>(sampler.SampleGrad(p, dPdx, dPdy, offset));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinFloatingPointType, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 [ForceInline]
 public vector<T,4> textureGradOffset(__TextureImpl<
-        vector<T,N>,
+        vector<T,4>,
         Shape,
         isArray,
         0, // isMS
@@ -3789,10 +3789,10 @@ public float textureGradOffset(sampler2DArrayShadow sampler, vec4 p, vec2 dPdx, 
 // textureProjGrad
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
-public vector<T,4> textureProjGrad(Sampler1D<vector<T,N>> sampler, vec2 p, float dPdx, float dPdy)
+public vector<T,4> textureProjGrad(Sampler1D<vector<T,4>> sampler, vec2 p, float dPdx, float dPdy)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3806,10 +3806,10 @@ public vector<T,4> textureProjGrad(Sampler1D<vector<T,N>> sampler, vec2 p, float
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
-public vector<T,4> textureProjGrad(Sampler1D<vector<T,N>> sampler, vec4 p, float dPdx, float dPdy)
+public vector<T,4> textureProjGrad(Sampler1D<vector<T,4>> sampler, vec4 p, float dPdx, float dPdy)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3827,10 +3827,10 @@ public vector<T,4> textureProjGrad(Sampler1D<vector<T,N>> sampler, vec4 p, float
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
-public vector<T,4> textureProjGrad(Sampler2D<vector<T,N>> sampler, vec3 p, vec2 dPdx, vec2 dPdy)
+public vector<T,4> textureProjGrad(Sampler2D<vector<T,4>> sampler, vec3 p, vec2 dPdx, vec2 dPdy)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3844,10 +3844,10 @@ public vector<T,4> textureProjGrad(Sampler2D<vector<T,N>> sampler, vec3 p, vec2 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
-public vector<T,4> textureProjGrad(Sampler2D<vector<T,N>> sampler, vec4 p, vec2 dPdx, vec2 dPdy)
+public vector<T,4> textureProjGrad(Sampler2D<vector<T,4>> sampler, vec4 p, vec2 dPdx, vec2 dPdy)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3865,10 +3865,10 @@ public vector<T,4> textureProjGrad(Sampler2D<vector<T,N>> sampler, vec4 p, vec2 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
-public vector<T,4> textureProjGrad(Sampler3D<vector<T,N>> sampler, vec4 p, vec3 dPdx, vec3 dPdy)
+public vector<T,4> textureProjGrad(Sampler3D<vector<T,4>> sampler, vec4 p, vec3 dPdx, vec3 dPdy)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3928,10 +3928,10 @@ public float textureProjGrad(sampler2DShadow sampler, vec4 p, vec2 dPdx, vec2 dP
 // textureProjGradOffset
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
-public vector<T,4> textureProjGradOffset(Sampler1D<vector<T,N>> sampler, vec2 p, float dPdx, float dPdy, constexpr int offset)
+public vector<T,4> textureProjGradOffset(Sampler1D<vector<T,4>> sampler, vec2 p, float dPdx, float dPdy, constexpr int offset)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3945,10 +3945,10 @@ public vector<T,4> textureProjGradOffset(Sampler1D<vector<T,N>> sampler, vec2 p,
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
-public vector<T,4> textureProjGradOffset(Sampler1D<vector<T,N>> sampler, vec4 p, float dPdx, float dPdy, constexpr int offset)
+public vector<T,4> textureProjGradOffset(Sampler1D<vector<T,4>> sampler, vec4 p, float dPdx, float dPdy, constexpr int offset)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3966,10 +3966,10 @@ public vector<T,4> textureProjGradOffset(Sampler1D<vector<T,N>> sampler, vec4 p,
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
-public vector<T,4> textureProjGradOffset(Sampler2D<vector<T,N>> sampler, vec3 p, vec2 dPdx, vec2 dPdy, constexpr ivec2 offset)
+public vector<T,4> textureProjGradOffset(Sampler2D<vector<T,4>> sampler, vec3 p, vec2 dPdx, vec2 dPdy, constexpr ivec2 offset)
 {
     __requireComputeDerivative();
     __target_switch
@@ -3983,10 +3983,10 @@ public vector<T,4> textureProjGradOffset(Sampler2D<vector<T,N>> sampler, vec3 p,
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
-public vector<T,4> textureProjGradOffset(Sampler2D<vector<T,N>> sampler, vec4 p, vec2 dPdx, vec2 dPdy, constexpr ivec2 offset)
+public vector<T,4> textureProjGradOffset(Sampler2D<vector<T,4>> sampler, vec4 p, vec2 dPdx, vec2 dPdy, constexpr ivec2 offset)
 {
     __requireComputeDerivative();
     __target_switch
@@ -4004,10 +4004,10 @@ public vector<T,4> textureProjGradOffset(Sampler2D<vector<T,N>> sampler, vec4 p,
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinFloatingPointType>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
-public vector<T,4> textureProjGradOffset(Sampler3D<vector<T,N>> sampler, vec4 p, vec3 dPdx, vec3 dPdy, constexpr ivec3 offset)
+public vector<T,4> textureProjGradOffset(Sampler3D<vector<T,4>> sampler, vec4 p, vec3 dPdx, vec3 dPdy, constexpr ivec3 offset)
 {
     __requireComputeDerivative();
     __target_switch
@@ -4071,11 +4071,11 @@ public float textureProjGradOffset(sampler2DShadow sampler, vec4 p, vec2 dPdx, v
 // textureGather
 // -------------------
 
-__generic<T:__BuiltinArithmeticType, let N:int, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinArithmeticType, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_gather)]
 public vector<T,4> textureGather(__TextureImpl<
-        vector<T,N>,
+        vector<T,4>,
         Shape,
         isArray,
         0, // isMS
@@ -4117,11 +4117,11 @@ public vec4 textureGather(__TextureImpl<
 // textureGatherOffset
 // -------------------
 
-__generic<T:__BuiltinArithmeticType, let N:int, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinArithmeticType, let isArray:int, let sampleCount:int, let format:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_gather)]
 public vector<T,4> textureGatherOffset(__TextureImpl<
-        vector<T,N>,
+        vector<T,4>,
         __Shape2D,
         isArray,
         0, // isMS
@@ -4163,11 +4163,11 @@ public vec4 textureGatherOffset(__TextureImpl<
 // textureGatherOffsets
 // -------------------
 
-__generic<T:__BuiltinArithmeticType, let N:int, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinArithmeticType, let isArray:int, let sampleCount:int, let format:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_gather)]
 public vector<T,4> textureGatherOffsets(__TextureImpl<
-        vector<T,N>,
+        vector<T,4>,
         __Shape2D,
         isArray,
         0, // isMS

--- a/tests/glsl-intrinsic/compute-derivative/intrinsic-derivative-function-in-compute.slang
+++ b/tests/glsl-intrinsic/compute-derivative/intrinsic-derivative-function-in-compute.slang
@@ -49,8 +49,8 @@ buffer MyBlockName
 
 uniform sampler1D uniform_sampler1D;
 
-__generic<T : __BuiltinFloatingPointType, let N : int>
-bool textureFuncs(Sampler1D<vector<T,N>> gsampler1D)
+__generic<T : __BuiltinFloatingPointType>
+bool textureFuncs(Sampler1D<vector<T,4>> gsampler1D)
 {
     typealias gvec4 = vector<T,4>;
 

--- a/tests/glsl-intrinsic/intrinsic-texture.slang
+++ b/tests/glsl-intrinsic/intrinsic-texture.slang
@@ -61,18 +61,18 @@ uniform usamplerBuffer uniform_usamplerBuffer;
 uniform usampler2DMS uniform_usampler2DMS;
 uniform usampler2DMSArray uniform_usampler2DMSArray;
 
-__generic<T : __BuiltinFloatingPointType, let N : int>
-bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
-    , Sampler2D<vector<T,N>> gsampler2D
-    , Sampler2DRect<vector<T,N>> gsampler2DRect
-    , Sampler3D<vector<T,N>> gsampler3D
-    , SamplerCube<vector<T,N>> gsamplerCube
-    , Sampler1DArray<vector<T,N>> gsampler1DArray
-    , Sampler2DArray<vector<T,N>> gsampler2DArray
-    , SamplerCubeArray<vector<T,N>> gsamplerCubeArray
-    , SamplerBuffer<vector<T,N>> gsamplerBuffer
-    , Sampler2DMS<vector<T,N>> gsampler2DMS
-    , Sampler2DMSArray<vector<T,N>> gsampler2DMSArray
+__generic<T : __BuiltinFloatingPointType>
+bool textureFuncs( Sampler1D<vector<T,4>> gsampler1D
+    , Sampler2D<vector<T,4>> gsampler2D
+    , Sampler2DRect<vector<T,4>> gsampler2DRect
+    , Sampler3D<vector<T,4>> gsampler3D
+    , SamplerCube<vector<T,4>> gsamplerCube
+    , Sampler1DArray<vector<T,4>> gsampler1DArray
+    , Sampler2DArray<vector<T,4>> gsampler2DArray
+    , SamplerCubeArray<vector<T,4>> gsamplerCubeArray
+    , SamplerBuffer<vector<T,4>> gsamplerBuffer
+    , Sampler2DMS<vector<T,4>> gsampler2DMS
+    , Sampler2DMSArray<vector<T,4>> gsampler2DMSArray
 )
 {
     // GLSL-LABEL: textureFuncs_0
@@ -1341,18 +1341,18 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         ;
 }
 
-__generic<T : __BuiltinArithmeticType, let N : int>
-bool itextureFuncs(Sampler1D<vector<T, N>> gsampler1D
-    , Sampler2D<vector<T, N>> gsampler2D
-    , Sampler2DRect<vector<T, N>> gsampler2DRect
-    , Sampler3D<vector<T, N>> gsampler3D
-    , SamplerCube<vector<T, N>> gsamplerCube
-    , Sampler1DArray<vector<T, N>> gsampler1DArray
-    , Sampler2DArray<vector<T, N>> gsampler2DArray
-    , SamplerCubeArray<vector<T, N>> gsamplerCubeArray
-    , SamplerBuffer<vector<T, N>> gsamplerBuffer
-    , Sampler2DMS<vector<T, N>> gsampler2DMS
-    , Sampler2DMSArray<vector<T, N>> gsampler2DMSArray
+__generic<T : __BuiltinArithmeticType>
+bool itextureFuncs(Sampler1D<vector<T, 4>> gsampler1D
+    , Sampler2D<vector<T, 4>> gsampler2D
+    , Sampler2DRect<vector<T, 4>> gsampler2DRect
+    , Sampler3D<vector<T, 4>> gsampler3D
+    , SamplerCube<vector<T, 4>> gsamplerCube
+    , Sampler1DArray<vector<T, 4>> gsampler1DArray
+    , Sampler2DArray<vector<T, 4>> gsampler2DArray
+    , SamplerCubeArray<vector<T, 4>> gsamplerCubeArray
+    , SamplerBuffer<vector<T, 4>> gsamplerBuffer
+    , Sampler2DMS<vector<T, 4>> gsampler2DMS
+    , Sampler2DMSArray<vector<T, 4>> gsampler2DMSArray
 )
 {
     // GLSL-LABEL: itextureFuncs_0

--- a/tests/language-feature/capability/intrinsic-texture-ignore-capability.slang
+++ b/tests/language-feature/capability/intrinsic-texture-ignore-capability.slang
@@ -50,16 +50,16 @@ uniform usampler2DArray uniform_usampler2DArray;
 uniform usamplerCubeArray uniform_usamplerCubeArray;
 uniform usamplerBuffer uniform_usamplerBuffer;
 
-__generic<T : __BuiltinFloatingPointType, let N : int>
-bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
-    , Sampler2D<vector<T,N>> gsampler2D
-    , Sampler2DRect<vector<T,N>> gsampler2DRect
-    , Sampler3D<vector<T,N>> gsampler3D
-    , SamplerCube<vector<T,N>> gsamplerCube
-    , Sampler1DArray<vector<T,N>> gsampler1DArray
-    , Sampler2DArray<vector<T,N>> gsampler2DArray
-    , SamplerCubeArray<vector<T,N>> gsamplerCubeArray
-    , SamplerBuffer<vector<T,N>> gsamplerBuffer
+__generic<T : __BuiltinFloatingPointType>
+bool textureFuncs( Sampler1D<vector<T,4>> gsampler1D
+    , Sampler2D<vector<T,4>> gsampler2D
+    , Sampler2DRect<vector<T,4>> gsampler2DRect
+    , Sampler3D<vector<T,4>> gsampler3D
+    , SamplerCube<vector<T,4>> gsamplerCube
+    , Sampler1DArray<vector<T,4>> gsampler1DArray
+    , Sampler2DArray<vector<T,4>> gsampler2DArray
+    , SamplerCubeArray<vector<T,4>> gsamplerCubeArray
+    , SamplerBuffer<vector<T,4>> gsamplerBuffer
 )
 {
     typealias gvec4 = vector<T,4>;
@@ -359,16 +359,16 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         ;
 }
 
-__generic<T : __BuiltinArithmeticType, let N : int>
-bool itextureFuncs(Sampler1D<vector<T, N>> gsampler1D
-    , Sampler2D<vector<T, N>> gsampler2D
-    , Sampler2DRect<vector<T, N>> gsampler2DRect
-    , Sampler3D<vector<T, N>> gsampler3D
-    , SamplerCube<vector<T, N>> gsamplerCube
-    , Sampler1DArray<vector<T, N>> gsampler1DArray
-    , Sampler2DArray<vector<T, N>> gsampler2DArray
-    , SamplerCubeArray<vector<T, N>> gsamplerCubeArray
-    , SamplerBuffer<vector<T, N>> gsamplerBuffer
+__generic<T : __BuiltinArithmeticType>
+bool itextureFuncs(Sampler1D<vector<T, 4>> gsampler1D
+    , Sampler2D<vector<T, 4>> gsampler2D
+    , Sampler2DRect<vector<T, 4>> gsampler2DRect
+    , Sampler3D<vector<T, 4>> gsampler3D
+    , SamplerCube<vector<T, 4>> gsamplerCube
+    , Sampler1DArray<vector<T, 4>> gsampler1DArray
+    , Sampler2DArray<vector<T, 4>> gsampler2DArray
+    , SamplerCubeArray<vector<T, 4>> gsamplerCubeArray
+    , SamplerBuffer<vector<T, 4>> gsamplerBuffer
 )
 {
     typealias gvec4 = vector<T, 4>;


### PR DESCRIPTION
GLSL supports only four types for textures: vec4, ivec4, uvec4, and float. The generic parameterization for the vector element count is not needed for the GLSL texture functions.

In other words, `N` is removed from `__generic` and it is replaced with `4`.