### PR TITLE
Fix typo SV_DispatchThreadIndex

### DIFF
--- a/tests/ir/factorial.slang
+++ b/tests/ir/factorial.slang
@@ -26,7 +26,7 @@ int factorial(int n)
 
 [numthreads(1, 1, 1)]
 void main(
-    uint tid   : SV_DispatchThreadIndex)
+    uint tid   : SV_DispatchThreadID)
 {
     output[tid] = factorial(input[tid]);
 }

--- a/tests/ir/string-literal-hash-reflection.slang
+++ b/tests/ir/string-literal-hash-reflection.slang
@@ -10,7 +10,7 @@ RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(4, 1, 1)]
 void computeMain(
-    uint tid   : SV_DispatchThreadIndex)
+    uint tid   : SV_DispatchThreadID)
 {
     int value = doSomethingElse() + getStringHash("Hello \t\n\0x083 World");   
     outputBuffer[tid] = value;

--- a/tests/ir/string-literal.slang
+++ b/tests/ir/string-literal.slang
@@ -3,7 +3,7 @@
 // CHECK: global_hashed_string_literals("Hello \t\n\0x083 World")
 [numthreads(1, 1, 1)]
 void main(
-    uint tid   : SV_DispatchThreadIndex)
+    uint tid   : SV_DispatchThreadID)
 {
 	"Hello \t\n\0x083 World";
 }


### PR DESCRIPTION
A correct semantic name is SV_DispatchThreadID with "ID" not "Index". Those tests don't actually run and they haven't caused any problems yet.