### PR TITLE
[Docs] fix spirv dead links on toc.html

### DIFF
--- a/docs/user-guide/toc.html
+++ b/docs/user-guide/toc.html
@@ -205,14 +205,14 @@
 <li data-link="spirv-target-specific#supported-hlsl-features-when-targeting-spir-v"><span>Supported HLSL features when targeting SPIR-V</span></li>
 <li data-link="spirv-target-specific#unsupported-glsl-keywords-when-targeting-spir-v"><span>Unsupported GLSL keywords when targeting SPIR-V</span></li>
 <li data-link="spirv-target-specific#supported-atomic-types-for-each-target"><span>Supported atomic types for each target</span></li>
-<li data-link="spirv-target-specific#constantbuffer-rwrasterizerorderedstructuredbuffer-rwrasterizerorderedbyteaddressbuffer"><span>ConstantBuffer, (RW/RasterizerOrdered)StructuredBuffer, (RW/RasterizerOrdered)ByteAddressBuffer</span></li>
+<li data-link="spirv-target-specific#constantbuffer-rwrasterizerorderedstructuredbuffer-rwrasterizerorderedbyteaddressbuffer"><span>ConstantBuffer, StructuredBuffer and ByteAddressBuffer</span></li>
 <li data-link="spirv-target-specific#parameterblock-for-spir-v-target"><span>ParameterBlock for SPIR-V target</span></li>
 <li data-link="spirv-target-specific#push-constants"><span>Push Constants</span></li>
 <li data-link="spirv-target-specific#specialization-constants"><span>Specialization Constants</span></li>
 <li data-link="spirv-target-specific#spir-v-specific-compiler-options"><span>SPIR-V specific Compiler options</span></li>
 <li data-link="spirv-target-specific#spir-v-specific-attributes"><span>SPIR-V specific Attributes </span></li>
 <li data-link="spirv-target-specific#multiple-entry-points-support"><span>Multiple entry points support</span></li>
-<li data-link="spirv-target-specific#memory-pointer-is-experimental"><span>Memory pointer is experimental</span></li>
+<li data-link="spirv-target-specific#memory-pointer-is-experimental"><span>Global memory pointers</span></li>
 <li data-link="spirv-target-specific#matrix-type-translation"><span>Matrix type translation</span></li>
 <li data-link="spirv-target-specific#legalization"><span>Legalization</span></li>
 <li data-link="spirv-target-specific#tessellation"><span>Tessellation</span></li>


### PR DESCRIPTION
I believe this will fix the dead links that occurred because of sub section renames.