### PR TITLE
Feature/capture

### DIFF
--- a/source/core/slang-stream.h
+++ b/source/core/slang-stream.h
@@ -138,7 +138,7 @@ public:
     void setContent(const void* contents, size_t contentsSize)
     {
         m_ownedContents.setCount(contentsSize);
-        if (contentsSize > 0)
+        if (contents != nullptr)
         {
             ::memcpy(m_ownedContents.getBuffer(), contents, contentsSize);
         }

--- a/source/slang-capture-replay/capture-manager.h
+++ b/source/slang-capture-replay/capture-manager.h
@@ -9,17 +9,31 @@ namespace SlangCapture
     {
     public:
         CaptureManager(uint64_t globalSessionHandle);
+
+        // Each method capture has to start with a FunctionHeader
         ParameterEncoder* beginMethodCapture(const ApiCallId& callId, uint64_t handleId);
-        void endMethodCapture();
+        ParameterEncoder* endMethodCapture();
+
+        // endMethodCaptureAppendOutput is an optional call that can be used to append output to
+        // the end of the capture. It has to start with a FunctionTailer
+        void endMethodCaptureAppendOutput();
     private:
         void clearWithHeader(const ApiCallId& callId, uint64_t handleId);
+        void clearWithTailer();
 
         struct FunctionHeader
         {
+            uint32_t         magic {0x44414548};
             ApiCallId        callId {InvalidCallId};
             uint64_t         handleId {0};
             uint64_t         dataSizeInBytes {0};
             uint64_t         threadId {0};
+        };
+
+        struct FunctionTailer
+        {
+            uint32_t     magic {0x4C494154};
+            uint32_t     dataSizeInBytes {0};
         };
 
         MemoryStream m_memoryStream;

--- a/source/slang-capture-replay/capture_utility.h
+++ b/source/slang-capture-replay/capture_utility.h
@@ -30,4 +30,8 @@ namespace SlangCapture
         }                                   \
     } while(0)
 
+#define SLANG_CAPTURE_CHECK(VALUE)          \
+    do {                                    \
+        SLANG_CAPTURE_ASSERT((VALUE) == SLANG_OK);      \
+    } while(0)
 #endif // CAPTURE_UTILITY_H

--- a/source/slang-capture-replay/output-stream.cpp
+++ b/source/slang-capture-replay/output-stream.cpp
@@ -26,7 +26,7 @@ namespace SlangCapture
 
     void FileOutputStream::write(const void* data, size_t len)
     {
-        SLANG_CAPTURE_ASSERT(SLANG_OK == m_fileStream.write(data, len));
+        SLANG_CAPTURE_CHECK(m_fileStream.write(data, len));
     }
 
     MemoryStream::MemoryStream()
@@ -35,12 +35,12 @@ namespace SlangCapture
 
     void FileOutputStream::flush()
     {
-        SLANG_CAPTURE_ASSERT(SLANG_OK == m_fileStream.flush());
+        SLANG_CAPTURE_CHECK(m_fileStream.flush());
     }
 
     void MemoryStream::write(const void* data, size_t len)
     {
-        SLANG_CAPTURE_ASSERT(SLANG_OK == m_memoryStream.write(data, len));
+        SLANG_CAPTURE_CHECK(m_memoryStream.write(data, len));
     }
 
     void MemoryStream::flush()

--- a/source/slang-capture-replay/output-stream.cpp
+++ b/source/slang-capture-replay/output-stream.cpp
@@ -26,7 +26,7 @@ namespace SlangCapture
 
     void FileOutputStream::write(const void* data, size_t len)
     {
-        SLANG_CAPTURE_ASSERT(m_fileStream.write(data, len));
+        SLANG_CAPTURE_ASSERT(SLANG_OK == m_fileStream.write(data, len));
     }
 
     MemoryStream::MemoryStream()
