### PR TITLE
Enable Hull shader test for SPIRV

### DIFF
--- a/tests/hlsl/simple-hull-shader-1.slang
+++ b/tests/hlsl/simple-hull-shader-1.slang
@@ -21,7 +21,7 @@ struct HsOut
 struct HscOut
 {
     float EdgeTessFactor[4] : SV_TessFactor;
-    float InsideTessFactor[1] : SV_InsideTessFactor;
+    float InsideTessFactor[2] : SV_InsideTessFactor;
     uint instanceId;
 };
 

--- a/tests/hlsl/simple-hull-shader-1.slang
+++ b/tests/hlsl/simple-hull-shader-1.slang
@@ -1,6 +1,5 @@
 //TEST:SIMPLE(filecheck=HLSL):-target hlsl -entry hullMain -stage hull -allow-glsl
 //TEST:SIMPLE(filecheck=GLSL):-target glsl -entry hullMain -stage hull -allow-glsl
-// Currently SPIR-V fails to compile this hull shader (#4914)
 //TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry hullMain -stage hull -allow-glsl
 
 //HLSL: hullMain
@@ -22,7 +21,7 @@ struct HsOut
 struct HscOut
 {
     float EdgeTessFactor[4] : SV_TessFactor;
-    float InsideTessFactor[2] : SV_InsideTessFactor;
+    float InsideTessFactor[1] : SV_InsideTessFactor;
     uint instanceId;
 };
 

--- a/tests/hlsl/simple-hull-shader-1.slang
+++ b/tests/hlsl/simple-hull-shader-1.slang
@@ -1,7 +1,7 @@
 //TEST:SIMPLE(filecheck=HLSL):-target hlsl -entry hullMain -stage hull -allow-glsl
 //TEST:SIMPLE(filecheck=GLSL):-target glsl -entry hullMain -stage hull -allow-glsl
 // Currently SPIR-V fails to compile this hull shader (#4914)
-//DISABLE_TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry hullMain -stage hull -allow-glsl
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry hullMain -stage hull -allow-glsl
 
 //HLSL: hullMain
 
@@ -9,9 +9,9 @@
 //GLSL-DAG: location = 1
 //GLSL-DAG: location = 2
 
-//SPIRV-DAG: location 0
-//SPIRV-DAG: location 1
-//SPIRV-DAG: location 2
+//SPIRV-DAG: OpDecorate {{.*}} Location 0
+//SPIRV-DAG: OpDecorate {{.*}} Location 1
+//SPIRV-DAG: OpDecorate {{.*}} Location 2
 
 struct HsOut
 {


### PR DESCRIPTION
One of Hull shader tests was disabled.
Git history doesn't tell much of why it was disabled.

This commit fixes a minor mistake and enables the test for SPIRV.