### PR TITLE
Make 'shared' keyword map to 'groupshared' in GLSL mode

### DIFF
--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -8335,6 +8335,26 @@ static NodeBase* parseCUDASMVersionModifier(Parser* parser, void* /*userData*/)
     parser->sink->diagnose(token, Diagnostics::invalidCUDASMVersion);
     return nullptr;
 }
+
+static NodeBase* parseSharedModifier(Parser* parser, void* /*userData*/)
+{
+    Modifier* modifier = nullptr;
+
+    // While in GLSL compatibility mode, 'shared' = 'groupshared' and not the
+    // D3D11 effect syntax.
+    if (parser->options.allowGLSLInput)
+    {
+        modifier = parser->astBuilder->create<HLSLGroupSharedModifier>();
+    }
+    else
+    {
+        modifier = parser->astBuilder->create<HLSLEffectSharedModifier>();
+    }
+    modifier->keywordName = getName(parser, "shared");
+    modifier->loc = parser->tokenReader.peekLoc();
+    return modifier;
+}
+
 static NodeBase* parseVolatileModifier(Parser* parser, void* /*userData*/)
 {
     ModifierListBuilder listBuilder;
@@ -8762,7 +8782,7 @@ static const SyntaxParseInfo g_parseSyntaxEntries[] = {
     _makeParseModifier("sample", HLSLSampleModifier::kReflectClassInfo),
     _makeParseModifier("centroid", HLSLCentroidModifier::kReflectClassInfo),
     _makeParseModifier("precise", PreciseModifier::kReflectClassInfo),
-    _makeParseModifier("shared", HLSLEffectSharedModifier::kReflectClassInfo),
+    _makeParseModifier("shared", parseSharedModifier),
     _makeParseModifier("groupshared", HLSLGroupSharedModifier::kReflectClassInfo),
     _makeParseModifier("static", HLSLStaticModifier::kReflectClassInfo),
     _makeParseModifier("uniform", HLSLUniformModifier::kReflectClassInfo),


### PR DESCRIPTION
The "shared" keyword in GLSL mode should be equivalent to "groupshared" in HLSL & Slang. It got interpreted as a D3D11 effect system thing instead, but that would never appear in GLSL code. Because of this, "shared" was ignored, breaking effectively any GLSL shader using shared memory. This PR fixes that by interpreting "shared" as HLSLGroupSharedModifier when GLSL input is allowed.

Related to #5989 but does not close that issue.