### PR TITLE
Migrate examples

### DIFF
--- a/examples/autodiff-texture/train.slang
+++ b/examples/autodiff-texture/train.slang
@@ -15,12 +15,12 @@ struct DifferentiableTexture
     float minLOD;
 
     [BackwardDerivative(bwd_LoadTexel)]
-    float4 LoadTexel(int3 location, int2 offset, uint dLayerW, uint dMipOffset)
+    float4 LoadTexel(int3 location, constexpr int2 offset, uint dLayerW, uint dMipOffset)
     {
         return texture.Load(location, offset);
     }
 
-    void bwd_LoadTexel(int3 location, int2 offset, uint dLayerW, uint dMipOffset, float4 val)
+    void bwd_LoadTexel(int3 location, constexpr int2 offset, uint dLayerW, uint dMipOffset, float4 val)
     {
         // Ignore alpha dimension for this example..
         int4 uval = int4(int3(val.xyz * 65536), 1);

--- a/examples/ray-tracing-pipeline/main.cpp
+++ b/examples/ray-tracing-pipeline/main.cpp
@@ -203,6 +203,11 @@ gfx::Result loadShaderProgram(
     diagnoseIfNeeded(diagnosticsBlob);
     SLANG_RETURN_ON_FAIL(result);
 
+    if (isTestMode())
+    {
+        printEntrypointHashes(componentTypes.getCount() - 1, 1, linkedProgram);
+    }
+
     gfx::IShaderProgram::Desc programDesc = {};
     programDesc.slangGlobalScope = linkedProgram;
     SLANG_RETURN_ON_FAIL(device->createProgram(programDesc, outProgram));
@@ -297,11 +302,14 @@ void onMouseUp(platform::MouseEventArgs args) { isMouseDown = false; }
 Slang::Result initialize()
 {
     initializeBase("Ray Tracing Pipeline", 1024, 768);
-    gWindow->events.mouseMove = [this](const platform::MouseEventArgs& e) { onMouseMove(e); };
-    gWindow->events.mouseUp = [this](const platform::MouseEventArgs& e) { onMouseUp(e); };
-    gWindow->events.mouseDown = [this](const platform::MouseEventArgs& e) { onMouseDown(e); };
-    gWindow->events.keyDown = [this](const platform::KeyEventArgs& e) { onKeyDown(e); };
-    gWindow->events.keyUp = [this](const platform::KeyEventArgs& e) { onKeyUp(e); };
+    if (!isTestMode())
+    {
+        gWindow->events.mouseMove = [this](const platform::MouseEventArgs& e) { onMouseMove(e); };
+        gWindow->events.mouseUp = [this](const platform::MouseEventArgs& e) { onMouseUp(e); };
+        gWindow->events.mouseDown = [this](const platform::MouseEventArgs& e) { onMouseDown(e); };
+        gWindow->events.keyDown = [this](const platform::KeyEventArgs& e) { onKeyDown(e); };
+        gWindow->events.keyUp = [this](const platform::KeyEventArgs& e) { onKeyUp(e); };
+    }
 
     IBufferResource::Desc vertexBufferDesc;
     vertexBufferDesc.type = IResource::Type::Buffer;
@@ -670,9 +678,13 @@ virtual void renderFrame(int frameBufferIndex) override
         presentCommandBuffer->close();
         gQueue->executeCommandBuffer(presentCommandBuffer);
     }
-    // With that, we are done drawing for one frame, and ready for the next.
-    //
-    gSwapchain->present();
+
+    if (!isTestMode())
+    {
+        // With that, we are done drawing for one frame, and ready for the next.
+        //
+        gSwapchain->present();
+    }
 }
 
 };

--- a/source/slang-record-replay/replay/json-consumer.cpp
+++ b/source/slang-record-replay/replay/json-consumer.cpp
@@ -1227,8 +1227,8 @@ namespace SlangRecord
                 _writePair(builder, indent, "this", Slang::StringUtil::makeStringWithFormat("0x%X", objectId));
                 _writePair(builder, indent, "type", Slang::StringUtil::makeStringWithFormat("0x%X", typeId));
                 _writePair(builder, indent, "rules", LayoutRulesToString(rules));
-                _writePair(builder, indent, "outDiagnostics", outDiagnosticsId);
-                _writePairNoComma(builder, indent, "retTypeReflectionId", outTypeLayoutReflectionId);
+                _writePair(builder, indent, "outDiagnostics", Slang::StringUtil::makeStringWithFormat("0x%X", outDiagnosticsId));
+                _writePairNoComma(builder, indent, "retTypeReflectionId", Slang::StringUtil::makeStringWithFormat("0x%X", outTypeLayoutReflectionId));
             }
         }
 

--- a/tools/slang-unit-test/unit-test-record-replay.cpp
+++ b/tools/slang-unit-test/unit-test-record-replay.cpp
@@ -419,7 +419,8 @@ static SlangResult runTests(UnitTestContext* context)
         "cpu-hello-world",
         "triangle",
         "shader-object",
-        "ray-tracing"
+        "ray-tracing",
+        "ray-tracing-pipeline"
     };
 
     SlangResult finalRes = SLANG_OK;

--- a/tools/slang-unit-test/unit-test-record-replay.cpp
+++ b/tools/slang-unit-test/unit-test-record-replay.cpp
@@ -420,7 +420,9 @@ static SlangResult runTests(UnitTestContext* context)
         "triangle",
         "shader-object",
         "ray-tracing",
-        "ray-tracing-pipeline"
+        "ray-tracing-pipeline",
+        "model-viewer",
+        "autodiff-texture"
     };
 
     SlangResult finalRes = SLANG_OK;


### PR DESCRIPTION
Migrate following examples:
  - model-view
  - autodiff-texture
  - ray-tracing-pipeline

and add them into slang-unit-test.

Add more error message in RecordReplay test