@@ -35,12 +35,12 @@ namespace SlangCapture
 
     void FileOutputStream::flush()
     {
-        SLANG_CAPTURE_ASSERT(m_fileStream.flush());
+        SLANG_CAPTURE_ASSERT(SLANG_OK == m_fileStream.flush());
     }
 
     void MemoryStream::write(const void* data, size_t len)
     {
-        SLANG_CAPTURE_ASSERT(m_memoryStream.write(data, len));
+        SLANG_CAPTURE_ASSERT(SLANG_OK == m_memoryStream.write(data, len));
     }
 
     void MemoryStream::flush()

--- a/source/slang-capture-replay/parameter-encoder.cpp
+++ b/source/slang-capture-replay/parameter-encoder.cpp
@@ -109,7 +109,7 @@ namespace SlangCapture
         }
         else
         {
-            uint32_t size = strlen(value);
+            uint32_t size = (uint32_t)strlen(value);
             encodeUint32(size);
             m_stream->write(value, size);
         }

--- a/source/slang-capture-replay/parameter-encoder.h
+++ b/source/slang-capture-replay/parameter-encoder.h
@@ -29,7 +29,9 @@ namespace SlangCapture
         void encodeEnumValue(T value) { encodeValue(static_cast<uint32_t>(value)); }
 
         void encodeString(const char* value);
+        void encodeStringArray(const char* const* strArray, size_t count);
         void encodePointer(const void* value, bool omitData = false, size_t size = 0);
+        void encodePointer(ISlangBlob* blob);
         void encodeAddress(const void* value) { encodeValue(reinterpret_cast<uint64_t>(value)); }
 
         void encodeStruct(slang::SessionDesc const& desc);

--- a/source/slang-capture-replay/slang-global-session.cpp
+++ b/source/slang-capture-replay/slang-global-session.cpp
@@ -42,16 +42,20 @@ namespace SlangCapture
 
         slang::ISession* actualSession = nullptr;
 
-        ParameterEncoder* encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_createSession, m_globalSessionHandle);
-        encoder->encodeStruct(desc);
-        encoder->encodeAddress(nullptr);
-        encoder = m_captureManager->endMethodCapture();
+        ParameterEncoder* encoder{};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_createSession, m_globalSessionHandle);
+            encoder->encodeStruct(desc);
+            encoder->encodeAddress(nullptr);
+            encoder = m_captureManager->endMethodCapture();
+        }
 
         SlangResult res = m_actualGlobalSession->createSession(desc, &actualSession);
 
-        encoder->encodeAddress(actualSession);
-        m_captureManager->endMethodCaptureAppendOutput();
-
+        {   // capture output
+            encoder->encodeAddress(actualSession);
+            m_captureManager->endMethodCaptureAppendOutput();
+        }
 
         if (actualSession != nullptr)
         {
@@ -75,6 +79,14 @@ namespace SlangCapture
     SLANG_NO_THROW SlangProfileID SLANG_MCALL GlobalSessionCapture::findProfile(char const* name)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_findProfile, m_globalSessionHandle);
+            encoder->encodeString(name);
+            encoder = m_captureManager->endMethodCapture();
+        }
+
         SlangProfileID profileId = m_actualGlobalSession->findProfile(name);
         return profileId;
     }
@@ -82,24 +94,58 @@ namespace SlangCapture
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::setDownstreamCompilerPath(SlangPassThrough passThrough, char const* path)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_setDownstreamCompilerPath, m_globalSessionHandle);
+            encoder->encodeEnumValue(passThrough);
+            encoder->encodeString(path);
+            m_captureManager->endMethodCapture();
+        }
+
         m_actualGlobalSession->setDownstreamCompilerPath(passThrough, path);
     }
 
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::setDownstreamCompilerPrelude(SlangPassThrough inPassThrough, char const* prelude)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_setDownstreamCompilerPrelude, m_globalSessionHandle);
+            encoder->encodeEnumValue(inPassThrough);
+            encoder->encodeString(prelude);
+            m_captureManager->endMethodCapture();
+        }
+
         m_actualGlobalSession->setDownstreamCompilerPrelude(inPassThrough, prelude);
     }
 
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::getDownstreamCompilerPrelude(SlangPassThrough inPassThrough, ISlangBlob** outPrelude)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_getDownstreamCompilerPrelude, m_globalSessionHandle);
+            encoder->encodeEnumValue(inPassThrough);
+            encoder->encodeAddress(nullptr);
+            encoder = m_captureManager->endMethodCapture();
+        }
+
         m_actualGlobalSession->getDownstreamCompilerPrelude(inPassThrough, outPrelude);
