### PR TITLE
Test varying inputs and outputs for wgsl

### DIFF
--- a/tests/compute/constexpr.slang
+++ b/tests/compute/constexpr.slang
@@ -2,6 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -gcompute -shaderobj
 //DISABLED://TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -gcompute -shaderobj
 //TEST(compute):COMPARE_COMPUTE_EX:-mtl -gcompute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-wgpu -gcompute -shaderobj
 
 //TEST_INPUT: Texture2D(size=4, content = one):name tex
 //TEST_INPUT: Sampler:name samp

--- a/tests/metal/nested-struct-fragment-input.slang
+++ b/tests/metal/nested-struct-fragment-input.slang
@@ -1,5 +1,6 @@
 //TEST:SIMPLE(filecheck=METAL): -target metal -stage fragment -entry fragmentMain
 //TEST:SIMPLE(filecheck=METALLIB): -target metallib -stage fragment -entry fragmentMain
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage fragment -entry fragmentMain
 
 // METAL: COARSEVERTEX_7
 // METAL: COARSEVERTEX_6
@@ -62,6 +63,16 @@ float4 fragmentMain(FragmentStageInput input)
     // METAL-DAG: {{.*}}->p3{{.*}}->p1{{.*}}=
     // METAL-DAG: {{.*}}->p3{{.*}}->p2{{.*}}->p1{{.*}}=
     // METAL-DAG: {{.*}}->p3{{.*}}->p3{{.*}}->p1{{.*}}=
+
+    // WGSL-DAG: {{.*}}._S{{.*}}=
+
+    // WGSL-DAG: {{.*}}.p2{{.*}}._S{{.*}}=
+    // WGSL-DAG: {{.*}}.p2{{.*}}.p2{{.*}}._S{{.*}}=
+    // WGSL-DAG: {{.*}}.p2{{.*}}.p3{{.*}}._S{{.*}}=
+
+    // WGSL-DAG: {{.*}}.p3{{.*}}._S{{.*}}=
+    // WGSL-DAG: {{.*}}.p3{{.*}}.p2{{.*}}._S{{.*}}=
+    // WGSL-DAG: {{.*}}.p3{{.*}}.p3{{.*}}._S{{.*}}=
 
     outputBuffer[0] = input.coarseVertex.p1 + input.coarseVertex.p2.p1 + +input.coarseVertex.p3.p1;
     return float4(0, 0, 0, 0);

--- a/tests/metal/nested-struct-fragment-output.slang
+++ b/tests/metal/nested-struct-fragment-output.slang
@@ -1,5 +1,6 @@
 //TEST:SIMPLE(filecheck=METAL): -target metal -stage fragment -entry fragmentMain
 //TEST:SIMPLE(filecheck=METALLIB): -target metallib -stage fragment -entry fragmentMain
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage fragment -entry fragmentMain
 
 //METAL-DAG: color(0)
 //METAL-DAG: color(1)
@@ -9,6 +10,15 @@
 //METAL-DAG: color(5)
 //METAL-DAG: color(6)
 //METAL-NOT: color(7)
+
+//WGSL-DAG: location(0)
+//WGSL-DAG: location(1)
+//WGSL-DAG: location(2)
+//WGSL-DAG: location(3)
+//WGSL-DAG: location(4)
+//WGSL-DAG: location(5)
+//WGSL-DAG: location(6)
+//WGSL-NOT: location(7)
 
 //METALLIB: @fragmentMain
 
@@ -68,6 +78,16 @@ FragmentStageOutput fragmentMain(FragmentStageInput input)
     // METAL-DAG: ={{.*}}.p3{{.*}}.p1
     // METAL-DAG: ={{.*}}.p3{{.*}}.p2{{.*}}.p1
     // METAL-DAG: ={{.*}}.p3{{.*}}.p3{{.*}}.p1
