### PR TITLE
Reduce dependency on std library

### DIFF
--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -661,6 +661,13 @@ namespace Slang
 #endif
     }
 
+    String Path::getCurrentPath()
+    {
+        Slang::String path;
+        getCanonical(".", path);
+        return path;
+    }
+
     String Path::getRelativePath(String base, String path)
     {
         std::filesystem::path p1(base.getBuffer());

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -562,6 +562,13 @@ namespace Slang
 #endif
     }
 
+    bool Path::createDirectoryRecursive(const String& path)
+    {
+        std::error_code ec;
+        std::filesystem::create_directories(path.getBuffer(), ec);
+        return !ec;
+    }
+
     /* static */SlangResult Path::getPathType(const String& path, SlangPathType* pathTypeOut)
     {
 #ifdef _WIN32

--- a/source/core/slang-io.h
+++ b/source/core/slang-io.h
@@ -197,6 +197,10 @@ namespace Slang
             /// @return SLANG_OK on success
         static SlangResult getCanonical(const String& path, String& outCanonicalPath);
 
+            /// Returns the current working directory
+            /// @return The path in platform native format. Returns empty string if failed.
+        static String getCurrentPath();
+
             /// Returns the executable path
             /// @return The path in platform native format. Returns empty string if failed.
         static String getExecutablePath();

--- a/source/core/slang-io.h
+++ b/source/core/slang-io.h
@@ -145,6 +145,7 @@ namespace Slang
         static void append(StringBuilder& ioBuilder, const UnownedStringSlice& path);
 
         static bool createDirectory(const String& path);
+        static bool createDirectoryRecursive(const String& path);
 
             /// Accept either style of delimiter
         SLANG_FORCE_INLINE static bool isDelimiter(char c) { return c == '/' || c == '\\'; }

--- a/source/slang-record-replay/record/output-stream.cpp
+++ b/source/slang-record-replay/record/output-stream.cpp
@@ -3,18 +3,17 @@
 
 namespace SlangRecord
 {
-    FileOutputStream::FileOutputStream(const std::string& filename, bool append)
+    FileOutputStream::FileOutputStream(const Slang::String& fileName, bool append)
     {
-        Slang::String path(filename.c_str());
         Slang::FileMode fileMode = append ? Slang::FileMode::Append : Slang::FileMode::Create;
         Slang::FileAccess fileAccess = Slang::FileAccess::Write;
         Slang::FileShare fileShare = Slang::FileShare::None;
 
-        SlangResult res = m_fileStream.init(path, fileMode, fileAccess, fileShare);
+        SlangResult res = m_fileStream.init(fileName, fileMode, fileAccess, fileShare);
 
         if (res != SLANG_OK)
         {
-            SlangRecord::slangRecordLog(SlangRecord::LogLevel::Error, "Failed to open file %s\n", filename.c_str());
+            SlangRecord::slangRecordLog(SlangRecord::LogLevel::Error, "Failed to open file %s\n", fileName.getBuffer());
             std::abort();
         }
     }

--- a/source/slang-record-replay/record/output-stream.h
+++ b/source/slang-record-replay/record/output-stream.h
@@ -1,7 +1,7 @@
 #ifndef OUTPUT_STREAM_H
 #define OUTPUT_STREAM_H
 
-#include <string>
+#include "../../core/slang-string.h"
 #include "../../core/slang-stream.h"
 
 namespace SlangRecord
@@ -17,7 +17,7 @@ namespace SlangRecord
     class FileOutputStream : public OutputStream
     {
     public:
-        FileOutputStream(const std::string& filename, bool append = false);
+        FileOutputStream(const Slang::String& fileName, bool append = false);
         virtual ~FileOutputStream() override;
         virtual void write(const void* data, size_t len) override;
         virtual void flush() override;

--- a/source/slang-record-replay/record/record-manager.cpp
+++ b/source/slang-record-replay/record/record-manager.cpp
@@ -15,7 +15,7 @@ namespace SlangRecord
         m_recordFileDirectory = Slang::Path::combine(m_recordFileDirectory, "slang-record");
         if (!Slang::File::exists(m_recordFileDirectory))
         {
-            if (!Slang::Path::createDirectories(m_recordFileDirectory))
+            if (!Slang::Path::createDirectoryRecursive(m_recordFileDirectory))
             {
                 slangRecordLog(LogLevel::Error, "Fail to create directory: %s\n",
                     m_recordFileDirectory.getBuffer());

--- a/source/slang-record-replay/record/record-manager.cpp
+++ b/source/slang-record-replay/record/record-manager.cpp
@@ -1,5 +1,3 @@
-
-#include <string>
 #include <sstream>
 #include <thread>
 #include "../util/record-utility.h"
@@ -14,21 +12,18 @@ namespace SlangRecord
         std::stringstream ss;
         ss << "gs-"<< globalSessionHandle <<"-t-"<<std::this_thread::get_id() << ".cap";
 
-        m_recordFileDirectory = m_recordFileDirectory / "slang-record";
-
-        Slang::String recordFileDirectory {m_recordFileDirectory.string().c_str()};
-        if (!Slang::File::exists(recordFileDirectory))
+        m_recordFileDirectory = Slang::Path::combine(m_recordFileDirectory, "slang-record");
+        if (!Slang::File::exists(m_recordFileDirectory))
         {
-            std::error_code ec;
-            if (!std::filesystem::create_directory(m_recordFileDirectory, ec))
+            if (!Slang::Path::createDirectories(m_recordFileDirectory))
             {
-                slangRecordLog(LogLevel::Error, "Fail to create directory: %s, error (%d): %s\n",
-                    m_recordFileDirectory.string().c_str(), ec.value(), ec.message().c_str());
+                slangRecordLog(LogLevel::Error, "Fail to create directory: %s\n",
+                    m_recordFileDirectory.getBuffer());
             }
         }
 
-        std::filesystem::path recordFilePath = m_recordFileDirectory / ss.str();
-        m_fileStream = std::make_unique<FileOutputStream>(recordFilePath.string());
+        Slang::String recordFilePath = Slang::Path::combine(m_recordFileDirectory, Slang::String(ss.str().c_str()));
+        m_fileStream = std::make_unique<FileOutputStream>(recordFilePath);
     }
 
     void RecordManager::clearWithHeader(const ApiCallId& callId, uint64_t handleId)

--- a/source/slang-record-replay/record/record-manager.h
+++ b/source/slang-record-replay/record/record-manager.h
@@ -1,9 +1,11 @@
 #ifndef RECORD_MANAGER_H
 #define RECORD_MANAGER_H
 
-#include <filesystem>
 #include "parameter-recorder.h"
 #include "../util/record-format.h"
+
+#include "../../core/slang-string.h"
+#include "../../core/slang-io.h"
 
 namespace SlangRecord
 {
@@ -20,7 +22,7 @@ namespace SlangRecord
         // the end of the record. It has to start with a FunctionTailer
         void apendOutput();
 
-        std::filesystem::path const& getRecordFileDirectory() const { return m_recordFileDirectory; }
+        const Slang::String& getRecordFileDirectory() const { return m_recordFileDirectory; }
 
     private:
         void clearWithHeader(const ApiCallId& callId, uint64_t handleId);
@@ -28,7 +30,7 @@ namespace SlangRecord
 
         MemoryStream m_memoryStream;
         std::unique_ptr<FileOutputStream> m_fileStream;
-        std::filesystem::path             m_recordFileDirectory = std::filesystem::current_path();
+        Slang::String m_recordFileDirectory = Slang::Path::getCurrentPath();
         ParameterRecorder m_recorder;
     };
 } // namespace SlangRecord

--- a/source/slang-record-replay/record/slang-filesystem.cpp
+++ b/source/slang-record-replay/record/slang-filesystem.cpp
@@ -59,8 +59,7 @@ namespace SlangRecord
                 slangRecordLog(LogLevel::Debug, "Create directory: %s to save captured shader file: %s\n",
                     dirPath.getBuffer(), filePath.getBuffer());
 
-                // Path::createDirectories can create the directory recursively.
-                if (!Path::createDirectories(dirPath))
+                if (!Path::createDirectoryRecursive(dirPath))
                 {
                     slangRecordLog(LogLevel::Error, "Fail to create directory: %s\n",
                         dirPath.getBuffer());

--- a/source/slang-record-replay/record/slang-filesystem.cpp
+++ b/source/slang-record-replay/record/slang-filesystem.cpp
@@ -52,25 +52,23 @@ namespace SlangRecord
         // know something wrong with the loadFile call if we can't find the file in the record directory.
         if ((res == SLANG_OK) && (*outBlob != nullptr) && ((*outBlob)->getBufferSize() != 0))
         {
-            std::filesystem::path filePath = m_recordManager->getRecordFileDirectory();
-            filePath = filePath / path;
-
-            if (!File::exists(filePath.parent_path().string().c_str()))
+            Slang::String filePath = Slang::Path::combine(m_recordManager->getRecordFileDirectory(), path);
+            Slang::String dirPath = Slang::Path::getParentDirectory(filePath);
+            if (!File::exists(dirPath))
             {
                 slangRecordLog(LogLevel::Debug, "Create directory: %s to save captured shader file: %s\n",
-                    filePath.parent_path().string().c_str(), filePath.filename().string().c_str());
+                    dirPath.getBuffer(), filePath.getBuffer());
 
-                std::error_code ec;
-                // std::filesystem::create_directories can create the directory recursively.
-                if (!std::filesystem::create_directories(filePath.parent_path(), ec))
+                // Path::createDirectories can create the directory recursively.
+                if (!Path::createDirectories(dirPath))
                 {
-                    slangRecordLog(LogLevel::Error, "Fail to create directory: %s, error (%d): %s\n",
-                        filePath.parent_path().string().c_str(), ec.value(), ec.message().c_str());
+                    slangRecordLog(LogLevel::Error, "Fail to create directory: %s\n",
+                        dirPath.getBuffer());
                     return SLANG_FAIL;
                 }
             }
 
-            FileOutputStream fileStream(filePath.string().c_str());
+            FileOutputStream fileStream(filePath);
 
             fileStream.write((*outBlob)->getBufferPointer(), (*outBlob)->getBufferSize());
             fileStream.flush();

--- a/source/slang-record-replay/replay/json-consumer.cpp
+++ b/source/slang-record-replay/replay/json-consumer.cpp
@@ -1,5 +1,3 @@
-#include <filesystem>
-
 #include "slang.h"
 #include "json-consumer.h"
 #include "../util/record-utility.h"
@@ -335,26 +333,22 @@ namespace SlangRecord
     }
 
 
-    JsonConsumer::JsonConsumer(const std::string& filePath)
+    JsonConsumer::JsonConsumer(const Slang::String& filePath)
     {
-        std::filesystem::path jsonFileDir(filePath);
-        jsonFileDir = std::filesystem::absolute(jsonFileDir);
-
-        if (!Slang::File::exists(jsonFileDir.parent_path().string().c_str()))
+        if (!Slang::File::exists(Slang::Path::getParentDirectory(filePath)))
         {
-            slangRecordLog(LogLevel::Error, "Directory for json file does not exist: %s\n", filePath.c_str());
+            slangRecordLog(LogLevel::Error, "Directory for json file does not exist: %s\n", filePath.getBuffer());
         }
 
-        Slang::String path(filePath.c_str());
         Slang::FileMode fileMode = Slang::FileMode::Create;
         Slang::FileAccess fileAccess = Slang::FileAccess::Write;
         Slang::FileShare fileShare = Slang::FileShare::None;
 
-        SlangResult res = m_fileStream.init(path, fileMode, fileAccess, fileShare);
+        SlangResult res = m_fileStream.init(filePath, fileMode, fileAccess, fileShare);
 
         if (res != SLANG_OK)
         {
-            slangRecordLog(LogLevel::Error, "Failed to open file %s\n", filePath.c_str());
+            slangRecordLog(LogLevel::Error, "Failed to open file %s\n", filePath.getBuffer());
         }
 
         m_isFileValid = true;

--- a/source/slang-record-replay/replay/json-consumer.h
+++ b/source/slang-record-replay/replay/json-consumer.h
@@ -56,7 +56,7 @@ namespace SlangRecord
     class JsonConsumer : public IDecoderConsumer
     {
     public:
-        JsonConsumer(const std::string& filePath);
+        JsonConsumer(const Slang::String& filePath);
 
         virtual void CreateGlobalSession(ObjectID outGlobalSessionId);
         virtual void IGlobalSession_createSession(ObjectID objectId, slang::SessionDesc const&  desc, ObjectID outSessionId);

--- a/source/slang-record-replay/replay/recordFile-processor.h
+++ b/source/slang-record-replay/replay/recordFile-processor.h
@@ -2,7 +2,6 @@
 #define FILE_PROCESSOR_H
 
 #include <cstdlib>
-#include <string>
 #include "../../core/slang-stream.h"
 #include "../util/record-utility.h"
 #include "slang-decoder.h"

--- a/source/slang-record-replay/util/record-utility.cpp
+++ b/source/slang-record-replay/util/record-utility.cpp
@@ -1,11 +1,11 @@
 
-#include <cstring>
-#include <string>
+#include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <mutex>
 
 #include "record-utility.h"
+#include "../../core/slang-string.h"
 #include "../../core/slang-string-util.h"
 
 constexpr const char* kRecordLayerEnvVar = "SLANG_RECORD_LAYER";
@@ -15,7 +15,7 @@ namespace SlangRecord
 {
     static thread_local unsigned int g_logLevel = LogLevel::Silent;
 
-    static bool getEnvironmentVariable(const char* name, std::string& out)
+    static bool getEnvironmentVariable(const char* name, Slang::String& out)
     {
 #ifdef _WIN32
         char* envVar = nullptr;
@@ -31,12 +31,12 @@ namespace SlangRecord
             out = envVar;
         }
 #endif
-        return out.empty() == false;
+        return out.getLength() > 0;
     }
 
     bool isRecordLayerEnabled()
     {
-        std::string envVarStr;
+        Slang::String envVarStr;
         if(getEnvironmentVariable(kRecordLayerEnvVar, envVarStr))
         {
             if (envVarStr == "1")
@@ -55,16 +55,12 @@ namespace SlangRecord
             return;
         }
 
-        std::string envVarStr;
+        Slang::String envVarStr;
         if (getEnvironmentVariable(kRecordLayerLogLevel, envVarStr))
         {
-            char* end = nullptr;
-            unsigned int logLevel = std::strtol(envVarStr.c_str(), &end, 10);
-            if (end && (*end == 0))
-            {
-                g_logLevel = std::min((unsigned int)(LogLevel::Verbose), logLevel);
-                return;
-            }
+            unsigned int logLevel = Slang::stringToUInt(envVarStr);
+            g_logLevel = std::min((unsigned int)(LogLevel::Verbose), logLevel);
+            return;
         }
     }
 

--- a/tools/slang-replay/main.cpp
+++ b/tools/slang-replay/main.cpp
@@ -1,10 +1,11 @@
 #include <stdio.h>
-#include <filesystem>
 
 #include <replay/recordFile-processor.h>
 #include <replay/json-consumer.h>
 #include <replay/replay-consumer.h>
 #include <replay/slang-decoder.h>
+
+#include "../../source/core/slang-io.h"
 
 struct Options
 {
@@ -77,11 +78,8 @@ int main(int argc, char *argv[])
 
     SlangRecord::RecordFileProcessor recordFileProcessor(options.recordFileName);
 
-
-    std::filesystem::path jsonPath = options.recordFileName.begin();
-    jsonPath.replace_extension(".json");
-
-    SlangRecord::JsonConsumer jsonConsumer(jsonPath.string());
+    Slang::String jsonPath = Slang::Path::replaceExt(options.recordFileName, "json");
+    SlangRecord::JsonConsumer jsonConsumer(jsonPath);
     SlangRecord::ReplayConsumer replayConsumer;
 
     SlangRecord::SlangDecoder decoder;


### PR DESCRIPTION
This is a first effort on reducing dependency on the std library, which is needed for #4784.

Usage of `std::string` is replaced with `Slang::String`.
Usage of `std::filesystem` is replaced with `Slang::String`, `Slang::File` and `Slang::Path` utilities.

`<filesystem>` is now only used in `slang-io.cpp` for `getRelativePath` and `createDirectoryRecursive` implementations. These should be replaced in future PRs.