### PR TITLE
Fix #5354, change diagnostic definition error message and expect output in test

### DIFF
--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -2060,7 +2060,7 @@ DIAGNOSTIC(
 DIAGNOSTIC(41000, Warning, unreachableCode, "unreachable code detected")
 DIAGNOSTIC(41001, Error, recursiveType, "type '$0' contains cyclic reference to itself.")
 
-DIAGNOSTIC(41010, Warning, missingReturn, "control flow may reach end of non-'void' function")
+DIAGNOSTIC(41010, Warning, missingReturn, "non-void function does not return in all cases")
 DIAGNOSTIC(
     41011,
     Error,

--- a/tests/diagnostics/missing-return.slang.expected
+++ b/tests/diagnostics/missing-return.slang.expected
@@ -1,9 +1,9 @@
 result code = 0
 standard error = {
-tests/diagnostics/missing-return.slang(7): warning 41010: control flow may reach end of non-'void' function
+tests/diagnostics/missing-return.slang(7): warning 41010: non-void function does not return in all cases
 int bad(int a, int b)
     ^~~
-tests/diagnostics/missing-return.slang(14): warning 41010: control flow may reach end of non-'void' function
+tests/diagnostics/missing-return.slang(14): warning 41010: non-void function does not return in all cases
 int alsoBad(int a, int b)
     ^~~~~~~
 }


### PR DESCRIPTION
This PR changes the warning message of 41010
from 
`control flow may reach end of non-'void' function`
to
`non-void function does not return in all cases`

This verbiage is much clearer on what the actual issue is, and addresses issue #5354 