### PR TITLE
Fix D3D12Core.dll loading problem for debug build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,13 +487,21 @@ endif()
 
 if(SLANG_ENABLE_PREBUILT_BINARIES)
     if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+        # DX Agility SDK requires the D3D12*.DLL files to be placed under a sub-directory, "D3D12".
+        # https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/#d3d12sdkpath-should-not-be-the-same-directory-as-the-application-exe
         file(GLOB prebuilt_binaries "${CMAKE_SOURCE_DIR}/external/slang-binaries/bin/windows-x64/*")
+        file(GLOB prebuilt_d3d12_binaries "${CMAKE_SOURCE_DIR}/external/slang-binaries/bin/windows-x64/[dD]3[dD]12*")
+        list(REMOVE_ITEM prebuilt_binaries ${prebuilt_d3d12_binaries})
         add_custom_target(
             copy-prebuilt-binaries ALL
             COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/$<CONFIG>/${runtime_subdir}
             COMMAND ${CMAKE_COMMAND} -E copy_if_different 
                 ${prebuilt_binaries}
                 ${CMAKE_BINARY_DIR}/$<CONFIG>/${runtime_subdir}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/$<CONFIG>/${runtime_subdir}/D3D12
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                ${prebuilt_d3d12_binaries}
+                ${CMAKE_BINARY_DIR}/$<CONFIG>/${runtime_subdir}/D3D12
             VERBATIM
         )
     endif()

--- a/source/core/slang-render-api-util.cpp
+++ b/source/core/slang-render-api-util.cpp
@@ -267,17 +267,9 @@ static bool _canLoadSharedLibrary(const char* libName)
 #if SLANG_WINDOWS_FAMILY
         case RenderApiType::Vulkan: return _canLoadSharedLibrary("vulkan-1") || _canLoadSharedLibrary("vk_swiftshader");
         case RenderApiType::WebGPU:
-#if _DEBUG
-            // At the moment, some CI issue is preventing tests to run in Debug builds.
-            // As a work-around in order to allow us to enable tests in Release builds ASSP,
-            // we skip WebGPU tests in by returning false here.
-            // https://github.com/shader-slang/slang/issues/5233#issuecomment-2411380030
-            return false;
-#else
             return _canLoadSharedLibrary("webgpu_dawn") &&
                 _canLoadSharedLibrary("dxcompiler") &&
                 _canLoadSharedLibrary("dxil");
-#endif // if SLANG_DEBUG
 #elif SLANG_APPLE_FAMILY
         case RenderApiType::Vulkan: return true;
         case RenderApiType::Metal:  return true;

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -122,6 +122,9 @@ void ShaderCompilerUtil::Output::reset()
         case SLANG_SOURCE_LANGUAGE_CUDA:
             spAddPreprocessorDefine(slangRequest, "__CUDA__", "1");
             break;
+        case SLANG_SOURCE_LANGUAGE_WGSL:
+            spAddPreprocessorDefine(slangRequest, "__WGSL__", "1");
+            break;
 
         default:
             assert(!"unexpected");

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1132,7 +1132,8 @@ static SlangResult _extractRenderTestRequirements(const CommandLine& cmdLine, Te
             break;
         case RenderApiType::WebGPU:
             target = SLANG_WGSL;
-            SLANG_ASSERT(!usePassthru);
+            nativeLanguage = SLANG_SOURCE_LANGUAGE_WGSL;
+            passThru = SLANG_PASS_THROUGH_TINT;
             break;
     }
 
@@ -4661,6 +4662,7 @@ SlangResult innerMain(int argc, char** argv)
             for (auto& test : context.failedFileTests)
             {
                 FileTestInfoImpl* fileTestInfo = static_cast<FileTestInfoImpl*>(test.Ptr());
+                TestReporter::SuiteScope suiteScope(&reporter, "tests");
                 TestReporter::TestScope scope(&reporter, fileTestInfo->testName);
                 reporter.addResult(TestResult::Fail);
             }


### PR DESCRIPTION
D3D12Core.dll had been copied to a wrong directory and slang has been using D3D12Core.dll from the system directory, C:\windows\system32.

D3D12Core.dll has to be copied from `external/slang-binaries/bin/windows-x64` to `build/Release/bin/D3D12` not to `build/Release/bin`.
The same is true for the debug build and it had to be copied to `build/Debug/bin/D3D12` not `build/Debug/bin`.

It hasn't been a problem for Release build, because the debug-layer is not enabled for Release build and it didn't cause the version mismatching problem with D3D12SDKLayers.dll. The Release build was loaded from either `build/Release/bin` or from `C:\windows\system32`, and it didn't matter which one was used.

The Debug build, however, got into a problem where D3D12Core.dll was loaded from the system directory whereas D3D12SDKLayers.dll was loaded from `build/Debug/bin` and it failed to load D3D12.dll entirely. This caused D3D12 to be "Not supported" for "Windows/Debug" configuration. Note that our CI explicitly excludes DX12 tests for the "Windows/Debug" configuration with a command-line argument "-api all-dx12", and DX12 tests were going to be ignored anyway.

The actual problem was observed when WGPU is implemented. WGPU started printing explicit errors for the load failure of D3D12.dll.

See more detailed explanation:
  https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/#d3d12sdkpath-should-not-be-the-same-directory-as-the-application-exe

Closes #5305
Closes #5276 