### PR TITLE
Metal: Support and test integer type textures

### DIFF
--- a/source/slang/slang-emit-metal.cpp
+++ b/source/slang/slang-emit-metal.cpp
@@ -552,13 +552,17 @@ void MetalSourceEmitter::emitSimpleTypeImpl(IRType* type)
         case kIROp_UInt64Type:
         case kIROp_FloatType:
         case kIROp_DoubleType:
-        case kIROp_Int16Type:
-        case kIROp_UInt16Type:
         case kIROp_HalfType:
         {
             m_writer->emit(getDefaultBuiltinTypeName(type->getOp()));
             return;
         }
+        case kIROp_Int16Type:
+            m_writer->emit("short");
+            return;
+        case kIROp_UInt16Type:
+            m_writer->emit("ushort");
+            return;
         case kIROp_IntPtrType:
             m_writer->emit("int64_t");
             return;

--- a/tests/metal/byte-address-buffer.slang
+++ b/tests/metal/byte-address-buffer.slang
@@ -22,9 +22,9 @@ void main_kernel(uint3 tid: SV_DispatchThreadID)
     // CHECK: uint [[WORD0:[a-zA-Z0-9_]+]] = as_type<uint>({{.*}}[(int(0))>>2]);
     // CHECK: uint8_t [[A:[a-zA-Z0-9_]+]] = uint8_t([[WORD0]] >> int(0) & 255U);
     // CHECK: uint [[WORD1:[a-zA-Z0-9_]+]] = as_type<uint>({{.*}}[(int(0))>>2]);
-    // CHECK: half [[H:[a-zA-Z0-9_]+]] = as_type<half>(uint16_t([[WORD1]] >> int(16) & 65535U));
+    // CHECK: half [[H:[a-zA-Z0-9_]+]] = as_type<half>(ushort([[WORD1]] >> int(16) & 65535U));
 
     // CHECK: {{.*}}[(int(128))>>2] = as_type<uint32_t>(({{.*}} & 4294967040U) | uint([[A]]) << int(0));
-    // CHECK: {{.*}}[(int(128))>>2] = as_type<uint32_t>(({{.*}} & 65535U) | uint(as_type<uint16_t>([[H]])) << int(16));
+    // CHECK: {{.*}}[(int(128))>>2] = as_type<uint32_t>(({{.*}} & 65535U) | uint(as_type<ushort>([[H]])) << int(16));
     buffer.Store(128, buffer.Load<TestStruct>(0));
 }

--- a/tests/metal/texture.slang
+++ b/tests/metal/texture.slang
@@ -1,32 +1,109 @@
-//TEST:SIMPLE(filecheck=METAL_CAPS_ERROR): -stage compute -entry computeMain -target metal -DEMIT_SOURCE -DNEED_TO_TEST_FOR_METAL_CAPABILITY
-//TEST:SIMPLE(filecheck=METAL): -stage compute -entry computeMain -target metal -DEMIT_SOURCE
-//TEST:SIMPLE(filecheck=METALLIB): -stage compute -entry computeMain -target metallib -DEMIT_SOURCE -DMETALLIB
-//TEST:SIMPLE(filecheck=HLSL): -stage compute -entry computeMain -target hlsl -DEMIT_SOURCE
-//TEST:SIMPLE(filecheck=SPIR): -stage compute -entry computeMain -target spirv -emit-spirv-directly -DEMIT_SOURCE
+//TEST:SIMPLE(filecheck=METAL): -stage compute -entry computeMain -target metal
+//TEST:SIMPLE(filecheck=METALLIB): -stage compute -entry computeMain -target metallib
+//TEST:SIMPLE(filecheck=HLSL): -stage compute -entry computeMain -target hlsl -DEXCLUDE_INTEGER_TYPE
+//TEST:SIMPLE(filecheck=SPIR): -stage compute -entry computeMain -target spirv -emit-spirv-directly -DEXCLUDE_HALF_TYPE -DEXCLUDE_SHORT_TYPE
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=FUNCTIONAL):-slang -compute -dx12 -profile cs_6_6 -use-dxil -shaderobj -output-using-type
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=FUNCTIONAL):-vk -emit-spirv-directly -compute -shaderobj -output-using-type -render-feature hardware-device -xslang -DEXCLUDE_DEPTH_TEXTURE
-
-// METAL_CAPS_ERROR: error 36107
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=FUNCTIONAL):-slang -compute -dx12 -profile cs_6_6 -use-dxil -shaderobj -output-using-type -xslang -DEXCLUDE_INTEGER_TYPE
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=FUNCTIONAL):-vk -emit-spirv-directly -compute -shaderobj -output-using-type -render-feature hardware-device -xslang -DEXCLUDE_HALF_TYPE -xslang -DEXCLUDE_SHORT_TYPE
 
 //TEST_INPUT: ubuffer(data=[0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
