### PR TITLE
Add function of getting hash string to wasm binding

### DIFF
--- a/source/slang-wasm/slang-wasm-bindings.cpp
+++ b/source/slang-wasm/slang-wasm-bindings.cpp
@@ -43,7 +43,10 @@ EMSCRIPTEN_BINDINGS(slang)
         .function("getEntryPointCodeBlob", &slang::wgsl::ComponentType::getEntryPointCodeBlob)
         .function("getTargetCodeBlob", &slang::wgsl::ComponentType::getTargetCodeBlob)
         .function("getTargetCode", &slang::wgsl::ComponentType::getTargetCode)
-        .function("loadStrings", &slang::wgsl::ComponentType::loadStrings, return_value_policy::take_ownership());
+        .function(
+            "loadStrings",
+            &slang::wgsl::ComponentType::loadStrings,
+            return_value_policy::take_ownership());
 
     class_<slang::wgsl::Module, base<slang::wgsl::ComponentType>>("Module")
         .function(

--- a/source/slang-wasm/slang-wasm-bindings.cpp
+++ b/source/slang-wasm/slang-wasm-bindings.cpp
@@ -42,7 +42,8 @@ EMSCRIPTEN_BINDINGS(slang)
         .function("getEntryPointCode", &slang::wgsl::ComponentType::getEntryPointCode)
         .function("getEntryPointCodeBlob", &slang::wgsl::ComponentType::getEntryPointCodeBlob)
         .function("getTargetCodeBlob", &slang::wgsl::ComponentType::getTargetCodeBlob)
-        .function("getTargetCode", &slang::wgsl::ComponentType::getTargetCode);
+        .function("getTargetCode", &slang::wgsl::ComponentType::getTargetCode)
+        .function("loadStrings", &slang::wgsl::ComponentType::loadStrings, return_value_policy::take_ownership());
 
     class_<slang::wgsl::Module, base<slang::wgsl::ComponentType>>("Module")
         .function(
@@ -214,4 +215,7 @@ EMSCRIPTEN_BINDINGS(slang)
         "createLanguageServer",
         &slang::wgsl::lsp::createLanguageServer,
         return_value_policy::take_ownership());
-}
+
+    class_<slang::wgsl::HashedString>("HashedString")
+        .function("getString", &slang::wgsl::HashedString::getString);
+};

--- a/source/slang-wasm/slang-wasm.cpp
+++ b/source/slang-wasm/slang-wasm.cpp
@@ -363,7 +363,7 @@ HashedString* ComponentType::loadStrings()
     }
 
     size_t stringSize = 0;
-    HashedString* hashedStrings  = new HashedString();
+    HashedString* hashedStrings = new HashedString();
     for (SlangUInt ii = 0; ii < hashedStringCount; ++ii)
     {
         // For each string we can fetch its bytes from the Slang

--- a/source/slang-wasm/slang-wasm.cpp
+++ b/source/slang-wasm/slang-wasm.cpp
@@ -344,6 +344,48 @@ emscripten::val ComponentType::getTargetCodeBlob(int targetIndex)
     return emscripten::val(emscripten::typed_memory_view(kernelBlob->getBufferSize(), ptr));
 }
 
