### PR TITLE
Remove warning about unspecified vkbinding

### DIFF
--- a/tests/diagnostics/hlsl-to-vulkan-shift-diagnostic.hlsl.expected
+++ b/tests/diagnostics/hlsl-to-vulkan-shift-diagnostic.hlsl.expected
@@ -1,11 +1,5 @@
 result code = -1
 standard error = {
-tests/diagnostics/hlsl-to-vulkan-shift-diagnostic.hlsl(11): warning 39013: shader parameter 'c' has a 'register' specified for D3D, but no '[[vk::binding(...)]]` specified for Vulkan
-ConstantBuffer<Data> c : register(b2);
-                         ^~~~~~~~
-tests/diagnostics/hlsl-to-vulkan-shift-diagnostic.hlsl(15): warning 39013: shader parameter 'u' has a 'register' specified for D3D, but no '[[vk::binding(...)]]` specified for Vulkan
-RWStructuredBuffer<Data> u : register(u11);
-                             ^~~~~~~~
 tests/diagnostics/hlsl-to-vulkan-shift-diagnostic.hlsl(15): error 39025: conflicting vulkan inferred binding for parameter 'c' overlap is 0 and 0
 RWStructuredBuffer<Data> u : register(u11);
                          ^

--- a/tests/diagnostics/vk-bindings.slang.expected
+++ b/tests/diagnostics/vk-bindings.slang.expected
@@ -1,8 +1,5 @@
 result code = -1
 standard error = {
-tests/diagnostics/vk-bindings.slang(6): warning 39013: shader parameter 't' has a 'register' specified for D3D, but no '[[vk::binding(...)]]` specified for Vulkan
-Texture2D t : register(t0);
-              ^~~~~~~~
 tests/diagnostics/vk-bindings.slang(14): error 39015: shader parameter 'b' consumes whole descriptor sets, so the binding must be in the form '[[vk::binding(0, ...)]]'; the non-zero binding '2' is not allowed
 [[vk::binding(2,1)]]
       ^~~~~~~


### PR DESCRIPTION
It is permitted that users omit explicit [vk::binding] settings on register definitions of HLSL-style, as they are opting into the default implicit mapping, as with DXC.

That does mean register IDs can clash between resources which have different register type but the same register number. For example:

Such a
problem can be resolved either with explicit bindings in source, or using the "-fvk-binding" slangc options which match DXC behavior.

Closes issue #5938