### PR TITLE
Support integer typed textures for GLSL

### DIFF
--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -1878,7 +1878,7 @@ public ivec3 textureSize(Sampler2DMSArray<vector<T,N>,sampleCount> sampler)
 // textureQueryLod
 // -------------------
 
-__generic<T:IFloat, let isArray:int, let sampleCount:int, let isShadow:int, let format:int>
+__generic<T, let isArray:int, let sampleCount:int, let isShadow:int, let format:int>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_querylod)]
 public vec2 textureQueryLod(__TextureImpl<
@@ -1910,10 +1910,11 @@ public vec2 textureQueryLod(__TextureImpl<
     }
 }
 
-__generic<T:IFloat, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let isShadow:int, let format:int>
+__generic<T, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let isShadow:int, let format:int>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_querylod)]
-public vec2 textureQueryLod(__TextureImpl<T,
+public vec2 textureQueryLod(__TextureImpl<
+        T,
         Shape,
         isArray,
         0, // isMS
@@ -2086,10 +2087,10 @@ public int textureQueryLevels(samplerCubeArrayShadow sampler)
 // textureSamples
 // -------------------
 
-__generic<T:__BuiltinArithmeticType, let N:int, let sampleCount:int>
+__generic<T, let sampleCount:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, image_samples)]
-public int textureSamples(Sampler2DMS<vector<T,N>,sampleCount> sampler)
+public int textureSamples(Sampler2DMS<T,sampleCount> sampler)
 {
     vector<int,2> dim;
     int sampleCount;
@@ -2098,10 +2099,10 @@ public int textureSamples(Sampler2DMS<vector<T,N>,sampleCount> sampler)
     return sampleCount;
 }
 
