### PR TITLE
Don't emit a warning when implicit casting from known in-range int lit to half.

### DIFF
--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -1327,7 +1327,7 @@ bool SemanticsVisitor::_coerce(
                 // For general types of implicit conversions, we issue a warning, unless `fromExpr`
                 // is a known constant and we know it won't cause a problem.
                 bool shouldEmitGeneralWarning = true;
-                if (isScalarIntegerType(toType))
+                if (isScalarIntegerType(toType) || isHalfType(toType))
                 {
                     if (auto intVal = tryFoldIntegerConstantExpression(
                             fromExpr,

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -7421,6 +7421,15 @@ bool SemanticsVisitor::isScalarIntegerType(Type* type)
     return isIntegerBaseType(baseType) || baseType == BaseType::Bool;
 }
 
+bool SemanticsVisitor::isHalfType(Type* type)
+{
+    auto basicType = as<BasicExpressionType>(type);
+    if (!basicType)
+        return false;
+    auto baseType = basicType->getBaseType();
+    return baseType == BaseType::Half;
+}
+
 bool SemanticsVisitor::isValidCompileTimeConstantType(Type* type)
 {
     return isScalarIntegerType(type) || isEnumType(type);
@@ -7466,6 +7475,9 @@ bool SemanticsVisitor::isIntValueInRangeOfType(IntegerLiteralValue value, Type* 
 #endif
         return value >= std::numeric_limits<int64_t>::min() &&
                value <= std::numeric_limits<int64_t>::max();
+
+    case BaseType::Half:
+        return value >= -2048 && value <= 2048;
     default:
         return false;
     }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1967,6 +1967,9 @@ public:
     /// Is `type` a scalar integer type.
     bool isScalarIntegerType(Type* type);
 
+    /// Is `type` a scalar half type.
+    bool isHalfType(Type* type);
+
     /// Is `type` something we allow as compile time constants, i.e. scalar integer and enum types.
     bool isValidCompileTimeConstantType(Type* type);
 

--- a/tests/bugs/half-coercion.slang
+++ b/tests/bugs/half-coercion.slang
@@ -1,0 +1,10 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target spirv
+
+// CHECK-NOT: warning
+
+RWStructuredBuffer<half> output;
+[numthreads(1,1,1)]
+void computeMain()
+{
+    output[0] = 0; // coercion from 0 to half should not result in a warning.
+}


### PR DESCRIPTION
Closes #5798.