### PR TITLE
Respect matrix layout in uniform and in/out parameters for HLSL target.

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -93,7 +93,7 @@ namespace Slang
         void checkDerivativeMemberAttributeParent(VarDeclBase* varDecl, DerivativeMemberAttribute* attr);
         void checkExtensionExternVarAttribute(VarDeclBase* varDecl, ExtensionExternVarModifier* m);
         void checkMeshOutputDecl(VarDeclBase* varDecl);
-
+        void maybeApplyMatrixLayoutModifier(VarDeclBase* varDecl);
         void checkVarDeclCommon(VarDeclBase* varDecl);
 
         void visitVarDecl(VarDecl* varDecl)
@@ -1516,6 +1516,22 @@ namespace Slang
             }
         }
     }
+    void SemanticsDeclHeaderVisitor::maybeApplyMatrixLayoutModifier(VarDeclBase* varDecl)
+    {
+        if (auto matrixType = as<MatrixExpressionType>(varDecl->type.type))
+        {
+            if (auto matrixLayoutModifier = varDecl->findModifier<MatrixLayoutModifier>())
+            {
+                auto matrixLayout = as<ColumnMajorLayoutModifier>(matrixLayoutModifier) ? SLANG_MATRIX_LAYOUT_COLUMN_MAJOR : SLANG_MATRIX_LAYOUT_ROW_MAJOR;
+                auto newMatrixType = getASTBuilder()->getMatrixType(
+                    matrixType->getElementType(),
+                    matrixType->getRowCount(),
+                    matrixType->getColumnCount(),
+                    getASTBuilder()->getIntVal(getASTBuilder()->getIntType(), matrixLayout));
+                varDecl->type.type = newMatrixType;
+            }
+        }
+    }
 
     void SemanticsDeclHeaderVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
     {
@@ -1598,19 +1614,7 @@ namespace Slang
         }
 
         // If there is a matrix layout modifier, we will modify the matrix type now.
-        if (auto matrixType = as<MatrixExpressionType>(varDecl->type.type))
-        {
-            if (auto matrixLayoutModifier = varDecl->findModifier<MatrixLayoutModifier>())
-            {
-                auto matrixLayout = as<ColumnMajorLayoutModifier>(matrixLayoutModifier) ? SLANG_MATRIX_LAYOUT_COLUMN_MAJOR : SLANG_MATRIX_LAYOUT_ROW_MAJOR;
-                auto newMatrixType = getASTBuilder()->getMatrixType(
-                    matrixType->getElementType(),
-                    matrixType->getRowCount(),
-                    matrixType->getColumnCount(),
-                    getASTBuilder()->getIntVal(getASTBuilder()->getIntType(), matrixLayout));
-                varDecl->type.type = newMatrixType;
-            }
-        }
+        maybeApplyMatrixLayoutModifier(varDecl);
 
         if (varDecl->initExpr)
         {
@@ -7675,6 +7679,8 @@ namespace Slang
                 addModifier(paramDecl, constModifier);
             }
         }
+
+        maybeApplyMatrixLayoutModifier(paramDecl);
 
         // Only texture types are allowed to have memory qualifiers on parameters
         if(!paramDecl->type || paramDecl->type->astNodeType != ASTNodeType::TextureType)

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -3862,7 +3862,7 @@ void CLikeSourceEmitter::emitVarModifiers(IRVarLayout* layout, IRInst* varDecl, 
     if (!layout)
         return;
 
-    emitMatrixLayoutModifiersImpl(layout);
+    emitMatrixLayoutModifiersImpl(varType);
 
     // Target specific modifier output
     emitImageFormatModifierImpl(varDecl, varType);

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -3520,7 +3520,7 @@ void CLikeSourceEmitter::emitParamTypeImpl(IRType* type, String const& name)
     {
         type = constRefType->getValueType();
     }
-
+    emitParamTypeModifier(type);
     emitType(type, name);
 }
 

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -497,7 +497,7 @@ public:
     virtual void emitMeshShaderModifiersImpl(IRInst* varInst) { SLANG_UNUSED(varInst) }
     virtual void emitSimpleTypeImpl(IRType* type) = 0;
     virtual void emitVarDecorationsImpl(IRInst* varDecl) { SLANG_UNUSED(varDecl);  }
