### PR TITLE
Cross compilation using cmake toolchain file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,14 +68,12 @@ jobs:
       - name: Change dev tools to host arch (linux and macos)
         run: |
           if [[ "${{matrix.os}}" == linux* && "${{matrix.platform}}" == "aarch64" && "$(uname -m)" != "aarch64" ]]; then
-            export CC=aarch64-linux-gnu-gcc
-            export CXX=aarch64-linux-gnu-g++
+            export CMAKE_TOOLCHAIN_FILE=cmake/ubuntu-cross-aarch64.cmake
           fi
           CMAKE_OSX_ARCHITECTURES="${{matrix.platform}}"
           CMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES//aarch64/arm64}
 
-          echo "CC=$CC" >> "$GITHUB_ENV"
-          echo "CXX=$CXX" >> "$GITHUB_ENV"
+          echo "CMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE" >> "$GITHUB_ENV"
           echo "CMAKE_OSX_ARCHITECTURES=$CMAKE_OSX_ARCHITECTURES" >> "$GITHUB_ENV"
 
       - name: Build Slang

--- a/cmake/ubuntu-cross-aarch64.cmake
+++ b/cmake/ubuntu-cross-aarch64.cmake
@@ -1,0 +1,13 @@
+# Target operating system / architecture.
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+# C/C++ compiler.
+set(CMAKE_C_COMPILER "/usr/bin/aarch64-linux-gnu-gcc")
+set(CMAKE_CXX_COMPILER "/usr/bin/aarch64-linux-gnu-g++")
+
+# Adjust the default behavior of the FIND_XXX() commands:
+# search programs in the host environment only.
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+


### PR DESCRIPTION
Using `CMAKE_TOOLCHAIN_FILE` to setup cross compilation to aarch64 on Ubuntu. This allows to properly set the `CMAKE_SYSTEM_PROCESSOR` value to the target processor architecture, fixing issues when building `slang-rhi` which depends on that cmake system value.