### PR TITLE
Make make_struct call consistent

### DIFF
--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -1962,8 +1962,6 @@ static LegalVal coerceToLegalType(IRTypeLegalizationContext* context, LegalType 
             ShortList<IRInst*> fields;
             for (auto field : structType->getFields())
             {
-                if (as<IRVoidType>(field->getFieldType()))
-                    continue;
                 auto fieldVal = coerceToLegalType(
                     context,
                     LegalType::simple(field->getFieldType()),


### PR DESCRIPTION
Close #6541.

Previously in type legalization pass, we skip the `VoidType` field when call `make_struct`, however in some optimization pass we keep counting the `VoidType` field. We have to make this behavior consistently over all our codebase.

So in this change, we spot the `make_struct` call and leave `VoidType` field as it.
