### PR TITLE
Parse slang.h for future language binding generation

### DIFF
--- a/include/slang.h
+++ b/include/slang.h
@@ -1729,8 +1729,6 @@ public:                                                              \
     typedef slang::IGlobalSession SlangSession;
 
 
-    typedef struct SlangProgramLayout SlangProgramLayout;
-
     /*!
     @brief A request for one or more compilation actions to be performed.
     */

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -52,6 +52,13 @@ generator(
     compiler-core
     slang-cpp-parser
 )
+generator(
+    slang-binding-generator
+    USE_FEWER_WARNINGS
+    LINK_WITH_PRIVATE
+    compiler-core
+    slang-cpp-parser
+)
 generator(slang-embed)
 generator(slang-generate USE_FEWER_WARNINGS)
 generator(slang-lookup-generator LINK_WITH_PRIVATE compiler-core)

--- a/tools/slang-binding-generator/binding-generator-main.cpp
+++ b/tools/slang-binding-generator/binding-generator-main.cpp
@@ -1,0 +1,161 @@
+#include "compiler-core/slang-diagnostic-sink.h"
+#include "compiler-core/slang-lexer.h"
+#include "compiler-core/slang-name.h"
+#include "compiler-core/slang-source-loc.h"
+#include "core/slang-file-system.h"
+#include "core/slang-io.h"
+#include "core/slang-list.h"
+#include "core/slang-string-slice-pool.h"
+#include "core/slang-string-util.h"
+#include "core/slang-string.h"
+#include "core/slang-writer.h"
+#include "slang-com-helper.h"
+#include "slang-cpp-parser/diagnostics.h"
+#include "slang-cpp-parser/file-util.h"
+#include "slang-cpp-parser/node-tree.h"
+#include "slang-cpp-parser/node.h"
+#include "slang-cpp-parser/options.h"
+#include "slang-cpp-parser/parser.h"
+#include "slang-cpp-parser/unit-test.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+namespace BindingGenerator
+{
+
+using namespace Slang;
+using namespace CppParse;
+
+class App
+{
+public:
+    SlangResult execute(const Options& options);
+
+    SlangResult executeWithArgs(int argc, const char* const* argv);
+
+    const Options& getOptions() const { return m_options; }
+
+    App(DiagnosticSink* sink, SourceManager* sourceManager, RootNamePool* rootNamePool)
+        : m_sink(sink), m_sourceManager(sourceManager), m_slicePool(StringSlicePool::Style::Default)
+    {
+        m_namePool.setRootNamePool(rootNamePool);
+    }
+
+protected:
+    NamePool m_namePool;
+
+    Options m_options;
+    DiagnosticSink* m_sink;
+    SourceManager* m_sourceManager;
+
+    StringSlicePool m_slicePool;
+};
+
+SlangResult App::execute(const Options& options)
+{
+    m_options = options;
+
+    if (options.m_runUnitTests)
+    {
+        SLANG_RETURN_ON_FAIL(UnitTestUtil::run());
+    }
+
+    IdentifierLookup identifierLookup;
+    identifierLookup.initDefault(options.m_markPrefix.getUnownedSlice());
+
+    NodeTree tree(&m_slicePool, &m_namePool, &identifierLookup);
+
+    // Read in each of the input files
+    for (Index i = 0; i < m_options.m_inputPaths.getCount(); ++i)
+    {
+        String inputPath;
+
+        if (m_options.m_inputDirectory.getLength())
+        {
+            inputPath = Path::combine(m_options.m_inputDirectory, m_options.m_inputPaths[i]);
+        }
+        else
+        {
+            inputPath = m_options.m_inputPaths[i];
+        }
+
+        // Read the input file
+        String contents;
+        SLANG_RETURN_ON_FAIL(FileUtil::readAllText(inputPath, m_sink, contents));
+
+        PathInfo pathInfo = PathInfo::makeFromString(inputPath);
+
+        SourceFile* sourceFile = m_sourceManager->createSourceFileWithString(pathInfo, contents);
+
+        SourceOrigin* sourceOrigin = tree.addSourceOrigin(sourceFile, options);
+
+        Parser parser(&tree, m_sink);
+        SLANG_RETURN_ON_FAIL(parser.parse(sourceOrigin, &m_options));
+    }
+
+    SLANG_RETURN_ON_FAIL(tree.calcDerivedTypes(m_sink));
+
+    // Dump out the tree
+    if (options.m_dump)
+    {
+        {
+            StringBuilder buf;
+            tree.getRootNode()->dump(0, buf);
+            m_sink->writer->write(buf.getBuffer(), buf.getLength());
+        }
+    }
+
+    return SLANG_OK;
+}
+
+SlangResult App::executeWithArgs(int argc, const char* const* argv)
+{
+    Options options;
+    OptionsParser optionsParser;
+    SLANG_RETURN_ON_FAIL(optionsParser.parse(argc, argv, m_sink, options));
+    SLANG_RETURN_ON_FAIL(execute(options));
+    return SLANG_OK;
+}
+
+} // namespace BindingGenerator
+
+int main(int argc, const char* const* argv)
+{
+    using namespace Slang;
+    using namespace BindingGenerator;
+
+    ComPtr<ISlangWriter> writer(new FileWriter(stderr, WriterFlag::AutoFlush));
+
+    RootNamePool rootNamePool;
+
+    SourceManager sourceManager;
+    sourceManager.initialize(nullptr, nullptr);
+
+    DiagnosticSink sink(&sourceManager, Lexer::sourceLocationLexer);
+    sink.writer = writer;
+
+    App app(&sink, &sourceManager, &rootNamePool);
+
+    try
+    {
+        if (SLANG_FAILED(app.executeWithArgs(argc - 1, argv + 1)))
+        {
+            sink.diagnose(SourceLoc(), CPPDiagnostics::extractorFailed);
+            return 1;
+        }
+        if (sink.getErrorCount())
+        {
+            sink.diagnose(SourceLoc(), CPPDiagnostics::extractorFailed);
+            return 1;
+        }
+    }
+    catch (...)
+    {
+        sink.diagnose(SourceLoc(), CPPDiagnostics::internalError);
+        return 1;
+    }
+
+    return 0;
+}

