### PR TITLE
Check for undefined %id in spirv_asm block.

### DIFF
--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -522,7 +522,17 @@ DIAGNOSTIC(
     Error,
     spirvInvalidTruncate,
     "__truncate has been given a source smaller than its target")
-
+DIAGNOSTIC(29112, Error, spirvInstructionWithNotEnoughOperands, "not enough operands for $0")
+DIAGNOSTIC(
+    29113,
+    Error,
+    spirvIdRedefinition,
+    "SPIRV id '%$0' is already defined in the current assembly block")
+DIAGNOSTIC(
+    29114,
+    Error,
+    spirvUndefinedId,
+    "SPIRV id '%$0' is not defined in the current assembly block location")
 //
 // 3xxxx - Semantic analysis
 //

--- a/tests/diagnostics/invalid-spv-obj.slang
+++ b/tests/diagnostics/invalid-spv-obj.slang
@@ -1,0 +1,10 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+
+[shader("compute")]
+[numthreads(1,1,1)]
+void main() {
+    int var2 = spirv_asm {
+        // CHECK: ([[# @LINE+1]]): error 29114
+        result: $$int = OpIMul $(15) %invalidId
+    };
+}


### PR DESCRIPTION
Closes [#5753](https://github.com/shader-slang/slang/issues/5753).