-    virtual void emitMatrixLayoutModifiersImpl(IRVarLayout* layout) { SLANG_UNUSED(layout);  }
+    virtual void emitMatrixLayoutModifiersImpl(IRType* varType) { SLANG_UNUSED(varType);  }
     virtual void emitTypeImpl(IRType* type, const StringSliceLoc* nameLoc);
     virtual void emitSimpleValueImpl(IRInst* inst);
     virtual void emitModuleImpl(IRModule* module, DiagnosticSink* sink);

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -505,6 +505,7 @@ public:
     virtual void emitVarExpr(IRInst* inst, EmitOpInfo const& outerPrec);
     virtual void emitOperandImpl(IRInst* inst, EmitOpInfo const& outerPrec);
     virtual void emitParamTypeImpl(IRType* type, String const& name);
+    virtual void emitParamTypeModifier(IRType* type) { SLANG_UNUSED(type); }
     virtual void emitIntrinsicCallExprImpl(IRCall* inst, UnownedStringSlice intrinsicDefinition, IRInst* intrinsicInst, EmitOpInfo const& inOuterPrec);
     virtual void emitFunctionPreambleImpl(IRInst* inst) { SLANG_UNUSED(inst); }
     virtual void emitLoopControlDecorationImpl(IRLoopControlDecoration* decl) { SLANG_UNUSED(decl); }

--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -810,9 +810,9 @@ void CUDASourceEmitter::emitVarDecorationsImpl(IRInst* varDecl)
     Super::emitVarDecorationsImpl(varDecl);
 }
 
-void CUDASourceEmitter::emitMatrixLayoutModifiersImpl(IRVarLayout* layout)
+void CUDASourceEmitter::emitMatrixLayoutModifiersImpl(IRType* varType)
 {
-    Super::emitMatrixLayoutModifiersImpl(layout);
+    Super::emitMatrixLayoutModifiersImpl(varType);
 }
 
 bool CUDASourceEmitter::tryEmitGlobalParamImpl(IRGlobalParam* varDecl, IRType* varType)

--- a/source/slang/slang-emit-cuda.h
+++ b/source/slang/slang-emit-cuda.h
@@ -76,7 +76,7 @@ protected:
     virtual void emitSimpleValueImpl(IRInst* inst) SLANG_OVERRIDE;
     virtual void emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount) SLANG_OVERRIDE;
     virtual void emitVarDecorationsImpl(IRInst* varDecl) SLANG_OVERRIDE;
-    virtual void emitMatrixLayoutModifiersImpl(IRVarLayout* layout) SLANG_OVERRIDE;
+    virtual void emitMatrixLayoutModifiersImpl(IRType* varType) SLANG_OVERRIDE;
     virtual void emitFunctionPreambleImpl(IRInst* inst) SLANG_OVERRIDE;
     virtual void _maybeEmitExportLike(IRInst* inst) SLANG_OVERRIDE { SLANG_UNUSED(inst); }
 

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -2850,28 +2850,28 @@ void GLSLSourceEmitter::emitVarDecorationsImpl(IRInst* varDecl)
 
 }
 
