### PR TITLE
Enable Link-Time-Code-Generation for Release builds

### DIFF
--- a/cmake/SlangTarget.cmake
+++ b/cmake/SlangTarget.cmake
@@ -156,6 +156,13 @@ function(slang_add_target dir type)
         return()
     endif()
 
+    # Enable link-time optimization for release builds
+    # See: https://cmake.org/cmake/help/latest/prop_tgt/INTERPROCEDURAL_OPTIMIZATION.html
+    set_target_properties(
+        ${target}
+        PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE
+    )
+
     #
     # Set the output directory
     #


### PR DESCRIPTION
Closes https://github.com/shader-slang/slang/discussions/5632

This commit enables Link Time Code Generation, or LTCG for short, for the release builds.

Because "incremental" build is enabled, this ends up using "/LTCG:incremental" rather than the full "/LTCG". It is still expected to more performant than without any "/LTCG" at all.

In order to use the full LTCG, we will need to give up the incremental build option for the Release build. We will need to decide if we wants to do it later.