### PR TITLE
Make -output-includes look like cl /showIncludes

### DIFF
--- a/source/compiler-core/slang-diagnostic-sink.cpp
+++ b/source/compiler-core/slang-diagnostic-sink.cpp
@@ -150,7 +150,7 @@ static void formatDiagnostic(
     DiagnosticSink::Flags flags,
     StringBuilder& outBuilder)
 {
-    if (flags & DiagnosticSink::Flag::HumaneLoc)
+    if (diagnostic.severity != Severity::OutputIncludes && (flags & DiagnosticSink::Flag::HumaneLoc))
     {
         outBuilder << humaneLoc.pathInfo.foundPath;
         outBuilder << "(";
@@ -584,7 +584,7 @@ bool DiagnosticSink::diagnoseImpl(
     DiagnosticInfo const& info,
     const UnownedStringSlice& formattedMessage)
 {
-    if (info.severity >= Severity::Error)
+    if (info.severity >= Severity::Error && info.severity != Severity::OutputIncludes)
     {
         m_errorCount++;
     }
@@ -603,7 +603,7 @@ bool DiagnosticSink::diagnoseImpl(
         m_parentSink->diagnoseImpl(info, formattedMessage);
     }
 
-    if (info.severity >= Severity::Fatal)
+    if (info.severity >= Severity::Fatal && info.severity != Severity::OutputIncludes)
     {
         // TODO: figure out a better policy for aborting compilation
         std::string message(formattedMessage.begin(), formattedMessage.end());
@@ -669,7 +669,7 @@ void DiagnosticSink::diagnoseRaw(Severity severity, char const* message)
 
 void DiagnosticSink::diagnoseRaw(Severity severity, const UnownedStringSlice& message)
 {
-    if (severity >= Severity::Error)
+    if (severity >= Severity::Error && severity != Severity::OutputIncludes )
     {
         m_errorCount++;
     }
@@ -692,7 +692,7 @@ void DiagnosticSink::diagnoseRaw(Severity severity, const UnownedStringSlice& me
         m_parentSink->diagnoseRaw(severity, message);
     }
 
-    if (severity >= Severity::Fatal)
+    if (severity >= Severity::Fatal && severity != Severity::OutputIncludes)
     {
         // TODO: figure out a better policy for aborting compilation
         SLANG_ABORT_COMPILATION("");

--- a/source/compiler-core/slang-diagnostic-sink.h
+++ b/source/compiler-core/slang-diagnostic-sink.h
@@ -18,7 +18,8 @@ enum class Severity
     Warning,
     Error,
     Fatal,
-    Internal
+    Internal,
+    OutputIncludes,
 };
 
 // Make sure that the slang.h severity constants match those defined here
@@ -48,6 +49,8 @@ inline const char* getSeverityName(Severity severity)
         return "fatal error";
     case Severity::Internal:
         return "internal error";
+    case Severity::OutputIncludes:
+        return "Note";
     default:
         return "unknown error";
     }

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -94,7 +94,7 @@ DIAGNOSTIC(
 DIAGNOSTIC(-1, Note, declaredHere, "declared here")
 DIAGNOSTIC(-1, Note, seeOtherDeclarationOf, "see other declaration of '$0'")
 DIAGNOSTIC(-1, Note, seePreviousDeclarationOf, "see previous declaration of '$0'")
-DIAGNOSTIC(-1, Note, includeOutput, "include $0")
+DIAGNOSTIC(-1, OutputIncludes, includeOutput, "including file: $0")
 DIAGNOSTIC(-1, Note, genericSignatureTried, "see declaration of $0")
 DIAGNOSTIC(-1, Note, entryPointCandidate, "see candidate declaration for entry point '$0'")
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3101,7 +3101,7 @@ static void _outputInclude(SourceFile* sourceFile, Index depth, DiagnosticSink* 
     // useful to output the full path for example
 
     const PathInfo& pathInfo = sourceFile->getPathInfo();
-    buf << "'" << pathInfo.foundPath << "'";
+    buf << pathInfo.uniqueIdentity;
 
     // TODO(JS)?
     // You might want to know where this include was from.


### PR DESCRIPTION
This change makes it easier to integrate slang into C++ build systems (e.g. ninja) that know how to rebuild files when their dependencies change.

The code is obviously terrible and punches through abstractions because I don't know the codebase well enough to do a good job of this, but this works as a proof of concept.

Demo:

```
> cat compute_shader.slang
#include "blah.slang"
[rest of the shader trimmed]
> cat build.ninja
rule slangc
    command = slangc $in -I. -output-includes -target metal -stage compute -o $out
    deps = msvc
build compute_shader.metal: slangc compute_shader.slang
> ninja
[1/1] slangc compute_shader.slang -I. -output-includes -target metal -stage compute -o compute_shader.metal
> ninja
ninja: no work to do.
> touch blah.slang
> ninja -f shader.ninja
[1/1] slangc compute_shader.slang -I. -output-includes -target metal -stage compute -o compute_shader.metal
> ninja -f shader.ninja
[1/1] slangc compute_shader.slang -I. -output-includes -target metal -stage compute -o compute_shader.metal
```

You can see ninja rebuilds compute_shader.slang when I touch blah.slang, which is what this patch enables. (It keeps rebuilding it because slangc doesn't update the output file's modtime, but that should be fixed separately)