### PR TITLE
Remove duplicate `VkPhysicalDeviceComputeShaderDerivativesFeaturesNV` extension structure in vk-api.h

### DIFF
--- a/tools/gfx/vulkan/vk-api.h
+++ b/tools/gfx/vulkan/vk-api.h
@@ -315,10 +315,6 @@ struct VulkanExtendedFeatureProperties
     VkPhysicalDeviceVulkan12Features vulkan12Features = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES
     };
-
-    VkPhysicalDeviceComputeShaderDerivativesFeaturesNV computeShaderDerivativesFeatures = {
-        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV
-    };
 };
 
 struct VulkanApi

--- a/tools/gfx/vulkan/vk-device.cpp
+++ b/tools/gfx/vulkan/vk-device.cpp
@@ -512,10 +512,6 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
         extendedFeatures.fragmentShadingRateFeatures.pNext = deviceFeatures2.pNext;
         deviceFeatures2.pNext = &extendedFeatures.fragmentShadingRateFeatures;
 
-        // Compute Quad Derivative features
-        extendedFeatures.computeShaderDerivativesFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.computeShaderDerivativesFeatures;
-
         if (VK_MAKE_VERSION(majorVersion, minorVersion, 0) >= VK_API_VERSION_1_2)
         {
             extendedFeatures.vulkan12Features.pNext = deviceFeatures2.pNext;
@@ -608,13 +604,6 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             extendedDynamicState,
             VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME,
             "extended-dynamic-states"
-        );
-
-        SIMPLE_EXTENSION_FEATURE(
-            extendedFeatures.computeShaderDerivativesFeatures,
-            computeDerivativeGroupQuads,
-            VK_NV_COMPUTE_SHADER_DERIVATIVES_EXTENSION_NAME,
-            "compute-shader-derivative"
         );
 
         if (extendedFeatures.accelerationStructureFeatures.accelerationStructure


### PR DESCRIPTION
This will be a source of a validation layer warning since 2 of the same extension is enabled.