### PR TITLE
Fix user-attribute-lookup wgpu crash

### DIFF
--- a/tests/bugs/user-attribute-lookup.slang
+++ b/tests/bugs/user-attribute-lookup.slang
@@ -1,6 +1,6 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
 //TEST(compute,vulkan):COMPARE_COMPUTE_EX:-vk -slang -compute -shaderobj
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-wgpu
+//TEST_INPUT: Sampler:name samplerState
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;


### PR DESCRIPTION
The WGPU backend was crashing because of the
unbound sampler state. Fix the test by adding
a test sampler.

Issue 5277