### PR TITLE
WGSL implement texture intrinsics except gather and sampler-less

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -1256,14 +1256,14 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_1D):
-                        __intrinsic_asm "textureSample($0, $1, ($2).x, $(2).y)";
+                        __intrinsic_asm "textureSample($0, $1, ($2).x, i32(($2).y))$z";
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "textureSample($0, $1, ($2).xy, $(2).z)";
+                        __intrinsic_asm "textureSample($0, $1, ($2).xy, i32(($2).z))$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "textureSample($0, $1, ($2).xyz, $(2).w)";
+                        __intrinsic_asm "textureSample($0, $1, ($2).xyz, i32(($2).w))$z";
                     }
                 }
-                __intrinsic_asm "textureSample($0, $1, $2)";
+                __intrinsic_asm "textureSample($0, $1, $2)$z";
         }
     }
 
@@ -1320,14 +1320,14 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_1D):
-                        __intrinsic_asm "textureSample($0, $1, ($2).x, $(2).y, $3)";
+                        __intrinsic_asm "textureSample($0, $1, ($2).x, i32(($2).y), $3)$z";
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "textureSample($0, $1, ($2).xy, $(2).z, $3)";
+                        __intrinsic_asm "textureSample($0, $1, ($2).xy, i32(($2).z), $3)$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "textureSample($0, $1, ($2).xyz, $(2).w, $3)";
+                        __intrinsic_asm "textureSample($0, $1, ($2).xyz, i32(($2).w), $3)$z";
                     }
                 }
-                __intrinsic_asm "textureSample($0, $1, $2, $3)";
+                __intrinsic_asm "textureSample($0, $1, $2, $3)$z";
         }
     }
 
@@ -1452,14 +1452,14 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_1D):
-                        __intrinsic_asm "textureSampleBias($0, $1, ($2).x, $(2).y, $3)";
+                        __intrinsic_asm "textureSampleBias($0, $1, ($2).x, i32(($2).y), $3)$z";
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "textureSampleBias($0, $1, ($2).xy, $(2).z, $3)";
+                        __intrinsic_asm "textureSampleBias($0, $1, ($2).xy, i32(($2).z), $3)$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "textureSampleBias($0, $1, ($2).xyz, $(2).w, $3)";
+                        __intrinsic_asm "textureSampleBias($0, $1, ($2).xyz, i32(($2).w), $3)$z";
                     }
                 }
-                __intrinsic_asm "textureSampleBias($0, $1, $2, $3)";
+                __intrinsic_asm "textureSampleBias($0, $1, $2, $3)$z";
         }
     }
 
@@ -1515,14 +1515,14 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_1D):
-                        __intrinsic_asm "textureSampleBias($0, $1, ($2).x, $(2).y, $3, $4)";
+                        __intrinsic_asm "textureSampleBias($0, $1, ($2).x, i32(($2).y), $3, $4)$z";
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "textureSampleBias($0, $1, ($2).xy, $(2).z, $3, $4)";
+                        __intrinsic_asm "textureSampleBias($0, $1, ($2).xy, i32(($2).z), $3, $4)$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "textureSampleBias($0, $1, ($2).xyz, $(2).w, $3, $4)";
+                        __intrinsic_asm "textureSampleBias($0, $1, ($2).xyz, i32(($2).w), $3, $4)$z";
                     }
                 }
-                __intrinsic_asm "textureSampleBias($0, $1, $2, $3, $4)";
+                __intrinsic_asm "textureSampleBias($0, $1, $2, $3, $4)$z";
         }
     }
 
@@ -1587,11 +1587,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 switch (Shape.flavor)
                 {
                 case $(SLANG_TEXTURE_1D):
-                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).x, $(2).y, $3)";
+                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).x, i32(($2).y), $3)";
                 case $(SLANG_TEXTURE_2D):
-                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).xy, $(2).z, $3)";
+                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).xy, i32(($2).z), $3)";
                 case $(SLANG_TEXTURE_CUBE):
-                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).xyz, $(2).w, $3)";
+                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).xyz, i32(($2).w), $3)";
                 }
             }
             __intrinsic_asm "textureSampleCompare($0, $1, $2, $3)";
@@ -1655,11 +1655,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 switch (Shape.flavor)
                 {
                 case $(SLANG_TEXTURE_1D):
-                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).x, $(2).y, $3)";
+                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).x, i32(($2).y), $3)";
                 case $(SLANG_TEXTURE_2D):
-                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).xy, $(2).z, $3)";
+                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).xy, i32(($2).z), $3)";
                 case $(SLANG_TEXTURE_CUBE):
-                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).xyz, $(2).w, $3)";
+                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).xyz, i32(($2).w), $3)";
                 }
             }
             __intrinsic_asm "textureSampleCompareLevel($0, $1, $2, $3)";
@@ -1720,11 +1720,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 switch (Shape.flavor)
                 {
                 case $(SLANG_TEXTURE_1D):
-                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).x, $(2).y, $3, $4)";
+                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).x, i32(($2).y), $3, $4)";
                 case $(SLANG_TEXTURE_2D):
-                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).xy, $(2).z, $3, $4)";
+                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).xy, i32(($2).z), $3, $4)";
                 case $(SLANG_TEXTURE_CUBE):
-                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).xyz, $(2).w, $3, $4)";
+                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).xyz, i32(($2).w), $3, $4)";
                 }
             }
             __intrinsic_asm "textureSampleCompare($0, $1, $2, $3, $4)";
@@ -1787,11 +1787,11 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 switch (Shape.flavor)
                 {
                 case $(SLANG_TEXTURE_1D):
-                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).x, $(2).y, $3, $4)";
+                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).x, i32(($2).y), $3, $4)";
                 case $(SLANG_TEXTURE_2D):
-                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).xy, $(2).z, $3, $4)";
+                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).xy, i32(($2).z), $3, $4)";
                 case $(SLANG_TEXTURE_CUBE):
-                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).xyz, $(2).w, $3, $4)";
+                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).xyz, i32(($2).w), $3, $4)";
                 }
             }
             __intrinsic_asm "textureSampleCompareLevel($0, $1, $2, $3, $4)";
@@ -1854,14 +1854,14 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_1D):
-                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).x, $(2).y, $3, $4)";
+                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).x, i32(($2).y), $3, $4)$z";
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).xy, $(2).z, $3, $4)";
+                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).xy, i32(($2).z), $3, $4)$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).xyz, $(2).w, $3, $4)";
+                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).xyz, i32(($2).w), $3, $4)$z";
                     }
                 }
-                __intrinsic_asm "textureSampleGrad($0, $1, $2, $3, $4)";
+                __intrinsic_asm "textureSampleGrad($0, $1, $2, $3, $4)$z";
         }
     }
 
@@ -1918,14 +1918,14 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_1D):
-                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).x, $(2).y, $3, $4, $5)";
+                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).x, i32(($2).y), $3, $4, $5)$z";
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).xy, $(2).z, $3, $4, $5)";
+                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).xy, i32(($2).z), $3, $4, $5)$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).xyz, $(2).w, $3, $4, $5)";
+                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).xyz, i32(($2).w), $3, $4, $5)$z";
                     }
                 }
-                __intrinsic_asm "textureSampleGrad($0, $1, $2, $3, $4, $5)";
+                __intrinsic_asm "textureSampleGrad($0, $1, $2, $3, $4, $5)$z";
         }
     }
 
@@ -2067,14 +2067,14 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_1D):
-                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).x, $(2).y, $3)";
+                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).x, i32(($2).y), $3)$z";
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).xy, $(2).z, $3)";
+                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).xy, i32(($2).z), $3)$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).xyz, $(2).w, $3)";
+                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).xyz, i32(($2).w), $3)$z";
                     }
                 }
-                __intrinsic_asm "textureSampleLevel($0, $1, $2, $3)";
+                __intrinsic_asm "textureSampleLevel($0, $1, $2, $3)$z";
         }
     }
 
@@ -2132,14 +2132,14 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_1D):
-                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).x, $(2).y, $3, $4)";
+                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).x, i32(($2).y), $3, $4)$z";
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).xy, $(2).z, $3, $4)";
+                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).xy, i32(($2).z), $3, $4)$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).xyz, $(2).w, $3, $4)";
+                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).xyz, i32(($2).w), $3, $4)$z";
                     }
                 }
-                __intrinsic_asm "textureSampleLevel($0, $1, $2, $3, $4)";
+                __intrinsic_asm "textureSampleLevel($0, $1, $2, $3, $4)$z";
         }
     }
 }
@@ -2743,19 +2743,27 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
         case wgsl:
             static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
                 , "WGSL supports only f32 type textures");
+            static_assert(Shape.flavor == $(SLANG_TEXTURE_1D)
+                || Shape.flavor == $(SLANG_TEXTURE_2D)
+                || Shape.flavor == $(SLANG_TEXTURE_3D)
+                , "WGSL supports textureLoad only for 1D, 2D and 3D textures");
             if (isArray == 1)
             {
                 switch (Shape.flavor)
                 {
-                case $(SLANG_TEXTURE_1D):
-                    __intrinsic_asm "textureLoad($0, ($1).x, $(1).y)";
                 case $(SLANG_TEXTURE_2D):
-                    __intrinsic_asm "textureLoad($0, ($1).xy, $(1).z)";
-                case $(SLANG_TEXTURE_CUBE):
-                    __intrinsic_asm "textureLoad($0, ($1).xyz, $(1).w)";
+                    __intrinsic_asm "textureLoad($0, ($1).xy, i32(($1).z), ($1).w)$z";
                 }
             }
-            __intrinsic_asm "textureLoad($0, $1)";
+            switch (Shape.flavor)
+            {
+            case $(SLANG_TEXTURE_1D):
+                __intrinsic_asm "textureLoad($0, ($1).x, ($1).y)$z";
+            case $(SLANG_TEXTURE_2D):
+                __intrinsic_asm "textureLoad($0, ($1).xy, ($1).z)$z";
+            case $(SLANG_TEXTURE_3D):
+                __intrinsic_asm "textureLoad($0, ($1).xyz, ($1).w)$z";
+            }
         }
     }
 
@@ -2801,14 +2809,14 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_1D):
-                        __intrinsic_asm "textureLoad($0, ($1).x, $(1).y, $2)";
+                        __intrinsic_asm "textureLoad($0, ($1).x, i32(($1).y), $2)$z";
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "textureLoad($0, ($1).xy, $(1).z, $2)";
+                        __intrinsic_asm "textureLoad($0, ($1).xy, i32(($1).z), $2)$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "textureLoad($0, ($1).xyz, $(1).w, $2)";
+                        __intrinsic_asm "textureLoad($0, ($1).xyz, i32(($1).w), $2)$z";
                     }
                 }
-                __intrinsic_asm "textureLoad($0, $1, $2)";
+                __intrinsic_asm "textureLoad($0, $1, $2)$z";
         }
     }
 
@@ -2943,14 +2951,14 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,form
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_1D):
-                        __intrinsic_asm "textureLoad($0, ($1).x, $(1).y, $2)";
+                        __intrinsic_asm "textureLoad($0, ($1).x, i32(($1).y), $2)$z";
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "textureLoad($0, ($1).xy, $(1).z, $2)";
+                        __intrinsic_asm "textureLoad($0, ($1).xy, i32(($1).z), $2)$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "textureLoad($0, ($1).xyz, $(1).w, $2)";
+                        __intrinsic_asm "textureLoad($0, ($1).xyz, i32(($1).w), $2)$z";
                     }
                 }
-                __intrinsic_asm "textureLoad($0, $1, $2)";
+                __intrinsic_asm "textureLoad($0, $1, $2)$z";
         }
     }
 
@@ -3181,14 +3189,14 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,form
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_1D):
-                        __intrinsic_asm "textureLoad($0, ($1).x, $(1).y)";
+                        __intrinsic_asm "textureLoad($0, ($1).x, i32(($1).y))$z";
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "textureLoad($0, ($1).xy, $(1).z)";
+                        __intrinsic_asm "textureLoad($0, ($1).xy, i32(($1).z))$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "textureLoad($0, ($1).xyz, $(1).w)";
+                        __intrinsic_asm "textureLoad($0, ($1).xyz, i32(($1).w))$z";
                     }
                 }
-                __intrinsic_asm "textureLoad($0, $1)";
+                __intrinsic_asm "textureLoad($0, $1)$z";
         }
     }
 
@@ -3360,14 +3368,14 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,form
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_1D):
-                        __intrinsic_asm "textureStore($0, ($1).x, $(1).y, $2)";
+                        __intrinsic_asm "textureStore($0, ($1).x, i32(($1).y), $2)$z";
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "textureStore($0, ($1).xy, $(1).z, $2)";
+                        __intrinsic_asm "textureStore($0, ($1).xy, i32(($1).z), $2)$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "textureStore($0, ($1).xyz, $(1).w, $2)";
+                        __intrinsic_asm "textureStore($0, ($1).xyz, i32(($1).w), $2)$z";
                     }
                 }
-                __intrinsic_asm "textureStore($0, $1, $2)";
+                __intrinsic_asm "textureStore($0, $1, $2)$z";
             }
         }
 
@@ -3439,14 +3447,14 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,form
                     switch (Shape.flavor)
                     {
                     case $(SLANG_TEXTURE_1D):
-                        __intrinsic_asm "textureLoad($0, ($1).x, $(1).y)";
+                        __intrinsic_asm "textureLoad($0, ($1).x, i32(($1).y))$z";
                     case $(SLANG_TEXTURE_2D):
-                        __intrinsic_asm "textureLoad($0, ($1).xy, $(1).z)";
+                        __intrinsic_asm "textureLoad($0, ($1).xy, i32(($1).z))$z";
                     case $(SLANG_TEXTURE_CUBE):
-                        __intrinsic_asm "textureLoad($0, ($1).xyz, $(1).w)";
+                        __intrinsic_asm "textureLoad($0, ($1).xyz, i32(($1).w))$z";
                     }
                 }
-                __intrinsic_asm "textureLoad($0, $1)";
+                __intrinsic_asm "textureLoad($0, $1)$z";
         }
     }
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -610,7 +610,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_cuda_glsl_hlsl_metal_spirv, texture_sm_4_0_fragment)]
+    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
     T Sample(vector<float, Shape.dimensions+isArray> location)
     {
         __requireComputeDerivative();
@@ -661,12 +661,14 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                     %sampled : __sampledType(T) = OpImageSampleImplicitLod $this $location None;
                     __truncate $$T result __sampledType(T) %sampled;
                 };
+            case wgsl:
+                return __getTexture().Sample(__getSampler(), location);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
     T Sample(vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __requireComputeDerivative();
@@ -689,6 +691,8 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                     %sampled : __sampledType(T) = OpImageSampleImplicitLod $this $location None|ConstOffset $offset;
                     __truncate $$T result __sampledType(T) %sampled;
                 };
+            case wgsl:
+                return __getTexture().Sample(__getSampler(), location, offset);
         }
     }
 
@@ -740,7 +744,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
     T SampleBias(vector<float, Shape.dimensions+isArray> location, float bias)
     {
         __requireComputeDerivative();
@@ -763,12 +767,14 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                     __truncate $$T result __sampledType(T) %sampled;
 
                 };