+HashedString* ComponentType::loadStrings()
+{
+    slang::ProgramLayout* slangReflection = interface()->getLayout();
+    if (!slangReflection)
+    {
+        g_error.type = std::string("USER");
+        g_error.message = std::string("Failed to get reflection data");
+        return nullptr;
+    }
+
+    SlangUInt hashedStringCount = slangReflection->getHashedStringCount();
+    if (hashedStringCount == 0)
+    {
+        g_error.type = std::string("USER");
+        g_error.message = std::string("Warn: No reflection data found");
+        return nullptr;
+    }
+
+    size_t stringSize = 0;
+    HashedString* hashedStrings  = new HashedString();
+    for (SlangUInt ii = 0; ii < hashedStringCount; ++ii)
+    {
+        // For each string we can fetch its bytes from the Slang
+        // reflection data.
+        //
+        size_t stringSize = 0;
+        char const* stringData = slangReflection->getHashedString(ii, &stringSize);
+
+        // Then we can compute the hash code for that string using
+        // another Slang API function.
+        //
+        // Note: the exact hashing algorithm that Slang uses for
+        // string literals is not currently documented, and may
+        // change in future releases of the compiler.
+        //
+        int hash = spComputeStringHash(stringData, stringSize);
+
+        hashedStrings->insertString(hash, std::string(stringData));
+    }
+    return hashedStrings;
+}
+
 namespace lsp
 {
 Position translate(Slang::LanguageServerProtocol::Position p)

--- a/source/slang-wasm/slang-wasm.h
+++ b/source/slang-wasm/slang-wasm.h
@@ -38,6 +38,23 @@ private:
     std::unordered_map<std::string, SlangCompileTarget> m_compileTargetMap;
 };
 
+class HashedString
+{
+public:
+    std::string getString(uint32_t hash)
+    {
+        return m_hashedStrings[(int)hash];
+    }
+
+    void insertString(int hash, const std::string& str)
+    {
+        m_hashedStrings[hash] = str;
+    }
+private:
+
+    std::unordered_map<int, std::string> m_hashedStrings;
+};
+
 CompileTargets* getCompileTargets();
 
 class ComponentType
@@ -57,6 +74,7 @@ public:
 
     slang::IComponentType* interface() const { return m_interface; }
 
+    HashedString* loadStrings();
     virtual ~ComponentType() = default;
 
 private:

--- a/source/slang-wasm/slang-wasm.h
+++ b/source/slang-wasm/slang-wasm.h
@@ -41,17 +41,10 @@ private:
 class HashedString
 {
 public:
-    std::string getString(uint32_t hash)
-    {
-        return m_hashedStrings[(int)hash];
-    }
+    std::string getString(uint32_t hash) { return m_hashedStrings[(int)hash]; }
+    void insertString(int hash, const std::string& str) { m_hashedStrings[hash] = str; }
 
-    void insertString(int hash, const std::string& str)
-    {
-        m_hashedStrings[hash] = str;
-    }
 private:
-
     std::unordered_map<int, std::string> m_hashedStrings;
 };
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -12169,7 +12169,7 @@ void SemanticsDeclCapabilityVisitor::visitInheritanceDecl(InheritanceDecl* inher
 DeclVisibility getDeclVisibility(Decl* decl)
 {
     if (as<GenericTypeParamDecl>(decl) || as<GenericValueParamDecl>(decl) ||
-        as<GenericTypeConstraintDecl>(decl))
+        as<GenericTypeConstraintDecl>(decl) || as<GenericTypePackParamDecl>(decl))
     {
         auto genericDecl = as<GenericDecl>(decl->parentDecl);
         if (!genericDecl)

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -12168,8 +12168,8 @@ void SemanticsDeclCapabilityVisitor::visitInheritanceDecl(InheritanceDecl* inher
 
 DeclVisibility getDeclVisibility(Decl* decl)
 {
-    if (as<GenericTypeParamDecl>(decl) || as<GenericValueParamDecl>(decl) ||
-        as<GenericTypeConstraintDecl>(decl) || as<GenericTypePackParamDecl>(decl))
+    if (as<GenericTypeParamDeclBase>(decl) || as<GenericValueParamDecl>(decl) ||
+        as<GenericTypeConstraintDecl>(decl))
     {
         auto genericDecl = as<GenericDecl>(decl->parentDecl);
         if (!genericDecl)


### PR DESCRIPTION
We add the functionalities to get the hashed string from shader code into our wasm binding code. This is key to support shader printf.

Also found a bug in the visibility the type generic, we forgot handling the type pack parameter.