### PR TITLE
Enable friendly-name option for SPIRV dump and validation

### DIFF
--- a/source/slang-glslang/slang-glslang.cpp
+++ b/source/slang-glslang/slang-glslang.cpp
@@ -175,6 +175,7 @@ extern "C"
 
     spvtools::ValidatorOptions options;
     options.SetScalarBlockLayout(true);
+    options.SetFriendlyNames(true);
 
     spvtools::SpirvTools tools(target_env);
     tools.SetMessageConsumer(validationMessageConsumer);
@@ -197,6 +198,7 @@ extern "C"
     options |= SPV_BINARY_TO_TEXT_OPTION_COMMENT;
     options |= SPV_BINARY_TO_TEXT_OPTION_PRINT;
     options |= SPV_BINARY_TO_TEXT_OPTION_COLOR;
+    options |= SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES;
 
     spv_diagnostic diagnostic = nullptr;
     spv_context context = spvContextCreate(kDefaultEnvironment);


### PR DESCRIPTION
This change will allow us to read the SPIRV-asm with more friendly variable names.

Currently it dumps the variables as numbers.
There are variable name decorations defined as a part of the dumped spirv, but we had to manually reference them.

With the friendly-name option enabled, the number style variable names are replaced with the string style names.
It will help us to read the spir-v dump more easily.