### PR TITLE
Constant-fold for the type-casting in switch-case labels

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -34,8 +34,7 @@
       "description": "Options specific for MSVC",
       "cacheVariables": {
         "CMAKE_C_FLAGS_INIT": "-D_ITERATOR_DEBUG_LEVEL=0 /MP",
-        "CMAKE_CXX_FLAGS_INIT": "-D_ITERATOR_DEBUG_LEVEL=0 /MP",
-        "CMAKE_DEFAULT_BUILD_TYPE": "RelWithDebInfo"
+        "CMAKE_CXX_FLAGS_INIT": "-D_ITERATOR_DEBUG_LEVEL=0 /MP"
       }
     },
     {

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2069,12 +2069,13 @@ IntVal* SemanticsVisitor::tryConstantFoldExpr(
         if (!isValidCompileTimeConstantType(substType))
             return nullptr;
 
-        IntVal* val = nullptr; 
+        IntVal* val = nullptr;
         if (auto floatLitExpr = typeCastOperand.as<FloatingPointLiteralExpr>())
         {
-            // When explicitly casting from float type to integer type, let's fold it as an integer value.
+            // When explicitly casting from float type to integer type, let's fold it as an integer
+	    // value.
             const IntegerLiteralValue value = IntegerLiteralValue(floatLitExpr.getExpr()->value);
-            val = m_astBuilder->getIntVal(m_astBuilder->getFloatType(), value);
+            val = m_astBuilder->getIntVal(substType, value);
         }
         else
         {

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2069,17 +2069,16 @@ IntVal* SemanticsVisitor::tryConstantFoldExpr(
         if (!isValidCompileTimeConstantType(substType))
             return nullptr;
 
-        IntVal* val = nullptr;
-        if (auto floatLitExpr = typeCastOperand.as<FloatingPointLiteralExpr>())
+        IntVal* val = tryConstantFoldExpr(typeCastOperand, kind, circularityInfo);
+        if (!val)
         {
-            // When explicitly casting from float type to integer type, let's fold it as an integer
-            // value.
-            const IntegerLiteralValue value = IntegerLiteralValue(floatLitExpr.getExpr()->value);
-            val = m_astBuilder->getIntVal(substType, value);
-        }
-        else
-        {
-            val = tryConstantFoldExpr(typeCastOperand, kind, circularityInfo);
+            if (auto floatLitExpr = typeCastOperand.as<FloatingPointLiteralExpr>())
+            {
+                // When explicitly casting from float type to integer type, let's fold it as
+                // an integer value.
+                const IntegerLiteralValue value = IntegerLiteralValue(floatLitExpr.getExpr()->value);
+                val = m_astBuilder->getIntVal(substType, value);
+            }
         }
 
         if (val)

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2073,7 +2073,7 @@ IntVal* SemanticsVisitor::tryConstantFoldExpr(
         if (auto floatLitExpr = typeCastOperand.as<FloatingPointLiteralExpr>())
         {
             // When explicitly casting from float type to integer type, let's fold it as an integer
-	    // value.
+            // value.
             const IntegerLiteralValue value = IntegerLiteralValue(floatLitExpr.getExpr()->value);
             val = m_astBuilder->getIntVal(substType, value);
         }

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2068,7 +2068,19 @@ IntVal* SemanticsVisitor::tryConstantFoldExpr(
             return nullptr;
         if (!isValidCompileTimeConstantType(substType))
             return nullptr;
-        auto val = tryConstantFoldExpr(typeCastOperand, kind, circularityInfo);
+
+        IntVal* val = nullptr; 
+        if (auto floatLitExpr = typeCastOperand.as<FloatingPointLiteralExpr>())
+        {
+            // When explicitly casting from float type to integer type, let's fold it as an integer value.
+            const IntegerLiteralValue value = IntegerLiteralValue(floatLitExpr.getExpr()->value);
+            val = m_astBuilder->getIntVal(m_astBuilder->getFloatType(), value);
+        }
+        else
+        {
+            val = tryConstantFoldExpr(typeCastOperand, kind, circularityInfo);
+        }
+
         if (val)
         {
             if (!expr.getExpr()->type)

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2076,7 +2076,8 @@ IntVal* SemanticsVisitor::tryConstantFoldExpr(
             {
                 // When explicitly casting from float type to integer type, let's fold it as
                 // an integer value.
-                const IntegerLiteralValue value = IntegerLiteralValue(floatLitExpr.getExpr()->value);
+                const IntegerLiteralValue value
+                    = IntegerLiteralValue(floatLitExpr.getExpr()->value);
                 val = m_astBuilder->getIntVal(substType, value);
             }
         }

--- a/tests/bugs/gh-5372.slang
+++ b/tests/bugs/gh-5372.slang
@@ -1,0 +1,45 @@
+//TEST:SIMPLE(filecheck=SPV): -allow-glsl -target spirv-asm -entry vertexMain -stage vertex
+
+// This test is to make sure the constant-folding works for the switch-case label.
+// The shader code is from VK-CTS but modified,
+//   dEQP-VK.glsl.switch.const_expr_in_label_dynamic_fragment
+
+layout(location = 0) in highp vec4 a_position;
+layout(location = 1) in highp vec4 a_coords;
+
+layout(location = 0) out mediump vec4 v_color;
+layout (std140, set=0, binding=0) uniform buffer0 { highp int ui_two; };
+
+void vertexMain(void)
+{
+    gl_Position = a_position;
+    highp vec4 coords = a_coords;
+    mediump vec3 res = vec3(0.0);
+
+    const int t = 2;
+    switch (ui_two)
+    {
+        //SPV-NOT:([[# @LINE+1]]): error
+        case int(0.0):
+            res = coords.xyz;
+            break;
+
+        //SPV-NOT:([[# @LINE+1]]): error
+        case 2-1:
+            res = coords.wzy;
+            break;
+
+        //SPV-NOT:([[# @LINE+1]]): error
+        case 3&(1<<1):
+            res = coords.yzw;
+            break;
+
+        //SPV-NOT:([[# @LINE+1]]): error
+        case t+1:
+            res = coords.zyx;
+            break;
+    }
+
+    v_color = vec4(res, 1.0);
+}
+

--- a/tests/diagnostics/attribute-error.slang
+++ b/tests/diagnostics/attribute-error.slang
@@ -2,7 +2,7 @@
 
 // Tests reflection of user defined attributes.
 
-//DIAGNOSTIC_TEST:REFLECTION:-stage compute -entry main -target hlsl
+//TEST:SIMPLE(filecheck=REFLECTION):-stage compute -entry main -target hlsl
 
 [__AttributeUsage(_AttributeTargets.Struct)]
 struct MyStructAttribute
@@ -16,9 +16,11 @@ struct DefaultValueAttribute
     int iParam;
 };
 
+//REFLECTION:([[# @LINE+1]]): error 30019: expected an expression of type 'float', got 'String'
 [MyStruct(0, "stringVal")] // attribute arg type mismatch
 struct A
 {
+    //REFLECTION:([[# @LINE+1]]): error 31002: attribute 'MyStruct' is not valid here
     [MyStruct(0, 10.0)] // attribute does not apply to this construct
     float x;
     [DefaultValue(2.0)] // attribute arg type mismatch


### PR DESCRIPTION
Closes https://github.com/shader-slang/slang/issues/5372

When the expresion used as a switch-case labels is a type-casting from floating-point type to an integer type, the floating-point literal also need to be constant-folded.