### PR TITLE
Resource searching for examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -704,10 +704,7 @@ if (SLANG_ENABLE_EXAMPLES AND SLANG_ENABLE_GFX)
     )
     set_target_properties(all-examples PROPERTIES FOLDER examples)
     function(example dir)
-        set(debug_dir ${dir})
-        if (MSVC)
-            set(debug_dir ${CMAKE_BINARY_DIR}/${dir})
-        endif()
+        set(debug_dir ${CMAKE_BINARY_DIR}/${dir})
 
         slang_add_target(
             ${dir}
@@ -729,31 +726,32 @@ if (SLANG_ENABLE_EXAMPLES AND SLANG_ENABLE_GFX)
             ${ARGN}
         )
 
-        if (MSVC)
-            get_filename_component(example_target ${dir} NAME)
-            file(GLOB asset_files
-                "${CMAKE_SOURCE_DIR}/${dir}/*.slang"
-                "${CMAKE_SOURCE_DIR}/${dir}/*.jpg"
-                "${CMAKE_SOURCE_DIR}/${dir}/*.obj"
-                "${CMAKE_SOURCE_DIR}/${dir}/*.mtl"
+        get_filename_component(example_target ${dir} NAME)
+        file(GLOB asset_files
+            "${CMAKE_SOURCE_DIR}/${dir}/*.slang"
+            "${CMAKE_SOURCE_DIR}/${dir}/*.jpg"
+            "${CMAKE_SOURCE_DIR}/${dir}/*.obj"
+            "${CMAKE_SOURCE_DIR}/${dir}/*.mtl"
+            "${CMAKE_SOURCE_DIR}/${dir}/*.h"
+        )
+
+        list(LENGTH asset_files asset_files_length)
+            if (asset_files_length GREATER 0)
+            set(copy_assets_target "${example_target}-copy-assets")
+
+            add_custom_target(
+                ${copy_assets_target}
+                COMMAND ${CMAKE_COMMAND} -E make_directory ${debug_dir}
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different ${asset_files} ${debug_dir}
+                COMMENT "Copy example assets to ${debug_dir}"
             )
 
-            list(LENGTH asset_files asset_files_length)
-                if (asset_files_length GREATER 0)
-                set(copy_assets_target "${example_target}-copy-assets")
+            set_target_properties(${copy_assets_target} PROPERTIES FOLDER "examples/copy_assets")
 
-                add_custom_target(
-                    ${copy_assets_target}
-                    COMMAND ${CMAKE_COMMAND} -E make_directory ${debug_dir}
-                    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${asset_files} ${debug_dir}
-                    COMMENT "Copy example assets to ${debug_dir}"
-                )
+            add_dependencies(${example_target} ${copy_assets_target})
 
-                set_target_properties(${copy_assets_target} PROPERTIES FOLDER "examples/copy_assets")
-
-                add_dependencies(${example_target} ${copy_assets_target})
-
-                # Copy DirectX shader binaries so signing doesn't fail when running from Visual Studio
+            # Copy DirectX shader binaries so signing doesn't fail when running from Visual Studio
+            if (MSVC)
                 if (SLANG_ENABLE_PREBUILT_BINARIES)
                     add_dependencies(${example_target} copy-prebuilt-binaries)
                 endif()

--- a/examples/autodiff-texture/main.cpp
+++ b/examples/autodiff-texture/main.cpp
@@ -10,6 +10,8 @@
 using namespace gfx;
 using namespace Slang;
 
+static const ExampleResources resourceBase("autodiff-texture");
+
 struct Vertex
 {
     float position[3];
@@ -45,7 +47,8 @@ struct AutoDiffTexture : public WindowedAppBase
         slangSession = device->getSlangSession();
 
         ComPtr<slang::IBlob> diagnosticsBlob;
-        slang::IModule* module = slangSession->loadModule(fileName, diagnosticsBlob.writeRef());
+        Slang::String path = resourceBase.resolveResource(fileName);
+        slang::IModule* module = slangSession->loadModule(path.getBuffer(), diagnosticsBlob.writeRef());
         diagnoseIfNeeded(diagnosticsBlob);
         if (!module)
             return SLANG_FAIL;
@@ -89,7 +92,8 @@ struct AutoDiffTexture : public WindowedAppBase
         slangSession = device->getSlangSession();
 
         ComPtr<slang::IBlob> diagnosticsBlob;
-        slang::IModule* module = slangSession->loadModule(fileName, diagnosticsBlob.writeRef());
+        Slang::String path = resourceBase.resolveResource(fileName);
+        slang::IModule* module = slangSession->loadModule(path.getBuffer(), diagnosticsBlob.writeRef());
         diagnoseIfNeeded(diagnosticsBlob);
         if (!module)
             return SLANG_FAIL;
@@ -294,25 +298,25 @@ struct AutoDiffTexture : public WindowedAppBase
         {
             ComPtr<IShaderProgram> shaderProgram;
             SLANG_RETURN_ON_FAIL(
-                loadRenderProgram(gDevice, "train", "fragmentMain", shaderProgram.writeRef()));
+                loadRenderProgram(gDevice, "train.slang", "fragmentMain", shaderProgram.writeRef()));
             gRefPipelineState = createRenderPipelineState(inputLayout, shaderProgram);
         }
         {
             ComPtr<IShaderProgram> shaderProgram;
             SLANG_RETURN_ON_FAIL(
-                loadRenderProgram(gDevice, "train", "diffFragmentMain", shaderProgram.writeRef()));
+                loadRenderProgram(gDevice, "train.slang", "diffFragmentMain", shaderProgram.writeRef()));
             gIterPipelineState = createRenderPipelineState(inputLayout, shaderProgram);
         }
         {
             ComPtr<IShaderProgram> shaderProgram;
             SLANG_RETURN_ON_FAIL(
-                loadRenderProgram(gDevice, "draw-quad", "fragmentMain", shaderProgram.writeRef()));
+                loadRenderProgram(gDevice, "draw-quad.slang", "fragmentMain", shaderProgram.writeRef()));
             gDrawQuadPipelineState = createRenderPipelineState(inputLayout, shaderProgram);
         }
         {
             ComPtr<IShaderProgram> shaderProgram;
             SLANG_RETURN_ON_FAIL(
-                loadComputeProgram(gDevice, "reconstruct", shaderProgram.writeRef()));
+                loadComputeProgram(gDevice, "reconstruct.slang", shaderProgram.writeRef()));
             gReconstructPipelineState = createComputePipelineState(shaderProgram);
         }
         {
@@ -322,16 +326,17 @@ struct AutoDiffTexture : public WindowedAppBase
         }
         {
             ComPtr<IShaderProgram> shaderProgram;
-            SLANG_RETURN_ON_FAIL(loadComputeProgram(gDevice, "buildmip", shaderProgram.writeRef()));
+            SLANG_RETURN_ON_FAIL(loadComputeProgram(gDevice, "buildmip.slang", shaderProgram.writeRef()));
             gBuildMipPipelineState = createComputePipelineState(shaderProgram);
         }
         {
             ComPtr<IShaderProgram> shaderProgram;
-            SLANG_RETURN_ON_FAIL(loadComputeProgram(gDevice, "learnmip", shaderProgram.writeRef()));
+            SLANG_RETURN_ON_FAIL(loadComputeProgram(gDevice, "learnmip.slang", shaderProgram.writeRef()));
             gLearnMipPipelineState = createComputePipelineState(shaderProgram);
         }
 
