### PR TITLE
Fix an incorrect iteration with a workList

### DIFF
--- a/source/slang/slang-ir-variable-scope-correction.cpp
+++ b/source/slang/slang-ir-variable-scope-correction.cpp
@@ -121,7 +121,7 @@ void VariableScopeCorrectionContext::_processFunction(IRFunc* funcInst)
 
     auto instAfterParam = funcInst->getFirstBlock()->getFirstOrdinaryInst();
 
-    for (int i = 0; i < workList.getCount(); i++)
+    for (Index i = 0; i < workList.getCount(); i++)
     {
         auto inst = workList[i];
         if (auto loopHeaderList = loopHeaderMap.tryGetValue(getBlock(inst)))

--- a/source/slang/slang-ir-variable-scope-correction.cpp
+++ b/source/slang/slang-ir-variable-scope-correction.cpp
@@ -121,12 +121,28 @@ void VariableScopeCorrectionContext::_processFunction(IRFunc* funcInst)
 
     auto instAfterParam = funcInst->getFirstBlock()->getFirstOrdinaryInst();
 
-    for (auto inst = workList.begin(); inst != workList.end(); inst++)
+    while (true)
     {
-        if (auto loopHeaderList = loopHeaderMap.tryGetValue(getBlock(*inst)))
+        // We cannot modify workList while iterating it
+        List<IRInst*> workList2;
+
+        for (auto inst = workList.begin(); inst != workList.end(); inst++)
         {
-            _processInstruction(dominatorTree, instAfterParam, *inst, *loopHeaderList, workList);
+            if (auto loopHeaderList = loopHeaderMap.tryGetValue(getBlock(*inst)))
+            {
+                _processInstruction(
+                    dominatorTree,
+                    instAfterParam,
+                    *inst,
+                    *loopHeaderList,
+                    workList2);
+            }
         }
+
+        if (workList2.getCount() == 0)
+            break;
+
+        workList = workList2;
     }
 }
 

--- a/source/slang/slang-ir-variable-scope-correction.cpp
+++ b/source/slang/slang-ir-variable-scope-correction.cpp
@@ -121,28 +121,13 @@ void VariableScopeCorrectionContext::_processFunction(IRFunc* funcInst)
 
     auto instAfterParam = funcInst->getFirstBlock()->getFirstOrdinaryInst();
 
-    while (true)
+    for (int i = 0; i < workList.getCount(); i++)
     {
-        // We cannot modify workList while iterating it
-        List<IRInst*> workList2;
-
-        for (auto inst = workList.begin(); inst != workList.end(); inst++)
+        auto inst = workList[i];
+        if (auto loopHeaderList = loopHeaderMap.tryGetValue(getBlock(inst)))
         {
-            if (auto loopHeaderList = loopHeaderMap.tryGetValue(getBlock(*inst)))
-            {
-                _processInstruction(
-                    dominatorTree,
-                    instAfterParam,
-                    *inst,
-                    *loopHeaderList,
-                    workList2);
-            }
+            _processInstruction(dominatorTree, instAfterParam, inst, *loopHeaderList, workList);
         }
-
-        if (workList2.getCount() == 0)
-            break;
-
-        workList = workList2;
     }
 }
 


### PR DESCRIPTION
We cannot modify workList while iterating it, because its type `List` is actually an array container.