### PR TITLE
Add datalayout for constant buffers.

### DIFF
--- a/docs/user-guide/a2-01-spirv-target-specific.md
+++ b/docs/user-guide/a2-01-spirv-target-specific.md
@@ -162,8 +162,8 @@ Push Constants
 ---------------------
 
 By default, a `uniform` parameter defined in the parameter list of an entrypoint function is translated to a push constant in SPIRV, if the type of the parameter is ordinary data type (no resources/textures).
-All `uniform` parameter defined in global scope are grouped together and placed in a default constant buffer. You can make a global uniform parameter laid out as a push constant by using the `[vk::push_constant]` attribute
-on the uniform parameter. All push constants follow the std430 layout by-default.
+All `uniform` parameters defined in global scope are grouped together and placed in a default constant buffer. You can make a global uniform parameter laid out as a push constant by using the `[vk::push_constant]` attribute
+on the uniform parameter. All push constants follow the std430 layout by default.
 
 Specialization Constants
 ------------------------

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1871,7 +1871,7 @@ for (int tt = 0; tt < kBaseTypeCount; ++tt)
 
 //@ public:
 
-__generic<T>
+__generic<T, L:IBufferDataLayout = DefaultDataLayout>
 __intrinsic_type($(kIROp_ConstantBufferType))
 __magic_type(ConstantBufferType)
 struct ConstantBuffer {}

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -10,12 +10,14 @@ void __requireGLSLExtension(String extensionName);
 /// Represents an interface for buffer data layout.
 /// This interface is used as a base for defining specific data layouts for buffers.
 [sealed]
+__magic_type(IBufferDataLayoutType)
 interface IBufferDataLayout
 {
 }
 
 /// @category misc_types
 __intrinsic_type($(kIROp_DefaultBufferLayoutType))
+__magic_type(DefaultDataLayoutType)
 struct DefaultDataLayout : IBufferDataLayout
 {};
 
@@ -23,6 +25,7 @@ struct DefaultDataLayout : IBufferDataLayout
 __intrinsic_type($(kIROp_Std140BufferLayoutType))
 [require(spirv)]
 [require(glsl)]
+__magic_type(Std140DataLayoutType)
 struct Std140DataLayout : IBufferDataLayout
 {};
 
@@ -30,11 +33,13 @@ struct Std140DataLayout : IBufferDataLayout
 __intrinsic_type($(kIROp_Std430BufferLayoutType))
 [require(spirv)]
 [require(glsl)]
+__magic_type(Std430DataLayoutType)
 struct Std430DataLayout : IBufferDataLayout
 {};
 
 /// @category misc_types
 __intrinsic_type($(kIROp_ScalarBufferLayoutType))
+__magic_type(ScalarDataLayoutType)
 struct ScalarDataLayout : IBufferDataLayout
 {};
 
@@ -20588,13 +20593,15 @@ const char* kDynamicResourceCastableTypes[] = {
 
     "SamplerState", "SamplerComparisonState",
 
-    "ConstantBuffer<T>", "TextureBuffer<T>",
+    "ConstantBuffer<T, L>", "TextureBuffer<T>",
 };
 
 for (auto typeName : kDynamicResourceCastableTypes) {
     auto kind = strstr(typeName, "Sampler") ? "Sampler" : "General";
 
     if (strstr(typeName, "StructuredBuffer<T, L>"))
+        sb << "__generic<T, L : IBufferDataLayout = DefaultDataLayout>\n";
+    else if (strstr(typeName, "ConstantBuffer<T, L>"))
         sb << "__generic<T, L : IBufferDataLayout = DefaultDataLayout>\n";
     else if (strstr(typeName, "Buffer<T>"))
         sb << "__generic<T>\n";

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -146,6 +146,16 @@ Type* SharedASTBuilder::getDiffInterfaceType()
     return m_diffInterfaceType;
 }
 
