### PR TITLE
ci: Update `actions/checkout` to always use v4

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     runs-on: [Windows, self-hosted]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
           fetch-depth: "0"
@@ -39,7 +39,7 @@ jobs:
         run: |
           cmake --preset default --fresh -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM -DCMAKE_COMPILE_WARNING_AS_ERROR=false
           cmake --workflow --preset release
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: "shader-slang/MDL-SDK"
           path: "external/MDL-SDK"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
           fetch-depth: "0"

--- a/.github/workflows/compile-regression-test.yml
+++ b/.github/workflows/compile-regression-test.yml
@@ -40,7 +40,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
           fetch-depth: "0"

--- a/.github/workflows/falcor-compiler-perf-test.yml
+++ b/.github/workflows/falcor-compiler-perf-test.yml
@@ -42,7 +42,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
           fetch-depth: "0"

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -40,7 +40,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
           fetch-depth: "0"

--- a/.github/workflows/push-benchmark-results.yml
+++ b/.github/workflows/push-benchmark-results.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: [Windows, benchmark, self-hosted]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "true"
           fetch-depth: "0"
@@ -32,7 +32,7 @@ jobs:
         run: |
           cmake --preset default --fresh -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM -DCMAKE_COMPILE_WARNING_AS_ERROR=false
           cmake --workflow --preset release
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: "shader-slang/MDL-SDK"
           path: "external/MDL-SDK"
@@ -42,7 +42,7 @@ jobs:
           cp ../../external/MDL-SDK/examples/mdl_sdk/dxr/content/slangified/*.slang .
           pip install prettytable argparse
           python compile.py --samples 16 --target dxil
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: "shader-slang/slang-material-modules-benchmark"
           path: "external/slang-material-modules-benchmark"

--- a/.github/workflows/release-linux-glibc-2-17.yml
+++ b/.github/workflows/release-linux-glibc-2-17.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
           fetch-depth: "0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
           fetch-depth: "0"
@@ -197,7 +197,7 @@ jobs:
 
       - name: Checkout stdlib reference
         if: matrix.os == 'windows' && matrix.platform == 'x86_64'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: shader-slang/stdlib-reference
           path: docs/stdlib-reference/


### PR DESCRIPTION
CI was using a mix of version 3 and 4. Version 3 results in a warning within the GitHub Actions UI as it was using a version of NodeJS that is deprecated within the GitHub Actions infrastructure.