### PR TITLE
DRAFT: Implement embedded precompiled dxil slang-module feature

### DIFF
--- a/slang.h
+++ b/slang.h
@@ -706,6 +706,9 @@ extern "C"
 
         /* When set, will generate SPIRV directly rather than via glslang. */
         SLANG_TARGET_FLAG_GENERATE_SPIRV_DIRECTLY = 1 << 10,
+
+        /* When set, the output for this target will be embedded as extra data in IR. */
+        SLANG_TARGET_FLAG_EMBED_OUTPUT_IN_IR = 1 << 11,
     };
     constexpr static SlangTargetFlags kDefaultTargetFlags = SLANG_TARGET_FLAG_GENERATE_SPIRV_DIRECTLY;
 
@@ -869,6 +872,8 @@ extern "C"
             DisableSourceMap,       // bool
             UnscopedEnum,           // bool
             PreserveParameters,       // bool: preserve all resource parameters in the output code.
+            EmbedDXIL,              // bool
+            EmbedSPIRV,             // bool
 
             // Target
 
@@ -897,6 +902,7 @@ extern "C"
             EmitSpirvDirectly,          // bool
             SPIRVCoreGrammarJSON,       // stringValue0: json path
             IncompleteLibrary,          // bool, when set, will not issue an error when the linked program has unresolved extern function symbols.
+            EmbedOutputInIR,            // bool
 
             // Downstream
 
@@ -3896,6 +3902,13 @@ namespace slang
             int                     targetIndex,
             SlangTargetFlags        flags) = 0;
 
