### PR TITLE
Enable core module embedding by default in CMake.

### DIFF
--- a/.github/workflows/release-linux-glibc-2-17.yml
+++ b/.github/workflows/release-linux-glibc-2-17.yml
@@ -26,7 +26,7 @@ jobs:
 
             cd /home/app
             git config --global --add safe.directory /home/app
-            cmake --preset default --fresh -DSLANG_SLANG_LLVM_FLAVOR=DISABLE -DSLANG_EMBED_STDLIB=1
+            cmake --preset default --fresh -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
             cmake --build --preset releaseWithDebugInfo
             cpack --preset releaseWithDebugInfo -G ZIP
             cpack --preset releaseWithDebugInfo -G TGZ

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,6 @@ jobs:
           cmake --preset default --fresh \
             -DSLANG_GENERATORS_PATH=build-platform-generators/bin \
             -DSLANG_ENABLE_EXAMPLES=OFF \
-            -DSLANG_EMBED_STDLIB=ON \
             "-DSLANG_SLANG_LLVM_FLAVOR=$(
               [[ "${{matrix.build-slang-llvm}}" = "true" ]] && echo "USE_SYSTEM_LLVM" || echo "DISABLE")"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ option(
 option(
     SLANG_EMBED_CORE_MODULE
     "Build slang with an embedded version of the core module"
+    ON
 )
 
 option(SLANG_ENABLE_FULL_IR_VALIDATION "Enable full IR validation (SLOW!)")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,7 +22,6 @@
       "binaryDir": "${sourceDir}/build.em",
       "cacheVariables": {
         "SLANG_SLANG_LLVM_FLAVOR": "DISABLE",
-        "SLANG_EMBED_CORE_MODULE": "ON",
         "CMAKE_C_FLAGS_INIT": "-fwasm-exceptions -Os",
         "CMAKE_CXX_FLAGS_INIT": "-fwasm-exceptions -Os",
         "CMAKE_EXE_LINKER_FLAGS": "-sASSERTIONS -sALLOW_MEMORY_GROWTH -fwasm-exceptions --export=__cpp_exception"

--- a/docs/building.md
+++ b/docs/building.md
@@ -125,7 +125,7 @@ See the [documentation on testing](../tools/slang-test/README.md) for more infor
 | Option                            | Default                    | Description                                                                                  |
 |-----------------------------------|----------------------------|----------------------------------------------------------------------------------------------|
 | `SLANG_VERSION`                   | Latest `v*` tag            | The project version, detected using git if available                                         |
-| `SLANG_EMBED_CORE_MODULE`         | `FALSE`                    | Build slang with an embedded version of the core module                                      |
+| `SLANG_EMBED_CORE_MODULE`         | `TRUE`                     | Build slang with an embedded version of the core module                                      |
 | `SLANG_EMBED_CORE_MODULE_SOURCE`  | `TRUE`                     | Embed the core module source in the binary                                                   |
 | `SLANG_ENABLE_ASAN`               | `FALSE`                    | Enable ASAN (address sanitizer)                                                              |
 | `SLANG_ENABLE_FULL_IR_VALIDATION` | `FALSE`                    | Enable full IR validation (SLOW!)                                                            |


### PR DESCRIPTION
It seems that release workflows were unexpectedly broken when STDLIB was renamed to CORE_MODULE.
Changed the option default because I think it just makes more sense. Removed explicit calls to enable it. Fixed docs.

Should `SLANG_EMBED_CORE_MODULE_SOURCE` be disabled too? Does it do anything useful?

As reported in https://github.com/shader-slang/slang/issues/5631

NOTE: I haven't really tested it at this point, but should work.
