### PR TITLE
Warn when inout parameter is never written

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2029,6 +2029,7 @@ T reinterpret(U value);
 // an out paramter.
 __generic<T>
 [__readNone]
+[semanticmutating]
 [ForceInline]
 void unused(inout T){}
 
@@ -2643,6 +2644,9 @@ attribute_syntax [__vulkanHitAttributes] : VulkanHitAttributesAttribute;
 
 __attributeTarget(FunctionDeclBase)
 attribute_syntax [mutating] : MutatingAttribute;
+
+__attributeTarget(FunctionDeclBase)
+attribute_syntax [semanticmutating] : SemanticMutatingAttribute;
 
 __attributeTarget(SetterDecl)
 attribute_syntax [nonmutating] : NonmutatingAttribute;

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2029,7 +2029,6 @@ T reinterpret(U value);
 // an out paramter.
 __generic<T>
 [__readNone]
-[semanticmutating]
 [ForceInline]
 void unused(inout T){}
 
@@ -2650,9 +2649,6 @@ attribute_syntax [__vulkanHitAttributes] : VulkanHitAttributesAttribute;
 
 __attributeTarget(FunctionDeclBase)
 attribute_syntax [mutating] : MutatingAttribute;
-
-__attributeTarget(FunctionDeclBase)
-attribute_syntax [semanticmutating] : SemanticMutatingAttribute;
 
 __attributeTarget(SetterDecl)
 attribute_syntax [nonmutating] : NonmutatingAttribute;

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2025,16 +2025,14 @@ T reinterpret(U value);
 
 // Use an otherwise unused value
 //
-// This can be used to silence the warning about returning before initializing
-// an out paramter.
+// This can be used to silence the warning about returning before initializing an out paramter.
 __generic<T>
 [__readNone]
 [ForceInline]
 __intrinsic_op($(kIROp_Unmodified))
 void unused(inout T){}
 
-// This can be used to silence the warning about not writing before initializing
-// an out paramter.
+// This can be used to silence the warning about not writing to an inout parameter.
 __generic<T>
 [__readNone]
 [ForceInline]

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2039,7 +2039,7 @@ __generic<T>
 [__readNone]
 [ForceInline]
 __intrinsic_op($(kIROp_Unmodified))
-void unmodified(inout T){}
+void unmodified(out T){}
 
 // Specialized function
 

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2030,7 +2030,16 @@ T reinterpret(U value);
 __generic<T>
 [__readNone]
 [ForceInline]
+__intrinsic_op($(kIROp_Unmodified))
 void unused(inout T){}
+
+// This can be used to silence the warning about not writing before initializing
+// an out paramter.
+__generic<T>
+[__readNone]
+[ForceInline]
+__intrinsic_op($(kIROp_Unmodified))
+void unmodified(inout T){}
 
 // Specialized function
 

--- a/source/slang/diff.meta.slang
+++ b/source/slang/diff.meta.slang
@@ -273,7 +273,7 @@ struct TensorView
     __subscript(uint index) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(index); }
-        [ForceInline] set { store(index, newValue); }
+        [ForceInline] [semanticmutating] set { store(index, newValue); }
 
         [__NoSideEffect]
         ref
@@ -288,7 +288,7 @@ struct TensorView
     __subscript(uint i1, uint i2) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i1, i2); }
-        [ForceInline] set { store(i1, i2, newValue); }
+        [ForceInline] [semanticmutating] set { store(i1, i2, newValue); }
         [__NoSideEffect]
         ref
         {
@@ -302,7 +302,7 @@ struct TensorView
     __subscript(uint2 i) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i.x, i.y); }
-        [ForceInline] set { store(i.x, i.y, newValue); }
+        [ForceInline] [semanticmutating] set { store(i.x, i.y, newValue); }
         [__NoSideEffect]
         ref
         {
@@ -316,7 +316,7 @@ struct TensorView
     __subscript(uint i1, uint i2, uint i3) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i1, i2, i3); }
-        [ForceInline] set { store(i1, i2, i3, newValue); }
+        [ForceInline] [semanticmutating] set { store(i1, i2, i3, newValue); }
         [__NoSideEffect]
         ref
         {
@@ -330,7 +330,7 @@ struct TensorView
     __subscript(uint3 i) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i.x, i.y, i.z); }
-        [ForceInline] set { store(i.x, i.y, i.z, newValue); }
+        [ForceInline] [semanticmutating] set { store(i.x, i.y, i.z, newValue); }
         [__NoSideEffect]
         ref
         {
@@ -344,7 +344,7 @@ struct TensorView
     __subscript(uint i1, uint i2, uint i3, uint i4) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i1, i2, i3, i4); }
