### PR TITLE
SPIRV backend: add support for tessellation stages.

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -3691,13 +3691,30 @@ struct ConsumeStructuredBuffer
     }
 };
 
+__intrinsic_op($(kIROp_GetElement))
+T __getElement<T, U, I>(U collection, I index);
+
 __generic<T, let N : int>
 [require(glsl_hlsl_spirv, hull)]
 __magic_type(HLSLInputPatchType)
 __intrinsic_type($(kIROp_HLSLInputPatchType))
 struct InputPatch
 {
-    __subscript(uint index) -> T;
+    __generic<TIndex : __BuiltinIntegerType>
+    __subscript(TIndex index)->T
+    {
+        [__unsafeForceInlineEarly]
+        get
+        {
+            __target_switch
+            {
+            case hlsl:
+                __intrinsic_asm ".operator[]";
+            default:
+                return __getElement<T>(this, index);
+            }
+        }
+    }
 };
 
 __generic<T, let N : int>
@@ -3706,7 +3723,21 @@ __magic_type(HLSLOutputPatchType)
 __intrinsic_type($(kIROp_HLSLOutputPatchType))
 struct OutputPatch
 {
-    __subscript(uint index) -> T;
+    __generic<TIndex : __BuiltinIntegerType>
+    __subscript(TIndex index)->T
+    {
+        [__unsafeForceInlineEarly]
+        get
+        {
+            __target_switch
+            {
+            case hlsl:
+                __intrinsic_asm ".operator[]";
+            default:
+                return __getElement<T>(this, index);
+            }
+        }
+    }
 };
 
 ${{{{

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -694,6 +694,7 @@ DIAGNOSTIC(39025, Error, conflictingVulkanInferredBindingForParameter, "conflict
 DIAGNOSTIC(39026, Error, matrixLayoutModifierOnNonMatrixType, "matrix layout modifier cannot be used on non-matrix type '$0'.")
 
 DIAGNOSTIC(39027, Error, getAttributeAtVertexMustReferToPerVertexInput, "'GetAttributeAtVertex' must reference a vertex input directly, and the vertex input must be decorated with 'pervertex' or 'nointerpolation'.")
+
 //
 
 // 4xxxx - IL code generation.
@@ -843,6 +844,8 @@ DIAGNOSTIC(56001, Error, unableToAutoMapCUDATypeToHostType, "Could not automatic
 
 
 DIAGNOSTIC(57001, Warning, spirvOptFailed, "spirv-opt failed. $0")
+DIAGNOSTIC(57002, Error, unknownPatchConstantParameter, "unknown patch constant parameter '$0'.")
+DIAGNOSTIC(57003, Error, unknownTessPartitioning, "unknown tessellation partitioning '$0'.")
 
 // GLSL Compatibility
 DIAGNOSTIC(58001, Error, entryPointMustReturnVoidWhenGlobalOutputPresent, "entry point must return 'void' when global output variables are present.")

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -2963,6 +2963,15 @@ struct SPIRVEmitContext
                 result = emitOpAtomicIDecrement(parent, inst, inst->getFullType(), inst->getOperand(0), memoryScope, memorySemantics);
             }
             break;
+        case kIROp_ControlBarrier:
+            {
+                IRBuilder builder{ inst };
+                const auto executionScope = emitIntConstant(IRIntegerValue{ SpvScopeWorkgroup }, builder.getUIntType());
+                const auto memoryScope = emitIntConstant(IRIntegerValue{ SpvScopeInvocation }, builder.getUIntType());
+                const auto memorySemantics = emitIntConstant(IRIntegerValue{ SpvMemorySemanticsMaskNone }, builder.getUIntType());
+                emitInst(parent, inst, SpvOpControlBarrier, executionScope, memoryScope, memorySemantics);
+            }
+            break;
         }
         if (result)
             emitDecorations(inst, getID(result));
@@ -3323,6 +3332,29 @@ struct SPIRVEmitContext
                     requireSPIRVCapability(SpvCapabilityMeshShadingEXT);
                     ensureExtensionDeclaration(UnownedStringSlice("SPV_EXT_mesh_shader"));
                     break;
+                case Stage::Hull:
+                {
+                    requireSPIRVCapability(SpvCapabilityTessellation);
+
+                    SpvExecutionMode mode = SpvExecutionModeSpacingEqual;
+                    if (auto partitioningDecor = entryPoint->findDecoration<IRPartitioningDecoration>())
+                    {
+                        auto arg = partitioningDecor->getPartitioning()->getStringSlice();
+                        if (arg.caseInsensitiveEquals(toSlice("integer")))
+                            mode = SpvExecutionModeSpacingEqual;
+                        else if (arg.caseInsensitiveEquals(toSlice("fractional_even")))
+                            mode = SpvExecutionModeSpacingFractionalEven;
+                        else if (arg.caseInsensitiveEquals(toSlice("fractional_odd")))
+                            mode = SpvExecutionModeSpacingFractionalOdd;
+                        else
+                            m_sink->diagnose(partitioningDecor, Diagnostics::unknownTessPartitioning, arg);
+                    }
+                    requireSPIRVExecutionMode(nullptr, getIRInstSpvID(entryPoint), mode);
+                    break;
+                }
+                case Stage::Domain:
+                    requireSPIRVCapability(SpvCapabilityTessellation);
+                    break;
                 default:
                     break;
                 }
@@ -3463,13 +3495,36 @@ struct SPIRVEmitContext
 
         case kIROp_OutputTopologyDecoration:
             {
+                auto entryPoint = decoration->getParent();
+                IREntryPointDecoration* entryPointDecor = entryPoint ? entryPoint->findDecoration<IREntryPointDecoration>() : nullptr;
+
                 const auto o = cast<IROutputTopologyDecoration>(decoration);
                 const auto t = o->getTopology()->getStringSlice();
-                const auto m =
-                      t == "triangle" ? SpvExecutionModeOutputTrianglesEXT
-                    : t == "line" ? SpvExecutionModeOutputLinesEXT
-                    : t == "point" ? SpvExecutionModeOutputPoints
-                    : SpvExecutionModeMax;
+
+                SpvExecutionMode m = SpvExecutionModeMax;
+                if (entryPointDecor)
+                {
+                    switch (entryPointDecor->getProfile().getStage())
+                    {
+                    case Stage::Domain:
+                    case Stage::Hull:
+                        if (t == "triangle_cw")
+                            m = SpvExecutionModeVertexOrderCw;
+                        else if (t == "triangle_ccw")
+                            m = SpvExecutionModeVertexOrderCcw;
+                        break;
+                    }
+                }
+                if (m == SpvExecutionModeMax)
+                {
+                    if (t == "triangle")
+                        m = SpvExecutionModeOutputTrianglesEXT;
+                    else if (t == "line")
+                        m = SpvExecutionModeOutputTrianglesEXT;
+                    else if (t == "point")
+                        m = SpvExecutionModeOutputPoints;
+                }
+                
                 SLANG_ASSERT(m != SpvExecutionModeMax);
                 requireSPIRVExecutionMode(decoration, dstID, m);
             }
@@ -3543,6 +3598,31 @@ struct SPIRVEmitContext
                 decoration,
                 dstID,
                 SpvDecorationPerVertexKHR);
+            break;
+        case kIROp_OutputControlPointsDecoration:
+            requireSPIRVExecutionMode(
+                decoration,
+                dstID,
+                SpvExecutionModeOutputVertices,
+                SpvLiteralInteger::from32(int32_t(getIntVal(decoration->getOperand(0)))));
+            break;
+        case kIROp_DomainDecoration:
+            {
+                auto domain = cast<IRDomainDecoration>(decoration);
+                SpvExecutionMode mode = SpvExecutionModeMax;
+                auto domainName = as<IRStringLit>(domain->getDomain());
+                if (!domainName)
+                    break;
+                auto domainStr = domainName->getStringSlice();
+                if (domainStr.startsWithCaseInsensitive(toSlice("tri")))
+                    mode = SpvExecutionModeTriangles;
+                else if (domainStr.caseInsensitiveEquals(toSlice("quad")))
+                    mode = SpvExecutionModeQuads;
+                else if (domainStr.caseInsensitiveEquals(toSlice("isoline")))
+                    mode = SpvExecutionModeIsolines;
+                if (mode != SpvExecutionModeMax)
+                    requireSPIRVExecutionMode(decoration, dstID, mode);
+            }
             break;
         case kIROp_MemoryQualifierSetDecoration:
         {
@@ -3941,6 +4021,18 @@ struct SPIRVEmitContext
             varInst,
             builtinVal
         );
+        switch (builtinVal)
+        {
+        case SpvBuiltInTessLevelInner:
+        case SpvBuiltInTessLevelOuter:
+            emitOpDecorate(
+                getSection(SpvLogicalSectionID::Annotations),
+                nullptr,
+                varInst,
+                SpvDecorationPatch
+            );
+            break;
+        }
         m_builtinGlobalVars[key] = varInst;
 
         maybeEmitFlatDecorationForBuiltinVar(irInst, varInst);

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -660,6 +660,8 @@ INST(SampleGrad, sampleGrad, 4, 0)
 
 INST(GroupMemoryBarrierWithGroupSync, GroupMemoryBarrierWithGroupSync, 0, 0)
 
+INST(ControlBarrier, ControlBarrier, 0, 0)
+
 // GPU_FOREACH loop of the form 
 INST(GpuForeach, gpuForeach, 3, 0)
 

--- a/source/slang/slang-ir-specialize-target-switch.cpp
+++ b/source/slang/slang-ir-specialize-target-switch.cpp
@@ -9,6 +9,16 @@ namespace Slang
 {
     void specializeTargetSwitch(TargetRequest* target, IRGlobalValueWithCode* code, DiagnosticSink* sink)
     {
+        if (auto gen = as<IRGeneric>(code))
+        {
+            auto retVal = findGenericReturnVal(gen);
+            if (auto innerCode = as<IRGlobalValueWithCode>(retVal))
+            {
+                specializeTargetSwitch(target, innerCode, sink);
+                return;
+            }
+        }
+
         bool changed = false;
         for (auto block : code->getBlocks())
         {
@@ -76,14 +86,6 @@ namespace Slang
             if (auto code = as<IRGlobalValueWithCode>(globalInst))
             {
                 specializeTargetSwitch(target, code, sink);
-                if (auto gen = as<IRGeneric>(code))
-                {
-                    auto retVal = findGenericReturnVal(gen);
-                    if (auto innerCode = as<IRGlobalValueWithCode>(retVal))
-                    {
-                        specializeTargetSwitch(target, innerCode, sink);
-                    }
-                }
             }
         }
     }

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -2092,6 +2092,23 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
 
         return arrayTypeLayout;
     }
+    else if (auto patchType = as<HLSLPatchType>(type))
+    {
+        // Similar to the MeshOutput case, a `InputPatch` or `OutputPatch` type is just like an array.
+        //
+        auto elementTypeLayout = processEntryPointVaryingParameter(context, patchType->getElementType(), state, varLayout);
+
+        RefPtr<ArrayTypeLayout> arrayTypeLayout = new ArrayTypeLayout();
+        arrayTypeLayout->elementTypeLayout = elementTypeLayout;
+        arrayTypeLayout->type = arrayType;
+
+        for (auto rr : elementTypeLayout->resourceInfos)
+        {
+            arrayTypeLayout->findOrAddResourceInfo(rr.kind)->count = rr.count;
+        }
+
+        return arrayTypeLayout;
+    }
     // Ignore a bunch of types that don't make sense here...
     else if (const auto subpassType = as<SubpassInputType>(type)) { return nullptr;  }
     else if (const auto textureType = as<TextureType>(type)) { return nullptr;  }

--- a/tests/spirv/tessellation.slang
+++ b/tests/spirv/tessellation.slang
@@ -1,0 +1,65 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+
+// CHECK-DAG: OpExecutionMode %main SpacingEqual
+
+// CHECK-DAG: OpExecutionMode %main OutputVertices 4
+
+// CHECK-DAG: OpExecutionMode %main VertexOrderCw
+
+// CHECK-DAG: OpExecutionMode %main Quads
+
+// CHECK: OpDecorate %gl_TessLevelOuter BuiltIn TessLevelOuter
+// CHECK: OpDecorate %gl_TessLevelOuter Patch
+// CHECK: OpDecorate %gl_TessLevelInner BuiltIn TessLevelInner
+// CHECK: OpDecorate %gl_TessLevelInner Patch
+
+// CHECK: OpControlBarrier %uint_2 %uint_4 %uint_0
+
+// CHECK: OpStore %gl_TessLevelOuter
+// CHECK: OpStore %gl_TessLevelInner
+
+struct VS_OUT
+{
+    float3 position : POSITION;
+};
+
+struct HS_OUT
+{
+    float3 position : POSITION;
+};
+
+struct HSC_OUT
+{
+    float EdgeTessFactor[4] : SV_TessFactor;
+    float InsideTessFactor[2] : SV_InsideTessFactor;
+};
+
+// Hull Shader (HS)
+[domain("quad")]
+[partitioning("integer")]
+[outputtopology("triangle_cw")]
+[outputcontrolpoints(4)]
+[patchconstantfunc("constants")]
+HS_OUT main(InputPatch<VS_OUT, 4> patch, uint i : SV_OutputControlPointID)
+{
+    HS_OUT o;
+    o.position = patch[i].position;
+    return o;
+}
+
+HSC_OUT constants(InputPatch<VS_OUT, 4> patch)
+{
+    float3 p0 = patch[0].position;
+    float3 p1 = patch[1].position;
+    float3 p2 = patch[2].position;
+    float3 p3 = patch[3].position;
+
+    HSC_OUT o;
+    o.EdgeTessFactor[0] = dot(p0, p1); 
+    o.EdgeTessFactor[1] = dot(p0, p3);
+    o.EdgeTessFactor[2] = dot(p2, p3);
+    o.EdgeTessFactor[3] = dot(p1, p2);
+    o.InsideTessFactor[0] = lerp(o.EdgeTessFactor[1], o.EdgeTessFactor[3], 0.5);
+    o.InsideTessFactor[1] = lerp(o.EdgeTessFactor[0], o.EdgeTessFactor[2], 0.5);
+    return o;
+}


### PR DESCRIPTION
Closes #4332.

The main task here is to properly lower `InputPatch<T>` and `OutputPatch<T>` to array types in SPIRV, and to combine both the hull shader and the patch constant function into a single entrypoint for SPIRV.

A hull shader in the form of:
```
struct HullInput { float3 inElement; }
struct ConstantOutput { float factor[4] : SV_TessFactor; }
struct HullOutput { float3 outElement; }

ConstantOutput constantFunc(InputPatch<HullInput, N> inPatch, OutputPatch<HullOutput, N> outPatch)
{
    // compute tess factor
}

[patchconstantfunc("constantFunc")]
HullOutput hull(InputPatch<HullInput, N> patch, int i : SV_OutputControlPointID)
{
           // compute outElmeent
} 
```

should be transformed to:
```
in float3 inElement[N];
out float3 outElement[N];

void hull()
{
       // compute outElement (original hull shader body)

      barrier;

      if (gl_InvocationID == 0) {
              // compute tess factor and set gl_TessLevelInner[N];  (constantFunc)
      }
}
```