### PR TITLE
Metal: Implement fix for non vector4 texture Load/Sample

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -2385,12 +2385,10 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
                 // lod is not supported for 1D texture
                 if (isArray == 1)
                     // Tv read(uint coord, uint array, uint lod = 0) const
-                    __intrinsic_asm "$c$0.read(uint(($1).x), uint(($1).y, uint(($1).z))$z";
-                    //__intrinsic_asm "$c$0.read(uint(($1).x), uint(($1).y))$z";
+                    __intrinsic_asm "$c$0.read(uint(($1).x), uint(($1).y))$z";
                 else
                     // Tv read(uint coord, uint lod = 0) const
-                    __intrinsic_asm "$c$0.read(uint(($1).x), uint(($1).y)$z";
-                    //__intrinsic_asm "$c$0.read(uint(($1).x))$z";
+                    __intrinsic_asm "$c$0.read(uint(($1).x))$z";
                 break;
             case $(SLANG_TEXTURE_2D):
                 if (isShadow == 1)

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -1135,11 +1135,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_1D):
-                        __intrinsic_asm "$0.sample($1, ($2).x, uint(($2).y))";
+                        __intrinsic_asm "$c$0.sample($1, ($2).x, uint(($2).y))$z";
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z))";
+                        __intrinsic_asm "$c$0.sample($1, ($2).xy, uint(($2).z))$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "$0.sample($1, ($2).xyz, uint(($2).w))";
+                        __intrinsic_asm "$c$0.sample($1, ($2).xyz, uint(($2).w))$z";
                     }
                 }
                 else
@@ -1150,7 +1150,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     case $(SLANG_TEXTURE_2D):
                     case $(SLANG_TEXTURE_3D):
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm ".sample";
+                        __intrinsic_asm "$c$0.sample($1, $2)$z";
                     }
                 }
                 // TODO: This needs to be handled by the capability system
@@ -1219,7 +1219,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z), $3)";
+                        __intrinsic_asm "$c$0.sample($1, ($2).xy, uint(($2).z), $3)$z";
                     }
                 }
                 else
@@ -1228,7 +1228,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     {
                     case $(SLANG_TEXTURE_2D):
                     case $(SLANG_TEXTURE_3D):
-                        __intrinsic_asm ".sample";
+                        __intrinsic_asm "$c$0.sample($1, $2, $3)$z";
                     }
                 }
                 // TODO: This needs to be handled by the capability system
@@ -1267,7 +1267,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z), min_lod_clamp($4), $3)";
+                        __intrinsic_asm "$c$0.sample($1, ($2).xy, uint(($2).z), min_lod_clamp($4), $3)$z";
                     }
                 }
                 else
@@ -1276,7 +1276,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     {
                     case $(SLANG_TEXTURE_2D):
                     case $(SLANG_TEXTURE_3D):
-                        __intrinsic_asm "$0.sample($1, $2, min_lod_clamp($4), $3)";
+                        __intrinsic_asm "$c$0.sample($1, $2, min_lod_clamp($4), $3)$z";
                     }
                 }
                 // TODO: This needs to be handled by the capability system
@@ -1333,9 +1333,9 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z), bias($3))";
+                        __intrinsic_asm "$c$0.sample($1, ($2).xy, uint(($2).z), bias($3))$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "$0.sample($1, ($2).xyz, uint(($2).w), bias($3))";
+                        __intrinsic_asm "$c$0.sample($1, ($2).xyz, uint(($2).w), bias($3))$z";
                     }
                 }
                 else
@@ -1345,7 +1345,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     case $(SLANG_TEXTURE_2D):
                     case $(SLANG_TEXTURE_3D):
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "$0.sample($1, $2, bias($3))";
+                        __intrinsic_asm "$c$0.sample($1, $2, bias($3))$z";
                     }
                 }
                 // TODO: This needs to be handled by the capability system
@@ -1383,7 +1383,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z), bias($3), $4)";
+                        __intrinsic_asm "$c$0.sample($1, ($2).xy, uint(($2).z), bias($3), $4)$z";
                     }
                 }
                 else
@@ -1392,7 +1392,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     {
                     case $(SLANG_TEXTURE_2D):
                     case $(SLANG_TEXTURE_3D):
-                        __intrinsic_asm "$0.sample($1, $2, bias($3), $4)";
+                        __intrinsic_asm "$c$0.sample($1, $2, bias($3), $4)$z";
                     }
                 }
                 // TODO: This needs to be handled by the capability system
@@ -1637,9 +1637,9 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z), gradient2d($3, $4))";
+                        __intrinsic_asm "$c$0.sample($1, ($2).xy, uint(($2).z), gradient2d($3, $4))$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "$0.sample($1, ($2).xyz, uint(($2).w), gradientcube($3, $4))";
+                        __intrinsic_asm "$c$0.sample($1, ($2).xyz, uint(($2).w), gradientcube($3, $4))$z";
                     }
                 }
                 else
