### PR TITLE
Fix TypeCheckingCache concurrency and candidate lifetime.

### DIFF
--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -2565,7 +2565,7 @@ Expr* SemanticsVisitor::ResolveInvoke(InvokeExpr* expr)
                 // We should only use the cached candidate if it is persistent direct declref
                 // created from GlobalSession's ASTBuilder, or it is created in the current Linkage.
                 if (candidate.cacheVersion == typeCheckingCache->version ||
-                    as<DirectDeclRef>(candidate.candidate.item.declRef.declRefBase))
+                    findNextOuterGeneric(candidate.decl) == nullptr)
                 {
                     context.bestCandidateStorage = candidate.candidate;
                     context.bestCandidate = &context.bestCandidateStorage;

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -3591,6 +3591,7 @@ public:
 
     RefPtr<RefObject> m_typeCheckingCache;
     TypeCheckingCache* getTypeCheckingCache();
+    std::mutex m_typeCheckingCacheMutex;
 
 private:
     struct BuiltinModuleInfo


### PR DESCRIPTION
If `candidate.candidate.item.declRef.declRefBase` is a genericapp declref created in previous session, it will be an invalid pointer, and `as<DirectDeclRef>(candidate.candidate.item.declRef.declRefBase)` will crash. We should instead use the decl to check if it is a generic decl ref.