### PR TITLE
Fix member lookup in left hand side of `where` clause.

### DIFF
--- a/tests/bugs/gh-6488-where-lookup.slang
+++ b/tests/bugs/gh-6488-where-lookup.slang
@@ -1,0 +1,11 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+
+// CHECK: OpEntryPoint
+
+interface IRealArray<T : __BuiltinFloatingPointType, int D> {}
+extension<T : __BuiltinFloatingPointType, int D> vector<T, D> : IRealArray<T, D> where T.Differential : __BuiltinFloatingPointType { }
+
+
+[numthreads(1,1,1)]
+void main()
+{}


### PR DESCRIPTION
Closes #6488.
Given:
```
interface IRealArray<T : __BuiltinFloatingPointType, int D> {}
extension<T : __BuiltinFloatingPointType, int D> vector<T, D> : IRealArray<T, D> where T.Differential : __BuiltinFloatingPointType { }
```
The issue is when we are applying `extension.T` to `IRealArray<T,D>`, we need to check `extension.T` is conforming to `__BuiltinFloatingPointType`. In doing so, we will need to form the inheritance list of `extension.T`. But forming this inheritance list requires us to check all `GenericTypeConstraintDecl`s on the generic decl that `extension.T` belongs to, which means checking the `where` clause. When we check the left hand side of the `where` clause, we need to lookup for `Differential` in `T`, and this gets back to needing the inheritance list of `T`, which is what we are currently computing for. Because the inheritance list is in-calculation, it will appear as an empty list during the lookup for `Differential` to avoid infinite cycle, and this resulted in the unexpected lookup failure.

The fix here is to skip checking all the `GenericTypeConstraintDecl` during inheritance list computation for a generic type parameter (`T`), if the left hand side of the constraint is a member lookup. This is safe because such constraint can never be defining subtype constraints for a generic type parameter.