### PR TITLE
[gfx] Metal graphics support

### DIFF
--- a/slang-gfx.h
+++ b/slang-gfx.h
@@ -1225,7 +1225,7 @@ struct DepthStencilDesc
     DepthStencilOpDesc  frontFace;
     DepthStencilOpDesc  backFace;
 
-    uint32_t stencilRef = 0;
+    uint32_t stencilRef = 0; // TODO: this should be removed
 };
 
 struct RasterizerDesc

--- a/source/compiler-core/slang-metal-compiler.cpp
+++ b/source/compiler-core/slang-metal-compiler.cpp
@@ -63,7 +63,7 @@ namespace Slang
     {
         ComPtr<IDownstreamCompiler> innerCppCompiler;
 
-        ExecutableLocation metalcLocation = ExecutableLocation(path, "metal");;
+        ExecutableLocation metalcLocation = ExecutableLocation(path, "metal");
         
         String metalSDKPath = path;
 

--- a/tools/gfx/metal/metal-buffer.h
+++ b/tools/gfx/metal/metal-buffer.h
@@ -17,7 +17,7 @@ class BufferResourceImpl : public BufferResource
 public:
     typedef BufferResource Parent;
 
-    RefPtr<DeviceImpl> m_device;
+    BreakableReference<DeviceImpl> m_device;
     NS::SharedPtr<MTL::Buffer> m_buffer;
 
     BufferResourceImpl(const IBufferResource::Desc& desc, DeviceImpl* device);

--- a/tools/gfx/metal/metal-command-buffer.cpp
+++ b/tools/gfx/metal/metal-command-buffer.cpp
@@ -80,12 +80,12 @@ Result CommandBufferImpl::getNativeHandle(InteropHandle* outHandle)
     return SLANG_E_NOT_IMPLEMENTED;
 }
 
-MTL::RenderCommandEncoder* CommandBufferImpl::getMetalRenderCommandEncoder()
+MTL::RenderCommandEncoder* CommandBufferImpl::getMetalRenderCommandEncoder(MTL::RenderPassDescriptor* renderPassDesc)
 {
     if (!m_metalRenderCommandEncoder)
     {
         endMetalCommandEncoder();
-        // m_metalRenderCommandEncoder = NS::RetainPtr(m_commandBuffer->renderCommandEncoder());
+        m_metalRenderCommandEncoder = NS::RetainPtr(m_commandBuffer->renderCommandEncoder(renderPassDesc));
     }
     return m_metalRenderCommandEncoder.get();
 }

--- a/tools/gfx/metal/metal-command-buffer.h
+++ b/tools/gfx/metal/metal-command-buffer.h
@@ -45,7 +45,7 @@ public:
 
     void beginCommandBuffer();
 
-    MTL::RenderCommandEncoder* getMetalRenderCommandEncoder();
+    MTL::RenderCommandEncoder* getMetalRenderCommandEncoder(MTL::RenderPassDescriptor* renderPassDesc);
     MTL::ComputeCommandEncoder* getMetalComputeCommandEncoder();
     MTL::BlitCommandEncoder* getMetalBlitCommandEncoder();
     void endMetalCommandEncoder();

--- a/tools/gfx/metal/metal-device.cpp
+++ b/tools/gfx/metal/metal-device.cpp
@@ -154,9 +154,9 @@ Result DeviceImpl::createFramebufferLayout(const IFramebufferLayout::Desc& desc,
 {
     AUTORELEASEPOOL
 
-    RefPtr<FramebufferLayoutImpl> layout = new FramebufferLayoutImpl;
-    SLANG_RETURN_ON_FAIL(layout->init(this, desc));
-    returnComPtr(outLayout, layout);
+    RefPtr<FramebufferLayoutImpl> layoutImpl = new FramebufferLayoutImpl;
+    SLANG_RETURN_ON_FAIL(layoutImpl->init(desc));
+    returnComPtr(outLayout, layoutImpl);
     return SLANG_OK;
 }
 

--- a/tools/gfx/metal/metal-device.cpp
+++ b/tools/gfx/metal/metal-device.cpp
@@ -381,6 +381,8 @@ Result DeviceImpl::createTextureResource(
         return SLANG_FAIL;
     }
 
+    // TODO: handle initData
+
     returnComPtr(outResource, textureImpl);
     return SLANG_OK;
 }

--- a/tools/gfx/metal/metal-device.cpp
+++ b/tools/gfx/metal/metal-device.cpp
@@ -558,8 +558,8 @@ Result DeviceImpl::createBufferView(
     RefPtr<BufferResourceViewImpl> viewImpl = new BufferResourceViewImpl(this);
     viewImpl->m_desc = desc;
     viewImpl->m_buffer = bufferImpl;
-    viewImpl->m_offset = desc.bufferRange.offset;;
-    viewImpl->m_size = desc.bufferRange.size == 0 ? bufferImpl->getDesc()->sizeInBytes : desc.bufferRange.size;;
+    viewImpl->m_offset = desc.bufferRange.offset;
+    viewImpl->m_size = desc.bufferRange.size == 0 ? bufferImpl->getDesc()->sizeInBytes : desc.bufferRange.size;
     returnComPtr(outView, viewImpl);
     return SLANG_OK;
 }

--- a/tools/gfx/metal/metal-device.cpp
+++ b/tools/gfx/metal/metal-device.cpp
@@ -429,6 +429,7 @@ Result DeviceImpl::createBufferResource(
         encoder->copyFromBuffer(stagingBuffer.get(), 0, bufferImpl->m_buffer.get(), 0, bufferSize);
         encoder->endEncoding();
         commandBuffer->commit();
+        commandBuffer->waitUntilCompleted();
     }
 
     returnComPtr(outResource, bufferImpl);

