### PR TITLE
Add WGSL support for `WaveGetLaneIndex` and `WaveGetLaneCount`

### DIFF
--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -6409,6 +6409,7 @@ public property uint gl_SubgroupID
 
 public property uint gl_SubgroupSize
 {
+    [ForceInline]
     [require(cpp_cuda_glsl_hlsl_spirv_wgsl, subgroup_basic)]
     get {
         setupExtForSubgroupBasicBuiltIn();
@@ -6418,6 +6419,7 @@ public property uint gl_SubgroupSize
 
 public property uint gl_SubgroupInvocationID
 {
+    [ForceInline]
     [require(cpp_cuda_glsl_hlsl_spirv_wgsl, subgroup_basic)]
     get {
         setupExtForSubgroupBasicBuiltIn();

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -20568,7 +20568,7 @@ ${
 // In order to support this approach, we need intrinsics that
 // can magically fetch the binding information for a resource.
 //
-// TODO: These operations are kind of *screaming* for us tohlsl.m
+// TODO: These operations are kind of *screaming* for us to
 // have a built-in `interface` that all of the opaque resource
 // types conform to, so that we can define builtins that work
 // for any resource type.

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -6,6 +6,9 @@ typedef uint UINT;
 __intrinsic_op($(kIROp_RequireGLSLExtension))
 void __requireGLSLExtension(String extensionName);
 
+__intrinsic_op($(kIROp_ImplicitSystemValue))
+uint __implicitSystemValue(String systemValueName);
+
 //@public:
 /// Represents an interface for buffer data layout.
 /// This interface is used as a base for defining specific data layouts for buffers.
@@ -15036,7 +15039,8 @@ uint WaveActiveCountBits(bool value)
 __glsl_extension(GL_KHR_shader_subgroup_basic)
 __spirv_version(1.3)
 [NonUniformReturn]
-[require(cuda_glsl_hlsl_spirv, subgroup_basic)]
+[ForceInline]
+[require(cuda_glsl_hlsl_spirv_wgsl, subgroup_basic)]
 uint WaveGetLaneCount()
 {
     __target_switch
@@ -15050,6 +15054,8 @@ uint WaveGetLaneCount()
             OpCapability GroupNonUniform;
             result:$$uint = OpLoad builtin(SubgroupSize:uint)
         };
+    case wgsl:
+        return __implicitSystemValue("SV_WaveLaneCount");
     }
 }
 
@@ -15057,7 +15063,8 @@ uint WaveGetLaneCount()
 __glsl_extension(GL_KHR_shader_subgroup_basic)
 __spirv_version(1.3)
 [NonUniformReturn]
-[require(cuda_glsl_hlsl_spirv, subgroup_basic)]
+[ForceInline]
+[require(cuda_glsl_hlsl_spirv_wgsl, subgroup_basic)]
 uint WaveGetLaneIndex()
 {
     __target_switch
@@ -15071,6 +15078,8 @@ uint WaveGetLaneIndex()
             OpCapability GroupNonUniform;
             result:$$uint = OpLoad builtin(SubgroupLocalInvocationId:uint)
         };
+    case wgsl:
+        return __implicitSystemValue("SV_WaveLaneIndex");
     }
 }
 
@@ -20554,7 +20563,7 @@ ${
 // In order to support this approach, we need intrinsics that
 // can magically fetch the binding information for a resource.
 //
-// TODO: These operations are kind of *screaming* for us to
+// TODO: These operations are kind of *screaming* for us tohlsl.m
 // have a built-in `interface` that all of the opaque resource
 // types conform to, so that we can define builtins that work
 // for any resource type.

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -6,6 +6,9 @@ typedef uint UINT;
 __intrinsic_op($(kIROp_RequireGLSLExtension))
 void __requireGLSLExtension(String extensionName);
 
+__intrinsic_op($(kIROp_RequireWGSLExtension))
+void __requireWGSLExtension(String extensionName);
+
 __intrinsic_op($(kIROp_ImplicitSystemValue))
 uint __implicitSystemValue(String systemValueName);
 
@@ -15055,6 +15058,7 @@ uint WaveGetLaneCount()
             result:$$uint = OpLoad builtin(SubgroupSize:uint)
         };
     case wgsl:
+        __requireWGSLExtension("subgroups");
         return __implicitSystemValue("SV_WaveLaneCount");
     }
 }
@@ -15079,6 +15083,7 @@ uint WaveGetLaneIndex()
             result:$$uint = OpLoad builtin(SubgroupLocalInvocationId:uint)
         };
     case wgsl:
+        __requireWGSLExtension("subgroups");
         return __implicitSystemValue("SV_WaveLaneIndex");
     }
 }

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -3059,6 +3059,11 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
         {
             break;
         }
+    case kIROp_RequireWGSLExtension:
+        {
+            emitRequireExtension(inst);
+            break;
+        }
     default:
         diagnoseUnhandledInst(inst);
         break;

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -3055,10 +3055,6 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
             emitOperand(as<IRGlobalValueRef>(inst)->getOperand(0), getInfo(EmitOp::General));
             break;
         }
-    case kIROp_ImplicitSystemValue:
-        {
-            break;
-        }
     case kIROp_RequireWGSLExtension:
         {
             emitRequireExtension(inst);

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -3055,6 +3055,10 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
             emitOperand(as<IRGlobalValueRef>(inst)->getOperand(0), getInfo(EmitOp::General));
             break;
         }
+    case kIROp_ImplicitSystemValue:
+        {
+            break;
+        }
     default:
         diagnoseUnhandledInst(inst);
         break;

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -414,18 +414,18 @@ public:
     /// Emit type attributes that should appear after, e.g., a `struct` keyword
     void emitPostKeywordTypeAttributes(IRInst* inst) { emitPostKeywordTypeAttributesImpl(inst); }
 
-    virtual void emitMemoryQualifiers(IRInst* /*varInst*/){};
+    virtual void emitMemoryQualifiers(IRInst* /*varInst*/) {};
     virtual void emitStructFieldAttributes(
         IRStructType* /* structType */,
         IRStructField* /* field */
-    ){};
+    ) {};
     void emitInterpolationModifiers(IRInst* varInst, IRType* valueType, IRVarLayout* layout);
     void emitMeshShaderModifiers(IRInst* varInst);
     virtual void emitPackOffsetModifier(
         IRInst* /*varInst*/,
         IRType* /*valueType*/,
         IRPackOffsetDecoration* /*decoration*/
-    ){};
+    ) {};
 
 
     /// Emit modifiers that should apply even for a declaration of an SSA temporary.
@@ -677,6 +677,8 @@ protected:
     // Emit the argument list (including paranthesis) in a `CallInst`
     void _emitCallArgList(IRCall* call, int startingOperandIndex = 1);
     virtual void emitCallArg(IRInst* arg);
+
+    virtual void emitRequireExtension(IRInst* inst) { SLANG_UNUSED(inst); }
 
     String _generateUniqueName(const UnownedStringSlice& slice);
 

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -414,18 +414,18 @@ public:
     /// Emit type attributes that should appear after, e.g., a `struct` keyword
     void emitPostKeywordTypeAttributes(IRInst* inst) { emitPostKeywordTypeAttributesImpl(inst); }
 
-    virtual void emitMemoryQualifiers(IRInst* /*varInst*/) {};
+    virtual void emitMemoryQualifiers(IRInst* /*varInst*/){};
     virtual void emitStructFieldAttributes(
         IRStructType* /* structType */,
         IRStructField* /* field */
-    ) {};
+    ){};
     void emitInterpolationModifiers(IRInst* varInst, IRType* valueType, IRVarLayout* layout);
     void emitMeshShaderModifiers(IRInst* varInst);
     virtual void emitPackOffsetModifier(
         IRInst* /*varInst*/,
         IRType* /*valueType*/,
         IRPackOffsetDecoration* /*decoration*/
-    ) {};
+    ){};
 
 
     /// Emit modifiers that should apply even for a declaration of an SSA temporary.

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -47,7 +47,7 @@ void GLSLSourceEmitter::_beforeComputeEmitProcessInstruction(
     //
     // Handle cases where "require" IR operations exist in the function body and are required
     // as entry point decorations.
-    auto entryPoints = getReferencingEntryPoints(m_referencingEntryPoints, parentFunc);
+    auto entryPoints = m_callGraph.getReferencingEntryPoints(parentFunc);
     if (entryPoints == nullptr)
         return;
 
@@ -81,7 +81,7 @@ void GLSLSourceEmitter::_beforeComputeEmitProcessInstruction(
 
 void GLSLSourceEmitter::beforeComputeEmitActions(IRModule* module)
 {
-    buildEntryPointReferenceGraph(this->m_referencingEntryPoints, module);
+    m_callGraph.build(module);
 
     IRBuilder builder(module);
     for (auto globalInst : module->getGlobalInsts())

--- a/source/slang/slang-emit-glsl.h
+++ b/source/slang/slang-emit-glsl.h
@@ -4,6 +4,7 @@
 
 #include "slang-emit-c-like.h"
 #include "slang-extension-tracker.h"
+#include "slang-ir-call-graph.h"
 
 namespace Slang
 {
@@ -178,7 +179,7 @@ protected:
 
     void _beforeComputeEmitProcessInstruction(IRInst* parentFunc, IRInst* inst, IRBuilder& builder);
 
-    Dictionary<IRInst*, HashSet<IRFunc*>> m_referencingEntryPoints;
+    CallGraph m_callGraph;
 
     RefPtr<ShaderExtensionTracker> m_glslExtensionTracker;
 };

--- a/source/slang/slang-emit-wgsl.cpp
+++ b/source/slang/slang-emit-wgsl.cpp
@@ -1696,4 +1696,9 @@ void WGSLSourceEmitter::handleRequiredCapabilitiesImpl(IRInst* inst)
     }
 }
 
+void WGSLSourceEmitter::emitRequireExtension(IRInst* inst)
+{
+    _requireExtension(as<IRRequireWGSLExtension>(inst)->getExtensionName());
+}
+
 } // namespace Slang

