### PR TITLE
Fix pointer offset logic and add executable tests.

### DIFF
--- a/source/slang/slang-ir-lower-buffer-element-type.cpp
+++ b/source/slang/slang-ir-lower-buffer-element-type.cpp
@@ -901,28 +901,6 @@ struct LoweredElementTypeContext
                         {
                             builder.setInsertBefore(ptrVal);
                             auto newArrayPtrVal = fieldAddr->getBase();
-                            // Is base a pointer to an empty struct? If so, don't offset it.
-                            // For example, if the user has written:
-                            // ```
-                            // struct S {int arr[]};
-                            // uniform S* p;
-                            // void test() { p->arr[1]; }
-                            // ```
-                            // Then `S` will become an empty struct after we remove `arr[]`.
-                            // And `p` will be come a `void*`.
-                            // We don't want to offset `p` to `p+1` to get the starting address of
-                            // the array in this case.
-                            IRSizeAndAlignment parentStructSize = {};
-                            getNaturalSizeAndAlignment(
-                                target->getOptionSet(),
-                                tryGetPointedToType(&builder, fieldAddr->getBase()->getDataType()),
-                                &parentStructSize);
-                            if (parentStructSize.size != 0)
-                            {
-                                newArrayPtrVal = builder.emitGetOffsetPtr(
-                                    fieldAddr->getBase(),
-                                    builder.getIntValue(builder.getIntType(), 1));
-                            }
                             auto loweredInnerType =
                                 getLoweredTypeInfo(unsizedArrayType->getElementType(), layoutRules);
 

--- a/tests/bugs/gh-3825.slang
+++ b/tests/bugs/gh-3825.slang
@@ -21,7 +21,6 @@ float4 fragment(): SV_Target
 }
 
 // CHECK: OpDecorate %_ptr_PhysicalStorageBuffer_Descriptors_natural ArrayStride 4
-// CHECK: %{{.*}} = OpPtrAccessChain %_ptr_PhysicalStorageBuffer_Descriptors_natural %{{.*}} %int_1
 // CHECK: OpBitcast %ulong
 // CHECK: OpIAdd %ulong %{{.*}} %ulong_4
 // CHECK: OpBitcast %_ptr_PhysicalStorageBuffer

--- a/tests/spirv/ptr-unsized-array-3.slang
+++ b/tests/spirv/ptr-unsized-array-3.slang
@@ -1,0 +1,29 @@
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -emit-spirv-directly
+//DISABLED_TEST: COMPARE_COMPUTE(filecheck-buffer=CHECK): -wgpu
+//DISABLED_TEST: COMPARE_COMPUTE(filecheck-buffer=CHECK): -d3d11
+//DISABLED_TEST: COMPARE_COMPUTE(filecheck-buffer=CHECK): -d3d12
+//DISABLED_TEST: COMPARE_COMPUTE(filecheck-buffer=CHECK): -metal
+
+// Test a pointer to a struct with a trailing unsized array.
+
+struct MeshStorage {
+    int foo;
+    uint64_t QuadData[];
+};
+
+//TEST_INPUT: set pStorage = ubuffer(data=[1 2 3 4 5 6 7 8],stride=4);
+uniform MeshStorage* pStorage;
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0],stride=4);
+uniform RWStructuredBuffer<uint> outputBuffer;
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    // CHECK: 5
+    // CHECK: 6
+    // CHECK: 1
+    outputBuffer[0] = (int)(pStorage.QuadData[1]&0xFFFFFFFF);
+    outputBuffer[1] = (int)(pStorage.QuadData[1]>>32);
+    outputBuffer[2] = pStorage.foo;
+}

--- a/tests/spirv/ptr-unsized-array-4.slang
+++ b/tests/spirv/ptr-unsized-array-4.slang
@@ -1,0 +1,25 @@
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -emit-spirv-directly
+//DISABLED_TEST: COMPARE_COMPUTE(filecheck-buffer=CHECK): -wgpu
+//DISABLED_TEST: COMPARE_COMPUTE(filecheck-buffer=CHECK): -d3d11
+//DISABLED_TEST: COMPARE_COMPUTE(filecheck-buffer=CHECK): -d3d12
+//DISABLED_TEST: COMPARE_COMPUTE(filecheck-buffer=CHECK): -metal
+
+// Test a pointer to a struct that has only one field and is an unsized array.
+struct MeshStorage {
+    uint64_t QuadData[];
+};
+
+//TEST_INPUT: set pStorage = ubuffer(data=[1 2 3 4 5 6 7 8],stride=4);
+uniform MeshStorage* pStorage;
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0],stride=4);
+uniform RWStructuredBuffer<uint> outputBuffer;
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    // CHECK: 3
+    // CHECK: 4
+    outputBuffer[0] = (int)(pStorage.QuadData[1]&0xFFFFFFFF);
+    outputBuffer[1] = (int)(pStorage.QuadData[1]>>32);
+}

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -222,7 +222,7 @@ struct AssignValsFromLayoutContext
             device,
             bufferResource));
 