+            case wgsl:
+                return __getTexture().SampleBias(__getSampler(), location, bias);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
     T SampleBias(vector<float, Shape.dimensions+isArray> location, float bias, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __requireComputeDerivative();
@@ -790,12 +796,14 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                     %sampled : __sampledType(T) = OpImageSampleImplicitLod $this $location None|Bias|ConstOffset $bias $offset;
                     __truncate $$T result __sampledType(T) %sampled;
                 };
+            case wgsl:
+                return __getTexture().SampleBias(__getSampler(), location, bias, offset);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
     float SampleCmp(vector<float, Shape.dimensions+isArray> location, float compareValue)
     {
         __requireComputeDerivative();
@@ -826,12 +834,14 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
             {
                 result:$$float = OpImageSampleDrefImplicitLod $this $location $compareValue;
             };
+        case wgsl:
+            return __getTexture().SampleCmp(__getComparisonSampler(), location, compareValue);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
     float SampleCmpLevelZero(vector<float, Shape.dimensions+isArray> location, float compareValue)
     {
         __target_switch
@@ -858,12 +868,14 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
             {
                 result:$$float = OpImageSampleDrefExplicitLod $this $location $compareValue Lod $zeroFloat;
             };
+        case wgsl:
+            return __getTexture().SampleCmpLevelZero(__getComparisonSampler(), location, compareValue);
         }
     }
 
     [__readNone] 
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
     float SampleCmp(vector<float, Shape.dimensions+isArray> location, float compareValue, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __requireComputeDerivative();
@@ -890,12 +902,14 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
             {
                 result:$$float = OpImageSampleDrefImplicitLod $this $location $compareValue ConstOffset $offset;
             };
+        case wgsl:
+            return __getTexture().SampleCmp(__getComparisonSampler(), location, compareValue, offset);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
     float SampleCmpLevelZero(vector<float, Shape.dimensions+isArray> location, float compareValue, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -922,12 +936,14 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
             {
                 result:$$float = OpImageSampleDrefExplicitLod $this $location $compareValue Lod|ConstOffset $zeroFloat $offset;
             };
+        case wgsl:
+            return __getTexture().SampleCmpLevelZero(__getComparisonSampler(), location, compareValue, offset);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
     T SampleGrad(vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY)
     {
         __target_switch
@@ -940,21 +956,22 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
             case cpp:
             case metal:
                 return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY);
-
             case glsl:
-            __intrinsic_asm "$ctextureGrad($0, $1, $2, $3)$z";
+                __intrinsic_asm "$ctextureGrad($0, $1, $2, $3)$z";
             case spirv:
                 return spirv_asm
                 {
                     %sampled : __sampledType(T) = OpImageSampleExplicitLod $this $location None|Grad $gradX $gradY;
                     __truncate $$T result __sampledType(T) %sampled;
                 };
+            case wgsl:
+                return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
     T SampleGrad(vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.dimensions> offset)
     {
         __target_switch
@@ -968,13 +985,15 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
             case metal:
                 return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY, offset);
             case glsl:
-            __intrinsic_asm "$ctextureGradOffset($0, $1, $2, $3, $4)$z";
+                __intrinsic_asm "$ctextureGradOffset($0, $1, $2, $3, $4)$z";
             case spirv:
                 return spirv_asm
                 {
                     %sampled : __sampledType(T) = OpImageSampleExplicitLod $this $location None|Grad|ConstOffset $gradX $gradY $offset;
                     __truncate $$T result __sampledType(T) %sampled;
                 };
+            case wgsl:
+                return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY, offset);
         }
     }
 
@@ -1008,7 +1027,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_cuda_glsl_hlsl_metal_spirv, texture_sm_4_0)]
+    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
     T SampleLevel(vector<float, Shape.dimensions+isArray> location, float level)
     {
         __target_switch
@@ -1060,12 +1079,14 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                     %sampled : __sampledType(T) = OpImageSampleExplicitLod $this $location None|Lod $level;
                     __truncate $$T result __sampledType(T) %sampled;
                 };
+            case wgsl:
+                return __getTexture().SampleLevel(__getSampler(), location, level);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
     T SampleLevel(vector<float, Shape.dimensions+isArray> location, float level, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -1078,7 +1099,6 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
             case cpp:
             case metal:
                 return __getTexture().SampleLevel(__getSampler(), location, level, offset);
-
             case glsl:
                 __intrinsic_asm "$ctextureLodOffset($0, $1, $2, $3)$z";
             case spirv:
@@ -1087,6 +1107,8 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                     %sampled : __sampledType(T) = OpImageSampleExplicitLod $this $location None|Lod|ConstOffset $level $offset;
                     __truncate $$T result __sampledType(T) %sampled;
                 };
+            case wgsl:
+                return __getTexture().SampleLevel(__getSampler(), location, level, offset);
         }
     }
 }
@@ -1147,7 +1169,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 {
     [__readNone]
     [ForceInline]
-    [require(cpp_cuda_glsl_hlsl_metal_spirv, texture_sm_4_0_fragment)]
+    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
     T Sample(SamplerState s, vector<float, Shape.dimensions+isArray> location)
     {
         __requireComputeDerivative();
@@ -1226,12 +1248,29 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     %sampled : __sampledType(T) = OpImageSampleImplicitLod %sampledImage $location None;
                     __truncate $$T result __sampledType(T) %sampled;
                 };
+            case wgsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    , "WGSL supports only f32 type textures");
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_1D):
+                        __intrinsic_asm "textureSample($0, $1, ($2).x, $(2).y)";
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "textureSample($0, $1, ($2).xy, $(2).z)";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "textureSample($0, $1, ($2).xyz, $(2).w)";
+                    }
+                }
+                __intrinsic_asm "textureSample($0, $1, $2)";
         }
     }
 
+
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
     T Sample(SamplerState s, vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __requireComputeDerivative();
@@ -1267,12 +1306,28 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
             case glsl:
                 __intrinsic_asm "$ctextureOffset($p, $2, $3)$z";
             case spirv:
-            return spirv_asm
-            {
-                %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
-                %sampled : __sampledType(T) = OpImageSampleImplicitLod %sampledImage $location None|ConstOffset $offset;
-                __truncate $$T result __sampledType(T) %sampled;
-            };
+                return spirv_asm
+                {
+                    %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
+                    %sampled : __sampledType(T) = OpImageSampleImplicitLod %sampledImage $location None|ConstOffset $offset;
+                    __truncate $$T result __sampledType(T) %sampled;
+                };
+            case wgsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    , "WGSL supports only f32 type textures");
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_1D):
+                        __intrinsic_asm "textureSample($0, $1, ($2).x, $(2).y, $3)";
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "textureSample($0, $1, ($2).xy, $(2).z, $3)";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "textureSample($0, $1, ($2).xyz, $(2).w, $3)";
+                    }
+                }
+                __intrinsic_asm "textureSample($0, $1, $2, $3)";
         }
     }
 
@@ -1344,7 +1399,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
     T SampleBias(SamplerState s, vector<float, Shape.dimensions+isArray> location, float bias)
     {
         __requireComputeDerivative();
@@ -1381,20 +1436,36 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 // TODO: This needs to be handled by the capability system
                 __intrinsic_asm "<invalid intrinsic>";
             case glsl:
-            __intrinsic_asm "$ctexture($p, $2, $3)$z";
+                __intrinsic_asm "$ctexture($p, $2, $3)$z";
             case spirv:
-            return spirv_asm
-            {
-                %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
-                %sampled : __sampledType(T) = OpImageSampleImplicitLod %sampledImage $location None|Bias $bias;
-                __truncate $$T result __sampledType(T) %sampled;
-            };
+                return spirv_asm
+                {
+                    %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
+                    %sampled : __sampledType(T) = OpImageSampleImplicitLod %sampledImage $location None|Bias $bias;
+                    __truncate $$T result __sampledType(T) %sampled;
+                };
+            case wgsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    , "WGSL supports only f32 type textures");
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_1D):
+                        __intrinsic_asm "textureSampleBias($0, $1, ($2).x, $(2).y, $3)";
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "textureSampleBias($0, $1, ($2).xy, $(2).z, $3)";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "textureSampleBias($0, $1, ($2).xyz, $(2).w, $3)";
+                    }
+                }
+                __intrinsic_asm "textureSampleBias($0, $1, $2, $3)";
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
     T SampleBias(SamplerState s, vector<float, Shape.dimensions+isArray> location, float bias, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __requireComputeDerivative();
@@ -1428,20 +1499,36 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 // TODO: This needs to be handled by the capability system
                 __intrinsic_asm "<invalid intrinsic>";
             case glsl:
-            __intrinsic_asm "$ctextureOffset($p, $2, $4, $3)$z";
+                __intrinsic_asm "$ctextureOffset($p, $2, $4, $3)$z";
             case spirv:
-            return spirv_asm
-            {
-                %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
-                %sampled : __sampledType(T) = OpImageSampleImplicitLod %sampledImage $location None|Bias|ConstOffset $bias $offset;
-                __truncate $$T result __sampledType(T) %sampled;
-            };
+                return spirv_asm
+                {
+                    %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
+                    %sampled : __sampledType(T) = OpImageSampleImplicitLod %sampledImage $location None|Bias|ConstOffset $bias $offset;
+                    __truncate $$T result __sampledType(T) %sampled;
+                };
+            case wgsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    , "WGSL supports only f32 type textures");
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_1D):
+                        __intrinsic_asm "textureSampleBias($0, $1, ($2).x, $(2).y, $3, $4)";
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "textureSampleBias($0, $1, ($2).xy, $(2).z, $3, $4)";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "textureSampleBias($0, $1, ($2).xyz, $(2).w, $3, $4)";
+                    }
+                }
+                __intrinsic_asm "textureSampleBias($0, $1, $2, $3, $4)";
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
     float SampleCmp(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue)
     {
         __requireComputeDerivative();
@@ -1492,12 +1579,28 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
                 result:$$float = OpImageSampleDrefImplicitLod %sampledImage $location $compareValue;
             };
+        case wgsl:
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                , "WGSL supports only f32 type textures");
+            if (isArray == 1)
+            {
+                switch (Shape.flavor)
+                {
+                case $(SLANG_TEXTURE_1D):
+                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).x, $(2).y, $3)";
+                case $(SLANG_TEXTURE_2D):
+                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).xy, $(2).z, $3)";
+                case $(SLANG_TEXTURE_CUBE):
+                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).xyz, $(2).w, $3)";
+                }
+            }
+            __intrinsic_asm "textureSampleCompare($0, $1, $2, $3)";
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
     float SampleCmpLevelZero(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue)
     {
         __target_switch
@@ -1544,12 +1647,28 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
                 result:$$float = OpImageSampleDrefExplicitLod %sampledImage $location $compareValue Lod $zeroFloat;
             };
+        case wgsl:
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                , "WGSL supports only f32 type textures");
+            if (isArray == 1)
+            {
+                switch (Shape.flavor)
+                {
+                case $(SLANG_TEXTURE_1D):
+                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).x, $(2).y, $3)";
+                case $(SLANG_TEXTURE_2D):
+                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).xy, $(2).z, $3)";
+                case $(SLANG_TEXTURE_CUBE):
+                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).xyz, $(2).w, $3)";
+                }
+            }
+            __intrinsic_asm "textureSampleCompareLevel($0, $1, $2, $3)";
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
     float SampleCmp(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __requireComputeDerivative();
@@ -1593,12 +1712,28 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
                 result:$$float = OpImageSampleDrefImplicitLod %sampledImage $location $compareValue ConstOffset $offset;
             };
+        case wgsl:
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                , "WGSL supports only f32 type textures");
+            if (isArray == 1)
+            {
+                switch (Shape.flavor)
+                {
+                case $(SLANG_TEXTURE_1D):
+                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).x, $(2).y, $3, $4)";
+                case $(SLANG_TEXTURE_2D):
+                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).xy, $(2).z, $3, $4)";
+                case $(SLANG_TEXTURE_CUBE):
+                    __intrinsic_asm "textureSampleCompare($0, $1, ($2).xyz, $(2).w, $3, $4)";
+                }
+            }
+            __intrinsic_asm "textureSampleCompare($0, $1, $2, $3, $4)";
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
     float SampleCmpLevelZero(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -1644,12 +1779,28 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
                 result:$$float = OpImageSampleDrefExplicitLod %sampledImage $location $compareValue Lod|ConstOffset $zeroFloat $offset;
             };
+        case wgsl:
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                , "WGSL supports only f32 type textures");
+            if (isArray == 1)
+            {
+                switch (Shape.flavor)
+                {
+                case $(SLANG_TEXTURE_1D):
+                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).x, $(2).y, $3, $4)";
+                case $(SLANG_TEXTURE_2D):
+                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).xy, $(2).z, $3, $4)";
+                case $(SLANG_TEXTURE_CUBE):
+                    __intrinsic_asm "textureSampleCompareLevel($0, $1, ($2).xyz, $(2).w, $3, $4)";
+                }
+            }
+            __intrinsic_asm "textureSampleCompareLevel($0, $1, $2, $3, $4)";
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
     T SampleGrad(SamplerState s, vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY)
     {
         __target_switch
@@ -1695,12 +1846,28 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     %sampled : __sampledType(T) = OpImageSampleExplicitLod %sampledImage $location None|Grad $gradX $gradY;
                     __truncate $$T result __sampledType(T) %sampled;
                 };
+            case wgsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    , "WGSL supports only f32 type textures");
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_1D):
+                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).x, $(2).y, $3, $4)";
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).xy, $(2).z, $3, $4)";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).xyz, $(2).w, $3, $4)";
+                    }
+                }
+                __intrinsic_asm "textureSampleGrad($0, $1, $2, $3, $4)";
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
     T SampleGrad(SamplerState s, vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.dimensions> offset)
     {
         __target_switch
@@ -1743,6 +1910,22 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     __truncate $$T result __sampledType(T) %sampled;
 
                 };
+            case wgsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    , "WGSL supports only f32 type textures");
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_1D):
+                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).x, $(2).y, $3, $4, $5)";
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).xy, $(2).z, $3, $4, $5)";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "textureSampleGrad($0, $1, ($2).xyz, $(2).w, $3, $4, $5)";
+                    }
+                }
+                __intrinsic_asm "textureSampleGrad($0, $1, $2, $3, $4, $5)";
         }
     }
 
@@ -1797,7 +1980,7 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_cuda_glsl_hlsl_metal_spirv, texture_sm_4_0)]
+    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
     T SampleLevel(SamplerState s, vector<float, Shape.dimensions+isArray> location, float level)
     {
         __target_switch
@@ -1870,19 +2053,35 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     }
                 }
             case spirv:
-            return spirv_asm
-            {
-                %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
-                %sampled : __sampledType(T) = OpImageSampleExplicitLod %sampledImage $location None|Lod $level;
-                __truncate $$T result __sampledType(T) %sampled;
-            };
+                return spirv_asm
+                {
+                    %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
+                    %sampled : __sampledType(T) = OpImageSampleExplicitLod %sampledImage $location None|Lod $level;
+                    __truncate $$T result __sampledType(T) %sampled;
+                };
+            case wgsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    , "WGSL supports only f32 type textures");
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_1D):
+                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).x, $(2).y, $3)";
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).xy, $(2).z, $3)";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).xyz, $(2).w, $3)";
+                    }
+                }
+                __intrinsic_asm "textureSampleLevel($0, $1, $2, $3)";
         }
     }
 
     [__readNone]
     [ForceInline]
 
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
     T SampleLevel(SamplerState s, vector<float, Shape.dimensions+isArray> location, float level, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -1925,6 +2124,22 @@ extension __TextureImpl<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     %sampled : __sampledType(T) = OpImageSampleExplicitLod %sampledImage $location None|Lod|ConstOffset $level $offset;
                     __truncate $$T result __sampledType(T) %sampled;
                 };
+            case wgsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    , "WGSL supports only f32 type textures");
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_1D):
+                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).x, $(2).y, $3, $4)";
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).xy, $(2).z, $3, $4)";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "textureSampleLevel($0, $1, ($2).xyz, $(2).w, $3, $4)";
+                    }
+                }
+                __intrinsic_asm "textureSampleLevel($0, $1, $2, $3, $4)";
         }
     }
 }
@@ -2433,7 +2648,7 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
     __glsl_extension(GL_EXT_samplerless_texture_functions)
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_samplerless)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1_samplerless)]
     T Load(vector<int, Shape.dimensions+isArray+1> location)
     {
         __target_switch
@@ -2525,13 +2740,29 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
                     __truncate $$T result __sampledType(T) %sampled;
                 };
             }
+        case wgsl:
+            static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                , "WGSL supports only f32 type textures");
+            if (isArray == 1)
+            {
+                switch (Shape.flavor)
+                {
+                case $(SLANG_TEXTURE_1D):
+                    __intrinsic_asm "textureLoad($0, ($1).x, $(1).y)";
+                case $(SLANG_TEXTURE_2D):
+                    __intrinsic_asm "textureLoad($0, ($1).xy, $(1).z)";
+                case $(SLANG_TEXTURE_CUBE):
+                    __intrinsic_asm "textureLoad($0, ($1).xyz, $(1).w)";
+                }
+            }
+            __intrinsic_asm "textureLoad($0, $1)";
         }
     }
 
     __glsl_extension(GL_EXT_samplerless_texture_functions)
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_samplerless)]
+    [require(cpp_glsl_hlsl_spirv_wgsl, texture_sm_4_1_samplerless)]
     T Load(vector<int, Shape.dimensions+isArray+1> location, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -2562,6 +2793,22 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
                         __truncate $$T result __sampledType(T) %sampled;
                     };
                 }
+            case wgsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    , "WGSL supports only f32 type textures");
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_1D):
+                        __intrinsic_asm "textureLoad($0, ($1).x, $(1).y, $2)";
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "textureLoad($0, ($1).xy, $(1).z, $2)";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "textureLoad($0, ($1).xyz, $(1).w, $2)";
+                    }
+                }
+                __intrinsic_asm "textureLoad($0, $1, $2)";
         }
     }
 
@@ -2584,7 +2831,7 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
         __glsl_extension(GL_EXT_samplerless_texture_functions)
         [__readNone]
         [ForceInline]
-        [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_samplerless)]
+        [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1_samplerless)]
         get
         {
             __target_switch
@@ -2614,6 +2861,8 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
                             __truncate $$T result __sampledType(T) %sampled;
                         };
                     }
+                case wgsl:
+                    return Load(__makeVector(location, 0));
             }
         }
     }
@@ -2630,7 +2879,7 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,form
     __glsl_extension(GL_EXT_samplerless_texture_functions)
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_samplerless)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1_samplerless)]
     T Load(vector<int, Shape.dimensions+isArray> location, int sampleIndex)
     {
         __target_switch
@@ -2686,12 +2935,28 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,form
                         __truncate $$T result __sampledType(T) %sampled;
                     };
                 }
+            case wgsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    , "WGSL supports only f32 type textures");
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_1D):
+                        __intrinsic_asm "textureLoad($0, ($1).x, $(1).y, $2)";
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "textureLoad($0, ($1).xy, $(1).z, $2)";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "textureLoad($0, ($1).xyz, $(1).w, $2)";
+                    }
+                }
+                __intrinsic_asm "textureLoad($0, $1, $2)";
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_samplerless)]
+    [require(cpp_glsl_hlsl_spirv_wgsl, texture_sm_4_1_samplerless)]
     T Load(vector<int, Shape.dimensions + isArray + 1> locationAndSampleIndex)
     {
         return Load(__vectorReshape<Shape.dimensions + isArray>(locationAndSampleIndex), locationAndSampleIndex[Shape.dimensions + isArray]);
@@ -2707,9 +2972,9 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,form
         {
             case cpp:
             case hlsl:
-            __intrinsic_asm ".Load";
+                __intrinsic_asm ".Load";
             case glsl:
-            __intrinsic_asm "$ctexelFetchOffset($0, $1, ($2), ($3))$z";
+                __intrinsic_asm "$ctexelFetchOffset($0, $1, ($2), ($3))$z";
             case spirv:
                 if (isCombined != 0)
                 {
@@ -2750,7 +3015,7 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,form
         __glsl_extension(GL_EXT_samplerless_texture_functions)
         [__readNone]
         [ForceInline]
-        [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_samplerless)]
+        [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1_samplerless)]
         get
         {
             __target_switch
@@ -2761,6 +3026,7 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,form
                 case metal:
                 case glsl:
                 case spirv:
+                case wgsl:
                     return Load(location, 0);
             }
         }
@@ -2770,7 +3036,7 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,form
         __glsl_extension(GL_EXT_samplerless_texture_functions)
         [__readNone]
         [ForceInline]
-        [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_samplerless)]
+        [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1_samplerless)]
         get
         {
             __target_switch
@@ -2781,6 +3047,7 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,form
                 case metal:
                 case glsl:
                 case spirv:
+                case wgsl:
                     return Load(location, sampleIndex);
             }
         }
@@ -2800,7 +3067,7 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,form
 {
     [__readNone]
     [ForceInline]
-    [require(cpp_cuda_glsl_hlsl_metal_spirv, texture_sm_4_1)]
+    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1)]
     T Load(vector<int, Shape.dimensions+isArray> location)
     {
         __target_switch
@@ -2906,6 +3173,22 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,form
                 }
                 static_assert(false, "Unsupported 'Load' of 'texture' for 'metal' target");
                 __intrinsic_asm "<invalid intrinsics>";
+            case wgsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    , "WGSL supports only f32 type textures");
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_1D):
+                        __intrinsic_asm "textureLoad($0, ($1).x, $(1).y)";
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "textureLoad($0, ($1).xy, $(1).z)";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "textureLoad($0, ($1).xyz, $(1).w)";
+                    }
+                }
+                __intrinsic_asm "textureLoad($0, $1)";
         }
     }
 
@@ -2955,7 +3238,7 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,form
     {
         [__readNone]
         [ForceInline]
-        [require(cpp_cuda_glsl_hlsl_metal_spirv, texture_sm_4_1)]
+        [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1)]
         get
         {
             __target_switch
@@ -2967,20 +3250,21 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,form
                 case spirv:
                 case cuda:
                 case metal:
+                case wgsl:
                     return Load(location);
             }
         }
 
         [nonmutating]
         [ForceInline]
-        [require(cpp_cuda_glsl_hlsl_metal_spirv, texture_sm_4_1)]
+        [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1)]
         set(T newValue)
         {
             __target_switch
             {
                 case cpp:
                 case hlsl:
-                __intrinsic_asm ".operator[]";
+                    __intrinsic_asm ".operator[]";
                 case glsl:
                     __glslImageStore(location, newValue);
                 case cuda:
@@ -3068,6 +3352,22 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,form
                         }
                         break;
                     }
+            case wgsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    , "WGSL supports only f32 type textures");
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_1D):
+                        __intrinsic_asm "textureStore($0, ($1).x, $(1).y, $2)";
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "textureStore($0, ($1).xy, $(1).z, $2)";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "textureStore($0, ($1).xyz, $(1).w, $2)";
+                    }
+                }
+                __intrinsic_asm "textureStore($0, $1, $2)";
             }
         }
 
@@ -3087,7 +3387,7 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,form
 {
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_compute_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1_compute_fragment)]
     T Load(vector<int, Shape.dimensions+isArray> location, int sampleIndex)
     {
         __target_switch
@@ -3131,6 +3431,22 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,form
                     %sampled:__sampledType(T) = OpImageRead $this $location Sample $sampleIndex;
                     __truncate $$T result __sampledType(T) %sampled;
                 };
+            case wgsl:
+                static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
+                    , "WGSL supports only f32 type textures");
+                if (isArray == 1)
+                {
+                    switch (Shape.flavor)
+                    {
+                    case $(SLANG_TEXTURE_1D):
+                        __intrinsic_asm "textureLoad($0, ($1).x, $(1).y)";
+                    case $(SLANG_TEXTURE_2D):
+                        __intrinsic_asm "textureLoad($0, ($1).xy, $(1).z)";
+                    case $(SLANG_TEXTURE_CUBE):
+                        __intrinsic_asm "textureLoad($0, ($1).xyz, $(1).w)";
+                    }
+                }
+                __intrinsic_asm "textureLoad($0, $1)";
         }
     }
 
@@ -3180,7 +3496,7 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,form
     {
         [__readNone]
         [ForceInline]
-        [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_compute_fragment)]
+        [require(cpp_glsl_hlsl_spirv_wgsl, texture_sm_4_1_compute_fragment)]
         get
         {
             __target_switch
@@ -3190,6 +3506,7 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,form
                     __intrinsic_asm "$0.sample[$2][$1]";
                 case glsl:
                 case spirv:
+                case wgsl:
                     return Load(location, sampleIndex);
             }
         }
@@ -3203,7 +3520,7 @@ extension __TextureImpl<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,form
             {
                 case cpp:
                 case hlsl:
-                __intrinsic_asm "$0.sample[$2][$1]";
+                    __intrinsic_asm "$0.sample[$2][$1]";
                 case glsl:
                     __glslImageStore(location, sampleIndex, newValue);
                 case spirv:

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -2764,6 +2764,7 @@ extension __TextureImpl<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,form
             case $(SLANG_TEXTURE_3D):
                 __intrinsic_asm "textureLoad($0, ($1).xyz, ($1).w)$z";
             }
+            return T();
         }
     }
 

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -298,9 +298,17 @@ alias cpp_glsl = cpp | glsl;
 /// [Compound]
 alias cpp_glsl_hlsl_spirv = cpp | glsl | hlsl | spirv;
 
+/// CPP, GLSL, HLSL, SPIRV and WGSL code-gen targets
+/// [Compound]
+alias cpp_glsl_hlsl_spirv_wgsl = cpp | glsl | hlsl | spirv | wgsl;
+
 /// CPP, GLSL, HLSL, Metal, and SPIRV code-gen targets
 /// [Compound]
 alias cpp_glsl_hlsl_metal_spirv = cpp | glsl | hlsl | metal | spirv;
+
+/// CPP, GLSL, HLSL, Metal, SPIRV and WGSL code-gen targets
+/// [Compound]
+alias cpp_glsl_hlsl_metal_spirv_wgsl = cpp | glsl | hlsl | metal | spirv | wgsl;
 
 /// CPP, and HLSL code-gen targets
 /// [Compound]

--- a/source/slang/slang-emit-wgsl.cpp
+++ b/source/slang/slang-emit-wgsl.cpp
@@ -482,6 +482,11 @@ void WGSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
                 break;
             }
 
+            if (texType->isShadow())
+            {
+                m_writer->emit("_depth");
+            }
+
             if (texType->isMultisample())
             {
                 m_writer->emit("_multisampled");
@@ -498,13 +503,16 @@ void WGSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
             if (texType->isArray())
                 m_writer->emit("_array");
 
-            m_writer->emit("<");
-            auto elemType = texType->getElementType();
-            if (auto vecElemType = as<IRVectorType>(elemType))
-                emitSimpleType(vecElemType->getElementType());
-            else
-                emitType(elemType);
-            m_writer->emit(">");
+            if (!texType->isShadow())
+            {
+                m_writer->emit("<");
+                auto elemType = texType->getElementType();
+                if (auto vecElemType = as<IRVectorType>(elemType))
+                    emitSimpleType(vecElemType->getElementType());
+                else
+                    emitType(elemType);
+                m_writer->emit(">");
+            }
         }
         return;
 

--- a/source/slang/slang-emit-wgsl.cpp
+++ b/source/slang/slang-emit-wgsl.cpp
@@ -472,7 +472,21 @@ void WGSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
     case kIROp_TextureType:
         if (auto texType = as<IRTextureType>(type))
         {
-            m_writer->emit("texture");
+            switch (texType->getAccess())
+            {
+            case SLANG_RESOURCE_ACCESS_READ_WRITE:
+                m_writer->emit("texture_storage");
+                break;
+            default:
+                m_writer->emit("texture");
+                break;
+            }
+
+            if (texType->isMultisample())
+            {
+                m_writer->emit("_multisampled");
+            }
+
             switch (texType->GetBaseShape())
             {
             case SLANG_TEXTURE_1D:		m_writer->emit("_1d");		break;

--- a/source/slang/slang-emit-wgsl.cpp
+++ b/source/slang/slang-emit-wgsl.cpp
@@ -469,6 +469,30 @@ void WGSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
         m_writer->emit(">");
         return;
     }
+    case kIROp_TextureType:
+        if (auto texType = as<IRTextureType>(type))
+        {
+            m_writer->emit("texture");
+            switch (texType->GetBaseShape())
+            {
+            case SLANG_TEXTURE_1D:		m_writer->emit("_1d");		break;
+            case SLANG_TEXTURE_2D:		m_writer->emit("_2d");		break;
+            case SLANG_TEXTURE_3D:		m_writer->emit("_3d");		break;
+            case SLANG_TEXTURE_CUBE:	m_writer->emit("_cube");	break;
+            }
+
+            if (texType->isArray())
+                m_writer->emit("_array");
+
+            m_writer->emit("<");
+            auto elemType = texType->getElementType();
+            if (auto vecElemType = as<IRVectorType>(elemType))
+                emitSimpleType(vecElemType->getElementType());
+            else
+                emitType(elemType);
+            m_writer->emit(">");
+        }
+        return;
 
     case kIROp_AtomicType:
     {

--- a/source/slang/slang-emit-wgsl.cpp
+++ b/source/slang/slang-emit-wgsl.cpp
@@ -494,10 +494,10 @@ void WGSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
 
             switch (texType->GetBaseShape())
             {
-            case SLANG_TEXTURE_1D:		m_writer->emit("_1d");		break;
-            case SLANG_TEXTURE_2D:		m_writer->emit("_2d");		break;
-            case SLANG_TEXTURE_3D:		m_writer->emit("_3d");		break;
-            case SLANG_TEXTURE_CUBE:	m_writer->emit("_cube");	break;
+            case SLANG_TEXTURE_1D:   m_writer->emit("_1d");   break;
+            case SLANG_TEXTURE_2D:   m_writer->emit("_2d");   break;
+            case SLANG_TEXTURE_3D:   m_writer->emit("_3d");   break;
+            case SLANG_TEXTURE_CUBE: m_writer->emit("_cube"); break;
             }
 
             if (texType->isArray())

--- a/source/slang/slang-stdlib-textures.h
+++ b/source/slang/slang-stdlib-textures.h
@@ -69,7 +69,8 @@ public:
         const String& spirvDefault,
         const String& spirvRWDefault,
         const String& spirvCombined,
-        const String& metal
+        const String& metal,
+        const String& wgsl
         );
     void writeFuncWithSig(
         const char* funcName,
@@ -80,6 +81,7 @@ public:
         const String& spirvCombined = String{},
         const String& cuda = String{},
         const String& metal = String{},
+        const String& wgsl = String{},
         const ReadNoneMode readNoneMode = ReadNoneMode::Never
     );
     void writeFunc(
@@ -92,6 +94,7 @@ public:
         const String& spirvCombined = String{},
         const String& cuda = String{},
         const String& metal = String{},
+        const String& wgsl = String{},
         const ReadNoneMode readNoneMode = ReadNoneMode::Never
     );
 

--- a/tests/wgsl/texture.slang
+++ b/tests/wgsl/texture.slang
@@ -442,6 +442,5 @@ void fragMain()
             tCubeArray_f32v4)
         ;
 