--- a/source/slang/slang-emit-wgsl.h
+++ b/source/slang/slang-emit-wgsl.h
@@ -65,6 +65,8 @@ public:
 
     virtual RefObject* getExtensionTracker() SLANG_OVERRIDE { return m_extensionTracker; }
 
+    virtual void emitRequireExtension(IRInst* inst) SLANG_OVERRIDE;
+
 private:
     bool maybeEmitSystemSemantic(IRInst* inst);
 

--- a/source/slang/slang-ir-call-graph.cpp
+++ b/source/slang/slang-ir-call-graph.cpp
@@ -2,7 +2,6 @@
 
 #include "slang-ir-clone.h"
 #include "slang-ir-insts.h"
-#include "slang-ir.h"
 
 namespace Slang
 {

--- a/source/slang/slang-ir-call-graph.cpp
+++ b/source/slang/slang-ir-call-graph.cpp
@@ -2,6 +2,7 @@
 
 #include "slang-ir-clone.h"
 #include "slang-ir-insts.h"
+#include "slang-ir.h"
 
 namespace Slang
 {
@@ -56,10 +57,13 @@ void buildEntryPointReferenceGraph(
         }
         switch (inst->getOp())
         {
+        // Only these instruction types are registered to the entry point reference graph.
         case kIROp_GlobalParam:
         case kIROp_SPIRVAsmOperandBuiltinVar:
+        case kIROp_ImplicitSystemValue:
             registerEntryPointReference(entryPoint, inst);
             break;
+
         case kIROp_Block:
         case kIROp_SPIRVAsm:
             for (auto child : inst->getChildren())

--- a/source/slang/slang-ir-call-graph.h
+++ b/source/slang/slang-ir-call-graph.h
@@ -14,4 +14,19 @@ HashSet<IRFunc*>* getReferencingEntryPoints(
     Dictionary<IRInst*, HashSet<IRFunc*>>& m_referencingEntryPoints,
     IRInst* inst);
 
+
+/*
+class FunctionCallGraph
+{
+public:
+    const HashSet<IRFunc*>* getReferencingFunctions(IRInst* inst) const;
+    const HashSet<IRCall*>* getFunctionCalls(IRFunc* func) const;
+
+private:
+    Dictionary<IRInst*, HashSet<IRFunc*>> m_referencingFunctions;
+    Dictionary<IRFunc*, HashSet<IRCall*>> m_functionCalls;
+};
+*/
+
+
 } // namespace Slang

--- a/source/slang/slang-ir-call-graph.h
+++ b/source/slang/slang-ir-call-graph.h
@@ -1,32 +1,41 @@
+#pragma once
+
 #include "slang-ir-clone.h"
 #include "slang-ir-insts.h"
 
 namespace Slang
 {
 
-void buildEntryPointReferenceGraph(
-    Dictionary<IRInst*, HashSet<IRFunc*>>& referencingEntryPoints,
-    IRModule* module,
-    Dictionary<IRInst*, HashSet<IRFunc*>>* referencingFunctions = nullptr,
-    Dictionary<IRFunc*, HashSet<IRCall*>>* referencingCalls = nullptr);
-
-HashSet<IRFunc*>* getReferencingEntryPoints(
-    Dictionary<IRInst*, HashSet<IRFunc*>>& m_referencingEntryPoints,
-    IRInst* inst);
-
-
-/*
-class FunctionCallGraph
+struct CallGraph
 {
 public:
+    CallGraph() = default;
+    explicit CallGraph(IRModule* module);
+
+    void build(IRModule* module);
+
+    /// Retrieves the set of entry points that invoke the given instruction in its call graph.
+    /// Returns nullptr if the instruction has no referencing entry points.
+    const HashSet<IRFunc*>* getReferencingEntryPoints(IRInst* inst) const;
+
+    /// Retrieves the set of functions that directly contain the given instruction in their body.
+    /// Returns nullptr if the instruction is not referenced by any function.
     const HashSet<IRFunc*>* getReferencingFunctions(IRInst* inst) const;
-    const HashSet<IRCall*>* getFunctionCalls(IRFunc* func) const;
+
+    /// Retrieves the set of calls that invoke the given function.
+    /// Returns nullptr if the function is never called.
+    const HashSet<IRCall*>* getReferencingCalls(IRFunc* func) const;
+
+
+    const Dictionary<IRInst*, HashSet<IRFunc*>>& getReferencingEntryPointsMap() const;
 
 private:
-    Dictionary<IRInst*, HashSet<IRFunc*>> m_referencingFunctions;
-    Dictionary<IRFunc*, HashSet<IRCall*>> m_functionCalls;
-};
-*/
+    void registerInstructionReference(IRInst* inst, IRFunc* entryPoint, IRFunc* parentFunc);
+    void registerCallReference(IRFunc* func, IRCall* call);
 
+    Dictionary<IRInst*, HashSet<IRFunc*>> m_referencingEntryPoints;
+    Dictionary<IRInst*, HashSet<IRFunc*>> m_referencingFunctions;
+    Dictionary<IRFunc*, HashSet<IRCall*>> m_referencingCalls;
+};
 
 } // namespace Slang

--- a/source/slang/slang-ir-call-graph.h
+++ b/source/slang/slang-ir-call-graph.h
@@ -14,7 +14,7 @@ public:
 
     void build(IRModule* module);
 
-    /// Retrieves the set of entry points that invoke the given instruction in its call graph.
+    /// Retrieves the set of entry points that transitively invoke the given instruction.
     /// Returns nullptr if the instruction has no referencing entry points.
     const HashSet<IRFunc*>* getReferencingEntryPoints(IRInst* inst) const;
 
@@ -25,7 +25,6 @@ public:
     /// Retrieves the set of calls that invoke the given function.
     /// Returns nullptr if the function is never called.
     const HashSet<IRCall*>* getReferencingCalls(IRFunc* func) const;
-
 
     const Dictionary<IRInst*, HashSet<IRFunc*>>& getReferencingEntryPointsMap() const;
 

--- a/source/slang/slang-ir-call-graph.h
+++ b/source/slang/slang-ir-call-graph.h
@@ -6,7 +6,9 @@ namespace Slang
 
 void buildEntryPointReferenceGraph(
     Dictionary<IRInst*, HashSet<IRFunc*>>& referencingEntryPoints,
-    IRModule* module);
+    IRModule* module,
+    Dictionary<IRInst*, HashSet<IRFunc*>>* referencingFunctions = nullptr,
+    Dictionary<IRFunc*, HashSet<IRCall*>>* referencingCalls = nullptr);
 
 HashSet<IRFunc*>* getReferencingEntryPoints(
     Dictionary<IRInst*, HashSet<IRFunc*>>& m_referencingEntryPoints,

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -671,6 +671,11 @@ INST(RequireComputeDerivative, RequireComputeDerivative, 0, 0)
 INST(StaticAssert, StaticAssert, 2, 0)
 INST(Printf, Printf, 1, 0)
 
+// Built-in inputs/outputs(system values) that are implicitly added.
+// These must be passed in as entry function parameters for the target language(eg. WGSL and Metal), but
+// do not explicitly originate from decorated entry point function parameters in Slang.
+INST(ImplicitSystemValue, ImplicitSystemValue, 1, 0)
+
 // Quad control execution modes.
 INST(RequireMaximallyReconverges, RequireMaximallyReconverges, 0, 0)
 INST(RequireQuadDerivatives, RequireQuadDerivatives, 0, 0)

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -667,6 +667,7 @@ INST(discard, discard, 0, 0)
 
 INST(RequirePrelude, RequirePrelude, 1, 0)
 INST(RequireGLSLExtension, RequireGLSLExtension, 1, 0)
+INST(RequireWGSLExtension, RequireWGSLExtension, 1, 0)
 INST(RequireComputeDerivative, RequireComputeDerivative, 0, 0)
 INST(StaticAssert, StaticAssert, 2, 0)
 INST(Printf, Printf, 1, 0)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -3479,6 +3479,16 @@ struct IRRequireGLSLExtension : IRInst
     }
 };
 
+struct IRRequireWGSLExtension : IRInst
+{
+    IR_LEAF_ISA(RequireWGSLExtension)
+    UnownedStringSlice getExtensionName()
+    {
+        return as<IRStringLit>(getOperand(0))->getStringSlice();
+    }
+};
+;
+
 struct IRRequireComputeDerivative : IRInst
 {
     IR_LEAF_ISA(RequireComputeDerivative)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -3499,6 +3499,15 @@ struct IRStaticAssert : IRInst
     IR_LEAF_ISA(StaticAssert)
 };
 
