### PR TITLE
Disallow only resources in constant buffers in parameterblocks on metal

### DIFF
--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -2564,7 +2564,7 @@ DIAGNOSTIC(
     56101,
     Error,
     resourceTypesInConstantBufferInParameterBlockNotAllowedOnMetal,
-    "nesting a 'ConstantBuffer' containing resource typews inside a 'ParameterBlock' is not "
+    "nesting a 'ConstantBuffer' containing resource types inside a 'ParameterBlock' is not "
     "supported on Metal, please use 'ParameterBlock' instead.")
 
 DIAGNOSTIC(57001, Warning, spirvOptFailed, "spirv-opt failed. $0")

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -2560,6 +2560,12 @@ DIAGNOSTIC(
     constantBufferInParameterBlockNotAllowedOnMetal,
     "nested 'ConstantBuffer' inside a 'ParameterBlock' is not supported on Metal, use "
     "'ParameterBlock' instead.")
+DIAGNOSTIC(
+    56101,
+    Error,
+    resourceTypesInConstantBufferInParameterBlockNotAllowedOnMetal,
+    "nesting a 'ConstantBuffer' containing resource typews inside a 'ParameterBlock' is not "
+    "supported on Metal, please use 'ParameterBlock' instead.")
 
 DIAGNOSTIC(57001, Warning, spirvOptFailed, "spirv-opt failed. $0")
 DIAGNOSTIC(57002, Error, unknownPatchConstantParameter, "unknown patch constant parameter '$0'.")

--- a/tests/diagnostics/nested-constant-buffer-in-parameter-block.slang
+++ b/tests/diagnostics/nested-constant-buffer-in-parameter-block.slang
@@ -1,20 +1,33 @@
 //TEST:SIMPLE(filecheck=CHECK): -target metal
 
-struct S
+struct T
 {
-    // CHECK-DAG: ([[# @LINE+1]]): error 56100:
-    ConstantBuffer<int> cb;
+    RWStructuredBuffer<int> buf;
+}
+    
+struct U
+{
+    ConstantBuffer<T> t;
 }
 
-ParameterBlock<S> s;
+struct S
+{
+    ConstantBuffer<RWStructuredBuffer<int>> cb;
+}
 
-// CHECK-DAG: ([[# @LINE+1]]): error 56100:
-ParameterBlock<ConstantBuffer<int>> s2;
+// CHECK-DAG: ([[# @LINE+1]]): error 56101:
+ParameterBlock<S> s1;
+
+// CHECK-DAG: ([[# @LINE+1]]): error 56101:
+ParameterBlock<U> s2;
+
+// CHECK-DAG: ([[# @LINE+1]]): error 56101:
+ParameterBlock<ConstantBuffer<RWStructuredBuffer<int>>> s3;
 
 RWStructuredBuffer<int> outputBuffer;
 
 [numthreads(1,1,1)]
 void kernelMain()
 {
-    outputBuffer[0] = s.cb + s2;
+    outputBuffer[0] = s1.cb[0] + s2.t.buf[0] + s3[0];
 }

