### PR TITLE
Add API method to specialize function reference with argument types

### DIFF
--- a/include/slang.h
+++ b/include/slang.h
@@ -2588,6 +2588,7 @@ extern "C"
     SLANG_API SlangReflectionType* spReflectionFunction_GetResultType(SlangReflectionFunction* func);
     SLANG_API SlangReflectionGeneric* spReflectionFunction_GetGenericContainer(SlangReflectionFunction* func);
     SLANG_API SlangReflectionFunction* spReflectionFunction_applySpecializations(SlangReflectionFunction* func, SlangReflectionGeneric* generic);
+    SLANG_API SlangReflectionFunction* spReflectionFunction_specializeWithArgTypes(SlangReflectionFunction* func, SlangInt argTypeCount, SlangReflectionType* const* argTypes);
 
     // Abstract Decl Reflection
 
@@ -3585,6 +3586,11 @@ namespace slang
         FunctionReflection* applySpecializations(GenericReflection* generic)
         {
             return (FunctionReflection*)spReflectionFunction_applySpecializations((SlangReflectionFunction*)this, (SlangReflectionGeneric*)generic);
+        }
+
+        FunctionReflection* specializeWithArgTypes(unsigned int argCount, TypeReflection* const* types)
+        {
+            return (FunctionReflection*)spReflectionFunction_specializeWithArgTypes((SlangReflectionFunction*)this, argCount, (SlangReflectionType* const*)types);
         }
     };
 

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -1510,7 +1510,7 @@ namespace Slang
             outGenericArgs.add(argExpr);
         }
     }
-
+    
     Type* Linkage::specializeType(
         Type*           unspecializedType,
         Int             argCount,

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -2168,6 +2168,11 @@ namespace Slang
             DeclRef<Decl>                       declRef,
             List<Expr*>                         argExprs,
             DiagnosticSink*                     sink);
+        
+        DeclRef<Decl> specializeWithArgTypes(
+            DeclRef<Decl>   funcDeclRef,
+            List<Type*>         argTypes,
+            DiagnosticSink*     sink);
 
         DiagnosticSink::Flags diagnosticSinkFlags = 0;
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -1370,10 +1370,6 @@ DeclRef<Decl> Linkage::specializeWithArgTypes(
     List<Type*>         argTypes,
     DiagnosticSink*     sink)
 {
-
-    // TODO: We should cache and re-use specialized types
-    // when the exact same arguments are provided again later.
-
     SharedSemanticsContext sharedSemanticsContext(this, nullptr, sink);
     SemanticsVisitor visitor(&sharedSemanticsContext);
 


### PR DESCRIPTION
- Adds `FunctionReflection::specializeWithArgTypes()`
- Fixes an issue with `findFunctionByName` returning a reference to a generic instead of a function-decl.