+
+        {
+            encoder->encodeAddress(*outPrelude);
+            m_captureManager->endMethodCaptureAppendOutput();
+        }
     }
 
     SLANG_NO_THROW const char* SLANG_MCALL GlobalSessionCapture::getBuildTagString()
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        // No need to capture this function. It's just a query function and it won't impact the internal state.
         const char* resStr = m_actualGlobalSession->getBuildTagString();
         return resStr;
     }
@@ -107,6 +153,15 @@ namespace SlangCapture
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::setDefaultDownstreamCompiler(SlangSourceLanguage sourceLanguage, SlangPassThrough defaultCompiler)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_setDefaultDownstreamCompiler, m_globalSessionHandle);
+            encoder->encodeEnumValue(sourceLanguage);
+            encoder->encodeEnumValue(defaultCompiler);
+            encoder = m_captureManager->endMethodCapture();
+        }
+
         SlangResult res = m_actualGlobalSession->setDefaultDownstreamCompiler(sourceLanguage, defaultCompiler);
         return res;
     }
@@ -114,6 +169,14 @@ namespace SlangCapture
     SLANG_NO_THROW SlangPassThrough SLANG_MCALL GlobalSessionCapture::getDefaultDownstreamCompiler(SlangSourceLanguage sourceLanguage)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_getDefaultDownstreamCompiler, m_globalSessionHandle);
+            encoder->encodeEnumValue(sourceLanguage);
+            encoder = m_captureManager->endMethodCapture();
+        }
+
         SlangPassThrough passThrough = m_actualGlobalSession->getDefaultDownstreamCompiler(sourceLanguage);
         return passThrough;
     }
@@ -121,43 +184,103 @@ namespace SlangCapture
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::setLanguagePrelude(SlangSourceLanguage inSourceLanguage, char const* prelude)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_setLanguagePrelude, m_globalSessionHandle);
+            encoder->encodeEnumValue(inSourceLanguage);
+            encoder->encodeString(prelude);
+            encoder = m_captureManager->endMethodCapture();
+        }
+
         m_actualGlobalSession->setLanguagePrelude(inSourceLanguage, prelude);
     }
 
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::getLanguagePrelude(SlangSourceLanguage inSourceLanguage, ISlangBlob** outPrelude)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_getLanguagePrelude, m_globalSessionHandle);
+            encoder->encodeEnumValue(inSourceLanguage);
+            encoder->encodeAddress(nullptr);
+            encoder = m_captureManager->endMethodCapture();
+        }
+
         m_actualGlobalSession->getLanguagePrelude(inSourceLanguage, outPrelude);
+
+        {
+            encoder->encodeAddress(*outPrelude);
+            m_captureManager->endMethodCaptureAppendOutput();
+        }
     }
 
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::createCompileRequest(slang::ICompileRequest** outCompileRequest)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_createCompileRequest, m_globalSessionHandle);
+            encoder->encodeAddress(nullptr);
+            encoder = m_captureManager->endMethodCapture();
+        }
+
         SlangResult res = m_actualGlobalSession->createCompileRequest(outCompileRequest);
