### PR TITLE
Fix crash when handling uninitialized resource type

### DIFF
--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -2551,11 +2551,7 @@ DIAGNOSTIC(
     attemptToQuerySizeOfUnsizedArray,
     "cannot obtain the size of an unsized array.")
 
-DIAGNOSTIC(
-    56003,
-    Error,
-    useOfUninitializedResouceType,
-    "use of uninitialized resource type '$0'.")
+DIAGNOSTIC(56003, Error, useOfUninitializedResourceType, "use of uninitialized resource type '$0'.")
 
 // Metal
 DIAGNOSTIC(

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -2551,7 +2551,7 @@ DIAGNOSTIC(
     attemptToQuerySizeOfUnsizedArray,
     "cannot obtain the size of an unsized array.")
 
-DIAGNOSTIC(56003, Error, useOfUninitializedResourceType, "use of uninitialized resource type '$0'.")
+DIAGNOSTIC(56003, Error, useOfUninitializedResourceType, "use of uninitialized opaque type '$0'.")
 
 // Metal
 DIAGNOSTIC(

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -2551,6 +2551,12 @@ DIAGNOSTIC(
     attemptToQuerySizeOfUnsizedArray,
     "cannot obtain the size of an unsized array.")
 
+DIAGNOSTIC(
+    56003,
+    Error,
+    useOfUninitializedResouceType,
+    "use of uninitialized resource type '$0'.")
+
 // Metal
 DIAGNOSTIC(
     56100,

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -2551,7 +2551,7 @@ DIAGNOSTIC(
     attemptToQuerySizeOfUnsizedArray,
     "cannot obtain the size of an unsized array.")
 
-DIAGNOSTIC(56003, Error, useOfUninitializedResourceType, "use of uninitialized opaque type '$0'.")
+DIAGNOSTIC(56003, Error, useOfUninitializedOpaqueType, "use of uninitialized opaque type '$0'.")
 
 // Metal
 DIAGNOSTIC(

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -2551,7 +2551,7 @@ DIAGNOSTIC(
     attemptToQuerySizeOfUnsizedArray,
     "cannot obtain the size of an unsized array.")
 
-DIAGNOSTIC(56003, Error, useOfUninitializedOpaqueHandle, "use of uninitialized opaque handle '$0'.")
+DIAGNOSTIC(56003, Fatal, useOfUninitializedOpaqueHandle, "use of uninitialized opaque handle '$0'.")
 
 // Metal
 DIAGNOSTIC(

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -2551,7 +2551,7 @@ DIAGNOSTIC(
     attemptToQuerySizeOfUnsizedArray,
     "cannot obtain the size of an unsized array.")
 
-DIAGNOSTIC(56003, Error, useOfUninitializedOpaqueType, "use of uninitialized opaque type '$0'.")
+DIAGNOSTIC(56003, Error, useOfUninitializedOpaqueHandle, "use of uninitialized opaque handle '$0'.")
 
 // Metal
 DIAGNOSTIC(

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -91,7 +91,10 @@ LegalVal LegalVal::wrappedBuffer(LegalVal const& baseVal, LegalElementWrapping c
 
 //
 
-IRTypeLegalizationContext::IRTypeLegalizationContext(TargetProgram* target, IRModule* inModule, DiagnosticSink* sink)
+IRTypeLegalizationContext::IRTypeLegalizationContext(
+    TargetProgram* target,
+    IRModule* inModule,
+    DiagnosticSink* sink)
 {
     targetProgram = target;
 
@@ -2052,11 +2055,14 @@ static LegalVal legalizeUndefined(IRTypeLegalizationContext* context, IRInst* in
 {
     if (auto structType = as<IRStructType>(inst->getFullType()))
     {
-        for (auto field: structType->getFields())
+        for (auto field : structType->getFields())
         {
             if (isResourceType(field->getFieldType()))
             {
-                context->m_sink->diagnose(field, Diagnostics::useOfUninitializedResouceType, field->getFieldType());
+                context->m_sink->diagnose(
+                    field,
+                    Diagnostics::useOfUninitializedResourceType,
+                    field->getFieldType());
                 SLANG_ABORT_COMPILATION("use of uninitialized resource type");
             }
         }
@@ -4064,7 +4070,10 @@ struct IRResourceTypeLegalizationContext : IRTypeLegalizationContext
 //
 struct IRExistentialTypeLegalizationContext : IRTypeLegalizationContext
 {
-    IRExistentialTypeLegalizationContext(TargetProgram* target, IRModule* module, DiagnosticSink* sink)
+    IRExistentialTypeLegalizationContext(
+        TargetProgram* target,
+        IRModule* module,
+        DiagnosticSink* sink)
         : IRTypeLegalizationContext(target, module, sink)
     {
     }

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -2064,7 +2064,6 @@ static LegalVal legalizeUndefined(IRTypeLegalizationContext* context, IRInst* in
             loc = getDiagnosticPos(containerType);
 
         context->m_sink->diagnose(loc, Diagnostics::useOfUninitializedOpaqueHandle, opaqueType);
-        SLANG_ABORT_COMPILATION("use of uninitialized resource type");
     }
     return LegalVal();
 }

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -2058,11 +2058,12 @@ static LegalVal legalizeUndefined(IRTypeLegalizationContext* context, IRInst* in
     {
         auto opaqueType = opaqueTypes[0];
         auto containerType = opaqueTypes.getCount() > 1 ? opaqueTypes[1] : opaqueType;
+        SourceLoc loc = findBestSourceLocFromUses(inst);
 
-        context->m_sink->diagnose(
-            containerType,
-            Diagnostics::useOfUninitializedResourceType,
-            opaqueType);
+        if (!loc.isValid())
+            loc = getDiagnosticPos(containerType);
+
+        context->m_sink->diagnose(loc, Diagnostics::useOfUninitializedOpaqueType, opaqueType);
         SLANG_ABORT_COMPILATION("use of uninitialized resource type");
     }
     return LegalVal();

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -2053,19 +2053,17 @@ static LegalVal coerceToLegalType(IRTypeLegalizationContext* context, LegalType 
 
 static LegalVal legalizeUndefined(IRTypeLegalizationContext* context, IRInst* inst)
 {
-    if (auto structType = as<IRStructType>(inst->getFullType()))
+    List<IRType*> opaqueTypes;
+    if (isOpaqueType(inst->getFullType(), opaqueTypes))
     {
-        for (auto field : structType->getFields())
-        {
-            if (isResourceType(field->getFieldType()))
-            {
-                context->m_sink->diagnose(
-                    field,
-                    Diagnostics::useOfUninitializedResourceType,
-                    field->getFieldType());
-                SLANG_ABORT_COMPILATION("use of uninitialized resource type");
-            }
-        }
+        auto opaqueType = opaqueTypes[0];
+        auto containerType = opaqueTypes.getCount() > 1 ? opaqueTypes[1] : opaqueType;
+
+        context->m_sink->diagnose(
+            containerType,
+            Diagnostics::useOfUninitializedResourceType,
+            opaqueType);
+        SLANG_ABORT_COMPILATION("use of uninitialized resource type");
     }
     return LegalVal();
 }

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -2063,7 +2063,7 @@ static LegalVal legalizeUndefined(IRTypeLegalizationContext* context, IRInst* in
         if (!loc.isValid())
             loc = getDiagnosticPos(containerType);
 
-        context->m_sink->diagnose(loc, Diagnostics::useOfUninitializedOpaqueType, opaqueType);
+        context->m_sink->diagnose(loc, Diagnostics::useOfUninitializedOpaqueHandle, opaqueType);
         SLANG_ABORT_COMPILATION("use of uninitialized resource type");
     }
     return LegalVal();

--- a/source/slang/slang-legalize-types.cpp
+++ b/source/slang/slang-legalize-types.cpp
@@ -198,6 +198,27 @@ bool isResourceType(IRType* type)
     return false;
 }
 
+bool isOpaqueType(IRType* type, List<IRType*>& opaqueTypes)
+{
+    if (isResourceType(type))
+    {
+        opaqueTypes.add(type);
+        return true;
+    }
+
+    if (auto structType = as<IRStructType>(type))
+    {
+        for (auto field : structType->getFields())
+        {
+            if (isOpaqueType(field->getFieldType(), opaqueTypes))
+            {
+                opaqueTypes.add(type);
+                return true;
+            }
+        }
+    }
+    return false;
+}
 // Helper wrapper function around isResourceType that checks if the given
 // type is a pointer to a resource type or a physical storage buffer.
 bool isPointerToResourceType(IRType* type)

--- a/source/slang/slang-legalize-types.cpp
+++ b/source/slang/slang-legalize-types.cpp
@@ -217,7 +217,29 @@ bool isOpaqueType(IRType* type, List<IRType*>& opaqueTypes)
             }
         }
     }
+
+    if (auto arrayType = as<IRArrayTypeBase>(type))
+    {
+        if (isOpaqueType(arrayType->getElementType(), opaqueTypes))
+        {
+            opaqueTypes.add(type);
+            return true;
+        }
+    }
+
     return false;
+}
+
+SourceLoc findBestSourceLocFromUses(IRInst* inst)
+{
+    for (auto use = inst->firstUse; use; use = use->nextUse)
+    {
+        auto user = use->getUser();
+        if (user->sourceLoc.isValid())
+            return user->sourceLoc;
+    }
+
+    return SourceLoc();
 }
 // Helper wrapper function around isResourceType that checks if the given
 // type is a pointer to a resource type or a physical storage buffer.

--- a/source/slang/slang-legalize-types.cpp
+++ b/source/slang/slang-legalize-types.cpp
@@ -254,7 +254,7 @@ SourceLoc findBestSourceLocFromUses(IRInst* inst)
             return user->sourceLoc;
     }
 
-    return SourceLoc();
+    return inst->sourceLoc;
 }
 // Helper wrapper function around isResourceType that checks if the given
 // type is a pointer to a resource type or a physical storage buffer.

--- a/source/slang/slang-legalize-types.cpp
+++ b/source/slang/slang-legalize-types.cpp
@@ -227,6 +227,21 @@ bool isOpaqueType(IRType* type, List<IRType*>& opaqueTypes)
         }
     }
 
+    if (auto tupleType = as<IRTupleTypeBase>(type))
+    {
+        for (UInt i = 0; i < tupleType->getOperandCount(); i++)
+        {
+            if (auto elementType = as<IRType>(tupleType->getOperand(i)))
+            {
+                if (isOpaqueType(elementType, opaqueTypes))
+                {
+                    opaqueTypes.add(type);
+                    return true;
+                }
+            }
+        }
+    }
+
     return false;
 }
 

--- a/source/slang/slang-legalize-types.h
+++ b/source/slang/slang-legalize-types.h
@@ -705,6 +705,7 @@ bool isResourceType(IRType* type);
 
 bool isOpaqueType(IRType* type, List<IRType*>& opaqueTypes);
 
+SourceLoc findBestSourceLocFromUses(IRInst* inst);
 } // namespace Slang
 
 #endif

--- a/source/slang/slang-legalize-types.h
+++ b/source/slang/slang-legalize-types.h
@@ -703,6 +703,7 @@ void legalizeEmptyTypes(TargetProgram* target, IRModule* module, DiagnosticSink*
 
 bool isResourceType(IRType* type);
 
+bool isOpaqueType(IRType* type, List<IRType*>& opaqueTypes);
 
 } // namespace Slang
 

--- a/source/slang/slang-legalize-types.h
+++ b/source/slang/slang-legalize-types.h
@@ -592,8 +592,9 @@ struct IRTypeLegalizationContext
     IRBuilder* builder;
     TargetProgram* targetProgram;
     IRBuilder builderStorage;
+    DiagnosticSink* m_sink;
 
-    IRTypeLegalizationContext(TargetProgram* target, IRModule* inModule);
+    IRTypeLegalizationContext(TargetProgram* target, IRModule* inModule, DiagnosticSink* sink);
 
     // When inserting new globals, put them before this one.
     IRInst* insertBeforeGlobal = nullptr;

--- a/tests/diagnostics/uninitialized-resource-type.slang
+++ b/tests/diagnostics/uninitialized-resource-type.slang
@@ -1,11 +1,16 @@
-//DIAGNOSTIC_TEST:SIMPLE: -target hlsl
+//DIAGNOSTIC_TEST:SIMPLE: -target hlsl -DTEST_1
+//DIAGNOSTIC_TEST:SIMPLE: -target hlsl -DTEST_2
 
 SamplerState sampler;
 
 struct Foo
 {
     bool sample_bar = false;
+#ifdef TEST_1
     Texture2D<float4> bar = {};
+#elif defined(TEST_2)
+    Texture2D<float4> bar[2];
+#endif
 };
 
 struct Result
@@ -18,7 +23,11 @@ Result process(in Foo foo)
     Result result = {};
 
     if (foo.sample_bar) {
+#ifdef TEST_1
         result.color = foo.bar.Sample(sampler, float2(0.0, 0.0));
+#elif defined(TEST_2)
+        result.color = foo.bar[0].Sample(sampler, float2(0.0, 0.0));
+#endif
     }
 
     return result;

--- a/tests/diagnostics/uninitialized-resource-type.slang
+++ b/tests/diagnostics/uninitialized-resource-type.slang
@@ -1,0 +1,33 @@
+//DIAGNOSTIC_TEST:SIMPLE: -target hlsl
+
+SamplerState sampler;
+
+struct Foo
+{
+    bool sample_bar = false;
+    Texture2D<float4> bar = {};
+};
+
+struct Result
+{
+    float4 color = float4(0.0);
+};
+
+Result process(in Foo foo)
+{
+    Result result = {};
+
+    if (foo.sample_bar) {
+        result.color = foo.bar.Sample(sampler, float2(0.0, 0.0));
+    }
+
+    return result;
+}
+
+[shader("compute")]
+[numthreads(8, 8, 1)]
+float4 cs_main(uint3 thread_id : SV_DispatchThreadID) {
+    Foo foo;
+    const let result = process(foo);
+    return result.color;
+}

--- a/tests/diagnostics/uninitialized-resource-type.slang.1.expected
+++ b/tests/diagnostics/uninitialized-resource-type.slang.1.expected
@@ -1,0 +1,9 @@
+result code = -1
+standard error = {
+tests/diagnostics/uninitialized-resource-type.slang(40): warning 41016: use of uninitialized variable 'foo'
+    const let result = process(foo);
+                              ^
+tests/diagnostics/uninitialized-resource-type.slang(40): error 56003: use of uninitialized opaque type 'array<Texture2D,2>'.
+    const let result = process(foo);
+                              ^
+}

--- a/tests/diagnostics/uninitialized-resource-type.slang.1.expected
+++ b/tests/diagnostics/uninitialized-resource-type.slang.1.expected
@@ -3,7 +3,7 @@ standard error = {
 tests/diagnostics/uninitialized-resource-type.slang(40): warning 41016: use of uninitialized variable 'foo'
     const let result = process(foo);
                               ^
-tests/diagnostics/uninitialized-resource-type.slang(40): error 56003: use of uninitialized opaque type 'array<Texture2D,2>'.
+tests/diagnostics/uninitialized-resource-type.slang(40): error 56003: use of uninitialized opaque handle 'array<Texture2D,2>'.
     const let result = process(foo);
                               ^
 }

--- a/tests/diagnostics/uninitialized-resource-type.slang.expected
+++ b/tests/diagnostics/uninitialized-resource-type.slang.expected
@@ -1,0 +1,9 @@
+result code = -1
+standard error = {
+tests/diagnostics/test1.slang(31): warning 41016: use of uninitialized variable 'foo'
+    const let result = process(foo);
+                              ^
+tests/diagnostics/test1.slang(5): error 56003: use of uninitialized resource type 'Texture2D'.
+struct Foo
+       ^~~
+}

--- a/tests/diagnostics/uninitialized-resource-type.slang.expected
+++ b/tests/diagnostics/uninitialized-resource-type.slang.expected
@@ -1,9 +1,9 @@
 result code = -1
 standard error = {
-tests/diagnostics/uninitialized-resource-type.slang(35): warning 41016: use of uninitialized variable 'foo'
+tests/diagnostics/uninitialized-resource-type.slang(40): warning 41016: use of uninitialized variable 'foo'
     const let result = process(foo);
                               ^
-tests/diagnostics/uninitialized-resource-type.slang(35): error 56003: use of uninitialized opaque type 'Texture2D'.
+tests/diagnostics/uninitialized-resource-type.slang(40): error 56003: use of uninitialized opaque handle 'Texture2D'.
     const let result = process(foo);
                               ^
 }

--- a/tests/diagnostics/uninitialized-resource-type.slang.expected
+++ b/tests/diagnostics/uninitialized-resource-type.slang.expected
@@ -1,9 +1,9 @@
 result code = -1
 standard error = {
-tests/diagnostics/uninitialized-resource-type.slang(31): warning 41016: use of uninitialized variable 'foo'
+tests/diagnostics/uninitialized-resource-type.slang(35): warning 41016: use of uninitialized variable 'foo'
     const let result = process(foo);
                               ^
-tests/diagnostics/uninitialized-resource-type.slang(5): error 56003: use of uninitialized opaque type 'Texture2D'.
-struct Foo
-       ^~~
+tests/diagnostics/uninitialized-resource-type.slang(35): error 56003: use of uninitialized opaque type 'Texture2D'.
+    const let result = process(foo);
+                              ^
 }

--- a/tests/diagnostics/uninitialized-resource-type.slang.expected
+++ b/tests/diagnostics/uninitialized-resource-type.slang.expected
@@ -1,9 +1,9 @@
 result code = -1
 standard error = {
-tests/diagnostics/test1.slang(31): warning 41016: use of uninitialized variable 'foo'
+tests/diagnostics/uninitialized-resource-type.slang(31): warning 41016: use of uninitialized variable 'foo'
     const let result = process(foo);
                               ^
-tests/diagnostics/test1.slang(5): error 56003: use of uninitialized resource type 'Texture2D'.
+tests/diagnostics/uninitialized-resource-type.slang(5): error 56003: use of uninitialized opaque type 'Texture2D'.
 struct Foo
        ^~~
 }


### PR DESCRIPTION
close #6328.

When declare a var with struct type, if the struct has a resource type field and it doesn't provide explicit constructor, because slang won't implicit construct such variable at declare site if user doesn't explicitly call the initializer list, we should report the resource type field uninitialized as an error to prevent future possible crash when legalize any use of such variable.