### PR TITLE
Fix WASM build

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,6 +22,7 @@
       "binaryDir": "${sourceDir}/build.em",
       "cacheVariables": {
         "SLANG_SLANG_LLVM_FLAVOR": "DISABLE",
+        "SLANG_ENABLE_SPLIT_DEBUG_INFO": "OFF",
         "CMAKE_C_FLAGS_INIT": "-fwasm-exceptions -Os",
         "CMAKE_CXX_FLAGS_INIT": "-fwasm-exceptions -Os",
         "CMAKE_EXE_LINKER_FLAGS": "-sASSERTIONS -sALLOW_MEMORY_GROWTH -fwasm-exceptions --export=__cpp_exception"


### PR DESCRIPTION
There is no objcopy and strip for WASM, so disable debug info stripping.

This closes #5924.