+Type* SharedASTBuilder::getIBufferDataLayoutType()
+{
+    if (!m_IBufferDataLayoutType)
+    {
+        auto decl = findMagicDecl("IBufferDataLayoutType");
+        m_IBufferDataLayoutType = DeclRefType::create(m_astBuilder, makeDeclRef<Decl>(decl));
+    }
+    return m_IBufferDataLayoutType;
+}
+
 Type* SharedASTBuilder::getErrorType()
 {
     if (!m_errorType)
@@ -296,6 +306,23 @@ PtrType* ASTBuilder::getPtrType(Type* valueType, AddressSpace addrSpace)
     return dynamicCast<PtrType>(getPtrType(valueType, addrSpace, "PtrType"));
 }
 
+Type* ASTBuilder::getDefaultLayoutType()
+{
+    return getSpecializedBuiltinType({}, "DefaultDataLayoutType");
+}
+Type* ASTBuilder::getStd140LayoutType()
+{
+    return getSpecializedBuiltinType({}, "Std140DataLayoutType");
+}
+Type* ASTBuilder::getStd430LayoutType()
+{
+    return getSpecializedBuiltinType({}, "Std430DataLayoutType");
+}
+Type* ASTBuilder::getScalarLayoutType()
+{
+    return getSpecializedBuiltinType({}, "ScalarDataLayoutType");
+}
+
 // Construct the type `Out<valueType>`
 OutType* ASTBuilder::getOutType(Type* valueType)
 {
@@ -358,9 +385,15 @@ ArrayExpressionType* ASTBuilder::getArrayType(Type* elementType, IntVal* element
         getSpecializedBuiltinType(makeArrayView(args), "ArrayExpressionType"));
 }
 
-ConstantBufferType* ASTBuilder::getConstantBufferType(Type* elementType)
+ConstantBufferType* ASTBuilder::getConstantBufferType(
+    Type* elementType,
+    Type* layoutType,
+    Val* layoutWitness)
 {
-    return as<ConstantBufferType>(getSpecializedBuiltinType(elementType, "ConstantBufferType"));
+    Val* args[] = {elementType, layoutType, layoutWitness};
+
+    return as<ConstantBufferType>(
+        getSpecializedBuiltinType(makeArrayView(args), "ConstantBufferType"));
 }
 
 ParameterBlockType* ASTBuilder::getParameterBlockType(Type* elementType)

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -39,6 +39,8 @@ public:
     /// Get the `IDifferentiable` type
     Type* getDiffInterfaceType();
 
+    Type* getIBufferDataLayoutType();
+
     Type* getErrorType();
     Type* getBottomType();
     Type* getInitializerListType();
@@ -89,6 +91,7 @@ protected:
     Type* m_bottomType = nullptr;
     Type* m_initializerListType = nullptr;
     Type* m_overloadedType = nullptr;
+    Type* m_IBufferDataLayoutType = nullptr;
 
     // The following types are created lazily, such that part of their definition
     // can be in the core module.
@@ -482,6 +485,11 @@ public:
     Type* getSpecializedBuiltinType(Type* typeParam, const char* magicTypeName);
     Type* getSpecializedBuiltinType(ArrayView<Val*> genericArgs, const char* magicTypeName);
 
+    Type* getDefaultLayoutType();
+    Type* getStd140LayoutType();
+    Type* getStd430LayoutType();
+    Type* getScalarLayoutType();
+
     Type* getInitializerListType() { return m_sharedASTBuilder->getInitializerListType(); }
     Type* getOverloadedType() { return m_sharedASTBuilder->getOverloadedType(); }
     Type* getErrorType() { return m_sharedASTBuilder->getErrorType(); }
@@ -525,7 +533,10 @@ public:
         IntVal* colCount,
         IntVal* layout);
 
-    ConstantBufferType* getConstantBufferType(Type* elementType);
+    ConstantBufferType* getConstantBufferType(
+        Type* elementType,
+        Type* layoutType,
+        Val* layoutIsILayout);
 
     ParameterBlockType* getParameterBlockType(Type* elementType);
 

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -113,6 +113,36 @@ class BuiltinType : public DeclRefType
     SLANG_ABSTRACT_AST_CLASS(BuiltinType)
 };
 
