### PR TITLE
Warnings for uninitialized fields in constructors

### DIFF
--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -371,8 +371,10 @@ class FunctionDeclBase : public CallableDecl
 class ConstructorDecl : public FunctionDeclBase
 {
     SLANG_AST_CLASS(ConstructorDecl)
-    
-    bool synthesized = false;
+   
+    // Indicates whether the declaration was synthesized by
+    // slang and not actually provided by the user
+    bool isSynthesized = false;
 };
 
 // A subscript operation used to index instances of a type

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -371,6 +371,8 @@ class FunctionDeclBase : public CallableDecl
 class ConstructorDecl : public FunctionDeclBase
 {
     SLANG_AST_CLASS(ConstructorDecl)
+    
+    bool synthesized = false;
 };
 
 // A subscript operation used to index instances of a type

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1813,6 +1813,7 @@ namespace Slang
         body->closingSourceLoc = ctor->closingSourceLoc;
         ctor->body = body;
         body->body = m_astBuilder->create<SeqStmt>();
+        ctor->synthesized = true;
         decl->addMember(ctor);
         return ctor;
     }

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1813,7 +1813,7 @@ namespace Slang
         body->closingSourceLoc = ctor->closingSourceLoc;
         ctor->body = body;
         body->body = m_astBuilder->create<SeqStmt>();
