### PR TITLE
Support unicode identifier names.

### DIFF
--- a/source/compiler-core/slang-lexer.cpp
+++ b/source/compiler-core/slang-lexer.cpp
@@ -352,7 +352,7 @@ namespace Slang
 
     static bool isNonAsciiCodePoint(unsigned int codePoint)
     {
-        return codePoint != -1 && codePoint >= 0x80;
+        return codePoint != 0xFFFFFFFF && codePoint >= 0x80;
     }
 
     static void _lexIdentifier(Lexer* lexer)

--- a/source/compiler-core/slang-lexer.cpp
+++ b/source/compiler-core/slang-lexer.cpp
@@ -219,8 +219,6 @@ namespace Slang
                 pos--;
                 c = getUnicodePointFromUTF8([&]() {return lexer->m_cursor[pos++]; });
             }
-            break;
-
             // Default case is to just hand along the byte we read as an ASCII code point.
         } while (offset--);
 

--- a/source/core/slang-char-encode.cpp
+++ b/source/core/slang-char-encode.cpp
@@ -211,4 +211,27 @@ CharEncoding* CharEncoding::UTF32 = &_utf32Encoding;
     return count;
 }
 
+Index UTF8Util::calcUTF16CharCount(const UnownedStringSlice& in)
+{
+    Index count = 0;
+    Index readPtr = 0;
+    for (;;)
+    {
+        int c = getUnicodePointFromUTF8([&]() -> Byte
+            {
+                if (readPtr < in.getLength())
+                    return in[readPtr++];
+                else
+                    return 0;
+            });
+        if (c == 0)
+            break;
+        Char16 buffer[2];
+        count += encodeUnicodePointToUTF16(c, buffer);
+        if (readPtr >= in.getLength())
+            break;
+    }
+    return count;
+}
+
 } // namespace Slang

--- a/source/core/slang-char-encode.h
+++ b/source/core/slang-char-encode.h
@@ -203,6 +203,10 @@ struct UTF8Util
         /// Non valid utf8 input or ending starting in partial characters, will produce 
         /// undefined results without error.
     static Index calcCodePointCount(const UnownedStringSlice& in);
+
+
+        /// Given a slice in UTF8, calculate the number of UTF16 characters needed to represent the string.
+    static Index calcUTF16CharCount(const UnownedStringSlice& in);
 };
 
 }

--- a/source/core/slang-char-util.h
+++ b/source/core/slang-char-util.h
@@ -61,7 +61,7 @@ struct CharUtil
         /// Returns the value if c interpretted as a octal digit
         /// If c is not a valid octal returns -1
     inline static int getOctalDigitValue(char c) { return isOctalDigit(c) ? (c - '0') : -1; }
