### PR TITLE
Language server performance and document symbol fix.

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1823,6 +1823,7 @@ namespace Slang
     static ConstructorDecl* _createCtor(SemanticsDeclVisitorBase* visitor, ASTBuilder* m_astBuilder, AggTypeDecl* decl)
     {
         auto ctor = m_astBuilder->create<ConstructorDecl>();
+        addModifier(ctor, m_astBuilder->create<SynthesizedModifier>());
         auto ctorName = visitor->getName("$init");
         ctor->ownedScope = m_astBuilder->create<Scope>();
         ctor->ownedScope->containerDecl = ctor;

--- a/source/slang/slang-language-server-document-symbols.cpp
+++ b/source/slang/slang-language-server-document-symbols.cpp
@@ -150,6 +150,8 @@ namespace Slang
                 continue;
             if (!nameLoc.loc.isValid())
                 continue;
+            if (child->hasModifier<SynthesizedModifier>() || child->hasModifier<ToBeSynthesizedModifier>())
+                continue;
             auto humaneLoc = srcManager->getHumaneLoc(nameLoc.loc, SourceLocType::Actual);
             if (humaneLoc.line == 0)
                 continue;

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3669,8 +3669,14 @@ RefPtr<Module> Linkage::findOrImportModule(
 
 
     // Look for a precompiled module first, if not exist, load from source.
-    for (int checkBinaryModule = 1; checkBinaryModule >= 0; checkBinaryModule--)
+    bool shouldCheckBinaryModuleSettings[2] = { true, false };
+
+    for (auto checkBinaryModule : shouldCheckBinaryModuleSettings)
     {
+        // When in language server, we always prefer to use source module if it is available.
+        if (isInLanguageServer())
+            checkBinaryModule = !checkBinaryModule;
+
         // Try without translating `_` to `-` first, if that fails, try translating.
         for (int translateUnderScore = 0; translateUnderScore <= 1; translateUnderScore++)
         {


### PR DESCRIPTION
Fix language server performance regression due to additional path search, we now always prefer to look at source modules instead of trying to search for binary modules first when in language server mode.

Fix a correctness issue where the synthesized constructor has invalid source loc info and caused visual studio code validation error.

Fixes #4560.
Fixes #4562.