### PR TITLE
Issue/legalize resource

### DIFF
--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -1171,6 +1171,7 @@ INST_RANGE(Layout, VarLayout, EntryPointLayout)
     INST(UNormAttr, unorm, 0, HOISTABLE)
     INST(SNormAttr, snorm, 0, HOISTABLE)
     INST(NoDiffAttr, no_diff, 0, HOISTABLE)
+    INST(NonUniformAttr, nonuniform, 0, HOISTABLE)
 
     /* SemanticAttr */
         INST(UserSemanticAttr, userSemantic, 2, HOISTABLE)

--- a/source/slang/slang-ir-specialize-function-call.cpp
+++ b/source/slang/slang-ir-specialize-function-call.cpp
@@ -564,7 +564,8 @@ struct FunctionParameterSpecializationContext
             // We should also add 2 more things such that our specialization
             // can handle the corner cases that if the oldBase is a nonuniform
             // resource and also the data type of oldIndex will be handled correctly.
-            // By doing so, just add the oldIndex to the key of call info.
+            // By doing so, we form an IRAttributedType to include both information
+            // and add it to the key of call info.
 
             List<IRAttr*> irAttrs;
             if (oldIndex->getOp() == kIROp_NonUniformResourceIndex)

--- a/source/slang/slang-ir-specialize-function-call.cpp
+++ b/source/slang/slang-ir-specialize-function-call.cpp
@@ -565,7 +565,16 @@ struct FunctionParameterSpecializationContext
             // can handle the corner cases that if the oldBase is a nonuniform
             // resource and also the data type of oldIndex will be handled correctly.
             // By doing so, just add the oldIndex to the key of call info.
-            ioInfo.key.vals.add(oldIndex);
+
+            List<IRAttr*> irAttrs;
+            if (oldIndex->getOp() == kIROp_NonUniformResourceIndex)
+            {
+                IRAttr* attr = getBuilder()->getAttr(kIROp_NonUniformAttr);
+                irAttrs.add(attr);
+            }
+            auto irType = getBuilder()->getAttributedType(oldIndex->getDataType(), irAttrs);
+            ioInfo.key.vals.add(irType);
+
             ioInfo.newArgs.add(oldIndex);
         }
         else if (oldArg->getOp() == kIROp_Load)

--- a/source/slang/slang-ir-specialize-function-call.cpp
+++ b/source/slang/slang-ir-specialize-function-call.cpp
@@ -5,6 +5,7 @@
 #include "slang-ir-clone.h"
 #include "slang-ir-insts.h"
 #include "slang-ir-ssa-simplification.h"
+#include "slang-ir-util.h"
 
 namespace Slang
 {
@@ -363,7 +364,7 @@ struct FunctionParameterSpecializationContext
             // a new callee function based on the original
             // function and the information we gathered.
             //
-            newFunc = generateSpecializedFunc(oldFunc, funcInfo);
+            newFunc = generateSpecializedFunc(oldFunc, funcInfo, callInfo);
             specializedFuncs.add(callInfo.key, newFunc);
         }
 
@@ -803,7 +804,8 @@ struct FunctionParameterSpecializationContext
     //
     IRFunc* generateSpecializedFunc(
         IRFunc*                         oldFunc,
-        FuncSpecializationInfo const&   funcInfo)
+        FuncSpecializationInfo const&   funcInfo,
+        CallSpecializationInfo const&   callInfo)
     {
         // We will make use of the infrastructure for cloning
         // IR code, that is defined in `ir-clone.{h,cpp}`.
@@ -933,6 +935,18 @@ struct FunctionParameterSpecializationContext
             newBodyInst->insertBefore(newFirstOrdinary);
         }
 
+        // We need to handle a corner case where the new argument of
+        // the callee of this specialized function could be a use of
+        // NonUniformResourceIndex(), in such case, any indexing operation
+        // on the global buffer by using this new argument should be
+        // decorated with NonUniformDecoration. However, inside the new
+        // specialized function, we don't have that information anymore.
+        // Therefore, we will need to scan the new argument list to find out
+        // this case, and insert the NonUniformResourceIndex() instruction
+        // on the corresponding parameter of the new specialized function.
+        maybeInsertNonUniformResourceIndex(newFunc, funcInfo, callInfo);
+
+
         // At this point we've created a new specialized function,
         // and as such it may contain call sites that were not
         // covered when we built our initial work list.
@@ -963,6 +977,44 @@ struct FunctionParameterSpecializationContext
         simplifyFunc(codeGenContext->getTargetProgram(), newFunc, IRSimplificationOptions::getFast(codeGenContext->getTargetProgram()));
 
         return newFunc;
