### PR TITLE
Fix the type error in kIROp_RWStructuredBufferLoad

### DIFF
--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -2068,7 +2068,9 @@ bool GLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
 
             emitOperand(inst->getOperand(0), leftSide(outerPrec, prec));
             m_writer->emit("._data[");
+            m_writer->emit("uint(");
             emitOperand(inst->getOperand(1), getInfo(EmitOp::General));
+            m_writer->emit(")");
             m_writer->emit("]");
 
             maybeCloseParens(needClose);

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -2068,6 +2068,7 @@ bool GLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
 
             emitOperand(inst->getOperand(0), leftSide(outerPrec, prec));
             m_writer->emit("._data[");
+            // glsl only support int/uint as array index
             m_writer->emit("uint(");
             emitOperand(inst->getOperand(1), getInfo(EmitOp::General));
             m_writer->emit(")");

--- a/tests/compute/byte-address-buffer-array.slang
+++ b/tests/compute/byte-address-buffer-array.slang
@@ -26,10 +26,10 @@ void computeMain(uint3 threadId : SV_DispatchThreadID)
     // CHECK1: {{.*}}[0] =  {{.*}}.data_0[0];
     // CHECK1: {{.*}}[1] =  {{.*}}.data_0[1];
     // CHECK1: vec4  {{.*}}[2];
-    // CHECK1: unpackStorage_0(buffer_0._data[0], {{.*}});
+    // CHECK1: unpackStorage_0(buffer_0._data[uint(0)], {{.*}});
     // CHECK1: vec4  {{.*}}[2] = buffer_0._data[0] = packStorage_0({{.*}});
-    // CHECK1: vec4 {{.*}} = buffer_2._data[1];
-    // CHECK1: vec4 {{.*}} = buffer_2._data[1] = vec4(buffer_1._data[1], buffer_1._data[2], buffer_1._data[3], buffer_1._data[4]);
+    // CHECK1: vec4 {{.*}} = buffer_2._data[uint(1)];
+    // CHECK1: vec4 {{.*}} = buffer_2._data[1] = vec4(buffer_1._data[uint(1)], buffer_1._data[uint(2)], buffer_1._data[uint(3)], buffer_1._data[uint(4)]);
 
     // CHECK2: float4 {{.*}}[int(2)] = (buffer_0).Load<float4 [int(2)] >(int(0));
     // CHECK2: buffer_0.Store(int(0),{{.*}});


### PR DESCRIPTION
In StructuredBuffer::Load(), we allow any type of integer as the input. However, when emitting glsl code,
StructuredBuffer::Load(index)
will be translated to the subscript index of the buffer, e.g. buffer[index], however, glsl doesn't allow 64bit integer as the subscript.

So the easiest fix is to convert the index to integer when emitting glsl.