-        [ForceInline] set { store(i1, i2, i3, i4, newValue); }
+        [ForceInline] [semanticmutating] set { store(i1, i2, i3, i4, newValue); }
         [__NoSideEffect]
         ref
         {
@@ -358,7 +358,7 @@ struct TensorView
     __subscript(uint4 i) -> T
     {
         [__NoSideEffect][ForceInline] get { return load(i.x, i.y, i.z, i.w); }
-        [ForceInline] set { store(i.x, i.y, i.z, i.w, newValue); }
+        [ForceInline] [semanticmutating] set { store(i.x, i.y, i.z, i.w, newValue); }
         [__NoSideEffect]
         ref
         {
@@ -372,7 +372,7 @@ struct TensorView
     __subscript(uint i1, uint i2, uint i3, uint i4, uint i5) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i1, i2, i3, i4, i5); }
-        [ForceInline] set { store(i1, i2, i3, i4, i5, newValue); }
+        [ForceInline] [semanticmutating] set { store(i1, i2, i3, i4, i5, newValue); }
         [__NoSideEffect]
         ref
         {

--- a/source/slang/diff.meta.slang
+++ b/source/slang/diff.meta.slang
@@ -273,7 +273,12 @@ struct TensorView
     __subscript(uint index) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(index); }
-        [ForceInline] set { store(index, newValue); }
+        
+        [ForceInline] set
+        {
+            unmodified(this);
+            store(index, newValue);
+        }
 
         [__NoSideEffect]
         ref
@@ -288,7 +293,13 @@ struct TensorView
     __subscript(uint i1, uint i2) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i1, i2); }
-        [ForceInline] set { store(i1, i2, newValue); }
+
+        [ForceInline] set
+        {
+            unmodified(this);
+            store(i1, i2, newValue);
+        }
+        
         [__NoSideEffect]
         ref
         {
@@ -302,7 +313,13 @@ struct TensorView
     __subscript(uint2 i) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i.x, i.y); }
-        [ForceInline] set { store(i.x, i.y, newValue); }
+
+        [ForceInline] set
+        {
+            unmodified(this);
+            store(i.x, i.y, newValue);
+        }
+
         [__NoSideEffect]
         ref
         {
@@ -316,7 +333,13 @@ struct TensorView
     __subscript(uint i1, uint i2, uint i3) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i1, i2, i3); }
-        [ForceInline] set { store(i1, i2, i3, newValue); }
+        
+        [ForceInline] set
+        {
+            unmodified(this);
+            store(i1, i2, i3, newValue);
+        }
+
         [__NoSideEffect]
         ref
         {
@@ -330,7 +353,13 @@ struct TensorView
     __subscript(uint3 i) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i.x, i.y, i.z); }
-        [ForceInline] set { store(i.x, i.y, i.z, newValue); }
+
+        [ForceInline] set
+        {
+            unmodified(this);
+            store(i.x, i.y, i.z, newValue);
+        }
+
         [__NoSideEffect]
         ref
         {
@@ -344,7 +373,13 @@ struct TensorView
     __subscript(uint i1, uint i2, uint i3, uint i4) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i1, i2, i3, i4); }
-        [ForceInline] set { store(i1, i2, i3, i4, newValue); }
+
+        [ForceInline] set
+        {
+            unmodified(this);
+            store(i1, i2, i3, i4, newValue);
+        }
+
         [__NoSideEffect]
         ref
         {
@@ -358,7 +393,13 @@ struct TensorView
     __subscript(uint4 i) -> T
     {
         [__NoSideEffect][ForceInline] get { return load(i.x, i.y, i.z, i.w); }
-        [ForceInline] set { store(i.x, i.y, i.z, i.w, newValue); }
+
+        [ForceInline] set
+        {
+            unmodified(this);
+            store(i.x, i.y, i.z, i.w, newValue);
+        }
+
         [__NoSideEffect]
         ref
         {
@@ -372,7 +413,13 @@ struct TensorView
     __subscript(uint i1, uint i2, uint i3, uint i4, uint i5) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i1, i2, i3, i4, i5); }
-        [ForceInline] set { store(i1, i2, i3, i4, i5, newValue); }
+        
+        [ForceInline] set
+        {
+            unmodified(this);
+            store(i1, i2, i3, i4, i5, newValue);
+        }
+
         [__NoSideEffect]
         ref
         {

--- a/source/slang/diff.meta.slang
+++ b/source/slang/diff.meta.slang
@@ -273,7 +273,7 @@ struct TensorView
     __subscript(uint index) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(index); }
-        [ForceInline] [semanticmutating] set { store(index, newValue); }
+        [ForceInline] set { store(index, newValue); }
 
         [__NoSideEffect]
         ref
@@ -288,7 +288,7 @@ struct TensorView
     __subscript(uint i1, uint i2) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i1, i2); }
-        [ForceInline] [semanticmutating] set { store(i1, i2, newValue); }
+        [ForceInline] set { store(i1, i2, newValue); }
         [__NoSideEffect]
         ref
         {
@@ -302,7 +302,7 @@ struct TensorView
     __subscript(uint2 i) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i.x, i.y); }
