### PR TITLE
Fix two specialization bugs

### DIFF
--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -873,6 +873,7 @@ static void maybeCopyLayoutInformationToParameters(IRFunc* func, IRBuilder* buil
 
 IRFunc* specializeIRForEntryPoint(
     IRSpecContext* context,
+    String const& mangledName,
     EntryPoint* entryPoint,
     UnownedStringSlice nameOverride)
 {
@@ -886,7 +887,6 @@ IRFunc* specializeIRForEntryPoint(
     // not the same as the mangled name of the decl.
     //
     RefPtr<IRSpecSymbol> sym;
-    auto mangledName = entryPoint->getEntryPointMangledName(0);
     if (!context->getSymbols().tryGetValue(mangledName, sym))
     {
         String hashedName = getHashedName(mangledName.getUnownedSlice());
@@ -1830,7 +1830,7 @@ LinkedIR linkIR(CodeGenContext* codeGenContext)
         auto nameOverride = program->getEntryPointNameOverride(entryPointIndex);
         auto entryPoint = program->getEntryPoint(entryPointIndex).get();
         irEntryPoints.add(
-            specializeIRForEntryPoint(context, entryPoint, nameOverride.getUnownedSlice()));
+            specializeIRForEntryPoint(context, entryPointMangledName, entryPoint, nameOverride.getUnownedSlice()));
     }
 
     // Layout information for global shader parameters is also required,

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -2980,7 +2980,7 @@ IRInst* specializeGenericImpl(
 
     List<IRInst*> pendingWorkList;
     SLANG_DEFER(for (Index ii = pendingWorkList.getCount() - 1; ii >= 0; ii--)
-                    context->addToWorkList(pendingWorkList[ii]););
+                    if(context) context->addToWorkList(pendingWorkList[ii]););
 
     // Now we will run through the body of the generic and
     // clone each of its instructions into the global scope,


### PR DESCRIPTION
The first bug was introduced in b2ca2d5a4efeae807d3c3f48f60235e47413b559 and ran some code at scope exit that dereferenced a nullptr context.

The second bug was introduced in bea1394ad35680940a0b69b9c67efc43764cc194 and would cause the wrong mangled name to be used during specialization.

This closes #5516.