### PR TITLE
Fix crash during emitCast of attributed type, allow MaxIters to take linktime const.

### DIFF
--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -744,7 +744,7 @@ class MaxItersAttribute : public Attribute
 {
     SLANG_AST_CLASS(MaxItersAttribute)
 
-    int32_t value = 0;
+    IntVal* value = 0;
 };
 
 // An inferred max iteration count on a loop.

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -720,11 +720,7 @@ Modifier* SemanticsVisitor::validateAttribute(
         }
         else
         {
-            auto cint = checkConstantIntVal(attr->args[0]);
-            if (cint)
-            {
-                maxItersAttrs->value = (int32_t)cint->getValue();
-            }
+            maxItersAttrs->value = checkLinkTimeConstantIntVal(attr->args[0]);
         }
     }
     else if (const auto userDefAttr = as<UserDefinedAttribute>(attr))

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -4637,9 +4637,14 @@ public:
             getIntValue(getIntType(), IRIntegerValue(mode)));
     }
 
-    void addLoopMaxItersDecoration(IRInst* value, IntegerLiteralValue iters)
+    void addLoopMaxItersDecoration(IRInst* value, IRIntegerValue iters)
     {
-        addDecoration(value, kIROp_LoopMaxItersDecoration, getIntValue(getIntType(), iters));
+        addDecoration(value, kIROp_LoopMaxItersDecoration, getIntValue(iters));
+    }
+
+    void addLoopMaxItersDecoration(IRInst* value, IRInst* iters)
+    {
+        addDecoration(value, kIROp_LoopMaxItersDecoration, iters);
     }
 
     void addLoopForceUnrollDecoration(IRInst* value, IntegerLiteralValue iters)

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3890,6 +3890,8 @@ enum class TypeCastStyle
 };
 static TypeCastStyle _getTypeStyleId(IRType* type)
 {
+    type = (IRType*)unwrapAttributedType(type);
+
     if (auto vectorType = as<IRVectorType>(type))
     {
         return _getTypeStyleId(vectorType->getElementType());

--- a/tests/bugs/gh-5781.slang
+++ b/tests/bugs/gh-5781.slang
@@ -1,0 +1,57 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+// CHECK: OpEntryPoint
+
+module test;
+
+public enum class MaterialID : uint { invalid = 0xffffffff };
+
+public struct Material : IDifferentiable
+{
+    float x;
+}
+
+public struct Hit
+{
+    MaterialID material;
+}
+
+public struct Scene
+{
+    StructuredBuffer<Material> materials;
+    RWStructuredBuffer<Material> grads;
+
+    [Differentiable]
+    Material load(MaterialID id) { return materials[uint(id)]; }
+
+    void accumulate(MaterialID id, Material d) { grads[uint(id)].x += d.x; }
+
+    [Differentiable, BackwardDerivative(_get_material_bwd)]
+    public Material get_material(MaterialID id) { return load(id); }
+
+    public void _get_material_bwd(MaterialID id, Material d) { accumulate(id, d); }
+
+    [Differentiable]
+    public Material get_material(Hit hit) { return get_material(hit.material); }
+}
+
+[Differentiable]
+float trace(const Scene scene, Hit hit)
+{
+    Material m = scene.get_material(hit);
+    return m.x;
+}
+
+
+[shader("compute")]
+void main(
+    uniform Scene scene,
+    uniform StructuredBuffer<uint> input,
+    uniform RWStructuredBuffer<float> output,
+    uniform RWStructuredBuffer<float> grads
+)
+{
+    Hit hit;
+    hit.material = MaterialID(input[0]);
+    output[0] = trace(scene, hit);
+    bwd_diff(trace)(scene, hit, grads[0]);
+}

--- a/tests/language-feature/constants/max-iters-link-time-const.slang
+++ b/tests/language-feature/constants/max-iters-link-time-const.slang
@@ -1,0 +1,15 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+// CHECK: OpEntryPoint
+
+extern static const int num = 10;
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    [MaxIters(num)]
+    for (int i = 0; i < num; i++)
+    {
+        outputBuffer[i] = i;
+    }
+}


### PR DESCRIPTION
Also allows MaxIters to take link time constants.

Closes #5781.
Closes #5770.