### PR TITLE
Extend `countbits` intrinsic for vector types

### DIFF
--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -1402,15 +1402,7 @@ __generic<let N:int>
 [require(cpp_cuda_glsl_hlsl_spirv, shader5_sm_5_0)]
 public vector<uint,N> bitCount(vector<uint,N> value)
 {
-    __target_switch
-    {
-    case glsl: __intrinsic_asm "bitCount";
-    case spirv: return spirv_asm {
-        result:$$vector<uint,N> = OpBitCount $value
-    };
-    default:
-        VECTOR_MAP_UNARY(uint, N, countbits, value);
-    }
+    return countbits(value);
 }
 
 [__readNone] 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -6936,6 +6936,57 @@ uint countbits(uint value)
     }
 }
 
+[__readNone]
+[require(cpp_cuda_glsl_hlsl_metal_spirv, shader5_sm_5_0)]
+uint2 countbits(uint2 value)
+{
+    __target_switch
+    {
+    case hlsl:
+        __intrinsic_asm "countbits";
+    case glsl:
+        __intrinsic_asm "bitCount";
+    case metal:
+        __intrinsic_asm "popcount";
+    default:
+        return uint2(countbits(value.x), countbits(value.y));
+    }
+}
+
+[__readNone]
+[require(cpp_cuda_glsl_hlsl_metal_spirv, shader5_sm_5_0)]
+uint3 countbits(uint3 value)
+{
+    __target_switch
+    {
+    case hlsl:
+        __intrinsic_asm "countbits";
+    case glsl:
+        __intrinsic_asm "bitCount";
+    case metal:
+        __intrinsic_asm "popcount";
+    default:
+        return uint3(countbits(value.x), countbits(value.y), countbits(value.z));
+    }
+}
+
+[__readNone]
+[require(cpp_cuda_glsl_hlsl_metal_spirv, shader5_sm_5_0)]
+uint4 countbits(uint4 value)
+{
+    __target_switch
+    {
+    case hlsl:
+        __intrinsic_asm "countbits";
+    case glsl:
+        __intrinsic_asm "bitCount";
+    case metal:
+        __intrinsic_asm "popcount";
+    default:
+        return uint4(countbits(value.x), countbits(value.y), countbits(value.z), countbits(value.w));
+    }
+}
+
 // Cross product
 // TODO: SPIRV does not support integer vectors.
 __generic<T : __BuiltinFloatingPointType>

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -6917,6 +6917,7 @@ vector<T,N> cospi(vector<T,N> x)
 
 // Population count
 [__readNone]
+[ForceInline]
 [require(cpp_cuda_glsl_hlsl_metal_spirv, shader5_sm_5_0)]
 uint countbits(uint value)
 {
@@ -6938,6 +6939,7 @@ uint countbits(uint value)
 
 __generic <let N : int>
 [__readNone]
+[ForceInline]
 [require(cpp_cuda_glsl_hlsl_metal_spirv, shader5_sm_5_0)]
 vector<uint, N> countbits(vector<uint, N> value)
 {

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -6936,9 +6936,10 @@ uint countbits(uint value)
     }
 }
 
+__generic <let N : int>
 [__readNone]
 [require(cpp_cuda_glsl_hlsl_metal_spirv, shader5_sm_5_0)]
-uint2 countbits(uint2 value)
+vector<uint, N> countbits(vector<uint, N> value)
 {
     __target_switch
     {
@@ -6948,42 +6949,10 @@ uint2 countbits(uint2 value)
         __intrinsic_asm "bitCount";
     case metal:
         __intrinsic_asm "popcount";
+    case spirv:
+        return spirv_asm {OpBitCount $$vector<uint, N> result $value};
     default:
-        return uint2(countbits(value.x), countbits(value.y));
-    }
-}
-
-[__readNone]
-[require(cpp_cuda_glsl_hlsl_metal_spirv, shader5_sm_5_0)]
-uint3 countbits(uint3 value)
-{
-    __target_switch
-    {
-    case hlsl:
-        __intrinsic_asm "countbits";
-    case glsl:
-        __intrinsic_asm "bitCount";
-    case metal:
-        __intrinsic_asm "popcount";
-    default:
-        return uint3(countbits(value.x), countbits(value.y), countbits(value.z));
-    }
-}
-
-[__readNone]
-[require(cpp_cuda_glsl_hlsl_metal_spirv, shader5_sm_5_0)]
-uint4 countbits(uint4 value)
-{
-    __target_switch
-    {
-    case hlsl:
-        __intrinsic_asm "countbits";
-    case glsl:
-        __intrinsic_asm "bitCount";
-    case metal:
-        __intrinsic_asm "popcount";
-    default:
-        return uint4(countbits(value.x), countbits(value.y), countbits(value.z), countbits(value.w));
+        VECTOR_MAP_UNARY(uint, N, countbits, value);
     }
 }
 

--- a/tests/hlsl-intrinsic/countbits.slang
+++ b/tests/hlsl-intrinsic/countbits.slang
@@ -1,0 +1,26 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-slang -compute -cpu
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-slang -compute -dx11
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-slang -compute -dx12
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-slang -vk -compute
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-slang -cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-slang -mtl -compute
+
+//CHK:1
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    uint r1 = countbits(0b1);
+    uint2 r2 = countbits(uint2(0b0, 0b1));
+    uint3 r3 = countbits(uint3(0b0, 0b1, 0b11));
+    uint4 r4 = countbits(uint4(0b0, 0b1, 0b11, 0b111));
+
+    outputBuffer[0] = true
+        && (r1 == 1)
+        && (r2.x == 0 && r2.y == 1)
+        && (r3.x == 0 && r3.y == 1 && r3.z == 2)
+        && (r4.x == 0 && r4.y == 1 && r4.z == 2 && r4.w == 3);
+}

--- a/tests/hlsl-intrinsic/countbits.slang
+++ b/tests/hlsl-intrinsic/countbits.slang
@@ -22,5 +22,6 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
         && (r1 == 1)
         && (r2.x == 0 && r2.y == 1)
         && (r3.x == 0 && r3.y == 1 && r3.z == 2)
-        && (r4.x == 0 && r4.y == 1 && r4.z == 2 && r4.w == 3);
+        && (r4.x == 0 && r4.y == 1 && r4.z == 2 && r4.w == 3)
+        ;
 }


### PR DESCRIPTION
Fixes #4439

Adds vector type overloads for the `countbits` intrinsic.