-__generic<T:__BuiltinArithmeticType, let N:int, let sampleCount:int>
+__generic<T, let sampleCount:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, image_samples)]
-public int textureSamples(Sampler2DMSArray<vector<T,N>,sampleCount> sampler)
+public int textureSamples(Sampler2DMSArray<T,sampleCount> sampler)
 {
     vector<int,3> dim;
     int sampleCount;
@@ -2118,7 +2119,7 @@ public int textureSamples(Sampler2DMSArray<vector<T,N>,sampleCount> sampler)
 // texture
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> texture(Sampler1D<vector<T,N>> sampler, float p)
@@ -2126,7 +2127,7 @@ public vector<T,4> texture(Sampler1D<vector<T,N>> sampler, float p)
     return __vectorReshape<4>(sampler.Sample(p));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> texture(Sampler1D<vector<T,N>> sampler, float p, constexpr float bias)
@@ -2134,7 +2135,7 @@ public vector<T,4> texture(Sampler1D<vector<T,N>> sampler, float p, constexpr fl
     return __vectorReshape<4>(sampler.SampleBias(p, bias));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinArithmeticType, let N:int, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let format:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> texture(__TextureImpl<
@@ -2152,7 +2153,7 @@ public vector<T,4> texture(__TextureImpl<
     return __vectorReshape<4>(sampler.Sample(p));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinArithmeticType, let N:int, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let format:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> texture(__TextureImpl<
@@ -2304,7 +2305,7 @@ public float texture(samplerCubeArrayShadow sampler, vec4 p, float compare)
 // textureProj
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProj(Sampler1D<vector<T,N>> sampler, vec2 p)
@@ -2321,7 +2322,7 @@ public vector<T,4> textureProj(Sampler1D<vector<T,N>> sampler, vec2 p)
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProj(Sampler1D<vector<T,N>> sampler, vec2 p, float bias)
@@ -2338,7 +2339,7 @@ public vector<T,4> textureProj(Sampler1D<vector<T,N>> sampler, vec2 p, float bia
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProj(Sampler1D<vector<T,N>> sampler, vec4 p)
@@ -2355,7 +2356,7 @@ public vector<T,4> textureProj(Sampler1D<vector<T,N>> sampler, vec4 p)
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProj(Sampler1D<vector<T,N>> sampler, vec4 p, float bias)
@@ -2372,7 +2373,7 @@ public vector<T,4> textureProj(Sampler1D<vector<T,N>> sampler, vec4 p, float bia
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProj(Sampler2D<vector<T,N>> sampler, vec3 p)
@@ -2389,7 +2390,7 @@ public vector<T,4> textureProj(Sampler2D<vector<T,N>> sampler, vec3 p)
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProj(Sampler2D<vector<T,N>> sampler, vec3 p, float bias)
@@ -2406,7 +2407,7 @@ public vector<T,4> textureProj(Sampler2D<vector<T,N>> sampler, vec3 p, float bia
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProj(Sampler2D<vector<T,N>> sampler, vec4 p)
@@ -2423,7 +2424,7 @@ public vector<T,4> textureProj(Sampler2D<vector<T,N>> sampler, vec4 p)
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProj(Sampler2D<vector<T,N>> sampler, vec4 p, float bias)
@@ -2440,7 +2441,7 @@ public vector<T,4> textureProj(Sampler2D<vector<T,N>> sampler, vec4 p, float bia
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProj(Sampler3D<vector<T,N>> sampler, vec4 p)
@@ -2457,7 +2458,7 @@ public vector<T,4> textureProj(Sampler3D<vector<T,N>> sampler, vec4 p)
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProj(Sampler3D<vector<T,N>> sampler, vec4 p, float bias)
@@ -2562,7 +2563,7 @@ public float textureProj(sampler2DShadow sampler, vec4 p, float bias)
 // textureLod
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureLod(Sampler1D<vector<T,N>> sampler, float p, float lod)
@@ -2570,7 +2571,7 @@ public vector<T,4> textureLod(Sampler1D<vector<T,N>> sampler, float p, float lod
     return __vectorReshape<4>(sampler.SampleLevel(p, lod));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinArithmeticType, let N:int, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let format:int>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureLod(__TextureImpl<
@@ -2649,7 +2650,7 @@ public float textureLod(sampler1DArrayShadow sampler, vec3 p, float lod)
 // textureOffset
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureOffset(Sampler1D<vector<T,N>> sampler, float p, constexpr int offset, float bias = 0.0)
@@ -2657,7 +2658,7 @@ public vector<T,4> textureOffset(Sampler1D<vector<T,N>> sampler, float p, conste
     return __vectorReshape<4>(sampler.SampleBias(p, bias, offset));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureOffset(Sampler2D<vector<T,N>> sampler, vec2 p, constexpr ivec2 offset, float bias = 0.0)
@@ -2665,7 +2666,7 @@ public vector<T,4> textureOffset(Sampler2D<vector<T,N>> sampler, vec2 p, constex
     return __vectorReshape<4>(sampler.SampleBias(p, bias, offset));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureOffset(Sampler3D<vector<T,N>> sampler, vec3 p, constexpr ivec3 offset, float bias = 0.0)
@@ -2739,7 +2740,7 @@ public float textureOffset(sampler1DShadow sampler, vec3 p, constexpr int offset
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureOffset(Sampler1DArray<vector<T,N>> sampler, vec2 p, constexpr int offset, float bias = 0.0)
@@ -2747,7 +2748,7 @@ public vector<T,4> textureOffset(Sampler1DArray<vector<T,N>> sampler, vec2 p, co
     return __vectorReshape<4>(sampler.SampleBias(p, bias, offset));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureOffset(Sampler2DArray<vector<T,N>> sampler, vec3 p, constexpr ivec2 offset, float bias = 0.0)
@@ -2918,7 +2919,7 @@ public vector<T,4> texelFetchOffset(Sampler2DRect<vector<T,N>> sampler, ivec2 p,
 // textureProjOffset
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjOffset(Sampler1D<vector<T,N>> sampler, vec2 p, constexpr int offset)
@@ -2935,7 +2936,7 @@ public vector<T,4> textureProjOffset(Sampler1D<vector<T,N>> sampler, vec2 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjOffset(Sampler1D<vector<T,N>> sampler, vec2 p, constexpr int offset, float bias)
@@ -2952,7 +2953,7 @@ public vector<T,4> textureProjOffset(Sampler1D<vector<T,N>> sampler, vec2 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjOffset(Sampler1D<vector<T,N>> sampler, vec4 p, constexpr int offset)
@@ -2973,7 +2974,7 @@ public vector<T,4> textureProjOffset(Sampler1D<vector<T,N>> sampler, vec4 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjOffset(Sampler1D<vector<T,N>> sampler, vec4 p, constexpr int offset, float bias)
@@ -2994,7 +2995,7 @@ public vector<T,4> textureProjOffset(Sampler1D<vector<T,N>> sampler, vec4 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjOffset(Sampler2D<vector<T,N>> sampler, vec3 p, constexpr ivec2 offset)
@@ -3011,7 +3012,7 @@ public vector<T,4> textureProjOffset(Sampler2D<vector<T,N>> sampler, vec3 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjOffset(Sampler2D<vector<T,N>> sampler, vec3 p, constexpr ivec2 offset, float bias)
@@ -3028,7 +3029,7 @@ public vector<T,4> textureProjOffset(Sampler2D<vector<T,N>> sampler, vec3 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjOffset(Sampler2D<vector<T,N>> sampler, vec4 p, constexpr ivec2 offset)
@@ -3049,7 +3050,7 @@ public vector<T,4> textureProjOffset(Sampler2D<vector<T,N>> sampler, vec4 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjOffset(Sampler2D<vector<T,N>> sampler, vec4 p, constexpr ivec2 offset, float bias)
@@ -3070,7 +3071,7 @@ public vector<T,4> textureProjOffset(Sampler2D<vector<T,N>> sampler, vec4 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjOffset(Sampler3D<vector<T,N>> sampler, vec4 p, constexpr ivec3 offset)
@@ -3087,7 +3088,7 @@ public vector<T,4> textureProjOffset(Sampler3D<vector<T,N>> sampler, vec4 p, con
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjOffset(Sampler3D<vector<T,N>> sampler, vec4 p, constexpr ivec3 offset, float bias)
@@ -3192,7 +3193,7 @@ public float textureProjOffset(sampler2DShadow sampler, vec4 p, constexpr ivec2 
 // textureLodOffset
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureLodOffset(Sampler1D<vector<T,N>> sampler, float p, float lod, constexpr int offset)
@@ -3200,7 +3201,7 @@ public vector<T,4> textureLodOffset(Sampler1D<vector<T,N>> sampler, float p, flo
     return __vectorReshape<4>(sampler.SampleLevel(p, lod, offset));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinArithmeticType, let N:int, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureLodOffset(__TextureImpl<
@@ -3282,7 +3283,7 @@ public float textureLodOffset(sampler1DArrayShadow sampler, vec3 p, float lod, c
 // textureProjLod
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjLod(Sampler1D<vector<T,N>> sampler, vec2 p, float lod)
@@ -3298,7 +3299,7 @@ public vector<T,4> textureProjLod(Sampler1D<vector<T,N>> sampler, vec2 p, float 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjLod(Sampler1D<vector<T,N>> sampler, vec4 p, float lod)
@@ -3318,7 +3319,7 @@ public vector<T,4> textureProjLod(Sampler1D<vector<T,N>> sampler, vec4 p, float 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjLod(Sampler2D<vector<T,N>> sampler, vec3 p, float lod)
@@ -3334,7 +3335,7 @@ public vector<T,4> textureProjLod(Sampler2D<vector<T,N>> sampler, vec3 p, float 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjLod(Sampler2D<vector<T,N>> sampler, vec4 p, float lod)
@@ -3354,7 +3355,7 @@ public vector<T,4> textureProjLod(Sampler2D<vector<T,N>> sampler, vec4 p, float 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjLod(Sampler3D<vector<T,N>> sampler, vec4 p, float lod)
@@ -3414,7 +3415,7 @@ public float textureProjLod(sampler2DShadow sampler, vec4 p, float lod)
 // textureProjLodOffset
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjLodOffset(Sampler1D<vector<T,N>> sampler, vec2 p, float lod, constexpr int offset)
@@ -3430,7 +3431,7 @@ public vector<T,4> textureProjLodOffset(Sampler1D<vector<T,N>> sampler, vec2 p, 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjLodOffset(Sampler1D<vector<T,N>> sampler, vec4 p, float lod, constexpr int offset)
@@ -3450,7 +3451,7 @@ public vector<T,4> textureProjLodOffset(Sampler1D<vector<T,N>> sampler, vec4 p, 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjLodOffset(Sampler2D<vector<T,N>> sampler, vec3 p, float lod, constexpr ivec2 offset)
@@ -3466,7 +3467,7 @@ public vector<T,4> textureProjLodOffset(Sampler2D<vector<T,N>> sampler, vec3 p, 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjLodOffset(Sampler2D<vector<T,N>> sampler, vec4 p, float lod, constexpr ivec2 offset)
@@ -3486,7 +3487,7 @@ public vector<T,4> textureProjLodOffset(Sampler2D<vector<T,N>> sampler, vec4 p, 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_sm_4_1_fragment)]
 public vector<T,4> textureProjLodOffset(Sampler3D<vector<T,N>> sampler, vec4 p, float lod, constexpr ivec3 offset)
@@ -3547,7 +3548,7 @@ public float textureProjLodOffset(sampler2DShadow sampler, vec4 p, float lod, co
 // -------------------
 
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureGrad(Sampler1D<vector<T,N>> sampler, float p, float dPdx, float dPdy)
@@ -3555,7 +3556,7 @@ public vector<T,4> textureGrad(Sampler1D<vector<T,N>> sampler, float p, float dP
     return __vectorReshape<4>(sampler.SampleGrad(p, dPdx, dPdy));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinArithmeticType, let N:int, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureGrad(__TextureImpl<
@@ -3662,7 +3663,7 @@ public float textureGrad(sampler2DArrayShadow sampler, vec4 p, vec2 dPdx, vec2 d
 // textureGradOffset
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureGradOffset(Sampler1D<vector<T,N>> sampler, float p, float dPdx, float dPdy, constexpr int offset)
@@ -3670,7 +3671,7 @@ public vector<T,4> textureGradOffset(Sampler1D<vector<T,N>> sampler, float p, fl
     return __vectorReshape<4>(sampler.SampleGrad(p, dPdx, dPdy, offset));
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
+__generic<T:__BuiltinArithmeticType, let N:int, Shape:__ITextureShape, let isArray:int, let sampleCount:int, let format:int>
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 [ForceInline]
 public vector<T,4> textureGradOffset(__TextureImpl<
@@ -3760,7 +3761,7 @@ public float textureGradOffset(sampler2DArrayShadow sampler, vec4 p, vec2 dPdx, 
 // textureProjGrad
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureProjGrad(Sampler1D<vector<T,N>> sampler, vec2 p, float dPdx, float dPdy)
@@ -3776,7 +3777,7 @@ public vector<T,4> textureProjGrad(Sampler1D<vector<T,N>> sampler, vec2 p, float
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureProjGrad(Sampler1D<vector<T,N>> sampler, vec4 p, float dPdx, float dPdy)
@@ -3796,7 +3797,7 @@ public vector<T,4> textureProjGrad(Sampler1D<vector<T,N>> sampler, vec4 p, float
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureProjGrad(Sampler2D<vector<T,N>> sampler, vec3 p, vec2 dPdx, vec2 dPdy)
@@ -3812,7 +3813,7 @@ public vector<T,4> textureProjGrad(Sampler2D<vector<T,N>> sampler, vec3 p, vec2 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureProjGrad(Sampler2D<vector<T,N>> sampler, vec4 p, vec2 dPdx, vec2 dPdy)
@@ -3832,7 +3833,7 @@ public vector<T,4> textureProjGrad(Sampler2D<vector<T,N>> sampler, vec4 p, vec2 
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureProjGrad(Sampler3D<vector<T,N>> sampler, vec4 p, vec3 dPdx, vec3 dPdy)
@@ -3892,7 +3893,7 @@ public float textureProjGrad(sampler2DShadow sampler, vec4 p, vec2 dPdx, vec2 dP
 // textureProjGradOffset
 // -------------------
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureProjGradOffset(Sampler1D<vector<T,N>> sampler, vec2 p, float dPdx, float dPdy, constexpr int offset)
@@ -3908,7 +3909,7 @@ public vector<T,4> textureProjGradOffset(Sampler1D<vector<T,N>> sampler, vec2 p,
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureProjGradOffset(Sampler1D<vector<T,N>> sampler, vec4 p, float dPdx, float dPdy, constexpr int offset)
@@ -3928,7 +3929,7 @@ public vector<T,4> textureProjGradOffset(Sampler1D<vector<T,N>> sampler, vec4 p,
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureProjGradOffset(Sampler2D<vector<T,N>> sampler, vec3 p, vec2 dPdx, vec2 dPdy, constexpr ivec2 offset)
@@ -3944,7 +3945,7 @@ public vector<T,4> textureProjGradOffset(Sampler2D<vector<T,N>> sampler, vec3 p,
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureProjGradOffset(Sampler2D<vector<T,N>> sampler, vec4 p, vec2 dPdx, vec2 dPdy, constexpr ivec2 offset)
@@ -3964,7 +3965,7 @@ public vector<T,4> textureProjGradOffset(Sampler2D<vector<T,N>> sampler, vec4 p,
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N:int>
+__generic<T:__BuiltinArithmeticType, let N:int>
 [ForceInline]
 [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
 public vector<T,4> textureProjGradOffset(Sampler3D<vector<T,N>> sampler, vec4 p, vec3 dPdx, vec3 dPdy, constexpr ivec3 offset)

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -510,10 +510,6 @@ float __glsl_texture_offset_level_zero_1d_shadow<TTexture, TCoord, TOffset>(TTex
     }
 }
 
-// TODO: Need to replace with a real static_assert when it is implemented.
-// This is a placeholder implementation
-void static_assert(constexpr bool condi, NativeString msg) {}
-
 __generic<T, Shape: __ITextureShape, let isArray:int, let isMS:int, let sampleCount:int, let isShadow:int, let format:int>
 extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 {

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -510,8 +510,11 @@ float __glsl_texture_offset_level_zero_1d_shadow<TTexture, TCoord, TOffset>(TTex
     }
 }
 
+// TODO: Need to replace with a real static_assert when it is implemented.
+// This is a placeholder implementation
+void static_assert(constexpr bool condi, NativeString msg) {}
 
-__generic<T:IFloat, Shape: __ITextureShape, let isArray:int, let isMS:int, let sampleCount:int, let isShadow:int, let format:int>
+__generic<T, Shape: __ITextureShape, let isArray:int, let isMS:int, let sampleCount:int, let isShadow:int, let format:int>
 extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 {
     static const int access = 0;
@@ -536,10 +539,12 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
         __target_switch
         {
         case hlsl:
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                , "HLSL supports only float and half type textures");
+            return __getTexture().CalculateLevelOfDetail(__getSampler(), location);
         case metal:
-            {
-                return __getTexture().CalculateLevelOfDetail(__getSampler(), location);
-            }
+            return __getTexture().CalculateLevelOfDetail(__getSampler(), location);
         case glsl:
             __intrinsic_asm "textureQueryLod($0, $1).x";
         case spirv:
@@ -559,10 +564,12 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
         __target_switch
         {
         case hlsl:
-        case metal:
-            {
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                , "HLSL supports only float and half type textures");
             return __getTexture().CalculateLevelOfDetailUnclamped(__getSampler(), location);
-            }
+        case metal:
+            return __getTexture().CalculateLevelOfDetailUnclamped(__getSampler(), location);
         case glsl:
             __intrinsic_asm "textureQueryLod($0, $1).y";
         case spirv:
@@ -581,8 +588,12 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
         __requireComputeDerivative();
         __target_switch
         {
-            case cpp:
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
+                return __getTexture().Sample(__getSampler(), location);
+            case cpp:
             case metal:
                 return __getTexture().Sample(__getSampler(), location);
             case glsl:
@@ -633,8 +644,12 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
         __requireComputeDerivative();
         __target_switch
         {
-            case cpp:
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
+                return __getTexture().Sample(__getSampler(), location, offset);
+            case cpp:
             case metal:
                 return __getTexture().Sample(__getSampler(), location, offset);
             case glsl:
@@ -658,8 +673,12 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
         __requireComputeDerivative();
         __target_switch
         {
-            case cpp:
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
+                return __getTexture().Sample(__getSampler(), location, offset, clamp);
+            case cpp:
             case metal:
                 return __getTexture().Sample(__getSampler(), location, offset, clamp);
             case glsl:
@@ -681,7 +700,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     {
         __target_switch
         {
-        case hlsl: __intrinsic_asm ".Sample";
+        case hlsl:
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                , "HLSL supports only float and half type textures");
+            __intrinsic_asm ".Sample";
         default:
             status = 0;
             return Sample(location, offset, clamp);
@@ -696,8 +719,12 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
         __requireComputeDerivative();
         __target_switch
         {
-            case cpp:
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
+                return __getTexture().SampleBias(__getSampler(), location, bias);
+            case cpp:
             case metal:
                 return __getTexture().SampleBias(__getSampler(), location, bias);
             case glsl:
@@ -720,8 +747,12 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
         __requireComputeDerivative();
         __target_switch
         {
-            case cpp:
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
+                return __getTexture().SampleBias(__getSampler(), location, bias, offset);
+            case cpp:
             case metal:
                 return __getTexture().SampleBias(__getSampler(), location, bias, offset);
             case glsl:
@@ -757,6 +788,10 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 return __glsl_texture(this, __makeVector(location, compareValue));
             }
         case hlsl:
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                , "HLSL supports only float and half type textures");
+            return __getTexture().SampleCmp(__getComparisonSampler(), location, compareValue);
         case metal:
             return __getTexture().SampleCmp(__getComparisonSampler(), location, compareValue);
         case spirv:
@@ -784,6 +819,10 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 return __glsl_texture_level_zero(this, __makeVector(location, compareValue));
             }
         case hlsl:
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                , "HLSL supports only float and half type textures");
+            return __getTexture().SampleCmpLevelZero(__getComparisonSampler(), location, compareValue);
         case metal:
             return __getTexture().SampleCmpLevelZero(__getComparisonSampler(), location, compareValue);
         case spirv:
@@ -813,6 +852,10 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 return __glsl_texture_offset(this, __makeVector(location, compareValue), offset);
             }
         case hlsl:
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                , "HLSL supports only float and half type textures");
+            return __getTexture().SampleCmp(__getComparisonSampler(), location, compareValue, offset);
         case metal:
             return __getTexture().SampleCmp(__getComparisonSampler(), location, compareValue, offset);
         case spirv:
@@ -840,6 +883,10 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 return __glsl_texture_offset_level_zero(this, __makeVector(location, compareValue), offset);
             }
         case hlsl:
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                , "HLSL supports only float and half type textures");
+            return __getTexture().SampleCmpLevelZero(__getComparisonSampler(), location, compareValue, offset);
         case metal:
             return __getTexture().SampleCmpLevelZero(__getComparisonSampler(), location, compareValue, offset);
         case spirv:
@@ -858,8 +905,12 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     {
         __target_switch
         {
-            case cpp:
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
+                return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY);
+            case cpp:
             case metal:
                 return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY);
 
@@ -881,8 +932,12 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     {
         __target_switch
         {
-            case cpp:
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
+                return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY, offset);
+            case cpp:
             case metal:
                 return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY, offset);
             case glsl:
@@ -904,8 +959,12 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     {
         __target_switch
         {
-            case cpp:
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
+                return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY, offset, lodClamp);
+            case cpp:
             case metal:
                 return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY, offset, lodClamp);
             case glsl:
@@ -927,8 +986,12 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     {
         __target_switch
         {
-            case cpp:
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
+                return __getTexture().SampleLevel(__getSampler(), location, level);
+            case cpp:
             case metal:
                 return __getTexture().SampleLevel(__getSampler(), location, level);
             case glsl:
@@ -980,8 +1043,12 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     {
         __target_switch
         {
-            case cpp:
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
+                return __getTexture().SampleLevel(__getSampler(), location, level, offset);
+            case cpp:
             case metal:
                 return __getTexture().SampleLevel(__getSampler(), location, level, offset);
 
@@ -1048,7 +1115,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,access,isShadow,0,forma
     }
 }
 
-__generic<T:IFloat, Shape: __ITextureShape, let isArray:int, let isMS:int, let sampleCount:int, let isShadow:int, let format:int>
+__generic<T, Shape: __ITextureShape, let isArray:int, let isMS:int, let sampleCount:int, let isShadow:int, let format:int>
 extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 {
     [__readNone]
@@ -1060,7 +1127,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
         __target_switch
         {
             case cpp:
+                __intrinsic_asm ".Sample";
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
                 __intrinsic_asm ".Sample";
             case metal:
                 if (isArray == 1)
@@ -1140,7 +1211,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
         __target_switch
         {
             case cpp:
+                __intrinsic_asm ".Sample";
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
                 __intrinsic_asm ".Sample";
             case metal:
                 if (isArray == 1)
@@ -1184,7 +1259,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
         __target_switch
         {
             case cpp:
+                __intrinsic_asm ".Sample";
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
                 __intrinsic_asm ".Sample";
             case metal:
                 if (isArray == 1)
@@ -1226,7 +1305,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
     {
         __target_switch
         {
-        case hlsl: __intrinsic_asm ".Sample";
+        case hlsl:
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                , "HLSL supports only float and half type textures");
+            __intrinsic_asm ".Sample";
         default:
             status = 0;
             return Sample(s, location, offset, clamp);
@@ -1242,8 +1325,12 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
         __target_switch
         {
             case cpp:
+                __intrinsic_asm ".SampleBias";
             case hlsl:
-            __intrinsic_asm ".SampleBias";
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
+                __intrinsic_asm ".SampleBias";
             case metal:
                 if (isArray == 1)
                 {
@@ -1288,8 +1375,12 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
         __target_switch
         {
             case cpp:
+                __intrinsic_asm ".SampleBias";
             case hlsl:
-            __intrinsic_asm ".SampleBias";
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
+                __intrinsic_asm ".SampleBias";
             case metal:
                 if (isArray == 1)
                 {
@@ -1344,6 +1435,9 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 return __glsl_texture(this, s, __makeVector(location,compareValue));
             }
         case hlsl:
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                , "HLSL supports only float and half type textures");
             __intrinsic_asm ".SampleCmp";
         case metal:
             if (isArray == 1)
@@ -1392,6 +1486,9 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 return __glsl_texture_level_zero(this, s, __makeVector(location,compareValue));
             }
         case hlsl:
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                , "HLSL supports only float and half type textures");
             __intrinsic_asm ".SampleCmpLevelZero";
         case metal:
             if (isArray == 1)
@@ -1442,6 +1539,9 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 return __glsl_texture_offset(this, s, __makeVector(location,compareValue), offset);
             }
         case hlsl:
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                , "HLSL supports only float and half type textures");
             __intrinsic_asm ".SampleCmp";
         case metal:
             if (isArray == 1)
@@ -1487,6 +1587,9 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 return __glsl_texture_offset_level_zero(this, s, __makeVector(location,compareValue), offset);
             }
         case hlsl:
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                , "HLSL supports only float and half type textures");
             __intrinsic_asm ".SampleCmpLevelZero";
         case metal:
             if (isShadow == 1)
@@ -1526,7 +1629,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
         __target_switch
         {
             case cpp:
+                __intrinsic_asm ".SampleGrad";
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
                 __intrinsic_asm ".SampleGrad";
             case metal:
                 if (isArray == 1)
@@ -1573,7 +1680,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
         __target_switch
         {
             case cpp:
+                __intrinsic_asm ".SampleGrad";
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
                 __intrinsic_asm ".SampleGrad";
             case metal:
                 if (isArray == 1)
@@ -1618,7 +1729,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
         __target_switch
         {
             case cpp:
+                __intrinsic_asm ".SampleGrad";
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
                 __intrinsic_asm ".SampleGrad";
             case metal:
                 if (isArray == 1)
@@ -1662,7 +1777,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
         __target_switch
         {
             case cpp:
+                __intrinsic_asm ".SampleLevel";
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
                 __intrinsic_asm ".SampleLevel";
             case metal:
                 if (isArray == 1)
@@ -1738,7 +1857,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
         __target_switch
         {
             case cpp:
+                __intrinsic_asm ".SampleLevel";
             case hlsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    || T is half || T is vector<half,2> || T is vector<half,3> || T is vector<half,4>
+                    , "HLSL supports only float and half type textures");
                 __intrinsic_asm ".SampleLevel";
             case metal:
                 if (isArray == 1)
@@ -2138,8 +2261,9 @@ vector<TElement,4> __texture_gatherCmp_offsets(__TextureImpl<T, Shape, isArray, 
 }
 
 ${{{{
-for (int isCombined = 0; isCombined<=1; isCombined++) {
-for (int isScalarTexture = 0; isScalarTexture <= 1; isScalarTexture++) {
+for (int isCombined = 0; isCombined < 2; isCombined++)
+for (int isScalarTexture = 0; isScalarTexture < 2; isScalarTexture++)
+{
     if (isScalarTexture == 0)
     {
         sb << "__generic<T:__BuiltinArithmeticType, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let isShadow:int, let format:int>\n";
@@ -2153,24 +2277,12 @@ for (int isScalarTexture = 0; isScalarTexture <= 1; isScalarTexture++) {
 }}}}
 { // begin extension for gather
 ${{{{
-    if (isCombined)
-    {
-}}}}
-    __intrinsic_op($(kIROp_CombinedTextureSamplerGetTexture))
-    __TextureImpl<T, Shape, isArray, 0, sampleCount, 0, isShadow, 0, format> __getTexture();
-
-    __intrinsic_op($(kIROp_CombinedTextureSamplerGetSampler))
-    SamplerState __getSampler();
-
-    __intrinsic_op($(kIROp_CombinedTextureSamplerGetSampler))
-    SamplerComparisonState __getComparisonSampler();
-${{{{
-    }
 
     // Gather component
     const char* samplerStateParam = isCombined ? "" : " s,";
     const char* getTexture = isCombined ? "__getTexture()" : "this";
-    for (int isCmp = 0; isCmp < 2; ++isCmp) {
+    for (int isCmp = 0; isCmp < 2; ++isCmp)
+    {
         const char* cmp = isCmp ? "Cmp" : "";
         const char* cmpParam = isCmp ? ", T compareValue" : "";
         const char* compareArg = isCmp ? ", compareValue" : "";
@@ -2179,7 +2291,8 @@ ${{{{
         const char* componentNames[] = { "", "Red", "Green", "Blue", "Alpha"};
         const char* glslComponentNames[] = { ", 0", ", 1", ", 2", ", 3" };
 
-        for (auto componentId = 0;  componentId < 5; componentId++) {
+        for (auto componentId = 0;  componentId < 5; componentId++)
+        {
             auto componentName = componentNames[componentId];
             auto glslComponent = (isCmp ? "" :glslComponentNames[componentId == 0 ? 0 : componentId - 1]);
     }}}}
@@ -2228,14 +2341,13 @@ ${{{{
         }
     }
     ${{{{
-    } // for (componentId)
+        } // for (componentId)
     } // for (isCmp)
     }}}}
 } // end extension for gather
 
 ${{{{
 } // for (isScalarTexture)
-} // for (isCombined)
 }}}}
 
 // Load/Subscript for readonly, no MS textures

--- a/tests/diagnostics/int-texture-sample.slang
+++ b/tests/diagnostics/int-texture-sample.slang
@@ -1,7 +1,14 @@
-//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):-target hlsl -stage compute -entry computeMain
 
-void test(Texture2D<int4> itex, SamplerState s)
+Texture2D<int4> t2D;
+SamplerState s;
+
+//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
+RWStructuredBuffer<int4> outputBuffer;
+
+void computeMain()
 {
-    // CHECK: ([[# @LINE+1]]): error
-    itex.Sample(s, float2(0.0, 0.0));
+    // CHECK: error 41400: {{.*}} HLSL supports only float and half type textures
+    outputBuffer[0] = t2D.Sample(s, float2(0.0, 0.0));
 }
+

--- a/tests/glsl-intrinsic/intrinsic-texture.slang
+++ b/tests/glsl-intrinsic/intrinsic-texture.slang
@@ -171,6 +171,9 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
     constexpr ivec3 offset3D = ivec3(0);
     constexpr ivec2 offsets[4] = { ivec2(0), ivec2(0), ivec2(0), ivec2(0) };
 
+    bool ignoreResultF32 = ignoreResult && T is float;
+    bool ignoreResultI32 = ignoreResult && T is int32_t;
+
     return true
         // 8.9.1. Texture Query Functions
 
@@ -220,7 +223,7 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}samplerCubeArray
         // SPIR: [[IMAGE:%[1-9][0-9]*]] = OpImage{{.*}}[[LOAD]]
         // SPIR: OpImageQuerySize{{.*}}[[IMAGE]]
-        && ivec3(4,4,2) == textureSize(gsamplerCubeArray, int(0))
+        && (ivec3(4,4,2) == textureSize(gsamplerCubeArray, int(0)) || ignoreResultI32)
 
         // GLSL: textureSize({{.*}}samplerCubeArrayShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}samplerCubeArrayShadow
@@ -244,7 +247,7 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler1DArray
         // SPIR: [[IMAGE:%[1-9][0-9]*]] = OpImage{{.*}}[[LOAD]]
         // SPIR: OpImageQuerySize{{.*}}[[IMAGE]]
-        && ivec2(4,2) == textureSize(gsampler1DArray, int(0))
+        && (ivec2(4,2) == textureSize(gsampler1DArray, int(0)) || ignoreResultI32 )
 
         // GLSL: textureSize({{.*}}sampler1DArrayShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler1DArrayShadow
@@ -256,7 +259,7 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DArray
         // SPIR: [[IMAGE:%[1-9][0-9]*]] = OpImage{{.*}}[[LOAD]]
         // SPIR: OpImageQuerySize{{.*}}[[IMAGE]]
-        && ivec3(4,4,2) == textureSize(gsampler2DArray, int(0))
+        && (ivec3(4,4,2) == textureSize(gsampler2DArray, int(0)) || ignoreResultI32)
 
         // GLSL: textureSize({{.*}}sampler2DArrayShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DArrayShadow
@@ -491,22 +494,22 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: texture({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageSampleDrefImplicitLod{{.*}}[[LOAD]]
-        && (float(0) == texture(uniform_sampler2DShadow, vec3(coord)) || ignoreResult)
+        && (float(0) == texture(uniform_sampler2DShadow, vec3(coord)) || ignoreResultF32)
 
         // GLSL: texture({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageSampleDrefImplicitLod{{.*}}[[LOAD]]{{.*}} Bias %
-        && (float(0) == texture(uniform_sampler2DShadow, vec3(coord), float(0)) || ignoreResult)
+        && (float(0) == texture(uniform_sampler2DShadow, vec3(coord), float(0)) || ignoreResultF32)
 
         // GLSL: texture({{.*}}samplerCubeShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}samplerCubeShadow
         // SPIR: OpImageSampleDrefImplicitLod{{.*}}[[LOAD]]
-        && (float(0) == texture(uniform_samplerCubeShadow, vec4(coord)) || ignoreResult)
+        && (float(0) == texture(uniform_samplerCubeShadow, vec4(coord)) || ignoreResultF32)
 
         // GLSL: texture({{.*}}samplerCubeShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}samplerCubeShadow
         // SPIR: OpImageSampleDrefImplicitLod{{.*}}[[LOAD]]{{.*}} Bias %
-        && (float(0) == texture(uniform_samplerCubeShadow, vec4(coord), float(0)) || ignoreResult)
+        && (float(0) == texture(uniform_samplerCubeShadow, vec4(coord), float(0)) || ignoreResultF32)
 
         // GLSL: texture({{.*}}sampler2DArray
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DArray
@@ -631,12 +634,12 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: textureProj({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageSampleProjDrefImplicitLod {{.*}}[[LOAD]]
-        && (float(0) == textureProj(uniform_sampler2DShadow, vec4(coord)) || ignoreResult)
+        && (float(0) == textureProj(uniform_sampler2DShadow, vec4(coord)) || ignoreResultF32)
 
         // GLSL: textureProj({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageSampleProjDrefImplicitLod {{.*}}[[LOAD]]{{.*}} Bias %
-        && (float(0) == textureProj(uniform_sampler2DShadow, vec4(coord), float(0)) || ignoreResult)
+        && (float(0) == textureProj(uniform_sampler2DShadow, vec4(coord), float(0)) || ignoreResultF32)
 
         // GLSL-COUNT-2: textureProj({{.*}}sampler2DRect
         // SPIR-COUNT-2: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DRect
@@ -672,7 +675,7 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: textureLod({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageSampleDrefExplicitLod {{.*}}[[LOAD]]{{.*}} Lod %
-        && (float(0) == textureLod(uniform_sampler2DShadow, vec3(coord), float(0)) || ignoreResult)
+        && (float(0) == textureLod(uniform_sampler2DShadow, vec3(coord), float(0)) || ignoreResultF32)
 
         // GLSL: textureLod({{.*}}sampler1DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler1DShadow
@@ -732,12 +735,12 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: textureOffset({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // S-PIR: OpImageSampleDrefImplicitLod {{.*}}[[LOAD]]{{.*}} ConstOffset %
-        && (float(0) == textureOffset(uniform_sampler2DShadow, vec3(coord), offset2D) || ignoreResult)
+        && (float(0) == textureOffset(uniform_sampler2DShadow, vec3(coord), offset2D) || ignoreResultF32)
 
         // GLSL: textureOffset({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageSampleDrefImplicitLod {{.*}}[[LOAD]]{{.*}} Bias|ConstOffset %
-        && (float(0) == textureOffset(uniform_sampler2DShadow, vec3(coord), offset2D, float(0)) || ignoreResult)
+        && (float(0) == textureOffset(uniform_sampler2DShadow, vec3(coord), offset2D, float(0)) || ignoreResultF32)
 
         // GLSL: textureOffset({{.*}}sampler2DRect
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DRect
@@ -833,7 +836,7 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: imageLoad({{.*}}samplerBuffer
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}samplerBuffer
         // SPIR: OpImageRead {{.*}}[[LOAD]]
-        && (gvec4(T(0)) == texelFetch(gsamplerBuffer, int(coord)) || ignoreResult)
+        && (gvec4(T(0)) == texelFetch(gsamplerBuffer, int(coord)) || ignoreResultF32)
 
         // GLSL: texelFetch({{.*}}sampler2DMS
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DMS
@@ -957,12 +960,12 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: textureProjOffset({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageSampleProjDrefImplicitLod {{.*}}[[LOAD]]{{.*}} ConstOffset %
-        && (float(0) == textureProjOffset(uniform_sampler2DShadow, vec4(coord), offset2D) || ignoreResult)
+        && (float(0) == textureProjOffset(uniform_sampler2DShadow, vec4(coord), offset2D) || ignoreResultF32)
 
         // GLSL: textureProjOffset({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageSampleProjDrefImplicitLod {{.*}}[[LOAD]]{{.*}} Bias|ConstOffset %
-        && (float(0) == textureProjOffset(uniform_sampler2DShadow, vec4(coord), offset2D, float(0)) || ignoreResult)
+        && (float(0) == textureProjOffset(uniform_sampler2DShadow, vec4(coord), offset2D, float(0)) || ignoreResultF32)
 
         // GLSL: textureLodOffset({{.*}}sampler1D
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler1D
@@ -987,7 +990,7 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: textureLodOffset({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageSampleDrefExplicitLod {{.*}}[[LOAD]]{{.*}} Lod|ConstOffset %
-        && (float(0) == textureLodOffset(uniform_sampler2DShadow, vec3(coord), float(0), offset2D) || ignoreResult)
+        && (float(0) == textureLodOffset(uniform_sampler2DShadow, vec3(coord), float(0), offset2D) || ignoreResultF32)
 
         // GLSL: textureLodOffset({{.*}}sampler1DArray
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler1DArray
@@ -1029,7 +1032,7 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: textureProjLod({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageSampleProjDrefExplicitLod {{.*}}[[LOAD]]{{.*}} Lod %
-        && (float(0) == textureProjLod(uniform_sampler2DShadow, vec4(coord), float(0)) || ignoreResult)
+        && (float(0) == textureProjLod(uniform_sampler2DShadow, vec4(coord), float(0)) || ignoreResultF32)
 
         // GLSL-COUNT-2: textureProjLodOffset({{.*}}sampler1D
         // SPIR-COUNT-2: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler1D
@@ -1056,7 +1059,7 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: textureProjLodOffset({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageSampleProjDrefExplicitLod {{.*}}[[LOAD]]{{.*}} Lod|ConstOffset %
-        && (float(0) == textureProjLodOffset(uniform_sampler2DShadow, vec4(coord), float(0), offset2D) || ignoreResult)
+        && (float(0) == textureProjLodOffset(uniform_sampler2DShadow, vec4(coord), float(0), offset2D) || ignoreResultF32)
 
         // GLSL: textureGrad({{.*}}sampler1D
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler1D
@@ -1111,12 +1114,12 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: textureGrad({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageSampleDrefExplicitLod {{.*}}[[LOAD]]{{.*}} Grad %
-        && (float(0) == textureGrad(uniform_sampler2DShadow, vec3(coord), vec2(0), vec2(0)) || ignoreResult)
+        && (float(0) == textureGrad(uniform_sampler2DShadow, vec3(coord), vec2(0), vec2(0)) || ignoreResultF32)
 
         // GLSL: textureGrad({{.*}}samplerCubeShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}samplerCubeShadow
         // SPIR: OpImageSampleDrefExplicitLod {{.*}}[[LOAD]]{{.*}} Grad %
-        && (float(0) == textureGrad(uniform_samplerCubeShadow, vec4(coord), vec3(0), vec3(0)) || ignoreResult)
+        && (float(0) == textureGrad(uniform_samplerCubeShadow, vec4(coord), vec3(0), vec3(0)) || ignoreResultF32)
 
         // GLSL: textureGrad({{.*}}sampler2DArrayShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DArrayShadow
@@ -1161,7 +1164,7 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: textureGradOffset({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageSampleDrefExplicitLod {{.*}}[[LOAD]]{{.*}} Grad|ConstOffset %
-        && (float(0) == textureGradOffset(uniform_sampler2DShadow, vec3(coord), vec2(0), vec2(0), offset2D) || ignoreResult)
+        && (float(0) == textureGradOffset(uniform_sampler2DShadow, vec3(coord), vec2(0), vec2(0), offset2D) || ignoreResultF32)
 
         // GLSL: textureGradOffset({{.*}}sampler2DArray
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DArray
@@ -1219,7 +1222,7 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: textureProjGrad({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageSampleProjDrefExplicitLod {{.*}}[[LOAD]]{{.*}} Grad %
-        && (float(0) == textureProjGrad(uniform_sampler2DShadow, vec4(coord), vec2(0), vec2(0)) || ignoreResult)
+        && (float(0) == textureProjGrad(uniform_sampler2DShadow, vec4(coord), vec2(0), vec2(0)) || ignoreResultF32)
 
         // GLSL-COUNT-2: textureProjGradOffset({{.*}}sampler1D
         // SPIR-COUNT-2: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler1D
@@ -1257,7 +1260,7 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: textureProjGradOffset({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageSampleProjDrefExplicitLod {{.*}}[[LOAD]]{{.*}} Grad|ConstOffset %
-        && (float(0) == textureProjGradOffset(uniform_sampler2DShadow, vec4(coord), vec2(0), vec2(0), offset2D) || ignoreResult)
+        && (float(0) == textureProjGradOffset(uniform_sampler2DShadow, vec4(coord), vec2(0), vec2(0), offset2D) || ignoreResultF32)
         
         // 8.9.4. Texture Gather Functions
 
@@ -1294,7 +1297,7 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: textureGather({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageDrefGather {{.*}}[[LOAD]]
-        && (vec4(0) == textureGather(uniform_sampler2DShadow, vec2(coord), float(0)) || ignoreResult)
+        && (vec4(0) == textureGather(uniform_sampler2DShadow, vec2(coord), float(0)) || ignoreResultF32)
 
         // GLSL: textureGather({{.*}}sampler2DArrayShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DArrayShadow
@@ -1304,7 +1307,7 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: textureGather({{.*}}samplerCubeShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}samplerCubeShadow
         // SPIR: OpImageDrefGather {{.*}}[[LOAD]]
-        && (vec4(0) == textureGather(uniform_samplerCubeShadow, vec3(coord), float(0)) || ignoreResult)
+        && (vec4(0) == textureGather(uniform_samplerCubeShadow, vec3(coord), float(0)) || ignoreResultF32)
 
         // GLSL: textureGather({{.*}}samplerCubeArrayShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}samplerCubeArrayShadow
@@ -1331,7 +1334,7 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: textureGatherOffset({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageDrefGather {{.*}}[[LOAD]]{{.*}} ConstOffset %
-        && (vec4(0) == textureGatherOffset(uniform_sampler2DShadow, vec2(coord), float(0), offset2D) || ignoreResult)
+        && (vec4(0) == textureGatherOffset(uniform_sampler2DShadow, vec2(coord), float(0), offset2D) || ignoreResultF32)
 
         // GLSL: textureGatherOffset({{.*}}sampler2DArrayShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DArrayShadow
@@ -1364,7 +1367,7 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         // GLSL: textureGatherOffsets({{.*}}sampler2DShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DShadow
         // SPIR: OpImageDrefGather {{.*}}[[LOAD]]{{.*}} ConstOffsets %
-        && (vec4(0) == textureGatherOffsets(uniform_sampler2DShadow, vec2(coord), float(0), offsets) || ignoreResult)
+        && (vec4(0) == textureGatherOffsets(uniform_sampler2DShadow, vec2(coord), float(0), offsets) || ignoreResultF32)
 
         // GLSL: textureGatherOffsets({{.*}}sampler2DArrayShadow
         // SPIR: [[LOAD:%[1-9][0-9]*]] = OpLoad{{.*}}sampler2DArrayShadow
@@ -1417,16 +1420,16 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         && vec4(0) == textureCubeLod(uniform_samplerCube, vec3(coord), float(0))
         && vec4(0) == shadow1D(uniform_sampler1DShadow, vec3(coord))
         && vec4(0) == shadow1D(uniform_sampler1DShadow, vec3(coord), float(0))
-        && (vec4(0) == shadow2D(uniform_sampler2DShadow, vec3(coord)) || ignoreResult)
-        && (vec4(0) == shadow2D(uniform_sampler2DShadow, vec3(coord), float(0)) || ignoreResult)
+        && (vec4(0) == shadow2D(uniform_sampler2DShadow, vec3(coord)) || ignoreResultF32)
+        && (vec4(0) == shadow2D(uniform_sampler2DShadow, vec3(coord), float(0)) || ignoreResultF32)
         && vec4(0) == shadow1DProj(uniform_sampler1DShadow, vec4(coord))
         && vec4(0) == shadow1DProj(uniform_sampler1DShadow, vec4(coord), float(0))
-        && (vec4(0) == shadow2DProj(uniform_sampler2DShadow, vec4(coord)) || ignoreResult)
-        && (vec4(0) == shadow2DProj(uniform_sampler2DShadow, vec4(coord), float(0)) || ignoreResult)
+        && (vec4(0) == shadow2DProj(uniform_sampler2DShadow, vec4(coord)) || ignoreResultF32)
+        && (vec4(0) == shadow2DProj(uniform_sampler2DShadow, vec4(coord), float(0)) || ignoreResultF32)
         && vec4(0) == shadow1DLod(uniform_sampler1DShadow, vec3(coord), float(0))
-        && (vec4(0) == shadow2DLod(uniform_sampler2DShadow, vec3(coord), float(0)) || ignoreResult)
+        && (vec4(0) == shadow2DLod(uniform_sampler2DShadow, vec3(coord), float(0)) || ignoreResultF32)
         && vec4(0) == shadow1DProjLod(uniform_sampler1DShadow, vec4(coord), float(0))
-        && (vec4(0) == shadow2DProjLod(uniform_sampler2DShadow, vec4(coord), float(0)) || ignoreResult)
+        && (vec4(0) == shadow2DProjLod(uniform_sampler2DShadow, vec4(coord), float(0)) || ignoreResultF32)
         ;
 }
 

--- a/tests/glsl-intrinsic/intrinsic-texture.slang
+++ b/tests/glsl-intrinsic/intrinsic-texture.slang
@@ -1,5 +1,5 @@
-//TEST:SIMPLE(filecheck=HLSL): -allow-glsl -stage compute  -entry computeMain -target hlsl
-//TEST:SIMPLE(filecheck=HLSL): -allow-glsl -stage fragment -entry fragMain -target hlsl
+//TEST:SIMPLE(filecheck=HLSL): -allow-glsl -stage compute  -entry computeMain -target hlsl -DHLSL
+//TEST:SIMPLE(filecheck=HLSL): -allow-glsl -stage fragment -entry fragMain -target hlsl -DHLSL
 //TEST:SIMPLE(filecheck=GLSL): -allow-glsl -stage compute  -entry computeMain -target glsl
 //TEST:SIMPLE(filecheck=GLSL): -allow-glsl -stage fragment -entry fragMain -target glsl
 //TEST:SIMPLE(filecheck=SPIR): -allow-glsl -stage compute  -entry computeMain -target spirv
@@ -8,6 +8,9 @@
 //TEST:SIMPLE(filecheck=CUDA): -allow-glsl -stage fragment -entry fragMain -target cuda
 
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl -output-using-type
+
+// TODO: This test revealed a few problems for a path from GLSL to HLSL
+//T-EST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-dx12 -compute -entry computeMain -allow-glsl -use-dxil -output-using-type -profile cs_6_6 -xslang -DHLSL
 
 
 //TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
@@ -144,7 +147,7 @@ uniform usampler2DMS uniform_usampler2DMS;
 //TEST_INPUT: TextureSampler2D(size=4, content = zero, arrayLength = 2):name uniform_usampler2DMSArray
 uniform usampler2DMSArray uniform_usampler2DMSArray;
 
-__generic<T : __BuiltinFloatingPointType, let N : int>
+__generic<T : __BuiltinArithmeticType, let N:int>
 bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
     , Sampler2D<vector<T,N>> gsampler2D
     , Sampler2DRect<vector<T,N>> gsampler2DRect
@@ -1427,101 +1430,6 @@ bool textureFuncs( Sampler1D<vector<T,N>> gsampler1D
         ;
 }
 
-__generic<T : __BuiltinArithmeticType, let N : int>
-bool itextureFuncs(Sampler1D<vector<T, N>> gsampler1D
-    , Sampler2D<vector<T, N>> gsampler2D
-    , Sampler2DRect<vector<T, N>> gsampler2DRect
-    , Sampler3D<vector<T, N>> gsampler3D
-    , SamplerCube<vector<T, N>> gsamplerCube
-    , Sampler1DArray<vector<T, N>> gsampler1DArray
-    , Sampler2DArray<vector<T, N>> gsampler2DArray
-    , SamplerCubeArray<vector<T, N>> gsamplerCubeArray
-    , SamplerBuffer<vector<T, N>> gsamplerBuffer
-    , Sampler2DMS<vector<T, N>> gsampler2DMS
-    , Sampler2DMSArray<vector<T, N>> gsampler2DMSArray
-    , bool ignoreResult
-)
-{
-    // GLSL-LABEL: itextureFuncs_0
-    typealias gvec4 = vector<T, 4>;
-
-    constexpr ivec2 offset2D = ivec2(0);
-    constexpr ivec3 offset3D = ivec3(0);
-    constexpr ivec2 offsets[4] = { ivec2(0), ivec2(0), ivec2(0), ivec2(0) };
-
-    return true
-        // 8.9.1. Texture Query Functions
-        && int(4) == textureSize(gsampler1D, int(0))
-        && ivec2(4) == textureSize(gsampler2D, int(0))
-        && ivec3(4) == textureSize(gsampler3D, int(0))
-        && ivec2(4) == textureSize(gsamplerCube, int(0))
-        && int(4) == textureSize(uniform_sampler1DShadow, int(0))
-        && (ivec2(4) == textureSize(uniform_sampler2DShadow, int(0)) || ignoreResult)
-        && (ivec2(4) == textureSize(uniform_samplerCubeShadow, int(0)) || ignoreResult)
-        && (ivec3(4,4,2) == textureSize(gsamplerCubeArray, int(0)) || ignoreResult)
-        && ivec3(4,4,2) == textureSize(uniform_samplerCubeArrayShadow, int(0))
-        && ivec2(4) == textureSize(gsampler2DRect)
-        && ivec2(4) == textureSize(uniform_sampler2DRectShadow)
-        && (ivec2(4,2) == textureSize(gsampler1DArray, int(0)) || ignoreResult)
-        && (ivec2(4,2) == textureSize(uniform_sampler1DArrayShadow, int(0)) || ignoreResult)
-        && (ivec3(4,4,2) == textureSize(gsampler2DArray, int(0)) || ignoreResult)
-        && ivec3(4,4,2) == textureSize(uniform_sampler2DArrayShadow, int(0))
-        && (int(4) == textureSize(gsamplerBuffer) || ignoreResult)
-        && ivec2(4) == textureSize(gsampler2DMS)
-        && ivec3(4,4,2) == textureSize(gsampler2DMSArray)
-        && gvec4(T(0)) == texelFetch(gsampler1D, int(0), int(0))
-        && gvec4(T(0)) == texelFetch(gsampler2D, ivec2(0), int(0))
-        && gvec4(T(0)) == texelFetch(gsampler3D, ivec3(0), int(0))
-        && gvec4(T(0)) == texelFetch(gsampler2DRect, ivec2(0))
-        && gvec4(T(0)) == texelFetch(gsampler1DArray, ivec2(0), int(0))
-        && gvec4(T(0)) == texelFetch(gsampler2DArray, ivec3(0), int(0))
-        && gvec4(T(0)) == texelFetch(gsamplerBuffer, int(0))
-        && gvec4(T(0)) == texelFetch(gsampler2DMS, ivec2(0), int(0))
-        && gvec4(T(0)) == texelFetch(gsampler2DMSArray, ivec3(0), int(0))
-        && gvec4(T(0)) == texelFetchOffset(gsampler1D, int(0), int(0), 0)
-        && gvec4(T(0)) == texelFetchOffset(gsampler2D, ivec2(0), int(0), offset2D)
-        && gvec4(T(0)) == texelFetchOffset(gsampler3D, ivec3(0), int(0), offset3D)
-        && gvec4(T(0)) == texelFetchOffset(gsampler2DRect, ivec2(0), offset2D)
-        && gvec4(T(0)) == texelFetchOffset(gsampler1DArray, ivec2(0), int(0), int(0))
-        && gvec4(T(0)) == texelFetchOffset(gsampler2DArray, ivec3(0), int(0), offset2D)
-
-        // 8.9.4. Texture Gather Functions
-        && gvec4(T(0)) == textureGather(gsampler2D, vec2(0))
-        && gvec4(T(0)) == textureGather(gsampler2D, vec2(0), int(0))
-        && gvec4(T(0)) == textureGather(gsampler2DArray, vec3(0))
-        && gvec4(T(0)) == textureGather(gsampler2DArray, vec3(0), int(0))
-        && gvec4(T(0)) == textureGather(gsamplerCube, vec3(0))
-        && gvec4(T(0)) == textureGather(gsamplerCube, vec3(0), int(0))
-        && gvec4(T(0)) == textureGather(gsamplerCubeArray, vec4(0))
-        && gvec4(T(0)) == textureGather(gsamplerCubeArray, vec4(0), int(0))
-        && gvec4(T(0)) == textureGather(gsampler2DRect, vec2(0))
-        && gvec4(T(0)) == textureGather(gsampler2DRect, vec2(0), int(0))
-        && vec4(0) == textureGather(uniform_sampler2DShadow, vec2(0), float(0))
-        && vec4(0) == textureGather(uniform_sampler2DArrayShadow, vec3(0), float(0))
-        && vec4(0) == textureGather(uniform_samplerCubeShadow, vec3(0), float(0))
-        && vec4(0) == textureGather(uniform_samplerCubeArrayShadow, vec4(0), float(0))
-        && vec4(0) == textureGather(uniform_sampler2DRectShadow, vec2(0), float(0))
-        && gvec4(T(0)) == textureGatherOffset(gsampler2D, vec2(0), offset2D)
-        && gvec4(T(0)) == textureGatherOffset(gsampler2D, vec2(0), offset2D, int(0))
-        && gvec4(T(0)) == textureGatherOffset(gsampler2DArray, vec3(0), offset2D)
-        && gvec4(T(0)) == textureGatherOffset(gsampler2DArray, vec3(0), offset2D, int(0))
-        && vec4(0) == textureGatherOffset(uniform_sampler2DShadow, vec2(0), float(0), offset2D)
-        && vec4(0) == textureGatherOffset(uniform_sampler2DArrayShadow, vec3(0), float(0), offset2D)
-        && gvec4(T(0)) == textureGatherOffset(gsampler2DRect, vec2(0), offset2D)
-        && gvec4(T(0)) == textureGatherOffset(gsampler2DRect, vec2(0), offset2D, int(0))
-        && vec4(0) == textureGatherOffset(uniform_sampler2DRectShadow, vec2(0), float(0), offset2D)
-        && gvec4(T(0)) == textureGatherOffsets(gsampler2D, vec2(0), offsets)
-        && gvec4(T(0)) == textureGatherOffsets(gsampler2D, vec2(0), offsets, int(0))
-        && gvec4(T(0)) == textureGatherOffsets(gsampler2DArray, vec3(0), offsets)
-        && gvec4(T(0)) == textureGatherOffsets(gsampler2DArray, vec3(0), offsets, int(0))
-        && vec4(0) == textureGatherOffsets(uniform_sampler2DShadow, vec2(0), float(0), offsets)
-        && vec4(0) == textureGatherOffsets(uniform_sampler2DArrayShadow, vec3(0), float(0), offsets)
-        && gvec4(T(0)) == textureGatherOffsets(gsampler2DRect, vec2(0), offsets)
-        && gvec4(T(0)) == textureGatherOffsets(gsampler2DRect, vec2(0), offsets, int(0))
-        && vec4(0) == textureGatherOffsets(uniform_sampler2DRectShadow, vec2(0), float(0), offsets)
-        ;
-}
-
 [require(cpp_cuda_glsl_hlsl_spirv,compute,fragment)]
 __extern_cpp void TEST_main()
 {
@@ -1553,7 +1461,8 @@ __extern_cpp void TEST_main()
             , uniform_sampler2DMSArray
             , ignoreResult
             )
-        && itextureFuncs(
+#if !defined(HLSL)
+        && textureFuncs(
             uniform_isampler1D
             , uniform_isampler2D
             , uniform_isampler2DRect
@@ -1567,7 +1476,7 @@ __extern_cpp void TEST_main()
             , uniform_isampler2DMSArray
             , ignoreResult
             )
-        && itextureFuncs(
+        && textureFuncs(
             uniform_usampler1D
             , uniform_usampler2D
             , uniform_usampler2DRect
@@ -1581,6 +1490,7 @@ __extern_cpp void TEST_main()
             , uniform_usampler2DMSArray
             , ignoreResult
             )
+#endif
         ;
 
     outputBuffer.result = int(result);


### PR DESCRIPTION
Closes #4196

This commit re-enables the ability to sample from an integer typed texture for GLSL functions while keeping it unavailable for HLSL target.

The type constrains for the GLSL texture functions are changed from __BuiltinFloatingPointType to __BuiltinArithmeticType, which may cause a trouble if the user shader implemented based on __BuiltinFloatingPointType.