### PR TITLE
Specialize existential return types when possible.

### DIFF
--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -779,8 +779,8 @@ namespace Slang
                 SLANG_ASSERT(constraintDecl2);
                 return TryUnifyTypes(constraints,
                     unifyCtx,
-                    constraintDecl1.getDecl()->getSup().type,
-                    constraintDecl2.getDecl()->getSup().type);
+                    getSup(m_astBuilder, constraintDecl1),
+                    getSup(m_astBuilder, constraintDecl2));
             }
         }
 

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -841,6 +841,10 @@ Result linkAndOptimizeIR(
     {
         simplifyIR(targetProgram, irModule, fastIRSimplificationOptions, sink);
     }
+    else if (requiredLoweringPassSet.generics)
+    {
+        eliminateDeadCode(irModule, fastIRSimplificationOptions.deadCodeElimOptions);
+    }
 
     if (!ArtifactDescUtil::isCpuLikeTarget(artifactDesc) &&
         targetProgram->getOptionSet().shouldRunNonEssentialValidation())

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -772,6 +772,11 @@ INST_RANGE(BindingQuery, GetRegisterIndex, GetRegisterSpace)
         needs to be special cased for lookup. */
     INST(TransitoryDecoration,              transitory,             0, 0)
 
+    // The result witness table that the functon's return type is a subtype of an interface.
+    // This is used to keep track of the original witness table in a function that used to
+    // return an existential value but now returns a concrete type after specialization.
+    INST(ResultWitnessDecoration,           ResultWitness,          1, 0)
+
     INST(VulkanRayPayloadDecoration,        vulkanRayPayload,       0, 0)
     INST(VulkanRayPayloadInDecoration,      vulkanRayPayloadIn,       0, 0)
     INST(VulkanHitAttributesDecoration,     vulkanHitAttributes,    0, 0)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -799,6 +799,17 @@ struct IRSequentialIDDecoration : IRDecoration
     IRIntegerValue getSequentialID() { return getSequentialIDOperand()->getValue(); }
 };
 
+struct IRResultWitnessDecoration : IRDecoration
+{
+    enum
+    {
+        kOp = kIROp_ResultWitnessDecoration
+    };
+    IR_LEAF_ISA(ResultWitnessDecoration)
+
+    IRInst* getWitness() { return getOperand(0); }
+};
+
 struct IRDynamicDispatchWitnessDecoration : IRDecoration
 {
     IR_LEAF_ISA(DynamicDispatchWitnessDecoration)
@@ -4539,6 +4550,11 @@ public:
     }
 
     void addHighLevelDeclDecoration(IRInst* value, Decl* decl);
+
+    IRDecoration* addResultWitnessDecoration(IRInst* value, IRInst* witness)
+    {
+        return addDecoration(value, kIROp_ResultWitnessDecoration, witness);
+    }
 
     IRDecoration* addTargetSystemValueDecoration(IRInst* value, UnownedStringSlice sysValName, UInt index = 0)
     {

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -1348,7 +1348,9 @@ struct SpecializationContext
             }
             else
             {
-                SLANG_UNEXPECTED("missing case for existential argument");
+                // We encountered an existential argument that we don't know how to handle,
+                // bail out.
+                return false;
             }
         }
 

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -1224,6 +1224,8 @@ struct SpecializationContext
                         witness = makeExistential->getWitnessTable();
                     else if (witness != makeExistential->getWitnessTable())
                         return false;
+                    if (isChildInstOf(witness, callee))
+                        return false;
                 }
                 else
                 {
@@ -1830,6 +1832,11 @@ struct SpecializationContext
                             witnessTable = makeExistential->getWitnessTable();
                         }
                         else if (concreteType != makeExistential->getWrappedValue()->getDataType())
