### PR TITLE
ci: Use v1.11 of the release-downloader action

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -116,7 +116,7 @@ runs:
         echo SCCACHE_IGNORE_SERVER_IO_ERROR=1 >> "$GITHUB_ENV"
 
     # Install swiftshader
-    - uses: robinraju/release-downloader@v1.8
+    - uses: robinraju/release-downloader@v1.11
       continue-on-error: true
       with:
         latest: true

--- a/.github/workflows/falcor-compiler-perf-test.yml
+++ b/.github/workflows/falcor-compiler-perf-test.yml
@@ -64,7 +64,7 @@ jobs:
             -DSLANG_ENABLE_CUDA=1
           cmake --workflow --preset "${{matrix.config}}"
 
-      - uses: robinraju/release-downloader@v1.9
+      - uses: robinraju/release-downloader@v1.11
         id: download
         with:
           # The source repository path.

--- a/.github/workflows/vk-gl-cts-nightly.yml
+++ b/.github/workflows/vk-gl-cts-nightly.yml
@@ -52,7 +52,7 @@ jobs:
             -DSLANG_ENABLE_GFX=1 \
             -DSLANG_ENABLE_TESTS=1
           cmake --workflow --preset "${{matrix.config}}"
-      - uses: robinraju/release-downloader@v1.7
+      - uses: robinraju/release-downloader@v1.11
         with:
           latest: true
           repository: "shader-slang/VK-GL-CTS"


### PR DESCRIPTION
CI was previous using different versions in different jobs but all were old and using a version of Node that has been deprecated within the GitHub Actions infrastructure.