@@ -1647,11 +1647,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "$0.sample($1, $2, gradient2d($3, $4))";
+                        __intrinsic_asm "$c$0.sample($1, $2, gradient2d($3, $4))$z";
                     case $(SLANG_TEXTURE_3D):
-                        __intrinsic_asm "$0.sample($1, $2, gradient3d($3, $4))";
+                        __intrinsic_asm "$c$0.sample($1, $2, gradient3d($3, $4))$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "$0.sample($1, $2, gradientcube($3, $4))";
+                        __intrinsic_asm "$c$0.sample($1, $2, gradientcube($3, $4))$z";
                     }
                 }
                 // TODO: This needs to be handled by the capability system
@@ -1688,7 +1688,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z), gradient2d($3, $4), $5)";
+                        __intrinsic_asm "$c$0.sample($1, ($2).xy, uint(($2).z), gradient2d($3, $4), $5)$z";
                     }
                 }
                 else
@@ -1696,9 +1696,9 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "$0.sample($1, $2, gradient2d($3, $4), $5)";
+                        __intrinsic_asm "$c$0.sample($1, $2, gradient2d($3, $4), $5)$z";
                     case $(SLANG_TEXTURE_3D):
-                        __intrinsic_asm "$0.sample($1, $2, gradient3d($3, $4), $5)";
+                        __intrinsic_asm "$c$0.sample($1, $2, gradient3d($3, $4), $5)$z";
                     }
                 }
                 // TODO: This needs to be handled by the capability system
@@ -1737,7 +1737,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "$0.sample($1, ($2).xy, uint(($2).z), gradient2d($3, $4), min_lod_clamp($6), $5)";
+                        __intrinsic_asm "$c$0.sample($1, ($2).xy, uint(($2).z), gradient2d($3, $4), min_lod_clamp($6), $5)$z";
                     }
                 }
                 else
@@ -1745,9 +1745,9 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "$0.sample($1, $2, gradient2d($3, $4), min_lod_clamp($6), $5)";
+                        __intrinsic_asm "$c$0.sample($1, $2, gradient2d($3, $4), min_lod_clamp($6), $5)$z";
                     case $(SLANG_TEXTURE_3D):
-                        __intrinsic_asm "$0.sample($1, $2, gradient3d($3, $4), min_lod_clamp($6), $5)";
+                        __intrinsic_asm "$c$0.sample($1, $2, gradient3d($3, $4), min_lod_clamp($6), $5)$z";
                     }
                 }
                 // TODO: This needs to be handled by the capability system
@@ -2385,35 +2385,37 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
                 // lod is not supported for 1D texture
                 if (isArray == 1)
                     // Tv read(uint coord, uint array, uint lod = 0) const
-                    __intrinsic_asm "$0.read(uint(($1).x), uint(($1).y))";
+                    __intrinsic_asm "$c$0.read(uint(($1).x), uint(($1).y, uint(($1).z))$z";
+                    //__intrinsic_asm "$c$0.read(uint(($1).x), uint(($1).y))$z";
                 else
                     // Tv read(uint coord, uint lod = 0) const
-                    __intrinsic_asm "$0.read(uint(($1).x))";
+                    __intrinsic_asm "$c$0.read(uint(($1).x), uint(($1).y)$z";
+                    //__intrinsic_asm "$c$0.read(uint(($1).x))$z";
                 break;
             case $(SLANG_TEXTURE_2D):
                 if (isShadow == 1)
                 {
                     if (isArray == 1)
                         // T read(uint2 coord, uint array, uint lod = 0) const
-                        __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
+                        __intrinsic_asm "$c$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))$z";
                     else
                         // T read(uint2 coord, uint lod = 0) const
-                        __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z))";
+                        __intrinsic_asm "$c$0.read(vec<uint,2>(($1).xy), uint(($1).z))$z";
                 }
                 else
                 {
                     if (isArray == 1)
                         // Tv read(uint2 coord, uint array, uint lod = 0) const
-                        __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
+                        __intrinsic_asm "$c$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))$z";
                     else
                         // Tv read(uint2 coord, uint lod = 0) const
-                        __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z))";
+                        __intrinsic_asm "$c$0.read(vec<uint,2>(($1).xy), uint(($1).z))$z";
                 }
                 break;
             case $(SLANG_TEXTURE_3D):
                 if (isShadow == 0 && isArray == 0)
                     // Tv read(uint3 coord, uint lod = 0) const