+struct IRImplicitSystemValue : IRInst
+{
+    IR_LEAF_ISA(ImplicitSystemValue)
+    UnownedStringSlice getSystemValueName()
+    {
+        return as<IRStringLit>(getOperand(0))->getStringSlice();
+    }
+};
+
 struct IREmbeddedDownstreamIR : IRInst
 {
     IR_LEAF_ISA(EmbeddedDownstreamIR)

--- a/source/slang/slang-ir-legalize-system-values.cpp
+++ b/source/slang/slang-ir-legalize-system-values.cpp
@@ -2,7 +2,6 @@
 
 #include "core/slang-dictionary.h"
 #include "core/slang-string.h"
-#include "slang-diagnostics.h"
 #include "slang-ir-insts.h"
 #include "slang-ir-legalize-varying-params.h"
 
@@ -13,14 +12,15 @@ class ImplicitSystemValueLegalizationContext
 {
 public:
     ImplicitSystemValueLegalizationContext(
-        const Dictionary<IRInst*, HashSet<IRFunc*>>& entryPointReferenceGraph,
+        IRModule* module,
         const Dictionary<IRInst*, HashSet<IRFunc*>>& functionReferenceGraph,
         const Dictionary<IRFunc*, HashSet<IRCall*>>& callReferenceGraph,
         const List<IRImplicitSystemValue*>& implicitSystemValueInstructions)
-        : m_entryPointReferenceGraph(entryPointReferenceGraph)
-        , m_functionReferenceGraph(functionReferenceGraph)
+        : m_functionReferenceGraph(functionReferenceGraph)
         , m_callReferenceGraph(callReferenceGraph)
         , m_implicitSystemValueInstructions(implicitSystemValueInstructions)
+        , m_builder(module)
+        , m_paramType(m_builder.getUIntType())
     {
     }
 
@@ -31,7 +31,7 @@ public:
             // for (auto entryPoint : *m_entryPointReferenceGraph.tryGetValue(implicitSysVal))
             for (auto entryPoint : *m_functionReferenceGraph.tryGetValue(implicitSysVal))
             {
-                auto param = getOrCreateSystemValueParam(entryPoint, implicitSysVal);
+                auto param = getOrCreateSystemValueVariable(entryPoint, implicitSysVal);
                 implicitSysVal->replaceUsesWith(param);
                 implicitSysVal->removeAndDeallocate();
             }
@@ -39,8 +39,14 @@ public:
     }
 
 private:
+    //
+    // A function (including entry points) must have at most one parameter for each system value
+    // semantic type.
+    //
+    // This map tracks the association between system value semantics and their corresponding
+    // function parameters.
+    //
     using SystemValueParamMap = Dictionary<SystemValueSemanticName, IRParam*>;
-
     SystemValueParamMap& getParamMap(IRFunc* func)
     {
         if (auto map = m_functionMap.tryGetValue(func))
@@ -56,6 +62,7 @@ private:
 
     //
     // Attempt to retrieve a parameter for a specific function and system value type combination.
+    // Returns nullptr if parameter has not been created.
     //
     IRParam* tryGetParam(IRFunc* func, SystemValueSemanticName systemValueName)
     {
@@ -69,6 +76,12 @@ private:
         }
     }
 
+    struct ModifyCallWorkItem
+    {
+        IRCall* call;
+        IRFunc* caller;
+    };
+
     //
     // Implicit system values are "global variables" and can be used anywhere within the source
     // code. The implementation target(i.e WGSL) however requires system values, aka built-in
@@ -78,123 +91,88 @@ private:
     // they are explicitly passed as parameters from the entry point to the relevant functions. This
     // means adding new parameters to the function signatures to include the required system values.
     //
-    struct CreateParamWorkItem
+    // This function traverses the call graph of a function that contains an implicit system value
+    // instruction, and adds necessary parameters to pass in the system value variable up to the
+    // entry point function. Returns work items of calls that need to be modified as a result of
+    // adding the parameters.
+    //
+    List<ModifyCallWorkItem> createFunctionParams(
+        IRFunc* func,
+        SystemValueSemanticName systemValueName,
+        UnownedStringSlice systemValueString)
     {
-        /// Function to add a new param to.
-        IRFunc* func;
+        List<IRFunc*> functionWorkList;
+        List<ModifyCallWorkItem> modifyCallWorkList;
 
-        /// System value semantic info.
-        SystemValueSemanticName systemValueName;
-        UnownedStringSlice systemValueString;
+        const auto addWorkItems = [&](const HashSet<IRCall*>& calls)
+        {
+            for (auto call : calls)
+            {
+                for (auto caller : m_functionReferenceGraph.getValue(call))
+                {
+                    // The caller(of a function that was added a parameter) also requires a
+                    // new parameter to pass in the system value variable to the callee.
+                    functionWorkList.add(caller);
 
-        Index paramIndex;
-    };
+                    // The call needs to be modified to add the new parameter.
+                    modifyCallWorkList.add({call, caller});
+                }
+            }
+        };
+
+        // Implicit system values are currently only being used for subgroup size and
+        // subgroup invocation id.
+        SLANG_ASSERT(
+            (systemValueName == SystemValueSemanticName::WaveLaneCount) ||
+            (systemValueName == SystemValueSemanticName::WaveLaneIndex));
+
+        const auto createParamWork = [&](IRFunc* func)
+        {
+            // If the parameter for system value type has not been created, create it.
+            if (!tryGetParam(func, systemValueName))
+            {
+                m_builder.setInsertBefore(func->getFirstBlock()->getFirstOrdinaryInst());
+
+                auto param = m_builder.emitParam(m_paramType);
+
+                // Add system value semantic decoration if adding to entry point.
+                if (func->findDecoration<IREntryPointDecoration>())
+                {
+                    m_builder.addSemanticDecoration(param, systemValueString);
+                }
+
+                getParamMap(func).add(systemValueName, param);
+
+                if (auto calls = m_callReferenceGraph.tryGetValue(func))
+                {
+                    addWorkItems(*calls);
+                }
+            }
+        };
+
+        functionWorkList.add(func);
+        for (Index i = 0; i < functionWorkList.getCount(); i++)
+        {
+            createParamWork(functionWorkList[i]);
+        }
+
+        return modifyCallWorkList;
+    }
 
     //
     // In addition to modifying the function signatures, we need to ensure the calls to the modified
     // function include the system value variable.
     //
-    struct ModifyCallWorkItem
+    void modifyCalls(
+        const List<ModifyCallWorkItem>& workItems,
+        SystemValueSemanticName systemValueName)
     {
-        /// Call to modify.
-        IRCall* call;
-
-        /// Parameter to add to the call.
-        // IRParam* paramToAdd;
-        Index paramIndex;
-    };
-
-    //
-    // Creates a new parameter for functions that require the implicit system value.
-    // Returns work items of calls that need to be modified as a result of adding the parameters.
-    //
-    List<ModifyCallWorkItem> createFunctionParams(
-        IRFunc* parentFunc,
-        IRImplicitSystemValue* implicitSysVal)
-    {
-        // Work list for parameter creation work.
-        List<CreateParamWorkItem> createParamWorkList;
-
-        // Work list for call replacement work.
-        List<ModifyCallWorkItem> modifyCallWorkList;
-
-        // List to store new parameters that represent system value variables - used to propagate
-        // the param variables from parameter creation work to call replacement work.
-        List<IRParam*> addedParams;
-
-        const auto systemValueName =
-            convertSystemValueSemanticNameToEnum(implicitSysVal->getSystemValueName());
-        SLANG_ASSERT(systemValueName != SystemValueSemanticName::Unknown);
-
-        createParamWorkList.add(
-            {parentFunc,
-             systemValueName,
-             implicitSysVal->getSystemValueName(),
-             addedParams.getCount()});
-        addedParams.add(nullptr);
-
-        const auto addWorkItems = [&](const HashSet<IRCall*>& calls, CreateParamWorkItem workItem)
+        for (const auto workItem : workItems)
         {
-            for (auto call : calls)
-            {
-                for (auto callerFunc : m_functionReferenceGraph.getValue(call))
-                {
-                    // The caller(of a function that was added a parameter) also requires a
-                    // new parameter to pass in the system value variable to the callee.
-                    workItem.func = callerFunc;
-                    workItem.paramIndex = addedParams.getCount();
-                    createParamWorkList.add(workItem);
-                    addedParams.add(nullptr);
+            auto call = workItem.call;
+            auto param = tryGetParam(workItem.caller, systemValueName);
+            SLANG_ASSERT(param);
 
-                    // The call needs to be modified to add the new parameter.
-                    modifyCallWorkList.add({call, workItem.paramIndex});
-                }
-            }
-        };
-
-        IRBuilder builder(parentFunc);
-
-        // The new system value parameter's type is harcoded.
-        //
-        // Implicit system values are currently only being used for subgroup size and
-        // subgroup invocation id, both of which are 32-bit unsigned.
-        SLANG_ASSERT(
-            (systemValueName == SystemValueSemanticName::WaveLaneCount) ||
-            (systemValueName == SystemValueSemanticName::WaveLaneIndex));
-        auto paramType = builder.getUIntType();
-
-        const auto createParamWork = [&](CreateParamWorkItem workItem)
-        {
-            // If the parameter for system value type has not been created, create it.
-            if (!tryGetParam(workItem.func, workItem.systemValueName))
-            {
-                builder.setInsertBefore(workItem.func->getFirstBlock()->getFirstOrdinaryInst());
-
-                auto param = builder.emitParam(paramType);
-
-                // Add system value semantic decoration if adding to entry point.
-                if (parentFunc->findDecoration<IREntryPointDecoration>())
-                {
-                    builder.addSemanticDecoration(param, workItem.systemValueString);
-                }
-
-                getParamMap(workItem.func).add(systemValueName, param);
-                addedParams[workItem.paramIndex] = param;
-
-                if (auto calls = m_callReferenceGraph.tryGetValue(workItem.func))
-                {
-                    addWorkItems(*calls, workItem);
-                }
-            }
-        };
-
-        for (Index i = 0; i < createParamWorkList.getCount(); i++)
-        {
-            createParamWork(createParamWorkList[i]);
-        }
-
-        const auto modifyCallWork = [&](IRCall* call, IRParam* param)
-        {
             List<IRInst*> newCallParams;
             for (auto arg : call->getArgsList())
             {
@@ -202,129 +180,61 @@ private:
             }
             newCallParams.add(param);
 
-            IRBuilder newBuilder(call);
-            newBuilder.setInsertAfter(call);
-            auto newCall = newBuilder.emitCallInst(paramType, call->getCallee(), newCallParams);
+            m_builder.setInsertAfter(call);
+            auto newCall = m_builder.emitCallInst(m_paramType, call->getCallee(), newCallParams);
 
-            // call->replaceUsesWith(newCall);
-            // call->transferDecorationsTo(newCall);
-            // call->removeAndDeallocate();
-        };
-
-        for (const auto workItem : modifyCallWorkList)
-        {
-            modifyCallWork(workItem.call, addedParams[workItem.paramIndex]);
+            call->replaceUsesWith(newCall);
+            call->transferDecorationsTo(newCall);
+            call->removeAndDeallocate();
         }
-
-        return modifyCallWorkList;
     }
 