--- a/tools/gfx/metal/metal-device.cpp
+++ b/tools/gfx/metal/metal-device.cpp
@@ -144,9 +144,9 @@ Result DeviceImpl::createSwapchain(
 {
     AUTORELEASEPOOL
 
-    RefPtr<SwapchainImpl> sc = new SwapchainImpl();
-    SLANG_RETURN_ON_FAIL(sc->init(this, desc, window));
-    returnComPtr(outSwapchain, sc);
+    RefPtr<SwapchainImpl> swapchainImpl = new SwapchainImpl();
+    SLANG_RETURN_ON_FAIL(swapchainImpl->init(this, desc, window));
+    returnComPtr(outSwapchain, swapchainImpl);
     return SLANG_OK;
 }
 
@@ -164,9 +164,9 @@ Result DeviceImpl::createRenderPassLayout(const IRenderPassLayout::Desc& desc, I
 {
     AUTORELEASEPOOL
 
-    RefPtr<RenderPassLayoutImpl> result = new RenderPassLayoutImpl;
-    SLANG_RETURN_ON_FAIL(result->init(this, desc));
-    returnComPtr(outRenderPassLayout, result);
+    RefPtr<RenderPassLayoutImpl> renderPassLayoutImpl = new RenderPassLayoutImpl;
+    SLANG_RETURN_ON_FAIL(renderPassLayoutImpl->init(this, desc));
+    returnComPtr(outRenderPassLayout, renderPassLayoutImpl);
     return SLANG_OK;
 }
 
@@ -174,9 +174,9 @@ Result DeviceImpl::createFramebuffer(const IFramebuffer::Desc& desc, IFramebuffe
 {
     AUTORELEASEPOOL
 
-    RefPtr<FramebufferImpl> fb = new FramebufferImpl;
-    SLANG_RETURN_ON_FAIL(fb->init(this, desc));
-    returnComPtr(outFramebuffer, fb);
+    RefPtr<FramebufferImpl> framebufferImpl = new FramebufferImpl;
+    SLANG_RETURN_ON_FAIL(framebufferImpl->init(this, desc));
+    returnComPtr(outFramebuffer, framebufferImpl);
     return SLANG_OK;
 }
 

--- a/tools/gfx/metal/metal-device.cpp
+++ b/tools/gfx/metal/metal-device.cpp
@@ -569,37 +569,9 @@ Result DeviceImpl::createInputLayout(IInputLayout::Desc const& desc, IInputLayou
 {
     AUTORELEASEPOOL
 
-    RefPtr<InputLayoutImpl> layout(new InputLayoutImpl);
-    layout->m_vertexDescriptor = NS::TransferPtr(MTL::VertexDescriptor::alloc()->init());
-    if (!layout->m_vertexDescriptor)
-    {
-        return SLANG_FAIL;
-    }
-
-    for (Int i = 0; i < desc.inputElementCount; ++i)
-    {
-        const auto& inputElement = desc.inputElements[i];
-        MTL::VertexAttributeDescriptor* desc = layout->m_vertexDescriptor->attributes()->object(i);
-        desc->setOffset(inputElement.offset);
-        desc->setBufferIndex(inputElement.bufferSlotIndex);
-        MTL::VertexFormat metalFormat = MetalUtil::translateVertexFormat(inputElement.format);
-        if (metalFormat == MTL::VertexFormatInvalid)
-        {
-            return SLANG_FAIL;
-        }
-        desc->setFormat(metalFormat);
-    }
-
-    for (Int i = 0; i < desc.vertexStreamCount; ++i)
-    {
-        const auto& vertexStream = desc.vertexStreams[i];
-        MTL::VertexBufferLayoutDescriptor* desc = layout->m_vertexDescriptor->layouts()->object(i);
-        desc->setStepFunction(MetalUtil::translateVertexStepFunction(vertexStream.slotClass));
-        desc->setStepRate(vertexStream.instanceDataStepRate);
-        desc->setStride(vertexStream.stride);
-    }
-
-    returnComPtr(outLayout, layout);
+    RefPtr<InputLayoutImpl> layoutImpl(new InputLayoutImpl);
+    SLANG_RETURN_ON_FAIL(layoutImpl->init(desc));
+    returnComPtr(outLayout, layoutImpl);
     return SLANG_OK;
 }
 

--- a/tools/gfx/metal/metal-framebuffer.cpp
+++ b/tools/gfx/metal/metal-framebuffer.cpp
@@ -12,17 +12,20 @@ using namespace Slang;
 namespace metal
 {
 
-FramebufferLayoutImpl::~FramebufferLayoutImpl()
+Result FramebufferLayoutImpl::init(const IFramebufferLayout::Desc& desc)
 {
-    //m_renderPass->release();
-}
-
-Result FramebufferLayoutImpl::init(DeviceImpl* device, const IFramebufferLayout::Desc& desc)
-{
-    // Metal doesn't have a notion of Framebuffers or FramebufferLayouts per se.
-    // We simply stash the desc and use it when creating the (convenience) Framebuffer
-    m_device = device;
-    m_desc = desc;
+    for (Index i = 0; i < desc.renderTargetCount; ++i)
+    {
+        m_renderTargets.add(desc.renderTargets[i]);
+    }
+    if (desc.depthStencil)
+    {
+        m_depthStencil = *desc.depthStencil;
+    }
+    else
+    {
+        m_depthStencil = {};
+    }
     return SLANG_OK;
 }
 

--- a/tools/gfx/metal/metal-framebuffer.h
+++ b/tools/gfx/metal/metal-framebuffer.h
@@ -31,21 +31,13 @@ class FramebufferImpl : public FramebufferBase
 {
 public:
     BreakableReference<DeviceImpl> m_device;
-    ShortList<ComPtr<IResourceView>> renderTargetViews;
-    ComPtr<IResourceView> depthStencilView;
+    RefPtr<FramebufferLayoutImpl> m_layout;
+    ShortList<RefPtr<TextureResourceViewImpl>> m_renderTargetViews;
+    RefPtr<TextureResourceViewImpl> m_depthStencilView;
     uint32_t m_width;
     uint32_t m_height;
-    MTL::ClearColor m_clearValues[kMaxTargets];
-    RefPtr<FramebufferLayoutImpl> m_layout;
-#if 0
-    Array<MTL::RenderPassColorAttachmentDescriptor*, kMaxTargets> m_colorTargetDescs;
-    MTL::RenderPassDepthAttachmentDescriptor* m_depthAttachmentDesc = nullptr;
-    MTL::RenderPassStencilAttachmentDescriptor* m_stencilAttachmentDesc = nullptr;
-#endif
 
 public:
-    ~FramebufferImpl();
-
     Result init(DeviceImpl* device, const IFramebuffer::Desc& desc);
 };
 

--- a/tools/gfx/metal/metal-framebuffer.h
+++ b/tools/gfx/metal/metal-framebuffer.h
@@ -20,20 +20,11 @@ enum
 class FramebufferLayoutImpl : public FramebufferLayoutBase
 {
 public:
-    RefPtr<DeviceImpl> m_device;
-    Desc m_desc;
-#if 0
-    MTL::RenderPassDescriptor* m_renderPass = nullptr;
-    Array<MTL::RenderPassColorAttachmentDescriptor*, kMaxTargets> m_targetDescs;
-    MTL::RenderPassDepthAttachmentDescriptor* m_depthAttachmentDesc = nullptr;
-    MTL::RenderPassStencilAttachmentDescriptor* m_stencilAttachmentDesc = nullptr;
-    bool m_hasDepthStencilTarget = false;
-    uint32_t m_renderTargetCount = 0;
-#endif
+    List<IFramebufferLayout::TargetLayout> m_renderTargets;
+    IFramebufferLayout::TargetLayout m_depthStencil;
 
 public:
-    ~FramebufferLayoutImpl();
-    Result init(DeviceImpl* device, const IFramebufferLayout::Desc& desc);
+    Result init(const IFramebufferLayout::Desc& desc);
 };
 
 class FramebufferImpl : public FramebufferBase

--- a/tools/gfx/metal/metal-framebuffer.h
+++ b/tools/gfx/metal/metal-framebuffer.h
@@ -36,6 +36,7 @@ public:
     RefPtr<TextureResourceViewImpl> m_depthStencilView;
     uint32_t m_width;
     uint32_t m_height;
+    uint32_t m_sampleCount;
 
 public:
     Result init(DeviceImpl* device, const IFramebuffer::Desc& desc);

--- a/tools/gfx/metal/metal-helper-functions.h
+++ b/tools/gfx/metal/metal-helper-functions.h
@@ -53,7 +53,6 @@ struct BindingOffset
 struct BindingContext
 {
     DeviceImpl* device = nullptr;
-    virtual void setData(const void* data, NS::UInteger length, NS::UInteger index) = 0;
     virtual void setBuffer(MTL::Buffer* buffer, NS::UInteger index) = 0;
     virtual void setTexture(MTL::Texture* texture, NS::UInteger index) = 0;
     virtual void setSampler(MTL::SamplerState* sampler, NS::UInteger index) = 0;
@@ -68,11 +67,6 @@ struct ComputeBindingContext : public BindingContext
         this->device = device;
         this->encoder = encoder;
         return SLANG_OK;
-    }
-
-    void setData(const void* data, NS::UInteger length, NS::UInteger index) override
-    {
-        encoder->setBytes(data, length, index);
     }
 
     void setBuffer(MTL::Buffer* buffer, NS::UInteger index) override

--- a/tools/gfx/metal/metal-helper-functions.h
+++ b/tools/gfx/metal/metal-helper-functions.h
@@ -85,6 +85,60 @@ struct ComputeBindingContext : public BindingContext
     }
 };
 
+struct VertexBindingContext : public BindingContext
+{
+    MTL::RenderCommandEncoder* encoder;
+
+    Result init(DeviceImpl* device, MTL::RenderCommandEncoder* encoder)
+    {
+        this->device = device;
+        this->encoder = encoder;
+        return SLANG_OK;
+    }
+
+    void setBuffer(MTL::Buffer* buffer, NS::UInteger index) override
+    {
+        encoder->setVertexBuffer(buffer, 0, index);
+    }
+
+    void setTexture(MTL::Texture* texture, NS::UInteger index) override
+    {
+        encoder->setVertexTexture(texture, index);
+    }
+
+    void setSampler(MTL::SamplerState* sampler, NS::UInteger index) override
+    {
+        encoder->setVertexSamplerState(sampler, index);
+    }
+};
+
+struct FragmentBindingContext : public BindingContext
+{
+    MTL::RenderCommandEncoder* encoder;
+
+    Result init(DeviceImpl* device, MTL::RenderCommandEncoder* encoder)
+    {
+        this->device = device;
+        this->encoder = encoder;
+        return SLANG_OK;
+    }
+
+    void setBuffer(MTL::Buffer* buffer, NS::UInteger index) override
+    {
+        encoder->setFragmentBuffer(buffer, 0, index);
+    }
+
+    void setTexture(MTL::Texture* texture, NS::UInteger index) override
+    {
+        encoder->setFragmentTexture(texture, index);
+    }
+
+    void setSampler(MTL::SamplerState* sampler, NS::UInteger index) override
+    {
+        encoder->setFragmentSamplerState(sampler, index);
+    }
+};
+
 } // namespace metal
 
 Result SLANG_MCALL getMetalAdapters(List<AdapterInfo>& outAdapters);

--- a/tools/gfx/metal/metal-pipeline-state.cpp
+++ b/tools/gfx/metal/metal-pipeline-state.cpp
@@ -50,40 +50,84 @@ void PipelineStateImpl::init(const RayTracingPipelineStateDesc& desc)
 
 Result PipelineStateImpl::createMetalRenderPipelineState()
 {
-    NS::SharedPtr<MTL::RenderPipelineDescriptor> pd = NS::TransferPtr(MTL::RenderPipelineDescriptor::alloc()->init());
     auto programImpl = static_cast<ShaderProgramImpl*>(m_program.Ptr());
-    if (programImpl)
+    if (!programImpl)
+        return SLANG_FAIL;
+
+    NS::SharedPtr<MTL::RenderPipelineDescriptor> pd = NS::TransferPtr(MTL::RenderPipelineDescriptor::alloc()->init());
+
+    for (const ShaderProgramImpl::Module& module : programImpl->m_modules)
     {
-        SLANG_RETURN_ON_FAIL(programImpl->compileShaders(m_device));
+        auto functionName = MetalUtil::createString(module.entryPointName.getBuffer());
+        NS::SharedPtr<MTL::Function> function = NS::TransferPtr(module.library->newFunction(functionName.get()));
+        if (!function)
+            return SLANG_FAIL;
+
+        switch (module.stage)
+        {
+        case SLANG_STAGE_VERTEX:
+            pd->setVertexFunction(function.get());
+            break;
+        case SLANG_STAGE_FRAGMENT:
+            pd->setFragmentFunction(function.get());
+            break;
+        default:
+            return SLANG_FAIL;
+        }
     }
 
-    const auto& programReflection = m_program->linkedProgram->getLayout();
-    const auto& composedProgram = m_program->linkedProgram;
-    for (SlangUInt i = 0; i < programReflection->getEntryPointCount(); ++i)
+    // Offset vertex buffer indices in vertex layout.
+    // They need to be in a range not used by other buffer bindings.
+    m_vertexBufferOffset = 10; // TODO get from layout
+    auto inputLayoutImpl = static_cast<InputLayoutImpl*>(desc.graphics.inputLayout);
+    NS::SharedPtr<MTL::VertexDescriptor> vertexDescriptor = inputLayoutImpl->createVertexDescriptor(m_vertexBufferOffset);
+    pd->setVertexDescriptor(vertexDescriptor.get());
+    pd->setInputPrimitiveTopology(MetalUtil::translatePrimitiveTopologyClass(desc.graphics.primitiveType));
+
+    // Set rasterization state
+    auto framebufferLayoutImpl = static_cast<FramebufferLayoutImpl*>(desc.graphics.framebufferLayout);
+    const auto& blendDesc = desc.graphics.blend;
+    GfxCount sampleCount = 1;
+
+    pd->setAlphaToCoverageEnabled(blendDesc.alphaToCoverageEnable);
+    // pd->setAlphaToOneEnabled(); // Currently not supported by gfx
+    // pd->setRasterizationEnabled(true); // Enabled by default
+
+    for (Index i = 0; i < framebufferLayoutImpl->m_renderTargets.getCount(); ++i)
     {
-        SlangStage stage = programReflection->getEntryPointByIndex(i)->getStage();
-        if (stage == SLANG_STAGE_VERTEX)
+        const IFramebufferLayout::TargetLayout& targetLayout = framebufferLayoutImpl->m_renderTargets[i];
+        MTL::RenderPipelineColorAttachmentDescriptor* colorAttachment = pd->colorAttachments()->object(i);
+        colorAttachment->setPixelFormat(MetalUtil::translatePixelFormat(targetLayout.format));
+        if (i < blendDesc.targetCount)
         {
-            ComPtr<slang::IBlob> metalCode;
-            {
-                ComPtr<slang::IBlob> diagnosticsBlob;
-                SlangResult result = composedProgram->getEntryPointCode(i, 0, metalCode.writeRef(), diagnosticsBlob.writeRef());
-                if (diagnosticsBlob)
-                {
-                    std::cout << diagnosticsBlob->getBufferPointer() << std::endl;
-                }
-                //MTL::Function* f = ...
-                //RETURN_ON_FAIL(result);
-                //pd->setVertexFunction();
-            }
+            const TargetBlendDesc& targetBlendDesc = blendDesc.targets[i];
+            colorAttachment->setBlendingEnabled(targetBlendDesc.enableBlend);
+            colorAttachment->setSourceRGBBlendFactor(MetalUtil::translateBlendFactor(targetBlendDesc.color.srcFactor));
+            colorAttachment->setDestinationRGBBlendFactor(MetalUtil::translateBlendFactor(targetBlendDesc.color.dstFactor));
+            colorAttachment->setRgbBlendOperation(MetalUtil::translateBlendOperation(targetBlendDesc.color.op));
+            colorAttachment->setSourceAlphaBlendFactor(MetalUtil::translateBlendFactor(targetBlendDesc.alpha.srcFactor));
+            colorAttachment->setDestinationAlphaBlendFactor(MetalUtil::translateBlendFactor(targetBlendDesc.alpha.dstFactor));
+            colorAttachment->setAlphaBlendOperation(MetalUtil::translateBlendOperation(targetBlendDesc.alpha.op));
+            colorAttachment->setWriteMask(MetalUtil::translateColorWriteMask(targetBlendDesc.writeMask));
         }
-        //pd->setFragmentFunction();
+        sampleCount = Math::Max(sampleCount, targetLayout.sampleCount);
     }
-    // pd->colorAttachments()->object(0)->setPixelFormat(...);
-    // pd->setDepthAttachmentPixelFormat(...);
-    // Set deftault viewport and scissor
-    // Set default rasterization state
-    // Set default framebuffer layout
+    if (framebufferLayoutImpl->m_depthStencil.format != Format::Unknown)
+    {
+        const IFramebufferLayout::TargetLayout& depthStencil = framebufferLayoutImpl->m_depthStencil;
+        MTL::PixelFormat pixelFormat = MetalUtil::translatePixelFormat(depthStencil.format);
+        if (MetalUtil::isDepthFormat(pixelFormat))
+        {
+            pd->setDepthAttachmentPixelFormat(MetalUtil::translatePixelFormat(depthStencil.format));
+        }
+        if (MetalUtil::isStencilFormat(pixelFormat))
+        {
+            pd->setStencilAttachmentPixelFormat(MetalUtil::translatePixelFormat(depthStencil.format));
+        }
+    }
+
+    pd->setRasterSampleCount(sampleCount);
+    
     NS::Error* error;
     m_renderPipelineState = NS::TransferPtr(m_device->m_device->newRenderPipelineState(pd.get(), &error));
     if (!m_renderPipelineState)
@@ -100,10 +144,9 @@ Result PipelineStateImpl::createMetalComputePipelineState()
     if (!programImpl)
         return SLANG_FAIL;
 
-    NS::SharedPtr<MTL::ComputePipelineDescriptor> pd = NS::TransferPtr(MTL::ComputePipelineDescriptor::alloc()->init());
-
-    auto functionName = MetalUtil::createString(programImpl->m_entryPointNames[0].getBuffer());
-    NS::SharedPtr<MTL::Function> function = NS::TransferPtr(programImpl->m_modules[0]->newFunction(functionName.get()));
+    const ShaderProgramImpl::Module& module = programImpl->m_modules[0];
+    auto functionName = MetalUtil::createString(module.entryPointName.getBuffer());
+    NS::SharedPtr<MTL::Function> function = NS::TransferPtr(module.library->newFunction(functionName.get()));
     if (!function)
         return SLANG_FAIL;
 
@@ -120,6 +163,8 @@ Result PipelineStateImpl::createMetalComputePipelineState()
 
 Result PipelineStateImpl::ensureAPIPipelineStateCreated()
 {
+    AUTORELEASEPOOL
+    
     switch (desc.type)
     {
     case PipelineType::Compute:

--- a/tools/gfx/metal/metal-pipeline-state.h
+++ b/tools/gfx/metal/metal-pipeline-state.h
@@ -16,6 +16,7 @@ class PipelineStateImpl : public PipelineStateBase
 public:
     RefPtr<DeviceImpl> m_device;
     NS::SharedPtr<MTL::RenderPipelineState> m_renderPipelineState;
+    NS::SharedPtr<MTL::DepthStencilState> m_depthStencilState;
     NS::SharedPtr<MTL::ComputePipelineState> m_computePipelineState;
     MTL::Size m_threadGroupSize;
     NS::UInteger m_vertexBufferOffset;

--- a/tools/gfx/metal/metal-pipeline-state.h
+++ b/tools/gfx/metal/metal-pipeline-state.h
@@ -18,6 +18,7 @@ public:
     NS::SharedPtr<MTL::RenderPipelineState> m_renderPipelineState;
     NS::SharedPtr<MTL::ComputePipelineState> m_computePipelineState;
     MTL::Size m_threadGroupSize;
+    NS::UInteger m_vertexBufferOffset;
 
     PipelineStateImpl(DeviceImpl* device);
     ~PipelineStateImpl();

--- a/tools/gfx/metal/metal-render-pass.cpp
+++ b/tools/gfx/metal/metal-render-pass.cpp
@@ -26,13 +26,14 @@ static inline MTL::LoadAction translateLoadOp(IRenderPassLayout::TargetLoadOp lo
 {
     switch (loadOp)
     {
-    case IRenderPassLayout::TargetLoadOp::Clear:
-        return MTL::LoadAction::LoadActionClear;
     case IRenderPassLayout::TargetLoadOp::Load:
-        return MTL::LoadAction::LoadActionLoad;
+        return MTL::LoadActionLoad;
+    case IRenderPassLayout::TargetLoadOp::Clear:
+        return MTL::LoadActionClear;
     case IRenderPassLayout::TargetLoadOp::DontCare:
+        return MTL::LoadActionDontCare;
     default:
-        return MTL::LoadAction::LoadActionDontCare;
+        return MTL::LoadAction(0);
     }
 }
 
@@ -41,10 +42,11 @@ static inline MTL::StoreAction translateStoreOp(IRenderPassLayout::TargetStoreOp
     switch (storeOp)
     {
     case IRenderPassLayout::TargetStoreOp::Store:
-        return MTL::StoreAction::StoreActionStore;
+        return MTL::StoreActionStore;
     case IRenderPassLayout::TargetStoreOp::DontCare:
+        return MTL::StoreActionDontCare;
     default:
-        return MTL::StoreAction::StoreActionDontCare;
+        return MTL::StoreAction(0);
     }
 }
 
@@ -57,27 +59,21 @@ Result RenderPassLayoutImpl::init(DeviceImpl* device, const IRenderPassLayout::D
 
     // Initialize render pass descriptor, filling in attachment metadata, but leaving texture data unbound.
     m_renderPassDesc = NS::TransferPtr(MTL::RenderPassDescriptor::alloc()->init());
-    m_renderPassDesc->setRenderTargetArrayLength(desc.renderTargetCount);
 
-    MTL::RenderPassColorAttachmentDescriptorArray* colorAttachments = m_renderPassDesc->colorAttachments();
+    m_renderPassDesc->setRenderTargetArrayLength(desc.renderTargetCount);
     for (GfxIndex i = 0; i < desc.renderTargetCount; ++i)
     {
-        MTL::RenderPassColorAttachmentDescriptor* colorAttach = MTL::RenderPassColorAttachmentDescriptor::alloc()->init();
-        colorAttach->setLoadAction(translateLoadOp(desc.renderTargetAccess[i].loadOp));
-        colorAttach->setStoreAction(translateStoreOp(desc.renderTargetAccess[i].storeOp));
-        // We set the texture when the render pass is executed, using the associated framebuffer.
-        colorAttach->setTexture(nullptr);
-        colorAttachments->setObject(colorAttach, i);
+        MTL::RenderPassColorAttachmentDescriptor* colorAttachment = m_renderPassDesc->colorAttachments()->object(i);
+        colorAttachment->setLoadAction(translateLoadOp(desc.renderTargetAccess[i].loadOp));
+        colorAttachment->setStoreAction(translateStoreOp(desc.renderTargetAccess[i].storeOp));
     }
+
     m_renderPassDesc->depthAttachment()->setLoadAction(translateLoadOp(desc.depthStencilAccess->loadOp));
     m_renderPassDesc->depthAttachment()->setStoreAction(translateStoreOp(desc.depthStencilAccess->storeOp));
-    // We set the depth texture when the render pass is executed, using the associated framebuffer.
-    m_renderPassDesc->depthAttachment()->setTexture(nullptr);
-    //m_renderPassDesc->depthAttachment()->setClearDepth(1000000.);
+
     m_renderPassDesc->stencilAttachment()->setLoadAction(translateLoadOp(desc.depthStencilAccess->loadOp));
     m_renderPassDesc->stencilAttachment()->setStoreAction(translateStoreOp(desc.depthStencilAccess->storeOp));
-    // We set the stencil texture when the render pass is executed, using the associated framebuffer.
-    m_renderPassDesc->stencilAttachment()->setTexture(nullptr);
+
     return SLANG_OK;
 }
 

--- a/tools/gfx/metal/metal-render-pass.cpp
+++ b/tools/gfx/metal/metal-render-pass.cpp
@@ -18,10 +18,6 @@ IRenderPassLayout* RenderPassLayoutImpl::getInterface(const Guid& guid)
     return nullptr;
 }
 
-RenderPassLayoutImpl::~RenderPassLayoutImpl()
-{
-}
-
 static inline MTL::LoadAction translateLoadOp(IRenderPassLayout::TargetLoadOp loadOp)
 {
     switch (loadOp)

--- a/tools/gfx/metal/metal-render-pass.h
+++ b/tools/gfx/metal/metal-render-pass.h
@@ -24,8 +24,6 @@ public:
     RefPtr<DeviceImpl> m_device;
     NS::SharedPtr<MTL::RenderPassDescriptor> m_renderPassDesc;
 
-    ~RenderPassLayoutImpl();
-
     Result init(DeviceImpl* device, const IRenderPassLayout::Desc& desc);
 };
 

--- a/tools/gfx/metal/metal-shader-program.cpp
+++ b/tools/gfx/metal/metal-shader-program.cpp
@@ -22,19 +22,22 @@ ShaderProgramImpl::~ShaderProgramImpl()
 
 Result ShaderProgramImpl::createShaderModule(slang::EntryPointReflection* entryPointInfo, ComPtr<ISlangBlob> kernelCode)
 {
-    m_codeBlobs.add(kernelCode);
-    const char* realEntryPointName = entryPointInfo->getNameOverride();
+    Module module;
+    module.stage = entryPointInfo->getStage();
+    module.entryPointName = entryPointInfo->getNameOverride();
+    module.code = kernelCode;
+    
     dispatch_data_t data = dispatch_data_create(kernelCode->getBufferPointer(), kernelCode->getBufferSize(), dispatch_get_main_queue(), NULL);
     NS::Error* error;
-    NS::SharedPtr<MTL::Library> library = NS::TransferPtr(m_device->m_device->newLibrary(data, &error));
-    if (!library)
+    module.library = NS::TransferPtr(m_device->m_device->newLibrary(data, &error));
+    if (!module.library)
     {
         // TODO use better mechanism for reporting errors
         std::cout << error->localizedDescription()->utf8String() << std::endl;
         return SLANG_E_INVALID_ARG;
     }
-    m_entryPointNames.add(realEntryPointName);
-    m_modules.add(library);
+
+    m_modules.add(module);
     return SLANG_OK;
 }
 

--- a/tools/gfx/metal/metal-shader-program.h
+++ b/tools/gfx/metal/metal-shader-program.h
@@ -16,11 +16,17 @@ class ShaderProgramImpl : public ShaderProgramBase
 {
 public:
     BreakableReference<DeviceImpl> m_device;
-
-    List<String> m_entryPointNames;
-    List<ComPtr<ISlangBlob>> m_codeBlobs; //< To keep storage of code in scope
-    List<NS::SharedPtr<MTL::Library>> m_modules;
     RefPtr<RootShaderObjectLayoutImpl> m_rootObjectLayout;
+
+    struct Module
+    {
+        SlangStage stage;
+        String entryPointName;
+        ComPtr<ISlangBlob> code;
+        NS::SharedPtr<MTL::Library> library;
+    };
+
+    List<Module> m_modules;
 
     ShaderProgramImpl(DeviceImpl* device);
     ~ShaderProgramImpl();

--- a/tools/gfx/metal/metal-swap-chain.h
+++ b/tools/gfx/metal/metal-swap-chain.h
@@ -28,11 +28,12 @@ public:
     WindowHandle m_windowHandle;
     CA::MetalLayer* m_metalLayer = nullptr;
     ShortList<RefPtr<TextureResourceImpl>> m_images;
-    NS::SharedPtr<MTL::Drawable> m_currentDrawable;
+    NS::SharedPtr<CA::MetalDrawable> m_currentDrawable;
     Index m_currentImageIndex = -1;
     MTL::PixelFormat m_metalFormat = MTL::PixelFormat::PixelFormatInvalid;
 
     void getWindowSize(int& widthOut, int& heightOut) const;
+    void createImages();
 
 public:
     ~SwapchainImpl();

--- a/tools/gfx/metal/metal-texture.h
+++ b/tools/gfx/metal/metal-texture.h
@@ -20,7 +20,7 @@ public:
     TextureResourceImpl(const Desc& desc, DeviceImpl* device);
     ~TextureResourceImpl();
 
-    RefPtr<DeviceImpl> m_device;
+    BreakableReference<DeviceImpl> m_device;
     NS::SharedPtr<MTL::Texture> m_texture;
     // TODO still needed?
     // MTL::PixelFormat m_metalFormat = MTL::PixelFormat::PixelFormatInvalid;

--- a/tools/gfx/metal/metal-util.cpp
+++ b/tools/gfx/metal/metal-util.cpp
@@ -176,6 +176,35 @@ MTL::VertexFormat MetalUtil::translateVertexFormat(Format format)
     }
 }
 
+bool MetalUtil::isDepthFormat(MTL::PixelFormat format)
+{
+    switch (format)
+    {
+    case MTL::PixelFormatDepth16Unorm:
+    case MTL::PixelFormatDepth32Float:
+    case MTL::PixelFormatDepth24Unorm_Stencil8:
+    case MTL::PixelFormatDepth32Float_Stencil8:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool MetalUtil::isStencilFormat(MTL::PixelFormat format)
+{
+    switch (format)
+    {
+    case MTL::PixelFormatStencil8:
+    case MTL::PixelFormatDepth24Unorm_Stencil8:
+    case MTL::PixelFormatDepth32Float_Stencil8:
+    case MTL::PixelFormatX32_Stencil8:
+    case MTL::PixelFormatX24_Stencil8:
+        return true;
+    default:
+        return false;
+    }
+}
+
 MTL::SamplerMinMagFilter MetalUtil::translateSamplerMinMagFilter(TextureFilteringMode mode)
 {
     switch (mode)
@@ -275,6 +304,22 @@ MTL::PrimitiveType MetalUtil::translatePrimitiveType(PrimitiveTopology topology)
         return MTL::PrimitiveTypeLineStrip;
     default:
         return MTL::PrimitiveType(0);
+    }
+}
+
+MTL::PrimitiveTopologyClass MetalUtil::translatePrimitiveTopologyClass(PrimitiveType type)
+{
+    switch (type)
+    {
+    case PrimitiveType::Point:
+        return MTL::PrimitiveTopologyClassPoint;
+    case PrimitiveType::Line: 
+        return MTL::PrimitiveTopologyClassLine;
+    case PrimitiveType::Triangle:
+        return MTL::PrimitiveTopologyClassTriangle;
+    case PrimitiveType::Patch:
+    default:
+        return MTL::PrimitiveTopologyClassUnspecified;
     }
 }
 

--- a/tools/gfx/metal/metal-util.cpp
+++ b/tools/gfx/metal/metal-util.cpp
@@ -259,4 +259,23 @@ MTL::VertexStepFunction MetalUtil::translateVertexStepFunction(InputSlotClass sl
     }
 }
 
+MTL::PrimitiveType MetalUtil::translatePrimitiveType(PrimitiveTopology topology)
+{
+    switch (topology)
+    {
+    case PrimitiveTopology::TriangleList:
+        return MTL::PrimitiveTypeTriangle;
+    case PrimitiveTopology::TriangleStrip:
+        return MTL::PrimitiveTypeTriangleStrip;
+    case PrimitiveTopology::PointList:
+        return MTL::PrimitiveTypePoint;
+    case PrimitiveTopology::LineList:
+        return MTL::PrimitiveTypeLine;
+    case PrimitiveTopology::LineStrip:
+        return MTL::PrimitiveTypeLineStrip;
+    default:
+        return MTL::PrimitiveType(0);
+    }
+}
+
 } // namespace gfx

--- a/tools/gfx/metal/metal-util.cpp
+++ b/tools/gfx/metal/metal-util.cpp
@@ -278,4 +278,80 @@ MTL::PrimitiveType MetalUtil::translatePrimitiveType(PrimitiveTopology topology)
     }
 }
 
+MTL::BlendFactor MetalUtil::translateBlendFactor(BlendFactor factor)
+{
+    switch (factor)
+    {
+    case BlendFactor::Zero:
+        return MTL::BlendFactorZero;
+    case BlendFactor::One:
+        return MTL::BlendFactorOne;
+    case BlendFactor::SrcColor:
+        return MTL::BlendFactorSourceColor;
+    case BlendFactor::InvSrcColor:
+        return MTL::BlendFactorOneMinusSourceColor;
+    case BlendFactor::SrcAlpha:
+        return MTL::BlendFactorSourceAlpha;
+    case BlendFactor::InvSrcAlpha:
+        return MTL::BlendFactorOneMinusSourceAlpha;
+    case BlendFactor::DestAlpha:
+        return MTL::BlendFactorDestinationAlpha;
+    case BlendFactor::InvDestAlpha:
+        return MTL::BlendFactorOneMinusDestinationAlpha;
+    case BlendFactor::DestColor:
+        return MTL::BlendFactorDestinationColor;
+    case BlendFactor::InvDestColor:
+        return MTL::BlendFactorOneMinusDestinationColor;
+    case BlendFactor::SrcAlphaSaturate:
+        return MTL::BlendFactorSourceAlphaSaturated;
+    case BlendFactor::BlendColor:
+        return MTL::BlendFactorBlendColor;
+    case BlendFactor::InvBlendColor:
+        return MTL::BlendFactorOneMinusBlendColor;
+    case BlendFactor::SecondarySrcColor:
+        return MTL::BlendFactorSource1Color;
+    case BlendFactor::InvSecondarySrcColor:
+        return MTL::BlendFactorOneMinusSource1Color;
+    case BlendFactor::SecondarySrcAlpha:
+        return MTL::BlendFactorSource1Alpha;
+    case BlendFactor::InvSecondarySrcAlpha:
+        return MTL::BlendFactorOneMinusSource1Alpha;
+    default:
+        return MTL::BlendFactor(0);
+    }
+}
+
+MTL::BlendOperation MetalUtil::translateBlendOperation(BlendOp op)
+{
+    switch (op)
+    {
+    case BlendOp::Add:
+        return MTL::BlendOperationAdd;
+    case BlendOp::Subtract:
+        return MTL::BlendOperationSubtract;
+    case BlendOp::ReverseSubtract:
+        return MTL::BlendOperationReverseSubtract;
+    case BlendOp::Min:
+        return MTL::BlendOperationMin;
+    case BlendOp::Max:
+        return MTL::BlendOperationMax;
+    default:
+        return MTL::BlendOperation(0);
+    }
+}
+
+MTL::ColorWriteMask MetalUtil::translateColorWriteMask(RenderTargetWriteMask::Type mask)
+{
+    MTL::ColorWriteMask result = MTL::ColorWriteMaskNone;
+    if (mask & RenderTargetWriteMask::EnableRed)
+        result |= MTL::ColorWriteMaskRed;
+    if (mask & RenderTargetWriteMask::EnableGreen)
+        result |= MTL::ColorWriteMaskGreen;
+    if (mask & RenderTargetWriteMask::EnableBlue)
+        result |= MTL::ColorWriteMaskBlue;
+    if (mask & RenderTargetWriteMask::EnableAlpha)
+        result |= MTL::ColorWriteMaskAlpha;
+    return result;
+}
+
 } // namespace gfx

