### PR TITLE
Improve Direct SPIRV Backend Test Coverage & Fix Associated Bug

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -19209,8 +19209,7 @@ ${
             return spirv_asm {
                 OpCapability ImageFootprintNV;
                 OpExtension "SPV_NV_shader_image_footprint";
-                %sampledImage:__sampledImageType(this) = OpSampledImage $this $sampler;
-                %resultVal:$$__FootprintData = OpImageSampleFootprintNV %sampledImage $coords $granularity $useCoarseLevel;
+                %resultVal:$$__FootprintData = OpImageSampleFootprintNV &this $coords $granularity $useCoarseLevel;
                 OpStore &footprint %resultVal;
                 result:$$bool = OpCompositeExtract %resultVal 0;
             };
@@ -19237,8 +19236,7 @@ ${
             return spirv_asm {
                 OpCapability ImageFootprintNV;
                 OpExtension "SPV_NV_shader_image_footprint";
-                %sampledImage:__sampledImageType(this) = OpSampledImage $this $sampler;
-                %resultVal:$$__FootprintData = OpImageSampleFootprintNV %sampledImage $coords $granularity $useCoarseLevel Bias $bias;
+                %resultVal:$$__FootprintData = OpImageSampleFootprintNV &this $coords $granularity $useCoarseLevel Bias $bias;
                 OpStore &footprint %resultVal;
                 result:$$bool = OpCompositeExtract %resultVal 0;
             };
@@ -19267,8 +19265,7 @@ ${
                 OpCapability ImageFootprintNV;
                 OpCapability MinLod;
                 OpExtension "SPV_NV_shader_image_footprint";
-                %sampledImage:__sampledImageType(this) = OpSampledImage $this $sampler;
-                %resultVal:$$__FootprintData = OpImageSampleFootprintNV %sampledImage $coords $granularity $useCoarseLevel MinLod $lodClamp;
+                %resultVal:$$__FootprintData = OpImageSampleFootprintNV &this $coords $granularity $useCoarseLevel MinLod $lodClamp;
                 OpStore &footprint %resultVal;
                 result:$$bool = OpCompositeExtract %resultVal 0;
             };
@@ -19298,8 +19295,7 @@ ${
                 OpCapability ImageFootprintNV;
                 OpCapability MinLod;
                 OpExtension "SPV_NV_shader_image_footprint";
-                %sampledImage:__sampledImageType(this) = OpSampledImage $this $sampler;
-                %resultVal:$$__FootprintData = OpImageSampleFootprintNV %sampledImage $coords $granularity $useCoarseLevel Bias|MinLod $bias $lodClamp;
+                %resultVal:$$__FootprintData = OpImageSampleFootprintNV &this $coords $granularity $useCoarseLevel Bias|MinLod $bias $lodClamp;
                 OpStore &footprint %resultVal;
                 result:$$bool = OpCompositeExtract %resultVal 0;
             };
@@ -19327,8 +19323,7 @@ ${
             return spirv_asm {
                 OpCapability ImageFootprintNV;
                 OpExtension "SPV_NV_shader_image_footprint";
-                %sampledImage:__sampledImageType(this) = OpSampledImage $this $sampler;
-                %resultVal:$$__FootprintData = OpImageSampleFootprintNV %sampledImage $coords $granularity $useCoarseLevel Lod $lod;
+                %resultVal:$$__FootprintData = OpImageSampleFootprintNV &this $coords $granularity $useCoarseLevel Lod $lod;
                 OpStore &footprint %resultVal;
                 result:$$bool = OpCompositeExtract %resultVal 0;
             };
@@ -19361,8 +19356,7 @@ ${{{
             return spirv_asm {
                 OpCapability ImageFootprintNV;
                 OpExtension "SPV_NV_shader_image_footprint";
-                %sampledImage:__sampledImageType(this) = OpSampledImage $this $sampler;
-                %resultVal:$$__FootprintData = OpImageSampleFootprintNV %sampledImage $coords $granularity $useCoarseLevel Grad $dx $dy;
+                %resultVal:$$__FootprintData = OpImageSampleFootprintNV &this $coords $granularity $useCoarseLevel Grad $dx $dy;
                 OpStore &footprint %resultVal;
                 result:$$bool = OpCompositeExtract %resultVal 0;
             };
@@ -19393,8 +19387,7 @@ ${{{
                 OpCapability ImageFootprintNV;
                 OpCapability MinLod;
                 OpExtension "SPV_NV_shader_image_footprint";
-                %sampledImage:__sampledImageType(this) = OpSampledImage $this $sampler;
-                %resultVal:$$__FootprintData = OpImageSampleFootprintNV %sampledImage $coords $granularity $useCoarseLevel Grad|MinLod $dx $dy $lodClamp;
+                %resultVal:$$__FootprintData = OpImageSampleFootprintNV &this $coords $granularity $useCoarseLevel Grad|MinLod $dx $dy $lodClamp;
                 OpStore &footprint %resultVal;
                 result:$$bool = OpCompositeExtract %resultVal 0;
             };

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -2591,7 +2591,10 @@ void GLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
         {
             case kIROp_RaytracingAccelerationStructureType:
             {
-                _requireRayQuery();
+                if (!isRaytracingStage(m_entryPointStage))
+                    _requireRayQuery();
+                else
+                    _requireRayTracing();
                 m_writer->emit("accelerationStructureEXT");
                 break;
             }

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -3590,8 +3590,8 @@ struct SPIRVEmitContext
         case kIROp_VulkanRayPayloadDecoration:
         case kIROp_VulkanRayPayloadInDecoration:
             // needed since GLSL will not set optypes accordingly, but will keep the decoration 
-            ensureExtensionDeclaration(UnownedStringSlice("SPV_KHR_ray_query"));
-            requireSPIRVCapability(SpvCapabilityRayQueryKHR);
+            ensureExtensionDeclaration(UnownedStringSlice("SPV_KHR_ray_tracing"));
+            requireSPIRVCapability(SpvCapabilityRayTracingKHR);
             isRayTracingObject = true;
             break;
         case kIROp_InterpolationModeDecoration:

--- a/source/slang/slang-profile.cpp
+++ b/source/slang/slang-profile.cpp
@@ -14,6 +14,22 @@ ProfileFamily getProfileFamily(ProfileVersion version)
     }
 }
 
+bool isRaytracingStage(Stage inStage)
+{
+    switch (inStage)
+    {
+    case Stage::RayGeneration:
+    case Stage::Miss:
+    case Stage::Intersection:
+    case Stage::ClosestHit:
+    case Stage::Callable:
+    case Stage::AnyHit:
+        return true;
+    default:
+        return false;
+    }
+}
+
 const char* getStageName(Stage stage)
 {
     switch(stage)

--- a/source/slang/slang-profile.h
+++ b/source/slang/slang-profile.h
@@ -56,6 +56,8 @@ namespace Slang
         
     };
 
+    bool isRaytracingStage(Stage inStage);
+
     const char* getStageName(Stage stage);
 
     void printDiagnosticArg(StringBuilder& sb, Stage val);

--- a/tests/gpu-feature/texture/query/footprint/nv-shader-texture-footprint-simple.slang
+++ b/tests/gpu-feature/texture/query/footprint/nv-shader-texture-footprint-simple.slang
@@ -1,4 +1,5 @@
 //TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry fragmentMain -stage fragment -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry fragmentMain -stage fragment
 //DISABLED_TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry fragmentMain -stage fragment -DENABLE_CLAMP -emit-spirv-directly
 //DISABLED_TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry fragmentMain -stage fragment
 //TEST:SIMPLE(filecheck=HLSL):-target hlsl -entry fragmentMain -stage fragment

--- a/tests/gpu-feature/texture/query/footprint/nv-shader-texture-footprint.slang
+++ b/tests/gpu-feature/texture/query/footprint/nv-shader-texture-footprint.slang
@@ -1,4 +1,5 @@
 //TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry fragmentMain -stage fragment -DENABLE_CLAMP
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry fragmentMain -stage fragment -DENABLE_CLAMP
 //DISABLED_TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry fragmentMain -stage fragment -DENABLE_CLAMP -emit-spirv-directly
 
 //DISABLED_TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry fragmentMain -stage fragment
@@ -84,14 +85,12 @@ void fragmentMain(
             float                       v : VARYING,
 
     uniform Texture2D                   texture_2D,
-// SPIRV: OpTypeImage
-// SPIRV-SAME: 2D
+// SPIRV-DAG: OpTypeImage {{.*}} 2D
 
 // HLSL-DAG: Texture2D{{.*}}register(t0)
 
     uniform Texture3D                   texture_3D,
-// SPIRV: OpTypeImage
-// SPIRV-SAME: 3D
+// SPIRV-DAG: OpTypeImage {{.*}} 3D
 
 // HLSL-DAG: Texture3D{{.*}}register(t1)
 

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-ahit.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-ahit.slang
@@ -1,35 +1,36 @@
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage anyhit -profile glsl_460+GL_EXT_ray_tracing -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage anyhit -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage anyhit
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage anyhit -profile sm_6_5 -DNOMOTION
 
+// SPIRV-NOT: OpCapability RayQueryKHR
+// SPIRV-DAG: RayTracingKHR
+// SPIRV-DAG: SPV_KHR_ray_tracing
+
 // SPIRV: OpEntryPoint
 
-// SPIRV: OpLoad %v3uint %gl_LaunchIDEXT
-// SPIRV: OpLoad %v3uint %gl_LaunchSizeEXT
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn LaunchIdNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn LaunchSizeNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn WorldRayOriginNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn WorldRayDirectionNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn RayTminNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn RayTmaxNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn IncomingRayFlagsNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn InstanceId
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn InstanceCustomIndexNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn RayGeometryIndexKHR
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn ObjectRayOriginNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn ObjectRayDirectionNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn ObjectToWorldNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn WorldToObjectNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn HitKindNV
 
-// SPIRV: OpLoad %v3float %gl_WorldRayOriginEXT
-// SPIRV: OpLoad %v3float %gl_WorldRayDirectionEXT
-// SPIRV: OpLoad %float %gl_RayTminEXT
-// SPIRV: OpLoad %float %gl_RayTmaxEXT
-// SPIRV: OpLoad %uint %gl_IncomingRayFlagsEXT
-
-// SPIRV: OpLoad %int %gl_InstanceID
-// SPIRV: OpLoad %int %gl_InstanceCustomIndexEXT
-// SPIRV: OpLoad %int %gl_GeometryIndexEXT
-// SPIRV: OpLoad %int %gl_PrimitiveID
-// SPIRV: OpLoad %v3float %gl_ObjectRayOriginEXT
-// SPIRV: OpLoad %v3float %gl_ObjectRayDirectionEXT
-// SPIRV: OpLoad %mat4v3float %gl_ObjectToWorldEXT
-// SPIRV: OpLoad %mat4v3float %gl_ObjectToWorldEXT
-// SPIRV: OpLoad %mat4v3float %gl_WorldToObjectEXT
-// SPIRV: OpLoad %mat4v3float %gl_WorldToObjectEXT
-// SPIRV: OpLoad %uint %gl_HitKindEXT
-
-// SPIRV: OpLoad %v3float %gl_ObjectRayOriginEXT
-// SPIRV: OpLoad %v3float %gl_ObjectRayDirectionEXT
-// SPIRV: OpLoad %float %gl_RayTmaxEXT
-// SPIRV: OpTerminateRayKHR
-// SPIRV: OpIgnoreIntersectionKHR
+// SPIRV-DAG: OpTypePointer HitAttributeNV
+// SPIRV-DAG: OpTypePointer IncomingRayPayloadNV
+ 
+// SPIRV-DAG: OpTerminateRayKHR
+// SPIRV-DAG: OpIgnoreIntersectionKHR
 
 // DXIL: main
 

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-chit.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-chit.slang
@@ -1,33 +1,43 @@
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage closesthit -profile glsl_460+GL_EXT_ray_tracing -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage closesthit -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage closesthit
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage closesthit -profile sm_6_5 -DNOMOTION
 
+// SPIRV-NOT: OpCapability RayQueryKHR
+// SPIRV-DAG: RayTracingKHR
+// SPIRV-DAG: RayTracingMotionBlurNV
+// SPIRV-DAG: SPV_KHR_ray_tracing
+// SPIRV-DAG: SPV_NV_ray_tracing_motion_blur
+
 // SPIRV: OpEntryPoint
 
-// SPIRV: OpLoad %v3uint %gl_LaunchIDEXT
-// SPIRV: OpLoad %v3uint %gl_LaunchSizeEXT
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn LaunchIdNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn LaunchSizeNV
+// SPIRV-DAG: OpDecorate %{{.*}} Binding 0
+// SPIRV-DAG: OpDecorate %{{.*}} DescriptorSet 0
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn WorldRayOriginNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn WorldRayDirectionNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn RayTminNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn RayTmaxNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn IncomingRayFlagsNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn InstanceId
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn InstanceCustomIndexNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn RayGeometryIndexKHR
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn ObjectRayOriginNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn ObjectRayDirectionNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn ObjectToWorldNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn WorldToObjectNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn HitKindNV
+
+// SPIRV-DAG: OpTypePointer IncomingRayPayloadNV
+// SPIRV-DAG: OpTypePointer RayPayloadNV
+// SPIRV-DAG: OpTypeAccelerationStructureKHR
+// SPIRV-DAG: OpTypePointer HitAttributeNV
+// SPIRV-DAG: OpTypePointer CallableDataNV
 
 // SPIRV: OpTraceRayKHR
 // SPIRV: OpTraceRayMotionNV
-
-// SPIRV: OpLoad %v3float %gl_WorldRayOriginEXT
-// SPIRV: OpLoad %v3float %gl_WorldRayDirectionEXT
-// SPIRV: OpLoad %float %gl_RayTminEXT
-// SPIRV: OpLoad %float %gl_RayTmaxEXT
-// SPIRV: OpLoad %uint %gl_IncomingRayFlagsEXT
-
-// SPIRV: OpLoad %int %gl_InstanceID
-// SPIRV: OpLoad %int %gl_InstanceCustomIndexEXT
-// SPIRV: OpLoad %int %gl_GeometryIndexEXT
-// SPIRV: OpLoad %int %gl_PrimitiveID
-// SPIRV: OpLoad %v3float %gl_ObjectRayOriginEXT
-// SPIRV: OpLoad %v3float %gl_ObjectRayDirectionEXT
-// SPIRV: OpLoad %mat4v3float %gl_ObjectToWorldEXT
-// SPIRV: OpLoad %mat4v3float %gl_ObjectToWorldEXT
-// SPIRV: OpLoad %mat4v3float %gl_WorldToObjectEXT
-// SPIRV: OpLoad %mat4v3float %gl_WorldToObjectEXT
-// SPIRV: OpLoad %uint %gl_HitKindEXT
-
 // SPIRV: OpExecuteCallableKHR
 
 // DXIL: main

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-int.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-int.slang
@@ -1,31 +1,33 @@
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage intersection -profile glsl_460+GL_EXT_ray_tracing -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage intersection -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage intersection
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage intersection -profile sm_6_5 -DNOMOTION
 
+// SPIRV-NOT: OpCapability RayQueryKHR
+// SPIRV-DAG: OpCapability RayTracingKHR
+// SPIRV-DAG: OpExtension "SPV_KHR_ray_tracing"
+
 // SPIRV: OpEntryPoint
 
-// SPIRV: OpLoad %v3uint %gl_LaunchIDEXT
-// SPIRV: OpLoad %v3uint %gl_LaunchSizeEXT
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn WorldRayOriginNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn WorldRayDirectionNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn LaunchIdNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn LaunchSizeNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn RayTminNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn RayTmaxNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn IncomingRayFlagsNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn InstanceId
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn InstanceCustomIndexNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn RayGeometryIndexKHR
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn ObjectRayOriginNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn ObjectRayDirectionNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn ObjectToWorldNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn WorldToObjectNV
 
-// SPIRV: OpLoad %v3float %gl_WorldRayOriginEXT
-// SPIRV: OpLoad %v3float %gl_WorldRayDirectionEXT
-// SPIRV: OpLoad %float %gl_RayTminEXT
-// SPIRV: OpLoad %float %gl_RayTmaxEXT
-// SPIRV: OpLoad %uint %gl_IncomingRayFlagsEXT
+// SPIRV-DAG: OpTypePointer HitAttributeNV
+// SPIRV-DAG: OpVariable %{{.*}} HitAttributeNV
 
-// SPIRV: OpLoad %int %gl_InstanceID
-// SPIRV: OpLoad %int %gl_InstanceCustomIndexEXT
-// SPIRV: OpLoad %int %gl_GeometryIndexEXT
-// SPIRV: OpLoad %int %gl_PrimitiveID
-// SPIRV: OpLoad %v3float %gl_ObjectRayOriginEXT
-// SPIRV: OpLoad %v3float %gl_ObjectRayDirectionEXT
-// SPIRV: OpLoad %mat4v3float %gl_ObjectToWorldEXT
-// SPIRV: OpLoad %mat4v3float %gl_ObjectToWorldEXT
-// SPIRV: OpLoad %mat4v3float %gl_WorldToObjectEXT
-// SPIRV: OpLoad %mat4v3float %gl_WorldToObjectEXT
-
-// SPIRV: OpLoad %float %gl_RayTminEXT
-// SPIRV: OpLoad %float %gl_RayTmaxEXT
 // SPIRV: OpReportIntersectionKHR
 
 // DXIL: main

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-miss.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-miss.slang
@@ -1,21 +1,28 @@
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry main -stage miss -profile glsl_460+GL_EXT_ray_tracing -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage miss -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage miss
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage miss -profile sm_6_5 -DNOMOTION
 
+// SPIRV-NOT: OpCapability RayQueryKHR
+// SPIRV-DAG: OpCapability RayTracingKHR
+// SPIRV-DAG: OpCapability RayTracingMotionBlurNV
+// SPIRV-DAG: SPV_KHR_ray_tracing
+// SPIRV-DAG: SPV_NV_ray_tracing_motion_blur
+
 // SPIRV: OpEntryPoint
 
-// SPIRV: OpLoad %v3uint %gl_LaunchIDEXT
-// SPIRV: OpLoad %v3uint %gl_LaunchSizeEXT
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn LaunchIdNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn LaunchSizeNV
+// SPIRV-DAG: OpDecorate %{{.*}} Binding 0
+// SPIRV-DAG: OpDecorate %{{.*}} DescriptorSet 0
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn WorldRayOriginNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn WorldRayDirectionNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn RayTminNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn RayTmaxNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn IncomingRayFlagsNV
 
 // SPIRV: OpTraceRayKHR
 // SPIRV: OpTraceRayMotionNV
-
-// SPIRV: OpLoad %v3float %gl_WorldRayOriginEXT
-// SPIRV: OpLoad %v3float %gl_WorldRayDirectionEXT
-// SPIRV: OpLoad %float %gl_RayTminEXT
-// SPIRV: OpLoad %float %gl_RayTmaxEXT
-// SPIRV: OpLoad %uint %gl_IncomingRayFlagsEXT
-
 // SPIRV: OpExecuteCallableKHR
 
 // DXIL: main

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-rgen.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-rgen.slang
@@ -1,11 +1,22 @@
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage raygeneration -profile glsl_460+GL_EXT_ray_tracing -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage raygeneration -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage raygeneration
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage raygeneration -profile sm_6_5 -DNOMOTION
 
+// SPIRV-NOT: OpCapability RayQueryKHR
+// SPIRV-DAG: OpCapability RayTracingKHR
+// SPIRV-DAG: OpCapability RayTracingMotionBlurNV
+// SPIRV-DAG: SPV_KHR_ray_tracing
+// SPIRV-DAG: SPV_NV_ray_tracing_motion_blur
+
 // SPIRV: OpEntryPoint
 
-// SPIRV: OpLoad %v3uint %gl_LaunchIDEXT
-// SPIRV: OpLoad %v3uint %gl_LaunchSizeEXT
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn LaunchIdNV
+// SPIRV-DAG: OpDecorate %{{.*}} BuiltIn LaunchSizeNV
+// SPIRV-DAG: OpDecorate %{{.*}} Binding 0
+// SPIRV-DAG: OpDecorate %{{.*}} DescriptorSet 0
+// SPIRV-DAG: OpDecorate %{{.*}} Binding 1
+// SPIRV-DAG: OpDecorate %{{.*}} DescriptorSet 0
 
 // SPIRV: OpTraceRayKHR
 // SPIRV: OpTraceRayMotionNV

--- a/tests/vkray/anyhit.slang
+++ b/tests/vkray/anyhit.slang
@@ -1,11 +1,7 @@
 // closesthit.slang
 
-// Note: explicitly requesting `spirv_1_4` as part of the compiler
-// options is for the benefit of the glslang pass-through path,
-// where we cannot infer the required SPIR-V version from the code
-// (and glslang doesn't include any such inference ability).
-
-//TEST:SIMPLE(filecheck=CHECK): -profile glsl_460+spirv_1_4 -stage anyhit -entry main -target spirv-assembly -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=GL_SPIRV): -stage anyhit -entry main -target spirv-assembly -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=SPIRV): -stage anyhit -entry main -target spirv
 
 struct SphereHitAttributes
 {
@@ -55,15 +51,27 @@ void main(
 	HitTriangleVertexPosition(index);
 }
 
-// CHECK: OpCapability RayTracing
-// CHECK: OpCapability RayTracingPositionFetchKHR
-// CHECK: OpEntryPoint AnyHitNV %main "main"
-// CHECK: OpDecorate %{{.*}} BuiltIn HitTriangleVertexPositionsKHR
-// CHECK: %_ptr_HitAttributeNV_SphereHitAttributes_0 = OpTypePointer HitAttributeNV %SphereHitAttributes_0
-// CHECK: %_S{{.*}} = OpVariable %_ptr_HitAttributeNV_SphereHitAttributes_0 HitAttributeNV
-// CHECK: %{{.*}} = OpAccessChain %_ptr_HitAttributeNV_v3float %_S{{.*}} %int_0
-// CHECK: OpTerminateRayKHR
-// CHECK: OpIgnoreIntersectionKHR
-// CHECK: %{{.*}} = OpAccessChain %_ptr_Input_v3float %{{.*}} %{{u?}}int_0
-// CHECK: %{{.*}} = OpAccessChain %_ptr_Input_v3float %{{.*}} %{{u?}}int_1
-// CHECK: %{{.*}} = OpAccessChain %_ptr_Input_v3float %{{.*}} %{{u?}}int_2
+// SPIRV-DAG: OpCapability RayTracing
+// SPIRV-DAG: OpCapability RayTracingPositionFetchKHR
+// SPIRV: OpEntryPoint
+// SPIRV: BuiltIn HitTriangleVertexPositionsKHR
+// SPIRV: OpTypePointer HitAttributeNV
+// SPIRV: OpTypePointer HitAttributeNV
+// SPIRV: OpVariable{{.*}}HitAttributeNV
+// SPIRV: OpIgnoreIntersectionKHR
+// SPIRV: OpTerminateRayKHR
+// SPIRV-DAG: %{{.*}} = OpAccessChain %{{.*}} %{{.*}} %{{.*}}
+// SPIRV-DAG: %{{.*}} = OpAccessChain %{{.*}} %{{.*}} %{{.*}}
+// SPIRV-DAG: %{{.*}} = OpAccessChain %{{.*}} %{{.*}} %{{.*}}
+
+// GL_SPIRV-DAG: OpCapability RayTracing
+// GL_SPIRV-DAG: OpCapability RayTracingPositionFetchKHR
+// GL_SPIRV: OpEntryPoint
+// GL_SPIRV: BuiltIn HitTriangleVertexPositionsKHR
+// GL_SPIRV-DAG: OpTypePointer HitAttributeNV
+// GL_SPIRV-DAG: OpTypePointer HitAttributeNV
+// GL_SPIRV: OpTerminateRayKHR
+// GL_SPIRV: OpIgnoreIntersectionKHR
+// GL_SPIRV-DAG: %{{.*}} = OpAccessChain %{{.*}} %{{.*}} %{{.*}}
+// GL_SPIRV-DAG: %{{.*}} = OpAccessChain %{{.*}} %{{.*}} %{{.*}}
+// GL_SPIRV-DAG: %{{.*}} = OpAccessChain %{{.*}} %{{.*}} %{{.*}}

--- a/tests/vkray/callable.slang
+++ b/tests/vkray/callable.slang
@@ -1,6 +1,7 @@
 // callable.slang
 
-//TEST:SIMPLE(filecheck=CHECK): -profile glsl_460+spirv_1_4 -stage callable -entry main -target spirv-assembly -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=CHECK): -stage callable -entry main -target spirv-assembly -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=CHECK): -stage callable -entry main -target spirv
 
 import callable_shared;
 
@@ -15,11 +16,11 @@ void main(in out MaterialPayload ioPayload)
 		0);
 }
 
-// CHECK: OpCapability RayTracingKHR
-// CHECK: OpExtension "SPV_KHR_ray_tracing"
-// CHECK: OpEntryPoint CallableNV %main
-// CHECK: %_ptr_IncomingCallableDataNV_MaterialPayload_0 = OpTypePointer IncomingCallableDataNV %MaterialPayload_0
-// CHECK: %_ptr_IncomingCallableDataNV_v2float = OpTypePointer IncomingCallableDataNV %v2float
-// CHECK: %_ptr_IncomingCallableDataNV_v4float = OpTypePointer IncomingCallableDataNV %v4float
-// CHECK: %{{.*}} = OpAccessChain %_ptr_IncomingCallableDataNV_v2float %_S1 %int_1
-// CHECK: %{{.*}} = OpAccessChain %_ptr_IncomingCallableDataNV_v4float %_S1 %int_0
+// CHECK-DAG: OpCapability RayTracingKHR
+// CHECK-DAG: OpExtension "SPV_KHR_ray_tracing"
+// CHECK: OpEntryPoint
+// CHECK-DAG: OpTypePointer IncomingCallableDataNV
+// CHECK-DAG: OpTypePointer IncomingCallableDataNV
+// CHECK-DAG: OpTypePointer IncomingCallableDataNV
+// CHECK-DAG: %{{.*}} = OpAccessChain %{{.*}} %{{.*}} %{{.*}}
+// CHECK-DAG: %{{.*}} = OpAccessChain %{{.*}} %{{.*}} %{{.*}}


### PR DESCRIPTION
fixes: #4001

1. Added direct-spirv tests for 'raytracing' and 'texture-footprint'
2. Fixed bug with texture-footprint using direct-spirv path
3. Changed when we emit raytracing/rayquery extensions with backends (to reduce 'incorrect' extension emitting)

Note: 
1. `tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-ahit.slang` checks for the following code:
```
// SPIRV-DAG: OpTerminateRayKHR
// SPIRV-DAG: OpIgnoreIntersectionKHR
```
This code is checked using `DAG` since the used `OpBranch` has varying ordering when emitted by direct-spirv versus glslang-spirv.