### PR TITLE
Improvements to formatting bot

### DIFF
--- a/.github/actions/format-setup/action.yml
+++ b/.github/actions/format-setup/action.yml
@@ -7,7 +7,8 @@ runs:
   steps:
     - name: install gersemi
       shell: bash
-      run: pip3 install gersemi
+      run: |
+        pip3 install gersemi colorama
 
     - name: install clang-format
       shell: bash

--- a/.github/actions/format-setup/action.yml
+++ b/.github/actions/format-setup/action.yml
@@ -1,0 +1,20 @@
+name: Formatting tools setup
+
+description: Performs setup common to the code formatting actions
+
+runs:
+  using: composite
+  steps:
+    - name: install gersemi
+      shell: bash
+      run: pip3 install gersemi
+
+    - name: install clang-format
+      shell: bash
+      run: |
+        tmpdir=$(mktemp -d)
+        curl -L -H "Authorization: token ${{github.token}}" \
+          -o "$tmpdir/clang-format" \
+          https://github.com/shader-slang/slang-binaries/raw/4e88845ec51641b4c92e68027e359090bdb219e0/clang-format/x86_64-linux/bin/clang-format
+        chmod +x "$tmpdir/clang-format"
+        echo "$tmpdir" >> $GITHUB_PATH

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,38 +6,74 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
+          path: pr-branch
 
-      - run: pip3 install gersemi
+      - name: Checkout target branch
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.SLANGBOT_PAT }}
+          repository: ${{ github.event.client_payload.pull_request.base.repo.full_name }}
+          ref: ${{ github.event.client_payload.pull_request.base.ref }}
+          path: target-branch
 
-      - name: install clang-format
+      - name: Setup
+        uses: ./target-branch/.github/actions/format-setup
+
+      - name: Run formatting
+        id: format
         run: |
-          tmpdir=$(mktemp -d)
-          curl -L -H "Authorization: token ${{ secrets.SLANGBOT_PAT }}" \
-            -o "$tmpdir/clang-format" \
-            https://github.com/shader-slang/slang-binaries/raw/4e88845ec51641b4c92e68027e359090bdb219e0/clang-format/x86_64-linux/bin/clang-format
-          chmod +x "$tmpdir/clang-format"
-          echo "$tmpdir" >> $GITHUB_PATH
-
-      - run: ./extras/formatting.sh
+          ./target-branch/extras/formatting.sh --source ./pr-branch
 
       - name: Configure Git commit signing
+        id: git-info
         run: |
           echo "${{ secrets.SLANGBOT_SIGNING_KEY }}" > "${{runner.temp}}"/signing_key
           chmod 600 "${{runner.temp}}"/signing_key
-          git config commit.gpgsign true
-          git config gpg.format ssh
-          git config user.signingkey "${{runner.temp}}"/signing_key
+          git -C pr-branch config commit.gpgsign true
+          git -C pr-branch config gpg.format ssh
+          git -C pr-branch config user.signingkey "${{runner.temp}}"/signing_key
+          bot_info=$(curl -s -H "Authorization: Bearer ${{ secrets.SLANGBOT_PAT }}" \
+            "https://api.github.com/user")
+          echo "bot_identity=$(echo $bot_info | jq --raw-output '.login + " <" + (.id|tostring) + "+" + .login + "@users.noreply.github.com>"')" >> $GITHUB_OUTPUT
+          echo "bot_name=$(echo $bot_info | jq --raw-output '.login')" >> $GITHUB_OUTPUT
 
-      - uses: EndBug/add-and-commit@v9
+      - name: Create Pull Request
+        id: create-pr
+        uses: peter-evans/create-pull-request@v7
         with:
