### PR TITLE
Migrate slang-test away from deprecated Slang API

### DIFF
--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1336,8 +1336,7 @@ static RenderApiFlags _getAvailableRenderApiFlags(TestContext* context)
 
                 // Check that the session has the generic C/CPP compiler availability - which is all
                 // we should need for CPU target
-                if (SLANG_SUCCEEDED(spSessionCheckPassThroughSupport(
-                        context->getSession(),
+                if (SLANG_SUCCEEDED(context->getSession()->checkPassThroughSupport(
                         SLANG_PASS_THROUGH_GENERIC_C_CPP)))
                 {
                     availableRenderApiFlags |= RenderApiFlags(1) << int(apiType);
@@ -2838,7 +2837,7 @@ static TestResult generateExpectedOutput(
             TypeTextUtil::findCompileTargetFromName(args[targetIndex + 1].getUnownedSlice());
 
         // Check the session supports it. If not we ignore it
-        if (SLANG_FAILED(spSessionCheckCompileTargetSupport(context->getSession(), target)))
+        if (SLANG_FAILED(context->getSession()->checkCompileTargetSupport(target)))
         {
             return TestResult::Ignored;
         }
@@ -4749,7 +4748,7 @@ SlangResult innerMain(int argc, char** argv)
                 continue;
             }
 
-            if (SLANG_SUCCEEDED(spSessionCheckPassThroughSupport(session, passThru)))
+            if (SLANG_SUCCEEDED(session->checkPassThroughSupport(passThru)))
             {
                 context.availableBackendFlags |= PassThroughFlags(1) << int(i);
 

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -16,8 +16,6 @@ thread_local int slangTestThreadIndex = 0;
 
 TestContext::TestContext()
 {
-    m_session = nullptr;
-
     /// if we are testing on arm, debug, we may want to increase the connection timeout
 #if (SLANG_PROCESSOR_ARM || SLANG_PROCESSOR_ARM_64) && defined(_DEBUG)
     // 10 mins(!). This seems to be the order of time needed for timeout on a CI ARM test system on
@@ -87,12 +85,7 @@ Result TestContext::init(const char* inExePath)
 {
     SlangGlobalSessionDesc desc = {};
     desc.enableGLSL = true;
-    slang_createGlobalSession2(&desc, &m_session);
-
-    if (!m_session)
-    {
-        return SLANG_FAIL;
-    }
+    slang::createGlobalSession(&desc, m_session.writeRef());
     exePath = inExePath;
     SLANG_RETURN_ON_FAIL(TestToolUtil::getExeDirectoryPath(inExePath, exeDirectoryPath));
     SLANG_RETURN_ON_FAIL(TestToolUtil::getDllDirectoryPath(inExePath, dllDirectoryPath));
@@ -109,10 +102,6 @@ TestContext::~TestContext()
         m_languageServerConnection->sendCall(
             LanguageServerProtocol::ExitParams::methodName,
             JSONValue::makeInt(0));
-    }
-    if (m_session)
-    {
-        spDestroySession(m_session);
     }
 }
 

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -201,7 +201,7 @@ protected:
     Slang::List<TestReporter*> m_reporters;
     Slang::List<TestRequirements*> m_testRequirements = nullptr;
 
-    SlangSession* m_session;
+    Slang::ComPtr<SlangSession> m_session;
 
     Slang::Dictionary<Slang::String, SharedLibraryTool> m_sharedLibTools;
 


### PR DESCRIPTION
This helps to address #4760.