### PR TITLE
Add base vertex and base instance system values

### DIFF
--- a/docs/user-guide/a2-01-spirv-target-specific.md
+++ b/docs/user-guide/a2-01-spirv-target-specific.md
@@ -60,8 +60,8 @@ The system-value semantics are translated to the following SPIR-V code.
 | `SV_RenderTargetArrayIndex`   | `BuiltIn Layer`                   |
 | `SV_SampleIndex`              | `BuiltIn SampleId`                |
 | `SV_ShadingRate`              | `BuiltIn PrimitiveShadingRateKHR` |
-| `SV_StartVertexLocation`      | `*Not supported*                  |
-| `SV_StartInstanceLocation`    | `*Not supported*                  |
+| `SV_StartVertexLocation`      | `BuiltIn BaseVertex`              |
+| `SV_StartInstanceLocation`    | `BuiltIn BaseInstance`            |
 | `SV_StencilRef`               | `BuiltIn FragStencilRefEXT`       |
 | `SV_Target<N>`                | `Location`                        |
 | `SV_TessFactor`               | `BuiltIn TessLevelOuter`          |

--- a/docs/user-guide/a2-02-metal-target-specific.md
+++ b/docs/user-guide/a2-02-metal-target-specific.md
@@ -40,6 +40,8 @@ The system-value semantics are translated to the following Metal attributes:
 | `SV_Target<N>`              | `[[color(N)]]`                                       |
 | `SV_VertexID`               | `[[vertex_id]]`                                      |
 | `SV_ViewportArrayIndex`     | `[[viewport_array_index]]`                           |
+| `SV_StartVertexLocation`    | `[[base_vertex]]`                                    |
+| `SV_StartInstanceLocation`  | `[[base_instance]]`                                  |
 
 Custom semantics are mapped to user attributes:
 

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -146,6 +146,8 @@ public in int gl_SampleID : SV_SampleIndex;
 public in int gl_VertexIndex : SV_VertexID;
 public in int gl_ViewIndex : SV_ViewID;
 public in int gl_ViewportIndex : SV_ViewportArrayIndex;
+public in int gl_BaseVertex : SV_StartVertexLocation;
+public in int gl_BaseInstance : SV_StartInstanceLocation;
 
 
 // Override operator* behavior to compute algebric product of matrices and vectors.

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -5303,6 +5303,16 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                             SpvBuiltInShadingRateKHR,
                             inst);
                 }
+                else if (semanticName == "sv_startvertexlocation")
+                {
+                    requireSPIRVCapability(SpvCapabilityDrawParameters);
+                    return getBuiltinGlobalVar(inst->getFullType(), SpvBuiltInBaseVertex, inst);
+                }
+                else if (semanticName == "sv_startinstancelocation")
+                {
+                    requireSPIRVCapability(SpvCapabilityDrawParameters);
+                    return getBuiltinGlobalVar(inst->getFullType(), SpvBuiltInBaseInstance, inst);
+                }
                 SLANG_UNREACHABLE("Unimplemented system value in spirv emit.");
             }
         }

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -831,6 +831,22 @@ GLSLSystemValueInfo* getGLSLSystemValueInfo(
             name = "gl_PrimitiveShadingRateEXT";
         }
     }
