### PR TITLE
Fix specialization constant miscompile in glsl mode.

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1709,6 +1709,18 @@ void SemanticsDeclHeaderVisitor::maybeApplyLayoutModifier(VarDeclBase* varDecl)
     }
 }
 
+bool isSpecializationConstant(VarDeclBase* varDecl)
+{
+    for (auto modifier : varDecl->modifiers)
+    {
+        if (as<SpecializationConstantAttribute>(modifier))
+            return true;
+        if (as<VkConstantIdAttribute>(modifier))
+            return true;
+    }
+    return false;
+}
+
 void SemanticsDeclHeaderVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
 {
     // A variable that didn't have an explicit type written must
@@ -1943,7 +1955,7 @@ void SemanticsDeclHeaderVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
             // without any `uniform` modifiers as true global variables by default.
             if (!varDecl->findModifier<HLSLUniformModifier>() &&
                 !varDecl->findModifier<InModifier>() && !varDecl->findModifier<OutModifier>() &&
-                !varDecl->findModifier<GLSLBufferModifier>())
+                !varDecl->findModifier<GLSLBufferModifier>() && !isSpecializationConstant(varDecl))
             {
                 if (!isUniformParameterType(varDecl->type))
                 {

--- a/tests/spirv/specialization-constant.slang
+++ b/tests/spirv/specialization-constant.slang
@@ -1,4 +1,6 @@
+//TEST:SIMPLE(filecheck=GLSL): -target glsl -allow-glsl
 //TEST:SIMPLE(filecheck=GLSL): -target glsl
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -allow-glsl
 //TEST:SIMPLE(filecheck=CHECK): -target spirv
 
 // CHECK-DAG: OpDecorate %[[C0:[0-9A-Za-z_]+]] SpecId 0


### PR DESCRIPTION
Closes [#5463](https://github.com/shader-slang/slang/issues/5463).