-    // FUNCTIONAL: 1
     outputBuffer[0] = int(result);
 }

--- a/tests/wgsl/texture.slang
+++ b/tests/wgsl/texture.slang
@@ -1,0 +1,657 @@
+//TEST:SIMPLE(filecheck=WGSL): -stage compute -entry computeMain -target wgsl
+
+//TEST_INPUT: ubuffer(data=[0], stride=4):out,name outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_f32v3
+Texture1D<float3> t1D_f32v3;
+//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_f32v3
+Texture2D<float3> t2D_f32v3;
+//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_f32v3
+Texture3D<float3> t3D_f32v3;
+//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_f32v3
+TextureCube<float3> tCube_f32v3;
+//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_f32v3
+Texture1DArray<float3> t1DArray_f32v3;
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_f32v3
+Texture2DArray<float3> t2DArray_f32v3;
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_f32v3
+TextureCubeArray<float3> tCubeArray_f32v3;
+
+//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_f32
+Texture1D<float4> t1D_f32;
+//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_f32
+Texture2D<float4> t2D_f32;
+//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_f32
+Texture3D<float4> t3D_f32;
+//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_f32
+TextureCube<float4> tCube_f32;
+
+//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_f32
+Texture1DArray<float4> t1DArray_f32;
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_f32
+Texture2DArray<float4> t2DArray_f32;
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_f32
+TextureCubeArray<float4> tCubeArray_f32;
+
+//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_f16
+Texture1D<half4> t1D_f16;
+//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_f16
+Texture2D<half4> t2D_f16;
+//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_f16
+Texture3D<half4> t3D_f16;
+//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_f16
+TextureCube<half4> tCube_f16;
+
+//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_f16
+Texture1DArray<half4> t1DArray_f16;
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_f16
+Texture2DArray<half4> t2DArray_f16;
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_f16
+TextureCubeArray<half4> tCubeArray_f16;
+
+//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_i32
+Texture1D<int4> t1D_i32;
+//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_i32
+Texture2D<int4> t2D_i32;
+//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_i32
+Texture3D<int4> t3D_i32;
+//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_i32
+TextureCube<int4> tCube_i32;
+
+//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_i32
+Texture1DArray<int4> t1DArray_i32;
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_i32
+Texture2DArray<int4> t2DArray_i32;
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_i32
+TextureCubeArray<int4> tCubeArray_i32;
+
+//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_u32
+Texture1D<uint4> t1D_u32;
+//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_u32
+Texture2D<uint4> t2D_u32;
+//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_u32
+Texture3D<uint4> t3D_u32;
+//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_u32
+TextureCube<uint4> tCube_u32;
+
+//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_u32
+Texture1DArray<uint4> t1DArray_u32;
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_u32
+Texture2DArray<uint4> t2DArray_u32;
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_u32
+TextureCubeArray<uint4> tCubeArray_u32;
+
+//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_i16
+Texture1D<int16_t4> t1D_i16;
+//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_i16
+Texture2D<int16_t4> t2D_i16;
+//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_i16
+Texture3D<int16_t4> t3D_i16;
+//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_i16
+TextureCube<int16_t4> tCube_i16;
+
+//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_i16
+Texture1DArray<int16_t4> t1DArray_i16;
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_i16
+Texture2DArray<int16_t4> t2DArray_i16;
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_i16
+TextureCubeArray<int16_t4> tCubeArray_i16;
+
+//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_u16
+Texture1D<uint16_t4> t1D_u16;
+//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_u16
+Texture2D<uint16_t4> t2D_u16;
+//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_u16
+Texture3D<uint16_t4> t3D_u16;
+//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_u16
+TextureCube<uint16_t4> tCube_u16;
+
+//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_u16
+Texture1DArray<uint16_t4> t1DArray_u16;
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_u16
+Texture2DArray<uint16_t4> t2DArray_u16;
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_u16
+TextureCubeArray<uint16_t4> tCubeArray_u16;
+
+// Metal doc says "For depth texture types, T must be float."
+__generic<T : __BuiltinType, let sampleCount:int=0, let format:int=0>
+typealias depth2d = __TextureImpl<
+    T,
+    __Shape2D,
+    0, // isArray
+    0, // isMS
+    sampleCount,
+    0, // access
+    1, // isShadow
+    0, // isCombined
+    format
+>;
+
+__generic<T : __BuiltinType, let sampleCount:int=0, let format:int=0>
+typealias depth2d_array = __TextureImpl<
+    T,
+    __Shape2D,
+    1, // isArray
+    0, // isMS
+    sampleCount,
+    0, // access
+    1, // isShadow
+    0, // isCombined
+    format
+>;
+
+__generic<T : __BuiltinType, let sampleCount:int=0, let format:int=0>
+typealias depthcube = __TextureImpl<
+    T,
+    __ShapeCube,
+    0, // isArray
+    0, // isMS
+    sampleCount,
+    0, // access
+    1, // isShadow
+    0, // isCombined
+    format
+>;
+
+__generic<T : __BuiltinType, let sampleCount:int=0, let format:int=0>
+typealias depthcube_array = __TextureImpl<
+    T,
+    __ShapeCube,
+    1, // isArray
+    0, // isMS
+    sampleCount,
+    0, // access
+    1, // isShadow
+    0, // isCombined
+    format
+>;
+
+//TEST_INPUT: Texture2D(size=4, content = zero):name d2D
+depth2d<float> d2D;
+//TEST_INPUT: TextureCube(size=4, content = zero):name dCube
+depthcube<float> dCube;
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name d2DArray
+depth2d_array<float> d2DArray;
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name dCubeArray
+depthcube_array<float> dCubeArray;
+
+//TEST_INPUT: Sampler:name samplerState
+SamplerState samplerState;
+//TEST_INPUT: Sampler:name shadowSampler
+SamplerComparisonState shadowSampler;
+
+
+__generic<T:__BuiltinArithmeticType, let N:int>
+bool TEST_texture(
+    Texture1D<vector<T,N>> t1D,
+    Texture2D<vector<T,N>> t2D,
+    Texture3D<vector<T,N>> t3D,
+    TextureCube<vector<T,N>> tCube,
+    Texture1DArray<vector<T,N>> t1DArray,
+    Texture2DArray<vector<T,N>> t2DArray,
+    TextureCubeArray<vector<T,N>> tCubeArray
+)
+{
+    // METAL-LABEL: TEST_texture
+    typealias Tvn = vector<T,N>;
+    typealias Tv4 = vector<T,4>;
+
+    float u = 0;
+    float u2 = 0.5;
+    constexpr const float ddx = 0.0f;
+    constexpr const float ddy = 0.0f;
+
+    uint width = 0, height = 0, depth = 0;
+    float fwidth = 0.0f, fheight = 0.0f, fdepth = 0.0f;
+    uint numLevels = 0, elements = 0, sampleCount = 0;
+    float fnumLevels = 0.0f, felements = 0.0f;
+
+    bool voidResult = true;
+#if 0
+
+    // ======================
+    //  void GetDimensions()
+    // ======================
+
+    // METAL: .get_width(
+    t1D.GetDimensions(width);
+    voidResult = voidResult && (uint(4) == width);
+
+    // METAL: .get_width({{.*}}.get_num_mip_levels()
+    t1D.GetDimensions(0, width, numLevels);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(3) == numLevels);
+
+    // METAL: .get_width({{.*}}.get_height(
+    t2D.GetDimensions(width, height);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}.get_num_mip_levels()
+    t2D.GetDimensions(0, width, height, numLevels);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+    voidResult = voidResult && (uint(3) == numLevels);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}.get_depth(
+    t3D.GetDimensions(width, height, depth);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+    voidResult = voidResult && (uint(4) == depth);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}.get_depth({{.*}}.get_num_mip_levels()
+    t3D.GetDimensions(0, width, height, depth, numLevels);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+    voidResult = voidResult && (uint(4) == depth);
+    voidResult = voidResult && (uint(3) == numLevels);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}
+    tCube.GetDimensions(width, height);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}.get_num_mip_levels()
+    tCube.GetDimensions(0, width, height, numLevels);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+    voidResult = voidResult && (uint(3) == numLevels);
+
+    // METAL: .get_width({{.*}}.get_array_size(
+    t1DArray.GetDimensions(width, elements);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(2) == elements);
+
+    // METAL: .get_width({{.*}}.get_num_mip_levels(
+    t1DArray.GetDimensions(0, width, elements, numLevels);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(2) == elements);
+    voidResult = voidResult && (uint(3) == numLevels);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}.get_array_size(
+    t2DArray.GetDimensions(width, height, elements);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+    voidResult = voidResult && (uint(2) == elements);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}.get_num_mip_levels(
+    t2DArray.GetDimensions(0, width, height, elements, numLevels);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+    voidResult = voidResult && (uint(2) == elements);
+    voidResult = voidResult && (uint(3) == numLevels);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}.get_array_size(
+    tCubeArray.GetDimensions(width, height, elements);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+    voidResult = voidResult && (uint(2) == elements);
+
+    // METAL: .get_width({{.*}}.get_height({{.*}}.get_num_mip_levels(
+    tCubeArray.GetDimensions(0, width, height, elements, numLevels);
+    voidResult = voidResult && (uint(4) == width);
+    voidResult = voidResult && (uint(4) == height);
+    voidResult = voidResult && (uint(2) == elements);
+    voidResult = voidResult && (uint(3) == numLevels);
+#endif
+
+    bool result = voidResult
+#if 0
+        // ===============================
+        // float CalculateLevelOfDetail()
+        // ===============================
+
+        // Metal doesn't support LOD for 1D texture
+
+        // METAL: t2D{{.*}}.calculate_clamped_lod({{.*}}
+        && float(0) == t2D.CalculateLevelOfDetail(samplerState, float2(u, u))
+
+        // METAL: t3D{{.*}}.calculate_clamped_lod({{.*}}
+        && float(0) == t3D.CalculateLevelOfDetail(samplerState, float3(u, u, u))
+
+        // METAL: tCube{{.*}}.calculate_clamped_lod({{.*}}
+        && float(0) == tCube.CalculateLevelOfDetail(samplerState, normalize(float3(u, 1 - u, u)))
+
+        // METAL: t2DArray{{.*}}.calculate_clamped_lod({{.*}}
+        && float(0) == t2DArray.CalculateLevelOfDetail(samplerState, float2(u, u))
+
+        // METAL: tCubeArray{{.*}}.calculate_clamped_lod({{.*}}
+        && float(0) == tCubeArray.CalculateLevelOfDetail(samplerState, normalize(float3(u, 1 - u, u)))
+
+        // ========================================
+        // float CalculateLevelOfDetailUnclamped()
+        // ========================================
+
+        // Metal doesn't support LOD for 1D texture
+
+        // METAL: t2D{{.*}}.calculate_unclamped_lod({{.*}}
+        && float(0) >= t2D.CalculateLevelOfDetailUnclamped(samplerState, float2(u, u))
+
+        // METAL: t3D{{.*}}.calculate_unclamped_lod({{.*}}
+        && float(0) >= t3D.CalculateLevelOfDetailUnclamped(samplerState, float3(u, u, u))
+
+        // METAL: tCube{{.*}}.calculate_unclamped_lod({{.*}}
+        && float(0) >= tCube.CalculateLevelOfDetailUnclamped(samplerState, normalize(float3(u, 1 - u, u)))
+
+        // METAL: t2DArray{{.*}}.calculate_unclamped_lod({{.*}}
+        && float(0) >= t2DArray.CalculateLevelOfDetailUnclamped(samplerState, float2(u, u))
+
+        // METAL: tCubeArray{{.*}}.calculate_unclamped_lod({{.*}}
+        && float(0) >= tCubeArray.CalculateLevelOfDetailUnclamped(samplerState, normalize(float3(u, 1 - u, u)))
+
+        // ===========
+        // T Sample()
+        // ===========
+
+        // METAL: t1D{{.*}}.sample(
+        && all(Tvn(T(0)) == t1D.Sample(samplerState, u))
+
+        // METAL: t2D{{.*}}.sample({{.*}}
+        && all(Tvn(T(0)) == t2D.Sample(samplerState, float2(u, u)))
+
+        // METAL: t3D{{.*}}.sample({{.*}}
+        && all(Tvn(T(0)) == t3D.Sample(samplerState, float3(u, u, u)))
+
+        // METAL: tCube{{.*}}.sample({{.*}}
+        && all(Tvn(T(0)) == tCube.Sample(samplerState, normalize(float3(u, 1 - u, u))))
+
+        // METAL: t1DArray{{.*}}.sample(
+        && all(Tvn(T(0)) == t1DArray.Sample(samplerState, float2(u, 0)))
+
+        // METAL: t2DArray{{.*}}.sample({{.*}}
+        && all(Tvn(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0)))
+
+        // METAL: tCubeArray{{.*}}.sample({{.*}}
+        && all(Tvn(T(0)) == tCubeArray.Sample(samplerState, float4(normalize(float3(u, 1 - u, u)), 0)))
+
+        // Offset variant
+
+        // Metal doesn't support Offset for 1D and Cube texture
+
+        // METAL: t2D{{.*}}.sample({{.*}}
+        && all(Tvn(T(0)) == t2D.Sample(samplerState, float2(u, u), int2(1, 1)))
+
+        // METAL: t3D{{.*}}.sample({{.*}}
+        && all(Tvn(T(0)) == t3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1)))
+
+        // METAL: t2DArray{{.*}}.sample({{.*}}
+        && all(Tvn(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1)))
+
+        // Clamp variant
+
+        // Metal doesn't support Offset for 1D and Cube texture
+
+        // METAL: t2D{{.*}}.sample({{.*}} min_lod_clamp(
+        && all(Tvn(T(0)) == t2D.Sample(samplerState, float2(u, u), int2(1, 1), float(1)))
+
+        // METAL: t3D{{.*}}.sample({{.*}} min_lod_clamp(
+        && all(Tvn(T(0)) == t3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1), float(1)))
+
+        // METAL: t2DArray{{.*}}.sample({{.*}} min_lod_clamp(
+        && all(Tvn(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1), float(1)))
+
+        // ===============
+        // T SampleBias()
+        // ===============
+
+        // Metal doesn't support Bias for 1D texture
+
+        // METAL: t2D{{.*}}.sample({{.*}}
+        && all(Tvn(T(0)) == t2D.SampleBias(samplerState, float2(u, u), float(-1)))
+
+        // METAL: t3D{{.*}}.sample({{.*}}
+        && all(Tvn(T(0)) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1)))
+
+        // METAL: tCube{{.*}}.sample({{.*}}
+        && all(Tvn(T(0)) == tCube.SampleBias(samplerState, normalize(float3(u, 1 - u, u)), float(-1)))
+
+        // METAL: t2DArray{{.*}}.sample({{.*}}
+        && all(Tvn(T(0)) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1)))
+
+        // METAL: tCubeArray{{.*}}.sample({{.*}}
+        && all(Tvn(T(0)) == tCubeArray.SampleBias(samplerState, float4(normalize(float3(u, 1 - u, u)), 0), float(-1)))
+
+        // Offset variant
+
+        // Metal doesn't support Offset for 1D and Cube texture
+
+        // METAL: t2D{{.*}}.sample({{.*}}
+        && all(Tvn(T(0)) == t2D.SampleBias(samplerState, float2(u, u), float(-1), int2(1, 1)))
+
+        // METAL: t3D{{.*}}.sample({{.*}}
+        && all(Tvn(T(0)) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1), int3(1, 1, 1)))
+
+        // METAL: t2DArray{{.*}}.sample({{.*}}
+        && all(Tvn(T(0)) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1), int2(1, 1)))
+
+        // ===================================
+        //  T SampleLevel()
+        // ===================================
+
+        // Metal doesn't support LOD for 1D texture
+
+        // METAL: t2D{{.*}}.sample({{.*}} level(
+        && all(Tvn(T(0)) == t2D.SampleLevel(samplerState, float2(u, u), 0))
+
+        // METAL: t3D{{.*}}.sample({{.*}} level(
+        && all(Tvn(T(0)) == t3D.SampleLevel(samplerState, float3(u, u, u), 0))
+
+        // METAL: tCube{{.*}}.sample({{.*}} level(
+        && all(Tvn(T(0)) == tCube.SampleLevel(samplerState, normalize(float3(u, 1 - u, u)), 0))
+
+        // METAL: t2DArray{{.*}}.sample({{.*}} level(
+        && all(Tvn(T(0)) == t2DArray.SampleLevel(samplerState, float3(u, u, 0), 0))
+
+        // METAL: tCubeArray{{.*}}.sample({{.*}} level(
+        && all(Tvn(T(0)) == tCubeArray.SampleLevel(samplerState, float4(normalize(float3(u, 1 - u, u)), 0), 0))
+
+        // Offset variant
+
+        // Metal doesn't support LOD for 1D texture
+
+        // METAL: t2D{{.*}}.sample({{.*}} level(
+        && all(Tvn(T(0)) == t2D.SampleLevel(samplerState, float2(u, u), 0, int2(1, 1)))
+
+        // METAL: t3D{{.*}}.sample({{.*}} level(
+        && all(Tvn(T(0)) == t3D.SampleLevel(samplerState, float3(u, u, u), 0, int3(1, 1, 1)))
+
+        // METAL: t2DArray{{.*}}.sample({{.*}} level(
+        && all(Tvn(T(0)) == t2DArray.SampleLevel(samplerState, float3(u, u, 0), 0, int2(1, 1)))
+
+        // ==================
+        // float SampleCmp()
+        // ==================
+
+        // METAL: d2D{{.*}}.sample_compare(
+        && float(0) == d2D.SampleCmp(shadowSampler, float2(u, u), 0)
+
+        // METAL: d2DArray{{.*}}.sample_compare(
+        && float(0) == d2DArray.SampleCmp(shadowSampler, float3(u, u, 0), 0)
+
+        // METAL: dCube{{.*}}.sample_compare(
+        && float(0) == dCube.SampleCmp(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
+
+        // METAL: dCubeArray{{.*}}.sample_compare(
+        && float(0) == dCubeArray.SampleCmp(shadowSampler, float4(normalize(float3(u, 1 - u, u)), 0), 0)
+
+        // Offset variant
+
+        // METAL: d2D{{.*}}.sample_compare(
+        && float(0) == d2D.SampleCmp(shadowSampler, float2(u2, u), 0, int2(0, 0))
+
+        // ===================================
+        //  float SampleCmpLevelZero()
+        // ===================================
+
+        // METAL: d2D{{.*}}.sample_compare(
+        && float(0) == d2D.SampleCmpLevelZero(shadowSampler, float2(u, u), 0)
+
+        // METAL: d2DArray{{.*}}.sample_compare(
+        && float(0) == d2DArray.SampleCmpLevelZero(shadowSampler, float3(u, u, 0), 0)
+
+        // METAL: dCube{{.*}}.sample_compare(
+        && float(0) == dCube.SampleCmpLevelZero(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
+
+        // METAL: dCubeArray{{.*}}.sample_compare(
+        && float(0) == dCubeArray.SampleCmpLevelZero(shadowSampler, float4(normalize(float3(u, 1-u, u)), 0), 0)
+
+        // Offset variant
+
+        // METAL: d2D{{.*}}.sample_compare(
+        && float(0) == d2D.SampleCmpLevelZero(shadowSampler, float2(u2, u), 0, int2(0, 0))
+
+        // ==================================
+        //  vector<T,4> Gather()
+        // ==================================
+
+        // METAL: t2D{{.*}}.gather(
+        && all(Tv4(T(0)) == t2D.Gather(samplerState, float2(u, u)))
+
+        // METAL: tCube{{.*}}.gather(
+        && all(Tv4(T(0)) == tCube.Gather(samplerState, normalize(float3(u, 1 - u, u))))
+
+        // METAL: t2DArray{{.*}}.gather(
+        && all(Tv4(T(0)) == t2DArray.Gather(samplerState, float3(u, u, 0)))
+
+        // METAL: tCubeArray{{.*}}.gather(
+        && all(Tv4(T(0)) == tCubeArray.Gather(samplerState, float4(normalize(float3(u, 1 - u, u)), 0)))
+
+        // Offset variant
+
+        // METAL: t2D{{.*}}.gather(
+        && all(Tv4(T(0)) == t2D.Gather(samplerState, float2(u2, u), int2(0, 0)))
+
+        // METAL: t2DArray{{.*}}.gather(
+        && all(Tv4(T(0)) == t2DArray.Gather(samplerState, float3(u2, u, 0), int2(0, 0)))
+
+        // =====================================
+        //  T SampleGrad()
+        // =====================================
+
+        // Metal doesn't support LOD for 1D texture
+
+        // METAL: t2D{{.*}}.sample(
+        && all(Tvn(T(0)) == t2D.SampleGrad(samplerState, float2(u, u), float2(ddx, ddx), float2(ddy, ddy)))
+
+        // METAL: t3D{{.*}}.sample(
+        && all(Tvn(T(0)) == t3D.SampleGrad(samplerState, float3(u, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
+
+        // METAL: tCube{{.*}}.sample(
+        && all(Tvn(T(0)) == tCube.SampleGrad(samplerState, normalize(float3(u, 1 - u, u)), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
+
+        // METAL: t2DArray{{.*}}.sample(
+        && all(Tvn(T(0)) == t2DArray.SampleGrad(samplerState, float3(u, u, 0.0f), float2(ddx, ddx), float2(ddy, ddy)))
+
+        // Offset variant
+
+        // METAL: t2D{{.*}}.sample(
+        && all(Tvn(T(0)) == t2D.SampleGrad(samplerState, float2(u2, u), float2(ddx, ddx), float2(ddy, ddy), int2(0, 0)))
+
+        // METAL: t3D{{.*}}.sample(
+        && all(Tvn(T(0)) == t3D.SampleGrad(samplerState, float3(u2, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy), int3(0, 0, 0)))
+
+        // METAL: t2DArray{{.*}}.sample(
+        && all(Tvn(T(0)) == t2DArray.SampleGrad(samplerState, float3(u2, u, 0.0f), float2(ddx, ddx), float2(ddy, ddy), int2(0, 0)))
+
+        // ===================
+        //  T Load()
+        // ===================
+
+        // METAL: t1D{{.*}}.read(
+        && all(Tvn(T(0)) == t1D.Load(int2(0, 0)))
+
+        // METAL: t2D{{.*}}.read(
+        && all(Tvn(T(0)) == t2D.Load(int3(0, 0, 0)))
+
+        // METAL: t3D{{.*}}.read(
+        && all(Tvn(T(0)) == t3D.Load(int4(0, 0, 0, 0)))
+
+        // METAL: t1DArray{{.*}}.read(
+        && all(Tvn(T(0)) == t1DArray.Load(int3(0, 0, 0)))
+
+        // METAL: t2DArray{{.*}}.read(
+        && all(Tvn(T(0)) == t2DArray.Load(int4(0, 0, 0, 0)))
+
+        // Offset variant
+
+        // Metal doesn't support offset variants for Load
+#endif
+        ;
+
+    return result;
+}
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    bool result = true
+        && TEST_texture<float, 3>(
+            t1D_f32v3,
+            t2D_f32v3,
+            t3D_f32v3,
+            tCube_f32v3,
+            t1DArray_f32v3,
+            t2DArray_f32v3,
+            tCubeArray_f32v3)
+#if 0
+        && TEST_texture<float, 4>(
+            t1D_f32,
+            t2D_f32,
+            t3D_f32,
+            tCube_f32,
+            t1DArray_f32,
+            t2DArray_f32,
+            tCubeArray_f32)
+#if !defined(EXCLUDE_HALF_TYPE)
+        && TEST_texture<half, 4>(
+            t1D_f16,
+            t2D_f16,
+            t3D_f16,
+            tCube_f16,
+            t1DArray_f16,
+            t2DArray_f16,
+            tCubeArray_f16)
+#endif
+#if !defined(EXCLUDE_INTEGER_TYPE)
+        && TEST_texture<int, 4>(
+            t1D_i32,
+            t2D_i32,
+            t3D_i32,
+            tCube_i32,
+            t1DArray_i32,
+            t2DArray_i32,
+            tCubeArray_i32)
+        && TEST_texture<uint, 4>(
+            t1D_u32,
+            t2D_u32,
+            t3D_u32,
+            tCube_u32,
+            t1DArray_u32,
+            t2DArray_u32,
+            tCubeArray_u32)
+#if !defined(EXCLUDE_SHORT_TYPE)
+        && TEST_texture<int16_t, 4>(
+            t1D_i16,
+            t2D_i16,
+            t3D_i16,
+            tCube_i16,
+            t1DArray_i16,
+            t2DArray_i16,
+            tCubeArray_i16)
+        && TEST_texture<uint16_t, 4>(
+            t1D_u16,
+            t2D_u16,
+            t3D_u16,
+            tCube_u16,
+            t1DArray_u16,
+            t2DArray_u16,
+            tCubeArray_u16)
+#endif
+#endif
+#endif
+        ;
+
+    // FUNCTIONAL: 1
+    outputBuffer[0] = int(result);
+}

--- a/tests/wgsl/texture.slang
+++ b/tests/wgsl/texture.slang
@@ -193,7 +193,7 @@ bool TEST_texture(
     TextureCubeArray<vector<T,N>> tCubeArray
 )
 {
-    // METAL-LABEL: TEST_texture
+    // WGSL-LABEL: TEST_texture
     typealias Tvn = vector<T,N>;
     typealias Tv4 = vector<T,4>;
 
@@ -208,187 +208,111 @@ bool TEST_texture(
     float fnumLevels = 0.0f, felements = 0.0f;
 
     bool voidResult = true;
-#if 0
 
     // ======================
     //  void GetDimensions()
     // ======================
 
-    // METAL: .get_width(
+    // WGSL doesn't support the mip level query;
+
+    // WGSL: textureDimensions(t1D
     t1D.GetDimensions(width);
     voidResult = voidResult && (uint(4) == width);
 
-    // METAL: .get_width({{.*}}.get_num_mip_levels()
-    t1D.GetDimensions(0, width, numLevels);
-    voidResult = voidResult && (uint(4) == width);
-    voidResult = voidResult && (uint(3) == numLevels);
-
-    // METAL: .get_width({{.*}}.get_height(
+    // WGSL: textureDimensions(t2D
     t2D.GetDimensions(width, height);
     voidResult = voidResult && (uint(4) == width);
     voidResult = voidResult && (uint(4) == height);
 
-    // METAL: .get_width({{.*}}.get_height({{.*}}.get_num_mip_levels()
-    t2D.GetDimensions(0, width, height, numLevels);
-    voidResult = voidResult && (uint(4) == width);
-    voidResult = voidResult && (uint(4) == height);
-    voidResult = voidResult && (uint(3) == numLevels);
-
-    // METAL: .get_width({{.*}}.get_height({{.*}}.get_depth(
+    // WGSL: textureDimensions(t3D
     t3D.GetDimensions(width, height, depth);
     voidResult = voidResult && (uint(4) == width);
     voidResult = voidResult && (uint(4) == height);
     voidResult = voidResult && (uint(4) == depth);
 
-    // METAL: .get_width({{.*}}.get_height({{.*}}.get_depth({{.*}}.get_num_mip_levels()
-    t3D.GetDimensions(0, width, height, depth, numLevels);
-    voidResult = voidResult && (uint(4) == width);
-    voidResult = voidResult && (uint(4) == height);
-    voidResult = voidResult && (uint(4) == depth);
-    voidResult = voidResult && (uint(3) == numLevels);
-
-    // METAL: .get_width({{.*}}.get_height({{.*}}
+    // WGSL: textureDimensions(tCube
     tCube.GetDimensions(width, height);
     voidResult = voidResult && (uint(4) == width);
     voidResult = voidResult && (uint(4) == height);
 
-    // METAL: .get_width({{.*}}.get_height({{.*}}.get_num_mip_levels()
-    tCube.GetDimensions(0, width, height, numLevels);
-    voidResult = voidResult && (uint(4) == width);
-    voidResult = voidResult && (uint(4) == height);
-    voidResult = voidResult && (uint(3) == numLevels);
-
-    // METAL: .get_width({{.*}}.get_array_size(
+    // WGSL: textureDimensions(t1DArray
     t1DArray.GetDimensions(width, elements);
     voidResult = voidResult && (uint(4) == width);
     voidResult = voidResult && (uint(2) == elements);
 
-    // METAL: .get_width({{.*}}.get_num_mip_levels(
-    t1DArray.GetDimensions(0, width, elements, numLevels);
-    voidResult = voidResult && (uint(4) == width);
-    voidResult = voidResult && (uint(2) == elements);
-    voidResult = voidResult && (uint(3) == numLevels);
-
-    // METAL: .get_width({{.*}}.get_height({{.*}}.get_array_size(
+    // WGSL: textureDimensions(t2DArray
     t2DArray.GetDimensions(width, height, elements);
     voidResult = voidResult && (uint(4) == width);
     voidResult = voidResult && (uint(4) == height);
     voidResult = voidResult && (uint(2) == elements);
 
-    // METAL: .get_width({{.*}}.get_height({{.*}}.get_num_mip_levels(
-    t2DArray.GetDimensions(0, width, height, elements, numLevels);
-    voidResult = voidResult && (uint(4) == width);
-    voidResult = voidResult && (uint(4) == height);
-    voidResult = voidResult && (uint(2) == elements);
-    voidResult = voidResult && (uint(3) == numLevels);
-
-    // METAL: .get_width({{.*}}.get_height({{.*}}.get_array_size(
+    // WGSL: textureDimensions(tCubeArray
     tCubeArray.GetDimensions(width, height, elements);
     voidResult = voidResult && (uint(4) == width);
     voidResult = voidResult && (uint(4) == height);
     voidResult = voidResult && (uint(2) == elements);
 
-    // METAL: .get_width({{.*}}.get_height({{.*}}.get_num_mip_levels(
-    tCubeArray.GetDimensions(0, width, height, elements, numLevels);
-    voidResult = voidResult && (uint(4) == width);
-    voidResult = voidResult && (uint(4) == height);
-    voidResult = voidResult && (uint(2) == elements);
-    voidResult = voidResult && (uint(3) == numLevels);
-#endif
-
     bool result = voidResult
-#if 0
         // ===============================
         // float CalculateLevelOfDetail()
         // ===============================
-
-        // Metal doesn't support LOD for 1D texture
-
-        // METAL: t2D{{.*}}.calculate_clamped_lod({{.*}}
-        && float(0) == t2D.CalculateLevelOfDetail(samplerState, float2(u, u))
-
-        // METAL: t3D{{.*}}.calculate_clamped_lod({{.*}}
-        && float(0) == t3D.CalculateLevelOfDetail(samplerState, float3(u, u, u))
-
-        // METAL: tCube{{.*}}.calculate_clamped_lod({{.*}}
-        && float(0) == tCube.CalculateLevelOfDetail(samplerState, normalize(float3(u, 1 - u, u)))
-
-        // METAL: t2DArray{{.*}}.calculate_clamped_lod({{.*}}
-        && float(0) == t2DArray.CalculateLevelOfDetail(samplerState, float2(u, u))
-
-        // METAL: tCubeArray{{.*}}.calculate_clamped_lod({{.*}}
-        && float(0) == tCubeArray.CalculateLevelOfDetail(samplerState, normalize(float3(u, 1 - u, u)))
+        // WGSL doesn't have a way to calculate mip-map level for the given coordinate
 
         // ========================================
         // float CalculateLevelOfDetailUnclamped()
         // ========================================
-
-        // Metal doesn't support LOD for 1D texture
-
-        // METAL: t2D{{.*}}.calculate_unclamped_lod({{.*}}
-        && float(0) >= t2D.CalculateLevelOfDetailUnclamped(samplerState, float2(u, u))
-
-        // METAL: t3D{{.*}}.calculate_unclamped_lod({{.*}}
-        && float(0) >= t3D.CalculateLevelOfDetailUnclamped(samplerState, float3(u, u, u))
-
-        // METAL: tCube{{.*}}.calculate_unclamped_lod({{.*}}
-        && float(0) >= tCube.CalculateLevelOfDetailUnclamped(samplerState, normalize(float3(u, 1 - u, u)))
-
-        // METAL: t2DArray{{.*}}.calculate_unclamped_lod({{.*}}
-        && float(0) >= t2DArray.CalculateLevelOfDetailUnclamped(samplerState, float2(u, u))
-
-        // METAL: tCubeArray{{.*}}.calculate_unclamped_lod({{.*}}
-        && float(0) >= tCubeArray.CalculateLevelOfDetailUnclamped(samplerState, normalize(float3(u, 1 - u, u)))
+        // WGSL doesn't have a way to calculate mip-map level for the given coordinate
 
         // ===========
         // T Sample()
         // ===========
 
-        // METAL: t1D{{.*}}.sample(
+#if 0
+        // WGSL: textureSample(t1D
         && all(Tvn(T(0)) == t1D.Sample(samplerState, u))
 
-        // METAL: t2D{{.*}}.sample({{.*}}
+        // WGSL: textureSample(t2D
         && all(Tvn(T(0)) == t2D.Sample(samplerState, float2(u, u)))
 
-        // METAL: t3D{{.*}}.sample({{.*}}
+        // WGSL: textureSample(t3D
         && all(Tvn(T(0)) == t3D.Sample(samplerState, float3(u, u, u)))
 
-        // METAL: tCube{{.*}}.sample({{.*}}
+        // WGSL: textureSample(tCube
         && all(Tvn(T(0)) == tCube.Sample(samplerState, normalize(float3(u, 1 - u, u))))
 
-        // METAL: t1DArray{{.*}}.sample(
+        // WGSL: textureSample(t1DArray
         && all(Tvn(T(0)) == t1DArray.Sample(samplerState, float2(u, 0)))
 
-        // METAL: t2DArray{{.*}}.sample({{.*}}
+        // WGSL: textureSample(t2DArray
         && all(Tvn(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0)))
 
-        // METAL: tCubeArray{{.*}}.sample({{.*}}
+        // WGSL: textureSample(tCubeArray
         && all(Tvn(T(0)) == tCubeArray.Sample(samplerState, float4(normalize(float3(u, 1 - u, u)), 0)))
 
         // Offset variant
 
         // Metal doesn't support Offset for 1D and Cube texture
 
-        // METAL: t2D{{.*}}.sample({{.*}}
+        // WGSL: t2D{{.*}}.sample({{.*}}
         && all(Tvn(T(0)) == t2D.Sample(samplerState, float2(u, u), int2(1, 1)))
 
-        // METAL: t3D{{.*}}.sample({{.*}}
+        // WGSL: t3D{{.*}}.sample({{.*}}
         && all(Tvn(T(0)) == t3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1)))
 
-        // METAL: t2DArray{{.*}}.sample({{.*}}
+        // WGSL: t2DArray{{.*}}.sample({{.*}}
         && all(Tvn(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1)))
 
         // Clamp variant
 
         // Metal doesn't support Offset for 1D and Cube texture
 
-        // METAL: t2D{{.*}}.sample({{.*}} min_lod_clamp(
+        // WGSL: t2D{{.*}}.sample({{.*}} min_lod_clamp(
         && all(Tvn(T(0)) == t2D.Sample(samplerState, float2(u, u), int2(1, 1), float(1)))
 
-        // METAL: t3D{{.*}}.sample({{.*}} min_lod_clamp(
+        // WGSL: t3D{{.*}}.sample({{.*}} min_lod_clamp(
         && all(Tvn(T(0)) == t3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1), float(1)))
 
-        // METAL: t2DArray{{.*}}.sample({{.*}} min_lod_clamp(
+        // WGSL: t2DArray{{.*}}.sample({{.*}} min_lod_clamp(
         && all(Tvn(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1), float(1)))
 
         // ===============
