### PR TITLE
Add checking for differentiability of the primal substitute function.

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -11855,6 +11855,27 @@ static void checkDerivativeAttribute(
         imaginaryArguments.directions,
         imaginaryArguments.thisArg,
         imaginaryArguments.thisArgDirection);
+
+    // For primal-substitute we'd also want to make sure that the differentiability
+    // level of the target is as high as the funcDecl itself
+    //
+    if (auto declRefExpr = as<DeclRefExpr>(attr->funcExpr))
+    {
+        if (auto declRef = declRefExpr->declRef)
+        {
+            auto targetDiffLevel = visitor->getShared()->getFuncDifferentiableLevel(
+                declRef.as<FunctionDeclBase>().getDecl());
+            auto currDiffLevel = visitor->getShared()->getFuncDifferentiableLevel(funcDecl);
+            if (targetDiffLevel < currDiffLevel)
+            {
+                visitor->getSink()->diagnose(
+                    attr->loc,
+                    Diagnostics::primalSubstituteTargetMustHaveHigherDifferentiabilityLevel,
+                    declRefExpr->declRef.getDecl(),
+                    funcDecl);
+            }
+        }
+    }
 }
 
 static void checkCudaKernelAttribute(

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -1190,6 +1190,12 @@ DIAGNOSTIC(
     Error,
     overloadedFuncUsedWithDerivativeOfAttributes,
     "cannot resolve overloaded functions for derivative-of attributes.")
+DIAGNOSTIC(
+    31158,
+    Error,
+    primalSubstituteTargetMustHaveHigherDifferentiabilityLevel,
+    "primal substitute function for differentiable method must also be differentiable. Use "
+    "[Differentiable] or [TreatAsDifferentiable] (for empty derivatives)")
 
 DIAGNOSTIC(31200, Warning, deprecatedUsage, "$0 has been deprecated: $1")
 DIAGNOSTIC(31201, Error, modifierNotAllowed, "modifier '$0' is not allowed here.")

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -2471,6 +2471,7 @@ void stripAutoDiffDecorationsFromChildren(IRInst* parent)
             case kIROp_BackwardDerivativePrimalDecoration:
             case kIROp_BackwardDerivativePrimalContextDecoration:
             case kIROp_BackwardDerivativePrimalReturnDecoration:
+            case kIROp_PrimalSubstituteDecoration:
             case kIROp_AutoDiffOriginalValueDecoration:
             case kIROp_UserDefinedBackwardDerivativeDecoration:
             case kIROp_IntermediateContextFieldDifferentialTypeDecoration:

--- a/tests/autodiff/primal-substitute-4.slang
+++ b/tests/autodiff/primal-substitute-4.slang
@@ -1,0 +1,46 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type -g0
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBufferPrimal
+RWStructuredBuffer<float> outputBufferPrimal;
+
+//TEST_INPUT:ubuffer(data=[1 2 3 4], stride=4):name=gradBuffer
+RWStructuredBuffer<float> gradBuffer;
+
+struct BufferWithGrad
+{
+    RWStructuredBuffer<float> primal;
+    RWStructuredBuffer<float> grad;
+
+    [Differentiable]
+    void add(float value) { primal[0] = primal[0] + detach(value); }
+
+    [PrimalSubstituteOf(add), Differentiable]
+    void add_subst(float value)
+    {
+    }
+
+    [BackwardDerivativeOf(add)]
+    void add_bwd(inout DifferentialPair<float> d)
+    {
+        d = diffPair(d.p, grad[0]);
+    }
+}
+
+[Differentiable]
+void diffCall(BufferWithGrad result)
+{
+    result.add(1.0f);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    BufferWithGrad bg = {outputBufferPrimal, gradBuffer};
+    diffCall(bg); 
+    bwd_diff(diffCall)(bg);
+
+    // CHECK: type: float
+    // CHECK-NEXT: 1.0
+    // CHECK-NEXT: 0.0
+}

--- a/tests/diagnostics/autodiff-primal-substitute.slang
+++ b/tests/diagnostics/autodiff-primal-substitute.slang
@@ -1,0 +1,44 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target spirv -entry computeMain -stage compute
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBufferPrimal
+RWStructuredBuffer<float> outputBufferPrimal;
+
+//TEST_INPUT:ubuffer(data=[1 2 3 4], stride=4):name=gradBuffer
+RWStructuredBuffer<float> gradBuffer;
+
+struct BufferWithGrad
+{
+    RWStructuredBuffer<float> primal;
+    RWStructuredBuffer<float> grad;
+
+    [Differentiable]
+    void add(float value) { primal[0] = primal[0] + detach(value); }
+
+    // check for diagnostic:
+    // CHECK-DAG: ([[# @LINE+1]]): error 31158
+    [PrimalSubstituteOf(add)]
+    void add_subst(float value)
+    {
+    }
+
+    [BackwardDerivativeOf(add)]
+    void add_bwd(inout DifferentialPair<float> d)
+    {
+        d = diffPair(d.p, grad[0]);
+    }
+}
+
+[Differentiable]
+void diffCall(BufferWithGrad result)
+{
+    result.add(1.0f);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    BufferWithGrad bg = {outputBufferPrimal, gradBuffer};
+    diffCall(bg); 
+    bwd_diff(diffCall)(bg);
+}


### PR DESCRIPTION
Adds a check to make sure the primal-substitute function is atleast as differentiable as the primal function. 

This avoids cases where the auto-diff apparatus expects a differentiable function (from front-end checking), but gets a non-differentiable one instead.

Fixes: #5867 