### PR TITLE
Fix cuda/cpp/metal crash when using GLSL shader inputs

### DIFF
--- a/source/slang/slang-ir-explicit-global-context.cpp
+++ b/source/slang/slang-ir-explicit-global-context.cpp
@@ -462,11 +462,15 @@ struct IntroduceExplicitGlobalContextPass
         for( IRUse* use = globalVar->firstUse; use; use = nextUse )
         {
             nextUse = use->nextUse;
+            auto user = use->getUser();
+
+            // Ensure the use site checked actually requires a replacement
+            if (as<IRDecoration>(user))
+                continue;
 
             // At each use site, we need to look up the context
             // pointer that is appropriate for that use.
             //
-            auto user = use->getUser();
             auto contextParam = findOrCreateContextPtrForInst(user);
             builder.setInsertBefore(user);
 

--- a/tests/glsl/matrix-mul.slang
+++ b/tests/glsl/matrix-mul.slang
@@ -1,5 +1,6 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv -stage vertex -entry main -allow-glsl -emit-spirv-directly
-//TEST:SIMPLE(filecheck=CHECK): -target spirv -stage vertex -entry main -allow-glsl
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -stage vertex -entry main -allow-glsl -emit-spirv-directly
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -stage vertex -entry main -allow-glsl
+//TEST:SIMPLE(filecheck=METAL): -target metal -stage vertex -entry main -allow-glsl
 #version 310 es
 layout(location = 0) in highp vec4 a_position;
 
@@ -13,8 +14,10 @@ void main()
 {
     gl_Position = m1 * m2 * a_position;
    
-    // CHECK: OpEntryPoint
-    // CHECK: OpMatrixTimesMatrix
-    // CHECK: OpMatrixTimesVector
+    // SPIRV: OpEntryPoint
+    // SPIRV: OpMatrixTimesMatrix
+    // SPIRV: OpMatrixTimesVector
+
+    // METAL: {{.*}}m1{{.*}}*{{.*}}m2{{.*}}*{{.*}}a_position{{.*}}
 }
 


### PR DESCRIPTION
fixes: #4377
Decorations were not expected as an input, this causes a crash since there is no 'context pointer' for a decoration use site.

Previously `layout(location = 0) in highp vec4 a_position;` caused a crash, now it does not.