### PR TITLE
Implement CheckAccessFullyMapped

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -113,7 +113,15 @@ struct ByteAddressBuffer
     }
 
     [__readNone]
-    uint Load(int location, out uint status);
+    [ForceInline]
+    [require(hlsl, byteaddressbuffer)]
+    uint Load(int location, out uint status)
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm ".Load";
+        }
+    }
 
     [__readNone]
     [ForceInline]
@@ -155,7 +163,15 @@ struct ByteAddressBuffer
     }
 
     [__readNone]
-    uint2 Load2(int location, out uint status);
+    [ForceInline]
+    [require(hlsl, byteaddressbuffer)]
+    uint2 Load2(int location, out uint status)
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm ".Load2";
+        }
+    }
 
     [__readNone]
     [ForceInline]
@@ -197,7 +213,15 @@ struct ByteAddressBuffer
     }
 
     [__readNone]
-    uint3 Load3(int location, out uint status);
+    [ForceInline]
+    [require(hlsl, byteaddressbuffer)]
+    uint3 Load3(int location, out uint status)
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm ".Load3";
+        }
+    }
 
     [__readNone]
     [ForceInline]
@@ -239,7 +263,15 @@ struct ByteAddressBuffer
     }
 
     [__readNone]
-    uint4 Load4(int location, out uint status);
+    [ForceInline]
+    [require(hlsl, byteaddressbuffer)]
+    uint4 Load4(int location, out uint status)
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm ".Load4";
+        }
+    }
 
     [__readNone]
     [ForceInline]
@@ -691,7 +723,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0_fragment)]
+    [require(hlsl, texture_sm_4_0_fragment)]
     T Sample(vector<float, Shape.dimensions+isArray> location, vector<int, Shape.planeDimensions> offset, float clamp, out uint status)
     {
         __target_switch
@@ -1296,7 +1328,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0_fragment)]
+    [require(hlsl, texture_sm_4_0_fragment)]
     T Sample(SamplerState s, vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset, float clamp, out uint status)
     {
         __target_switch
@@ -2504,7 +2536,7 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_samplerless)]
+    [require(hlsl, texture_sm_4_1_samplerless)]
     T Load(vector<int, Shape.dimensions+isArray+1> location, constexpr vector<int, Shape.planeDimensions> offset, out uint status)
     {
         __target_switch
@@ -2670,7 +2702,7 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,form
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_samplerless)]
+    [require(hlsl, texture_sm_4_1_samplerless)]
     T Load(vector<int, Shape.dimensions+isArray> location, int sampleIndex, constexpr vector<int, Shape.planeDimensions> offset, out uint status)
     {
         __target_switch
@@ -2869,7 +2901,7 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,form
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
+    [require(hlsl, texture_sm_4_1)]
     T Load(vector<int, Shape.dimensions+isArray> location, vector<int, Shape.dimensions+isArray> offset, out uint status)
     {
         __target_switch
@@ -3092,6 +3124,7 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,form
 
     [__readNone]
     [ForceInline]
+    [require(hlsl, texture_sm_4_1_compute_fragment)]
     T Load(vector<int, Shape.dimensions+isArray> location, int sampleIndex, vector<int, Shape.dimensions+isArray> offset, out uint status)
     {
         __target_switch
@@ -3764,7 +3797,7 @@ struct StructuredBuffer
     T Load<TIndex : __BuiltinIntegerType>(TIndex location);
 
     __intrinsic_op($(kIROp_StructuredBufferLoadStatus))
-    [require(cpp_cuda_glsl_hlsl_spirv, structuredbuffer)]
+    [require(hlsl, structuredbuffer)]
     T Load<TIndex : __BuiltinIntegerType>(TIndex location, out uint status);
 
     __generic<TIndex : __BuiltinIntegerType>
@@ -3894,7 +3927,15 @@ struct $(item.name)
     }
 
     [__NoSideEffect]
-    uint Load(int location, out uint status);
+    [ForceInline]
+    [require(hlsl, byteaddressbuffer_rw)]
+    uint Load(int location, out uint status)
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm ".Load";
+        }
+    }
 
     [__NoSideEffect]
     [ForceInline]
@@ -3936,7 +3977,15 @@ struct $(item.name)
     }
 
     [__NoSideEffect]
