### PR TITLE
Remove 'raw' default construct insts for SPIRV emit

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -89,6 +89,7 @@
 #include "slang-ir-ssa.h"
 #include "slang-ir-string-hash.h"
 #include "slang-ir-strip-cached-dict.h"
+#include "slang-ir-strip-default-construct.h"
 #include "slang-ir-strip-witness-tables.h"
 #include "slang-ir-strip.h"
 #include "slang-ir-synthesize-active-mask.h"
@@ -1418,6 +1419,19 @@ Result linkAndOptimizeIR(
     // If we are going to support function-pointer based, "real" modular dynamic dispatch,
     // we will need to disable this pass.
     stripWitnessTables(irModule);
+
+    switch (target)
+    {
+    // On targets that don't support default initialization, remove 'raw' default construct
+    // insts because our code-gen will not have any way to emit them.
+    //
+    case CodeGenTarget::SPIRV:
+        if (targetProgram->shouldEmitSPIRVDirectly())
+            removeRawDefaultConstructors(irModule);
+        break;
+    default:
+        break;
+    }
 
 #if 0
     dumpIRIfEnabled(codeGenContext, irModule, "AFTER STRIP WITNESS TABLES");

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -2894,6 +2894,13 @@ struct IRUndefined : IRInst
 {
 };
 
+// Special inst for targets that support default initialization,
+// like the braces '= {}' in C/HLSL
+struct IRDefaultConstruct : IRInst
+{
+    IR_LEAF_ISA(DefaultConstruct)
+};
+
 // A global-scope generic parameter (a type parameter, a
 // constraint parameter, etc.)
 struct IRGlobalGenericParam : IRInst

--- a/source/slang/slang-ir-strip-default-construct.cpp
+++ b/source/slang/slang-ir-strip-default-construct.cpp
@@ -1,0 +1,45 @@
+// slang-ir-strip-default-construct.cpp
+#include "slang-ir-strip-default-construct.h"
+
+#include "slang-ir-inst-pass-base.h"
+#include "slang-ir-insts.h"
+#include "slang-ir.h"
+
+namespace Slang
+{
+
+struct RemoveDefaultConstructInsts : InstPassBase
+{
+    RemoveDefaultConstructInsts(IRModule* module)
+        : InstPassBase(module)
+    {
+    }
+    void processModule()
+    {
+        processInstsOfType<IRDefaultConstruct>(
+            kIROp_DefaultConstruct,
+            [&](IRDefaultConstruct* defaultConstruct)
+            {
+                List<IRInst*> instsToRemove;
+                for (auto use = defaultConstruct->firstUse; use; use = use->nextUse)
+                {
+                    if (as<IRStore>(use->getUser()))
+                        instsToRemove.add(use->getUser());
+                    else
+                        return; // Ignore this inst if there are non-store uses.
+                }
+
+                for (auto inst : instsToRemove)
+                    inst->removeAndDeallocate();
+
+                defaultConstruct->removeAndDeallocate();
+            });
+    }
+};
+
+void removeRawDefaultConstructors(IRModule* module)
+{
+    RemoveDefaultConstructInsts(module).processModule();
+}
+
+} // namespace Slang

--- a/source/slang/slang-ir-strip-default-construct.h
+++ b/source/slang/slang-ir-strip-default-construct.h
@@ -1,0 +1,11 @@
+// slang-ir-strip-default-construct.h
+#pragma once
+
+namespace Slang
+{
+struct IRModule;
+
+/// Strip the contents of all witness table instructions from the given IR `module`
+void removeRawDefaultConstructors(IRModule* module);
+
+} // namespace Slang


### PR DESCRIPTION
Our auto-diff step currently emits a few 'raw' `OpDefaultConstruct` insts for intermediate data types, mostly to silence HLSL errors about uninitialized variables. This is a redundant inst, because our auto-diff pass will always make sure all generated fields are individually set.
 
Usually, these intermediate types are made up of zero-initializable types so they get lowered to `OpMakeStruct`, so targets like SPIRV where `OpDefaultConstruct` does not exist don't run into issues.

For some special types, it is not easy (or safe) to emit such zero initializers, so we will instead run a pass to remove `OpDefaultConstruct` for backends where it is not available (thankfully, these backends do not complain about uninitialized variables, so the code correctness is unaffected)