+        virtual SLANG_NO_THROW void SLANG_MCALL setTargetGenerateWholeProgram(
+            int                     targetIndex,
+            bool                    value) = 0;
+
+        virtual SLANG_NO_THROW void SLANG_MCALL setTargetEmbedOutputInIR(
+            int                     targetIndex,
+            bool                    value) = 0;
 
             /*!
             @brief Set the floating point mode (e.g., precise or fast) to use a target.

--- a/source/slang/slang-compiler-options.cpp
+++ b/source/slang/slang-compiler-options.cpp
@@ -202,6 +202,7 @@ namespace Slang
         else
             set(CompilerOptionName::EmitSpirvViaGLSL, true);
         set(CompilerOptionName::ParameterBlocksUseRegisterSpaces, (flags & SLANG_TARGET_FLAG_PARAMETER_BLOCKS_USE_REGISTER_SPACES) != 0);
+        set(CompilerOptionName::EmbedOutputInIR, (flags & SLANG_TARGET_FLAG_EMBED_OUTPUT_IN_IR) != 0);
     }
 
     void CompilerOptionSet::addTargetFlags(SlangTargetFlags flags)
@@ -217,6 +218,9 @@ namespace Slang
 
         if ((flags & SLANG_TARGET_FLAG_PARAMETER_BLOCKS_USE_REGISTER_SPACES) != 0)
             set(CompilerOptionName::ParameterBlocksUseRegisterSpaces, true);
+
+        if ((flags & SLANG_TARGET_FLAG_EMBED_OUTPUT_IN_IR) != 0)
+            set(CompilerOptionName::EmbedOutputInIR, true);
     }
     MatrixLayoutMode CompilerOptionSet::getMatrixLayoutMode()
     {

--- a/source/slang/slang-compiler-tu.cpp
+++ b/source/slang/slang-compiler-tu.cpp
@@ -1,0 +1,73 @@
+// slang-compiler-tu.cpp: Compiles translation units to target language
+//
+
+#include "../core/slang-basic.h"
+#include "../core/slang-platform.h"
+#include "../core/slang-io.h"
+#include "../core/slang-string-util.h"
+//#include "../core/slang-hex-dump-util.h"
+#include "../core/slang-castable.h"
+
+#include "slang-check.h"
+#include "slang-compiler.h"
+
+#include "../compiler-core/slang-lexer.h"
+
+// Artifact
+#include "../compiler-core/slang-artifact-desc-util.h"
+#include "../compiler-core/slang-artifact-representation-impl.h"
+#include "../compiler-core/slang-artifact-impl.h"
+#include "../compiler-core/slang-artifact-util.h"
+#include "../compiler-core/slang-artifact-associated.h"
+#include "../compiler-core/slang-artifact-diagnostic-util.h"
+#include "../compiler-core/slang-artifact-container-util.h"
+
+// Artifact output
+#include "slang-artifact-output-util.h"
+
+#include "slang-lower-to-ir.h"
+#include "slang-mangle.h"
+#include "slang-parameter-binding.h"
+#include "slang-parser.h"
+#include "slang-preprocessor.h"
+#include "slang-type-layout.h"
+
+#include "slang-serialize-ast.h"
+#include "slang-serialize-container.h"
+
+namespace Slang
+{
+    SLANG_NO_THROW SlangResult SLANG_MCALL Module::precompileForTargets(
+        DiagnosticSink* sink,
+        EndToEndCompileRequest* endToEndReq,
+        TargetRequest* targetReq)
+    {
+        SLANG_UNUSED(sink);
+        assert(this->getIRModule());
+        auto module = getIRModule();
+        Slang::Session* session = endToEndReq->getSession();
+        Slang::ASTBuilder* astBuilder = session->getGlobalASTBuilder();
+        Slang::Linkage* builtinLinkage = session->getBuiltinLinkage();
+        Slang::Linkage linkage(session, astBuilder, builtinLinkage);
+        linkage.addTarget(Slang::CodeGenTarget::DXIL);
+        
+        TargetProgram tp(this, targetReq);
+        
+        CodeGenContext::EntryPointIndices entryPointIndices;
+        CodeGenContext::Shared sharedCodeGenContext(&tp, entryPointIndices, sink, endToEndReq);
+        CodeGenContext codeGenContext(&sharedCodeGenContext);
+        
+        ComPtr<IArtifact> outArtifact;
+        codeGenContext.emitTranslationUnit(outArtifact);
+        
+        ISlangBlob* blob;
+        outArtifact->loadBlob(ArtifactKeep::Yes, &blob);
+
+        auto builder = IRBuilder(module);
+        builder.setInsertInto(module);
+        printf("Emit embedded DXIL. Blob size %d\n", blob->getBufferSize());
+        builder.emitEmbeddedDXIL(blob);
+               
+        return SLANG_OK;
+    }
+}

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -761,6 +761,11 @@ namespace Slang
 #   pragma warning(pop)
 #endif
 
+    SlangResult CodeGenContext::emitTranslationUnit(ComPtr<IArtifact>& outArtifact)
+    {
+        return emitWithDownstreamForEntryPoints(outArtifact);
+    }
+
     String GetHLSLProfileName(Profile profile)
     {
         switch( profile.getFamily() )
@@ -1990,8 +1995,8 @@ namespace Slang
             {                
                 if (auto artifact = targetProgram->getExistingWholeProgramResult())
                 {
-		    // TODO: Is it a hack to flag targets as 'embedded' and then omit them from
-		    // artifacts like this?
+                    // TODO: Is it a hack to flag targets as 'embedded' and then omit them from
+                    // artifacts like this?
                     if (!targetProgram->getOptionSet().getBoolOption(CompilerOptionName::EmbedOutputInIR))
                     {
                         artifacts.add(ComPtr<IArtifact>(artifact));
@@ -2266,6 +2271,7 @@ namespace Slang
             {
                 auto targetProgram = program->getTargetProgram(targetReq);
 
+#if 0
                 if (targetProgram->getOptionSet().getBoolOption(CompilerOptionName::EmbedOutputInIR))
                 {
                     // TODO:
@@ -2295,6 +2301,7 @@ namespace Slang
                         }
                     }
                 }
+#endif
             }
         }
         

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -2749,6 +2749,8 @@ namespace Slang
         virtual SLANG_NO_THROW void SLANG_MCALL setTargetFloatingPointMode(int targetIndex, SlangFloatingPointMode mode) SLANG_OVERRIDE;
         virtual SLANG_NO_THROW void SLANG_MCALL setTargetMatrixLayoutMode(int targetIndex, SlangMatrixLayoutMode mode) SLANG_OVERRIDE;
         virtual SLANG_NO_THROW void SLANG_MCALL setTargetForceGLSLScalarBufferLayout(int targetIndex, bool value) SLANG_OVERRIDE;
+        virtual SLANG_NO_THROW void SLANG_MCALL setTargetGenerateWholeProgram(int targetIndex, bool value) SLANG_OVERRIDE;
+        virtual SLANG_NO_THROW void SLANG_MCALL setTargetEmbedOutputInIR(int targetIndex, bool value) SLANG_OVERRIDE;
         virtual SLANG_NO_THROW void SLANG_MCALL setMatrixLayoutMode(SlangMatrixLayoutMode mode) SLANG_OVERRIDE;
         virtual SLANG_NO_THROW void SLANG_MCALL setDebugInfoLevel(SlangDebugInfoLevel level) SLANG_OVERRIDE;
         virtual SLANG_NO_THROW void SLANG_MCALL setOptimizationLevel(SlangOptimizationLevel level) SLANG_OVERRIDE;

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1453,6 +1453,11 @@ namespace Slang
         /// Get the unique identity of the module.
         virtual SLANG_NO_THROW const char* SLANG_MCALL getUniqueIdentity() override;
 
+        /// Precompile TU to target language
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL precompileForTargets(
+            DiagnosticSink* sink,
+            EndToEndCompileRequest* endToEndReq,
+            TargetRequest* targetReq);
 
         virtual void buildHash(DigestBuilder<SHA1>& builder) SLANG_OVERRIDE;
 
@@ -2672,6 +2677,8 @@ namespace Slang
         //
 
         SlangResult emitEntryPoints(ComPtr<IArtifact>& outArtifact);
+
+        SlangResult emitTranslationUnit(ComPtr<IArtifact>& outArtifact);
 
         void maybeDumpIntermediate(IArtifact* artifact);
 

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -291,6 +291,7 @@ INST(Block, block, 0, PARENT)
     INST(FloatLit, float_constant, 0, 0)
     INST(PtrLit, ptr_constant, 0, 0)
     INST(StringLit, string_constant, 0, 0)
+    INST(BlobLit, string_constant, 0, 0)
     INST(VoidLit, void_constant, 0, 0)
 INST_RANGE(Constant, BoolLit, VoidLit)
 
@@ -1192,6 +1193,10 @@ INST(DebugSource, DebugSource, 2, HOISTABLE)
 INST(DebugLine, DebugLine, 5, 0)
 INST(DebugVar, DebugVar, 4, 0)
 INST(DebugValue, DebugValue, 2, 0)
+
+/* Embedded Precompiled Libraries */
+INST(EmbeddedDXIL, EmbeddedDXIL, 1, 0)
+INST(EmbeddedSPIRV, EmbeddedSPIRV, 1, 0)
 
 /* Inline assembly */
 

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -3435,6 +3435,7 @@ public:
     IRInst* getIntValue(IRType* type, IRIntegerValue value);
     IRInst* getFloatValue(IRType* type, IRFloatingPointValue value);
     IRStringLit* getStringValue(const UnownedStringSlice& slice);
