### PR TITLE
Exclude synthesized code from code auto documentation system

### DIFF
--- a/source/slang/slang-doc-ast.cpp
+++ b/source/slang/slang-doc-ast.cpp
@@ -48,14 +48,14 @@ namespace Slang {
     }
 }
 
-bool doWeDocDecl(Decl* decl)
+bool shouldDocumentDecl(Decl* decl)
 {
     return !getText(decl->getName()).startsWith("$__syn") && !decl->hasModifier<SynthesizedModifier>();
 }
 
 static void _addDeclRec(Decl* decl, List<Decl*>& outDecls)
 {
-    if (decl == nullptr || !doWeDocDecl(decl))
+    if (decl == nullptr || !shouldDocumentDecl(decl))
     {
         return;
     }
@@ -115,7 +115,7 @@ SlangResult ASTMarkupUtil::extract(ModuleDecl* moduleDecl, SourceManager* source
             item.searchStyle = getSearchStyle(decl);
 
             // Don't generate documentation for synthesized members.
-            if (!doWeDocDecl(decl))
+            if (!shouldDocumentDecl(decl))
                 item.searchStyle = DocMarkupExtractor::SearchStyle::None;
         }
 

--- a/source/slang/slang-doc-ast.cpp
+++ b/source/slang/slang-doc-ast.cpp
@@ -3,6 +3,7 @@
 
 #include "../core/slang-string-util.h"
 
+#include "slang/slang-ast-support-types.h"
 //#include "slang-ast-builder.h"
 //#include "slang-ast-print.h"
 
@@ -47,9 +48,14 @@ namespace Slang {
     }
 }
 
+bool doWeDocDecl(Decl* decl)
+{
+    return !getText(decl->getName()).startsWith("$__syn") && !decl->hasModifier<SynthesizedModifier>();
+}
+
 static void _addDeclRec(Decl* decl, List<Decl*>& outDecls)
 {
-    if (decl == nullptr)
+    if (decl == nullptr || !doWeDocDecl(decl))
     {
         return;
     }
@@ -109,7 +115,7 @@ SlangResult ASTMarkupUtil::extract(ModuleDecl* moduleDecl, SourceManager* source
             item.searchStyle = getSearchStyle(decl);
 
             // Don't generate documentation for synthesized members.
-            if (getText(decl->getName()).startsWith("$__syn"))
+            if (!doWeDocDecl(decl))
                 item.searchStyle = DocMarkupExtractor::SearchStyle::None;
         }
 

--- a/source/slang/slang-doc-ast.h
+++ b/source/slang/slang-doc-ast.h
@@ -8,6 +8,8 @@
 
 #include "slang-ast-all.h"
 
+#include "slang-syntax.h"
+
 namespace Slang {
 
 /* Holds the documentation markup that is associated with each node (typically a decl) from a module */
@@ -86,6 +88,8 @@ struct ASTMarkupUtil
         /// in outMarkup
     static SlangResult extract(ModuleDecl* moduleDecl, SourceManager* sourceManager, DiagnosticSink* sink, ASTMarkup* outMarkup, bool searchOrindaryComments = false);
 };
+
+bool doWeDocDecl(Decl* decl);
 
 } // namespace Slang
 

--- a/source/slang/slang-doc-ast.h
+++ b/source/slang/slang-doc-ast.h
@@ -89,7 +89,7 @@ struct ASTMarkupUtil
     static SlangResult extract(ModuleDecl* moduleDecl, SourceManager* sourceManager, DiagnosticSink* sink, ASTMarkup* outMarkup, bool searchOrindaryComments = false);
 };
 
-bool doWeDocDecl(Decl* decl);
+bool shouldDocumentDecl(Decl* decl);
 
 } // namespace Slang
 

--- a/source/slang/slang-doc-markdown-writer.cpp
+++ b/source/slang/slang-doc-markdown-writer.cpp
@@ -1070,7 +1070,7 @@ void DocMarkdownWriter::writeAggType(const ASTMarkup::Entry& entry, AggTypeDeclB
         List<Decl*> uniqueMethods;
         for (const auto& [_, decl] : memberDict)
         {
-            if (!doWeDocDecl(decl))
+            if (!shouldDocumentDecl(decl))
                 continue;
             CallableDecl* callableDecl = as<CallableDecl>(decl);
             if (callableDecl && isVisible(callableDecl))

--- a/source/slang/slang-doc-markdown-writer.cpp
+++ b/source/slang/slang-doc-markdown-writer.cpp
@@ -1070,6 +1070,8 @@ void DocMarkdownWriter::writeAggType(const ASTMarkup::Entry& entry, AggTypeDeclB
         List<Decl*> uniqueMethods;
         for (const auto& [_, decl] : memberDict)
         {
+            if (!doWeDocDecl(decl))
+                continue;
             CallableDecl* callableDecl = as<CallableDecl>(decl);
             if (callableDecl && isVisible(callableDecl))
             {


### PR DESCRIPTION
Fixes #4888
Changes to exclude synthesized code from code-auto-documentation system