-        gTexView = createTextureFromFile("checkerboard.jpg", textureWidth, textureHeight);
+        Slang::String imagePath = resourceBase.resolveResource("checkerboard.jpg");
+        gTexView = createTextureFromFile(imagePath.getBuffer(), textureWidth, textureHeight);
         initMipOffsets(textureWidth, textureHeight);
 
         gfx::IBufferResource::Desc bufferDesc = {};

--- a/examples/cpu-com-example/main.cpp
+++ b/examples/cpu-com-example/main.cpp
@@ -9,10 +9,13 @@
 
 // This includes a useful small function for setting up the prelude (described more further below).
 #include "../../source/core/slang-test-tool-util.h"
+#include "examples/example-base/example-base.h"
 
 // Slang namespace is used for elements support code (like core) which we use here
 // for ComPtr<> and TestToolUtil
 using namespace Slang;
+
+static const ExampleResources resourceBase("cpu-com-example");
 
 // For the moment we have to explicitly write the Slang COM interface in C++ code. It *MUST* match 
 // the interface in the slang source
@@ -79,7 +82,8 @@ static SlangResult _innerMain(int argc, char** argv)
     const int translationUnitIndex = request->addTranslationUnit(SLANG_SOURCE_LANGUAGE_SLANG, nullptr);
 
     // Set the source file for the translation unit