@@ -397,32 +321,32 @@ bool TEST_texture(
 
         // Metal doesn't support Bias for 1D texture
 
-        // METAL: t2D{{.*}}.sample({{.*}}
+        // WGSL: t2D{{.*}}.sample({{.*}}
         && all(Tvn(T(0)) == t2D.SampleBias(samplerState, float2(u, u), float(-1)))
 
-        // METAL: t3D{{.*}}.sample({{.*}}
+        // WGSL: t3D{{.*}}.sample({{.*}}
         && all(Tvn(T(0)) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1)))
 
-        // METAL: tCube{{.*}}.sample({{.*}}
+        // WGSL: tCube{{.*}}.sample({{.*}}
         && all(Tvn(T(0)) == tCube.SampleBias(samplerState, normalize(float3(u, 1 - u, u)), float(-1)))
 
-        // METAL: t2DArray{{.*}}.sample({{.*}}
+        // WGSL: t2DArray{{.*}}.sample({{.*}}
         && all(Tvn(T(0)) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1)))
 
-        // METAL: tCubeArray{{.*}}.sample({{.*}}
+        // WGSL: tCubeArray{{.*}}.sample({{.*}}
         && all(Tvn(T(0)) == tCubeArray.SampleBias(samplerState, float4(normalize(float3(u, 1 - u, u)), 0), float(-1)))
 
         // Offset variant
 
         // Metal doesn't support Offset for 1D and Cube texture
 