-                    __intrinsic_asm "$0.read(vec<uint,3>(($1).xyz), uint(($1).w))";
+                    __intrinsic_asm "$c$0.read(vec<uint,3>(($1).xyz), uint(($1).w))$z";
                 break;
             case $(SLANG_TEXTURE_CUBE):
                 if (isShadow == 1)
@@ -2423,7 +2425,7 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
                         __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
                     else
                         // T read(uint2 coord, uint face, uint lod = 0) const
-                        __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
+                        __intrinsic_asm "$c$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))$z";
                 }
                 else
                 {
@@ -2432,7 +2434,7 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
                         __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
                     else
                         // Tv read(uint2 coord, uint face, uint lod = 0) const
-                        __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
+                        __intrinsic_asm "$c$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))$z";
                 }
                 break;
             }
@@ -2583,20 +2585,20 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,form
                         if (isArray == 1)
                             // Document seems to have a typo. `lod` must be `sample`.
                             // Tv read(uint2 coord, uint array, uint lod = 0) const
-                            __intrinsic_asm "$0.read(($1).xy, ($1).z, uint($2))";
+                            __intrinsic_asm "$c$0.read(($1).xy, ($1).z, uint($2))$z";
                         else
                             // T read(uint2 coord, uint sample) const
-                            __intrinsic_asm "$0.read($1, uint($2))";
+                            __intrinsic_asm "$c$0.read($1, uint($2))$z";
                     }
                     else
                     {
                         if (isArray == 1)
                             // Document seems to have a typo. `lod` must be `sample`.
                             // Tv read(uint2 coord, uint array, uint lod = 0) const
-                            __intrinsic_asm "$0.read(($1).xy, ($1).z, uint($2))";
+                            __intrinsic_asm "$c$0.read(($1).xy, ($1).z, uint($2))$z";
                         else
                             // Tv read(uint2 coord, uint sample) const
-                            __intrinsic_asm "$0.read($1, uint($2))";
+                            __intrinsic_asm "$c$0.read($1, uint($2))$z";
                     }
                     break;
                 }
@@ -2788,35 +2790,35 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,form
                     // lod is not supported for 1D texture
                     if (isArray == 1)
                         // Tv read(uint coord, uint array, uint lod = 0) const
-                        __intrinsic_asm "$0.read(uint(($1).x), uint(($1).y))";
+                        __intrinsic_asm "$c$0.read(uint(($1).x), uint(($1).y))$z";
                     else
                         // Tv read(uint coord, uint lod = 0) const
-                        __intrinsic_asm "$0.read(uint(($1).x))";
+                        __intrinsic_asm "$c$0.read(uint($1))$z";
                     break;
                 case $(SLANG_TEXTURE_2D):
                     if (isShadow == 1)
                     {
                         if (isArray == 1)
                             // T read(uint2 coord, uint array, uint lod = 0) const
-                            __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
+                            __intrinsic_asm "$c$0.read(vec<uint,2>(($1).xy), uint(($1).z))$z";
                         else
                             // T read(uint2 coord, uint lod = 0) const
-                            __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z))";
+                            __intrinsic_asm "$c$0.read(vec<uint,2>(($1).xy))$z";
                     }
                     else
                     {
                         if (isArray == 1)
                             // Tv read(uint2 coord, uint array, uint lod = 0) const
-                            __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
+                            __intrinsic_asm "$c$0.read(vec<uint,2>(($1).xy), uint(($1).z))$z";
                         else
                             // Tv read(uint2 coord, uint lod = 0) const
-                            __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z))";
+                            __intrinsic_asm "$c$0.read(vec<uint,2>(($1).xy))$z";
                     }
                     break;
                 case $(SLANG_TEXTURE_3D):
                     if (isShadow == 0 && isArray == 0)
                         // Tv read(uint3 coord, uint lod = 0) const
-                        __intrinsic_asm "$0.read(vec<uint,3>(($1).xyz), uint(($1).w))";
+                        __intrinsic_asm "$c$0.read(vec<uint,3>(($1).xyz))$z";
                     break;
                 case $(SLANG_TEXTURE_CUBE):
                     if (isShadow == 1)
@@ -2826,7 +2828,7 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,form
                             __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z)%6, uint(($1).z)/6, uint(($1).w))";
                         else
                             // T read(uint2 coord, uint face, uint lod = 0) const
-                            __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
+                            __intrinsic_asm "$c$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))$z";
                     }
                     else
                     {
@@ -2835,7 +2837,7 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,form
                             __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z)%6, uint(($1).z)/6, uint(($1).w))";
                         else
                             // Tv read(uint2 coord, uint face, uint lod = 0) const
-                            __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))";
+                            __intrinsic_asm "$c$0.read(vec<uint,2>(($1).xy), uint(($1).z), uint(($1).w))$z";
                     }
                     break;
                 }