-    request->addTranslationUnitSourceFile(translationUnitIndex, "shader.slang");
+    Slang::String path = resourceBase.resolveResource("shader.slang");
+    request->addTranslationUnitSourceFile(translationUnitIndex, path.getBuffer());
 
     const SlangResult compileRes = request->compile();
 

--- a/examples/cpu-hello-world/main.cpp
+++ b/examples/cpu-hello-world/main.cpp
@@ -25,6 +25,7 @@
 
 // This includes a useful small function for setting up the prelude (described more further below).
 #include "../../source/core/slang-test-tool-util.h"
+#include "examples/example-base/example-base.h"
 
 // Slang namespace is used for elements support code (like core) which we use here
 // for ComPtr<> and TestToolUtil
@@ -39,6 +40,8 @@ using namespace Slang;
 // laid out in the manner that the generated slang code expects. 
 #define SLANG_PRELUDE_NAMESPACE CPPPrelude
 #include "../../prelude/slang-cpp-types.h"
+
+static const ExampleResources resourceBase("cpu-hello-world");
 
 struct UniformState;
 
@@ -102,7 +105,8 @@ static SlangResult _innerMain(int argc, char** argv)
     // We will load source code for our translation unit from the file `shader.slang`.
     // There are also variations of this API for adding source code from application-provided buffers.
     //
-    spAddTranslationUnitSourceFile(slangRequest, translationUnitIndex, "shader.slang");
+    Slang::String path = resourceBase.resolveResource("shader.slang");
+    spAddTranslationUnitSourceFile(slangRequest, translationUnitIndex, path.getBuffer());
 
     // Once all of the input options for the compiler have been specified,
     // we can invoke `spCompile` to run the compiler and see if any errors

--- a/examples/example-base/example-base.h
+++ b/examples/example-base/example-base.h
@@ -3,6 +3,7 @@
 #include "slang-gfx.h"
 #include "tools/platform/window.h"
 #include "source/core/slang-basic.h"
+#include "source/core/slang-io.h"
 
 #ifdef _WIN32
 void _Win32OutputDebugString(const char* str);
@@ -27,7 +28,7 @@ protected:
     Slang::ComPtr<gfx::ICommandQueue> gQueue;
 
     Slang::Result initializeBase(
-        const char* titile,
+        const char* title,
         int width,
         int height,
         gfx::DeviceType deviceType = gfx::DeviceType::Default);
@@ -41,6 +42,29 @@ protected:
 public:
     platform::Window* getWindow() { return gWindow.Ptr(); }
     virtual void finalize() { gQueue->waitOnHost(); }
