### PR TITLE
Make precompileForTargets work with Slang API

### DIFF
--- a/include/slang.h
+++ b/include/slang.h
@@ -5305,6 +5305,10 @@ namespace slang
             SlangInt32 index) = 0;
 
         virtual SLANG_NO_THROW DeclReflection* SLANG_MCALL getModuleReflection() = 0;
+
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL precompileForTarget(
+            SlangCompileTarget target,
+            ISlangBlob** outDiagnostics) = 0;
     };
     
     #define SLANG_UUID_IModule IModule::getTypeGuid()

--- a/source/compiler-core/slang-source-loc.cpp
+++ b/source/compiler-core/slang-source-loc.cpp
@@ -597,7 +597,6 @@ void SourceFile::setContents(ISlangBlob* blob)
 
     char const* decodedContentBegin = (char const*)m_contentBlob->getBufferPointer();
     const UInt decodedContentSize = m_contentBlob->getBufferSize();
-    assert(decodedContentSize <= rawContentSize);
     char const* decodedContentEnd = decodedContentBegin + decodedContentSize;
 
     m_content = UnownedStringSlice(decodedContentBegin, decodedContentEnd);

--- a/source/slang-record-replay/record/slang-module.cpp
+++ b/source/slang-record-replay/record/slang-module.cpp
@@ -213,6 +213,17 @@ namespace SlangRecord
         return res;
     }
 
+    SLANG_NO_THROW SlangResult ModuleRecorder::precompileForTarget(
+        SlangCompileTarget target,
+        ISlangBlob** outDiagnostics)
+    {
+        // TODO: We should record this call
+        slangRecordLog(LogLevel::Verbose, "%s\n", __PRETTY_FUNCTION__);
+        SlangResult res = m_actualModule->precompileForTarget(target, outDiagnostics);
+        return res;
+    };
+
+
     SLANG_NO_THROW slang::ISession* ModuleRecorder::getSession()
     {
         slangRecordLog(LogLevel::Verbose, "%s\n", __PRETTY_FUNCTION__);

--- a/source/slang-record-replay/record/slang-module.h
+++ b/source/slang-record-replay/record/slang-module.h
@@ -39,6 +39,9 @@ namespace SlangRecord
         virtual SLANG_NO_THROW SlangInt32 SLANG_MCALL getDependencyFileCount() override;
         virtual SLANG_NO_THROW char const* SLANG_MCALL getDependencyFilePath(
             SlangInt32 index) override;
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL precompileForTarget(
+            SlangCompileTarget target,
+            ISlangBlob** outDiagnostics) override;
 
         // Interfaces for `IComponentType`
         virtual SLANG_NO_THROW slang::ISession* SLANG_MCALL getSession() override;

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1476,10 +1476,9 @@ namespace Slang
             SlangInt32 index) override;
 
         /// Precompile TU to target language
-        virtual SLANG_NO_THROW SlangResult SLANG_MCALL precompileForTargets(
-            DiagnosticSink* sink,
-            EndToEndCompileRequest* endToEndReq,
-            TargetRequest* targetReq);
+        virtual SLANG_NO_THROW SlangResult SLANG_MCALL precompileForTarget(
+            SlangCompileTarget target,
+            slang::IBlob** outDiagnostics) override;
 
         virtual void buildHash(DigestBuilder<SHA1>& builder) SLANG_OVERRIDE;
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3159,10 +3159,10 @@ SlangResult EndToEndCompileRequest::executeActionsInner()
 
             for (auto translationUnit : frontEndReq->translationUnits)
             {
-                translationUnit->getModule()->precompileForTargets(
-                    getSink(),
-                    this,
-                    targetReq);
+                SlangCompileTarget target = SlangCompileTarget(targetReq->getTarget());
+                translationUnit->getModule()->precompileForTarget(
+                    target,
+                    nullptr);
             }
         }
     }

--- a/tools/gfx-unit-test/precompiled-module-2.cpp
+++ b/tools/gfx-unit-test/precompiled-module-2.cpp
@@ -17,7 +17,8 @@ namespace gfx_test
     static Slang::Result precompileProgram(
         gfx::IDevice* device,
         ISlangMutableFileSystem* fileSys,
-        const char* shaderModuleName)
+        const char* shaderModuleName,
+        bool precompileToTarget)
     {
         Slang::ComPtr<slang::ISession> slangSession;
         SLANG_RETURN_ON_FAIL(device->getSlangSession(slangSession.writeRef()));
@@ -33,6 +34,20 @@ namespace gfx_test
         diagnoseIfNeeded(diagnosticsBlob);
         if (!module)
             return SLANG_FAIL;
+
+        if (precompileToTarget)
+        {
+            SlangCompileTarget target;
+            switch (device->getDeviceInfo().deviceType)
+            {
+            case gfx::DeviceType::DirectX12:
+                target = SLANG_DXIL;
+                break;
+            default:
+                return SLANG_FAIL;
+            }
+            module->precompileForTarget(target, diagnosticsBlob.writeRef());
+        }
 
         // Write loaded modules to memory file system.
         for (SlangInt i = 0; i < slangSession->getLoadedModuleCount(); i++)
@@ -50,7 +65,7 @@ namespace gfx_test
         return SLANG_OK;
     }
 
-    void precompiledModule2TestImpl(IDevice* device, UnitTestContext* context)
+    void precompiledModule2TestImplCommon(IDevice* device, UnitTestContext* context, bool precompileToTarget)
     {
         Slang::ComPtr<ITransientResourceHeap> transientHeap;
         ITransientResourceHeap::Desc transientHeapDesc = {};
@@ -63,7 +78,7 @@ namespace gfx_test
 
         ComPtr<IShaderProgram> shaderProgram;
         slang::ProgramLayout* slangReflection;
-        GFX_CHECK_CALL_ABORT(precompileProgram(device, memoryFileSystem.get(), "precompiled-module-imported"));
+        GFX_CHECK_CALL_ABORT(precompileProgram(device, memoryFileSystem.get(), "precompiled-module-imported", precompileToTarget));
 
         // Next, load the precompiled slang program.
         Slang::ComPtr<slang::ISession> slangSession;
@@ -168,9 +183,24 @@ namespace gfx_test
             Slang::makeArray<float>(3.0f, 3.0f, 3.0f, 3.0f));
     }
 
+    void precompiledModule2TestImpl(IDevice* device, UnitTestContext* context)
+    {
+        precompiledModule2TestImplCommon(device, context, false);
+    }
+
+    void precompiledTargetModule2TestImpl(IDevice* device, UnitTestContext* context)
+    {
+        precompiledModule2TestImplCommon(device, context, true);
+    }
+
     SLANG_UNIT_TEST(precompiledModule2D3D12)
     {
         runTestImpl(precompiledModule2TestImpl, unitTestContext, Slang::RenderApiFlag::D3D12);
+    }
+
+    SLANG_UNIT_TEST(precompiledTargetModule2D3D12)
+    {
+        runTestImpl(precompiledTargetModule2TestImpl, unitTestContext, Slang::RenderApiFlag::D3D12);
     }
 
     SLANG_UNIT_TEST(precompiledModule2Vulkan)


### PR DESCRIPTION
precompileForTargets, renamed to precompileForTarget, does not need an EndToEndCompileRequest and some objects created from it are not necessary either.

Take only a target enum and a diagnostic blob as input and handle everything else internally, such as creating the TargetReq with chosen profile.

Fixes #4790