-        ctor->synthesized = true;
+        ctor->isSynthesized = true;
         decl->addMember(ctor);
         return ctor;
     }

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -745,6 +745,7 @@ DIAGNOSTIC(41017, Warning, usingUninitializedGlobalVariable, "use of uninitializ
 DIAGNOSTIC(41018, Warning, returningWithUninitializedOut, "returning without initializing out parameter '$0'")
 DIAGNOSTIC(41019, Warning, returningWithPartiallyUninitializedOut, "returning without fully initializing out parameter '$0'")
 DIAGNOSTIC(41020, Warning, constructorUninitializedField, "exiting constructor without initializing field '$0'")
+DIAGNOSTIC(41020, Warning, fieldNotDefaultInitialized, "default initializer for '$0' will not initialize field '$1'")
 
 DIAGNOSTIC(41011, Error, typeDoesNotFitAnyValueSize, "type '$0' does not fit in the size required by its conforming interface.")
 DIAGNOSTIC(41012, Note, typeAndLimit, "sizeof($0) is $1, limit is $2")

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -745,7 +745,7 @@ DIAGNOSTIC(41017, Warning, usingUninitializedGlobalVariable, "use of uninitializ
 DIAGNOSTIC(41018, Warning, returningWithUninitializedOut, "returning without initializing out parameter '$0'")
 DIAGNOSTIC(41019, Warning, returningWithPartiallyUninitializedOut, "returning without fully initializing out parameter '$0'")
 DIAGNOSTIC(41020, Warning, constructorUninitializedField, "exiting constructor without initializing field '$0'")
-DIAGNOSTIC(41020, Warning, fieldNotDefaultInitialized, "default initializer for '$0' will not initialize field '$1'")
+DIAGNOSTIC(41021, Warning, fieldNotDefaultInitialized, "default initializer for '$0' will not initialize field '$1'")
 
 DIAGNOSTIC(41011, Error, typeDoesNotFitAnyValueSize, "type '$0' does not fit in the size required by its conforming interface.")
 DIAGNOSTIC(41012, Note, typeAndLimit, "sizeof($0) is $1, limit is $2")

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -744,6 +744,7 @@ DIAGNOSTIC(41016, Warning, usingUninitializedVariable, "use of uninitialized var
 DIAGNOSTIC(41017, Warning, usingUninitializedGlobalVariable, "use of uninitialized global variable '$0'")
 DIAGNOSTIC(41018, Warning, returningWithUninitializedOut, "returning without initializing out parameter '$0'")
 DIAGNOSTIC(41019, Warning, returningWithPartiallyUninitializedOut, "returning without fully initializing out parameter '$0'")
+DIAGNOSTIC(41020, Warning, constructorUninitializedField, "exiting constructor without initializing field '$0'")
 
 DIAGNOSTIC(41011, Error, typeDoesNotFitAnyValueSize, "type '$0' does not fit in the size required by its conforming interface.")
 DIAGNOSTIC(41012, Note, typeAndLimit, "sizeof($0) is $1, limit is $2")

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -925,6 +925,7 @@ INST_RANGE(BindingQuery, GetRegisterIndex, GetRegisterSpace)
 
     INST(SemanticDecoration, semantic, 2, 0)
     INST(ConstructorDecoration, constructor, 0, 0)
+    INST(SynthesizedDecoration, synthesized, 0, 0)
 
     INST(PackOffsetDecoration, packoffset, 2, 0)
 

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -924,9 +924,7 @@ INST_RANGE(BindingQuery, GetRegisterIndex, GetRegisterSpace)
     INST_RANGE(StageAccessDecoration, StageReadAccessDecoration, StageWriteAccessDecoration)
 
     INST(SemanticDecoration, semantic, 2, 0)
-    INST(ConstructorDecoration, constructor, 0, 0)
-    INST(SynthesizedDecoration, synthesized, 0, 0)
-
+    INST(ConstructorDecoration, constructor, 1, 0)
     INST(PackOffsetDecoration, packoffset, 2, 0)
 
         // Reflection metadata for a shader parameter that provides the original type name.

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -924,6 +924,8 @@ INST_RANGE(BindingQuery, GetRegisterIndex, GetRegisterSpace)
     INST_RANGE(StageAccessDecoration, StageReadAccessDecoration, StageWriteAccessDecoration)
 
     INST(SemanticDecoration, semantic, 2, 0)
+    INST(ConstructorDecoration, constructor, 0, 0)
+
     INST(PackOffsetDecoration, packoffset, 2, 0)
 
         // Reflection metadata for a shader parameter that provides the original type name.

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -1358,6 +1358,11 @@ struct IRSemanticDecoration : public IRDecoration
     int getSemanticIndex() { return int(getIntVal(getSemanticIndexOperand())); }
 };
 
+struct IRConstructorDecorartion : IRDecoration
+{
+    IR_LEAF_ISA(ConstructorDecoration)
+};
+
 struct IRPackOffsetDecoration : IRDecoration
 {
     enum
@@ -4522,6 +4527,11 @@ public:
     IRSemanticDecoration* addSemanticDecoration(IRInst* value, UnownedStringSlice const& text, int index = 0)
     {
         return as<IRSemanticDecoration>(addDecoration(value, kIROp_SemanticDecoration, getStringValue(text), getIntValue(getIntType(), index)));
+    }
+
+    void addConstructorDecoration(IRInst* value)
+    {
+        addDecoration(value, kIROp_ConstructorDecoration);
     }
 
     void addRequireSPIRVDescriptorIndexingExtensionDecoration(IRInst* value)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -1361,11 +1361,8 @@ struct IRSemanticDecoration : public IRDecoration
 struct IRConstructorDecorartion : IRDecoration
 {
     IR_LEAF_ISA(ConstructorDecoration)
-};
 
-struct IRSynthesizedDecoration : IRDecoration
-{
-    IR_LEAF_ISA(SynthesizedDecoration)
+    bool getSynthesizedStatus() { return cast<IRBoolLit>(getOperand(0))->getValue(); }
 };
 
 struct IRPackOffsetDecoration : IRDecoration
@@ -4534,14 +4531,9 @@ public:
         return as<IRSemanticDecoration>(addDecoration(value, kIROp_SemanticDecoration, getStringValue(text), getIntValue(getIntType(), index)));
     }
 
-    void addConstructorDecoration(IRInst* value)
+    void addConstructorDecoration(IRInst* value, bool synthesizedConstructor)
     {
-        addDecoration(value, kIROp_ConstructorDecoration);
-    }
-    
-    void addSynthesizedDecoration(IRInst* value)
-    {
-        addDecoration(value, kIROp_SynthesizedDecoration);
+        addDecoration(value, kIROp_ConstructorDecoration, getBoolValue(synthesizedConstructor));
     }
 
     void addRequireSPIRVDescriptorIndexingExtensionDecoration(IRInst* value)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -1363,6 +1363,11 @@ struct IRConstructorDecorartion : IRDecoration
     IR_LEAF_ISA(ConstructorDecoration)
 };
 
+struct IRSynthesizedDecoration : IRDecoration
+{
+    IR_LEAF_ISA(SynthesizedDecoration)
+};
+
 struct IRPackOffsetDecoration : IRDecoration
 {
     enum
@@ -4532,6 +4537,11 @@ public:
     void addConstructorDecoration(IRInst* value)
     {
         addDecoration(value, kIROp_ConstructorDecoration);
+    }
+    
+    void addSynthesizedDecoration(IRInst* value)
+    {
+        addDecoration(value, kIROp_SynthesizedDecoration);
     }
 
     void addRequireSPIRVDescriptorIndexingExtensionDecoration(IRInst* value)

--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -350,12 +350,10 @@ namespace Slang
 
     static bool isInstStoredInto(ReachabilityContext& reachability, IRInst* reference, IRInst* inst)
     {
-        auto addresses = getAliasableInstructions(inst);
-        
         List<IRInst*> stores;
         List<IRInst*> loads;
 
-        for (auto alias : addresses)
+        for (auto alias : getAliasableInstructions(inst))
         {
             for (auto use = alias->firstUse; use; use = use->nextUse)
             {
@@ -439,7 +437,10 @@ namespace Slang
         if (!stype)
             return;
 
+        // Don't bother giving warnings if its not being used
         bool synthesized = constructor->getSynthesizedStatus();
+        if (synthesized && !func->firstUse)
+            return;
         
         auto printWarnings = [&](const List<IRStructField*>& fields, IRReturn* ret)
         {

--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -348,18 +348,6 @@ namespace Slang
         return loads;
     }
 
-    static bool isReturnedValue(IRInst* inst)
-    {
-        for (auto use = inst->firstUse; use; use = use->nextUse)
-        {
-            IRInst* user = use->getUser();
-            if (as<IRReturn>(user))
-                return true;
-        }
-
-        return false;
-    }
-
     static bool isInstStoredInto(ReachabilityContext& reachability, IRInst* reference, IRInst* inst)
     {
         auto addresses = getAliasableInstructions(inst);
@@ -539,6 +527,10 @@ namespace Slang
                 }
             }
         }
+
+        // Separate analysis for constructors
+        if (constructor)
+            checkConstructor(func, reachability, sink);
     }
 
     static void checkUninitializedGlobals(IRGlobalVar* variable, DiagnosticSink* sink)

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9694,9 +9694,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                 }
 
                 // Used for diagnostics
-                getBuilder()->addConstructorDecoration(irFunc);
-                if (constructorDecl->synthesized)
-                    getBuilder()->addSynthesizedDecoration(irFunc);
+                getBuilder()->addConstructorDecoration(irFunc, constructorDecl->isSynthesized);
             }
 
             // We lower whatever statement was stored on the declaration

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9692,6 +9692,9 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                         subContext->irBuilder->emitStore(thisVar, allocatedObj);
                     }
                 }
