### PR TITLE
Fix resource specialization with `-embed-dxil`

### DIFF
--- a/source/slang/slang-ir-specialize-resources.cpp
+++ b/source/slang/slang-ir-specialize-resources.cpp
@@ -248,7 +248,11 @@ struct ResourceOutputSpecializationPass
             newFunc->removeAndDeallocate();
             // Check if `oldFunc` is the reason for failing,
             // Otherwise don't add to 'unspecializableFuncs'
-            if(result == SpecializeFuncResult::ThisFuncFailed)
+            //
+            // Ensure oldFunc has uses, else, there is nothing to specialize here.
+            // If oldFunc has IRKeepAlive, this code should be assumed to have a 
+            // "dynamic" resource value.
+            if(result == SpecializeFuncResult::ThisFuncFailed && oldFunc->hasUses())
                 unspecializableFuncs->add(oldFunc);
             return false;
         }

--- a/source/slang/slang-ir-specialize-resources.cpp
+++ b/source/slang/slang-ir-specialize-resources.cpp
@@ -315,6 +315,10 @@ struct ResourceOutputSpecializationPass
             specializeCallSite(oldCall, newFunc, funcInfo);
         }
         specializedFuncs.add(oldFunc);
+
+        // Since we can no longer fail and we are replacing all `Func` uses, 'KeepAlive'
+        // can be removed from the oldFunc so DCE can it clean-up.
+        oldFunc->findDecoration<IRKeepAliveDecoration>()->removeAndDeallocate();
         return true;
     }
 

--- a/source/slang/slang-ir-specialize-resources.cpp
+++ b/source/slang/slang-ir-specialize-resources.cpp
@@ -248,8 +248,6 @@ struct ResourceOutputSpecializationPass
             newFunc->removeAndDeallocate();
             // Check if `oldFunc` is the reason for failing,
             // Otherwise don't add to 'unspecializableFuncs'
-            //
-            // Don't continue to try and specialize unused functions, these won't emit in IR
             if(result == SpecializeFuncResult::ThisFuncFailed)
                 unspecializableFuncs->add(oldFunc);
             return false;

--- a/source/slang/slang-ir-specialize-resources.cpp
+++ b/source/slang/slang-ir-specialize-resources.cpp
@@ -248,6 +248,8 @@ struct ResourceOutputSpecializationPass
             newFunc->removeAndDeallocate();
             // Check if `oldFunc` is the reason for failing,
             // Otherwise don't add to 'unspecializableFuncs'
+            //
+            // Don't continue to try and specialize unused functions, these won't emit in IR
             if(result == SpecializeFuncResult::ThisFuncFailed)
                 unspecializableFuncs->add(oldFunc);
             return false;
@@ -318,7 +320,8 @@ struct ResourceOutputSpecializationPass
 
         // Since we can no longer fail and we are replacing all `Func` uses, 'KeepAlive'
         // can be removed from the oldFunc so DCE can it clean-up.
-        oldFunc->findDecoration<IRKeepAliveDecoration>()->removeAndDeallocate();
+        if(auto keepAliveDecoration = oldFunc->findDecoration<IRKeepAliveDecoration>())
+            keepAliveDecoration->removeAndDeallocate();
         return true;
     }
 

--- a/tests/library/precompiled-module-library-resource.slang
+++ b/tests/library/precompiled-module-library-resource.slang
@@ -9,6 +9,9 @@ module "precompiled-module-library-resource";
 
 public struct ResourceStruct {
     public StructuredBuffer<int> buffer;
+    void funcInoutResource(out StructuredBuffer<int> bufferIn)
+    {
+    }
 };
 
 public int resource_in_parameter(StructuredBuffer<int> buffer)

--- a/tests/library/precompiled-module-library-resource.slang
+++ b/tests/library/precompiled-module-library-resource.slang
@@ -9,8 +9,10 @@ module "precompiled-module-library-resource";
 
 public struct ResourceStruct {
     public StructuredBuffer<int> buffer;
-    void funcInoutResource(out StructuredBuffer<int> bufferIn)
+    
+    __init(StructuredBuffer<int> bufferIn)
     {
+        buffer = bufferIn;
     }
 };
 


### PR DESCRIPTION
fixes: #4989

Changes:
1. Before handing off to DCE an `oldFunc` which should be removed, clean up any leftover `IRKeepAliveDecoration` (else DCE won't remove our `oldFunc`s)