### PR TITLE
Don't initialize temp var for out parameters when generating the backward diff function

### DIFF
--- a/source/slang/slang-ir-autodiff-rev.cpp
+++ b/source/slang/slang-ir-autodiff-rev.cpp
@@ -528,10 +528,12 @@ InstPair BackwardDiffTranscriber::transcribeFuncHeader(IRBuilder* inBuilder, IRF
                 // If primal parameter is mutable, we need to pass in a temp var.
                 auto tempVar = builder.emitVar(primalParamPtrType->getValueType());
 
-                // We also need to setup the initial value of the temp var, otherwise
-                // the temp var will be uninitialized which could cause undefined behavior
-                // in the primal function.
-                builder.emitStore(tempVar, primalArg);
+                // If the parameter is not a pure 'out' param, we also need to setup the initial
+                // value of the temp var, otherwise the temp var will be uninitialized which could
+                // cause undefined behavior in the primal function.
+                //
+                if (!as<IROutType>(primalParamType))
+                    builder.emitStore(tempVar, primalArg);
 
                 primalArgs.add(tempVar);
             }

--- a/tests/autodiff/out-parameters-2.slang
+++ b/tests/autodiff/out-parameters-2.slang
@@ -1,0 +1,49 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+typedef DifferentialPair<float> dpfloat;
+
+struct Foo : IDifferentiable
+{
+    float a;
+    int b;
+}
+
+[PreferCheckpoint]
+float k()
+{
+    return outputBuffer[3] + 1;
+}
+
+[Differentiable]
+void h(float x, float y, out Foo result)
+{
+    float p = no_diff k();
+    float m = x + y + p;
+    float n = x - y;
+    float r = m * n + 2 * x * y;
+
+    result = {r, 2};
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    float x = 2.0;
+    float y = 3.5;
+    float dx = 1.0;
+    float dy = 0.5;
+
+    dpfloat dresult;
+    dpfloat dpx = diffPair(x);
+    dpfloat dpy = diffPair(y);
+    Foo.Differential dFoo;
+    dFoo.a = 1.0;
+    bwd_diff(h)(dpx, dpy, dFoo);
+
+    outputBuffer[0] = dpx.d; // CHECK: 12.0
+    outputBuffer[1] = dpy.d; // CHECK: -4.0
+}


### PR DESCRIPTION
This fixes an issue where 'out' parameters to the primal context function can be accidentally initialized using the wrong input to the backward function.