### PR TITLE
Fix wgsl float texture format inference silent failure

### DIFF
--- a/source/slang/slang-emit-wgsl.cpp
+++ b/source/slang/slang-emit-wgsl.cpp
@@ -352,12 +352,18 @@ static const char* getWgslImageFormat(IRTextureTypeBase* type)
         // normally just resolve to unknown.
         auto elementType = type->getElementType();
         Int vectorWidth = 1;
-        if (auto vectorType = as<IRVectorType>(elementType);
-            auto intLitVal = as<IRIntLit>(vectorType->getElementCount()))
+        if (auto elementVecType = as<IRVectorType>(elementType))
         {
-            vectorWidth = intLitVal->getValue();
+            if (auto intLitVal = as<IRIntLit>(elementVecType->getElementCount()))
+            {
+                vectorWidth = (Int)intLitVal->getValue();
+            }
+            else
+            {
+                vectorWidth = 0;
+            }
+            elementType = elementVecType->getElementType();
         }
-        elementType = getVectorElementType((IRType*)elementType);
         if (auto basicType = as<IRBasicType>(elementType))
         {
             switch (basicType->getBaseType())


### PR DESCRIPTION
Previously compiling a slang file with `RWTexture<float>` would fail silently and hang the playground. This changes the code to be closer to the `glsl` implementation and fixes the failure.

Still not exactly sure why the previous code didn't work but I think it had something to do with chaining the declarations in the if statement.