### PR TITLE
expose value of constant integers in module reflection

### DIFF
--- a/examples/reflection-api/compute-simple.slang
+++ b/examples/reflection-api/compute-simple.slang
@@ -1,5 +1,8 @@
 // compute-simple.slang
 
+static const uint THREADGROUP_SIZE_X = 8;
+static const uint THREADGROUP_SIZE_Y = THREADGROUP_SIZE_X;
+
 struct ImageProcessingOptions
 {
     float3 tintColor;
@@ -10,7 +13,7 @@ struct ImageProcessingOptions
 }
 
 [shader("compute")]
-[numthreads(8, 8)]
+[numthreads(THREADGROUP_SIZE_X, THREADGROUP_SIZE_Y)]
 void processImage(
     uint3 threadID : SV_DispatchThreadID,
     uniform Texture2D inputImage,

--- a/examples/reflection-api/main.cpp
+++ b/examples/reflection-api/main.cpp
@@ -114,6 +114,22 @@ struct ReflectingPrinting
 
         List<ComPtr<slang::IComponentType>> componentsToLink;
 
+        // ### Variable decls
+        // 
+        key("global constants");
+        WITH_ARRAY()
+        for (auto decl: module->getModuleReflection()->getChildren()) {
+            if (auto varDecl = decl->asVariable();
+                varDecl 
+                && varDecl->findModifier(slang::Modifier::Const)
+                && varDecl->findModifier(slang::Modifier::Static)
+                )
+            {
+                element();
+                printVariable(varDecl);
+            }
+        }
+
         // ### Finding Entry Points
         //
 
@@ -213,6 +229,13 @@ struct ReflectingPrinting
         printQuotedString(name);
         key("type");
         printType(type);
+
+        int64_t value;
+        if (SLANG_SUCCEEDED(variable->getDefaultValueInt(&value)))
+        {
+            key("value");
+            printf("%" PRId64, value);
+        }
     }
 
     // ### Types

--- a/examples/reflection-api/main.cpp
+++ b/examples/reflection-api/main.cpp
@@ -115,15 +115,14 @@ struct ReflectingPrinting
         List<ComPtr<slang::IComponentType>> componentsToLink;
 
         // ### Variable decls
-        // 
+        //
         key("global constants");
         WITH_ARRAY()