+class DataLayoutType : public BuiltinType
+{
+    SLANG_ABSTRACT_AST_CLASS(DataLayoutType)
+};
+
+class IBufferDataLayoutType : public BuiltinType
+{
+    SLANG_AST_CLASS(IBufferDataLayoutType)
+};
+
+class DefaultDataLayoutType : public DataLayoutType
+{
+    SLANG_AST_CLASS(DefaultDataLayoutType)
+};
+
+class Std430DataLayoutType : public DataLayoutType
+{
+    SLANG_AST_CLASS(Std430DataLayoutType)
+};
+
+class Std140DataLayoutType : public DataLayoutType
+{
+    SLANG_AST_CLASS(Std140DataLayoutType)
+};
+
+class ScalarDataLayoutType : public DataLayoutType
+{
+    SLANG_AST_CLASS(ScalarDataLayoutType)
+};
+
 class FeedbackType : public BuiltinType
 {
     SLANG_AST_CLASS(FeedbackType)
@@ -374,6 +404,7 @@ class ParameterGroupType : public PointerLikeType
 class UniformParameterGroupType : public ParameterGroupType
 {
     SLANG_AST_CLASS(UniformParameterGroupType)
+    Type* getLayoutType();
 };
 
 class VaryingParameterGroupType : public ParameterGroupType

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1149,6 +1149,8 @@ public:
     TypeExp TranslateTypeNodeForced(TypeExp const& typeExp);
     TypeExp TranslateTypeNode(TypeExp const& typeExp);
     Type* getRemovedModifierType(ModifiedType* type, ModifierVal* modifier);
+    Type* getConstantBufferType(Type* elementType, Type* layoutType);
+
     DeclRefType* getExprDeclRefType(Expr* expr);
 
     /// Is `decl` usable as a static member?

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -280,6 +280,8 @@ bool isUniformParameterType(Type* type)
         return true;
     if (as<SamplerStateType>(type))
         return true;
+    if (as<PtrType>(type))
+        return true;
     if (auto arrayType = as<ArrayExpressionType>(type))
         return isUniformParameterType(arrayType->getElementType());
     if (auto modType = as<ModifiedType>(type))

--- a/source/slang/slang-check-type.cpp
+++ b/source/slang/slang-check-type.cpp
@@ -101,6 +101,13 @@ Type* SemanticsVisitor::getRemovedModifierType(ModifiedType* modifiedType, Modif
     return m_astBuilder->getModifiedType(modifiedType->getBase(), newModifiers);
 }
 
+Type* SemanticsVisitor::getConstantBufferType(Type* elementType, Type* layoutType)
+{
+    auto iBufferDataLayoutType = m_astBuilder->getSharedASTBuilder()->getIBufferDataLayoutType();
+    auto witness = isSubtype(layoutType, iBufferDataLayoutType, IsSubTypeOptions());
+    return m_astBuilder->getConstantBufferType(elementType, layoutType, witness);
+}
+
 Expr* SemanticsVisitor::ExpectATypeRepr(Expr* expr)
 {
     if (auto overloadedExpr = as<OverloadedExpr>(expr))

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -1310,6 +1310,13 @@ void HLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
         _emitHLSLSubpassInputType(subpassType);
         return;
     }
+    else if (auto cbufferType = as<IRConstantBufferType>(type))
+    {
+        m_writer->emit("ConstantBuffer<");
+        emitType(cbufferType->getElementType());
+        m_writer->emit(" >");
+        return;
+    }
     else if (auto structuredBufferType = as<IRHLSLStructuredBufferTypeBase>(type))
     {
         switch (structuredBufferType->getOp())

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -642,6 +642,7 @@ Result linkAndOptimizeIR(
     //
     {
         CollectEntryPointUniformParamsOptions passOptions;
+        passOptions.targetReq = targetRequest;
         switch (target)
         {
         case CodeGenTarget::HostCPPSource:

--- a/source/slang/slang-ir-collect-global-uniforms.cpp
+++ b/source/slang/slang-ir-collect-global-uniforms.cpp
@@ -155,7 +155,9 @@ struct CollectGlobalUniformParametersContext
         IRType* wrapperParamType = wrapperStructType;
         if (globalParameterGroupTypeLayout)
         {
-            auto wrapperParamGroupType = builder->getConstantBufferType(wrapperStructType);
+            auto wrapperParamGroupType = builder->getConstantBufferType(
+                wrapperStructType,
+                builder->getType(kIROp_DefaultBufferLayoutType));
             wrapperParamType = wrapperParamGroupType;
         }
 

--- a/source/slang/slang-ir-entry-point-uniforms.cpp
+++ b/source/slang/slang-ir-entry-point-uniforms.cpp
@@ -403,7 +403,16 @@ struct CollectEntryPointUniformParams : PerEntryPointPass
             // If we need a constant buffer, then the global
             // shader parameter will be a `ConstantBuffer<paramStructType>`
             //
-            auto constantBufferType = builder.getConstantBufferType(paramStructType);
+            IRType* layoutType = nullptr;
+
+            if (m_options.targetReq->getOptionSet().getBoolOption(
+                    CompilerOptionName::GLSLForceScalarLayout))
+                layoutType = builder.getType(kIROp_ScalarBufferLayoutType);
+            else if (isKhronosTarget(m_options.targetReq))
+                layoutType = builder.getType(kIROp_Std430BufferLayoutType);
+            else
+                layoutType = builder.getType(kIROp_DefaultBufferLayoutType);
+            auto constantBufferType = builder.getConstantBufferType(paramStructType, layoutType);
             collectedParam = builder.createParam(constantBufferType);
         }
         else

--- a/source/slang/slang-ir-entry-point-uniforms.h
+++ b/source/slang/slang-ir-entry-point-uniforms.h
@@ -12,6 +12,7 @@ struct CollectEntryPointUniformParamsOptions
     // TODO(JS): Not sure if it makes sense to initialize to true or false. Go with false as
     // seems to fit usage.
     bool alwaysCreateCollectedParam = false;
+    TargetRequest* targetReq = nullptr;
 };
 
 /// Collect entry point uniform parameters into a wrapper `struct` and/or buffer

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -3719,7 +3719,7 @@ public:
         return getFuncType(paramTypes.getCount(), paramTypes.getBuffer(), resultType);
     }
 
-    IRConstantBufferType* getConstantBufferType(IRType* elementType);
+    IRConstantBufferType* getConstantBufferType(IRType* elementType, IRType* layout);
 
     IRGLSLOutputParameterGroupType* getGLSLOutputParameterGroupType(IRType* valueType);
 

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -4016,12 +4016,15 @@ struct IRResourceTypeLegalizationContext : IRTypeLegalizationContext
 
     bool isSimpleType(IRType*) override { return false; }
 
-    LegalType createLegalUniformBufferType(IROp op, LegalType legalElementType) override
+    LegalType createLegalUniformBufferType(
+        IROp op,
+        LegalType legalElementType,
+        IRInst* layoutOperand) override
     {
         // The appropriate strategy for legalizing uniform buffers
         // with resources inside already exists, so we can delegate to it.
         //
-        return createLegalUniformBufferTypeForResources(this, op, legalElementType);
+        return createLegalUniformBufferTypeForResources(this, op, legalElementType, layoutOperand);
     }
 };
 
@@ -4045,7 +4048,10 @@ struct IRExistentialTypeLegalizationContext : IRTypeLegalizationContext
 
     bool isSimpleType(IRType*) override { return false; }
 
-    LegalType createLegalUniformBufferType(IROp op, LegalType legalElementType) override
+    LegalType createLegalUniformBufferType(
+        IROp op,
+        LegalType legalElementType,
+        IRInst* layoutOperand) override
     {
         // We'll delegate the logic for creating uniform buffers
         // over a mix of ordinary and existential-box types to
@@ -4054,7 +4060,11 @@ struct IRExistentialTypeLegalizationContext : IRTypeLegalizationContext
         // TODO: We should eventually try to refactor this code
         // so that related functionality is grouped together.
         //
-        return createLegalUniformBufferTypeForExistentials(this, op, legalElementType);
+        return createLegalUniformBufferTypeForExistentials(
+            this,
+            op,
+            legalElementType,
+            layoutOperand);
     }
 };
 
