### PR TITLE
Make sure `NullDifferential` and its witness are removed after autodiff.

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2928,6 +2928,9 @@ __attributeTarget(DeclBase)
 attribute_syntax [builtin] : BuiltinAttribute;
 
 __attributeTarget(DeclBase)
+attribute_syntax[__AutoDiffBuiltin] : AutoDiffBuiltinAttribute;
+
+__attributeTarget(DeclBase)
 attribute_syntax [__requiresNVAPI] : RequiresNVAPIAttribute;
 
 __attributeTarget(AggTypeDecl)

--- a/source/slang/diff.meta.slang
+++ b/source/slang/diff.meta.slang
@@ -26,6 +26,7 @@ __attributeTarget(FunctionDeclBase)
 attribute_syntax [NoDiffThis] : NoDiffThisAttribute;
 
 // A 'none-type' that acts as a run-time sentinel for zero differentials.
+[__AutoDiffBuiltin]
 export struct NullDifferential : IDifferentiable
 { 
     // for now, we'll use at least one field to make sure the type is non-empty

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -1171,6 +1171,12 @@ class BuiltinAttribute : public Attribute
 {
     SLANG_AST_CLASS(BuiltinAttribute)
 };
+    
+    /// An attribute that marks a decl as a compiler built-in object for the autodiff system.
+class AutoDiffBuiltinAttribute : public Attribute
+{
+    SLANG_AST_CLASS(AutoDiffBuiltinAttribute)
+};
 
     /// An attribute that defines the size of `AnyValue` type to represent a polymoprhic value that conforms to
     /// the decorated interface type.

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -1177,9 +1177,9 @@ void stripDerivativeDecorations(IRInst* inst)
 
 void stripAutoDiffDecorationsFromChildren(IRInst* parent)
 {
-    bool shouldRemoveKeepAliveDecorations = false;
     for (auto inst : parent->getChildren())
     {
+        bool shouldRemoveKeepAliveDecorations = false;
         for (auto decor = inst->getFirstDecoration(); decor; )
         {
             auto next = decor->getNextDecoration();

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -968,6 +968,9 @@ INST_RANGE(BindingQuery, GetRegisterIndex, GetRegisterSpace)
         /// Decorates a auto-diff transcribed value with the original value that the inst is transcribed from.
     INST(AutoDiffOriginalValueDecoration, AutoDiffOriginalValueDecoration, 1, 0)
 
+        /// Decorates a type as auto-diff builtin type.
+    INST(AutoDiffBuiltinDecoration, AutoDiffBuiltinDecoration, 0, 0)
+
         /// Used by the auto-diff pass to hold a reference to the
         /// generated derivative function.
     INST(ForwardDerivativeDecoration, fwdDerivative, 1, 0)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -4992,6 +4992,11 @@ public:
         addDecoration(value, kIROp_DynamicUniformDecoration);
     }
 
+    void addAutoDiffBuiltinDecoration(IRInst* value)
+    {
+        addDecoration(value, kIROp_AutoDiffBuiltinDecoration);
+    }
+
         /// Add a decoration that indicates that the given `inst` depends on the given `dependency`.
         ///
         /// This decoration can be used to ensure that a value that an instruction

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -8883,6 +8883,8 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         {
             if (as<NonCopyableTypeAttribute>(modifier))
                 subBuilder->addNonCopyableTypeDecoration(irAggType);
+            else if (as<AutoDiffBuiltinAttribute>(modifier))
+                subBuilder->addAutoDiffBuiltinDecoration(irAggType);
         }
      
 

--- a/tests/language-feature/generics/variadic-0.slang
+++ b/tests/language-feature/generics/variadic-0.slang
@@ -2,6 +2,9 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -cpu -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -shaderobj -output-using-type
 
+//TEST:SIMPLE(filecheck=CHECK): -target glsl
+// CHECK-NOT: NullDifferential
+
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 


### PR DESCRIPTION
Closes #4957.

This is to make sure we always remove the `export`/`keepalive` decorations on the builtin `NullDifferential` type regardless of whether autodiff pass is run. To make it easy to identify this type from the linked IR, we add a `[__AutoDiffBuiltin]` attribute so we can easily trigger the logic to remove `export` decoration when we see this decoration.