+    }
+
+    void maybeInsertNonUniformResourceIndex(
+        IRFunc* newFunc,
+        FuncSpecializationInfo const&   funcInfo,
+        CallSpecializationInfo const&   callInfo)
+    {
+        auto builder = getBuilder();
+        uint32_t paramIndex = 0;
+
+        SLANG_ASSERT(callInfo.newArgs.getCount() == funcInfo.newParams.getCount());
+
+        // Iterate over the new arguments, new parameters pair, and
+        // find out if there is any use of NonUniformResourceIndex()
+        // in the new arguments.
+        for (auto newArg : callInfo.newArgs)
+        {
+            if (newArg->getOp() == Slang::kIROp_NonUniformResourceIndex)
+            {
+                auto firstOrdinary = newFunc->getFirstOrdinaryInst();
+
+                IRCloneEnv cloneEnv;
+                auto newParam = funcInfo.newParams[paramIndex];
+
+                // Clone the NonUniformResourceIndex call and insert it at beginning
+                // of the function. Then replace every use of the parameter with the
+                // NonUniformResourceIndex.
+                auto clonedInst = cloneInstAndOperands(&cloneEnv, builder, newArg);
+                clonedInst->insertBefore(firstOrdinary);
+                newParam->replaceUsesWith(clonedInst);
+
+                // At last, set the operand of the NonUniformResourceIndex to the new parameter
+                // because we haven't done it yet during inst clone.
+                clonedInst->setOperand(0, newParam);
+            }
+            paramIndex++;
+        }
+
     }
 };
 

--- a/source/slang/slang-ir-specialize-function-call.cpp
+++ b/source/slang/slang-ir-specialize-function-call.cpp
@@ -553,10 +553,6 @@ struct FunctionParameterSpecializationContext
             // We start by recursively setting up whatever
             // `oldBase` needs:
             //
-            // TODO: We should add check 2 more things in the key
-            // such that our specialization can handle the corner cases
-            // that if the oldBase is a nonuniform resource and also
-            // the data type of oldIndex will be handled correctly.
             getCallInfoForArg(ioInfo, oldBase);
 
             // Then we process `oldIndex` just like we
@@ -565,10 +561,10 @@ struct FunctionParameterSpecializationContext
             // the arguments at the new call site, and
             // don't add anything to the specialization key.
             //
-            // if (oldIndex->getOp() == kIROp_NonUniformResourceIndex)
-            // {
-            //
-            // }
+            // We should also add 2 more things such that our specialization
+            // can handle the corner cases that if the oldBase is a nonuniform
+            // resource and also the data type of oldIndex will be handled correctly.
+            // By doing so, just add the oldIndex to the key of call info.
             ioInfo.key.vals.add(oldIndex);
             ioInfo.newArgs.add(oldIndex);
         }

--- a/source/slang/slang-ir-specialize-function-call.cpp
+++ b/source/slang/slang-ir-specialize-function-call.cpp
@@ -372,7 +372,7 @@ struct FunctionParameterSpecializationContext
             // We don't need to call this function if the specialized function
             // is not pre-existing, because the we will specialize the function
             // based on the call site info exactly, so there is no way that the
-            // arguments don't match the parameters of the function.
+            // arguments mismatch the parameters of the function.
             typeCastForNewArguments(newFunc, oldCall, callInfo);
         }
 