-        if (dstCursor.getTypeLayout()->getSize() != 0)
+        if (dstCursor.getTypeLayout()->getType()->getKind() == slang::TypeReflection::Kind::Pointer)
         {
             // dstCursor is pointer to an ordinary uniform data field,
             // we should write bufferResource as a pointer.

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -76,6 +76,12 @@ struct ShaderOutputPlan
     List<Item> items;
 };
 
+// A context for hodling resources allocated for a test.
+struct TestResourceContext
+{
+    List<ComPtr<IResource>> resources;
+};
+
 class RenderTestApp
 {
 public:
@@ -134,6 +140,7 @@ protected:
     Options m_options;
 
     ShaderOutputPlan m_outputPlan;
+    TestResourceContext m_resourceContext;
 };
 
 struct AssignValsFromLayoutContext
@@ -141,6 +148,7 @@ struct AssignValsFromLayoutContext
     IDevice* device;
     slang::ISession* slangSession;
     ShaderOutputPlan& outputPlan;
+    TestResourceContext& resourceContext;
     slang::ProgramLayout* slangReflection;
     IAccelerationStructure* accelerationStructure;
 
@@ -148,11 +156,13 @@ struct AssignValsFromLayoutContext
         IDevice* device,
         slang::ISession* slangSession,
         ShaderOutputPlan& outputPlan,
+        TestResourceContext& resourceContext,
         slang::ProgramLayout* slangReflection,
         IAccelerationStructure* accelerationStructure)
         : device(device)
         , slangSession(slangSession)
         , outputPlan(outputPlan)
+        , resourceContext(resourceContext)
         , slangReflection(slangReflection)
         , accelerationStructure(accelerationStructure)
     {
@@ -204,12 +214,23 @@ struct AssignValsFromLayoutContext
             bufferData.add(0);
 
         ComPtr<IBuffer> bufferResource;
+
         SLANG_RETURN_ON_FAIL(ShaderRendererUtil::createBuffer(
             srcBuffer,
             /*entry.isOutput,*/ bufferSize,
             bufferData.getBuffer(),
             device,
             bufferResource));
+
+        if (dstCursor.getTypeLayout()->getSize() != 0)
+        {
+            // dstCursor is pointer to an ordinary uniform data field,
+            // we should write bufferResource as a pointer.
+            uint64_t addr = bufferResource->getDeviceAddress();
+            dstCursor.setData(&addr, sizeof(addr));
+            resourceContext.resources.add(ComPtr<IResource>(bufferResource.get()));
+            return SLANG_OK;
+        }
 
         ComPtr<IBuffer> counterResource;
         const auto explicitCounterCursor = dstCursor.getExplicitCounter();
@@ -488,11 +509,17 @@ SlangResult _assignVarsFromLayout(
     IShaderObject* shaderObject,
     ShaderInputLayout const& layout,
     ShaderOutputPlan& ioOutputPlan,
+    TestResourceContext& ioResourceContext,
     slang::ProgramLayout* slangReflection,
     IAccelerationStructure* accelerationStructure)
 {
-    AssignValsFromLayoutContext
-        context(device, slangSession, ioOutputPlan, slangReflection, accelerationStructure);
+    AssignValsFromLayoutContext context(
+        device,
+        slangSession,
+        ioOutputPlan,
+        ioResourceContext,
+        slangReflection,
+        accelerationStructure);
     ShaderCursor rootCursor = ShaderCursor(shaderObject);
     return context.assign(rootCursor, layout.rootVal);
 }
@@ -510,6 +537,7 @@ Result RenderTestApp::applyBinding(IShaderObject* rootObject)
         rootObject,
         m_compilationOutput.layout,
         m_outputPlan,
+        m_resourceContext,
         slangReflection,
         m_topLevelAccelerationStructure);
 }


### PR DESCRIPTION
Closes #5351.

This change allows us to finally run executable tests for pointers.