### PR TITLE
Fix overload resolution for `ModuleDeclarationDecl`

### DIFF
--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -4848,10 +4848,18 @@ Expr* SemanticsVisitor::maybeInsertImplicitOpForMemberBase(
     //
     baseExpr = maybeOpenExistential(baseExpr);
 
+    // If we have an overloaded expression, we'll try to refine it.
+    if (auto overloadedExpr = as<OverloadedExpr>(baseExpr))
+        baseExpr = resolveOverloadedExpr(overloadedExpr, LookupMask::Default);
+
+    // In case our base expressin is still overloaded, we can perform
+    // some more refinement.
+    //
     // Handle the case of an overloaded base expression
     // here, in case we can use the name of the member to
     // disambiguate which of the candidates is meant, or if
     // we can return an overloaded result.
+    //
     if (auto overloadedExpr = as<OverloadedExpr>(baseExpr))
     {
         // If a member (dynamic or static) lookup result contains both the actual definition

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -4848,10 +4848,6 @@ Expr* SemanticsVisitor::maybeInsertImplicitOpForMemberBase(
     //
     baseExpr = maybeOpenExistential(baseExpr);
 
-    // If we have an overloaded expression, we'll try to refine it.
-    if (auto overloadedExpr = as<OverloadedExpr>(baseExpr))
-        baseExpr = resolveOverloadedExpr(overloadedExpr, LookupMask::Default);
-
     // In case our base expressin is still overloaded, we can perform
     // some more refinement.
     //
@@ -4866,7 +4862,7 @@ Expr* SemanticsVisitor::maybeInsertImplicitOpForMemberBase(
         // and the interface definition obtained from inheritance, we want to filter out
         // the interface definitions.
         LookupResult filteredLookupResult;
-        for (auto lookupResult : overloadedExpr->lookupResult2)
+        for (auto lookupResult : overloadedExpr->lookupResult2.items)
         {
             bool shouldRemove = false;
             if (lookupResult.declRef.getParent().as<InterfaceDecl>())

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1345,7 +1345,7 @@ int SemanticsVisitor::CompareLookupResultItems(
     bool leftIsModule = (as<ModuleDeclarationDecl>(left.declRef) != nullptr);
     bool rightIsModule = (as<ModuleDeclarationDecl>(right.declRef) != nullptr);
     if (leftIsModule != rightIsModule)
-        return int(rightIsModule) - int(leftIsModule);
+        return int(leftIsModule) - int(rightIsModule);
 
     // If both are interface requirements, prefer the more derived interface.
     if (leftIsInterfaceRequirement && rightIsInterfaceRequirement)

--- a/tests/language-feature/namespaces/namespace-import/overload-resolve.slang
+++ b/tests/language-feature/namespaces/namespace-import/overload-resolve.slang
@@ -8,11 +8,6 @@ namespace test
     {
         return x;
     }
-
-    uint g(uint x)
-    {
-        return x;
-    }
 }
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
@@ -25,7 +20,6 @@ void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
     int inVal = tid;
     // Should be able to resolve 'test' properly (and not get confused by the module declaration with the same name)
     int outVal = test.f<3>(vector<uint, 3>(1, 2, 3)).y;
-    //int outVal = test.g(2);
     outputBuffer[tid] = outVal;
     // CHECK: 2
 }

--- a/tests/language-feature/namespaces/namespace-import/overload-resolve.slang
+++ b/tests/language-feature/namespaces/namespace-import/overload-resolve.slang
@@ -1,0 +1,31 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj
+
+module test;
+
+namespace test
+{
+    vector<uint, N> f<int N>(vector<uint, N> x)
+    {
+        return x;
+    }
+
+    uint g(uint x)
+    {
+        return x;
+    }
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+{
+    int tid = dispatchThreadID.x;
+    int inVal = tid;
+    // Should be able to resolve 'test' properly (and not get confused by the module declaration with the same name)
+    int outVal = test.f<3>(vector<uint, 3>(1, 2, 3)).y;
+    //int outVal = test.g(2);
+    outputBuffer[tid] = outVal;
+    // CHECK: 2
+}


### PR DESCRIPTION
- Fixed comparison returning an inverted value.
- Fixed iteration over lookup result items (should iterate over items even if `declRef` is null)

Fixes: https://github.com/shader-slang/slang/issues/6484