### PR TITLE
Deduplicate witness table while specializing generic functions

### DIFF
--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -1634,6 +1634,17 @@ void DifferentiableTypeConformanceContext::buildGlobalWitnessDictionary()
     {
         if (auto pairType = as<IRDifferentialPairTypeBase>(globalInst))
         {
+#if 0
+            if (auto vecType = as<IRVectorType>(pairType->getValueType()))
+            {
+                auto op0 = vecType->getOperand(0);
+                if (op0->getOp() == kIROp_FloatType)
+                {
+                    int a = 0;
+                    ++a;
+                }
+            }
+#endif
             addTypeToDictionary(pairType->getValueType(), pairType->getWitness());
         }
 

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -1634,17 +1634,6 @@ void DifferentiableTypeConformanceContext::buildGlobalWitnessDictionary()
     {
         if (auto pairType = as<IRDifferentialPairTypeBase>(globalInst))
         {
-#if 0
-            if (auto vecType = as<IRVectorType>(pairType->getValueType()))
-            {
-                auto op0 = vecType->getOperand(0);
-                if (op0->getOp() == kIROp_FloatType)
-                {
-                    int a = 0;
-                    ++a;
-                }
-            }
-#endif
             addTypeToDictionary(pairType->getValueType(), pairType->getWitness());
         }
 

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -3123,7 +3123,7 @@ IRInst* specializeGenericImpl(
             //
             if (auto witnessTable = as<IRWitnessTable>(ii))
             {
-                // CLone type and concreteType to use as cache-key
+                // Clone type and concreteType to use as cache-key
                 auto witnessTableType = witnessTable->getFullType();
                 IRType* clonedWitnessTableType =
                     as<IRType>(cloneInst(&env, builder, witnessTableType));
@@ -3137,7 +3137,7 @@ IRInst* specializeGenericImpl(
 
                 if (!context->mapClonedWitnessTable.tryGetValue(cacheKey, clonedInst))
                 {
-                    // Not found from cache and need to create a new one
+                    // It is not found from cache and we need to create a new one.
                     clonedInst = builder->emitIntrinsicInst(
                         clonedWitnessTableType,
                         kIROp_WitnessTable,
@@ -3146,12 +3146,11 @@ IRInst* specializeGenericImpl(
 
                     clonedInst->sourceLoc = ii->sourceLoc;
 
-                    if (clonedInst != ii)
-                    {
-                        // TODO: Decoration shouldn't matter but it casues a trouble if we don't
-                        // clone them here. It is unclear why.
-                        cloneInstDecorationsAndChildren(&env, builder->getModule(), ii, clonedInst);
-                    }
+                    // It seems that the children are same when the witnessTableType and the
+                    // concrete type are same.
+                    // If it changes in the future, we will need to clone the witness-table-entries
+                    // from the children and use them as the cacheKey as well.
+                    cloneInstDecorationsAndChildren(&env, builder->getModule(), ii, clonedInst);
 
                     context->mapClonedWitnessTable.add(cacheKey, clonedInst);
                 }

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -59,24 +59,18 @@ struct SpecializationContext
     {
         IRWitnessTableType* witnessTableType;
         IRInst* concreteType;
-        IRInstListBase decorationsAndChildren;
 
         WitnessTableKey(IRWitnessTable* wt)
             : witnessTableType(as<IRWitnessTableType>(wt->getFullType()))
             , concreteType(wt->getOperand(0))
-            , decorationsAndChildren(wt->getDecorationsAndChildren())
-        {}
-
-        bool operator==(const WitnessTableKey &other) const
         {
-            if (witnessTableType != other.witnessTableType)
-                return false;
-            if (concreteType != other.concreteType)
-                return false;
-            if (decorationsAndChildren.first != other.decorationsAndChildren.first)
-                return false;
-            return true;
-            }
+        }
+
+        bool operator==(const WitnessTableKey& other) const
+        {
+            return witnessTableType == other.witnessTableType && concreteType == other.concreteType;
+        }
+
         HashCode getHashCode() const
         {
             return combineHash(HashCode(witnessTableType), HashCode(concreteType));
@@ -3135,8 +3129,7 @@ IRInst* specializeGenericImpl(
                 IRInst* cachedInst;
                 if (context->mapClonedWitnessTable.tryGetValue(clonedWitness, cachedInst))
                 {
-                    builder->setInsertBefore(clonedInst);
-                    clonedInst->replaceUsesWith(cachedInst);
+                    env.mapOldValToNew[ii] = cachedInst;
                     clonedInst->removeAndDeallocate();
                     clonedInst = cachedInst;
                 }


### PR DESCRIPTION
This commit fixes an issue that Slang sometimes emits duplicated DiffPair_XX structs when targeting HLSL.

This fix is required for upgrading DXC version from 1.7 to 1.9. With DXC 1.7, it had been fine even with the duplicated structs as long as their member variables are identical. But with DXC 1.9, it causes a compile error.

Closes https://github.com/shader-slang/slang/issues/6364