--- a/tests/compute/nonuniformres-as-function-parameter.slang
+++ b/tests/compute/nonuniformres-as-function-parameter.slang
@@ -1,0 +1,95 @@
+//TEST:SIMPLE(filecheck=CHECK-SPV):-target spirv -entry main -stage compute
+//TEST:SIMPLE(filecheck=CHECK-GLSL-SPV):-target spirv -entry main -stage compute -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=CHECK-GLSL):-target glsl -entry main -stage compute
+//TEST:SIMPLE(filecheck=CHECK-HLSL):-target hlsl -entry main -stage compute
+
+RWStructuredBuffer<uint> globalBuffer[] : register(t0, space0);
+RWStructuredBuffer<uint3> outputBuffer;
+
+struct MyStruct
+{
+    uint a;
+    uint b;
+    uint c;
+};
+
+
+MyStruct func(RWStructuredBuffer<uint> buffer)
+{
+    MyStruct a;
+
+    // CHECK-GLSL: globalBuffer_0[nonuniformEXT({{.*}})]
+    // CHECK-GLSL: globalBuffer_0[nonuniformEXT({{.*}})]
+    a.a = buffer[0];
+    a.b = a.a + 1;
+    a.c = a.a + a.b + 1;
+
+    return a;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main(uint2 pixelIndex : SV_DispatchThreadID)
+{
+    uint bufferIdx = pixelIndex.x;
+
+    // CHECK-SPV: OpDecorate %[[VAR1:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK-SPV: OpDecorate %[[VAR2:[a-zA-Z0-9_]+]] NonUniform
+
+
+    // CHECK-GLSL-SPV: OpDecorate %[[VAR1:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK-GLSL-SPV: OpDecorate %[[VAR2:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK-GLSL-SPV: OpDecorate %[[VAR3:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK-GLSL-SPV: OpDecorate %[[VAR4:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK-GLSL-SPV: OpDecorate %[[VAR5:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK-GLSL-SPV: OpDecorate %[[VAR6:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK-GLSL-SPV: OpDecorate %[[VAR7:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK-GLSL-SPV: OpDecorate %[[VAR8:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK-GLSL-SPV: OpDecorate %[[VAR9:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK-GLSL-SPV: OpDecorate %[[VAR10:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK-GLSL-SPV: OpDecorate %[[VAR11:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK-GLSL-SPV: OpDecorate %[[VAR12:[a-zA-Z0-9_]+]] NonUniform
+
+    // CHECK-GLSL: layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+    uint nonUniformIdx = NonUniformResourceIndex(bufferIdx);
+    RWStructuredBuffer<uint> buffer = globalBuffer[nonUniformIdx];
+
+    // CHECK-SPV: %[[VAR3:[a-zA-Z0-9_]+]] = OpBitcast %int %bufferIdx
+    // CHECK-SPV: %[[VAR1]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %[[VAR3]]
+
+    // CHECK-GLSL-SPV: %[[VAR1:[a-zA-Z0-9_]+]] = OpCopyObject %int %{{.*}}
+    // CHECK-GLSL-SPV: %[[VAR2:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR1]] %int_0 %int_0
+    // CHECK-GLSL-SPV: %[[VAR3:[a-zA-Z0-9_]+]] = OpLoad %uint %[[VAR2]]
+    //
+    // CHECK-GLSL-SPV: %[[VAR4:[a-zA-Z0-9_]+]] = OpCopyObject %int %{{.*}}
+    // CHECK-GLSL-SPV: %[[VAR5:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR4]] %int_0 %int_0
+    // CHECK-GLSL-SPV: %[[VAR6:[a-zA-Z0-9_]+]] = OpLoad %uint %[[VAR5]]
+
+    // CHECK-GLSL: func_0({{.*}}nonuniformEXT({{.*}}))
+    // CHECK-HLSL: func_0(globalBuffer_0[NonUniformResourceIndex({{.*}})])
+    MyStruct myStruct = func(buffer);
+
+    // CHECK-GLSL-SPV: OpCopyObject %int %{{.*}}
+    int bufferIdx2 = pixelIndex.y;
+
+    // CHECK-SPV: %[[VAR2]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %bufferIdx2
+
+
+    // CHECK-GLSL-SPV: %[[VAR7:[a-zA-Z0-9_]+]] = OpCopyObject %int %{{.*}}
+    // CHECK-GLSL-SPV: %[[VAR8:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR7]] %int_0 %int_0
+    // CHECK-GLSL-SPV: %[[VAR9:[a-zA-Z0-9_]+]] = OpLoad %uint %[[VAR8]]
+
+    // CHECK-GLSL-SPV: %[[VAR10:[a-zA-Z0-9_]+]] = OpCopyObject %int %{{.*}}
+    // CHECK-GLSL-SPV: %[[VAR11:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR10]] %int_0 %int_0
+    // CHECK-GLSL-SPV: %[[VAR12:[a-zA-Z0-9_]+]] = OpLoad %uint %[[VAR11]]
+    RWStructuredBuffer<uint> buffer2 = globalBuffer[NonUniformResourceIndex(bufferIdx2)];
+
+    // CHECK-GLSL: func_0({{.*}}nonuniformEXT({{.*}}))
+    // CHECK-HLSL: func_0(globalBuffer_0[NonUniformResourceIndex({{.*}})])
+    MyStruct myStruct2 = func(buffer2);
+
+    outputBuffer[0] = uint3(myStruct.a, myStruct.b, myStruct.c);
+    outputBuffer[1] = uint3(myStruct2.a, myStruct2.b, myStruct2.c);
+}
+

--- a/tests/compute/nonuniformres-as-function-parameter.slang
+++ b/tests/compute/nonuniformres-as-function-parameter.slang
@@ -1,9 +1,9 @@
-//TEST:SIMPLE(filecheck=CHECK-SPV):-target spirv -entry main -stage compute
-//TEST:SIMPLE(filecheck=CHECK-GLSL-SPV):-target spirv -entry main -stage compute -emit-spirv-via-glsl
-//TEST:SIMPLE(filecheck=CHECK-GLSL):-target glsl -entry main -stage compute
-//TEST:SIMPLE(filecheck=CHECK-HLSL):-target hlsl -entry main -stage compute
-
+//TEST:SIMPLE(filecheck=CHECK_SPV):-target spirv -entry main -stage compute
+//TEST:SIMPLE(filecheck=CHECK_GLSL_SPV):-target spirv -entry main -stage compute -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=CHECK_GLSL):-target glsl -entry main -stage compute
+//TEST:SIMPLE(filecheck=CHECK_HLSL):-target hlsl -entry main -stage compute
 RWStructuredBuffer<uint> globalBuffer[] : register(t0, space0);
+RWStructuredBuffer<uint> globalBuffer1[] : register(t1, space0);
 RWStructuredBuffer<uint3> outputBuffer;
 
 struct MyStruct
@@ -18,8 +18,14 @@ MyStruct func(RWStructuredBuffer<uint> buffer)
 {
     MyStruct a;
 
-    // CHECK-GLSL: globalBuffer_0[nonuniformEXT({{.*}})]
-    // CHECK-GLSL: globalBuffer_0[nonuniformEXT({{.*}})]
+    // CHECK_GLSL: globalBuffer_0[nonuniformEXT({{.*}})]
+    // CHECK_GLSL: globalBuffer_0[nonuniformEXT({{.*}})]
+
+    // For the last test case that the callee passes globalBuffer1,
+    // we should not see nonuniformEXT here.
+
+    // CHECK_GLSL: globalBuffer1_0[_{{.*}})]
+    // CHECK_GLSL: globalBuffer1_0[_{{.*}})]
     a.a = buffer[0];
     a.b = a.a + 1;
     a.c = a.a + a.b + 1;
@@ -31,65 +37,74 @@ MyStruct func(RWStructuredBuffer<uint> buffer)
 [numthreads(1, 1, 1)]
 void main(uint2 pixelIndex : SV_DispatchThreadID)
 {
+
+    // CHECK_SPV: OpDecorate %[[VAR1:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_SPV: OpDecorate %[[VAR2:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_SPV-NOT: OpDecorate %[[VAR3:[a-zA-Z0-9_]+]] NonUniform
+
+
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR1:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR2:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR3:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR4:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR5:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR6:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR7:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR8:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR9:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR10:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR11:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR12:[a-zA-Z0-9_]+]] NonUniform
+
+
+    // CHECK_GLSL_SPV: OpCopyObject %int %{{.*}}
     uint bufferIdx = pixelIndex.x;
-
-    // CHECK-SPV: OpDecorate %[[VAR1:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK-SPV: OpDecorate %[[VAR2:[a-zA-Z0-9_]+]] NonUniform
-
-
-    // CHECK-GLSL-SPV: OpDecorate %[[VAR1:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK-GLSL-SPV: OpDecorate %[[VAR2:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK-GLSL-SPV: OpDecorate %[[VAR3:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK-GLSL-SPV: OpDecorate %[[VAR4:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK-GLSL-SPV: OpDecorate %[[VAR5:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK-GLSL-SPV: OpDecorate %[[VAR6:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK-GLSL-SPV: OpDecorate %[[VAR7:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK-GLSL-SPV: OpDecorate %[[VAR8:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK-GLSL-SPV: OpDecorate %[[VAR9:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK-GLSL-SPV: OpDecorate %[[VAR10:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK-GLSL-SPV: OpDecorate %[[VAR11:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK-GLSL-SPV: OpDecorate %[[VAR12:[a-zA-Z0-9_]+]] NonUniform
-
-    // CHECK-GLSL: layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
-
     uint nonUniformIdx = NonUniformResourceIndex(bufferIdx);
     RWStructuredBuffer<uint> buffer = globalBuffer[nonUniformIdx];
 
-    // CHECK-SPV: %[[VAR3:[a-zA-Z0-9_]+]] = OpBitcast %int %bufferIdx
-    // CHECK-SPV: %[[VAR1]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %[[VAR3]]
+    // CHECK_SPV: %[[VAR1]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %bufferIdx
 
-    // CHECK-GLSL-SPV: %[[VAR1:[a-zA-Z0-9_]+]] = OpCopyObject %int %{{.*}}
-    // CHECK-GLSL-SPV: %[[VAR2:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR1]] %int_0 %int_0
-    // CHECK-GLSL-SPV: %[[VAR3:[a-zA-Z0-9_]+]] = OpLoad %uint %[[VAR2]]
+    // CHECK_GLSL_SPV: %[[VAR1:[a-zA-Z0-9_]+]] = OpCopyObject %int %{{.*}}
+    // CHECK_GLSL_SPV: %[[VAR2:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR1]] %int_0 %int_0
+    // CHECK_GLSL_SPV: %[[VAR3:[a-zA-Z0-9_]+]] = OpLoad %uint %[[VAR2]]
     //
-    // CHECK-GLSL-SPV: %[[VAR4:[a-zA-Z0-9_]+]] = OpCopyObject %int %{{.*}}
-    // CHECK-GLSL-SPV: %[[VAR5:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR4]] %int_0 %int_0
-    // CHECK-GLSL-SPV: %[[VAR6:[a-zA-Z0-9_]+]] = OpLoad %uint %[[VAR5]]
+    // CHECK_GLSL_SPV: %[[VAR4:[a-zA-Z0-9_]+]] = OpCopyObject %int %{{.*}}
+    // CHECK_GLSL_SPV: %[[VAR5:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR4]] %int_0 %int_0
+    // CHECK_GLSL_SPV: %[[VAR6:[a-zA-Z0-9_]+]] = OpLoad %uint %[[VAR5]]
 
-    // CHECK-GLSL: func_0({{.*}}nonuniformEXT({{.*}}))
-    // CHECK-HLSL: func_0(globalBuffer_0[NonUniformResourceIndex({{.*}})])
+    // CHECK_GLSL: func_0({{.*}}nonuniformEXT({{.*}}))
+    // CHECK_HLSL: func_0(globalBuffer_0[NonUniformResourceIndex({{.*}})])
     MyStruct myStruct = func(buffer);
 
-    // CHECK-GLSL-SPV: OpCopyObject %int %{{.*}}
     int bufferIdx2 = pixelIndex.y;
 
-    // CHECK-SPV: %[[VAR2]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %bufferIdx2
+    // CHECK_SPV: %[[VAR2]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %bufferIdx2
 
 
-    // CHECK-GLSL-SPV: %[[VAR7:[a-zA-Z0-9_]+]] = OpCopyObject %int %{{.*}}
-    // CHECK-GLSL-SPV: %[[VAR8:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR7]] %int_0 %int_0
-    // CHECK-GLSL-SPV: %[[VAR9:[a-zA-Z0-9_]+]] = OpLoad %uint %[[VAR8]]
+    // CHECK_GLSL-SPV: %[[VAR7:[a-zA-Z0-9_]+]] = OpCopyObject %int %{{.*}}
+    // CHECK_GLSL-SPV: %[[VAR8:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR7]] %int_0 %int_0
+    // CHECK_GLSL-SPV: %[[VAR9:[a-zA-Z0-9_]+]] = OpLoad %uint %[[VAR8]]
 
-    // CHECK-GLSL-SPV: %[[VAR10:[a-zA-Z0-9_]+]] = OpCopyObject %int %{{.*}}
-    // CHECK-GLSL-SPV: %[[VAR11:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR10]] %int_0 %int_0
-    // CHECK-GLSL-SPV: %[[VAR12:[a-zA-Z0-9_]+]] = OpLoad %uint %[[VAR11]]
+    // CHECK_GLSL-SPV: %[[VAR10:[a-zA-Z0-9_]+]] = OpCopyObject %int %{{.*}}
+    // CHECK_GLSL-SPV: %[[VAR11:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR10]] %int_0 %int_0
+    // CHECK_GLSL-SPV: %[[VAR12:[a-zA-Z0-9_]+]] = OpLoad %uint %[[VAR11]]
     RWStructuredBuffer<uint> buffer2 = globalBuffer[NonUniformResourceIndex(bufferIdx2)];
 
-    // CHECK-GLSL: func_0({{.*}}nonuniformEXT({{.*}}))
-    // CHECK-HLSL: func_0(globalBuffer_0[NonUniformResourceIndex({{.*}})])
+    // CHECK_GLSL: func_1({{.*}}nonuniformEXT({{.*}}))
+    // CHECK_HLSL: func_0(globalBuffer_0[NonUniformResourceIndex({{.*}})])
     MyStruct myStruct2 = func(buffer2);
+
+
+    int bufferIdx3 = pixelIndex.y;
+    RWStructuredBuffer<uint> buffer3 = globalBuffer1[bufferIdx3];
+
+    // Test to make sure this command is not decorated with NonUniform:
+    // see the check: "CHECK_SPV-NOT: OpDecorate %[[VAR3:[a-zA-Z0-9_]+]] NonUniform" above.
+    // CHECK_SPV: %[[VAR3:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %bufferIdx2
+    MyStruct myStruct3 = func(buffer3);
 
     outputBuffer[0] = uint3(myStruct.a, myStruct.b, myStruct.c);
     outputBuffer[1] = uint3(myStruct2.a, myStruct2.b, myStruct2.c);
+    outputBuffer[2] = uint3(myStruct3.a, myStruct3.b, myStruct3.c);
 }
 

