### PR TITLE
render-test: Limit 1d textures to 1 MIP level

### DIFF
--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -1480,7 +1480,9 @@ void generateTextureDataRGB8(TextureData& output, const InputTextureDesc& inputD
     output.m_arraySize = arraySize;
     output.m_textureSize = inputDesc.size;
 
-    const Index maxMipLevels = Math::Log2Floor(output.m_textureSize) + 1;
+    // WebGPU requires 1d textures to have at most 1 level
+    // https://www.w3.org/TR/webgpu/#abstract-opdef-maximum-miplevel-count
+    const Index maxMipLevels = (inputDesc.dimension == 1) ? 1 : (Math::Log2Floor(output.m_textureSize) + 1);
     Index mipLevels = (inputDesc.mipMapCount <= 0) ? maxMipLevels : inputDesc.mipMapCount;
     mipLevels = (mipLevels > maxMipLevels) ? maxMipLevels : mipLevels;
 


### PR DESCRIPTION
This is due to a limitation in WGSL.
See https://www.w3.org/TR/webgpu/#abstract-opdef-maximum-miplevel-count.

This helps to address issue #4943.