### PR TITLE
Enable emscripten builds to compile slang.dll to WebAssembly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,13 @@ add_custom_target(
     all-generators
     COMMENT "meta target which depends on all generators"
 )
+
+if(CMAKE_HOST_WIN32)
+  set(CMAKE_HOST_EXECUTABLE_SUFFIX ".exe")
+else()
+  set(CMAKE_HOST_EXECUTABLE_SUFFIX "")
+endif()
+
 set_target_properties(all-generators PROPERTIES FOLDER generators)
 function(generator dir)
     if(SLANG_GENERATORS_PATH)
@@ -267,7 +274,7 @@ function(generator dir)
             TARGET ${target}
             PROPERTY
                 IMPORTED_LOCATION
-                    "${SLANG_GENERATORS_PATH}/${target}${CMAKE_EXECUTABLE_SUFFIX}"
+                    "${SLANG_GENERATORS_PATH}/${target}${CMAKE_HOST_EXECUTABLE_SUFFIX}"
         )
     else()
         slang_add_target(

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,6 +16,16 @@
       }
     },
     {
+      "name": "emscripten",
+      "description": "Emscripten-based Wasm build",
+      "generator": "ninja",
+      "binaryDir": "${sourceDir}/build.em",
+      "cacheVariables": {
+        "SLANG_SLANG_LLVM_FLAVOR": "DISABLE",
+        "CMAKE_EXE_LINKER_FLAGS": "-sASSERTIONS -sALLOW_MEMORY_GROWTH"
+      }
+    },
+    {
       "name": "msvc-base",
       "hidden": true,
       "inherits": "default",
@@ -73,6 +83,14 @@
       "name": "release",
       "configurePreset": "default",
       "configuration": "Release"
+    },
+    {
+      "name": "emscripten",
+      "configurePreset": "emscripten",
+      "configuration": "Release",
+      "targets": [
+        "slang"
+      ]
     },
     {
       "name": "generators",

--- a/docs/building.md
+++ b/docs/building.md
@@ -47,6 +47,20 @@ cmake --build --preset release # to build from the CLI
 
 The `vs2022-dev` preset turns on features that makes debugging easy.
 
+### WebAssembly build
+
+First do a native build of the `all-generators` target, so that you get the generator executables in a path like `build\generators\Debug\bin` under the
+Slang source tree.
+
+For an [emscripten](https://emscripten.org) -based build targeting [WebAssembly](https://webassembly.org), run:
+```bash
+emcmake cmake -DSLANG_GENERATORS_PATH=%SLANG_SRC_PATH%\build\generators\Debug\bin --preset emscripten -G "Ninja"
+cmake --build --preset emscripten --target slang
+```
+
+**Note:** `emcmake` is a `cmake` wrapper that comes with [`emsdk`](https://emscripten.org/docs/getting_started/downloads.html), it will wrap your `cmake` calls with setup options that add support for emscripten.
+**Note:** If this fails, try running the command that `emcmake` outputs, directly.
+
 ## Testing
 
 ```bash

--- a/include/slang.h
+++ b/include/slang.h
@@ -111,6 +111,8 @@ Operating system defines, see http://sourceforge.net/p/predef/wiki/OperatingSyst
 #        define SLANG_PSP2 1
 #    elif defined(__ghs__)
 #        define SLANG_WIIU 1
+#    elif defined(__EMSCRIPTEN__)
+#        define SLANG_WASM 1
 #    else
 #        error "unknown target platform"
 #    endif
@@ -417,7 +419,9 @@ convention for interface methods.
 #   define SLANG_PROCESSOR_ARM 1
 #elif defined(_M_ARM64) || defined(__aarch64__)
 #   define SLANG_PROCESSOR_ARM_64 1
-#endif 
+#elif defined(__EMSCRIPTEN__)
+#   define SLANG_PROCESSOR_WASM 1
+#endif
 
 #ifndef SLANG_PROCESSOR_ARM
 #   define SLANG_PROCESSOR_ARM 0
@@ -465,6 +469,8 @@ convention for interface methods.
 #   endif
 #elif SLANG_PROCESSOR_FAMILY_POWER_PC
 #       define SLANG_BIG_ENDIAN 1
+#elif SLANG_WASM
+#       define SLANG_LITTLE_ENDIAN 1
 #endif
 
 #ifndef SLANG_LITTLE_ENDIAN

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -20,7 +20,8 @@
 #   include <shellapi.h>
 #endif
 
-#if defined(__linux__) || defined(__CYGWIN__) || SLANG_APPLE_FAMILY
+#if defined(__linux__) || defined(__CYGWIN__) || SLANG_APPLE_FAMILY || SLANG_WASM
+#   include <fcntl.h>
 #   include <unistd.h>
 // For Path::find
 #   include <fnmatch.h>
@@ -1012,6 +1013,7 @@ namespace Slang
         }
         return SLANG_FAIL;
 #else
+        SLANG_UNUSED(outPath);
         return SLANG_E_NOT_IMPLEMENTED;
 #endif
     }

--- a/source/slang/slang-ast-dump.cpp
+++ b/source/slang/slang-ast-dump.cpp
@@ -304,9 +304,9 @@ struct ASTDumpContext
 
     void dump(uint32_t v)
     {
-        m_writer->emit(UInt(v));
+        m_writer->emit((uint64_t)v);
     }
-    void dump(UInt v)
+    void dump(uint64_t v)
     {
         m_writer->emit(v);
     }

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -3748,7 +3748,7 @@ static void _appendRange(Index start, LayoutSize size, StringBuilder& ioBuf)
         ioBuf << "[ " << start << " ... ";
         if (size.isFinite())
         {
-            ioBuf << start + size.getFiniteValue() << ")";
+            ioBuf << start + (Index)size.getFiniteValue() << ")";
         }
         else
         {

--- a/source/slang/slang-workspace-version.cpp
+++ b/source/slang/slang-workspace-version.cpp
@@ -457,7 +457,7 @@ ArrayView<Index> DocumentVersion::getUTF8Boundaries(Index line)
 }
 
 void DocumentVersion::oneBasedUTF8LocToZeroBasedUTF16Loc(
-    Index inLine, Index inCol, Index& outLine, Index& outCol)
+    Index inLine, Index inCol, int64_t& outLine, int64_t& outCol)
 {
     if (inLine <= 0)
     {
@@ -472,12 +472,12 @@ void DocumentVersion::oneBasedUTF8LocToZeroBasedUTF16Loc(
 }
 
 void DocumentVersion::oneBasedUTF8LocToZeroBasedUTF16Loc(
-    Index inLine, Index inCol, int& outLine, int& outCol)
+    Index inLine, Index inCol, int32_t& outLine, int32_t& outCol)
 {
-    Index ioutLine, ioutCol;
+    int64_t ioutLine, ioutCol;
     oneBasedUTF8LocToZeroBasedUTF16Loc(inLine, inCol, ioutLine, ioutCol);
-    outLine = (int)ioutLine;
-    outCol = (int)ioutCol;
+    outLine = (int32_t)ioutLine;
+    outCol = (int32_t)ioutCol;
 }
 
 void DocumentVersion::zeroBasedUTF16LocToOneBasedUTF8Loc(

--- a/source/slang/slang-workspace-version.h
+++ b/source/slang/slang-workspace-version.h
@@ -38,9 +38,9 @@ namespace Slang
         ArrayView<Index> getUTF8Boundaries(Index line);
 
         void oneBasedUTF8LocToZeroBasedUTF16Loc(
-            Index inLine, Index inCol, Index& outLine, Index& outCol);
+            Index inLine, Index inCol, int64_t& outLine, int64_t& outCol);
         void oneBasedUTF8LocToZeroBasedUTF16Loc(
-            Index inLine, Index inCol, int& outLine, int& outCol);
+            Index inLine, Index inCol, int32_t& outLine, int32_t& outCol);
         void zeroBasedUTF16LocToOneBasedUTF8Loc(
             Index inLine, Index inCol, Index& outLine, Index& outCol);
 


### PR DESCRIPTION
Add support for Wasm build target