### PR TITLE
Lower the priority of looking up the rank of scope

### DIFF
--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1454,7 +1454,7 @@ namespace Slang
         for (auto node = prefixDecl; node != nullptr; node = node.getParent())
         {
             Decl* key = node.getDecl();
-            uint32_t value = refPath.getCount();
+            uint32_t value = (uint32_t)refPath.getCount();
             refPath.add(key, value);
         }
 

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1582,11 +1582,6 @@ namespace Slang
             if (externExportDiff)
                 return externExportDiff;
 
-            // If we reach here, we will attempt to use overload rank to break the ties.
-            auto overloadRankDiff = getOverloadRank(right->item.declRef) - getOverloadRank(left->item.declRef);
-            if (overloadRankDiff)
-                return overloadRankDiff;
-
             // We need to consider the distance of the declarations to the global scope to resolve this case:
             //      float f(float x);
             //      struct S
@@ -1599,6 +1594,12 @@ namespace Slang
             auto scopeRank = getScopeRank(left->item.declRef, right->item.declRef, this->m_outerScope);
             if (scopeRank)
                 return scopeRank;
+
+            // If we reach here, we will attempt to use overload rank to break the ties.
+            auto overloadRankDiff = getOverloadRank(right->item.declRef) - getOverloadRank(left->item.declRef);
+            if (overloadRankDiff)
+                return overloadRankDiff;
+
         }
 
         return 0;

--- a/tests/bugs/overload-ambiguous-1.slang
+++ b/tests/bugs/overload-ambiguous-1.slang
@@ -1,0 +1,65 @@
+// https://github.com/shader-slang/slang/issues/4476
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cuda -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cpu -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute -shaderobj
+
+//TEST_INPUT:ubuffer(data=[0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<uint> outputBuffer;
+
+namespace A1
+{
+    uint func()
+    {
+        return 1u;
+    }
+
+    namespace A2
+    {
+        uint func()
+        {
+            return 2u;
+        }
+
+        namespace A3
+        {
+            uint func()
+            {
+                return 3u;
+            }
+
+            uint test2()
+            {
+                return func();      // choose A3::func()
+            }
+        }
+
+        namespace A4
+        {
+            uint test()
+            {
+                return func();      // choose A2::func()
+            }
+        }
+    }
+}
+
+[numthreads(1, 1, 1)]
+[shader("compute")]
+void computeMain(uint3 threadID: SV_DispatchThreadID)
+{
+    using namespace A1;
+    using namespace A1::A2;
+    using namespace A1::A2::A3;
+    using namespace A1::A2::A4;
+    outputBuffer[0] = test();
+    // BUF: 2
+
+    outputBuffer[1] = func(); // choose the A1::func()
+    // BUF-NEXT: 1
+
+    outputBuffer[2] = test2();
+    // BUF-NEXT: 3
+}

--- a/tests/bugs/overload-ambiguous-2.slang
+++ b/tests/bugs/overload-ambiguous-2.slang
@@ -1,0 +1,67 @@
+// https://github.com/shader-slang/slang/issues/4476
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cuda -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cpu -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute -shaderobj
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<uint> outputBuffer;
+
+namespace A
+{
+    struct Struct1<let SIZE : uint>
+    {
+        uint data;
+    };
+
+    Struct1<Z1> myFunc<let Z0 : uint, let Z1 : uint>(Struct1<Z0> inputS1)
+    {
+        Struct1<Z1> s1;
+        s1.data = inputS1.data + 2U;
+        return s1;
+    }
+};
+
+
+A::Struct1<Z1> myFunc<let Z0 : uint, let Z1 : uint>(A::Struct1<Z0> inputS1)
+{
+    A::Struct1<Z1> s1;
+    s1.data = inputS1.data + 5U;
+    return s1;
+}
+
+namespace A
+{
+    struct Struct2<let SIZE : uint>
+    {
+        Struct1<SIZE> s1;
+    }
+
+    Struct2<Z1> myFunc<let Z0 : uint, let Z1 : uint>(Struct2<Z0> inputS2)
+    {
+        Struct2<Z1> s2;
+        // We want to cover a corner case in our compiler where:
+        // when looking up "myFunc", the compiler should find
+        //   Struct1<Z1> A::myFunc<let Z0 : uint, let Z1 : uint>(Struct1<Z0> inputS1)
+        // and it won't be ambiguous with the global "myFunc".
+        s2.s1 = myFunc<Z0, Z1>(inputS2.s1);
+        return s2;
+    }
+};
+
+[numthreads(1, 1, 1)]
+[shader("compute")]
+void computeMain(uint3 threadID: SV_DispatchThreadID)
+{
+    using namespace A;
+
+    Struct2<10> input = {threadID.x};
+
+    Struct2<20> output;
+    output = myFunc<10, 20>(input);
+    outputBuffer[0] = output.s1.data;
+
+    // BUF: 2
+}

--- a/tests/bugs/overload-ambiguous.slang
+++ b/tests/bugs/overload-ambiguous.slang
@@ -6,7 +6,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -dx12 -shaderobj
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute -shaderobj
 
-//TEST_INPUT:ubuffer(data=[0 0], stride=4):out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
 
 
@@ -34,7 +34,18 @@ struct DataObtainer
     }
 }
 
-RWStructuredBuffer<uint> output;
+uint myFunc(uint a)
+{
+    return a + 1u;
+}
+
+__generic<T: __BuiltinIntegerType>
+uint myFunc(T a)
+{
+    uint b = __intCast<uint, T>(a);
+    return b + 2u;
+}
+
 
 [numthreads(1, 1, 1)]
 [shader("compute")]
@@ -43,6 +54,10 @@ void computeMain(uint3 threadID: SV_DispatchThreadID)
     DataObtainer obtainer = {2u};
     outputBuffer[0] = obtainer.getValue();
     outputBuffer[1] = obtainer.getValue2();
+
+    uint a = 1u;
+    outputBuffer[2] = myFunc(a); // will call myFunc(uint) which more specialized
     // BUF: 2
     // BUF-NEXT: 1
+    // BUF-NEXT: 2
 }

--- a/tests/diagnostics/overload-ambiguous.slang
+++ b/tests/diagnostics/overload-ambiguous.slang
@@ -1,0 +1,45 @@
+// https://github.com/shader-slang/slang/issues/4476
+
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):
+RWStructuredBuffer<uint> outputBuffer;
+
+namespace A1
+{
+    uint func()
+    {
+        return 1u;
+    }
+
+    namespace A2
+    {
+        uint func()
+        {
+            return 2u;
+        }
+    }
+}
+namespace B1
+{
+    uint func()
+    {
+        return 4u;
+    }
+}
+
+[numthreads(1, 1, 1)]
+[shader("compute")]
+void computeMain(uint3 threadID: SV_DispatchThreadID)
+{
+    using namespace A1;
+    using namespace A1::A2;
+    using namespace B1;
+    using namespace C1;
+
+    // Only A1::func() and B1::func() will cause ambiguity because the distance from
+    // the reference site to those two functions declaration are the same.
+    outputBuffer[0] = func();
+    // CHECK-NOT: {{.*}}A2::func() -> uint
+    // CHECK: ambiguous call to 'func' with arguments of type ()
+    // CHECK: candidate: func B1::func() -> uint
+    // CHECK: candidate: func A1::func() -> uint
+}


### PR DESCRIPTION
In the previous change of #5060, we propose a way to resolve the ambiguous call when considering the scope of a function.

But this rule should be considered as a low priority than "specialized candidate", aka. we should consider more "specialized candiate" first.