### PR TITLE
refactor render test to use latest slang-rhi

### DIFF
--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -34,7 +34,7 @@ static rhi::DeviceType _toRenderType(Slang::RenderApiType apiType)
     case RenderApiType::CPU:    return rhi::DeviceType::CPU;
     case RenderApiType::CUDA:   return rhi::DeviceType::CUDA;
     default:
-        return rhi::DeviceType::Unknown;
+        return rhi::DeviceType::Default;
     }
 }
 
@@ -244,7 +244,7 @@ static rhi::DeviceType _toRenderType(Slang::RenderApiType apiType)
                 UnownedStringSlice argName = argSlice.tail(1);
                 DeviceType deviceType = _toRenderType(RenderApiUtil::findApiTypeByName(argName));
 
-                if (deviceType != DeviceType::Unknown)
+                if (deviceType != DeviceType::Default)
                 {
                     outOptions.deviceType = deviceType;
                     continue;
@@ -253,7 +253,7 @@ static rhi::DeviceType _toRenderType(Slang::RenderApiType apiType)
                 // Lookup the target language type
                 DeviceType targetLanguageDeviceType = _toRenderType(RenderApiUtil::findImplicitLanguageRenderApiType(argName));
                     
-                if (targetLanguageDeviceType != DeviceType::Unknown || argName == "glsl")
+                if (targetLanguageDeviceType != DeviceType::Default || argName == "glsl")
                 {
                     outOptions.targetLanguageDeviceType = targetLanguageDeviceType;
                     outOptions.inputLanguageID = (argName == "hlsl" || argName == "glsl" || argName == "cpp" || argName == "cxx" || argName == "c") ?  InputLanguageID::Native : InputLanguageID::Slang;
@@ -266,7 +266,7 @@ static rhi::DeviceType _toRenderType(Slang::RenderApiType apiType)
     }
 
     // If a render option isn't set use defaultRenderType 
-    outOptions.deviceType = (outOptions.deviceType == DeviceType::Unknown)
+    outOptions.deviceType = (outOptions.deviceType == DeviceType::Default)
                                 ? outOptions.targetLanguageDeviceType
                                 : outOptions.deviceType;
 

--- a/tools/render-test/options.h
+++ b/tools/render-test/options.h
@@ -53,9 +53,9 @@ struct Options
 	ShaderProgramType shaderType = ShaderProgramType::Graphics;
 
         /// The renderer type inferred from the target language type. Used if a rendererType is not explicitly set.
-    DeviceType targetLanguageDeviceType = DeviceType::Unknown;
+    DeviceType targetLanguageDeviceType = DeviceType::Default;
         /// The set render type
-    DeviceType deviceType = DeviceType::Unknown;
+    DeviceType deviceType = DeviceType::Default;
     InputLanguageID inputLanguageID = InputLanguageID::Slang;
     SlangSourceLanguage sourceLanguage = SLANG_SOURCE_LANGUAGE_UNKNOWN;
 

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -127,18 +127,18 @@ protected:
     IDevice* m_device;
     ComPtr<ICommandQueue> m_queue;
     ComPtr<ITransientResourceHeap> m_transientHeap;
-    ComPtr<IRenderPassLayout> m_renderPass;
     ComPtr<IInputLayout> m_inputLayout;
-    ComPtr<IBufferResource> m_vertexBuffer;
+    ComPtr<IBuffer> m_vertexBuffer;
     ComPtr<IShaderProgram> m_shaderProgram;
-    ComPtr<IPipelineState> m_pipelineState;
-    ComPtr<IFramebufferLayout> m_framebufferLayout;
-    ComPtr<IFramebuffer> m_framebuffer;
-    ComPtr<ITextureResource> m_colorBuffer;
+    ComPtr<IPipeline> m_pipeline;
+    ComPtr<ITexture> m_depthBuffer;
+    ComPtr<ITextureView> m_depthBufferView;
+    ComPtr<ITexture> m_colorBuffer;
+    ComPtr<ITextureView> m_colorBufferView;
 
-    ComPtr<IBufferResource> m_blasBuffer;
+    ComPtr<IBuffer> m_blasBuffer;
     ComPtr<IAccelerationStructure> m_bottomLevelAccelerationStructure;
-    ComPtr<IBufferResource> m_tlasBuffer;
+    ComPtr<IBuffer> m_tlasBuffer;
     ComPtr<IAccelerationStructure> m_topLevelAccelerationStructure;
 
     ShaderCompilerUtil::OutputAndLayout m_compilationOutput;
@@ -212,10 +212,10 @@ struct AssignValsFromLayoutContext
         for (size_t i = bufferData.getCount(); i < bufferSize / sizeof(uint32_t); i++)
             bufferData.add(0);
 
-        ComPtr<IBufferResource> bufferResource;
-        SLANG_RETURN_ON_FAIL(ShaderRendererUtil::createBufferResource(srcBuffer, /*entry.isOutput,*/ bufferSize, bufferData.getBuffer(), device, bufferResource));
+        ComPtr<IBuffer> bufferResource;
+        SLANG_RETURN_ON_FAIL(ShaderRendererUtil::createBuffer(srcBuffer, /*entry.isOutput,*/ bufferSize, bufferData.getBuffer(), device, bufferResource));
 
-        ComPtr<IBufferResource> counterResource;
+        ComPtr<IBuffer> counterResource;
         const auto explicitCounterCursor = dstCursor.getExplicitCounter();
         if(srcBuffer.counter != ~0u)
         {
@@ -238,7 +238,7 @@ struct AssignValsFromLayoutContext
                     1,
                     Format::Unknown,
                 };
-                SLANG_RETURN_ON_FAIL(ShaderRendererUtil::createBufferResource(
+                SLANG_RETURN_ON_FAIL(ShaderRendererUtil::createBuffer(
                     counterBufferDesc,
                     sizeof(srcBuffer.counter),
                     &srcBuffer.counter,
@@ -254,11 +254,14 @@ struct AssignValsFromLayoutContext
             return SLANG_E_INVALID_ARG;
         }
 
-        IResourceView::Desc viewDesc = {};
-        viewDesc.type = IResourceView::Type::UnorderedAccess;
-        viewDesc.format = srcBuffer.format;
-        auto bufferView = device->createBufferView(bufferResource, counterResource, viewDesc);
-        dstCursor.setResource(bufferView);
+        if (counterResource)
+        {
+            dstCursor.setBinding(Binding(bufferResource, counterResource));
+        }
+        else
+        {
+            dstCursor.setBinding(bufferResource);
+        }
         maybeAddOutput(dstCursor, srcVal, bufferResource);
 
         return SLANG_OK;
@@ -269,19 +272,13 @@ struct AssignValsFromLayoutContext
         auto& textureEntry = srcVal->textureVal;
         auto& samplerEntry = srcVal->samplerVal;
 
-        ComPtr<ITextureResource> texture;
-        SLANG_RETURN_ON_FAIL(ShaderRendererUtil::generateTextureResource(
+        ComPtr<ITexture> texture;
+        SLANG_RETURN_ON_FAIL(ShaderRendererUtil::generateTexture(
             textureEntry->textureDesc, ResourceState::ShaderResource, device, texture));
 
-        auto sampler = _createSamplerState(device, samplerEntry->samplerDesc);
+        auto sampler = _createSampler(device, samplerEntry->samplerDesc);
 
-        IResourceView::Desc viewDesc = {};
-        viewDesc.type = IResourceView::Type::ShaderResource;
-        auto textureView = device->createTextureView(
-            texture,
-            viewDesc);
-
-        dstCursor.setCombinedTextureSampler(textureView, sampler);
+        dstCursor.setBinding(Binding(texture, sampler));
         maybeAddOutput(dstCursor, srcVal, texture);
 
         return SLANG_OK;
@@ -289,41 +286,23 @@ struct AssignValsFromLayoutContext
 
     SlangResult assignTexture(ShaderCursor const& dstCursor, ShaderInputLayout::TextureVal* srcVal)
     {
-        ComPtr<ITextureResource> texture;
-        ResourceState defaultState = ResourceState::ShaderResource;
-        IResourceView::Type viewType = IResourceView::Type::ShaderResource;
+        ComPtr<ITexture> texture;
+        ResourceState defaultState = srcVal->textureDesc.isRWTexture ?
+            ResourceState::UnorderedAccess : ResourceState::ShaderResource;
 
-        if (srcVal->textureDesc.isRWTexture)
-        {
-            defaultState = ResourceState::UnorderedAccess;
-            viewType = IResourceView::Type::UnorderedAccess;
-        }
-
-        SLANG_RETURN_ON_FAIL(ShaderRendererUtil::generateTextureResource(
+        SLANG_RETURN_ON_FAIL(ShaderRendererUtil::generateTexture(
             srcVal->textureDesc, defaultState, device, texture));
 
-        IResourceView::Desc viewDesc = {};
-        viewDesc.type = viewType;
-        viewDesc.format = texture->getDesc()->format;
-        auto textureView = device->createTextureView(
-            texture,
-            viewDesc);
-
-        if (!textureView)
-        {
-            return SLANG_FAIL;
-        }
-
-        dstCursor.setResource(textureView);
+        dstCursor.setBinding(texture);
         maybeAddOutput(dstCursor, srcVal, texture);
         return SLANG_OK;
     }
 
     SlangResult assignSampler(ShaderCursor const& dstCursor, ShaderInputLayout::SamplerVal* srcVal)
     {
-        auto sampler = _createSamplerState(device, srcVal->samplerDesc);
+        auto sampler = _createSampler(device, srcVal->samplerDesc);
 
-        dstCursor.setSampler(sampler);
+        dstCursor.setBinding(sampler);
         return SLANG_OK;
     }
 
@@ -437,7 +416,7 @@ struct AssignValsFromLayoutContext
         ShaderCursor const& dstCursor,
         ShaderInputLayout::AccelerationStructureVal* srcVal)
     {
-        dstCursor.setResource(accelerationStructure);
+        dstCursor.setBinding(accelerationStructure);
         return SLANG_OK;
     }
 
@@ -511,7 +490,7 @@ Result RenderTestApp::applyBinding(PipelineType pipelineType, ICommandEncoder* e
     case PipelineType::Compute:
         {
             IComputeCommandEncoder* computeEncoder = static_cast<IComputeCommandEncoder*>(encoder);
-            auto rootObject = computeEncoder->bindPipeline(m_pipelineState);
+            auto rootObject = computeEncoder->bindPipeline(m_pipeline);
             SLANG_RETURN_ON_FAIL(_assignVarsFromLayout(
                 m_device,
                 slangSession,
@@ -525,7 +504,7 @@ Result RenderTestApp::applyBinding(PipelineType pipelineType, ICommandEncoder* e
     case PipelineType::Graphics:
         {
             IRenderCommandEncoder* renderEncoder = static_cast<IRenderCommandEncoder*>(encoder);
-            auto rootObject = renderEncoder->bindPipeline(m_pipelineState);
+            auto rootObject = renderEncoder->bindPipeline(m_pipeline);
             SLANG_RETURN_ON_FAIL(_assignVarsFromLayout(
                 m_device,
                 slangSession,
@@ -559,7 +538,7 @@ SlangResult RenderTestApp::initialize(
     // Once the shaders have been compiled we load them via the underlying API.
     //
     ComPtr<ISlangBlob> outDiagnostics;
-    auto result = device->createProgram(m_compilationOutput.output.desc, m_shaderProgram.writeRef(), outDiagnostics.writeRef());
+    auto result = device->createShaderProgram(m_compilationOutput.output.desc, m_shaderProgram.writeRef(), outDiagnostics.writeRef());
 
     // If there was a failure creating a program, we can't continue
     // Special case SLANG_E_NOT_AVAILABLE error code to make it a failure,
@@ -585,10 +564,10 @@ SlangResult RenderTestApp::initialize(
 
         case Options::ShaderProgramType::Compute:
             {
-                ComputePipelineStateDesc desc;
+                ComputePipelineDesc desc;
                 desc.program = m_shaderProgram;
 
-                m_pipelineState = device->createComputePipelineState(desc);
+                m_pipeline = device->createComputePipeline(desc);
             }
             break;
 
@@ -614,37 +593,44 @@ SlangResult RenderTestApp::initialize(
                 SLANG_RETURN_ON_FAIL(device->createInputLayout(
                     sizeof(Vertex), inputElements, SLANG_COUNT_OF(inputElements), inputLayout.writeRef()));
 
-                IBufferResource::Desc vertexBufferDesc;
-                vertexBufferDesc.type = IResource::Type::Buffer;
-                vertexBufferDesc.sizeInBytes = kVertexCount * sizeof(Vertex);
+                BufferDesc vertexBufferDesc;
+                vertexBufferDesc.size = kVertexCount * sizeof(Vertex);
                 vertexBufferDesc.memoryType = MemoryType::Upload;
+                vertexBufferDesc.usage = BufferUsage::VertexBuffer;
                 vertexBufferDesc.defaultState = ResourceState::VertexBuffer;
-                vertexBufferDesc.allowedStates = ResourceStateSet(ResourceState::VertexBuffer);
 
-                SLANG_RETURN_ON_FAIL(device->createBufferResource(
+                SLANG_RETURN_ON_FAIL(device->createBuffer(
                     vertexBufferDesc,
                     kVertexData,
                     m_vertexBuffer.writeRef()));
 
-                GraphicsPipelineStateDesc desc;
+                ColorTargetState colorTarget;
+                colorTarget.format = Format::R8G8B8A8_UNORM;
+                RenderPipelineDesc desc;
                 desc.program = m_shaderProgram;
                 desc.inputLayout = inputLayout;
-                desc.framebufferLayout = m_framebufferLayout;
-                m_pipelineState = device->createGraphicsPipelineState(desc);
+                desc.targets = &colorTarget;
+                desc.targetCount = 1;
+                desc.depthStencil.format = Format::D32_FLOAT;
+                m_pipeline = device->createRenderPipeline(desc);
             }
             break;
         case Options::ShaderProgramType::GraphicsMeshCompute:
         case Options::ShaderProgramType::GraphicsTaskMeshCompute:
             {
-                GraphicsPipelineStateDesc desc;
+                ColorTargetState colorTarget;
+                colorTarget.format = Format::R8G8B8A8_UNORM;
+                RenderPipelineDesc desc;
                 desc.program = m_shaderProgram;
-                desc.framebufferLayout = m_framebufferLayout;
-                m_pipelineState = device->createGraphicsPipelineState(desc);
+                desc.targets = &colorTarget;
+                desc.targetCount = 1;
+                desc.depthStencil.format = Format::D32_FLOAT;
+                m_pipeline = device->createRenderPipeline(desc);
             }
         }
     }
     // If success must have a pipeline state
-    return m_pipelineState ? SLANG_OK : SLANG_FAIL;
+    return m_pipeline ? SLANG_OK : SLANG_FAIL;
 }
 
 Result RenderTestApp::_initializeShaders(
@@ -655,7 +641,7 @@ Result RenderTestApp::_initializeShaders(
 {
     SLANG_RETURN_ON_FAIL(ShaderCompilerUtil::compileWithLayout(device->getSlangSession()->getGlobalSession(), m_options, input, m_compilationOutput));
     m_shaderInputLayout = m_compilationOutput.layout;
-    m_shaderProgram = device->createProgram(m_compilationOutput.output.desc);
+    m_shaderProgram = device->createShaderProgram(m_compilationOutput.output.desc);
     return m_shaderProgram ? SLANG_OK : SLANG_FAIL;
 }
 
@@ -670,102 +656,54 @@ void RenderTestApp::_initializeRenderPass()
     m_queue = m_device->createCommandQueue(queueDesc);
     SLANG_ASSERT(m_queue);
     
-    rhi::ITextureResource::Desc depthBufferDesc;
-    depthBufferDesc.type = IResource::Type::Texture2D;
+    rhi::TextureDesc depthBufferDesc;
+    depthBufferDesc.type = TextureType::Texture2D;
     depthBufferDesc.size.width = gWindowWidth;
     depthBufferDesc.size.height = gWindowHeight;
     depthBufferDesc.size.depth = 1;
     depthBufferDesc.numMipLevels = 1;
     depthBufferDesc.format = Format::D32_FLOAT;
+    depthBufferDesc.usage = TextureUsage::DepthWrite;
     depthBufferDesc.defaultState = ResourceState::DepthWrite;
-    depthBufferDesc.allowedStates = ResourceState::DepthWrite;
+    m_depthBuffer = m_device->createTexture(depthBufferDesc, nullptr);
+    SLANG_ASSERT(m_depthBuffer);
+    m_depthBufferView = m_device->createTextureView(m_depthBuffer, {});
+    SLANG_ASSERT(m_depthBufferView);
 
-    ComPtr<rhi::ITextureResource> depthBufferResource =
-        m_device->createTextureResource(depthBufferDesc, nullptr);
-    SLANG_ASSERT(depthBufferResource);
-
-    rhi::ITextureResource::Desc colorBufferDesc;
-    colorBufferDesc.type = IResource::Type::Texture2D;
+    rhi::TextureDesc colorBufferDesc;
+    colorBufferDesc.type = TextureType::Texture2D;
     colorBufferDesc.size.width = gWindowWidth;
     colorBufferDesc.size.height = gWindowHeight;
     colorBufferDesc.size.depth = 1;
     colorBufferDesc.numMipLevels = 1;
     colorBufferDesc.format = Format::R8G8B8A8_UNORM;
+    colorBufferDesc.usage = TextureUsage::RenderTarget;
     colorBufferDesc.defaultState = ResourceState::RenderTarget;
-    colorBufferDesc.allowedStates = ResourceState::RenderTarget;
-    m_colorBuffer = m_device->createTextureResource(colorBufferDesc, nullptr);
+    m_colorBuffer = m_device->createTexture(colorBufferDesc, nullptr);
     SLANG_ASSERT(m_colorBuffer);
-
-    rhi::IResourceView::Desc colorBufferViewDesc = {};
-    memset(&colorBufferViewDesc, 0, sizeof(colorBufferViewDesc));
-    colorBufferViewDesc.format = rhi::Format::R8G8B8A8_UNORM;
-    colorBufferViewDesc.renderTarget.shape = rhi::IResource::Type::Texture2D;
-    colorBufferViewDesc.type = rhi::IResourceView::Type::RenderTarget;
-    ComPtr<rhi::IResourceView> rtv =
-        m_device->createTextureView(m_colorBuffer.get(), colorBufferViewDesc);
-    SLANG_ASSERT(rtv);
-
-    rhi::IResourceView::Desc depthBufferViewDesc = {};
-    memset(&depthBufferViewDesc, 0, sizeof(depthBufferViewDesc));
-    depthBufferViewDesc.format = rhi::Format::D32_FLOAT;
-    depthBufferViewDesc.renderTarget.shape = rhi::IResource::Type::Texture2D;
-    depthBufferViewDesc.type = rhi::IResourceView::Type::DepthStencil;
-    ComPtr<rhi::IResourceView> dsv =
-        m_device->createTextureView(depthBufferResource.get(), depthBufferViewDesc);
-    SLANG_ASSERT(dsv);
-
-    IFramebufferLayout::TargetLayout colorTarget = {rhi::Format::R8G8B8A8_UNORM, 1};
-    IFramebufferLayout::TargetLayout depthTarget = {rhi::Format::D32_FLOAT, 1};
-    rhi::IFramebufferLayout::Desc framebufferLayoutDesc;
-    framebufferLayoutDesc.renderTargetCount = 1;
-    framebufferLayoutDesc.renderTargets = &colorTarget;
-    framebufferLayoutDesc.depthStencil = &depthTarget;
-    m_device->createFramebufferLayout(framebufferLayoutDesc, m_framebufferLayout.writeRef());
-
-    rhi::IFramebuffer::Desc framebufferDesc;
-    framebufferDesc.renderTargetCount = 1;
-    framebufferDesc.depthStencilView = dsv.get();
-    framebufferDesc.renderTargetViews = rtv.readRef();
-    framebufferDesc.layout = m_framebufferLayout;
-    m_device->createFramebuffer(framebufferDesc, m_framebuffer.writeRef());
-    
-    IRenderPassLayout::Desc renderPassDesc = {};
-    renderPassDesc.framebufferLayout = m_framebufferLayout;
-    renderPassDesc.renderTargetCount = 1;
-    IRenderPassLayout::TargetAccessDesc renderTargetAccess = {};
-    IRenderPassLayout::TargetAccessDesc depthStencilAccess = {};
-    renderTargetAccess.loadOp = IRenderPassLayout::TargetLoadOp::Clear;
-    renderTargetAccess.storeOp = IRenderPassLayout::TargetStoreOp::Store;
-    renderTargetAccess.initialState = ResourceState::Undefined;
-    renderTargetAccess.finalState = ResourceState::RenderTarget;
-    depthStencilAccess.loadOp = IRenderPassLayout::TargetLoadOp::Clear;
-    depthStencilAccess.storeOp = IRenderPassLayout::TargetStoreOp::Store;
-    depthStencilAccess.initialState = ResourceState::Undefined;
-    depthStencilAccess.finalState = ResourceState::DepthWrite;
-    renderPassDesc.renderTargetAccess = &renderTargetAccess;
-    renderPassDesc.depthStencilAccess = &depthStencilAccess;
-    m_device->createRenderPassLayout(renderPassDesc, m_renderPass.writeRef());
+    m_colorBufferView = m_device->createTextureView(m_colorBuffer, {});
+    SLANG_ASSERT(m_colorBufferView);
 }
 
 void RenderTestApp::_initializeAccelerationStructure()
 {
     if (!m_device->hasFeature("ray-tracing"))
         return;
-    IBufferResource::Desc vertexBufferDesc = {};
-    vertexBufferDesc.type = IResource::Type::Buffer;
-    vertexBufferDesc.sizeInBytes = kVertexCount * sizeof(Vertex);
-    vertexBufferDesc.defaultState = ResourceState::ShaderResource;
-    ComPtr<IBufferResource> vertexBuffer =
-        m_device->createBufferResource(vertexBufferDesc, &kVertexData[0]);
+    BufferDesc vertexBufferDesc = {};
+    vertexBufferDesc.size = kVertexCount * sizeof(Vertex);
+    vertexBufferDesc.usage = BufferUsage::AccelerationStructureBuildInput;
+    vertexBufferDesc.defaultState = ResourceState::AccelerationStructureBuildInput;
+    ComPtr<IBuffer> vertexBuffer =
+        m_device->createBuffer(vertexBufferDesc, &kVertexData[0]);
 
-    IBufferResource::Desc transformBufferDesc = {};
-    transformBufferDesc.type = IResource::Type::Buffer;
-    transformBufferDesc.sizeInBytes = sizeof(float) * 12;
-    transformBufferDesc.defaultState = ResourceState::ShaderResource;
+    BufferDesc transformBufferDesc = {};
+    transformBufferDesc.size = sizeof(float) * 12;
+    transformBufferDesc.usage = BufferUsage::AccelerationStructureBuildInput;
+    transformBufferDesc.defaultState = ResourceState::AccelerationStructureBuildInput;
     float transformData[12] = {
         1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f};
-    ComPtr<IBufferResource> transformBuffer =
-        m_device->createBufferResource(transformBufferDesc, &transformData);
+    ComPtr<IBuffer> transformBuffer =
+        m_device->createBuffer(transformBufferDesc, &transformData);
 
     // Build bottom level acceleration structure.
     {
@@ -792,20 +730,20 @@ void RenderTestApp::_initializeAccelerationStructure()
         m_device->getAccelerationStructurePrebuildInfo(
             accelerationStructureBuildInputs, &accelerationStructurePrebuildInfo);
         // Allocate buffers for acceleration structure.
-        IBufferResource::Desc asDraftBufferDesc = {};
-        asDraftBufferDesc.type = IResource::Type::Buffer;
+        BufferDesc asDraftBufferDesc = {};
+        asDraftBufferDesc.usage = BufferUsage::AccelerationStructure;
         asDraftBufferDesc.defaultState = ResourceState::AccelerationStructure;
-        asDraftBufferDesc.sizeInBytes = accelerationStructurePrebuildInfo.resultDataMaxSize;
-        ComPtr<IBufferResource> draftBuffer = m_device->createBufferResource(asDraftBufferDesc);
-        IBufferResource::Desc scratchBufferDesc = {};
-        scratchBufferDesc.type = IResource::Type::Buffer;
+        asDraftBufferDesc.size = accelerationStructurePrebuildInfo.resultDataMaxSize;
+        ComPtr<IBuffer> draftBuffer = m_device->createBuffer(asDraftBufferDesc);
+        BufferDesc scratchBufferDesc = {};
+        scratchBufferDesc.usage = BufferUsage::UnorderedAccess;
         scratchBufferDesc.defaultState = ResourceState::UnorderedAccess;
-        scratchBufferDesc.sizeInBytes = accelerationStructurePrebuildInfo.scratchDataSize;
-        ComPtr<IBufferResource> scratchBuffer = m_device->createBufferResource(scratchBufferDesc);
+        scratchBufferDesc.size = accelerationStructurePrebuildInfo.scratchDataSize;
+        ComPtr<IBuffer> scratchBuffer = m_device->createBuffer(scratchBufferDesc);
 
         // Build acceleration structure.
         ComPtr<IQueryPool> compactedSizeQuery;
-        IQueryPool::Desc queryPoolDesc = {};
+        QueryPoolDesc queryPoolDesc = {};
         queryPoolDesc.count = 1;
         queryPoolDesc.type = QueryType::AccelerationStructureCompactedSize;
         m_device->createQueryPool(queryPoolDesc, compactedSizeQuery.writeRef());
@@ -837,11 +775,11 @@ void RenderTestApp::_initializeAccelerationStructure()
 
         uint64_t compactedSize = 0;
         compactedSizeQuery->getResult(0, 1, &compactedSize);
-        IBufferResource::Desc asBufferDesc = {};
-        asBufferDesc.type = IResource::Type::Buffer;
+        BufferDesc asBufferDesc = {};
+        asBufferDesc.usage = BufferUsage::AccelerationStructure;
         asBufferDesc.defaultState = ResourceState::AccelerationStructure;
-        asBufferDesc.sizeInBytes = (Size)compactedSize;
-        m_blasBuffer = m_device->createBufferResource(asBufferDesc);
+        asBufferDesc.size = (Size)compactedSize;
+        m_blasBuffer = m_device->createBuffer(asBufferDesc);
         IAccelerationStructure::CreateDesc createDesc;
         createDesc.buffer = m_blasBuffer;
         createDesc.kind = IAccelerationStructure::Kind::BottomLevel;
@@ -874,13 +812,13 @@ void RenderTestApp::_initializeAccelerationStructure()
             1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f};
         memcpy(&instanceDescs[0].transform[0][0], transformMatrix, sizeof(float) * 12);
 
-        IBufferResource::Desc instanceBufferDesc = {};
-        instanceBufferDesc.type = IResource::Type::Buffer;
-        instanceBufferDesc.sizeInBytes =
+        BufferDesc instanceBufferDesc = {};
+        instanceBufferDesc.size =
             instanceDescs.getCount() * sizeof(IAccelerationStructure::InstanceDesc);
+        instanceBufferDesc.usage = BufferUsage::AccelerationStructureBuildInput;
         instanceBufferDesc.defaultState = ResourceState::AccelerationStructureBuildInput;
-        ComPtr<IBufferResource> instanceBuffer =
-            m_device->createBufferResource(instanceBufferDesc, instanceDescs.getBuffer());
+        ComPtr<IBuffer> instanceBuffer =
+            m_device->createBuffer(instanceBufferDesc, instanceDescs.getBuffer());
 
         IAccelerationStructure::BuildInputs accelerationStructureBuildInputs = {};
         IAccelerationStructure::PrebuildInfo accelerationStructurePrebuildInfo = {};
@@ -892,17 +830,17 @@ void RenderTestApp::_initializeAccelerationStructure()
         m_device->getAccelerationStructurePrebuildInfo(
             accelerationStructureBuildInputs, &accelerationStructurePrebuildInfo);
 
-        IBufferResource::Desc asBufferDesc = {};
-        asBufferDesc.type = IResource::Type::Buffer;
+        BufferDesc asBufferDesc = {};
+        asBufferDesc.usage = BufferUsage::AccelerationStructure;
         asBufferDesc.defaultState = ResourceState::AccelerationStructure;
-        asBufferDesc.sizeInBytes = (size_t)accelerationStructurePrebuildInfo.resultDataMaxSize;
-        m_tlasBuffer = m_device->createBufferResource(asBufferDesc);
+        asBufferDesc.size = (size_t)accelerationStructurePrebuildInfo.resultDataMaxSize;
+        m_tlasBuffer = m_device->createBuffer(asBufferDesc);
 
-        IBufferResource::Desc scratchBufferDesc = {};
-        scratchBufferDesc.type = IResource::Type::Buffer;
+        BufferDesc scratchBufferDesc = {};
+        scratchBufferDesc.usage = BufferUsage::UnorderedAccess;
         scratchBufferDesc.defaultState = ResourceState::UnorderedAccess;
-        scratchBufferDesc.sizeInBytes = (size_t)accelerationStructurePrebuildInfo.scratchDataSize;
-        ComPtr<IBufferResource> scratchBuffer = m_device->createBufferResource(scratchBufferDesc);
+        scratchBufferDesc.size = (size_t)accelerationStructurePrebuildInfo.scratchDataSize;
+        ComPtr<IBuffer> scratchBuffer = m_device->createBuffer(scratchBufferDesc);
 
         IAccelerationStructure::CreateDesc createDesc = {};
         createDesc.buffer = m_tlasBuffer;
@@ -987,48 +925,16 @@ Result RenderTestApp::writeBindingOutput(const String& fileName)
     for(auto outputItem : m_outputPlan.items)
     {
         auto resource = outputItem.resource;
-        if (resource && resource->getType() == IResource::Type::Buffer)
+        IBuffer* buffer = nullptr;
+        resource->queryInterface(IBuffer::getTypeGuid(), (void**)&buffer);
+        if (buffer)
         {
-            IBufferResource* bufferResource = static_cast<IBufferResource*>(resource.get());
-            auto bufferDesc = *bufferResource->getDesc();
-            const size_t bufferSize = bufferDesc.sizeInBytes;
+            const BufferDesc& bufferDesc = buffer->getDesc();
+            const size_t bufferSize = bufferDesc.size;
 
             ComPtr<ISlangBlob> blob;
-            if(bufferDesc.memoryType == MemoryType::ReadBack)
-            {
-                // The buffer is already allocated for CPU access, so we can read it back directly.
-                //
-                m_device->readBufferResource(bufferResource, 0, bufferSize, blob.writeRef());
-            }
-            else
-            {
-                // The buffer is not CPU-readable, so we will copy it using a staging buffer.
-
-                auto stagingBufferDesc = bufferDesc;
-                stagingBufferDesc.memoryType = MemoryType::ReadBack;
-                stagingBufferDesc.allowedStates =
-                    ResourceStateSet(ResourceState::CopyDestination, ResourceState::CopySource);
-                stagingBufferDesc.defaultState = ResourceState::CopyDestination;
-
-                ComPtr<IBufferResource> stagingBuffer;
-                SLANG_RETURN_ON_FAIL(m_device->createBufferResource(stagingBufferDesc, nullptr, stagingBuffer.writeRef()));
-
-                ComPtr<ICommandBuffer> commandBuffer;
-                SLANG_RETURN_ON_FAIL(
-                    m_transientHeap->createCommandBuffer(commandBuffer.writeRef()));
-
-                IResourceCommandEncoder* encoder = nullptr;
-                commandBuffer->encodeResourceCommands(&encoder);
-                encoder->copyBuffer(stagingBuffer, 0, bufferResource, 0, bufferSize);
-                encoder->endEncoding();
-
-                commandBuffer->close();
-                m_queue->executeCommandBuffer(commandBuffer);
-                m_transientHeap->finish();
-                m_transientHeap->synchronizeAndReset();
-
-                SLANG_RETURN_ON_FAIL(m_device->readBufferResource(stagingBuffer, 0, bufferSize, blob.writeRef()));
-            }
+            m_device->readBuffer(buffer, 0, bufferSize, blob.writeRef());
+            buffer->release();
 
             if (!blob)
             {
@@ -1054,7 +960,7 @@ Result RenderTestApp::writeScreen(const String& filename)
 {
     size_t rowPitch, pixelSize;
     ComPtr<ISlangBlob> blob;
-    SLANG_RETURN_ON_FAIL(m_device->readTextureResource(
+    SLANG_RETURN_ON_FAIL(m_device->readTexture(
         m_colorBuffer, ResourceState::RenderTarget, blob.writeRef(), &rowPitch, &pixelSize));
     auto bufferSize = blob->getBufferSize();
     uint32_t width = static_cast<uint32_t>(rowPitch / pixelSize);
@@ -1073,7 +979,24 @@ Result RenderTestApp::update()
     }
     else
     {
-        auto encoder = commandBuffer->encodeRenderCommands(m_renderPass, m_framebuffer);
+        RenderPassColorAttachment colorAttachment = {};
+        colorAttachment.view = m_colorBufferView;
+        colorAttachment.loadOp = LoadOp::Clear;
+        colorAttachment.storeOp = StoreOp::Store;
+        colorAttachment.initialState = ResourceState::Undefined;
+        colorAttachment.finalState = ResourceState::RenderTarget;
+        RenderPassDepthStencilAttachment depthStencilAttachment = {};
+        depthStencilAttachment.view = m_depthBufferView;
+        depthStencilAttachment.depthLoadOp = LoadOp::Clear;
+        depthStencilAttachment.depthStoreOp = StoreOp::Store;
+        depthStencilAttachment.initialState = ResourceState::Undefined;
+        depthStencilAttachment.finalState = ResourceState::DepthWrite;
+        RenderPassDesc renderPass = {};
+        renderPass.colorAttachments = &colorAttachment;
+        renderPass.colorAttachmentCount = 1;
+        renderPass.depthStencilAttachment = &depthStencilAttachment;
+
+        auto encoder = commandBuffer->encodeRenderCommands(renderPass);
         rhi::Viewport viewport = {};
         viewport.maxZ = 1.0f;
         viewport.extentX = (float)gWindowWidth;
@@ -1113,7 +1036,7 @@ Result RenderTestApp::update()
                 if (binding.resource && binding.resource->isBuffer())
                 {
                     BufferResource* bufferResource = static_cast<BufferResource*>(binding.resource.Ptr());
-                    const size_t bufferSize = bufferResource->getDesc().sizeInBytes;
+                    const size_t bufferSize = bufferResource->getDesc().size;
                     unsigned int* ptr = (unsigned int*)m_renderer->map(bufferResource, MapFlavor::HostRead);
                     if (!ptr)
                     {                            
@@ -1252,7 +1175,7 @@ static SlangResult _innerMain(Slang::StdWriters* stdWriters, SlangSession* sessi
 
 	// Parse command-line options
 	SLANG_RETURN_ON_FAIL(Options::parse(argcIn, argvIn, StdWriters::getError(), options));
-    if (options.deviceType == DeviceType::Unknown)
+    if (options.deviceType == DeviceType::Default)
     {
         return SLANG_OK;
     }

--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -19,9 +19,15 @@ namespace renderer_test
 
     Format _getFormatFromName(const UnownedStringSlice& slice)
     {
-#define SLANG_FORMAT_CASE(name, blockSizeInBytes, pixelsPerBlock) if (slice == #name) return Format::name; else 
-
-        SLANG_RHI_FORMAT(SLANG_FORMAT_CASE)
+        for (int i = 0; i < int(Format::_Count); ++i)
+        {
+            FormatInfo info;
+            rhiGetFormatInfo(Format(i), &info);
+            if (slice == info.name)
+            {
+                return Format(i);
+            }
+        }
         return Format::Unknown;
     }
 

--- a/tools/render-test/shader-renderer-util.cpp
+++ b/tools/render-test/shader-renderer-util.cpp
@@ -13,49 +13,26 @@ inline int calcMipSize(int size, int level)
     return size > 0 ? size : 1;
 }
 
-inline ITextureResource::Extents calcMipSize(ITextureResource::Extents size, int mipLevel)
+inline Extents calcMipSize(Extents size, int mipLevel)
 {
-    ITextureResource::Extents rs;
+    Extents rs;
     rs.width = calcMipSize(size.width, mipLevel);
     rs.height = calcMipSize(size.height, mipLevel);
     rs.depth = calcMipSize(size.depth, mipLevel);
     return rs;
 }
 
-/// Calculate the effective array size - in essence the amount if mip map sets needed.
-/// In practice takes into account if the arraySize is 0 (it's not an array, but it will still have
-/// at least one mip set) and if the type is a cubemap (multiplies the amount of mip sets by 6)
-inline int calcEffectiveArraySize(const ITextureResource::Desc& desc)
-{
-    const int arrSize = (desc.arraySize > 0) ? desc.arraySize : 1;
-
-    switch (desc.type)
-    {
-    case IResource::Type::Texture1D: // fallthru
-    case IResource::Type::Texture2D:
-        {
-            return arrSize;
-        }
-    case IResource::Type::TextureCube:
-        return arrSize * 6;
-    case IResource::Type::Texture3D:
-        return 1;
-    default:
-        return 0;
-    }
-}
-
 /// Given the type works out the maximum dimension size
-inline int calcMaxDimension(ITextureResource::Extents size, IResource::Type type)
+inline int calcMaxDimension(Extents size, TextureType type)
 {
     switch (type)
     {
-    case IResource::Type::Texture1D:
+    case TextureType::Texture1D:
         return size.width;
-    case IResource::Type::Texture3D:
+    case TextureType::Texture3D:
         return Math::Max(Math::Max(size.width, size.height), size.depth);
-    case IResource::Type::TextureCube: // fallthru
-    case IResource::Type::Texture2D:
+    case TextureType::TextureCube: // fallthru
+    case TextureType::Texture2D:
         {
             return Math::Max(size.width, size.height);
         }
@@ -65,115 +42,103 @@ inline int calcMaxDimension(ITextureResource::Extents size, IResource::Type type
 }
 
 /// Given the type, calculates the number of mip maps. 0 on error
-inline int calcNumMipLevels(IResource::Type type, ITextureResource::Extents size)
+inline int calcNumMipLevels(TextureType type, Extents size)
 {
     const int maxDimensionSize = calcMaxDimension(size, type);
     return (maxDimensionSize > 0) ? (Math::Log2Floor(maxDimensionSize) + 1) : 0;
 }
 
-/// Calculate the total number of sub resources. 0 on error.
-inline int calcNumSubResources(const ITextureResource::Desc& desc)
-{
-    const int numMipMaps =
-        (desc.numMipLevels > 0) ? desc.numMipLevels : calcNumMipLevels(desc.type, desc.size);
-    const int arrSize = (desc.arraySize > 0) ? desc.arraySize : 1;
-
-    switch (desc.type)
-    {
-    case IResource::Type::Texture1D:
-    case IResource::Type::Texture2D:
-    case IResource::Type::Texture3D:
-        {
-            return numMipMaps * arrSize;
-        }
-    case IResource::Type::TextureCube:
-        {
-            // There are 6 faces to a cubemap
-            return numMipMaps * arrSize * 6;
-        }
-    default:
-        return 0;
-    }
-}
-
-/* static */ Result ShaderRendererUtil::generateTextureResource(
+/* static */ Result ShaderRendererUtil::generateTexture(
     const InputTextureDesc& inputDesc,
     ResourceState defaultState,
     IDevice* device,
-    ComPtr<ITextureResource>& textureOut)
+    ComPtr<ITexture>& textureOut)
 {
     TextureData texData;
     generateTextureData(texData, inputDesc);
-    return createTextureResource(inputDesc, texData, defaultState, device, textureOut);
+    return createTexture(inputDesc, texData, defaultState, device, textureOut);
 }
 
-/* static */ Result ShaderRendererUtil::createTextureResource(
+/* static */ Result ShaderRendererUtil::createTexture(
     const InputTextureDesc& inputDesc,
     const TextureData& texData,
     ResourceState defaultState,
     IDevice* device,
-    ComPtr<ITextureResource>& textureOut)
+    ComPtr<ITexture>& textureOut)
 {
-    ITextureResource::Desc textureResourceDesc = {};
+    TextureDesc textureDesc = {};
 
     // Default to R8G8B8A8_UNORM
     const Format format = (inputDesc.format == Format::Unknown) ? Format::R8G8B8A8_UNORM : inputDesc.format;
 
-    textureResourceDesc.sampleDesc = ITextureResource::SampleDesc{inputDesc.sampleCount, 0};
-    textureResourceDesc.format = format;
-    textureResourceDesc.numMipLevels = texData.m_mipLevels;
-    textureResourceDesc.arraySize = inputDesc.arrayLength;
-    textureResourceDesc.allowedStates =
-        ResourceStateSet(defaultState, ResourceState::CopyDestination, ResourceState::CopySource);
-    textureResourceDesc.defaultState = defaultState;
+    textureDesc.sampleCount = inputDesc.sampleCount;
+    textureDesc.format = format;
+    textureDesc.numMipLevels = texData.m_mipLevels;
+    textureDesc.arrayLength = inputDesc.arrayLength > 0 ? inputDesc.arrayLength : 1;
+    textureDesc.usage = TextureUsage::CopyDestination | TextureUsage::CopySource;
+    switch (defaultState)
+    {
+    case ResourceState::ShaderResource:
+        textureDesc.usage |= TextureUsage::ShaderResource;
+        break;
+    case ResourceState::UnorderedAccess:
+        textureDesc.usage |= TextureUsage::UnorderedAccess;
+        break;
+    default:
+        return SLANG_FAIL;
+    }
+    textureDesc.defaultState = defaultState;
 
     // It's the same size in all dimensions
     switch (inputDesc.dimension)
     {
         case 1:
         {
-            textureResourceDesc.type = IResource::Type::Texture1D;
-            textureResourceDesc.size.width = inputDesc.size;
-            textureResourceDesc.size.height = 1;
-            textureResourceDesc.size.depth = 1;
+            textureDesc.type = TextureType::Texture1D;
+            textureDesc.size.width = inputDesc.size;
+            textureDesc.size.height = 1;
+            textureDesc.size.depth = 1;
 
             break;
         }
         case 2:
         {
-            textureResourceDesc.type = inputDesc.isCube ? IResource::Type::TextureCube : IResource::Type::Texture2D;
-            textureResourceDesc.size.width = inputDesc.size;
-            textureResourceDesc.size.height = inputDesc.size;
-            textureResourceDesc.size.depth = 1;
+            textureDesc.type = inputDesc.isCube ? TextureType::TextureCube : TextureType::Texture2D;
+            textureDesc.size.width = inputDesc.size;
+            textureDesc.size.height = inputDesc.size;
+            textureDesc.size.depth = 1;
             break;
         }
         case 3:
         {
-            textureResourceDesc.type = IResource::Type::Texture3D;
-            textureResourceDesc.size.width = inputDesc.size;
-            textureResourceDesc.size.height = inputDesc.size;
-            textureResourceDesc.size.depth = inputDesc.size;
+            textureDesc.type = TextureType::Texture3D;
+            textureDesc.size.width = inputDesc.size;
+            textureDesc.size.height = inputDesc.size;
+            textureDesc.size.depth = inputDesc.size;
             break;
         }
     }
 
-    const int effectiveArraySize = calcEffectiveArraySize(textureResourceDesc);
-    const int numSubResources = calcNumSubResources(textureResourceDesc);
-
-    List<ITextureResource::SubresourceData> initSubresources;
-    int subResourceCounter = 0;
-    for( int a = 0; a < effectiveArraySize; ++a )
+    if (textureDesc.numMipLevels == 0)
     {
-        for( int m = 0; m < textureResourceDesc.numMipLevels; ++m )
+        textureDesc.numMipLevels = calcNumMipLevels(textureDesc.type, textureDesc.size);
+    }
+
+    List<SubresourceData> initSubresources;
+    int arrayLayerCount = textureDesc.arrayLength * (textureDesc.type == TextureType::TextureCube ? 6 : 1);
+    int subResourceCounter = 0;
+    for( int a = 0; a < arrayLayerCount; ++a )
+    {
+        for( int m = 0; m < textureDesc.numMipLevels; ++m )
         {
             int subResourceIndex = subResourceCounter++;
-            const int mipWidth = calcMipSize(textureResourceDesc.size.width, m);
-            const int mipHeight = calcMipSize(textureResourceDesc.size.height, m);
+            const int mipWidth = calcMipSize(textureDesc.size.width, m);
+            const int mipHeight = calcMipSize(textureDesc.size.height, m);
 
             auto strideY = mipWidth * sizeof(uint32_t);
             auto strideZ = mipHeight * strideY;
 
-            ITextureResource::SubresourceData subresourceData;
+            SubresourceData subresourceData;
             subresourceData.data = texData.m_slices[subResourceIndex].values;
             subresourceData.strideY = strideY;
             subresourceData.strideZ = strideZ;
@@ -182,31 +147,26 @@ inline int calcNumSubResources(const ITextureResource::Desc& desc)
         }
     }
 
-    textureOut = device->createTextureResource(textureResourceDesc, initSubresources.getBuffer());
+    textureOut = device->createTexture(textureDesc, initSubresources.getBuffer());
 
     return textureOut ? SLANG_OK : SLANG_FAIL;
 }
 
-/* static */ Result ShaderRendererUtil::createBufferResource(
+/* static */ Result ShaderRendererUtil::createBuffer(
     const InputBufferDesc& inputDesc,
     size_t bufferSize,
     const void* initData,
     IDevice* device,
-    Slang::ComPtr<IBufferResource>& bufferOut)
+    Slang::ComPtr<IBuffer>& bufferOut)
 {
-    IBufferResource::Desc srcDesc;
-    srcDesc.type = IResource::Type::Buffer;
-    srcDesc.sizeInBytes = bufferSize;
-    srcDesc.format = inputDesc.format;
-    srcDesc.elementSize = inputDesc.stride;
-    srcDesc.defaultState = ResourceState::UnorderedAccess;
-    srcDesc.allowedStates = ResourceStateSet(
-        ResourceState::CopyDestination,
-        ResourceState::CopySource,
-        ResourceState::UnorderedAccess,
-        ResourceState::ShaderResource);
+    BufferDesc bufferDesc;
+    bufferDesc.size = bufferSize;
+    bufferDesc.format = inputDesc.format;
+    bufferDesc.elementSize = inputDesc.stride;
+    bufferDesc.usage = BufferUsage::CopyDestination | BufferUsage::CopySource | BufferUsage::ShaderResource | BufferUsage::UnorderedAccess;
+    bufferDesc.defaultState = ResourceState::UnorderedAccess;
 
-    ComPtr<IBufferResource> bufferResource = device->createBufferResource(srcDesc, initData);
+    ComPtr<IBuffer> bufferResource = device->createBuffer(bufferDesc, initData);
     if (!bufferResource)
     {
         return SLANG_FAIL;
@@ -216,21 +176,21 @@ inline int calcNumSubResources(const ITextureResource::Desc& desc)
     return SLANG_OK;
 }
 
-static ISamplerState::Desc _calcSamplerDesc(const InputSamplerDesc& srcDesc)
+static SamplerDesc _calcSamplerDesc(const InputSamplerDesc& srcDesc)
 {
-    ISamplerState::Desc dstDesc;
+    SamplerDesc samplerDesc;
     if (srcDesc.isCompareSampler)
     {
-        dstDesc.reductionOp = TextureReductionOp::Comparison;
-        dstDesc.comparisonFunc = ComparisonFunc::Less;
+        samplerDesc.reductionOp = TextureReductionOp::Comparison;
+        samplerDesc.comparisonFunc = ComparisonFunc::Less;
     }
-    return dstDesc;
+    return samplerDesc;
 }
 
-ComPtr<ISamplerState> _createSamplerState(IDevice* device,
+ComPtr<ISampler> _createSampler(IDevice* device,
     const InputSamplerDesc& srcDesc)
 {
-    return device->createSamplerState(_calcSamplerDesc(srcDesc));
+    return device->createSampler(_calcSamplerDesc(srcDesc));
 }
 
 } // renderer_test

--- a/tools/render-test/shader-renderer-util.h
+++ b/tools/render-test/shader-renderer-util.h
@@ -8,33 +8,33 @@ namespace renderer_test {
 
 using namespace Slang;
 
-ComPtr<ISamplerState> _createSamplerState(IDevice* device, const InputSamplerDesc& srcDesc);
+ComPtr<ISampler> _createSampler(IDevice* device, const InputSamplerDesc& srcDesc);
 
 /// Utility class containing functions that construct items on the renderer using the ShaderInputLayout representation
 struct ShaderRendererUtil
 {
-        /// Generate a texture using the InputTextureDesc and construct a TextureResource using the Renderer with the contents
-    static Slang::Result generateTextureResource(
+        /// Generate a texture using the InputTextureDesc and construct a Texture using the Renderer with the contents
+    static Slang::Result generateTexture(
         const InputTextureDesc& inputDesc,
         ResourceState defaultState,
         IDevice* device,
-        ComPtr<ITextureResource>& textureOut);
+        ComPtr<ITexture>& textureOut);
 
         /// Create texture resource using inputDesc, and texData to describe format, and contents
-    static Slang::Result createTextureResource(
+    static Slang::Result createTexture(
         const InputTextureDesc& inputDesc,
         const TextureData& texData,
         ResourceState defaultState,
         IDevice* device,
-        ComPtr<ITextureResource>& textureOut);
+        ComPtr<ITexture>& textureOut);
 
         /// Create the BufferResource using the renderer from the contents of inputDesc
-    static Slang::Result createBufferResource(
+    static Slang::Result createBuffer(
         const InputBufferDesc& inputDesc,
         size_t bufferSize,
         const void* initData,
         IDevice* device,
-        ComPtr<IBufferResource>& bufferOut);
+        ComPtr<IBuffer>& bufferOut);
 };
 
 } // renderer_test

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -23,36 +23,6 @@ static const char rtEntryPointName[] = "raygenMain";
 static const char taskEntryPointName[] = "taskMain";
 static const char meshEntryPointName[] = "meshMain";
 
-rhi::StageType translateStage(SlangStage slangStage)
-{
-    switch(slangStage)
-    {
-    default:
-        SLANG_ASSERT(!"unhandled case");
-        return rhi::StageType::Unknown;
-
-#define CASE(FROM, TO) \
-    case SLANG_STAGE_##FROM: return rhi::StageType::TO
-
-    CASE(VERTEX,    Vertex);
-    CASE(HULL,      Hull);
-    CASE(DOMAIN,    Domain);
-    CASE(GEOMETRY,  Geometry);
-    CASE(FRAGMENT,  Fragment);
-
-    CASE(COMPUTE,   Compute);
-
-    CASE(RAY_GENERATION,    RayGeneration);
-    CASE(INTERSECTION,      Intersection);
-    CASE(ANY_HIT,           AnyHit);
-    CASE(CLOSEST_HIT,       ClosestHit);
-    CASE(MISS,              Miss);
-    CASE(CALLABLE,          Callable);
-
-#undef CASE
-    }
-}
-
 void ShaderCompilerUtil::Output::set(
     slang::IComponentType*              inSlangProgram)
 {

--- a/tools/render-test/slang-support.h
+++ b/tools/render-test/slang-support.h
@@ -10,8 +10,6 @@
 
 namespace renderer_test {
 
-rhi::StageType translateStage(SlangStage slangStage);
-
 struct ShaderCompileRequest
 {
     struct SourceInfo
@@ -71,7 +69,7 @@ struct ShaderCompilerUtil
         }
 
         ComPtr<slang::IComponentType> slangProgram;
-        IShaderProgram::Desc desc = {};
+        ShaderProgramDesc desc = {};
 
             /// Compile request that owns the lifetime of compiled kernel code.
         ComPtr<SlangCompileRequest> m_requestForKernels = nullptr;


### PR DESCRIPTION
- Update to latest version of `slang-rhi`.
- Refactor render test to new `slang-rhi` API.