-void GLSLSourceEmitter::emitMatrixLayoutModifiersImpl(IRVarLayout* layout)
+void GLSLSourceEmitter::emitMatrixLayoutModifiersImpl(IRType* varType)
 {
     // When a variable has a matrix type, we want to emit an explicit
     // layout qualifier based on what the layout has been computed to be.
     //
 
-    auto typeLayout = layout->getTypeLayout()->unwrapArray();
+    auto matrixType = as<IRMatrixType>(unwrapArray(varType));
 
-    if (auto matrixTypeLayout = as<IRMatrixTypeLayout>(typeLayout))
+    if (matrixType)
     {
         // Reminder: the meaning of row/column major layout
         // in our semantics is the *opposite* of what GLSL
         // calls them, because what they call "columns"
         // are what we call "rows."
         //
-        switch (matrixTypeLayout->getMode())
+        switch (getIntVal(matrixType->getLayout()))
         {
-            case kMatrixLayoutMode_ColumnMajor:
+            case SLANG_MATRIX_LAYOUT_COLUMN_MAJOR:
                 m_writer->emit("layout(row_major)\n");
                 break;
 
-            case kMatrixLayoutMode_RowMajor:
+            case SLANG_MATRIX_LAYOUT_ROW_MAJOR:
                 m_writer->emit("layout(column_major)\n");
                 break;
         }

--- a/source/slang/slang-emit-glsl.h
+++ b/source/slang/slang-emit-glsl.h
@@ -42,7 +42,7 @@ protected:
     virtual void emitSimpleTypeImpl(IRType* type) SLANG_OVERRIDE;
     virtual void emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount) SLANG_OVERRIDE;
     virtual void emitVarDecorationsImpl(IRInst* varDecl) SLANG_OVERRIDE;
-    virtual void emitMatrixLayoutModifiersImpl(IRVarLayout* layout) SLANG_OVERRIDE;
+    virtual void emitMatrixLayoutModifiersImpl(IRType* varType) SLANG_OVERRIDE;
     virtual void emitTypeImpl(IRType* type, const StringSliceLoc* nameAndLoc) SLANG_OVERRIDE;
     virtual void emitParamTypeImpl(IRType* type, String const& name) SLANG_OVERRIDE;
     virtual void emitFuncDecorationImpl(IRDecoration* decoration) SLANG_OVERRIDE;

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -959,21 +959,6 @@ void HLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
         case kIROp_MatrixType:
         {
             auto matType = (IRMatrixType*)type;
-            auto matrixLayout = getIntVal(matType->getLayout());
-            if (getTargetProgram()->getOptionSet().getMatrixLayoutMode() != (MatrixLayoutMode)matrixLayout)
-            {
-                switch (matrixLayout)
-                {
-                case SLANG_MATRIX_LAYOUT_COLUMN_MAJOR:
-                    m_writer->emit("column_major ");
-                    break;
-                case SLANG_MATRIX_LAYOUT_ROW_MAJOR:
-                    m_writer->emit("row_major ");
-                    break;
-                default:
-                    break;
-                }
-            }
             bool canUseSugar = true;
             switch (matType->getElementType()->getOp())
             {
@@ -1345,8 +1330,24 @@ void HLSLSourceEmitter::emitVarDecorationsImpl(IRInst* varDecl)
 
 void HLSLSourceEmitter::emitMatrixLayoutModifiersImpl(IRType* type)
 {
-    // For HLSL, matrix layout is emitted with type, so no work to do here.
-    SLANG_UNUSED(type);
+    auto matType = as<IRMatrixType>(type);
+    if (!matType)
+        return;
+    auto matrixLayout = getIntVal(matType->getLayout());
+    if (getTargetProgram()->getOptionSet().getMatrixLayoutMode() != (MatrixLayoutMode)matrixLayout)
+    {
+        switch (matrixLayout)
+        {
+        case SLANG_MATRIX_LAYOUT_COLUMN_MAJOR:
+            m_writer->emit("column_major ");
+            break;
+        case SLANG_MATRIX_LAYOUT_ROW_MAJOR:
+            m_writer->emit("row_major ");
+            break;
+        default:
+            break;
+        }
+    }
 }
 
 void HLSLSourceEmitter::handleRequiredCapabilitiesImpl(IRInst* inst)

--- a/source/slang/slang-emit-hlsl.h
+++ b/source/slang/slang-emit-hlsl.h
@@ -46,6 +46,7 @@ protected:
     virtual void emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount) SLANG_OVERRIDE;
     virtual void emitVarDecorationsImpl(IRInst* varDecl) SLANG_OVERRIDE;
     virtual void emitMatrixLayoutModifiersImpl(IRType* varType) SLANG_OVERRIDE;
+    virtual void emitParamTypeModifier(IRType* type) SLANG_OVERRIDE { emitMatrixLayoutModifiersImpl(type); }
 
     virtual bool tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;
     virtual void emitSimpleValueImpl(IRInst* inst) SLANG_OVERRIDE;

--- a/source/slang/slang-emit-hlsl.h
+++ b/source/slang/slang-emit-hlsl.h
@@ -45,7 +45,7 @@ protected:
     virtual void emitSimpleTypeImpl(IRType* type) SLANG_OVERRIDE;
     virtual void emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount) SLANG_OVERRIDE;
     virtual void emitVarDecorationsImpl(IRInst* varDecl) SLANG_OVERRIDE;
-    virtual void emitMatrixLayoutModifiersImpl(IRVarLayout* layout) SLANG_OVERRIDE;
+    virtual void emitMatrixLayoutModifiersImpl(IRType* varType) SLANG_OVERRIDE;
 
     virtual bool tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;
     virtual void emitSimpleValueImpl(IRInst* inst) SLANG_OVERRIDE;

--- a/source/slang/slang-emit-metal.cpp
+++ b/source/slang/slang-emit-metal.cpp
@@ -1091,7 +1091,7 @@ void MetalSourceEmitter::emitVarDecorationsImpl(IRInst* varInst)
     SLANG_UNUSED(varInst);
 }
 
