### PR TITLE
Fix several bugs with `specializeWithArgTypes()`

### DIFF
--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -2281,6 +2281,8 @@ namespace Slang
             Expr*               funcExpr,
             List<Type*>         argTypes,
             DiagnosticSink*     sink);
+        
+        bool isSpecialized(DeclRef<Decl> declRef);
 
         DiagnosticSink::Flags diagnosticSinkFlags = 0;
 

--- a/source/slang/slang-reflection-api.cpp
+++ b/source/slang/slang-reflection-api.cpp
@@ -808,9 +808,9 @@ SlangReflectionFunction* tryConvertExprToFunctionReflection(ASTBuilder* astBuild
         auto declRef = declRefExpr->declRef;
         if (auto genericDeclRef = declRef.as<GenericDecl>())
         {
-            auto innerDeclRef = substituteDeclRef(
-                SubstitutionSet(genericDeclRef), astBuilder, genericDeclRef.getDecl()->inner);
-            declRef = createDefaultSubstitutionsIfNeeded(astBuilder, nullptr, innerDeclRef);
+            auto innerDeclRef = createDefaultSubstitutionsIfNeeded(astBuilder, nullptr, genericDeclRef.getDecl()->inner);
+            declRef = substituteDeclRef(
+                SubstitutionSet(genericDeclRef), astBuilder, innerDeclRef);
         }
 
         if (auto funcDeclRef = declRef.as<FunctionDeclBase>())

--- a/source/slang/slang-reflection-api.cpp
+++ b/source/slang/slang-reflection-api.cpp
@@ -3194,7 +3194,12 @@ SLANG_API SlangReflectionFunction* spReflectionFunction_specializeWithArgTypes(
     try 
     {
         DiagnosticSink sink(linkage->getSourceManager(), Lexer::sourceLocationLexer);
-        return convert(linkage->specializeWithArgTypes(funcExpr, argTypeList, &sink).as<FunctionDeclBase>());
+        auto resultFunc = linkage->specializeWithArgTypes(funcExpr, argTypeList, &sink).as<FunctionDeclBase>();
+
+        if (sink.getErrorCount() != 0)
+            return nullptr; // Failed coercion.
+
+        return convert(resultFunc);
     }
     catch (...)
     {

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -1418,6 +1418,19 @@ bool Linkage::isSpecialized(DeclRef<Decl> declRef)
     return false;
 }
 
+bool isFuncGeneric(DeclRef<Decl> declRef)
+{
+    if (auto funcDecl = as<FuncDecl>(declRef.getDecl()))
+    {
+        if (funcDecl->parentDecl && as<GenericDecl>(funcDecl->parentDecl))
+        {
+            return true;
+        }
+    }
+    
+    return false;
+}
+
 DeclRef<Decl> Linkage::specializeWithArgTypes(
     Expr*               funcExpr,
     List<Type*>         argTypes,
@@ -1430,7 +1443,7 @@ DeclRef<Decl> Linkage::specializeWithArgTypes(
     
     if (auto declRefFuncExpr = as<DeclRefExpr>(funcExpr))
     {
-        if (!isSpecialized(declRefFuncExpr->declRef))
+        if (isFuncGeneric(declRefFuncExpr->declRef) && !isSpecialized(declRefFuncExpr->declRef))
         {
             if (auto genericDeclRef = getGenericParentDeclRef(
                 getCurrentASTBuilder(),
@@ -1454,6 +1467,7 @@ DeclRef<Decl> Linkage::specializeWithArgTypes(
         //
         auto argExpr = getCurrentASTBuilder()->create<VarExpr>();
         argExpr->type = argType;
+        argExpr->type.isLeftValue = true;
         argExprs.add(argExpr);
     }
 


### PR DESCRIPTION
- Adds a check for methods that are already specialized.
- Fixes an issue where thread-local ast-builder is not available,  causing more complex specialization checks to crash
- Use the diagnostic sink to decide if the resolution was successful.
- Add some more cases to the reflection unit-tests

Fixes: https://github.com/shader-slang/slang/issues/5378