### PR TITLE
Fixed Session::queryInterface not returning OK when querying for IUnknown/ISlangUnknown

### DIFF
--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -608,7 +608,7 @@ Session::queryInterface(SlangUUID const& uuid, void** outObject)
         return SLANG_OK;
     }
 
-    if (uuid == ISlangUnknown::getTypeGuid() && uuid == IGlobalSession::getTypeGuid())
+    if (uuid == ISlangUnknown::getTypeGuid() || uuid == IGlobalSession::getTypeGuid())
     {
         addReference();
         *outObject = static_cast<slang::IGlobalSession*>(this);


### PR DESCRIPTION
Hello,

I have been trying to use the Slang Compilation API in C# by interfacing with the COM-lite API.

I've been able to call the API functions by directly interfacing with the vtable in unsafe C#, but for my own sanity, I was trying to use the [source generated ComWrappers API](https://learn.microsoft.com/en-us/dotnet/standard/native-interop/comwrappers-source-generation) introduced in .NET 8 to handle everything for me. However, I kept running into a low-level runtime error when it tries to create a wrapper object for the Slang `IGlobalSession` object.

After a little digging, I found the issue. The .NET runtime is checking if the Slang `IGlobalSession` implements `IUnknown` by calling `QueryInterface`. `IGlobalSession` implements `ISlangUnknown`, which shares the same IID as `IUnknown`, so it should work, right?

Well, it would if it weren't for this small error in the code:
<https://github.com/shader-slang/slang/blob/f3b916ebe529abbc35a351b20b2c70129a193208/source/slang/slang.cpp#L611>
That `&&` is almost certainly supposed to be `||`.

I've built with this change and confirmed it fixes the runtime error and allows me to use Slang in C#.