--- a/tools/gfx/metal/metal-util.cpp
+++ b/tools/gfx/metal/metal-util.cpp
@@ -275,6 +275,31 @@ MTL::CompareFunction MetalUtil::translateCompareFunction(ComparisonFunc func)
     }
 }
 
+MTL::StencilOperation MetalUtil::translateStencilOperation(StencilOp op)
+{
+    switch (op)
+    {
+    case StencilOp::Keep:
+        return MTL::StencilOperationKeep;
+    case StencilOp::Zero:
+        return MTL::StencilOperationZero;
+    case StencilOp::Replace:
+        return MTL::StencilOperationReplace;
+    case StencilOp::IncrementSaturate:
+        return MTL::StencilOperationIncrementClamp;
+    case StencilOp::DecrementSaturate:
+        return MTL::StencilOperationDecrementClamp;
+    case StencilOp::Invert:
+        return MTL::StencilOperationInvert;
+    case StencilOp::IncrementWrap:
+        return MTL::StencilOperationIncrementWrap;
+    case StencilOp::DecrementWrap:
+        return MTL::StencilOperationDecrementWrap;
+    default:
+        return MTL::StencilOperation(0);
+    }
+}
+
 MTL::VertexStepFunction MetalUtil::translateVertexStepFunction(InputSlotClass slotClass)
 {
     switch (slotClass)
@@ -397,6 +422,47 @@ MTL::ColorWriteMask MetalUtil::translateColorWriteMask(RenderTargetWriteMask::Ty
     if (mask & RenderTargetWriteMask::EnableAlpha)
         result |= MTL::ColorWriteMaskAlpha;
     return result;
+}
+
+MTL::Winding MetalUtil::translateWinding(FrontFaceMode mode)
+{
+    switch (mode)
+    {
+    case FrontFaceMode::CounterClockwise:
+        return MTL::WindingCounterClockwise;
+    case FrontFaceMode::Clockwise:
+        return MTL::WindingClockwise;
+    default:
+        return MTL::Winding(0);
+    }
+}
+
+MTL::CullMode MetalUtil::translateCullMode(CullMode mode)
+{
+    switch (mode)
+    {
+    case CullMode::None:
+        return MTL::CullModeNone;
+    case CullMode::Front:
+        return MTL::CullModeFront;
+    case CullMode::Back:
+        return MTL::CullModeBack;
+    default:
+        return MTL::CullMode(0);
+    }
+}
+
+MTL::TriangleFillMode MetalUtil::translateTriangleFillMode(FillMode mode)
+{
+    switch (mode)
+    {
+    case FillMode::Solid:
+        return MTL::TriangleFillModeFill;
+    case FillMode::Wireframe:
+        return MTL::TriangleFillModeLines;
+    default:
+        return MTL::TriangleFillMode(0);
+    }
 }
 
 } // namespace gfx

