### PR TITLE
Fix maximal gcc downstream compiler optimization level

### DIFF
--- a/source/compiler-core/slang-gcc-compiler-util.cpp
+++ b/source/compiler-core/slang-gcc-compiler-util.cpp
@@ -551,7 +551,7 @@ static SlangResult _parseGCCFamilyLine(
         }
     case OptimizationLevel::Maximal:
         {
-            cmdLine.addArg("-O4");
+            cmdLine.addArg("-O3");
             break;
         }
     default:


### PR DESCRIPTION
There is no `-O4` in [gcc docs](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html), and [anything above -O3 is the same as -O3](https://stackoverflow.com/a/30308151) actually.
More importantly, metal compiler will generate a warning `"metal 32023.404: : warning : -O4 is equivalent to -O3 [-Wdeprecated]"` when it is used with `-O4`.
So it‘s better to use `-O3` for `OptimizationLevel::Maximal`.
