### PR TITLE
Fix issue with synthesized `__init` methods not getting added to witness table

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -4268,8 +4268,8 @@ namespace Slang
         }
         if (isDefaultInitializableType)
             context->parentDecl->addMember(ctorDecl);
-        else
-            _addMethodWitness(witnessTable, requiredMemberDeclRef, makeDeclRef(ctorDecl));
+        
+        _addMethodWitness(witnessTable, requiredMemberDeclRef, makeDeclRef(ctorDecl));
         
         return true;
     }

--- a/tests/compute/assoctype-nested-lookup.slang
+++ b/tests/compute/assoctype-nested-lookup.slang
@@ -6,7 +6,7 @@
 //TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-interface IFoo
+interface IFoo : IDefaultInitializable
 {
     associatedtype Bar : IFoo;
 };


### PR DESCRIPTION
This is a quick fix:  we weren't registering a synthesized constructor onto the witness table for dynamic dispatch.

Fixes: https://github.com/shader-slang/slang/issues/4637