### PR TITLE
Fixed "stage:" and "result:" field names for JSON reflection

### DIFF
--- a/source/slang/slang-reflection-json.cpp
+++ b/source/slang/slang-reflection-json.cpp
@@ -1006,22 +1006,22 @@ static void emitReflectionEntryPointJSON(
     switch (entryPoint->getStage())
     {
     case SLANG_STAGE_VERTEX:
-        writer << ",\n\"stage:\": \"vertex\"";
+        writer << ",\n\"stage\": \"vertex\"";
         break;
     case SLANG_STAGE_HULL:
-        writer << ",\n\"stage:\": \"hull\"";
+        writer << ",\n\"stage\": \"hull\"";
         break;
     case SLANG_STAGE_DOMAIN:
-        writer << ",\n\"stage:\": \"domain\"";
+        writer << ",\n\"stage\": \"domain\"";
         break;
     case SLANG_STAGE_GEOMETRY:
-        writer << ",\n\"stage:\": \"geometry\"";
+        writer << ",\n\"stage\": \"geometry\"";
         break;
     case SLANG_STAGE_FRAGMENT:
-        writer << ",\n\"stage:\": \"fragment\"";
+        writer << ",\n\"stage\": \"fragment\"";
         break;
     case SLANG_STAGE_COMPUTE:
-        writer << ",\n\"stage:\": \"compute\"";
+        writer << ",\n\"stage\": \"compute\"";
         break;
     default:
         break;
@@ -1051,7 +1051,7 @@ static void emitReflectionEntryPointJSON(
     }
     if (auto resultVarLayout = entryPoint->getResultVarLayout())
     {
-        writer << ",\n\"result:\": ";
+        writer << ",\n\"result\": ";
         emitReflectionParamJSON(writer, resultVarLayout);
     }
 

--- a/tests/bindings/hlsl-to-vulkan-array.hlsl.expected
+++ b/tests/bindings/hlsl-to-vulkan-array.hlsl.expected
@@ -64,8 +64,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/bindings/hlsl-to-vulkan-combined.hlsl.expected
+++ b/tests/bindings/hlsl-to-vulkan-combined.hlsl.expected
@@ -24,8 +24,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/bindings/hlsl-to-vulkan-global.hlsl.expected
+++ b/tests/bindings/hlsl-to-vulkan-global.hlsl.expected
@@ -39,8 +39,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/bindings/hlsl-to-vulkan-shift-implicit.hlsl.expected
+++ b/tests/bindings/hlsl-to-vulkan-shift-implicit.hlsl.expected
@@ -132,8 +132,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/bindings/hlsl-to-vulkan-shift.hlsl.expected
+++ b/tests/bindings/hlsl-to-vulkan-shift.hlsl.expected
@@ -132,8 +132,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/cross-compile/cpp-resource-reflection.slang.32.expected
+++ b/tests/cross-compile/cpp-resource-reflection.slang.32.expected
@@ -109,7 +109,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "computeMain",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "dispatchThreadID",

--- a/tests/cross-compile/cpp-resource-reflection.slang.64.expected
+++ b/tests/cross-compile/cpp-resource-reflection.slang.64.expected
@@ -109,7 +109,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "computeMain",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "dispatchThreadID",

--- a/tests/cuda/cuda-reflection.slang.expected
+++ b/tests/cuda/cuda-reflection.slang.expected
@@ -228,7 +228,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "dispatchThreadID",

--- a/tests/hlsl-intrinsic/sampler-feedback/sampler-feedback-basic.slang.expected
+++ b/tests/hlsl-intrinsic/sampler-feedback/sampler-feedback-basic.slang.expected
@@ -90,8 +90,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/ir/string-literal-hash-reflection.slang.expected
+++ b/tests/ir/string-literal-hash-reflection.slang.expected
@@ -21,7 +21,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "computeMain",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "tid",

--- a/tests/reflection/actual-global.slang.expected
+++ b/tests/reflection/actual-global.slang.expected
@@ -29,7 +29,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "computeMain",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "dispatchThreadID",

--- a/tests/reflection/arrays.hlsl.expected
+++ b/tests/reflection/arrays.hlsl.expected
@@ -142,8 +142,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/attribute.slang.expected
+++ b/tests/reflection/attribute.slang.expected
@@ -265,7 +265,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "dispatchThreadID",

--- a/tests/reflection/binding-gl.hlsl.expected
+++ b/tests/reflection/binding-gl.hlsl.expected
@@ -138,8 +138,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/binding-push-constant-gl.hlsl.expected
+++ b/tests/reflection/binding-push-constant-gl.hlsl.expected
@@ -195,8 +195,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/buffer-layout.slang.1.expected
+++ b/tests/reflection/buffer-layout.slang.1.expected
@@ -249,7 +249,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "dispatchThreadID",

--- a/tests/reflection/buffer-layout.slang.expected
+++ b/tests/reflection/buffer-layout.slang.expected
@@ -249,7 +249,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "dispatchThreadID",

--- a/tests/reflection/cross-compile.slang.expected
+++ b/tests/reflection/cross-compile.slang.expected
@@ -70,8 +70,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/default-space.slang.expected
+++ b/tests/reflection/default-space.slang.expected
@@ -57,8 +57,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/explicit-register-space.slang.expected
+++ b/tests/reflection/explicit-register-space.slang.expected
@@ -16,8 +16,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/gh-55.glsl.expected
+++ b/tests/reflection/gh-55.glsl.expected
@@ -44,7 +44,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage": "fragment"
         }
     ]
 }