+
+    // WGSL-DAG: ={{.*}}._S{{.*}}
+
+    // WGSL-DAG: ={{.*}}.p2{{.*}}._S{{.*}}
+    // WGSL-DAG: ={{.*}}.p2{{.*}}.p2{{.*}}._S{{.*}}
+    // WGSL-DAG: ={{.*}}.p2{{.*}}.p3{{.*}}._S{{.*}}
+
+    // WGSL-DAG: ={{.*}}.p3{{.*}}._S{{.*}}
+    // WGSL-DAG: ={{.*}}.p3{{.*}}.p2{{.*}}._S{{.*}}
+    // WGSL-DAG: ={{.*}}.p3{{.*}}.p3{{.*}}._S{{.*}}
 
 	outputBuffer[0] = 1;
 	return output;

--- a/tests/metal/nested-struct-multi-entry-point-vertex.slang
+++ b/tests/metal/nested-struct-multi-entry-point-vertex.slang
@@ -2,16 +2,28 @@
 //TEST:SIMPLE(filecheck=METALLIB1): -target metallib -stage vertex -entry vertexMain1
 //TEST:SIMPLE(filecheck=METAL2): -target metal -stage vertex -entry vertexMain2
 //TEST:SIMPLE(filecheck=METALLIB2): -target metallib -stage vertex -entry vertexMain2
+//TEST:SIMPLE(filecheck=WGSL1): -target wgsl -stage vertex -entry vertexMain1
+//TEST:SIMPLE(filecheck=WGSL2): -target wgsl -stage vertex -entry vertexMain2
 
 //METALLIB1: @vertexMain1
 //METAL1-DAG: attribute(0)
 //METAL1-DAG: attribute(1)
 //METAL1-NOT: attribute(2)
 
+//WGSL1-DAG: fn vertexMain1
+//WGSL1-DAG: location(0)
+//WGSL1-DAG: location(1)
+//WGSL1-NOT: location(2)
+
 //METALLIB2: @vertexMain2
 //METAL2-DAG: attribute(0)
 //METAL2-DAG: attribute(1)
 //METAL2-DAG: attribute(2)
