### PR TITLE
Fix extension override behavior, and disallow extension on interface types.

### DIFF
--- a/docs/user-guide/03-convenience-features.md
+++ b/docs/user-guide/03-convenience-features.md
@@ -611,13 +611,6 @@ This feature is similar to extensions in Swift and partial classes in C#.
 > #### Note:
 > You can only extend a type with additional methods. Extending with additional data fields is not allowed.
 
-Note that `interface` types cannot be extended, because extending an `interface` with new requirements would make all existing types that conforms
-to the interface no longer valid. However, Slang allows generic extensions, so the following is valid:
-```
-// Provide additional methods for all types that conforms to `IFoo`.
-extension<T:IFoo> T {...}
-```
-
 Multi-level break
 -------------------
 

--- a/docs/user-guide/03-convenience-features.md
+++ b/docs/user-guide/03-convenience-features.md
@@ -611,6 +611,13 @@ This feature is similar to extensions in Swift and partial classes in C#.
 > #### Note:
 > You can only extend a type with additional methods. Extending with additional data fields is not allowed.
 
+Note that `interface` types cannot be extended, because extending an `interface` with new requirements would make all existing types that conforms
+to the interface no longer valid. However, Slang allows generic extensions, so the following is valid:
+```
+// Provide additional methods for all types that conforms to `IFoo`.
+extension<T:IFoo> T {...}
+```
+
 Multi-level break
 -------------------
 

--- a/docs/user-guide/06-interfaces-generics.md
+++ b/docs/user-guide/06-interfaces-generics.md
@@ -626,7 +626,6 @@ extension MyObject : IBar, IBar2
 }
 ```
 
-
 `is` and `as` Operator
 ----------------------------
 
@@ -780,9 +779,10 @@ interface IFoo
     int foo();
 }
 
-// Direct extension on MyObject:
-struct MyObject : IBase
+// MyObject directly implements IBase:
+struct MyObject : IBase, IFoo
 {
+    int foo() { return 0; }
 }
 
 // Generic extension that applies to all types that conforms to `IBase`:
@@ -800,7 +800,7 @@ int test()
 {
     MyObject obj;
 
-    // Returns 0, the conformance defined by the direct extension
+    // Returns 0, the conformance defined directly by the type
     // is preferred.
     return helper(obj);
 }

--- a/docs/user-guide/06-interfaces-generics.md
+++ b/docs/user-guide/06-interfaces-generics.md
@@ -626,6 +626,52 @@ extension MyObject : IBar, IBar2
 }
 ```
 
+Note that `interface` types cannot be extended, because extending an `interface` with new requirements would make all existing types that conforms
+to the interface no longer valid. However, Slang allows generic extensions, so the following is valid:
+
+```
+// Provide additional methods for all types that conforms to `IFoo`,
+// so that they also conform to 'IBar'.
+extension<T:IFoo> T : IBar {...}
+```
+
+In the presence of extensions, it is possible for a type to have multiple ways to 
+conform to an interface. In this case, Slang will always prefer the more specific conformance
+over the generic one. For example, the following code illustrates this behavior:
+
+```csharp
+interface IBase{}
+interface IFoo
+{
+    int foo();
+}
+
+// Direct extension on MyObject:
+struct MyObject : IBase
+{
+}
+
+// Generic extension that applies to all types that conforms to `IBase`:
+extension<T:IBase> T : IFoo
+{
+    int foo() { return 1; }
+}
+
+int helper<T:IFoo>(T obj)
+{
+    return obj.foo();
+}
+
+int test()
+{
+    MyObject obj;
+
+    // Returns 0, the conformance defined by the direct extension
+    // is preferred.
+    return helper(obj);
+}
+```
+
 `is` and `as` Operator
 ----------------------------
 

--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -83,14 +83,20 @@ namespace Slang
         Type*                   interfaceType)
     {
         // The most basic test here should be: does the type declare conformance to the trait.
-        if (isSubtype(type, interfaceType, constraints->additionalSubtypeWitnesses ? IsSubTypeOptions::NoCaching : IsSubTypeOptions::None))
-            return type;
-
-        // If additional subtype witnesses are provided for `type` in `constraints`,
-        // try to use them to see if the interface is satisfied.
+       
         if (constraints->subTypeForAdditionalWitnesses == type)
         {
+            // If additional subtype witnesses are provided for `type` in `constraints`,
+            // try to use them to see if the interface is satisfied.
             if (constraints->additionalSubtypeWitnesses->containsKey(interfaceType))
+                return type;
+        }
+        else
+        {
+            if (isSubtype(
+                type,
+                interfaceType,
+                constraints->additionalSubtypeWitnesses ? IsSubTypeOptions::NoCaching : IsSubTypeOptions::None))
                 return type;
         }
 
@@ -653,18 +659,22 @@ namespace Slang
             }
 
             // Search for a witness that shows the constraint is satisfied.
-            auto subTypeWitness = isSubtype(
-                sub,
-                sup,
-                system->additionalSubtypeWitnesses ? IsSubTypeOptions::NoCaching : IsSubTypeOptions::None);
-            if (!subTypeWitness)
+            SubtypeWitness* subTypeWitness = nullptr;
+            if (sub == system->subTypeForAdditionalWitnesses)
             {
-                if (sub == system->subTypeForAdditionalWitnesses)
-                {
-                    // If no witness was found, try to find the witness from additional witness.
-                    system->additionalSubtypeWitnesses->tryGetValue(sup, subTypeWitness);
-                }
+                // If we are trying to find the subtype info for a type whose inheritance info is
+                // being calculated, use what we have already known about the type.
+                system->additionalSubtypeWitnesses->tryGetValue(sup, subTypeWitness);
             }
