### PR TITLE
Add intptr_t abs/min/max operations for CPU & CUDA targets

### DIFF
--- a/prelude/slang-cpp-scalar-intrinsics.h
+++ b/prelude/slang-cpp-scalar-intrinsics.h
@@ -765,6 +765,39 @@ SLANG_FORCE_INLINE int64_t I64_max(int64_t a, int64_t b)
     return a > b ? a : b;
 }
 
+// ----------------------------- UPTR -----------------------------------------
+
+SLANG_FORCE_INLINE uintptr_t UPTR_abs(uintptr_t f)
+{
+    return f;
+}
+
+SLANG_FORCE_INLINE uintptr_t UPTR_min(uintptr_t a, uintptr_t b)
+{
+    return a < b ? a : b;
+}
+
+SLANG_FORCE_INLINE uintptr_t UPTR_max(uintptr_t a, uintptr_t b)
+{
+    return a > b ? a : b;
+}
+
+// ----------------------------- IPTR -----------------------------------------
+
+SLANG_FORCE_INLINE intptr_t IPTR_abs(intptr_t f)
+{
+    return (f < 0) ? -f : f;
+}
+
+SLANG_FORCE_INLINE intptr_t IPTR_min(intptr_t a, intptr_t b)
+{
+    return a < b ? a : b;
+}
+
+SLANG_FORCE_INLINE intptr_t IPTR_max(intptr_t a, intptr_t b)
+{
+    return a > b ? a : b;
+}
 
 // ----------------------------- Interlocked ---------------------------------
 

--- a/prelude/slang-cuda-prelude.h
+++ b/prelude/slang-cuda-prelude.h
@@ -1902,6 +1902,39 @@ SLANG_FORCE_INLINE SLANG_CUDA_CALL uint32_t U64_countbits(uint64_t v)
     return __popcll(v);
 }
 
+// ----------------------------- IPTR -----------------------------------------
+
+SLANG_FORCE_INLINE SLANG_CUDA_CALL intptr_t IPTR_abs(intptr_t f)
+{
+    return (f < 0) ? -f : f;
+}
+
+SLANG_FORCE_INLINE SLANG_CUDA_CALL intptr_t IPTR_min(intptr_t a, intptr_t b)
+{
+    return a < b ? a : b;
+}
+
+SLANG_FORCE_INLINE SLANG_CUDA_CALL intptr_t IPTR_max(intptr_t a, intptr_t b)
+{
+    return a > b ? a : b;
+}
+
+// ----------------------------- UPTR -----------------------------------------
+
+SLANG_FORCE_INLINE SLANG_CUDA_CALL uintptr_t UPTR_abs(uintptr_t f)
+{
+    return f;
+}
+
+SLANG_FORCE_INLINE SLANG_CUDA_CALL uintptr_t UPTR_min(uintptr_t a, uintptr_t b)
+{
+    return a < b ? a : b;
+}
+
+SLANG_FORCE_INLINE SLANG_CUDA_CALL uintptr_t UPTR_max(uintptr_t a, uintptr_t b)
+{
+    return a > b ? a : b;
+}
 
 // ----------------------------- ResourceType -----------------------------------------
 

--- a/prelude/slang-cuda-prelude.h
+++ b/prelude/slang-cuda-prelude.h
@@ -205,11 +205,13 @@ typedef signed char int8_t;
 typedef short int16_t;
 typedef int int32_t;
 typedef long long int64_t;
+typedef ptrdiff_t intptr_t;
 
 typedef unsigned char uint8_t;
 typedef unsigned short uint16_t;
 typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
+typedef size_t uintptr_t;
 
 #endif
 

--- a/source/slang/slang-intrinsic-expand.cpp
+++ b/source/slang/slang-intrinsic-expand.cpp
@@ -704,6 +704,8 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
                 CASE(UInt16Type, U16);
                 CASE(UIntType, U32);
                 CASE(UInt64Type, U64);
+                CASE(IntPtrType, IPTR);
+                CASE(UIntPtrType, UPTR);
                 CASE(HalfType, F16);
                 CASE(FloatType, F32);
                 CASE(DoubleType, F64);


### PR DESCRIPTION
This PR allows using abs/min/max with uintptr_t & intptr_t (= size_t as well).

This only covers the CPU and CUDA targets because they use the same code path, where this is easy to implement. For the rest of the targets, there seems to be many more obstacles, so I didn't do those in this PR (`Slang::getIntTypeInfo()` can't handle these types, so there's quite a few contexts where they don't work, it's not just these builtins)

Previously, e.g.
```hlsl
export __extern_cpp int main()
{
    size_t a = 1;
    size_t b = 2;

    printf("%lu\n", max(a, b));
    return 0;
}
```
would result in
```
(0): error 99999: Slang compilation aborted due to an exception of N5Slang13InternalErrorE: unexpected: unexpected type in intrinsic definition
```
