### PR TITLE
Clone name hint decoration when emiting Undefined

### DIFF
--- a/source/slang/slang-ir-ssa.cpp
+++ b/source/slang/slang-ir-ssa.cpp
@@ -694,6 +694,7 @@ IRInst* readVarRec(ConstructSSAContext* context, SSABlockInfo* blockInfo, IRVar*
 
             auto type = var->getDataType()->getValueType();
             val = blockInfo->builder.emitUndefined(type);
+            cloneRelevantDecorations(var, val);
         }
         else if (!multiplePreds)
         {
@@ -776,6 +777,7 @@ IRInst* readVar(ConstructSSAContext* context, SSABlockInfo* blockInfo, IRVar* va
         //
         auto type = var->getDataType()->getValueType();
         val = blockInfo->builder.emitUndefined(type);
+        cloneRelevantDecorations(var, val);
         writeVar(context, blockInfo, var, val);
         return val;
     }

--- a/tests/diagnostics/uninitialized-variable-name-in-error-message.slang
+++ b/tests/diagnostics/uninitialized-variable-name-in-error-message.slang
@@ -6,6 +6,12 @@
 RWStructuredBuffer<float> gInput;
 RWStructuredBuffer<float> outputBuffer;
 
+//CHK-DAG: ([[#@LINE+1]]): warning 41016: use of uninitialized variable 'a'
+float func1() { float a; return a; }
+
+//CHK-DAG: ([[#@LINE+1]]): warning 41016: use of uninitialized variable 'b'
+float func2() { float b; return b; }
+
 int test(int inVal)
 {
     return inVal;
@@ -16,12 +22,16 @@ int test(int inVal)
 void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
 {
     int tid = dispatchThreadID.x;
-    int inVal; // = tid; // intentionally uninitialized
+    int inVal1; // intentionally uninitialized
+    int inVal2; // intentionally uninitialized
 
     for (int i = 0; i <2; ++i)
     {
-        // CHK: ([[#@LINE+1]]): warning 41016: use of uninitialized variable 'inVal'
-        int outVal = test(inVal);
+        // CHK-DAG: ([[#@LINE+1]]): warning 41016: use of uninitialized variable 'inVal1'
+        int outVal = test(inVal1);
+
+        // CHK-DAG: ([[#@LINE+1]]): warning 41016: use of uninitialized variable 'inVal2'
+        outVal += test(inVal2);
         outputBuffer[tid] = outVal;
     }
 }

--- a/tests/diagnostics/uninitialized-variable-name-in-error-message.slang
+++ b/tests/diagnostics/uninitialized-variable-name-in-error-message.slang
@@ -1,0 +1,27 @@
+//TEST:SIMPLE(filecheck=CHK):
+
+// Test if the variable name is a part of the error message
+// when it is used inside of for-loop
+
+RWStructuredBuffer<float> gInput;
+RWStructuredBuffer<float> outputBuffer;
+
+int test(int inVal)
+{
+    return inVal;
+}
+
+[Shader("compute")]
+[NumThreads(4, 1, 1)]
+void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+{
+    int tid = dispatchThreadID.x;
+    int inVal; // = tid; // intentionally uninitialized
+
+    for (int i = 0; i <2; ++i)
+    {
+        // CHK: ([[#@LINE+1]]): warning 41016: use of uninitialized variable 'inVal'
+        int outVal = test(inVal);
+        outputBuffer[tid] = outVal;
+    }
+}


### PR DESCRIPTION
When emiting "Undefined", we lost the information of where it was synthasized from. This prevents us from providing more helpful error messages.

The issue was the when we handle "IRLoop", the inputs parameters to the Phi didn't clone the name hint decoration. This commit clones them when emiting "Undefined".

Closes https://github.com/shader-slang/slang/issues/6305