@@ -3044,20 +3046,20 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,form
                         if (isArray == 1)
                             // The document seems to have a typo. `lod` must mean `sample`.
                             // Tv read(uint2 coord, uint array, uint lod = 0) const
-                            __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), $2)";
+                            __intrinsic_asm "$c$0.read(vec<uint,2>(($1).xy), uint(($1).z), $2)$z";
                         else
                             // T read(uint2 coord, uint sample) const
-                            __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), $2)";
+                            __intrinsic_asm "$c$0.read(vec<uint,2>(($1).xy), $2)$z";
                     }
                     else
                     {
                         if (isArray == 1)
                             // The document seems to have a typo. `lod` must mean `sample`.
                             // Tv read(uint2 coord, uint array, uint lod = 0) const
-                            __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), uint(($1).z), $2)";
+                            __intrinsic_asm "$c$0.read(vec<uint,2>(($1).xy), uint(($1).z), $2)$z";
                         else
                             // Tv read(uint2 coord, uint sample) const
-                            __intrinsic_asm "$0.read(vec<uint,2>(($1).xy), $2)";
+                            __intrinsic_asm "$c$0.read(vec<uint,2>(($1).xy), $2)$z";
                     }
                     break;
                 }
@@ -15010,7 +15012,7 @@ extension __TextureImpl<T, __ShapeBuffer, 0, 0, 0, $(aa), 0, 0, format>
         __target_switch
         {
         case hlsl: __intrinsic_asm ".Load";
-        case metal: __intrinsic_asm "$0.read(uint($1))";
+        case metal: __intrinsic_asm "$c$0.read(uint($1))$z";
         case glsl: __intrinsic_asm "$(glslLoadFuncName)($0, $1)$z";
         case spirv: return spirv_asm {
                 %sampled:__sampledType(T) = $(spvLoadInstName) $this $location;

--- a/tests/bugs/buffer-swizzle-store.slang
+++ b/tests/bugs/buffer-swizzle-store.slang
@@ -1,9 +1,6 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj -output-using-type
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-mtl -compute -shaderobj -output-using-type
-//TEST:SIMPLE(filecheck=METALLIB): -target metallib -stage compute -entry computeMain
-
-//METALLIB: @computeMain
+//DISABLE_TEST(compute):COMPARE_COMPUTE:-slang -shaderobj -mtl
 
 //TEST_INPUT: RWTexture2D(format=R16G16_FLOAT, size=4, content = one, mipMaps = 1):name g_test
 [format("rg16f")]

--- a/tests/bugs/buffer-swizzle-store.slang
+++ b/tests/bugs/buffer-swizzle-store.slang
@@ -1,6 +1,9 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj -output-using-type
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -output-using-type
-//DISABLE_TEST(compute):COMPARE_COMPUTE:-slang -shaderobj -mtl
+//TEST(compute):COMPARE_COMPUTE_EX:-mtl -compute -shaderobj -output-using-type
+//TEST:SIMPLE(filecheck=METALLIB): -target metallib -stage compute -entry computeMain
+
+//METALLIB: @computeMain
 
 //TEST_INPUT: RWTexture2D(format=R16G16_FLOAT, size=4, content = one, mipMaps = 1):name g_test
 [format("rg16f")]

--- a/tests/metal/texture.slang
+++ b/tests/metal/texture.slang
@@ -9,6 +9,21 @@
 //TEST_INPUT: ubuffer(data=[0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
+//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_f32v3
+Texture1D<float3> t1D_f32v3;
+//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_f32v3
+Texture2D<float3> t2D_f32v3;
+//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_f32v3
+Texture3D<float3> t3D_f32v3;
+//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_f32v3
+TextureCube<float3> tCube_f32v3;
+//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_f32v3
+Texture1DArray<float3> t1DArray_f32v3;
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_f32v3
+Texture2DArray<float3> t2DArray_f32v3;
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_f32v3
+TextureCubeArray<float3> tCubeArray_f32v3;
+
 //TEST_INPUT: Texture1D(size=4, content = zero):name t1D_f32
 Texture1D<float4> t1D_f32;
 //TEST_INPUT: Texture2D(size=4, content = zero):name t2D_f32
@@ -173,19 +188,20 @@ SamplerState samplerState;
 SamplerComparisonState shadowSampler;
 
 
-__generic<T:__BuiltinArithmeticType>
+__generic<T:__BuiltinArithmeticType, let N:int>
 bool TEST_texture(
-    Texture1D<vector<T,4>> t1D,
-    Texture2D<vector<T,4>> t2D,
-    Texture3D<vector<T,4>> t3D,
-    TextureCube<vector<T,4>> tCube,
-    Texture1DArray<vector<T,4>> t1DArray,
-    Texture2DArray<vector<T,4>> t2DArray,
-    TextureCubeArray<vector<T,4>> tCubeArray
+    Texture1D<vector<T,N>> t1D,
+    Texture2D<vector<T,N>> t2D,
+    Texture3D<vector<T,N>> t3D,
+    TextureCube<vector<T,N>> tCube,
+    Texture1DArray<vector<T,N>> t1DArray,
+    Texture2DArray<vector<T,N>> t2DArray,
+    TextureCubeArray<vector<T,N>> tCubeArray
 )
 {
     // METAL-LABEL: TEST_texture
-    typealias Tv = vector<T,4>;
+    typealias Tvn = vector<T,N>;
+    typealias Tv4 = vector<T,4>;
 
     float u = 0;
     float u2 = 0.5;
@@ -357,31 +373,31 @@ bool TEST_texture(
 
         // METAL: t1D{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_1d.v4f32(
-        && all(Tv(T(0)) == t1D.Sample(samplerState, u))
+        && all(Tvn(T(0)) == t1D.Sample(samplerState, u))
 
         // METAL: t2D{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
-        && all(Tv(T(0)) == t2D.Sample(samplerState, float2(u, u)))
+        && all(Tvn(T(0)) == t2D.Sample(samplerState, float2(u, u)))
 
         // METAL: t3D{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
-        && all(Tv(T(0)) == t3D.Sample(samplerState, float3(u, u, u)))
+        && all(Tvn(T(0)) == t3D.Sample(samplerState, float3(u, u, u)))
 
         // METAL: tCube{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_cube.v4f32(
-        && all(Tv(T(0)) == tCube.Sample(samplerState, normalize(float3(u, 1 - u, u))))
+        && all(Tvn(T(0)) == tCube.Sample(samplerState, normalize(float3(u, 1 - u, u))))
 
         // METAL: t1DArray{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_1d_array.v4f32(
-        && all(Tv(T(0)) == t1DArray.Sample(samplerState, float2(u, 0)))
+        && all(Tvn(T(0)) == t1DArray.Sample(samplerState, float2(u, 0)))
 
         // METAL: t2DArray{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
-        && all(Tv(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0)))
+        && all(Tvn(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0)))
 
         // METAL: tCubeArray{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_cube_array.v4f32(
-        && all(Tv(T(0)) == tCubeArray.Sample(samplerState, float4(normalize(float3(u, 1 - u, u)), 0)))
+        && all(Tvn(T(0)) == tCubeArray.Sample(samplerState, float4(normalize(float3(u, 1 - u, u)), 0)))
 
         // Offset variant
 
@@ -389,15 +405,15 @@ bool TEST_texture(
 
         // METAL: t2D{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
-        && all(Tv(T(0)) == t2D.Sample(samplerState, float2(u, u), int2(1, 1)))
+        && all(Tvn(T(0)) == t2D.Sample(samplerState, float2(u, u), int2(1, 1)))
 
         // METAL: t3D{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
-        && all(Tv(T(0)) == t3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1)))
+        && all(Tvn(T(0)) == t3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1)))
 
         // METAL: t2DArray{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