-//TEST_INPUT: Texture1D(size=4, content = one):name t1D
-Texture1D<float> t1D;
-//TEST_INPUT: Texture2D(size=4, content = one):name t2D
-Texture2D<float> t2D;
-//TEST_INPUT: Texture3D(size=4, content = one):name t3D
-Texture3D<float> t3D;
-//TEST_INPUT: TextureCube(size=4, content = one):name tCube
-TextureCube<float> tCube;
+//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_f32
+Texture1D<float4> t1D_f32;
+//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_f32
+Texture2D<float4> t2D_f32;
+//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_f32
+Texture3D<float4> t3D_f32;
+//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_f32
+TextureCube<float4> tCube_f32;
 
-//TEST_INPUT: Texture1D(size=4, content = one, arrayLength=2):name t1DArray
-Texture1DArray<float> t1DArray;
-//TEST_INPUT: Texture2D(size=4, content = one, arrayLength=2):name t2DArray
-Texture2DArray<float> t2DArray;
-//TEST_INPUT: TextureCube(size=4, content = one, arrayLength=2):name tCubeArray
-TextureCubeArray<float> tCubeArray;
+//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_f32
+Texture1DArray<float4> t1DArray_f32;
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_f32
+Texture2DArray<float4> t2DArray_f32;
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_f32
+TextureCubeArray<float4> tCubeArray_f32;
+
+//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_f16
+Texture1D<half4> t1D_f16;
+//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_f16
+Texture2D<half4> t2D_f16;
+//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_f16
+Texture3D<half4> t3D_f16;
+//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_f16
+TextureCube<half4> tCube_f16;
+
+//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_f16
+Texture1DArray<half4> t1DArray_f16;
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_f16
+Texture2DArray<half4> t2DArray_f16;
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_f16
+TextureCubeArray<half4> tCubeArray_f16;
+
+//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_i32
+Texture1D<int4> t1D_i32;
+//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_i32
+Texture2D<int4> t2D_i32;
+//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_i32
+Texture3D<int4> t3D_i32;
+//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_i32
+TextureCube<int4> tCube_i32;
+
+//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_i32
+Texture1DArray<int4> t1DArray_i32;
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_i32
+Texture2DArray<int4> t2DArray_i32;
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_i32
+TextureCubeArray<int4> tCubeArray_i32;
+
+//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_u32
+Texture1D<uint4> t1D_u32;
+//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_u32
+Texture2D<uint4> t2D_u32;
+//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_u32
+Texture3D<uint4> t3D_u32;
+//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_u32
+TextureCube<uint4> tCube_u32;
+
+//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_u32
+Texture1DArray<uint4> t1DArray_u32;
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_u32
+Texture2DArray<uint4> t2DArray_u32;
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_u32
+TextureCubeArray<uint4> tCubeArray_u32;
+
+//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_i16
+Texture1D<int16_t4> t1D_i16;
+//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_i16
+Texture2D<int16_t4> t2D_i16;
+//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_i16
+Texture3D<int16_t4> t3D_i16;
+//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_i16
+TextureCube<int16_t4> tCube_i16;
+
+//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_i16
+Texture1DArray<int16_t4> t1DArray_i16;
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_i16
+Texture2DArray<int16_t4> t2DArray_i16;
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_i16
+TextureCubeArray<int16_t4> tCubeArray_i16;
+
+//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_u16
+Texture1D<uint16_t4> t1D_u16;
+//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_u16
+Texture2D<uint16_t4> t2D_u16;
+//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_u16
+Texture3D<uint16_t4> t3D_u16;
+//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_u16
+TextureCube<uint16_t4> tCube_u16;
+
+//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_u16
+Texture1DArray<uint16_t4> t1DArray_u16;
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_u16
+Texture2DArray<uint16_t4> t2DArray_u16;
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_u16
+TextureCubeArray<uint16_t4> tCubeArray_u16;
 
 // Metal doc says "For depth texture types, T must be float."
 __generic<T : __BuiltinType, let sampleCount:int=0, let format:int=0>
