### PR TITLE
Fix the parser issue for not recognize Generic<T>[N]

### DIFF
--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -2335,6 +2335,7 @@ static Expr* tryParseGenericApp(Parser* parser, Expr* base)
         case TokenType::Dot:
         case TokenType::LParent:
         case TokenType::RParent:
+        case TokenType::LBracket:
         case TokenType::RBracket:
         case TokenType::Colon:
         case TokenType::Comma:


### PR DESCRIPTION
Close #5911.

In this issue, if we define the generic in source file 1, and import it into source file 2, then when parsing the reference of that generic in source file 2, we will not parse the generic directly, instead we have a logic to speculate it as generics first with a fake diagnostic sink, and if there is no error report, we will consider it as a actual generic and will parse it again.

In this logic, we will also disambiguate the expression based on the following token, but we didn't consider the token '[', so we will finally not treat the expression as generic.

The fix is just simply adding '[' .