### PR TITLE
Neaten filecheck output for non-passing nested-parameter-block test

### DIFF
--- a/tests/bindings/nested-parameter-block-2.slang
+++ b/tests/bindings/nested-parameter-block-2.slang
@@ -37,6 +37,10 @@ ParameterBlock<MyBuffer> pb2;
 [numthreads(4,1,1)]
 void computeMain(uint3 sv_dispatchThreadID : SV_DispatchThreadID)
 {
-    // CHECK: 4
+    // CHECK: type: uint32_t
+    // CHECK-NEXT: 4
+    // CHECK-NEXT: 4
+    // CHECK-NEXT: 4
+    // CHECK-NEXT: 4
     pb2.resultBuffer[sv_dispatchThreadID.x] = scene.sceneCb.value.x + scene.data[0].x + scene.material.cb.value.x + scene.material.data[0].x;
 }


### PR DESCRIPTION
With this context filecheck can generate a better error when it fails