### PR TITLE
Fix inaccurate documentation in member function mutability.

### DIFF
--- a/docs/user-guide/03-convenience-features.md
+++ b/docs/user-guide/03-convenience-features.md
@@ -149,7 +149,7 @@ int rs = foo.staticMethod(a,b);
 
 ### Mutability of member function
 
-For GPU performance considerations, the `this` argument in a member function is immutable by default. Attempting to modify `this` will throw compile errors. If you intend to define a member function that mutates the object, use `[mutating]` attribute on the member function as shown in the following example.
+For GPU performance considerations, the `this` argument in a member function is immutable by default. Attempting to modify `this` will result in a compile error. If you intend to define a member function that mutates the object, use `[mutating]` attribute on the member function as shown in the following example.
 
 ```hlsl
 struct Foo

--- a/docs/user-guide/03-convenience-features.md
+++ b/docs/user-guide/03-convenience-features.md
@@ -149,7 +149,7 @@ int rs = foo.staticMethod(a,b);
 
 ### Mutability of member function
 
-For GPU performance considerations, the `this` argument in a member function is immutable by default. If you modify the content in `this` argument, the modification will be discarded after the call and does not affect the input object. If you intend to define a member function that mutates the object, use `[mutating]` attribute on the member function as shown in the following example.
+For GPU performance considerations, the `this` argument in a member function is immutable by default. Attempting to modify `this` will throw compile errors. If you intend to define a member function that mutates the object, use `[mutating]` attribute on the member function as shown in the following example.
 
 ```hlsl
 struct Foo
@@ -159,14 +159,14 @@ struct Foo
     [mutating]
     void setCount(int x) { count = x; }
 
-    void setCount2(int x) { count = x; }
+    // This would fail to compile.
+    // void setCount2(int x) { count = x; }
 }
 
 void test()
 {
     Foo f;
-    f.setCount(1); // f.count is 1 after the call.
-    f.setCount2(2); // f.count is still 1 after the call.
+    f.setCount(1); // Compiles
 }
 ```
 


### PR DESCRIPTION
It previously stated that changes would simply not be applied, which is not the case based on the playground:

```slang
struct Foo {
    int count;
    void setCount(int x) {
        count = x;
    }
}

void test() {
    Foo f;
    f.setCount(1);
}
```
Gives this compile error
```
USER error: /user.slang(4): error 30011: left of '=' is not an l-value.
        count = x;
              ^
/user.slang(4): note 30049: a 'this' parameter is an immutable parameter by default in Slang; apply the `[mutating]` attribute to the function declaration to opt in to a mutable `this`
(0): error 39999: import of module 'user' failed because of a compilation error
(0): fatal error 39999: compilation ceased
```

It may also be worth removing the "for gpu performance considerations" since it doesn't impact performance at all.