### PR TITLE
[WIP] Allow duplication of OpTypeNodePayloadArrayAMDX

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -4211,6 +4211,25 @@ attribute_syntax [QuadDerivatives] : QuadDerivativesAttribute;
 __attributeTarget(FuncDecl)
 attribute_syntax [RequireFullQuads] : RequireFullQuadsAttribute;
 
-__generic<T>
-typealias NodePayloadPtr = Ptr<T, $( (uint64_t)AddressSpace::NodePayloadAMDX)>;
+// Work-graphs
+
+/// @internal
+/// __SPIRVNodePayloadArray is to emit OpTypeNodePayloadArrayAMDX and
+/// SpvDecorationPayloadNodeNameAMDX for it.
+///
+__generic<RecordType, let nodeID : int>
+__intrinsic_type($(kIROp_SPIRVNodePayloadArrayType))
+struct __SPIRVNodePayloadArray;
+
+/// @internal
+/// NodePayloadArrayPtr is a pointer type for "NodePayloadAMDX" storage-class and it points to an array of work-graph nodes
+///
+__generic<RecordType, let nodeID : int>
+typealias NodePayloadArrayPtr = Ptr<__SPIRVNodePayloadArray<RecordType, nodeID>, $( (uint64_t)AddressSpace::NodePayloadAMDX)>;
+
+/// @internal
+/// NodePayloadPtr is a pointer type for "NodePayloadAMDX" storage-class and it points to a `RecordType`.
+///
+__generic<RecordType>
+typealias NodePayloadPtr = Ptr<RecordType, $( (uint64_t)AddressSpace::NodePayloadAMDX)>;
 

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -4227,9 +4227,9 @@ struct __SPIRVNodePayloadArray;
 __generic<BaseType, let nodeID : int>
 typealias NodePayloadArrayPtr = Ptr<__SPIRVNodePayloadArray<BaseType, nodeID>, $( (uint64_t)AddressSpace::NodePayloadAMDX)>;
 
-/// @public
-/// FunctionPtr is a pointer type for "Function" storage-class and it points to a `BaseType`.
+/// @internal
+/// NodePayloadPtr is a pointer type for "NodePayloadAMDX" storage-class and it points to a `RecordType`.
 ///
-__generic<BaseType>
-typealias FunctionPtr = Ptr<BaseType, $( (uint64_t)AddressSpace::Function)>;
+__generic<RecordType>
+typealias NodePayloadPtr = Ptr<RecordType, $( (uint64_t)AddressSpace::NodePayloadAMDX)>;
 

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -4217,19 +4217,19 @@ attribute_syntax [RequireFullQuads] : RequireFullQuadsAttribute;
 /// __SPIRVNodePayloadArray is to emit OpTypeNodePayloadArrayAMDX and
 /// SpvDecorationPayloadNodeNameAMDX for it.
 ///
-__generic<RecordType, let nodeID : int>
+__generic<BaseType, let nodeID : int>
 __intrinsic_type($(kIROp_SPIRVNodePayloadArrayType))
 struct __SPIRVNodePayloadArray;
 
 /// @internal
 /// NodePayloadArrayPtr is a pointer type for "NodePayloadAMDX" storage-class and it points to an array of work-graph nodes
 ///
-__generic<RecordType, let nodeID : int>
-typealias NodePayloadArrayPtr = Ptr<__SPIRVNodePayloadArray<RecordType, nodeID>, $( (uint64_t)AddressSpace::NodePayloadAMDX)>;
+__generic<BaseType, let nodeID : int>
+typealias NodePayloadArrayPtr = Ptr<__SPIRVNodePayloadArray<BaseType, nodeID>, $( (uint64_t)AddressSpace::NodePayloadAMDX)>;
 
-/// @internal
-/// NodePayloadPtr is a pointer type for "NodePayloadAMDX" storage-class and it points to a `RecordType`.
+/// @public
+/// FunctionPtr is a pointer type for "Function" storage-class and it points to a `BaseType`.
 ///
-__generic<RecordType>
-typealias NodePayloadPtr = Ptr<RecordType, $( (uint64_t)AddressSpace::NodePayloadAMDX)>;
+__generic<BaseType>
+typealias FunctionPtr = Ptr<BaseType, $( (uint64_t)AddressSpace::Function)>;
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -24356,15 +24356,19 @@ struct ThreadNodeOutputRecords
     NodePayloadArrayPtr<RecordType, nodeID> alloc;
 
     [ForceInline]
-    [require(spirv)] // [require(spirv, thread)]
+    [require(hlsl_spirv)] // [require(hlsl_spirv, thread)]
     __init(int recordCount, int nodeIndex = 0)
     {
-        // TODO: It seems that unexpected SPIRV code gets emitted here when
-        // assign from spriv_asm to `alloc` such as `get_field_addr`
-        alloc = spirv_asm
+        __target_switch
         {
-            result = OpAllocateNodePayloadsAMDX $$NodePayloadArrayPtr<RecordType, nodeID> Workgroup $recordCount $nodeIndex;
-        };
+        case hlsl: return;
+        case spirv:
+            alloc = spirv_asm
+            {
+                result = OpAllocateNodePayloadsAMDX $$NodePayloadArrayPtr<RecordType, nodeID> Workgroup $recordCount $nodeIndex;
+            };
+            return;
+        }
     }
 
     [ForceInline]
@@ -24384,23 +24388,22 @@ struct ThreadNodeOutputRecords
         get { return Get(index); }
     }
 
+    [ForceInline]
     FunctionPtr<RecordType> Get(int index = 0)
     {
         __target_switch
         {
         case hlsl: __intrinsic_asm ".Get";
         case spirv:
-            let tmp = reinterpret<NodePayloadArrayPtr<RecordType, nodeID>>(alloc);
-            let ptr = spirv_asm
+            return spirv_asm
             {
                 %tempPtrVar  = OpVariable $$FunctionPtr<__SPIRVNodePayloadArray<RecordType, nodeID>> Function;
 
-                %loaded = OpLoad $$__SPIRVNodePayloadArray<RecordType, nodeID> $tmp;
+                %loaded = OpLoad $$__SPIRVNodePayloadArray<RecordType, nodeID> $alloc;
                 OpStore %tempPtrVar %loaded;
 
                 result : $$FunctionPtr<RecordType> = OpAccessChain %tempPtrVar $index
             };
-            return ptr;
         }
     }
 };

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -24353,11 +24353,11 @@ int8_t4_packed pack_clamp_s8(int16_t4 unpackedValue)
 __generic<RecordType, let nodeID : int>
 struct ThreadNodeOutputRecords
 {
-    FunctionPtr<__SPIRVNodePayloadArray<RecordType, nodeID>> alloc;
+    NodePayloadArrayPtr<RecordType, nodeID> alloc;
 
     [ForceInline]
     [require(hlsl_spirv)] // [require(hlsl_spirv, thread)]
-    __init(int recordCount, int nodeIndex = 0)
+    __init(int recordCount, int nodeIndex = 0) // , constexpr String nodeStr)
     {
         __target_switch
         {
@@ -24365,16 +24365,11 @@ struct ThreadNodeOutputRecords
         case spirv:
             alloc = spirv_asm
             {
-                %alloc = OpAllocateNodePayloadsAMDX $$NodePayloadArrayPtr<RecordType, nodeID> Workgroup $recordCount $nodeIndex;
-
-                %loaded = OpLoad $$__SPIRVNodePayloadArray<RecordType, nodeID> %alloc;
-
-                %tempPtrVar  = OpVariable $$FunctionPtr<__SPIRVNodePayloadArray<RecordType, nodeID>> Function;
-                OpStore %tempPtrVar %loaded;
-
-                result : $$FunctionPtr<__SPIRVNodePayloadArray<RecordType, nodeID>> = OpCopyObject %tempPtrVar;
+                //TODO: `String` doesn't seem to work inside of spirv_asm.
+                //%nodeStr = OpConstantStringAMDX $nodeStr;
+                //OpDecorateId $$__SPIRVNodePayloadArray<BaseType, nodeID> PayloadNodeNameAMDX %nodeStr;
+                result = OpAllocateNodePayloadsAMDX $$NodePayloadArrayPtr<RecordType, nodeID> Workgroup $recordCount $nodeIndex;
             };
-            return;
         }
     }
 
@@ -24389,14 +24384,15 @@ struct ThreadNodeOutputRecords
         }
     }
 
