### PR TITLE
SizeOfLikeExpr has type int

### DIFF
--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -3393,6 +3393,7 @@ namespace Slang
     Expr* SemanticsExprVisitor::visitSizeOfLikeExpr(SizeOfLikeExpr* sizeOfLikeExpr)
     {
         auto valueExpr = dispatch(sizeOfLikeExpr->value);
+        sizeOfLikeExpr->type = m_astBuilder->getIntType();
         
         Type* type = nullptr;
 

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -1781,7 +1781,7 @@ namespace Slang
             if (expr->typeExpr)
                 expr->typeExpr->accept(this, nullptr);
         }
-        void visiSizeOfLikeExpr(SizeOfLikeExpr* expr)
+        void visitSizeOfLikeExpr(SizeOfLikeExpr* expr)
         {
             if (expr->value)
                 expr->value->accept(this, nullptr);


### PR DESCRIPTION
As to why this ever worked in non-stdlib code, I still don't know

Fixes https://github.com/shader-slang/slang/issues/5191