### PR TITLE
Allow passing sized array to unsized array parameter.

### DIFF
--- a/docs/user-guide/02-conventional-features.md
+++ b/docs/user-guide/02-conventional-features.md
@@ -111,12 +111,52 @@ In some cases the element count is then inferred from the initial value of a var
 int a[] = { 1, 2, 3 };
 ```
 
-In other cases, the result is a _runtime-sized_ array, where the actual element count will be determined later:
+In other cases, the result is a _unsized_ array, where the actual element count will be determined later:
 
 ```hlsl
 // the type of `b` is `int[]`
 void f( int b[] )
 { ... }
+```
+
+It is allowed to pass a sized array as argument to an unsized array parameter when calling a function.
+
+Array types has a `getCount()` memeber function that returns the length of the array.
+
+```hlsl
+int f( int b[] )
+{
+    return b.getCount(); // Note: all arguments to `b` must be resolvable to sized arrays.
+}
+
+void test()
+{
+    int arr[3] = { 1, 2, 3 };
+    int x = f(arr); // OK, passing sized array to unsized array parameter, x will be 3.
+}
+```
+
+Please note that if a function calls `getCount()` method on an unsized array parameter, then all
+calls to that function must provide a sized array argument, otherwise the compiler will not be able
+to resolve the size and will report an error. The following code shows an example of valid and
+invalid cases.
+
+```hlsl
+int f( int b[] )
+{
+    return b.getCount();
+}
+int g( int b[] )
+{
+    return f(b); // transitive calls are allowed.
+}
+uniform int unsizedParam[];
+void test()
+{
+    g(unsizedParam); // Not OK, `unsizedParam` doesn't have a known size at compile time.
+    int arr[3];
+    g(arr); // OK.
+}
 ```
 
 There are more limits on how runtime-sized arrays can be used than on arrays of statically-known element count.

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1040,8 +1040,8 @@ __generic<T, let N:int>
 __magic_type(ArrayExpressionType)
 struct Array : IArray<T>
 {
-    [ForceInline]
-    int getCount() { return N; }
+    __intrinsic_op($(kIROp_GetArrayLength))
+    int getCount();
 
     __subscript(int index) -> T
     {
@@ -1049,7 +1049,6 @@ struct Array : IArray<T>
         get;
     }
 }
-
     /// An `N` component vector with elements of type `T`.
 __generic<T = float, let N : int = 4>
 __magic_type(VectorExpressionType)

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -96,6 +96,7 @@ namespace Slang
 
         kConversionCost_GenericParamUpcast = 1,
         kConversionCost_UnconstraintGenericParam = 20,
+        kConversionCost_SizedArrayToUnsizedArray = 30,
 
         // Convert between matrices of different layout
         kConversionCost_MatrixLayout = 5,

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -750,6 +750,31 @@ namespace Slang
             return true;
         }
 
+        // Allow implicit conversion from sized array to unsized array when
+        // calling a function.
+        // Note: we implement the logic here instead of an implicit_conversion
+        // intrinsic in the stdlib because we only want to allow this conversion
+        // when calling a function.
+        //
+        if (site == CoercionSite::Argument)
+        {
+            if (auto fromArrayType = as<ArrayExpressionType>(fromType))
+            {
+                if (auto toArrayType = as<ArrayExpressionType>(toType))
+                {
+                    if (fromArrayType->getElementType()->equals(toArrayType->getElementType())
+                        && toArrayType->isUnsized())
+                    {
+                        if (outToExpr)
+                            *outToExpr = fromExpr;
+                        if (outCost)
+                            *outCost = kConversionCost_SizedArrayToUnsizedArray;
+                        return true;
+                    }
+                }
+            }
+        }
+
         // Another important case is when either the "to" or "from" type
         // represents an error. In such a case we must have already
         // reporeted the error, so it is better to allow the conversion

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -857,6 +857,7 @@ DIAGNOSTIC(55201, Error, unsupportedRecursion, "recursion detected in call to '$
 DIAGNOSTIC(55202, Error, systemValueAttributeNotSupported, "system value semantic '$0' is not supported for the current target.")
 DIAGNOSTIC(55203, Error, systemValueTypeIncompatible, "system value semantic '$0' should have type '$1' or be convertible to type '$1'.")
 DIAGNOSTIC(56001, Error, unableToAutoMapCUDATypeToHostType, "Could not automatically map '$0' to a host type. Automatic binding generation failed for '$1'")
+DIAGNOSTIC(56002, Error, attemptToQuerySizeOfUnsizedArray, "cannot obtain the size of an unsized array.")
 
 DIAGNOSTIC(57001, Warning, spirvOptFailed, "spirv-opt failed. $0")
 DIAGNOSTIC(57002, Error, unknownPatchConstantParameter, "unknown patch constant parameter '$0'.")

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -947,13 +947,13 @@ Result linkAndOptimizeIR(
     specializeResourceUsage(codeGenContext, irModule);
     specializeFuncsForBufferLoadArgs(codeGenContext, irModule);
 
-    // For GLSL targets, we also want to specialize calls to functions that
-    // takes array parameters if possible, to avoid performance issues on
-    // those platforms.
-    if (isKhronosTarget(targetRequest))
-    {
-        specializeArrayParameters(codeGenContext, irModule);
-    }
+    // We also want to specialize calls to functions that
+    // takes unsized array parameters if possible.
+    // Moreover, for Khronos targets, we also want to specialize calls to functions
+    // that takes arrays/structs containing arrays as parameters with the actual
+    // global array object to avoid loading big arrays into SSA registers, which seems
+    // to cause performance issues.
+    specializeArrayParameters(codeGenContext, irModule);
 
 #if 0
     dumpIRIfEnabled(codeGenContext, irModule, "AFTER RESOURCE SPECIALIZATION");

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -1943,6 +1943,9 @@ InstPair ForwardDiffTranscriber::transcribeInstImpl(IRBuilder* builder, IRInst* 
     case kIROp_DebugLine:
     case kIROp_DebugVar:
     case kIROp_DebugValue:
+    case kIROp_GetArrayLength:
+    case kIROp_SizeOf:
+    case kIROp_AlignOf:
         return transcribeNonDiffInst(builder, origInst);
 
         // A call to createDynamicObject<T>(arbitraryData) cannot provide a diff value,

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -1108,7 +1108,7 @@ INST(TreatAsDynamicUniform, TreatAsDynamicUniform, 1, 0)
 
 INST(SizeOf,                            sizeOf,                     1, 0)
 INST(AlignOf,                           alignOf,                    1, 0)
-
+INST(GetArrayLength,                    GetArrayLength,             1, 0)
 INST(IsType, IsType, 3, 0)
 INST(TypeEquals, TypeEquals, 2, 0)
 INST(IsInt, IsInt, 1, 0)

--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -283,6 +283,14 @@ struct PeepholeContext : InstPassBase
                 changed = true;
             }
             break;
+        case kIROp_GetArrayLength:
+            if (auto arrayType = as<IRArrayType>(inst->getOperand(0)->getDataType()))
+            {
+                inst->replaceUsesWith(arrayType->getElementCount());
+                maybeRemoveOldInst(inst);
+                changed = true;
+            }
+            break;
         case kIROp_GetResultError:
             if (inst->getOperand(0)->getOp() == kIROp_MakeResultError)
             {

--- a/source/slang/slang-ir-specialize-function-call.h
+++ b/source/slang/slang-ir-specialize-function-call.h
@@ -15,6 +15,8 @@ namespace Slang
         virtual bool doesParamWantSpecialization(IRParam* param, IRInst* arg) = 0;
 
         virtual bool isParamSuitableForSpecialization(IRParam* param, IRInst* arg);
+
+        virtual bool doesParamTypeWantSpecialization(IRParam* param, IRInst* arg);
     };
 
 

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -8250,6 +8250,7 @@ namespace Slang
         case kIROp_TorchTensorGetView:
         case kIROp_GetStringHash:
         case kIROp_AllocateOpaqueHandle:
+        case kIROp_GetArrayLength:
             return false;
 
         case kIROp_ForwardDifferentiate:

--- a/tests/language-feature/unsized-array.slang
+++ b/tests/language-feature/unsized-array.slang
@@ -1,0 +1,36 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+int test(int arr[])
+{
+    return arr[0] + arr.getCount();
+}
+
+int test2<T>(inout T arr[])
+{
+    return arr.getCount();
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID: SV_DispatchThreadID)
+{
+    int arr[3] = {1, 2, 3};
+
+    // CHECK: 4
+    outputBuffer[0] = test(arr);
+
+    // CHECK: 3
+    outputBuffer[1] = test2(arr);
+
+    int arr2[2] = { 1, 2 };
+
+    // CHECK: 3
+    outputBuffer[2] = test(arr2);
+
+    // CHECK: 2
+    outputBuffer[3] = test2(arr2);
+
+}

--- a/tests/language-feature/unsized-array.slang
+++ b/tests/language-feature/unsized-array.slang
@@ -6,7 +6,8 @@ RWStructuredBuffer<int> outputBuffer;
 
 int g(int arr[])
 {
-    return arr.getCount();
+    int tmp[] = arr;
+    return tmp.getCount();
 }
 
 int test(int arr[])

--- a/tests/language-feature/unsized-array.slang
+++ b/tests/language-feature/unsized-array.slang
@@ -4,9 +4,14 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
+int g(int arr[])
+{
+    return arr.getCount();
+}
+
 int test(int arr[])
 {
-    return arr[0] + arr.getCount();
+    return arr[0] + g(arr);
 }
 
 int test2<T>(inout T arr[])


### PR DESCRIPTION
Closes #4701.

This changes extends the function call specialization pass to be able to specialize the type of a parameter.
If we see a call with sized array arguments to an unsized array parameter, we will specialize the callee to take a sized array parameter instead. This allows us to implement `kIROp_GetArrayLength` opcode that returns the size of an array.

If we cannot optimize out GetArrayLength, we will diagnose an error. This will the case if the user calls GetArrayLength on an unsized array that cannot be resolved to a sized array during compilation.