### PR TITLE
Add diagnostic to verify the left hand side of a generic constraint.

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2522,7 +2522,7 @@ namespace Slang
                 // interface IFoo {
                 //    associatedtype T
                 //        where T : IFoo  // OK, constraint is on the associatedtype T itself.
-                //        where T.T == X; // OK, constraint is on the associated type of T.
+                //        where T.T == X  // OK, constraint is on the associated type of T.
                 //        where int == X; // Error, int is not a valid left hand side of a constraint.
                 //  }
                 // ```

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -740,6 +740,10 @@ namespace Slang
             m_mapTypePairToImplicitCastMethod[key] = candidate;
         }
 
+        // Get the inner most generic decl that a decl-ref is dependent on.
+        // For example, `Foo<T>` depends on the generic decl that defines `T`.
+        //
+        DeclRef<GenericDecl> getDependentGenericParent(DeclRef<Decl> declRef);
     private:
             /// Mapping from type declarations to the known extensiosn that apply to them
         Dictionary<AggTypeDecl*, RefPtr<CandidateExtensionList>> m_mapTypeDeclToCandidateExtensions;
@@ -766,10 +770,6 @@ namespace Slang
         InheritanceInfo _calcInheritanceInfo(Type* type, InheritanceCircularityInfo* circularityInfo);
         InheritanceInfo _calcInheritanceInfo(DeclRef<Decl> declRef, DeclRefType* correspondingType, InheritanceCircularityInfo* circularityInfo);
 
-        // Get the inner most generic decl that a decl-ref is dependent on.
-        // For example, `Foo<T>` depends on the generic decl that defines `T`.
-        //
-        DeclRef<GenericDecl> getDependentGenericParent(DeclRef<Decl> declRef);
         void getDependentGenericParentImpl(DeclRef<GenericDecl>& genericParent, DeclRef<Decl> declRef);
 
         struct DirectBaseInfo

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -519,6 +519,7 @@ DIAGNOSTIC(39901, Fatal , cannotProcessInclude, "internal compiler error: cannot
 // 304xx: generics
 DIAGNOSTIC(30400, Error, genericTypeNeedsArgs, "generic type '$0' used without argument")
 DIAGNOSTIC(30401, Error, invalidTypeForConstraint, "type '$0' cannot be used as a constraint.")
+DIAGNOSTIC(30402, Error, invalidConstraintSubType, "type '$0' is not a valid left hand side of a type constraint.")
 
 // 305xx: initializer lists
 DIAGNOSTIC(30500, Error, tooManyInitializers, "too many initializers (expected $0, got $1)")

--- a/tests/diagnostics/generic-constraint-left-hand-side.slang
+++ b/tests/diagnostics/generic-constraint-left-hand-side.slang
@@ -1,0 +1,7 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):
+
+// Check that we can issue diagnostic on invalid left hand side of a type constraint.
+
+// CHECK: ([[# @LINE+1]]): error 30402
+void f<T>() where int : IInteger
+{}


### PR DESCRIPTION
(This PR is based on top of PR #5111.)

Add validation on left hand side of type generic. For example, we need to diagnose an error for:
```
void foo<T>() where int : X {} // int cannot be left hand side of a generic constraint.
```

Closes #5113.