### PR TITLE
Remove dxc disassemble debug code

### DIFF
--- a/source/compiler-core/slang-dxc-compiler.cpp
+++ b/source/compiler-core/slang-dxc-compiler.cpp
@@ -593,9 +593,6 @@ SlangResult DXCDownstreamCompiler::compile(const CompileOptions& inOptions, IArt
             dxcOperationResult.writeRef()));
 
         SLANG_RETURN_ON_FAIL(_handleOperationResult(dxcOperationResult, diagnostics, dxcResultBlob));
-
-        ComPtr<IDxcBlobEncoding> dxcResultBlob2 = nullptr;
-        dxcCompiler->Disassemble(dxcResultBlob, dxcResultBlob2.writeRef());
     }
 
     // If we have libraries then we need to link...


### PR DESCRIPTION
Some debug code was left in by accident which called DXC to disassemble the DXIL it produced.