### PR TITLE
Fix handling of pointer logic in wgsl backend.

### DIFF
--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -1998,6 +1998,11 @@ void CLikeSourceEmitter::emitIntrinsicCallExprImpl(
     }
 }
 
+void CLikeSourceEmitter::emitCallArg(IRInst* inst)
+{
+    emitOperand(inst, getInfo(EmitOp::General));
+}
+
 void CLikeSourceEmitter::_emitCallArgList(IRCall* inst, int startingOperandIndex)
 {
     bool isFirstArg = true;
@@ -2018,7 +2023,7 @@ void CLikeSourceEmitter::_emitCallArgList(IRCall* inst, int startingOperandIndex
             m_writer->emit(", ");
         else
             isFirstArg = false;
-        emitOperand(inst->getOperand(aa), getInfo(EmitOp::General));
+        emitCallArg(inst->getOperand(aa));
     }
     m_writer->emit(")");
 }
@@ -4201,7 +4206,7 @@ void CLikeSourceEmitter::emitGlobalParam(IRGlobalParam* varDecl)
 
     emitRateQualifiersAndAddressSpace(varDecl);
     emitVarKeyword(varType, varDecl);
-    emitGlobalParamType(varType, getName(varDecl));
+    emitType(varType, getName(varDecl));
 
     emitSemantics(varDecl);
 

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -1646,16 +1646,11 @@ bool CLikeSourceEmitter::shouldFoldInstIntoUseSites(IRInst* inst)
     return true;
 }
 