-void MetalSourceEmitter::emitMatrixLayoutModifiersImpl(IRVarLayout*)
+void MetalSourceEmitter::emitMatrixLayoutModifiersImpl(IRType*)
 {
     // Metal only supports column major layout, and we must have
     // already translated all matrix ops to assume column-major

--- a/source/slang/slang-emit-metal.h
+++ b/source/slang/slang-emit-metal.h
@@ -44,7 +44,7 @@ protected:
     virtual void emitParamTypeImpl(IRType* type, String const& name) SLANG_OVERRIDE;
     virtual void emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount) SLANG_OVERRIDE;
     virtual void emitVarDecorationsImpl(IRInst* varDecl) SLANG_OVERRIDE;
-    virtual void emitMatrixLayoutModifiersImpl(IRVarLayout* layout) SLANG_OVERRIDE;
+    virtual void emitMatrixLayoutModifiersImpl(IRType* varType) SLANG_OVERRIDE;
 
     virtual bool tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;
     virtual bool tryEmitInstStmtImpl(IRInst* inst) SLANG_OVERRIDE;

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -610,6 +610,8 @@ struct MetalLayoutRulesImpl : public CPULayoutRulesImpl
 {
     SimpleLayoutInfo GetVectorLayout(BaseType elementType, SimpleLayoutInfo elementInfo, size_t elementCount) override
     {
+        SLANG_UNUSED(elementType);
+        
         const auto elementSize = elementInfo.size.getFiniteValue();
         auto alignedElementCount = 1 << Math::Log2Ceil(elementCount);
 

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -611,9 +611,9 @@ struct MetalLayoutRulesImpl : public CPULayoutRulesImpl
     SimpleLayoutInfo GetVectorLayout(BaseType elementType, SimpleLayoutInfo elementInfo, size_t elementCount) override
     {
         SLANG_UNUSED(elementType);
-        
+
         const auto elementSize = elementInfo.size.getFiniteValue();
-        auto alignedElementCount = 1 << Math::Log2Ceil(elementCount);
+        auto alignedElementCount = 1 << Math::Log2Ceil((uint32_t)elementCount);
 
         // Metal aligns vectors to 2/4 element boundaries.
         size_t size = elementSize * elementCount;

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -606,6 +606,26 @@ struct CUDALayoutRulesImpl : DefaultLayoutRulesImpl
     }
 };
 
+struct MetalLayoutRulesImpl : public CPULayoutRulesImpl
+{
+    SimpleLayoutInfo GetVectorLayout(BaseType elementType, SimpleLayoutInfo elementInfo, size_t elementCount) override
+    {
+        const auto elementSize = elementInfo.size.getFiniteValue();
+        auto alignedElementCount = 1 << Math::Log2Ceil(elementCount);
+
+        // Metal aligns vectors to 2/4 element boundaries.
+        size_t size = elementSize * elementCount;
+        size_t alignment = alignedElementCount * elementSize;
+
+        SimpleLayoutInfo vectorInfo;
+        vectorInfo.kind = elementInfo.kind;
+        vectorInfo.size = size;
+        vectorInfo.alignment = alignment;
+     
+        return vectorInfo;
+    }
+};
+
 struct HLSLStructuredBufferLayoutRulesImpl : DefaultLayoutRulesImpl
 {
     // HLSL structured buffers drop the restrictions added for constant buffers,
@@ -1696,6 +1716,7 @@ struct MetalArgumentBufferElementLayoutRulesImpl : ObjectLayoutRulesImpl, Defaul
 
 static MetalObjectLayoutRulesImpl kMetalObjectLayoutRulesImpl;
 static MetalArgumentBufferElementLayoutRulesImpl kMetalArgumentBufferElementLayoutRulesImpl;
+static MetalLayoutRulesImpl kMetalLayoutRulesImpl;
 
 LayoutRulesImpl kMetalAnyValueLayoutRulesImpl_ = {
     &kMetalLayoutRulesFamilyImpl,
@@ -1704,7 +1725,7 @@ LayoutRulesImpl kMetalAnyValueLayoutRulesImpl_ = {
 };
 
 LayoutRulesImpl kMetalConstantBufferLayoutRulesImpl_ = {
-    &kMetalLayoutRulesFamilyImpl, & kCPULayoutRulesImpl, &kMetalObjectLayoutRulesImpl,
+    &kMetalLayoutRulesFamilyImpl, & kMetalLayoutRulesImpl, &kMetalObjectLayoutRulesImpl,
 };
 
 LayoutRulesImpl kMetalParameterBlockLayoutRulesImpl_ = {
@@ -1712,7 +1733,7 @@ LayoutRulesImpl kMetalParameterBlockLayoutRulesImpl_ = {
 };
 
 LayoutRulesImpl kMetalStructuredBufferLayoutRulesImpl_ = {
-    &kMetalLayoutRulesFamilyImpl, &kCPULayoutRulesImpl, & kMetalObjectLayoutRulesImpl,
+    &kMetalLayoutRulesFamilyImpl, &kMetalLayoutRulesImpl, & kMetalObjectLayoutRulesImpl,
 };
 
 LayoutRulesImpl kMetalVaryingInputLayoutRulesImpl_ = {

--- a/tests/compute/constant-buffer-memory-packing.slang
+++ b/tests/compute/constant-buffer-memory-packing.slang
@@ -9,12 +9,12 @@
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-mtl -compute
 
-// CPP/Metal/CUDA due to natural layout rules will recieve the following ROW matrix:
+// CPP/CUDA due to natural layout rules will recieve the following ROW matrix:
 // {1,2,3}
 // {0,4,5}
 // {6,0,7}
 
-// GLSL/SPIRV/HLSL with cbuffer layout rules will recieve the following ROW/COL matrix:
+// GLSL/SPIRV/HLSL/Metal with cbuffer layout rules will recieve the following ROW/COL matrix:
 // {1,2,3}
 // {4,5,6}
 // {7,8,9}

--- a/tests/compute/constant-buffer-memory-packing.slang
+++ b/tests/compute/constant-buffer-memory-packing.slang
@@ -3,11 +3,11 @@
 // Metal/CPP/CUDA do not deal with packing currently, different results will occur.
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cpu -compute -xslang -DTARGET_WITHOUT_PACKING
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cuda -compute -xslang -DTARGET_WITHOUT_PACKING
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-mtl -compute -xslang -DTARGET_WITHOUT_PACKING
 
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute -emit-spirv-via-glsl
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-mtl -compute
 
 // CPP/Metal/CUDA due to natural layout rules will recieve the following ROW matrix:
 // {1,2,3}

--- a/tests/compute/constant-buffer-memory-packing.slang
+++ b/tests/compute/constant-buffer-memory-packing.slang
@@ -5,29 +5,29 @@
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cuda -compute -xslang -DTARGET_WITHOUT_PACKING
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-mtl -compute -xslang -DTARGET_WITHOUT_PACKING
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute -emit-spirv-via-glsl
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute
 
-// CPP/Metal/CUDA due to not having memory packing will recieve the following ROW matrix:
+// CPP/Metal/CUDA due to natural layout rules will recieve the following ROW matrix:
 // {1,2,3}
 // {0,4,5}
 // {6,0,7}
 
-// GLSL/SPIRV/HLSL due to having memory packing will recieve the following ROW/COL matrix:
+// GLSL/SPIRV/HLSL with cbuffer layout rules will recieve the following ROW/COL matrix:
 // {1,2,3}
-// {0,4,5}
-// {6,0,7}
+// {4,5,6}
+// {7,8,9}
 
 //TEST_INPUT:cbuffer(data=[1.0 2.0 3.0 0.0  4.0 5.0 6.0 0.0  7.0 8.0 9.0 0]):name matrixTestCBuf1
 ConstantBuffer<row_major float3x3> matrixTestCBuf1;
 
 // CPP/Metal/CUDA due to not having memory packing will recieve the following COL matrix post-transpose:
-// {1,0,8}
-// {4,2,0}
-// {7,5,3}
+// {1,0,6}
+// {2,4,0}
+// {3,5,7}
 
-//TEST_INPUT:cbuffer(data=[1.0 4.0 7.0 0.0  2.0 5.0 8.0 0.0  3.0 6.0 9.0 0.0]):name matrixTestCBuf2
+//TEST_INPUT:cbuffer(data=[1.0 2.0 3.0 0.0  4.0 5.0 6.0 0.0  7.0 8.0 9.0 0]):name matrixTestCBuf2
 ConstantBuffer<column_major float3x3> matrixTestCBuf2;
 
 //TEST_INPUT:cbuffer(data=[1.0 2.0 3.0 0.0  4.0 5.0 6.0 0.0]):name NeedsPadding
@@ -55,34 +55,7 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
     matrixTest2 = matrixTestCBuf2;
 
     output[0] = uint(true
-#ifndef TARGET_WITHOUT_PACKING
-            && floatCheck(matrixTest1[0][0], 1)
-            && floatCheck(matrixTest1[0][1], 2)
-            && floatCheck(matrixTest1[0][2], 3)
-            && floatCheck(matrixTest1[1][0], 4)
-            && floatCheck(matrixTest1[1][1], 5)
-            && floatCheck(matrixTest1[1][2], 6)
-            && floatCheck(matrixTest1[2][0], 7)
-            && floatCheck(matrixTest1[2][1], 8)
-            && floatCheck(matrixTest1[2][2], 9)
-
-            && floatCheck(matrixTest2[0][0], 1)
-            && floatCheck(matrixTest2[0][1], 2)
-            && floatCheck(matrixTest2[0][2], 3)
-            && floatCheck(matrixTest2[1][0], 4)
-            && floatCheck(matrixTest2[1][1], 5)
-            && floatCheck(matrixTest2[1][2], 6)
-            && floatCheck(matrixTest2[2][0], 7)
-            && floatCheck(matrixTest2[2][1], 8)
-            && floatCheck(matrixTest2[2][2], 9)
-
-            && floatCheck(data1[0], 1)
-            && floatCheck(data1[1], 2)
-            && floatCheck(data1[2], 3)
-            && floatCheck(data2[0], 4)
-            && floatCheck(data2[1], 5)
-            && floatCheck(data2[2], 6)
-#else
+#ifdef TARGET_WITHOUT_PACKING
             && floatCheck(matrixTest1[0][0], 1)
             && floatCheck(matrixTest1[0][1], 2)
             && floatCheck(matrixTest1[0][2], 3)
@@ -95,13 +68,13 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
 
             && floatCheck(matrixTest2[0][0], 1)
             && floatCheck(matrixTest2[0][1], 0)
-            && floatCheck(matrixTest2[0][2], 8)
-            && floatCheck(matrixTest2[1][0], 4)
-            && floatCheck(matrixTest2[1][1], 2)
+            && floatCheck(matrixTest2[0][2], 6)
+            && floatCheck(matrixTest2[1][0], 2)
+            && floatCheck(matrixTest2[1][1], 4)
             && floatCheck(matrixTest2[1][2], 0)
-            && floatCheck(matrixTest2[2][0], 7)
+            && floatCheck(matrixTest2[2][0], 3)
             && floatCheck(matrixTest2[2][1], 5)
-            && floatCheck(matrixTest2[2][2], 3)
+            && floatCheck(matrixTest2[2][2], 7)
 
             && floatCheck(data1[0], 1)
             && floatCheck(data1[1], 2)
@@ -109,10 +82,34 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
             && floatCheck(data2[0], 0)
             && floatCheck(data2[1], 4)
             && floatCheck(data2[2], 5)
+#else
+            && floatCheck(matrixTest1[0][0], 1)
+            && floatCheck(matrixTest1[0][1], 2)
+            && floatCheck(matrixTest1[0][2], 3)
+            && floatCheck(matrixTest1[1][0], 4)
+            && floatCheck(matrixTest1[1][1], 5)
+            && floatCheck(matrixTest1[1][2], 6)
+            && floatCheck(matrixTest1[2][0], 7)
+            && floatCheck(matrixTest1[2][1], 8)
+            && floatCheck(matrixTest1[2][2], 9)
+
+            && floatCheck(matrixTest2[0][0], 1)
+            && floatCheck(matrixTest2[0][1], 4)
+            && floatCheck(matrixTest2[0][2], 7)
+            && floatCheck(matrixTest2[1][0], 2)
+            && floatCheck(matrixTest2[1][1], 5)
+            && floatCheck(matrixTest2[1][2], 8)
+            && floatCheck(matrixTest2[2][0], 3)
+            && floatCheck(matrixTest2[2][1], 6)
+            && floatCheck(matrixTest2[2][2], 9)
+
+            && floatCheck(data1[0], 1)
+            && floatCheck(data1[1], 2)
+            && floatCheck(data1[2], 3)
+            && floatCheck(data2[0], 4)
+            && floatCheck(data2[1], 5)
+            && floatCheck(data2[2], 6)
 #endif
         );
-    output[1] = (uint)matrixTest2[0][0];
-    output[2] = (uint)matrixTest2[0][1];
-    output[3] = (uint)matrixTest2[0][2];
     //BUF: 1
 }

--- a/tests/compute/constant-buffer-memory-packing.slang
+++ b/tests/compute/constant-buffer-memory-packing.slang
@@ -19,7 +19,7 @@
 // {4,5,6}
 // {7,8,9}
 
-//TEST_INPUT:cbuffer(data=[1.0 2.0 3.0 0.0  4.0 5.0 6.0 0.0  7.0 8.0 9.0 0]):name matrixTestCBuf1
+//TEST_INPUT:cbuffer(data=[1.0 2.0 3.0 0.0  4.0 5.0 6.0 0.0  7.0 8.0 9.0 0.0]):name matrixTestCBuf1
 ConstantBuffer<row_major float3x3> matrixTestCBuf1;
 
 // CPP/Metal/CUDA due to not having memory packing will recieve the following COL matrix post-transpose:
@@ -27,7 +27,7 @@ ConstantBuffer<row_major float3x3> matrixTestCBuf1;
 // {2,4,0}
 // {3,5,7}
 
-//TEST_INPUT:cbuffer(data=[1.0 2.0 3.0 0.0  4.0 5.0 6.0 0.0  7.0 8.0 9.0 0]):name matrixTestCBuf2
+//TEST_INPUT:cbuffer(data=[1.0 2.0 3.0 0.0  4.0 5.0 6.0 0.0  7.0 8.0 9.0 0.0]):name matrixTestCBuf2
 ConstantBuffer<column_major float3x3> matrixTestCBuf2;
 
 //TEST_INPUT:cbuffer(data=[1.0 2.0 3.0 0.0  4.0 5.0 6.0 0.0]):name NeedsPadding

--- a/tests/language-feature/types/matrix-layout-uniform.slang
+++ b/tests/language-feature/types/matrix-layout-uniform.slang
@@ -1,0 +1,19 @@
+//TEST:SIMPLE(filecheck=HLSL): -target hlsl -profile vs_6_0 -entry Main
+
+// HLSL: #pragma pack_matrix(column_major)
+// HLSL-NOT: row_major float4x4 worldToClip
+// HLSL: row_major float4x4 instanceMeshToWorld
+
+[shader("vertex")]
+void Main(
+    uniform column_major float4x4 worldToClip,
+    out float4 SV_Position : SV_Position,
+    in row_major float4x4 instanceMeshToWorld : instanceMeshToWorld,
+    in float3 vertexPositionInMesh : vertexPositionInMesh
+)
+{
+    SV_Position = mul(
+        mul(worldToClip, instanceMeshToWorld),
+        float4(vertexPositionInMesh, 1.f),
+    );
+}


### PR DESCRIPTION
Closes #4873.

Also fixes incorrect metal constant buffer layout calculation revealed by a test.