### PR TITLE
Make sure to resolve overloaded expr for call args.

### DIFF
--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2652,7 +2652,7 @@ namespace Slang
         // Next check the argument expressions
         for (auto & arg : expr->arguments)
         {
-            arg = CheckTerm(arg);
+            arg = CheckExpr(arg);
         }
 
         // if the expression is '&&' or '||', we will convert it

--- a/tests/bugs/gh-4863.slang
+++ b/tests/bugs/gh-4863.slang
@@ -1,0 +1,36 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUFFER):-compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUFFER):-vk -compute -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+interface IFoo
+{
+  property float bar1 {get; set;}
+};
+
+struct Foo : IFoo
+{
+  uint4 data = 0;
+  property float bar1
+  {
+    get { return asfloat(data.w); }
+    set { data.w = asuint(newValue); }
+  }
+};
+
+void doThing(inout Foo foo, uint2 ipos)
+{
+  foo.bar1 = 2;
+  foo.bar1 += 1.0f;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint2 ipos : SV_DispatchThreadID)
+{
+  Foo foo;
+  doThing(foo, ipos);
+  // BUFFER: 3
+  outputBuffer[0] = (int)foo.bar1;
+}


### PR DESCRIPTION
Closes #4863.

The fix here is to make sure we resolve overloaded exprs for call arguments.