### PR TITLE
Avoiding the use of the global AST builder in DeclRefType::create

### DIFF
--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -526,9 +526,6 @@ Index getFilterCountImpl(const ReflectClassInfo& clsInfo, MemberFilterStyle filt
             {
                 SLANG_UNEXPECTED("unhandled type");
             }
-            // Always create builtin types in global AST builder.
-            if (astBuilder->getSharedASTBuilder()->getInnerASTBuilder() != astBuilder)
-                return DeclRefType::create(astBuilder->getSharedASTBuilder()->getInnerASTBuilder(), declRef);
 
             declRef = createDefaultSubstitutionsIfNeeded(astBuilder, nullptr, declRef);
             ValNodeDesc nodeDesc = {};

--- a/tests/modules/compile.bat
+++ b/tests/modules/compile.bat
@@ -1,0 +1,5 @@
+del *.dxil
+del *.slang-module
+slangc.exe hit.slang -stage closesthit -entry closesthit -target dxil -o monolithic.dxil
+slangc.exe environment.slang -o environment.slang-module
+slangc.exe hit.slang -stage closesthit -entry closesthit -target dxil -o precompiled.dxil

--- a/tests/modules/compile.bat
+++ b/tests/modules/compile.bat
@@ -1,5 +1,0 @@
-del *.dxil
-del *.slang-module
-slangc.exe hit.slang -stage closesthit -entry closesthit -target dxil -o monolithic.dxil
-slangc.exe environment.slang -o environment.slang-module
-slangc.exe hit.slang -stage closesthit -entry closesthit -target dxil -o precompiled.dxil

--- a/tests/modules/environment.slang
+++ b/tests/modules/environment.slang
@@ -1,0 +1,29 @@
+module environment;
+
+uint lcg(inout uint prev)
+{
+    const uint LCG_A = 1664525u;
+    const uint LCG_C = 1013904223u;
+    prev = (LCG_A * prev + LCG_C);
+    return prev & 0x00FFFFFF;
+}
+
+public float rnd(inout uint prev)
+{
+    return ((float) lcg(prev) / (float) 0x01000000);
+}
+
+public struct Environment_sample_data
+{
+    uint alias;
+    float q;
+};
+
+public float3 environment_sample(StructuredBuffer <Environment_sample_data> sample_buffer, inout int seed)
+{
+    float3 xi;
+    xi.x = rnd(seed);
+    xi.y = rnd(seed);
+    xi.z = rnd(seed);
+    return xi.z;
+}

--- a/tests/modules/hit.slang
+++ b/tests/modules/hit.slang
@@ -1,3 +1,6 @@
+//TEST:COMPILE: tests/modules/environment.slang -o tests/modules/environment.slang-module
+//TEST:COMPILE: tests/modules/hit.slang -stage closesthit -entry closesthit -target dxil -o monolithic.dxil
+
 import environment;
 
 StructuredBuffer <Environment_sample_data> environment_sample_buffer;

--- a/tests/modules/hit.slang
+++ b/tests/modules/hit.slang
@@ -1,0 +1,21 @@
+import environment;
+
+StructuredBuffer <Environment_sample_data> environment_sample_buffer;
+
+float3 sample_lights(inout uint seed)
+{
+    return environment_sample(environment_sample_buffer, seed);
+}
+
+struct RadianceHitInfo
+{
+    float3 contribution;
+};
+
+struct Attributes
+{
+    float2 bary;
+};
+
+[shader("closesthit")]
+void closesthit(inout RadianceHitInfo payload, Attributes attrib) {}


### PR DESCRIPTION
Fixes #4823