### PR TITLE
Require GL_EXT_samplerless_texture_functions only if needed

### DIFF
--- a/source/slang/slang-core-module-textures.cpp
+++ b/source/slang/slang-core-module-textures.cpp
@@ -374,6 +374,7 @@ void TextureTypeInfo::writeGetDimensionFunctions()
                         glsl << ", ($" << aa++ << " = textureQueryLevels($0))";
                     }
                 };
+                glsl << "if (isCombined == 0) { __requireGLSLExtension(\"GL_EXT_samplerless_texture_functions\"); }\n";
                 glsl << "if (access == " << kCoreModule_ResourceAccessReadOnly
                      << ") __intrinsic_asm \"";
                 emitIntrinsic(toSlice("textureSize"), !isMultisample);
@@ -491,7 +492,6 @@ void TextureTypeInfo::writeGetDimensionFunctions()
             }
 
             sb << "    __glsl_version(450)\n";
-            sb << "    __glsl_extension(GL_EXT_samplerless_texture_functions)\n";
 
             sb << "    [require(cpp";
             if (glsl.getLength())

--- a/source/slang/slang-core-module-textures.cpp
+++ b/source/slang/slang-core-module-textures.cpp
@@ -374,7 +374,8 @@ void TextureTypeInfo::writeGetDimensionFunctions()
                         glsl << ", ($" << aa++ << " = textureQueryLevels($0))";
                     }
                 };
-                glsl << "if (isCombined == 0) { __requireGLSLExtension(\"GL_EXT_samplerless_texture_functions\"); }\n";
+                glsl << "if (isCombined == 0) { "
+                        "__requireGLSLExtension(\"GL_EXT_samplerless_texture_functions\"); }\n";
                 glsl << "if (access == " << kCoreModule_ResourceAccessReadOnly
                      << ") __intrinsic_asm \"";
                 emitIntrinsic(toSlice("textureSize"), !isMultisample);

--- a/tests/bugs/gh-5518.slang
+++ b/tests/bugs/gh-5518.slang
@@ -1,0 +1,18 @@
+//TEST:SIMPLE(filecheck=GLSL): -profile spirv_1_5+fragment -entry fragmentMain -target glsl
+
+// Ensure that the use of combined samplers does not needlessly require
+// GL_EXT_samplerless_texture_functions
+
+// GLSL-NOT: #extension GL_EXT_samplerless_texture_functions : require
+
+layout(binding=1) Sampler3D sampler;
+
+[shader("fragment")]
+float4 fragmentMain() : SV_Target
+{
+	int sizeX;
+	int sizeY;
+	int sizeZ;
+	sampler.GetDimensions(sizeX, sizeY, sizeZ);
+	return float4(sizeX, sizeY, sizeZ, 1.0);
+}


### PR DESCRIPTION
This extension is only necessary when using texture functions on non-combined texture/samplers.

Fixes #5518