### PR TITLE
SP004: implement initialize list translation to ctor

### DIFF
--- a/docs/proposals/004-initialization.md
+++ b/docs/proposals/004-initialization.md
@@ -201,6 +201,7 @@ If the above code passes type check, then it will be used as the way to initiali
 If the above code does not pass type check, and if there is only one constructor for`MyType` that is synthesized as described in the previous section (and therefore marked as `[Synthesized]`, Slang continues to check if `S` meets the standard of a "legacy C-style struct` type.
 A type is a "legacy C-Style struct" if all of the following conditions are met:
 - It is a user-defined struct type or a basic scalar, vector or matrix type, e.g. `int`, `float4x4`.
+- It does not inherit from any other types.
 - It does not contain any explicit constructors defined by the user.
 - All its members have the same visibility as the type itself.
 - All its members are legacy C-Style structs or arrays of legacy C-style structs.

--- a/docs/proposals/004-initialization.md
+++ b/docs/proposals/004-initialization.md
@@ -129,6 +129,39 @@ MyType x = MyType(y); // equivalent to `x = y`.
 
 The compiler will attempt to resolve all type casts using type coercion rules, if that failed, will fall back to resolve it as a constructor call.
 
+### Inheritance Initialization
+For derived struct, slang will synthesized the constructor by bring the parameters from the base struct's constructor if the base struct also has a synthesized constructor. For example:
+```csharp
+struct Base
+{
+  int x;
+  // compiler synthesizes:
+  // __init(int x) { ... }
+}
+struct Derived : Base
+{
+  int y;
+  // compiler synthesizes:
+  // __init(int x, int y) { ... }
+}
+```
+
+However, if the base struct has explicit ctors, the compiler will not synthesize a constructor for the derived struct.
+For example, given
+```csharp
+struct Base { int x; __init(int x) { this.x = x; } }
+struct Derived : Base { int y;}
+```
+The compiler will not synthesize a constructor for `Derived`, and the following code will fail to compile:
+```csharp
+
+Derived d = {1};            // error, no matching ctor.
+Derived d = {1, 2};         // error, no matching ctor.
+Derived d = Derived(1);     // error, no matching ctor.
+Derived d = Derived(1, 2);  // error, no matching ctor.
+```
+
+
 ### Initialization List
 
 Slang allows initialization of a variable by assigning it with an initialization list. 
@@ -371,6 +404,25 @@ internal void test9()
   Visibility4 t = {0, 0}; // OK, initialized to {0,0} via ctor call.
   Visibility4 t1 = {3}; // OK, initialized to {3,2} via ctor call.
   Visibility4 t2 = {}; // OK, initialized to {1,2} via ctor call.
+}
+
+struct Base
+{
+  int x;
+  int y;
+  // compiler synthesizes:
+  // internal __init(int x, int y);
+}
+struct Derived : Base
+{
+  int z;
+  // compiler synthesizes:
+  // internal __init(int x, int y, int z);
+}
+
+void test10()
+{
+  Derived t = {1, 2, 3}; // OK, initialized to {1, 2, 3} via ctor call.
 }
 ```
 

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -372,9 +372,20 @@ class ConstructorDecl : public FunctionDeclBase
 {
     SLANG_AST_CLASS(ConstructorDecl)
 
-    // Indicates whether the declaration was synthesized by
-    // slang and not actually provided by the user
-    bool isSynthesized = false;
+    enum class ConstructorTags : int
+    {
+        None = 0x00,
+        // Indicates whether the declaration was synthesized by
+        // Slang and not actually provided by the user
+        Synthesized = 0x01,
+        // Member initialize constructor is definitely a synthesized ctor,
+        // but it takes parameters.
+        MemberInitCtor = 0x03
+    };
+
+    int m_tags = (int)ConstructorTags::None;
+    void addTag(ConstructorTags tag) { m_tags = (int)tag; }
+    bool containsTag(ConstructorTags tag) { return m_tags & (int)tag; }
 };
 
 // A subscript operation used to index instances of a type

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -165,6 +165,11 @@ class AggTypeDecl : public  AggTypeDeclBase
 class StructDecl: public AggTypeDecl
 {
     SLANG_AST_CLASS(StructDecl);
+
+SLANG_UNREFLECTED
+    // We will use these auxiliary to help in synthesizing the member initialize constructor.
+    Slang::HashSet<VarDeclBase*>            m_membersVisibleInCtor;
+    Dictionary<int, ConstructorDecl*>       m_synthesizedCtorMap;
 };
 
 class ClassDecl : public AggTypeDecl
@@ -380,11 +385,11 @@ class ConstructorDecl : public FunctionDeclBase
         Synthesized = 0x01,
         // Member initialize constructor is definitely a synthesized ctor,
         // but it takes parameters.
-        MemberInitCtor = 0x03
+        MemberInitCtor = 0x02
     };
 
     int m_tags = (int)ConstructorTags::None;
-    void addTag(ConstructorTags tag) { m_tags = (int)tag; }
+    void addTag(ConstructorTags tag) { m_tags |= (int)tag; }
     bool containsTag(ConstructorTags tag) { return m_tags & (int)tag; }
 };
 

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -170,6 +170,7 @@ SLANG_UNREFLECTED
     // We will use these auxiliary to help in synthesizing the member initialize constructor.
     Slang::HashSet<VarDeclBase*>            m_membersVisibleInCtor;
     Dictionary<int, ConstructorDecl*>       m_synthesizedCtorMap;
+    bool                                    m_hasExplicitCtorInExtension = false;
 };
 
 class ClassDecl : public AggTypeDecl

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -201,21 +201,6 @@ namespace Slang
         return baseStructDeclRef;
     }
 
-    bool SemanticsVisitor::_hasExplicitConstructor(StructDecl* structDecl)
-    {
-        bool result = false;
-        for (auto ctor : getMembersOfType<ConstructorDecl>(getASTBuilder(), structDecl, MemberFilterStyle::All))
-        {
-            // constructor that is not synthesized must be user defined.
-            if (ctor.getDecl()->findModifier<SynthesizedModifier>() == nullptr)
-            {
-                result = true;
-                break;
-            }
-        }
-        return result;
-    }
-
     // TODO: We might need to find a good way to get the synthesized constructor instead of traversing all of constructors.
     ConstructorDecl* SemanticsVisitor::_getSynthesizedConstructor(StructDecl* structDecl)
     {
@@ -230,6 +215,114 @@ namespace Slang
         return nullptr;
     }
 
+    static StructDecl* _getStructDecl(Type* type)
+    {
+        if( as<VectorExpressionType>(type) ||
+            as<MatrixExpressionType>(type) ||
+            as<ArithmeticExpressionType>(type) ||
+            as<BuiltinType>(type))
+        {
+            return nullptr;
+        }
+
+        if(auto declRefType = as<DeclRefType>(type))
+        {
+            auto structDecl = as<StructDecl>(declRefType->getDeclRef());
+            return structDecl.getDecl();
+        }
+
+        return nullptr;
+    }
+
+    bool SemanticsVisitor::_cStyleStructBasicCheck(Decl* decl)
+    {
+        // 1. It has to be a user-defined struct type, or a basic scalar, vector or matrix type
+        if (isFromStdLib(decl))
+            return false;
+
+        if (auto varDecl = as<VarDecl>(decl))
+        {
+            auto type = varDecl->getType();
+            if( as<VectorExpressionType>(type) ||
+                as<MatrixExpressionType>(type) ||
+                as<BasicExpressionType>(type))
+                return true;
+            else
+                return false;
+        }
+
+        auto structDecl = as<StructDecl>(decl);
+        if (!structDecl)
+            return false;
+
+        // 2. It cannot have inheritance
+        if (structDecl->getMembersOfType<InheritanceDecl>().getCount() > 0)
+            return false;
+
+        // 3. It cannot have explicit constructor
+        if (_hasExplicitConstructor(structDecl))
+            return false;
+
+        // 4. All of its members have to have the same visibility as the struct itself.
+        DeclVisibility structVisibility = getDeclVisibility(structDecl);
+        for (auto varDeclRef : getMembersOfType<VarDeclBase>(getASTBuilder(), structDecl, MemberFilterStyle::Instance))
+        {
+            auto varDecl = varDeclRef.getDecl();
+            if (getDeclVisibility(varDecl) != structVisibility)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // TODO: We need to cache the result of this check, though it's not a heavy call.
+    bool SemanticsVisitor::isCStyleStruct(StructDecl* structDecl)
+    {
+        // rules 1-4 are checked in _cStyleStructBasicCheck for all the non-array members
+        if(!_cStyleStructBasicCheck(structDecl))
+            return false;
+
+        // 5. All its members are legacy C-Style structs or arrays of legacy C-style structs
+        for (auto varDeclRef : getMembersOfType<VarDeclBase>(getASTBuilder(), structDecl, MemberFilterStyle::Instance))
+        {
+            auto varDecl = varDeclRef.getDecl();
+
+            // if the member is an array, check if the element is legacy C-style rule.
+            if (auto arrayType = as<ArrayExpressionType>(varDecl->getType()))
+            {
+                auto* elementType = arrayType->getElementType();
+                ArrayExpressionType* nextType = nullptr;
+                while(nextType = as<ArrayExpressionType>(elementType))
+                {
+                    elementType = nextType->getElementType();
+                }
+                if(auto structDecl = _getStructDecl(elementType))
+                {
+                    if (!_cStyleStructBasicCheck(structDecl))
+                        return false;
+                }
+                else
+                {
+                    // if the element is not a struct, it has to be a scalar, vector or matrix.
+                    if( !as<VectorExpressionType>(elementType) &&
+                        !as<MatrixExpressionType>(elementType) &&
+                        !as<BasicExpressionType>(elementType))
+                    {
+                        return false;
+                    }
+                }
+            }
+            else
+            {
+                // all the other members still go through the basic check.
+                if (!_cStyleStructBasicCheck(varDecl))
+                    return false;
+            }
+        }
+        return true;
+    }
+
     Expr* SemanticsVisitor::_prepareCtorInvokeExpr(Type* toType, const SourceLoc& loc, const List<Expr*>& coercedArgs)
     {
         auto* varExpr = getASTBuilder()->create<VarExpr>();
@@ -240,9 +333,7 @@ namespace Slang
         constructorExpr->functionExpr = varExpr;
         constructorExpr->arguments.addRange(coercedArgs);
         constructorExpr->loc = loc;
-        auto resolvedConstructorExpr = CheckExpr(constructorExpr);
-
-        return resolvedConstructorExpr;
+        return constructorExpr;
     }
 
     // translation from initializer list to constructor invocation if the struct has constructor.
@@ -262,6 +353,7 @@ namespace Slang
                 if (_hasExplicitConstructor(toStructDeclRef.getDecl()))
                 {
                     auto ctorInvokeExpr = _prepareCtorInvokeExpr(toType, fromInitializerListExpr->loc, fromInitializerListExpr->args);
+                    ctorInvokeExpr = CheckTerm(ctorInvokeExpr);
                     if (outExpr && ctorInvokeExpr)
                     {
                         *outExpr = ctorInvokeExpr;
@@ -289,19 +381,25 @@ namespace Slang
         }
 
         if (!structDecl || isFromStdLib(structDecl))
-            return true;
+            return false;
 
+        bool isCStyle = isCStyleStruct(structDecl);
         auto synthesizedConstructor = _getSynthesizedConstructor(structDecl);
         SLANG_ASSERT(synthesizedConstructor);
 
         List<Expr*> coercedArgs;
         auto ctorInvokeExpr = _prepareCtorInvokeExpr(toType, fromInitializerListExpr->loc, fromInitializerListExpr->args);
+
+        DiagnosticSink tempSink(getSourceManager(), nullptr);
+        SemanticsVisitor subVisitor(withSink(&tempSink));
+        ctorInvokeExpr = subVisitor.CheckExpr(ctorInvokeExpr);
+
         if (ctorInvokeExpr)
         {
             // The reason we need to check the coercion again is that the ResolveInvoke() could still find us
             // the wrong constructor when there is inheritance. e.g.:
-            // struct A { int a; };// __init(int a) will be synthesized.
-            // struct B : A { int b; };// __init(int a, int b) will be synthesized.
+            // struct A { int a; };     // __init(int a) will be synthesized.
+            // struct B : A { int b; }; // __init(int a, int b) will be synthesized.
             // B b = {1};   // This should report an error, but the ResolveInvoke() will find the A.__init(int a).
             //
             // This will not happen when both A and B have explicit constructors, because 'coerce()' will be called after 'ResolveInvoke()'.
@@ -310,18 +408,32 @@ namespace Slang
             //
             // TODO: should we improve the ResolveInvoke() to handle this case? Because A.__init(int a) should not be found at first place,
             // Base class cannot construct a Derived class.
-            if (!canCoerce(toType, ctorInvokeExpr->type, ctorInvokeExpr, nullptr))
+            if (!tempSink.getErrorCount())
             {
-                // TODO:
-                // 1. Create a more explainable error message.
-                // 2. We should not diagnose here, because we will need a fall back mechanism.
-                return false;
+                if (!canCoerce(toType, ctorInvokeExpr->type, ctorInvokeExpr, nullptr))
+                {
+                    // TODO:
+                    // 1. Create a more explainable error message.
+                    // 2. We should not diagnose here, because we will need a fall back mechanism.
+                    tempSink.diagnose(fromInitializerListExpr->loc, Diagnostics::typeMismatch, toType, ctorInvokeExpr->type);
+                    return false;
+                }
+                else
+                {
+                    if (outExpr)
+                        *outExpr = ctorInvokeExpr;
+                    return true;
+                }
             }
             else
             {
-                if (outExpr)
-                    *outExpr = ctorInvokeExpr;
-                return true;
+                if (isCStyle)
+                {
+                    return false;
+                }
+                Slang::ComPtr<ISlangBlob> blob;
+                tempSink.getBlobIfNeeded(blob.writeRef());
+                getSink()->diagnoseRaw(Severity::Error, static_cast<char const*>(blob->getBufferPointer()));
             }
         }
         return false;
@@ -680,13 +792,9 @@ namespace Slang
         }
 
         // try to invoke the synthesized constructor if it exists
-        if (!_invokeExprForSynthesizedCtor(toType, fromInitializerListExpr, outToExpr))
+        if (_invokeExprForSynthesizedCtor(toType, fromInitializerListExpr, outToExpr))
         {
-            // TODO: check if it's C-style initializer list
-            // if it's not, return error.
-            // if it is, return, fall-back to legacy logic
-            getSink()->diagnoseRaw(Severity::Error, "Synthesized Constructor is not found\n");
-            return false;
+            return true;
         }
 
         // We will fall back to the legacy logic of initialize list.

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -103,8 +103,7 @@ namespace Slang
         Type*                toType,
         Expr**               outToExpr,
         InitializerListExpr* fromInitializerListExpr,
-        UInt                 &ioInitArgIndex,
-        bool                 useLegacyMode)
+        UInt                 &ioInitArgIndex)
     {
         // First, we will check if we have run out of arguments
         // on the initializer list.
@@ -161,8 +160,7 @@ namespace Slang
             toType,
             outToExpr,
             fromInitializerListExpr,
-            ioInitArgIndex,
-            useLegacyMode);
+            ioInitArgIndex);
     }
 
     DeclRefType* findBaseStructType(ASTBuilder* astBuilder, DeclRef<StructDecl> structTypeDeclRef)
@@ -277,36 +275,27 @@ namespace Slang
 
     bool SemanticsVisitor::_invokeExprForSynthesizedCtor(
         Type*                   toType,
-        StructDecl*             structDecl,
         InitializerListExpr*    fromInitializerListExpr,
-        UInt                    &ioArgIndex,
         Expr**                  outExpr)
     {
+        StructDecl* structDecl = nullptr;
+        if(auto toDeclRefType = as<DeclRefType>(toType))
+        {
+            auto toTypeDeclRef = toDeclRefType->getDeclRef();
+            if(auto toStructDeclRef = toTypeDeclRef.as<StructDecl>())
+            {
+                structDecl = toStructDeclRef.getDecl();
+            }
+        }
+
+        if (!structDecl || isFromStdLib(structDecl))
+            return true;
+
         auto synthesizedConstructor = _getSynthesizedConstructor(structDecl);
         SLANG_ASSERT(synthesizedConstructor);
 
         List<Expr*> coercedArgs;
-
-        for(auto param : getParameters(getASTBuilder(), synthesizedConstructor))
-        {
-            Expr* coercedArg = nullptr;
-            bool argResult = _readValueFromInitializerList(
-                getType(m_astBuilder, param),
-                &coercedArg,
-                fromInitializerListExpr,
-                ioArgIndex);
-
-            // No point in trying further if any argument fails
-            if(!argResult)
-                return false;
-
-            if( coercedArg )
-            {
-                coercedArgs.add(coercedArg);
-            }
-        }
-
-        auto ctorInvokeExpr = _prepareCtorInvokeExpr(toType, fromInitializerListExpr->loc, coercedArgs);
+        auto ctorInvokeExpr = _prepareCtorInvokeExpr(toType, fromInitializerListExpr->loc, fromInitializerListExpr->args);
         if (ctorInvokeExpr)
         {
             // The reason we need to check the coercion again is that the ResolveInvoke() could still find us
@@ -326,7 +315,6 @@ namespace Slang
                 // TODO:
                 // 1. Create a more explainable error message.
                 // 2. We should not diagnose here, because we will need a fall back mechanism.
-                getSink()->diagnose(fromInitializerListExpr->loc, Diagnostics::typeMismatch, toType, ctorInvokeExpr->type);
                 return false;
             }
             else
@@ -343,8 +331,7 @@ namespace Slang
         Type*                inToType,
         Expr**               outToExpr,
         InitializerListExpr* fromInitializerListExpr,
-        UInt                 &ioArgIndex,
-        bool                 useLegacyMode)
+        UInt                 &ioArgIndex)
     {
         auto toType = inToType;
         UInt argCount = fromInitializerListExpr->args.getCount();
@@ -565,62 +552,50 @@ namespace Slang
             auto toTypeDeclRef = toDeclRefType->getDeclRef();
             if(auto toStructDeclRef = toTypeDeclRef.as<StructDecl>())
             {
-                // TODO: create a function '_createCtorInvokeExpr()'
-                // We must have a synthesized constructor here there are only two cases that we don't synthesized constructor:
-                // 1. It is a stdlib struct.
-                // 2. It is a struct that has user defined constructor. (In this case, we should have already handled it in _coerceInitializerList)
-                if (!isFromStdLib(toStructDeclRef.getDecl()) && !useLegacyMode)
+                // Trying to initialize a `struct` type given an initializer list.
+                //
+                // Before we iterate over the fields, we want to check if this struct
+                // inherits from another `struct` type. If so, we want to read
+                // an initializer for that base type first.
+                //
+                if (auto baseStructType = findBaseStructType(m_astBuilder, toStructDeclRef))
                 {
-                    return _invokeExprForSynthesizedCtor(inToType, toStructDeclRef.getDecl(), fromInitializerListExpr, ioArgIndex, outToExpr);
-                }
-                else
-                {
-                    // Trying to initialize a `struct` type given an initializer list.
-                    //
-                    // Before we iterate over the fields, we want to check if this struct
-                    // inherits from another `struct` type. If so, we want to read
-                    // an initializer for that base type first.
-                    //
-                    if (auto baseStructType = findBaseStructType(m_astBuilder, toStructDeclRef))
+                    Expr* coercedArg = nullptr;
+                    bool argResult = _readValueFromInitializerList(
+                        baseStructType,
+                        outToExpr ? &coercedArg : nullptr,
+                        fromInitializerListExpr,
+                        ioArgIndex);
+
+                    // No point in trying further if any argument fails
+                    if (!argResult)
+                        return false;
+
+                    if (coercedArg)
                     {
-                        Expr* coercedArg = nullptr;
-                        bool argResult = _readValueFromInitializerList(
-                            baseStructType,
-                            outToExpr ? &coercedArg : nullptr,
-                            fromInitializerListExpr,
-                            ioArgIndex);
-
-                        // No point in trying further if any argument fails
-                        if (!argResult)
-                            return false;
-
-                        if (coercedArg)
-                        {
-                            coercedArgs.add(coercedArg);
-                        }
+                        coercedArgs.add(coercedArg);
                     }
+                }
 
-                    // We will go through the fields in order and try to match them
-                    // up with initializer arguments.
-                    //
-                    for(auto fieldDeclRef : getMembersOfType<VarDecl>(m_astBuilder, toStructDeclRef, MemberFilterStyle::Instance))
+                // We will go through the fields in order and try to match them
+                // up with initializer arguments.
+                //
+                for(auto fieldDeclRef : getMembersOfType<VarDecl>(m_astBuilder, toStructDeclRef, MemberFilterStyle::Instance))
+                {
+                    Expr* coercedArg = nullptr;
+                    bool argResult = _readValueFromInitializerList(
+                        getType(m_astBuilder, fieldDeclRef),
+                        outToExpr ? &coercedArg : nullptr,
+                        fromInitializerListExpr,
+                        ioArgIndex);
+
+                    // No point in trying further if any argument fails
+                    if(!argResult)
+                        return false;
+
+                    if( coercedArg )
                     {
-                        Expr* coercedArg = nullptr;
-                        bool argResult = _readValueFromInitializerList(
-                            getType(m_astBuilder, fieldDeclRef),
-                            outToExpr ? &coercedArg : nullptr,
-                            fromInitializerListExpr,
-                            ioArgIndex,
-                            true);
-
-                        // No point in trying further if any argument fails
-                        if(!argResult)
-                            return false;
-
-                        if( coercedArg )
-                        {
-                            coercedArgs.add(coercedArg);
-                        }
+                        coercedArgs.add(coercedArg);
                     }
                 }
             }
@@ -704,12 +679,20 @@ namespace Slang
             return true;
         }
 
+        // try to invoke the synthesized constructor if it exists
+        if (!_invokeExprForSynthesizedCtor(toType, fromInitializerListExpr, outToExpr))
+        {
+            // TODO: check if it's C-style initializer list
+            // if it's not, return error.
+            // if it is, return, fall-back to legacy logic
+            getSink()->diagnoseRaw(Severity::Error, "Synthesized Constructor is not found\n");
+            return false;
+        }
+
         // We will fall back to the legacy logic of initialize list.
         if(!_readAggregateValueFromInitializerList(toType, outToExpr, fromInitializerListExpr, argIndex))
         {
-            bool useLegacyMode = true;
-            if(!_readAggregateValueFromInitializerList(toType, outToExpr, fromInitializerListExpr, argIndex, useLegacyMode))
-                return false;
+            return false;
         }
 
         if(argIndex != argCount)

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -403,6 +403,12 @@ namespace Slang
 
         bool isCStyle = isCStyleStruct(structDecl);
 
+        DiagnosticSink tempSink(getSourceManager(), nullptr);
+        SemanticsVisitor subVisitor(withSink(&tempSink));
+
+        // First make sure the struct is fully checked, otherwise the synthesized constructor may not be created yet.
+        subVisitor.ensureDecl(structDecl, DeclCheckState::DefinitionChecked);
+
         if (structDecl->m_synthesizedCtorMap.getCount() == 0)
         {
             return false;
@@ -410,9 +416,6 @@ namespace Slang
 
         List<Expr*> coercedArgs;
         auto ctorInvokeExpr = _createCtorInvokeExpr(toType, fromInitializerListExpr->loc, fromInitializerListExpr->args);
-
-        DiagnosticSink tempSink(getSourceManager(), nullptr);
-        SemanticsVisitor subVisitor(withSink(&tempSink));
         ctorInvokeExpr = subVisitor.CheckExpr(ctorInvokeExpr);
 
         if (ctorInvokeExpr)

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -103,7 +103,8 @@ namespace Slang
         Type*                toType,
         Expr**               outToExpr,
         InitializerListExpr* fromInitializerListExpr,
-        UInt                       &ioInitArgIndex)
+        UInt                 &ioInitArgIndex,
+        bool                 useLegacyMode)
     {
         // First, we will check if we have run out of arguments
         // on the initializer list.
@@ -160,7 +161,8 @@ namespace Slang
             toType,
             outToExpr,
             fromInitializerListExpr,
-            ioInitArgIndex);
+            ioInitArgIndex,
+            useLegacyMode);
     }
 
     DeclRefType* findBaseStructType(ASTBuilder* astBuilder, DeclRef<StructDecl> structTypeDeclRef)
@@ -201,11 +203,148 @@ namespace Slang
         return baseStructDeclRef;
     }
 
+    bool SemanticsVisitor::_hasExplicitConstructor(StructDecl* structDecl)
+    {
+        bool result = false;
+        for (auto ctor : getMembersOfType<ConstructorDecl>(getASTBuilder(), structDecl, MemberFilterStyle::All))
+        {
+            // constructor that is not synthesized must be user defined.
+            if (ctor.getDecl()->findModifier<SynthesizedModifier>() == nullptr)
+            {
+                result = true;
+                break;
+            }
+        }
+        return result;
+    }
+
+    // TODO: We might need to find a good way to get the synthesized constructor instead of traversing all of constructors.
+    ConstructorDecl* SemanticsVisitor::_getSynthesizedConstructor(StructDecl* structDecl)
+    {
+        for (auto ctor : getMembersOfType<ConstructorDecl>(getASTBuilder(), structDecl, MemberFilterStyle::All))
+        {
+            if (ctor.getDecl()->findModifier<SynthesizedModifier>() != nullptr)
+            {
+                return ctor.getDecl();
+            }
+        }
+
+        return nullptr;
+    }
+
+    Expr* SemanticsVisitor::_prepareCtorInvokeExpr(Type* toType, const SourceLoc& loc, const List<Expr*>& coercedArgs)
+    {
+        auto* varExpr = getASTBuilder()->create<VarExpr>();
+        varExpr->type = (QualType)getASTBuilder()->getTypeType(toType);
+        varExpr->declRef = isDeclRefTypeOf<Decl>(toType);
+
+        auto* constructorExpr = getASTBuilder()->create<InvokeExpr>();
+        constructorExpr->functionExpr = varExpr;
+        constructorExpr->arguments.addRange(coercedArgs);
+        constructorExpr->loc = loc;
+        auto resolvedConstructorExpr = CheckExpr(constructorExpr);
+
+        return resolvedConstructorExpr;
+    }
+
+    // translation from initializer list to constructor invocation if the struct has constructor.
+    bool SemanticsVisitor::_invokeExprForExplicitCtor(Type* toType, InitializerListExpr* fromInitializerListExpr, Expr** outExpr)
+    {
+        if(auto toDeclRefType = as<DeclRefType>(toType))
+        {
+            auto toTypeDeclRef = toDeclRefType->getDeclRef();
+            if(auto toStructDeclRef = toTypeDeclRef.as<StructDecl>())
+            {
+                if (isFromStdLib(toStructDeclRef.getDecl()))
+                {
+                    // If the struct is from stdlib, we will not try to create a constructor.
+                    return false;
+                }
+
+                if (_hasExplicitConstructor(toStructDeclRef.getDecl()))
+                {
+                    auto ctorInvokeExpr = _prepareCtorInvokeExpr(toType, fromInitializerListExpr->loc, fromInitializerListExpr->args);
+                    if (outExpr && ctorInvokeExpr)
+                    {
+                        *outExpr = ctorInvokeExpr;
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    bool SemanticsVisitor::_invokeExprForSynthesizedCtor(
+        Type*                   toType,
+        StructDecl*             structDecl,
+        InitializerListExpr*    fromInitializerListExpr,
+        UInt                    &ioArgIndex,
+        Expr**                  outExpr)
+    {
+        auto synthesizedConstructor = _getSynthesizedConstructor(structDecl);
+        SLANG_ASSERT(synthesizedConstructor);
+
+        List<Expr*> coercedArgs;
+
+        for(auto param : getParameters(getASTBuilder(), synthesizedConstructor))
+        {
+            Expr* coercedArg = nullptr;
+            bool argResult = _readValueFromInitializerList(
+                getType(m_astBuilder, param),
+                &coercedArg,
+                fromInitializerListExpr,
+                ioArgIndex);
+
+            // No point in trying further if any argument fails
+            if(!argResult)
+                return false;
+
+            if( coercedArg )
+            {
+                coercedArgs.add(coercedArg);
+            }
+        }
+
+        auto ctorInvokeExpr = _prepareCtorInvokeExpr(toType, fromInitializerListExpr->loc, coercedArgs);
+        if (ctorInvokeExpr)
+        {
+            // The reason we need to check the coercion again is that the ResolveInvoke() could still find us
+            // the wrong constructor when there is inheritance. e.g.:
+            // struct A { int a; };// __init(int a) will be synthesized.
+            // struct B : A { int b; };// __init(int a, int b) will be synthesized.
+            // B b = {1};   // This should report an error, but the ResolveInvoke() will find the A.__init(int a).
+            //
+            // This will not happen when both A and B have explicit constructors, because 'coerce()' will be called after 'ResolveInvoke()'.
+            // However, in this initialize list to synthesized constructor translation path, 'coerce()' will not be called.
+            // But that is the only case, therefore, we will do a quick check here.
+            //
+            // TODO: should we improve the ResolveInvoke() to handle this case? Because A.__init(int a) should not be found at first place,
+            // Base class cannot construct a Derived class.
+            if (!canCoerce(toType, ctorInvokeExpr->type, ctorInvokeExpr, nullptr))
+            {
+                // TODO:
+                // 1. Create a more explainable error message.
+                // 2. We should not diagnose here, because we will need a fall back mechanism.
+                getSink()->diagnose(fromInitializerListExpr->loc, Diagnostics::typeMismatch, toType, ctorInvokeExpr->type);
+                return false;
+            }
+            else
+            {
+                if (outExpr)
+                    *outExpr = ctorInvokeExpr;
+                return true;
+            }
+        }
+        return false;
+    }
+
     bool SemanticsVisitor::_readAggregateValueFromInitializerList(
         Type*                inToType,
         Expr**               outToExpr,
         InitializerListExpr* fromInitializerListExpr,
-        UInt                       &ioArgIndex)
+        UInt                 &ioArgIndex,
+        bool                 useLegacyMode)
     {
         auto toType = inToType;
         UInt argCount = fromInitializerListExpr->args.getCount();
@@ -426,50 +565,62 @@ namespace Slang
             auto toTypeDeclRef = toDeclRefType->getDeclRef();
             if(auto toStructDeclRef = toTypeDeclRef.as<StructDecl>())
             {
-                // Trying to initialize a `struct` type given an initializer list.
-                //
-                // Before we iterate over the fields, we want to check if this struct
-                // inherits from another `struct` type. If so, we want to read
-                // an initializer for that base type first.
-                //
-                if (auto baseStructType = findBaseStructType(m_astBuilder, toStructDeclRef))
+                // TODO: create a function '_createCtorInvokeExpr()'
+                // We must have a synthesized constructor here there are only two cases that we don't synthesized constructor:
+                // 1. It is a stdlib struct.
+                // 2. It is a struct that has user defined constructor. (In this case, we should have already handled it in _coerceInitializerList)
+                if (!isFromStdLib(toStructDeclRef.getDecl()) && !useLegacyMode)
                 {
-                    Expr* coercedArg = nullptr;
-                    bool argResult = _readValueFromInitializerList(
-                        baseStructType,
-                        outToExpr ? &coercedArg : nullptr,
-                        fromInitializerListExpr,
-                        ioArgIndex);
-
-                    // No point in trying further if any argument fails
-                    if (!argResult)
-                        return false;
-
-                    if (coercedArg)
-                    {
-                        coercedArgs.add(coercedArg);
-                    }
+                    return _invokeExprForSynthesizedCtor(inToType, toStructDeclRef.getDecl(), fromInitializerListExpr, ioArgIndex, outToExpr);
                 }
-
-                // We will go through the fields in order and try to match them
-                // up with initializer arguments.
-                //
-                for(auto fieldDeclRef : getMembersOfType<VarDecl>(m_astBuilder, toStructDeclRef, MemberFilterStyle::Instance))
+                else
                 {
-                    Expr* coercedArg = nullptr;
-                    bool argResult = _readValueFromInitializerList(
-                        getType(m_astBuilder, fieldDeclRef),
-                        outToExpr ? &coercedArg : nullptr,
-                        fromInitializerListExpr,
-                        ioArgIndex);
-
-                    // No point in trying further if any argument fails
-                    if(!argResult)
-                        return false;
-
-                    if( coercedArg )
+                    // Trying to initialize a `struct` type given an initializer list.
+                    //
+                    // Before we iterate over the fields, we want to check if this struct
+                    // inherits from another `struct` type. If so, we want to read
+                    // an initializer for that base type first.
+                    //
+                    if (auto baseStructType = findBaseStructType(m_astBuilder, toStructDeclRef))
                     {
-                        coercedArgs.add(coercedArg);
+                        Expr* coercedArg = nullptr;
+                        bool argResult = _readValueFromInitializerList(
+                            baseStructType,
+                            outToExpr ? &coercedArg : nullptr,
+                            fromInitializerListExpr,
+                            ioArgIndex);
+
+                        // No point in trying further if any argument fails
+                        if (!argResult)
+                            return false;
+
+                        if (coercedArg)
+                        {
+                            coercedArgs.add(coercedArg);
+                        }
+                    }
+
+                    // We will go through the fields in order and try to match them
+                    // up with initializer arguments.
+                    //
+                    for(auto fieldDeclRef : getMembersOfType<VarDecl>(m_astBuilder, toStructDeclRef, MemberFilterStyle::Instance))
+                    {
+                        Expr* coercedArg = nullptr;
+                        bool argResult = _readValueFromInitializerList(
+                            getType(m_astBuilder, fieldDeclRef),
+                            outToExpr ? &coercedArg : nullptr,
+                            fromInitializerListExpr,
+                            ioArgIndex,
+                            true);
+
+                        // No point in trying further if any argument fails
+                        if(!argResult)
+                            return false;
+
+                        if( coercedArg )
+                        {
+                            coercedArgs.add(coercedArg);
+                        }
                     }
                 }
             }
@@ -547,8 +698,19 @@ namespace Slang
            !canCoerce(toType, fromInitializerListExpr->type, nullptr))
             return _failedCoercion(toType, outToExpr, fromInitializerListExpr);
 
+        // try to invoke the user-defined constructor if it exists
+        if(_invokeExprForExplicitCtor(toType, fromInitializerListExpr, outToExpr))
+        {
+            return true;
+        }
+
+        // We will fall back to the legacy logic of initialize list.
         if(!_readAggregateValueFromInitializerList(toType, outToExpr, fromInitializerListExpr, argIndex))
-            return false;
+        {
+            bool useLegacyMode = true;
+            if(!_readAggregateValueFromInitializerList(toType, outToExpr, fromInitializerListExpr, argIndex, useLegacyMode))
+                return false;
+        }
 
         if(argIndex != argCount)
         {

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -7306,6 +7306,21 @@ namespace Slang
         getSink()->diagnose(loc, Diagnostics::invalidEnumTagType, type);
     }
 
+    bool SemanticsVisitor::_hasExplicitConstructor(StructDecl* structDecl)
+    {
+        bool result = false;
+        for (auto ctor : getMembersOfType<ConstructorDecl>(getASTBuilder(), structDecl, MemberFilterStyle::All))
+        {
+            // constructor that is not synthesized must be user defined.
+            if (ctor.getDecl()->findModifier<SynthesizedModifier>() == nullptr)
+            {
+                result = true;
+                break;
+            }
+        }
+        return result;
+    }
+
     void SemanticsDeclBasesVisitor::visitEnumDecl(EnumDecl* decl)
     {
         SLANG_OUTER_SCOPE_CONTEXT_DECL_RAII(this, decl);
@@ -11229,6 +11244,10 @@ namespace Slang
         auto defaultCtor = _getDefaultCtor(structDecl);
         if (!defaultCtor)
             _createCtor(this, m_astBuilder, structDecl);
+
+
+        // ConstructorDecl* defaultCtorDecl = nullptr;
+        // _getCtorList(getASTBuilder(), this, structDecl, nullptr);
 
         int backingWidth = 0;
         [[maybe_unused]]

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -8769,9 +8769,6 @@ private:
             cachedDeclToCheckedVar.add({ member, checkedMemberVarExpr });
         }
 
-        if (!checkedMemberVarExpr->type.isLeftValue)
-            return;
-
         seqStmtChild->stmts.add(stmt);
     }
 
@@ -11426,6 +11423,7 @@ private:
         // 1. The constructor's name is always `$init`, we create one without parameters now.
         ConstructorDecl* ctor = _createCtor(this, getASTBuilder(), structDecl);
         ctor->addTag(ConstructorDecl::ConstructorTags::MemberInitCtor);
+        addVisibilityModifier(getASTBuilder(), ctor, ctorVisibility);
         structDecl->m_synthesizedCtorMap.addIfNotExists((int)ConstructorDecl::ConstructorTags::MemberInitCtor, ctor);
 
         ctor->members.reserve(resultMembers.getCount());

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -23,6 +23,7 @@ namespace Slang
 {
     static ConstructorDecl* _getDefaultCtor(StructDecl* structDecl);
     static List<ConstructorDecl*> _getCtorList(ASTBuilder* m_astBuilder, SemanticsVisitor* visitor, StructDecl* structDecl, ConstructorDecl** defaultCtorOut);
+    static Expr* constructDefaultInitExprForVar(SemanticsVisitor* visitor, VarDeclBase* varDecl);
 
         /// Visitor to transition declarations to `DeclCheckState::CheckedModifiers`
     struct SemanticsDeclModifiersVisitor
@@ -221,6 +222,15 @@ namespace Slang
         void _validateExtensionDeclMembers(ExtensionDecl* decl);
 
         void visitExtensionDecl(ExtensionDecl* decl);
+
+        // Synthesize the constructor declaration for a struct during header visit, as we
+        // need to have such declaration first such that the overloading resolution can lookup
+        // such constructor and complete the initialize list to constructor translation.
+        //
+        // We will defer the actual implementation of the constructor to the body visit, because
+        // we will have full information about each field in the struct during that stage.
+        void _synthesizeEmptyConstructor(StructDecl* structDecl);
+        void _searchMembersWithHigherVisibility(StructDecl* structDecl, const DeclVisibility& ctorVisibility, List<VarDeclBase*>& resultMembers);
     };
 
     struct SemanticsDeclTypeResolutionVisitor
@@ -1983,13 +1993,32 @@ namespace Slang
         return ctor;
     }
 
+    static inline bool _isDefaultCtor(ConstructorDecl* ctor)
+    {
+        auto allParamHaveInitExpr = [](ConstructorDecl* ctor)
+        {
+            for (auto i : ctor->getParameters())
+                if (!i->initExpr)
+                    return false;
+            return true;
+        };
+
+        // 1. default ctor must have definition
+        // 2. either 2.1 or 2.2 is safisfied
+        // 2.1. default ctor must have no parameters
+        // 2.2. default ctor can have parameters, but all parameters have init expr (Because we won't differentiate this case from 2.)
+        if (ctor->body && (ctor->members.getCount() == 0 || allParamHaveInitExpr(ctor)))
+            return true;
+
+        return false;
+    }
+
     static ConstructorDecl* _getDefaultCtor(StructDecl* structDecl)
     {
         for (auto ctor : structDecl->getMembersOfType<ConstructorDecl>())
         {
-            if (!ctor->body || ctor->members.getCount() != 0)
-                continue;
-            return ctor;
+            if (_isDefaultCtor(ctor))
+                return ctor;
         }
         return nullptr;
     }
@@ -2017,9 +2046,8 @@ namespace Slang
             if (!ctor || !ctor->body)
                 return;
             ctorList.add(ctor);
-            if (ctor->members.getCount() != 0)
-                return;
-            *defaultCtorOut = ctor;
+            if (_isDefaultCtor(ctor))
+                *defaultCtorOut = ctor;
         };
         if (ctorLookupResult.items.getCount() == 0)
         {
@@ -6939,6 +6967,111 @@ namespace Slang
         }
     }
 
+    void SemanticsDeclBasesVisitor::_searchMembersWithHigherVisibility(StructDecl* structDecl, const DeclVisibility& ctorVisibility, List<VarDeclBase*>& resultMembers)
+    {
+        auto findMembers = [&](StructDecl* structDecl)
+        {
+            for (auto varDeclRef : getMembersOfType<VarDeclBase>(getASTBuilder(), structDecl, MemberFilterStyle::Instance))
+            {
+                auto varDecl = varDeclRef.getDecl();
+                if (getDeclVisibility(varDecl) >= ctorVisibility)
+                {
+                    resultMembers.add(varDecl);
+                }
+            }
+        };
+
+        for (auto inheritanceMember : structDecl->getMembersOfType<InheritanceDecl>())
+        {
+            auto declRefType = as<DeclRefType>(inheritanceMember->base.type);
+            if (!declRefType)
+                continue;
+
+            auto structOfInheritance = as<StructDecl>(declRefType->getDeclRef().getDecl());
+            if (!structOfInheritance)
+                continue;
+
+            findMembers(structOfInheritance);
+        }
+
+        findMembers(structDecl);
+    }
+
+    // If a struct's member has:
+    // 1. an initialize expersion: Struct S {int a = 1;}; or
+    // 2. a default value: Struct T{}; Struct S {T t;}
+    //    Note, If a type is not default initializable, it doesn't have default value.
+    // it can be associated with default value expression in the constructor signature.
+    // This function helps to check whether either of those 2 conditions are met and create
+    // a default value for the parameter.
+    // It's totally fine that there is no default value for the parameter, in this case, user
+    // code has to provide the argument for this parameter.
+    static Expr* _getParamDefaultValue(SemanticsVisitor* visitor, VarDeclBase* varDecl)
+    {
+        // 1st condition is easy, we can just use the init expression as the default value.
+        if (varDecl->initExpr)
+        {
+            return varDecl->initExpr;
+        }
+
+        // For the 2nd condition, we need to check if the type is default initializable, if so,
+        // we can use the default constructor.
+        return constructDefaultInitExprForVar(visitor, varDecl);
+    }
+
+    void SemanticsDeclBasesVisitor::_synthesizeEmptyConstructor(StructDecl* structDecl)
+    {
+        // If a type already defines any explicit constructors, do not synthesize any constructors.
+        if (_hasExplicitConstructor(structDecl))
+            return;
+
+        // synthesize the signature first.
+        // The constructor's visibility level is the same as the struct itself.
+        // See: https://github.com/shader-slang/slang/blob/master/docs/proposals/004-initialization.md#synthesis-of-constructors-for-member-initialization
+        DeclVisibility ctorVisibility = getDeclVisibility(structDecl);
+
+        // Only the members whose visibility level is higher or equal than the
+        // constructor's visibility level will appear in the constructor's parameter list.
+        List<VarDeclBase*> resultMembers;
+        _searchMembersWithHigherVisibility(structDecl, ctorVisibility, resultMembers);
+
+        // synthesize the constructor signature:
+        // 1. The constructor's name is always `$init`, we create one without parameters now.
+        ConstructorDecl* ctor = _createCtor(this, getASTBuilder(), structDecl);
+        ctor->members.reserve(resultMembers.getCount());
+
+        // 2. Add the parameter list
+        uint32_t paramIndex = 0;
+        bool stopProcessingDefaultValues = false;
+        for (SlangInt i = resultMembers.getCount() - 1; i >= 0; i--)
+        {
+            auto member = resultMembers[i];
+            auto ctorParam = m_astBuilder->create<ParamDecl>();
+            ctorParam->type = (TypeExp)member->type;
+
+            if (!stopProcessingDefaultValues)
+                ctorParam->initExpr = _getParamDefaultValue(this, member);
+
+            if (!ctorParam->initExpr)
+                stopProcessingDefaultValues = true;
+
+            ctorParam->parentDecl = ctor;
+            StringBuilder prefix;
+            prefix << "param_" << paramIndex++ << "_";
+
+            Name* paramName = member->getName() ?
+                getName(prefix + member->getName()->text) :
+                getName(prefix);
+
+            ctorParam->nameAndLoc = NameLoc(paramName, ctor->loc);
+            ctor->members.add(ctorParam);
+        }
+        ctor->members.reverse();
+
+        // 3. Add the modifiers, there is some special handling for the synthesized constructor that requires
+        // us to add some modifiers.
+    }
+
     void SemanticsDeclBasesVisitor::visitStructDecl(StructDecl* decl)
     {
         // A `struct` type can only inherit from `struct` or `interface` types.
@@ -7022,7 +7155,11 @@ namespace Slang
             // a circular inheritance relationship.
 
             _validateCrossModuleInheritance(decl, inheritanceDecl);
+
         }
+
+        if (!isFromStdLib(decl))
+            _synthesizeEmptyConstructor(decl);
     }
 
     void SemanticsDeclBasesVisitor::visitClassDecl(ClassDecl* decl)

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2726,7 +2726,8 @@ namespace Slang
 
         if (auto varExpr = as<VarExpr>(expr->functionExpr))
         {
-            if ((varExpr->name->text == "&&") || (varExpr->name->text == "||"))
+            if (varExpr->name &&
+                ((varExpr->name->text == "&&") || (varExpr->name->text == "||")))
             {
                 // We only use short-circuiting in scalar input, will fall back
                 // to non-short-circuiting in vector input.

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -2770,8 +2770,8 @@ namespace Slang
         bool _invokeExprForExplicitCtor(Type* toType, InitializerListExpr* fromInitializerListExpr, Expr** outExpr);
         bool _invokeExprForSynthesizedCtor(Type* toType, InitializerListExpr* fromInitializerListExpr, Expr** outExpr);
         Expr* _createCtorInvokeExpr(Type* toType, const SourceLoc& loc, const List<Expr*>& coercedArgs);
-        bool _hasExplicitConstructor(StructDecl* structDecl);
-        ConstructorDecl* _getSynthesizedConstructor(StructDecl* structDecl);
+        bool _hasExplicitConstructor(StructDecl* structDecl, bool checkBaseType);
+        ConstructorDecl* _getSynthesizedConstructor(StructDecl* structDecl, ConstructorDecl::ConstructorTags tags);
         bool isCStyleStruct(StructDecl* structDecl);
         bool _cStyleStructBasicCheck(Decl* decl);
     };

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1503,8 +1503,7 @@ namespace Slang
             Type*                toType,
             Expr**               outToExpr,
             InitializerListExpr* fromInitializerListExpr,
-            UInt                 &ioInitArgIndex,
-            bool                 useLegacyMode = false);
+            UInt                 &ioInitArgIndex);
 
             /// Read an aggregate value from an initializer list expression.
             ///
@@ -1529,8 +1528,7 @@ namespace Slang
             Type*                inToType,
             Expr**               outToExpr,
             InitializerListExpr* fromInitializerListExpr,
-            UInt                 &ioArgIndex,
-            bool                 useLegacyMode = false);
+            UInt                 &ioArgIndex);
 
             /// Coerce an initializer-list expression to a specific type.
             ///
@@ -2770,18 +2768,10 @@ namespace Slang
             CompletionSuggestions::ScopeKind scopeKind, LookupResult const& lookupResult);
 
         bool _invokeExprForExplicitCtor(Type* toType, InitializerListExpr* fromInitializerListExpr, Expr** outExpr);
-        bool _invokeExprForSynthesizedCtor(
-            Type*                   toType,
-            StructDecl*             structDecl,
-            InitializerListExpr*    fromInitializerListExpr,
-            UInt                    &ioArgIndex,
-            Expr**                  outExpr);
-
+        bool _invokeExprForSynthesizedCtor(Type* toType, InitializerListExpr* fromInitializerListExpr, Expr** outExpr);
         Expr* _prepareCtorInvokeExpr(Type* toType, const SourceLoc& loc, const List<Expr*>& coercedArgs);
-
         bool _hasExplicitConstructor(StructDecl* structDecl);
         ConstructorDecl* _getSynthesizedConstructor(StructDecl* structDecl);
-
     };
 
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1503,7 +1503,8 @@ namespace Slang
             Type*                toType,
             Expr**               outToExpr,
             InitializerListExpr* fromInitializerListExpr,
-            UInt                       &ioInitArgIndex);
+            UInt                 &ioInitArgIndex,
+            bool                 useLegacyMode = false);
 
             /// Read an aggregate value from an initializer list expression.
             ///
@@ -1528,7 +1529,8 @@ namespace Slang
             Type*                inToType,
             Expr**               outToExpr,
             InitializerListExpr* fromInitializerListExpr,
-            UInt                       &ioArgIndex);
+            UInt                 &ioArgIndex,
+            bool                 useLegacyMode = false);
 
             /// Coerce an initializer-list expression to a specific type.
             ///
@@ -2766,6 +2768,20 @@ namespace Slang
 
         void suggestCompletionItems(
             CompletionSuggestions::ScopeKind scopeKind, LookupResult const& lookupResult);
+
+        bool _invokeExprForExplicitCtor(Type* toType, InitializerListExpr* fromInitializerListExpr, Expr** outExpr);
+        bool _invokeExprForSynthesizedCtor(
+            Type*                   toType,
+            StructDecl*             structDecl,
+            InitializerListExpr*    fromInitializerListExpr,
+            UInt                    &ioArgIndex,
+            Expr**                  outExpr);
+
+        Expr* _prepareCtorInvokeExpr(Type* toType, const SourceLoc& loc, const List<Expr*>& coercedArgs);
+
+        bool _hasExplicitConstructor(StructDecl* structDecl);
+        ConstructorDecl* _getSynthesizedConstructor(StructDecl* structDecl);
+
     };
 
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -2772,6 +2772,8 @@ namespace Slang
         Expr* _prepareCtorInvokeExpr(Type* toType, const SourceLoc& loc, const List<Expr*>& coercedArgs);
         bool _hasExplicitConstructor(StructDecl* structDecl);
         ConstructorDecl* _getSynthesizedConstructor(StructDecl* structDecl);
+        bool isCStyleStruct(StructDecl* structDecl);
+        bool _cStyleStructBasicCheck(Decl* decl);
     };
 
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1062,6 +1062,10 @@ namespace Slang
 
         OrderedHashSet<Type*>* getCapturedTypePacks() { return m_capturedTypePacks; }
 
+        void setCheckForSynthesizedCtor(bool checkForSynthesizedCtor)
+        {
+            m_checkForSynthesizedCtor = checkForSynthesizedCtor;
+        }
     private:
         SharedSemanticsContext* m_shared = nullptr;
 
@@ -1107,6 +1111,9 @@ namespace Slang
         ExpandExpr* m_parentExpandExpr = nullptr;
 
         OrderedHashSet<Type*>* m_capturedTypePacks = nullptr;
+
+        // Flag to indicate whether this check is to check a synthesized constructor
+        bool m_checkForSynthesizedCtor = false;
     };
 
     struct OuterScopeContextRAII

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -744,6 +744,16 @@ namespace Slang
             m_mapTypePairToImplicitCastMethod[key] = candidate;
         }
 
+        bool* isCStyleStruct(StructDecl* structDecl)
+        {
+            return m_isCStyleStructCache.tryGetValue(structDecl);
+        }
+
+        void cacheCStyleStruct(StructDecl* structDecl, bool isCStyle)
+        {
+            m_isCStyleStructCache.addIfNotExists(structDecl, isCStyle);
+        }
+
         // Get the inner most generic decl that a decl-ref is dependent on.
         // For example, `Foo<T>` depends on the generic decl that defines `T`.
         //
@@ -869,6 +879,7 @@ namespace Slang
         Dictionary<DeclRef<Decl>, InheritanceInfo> m_mapDeclRefToInheritanceInfo;
         Dictionary<TypePair, SubtypeWitness*> m_mapTypePairToSubtypeWitness;
         Dictionary<ImplicitCastMethodKey, ImplicitCastMethod> m_mapTypePairToImplicitCastMethod;
+        Dictionary<StructDecl*, bool> m_isCStyleStructCache;
     };
 
         /// Local/scoped state of the semantic-checking system

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -2769,7 +2769,7 @@ namespace Slang
 
         bool _invokeExprForExplicitCtor(Type* toType, InitializerListExpr* fromInitializerListExpr, Expr** outExpr);
         bool _invokeExprForSynthesizedCtor(Type* toType, InitializerListExpr* fromInitializerListExpr, Expr** outExpr);
-        Expr* _prepareCtorInvokeExpr(Type* toType, const SourceLoc& loc, const List<Expr*>& coercedArgs);
+        Expr* _createCtorInvokeExpr(Type* toType, const SourceLoc& loc, const List<Expr*>& coercedArgs);
         bool _hasExplicitConstructor(StructDecl* structDecl);
         ConstructorDecl* _getSynthesizedConstructor(StructDecl* structDecl);
         bool isCStyleStruct(StructDecl* structDecl);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -10017,7 +10017,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                 }
 
                 // Used for diagnostics
-                getBuilder()->addConstructorDecoration(irFunc, constructorDecl->isSynthesized);
+                getBuilder()->addConstructorDecoration(irFunc, constructorDecl->containsTag(ConstructorDecl::ConstructorTags::Synthesized));
             }
 
             // We lower whatever statement was stored on the declaration

--- a/tests/autodiff/differential-type-constructor.slang
+++ b/tests/autodiff/differential-type-constructor.slang
@@ -14,11 +14,11 @@ RWStructuredBuffer<float> outputBuffer;
 void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
 {
     {
-        var dp = diffPair(MyStruct(), MyStruct.Differential());
+        var dp = diffPair(MyStruct(0.0, 0), MyStruct.Differential(0.0));
 
         outputBuffer[0] = dp.d.a;
 
-        var dp2 = diffPair<MyStruct>(MyStruct(), MyStruct.Differential(1.f));
+        var dp2 = diffPair<MyStruct>(MyStruct(0.0, 0), MyStruct.Differential(1.f));
 
         outputBuffer[1] = dp2.d.a;
     }

--- a/tests/autodiff/generic-constructor.slang
+++ b/tests/autodiff/generic-constructor.slang
@@ -19,6 +19,16 @@ struct Impl : IFoo
     {
         x = v.x;
     }
+
+    // We have to add this __init so that the following code can still work:
+    // Impl.Differential v0 = { (float)x };
+    // because when there is a explicit constructor defined, we will not fall back
+    // to legacy constructor. So this construction will fail.
+    [Differentiable]
+    __init(float v)
+    {
+        x = v;
+    }
 }
 
 [Differentiable]

--- a/tests/autodiff/generic-impl-jvp.slang
+++ b/tests/autodiff/generic-impl-jvp.slang
@@ -161,6 +161,16 @@ struct lineardvector : IDifferentiable
             val.values[i] = a[i];
         }
     }
+
+    // Add a new constructor for dadd() function.
+    __init(Real a[N])
+    {
+        [ForceUnroll]
+        for (int i = 0; i < N; i++)
+        {
+            val.values[i] = a[i];
+        }
+    }
 };
 
 __generic<let N : int>
@@ -204,12 +214,24 @@ struct linearvector : MyLinearArithmeticType, IDifferentiable
 
     static Differential dadd(Differential a, Differential b)
     {
-        return { myvector<Real, N>.dadd(a.val, b.val) };
+        // return { myvector<Real, N>.dadd(a.val, b.val) };
+        //
+        // Above code will not work because
+        // myvector<Real, N>.dadd will return dvector<T.Differential, N> type
+        // while Differential == lineardvector<N> type
+        // and the constructor of lineardvector<N> requires a vector<Real.Differential, N> type
+        // and dvector<T.Differential, N> != vector<Real.Differential, N>, though they have the
+        // same members.
+        //
+        // In our new design, generic will not be C-Style struct anymore.
+        dvector<Real.Differential, N> d = myvector<Real, N>.dadd(a.val, b.val);
+        return {d.values};
     }
 
     static Differential dmul<T: __BuiltinRealType>(T a, Differential b)
     {
-        return { myvector<Real, N>.dmul<T>(a, b.val) };
+        dvector<Real.Differential, N> d = myvector<Real, N>.dmul<T>(a, b.val);
+        return {d.values};
     }
 
     [ForwardDifferentiable]

--- a/tests/autodiff/self-differential-generic-type-synthesis.slang
+++ b/tests/autodiff/self-differential-generic-type-synthesis.slang
@@ -17,7 +17,7 @@ struct Ray<let N: int> : IDifferentiable {
 [numthreads(1, 1, 1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
-    Ray<4> ray = Ray<4>();
+    Ray<4> ray = Ray<4>(0.0, float4(0.0), float4(0.0));
     Ray<4>.Differential ray2;
 
     ray.a = 1.f;

--- a/tests/autodiff/self-differential-type-synthesis.slang
+++ b/tests/autodiff/self-differential-type-synthesis.slang
@@ -17,7 +17,7 @@ struct Ray : IDifferentiable {
 [numthreads(1, 1, 1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
-    Ray ray = Ray();
+    Ray ray = Ray(0, float3(0, 0, 0), float3(0, 0, 0));
     Ray.Differential ray2;
 
     ray.a = 1.f;

--- a/tests/bugs/addr-scope-fix.slang
+++ b/tests/bugs/addr-scope-fix.slang
@@ -1,4 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX:-vk -slang -compute -shaderobj -output-using-type
 
 //TEST_INPUT:ubuffer(data=[0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/bugs/generic-default-value.slang
+++ b/tests/bugs/generic-default-value.slang
@@ -1,4 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj 
+//TEST(compute):COMPARE_COMPUTE_EX:-vk -slang -compute -shaderobj 
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;
@@ -8,6 +9,10 @@ works with a generic */
 
 struct Check<T>
 {
+    // T is not default initialize type, because it's a generic type parameter.
+    // Therefore, when we synthesize the contructor, we won't create a default value
+    // for it.
+    // __init(T v);
     T v;
 };
 
@@ -16,8 +21,8 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     int index = int(dispatchThreadID.x);
 
-    Check<float> v = {};
-    
+    Check<float> v = {0}; // this has to be translated to `Check<float>.__init(0);` because it's not a C-Style struct
+
     outputBuffer[index] = index + int(v.v); 
 }
 

--- a/tests/bugs/overload-ambiguous-2.slang
+++ b/tests/bugs/overload-ambiguous-2.slang
@@ -57,7 +57,7 @@ void computeMain(uint3 threadID: SV_DispatchThreadID)
 {
     using namespace A;
 
-    Struct2<10> input = {threadID.x};
+    Struct2<10> input = {{threadID.x}};
 
     Struct2<20> output;
     output = myFunc<10, 20>(input);

--- a/tests/diagnostics/interfaces/anyvalue-size-validation.slang
+++ b/tests/diagnostics/interfaces/anyvalue-size-validation.slang
@@ -26,6 +26,6 @@ RWStructuredBuffer<uint> output;
 [numthreads(4, 1, 1)]
 void main()
 {
-    S s = S();
+    S s = S(1, 2, 3);
     output[0] = test(s).a;
 }

--- a/tests/diagnostics/mismatching-types.slang
+++ b/tests/diagnostics/mismatching-types.slang
@@ -62,6 +62,7 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     // expected an expression of type 'GenericOuter<int>.NonGenericInner', got 'GenericOuter<float>.NonGenericInner'
     a.ng = b.ng;
     // expected an expression of type 'NonGenericOuter.GenericInner<int>', got 'int'
+    // explicit conversion from 'int' to 'GenericInner<int>' is possible
     c.i = 0;
     // expected an expression of type 'NonGenericOuter.GenericInner<int>', got 'NonGenericOuter.GenericInner<float>'
     c.i = c.f;

--- a/tests/diagnostics/mismatching-types.slang
+++ b/tests/diagnostics/mismatching-types.slang
@@ -49,9 +49,13 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     
     // expected an expression of type 'GenericOuter<int>', got 'int'
     a = 0;
+
     // expected an expression of type 'GenericOuter<int>.GenericInner<int>', got 'int'
+    // explicit conversion from 'int' to 'GenericOuter<int>.GenericInner<int>' is possible
     a.g = 0;
+
     // expected an expression of type 'GenericOuter<int>.NonGenericInner', got 'int'
+    // explicit conversion from 'int' to 'GenericOuter<int>.NonGenericInner' is possible
     a.ng = 0;
     // expected an expression of type 'GenericOuter<int>.GenericInner<int>', got 'GenericOuter<float>.GenericInner<float>'
     a.g = b.g;
@@ -61,7 +65,9 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     c.i = 0;
     // expected an expression of type 'NonGenericOuter.GenericInner<int>', got 'NonGenericOuter.GenericInner<float>'
     c.i = c.f;
+
     // expected an expression of type 'NonGenericOuter.GenericInner<int>.ReallyNested', got 'int'
+    // explicit conversion from 'int' to 'GenericInner<int>.ReallyNested' is possible
     c.i.n = 0;
     // OK
     c.i.n.val = 0;

--- a/tests/diagnostics/mismatching-types.slang.expected
+++ b/tests/diagnostics/mismatching-types.slang.expected
@@ -20,6 +20,7 @@ tests/diagnostics/mismatching-types.slang(63): error 30019: expected an expressi
 tests/diagnostics/mismatching-types.slang(65): error 30019: expected an expression of type 'GenericInner<int>', got 'int'
     c.i = 0;
           ^
+tests/diagnostics/mismatching-types.slang(65): note: explicit conversion from 'int' to 'GenericInner<int>' is possible
 tests/diagnostics/mismatching-types.slang(67): error 30019: expected an expression of type 'GenericInner<int>', got 'GenericInner<float>'
     c.i = c.f;
             ^
@@ -32,6 +33,7 @@ tests/diagnostics/mismatching-types.slang(80): error 30019: expected an expressi
                         ^~~
 tests/diagnostics/mismatching-types.slang(82): error 30019: expected an expression of type 'Texture2D<float>', got 'Texture1D<float>'
     Texture2D<float> t2 = tex;
+                          ^~~
 }
 standard output = {
 }

--- a/tests/diagnostics/mismatching-types.slang.expected
+++ b/tests/diagnostics/mismatching-types.slang.expected
@@ -3,33 +3,35 @@ standard error = {
 tests/diagnostics/mismatching-types.slang(51): error 30019: expected an expression of type 'GenericOuter<int>', got 'int'
     a = 0;
         ^
-tests/diagnostics/mismatching-types.slang(53): error 30019: expected an expression of type 'GenericOuter<int>.GenericInner<int>', got 'int'
+tests/diagnostics/mismatching-types.slang(55): error 30019: expected an expression of type 'GenericOuter<int>.GenericInner<int>', got 'int'
     a.g = 0;
           ^
-tests/diagnostics/mismatching-types.slang(55): error 30019: expected an expression of type 'GenericOuter<int>.NonGenericInner', got 'int'
+tests/diagnostics/mismatching-types.slang(55): note: explicit conversion from 'int' to 'GenericOuter<int>.GenericInner<int>' is possible
+tests/diagnostics/mismatching-types.slang(59): error 30019: expected an expression of type 'GenericOuter<int>.NonGenericInner', got 'int'
     a.ng = 0;
            ^
-tests/diagnostics/mismatching-types.slang(57): error 30019: expected an expression of type 'GenericOuter<int>.GenericInner<int>', got 'GenericOuter<float>.GenericInner<float>'
+tests/diagnostics/mismatching-types.slang(59): note: explicit conversion from 'int' to 'GenericOuter<int>.NonGenericInner' is possible
+tests/diagnostics/mismatching-types.slang(61): error 30019: expected an expression of type 'GenericOuter<int>.GenericInner<int>', got 'GenericOuter<float>.GenericInner<float>'
     a.g = b.g;
             ^
-tests/diagnostics/mismatching-types.slang(59): error 30019: expected an expression of type 'GenericOuter<int>.NonGenericInner', got 'GenericOuter<float>.NonGenericInner'
+tests/diagnostics/mismatching-types.slang(63): error 30019: expected an expression of type 'GenericOuter<int>.NonGenericInner', got 'GenericOuter<float>.NonGenericInner'
     a.ng = b.ng;
              ^~
-tests/diagnostics/mismatching-types.slang(61): error 30019: expected an expression of type 'GenericInner<int>', got 'int'
+tests/diagnostics/mismatching-types.slang(65): error 30019: expected an expression of type 'GenericInner<int>', got 'int'
     c.i = 0;
           ^
-tests/diagnostics/mismatching-types.slang(63): error 30019: expected an expression of type 'GenericInner<int>', got 'GenericInner<float>'
+tests/diagnostics/mismatching-types.slang(67): error 30019: expected an expression of type 'GenericInner<int>', got 'GenericInner<float>'
     c.i = c.f;
             ^
-tests/diagnostics/mismatching-types.slang(65): error 30019: expected an expression of type 'GenericInner<int>.ReallyNested', got 'int'
+tests/diagnostics/mismatching-types.slang(71): error 30019: expected an expression of type 'GenericInner<int>.ReallyNested', got 'int'
     c.i.n = 0;
             ^
-tests/diagnostics/mismatching-types.slang(74): error 30019: expected an expression of type 'Texture1D<int>', got 'Texture1D<float>'
+tests/diagnostics/mismatching-types.slang(71): note: explicit conversion from 'int' to 'GenericInner<int>.ReallyNested' is possible
+tests/diagnostics/mismatching-types.slang(80): error 30019: expected an expression of type 'Texture1D<int>', got 'Texture1D<float>'
     Texture1D<int> t1 = tex;
                         ^~~
-tests/diagnostics/mismatching-types.slang(76): error 30019: expected an expression of type 'Texture2D<float>', got 'Texture1D<float>'
+tests/diagnostics/mismatching-types.slang(82): error 30019: expected an expression of type 'Texture2D<float>', got 'Texture1D<float>'
     Texture2D<float> t2 = tex;
-                          ^~~
 }
 standard output = {
 }

--- a/tests/diagnostics/mismatching-types.slang.expected
+++ b/tests/diagnostics/mismatching-types.slang.expected
@@ -17,21 +17,20 @@ tests/diagnostics/mismatching-types.slang(61): error 30019: expected an expressi
 tests/diagnostics/mismatching-types.slang(63): error 30019: expected an expression of type 'GenericOuter<int>.NonGenericInner', got 'GenericOuter<float>.NonGenericInner'
     a.ng = b.ng;
              ^~
-tests/diagnostics/mismatching-types.slang(65): error 30019: expected an expression of type 'GenericInner<int>', got 'int'
+tests/diagnostics/mismatching-types.slang(66): error 30019: expected an expression of type 'GenericInner<int>', got 'int'
     c.i = 0;
           ^
-tests/diagnostics/mismatching-types.slang(65): note: explicit conversion from 'int' to 'GenericInner<int>' is possible
-tests/diagnostics/mismatching-types.slang(67): error 30019: expected an expression of type 'GenericInner<int>', got 'GenericInner<float>'
+tests/diagnostics/mismatching-types.slang(68): error 30019: expected an expression of type 'GenericInner<int>', got 'GenericInner<float>'
     c.i = c.f;
             ^
-tests/diagnostics/mismatching-types.slang(71): error 30019: expected an expression of type 'GenericInner<int>.ReallyNested', got 'int'
+tests/diagnostics/mismatching-types.slang(72): error 30019: expected an expression of type 'GenericInner<int>.ReallyNested', got 'int'
     c.i.n = 0;
             ^
-tests/diagnostics/mismatching-types.slang(71): note: explicit conversion from 'int' to 'GenericInner<int>.ReallyNested' is possible
-tests/diagnostics/mismatching-types.slang(80): error 30019: expected an expression of type 'Texture1D<int>', got 'Texture1D<float>'
+tests/diagnostics/mismatching-types.slang(72): note: explicit conversion from 'int' to 'GenericInner<int>.ReallyNested' is possible
+tests/diagnostics/mismatching-types.slang(81): error 30019: expected an expression of type 'Texture1D<int>', got 'Texture1D<float>'
     Texture1D<int> t1 = tex;
                         ^~~
-tests/diagnostics/mismatching-types.slang(82): error 30019: expected an expression of type 'Texture2D<float>', got 'Texture1D<float>'
+tests/diagnostics/mismatching-types.slang(83): error 30019: expected an expression of type 'Texture2D<float>', got 'Texture1D<float>'
     Texture2D<float> t2 = tex;
                           ^~~
 }

--- a/tests/language-feature/generics/struct-generic-value-param.slang
+++ b/tests/language-feature/generics/struct-generic-value-param.slang
@@ -17,6 +17,7 @@
 // when trying out the feature.
 
 //TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE: -vk -shaderobj
 
 import struct_generic_value_param_import;
 

--- a/tests/language-feature/interfaces/zero-init-interface.slang
+++ b/tests/language-feature/interfaces/zero-init-interface.slang
@@ -1,6 +1,7 @@
 // Test that we can zero-init a struct with interface typed member.
 
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUFFER): -shaderobj
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUFFER): -vk -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
@@ -26,7 +27,8 @@ struct MyType
 [numthreads(1, 1, 1)]
 void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
 {
-    MyType t = {};
+    // Note 'MyType' is not a C-Style struct
+    MyType t = {{}};
     // BUFFER: 1
     outputBuffer[0] = t.foo.method();
 }

--- a/tests/language-feature/overloaded-subscript.slang
+++ b/tests/language-feature/overloaded-subscript.slang
@@ -38,7 +38,8 @@ RWStructuredBuffer<int> outputBuffer;
 [numthreads(1,1,1)]
 void computeMain()
 {
-    MyArray<int> arr = {};
+    // note: MyArray<int> arr = {} doesn't work anymore.
+    MyArray<int> arr = {{1, 2, 3, 4}};
     arr[0] = 1;
     arr[1] = 2;
     // CHECK: 1

--- a/tests/language-feature/properties/property-in-interface.slang
+++ b/tests/language-feature/properties/property-in-interface.slang
@@ -1,6 +1,6 @@
 // property-in-interface.slang
 
-//TEST(compute):COMPARE_COMPUTE: -shaderobj
+//TEST(compute):COMPARE_COMPUTE: -shaderobj -vk
 
 // Test that interfaces can include property declarations.
 
@@ -46,7 +46,7 @@ int test(int value)
 }
 
 //TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4):out,name=outputBuffer
-RWStructuredBuffer<int> outputBuffer : register(u0);
+RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(4, 1, 1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)

--- a/tests/pipeline/rasterization/mesh/hlsl-syntax.slang.expected
+++ b/tests/pipeline/rasterization/mesh/hlsl-syntax.slang.expected
@@ -1,0 +1,136 @@
+result code = 0
+standard error = {
+}
+standard output = {
+; SPIR-V
+; Version: 1.4
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 141
+; Schema: 0
+OpCapability MeshShadingEXT
+OpExtension "SPV_EXT_mesh_shader"
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint MeshEXT %main "main" %gl_MeshVerticesEXT %verts_color_0 %gl_LocalInvocationIndex %gl_PrimitiveTriangleIndicesEXT
+OpExecutionMode %main LocalSize 3 1 1
+OpExecutionMode %main OutputVertices 3
+OpExecutionMode %main OutputPrimitivesEXT 1
+OpExecutionMode %main OutputTrianglesEXT
+
+; Debug Information
+OpSource GLSL 450
+OpSourceExtension "GL_EXT_mesh_shader"
+OpSourceExtension "GL_GOOGLE_cpp_style_line_directive"
+OpName %main "main"                                 ; id %4
+OpName %gl_MeshPerVertexEXT "gl_MeshPerVertexEXT"   ; id %74
+OpMemberName %gl_MeshPerVertexEXT 0 "gl_Position"
+OpName %gl_MeshVerticesEXT "gl_MeshVerticesEXT"     ; id %77
+OpName %verts_color_0 "verts_color_0"               ; id %84
+OpName %gl_LocalInvocationIndex "gl_LocalInvocationIndex"   ; id %93
+OpName %param "param"                                       ; id %94
+OpName %gl_PrimitiveTriangleIndicesEXT "gl_PrimitiveTriangleIndicesEXT"     ; id %104
+
+; Annotations
+OpMemberDecorate %gl_MeshPerVertexEXT 0 BuiltIn Position
+OpDecorate %gl_MeshPerVertexEXT Block
+OpDecorate %verts_color_0 Location 0
+OpDecorate %gl_LocalInvocationIndex BuiltIn LocalInvocationIndex
+OpDecorate %gl_PrimitiveTriangleIndicesEXT BuiltIn PrimitiveTriangleIndicesEXT
+OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+OpDecorate %114 NonWritable
+OpDecorate %117 NonWritable
+
+; Types, variables and constants
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v4float = OpTypeVector %float 4
+%v3float = OpTypeVector %float 3
+%_ptr_Function_v3float = OpTypePointer Function %v3float
+%uint = OpTypeInt 32 0
+%_ptr_Function_uint = OpTypePointer Function %uint
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%uint_3 = OpConstant %uint 3
+%bool = OpTypeBool
+%v2float = OpTypeVector %float 2
+%_arr_v2float_uint_3 = OpTypeArray %v2float %uint_3
+%float_0 = OpConstant %float 0
+%float_n0_5 = OpConstant %float -0.5
+%46 = OpConstantComposite %v2float %float_0 %float_n0_5
+%float_0_5 = OpConstant %float 0.5
+%48 = OpConstantComposite %v2float %float_0_5 %float_0_5
+%49 = OpConstantComposite %v2float %float_n0_5 %float_0_5
+%50 = OpConstantComposite %_arr_v2float_uint_3 %46 %48 %49
+%_ptr_Function__arr_v2float_uint_3 = OpTypePointer Function %_arr_v2float_uint_3
+%_ptr_Function_v2float = OpTypePointer Function %v2float
+%float_1 = OpConstant %float 1
+%_arr_v3float_uint_3 = OpTypeArray %v3float %uint_3
+%62 = OpConstantComposite %v3float %float_1 %float_1 %float_0
+%63 = OpConstantComposite %v3float %float_0 %float_1 %float_1
+%64 = OpConstantComposite %v3float %float_1 %float_0 %float_1
+%65 = OpConstantComposite %_arr_v3float_uint_3 %62 %63 %64
+%_ptr_Function__arr_v3float_uint_3 = OpTypePointer Function %_arr_v3float_uint_3
+%gl_MeshPerVertexEXT = OpTypeStruct %v4float        ; Block
+%_arr_gl_MeshPerVertexEXT_uint_3 = OpTypeArray %gl_MeshPerVertexEXT %uint_3
+%_ptr_Output__arr_gl_MeshPerVertexEXT_uint_3 = OpTypePointer Output %_arr_gl_MeshPerVertexEXT_uint_3
+%gl_MeshVerticesEXT = OpVariable %_ptr_Output__arr_gl_MeshPerVertexEXT_uint_3 Output
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%_ptr_Output__arr_v3float_uint_3 = OpTypePointer Output %_arr_v3float_uint_3
+%verts_color_0 = OpVariable %_ptr_Output__arr_v3float_uint_3 Output     ; Location 0
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+%uint_1 = OpConstant %uint 1
+%_ptr_Input_uint = OpTypePointer Input %uint
+%gl_LocalInvocationIndex = OpVariable %_ptr_Input_uint Input    ; BuiltIn LocalInvocationIndex
+%v3uint = OpTypeVector %uint 3
+%_arr_v3uint_uint_1 = OpTypeArray %v3uint %uint_1
+%_ptr_Output__arr_v3uint_uint_1 = OpTypePointer Output %_arr_v3uint_uint_1
+%gl_PrimitiveTriangleIndicesEXT = OpVariable %_ptr_Output__arr_v3uint_uint_1 Output     ; BuiltIn PrimitiveTriangleIndicesEXT
+%uint_0 = OpConstant %uint 0
+%uint_2 = OpConstant %uint 2
+%108 = OpConstantComposite %v3uint %uint_0 %uint_1 %uint_2
+%_ptr_Output_v3uint = OpTypePointer Output %v3uint
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_3 %uint_1 %uint_1     ; BuiltIn WorkgroupSize
+
+; Function main
+%main = OpFunction %void None %3
+%5 = OpLabel
+%114 = OpVariable %_ptr_Function__arr_v2float_uint_3 Function %50   ; NonWritable
+%117 = OpVariable %_ptr_Function__arr_v3float_uint_3 Function %65   ; NonWritable
+%param = OpVariable %_ptr_Function_uint Function
+OpSetMeshOutputsEXT %uint_3 %uint_1
+%95 = OpLoad %uint %gl_LocalInvocationIndex
+OpStore %param %95
+OpStore %114 %50
+OpStore %117 %65
+%120 = OpULessThan %bool %95 %uint_3
+OpSelectionMerge %140 None
+OpBranchConditional %120 %121 %140
+%121 = OpLabel
+%122 = OpLoad %uint %param
+%123 = OpAccessChain %_ptr_Function_v2float %114 %122
+%124 = OpLoad %v2float %123
+%125 = OpCompositeExtract %float %124 0
+%126 = OpCompositeExtract %float %124 1
+%127 = OpCompositeConstruct %v4float %125 %126 %float_0 %float_1
+%129 = OpAccessChain %_ptr_Function_v3float %117 %122
+%130 = OpLoad %v3float %129
+%135 = OpAccessChain %_ptr_Output_v4float %gl_MeshVerticesEXT %122 %int_0
+OpStore %135 %127
+%139 = OpAccessChain %_ptr_Output_v3float %verts_color_0 %122
+OpStore %139 %130
+OpBranch %140
+%140 = OpLabel
+%97 = OpLoad %uint %gl_LocalInvocationIndex
+%98 = OpULessThan %bool %97 %uint_1
+OpSelectionMerge %100 None
+OpBranchConditional %98 %99 %100
+%99 = OpLabel
+%105 = OpLoad %uint %gl_LocalInvocationIndex
+%110 = OpAccessChain %_ptr_Output_v3uint %gl_PrimitiveTriangleIndicesEXT %105
+OpStore %110 %108
+OpBranch %100
+%100 = OpLabel
+OpReturn
+OpFunctionEnd
+}

--- a/tests/pipeline/rasterization/mesh/hlsl-syntax.slang.glsl
+++ b/tests/pipeline/rasterization/mesh/hlsl-syntax.slang.glsl
@@ -2,27 +2,40 @@
 #extension GL_EXT_mesh_shader : require
 layout(row_major) uniform;
 layout(row_major) buffer;
-const vec3  colors_0[3] = { vec3(1.0, 1.0, 0.0), vec3(0.0, 1.0, 1.0), vec3(1.0, 0.0, 1.0) };
-const vec2  positions_0[3] = { vec2(0.0, -0.5), vec2(0.5, 0.5), vec2(-0.5, 0.5) };
-layout(location = 0)
-out vec3  verts_color_0[3];
 
 out gl_MeshPerVertexEXT
 {
     vec4 gl_Position;
 } gl_MeshVerticesEXT[3];
 
+const vec3  colors_0[3] = { vec3(1.0, 1.0, 0.0), vec3(0.0, 1.0, 1.0), vec3(1.0, 0.0, 1.0) };
+const vec2  positions_0[3] = { vec2(0.0, -0.5), vec2(0.5, 0.5), vec2(-0.5, 0.5) };
 
+struct Vertex_0
+{
+    vec4 pos_0;
+    vec3 color_0;
+};
+
+Vertex_0 Vertex_x24init_0(vec4 pos_1, vec3 color_1)
+{
+    Vertex_0 _S1;
+
+    _S1.pos_0 = pos_1;
+    _S1.color_0 = color_1;
+    return _S1;
+}
+
+layout(location = 0)
+out vec3  verts_color_0[3];
 out uvec3  gl_PrimitiveTriangleIndicesEXT[1];
 void foo_0(uint _S2)
 {
     if(_S2 < 3U)
     {
-        gl_MeshVerticesEXT[_S2].gl_Position = vec4(positions_0[_S2], 0.0, 1.0);
-        verts_color_0[_S2] = colors_0[_S2];
-    }
-    else
-    {
+        Vertex_0 _S3 = Vertex_x24init_0(vec4(positions_0[_S2], 0.0, 1.0), colors_0[_S2]);
+        gl_MeshVerticesEXT[_S2].gl_Position = _S3.pos_0;
+        verts_color_0[_S2] = _S3.color_0;
     }
     return;
 }
@@ -39,8 +52,6 @@ void main()
     {
         gl_PrimitiveTriangleIndicesEXT[gl_LocalInvocationIndex] = uvec3(0U, 1U, 2U);
     }
-    else
-    {
-    }
     return;
 }
+

--- a/tools/slang-unit-test/unit-test-decl-tree-reflection.cpp
+++ b/tools/slang-unit-test/unit-test-decl-tree-reflection.cpp
@@ -118,10 +118,10 @@ SLANG_UNIT_TEST(declTreeReflection)
     SLANG_CHECK(moduleDeclReflection->getKind() == slang::DeclReflection::Kind::Module);
     SLANG_CHECK(moduleDeclReflection->getChildrenCount() == 9);
 
-    // First declaration should be a struct with 1 variable
+    // First declaration should be a struct with 1 variable and a synthesized constructor
     auto firstDecl = moduleDeclReflection->getChild(0);
     SLANG_CHECK(firstDecl->getKind() == slang::DeclReflection::Kind::Struct);
-    SLANG_CHECK(firstDecl->getChildrenCount() == 1);
+    SLANG_CHECK(firstDecl->getChildrenCount() == 2);
 
     {
         slang::TypeReflection* type = firstDecl->getType();


### PR DESCRIPTION
First PR for #5192.

This is the first change to implement part of SP004, what this change does:

1. We synthesize a member-wise constructor for each struct follow the rules described in SP004.

2. Add logic to translate the initialize list to constructor invoke

TODO: what needs to be done next

1. We didn't fill the body of the synthesized constructor
  - This is relative easy task.

2. The fall back to legacy initialize list logic is not done
  - I found out that it's straight forward to put this logic after ResolveInvoke() call, because after ResolveInvoke() we will need to do a final 'coerce()' check to determine whether the candidate is applicable to use. If that fails, we can do the C-Style struct check and fall back to legacy logic.

3. Should we enable this for stdlib as well?
  - Our stdlib has some syntax that external users cannot use, so whether this change could break anything is unknown for now. It needs some extra effort to investigate and debugging the potential compile issue.