### PR TITLE
Correctly parse multiple escaped newlines

### DIFF
--- a/source/compiler-core/slang-lexer.cpp
+++ b/source/compiler-core/slang-lexer.cpp
@@ -185,7 +185,7 @@ namespace Slang
 
             c = lexer->m_cursor[pos++];
 
-            if (c == '\\')
+            while (c == '\\')
             {
                 // We might have a backslash-escaped newline.
                 // Look at the next byte (if any) to see.
@@ -198,18 +198,21 @@ namespace Slang
                 case '\r': case '\n':
                 {
                     // The newline was escaped, so return the code point after *that*
-
                     int e = lexer->m_cursor[pos++];
                     if ((d ^ e) == ('\r' ^ '\n'))
                         c = lexer->m_cursor[pos++];
                     else
                         c = e;
-                    break;
+                    continue;
                 }
 
                 default:
                     break;
                 }
+
+                // Only continue this while loop in the case where we consumed
+                // some newlines
+                break;
             }
             // TODO: handle UTF-8 encoding for non-ASCII code points here
 

--- a/tests/bugs/gh-4667.slang
+++ b/tests/bugs/gh-4667.slang
@@ -1,0 +1,4 @@
+//TEST:SIMPLE:
+\
+\
+int x;


### PR DESCRIPTION
closes https://github.com/shader-slang/slang/issues/4667