### PR TITLE
Fix compilation on musl libc targets

### DIFF
--- a/source/core/slang-stream.cpp
+++ b/source/core/slang-stream.cpp
@@ -5,6 +5,7 @@
 #include "slang-io.h"
 #include "slang-process.h"
 
+#include <stdio.h>
 #include <thread>
 
 namespace Slang


### PR DESCRIPTION
The musl libc replacement removed fopen64, fgetpos64, and other 64-bit variants because it's 64-bit only. However, it does have the following in its headers:

    #define fgetpos64 fgetpos

Just importing `<stdio.h>` is enough to get slang compiling on musl systems like Alpine Linux.

Fixes #6330.