### PR TITLE
Get options also from the default target

### DIFF
--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -1111,6 +1111,7 @@ SLANG_NO_THROW SlangResult SLANG_MCALL Session::parseCommandLineArguments(
     SerializedOptionsData& optionData = outData->options[optionDataIndex];
     optionDataIndex++;
     tempReq->getOptionSet().serialize(&optionData);
+    tempReq->m_optionSetForDefaultTarget.serialize(&optionData);
     for (auto target : tempReq->getLinkage()->targets)
     {
         slang::TargetDesc tdesc;


### PR DESCRIPTION
This helps to address issue #4760.

The particular issue motivating this fix is that
IGlobalSession::parseCommandLineArguments uses a temporary compile request to parse options.
The compile request only adds the OptionKind::ForceDXLayout (-fvk-use-dx-layout) to the "current target" which may be the default target, which IGlobalSession::parseCommandLineArguments didn't look for, meaning that options like ForceDXLayout were just ignored.
This leads to test failures in tests that rely on this option, e.g. tests/spirv/cbuffer-dx-layout-1.slang.