--- a/tools/slang-unit-test/unit-test-metal-parameter-block-constant-buffer.cpp
+++ b/tools/slang-unit-test/unit-test-metal-parameter-block-constant-buffer.cpp
@@ -1,0 +1,133 @@
+// unit-test-ptr-layout.cpp
+
+#include "slang-com-ptr.h"
+#include "slang.h"
+#include "unit-test/slang-unit-test.h"
+
+#include <stdlib.h>
+
+using namespace Slang;
+
+SLANG_UNIT_TEST(metalConstantBufferInParameterBlockLayout)
+{
+    const char* testSource = R"(
+        struct T 
+        {
+            float4 m0;
+            float m1;
+            float3 m2;
+        };
+
+        ParameterBlock<ConstantBuffer<T>> params;
+    )";
+
+    ComPtr<slang::IGlobalSession> globalSession;
+    SLANG_CHECK(slang_createGlobalSession(SLANG_API_VERSION, globalSession.writeRef()) == SLANG_OK);
+
+    slang::TargetDesc targetDesc = {};
+    targetDesc.format = SLANG_METAL;
+    targetDesc.profile = globalSession->findProfile("metal");
+
+    slang::SessionDesc sessionDesc = {};
+    sessionDesc.targetCount = 1;
+    sessionDesc.targets = &targetDesc;
+
+    ComPtr<slang::ISession> session;
+    SLANG_CHECK(globalSession->createSession(sessionDesc, session.writeRef()) == SLANG_OK);
+
+    ComPtr<slang::IBlob> diagnosticBlob;
+    auto module = session->loadModuleFromSourceString(
+        "test",
+        "test.slang",
+        testSource,
+        diagnosticBlob.writeRef());
+    SLANG_CHECK(module != nullptr);
+
+    auto testBody = [&]()
+    {
+        auto reflection = module->getLayout();
+
+        // Collect our layouts
+        auto paramBlockType = reflection->findTypeByName("ParameterBlock<ConstantBuffer<T>>");
+        SLANG_CHECK(paramBlockType != nullptr);
+        auto paramBlockLayout = reflection->getTypeLayout(paramBlockType);
+        SLANG_CHECK(paramBlockLayout != nullptr);
+        auto cbufferLayout = paramBlockLayout->getElementTypeLayout();
+        SLANG_CHECK(cbufferLayout != nullptr);
+        auto structLayout = cbufferLayout->getElementTypeLayout();
+        SLANG_CHECK(structLayout != nullptr);
+
+        // Check offsets follow constant buffer rules (uniform alignment)
+        // m0 : float4 should be at offset 0
+        // m1 : float  should be at offset 16 (after float4)
+        // m2 : float3 should be at offset 32 (aligned to 16-byte boundary)
+        SLANG_CHECK(structLayout->getFieldCount() == 3);
+        SLANG_CHECK(structLayout->getFieldByIndex(0)->getOffset() == 0);
+        SLANG_CHECK(structLayout->getFieldByIndex(1)->getOffset() == 16);
+        SLANG_CHECK(structLayout->getFieldByIndex(2)->getOffset() == 32);
+    };
+
+    testBody();
+}
+
+SLANG_UNIT_TEST(metalArgumentBufferLayout)
+{
+    const char* testSource = R"(
+        struct T 
+        {
+            float4 m0;
+            float m1;
+            float3 m2;
+        };
+
+        // Using ParameterBlock directly without ConstantBuffer wrapper
+        ParameterBlock<T> params;
+    )";
+
+    ComPtr<slang::IGlobalSession> globalSession;
+    SLANG_CHECK(slang_createGlobalSession(SLANG_API_VERSION, globalSession.writeRef()) == SLANG_OK);
+
+    slang::TargetDesc targetDesc = {};
+    targetDesc.format = SLANG_METAL;
+    targetDesc.profile = globalSession->findProfile("metal");
+
+    slang::SessionDesc sessionDesc = {};
+    sessionDesc.targetCount = 1;
+    sessionDesc.targets = &targetDesc;
+
+    ComPtr<slang::ISession> session;
+    SLANG_CHECK(globalSession->createSession(sessionDesc, session.writeRef()) == SLANG_OK);
+
+    ComPtr<slang::IBlob> diagnosticBlob;
+    auto module = session->loadModuleFromSourceString(
+        "test",
+        "test.slang",
+        testSource,
+        diagnosticBlob.writeRef());
+    SLANG_CHECK(module != nullptr);
+
+    auto testBody = [&]()
+    {
+        auto reflection = module->getLayout();
+
+        // Collect our layouts
+        auto paramBlockType = reflection->findTypeByName("ParameterBlock<T>");
+        SLANG_CHECK(paramBlockType != nullptr);
+        auto paramBlockLayout = reflection->getTypeLayout(paramBlockType);
+        SLANG_CHECK(paramBlockLayout != nullptr);
+        auto structLayout = paramBlockLayout->getElementTypeLayout();
+        SLANG_CHECK(structLayout != nullptr);
+
+        // Check that offsets follow Metal argument buffer rules
+        // Fields should have 0 offset and meaningful binding indices
+        SLANG_CHECK(structLayout->getFieldCount() == 3);
+        SLANG_CHECK(structLayout->getFieldByIndex(0)->getOffset() == 0);
+        SLANG_CHECK(structLayout->getFieldByIndex(1)->getOffset() == 0);
+        SLANG_CHECK(structLayout->getFieldByIndex(2)->getOffset() == 0);
+        SLANG_CHECK(structLayout->getFieldByIndex(0)->getBindingIndex() == 0);
+        SLANG_CHECK(structLayout->getFieldByIndex(1)->getBindingIndex() == 1);
+        SLANG_CHECK(structLayout->getFieldByIndex(2)->getBindingIndex() == 2);
+    };
+
+    testBody();
+}


### PR DESCRIPTION
This loosens the check on constant buffers in parameter blocks in metal

Disallow only resources in constant buffers in parameterblocks on metal

closes https://github.com/shader-slang/slang/issues/6200