### PR TITLE
Fix reinterpret<T> for 64-bit types

### DIFF
--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -426,7 +426,7 @@ struct AnyValueMarshallingContext
                             uintPtrType,
                             anyValueVar,
                             anyValInfo->fieldKeys[fieldOffset]);
-                        builder->emitStore(dstAddr, lowBits);
+                        builder->emitStore(dstAddr, highBits);
                         fieldOffset++;
                     }
                 }


### PR DESCRIPTION
Fixes the upper 32 bits of 64-bit values in AnyValue packing. The low 32 bits were repeated in the high bits. This caused `reinterpret<T>` to behave incorrectly for basic 64-bit types.

An example of the issue:
```hlsl
export __extern_cpp int main()
{
    int64_t ptr = 0x0123456789ABCDEF;
    uint64_t ptr2 = reinterpret<uint64_t>(ptr);
    printf("%lX\n", ptr);
    printf("%lX\n", ptr2);
    return 0;
}
```
prints:
```
123456789ABCDEF
89ABCDEF89ABCDEF
```
This also affects pointers, so reinterpreting addresses broke them.