-bool CLikeSourceEmitter::isPointerSyntaxRequiredImpl(IRInst* /* inst */)
-{
-    return doesTargetSupportPtrTypes();
-}
-
 void CLikeSourceEmitter::emitDereferenceOperand(IRInst* inst, EmitOpInfo const& outerPrec)
 {
     EmitOpInfo newOuterPrec = outerPrec;
 
-    if (isPointerSyntaxRequiredImpl(inst))
+    if (doesTargetSupportPtrTypes())
     {
         switch (inst->getOp())
         {
@@ -1754,7 +1749,7 @@ void CLikeSourceEmitter::emitDereferenceOperand(IRInst* inst, EmitOpInfo const& 
 
 void CLikeSourceEmitter::emitVarExpr(IRInst* inst, EmitOpInfo const& outerPrec)
 {
-    if (isPointerSyntaxRequiredImpl(inst))
+    if (doesTargetSupportPtrTypes())
     {
         auto prec = getInfo(EmitOp::Prefix);
         auto newOuterPrec = outerPrec;
@@ -2296,7 +2291,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
 
         IRFieldAddress* ii = (IRFieldAddress*) inst;
 
-        if (isPointerSyntaxRequiredImpl(inst))
+        if (doesTargetSupportPtrTypes())
         {
             auto prec = getInfo(EmitOp::Prefix);
             needClose = maybeEmitParens(outerPrec, prec);

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -257,7 +257,6 @@ public:
     void emitType(IRType* type);
     void emitType(IRType* type, Name* name, SourceLoc const& nameLoc);
     void emitType(IRType* type, NameLoc const& nameAndLoc);
-    virtual void emitGlobalParamType(IRType* type, String const& name) {emitType(type, name);}
     bool hasExplicitConstantBufferOffset(IRInst* cbufferType);
     bool isSingleElementConstantBuffer(IRInst* cbufferType);
     bool shouldForceUnpackConstantBufferElements(IRInst* cbufferType);
@@ -566,6 +565,7 @@ public:
 
         // Emit the argument list (including paranthesis) in a `CallInst`
     void _emitCallArgList(IRCall* call, int startingOperandIndex = 1);
+    virtual void emitCallArg(IRInst* arg);
 
     String _generateUniqueName(const UnownedStringSlice& slice);
 

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -430,7 +430,6 @@ public:
 
     void emitGlobalInst(IRInst* inst);
     virtual void emitGlobalInstImpl(IRInst* inst);
-    virtual bool isPointerSyntaxRequiredImpl(IRInst* inst);
 
     void ensureInstOperand(ComputeEmitActionsContext* ctx, IRInst* inst, EmitAction::Level requiredLevel = EmitAction::Level::Definition);
 

--- a/source/slang/slang-emit-wgsl.cpp
+++ b/source/slang/slang-emit-wgsl.cpp
@@ -23,12 +23,13 @@
 // 'transpose' calls, or else perform more complicated transformations that
 // end up duplicating expressions many times.
 
-namespace Slang {
+namespace Slang
+{
 
 void WGSLSourceEmitter::emitSwitchCaseSelectorsImpl(
     IRBasicType *const switchConditionType,
-    const SwitchRegion::Case *const currentCase, const bool isDefault
-    )
+    const SwitchRegion::Case *const currentCase,
+    const bool isDefault)
 {
     // WGSL has special syntax for blocks sharing case labels:
     // "case 2, 3, 4: ...;" instead of the C-like syntax
@@ -80,8 +81,8 @@ void WGSLSourceEmitter::emitSwitchCaseSelectorsImpl(
 }
 
 void WGSLSourceEmitter::emitParameterGroupImpl(
-    IRGlobalParam* varDecl, IRUniformParameterGroupType* type
-)
+    IRGlobalParam* varDecl,
+    IRUniformParameterGroupType* type)
 {
     auto varLayout = getVarLayout(varDecl);
     SLANG_RELEASE_ASSERT(varLayout);
@@ -140,8 +141,8 @@ void WGSLSourceEmitter::emitParameterGroupImpl(
 }
 
 void WGSLSourceEmitter::emitEntryPointAttributesImpl(
-    IRFunc* irFunc, IREntryPointDecoration* entryPointDecor
-    )
+    IRFunc* irFunc,
+    IREntryPointDecoration* entryPointDecor)
 {
     auto stage = entryPointDecor->getProfile().getStage();
 
@@ -238,9 +239,7 @@ static bool isPowerOf2(const uint32_t n)
     return (n != 0U) && ((n - 1U) & n) == 0U;
 }
 
-void WGSLSourceEmitter::emitStructFieldAttributes(
-    IRStructType * structType, IRStructField * field
-    )
+void WGSLSourceEmitter::emitStructFieldAttributes(IRStructType * structType, IRStructField * field)
 {
     // Tint emits errors unless we explicitly spell out the layout in some cases, so emit
     // offset and align attribtues for all fields.
@@ -271,26 +270,6 @@ void WGSLSourceEmitter::emitStructFieldAttributes(
     m_writer->emit("@align(");
     m_writer->emit(fieldAlignment);
     m_writer->emit(")");
-}
-
-bool WGSLSourceEmitter::isPointerSyntaxRequiredImpl(IRInst* inst)
-{
-    if (inst->getOp() == kIROp_RWStructuredBufferGetElementPtr)
-        return false;
-
-    // Don't emit "->" to access fields in resource structs
-    if (inst->getOp() == kIROp_FieldAddress)
-        return false;
-
-    // Don't emit "*" to access fields in resource structs
-    if (inst->getOp() == kIROp_GlobalParam)
-        return false;
-
-    // Emit 'globalVar' instead of  "*&globalVar"
-    if (inst->getOp() == kIROp_GlobalVar)
-        return false;
-
-    return true;
 }
 
 void WGSLSourceEmitter::emit(const AddressSpace addressSpace)
@@ -647,8 +626,8 @@ void WGSLSourceEmitter::emitDeclaratorImpl(DeclaratorInfo* declarator)
 }
 
 void WGSLSourceEmitter::emitSimpleTypeAndDeclaratorImpl(
-    IRType* type, DeclaratorInfo* declarator
-    )
+    IRType* type,
+    DeclaratorInfo* declarator)
 {
     if (declarator)
     {
@@ -1094,9 +1073,7 @@ bool WGSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
     return false;
 }
 
-void WGSLSourceEmitter::emitVectorTypeNameImpl(
-    IRType* elementType, IRIntegerValue elementCount
-    )
+void WGSLSourceEmitter::emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount)
 {
 
     if (elementCount > 1)

--- a/source/slang/slang-emit-wgsl.h
+++ b/source/slang/slang-emit-wgsl.h
@@ -13,53 +13,36 @@ public:
         : CLikeSourceEmitter(desc)
     {}
 
-    virtual void emitParameterGroupImpl(
-        IRGlobalParam* varDecl, IRUniformParameterGroupType* type
-    ) SLANG_OVERRIDE;
-    virtual void emitEntryPointAttributesImpl(
-        IRFunc* irFunc, IREntryPointDecoration* entryPointDecor
-    ) SLANG_OVERRIDE;
+    virtual void emitParameterGroupImpl(IRGlobalParam* varDecl, IRUniformParameterGroupType* type) SLANG_OVERRIDE;
+    virtual void emitEntryPointAttributesImpl(IRFunc* irFunc, IREntryPointDecoration* entryPointDecor) SLANG_OVERRIDE;
     virtual void emitSimpleTypeImpl(IRType* type) SLANG_OVERRIDE;
-    virtual void emitVectorTypeNameImpl(
-        IRType* elementType, IRIntegerValue elementCount
-    ) SLANG_OVERRIDE;
+    virtual void emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount) SLANG_OVERRIDE;
     virtual void emitFuncHeaderImpl(IRFunc* func) SLANG_OVERRIDE;
     virtual void emitSimpleValueImpl(IRInst* inst) SLANG_OVERRIDE;
-    virtual bool tryEmitInstExprImpl(
-        IRInst* inst, const EmitOpInfo& inOuterPrec
-    ) SLANG_OVERRIDE;
+    virtual bool tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOuterPrec) SLANG_OVERRIDE;
     virtual bool tryEmitInstStmtImpl(IRInst* inst) SLANG_OVERRIDE;
     virtual void emitSwitchCaseSelectorsImpl(
         IRBasicType *const switchCondition,
         const SwitchRegion::Case *const currentCase,
-        const bool isDefault
-    ) SLANG_OVERRIDE;
-    virtual void emitSimpleTypeAndDeclaratorImpl(
-        IRType* type, DeclaratorInfo* declarator
-    ) SLANG_OVERRIDE;
+        const bool isDefault) SLANG_OVERRIDE;
+    virtual void emitSimpleTypeAndDeclaratorImpl(IRType* type, DeclaratorInfo* declarator) SLANG_OVERRIDE;
     virtual void emitVarKeywordImpl(IRType * type, IRInst* varDecl) SLANG_OVERRIDE;
     virtual void emitDeclaratorImpl(DeclaratorInfo* declarator) SLANG_OVERRIDE;
     virtual void emitStructDeclarationSeparatorImpl() SLANG_OVERRIDE;
     virtual void emitLayoutQualifiersImpl(IRVarLayout* layout) SLANG_OVERRIDE;
     virtual void emitSimpleFuncParamImpl(IRParam* param) SLANG_OVERRIDE;
     virtual void emitParamTypeImpl(IRType* type, const String& name) SLANG_OVERRIDE;
-    virtual bool isPointerSyntaxRequiredImpl(IRInst* inst) SLANG_OVERRIDE;
     virtual void _emitType(IRType* type, DeclaratorInfo* declarator) SLANG_OVERRIDE;
     virtual void emitFrontMatterImpl(TargetRequest* targetReq) SLANG_OVERRIDE;
-    virtual void emitStructFieldAttributes(
-        IRStructType * structType, IRStructField * field
-    ) SLANG_OVERRIDE;
+    virtual void emitStructFieldAttributes(IRStructType * structType, IRStructField * field) SLANG_OVERRIDE;
     virtual void emitGlobalParamType(IRType* type, const String& name) SLANG_OVERRIDE;
-    virtual void emitOperandImpl(
-        IRInst* inst, const EmitOpInfo& outerPrec
-    ) SLANG_OVERRIDE;
+    virtual void emitOperandImpl(IRInst* inst, const EmitOpInfo& outerPrec) SLANG_OVERRIDE;
 
     virtual void emitIntrinsicCallExprImpl(
         IRCall* inst,
         UnownedStringSlice intrinsicDefinition,
         IRInst* intrinsicInst,
-        EmitOpInfo const& inOuterPrec
-    ) SLANG_OVERRIDE;
+        EmitOpInfo const& inOuterPrec) SLANG_OVERRIDE;
 
     void emit(const AddressSpace addressSpace);
 
@@ -69,10 +52,9 @@ private:
     void emitMatrixType(
         IRType *const elementType,
         const IRIntegerValue& rowCountWGSL,
-        const IRIntegerValue& colCountWGSL
-    );
+        const IRIntegerValue& colCountWGSL);
 
-    bool m_f16ExtensionEnabled {false};
+    bool m_f16ExtensionEnabled = false;
 
 };
 

--- a/source/slang/slang-emit-wgsl.h
+++ b/source/slang/slang-emit-wgsl.h
@@ -28,6 +28,7 @@ public:
     virtual void emitSimpleTypeAndDeclaratorImpl(IRType* type, DeclaratorInfo* declarator) SLANG_OVERRIDE;
     virtual void emitVarKeywordImpl(IRType * type, IRInst* varDecl) SLANG_OVERRIDE;
     virtual void emitDeclaratorImpl(DeclaratorInfo* declarator) SLANG_OVERRIDE;
+    virtual void emitOperandImpl(IRInst* operand, EmitOpInfo const& outerPrec) SLANG_OVERRIDE;
     virtual void emitStructDeclarationSeparatorImpl() SLANG_OVERRIDE;
     virtual void emitLayoutQualifiersImpl(IRVarLayout* layout) SLANG_OVERRIDE;
     virtual void emitSimpleFuncParamImpl(IRParam* param) SLANG_OVERRIDE;
@@ -35,8 +36,7 @@ public:
     virtual void _emitType(IRType* type, DeclaratorInfo* declarator) SLANG_OVERRIDE;
     virtual void emitFrontMatterImpl(TargetRequest* targetReq) SLANG_OVERRIDE;
     virtual void emitStructFieldAttributes(IRStructType * structType, IRStructField * field) SLANG_OVERRIDE;
-    virtual void emitGlobalParamType(IRType* type, const String& name) SLANG_OVERRIDE;
-    virtual void emitOperandImpl(IRInst* inst, const EmitOpInfo& outerPrec) SLANG_OVERRIDE;
+    virtual void emitCallArg(IRInst* inst) SLANG_OVERRIDE;
 
     virtual void emitIntrinsicCallExprImpl(
         IRCall* inst,

--- a/tests/language-feature/atomic-t/atomic-0.slang
+++ b/tests/language-feature/atomic-t/atomic-0.slang
@@ -12,46 +12,32 @@ void computeMain()
     bool result = true;
     if (outputBuffer[0].add(1) != 0)
         result = false;
-    AllMemoryBarrierWithGroupSync();
     if (outputBuffer[0].sub(1) != 1)
         result = false;
-    AllMemoryBarrierWithGroupSync();
     if (outputBuffer[0].max(2) != 0)
         result = false;
-    AllMemoryBarrierWithGroupSync();
     if (outputBuffer[0].min(1) != 2)
         result = false;
-    AllMemoryBarrierWithGroupSync();
     if (outputBuffer[0].or(3) != 1)
         result = false;
-    AllMemoryBarrierWithGroupSync();
     if (outputBuffer[0].and(2) != 3)
         result = false;
-    AllMemoryBarrierWithGroupSync();
     if (outputBuffer[0].xor(3) != 2)
         result = false;
-    AllMemoryBarrierWithGroupSync();
     if (outputBuffer[0].exchange(4) != 1)
         result = false;
-    AllMemoryBarrierWithGroupSync();
     if (outputBuffer[0].compareExchange(4, 5) != 4)
     {} //result = false; // for some reason this fails on Metal Github CI, so disabling.
-    AllMemoryBarrierWithGroupSync();
     if (outputBuffer[0].load() != 5)
         result = false;
-    AllMemoryBarrierWithGroupSync();
     if (outputBuffer[0].increment() != 5)
         result = false;
-    AllMemoryBarrierWithGroupSync();
     if (outputBuffer[0].decrement() != 6)
         result = false;
-    AllMemoryBarrierWithGroupSync();
     // CHECK: 6
     outputBuffer[0].store(6);
-    AllMemoryBarrierWithGroupSync();
     if (outputBuffer[0].load() != 6)
         result = false;
-    AllMemoryBarrierWithGroupSync();
     // CHECK: 1
     if (result)
         outputBuffer[1].store(1);

--- a/tests/wgsl/inout.slang
+++ b/tests/wgsl/inout.slang
@@ -1,0 +1,24 @@
+//TEST:SIMPLE(filecheck=CHECK): -target wgsl
+
+RWStructuredBuffer<float> outputBuffer;
+
+// CHECK: fn inner{{.*}}( x{{.*}} : ptr<function, f32>)
+// CHECK: (*x{{.*}}) = (*x{{.*}}) + 1.0
+void inner(inout float x)
+{
+    x = x + 1;
+}
+
+// CHECK: fn test{{.*}}( x{{.*}} : ptr<function, f32>)
+void test(inout float x)
+{
+    inner(x);
+}
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    float x = 0.0;
+    test(x);
+    outputBuffer[0] = x;
+}

--- a/tests/wgsl/inout.slang
+++ b/tests/wgsl/inout.slang
@@ -15,10 +15,18 @@ void test(inout float x)
     inner(x);
 }
 
-[numthreads(1,1,1)]
-void computeMain()
+struct MyType
 {
-    float x = 0.0;
-    test(x);
-    outputBuffer[0] = x;
+    float myField[3];
+}
+
+[numthreads(1,1,1)]
+void computeMain(int id : SV_DispatchThreadID)
+{
+    MyType v;
+    v.myField[id] = 0.0f;
+    // CHECK: test{{.*}}(&({{.*}}));
+    test(v.myField[id]);
+    v.myField[1] = 2.0;
+    outputBuffer[0] = v.myField[id];
 }


### PR DESCRIPTION
This PR overhauls the logic of handling pointer dereference in WGSL backend.

Basically we treat WGSL as a target that doesn't support pointers, so we never emit any pointer logic for variable reference or structured buffer reference, i.e. no `*`, `&`, `->` etc. through out the emit logic like what we are doing for hlsl and glsl, except:

1. When emitting an `inout` parameter, emit it as `ptr<function, T> param`.
2. When referencing a `inout` parameter as operand, emit it as `(*param)` so the rest of logic won't need to deal with pointers.
3. When calling a function with an argument to an `inout` parameter, emit the argument as `&arg`.

Aside from call sites, we treat wgsl as a language that doesn't have pointers everywhere else. This should work exactly as WGSL expected, since pointers in WGSL is almost solely used to express mutable parameters. So we are basically treating `&` and `*` as the syntax around mutable parameters instead of something really meaningful.

The other legalization step introduced in this PR is to work around the WGSL restriction on not allowing to pass a pointer to a sub part of a composite value as argument to an inout parameter. To make such code work, we will need to introduce a temp var for the argument and pass the temp var into the function instead, and then write back the new value of the temp var to the original pointer arg after the call.