### PR TITLE
Update Slang-RHI/slang

### DIFF
--- a/tests/autodiff/float-cast.slang
+++ b/tests/autodiff/float-cast.slang
@@ -1,5 +1,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj -output-using-type -render-features half
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -output-using-type -render-features half
+// Not supported in WGSL: Double and other unsupported scalar types
+//DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-wgpu
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;


### PR DESCRIPTION
This brings in new fixes for WebGPU.
In particular, the "use_dxc" toggle is now used, which should enable these tests to run on WebGPU, if f16 is otherwise supported:

- `tests/language-feature/generics/variadic-0.slang`
- `tests/language-feature/generics/tuple.slang`

This closes #5605.