### PR TITLE
Fix compiler warning when using slang.h with gcc/clang on Windows

### DIFF
--- a/include/slang.h
+++ b/include/slang.h
@@ -273,7 +273,7 @@ convention for interface methods.
 #endif
 
 // Microsoft VC specific
-#if SLANG_MICROSOFT_FAMILY
+#if SLANG_VC
     #define SLANG_NO_INLINE __declspec(noinline)
     #define SLANG_FORCE_INLINE __forceinline
     #define SLANG_BREAKPOINT(id) __debugbreak();


### PR DESCRIPTION
The macros SLANG_NO_INLINE, SLANG_FORCE_INLINE, SLANG_BREAKPOINT and SLANG_ALIGN_OF end up getting defined twice when using g++ or clang++ with the slang.h header on Windows.

Change the VC specific definitions to depend on SLANG_VC instead of SLANG_MICROSOFT_FAMILY.

Resolves #5765 