### PR TITLE
Emit memory qualifiers once when compiling to GLSL

### DIFF
--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -228,7 +228,6 @@ void GLSLSourceEmitter::_emitGLSLStructuredBuffer(IRGlobalParam* varDecl, IRHLSL
     HLSLAppendStructuredBufferType                  - Write
     HLSLConsumeStructuredBufferType                 - TODO (JS): Its possible that this can be readonly, but we currently don't support on GLSL
     */
-    _emitMemoryQualifierDecorations(varDecl);
     if (as<IRHLSLStructuredBufferType>(structuredBufferType))
     {
         m_writer->emit("readonly ");

--- a/tests/bugs/gh-4818-1.slang
+++ b/tests/bugs/gh-4818-1.slang
@@ -1,0 +1,11 @@
+//TEST:SIMPLE(filecheck=CHECK): -target glsl -entry computeMain -stage compute
+
+// CHECK: coherent
+// CHECK-NOT: coherent
+
+globallycoherent RWByteAddressBuffer bab;
+RWStructuredBuffer<uint> output;
+void computeMain()
+{
+    output[0] = bab.Load<uint>(0);
+}

--- a/tests/bugs/gh-4818-2.slang
+++ b/tests/bugs/gh-4818-2.slang
@@ -1,0 +1,11 @@
+//TEST:SIMPLE(filecheck=CHECK): -target glsl -entry computeMain -stage compute
+
+// CHECK: coherent
+// CHECK-NOT: coherent
+
+globallycoherent StructuredBuffer<uint> sb;
+RWStructuredBuffer<uint> output;
+void computeMain()
+{
+    output[0] = sb.Load(0);
+}


### PR DESCRIPTION
Fixes #4818

Emit memory qualifiers once when compiling to GLSL.
This is required because 2 of the same memory qualifiers on an object is a compile error