### PR TITLE
Update documentation for #include to indicate it is for legacy code and new code should use modules

### DIFF
--- a/docs/user-guide/02-conventional-features.md
+++ b/docs/user-guide/02-conventional-features.md
@@ -492,6 +492,11 @@ Slang supports a C-style preprocessor with the following directives;
 
 Variadic macros are supported by the Slang preprocessor.
 
+> #### Note ####
+> The use of `#include` in new code is discouraged as this functionality has
+> been superseded by the module system, please refer to
+> [./04-modules-and-access-control.md](./04-modules-and-access-control.md)
+
 Attributes
 ----------
 


### PR DESCRIPTION
Closes https://github.com/shader-slang/slang/issues/4281