### PR TITLE
Remove includes of glslang private headers

### DIFF
--- a/source/slang-glslang/slang-glslang.cpp
+++ b/source/slang-glslang/slang-glslang.cpp
@@ -3,15 +3,9 @@
 
 
 #include "glslang/Public/ResourceLimits.h"
-#include "StandAlone/Worklist.h"
-#include "glslang/Include/ShHandle.h"
 #include "glslang/Public/ShaderLang.h"
 #include "SPIRV/GlslangToSpv.h"
-#include "SPIRV/GLSL.std.450.h"
-#include "SPIRV/doc.h"
 #include "SPIRV/disassemble.h"
-
-#include "glslang/MachineIndependent/localintermediate.h"
 
 #include "slang.h"
 
@@ -23,6 +17,7 @@
 #endif
 
 #include <memory>
+#include <mutex>
 #include <sstream>
 
 // This is a wrapper to allow us to run the `glslang` compiler


### PR DESCRIPTION
The slang-glslang.cpp file was including private glslang headers, however they don't even seem to be necessary and can be safely removed. After this change, only the public glslang headers are used.