+
+//WGSL2-DAG: fn vertexMain2
+//WGSL2-DAG: location(0)
+//WGSL2-DAG: location(1)
+//WGSL2-DAG: location(2)
 
 struct SharedStruct
 {

--- a/tests/metal/no-struct-vertex-output.slang
+++ b/tests/metal/no-struct-vertex-output.slang
@@ -1,8 +1,12 @@
 //TEST:SIMPLE(filecheck=METAL): -target metallib -stage vertex -entry vertexMain
 //TEST:SIMPLE(filecheck=METALLIB): -target metallib -stage vertex -entry vertexMain
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage vertex -entry vertexMain
 
 //METAL-DAG: position
 //METALLIB: @vertexMain
+
+//WGSL-DAG: @builtin(position)
+//WGSL-DAG: @vertex
 
 // Vertex Shader
 

--- a/tests/metal/sv_target-complex-1.slang
+++ b/tests/metal/sv_target-complex-1.slang
@@ -1,5 +1,6 @@
-//TEST:SIMPLE(filecheck=CHECK): -target metal
-//TEST:SIMPLE(filecheck=CHECK-ASM): -target metallib
+//TEST:SIMPLE(filecheck=METAL): -target metal
+//TEST:SIMPLE(filecheck=METAL-ASM): -target metallib
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -entry fragmentMain -stage fragment
 
 struct NestedReturn
 {
@@ -20,12 +21,18 @@ struct Output
     NestedReturn2 debug2 : SV_TaRget3;
 }
 
-// CHECK-ASM: define {{.*}} @fragmentMain
-// CHECK: color(0)
-// CHECK-DAG: color(1)
-// CHECK-DAG: color(2)
-// CHECK-DAG: color(3)
-// CHECK-DAG: color(4)
+// METAL-ASM: define {{.*}} @fragmentMain
+// METAL: color(0)
+// METAL-DAG: color(1)
+// METAL-DAG: color(2)
+// METAL-DAG: color(3)
+// METAL-DAG: color(4)
+
+// WGSL: location(0)
+// WGSL-DAG: location(1)
+// WGSL-DAG: location(2)
+// WGSL-DAG: location(3)
+// WGSL-DAG: location(4)
 
 [shader("fragment")]
 Output fragmentMain()

--- a/tests/metal/sv_target-complex-2.slang
+++ b/tests/metal/sv_target-complex-2.slang
@@ -1,5 +1,6 @@
-//TEST:SIMPLE(filecheck=CHECK): -target metal
-//TEST:SIMPLE(filecheck=CHECK-ASM): -target metallib
+//TEST:SIMPLE(filecheck=METAL): -target metal
+//TEST:SIMPLE(filecheck=METAL-ASM): -target metallib
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -entry fragmentMain -stage fragment
 
 struct NestedReturn
 {
@@ -14,11 +15,16 @@ struct Output
     float4 Material : SV_Target2;
 }
 
-// CHECK-ASM: define {{.*}} @fragmentMain
-// CHECK: color(0)
-// CHECK: color(1)
-// CHECK-DAG: color(3)
-// CHECK-DAG: color(2)
+// METAL-ASM: define {{.*}} @fragmentMain
+// METAL: color(0)
+// METAL: color(1)
+// METAL-DAG: color(3)
+// METAL-DAG: color(2)
+
+// WGSL-DAG: location(0)
+// WGSL-DAG: location(1)
+// WGSL-DAG: location(3)
+// WGSL-DAG: location(2)
 
 [shader("fragment")]
 Output fragmentMain()

--- a/tests/wgsl/semantic-coverage.slang
+++ b/tests/wgsl/semantic-coverage.slang
@@ -1,0 +1,16 @@
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage fragment -entry main
+
+//WGSL-DAG: @builtin(sample_mask)
+//WGSL-DAG: @fragment
+
+struct Out 
+{
+    uint coverage : SV_Coverage;
+};
+
+Out main() 
+{
+    Out output;
+    output.coverage = 1;
+    return output;
+}

--- a/tests/wgsl/semantic-depth.slang
+++ b/tests/wgsl/semantic-depth.slang
@@ -1,0 +1,16 @@
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage fragment -entry main
+
+//WGSL-DAG: @builtin(frag_depth)
+//WGSL-DAG: @fragment
+
+struct Out 
+{
+    float depth : SV_Depth;
+};
+
+Out main() 
+{
+    Out output;
+    output.depth = 1.0;
+    return output;
+}

--- a/tests/wgsl/semantic-dispatch-thread-id.slang
+++ b/tests/wgsl/semantic-dispatch-thread-id.slang
@@ -1,0 +1,9 @@
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage compute -entry main
+
+//WGSL-DAG: @builtin(global_invocation_id)
+//WGSL-DAG: @compute
+
+void main(uint3 dtid : SV_DispatchThreadID) 
+{
+    // Empty compute shader
+}

--- a/tests/wgsl/semantic-group-id.slang
+++ b/tests/wgsl/semantic-group-id.slang
@@ -1,0 +1,9 @@
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage compute -entry main
+
+//WGSL-DAG: @builtin(workgroup_id)
+//WGSL-DAG: @compute
+
+void main(uint3 gid : SV_GroupID) 
+{
+    // Empty compute shader
+}

--- a/tests/wgsl/semantic-group-index.slang
+++ b/tests/wgsl/semantic-group-index.slang
@@ -1,0 +1,9 @@
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage compute -entry main
+
+//WGSL-DAG: @builtin(local_invocation_index)
+//WGSL-DAG: @compute
+
+void main(uint idx : SV_GroupIndex) 
+{
+    // Empty compute shader
+}

--- a/tests/wgsl/semantic-group-thread-id.slang
+++ b/tests/wgsl/semantic-group-thread-id.slang
@@ -1,0 +1,9 @@
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage compute -entry main
+
+//WGSL-DAG: @builtin(local_invocation_id)
+//WGSL-DAG: @compute
+
+void main(uint3 gtid : SV_GroupThreadID) 
+{
+    // Empty compute shader
+}

--- a/tests/wgsl/semantic-instance-id.slang
+++ b/tests/wgsl/semantic-instance-id.slang
@@ -1,0 +1,9 @@
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage vertex -entry main
+
+//WGSL-DAG: @builtin(instance_index)
+//WGSL-DAG: @vertex
+
+float4 main(uint instanceID : SV_InstanceID) : SV_Position 
+{
+    return float4(1,1,1,1);
+}

--- a/tests/wgsl/semantic-is-front-face.slang
+++ b/tests/wgsl/semantic-is-front-face.slang
@@ -1,0 +1,9 @@
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage fragment -entry main
+
+//WGSL-DAG: @builtin(front_facing)
+//WGSL-DAG: @fragment
+
+float4 main(bool isFront : SV_IsFrontFace) : SV_Target 
+{
+    return float4(1,1,1,1);
+}

--- a/tests/wgsl/semantic-position.slang
+++ b/tests/wgsl/semantic-position.slang
@@ -1,0 +1,16 @@
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage vertex -entry main
+
+//WGSL-DAG: @builtin(position)
+//WGSL-DAG: @vertex
+
+struct S 
+{
+    float4 position : SV_Position;
+};
+
+S main() 
+{
+    S output;
+    output.position = float4(0,0,0,1);
+    return output;
+}

--- a/tests/wgsl/semantic-sample-index.slang
+++ b/tests/wgsl/semantic-sample-index.slang
@@ -1,0 +1,9 @@
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage fragment -entry main
+
+//WGSL-DAG: @builtin(sample_index)
+//WGSL-DAG: @fragment
+
+float4 main(uint sampleIndex : SV_SampleIndex) : SV_Target 
+{
+    return float4(1,1,1,1);
+}

--- a/tests/wgsl/semantic-vertex-id.slang
+++ b/tests/wgsl/semantic-vertex-id.slang
@@ -1,0 +1,9 @@
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage vertex -entry main
+
+//WGSL-DAG: @builtin(vertex_index)
+//WGSL-DAG: @vertex
+
+float4 main(uint vertexID : SV_VertexID) : SV_Position 
+{
+    return float4(1,1,1,1);
+}


### PR DESCRIPTION
Closes https://github.com/shader-slang/slang/issues/5067

New tests, covering what's declared supported in the WGSL support docs

- tests/wgsl/semantic-coverage.slang
- tests/wgsl/semantic-depth.slang
- tests/wgsl/semantic-dispatch-thread-id.slang
- tests/wgsl/semantic-group-id.slang
- tests/wgsl/semantic-group-index.slang
- tests/wgsl/semantic-group-thread-id.slang
- tests/wgsl/semantic-instance-id.slang
- tests/wgsl/semantic-is-front-face.slang
- tests/wgsl/semantic-position.slang
- tests/wgsl/semantic-sample-index.slang
- tests/wgsl/semantic-vertex-id.slang

WGSL enabled existing tests:
- tests/compute/compile-time-loop.slang
- tests/compute/constexpr.slang
- tests/compute/discard-stmt.slang
- tests/metal/nested-struct-fragment-input.slang
- tests/metal/nested-struct-fragment-output.slang
- tests/metal/nested-struct-multi-entry-point-vertex.slang
- tests/metal/no-struct-vertex-output.slang
- tests/metal/sv_target-complex-1.slang
- tests/metal/sv_target-complex-2.slang
- tests/bugs/texture2d-gather.hlsl
- tests/render/cross-compile-entry-point.slang
- tests/render/nointerpolation.hlsl
- tests/render/render0.hlsl
- tests/render/cross-compile0.hlsl
- tests/render/imported-parameters.hlsl
- tests/render/unused-discard.hlsl

Can't be enabled due to missing wgsl features

- tests/compute/texture-sampling.slang