-        [ForceInline] [semanticmutating] set { store(i.x, i.y, newValue); }
+        [ForceInline] set { store(i.x, i.y, newValue); }
         [__NoSideEffect]
         ref
         {
@@ -316,7 +316,7 @@ struct TensorView
     __subscript(uint i1, uint i2, uint i3) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i1, i2, i3); }
-        [ForceInline] [semanticmutating] set { store(i1, i2, i3, newValue); }
+        [ForceInline] set { store(i1, i2, i3, newValue); }
         [__NoSideEffect]
         ref
         {
@@ -330,7 +330,7 @@ struct TensorView
     __subscript(uint3 i) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i.x, i.y, i.z); }
-        [ForceInline] [semanticmutating] set { store(i.x, i.y, i.z, newValue); }
+        [ForceInline] set { store(i.x, i.y, i.z, newValue); }
         [__NoSideEffect]
         ref
         {
@@ -344,7 +344,7 @@ struct TensorView
     __subscript(uint i1, uint i2, uint i3, uint i4) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i1, i2, i3, i4); }
-        [ForceInline] [semanticmutating] set { store(i1, i2, i3, i4, newValue); }
+        [ForceInline] set { store(i1, i2, i3, i4, newValue); }
         [__NoSideEffect]
         ref
         {
@@ -358,7 +358,7 @@ struct TensorView
     __subscript(uint4 i) -> T
     {
         [__NoSideEffect][ForceInline] get { return load(i.x, i.y, i.z, i.w); }
-        [ForceInline] [semanticmutating] set { store(i.x, i.y, i.z, i.w, newValue); }
+        [ForceInline] set { store(i.x, i.y, i.z, i.w, newValue); }
         [__NoSideEffect]
         ref
         {
@@ -372,7 +372,7 @@ struct TensorView
     __subscript(uint i1, uint i2, uint i3, uint i4, uint i5) -> T
     {
         [ForceInline] [__NoSideEffect] get { return load(i1, i2, i3, i4, i5); }
-        [ForceInline] [semanticmutating] set { store(i1, i2, i3, i4, i5, newValue); }
+        [ForceInline] set { store(i1, i2, i3, i4, i5, newValue); }
         [__NoSideEffect]
         ref
         {

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -997,15 +997,6 @@ class MutatingAttribute : public Attribute
     SLANG_AST_CLASS(MutatingAttribute)
 };
 
-// A '[semanticmutating]` attribute which indicates that
-// a member function should be treated as a `[mutating]`
-// method but does not modify things through its `this`
-// argument.
-class SemanticMutatingAttribute : public Attribute
-{
-    SLANG_AST_CLASS(SemanticMutatingAttribute);
-};
-
 // A `[nonmutating]` attribute, which indicates that a
 // `set` accessor does not need to modify anything through
 // its `this` parameter.

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -997,6 +997,15 @@ class MutatingAttribute : public Attribute
     SLANG_AST_CLASS(MutatingAttribute)
 };
 
+// A '[semanticmutating]` attribute which indicates that
+// a member function should be treated as a `[mutating]`
+// method but does not modify things through its `this`
+// argument.
+class SemanticMutatingAttribute : public Attribute
+{
+    SLANG_AST_CLASS(SemanticMutatingAttribute);
+};
+
 // A `[nonmutating]` attribute, which indicates that a
 // `set` accessor does not need to modify anything through
 // its `this` parameter.

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -749,6 +749,7 @@ DIAGNOSTIC(41018, Warning, returningWithUninitializedOut, "returning without ini
 DIAGNOSTIC(41019, Warning, returningWithPartiallyUninitializedOut, "returning without fully initializing out parameter '$0'")
 DIAGNOSTIC(41020, Warning, constructorUninitializedField, "exiting constructor without initializing field '$0'")
 DIAGNOSTIC(41021, Warning, fieldNotDefaultInitialized, "default initializer for '$0' will not initialize field '$1'")
+DIAGNOSTIC(41022, Warning, inOutNeverStoredInto, "inout parameter '$0' is never written to")
 
 DIAGNOSTIC(41011, Error, typeDoesNotFitAnyValueSize, "type '$0' does not fit in the size required by its conforming interface.")
 DIAGNOSTIC(41012, Note, typeAndLimit, "sizeof($0) is $1, limit is $2")

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -750,6 +750,7 @@ DIAGNOSTIC(41019, Warning, returningWithPartiallyUninitializedOut, "returning wi
 DIAGNOSTIC(41020, Warning, constructorUninitializedField, "exiting constructor without initializing field '$0'")
 DIAGNOSTIC(41021, Warning, fieldNotDefaultInitialized, "default initializer for '$0' will not initialize field '$1'")
 DIAGNOSTIC(41022, Warning, inOutNeverStoredInto, "inout parameter '$0' is never written to")
+DIAGNOSTIC(41023, Warning, methodNeverMutates, "function marked mutable but never modifies object")
 
 DIAGNOSTIC(41011, Error, typeDoesNotFitAnyValueSize, "type '$0' does not fit in the size required by its conforming interface.")
 DIAGNOSTIC(41012, Note, typeAndLimit, "sizeof($0) is $1, limit is $2")

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -753,7 +753,7 @@ DIAGNOSTIC(41019, Warning, returningWithPartiallyUninitializedOut, "returning wi
 DIAGNOSTIC(41020, Warning, constructorUninitializedField, "exiting constructor without initializing field '$0'")
 DIAGNOSTIC(41021, Warning, fieldNotDefaultInitialized, "default initializer for '$0' will not initialize field '$1'")
 DIAGNOSTIC(41022, Warning, inOutNeverStoredInto, "inout parameter '$0' is never written to")
-DIAGNOSTIC(41023, Warning, methodNeverMutates, "function marked mutable but never modifies object")
+DIAGNOSTIC(41023, Warning, methodNeverMutates, "method marked `[mutable]` but never modifies `this`")
 
 DIAGNOSTIC(41011, Error, typeDoesNotFitAnyValueSize, "type '$0' does not fit in the size required by its conforming interface.")
 DIAGNOSTIC(41012, Note, typeAndLimit, "sizeof($0) is $1, limit is $2")

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -2889,6 +2889,9 @@ void CLikeSourceEmitter::_emitInst(IRInst* inst)
     case kIROp_DebugValue:
         break;
 
+    case kIROp_Unmodified:
+        break;
+
         // Insts that needs to be emitted as code blocks.
     case kIROp_CudaKernelLaunch:
     case kIROp_AtomicCounterIncrement:

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -2719,6 +2719,7 @@ struct SPIRVEmitContext
         case kIROp_Specialize:
         case kIROp_MissingReturn:
         case kIROp_StaticAssert:
+        case kIROp_Unmodified:
             break;
         case kIROp_Var:
             result = emitVar(parent, inst);

--- a/source/slang/slang-ir-addr-inst-elimination.cpp
+++ b/source/slang/slang-ir-addr-inst-elimination.cpp
@@ -169,6 +169,7 @@ struct AddressInstEliminationContext
                     break;
                 case kIROp_GetElementPtr:
                 case kIROp_FieldAddress:
+                case kIROp_Unmodified:
                     break;
                 default:
                     sink->diagnose(use->getUser()->sourceLoc, Diagnostics::unsupportedUseOfLValueForAutoDiff);

--- a/source/slang/slang-ir-autodiff-transcriber-base.h
+++ b/source/slang/slang-ir-autodiff-transcriber-base.h
@@ -123,8 +123,14 @@ struct AutoDiffTranscriberBase
 
     InstPair transcribeBlock(IRBuilder* builder, IRBlock* origBlock)
     {
-        HashSet<IRInst*> emptySet;
-        return transcribeBlockImpl(builder, origBlock, emptySet);
+        HashSet<IRInst*> ignore;
+        for (auto inst = origBlock->getFirstInst(); inst; inst = inst->next)
+        {
+            if (inst->m_op == kIROp_Unmodified)
+                ignore.add(inst);
+        }
+
+        return transcribeBlockImpl(builder, origBlock, ignore);
     }
 
     // Transcribe a generic definition

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -1095,6 +1095,7 @@ INST(ExtractTaggedUnionPayload,         extractTaggedUnionPayload,  1, 0)
 
 INST(BitCast,                           bitCast,                    1, 0)
 INST(Reinterpret,                       reinterpret,                1, 0)
+INST(Unmodified,                        unmodified,                1, 0)
 INST(OutImplicitCast,                   outImplicitCast,           1, 0)
 INST(InOutImplicitCast,                 inOutImplicitCast,         1, 0)
 INST(IntCast, intCast, 1, 0)

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -930,6 +930,7 @@ INST_RANGE(BindingQuery, GetRegisterIndex, GetRegisterSpace)
 
     INST(SemanticDecoration, semantic, 2, 0)
     INST(ConstructorDecoration, constructor, 1, 0)
+    INST(MethodDecoration, method, 0, 0)
     INST(PackOffsetDecoration, packoffset, 2, 0)
 
         // Reflection metadata for a shader parameter that provides the original type name.

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -930,7 +930,6 @@ INST_RANGE(BindingQuery, GetRegisterIndex, GetRegisterSpace)
     INST_RANGE(StageAccessDecoration, StageReadAccessDecoration, StageWriteAccessDecoration)
 
     INST(SemanticDecoration, semantic, 2, 0)
-    INST(SemanticMutatingDecoration, semanticMutating, 0, 0)
     INST(ConstructorDecoration, constructor, 1, 0)
     INST(MethodDecoration, method, 0, 0)
     INST(PackOffsetDecoration, packoffset, 2, 0)

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -929,6 +929,7 @@ INST_RANGE(BindingQuery, GetRegisterIndex, GetRegisterSpace)
     INST_RANGE(StageAccessDecoration, StageReadAccessDecoration, StageWriteAccessDecoration)
 
     INST(SemanticDecoration, semantic, 2, 0)
+    INST(SemanticMutatingDecoration, semanticMutating, 0, 0)
     INST(ConstructorDecoration, constructor, 1, 0)
     INST(MethodDecoration, method, 0, 0)
     INST(PackOffsetDecoration, packoffset, 2, 0)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -1358,6 +1358,11 @@ struct IRSemanticDecoration : public IRDecoration
     int getSemanticIndex() { return int(getIntVal(getSemanticIndexOperand())); }
 };
 
+// Indicates that a function should be treated as a write
+// even if it internally does not actually perform any writes.
+// Used to circumvent diagnistics system without `inout` parameters.
+IR_SIMPLE_DECORATION(SemanticMutatingDecoration)
+
 struct IRConstructorDecorartion : IRDecoration
 {
     IR_LEAF_ISA(ConstructorDecoration)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -1365,6 +1365,8 @@ struct IRConstructorDecorartion : IRDecoration
     bool getSynthesizedStatus() { return cast<IRBoolLit>(getOperand(0))->getValue(); }
 };
 
+IR_SIMPLE_DECORATION(MethodDecoration)
+
 struct IRPackOffsetDecoration : IRDecoration
 {
     enum

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -1358,11 +1358,6 @@ struct IRSemanticDecoration : public IRDecoration
     int getSemanticIndex() { return int(getIntVal(getSemanticIndexOperand())); }
 };
 
-// Indicates that a function should be treated as a write
-// even if it internally does not actually perform any writes.
-// Used to circumvent diagnistics system without `inout` parameters.
-IR_SIMPLE_DECORATION(SemanticMutatingDecoration)
-
 struct IRConstructorDecorartion : IRDecoration
 {
     IR_LEAF_ISA(ConstructorDecoration)

--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -46,9 +46,9 @@ namespace Slang
 
     enum ParameterCheckType
     {
-        Never,
-        AsOut,
-        AsInOut   
+        Never,    // Parameter does NOT to be checked for uninitialization (e.g. is `in` or special type)
+        AsOut,    // Parameter DOES need to be checked for usage before initializations
+        AsInOut   // Parameter DOES need to be checked to see if it is ever written to
     };
 
     static ParameterCheckType isPotentiallyUnintended(IRParam* param, Stage stage, int index)

--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -590,26 +590,20 @@ namespace Slang
             stage = entry->getProfile().getStage();
 
         bool structMethod = func->findDecoration<IRMethodDecoration>();
-        bool semanticMutating = func->findDecoration<IRSemanticMutatingDecoration>();
 
         // Check out parameters
-        if (!semanticMutating)
+        int index = 0;
+        for (auto param : firstBlock->getParams())
         {
-            // Ignore if the user has specified through `[semanticmutating]`
-            // that the parameters are being written to in some sense
-            int index = 0;
-            for (auto param : firstBlock->getParams())
-            {
-                bool isThis = structMethod && (index == 0);
+            bool isThis = structMethod && (index == 0);
 
-                ParameterCheckType checkType = isPotentiallyUnintended(param, stage, index);
-                if (checkType == AsOut)
-                    checkParameterAsOut(reachability, func, param, sink);
-                else if (checkType == AsInOut)
-                    checkParameterAsInOut(param, func, isThis, sink);
+            ParameterCheckType checkType = isPotentiallyUnintended(param, stage, index);
+            if (checkType == AsOut)
+                checkParameterAsOut(reachability, func, param, sink);
+            else if (checkType == AsInOut)
+                checkParameterAsInOut(param, func, isThis, sink);
 
-                index++;
-            }
+            index++;
         }
 
         // Check ordinary instructions

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9546,6 +9546,8 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // For diagnostics
         if (as<StructDecl>(decl->parentDecl))
             getBuilder()->addSimpleDecoration<IRMethodDecoration>(irFunc);
+        if (decl->hasModifier<SemanticMutatingAttribute>())
+            getBuilder()->addSimpleDecoration<IRSemanticMutatingDecoration>(irFunc);
 
         auto irFuncType = info.type;
         auto& irResultType = info.resultType;

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9546,8 +9546,6 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // For diagnostics
         if (as<StructDecl>(decl->parentDecl))
             getBuilder()->addSimpleDecoration<IRMethodDecoration>(irFunc);
-        if (decl->hasModifier<SemanticMutatingAttribute>())
-            getBuilder()->addSimpleDecoration<IRSemanticMutatingDecoration>(irFunc);
 
         auto irFuncType = info.type;
         auto& irResultType = info.resultType;

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9509,7 +9509,6 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
     LoweredValInfo lowerFuncDeclInContext(IRGenContext* subContext, IRBuilder* subBuilder, FunctionDeclBase* decl, bool emitBody = true)
     {
-
         IRGeneric* outerGeneric = nullptr;
         subContext->funcDecl = decl;
 
@@ -9543,6 +9542,10 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                 getBuilder()->addForceInlineDecoration(irFunc);
             }
         }
+
+        // For diagnostics
+        if (as<StructDecl>(decl->parentDecl))
+            getBuilder()->addSimpleDecoration<IRMethodDecoration>(irFunc);
 
         auto irFuncType = info.type;
         auto& irResultType = info.resultType;

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -5683,7 +5683,7 @@ void Session::addBuiltinSource(
         sourceBlob);
 
     SlangResult res = compileRequest->executeActionsInner();
-    // if (SLANG_FAILED(res))
+    if (SLANG_FAILED(res))
     {
         char const* diagnostics = sink.outputBuffer.getBuffer();
         fprintf(stderr, "%s", diagnostics);

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -5683,7 +5683,7 @@ void Session::addBuiltinSource(
         sourceBlob);
 
     SlangResult res = compileRequest->executeActionsInner();
-    if (SLANG_FAILED(res))
+    // if (SLANG_FAILED(res))
     {
         char const* diagnostics = sink.outputBuffer.getBuffer();
         fprintf(stderr, "%s", diagnostics);

--- a/tests/autodiff/reverse-inout-param-custom-derivative.slang
+++ b/tests/autodiff/reverse-inout-param-custom-derivative.slang
@@ -5,7 +5,7 @@
 //TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-float rng(inout int state, float x)
+float rng(int state, float x)
 {
     return state + x;
 }

--- a/tests/bugs/gl-33-ext.slang
+++ b/tests/bugs/gl-33-ext.slang
@@ -4,5 +4,5 @@
 public struct A
 {
     public int state;
-    [mutating] public int next() { return state; }
+    public int next() { return state; }
 };

--- a/tests/bugs/optional.slang
+++ b/tests/bugs/optional.slang
@@ -14,7 +14,7 @@ struct P
 }
 struct Tr
 {
-    int test<T:IArithmetic>(T t, inout P p)
+    int test<T:IArithmetic>(T t, P p)
     {
         const IFoo hit = p.f;
         let castResult = hit as S;

--- a/tests/diagnostics/inout-never-written.slang
+++ b/tests/diagnostics/inout-never-written.slang
@@ -30,8 +30,8 @@ struct A
     //CHK-DAG: ([[# @LINE + 1]]): warning 41023: method marked `[mutable]` but never modifies `this`
     [mutating] int next() { return state; }
     
-    // This is ok because of the attribute
-    [semanticmutating] int progress() {}
+    // TODO: unmodified(...)
+    int progress() {}
 };
 
 __generic <T>

--- a/tests/diagnostics/inout-never-written.slang
+++ b/tests/diagnostics/inout-never-written.slang
@@ -1,0 +1,26 @@
+//TEST:SIMPLE(filecheck=CHK): -target spirv
+
+struct State
+{
+    float3 v;
+    float3 n;
+    int rnd;
+};
+
+//CHK-DAG: ([[# @LINE + 1]]): warning 41022: inout parameter 'x' is never written to
+void int_never_assigned(inout int x) {}
+
+//CHK-DAG: ([[# @LINE + 1]]): warning 41022: inout parameter 'state' is never written to
+void state_never_assigned(inout State state, inout float v)
+{
+    v = state.v.x;
+}
+
+void state_assigned(inout State state)
+{
+    int3 vi = __slang_noop_cast <int3, float3> (state.v);
+    int3 ni = __slang_noop_cast <int3, float3> (state.n);
+    state.rnd = dot(vi, ni);
+}
+
+//CHK-NOT: warning 41022

--- a/tests/diagnostics/inout-never-written.slang
+++ b/tests/diagnostics/inout-never-written.slang
@@ -18,9 +18,7 @@ void state_never_assigned(inout State state, inout float v)
 
 void state_assigned(inout State state)
 {
-    int3 vi = __slang_noop_cast <int3, float3> (state.v);
-    int3 ni = __slang_noop_cast <int3, float3> (state.n);
-    state.rnd = dot(vi, ni);
+    state.rnd = (int) dot(state.v, state.n);
 }
 
 struct A

--- a/tests/diagnostics/inout-never-written.slang
+++ b/tests/diagnostics/inout-never-written.slang
@@ -31,7 +31,11 @@ struct A
     [mutating] int next() { return state; }
     
     // TODO: unmodified(...)
-    int progress() {}
+    [mutating] int progress()
+    {
+        unmodified(state);
+        return state;
+    }
 };
 
 __generic <T>

--- a/tests/diagnostics/inout-never-written.slang
+++ b/tests/diagnostics/inout-never-written.slang
@@ -28,7 +28,6 @@ struct A
     //CHK-DAG: ([[# @LINE + 1]]): warning 41023: method marked `[mutable]` but never modifies `this`
     [mutating] int next() { return state; }
     
-    // TODO: unmodified(...)
     [mutating] int progress()
     {
         unmodified(state);

--- a/tests/diagnostics/inout-never-written.slang
+++ b/tests/diagnostics/inout-never-written.slang
@@ -27,8 +27,11 @@ struct A
 {
     int state;
 
-    //CHK-DAG: ([[# @LINE + 1]]): warning 41023: function marked mutable but never modifies object
+    //CHK-DAG: ([[# @LINE + 1]]): warning 41023: method marked `[mutable]` but never modifies `this`
     [mutating] int next() { return state; }
+    
+    // This is ok because of the attribute
+    [semanticmutating] int progress() {}
 };
 
 __generic <T>
@@ -36,7 +39,7 @@ struct B
 {
     int state;
 
-    //CHK-DAG: ([[# @LINE + 1]]): warning 41023: function marked mutable but never modifies object
+    //CHK-DAG: ([[# @LINE + 1]]): warning 41023: method marked `[mutable]` but never modifies `this`
     [mutating] int next() { return state; }
 };
 

--- a/tests/diagnostics/inout-never-written.slang
+++ b/tests/diagnostics/inout-never-written.slang
@@ -23,4 +23,22 @@ void state_assigned(inout State state)
     state.rnd = dot(vi, ni);
 }
 
+struct A
+{
+    int state;
+
+    //CHK-DAG: ([[# @LINE + 1]]): warning 41023: function marked mutable but never modifies object
+    [mutating] int next() { return state; }
+};
+
+__generic <T>
+struct B
+{
+    int state;
+
+    //CHK-DAG: ([[# @LINE + 1]]): warning 41023: function marked mutable but never modifies object
+    [mutating] int next() { return state; }
+};
+
 //CHK-NOT: warning 41022
+//CHK-NOT: warning 41023

--- a/tests/hlsl-intrinsic/matrix-double.slang
+++ b/tests/hlsl-intrinsic/matrix-double.slang
@@ -44,7 +44,7 @@ IntMatrix makeIntMatrix(int v)
     return m;
 }
 
-void test1(inout FloatMatrix ft, inout FloatMatrix f, int idx)
+void test1(inout FloatMatrix ft, __ref FloatMatrix f, int idx)
 {
     // fmod
     ft += FloatMatrix(IntMatrix(((f % makeFloatMatrix(0.11f)) * makeFloatMatrix(100)) + makeFloatMatrix(0.5)));
@@ -110,7 +110,7 @@ void test1(inout FloatMatrix ft, inout FloatMatrix f, int idx)
     ft += max(f, makeFloatMatrix(0.75));
 }
 
-void test2(inout FloatMatrix ft, inout FloatMatrix f)
+void test2(inout FloatMatrix ft, __ref FloatMatrix f)
 {
     ft += pow(makeFloatMatrix(0.5), f);
 

--- a/tests/hlsl-intrinsic/matrix-double.slang
+++ b/tests/hlsl-intrinsic/matrix-double.slang
@@ -44,8 +44,10 @@ IntMatrix makeIntMatrix(int v)
     return m;
 }
 
-void test1(inout FloatMatrix ft, __ref FloatMatrix f, int idx)
+void test1(inout FloatMatrix ft, inout FloatMatrix f, int idx)
 {
+    unmodified(f);
+
     // fmod
     ft += FloatMatrix(IntMatrix(((f % makeFloatMatrix(0.11f)) * makeFloatMatrix(100)) + makeFloatMatrix(0.5)));
 
@@ -110,8 +112,10 @@ void test1(inout FloatMatrix ft, __ref FloatMatrix f, int idx)
     ft += max(f, makeFloatMatrix(0.75));
 }
 
-void test2(inout FloatMatrix ft, __ref FloatMatrix f)
+void test2(inout FloatMatrix ft, inout FloatMatrix f)
 {
+    unmodified(f);
+
     ft += pow(makeFloatMatrix(0.5), f);
 
     ft += smoothstep(makeFloatMatrix(0.2), makeFloatMatrix(0.7), f);

--- a/tests/hlsl-intrinsic/size-of/align-of-3.slang
+++ b/tests/hlsl-intrinsic/size-of/align-of-3.slang
@@ -10,7 +10,7 @@
 RWStructuredBuffer<int> outputBuffer;
 
 
-int getParamSize(inout uint3 v)
+int getParamSize(uint3 v)
 {
     return alignof(v);
 }
@@ -19,7 +19,7 @@ int getParamSize(inout uint3 v)
 // With "natural" layout size must be the same across all targets.
 // The parameter passing semantic is "value in/value out", so the size 
 // will always be the size of the *value* regardless. So uint3 in this case.
-int getParamSizeWithDirection(inout uint3 v)
+int getParamSizeWithDirection(uint3 v)
 {
     return alignof(v);
 }

--- a/tests/hlsl-intrinsic/size-of/size-of-3.slang
+++ b/tests/hlsl-intrinsic/size-of/size-of-3.slang
@@ -10,7 +10,7 @@
 RWStructuredBuffer<int> outputBuffer;
 
 
-int getParamSize(inout uint3 v)
+int getParamSize(uint3 v)
 {
     return sizeof(v);
 }
@@ -19,7 +19,7 @@ int getParamSize(inout uint3 v)
 // With "natural" layout size must be the same across all targets.
 // The parameter passing semantic is "value in/value out", so the size 
 // will always be the size of the *value* regardless. So uint3 in this case.
-int getParamSizeWithDirection(inout uint3 v)
+int getParamSizeWithDirection(uint3 v)
 {
     return sizeof(v);
 }

--- a/tests/language-feature/struct-field-initializers/struct-field-no-initializer-complex-types.slang
+++ b/tests/language-feature/struct-field-initializers/struct-field-no-initializer-complex-types.slang
@@ -6,7 +6,7 @@
 //TEST_INPUT:ubuffer(data=[0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
 
-struct DefaultData
+struct DefaultData : IDefaultInitializable
 {
     static const int2 val = int2(0, 1);
     float2 size;
@@ -16,13 +16,10 @@ struct DefaultData
 
 extension DefaultData
 {
-    int someGet()
-    {
-        return val.x;
-    }
+    int someGet() { return val.x; }
 }
 
-int loadDefaultData(inout DefaultData noInit)
+int loadDefaultData(DefaultData noInit)
 {
     outputBuffer[1] = 1;
     return noInit.someGet();

--- a/tests/language-feature/unsized-array.slang
+++ b/tests/language-feature/unsized-array.slang
@@ -15,8 +15,9 @@ int test(int arr[])
     return arr[0] + g(arr);
 }
 
-int test2<T>(__ref T arr[])
+int test2<T>(inout T arr[])
 {
+    unmodified(arr);
     return arr.getCount();
 }
 

--- a/tests/language-feature/unsized-array.slang
+++ b/tests/language-feature/unsized-array.slang
@@ -15,7 +15,7 @@ int test(int arr[])
     return arr[0] + g(arr);
 }
 
-int test2<T>(inout T arr[])
+int test2<T>(__ref T arr[])
 {
     return arr.getCount();
 }

--- a/tests/pipeline/ray-tracing/trace-ray-inline.slang
+++ b/tests/pipeline/ray-tracing/trace-ray-inline.slang
@@ -55,8 +55,9 @@ void myTriangleClosestHit(inout MyRayPayload payload)
 // In this case, the return value is used to specify
 // whether the hit should be accepted (true) or ignored (false).
 //
-bool myTriangleAnyHit(MyRayPayload payload)
+bool myTriangleAnyHit(inout MyRayPayload payload)
 {
+    unmodified(payload);
 	return true;
 }
 

--- a/tests/pipeline/ray-tracing/trace-ray-inline.slang
+++ b/tests/pipeline/ray-tracing/trace-ray-inline.slang
@@ -55,7 +55,7 @@ void myTriangleClosestHit(inout MyRayPayload payload)
 // In this case, the return value is used to specify
 // whether the hit should be accepted (true) or ignored (false).
 //
-bool myTriangleAnyHit(inout MyRayPayload payload)
+bool myTriangleAnyHit(MyRayPayload payload)
 {
 	return true;
 }
@@ -73,7 +73,7 @@ void myProceduralClosestHit(inout MyRayPayload payload, MyProceduralHitAttrs att
 {
 	payload.value = attrs.value;
 }
-bool myProceduralAnyHit(inout MyRayPayload payload)
+bool myProceduralAnyHit(MyRayPayload payload)
 {
 	return true;
 }
@@ -85,7 +85,7 @@ bool myProceduralAnyHit(inout MyRayPayload payload)
 // For now we will only deal with the single-intersection
 // case.
 //
-bool myProceduralIntersection(inout float tHit, inout MyProceduralHitAttrs hitAttrs)
+bool myProceduralIntersection(float tHit, MyProceduralHitAttrs hitAttrs)
 {
 	return true;
 }

--- a/tests/pipeline/ray-tracing/trace-ray-inline.slang
+++ b/tests/pipeline/ray-tracing/trace-ray-inline.slang
@@ -74,8 +74,9 @@ void myProceduralClosestHit(inout MyRayPayload payload, MyProceduralHitAttrs att
 {
 	payload.value = attrs.value;
 }
-bool myProceduralAnyHit(MyRayPayload payload)
+bool myProceduralAnyHit(inout MyRayPayload payload)
 {
+    unmodified(payload);
 	return true;
 }
 
@@ -86,8 +87,10 @@ bool myProceduralAnyHit(MyRayPayload payload)
 // For now we will only deal with the single-intersection
 // case.
 //
-bool myProceduralIntersection(float tHit, MyProceduralHitAttrs hitAttrs)
+bool myProceduralIntersection(inout float tHit, inout MyProceduralHitAttrs hitAttrs)
 {
+    unmodified(tHit);
+    unmodified(hitAttrs);
 	return true;
 }
 


### PR DESCRIPTION
Addresses #4698 as one approach to diagnose the potential problem.

A new intrinsic function `unmodified(inout T)` has been added to explicitly indicate that an `inout` variable will not be modified in the function.

This is only one way to address the specific validation error in #4698. In general it seems that DXC does some more extensive checks on actual struct fields (as opposed to observing arbitrary struct writes), so that will be the next step.