### PR TITLE
Embed core module in wasm build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ vkd3d-proton.cache.write
 .*.swp
 .*.swo
 /generators
+/tests/library/linked.spirv

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,6 +22,7 @@
       "binaryDir": "${sourceDir}/build.em",
       "cacheVariables": {
         "SLANG_SLANG_LLVM_FLAVOR": "DISABLE",
+        "SLANG_EMBED_CORE_MODULE": "ON",
         "CMAKE_C_FLAGS_INIT": "-fwasm-exceptions -Os",
         "CMAKE_CXX_FLAGS_INIT": "-fwasm-exceptions -Os",
         "CMAKE_EXE_LINKER_FLAGS": "-sASSERTIONS -sALLOW_MEMORY_GROWTH -fwasm-exceptions --export=__cpp_exception"
@@ -71,7 +72,8 @@
       "inherits": "default",
       "description": "Build the compile time generators used in building Slang",
       "cacheVariables": {
-        "SLANG_SLANG_LLVM_FLAVOR": "DISABLE"
+        "SLANG_SLANG_LLVM_FLAVOR": "DISABLE",
+        "SLANG_ENABLE_SLANG_RHI": false
       }
     }
   ],
@@ -95,19 +97,25 @@
       "name": "emscripten",
       "configurePreset": "emscripten",
       "configuration": "Release",