-    __subscript(uint index) -> FunctionPtr<RecordType>
+    __subscript(uint index) -> NodePayloadPtr<RecordType>
     {
         [ForceInline]
         get { return Get(index); }
     }
 
     [ForceInline]
-    FunctionPtr<RecordType> Get(int index = 0)
+    [require(hlsl_spirv)] // [require(hlsl_spirv, thread)]
+    NodePayloadPtr<RecordType> Get(int index = 0)
     {
         __target_switch
         {
@@ -24404,7 +24400,7 @@ struct ThreadNodeOutputRecords
         case spirv:
             return spirv_asm
             {
-                result : $$FunctionPtr<RecordType> = OpAccessChain $alloc $index
+                result : $$NodePayloadPtr<RecordType> = OpAccessChain $alloc $index
             };
         }
     }
@@ -24416,8 +24412,31 @@ struct ThreadNodeOutputRecords
 __generic<RecordType, let nodeID : int>
 struct DispatchNodeInputRecord
 {
+    NodePayloadArrayPtr<RecordType, nodeID> payload;
+
+    [ForceInline]
+    [require(hlsl_spirv)] // [require(hlsl_spirv, broadcasting)]
+    __init()
+    {
+        __target_switch
+        {
+        case hlsl: return;
+        case spirv:
+            //TODO: It may be simpler if we add a new __intrinsic_op for OpVariable with NodePayloadAMDX.
+            payload = spirv_asm
+            {
+                // The variable name, "%payload", is required here,
+                // because it needs to be send to OpEntryPoint as an interface.
+                %payload = OpVariable $$NodePayloadArrayPtr<RecordType, nodeID> NodePayloadAMDX;
+                result : $$NodePayloadArrayPtr<RecordType, nodeID> = OpCopyObject %payload;
+            };
+        }
+    }
+
     /// Provide an access to a record object that only holds a single record.
-    FunctionPtr<RecordType> Get()
+    [ForceInline]
+    [require(hlsl_spirv)] // [require(hlsl_spirv, broadcasting)]
+    NodePayloadPtr<RecordType> Get()
     {
         int index = 0;
 
@@ -24425,19 +24444,10 @@ struct DispatchNodeInputRecord
         {
         case hlsl: __intrinsic_asm ".Get";
         case spirv:
-            let ptr = spirv_asm
+            return spirv_asm
             {
-                %nodePtrType = OpTypePointer NodePayloadAMDX $$__SPIRVNodePayloadArray<RecordType, nodeID>;
-                %nodePtrVar = OpVariable %nodePtrType NodePayloadAMDX;
-
-                %tempPtrVar = OpVariable $$FunctionPtr<__SPIRVNodePayloadArray<RecordType, nodeID>> Function;
-
-                %loaded = OpLoad $$__SPIRVNodePayloadArray<RecordType, nodeID> %nodePtrVar;
-                OpStore %tempPtrVar %loaded;
-
-                result : $$FunctionPtr<RecordType> = OpAccessChain %tempPtrVar $index;
+                result : $$NodePayloadPtr<RecordType> = OpAccessChain $payload $index;
             };
-            return ptr;
         }
     }
 };

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -24347,28 +24347,85 @@ int8_t4_packed pack_clamp_s8(int16_t4 unpackedValue)
 
 // Work-graphs
 
+///@public
+/// Set of zero or more records for each thread.
+///
+__generic<RecordType, let nodeID : int>
+struct ThreadNodeOutputRecords
+{
+    NodePayloadArrayPtr<RecordType, nodeID> alloc;
+
+    [ForceInline]
+    [require(spirv)] // [require(spirv, thread)]
+    __init(int recordCount, int nodeIndex = 0)
+    {
+        alloc = spirv_asm
+        {
+            result = OpAllocateNodePayloadsAMDX $$NodePayloadArrayPtr<RecordType, nodeID> Workgroup $recordCount $nodeIndex;
+        };
+    }
+
+    [ForceInline]
+    [require(hlsl_spirv)] // [require(hlsl_spirv, thread)]
+    void OutputComplete()
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm ".OutputComplete";
+        case spirv: spirv_asm { OpEnqueueNodePayloadsAMDX $alloc; };
+        }
+    }
+
+    __subscript(uint index) -> NodePayloadPtr<RecordType>
+    {
+        [ForceInline]
+        get { return Get(index); }
+    }
+
+    [ForceInline]
+    [require(hlsl_spirv)] // [require(hlsl_spirv, thread)]
+    NodePayloadPtr<RecordType> Get(int index = 0)
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm ".Get";
+        case spirv:
+            NodePayloadArrayPtr<RecordType, nodeID> ptr = spirv_asm
+            {
+                %ptr  = OpTypePointer Function $$__SPIRVNodePayloadArray<RecordType, nodeID>;
+                %var  = OpVariable %ptr Function;
+                        OpStore %var $alloc;
+                %Load = OpLoad $$NodePayloadArrayPtr<RecordType, nodeID> %var;
+                result : $$NodePayloadArrayPtr<RecordType, nodeID> = OpAccessChain %Load $index
+            };
+            return reinterpret<NodePayloadPtr<RecordType>>(ptr);
+        }
+    }
+};
+
 //@public:
-/// read-only input to Broadcasting launch node.
-__generic<T>
-//TODO: DispatchNodeInputRecord should be available only for broadcasting node shader.
-//[require(broadcasting_node)]
-[require(spirv)]
+/// Read-only input to Broadcasting launch node.
+///
+__generic<RecordType, let nodeID : int>
 struct DispatchNodeInputRecord
 {
     /// Provide an access to a record object that only holds a single record.
-    NodePayloadPtr<T> Get()
+    [ForceInline]
+    [require(hlsl_spirv)] // [require(hlsl_spirv, broadcasting)]
+    NodePayloadPtr<RecordType> Get()
     {
         int index = 0;
         __target_switch
         {
+        case hlsl: __intrinsic_asm ".Get";
         case spirv:
-            return spirv_asm
+            NodePayloadArrayPtr<RecordType, nodeID> ptr = spirv_asm
             {
-                %in_payload_t = OpTypeNodePayloadArrayAMDX $$T;
-                %in_payload_ptr_t = OpTypePointer NodePayloadAMDX %in_payload_t;
-                %var = OpVariable %in_payload_ptr_t NodePayloadAMDX;
-                result : $$NodePayloadPtr<T> = OpAccessChain %var $index;
+                %ptr = OpTypePointer NodePayloadAMDX $$__SPIRVNodePayloadArray<RecordType, nodeID>;
+                %var = OpVariable %ptr NodePayloadAMDX;
+                result : $$NodePayloadArrayPtr<RecordType, nodeID> = OpAccessChain %var $index;
             };
+            return reinterpret<NodePayloadPtr<RecordType>>(ptr);
         }
     }
 };

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -24450,6 +24450,15 @@ struct DispatchNodeInputRecord
             };
         }
     }
+
+    [ForceInline]
+    uint Count()
+    {
+        return spirv_asm
+        {
+            result: $$uint = OpNodePayloadArrayLengthAMDX $payload;
+        };
+    }
 };
 
 //

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -24359,6 +24359,8 @@ struct ThreadNodeOutputRecords
     [require(spirv)] // [require(spirv, thread)]
     __init(int recordCount, int nodeIndex = 0)
     {
+        // TODO: It seems that unexpected SPIRV code gets emitted here when
+        // assign from spriv_asm to `alloc` such as `get_field_addr`
         alloc = spirv_asm
         {
             result = OpAllocateNodePayloadsAMDX $$NodePayloadArrayPtr<RecordType, nodeID> Workgroup $recordCount $nodeIndex;
@@ -24376,29 +24378,29 @@ struct ThreadNodeOutputRecords
         }
     }
 
