### PR TITLE
Enable debug log for VK CTS workflow

### DIFF
--- a/.github/workflows/vk-gl-cts-nightly.yml
+++ b/.github/workflows/vk-gl-cts-nightly.yml
@@ -8,6 +8,8 @@ concurrency:
   cancel-in-progress: true
 env:
   DISABLE_CTS_SLANG: 0
+  ACTIONS_RUNNER_DEBUG: true
+  ACTIONS_STEP_DEBUG: true
 jobs:
   build:
     strategy:
@@ -80,6 +82,12 @@ jobs:
       working-directory: ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.3-win64\VK-GL-CTS_WithSlang-0.0.3-win64
       run: |
         .\deqp-vk.exe --deqp-archive-dir=${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.3-win64\VK-GL-CTS_WithSlang-0.0.3-win64 --deqp-caselist-file=${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.3-win64\VK-GL-CTS_WithSlang-0.0.3-win64\slang-passing-tests.txt --deqp-waiver-file=${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.3-win64\VK-GL-CTS_WithSlang-0.0.3-win64\slang-waiver-tests.xml
+
+    - name: Dump TestResults.qpa if failed
+      shell: pwsh
+      if: ${{ !success() }}
+      working-directory: ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.3-win64\VK-GL-CTS_WithSlang-0.0.3-win64
+      run: Get-Content TestResults.qpa -Tail 1000
     - name: success notification
       id: slack-notify-success
       if: ${{ success() }}


### PR DESCRIPTION
Closes #5161

This commit enables the workflow debug message for running VK CTS workflow.

Currently three CTS tests are causing a crash of deqp with an exit code 1. And when the debug message printing is enabled, this crash is no longer happening, which is unexpected. It seems like the issue is on the CI runner process rather than Slang, driver nor deqp.

We will keep the log message enabled not only to avoid the crash but also to see more information when things went wrong.

This commit also prints the last 1,000 lines of TestResults.qpa when deqp had a failing test or deqp was exited unexpectedly. This will help us to debug the problem faster.