-        && all(Tv(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1)))
+        && all(Tvn(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1)))
 
         // Clamp variant
 
@@ -405,15 +421,15 @@ bool TEST_texture(
 
         // METAL: t2D{{.*}}.sample({{.*}} min_lod_clamp(
         // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
-        && all(Tv(T(0)) == t2D.Sample(samplerState, float2(u, u), int2(1, 1), float(1)))
+        && all(Tvn(T(0)) == t2D.Sample(samplerState, float2(u, u), int2(1, 1), float(1)))
 
         // METAL: t3D{{.*}}.sample({{.*}} min_lod_clamp(
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
-        && all(Tv(T(0)) == t3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1), float(1)))
+        && all(Tvn(T(0)) == t3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1), float(1)))
 
         // METAL: t2DArray{{.*}}.sample({{.*}} min_lod_clamp(
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
-        && all(Tv(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1), float(1)))
+        && all(Tvn(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1), float(1)))
 
         // ===============
         // T SampleBias()
@@ -423,23 +439,23 @@ bool TEST_texture(
 
         // METAL: t2D{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
-        && all(Tv(T(0)) == t2D.SampleBias(samplerState, float2(u, u), float(-1)))
+        && all(Tvn(T(0)) == t2D.SampleBias(samplerState, float2(u, u), float(-1)))
 
         // METAL: t3D{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
-        && all(Tv(T(0)) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1)))
+        && all(Tvn(T(0)) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1)))
 
         // METAL: tCube{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_cube.v4f32(
