### PR TITLE
Preserve name in DeclRefExpr for correct highlighitng of `This`.

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1991,7 +1991,7 @@ namespace Slang
         {
             auto* invoke = visitor->getASTBuilder()->create<InvokeExpr>();
             auto member = visitor->getASTBuilder()->getMemberDeclRef(declRefType->getDeclRef(), defaultCtor);
-            invoke->functionExpr = visitor->ConstructDeclRefExpr(member, nullptr, defaultCtor->loc, nullptr);
+            invoke->functionExpr = visitor->ConstructDeclRefExpr(member, nullptr, defaultCtor->getName(), defaultCtor->loc, nullptr);
             return invoke;
         }
         else
@@ -10097,7 +10097,7 @@ namespace Slang
         // aggregate type, we want to form a full declref with default arguments.
         declRef = createDefaultSubstitutionsIfNeeded(astBuilder, visitor, declRef);
 
-        auto declRefExpr = visitor->ConstructDeclRefExpr(declRef, nullptr, derivativeOfAttr->loc, nullptr);
+        auto declRefExpr = visitor->ConstructDeclRefExpr(declRef, nullptr, declRef.getName(), derivativeOfAttr->loc, nullptr);
         declRefExpr->type.type = nullptr;
         derivativeAttr->args.add(declRefExpr);
         derivativeAttr->funcExpr = declRefExpr;

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -326,10 +326,11 @@ namespace Slang
     }
 
     DeclRefExpr* SemanticsVisitor::ConstructDeclRefExpr(
-        DeclRef<Decl>   declRef,
-        Expr*    baseExpr,
+        DeclRef<Decl> declRef,
+        Expr* baseExpr,
+        Name* name,
         SourceLoc loc,
-        Expr*    originalExpr)
+        Expr* originalExpr)
     {
         // Compute the type that this declaration reference will have in context.
         //
@@ -382,7 +383,7 @@ namespace Slang
                 expr->loc = loc;
                 expr->type = type;
                 expr->baseExpression = baseExpr;
-                expr->name = declRef.getName();
+                expr->name = name;
                 expr->declRef = declRef;
                 expr->memberOperatorLoc = _getMemberOpLoc(originalExpr);
                 return expr;
@@ -399,7 +400,7 @@ namespace Slang
                 expr->loc = loc;
                 expr->type = type;
                 expr->baseExpression = baseTypeExpr;
-                expr->name = declRef.getName();
+                expr->name = name;
                 expr->declRef = declRef;
                 expr->memberOperatorLoc = _getMemberOpLoc(originalExpr);
                 return expr;
@@ -413,7 +414,7 @@ namespace Slang
                 expr->loc = loc;
                 expr->type = type;
                 expr->baseExpression = baseExpr;
-                expr->name = declRef.getName();
+                expr->name = name;
                 expr->declRef = declRef;
                 expr->memberOperatorLoc = _getMemberOpLoc(originalExpr);
 
@@ -464,7 +465,7 @@ namespace Slang
             //
             auto expr = m_astBuilder->create<VarExpr>();
             expr->loc = loc;
-            expr->name = declRef.getName();
+            expr->name = name;
             expr->type = type;
             expr->declRef = declRef;
             // Keep a reference to the original expr if it was a genericApp/member.
@@ -666,13 +667,15 @@ namespace Slang
         return ConstructDeclRefExpr(
             synthDeclMemberRef,
             nullptr,
+            item.declRef.getName(),
             originalExpr ? originalExpr->loc : SourceLoc(),
             originalExpr);
     }
 
     Expr* SemanticsVisitor::ConstructLookupResultExpr(
         LookupResultItem const& item,
-        Expr*            baseExpr,
+        Expr* baseExpr,
+        Name* name,
         SourceLoc loc,
         Expr* originalExpr)
     {
@@ -696,7 +699,7 @@ namespace Slang
             switch (breadcrumb->kind)
             {
             case LookupResultItem::Breadcrumb::Kind::Member:
-                bb = ConstructDeclRefExpr(breadcrumb->declRef, bb, loc, originalExpr);
+                bb = ConstructDeclRefExpr(breadcrumb->declRef, bb, name, loc, originalExpr);
                 break;
 
             case LookupResultItem::Breadcrumb::Kind::Deref:
@@ -827,7 +830,7 @@ namespace Slang
             }
         }
 