@@ -4090,7 +4100,10 @@ struct IREmptyTypeLegalizationContext : IRTypeLegalizationContext
         return false;
     }
 
-    LegalType createLegalUniformBufferType(IROp, LegalType) override { return LegalType(); }
+    LegalType createLegalUniformBufferType(IROp, LegalType, IRInst*) override
+    {
+        return LegalType();
+    }
 };
 
 // The main entry points that are used when transforming IR code

--- a/source/slang/slang-ir-lower-buffer-element-type.cpp
+++ b/source/slang/slang-ir-lower-buffer-element-type.cpp
@@ -1376,7 +1376,25 @@ IRTypeLayoutRules* getTypeLayoutRuleForBuffer(TargetProgram* target, IRType* buf
         }
     case kIROp_ConstantBufferType:
     case kIROp_ParameterBlockType:
-        return IRTypeLayoutRules::getStd140();
+        {
+            auto parameterGroupType = as<IRUniformParameterGroupType>(bufferType);
+
+            auto layoutTypeOp = parameterGroupType->getDataLayout()
+                                    ? parameterGroupType->getDataLayout()->getOp()
+                                    : kIROp_DefaultBufferLayoutType;
+            switch (layoutTypeOp)
+            {
+            case kIROp_DefaultBufferLayoutType:
+                return IRTypeLayoutRules::getStd140();
+            case kIROp_Std140BufferLayoutType:
+                return IRTypeLayoutRules::getStd140();
+            case kIROp_Std430BufferLayoutType:
+                return IRTypeLayoutRules::getStd430();
+            case kIROp_ScalarBufferLayoutType:
+                return IRTypeLayoutRules::getNatural();
+            }
+            return IRTypeLayoutRules::getStd140();
+        }
     case kIROp_PtrType:
         return IRTypeLayoutRules::getNatural();
     }

