### PR TITLE
Use DebugDeclare instead of DebugValue.

### DIFF
--- a/source/slang/slang-emit-spirv-ops-debug-info-ext.h
+++ b/source/slang/slang-emit-spirv-ops-debug-info-ext.h
@@ -138,6 +138,14 @@ SpvInst* emitOpDebugValue(SpvInstParent* parent, IRInst* inst, const T& idResult
 }
 
 template<typename T, typename Ts>
+SpvInst* emitOpDebugDeclare(SpvInstParent* parent, IRInst* inst, const T& idResultType, SpvInst* set, SpvInst* debugLocalVar, IRInst* actualLocalVar, SpvInst* expression, const Ts& indices)
+{
+    static_assert(isSingular<T>);
+    static_assert(isPlural<Ts>);
+
+    return emitInst(parent, inst, SpvOpExtInst, idResultType, kResultID, set, SpvWord(28), debugLocalVar, actualLocalVar, expression, indices);
+}
+template<typename T, typename Ts>
 SpvInst* emitOpDebugExpression(SpvInstParent* parent, IRInst* inst, const T& idResultType, SpvInst* set, const Ts& operations)
 {
     static_assert(isSingular<T>);

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -3049,6 +3049,7 @@ struct SPIRVEmitContext
         {
             auto debugVarPtrType = builder.getPtrType(varType, AddressSpace::Function);
             auto actualHelperVar = emitOpVariable(parent, debugVar, debugVarPtrType, SpvStorageClassFunction);
+            maybeEmitPointerDecoration(actualHelperVar, debugVar);
             return actualHelperVar;
         }
         return nullptr;
@@ -4864,7 +4865,8 @@ struct SPIRVEmitContext
                     getSection(SpvLogicalSectionID::Annotations),
                     nullptr,
                     varInst,
-                    (inst->getOp() == kIROp_GlobalVar || inst->getOp() == kIROp_Var ? SpvDecorationAliasedPointer : SpvDecorationAliased)
+                    (inst->getOp() == kIROp_GlobalVar || inst->getOp() == kIROp_Var || inst->getOp() == kIROp_DebugVar
+                        ? SpvDecorationAliasedPointer : SpvDecorationAliased)
                 );
             }
         }

--- a/source/slang/slang-ir-addr-inst-elimination.cpp
+++ b/source/slang/slang-ir-addr-inst-elimination.cpp
@@ -170,6 +170,7 @@ struct AddressInstEliminationContext
                 case kIROp_GetElementPtr:
                 case kIROp_FieldAddress:
                 case kIROp_Unmodified:
+                case kIROp_DebugValue:
                     break;
                 default:
                     sink->diagnose(use->getUser()->sourceLoc, Diagnostics::unsupportedUseOfLValueForAutoDiff);

--- a/source/slang/slang-ir-insert-debug-value-store.cpp
+++ b/source/slang/slang-ir-insert-debug-value-store.cpp
@@ -172,36 +172,11 @@ namespace Slang
 
             // Helper func to insert debugValue updates.
             auto setDebugValue = [&](
-                IRInst* debugVar, IRInst* rootVar, IRInst* newValue,
-                ArrayView<IRInst*> accessChain, ArrayView<IRInst*> types)
+                IRInst* debugVar, IRInst* /*rootVar*/, IRInst* newValue,
+                ArrayView<IRInst*> accessChain, ArrayView<IRInst*> /*types*/)
                 {
-                    // SPIRV does not allow dynamic indices in DebugValue,
-                    // so we need to stop the access chain at the first dynamic index.
-                    Index i = 0;
-                    for (; i < accessChain.getCount(); i++)
-                    {
-                        if (as<IRStructKey>(accessChain[i]))
-                        {
-                            continue;
-                        }
-                        if (as<IRIntLit>(accessChain[i]))
-                        {
-                            continue;
-                        }
-                        break;
-                    }
-                    // If everything is static on the access chain, we can simply emit a DebugValue.
-                    if (i == accessChain.getCount())
-                    {
-                        builder.emitDebugValue(debugVar, newValue, accessChain);
-                        return;
-                    }
-
-                    // Otherwise we need to load the entire composite value starting at the dynamic index access chain
-                    // and set it.
-                    auto compositePtr = builder.emitElementAddress(rootVar, accessChain.head(i), types.head(i));
-                    auto compositeVal = builder.emitLoad(compositePtr);
-                    builder.emitDebugValue(debugVar, compositeVal, accessChain.head(i));
+                    auto ptr = builder.emitElementAddress(debugVar, accessChain);
+                    builder.emitDebugValue(ptr, newValue, ArrayView<IRInst*>());
                 };
             for (auto block : func->getBlocks())
             {

--- a/source/slang/slang-ir-insert-debug-value-store.cpp
+++ b/source/slang/slang-ir-insert-debug-value-store.cpp
@@ -136,8 +136,7 @@ namespace Slang
                     paramVal = builder.emitLoad(param);
                 if (paramVal)
                 {
-                    ArrayView<IRInst*> accessChain;
-                    builder.emitDebugValue(debugVar, paramVal, accessChain);
+                    builder.emitDebugValue(debugVar, paramVal);
                 }
                 paramIndex++;
             }
