### PR TITLE
CI: Build the full slang-wasm.[js|wasm] targets instead of just the s…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,10 +125,9 @@ jobs:
               mkdir generators
               cmake --install build --prefix generators --component generators
               emcmake cmake -DSLANG_GENERATORS_PATH=generators/bin --preset emscripten -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
-              cmake --build --preset emscripten --config "$cmake_config" --target slang
-              [ -f "build.em/$cmake_config/lib/libslang.a" ]
-              [ -f "build.em/$cmake_config/lib/libcompiler-core.a" ]
-              [ -f "build.em/$cmake_config/lib/libcore.a" ]
+              cmake --build --preset emscripten --config "$cmake_config" --target slang-wasm
+              [ -f "build.em/$cmake_config/bin/slang-wasm.wasm" ]
+              [ -f "build.em/$cmake_config/bin/slang-wasm.js" ]
           else
             if [[ "${{ matrix.os }}" =~ "windows" && "${{ matrix.config }}" != "release" && "${{ matrix.config }}" != "releaseWithDebugInfo" ]]; then
               # Doing a debug build will try to link against a release built llvm, this


### PR DESCRIPTION
…lang library.

A recent build breakage for slang-wasm.[js|wasm] was not noticed by CI since it built the slang library target instead of the slang-wasm.js "executable" target. (We added a that used objcopy to split debug info from executables. objcopy does not report errors when it finds object files with unexpected format inside static libraries, but it *does* report errors when it's run on an exceutable of unexpected format, such as in the case of slang-wasm.js.)

This closes #5959.