+
+        {
+            encoder->encodeAddress(*outCompileRequest);
+            m_captureManager->endMethodCaptureAppendOutput();
+        }
+
         return res;
     }
 
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::addBuiltins(char const* sourcePath, char const* sourceString)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_addBuiltins, m_globalSessionHandle);
+            encoder->encodeString(sourcePath);
+            encoder->encodeString(sourceString);
+            encoder = m_captureManager->endMethodCapture();
+        }
+
         m_actualGlobalSession->addBuiltins(sourcePath, sourceString);
     }
 
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::setSharedLibraryLoader(ISlangSharedLibraryLoader* loader)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+        // TODO: Not sure if we need to capture this function. Because this functions is something like the file system
+        // override, it's provided by user code. So capturing it makes no sense. The only way is to wrapper this interface
+        // by our own implementation, and capture it there.
         m_actualGlobalSession->setSharedLibraryLoader(loader);
     }
 
     SLANG_NO_THROW ISlangSharedLibraryLoader* SLANG_MCALL GlobalSessionCapture::getSharedLibraryLoader()
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_getSharedLibraryLoader, m_globalSessionHandle);
+            encoder->encodeAddress(nullptr);
+        }
+
         ISlangSharedLibraryLoader* loader = m_actualGlobalSession->getSharedLibraryLoader();
+
+        {
+            encoder->encodeAddress(loader);
+        }
         return loader;
     }
 
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::checkCompileTargetSupport(SlangCompileTarget target)
     {
+        // No need to capture this function. It's just a query function and it won't impact the internal state.
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
         SlangResult res = m_actualGlobalSession->checkCompileTargetSupport(target);
         return res;
@@ -165,6 +288,7 @@ namespace SlangCapture
 
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::checkPassThroughSupport(SlangPassThrough passThrough)
     {
+        // No need to capture this function. It's just a query function and it won't impact the internal state.
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
         SlangResult res = m_actualGlobalSession->checkPassThroughSupport(passThrough);
         return res;
@@ -173,6 +297,13 @@ namespace SlangCapture
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::compileStdLib(slang::CompileStdLibFlags flags)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_compileStdLib, m_globalSessionHandle);
+            encoder->encodeEnumValue(flags);
+        }
+
         SlangResult res = m_actualGlobalSession->compileStdLib(flags);
         return res;
     }
@@ -180,6 +311,14 @@ namespace SlangCapture
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::loadStdLib(const void* stdLib, size_t stdLibSizeInBytes)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_loadStdLib, m_globalSessionHandle);
+            encoder->encodePointer(stdLib, false, stdLibSizeInBytes);
+            m_captureManager->endMethodCapture();
+        }
+
         SlangResult res = m_actualGlobalSession->loadStdLib(stdLib, stdLibSizeInBytes);
         return res;
     }
@@ -187,12 +326,22 @@ namespace SlangCapture
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::saveStdLib(SlangArchiveType archiveType, ISlangBlob** outBlob)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_saveStdLib, m_globalSessionHandle);
+            encoder->encodeEnumValue(archiveType);
+            encoder->encodeAddress(outBlob);
+            m_captureManager->endMethodCapture();
+        }
+
         SlangResult res = m_actualGlobalSession->saveStdLib(archiveType, outBlob);
         return res;
     }
 
     SLANG_NO_THROW SlangCapabilityID SLANG_MCALL GlobalSessionCapture::findCapability(char const* name)
     {
+        // No need to capture this function. It's just a query function and it won't impact the internal state.
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
         SlangCapabilityID capId = m_actualGlobalSession->findCapability(name);
         return capId;
@@ -201,11 +350,22 @@ namespace SlangCapture
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::setDownstreamCompilerForTransition(SlangCompileTarget source, SlangCompileTarget target, SlangPassThrough compiler)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_setDownstreamCompilerForTransition, m_globalSessionHandle);
+            encoder->encodeEnumValue(source);
+            encoder->encodeEnumValue(target);
+            encoder->encodeEnumValue(compiler);
+            m_captureManager->endMethodCapture();
+        }
+
         m_actualGlobalSession->setDownstreamCompilerForTransition(source, target, compiler);
     }
 
     SLANG_NO_THROW SlangPassThrough SLANG_MCALL GlobalSessionCapture::getDownstreamCompilerForTransition(SlangCompileTarget source, SlangCompileTarget target)
     {
+        // No need to capture this function. It's just a query function and it won't impact the internal state.
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
         SlangPassThrough passThrough = m_actualGlobalSession->getDownstreamCompilerForTransition(source, target);
         return passThrough;
@@ -213,6 +373,7 @@ namespace SlangCapture
 
     SLANG_NO_THROW void SLANG_MCALL GlobalSessionCapture::getCompilerElapsedTime(double* outTotalTime, double* outDownstreamTime)
     {
+        // No need to capture this function. It's just a query function and it won't impact the internal state.
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
         m_actualGlobalSession->getCompilerElapsedTime(outTotalTime, outDownstreamTime);
     }
@@ -220,6 +381,14 @@ namespace SlangCapture
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::setSPIRVCoreGrammar(char const* jsonPath)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_setSPIRVCoreGrammar, m_globalSessionHandle);
+            encoder->encodeString(jsonPath);
+            m_captureManager->endMethodCapture();
+        }
+
         SlangResult res = m_actualGlobalSession->setSPIRVCoreGrammar(jsonPath);
         return res;
     }
