### PR TITLE
Sharpen condition on warning about used capabilities

### DIFF
--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -537,9 +537,17 @@ void validateEntryPoint(EntryPoint* entryPoint, DiagnosticSink* sink)
         }
         else
         {
-            // Only attempt to error if a user adds to slangc either `-profile` or `-capability`
-            if ((target->getOptionSet().hasOption(CompilerOptionName::Capability) ||
-                 target->getOptionSet().hasOption(CompilerOptionName::Profile)) &&
+            auto& targetOptionSet = target->getOptionSet();
+            bool specificProfileRequested =
+                targetOptionSet.hasOption(CompilerOptionName::Profile) &&
+                (targetOptionSet.getIntOption(CompilerOptionName::Profile) !=
+                 SLANG_PROFILE_UNKNOWN);
+            bool specificCapabilityRequested =
+                targetOptionSet.hasOption(CompilerOptionName::Capability) &&
+                (targetOptionSet.getIntOption(CompilerOptionName::Capability) !=
+                 SLANG_CAPABILITY_UNKNOWN);
+            // Only attempt to error if a specific profile or capability is requested
+            if ((specificCapabilityRequested || specificProfileRequested) &&
                 targetCaps.atLeastOneSetImpliedInOther(
                     entryPointFuncDecl->inferredCapabilityRequirements) ==
                     CapabilitySet::ImpliesReturnFlags::NotImplied)


### PR DESCRIPTION
Sharpen condition on warning about used capabilities relative to a requested profile or capability.

If the profile/capability in options set, but set to unknown, then don't count the setting as requesting a particular profile/capability.

This helps in addressing issue #4760 because the new session-based compilation API always adds a profile setting via Linkage::addTarget, even if the profile is unknown.

That caused lots of tests to fail due to unexpected output: "warning 41012: entry point 'computeMain' uses additional capabilities that are not part of the specified profile..."

The old compilation request -based API did not add profile/capabiltiy to the options, and so did not generate this warning.