-        // METAL: t2D{{.*}}.sample({{.*}}
+        // WGSL: t2D{{.*}}.sample({{.*}}
         && all(Tvn(T(0)) == t2D.SampleBias(samplerState, float2(u, u), float(-1), int2(1, 1)))
 
-        // METAL: t3D{{.*}}.sample({{.*}}
+        // WGSL: t3D{{.*}}.sample({{.*}}
         && all(Tvn(T(0)) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1), int3(1, 1, 1)))
 
-        // METAL: t2DArray{{.*}}.sample({{.*}}
+        // WGSL: t2DArray{{.*}}.sample({{.*}}
         && all(Tvn(T(0)) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1), int2(1, 1)))
 
         // ===================================
@@ -431,98 +355,98 @@ bool TEST_texture(
 
         // Metal doesn't support LOD for 1D texture
 
-        // METAL: t2D{{.*}}.sample({{.*}} level(
+        // WGSL: t2D{{.*}}.sample({{.*}} level(
         && all(Tvn(T(0)) == t2D.SampleLevel(samplerState, float2(u, u), 0))
 
-        // METAL: t3D{{.*}}.sample({{.*}} level(
+        // WGSL: t3D{{.*}}.sample({{.*}} level(
         && all(Tvn(T(0)) == t3D.SampleLevel(samplerState, float3(u, u, u), 0))
 
-        // METAL: tCube{{.*}}.sample({{.*}} level(
+        // WGSL: tCube{{.*}}.sample({{.*}} level(
         && all(Tvn(T(0)) == tCube.SampleLevel(samplerState, normalize(float3(u, 1 - u, u)), 0))
 
-        // METAL: t2DArray{{.*}}.sample({{.*}} level(
+        // WGSL: t2DArray{{.*}}.sample({{.*}} level(
         && all(Tvn(T(0)) == t2DArray.SampleLevel(samplerState, float3(u, u, 0), 0))
 
-        // METAL: tCubeArray{{.*}}.sample({{.*}} level(
+        // WGSL: tCubeArray{{.*}}.sample({{.*}} level(
         && all(Tvn(T(0)) == tCubeArray.SampleLevel(samplerState, float4(normalize(float3(u, 1 - u, u)), 0), 0))
 
         // Offset variant
 
         // Metal doesn't support LOD for 1D texture
 
-        // METAL: t2D{{.*}}.sample({{.*}} level(
+        // WGSL: t2D{{.*}}.sample({{.*}} level(
         && all(Tvn(T(0)) == t2D.SampleLevel(samplerState, float2(u, u), 0, int2(1, 1)))
 
-        // METAL: t3D{{.*}}.sample({{.*}} level(
+        // WGSL: t3D{{.*}}.sample({{.*}} level(
         && all(Tvn(T(0)) == t3D.SampleLevel(samplerState, float3(u, u, u), 0, int3(1, 1, 1)))
 
-        // METAL: t2DArray{{.*}}.sample({{.*}} level(
+        // WGSL: t2DArray{{.*}}.sample({{.*}} level(
         && all(Tvn(T(0)) == t2DArray.SampleLevel(samplerState, float3(u, u, 0), 0, int2(1, 1)))
 
         // ==================
         // float SampleCmp()
         // ==================
 
-        // METAL: d2D{{.*}}.sample_compare(
+        // WGSL: d2D{{.*}}.sample_compare(
         && float(0) == d2D.SampleCmp(shadowSampler, float2(u, u), 0)
 
-        // METAL: d2DArray{{.*}}.sample_compare(
+        // WGSL: d2DArray{{.*}}.sample_compare(
         && float(0) == d2DArray.SampleCmp(shadowSampler, float3(u, u, 0), 0)
 
-        // METAL: dCube{{.*}}.sample_compare(
+        // WGSL: dCube{{.*}}.sample_compare(
         && float(0) == dCube.SampleCmp(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
 
-        // METAL: dCubeArray{{.*}}.sample_compare(
+        // WGSL: dCubeArray{{.*}}.sample_compare(
         && float(0) == dCubeArray.SampleCmp(shadowSampler, float4(normalize(float3(u, 1 - u, u)), 0), 0)
 
         // Offset variant
 
-        // METAL: d2D{{.*}}.sample_compare(
+        // WGSL: d2D{{.*}}.sample_compare(
         && float(0) == d2D.SampleCmp(shadowSampler, float2(u2, u), 0, int2(0, 0))
 
         // ===================================
         //  float SampleCmpLevelZero()
         // ===================================
 
-        // METAL: d2D{{.*}}.sample_compare(
+        // WGSL: d2D{{.*}}.sample_compare(
         && float(0) == d2D.SampleCmpLevelZero(shadowSampler, float2(u, u), 0)
 
-        // METAL: d2DArray{{.*}}.sample_compare(
+        // WGSL: d2DArray{{.*}}.sample_compare(
         && float(0) == d2DArray.SampleCmpLevelZero(shadowSampler, float3(u, u, 0), 0)
 
-        // METAL: dCube{{.*}}.sample_compare(
+        // WGSL: dCube{{.*}}.sample_compare(
         && float(0) == dCube.SampleCmpLevelZero(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
 
-        // METAL: dCubeArray{{.*}}.sample_compare(
+        // WGSL: dCubeArray{{.*}}.sample_compare(
         && float(0) == dCubeArray.SampleCmpLevelZero(shadowSampler, float4(normalize(float3(u, 1-u, u)), 0), 0)
 
         // Offset variant
 
-        // METAL: d2D{{.*}}.sample_compare(
+        // WGSL: d2D{{.*}}.sample_compare(
         && float(0) == d2D.SampleCmpLevelZero(shadowSampler, float2(u2, u), 0, int2(0, 0))
 
         // ==================================
         //  vector<T,4> Gather()
         // ==================================
 
-        // METAL: t2D{{.*}}.gather(
+        // WGSL: t2D{{.*}}.gather(
         && all(Tv4(T(0)) == t2D.Gather(samplerState, float2(u, u)))
 
-        // METAL: tCube{{.*}}.gather(
+        // WGSL: tCube{{.*}}.gather(
         && all(Tv4(T(0)) == tCube.Gather(samplerState, normalize(float3(u, 1 - u, u))))
 
-        // METAL: t2DArray{{.*}}.gather(
+        // WGSL: t2DArray{{.*}}.gather(
         && all(Tv4(T(0)) == t2DArray.Gather(samplerState, float3(u, u, 0)))
 
-        // METAL: tCubeArray{{.*}}.gather(
+        // WGSL: tCubeArray{{.*}}.gather(
         && all(Tv4(T(0)) == tCubeArray.Gather(samplerState, float4(normalize(float3(u, 1 - u, u)), 0)))
 
         // Offset variant
 
-        // METAL: t2D{{.*}}.gather(
+        // WGSL: t2D{{.*}}.gather(
         && all(Tv4(T(0)) == t2D.Gather(samplerState, float2(u2, u), int2(0, 0)))
 
-        // METAL: t2DArray{{.*}}.gather(
+        // WGSL: t2DArray{{.*}}.gather(
         && all(Tv4(T(0)) == t2DArray.Gather(samplerState, float3(u2, u, 0), int2(0, 0)))
 
         // =====================================
@@ -531,46 +455,46 @@ bool TEST_texture(
 
         // Metal doesn't support LOD for 1D texture
 
-        // METAL: t2D{{.*}}.sample(
+        // WGSL: t2D{{.*}}.sample(
         && all(Tvn(T(0)) == t2D.SampleGrad(samplerState, float2(u, u), float2(ddx, ddx), float2(ddy, ddy)))
 
-        // METAL: t3D{{.*}}.sample(
+        // WGSL: t3D{{.*}}.sample(
         && all(Tvn(T(0)) == t3D.SampleGrad(samplerState, float3(u, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
 
-        // METAL: tCube{{.*}}.sample(
+        // WGSL: tCube{{.*}}.sample(
         && all(Tvn(T(0)) == tCube.SampleGrad(samplerState, normalize(float3(u, 1 - u, u)), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
 
-        // METAL: t2DArray{{.*}}.sample(
+        // WGSL: t2DArray{{.*}}.sample(
         && all(Tvn(T(0)) == t2DArray.SampleGrad(samplerState, float3(u, u, 0.0f), float2(ddx, ddx), float2(ddy, ddy)))
 
         // Offset variant
 
-        // METAL: t2D{{.*}}.sample(
+        // WGSL: t2D{{.*}}.sample(
         && all(Tvn(T(0)) == t2D.SampleGrad(samplerState, float2(u2, u), float2(ddx, ddx), float2(ddy, ddy), int2(0, 0)))
 
-        // METAL: t3D{{.*}}.sample(
+        // WGSL: t3D{{.*}}.sample(
         && all(Tvn(T(0)) == t3D.SampleGrad(samplerState, float3(u2, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy), int3(0, 0, 0)))
 
-        // METAL: t2DArray{{.*}}.sample(
+        // WGSL: t2DArray{{.*}}.sample(
         && all(Tvn(T(0)) == t2DArray.SampleGrad(samplerState, float3(u2, u, 0.0f), float2(ddx, ddx), float2(ddy, ddy), int2(0, 0)))
 
         // ===================
         //  T Load()
         // ===================
 
-        // METAL: t1D{{.*}}.read(
+        // WGSL: t1D{{.*}}.read(
         && all(Tvn(T(0)) == t1D.Load(int2(0, 0)))
 
-        // METAL: t2D{{.*}}.read(
+        // WGSL: t2D{{.*}}.read(
         && all(Tvn(T(0)) == t2D.Load(int3(0, 0, 0)))
 
-        // METAL: t3D{{.*}}.read(
+        // WGSL: t3D{{.*}}.read(
         && all(Tvn(T(0)) == t3D.Load(int4(0, 0, 0, 0)))
 
-        // METAL: t1DArray{{.*}}.read(
+        // WGSL: t1DArray{{.*}}.read(
         && all(Tvn(T(0)) == t1DArray.Load(int3(0, 0, 0)))
 
-        // METAL: t2DArray{{.*}}.read(
+        // WGSL: t2DArray{{.*}}.read(
         && all(Tvn(T(0)) == t2DArray.Load(int4(0, 0, 0, 0)))
 
         // Offset variant

--- a/tests/wgsl/texture.slang
+++ b/tests/wgsl/texture.slang
@@ -123,17 +123,13 @@ bool TEST_texture(
     constexpr const float ddy = 0.0f;
 
     uint width = 0, height = 0, depth = 0;
-    float fwidth = 0.0f, fheight = 0.0f, fdepth = 0.0f;
-    uint numLevels = 0, elements = 0, sampleCount = 0;
-    float fnumLevels = 0.0f, felements = 0.0f;
+    uint elements = 0;
 
     bool voidResult = true;
 
     // ======================
     //  void GetDimensions()
     // ======================
-
-    // WGSL doesn't support the mip level query;
 
     // WGSL: textureDimensions({{\(*}}t1D
     t1D.GetDimensions(width);

--- a/tests/wgsl/texture.slang
+++ b/tests/wgsl/texture.slang
@@ -1,4 +1,5 @@
-//TEST:SIMPLE(filecheck=WGSL): -stage compute -entry computeMain -target wgsl
+// WGSL supports "textureSample()" only in fragment shader
+//TEST:SIMPLE(filecheck=WGSL): -stage fragment -entry fragMain -target wgsl
 
 //TEST_INPUT: ubuffer(data=[0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;
@@ -18,103 +19,22 @@ Texture2DArray<float3> t2DArray_f32v3;
 //TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_f32v3
 TextureCubeArray<float3> tCubeArray_f32v3;
 
-//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_f32
-Texture1D<float4> t1D_f32;
-//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_f32
-Texture2D<float4> t2D_f32;
-//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_f32
-Texture3D<float4> t3D_f32;
-//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_f32
-TextureCube<float4> tCube_f32;
+//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_f32v4
+Texture1D<float4> t1D_f32v4;
+//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_f32v4
+Texture2D<float4> t2D_f32v4;
+//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_f32v4
+Texture3D<float4> t3D_f32v4;
+//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_f32v4
+TextureCube<float4> tCube_f32v4;
 
-//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_f32
-Texture1DArray<float4> t1DArray_f32;
-//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_f32
-Texture2DArray<float4> t2DArray_f32;
-//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_f32
-TextureCubeArray<float4> tCubeArray_f32;
+//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_f32v4
+Texture1DArray<float4> t1DArray_f32v4;
+//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_f32v4
+Texture2DArray<float4> t2DArray_f32v4;
+//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_f32v4
+TextureCubeArray<float4> tCubeArray_f32v4;
 
-//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_f16
-Texture1D<half4> t1D_f16;
-//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_f16
-Texture2D<half4> t2D_f16;
-//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_f16
-Texture3D<half4> t3D_f16;
-//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_f16
-TextureCube<half4> tCube_f16;
-
-//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_f16
-Texture1DArray<half4> t1DArray_f16;
-//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_f16
-Texture2DArray<half4> t2DArray_f16;
-//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_f16
-TextureCubeArray<half4> tCubeArray_f16;
-
-//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_i32
-Texture1D<int4> t1D_i32;
-//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_i32
-Texture2D<int4> t2D_i32;
-//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_i32
-Texture3D<int4> t3D_i32;
-//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_i32
-TextureCube<int4> tCube_i32;
-
-//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_i32
-Texture1DArray<int4> t1DArray_i32;
-//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_i32
-Texture2DArray<int4> t2DArray_i32;
-//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_i32
-TextureCubeArray<int4> tCubeArray_i32;
-
-//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_u32
-Texture1D<uint4> t1D_u32;
-//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_u32
-Texture2D<uint4> t2D_u32;
-//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_u32
-Texture3D<uint4> t3D_u32;
-//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_u32
-TextureCube<uint4> tCube_u32;
-
-//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_u32
-Texture1DArray<uint4> t1DArray_u32;
-//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_u32
-Texture2DArray<uint4> t2DArray_u32;
-//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_u32
-TextureCubeArray<uint4> tCubeArray_u32;
-
-//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_i16
-Texture1D<int16_t4> t1D_i16;
-//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_i16
-Texture2D<int16_t4> t2D_i16;
-//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_i16
-Texture3D<int16_t4> t3D_i16;
-//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_i16
-TextureCube<int16_t4> tCube_i16;
-
-//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_i16
-Texture1DArray<int16_t4> t1DArray_i16;
-//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_i16
-Texture2DArray<int16_t4> t2DArray_i16;
-//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_i16
-TextureCubeArray<int16_t4> tCubeArray_i16;
-
-//TEST_INPUT: Texture1D(size=4, content = zero):name t1D_u16
-Texture1D<uint16_t4> t1D_u16;
-//TEST_INPUT: Texture2D(size=4, content = zero):name t2D_u16
-Texture2D<uint16_t4> t2D_u16;
-//TEST_INPUT: Texture3D(size=4, content = zero):name t3D_u16
-Texture3D<uint16_t4> t3D_u16;
-//TEST_INPUT: TextureCube(size=4, content = zero):name tCube_u16
-TextureCube<uint16_t4> tCube_u16;
-
-//TEST_INPUT: Texture1D(size=4, content = zero, arrayLength=2):name t1DArray_u16
-Texture1DArray<uint16_t4> t1DArray_u16;
-//TEST_INPUT: Texture2D(size=4, content = zero, arrayLength=2):name t2DArray_u16
-Texture2DArray<uint16_t4> t2DArray_u16;
-//TEST_INPUT: TextureCube(size=4, content = zero, arrayLength=2):name tCubeArray_u16
-TextureCubeArray<uint16_t4> tCubeArray_u16;
-
-// Metal doc says "For depth texture types, T must be float."
 __generic<T : __BuiltinType, let sampleCount:int=0, let format:int=0>
 typealias depth2d = __TextureImpl<
     T,
@@ -215,38 +135,38 @@ bool TEST_texture(
 
     // WGSL doesn't support the mip level query;
 
-    // WGSL: textureDimensions(t1D
+    // WGSL: textureDimensions({{\(*}}t1D
     t1D.GetDimensions(width);
     voidResult = voidResult && (uint(4) == width);
 
-    // WGSL: textureDimensions(t2D
+    // WGSL: textureDimensions({{\(*}}t2D
     t2D.GetDimensions(width, height);
     voidResult = voidResult && (uint(4) == width);
     voidResult = voidResult && (uint(4) == height);
 
-    // WGSL: textureDimensions(t3D
+    // WGSL: textureDimensions({{\(*}}t3D
     t3D.GetDimensions(width, height, depth);
     voidResult = voidResult && (uint(4) == width);
     voidResult = voidResult && (uint(4) == height);
     voidResult = voidResult && (uint(4) == depth);
 
-    // WGSL: textureDimensions(tCube
+    // WGSL: textureDimensions({{\(*}}tCube
     tCube.GetDimensions(width, height);
     voidResult = voidResult && (uint(4) == width);
     voidResult = voidResult && (uint(4) == height);
 
-    // WGSL: textureDimensions(t1DArray
+    // WGSL: textureDimensions({{\(*}}t1DArray
     t1DArray.GetDimensions(width, elements);
     voidResult = voidResult && (uint(4) == width);
     voidResult = voidResult && (uint(2) == elements);
 
-    // WGSL: textureDimensions(t2DArray
+    // WGSL: textureDimensions({{\(*}}t2DArray
     t2DArray.GetDimensions(width, height, elements);
     voidResult = voidResult && (uint(4) == width);
     voidResult = voidResult && (uint(4) == height);
     voidResult = voidResult && (uint(2) == elements);
 
-    // WGSL: textureDimensions(tCubeArray
+    // WGSL: textureDimensions({{\(*}}tCubeArray
     tCubeArray.GetDimensions(width, height, elements);
     voidResult = voidResult && (uint(4) == width);
     voidResult = voidResult && (uint(4) == height);
@@ -265,249 +185,247 @@ bool TEST_texture(
 
         // ===========
         // T Sample()
+        // https://www.w3.org/TR/WGSL/#texturesample
         // ===========
 
-#if 0
-        // WGSL: textureSample(t1D
+        // WGSL: textureSample({{\(*}}t1D
         && all(Tvn(T(0)) == t1D.Sample(samplerState, u))
 
-        // WGSL: textureSample(t2D
+        // WGSL: textureSample({{\(*}}t2D
         && all(Tvn(T(0)) == t2D.Sample(samplerState, float2(u, u)))
 
-        // WGSL: textureSample(t3D
+        // WGSL: textureSample({{\(*}}t3D
         && all(Tvn(T(0)) == t3D.Sample(samplerState, float3(u, u, u)))
 
-        // WGSL: textureSample(tCube
+        // WGSL: textureSample({{\(*}}tCube
         && all(Tvn(T(0)) == tCube.Sample(samplerState, normalize(float3(u, 1 - u, u))))
 
-        // WGSL: textureSample(t1DArray
-        && all(Tvn(T(0)) == t1DArray.Sample(samplerState, float2(u, 0)))
+        // WGSL doesn't support textureSample for 1d_array and 3d_array; only 2d and cube
 
-        // WGSL: textureSample(t2DArray
+        // WGSL: textureSample({{\(*}}t2DArray
         && all(Tvn(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0)))
 
-        // WGSL: textureSample(tCubeArray
+        // WGSL: textureSample({{\(*}}tCubeArray
         && all(Tvn(T(0)) == tCubeArray.Sample(samplerState, float4(normalize(float3(u, 1 - u, u)), 0)))
 
         // Offset variant
 
-        // Metal doesn't support Offset for 1D and Cube texture
+        // WGSL: textureSample({{\(*}}t1D
+        && all(Tvn(T(0)) == t1D.Sample(samplerState, u, 1))
 
-        // WGSL: t2D{{.*}}.sample({{.*}}
+        // WGSL: textureSample({{\(*}}t2D
         && all(Tvn(T(0)) == t2D.Sample(samplerState, float2(u, u), int2(1, 1)))
 
-        // WGSL: t3D{{.*}}.sample({{.*}}
+        // WGSL: textureSample({{\(*}}t3D
         && all(Tvn(T(0)) == t3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1)))
 
-        // WGSL: t2DArray{{.*}}.sample({{.*}}
+        // WGSL doesn't support offset variant for cube and cube_array
+
+        // WGSL: textureSample({{\(*}}t2DArray
         && all(Tvn(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1)))
 
         // Clamp variant
-
-        // Metal doesn't support Offset for 1D and Cube texture
-
-        // WGSL: t2D{{.*}}.sample({{.*}} min_lod_clamp(
-        && all(Tvn(T(0)) == t2D.Sample(samplerState, float2(u, u), int2(1, 1), float(1)))
-
-        // WGSL: t3D{{.*}}.sample({{.*}} min_lod_clamp(
-        && all(Tvn(T(0)) == t3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1), float(1)))
-
-        // WGSL: t2DArray{{.*}}.sample({{.*}} min_lod_clamp(
-        && all(Tvn(T(0)) == t2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1), float(1)))
+        // WGSL doesn't support clamp variants for `textureSample()`
 
         // ===============
         // T SampleBias()
+        // https://www.w3.org/TR/WGSL/#texturesamplebias
         // ===============
 
-        // Metal doesn't support Bias for 1D texture
+        // WGSL doesn't support Bias for 1D texture
 
-        // WGSL: t2D{{.*}}.sample({{.*}}
+        // WGSL: textureSampleBias({{\(*}}t2D
         && all(Tvn(T(0)) == t2D.SampleBias(samplerState, float2(u, u), float(-1)))
 
-        // WGSL: t3D{{.*}}.sample({{.*}}
+        // WGSL: textureSampleBias({{\(*}}t3D
         && all(Tvn(T(0)) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1)))
 
-        // WGSL: tCube{{.*}}.sample({{.*}}
+        // WGSL: textureSampleBias({{\(*}}tCube
         && all(Tvn(T(0)) == tCube.SampleBias(samplerState, normalize(float3(u, 1 - u, u)), float(-1)))
 
-        // WGSL: t2DArray{{.*}}.sample({{.*}}
+        // WGSL: textureSampleBias({{\(*}}t2DArray
         && all(Tvn(T(0)) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1)))
 
