### PR TITLE
Fix SPIRV error for WorkGraphs

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -24407,9 +24407,7 @@ struct DispatchNodeInputRecord
         case spirv:
             return spirv_asm
             {
-                %in_payload_t = OpTypeNodePayloadArrayAMDX $$T;
-                %in_payload_ptr_t = OpTypePointer NodePayloadAMDX %in_payload_t;
-                %var = OpVariable %in_payload_ptr_t NodePayloadAMDX;
+                %var = OpVariable $$NodePayloadPtr<T> NodePayloadAMDX;
                 result : $$NodePayloadPtr<T> = OpAccessChain %var $index;
             };
         }

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1542,7 +1542,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 else if (storageClass == SpvStorageClassNodePayloadAMDX)
                 {
                     auto spvValueType = ensureInst(valueType);
-                    auto spvNodePayloadType = emitOpTypeNodePayloadArray(inst, spvValueType);
+                    auto spvNodePayloadType = emitOpTypeNodePayloadArray(nullptr, spvValueType);
                     valueTypeId = getID(spvNodePayloadType);
                 }
                 else

--- a/tests/workgraphs/consumer.slang
+++ b/tests/workgraphs/consumer.slang
@@ -20,6 +20,9 @@ void main(uint3 dispatchThreadId : SV_GroupThreadID)
     int myData = recordData.myData;
 }
 
+//CHK: OpCapability ShaderEnqueueAMDX
+//CHK: OpExtension "SPV_AMDX_shader_enqueue"
+
 //CHK: ; Types, variables and constants
 //CHK: [[MemberType:%[a-zA-Z_0-9]+]] = OpTypeInt 32 1
 //CHK: [[StructType:%[a-zA-Z_0-9]+]] = OpTypeStruct [[MemberType]]


### PR DESCRIPTION
This commit resolves an error message that is caused while emitting SPIRV code.

The cause was on the fact that there is no corresponding IRInst for one of SPIRV instructions when emitting,
```
%in_payload_t = OpTypeNodePayloadArrayAMDX $$T;
%in_payload_ptr_t = OpTypePointer NodePayloadAMDX %in_payload_t;
```

There is an IRInst for `OpTypePointer` but there isn't IRInst corresponding to `OpTypeNodePayloadArrayAMDX`. When Slang emits `OpTypePointer` with its second operand `OpTypeNodePayloadArrayAMDX`, it is going to be emitted without a matching IRInst.

Closes https://github.com/shader-slang/slang/issues/6391