@@ -81,13 +158,13 @@ typealias depthcube_array = __TextureImpl<
     format
 >;
 
-//TEST_INPUT: Texture2D(size=4, content = one):name d2D
+//TEST_INPUT: Texture2D(size=4, content = zero):name d2D
 depth2d<float> d2D;
-//TEST_INPUT: TextureCube(size=4, content = one):name dCube
+//TEST_INPUT: TextureCube(size=4, content = zero):name dCube
 depthcube<float> dCube;
-//TEST_INPUT: Texture2D(size=4, content = one, arrayLength=2):name d2DArray
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name d2DArray
 depth2d_array<float> d2DArray;
-//TEST_INPUT: TextureCube(size=4, content = one, arrayLength=2):name dCubeArray
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name dCubeArray
 depthcube_array<float> dCubeArray;
 
 //TEST_INPUT: Sampler:name samplerState
@@ -96,17 +173,19 @@ SamplerState samplerState;
 SamplerComparisonState shadowSampler;
 
 
-bool TEST_texture_float()
+__generic<T:__BuiltinArithmeticType>
+bool TEST_texture(
+    Texture1D<vector<T,4>> t1D,
+    Texture2D<vector<T,4>> t2D,
+    Texture3D<vector<T,4>> t3D,
+    TextureCube<vector<T,4>> tCube,
+    Texture1DArray<vector<T,4>> t1DArray,
+    Texture2DArray<vector<T,4>> t2DArray,
+    TextureCubeArray<vector<T,4>> tCubeArray
+)
 {
-    // Metal textures support `Tv` types, which "denotes a 4-component vector
-    // type based on the templated type <T> for declaring the texture type:
-    //  - If T is float, Tv is float4.
-    //  - If T is half, Tv is half4.
-    //  - If T is int, Tv is int4.
-    //  - If T is uint, Tv is uint4.
-    //  - If T is short, Tv is short4.
-    //  - If T is ushort, Tv is ushort4."
-    typealias Tv = vector<float,4>;
+    // METAL-LABEL: TEST_texture
+    typealias Tv = vector<T,4>;
 
     float u = 0;
     float u2 = 0.5;
@@ -224,10 +303,7 @@ bool TEST_texture_float()
         // float CalculateLevelOfDetail()
         // ===============================
 
-#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
         // Metal doesn't support LOD for 1D texture
-        && float(0) == t1D.CalculateLevelOfDetail(samplerState, u)
-#endif
 
         // METAL: t2D{{.*}}.calculate_clamped_lod({{.*}}
         // METALLIB: call {{.*}}.calculate_clamped_lod_texture_2d(
@@ -253,10 +329,7 @@ bool TEST_texture_float()
         // float CalculateLevelOfDetailUnclamped()
         // ========================================
 
-#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
         // Metal doesn't support LOD for 1D texture
-        && float(0) >= t1D.CalculateLevelOfDetailUnclamped(samplerState, u)
-#endif
 
         // METAL: t2D{{.*}}.calculate_unclamped_lod({{.*}}
         // METALLIB: call {{.*}}.calculate_unclamped_lod_texture_2d(
@@ -284,197 +357,173 @@ bool TEST_texture_float()
 
         // METAL: t1D{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_1d.v4f32(
-        && all(Tv(1) == t1D.Sample(samplerState, u))
+        && all(Tv(T(0)) == t1D.Sample(samplerState, u))
 
         // METAL: t2D{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
-        && all(Tv(1) == t2D.Sample(samplerState, float2(u, u)))
+        && all(Tv(T(0)) == t2D.Sample(samplerState, float2(u, u)))
 
         // METAL: t3D{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
-        && all(Tv(1) == t3D.Sample(samplerState, float3(u, u, u)))
+        && all(Tv(T(0)) == t3D.Sample(samplerState, float3(u, u, u)))
 
         // METAL: tCube{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_cube.v4f32(
-        && all(Tv(1) == tCube.Sample(samplerState, normalize(float3(u, 1 - u, u))))
+        && all(Tv(T(0)) == tCube.Sample(samplerState, normalize(float3(u, 1 - u, u))))
 
         // METAL: t1DArray{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_1d_array.v4f32(
-        && all(Tv(1) == t1DArray.Sample(samplerState, float2(u, 0)))
+        && all(Tv(T(0)) == t1DArray.Sample(samplerState, float2(u, 0)))
 
         // METAL: t2DArray{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
-        && all(Tv(1) == t2DArray.Sample(samplerState, float3(u, u, 0)))
+        && all(Tv(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0)))
 
         // METAL: tCubeArray{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_cube_array.v4f32(