--- a/tests/compute/nonuniformres-as-function-parameter.slang
+++ b/tests/compute/nonuniformres-as-function-parameter.slang
@@ -20,7 +20,7 @@ MyStruct func(RWStructuredBuffer<uint> buffer)
     // CHECK_GLSL: globalBuffer_0[nonuniformEXT({{.*}})]
     // CHECK_GLSL: globalBuffer_0[nonuniformEXT({{.*}})]
 
-    // For the last test case that the callee passes globalBuffer1,
+    // For the last test case 3 that the callee passes globalBuffer[bufferIdx3] to the function,
     // we should not see nonuniformEXT here.
 
     // CHECK_GLSL: globalBuffer_0[_{{.*}})]
@@ -39,6 +39,7 @@ void main(uint2 pixelIndex : SV_DispatchThreadID)
 
     // CHECK_SPV: OpDecorate %[[VAR1:[a-zA-Z0-9_]+]] NonUniform
     // CHECK_SPV: OpDecorate %[[VAR2:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_SPV: OpDecorate %[[VAR3:[a-zA-Z0-9_]+]] NonUniform
 
 
     // CHECK_GLSL_SPV: OpDecorate %[[VAR1:[a-zA-Z0-9_]+]] NonUniform
@@ -55,8 +56,13 @@ void main(uint2 pixelIndex : SV_DispatchThreadID)
     // CHECK_GLSL_SPV: OpDecorate %[[VAR12:[a-zA-Z0-9_]+]] NonUniform
     // CHECK_GLSL_SPV: OpDecorate %[[VAR13:[a-zA-Z0-9_]+]] NonUniform
     // CHECK_GLSL_SPV: OpDecorate %[[VAR14:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR15:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR16:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR17:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR18:[a-zA-Z0-9_]+]] NonUniform
 
 