+
+                // Used for diagnostics
+                getBuilder()->addConstructorDecoration(irFunc);
             }
 
             // We lower whatever statement was stored on the declaration

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9695,6 +9695,8 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
                 // Used for diagnostics
                 getBuilder()->addConstructorDecoration(irFunc);
+                if (constructorDecl->synthesized)
+                    getBuilder()->addSynthesizedDecoration(irFunc);
             }
 
             // We lower whatever statement was stored on the declaration

--- a/tests/compute/struct-default-init.slang
+++ b/tests/compute/struct-default-init.slang
@@ -3,9 +3,9 @@
 
 struct Test
 {
-	int a;
+	int a = 0;
 	int b = 1;
-	int c;
+	int c = 0;
 	int d = 1 + 1;
 }
 

--- a/tests/diagnostics/uninitialized-fields.slang
+++ b/tests/diagnostics/uninitialized-fields.slang
@@ -2,70 +2,91 @@
 
 extern static const int flag;
 
-//struct None
-//{
-//    int a;
-//    int b;
-
-//    __init()
-//    {
-//        a = 0;
-//        b = 0;
-//    }
-//}
-
-//struct Simple
-//{
-//    int value;
-//    Simple *next;
-
-//    __init(int v, Simple* ptr)
-//    {
-//        value = v;
-//        //CHK-DAG: warning 41020: exiting constructor without initializing field 'next'
-//    }
-//}
-
-//struct Conditional
-//{
-//    int field;
-//    int another_field;
-
-//    __init()
-//    {
-//        field = 0;
-//        if (flag == 0)
-//            //CHK-DAG: warning 41020: exiting constructor without initializing field 'another_field'
-//            return;
-
-//        another_field = 0;
-//    }
-//};
-
-//struct Partial
-//{
-//    int inline = 0;
-//    int body = 0;
-
-//    __init(int x)
-//    {
-//        body = x;
-//    }
-//}
-
-// TODO: warning should be a bit different for here?
-struct Test
+struct None
 {
+    int a;
+    int b;
+
+    __init()
+    {
+        a = 0;
+        b = 0;
+    }
+}
+
+struct Simple
+{
+    int value;
+    Simple *next;
+
+    __init(int v, Simple* ptr)
+    {
+        value = v;
+        //CHK-DAG: warning 41020: exiting constructor without initializing field 'next'
+    }
+}
+
+struct Conditional
+{
+    int field;
+    int another_field;
+
+    __init()
+    {
+        field = 0;
+        if (flag == 0)
+            //CHK-DAG: warning 41020: exiting constructor without initializing field 'another_field'
+            return;
+
+        another_field = 0;
+    }
+};
+
+struct Partial
+{
+    int inline = 0;
+    int body = 0;
+
+    __init(int x)
+    {
+        body = x;
+    }
+}
+
+// Warnings here should be a bit different
+struct Implicit
+{
+    //CHK-DAG: warning 41021: default initializer for 'Implicit' will not initialize field 'a'
 	int a;
 	int b = 1;
+    //CHK-DAG: warning 41021: default initializer for 'Implicit' will not initialize field 'c'
 	int c;
 	int d = 1 + 1;
 }
 
