### PR TITLE
Remove duplicate call to install() for libslang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,15 +357,12 @@ configure_package_config_file(
     INSTALL_DESTINATION cmake
 )
 
-# Conditionally handle the case for Emscripten where slang does not create linkable
-# targets. In this case do not export the targets. Otherwise, just export the 
-# slang target, as this is the library that is required to use the compiler. This possibly
-# should later be expanded to include slang-rhi targets if some program intends to use them, 
-# but possibly wait for a future request before expanding this export set.
+# Conditionally handle the case for Emscripten where slang does not create
+# linkable targets. In this case do not export the targets. Otherwise, just
+# export the slang targets. 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-    install(TARGETS slang EXPORT SlangExportTarget)
     install(
-        EXPORT SlangExportTarget
+        EXPORT SlangTargets
         FILE ${PROJECT_NAME}Targets.cmake
         NAMESPACE ${PROJECT_NAME}::
         DESTINATION cmake

--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -88,6 +88,7 @@ function(fetch_or_build_slang_llvm)
             EXPORT_MACRO_PREFIX SLANG
             INSTALL
             INSTALL_COMPONENT slang-llvm
+            EXPORT_SET_NAME SlangTargets
         )
         # If we don't include this, then the symbols in the LLVM linked here may
         # conflict with those of other LLVMs linked at runtime, for instance in mesa.

--- a/cmake/SlangTarget.cmake
+++ b/cmake/SlangTarget.cmake
@@ -53,6 +53,8 @@ function(slang_add_target dir type)
         # explicit name instead, used for externally built things such as
         # slang-glslang and slang-llvm which have large pdb files
         DEBUG_INFO_INSTALL_COMPONENT
+        # The name of the Export set to associate with this installed target
+        EXPORT_SET_NAME
     )
     set(multi_value_args
         # Use exactly these sources, instead of globbing from the directory
@@ -408,22 +410,31 @@ function(slang_add_target dir type)
     # Mark for installation
     #
     macro(i)
+        if(ARG_EXPORT_SET_NAME)
+            set(export_args EXPORT ${ARG_EXPORT_SET_NAME})
+        else()
+            if(type MATCHES "^(EXECUTABLE|SHARED|MODULE)$")
+                message(
+                    WARNING
+                    "Target ${target} is set to be INSTALLED but EXPORT_SET_NAME wasn't specified"
+                )
+            endif()
+            set(export_args)
+        endif()
         install(
-            TARGETS ${target}
-            EXPORT SlangTargets
+            TARGETS ${target} ${export_args}
             ARCHIVE DESTINATION ${archive_subdir} ${ARGN}
             LIBRARY DESTINATION ${library_subdir} ${ARGN}
             RUNTIME DESTINATION ${runtime_subdir} ${ARGN}
             PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} ${ARGN}
         )
     endmacro()
-    if(ARG_INSTALL)
-        i()
-        set(pdb_component "debug-info")
-    endif()
     if(ARG_INSTALL_COMPONENT)
         i(EXCLUDE_FROM_ALL COMPONENT ${ARG_INSTALL_COMPONENT})
         set(pdb_component "${ARG_INSTALL_COMPONENT}-debug-info")
+    elseif(ARG_INSTALL)
+        i()
+        set(pdb_component "debug-info")
     endif()
     if(ARG_DEBUG_INFO_INSTALL_COMPONENT)
         set(pdb_component ${ARG_DEBUG_INFO_INSTALL_COMPONENT})

--- a/source/slang-glslang/CMakeLists.txt
+++ b/source/slang-glslang/CMakeLists.txt
@@ -9,6 +9,7 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
         LINK_WITH_PRIVATE glslang SPIRV SPIRV-Tools-opt
         INCLUDE_DIRECTORIES_PRIVATE ${slang_SOURCE_DIR}/include
         INSTALL
+        EXPORT_SET_NAME SlangTargets
         DEBUG_INFO_INSTALL_COMPONENT slang-glslang-debug-info
     )
     # Our only interface is through what we define in source/slang-glslang, in the

--- a/source/slang-rt/CMakeLists.txt
+++ b/source/slang-rt/CMakeLists.txt
@@ -10,5 +10,10 @@ if(SLANG_ENABLE_SLANGRT)
         EXPORT_MACRO_PREFIX SLANG_RT
         INCLUDE_DIRECTORIES_PUBLIC ${slang_SOURCE_DIR}/include
         INSTALL
+        # This depends on unordered_dense in the header, so we can't export
+        # this via cmake without obligating ourselves to also install our
+        # bundled version of unordered_dense, give it this different export set
+        # name so we don't attempt to export it
+        EXPORT_SET_NAME SlangRTTargets
     )
 endif()

--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -233,6 +233,8 @@ set(slang_public_lib_args
     $<IF:$<BOOL:${SLANG_EMBED_CORE_MODULE}>,slang-embedded-core-module,slang-no-embedded-core-module>
     $<IF:$<BOOL:${SLANG_EMBED_CORE_MODULE_SOURCE}>,slang-embedded-core-module-source,slang-no-embedded-core-module-source>
     INSTALL
+    EXPORT_SET_NAME
+    SlangTargets
 )
 
 #
@@ -284,6 +286,7 @@ else()
         OUTPUT_DIR generators
         FOLDER generators
         INSTALL_COMPONENT generators
+        EXPORT_SET_NAME SlangGeneratorTargets
     )
     slang_add_target(
         .

--- a/source/slangc/CMakeLists.txt
+++ b/source/slangc/CMakeLists.txt
@@ -6,5 +6,6 @@ if(SLANG_ENABLE_SLANGC)
         DEBUG_DIR ${slang_SOURCE_DIR}
         LINK_WITH_PRIVATE core slang Threads::Threads
         INSTALL
+        EXPORT_SET_NAME SlangTargets
     )
 endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -39,6 +39,7 @@ function(generator dir)
             REQUIRED_BY all-generators
             FOLDER generators
             INSTALL_COMPONENT generators
+            EXPORT_SET_NAME SlangGeneratorTargets
             ${ARGN}
         )
     endif()
@@ -93,6 +94,7 @@ if(SLANG_ENABLE_SLANGD)
             slang-capability-defs
             Threads::Threads
         INSTALL
+        EXPORT_SET_NAME SlangTargets
     )
 endif()
 
@@ -152,6 +154,7 @@ if(SLANG_ENABLE_GFX)
             ${slang_SOURCE_DIR}/include
         REQUIRES copy-gfx-slang-modules
         INSTALL
+        EXPORT_SET_NAME SlangTargets
         FOLDER gfx
     )
     set(modules_dest_dir $<TARGET_FILE_DIR:slang-test>)


### PR DESCRIPTION
Closes https://github.com/shader-slang/slang/issues/5764

Also mention other installed targets in cmake config

Technically a breaking change if anyone is used to the `lib64` install location, but that never made it into a release