--- a/tests/reflection/global-type-params.slang.expected
+++ b/tests/reflection/global-type-params.slang.expected
@@ -180,8 +180,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/global-uniforms.hlsl.expected
+++ b/tests/reflection/global-uniforms.hlsl.expected
@@ -71,7 +71,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage": "fragment"
         }
     ]
 }

--- a/tests/reflection/matrix-layout.slang.1.expected
+++ b/tests/reflection/matrix-layout.slang.1.expected
@@ -230,8 +230,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/matrix-layout.slang.expected
+++ b/tests/reflection/matrix-layout.slang.expected
@@ -230,8 +230,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/mix-explicit-and-implicit-spaces.slang.expected
+++ b/tests/reflection/mix-explicit-and-implicit-spaces.slang.expected
@@ -140,7 +140,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "compute",
+            "stage": "compute",
             "threadGroupSize": [1, 1, 1]
         }
     ]

--- a/tests/reflection/multi-file.hlsl.expected
+++ b/tests/reflection/multi-file.hlsl.expected
@@ -402,8 +402,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "mainVS",
-            "stage:": "vertex",
-            "result:": {
+            "stage": "vertex",
+            "result": {
                 "semanticName": "SV_POSITION",
                 "type": {
                     "kind": "vector",
@@ -417,8 +417,8 @@ standard output = {
         },
         {
             "name": "mainFS",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/parameter-block-explicit-space.slang.expected
+++ b/tests/reflection/parameter-block-explicit-space.slang.expected
@@ -196,8 +196,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/parameter-block.slang.1.expected
+++ b/tests/reflection/parameter-block.slang.1.expected
@@ -77,8 +77,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/parameter-block.slang.2.expected
+++ b/tests/reflection/parameter-block.slang.2.expected
@@ -74,8 +74,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/parameter-block.slang.expected
+++ b/tests/reflection/parameter-block.slang.expected
@@ -71,8 +71,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/ptr/ptr-generic.slang.expected
+++ b/tests/reflection/ptr/ptr-generic.slang.expected
@@ -29,7 +29,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "computeMain",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "dispatchThreadID",

--- a/tests/reflection/ptr/ptr-global.slang.expected
+++ b/tests/reflection/ptr/ptr-global.slang.expected
@@ -60,7 +60,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "computeMain",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "dispatchThreadID",

--- a/tests/reflection/ptr/ptr-self-reference.slang.expected
+++ b/tests/reflection/ptr/ptr-self-reference.slang.expected
@@ -52,7 +52,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "computeMain",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "dispatchThreadID",

--- a/tests/reflection/ptr/ptr-struct.slang.expected
+++ b/tests/reflection/ptr/ptr-struct.slang.expected
@@ -102,7 +102,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "computeMain",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "dispatchThreadID",

--- a/tests/reflection/reflect-imported-code.hlsl.expected
+++ b/tests/reflection/reflect-imported-code.hlsl.expected
@@ -116,8 +116,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/reflect-static.slang.expected
+++ b/tests/reflection/reflect-static.slang.expected
@@ -103,7 +103,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "computeMain",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "dispatchThreadID",

--- a/tests/reflection/reflection0.hlsl.expected
+++ b/tests/reflection/reflection0.hlsl.expected
@@ -62,8 +62,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/resource-in-cbuffer.hlsl.expected
+++ b/tests/reflection/resource-in-cbuffer.hlsl.expected
@@ -109,8 +109,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/sample-index-input.hlsl.expected
+++ b/tests/reflection/sample-index-input.hlsl.expected
@@ -9,7 +9,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
+            "stage": "fragment",
             "parameters": [
                 {
                     "name": "input",
@@ -46,7 +46,7 @@ standard output = {
                 }
             ],
             "usesAnySampleRateInput": true,
-            "result:": {
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/sample-rate-input.hlsl.expected
+++ b/tests/reflection/sample-rate-input.hlsl.expected
@@ -9,7 +9,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
+            "stage": "fragment",
             "parameters": [
                 {
                     "name": "input",
@@ -52,7 +52,7 @@ standard output = {
                 }
             ],
             "usesAnySampleRateInput": true,
-            "result:": {
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/shared-modifier.hlsl.expected
+++ b/tests/reflection/shared-modifier.hlsl.expected
@@ -24,7 +24,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
+            "stage": "fragment",
             "parameters": [
                 {
                     "name": "uv",
@@ -41,7 +41,7 @@ standard output = {
                     }
                 }
             ],
-            "result:": {
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/std430-layout.glsl.expected
+++ b/tests/reflection/std430-layout.glsl.expected
@@ -107,7 +107,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment"
+            "stage": "fragment"
         }
     ]
 }

--- a/tests/reflection/structured-buffer.slang.expected
+++ b/tests/reflection/structured-buffer.slang.expected
@@ -78,8 +78,8 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "fragment",
-            "result:": {
+            "stage": "fragment",
+            "result": {
                 "stage": "fragment",
                 "binding": {"kind": "varyingOutput", "index": 0},
                 "semanticName": "SV_TARGET",

--- a/tests/reflection/thread-group-size.hlsl.expected
+++ b/tests/reflection/thread-group-size.hlsl.expected
@@ -21,7 +21,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "tid",

--- a/tests/reflection/unbounded-arrays.hlsl.1.expected
+++ b/tests/reflection/unbounded-arrays.hlsl.1.expected
@@ -113,7 +113,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "tid",

--- a/tests/reflection/used-parameters.slang.expected
+++ b/tests/reflection/used-parameters.slang.expected
@@ -254,7 +254,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "dispatchThreadID",

--- a/tests/reflection/vertex-input-semantics.hlsl.expected
+++ b/tests/reflection/vertex-input-semantics.hlsl.expected
@@ -9,7 +9,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "main",
-            "stage:": "vertex",
+            "stage": "vertex",
             "parameters": [
                 {
                     "name": "a",
@@ -161,7 +161,7 @@ standard output = {
                     }
                 }
             ],
-            "result:": {
+            "result": {
                 "semanticName": "SV_POSITION",
                 "type": {
                     "kind": "vector",

--- a/tests/slang-extension/dynamic-resource-gl.slang.1.expected
+++ b/tests/slang-extension/dynamic-resource-gl.slang.1.expected
@@ -51,7 +51,7 @@ standard output = {
     "entryPoints": [
         {
             "name": "computeMain",
-            "stage:": "compute",
+            "stage": "compute",
             "parameters": [
                 {
                     "name": "tid",


### PR DESCRIPTION
```
"stage:" -> "stage"
"result:" -> "result"
```