### PR TITLE
update slang-rhi (shader object refactor)

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -105,6 +105,21 @@
       "configuration": "RelWithDebInfo"
     },
     {
+      "name": "vs2022-debug",
+      "configurePreset": "vs2022",
+      "configuration": "Debug"
+    },
+    {
+      "name": "vs2022-release",
+      "configurePreset": "vs2022",
+      "configuration": "Release"
+    },
+    {
+      "name": "vs2022-releaseWithDebugInfo",
+      "configurePreset": "vs2022",
+      "configuration": "RelWithDebInfo"
+    },
+    {
       "name": "emscripten",
       "configurePreset": "emscripten",
       "configuration": "Release",

--- a/tests/bugs/ray-query-in-generic.slang
+++ b/tests/bugs/ray-query-in-generic.slang
@@ -36,8 +36,6 @@ struct Ray
     float3 eval(float t) { return origin + t * dir; }
 };
 
-RaytracingAccelerationStructure sceneBVH;
-
 uint getCommittedStatus<let Flags : int>(RayQuery<Flags> q)
 {
     return q.CommittedStatus();

--- a/tests/compute/byte-address-buffer-aligned.slang
+++ b/tests/compute/byte-address-buffer-aligned.slang
@@ -9,6 +9,7 @@
 
 // Confirm compilation of `(RW)ByteAddressBuffer` with aligned load / stores to wider data types.
 
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=buffer0
 [vk::binding(2, 3)] RWByteAddressBuffer buffer0;
 
 [shader("compute")]

--- a/tests/compute/byte-address-buffer-array.slang
+++ b/tests/compute/byte-address-buffer-array.slang
@@ -9,6 +9,7 @@
 
 // Confirm compilation of `(RW)ByteAddressBuffer` with aligned load / stores to wider data types.
 
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=buffer
 [vk::binding(2, 3)] RWByteAddressBuffer buffer;
 struct Block {
     float4 val[2];

--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -249,9 +249,9 @@ static rhi::DeviceType _toRenderType(Slang::RenderApiType apiType)
         {
             SLANG_RETURN_ON_FAIL(reader.expectArg(outOptions.entryPointName));
         }
-        else if (argValue == "-enable-backend-validation")
+        else if (argValue == "-enable-debug-layers")
         {
-            outOptions.enableBackendValidation = true;
+            outOptions.enableDebugLayers = true;
         }
         else if (argValue == "-dx12-experimental")
         {

--- a/tools/render-test/options.h
+++ b/tools/render-test/options.h
@@ -87,7 +87,7 @@ struct Options
 
     bool generateSPIRVDirectly = true;
 
-    bool enableBackendValidation = false;
+    bool enableDebugLayers = false;
 
     bool dx12Experimental = false;
 

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -3524,7 +3524,7 @@ TestResult runComputeComparisonImpl(
     // This is due to the limitation that Slang RPC implementation expects only
     // one time communication.
     if (input.spawnType != SpawnType::UseTestServer)
-        cmdLine.addArg("-enable-backend-validation");
+        cmdLine.addArg("-enable-debug-layers");
 #endif
 
     if (context->isExecuting())


### PR DESCRIPTION
changes in slang-rhi:

- fix build issue where chrono was not included
- always build cuda driver api
- Viewport::fromSize and ScissorRect::fromSize
- rename structs
- arena allocator cleanup + test
- work on fences
- remove ref counting
- expose dynamically loaded cuda driver api
- add BufferUsage::Shared and TextureUsage::Shared
- Metal improvements
- enable shadowing warnings
- increase warnings on apple clang
- generate label for texture views
- add surface, rasterization and parameter-block device features
- add GPU_TEST_CASE macro
- remove enableBackendValidation from DeviceDesc
- add copy buffer test
- CUDA surface
- update api.md
- Refactor shader object
- cooperative vector support