-    uint2 Load2(int location, out uint status);
+    [ForceInline]
+    [require(hlsl, byteaddressbuffer_rw)]
+    uint2 Load2(int location, out uint status)
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm ".Load2";
+        }
+    }
 
     [__NoSideEffect]
     [ForceInline]
@@ -3978,7 +4027,15 @@ struct $(item.name)
     }
 
     [__NoSideEffect]
-    uint3 Load3(int location, out uint status);
+    [ForceInline]
+    [require(hlsl, byteaddressbuffer_rw)]
+    uint3 Load3(int location, out uint status)
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm ".Load3";
+        }
+    }
 
     [__NoSideEffect]
     [ForceInline]
@@ -4020,7 +4077,15 @@ struct $(item.name)
     }
 
     [__NoSideEffect]
-    uint4 Load4(int location, out uint status);
+    [ForceInline]
+    [require(hlsl, byteaddressbuffer_rw)]
+    uint4 Load4(int location, out uint status)
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm ".Load4";
+        }
+    }
 
     [__NoSideEffect]
     [ForceInline]
@@ -6636,7 +6701,15 @@ T copysign(T x, T y)
 
 
 // Check access status to tiled resource
-bool CheckAccessFullyMapped(uint status);
+[ForceInline]
+[require(hlsl, sm_5_0)]
+bool CheckAccessFullyMapped(out uint status)
+{
+    __target_switch
+    {
+    case hlsl: __intrinsic_asm "CheckAccessFullyMapped";
+    }
+}
 
 // Clamp (HLSL SM 1.0)
 __generic<T : __BuiltinIntegerType>
@@ -15179,6 +15252,7 @@ for (int aa = 0; aa < kBaseBufferAccessLevelCount; ++aa)
     char const* spvLoadInstName = (isReadOnly) ? "OpImageFetch" : "OpImageRead";
     char const* requireToSetQuery = (isReadOnly) ? "[require(glsl_hlsl_metal_spirv, texture_size)]" : "[require(glsl_hlsl_metal_spirv, image_size)]";
     char const* requireToSet = (isReadOnly) ? "[require(glsl_hlsl_metal_spirv, texture_sm_4_1)]" : "[require(glsl_hlsl_metal_spirv, texture_sm_4_1_compute_fragment)]";
+    char const* requireToSet_onlyHLSL = (isReadOnly) ? "[require(hlsl, texture_sm_4_1)]" : "[require(hlsl, texture_sm_4_1_compute_fragment)]";
 }}}}
 
 __generic<T, let format:int>
@@ -15219,8 +15293,14 @@ extension __TextureImpl<T, __ShapeBuffer, 0, 0, 0, $(aa), 0, 0, format>
     }
 
     $(isReadOnly?"[__readNone] ":"")