-          fetch: false
-          message: "format code"
-          push: true
+          token: ${{ secrets.SLANGBOT_PAT }}
+          path: pr-branch
+          commit-message: "format code"
+          title: "Format code for PR #${{ github.event.client_payload.pull_request.number }}"
+          body: "Automated code formatting for ${{ github.event.client_payload.pull_request.url }}"
+          committer: ${{ steps.git-info.outputs.bot_identity }}
+          author: ${{ steps.git-info.outputs.bot_identity }}
+          branch: format-${{ github.event.client_payload.pull_request.number }}-${{ github.event.client_payload.pull_request.head.ref }}
+          base: ${{ github.event.client_payload.pull_request.head.ref }}
+          push-to-fork: ${{ steps.git-info.outputs.bot_name }}/slang
+          delete-branch: true
+
+      - name: Comment on PR
+        uses: peter-evans/create-or-update-comment@v4
+        if: always()
+        with:
+          token: ${{ secrets.SLANGBOT_PAT }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          issue-number: ${{ github.event.client_payload.pull_request.number }}
+          body: |
+            ${{ 
+              steps.format.conclusion == 'failure'
+              && format('❌ Formatting failed. Please check the [workflow run](https://github.com/{0}/actions/runs/{1})', github.repository, github.run_id)
+              || (steps.create-pr.conclusion == 'failure' 
+                  && format('❌ Failed to create formatting pull request. Please check the [workflow run](https://github.com/{0}/actions/runs/{1})', github.repository, github.run_id)
+                  || format('🌈 Formatted, please merge the changes from [this PR]({0})', steps.create-pr.outputs.pull-request-url))
+            }}
 
       - name: Add reaction
         uses: peter-evans/create-or-update-comment@v4

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -12,14 +12,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           reaction-token: ${{ secrets.SLANGBOT_PAT }}
-          config: >
-            [
-              {
-                "command": "format",
-                "permission": "none",
-                "issue_type": "pull-request"
-              }
-            ]
+          issue-type: pull-request
+          commands: | 
+            format
 
       - name: Edit comment with error message
         if: steps.scd.outputs.error-message

--- a/extras/formatting.sh
+++ b/extras/formatting.sh
@@ -6,11 +6,13 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 source_dir="$(dirname "$script_dir")"
 
 check_only=0
+no_version_check=0
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
   -h | --help) help=1 ;;
   --check-only) check_only=1 ;;
+  --no-version-check) no_version_check=1 ;;
   --source)
     source_dir="$2"
     shift
@@ -24,11 +26,12 @@ if [ "$help" ]; then
   cat <<EOF
 $me: Format or check formatting of files in this repo
 
-Usage: $me [--check-only] [--source <path>]
+Usage: $me [--check-only] [--no-version-check] [--source <path>]
 
 Options:
-    --check-only     Check formatting without modifying files
-    --source         Path to source directory to format (defaults to parent of script directory)
+    --check-only       Check formatting without modifying files
+    --no-version-check Skip version compatibility checks
+    --source           Path to source directory to format (defaults to parent of script directory)
 EOF
   exit 0
 fi
@@ -46,10 +49,12 @@ require_bin() {
     return
   fi
 
-  version=$("$name" --version | grep -oP "$name(?:\s+version)?\s+\K\d+\.\d+\.?\d*")
-  if ! printf '%s\n%s\n' "$required" "$version" | sort -V -C; then
-    echo "$name version $version is too old. Version $required or newer is required."
-    missing_bin=1
+  if [ "$no_version_check" -eq 0 ]; then
+    version=$("$name" --version | grep -oP "$name(?:\s+version)?\s+\K\d+\.\d+\.?\d*")
+    if ! printf '%s\n%s\n' "$required" "$version" | sort -V -C; then
+      echo "$name version $version is too old. Version $required or newer is required."
+      missing_bin=1
+    fi
   fi
 }
 
@@ -82,3 +87,4 @@ cmake_formatting() {
 cmake_formatting
 
 exit $exit_code
+

--- a/extras/formatting.sh
+++ b/extras/formatting.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-cd "$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)" || exit 1
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+source_dir="$(dirname "$script_dir")"
 
 check_only=0
 
@@ -11,6 +11,10 @@ while [[ "$#" -gt 0 ]]; do
   case $1 in
   -h | --help) help=1 ;;
   --check-only) check_only=1 ;;
+  --source)
+    source_dir="$2"
+    shift
+    ;;
   esac
   shift
 done
@@ -20,13 +24,16 @@ if [ "$help" ]; then
   cat <<EOF
 $me: Format or check formatting of files in this repo
 
-Usage: $me [--check-only]
+Usage: $me [--check-only] [--source <path>]
 
 Options:
     --check-only     Check formatting without modifying files
+    --source         Path to source directory to format (defaults to parent of script directory)
 EOF
   exit 0
 fi
+
+cd "$source_dir" || exit 1
 
 require_bin() {
   local name="$1"
@@ -47,11 +54,7 @@ require_bin() {
 }
 
 require_bin "git" "1.8"
-require_bin "gersemi" "0.16.2"
-
-if [ "${missing_bin:-}" = "1" ]; then
-  exit 1
-fi
+require_bin "gersemi" "0.17"
 
 if [ "$missing_bin" ]; then
   exit 1


### PR DESCRIPTION
It now opens a PR against the target branch, rather than committing directly. this means we can give the bot far fewer permissions.

Also, it formats using the script in the destination branch, which by virtue of the actions being hosted in this repository is something we've signed off on, so we should be less concerned with the bot executing arbitrary code from a PR. The disadvantage of this is that one can't change external/formatting.sh and also call `/format` to apply these changes in the same pr