--- a/source/slang/slang-ir-optix-entry-point-uniforms.cpp
+++ b/source/slang/slang-ir-optix-entry-point-uniforms.cpp
@@ -253,7 +253,9 @@ struct CollectOptixEntryPointUniformParams : PerEntryPointPass
         // TODO: reconcile this with OptiX, as the current logic works, but is still focused on
         // VK/DXR..
         //
-        auto constantBufferType = builder.getConstantBufferType(paramStructType);
+        auto constantBufferType = builder.getConstantBufferType(
+            paramStructType,
+            builder.getType(kIROp_DefaultBufferLayoutType));
         collectedParam = builder.createParam(constantBufferType);
 
         // The global shader parameter should have the layout

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3046,10 +3046,10 @@ IRWitnessTableIDType* IRBuilder::getWitnessTableIDType(IRType* baseType)
         createIntrinsicInst(nullptr, kIROp_WitnessTableIDType, 1, (IRInst* const*)&baseType);
 }
 
-IRConstantBufferType* IRBuilder::getConstantBufferType(IRType* elementType)
+IRConstantBufferType* IRBuilder::getConstantBufferType(IRType* elementType, IRType* layoutType)
 {
-    IRInst* operands[] = {elementType};
-    return (IRConstantBufferType*)getType(kIROp_ConstantBufferType, 1, operands);
+    IRInst* operands[] = {elementType, layoutType};
+    return (IRConstantBufferType*)getType(kIROp_ConstantBufferType, 2, operands);
 }
 
 IRGLSLOutputParameterGroupType* IRBuilder::getGLSLOutputParameterGroupType(IRType* elementType)

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1574,7 +1574,14 @@ SIMPLE_IR_TYPE(MetalMeshGridPropertiesType, Type)
 
 SIMPLE_IR_TYPE(GLSLInputAttachmentType, Type)
 SIMPLE_IR_PARENT_TYPE(ParameterGroupType, PointerLikeType)
-SIMPLE_IR_PARENT_TYPE(UniformParameterGroupType, ParameterGroupType)
+
+struct IRUniformParameterGroupType : IRParameterGroupType
+{
+    IR_PARENT_ISA(UniformParameterGroupType)
+
+    IRType* getDataLayout() { return getOperandCount() > 1 ? (IRType*)getOperand(1) : nullptr; }
+};
+
 SIMPLE_IR_PARENT_TYPE(VaryingParameterGroupType, ParameterGroupType)
 SIMPLE_IR_TYPE(ConstantBufferType, UniformParameterGroupType)
 SIMPLE_IR_TYPE(TextureBufferType, UniformParameterGroupType)

