### PR TITLE
Fix a bug in default ctor synthesizing

### DIFF
--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -408,7 +408,12 @@ bool SemanticsVisitor::createInvokeExprForSynthesizedCtor(
         // When a struct has no constructor and it's not a C-style type, the initializer list is
         // invalid.
         isCStyle = isCStyleType(toType, isVisit);
-        if (!isCStyle)
+
+        // WAR: We currently still has to allow legacy initializer list for array type until we have
+        // more proper solution for array initialization, so if the right hand side is an array
+        // type, we will not report error and fall-back to legacy initializer list logic.
+        bool isArrayType = as<ArrayExpressionType>(toType) != nullptr;
+        if (!isCStyle && !isArrayType)
         {
             getSink()->diagnose(
                 fromInitializerListExpr->loc,
@@ -419,6 +424,7 @@ bool SemanticsVisitor::createInvokeExprForSynthesizedCtor(
         return false;
     }
 
+    isCStyle = isCStyleType(toType, isVisit);
     // TODO: This is just a special case for a backwards-compatibility feature
     // for HLSL, this flag will imply that the initializer list is synthesized
     // for a type cast from a literal zero to a 'struct'. In this case, we will fall

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -401,11 +401,12 @@ bool SemanticsVisitor::createInvokeExprForSynthesizedCtor(
 
     HashSet<Type*> isVisit;
     bool isCStyle = false;
-    if(!_getSynthesizedConstructor(
+    if (!_getSynthesizedConstructor(
             structDecl,
             ConstructorDecl::ConstructorFlavor::SynthesizedDefault))
     {
-        // When a struct has no constructor and it's not a C-style type, the initializer list is invalid.
+        // When a struct has no constructor and it's not a C-style type, the initializer list is
+        // invalid.
         isCStyle = isCStyleType(toType, isVisit);
         if (!isCStyle)
         {

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -12412,7 +12412,7 @@ bool SemanticsDeclAttributesVisitor::_synthesizeCtorSignature(StructDecl* struct
     // any constructors. see:
     // https://github.com/shader-slang/slang/blob/master/docs/proposals/004-initialization.md#inheritance-initialization
     if (_hasExplicitConstructor(structDecl, true))
-        return false;
+        return true;
 
     // synthesize the signature first.
     // The constructor's visibility level is the same as the struct itself.

--- a/tests/initializer-list/explicit-ctor-diagnostic.slang
+++ b/tests/initializer-list/explicit-ctor-diagnostic.slang
@@ -16,4 +16,7 @@ void test()
 {
    // CHECK: error 39999: too many arguments to call (got 2, expected 1)
    ExplicitCtor e = {1, 2}; // error, no ctor matches initializer list.
+
+   // CHECK: error 39999: not enough arguments to call (got 0, expected 1)
+   ExplicitCtor e1 = {};
 }

--- a/tests/initializer-list/struct-inherit-diagnostics.slang
+++ b/tests/initializer-list/struct-inherit-diagnostics.slang
@@ -22,18 +22,18 @@ struct DefaultStruct2 : DefaultStruct_base
 [numthreads(1, 1, 1)]
 void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
 {
-    // error 30504: cannot use initializer list for type 'DefaultStruct1'
+    //CHECK: error 30504: cannot use initializer list for type 'DefaultStruct1'
     DefaultStruct1 s1 = {};
 
-    // error 30504: cannot use initializer list for type 'DefaultStruct1'
+    //CHECK: error 30504: cannot use initializer list for type 'DefaultStruct1'
     DefaultStruct1 s2 = {1};
 
-    // error 30504: cannot use initializer list for type 'DefaultStruct1'
+    //CHECK: error 30504: cannot use initializer list for type 'DefaultStruct1'
     DefaultStruct1 s3 = {1, 2};
 
-    // error 30504: cannot use initializer list for type 'DefaultStruct2'
+    //CHECK: error 30504: cannot use initializer list for type 'DefaultStruct2'
     DefaultStruct2 s4 = {};
 
-    // error 30504: cannot use initializer list for type 'DefaultStruct2'
+    //CHECK: error 30504: cannot use initializer list for type 'DefaultStruct2'
     DefaultStruct2 s5 = {1};
 }

--- a/tests/initializer-list/struct-inherit-diagnostics.slang
+++ b/tests/initializer-list/struct-inherit-diagnostics.slang
@@ -1,0 +1,39 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):
+
+struct DefaultStruct_base
+{
+    int data0;
+    __init()
+    {
+        data0 = 2;
+    }
+};
+
+struct DefaultStruct1 : DefaultStruct_base
+{
+    int data1 = 1;
+};
+
+struct DefaultStruct2 : DefaultStruct_base
+{
+
+};
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    // error 30504: cannot use initializer list for type 'DefaultStruct1'
+    DefaultStruct1 s1 = {};
+
+    // error 30504: cannot use initializer list for type 'DefaultStruct1'
+    DefaultStruct1 s2 = {1};
+
+    // error 30504: cannot use initializer list for type 'DefaultStruct1'
+    DefaultStruct1 s3 = {1, 2};
+
+    // error 30504: cannot use initializer list for type 'DefaultStruct2'
+    DefaultStruct2 s4 = {};
+
+    // error 30504: cannot use initializer list for type 'DefaultStruct2'
+    DefaultStruct2 s5 = {1};
+}

--- a/tests/initializer-list/struct-inherit.slang
+++ b/tests/initializer-list/struct-inherit.slang
@@ -16,51 +16,42 @@ struct DefaultStruct_base
 
     __init()
     {
-        data1 = 1;
+        data0 = 2;
+        data1 = 3;
     }
 };
+
 struct DefaultStruct1 : DefaultStruct_base
 {
     int data2 = 1;
-};
-struct DefaultStruct2 : DefaultStruct_base
-{
-    int data2 = 1;
     __init()
     {
-        if (data0 != 1)
+        if (data0 == 2)
         {
-            data2 = 0;
+            data2 = 4;
         }
     }
 };
-struct DefaultStruct3 : DefaultStruct_base
+
+struct DefaultStruct2 : DefaultStruct_base
 {
     __init()
     {
     }
 };
-struct DefaultStruct4 : DefaultStruct_base
-{
-};
+
 [numthreads(1, 1, 1)]
 void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
 {
-    DefaultStruct1 s1 = {};
+    DefaultStruct1 s1;
     DefaultStruct2 s2;
-    DefaultStruct3 s3;
-    DefaultStruct4 s4 = {};
+
     // BUF: 1
     outputBuffer[0] = true
-        && s1.data0 == 1
-        && s1.data1 == 1
-        && s1.data2 == 1
-        && s2.data0 == 1
-        && s2.data1 == 1
-        && s2.data2 == 1
-        && s3.data0 == 1
-        && s3.data1 == 1
-        && s4.data0 == 1
-        && s4.data1 == 1
+        && s1.data0 == 2
+        && s1.data1 == 3
+        && s1.data2 == 4
+        && s2.data0 == 2
+        && s2.data1 == 3
         ;
 }

--- a/tests/language-feature/interfaces/default-construct-conformance.slang
+++ b/tests/language-feature/interfaces/default-construct-conformance.slang
@@ -33,6 +33,11 @@ struct TestAny : ITest
         value = v;
     }
 
+    __init()
+    {
+        value = 0;
+    }
+
     uint getValue() { return value; }
 }
 


### PR DESCRIPTION
This is fix for the implementation bug, when a struct has explict ctor we should not synthesize the default ctor anymore.