### PR TITLE
Add implementation for 'uploadTextureData' in metal

### DIFF
--- a/tools/gfx/metal/metal-device.cpp
+++ b/tools/gfx/metal/metal-device.cpp
@@ -331,7 +331,9 @@ Result DeviceImpl::getTextureAllocationInfo(
     FormatInfo formatInfo;
     gfxGetFormatInfo(desc.format, &formatInfo);
     MTL::PixelFormat pixelFormat = MetalUtil::translatePixelFormat(desc.format);
-    Size alignment = m_device->minimumLinearTextureAlignmentForPixelFormat(pixelFormat);
+    bool isCompressed = gfxIsCompressedFormat(desc.format);
+    Size alignment =
+        isCompressed ? 1 : m_device->minimumLinearTextureAlignmentForPixelFormat(pixelFormat);
     Size size = 0;
     ITextureResource::Extents extents = desc.size;
     extents.width = extents.width ? extents.width : 1;


### PR DESCRIPTION
Close #6386.
- Implement uploadTextureData in metal
- Fix a bug in 'copyTextureToBuffer' in metal The last parameter for Metal::copyFromTexture is the 'destinationBytesPerImage', but previous implementation fill in the destination size which is wrong in 3-D texture.