+    IRBlobLit* getBlobValue(ISlangBlob* blob);
     IRPtrLit* _getPtrValue(void* ptr);
     IRPtrLit* getNullPtrValue(IRType* type);
     IRPtrLit* getNullVoidPtrValue() { return getNullPtrValue(getPtrType(getVoidType())); }
@@ -3949,6 +3950,9 @@ public:
 
     IRInst* emitByteAddressBufferStore(IRInst* byteAddressBuffer, IRInst* offset, IRInst* value);
     IRInst* emitByteAddressBufferStore(IRInst* byteAddressBuffer, IRInst* offset, IRInst* alignment, IRInst* value);
+
+    IRInst* emitEmbeddedDXIL(ISlangBlob* blob);
+    IRInst* emitEmbeddedSPIRV(ISlangBlob* blob);
 
     IRFunc* createFunc();
     IRGlobalVar* createGlobalVar(

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -2059,7 +2059,7 @@ namespace Slang
 
     UnownedStringSlice IRConstant::getStringSlice()
     {
-        assert(getOp() == kIROp_StringLit);
+        assert(getOp() == kIROp_StringLit || getOp() == kIROp_BlobLit);
         // If the transitory decoration is set, then this is uses the transitoryStringVal for the text storage.
         // This is typically used when we are using a transitory IRInst held on the stack (such that it can be looked up in cached), 
         // that just points to a string elsewhere, and NOT the typical normal style, where the string is held after the instruction in memory.
@@ -2133,6 +2133,7 @@ namespace Slang
             {
                 return value.ptrVal == rhs->value.ptrVal;
             }
+            case kIROp_BlobLit:
             case kIROp_StringLit:
             {
                 return getStringSlice() == rhs->getStringSlice();
@@ -2174,6 +2175,7 @@ namespace Slang
             {
                 return combineHash(code, Slang::getHashCode(value.ptrVal));
             }
+            case kIROp_BlobLit:
             case kIROp_StringLit:
             {
                 const UnownedStringSlice slice = getStringSlice();
@@ -2264,6 +2266,7 @@ namespace Slang
                 irValue->value.ptrVal = keyInst.value.ptrVal;
                 break;
             }
+            case kIROp_BlobLit:
             case kIROp_StringLit:
             {
                 const UnownedStringSlice slice = keyInst.getStringSlice();
@@ -2385,6 +2388,29 @@ namespace Slang
         dstSlice.numChars = uint32_t(inSlice.getLength());
 
         return static_cast<IRStringLit*>(_findOrEmitConstant(keyInst));
+    }
+
+    IRBlobLit* IRBuilder::getBlobValue(ISlangBlob* blob)
+    {
+        IRConstant keyInst;
+        memset(&keyInst, 0, sizeof(keyInst));
+
+        UnownedStringSlice inSlice((const char*)(blob->getBufferPointer()), blob->getBufferSize());
+
+        // Mark that this is on the stack...
+        IRDecoration stackDecoration;
+        memset(&stackDecoration, 0, sizeof(stackDecoration));
+        stackDecoration.m_op = kIROp_TransitoryDecoration;
+        stackDecoration.insertAtEnd(&keyInst);
+
+        keyInst.m_op = kIROp_BlobLit;
+        keyInst.typeUse.usedValue = nullptr; // not used
+
+        IRConstant::StringSliceValue& dstSlice = keyInst.value.transitoryStringVal;
+        dstSlice.chars = const_cast<char*>(inSlice.begin());
+        dstSlice.numChars = uint32_t(inSlice.getLength());
+
+        return static_cast<IRBlobLit*>(_findOrEmitConstant(keyInst));
     }
 
     IRPtrLit* IRBuilder::_getPtrValue(void* data)
@@ -3793,6 +3819,20 @@ namespace Slang
             return emitIntrinsicInst(type, kIROp_DefaultConstruct, 0, nullptr);
         }
         return nullptr;
+    }
+
+    IRInst* IRBuilder::emitEmbeddedDXIL(ISlangBlob *blob)
+    {
+        IRInst* args[] = { getBlobValue(blob) };
+
+        return emitIntrinsicInst(getVoidType(), kIROp_EmbeddedDXIL, 1, args);
+    }
+
+    IRInst* IRBuilder::emitEmbeddedSPIRV(ISlangBlob* blob)
+    {
+        IRInst* args[] = { getBlobValue(blob) };
+
+        return emitIntrinsicInst(getVoidType(), kIROp_EmbeddedSPIRV, 1, args);
     }
 
     enum class TypeCastStyle
@@ -7017,6 +7057,10 @@ namespace Slang
 
             case kIROp_BoolLit:
                 dump(context, irConst->value.intVal ? "true" : "false");
+                return;
+
+            case kIROp_BlobLit:
+                dump(context, "<binary blob>");
                 return;
 
             case kIROp_StringLit:

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1168,6 +1168,11 @@ struct IRStringLit : IRConstant
     IR_LEAF_ISA(StringLit);
 };
 
