### PR TITLE
Metal fix

### DIFF
--- a/source/slang/slang-emit-metal.cpp
+++ b/source/slang/slang-emit-metal.cpp
@@ -136,8 +136,15 @@ void MetalSourceEmitter::_emitHLSLTextureType(IRTextureTypeBase* texType)
     switch (texType->getAccess())
     {
     case SLANG_RESOURCE_ACCESS_READ:
-        m_writer->emit("access::sample");
-        break;
+        {
+            // Metal does not support access::sample for texture buffers, so we need to emit
+            // access::read instead.
+            if (texType->GetBaseShape() == SLANG_TEXTURE_BUFFER)
+                m_writer->emit("access::read");
+            else
+                m_writer->emit("access::sample");
+            break;
+        }
 
     case SLANG_RESOURCE_ACCESS_WRITE:
         m_writer->emit("access::write");

--- a/tests/metal/test_buffer.slang
+++ b/tests/metal/test_buffer.slang
@@ -1,0 +1,17 @@
+// Test that Buffer<T> maps to texture_buffer<uint, access::read> in Metal
+
+//TEST:SIMPLE(filecheck=METAL): -stage compute -entry computeMain -target metal
+
+
+// METAL: texture_buffer<uint, access::read> inputBuffer_{{.*}}
+Buffer<uint> inputBuffer;
+
+RWStructuredBuffer<uint> outputBuffer;
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 dtid : SV_DispatchThreadID)
+{
+    uint idx = dtid.x;
+    // Load values from the buffer to verify correct access
+    outputBuffer[idx] = inputBuffer.Load(idx);
+}

--- a/tools/gfx/metal/metal-device.cpp
+++ b/tools/gfx/metal/metal-device.cpp
@@ -653,8 +653,8 @@ Result DeviceImpl::createTextureView(
     MTL::PixelFormat pixelFormat = desc.format == Format::Unknown
                                        ? textureImpl->m_pixelFormat
                                        : MetalUtil::translatePixelFormat(desc.format);
-    NS::Range levelRange(sr.baseArrayLayer, sr.layerCount);
-    NS::Range sliceRange(sr.mipLevel, sr.mipLevelCount);
+    NS::Range sliceRange(sr.baseArrayLayer, sr.layerCount);
+    NS::Range levelRange(sr.mipLevel, sr.mipLevelCount);
 
     viewImpl->m_textureView = NS::TransferPtr(textureImpl->m_texture->newTextureView(
         pixelFormat,


### PR DESCRIPTION
Fix the issue in creating texture view in metal.
  In newTextureView, levelRange should represent the mipmap level range,
  while sliceRange should represent the texture layer range for texture
  array. But the implementation inverses those two wrongly.


Fix the issue when emitting read only texture_buffer<>
  texture_buffer doesn't support access::sample, we should emit access::read when it's read only buffer.
