### PR TITLE
DO NOT REVIEW YET: Proper fix for COMPARE_HLSL_RENDER and WGPU API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,13 +487,21 @@ endif()
 
 if(SLANG_ENABLE_PREBUILT_BINARIES)
     if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+        # DX Agility SDK requires the D3D12*.DLL files to be placed under a sub-directory, "D3D12".
+        # https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/#d3d12sdkpath-should-not-be-the-same-directory-as-the-application-exe
         file(GLOB prebuilt_binaries "${CMAKE_SOURCE_DIR}/external/slang-binaries/bin/windows-x64/*")
+        file(GLOB prebuilt_d3d12_binaries "${CMAKE_SOURCE_DIR}/external/slang-binaries/bin/windows-x64/[dD]3[dD]12*")
+        list(REMOVE_ITEM prebuilt_binaries ${prebuilt_d3d12_binaries})
         add_custom_target(
             copy-prebuilt-binaries ALL
             COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/$<CONFIG>/${runtime_subdir}
             COMMAND ${CMAKE_COMMAND} -E copy_if_different 
                 ${prebuilt_binaries}
                 ${CMAKE_BINARY_DIR}/$<CONFIG>/${runtime_subdir}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/$<CONFIG>/${runtime_subdir}/D3D12
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                ${prebuilt_d3d12_binaries}
+                ${CMAKE_BINARY_DIR}/$<CONFIG>/${runtime_subdir}/D3D12
             VERBATIM
         )
     endif()

--- a/source/core/slang-render-api-util.cpp
+++ b/source/core/slang-render-api-util.cpp
@@ -267,17 +267,9 @@ static bool _canLoadSharedLibrary(const char* libName)
 #if SLANG_WINDOWS_FAMILY
         case RenderApiType::Vulkan: return _canLoadSharedLibrary("vulkan-1") || _canLoadSharedLibrary("vk_swiftshader");
         case RenderApiType::WebGPU:
-#if _DEBUG
-            // At the moment, some CI issue is preventing tests to run in Debug builds.
-            // As a work-around in order to allow us to enable tests in Release builds ASSP,
-            // we skip WebGPU tests in by returning false here.
-            // https://github.com/shader-slang/slang/issues/5233#issuecomment-2411380030
-            return false;
-#else
             return _canLoadSharedLibrary("webgpu_dawn") &&
                 _canLoadSharedLibrary("dxcompiler") &&
                 _canLoadSharedLibrary("dxil");
-#endif // if SLANG_DEBUG
 #elif SLANG_APPLE_FAMILY
         case RenderApiType::Vulkan: return true;
         case RenderApiType::Metal:  return true;

--- a/tests/bugs/texture2d-gather.hlsl
+++ b/tests/bugs/texture2d-gather.hlsl
@@ -1,5 +1,4 @@
 //TEST(smoke):COMPARE_HLSL_RENDER:
-//DISABLE_TEST(smoke):COMPARE_HLSL_RENDER:-mtl
 //TEST_INPUT: Texture2D(size=16, content=chessboard, format=R32_FLOAT):name g_texture
 //TEST_INPUT: Sampler :name g_sampler
 

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -122,6 +122,9 @@ void ShaderCompilerUtil::Output::reset()
         case SLANG_SOURCE_LANGUAGE_CUDA:
             spAddPreprocessorDefine(slangRequest, "__CUDA__", "1");
             break;
+        case SLANG_SOURCE_LANGUAGE_WGSL:
+            spAddPreprocessorDefine(slangRequest, "__WGSL__", "1");
+            break;
 
         default:
             assert(!"unexpected");

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1132,7 +1132,8 @@ static SlangResult _extractRenderTestRequirements(const CommandLine& cmdLine, Te
             break;
         case RenderApiType::WebGPU:
             target = SLANG_WGSL;
-            SLANG_ASSERT(!usePassthru);
+            nativeLanguage = SLANG_SOURCE_LANGUAGE_WGSL;
+            passThru = SLANG_PASS_THROUGH_TINT;
             break;
     }
 
@@ -4661,6 +4662,7 @@ SlangResult innerMain(int argc, char** argv)
             for (auto& test : context.failedFileTests)
             {
                 FileTestInfoImpl* fileTestInfo = static_cast<FileTestInfoImpl*>(test.Ptr());
+                TestReporter::SuiteScope suiteScope(&reporter, "tests");
                 TestReporter::TestScope scope(&reporter, fileTestInfo->testName);
                 reporter.addResult(TestResult::Fail);
             }

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -3357,6 +3357,15 @@ TestResult doRenderComparisonTestRun(TestContext* context, TestInput& input, cha
 
     for( auto arg : input.testOptions->args )
     {
+        if (arg.getLength() && arg[0] == '-')
+        {
+            UnownedStringSlice argName = UnownedStringSlice(arg.begin() + 1, arg.end());
+            RenderApiType renderApiType = RenderApiUtil::findApiTypeByName(argName);
+            bool apiFound = (renderApiType != RenderApiType::Unknown);
+            if (apiFound)
+                continue; // API name is already handled in runHLSLRenderComparisonTest()
+        }
+
         cmdLine.addArg(arg);
     }
 
@@ -3615,7 +3624,23 @@ TestResult runHLSLRenderComparisonTestImpl(
 
 TestResult runHLSLRenderComparisonTest(TestContext* context, TestInput& input)
 {
-    return runHLSLRenderComparisonTestImpl(context, input, "-hlsl", "-slang");
+    String apiActual = "-slang";
+    for (auto arg : input.testOptions->args)
+    {
+        if (arg.getLength() && arg[0] == '-')
+        {
+            UnownedStringSlice argName = UnownedStringSlice(arg.begin() + 1, arg.end());
+            RenderApiType renderApiType = RenderApiUtil::findApiTypeByName(argName);
+            bool apiFound = (renderApiType != RenderApiType::Unknown);
+            if (apiFound)
+            {
+                apiActual = arg;
+                break;
+            }
+        }
+    }
+
+    return runHLSLRenderComparisonTestImpl(context, input, "-hlsl", apiActual.getBuffer());
 }
 
 TestResult runHLSLCrossCompileRenderComparisonTest(TestContext* context, TestInput& input)


### PR DESCRIPTION
Closes #5276

The issue turned out to be related to the use of `COMPARE_HLSL_RENDER` keyword in the file, `tests/bugs/texture2d-gather.hlsl`.
The fact that the file has an extension, ".hlsl", was unrelated to the issue.

The [document](https://github.com/shader-slang/slang/blob/master/tools/slang-test/README.md#test-types) describes what `COMPARE_HLSL_RENDER` does as following,
> Runs 'render-test' rendering two images - one for hlsl (expected), and one for slang saving to .png files. The images must match for the test to pass.

Basically, it compiles the given shader with DXC compiler and generate an output image.
And then it compiles with each and every render API and generate an output image and compare it to the output from DXC.

The problem is on how the input arguments are generated when rendering for metal and wgpu.
The command-line argument for rendering with DXC is, as an example,
```
-wgpu -hlsl -o .expected.png
```
And the command-line argument for rendering with WGPU API is,
```
-wgpu -slang -o .actual.png
```

The first set of arguments conflict in a way that "-wgpu" instructs to use Tint as the renderer at the same time, it tells to use DXC compile with the next argument, "-hlsl". In this case, "-wgpu" should be ignored.
The second set is kind of O.K, because "-slang" and "-wgpu" don't conflict. "-slang" instructs to treat the input as slang shader and "-wgpu" instructs to use WGPU as the output render API.









