### PR TITLE
Start autodiff pass if `IRDerivativeMemberDecoration` is found

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -292,6 +292,7 @@ void calcRequiredLoweringPassSet(RequiredLoweringPassSet& result, CodeGenContext
     case kIROp_BackwardDifferentiate:
     case kIROp_ForwardDifferentiate:
     case kIROp_MakeDifferentialPairUserCode:
+    case kIROp_DerivativeMemberDecoration:
         result.autodiff = true;
         break;
     case kIROp_VerticesType:

--- a/tests/compute/struct-autodiff-default-init.slang
+++ b/tests/compute/struct-autodiff-default-init.slang
@@ -1,0 +1,25 @@
+// struct-default-init.slang
+//TEST:SIMPLE(filecheck=HLSL): -target hlsl -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=GLSL): -target glsl -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=METAL): -target metal -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=CPP): -target cpp -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -entry computeMain -stage compute
+
+// HLSL: computeMain
+// GLSL: main
+// METAL: computeMain
+// CPP: computeMain
+// SPIRV: OpEntryPoint
+
+struct PowActivationEx : IDifferentiable
+{
+	float power;
+}
+RWStructuredBuffer<float> return_value;
+
+[numthreads(256, 1, 1)]
+void computeMain()
+{
+    PowActivationEx args;
+	return_value[0] = args.power;
+}


### PR DESCRIPTION
Fixes #4622

Problem:
Currently, if a decoration refers to its-parent through its operands we will have a recursive dependency and fail. The reason we encounter this problem is because autodiff decorations are not stripped if the autodiff -pass never runs. This happens due to the autodiff pass not running if we only have a `IRDerivativeMemberDecoration`.

Solution:
Start autodiff pass if we found a `IRDerivativeMemberDecoration`.