### PR TITLE
Allow explicit test root

### DIFF
--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -992,12 +992,12 @@ static SlangResult _calcExectuablePath(char* outPath, size_t* ioSize)
     {
         return SLANG_FAIL;
     }
-    if (size_t(resSize) >= bufferSize)
+    if (size_t(resSize + 1) >= bufferSize)
     {
         return SLANG_E_BUFFER_TOO_SMALL;
     }
     // Zero terminate
-    outPath[resSize - 1] = 0;
+    outPath[resSize] = 0;
     return SLANG_OK;
 #else
     String text = Slang::File::readAllText("/proc/self/maps");

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -377,7 +377,7 @@ static bool _isSubCommand(const char* arg)
     if (optionsOut->testDir.getLength() == 0)
     {
         // If the test directory isn't set, use the "tests" directory
-        optionsOut->testDir = String("tests");
+        optionsOut->testDir = String("tests/");
     }
 
     return SLANG_OK;

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -327,6 +327,15 @@ static bool _isSubCommand(const char* arg)
                 optionsOut->expectedFailureList.add(line);
             }
         }
+        else if (strcmp(arg, "-test-dir") == 0)
+        {
+            if (argCursor == argEnd)
+            {
+                stdError.print("error: expected operand for '%s'\n", arg);
+                return SLANG_FAIL;
+            }
+            optionsOut->testDir = *argCursor++;
+        }
         else
         {
             stdError.print("unknown option '%s'\n", arg);
@@ -363,6 +372,12 @@ static bool _isSubCommand(const char* arg)
         {
             optionsOut->binDir = Path::getParentDirectory(exePath);
         }
+    }
+
+    if (optionsOut->testDir.getLength() == 0)
+    {
+        // If the test directory isn't set, use the "tests" directory
+        optionsOut->testDir = String("tests");
     }
 
     return SLANG_OK;

--- a/tools/slang-test/options.h
+++ b/tools/slang-test/options.h
@@ -51,6 +51,9 @@ struct Options
     // Directory to use when looking for binaries to run. If empty it's not set.
     Slang::String binDir;
 
+    // Root directory to use when looking for test cases
+    Slang::String testDir;
+
     // only run test cases with names have one of these prefixes.
     Slang::List<Slang::String> testPrefixes;
 

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -4427,10 +4427,10 @@ void runTestsInParallel(TestContext* context, int count, const F& f)
     context->setTestReporter(originalReporter);
 }
 
-void runTestsInDirectory(TestContext* context, String directoryPath)
+void runTestsInDirectory(TestContext* context)
 {
     List<String> files;
-    getFilesInDirectory(directoryPath, files);
+    getFilesInDirectory(context->options.testDir, files);
     auto processFile = [&](String file)
     {
         if (shouldRunTest(context, file))
@@ -4865,9 +4865,7 @@ SlangResult innerMain(int argc, char** argv)
         {
             TestReporter::SuiteScope suiteScope(&reporter, "tests");
             // Enumerate test files according to policy
-            // TODO: add more directories to this list
-            // TODO: allow for a command-line argument to select a particular directory
-            runTestsInDirectory(&context, "tests/");
+            runTestsInDirectory(&context);
         }
 
         // Run the unit tests (these are internal C++ tests - not specified via files in a


### PR DESCRIPTION
Intended to address #5979.

From what I can tell, this should be a non-breaking change. The existing tests still run correctly, and I've verified on my computer that I can use an arbitrary test directory with the `-test-dir` option.

While attempting to implement this, I did also notice an off-by-one issue with the binary name on Linux. While `_calcExectuablePath` properly null-terminates the program path, it overwrites the final non-null character of the name. This ends up breaking functions like `Path::getCanonical` later on, because `slang-tes` does not exist. If that change should be in a separate PR, please let me know.