+struct IRBlobLit : IRConstant
+{
+    IR_LEAF_ISA(BlobLit);
+};
+
 struct IRPtrLit : IRConstant
 {
     IR_LEAF_ISA(PtrLit);

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -353,7 +353,11 @@ void initCommandOptions(CommandOptions& options)
         "The language to be used for source embedding. Defaults to C/C++. Currently only C/C++ are supported"},
         { OptionKind::DisableShortCircuit, "-disable-short-circuit", nullptr, "Disable short-circuiting for \"&&\" and \"||\" operations" },
         { OptionKind::UnscopedEnum, "-unscoped-enum", nullptr, "Treat enums types as unscoped by default."},
-        { OptionKind::PreserveParameters, "-preserve-params", nullptr, "Preserve all resource parameters in the output code, even if they are not used by the shader."}
+        { OptionKind::PreserveParameters, "-preserve-params", nullptr, "Preserve all resource parameters in the output code, even if they are not used by the shader."},
+        { OptionKind::EmbedDXIL, "-embed-dxil", nullptr,
+        "Embed DXIL into emitted slang-modules for faster linking" },
+        { OptionKind::EmbedSPIRV, "-embed-spirv", nullptr,
+        "Embed SPIR-V into emitted slang-modules for faster linking" },
     };
 
     _addOptions(makeConstArrayView(generalOpts), options);
