### PR TITLE
Git-ignore for VIM temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,8 @@ vkd3d-proton.cache
 vkd3d-proton.cache.write
 *_d3d11.log
 *_dxgi.log
+
+# Vim temporary files
+*~
+.*.swp
+.*.swo


### PR DESCRIPTION
Following git-ignore rules are added to ignore VIM temporary files:
- *\~: Ignores all files ending with a tilde (~), which are Vim's backup files.
- .*.swp: Ignores Vim swap files, which have .swp extension.
- .*.swo: Ignores Vim swap files created when a .swp file already exists.