--- a/tools/gfx/metal/metal-util.h
+++ b/tools/gfx/metal/metal-util.h
@@ -50,6 +50,8 @@ struct MetalUtil
 
     static MTL::VertexStepFunction translateVertexStepFunction(InputSlotClass slotClass);
 
+    static MTL::PrimitiveType translatePrimitiveType(PrimitiveTopology topology);
+
 };
 
 struct ScopedAutoreleasePool

--- a/tools/gfx/metal/metal-util.h
+++ b/tools/gfx/metal/metal-util.h
@@ -52,6 +52,10 @@ struct MetalUtil
 
     static MTL::PrimitiveType translatePrimitiveType(PrimitiveTopology topology);
 
+    static MTL::BlendFactor translateBlendFactor(BlendFactor factor);
+    static MTL::BlendOperation translateBlendOperation(BlendOp op);
+    static MTL::ColorWriteMask translateColorWriteMask(RenderTargetWriteMask::Type mask);
+
 };
 
 struct ScopedAutoreleasePool

--- a/tools/gfx/metal/metal-util.h
+++ b/tools/gfx/metal/metal-util.h
@@ -32,6 +32,7 @@ struct MetalUtil
     static MTL::SamplerMipFilter translateSamplerMipFilter(TextureFilteringMode mode);
     static MTL::SamplerAddressMode translateSamplerAddressMode(TextureAddressingMode mode);
     static MTL::CompareFunction translateCompareFunction(ComparisonFunc func); 
