### PR TITLE
Add Path::removeNonEmpty() to remove non-empty dir

### DIFF
--- a/source/core/slang-io.h
+++ b/source/core/slang-io.h
@@ -217,6 +217,11 @@ namespace Slang
             /// @return SLANG_OK if file or directory is removed
         static SlangResult remove(const String& path);
 
+            /// Remove a file or directory at specified path. The directory can be non-empty.
+            /// @param path
+            /// @return SLANG_OK if file or directory is removed
+        static SlangResult removeNonEmpty(const String& path);
+
         static bool equals(String path1, String path2);
 
             /// Turn `path` into a relative path from base.


### PR DESCRIPTION
We've implemented a function in slang-record-replay unit test to remove the non-empty directory, now move this function into slang `Path` namespace to make this function as an utility.

Close issue #4916