### PR TITLE
Fix incorrect resolve of specialization instance

### DIFF
--- a/tests/diagnostics/uninitialized-generic.slang
+++ b/tests/diagnostics/uninitialized-generic.slang
@@ -1,0 +1,30 @@
+//TEST:SIMPLE(filecheck=CHK): -target spirv -entry computeMain
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+groupshared float4 gsVar;
+
+__generic<TYPE1 : __BuiltinArithmeticType>
+struct MyContainer
+{
+    __generic<TYPE2 : __BuiltinArithmeticType>
+    void store(__ref vector<TYPE2,4> v)
+    {
+        v[0] = TYPE2(0);
+        v[1] = TYPE2(1);
+        v[2] = TYPE2(2);
+        v[3] = TYPE2(3);
+    }
+};
+
+[Shader("compute")]
+[NumThreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+{
+    MyContainer<float> obj;
+    obj.store(gsVar);
+
+    // CHK-NOT:warning 41017:
+    outputBuffer[0] = gsVar.x;
+}

--- a/tests/diagnostics/uninitialized-local-variables.slang
+++ b/tests/diagnostics/uninitialized-local-variables.slang
@@ -38,13 +38,14 @@ int use_undefined_value(int k)
     return x;
 }
 
-// Returning uninitialized values
+// We don't know the exact type of T yet.
+// T may not have any members, and it may not need any initialization.
 __generic<T>
 T generic_undefined_return()
 {
-    T x;
-    //CHK-DAG: warning 41016: use of uninitialized variable 'x'
-    return x;
+    T y;
+    //CHK-NOT: warning 41016: use of uninitialized variable 'y'
+    return y;
 }
 
 // Array variables


### PR DESCRIPTION
While checking the uninitialized variables, we were not resolving the specialized instance correctly. This commit repeats the resolve while the result is a specialization instance. A new test is added for this:
  tests/diagnostics/uninitialized-generic.slang

After the problem is fixed, it revealed another problem in existing tests:
  tests/compute/nested-generics2.slang
  tests/diagnostics/uninitialized-local-variables.slang

When a struct has a member variable whose type is a generic type, we cannot iterate over its member variables yet, because the type is unknown until the generic function/struct is specialized. We will have to give up checking for these cases.