### PR TITLE
Add test for visibility in translation unit with multiple source files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,10 @@ jobs:
            --platform "${{matrix.platform}}" \
            --config "${{matrix.config}}" \
            --skip-file tests/expected-example-failure-github.txt
+      - name: Run slangc tests
+        if: steps.filter.outputs.should-run == 'true' && matrix.platform != 'wasm'
+        run: |
+          PATH=$bin_dir:$PATH tools/slangc-test/test.sh
       - name: Test Slang via glsl
         if: steps.filter.outputs.should-run == 'true' && matrix.full-gpu-tests && matrix.platform != 'wasm'
         run: |

--- a/tools/slangc-test/multiple-source-files/A.slang
+++ b/tools/slangc-test/multiple-source-files/A.slang
@@ -1,0 +1,3 @@
+module A;
+
+public int test() { return 1; }

--- a/tools/slangc-test/multiple-source-files/source1.slang
+++ b/tools/slangc-test/multiple-source-files/source1.slang
@@ -1,0 +1,6 @@
+module source1;
+
+import A;
+
+[shader("compute")]
+void computeMain1() { int a = test(); }

--- a/tools/slangc-test/multiple-source-files/source2.slang
+++ b/tools/slangc-test/multiple-source-files/source2.slang
@@ -1,0 +1,2 @@
+[shader("compute")]
+void computeMain2() { }

--- a/tools/slangc-test/test.sh
+++ b/tools/slangc-test/test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -e
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+summary=()
+failure_count=0
+test_count=0
+
+test() {
+  local name
+  local exit_code
+  name=$1
+  shift
+  pushd "$name" 1>/dev/null 2>&1
+  echo "Running $name..."
+  "$@" || exit_code=$?
+  summary=("${summary[@]}" "$name: ")
+  if [[ $exit_code -eq 0 ]]; then
+    summary=("${summary[@]}" "  success")
+  else
+    summary=("${summary[@]}" "  failure (exit code: $exit_code)")
+  fi
+  popd 1>/dev/null 2>&1
+  echo
+  test_count=$((test_count + 1))
+}
+
+cd "${script_dir}"
+
+test multiple-source-files slangc source1.slang source2.slang
+
+echo ""
+echo "Summary: "
+echo
+for line in "${summary[@]}"; do
+  printf '  %s\n' "$line"
+done
+echo ""
+echo "$failure_count failed, out of $test_count tests"
+if [[ $failure_count -ne 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
I didn't find a way to trigger this via the Slang API, so add a `slangc` test instead.
- Add `slangc` tests to CI
- Add a `slangc` test for issue #6221

This closes #6221.