-        // WGSL: tCubeArray{{.*}}.sample({{.*}}
+        // WGSL: textureSampleBias({{\(*}}tCubeArray
         && all(Tvn(T(0)) == tCubeArray.SampleBias(samplerState, float4(normalize(float3(u, 1 - u, u)), 0), float(-1)))
 
         // Offset variant
 
-        // Metal doesn't support Offset for 1D and Cube texture
-
-        // WGSL: t2D{{.*}}.sample({{.*}}
+        // WGSL: textureSampleBias({{\(*}}t2D
         && all(Tvn(T(0)) == t2D.SampleBias(samplerState, float2(u, u), float(-1), int2(1, 1)))
 
-        // WGSL: t3D{{.*}}.sample({{.*}}
+        // WGSL: textureSampleBias({{\(*}}t3D
         && all(Tvn(T(0)) == t3D.SampleBias(samplerState, float3(u, u, u), float(-1), int3(1, 1, 1)))
 
-        // WGSL: t2DArray{{.*}}.sample({{.*}}
+        // WGSL: textureSampleBias({{\(*}}t2DArray
         && all(Tvn(T(0)) == t2DArray.SampleBias(samplerState, float3(u, u, 0), float(-1), int2(1, 1)))
 
         // ===================================
-        //  T SampleLevel()
+        // T SampleLevel()
+        // https://www.w3.org/TR/WGSL/#texturesamplelevel
         // ===================================
 
