### PR TITLE
Auto enable `-fvk-use-entrypoint-name` when there is more than one entrypoint.

### DIFF
--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -3723,7 +3723,7 @@ void legalizeEntryPointForGLSL(
     // Rename the entrypoint to "main" to conform to GLSL standard,
     // if the compile options require us to do it.
     if (!shouldUseOriginalEntryPointName(codeGenContext) &&
-        codeGenContext->getEntryPointCount() != 1)
+        codeGenContext->getEntryPointCount() == 1)
     {
         entryPointDecor->setName(builder.getStringValue(UnownedStringSlice("main")));
     }

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -3722,7 +3722,8 @@ void legalizeEntryPointForGLSL(
 
     // Rename the entrypoint to "main" to conform to GLSL standard,
     // if the compile options require us to do it.
-    if (!shouldUseOriginalEntryPointName(codeGenContext))
+    if (!shouldUseOriginalEntryPointName(codeGenContext) &&
+        codeGenContext->getEntryPointCount() != 1)
     {
         entryPointDecor->setName(builder.getStringValue(UnownedStringSlice("main")));
     }

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -2352,6 +2352,7 @@ static Expr* tryParseGenericApp(Parser* parser, Expr* base)
         case TokenType::OpEql:
         case TokenType::OpNeq:
         case TokenType::OpGreater:
+        case TokenType::OpRsh:
         case TokenType::EndOfFile:
             {
                 return parseGenericApp(parser, base);

--- a/tests/spirv/multi-entrypoint-no-rename.slang
+++ b/tests/spirv/multi-entrypoint-no-rename.slang
@@ -1,0 +1,12 @@
+//TEST:SIMPLE(filecheck=CHECK): -entry main1 -entry main2 -target spirv
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+
+// CHECK: OpEntryPoint MissKHR %missShader "missShader"
+// CHECK: OpEntryPoint MissKHR %missShader2 "missShader2"
+
+struct RayPayload{};
+[shader("miss")]
+void missShader(inout RayPayload payload) { }
+
+[shader("miss")]
+void missShader2(inout RayPayload payload)  { }

--- a/tests/spirv/multi-entrypoint-no-rename.slang
+++ b/tests/spirv/multi-entrypoint-no-rename.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -entry main1 -entry main2 -target spirv
+//TEST:SIMPLE(filecheck=CHECK): -entry missShader -entry missShader2 -target spirv
 //TEST:SIMPLE(filecheck=CHECK): -target spirv
 
 // CHECK: OpEntryPoint MissKHR %missShader "missShader"


### PR DESCRIPTION
Closes #6248.