-    IRParam* getOrCreateSystemValueParam(IRFunc* parentFunc, IRImplicitSystemValue* implicitSysVal)
+    IRParam* getOrCreateSystemValueVariable(
+        IRFunc* parentFunc,
+        IRImplicitSystemValue* implicitSysVal)
     {
-        const auto systemValueName =
+        auto systemValueName =
             convertSystemValueSemanticNameToEnum(implicitSysVal->getSystemValueName());
         SLANG_ASSERT(systemValueName != SystemValueSemanticName::Unknown);
 
+        // If parameter for the specific function and system value type combination was already
+        // created, return it directly.
         if (auto param = tryGetParam(parentFunc, systemValueName))
         {
             return param;
         }
 
-        createFunctionParams(parentFunc, implicitSysVal);
+        // Create new parameters for the relevant functions up to the entry point function.
+        const auto callWorkItems =
+            createFunctionParams(parentFunc, systemValueName, implicitSysVal->getSystemValueName());
+
+        // Modify related function calls to account for the new parameters.
+        modifyCalls(callWorkItems, systemValueName);
+
         return tryGetParam(parentFunc, systemValueName);
     }
 
-    // void replaceCalls() {}
-
-    IRParam* getOrCreateSystemValueParam2(IRFunc* parentFunc, IRImplicitSystemValue* implicitSysVal)
-    {
-        if (!m_functionMap.containsKey(parentFunc))
-        {
-            m_functionMap.add(parentFunc, SystemValueParamMap());
-        }
-        auto systemValueParamMap = m_functionMap.tryGetValue(parentFunc);
-
-        const auto systemValueName =
-            convertSystemValueSemanticNameToEnum(implicitSysVal->getSystemValueName());
-        SLANG_ASSERT(systemValueName != SystemValueSemanticName::Unknown);
-
-        IRParam* param;
-        const auto paramPtr = systemValueParamMap->tryGetValue(systemValueName);
-        if (paramPtr == nullptr)
-        {
-            IRBuilder builder(parentFunc);
-            builder.setInsertBefore(parentFunc->getFirstBlock()->getFirstOrdinaryInst());
-
-            // The new system value parameter's type is harcoded.
-            //
-            // Implicit system values are currently only being used for subgroup size and subgroup
-            // invocation id, both of which are 32-bit unsigned.
-            SLANG_ASSERT(
-                (systemValueName == SystemValueSemanticName::WaveLaneCount) ||
-                (systemValueName == SystemValueSemanticName::WaveLaneIndex));
-            auto paramType = builder.getUIntType();
-            param = builder.emitParam(paramType);
-
-
-            if (parentFunc->findDecoration<IREntryPointDecoration>())
-            {
-                builder.addSemanticDecoration(param, implicitSysVal->getSystemValueName());
-            }
-
-            systemValueParamMap->add(systemValueName, param);
-
-            if (m_callReferenceGraph.containsKey(parentFunc))
-            {
-                for (auto call : m_callReferenceGraph.getValue(parentFunc))
-                {
-                    for (auto callParentFunc : m_functionReferenceGraph.getValue(call))
-                    {
-                        SLANG_ASSERT(parentFunc != callParentFunc);
-                        auto newCallParam =
-                            getOrCreateSystemValueParam(callParentFunc, implicitSysVal);
-
-                        List<IRInst*> newCallParams;
-                        for (auto arg : call->getArgsList())
-                        {
-                            newCallParams.add(arg);
-                        }
-                        newCallParams.add(newCallParam);
-
-                        builder.setInsertAfter(call);
-                        auto newCall = builder.emitCallInst(paramType, parentFunc, newCallParams);
-
-                        call->replaceUsesWith(newCall);
-                        call->transferDecorationsTo(newCall);
-                        call->removeAndDeallocate();
-                    }
-                }
-            }
-        }
-        else
-        {
-            param = *paramPtr;
-        }
-
-        return param;
-    }
-
-
-    const Dictionary<IRInst*, HashSet<IRFunc*>>& m_entryPointReferenceGraph;
     const Dictionary<IRInst*, HashSet<IRFunc*>>& m_functionReferenceGraph;
     const Dictionary<IRFunc*, HashSet<IRCall*>>& m_callReferenceGraph;
     const List<IRImplicitSystemValue*>& m_implicitSystemValueInstructions;
 
     Dictionary<IRFunc*, SystemValueParamMap> m_functionMap;
