### PR TITLE
Don't treat StrcturedBuffer<IFoo> as a specializable param.

### DIFF
--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -79,15 +79,6 @@ static void _collectExistentialSpecializationParamsRec(
             loc);
         return;
     }
-    else if (auto structuredBufferType = as<HLSLStructuredBufferTypeBase>(type))
-    {
-        _collectExistentialSpecializationParamsRec(
-            astBuilder,
-            ioSpecializationParams,
-            structuredBufferType->getElementType(),
-            loc);
-        return;
-    }
 
     if (auto declRefType = as<DeclRefType>(type))
     {

--- a/source/slang/slang-mangle.cpp
+++ b/source/slang/slang-mangle.cpp
@@ -817,6 +817,7 @@ String getMangledTypeName(ASTBuilder* astBuilder, Type* type)
 {
     SLANG_AST_BUILDER_RAII(astBuilder);
     ManglingContext context(astBuilder);
+    emitRaw(&context, "_ST");
     emitType(&context, type);
     return context.sb.produceString();
 }

--- a/tests/bugs/dyn-dispatch-single-conformance.slang
+++ b/tests/bugs/dyn-dispatch-single-conformance.slang
@@ -1,0 +1,27 @@
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK): -output-using-type
+
+interface IFoo
+{
+    float3 get();
+}
+
+struct Foo : IFoo
+{
+    float3 val;
+    float3 get() { return val; }
+};
+
+//TEST_INPUT: type_conformance Foo:IFoo=0
+
+//TEST_INPUT:set foo = ubuffer(data=[0 0 0 0 1.0 2.0 3.0 0.0], stride=4)
+StructuredBuffer<IFoo> foo;
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    // CHECK: 1.0
+    outputBuffer[0] = foo[0].get().x;
+}

--- a/tests/compute/dynamic-dispatch-13.slang
+++ b/tests/compute/dynamic-dispatch-13.slang
@@ -17,7 +17,6 @@ interface IInterface
 RWStructuredBuffer<int> gOutputBuffer;
 //TEST_INPUT: set gCb = new StructuredBuffer<IInterface>{new MyImpl{1}};
 RWStructuredBuffer<IInterface> gCb;
-// Add two elements into the structured buffer to prevent specialization.
 //TEST_INPUT: set gCb1 = new StructuredBuffer<IInterface>{new MyImpl{1}, new MyImpl2{2}};
 RWStructuredBuffer<IInterface> gCb1;
 

--- a/tests/compute/dynamic-dispatch-14.slang
+++ b/tests/compute/dynamic-dispatch-14.slang
@@ -23,12 +23,10 @@ interface IInterface
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=gOutputBuffer
 RWStructuredBuffer<int> gOutputBuffer;
 
-
-// Specialize gCb1, but not gCb2
 //TEST_INPUT: set gCb = new StructuredBuffer<IInterface>{new MyImpl{1}};
 RWStructuredBuffer<IInterface> gCb;
 
-//TEST_INPUT: set gCb1 = dynamic new StructuredBuffer<IInterface>{new MyImpl{1}}
+//TEST_INPUT: set gCb1 = new StructuredBuffer<IInterface>{new MyImpl{1}}
 RWStructuredBuffer<IInterface> gCb1;
 
 [numthreads(4, 1, 1)]

--- a/tests/compute/dynamic-dispatch-15.slang
+++ b/tests/compute/dynamic-dispatch-15.slang
@@ -14,7 +14,7 @@ interface IInterface
 //TEST_INPUT:ubuffer(data=[0], stride=4):out,name=gOutputBuffer
 RWStructuredBuffer<float> gOutputBuffer;
 
-//TEST_INPUT: set gObj = dynamic new StructuredBuffer<IInterface>[new FloatVal{1.0}, new Float4Val{{[2.0, 3.0, 4.0, 5.0]}}, new IntVal{6}, new Int4Val{[7,8,9,10]}];
+//TEST_INPUT: set gObj = new StructuredBuffer<IInterface>[new FloatVal{1.0}, new Float4Val{{[2.0, 3.0, 4.0, 5.0]}}, new IntVal{6}, new Int4Val{[7,8,9,10]}];
 RWStructuredBuffer<IInterface> gObj;
 
 [numthreads(1, 1, 1)]

--- a/tests/compute/interface-assoc-type-param.slang
+++ b/tests/compute/interface-assoc-type-param.slang
@@ -16,7 +16,8 @@ interface IEval
     uint eval();
 }
 
-export struct Impl : IInterface
+//TEST_INPUT: type_conformance Impl:IInterface = 0
+struct Impl : IInterface
 {
     uint val;
     struct TEval : IEval

--- a/tests/language-feature/interfaces/empty-type-conformance.slang
+++ b/tests/language-feature/interfaces/empty-type-conformance.slang
@@ -1,5 +1,3 @@
-// Test that we allow empty type conformances.
-
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx11 -compute  -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute  -output-using-type
 
@@ -17,6 +15,8 @@ StructuredBuffer<TestInterface> inBuffer;
 
 //TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0], stride=4);
 RWStructuredBuffer<float> outputBuffer;
+
+//TEST_INPUT: type_conformance TestImplementation:TestInterface=0
 
 [shader("compute")]
 [numthreads(1, 1, 1)]


### PR DESCRIPTION
Fixes #5629.

When we have a `StructuredBuffer<IFoo>` parameter, we shouldn't treat it as a statically specializable parameter because we never want to directly replace `IFoo` with any concrete type. Instead we want to always rely on the dynamic dispatch handling logic to insert proper header to maintain data layout consistency.