### PR TITLE
add SLANG_USER_CONFIG

### DIFF
--- a/include/slang.h
+++ b/include/slang.h
@@ -1,6 +1,10 @@
 #ifndef SLANG_H
 #define SLANG_H
 
+#ifdef SLANG_USER_CONFIG
+#include SLANG_USER_CONFIG
+#endif
+
 /** \file slang.h
 
 The Slang API provides services to compile, reflect, and specialize code


### PR DESCRIPTION
This allows clients to define `SLANG_USER_CONFIG` to include a config file that sets defines picked up by `slang.h`.