### PR TITLE
Fix bug with uninitiailized variable warnings in nested scopes

### DIFF
--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -377,21 +377,24 @@ namespace Slang
         }
 
         // Check ordinary instructions
-        for (auto inst = firstBlock->getFirstInst(); inst; inst = inst->getNextInst())
+        for (auto block : func->getBlocks())
         {
-            if (!isUninitializedValue(inst))
-                continue;
-
-            IRType* type = inst->getFullType();
-            if (canIgnoreType(type, nullptr))
-               continue;
-
-            auto loads = getUnresolvedVariableLoads(reachability, inst);
-            for (auto load : loads)
+            for (auto inst = block->getFirstInst(); inst; inst = inst->getNextInst())
             {
-                sink->diagnose(load,
+                if (!isUninitializedValue(inst))
+                    continue;
+
+                IRType* type = inst->getFullType();
+                if (canIgnoreType(type, nullptr))
+                    continue;
+
+                auto loads = getUnresolvedVariableLoads(reachability, inst);
+                for (auto load : loads)
+                {
+                    sink->diagnose(load,
                         Diagnostics::usingUninitializedVariable,
                         inst);
+                }
             }
         }
     }

--- a/tests/diagnostics/uninitialized-local-variables.slang
+++ b/tests/diagnostics/uninitialized-local-variables.slang
@@ -148,4 +148,30 @@ float structs()
     return result;
 }
 
+// Warnings even in nested scopes
+float nested_scopes(int x, inout float p)
+{
+    if (x == 0)
+    {
+        float y;
+        //CHK-DAG: warning 41016: use of uninitialized variable 'y'
+        return y;
+    }
+    else if (x == 1)
+    {
+        float y;
+        //CHK-DAG: warning 41016: use of uninitialized variable 'y'
+        p = y + 1;
+
+        if (x == 2)
+        {
+            float z;
+            //CHK-DAG: warning 41016: use of uninitialized variable 'z'
+            p += z;
+        }
+    }
+
+    return 1.0;
+}
+
 //CHK-NOT: warning 41016

--- a/tests/hlsl-intrinsic/size-of/align-of-3.slang
+++ b/tests/hlsl-intrinsic/size-of/align-of-3.slang
@@ -24,7 +24,7 @@ int getParamSizeWithDirection(inout uint3 v)
     return alignof(v);
 }
 
-struct TestThis
+struct TestThis : IDefaultInitializable
 {
     int getSize()
     {

--- a/tests/hlsl-intrinsic/size-of/size-of-3.slang
+++ b/tests/hlsl-intrinsic/size-of/size-of-3.slang
@@ -24,7 +24,7 @@ int getParamSizeWithDirection(inout uint3 v)
     return sizeof(v);
 }
 
-struct TestThis
+struct TestThis : IDefaultInitializable
 {
     int getSize()
     {


### PR DESCRIPTION
Addressed to #3832 

Fixes a bug in #4530 which results in the warning system ignoring uninitialized variables in nested scopes.