-        return ConstructDeclRefExpr(item.declRef, bb, loc, originalExpr);
+        return ConstructDeclRefExpr(item.declRef, bb, name, loc, originalExpr);
     }
 
     void SemanticsVisitor::suggestCompletionItems(
@@ -844,9 +847,9 @@ namespace Slang
 
 
     Expr* SemanticsVisitor::createLookupResultExpr(
-        Name*                   name,
-        LookupResult const&     lookupResult,
-        Expr*            baseExpr,
+        Name* name,
+        LookupResult const& lookupResult,
+        Expr* baseExpr,
         SourceLoc loc,
         Expr* originalExpr)
     {
@@ -864,7 +867,7 @@ namespace Slang
         }
         else
         {
-            return ConstructLookupResultExpr(lookupResult.item, baseExpr, loc, originalExpr);
+            return ConstructLookupResultExpr(lookupResult.item, baseExpr, name, loc, originalExpr);
         }
     }
 
@@ -1058,7 +1061,7 @@ namespace Slang
             // expression.
             //
             return ConstructLookupResultExpr(
-                lookupResult.item, overloadedExpr->base, overloadedExpr->loc, overloadedExpr);
+                lookupResult.item, overloadedExpr->base, overloadedExpr->name, overloadedExpr->loc, overloadedExpr);
         }
 
         // Otherwise, we weren't able to resolve the overloading given
@@ -1166,6 +1169,7 @@ namespace Slang
                     auto diffTypeExpr = ConstructLookupResultExpr(
                         diffTypeLookupResult.item,
                         baseTypeExpr,
+                        declRefType->getDeclRef().getName(),
                         declRefType->getDeclRef().getLoc(),
                         baseTypeExpr);
 
@@ -3145,6 +3149,7 @@ namespace Slang
             {
                 auto lookupResultExpr = semantics->ConstructLookupResultExpr(item,
                     nullptr,
+                    overloadedExpr->name,
                     overloadedExpr->loc,
                     nullptr);
                 auto candidateExpr = actions->createHigherOrderInvokeExpr(semantics);

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1219,10 +1219,11 @@ namespace Slang
         }
 
         DeclRefExpr* ConstructDeclRefExpr(
-            DeclRef<Decl>   declRef,
-            Expr*    baseExpr,
+            DeclRef<Decl> declRef,
+            Expr* baseExpr,
+            Name* name,
             SourceLoc loc,
-            Expr*    originalExpr);
+            Expr* originalExpr);
 
         Expr* ConstructDerefExpr(
             Expr*    base,
@@ -1236,16 +1237,17 @@ namespace Slang
 
         Expr* ConstructLookupResultExpr(
             LookupResultItem const& item,
-            Expr*            baseExpr,
+            Expr* baseExpr,
+            Name* name,
             SourceLoc loc,
             Expr* originalExpr);
 
         Expr* createLookupResultExpr(
-            Name*                   name,
-            LookupResult const&     lookupResult,
-            Expr*            baseExpr,
+            Name* name,
+            LookupResult const& lookupResult,
+            Expr* baseExpr,
             SourceLoc loc,
-            Expr*    originalExpr);
+            Expr* originalExpr);
 
         DeclVisibility getTypeVisibility(Type* type);
         bool isDeclVisibleFromScope(DeclRef<Decl> declRef, Scope* scope);

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -983,6 +983,7 @@ namespace Slang
         return ConstructDeclRefExpr(
             innerDeclRef,
             base,
+            innerDeclRef.getName(),
             originalExpr->loc,
             originalExpr);
     }