+};
+
+struct ExampleResources {
+    Slang::String baseDir;
+
+    ExampleResources(const Slang::String &dir) : baseDir(dir) {}
+    
+    Slang::String resolveResource(const char* fileName) const {
+        static const Slang::List<Slang::String> directories {
+            "examples",
+            "../examples",
+            "../../examples",
+        };
+    
+        for (const Slang::String& dir : directories) {      
+            Slang::StringBuilder pathSb;
+            pathSb << dir  << "/" << baseDir << "/" << fileName;
+            if (Slang::File::exists(pathSb.getBuffer()))
+                return pathSb.toString();
+        }
+
+        return fileName;
+    }
 };
 
 int64_t getCurrentTime();

--- a/examples/gpu-printing/main.cpp
+++ b/examples/gpu-printing/main.cpp
@@ -1,19 +1,21 @@
 // main.cpp
+#include <string>
 
 #include <slang.h>
 
 #include <slang-com-ptr.h>
 using Slang::ComPtr;
 
+#include "gpu-printing.h"
 #include "slang-gfx.h"
 #include "gfx-util/shader-cursor.h"
 #include "tools/platform/window.h"
 #include "source/core/slang-basic.h"
+#include "examples/example-base/example-base.h"
+
 using namespace gfx;
 
-#include <string>
-
-#include "gpu-printing.h"
+static const ExampleResources resourceBase("gpu-printing");
 
 ComPtr<slang::ISession> createSlangSession(gfx::IDevice* device)
 {
@@ -87,11 +89,16 @@ Result execute()
     Result res = gfxCreateDevice(&deviceDesc, gDevice.writeRef());
     if(SLANG_FAILED(res)) return res;
 
+    Slang::String path = resourceBase.resolveResource("kernels.slang");
+
     gSlangSession = createSlangSession(gDevice);
-    gSlangModule = compileShaderModuleFromFile(gSlangSession, "kernels.slang");
+    gSlangModule = compileShaderModuleFromFile(gSlangSession, path.getBuffer());
+    if(!gSlangModule)
+        return SLANG_FAIL;
 
     gProgram = loadComputeProgram(gSlangModule, "computeMain");
-    if(!gProgram) return SLANG_FAIL;
+    if(!gProgram)
+        return SLANG_FAIL;
 
     ComputePipelineStateDesc desc;
     desc.program = gProgram;

--- a/examples/hello-world/main.cpp
+++ b/examples/hello-world/main.cpp
@@ -15,6 +15,8 @@
 
 using Slang::ComPtr;
 
+static const ExampleResources resourceBase("hello-world");
+
 struct HelloWorldExample
 {
     // The Vulkan functions pointers result from loading the vulkan library.
@@ -137,7 +139,8 @@ int HelloWorldExample::createComputePipelineFromShader()
     slang::IModule* slangModule = nullptr;
     {
         ComPtr<slang::IBlob> diagnosticBlob;
-        slangModule = session->loadModule("hello-world", diagnosticBlob.writeRef());
+        Slang::String path = resourceBase.resolveResource("hello-world.slang");
+        slangModule = session->loadModule(path.getBuffer(), diagnosticBlob.writeRef());
         diagnoseIfNeeded(diagnosticBlob);
         if (!slangModule)
             return -1;

--- a/examples/model-viewer/main.cpp
+++ b/examples/model-viewer/main.cpp
@@ -39,6 +39,8 @@ using namespace gfx;
 using Slang::RefObject;
 using Slang::RefPtr;
 
+static const ExampleResources resourceBase("model-viewer");
+
 struct RendererContext
 {
     IDevice* device;
@@ -53,8 +55,13 @@ struct RendererContext
     {
         device = inDevice;
         ComPtr<ISlangBlob> diagnostic;
-        shaderModule = device->getSlangSession()->loadModule("shaders", diagnostic.writeRef());
+        Slang::String path = resourceBase.resolveResource("shaders.slang").getBuffer();
+        shaderModule = device->getSlangSession()->loadModule(
+            path.getBuffer(),
+            diagnostic.writeRef());
         diagnoseIfNeeded(diagnostic);
+        if (!shaderModule)
+            return SLANG_FAIL;
 
         // Compose the shader program for drawing models by combining the shader module
         // and entry points ("vertexMain" and "fragmentMain").
@@ -786,7 +793,8 @@ Result initialize()
     // Support for loading more interesting/complex models will be added
     // to this example over time (although model loading is *not* the focus).
     //
-    loadAndAddModel("cube.obj");
+    Slang::String path = resourceBase.resolveResource("cube.obj").getBuffer();
+    loadAndAddModel(path.getBuffer());
 
     return SLANG_OK;
 }

--- a/examples/nv-aftermath-example/main.cpp
+++ b/examples/nv-aftermath-example/main.cpp
@@ -15,6 +15,8 @@
 using namespace gfx;
 using namespace Slang;
 
+static const ExampleResources resourceBase("nv-aftermath-example");
+
 // This example is based on the "triangle" sample.
 //
 // This examples purpose is to show how to use the aftermath SDK to capture
@@ -283,7 +285,8 @@ gfx::Result AftermathCrashExample::loadShaderProgram(
     }
 
     ComPtr<slang::IBlob> diagnosticsBlob;
-    slang::IModule* module = slangSession->loadModule("shaders", diagnosticsBlob.writeRef());
+    Slang::String path = resourceBase.resolveResource("shaders.slang");
+    slang::IModule* module = slangSession->loadModule(path.getBuffer(), diagnosticsBlob.writeRef());
     diagnoseIfNeeded(diagnosticsBlob);
     if (!module)
         return SLANG_FAIL;

--- a/examples/ray-tracing-pipeline/main.cpp
+++ b/examples/ray-tracing-pipeline/main.cpp
@@ -15,6 +15,8 @@
 using namespace gfx;
 using namespace Slang;
 
+static const ExampleResources resourceBase("ray-tracing-pipeline");
+
 struct Uniforms
 {
     float screenWidth, screenHeight;
@@ -161,7 +163,8 @@ gfx::Result loadShaderProgram(
     slangSession = device->getSlangSession();
 
     ComPtr<slang::IBlob> diagnosticsBlob;
-    slang::IModule* module = slangSession->loadModule("shaders", diagnosticsBlob.writeRef());
+    Slang::String path = resourceBase.resolveResource("shaders.slang");
+    slang::IModule* module = slangSession->loadModule(path.getBuffer(), diagnosticsBlob.writeRef());
     diagnoseIfNeeded(diagnosticsBlob);
     if(!module)
         return SLANG_FAIL;

--- a/examples/ray-tracing/main.cpp
+++ b/examples/ray-tracing/main.cpp
@@ -15,6 +15,8 @@
 using namespace gfx;
 using namespace Slang;
 
+static const ExampleResources resourceBase("ray-tracing");
+
 struct Uniforms
 {
     float screenWidth, screenHeight;
@@ -161,7 +163,8 @@ gfx::Result loadShaderProgram(
     slangSession = device->getSlangSession();
 
     ComPtr<slang::IBlob> diagnosticsBlob;
-    slang::IModule* module = slangSession->loadModule("shaders", diagnosticsBlob.writeRef());
+    Slang::String path = resourceBase.resolveResource("shaders.slang");
+    slang::IModule* module = slangSession->loadModule(path.getBuffer(), diagnosticsBlob.writeRef());
     diagnoseIfNeeded(diagnosticsBlob);
     if(!module)
         return SLANG_FAIL;

--- a/examples/shader-object/main.cpp
+++ b/examples/shader-object/main.cpp
@@ -15,17 +15,11 @@ using Slang::ComPtr;
 #include "slang-gfx.h"
 #include "gfx-util/shader-cursor.h"
 #include "source/core/slang-basic.h"
+#include "examples/example-base/example-base.h"
 
 using namespace gfx;
 
-// Helper function for print out diagnostic messages output by Slang compiler.
-void diagnoseIfNeeded(slang::IBlob* diagnosticsBlob)
-{
-    if (diagnosticsBlob != nullptr)
-    {
-        printf("%s", (const char*)diagnosticsBlob->getBufferPointer());
-    }
-}
+static const ExampleResources resourceBase("shader-object");
 
 // Loads the shader code defined in `shader-object.slang` for use by the `gfx` layer.
 //
@@ -62,7 +56,8 @@ Result loadShaderProgram(
     //      import shader_object;
     //
     ComPtr<slang::IBlob> diagnosticsBlob;
-    slang::IModule* module = slangSession->loadModule("shader-object", diagnosticsBlob.writeRef());
+    Slang::String path = resourceBase.resolveResource("shader-object.slang");
+    slang::IModule* module = slangSession->loadModule(path.getBuffer(), diagnosticsBlob.writeRef());
     diagnoseIfNeeded(diagnosticsBlob);
     if(!module)
         return SLANG_FAIL;

--- a/examples/shader-toy/main.cpp
+++ b/examples/shader-toy/main.cpp
@@ -28,6 +28,8 @@ using Slang::ComPtr;
 
 #include <chrono>
 
+static const ExampleResources resourceBase("shader-toy");
+
 using namespace gfx;
 
 // In order to display a shader toy effect using rasterization-based shader
@@ -109,7 +111,8 @@ Result loadShaderProgram(gfx::IDevice* device, ComPtr<gfx::IShaderProgram>& outS
     //      import shader_toy;
     //
     ComPtr<slang::IBlob> diagnosticsBlob;
-    slang::IModule* module = slangSession->loadModule("shader-toy", diagnosticsBlob.writeRef());
+    Slang::String shaderToyPath = resourceBase.resolveResource("shader-toy.slang");
+    slang::IModule* module = slangSession->loadModule(shaderToyPath.getBuffer(), diagnosticsBlob.writeRef());
     diagnoseIfNeeded(diagnosticsBlob);
     if(!module)
         return SLANG_FAIL;
@@ -197,9 +200,9 @@ Result loadShaderProgram(gfx::IDevice* device, ComPtr<gfx::IShaderProgram>& outS
     // same module, and to demonstrate that we will load a different
     // module to provide the effect type we will plug in.
     //
-    const char* effectModuleName = "example-effect";
     const char* effectTypeName = "ExampleEffect";
-    slang::IModule* effectModule = slangSession->loadModule(effectModuleName, diagnosticsBlob.writeRef());
+    Slang::String effectModulePath = resourceBase.resolveResource("example-effect.slang");
+    slang::IModule* effectModule = slangSession->loadModule(effectModulePath.getBuffer(), diagnosticsBlob.writeRef());
     diagnoseIfNeeded(diagnosticsBlob);
     if(!module)
         return SLANG_FAIL;

--- a/examples/triangle/main.cpp
+++ b/examples/triangle/main.cpp
@@ -42,6 +42,8 @@
 using namespace gfx;
 using namespace Slang;
 
+static const ExampleResources resourceBase("triangle");
+
 // For the purposes of a small example, we will define the vertex data for a
 // single triangle directly in the source file. It should be easy to extend
 // this example to load data from an external source, if desired.
@@ -112,7 +114,8 @@ gfx::Result loadShaderProgram(
     // already been loaded previously, that would be used directly.
     //
     ComPtr<slang::IBlob> diagnosticsBlob;
-    slang::IModule* module = slangSession->loadModule("shaders", diagnosticsBlob.writeRef());
+    Slang::String path = resourceBase.resolveResource("shaders.slang");
+    slang::IModule* module = slangSession->loadModule(path.getBuffer(), diagnosticsBlob.writeRef());
     diagnoseIfNeeded(diagnosticsBlob);
     if(!module)
         return SLANG_FAIL;


### PR DESCRIPTION
Fixes #4314 

Extending examples so that they search for the resources needed in directories above CWD.

Now copies of the example resources are put into build for all platforms (before used to be only Windows).

Users should now be able to run the programs anywhere within the build directory (even from CLI).