### PR TITLE
Fix a false failure when using the latest SPIR-V

### DIFF
--- a/tests/bugs/gh-3087-multi-entry-point.slang
+++ b/tests/bugs/gh-3087-multi-entry-point.slang
@@ -5,11 +5,11 @@
 
 // we should only have 1 'BuiltIn InstanceIndex' since the `Output` and `Input` semantic
 // for `InstanceIndex` should be converted to a non-builtin
-// CHECK: OpDecorate %gl_InstanceIndex BuiltIn InstanceIndex
+// CHECK-DAG: OpDecorate %gl_InstanceIndex BuiltIn InstanceIndex
 // CHECK-NOT: OpDecorate %gl_InstanceIndex BuiltIn InstanceIndex
 
 // We require 1 `Flat` for the fragment input `uint`
-// CHECK: OpDecorate %{{[1-9][0-9]*}} Flat
+// CHECK-DAG: OpDecorate %{{[1-9][0-9]*}} Flat
 // CHECK-NOT: OpDecorate %{{[1-9][0-9]*}} Flat
 
 struct VIn

--- a/tests/bugs/gh-3087-multi-entry-point.slang
+++ b/tests/bugs/gh-3087-multi-entry-point.slang
@@ -5,12 +5,12 @@
 
 // we should only have 1 'BuiltIn InstanceIndex' since the `Output` and `Input` semantic
 // for `InstanceIndex` should be converted to a non-builtin
-// CHECK-DAG: BuiltIn InstanceIndex
-// CHECK-NOT: BuiltIn InstanceIndex
+// CHECK: OpDecorate %gl_InstanceIndex BuiltIn InstanceIndex
+// CHECK-NOT: OpDecorate %gl_InstanceIndex BuiltIn InstanceIndex
 
 // We require 1 `Flat` for the fragment input `uint`
-// SPIRV: Flat
-// SPIRV-NOT: Flat
+// CHECK: OpDecorate %{{[1-9][0-9]*}} Flat
+// CHECK-NOT: OpDecorate %{{[1-9][0-9]*}} Flat
 
 struct VIn
 {

--- a/tests/bugs/gh-3087.slang
+++ b/tests/bugs/gh-3087.slang
@@ -10,9 +10,10 @@
 
 // SPIRV: OpEntryPoint
 // SPIRV-NOT: BuiltIn InstanceIndex
+
 // We require 1 `Flat` for the fragment input `uint`
-// SPIRV: Flat
-// SPIRV-NOT: Flat
+// SPIRV: OpDecorate %{{[1-9][0-9]*}} Flat
+// SPIRV-NOT: OpDecorate %{{[1-9][0-9]*}} Flat
 
 
 struct PSInput


### PR DESCRIPTION
With the current SPIR-V, the test emits the following,
```
; Annotations
OpDecorate %8 Flat

; Types, variables and constants
%8 = OpVariable %_ptr_Input_int Input
```
With the latest SPIR-V, the same test emits the following with an additional comment,
```
; Annotations
OpDecorate %8 Flat

; Types, variables and constants
%8 = OpVariable %_ptr_Input_int Input ; Location 0, Flat
```
This results in a false failure where it is not a real failure.