### PR TITLE
Support HLSL `.sample` operators for MS textures

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -3202,6 +3202,7 @@ struct __TextureMip<T, Shape : __ITextureShape, let isArray : int, let isCombine
         get { return tex.Load(__makeVector(pos, mip)); }
     }
 }
+
 struct __TextureMips<T, Shape : __ITextureShape, let isArray : int, let isCombined : int, let format : int>
 {
     __TextureImpl<T, Shape, isArray, 0 /*isMS*/, 0 /*sampleCount*/, 0 /*access*/, 0 /*isShadow*/, isCombined, format> tex;
@@ -3216,6 +3217,38 @@ __generic<T, Shape : __ITextureShape, let isArray : int, let isCombined : int, l
 extension __TextureImpl<T, Shape, isArray, 0 /*isMS*/, 0 /*sampleCount*/, 0 /*access*/, 0 /*isShadow*/, isCombined, format>
 {
     property __TextureMips<T, Shape, isArray, isCombined, format> mips
+    {
+        [__unsafeForceInlineEarly]
+        get { return { this }; }
+    }
+}
+
+// Definitions to support the .sample[][] operator.
+struct __TextureSample<T, Shape : __ITextureShape, let isArray : int, let isCombined : int, let format : int>
+{
+    __TextureImpl<T, Shape, isArray, 1 /*isMS*/, 0 /*sampleCount*/, 0 /*access*/, 0 /*isShadow*/, isCombined, format> tex;
+    int sample;
+    __subscript(vector<int, isArray + Shape.dimensions> pos)->T
+    {
+        [__unsafeForceInlineEarly]
+        get { return tex[pos, sample]; }
+    }
+}
+
+struct __TextureSampleMS<T, Shape : __ITextureShape, let isArray : int, let isCombined : int, let format : int>
+{
+    __TextureImpl<T, Shape, isArray, 1 /*isMS*/, 0 /*sampleCount*/, 0 /*access*/, 0 /*isShadow*/, isCombined, format> tex;
+    __subscript(int sample)->__TextureSample<T, Shape, isArray, isCombined, format>
+    {
+        [__unsafeForceInlineEarly]
+        get { return { tex, sample }; }
+    }
+}
+
+__generic<T, Shape : __ITextureShape, let isArray : int, let isCombined : int, let format : int>
+extension __TextureImpl<T, Shape, isArray, 1 /*isMS*/, 0 /*sampleCount*/, 0 /*access*/, 0 /*isShadow*/, isCombined, format>
+{
+    property __TextureSampleMS<T, Shape, isArray, isCombined, format> sample
     {
         [__unsafeForceInlineEarly]
         get { return { this }; }

--- a/tests/hlsl/texture-sample-operator.slang
+++ b/tests/hlsl/texture-sample-operator.slang
@@ -1,0 +1,13 @@
+Texture2DMS <int3> t1;
+Texture2DMSArray <float4> t2;
+
+float4 main()
+{
+    uint2 p1 = uint2(1, 2);
+    int3 a1 = t1.sample[7][p1];
+
+    uint p2 = uint(1);
+    float4 a2 = t2.sample[p2][uint3(1, 2, 3)];
+
+    return float4(float3(a1), 0) + a2;
+}

--- a/tests/hlsl/texture-sample-operator.slang
+++ b/tests/hlsl/texture-sample-operator.slang
@@ -1,11 +1,25 @@
+//TEST:SIMPLE(filecheck=HLSL): -target hlsl -stage vertex
+//TEST:SIMPLE(filecheck=GLSL): -target glsl -stage vertex
+//TEST:SIMPLE(filecheck=METAL): -target metal -stage vertex
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -stage vertex
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv-asm -stage vertex
+
 Texture2DMS <int3> t1;
 Texture2DMSArray <float4> t2;
 
 float4 main()
 {
+    // HLSL: .sample
+    // GLSL: texelFetch
+    // SPIRV: OpImageFetch %v4int {{.*}} Sample {{.*}}
+    // METAL: .read
     uint2 p1 = uint2(1, 2);
     int3 a1 = t1.sample[7][p1];
 
+    // HLSL: .sample
+    // GLSL: texelFetch
+    // SPIRV: OpImageFetch %v4float {{.*}} Sample {{.*}}
+    // METAL: .read
     uint p2 = uint(1);
     float4 a2 = t2.sample[p2][uint3(1, 2, 3)];
 


### PR DESCRIPTION
Fixes #4497

Includes a test to ensure the generated code has the appropriate functions for all targets.