### PR TITLE
Don't remove in-use globals

### DIFF
--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -3353,8 +3353,8 @@ void legalizeEntryPointParameterForGLSL(
                 // globalVarToReplaceNextUse to catch the next use before it is removed from the
                 // list of uses.
                 globalVar->replaceUsesWith(realGlobalVar);
+                globalVar->removeAndDeallocate();
             }
-            globalVar->removeAndDeallocate();
         }
     }
     else


### PR DESCRIPTION
The GLSL interface block implementation accidentally removed global variables which are still in use.