### PR TITLE
Recognize a new spirv header json grammar keyword "aliases"

### DIFF
--- a/source/compiler-core/slang-spirv-core-grammar.cpp
+++ b/source/compiler-core/slang-spirv-core-grammar.cpp
@@ -60,6 +60,7 @@ struct Enumerant
     UnownedStringSlice enumerant;
     JSONValue value;
     List<UnownedStringSlice> capabilities;
+    List<UnownedStringSlice> aliases;
     // List<Operand> parameters;
     // UnownedStringSlice version;
     // UnownedStringSlice lastVersion;
@@ -70,6 +71,7 @@ SLANG_MAKE_STRUCT_RTTI_INFO(
     SLANG_RTTI_FIELD(enumerant),
     SLANG_RTTI_FIELD(value),
     SLANG_OPTIONAL_RTTI_FIELD(capabilities),
+    SLANG_OPTIONAL_RTTI_FIELD(aliases),
     // SLANG_OPTIONAL_RTTI_FIELD(parameters),
     // SLANG_OPTIONAL_RTTI_FIELD(version),
     // SLANG_OPTIONAL_RTTI_FIELD(lastVersion),
@@ -152,6 +154,11 @@ static Dictionary<UnownedStringSlice, SpvWord> operandKindToDict(
                 );
         }
         dict.add(e.enumerant, valueInt);
+
+        for (auto alias : e.aliases)
+        {
+            dict.add(alias, valueInt);
+        }
     }
     return dict;
 }

--- a/tools/slang-lookup-generator/lookup-generator-main.cpp
+++ b/tools/slang-lookup-generator/lookup-generator-main.cpp
@@ -38,6 +38,7 @@ static List<String> extractOpNames(UnownedStringSlice& error, const JSONValue& v
     // List<String> result = match(myJSONValue, "instructions", AsArray, "opname", AsString);
     const auto instKey = container.findKey(UnownedStringSlice("instructions"));
     const auto opnameKey = container.findKey(UnownedStringSlice("opname"));
+    const auto aliasesKey = container.findKey(UnownedStringSlice("aliases"));
     if (!instKey)
     {
         error = UnownedStringSlice("JSON parsing failed, no \"instructions\" key\n");
@@ -64,6 +65,18 @@ static List<String> extractOpNames(UnownedStringSlice& error, const JSONValue& v
             return {};
         }
         opnames.add(container.getString(opname));
+
+        if (aliasesKey)
+        {
+            auto aliases = container.findObjectValue(inst, aliasesKey);
+            if (aliases.isValid() && aliases.type == JSONValue::Type::Array)
+            {
+                for (auto& alias : container.getArray(aliases))
+                {
+                    opnames.add(container.getString(alias));
+                }
+            }
+        }
     }
 
     return opnames;


### PR DESCRIPTION
Closes https://github.com/shader-slang/slang/issues/5350

This commit will handle the new JSON keyword "aliases" in SPIRV-Header grammar files.

"aliases" are used in two places: one for "opname" and another for "enumerants".

This commit itself wouldn't do anything until we integrate new commits from SPIRV-Header repo.