### PR TITLE
Fix Texture2DMSArray

### DIFF
--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -1636,8 +1636,6 @@ public typealias sampler2DMS = Sampler2DMS<float4>;
 public typealias isampler2DMS = Sampler2DMS<int4>;
 public typealias usampler2DMS = Sampler2DMS<uint4>;
 
-__generic<T=float4, let sampleCount:int=0, let format:int=0>
-public typealias Sampler2DMSArray = Sampler2DArrayMS<T, sampleCount, format>;
 public typealias sampler2DMSArray = Sampler2DMSArray<float4>;
 public typealias isampler2DMSArray = Sampler2DMSArray<int4>;
 public typealias usampler2DMSArray = Sampler2DMSArray<uint4>;

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -3231,7 +3231,7 @@ ${{{{
         auto requireString = requireStringBuilder.toString();
 }}}}
 $(requireString)
-typealias $(accessPrefix[access])$(textureTypeName)$(shapeTypeNames[shape])$(arrayPostFix[isArray])$(msPostFix[isMS])<T=float4, let sampleCount:int=0, let format:int=0> = __TextureImpl<T, __Shape$(shapeTypeNames[shape]), $(isArray), $(isMS), sampleCount, $(access), 0, $(isCombined), format>;
+typealias $(accessPrefix[access])$(textureTypeName)$(shapeTypeNames[shape])$(msPostFix[isMS])$(arrayPostFix[isArray])<T=float4, let sampleCount:int=0, let format:int=0> = __TextureImpl<T, __Shape$(shapeTypeNames[shape]), $(isArray), $(isMS), sampleCount, $(access), 0, $(isCombined), format>;
 ${{{{
 }
 }}}}

--- a/tests/compute/texture-subscript-multisample.slang
+++ b/tests/compute/texture-subscript-multisample.slang
@@ -12,8 +12,8 @@
 //TEST_INPUT: RWTexture2D(format=R8G8B8A8_SINT, size=4, content = zero, sampleCount=two, mipMaps = 1):name outputTexture2DMS
 RWTexture2DMS<int4> outputTexture2DMS;
 
-//TEST_INPUT: RWTexture2D(format=R8G8B8A8_SINT, size=4, content = zero, arrayLength=2, sampleCount=two, mipMaps = 1):name outputTexture2DArrayMS
-RWTexture2DArrayMS<int4> outputTexture2DArrayMS;
+//TEST_INPUT: RWTexture2D(format=R8G8B8A8_SINT, size=4, content = zero, arrayLength=2, sampleCount=two, mipMaps = 1):name outputTexture2DMSArray
+RWTexture2DMSArray<int4> outputTexture2DMSArray;
 
 //TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
@@ -26,15 +26,15 @@ void computeMain()
     outputTexture2DMS[0, 0].xz = int2(1,2);
     outputTexture2DMS[int2(0, 0), 1].xz = int2(3,4);
 
-    outputTexture2DArrayMS[0, 0].xz = int2(1,2);
-    outputTexture2DArrayMS[int3(0, 0, 1), 1].xz = int2(3,4);
+    outputTexture2DMSArray[0, 0].xz = int2(1,2);
+    outputTexture2DMSArray[int3(0, 0, 1), 1].xz = int2(3,4);
 
     outputBuffer[0] = uint(true
             && all(outputTexture2DMS[0, 0] == int4(1, 0, 2, 0)) == true
             && all(outputTexture2DMS[int2(0, 0), 1] == int4(3, 0, 4, 0))  == true
 
-            && all(outputTexture2DArrayMS[0, 0] == int4(1, 0, 2, 0)) == true
-            && all(outputTexture2DArrayMS[int3(0, 0, 1), 1] == int4(3, 0, 4, 0))  == true
+            && all(outputTexture2DMSArray[0, 0] == int4(1, 0, 2, 0)) == true
+            && all(outputTexture2DMSArray[int3(0, 0, 1), 1] == int4(3, 0, 4, 0))  == true
             );
 }
 


### PR DESCRIPTION
Close #4427

We had the postfix order wrong for the keyword MS. This commit changes the incorrect name Texture2DArrayMS to Texture2DMSArray.