+    static MTL::StencilOperation translateStencilOperation(StencilOp op);
 
     static MTL::VertexStepFunction translateVertexStepFunction(InputSlotClass slotClass);
 
@@ -41,6 +42,10 @@ struct MetalUtil
     static MTL::BlendFactor translateBlendFactor(BlendFactor factor);
     static MTL::BlendOperation translateBlendOperation(BlendOp op);
     static MTL::ColorWriteMask translateColorWriteMask(RenderTargetWriteMask::Type mask);
+
+    static MTL::Winding translateWinding(FrontFaceMode mode);
+    static MTL::CullMode translateCullMode(CullMode mode);
+    static MTL::TriangleFillMode translateTriangleFillMode(FillMode mode);
 
 };
 

--- a/tools/gfx/metal/metal-util.h
+++ b/tools/gfx/metal/metal-util.h
@@ -25,23 +25,8 @@ struct MetalUtil
     static MTL::PixelFormat translatePixelFormat(Format format);
     static MTL::VertexFormat translateVertexFormat(Format format);
 
-    static inline bool isDepthFormat(MTL::PixelFormat format)
-    {
-        switch (format)
-        {
-            return true;
-        }
-        return false;
-    }
-
-    static inline bool isStencilFormat(MTL::PixelFormat format)
-    {
-        switch (format)
-        {
-            return true;
-        }
-        return false;
-    }
+    static bool isDepthFormat(MTL::PixelFormat format);
+    static bool isStencilFormat(MTL::PixelFormat format);
 
     static MTL::SamplerMinMagFilter translateSamplerMinMagFilter(TextureFilteringMode mode);
     static MTL::SamplerMipFilter translateSamplerMipFilter(TextureFilteringMode mode);
