### PR TITLE
Error out when constructing tensor views from tensors with 0 stride.

### DIFF
--- a/prelude/slang-torch-prelude.h
+++ b/prelude/slang-torch-prelude.h
@@ -140,6 +140,9 @@ TensorView make_tensor_view(torch::Tensor val, const char* name, torch::ScalarTy
     for (int i = 0; i < val.dim(); ++i)
     {
         res.strides[i] = val.stride(i) * elementSize;
+        if (res.strides[i] == 0)
+            throw std::runtime_error(std::string(name).append(": tensors with broadcasted dimensions are not supported (use tensor.contiguous() to make tensor whole)").c_str());
+
         res.sizes[i] = val.size(i);
         if (res.sizes[i] > 0)
             isEmpty = false;


### PR DESCRIPTION
This avoids a problem with broadcasted tensors. Our tensor-view platform is designed to allow unrestricted access to tensor memory, while broadcasted tensors were designed for 'read-only' use-cases. Trying to write into a broadcasted tensor needs re-allocation, which Slang is not designed to do.

For now, we enforce contiguity on tensors with any 0 strides.

In the future, we will introduce a ConstTensorView object to allow such tensors to be used as an input.

This patch also propagates name-hint information through structs & arrays of tensors, to allow sensible names for the error messages (before this the error messages were temporary inst numbers, which is nearly impossible to debug)

Resolves a part of #3855 (will open a new issue for ConstTensorView if necessary)

This is a potentially breaking change because some cases where we were (incorrectly) allowing broadcasted tensors will now error out. The fix is typically quite simple: call `.contiguous()` on the tensor before passing it in.