### PR TITLE
Fix the type coerce issue

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -9204,7 +9204,6 @@ void SemanticsDeclBodyVisitor::visitAggTypeDecl(AggTypeDecl* aggTypeDecl)
         inheritanceDefaultCtorList.add(
             DeclAndCtorInfo(m_astBuilder, this, structOfInheritance, declRefType, true));
     }
-    calcThisType(makeDeclRef(structDecl));
     DeclAndCtorInfo structDeclInfo = DeclAndCtorInfo(
         m_astBuilder,
         this,

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -9090,8 +9090,7 @@ void SemanticsDeclBodyVisitor::synthesizeCtorBodyForBases(
 
         auto assign = m_astBuilder->create<AssignExpr>();
 
-        assign->left =
-            coerce(CoercionSite::Initializer, declRefType, thisExpr);
+        assign->left = coerce(CoercionSite::Initializer, declRefType, thisExpr);
         assign->right = invoke;
 
         auto stmt = m_astBuilder->create<ExpressionStmt>();
@@ -9206,7 +9205,12 @@ void SemanticsDeclBodyVisitor::visitAggTypeDecl(AggTypeDecl* aggTypeDecl)
             DeclAndCtorInfo(m_astBuilder, this, structOfInheritance, declRefType, true));
     }
     calcThisType(makeDeclRef(structDecl));
-    DeclAndCtorInfo structDeclInfo = DeclAndCtorInfo(m_astBuilder, this, structDecl, calcThisType(makeDeclRef(structDecl)), false);
+    DeclAndCtorInfo structDeclInfo = DeclAndCtorInfo(
+        m_astBuilder,
+        this,
+        structDecl,
+        calcThisType(makeDeclRef(structDecl)),
+        false);
 
     // ensure all varDecl members are processed up to SemanticsBodyVisitor so we can be sure that if
     // init expressions of members are to be synthisised, they are.

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -329,12 +329,12 @@ struct SemanticsDeclBodyVisitor : public SemanticsDeclVisitorBase,
         DeclAndCtorInfo(
             ASTBuilder* m_astBuilder,
             SemanticsVisitor* visitor,
-            StructDecl* parent,
-            Type* type,
+            StructDecl* inParent,
+            Type* inType,
             const bool getOnlyDefault)
         {
-            this->parent = parent;
-            this->type = type;
+            parent = inParent;
+            type = inType;
             if (getOnlyDefault)
                 defaultCtor = _getDefaultCtor(parent);
             else

--- a/tests/language-feature/initializer-lists/inheritance-generic.slang
+++ b/tests/language-feature/initializer-lists/inheritance-generic.slang
@@ -1,0 +1,26 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUFFER):-shaderobj -vk
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUFFER):-shaderobj
+
+struct Base<let ND:int>
+{
+    int a = 1;
+}
+
+struct Derived<let ND:int>: Base<ND>
+{
+    bool x;
+    bool y;
+}
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=result
+RWStructuredBuffer<int> result;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    Derived<3> d;
+
+    // BUFFER: 1
+    result[0] = d.a;
+}


### PR DESCRIPTION
When synthesize the default ctor, if there is a base type we will synthesize an InvokeExpr to call base type's default ctor as well. But we should use the type of the inheritanceDecl instead of base struct decl.