@@ -51,6 +36,7 @@ struct MetalUtil
     static MTL::VertexStepFunction translateVertexStepFunction(InputSlotClass slotClass);
 
     static MTL::PrimitiveType translatePrimitiveType(PrimitiveTopology topology);
+    static MTL::PrimitiveTopologyClass translatePrimitiveTopologyClass(PrimitiveType type);
 
     static MTL::BlendFactor translateBlendFactor(BlendFactor factor);
     static MTL::BlendOperation translateBlendOperation(BlendOp op);

--- a/tools/gfx/metal/metal-vertex-layout.cpp
+++ b/tools/gfx/metal/metal-vertex-layout.cpp
@@ -1,0 +1,57 @@
+// metal-vertex-layout.cpp
+#include "metal-vertex-layout.h"
+#include "metal-util.h"
+
+namespace gfx
+{
+
+using namespace Slang;
+
+namespace metal
+{
+
+Result InputLayoutImpl::init(const IInputLayout::Desc& desc)
+{
+    for (Index i = 0; i < desc.inputElementCount; i++)
+    {
+        if (MetalUtil::translateVertexFormat(desc.inputElements[i].format) == MTL::VertexFormatInvalid)
+        {
+            return SLANG_E_INVALID_ARG;
+        }
+        m_inputElements.add(desc.inputElements[i]);
+    }
+    for (Index i = 0; i < desc.vertexStreamCount; i++)
+    {
+        m_vertexStreams.add(desc.vertexStreams[i]);
+    }
+    return SLANG_OK;
+}
+
+NS::SharedPtr<MTL::VertexDescriptor> InputLayoutImpl::createVertexDescriptor(NS::UInteger vertexBufferIndexOffset)
+{
+    NS::SharedPtr<MTL::VertexDescriptor> vertexDescriptor = NS::TransferPtr(MTL::VertexDescriptor::alloc()->init());
+
+    for (Index i = 0; i < m_inputElements.getCount(); i++)
+    {
+        const auto& inputElement = m_inputElements[i];
+        MTL::VertexAttributeDescriptor* desc = vertexDescriptor->attributes()->object(i);
+        desc->setOffset(inputElement.offset);
+        desc->setBufferIndex(inputElement.bufferSlotIndex + vertexBufferIndexOffset);
+        MTL::VertexFormat metalFormat = MetalUtil::translateVertexFormat(inputElement.format);
+        desc->setFormat(metalFormat);
+    }
+
+    for (Index i = 0; i < m_vertexStreams.getCount(); i++)
+    {
+        const auto& vertexStream = m_vertexStreams[i];
+        MTL::VertexBufferLayoutDescriptor* desc = vertexDescriptor->layouts()->object(i + vertexBufferIndexOffset);
+        desc->setStepFunction(MetalUtil::translateVertexStepFunction(vertexStream.slotClass));
+        desc->setStepRate(vertexStream.slotClass == InputSlotClass::PerVertex ? 1 : vertexStream.instanceDataStepRate);
+        desc->setStride(vertexStream.stride);
+    }
+
+    return vertexDescriptor;
+}
+
+} // namespace metal
+} // namespace gfx