-        && all(Tv(1) == tCubeArray.Sample(samplerState, float4(normalize(float3(u, 1 - u, u)), 0)))
+        && all(Tv(T(0)) == tCubeArray.Sample(samplerState, float4(normalize(float3(u, 1 - u, u)), 0)))
 
         // Offset variant
 
-#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
         // Metal doesn't support Offset for 1D and Cube texture
-        && all(Tv(1) == t1D.Sample(samplerState, u2, 1))
-        && all(Tv(1) == t1DArray.Sample(samplerState, float2(u2, 0), 1))
-#endif
 
         // METAL: t2D{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
-        && all(Tv(1) == t2D.Sample(samplerState, float2(u, u), int2(1, 1)))
+        && all(Tv(T(0)) == t2D.Sample(samplerState, float2(u, u), int2(1, 1)))
 
         // METAL: t3D{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
-        && all(Tv(1) == t3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1)))
+        && all(Tv(T(0)) == t3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1)))
 
         // METAL: t2DArray{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
-        && all(Tv(1) == t2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1)))
+        && all(Tv(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1)))
 
         // Clamp variant
 
-#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
         // Metal doesn't support Offset for 1D and Cube texture
-        && all(Tv(1) == t1D.Sample(samplerState, u2, 1, float(1)))
-        && all(Tv(1) == t1DArray.Sample(samplerState, float2(u2, 0), 1, float(1)))
-#endif
 
         // METAL: t2D{{.*}}.sample({{.*}} min_lod_clamp(
         // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
-        && all(Tv(1) == t2D.Sample(samplerState, float2(u, u), int2(1, 1), float(1)))
+        && all(Tv(T(0)) == t2D.Sample(samplerState, float2(u, u), int2(1, 1), float(1)))
 
         // METAL: t3D{{.*}}.sample({{.*}} min_lod_clamp(
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
-        && all(Tv(1) == t3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1), float(1)))
+        && all(Tv(T(0)) == t3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1), float(1)))
 
         // METAL: t2DArray{{.*}}.sample({{.*}} min_lod_clamp(
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
-        && all(Tv(1) == t2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1), float(1)))
+        && all(Tv(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1), float(1)))
 
         // ===============
         // T SampleBias()
         // ===============
 
-#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
         // Metal doesn't support Bias for 1D texture
-        && all(Tv(1) == t1D.SampleBias(samplerState, u, float(-1)))
-        && all(Tv(1) == t1DArray.SampleBias(samplerState, float2(u, 0), float(-1)))
-#endif
 
         // METAL: t2D{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
-        && all(Tv(1) == t2D.SampleBias(samplerState, float2(u, u), float(-1)))
+        && all(Tv(T(0)) == t2D.SampleBias(samplerState, float2(u, u), float(-1)))
 
         // METAL: t3D{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
-        && all(Tv(1) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1)))
+        && all(Tv(T(0)) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1)))
 
         // METAL: tCube{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_cube.v4f32(
-        && all(Tv(1) == tCube.SampleBias(samplerState, normalize(float3(u, 1 - u, u)), float(-1)))
+        && all(Tv(T(0)) == tCube.SampleBias(samplerState, normalize(float3(u, 1 - u, u)), float(-1)))
 
         // METAL: t2DArray{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
-        && all(Tv(1) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1)))
+        && all(Tv(T(0)) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1)))
 
         // METAL: tCubeArray{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_cube_array.v4f32(
-        && all(Tv(1) == tCubeArray.SampleBias(samplerState, float4(normalize(float3(u, 1 - u, u)), 0), float(-1)))
+        && all(Tv(T(0)) == tCubeArray.SampleBias(samplerState, float4(normalize(float3(u, 1 - u, u)), 0), float(-1)))
 
         // Offset variant
 
-#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
         // Metal doesn't support Offset for 1D and Cube texture
-        && all(Tv(1) == t1D.SampleBias(samplerState, u2, float(-1), 1))
-        && all(Tv(1) == t1DArray.SampleBias(samplerState, float2(u2, 0), float(-1), 1))
-#endif
 
         // METAL: t2D{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
-        && all(Tv(1) == t2D.SampleBias(samplerState, float2(u, u), float(-1), int2(1, 1)))
+        && all(Tv(T(0)) == t2D.SampleBias(samplerState, float2(u, u), float(-1), int2(1, 1)))
 
         // METAL: t3D{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
