### PR TITLE
Add SLANG_ENABLE_DXIL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,8 @@ option(
     ON
 )
 
+option(SLANG_ENABLE_DXIL "Enable generating DXIL with DXC" ON)
+
 option(SLANG_ENABLE_FULL_IR_VALIDATION "Enable full IR validation (SLOW!)")
 option(SLANG_ENABLE_IR_BREAK_ALLOC, "Enable _debugUID on IR allocation")
 option(SLANG_ENABLE_ASAN "Enable ASAN (address sanitizer)")

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -194,23 +194,14 @@ function(set_default_compile_options target)
     # Settings dependent on config options
     #
 
-    if(SLANG_ENABLE_FULL_DEBUG_VALIDATION)
-        target_compile_definitions(
-            ${target}
-            PRIVATE SLANG_ENABLE_FULL_IR_VALIDATION
-        )
-    endif()
-
-    if(SLANG_ENABLE_IR_BREAK_ALLOC)
-        target_compile_definitions(
-            ${target}
-            PRIVATE SLANG_ENABLE_IR_BREAK_ALLOC
-        )
-    endif()
-
-    if(SLANG_ENABLE_DX_ON_VK)
-        target_compile_definitions(${target} PRIVATE SLANG_CONFIG_DX_ON_VK)
-    endif()
+    target_compile_definitions(
+        ${target}
+        PRIVATE
+            SLANG_ENABLE_DXIL_SUPPORT=$<BOOL:${SLANG_ENABLE_DXIL}>
+            $<$<BOOL:${SLANG_ENABLE_FULL_DEBUG_VALIDATION}>:SLANG_ENABLE_FULL_IR_VALIDATION>
+            $<$<BOOL:${SLANG_ENABLE_IR_BREAK_ALLOC}>:SLANG_ENABLE_IR_BREAK_ALLOC>
+            $<$<BOOL:${SLANG_ENABLE_DX_ON_VK}>:SLANG_CONFIG_DX_ON_VK>
+    )
 
     if(SLANG_ENABLE_ASAN)
         add_supported_cxx_flags(

--- a/docs/building.md
+++ b/docs/building.md
@@ -152,6 +152,7 @@ See the [documentation on testing](../tools/slang-test/README.md) for more infor
 | `SLANG_VERSION`                   | Latest `v*` tag            | The project version, detected using git if available                                         |
 | `SLANG_EMBED_CORE_MODULE`         | `TRUE`                     | Build slang with an embedded version of the core module                                      |
 | `SLANG_EMBED_CORE_MODULE_SOURCE`  | `TRUE`                     | Embed the core module source in the binary                                                   |
+| `SLANG_ENABLE_DXIL`               | `TRUE`                     | Enable generating DXIL using DXC                                                             |
 | `SLANG_ENABLE_ASAN`               | `FALSE`                    | Enable ASAN (address sanitizer)                                                              |
 | `SLANG_ENABLE_FULL_IR_VALIDATION` | `FALSE`                    | Enable full IR validation (SLOW!)                                                            |
 | `SLANG_ENABLE_IR_BREAK_ALLOC`     | `FALSE`                    | Enable IR BreakAlloc functionality for debugging.                                            |


### PR DESCRIPTION
At the moment there's no way to easily disable this functionality 

(Happy that the linux support was so good until now that there was no call for this :D)