### PR TITLE
Do not add carrage return to shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # indicate generated files so they don't appear in GitHub diffs
 *.slang.cpp linguist-generated
+
+# Set the line endings to LF for shell scripts
+*.sh text eol=lf


### PR DESCRIPTION
This commit prevents GIT from adding carrage return characters to shell script files whose file extension is ".sh".

Currently git automatically adds a carrage return characters to all lines in text files, which makes them Windows text file. This causes a trouble when a shell script is submitted and it is ran on WSL, because bash on WSL expects the script files in a unix text file format.