### PR TITLE
Cleanup global memory allocations on shutdown.

### DIFF
--- a/include/slang.h
+++ b/include/slang.h
@@ -5351,6 +5351,14 @@ Returns nullptr if there isn't an embedded stdlib.
 */
 SLANG_API ISlangBlob* slang_getEmbeddedStdLib();
 
+
+/* Cleanup all global allocations used by Slang, to prevent memory leak detectors from
+ reporting them as leaks. This function should only be called after all Slang objects
+ have been released. No other Slang functions such as `createGlobalSession`
+ should be called after this function.
+ */
+SLANG_EXTERN_C SLANG_API void slang_shutdown();
+
 namespace slang
 {
     inline SlangResult createGlobalSession(
@@ -5358,6 +5366,7 @@ namespace slang
     {
         return slang_createGlobalSession(SLANG_API_VERSION, outGlobalSession);
     }
+    inline void shutdown() { slang_shutdown(); }
 }
 
 /** @see slang::ICompileRequest::getProgram

--- a/source/compiler-core/slang-spirv-core-grammar.h
+++ b/source/compiler-core/slang-spirv-core-grammar.h
@@ -16,7 +16,8 @@ namespace Slang
     struct SPIRVCoreGrammarInfo : public RefObject
     {
         static RefPtr<SPIRVCoreGrammarInfo> loadFromJSON(SourceView& source, DiagnosticSink& sink);
-        static RefPtr<SPIRVCoreGrammarInfo> getEmbeddedVersion();
+        static RefPtr<SPIRVCoreGrammarInfo>& getEmbeddedVersion();
+        static inline void freeEmbeddedGrammerInfo() { getEmbeddedVersion() = nullptr; }
 
         template<typename K, typename T>
         struct Lookup

--- a/source/core/slang-performance-profiler.cpp
+++ b/source/core/slang-performance-profiler.cpp
@@ -42,6 +42,10 @@ namespace Slang
         {
             data.clear();
         }
+        virtual void dispose() override
+        {
+            data = decltype(data)();
+        }
     };
 
     PerformanceProfiler* Slang::PerformanceProfiler::getProfiler()

--- a/source/core/slang-performance-profiler.h
+++ b/source/core/slang-performance-profiler.h
@@ -29,6 +29,7 @@ public:
     virtual void exitFunction(FuncProfileContext context) = 0;
     virtual void getResult(StringBuilder& out) = 0;
     virtual void clear() = 0;
+    virtual void dispose() = 0;
 public:
     static PerformanceProfiler* getProfiler();
 };

--- a/source/slang/slang-api.cpp
+++ b/source/slang/slang-api.cpp
@@ -1,9 +1,10 @@
 // slang-api.cpp
 
 #include "slang-compiler.h"
-
 #include "slang-repro.h"
-
+#include "slang-capability.h"
+#include "../core/slang-rtti-info.h"
+#include "../core/slang-performance-profiler.h"
 #include "../core/slang-shared-library.h"
 #include "../slang-record-replay/record/slang-global-session.h"
 #include "../slang-record-replay/util/record-utility.h"
@@ -137,6 +138,14 @@ SLANG_API SlangResult slang_createGlobalSession(
 #endif
 
     return SLANG_OK;
+}
+
+SLANG_API void slang_shutdown()
+{
+    Slang::PerformanceProfiler::getProfiler()->dispose();
+    Slang::SPIRVCoreGrammarInfo::freeEmbeddedGrammerInfo();
+    Slang::RttiInfo::deallocateAll();
+    Slang::freeCapabilityDefs();
 }
 
 SLANG_API SlangResult slang_createGlobalSessionWithoutStdLib(

--- a/source/slang/slang-capability.h
+++ b/source/slang/slang-capability.h
@@ -371,6 +371,8 @@ const CapabilityAtomSet& getAtomSetOfStages();
 
 bool hasTargetAtom(const CapabilityAtomSet& setIn, CapabilityAtom& targetAtom);
 
+void freeCapabilityDefs();
+
 //#define UNIT_TEST_CAPABILITIES
 #ifdef UNIT_TEST_CAPABILITIES
 void TEST_CapabilitySet();

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -140,7 +140,7 @@ void Session::init()
 {
     SLANG_ASSERT(BaseTypeInfo::check());
 
-    
+
     _initCodeGenTransitionMap();
 
     ::memset(m_downstreamCompilerLocators, 0, sizeof(m_downstreamCompilerLocators));

--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -104,7 +104,7 @@ SLANG_TEST_TOOL_API SlangResult innerMain(StdWriters* stdWriters, slang::IGlobal
     SlangResult res = _compile(compileRequest, argc, argv);
     // Now that we are done, clean up after ourselves
     spDestroyCompileRequest(compileRequest);
-
+    
     return res;
 }
 
@@ -112,6 +112,7 @@ int MAIN(int argc, char** argv)
 {
     auto stdWriters = StdWriters::initDefaultSingleton();
     SlangResult res = innerMain(stdWriters, nullptr, argc, argv);
+    slang::shutdown();
     return (int)TestToolUtil::getReturnCode(res);
 }
 

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -1545,6 +1545,7 @@ int main(int argc, char**  argv)
     SlangResult res = innerMain(stdWriters, session, argc, argv);
     spDestroySession(session);
 
+    slang::shutdown();
 	return (int)TestToolUtil::getReturnCode(res);
 }
 

--- a/tools/slang-capability-generator/capability-generator-main.cpp
+++ b/tools/slang-capability-generator/capability-generator-main.cpp
@@ -770,11 +770,11 @@ SlangResult generateDefinitions(DiagnosticSink* sink, List<RefPtr<CapabilityDef>
         }
     }
     outputUIntSetGenerator("generatorOf_kAnyTargetUIntSetBuffer", anyTargetUIntSetHash, anyTargetAtomSet);
-    anyTargetUIntSetHash << "const static CapabilityAtomSet kAnyTargetUIntSetBuffer = generatorOf_kAnyTargetUIntSetBuffer();\n";
+    anyTargetUIntSetHash << "static CapabilityAtomSet kAnyTargetUIntSetBuffer = generatorOf_kAnyTargetUIntSetBuffer();\n";
     sbCpp << anyTargetUIntSetHash;
 
     outputUIntSetGenerator("generatorOf_kAnyStageUIntSetBuffer", anyStageUIntSetHash, anyStageAtomSet);
-    anyStageUIntSetHash << "const static CapabilityAtomSet kAnyStageUIntSetBuffer = generatorOf_kAnyStageUIntSetBuffer();\n";
+    anyStageUIntSetHash << "static CapabilityAtomSet kAnyStageUIntSetBuffer = generatorOf_kAnyStageUIntSetBuffer();\n";
     sbCpp << anyStageUIntSetHash;
 
     sbHeader << "\nenum {\n";
@@ -899,6 +899,14 @@ SlangResult generateDefinitions(DiagnosticSink* sink, List<RefPtr<CapabilityDef>
     }
     
     sbCpp << "};\n";
+
+    sbCpp
+        << "void freeCapabilityDefs()\n"
+        << "{\n"
+        << "    for (auto& cap : kCapabilityArray) { cap = CapabilityAtomSet(); }\n"
+        << "    kAnyTargetUIntSetBuffer = CapabilityAtomSet();\n"
+        << "    kAnyStageUIntSetBuffer = CapabilityAtomSet();\n"
+        << "}\n";
     return SLANG_OK;
 }
 

--- a/tools/slang-reflection-test/slang-reflection-test-main.cpp
+++ b/tools/slang-reflection-test/slang-reflection-test-main.cpp
@@ -1446,6 +1446,6 @@ int main(
     
     SlangResult res = innerMain(stdWriters, session, argc, argv);
     spDestroySession(session);
-
+    slang::shutdown();
     return SLANG_FAILED(res) ? 1 : 0;
 }

--- a/tools/slang-spirv-embed-generator/spirv-embed-generator-main.cpp
+++ b/tools/slang-spirv-embed-generator/spirv-embed-generator-main.cpp
@@ -418,7 +418,7 @@ void writeInfo(
     //
     // Now write out the function which holds onto the static embedded info table
     //
-    line("RefPtr<SPIRVCoreGrammarInfo> SPIRVCoreGrammarInfo::getEmbeddedVersion()");
+    line("RefPtr<SPIRVCoreGrammarInfo>& SPIRVCoreGrammarInfo::getEmbeddedVersion()");
     line("{");
     line("    static RefPtr<SPIRVCoreGrammarInfo> embedded = [](){");
     line("        RefPtr<SPIRVCoreGrammarInfo> info = new SPIRVCoreGrammarInfo();");

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -4618,7 +4618,7 @@ int main(int argc, char** argv)
 {
     const SlangResult res = innerMain(argc, argv);
 
-    Slang::RttiInfo::deallocateAll();
+    slang::shutdown();
 
 #ifdef _MSC_VER
     _CrtDumpMemoryLeaks();

--- a/tools/slangd/main.cpp
+++ b/tools/slangd/main.cpp
@@ -23,5 +23,7 @@ int main(int argc, const char* const* argv)
     }
     Slang::LanguageServerStartupOptions options;
     options.parse(argc, argv);
-    return Slang::runLanguageServer(options);
+    auto result =  Slang::runLanguageServer(options);
+    slang::shutdown();
+    return result;
 }

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -563,7 +563,7 @@ SlangResult _execute(int argc, const char* const* argv)
     TestServer server;
     SLANG_RETURN_ON_FAIL(server.init(argc, argv));
     SLANG_RETURN_ON_FAIL(server.execute());
-
+    slang::shutdown();
     return SLANG_OK;
 }
 


### PR DESCRIPTION
Closes #4208.

We have many global constants that holds heap allocated memory. This PR adds a `slang::shutdown()` API to clean them up.
This isn't strictly necessary to call from user code, but it gets rid of crt memory leak detection errors.