+                        {
+                            concreteType = nullptr;
+                            break;
+                        }
+                        if (isChildInstOf(witnessTable, newFunc))
                         {
                             concreteType = nullptr;
                             break;

--- a/tests/language-feature/generics/generic-return-type-requirement.slang
+++ b/tests/language-feature/generics/generic-return-type-requirement.slang
@@ -1,0 +1,39 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+//TEST:SIMPLE(filecheck=HLSL): -target hlsl -profile cs_6_0 -entry computeMain
+
+// HLSL-NOT: AnyValue
+
+interface IStack<let D : int>
+{
+    __generic<let N : int>
+    IStack<D - N> popN();
+
+    int get();
+}
+struct StackImpl<let D : int> : IStack<D>
+{
+    // We should be able to specialize the callsites of this function to use
+    // the concrete type instead of resorting to dynamic dispatch.
+    __generic<let N : int>
+    IStack<D - N> popN() { return StackImpl<D-N>(); }
+
+    int get() { return D; }
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+int test<int D, S : IStack<D>>(S stack)
+{
+    return stack.popN<2>().get();
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+{
+    StackImpl<5> stack;
+
+    // CHECK: 2
+    outputBuffer[0] = test(stack);
+}

--- a/tests/language-feature/generics/nested-gen-value-param-inference-2.slang
+++ b/tests/language-feature/generics/nested-gen-value-param-inference-2.slang
@@ -13,10 +13,19 @@ void acceptor<let D : int, S : IValueGeneric<D>>(NestedValueGeneric<D, S> x)
 {
     outputBuffer[0] = D + x.x;
 }
-void test(NestedValueGeneric<2, ValGenericImpl<2>> x)
+
+extension<let D : int, S : IValueGeneric<D>> NestedValueGeneric<D, S>
 {
-    // Test that we can correctly infer acceptor.D and acceptor.S from `x`.
-    acceptor(x);
+    void foo()
+    {
+        acceptor(this);
+    }
+}
+void test2(NestedValueGeneric<2, ValGenericImpl<2>> x)
+{
+    // 'foo' should be a member of 'NestedValueGeneric<2, ValGenericImpl<2>>' through
+    // the extension above.
+    x.foo();
 }
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
@@ -27,6 +36,6 @@ void computeMain(int3 dispatchThreadID: SV_DispatchThreadID)
 {
     NestedValueGeneric<2, ValGenericImpl<2>> x;
     x.x = 1;
-    test(x);
+    test2(x);
     // CHECK: 3
 }

--- a/tests/language-feature/generics/nested-gen-value-param-inference.slang
+++ b/tests/language-feature/generics/nested-gen-value-param-inference.slang
@@ -1,0 +1,32 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+
+interface IValueGeneric<let D : int> {}
+struct ValGenericImpl<let D : int> : IValueGeneric<D> {}
+
+struct NestedValueGeneric<let D : int, S : IValueGeneric<D>>
+{
+    int x;
+}
+
+void acceptor<let D : int, S : IValueGeneric<D>>(NestedValueGeneric<D, S> x)
+{
+    outputBuffer[0] = D + x.x;
+}
+void test(NestedValueGeneric<2, ValGenericImpl<2>> x)
+{
+    // could not specialize generic for arguments of type (NestedValueGeneric<2, ValGenericImpl<2>>)
+    acceptor(x);
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID: SV_DispatchThreadID)
+{
+    NestedValueGeneric<2, ValGenericImpl<2>> x;
+    x.x = 1;
+    test(x);
+    // CHECK: 3
+}

--- a/tests/language-feature/interfaces/default-construct-conformance.slang
+++ b/tests/language-feature/interfaces/default-construct-conformance.slang
@@ -36,22 +36,18 @@ struct TestAny : ITest
     uint getValue() { return value; }
 }
 
-// CHECK: Tuple{{.*}} makeTest0{{.*}}()
-// CHECK: Tuple{{.*}} = { uint2(0U, 0U), uint2(0U, 0U), packAnyValue4{{.*}} };
 ITest makeTest0()
 {
     return Test0();
 }
 
-// CHECK: Tuple{{.*}} makeTest1{{.*}}()
-// CHECK: Tuple{{.*}} = { uint2(0U, 0U), uint2(1U, 0U), packAnyValue4{{.*}} };
 ITest makeTest1()
 {
     return Test1();
 }
 
-// CHECK: Tuple{{.*}} makeTestAny{{.*}}()
-// CHECK: Tuple{{.*}} = { uint2(0U, 0U), uint2(2U, 0U), packAnyValue4{{.*}} };
+// CHECK: TestAny{{.*}} makeTestAny{{.*}}()
+// CHECK: return TestAny_{{.*}}init{{.*}}()
 ITest makeTestAny()
 {
     return TestAny();


### PR DESCRIPTION
Paritally addresses #5035.

This PR enhances our specialization logic so that functions that returns an existential value can now be specailized into a function that returns a concrete type. This avoid us generating unnecessary dynamic dispatch logic when the return type of the function is statically known.