### PR TITLE
DO NOT REVIEW: CTS CI test only

### DIFF
--- a/.github/workflows/vk-gl-cts-nightly.yml
+++ b/.github/workflows/vk-gl-cts-nightly.yml
@@ -1,8 +1,8 @@
 name: VK-GL-CTS Nightly
 
 on:
-  schedule:
-    - cron: '00 07 * * *'
+  pull_request:
+    branches: [master]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Manually trigger VK-CTS on pull request

This is to double check if CTS is still failing as is.
The nightly failed again last night so I am sure it still fails.
But I like to double check it.