### PR TITLE
Warnings target switch intrinsic asm

### DIFF
--- a/source/slang/slang-ir-reachability.cpp
+++ b/source/slang/slang-ir-reachability.cpp
@@ -69,20 +69,6 @@ namespace Slang
             }
         }
 
-        // Special cases
-        
-        // Target switches; treat as reachable from any of its cases
-        if (auto tswitch = as<IRTargetSwitch>(to))
-        {
-            IRBlock* upper = getBlock(from);
-            for (Slang::UInt i = 0; i < tswitch->getCaseCount(); i++)
-            {
-                IRBlock* caseBlock = tswitch->getCaseBlock(i);
-                if (caseBlock == upper || isBlockReachable(caseBlock, upper))
-                    return true;
-            }
-        }
-
         return isBlockReachable(getBlock(from), getBlock(to));
     }
 

--- a/source/slang/slang-ir-reachability.cpp
+++ b/source/slang/slang-ir-reachability.cpp
@@ -1,5 +1,6 @@
 #include "slang-ir-reachability.h"
 #include "slang-ir-insts.h"
+#include "slang-ir-util.h"
 
 namespace Slang
 {
@@ -59,7 +60,7 @@ namespace Slang
     {
         // If inst1 and inst2 are in the same block,
         // we test if inst2 appears after inst1.
-        if (from->getParent() == to->getParent())
+        if (getBlock(from) == getBlock(to))
         {
             for (auto inst = from->getNextInst(); inst; inst = inst->getNextInst())
             {
@@ -73,7 +74,7 @@ namespace Slang
         // Target switches; treat as reachable from any of its cases
         if (auto tswitch = as<IRTargetSwitch>(to))
         {
-            IRBlock* upper = as<IRBlock>(from->getParent());
+            IRBlock* upper = getBlock(from);
             for (Slang::UInt i = 0; i < tswitch->getCaseCount(); i++)
             {
                 IRBlock* caseBlock = tswitch->getCaseBlock(i);
@@ -82,7 +83,7 @@ namespace Slang
             }
         }
 
-        return isBlockReachable(as<IRBlock>(from->getParent()), as<IRBlock>(to->getParent()));
+        return isBlockReachable(getBlock(from), getBlock(to));
     }
 
     bool ReachabilityContext::isBlockReachable(IRBlock* from, IRBlock* to)

--- a/source/slang/slang-ir-reachability.cpp
+++ b/source/slang/slang-ir-reachability.cpp
@@ -55,15 +55,15 @@ namespace Slang
         }
     }
     
-    bool ReachabilityContext::isInstReachable(IRInst* inst1, IRInst* inst2)
+    bool ReachabilityContext::isInstReachable(IRInst* from, IRInst* to)
     {
         // If inst1 and inst2 are in the same block,
         // we test if inst2 appears after inst1.
-        if (inst1->getParent() == inst2->getParent())
+        if (from->getParent() == to->getParent())
         {
-            for (auto inst = inst1->getNextInst(); inst; inst = inst->getNextInst())
+            for (auto inst = from->getNextInst(); inst; inst = inst->getNextInst())
             {
-                if (inst == inst2)
+                if (inst == to)
                     return true;
             }
         }
@@ -71,9 +71,9 @@ namespace Slang
         // Special cases
         
         // Target switches; treat as reachable from any of its cases
-        if (auto tswitch = as<IRTargetSwitch>(inst2))
+        if (auto tswitch = as<IRTargetSwitch>(to))
         {
-            IRBlock* upper = as<IRBlock>(inst1->getParent());
+            IRBlock* upper = as<IRBlock>(from->getParent());
             for (Slang::UInt i = 0; i < tswitch->getCaseCount(); i++)
             {
                 IRBlock* caseBlock = tswitch->getCaseBlock(i);
@@ -82,7 +82,7 @@ namespace Slang
             }
         }
 
-        return isBlockReachable(as<IRBlock>(inst1->getParent()), as<IRBlock>(inst2->getParent()));
+        return isBlockReachable(as<IRBlock>(from->getParent()), as<IRBlock>(to->getParent()));
     }
 
     bool ReachabilityContext::isBlockReachable(IRBlock* from, IRBlock* to)

--- a/source/slang/slang-ir-reachability.cpp
+++ b/source/slang/slang-ir-reachability.cpp
@@ -74,7 +74,7 @@ namespace Slang
         // Target switches; treat as reachable from its cases
         if (auto tswitch = as<IRTargetSwitch>(inst2))
         {
-            for (int i = 0; i < tswitch->getCaseCount(); i++)
+            for (Slang::UInt i = 0; i < tswitch->getCaseCount(); i++)
             {
                 IRBlock* block = tswitch->getCaseBlock(i);
                 if (isWithinBlock(block, inst1))

--- a/source/slang/slang-ir-reachability.h
+++ b/source/slang/slang-ir-reachability.h
@@ -16,23 +16,9 @@ struct ReachabilityContext
     ReachabilityContext() = default;
     ReachabilityContext(IRGlobalValueWithCode* code);
 
+    bool isInstReachable(IRInst* inst1, IRInst* inst2);
     bool isBlockReachable(IRBlock* from, IRBlock* to);
-
-    bool isInstReachable(IRInst* inst1, IRInst* inst2)
-    {
-        // If inst1 and inst2 are in the same block,
-        // we test if inst2 appears after inst1.
-        if (inst1->getParent() == inst2->getParent())
-        {
-            for (auto inst = inst1->getNextInst(); inst; inst = inst->getNextInst())
-            {
-                if (inst == inst2)
-                    return true;
-            }
-        }
-
-        return isBlockReachable(as<IRBlock>(inst1->getParent()), as<IRBlock>(inst2->getParent()));
-    }
+    bool isWithinBlock(IRBlock* block, IRInst* tinst);
 };
 
 }

--- a/source/slang/slang-ir-reachability.h
+++ b/source/slang/slang-ir-reachability.h
@@ -18,7 +18,6 @@ struct ReachabilityContext
 
     bool isInstReachable(IRInst* inst1, IRInst* inst2);
     bool isBlockReachable(IRBlock* from, IRBlock* to);
-    bool isWithinBlock(IRBlock* block, IRInst* tinst);
 };
 
 }

