### PR TITLE
Fix UAV access for 3d texture mips

### DIFF
--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -1569,7 +1569,7 @@ Result DeviceImpl::createTextureView(
             d3d12desc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE3D;
             d3d12desc.Texture3D.MipSlice = desc.subresourceRange.mipLevel;
             d3d12desc.Texture3D.FirstWSlice = desc.subresourceRange.baseArrayLayer;
-            d3d12desc.Texture3D.WSize = resourceDesc.size.depth;
+            d3d12desc.Texture3D.WSize = resourceDesc.size.depth >> desc.subresourceRange.mipLevel;
             break;
         default:
             return SLANG_FAIL;


### PR DESCRIPTION
Correctly adjust WSize when accessing none-zero mip level of a 3D texture.

WSize is now calculated correctly by shifting down the depth. In theory WSize could probably be set to -1, however the mip0 case already works, so I see no reason to mess with it.