-        && all(Tv(1) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1), int3(1, 1, 1)))
+        && all(Tv(T(0)) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1), int3(1, 1, 1)))
 
         // METAL: t2DArray{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
-        && all(Tv(1) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1), int2(1, 1)))
+        && all(Tv(T(0)) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1), int2(1, 1)))
 
         // ===================================
         //  T SampleLevel()
         // ===================================
 
-#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
         // Metal doesn't support LOD for 1D texture
-        && all(Tv(1) == t1D.SampleLevel(samplerState, u, 0))
-        && all(Tv(1) == t1DArray.SampleLevel(samplerState, float2(u, 0), 0))
-#endif
 
         // METAL: t2D{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
-        && all(Tv(1) == t2D.SampleLevel(samplerState, float2(u, u), 0))
+        && all(Tv(T(0)) == t2D.SampleLevel(samplerState, float2(u, u), 0))
 
         // METAL: t3D{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
-        && all(Tv(1) == t3D.SampleLevel(samplerState, float3(u, u, u), 0))
+        && all(Tv(T(0)) == t3D.SampleLevel(samplerState, float3(u, u, u), 0))
 
         // METAL: tCube{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_cube.v4f32(
-        && all(Tv(1) == tCube.SampleLevel(samplerState, normalize(float3(u, 1 - u, u)), 0))
+        && all(Tv(T(0)) == tCube.SampleLevel(samplerState, normalize(float3(u, 1 - u, u)), 0))
 
         // METAL: t2DArray{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
-        && all(Tv(1) == t2DArray.SampleLevel(samplerState, float3(u, u, 0), 0))
+        && all(Tv(T(0)) == t2DArray.SampleLevel(samplerState, float3(u, u, 0), 0))
 
         // METAL: tCubeArray{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_cube_array.v4f32(
-        && all(Tv(1) == tCubeArray.SampleLevel(samplerState, float4(normalize(float3(u, 1 - u, u)), 0), 0))
+        && all(Tv(T(0)) == tCubeArray.SampleLevel(samplerState, float4(normalize(float3(u, 1 - u, u)), 0), 0))
 
         // Offset variant
 
-#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
         // Metal doesn't support LOD for 1D texture
-        && all(Tv(1) == t1D.SampleLevel(samplerState, u2, 0, 1))
-        && all(Tv(1) == t1DArray.SampleLevel(samplerState, float2(u2, 0), 0, 1))
-#endif
 
         // METAL: t2D{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
-        && all(Tv(1) == t2D.SampleLevel(samplerState, float2(u, u), 0, int2(1, 1)))
+        && all(Tv(T(0)) == t2D.SampleLevel(samplerState, float2(u, u), 0, int2(1, 1)))
 
         // METAL: t3D{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
-        && all(Tv(1) == t3D.SampleLevel(samplerState, float3(u, u, u), 0, int3(1, 1, 1)))
+        && all(Tv(T(0)) == t3D.SampleLevel(samplerState, float3(u, u, u), 0, int3(1, 1, 1)))
 
         // METAL: t2DArray{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
-        && all(Tv(1) == t2DArray.SampleLevel(samplerState, float3(u, u, 0), 0, int2(1, 1)))
+        && all(Tv(T(0)) == t2DArray.SampleLevel(samplerState, float3(u, u, 0), 0, int2(1, 1)))
 
-#ifndef EXCLUDE_DEPTH_TEXTURE // Our vulkan backend don't support SampleCmp from a rgb texture.
         // ==================
         // float SampleCmp()
         // ==================
+
         // METAL: d2D{{.*}}.sample_compare(
         // METALLIB: call {{.*}}.sample_compare_depth_2d.f32(
-        && float(1) == d2D.SampleCmp(shadowSampler, float2(u, u), 0)
+        && float(0) == d2D.SampleCmp(shadowSampler, float2(u, u), 0)
 
         // METAL: d2DArray{{.*}}.sample_compare(
         // METALLIB: call {{.*}}.sample_compare_depth_2d_array.f32(
-        && float(1) == d2DArray.SampleCmp(shadowSampler, float3(u, u, 0), 0)
+        && float(0) == d2DArray.SampleCmp(shadowSampler, float3(u, u, 0), 0)
 
         // METAL: dCube{{.*}}.sample_compare(
         // METALLIB: call {{.*}}.sample_compare_depth_cube.f32(
