### PR TITLE
Fix SPIRV emit for small-integer texture types.

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -6423,11 +6423,12 @@ struct SPIRVEmitContext
                 // If the component types are not the same, convert them to be so.
                 if (!isTypeEqual(getVectorElementType(toType), fromElementType))
                 {
+                    SpvOp convertOp = isIntegralType(fromElementType) ? (isSignedType(fromElementType) ? SpvOpSConvert : SpvOpUConvert) : SpvOpFConvert;
                     auto newFromType = replaceVectorElementType(fromType, getVectorElementType(toType));
                     fromSpvInst = emitInstCustomOperandFunc(
                         parent,
                         nullptr,
-                        SpvOpFConvert,
+                        convertOp,
                         [&]() {
                             emitOperand(newFromType);
                             emitOperand(kResultID),

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -1557,10 +1557,24 @@ void hoistInstOutOfASMBlocks(IRBlock* block)
 IRType* getSPIRVSampledElementType(IRInst* sampledType)
 {
     auto sampledElementType = getVectorElementType((IRType*)sampledType);
-    if (sampledElementType->getOp() == kIROp_HalfType)
+    
+    IRBuilder builder(sampledType);
+    switch (sampledElementType->getOp())
     {
-        IRBuilder builder(sampledType);
+    case kIROp_HalfType:
         sampledElementType = builder.getBasicType(BaseType::Float);
+        break;
+    case kIROp_UInt16Type:
+    case kIROp_UInt8Type:
+    case kIROp_CharType:
+        sampledElementType = builder.getBasicType(BaseType::UInt);
+        break;
+    case kIROp_Int8Type:
+    case kIROp_Int16Type:
+        sampledElementType = builder.getBasicType(BaseType::Int);
+        break;
+    default:
+        break;
     }
     return sampledElementType;
 }

--- a/tests/spirv/small-int-texture.slang
+++ b/tests/spirv/small-int-texture.slang
@@ -1,6 +1,6 @@
 // Test that we can translate textures whose element type is a small integer type to valid spirv.
 
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
 
 //TEST_INPUT: RWTexture2D(format=R8_UINT, size=4, content = one, mipMaps = 1):name g_Image
 RWTexture2D<uint8_t> g_Image;

--- a/tests/spirv/small-int-texture.slang
+++ b/tests/spirv/small-int-texture.slang
@@ -1,0 +1,17 @@
+// Test that we can translate textures whose element type is a small integer type to valid spirv.
+
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -output-using-type
+
+//TEST_INPUT: RWTexture2D(format=R8_UINT, size=4, content = one, mipMaps = 1):name g_Image
+RWTexture2D<uint8_t> g_Image;
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(int id: SV_DispatchThreadID) {
+    g_Image[id] = uint8_t(23);
+    AllMemoryBarrier();
+    // CHECK: 23
+    outputBuffer[0] = g_Image[id];
+}


### PR DESCRIPTION
Closes #4748.