+            else
+            {
+                // The general case is to initiate a subtype query.
+                subTypeWitness = isSubtype(
+                    sub,
+                    sup,
+                    system->additionalSubtypeWitnesses ? IsSubTypeOptions::NoCaching : IsSubTypeOptions::None);
+            }
+
             if(subTypeWitness)
             {
                 // We found a witness, so it will become an (implicit) argument.

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -8246,7 +8246,12 @@ namespace Slang
         if (auto targetDeclRefType = as<DeclRefType>(decl->targetType))
         {
             // Attach our extension to that type as a candidate...
-            if (auto aggTypeDeclRef = targetDeclRefType->getDeclRef().as<AggTypeDecl>())
+            if (targetDeclRefType->getDeclRef().as<InterfaceDecl>())
+            {
+                getSink()->diagnose(decl->targetType.exp, Diagnostics::invalidExtensionOnInterface, decl->targetType);
+                return;
+            }
+            else if (auto aggTypeDeclRef = targetDeclRefType->getDeclRef().as<AggTypeDecl>())
             {
                 auto aggTypeDecl = aggTypeDeclRef.getDecl();
 
@@ -8303,6 +8308,7 @@ namespace Slang
         // to extend.
         //
         decl->targetType = CheckProperType(decl->targetType);
+
         _validateExtensionDeclTargetType(decl);
 
         _validateExtensionDeclMembers(decl);
@@ -9188,13 +9194,13 @@ namespace Slang
                 // look up extensions based on what would be visible to that
                 // module.
                 //
-                // We need to consider the extensions declared in the module itself,
+                // Extensions declared in the module itself should have already
+                // been registered when we check them, but we still need to bring
                 // along with everything the module imported.
                 //
                 // Note: there is an implicit assumption here that the `importedModules`
                 // member on the `SharedSemanticsContext` is accurate in this case.
                 //
-                _addCandidateExtensionsFromModule(m_module->getModuleDecl());
                 for( auto moduleDecl : this->importedModulesList )
                 {
                     _addCandidateExtensionsFromModule(moduleDecl);

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -554,6 +554,7 @@ DIAGNOSTIC(30832, Error, invalidTypeForInheritance, "type '$0' cannot be used fo
 
 DIAGNOSTIC(30850, Error, invalidExtensionOnType, "type '$0' cannot be extended. `extension` can only be used to extend a nominal type.")
 DIAGNOSTIC(30851, Error, invalidMemberTypeInExtension, "$0 cannot be a part of an `extension`")
+DIAGNOSTIC(30852, Error, invalidExtensionOnInterface, "cannot extend interface type '$0'. consider using a generic extension: `extension<T:$0> T {...}`.")
 
 // 309xx: subscripts
 DIAGNOSTIC(30900, Error, multiDimensionalArrayNotSupported, "multi-dimensional array is not supported.")

--- a/tests/diagnostics/interfaces/interface-extension.slang
+++ b/tests/diagnostics/interfaces/interface-extension.slang
@@ -1,0 +1,10 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):-target cpp -stage compute -entry main -disable-specialization
+
+interface IFoo{}
+
+
+// CHECK: ([[# @LINE+1]]): error 30852
+extension IFoo
+{
+    int f() { return 0; }
+}

--- a/tests/language-feature/extensions/extension-override.slang
+++ b/tests/language-feature/extensions/extension-override.slang
@@ -1,0 +1,65 @@
+// Test that the override behavior around extensions and generic extensions works as expected.
+
+// When there are multiple ways for a type to conform to an interface, then the expected behavior
+// is that:
+// 1. If the type directly implements an interface, use that conformance.
+// 2. Otherwise, if there is a direct extension on the type that makes it conform to the interface, use that
+//    extension.
+// 3. Otherwise, if there is a generic extension that makes the type conform to the interface, use that.
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj
+interface IFoo
+{
+    int getVal();
+}
+
+interface IBar
+{
+    int getValPlusOne();
+}
+
+interface IBaz
+{
+    int getValPlusTwo();
+}
+
+struct MyInt
+{
+    int v;
+}
+
+extension MyInt : IFoo
+{
+    int getVal() { return v; }
+}
+
+extension MyInt : IBar
+{
+    int getValPlusOne() { return this.getVal() + 2; }
+}
+
+extension<T: IFoo> T : IBar
+{
+    int getValPlusOne() { return this.getVal() + 1; }
+}
+
+int helper1<T:IBar>(T v){ return v.getValPlusOne();}
+int helper2<T:IFoo>(T v){ return v.getValPlusOne();}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    MyInt v = {1};
+
+    // CHECK: 3
+    outputBuffer[0] = v.getValPlusOne(); // should call MyInt::ext::getValPlusOne();
+
+    // CHECK: 3
+    outputBuffer[1] = helper1(v); // should call MyInt::ext::getValPlusOne();
+
+    // CHECK: 2
+    outputBuffer[2] = helper2(v); // should call T::ext::getValPlusOne();
+}


### PR DESCRIPTION
With `extension<T:IFoo> T` supported, this PR disallows the ill-defined `extension IFoo` syntax.

This is a technically breaking change, but we must clean up this part of the language before more widespread use of this problematic feature.

Also added a test to make sure the overriding behavior of extensions are correct.

## Breaking Change:

`extension IFoo {}` where `IFoo` is an interface type will now result in a compile time error. This kind of code should always be written as `extension<T:IFoo> T` in the future.