-        && all(Tv(T(0)) == tCube.SampleBias(samplerState, normalize(float3(u, 1 - u, u)), float(-1)))
+        && all(Tvn(T(0)) == tCube.SampleBias(samplerState, normalize(float3(u, 1 - u, u)), float(-1)))
 
         // METAL: t2DArray{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
-        && all(Tv(T(0)) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1)))
+        && all(Tvn(T(0)) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1)))
 
         // METAL: tCubeArray{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_cube_array.v4f32(
-        && all(Tv(T(0)) == tCubeArray.SampleBias(samplerState, float4(normalize(float3(u, 1 - u, u)), 0), float(-1)))
+        && all(Tvn(T(0)) == tCubeArray.SampleBias(samplerState, float4(normalize(float3(u, 1 - u, u)), 0), float(-1)))
 
         // Offset variant
 
@@ -447,15 +463,15 @@ bool TEST_texture(
 
         // METAL: t2D{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
-        && all(Tv(T(0)) == t2D.SampleBias(samplerState, float2(u, u), float(-1), int2(1, 1)))
+        && all(Tvn(T(0)) == t2D.SampleBias(samplerState, float2(u, u), float(-1), int2(1, 1)))
 
         // METAL: t3D{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
-        && all(Tv(T(0)) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1), int3(1, 1, 1)))
+        && all(Tvn(T(0)) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1), int3(1, 1, 1)))
 
         // METAL: t2DArray{{.*}}.sample({{.*}}
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
-        && all(Tv(T(0)) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1), int2(1, 1)))
+        && all(Tvn(T(0)) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1), int2(1, 1)))
 
         // ===================================
         //  T SampleLevel()
