### PR TITLE
SCCP instead of CFG to clear unused blocks using `isTextureAccess` with `static_assert`

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -911,7 +911,7 @@ Result linkAndOptimizeIR(
     legalizeVectorTypes(irModule, sink);
 
     // Legalize `__isTextureAccess` and related.
-    legalizeIsTextureAccess(irModule);
+    legalizeIsTextureAccess(irModule, sink);
 
     // Once specialization and type legalization have been performed,
     // we should perform some of our basic optimization steps again,

--- a/source/slang/slang-ir-legalize-is-texture-access.cpp
+++ b/source/slang/slang-ir-legalize-is-texture-access.cpp
@@ -8,7 +8,7 @@
 #include "slang-parameter-binding.h"
 #include "slang-ir-legalize-image-subscript.h"
 #include "slang-ir-legalize-varying-params.h"
-#include "slang-ir-simplify-cfg.h"
+#include "slang-ir-sccp.h"
 
 namespace Slang
 {
@@ -17,9 +17,9 @@ namespace Slang
         return as<IRImageSubscript>(getRootAddr(inst->getOperand(0)));
     }
 
-    void legalizeIsTextureAccess(IRModule* module)
+    void legalizeIsTextureAccess(IRModule* module, DiagnosticSink* sink)
     {
-        HashSet<IRFunc*> functionsToSimplifyCFG;
+        HashSet<IRFunc*> functionsToSCCP;
         IRBuilder builder(module);
         for (auto globalInst : module->getModuleInst()->getChildren())
         {
@@ -41,7 +41,7 @@ namespace Slang
                         else
                         {
                             inst->replaceUsesWith(builder.getBoolValue(false));
-                            functionsToSimplifyCFG.add(func);
+                            functionsToSCCP.add(func);
                         }
                         inst->removeAndDeallocate();
                         continue;
@@ -53,7 +53,7 @@ namespace Slang
                         else
                         {
                             inst->replaceUsesWith(builder.getBoolValue(false));
-                            functionsToSimplifyCFG.add(func);
+                            functionsToSCCP.add(func);
                         }
                         inst->removeAndDeallocate();
                         continue;
@@ -66,7 +66,7 @@ namespace Slang
                         else
                         {
                             inst->replaceUsesWith(builder.getBoolValue(false));
-                            functionsToSimplifyCFG.add(func);
+                            functionsToSCCP.add(func);
                         }
                         inst->removeAndDeallocate();
                         continue;
@@ -75,10 +75,11 @@ namespace Slang
                 }   
             }
         }
-        // Requires a simplifyCFG to ensure Slang does not evaluate 'IRTextureType' code path for 
-        // 'inst' for when 'inst' is not a 'IRTextureType'/TextureAccessor
-        for(auto func : functionsToSimplifyCFG)
-            simplifyCFG(func, CFGSimplificationOptions::getFast());
+        // Requires a SCCP to ensure Slang does not evaluate 'IRTextureType' code path
+        // and unresolved 'isTextureAccess' operations for when 'inst' is not a
+        // 'IRTextureType'/`TextureAccessor`
+        for (auto func : functionsToSCCP)
+            applySparseConditionalConstantPropagation(func, sink); 
     }
 }
 

--- a/source/slang/slang-ir-legalize-is-texture-access.h
+++ b/source/slang/slang-ir-legalize-is-texture-access.h
@@ -7,5 +7,5 @@ namespace Slang
 {
     class DiagnosticSink;
 
-    void legalizeIsTextureAccess(IRModule* module);
+    void legalizeIsTextureAccess(IRModule* module, DiagnosticSink* sink);
 }

--- a/tests/hlsl-intrinsic/atomic/atomic-intrinsics.slang
+++ b/tests/hlsl-intrinsic/atomic/atomic-intrinsics.slang
@@ -1,6 +1,7 @@
 //DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=DX12):-slang -compute -dx12 -profile cs_6_0 -use-dxil -shaderobj -output-using-type -xslang -DDX12
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=VK):-vk -emit-spirv-directly -compute -shaderobj -output-using-type -render-feature hardware-device -xslang -DVK
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=VK):-vk -emit-spirv-via-glsl -compute -shaderobj -output-using-type -render-feature hardware-device -xslang -DVK -xslang -minimum-slang-optimization
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=VK):-vk -emit-spirv-via-glsl -compute -shaderobj -output-using-type -render-feature hardware-device -xslang -DVK
 //DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj -output-using-type
 


### PR DESCRIPTION
Fixes: #4639

Currently we use 'simplify CFG' to remove unused blocks using `isTextureAccess` functions. This works because the code then uses the 'simplify SCCP' inside 'SimplifyIR' to remove all code associated with unused code blocks.

Due to reliance on 'SimplifyIR' this code does not work when using slang with a 'minimal optimization flag'. Calling 'simplify SCCP' directly solves this dependency.