--- a/tools/gfx/metal/metal-vertex-layout.h
+++ b/tools/gfx/metal/metal-vertex-layout.h
@@ -14,7 +14,11 @@ namespace metal
 class InputLayoutImpl : public InputLayoutBase
 {
 public:
-    NS::SharedPtr<MTL::VertexDescriptor> m_vertexDescriptor;
+    List<InputElementDesc> m_inputElements;
+    List<VertexStreamDesc> m_vertexStreams;
+
+    Result init(const IInputLayout::Desc& desc);
+    NS::SharedPtr<MTL::VertexDescriptor> createVertexDescriptor(NS::UInteger vertexBufferIndexOffset);
 };
 
 } // namespace metal

--- a/tools/gfx/vulkan/vk-fence.cpp
+++ b/tools/gfx/vulkan/vk-fence.cpp
@@ -52,7 +52,7 @@ Result FenceImpl::init(const IFence::Desc& desc)
     {
 #if SLANG_WINDOWS_FAMILY
         exportSemaphoreWin32HandleInfoKHR.sType = VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR;
-        exportSemaphoreWin32HandleInfoKHR.pNext = timelineCreateInfo.pNext;;
+        exportSemaphoreWin32HandleInfoKHR.pNext = timelineCreateInfo.pNext;
         exportSemaphoreWin32HandleInfoKHR.pAttributes = nullptr;
         exportSemaphoreWin32HandleInfoKHR.dwAccess = GENERIC_ALL;
         exportSemaphoreWin32HandleInfoKHR.name = (LPCWSTR)nullptr;


### PR DESCRIPTION
Adds support for basic Metal graphics pipelines.

Resource binding for different shader stages is not handled correctly yet. But otherwise, this should support most of gfx API for graphics pipelines, framebuffers etc.

The swapchain is implemented using extra backbuffer images, doing an extra copy to the Metal renderable on present. This is to support the current API of gfx, which needs explicit access to the backbuffer images. Metal doesn't support this natively.