### PR TITLE
Fix bug: IgnoreInheritance in lookup

### DIFF
--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -2175,7 +2175,7 @@ void SemanticsVisitor::AddTypeOverloadCandidates(Type* type, OverloadResolveCont
         type,
         context.sourceScope,
         LookupMask::Default,
-        LookupOptions::NoDeref);
+        LookupOptions::IgnoreInheritance);
 
     AddOverloadCandidates(initializers, context);
 }


### PR DESCRIPTION
When specifying IgnoreInheritance in lookup, it will ignore all members in the self extension for generic, the reason is that it doesn't specialize the target type of the extension decl when comparing with self type, so it will result that every type is unequal to the target type.