### PR TITLE
Install the missing public headers in release package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -803,5 +803,9 @@ install(DIRECTORY
   "${slang_SOURCE_DIR}/docs/"
   DESTINATION share/doc/slang
 )
+install(DIRECTORY
+  "${slang_SOURCE_DIR}/include"
+  DESTINATION .
+)
 
 include(CPack)


### PR DESCRIPTION
In the change:
2db15080 Move the file public header files to `include` dir (#4636)

we miss the installation of the public headers as they move to a new `include` folder, and cpack doesn't catch those automatically.

Therefore, add the install command to install those headers.