### PR TITLE
Fix codegen bug when targeting PTX with new API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,14 +176,16 @@ jobs:
               -category ${{ matrix.test-category }} \
               -api all-dx12 \
               -expected-failure-list tests/expected-failure-github.txt \
-              -expected-failure-list tests/expected-failure-record-replay-tests.txt
+              -expected-failure-list tests/expected-failure-record-replay-tests.txt \
+              -expected-failure-list tests/expected-failure-github-runner.txt
           else
             "$bin_dir/slang-test" \
               -use-test-server \
               -category ${{ matrix.test-category }} \
               -api all-dx12 \
               -expected-failure-list tests/expected-failure-github.txt \
-              -expected-failure-list tests/expected-failure-record-replay-tests.txt
+              -expected-failure-list tests/expected-failure-record-replay-tests.txt \
+              -expected-failure-list tests/expected-failure-github-runner.txt
           fi
       - name: Run Slang examples
         if: steps.filter.outputs.should-run == 'true' && matrix.platform != 'wasm' && matrix.full-gpu-tests

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -3214,7 +3214,8 @@ void collectParameterLists(
         // For now we will rely on a follow up pass to remove unnecessary temporary variables if
         // we can determine that they are never actually writtten to by the user.
         //
-        bool lowerVaryingInputAsConstRef = declRef.getDecl()->hasModifier<EntryPointAttribute>();
+        bool lowerVaryingInputAsConstRef = declRef.getDecl()->hasModifier<EntryPointAttribute>() ||
+                                           declRef.getDecl()->hasModifier<NumThreadsAttribute>();
 
         // Don't collect parameters from the outer scope if
         // we are in a `static` context.

--- a/tests/expected-failure-github-runner.txt
+++ b/tests/expected-failure-github-runner.txt
@@ -1,0 +1,1 @@
+slang-unit-test-tool/cudaCodeGenBug.internal

--- a/tools/slang-unit-test/unit-test-find-check-entrypoint.cpp
+++ b/tools/slang-unit-test/unit-test-find-check-entrypoint.cpp
@@ -71,3 +71,68 @@ SLANG_UNIT_TEST(findAndCheckEntryPoint)
     SLANG_CHECK(code != nullptr);
     SLANG_CHECK(code->getBufferSize() != 0);
 }
+
+// This test reproduces issue #6507, where it was noticed that compilation of
+// tests/compute/simple.slang for PTX target generates invalid code.
+// TODO: Remove this when issue #4760 is resolved, because at that point
+// tests/compute/simple.slang should cover the same issue.
+SLANG_UNIT_TEST(cudaCodeGenBug)
+{
+    // Source for a module that contains an undecorated entrypoint.
+    const char* userSourceBody = R"(
+        RWStructuredBuffer<float> outputBuffer;
+
+        [numthreads(4, 1, 1)]
+        void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+        {
+            outputBuffer[dispatchThreadID.x] = float(dispatchThreadID.x);
+        }
+        )";
+
+    auto moduleName = "moduleG" + String(Process::getId());
+    String userSource = "import " + moduleName + ";\n" + userSourceBody;
+    ComPtr<slang::IGlobalSession> globalSession;
+    SLANG_CHECK(slang_createGlobalSession(SLANG_API_VERSION, globalSession.writeRef()) == SLANG_OK);
+    slang::TargetDesc targetDesc = {};
+    targetDesc.format = SLANG_PTX;
+    slang::SessionDesc sessionDesc = {};
+    sessionDesc.targetCount = 1;
+    sessionDesc.targets = &targetDesc;
+    ComPtr<slang::ISession> session;
+    SLANG_CHECK(globalSession->createSession(sessionDesc, session.writeRef()) == SLANG_OK);
+
+    ComPtr<slang::IBlob> diagnosticBlob;
+    auto module = session->loadModuleFromSourceString(
+        "m",
+        "m.slang",
+        userSourceBody,
+        diagnosticBlob.writeRef());
+    SLANG_CHECK(module != nullptr);
+
+    ComPtr<slang::IEntryPoint> entryPoint;
+    module->findAndCheckEntryPoint(
+        "computeMain",
+        SLANG_STAGE_COMPUTE,
+        entryPoint.writeRef(),
+        diagnosticBlob.writeRef());
+    SLANG_CHECK(entryPoint != nullptr);
+
+    ComPtr<slang::IComponentType> compositeProgram;
+    slang::IComponentType* components[] = {module, entryPoint.get()};
+    session->createCompositeComponentType(
+        components,
+        2,
+        compositeProgram.writeRef(),
+        diagnosticBlob.writeRef());
+    SLANG_CHECK(compositeProgram != nullptr);
+
+    ComPtr<slang::IComponentType> linkedProgram;
+    compositeProgram->link(linkedProgram.writeRef(), diagnosticBlob.writeRef());
+    SLANG_CHECK(linkedProgram != nullptr);
+
+    ComPtr<slang::IBlob> code;
+    auto res = linkedProgram->getEntryPointCode(0, 0, code.writeRef(), diagnosticBlob.writeRef());
+    SLANG_CHECK(res == SLANG_OK);
+    SLANG_CHECK(code != nullptr);
+    SLANG_CHECK(code->getBufferSize() != 0);
+}


### PR DESCRIPTION
- add a repro of the problem
  - This is added as a unit test, because the new API is not yet in use for the tests in tests/ 
  - This unit test can be removed when the new API is used for tests/
- Simple fix that detects entry points more robustly when applying some "ConstRef hack"
  - When using the old API, an explicit EntryPointAttribute was being attached to the entry point, even though none was present in the code

See issue #6507 for debugging notes.

This closes issue #6507.