### PR TITLE
Track ContainerDecl with synthesized scope variable for `DifferentialType`

### DIFF
--- a/source/slang/slang-ast-synthesis.h
+++ b/source/slang/slang-ast-synthesis.h
@@ -52,6 +52,7 @@ public:
         auto parentScope = getScope(decl);
         decl->ownedScope = m_builder->create<Scope>();
         decl->ownedScope->parent = parentScope;
+        decl->ownedScope->containerDecl = decl;
         pushContainerScope(decl);
     }
 


### PR DESCRIPTION
Fixes #4879

Track ContainerDecl with synthesized scope variable for `DifferentialType`  