@@ -426,7 +430,8 @@ void initCommandOptions(CommandOptions& options)
         "A path to a specific spirv.core.grammar.json to use when generating SPIR-V output" },
         { OptionKind::IncompleteLibrary, "-incomplete-library", nullptr,
         "Allow generating code from incomplete libraries with unresolved external functions" },
-
+        { OptionKind::EmbedOutputInIR, "-embed-output-in-ir", nullptr,
+        "Redundant option, need do this or the embed-dxil/embed-spirv, not both" },
     };
 
     _addOptions(makeConstArrayView(targetOpts), options);
@@ -697,6 +702,8 @@ struct OptionsParser
     RawTarget* getCurrentTarget();
     void setProfileVersion(RawTarget* rawTarget, ProfileVersion profileVersion);
     void addCapabilityAtom(RawTarget* rawTarget, CapabilityName atom);
+
+    SlangResult addEmbeddedLibrary(const CodeGenTarget format);
     
     void setFloatingPointMode(RawTarget* rawTarget, FloatingPointMode mode);
     
@@ -1622,6 +1629,21 @@ SlangResult OptionsParser::_parseProfile(const CommandLineArg& arg)
     return SLANG_OK;
 }
 
+// Creates a target of the specified type whose output will be embedded as IR metadata
+SlangResult OptionsParser::addEmbeddedLibrary(const CodeGenTarget format)
+{
+    RawTarget rawTarget;
+    rawTarget.format = format;
+    // Silently allow redundant targets if it is the same as the last specified target.
+    if (m_rawTargets.getCount() != 0 && m_rawTargets.getLast().format == rawTarget.format)
+        return SLANG_OK;
+    rawTarget.optionSet.set(CompilerOptionName::EmbedOutputInIR, true);
+    rawTarget.optionSet.addTargetFlags(SLANG_TARGET_FLAG_GENERATE_WHOLE_PROGRAM);
+
+    m_rawTargets.add(rawTarget);
+    return SLANG_OK;
+}
+
 SlangResult OptionsParser::_parse(
     int             argc,
     char const* const* argv)
@@ -1912,6 +1934,8 @@ SlangResult OptionsParser::_parse(
                 linkage->m_optionSet.set(optionKind, compressionType);
                 break;
             }
+            case OptionKind::EmbedDXIL: SLANG_RETURN_ON_FAIL(addEmbeddedLibrary(CodeGenTarget::DXIL)); break;
+            case OptionKind::EmbedSPIRV: SLANG_RETURN_ON_FAIL(addEmbeddedLibrary(CodeGenTarget::SPIRV)); break;
             case OptionKind::Target:
             {
                 CommandLineArg name;
@@ -2742,6 +2766,16 @@ SlangResult OptionsParser::_parse(
             if (rawTarget.optionSet.shouldUseScalarLayout())
             {
                 m_compileRequest->setTargetForceGLSLScalarBufferLayout(targetID, true);
+            }
+
+            if (rawTarget.optionSet.getBoolOption(CompilerOptionName::GenerateWholeProgram))
+            {
+                m_compileRequest->setTargetGenerateWholeProgram(targetID, true);
+            }
+
+            if (rawTarget.optionSet.getBoolOption(CompilerOptionName::EmbedOutputInIR))
+            {
+                m_compileRequest->setTargetEmbedOutputInIR(targetID, true);
             }
         }
 

--- a/source/slang/slang-serialize-container.cpp
+++ b/source/slang/slang-serialize-container.cpp
@@ -348,6 +348,12 @@ namespace Slang {
             }
         }
 
