### PR TITLE
Track uninitialized values of `Ptr<Specialize<T>>` inside type `T` without hang

### DIFF
--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -180,9 +180,8 @@ namespace Slang
             // Avoid the recursive step if its a
             // recursive structure like a linked list
             IRType* ptype = ptr->getValueType();
-            if (auto spec = as<IRSpecialize>(ptype))
-                if(auto resolvedType = as<IRType>(resolveSpecialization(spec)))
-                    ptype = resolvedType;
+            if(auto resolvedType = as<IRType>(getResolvedInstForDecorations(ptype)))
+                ptype = resolvedType;
             return (ptype != upper) && canIgnoreType(ptype, upper);
         }
 

--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -180,6 +180,9 @@ namespace Slang
             // Avoid the recursive step if its a
             // recursive structure like a linked list
             IRType* ptype = ptr->getValueType();
+            if (auto spec = as<IRSpecialize>(ptype))
+                if(auto resolvedType = as<IRType>(resolveSpecialization(spec)))
+                    ptype = resolvedType;
             return (ptype != upper) && canIgnoreType(ptype, upper);
         }
 


### PR DESCRIPTION
Fixes #4878

Track uninitialized values of `Ptr<Specialize<T>>` inside type `T` without hang

Note: related to `tests/reflection/ptr/ptr-generic.slang`