@@ -465,23 +481,23 @@ bool TEST_texture(
 
         // METAL: t2D{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
-        && all(Tv(T(0)) == t2D.SampleLevel(samplerState, float2(u, u), 0))
+        && all(Tvn(T(0)) == t2D.SampleLevel(samplerState, float2(u, u), 0))
 
         // METAL: t3D{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
-        && all(Tv(T(0)) == t3D.SampleLevel(samplerState, float3(u, u, u), 0))
+        && all(Tvn(T(0)) == t3D.SampleLevel(samplerState, float3(u, u, u), 0))
 
         // METAL: tCube{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_cube.v4f32(
-        && all(Tv(T(0)) == tCube.SampleLevel(samplerState, normalize(float3(u, 1 - u, u)), 0))
+        && all(Tvn(T(0)) == tCube.SampleLevel(samplerState, normalize(float3(u, 1 - u, u)), 0))
 
         // METAL: t2DArray{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
-        && all(Tv(T(0)) == t2DArray.SampleLevel(samplerState, float3(u, u, 0), 0))
+        && all(Tvn(T(0)) == t2DArray.SampleLevel(samplerState, float3(u, u, 0), 0))
 
         // METAL: tCubeArray{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_cube_array.v4f32(
-        && all(Tv(T(0)) == tCubeArray.SampleLevel(samplerState, float4(normalize(float3(u, 1 - u, u)), 0), 0))
+        && all(Tvn(T(0)) == tCubeArray.SampleLevel(samplerState, float4(normalize(float3(u, 1 - u, u)), 0), 0))
 
         // Offset variant
 
@@ -489,15 +505,15 @@ bool TEST_texture(
 
         // METAL: t2D{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_2d.v4f32(
-        && all(Tv(T(0)) == t2D.SampleLevel(samplerState, float2(u, u), 0, int2(1, 1)))
+        && all(Tvn(T(0)) == t2D.SampleLevel(samplerState, float2(u, u), 0, int2(1, 1)))
 
         // METAL: t3D{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_3d.v4f32(
-        && all(Tv(T(0)) == t3D.SampleLevel(samplerState, float3(u, u, u), 0, int3(1, 1, 1)))
+        && all(Tvn(T(0)) == t3D.SampleLevel(samplerState, float3(u, u, u), 0, int3(1, 1, 1)))
 
         // METAL: t2DArray{{.*}}.sample({{.*}} level(
         // METALLIB: call {{.*}}.sample_texture_2d_array.v4f32(
-        && all(Tv(T(0)) == t2DArray.SampleLevel(samplerState, float3(u, u, 0), 0, int2(1, 1)))
+        && all(Tvn(T(0)) == t2DArray.SampleLevel(samplerState, float3(u, u, 0), 0, int2(1, 1)))
 
         // ==================
         // float SampleCmp()
@@ -557,29 +573,29 @@ bool TEST_texture(
 
         // METAL: t2D{{.*}}.gather(
         // METALLIB: call {{.*}}.gather_texture_2d.v4f32(
-        && all(Tv(T(0)) == t2D.Gather(samplerState, float2(u, u)))
+        && all(Tv4(T(0)) == t2D.Gather(samplerState, float2(u, u)))
 
         // METAL: tCube{{.*}}.gather(
         // METALLIB: call {{.*}}.gather_texture_cube.v4f32(
-        && all(Tv(T(0)) == tCube.Gather(samplerState, normalize(float3(u, 1 - u, u))))
+        && all(Tv4(T(0)) == tCube.Gather(samplerState, normalize(float3(u, 1 - u, u))))
 
         // METAL: t2DArray{{.*}}.gather(
         // METALLIB: call {{.*}}.gather_texture_2d_array.v4f32(
-        && all(Tv(T(0)) == t2DArray.Gather(samplerState, float3(u, u, 0)))
+        && all(Tv4(T(0)) == t2DArray.Gather(samplerState, float3(u, u, 0)))
 
         // METAL: tCubeArray{{.*}}.gather(
         // METALLIB: call {{.*}}.gather_texture_cube_array.v4f32(
-        && all(Tv(T(0)) == tCubeArray.Gather(samplerState, float4(normalize(float3(u, 1 - u, u)), 0)))
+        && all(Tv4(T(0)) == tCubeArray.Gather(samplerState, float4(normalize(float3(u, 1 - u, u)), 0)))
 
         // Offset variant
 
         // METAL: t2D{{.*}}.gather(
         // METALLIB: call {{.*}}.gather_texture_2d.v4f32(
-        && all(Tv(T(0)) == t2D.Gather(samplerState, float2(u2, u), int2(0, 0)))
+        && all(Tv4(T(0)) == t2D.Gather(samplerState, float2(u2, u), int2(0, 0)))
 
         // METAL: t2DArray{{.*}}.gather(
         // METALLIB: call {{.*}}.gather_texture_2d_array.v4f32(
-        && all(Tv(T(0)) == t2DArray.Gather(samplerState, float3(u2, u, 0), int2(0, 0)))
+        && all(Tv4(T(0)) == t2DArray.Gather(samplerState, float3(u2, u, 0), int2(0, 0)))
 
         // =====================================
         //  T SampleGrad()
@@ -589,33 +605,33 @@ bool TEST_texture(
 
         // METAL: t2D{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_2d_grad.v4f32(
-        && all(Tv(T(0)) == t2D.SampleGrad(samplerState, float2(u, u), float2(ddx, ddx), float2(ddy, ddy)))
+        && all(Tvn(T(0)) == t2D.SampleGrad(samplerState, float2(u, u), float2(ddx, ddx), float2(ddy, ddy)))
 
         // METAL: t3D{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_3d_grad.v4f32(
-        && all(Tv(T(0)) == t3D.SampleGrad(samplerState, float3(u, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
+        && all(Tvn(T(0)) == t3D.SampleGrad(samplerState, float3(u, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
 
         // METAL: tCube{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_cube_grad.v4f32(
-        && all(Tv(T(0)) == tCube.SampleGrad(samplerState, normalize(float3(u, 1 - u, u)), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
+        && all(Tvn(T(0)) == tCube.SampleGrad(samplerState, normalize(float3(u, 1 - u, u)), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
 
         // METAL: t2DArray{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_2d_array_grad.v4f32(
-        && all(Tv(T(0)) == t2DArray.SampleGrad(samplerState, float3(u, u, 0.0f), float2(ddx, ddx), float2(ddy, ddy)))
+        && all(Tvn(T(0)) == t2DArray.SampleGrad(samplerState, float3(u, u, 0.0f), float2(ddx, ddx), float2(ddy, ddy)))
 
         // Offset variant
 
         // METAL: t2D{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_2d_grad.v4f32(
-        && all(Tv(T(0)) == t2D.SampleGrad(samplerState, float2(u2, u), float2(ddx, ddx), float2(ddy, ddy), int2(0, 0)))
+        && all(Tvn(T(0)) == t2D.SampleGrad(samplerState, float2(u2, u), float2(ddx, ddx), float2(ddy, ddy), int2(0, 0)))
 
         // METAL: t3D{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_3d_grad.v4f32(
-        && all(Tv(T(0)) == t3D.SampleGrad(samplerState, float3(u2, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy), int3(0, 0, 0)))
+        && all(Tvn(T(0)) == t3D.SampleGrad(samplerState, float3(u2, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy), int3(0, 0, 0)))
 
         // METAL: t2DArray{{.*}}.sample(
         // METALLIB: call {{.*}}.sample_texture_2d_array_grad.v4f32(
-        && all(Tv(T(0)) == t2DArray.SampleGrad(samplerState, float3(u2, u, 0.0f), float2(ddx, ddx), float2(ddy, ddy), int2(0, 0)))
+        && all(Tvn(T(0)) == t2DArray.SampleGrad(samplerState, float3(u2, u, 0.0f), float2(ddx, ddx), float2(ddy, ddy), int2(0, 0)))
 
         // ===================
         //  T Load()
@@ -623,23 +639,23 @@ bool TEST_texture(
 
         // METAL: t1D{{.*}}.read(
         // METALLIB: call {{.*}}.read_texture_1d.v4f32(
-        && all(Tv(T(0)) == t1D.Load(int2(0, 0)))
+        && all(Tvn(T(0)) == t1D.Load(int2(0, 0)))
 
         // METAL: t2D{{.*}}.read(
         // METALLIB: call {{.*}}.read_texture_2d.v4f32(
-        && all(Tv(T(0)) == t2D.Load(int3(0, 0, 0)))
+        && all(Tvn(T(0)) == t2D.Load(int3(0, 0, 0)))
 
         // METAL: t3D{{.*}}.read(
         // METALLIB: call {{.*}}.read_texture_3d.v4f32(
-        && all(Tv(T(0)) == t3D.Load(int4(0, 0, 0, 0)))
+        && all(Tvn(T(0)) == t3D.Load(int4(0, 0, 0, 0)))
 
         // METAL: t1DArray{{.*}}.read(
         // METALLIB: call {{.*}}.read_texture_1d_array.v4f32(
-        && all(Tv(T(0)) == t1DArray.Load(int3(0, 0, 0)))
+        && all(Tvn(T(0)) == t1DArray.Load(int3(0, 0, 0)))
 
         // METAL: t2DArray{{.*}}.read(
         // METALLIB: call {{.*}}.read_texture_2d_array.v4f32(
-        && all(Tv(T(0)) == t2DArray.Load(int4(0, 0, 0, 0)))
+        && all(Tvn(T(0)) == t2DArray.Load(int4(0, 0, 0, 0)))
 
         // Offset variant
 
@@ -656,6 +672,14 @@ void computeMain()
     // HLSL: void computeMain(
 
     bool result = true
+        && TEST_texture<float, 3>(
+            t1D_f32v3,
+            t2D_f32v3,
+            t3D_f32v3,
+            tCube_f32v3,
+            t1DArray_f32v3,
+            t2DArray_f32v3,
+            tCubeArray_f32v3)
         // Metal textures support `Tv` types, which "denotes a 4-component vector
         // type based on the templated type <T> for declaring the texture type:
         //  - If T is float, Tv is float4.
@@ -664,7 +688,7 @@ void computeMain()
         //  - If T is uint, Tv is uint4.
         //  - If T is short, Tv is short4.
         //  - If T is ushort, Tv is ushort4."
-        && TEST_texture<float>(
+        && TEST_texture<float, 4>(
             t1D_f32,
             t2D_f32,
             t3D_f32,
@@ -673,7 +697,7 @@ void computeMain()
             t2DArray_f32,
             tCubeArray_f32)
 #if !defined(EXCLUDE_HALF_TYPE)
-        && TEST_texture<half>(
+        && TEST_texture<half, 4>(
             t1D_f16,
             t2D_f16,
             t3D_f16,
@@ -683,7 +707,7 @@ void computeMain()
             tCubeArray_f16)
 #endif
 #if !defined(EXCLUDE_INTEGER_TYPE)
-        && TEST_texture<int>(
+        && TEST_texture<int, 4>(
             t1D_i32,
             t2D_i32,
             t3D_i32,
@@ -691,7 +715,7 @@ void computeMain()
             t1DArray_i32,
             t2DArray_i32,
             tCubeArray_i32)
-        && TEST_texture<uint>(
+        && TEST_texture<uint, 4>(
             t1D_u32,
             t2D_u32,
             t3D_u32,
@@ -700,7 +724,7 @@ void computeMain()
             t2DArray_u32,
             tCubeArray_u32)
 #if !defined(EXCLUDE_SHORT_TYPE)
-        && TEST_texture<int16_t>(
+        && TEST_texture<int16_t, 4>(
             t1D_i16,
             t2D_i16,
             t3D_i16,
@@ -708,7 +732,7 @@ void computeMain()
             t1DArray_i16,
             t2DArray_i16,
             tCubeArray_i16)
-        && TEST_texture<uint16_t>(
+        && TEST_texture<uint16_t, 4>(
             t1D_u16,
             t2D_u16,
             t3D_u16,


### PR DESCRIPTION
fixes: #4405

The change modifies stdlib to ensures all metal texture `read`/`sample` uses swizzle their `vector<T,4>` output into the same parent element type of __TextureImpl<T>

1. Added test cases to texture.slang to cover all types.
