### PR TITLE
Add referenced modules as libraries when creating a session

### DIFF
--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -1748,13 +1748,17 @@ SlangResult OptionsParser::_expectInt(const CommandLineArg& initArg, Int& outInt
     return SLANG_OK;
 }
 
-SlangResult OptionsParser::addReferencedModule(String path, SourceLoc loc, bool includeEntryPoint)
+SlangResult createArtifactFromReferencedModule(
+    String path,
+    SourceLoc loc,
+    DiagnosticSink* sink,
+    IArtifact** outArtifact)
 {
     auto desc = ArtifactDescUtil::getDescFromPath(path.getUnownedSlice());
 
     if (desc.kind == ArtifactKind::Unknown)
     {
-        m_sink->diagnose(loc, Diagnostics::unknownLibraryKind, Path::getPathExt(path));
+        sink->diagnose(loc, Diagnostics::unknownLibraryKind, Path::getPathExt(path));
         return SLANG_FAIL;
     }
 
@@ -1772,7 +1776,7 @@ SlangResult OptionsParser::addReferencedModule(String path, SourceLoc loc, bool 
 
     if (!ArtifactDescUtil::isLinkable(desc))
     {
-        m_sink->diagnose(loc, Diagnostics::kindNotLinkable, Path::getPathExt(path));
+        sink->diagnose(loc, Diagnostics::kindNotLinkable, Path::getPathExt(path));
         return SLANG_FAIL;
     }
 
@@ -1803,11 +1807,20 @@ SlangResult OptionsParser::addReferencedModule(String path, SourceLoc loc, bool 
             nullptr);
         if (!fileRep->exists())
         {
-            m_sink->diagnose(loc, Diagnostics::libraryDoesNotExist, path);
+            sink->diagnose(loc, Diagnostics::libraryDoesNotExist, path);
             return SLANG_FAIL;
         }
     }
     artifact->addRepresentation(fileRep);
+    *outArtifact = artifact.detach();
+    return SLANG_OK;
+}
+
+SlangResult OptionsParser::addReferencedModule(String path, SourceLoc loc, bool includeEntryPoint)
+{
+    ComPtr<IArtifact> artifact;
+    SLANG_RETURN_ON_FAIL(
+        createArtifactFromReferencedModule(path, loc, m_sink, artifact.writeRef()));
 
     SLANG_RETURN_ON_FAIL(_addLibraryReference(m_requestImpl, path, artifact, includeEntryPoint));
     for (Index i = m_rawTranslationUnits.getCount(); i < m_requestImpl->getTranslationUnitCount();

--- a/source/slang/slang-options.h
+++ b/source/slang/slang-options.h
@@ -2,12 +2,15 @@
 #ifndef SLANG_OPTIONS_H
 #define SLANG_OPTIONS_H
 
+#include "../compiler-core/slang-source-loc.h"
 #include "../core/slang-basic.h"
 
 namespace Slang
 {
 
 struct CommandOptions;
+class DiagnosticSink;
+class IArtifact;
 
 UnownedStringSlice getCodeGenTargetName(SlangCompileTarget target);
 
@@ -19,6 +22,12 @@ void initCommandOptions(CommandOptions& commandOptions);
 enum class Stage : SlangUInt32;
 
 SlangSourceLanguage findSourceLanguageFromPath(const String& path, Stage& outImpliedStage);
+
+SlangResult createArtifactFromReferencedModule(
+    String path,
+    SourceLoc loc,
+    DiagnosticSink* sink,
+    IArtifact** outArtifact);
 
 } // namespace Slang
 #endif


### PR DESCRIPTION
In the legacy compile request based API, the referenced modules are added to the request's linkage libraries as part of compiler option parsing. In the non-legacy compilation API, the argument parsing creates a temprary compile request and so those libraries only survive as options.

This change will look for such options when creating an ISession object, and again add the referenced modules to the libraries of the new linkage that's contained in the ISession object.

This is done in two steps:

1. Factor out a helper to create a referenced module artifact in the same way as it's done during legacy option parsing.
2. Use the helper function to create artifacts to add to the linkage libararies, when the session is created.

This helps to address issue #4760, because it enables passing in downstream modules via options, as is required for the following tests:
```
tests/library/library-test.slang.2 (dx12)
tests/library/export-test.slang.2 (dx12)
```