--- a/source/slang/slang-legalize-types.h
+++ b/source/slang/slang-legalize-types.h
@@ -654,7 +654,10 @@ struct IRTypeLegalizationContext
     /// This function will only be called if `legalElementType` is
     /// somehow non-trivial.
     ///
-    virtual LegalType createLegalUniformBufferType(IROp op, LegalType legalElementType) = 0;
+    virtual LegalType createLegalUniformBufferType(
+        IROp op,
+        LegalType legalElementType,
+        IRInst* layoutOperand) = 0;
 };
 
 // This typedef exists to support pre-existing code from when
@@ -675,7 +678,8 @@ ModuleDecl* findModuleForDecl(Decl* decl);
 LegalType createLegalUniformBufferTypeForResources(
     TypeLegalizationContext* context,
     IROp op,
-    LegalType legalElementType);
+    LegalType legalElementType,
+    IRInst* layoutOperand);
 
 /// Create a uniform buffer type suitable for existential legalization.
 ///
@@ -686,7 +690,8 @@ LegalType createLegalUniformBufferTypeForResources(
 LegalType createLegalUniformBufferTypeForExistentials(
     TypeLegalizationContext* context,
     IROp op,
-    LegalType legalElementType);
+    LegalType legalElementType,
+    IRInst* layoutOperand);
 
 
 void legalizeExistentialTypeLayout(TargetProgram* target, IRModule* module, DiagnosticSink* sink);

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -3799,6 +3799,7 @@ static bool _calcNeedsDefaultSpace(SharedParameterBindingContext& sharedContext)
             case LayoutResourceKind::RegisterSpace:
             case LayoutResourceKind::SubElementRegisterSpace:
             case LayoutResourceKind::PushConstantBuffer:
+            case LayoutResourceKind::SpecializationConstant:
                 continue;
             case LayoutResourceKind::Uniform:
                 {

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -707,7 +707,7 @@ RefPtr<TypeLayout> getTypeLayoutForGlobalShaderParameter(
             // If the target doesn't support specialization constants, then we will
             // layout them as ordinary uniform data.
             specializationConstantRule =
-                rules->getConstantBufferRules(context->getTargetRequest()->getOptionSet());
+                rules->getConstantBufferRules(context->getTargetRequest()->getOptionSet(), type);
         }
         return createTypeLayoutWith(layoutContext, specializationConstantRule, type);
     }
@@ -718,7 +718,7 @@ RefPtr<TypeLayout> getTypeLayoutForGlobalShaderParameter(
     // shader parameter.
     return createTypeLayoutWith(
         layoutContext,
-        rules->getConstantBufferRules(context->getTargetRequest()->getOptionSet()),
+        rules->getConstantBufferRules(context->getTargetRequest()->getOptionSet(), type),
         type);
 }
 
