### PR TITLE
Fail assertion on debug build when memory leaks

### DIFF
--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -140,6 +140,7 @@ int wmain(int argc, wchar_t** argv)
     }
 
 #ifdef _MSC_VER
+    // _CrtXXX functions are functional only for debug build. The spec says,
     // "When _DEBUG isn't defined, calls to _CrtSetReportMode are removed
     // during preprocessing."
     _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
@@ -149,7 +150,9 @@ int wmain(int argc, wchar_t** argv)
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
     _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
 
-    _CrtDumpMemoryLeaks();
+    int memleakDetected = _CrtDumpMemoryLeaks();
+    SLANG_UNUSED(memleakDetected);
+    assert(!memleakDetected);
 #endif
 
     return result;


### PR DESCRIPTION
This commit makes the memory leaks harder to miss by triggering an assertion failure for memory leaks. It works only for Windows Debug build.

SLANG_ASSERT doesn't print the info where the assertion failure happens, for an unknown reason. Using the system assert as a workaround.