### PR TITLE
Fix DCE for calls to functions that have associations

### DIFF
--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -1240,28 +1240,27 @@ void forEachAssociatedFunction(IRInst* func, TFunc callback)
         case kIROp_UserDefinedBackwardDerivativeDecoration:
             if (as<IRUserDefinedBackwardDerivativeDecoration>(decor))
             {
-                auto associatedFunc =
-                    as<IRGlobalValueWithCode>(as<IRUserDefinedBackwardDerivativeDecoration>(decor)
-                                                  ->getBackwardDerivativeFunc());
-                callback(associatedFunc);
+                auto associatedCallee = as<IRUserDefinedBackwardDerivativeDecoration>(decor)
+                                            ->getBackwardDerivativeFunc();
+                callback(associatedCallee);
             }
             break;
 
         case kIROp_ForwardDerivativeDecoration:
             if (as<IRForwardDerivativeDecoration>(decor))
             {
-                auto associatedFunc = as<IRGlobalValueWithCode>(
-                    as<IRForwardDerivativeDecoration>(decor)->getForwardDerivativeFunc());
-                callback(associatedFunc);
+                auto associatedCallee =
+                    as<IRForwardDerivativeDecoration>(decor)->getForwardDerivativeFunc();
+                callback(associatedCallee);
             }
             break;
 
         case kIROp_PrimalSubstituteDecoration:
             if (as<IRPrimalSubstituteDecoration>(decor))
             {
-                auto associatedFunc = as<IRGlobalValueWithCode>(
-                    as<IRPrimalSubstituteDecoration>(decor)->getPrimalSubstituteFunc());
-                callback(associatedFunc);
+                auto associatedCallee =
+                    as<IRPrimalSubstituteDecoration>(decor)->getPrimalSubstituteFunc();
+                callback(associatedCallee);
             }
             break;
 
@@ -1299,9 +1298,9 @@ bool doesCalleeHaveSideEffect(IRInst* callee)
     {
         forEachAssociatedFunction(
             callee,
-            [&](IRGlobalValueWithCode* associatedFunc)
+            [&](IRInst* associatedCallee)
             {
-                sideEffect |= doesCalleeHaveSideEffect(associatedFunc);
+                sideEffect |= doesCalleeHaveSideEffect(associatedCallee);
                 return;
             });
     }

--- a/tests/autodiff/custom-diff-empty-func.slang
+++ b/tests/autodiff/custom-diff-empty-func.slang
@@ -1,0 +1,35 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type -g0
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+void foo_bwd(float a, inout DifferentialPair<float> dpx)
+{
+    outputBuffer[2] = 2.f;
+}
+
+[Differentiable, BackwardDerivative(foo_bwd)]
+void foo(no_diff float a, float x)
+{ }
+
+[Differentiable]
+float outerFunc(no_diff float a, float x)
+{
+    foo(a, x);
+    return 1.f;
+}
+
+[numthreads(1, 1, 1)]
+[shader("compute")]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    float a = 10.0;
+    DifferentialPair<float> dpx = DifferentialPair<float>(4.f, 1.f);
+    bwd_diff(outerFunc)(a, dpx, 1.0);
+    
+    // CHECK: type: float
+    // CHECK: 0.0
+    // CHECK: 0.0
+    // CHECK: 2.0
+    // CHECK: 0.0
+}


### PR DESCRIPTION
DCE will now check for side-effect-ness on other functions that are associated with the callee being checked.

Fixes: #5755 