@@ -172,11 +171,11 @@ namespace Slang
 
             // Helper func to insert debugValue updates.
             auto setDebugValue = [&](
-                IRInst* debugVar, IRInst* /*rootVar*/, IRInst* newValue,
-                ArrayView<IRInst*> accessChain, ArrayView<IRInst*> /*types*/)
+                IRInst* debugVar, IRInst* newValue,
+                ArrayView<IRInst*> accessChain)
                 {
                     auto ptr = builder.emitElementAddress(debugVar, accessChain);
-                    builder.emitDebugValue(ptr, newValue, ArrayView<IRInst*>());
+                    builder.emitDebugValue(ptr, newValue);
                 };
             for (auto block : func->getBlocks())
             {
@@ -188,26 +187,24 @@ namespace Slang
                     if (auto storeInst = as<IRStore>(inst))
                     {
                         List<IRInst*> accessChain;
-                        List<IRInst*> types;
-                        auto varInst = getRootAddr(storeInst->getPtr(), accessChain, &types);
+                        auto varInst = getRootAddr(storeInst->getPtr(), accessChain);
                         IRInst* debugVar = nullptr;
                         if (mapVarToDebugVar.tryGetValue(varInst, debugVar))
                         {
                             builder.setInsertAfter(storeInst);
-                            setDebugValue(debugVar, varInst, storeInst->getVal(), accessChain.getArrayView(), types.getArrayView());
+                            setDebugValue(debugVar, storeInst->getVal(), accessChain.getArrayView());
                         }
                     }
                     else if (auto swizzledStore = as<IRSwizzledStore>(inst))
                     {
                         List<IRInst*> accessChain;
-                        List<IRInst*> types;
-                        auto varInst = getRootAddr(swizzledStore->getDest(), accessChain, &types);
+                        auto varInst = getRootAddr(swizzledStore->getDest(), accessChain);
                         IRInst* debugVar = nullptr;
                         if (mapVarToDebugVar.tryGetValue(varInst, debugVar))
                         {
                             builder.setInsertAfter(swizzledStore);
                             auto loadVal = builder.emitLoad(swizzledStore->getDest());
-                            setDebugValue(debugVar, varInst, loadVal, accessChain.getArrayView(), types.getArrayView());
+                            setDebugValue(debugVar, loadVal, accessChain.getArrayView());
                         }
                     }
                     else if (auto callInst = as<IRCall>(inst))
@@ -221,14 +218,13 @@ namespace Slang
                             if (!as<IRPtrTypeBase>(arg->getDataType()))
                                 continue;
                             List<IRInst*> accessChain;
-                            List<IRInst*> types;
-                            auto varInst = getRootAddr(arg, accessChain, &types);
+                            auto varInst = getRootAddr(arg, accessChain);
                             IRInst* debugVar = nullptr;
                             if (mapVarToDebugVar.tryGetValue(varInst, debugVar))
                             {
                                 builder.setInsertAfter(callInst);
                                 auto loadVal = builder.emitLoad(arg);
-                                setDebugValue(debugVar, varInst, loadVal, accessChain.getArrayView(), types.getArrayView());
+                                setDebugValue(debugVar, loadVal, accessChain.getArrayView());
                             }
                         }
                     }

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -3289,8 +3289,6 @@ struct IRDebugValue : IRInst
     IR_LEAF_ISA(DebugValue)
     IRInst* getDebugVar() { return getOperand(0); }
     IRInst* getValue() { return getOperand(1); }
