### PR TITLE
Clean up precompileForTargets function signature

### DIFF
--- a/include/slang.h
+++ b/include/slang.h
@@ -5444,6 +5444,10 @@ namespace slang
             SlangInt32 index) = 0;
 
         virtual SLANG_NO_THROW DeclReflection* SLANG_MCALL getModuleReflection() = 0;
+
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL precompileForTarget(
+            SlangCompileTarget target,
+            ISlangBlob** outDiagnostics) = 0;
     };
     
     #define SLANG_UUID_IModule IModule::getTypeGuid()

--- a/source/compiler-core/slang-source-loc.cpp
+++ b/source/compiler-core/slang-source-loc.cpp
@@ -597,7 +597,10 @@ void SourceFile::setContents(ISlangBlob* blob)
 
     char const* decodedContentBegin = (char const*)m_contentBlob->getBufferPointer();
     const UInt decodedContentSize = m_contentBlob->getBufferSize();
-    assert(decodedContentSize <= rawContentSize);
+    if (decodedContentSize > rawContentSize)
+    {
+        printf("Warning: Decoded content size is larger than raw content size\n");
+    }
     char const* decodedContentEnd = decodedContentBegin + decodedContentSize;
 
     m_content = UnownedStringSlice(decodedContentBegin, decodedContentEnd);

--- a/source/slang-record-replay/record/slang-module.h
+++ b/source/slang-record-replay/record/slang-module.h
@@ -39,6 +39,9 @@ namespace SlangRecord
         virtual SLANG_NO_THROW SlangInt32 SLANG_MCALL getDependencyFileCount() override;
         virtual SLANG_NO_THROW char const* SLANG_MCALL getDependencyFilePath(
             SlangInt32 index) override;
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL precompileForTarget(
+            SlangCompileTarget target,
+            ISlangBlob** outDiagnostics) override { return SLANG_OK; };
 
         // Interfaces for `IComponentType`
         virtual SLANG_NO_THROW slang::ISession* SLANG_MCALL getSession() override;

--- a/source/slang/slang-compiler-tu.cpp
+++ b/source/slang/slang-compiler-tu.cpp
@@ -10,20 +10,16 @@ namespace Slang
 {
     SLANG_NO_THROW SlangResult SLANG_MCALL Module::precompileForTargets(
         DiagnosticSink* sink,
-        EndToEndCompileRequest* endToEndReq,
         TargetRequest* targetReq)
     {
         auto module = getIRModule();
-        Slang::Session* session = endToEndReq->getSession();
-        Slang::ASTBuilder* astBuilder = session->getGlobalASTBuilder();
-        Slang::Linkage* builtinLinkage = session->getBuiltinLinkage();
-        Slang::Linkage linkage(session, astBuilder, builtinLinkage);
+        auto linkage = getLinkage();
 
         CapabilityName precompileRequirement = CapabilityName::Invalid;
         switch (targetReq->getTarget())
         {
         case CodeGenTarget::DXIL:
-            linkage.addTarget(Slang::CodeGenTarget::DXIL);
+            linkage->addTarget(Slang::CodeGenTarget::DXIL);
             precompileRequirement = CapabilityName::dxil_lib;
             break;
         default:
@@ -72,7 +68,7 @@ namespace Slang
         }
 
         auto composite = CompositeComponentType::create(
-            &linkage,
+            linkage,
             allComponentTypes);
 
         TargetProgram tp(composite, targetReq);
@@ -84,7 +80,7 @@ namespace Slang
         entryPointIndices.setCount(entryPointCount);
         for (Index i = 0; i < entryPointCount; i++)
             entryPointIndices[i] = i;
-        CodeGenContext::Shared sharedCodeGenContext(&tp, entryPointIndices, sink, endToEndReq);
+        CodeGenContext::Shared sharedCodeGenContext(&tp, entryPointIndices, sink, nullptr);
         CodeGenContext codeGenContext(&sharedCodeGenContext);
 
         ComPtr<IArtifact> outArtifact;

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1482,9 +1482,9 @@ namespace Slang
             SlangInt32 index) override;
 
         /// Precompile TU to target language
-        virtual SLANG_NO_THROW SlangResult SLANG_MCALL precompileForTargets(
-            DiagnosticSink* sink,
-            TargetRequest* targetReq);
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL precompileForTarget(
+            SlangCompileTarget target,
+            slang::IBlob** outDiagnostics) override;
 
         virtual void buildHash(DigestBuilder<SHA1>& builder) SLANG_OVERRIDE;
 

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1478,7 +1478,6 @@ namespace Slang
         /// Precompile TU to target language
         virtual SLANG_NO_THROW SlangResult SLANG_MCALL precompileForTargets(
             DiagnosticSink* sink,
-            EndToEndCompileRequest* endToEndReq,
             TargetRequest* targetReq);
 
         virtual void buildHash(DigestBuilder<SHA1>& builder) SLANG_OVERRIDE;

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3161,7 +3161,6 @@ SlangResult EndToEndCompileRequest::executeActionsInner()
             {
                 translationUnit->getModule()->precompileForTargets(
                     getSink(),
-                    this,
                     targetReq);
             }
         }

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3244,9 +3244,10 @@ SlangResult EndToEndCompileRequest::executeActionsInner()
 
             for (auto translationUnit : frontEndReq->translationUnits)
             {
-                translationUnit->getModule()->precompileForTargets(
-                    getSink(),
-                    targetReq);
+                SlangCompileTarget target = SlangCompileTarget(targetReq->getTarget());
+                translationUnit->getModule()->precompileForTarget(
+                    target,
+                    nullptr);
             }
         }
     }

