### PR TITLE
Allow an enum case to reference a previously defined value.

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -788,6 +788,9 @@ namespace Slang
         if(as<ConstructorDecl>(decl))
             return true;
 
+        if (as<EnumCaseDecl>(decl))
+            return true;
+
         // Things nested inside functions may have dependencies
         // on values from the enclosing scope, but this needs to
         // be dealt with via "capture" so they are also effectively

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -4945,6 +4945,7 @@ namespace Slang
             parseOptionalInheritanceClause(parser, decl);
             parser->ReadToken(TokenType::LBrace);
             Token closingToken;
+            parser->pushScopeAndSetParent(decl);
             while (!AdvanceIfMatch(parser, MatchedTokenType::CurlyBraces, &closingToken))
             {
                 EnumCaseDecl* caseDecl = parseEnumCaseDecl(parser);
@@ -4955,6 +4956,7 @@ namespace Slang
 
                 parser->ReadToken(TokenType::Comma);
             }
+            parser->PopScope();
             decl->closingSourceLoc = closingToken.loc;
             return decl;
         });

--- a/tests/language-feature/enums/reference-previous.slang
+++ b/tests/language-feature/enums/reference-previous.slang
@@ -1,0 +1,15 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj
+
+// Test that a enum case can reference a previously defined case.
+
+enum Check { V = 1, X = V+2 };
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+{
+    // CHECK: 3
+    outputBuffer[0] = Check.X;
+}


### PR DESCRIPTION
Closes #2893.