+    else if (semanticName == "sv_startvertexlocation")
+    {
+        context->requireGLSLVersion(ProfileVersion::GLSL_460);
+
+        // uint in hlsl, int in glsl (https://www.khronos.org/opengl/wiki/Built-in_Variable_(GLSL))
+        requiredType = builder->getBasicType(BaseType::Int);
+        name = "gl_BaseVertex";
+    }
+    else if (semanticName == "sv_startinstancelocation")
+    {
+        context->requireGLSLVersion(ProfileVersion::GLSL_460);
+
+        // uint in hlsl, int in glsl (https://www.khronos.org/opengl/wiki/Built-in_Variable_(GLSL))
+        requiredType = builder->getBasicType(BaseType::Int);
+        name = "gl_BaseInstance";
+    }
 
     if (name)
     {

--- a/source/slang/slang-ir-legalize-varying-params.h
+++ b/source/slang/slang-ir-legalize-varying-params.h
@@ -57,6 +57,8 @@ IRInst* emitCalcGroupIndex(IRBuilder& builder, IRInst* groupThreadID, IRInst* gr
     M(ViewID, SV_ViewID)                                 \
     M(ViewportArrayIndex, SV_ViewportArrayIndex)         \
     M(Target, SV_Target)                                 \
+    M(StartVertexLocation, SV_StartVertexLocation)       \
+    M(StartInstanceLocation, SV_StartInstanceLocation)   \
     /* end */
 
 /// A known system-value semantic name that can be applied to a parameter

--- a/source/slang/slang-ir-metal-legalize.cpp
+++ b/source/slang/slang-ir-metal-legalize.cpp
@@ -660,6 +660,18 @@ struct LegalizeMetalEntryPointContext
 
                 break;
             }
+        case SystemValueSemanticName::StartVertexLocation:
+            {
+                result.metalSystemValueName = toSlice("base_vertex");
+                result.permittedTypes.add(builder.getBasicType(BaseType::UInt));
+                break;
+            }
+        case SystemValueSemanticName::StartInstanceLocation:
+            {
+                result.metalSystemValueName = toSlice("base_instance");
+                result.permittedTypes.add(builder.getBasicType(BaseType::UInt));
+                break;
+            }
         default:
             m_sink->diagnose(
                 parentVar,

--- a/source/slang/slang-ir-wgsl-legalize.cpp
+++ b/source/slang/slang-ir-wgsl-legalize.cpp
@@ -359,6 +359,8 @@ struct LegalizeWGSLEntryPointContext
 
         case SystemValueSemanticName::ViewID:
         case SystemValueSemanticName::ViewportArrayIndex:
+        case SystemValueSemanticName::StartVertexLocation:
+        case SystemValueSemanticName::StartInstanceLocation:
             {
                 result.isUnsupported = true;
                 break;

--- a/source/slang/slang-language-server-completion.cpp
+++ b/source/slang/slang-language-server-completion.cpp
@@ -126,6 +126,8 @@ static const char* hlslSemanticNames[] = {
     "SV_ViewID",
     "SV_ViewportArrayIndex",
     "SV_ShadingRate",
+    "SV_StartVertexLocation",
+    "SV_StartInstanceLocation",
 };
 
 bool isDeclKeyword(const UnownedStringSlice& slice)

--- a/tests/glsl-intrinsic/system-values-draw-parameters.slang
+++ b/tests/glsl-intrinsic/system-values-draw-parameters.slang
@@ -1,0 +1,19 @@
+//TEST:SIMPLE(filecheck=CHECK_SPIRV): -entry main -stage compute -target spirv
+//TEST:SIMPLE(filecheck=CHECK_GLSL): -entry main -stage compute -target glsl
+//TEST:SIMPLE(filecheck=CHECK_HLSL): -entry main -stage compute -target hlsl
+//TEST:SIMPLE(filecheck=CHECK_METAL): -entry main -stage compute -target metal
+
+#version 460
+
+void main()
+{
+    float x = float(gl_VertexIndex + gl_BaseVertex) * 0.1f;
+    float y = float(gl_InstanceIndex + gl_BaseInstance) * 0.2f;
+    gl_Position = vec4(x, y, 0.0f, 1.0f); // Output 2D position with z=0 and w=1.
+
+    // CHECK_SPIRV: BuiltIn BaseInstance
+    // CHECK_GLSL: gl_BaseInstance
+    // CHECK_HLSL: SV_StartInstanceLocation
+    // CHECK_METAL: base_instance
+}
+

--- a/tests/glsl-intrinsic/system-values-draw-parameters.slang
+++ b/tests/glsl-intrinsic/system-values-draw-parameters.slang
@@ -1,7 +1,7 @@
-//TEST:SIMPLE(filecheck=CHECK_SPIRV): -entry main -stage compute -target spirv
-//TEST:SIMPLE(filecheck=CHECK_GLSL): -entry main -stage compute -target glsl
-//TEST:SIMPLE(filecheck=CHECK_HLSL): -entry main -stage compute -target hlsl
-//TEST:SIMPLE(filecheck=CHECK_METAL): -entry main -stage compute -target metal
+//TEST:SIMPLE(filecheck=CHECK_SPIRV): -entry main -stage vertex -target spirv
+//TEST:SIMPLE(filecheck=CHECK_GLSL): -entry main -stage vertex -target glsl
+//TEST:SIMPLE(filecheck=CHECK_HLSL): -entry main -stage vertex -target hlsl
+//TEST:SIMPLE(filecheck=CHECK_METAL): -entry main -stage vertex -target metal
 
 #version 460
 

--- a/tests/hlsl-intrinsic/system-values-draw-parameters.slang
+++ b/tests/hlsl-intrinsic/system-values-draw-parameters.slang
@@ -1,0 +1,34 @@
+//TEST:SIMPLE(filecheck=CHECK_SPIRV): -entry main -stage compute -target spirv
+//TEST:SIMPLE(filecheck=CHECK_GLSL): -entry main -stage compute -target glsl
+//TEST:SIMPLE(filecheck=CHECK_HLSL): -entry main -stage compute -target hlsl
+//TEST:SIMPLE(filecheck=CHECK_METAL): -entry main -stage compute -target metal
+
+struct VSInput
+{
+    uint vertexID : SV_VertexID;
+    uint instanceID : SV_InstanceID;
+};
+
+struct VSOutput
+{
+    float4 position : SV_POSITION;
+};
+
+VSOutput main(VSInput input, 
+              uint startVertexLocation : SV_StartVertexLocation, 
+              uint startInstanceLocation : SV_StartInstanceLocation)
+{
+    VSOutput output;
+
+    float x = (float)(input.vertexID + startVertexLocation) * 0.1f;
+    float y = (float)(input.instanceID + startInstanceLocation) * 0.2f;
+    output.position = float4(x, y, 0.0f, 1.0f);
+
+    // CHECK_SPIRV: BuiltIn BaseInstance
+    // CHECK_GLSL: gl_BaseInstance
+    // CHECK_HLSL: SV_StartInstanceLocation
+    // CHECK_METAL: base_instance
+
+    return output;
+}
+

--- a/tests/hlsl-intrinsic/system-values-draw-parameters.slang
+++ b/tests/hlsl-intrinsic/system-values-draw-parameters.slang
@@ -1,7 +1,7 @@
-//TEST:SIMPLE(filecheck=CHECK_SPIRV): -entry main -stage compute -target spirv
-//TEST:SIMPLE(filecheck=CHECK_GLSL): -entry main -stage compute -target glsl
-//TEST:SIMPLE(filecheck=CHECK_HLSL): -entry main -stage compute -target hlsl
-//TEST:SIMPLE(filecheck=CHECK_METAL): -entry main -stage compute -target metal
+//TEST:SIMPLE(filecheck=CHECK_SPIRV): -entry main -stage vertex -target spirv
+//TEST:SIMPLE(filecheck=CHECK_GLSL): -entry main -stage vertex -target glsl
+//TEST:SIMPLE(filecheck=CHECK_HLSL): -entry main -stage vertex -target hlsl
+//TEST:SIMPLE(filecheck=CHECK_METAL): -entry main -stage vertex -target metal
 
 struct VSInput
 {


### PR DESCRIPTION
Adds base vertex and base instance system value semantics that were introduced in [SM 6.8](https://microsoft.github.io/DirectX-Specs/d3d/HLSL_ShaderModel6_8.html#extended-command-information). Parallel implementations already exist on GLSL, SPIRV and Metal but not WGSL.