### PR TITLE
Don't crash when precompiling twice

### DIFF
--- a/source/slang/slang-compiler-tu.cpp
+++ b/source/slang/slang-compiler-tu.cpp
@@ -95,6 +95,18 @@ Module::precompileForTarget(SlangCompileTarget target, slang::IBlob** outDiagnos
 {
     CodeGenTarget targetEnum = CodeGenTarget(target);
 
+    // Don't precompile twice for the same target
+    for (auto globalInst : getIRModule()->getModuleInst()->getChildren())
+    {
+        if (auto inst = as<IREmbeddedDownstreamIR>(globalInst))
+        {
+            if (inst->getTarget() == targetEnum)
+            {
+                return SLANG_OK;
+            }
+        }
+    }
+
     auto module = getIRModule();
     auto linkage = getLinkage();
     auto builder = IRBuilder(module);

--- a/tools/gfx-unit-test/precompiled-module-2.cpp
+++ b/tools/gfx-unit-test/precompiled-module-2.cpp
@@ -59,8 +59,15 @@ static Slang::Result precompileProgram(
                 (void**)precompileService.writeRef()) == SLANG_OK)
         {
             Slang::ComPtr<slang::IBlob> diagnosticsBlob;
-            precompileService->precompileForTarget(target, diagnosticsBlob.writeRef());
+            auto res = precompileService->precompileForTarget(target, diagnosticsBlob.writeRef());
             diagnoseIfNeeded(diagnosticsBlob);
+            SLANG_RETURN_ON_FAIL(res);
+
+            // compile a second time to check for driver bugs.
+            diagnosticsBlob = nullptr;
+            res = precompileService->precompileForTarget(target, diagnosticsBlob.writeRef());
+            diagnoseIfNeeded(diagnosticsBlob);
+            SLANG_RETURN_ON_FAIL(res);
         }
     }
 


### PR DESCRIPTION
Abort precompileForTarget if it's already done.

Fixes #6516