### PR TITLE
Open existential on arguments after overload resolution.

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -4226,7 +4226,7 @@ namespace Slang
         //
         DiagnosticSink tempSink(getSourceManager(), nullptr);
         ExprLocalScope localScope;
-        SemanticsVisitor subVisitor(withSink(&tempSink).withExprLocalScope(&localScope));
+        SemanticsVisitor subVisitor(withSink(&tempSink).withParentFunc(synFuncDecl).withExprLocalScope(&localScope));
 
         // With our temporary diagnostic sink soaking up any messages
         // from overload resolution, we can now try to resolve

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -2238,7 +2238,6 @@ namespace Slang
 
         // Look at the base expression for the call, and figure out how to invoke it.
         auto funcExpr = expr->functionExpr;
-        auto funcExprType = funcExpr->type;
 
         // If we are trying to apply an erroneous expression, then just bail out now.
         if(IsErrorExpr(funcExpr))
@@ -2267,26 +2266,6 @@ namespace Slang
         for (auto& arg : expr->arguments)
         {
             arg = maybeOpenRef(arg);
-        }
-
-        auto funcType = as<FuncType>(funcExprType);
-        for (Index i = 0; i < expr->arguments.getCount(); i++)
-        {
-            auto& arg = expr->arguments[i];
-            if (funcType && i < funcType->getParamCount())
-            {
-                switch (funcType->getParamDirection(i))
-                {
-                case kParameterDirection_Out:
-                case kParameterDirection_InOut:
-                case kParameterDirection_Ref:
-                case kParameterDirection_ConstRef:
-                    continue;
-                default:
-                    break;
-                }
-            }
-            arg = maybeOpenExistential(arg);
         }
 
         context.originalExpr = expr;
@@ -2415,6 +2394,40 @@ namespace Slang
             // the user the most help we can.
             if (shouldAddToCache)
                 typeCheckingCache->resolvedOperatorOverloadCache[key] = *context.bestCandidate;
+            auto funcType = context.bestCandidate->funcType;
+            ShortList<ParameterDirection> paramDirections;
+            if (funcType)
+            {
+                for (Index i = 0; i < funcType->getParamCount(); i++)
+                {
+                    paramDirections.add(funcType->getParamDirection(i));
+                }
+            }
+            else if (auto callableDeclRef = context.bestCandidate->item.declRef.as<CallableDecl>())
+            {
+                for (auto param : callableDeclRef.getDecl()->getMembersOfType<ParamDecl>())
+                {
+                    paramDirections.add(getParameterDirection(param));
+                }
+            }
+            for (Index i = 0; i < expr->arguments.getCount(); i++)
+            {
+                auto& arg = expr->arguments[i];
+                if (i < paramDirections.getCount())
+                {
+                    switch (paramDirections[i])
+                    {
+                    case kParameterDirection_Out:
+                    case kParameterDirection_InOut:
+                    case kParameterDirection_Ref:
+                    case kParameterDirection_ConstRef:
+                        continue;
+                    default:
+                        break;
+                    }
+                }
+                arg = maybeOpenExistential(arg);
+            }
             return CompleteOverloadCandidate(context, *context.bestCandidate);
         }
 
@@ -2447,7 +2460,7 @@ namespace Slang
 
         // Nothing at all was found that we could even consider invoking.
         // In all other cases, this is an error.
-        getSink()->diagnose(expr->functionExpr, Diagnostics::expectedFunction, funcExprType);
+        getSink()->diagnose(expr->functionExpr, Diagnostics::expectedFunction, funcExpr->type);
         expr->type = QualType(m_astBuilder->getErrorType());
         return expr;
     }

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -2410,7 +2410,7 @@ namespace Slang
             }
             else if (auto callableDeclRef = context.bestCandidate->item.declRef.as<CallableDecl>())
             {
-                for (auto param : callableDeclRef.getDecl()->getMembersOfType<ParamDecl>())
+                for (auto param : callableDeclRef.getDecl()->getParameters())
                 {
                     paramDirections.add(getParameterDirection(param));
                 }

--- a/tests/bugs/gh-4467.slang
+++ b/tests/bugs/gh-4467.slang
@@ -1,0 +1,43 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHK): -d3d12 -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHK): -vk -compute -shaderobj -output-using-type
+
+
+// Test that we can synthesize a [mutating] interface requirement from a nonmutating implementation,
+// and the interface requirement signature contains an output interface-typed parameter.
+
+//TEST_INPUT: ubuffer(data=[0 0], stride=4):out,name outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+interface IFoo
+{
+    int getVal();
+};
+
+interface IBar
+{
+    [mutating] void method(out IFoo o);
+};
+
+struct FooImpl : IFoo
+{
+    int x;
+    int getVal() { return x; }
+}
+
+struct BarImpl : IBar
+{
+    void method(out IFoo o)
+    {
+        o = FooImpl(1);
+    }
+};
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    BarImpl bar;
+    IFoo foo;
+    bar.method(foo);
+    // CHK: 1
+    outputBuffer[0] = foo.getVal();
+}


### PR DESCRIPTION
Closes #4467.

The problem revealed here is that in `ResolveInvoke` we are performing `openExistential` on arguments before resolving overloaded callees. This is needed in order to correctly resolve generic arguments for generic callees. However we can't always us the opened existential value as argument if the parameter is mutable.

So the fix here is to switch back to original argument expr after an overload candidate is picked and we can figure out the corresponding parameter is a mutable one.