--- a/tools/slang-cpp-parser/parser.h
+++ b/tools/slang-cpp-parser/parser.h
@@ -13,8 +13,6 @@ using namespace Slang;
 class Parser
 {
 public:
-    typedef uint32_t NodeTypeBitType;
-
     SlangResult expect(TokenType type, Token* outToken = nullptr);
 
     bool advanceIfMarker(Token* outToken = nullptr);
@@ -28,14 +26,6 @@ public:
 
     /// Parse the contents of the source file
     SlangResult parse(SourceOrigin* sourceOrigin, const Options* options);
-
-    void setKindEnabled(Node::Kind kind, bool isEnabled = true);
-    bool isTypeEnabled(Node::Kind kind)
-    {
-        return (m_nodeTypeEnabled & (NodeTypeBitType(1) << int(kind))) != 0;
-    }
-
-    void setKindsEnabled(const Node::Kind* kinds, Index kindsCount, bool isEnabled = true);
 
     Parser(NodeTree* nodeTree, DiagnosticSink* sink);
 
@@ -91,8 +81,6 @@ protected:
     SlangResult _consumeToSync();
     /// Consumes balanced parens. Will return an error if not matched. Assumes starts on opening (
     SlangResult _consumeBalancedParens();
-
-    NodeTypeBitType m_nodeTypeEnabled;
 
     TokenList m_tokenList;
     TokenReader m_reader;

--- a/tools/slang-cpp-parser/unit-test.cpp
+++ b/tools/slang-cpp-parser/unit-test.cpp
@@ -91,16 +91,6 @@ static const char someSource[] = "class ISomeInterface\n"
 
         Parser parser(&tree, &state.m_sink);
 
-
-        {
-            const Node::Kind enableKinds[] = {
-                Node::Kind::Enum,
-                Node::Kind::EnumClass,
-                Node::Kind::EnumCase,
-                Node::Kind::TypeDef};
-            parser.setKindsEnabled(enableKinds, SLANG_COUNT_OF(enableKinds));
-        }
-
         SlangResult res = parser.parse(sourceOrigin, &state.m_options);
 
         if (state.m_sink.outputBuffer.getLength())


### PR DESCRIPTION
This implements parsing of *slang.h* as part of #5565. It adds the specific requirements to parse that file to *slang-cpp-parser* which was introduced in #5675. Additionally this adds a new target *slang-binding-generator* that can be used in the future to implement the language bindings in. For now it just provides a testing environment.

Currently a draft PR so people know this is being worked on and to collect feedback on how the lack of a preprocessor in the parser should be handled, see `TODO:` comments in the code.

Before this gets merged I'd still like to do some refactoring to reduce code duplication between the newly created *slang-binding-generator* and *slang-cpp-extractor* which it was derived from.

Even though the newly added target doesn't generate code yet, we should probably already run it as part of the build to ensure this work doesn't break once merged. Suggestions on how to do that in CMake are welcome.

To test the parser, you may run a command similar to this: `slang-binding-generator -d C:\dev\slang\include slang.h -dump`.