@@ -2421,11 +2421,21 @@ static RefPtr<TypeLayout> computeEntryPointParameterTypeLayout(
         // a uniform shader parameter passed via the implicitly-defined
         // constant buffer (e.g., the `$Params` constant buffer seen in fxc/dxc output).
         //
-        return createTypeLayoutWith(
-            context->layoutContext,
-            context->getRulesFamily()->getConstantBufferRules(
-                context->getTargetRequest()->getOptionSet()),
-            paramType);
+        LayoutRulesImpl* layoutRules = nullptr;
+        if (isKhronosTarget(context->getTargetRequest()))
+        {
+            // For Vulkan, entry point uniform parameters are laid out using push constant buffer
+            // rules (defaults to std430).
+            layoutRules = context->getRulesFamily()->getShaderStorageBufferRules(
+                context->getTargetProgram()->getOptionSet());
+        }
+        else
+        {
+            layoutRules = context->getRulesFamily()->getConstantBufferRules(
+                context->getTargetRequest()->getOptionSet(),
+                paramType);
+        }
+        return createTypeLayoutWith(context->layoutContext, layoutRules, paramType);
     }
     else
     {
@@ -2783,12 +2793,13 @@ static ParameterBindingAndKindInfo _allocateConstantBufferBinding(ParameterBindi
     UInt space = context->shared->defaultSpace;
     auto usedRangeSet = _getOrCreateUsedRangeSetForSpace(context, space);
 
-    auto layoutInfo = context->getRulesFamily()
-                          ->getConstantBufferRules(context->getTargetRequest()->getOptionSet())
-                          ->GetObjectLayout(
-                              ShaderParameterKind::ConstantBuffer,
-                              context->layoutContext.objectLayoutOptions)
-                          .getSimple();
+    auto layoutInfo =
+        context->getRulesFamily()
+            ->getConstantBufferRules(context->getTargetRequest()->getOptionSet(), nullptr)
+            ->GetObjectLayout(
+                ShaderParameterKind::ConstantBuffer,
+                context->layoutContext.objectLayoutOptions)
+            .getSimple();
 
     ParameterBindingAndKindInfo info;
     info.kind = layoutInfo.kind;
@@ -2809,7 +2820,9 @@ static ParameterBindingAndKindInfo _assignConstantBufferBinding(
     auto usedRangeSet = _getOrCreateUsedRangeSetForSpace(context, space);
 
     auto layoutInfo = context->getRulesFamily()
-                          ->getConstantBufferRules(context->getTargetRequest()->getOptionSet())
+                          ->getConstantBufferRules(
+                              context->getTargetRequest()->getOptionSet(),
+                              varLayout->typeLayout ? varLayout->typeLayout->getType() : nullptr)
                           ->GetObjectLayout(
                               ShaderParameterKind::ConstantBuffer,
                               context->layoutContext.objectLayoutOptions)

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -985,6 +985,11 @@ Val* _tryLookupConcreteAssociatedTypeFromThisTypeSubst(ASTBuilder* builder, Decl
     return nullptr;
 }
 
+Type* UniformParameterGroupType::getLayoutType()
+{
+    return as<Type>(getGenericArg(getDeclRef(), 1));
+}
+
 ModuleDecl* getModuleDecl(Decl* decl)
 {
     for (auto dd = decl; dd; dd = dd->parentDecl)

--- a/source/slang/slang-type-layout.h
+++ b/source/slang/slang-type-layout.h
@@ -1105,7 +1105,9 @@ struct LayoutRulesImpl
 struct LayoutRulesFamilyImpl
 {
     virtual LayoutRulesImpl* getAnyValueRules() = 0;
-    virtual LayoutRulesImpl* getConstantBufferRules(CompilerOptionSet& compilerOptions) = 0;
+    virtual LayoutRulesImpl* getConstantBufferRules(
+        CompilerOptionSet& compilerOptions,
+        Type* containerType) = 0;
     virtual LayoutRulesImpl* getPushConstantBufferRules() = 0;
     virtual LayoutRulesImpl* getTextureBufferRules(CompilerOptionSet& compilerOptions) = 0;
     virtual LayoutRulesImpl* getVaryingInputRules() = 0;

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -1608,7 +1608,9 @@ SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL Linkage::getContainerType(
         {
         case slang::ContainerType::ConstantBuffer:
             {
-                ConstantBufferType* cbType = getASTBuilder()->getConstantBufferType(type);
+                SemanticsVisitor visitor(getSemanticsForReflection());
+                auto layoutType = getASTBuilder()->getDefaultLayoutType();
+                Type* cbType = visitor.getConstantBufferType(type, layoutType);
                 containerTypeReflection = cbType;
             }
             break;

--- a/tests/bugs/vk-shift-uniform-issue.slang
+++ b/tests/bugs/vk-shift-uniform-issue.slang
@@ -13,7 +13,7 @@
 // CHECK-NEXT:uniform sampler sampler1_0;
 
 // CHECK: layout(push_constant)
-// CHECK-NEXT: layout(std140) uniform
+// CHECK-NEXT: layout(std430) uniform
 
 // CHECK:layout(binding = 1004)
 // CHECK-NEXT:layout(std140) uniform

--- a/tests/reflection/binding-push-constant-gl.hlsl.expected
+++ b/tests/reflection/binding-push-constant-gl.hlsl.expected
@@ -138,7 +138,7 @@ standard output = {
                             }
                         ]
                     },
-                    "binding": {"kind": "uniform", "offset": 0, "size": 16}
+                    "binding": {"kind": "uniform", "offset": 0, "size": 8}
                 }
             }
         },

--- a/tests/spirv/constant-buffer-layout.slang
+++ b/tests/spirv/constant-buffer-layout.slang
@@ -1,0 +1,45 @@
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -emit-spirv-directly
+
+//SPIRV: ArrayStride 12
+
+struct Test
+{
+//SPIRV: Offset 0
+    uint v0;
+
+//SPIRV: Offset 4
+// matrix always start on a new register
+    float3x3 v1;
+//SPIRV: Offset 40
+// Non-matrix can pack with a partially filled register
+    uint v2;
+};
+
+ConstantBuffer<Test, ScalarDataLayout> buffer;
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+__generic<T : IArithmetic, let N : int>
+bool comp(vector<T,N> v1, vector<T,N> v2)
+{
+    for (uint i = 0; i < N; i++)
+        if (v1[i] != v2[i])
+            return false;
+
+    return true;
+}
+
+[shader("compute")]
+[numthreads(2, 2, 1)]
+void computeMain()
+{
+    // CHECK: 64
+    outputBuffer[0] = (true
+            && buffer.v0 == 1
+            && comp(buffer.v1[0], float3(2, 3, 4))
+            && comp(buffer.v1[1], float3(5, 6, 7))
+            && comp(buffer.v1[2], float3(8, 9, 10))
+            && buffer.v2 == 11
+        ) ? 100 : 0;
+}

--- a/tests/spirv/push-constant-layout.slang
+++ b/tests/spirv/push-constant-layout.slang
@@ -1,0 +1,26 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -fvk-use-entrypoint-name
+// CHECK-NOT: std140
+struct Transform
+{
+    float4 Tint;
+    float2x2 ScaleRot; // << why u no std430???
+    float2 Translation;
+};
+
+[[vk::push_constant]]
+ConstantBuffer<Transform> transform1;
+
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1,1,1)]
+void computeMain1()
+{
+    outputBuffer[0] = transform1.Translation.x;
+}
+
+[numthreads(1,1,1)]
+void computeMain2(
+    [vk::push_constant] ConstantBuffer<Transform> transform2)
+{
+    outputBuffer[0] = transform2.Translation.x;
+}

