### PR TITLE
Upgrade actions/upload-artifact from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
             -emit-spirv-via-glsl \
             -api vk \
             -expected-failure-list tests/expected-failure.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: steps.filter.outputs.should-run == 'true' && ! matrix.full-gpu-tests
         with:
           name: slang-build-${{matrix.os}}-${{matrix.platform}}-${{matrix.compiler}}-${{matrix.config}}


### PR DESCRIPTION
The version 3 of actions/upload-artifact will be deprecated soon. https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

This commit upgrades to v4.
There is a document describing how to migrate/upgrade: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md

The breaking change on v4 is that the uploaded files are immutable and we can no longer append files with the same name. We don't seem to be doing it so it should be fine for us.

Closes https://github.com/shader-slang/slang/issues/6050