### PR TITLE
Add CI step to build WebAssembly version of Slang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,15 @@ jobs:
         os: [linux, macos, windows]
         config: [debug, release]
         compiler: [gcc, clang, cl]
-        platform: [x86_64, aarch64]
+        platform: [x86_64, aarch64, wasm]
         exclude:
           # Default to x64, but aarch64 on osx
           - { os: linux, platform: aarch64 }
           - { os: windows, platform: aarch64 }
           - { os: macos, platform: x86_64 }
+          - { os: linux, config: debug, platform: wasm }
+          - { os: windows, platform: wasm }
+          - { os: macos, platform: wasm }
           # Unused compiler configs
           - { os: linux, compiler: clang }
           - { os: linux, compiler: cl }
@@ -96,26 +99,44 @@ jobs:
           build-llvm: true
       - name: Build Slang
         run: |
-          if [[ "${{ matrix.os }}" =~ "windows" && "${{ matrix.config }}" != "release" ]]; then
-            # Doing a debug build will try to link against a release built llvm, this
-            # is a problem on Windows, so make slang-llvm in release build and use
-            # that as though it's a fetched binary via these presets.
-            cmake --workflow --preset slang-llvm
-            # Configure, pointing to our just-generated slang-llvm archive
-            cmake --preset default --fresh \
-              -DSLANG_SLANG_LLVM_FLAVOR=FETCH_BINARY \
-              "-DSLANG_SLANG_LLVM_BINARY_URL=$(pwd)/build/dist-release/slang-llvm.zip" \
-              "-DCMAKE_COMPILE_WARNING_AS_ERROR=${{matrix.warnings-as-errors}}"
-            cmake --workflow --preset "${{matrix.config}}"
+          if [[ "${{ matrix.platform }}" = "wasm" ]]; then
+              git clone https://github.com/emscripten-core/emsdk.git
+              pushd emsdk
+                ./emsdk install latest
+                ./emsdk activate latest
+                source ./emsdk_env.sh
+              popd
+              cmake --workflow --preset generators --fresh
+              mkdir generators
+              cmake --install build --prefix generators --component generators
+              emcmake cmake -DSLANG_GENERATORS_PATH=generators/bin --preset emscripten -G "Ninja"
+              cmake --build --preset emscripten --target slang
+              [ -f "build.em/Release/lib/libslang.a" ]
+              [ -f "build.em/Release/lib/libcompiler-core.a" ]
+              [ -f "build.em/Release/lib/libcore.a" ]
           else
-            # Otherwise, use the system llvm we have just build or got from the
-            # cache in the setup phase
-            cmake --preset default --fresh \
-              -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
-              -DCMAKE_COMPILE_WARNING_AS_ERROR=${{matrix.warnings-as-errors}}
-            cmake --workflow --preset "${{matrix.config}}"
+            if [[ "${{ matrix.os }}" =~ "windows" && "${{ matrix.config }}" != "release" ]]; then
+              # Doing a debug build will try to link against a release built llvm, this
+              # is a problem on Windows, so make slang-llvm in release build and use
+              # that as though it's a fetched binary via these presets.
+              cmake --workflow --preset slang-llvm
+              # Configure, pointing to our just-generated slang-llvm archive
+              cmake --preset default --fresh \
+                -DSLANG_SLANG_LLVM_FLAVOR=FETCH_BINARY \
+                "-DSLANG_SLANG_LLVM_BINARY_URL=$(pwd)/build/dist-release/slang-llvm.zip" \
+                "-DCMAKE_COMPILE_WARNING_AS_ERROR=${{matrix.warnings-as-errors}}"
+              cmake --workflow --preset "${{matrix.config}}"
+            else
+              # Otherwise, use the system llvm we have just build or got from the
+              # cache in the setup phase
+              cmake --preset default --fresh \
+                -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
+                -DCMAKE_COMPILE_WARNING_AS_ERROR=${{matrix.warnings-as-errors}}
+              cmake --workflow --preset "${{matrix.config}}"
+            fi
           fi
       - name: Test Slang
+        if: ${{ matrix.platform != 'wasm' }}
         run: |
           export SLANG_RUN_SPIRV_VALIDATION=1
           export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1
@@ -140,7 +161,7 @@ jobs:
               -expected-failure-list tests/expected-failure-record-replay-tests.txt
           fi
       - name: Test Slang via glsl
-        if: ${{matrix.full-gpu-tests}}
+        if: ${{ matrix.full-gpu-tests && matrix.platform != 'wasm' }}
         run: |
           export SLANG_RUN_SPIRV_VALIDATION=1
           export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1

--- a/docs/building.md
+++ b/docs/building.md
@@ -49,17 +49,37 @@ The `vs2022-dev` preset turns on features that makes debugging easy.
 
 ### WebAssembly build
 
-First do a native build of the `all-generators` target, so that you get the generator executables in a path like `build\generators\Debug\bin` under the
-Slang source tree.
+In order to build WebAssembly build of Slang, Slang needs to be compiled with [Emscripten SDK](https://github.com/emscripten-core/emsdk).
+You can find more information about [Emscripten](https://emscripten.org/).
 
-For an [emscripten](https://emscripten.org) -based build targeting [WebAssembly](https://webassembly.org), run:
+You need to clone the EMSDK repo. And you need to install and activate the latest.
 ```bash
-emcmake cmake -DSLANG_GENERATORS_PATH=%SLANG_SRC_PATH%\build\generators\Debug\bin --preset emscripten -G "Ninja"
+git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk
+./emsdk install latest  # For Windows, emsdk.bat install latest
+./emsdk activate latest # For Windows, emsdk.bat activate latest
+```
+
+After EMSDK is activated, Slang needs to be built in three steps: build "generators", configure the build with "emcmake" and build.
+For more information about "generators", please refer to the later part of the documentation about [cross-compiling](docs/building.md#cross-compiling).
+```bash
+# Build generators.
+cmake --workflow --preset generators --fresh
+mkdir generators
+cmake --install build --prefix generators --component generators
+
+# Configure the build with emcmake.
+# emcmake is available only when emsdk_env setup the environment correctly.
+pushd ../emsdk
+source ./emsdk_env # For Windows, emsdk_env.bat
+popd
+emcmake cmake -DSLANG_GENERATORS_PATH=generators/bin --preset emscripten -G "Ninja"
+
+# Build build.em/Release/bin/libslang.a
 cmake --build --preset emscripten --target slang
 ```
 
-**Note:** `emcmake` is a `cmake` wrapper that comes with [`emsdk`](https://emscripten.org/docs/getting_started/downloads.html), it will wrap your `cmake` calls with setup options that add support for emscripten.
-**Note:** If this fails, try running the command that `emcmake` outputs, directly.
+**Note:** If the last build step fails, try running the command that `emcmake` outputs, directly.
 
 ## Testing
 


### PR DESCRIPTION
Closes #5117

This adds a build step of WebAssembly version of Slang for all platforms and all configurations.
The new build step appears to take about double times of time compared to the regular Slang build step.