### PR TITLE
Update Slang-RHI and enable any debug layers up-front

### DIFF
--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -1408,6 +1408,7 @@ static SlangResult _innerMain(
         desc.slang.slangGlobalSession = session;
         desc.slang.targetProfile = options.profileName.getBuffer();
         {
+            getRHI()->enableDebugLayers();
             SlangResult res = getRHI()->createDevice(desc, device.writeRef());
             if (SLANG_FAILED(res))
             {

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -1404,7 +1404,7 @@ static SlangResult _innerMain(
             }
         }
 
-        desc.nvapiExtnSlot = int(nvapiExtnSlot);
+        desc.nvapiExtUavSlot = uint32_t(nvapiExtnSlot);
         desc.slang.slangGlobalSession = session;
         desc.slang.targetProfile = options.profileName.getBuffer();
         {

--- a/tools/render-test/shader-input-layout.h
+++ b/tools/render-test/shader-input-layout.h
@@ -324,7 +324,7 @@ public:
     public:
         Slang::String derivedTypeName;
         Slang::String baseTypeName;
-        Int idOverride = -1;
+        Slang::Int idOverride = -1;
     };
     Slang::List<TypeConformanceVal> typeConformances;
 

--- a/tools/render-test/slang-support.h
+++ b/tools/render-test/slang-support.h
@@ -36,7 +36,7 @@ struct ShaderCompileRequest
     public:
         Slang::String derivedTypeName;
         Slang::String baseTypeName;
-        Int idOverride;
+        Slang::Int idOverride;
     };
 
     SourceInfo source;


### PR DESCRIPTION
As [1] shows, creating a D3D12 device and then enabling debug layers causes future device creation to fail.
That means enabling debug layers is a process-wide decision that should be done at startup, and not just before creating an individual device. Previously, Slang-RHI enabled debug layers as part of device creation. The new Slang-RHI revision doesn't do that anymore, but instead allows the user to enable debug layers earlier, with a separate API.
This change calls the mentioned API before creating any device.

This closes #6172.