### PR TITLE
Checkout LLVM as a workflow action rather than git-clone command

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -66,23 +66,59 @@ runs:
         echo "bin_dir=$bin_dir" >> "$GITHUB_ENV"
         echo "lib_dir=$lib_dir" >> "$GITHUB_ENV"
 
-    # Try to restore a LLVM install, and build it otherwise
-    - uses: actions/cache/restore@v4
+    # Try to restore a LLVM build cache, and build it otherwise
+    - name: "Restore cache (attempt: 1/2)"
+      uses: actions/cache/restore@v4
       id: cache-llvm
       if: inputs.build-llvm == 'true'
       with:
         path: ${{ github.workspace }}/build/llvm-project-install
         # Use os*compiler*platform in lieu of an ABI key here, which is what we really want
         key: llvm-${{ inputs.os }}-${{ inputs.compiler }}-${{ inputs.platform }}-${{ hashFiles('external/build-llvm.sh') }}
-    - name: Build LLVM
+
+    # Checkout while waiting for the second try of restoring the cache
+    - name: Checkout LLVM project if restore cache failed
+      uses: actions/checkout@v4
+      id: checkout-llvm
       if: inputs.build-llvm == 'true' && steps.cache-llvm.outputs.cache-hit != 'true'
-      shell: bash
-      run: ./external/build-llvm.sh --install-prefix "${{ github.workspace }}/build/llvm-project-install"
-    - uses: actions/cache/save@v4
+      with:
+        #repository: llvm/llvm-project
+        repository: shader-slang/llvm-project
+        ref: llvmorg-13.0.1
+        path: build/llvm-source
+        fetch-depth: '1'
+        fetch-tags: true
+
+    # Once the cache server is busy, it usually becomes busy for awhile.
+    # The second attempt here is more likely to fail again.
+    # But the overhead of retry is very low, and let's try after spending some time checking out LLVM repo.
+    - name: "Restore cache (attempt: 2/2)"
+      uses: actions/cache/restore@v4
+      id: cache-llvm-2
       if: inputs.build-llvm == 'true' && steps.cache-llvm.outputs.cache-hit != 'true'
       with:
         path: ${{ github.workspace }}/build/llvm-project-install
         key: ${{ steps.cache-llvm.outputs.cache-primary-key }}
+
+    # Build LLVM only if all attempts of the restoring the cache failed.
+    - name: Build LLVM
+      id: build-llvm
+      if: steps.checkout-llvm.outcome == 'success' && steps.cache-llvm-2.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        ./external/build-llvm.sh \
+          --install-prefix "${{ github.workspace }}/build/llvm-project-install" \
+          --repo "${{github.workspace}}/build/llvm-source" \
+          --branch llvmorg-13.0.1
+
+    # Save LLVM cache if the building step was successful
+    - name: Save LLVM cache
+      uses: actions/cache/save@v4
+      if: steps.build-llvm.outcome == 'success'
+      with:
+        path: ${{ github.workspace }}/build/llvm-project-install
+        key: ${{ steps.cache-llvm.outputs.cache-primary-key }}
+
 
     # Run this after building llvm, it's pointless to fill the caches with
     # infrequent llvm build products


### PR DESCRIPTION
Closes https://github.com/shader-slang/slang/issues/5201

Currently ci.yml builds slang-llvm all the time for all platforms.
Because it takes too long, we store the output files in the cache.
If the cache server is too busy, slang-llvm will be rebuilt, which will take awhile, but it will eventually work out.

The problem is that git-clone was failing for cloning the LLMV repo.
This is a less expected result, because cloning a git repository normally don't fail.
We think that when the git-clone command is manually executed, there might be limit on the network connection based on IP or some sort.
We expect that this problem will be resolved if we use actions/checkout in the workflow.

Also this commit uses a forked repo of llvm under shader-slang
organization to avoid network traffic on the original llvm repo.