### PR TITLE
Disable warnings for input global variables

### DIFF
--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -903,7 +903,7 @@ INST_RANGE(BindingQuery, GetRegisterIndex, GetRegisterSpace)
     INST(AlwaysFoldIntoUseSiteDecoration, alwaysFold, 0, 0)
 
     INST(GlobalOutputDecoration, output, 0, 0)
-    INST(GlobalInputDecoration, output, 0, 0)
+    INST(GlobalInputDecoration, input, 0, 0)
     INST(GLSLLocationDecoration, glslLocation, 1, 0)
     INST(GLSLOffsetDecoration, glslOffset, 1, 0)
     INST(PayloadDecoration, payload, 0, 0)

--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -552,6 +552,9 @@ namespace Slang
         if (variable->findDecoration<IRSemanticDecoration>())
             return;
 
+        if (variable->findDecoration<IRGlobalInputDecoration>())
+            return;
+
         // Check for initialization blocks
         for (auto inst : variable->getChildren())
         {

--- a/tests/diagnostics/uninitialized-globals.slang
+++ b/tests/diagnostics/uninitialized-globals.slang
@@ -45,7 +45,7 @@ float use_later_writte()
     return writtenLater;
 }
 
-// Should not warn here (glsl layout decoration check)
+// Varying inputs never warn
 layout(location = 0) in vec4 data;
 
 vec4 glsl_layout_in_ok()

--- a/tests/diagnostics/uninitialized-globals.slang
+++ b/tests/diagnostics/uninitialized-globals.slang
@@ -53,7 +53,7 @@ vec4 glsl_layout_in_ok()
     return data;
 }
 
-// Invalid use of layout variables
+// Layout outputs should still be written to at some point
 layout(location = 1) out vec4 x;
 
 vec4 glsl_layout_out_undefined()
@@ -62,16 +62,18 @@ vec4 glsl_layout_out_undefined()
     return x;
 }
 
-// OK use of layout variables
+// OK use of layout output variables
 layout(location = 2) out vec4 y;
 
 void glsl_layout_out_store(vec4 data)
 {
+    // Written to here...
     y = data;
 }
 
 vec4 glsl_layout_out_ok()
 {
+    // ...so read here is treated as OK
     return y;
 }
 

--- a/tests/diagnostics/uninitialized-globals.slang
+++ b/tests/diagnostics/uninitialized-globals.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHK): -target spirv
+//TEST:SIMPLE(filecheck=CHK): -allow-glsl -target spirv
 
 // Using groupshared variables
 groupshared float4 gsConstexpr = float4(1.0f);
@@ -12,7 +12,7 @@ float use_constexpr_initialized_gs()
 
 float use_undefined_gs()
 {
-    //CHK-DAG: warning 41017: use of uninitialized global variable 'gsUndefined'
+    //CHK-DAG: ([[# @LINE + 1]]): warning 41017: use of uninitialized global variable 'gsUndefined'
     return gsUndefined.x;
 }
 
@@ -35,7 +35,7 @@ void write_to_later()
 
 float use_never_written()
 {
-    //CHK-DAG: warning 41017: use of uninitialized global variable 'writtenNever'
+    //CHK-DAG: ([[# @LINE + 1]]): warning 41017: use of uninitialized global variable 'writtenNever'
     return writtenNever;
 }
 
@@ -43,6 +43,36 @@ float use_never_written()
 float use_later_writte()
 {
     return writtenLater;
+}
+
+// Should not warn here (glsl layout decoration check)
+layout(location = 0) in vec4 data;
+
+vec4 glsl_layout_in_ok()
+{
+    return data;
+}
+
+// Invalid use of layout variables
+layout(location = 1) out vec4 x;
+
+vec4 glsl_layout_out_undefined()
+{
+    //CHK-DAG: ([[# @LINE + 1]]): warning 41017: use of uninitialized global variable 'x'
+    return x;
+}
+
+// OK use of layout variables
+layout(location = 2) out vec4 y;
+
+void glsl_layout_out_store(vec4 data)
+{
+    y = data;
+}
+
+vec4 glsl_layout_out_ok()
+{
+    return y;
 }
 
 //CHK-NOT: warning 41017

--- a/tests/diagnostics/uninitialized-globals.slang
+++ b/tests/diagnostics/uninitialized-globals.slang
@@ -62,7 +62,6 @@ vec4 glsl_layout_out_undefined()
     return x;
 }
 
-// OK use of layout output variables
 layout(location = 2) out vec4 y;
 
 void glsl_layout_out_store(vec4 data)

--- a/tests/diagnostics/uninitialized-globals.slang
+++ b/tests/diagnostics/uninitialized-globals.slang
@@ -12,7 +12,7 @@ float use_constexpr_initialized_gs()
 
 float use_undefined_gs()
 {
-    //CHK-DAG: ([[# @LINE + 1]]): warning 41017: use of uninitialized global variable 'gsUndefined'
+    //CHK-DAG: ([[# @LINE + 1]]): warning 41017: use of uninitialized global variable 'gsUninitialized'
     return gsUninitialized.x;
 }
 

--- a/tests/diagnostics/uninitialized-globals.slang
+++ b/tests/diagnostics/uninitialized-globals.slang
@@ -2,7 +2,7 @@
 
 // Using groupshared variables
 groupshared float4 gsConstexpr = float4(1.0f);
-groupshared float4 gsUndefined;
+groupshared float4 gsUninitialized;
 
 // OK
 float use_constexpr_initialized_gs()
@@ -13,7 +13,7 @@ float use_constexpr_initialized_gs()
 float use_undefined_gs()
 {
     //CHK-DAG: ([[# @LINE + 1]]): warning 41017: use of uninitialized global variable 'gsUndefined'
-    return gsUndefined.x;
+    return gsUninitialized.x;
 }
 
 // Using static variables


### PR DESCRIPTION
Fixes an undesired warning issued when using GLSL layout variables. The higher level problem is that the warning system was not skipping checks for input global variables.