### PR TITLE
Fix a bug with hoisting 'IRVar' insts that are used outside the loop

### DIFF
--- a/source/slang/slang-ir-autodiff-primal-hoist.cpp
+++ b/source/slang/slang-ir-autodiff-primal-hoist.cpp
@@ -371,17 +371,17 @@ void splitLoopConditionBlockInsts(
             // Shouldn't see any vars.
             SLANG_ASSERT(!as<IRVar>(inst));
 
-            HashSet<IRUse*> loopUses;
-            HashSet<IRUse*> afterLoopUses;
+            List<IRUse*> loopUses;
+            List<IRUse*> afterLoopUses;
 
             // Get the indices for the condition block
-            auto condBlockIndices = indexedBlockInfo.getValue(condBlock);
+            auto& condBlockIndices = indexedBlockInfo[condBlock];
 
             // Check all uses of this inst
             for (auto use = inst->firstUse; use; use = use->nextUse)
             {
                 auto userBlock = getBlock(use->getUser());
-                auto userBlockIndices = indexedBlockInfo.getValue(as<IRBlock>(userBlock));
+                auto& userBlockIndices = indexedBlockInfo[userBlock];
 
                 // If all of the condBlock's indices are a subset of the userBlock's indices,
                 // then the userBlock is inside the loop.
@@ -399,13 +399,12 @@ void splitLoopConditionBlockInsts(
             {
                 setInsertAfterOrdinaryInst(&builder, inst);
                 auto copy = builder.emitCheckpointObject(inst);
-                copy->sourceLoc = inst->sourceLoc; // Copy source location so that checkpoint
-                                                   // reporting is accurate
+
+                // Copy source location so that checkpoint reporting is accurate
+                copy->sourceLoc = inst->sourceLoc;
                 // Replace after-loop uses with the copy
                 for (auto use : afterLoopUses)
                 {
-                    // Sanity check
-                    SLANG_ASSERT(!loopUses.contains(use));
                     builder.replaceOperand(use, copy);
                 }
             }

--- a/source/slang/slang-ir-autodiff-primal-hoist.cpp
+++ b/source/slang/slang-ir-autodiff-primal-hoist.cpp
@@ -358,6 +358,10 @@ void splitLoopConditionBlockInsts(
     //
     IRBuilder builder(func->getModule());
 
+
+    List<IRUse*> loopUses;
+    List<IRUse*> afterLoopUses;
+
     for (auto condBlock : loopConditionBlocks)
     {
         // For each inst in the primal condition block, check if it has uses inside the loop body
@@ -371,11 +375,11 @@ void splitLoopConditionBlockInsts(
             // Shouldn't see any vars.
             SLANG_ASSERT(!as<IRVar>(inst));
 
-            List<IRUse*> loopUses;
-            List<IRUse*> afterLoopUses;
-
             // Get the indices for the condition block
             auto& condBlockIndices = indexedBlockInfo[condBlock];
+
+            loopUses.clear();
+            afterLoopUses.clear();
 
             // Check all uses of this inst
             for (auto use = inst->firstUse; use; use = use->nextUse)
@@ -402,6 +406,7 @@ void splitLoopConditionBlockInsts(
 
                 // Copy source location so that checkpoint reporting is accurate
                 copy->sourceLoc = inst->sourceLoc;
+
                 // Replace after-loop uses with the copy
                 for (auto use : afterLoopUses)
                 {

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -716,6 +716,8 @@ INST(BitNot, bitnot, 1, 0)
 
 INST(Select, select, 3, 0)
 
+INST(CheckpointObject, checkpointObj, 1, 0)
+
 INST(GetStringHash, getStringHash, 1, 0)
 
 INST(WaveGetActiveMask, waveGetActiveMask, 0, 0)

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -2664,6 +2664,22 @@ struct IRDiscard : IRTerminatorInst
 {
 };
 
+// Used for representing a distinct copy of an object.
+// This will get lowered into a no-op in the backend,
+// but is useful for IR transformations that need to consider
+// different uses of an inst separately.
+//
+// For example, when we hoist primal insts out of a loop,
+// we need to make distinct copies of the inst for its uses
+// within the loop body and outside of it.
+//
+struct IRCheckpointObject : IRInst
+{
+    IR_LEAF_ISA(CheckpointObject);
+
+    IRInst* getVal() { return getOperand(0); }
+};
+
 // Signals that this point in the code should be unreachable.
 // We can/should emit a dataflow error if we can ever determine
 // that a block ending in one of these can actually be
@@ -4407,6 +4423,8 @@ public:
     IRInst* emitThrow(IRInst* val);
 
     IRInst* emitDiscard();
+
+    IRInst* emitCheckpointObject(IRInst* value);
 
     IRInst* emitUnreachable();
     IRInst* emitMissingReturn();

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -2068,9 +2068,36 @@ Int getSpecializationConstantId(IRGlobalParam* param)
     return offset->getOffset();
 }
 
+IRBlock* getLoopHeaderForConditionBlock(IRBlock* block)
+{
+    // Go through uses and check if any of them are a loop condition block.
+    for (auto use = block->firstUse; use; use = use->nextUse)
+    {
+        if (auto loop = as<IRLoop>(use->getUser()))
+        {
+            if (loop->getTargetBlock() == block)
+                return cast<IRBlock>(loop->getParent());
+        }
+    }
+    return nullptr;
+}
+
 void legalizeDefUse(IRGlobalValueWithCode* func)
 {
     auto dom = computeDominatorTree(func);
+
+    // Make a map of loop condition blocks to their loop header.
+    // We need this because we'll be treating loop condition blocks as
+    // special cases (they are the special blocks since they "dominate" themselves,
+    // in the dominator tree sense)
+    //
+    Dictionary<IRBlock*, IRBlock*> loopHeaderBlockMap;
+    for (auto block : func->getBlocks())
+    {
+        if (auto header = getLoopHeaderForConditionBlock(block))
+            loopHeaderBlockMap.add(block, header);
+    }
+
     for (auto block : func->getBlocks())
     {
         for (auto inst : block->getModifiableChildren())
@@ -2089,16 +2116,22 @@ void legalizeDefUse(IRGlobalValueWithCode* func)
             }
             SLANG_ASSERT(commonDominator);
 
-            if (commonDominator == block)
+            // If commonDominator is 'block' and if the inst is not a Var in
+            // a loop condition block, we can skip the legalization.
+            //
+            if (commonDominator == block &&
+                !(as<IRVar>(inst) && loopHeaderBlockMap.containsKey(block)))
                 continue;
 
-            // If the common dominator is not `block`, it means we have detected
-            // uses that is no longer dominated by the current definition, and need
-            // to be fixed.
-
-            // Normally, we can simply move the definition to the common dominator.
+            // Normally, if the common dominator is not `block`, we can simply move the definition
+            // to the common dominator.
             // An exception is when the common dominator is the target block of a
-            // loop. Note that after normalization, loops are in the form of:
+            // loop.
+            // Another exception is when a var in the loop condition block is accessed both inside
+            // and outside the loop. It is technically visible, but effects on the 'var' are not
+            // visible outside the loop, so we'll need to hoist it out of the loop.
+            //
+            // Note that after normalization, loops are in the form of:
             // ```
             // loop { if (condition) block; else break; }
             // ```
@@ -2107,38 +2140,47 @@ void legalizeDefUse(IRGlobalValueWithCode* func)
             // In this case, we should insert a var/move the inst before the loop
             // instead of before the `if`. This situation can occur in the IR if
             // the original code is lowered from a `do-while` loop.
-            for (auto use = commonDominator->firstUse; use; use = use->nextUse)
+            //
+            bool shouldInitializeVar = false;
+            if (loopHeaderBlockMap.containsKey(commonDominator))
             {
-                if (auto loopUser = as<IRLoop>(use->getUser()))
-                {
-                    if (loopUser->getTargetBlock() == commonDominator)
-                    {
-                        bool shouldMoveToHeader = false;
-                        // Check that the break-block dominates any of the uses are past the break
-                        // block
-                        for (auto _use = inst->firstUse; _use; _use = _use->nextUse)
-                        {
-                            if (dom->dominates(
-                                    loopUser->getBreakBlock(),
-                                    _use->getUser()->getParent()))
-                            {
-                                shouldMoveToHeader = true;
-                                break;
-                            }
-                        }
+                bool shouldMoveToHeader = false;
 
-                        if (shouldMoveToHeader)
-                            commonDominator = as<IRBlock>(loopUser->getParent());
+                // Check that the break-block dominates any of the uses are past the break
+                // block
+                for (auto _use = inst->firstUse; _use; _use = _use->nextUse)
+                {
+                    if (dom->dominates(
+                            as<IRLoop>(loopHeaderBlockMap[commonDominator]->getTerminator())
+                                ->getBreakBlock(),
+                            _use->getUser()->getParent()))
+                    {
+                        shouldMoveToHeader = true;
                         break;
                     }
                 }
+                if (shouldMoveToHeader)
+                {
+                    commonDominator = loopHeaderBlockMap[commonDominator];
+                    shouldInitializeVar = true;
+                }
             }
+
             // Now we can legalize uses based on the type of `inst`.
             if (auto var = as<IRVar>(inst))
             {
                 // If inst is an var, this is easy, we just move it to the
                 // common dominator.
                 var->insertBefore(commonDominator->getTerminator());
+                if (shouldInitializeVar)
+                {
+                    IRBuilder builder(func);
+                    builder.setInsertAfter(var);
+                    builder.emitStore(
+                        var,
+                        builder.emitDefaultConstruct(
+                            as<IRPtrTypeBase>(var->getDataType())->getValueType()));
+                }
             }
             else
             {

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -5652,6 +5652,13 @@ IRInst* IRBuilder::emitDiscard()
     return inst;
 }
 
+IRInst* IRBuilder::emitCheckpointObject(IRInst* value)
+{
+    auto inst =
+        createInst<IRCheckpointObject>(this, kIROp_CheckpointObject, value->getFullType(), value);
+    addInst(inst);
+    return inst;
+}
 
 IRInst* IRBuilder::emitBranch(IRBlock* pBlock)
 {

--- a/tests/autodiff/reverse-continue-loop.slang
+++ b/tests/autodiff/reverse-continue-loop.slang
@@ -16,7 +16,7 @@ float test_loop_with_continue(float y)
     //CHK-DAG: note: 20 bytes (FixedArray<float, 5> ) used to checkpoint the following item:
     float t = y;
 
-    //CHK-DAG: note: 4 bytes (int32_t) used for a loop counter here:
+    //CHK-DAG: note: 4 bytes (int32_t) used to checkpoint the following item:
     for (int i = 0; i < 3; i++)
     {
         if (t > 4.0)

--- a/tests/autodiff/reverse-loop-immediate-return.slang
+++ b/tests/autodiff/reverse-loop-immediate-return.slang
@@ -1,0 +1,59 @@
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK): -slang -compute -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+
+[BackwardDerivative(set_bwd)]
+void set(uint idx, float x)
+{
+    outputBuffer[idx] = x;
+}
+
+void set_bwd(uint idx, inout DifferentialPair<float> x)
+{
+    // For debugging, we'll set the derivative to 1.0
+    x = DifferentialPair<float>(x.p, 1.0f);
+}
+
+[Differentiable]
+void run(
+    uint idx,
+    float x)
+{
+    if (idx >= 1) return;
+
+    if (idx == 0)
+    { }
+
+    for (int i = 0; i < 1; i++)
+    {
+        if (idx > 0)
+        {
+            return;
+        }
+
+        if (idx == 0)
+        { 
+            x = x * 2.0f;
+        }
+    }
+
+    if (idx == 0)
+    { }
+
+    set(idx, x);
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    // bwd_diff
+    DifferentialPair<float> dpa = DifferentialPair<float>(1.0, 0.0);
+    bwd_diff(run)(dispatchThreadID.x, dpa);
+    outputBuffer[dispatchThreadID.x] = dpa.d; 
+    
+    // CHECK: type: float
+    // CHECK: 2.0
+}


### PR DESCRIPTION
- We introduce a 'OpCheckpointObject' inst and use that to split loop state insts into two pieces (one for within-loop uses and one for outside-loop uses.
- This allows the two kinds of uses to be handled separately by the hoisting mechanism
- `OpCheckpointObject` is then lowered to a no-op after hoisting is complete.

Also added a test to check for this.

Fixes: https://github.com/shader-slang/slang/issues/6394 and https://github.com/shader-slang/slang/issues/5999