--- a/tests/spirv/push-constant-layout.slang
+++ b/tests/spirv/push-constant-layout.slang
@@ -3,7 +3,7 @@
 struct Transform
 {
     float4 Tint;
-    float2x2 ScaleRot; // << why u no std430???
+    float2x2 ScaleRot;
     float2 Translation;
 };
 

--- a/tests/spirv/spec-constant-space.slang
+++ b/tests/spirv/spec-constant-space.slang
@@ -1,0 +1,17 @@
+// Test that use of specialiation constants does not cause space 0 to be reserved.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+
+// CHECK-NOT: DescriptorSet 1
+
+struct MyData { float4 val; RWStructuredBuffer<float> outputBuffer; }
+
+
+[vk::specialization_constant]
+const int kSpecializationConstant = 0;
+
+[NumThreads(1,1,1)]
+void main(ParameterBlock<MyData> g_data)
+{
+    g_data.outputBuffer[0] = g_data.val.x;
+}

--- a/tests/spirv/spec-constant-space.slang
+++ b/tests/spirv/spec-constant-space.slang
@@ -1,4 +1,4 @@
-// Test that use of specialiation constants does not cause space 0 to be reserved.
+// Test that use of specialization constants does not cause space 0 to be reserved.
 
 //TEST:SIMPLE(filecheck=CHECK): -target spirv
 


### PR DESCRIPTION
Closes #5598.
Closes #5595.

This PR adds support for specifying data layout for constant buffers, and fixes the default layout of push constant buffer to be std430.

ConstantBuffer can now be specified with a buffer layout, similar to StructuredBuffer:
```
ConstantBuffer<T, Std430DataLayout> buffer;
```

Also fixes a bug that incorrectly causes specialization constants to occupy space 0.