### PR TITLE
Fix release build failure

### DIFF
--- a/cmake/SlangTarget.cmake
+++ b/cmake/SlangTarget.cmake
@@ -390,35 +390,29 @@ function(slang_add_target dir type)
     #
     # Mark for installation
     #
-    if(ARG_INSTALL OR ARG_INSTALL_COMPONENT)
-        set(component_args)
-        if(ARG_INSTALL_COMPONENT)
-            set(component_args COMPONENT ${ARG_INSTALL_COMPONENT})
-        endif()
-        set(exclude_arg)
-        if(NOT ARG_INSTALL)
-            set(exclude_arg EXCLUDE_FROM_ALL)
-        endif()
+    macro(i)
         install(
             TARGETS ${target}
             EXPORT SlangTargets
             ARCHIVE
             DESTINATION ${archive_subdir}
-            ${component_args}
-            ${exclude_arg}
+            ${ARGN}
             LIBRARY
             DESTINATION ${library_subdir}
-            ${component_args}
-            ${exclude_arg}
+            ${ARGN}
             RUNTIME
             DESTINATION ${runtime_subdir}
-            ${component_args}
-            ${exclude_arg}
+            ${ARGN}
             PUBLIC_HEADER
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-            ${component_args}
-            ${exclude_arg}
+            ${ARGN}
         )
+    endmacro()
+    if(ARG_INSTALL)
+        i()
+    endif()
+    if(ARG_INSTALL_COMPONENT)
+        i(EXCLUDE_FROM_ALL COMPONENT ${ARG_INSTALL_COMPONENT})
     endif()
 endfunction()
 

--- a/source/slang-stdlib/CMakeLists.txt
+++ b/source/slang-stdlib/CMakeLists.txt
@@ -87,6 +87,8 @@ add_custom_command(
     VERBATIM
 )
 
+add_custom_target(generate_stdlib_headers DEPENDS ${stdlib_meta_generated_headers})
+
 #
 # Generate embedded stdlib source
 #
@@ -106,6 +108,7 @@ set(stdlib_source_common_args
     EXPLICIT_SOURCE 
       ./slang-embedded-stdlib-source.cpp
       ${stdlib_meta_generated_headers}
+    REQUIRES generate_stdlib_headers
     EXTRA_COMPILE_DEFINITIONS_PRIVATE SLANG_EMBED_STDLIB_SOURCE
     INCLUDE_DIRECTORIES_PRIVATE 
       ${stdlib_meta_output_dir}

--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -179,8 +179,6 @@ set(slang_build_args
         # a warning is disabled for a memset boundary check.
         # everything looked fine and it is unclear why the checking fails
         $<$<CXX_COMPILER_ID:GNU>:-Wno-error=stringop-overflow>
-    # slang.h is in the project root, so include that directory in the interface
-    # for slang
     INCLUDE_DIRECTORIES_PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/slang-version-header
     EXPORT_MACRO_PREFIX SLANG
     EXPORT_TYPE_AS ${SLANG_LIB_TYPE} 
@@ -198,11 +196,13 @@ set(slang_link_args
         SPIRV-Headers
 )
 set(slang_interface_args
+    # slang.h is in the project root, so include that directory in the interface
+    # for slang
     INCLUDE_DIRECTORIES_PUBLIC ${slang_SOURCE_DIR}
 ) 
 set(slang_public_lib_args
     PUBLIC_HEADERS 
-        ${slang_SOURCE_DIR}/slang*.h 
+        ${slang_SOURCE_DIR}/include/slang*.h 
         ${CMAKE_CURRENT_BINARY_DIR}/slang-version-header/*.h
     LINK_WITH_PRIVATE
         $<IF:$<BOOL:${SLANG_EMBED_STDLIB}>,slang-embedded-stdlib,slang-no-embedded-stdlib>
@@ -229,6 +229,7 @@ if(NOT SLANG_EMBED_STDLIB)
         ${slang_link_args}
         ${slang_interface_args}
         ${slang_public_lib_args}
+        INSTALL_COMPONENT generators
     )
     add_library(slang-without-embedded-stdlib ALIAS slang) 
 else()
@@ -256,6 +257,9 @@ else()
             slang-common-objects
             slang-no-embedded-stdlib 
             slang-embedded-stdlib-source
+        OUTPUT_DIR generators
+        FOLDER generators
+        INSTALL_COMPONENT generators
     )
     slang_add_target(
         .


### PR DESCRIPTION
Install slang shared object when we build just the generators, this config is used for release builds where we need to build generators separately to accommodate cross compiling