-    __subscript(uint index) -> NodePayloadPtr<RecordType>
+    __subscript(uint index) -> FunctionPtr<RecordType>
     {
         [ForceInline]
         get { return Get(index); }
     }
 
-    [ForceInline]
-    [require(hlsl_spirv)] // [require(hlsl_spirv, thread)]
-    NodePayloadPtr<RecordType> Get(int index = 0)
+    FunctionPtr<RecordType> Get(int index = 0)
     {
         __target_switch
         {
         case hlsl: __intrinsic_asm ".Get";
         case spirv:
-            NodePayloadArrayPtr<RecordType, nodeID> ptr = spirv_asm
+            let tmp = reinterpret<NodePayloadArrayPtr<RecordType, nodeID>>(alloc);
+            let ptr = spirv_asm
             {
-                %ptr  = OpTypePointer Function $$__SPIRVNodePayloadArray<RecordType, nodeID>;
-                %var  = OpVariable %ptr Function;
-                        OpStore %var $alloc;
-                %Load = OpLoad $$NodePayloadArrayPtr<RecordType, nodeID> %var;
-                result : $$NodePayloadArrayPtr<RecordType, nodeID> = OpAccessChain %Load $index
+                %tempPtrVar  = OpVariable $$FunctionPtr<__SPIRVNodePayloadArray<RecordType, nodeID>> Function;
+
+                %loaded = OpLoad $$__SPIRVNodePayloadArray<RecordType, nodeID> $tmp;
+                OpStore %tempPtrVar %loaded;
+
+                result : $$FunctionPtr<RecordType> = OpAccessChain %tempPtrVar $index
             };
-            return reinterpret<NodePayloadPtr<RecordType>>(ptr);
+            return ptr;
         }
     }
 };
@@ -24410,22 +24412,27 @@ __generic<RecordType, let nodeID : int>
 struct DispatchNodeInputRecord
 {
     /// Provide an access to a record object that only holds a single record.
-    [ForceInline]
-    [require(hlsl_spirv)] // [require(hlsl_spirv, broadcasting)]
-    NodePayloadPtr<RecordType> Get()
+    FunctionPtr<RecordType> Get()
     {
         int index = 0;
+
         __target_switch
         {
         case hlsl: __intrinsic_asm ".Get";
         case spirv:
-            NodePayloadArrayPtr<RecordType, nodeID> ptr = spirv_asm
+            let ptr = spirv_asm
             {
-                %ptr = OpTypePointer NodePayloadAMDX $$__SPIRVNodePayloadArray<RecordType, nodeID>;
-                %var = OpVariable %ptr NodePayloadAMDX;
-                result : $$NodePayloadArrayPtr<RecordType, nodeID> = OpAccessChain %var $index;
+                %nodePtrType = OpTypePointer NodePayloadAMDX $$__SPIRVNodePayloadArray<RecordType, nodeID>;
+                %nodePtrVar = OpVariable %nodePtrType NodePayloadAMDX;
+
+                %tempPtrVar = OpVariable $$FunctionPtr<__SPIRVNodePayloadArray<RecordType, nodeID>> Function;
+
+                %loaded = OpLoad $$__SPIRVNodePayloadArray<RecordType, nodeID> %nodePtrVar;
+                OpStore %tempPtrVar %loaded;
+
+                result : $$FunctionPtr<RecordType> = OpAccessChain %tempPtrVar $index;
             };
-            return reinterpret<NodePayloadPtr<RecordType>>(ptr);
+            return ptr;
         }
     }
 };

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -24353,7 +24353,7 @@ int8_t4_packed pack_clamp_s8(int16_t4 unpackedValue)
 __generic<RecordType, let nodeID : int>
 struct ThreadNodeOutputRecords
 {
-    NodePayloadArrayPtr<RecordType, nodeID> alloc;
+    FunctionPtr<__SPIRVNodePayloadArray<RecordType, nodeID>> alloc;
 
     [ForceInline]
     [require(hlsl_spirv)] // [require(hlsl_spirv, thread)]
@@ -24365,7 +24365,14 @@ struct ThreadNodeOutputRecords
         case spirv:
             alloc = spirv_asm
             {
-                result = OpAllocateNodePayloadsAMDX $$NodePayloadArrayPtr<RecordType, nodeID> Workgroup $recordCount $nodeIndex;
+                %alloc = OpAllocateNodePayloadsAMDX $$NodePayloadArrayPtr<RecordType, nodeID> Workgroup $recordCount $nodeIndex;
+
+                %loaded = OpLoad $$__SPIRVNodePayloadArray<RecordType, nodeID> %alloc;
+
+                %tempPtrVar  = OpVariable $$FunctionPtr<__SPIRVNodePayloadArray<RecordType, nodeID>> Function;
+                OpStore %tempPtrVar %loaded;
+
+                result : $$FunctionPtr<__SPIRVNodePayloadArray<RecordType, nodeID>> = OpCopyObject %tempPtrVar;
             };
             return;
         }
@@ -24397,12 +24404,7 @@ struct ThreadNodeOutputRecords
         case spirv:
             return spirv_asm
             {
-                %tempPtrVar  = OpVariable $$FunctionPtr<__SPIRVNodePayloadArray<RecordType, nodeID>> Function;
-
-                %loaded = OpLoad $$__SPIRVNodePayloadArray<RecordType, nodeID> $alloc;
-                OpStore %tempPtrVar %loaded;
-
-                result : $$FunctionPtr<RecordType> = OpAccessChain %tempPtrVar $index
+                result : $$FunctionPtr<RecordType> = OpAccessChain $alloc $index
             };
         }
     }

--- a/source/slang/slang-emit-spirv-ops.h
+++ b/source/slang/slang-emit-spirv-ops.h
@@ -2604,7 +2604,7 @@ SpvInst* emitOpConstantString(IRInst* inst, const UnownedStringSlice& str)
         str);
 }
 
