### PR TITLE
Fix the issue in resolving the overload functions

### DIFF
--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1347,12 +1347,12 @@ namespace Slang
             }
         }
 
-        // We need to consider the distance of the declarations from the global scope to resolve this case:
+        // We need to consider the distance of the declarations to the global scope to resolve this case:
         //      float f(float x);
         //      struct S
         //      {
         //          float f(float x);
-        //          float g(float y) { return f(y); }   // will call S::f
+        //          float g(float y) { return f(y); }   // will call S::f() instead of ::f()
         //      }
         // We don't need to know the call site of 'f(y)', but only need to count the two candidates' distance to the global scope,
         // because this function will only choose the valid candidates. So if there is situation like this:
@@ -1363,7 +1363,7 @@ namespace Slang
         int rightDistance = 0;
         countDistanceToGloablScope(left.declRef, right.declRef, leftDistance, rightDistance);
         if (leftDistance != rightDistance)
-            return leftDistance < rightDistance ? -1 : 1;
+            return leftDistance > rightDistance ? -1 : 1;
 
         // TODO: We should generalize above rules such that in a tie a declaration
         // A::m is better than B::m when all other factors are equal and

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1,4 +1,5 @@
 // slang-check-overload.cpp
+#include "slang-ast-base.h"
 #include "slang-check-impl.h"
 
 #include "slang-lookup.h"
@@ -1199,6 +1200,28 @@ namespace Slang
         return parent;
     }
 
+    void countDistanceToGloablScope(DeclRef<Slang::Decl> const& leftDecl,
+                                    DeclRef<Slang::Decl> const& rightDecl,
+                                    int& leftDistance, int& rightDistance)
+    {
+        leftDistance = 0;
+        rightDistance = 0;
+
+        DeclRef<Decl> decl = leftDecl;
+        while(decl)
+        {
+            leftDistance++;
+            decl = decl.getParent();
+        }
+
+        decl = rightDecl;
+        while(decl)
+        {
+            rightDistance++;
+            decl = decl.getParent();
+        }
+    }
+
     // Returns -1 if left is preferred, 1 if right is preferred, and 0 if they are equal.
     //
     int SemanticsVisitor::CompareLookupResultItems(
@@ -1323,6 +1346,24 @@ namespace Slang
                 }
             }
         }
+
+        // We need to consider the distance of the declarations from the global scope to resolve this case:
+        //      float f(float x);
+        //      struct S
+        //      {
+        //          float f(float x);
+        //          float g(float y) { return f(y); }   // will call S::f
+        //      }
+        // We don't need to know the call site of 'f(y)', but only need to count the two candidates' distance to the global scope,
+        // because this function will only choose the valid candidates. So if there is situation like this:
+        //  void main() {  S s; s.f(1.0);} or
+        //  struct T { float g(y) { f(y); } }, there won't be ambiguity.
+        //  So we just need to count which declaration is farther from the global scope and favor the farther one.
+        int leftDistance = 0;
+        int rightDistance = 0;
+        countDistanceToGloablScope(left.declRef, right.declRef, leftDistance, rightDistance);
+        if (leftDistance != rightDistance)
+            return leftDistance < rightDistance ? -1 : 1;
 
         // TODO: We should generalize above rules such that in a tie a declaration
         // A::m is better than B::m when all other factors are equal and

--- a/tests/bugs/overload-ambiguous.slang
+++ b/tests/bugs/overload-ambiguous.slang
@@ -1,0 +1,48 @@
+// https://github.com/shader-slang/slang/issues/4476
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cuda -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cpu -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute -shaderobj
+
+//TEST_INPUT:ubuffer(data=[0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<uint> outputBuffer;
+
+
+uint getData()
+{
+    return 1u;
+}
+
+struct DataObtainer
+{
+    uint data;
+    uint getData()
+    {
+        return data;
+    }
+
+    uint getValue()
+    {
+        return getData(); // will call DataObtainer::getData()
+    }
+
+    uint getValue2()
+    {
+        return ::getData(); // will call global getData()
+    }
+}
+
+RWStructuredBuffer<uint> output;
+
+[numthreads(1, 1, 1)]
+[shader("compute")]
+void computeMain(uint3 threadID: SV_DispatchThreadID)
+{
+    DataObtainer obtainer = {2u};
+    outputBuffer[0] = obtainer.getValue();
+    outputBuffer[1] = obtainer.getValue2();
+    // BUF: 2
+    // BUF-NEXT: 1
+}


### PR DESCRIPTION
This change fix the issue #4476.

When looking up the overloaded functions, we need to consider the declaration's distance to the global scope, and will prefer the farther one. The reason that this can work is because in overloaded resolution function `CompareLookupResultItems`, only valid candidates will be considered here, so farther to the global scope implies it's more closer to the callsite. And we really want to choose the one closer to the callsite.