-        // Metal doesn't support LOD for 1D texture
+        // WGSL doesn't support textureSampleLevel for 1D texture
 
-        // WGSL: t2D{{.*}}.sample({{.*}} level(
+        // WGSL: textureSampleLevel({{\(*}}t2D
         && all(Tvn(T(0)) == t2D.SampleLevel(samplerState, float2(u, u), 0))
 
-        // WGSL: t3D{{.*}}.sample({{.*}} level(
+        // WGSL: textureSampleLevel({{\(*}}t3D
         && all(Tvn(T(0)) == t3D.SampleLevel(samplerState, float3(u, u, u), 0))
 
-        // WGSL: tCube{{.*}}.sample({{.*}} level(
+        // WGSL: textureSampleLevel({{\(*}}tCube
         && all(Tvn(T(0)) == tCube.SampleLevel(samplerState, normalize(float3(u, 1 - u, u)), 0))
 
-        // WGSL: t2DArray{{.*}}.sample({{.*}} level(
+        // WGSL: textureSampleLevel({{\(*}}t2DArray
         && all(Tvn(T(0)) == t2DArray.SampleLevel(samplerState, float3(u, u, 0), 0))
 
-        // WGSL: tCubeArray{{.*}}.sample({{.*}} level(
+        // WGSL: textureSampleLevel({{\(*}}tCubeArray
         && all(Tvn(T(0)) == tCubeArray.SampleLevel(samplerState, float4(normalize(float3(u, 1 - u, u)), 0), 0))
 
         // Offset variant
 
-        // Metal doesn't support LOD for 1D texture
-
-        // WGSL: t2D{{.*}}.sample({{.*}} level(
+        // WGSL: textureSampleLevel({{\(*}}t2D
         && all(Tvn(T(0)) == t2D.SampleLevel(samplerState, float2(u, u), 0, int2(1, 1)))
 
-        // WGSL: t3D{{.*}}.sample({{.*}} level(
+        // WGSL: textureSampleLevel({{\(*}}t3D
         && all(Tvn(T(0)) == t3D.SampleLevel(samplerState, float3(u, u, u), 0, int3(1, 1, 1)))
 
-        // WGSL: t2DArray{{.*}}.sample({{.*}} level(
+        // WGSL: textureSampleLevel({{\(*}}t2DArray
         && all(Tvn(T(0)) == t2DArray.SampleLevel(samplerState, float3(u, u, 0), 0, int2(1, 1)))
 
         // ==================
         // float SampleCmp()
+        // https://www.w3.org/TR/WGSL/#texturesamplecompare
         // ==================
 
-        // WGSL: d2D{{.*}}.sample_compare(
+        // WGSL: textureSampleCompare({{\(*}}d2D
         && float(0) == d2D.SampleCmp(shadowSampler, float2(u, u), 0)
 
-        // WGSL: d2DArray{{.*}}.sample_compare(
+        // WGSL: textureSampleCompare({{\(*}}d2DArray
         && float(0) == d2DArray.SampleCmp(shadowSampler, float3(u, u, 0), 0)
 
-        // WGSL: dCube{{.*}}.sample_compare(
+        // WGSL: textureSampleCompare({{\(*}}dCube
         && float(0) == dCube.SampleCmp(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
 
-        // WGSL: dCubeArray{{.*}}.sample_compare(
+        // WGSL: textureSampleCompare({{\(*}}dCubeArray
         && float(0) == dCubeArray.SampleCmp(shadowSampler, float4(normalize(float3(u, 1 - u, u)), 0), 0)
 
         // Offset variant
 
-        // WGSL: d2D{{.*}}.sample_compare(
+        // WGSL doesn't support the offset variant for cube and cube_array
+
+        // WGSL: textureSampleCompare({{\(*}}d2D
         && float(0) == d2D.SampleCmp(shadowSampler, float2(u2, u), 0, int2(0, 0))
 
+        // WGSL: textureSampleCompare({{\(*}}d2DArray
+        && float(0) == d2DArray.SampleCmp(shadowSampler, float3(u2, u, u), 0, int2(0, 0))
+
         // ===================================
-        //  float SampleCmpLevelZero()
+        // float SampleCmpLevelZero()
+        // https://www.w3.org/TR/WGSL/#texturesamplecomparelevel
         // ===================================
 
-        // WGSL: d2D{{.*}}.sample_compare(
+        // WGSL: textureSampleCompareLevel({{\(*}}d2D
         && float(0) == d2D.SampleCmpLevelZero(shadowSampler, float2(u, u), 0)
 
-        // WGSL: d2DArray{{.*}}.sample_compare(
+        // WGSL: textureSampleCompareLevel({{\(*}}d2DArray
         && float(0) == d2DArray.SampleCmpLevelZero(shadowSampler, float3(u, u, 0), 0)
 
-        // WGSL: dCube{{.*}}.sample_compare(
+        // WGSL: textureSampleCompareLevel({{\(*}}dCube
         && float(0) == dCube.SampleCmpLevelZero(shadowSampler, normalize(float3(u, 1 - u, u)), 0)
 
-        // WGSL: dCubeArray{{.*}}.sample_compare(
+        // WGSL: textureSampleCompareLevel({{\(*}}dCubeArray
         && float(0) == dCubeArray.SampleCmpLevelZero(shadowSampler, float4(normalize(float3(u, 1-u, u)), 0), 0)
 
         // Offset variant
 
-        // WGSL: d2D{{.*}}.sample_compare(
+        // WGSL: textureSampleCompareLevel({{\(*}}d2D
         && float(0) == d2D.SampleCmpLevelZero(shadowSampler, float2(u2, u), 0, int2(0, 0))
 
+        // WGSL: textureSampleCompareLevel({{\(*}}d2DArray
+        && float(0) == d2DArray.SampleCmpLevelZero(shadowSampler, float3(u2, u, u), 0, int2(0, 0))
+
         // ==================================
-        //  vector<T,4> Gather()
+        // vector<T,4> Gather()
+        // https://www.w3.org/TR/WGSL/#texturegather
         // ==================================
 
-        // WGSL: t2D{{.*}}.gather(
+#if 0
         && all(Tv4(T(0)) == t2D.Gather(samplerState, float2(u, u)))
 
-        // WGSL: tCube{{.*}}.gather(
         && all(Tv4(T(0)) == tCube.Gather(samplerState, normalize(float3(u, 1 - u, u))))
 
-        // WGSL: t2DArray{{.*}}.gather(
         && all(Tv4(T(0)) == t2DArray.Gather(samplerState, float3(u, u, 0)))
 
-        // WGSL: tCubeArray{{.*}}.gather(
         && all(Tv4(T(0)) == tCubeArray.Gather(samplerState, float4(normalize(float3(u, 1 - u, u)), 0)))
 
         // Offset variant
 
-        // WGSL: t2D{{.*}}.gather(
         && all(Tv4(T(0)) == t2D.Gather(samplerState, float2(u2, u), int2(0, 0)))
 
-        // WGSL: t2DArray{{.*}}.gather(
         && all(Tv4(T(0)) == t2DArray.Gather(samplerState, float3(u2, u, 0), int2(0, 0)))
+#endif
 
         // =====================================
-        //  T SampleGrad()
+        // T SampleGrad()
+        // https://www.w3.org/TR/WGSL/#texturesamplegrad
         // =====================================
 
-        // Metal doesn't support LOD for 1D texture
+        // WGSL doesn't support textureSampleGrad for 1D textures
 
-        // WGSL: t2D{{.*}}.sample(
+        // WGSL: textureSampleGrad({{\(*}}t2D
         && all(Tvn(T(0)) == t2D.SampleGrad(samplerState, float2(u, u), float2(ddx, ddx), float2(ddy, ddy)))
 
-        // WGSL: t3D{{.*}}.sample(
+        // WGSL: textureSampleGrad({{\(*}}t3D
         && all(Tvn(T(0)) == t3D.SampleGrad(samplerState, float3(u, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
 
-        // WGSL: tCube{{.*}}.sample(
+        // WGSL: textureSampleGrad({{\(*}}tCube
         && all(Tvn(T(0)) == tCube.SampleGrad(samplerState, normalize(float3(u, 1 - u, u)), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
 
-        // WGSL: t2DArray{{.*}}.sample(
+        // WGSL: textureSampleGrad({{\(*}}t2DArray
         && all(Tvn(T(0)) == t2DArray.SampleGrad(samplerState, float3(u, u, 0.0f), float2(ddx, ddx), float2(ddy, ddy)))
+
+        // WGSL: textureSampleGrad({{\(*}}tCubeArray
+        && all(Tvn(T(0)) == tCubeArray.SampleGrad(samplerState, float4(normalize(float3(u, 1 - u, u)), 0), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy)))
 
         // Offset variant
 
-        // WGSL: t2D{{.*}}.sample(
+        // WGSL: textureSampleGrad({{\(*}}t2D
         && all(Tvn(T(0)) == t2D.SampleGrad(samplerState, float2(u2, u), float2(ddx, ddx), float2(ddy, ddy), int2(0, 0)))
 
-        // WGSL: t3D{{.*}}.sample(
+        // WGSL: textureSampleGrad({{\(*}}t3D
         && all(Tvn(T(0)) == t3D.SampleGrad(samplerState, float3(u2, u, u), float3(ddx, ddx, ddx), float3(ddy, ddy, ddy), int3(0, 0, 0)))
 
-        // WGSL: t2DArray{{.*}}.sample(
+        // WGSL: textureSampleGrad({{\(*}}t2DArray
         && all(Tvn(T(0)) == t2DArray.SampleGrad(samplerState, float3(u2, u, 0.0f), float2(ddx, ddx), float2(ddy, ddy), int2(0, 0)))
 
         // ===================
-        //  T Load()
+        // T Load()
+        // https://www.w3.org/TR/WGSL/#textureload
         // ===================
 
-        // WGSL: t1D{{.*}}.read(
+        // WGSL: textureLoad({{\(*}}t1D
         && all(Tvn(T(0)) == t1D.Load(int2(0, 0)))
 
-        // WGSL: t2D{{.*}}.read(
+        // WGSL: textureLoad({{\(*}}t2D
         && all(Tvn(T(0)) == t2D.Load(int3(0, 0, 0)))
 
-        // WGSL: t3D{{.*}}.read(
+        // WGSL: textureLoad({{\(*}}t3D
         && all(Tvn(T(0)) == t3D.Load(int4(0, 0, 0, 0)))
 
-        // WGSL: t1DArray{{.*}}.read(
-        && all(Tvn(T(0)) == t1DArray.Load(int3(0, 0, 0)))
+        // WGSL supports array only for 2D
 
-        // WGSL: t2DArray{{.*}}.read(
+        // WGSL: textureLoad({{\(*}}t2DArray
         && all(Tvn(T(0)) == t2DArray.Load(int4(0, 0, 0, 0)))
 
         // Offset variant
-
-        // Metal doesn't support offset variants for Load
-#endif
+        // WGSL doesn't support offset variants for Load
         ;
 
     return result;
 }
 
-[numthreads(1, 1, 1)]
-void computeMain()
+void fragMain()
 {
     bool result = true
         && TEST_texture<float, 3>(
@@ -518,62 +436,14 @@ void computeMain()
             t1DArray_f32v3,
             t2DArray_f32v3,
             tCubeArray_f32v3)
-#if 0
         && TEST_texture<float, 4>(
-            t1D_f32,
-            t2D_f32,
-            t3D_f32,
-            tCube_f32,
-            t1DArray_f32,
-            t2DArray_f32,
-            tCubeArray_f32)
-#if !defined(EXCLUDE_HALF_TYPE)
-        && TEST_texture<half, 4>(
-            t1D_f16,
-            t2D_f16,
-            t3D_f16,
-            tCube_f16,
-            t1DArray_f16,
-            t2DArray_f16,
-            tCubeArray_f16)
-#endif
-#if !defined(EXCLUDE_INTEGER_TYPE)
-        && TEST_texture<int, 4>(
-            t1D_i32,
-            t2D_i32,
-            t3D_i32,
-            tCube_i32,
-            t1DArray_i32,
-            t2DArray_i32,
-            tCubeArray_i32)
-        && TEST_texture<uint, 4>(
-            t1D_u32,
-            t2D_u32,
-            t3D_u32,
-            tCube_u32,
-            t1DArray_u32,
-            t2DArray_u32,
-            tCubeArray_u32)
-#if !defined(EXCLUDE_SHORT_TYPE)
-        && TEST_texture<int16_t, 4>(
-            t1D_i16,
-            t2D_i16,
-            t3D_i16,
-            tCube_i16,
-            t1DArray_i16,
-            t2DArray_i16,
-            tCubeArray_i16)
-        && TEST_texture<uint16_t, 4>(
-            t1D_u16,
-            t2D_u16,
-            t3D_u16,
-            tCube_u16,
-            t1DArray_u16,
-            t2DArray_u16,
-            tCubeArray_u16)
-#endif
-#endif
-#endif
+            t1D_f32v4,
+            t2D_f32v4,
+            t3D_f32v4,
+            tCube_f32v4,
+            t1DArray_f32v4,
+            t2DArray_f32v4,
+            tCubeArray_f32v4)
         ;
 
     // FUNCTIONAL: 1


### PR DESCRIPTION
This PR implements all of the texture intrinsics for WGSL except "Gather" and sampler-less.
They will be implemented in a separate PR.

A few things to note:
- texture sampling functions are available only for the fragment shader stage; not for compute
- WGSL doesn't have any functions similar to CalculateLevelOfDetail or CalculateLevelOfDetailUnclamped.
- WGSL doesn't have a function overlaoding for `textureSample` with "clamp" or "status" arguments.
- WGSL doesn't support Load operation with offset for texture_multisampled_XX and texture_storage_XX.
- WGSL supports only four types of depth textures: 2D, 2D_array, cube and cube_array.
- WGSL doesn't support "offset" variants for cube and cube_array.
