### PR TITLE
Add intrinsic for clock2x32ARB

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -20225,3 +20225,22 @@ struct ConstBufferPointer
         }
     }
 }
+
+__glsl_version(450)
+__glsl_extension(GL_ARB_shader_clock)
+__target_intrinsic(glsl, clock2x32ARB)
+[require(glsl_spirv, GL_ARB_shader_clock)]
+uint2 clock2x32ARB()
+{
+    __target_switch
+    {
+    case glsl: __intrinsic_asm "clock2x32ARB";
+    case spirv:
+        const uint32_t scopeId_subgroup = 3;
+        return spirv_asm {
+        OpCapability ShaderClockKHR;
+        OpExtension "SPV_KHR_shader_clock";
+        result:$$uint2 = OpReadClockKHR $scopeId_subgroup;
+        };
+    }
+}

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -316,6 +316,7 @@ def _GL_ARB_sparse_texture2 : _GL_ARB_sparse_texture;
 def _GL_ARB_sparse_texture_clamp : _GL_ARB_sparse_texture2;
 def _GL_ARB_texture_gather : _GLSL_130;
 def _GL_ARB_texture_query_levels : _GLSL_130;
+def _GL_ARB_shader_clock : _GLSL_450;
 
 def _GL_KHR_memory_scope_semantics : _GLSL_420;
 def _GL_KHR_shader_subgroup_arithmetic : _GLSL_140;
@@ -370,6 +371,7 @@ alias GL_ARB_shader_texture_image_samples = _GL_ARB_shader_texture_image_samples
 alias GL_ARB_sparse_texture_clamp = _GL_ARB_sparse_texture_clamp | spvSparseResidency;
 alias GL_ARB_texture_gather = _GL_ARB_texture_gather | spvImageGatherExtended | metal;
 alias GL_ARB_texture_query_levels = _GL_ARB_texture_query_levels | spvImageQuery | metal;
+alias GL_ARB_shader_clock = _GL_ARB_shader_clock | spvShaderClockKHR;
 
 alias GL_KHR_memory_scope_semantics = _GL_KHR_memory_scope_semantics | _spirv_1_0;
 alias GL_KHR_shader_subgroup_arithmetic = _GL_KHR_shader_subgroup_arithmetic | spvGroupNonUniformArithmetic;

--- a/tests/glsl-intrinsic/clock-read.slang
+++ b/tests/glsl-intrinsic/clock-read.slang
@@ -1,0 +1,19 @@
+//TEST:SIMPLE(filecheck=CHECK1): -target glsl
+//TEST:SIMPLE(filecheck=CHECK2): -target spirv
+//TEST:SIMPLE(filecheck=CHECK3): -target spirv -emit-spirv-via-glsl
+
+
+// CHECK1: GL_ARB_shader_clock : require
+// CHECK2: OpCapability ShaderClockKHR
+// CHECK2: OpExtension "SPV_KHR_shader_clock"
+RWStructuredBuffer<float> output;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 id: SV_DispatchThreadID)
+{
+    output[0] = clock2x32ARB().x;
+    // CHECK1: clock2x32ARB
+    // CHECK2: OpReadClockKHR %v2uint %uint_3
+    // CHECK3: OpReadClockKHR %v2uint %uint_3
+}


### PR DESCRIPTION
Close issue #4564.

This change adds the glsl intrinsic clock2x32ARB support.
Also define a cap: GL_ARB_shader_clock.