### PR TITLE
Add `RaytracingAccelerationStructure::__init(uint64_t)`.

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -15592,7 +15592,23 @@ struct RayDesc
 __builtin
 __magic_type(RaytracingAccelerationStructureType)
 __intrinsic_type($(kIROp_RaytracingAccelerationStructureType))
-struct RaytracingAccelerationStructure {};
+struct RaytracingAccelerationStructure
+{
+    [require(glsl_spirv, raytracing)]
+    [__readNone]
+    __init(uint64_t address)
+    {
+        __target_switch
+        {
+        case spirv:
+            return spirv_asm {
+                result: $$RaytracingAccelerationStructure = OpConvertUToAccelerationStructureKHR $address;
+            };
+        case glsl:
+            __intrinsic_asm "accelerationStructureEXT($0)";
+        }
+    }
+};
 
 // 10.1.4 - Subobject Definitions
 

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -3139,6 +3139,7 @@ void GLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
         }
     case kIROp_RayQueryType:
         {
+            _requireRayQuery();
             m_writer->emit("rayQueryEXT");
             return;
         }

--- a/tests/spirv/u-to-accelstruct.slang
+++ b/tests/spirv/u-to-accelstruct.slang
@@ -1,0 +1,22 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-via-glsl
+
+uniform uint64_t accelStructAddr;
+RWStructuredBuffer<int> output;
+
+// CHECK: %[[REG:[A-Za-z0-9_]+]] = OpConvertUToAccelerationStructureKHR
+// CHECK: OpRayQueryInitializeKHR %rayQuery{{.*}} %[[REG]]
+
+[numthreads(1,1,1)]
+void main()
+{
+    let accelStruct = RaytracingAccelerationStructure(accelStructAddr);
+    RayQuery rayQuery;
+    RayDesc ray;
+    ray.Direction = float3(0, 0, 1);
+    ray.Origin = float3(0, 0, 0);
+    ray.TMax = 1000;
+    ray.TMin = 0;
+    let rs = rayQuery.TraceRayInline(accelStruct, 0, 0, ray);
+    output[0] = rayQuery.CandidateGeometryIndex();
+}


### PR DESCRIPTION
Closes [#5801](https://github.com/shader-slang/slang/issues/5801).