### PR TITLE
Fix entrypoint naming in glsl backend.

### DIFF
--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -1085,7 +1085,19 @@ String CLikeSourceEmitter::generateName(IRInst* inst)
             // use the appropriate options for glslang to
             // make it support a non-`main` name.
             //
-            return "main";
+            // A function may have an entry-point deocration if it
+            // is declared by the user as an entry-point function.
+            // However it may not actually be compiled as an entry-point
+            // when generating code for targets that doesn't support
+            // multiple entry-points.
+            // We only want to emit "main" for user-marked entrypoint
+            // functions that are actually being selected as entrypoint
+            // for current compilation. We can do so by checking if
+            // a layout decoration existed on the function.
+            if (inst->findDecoration<IRLayoutDecoration>())
+            {
+                return "main";
+            }
         }
 
         return generateEntryPointNameImpl(entryPointDecor);

--- a/tools/slang-unit-test/unit-test-find-entrypoint-nested.cpp
+++ b/tools/slang-unit-test/unit-test-find-entrypoint-nested.cpp
@@ -22,6 +22,7 @@ SLANG_UNIT_TEST(findEntryPointNested)
         [shader("raygeneration")]
         void inner()
         {
+            AllMemoryBarrier();
         }
         [shader("raygeneration")]
         void outer()
@@ -40,6 +41,13 @@ SLANG_UNIT_TEST(findEntryPointNested)
     slang::SessionDesc sessionDesc = {};
     sessionDesc.targetCount = 1;
     sessionDesc.targets = &targetDesc;
+    sessionDesc.compilerOptionEntryCount = 1;
+    slang::CompilerOptionEntry compilerOptionEntry = {};
+    compilerOptionEntry.name = slang::CompilerOptionName::EmitSpirvViaGLSL;
+    compilerOptionEntry.value.kind = slang::CompilerOptionValueKind::Int;
+    compilerOptionEntry.value.intValue0 = 1;
+    sessionDesc.compilerOptionEntries = &compilerOptionEntry;
+
     ComPtr<slang::ISession> session;
     SLANG_CHECK(globalSession->createSession(sessionDesc, session.writeRef()) == SLANG_OK);
 


### PR DESCRIPTION
When there is
```
[shader("compute")]
void inner() { ... }

[shader("compute")]
void outer() { inner(); }
```

And the user trys to compile `outer` to glsl, we are currently generating two functions named `main` in the output glsl because both functions are marked as entrypoint, and there is the logic to emit all entrypoints as `main`. This is wrong if a user-declared entrypoint isn't being selected as the entrypoint in the current compilation session.