### PR TITLE
Add WGSL to list of formats supporting multiple entry points

### DIFF
--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -3509,6 +3509,7 @@ SlangResult OptionsParser::_parse(int argc, char const* const* argv)
                     case CodeGenTarget::MetalLib:
                     case CodeGenTarget::MetalLibAssembly:
                     case CodeGenTarget::Metal:
+                    case CodeGenTarget::WGSL:
                         rawOutput.isWholeProgram = true;
                         break;
                     case CodeGenTarget::SPIRV:

--- a/tests/wgsl/multiple-entrypoints.slang
+++ b/tests/wgsl/multiple-entrypoints.slang
@@ -1,0 +1,28 @@
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl
+
+//WGSL-DAG: @builtin(global_invocation_id)
+//WGSL-DAG: @compute
+
+[shader("compute")]
+void main_compute(uint3 dtid : SV_DispatchThreadID) 
+{
+    // Empty compute shader
+}
+
+//WGSL-DAG: @builtin(front_facing)
+//WGSL-DAG: @fragment
+
+[shader("fragment")]
+float4 main_fragment(bool isFront : SV_IsFrontFace) : SV_Target 
+{
+    return float4(1,1,1,1);
+}
+
+//WGSL-DAG: @builtin(vertex_index)
+//WGSL-DAG: @vertex
+
+[shader("vertex")]
+float4 main_vertex(uint vertexID : SV_VertexID) : SV_Position 
+{
+    return float4(1,1,1,1);
+}


### PR DESCRIPTION
The WGSL code generator already supports this, it just wasn't possible to use it with `slangc`, e.g.:

```sh
cd examples/wgpu-html5
slangc -target wgsl -entry vertexMain -stage vertex -entry fragmentMain -stage fragment -o shader.wgsl shader.slang
```

Fixes #6322