### PR TITLE
Add API for getting last internal error message

### DIFF
--- a/include/slang.h
+++ b/include/slang.h
@@ -4416,7 +4416,7 @@ SLANG_API ISlangBlob* slang_getEmbeddedCoreModule();
 SLANG_EXTERN_C SLANG_API void slang_shutdown();
 
 /* Return the last signaled internal error message.
-*/
+ */
 SLANG_EXTERN_C SLANG_API const char* slang_getLastInternalErrorMessage();
 
 namespace slang

--- a/include/slang.h
+++ b/include/slang.h
@@ -4415,6 +4415,10 @@ SLANG_API ISlangBlob* slang_getEmbeddedCoreModule();
  */
 SLANG_EXTERN_C SLANG_API void slang_shutdown();
 
+/* Return the last signaled internal error message.
+*/
+SLANG_EXTERN_C SLANG_API const char* slang_getLastInternalErrorMessage();
+
 namespace slang
 {
 inline SlangResult createGlobalSession(slang::IGlobalSession** outGlobalSession)
@@ -4424,6 +4428,10 @@ inline SlangResult createGlobalSession(slang::IGlobalSession** outGlobalSession)
 inline void shutdown()
 {
     slang_shutdown();
+}
+inline const char* getLastInternalErrorMessage()
+{
+    return slang_getLastInternalErrorMessage();
 }
 } // namespace slang
 

--- a/source/core/slang-signal.cpp
+++ b/source/core/slang-signal.cpp
@@ -6,7 +6,7 @@
 namespace Slang
 {
 
-static String s_lastSignalMessage;
+thread_local String g_lastSignalMessage;
 
 static const char* _getSignalTypeAsText(SignalType type)
 {
@@ -56,7 +56,7 @@ String _getMessage(SignalType type, char const* message)
         printf("%s\n", _getMessage(type, message).getBuffer());
     }
 
-    s_lastSignalMessage = _getMessage(type, message);
+    g_lastSignalMessage = _getMessage(type, message);
 
 #if SLANG_HAS_EXCEPTIONS
     switch (type)
@@ -81,7 +81,7 @@ String _getMessage(SignalType type, char const* message)
 
 const char* getLastSignalMessage()
 {
-    return s_lastSignalMessage.getBuffer();
+    return g_lastSignalMessage.getBuffer();
 }
 
 } // namespace Slang

--- a/source/core/slang-signal.cpp
+++ b/source/core/slang-signal.cpp
@@ -6,6 +6,8 @@
 namespace Slang
 {
 
+static String s_lastSignalMessage;
+
 static const char* _getSignalTypeAsText(SignalType type)
 {
     switch (type)
@@ -54,6 +56,8 @@ String _getMessage(SignalType type, char const* message)
         printf("%s\n", _getMessage(type, message).getBuffer());
     }
 
+    s_lastSignalMessage = _getMessage(type, message);
+
 #if SLANG_HAS_EXCEPTIONS
     switch (type)
     {
@@ -73,6 +77,11 @@ String _getMessage(SignalType type, char const* message)
     // 'panic'. Exit with an error code as we can't throw or catch.
     exit(-1);
 #endif
+}
+
+const char* getLastSignalMessage()
+{
+    return s_lastSignalMessage.getBuffer();
 }
 
 } // namespace Slang

--- a/source/core/slang-signal.h
+++ b/source/core/slang-signal.h
@@ -35,6 +35,8 @@ enum class SignalType
     ::Slang::handleSignal(::Slang::SignalType::AbortCompilation, msg)
 
 
+const char* getLastSignalMessage();
+
 } // namespace Slang
 
 #endif

--- a/source/slang/slang-api.cpp
+++ b/source/slang/slang-api.cpp
@@ -3,6 +3,7 @@
 #include "../core/slang-performance-profiler.h"
 #include "../core/slang-rtti-info.h"
 #include "../core/slang-shared-library.h"
+#include "../core/slang-signal.h"
 #include "../slang-record-replay/record/slang-global-session.h"
 #include "../slang-record-replay/util/record-utility.h"
 #include "slang-capability.h"
@@ -171,6 +172,11 @@ SLANG_API SlangResult slang_createGlobalSessionWithoutCoreModule(
 
     *outGlobalSession = result.detach();
     return SLANG_OK;
+}
+
+SLANG_API const char* slang_getLastInternalErrorMessage()
+{
+    return Slang::getLastSignalMessage();
 }
 
 SLANG_API void spDestroySession(SlangSession* inSession)


### PR DESCRIPTION
This adds a public API function `getLastInternalErrorMessage` that can be used to access the message of the last raised internal signal. This allows API users to access the same error message that is also output for internal errors when running `slangc` and get some minimal hint at what error was raised.