### PR TITLE
support SV_ViewIndex for Metal

### DIFF
--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -3201,7 +3201,9 @@ protected:
             }
         case SystemValueSemanticName::ViewID:
             {
-                result.isUnsupported = true;
+                result.systemValueName = toSlice("amplification_id");
+                result.permittedTypes.add(builder.getBasicType(BaseType::UInt));
+                result.permittedTypes.add(builder.getBasicType(BaseType::UInt16));
                 break;
             }
         case SystemValueSemanticName::ViewportArrayIndex:

--- a/tests/hlsl-intrinsic/system-values-draw-parameters.slang
+++ b/tests/hlsl-intrinsic/system-values-draw-parameters.slang
@@ -3,6 +3,8 @@
 //TEST:SIMPLE(filecheck=CHECK_HLSL): -entry main -stage vertex -target hlsl
 //TEST:SIMPLE(filecheck=CHECK_METAL): -entry main -stage vertex -target metal
 
+StructuredBuffer<float> scales;
+
 struct VSInput
 {
     uint vertexID : SV_VertexID;
@@ -16,18 +18,29 @@ struct VSOutput
 
 VSOutput main(VSInput input, 
               uint startVertexLocation : SV_StartVertexLocation, 
-              uint startInstanceLocation : SV_StartInstanceLocation)
+              uint startInstanceLocation : SV_StartInstanceLocation,
+              uint viewIndex : SV_ViewID)
 {
     VSOutput output;
 
     float x = (float)(input.vertexID + startVertexLocation) * 0.1f;
     float y = (float)(input.instanceID + startInstanceLocation) * 0.2f;
-    output.position = float4(x, y, 0.0f, 1.0f);
+    output.position = float4(x, y, 0.0f, 1.0f) * scales[viewIndex];
+
+    // CHECK_SPIRV: BuiltIn BaseVertex
+    // CHECK_GLSL: gl_BaseVertex
+    // CHECK_HLSL: SV_StartVertexLocation
+    // CHECK_METAL: base_vertex
 
     // CHECK_SPIRV: BuiltIn BaseInstance
     // CHECK_GLSL: gl_BaseInstance
     // CHECK_HLSL: SV_StartInstanceLocation
     // CHECK_METAL: base_instance
+
+    // CHECK_SPIRV: BuiltIn ViewIndex
+    // CHECK_GLSL: gl_ViewIndex
+    // CHECK_HLSL: SV_ViewID
+    // CHECK_METAL: amplification_id
 
     return output;
 }


### PR DESCRIPTION
Closes #6081.

Metal supports multiview rendering through [vertex amplification](https://developer.apple.com/documentation/metal/improving-rendering-performance-with-vertex-amplification) - view index in shader is supported through builtin attribute `[[amplification_id]]`.