### PR TITLE
Include inout cast operation as an aliasing instruction

### DIFF
--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -110,6 +110,7 @@ namespace Slang
         case kIROp_FieldAddress:
         case kIROp_GetElement:
         case kIROp_GetElementPtr:
+        case kIROp_InOutImplicitCast:
             return true;
         default:
             break;

--- a/tests/diagnostics/inout-never-written.slang
+++ b/tests/diagnostics/inout-never-written.slang
@@ -44,5 +44,31 @@ struct B
     [mutating] int next() { return state; }
 };
 
+// Sometimes an inOutImplicitCast is done,
+// this needs to be tracked as an alias;
+// none of the following functions should 
+// generate warnings
+uint lcg(inout uint prev)
+{
+    const uint LCG_A = 1664525u;
+    const uint LCG_C = 1013904223u;
+    prev = (LCG_A * prev + LCG_C);
+    return prev & 0x00FFFFFF;
+}
+
+float rnd(inout uint prev)
+{
+    return ((float) lcg(prev) / (float) 0x01000000);
+}
+
+float3 sample(inout int seed)
+{
+    float3 xi;
+    xi.x = rnd(seed);
+    xi.y = rnd(seed);
+    xi.z = rnd(seed);
+    return xi.z;
+}
+
 //CHK-NOT: warning 41022
 //CHK-NOT: warning 41023


### PR DESCRIPTION
Noticed this when warnings are issued from #4823, so there are additional tests added to `inout-never-used.slang`.

Previously, the warnings were:
```
environment.slang(22): warning 41022: inout parameter 'seed' is never written to
public float3 environment_sample(StructuredBuffer <Environment_sample_data> sample_buffer, inout int seed)
              ^~~~~~~~~~~~~~~~~~
hit.slang(5): warning 41022: inout parameter 'seed' is never written to
float3 sample_lights(inout uint seed)
       ^~~~~~~~~~~~~
```

With this PR they should not be emitted.