### PR TITLE
Fix static build and install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,12 +385,14 @@ configure_package_config_file(
 # linkable targets. In this case do not export the targets. Otherwise, just
 # export the slang targets. 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-    install(
-        EXPORT SlangTargets
-        FILE ${PROJECT_NAME}Targets.cmake
-        NAMESPACE ${PROJECT_NAME}::
-        DESTINATION cmake
-    )
+    if(NOT ${SLANG_BUILD_TYPE} STREQUAL "STATIC")
+        install(
+            EXPORT SlangTargets
+            FILE ${PROJECT_NAME}Targets.cmake
+            NAMESPACE ${PROJECT_NAME}::
+            DESTINATION cmake
+        )
+    endif()
 endif()
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,8 @@ option(
     ON
 )
 
+option(SLANG_ENABLE_RELEASE_LTO "Enable LTO for Release builds" ON)
+
 option(
     SLANG_ENABLE_SPLIT_DEBUG_INFO
     "Generate split debug info for debug builds"

--- a/cmake/SlangTarget.cmake
+++ b/cmake/SlangTarget.cmake
@@ -166,12 +166,14 @@ function(slang_add_target dir type)
 
     # Enable link-time optimization for release builds
     # See: https://cmake.org/cmake/help/latest/prop_tgt/INTERPROCEDURAL_OPTIMIZATION.html
-    set_target_properties(
-        ${target}
-        PROPERTIES
-            INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE
-            INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO TRUE
-    )
+    if(SLANG_ENABLE_RELEASE_LTO)
+        set_target_properties(
+            ${target}
+            PROPERTIES
+                INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE
+                INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO TRUE
+        )
+    endif()
 
     #
     # Set the output directory

--- a/docs/building.md
+++ b/docs/building.md
@@ -165,6 +165,7 @@ See the [documentation on testing](../tools/slang-test/README.md) for more infor
 | `SLANG_ENABLE_EXAMPLES`           | `TRUE`                     | Enable example targets, requires SLANG_ENABLE_GFX                                            |
 | `SLANG_LIB_TYPE`                  | `SHARED`                   | How to build the slang library                                                               |
 | `SLANG_ENABLE_RELEASE_DEBUG_INFO` | `TRUE`                     | Enable generating debug info for Release configs                                             |
+| `SLANG_ENABLE_RELEASE_LTO`        | `TRUE`                     | Enable LTO for Release builds                                                                |
 | `SLANG_ENABLE_SPLIT_DEBUG_INFO`   | `TRUE`                     | Enable generating split debug info for Debug and RelWithDebInfo configs                      |
 | `SLANG_SLANG_LLVM_FLAVOR`         | `FETCH_BINARY_IF_POSSIBLE` | How to set up llvm support                                                                   |
 | `SLANG_SLANG_LLVM_BINARY_URL`     | System dependent           | URL specifying the location of the slang-llvm prebuilt library                               |

--- a/prelude/CMakeLists.txt
+++ b/prelude/CMakeLists.txt
@@ -23,12 +23,14 @@ endforeach()
 slang_add_target(
     .
     OBJECT
+    EXPORT_MACRO_PREFIX SLANG
     EXPLICIT_SOURCE ${prelude_source}
     EXCLUDE_FROM_ALL
     TARGET_NAME prelude
     INCLUDE_DIRECTORIES_PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/../include
+    EXPORT_TYPE_AS ${SLANG_LIB_TYPE}
     LINK_WITH_PRIVATE unordered_dense::unordered_dense
     PUBLIC_HEADERS ${CMAKE_CURRENT_LIST_DIR}/slang*.h
     # It's an object library, so the install step only installs the headers

--- a/source/compiler-core/CMakeLists.txt
+++ b/source/compiler-core/CMakeLists.txt
@@ -1,6 +1,7 @@
 slang_add_target(
     .
     STATIC
+    EXPORT_MACRO_PREFIX SLANG
     EXCLUDE_FROM_ALL
     USE_EXTRA_WARNINGS
     LINK_WITH_PRIVATE core

--- a/source/core/CMakeLists.txt
+++ b/source/core/CMakeLists.txt
@@ -1,6 +1,7 @@
 slang_add_target(
     .
     STATIC
+    EXPORT_MACRO_PREFIX SLANG
     EXCLUDE_FROM_ALL
     USE_EXTRA_WARNINGS
     LINK_WITH_PRIVATE miniz lz4_static Threads::Threads ${CMAKE_DL_LIBS}

--- a/source/slang-rt/CMakeLists.txt
+++ b/source/slang-rt/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(SLANG_ENABLE_SLANGRT)
     slang_add_target(
         .
-        SHARED
+        ${SLANG_LIB_TYPE}
         # This compiles 'core' again with the SLANG_RT_DYNAMIC_EXPORT macro defined
         EXTRA_SOURCE_DIRS ${slang_SOURCE_DIR}/source/core
         USE_EXTRA_WARNINGS

--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -28,8 +28,10 @@ add_custom_command(
 slang_add_target(
     slang-capability-defs
     OBJECT
+    EXPORT_MACRO_PREFIX SLANG
     USE_EXTRA_WARNINGS
     EXPLICIT_SOURCE ${SLANG_CAPABILITY_GENERATED_HEADERS}
+    EXPORT_TYPE_AS ${SLANG_LIB_TYPE}
     LINK_WITH_PRIVATE core
     INCLUDE_DIRECTORIES_PUBLIC
         "${SLANG_CAPABILITY_OUTPUT_DIR}"
@@ -40,8 +42,10 @@ slang_add_target(
 slang_add_target(
     slang-capability-lookup
     OBJECT
+    EXPORT_MACRO_PREFIX SLANG
     USE_EXTRA_WARNINGS
     EXPLICIT_SOURCE ${SLANG_CAPABILITY_GENERATED_SOURCE}
+    EXPORT_TYPE_AS ${SLANG_LIB_TYPE}
     LINK_WITH_PRIVATE core slang-capability-defs
     EXCLUDE_FROM_ALL
     FOLDER generated
@@ -157,10 +161,12 @@ add_custom_command(
 slang_add_target(
     slang-lookup-tables
     OBJECT
+    EXPORT_MACRO_PREFIX SLANG
     USE_EXTRA_WARNINGS
     EXPLICIT_SOURCE
         ${SLANG_LOOKUP_GENERATED_SOURCE}
         ${SLANG_SPIRV_CORE_GRAMMAR_SOURCE}
+    EXPORT_TYPE_AS ${SLANG_LIB_TYPE}
     LINK_WITH_PRIVATE core SPIRV-Headers
     EXCLUDE_FROM_ALL
     FOLDER generated
@@ -274,6 +280,7 @@ else()
     slang_add_target(
         .
         ${SLANG_LIB_TYPE}
+        EXPORT_MACRO_PREFIX SLANG
         ${slang_link_args}
         ${slang_interface_args}
         NO_SOURCE
@@ -291,6 +298,7 @@ else()
     slang_add_target(
         .
         ${SLANG_LIB_TYPE}
+        EXPORT_MACRO_PREFIX SLANG
         ${slang_link_args}
         ${slang_interface_args}
         ${slang_public_lib_args}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -73,6 +73,7 @@ generator(
 slang_add_target(
     slang-cpp-parser
     STATIC
+    EXPORT_MACRO_PREFIX SLANG
     USE_FEWER_WARNINGS
     LINK_WITH_PRIVATE core compiler-core
     INCLUDE_DIRECTORIES_PUBLIC .
@@ -104,7 +105,7 @@ if(SLANG_ENABLE_GFX)
     #
     slang_add_target(
         platform
-        SHARED
+        ${SLANG_LIB_TYPE}
         EXCLUDE_FROM_ALL
         USE_FEWER_WARNINGS
         LINK_WITH_PRIVATE
@@ -128,7 +129,7 @@ if(SLANG_ENABLE_GFX)
     #
     slang_add_target(
         gfx
-        SHARED
+        ${SLANG_LIB_TYPE}
         USE_FEWER_WARNINGS
         LINK_WITH_PRIVATE
             core


### PR DESCRIPTION
Main goal of the PR is to simplify building statically when used as a submodule by a downstream project.

Fixes #5832 by adding missing STATIC arguments in cmake. 

Improves the state on #5821 by fixing build errors, but does not entirely fix the static build install, just disables the failing part. Completely fixing the problem requires being more careful with what dependencies are PRIVATE and PUBLIC or adding additional explicit targets to install.

Also adds an option to disable LTO, this can be useful to limit the size of static libs (`slang.lib` is currently ~2GB when using LTO).