### PR TITLE
Set `nullptr` to coerce into the default value of `T*` type

### DIFF
--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -903,7 +903,11 @@ namespace Slang
                 *outCost = kConversionCost_NullPtrToPtr;
             }
             if (outToExpr)
-                *outToExpr = fromExpr;
+            {
+                auto* defaultExpr = getASTBuilder()->create<DefaultConstructExpr>();
+                defaultExpr->type = QualType(toType);
+                *outToExpr = defaultExpr;
+            }
             return true;
         }
         // none_t can be cast into any Optional<T> type.

--- a/tests/bugs/assign-nullptr.slang
+++ b/tests/bugs/assign-nullptr.slang
@@ -1,0 +1,14 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -stage compute -entry computeMain -O0
+
+//CHECK: %[[NULLPTR_VAL:[a-zA-Z0-9_]+]] = OpConvertUToPtr %_ptr_PhysicalStorageBuffer_int %{{.*}}
+//CHECK: OpStore %ptr %[[NULLPTR_VAL]]
+
+[vk::push_constant] int* dest;
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    int* ptr = nullptr;
+    if (dispatchThreadID.x % 2 == 0) ptr = dest;
+    if (ptr) *ptr = 123;
+
+}


### PR DESCRIPTION
Fixes #4754

Changes:
* Currently the way we resolve `nullptr` produces invalid code-gen due to type-mismatching. Now we assign `nullptr` by using `DefaultConstructExpr` to assign a `nullptr`. This correctly assigns `nullptr` to the target `T*` type since the default of `T*` is `nullptr`.