### PR TITLE
Small SPIRV emit cleanup around vector element extract.

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -4776,7 +4776,10 @@ struct SPIRVEmitContext
 
         IRBuilder builder(m_irModule);
         builder.setInsertBefore(inst);
-        if (auto index = as<IRIntLit>(inst->getIndex()))
+        auto indexOperand = inst->getIndex();
+        if (auto globalValueRef = as<IRGlobalValueRef>(indexOperand))
+            indexOperand = globalValueRef->getValue();
+        if (auto index = as<IRIntLit>(indexOperand))
         {
             return emitOpCompositeExtract(
                 parent,


### PR DESCRIPTION
If we have `GetElement(vector, index)` where `index` is a `GlobalValueRef(IntLit)`, we still want to generate OpCompositeExtract instead of `OpVectorExtractDynamic`.