### PR TITLE
Revert uint<->int implicit cast cost to prefer promotion to unsigned.

### DIFF
--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -127,10 +127,10 @@ enum : ConversionCost
 
     // Same-size size unsigned->signed conversions are potentially lossy, but they are commonly
     // allowed silently.
-    kConversionCost_SameSizeUnsignedToSignedConversion = 250,
+    kConversionCost_SameSizeUnsignedToSignedConversion = 300,
 
     // Conversion from signed->unsigned integer of same or greater size
-    kConversionCost_SignedToUnsignedConversion = 300,
+    kConversionCost_SignedToUnsignedConversion = 250,
 
     // Cost of converting an integer to a floating-point type
     kConversionCost_IntegerToFloatConversion = 400,

--- a/tests/compute/unbounded-array-of-array-syntax.slang
+++ b/tests/compute/unbounded-array-of-array-syntax.slang
@@ -1,6 +1,6 @@
 //IGNORE_TEST:CPU_REFLECTION: -profile cs_5_0 -entry computeMain -target cpp
 //DISABLED_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute
-//TEST:CROSS_COMPILE:-target dxbc-assembly -entry computeMain -profile cs_5_1
+//TEST:SIMPLE(filecheck=DXIL):-target dxbc-assembly -entry computeMain -profile cs_5_1
 //TEST:SIMPLE(filecheck=CHECK):-target spirv-assembly -entry computeMain -profile cs_5_1 -emit-spirv-via-glsl
 //DISABLED_TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute
 
@@ -16,6 +16,7 @@ RWStructuredBuffer<int> g_aoa[];
 [numthreads(8, 1, 1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
+    // DXIL: cs_5_1
     // CHECK: OpCapability {{(ShaderNonUniform|StorageBufferArrayNonUniformIndexing)}}
     // CHECK: OpCapability {{(ShaderNonUniform|StorageBufferArrayNonUniformIndexing)}}
     // CHECK-DAG: OpDecorate %[[N1:[a-zA-Z0-9_]+]] NonUniform

--- a/tests/language-feature/overload-resolution-signed-unsigned.slang
+++ b/tests/language-feature/overload-resolution-signed-unsigned.slang
@@ -1,0 +1,20 @@
+//TEST:SIMPLE(filecheck=CHECK): -target hlsl -stage compute -entry main
+RWStructuredBuffer<float> result;
+// CHECK-NOT: result{{.*}}[int(0)] = 1
+// CHECK: result{{.*}}[int(0)] = 2
+// CHECK-NOT: result{{.*}}[int(0)] = 1
+[numthreads(1,1,1)]
+void main()
+{
+    int ic = -1;
+    uint a = 2;
+    if (ic < a)
+    {
+        result[0] = 1;
+    }
+    else
+    {
+        // Should pick this branch according to C spec.
+        result[0] = 2;
+    }
+}

--- a/tests/metal/atomic-texture-texture1d.slang
+++ b/tests/metal/atomic-texture-texture1d.slang
@@ -128,7 +128,7 @@ void test()
 	InterlockedOr(intTexture1DArray[0], valInt, originalValueInt);
 	InterlockedXor(intTexture1DArray[0], valInt, originalValueInt);
 	InterlockedExchange(intTexture1DArray[0], valInt, originalValueInt);
-	InterlockedCompareExchange(intTexture1DArray[0], valInt, compareValueInt, originalValueUInt);
+	InterlockedCompareExchange(intTexture1DArray[0], valInt, compareValueInt, originalValueInt);
 	InterlockedCompareStore(intTexture1DArray[0], valUInt, compareValueUInt);
 
 	InterlockedAdd(uintTexture1DArray[0], valUInt);


### PR DESCRIPTION
This is a breaking change, but the change is to make Slang's overload resolution aligned with C specification.

Basically, when there is a binary operator that takes (int, int) or (uint, uint), and the argument is of type (int, uint), the expected behavior is to convert the `int` to `uint` instead of the other way around.

Closes #5473.