--- a/source/slang/slang-ir-reachability.h
+++ b/source/slang/slang-ir-reachability.h
@@ -16,7 +16,7 @@ struct ReachabilityContext
     ReachabilityContext() = default;
     ReachabilityContext(IRGlobalValueWithCode* code);
 
-    bool isInstReachable(IRInst* inst1, IRInst* inst2);
+    bool isInstReachable(IRInst* from, IRInst* to);
     bool isBlockReachable(IRBlock* from, IRBlock* to);
 };
 

--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -222,7 +222,7 @@ namespace Slang
 
     static void collectTargetSwitchCases(List<IRInst*>& stores, IRTargetSwitch* tswitch)
     {
-        for (int i = 0; i < tswitch->getCaseCount(); i++)
+        for (Slang::UInt i = 0; i < tswitch->getCaseCount(); i++)
         {
             IRBlock* block = tswitch->getCaseBlock(i);
             for (auto inst = block->getFirstInst(); inst; inst = inst->next)

--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -342,10 +342,8 @@ namespace Slang
             }
 
             auto t = b->getTerminator();
-            if (as<IRUnreachable>(t) || as<IRGenericAsm>(t))
-                continue;
-
-            loads.add(b->getTerminator());
+            if (as<IRTargetSwitch>(t) || as<IRReturn>(t))
+                loads.add(t);
         }
 
         cancelLoads(reachability, stores, loads);

--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -37,30 +37,30 @@ namespace Slang
             || (inst->m_op == kIROp_Var);
     }
 