-        && float(1) == dCube.SampleCmp(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
+        && float(0) == dCube.SampleCmp(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
 
         // METAL: dCubeArray{{.*}}.sample_compare(
         // METALLIB: call {{.*}}.sample_compare_depth_cube_array.f32(
-        && float(1) == dCubeArray.SampleCmp(shadowSampler, float4(normalize(float3(u, 1 - u, u)), 0), 0)
+        && float(0) == dCubeArray.SampleCmp(shadowSampler, float4(normalize(float3(u, 1 - u, u)), 0), 0)
 
         // Offset variant
 
         // METAL: d2D{{.*}}.sample_compare(
         // METALLIB: call {{.*}}.sample_compare_depth_2d.f32(
-        && float(1) == d2D.SampleCmp(shadowSampler, float2(u2, u), 0, int2(0, 0))
+        && float(0) == d2D.SampleCmp(shadowSampler, float2(u2, u), 0, int2(0, 0))
 
         // ===================================
         //  float SampleCmpLevelZero()
@@ -482,97 +531,91 @@ bool TEST_texture_float()
 
         // METAL: d2D{{.*}}.sample_compare(
         // METALLIB: call {{.*}}.sample_compare_depth_2d.f32(
-        && float(1) == d2D.SampleCmpLevelZero(shadowSampler, float2(u, u), 0)
+        && float(0) == d2D.SampleCmpLevelZero(shadowSampler, float2(u, u), 0)
 
         // METAL: d2DArray{{.*}}.sample_compare(
         // METALLIB: call {{.*}}.sample_compare_depth_2d_array.f32(
-        && float(1) == d2DArray.SampleCmpLevelZero(shadowSampler, float3(u, u, 0), 0)
+        && float(0) == d2DArray.SampleCmpLevelZero(shadowSampler, float3(u, u, 0), 0)
 
         // METAL: dCube{{.*}}.sample_compare(
         // METALLIB: call {{.*}}.sample_compare_depth_cube.f32(
-        && float(1) == dCube.SampleCmpLevelZero(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
+        && float(0) == dCube.SampleCmpLevelZero(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
 
         // METAL: dCubeArray{{.*}}.sample_compare(
         // METALLIB: call {{.*}}.sample_compare_depth_cube_array.f32(
-        && float(1) == dCubeArray.SampleCmpLevelZero(shadowSampler, float4(normalize(float3(u, 1-u, u)), 0), 0)
+        && float(0) == dCubeArray.SampleCmpLevelZero(shadowSampler, float4(normalize(float3(u, 1-u, u)), 0), 0)
 
         // Offset variant
 
         // METAL: d2D{{.*}}.sample_compare(
         // METALLIB: call {{.*}}.sample_compare_depth_2d.f32(
-        && float(1) == d2D.SampleCmpLevelZero(shadowSampler, float2(u2, u), 0, int2(0, 0))
-#endif
+        && float(0) == d2D.SampleCmpLevelZero(shadowSampler, float2(u2, u), 0, int2(0, 0))
+
         // ==================================
         //  vector<T,4> Gather()
         // ==================================
 
         // METAL: t2D{{.*}}.gather(
         // METALLIB: call {{.*}}.gather_texture_2d.v4f32(
-        && all(Tv(1) == t2D.Gather(samplerState, float2(u, u)))
+        && all(Tv(T(0)) == t2D.Gather(samplerState, float2(u, u)))
 
         // METAL: tCube{{.*}}.gather(
         // METALLIB: call {{.*}}.gather_texture_cube.v4f32(
-        && all(Tv(1) == tCube.Gather(samplerState, normalize(float3(u, 1 - u, u))))
+        && all(Tv(T(0)) == tCube.Gather(samplerState, normalize(float3(u, 1 - u, u))))
 
         // METAL: t2DArray{{.*}}.gather(
         // METALLIB: call {{.*}}.gather_texture_2d_array.v4f32(
-        && all(Tv(1) == t2DArray.Gather(samplerState, float3(u, u, 0)))
+        && all(Tv(T(0)) == t2DArray.Gather(samplerState, float3(u, u, 0)))
 
         // METAL: tCubeArray{{.*}}.gather(
         // METALLIB: call {{.*}}.gather_texture_cube_array.v4f32(
-        && all(Tv(1) == tCubeArray.Gather(samplerState, float4(normalize(float3(u, 1 - u, u)), 0)))
+        && all(Tv(T(0)) == tCubeArray.Gather(samplerState, float4(normalize(float3(u, 1 - u, u)), 0)))
 
         // Offset variant
 
         // METAL: t2D{{.*}}.gather(
         // METALLIB: call {{.*}}.gather_texture_2d.v4f32(
-        && all(Tv(1) == t2D.Gather(samplerState, float2(u2, u), int2(0, 0)))
+        && all(Tv(T(0)) == t2D.Gather(samplerState, float2(u2, u), int2(0, 0)))
 
         // METAL: t2DArray{{.*}}.gather(
         // METALLIB: call {{.*}}.gather_texture_2d_array.v4f32(
-        && all(Tv(1) == t2DArray.Gather(samplerState, float3(u2, u, 0), int2(0, 0)))
+        && all(Tv(T(0)) == t2DArray.Gather(samplerState, float3(u2, u, 0), int2(0, 0)))
 
         // =====================================
         //  T SampleGrad()
         // =====================================
 
-#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
         // Metal doesn't support LOD for 1D texture
-        && all(Tv(1) == t1D.SampleGrad(samplerState, 0.0f, ddx, ddy))
-        && all(Tv(1) == t1DArray.SampleGrad(samplerState, float2(0.0f, 0.0f), ddx, ddy))
-        && all(Tv(1) == t1D.SampleGrad(samplerState, 0.0f, ddx, ddy, 0))
-        && all(Tv(1) == t1DArray.SampleGrad(samplerState, float2(0.0f, 0.0f), ddx, ddy, 0))
-#endif
 
         // METAL: t2D{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_2d_grad.v4f32(
-        && all(Tv(1) == t2D.SampleGrad(samplerState, float2(u, u), float2(ddx, ddx), float2(ddy, ddy)))
+        && all(Tv(T(0)) == t2D.SampleGrad(samplerState, float2(u, u), float2(ddx, ddx), float2(ddy, ddy)))
 
         // METAL: t3D{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_3d_grad.v4f32(
-        && all(Tv(1) == t3D.SampleGrad(samplerState, float3(u, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
+        && all(Tv(T(0)) == t3D.SampleGrad(samplerState, float3(u, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
 
         // METAL: tCube{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_cube_grad.v4f32(
-        && all(Tv(1) == tCube.SampleGrad(samplerState, normalize(float3(u, 1 - u, u)), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
+        && all(Tv(T(0)) == tCube.SampleGrad(samplerState, normalize(float3(u, 1 - u, u)), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
 
         // METAL: t2DArray{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_2d_array_grad.v4f32(
-        && all(Tv(1) == t2DArray.SampleGrad(samplerState, float3(u, u, 0.0f), float2(ddx, ddx), float2(ddy, ddy)))
+        && all(Tv(T(0)) == t2DArray.SampleGrad(samplerState, float3(u, u, 0.0f), float2(ddx, ddx), float2(ddy, ddy)))
 
         // Offset variant
 
         // METAL: t2D{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_2d_grad.v4f32(
-        && all(Tv(1) == t2D.SampleGrad(samplerState, float2(u2, u), float2(ddx, ddx), float2(ddy, ddy), int2(0, 0)))
+        && all(Tv(T(0)) == t2D.SampleGrad(samplerState, float2(u2, u), float2(ddx, ddx), float2(ddy, ddy), int2(0, 0)))
 
         // METAL: t3D{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_3d_grad.v4f32(
-        && all(Tv(1) == t3D.SampleGrad(samplerState, float3(u2, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy), int3(0, 0, 0)))
+        && all(Tv(T(0)) == t3D.SampleGrad(samplerState, float3(u2, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy), int3(0, 0, 0)))
 
         // METAL: t2DArray{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_2d_array_grad.v4f32(
-        && all(Tv(1) == t2DArray.SampleGrad(samplerState, float3(u2, u, 0.0f), float2(ddx, ddx), float2(ddy, ddy), int2(0, 0)))
+        && all(Tv(T(0)) == t2DArray.SampleGrad(samplerState, float3(u2, u, 0.0f), float2(ddx, ddx), float2(ddy, ddy), int2(0, 0)))
 
         // ===================
         //  T Load()
@@ -580,39 +623,31 @@ bool TEST_texture_float()
 
         // METAL: t1D{{.*}}.read(
         // METALLIB: call {{.*}}.read_texture_1d.v4f32(
-        && all(Tv(1) == t1D.Load(int2(0, 0)))
+        && all(Tv(T(0)) == t1D.Load(int2(0, 0)))
 
         // METAL: t2D{{.*}}.read(
         // METALLIB: call {{.*}}.read_texture_2d.v4f32(
-        && all(Tv(1) == t2D.Load(int3(0, 0, 0)))
+        && all(Tv(T(0)) == t2D.Load(int3(0, 0, 0)))
 
         // METAL: t3D{{.*}}.read(
         // METALLIB: call {{.*}}.read_texture_3d.v4f32(
-        && all(Tv(1) == t3D.Load(int4(0, 0, 0, 0)))
+        && all(Tv(T(0)) == t3D.Load(int4(0, 0, 0, 0)))
 
         // METAL: t1DArray{{.*}}.read(
         // METALLIB: call {{.*}}.read_texture_1d_array.v4f32(
-        && all(Tv(1) == t1DArray.Load(int3(0, 0, 0)))
+        && all(Tv(T(0)) == t1DArray.Load(int3(0, 0, 0)))
 
         // METAL: t2DArray{{.*}}.read(
         // METALLIB: call {{.*}}.read_texture_2d_array.v4f32(
-        && all(Tv(1) == t2DArray.Load(int4(0, 0, 0, 0)))
+        && all(Tv(T(0)) == t2DArray.Load(int4(0, 0, 0, 0)))
 
         // Offset variant
 
-#if defined(NEED_TO_TEST_FOR_METAL_CAPABILITY)
         // Metal doesn't support offset variants for Load
-        && all(Tv(1) == t1D.Load(int2(0, 0), 0))
-        && all(Tv(1) == t2D.Load(int3(0, 0, 0), int2(0,0)))
-        && all(Tv(1) == t3D.Load(int4(0, 0, 0, 0), int3(0, 0, 0)))
-        && all(Tv(1) == t1DArray.Load(int3(0, 0, 0), 0))
-        && all(Tv(1) == t2DArray.Load(int4(0, 0, 0, 0), int2(0, 0)))
-#endif
         ;
 
     return result;
 }
-
 
 [numthreads(1, 1, 1)]
 void computeMain()
@@ -621,7 +656,68 @@ void computeMain()
     // HLSL: void computeMain(
 
     bool result = true
-        && TEST_texture_float()
+        // Metal textures support `Tv` types, which "denotes a 4-component vector
+        // type based on the templated type <T> for declaring the texture type:
+        //  - If T is float, Tv is float4.
+        //  - If T is half, Tv is half4.
+        //  - If T is int, Tv is int4.
+        //  - If T is uint, Tv is uint4.
+        //  - If T is short, Tv is short4.
+        //  - If T is ushort, Tv is ushort4."
+        && TEST_texture<float>(
+            t1D_f32,
+            t2D_f32,
+            t3D_f32,
+            tCube_f32,
+            t1DArray_f32,
+            t2DArray_f32,
+            tCubeArray_f32)
+#if !defined(EXCLUDE_HALF_TYPE)
+        && TEST_texture<half>(
+            t1D_f16,
+            t2D_f16,
+            t3D_f16,
+            tCube_f16,
+            t1DArray_f16,
+            t2DArray_f16,
+            tCubeArray_f16)
+#endif
+#if !defined(EXCLUDE_INTEGER_TYPE)
+        && TEST_texture<int>(
+            t1D_i32,
+            t2D_i32,
+            t3D_i32,
+            tCube_i32,
+            t1DArray_i32,
+            t2DArray_i32,
+            tCubeArray_i32)
+        && TEST_texture<uint>(
+            t1D_u32,
+            t2D_u32,
+            t3D_u32,
+            tCube_u32,
+            t1DArray_u32,
+            t2DArray_u32,
+            tCubeArray_u32)
+#if !defined(EXCLUDE_SHORT_TYPE)
+        && TEST_texture<int16_t>(
+            t1D_i16,
+            t2D_i16,
+            t3D_i16,
+            tCube_i16,
+            t1DArray_i16,
+            t2DArray_i16,
+            tCubeArray_i16)
+        && TEST_texture<uint16_t>(
+            t1D_u16,
+            t2D_u16,
+            t3D_u16,
+            tCube_u16,
+            t1DArray_u16,
+            t2DArray_u16,
+            tCubeArray_u16)
+#endif
+#endif
         ;
 
     // FUNCTIONAL: 1


### PR DESCRIPTION
This commit adds testing for Metal texture functions with the following six types that the document says supported:
 - float
 - half
 - int32_t
 - uint32_t
 - int16_t
 - uint16_t