### PR TITLE
Fix inccorect dropping of declref during Unification of DeclaredSubtypeWitness.

### DIFF
--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -779,8 +779,8 @@ namespace Slang
                 SLANG_ASSERT(constraintDecl2);
                 return TryUnifyTypes(constraints,
                     unifyCtx,
-                    constraintDecl1.getDecl()->getSup().type,
-                    constraintDecl2.getDecl()->getSup().type);
+                    getSup(m_astBuilder, constraintDecl1),
+                    getSup(m_astBuilder, constraintDecl2));
             }
         }
 

--- a/tests/language-feature/generics/nested-gen-value-param-inference.slang
+++ b/tests/language-feature/generics/nested-gen-value-param-inference.slang
@@ -1,0 +1,32 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+
+interface IValueGeneric<let D : int> {}
+struct ValGenericImpl<let D : int> : IValueGeneric<D> {}
+
+struct NestedValueGeneric<let D : int, S : IValueGeneric<D>>
+{
+    int x;
+}
+
+void acceptor<let D : int, S : IValueGeneric<D>>(NestedValueGeneric<D, S> x)
+{
+    outputBuffer[0] = D + x.x;
+}
+void test(NestedValueGeneric<2, ValGenericImpl<2>> x)
+{
+    // could not specialize generic for arguments of type (NestedValueGeneric<2, ValGenericImpl<2>>)
+    acceptor(x);
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID: SV_DispatchThreadID)
+{
+    NestedValueGeneric<2, ValGenericImpl<2>> x;
+    x.x = 1;
+    test(x);
+    // CHECK: 3
+}


### PR DESCRIPTION
Closes #5033.