-    UInt getAccessChainCount() { return getOperandCount() - 2; }
-    IRInst* getAccessChain(UInt index) { return getOperand(2 + index); }
 };
 
 struct IRDebugLocationDecoration : IRDecoration
@@ -3798,7 +3796,7 @@ public:
     IRInst* emitDebugSource(UnownedStringSlice fileName, UnownedStringSlice source);
     IRInst* emitDebugLine(IRInst* source, IRIntegerValue lineStart, IRIntegerValue lineEnd, IRIntegerValue colStart, IRIntegerValue colEnd);
     IRInst* emitDebugVar(IRType* type, IRInst* source, IRInst* line, IRInst* col, IRInst* argIndex = nullptr);
-    IRInst* emitDebugValue(IRInst* debugVar, IRInst* debugValue, ArrayView<IRInst*> accessChain);
+    IRInst* emitDebugValue(IRInst* debugVar, IRInst* debugValue);
 
         /// Emit an LiveRangeStart instruction indicating the referenced item is live following this instruction
     IRLiveRangeStart* emitLiveRangeStart(IRInst* referenced);

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -886,19 +886,13 @@ static LegalVal legalizeDebugVar(IRTypeLegalizationContext* context, LegalType t
 static LegalVal legalizeDebugValue(IRTypeLegalizationContext* context, LegalVal debugVar, LegalVal debugValue, IRDebugValue* originalInst)
 {
     // For now we just discard any special part and keep the ordinary part.
-    ShortList<IRInst*> accessChain;
-    for (UInt i = 0; i < originalInst->getAccessChainCount(); i++)
-    {
-        accessChain.add(originalInst->getAccessChain(i));
-    }
     switch (debugValue.flavor)
     {
     case LegalType::Flavor::simple:
         return LegalVal::simple(
             context->builder->emitDebugValue(
                 debugVar.getSimple(),
-                debugValue.getSimple(),
-                accessChain.getArrayView().arrayView));
+                debugValue.getSimple()));
     case LegalType::Flavor::none:
         return LegalVal();
     case LegalType::Flavor::pair:

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3334,12 +3334,11 @@ namespace Slang
         }
     }
 
-    IRInst* IRBuilder::emitDebugValue(IRInst* debugVar, IRInst* debugValue, ArrayView<IRInst*> accessChain)
+    IRInst* IRBuilder::emitDebugValue(IRInst* debugVar, IRInst* debugValue)
     {
         List<IRInst*> args;
         args.add(debugVar);
         args.add(debugValue);
-        args.addRange(accessChain);
         return emitIntrinsicInst(getVoidType(), kIROp_DebugValue, (UInt)args.getCount(), args.getBuffer());
     }
 

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3325,12 +3325,12 @@ namespace Slang
         if (argIndex)
         {
             IRInst* args[] = { source, line, col, argIndex };
-            return emitIntrinsicInst(type, kIROp_DebugVar, 4, args);
+            return emitIntrinsicInst(getPtrType(type), kIROp_DebugVar, 4, args);
         }
         else
         {
             IRInst* args[] = { source, line, col };
-            return emitIntrinsicInst(type, kIROp_DebugVar, 3, args);
+            return emitIntrinsicInst(getPtrType(type), kIROp_DebugVar, 3, args);
         }
     }
 

--- a/tests/spirv/debug-type-pointer-2.slang
+++ b/tests/spirv/debug-type-pointer-2.slang
@@ -18,7 +18,7 @@ uniform Problem probs;
 
 RWStructuredBuffer<float4> outputBuffer;
 [shader("compute")]
-float4 main()
+void main()
 {
     outputBuffer[0] = float(probs.getVal());
 }

--- a/tests/spirv/debug-type-pointer.slang
+++ b/tests/spirv/debug-type-pointer.slang
@@ -32,7 +32,6 @@ struct LinkedNode
 
 float test(LinkedNode *pNode)
 {
-    //SPV: DebugValue %pNodeNext
     LinkedNode *pNodeNext = pNode->pNext;
     return *(pNode->pValue) + pNodeNext->value;
 }


### PR DESCRIPTION
Closes #5398.

Fix missing DebugLine before loop conditions.
Fix duplicate DebugEntryPoint declarations.