### PR TITLE
Fix IR lowering for generic interface types.

### DIFF
--- a/tests/language-feature/constants/static-const-in-generic-interface.slang
+++ b/tests/language-feature/constants/static-const-in-generic-interface.slang
@@ -1,0 +1,33 @@
+// static-const-in-generic-interface.slang
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj
+
+// Test that `static const` variable declarations inside of
+// a generic `interface` type correctly translate to interface requirements.
+
+interface ITest<T:__BuiltinIntegerType>
+{
+    static const T kUserDefinedValue;
+}
+
+struct Impl : ITest<int>
+{
+    static const int kUserDefinedValue = 4;
+}
+
+struct EnsureCompileTimeEval<T : __BuiltinIntegerType>
+{
+    static T getValue<U : ITest<T>>() { return U.kUserDefinedValue; }
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+{
+    static const int result = EnsureCompileTimeEval<int>.getValue<Impl>();
+    int outVal = result;
+    // CHECK: 4
+    outputBuffer[0] = outVal;
+}

--- a/tests/language-feature/interfaces/generic-interface-conformance.slang
+++ b/tests/language-feature/interfaces/generic-interface-conformance.slang
@@ -1,0 +1,31 @@
+// Test that we allow type conformances whose base interface is generic.
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx11 -compute  -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute  -output-using-type
+
+public interface ITestInterface<Real : IFloat> {
+    Real sample();
+}
+
+struct TestInterfaceImpl<Real : IFloat> : ITestInterface<Real> {
+    Real sample() {
+        return x;
+    }
+    Real x;
+}
+
+//TEST_INPUT: set data = new StructuredBuffer<ITestInterface<float> >[new TestInterfaceImpl<float>{1.0}];
+StructuredBuffer<ITestInterface<float>> data;
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0], stride=4);
+RWStructuredBuffer<int> outputBuffer;
+
+//TEST_INPUT: type_conformance TestInterfaceImpl<float>:ITestInterface<float> = 3
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    let obj = data[0];
+    // CHECK: 1
+    outputBuffer[0] = int(obj.sample());
+}

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -4617,8 +4617,8 @@ SlangResult innerMain(int argc, char** argv)
 int main(int argc, char** argv)
 {
     const SlangResult res = innerMain(argc, argv);
-
     slang::shutdown();
+    Slang::RttiInfo::deallocateAll();
 
 #ifdef _MSC_VER
     _CrtDumpMemoryLeaks();


### PR DESCRIPTION
Closes #4749.

The issue being fixed here is that when we lower a generic interface to IR, the function types aren't lowered from proper DeclRef with default substitute info, so they end up being direct `IRGeneric` insts, instead of a `specialize(IRGeneric, ...)` inst. This leads to incorrect interface types after specialization pass. The fix is simply lower the function types using a declref.