### PR TITLE
Capabilities System: Inclusive join logic bug

### DIFF
--- a/tools/slang-capability-generator/capability-generator-main.cpp
+++ b/tools/slang-capability-generator/capability-generator-main.cpp
@@ -517,7 +517,7 @@ struct CapabilityDisjunction
             return;
         for (auto& conjunction : conjunctions)
         {
-            if (c.implies(conjunction))
+            if (conjunction.implies(c))
                 return;
         }
         for (Index i = 0; i < conjunctions.getCount();)


### PR DESCRIPTION
fixes: #4293


Currently the code does:
```
    void inclusiveJoinConjunction(CapabilitySharedContext& context, CapabilityConjunction& c, List<CapabilityConjunction>& toAddAfter)
    {
        if (c.isImpossible())
            return;
        for (auto& conjunction : conjunctions)
        {
            if (c.implies(conjunction))
                return;
        }
```
This is incorrect because it means that "if the set we are going to add is a super set of an element, don't add it". This does not make sense since inclusive join is meant to be 'additive' of super sets.

Correct behavior code:
```
    void inclusiveJoinConjunction(CapabilitySharedContext& context, CapabilityConjunction& c, List<CapabilityConjunction>& toAddAfter)
    {
        if (c.isImpossible())
            return;
        for (auto& conjunction : conjunctions)
        {
            if (conjunction.implies(c))
                return;
        }
```
This is correct behavior because it means that: "if the set we are going to add is a sub set of an element, ignore it". This makes sense since inclusive join can then add super sets in-place of subsets

