### PR TITLE
Set debug working directory for slangc.exe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,7 @@ if(SLANG_ENABLE_SLANGC)
         source/slangc
         EXECUTABLE
         USE_FEWER_WARNINGS
+        DEBUG_DIR ${slang_SOURCE_DIR}
         LINK_WITH_PRIVATE core slang Threads::Threads
         INSTALL
     )


### PR DESCRIPTION
This commit changes the working directory setting for slangc.exe in Visual Studio Debugging from "build" directory to the root of the repository.

It is often the case that the users debug slang shaders under "tests" directory, and the working directory needs to be manually changed to the root directory of the repository.