### PR TITLE
[Docs] Extensions -  better wording for c# equivalent

### DIFF
--- a/docs/user-guide/03-convenience-features.md
+++ b/docs/user-guide/03-convenience-features.md
@@ -567,7 +567,7 @@ void test()
 }
 ```
 
-This feature is similar to extensions in Swift and partial classes in C#.
+This feature is similar to extensions in Swift and extension methods in C#.
 
 > #### Note:
 > You can only extend a type with additional methods. Extending with additional data fields is not allowed.


### PR DESCRIPTION
slang extensions looks same as c# extension methods, not partial classes. Partial classes allow extending types to introduce more variables unlike slang extensions. And you cannot extend that types not partial to begin with. Where extension methods allows that. Also c# users that use extension methods much more  than partial types, probably.