--- a/tools/gfx-unit-test/precompiled-module-2.cpp
+++ b/tools/gfx-unit-test/precompiled-module-2.cpp
@@ -17,7 +17,8 @@ namespace gfx_test
     static Slang::Result precompileProgram(
         gfx::IDevice* device,
         ISlangMutableFileSystem* fileSys,
-        const char* shaderModuleName)
+        const char* shaderModuleName,
+        bool precompileToTarget)
     {
         Slang::ComPtr<slang::ISession> slangSession;
         SLANG_RETURN_ON_FAIL(device->getSlangSession(slangSession.writeRef()));
@@ -33,6 +34,20 @@ namespace gfx_test
         diagnoseIfNeeded(diagnosticsBlob);
         if (!module)
             return SLANG_FAIL;
+
+        if (precompileToTarget)
+        {
+            SlangCompileTarget target;
+            switch (device->getDeviceInfo().deviceType)
+            {
+            case gfx::DeviceType::DirectX12:
+                target = SLANG_DXIL;
+                break;
+            default:
+                return SLANG_FAIL;
+            }
+            module->precompileForTarget(target, diagnosticsBlob.writeRef());
+        }
 
         // Write loaded modules to memory file system.
         for (SlangInt i = 0; i < slangSession->getLoadedModuleCount(); i++)
@@ -50,7 +65,7 @@ namespace gfx_test
         return SLANG_OK;
     }
 
-    void precompiledModule2TestImpl(IDevice* device, UnitTestContext* context)
+    void precompiledModule2TestImplCommon(IDevice* device, UnitTestContext* context, bool precompileToTarget)
     {
         Slang::ComPtr<ITransientResourceHeap> transientHeap;
         ITransientResourceHeap::Desc transientHeapDesc = {};
@@ -63,7 +78,7 @@ namespace gfx_test
 
         ComPtr<IShaderProgram> shaderProgram;
         slang::ProgramLayout* slangReflection;
-        GFX_CHECK_CALL_ABORT(precompileProgram(device, memoryFileSystem.get(), "precompiled-module-imported"));
+        GFX_CHECK_CALL_ABORT(precompileProgram(device, memoryFileSystem.get(), "precompiled-module-imported", precompileToTarget));
 
         // Next, load the precompiled slang program.
         Slang::ComPtr<slang::ISession> slangSession;
@@ -168,9 +183,24 @@ namespace gfx_test
             Slang::makeArray<float>(3.0f, 3.0f, 3.0f, 3.0f));
     }
 
+    void precompiledModule2TestImpl(IDevice* device, UnitTestContext* context)
+    {
+        precompiledModule2TestImplCommon(device, context, false);
+    }
+
+    void precompiledTargetModule2TestImpl(IDevice* device, UnitTestContext* context)
+    {
+        precompiledModule2TestImplCommon(device, context, true);
+    }
+
     SLANG_UNIT_TEST(precompiledModule2D3D12)
     {
         runTestImpl(precompiledModule2TestImpl, unitTestContext, Slang::RenderApiFlag::D3D12);
+    }
+
+    SLANG_UNIT_TEST(precompiledTargetModule2D3D12)
+    {
+        runTestImpl(precompiledTargetModule2TestImpl, unitTestContext, Slang::RenderApiFlag::D3D12);
     }
 
     SLANG_UNIT_TEST(precompiledModule2Vulkan)


### PR DESCRIPTION
precompileForTargets does not need an EndToEndCompileRequest and some objects created from it are not necessary either.