-      "targets": ["slang-wasm"]
+      "targets": [
+        "slang-wasm"
+      ]
     },
     {
       "name": "generators",
       "inherits": "release",
       "configurePreset": "generators",
-      "targets": ["all-generators"]
+      "targets": [
+        "all-generators"
+      ]
     },
     {
       "name": "slang-llvm",
       "inherits": "release",
       "configurePreset": "slang-llvm",
-      "targets": ["slang-llvm"]
+      "targets": [
+        "slang-llvm"
+      ]
     }
   ],
   "packagePresets": [
@@ -115,7 +123,9 @@
       "name": "base",
       "hidden": true,
       "configurePreset": "default",
-      "generators": ["ZIP"],
+      "generators": [
+        "ZIP"
+      ],
       "variables": {
         "CPACK_PACKAGE_FILE_NAME": "slang",
         "CPACK_COMPONENTS_ALL": "Unspecified;metadata;slang-llvm"
@@ -124,19 +134,25 @@
     {
       "name": "release",
       "inherits": "base",
-      "configurations": ["Release"],
+      "configurations": [
+        "Release"
+      ],
       "packageDirectory": "dist-release"
     },
     {
       "name": "releaseWithDebugInfo",
       "inherits": "base",
-      "configurations": ["RelWithDebInfo"],
+      "configurations": [
+        "RelWithDebInfo"
+      ],
       "packageDirectory": "dist-releaseWithDebugInfo"
     },
     {
       "name": "debug",
       "inherits": "base",
-      "configurations": ["Debug"],
+      "configurations": [
+        "Debug"
+      ],
       "packageDirectory": "dist-debug"
     },
     {

--- a/source/compiler-core/slang-artifact-associated-impl.h
+++ b/source/compiler-core/slang-artifact-associated-impl.h
@@ -189,7 +189,7 @@ public:
         SLANG_OVERRIDE;
 
     // IMetadata
-    SLANG_NO_THROW virtual SlangResult SLANG_MCALL isParameterLocationUsed(
+    SLANG_NO_THROW virtual SlangResult isParameterLocationUsed(
         SlangParameterCategory category, // is this a `t` register? `s` register?
         SlangUInt spaceIndex,            // `space` for D3D12, `set` for Vulkan
         SlangUInt registerIndex,         // `register` for D3D12, `binding` for Vulkan

--- a/source/slang-record-replay/record/slang-module.h
+++ b/source/slang-record-replay/record/slang-module.h
@@ -180,7 +180,7 @@ public:
             outDiagnostics);
     }
 
-    virtual SLANG_NO_THROW slang::DeclReflection* getModuleReflection() override;
+    virtual SLANG_NO_THROW slang::DeclReflection* SLANG_MCALL getModuleReflection() override;
 
     slang::IModule* getActualModule() const { return m_actualModule; }
 

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -552,7 +552,7 @@ class GenericTypeParamDeclBase : public SimpleTypeDecl
     SLANG_AST_CLASS(GenericTypeParamDeclBase)
 
     // The index of the generic parameter.
-    Index parameterIndex = -1;
+    int parameterIndex = -1;
 };
 
 class GenericTypeParamDecl : public GenericTypeParamDeclBase
@@ -597,7 +597,7 @@ class GenericValueParamDecl : public VarDeclBase
     SLANG_AST_CLASS(GenericValueParamDecl)
 
     // The index of the generic parameter.
-    Index parameterIndex = 0;
+    int parameterIndex = 0;
 };
 
 // An empty declaration (which might still have modifiers attached).

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -293,7 +293,7 @@ class SwizzleExpr : public Expr
 {
     SLANG_AST_CLASS(SwizzleExpr)
     Expr* base = nullptr;
-    ShortList<UInt, 4> elementIndices;
+    ShortList<uint32_t, 4> elementIndices;
     SourceLoc memberOpLoc;
 };
 

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -398,7 +398,7 @@ class HLSLPackOffsetSemantic : public HLSLLayoutSemantic
 {
     SLANG_AST_CLASS(HLSLPackOffsetSemantic)
 
-    Index uniformOffset = 0;
+    int uniformOffset = 0;
 };
 
 

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -689,7 +689,7 @@ struct SubstitutionSet
     // `T` is a type pack, then packExpansionIndex will have a value starting from 0
     // to the count of the type pack during expansion of the `expand` type when we
     // substitute `each T` with the element of `T` at index `packExpansionIndex`.
-    Index packExpansionIndex = -1;
+    int packExpansionIndex = -1;
 
     SubstitutionSet() = default;
     SubstitutionSet(DeclRefBase* declRefBase)

--- a/source/slang/slang-ast-type.cpp
+++ b/source/slang/slang-ast-type.cpp
@@ -706,7 +706,7 @@ Val* ExpandType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet
         ShortList<Type*> expandedTypes;
         SLANG_ASSERT(capturedPacks.getCount() != 0);
 
-        for (Index i = 0; i < concreteTypePacks[0]->getTypeCount(); i++)
+        for (int i = 0; i < (int)concreteTypePacks[0]->getTypeCount(); i++)
         {
             subst.packExpansionIndex = i;
             auto substElementType = getPatternType()->substituteImpl(astBuilder, subst, &diff);

--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -364,7 +364,7 @@ Val* ExpandSubtypeWitness::_substituteImplOverride(
         // If sub is substituted into a concrete type pack, we should return a
         // TypePackSubtypeWitness.
         ShortList<SubtypeWitness*> newWitnesses;
-        for (Index i = 0; i < subTypePack->getTypeCount(); i++)
+        for (int i = 0; i < (int)subTypePack->getTypeCount(); i++)
         {
             auto elementType = subTypePack->getElementType(i);
             subst.packExpansionIndex = i;

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2817,7 +2817,7 @@ void SemanticsDeclHeaderVisitor::visitGenericDecl(GenericDecl* genericDecl)
     //
     // Accessing the members via index side steps the issue.
 
-    Index parameterIndex = 0;
+    int parameterIndex = 0;
     const auto& members = genericDecl->members;
     for (Index i = 0; i < members.getCount(); ++i)
     {
@@ -4392,7 +4392,7 @@ void SemanticsVisitor::addRequiredParamsToSynthesizedDecl(
                 auto elementType = typePack->getElementType(i);
                 auto synMemberExpr = m_astBuilder->create<SwizzleExpr>();
                 synMemberExpr->base = synArg;
-                synMemberExpr->elementIndices.add((UInt)i);
+                synMemberExpr->elementIndices.add((uint32_t)i);
                 synMemberExpr->type = elementType;
                 synArgs.add(synMemberExpr);
             }

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -4308,7 +4308,7 @@ Expr* SemanticsVisitor::checkTupleSwizzleExpr(MemberExpr* memberExpr, TupleType*
     auto span = swizzleText.getUnownedSlice();
     Index pos = 0;
 
-    ShortList<UInt> elementCoords;
+    ShortList<uint32_t> elementCoords;
 
     bool anyDuplicates = false;
 
@@ -4316,7 +4316,7 @@ Expr* SemanticsVisitor::checkTupleSwizzleExpr(MemberExpr* memberExpr, TupleType*
     // Every update to cursor corresponds to a check against 0-termination
     while (pos < span.getLength())
     {
-        UInt elementCoord;
+        uint32_t elementCoord;
 
         // Check for the preceding underscore
         if (span[pos] != '_')
@@ -4341,7 +4341,7 @@ Expr* SemanticsVisitor::checkTupleSwizzleExpr(MemberExpr* memberExpr, TupleType*
             // member lookup.
             return checkGeneralMemberLookupExpr(memberExpr, baseTupleType);
         }
-        elementCoord = (UInt)StringUtil::parseIntAndAdvancePos(span, pos);
+        elementCoord = (uint32_t)StringUtil::parseIntAndAdvancePos(span, pos);
 
         if (elementCoord >= tupleElementCount)
         {
@@ -4400,7 +4400,7 @@ Expr* SemanticsVisitor::CheckSwizzleExpr(
     swizExpr->memberOpLoc = memberRefExpr->memberOperatorLoc;
     IntegerLiteralValue limitElement = baseElementCount;
 
-    ShortList<UInt, 4> elementIndices;
+    ShortList<uint32_t, 4> elementIndices;
 
     bool anyDuplicates = false;
     bool anyError = false;

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -1622,7 +1622,7 @@ public:
 
     virtual void buildHash(DigestBuilder<SHA1>& builder) SLANG_OVERRIDE;
 
-    virtual slang::DeclReflection* getModuleReflection() SLANG_OVERRIDE;
+    virtual slang::DeclReflection* SLANG_MCALL getModuleReflection() SLANG_OVERRIDE;
 
     void setDigest(SHA1::Digest const& digest) { m_digest = digest; }
     SHA1::Digest computeDigest();

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -4253,7 +4253,17 @@ public:
         UInt elementCount,
         IRInst* const* elementIndices);
 
-    IRInst* emitSwizzle(IRType* type, IRInst* base, UInt elementCount, UInt const* elementIndices);
+    IRInst* emitSwizzle(
+        IRType* type,
+        IRInst* base,
+        UInt elementCount,
+        uint64_t const* elementIndices);
+
+    IRInst* emitSwizzle(
+        IRType* type,
+        IRInst* base,
+        UInt elementCount,
+        uint32_t const* elementIndices);
 
     IRInst* emitSwizzleSet(
         IRType* type,
@@ -4267,7 +4277,14 @@ public:
         IRInst* base,
         IRInst* source,
         UInt elementCount,
-        UInt const* elementIndices);
+        uint64_t const* elementIndices);
+
+    IRInst* emitSwizzleSet(
+        IRType* type,
+        IRInst* base,
+        IRInst* source,
+        UInt elementCount,
+        uint32_t const* elementIndices);
 
     IRInst* emitSwizzledStore(
         IRInst* dest,
@@ -4279,7 +4296,13 @@ public:
         IRInst* dest,
         IRInst* source,
         UInt elementCount,
-        UInt const* elementIndices);
+        uint32_t const* elementIndices);
+
+    IRInst* emitSwizzledStore(
+        IRInst* dest,
+        IRInst* source,
+        UInt elementCount,
+        uint64_t const* elementIndices);
 
 
     IRInst* emitReturn(IRInst* val);

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -5311,7 +5311,24 @@ IRInst* IRBuilder::emitSwizzle(
     IRType* type,
     IRInst* base,
     UInt elementCount,
-    UInt const* elementIndices)
+    uint64_t const* elementIndices)
+{
+    auto intType = getBasicType(BaseType::Int);
+
+    IRInst* irElementIndices[4];
+    for (UInt ii = 0; ii < elementCount; ++ii)
+    {
+        irElementIndices[ii] = getIntValue(intType, elementIndices[ii]);
+    }
+
+    return emitSwizzle(type, base, elementCount, irElementIndices);
+}
+
+IRInst* IRBuilder::emitSwizzle(
+    IRType* type,
+    IRInst* base,
+    UInt elementCount,
+    uint32_t const* elementIndices)
 {
     auto intType = getBasicType(BaseType::Int);
 
@@ -5380,7 +5397,25 @@ IRInst* IRBuilder::emitSwizzleSet(
     IRInst* base,
     IRInst* source,
     UInt elementCount,
-    UInt const* elementIndices)
+    uint32_t const* elementIndices)
+{
+    auto intType = getBasicType(BaseType::Int);
+
+    IRInst* irElementIndices[4];
+    for (UInt ii = 0; ii < elementCount; ++ii)
+    {
+        irElementIndices[ii] = getIntValue(intType, elementIndices[ii]);
+    }
+
+    return emitSwizzleSet(type, base, source, elementCount, irElementIndices);
+}
+
+IRInst* IRBuilder::emitSwizzleSet(
+    IRType* type,
+    IRInst* base,
+    IRInst* source,
+    UInt elementCount,
+    uint64_t const* elementIndices)
 {
     auto intType = getBasicType(BaseType::Int);
 
@@ -5419,7 +5454,24 @@ IRInst* IRBuilder::emitSwizzledStore(
     IRInst* dest,
     IRInst* source,
     UInt elementCount,
-    UInt const* elementIndices)
+    uint32_t const* elementIndices)
+{
+    auto intType = getBasicType(BaseType::Int);
+
+    IRInst* irElementIndices[4];
+    for (UInt ii = 0; ii < elementCount; ++ii)
+    {
+        irElementIndices[ii] = getIntValue(intType, elementIndices[ii]);
+    }
+
+    return emitSwizzledStore(dest, source, elementCount, irElementIndices);
+}
+
+IRInst* IRBuilder::emitSwizzledStore(
+    IRInst* dest,
+    IRInst* source,
+    UInt elementCount,
+    uint64_t const* elementIndices)
 {
     auto intType = getBasicType(BaseType::Int);
 

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -333,8 +333,8 @@ struct SwizzledLValueInfo : ExtendedValueInfo
     // The base expression (this should be an l-value)
     LoweredValInfo base;
 
-    // THe indices for the elements being swizzled
-    ShortList<UInt, 4> elementIndices;
+    // The indices for the elements being swizzled
+    ShortList<uint32_t, 4> elementIndices;
 };
 
 // Represents the result of a matrix swizzle operation in an l-value context.
@@ -5495,7 +5495,7 @@ struct LValueExprLoweringVisitor : ExprLoweringVisitorBase<LValueExprLoweringVis
             RefPtr<SwizzledLValueInfo> swizzledLValue = new SwizzledLValueInfo;
             swizzledLValue->type = irType;
             swizzledLValue->base = baseSwizzleInfo->base;
-            swizzledLValue->elementIndices = elementCount;
+            swizzledLValue->elementIndices.add((uint32_t)elementCount);
 
             // Take the swizzle element of the "outer" swizzle, as it was
             // written by the user. In our running example of `foo[i].zw.y`
@@ -7146,7 +7146,7 @@ void assign(IRGenContext* context, LoweredValInfo const& inLeft, LoweredValInfo 
     // If there's a single element, just emit a regular store, otherwise
     // proceed with a swizzle store
     auto swizzledStore =
-        [builder](IRInst* dest, IRInst* source, UInt elementCount, UInt const* elementIndices)
+        [builder](IRInst* dest, IRInst* source, UInt elementCount, uint32_t const* elementIndices)
     {
         if (elementCount == 1)
         {
@@ -7272,14 +7272,14 @@ top:
             // The number of element writes in each row
             UInt rowSizes[maxRowIndex] = {};
             // The columns being written to in each row
-            UInt rowWrites[maxRowIndex][maxCols];
+            uint32_t rowWrites[maxRowIndex][maxCols];
             // The RHS element indices being written in each row
             UInt rowIndices[maxRowIndex][maxCols];
             for (UInt i = 0; i < swizzleInfo->elementCount; ++i)
             {
                 const auto& c = swizzleInfo->elementCoords[i];
                 auto& rowSize = rowSizes[c.row];
-                rowWrites[c.row][rowSize] = c.col;
+                rowWrites[c.row][rowSize] = (uint32_t)c.col;
                 rowIndices[c.row][rowSize] = i;
                 ++rowSize;
             }

--- a/tools/slang-cpp-extractor/diagnostic-defs.h
+++ b/tools/slang-cpp-extractor/diagnostic-defs.h
@@ -75,6 +75,11 @@ DIAGNOSTIC(
     destructorNameDoesntMatch,
     "Destructor name doesn't match class name '$0'");
 DIAGNOSTIC(100023, Error, cannotParseCallable, "Cannot parse callable");
+DIAGNOSTIC(
+    100024,
+    Error,
+    cannoseUseArchDependentType,
+    "Cannot use architecture dependent type '$0' for serializable data.")
 
 // Command line errors 100100
 

--- a/tools/slang-cpp-extractor/parser.cpp
+++ b/tools/slang-cpp-extractor/parser.cpp
@@ -1849,7 +1849,8 @@ SlangResult Parser::_maybeParseContained(Node** outNode)
                     "UIndex",
                     "UCount",
                     "PtrInt",
-                    "intptr_t"};
+                    "intptr_t",
+                    "uintptr_t"};
                 for (const auto& illegalType : illegalTypes)
                 {
                     int index = typeName.indexOf(UnownedStringSlice(illegalType));

--- a/tools/slang-cpp-extractor/parser.cpp
+++ b/tools/slang-cpp-extractor/parser.cpp
@@ -1524,6 +1524,11 @@ bool Parser::_isCtor()
     return isCtor;
 }
 
+bool isAlphaNumeric(char c)
+{
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
+}
+
 SlangResult Parser::_maybeParseContained(Node** outNode)
 {
     *outNode = nullptr;
@@ -1833,7 +1838,36 @@ SlangResult Parser::_maybeParseContained(Node** outNode)
             fieldNode->m_name = nameToken;
             fieldNode->m_reflectionType = m_currentScope->getContainedReflectionType();
             fieldNode->m_isStatic = isStatic;
-
+            if (fieldNode->m_reflectionType == ReflectionType::Reflected)
+            {
+                static const char* illegalTypes[] = {
+                    "size_t",
+                    "Int",
+                    "UInt",
+                    "Index",
+                    "Count",
+                    "UIndex",
+                    "UCount",
+                    "PtrInt",
+                    "intptr_t"};
+                for (const auto& illegalType : illegalTypes)
+                {
+                    int index = typeName.indexOf(UnownedStringSlice(illegalType));
+                    if (index != -1)
+                    {
+                        index += UnownedStringSlice(illegalType).getLength();
+                        if (index >= typeName.getLength() || !isAlphaNumeric(typeName[index]))
+                        {
+                            // Cannot use this type in a field (as it's arch dependent
+                            m_sink->diagnose(
+                                nameToken,
+                                CPPDiagnostics::cannoseUseArchDependentType,
+                                illegalType);
+                            return SLANG_FAIL;
+                        }
+                    }
+                }
+            }
             m_currentScope->addChild(fieldNode);
 
             *outNode = fieldNode;
@@ -2187,7 +2221,8 @@ SlangResult Parser::parse(SourceOrigin* sourceOrigin, const Options* options)
                     m_sink->diagnose(m_reader.peekToken(), CPPDiagnostics::braceOpenAtEndOfFile);
                     return SLANG_FAIL;
                 }
-
+                if (m_sink->getErrorCount())
+                    return SLANG_FAIL;
                 return SLANG_OK;
             }
         case TokenType::Pound:


### PR DESCRIPTION
This change allows us to embed prebuilt core module in WebAssembly.

The main issue being fixed here is that some of our AST nodes contain fields of type `Index` or `UInt`, whose sizes are architecture dependent. This means that the serialized module produced from x64 build system won't correct load by the web assembly module, which is 32-bit. The fix is to get rid of these arch-dependent int types in AST nodes.

To prevent future regression, the slang-cpp-extract application is updated to report an error if it sees an AST node field is of such types.