### PR TITLE
Add support for textureLod with sampler2DArrayShadow in GLSL compatibility mode

### DIFF
--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -2442,6 +2442,25 @@ public float textureLod(sampler2DShadow sampler, vec3 p, float lod)
 
 [ForceInline]
 [require(glsl_hlsl_spirv, texture_shadowlod)]
+public float textureLod(sampler2DArrayShadow sampler, vec4 p, float lod)
+{
+    __target_switch
+    {
+    case glsl: __intrinsic_asm "textureLod";
+    case spirv:
+    {
+        float compareValue = p.w;
+        return spirv_asm {
+            result:$$float = OpImageSampleDrefExplicitLod $sampler $p $compareValue Lod $lod
+        };
+    }
+    default:
+        return sampler.SampleCmp(p.xyz, p.w);
+    }
+}
+
+[ForceInline]
+[require(glsl_hlsl_spirv, texture_shadowlod)]
 public float textureLod(sampler1DShadow sampler, vec3 p, float lod)
 {
     __target_switch


### PR DESCRIPTION
[EXT_texture_shadow_lod](https://github.com/KhronosGroup/OpenGL-Registry/blob/main/extensions/EXT/EXT_texture_shadow_lod.txt) specifies that this function should exist, so it shall.

Not sure why it's missing from the [reference pages](https://registry.khronos.org/OpenGL-Refpages/gl4/html/textureLod.xhtml) though, but it works anyway. I'm using this for cascaded shadow maps, which now work as they should with this patch.