### PR TITLE
Improve on spirv generation compile option

### DIFF
--- a/examples/hello-world/main.cpp
+++ b/examples/hello-world/main.cpp
@@ -117,10 +117,18 @@ int HelloWorldExample::createComputePipelineFromShader()
     slang::TargetDesc targetDesc = {};
     targetDesc.format = SLANG_SPIRV;
     targetDesc.profile = slangGlobalSession->findProfile("spirv_1_5");
-    targetDesc.flags = SLANG_TARGET_FLAG_GENERATE_SPIRV_DIRECTLY;
+    targetDesc.flags = 0;
+
 
     sessionDesc.targets = &targetDesc;
     sessionDesc.targetCount = 1;
+
+    std::vector<slang::CompilerOptionEntry> options;
+    options.push_back(
+        {slang::CompilerOptionName::EmitSpirvDirectly,
+         {slang::CompilerOptionValueKind::Int, 1, 0, nullptr, nullptr}});
+    sessionDesc.compilerOptionEntries = options.data();
+    sessionDesc.compilerOptionEntryCount = options.size();
 
     ComPtr<slang::ISession> session;
     RETURN_ON_FAIL(slangGlobalSession->createSession(sessionDesc, session.writeRef()));

--- a/include/slang.h
+++ b/include/slang.h
@@ -713,6 +713,7 @@ typedef uint32_t SlangSizeT;
         SLANG_TARGET_FLAG_DUMP_IR = 1 << 9,
 
         /* When set, will generate SPIRV directly rather than via glslang. */
+        // This flag will be deprecated, use CompilerOption instead.
         SLANG_TARGET_FLAG_GENERATE_SPIRV_DIRECTLY = 1 << 10,
     };
     constexpr static SlangTargetFlags kDefaultTargetFlags =
@@ -845,6 +846,13 @@ typedef uint32_t SlangSizeT;
                                              or may involve severe space-vs-speed tradeoffs */
     };
 
+    enum SlangEmitSpirvMethod
+    {
+        SLANG_EMIT_SPIRV_DEFAULT = 0,
+        SLANG_EMIT_SPIRV_VIA_GLSL,
+        SLANG_EMIT_SPIRV_DIRECTLY,
+    };
+
     // All compiler option names supported by Slang.
     namespace slang
     {
@@ -914,8 +922,8 @@ typedef uint32_t SlangSizeT;
         GLSLForceScalarLayout,   // bool
         EnableEffectAnnotations, // bool
 
-        EmitSpirvViaGLSL,     // bool
-        EmitSpirvDirectly,    // bool
+        EmitSpirvViaGLSL,     // bool (will be deprecated)
+        EmitSpirvDirectly,    // bool (will be deprecated)
         SPIRVCoreGrammarJSON, // stringValue0: json path
         IncompleteLibrary,    // bool, when set, will not issue an error when the linked program has
                               // unresolved extern function symbols.
@@ -991,6 +999,10 @@ typedef uint32_t SlangSizeT;
                                  // precompiled modules if it is up-to-date with its source.
         EmbedDownstreamIR,       // bool
         ForceDXLayout,           // bool
+
+        // Add this new option to the end of the list to avoid breaking ABI as much as possible.
+        // Setting of EmitSpirvDirectly or EmitSpirvViaGLSL will turn into this option internally.
+        EmitSpirvMethod, // enum SlangEmitSpirvMethod
         CountOf,
     };
 

--- a/source/slang/slang-compiler-options.h
+++ b/source/slang/slang-compiler-options.h
@@ -334,9 +334,10 @@ struct CompilerOptionSet
 
     bool shouldEmitSPIRVDirectly()
     {
-        if (getBoolOption(CompilerOptionName::EmitSpirvViaGLSL))
-            return false;
-        return true;
+        SlangEmitSpirvMethod emitSpvMethod =
+            getEnumOption<SlangEmitSpirvMethod>(CompilerOptionName::EmitSpirvMethod);
+
+        return (emitSpvMethod != SlangEmitSpirvMethod::SLANG_EMIT_SPIRV_VIA_GLSL);
     }
 
     bool shouldUseScalarLayout()

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -2728,7 +2728,20 @@ SlangResult OptionsParser::_parse(int argc, char const* const* argv)
         case OptionKind::EmitSpirvViaGLSL:
         case OptionKind::EmitSpirvDirectly:
             {
-                getCurrentTarget()->optionSet.add(optionKind, true);
+                SlangEmitSpirvMethod selectMethod = (optionKind == OptionKind::EmitSpirvViaGLSL)
+                                                        ? SLANG_EMIT_SPIRV_VIA_GLSL
+                                                        : SLANG_EMIT_SPIRV_DIRECTLY;
+
+                SlangEmitSpirvMethod currentMethod =
+                    getCurrentTarget()->optionSet.getEnumOption<SlangEmitSpirvMethod>(
+                        OptionKind::EmitSpirvMethod);
+                // When both flag turns on, spirv-direcly mode will always take higher priority.
+                // By default (value 0), spirv-via-glsl mode is used, and any input flag can
+                // override the default value.
+                if (selectMethod > currentMethod)
+                {
+                    getCurrentTarget()->optionSet.set(OptionKind::EmitSpirvMethod, selectMethod);
+                }
             }
             break;
         case OptionKind::SPIRVCoreGrammarJSON:


### PR DESCRIPTION
CompilerOptionName::EmitSpirvViaGLSL and CompilerOptionName::EmitSpirvDirectly options are not mutually exclusive, but due to compatible reason, we cannot delete those options. Instead, this change makes the effort to create a new option name EmitSpirvMethod, and we will turn those two options into the new one internally. Also, we put a priority implicitly on those two options, where EmitSpirvDirectly always win if it's set.

We have another location that can setup the same option, where is through SlangTargetFlags::SLANG_TARGET_FLAG_GENERATE_SPIRV_DIRECTLY.

We should definitely deprecate this flag to avoid more confusing. But for the same compatible reason, we cannot do that in this PR. Again, we will encourage people to not use this flag, but using the CompilerOptionName instead. In this PR, we will also implicitly give CompilerOptionName higher priority, it means that as long as user setup the CompilerOptionName for emit spirv method, it always take higher priority for the final decision.