@@ -1037,6 +1038,7 @@ namespace Slang
                 baseExpr = ConstructLookupResultExpr(
                     candidate.item,
                     context.baseExpr,
+                    candidate.item.declRef.getName(),
                     context.funcLoc,
                     context.originalExpr);
                 break;
@@ -2173,7 +2175,7 @@ namespace Slang
                 if (lastInner)
                 {
                     auto baseExpr = GetBaseExpr(funcDeclRefExpr);
-                    lastInner->baseFunction = ConstructLookupResultExpr(candidate.item, baseExpr, funcDeclRefExpr->loc, funcDeclRefExpr);
+                    lastInner->baseFunction = ConstructLookupResultExpr(candidate.item, baseExpr, funcDeclRefExpr->name, funcDeclRefExpr->loc, funcDeclRefExpr);
                 }
                 candidate.exprVal = expr;
                 expr->type.type = diffFuncType;

--- a/source/slang/slang-language-server-semantic-tokens.cpp
+++ b/source/slang/slang-language-server-semantic-tokens.cpp
@@ -50,7 +50,7 @@ List<SemanticToken> getSemanticTokens(Linkage* linkage, Module* module, UnownedS
             token.type != SemanticTokenType::NormalText)
             result.add(token);
     };
-    auto handleDeclRef = [&](DeclRef<Decl> declRef, Expr* originalExpr, SourceLoc loc)
+    auto handleDeclRef = [&](DeclRef<Decl> declRef, Expr* originalExpr, Name* name, SourceLoc loc)
     {
         if (!declRef)
             return;
@@ -59,7 +59,8 @@ List<SemanticToken> getSemanticTokens(Linkage* linkage, Module* module, UnownedS
             decl = genDecl->inner;
         if (!decl)
             return;
-        auto name = declRef.getDecl()->getName();
+        if (!name)
+            name = declRef.getDecl()->getName();
         if (!name)
             return;
         // Don't look at the expr if it is defined in a different file.
@@ -134,13 +135,13 @@ List<SemanticToken> getSemanticTokens(Linkage* linkage, Module* module, UnownedS
         {
             if (auto declRefExpr = as<DeclRefExpr>(node))
             {
-                handleDeclRef(declRefExpr->declRef, declRefExpr->originalExpr, declRefExpr->loc);
+                handleDeclRef(declRefExpr->declRef, declRefExpr->originalExpr, declRefExpr->name, declRefExpr->loc);
             }
             else if (auto overloadedExpr = as<OverloadedExpr>(node))
             {
                 if (overloadedExpr->lookupResult2.items.getCount())
                 {
-                    handleDeclRef(overloadedExpr->lookupResult2.items[0].declRef, overloadedExpr->originalExpr, overloadedExpr->loc);
+                    handleDeclRef(overloadedExpr->lookupResult2.items[0].declRef, overloadedExpr->originalExpr, overloadedExpr->name, overloadedExpr->loc);
                 }
             }
             else if (auto accessorDecl = as<AccessorDecl>(node))

--- a/tests/language-server/this-type-hover.slang
+++ b/tests/language-server/this-type-hover.slang
@@ -5,7 +5,7 @@ struct G
 
 extension G
 {
-    //HOVER:9,7
+//HOVER:9,7
     This my();
 }
 

--- a/tests/language-server/this-type-hover.slang
+++ b/tests/language-server/this-type-hover.slang
@@ -1,0 +1,12 @@
+//TEST:LANG_SERVER(filecheck=CHECK):
+
+struct G
+{}
+
+extension G
+{
+    //HOVER:9,7
+    This my();
+}
+
+// CHECK: struct G


### PR DESCRIPTION
Closes #4981.

Fix a bug in language server that incorrectly highlights `This` type declref using the token length of the actual type name instead of just highlighting 4 characters.

The fix is to make sure the `name` field of constructed `DeclRefExpr` for the lookup result uses the `name` from the original `VarExpr` instead of the name from the referenced decl.