-    
+
     struct CharFlagMap
     {
         Flags flags[0x100];

--- a/source/core/slang-std-writers.cpp
+++ b/source/core/slang-std-writers.cpp
@@ -1,6 +1,10 @@
 
 #include "slang-std-writers.h"
 
+#ifdef SLANG_WINDOWS_FAMILY
+#include <Windows.h>
+#endif
+
 namespace Slang
 {
 
@@ -8,8 +12,11 @@ namespace Slang
 
 /* static */RefPtr<StdWriters> StdWriters::createDefault()
 {
+#ifdef SLANG_WINDOWS_FAMILY
+    SetConsoleCP(CP_UTF8);
+    SetConsoleOutputCP(CP_UTF8);
+#endif
     RefPtr<StdWriters> stdWriters(new StdWriters);
-
     RefPtr<FileWriter> stdError(new FileWriter(stderr, WriterFlag::AutoFlush | WriterFlag::IsUnowned));
     RefPtr<FileWriter> stdOut(new FileWriter(stdout, WriterFlag::AutoFlush | WriterFlag::IsUnowned));
 

--- a/source/core/slang-std-writers.cpp
+++ b/source/core/slang-std-writers.cpp
@@ -1,7 +1,7 @@
 
 #include "slang-std-writers.h"
 
-#ifdef SLANG_WINDOWS_FAMILY
+#if SLANG_WINDOWS_FAMILY
 #include <Windows.h>
 #endif
 
@@ -12,7 +12,7 @@ namespace Slang
 
 /* static */RefPtr<StdWriters> StdWriters::createDefault()
 {
-#ifdef SLANG_WINDOWS_FAMILY
+#if SLANG_WINDOWS_FAMILY
     SetConsoleCP(CP_UTF8);
     SetConsoleOutputCP(CP_UTF8);
 #endif

--- a/source/slang/slang-language-server-document-symbols.cpp
+++ b/source/slang/slang-language-server-document-symbols.cpp
@@ -167,7 +167,7 @@ namespace Slang
                 sym.selectionRange.start.line = (int)line;
                 sym.selectionRange.start.character = (int)col;
                 sym.selectionRange.end.line = (int)line;
-                sym.selectionRange.end.character = (int)(col + nameLoc.name->text.getLength());
+                sym.selectionRange.end.character = (int)(col + (int)UTF8Util::calcUTF16CharCount(nameLoc.name->text.getUnownedSlice()));
                 sym.range.start.line = (int)line;
                 sym.range.start.character = 0;
                 sym.range.end.line = (int)line;

--- a/source/slang/slang-language-server.cpp
+++ b/source/slang/slang-language-server.cpp
@@ -654,9 +654,12 @@ SlangResult LanguageServer::hover(
             maybeAppendAdditionalOverloadsHint();
             auto nodeHumaneLoc =
                 version->linkage->getSourceManager()->getHumaneLoc(leafNode->loc);
-            hover.range.start.line = int(nodeHumaneLoc.line - 1);
-            hover.range.end.line = int(nodeHumaneLoc.line - 1);
-            hover.range.start.character = int(nodeHumaneLoc.column - 1);
+            doc->oneBasedUTF8LocToZeroBasedUTF16Loc(
+                nodeHumaneLoc.line,
+                nodeHumaneLoc.column,
+                hover.range.start.line,
+                hover.range.start.character);
+            hover.range.end = hover.range.start;
             auto name = declRef.getName();
             if (auto ctorDecl = declRef.as<ConstructorDecl>())
             {
@@ -668,17 +671,19 @@ SlangResult LanguageServer::hover(
             }
             if (name)
             {
-                hover.range.end.character = int(nodeHumaneLoc.column + name->text.getLength() - 1);
+                hover.range.end.character = hover.range.start.character + (int)UTF8Util::calcUTF16CharCount(name->text.getUnownedSlice());
             }
         }
     };
     auto fillLoc = [&](SourceLoc loc)
     {
         auto humaneLoc = version->linkage->getSourceManager()->getHumaneLoc(loc, SourceLocType::Actual);
-        hover.range.start.line = int(humaneLoc.line - 1);
-        hover.range.end.line = int(humaneLoc.line - 1);
-        hover.range.start.character = int(humaneLoc.column - 1);
-        hover.range.end.character = hover.range.start.character + int(doc->getTokenLength(humaneLoc.line, humaneLoc.column));
+        doc->oneBasedUTF8LocToZeroBasedUTF16Loc(humaneLoc.line, humaneLoc.column, hover.range.start.line, hover.range.start.character);
+        doc->oneBasedUTF8LocToZeroBasedUTF16Loc(
+            humaneLoc.line,
+            humaneLoc.column + doc->getTokenLength(humaneLoc.line, humaneLoc.column),
+            hover.range.end.line,
+            hover.range.end.character);
     };
     auto fillExprHoverInfo = [&](Expr* expr)
     {
@@ -851,7 +856,7 @@ SlangResult LanguageServer::gotoDefinition(
                                                                 : declRefExpr->declRef.getLoc(),
                     SourceLocType::Actual);
             auto name = declRefExpr->declRef.getName();
-            locations.add(LocationResult{location, name ? (int)name->text.getLength() : 0});
+            locations.add(LocationResult{location, name ? (int)UTF8Util::calcUTF16CharCount(name->text.getUnownedSlice()) : 0});
         }
     }
     else if (auto overloadedExpr = as<OverloadedExpr>(leafNode))
@@ -863,7 +868,7 @@ SlangResult LanguageServer::gotoDefinition(
                 auto location = version->linkage->getSourceManager()->getHumaneLoc(
                     item.declRef.getNameLoc(), SourceLocType::Actual);
                 auto name = item.declRef.getName();
-                locations.add(LocationResult{location, name ? (int)name->text.getLength() : 0});
+                locations.add(LocationResult{location, name ? (int)UTF8Util::calcUTF16CharCount(name->text.getUnownedSlice()) : 0});
             }
         }
         else 
@@ -874,7 +879,7 @@ SlangResult LanguageServer::gotoDefinition(
                 auto location = version->linkage->getSourceManager()->getHumaneLoc(
                     item.declRef.getNameLoc(), SourceLocType::Actual);
                 auto name = item.declRef.getName();
-                locations.add(LocationResult{location, name ? (int)name->text.getLength() : 0});
+                locations.add(LocationResult{location, name ? (int)UTF8Util::calcUTF16CharCount(name->text.getUnownedSlice()) : 0});
             }
         }
     }