@@ -228,14 +397,40 @@ namespace SlangCapture
         int argc, const char* const* argv, slang::SessionDesc* outSessionDesc, ISlangUnknown** outAllocation)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_parseCommandLineArguments, m_globalSessionHandle);
+            encoder->encodeStringArray(argv, argc);
+            encoder = m_captureManager->endMethodCapture();
+        }
+
         SlangResult res = m_actualGlobalSession->parseCommandLineArguments(argc, argv, outSessionDesc, outAllocation);
+
+        {
+            encoder->encodeStruct(*outSessionDesc);
+            encoder->encodeAddress(*outAllocation);
+        }
         return res;
     }
 
     SLANG_NO_THROW SlangResult SLANG_MCALL GlobalSessionCapture::getSessionDescDigest(slang::SessionDesc* sessionDesc, ISlangBlob** outBlob)
     {
         slangCaptureLog(LogLevel::Verbose, "%p: %s\n", m_actualGlobalSession.get(), __PRETTY_FUNCTION__);
+
+        ParameterEncoder* encoder {};
+        {
+            encoder = m_captureManager->beginMethodCapture(ApiCallId::IGlobalSession_getSessionDescDigest, m_globalSessionHandle);
+            encoder->encodeStruct(*sessionDesc);
+            encoder = m_captureManager->endMethodCapture();
+        }
+
         SlangResult res = m_actualGlobalSession->getSessionDescDigest(sessionDesc, outBlob);
+
+        {
+            encoder->encodeAddress(*outBlob);
+            m_captureManager->endMethodCaptureAppendOutput();
+        }
         return res;
     }
 }

--- a/source/slang-capture-replay/slang-global-session.h
+++ b/source/slang-capture-replay/slang-global-session.h
@@ -77,7 +77,7 @@ namespace SlangCapture
             // session at the same time. So even if there is one session used by multiple threads, those threads will execute the compile jobs
             // sequentially.
             std::unique_ptr<CaptureManager>      m_captureManager;
-            uint64_t                             m_thisHandle = 0;
+            uint64_t                             m_globalSessionHandle = 0;
     };
 } // namespace Slang
 


### PR DESCRIPTION
The basic format for the capture encode is as follow:

Header:
4 bytes: magic number ('H' 'E' 'A' 'D' )
4 bytes: call id - specify the method name
8 bytes: handle id - specify 'this' pointer
8 bytes: payload size in bytes - specify the data size of parameters
8 bytes: thread id

Payload:
Encode for all the parameters.

Tailer (optional):
Tailer is an optional, it only used when the output of the method is
also stored in the method. Usually it just the opaque handle allocated
by slang.

4 bytes: magic number ('T' 'A' 'I' 'L')
4 bytes: payload size in bytes.


Add encoding logic for all the member functions of IGlobalSession,
except those query functions that do not impact the internal state
of slang.

Because some get functions will invoke allocations by slang, these
functions are account for the "query functions". Therefore those
functions are still captured.

All the allocations are stored by using their address, because those
allocations are opaque and will finally be used as inputs for other
APIs, there is no need to store the data. We just need to track
those address and know which APIs will consume them.