-// https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorateId
+// https://github.khronos.org/SPIRV-Registry/extensions/AMD/SPV_AMDX_shader_enqueue.html#_decorations
 template<typename T1, typename T2>
 SpvInst* emitOpDecoratePayloadNodeName(IRInst* inst, const T1& target, const T2& id)
 {

--- a/source/slang/slang-emit-spirv-ops.h
+++ b/source/slang/slang-emit-spirv-ops.h
@@ -2585,12 +2585,36 @@ template<typename T>
 SpvInst* emitOpTypeNodePayloadArray(IRInst* inst, const T& type)
 {
     static_assert(isSingular<T>);
-    return emitInstMemoized(
+    return emitInst(
         getSection(SpvLogicalSectionID::ConstantsAndTypes),
         inst,
         SpvOpTypeNodePayloadArrayAMDX,
         kResultID,
         type);
+}
+
+// https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/AMD/SPV_AMDX_shader_enqueue.html#OpTypeNodePayloadArrayAMDX
+SpvInst* emitOpConstantString(IRInst* inst, const UnownedStringSlice& str)
+{
+    return emitInstMemoized(
+        getSection(SpvLogicalSectionID::ConstantsAndTypes),
+        inst,
+        SpvOpConstantStringAMDX,
+        kResultID,
+        str);
+}
+
+// https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorateId
+template<typename T1, typename T2>
+SpvInst* emitOpDecoratePayloadNodeName(IRInst* inst, const T1& target, const T2& id)
+{
+    return emitInst(
+        getSection(SpvLogicalSectionID::Annotations),
+        inst,
+        SpvOpDecorateId,
+        target,
+        SpvDecorationPayloadNodeNameAMDX,
+        id);
 }
 
 #endif // SLANG_IN_SPIRV_EMIT_CONTEXT

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1931,8 +1931,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         case kIROp_SPIRVNodePayloadArrayType:
             if (auto nodePayloadArrayType = as<IRSPIRVNodePayloadArrayType>(inst))
             {
-                auto newType = emitOpTypeNodePayloadArray(
-                    inst, nodePayloadArrayType->getRecordType());
+                auto newType =
+                    emitOpTypeNodePayloadArray(inst, nodePayloadArrayType->getRecordType());
 
                 // TODO: This is a temporary hack.
                 // The NodeID must come from an attribute [NodeID("name")].
@@ -1941,10 +1941,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 SpvInst* spvStr = emitOpConstantString(nullptr, str.getUnownedSlice());
                 (void)spvStr;
 
-                auto r = emitOpDecoratePayloadNodeName(
-                    nullptr,
-                    newType,
-                    spvStr);
+                auto r = emitOpDecoratePayloadNodeName(nullptr, newType, spvStr);
                 (void)r;
                 return newType;
             }

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -7857,7 +7857,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
     {
         SpvInst* last = nullptr;
 
-        auto &idMap = m_idMaps.getOrAddValue(inst, Dictionary<UnownedStringSlice, SpvWord>());
+        auto& idMap = m_idMaps.getOrAddValue(inst, Dictionary<UnownedStringSlice, SpvWord>());
 
         for (const auto spvInst : inst->getInsts())
         {
@@ -8208,7 +8208,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 if (opcode == SpvOpVariable)
                 {
                     // SPIRV validator says,
-                    // "All OpVariable instructions in a function must be the first instructions in the first block."
+                    // "All OpVariable instructions in a function must be the first instructions in
+                    // the first block."
                     opParent = firstLabel;
 
                     auto opStorageClass = spvInst->getOperand(3);

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1934,6 +1934,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 auto newType = emitOpTypeNodePayloadArray(
                     inst, nodePayloadArrayType->getRecordType());
 
+                // TODO: This is a temporary hack.
+                // The NodeID must come from an attribute [NodeID("name")].
                 Slang::StringBuilder str;
                 str << "NodeID_" << uint32_t(nodePayloadArrayType->getNodeID()->getValue());
                 SpvInst* spvStr = emitOpConstantString(nullptr, str.getUnownedSlice());
@@ -7895,7 +7897,6 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                         return getSection(SpvLogicalSectionID::Annotations);
                     case SpvOpTypeNodePayloadArrayAMDX:
                         return getSection(SpvLogicalSectionID::ConstantsAndTypes);
-
                     default:
                         return defaultParent;
                     }

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1934,6 +1934,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 auto newType =
                     emitOpTypeNodePayloadArray(inst, nodePayloadArrayType->getRecordType());
 
+ #if 0
                 // TODO: This is a temporary hack.
                 // The NodeID must come from an attribute [NodeID("name")].
                 Slang::StringBuilder str;
@@ -1941,8 +1942,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 SpvInst* spvStr = emitOpConstantString(nullptr, str.getUnownedSlice());
                 (void)spvStr;
 
-                auto r = emitOpDecoratePayloadNodeName(nullptr, newType, spvStr);
-                (void)r;
+                emitOpDecoratePayloadNodeName(nullptr, newType, spvStr);
+#endif
                 return newType;
             }
         default:

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1585,8 +1585,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 else if (storageClass == SpvStorageClassNodePayloadAMDX)
                 {
                     auto spvValueType = ensureInst(valueType);
-                    auto spvNodePayloadType = emitOpTypeNodePayloadArray(inst, spvValueType);
-                    valueTypeId = getID(spvNodePayloadType);
+                    valueTypeId = getID(spvValueType);
                 }
                 else
                 {
@@ -1929,6 +1928,24 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         case kIROp_IndicesType:
         case kIROp_PrimitivesType:
             return nullptr;
+        case kIROp_SPIRVNodePayloadArrayType:
+            if (auto nodePayloadArrayType = as<IRSPIRVNodePayloadArrayType>(inst))
+            {
+                auto newType = emitOpTypeNodePayloadArray(
+                    inst, nodePayloadArrayType->getRecordType());
+
+                Slang::StringBuilder str;
+                str << "NodeID_" << uint32_t(nodePayloadArrayType->getNodeID()->getValue());
+                SpvInst* spvStr = emitOpConstantString(nullptr, str.getUnownedSlice());
+                (void)spvStr;
+
+                auto r = emitOpDecoratePayloadNodeName(
+                    nullptr,
+                    newType,
+                    spvStr);
+                (void)r;
+                return newType;
+            }
         default:
             {
                 if (as<IRSPIRVAsmOperand>(inst))
@@ -7878,6 +7895,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                         return getSection(SpvLogicalSectionID::Annotations);
                     case SpvOpTypeNodePayloadArrayAMDX:
                         return getSection(SpvLogicalSectionID::ConstantsAndTypes);
+
                     default:
                         return defaultParent;
                     }

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1928,8 +1928,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         case kIROp_PrimitivesType:
             return nullptr;
         case kIROp_SPIRVNodePayloadArrayType:
-            if (auto nodePayloadArrayType = as<IRSPIRVNodePayloadArrayType>(inst))
             {
+                auto nodePayloadArrayType = cast<IRSPIRVNodePayloadArrayType>(inst);
                 auto newType =
                     emitOpTypeNodePayloadArray(inst, nodePayloadArrayType->getRecordType());
                 return newType;

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1565,6 +1565,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     break;
                 case SpvStorageClassNodePayloadAMDX:
                     requireSPIRVCapability(SpvCapabilityShaderEnqueueAMDX);
+                    requireSPIRVCapability(SpvCapabilityVariablePointers); // TODO: need to relocate to a more proper place.
                     ensureExtensionDeclaration(UnownedStringSlice("SPV_AMDX_shader_enqueue"));
                     break;
                 }

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -265,6 +265,9 @@ INST(ExpandTypeOrVal, ExpandTypeOrVal, 1, HOISTABLE)
 // A type that identifies it's contained type as being emittable as `spirv_literal.
 INST(SPIRVLiteralType, spirvLiteralType, 1, HOISTABLE)
 
+// WorkGraphs
+INST(SPIRVNodePayloadArrayType, spirvNodePayloadArrayType, 2, HOISTABLE)
+
 // A TypeType-typed IRValue represents a IRType.
 // It is used to represent a type parameter/argument in a generics.
 INST(TypeType, type_t, 0, HOISTABLE)

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1762,6 +1762,8 @@ struct IRSPIRVNodePayloadArrayType : IRType
     IR_LEAF_ISA(SPIRVNodePayloadArrayType)
 
     IRType* getRecordType() { return static_cast<IRType*>(getOperand(0)); }
+
+    // TODO: getNodeID needs to return `IRStringLit*`.
     IRIntLit* getNodeID() { return static_cast<IRIntLit*>(getOperand(1)); }
 };
 

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1757,6 +1757,14 @@ struct IRSPIRVLiteralType : IRType
     IRType* getValueType() { return static_cast<IRType*>(getOperand(0)); }
 };
 
+struct IRSPIRVNodePayloadArrayType : IRType
+{
+    IR_LEAF_ISA(SPIRVNodePayloadArrayType)
+
+    IRType* getRecordType() { return static_cast<IRType*>(getOperand(0)); }
+    IRIntLit* getNodeID() { return static_cast<IRIntLit*>(getOperand(1)); }
+};
+
 struct IRPtrTypeBase : IRType
 {
     IRType* getValueType() { return (IRType*)getOperand(0); }

--- a/tests/a.slang
+++ b/tests/a.slang
@@ -1,4 +1,5 @@
 //TEST:SIMPLE(filecheck=CHK): -target spirv-asm -stage compute -entry computeMain -profile sm_6_0 -capability spirv_1_4
+
 RWStructuredBuffer<int> inputBuffer;
 
 struct RecordData
@@ -32,16 +33,20 @@ void computeMain()
 //CHK-DAG: [[StructType:%[a-zA-Z_0-9]+]] = OpTypeStruct [[MemberType]]
 //CHK-DAG: [[PayloadType:%[a-zA-Z_0-9]+]] = OpTypeNodePayloadArrayAMDX [[StructType]]
 //CHK-DAG: [[NodePtrType:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[PayloadType]]
-//CHK-DAG: [[StructPtrType:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[StructType]]
+//CHK-DAG: [[TempPtrType:%[a-zA-Z_0-9]+]] = OpTypePointer Function [[PayloadType]]
+//CHK-DAG: [[FuncPtrType:%[a-zA-Z_0-9]+]] = OpTypePointer Function [[StructType]]
 
 //CHK: ; Function
 
 // ThreadNodeOutputRecords::__init()
+//CHK: [[TempPtrVar:%[a-zA-Z_0-9]+]] = OpVariable [[TempPtrType]] Function
 //CHK: [[Alloc:%[a-zA-Z_0-9]+]] = OpAllocateNodePayloadsAMDX [[NodePtrType]] %
+//CHK: [[Loaded:%[a-zA-Z_0-9]+]] = OpLoad [[PayloadType]] [[Alloc]]
+//CHK: OpStore [[TempPtrVar]] [[Loaded]]
 
 // ThreadNodeOutputRecords::Get()
-//CHK: = OpAccessChain [[StructPtrType]] [[Alloc]]
+//CHK: = OpAccessChain [[FuncPtrType]] %
 
 // ThreadNodeOutputRecords::OutputComplete()
-//CHK: OpEnqueueNodePayloadsAMDX [[Alloc]]
+//CHK: OpEnqueueNodePayloadsAMDX %
 

--- a/tests/workgraphs/consumer.slang
+++ b/tests/workgraphs/consumer.slang
@@ -30,12 +30,8 @@ void computeMain(uint3 dispatchThreadId : SV_GroupThreadID)
 //CHK: [[PayloadType:%[a-zA-Z_0-9]+]] = OpTypeNodePayloadArrayAMDX [[StructType]]
 //CHK: [[NodePtrType:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[PayloadType]]
 //CHK: [[NodePtrVar:%[a-zA-Z_0-9]+]] = OpVariable [[NodePtrType]] NodePayloadAMDX
-//CHK: [[TempPtrType:%[a-zA-Z_0-9]+]] = OpTypePointer Function [[PayloadType]]
-//CHK: [[FuncPtrType:%[a-zA-Z_0-9]+]] = OpTypePointer Function [[StructType]]
+//CHK: [[StructPtrType:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[StructType]]
 
 //CHK: ; Function
-//CHK: [[TempPtrVar:%[a-zA-Z_0-9]+]] = OpVariable [[TempPtrType]] Function
-//CHK: [[Loaded:%[a-zA-Z_0-9]+]] = OpLoad [[PayloadType]] [[NodePtrVar]]
-//CHK: OpStore [[TempPtrVar]] [[Loaded]]
-//CHK: = OpAccessChain [[FuncPtrType]] [[TempPtrVar]]
+//CHK: = OpAccessChain [[StructPtrType]] [[NodePtrVar]]
 

--- a/tests/workgraphs/consumer.slang
+++ b/tests/workgraphs/consumer.slang
@@ -11,12 +11,6 @@ struct RecordData
 [numthreads(1, 1, 1)]
 void computeMain(uint3 dispatchThreadId : SV_GroupThreadID)
 {
-    spirv_asm
-    {
-        OpExecutionMode $computeMain ShaderIndexAMDX $(0);
-        OpExecutionMode $computeMain StaticNumWorkgroupsAMDX $(1) $(1) $(1);
-    };
-
     //TODO: "myNodeID" is supposed to come from [NodeID("name")] attribute of the entry point.
     // Until it is implemented properly, we will use an int-type generic argument.
     //
@@ -34,9 +28,14 @@ void computeMain(uint3 dispatchThreadId : SV_GroupThreadID)
 //CHK: [[MemberType:%[a-zA-Z_0-9]+]] = OpTypeInt 32 1
 //CHK: [[StructType:%[a-zA-Z_0-9]+]] = OpTypeStruct [[MemberType]]
 //CHK: [[PayloadType:%[a-zA-Z_0-9]+]] = OpTypeNodePayloadArrayAMDX [[StructType]]
-//CHK: [[PtrType:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[PayloadType]]
+//CHK: [[NodePtrType:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[PayloadType]]
+//CHK: [[NodePtrVar:%[a-zA-Z_0-9]+]] = OpVariable [[NodePtrType]] NodePayloadAMDX
+//CHK: [[TempPtrType:%[a-zA-Z_0-9]+]] = OpTypePointer Function [[PayloadType]]
+//CHK: [[FuncPtrType:%[a-zA-Z_0-9]+]] = OpTypePointer Function [[StructType]]
 
 //CHK: ; Function
-//CHK: [[VarName:%[a-zA-Z_0-9]+]] = OpVariable [[PtrType]] NodePayloadAMDX
-//CHK: = OpAccessChain [[PtrType]] [[VarName]]
+//CHK: [[TempPtrVar:%[a-zA-Z_0-9]+]] = OpVariable [[TempPtrType]] Function
+//CHK: [[Loaded:%[a-zA-Z_0-9]+]] = OpLoad [[PayloadType]] [[NodePtrVar]]
+//CHK: OpStore [[TempPtrVar]] [[Loaded]]
+//CHK: = OpAccessChain [[FuncPtrType]] [[TempPtrVar]]
 

--- a/tests/workgraphs/consumer.slang
+++ b/tests/workgraphs/consumer.slang
@@ -1,4 +1,7 @@
-//TEST:SIMPLE(filecheck=CHK): -target spirv-asm -stage compute -entry main -skip-spirv-validation
+//TEST:SIMPLE(filecheck=CHK): -target spirv-asm -stage compute -entry computeMain -skip-spirv-validation
+
+RWStructuredBuffer<int> outputBuffer;
+
 struct RecordData
 {
     int myData;
@@ -6,19 +9,26 @@ struct RecordData
 
 [shader("compute")]
 [numthreads(1, 1, 1)]
-void main(uint3 dispatchThreadId : SV_GroupThreadID)
+void computeMain(uint3 dispatchThreadId : SV_GroupThreadID)
 {
     spirv_asm
     {
-        OpExecutionMode $main ShaderIndexAMDX $(0);
-        OpExecutionMode $main StaticNumWorkgroupsAMDX $(1) $(1) $(1);
+        OpExecutionMode $computeMain ShaderIndexAMDX $(0);
+        OpExecutionMode $computeMain StaticNumWorkgroupsAMDX $(1) $(1) $(1);
     };
 
-    DispatchNodeInputRecord<RecordData> inputData;
+    //TODO: "myNodeID" is supposed to come from [NodeID("name")] attribute of the entry point.
+    // Until it is implemented properly, we will use an int-type generic argument.
+    //
+    #define myNodeID 0
+    DispatchNodeInputRecord<RecordData, myNodeID> inputData;
 
-    let recordData = inputData.Get();
-    int myData = recordData.myData;
+    int myData = inputData.Get().myData;
+    outputBuffer[dispatchThreadId.x] = myData;
 }
+
+//CHK: OpCapability ShaderEnqueueAMDX
+//CHK: OpExtension "SPV_AMDX_shader_enqueue"
 
 //CHK: ; Types, variables and constants
 //CHK: [[MemberType:%[a-zA-Z_0-9]+]] = OpTypeInt 32 1

--- a/tests/workgraphs/producer-multi-nodes.slang
+++ b/tests/workgraphs/producer-multi-nodes.slang
@@ -11,12 +11,6 @@ struct RecordData
 [numthreads(1, 1, 1)]
 void computeMain()
 {
-    spirv_asm
-    {
-        OpExecutionMode $computeMain ShaderIndexAMDX $(0);
-        OpExecutionMode $computeMain StaticNumWorkgroupsAMDX $(1) $(1) $(1);
-    };
-
     //TODO: "myNodeID" is supposed to come from [NodeID("name")] attribute on "node" variable.
     // Until it is implemented properly, we will use an int-type generic argument.
     //
@@ -44,25 +38,19 @@ void computeMain()
 //CHK-DAG: [[PayloadType2:%[a-zA-Z_0-9]+]] = OpTypeNodePayloadArrayAMDX [[StructType]]
 //CHK-DAG: [[NodePtrType1:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[PayloadType1]]
 //CHK-DAG: [[NodePtrType2:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[PayloadType2]]
-//CHK-DAG: [[TempPtrType1:%[a-zA-Z_0-9]+]] = OpTypePointer Function [[PayloadType1]]
-//CHK-DAG: [[TempPtrType2:%[a-zA-Z_0-9]+]] = OpTypePointer Function [[PayloadType2]]
-//CHK-DAG: [[FuncPtrType:%[a-zA-Z_0-9]+]] = OpTypePointer Function [[StructType]]
+//CHK-DAG: [[StructPtrType:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[StructType]]
 
 //CHK: ; Function
 
 // ThreadNodeOutputRecords::__init()
-//CHK-DAG: [[TempPtrVar1:%[a-zA-Z_0-9]+]] = OpVariable [[TempPtrType1]] Function
-//CHK-DAG: [[TempPtrVar2:%[a-zA-Z_0-9]+]] = OpVariable [[TempPtrType2]] Function
 //CHK-DAG: [[Alloc1:%[a-zA-Z_0-9]+]] = OpAllocateNodePayloadsAMDX [[NodePtrType1]] %
 //CHK-DAG: [[Alloc2:%[a-zA-Z_0-9]+]] = OpAllocateNodePayloadsAMDX [[NodePtrType2]] %
-//CHK-DAG: [[Loaded1:%[a-zA-Z_0-9]+]] = OpLoad [[PayloadType1]] [[Alloc1]]
-//CHK-DAG: [[Loaded2:%[a-zA-Z_0-9]+]] = OpLoad [[PayloadType2]] [[Alloc2]]
-//CHK-DAG: OpStore [[TempPtrVar1]] [[Loaded1]]
-//CHK-DAG: OpStore [[TempPtrVar2]] [[Loaded2]]
 
 // ThreadNodeOutputRecords::Get()
-//CHK-COUNT-2: = OpAccessChain [[FuncPtrType]] %
+//CHK: = OpAccessChain [[StructPtrType]] [[Alloc1]]
+//CHK: = OpAccessChain [[StructPtrType]] [[Alloc2]]
 
 // ThreadNodeOutputRecords::OutputComplete()
-//CHK-COUNT-2: OpEnqueueNodePayloadsAMDX %
+//CHK: OpEnqueueNodePayloadsAMDX [[Alloc1]]
+//CHK: OpEnqueueNodePayloadsAMDX [[Alloc2]]
 

--- a/tests/workgraphs/producer-multi-nodes.slang
+++ b/tests/workgraphs/producer-multi-nodes.slang
@@ -36,36 +36,33 @@ void computeMain()
 //CHK: OpCapability ShaderEnqueueAMDX
 //CHK: OpExtension "SPV_AMDX_shader_enqueue"
 
-//CHK: ; Annotations
+//CHK: ; Types, variables and constants
 
-//CHK-DAG: [[RecordType1:%[a-zA-Z_0-9]+]] = OpTypeNodePayloadArrayAMDX %RecordData
-//CHK-DAG: [[RecordType2:%[a-zA-Z_0-9]+]] = OpTypeNodePayloadArrayAMDX %RecordData
-//CHK-DAG: [[PtrType1:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[RecordType1]]
-//CHK-DAG: [[PtrType2:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[RecordType2]]
-//CHK-DAG: [[NodeID_1:%[a-zA-Z_0-9]+]] = OpConstantStringAMDX "NodeID_0"
-//CHK-DAG: [[NodeID_2:%[a-zA-Z_0-9]+]] = OpConstantStringAMDX "NodeID_1"
-//CHK-DAG: OpDecorateId [[RecordType1]] PayloadNodeNameAMDX [[NodeID_1]]
-//CHK-DAG: OpDecorateId [[RecordType2]] PayloadNodeNameAMDX [[NodeID_2]]
-
-//CHK-NOT: = OpTypeNodePayloadArrayAMDX
-//CHK-NOT: = OpConstantStringAMDX
-//CHK-NOT: OpDecorateID {{.*}} PayloadNodeNameAMDX
+//CHK-DAG: [[MemberType:%[a-zA-Z_0-9]+]] = OpTypeInt 32 1
+//CHK-DAG: [[StructType:%[a-zA-Z_0-9]+]] = OpTypeStruct [[MemberType]]
+//CHK-DAG: [[PayloadType1:%[a-zA-Z_0-9]+]] = OpTypeNodePayloadArrayAMDX [[StructType]]
+//CHK-DAG: [[PayloadType2:%[a-zA-Z_0-9]+]] = OpTypeNodePayloadArrayAMDX [[StructType]]
+//CHK-DAG: [[NodePtrType1:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[PayloadType1]]
+//CHK-DAG: [[NodePtrType2:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[PayloadType2]]
+//CHK-DAG: [[TempPtrType1:%[a-zA-Z_0-9]+]] = OpTypePointer Function [[PayloadType1]]
+//CHK-DAG: [[TempPtrType2:%[a-zA-Z_0-9]+]] = OpTypePointer Function [[PayloadType2]]
+//CHK-DAG: [[FuncPtrType:%[a-zA-Z_0-9]+]] = OpTypePointer Function [[StructType]]
 
 //CHK: ; Function
 
 // ThreadNodeOutputRecords::__init()
-//CHK-DAG: [[Alloc1:%[a-zA-Z_0-9]+]] = OpAllocateNodePayloadsAMDX [[PtrType1]] %
-//CHK-DAG: [[Alloc2:%[a-zA-Z_0-9]+]] = OpAllocateNodePayloadsAMDX [[PtrType2]] %
-//CHK-NOT: = OpAllocateNodePayloadsAMDX
+//CHK-DAG: [[TempPtrVar1:%[a-zA-Z_0-9]+]] = OpVariable [[TempPtrType1]] Function
+//CHK-DAG: [[TempPtrVar2:%[a-zA-Z_0-9]+]] = OpVariable [[TempPtrType2]] Function
+//CHK-DAG: [[Alloc1:%[a-zA-Z_0-9]+]] = OpAllocateNodePayloadsAMDX [[NodePtrType1]] %
+//CHK-DAG: [[Alloc2:%[a-zA-Z_0-9]+]] = OpAllocateNodePayloadsAMDX [[NodePtrType2]] %
+//CHK-DAG: [[Loaded1:%[a-zA-Z_0-9]+]] = OpLoad [[PayloadType1]] [[Alloc1]]
+//CHK-DAG: [[Loaded2:%[a-zA-Z_0-9]+]] = OpLoad [[PayloadType2]] [[Alloc2]]
+//CHK-DAG: OpStore [[TempPtrVar1]] [[Loaded1]]
+//CHK-DAG: OpStore [[TempPtrVar2]] [[Loaded2]]
 
 // ThreadNodeOutputRecords::Get()
-//CHK-DAG: [[Load1:%[a-zA-Z_0-9]+]] = OpLoad [[PtrType1]] %var
-//CHK-DAG: [[Load2:%[a-zA-Z_0-9]+]] = OpLoad [[PtrType2]] %var
-//CHK-DAG: = OpAccessChain [[PtrType1]] [[Load1]] %
-//CHK-DAG: = OpAccessChain [[PtrType2]] [[Load2]] %
+//CHK-COUNT-2: = OpAccessChain [[FuncPtrType]] %
 
 // ThreadNodeOutputRecords::OutputComplete()
-//CHK-DAG: OpEnqueueNodePayloadsAMDX [[Alloc1]]
-//CHK-DAG: OpEnqueueNodePayloadsAMDX [[Alloc2]]
-//CHK-NOT: OpEnqueueNodePayloadsAMDX
+//CHK-COUNT-2: OpEnqueueNodePayloadsAMDX %
 

--- a/tests/workgraphs/producer-multi-nodes.slang
+++ b/tests/workgraphs/producer-multi-nodes.slang
@@ -1,0 +1,71 @@
+//TEST:SIMPLE(filecheck=CHK): -target spirv-asm -stage compute -entry computeMain -skip-spirv-validation
+
+RWStructuredBuffer<int> inputBuffer;
+
+struct RecordData
+{
+    int myData;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    spirv_asm
+    {
+        OpExecutionMode $computeMain ShaderIndexAMDX $(0);
+        OpExecutionMode $computeMain StaticNumWorkgroupsAMDX $(1) $(1) $(1);
+    };
+
+    //TODO: "myNodeID" is supposed to come from [NodeID("name")] attribute on "node" variable.
+    // Until it is implemented properly, we will use an int-type generic argument.
+    //
+    #define myNodeID_1 0
+    #define myNodeID_2 1
+
+    ThreadNodeOutputRecords<RecordData, myNodeID_1> node1 = { 1 };
+    ThreadNodeOutputRecords<RecordData, myNodeID_2> node2 = { 1 };
+
+    node1.Get().myData = inputBuffer[0];
+    node2.Get().myData = inputBuffer[0];
+
+    node1.OutputComplete();
+    node2.OutputComplete();
+}
+
+//CHK: OpCapability ShaderEnqueueAMDX
+//CHK: OpExtension "SPV_AMDX_shader_enqueue"
+
+//CHK: ; Annotations
+
+//CHK-DAG: [[RecordType1:%[a-zA-Z_0-9]+]] = OpTypeNodePayloadArrayAMDX %RecordData
+//CHK-DAG: [[RecordType2:%[a-zA-Z_0-9]+]] = OpTypeNodePayloadArrayAMDX %RecordData
+//CHK-DAG: [[PtrType1:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[RecordType1]]
+//CHK-DAG: [[PtrType2:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[RecordType2]]
+//CHK-DAG: [[NodeID_1:%[a-zA-Z_0-9]+]] = OpConstantStringAMDX "NodeID_0"
+//CHK-DAG: [[NodeID_2:%[a-zA-Z_0-9]+]] = OpConstantStringAMDX "NodeID_1"
+//CHK-DAG: OpDecorateId [[RecordType1]] PayloadNodeNameAMDX [[NodeID_1]]
+//CHK-DAG: OpDecorateId [[RecordType2]] PayloadNodeNameAMDX [[NodeID_2]]
+
+//CHK-NOT: = OpTypeNodePayloadArrayAMDX
+//CHK-NOT: = OpConstantStringAMDX
+//CHK-NOT: OpDecorateID {{.*}} PayloadNodeNameAMDX
+
+//CHK: ; Function
+
+// ThreadNodeOutputRecords::__init()
+//CHK-DAG: [[Alloc1:%[a-zA-Z_0-9]+]] = OpAllocateNodePayloadsAMDX [[PtrType1]] %
+//CHK-DAG: [[Alloc2:%[a-zA-Z_0-9]+]] = OpAllocateNodePayloadsAMDX [[PtrType2]] %
+//CHK-NOT: = OpAllocateNodePayloadsAMDX
+
+// ThreadNodeOutputRecords::Get()
+//CHK-DAG: [[Load1:%[a-zA-Z_0-9]+]] = OpLoad [[PtrType1]] %var
+//CHK-DAG: [[Load2:%[a-zA-Z_0-9]+]] = OpLoad [[PtrType2]] %var
+//CHK-DAG: = OpAccessChain [[PtrType1]] [[Load1]] %
+//CHK-DAG: = OpAccessChain [[PtrType2]] [[Load2]] %
+
+// ThreadNodeOutputRecords::OutputComplete()
+//CHK-DAG: OpEnqueueNodePayloadsAMDX [[Alloc1]]
+//CHK-DAG: OpEnqueueNodePayloadsAMDX [[Alloc2]]
+//CHK-NOT: OpEnqueueNodePayloadsAMDX
+

--- a/tests/workgraphs/producer.slang
+++ b/tests/workgraphs/producer.slang
@@ -30,6 +30,8 @@ void computeMain()
 //CHK: OpCapability ShaderEnqueueAMDX
 //CHK: OpExtension "SPV_AMDX_shader_enqueue"
 
+//CHK: ; Annotations
+
 //CHK-DAG: [[RecordType:%[a-zA-Z_0-9]+]] = OpTypeNodePayloadArrayAMDX %RecordData
 //CHK-DAG: [[PtrType:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[RecordType]]
 //CHK-DAG: [[NodeID:%[a-zA-Z_0-9]+]] = OpConstantStringAMDX "NodeID_0"
@@ -38,6 +40,8 @@ void computeMain()
 //CHK-NOT: = OpTypeNodePayloadArrayAMDX
 //CHK-NOT: = OpConstantStringAMDX
 //CHK-NOT: OpDecorateID {{.*}} PayloadNodeNameAMDX
+
+//CHK: ; Function
 
 // ThreadNodeOutputRecords::__init()
 //CHK: [[Alloc:%[a-zA-Z_0-9]+]] = OpAllocateNodePayloadsAMDX [[PtrType]] %

--- a/tests/workgraphs/producer.slang
+++ b/tests/workgraphs/producer.slang
@@ -11,11 +11,6 @@ struct RecordData
 [numthreads(1, 1, 1)]
 void computeMain()
 {
-    spirv_asm
-    {
-        OpExecutionMode $computeMain ShaderIndexAMDX $(0);
-        OpExecutionMode $computeMain StaticNumWorkgroupsAMDX $(1) $(1) $(1);
-    };
 
     //TODO: "myNodeID" is supposed to come from [NodeID("name")] attribute on "node" variable.
     // Until it is implemented properly, we will use an int-type generic argument.

--- a/tests/workgraphs/producer.slang
+++ b/tests/workgraphs/producer.slang
@@ -1,5 +1,4 @@
 //TEST:SIMPLE(filecheck=CHK): -target spirv-asm -stage compute -entry computeMain -skip-spirv-validation
-
 RWStructuredBuffer<int> inputBuffer;
 
 struct RecordData
@@ -27,10 +26,9 @@ void computeMain()
 
 //CHK: ; Annotations
 
-//CHK-DAG: [[RecordType:%[a-zA-Z_0-9]+]] = OpTypeNodePayloadArrayAMDX %RecordData
-//CHK-DAG: [[PtrType:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[RecordType]]
-//CHK-DAG: [[NodeID:%[a-zA-Z_0-9]+]] = OpConstantStringAMDX "NodeID_0"
-//CHK-DAG: OpDecorateId [[RecordType]] PayloadNodeNameAMDX [[NodeID]]
+//CHK-DAG: [[PayloadRecordType:%[a-zA-Z_0-9]+]] = OpTypeNodePayloadArrayAMDX %RecordData
+//CHK-DAG: [[NodePtrType:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[PayloadRecordType]]
+//CHK-DAG: [[FuncPtrType:%[a-zA-Z_0-9]+]] = OpTypePointer Function %RecordData
 
 //CHK-NOT: = OpTypeNodePayloadArrayAMDX
 //CHK-NOT: = OpConstantStringAMDX
@@ -39,12 +37,13 @@ void computeMain()
 //CHK: ; Function
 
 // ThreadNodeOutputRecords::__init()
-//CHK: [[Alloc:%[a-zA-Z_0-9]+]] = OpAllocateNodePayloadsAMDX [[PtrType]] %
+//CHK: [[Alloc:%[a-zA-Z_0-9]+]] = OpAllocateNodePayloadsAMDX [[NodePtrType]] %
 //CHK-NOT: = OpAllocateNodePayloadsAMDX
 
 // ThreadNodeOutputRecords::Get()
-//CHK: [[Load:%[a-zA-Z_0-9]+]] = OpLoad [[PtrType]] %var
-//CHK: = OpAccessChain [[PtrType]] [[Load]] %
+//CHK: [[Load:%[a-zA-Z_0-9]+]] = OpLoad [[PayloadRecordType]]
+//CHK: OpStore [[Var:%[a-zA-Z_0-9]+]] [[Load]]
+//CHK: = OpAccessChain [[FuncPtrType]] [[Var]] %
 
 // ThreadNodeOutputRecords::OutputComplete()
 //CHK: OpEnqueueNodePayloadsAMDX [[Alloc]]

--- a/tests/workgraphs/producer.slang
+++ b/tests/workgraphs/producer.slang
@@ -24,28 +24,26 @@ void computeMain()
 //CHK: OpCapability ShaderEnqueueAMDX
 //CHK: OpExtension "SPV_AMDX_shader_enqueue"
 
-//CHK: ; Annotations
+//CHK: ; Types, variables and constants
 
-//CHK-DAG: [[PayloadRecordType:%[a-zA-Z_0-9]+]] = OpTypeNodePayloadArrayAMDX %RecordData
-//CHK-DAG: [[NodePtrType:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[PayloadRecordType]]
-//CHK-DAG: [[FuncPtrType:%[a-zA-Z_0-9]+]] = OpTypePointer Function %RecordData
-
-//CHK-NOT: = OpTypeNodePayloadArrayAMDX
-//CHK-NOT: = OpConstantStringAMDX
-//CHK-NOT: OpDecorateID {{.*}} PayloadNodeNameAMDX
+//CHK-DAG: [[MemberType:%[a-zA-Z_0-9]+]] = OpTypeInt 32 1
+//CHK-DAG: [[StructType:%[a-zA-Z_0-9]+]] = OpTypeStruct [[MemberType]]
+//CHK-DAG: [[PayloadType:%[a-zA-Z_0-9]+]] = OpTypeNodePayloadArrayAMDX [[StructType]]
+//CHK-DAG: [[NodePtrType:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[PayloadType]]
+//CHK-DAG: [[TempPtrType:%[a-zA-Z_0-9]+]] = OpTypePointer Function [[PayloadType]]
+//CHK-DAG: [[FuncPtrType:%[a-zA-Z_0-9]+]] = OpTypePointer Function [[StructType]]
 
 //CHK: ; Function
 
 // ThreadNodeOutputRecords::__init()
+//CHK: [[TempPtrVar:%[a-zA-Z_0-9]+]] = OpVariable [[TempPtrType]] Function
 //CHK: [[Alloc:%[a-zA-Z_0-9]+]] = OpAllocateNodePayloadsAMDX [[NodePtrType]] %
-//CHK-NOT: = OpAllocateNodePayloadsAMDX
+//CHK: [[Loaded:%[a-zA-Z_0-9]+]] = OpLoad [[PayloadType]] [[Alloc]]
+//CHK: OpStore [[TempPtrVar]] [[Loaded]]
 
 // ThreadNodeOutputRecords::Get()
-//CHK: [[Load:%[a-zA-Z_0-9]+]] = OpLoad [[PayloadRecordType]]
-//CHK: OpStore [[Var:%[a-zA-Z_0-9]+]] [[Load]]
-//CHK: = OpAccessChain [[FuncPtrType]] [[Var]] %
+//CHK: = OpAccessChain [[FuncPtrType]] %
 
 // ThreadNodeOutputRecords::OutputComplete()
-//CHK: OpEnqueueNodePayloadsAMDX [[Alloc]]
-//CHK-NOT: OpEnqueueNodePayloadsAMDX
+//CHK: OpEnqueueNodePayloadsAMDX %
 

--- a/tests/workgraphs/producer.slang
+++ b/tests/workgraphs/producer.slang
@@ -1,0 +1,53 @@
+//TEST:SIMPLE(filecheck=CHK): -target spirv-asm -stage compute -entry computeMain -skip-spirv-validation
+
+RWStructuredBuffer<int> inputBuffer;
+
+struct RecordData
+{
+    int myData;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    spirv_asm
+    {
+        OpExecutionMode $computeMain ShaderIndexAMDX $(0);
+        OpExecutionMode $computeMain StaticNumWorkgroupsAMDX $(1) $(1) $(1);
+    };
+
+    //TODO: "myNodeID" is supposed to come from [NodeID("name")] attribute on "node" variable.
+    // Until it is implemented properly, we will use an int-type generic argument.
+    //
+    #define myNodeID 0
+    ThreadNodeOutputRecords<RecordData, myNodeID> node = { 1 };
+
+    node.Get().myData = inputBuffer[0];
+    node.OutputComplete();
+}
+
+//CHK: OpCapability ShaderEnqueueAMDX
+//CHK: OpExtension "SPV_AMDX_shader_enqueue"
+
+//CHK-DAG: [[RecordType:%[a-zA-Z_0-9]+]] = OpTypeNodePayloadArrayAMDX %RecordData
+//CHK-DAG: [[PtrType:%[a-zA-Z_0-9]+]] = OpTypePointer NodePayloadAMDX [[RecordType]]
+//CHK-DAG: [[NodeID:%[a-zA-Z_0-9]+]] = OpConstantStringAMDX "NodeID_0"
+//CHK-DAG: OpDecorateId [[RecordType]] PayloadNodeNameAMDX [[NodeID]]
+
+//CHK-NOT: = OpTypeNodePayloadArrayAMDX
+//CHK-NOT: = OpConstantStringAMDX
+//CHK-NOT: OpDecorateID {{.*}} PayloadNodeNameAMDX
+
+// ThreadNodeOutputRecords::__init()
+//CHK: [[Alloc:%[a-zA-Z_0-9]+]] = OpAllocateNodePayloadsAMDX [[PtrType]] %
+//CHK-NOT: = OpAllocateNodePayloadsAMDX
+
+// ThreadNodeOutputRecords::Get()
+//CHK: [[Load:%[a-zA-Z_0-9]+]] = OpLoad [[PtrType]] %var
+//CHK: = OpAccessChain [[PtrType]] [[Load]] %
+
+// ThreadNodeOutputRecords::OutputComplete()
+//CHK: OpEnqueueNodePayloadsAMDX [[Alloc]]
+//CHK-NOT: OpEnqueueNodePayloadsAMDX
+


### PR DESCRIPTION
Closes https://github.com/shader-slang/slang/issues/6391

This commit is mainly to allow OpTypeNodePayloadArrayAMDX to be duplicated in SPIRV when using WorkGraphs.

AMD spec requires that there should be dedicated type declaration with OpTypeNodePayloadArrayAMDX for each "node". And each of them should be decorated with PayloadNodeNameAMDX.
https://docs.vulkan.org/features/latest/features/proposals/VK_AMDX_shader_enqueue.html

This behavior is very different from how "types" are declared. Normally types are declared only once and they are shared across the whole program. But for the work-graphs, each "RecordType" belongs to each node and they need to be declared for each node.

Consider the following HLSL example where a producer triggers two consumer nodes. Each node will be differentiated by "NodeID" attribute.

```
[Shader("node")]
[NodeLaunch("broadcasting")]
[NumThreads(4,1,1)]
void myFancyNode(...,
    [NodeID("myNode1")] NodeOutput<MY_RECORD> myRecords1,
    [NodeID("myNode2")] NodeOutput<MY_RECORD> myRecords2,
    ...)
{
    ThreadNodeOutputRecords<MY_RECORD> myRecord1 = myRecords1.GetThreadNodeOutputRecords(1);
    myRecord1.myData = 1;
    myRecord1.OutputCompelete();

    ThreadNodeOutputRecords<MY_RECORD> myRecord2 = myRecords2.GetThreadNodeOutputRecords(1);
    myRecord2.myData = 1;
    myRecord2.OutputCompelete();
}
```

Even though both are using the same type, "MY_RECORD", each of them needs to be declared separately. The generated SPIR-V code for the HLSL above is something like the following,
```
%str_node1 = OpConstantStringAMDX "myNode1";
%str_node2 = OpConstantStringAMDX "myNode1";

%type_node1 = OpTypeNodePayloadArrayAMDX %type_myRecord;
%type_node2 = OpTypeNodePayloadArrayAMDX %type_myRecord;

OpDecorateId %type_node1 PayloadNodeNameAMDX %str_node1;
OpDecorateId %type_node2 PayloadNodeNameAMDX %str_node2;
```
Note that `%type_node1` and `%type_node2` are equivalent, but they must be declared separately because each of them will be decorated with different nodeID string.