-        for (auto decl: module->getModuleReflection()->getChildren()) {
-            if (auto varDecl = decl->asVariable();
-                varDecl 
-                && varDecl->findModifier(slang::Modifier::Const)
-                && varDecl->findModifier(slang::Modifier::Static)
-                )
+        for (auto decl : module->getModuleReflection()->getChildren())
+        {
+            if (auto varDecl = decl->asVariable(); varDecl &&
+                                                   varDecl->findModifier(slang::Modifier::Const) &&
+                                                   varDecl->findModifier(slang::Modifier::Static))
             {
                 element();
                 printVariable(varDecl);

--- a/include/slang-deprecated.h
+++ b/include/slang-deprecated.h
@@ -660,8 +660,7 @@ extern "C"
         char const* name);
     SLANG_API bool spReflectionVariable_HasDefaultValue(SlangReflectionVariable* inVar);
     SLANG_API SlangResult
-    spReflectionVariable_GetDefaultValueInt(SlangReflectionVariable* inVar,
-        int64_t* rs);
+    spReflectionVariable_GetDefaultValueInt(SlangReflectionVariable* inVar, int64_t* rs);
     SLANG_API SlangReflectionGeneric* spReflectionVariable_GetGenericContainer(
         SlangReflectionVariable* var);
     SLANG_API SlangReflectionVariable* spReflectionVariable_applySpecializations(

--- a/include/slang-deprecated.h
+++ b/include/slang-deprecated.h
@@ -659,6 +659,9 @@ extern "C"
         SlangSession* globalSession,
         char const* name);
     SLANG_API bool spReflectionVariable_HasDefaultValue(SlangReflectionVariable* inVar);
+    SLANG_API SlangResult
+    spReflectionVariable_GetDefaultValueInt(SlangReflectionVariable* inVar,
+        int64_t* rs);
     SLANG_API SlangReflectionGeneric* spReflectionVariable_GetGenericContainer(
         SlangReflectionVariable* var);
     SLANG_API SlangReflectionVariable* spReflectionVariable_applySpecializations(

--- a/include/slang.h
+++ b/include/slang.h
@@ -2832,6 +2832,11 @@ struct VariableReflection
         return spReflectionVariable_HasDefaultValue((SlangReflectionVariable*)this);
     }
 
+    SlangResult getDefaultValueInt(int64_t* value)
+    {
+        return spReflectionVariable_GetDefaultValueInt((SlangReflectionVariable*)this, value);
+    }
+
     GenericReflection* getGenericContainer()
     {
         return (GenericReflection*)spReflectionVariable_GetGenericContainer(

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1445,7 +1445,10 @@ IntVal* SemanticsVisitor::_validateCircularVarDefinition(VarDeclBase* varDecl)
     //
     if (!isScalarIntegerType(varDecl->type))
         return nullptr;
-    return tryConstantFoldDeclRef(DeclRef<VarDeclBase>(varDecl), ConstantFoldingKind::LinkTime, nullptr);
+    return tryConstantFoldDeclRef(
+        DeclRef<VarDeclBase>(varDecl),
+        ConstantFoldingKind::LinkTime,
+        nullptr);
 }
 
 void SemanticsDeclModifiersVisitor::visitStructDecl(StructDecl* structDecl)

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2350,13 +2350,12 @@ void SemanticsDeclBodyVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
         // a constant with a circular definition.
         //
         varDecl->setCheckState(DeclCheckState::DefinitionChecked);
-        auto intVal = _validateCircularVarDefinition(varDecl);
 
         // Update constant value
         //
         if (!varDecl->val)
         {
-            varDecl->val = intVal;
+            varDecl->val = _validateCircularVarDefinition(varDecl);
         }
     }
     else

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1430,7 +1430,7 @@ bool SemanticsVisitor::shouldSkipChecking(Decl* decl, DeclCheckState state)
     return false;
 }
 
-void SemanticsVisitor::_validateCircularVarDefinition(VarDeclBase* varDecl)
+IntVal* SemanticsVisitor::_validateCircularVarDefinition(VarDeclBase* varDecl)
 {
     // The easiest way to test if the declaration is circular is to
     // validate it as a constant.
@@ -1444,8 +1444,8 @@ void SemanticsVisitor::_validateCircularVarDefinition(VarDeclBase* varDecl)
     //
     //
     if (!isScalarIntegerType(varDecl->type))
-        return;
-    tryConstantFoldDeclRef(DeclRef<VarDeclBase>(varDecl), ConstantFoldingKind::LinkTime, nullptr);
+        return nullptr;
+    return tryConstantFoldDeclRef(DeclRef<VarDeclBase>(varDecl), ConstantFoldingKind::LinkTime, nullptr);
 }
 
 void SemanticsDeclModifiersVisitor::visitStructDecl(StructDecl* structDecl)
@@ -2350,7 +2350,14 @@ void SemanticsDeclBodyVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
         // a constant with a circular definition.
         //
         varDecl->setCheckState(DeclCheckState::DefinitionChecked);
-        _validateCircularVarDefinition(varDecl);
+        auto intVal = _validateCircularVarDefinition(varDecl);
+
+        // Update constant value
+        //
+        if (!varDecl->val)
+        {
+            varDecl->val = intVal;
+        }
     }
     else
     {

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1496,7 +1496,7 @@ public:
     /// by calling a function that indirectly reads the variable) will be allowed and then
     /// exhibit undefined behavior at runtime.
     ///
-    void _validateCircularVarDefinition(VarDeclBase* varDecl);
+    IntVal* _validateCircularVarDefinition(VarDeclBase* varDecl);
 
     bool shouldSkipChecking(Decl* decl, DeclCheckState state);
 

--- a/source/slang/slang-reflection-api.cpp
+++ b/source/slang/slang-reflection-api.cpp
@@ -3164,6 +3164,22 @@ SLANG_API bool spReflectionVariable_HasDefaultValue(SlangReflectionVariable* inV
     return false;
 }
 
+SLANG_API SlangResult
+spReflectionVariable_GetDefaultValueInt(SlangReflectionVariable* inVar, int64_t* rs)
+{
+    auto decl = convert(inVar).getDecl();
+    if (auto varDecl = as<VarDeclBase>(decl))
+    {
+        if (auto constantVal = as<ConstantIntVal>(varDecl->val))
+        {
+            *rs = constantVal->getValue();
+            return 0;
+        }
+    }
+
+    return SLANG_E_INVALID_ARG;
+}
+
 SLANG_API SlangReflectionGeneric* spReflectionVariable_GetGenericContainer(
     SlangReflectionVariable* var)
 {


### PR DESCRIPTION
One of the pain points of working with shaders is needing to keep the definitions of interface types in sync between shader and device code. With the reflection API of slang, it is possible to automate this process by generating a header file for the host language from the reflection data, that contains all interface types used in the shader.
However, one thing missing is the ability to get the value of compile-time constants defined in the shaders. This is useful if you have some constant that an algorithm or a data structure depends on, like a static block or tile size, and you don't want to have to keep them in sync manually between host and shader.

To solve this (at least for integers) this PR adds `VariableReflection::getDefaultValueInt` to get the default value of a variable if it is a compile-time constant integer. The reflection-api example has also been updated to print all the static const variables of a module and their values.

Internally, this uses the `VarDeclBase::val` field that should contain the constant-folded initializer value. However, currently this field is null if, for instance, the initializer is a variable reference (as is the case for THREADGROUP_SIZE_Y in the `compute-simple.slang` of the reflection-api example). It seems to be initialized in `SemanticsDeclHeaderVisitor::checkVarDeclCommon`, which then goes through `SemanticsVisitor::tryConstantFoldExpr`, which does try to follow variable references. However it seems that at this point the reference cannot be resolved. I'd like to make this work before trying to merge this.