+	// TODO:
+	// Serialization of target component IR is causing the embedded precompiled binary
+	// feature to fail. The resulting data modules contain both TU IR and TC IR, with only
+	// one module header. Yong suggested to ignore the TC IR for now, though also that
+	// OV was using the feature, so disabling this might cause problems.
+#if 0
         if (data.targetComponents.getCount() && (options.optionFlags & SerialOptionFlag::IRModule))
         {
             // TODO: in the case where we have specialization, we might need
@@ -365,6 +371,7 @@ namespace Slang {
                 SLANG_RETURN_ON_FAIL(IRSerialWriter::writeContainer(serialData, options.compressionType, container));
             }
         }
+#endif
     }
 
     if (data.entryPoints.getCount())

--- a/source/slang/slang-serialize-ir.cpp
+++ b/source/slang/slang-serialize-ir.cpp
@@ -195,6 +195,14 @@ Result IRSerialWriter::write(IRModule* module, SerialSourceLocWriter* sourceLocW
                 switch (srcInst->getOp())
                 {
                     // Special handling for the ir const derived types
+                    case kIROp_BlobLit:
+                    {
+			// Blobs are serialized into string table like strings
+                        auto stringLit = static_cast<IRBlobLit*>(srcInst);
+                        dstInst.m_payloadType = PayloadType::String_1;
+                        dstInst.m_payload.m_stringIndices[0] = getStringIndex(stringLit->getStringSlice());
+                        break;
+                    }
                     case kIROp_StringLit:
                     {
                         auto stringLit = static_cast<IRStringLit*>(srcInst);
@@ -790,6 +798,7 @@ Result IRSerialReader::read(const IRSerialData& data, Session* session, SerialSo
                         op, operandCount, prefixSize));
                     break;
                 }
+                case kIROp_BlobLit:
                 case kIROp_StringLit:
                 {
                     SLANG_ASSERT(srcInst.m_payloadType == PayloadType::String_1);

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -5686,6 +5686,16 @@ void EndToEndCompileRequest::setTargetMatrixLayoutMode(int targetIndex, SlangMat
     getTargetOptionSet(targetIndex).setMatrixLayoutMode(MatrixLayoutMode(mode));
 }
 
+void EndToEndCompileRequest::setTargetGenerateWholeProgram(int targetIndex, bool value)
+{
+    getTargetOptionSet(targetIndex).set(CompilerOptionName::GenerateWholeProgram, value);
+}
+
+void EndToEndCompileRequest::setTargetEmbedOutputInIR(int targetIndex, bool value)
+{
+    getTargetOptionSet(targetIndex).set(CompilerOptionName::EmbedOutputInIR, value);
+}
+
 void EndToEndCompileRequest::setTargetLineDirectiveMode(
     SlangInt targetIndex,
     SlangLineDirectiveMode mode)

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3087,6 +3087,24 @@ SlangResult EndToEndCompileRequest::executeActionsInner()
         return SLANG_OK;
     }
 
+    // If requested, attempt to compile the translation unit all the way down to the target language
+    // and stash the result blob in an IR op.
+    for (auto targetReq : getLinkage()->targets)
+    {
+        if (targetReq->getOptionSet().getBoolOption(CompilerOptionName::EmbedOutputInIR))
+        {
+            auto frontEndReq = getFrontEndReq();
+
+            for (auto translationUnit : frontEndReq->translationUnits)
+            {
+                translationUnit->getModule()->precompileForTargets(
+                    getSink(),
+                    this,
+                    targetReq);
+            }
+        }
+    }
+
     // If codegen is enabled, we need to move along to
     // apply any generic specialization that the user asked for.
     //


### PR DESCRIPTION
When specified "-embed-dxil" creates an implicit DXIL target which is compiled
with DXC and stored in the slang-module as an IR operation.

When a slang-module is loaded, any precompiled binaries are loaded too
and are used to skip IR linking and optimization stages, instead passing
through to DXC for linkage.