### PR TITLE
Make `getDependencyFilePath` return most unique identity.

### DIFF
--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -2722,7 +2722,7 @@ SLANG_NO_THROW char const* SLANG_MCALL Module::getDependencyFilePath(SlangInt32 
 {
     SourceFile* sourceFile = getFileDependencies()[index];
     return sourceFile->getPathInfo().hasFoundPath()
-               ? sourceFile->getPathInfo().foundPath.getBuffer()
+               ? sourceFile->getPathInfo().getMostUniqueIdentity().getBuffer()
                : nullptr;
 }
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -6890,7 +6890,7 @@ char const* EndToEndCompileRequest::getDependencyFilePath(int index)
     auto program = frontEndReq->getGlobalAndEntryPointsComponentType();
     SourceFile* sourceFile = program->getFileDependencies()[index];
     return sourceFile->getPathInfo().hasFoundPath()
-               ? sourceFile->getPathInfo().foundPath.getBuffer()
+               ? sourceFile->getPathInfo().getMostUniqueIdentity().getBuffer()
                : "unknown";
 }
 


### PR DESCRIPTION
Closes #5332.