+
+    IRBuilder m_builder;
+
+    // Implicit system values are currently only being used for subgroup size and
+    // subgroup invocation id, both of which are 32-bit unsigned.
+    IRType* m_paramType;
 };
 
 void legalizeImplicitSystemValues(
-    const Dictionary<IRInst*, HashSet<IRFunc*>>& entryPointReferenceGraph,
+    IRModule* module,
     const Dictionary<IRInst*, HashSet<IRFunc*>>& functionReferenceGraph,
     const Dictionary<IRFunc*, HashSet<IRCall*>>& callReferenceGraph,
     const List<IRImplicitSystemValue*>& implicitSystemValueInstructions)
 {
     ImplicitSystemValueLegalizationContext(
-        entryPointReferenceGraph,
+        module,
         functionReferenceGraph,
         callReferenceGraph,
         implicitSystemValueInstructions)

--- a/source/slang/slang-ir-legalize-system-values.cpp
+++ b/source/slang/slang-ir-legalize-system-values.cpp
@@ -101,12 +101,6 @@ private:
         SystemValueSemanticName systemValueName,
         UnownedStringSlice systemValueString)
     {
-        // Implicit system values are currently only being used for subgroup size and
-        // subgroup invocation id.
-        SLANG_ASSERT(
-            (systemValueName == SystemValueSemanticName::WaveLaneCount) ||
-            (systemValueName == SystemValueSemanticName::WaveLaneIndex));
-
         List<IRFunc*> createParamWorkList;
         List<ModifyCallWorkItem> modifyCallWorkList;
 
@@ -196,7 +190,12 @@ private:
     {
         auto systemValueName =
             convertSystemValueSemanticNameToEnum(implicitSysVal->getSystemValueName());
-        SLANG_ASSERT(systemValueName != SystemValueSemanticName::Unknown);
+
+        // Implicit system values are currently only being used for subgroup size and
+        // subgroup invocation id.
+        SLANG_ASSERT(
+            (systemValueName == SystemValueSemanticName::WaveLaneCount) ||
+            (systemValueName == SystemValueSemanticName::WaveLaneIndex));
 
         // If parameter for the specific function and system value type combination was already
         // created, return it directly.

--- a/source/slang/slang-ir-legalize-system-values.cpp
+++ b/source/slang/slang-ir-legalize-system-values.cpp
@@ -1,0 +1,92 @@
+#include "slang-ir-legalize-system-values.h"
+
+#include "core/slang-dictionary.h"
+#include "slang-diagnostics.h"
+#include "slang-ir-insts.h"
+#include "slang-ir-legalize-varying-params.h"
+
+namespace Slang
+{
+
+class ImplicitSystemValueLegalizationContext
+{
+public:
+    ImplicitSystemValueLegalizationContext(
+        const Dictionary<IRInst*, HashSet<IRFunc*>>& entryPointReferenceGraph,
+        const List<IRImplicitSystemValue*>& implicitSystemValueInstructions)
+        : m_entryPointReferenceGraph(entryPointReferenceGraph)
+        , m_implicitSystemValueInstructions(implicitSystemValueInstructions)
+    {
+    }
+
+    void legalize()
+    {
+        for (auto implicitSysVal : m_implicitSystemValueInstructions)
+        {
+            for (auto entryPoint : *m_entryPointReferenceGraph.tryGetValue(implicitSysVal))
+            {
+                auto param = getOrCreateSystemValueParam(entryPoint, implicitSysVal);
+                implicitSysVal->replaceUsesWith(param);
+                implicitSysVal->removeAndDeallocate();
+            }
+        }
+    }
+
+private:
+    IRParam* getOrCreateSystemValueParam(IRFunc* entryPoint, IRImplicitSystemValue* implicitSysVal)
+    {
+        if (!m_entryPointMap.containsKey(entryPoint))
+        {
+            m_entryPointMap.add(entryPoint, SystemValueParamMap());
+        }
+        auto systemValueParamMap = m_entryPointMap.tryGetValue(entryPoint);
+
+        const auto systemValueName =
+            convertSystemValueSemanticNameToEnum(implicitSysVal->getSystemValueName());
+        SLANG_ASSERT(systemValueName != SystemValueSemanticName::Unknown);
+
+        IRParam* param;
+        const auto paramPtr = systemValueParamMap->tryGetValue(systemValueName);
+        if (paramPtr == nullptr)
+        {
+            IRBuilder builder(entryPoint);
+            builder.setInsertBefore(entryPoint->getFirstBlock()->getFirstOrdinaryInst());
+
+            // The new system value parameter's type is harcoded.
+            //
+            // Implicit system values are currently only being used for subgroup size and subgroup
+            // invocation id, both of which are 32-bit unsigned.
+            SLANG_ASSERT(
+                (systemValueName == SystemValueSemanticName::WaveLaneCount) ||
+                (systemValueName == SystemValueSemanticName::WaveLaneIndex));
+            param = builder.emitParam(builder.getUIntType());
+            builder.addSemanticDecoration(param, implicitSysVal->getSystemValueName());
+
+            systemValueParamMap->add(systemValueName, param);
+        }
+        else
+        {
+            param = *paramPtr;
+        }
+
+        return param;
+    }
+
+    using SystemValueParamMap = Dictionary<SystemValueSemanticName, IRParam*>;
+
+    const Dictionary<IRInst*, HashSet<IRFunc*>>& m_entryPointReferenceGraph;
+    const List<IRImplicitSystemValue*>& m_implicitSystemValueInstructions;
+    Dictionary<IRFunc*, SystemValueParamMap> m_entryPointMap;
+};
+
+void legalizeImplicitSystemValues(
+    const Dictionary<IRInst*, HashSet<IRFunc*>>& entryPointReferenceGraph,
+    const List<IRImplicitSystemValue*>& implicitSystemValueInstructions)
+{
+    ImplicitSystemValueLegalizationContext(
+        entryPointReferenceGraph,
+        implicitSystemValueInstructions)
+        .legalize();
+}
+
+} // namespace Slang

--- a/source/slang/slang-ir-legalize-system-values.cpp
+++ b/source/slang/slang-ir-legalize-system-values.cpp
@@ -28,7 +28,6 @@ public:
     {
         for (auto implicitSysVal : m_implicitSystemValueInstructions)
         {
-            // for (auto entryPoint : *m_entryPointReferenceGraph.tryGetValue(implicitSysVal))
             for (auto entryPoint : *m_functionReferenceGraph.tryGetValue(implicitSysVal))
             {
                 auto param = getOrCreateSystemValueVariable(entryPoint, implicitSysVal);

--- a/source/slang/slang-ir-legalize-system-values.cpp
+++ b/source/slang/slang-ir-legalize-system-values.cpp
@@ -1,6 +1,7 @@
 #include "slang-ir-legalize-system-values.h"
 
 #include "core/slang-dictionary.h"
+#include "core/slang-string.h"
 #include "slang-diagnostics.h"
 #include "slang-ir-insts.h"
 #include "slang-ir-legalize-varying-params.h"
@@ -13,8 +14,12 @@ class ImplicitSystemValueLegalizationContext
 public:
     ImplicitSystemValueLegalizationContext(
         const Dictionary<IRInst*, HashSet<IRFunc*>>& entryPointReferenceGraph,
+        const Dictionary<IRInst*, HashSet<IRFunc*>>& functionReferenceGraph,
+        const Dictionary<IRFunc*, HashSet<IRCall*>>& callReferenceGraph,
         const List<IRImplicitSystemValue*>& implicitSystemValueInstructions)
         : m_entryPointReferenceGraph(entryPointReferenceGraph)
+        , m_functionReferenceGraph(functionReferenceGraph)
+        , m_callReferenceGraph(callReferenceGraph)
         , m_implicitSystemValueInstructions(implicitSystemValueInstructions)
     {
     }
@@ -23,7 +28,8 @@ public:
     {
         for (auto implicitSysVal : m_implicitSystemValueInstructions)
         {
-            for (auto entryPoint : *m_entryPointReferenceGraph.tryGetValue(implicitSysVal))
+            // for (auto entryPoint : *m_entryPointReferenceGraph.tryGetValue(implicitSysVal))
+            for (auto entryPoint : *m_functionReferenceGraph.tryGetValue(implicitSysVal))
             {
                 auto param = getOrCreateSystemValueParam(entryPoint, implicitSysVal);
                 implicitSysVal->replaceUsesWith(param);
@@ -33,13 +39,210 @@ public:
     }
 
 private:
-    IRParam* getOrCreateSystemValueParam(IRFunc* entryPoint, IRImplicitSystemValue* implicitSysVal)
+    using SystemValueParamMap = Dictionary<SystemValueSemanticName, IRParam*>;
+
+    SystemValueParamMap& getParamMap(IRFunc* func)
     {
-        if (!m_entryPointMap.containsKey(entryPoint))
+        if (auto map = m_functionMap.tryGetValue(func))
         {
-            m_entryPointMap.add(entryPoint, SystemValueParamMap());
+            return *map;
         }
-        auto systemValueParamMap = m_entryPointMap.tryGetValue(entryPoint);
+        else
+        {
+            m_functionMap.add(func, SystemValueParamMap());
+            return m_functionMap.getValue(func);
+        }
+    }
+
+    //
+    // Attempt to retrieve a parameter for a specific function and system value type combination.
+    //
+    IRParam* tryGetParam(IRFunc* func, SystemValueSemanticName systemValueName)
+    {
+        if (auto param = getParamMap(func).tryGetValue(systemValueName))
+        {
+            return *param;
+        }
+        else
+        {
+            return nullptr;
+        }
+    }
+
+    //
+    // Implicit system values are "global variables" and can be used anywhere within the source
+    // code. The implementation target(i.e WGSL) however requires system values, aka built-in
+    // values, to be accessed via parameters to the entry point; they are not globally available.
+    //
+    // For any implicit system values found in non entry point functions, we need to ensure that
+    // they are explicitly passed as parameters from the entry point to the relevant functions. This
+    // means adding new parameters to the function signatures to include the required system values.
+    //
+    struct CreateParamWorkItem
+    {
+        /// Function to add a new param to.
+        IRFunc* func;
+
+        /// System value semantic info.
+        SystemValueSemanticName systemValueName;
+        UnownedStringSlice systemValueString;
+
+        Index paramIndex;
+    };
+
+    //
+    // In addition to modifying the function signatures, we need to ensure the calls to the modified
+    // function include the system value variable.
+    //
+    struct ModifyCallWorkItem
+    {
+        /// Call to modify.
+        IRCall* call;
+
+        /// Parameter to add to the call.
+        // IRParam* paramToAdd;
+        Index paramIndex;
+    };
+
+    //
+    // Creates a new parameter for functions that require the implicit system value.
+    // Returns work items of calls that need to be modified as a result of adding the parameters.
+    //
+    List<ModifyCallWorkItem> createFunctionParams(
+        IRFunc* parentFunc,
+        IRImplicitSystemValue* implicitSysVal)
+    {
+        // Work list for parameter creation work.
+        List<CreateParamWorkItem> createParamWorkList;
+
+        // Work list for call replacement work.
+        List<ModifyCallWorkItem> modifyCallWorkList;
+
+        // List to store new parameters that represent system value variables - used to propagate
+        // the param variables from parameter creation work to call replacement work.
+        List<IRParam*> addedParams;
+
+        const auto systemValueName =
+            convertSystemValueSemanticNameToEnum(implicitSysVal->getSystemValueName());
+        SLANG_ASSERT(systemValueName != SystemValueSemanticName::Unknown);
+
+        createParamWorkList.add(
+            {parentFunc,
+             systemValueName,
+             implicitSysVal->getSystemValueName(),
+             addedParams.getCount()});
+        addedParams.add(nullptr);
+
+        const auto addWorkItems = [&](const HashSet<IRCall*>& calls, CreateParamWorkItem workItem)
+        {
+            for (auto call : calls)
+            {
+                for (auto callerFunc : m_functionReferenceGraph.getValue(call))
+                {
+                    // The caller(of a function that was added a parameter) also requires a
+                    // new parameter to pass in the system value variable to the callee.
+                    workItem.func = callerFunc;
+                    workItem.paramIndex = addedParams.getCount();
+                    createParamWorkList.add(workItem);
+                    addedParams.add(nullptr);
+
+                    // The call needs to be modified to add the new parameter.
+                    modifyCallWorkList.add({call, workItem.paramIndex});
+                }
+            }
+        };
+
+        IRBuilder builder(parentFunc);
+
+        // The new system value parameter's type is harcoded.
+        //
+        // Implicit system values are currently only being used for subgroup size and
+        // subgroup invocation id, both of which are 32-bit unsigned.
+        SLANG_ASSERT(
+            (systemValueName == SystemValueSemanticName::WaveLaneCount) ||
+            (systemValueName == SystemValueSemanticName::WaveLaneIndex));
+        auto paramType = builder.getUIntType();
+
+        const auto createParamWork = [&](CreateParamWorkItem workItem)
+        {
+            // If the parameter for system value type has not been created, create it.
+            if (!tryGetParam(workItem.func, workItem.systemValueName))
+            {
+                builder.setInsertBefore(workItem.func->getFirstBlock()->getFirstOrdinaryInst());
+
+                auto param = builder.emitParam(paramType);
+
+                // Add system value semantic decoration if adding to entry point.
+                if (parentFunc->findDecoration<IREntryPointDecoration>())
+                {
+                    builder.addSemanticDecoration(param, workItem.systemValueString);
+                }
+
+                getParamMap(workItem.func).add(systemValueName, param);
+                addedParams[workItem.paramIndex] = param;
+
+                if (auto calls = m_callReferenceGraph.tryGetValue(workItem.func))
+                {
+                    addWorkItems(*calls, workItem);
+                }
+            }
+        };
+
+        for (Index i = 0; i < createParamWorkList.getCount(); i++)
+        {
+            createParamWork(createParamWorkList[i]);
+        }
+
+        const auto modifyCallWork = [&](IRCall* call, IRParam* param)
+        {
+            List<IRInst*> newCallParams;
+            for (auto arg : call->getArgsList())
+            {
+                newCallParams.add(arg);
+            }
+            newCallParams.add(param);
+
+            IRBuilder newBuilder(call);
+            newBuilder.setInsertAfter(call);
+            auto newCall = newBuilder.emitCallInst(paramType, call->getCallee(), newCallParams);
+
+            // call->replaceUsesWith(newCall);
+            // call->transferDecorationsTo(newCall);
+            // call->removeAndDeallocate();
+        };
+
+        for (const auto workItem : modifyCallWorkList)
+        {
+            modifyCallWork(workItem.call, addedParams[workItem.paramIndex]);
+        }
+
+        return modifyCallWorkList;
+    }
+
+    IRParam* getOrCreateSystemValueParam(IRFunc* parentFunc, IRImplicitSystemValue* implicitSysVal)
+    {
+        const auto systemValueName =
+            convertSystemValueSemanticNameToEnum(implicitSysVal->getSystemValueName());
+        SLANG_ASSERT(systemValueName != SystemValueSemanticName::Unknown);
+
+        if (auto param = tryGetParam(parentFunc, systemValueName))
+        {
+            return param;
+        }
+
+        createFunctionParams(parentFunc, implicitSysVal);
+        return tryGetParam(parentFunc, systemValueName);
+    }
+
+    // void replaceCalls() {}
+
+    IRParam* getOrCreateSystemValueParam2(IRFunc* parentFunc, IRImplicitSystemValue* implicitSysVal)
+    {
+        if (!m_functionMap.containsKey(parentFunc))
+        {
+            m_functionMap.add(parentFunc, SystemValueParamMap());
+        }
+        auto systemValueParamMap = m_functionMap.tryGetValue(parentFunc);
 
         const auto systemValueName =
             convertSystemValueSemanticNameToEnum(implicitSysVal->getSystemValueName());
@@ -49,8 +252,8 @@ private:
         const auto paramPtr = systemValueParamMap->tryGetValue(systemValueName);
         if (paramPtr == nullptr)
         {
-            IRBuilder builder(entryPoint);
-            builder.setInsertBefore(entryPoint->getFirstBlock()->getFirstOrdinaryInst());
+            IRBuilder builder(parentFunc);
+            builder.setInsertBefore(parentFunc->getFirstBlock()->getFirstOrdinaryInst());
 
             // The new system value parameter's type is harcoded.
             //
@@ -59,10 +262,43 @@ private:
             SLANG_ASSERT(
                 (systemValueName == SystemValueSemanticName::WaveLaneCount) ||
                 (systemValueName == SystemValueSemanticName::WaveLaneIndex));
-            param = builder.emitParam(builder.getUIntType());
-            builder.addSemanticDecoration(param, implicitSysVal->getSystemValueName());
+            auto paramType = builder.getUIntType();
+            param = builder.emitParam(paramType);
+
+
+            if (parentFunc->findDecoration<IREntryPointDecoration>())
+            {
+                builder.addSemanticDecoration(param, implicitSysVal->getSystemValueName());
+            }
 
             systemValueParamMap->add(systemValueName, param);
+
+            if (m_callReferenceGraph.containsKey(parentFunc))
+            {
+                for (auto call : m_callReferenceGraph.getValue(parentFunc))
+                {
+                    for (auto callParentFunc : m_functionReferenceGraph.getValue(call))
+                    {
+                        SLANG_ASSERT(parentFunc != callParentFunc);
+                        auto newCallParam =
+                            getOrCreateSystemValueParam(callParentFunc, implicitSysVal);
+
+                        List<IRInst*> newCallParams;
+                        for (auto arg : call->getArgsList())
+                        {
+                            newCallParams.add(arg);
+                        }
+                        newCallParams.add(newCallParam);
+
+                        builder.setInsertAfter(call);
+                        auto newCall = builder.emitCallInst(paramType, parentFunc, newCallParams);
+
+                        call->replaceUsesWith(newCall);
+                        call->transferDecorationsTo(newCall);
+                        call->removeAndDeallocate();
+                    }
+                }
+            }
         }
         else
         {
@@ -72,19 +308,25 @@ private:
         return param;
     }
 
-    using SystemValueParamMap = Dictionary<SystemValueSemanticName, IRParam*>;
 
     const Dictionary<IRInst*, HashSet<IRFunc*>>& m_entryPointReferenceGraph;
+    const Dictionary<IRInst*, HashSet<IRFunc*>>& m_functionReferenceGraph;
+    const Dictionary<IRFunc*, HashSet<IRCall*>>& m_callReferenceGraph;
     const List<IRImplicitSystemValue*>& m_implicitSystemValueInstructions;
-    Dictionary<IRFunc*, SystemValueParamMap> m_entryPointMap;
+
+    Dictionary<IRFunc*, SystemValueParamMap> m_functionMap;
 };
 
 void legalizeImplicitSystemValues(
     const Dictionary<IRInst*, HashSet<IRFunc*>>& entryPointReferenceGraph,
+    const Dictionary<IRInst*, HashSet<IRFunc*>>& functionReferenceGraph,
+    const Dictionary<IRFunc*, HashSet<IRCall*>>& callReferenceGraph,
     const List<IRImplicitSystemValue*>& implicitSystemValueInstructions)
 {
     ImplicitSystemValueLegalizationContext(
         entryPointReferenceGraph,
+        functionReferenceGraph,
+        callReferenceGraph,
         implicitSystemValueInstructions)
         .legalize();
 }

--- a/source/slang/slang-ir-legalize-system-values.h
+++ b/source/slang/slang-ir-legalize-system-values.h
@@ -7,6 +7,8 @@ namespace Slang
 
 void legalizeImplicitSystemValues(
     const Dictionary<IRInst*, HashSet<IRFunc*>>& entryPointReferenceGraph,
+    const Dictionary<IRInst*, HashSet<IRFunc*>>& functionReferenceGraph,
+    const Dictionary<IRFunc*, HashSet<IRCall*>>& callReferenceGraph,
     const List<IRImplicitSystemValue*>& implicitSystemValueInstructions);
 
 } // namespace Slang

--- a/source/slang/slang-ir-legalize-system-values.h
+++ b/source/slang/slang-ir-legalize-system-values.h
@@ -6,7 +6,7 @@ namespace Slang
 {
 
 void legalizeImplicitSystemValues(
-    const Dictionary<IRInst*, HashSet<IRFunc*>>& entryPointReferenceGraph,
+    IRModule* module,
     const Dictionary<IRInst*, HashSet<IRFunc*>>& functionReferenceGraph,
     const Dictionary<IRFunc*, HashSet<IRCall*>>& callReferenceGraph,
     const List<IRImplicitSystemValue*>& implicitSystemValueInstructions);

--- a/source/slang/slang-ir-legalize-system-values.h
+++ b/source/slang/slang-ir-legalize-system-values.h
@@ -1,0 +1,12 @@
+// slang-ir-legalize-system-values.h
+#pragma once
+#include "slang-ir-insts.h"
+
+namespace Slang
+{
+
+void legalizeImplicitSystemValues(
+    const Dictionary<IRInst*, HashSet<IRFunc*>>& entryPointReferenceGraph,
+    const List<IRImplicitSystemValue*>& implicitSystemValueInstructions);
+
+} // namespace Slang

--- a/source/slang/slang-ir-legalize-system-values.h
+++ b/source/slang/slang-ir-legalize-system-values.h
@@ -1,5 +1,6 @@
 // slang-ir-legalize-system-values.h
 #pragma once
+#include "slang-ir-call-graph.h"
 #include "slang-ir-insts.h"
 
 namespace Slang
@@ -7,8 +8,7 @@ namespace Slang
 
 void legalizeImplicitSystemValues(
     IRModule* module,
-    const Dictionary<IRInst*, HashSet<IRFunc*>>& functionReferenceGraph,
-    const Dictionary<IRFunc*, HashSet<IRCall*>>& callReferenceGraph,
+    const CallGraph& callGraph,
     const List<IRImplicitSystemValue*>& implicitSystemValueInstructions);
 
 } // namespace Slang

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -3854,6 +3854,20 @@ protected:
                 break;
             }
 
+        case SystemValueSemanticName::WaveLaneCount:
+            {
+                result.systemValueName = toSlice("subgroup_size");
+                result.permittedTypes.add(builder.getUIntType());
+                break;
+            }
+
+        case SystemValueSemanticName::WaveLaneIndex:
+            {
+                result.systemValueName = toSlice("subgroup_invocation_id");
+                result.permittedTypes.add(builder.getUIntType());
+                break;
+            }
+
         default:
             {
                 m_sink->diagnose(

--- a/source/slang/slang-ir-legalize-varying-params.h
+++ b/source/slang/slang-ir-legalize-varying-params.h
@@ -68,6 +68,8 @@ void depointerizeInputParams(IRFunc* entryPoint);
     M(Target, SV_Target)                                 \
     M(StartVertexLocation, SV_StartVertexLocation)       \
     M(StartInstanceLocation, SV_StartInstanceLocation)   \
+    M(WaveLaneCount, SV_WaveLaneCount)                   \
+    M(WaveLaneIndex, SV_WaveLaneIndex)                   \
     /* end */
 
 /// A known system-value semantic name that can be applied to a parameter

--- a/source/slang/slang-ir-specialize-stage-switch.cpp
+++ b/source/slang/slang-ir-specialize-stage-switch.cpp
@@ -123,8 +123,7 @@ void specializeFuncToStage(
 
 void specializeStageSwitch(IRModule* module)
 {
-    Dictionary<IRInst*, HashSet<IRFunc*>> mapInstToReferencingEntryPoints;
-    buildEntryPointReferenceGraph(mapInstToReferencingEntryPoints, module);
+    const auto callGraph = CallGraph(module);
 
     HashSet<IRInst*> stageSpecificFunctions;
     discoverStageSpecificFunctions(stageSpecificFunctions, module);
@@ -133,7 +132,7 @@ void specializeStageSwitch(IRModule* module)
     Dictionary<IRInst*, Dictionary<Stage, IRInst*>> mapFuncToStageSpecializedFunc;
     for (auto func : stageSpecificFunctions)
     {
-        auto referencingEntryPoints = mapInstToReferencingEntryPoints.tryGetValue(func);
+        auto referencingEntryPoints = callGraph.getReferencingEntryPoints(func);
         if (!referencingEntryPoints)
             continue;
         if (func->findDecoration<IREntryPointDecoration>())

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -2,7 +2,6 @@
 #include "slang-ir-spirv-legalize.h"
 
 #include "slang-emit-base.h"
-#include "slang-ir-call-graph.h"
 #include "slang-ir-clone.h"
 #include "slang-ir-composite-reg-to-mem.h"
 #include "slang-ir-dce.h"
@@ -2102,7 +2101,7 @@ static bool hasExplicitInterlockInst(IRFunc* func)
 void insertFragmentShaderInterlock(SPIRVEmitSharedContext* context, IRModule* module)
 {
     HashSet<IRFunc*> fragmentShaders;
-    for (auto& [inst, entryPoints] : context->m_referencingEntryPoints)
+    for (const auto& [inst, entryPoints] : context->m_callGraph.getReferencingEntryPointsMap())
     {
         if (isRasterOrderedResource(inst))
         {
@@ -2154,7 +2153,7 @@ void legalizeIRForSPIRV(
     SLANG_UNUSED(entryPoints);
     legalizeSPIRV(context, module, codeGenContext->getSink());
     simplifyIRForSpirvLegalization(context->m_targetProgram, codeGenContext->getSink(), module);
-    buildEntryPointReferenceGraph(context->m_referencingEntryPoints, module);
+    context->m_callGraph.build(module);
     insertFragmentShaderInterlock(context, module);
 }
 

--- a/source/slang/slang-ir-spirv-legalize.h
+++ b/source/slang/slang-ir-spirv-legalize.h
@@ -1,6 +1,7 @@
 // slang-ir-spirv-legalize.h
 #pragma once
 #include "../core/slang-basic.h"
+#include "slang-ir-call-graph.h"
 #include "slang-ir-insts.h"
 #include "slang-ir-spirv-snippet.h"
 
@@ -20,9 +21,8 @@ struct SPIRVEmitSharedContext
     TargetProgram* m_targetProgram;
     Dictionary<IRTargetIntrinsicDecoration*, RefPtr<SpvSnippet>> m_parsedSpvSnippets;
 
-    Dictionary<IRInst*, HashSet<IRFunc*>>
-        m_referencingEntryPoints; // The entry-points that directly or transitively reference this
-                                  // global inst.
+    // Track entry-points that directly or transitively reference this global inst.
+    CallGraph m_callGraph;
 
     DiagnosticSink* m_sink;
     const SPIRVCoreGrammarInfo* m_grammarInfo;

--- a/source/slang/slang-ir-wgsl-legalize.cpp
+++ b/source/slang/slang-ir-wgsl-legalize.cpp
@@ -1,6 +1,5 @@
 #include "slang-ir-wgsl-legalize.h"
 
-#include "slang-ir-call-graph.h"
 #include "slang-ir-insts.h"
 #include "slang-ir-legalize-binary-operator.h"
 #include "slang-ir-legalize-global-values.h"
@@ -235,19 +234,10 @@ void legalizeIRForWGSL(IRModule* module, DiagnosticSink* sink)
     // Legalize implicit system values to entry point parameters.
     if (instContext.implicitSystemValueInstructions.getCount() != 0)
     {
-        Dictionary<IRInst*, HashSet<IRFunc*>> entryPointReferenceGraph;
-        // Dictionary<IRInst*, HashSet<CallItem>> functionReferenceGraph;
-        Dictionary<IRInst*, HashSet<IRFunc*>> functionReferenceGraph;
-        Dictionary<IRFunc*, HashSet<IRCall*>> callReferenceGraph;
-        buildEntryPointReferenceGraph(
-            entryPointReferenceGraph,
-            module,
-            &functionReferenceGraph,
-            &callReferenceGraph);
+        const auto callGraph = CallGraph(module);
         legalizeImplicitSystemValues(
             module,
-            functionReferenceGraph,
-            callReferenceGraph,
+            callGraph,
             instContext.implicitSystemValueInstructions);
     }
 

--- a/source/slang/slang-ir-wgsl-legalize.cpp
+++ b/source/slang/slang-ir-wgsl-legalize.cpp
@@ -236,9 +236,18 @@ void legalizeIRForWGSL(IRModule* module, DiagnosticSink* sink)
     if (instContext.implicitSystemValueInstructions.getCount() != 0)
     {
         Dictionary<IRInst*, HashSet<IRFunc*>> entryPointReferenceGraph;
-        buildEntryPointReferenceGraph(entryPointReferenceGraph, module);
+        // Dictionary<IRInst*, HashSet<CallItem>> functionReferenceGraph;
+        Dictionary<IRInst*, HashSet<IRFunc*>> functionReferenceGraph;
+        Dictionary<IRFunc*, HashSet<IRCall*>> callReferenceGraph;
+        buildEntryPointReferenceGraph(
+            entryPointReferenceGraph,
+            module,
+            &functionReferenceGraph,
+            &callReferenceGraph);
         legalizeImplicitSystemValues(
             entryPointReferenceGraph,
+            functionReferenceGraph,
+            callReferenceGraph,
             instContext.implicitSystemValueInstructions);
     }
 

--- a/source/slang/slang-ir-wgsl-legalize.cpp
+++ b/source/slang/slang-ir-wgsl-legalize.cpp
@@ -245,7 +245,7 @@ void legalizeIRForWGSL(IRModule* module, DiagnosticSink* sink)
             &functionReferenceGraph,
             &callReferenceGraph);
         legalizeImplicitSystemValues(
-            entryPointReferenceGraph,
+            module,
             functionReferenceGraph,
             callReferenceGraph,
             instContext.implicitSystemValueInstructions);

--- a/tests/glsl-intrinsic/shader-subgroup/shader-subgroup-builtin-variables.slang
+++ b/tests/glsl-intrinsic/shader-subgroup/shader-subgroup-builtin-variables.slang
@@ -10,6 +10,7 @@
 
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl -emit-spirv-directly
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain -allow-glsl -xslang -DWGPU
 #version 430
 
 //TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
@@ -24,15 +25,17 @@ void computeMain()
 {
     if (gl_GlobalInvocationID.x == 3) {
         outputBuffer.data[0] = true
-            && gl_NumSubgroups == 1
-            && gl_SubgroupID  == 0 //1 subgroup, 0 based indexing
             && gl_SubgroupSize == 32
             && gl_SubgroupInvocationID == 3
+#if !defined(WGPU)
+            && gl_SubgroupID  == 0 //1 subgroup, 0 based indexing
+            && gl_NumSubgroups == 1
             && gl_SubgroupEqMask == uvec4(0b1000,0,0,0)
             && gl_SubgroupGeMask == uvec4(0xFFFFFFF8,0,0,0)
             && gl_SubgroupGtMask == uvec4(0xFFFFFFF0,0,0,0)
             && gl_SubgroupLeMask == uvec4(0b1111,0,0,0)
             && gl_SubgroupLtMask == uvec4(0b111,0,0,0)
+#endif
             ;
     }
     // CHECK_GLSL: void main(

--- a/tests/hlsl-intrinsic/wave-get-lane-index.slang
+++ b/tests/hlsl-intrinsic/wave-get-lane-index.slang
@@ -4,6 +4,7 @@
 //TEST:COMPARE_COMPUTE_EX:-slang -compute -dx12 -use-dxil -profile cs_6_0 -shaderobj
 //TEST(vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
 //TEST:COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX:-wgpu -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/wgsl/implicit-system-values-dynamic-dispatch.slang
+++ b/tests/wgsl/implicit-system-values-dynamic-dispatch.slang
@@ -1,9 +1,13 @@
 // Test calling differentiable function through dynamic dispatch.
 
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain -output-using-type
 
-//TEST_INPUT:ubuffer(data=[0 0], stride=4):out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
+
+//TEST_INPUT: type_conformance Impl1:IInterface = 0
+//TEST_INPUT: type_conformance Impl2:IInterface = 1
+//TEST_INPUT: type_conformance Impl3:IInterface = 2
 
 [anyValueSize(16)]
 interface IInterface
@@ -15,31 +19,50 @@ struct Impl1 : IInterface
 {
     uint getLaneIndex(uint base)
     {
-        return base * WaveGetLaneIndex();
+        return base; 
     }
-};
-
+}
 
 struct Impl2 : IInterface
 {
     uint getLaneIndex(uint base)
     {
-        return base; 
+        return base * WaveGetLaneIndex() * 2; 
     }
 }
 
-//TEST_INPUT: type_conformance Impl1:IInterface = 0
-//TEST_INPUT: type_conformance Impl2:IInterface = 1
+struct Impl3 : IInterface
+{
+    uint getLaneIndex(uint base)
+    {
+        return base + WaveGetLaneIndex();
+    }
+};
 
-[numthreads(1, 1, 1)]
+[numthreads(2, 1, 1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
-    var obj = createDynamicObject<IInterface>(dispatchThreadID.x, 0); // Impl1
-    outputBuffer[0] = obj.getLaneIndex(5);
+    const uint base = 5;
 
-    obj = createDynamicObject<IInterface>(dispatchThreadID.x + 1, 0); // Impl2
-    outputBuffer[1] = obj.getLaneIndex(5);
+    if (dispatchThreadID.x == 0)
+    {
+        var obj = createDynamicObject<IInterface>(dispatchThreadID.x, 0); // Impl0
+        outputBuffer[0] = obj.getLaneIndex(base);
 
-    // BUF: 0
-    // BUF-NEXT: 5
+        obj = createDynamicObject<IInterface>(dispatchThreadID.x + 1, 0); // Impl1
+        outputBuffer[1] = obj.getLaneIndex(base);
+    }
+    else
+    {
+        var obj = createDynamicObject<IInterface>(dispatchThreadID.x, 0); // Impl1
+        outputBuffer[2] = obj.getLaneIndex(base);
+
+        obj = createDynamicObject<IInterface>(dispatchThreadID.x + 1, 0); // Impl2
+        outputBuffer[3] = obj.getLaneIndex(base);
+    }
+    
+    // BUF: 5
+    // BUF-NEXT: 0
+    // BUF-NEXT: 10
+    // BUF-NEXT: 6
 }

--- a/tests/wgsl/implicit-system-values-dynamic-dispatch.slang
+++ b/tests/wgsl/implicit-system-values-dynamic-dispatch.slang
@@ -1,0 +1,45 @@
+// Test calling differentiable function through dynamic dispatch.
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain
+
+//TEST_INPUT:ubuffer(data=[0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<uint> outputBuffer;
+
+[anyValueSize(16)]
+interface IInterface
+{
+    uint getLaneIndex(uint base);
+}
+
+struct Impl1 : IInterface
+{
+    uint getLaneIndex(uint base)
+    {
+        return base * WaveGetLaneIndex();
+    }
+};
+
+
+struct Impl2 : IInterface
+{
+    uint getLaneIndex(uint base)
+    {
+        return base; 
+    }
+}
+
+//TEST_INPUT: type_conformance Impl1:IInterface = 0
+//TEST_INPUT: type_conformance Impl2:IInterface = 1
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    var obj = createDynamicObject<IInterface>(dispatchThreadID.x, 0); // Impl1
+    outputBuffer[0] = obj.getLaneIndex(5);
+
+    obj = createDynamicObject<IInterface>(dispatchThreadID.x + 1, 0); // Impl2
+    outputBuffer[1] = obj.getLaneIndex(5);
+
+    // BUF: 0
+    // BUF-NEXT: 5
+}

--- a/tests/wgsl/implicit-system-values.slang
+++ b/tests/wgsl/implicit-system-values.slang
@@ -43,6 +43,21 @@ struct Impl3 : IInterface
     }
 };
 
+struct Impl4 : IInterface
+{
+    uint getLaneIndex()
+    {
+        return WaveGetLaneIndex() + 2;
+    }
+
+    uint getLaneIndex(uint base) 
+    {
+        return base * 2;
+    }
+};
+
+
+
 uint getLaneIndexGeneric<T>(T interface, uint base = 3) where T : IInterface
 {
     return interface.getLaneIndex(base);
@@ -57,47 +72,51 @@ struct MyStruct<T> where T : IInterface
     }
 }
 
-
-void testDynamicDispatch()
-{
-}
-
 [numthreads(1,1,1)]
 void computeMain()
 {
     Impl1 impl1;
     Impl2 impl2;
     Impl3 impl3;
+    Impl4 impl4;
 
     MyStruct<Impl1> s1;
     MyStruct<Impl2> s2;
     MyStruct<Impl3> s3;
+    MyStruct<Impl4> s4;
 
     // BUF: 1
     outputBuffer[0] = uint(
-        true
-
+        (0 == WaveGetLaneIndex())
+        
         // Interface implementations.
         && (0 == impl1.getLaneIndex())
-        && (1 == impl1.getLaneIndex(2))
         && (100 == impl2.getLaneIndex())
         && (2 == impl3.getLaneIndex())
+        && (2 == impl4.getLaneIndex())
+        && (2 == impl1.getLaneIndex(2))
+        && (1 == impl2.getLaneIndex(2))
         && (3 == impl3.getLaneIndex(2))
+        && (12 == impl4.getLaneIndex(6))
 
         // Interface as function generic parameter.
-        && (4 == getLaneIndexGeneric(impl1, 4))
-        && (3 == getLaneIndexGeneric(impl2, 4))
-        && (5 == getLaneIndexGeneric(impl3, 4))
         && (3 == getLaneIndexGeneric(impl1))
         && (2 == getLaneIndexGeneric(impl2))
         && (4 == getLaneIndexGeneric(impl3))
+        && (6 == getLaneIndexGeneric(impl4))
+        && (4 == getLaneIndexGeneric(impl1, 4))
+        && (3 == getLaneIndexGeneric(impl2, 4))
+        && (5 == getLaneIndexGeneric(impl3, 4))
+        && (8 == getLaneIndexGeneric(impl4, 4))
 
         // Interface as struct generic member.
         && (5 == s1.getLaneIndex(5))
         && (4 == s2.getLaneIndex(5))
         && (6 == s3.getLaneIndex(5))
+        && (10 == s4.getLaneIndex(5))
         && (4 == s1.getLaneIndex())
         && (3 == s2.getLaneIndex())
         && (5 == s3.getLaneIndex())
+        && (8 == s4.getLaneIndex())
     );
 }

--- a/tests/wgsl/implicit-system-values.slang
+++ b/tests/wgsl/implicit-system-values.slang
@@ -1,0 +1,103 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<uint> outputBuffer;
+
+interface IInterface
+{
+    uint getLaneIndex();
+    uint getLaneIndex(uint base);
+};
+
+struct Impl1 : IInterface
+{
+    uint getLaneIndex()
+    {
+        return WaveGetLaneIndex();
+    }
+
+    uint getLaneIndex(uint base) 
+    {
+        return base + WaveGetLaneIndex();
+    }
+};
+
+struct Impl2 : IInterface
+{
+    uint getLaneIndex()
+    {
+        return 100;
+    }
+
+    uint getLaneIndex(uint base) 
+    {
+        return base - 1;
+    }
+};
+
+struct Impl3 : IInterface
+{
+    uint getLaneIndex(uint base = 1)
+    {
+        return base + WaveGetLaneIndex() + 1;
+    }
+};
+
+uint getLaneIndexGeneric<T>(T interface, uint base = 3) where T : IInterface
+{
+    return interface.getLaneIndex(base);
+}
+
+struct MyStruct<T> where T : IInterface
+{
+    T interface;
+    uint getLaneIndex(uint base = 4)
+    {
+        return interface.getLaneIndex(base);
+    }
+}
+
+
+void testDynamicDispatch()
+{
+}
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    Impl1 impl1;
+    Impl2 impl2;
+    Impl3 impl3;
+
+    MyStruct<Impl1> s1;
+    MyStruct<Impl2> s2;
+    MyStruct<Impl3> s3;
+
+    // BUF: 1
+    outputBuffer[0] = uint(
+        true
+
+        // Interface implementations.
+        && (0 == impl1.getLaneIndex())
+        && (1 == impl1.getLaneIndex(2))
+        && (100 == impl2.getLaneIndex())
+        && (2 == impl3.getLaneIndex())
+        && (3 == impl3.getLaneIndex(2))
+
+        // Interface as function generic parameter.
+        && (4 == getLaneIndexGeneric(impl1, 4))
+        && (3 == getLaneIndexGeneric(impl2, 4))
+        && (5 == getLaneIndexGeneric(impl3, 4))
+        && (3 == getLaneIndexGeneric(impl1))
+        && (2 == getLaneIndexGeneric(impl2))
+        && (4 == getLaneIndexGeneric(impl3))
+
+        // Interface as struct generic member.
+        && (5 == s1.getLaneIndex(5))
+        && (4 == s2.getLaneIndex(5))
+        && (6 == s3.getLaneIndex(5))
+        && (4 == s1.getLaneIndex())
+        && (3 == s2.getLaneIndex())
+        && (5 == s3.getLaneIndex())
+    );
+}


### PR DESCRIPTION
Closes #6208.

Adds WGSL support for `WaveGetLaneIndex` and `WaveGetLaneCount`.

This change introduces an IR legalization step that allows WGSL builtin(system value) parameters to be propagated
to any other function by traversing its call graph. This is because `WaveGetLaneIndex` and `WaveGetLaneCount`
are "global functions" in HLSL that can be called anywhere while WGSL implements them through
built-in values that need to be passed in to the entry point parameter(Metal is similar).
Traversing the call graph, adding parameters and updating calls "just works" because it is
performed after all the function calls are resolved and lowered and because there is no
support for pointer-based/proper vtable dynamic dispatches.

The change additionally adds `SV_WaveLaneIndex` and `SV_WaveCount` system value semantic names.
This is done so system values can be legalized uniformly for WGSL and Metal targets. It is also
possible to just add these semantic names and add support for these in HLSL(which is easy), while
not supporting `WaveGetLane*` in WGSL and not have a entry point param -> call graph system value
parameter propagation system. This works for these specific intrinsics but does not really work
for Metal's (future) implementation `quadSwap*` intrinsics that require this propagation mechanism - this is a future change that will utilize this PR's code.

The code changes consist 3 parts:
1. `SV_WaveLaneIndex` and `SV_WaveCount` system value semantic names.
2. New implicit system value inst type and legalization step, where relevant function signatures and calls are updated.
   Implementation is placed in one cpp file.
3. `slang-ir-call-graph.cpp` updates to also track function calls in addition to entry points.
