### PR TITLE
Support an Upper-case variant of [NumThreads]

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2626,6 +2626,9 @@ __attributeTarget(FuncDecl)
 attribute_syntax [numthreads(x: int, y: int = 1, z: int = 1)]   : NumThreadsAttribute;
 
 __attributeTarget(FuncDecl)
+attribute_syntax [NumThreads(x: int, y: int = 1, z: int = 1)]   : NumThreadsAttribute;
+
+__attributeTarget(FuncDecl)
 attribute_syntax [WaveSize(numLanes: int)]   : WaveSizeAttribute;
 
 //

--- a/tests/compute/frem.slang
+++ b/tests/compute/frem.slang
@@ -19,7 +19,7 @@ int test(int inVal)
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-[numthreads(4, 1, 1)]
+[NumThreads(4, 1, 1)]
 void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
 {
 	int tid = dispatchThreadID.x;


### PR DESCRIPTION
Closes #4746.

This commit adds a support for "NumThreads" attribute keyword along with an existing "numthreads", all in lower case.

The attribute keywords in HLSL are case-insensitive. As an example, one of D3D documents says,
> "The attribute name "Shader" is case insensitive."
https://microsoft.github.io/DirectX-Specs/d3d/WorkGraphs.html

Slang, however, doesn't support the case-insensitivity. They should be all lower-case or CamelCasing starting with an upper case.