-struct Normal
+struct Pass
 {
-    int x;
-    __init() { x = 0; }
+    int x = 0;
+    int y = 0;
+}
+
+struct Impl
+{
+    float x;
+
+    __init(float val)
+    {
+        x = val;
+    }
+
+    __init()
+    {
+        float val = 2.0;
+
+        // Shouldn't trigger a warning here
+        return Impl(val);
+    }
 }
 
 //CHK-NOT: warning 41020
+//CHK-NOT: warning 41021

--- a/tests/diagnostics/uninitialized-fields.slang
+++ b/tests/diagnostics/uninitialized-fields.slang
@@ -2,55 +2,70 @@
 
 extern static const int flag;
 
-struct None
-{
-    int a;
-    int b;
+//struct None
+//{
+//    int a;
+//    int b;
 
-    __init()
-    {
-        a = 0;
-        b = 0;
-    }
+//    __init()
+//    {
+//        a = 0;
+//        b = 0;
+//    }
+//}
+
+//struct Simple
+//{
+//    int value;
+//    Simple *next;
+
+//    __init(int v, Simple* ptr)
+//    {
+//        value = v;
+//        //CHK-DAG: warning 41020: exiting constructor without initializing field 'next'
+//    }
+//}
+
+//struct Conditional
+//{
+//    int field;
+//    int another_field;
+
+//    __init()
+//    {
+//        field = 0;
+//        if (flag == 0)
+//            //CHK-DAG: warning 41020: exiting constructor without initializing field 'another_field'
+//            return;
+
+//        another_field = 0;
+//    }
+//};
+
+//struct Partial
+//{
+//    int inline = 0;
+//    int body = 0;
+
+//    __init(int x)
+//    {
+//        body = x;
+//    }
+//}
+
+// TODO: warning should be a bit different for here?
+struct Test
+{
+	int a;
+	int b = 1;
+	int c;
+	int d = 1 + 1;
 }
 
-struct Simple
+struct Normal
 {
-    int value;
-    Simple *next;
-
-    __init(int v, Simple* ptr)
-    {
-        value = v;
-        //CHK-DAG: warning 41020: exiting constructor without initializing field 'next'
-    }
-}
-
-struct Conditional
-{
-    int field;
-    int another_field;
-
-    __init()
-    {
-        field = 0;
-        if (flag == 0)
-            //CHK-DAG: warning 41020: exiting constructor without initializing field 'another_field'
-            return;
-
-        another_field = 0;
-    }
-};
-
-struct Partial
-{
-    int inline = 0;
-    int body = 0;
-
-    __init(int x)
-    {
-        body = x;
-    }
+    int x;
+    __init() { x = 0; }
 }
 
 //CHK-NOT: warning 41020

--- a/tests/diagnostics/uninitialized-fields.slang
+++ b/tests/diagnostics/uninitialized-fields.slang
@@ -1,4 +1,32 @@
-struct A
+//TEST:SIMPLE(filecheck=CHK): -target spirv
+
+extern static const int flag;
+
+struct None
+{
+    int a;
+    int b;
+
+    __init()
+    {
+        a = 0;
+        b = 0;
+    }
+}
+
+struct Simple
+{
+    int value;
+    Simple *next;
+
+    __init(int v, Simple* ptr)
+    {
+        value = v;
+        //CHK-DAG: warning 41020: exiting constructor without initializing field 'next'
+    }
+}
+
+struct Conditional
 {
     int field;
     int another_field;
@@ -6,6 +34,23 @@ struct A
     __init()
     {
         field = 0;
-        return;
+        if (flag == 0)
+            //CHK-DAG: warning 41020: exiting constructor without initializing field 'another_field'
+            return;
+
+        another_field = 0;
     }
 };
+
+struct Partial
+{
+    int inline = 0;
+    int body = 0;
+
+    __init(int x)
+    {
+        body = x;
+    }
+}
+
+//CHK-NOT: warning 41020

--- a/tests/diagnostics/uninitialized-fields.slang
+++ b/tests/diagnostics/uninitialized-fields.slang
@@ -1,0 +1,11 @@
+struct A
+{
+    int field;
+    int another_field;
+
+    __init()
+    {
+        field = 0;
+        return;
+    }
+};

--- a/tests/diagnostics/uninitialized-fields.slang
+++ b/tests/diagnostics/uninitialized-fields.slang
@@ -57,11 +57,27 @@ struct Partial
 struct Implicit
 {
     //CHK-DAG: warning 41021: default initializer for 'Implicit' will not initialize field 'a'
-	int a;
-	int b = 1;
+    int a;
+    int b = 1;
     //CHK-DAG: warning 41021: default initializer for 'Implicit' will not initialize field 'c'
-	int c;
-	int d = 1 + 1;
+    int c;
+    int d = 1 + 1;
+}
+
+int using_implicit(int x)
+{
+    Implicit impl;
+    impl.a = x;
+    return impl.c;
+}
+
+struct UnusedImplicit
+{
+    // Shouldn't warn here, since its never used
+    int a;
+    int b = 1;
+    int c;
+    int d = 1 + 1;
 }
 
 struct Pass

--- a/tests/language-feature/struct-field-initializers/struct-field-initializer.slang
+++ b/tests/language-feature/struct-field-initializers/struct-field-initializer.slang
@@ -11,7 +11,7 @@ static int myThree = 1+2;
 
 struct DefaultStructNoInit
 {
-    int data0;
+    int data0 = 0;
     int data1 = myTwo;
     int data2 = 2;
 };


### PR DESCRIPTION
Addresses #4578 

Adds new tests in the file `tests/diagnostics/uninitialized-fields.slang`.

Warnings will look like the following:

```
.\tests\diagnostics\uninitialized-fields.slang(22): warning 41020: exiting constructor without initializing field 'next'
    __init(int v, Simple* ptr)
    ^~~~~~
.\tests\diagnostics\uninitialized-fields.slang(39): warning 41020: exiting constructor without initializing field 'another_field'
            return;
            ^~~~~~
.\tests\diagnostics\uninitialized-fields.slang(60): warning 41021: default initializer for 'Implicit' will not initialize field 'a'
    int a;
        ^
.\tests\diagnostics\uninitialized-fields.slang(63): warning 41021: default initializer for 'Implicit' will not initialize field 'c'
    int c;
        ^
```

New decorations:
* ConstructorDecoration: indicates whether an IRFunc is a constructor
* SynthesizedDecoration: indicates whether an IRFunc was synthesized (for improved diagnostics)