### PR TITLE
Import into the scope of the import decl, rather than module scope

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -10178,7 +10178,12 @@ void SemanticsDeclHeaderVisitor::visitImportDecl(ImportDecl* decl)
     // the module's scope.
 
     auto name = decl->moduleNameAndLoc.name;
-    auto scope = getModuleDecl(decl)->ownedScope;
+
+    // We should import the module into the same scope as the decl.
+    // Note that if the module consists of multiple source files, the scope of the module may not
+    // correspond to the scope of this import declaration, since the module scope gets overwritten
+    // each time a new source file is parsed into it.
+    auto scope = decl->scope;
 
     // Try to load a module matching the name
     auto importedModule = findOrImportModule(


### PR DESCRIPTION
When a module consists of multiple source files, the module scope gets over-written for each source file that's parsed into the module.
On the other hand, SemanticsVisitor::importModuleIntoScope will import into the scope of the module corresponding to the import declaration. The result is that if you do something like the following, where source1.slang contains an import statement, then the imported module will get imported into the module scope corresponding to source2.slang.

    slangc source1.slang source2.slang # 1 module from 2 source files

This patch fixes this problem by importing into the scope of the import statement, rather than the scope of the corresponding module, since that may have been overwritten.

This closes #6221.