### PR TITLE
Fix unused struct in  sample shader

### DIFF
--- a/examples/triangle/shaders.slang
+++ b/examples/triangle/shaders.slang
@@ -57,10 +57,12 @@ VertexStageOutput vertexMain(
 // Fragment Shader
 
 [shader("fragment")]
-float4 fragmentMain(
+Fragment fragmentMain(
     CoarseVertex coarseVertex : CoarseVertex) : SV_Target
 {
     float3 color = coarseVertex.color;
 
-    return float4(color, 1.0);
+    Fragment output;
+    output.color = float4(color, 1.0);
+    return output;
 }


### PR DESCRIPTION
Hi, I'm new here.

I was looking at the triangle sample and noticed that it declared a struct `Fragment` for the fragment shader output but didn't actually use it, so I decided to fix that.

Of course, I could have just deleted `Fragment`, but I chose to use it to demonstrate that we can use a custom struct for output.