@@ -909,8 +914,11 @@ SlangResult LanguageServer::gotoDefinition(
             {
                 result.uri =
                     URI::fromLocalFilePath(loc.loc.pathInfo.foundPath.getUnownedSlice()).uri;
-                result.range.start.line = int(loc.loc.line - 1);
-                result.range.start.character = int(loc.loc.column - 1);
+                doc->oneBasedUTF8LocToZeroBasedUTF16Loc(
+                    loc.loc.line,
+                    loc.loc.column,
+                    result.range.start.line,
+                    result.range.start.character);
                 result.range.end = result.range.start;
                 result.range.end.character += loc.length;
                 results.add(result);

--- a/source/slang/slang-workspace-version.cpp
+++ b/source/slang/slang-workspace-version.cpp
@@ -406,9 +406,9 @@ ArrayView<Index> DocumentVersion::getUTF16Boundaries(Index line)
         {
             List<Index> bounds;
             Index index = 0;
+            Index codePointIndex = 0;
             while (index < slice.getLength())
             {
-                auto startIndex = index;
                 const Char32 codePoint = getUnicodePointFromUTF8(
                     [&]() -> Byte
                     {
@@ -422,7 +422,8 @@ ArrayView<Index> DocumentVersion::getUTF16Boundaries(Index line)
                 Char16 buffer[2];
                 int count = encodeUnicodePointToUTF16Reversed(codePoint, buffer);
                 for (int i = 0; i < count; i++)
-                    bounds.add(startIndex);
+                    bounds.add(codePointIndex);
+                codePointIndex++;
             }
             bounds.add(slice.getLength());
             utf16CharStarts.add(_Move(bounds));
@@ -445,6 +446,15 @@ void DocumentVersion::oneBasedUTF8LocToZeroBasedUTF16Loc(
     auto bounds = getUTF16Boundaries(inLine);
     outLine = rsLine;
     outCol = std::lower_bound(bounds.begin(), bounds.end(), inCol - 1) - bounds.begin();
+}
+
+void DocumentVersion::oneBasedUTF8LocToZeroBasedUTF16Loc(
+    Index inLine, Index inCol, int& outLine, int& outCol)
+{
+    Index ioutLine, ioutCol;
+    oneBasedUTF8LocToZeroBasedUTF16Loc(inLine, inCol, ioutLine, ioutCol);
+    outLine = (int)ioutLine;
+    outCol = (int)ioutCol;
 }
 
 void DocumentVersion::zeroBasedUTF16LocToOneBasedUTF8Loc(

--- a/source/slang/slang-workspace-version.h
+++ b/source/slang/slang-workspace-version.h
@@ -36,6 +36,8 @@ namespace Slang
 
         void oneBasedUTF8LocToZeroBasedUTF16Loc(
             Index inLine, Index inCol, Index& outLine, Index& outCol);
+        void oneBasedUTF8LocToZeroBasedUTF16Loc(
+            Index inLine, Index inCol, int& outLine, int& outCol);
         void zeroBasedUTF16LocToOneBasedUTF8Loc(
             Index inLine, Index inCol, Index& outLine, Index& outCol);
 

--- a/source/slang/slang-workspace-version.h
+++ b/source/slang/slang-workspace-version.h
@@ -20,7 +20,8 @@ namespace Slang
         String path;
         String text;
         List<UnownedStringSlice> lines;
-        List<List<Index>> utf16CharStarts;
+        List<List<Index>> mapUTF16CharIndexToCodePointIndex;
+        List<List<Index>> mapCodePointIndexToUTF8ByteOffset;
     public:
         void setPath(String filePath)
         {
@@ -32,7 +33,9 @@ namespace Slang
         const String& getText() { return text; }
         void setText(const String& newText);
 
+        void ensureUTFBoundsAvailable();
         ArrayView<Index> getUTF16Boundaries(Index line);
+        ArrayView<Index> getUTF8Boundaries(Index line);
 
         void oneBasedUTF8LocToZeroBasedUTF16Loc(
             Index inLine, Index inCol, Index& outLine, Index& outCol);
@@ -62,7 +65,11 @@ namespace Slang
                 return -1;
 
             Index lineStart = lineIndex >= 1 ? getLineStart(lines[lineIndex - 1]) : 0;
-            return lineStart + colIndex - 1;
+            auto boundaries = getUTF8Boundaries(lineIndex);
+            Index byteOffset = 0;
+            if (colIndex > 0 && colIndex <= boundaries.getCount())
+                byteOffset = boundaries[colIndex - 1];
+            return lineStart + byteOffset;
         }
 
         // Get 1-based, utf-8 encoding location from offset.
@@ -83,6 +90,8 @@ namespace Slang
             {
                 col = Index(offset - getLineStart(lines[line-1])) + 1;
             }
+            if (line > 0 && line <= lines.getCount())
+                col = UTF8Util::calcCodePointCount(lines[line-1].head(col));
         }
 
         // Get line from 1-based index.

--- a/tests/front-end/unicode-identifier.slang
+++ b/tests/front-end/unicode-identifier.slang
@@ -17,5 +17,5 @@ float /*комментарий*/ 圆周率_円周率_원주율()
 void computeMain()
 {
     // CHECK: 3.14
-    outputBuffer[0] = 圆周率_円周率_원주율()                                                                                                          ;
+    outputBuffer[0] = 圆周率_円周率_원주율();
 }

--- a/tests/front-end/unicode-identifier.slang
+++ b/tests/front-end/unicode-identifier.slang
@@ -1,0 +1,21 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type -xslang -O0
+
+// Test that we can use unicode characters in identifier names.
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+static const float π = float.getPi();
+
+float 圆周率_円周率_원주율()
+{
+    return π;   
+}
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // CHECK: 3.14
+    outputBuffer[0] = 圆周率_円周率_원주율();
+}

--- a/tests/front-end/unicode-identifier.slang
+++ b/tests/front-end/unicode-identifier.slang
@@ -8,7 +8,7 @@ RWStructuredBuffer<float> outputBuffer;
 
 static const float π = float.getPi();
 
-float 圆周率_円周率_원주율()
+float /*комментарий*/ 圆周率_円周率_원주율()
 {
     return π;   
 }
@@ -17,5 +17,5 @@ float 圆周率_円周率_원주율()
 void computeMain()
 {
     // CHECK: 3.14
-    outputBuffer[0] = 圆周率_円周率_원주율();
+    outputBuffer[0] = 圆周率_円周率_원주율()                                                                                                          ;
 }


### PR DESCRIPTION
Closes #4553.

The main fix here is to handle unicode utf8 bytes during lexing, and treat all unicode characters as a valid identifier character.