+    // Test case 1: slang will specialize the func call to 'MyStruct func(uint)'
     uint bufferIdx = pixelIndex.x;
     uint nonUniformIdx = NonUniformResourceIndex(bufferIdx);
     RWStructuredBuffer<uint> buffer = globalBuffer[nonUniformIdx];
@@ -65,13 +71,13 @@ void main(uint2 pixelIndex : SV_DispatchThreadID)
 
     // CHECK_GLSL_SPV: %[[VAR1]] = OpCopyObject %uint %{{.*}}
 
-    // CHECK_GLSL_SPV: %[[VAR3]] = OpCopyObject %uint %[[VAR1]]
-    // CHECK_GLSL_SPV: %[[VAR4]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR3]] %int_0 %int_0
-    // CHECK_GLSL_SPV: %[[VAR5]] = OpLoad %uint %[[VAR4]]
+    // CHECK_GLSL_SPV: %[[VAR4]] = OpCopyObject %uint %[[VAR1]]
+    // CHECK_GLSL_SPV: %[[VAR5]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR4]] %int_0 %int_0
+    // CHECK_GLSL_SPV: %[[VAR6]] = OpLoad %uint %[[VAR5]]
 
-    // CHECK_GLSL_SPV: %[[VAR6]] = OpCopyObject %uint %[[VAR1]]
-    // CHECK_GLSL_SPV: %[[VAR7]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR6]] %int_0 %int_0
-    // CHECK_GLSL_SPV: %[[VAR8]] = OpLoad %uint %[[VAR7]]
+    // CHECK_GLSL_SPV: %[[VAR7]] = OpCopyObject %uint %[[VAR1]]
+    // CHECK_GLSL_SPV: %[[VAR8]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR7]] %int_0 %int_0
+    // CHECK_GLSL_SPV: %[[VAR9]] = OpLoad %uint %[[VAR8]]
 
     // CHECK_GLSL: func_0({{.*}}nonuniformEXT({{.*}}))
     // CHECK_HLSL: func_0(globalBuffer_0[NonUniformResourceIndex({{.*}})])
