### PR TITLE
Replace the word stdlib or standard-library with core-module for source code

### DIFF
--- a/prelude/slang-cpp-scalar-intrinsics.h
+++ b/prelude/slang-cpp-scalar-intrinsics.h
@@ -431,7 +431,7 @@ SLANG_FORCE_INLINE uint64_t U64_abs(uint64_t f) { return f; }
 SLANG_FORCE_INLINE uint64_t U64_min(uint64_t a, uint64_t b) { return a < b ? a : b; }
 SLANG_FORCE_INLINE uint64_t U64_max(uint64_t a, uint64_t b) { return a > b ? a : b; }
 
-// TODO(JS): We don't define countbits for 64bit in stdlib currently.
+// TODO(JS): We don't define countbits for 64bit in the core module currently.
 // It's not clear from documentation if it should return 32 or 64 bits, if it exists. 
 // 32 bits can always hold the result, and will be implicitly promoted. 
 SLANG_FORCE_INLINE uint32_t U64_countbits(uint64_t v)

--- a/prelude/slang-cuda-prelude.h
+++ b/prelude/slang-cuda-prelude.h
@@ -1348,7 +1348,7 @@ struct RWByteAddressBuffer
         memcpy((char*)data + index, &value, sizeof(T));
     }
     
-        /// Can be used in stdlib to gain access
+        /// Can be used in the core module to gain access
     template <typename T>
     SLANG_CUDA_CALL T* _getPtrAt(size_t index)
     {

--- a/source/slang-core-module/slang-embedded-core-module-source.cpp
+++ b/source/slang-core-module/slang-embedded-core-module-source.cpp
@@ -288,7 +288,7 @@ namespace Slang
         if (!coreLibraryCode)
         {
             StringBuilder sb;
-            const String path = getStdlibPath();
+            const String path = getCoreModulePath();
             #include "core.meta.slang.h"
             coreLibraryCode = StringBlob::moveCreate(sb);
         }
@@ -301,7 +301,7 @@ namespace Slang
 #if SLANG_EMBED_CORE_MODULE_SOURCE
         if (!hlslLibraryCode)
         {
-            const String path = getStdlibPath();
+            const String path = getCoreModulePath();
             StringBuilder sb;
             #include "hlsl.meta.slang.h"
             hlslLibraryCode = StringBlob::moveCreate(sb);
@@ -315,7 +315,7 @@ namespace Slang
 #if SLANG_EMBED_CORE_MODULE_SOURCE
         if (!autodiffLibraryCode)
         {
-            const String path = getStdlibPath();
+            const String path = getCoreModulePath();
             StringBuilder sb;
             #include "diff.meta.slang.h"
             autodiffLibraryCode = StringBlob::moveCreate(sb);
@@ -328,7 +328,7 @@ namespace Slang
     {
         if (!glslLibraryCode)
         {
-            const String path = getStdlibPath();
+            const String path = getCoreModulePath();
             StringBuilder sb;
             #include "glsl.meta.slang.h"
             glslLibraryCode = StringBlob::moveCreate(sb);

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -2405,12 +2405,12 @@ for (int isArray = 0; isArray <= 1; isArray++)
 for (int isMS = 0; isMS <= 1; isMS++) {
     if (isMS)
     {
-        if (shapeIndex != kStdlibShapeIndex2D)
+        if (shapeIndex != kCoreModule_ShapeIndex2D)
             continue;
     }
     if (isArray)
     {
-        if (shapeIndex == kStdlibShapeIndex3D)
+        if (shapeIndex == kCoreModule_ShapeIndex3D)
             continue;
     }
     auto shapeTypeName = kTextureShapeTypeNames[shapeIndex];
@@ -3025,7 +3025,7 @@ extension _Texture<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,format>
 {
 //@hidden:
     static const int isMS = 0;
-    static const int access = $(kStdlibResourceAccessReadOnly);
+    static const int access = $(kCoreModule_ResourceAccessReadOnly);
 //@public:
     __glsl_extension(GL_EXT_samplerless_texture_functions)
     [__readNone]
@@ -3258,7 +3258,7 @@ __generic<T, Shape: __ITextureShape, let isArray:int, let sampleCount:int, let i
 extension _Texture<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,format>
 {
 //@hidden:
-    static const int access = $(kStdlibResourceAccessReadOnly);
+    static const int access = $(kCoreModule_ResourceAccessReadOnly);
     static const int isMS = 1;
 //@public:
     __glsl_extension(GL_EXT_samplerless_texture_functions)
@@ -3432,7 +3432,7 @@ extension _Texture<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,format>
 
 // Load/Subscript for readwrite textures
 ${{{{
-    for (int access = kStdlibResourceAccessReadWrite; access<=kStdlibResourceAccessRasterizerOrdered; access++) {
+    for (int access = kCoreModule_ResourceAccessReadWrite; access <= kCoreModule_ResourceAccessRasterizerOrdered; access++) {
         const char* glslIntrinsic = "$cimageLoad($0, $1)$z";
         const char* glslIntrinsicOffset = "$cimageLoad($0, ($1)+($2))$z";
         const char* glslIntrinsicMS = "$cimageLoad($0, $1, $2)$z";
@@ -3748,7 +3748,7 @@ extension _Texture<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,format>
 }
 
 ${{{{
-if (access == kStdlibResourceAccessReadWrite) {
+if (access == kCoreModule_ResourceAccessReadWrite) {
 }}}}
 
 // RW MS textures.
@@ -3901,7 +3901,7 @@ extension _Texture<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,format>
 }
 
 ${{{{
-} // if (access == kStdlibResourceAccessReadWrite) // for RW MS textures.
+} // if (access == kCoreModule_ResourceAccessReadWrite) // for RW MS textures.
 } // for (access).
 }}}}
 
@@ -3983,13 +3983,13 @@ ${{{{
     for (int isArray = 0; isArray<=1; isArray++)
     for (int isMS = 0; isMS<=1; isMS++)
     for (int isCombined = 0; isCombined<=1; isCombined++)
-    for (int access = kStdlibResourceAccessReadOnly; access<=kStdlibResourceAccessFeedback; access++) {
-        if (access != kStdlibResourceAccessReadOnly)
+    for (int access = kCoreModule_ResourceAccessReadOnly; access <= kCoreModule_ResourceAccessFeedback; access++) {
+        if (access != kCoreModule_ResourceAccessReadOnly)
         {
             // No RW Cube.
-            if (shape == kStdlibShapeIndexCube) continue;
+            if (shape == kCoreModule_ShapeIndexCube) continue;
         }
-        if (access == kStdlibResourceAccessFeedback)
+        if (access == kCoreModule_ResourceAccessFeedback)
         {
             // Feedback only defined for Texture2D and Texture2DArray.
             if (shape != 1) continue;
@@ -3999,14 +3999,14 @@ ${{{{
         if (isMS)
         {
             // Only Texture2DMS.
-            if (shape != kStdlibShapeIndex2D)
+            if (shape != kCoreModule_ShapeIndex2D)
                 continue;
             // Only Texture2DMS or RWTexture2DMS.
-            if (access >= kStdlibShapeIndex3D)
+            if (access >= kCoreModule_ShapeIndex3D)
                 continue;
         }
         // No 3D Array.
-        if (shape == kStdlibShapeIndex3D && isArray == 1)
+        if (shape == kCoreModule_ShapeIndex3D && isArray == 1)
             continue;
         const char* textureTypeName = isCombined ? "Sampler" : "Texture";
 }}}}
@@ -9924,7 +9924,7 @@ __generic<T : __BuiltinIntegerType>
 [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, sm_4_0_version)]
 T max(T x, T y)
 {
-    // Note: a stdlib implementation of `max` (or `min`) will require splitting
+    // Note: a core module implementation of `max` (or `min`) will require splitting
     // floating-point and integer cases apart, because the floating-point
     // version needs to correctly handle the case where one of the inputs
     // is not-a-number.
@@ -15159,7 +15159,7 @@ struct BuiltInTriangleIntersectionAttributes
 // 10.2 Shaders
 
 // Right now new shader stages need to be added directly to the compiler
-// implementation, rather than being something that can be declared in the stdlib.
+// implementation, rather than being something that can be declared in the core module.
 
 // 10.3 - Intrinsics
 
@@ -16058,7 +16058,7 @@ struct SAMPLER_FEEDBACK_MIP_REGION_USED : __BuiltinSamplerFeedbackType {};
 // All of these objects are write-only resources that point to a special kind of unordered access view meant for sampler feedback.
 
 __generic<T:__BuiltinSamplerFeedbackType>
-extension _Texture<T,__Shape2D, 0, 0, 0, $(kStdlibResourceAccessFeedback), 0, 0, 0>
+extension _Texture<T,__Shape2D, 0, 0, 0, $(kCoreModule_ResourceAccessFeedback), 0, 0, 0>
 {
     // With Clamp
 
@@ -16138,7 +16138,7 @@ extension _Texture<T,__Shape2D, 0, 0, 0, $(kStdlibResourceAccessFeedback), 0, 0,
 };
 
 __generic<T:__BuiltinSamplerFeedbackType>
-extension _Texture<T,__Shape2D, 1, 0, 0, $(kStdlibResourceAccessFeedback), 0, 0, 0>
+extension _Texture<T,__Shape2D, 1, 0, 0, $(kCoreModule_ResourceAccessFeedback), 0, 0, 0>
 {
     // With Clamp
 
@@ -19254,7 +19254,7 @@ ${
 // We introduce a few convenience type aliases here,
 // which both keep our declarations simpler and easier
 // to understand, but which might *also* be useful to
-// users of the stdlib, so that they can write things
+// users of the standard module, so that they can write things
 // like `Texture2D.Footprint`, and also have auto-complete
 // help them find such members.
 //
@@ -19273,7 +19273,7 @@ ${
 // parameter to the query operation(s). We define
 // the GLSL functions here as intrinsics, so that
 // we can refer to them later in the definitions
-// of our stdlib operaitons.
+// of our standard module operaitons; not just in glsl module.
 //
 // Note: despite the GLSL extension defining the `granularity`
 // member of the query result as having type `uint`, the
@@ -19606,7 +19606,7 @@ for(auto levelChoice : kLevelChoices)
 
 ${
 // We now define the portable operations that will be officially
-// supported by the standard library. For each operation, we
+// supported by the standard module. For each operation, we
 // need to provide both a version that maps to the GLSL extension,
 // and a version that uses the NVAPI functions.
 //
@@ -19850,7 +19850,7 @@ ${{{{
 
 //<T, Shape: __ITextureShape, let isArray:int, let isMS:int, let sampleCount:int, let access:int, let isShadow:int, let isCombined:int, let format:int>
 __generic<Shape:__ITextureShape1D2D3D, let format : int>
-extension _Texture<float, Shape, 0, 0, 0, $(kStdlibResourceAccessReadWrite), 0, 0, format>
+extension _Texture<float, Shape, 0, 0, 0, $(kCoreModule_ResourceAccessReadWrite), 0, 0, format>
 {
     [__requiresNVAPI]
     [ForceInline]

--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -458,7 +458,7 @@ class Val : public NodeBase
     }
     List<ValNodeOperand> m_operands;
 
-    // Private use by stdlib deserialization only. Since we know the Vals serialized into stdlib is already
+    // Private use by the core module deserialization only. Since we know the Vals serialized into the core module is already
     // unique, we can just use `this` pointer as the `m_resolvedVal` so we don't need to resolve them again.
     void _setUnique();
 protected:

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -229,7 +229,7 @@ ASTBuilder::ASTBuilder(SharedASTBuilder* sharedASTBuilder, const String& name):
 {
     SLANG_ASSERT(sharedASTBuilder);
     // Copy Val deduplication map over so we don't create duplicate Vals that are already
-    // existent in the stdlib.
+    // existent in the core module.
     m_cachedNodes = sharedASTBuilder->getInnerASTBuilder()->m_cachedNodes;
 }
 

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -89,7 +89,7 @@ protected:
     Type* m_overloadedType = nullptr;
 
     // The following types are created lazily, such that part of their definition
-    // can be in the standard library
+    // can be in the core module.
     // 
     // Note(tfoley): These logically belong to `Type`,
     // but order-of-declaration stuff makes that tricky

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -24,7 +24,7 @@ class ParamModifier : public Modifier { SLANG_AST_CLASS(ParamModifier)};
 class ExternModifier : public Modifier { SLANG_AST_CLASS(ExternModifier)};
 class HLSLExportModifier : public Modifier { SLANG_AST_CLASS(HLSLExportModifier) };
 class TransparentModifier : public Modifier { SLANG_AST_CLASS(TransparentModifier)};
-class FromStdLibModifier : public Modifier { SLANG_AST_CLASS(FromStdLibModifier)};
+class FromCoreModuleModifier : public Modifier { SLANG_AST_CLASS(FromCoreModuleModifier)};
 class PrefixModifier : public Modifier { SLANG_AST_CLASS(PrefixModifier)};
 class PostfixModifier : public Modifier { SLANG_AST_CLASS(PostfixModifier)};
 class ExportedModifier : public Modifier { SLANG_AST_CLASS(ExportedModifier)};
@@ -1194,7 +1194,7 @@ class AnyValueSizeAttribute : public Attribute
     int32_t size;
 };
 
-    /// This is a stop-gap solution to break overload ambiguity in stdlib.
+    /// This is a stop-gap solution to break overload ambiguity in the core module.
     /// When there is a function overload ambiguity, the compiler will pick the one with higher rank
     /// specified by this attribute. An overload without this attribute will have a rank of 0.
     /// In the future, we should enhance our type system to take into account the "specialized"-ness

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -943,7 +943,7 @@ class EntryPointAttribute : public Attribute
 };
 
 // A `[__vulkanRayPayload(location)]` attribute, which is used in the
-// standard library implementation to indicate that a variable
+// core module implementation to indicate that a variable
 // actually represents the input/output interface for a Vulkan
 // ray tracing shader to pass per-ray payload information.
 class VulkanRayPayloadAttribute : public Attribute 
@@ -960,7 +960,7 @@ class VulkanRayPayloadInAttribute : public Attribute
 };
 
 // A `[__vulkanCallablePayload(location)]` attribute, which is used in the
-// standard library implementation to indicate that a variable
+// core module implementation to indicate that a variable
 // actually represents the input/output interface for a Vulkan
 // ray tracing shader to pass payload information to/from a callee.
 class VulkanCallablePayloadAttribute : public Attribute 
@@ -977,7 +977,7 @@ class VulkanCallablePayloadInAttribute : public Attribute
 };
 
 // A `[__vulkanHitAttributes]` attribute, which is used in the
-// standard library implementation to indicate that a variable
+// core module implementation to indicate that a variable
 // actually represents the output interface for a Vulkan
 // intersection shader to pass hit attribute information.
 class VulkanHitAttributesAttribute : public Attribute 
@@ -986,7 +986,7 @@ class VulkanHitAttributesAttribute : public Attribute
 };
 
 // A `[__vulkanHitObjectAttributes(location)]` attribute, which is used in the
-// standard library implementation to indicate that a variable
+// core module implementation to indicate that a variable
 // actually represents the attributes on a HitObject as part of
 // Shader ExecutionReordering
 class VulkanHitObjectAttributesAttribute : public Attribute

--- a/source/slang/slang-ast-type.cpp
+++ b/source/slang/slang-ast-type.cpp
@@ -1025,7 +1025,7 @@ SlangResourceShape ResourceType::getShape()
 
 bool ResourceType::isArray()
 {
-    auto isArray = _getGenericTypeArg(this, kStdlibTextureIsArrayParameterIndex);
+    auto isArray = _getGenericTypeArg(this, kCoreModule_TextureIsArrayParameterIndex);
     if (auto constIntVal = as<ConstantIntVal>(isArray))
         return constIntVal->getValue() != 0;
     return false;
@@ -1033,7 +1033,7 @@ bool ResourceType::isArray()
 
 bool ResourceType::isMultisample()
 {
-    auto isMS = _getGenericTypeArg(this, kStdlibTextureIsMultisampleParameterIndex);
+    auto isMS = _getGenericTypeArg(this, kCoreModule_TextureIsMultisampleParameterIndex);
     if (auto constIntVal = as<ConstantIntVal>(isMS))
         return constIntVal->getValue() != 0;
     return false;
@@ -1041,7 +1041,7 @@ bool ResourceType::isMultisample()
 
 bool ResourceType::isShadow()
 {
-    auto isShadow = _getGenericTypeArg(this, kStdlibTextureIsShadowParameterIndex);
+    auto isShadow = _getGenericTypeArg(this, kCoreModule_TextureIsShadowParameterIndex);
     if (auto constIntVal = as<ConstantIntVal>(isShadow))
         return constIntVal->getValue() != 0;
     return false;
@@ -1049,15 +1049,15 @@ bool ResourceType::isShadow()
 
 bool ResourceType::isFeedback()
 {
-    auto access = _getGenericTypeArg(this, kStdlibTextureAccessParameterIndex);
+    auto access = _getGenericTypeArg(this, kCoreModule_TextureAccessParameterIndex);
     if (auto constIntVal = as<ConstantIntVal>(access))
-        return constIntVal->getValue() == kStdlibResourceAccessFeedback;
+        return constIntVal->getValue() == kCoreModule_ResourceAccessFeedback;
     return false;
 }
 
 bool ResourceType::isCombined()
 {
-    auto combined = _getGenericTypeArg(this, kStdlibTextureIsCombinedParameterIndex);
+    auto combined = _getGenericTypeArg(this, kCoreModule_TextureIsCombinedParameterIndex);
     if (auto constIntVal = as<ConstantIntVal>(combined))
         return constIntVal->getValue() != 0;
     return false;
@@ -1078,18 +1078,18 @@ bool SubpassInputType::isMultisample()
 
 SlangResourceAccess ResourceType::getAccess()
 {
-    auto access = _getGenericTypeArg(this, kStdlibTextureAccessParameterIndex);
+    auto access = _getGenericTypeArg(this, kCoreModule_TextureAccessParameterIndex);
     if (auto constIntVal = as<ConstantIntVal>(access))
     {
         switch (constIntVal->getValue())
         {
-        case kStdlibResourceAccessReadOnly:
+        case kCoreModule_ResourceAccessReadOnly:
             return SLANG_RESOURCE_ACCESS_READ;
-        case kStdlibResourceAccessReadWrite:
+        case kCoreModule_ResourceAccessReadWrite:
             return SLANG_RESOURCE_ACCESS_READ_WRITE;
-        case kStdlibResourceAccessRasterizerOrdered:
+        case kCoreModule_ResourceAccessRasterizerOrdered:
             return SLANG_RESOURCE_ACCESS_RASTER_ORDERED;
-        case kStdlibResourceAccessFeedback:
+        case kCoreModule_ResourceAccessFeedback:
             return SLANG_RESOURCE_ACCESS_FEEDBACK;
         default:
             break;

--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -72,7 +72,7 @@ Val* Val::resolve()
 #ifdef _DEBUG
     if (m_resolvedVal->_debugUID > 0 && this->_debugUID < 0)
     {
-        SLANG_ASSERT_FAILURE("should not be modifying stdlib vals outside of stdlib checking.");
+        SLANG_ASSERT_FAILURE("should not be modifying the core module vals outside of the core module checking.");
     }
 #endif
     return m_resolvedVal;

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -774,7 +774,7 @@ namespace Slang
         // Allow implicit conversion from sized array to unsized array when
         // calling a function.
         // Note: we implement the logic here instead of an implicit_conversion
-        // intrinsic in the stdlib because we only want to allow this conversion
+        // intrinsic in the core module because we only want to allow this conversion
         // when calling a function.
         //
         if (site == CoercionSite::Argument)

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1796,7 +1796,7 @@ namespace Slang
         // global shader parameter to Slang, but we want to be able to
         // associate special behavior with it to make downstream compilation
         // work nicely (especially in the case where certain cross-platform
-        // operations in the Slang standard library need to use NVAPI).
+        // operations in the Slang core module need to use NVAPI).
         //
         // We will detect a global variable declaration that appears to
         // be declaring `g_NvidiaExt` from NVAPI, and mark it with a special
@@ -2957,7 +2957,7 @@ namespace Slang
 
         /// Recursively register any builtin declarations that need to be attached to the `session`.
         ///
-        /// This function should only be needed for declarations in the standard library.
+        /// This function should only be needed for declarations in the core module.
         ///
     static void _registerBuiltinDeclsRec(Session* session, Decl* decl)
     {
@@ -3026,18 +3026,18 @@ namespace Slang
 
     void SemanticsDeclVisitorBase::checkModule(ModuleDecl* moduleDecl)
     {
-        // When we are dealing with code from the standard library,
+        // When we are dealing with code from the core modules,
         // there is a potential problem where we might need to look
         // up built-in types like `Int` through the session (e.g.,
         // to determine the type for an integer literal), but those
         // types might not have been registered yet. We solve that
-        // by doing a pre-process on standard-library code to find
+        // by doing a pre-process on the core module code to find
         // and register any built-in declarations.
         //
         // TODO: This could be factored into another visitor pass
         // that fits the more standard checking below, but that would
         // seemingly add overhead to checking things other than
-        // the standard library.
+        // the core module.
         //
         if(isFromCoreModule(moduleDecl))
         {
@@ -9847,7 +9847,7 @@ namespace Slang
             m_candidateExtensionListsBuilt = true;
 
             // We need to make sure that all extensions that were declared
-            // as part of our standard-library modules are always visible,
+            // as parts of our core module are always visible,
             // even if they are not explicit `import`ed into user code.
             //
             for( auto module : getSession()->coreModules )

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -3039,7 +3039,7 @@ namespace Slang
         // seemingly add overhead to checking things other than
         // the standard library.
         //
-        if(isFromStdLib(moduleDecl))
+        if(isFromCoreModule(moduleDecl))
         {
             _registerBuiltinDeclsRec(getSession(), moduleDecl);
         }
@@ -4924,7 +4924,7 @@ namespace Slang
         // code to dispatch to the special-case logic used when doing
         // semantic checking for member expressions.
         //
-        // Note: an alternative would be to change the stdlib declarations
+        // Note: an alternative would be to change the core module declarations
         // of vectors/matrices so that all the swizzles are defined as
         // `property` declarations. There are some C++ math libraries (like GLM)
         // that implement swizzle syntax by a similar approach of statically
@@ -5127,7 +5127,7 @@ namespace Slang
             else
             {
                 // While there are other kinds of accessors than `get` and `set`,
-                // those are currently only reserved for stdlib-internal use.
+                // those are currently only reserved for the internal use in the core module.
                 // We will not bother with synthesis for those cases.
                 //
                 return false;
@@ -5408,7 +5408,7 @@ namespace Slang
             else
             {
                 // While there are other kinds of accessors than `get` and `set`,
-                // those are currently only reserved for stdlib-internal use.
+                // those are currently only reserved for the internal use in the core module.
                 // We will not bother with synthesis for those cases.
                 //
                 return false;
@@ -6997,7 +6997,7 @@ namespace Slang
                 continue;
             }
 
-            if (this->getOptionSet().getBoolOption(CompilerOptionName::ZeroInitialize) && !isFromStdLib(decl))
+            if (this->getOptionSet().getBoolOption(CompilerOptionName::ZeroInitialize) && !isFromCoreModule(decl))
             {
                 // Force add IDefaultInitializable to any struct missing (transitively) `IDefaultInitializable`.
                 auto* defaultInitializableType = m_astBuilder->getDefaultInitializableType();
@@ -9850,7 +9850,7 @@ namespace Slang
             // as part of our standard-library modules are always visible,
             // even if they are not explicit `import`ed into user code.
             //
-            for( auto module : getSession()->stdlibModules )
+            for( auto module : getSession()->coreModules )
             {
                 _addCandidateExtensionsFromModule(module->getModuleDecl());
             }
@@ -10101,7 +10101,7 @@ namespace Slang
         {
             m_associatedDeclListsBuilt = true;
 
-            for (auto module : getSession()->stdlibModules)
+            for (auto module : getSession()->coreModules)
             {
                 _addDeclAssociationsFromModule(module->getModuleDecl());
             }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -2112,7 +2112,7 @@ namespace Slang
             Type*              elementType);
 
         // The way that we have designed out type system, pretyt much *every*
-        // type is a reference to some declaration in the standard library.
+        // type is a reference to some declaration in the core module.
         // That means that when we construct a new type on the fly, we need
         // to make sure that it is wired up to reference the appropriate
         // declaration, or else it won't compare as equal to other types

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -2096,7 +2096,7 @@ namespace Slang
         // to go through the type coercion logic first/instead, because
         // by doing so we could weed out cases where a type is "constructed"
         // from a value of the same type. There is no need in Slang for
-        // "copy constructors" but the stdlib currently has to define
+        // "copy constructors" but the core module currently has to define
         // some just to make code that does, e.g., `float(1.0f)` work.)
 
         LookupResult initializers = lookUpMember(
@@ -2407,7 +2407,7 @@ namespace Slang
     Expr* SemanticsVisitor::ResolveInvoke(InvokeExpr* expr)
     {
         OverloadResolveContext context;
-        // check if this is a stdlib operator call, if so we want to use cached results
+        // check if this is a core module operator call, if so we want to use cached results
         // to speed up compilation
         bool shouldAddToCache = false;
         OperatorOverloadCacheKey key;

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -352,7 +352,7 @@ namespace Slang
         //   There's actually a lot of detail to semantic checking, in
         //   that the AST-level code should probably be validating the
         //   use of system-value semantics by linking them to explicit
-        //   declarations in the standard library. We should also be
+        //   declarations in the core module. We should also be
         //   using profile information on those declarations to infer
         //   appropriate profile restrictions on the entry point.
         //

--- a/source/slang/slang-check.h
+++ b/source/slang/slang-check.h
@@ -19,7 +19,7 @@ namespace Slang
     class TranslationUnitRequest;
 
     bool isGlobalShaderParameter(VarDeclBase* decl);
-    bool isFromStdLib(Decl* decl);
+    bool isFromCoreModule(Decl* decl);
 
     void registerBuiltinDecls(Session* session, Decl* decl);
 

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -1749,7 +1749,7 @@ namespace Slang
             // The user requested no output
             return SLANG_OK;
 
-            // Note(tfoley): We currently hit this case when compiling the stdlib
+            // Note(tfoley): We currently hit this case when compiling the core module
         case CodeGenTarget::Unknown:
             return SLANG_OK;
 

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -2480,8 +2480,8 @@ namespace Slang
 
         List<RefPtr<ComponentType>> const& getUnspecializedEntryPoints() { return m_unspecializedEntryPoints; }
 
-            /// Does the code we are compiling represent part of the Slang standard library?
-        bool m_isStandardLibraryCode = false;
+            /// Does the code we are compiling represent part of the Slang core module?
+        bool m_isCoreModuleCode = false;
 
         Name* m_defaultModuleName = nullptr;
 

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -3274,7 +3274,7 @@ namespace Slang
         SLANG_NO_THROW SlangResult SLANG_MCALL checkCompileTargetSupport(SlangCompileTarget target) override;
         SLANG_NO_THROW SlangResult SLANG_MCALL checkPassThroughSupport(SlangPassThrough passThrough) override;
 
-        void writeStdlibDoc(String config);
+        void writeCoreModuleDoc(String config);
         SLANG_NO_THROW SlangResult SLANG_MCALL compileCoreModule(slang::CompileCoreModuleFlags flags) override;
         SLANG_NO_THROW SlangResult SLANG_MCALL loadCoreModule(const void* coreModule, size_t coreModuleSizeInBytes) override;
         SLANG_NO_THROW SlangResult SLANG_MCALL saveCoreModule(SlangArchiveType archiveType, ISlangBlob** outBlob) override;
@@ -3312,7 +3312,7 @@ namespace Slang
         Scope* autodiffLanguageScope = nullptr;
 
         ModuleDecl* baseModuleDecl = nullptr;
-        List<RefPtr<Module>> stdlibModules;
+        List<RefPtr<Module>> coreModules;
 
         SourceManager   builtinSourceManager;
 
@@ -3336,8 +3336,8 @@ namespace Slang
 
         RefPtr<ASTBuilder> globalAstBuilder;
 
-        // Generated code for stdlib, etc.
-        String stdlibPath;
+        // Generated code for core module, etc.
+        String coreModulePath;
 
         ComPtr<ISlangBlob> coreLibraryCode;
         //ComPtr<ISlangBlob> slangLibraryCode;
@@ -3345,7 +3345,7 @@ namespace Slang
         ComPtr<ISlangBlob> glslLibraryCode;
         ComPtr<ISlangBlob> autodiffLibraryCode;
 
-        String  getStdlibPath();
+        String  getCoreModulePath();
 
         ComPtr<ISlangBlob> getCoreLibraryCode();
         ComPtr<ISlangBlob> getHLSLLibraryCode();
@@ -3375,7 +3375,7 @@ namespace Slang
             /// Get the prelude associated with the language
         const String& getPreludeForLanguage(SourceLanguage language) { return m_languagePreludes[int(language)]; }
 
-            /// Get the built in linkage -> handy to get the stdlibs from
+            /// Get the built in linkage -> handy to get the core module from
         Linkage* getBuiltinLinkage() const { return m_builtinLinkage; }
 
         Name* getCompletionRequestTokenName() const { return m_completionTokenName; }
@@ -3412,7 +3412,7 @@ namespace Slang
 
         SlangResult _loadRequest(EndToEndCompileRequest* request, const void* data, size_t size);
 
-            /// Linkage used for all built-in (stdlib) code.
+            /// Linkage used for all built-in (core module) code.
         RefPtr<Linkage> m_builtinLinkage;
 
         String m_downstreamCompilerPaths[int(PassThroughMode::CountOf)];         ///< Paths for each pass through

--- a/source/slang/slang-core-module-textures.cpp
+++ b/source/slang/slang-core-module-textures.cpp
@@ -100,7 +100,7 @@ void TextureTypeInfo::writeFuncBody(
         if (spirvDefault.getLength() && spirvCombined.getLength())
         {
             sb << i << "case spirv:\n";
-            sb << i << "if (access == " << kStdlibResourceAccessReadWrite << ")\n";
+            sb << i << "if (access == " << kCoreModule_ResourceAccessReadWrite << ")\n";
             sb << i << "return spirv_asm\n";
             {
                 BraceScope spirvRWScope{ i, sb, ";\n" };
@@ -365,7 +365,7 @@ void TextureTypeInfo::writeGetDimensionFunctions()
                             glsl << ", ($" << aa++ << " = textureQueryLevels($0))";
                         }
                     };
-                glsl << "if (access == " << kStdlibResourceAccessReadOnly << ") __intrinsic_asm \"";
+                glsl << "if (access == " << kCoreModule_ResourceAccessReadOnly << ") __intrinsic_asm \"";
                 emitIntrinsic(toSlice("textureSize"), !isMultisample);
                 glsl << "\";\n";
                 glsl << "__intrinsic_asm \"";

--- a/source/slang/slang-core-module.cpp
+++ b/source/slang/slang-core-module.cpp
@@ -8,9 +8,9 @@
 
 namespace Slang
 {
-    String Session::getStdlibPath()
+    String Session::getCoreModulePath()
     {
-        if(stdlibPath.getLength() == 0)
+        if(coreModulePath.getLength() == 0)
         {
             // Make sure we have a line of text from __FILE__, that we'll extract the filename from
             List<UnownedStringSlice> lines;
@@ -18,8 +18,8 @@ namespace Slang
             SLANG_ASSERT(lines.getCount() > 0 && lines[0].getLength() > 0);
 
             // Make the path just the filename to remove issues around path being included on different targets
-            stdlibPath = Path::getFileName(lines[0]);
+            coreModulePath = Path::getFileName(lines[0]);
         }
-        return stdlibPath;
+        return coreModulePath;
     }
 }

--- a/source/slang/slang-doc-markdown-writer.cpp
+++ b/source/slang/slang-doc-markdown-writer.cpp
@@ -2616,7 +2616,7 @@ DocumentPage* DocMarkdownWriter::writeAll(UnownedStringSlice configStr)
             m_output[page->path] = page;
             return page.get();
         };
-    m_rootPage = addBuiltinPage(nullptr, toSlice("index.md"), m_config.title.getUnownedSlice(), toSlice("Standard Library Reference"));
+    m_rootPage = addBuiltinPage(nullptr, toSlice("index.md"), m_config.title.getUnownedSlice(), toSlice("Core Module Reference"));
     m_rootPage->skipWrite = true;
 
     m_interfacesPage = addBuiltinPage(m_rootPage.get(), toSlice("interfaces/index.md"), toSlice("Interfaces"), toSlice("Interfaces"));

--- a/source/slang/slang-doc-markdown-writer.cpp
+++ b/source/slang/slang-doc-markdown-writer.cpp
@@ -1104,7 +1104,7 @@ void DocMarkdownWriter::_appendRequirements(const Requirement& requirement)
 
         // TODO: We should probably print the capabilities for each stage set if the requirements differ between
         // different stages, but for now we'll just print the first one, assuming the rest are the same.
-        // This is currently true for most if not all of our stdlib decls.
+        // This is currently true for most if not all of our core module decls.
         //
         if (targetSet.second.shaderStageSets.getCount() > 0 &&
             targetSet.second.shaderStageSets.begin()->second.atomSet.has_value())

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -2672,7 +2672,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
     case kIROp_WrapExistential:
         {
             // Normally `WrapExistential` shouldn't exist in user code at this point.
-            // The only exception is when the user is calling a stdlib generic
+            // The only exception is when the user is calling a core module generic
             // function that has an existential type argument, for example
             // `StructuredBuffer<ISomething>.Load()`.
             // We can safely ignore the `wrapExistential` operation in this case.

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -1044,7 +1044,7 @@ InstPair ForwardDiffTranscriber::transcribeSpecialize(IRBuilder* builder, IRSpec
         SLANG_RELEASE_ASSERT(diffBaseSpecialize);
 
         // Note: this assumes that the generic arguments to specialize the derivative is the same as the
-        // generic args to specialize the primal function. This is true for all of our stdlib functions,
+        // generic args to specialize the primal function. This is true for all of our core module functions,
         // but we may need to rely on more general substitution logic here.
         auto diffSpecialize = builder->emitSpecializeInst(
             builder->getTypeKind(), diffBaseSpecialize->getBase(), args.getCount(), args.getBuffer());

--- a/source/slang/slang-ir-autodiff-rev.cpp
+++ b/source/slang/slang-ir-autodiff-rev.cpp
@@ -1332,7 +1332,7 @@ namespace Slang
             SLANG_RELEASE_ASSERT(diffBaseSpecialize);
 
             // Note: this assumes that the generic arguments to specialize the derivative is the same as the
-            // generic args to specialize the primal function. This is true for all of our stdlib functions,
+            // generic args to specialize the primal function. This is true for all of our core module functions,
             // but we may need to rely on more general substitution logic here.
             auto diffSpecialize = builder->emitSpecializeInst(
                 builder->getTypeKind(), diffBaseSpecialize->getBase(), args.getCount(), args.getBuffer());

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -2889,7 +2889,7 @@ void legalizeEntryPointParameterForGLSL(
         // TODO: This approach to generating geometry shader code
         // is not ideal, and we should strive to find a better
         // approach that involes coding the `EmitVertex` operation
-        // directly in the stdlib, similar to how ray-tracing
+        // directly in the core module, similar to how ray-tracing
         // operations like `TraceRay` are handled.
         //
         builder->setInsertBefore(func->getFirstBlock()->getFirstOrdinaryInst());

--- a/source/slang/slang-ir-inline.cpp
+++ b/source/slang/slang-ir-inline.cpp
@@ -425,18 +425,18 @@ struct InliningPassBase
         // An assumption here is that [__unsafeForceInlineEarly] will not be in user code (when we have more
         // general inlining this will not follow).
         //
-        // Therefore we probably *don't* want to copy sourceLoc from the original definition in the stdlib because
+        // Therefore we probably *don't* want to copy sourceLoc from the original definition in the core module because
         //
-        // * That won't be much use to the user (they can't easily see stdlib code currently for example)
-        // * That the definitions in stdlib are currently 'mundane' and largely exist to flesh out language features - such that
-        //   their being in the stdlib would likely be surprising to users
+        // * That won't be much use to the user (they can't easily see the core module code currently for example)
+        // * That the definitions in the core module are currently 'mundane' and largely exist to flesh out language features - such that
+        //   their being in the core module would likely be surprising to users
         //
         // That being the case, we actually copy the call sites sourceLoc if it's defined, and only fall back
         // onto the originating loc, if that's not defined.
         //
-        // We *could* vary behavior if we knew if the function was defined in the stdlib. There doesn't appear 
+        // We *could* vary behavior if we knew if the function was defined in the core module. There doesn't appear 
         // to be a decoration for this.
-        // We could find out by looking at the source loc and checking if it's in the range of stdlib - this would actually be
+        // We could find out by looking at the source loc and checking if it's in the range of the core module - this would actually be
         // a fast and easy but to do properly this way you'd want a way to mark that source range that would also work across
         // serialization.
         // 

--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -1757,9 +1757,9 @@ LinkedIR linkIR(
 
     List<IRModule*> irModules;
 
-    // Link stdlib modules.
-    auto& stdlibModules = static_cast<Session*>(linkage->getGlobalSession())->stdlibModules;
-    for (auto& m : stdlibModules)
+    // Link the core modules.
+    auto& coreModules = static_cast<Session*>(linkage->getGlobalSession())->coreModules;
+    for (auto& m : coreModules)
         irModules.add(m->getIRModule());
 
     // Link modules in the program.

--- a/source/slang/slang-ir-lower-combined-texture-sampler.cpp
+++ b/source/slang/slang-ir-lower-combined-texture-sampler.cpp
@@ -38,7 +38,7 @@ namespace Slang
             builder.addNameHintDecoration(info.texture, toSlice("texture"));
             info.type = structType;
 
-            bool isMutable = getIntVal(textureType->getAccessInst()) == kStdlibResourceAccessReadOnly ? false : true;
+            bool isMutable = getIntVal(textureType->getAccessInst()) == kCoreModule_ResourceAccessReadOnly ? false : true;
 
             info.textureType = builder.getTextureType(textureType->getElementType(),
                 textureType->getShapeInst(),

--- a/source/slang/slang-ir-lower-generics.cpp
+++ b/source/slang/slang-ir-lower-generics.cpp
@@ -266,7 +266,7 @@ namespace Slang
             return;
 
         // At this point, we should no longer need to care any `WrapExistential` insts,
-        // although they could still exist in the IR in order to call generic stdlib functions,
+        // although they could still exist in the IR in order to call generic core module functions,
         // e.g. RWStucturedBuffer.Load(WrapExistential(sbuffer, type), index).
         // We should remove them now.
         stripWrapExistential(module);
@@ -289,7 +289,7 @@ namespace Slang
             return;
 
         // At this point, we should no longer need to care any `WrapExistential` insts,
-        // although they could still exist in the IR in order to call generic stdlib functions,
+        // although they could still exist in the IR in order to call generic core module functions,
         // e.g. RWStucturedBuffer.Load(WrapExistential(sbuffer, type), index).
         // We should remove them now.
         stripWrapExistential(module);

--- a/source/slang/slang-ir-obfuscate-loc.cpp
+++ b/source/slang/slang-ir-obfuscate-loc.cpp
@@ -48,8 +48,8 @@ static void _findInstsRec(IRInst* inst, List<InstWithLoc>& out)
     }
 }
 
-// We assume the root source manager is the stdlibs
-static SourceLoc _getStdLibLastLoc(SourceManager* sourceManager)
+// We assume the root source manager is the core module
+static SourceLoc _getCoreModuleLastLoc(SourceManager* sourceManager)
 {
     auto rootManager = sourceManager;
     while (rootManager->getParent())
@@ -95,7 +95,7 @@ SlangResult obfuscateModuleLocs(IRModule* module, SourceManager* sourceManager)
     {
         SourceView* sourceView = nullptr;
 
-        const SourceLoc endStdLibLoc = _getStdLibLastLoc(sourceManager);
+        const SourceLoc endCoreModuleLoc = _getCoreModuleLastLoc(sourceManager);
 
         SourceLoc curLoc;
         for (const auto& instWithLoc : instWithLocs)
@@ -109,8 +109,8 @@ SlangResult obfuscateModuleLocs(IRModule* module, SourceManager* sourceManager)
                 // This is the current loc
                 curLoc = instWithLoc.loc;
             
-                // Ignore any stdlib locs in the hash
-                if (instWithLoc.loc.getRaw() < endStdLibLoc.getRaw())
+                // Ignore any core module locs in the hash
+                if (instWithLoc.loc.getRaw() < endCoreModuleLoc.getRaw())
                 {
                     continue;
                 }

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -812,7 +812,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                         {
                             // If we are passing an address from a structured buffer as a
                             // ref argument, pass the original pointer as is.
-                            // This is to support stdlib atomic functions.
+                            // This is to support core module atomic functions.
                             newArgs.add(arg);
                             continue;
                         }

--- a/source/slang/slang-ir-synthesize-active-mask.cpp
+++ b/source/slang/slang-ir-synthesize-active-mask.cpp
@@ -111,7 +111,7 @@ struct SynthesizeActiveMaskForModuleContext
     {
         // We use the plain 32-bit `uint` type masks we
         // generate here since it matches the current
-        // definition of `WaveMask` in the standard library.
+        // definition of `WaveMask` in the core module.
         //
         // TODO: If/when the `WaveMask` type in the core module is
         // made opaque, this should use the opaque type instead,

--- a/source/slang/slang-ir-synthesize-active-mask.cpp
+++ b/source/slang/slang-ir-synthesize-active-mask.cpp
@@ -113,7 +113,7 @@ struct SynthesizeActiveMaskForModuleContext
         // generate here since it matches the current
         // definition of `WaveMask` in the standard library.
         //
-        // TODO: If/when the `WaveMask` type in the stdlib is
+        // TODO: If/when the `WaveMask` type in the core module is
         // made opaque, this should use the opaque type instead,
         // so that the pass is compatible with all targets that
         // support  a wave mask.

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -377,7 +377,7 @@ namespace Slang
             type = rateQualType->getValueType();
         }
 
-        // The "true" pointers and the pointer-like stdlib types are the easy cases.
+        // The "true" pointers and the pointer-like core module types are the easy cases.
         if( auto ptrType = as<IRPtrTypeBase>(type) )
         {
             return ptrType->getValueType();

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1398,14 +1398,14 @@ SIMPLE_IR_TYPE(BasicBlockType, Type)
 
 struct IRResourceTypeBase : IRType
 {
-    IRInst* getShapeInst() { return getOperand(kStdlibTextureShapeParameterIndex); }
-    IRInst* getIsArrayInst() { return getOperand(kStdlibTextureIsArrayParameterIndex); }
-    IRInst* getIsMultisampleInst() { return getOperand(kStdlibTextureIsMultisampleParameterIndex); }
-    IRInst* getSampleCountInst() { return getOperand(kStdlibTextureSampleCountParameterIndex); }
-    IRInst* getAccessInst() { return getOperand(kStdlibTextureAccessParameterIndex); }
-    IRInst* getIsShadowInst() { return getOperand(kStdlibTextureIsShadowParameterIndex); }
-    IRInst* getIsCombinedInst() { return getOperand(kStdlibTextureIsCombinedParameterIndex); }
-    IRInst* getFormatInst() { return getOperand(kStdlibTextureFormatParameterIndex); }
+    IRInst* getShapeInst() { return getOperand(kCoreModule_TextureShapeParameterIndex); }
+    IRInst* getIsArrayInst() { return getOperand(kCoreModule_TextureIsArrayParameterIndex); }
+    IRInst* getIsMultisampleInst() { return getOperand(kCoreModule_TextureIsMultisampleParameterIndex); }
+    IRInst* getSampleCountInst() { return getOperand(kCoreModule_TextureSampleCountParameterIndex); }
+    IRInst* getAccessInst() { return getOperand(kCoreModule_TextureAccessParameterIndex); }
+    IRInst* getIsShadowInst() { return getOperand(kCoreModule_TextureIsShadowParameterIndex); }
+    IRInst* getIsCombinedInst() { return getOperand(kCoreModule_TextureIsCombinedParameterIndex); }
+    IRInst* getFormatInst() { return getOperand(kCoreModule_TextureFormatParameterIndex); }
 
     SlangResourceShape GetBaseShape()
     {
@@ -1425,7 +1425,7 @@ struct IRResourceTypeBase : IRType
             return SLANG_RESOURCE_NONE;
         }
     }
-    bool isFeedback() { return getIntVal(getAccessInst()) == kStdlibResourceAccessFeedback; }
+    bool isFeedback() { return getIntVal(getAccessInst()) == kCoreModule_ResourceAccessFeedback; }
     bool isMultisample() { return getIntVal(getIsMultisampleInst()) != 0; }
     bool isArray() { return getIntVal(getIsArrayInst()) != 0; }
     bool isShadow() { return getIntVal(getIsShadowInst()) != 0; }
@@ -1434,18 +1434,18 @@ struct IRResourceTypeBase : IRType
     SlangResourceShape getShape() { return (SlangResourceShape)((uint32_t)GetBaseShape() | (isArray() ? SLANG_TEXTURE_ARRAY_FLAG : SLANG_RESOURCE_NONE)); }
     SlangResourceAccess getAccess()
     {
-        auto constVal = as<IRIntLit>(getOperand(kStdlibTextureAccessParameterIndex));
+        auto constVal = as<IRIntLit>(getOperand(kCoreModule_TextureAccessParameterIndex));
         if (constVal)
         {
             switch (getIntVal(constVal))
             {
-            case kStdlibResourceAccessReadOnly:
+            case kCoreModule_ResourceAccessReadOnly:
                 return SLANG_RESOURCE_ACCESS_READ;
-            case kStdlibResourceAccessReadWrite:
+            case kCoreModule_ResourceAccessReadWrite:
                 return SLANG_RESOURCE_ACCESS_READ_WRITE;
-            case kStdlibResourceAccessRasterizerOrdered:
+            case kCoreModule_ResourceAccessRasterizerOrdered:
                 return SLANG_RESOURCE_ACCESS_RASTER_ORDERED;
-            case kStdlibResourceAccessFeedback:
+            case kCoreModule_ResourceAccessFeedback:
                 return SLANG_RESOURCE_ACCESS_FEEDBACK;
             default:
                 break;

--- a/source/slang/slang-lookup.cpp
+++ b/source/slang/slang-lookup.cpp
@@ -225,7 +225,7 @@ static void _lookUpDirectAndTransparentMembers(
     }
 
     // Don't look up transparent members if we are looking for attributes, since
-    // they are always defined at global scope in the stdlib. Trying to lookup transparent
+    // they are always defined at global scope in the core module. Trying to lookup transparent
     // members during attribute lookup can lead to infinite recursion on transparent types.
     if ((int)request.mask & (int)LookupMask::Attribute)
         return;

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9681,7 +9681,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         if(decl->body)
             return;
 
-        // Only standard library declarations should get any kind of catch-all
+        // Only core module declarations should get any kind of catch-all
         // treatment by default. Declarations in user case are responsible
         // for marking things as target intrinsics if they want to go down
         // that (unsupported) route.

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -655,11 +655,11 @@ ModuleDecl* findModuleDecl(Decl* decl)
     return nullptr;
 }
 
-bool isFromStdLib(Decl* decl)
+bool isFromCoreModule(Decl* decl)
 {
     for (auto dd = decl; dd; dd = dd->parentDecl)
     {
-        if (dd->hasModifier<FromStdLibModifier>())
+        if (dd->hasModifier<FromCoreModuleModifier>())
             return true;
     }
     return false;
@@ -707,7 +707,7 @@ bool isEffectivelyStatic(
     Decl*           decl,
     ContainerDecl*  parentDecl);
 
-bool isStdLibMemberFuncDecl(
+bool isCoreModuleMemberFuncDecl(
     Decl*   decl);
 
 // Ensure that a version of the given declaration has been emitted to the IR
@@ -1442,10 +1442,10 @@ static void addLinkageDecoration(
 
     // Obfuscate the mangled names if necessary.
     // 
-    // Care is needed around stdlib as it is only compiled once and *without* obfuscation, 
-    // so any linkage name to stdlib *shouldn't* have obfuscation applied to it.
+    // Care is needed around the core module as it is only compiled once and *without* obfuscation, 
+    // so any linkage name to the core module *shouldn't* have obfuscation applied to it.
     if (context->shared->m_obfuscateCode && 
-        !isFromStdLib(decl))
+        !isFromCoreModule(decl))
     {
         const auto obfuscatedName = getHashedName(mangledName.getUnownedSlice());
     
@@ -9549,7 +9549,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             }
             else
             {
-                if( isStdLibMemberFuncDecl(decl) )
+                if( isCoreModuleMemberFuncDecl(decl) )
                 {
                     // We will mark member functions by appending a `.` to the
                     // start of their name.
@@ -9623,8 +9623,8 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         }
     }
 
-        /// Is `decl` a member function (or effectively a member function) when considered as a stdlib declaration?
-    bool isStdLibMemberFuncDecl(
+        /// Is `decl` a member function (or effectively a member function) when considered as a core module declaration?
+    bool isCoreModuleMemberFuncDecl(
         Decl*   inDecl)
     {
         auto decl = as<CallableDecl>(inDecl);
@@ -9670,7 +9670,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         return false;
     }
 
-        /// Add a "catch-all" decoration for a stdlib function if it would be needed
+        /// Add a "catch-all" decoration for a core module function if it would be needed
     void addCatchAllIntrinsicDecorationIfNeeded(
         IRInst*             irInst,
         FunctionDeclBase*   decl)
@@ -9686,7 +9686,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // for marking things as target intrinsics if they want to go down
         // that (unsupported) route.
         //
-        if(!isFromStdLib(decl))
+        if(!isFromCoreModule(decl))
             return;
 
         // No need to worry about functions that lower to intrinsic IR opcodes
@@ -9719,7 +9719,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // (the assumption is that a catch-all definition of a member function
         // is itself implemented as a member function).
         //
-        if( isStdLibMemberFuncDecl(decl) )
+        if( isCoreModuleMemberFuncDecl(decl) )
         {
             // We will mark member functions by appending a `.` to the
             // start of their name.

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -545,8 +545,8 @@ void initCommandOptions(CommandOptions& options)
     {
         { OptionKind::ArchiveType, "-archive-type", "-archive-type <archive-type>", "Set the archive type for -save-core-module. Default is zip." },
         { OptionKind::CompileCoreModule, "-compile-core-module", nullptr, 
-        "Compile the StdLib from embedded sources. "
-        "Will return a failure if there is already a StdLib available."},
+        "Compile the core module from embedded sources. "
+        "Will return a failure if there is already a core module available."},
         { OptionKind::Doc, "-doc", nullptr, "Write documentation for -compile-core-module" },
         { OptionKind::IrCompression,"-ir-compression", "-ir-compression <type>", 
         "Set compression for IR and AST outputs.\n"
@@ -797,8 +797,8 @@ struct OptionsParser
     int m_currentTranslationUnitIndex = -1;
 
     bool m_hasLoadedRepro = false;
-    bool m_compileStdLib = false;
-    slang::CompileCoreModuleFlags m_compileStdLibFlags;
+    bool m_compileCoreModule = false;
+    slang::CompileCoreModuleFlags m_compileCoreModuleFlags;
 
     SlangArchiveType m_archiveType = SLANG_ARCHIVE_TYPE_RIFF_LZ4;
     
@@ -1762,7 +1762,7 @@ SlangResult OptionsParser::_parse(
 
                 break;
             }
-            case OptionKind::CompileCoreModule: m_compileStdLib = true; break;
+            case OptionKind::CompileCoreModule: m_compileCoreModule = true; break;
             case OptionKind::ArchiveType:
             {
                 SLANG_RETURN_ON_FAIL(_expectValue(m_archiveType));
@@ -1810,8 +1810,8 @@ SlangResult OptionsParser::_parse(
             }
             case OptionKind::Doc:
             {
-                // If compiling stdlib is enabled, will write out documentation
-                m_compileStdLibFlags |= slang::CompileCoreModuleFlag::WriteDocumentation;
+                // When compiling the core module, it will write out a documentation.
+                m_compileCoreModuleFlags |= slang::CompileCoreModuleFlag::WriteDocumentation;
 
                 // Enable writing out documentation on the req
                 linkage->m_optionSet.set(CompilerOptionName::Doc, true);
@@ -2378,9 +2378,9 @@ SlangResult OptionsParser::_parse(
         }
     }
 
-    if (m_compileStdLib)
+    if (m_compileCoreModule)
     {
-        SLANG_RETURN_ON_FAIL(m_session->compileCoreModule(m_compileStdLibFlags));
+        SLANG_RETURN_ON_FAIL(m_session->compileCoreModule(m_compileCoreModuleFlags));
     }
 
     // TODO(JS): This is a restriction because of how setting of state works for load repro

--- a/source/slang/slang-type-system-shared.h
+++ b/source/slang/slang-type-system-shared.h
@@ -39,25 +39,25 @@ FOREACH_BASE_TYPE(DEFINE_BASE_TYPE)
         SamplerComparisonState,
     };
 
-    const int kStdlibResourceAccessReadOnly = 0;
-    const int kStdlibResourceAccessReadWrite = 1;
-    const int kStdlibResourceAccessRasterizerOrdered = 2;
-    const int kStdlibResourceAccessFeedback = 3;
+    const int kCoreModule_ResourceAccessReadOnly = 0;
+    const int kCoreModule_ResourceAccessReadWrite = 1;
+    const int kCoreModule_ResourceAccessRasterizerOrdered = 2;
+    const int kCoreModule_ResourceAccessFeedback = 3;
 
-    const int kStdlibShapeIndex1D = 0;
-    const int kStdlibShapeIndex2D = 1;
-    const int kStdlibShapeIndex3D = 2;
-    const int kStdlibShapeIndexCube = 3;
-    const int kStdlibShapeIndexBuffer = 4;
+    const int kCoreModule_ShapeIndex1D = 0;
+    const int kCoreModule_ShapeIndex2D = 1;
+    const int kCoreModule_ShapeIndex3D = 2;
+    const int kCoreModule_ShapeIndexCube = 3;
+    const int kCoreModule_ShapeIndexBuffer = 4;
 
-    const int kStdlibTextureShapeParameterIndex = 1;
-    const int kStdlibTextureIsArrayParameterIndex = 2;
-    const int kStdlibTextureIsMultisampleParameterIndex = 3;
-    const int kStdlibTextureSampleCountParameterIndex = 4;
-    const int kStdlibTextureAccessParameterIndex = 5;
-    const int kStdlibTextureIsShadowParameterIndex = 6;
-    const int kStdlibTextureIsCombinedParameterIndex = 7;
-    const int kStdlibTextureFormatParameterIndex = 8;
+    const int kCoreModule_TextureShapeParameterIndex = 1;
+    const int kCoreModule_TextureIsArrayParameterIndex = 2;
+    const int kCoreModule_TextureIsMultisampleParameterIndex = 3;
+    const int kCoreModule_TextureSampleCountParameterIndex = 4;
+    const int kCoreModule_TextureAccessParameterIndex = 5;
+    const int kCoreModule_TextureIsShadowParameterIndex = 6;
+    const int kCoreModule_TextureIsCombinedParameterIndex = 7;
+    const int kCoreModule_TextureFormatParameterIndex = 8;
 
     enum class AddressSpace : uint64_t
     {

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -2937,19 +2937,19 @@ void FrontEndCompileRequest::parseTranslationUnit(
     module->setModuleDecl(translationUnitSyntax);
 
     // When compiling a module of code that belongs to the Slang
-    // standard library, we add a modifier to the module to act
+    // core module, we add a modifier to the module to act
     // as a marker, so that downstream code can detect declarations
-    // that came from the standard library (by walking up their
+    // that came from the core module (by walking up their
     // chain of ancestors and looking for the marker), and treat
     // them differently from user declarations.
     //
     // We are adding the marker here, before we even parse the
     // code in the module, in case the subsequent steps would
-    // like to treat the standard library differently. Alternatively
+    // like to treat the core module differently. Alternatively
     // we could pass down the `m_isStandardLibraryCode` flag to
     // these passes.
     //
-    if( m_isStandardLibraryCode )
+    if( m_isCoreModuleCode )
     {
         translationUnitSyntax->modifiers.first = astBuilder->create<FromCoreModuleModifier>();
     }
@@ -5898,7 +5898,7 @@ void Session::addBuiltinSource(
         m_builtinLinkage,
         nullptr,
         &sink);
-    compileRequest->m_isStandardLibraryCode = true;
+    compileRequest->m_isCoreModuleCode = true;
 
     // Set the source manager on the sink
     sink.setSourceManager(sourceManager);
@@ -5922,7 +5922,7 @@ void Session::addBuiltinSource(
 
         PlatformUtil::outputDebugMessage(diagnostics);
 
-        SLANG_UNEXPECTED("error in Slang standard library");
+        SLANG_UNEXPECTED("error in Slang core module");
     }
     
     // Compiling the core module should not yield any warnings.

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -185,7 +185,7 @@ void Session::init()
     // Create scopes for various language builtins.
     //
     // TODO: load these on-demand to avoid parsing
-    // stdlib code for languages the user won't use.
+    // the core module code for languages the user won't use.
 
     baseLanguageScope = builtinAstBuilder->create<Scope>();
 
@@ -312,7 +312,7 @@ SlangResult Session::checkPassThroughSupport(SlangPassThrough inPassThrough)
     return checkExternalCompilerSupport(this, PassThroughMode(inPassThrough));
 }
 
-void Session::writeStdlibDoc(String config)
+void Session::writeCoreModuleDoc(String config)
 {
     ASTBuilder* astBuilder = getBuiltinLinkage()->getASTBuilder();
     SourceManager* sourceManager = getBuiltinSourceManager();
@@ -322,10 +322,10 @@ void Session::writeStdlibDoc(String config)
     List<String> docStrings;
 
     // For all the modules add their doc output to docStrings
-    for (Module* stdlibModule : stdlibModules)
+    for (Module* m : coreModules)
     {
         RefPtr<ASTMarkup> markup(new ASTMarkup);
-        ASTMarkupUtil::extract(stdlibModule->getModuleDecl(), sourceManager, &sink, markup);
+        ASTMarkupUtil::extract(m->getModuleDecl(), sourceManager, &sink, markup);
 
         DocMarkdownWriter writer(markup, astBuilder, &sink);
         auto rootPage = writer.writeAll(config.getUnownedSlice());
@@ -348,26 +348,26 @@ SlangResult Session::compileCoreModule(slang::CompileCoreModuleFlags compileFlag
 
     if (m_builtinLinkage->mapNameToLoadedModules.getCount())
     {
-        // Already have a StdLib loaded
+        // Already have a core module loaded
         return SLANG_FAIL;
     }
 
 #ifdef _DEBUG
-    // Print a message in debug builds to notice the user that compiling the stdlib
+    // Print a message in debug builds to notice the user that compiling the core module
     // can take a while.
     time_t beginTime;
     time(&beginTime);
-    fprintf(stderr, "Compiling stdlib on debug build, this can take a while.\n");
+    fprintf(stderr, "Compiling core module on debug build, this can take a while.\n");
 #endif
 
     // TODO(JS): Could make this return a SlangResult as opposed to exception
-    StringBuilder stdLibSrcBuilder;
-    stdLibSrcBuilder
+    StringBuilder coreModuleSrcBuilder;
+    coreModuleSrcBuilder
         << (const char*)getCoreLibraryCode()->getBufferPointer()
         << (const char*)getHLSLLibraryCode()->getBufferPointer()
         << (const char*)getAutodiffLibraryCode()->getBufferPointer();
-    auto stdLibSrcBlob = StringBlob::moveCreate(stdLibSrcBuilder.produceString());
-    addBuiltinSource(coreLanguageScope, "core", stdLibSrcBlob);
+    auto coreModuleSrcBlob = StringBlob::moveCreate(coreModuleSrcBuilder.produceString());
+    addBuiltinSource(coreLanguageScope, "core", coreModuleSrcBlob);
 
     if (compileFlags & slang::CompileCoreModuleFlag::WriteDocumentation)
     {
@@ -379,7 +379,7 @@ SlangResult Session::compileCoreModule(slang::CompileCoreModuleFlags compileFlag
         }
         else
         {
-            writeStdlibDoc(configText);
+            writeCoreModuleDoc(configText);
         }
     }
 
@@ -388,7 +388,7 @@ SlangResult Session::compileCoreModule(slang::CompileCoreModuleFlags compileFlag
 #ifdef _DEBUG
     time_t endTime;
     time(&endTime);
-    fprintf(stderr, "Compiling stdlib took %.2f seconds.\n", difftime(endTime, beginTime));
+    fprintf(stderr, "Compiling core module took %.2f seconds.\n", difftime(endTime, beginTime));
 #endif
     return SLANG_OK;
 }
@@ -399,7 +399,7 @@ SlangResult Session::loadCoreModule(const void* coreModule, size_t coreModuleSiz
 
     if (m_builtinLinkage->mapNameToLoadedModules.getCount())
     {
-        // Already have a StdLib loaded
+        // Already have a core module loaded
         return SLANG_FAIL;
     }
 
@@ -521,7 +521,7 @@ SlangResult Session::_readBuiltinModule(ISlangFileSystem* fileSystem, Scope* sco
 
         if (moduleDecl)
         {
-            if (isFromStdLib(moduleDecl))
+            if (isFromCoreModule(moduleDecl))
             {
                 registerBuiltinDecls(this, moduleDecl);
             }
@@ -551,7 +551,7 @@ SlangResult Session::_readBuiltinModule(ISlangFileSystem* fileSystem, Scope* sco
 
         // We need to retain this AST so that we can use it in other code
         // (Note that the `Scope` type does not retain the AST it points to)
-        stdlibModules.add(module);
+        coreModules.add(module);
     }
 
     return SLANG_OK;
@@ -2951,7 +2951,7 @@ void FrontEndCompileRequest::parseTranslationUnit(
     //
     if( m_isStandardLibraryCode )
     {
-        translationUnitSyntax->modifiers.first = astBuilder->create<FromStdLibModifier>();
+        translationUnitSyntax->modifiers.first = astBuilder->create<FromCoreModuleModifier>();
     }
 
     // We use a custom handler for preprocessor callbacks, to
@@ -5925,7 +5925,7 @@ void Session::addBuiltinSource(
         SLANG_UNEXPECTED("error in Slang standard library");
     }
     
-    // Compiling stdlib should not yield any warnings.
+    // Compiling the core module should not yield any warnings.
     SLANG_ASSERT(sink.outputBuffer.getLength() == 0);
 
     // Extract the AST for the code we just parsed
@@ -5957,7 +5957,7 @@ void Session::addBuiltinSource(
 
     // We need to retain this AST so that we can use it in other code
     // (Note that the `Scope` type does not retain the AST it points to)
-    stdlibModules.add(module);
+    coreModules.add(module);
 }
 
 Session::~Session()
@@ -5970,7 +5970,7 @@ Session::~Session()
     globalAstBuilder.setNull();
 
     // destroy modules next
-    stdlibModules = decltype(stdlibModules)();
+    coreModules = decltype(coreModules)();
 }
 
 }

--- a/tests/bugs/extension-lifetime.slang
+++ b/tests/bugs/extension-lifetime.slang
@@ -2,16 +2,16 @@
 
 // This test is a regresion test for a bug where `extension`
 // declarations are incorrectly being cached on the declarations
-// they extend, so that an extension of a stdlib type (like `float`)
+// they extend, so that an extension of a core module type (like `float`)
 // ends up attaching a declaration from one compile request to that
-// type, and then later compile requests that use that stdlib type
+// type, and then later compile requests that use the core module type
 // try to look up through that extension even though (1) that
 // shouldn't make sense semantically, and (2) that extension will
 // have been deallocated when its parent compile request was
 // destroyed.
 //
 // This test relies on the fact that our test runner uses a single
-// slang compilation session (which loads the stdlib code) across
+// slang compilation session (which loads the core module code) across
 // multiple compilation tests. We can thus make this file contain
 // two identical tests, with the knowledge that the second one
 // will lead to the bad/crashing behavior if the first one ran

--- a/tests/diagnostics/bad-operator-call.slang
+++ b/tests/diagnostics/bad-operator-call.slang
@@ -4,8 +4,8 @@
 
 // Test that bad calls to operators produce reasonable diagnostic messages.
 
-// Note: This test is currently Windows-only becase our Linux builds
-// seem to print references to the stdlib code with paths that don't
+// Note: This test is currently Windows-only because our Linux builds
+// seem to print references to the core module code with paths that don't
 // match the Windows build (which generated our baseline).
 
 struct S {}

--- a/tests/hlsl-intrinsic/matrix-double.slang
+++ b/tests/hlsl-intrinsic/matrix-double.slang
@@ -1,6 +1,6 @@
 // TODO(JS):
 // It doesn't look like fxc, dxc, vk support double versions of many of the intrinsics, so they are disabled here.
-// Arguably we should implement simple intrinsics if missing in the stdlib
+// Arguably we should implement simple intrinsics if missing in the core module.
 // More complicated functions (like say sin) can also be written, if not available on a target, but requires significant
 // care.
 

--- a/tests/hlsl-intrinsic/wave.slang
+++ b/tests/hlsl-intrinsic/wave.slang
@@ -29,7 +29,7 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     /// value |= (product << 8);    
         
     // TODO(JS): NOTE! This only works with uint, *NOT* int on HLSL/DXC. 
-    // We need to update the stdlib to reflect this.
+    // We need to update the core module to reflect this.
     uint xor = WaveActiveBitXor(uint(idx + 1));
     value |= int(xor << 12);
     


### PR DESCRIPTION
Related to https://github.com/shader-slang/slang/issues/5335

This commit replaces the word "stdlib" and "standard library" in the source code with "core module".