### PR TITLE
Use perfect forwardnig to preserve the parameters for log

### DIFF
--- a/examples/example-base/example-base.h
+++ b/examples/example-base/example-base.h
@@ -94,10 +94,10 @@ int64_t getTimerFrequency();
 template<typename... TArgs>
 inline void reportError(const char* format, TArgs... args)
 {
-    printf(format, args...);
+    printf(format, std::forward<TArgs>(args)...);
 #ifdef _WIN32
     char buffer[4096];
-    sprintf_s(buffer, format, args...);
+    sprintf_s(buffer, format, std::forward<TArgs>(args)...);
     _Win32OutputDebugString(buffer);
 #endif
 }


### PR DESCRIPTION
On Discord, one of users reported that the error reporting logic encountered a buffer overrun when the error message is long.
https://discord.com/channels/1303735196696445038/1316453522493149236/1316453522493149236

The issue itself isn't Slang related but it will be better to have a more stable example.

Since I was not able to reproduce the issue, this is a speculative fix.