### PR TITLE
DNI: enable debug info splitting in WASM build 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
       - name: Build Slang
         if: steps.filter.outputs.should-run == 'true'
         run: |
+          set -e
           if [[ "${{ matrix.platform }}" = "wasm" ]]; then
               git clone https://github.com/emscripten-core/emsdk.git
               pushd emsdk
@@ -125,10 +126,9 @@ jobs:
               mkdir generators
               cmake --install build --prefix generators --component generators
               emcmake cmake -DSLANG_GENERATORS_PATH=generators/bin --preset emscripten -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
-              cmake --build --preset emscripten --config "$cmake_config" --target slang
-              [ -f "build.em/$cmake_config/lib/libslang.a" ]
-              [ -f "build.em/$cmake_config/lib/libcompiler-core.a" ]
-              [ -f "build.em/$cmake_config/lib/libcore.a" ]
+              cmake --build --preset emscripten --config "$cmake_config" --target slang-wasm
+              [ -f "build.em/$cmake_config/bin/slang-wasm.wasm" ]
+              [ -f "build.em/$cmake_config/bin/slang-wasm.js" ]
           else
             if [[ "${{ matrix.os }}" =~ "windows" && "${{ matrix.config }}" != "release" && "${{ matrix.config }}" != "releaseWithDebugInfo" ]]; then
               # Doing a debug build will try to link against a release built llvm, this

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,7 +22,6 @@
       "binaryDir": "${sourceDir}/build.em",
       "cacheVariables": {
         "SLANG_SLANG_LLVM_FLAVOR": "DISABLE",
-        "SLANG_ENABLE_SPLIT_DEBUG_INFO": "OFF",
         "CMAKE_C_FLAGS_INIT": "-fwasm-exceptions -Os",
         "CMAKE_CXX_FLAGS_INIT": "-fwasm-exceptions -Os",
         "CMAKE_EXE_LINKER_FLAGS": "-sASSERTIONS -sALLOW_MEMORY_GROWTH -fwasm-exceptions --export=__cpp_exception"


### PR DESCRIPTION
This is expected to make the WASM build fail, to investigate https://github.com/shader-slang/slang/issues/5959.