### PR TITLE
UseHighestVersion when calling spirv-link

### DIFF
--- a/source/slang-glslang/slang-glslang.cpp
+++ b/source/slang-glslang/slang-glslang.cpp
@@ -997,6 +997,8 @@ extern "C"
         spvtools::Context context(SPV_ENV_UNIVERSAL_1_5);
         spvtools::LinkerOptions options = {};
 
+        options.SetUseHighestVersion(true);
+
         spvtools::MessageConsumer consumer = [](spv_message_level_t level,
                                                 const char* source,
                                                 const spv_position_t& position,


### PR DESCRIPTION
Precompiled SPIR-V bits can independently resolve to different versions of SPIR-V.

To avoid a linker error about mismatched versions, use a linker feature to automatically use the highest version listed in the modules.

Fixes #6548