### PR TITLE
Fix GLSL mix(T,T,bool) SPIR-V output

### DIFF
--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -493,7 +493,7 @@ public T mix(T x, T y, bool a)
     {
     case glsl: __intrinsic_asm "mix";
     case spirv: return spirv_asm {
-        result:$$T = OpSelect $a $x $y
+        result:$$T = OpSelect $a $y $x
     };
     default:
         return (a ? y : x);
@@ -510,7 +510,7 @@ public vector<T, N> mix(vector<T, N> x, vector<T, N> y, vector<bool, N> a)
     {
     case glsl: __intrinsic_asm "mix";
     case spirv: return spirv_asm {
-        result:$$vector<T,N> = OpSelect $a $x $y
+        result:$$vector<T,N> = OpSelect $a $y $x
     };
     default:
         vector<T, N> result;


### PR DESCRIPTION
`mix(a,b,t)` should be `a` when t=0 and `b` t=1. The cases where `t` is bool have special overloads in `glsl.meta.slang`, which use the OpSelect instruction. The [parameters for OpSelect](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpSelect) were flipped, so `mix(a,b,true)` returned `a` instead of `b`. This PR fixes that.