### PR TITLE
Use user defined type name in glsl buffer declarations.

### DIFF
--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -454,9 +454,8 @@ void GLSLSourceEmitter::_emitGLSLParameterGroup(IRGlobalParam* varDecl, IRUnifor
     }
 
     // Generate a name for the block.
-    m_writer->emit("block_");
-    m_writer->emit(getName(type->getElementType()));
-
+    m_writer->emit(_generateUniqueName(
+        (StringBuilder() << "block_" << getUnmangledName(type->getElementType()).getUnownedSlice()).getUnownedSlice()));
 
     auto elementType = type->getElementType();
     auto structType = as<IRStructType>(elementType);

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -453,7 +453,8 @@ void GLSLSourceEmitter::_emitGLSLParameterGroup(IRGlobalParam* varDecl, IRUnifor
         m_writer->emit(") uniform ");
     }
 
-    // Generate a dummy name for the block
+    // Generate a name for the block.
+    m_writer->emit("block_");
     m_writer->emit(getName(type->getElementType()));
 
 

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -454,8 +454,7 @@ void GLSLSourceEmitter::_emitGLSLParameterGroup(IRGlobalParam* varDecl, IRUnifor
     }
 
     // Generate a dummy name for the block
-    m_writer->emit("_S");
-    m_writer->emit(m_uniqueIDCounter++);
+    m_writer->emit(getName(type->getElementType()));
 
 
     auto elementType = type->getElementType();

--- a/tests/bindings/hlsl-to-vulkan-global-binding.hlsl
+++ b/tests/bindings/hlsl-to-vulkan-global-binding.hlsl
@@ -5,7 +5,7 @@
 // CHECK: layout(binding = 1)
 // CHECK: uniform sampler sampler_0;
 // CHECK: layout(binding = 5, set = 9)
-// CHECK: layout(std140) uniform _S1
+// CHECK: layout(std140) uniform block_
 
 uniform int a;
 uniform float b;

--- a/tests/cross-compile/texture-load.slang
+++ b/tests/cross-compile/texture-load.slang
@@ -3,7 +3,7 @@
 // Confirm that texture `Load` operations yield the
 // expected type when compiled to SPIR-V.
 
-//TEST:CROSS_COMPILE:-target spirv-assembly -entry main -stage compute
+//TEST:SIMPLE(filecheck=CHECK):-target spirv-assembly -entry main -stage compute -emit-spirv-via-glsl
 
 Texture2D<float2>   inputTexture;
 RWTexture2D<float2> outputTexture;
@@ -12,6 +12,8 @@ cbuffer C
 {
 	int2 pos;
 }
+
+// CHECK: OpImageWrite
 
 [numthreads(16, 16, 1)]
 void main(uint2 pixelIndex : SV_DispatchThreadID)


### PR DESCRIPTION
Closes #5056.