### PR TITLE
Change `IDefaultInitializableType` to `IDefaultInitializable`

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -75,7 +75,7 @@ syntax snorm : SNormModifier;
 syntax __extern_cpp : ExternCppModifier;
 
 __magic_type(DefaultInitializableType)
-interface IDefaultInitializableType
+interface IDefaultInitializable
 {
     __builtin_requirement($( (int)BuiltinRequirementKind::DefaultInitializableConstructor))
     __init();

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -6163,7 +6163,7 @@ namespace Slang
 
             if (this->getOptionSet().getBoolOption(CompilerOptionName::ZeroInitialize) && !isFromStdLib(decl))
             {
-                // Force add IDefaultInitializableType to any struct missing (transitively) `IDefaultInitializableType`.
+                // Force add IDefaultInitializable to any struct missing (transitively) `IDefaultInitializable`.
                 auto* defaultInitializableType = m_astBuilder->getDefaultInitializableType();
                 if(!isSubtype(DeclRefType::create(m_astBuilder, decl), defaultInitializableType, IsSubTypeOptions::NotReadyForLookup))
                 {

--- a/tests/language-feature/zero-initialize/IDefaultExplicit-wrapper-type.slang
+++ b/tests/language-feature/zero-initialize/IDefaultExplicit-wrapper-type.slang
@@ -10,15 +10,15 @@
 //TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
-struct Base : IDefaultInitializableType
+struct Base : IDefaultInitializable
 {
     int data1;
 };
 
-struct idefault1_base : IDefaultInitializableType
+struct idefault1_base : IDefaultInitializable
 {
 };
-interface idefault2_base : IDefaultInitializableType
+interface idefault2_base : IDefaultInitializable
 {
 };
 

--- a/tests/language-feature/zero-initialize/IDefaultExplicit.slang
+++ b/tests/language-feature/zero-initialize/IDefaultExplicit.slang
@@ -9,12 +9,12 @@
 //TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
-struct idefault1 : IDefaultInitializableType
+struct idefault1 : IDefaultInitializable
 {
     uint data;
 };
 
-struct idefault2_base : IDefaultInitializableType
+struct idefault2_base : IDefaultInitializable
 {
     uint data1;
 };
@@ -23,7 +23,7 @@ struct idefault2 : idefault2_base
     uint data2 = 1;
 };
 
-interface idefault3_base : IDefaultInitializableType
+interface idefault3_base : IDefaultInitializable
 {
 };
 struct idefault3 : idefault3_base
@@ -36,11 +36,11 @@ struct idefault4
     uint data;
 };
 
-extension idefault4 : IDefaultInitializableType
+extension idefault4 : IDefaultInitializable
 {
 }
 
-struct idefault5_base : IDefaultInitializableType
+struct idefault5_base : IDefaultInitializable
 {
     uint data1;
 };

--- a/tests/language-feature/zero-initialize/IDefaultExplicitGenerics.slang
+++ b/tests/language-feature/zero-initialize/IDefaultExplicitGenerics.slang
@@ -10,7 +10,7 @@
 RWStructuredBuffer<int> outputBuffer;
 
 __generic<T>
-struct idefault1 : IDefaultInitializableType
+struct idefault1 : IDefaultInitializable
 {
     vector<T,4> data;
 };


### PR DESCRIPTION
Change `IDefaultInitializableType` to `IDefaultInitializable` to use a uniform naming scheme for `interface` identifiers across Slang.