-    static bool isUndefinedParam(IRParam* param)
+    static bool isPotentiallyUnintended(IRParam* param)
     {
-            auto outType = as<IROutType>(param->getFullType());
-            if (!outType)
-                return false;
+        auto outType = as<IROutType>(param->getFullType());
+        if (!outType)
+            return false;
 
-            // Don't check `out Vertices<T>` or `out Indices<T>` parameters
-            // in mesh shaders.
-            // TODO: we should find a better way to represent these mesh shader
-            // parameters so they conform to the initialize before use convention.
-            // For example, we can use a `OutputVetices` and `OutputIndices` type
-            // to represent an output, like `OutputPatch` in domain shader.
-            // For now, we just skip the check for these parameters.
-            switch (outType->getValueType()->getOp())
-            {
-            case kIROp_VerticesType:
-            case kIROp_IndicesType:
-            case kIROp_PrimitivesType:
-                return false;
-            default:
-                break;
-            }
+        // Don't check `out Vertices<T>` or `out Indices<T>` parameters
+        // in mesh shaders.
+        // TODO: we should find a better way to represent these mesh shader
+        // parameters so they conform to the initialize before use convention.
+        // For example, we can use a `OutputVetices` and `OutputIndices` type
+        // to represent an output, like `OutputPatch` in domain shader.
+        // For now, we just skip the check for these parameters.
+        switch (outType->getValueType()->getOp())
+        {
+        case kIROp_VerticesType:
+        case kIROp_IndicesType:
+        case kIROp_PrimitivesType:
+            return false;
+        default:
+            break;
+        }
 
-            return true;
+        return true;
     }
 
     static bool isAliasable(IRInst* inst)
@@ -220,6 +220,22 @@ namespace Slang
             loads.add(call);
     }
 
+    static void collectTargetSwitchCases(List<IRInst*>& stores, IRTargetSwitch* tswitch)
+    {
+        for (int i = 0; i < tswitch->getCaseCount(); i++)
+        {
+            IRBlock* block = tswitch->getCaseBlock(i);
+            for (auto inst = block->getFirstInst(); inst; inst = inst->next)
+            {
+                // Only worry about special cases,
+                // the rest should be taken care of
+                // at collectLoadStore
+                if (as<IRGenericAsm>(tswitch))
+                    stores.add(tswitch);
+            }
+        }
+    }
+
     static void collectLoadStore(List<IRInst*>& stores, List<IRInst*>& loads, IRInst* user, IRInst* inst)
     {
         // Meta intrinsics (which evaluate on type) do nothing
@@ -248,8 +264,6 @@ namespace Slang
         case kIROp_Store:
         case kIROp_SwizzledStore:
         case kIROp_SPIRVAsm:
-        case kIROp_GenericAsm:
-            // For now assume that __intrinsic_asm blocks will do the right thing...
             stores.add(user);
             break;
 
@@ -292,14 +306,9 @@ namespace Slang
         }
     }
 
-    static List<IRInst*> getUnresolvedParamLoads(ReachabilityContext &reachability, IRFunc* func, IRInst* inst)
+    static void collectAliasableLoadStores(IRInst* inst, List<IRInst*>& stores, List<IRInst*>& loads)
     {
-        // Collect all aliasable addresses
         auto addresses = getAliasableInstructions(inst);
-
-        // Partition instructions
-        List<IRInst*> stores;
-        List<IRInst*> loads;
 
         for (auto alias : addresses)
         {
@@ -310,15 +319,33 @@ namespace Slang
                 collectLoadStore(stores, loads, user, alias);
             }
         }
+    }
 
