### PR TITLE
Parse scope for local variable declaration

### DIFF
--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -5349,9 +5349,9 @@ namespace Slang
         {
             statement = ParseExpressionStatement();
         }
-        else if (LookAheadToken(TokenType::Identifier))
+        else if (LookAheadToken(TokenType::Identifier) || LookAheadToken(TokenType::Scope))
         {
-            if (LookAheadToken(TokenType::Colon, 1))
+            if (LookAheadToken(TokenType::Identifier) && LookAheadToken(TokenType::Colon, 1))
             {
                 // An identifier followed by an ":" is a label.
                 return parseLabelStatement();

--- a/tests/bugs/gh-4457.slang
+++ b/tests/bugs/gh-4457.slang
@@ -1,0 +1,27 @@
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-vk -compute -shaderobj -output-using-type
+
+// This tests if the scope(::) is recognized for a local variable declaration.
+
+//TEST_INPUT: ubuffer(data=[0 0], stride=4):out,name outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[UnscopedEnum]
+enum Number {
+  First = 1,
+  Second,
+};
+
+static ::Number foo = First;
+
+[numthreads(4, 1, 1)]
+void computeMain(int3 dispatchThreadID: SV_DispatchThreadID)
+{
+  // The scope(::) should be recognized
+  static ::Number bar = Second;
+
+  //CHK:1
+  //CHK-NEXT:2
+  outputBuffer[0] = int(foo);
+  outputBuffer[1] = int(bar);
+}
+


### PR DESCRIPTION
When a local variable is declaraed, a scope(::) was not properly parsed for its type name. This commit fixes it.

Close #4457