### PR TITLE
Fix ConstantIntVal::toText when the val is a enum.

### DIFF
--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -210,6 +210,8 @@ class EnumCaseDecl : public Decl
 
     // Tag value
     Expr* tagExpr = nullptr;
+
+    IntVal* tagVal = nullptr;
 };
 
 // A member of InterfaceDecl representing the abstract ThisType.

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -7969,7 +7969,7 @@ void SemanticsDeclBodyVisitor::visitEnumCaseDecl(EnumCaseDecl* decl)
         // We want to enforce that this is an integer constant
         // expression, but we don't actually care to retain
         // the value.
-        CheckIntegerConstantExpression(
+        decl->tagVal = CheckIntegerConstantExpression(
             initExpr,
             IntegerConstantExpressionCoercionType::AnyInteger,
             nullptr,

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -7967,8 +7967,7 @@ void SemanticsDeclBodyVisitor::visitEnumCaseDecl(EnumCaseDecl* decl)
         initExpr = coerce(CoercionSite::General, tagType, initExpr);
 
         // We want to enforce that this is an integer constant
-        // expression, but we don't actually care to retain
-        // the value.
+        // expression.
         decl->tagVal = CheckIntegerConstantExpression(
             initExpr,
             IntegerConstantExpressionCoercionType::AnyInteger,

--- a/tests/language-server/typename-enum-intval.slang
+++ b/tests/language-server/typename-enum-intval.slang
@@ -1,0 +1,24 @@
+//TEST:LANG_SERVER(filecheck=CHECK):
+
+namespace ns {
+enum Test : uint32_t
+{
+    A = 1,
+    B = 2,
+}
+
+struct Foo<let T : Test>
+{
+}
+}
+
+void f()
+{
+//HOVER:18,25
+    ns.Foo<ns.Test.A> first;
+//HOVER:20,27
+    ns.Foo<ns.Test(3)> second;
+}
+
+// CHECK: ns.Foo<ns.Test.A>
+// CHECK: ns.Foo<ns.Test(3)>


### PR DESCRIPTION
Closes #6225.