-        // Only for out params we shall add all returns
+    static List<IRInst*> getUnresolvedParamLoads(ReachabilityContext &reachability, IRFunc* func, IRInst* inst)
+    {
+        // Partition instructions
+        List<IRInst*> stores;
+        List<IRInst*> loads;
+
+        collectAliasableLoadStores(inst, stores, loads);
+
+        // Special cases for parameters
         for (const auto& b : func->getBlocks())
         {
-            auto t = as<IRReturn>(b->getTerminator());
-            if (!t)
+            for (auto binst = b->getFirstInst(); binst; binst = binst->next)
+            {
+                if (as<IRGenericAsm>(binst))
+                    stores.add(binst);
+
+                if (auto tswitch = as<IRTargetSwitch>(binst))
+                    collectTargetSwitchCases(stores, tswitch);
+            }
+
+            auto t = b->getTerminator();
+            if (as<IRUnreachable>(t) || as<IRGenericAsm>(t))
                 continue;
 
-            loads.add(t);
+            loads.add(b->getTerminator());
         }
 
         cancelLoads(reachability, stores, loads);
@@ -328,20 +355,11 @@ namespace Slang
 
     static List<IRInst*> getUnresolvedVariableLoads(ReachabilityContext &reachability, IRInst* inst)
     {
-        auto addresses = getAliasableInstructions(inst);
-
         // Partition instructions
         List<IRInst*> stores;
         List<IRInst*> loads;
 
-        for (auto alias : addresses)
-        {
-            for (auto use = alias->firstUse; use; use = use->nextUse)
-            {
-                IRInst* user = use->getUser();
-                collectLoadStore(stores, loads, user, alias);
-            }
-        }
+        collectAliasableLoadStores(inst, stores, loads);
 
         cancelLoads(reachability, stores, loads);
 
@@ -497,14 +515,14 @@ namespace Slang
         // Check out parameters
         for (auto param : firstBlock->getParams())
         {
-            if (!isUndefinedParam(param))
+            if (!isPotentiallyUnintended(param))
                 continue;
 
             auto loads = getUnresolvedParamLoads(reachability, func, param);
             for (auto load : loads)
             {
                 sink->diagnose(load,
-                        as <IRReturn> (load)
+                        as<IRTerminatorInst>(load)
                         ? Diagnostics::returningWithUninitializedOut
                         : Diagnostics::usingUninitializedOut,
                         param);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -6398,6 +6398,9 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
 
     void visitTargetSwitchStmt(TargetSwitchStmt* stmt)
     {
+        if (!stmt->targetCases.getCount())
+            return;
+
         auto builder = getBuilder();
         startBlockIfNeeded(stmt);
         auto initialBlock = builder->getBlock();

--- a/tests/diagnostics/uninitialized-out-parameters.slang
+++ b/tests/diagnostics/uninitialized-out-parameters.slang
@@ -3,24 +3,24 @@
 // Using before assigning
 float regular_undefined_use(out float3 v)
 {
-    //CHK-DAG: warning 41015: use of uninitialized out parameter 'v'
+    //CHK-DAG: (7): warning 41015: use of uninitialized out parameter 'v'
     float r = v.x + 1.0;
     
-    //CHK-DAG: warning 41018: returning without initializing out parameter 'v'
+    //CHK-DAG: (10): warning 41018: returning without initializing out parameter 'v'
     return r;
 }
 
 // Returning before assigning
 float returning_undefined_use(out float x)
 {
-    //CHK-DAG: warning 41018: returning without initializing out parameter 'x'
+    //CHK-DAG: (17): warning 41018: returning without initializing out parameter 'x'
     return 0;
 }
 
 // Implicit, still returning before assigning
 void implicit_undefined_use(out float x) 
 {
-    //CHK-DAG: warning 41018: returning without initializing out parameter 'x'
+    //CHK-DAG: (24): warning 41018: returning without initializing out parameter 'x'
 }
 
 // Warn on potential return paths
@@ -28,7 +28,7 @@ void control_flow_undefined(bool b, out float y)
 {
     if(b)
     {
-        //CHK-DAG: warning 41018: returning without initializing out parameter 'y'
+        //CHK-DAG: (32): warning 41018: returning without initializing out parameter 'y'
         return;
     }
     y = 0;
@@ -56,7 +56,7 @@ void instrincs_defined(float x, out float exp)
 // Specialized handling for target switches
 void target_switching_undefined(float x, out float exp)
 {
-    //CHK-DAG: warning 41018: returning without initializing out parameter 'exp'
+    //CHK-DAG: (60): warning 41018: returning without initializing out parameter 'exp'
     __target_switch {}
 }
 

--- a/tests/diagnostics/uninitialized-out-parameters.slang
+++ b/tests/diagnostics/uninitialized-out-parameters.slang
@@ -3,24 +3,24 @@
 // Using before assigning
 float regular_undefined_use(out float3 v)
 {
-    //CHK-DAG: (7): warning 41015: use of uninitialized out parameter 'v'
+    //CHK-DAG: ([[# @LINE + 1]]): warning 41015: use of uninitialized out parameter 'v'
     float r = v.x + 1.0;
     
-    //CHK-DAG: (10): warning 41018: returning without initializing out parameter 'v'
+    //CHK-DAG: ([[# @LINE + 1]]): warning 41018: returning without initializing out parameter 'v'
     return r;
 }
 
 // Returning before assigning
 float returning_undefined_use(out float x)
 {
-    //CHK-DAG: (17): warning 41018: returning without initializing out parameter 'x'
+    //CHK-DAG: ([[# @LINE + 1]]): warning 41018: returning without initializing out parameter 'x'
     return 0;
 }
 
 // Implicit, still returning before assigning
 void implicit_undefined_use(out float x) 
 {
-    //CHK-DAG: (24): warning 41018: returning without initializing out parameter 'x'
+    //CHK-DAG: ([[# @LINE + 1]]): warning 41018: returning without initializing out parameter 'x'
 }
 
 // Warn on potential return paths
@@ -28,7 +28,7 @@ void control_flow_undefined(bool b, out float y)
 {
     if(b)
     {
-        //CHK-DAG: (32): warning 41018: returning without initializing out parameter 'y'
+        //CHK-DAG: ([[# @LINE + 1]]): warning 41018: returning without initializing out parameter 'y'
         return;
     }
     y = 0;
@@ -56,7 +56,7 @@ void instrincs_defined(float x, out float exp)
 // Specialized handling for target switches
 void target_switching_undefined(float x, out float exp)
 {
-    //CHK-DAG: (60): warning 41018: returning without initializing out parameter 'exp'
+    //CHK-DAG: ([[# @LINE + 1]]): warning 41018: returning without initializing out parameter 'exp'
     __target_switch {}
 }
 

--- a/tests/diagnostics/uninitialized-out-parameters.slang
+++ b/tests/diagnostics/uninitialized-out-parameters.slang
@@ -56,7 +56,7 @@ void instrincs_defined(float x, out float exp)
 // Specialized handling for target switches
 void target_switching_undefined(float x, out float exp)
 {
-    //CHK-DAG: ([[# @LINE + 1]]): warning 41018: returning without initializing out parameter 'exp'
+    //CHK-DAG: ([[# @LINE + 2]]): warning 41018: returning without initializing out parameter 'exp'
     __target_switch {}
 }
 

--- a/tests/diagnostics/uninitialized-out-parameters.slang
+++ b/tests/diagnostics/uninitialized-out-parameters.slang
@@ -47,11 +47,13 @@ void control_flow_defined(bool b, out float y)
     return;
 }
 
+// Specialized handling for intrinsic asm
 void instrincs_defined(float x, out float exp)
 {
     __intrinsic_asm "frexp";
 }
 
+// Specialized handling for target switches
 void target_switching_undefined(float x, out float exp)
 {
     //CHK-DAG: warning 41018: returning without initializing out parameter 'exp'
@@ -63,6 +65,28 @@ void target_switching_defined(float x, out float exp)
     __target_switch
     {
     case glsl: __intrinsic_asm "frexp";
+    }
+}
+
+void target_switching_blocks(uint x, out half v)
+{
+    __target_switch
+    {
+    case hlsl:
+        if ((x & 2) == 0)
+            v = half(1);
+        else
+            v = half(1);
+        return;
+    case glsl:
+    case spirv:
+        {
+            if ((x & 2) == 0)
+                v = half(1);
+            else
+                v = half(1);
+            return;
+        }
     }
 }
 

--- a/tests/diagnostics/uninitialized-out-parameters.slang
+++ b/tests/diagnostics/uninitialized-out-parameters.slang
@@ -47,5 +47,24 @@ void control_flow_defined(bool b, out float y)
     return;
 }
 
+void instrincs_defined(float x, out float exp)
+{
+    __intrinsic_asm "frexp";
+}
+
+void target_switching_undefined(float x, out float exp)
+{
+    //CHK-DAG: warning 41018: returning without initializing out parameter 'exp'
+    __target_switch {}
+}
+
+void target_switching_defined(float x, out float exp)
+{
+    __target_switch
+    {
+    case glsl: __intrinsic_asm "frexp";
+    }
+}
+
 //CHK-NOT: warning 41015
 //CHK-NOT: warning 41018


### PR DESCRIPTION
Handles #4720 

Also adds a fix to skip generating IR for empty target switches. Previously this would result in generating an unreachable block, which would have necessitated special handling for target switches.