### PR TITLE
Add module reference options to options list when parsing them

### DIFF
--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -1831,7 +1831,20 @@ SlangResult OptionsParser::_parseReferenceModule(const CommandLineArg& arg)
     CommandLineArg referenceModuleName;
     SLANG_RETURN_ON_FAIL(m_reader.expectArg(referenceModuleName));
 
-    return addReferencedModule(referenceModuleName.value, referenceModuleName.loc, true);
+    // Add the module to the request
+    SLANG_RETURN_ON_FAIL(
+        addReferencedModule(referenceModuleName.value, referenceModuleName.loc, true));
+
+    // In addition to adding the module to the request, we also add to the options set, because
+    // the same options parser is also used for IGlobalSession::parseCommandLineArguments, which
+    // parses options via a dummy request that is destroyed once the command line options are
+    // obtained. Therefore, also add the option here so that
+    // IGlobalSession::parseCommandLineArguments can return them.
+    m_requestImpl->getLinkage()->m_optionSet.add(
+        CompilerOptionName::ReferenceModule,
+        referenceModuleName.value);
+
+    return SLANG_OK;
 }
 
 SlangResult OptionsParser::_parseReproFileSystem(const CommandLineArg& arg)


### PR DESCRIPTION
Previously, the module was just added to the compile request directly. This is a problem because the non-deprecated command line option parsing interface IGlobalSession::parseCommandLineArguments just creates a temporary compile request. Therefore these options are currently not detected by the API.

This helps to address issue #4760 since it will need to access these modules in order to supply all of the required code.