@@ -79,36 +85,57 @@ void main(uint2 pixelIndex : SV_DispatchThreadID)
 
     int bufferIdx2 = pixelIndex.y;
 
+    // Test case 2: Make sure we cover the case for the different data type of the index.
+    // In this case, slang will specialize the function to 'MyStruct func(int)'
     // CHECK_SPV: %[[VAR2]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %bufferIdx2
 
 
     // CHECK_GLSL_SPV: %[[VAR2]] = OpCopyObject %int %{{.*}}
 
-    // CHECK_GLSL-SPV: %[[VAR9]] = OpCopyObject %int %[[VAR2]]
-    // CHECK_GLSL-SPV: %[[VAR10]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR9]] %int_0 %int_0
-    // CHECK_GLSL-SPV: %[[VAR11]] = OpLoad %uint %[[VAR10]]
+    // CHECK_GLSL-SPV: %[[VAR10]] = OpCopyObject %int %[[VAR2]]
+    // CHECK_GLSL-SPV: %[[VAR11]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR10]] %int_0 %int_0
+    // CHECK_GLSL-SPV: %[[VAR12]] = OpLoad %uint %[[VAR11]]
 
-    // CHECK_GLSL-SPV: %[[VAR12]] = OpCopyObject %int %[[VAR2]]
-    // CHECK_GLSL-SPV: %[[VAR13]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR12]] %int_0 %int_0
-    // CHECK_GLSL-SPV: %[[VAR14]] = OpLoad %uint %[[VAR13]]
+    // CHECK_GLSL-SPV: %[[VAR13]] = OpCopyObject %int %[[VAR2]]
+    // CHECK_GLSL-SPV: %[[VAR14]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR13]] %int_0 %int_0
+    // CHECK_GLSL-SPV: %[[VAR15]] = OpLoad %uint %[[VAR14]]
     RWStructuredBuffer<uint> buffer2 = globalBuffer[NonUniformResourceIndex(bufferIdx2)];
 
     // CHECK_GLSL: func_1({{.*}}nonuniformEXT({{.*}}))
     // CHECK_HLSL: func_0(globalBuffer_0[NonUniformResourceIndex({{.*}})])
     MyStruct myStruct2 = func(buffer2);
 
-
+    // Test case 3: Test the case that we handle the uniformity correctly, the NonUniformResourceIndex will not propagate
+    // to the function, so there should no NonUniform decoration appeared.
     int bufferIdx3 = pixelIndex.y;
     RWStructuredBuffer<uint> buffer3 = globalBuffer[bufferIdx3];
 
-    // CHECK_SPV: %[[VAR3:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %bufferIdx2
+    // CHECK_SPV: %[[VAR4:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %bufferIdx2
 
     // Test to make sure this command is not decorated with NonUniform:
-    // CHECK_SPV-NOT: OpDecorate %[[VAR3]] NonUniform
+    // CHECK_SPV-NOT: OpDecorate %[[VAR4]] NonUniform
     MyStruct myStruct3 = func(buffer3);