-    $(requireToSet)
-    T Load(int location, out uint status);
+    $(requireToSet_onlyHLSL)
+    T Load(int location, out uint status)
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm ".Load";
+        }
+    }
 
     __subscript(uint index) -> T {
 

--- a/tests/hlsl-intrinsic/texture/partial-resident-texture.slang
+++ b/tests/hlsl-intrinsic/texture/partial-resident-texture.slang
@@ -32,18 +32,20 @@ bool TEST_texture(
     int3 iuvs = int3(iuv, sampleIndex);
 
     return true
+        // Make sure CheckAccessFullyMapped can return false
+        && (status = 0, !CheckAccessFullyMapped(status))
+
         // Sample
-        && all(TN(T(1)) == t2D.Sample(samplerState, uv, offset, status)) && CheckAccessFullyMapped(status)
-        && all(TN(T(1)) == t2D.Sample(samplerState, uv, offset, clamp, status)) && CheckAccessFullyMapped(status)
+        && (status = 0, all(TN(T(1)) == t2D.Sample(samplerState, uv, offset, clamp, status))) && CheckAccessFullyMapped(status)
 
         // Load
-        && all(TN(T(1)) == t2DMS.Load(iuv, sampleIndex, offset, status)) && CheckAccessFullyMapped(status)
-        && all(TN(T(1)) == t2D.Load(iuvs, offset, status)) && CheckAccessFullyMapped(status)
-        && 2 == outputBuffer.Load(0, status) && CheckAccessFullyMapped(status)
-        && 1 == iBuf.Load(0, status) && CheckAccessFullyMapped(status)
-        && all(int2(1) == iBuf.Load2(0, status)) && CheckAccessFullyMapped(status)
-        && all(int3(1) == iBuf.Load3(0, status)) && CheckAccessFullyMapped(status)
-        && all(int4(1) == iBuf.Load4(0, status)) && CheckAccessFullyMapped(status)
+        && (status = 0, all(TN(T(1)) == t2DMS.Load(iuv, sampleIndex, offset, status))) && CheckAccessFullyMapped(status)
+        && (status = 0, all(TN(T(1)) == t2D.Load(iuvs, offset, status))) && CheckAccessFullyMapped(status)
+        && (status = 0, 2 == outputBuffer.Load(0, status)) && CheckAccessFullyMapped(status)
+        && (status = 0, 1 == iBuf.Load(0, status)) && CheckAccessFullyMapped(status)
+        && (status = 0, all(int2(1) == iBuf.Load2(0, status))) && CheckAccessFullyMapped(status)
+        && (status = 0, all(int3(1) == iBuf.Load3(0, status))) && CheckAccessFullyMapped(status)
+        && (status = 0, all(int4(1) == iBuf.Load4(0, status))) && CheckAccessFullyMapped(status)
         ;
 }
 

--- a/tests/hlsl-intrinsic/texture/partial-resident-texture.slang
+++ b/tests/hlsl-intrinsic/texture/partial-resident-texture.slang
@@ -1,0 +1,59 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-slang -compute -shaderobj -output-using-type -use-dxil -profile cs_6_6 -dx12
+
+//TEST_INPUT: ubuffer(data=[2], stride=4):out,name outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+//TEST_INPUT: Texture2D(size=4, content = one):name t2D_f32
+Texture2D<float4> t2D_f32;
+
+//TEST_INPUT: Texture2D(size=4, content = one):name t2DMS_f32
+Texture2DMS<float4> t2DMS_f32;
+
+//TEST_INPUT:ubuffer(data=[1 1 1 1]):name=iBuf
+RWByteAddressBuffer iBuf;
+
+//TEST_INPUT: Sampler:name samplerState
+SamplerState samplerState;
+
+__generic<T : __BuiltinArithmeticType, let N:int>
+bool TEST_texture(
+    Texture2D<vector<T,N>> t2D,
+    Texture2DMS<vector<T,N>> t2DMS)
+{
+    typealias TN = vector<T,N>;
+    constexpr const int2 offset = int2(0, 0);
+    uint status;
+    float clamp = 0;
+
+    float2 uv = float2(0.5f, 0.5f);
+
+    int sampleIndex = 0;
+    int2 iuv = int2(1, 1);
+    int3 iuvs = int3(iuv, sampleIndex);
+
+    return true
+        // Sample
+        && all(TN(T(1)) == t2D.Sample(samplerState, uv, offset, status)) && CheckAccessFullyMapped(status)
+        && all(TN(T(1)) == t2D.Sample(samplerState, uv, offset, clamp, status)) && CheckAccessFullyMapped(status)
+
+        // Load
+        && all(TN(T(1)) == t2DMS.Load(iuv, sampleIndex, offset, status)) && CheckAccessFullyMapped(status)
+        && all(TN(T(1)) == t2D.Load(iuvs, offset, status)) && CheckAccessFullyMapped(status)
+        && 2 == outputBuffer.Load(0, status) && CheckAccessFullyMapped(status)
+        && 1 == iBuf.Load(0, status) && CheckAccessFullyMapped(status)
+        && all(int2(1) == iBuf.Load2(0, status)) && CheckAccessFullyMapped(status)
+        && all(int3(1) == iBuf.Load3(0, status)) && CheckAccessFullyMapped(status)
+        && all(int4(1) == iBuf.Load4(0, status)) && CheckAccessFullyMapped(status)
+        ;
+}
+
+[numthreads(4, 1, 1)]
+void computeMain(int3 dispatchThreadID: SV_DispatchThreadID)
+{
+    bool result = true
+        && TEST_texture(t2D_f32, t2DMS_f32)
+        ;
+
+    //CHK:1
+    outputBuffer[0] = int(result);
+}


### PR DESCRIPTION
Closes #4438
Closes #4445
Closes #1712
Related to #4495

This commit implements "CheckAccessFullyMapped()" for HLSL target. All of other "status" variants for Sample/Load are limited to HLSL by the capability system, because they not properly implemented yet.