### PR TITLE
Allow only specific spv storage classes for binding decoration

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1806,9 +1806,15 @@ struct SPIRVEmitContext
     // set or binding.
     static inline bool isBindingAllowed(SpvStorageClass storageClass)
     {
-        return  (storageClass == SpvStorageClassUniformConstant) ||
-                (storageClass == SpvStorageClassStorageBuffer) ||
-                (storageClass == SpvStorageClassUniform);
+        switch(storageClass)
+        {
+        case SpvStorageClassUniformConstant:
+        case SpvStorageClassUniform:
+        case SpvStorageClassStorageBuffer:
+            return true;
+        default:
+            return false;
+        }
     }
 
     SpvCapability getImageFormatCapability(SpvImageFormat format)
@@ -2220,15 +2226,16 @@ struct SPIRVEmitContext
             case LayoutResourceKind::UnorderedAccess:
             case LayoutResourceKind::SamplerState:
             case LayoutResourceKind::DescriptorTableSlot:
-                if (isBindingDecorationAllowed)
-                {
-                    emitOpDecorateBinding(
-                        getSection(SpvLogicalSectionID::Annotations),
-                        nullptr,
-                        varInst,
-                        SpvLiteralInteger::from32(int32_t(index)));
-                }
-                if (!isDescirptorSetDecorated && isBindingDecorationAllowed)
+                if (!isBindingDecorationAllowed)
+                    break;
+
+                emitOpDecorateBinding(
+                    getSection(SpvLogicalSectionID::Annotations),
+                    nullptr,
+                    varInst,
+                    SpvLiteralInteger::from32(int32_t(index)));
+
+                if (!isDescirptorSetDecorated)
                 {
                     if (space)
                     {

--- a/tests/bindings/binding-spv-storage-class.slang
+++ b/tests/bindings/binding-spv-storage-class.slang
@@ -1,0 +1,55 @@
+// binding-spv-storage-class.slang
+
+//TEST:SIMPLE(filecheck=GL-SPIRV): -stage anyhit -entry main -target spirv-assembly -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=SPIRV): -stage anyhit -entry main -target spirv
+
+// This test checks that the only the resource with Uniform, Storage or UniformConstant storage class can be decorated by binding or descriptor set.
+struct MyStruct
+{
+    float3 org;
+    float3 dir;
+};
+
+// ShaderRecordKHR storage class
+layout(shaderRecordNV) ConstantBuffer<MyStruct> myStruct : register(b0, space1);
+
+// Uniform buffer
+ConstantBuffer<MyStruct> myStruct1 : register(b1, space1);
+
+// Storage buffer
+RWStructuredBuffer<MyStruct> myStruct2 : register(b2, space1);
+
+// UniformConstant
+Texture2D<float>    texture: register(b3, space1);
+SamplerState        sampler: register(b4, space1);
+
+[shader("anyhit")]
+void main(out float3 pos)
+{
+    pos = myStruct.org + myStruct.dir +
+          myStruct1.org + myStruct1.dir +
+          myStruct2[0].org + myStruct2[0].dir;
+
+    pos.x = texture.SampleLevel(
+            sampler,
+            pos.xy, 0);
+}
+
+// SPIRV: OpDecorate %myStruct1{{.*}} Binding 1
+// SPIRV: OpDecorate %myStruct1{{.*}} DescriptorSet 1
+// SPIRV: OpDecorate %myStruct2{{.*}} Binding 2
+// SPIRV: OpDecorate %myStruct2{{.*}} DescriptorSet 1
+// SPIRV: OpDecorate %texture{{.*}} Binding 3
+// SPIRV: OpDecorate %texture{{.*}} DescriptorSet 1
+// SPIRV: OpDecorate %sampler{{.*}} Binding 4
+// SPIRV: OpDecorate %sampler{{.*}} DescriptorSet 1
+//
+//
+// GL-SPIRV: OpDecorate %myStruct1{{.*}} DescriptorSet 1
+// GL-SPIRV: OpDecorate %myStruct1{{.*}} Binding 1
+// GL-SPIRV: OpDecorate %myStruct2{{.*}} DescriptorSet 1
+// GL-SPIRV: OpDecorate %myStruct2{{.*}} Binding 2
+// GL-SPIRV: OpDecorate %texture{{.*}} DescriptorSet 1
+// GL-SPIRV: OpDecorate %texture{{.*}} Binding 3
+// GL-SPIRV: OpDecorate %sampler{{.*}} DescriptorSet 1
+// GL-SPIRV: OpDecorate %sampler{{.*}} Binding 4


### PR DESCRIPTION
In
https://registry.khronos.org/vulkan/specs/1.3/html/chap37.html#VUID-StandaloneSpirv-DescriptorSet-06491

it states that
If a variable is decorated by DescriptorSet or Binding, the Storage class must be UniformConstant, Uniform and StorageBuffer.

So apply this rule to our emit-spirv logic.