+
+
+    // Test case 4: Test to make sure we correctly cover the case that intCast or uintCast of a NonUniformResourceIndex
+    // is still a NonUniformResourceIndex.
+
+    // CHECK_SPV: %[[VAR5:[a-zA-Z0-9_]+]] = OpBitcast %uint %{{.*}}
+    // CHECK_SPV: %[[VAR3]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %[[VAR5]]
+
+    // CHECK_GLSL-SPV: %[[VAR19:[a-zA-Z0-9_]+]]  = OpBitcast %int %[[VAR3]]
+    // CHECK_GLSL-SPV: %[[VAR16]] = OpCopyObject %int %[[VAR19]]
+    // CHECK_GLSL-SPV: %[[VAR17]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR16]] %int_0 %int_0
+    // CHECK_GLSL-SPV: %[[VAR18]] = OpLoad %uint %[[VAR17]]
+    //
+    // Since after the nested cast, the index data type is 'uint' now, make sure it calls the same function as the test case 1.
+    // CHECK_GLSL: func_0({{.*}}nonuniformEXT({{.*}}))
+    RWStructuredBuffer<uint> buffer4 = globalBuffer[(uint)((int)NonUniformResourceIndex(bufferIdx))];
+    MyStruct myStruct4 = func(buffer4);
 
     outputBuffer[0] = uint3(myStruct.a, myStruct.b, myStruct.c);
     outputBuffer[1] = uint3(myStruct2.a, myStruct2.b, myStruct2.c);
     outputBuffer[2] = uint3(myStruct3.a, myStruct3.b, myStruct3.c);
+    outputBuffer[3] = uint3(myStruct4.a, myStruct4.b, myStruct4.c);
 }
 

--- a/tests/compute/nonuniformres-as-function-parameter.slang
+++ b/tests/compute/nonuniformres-as-function-parameter.slang
@@ -3,7 +3,6 @@
 //TEST:SIMPLE(filecheck=CHECK_GLSL):-target glsl -entry main -stage compute
 //TEST:SIMPLE(filecheck=CHECK_HLSL):-target hlsl -entry main -stage compute
 RWStructuredBuffer<uint> globalBuffer[] : register(t0, space0);
-RWStructuredBuffer<uint> globalBuffer1[] : register(t1, space0);
 RWStructuredBuffer<uint3> outputBuffer;
 
 struct MyStruct
@@ -24,8 +23,8 @@ MyStruct func(RWStructuredBuffer<uint> buffer)
     // For the last test case that the callee passes globalBuffer1,
     // we should not see nonuniformEXT here.
 
-    // CHECK_GLSL: globalBuffer1_0[_{{.*}})]
-    // CHECK_GLSL: globalBuffer1_0[_{{.*}})]
+    // CHECK_GLSL: globalBuffer_0[_{{.*}})]
+    // CHECK_GLSL: globalBuffer_0[_{{.*}})]
     a.a = buffer[0];
     a.b = a.a + 1;
     a.c = a.a + a.b + 1;
@@ -40,7 +39,6 @@ void main(uint2 pixelIndex : SV_DispatchThreadID)
 
     // CHECK_SPV: OpDecorate %[[VAR1:[a-zA-Z0-9_]+]] NonUniform
     // CHECK_SPV: OpDecorate %[[VAR2:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_SPV-NOT: OpDecorate %[[VAR3:[a-zA-Z0-9_]+]] NonUniform
 
 
     // CHECK_GLSL_SPV: OpDecorate %[[VAR1:[a-zA-Z0-9_]+]] NonUniform
@@ -55,22 +53,25 @@ void main(uint2 pixelIndex : SV_DispatchThreadID)
     // CHECK_GLSL_SPV: OpDecorate %[[VAR10:[a-zA-Z0-9_]+]] NonUniform
     // CHECK_GLSL_SPV: OpDecorate %[[VAR11:[a-zA-Z0-9_]+]] NonUniform
     // CHECK_GLSL_SPV: OpDecorate %[[VAR12:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR13:[a-zA-Z0-9_]+]] NonUniform
+    // CHECK_GLSL_SPV: OpDecorate %[[VAR14:[a-zA-Z0-9_]+]] NonUniform
 
 
-    // CHECK_GLSL_SPV: OpCopyObject %int %{{.*}}
     uint bufferIdx = pixelIndex.x;
     uint nonUniformIdx = NonUniformResourceIndex(bufferIdx);
     RWStructuredBuffer<uint> buffer = globalBuffer[nonUniformIdx];
 
     // CHECK_SPV: %[[VAR1]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %bufferIdx
 
-    // CHECK_GLSL_SPV: %[[VAR1:[a-zA-Z0-9_]+]] = OpCopyObject %int %{{.*}}
-    // CHECK_GLSL_SPV: %[[VAR2:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR1]] %int_0 %int_0
-    // CHECK_GLSL_SPV: %[[VAR3:[a-zA-Z0-9_]+]] = OpLoad %uint %[[VAR2]]
-    //
-    // CHECK_GLSL_SPV: %[[VAR4:[a-zA-Z0-9_]+]] = OpCopyObject %int %{{.*}}
-    // CHECK_GLSL_SPV: %[[VAR5:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR4]] %int_0 %int_0
-    // CHECK_GLSL_SPV: %[[VAR6:[a-zA-Z0-9_]+]] = OpLoad %uint %[[VAR5]]
+    // CHECK_GLSL_SPV: %[[VAR1]] = OpCopyObject %uint %{{.*}}
+
+    // CHECK_GLSL_SPV: %[[VAR3]] = OpCopyObject %uint %[[VAR1]]
+    // CHECK_GLSL_SPV: %[[VAR4]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR3]] %int_0 %int_0
+    // CHECK_GLSL_SPV: %[[VAR5]] = OpLoad %uint %[[VAR4]]
+
+    // CHECK_GLSL_SPV: %[[VAR6]] = OpCopyObject %uint %[[VAR1]]
+    // CHECK_GLSL_SPV: %[[VAR7]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR6]] %int_0 %int_0
+    // CHECK_GLSL_SPV: %[[VAR8]] = OpLoad %uint %[[VAR7]]
 
     // CHECK_GLSL: func_0({{.*}}nonuniformEXT({{.*}}))
     // CHECK_HLSL: func_0(globalBuffer_0[NonUniformResourceIndex({{.*}})])
@@ -81,13 +82,15 @@ void main(uint2 pixelIndex : SV_DispatchThreadID)
     // CHECK_SPV: %[[VAR2]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %bufferIdx2
 
 
-    // CHECK_GLSL-SPV: %[[VAR7:[a-zA-Z0-9_]+]] = OpCopyObject %int %{{.*}}
-    // CHECK_GLSL-SPV: %[[VAR8:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR7]] %int_0 %int_0
-    // CHECK_GLSL-SPV: %[[VAR9:[a-zA-Z0-9_]+]] = OpLoad %uint %[[VAR8]]
+    // CHECK_GLSL_SPV: %[[VAR2]] = OpCopyObject %int %{{.*}}
 
-    // CHECK_GLSL-SPV: %[[VAR10:[a-zA-Z0-9_]+]] = OpCopyObject %int %{{.*}}
-    // CHECK_GLSL-SPV: %[[VAR11:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR10]] %int_0 %int_0
-    // CHECK_GLSL-SPV: %[[VAR12:[a-zA-Z0-9_]+]] = OpLoad %uint %[[VAR11]]
+    // CHECK_GLSL-SPV: %[[VAR9]] = OpCopyObject %int %[[VAR2]]
+    // CHECK_GLSL-SPV: %[[VAR10]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR9]] %int_0 %int_0
+    // CHECK_GLSL-SPV: %[[VAR11]] = OpLoad %uint %[[VAR10]]
+
+    // CHECK_GLSL-SPV: %[[VAR12]] = OpCopyObject %int %[[VAR2]]
+    // CHECK_GLSL-SPV: %[[VAR13]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR12]] %int_0 %int_0
+    // CHECK_GLSL-SPV: %[[VAR14]] = OpLoad %uint %[[VAR13]]
     RWStructuredBuffer<uint> buffer2 = globalBuffer[NonUniformResourceIndex(bufferIdx2)];
 
     // CHECK_GLSL: func_1({{.*}}nonuniformEXT({{.*}}))
@@ -96,11 +99,12 @@ void main(uint2 pixelIndex : SV_DispatchThreadID)
 
 
     int bufferIdx3 = pixelIndex.y;
-    RWStructuredBuffer<uint> buffer3 = globalBuffer1[bufferIdx3];
+    RWStructuredBuffer<uint> buffer3 = globalBuffer[bufferIdx3];
+
+    // CHECK_SPV: %[[VAR3:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %bufferIdx2
 
     // Test to make sure this command is not decorated with NonUniform:
-    // see the check: "CHECK_SPV-NOT: OpDecorate %[[VAR3:[a-zA-Z0-9_]+]] NonUniform" above.
-    // CHECK_SPV: %[[VAR3:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %bufferIdx2
+    // CHECK_SPV-NOT: OpDecorate %[[VAR3]] NonUniform
     MyStruct myStruct3 = func(buffer3);
 
     outputBuffer[0] = uint3(myStruct.a, myStruct.b, myStruct.c);


### PR DESCRIPTION
Fix the issue https://github.com/shader-slang/slang/issues/4763.

This PR fixes two issue:
1. Fix the issue that after `specializeFunctionCalls`, `NonUniformResourceIndex` is ignored in the generated specialized
function.

The reason is that if the function has a non-uniform resource parameter, we will legalize it by replacing the resource parameter with a index, and indexing of the resource will be moved inside the specialized function.

e.g.

```
void func(ResourceType resource) { ... }
func(resource[NonUniformResourceIndex(0)])
```
will be specialized into

```
void func(int index) { resource[index]; }
func(0);
```

In this case, inside the function, we will loose the information about whether the resource is a non-uniform. So we add the handling for this corner case by adding insert a `NonUniformResourceIndex` into the specialized function:

```
void func(int index) {
int nonUniformIdx = NonUniformResourceIndex(index);
resource[nonUniformIdx];
}
```

2. Fix the issue that arguments mismatch after `specializeCall()`. 
For example, if the function parameter contains a resource type

```
void func(ResourceType res) { ... }

int index = ...
func(resources[index]);
```

This will be specialized into

```
void func(int index) { resources[index] }

int index = ...
func(index);
```

However, if we have more than 1 call sites, and the other call site doesn't use `int` as the index, e.g.

```
uint index = ...
func(resources[index]);
```
this call site will be specialized into

```
uint index = ...
func(index);
```

this will be invalid, because the argument doesn't match the parameter.

Therefore, after the `specializeCall()`, we will do a type check and cast for the argument list to make the types consistent.