### PR TITLE
update slang-rhi

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -181,8 +181,8 @@ if(SLANG_ENABLE_SLANG_RHI)
 
     # Not disabling these break tests (issue #5474)
     set(SLANG_RHI_FETCH_DXC OFF)
-    set(SLANG_RHI_FETCH_AGILITY_SDK OFF)
-
+    set(SLANG_RHI_ENABLE_AGILITY_SDK OFF)
+    
     set(SLANG_RHI_ENABLE_NVAPI ${SLANG_ENABLE_NVAPI})
 
     if(SLANG_ENABLE_DX_ON_VK)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -182,7 +182,7 @@ if(SLANG_ENABLE_SLANG_RHI)
     # Not disabling these break tests (issue #5474)
     set(SLANG_RHI_FETCH_DXC OFF)
     set(SLANG_RHI_ENABLE_AGILITY_SDK OFF)
-    
+
     set(SLANG_RHI_ENABLE_NVAPI ${SLANG_ENABLE_NVAPI})
 
     if(SLANG_ENABLE_DX_ON_VK)

--- a/tests/bugs/buffer-swizzle-store.slang
+++ b/tests/bugs/buffer-swizzle-store.slang
@@ -4,7 +4,7 @@
 // Not supported in WGSL: read-write storage texture with "rg16f" format
 //DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-wgpu
 
-//TEST_INPUT: RWTexture2D(format=R16G16_FLOAT, size=4, content = one, mipMaps = 1):name g_test
+//TEST_INPUT: RWTexture2D(format=RG16Float, size=4, content = one, mipMaps = 1):name g_test
 [format("rg16f")]
 RWTexture2D<float2> g_test;
 

--- a/tests/bugs/gh-4411.slang
+++ b/tests/bugs/gh-4411.slang
@@ -1,10 +1,10 @@
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute -shaderobj
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -dx12 -use-dxil -shaderobj
 
-//TEST_INPUT:RWTexture1D(format=R32_UINT, size=8, content = zero, mipMaps = 1):name=texture1D
+//TEST_INPUT:RWTexture1D(format=R32Uint, size=8, content = zero, mipMaps = 1):name=texture1D
 RWTexture1D<uint> texture1D;
 
-//TEST_INPUT:RWTexture2D(format=R32_UINT, size=8, content = zero, mipMaps = 1):name=texture2D
+//TEST_INPUT:RWTexture2D(format=R32Uint, size=8, content = zero, mipMaps = 1):name=texture2D
 RWTexture2D<uint> texture2D;
 
 //TEST_INPUT:ubuffer(data=[0]):out,name=outputBuffer

--- a/tests/bugs/texture2d-gather.hlsl
+++ b/tests/bugs/texture2d-gather.hlsl
@@ -1,6 +1,6 @@
 //TEST(smoke):COMPARE_HLSL_RENDER:
 //DISABLE_TEST(smoke):COMPARE_HLSL_RENDER:-mtl
-//TEST_INPUT: Texture2D(size=16, content=chessboard, format=R32_FLOAT):name g_texture
+//TEST_INPUT: Texture2D(size=16, content=chessboard, format=R32Float):name g_texture
 //TEST_INPUT: Sampler :name g_sampler
 
 Texture2D<float> g_texture;

--- a/tests/compute/half-rw-texture-convert.slang
+++ b/tests/compute/half-rw-texture-convert.slang
@@ -11,15 +11,15 @@
 // Note that this test is a little silly. The output does not confirm that the write actually worked.
 // half-rw-texture-convert2.slang tests this
 
-//TEST_INPUT: RWTexture2D(format=R16_FLOAT, size=4, content = one, mipMaps = 1):name rwt2D
+//TEST_INPUT: RWTexture2D(format=R16Float, size=4, content = one, mipMaps = 1):name rwt2D
 [format("r16f")]
 RWTexture2D<float> rwt2D;
 
-//TEST_INPUT: RWTexture2D(format=R16G16_FLOAT, size=4, content = one, mipMaps = 1):name rwt2D_2
+//TEST_INPUT: RWTexture2D(format=RG16Float, size=4, content = one, mipMaps = 1):name rwt2D_2
 [format("rg16f")]
 RWTexture2D<float2> rwt2D_2;
 
-//TEST_INPUT: RWTexture2D(format=R16G16B16A16_FLOAT, size=4, content = one, mipMaps = 1):name rwt2D_4
+//TEST_INPUT: RWTexture2D(format=RGBA16Float, size=4, content = one, mipMaps = 1):name rwt2D_4
 [format("rgba16f")]
 RWTexture2D<float4> rwt2D_4;
 

--- a/tests/compute/half-rw-texture-convert2.slang
+++ b/tests/compute/half-rw-texture-convert2.slang
@@ -8,15 +8,15 @@
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type -shaderobj
 //TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type -shaderobj -render-features half
 
-//TEST_INPUT: RWTexture2D(format=R16_FLOAT, size=4, content = one, mipMaps = 1):name rwt2D
+//TEST_INPUT: RWTexture2D(format=R16Float, size=4, content = one, mipMaps = 1):name rwt2D
 [format("r16f")]
 RWTexture2D<float> rwt2D;
 
-//TEST_INPUT: RWTexture2D(format=R16G16_FLOAT, size=4, content = one, mipMaps = 1):name rwt2D_2
+//TEST_INPUT: RWTexture2D(format=RG16Float, size=4, content = one, mipMaps = 1):name rwt2D_2
 [format("rg16f")]
 RWTexture2D<float2> rwt2D_2;
 
-//TEST_INPUT: RWTexture2D(format=R16G16B16A16_FLOAT, size=4, content = one, mipMaps = 1):name rwt2D_4
+//TEST_INPUT: RWTexture2D(format=RGBA16Float, size=4, content = one, mipMaps = 1):name rwt2D_4
 [format("rgba16f")]
 RWTexture2D<float4> rwt2D_4;
 

--- a/tests/compute/half-rw-texture-simple.slang
+++ b/tests/compute/half-rw-texture-simple.slang
@@ -10,13 +10,13 @@
 //DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -output-using-type -shaderobj
 //TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type -shaderobj -render-features half
 
-//TEST_INPUT: RWTexture1D(format=R16_FLOAT, size=4, content = one, mipMaps = 1):name rwt1D
+//TEST_INPUT: RWTexture1D(format=R16Float, size=4, content = one, mipMaps = 1):name rwt1D
 RWTexture1D<half> rwt1D;
 
-//TEST_INPUT: RWTexture2D(format=R16_FLOAT, size=4, content = one, mipMaps = 1):name rwt2D
+//TEST_INPUT: RWTexture2D(format=R16Float, size=4, content = one, mipMaps = 1):name rwt2D
 RWTexture2D<half> rwt2D;
 
-//TEST_INPUT: RWTexture2D(format=R16G16B16A16_FLOAT, size=4, content = one, mipMaps = 1):name rwt2D_4
+//TEST_INPUT: RWTexture2D(format=RGBA16Float, size=4, content = one, mipMaps = 1):name rwt2D_4
 RWTexture2D<half4> rwt2D_4;
 
 //TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer

--- a/tests/compute/half-texture-simple.slang
+++ b/tests/compute/half-texture-simple.slang
@@ -7,23 +7,23 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute  -shaderobj
 
 // Doesn't work on CUDA, not clear why yet
-//DISABLE_TEST_INPUT: Texture1D(format=R16_FLOAT, size=4, content = one, mipMaps=1):name tLoad1D
+//DISABLE_TEST_INPUT: Texture1D(format=R16Float, size=4, content = one, mipMaps=1):name tLoad1D
 //Texture1D<float> tLoad1D;
 
-//TEST_INPUT: Texture1D(format=R16_FLOAT, size=4, content = one):name t1D
+//TEST_INPUT: Texture1D(format=R16Float, size=4, content = one):name t1D
 Texture1D<float> t1D;
-//TEST_INPUT: Texture2D(format=R16_FLOAT, size=4, content = one):name t2D
+//TEST_INPUT: Texture2D(format=R16Float, size=4, content = one):name t2D
 Texture2D<float> t2D;
-//TEST_INPUT: Texture3D(format=R16_FLOAT, size=4, content = one):name t3D
+//TEST_INPUT: Texture3D(format=R16Float, size=4, content = one):name t3D
 Texture3D<float> t3D;
-//TEST_INPUT: TextureCube(format=R16_FLOAT, size=4, content = one):name tCube
+//TEST_INPUT: TextureCube(format=R16Float, size=4, content = one):name tCube
 TextureCube<float> tCube;
 
-//TEST_INPUT: Texture1D(format=R16_FLOAT, size=4, content = one, arrayLength=2):name t1DArray
+//TEST_INPUT: Texture1D(format=R16Float, size=4, content = one, arrayLength=2):name t1DArray
 Texture1DArray<float> t1DArray;
-//TEST_INPUT: Texture2D(format=R16_FLOAT, size=4, content = one, arrayLength=2):name t2DArray
+//TEST_INPUT: Texture2D(format=R16Float, size=4, content = one, arrayLength=2):name t2DArray
 Texture2DArray<float> t2DArray;
-//TEST_INPUT: TextureCube(format=R16_FLOAT, size=4, content = one, arrayLength=2):name tCubeArray
+//TEST_INPUT: TextureCube(format=R16Float, size=4, content = one, arrayLength=2):name tCubeArray
 TextureCubeArray<float> tCubeArray;
 
 //TEST_INPUT: Sampler:name samplerState

--- a/tests/compute/rw-texture-simple.slang
+++ b/tests/compute/rw-texture-simple.slang
@@ -8,11 +8,11 @@
 
 //TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -output-using-type -shaderobj
 
-//TEST_INPUT: RWTexture1D(format=R32_FLOAT, size=4, content = one, mipMaps = 1):name rwt1D
+//TEST_INPUT: RWTexture1D(format=R32Float, size=4, content = one, mipMaps = 1):name rwt1D
 RWTexture1D<float> rwt1D;
-//TEST_INPUT: RWTexture2D(format=R32_FLOAT, size=4, content = one, mipMaps = 1):name rwt2D
+//TEST_INPUT: RWTexture2D(format=R32Float, size=4, content = one, mipMaps = 1):name rwt2D
 RWTexture2D<float> rwt2D;
-//TEST_INPUT: RWTexture3D(format=R32_FLOAT, size=4, content = one, mipMaps = 1):name rwt3D
+//TEST_INPUT: RWTexture3D(format=R32Float, size=4, content = one, mipMaps = 1):name rwt3D
 RWTexture3D<float> rwt3D;
 
 //TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer

--- a/tests/compute/texture-subscript-multisample.slang
+++ b/tests/compute/texture-subscript-multisample.slang
@@ -8,10 +8,10 @@
 //METAL_ERROR: error 41402
 //METALLIB: error 41402
 
-//TEST_INPUT: RWTexture2D(format=R8G8B8A8_SINT, size=4, content = zero, sampleCount=two, mipMaps = 1):name outputTexture2DMS
+//TEST_INPUT: RWTexture2D(format=RGBA8Sint, size=4, content = zero, sampleCount=two, mipMaps = 1):name outputTexture2DMS
 RWTexture2DMS<int4> outputTexture2DMS;
 
-//TEST_INPUT: RWTexture2D(format=R8G8B8A8_SINT, size=4, content = zero, arrayLength=2, sampleCount=two, mipMaps = 1):name outputTexture2DMSArray
+//TEST_INPUT: RWTexture2D(format=RGBA8Sint, size=4, content = zero, arrayLength=2, sampleCount=two, mipMaps = 1):name outputTexture2DMSArray
 RWTexture2DMSArray<int4> outputTexture2DMSArray;
 
 //TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer

--- a/tests/compute/texture-subscript.slang
+++ b/tests/compute/texture-subscript.slang
@@ -8,16 +8,16 @@
 //METAL-NOT: error 41402
 //METALLIB: @computeMain
 
-//TEST_INPUT: RWTexture1D(format=R8G8B8A8_SINT, size=8, content = zero, mipMaps = 1):name outputTexture1D
+//TEST_INPUT: RWTexture1D(format=RGBA8Sint, size=8, content = zero, mipMaps = 1):name outputTexture1D
 RWTexture1D<int4> outputTexture1D;
 
-//TEST_INPUT: RWTexture2D(format=R8G8B8A8_SINT, size=8, content = zero, mipMaps = 1):name outputTexture2D
+//TEST_INPUT: RWTexture2D(format=RGBA8Sint, size=8, content = zero, mipMaps = 1):name outputTexture2D
 RWTexture2D<int4> outputTexture2D;
 
-//TEST_INPUT: RWTexture3D(format=R8G8B8A8_SINT, size=8, content = zero, mipMaps = 1):name outputTexture3D
+//TEST_INPUT: RWTexture3D(format=RGBA8Sint, size=8, content = zero, mipMaps = 1):name outputTexture3D
 RWTexture3D<int4> outputTexture3D;
 
-//TEST_INPUT: RWTexture2D(format=R8G8B8A8_SINT, size=4, content = zero, arrayLength=2, mipMaps = 1):name outputTexture2DArray
+//TEST_INPUT: RWTexture2D(format=RGBA8Sint, size=4, content = zero, arrayLength=2, mipMaps = 1):name outputTexture2DArray
 RWTexture2DArray<int4> outputTexture2DArray;
 
 //TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer

--- a/tests/expected-failure-github.txt
+++ b/tests/expected-failure-github.txt
@@ -14,3 +14,5 @@ tests/language-feature/shader-params/interface-shader-param-ordinary.slang.4 syn
 tests/glsl-intrinsic/shader-subgroup/shader-subgroup-builtin-variables.slang.8 (mtl)
 tests/glsl-intrinsic/shader-subgroup/shader-subgroup-builtin-variables-2.slang.3 (mtl)
 tests/hlsl-intrinsic/texture/partial-resident-texture-combined.slang (dx12)
+tests/compute/cbuffer-legalize.slang.2 syn (mtl)
+tests/hlsl-intrinsic/classify-float.slang.5 syn (wgpu)

--- a/tests/glsl-intrinsic/image/i64imageDim.slang
+++ b/tests/glsl-intrinsic/image/i64imageDim.slang
@@ -17,30 +17,30 @@ buffer MyBlockName2
 
 layout(local_size_x = 1) in;
 
-//TEST_INPUT: set image_1d = RWTexture1D(format=R64_SINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_1d = RWTexture1D(format=R64Sint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=0,r64i) i64image1D image_1d;
 #ifdef TEST_when_hardware_supports_i64_and_u64_buffers
-//COM:TEST_INPUT: set image_buffer = RWTextureBuffer(format=R64_INT, stride=8, data=[0 1 0 1 0 1 0 1])
+//COM:TEST_INPUT: set image_buffer = RWTextureBuffer(format=R64Sint, stride=8, data=[0 1 0 1 0 1 0 1])
 uniform layout(binding=1,r64i) i64imageBuffer image_buffer;
 #endif // #ifdef TEST_when_hardware_supports_i64_and_u64_buffers
-//TEST_INPUT: set image_1dArray = RWTexture1D(format=R64_SINT, size=4, content=one, mipMaps = 1, arrayLength=2)
+//TEST_INPUT: set image_1dArray = RWTexture1D(format=R64Sint, size=4, content=one, mipMaps = 1, arrayLength=2)
 uniform layout(binding=2,r64i) i64image1DArray image_1dArray;
-//TEST_INPUT: set image_2d = RWTexture2D(format=R64_SINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_2d = RWTexture2D(format=R64Sint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=3,r64i) i64image2D image_2d;
-//TEST_INPUT: set image_2dRect = RWTexture2D(format=R64_SINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_2dRect = RWTexture2D(format=R64Sint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=4,r64i) i64image2DRect image_2dRect;
-//TEST_INPUT: set image_2dArray = RWTexture2D(format=R64_SINT, size=4, content=one, mipMaps = 1, arrayLength=2)
+//TEST_INPUT: set image_2dArray = RWTexture2D(format=R64Sint, size=4, content=one, mipMaps = 1, arrayLength=2)
 uniform layout(binding=6,r64i) i64image2DArray image_2dArray;
-//TEST_INPUT: set image_3d = RWTexture3D(format=R64_SINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_3d = RWTexture3D(format=R64Sint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=7,r64i) i64image3D image_3d;
-//TEST_INPUT: set image_cube = RWTextureCube(format=R64_SINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_cube = RWTextureCube(format=R64Sint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=8,r64i) i64imageCube image_cube;
-//TEST_INPUT: set image_cubeArray = RWTextureCube(format=R64_SINT, size=4, content=one, mipMaps = 1, arrayLength=2)
+//TEST_INPUT: set image_cubeArray = RWTextureCube(format=R64Sint, size=4, content=one, mipMaps = 1, arrayLength=2)
 uniform layout(binding=9,r64i) i64imageCubeArray image_cubeArray;
 #ifdef test_when_hardware_supports_i64_and_u64_sampled_textures
-//COM:TEST_INPUT: set image_2dMultiSample = RWTexture2D(format=R64_SINT, size=4, content=one, mipMaps = 1, sampleCount = two)
+//COM:TEST_INPUT: set image_2dMultiSample = RWTexture2D(format=R64Sint, size=4, content=one, mipMaps = 1, sampleCount = two)
 uniform layout(binding=5,r64i) i64image2DMS image_2dMultiSample;
-//COM:TEST_INPUT: set image_2dMultiSampleArray = RWTexture2D(format=R64_SINT, size=4, content=one, mipMaps = 1, arrayLength=2, sampleCount = two)
+//COM:TEST_INPUT: set image_2dMultiSampleArray = RWTexture2D(format=R64Sint, size=4, content=one, mipMaps = 1, arrayLength=2, sampleCount = two)
 uniform layout(binding=10,r64i) i64image2DMSArray image_2dMultiSampleArray;
 #endif // #ifdef test_when_hardware_supports_i64_and_u64_sampled_textures
 

--- a/tests/glsl-intrinsic/image/iimageDim.slang
+++ b/tests/glsl-intrinsic/image/iimageDim.slang
@@ -11,27 +11,27 @@ buffer MyBlockName2
 
 layout(local_size_x = 1) in;
 
-//TEST_INPUT: set image_1d = RWTexture1D(format=R32_SINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_1d = RWTexture1D(format=R32Sint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=0,r32i) iimage1D image_1d;
-//TEST_INPUT: set image_buffer = RWTextureBuffer(format=R32_SINT, stride=8, data=[1 1 1 1])
+//TEST_INPUT: set image_buffer = RWTextureBuffer(format=R32Sint, stride=8, data=[1 1 1 1])
 uniform layout(binding=1,r32i) iimageBuffer image_buffer;
-//TEST_INPUT: set image_1dArray = RWTexture1D(format=R32_SINT, size=4, content=one, mipMaps = 1, arrayLength=2)
+//TEST_INPUT: set image_1dArray = RWTexture1D(format=R32Sint, size=4, content=one, mipMaps = 1, arrayLength=2)
 uniform layout(binding=2,r32i) iimage1DArray image_1dArray;
-//TEST_INPUT: set image_2d = RWTexture2D(format=R32_SINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_2d = RWTexture2D(format=R32Sint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=3,r32i) iimage2D image_2d;
-//TEST_INPUT: set image_2dRect = RWTexture2D(format=R32_SINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_2dRect = RWTexture2D(format=R32Sint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=4,r32i) iimage2DRect image_2dRect;
-//TEST_INPUT: set image_2dMultiSample = RWTexture2D(format=R32_SINT, size=4, content=one, mipMaps = 1, sampleCount = two)
+//TEST_INPUT: set image_2dMultiSample = RWTexture2D(format=R32Sint, size=4, content=one, mipMaps = 1, sampleCount = two)
 uniform layout(binding=5,r32i) iimage2DMS image_2dMultiSample;
-//TEST_INPUT: set image_2dArray = RWTexture2D(format=R32_SINT, size=4, content=one, mipMaps = 1, arrayLength=2)
+//TEST_INPUT: set image_2dArray = RWTexture2D(format=R32Sint, size=4, content=one, mipMaps = 1, arrayLength=2)
 uniform layout(binding=6,r32i) iimage2DArray image_2dArray;
-//TEST_INPUT: set image_3d = RWTexture3D(format=R32_SINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_3d = RWTexture3D(format=R32Sint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=7,r32i) iimage3D image_3d;
-//TEST_INPUT: set image_cube = RWTextureCube(format=R32_SINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_cube = RWTextureCube(format=R32Sint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=8,r32i) iimageCube image_cube;
-//TEST_INPUT: set image_cubeArray = RWTextureCube(format=R32_SINT, size=4, content=one, mipMaps = 1, arrayLength=2)
+//TEST_INPUT: set image_cubeArray = RWTextureCube(format=R32Sint, size=4, content=one, mipMaps = 1, arrayLength=2)
 uniform layout(binding=9,r32i) iimageCubeArray image_cubeArray;
-//TEST_INPUT: set image_2dMultiSampleArray = RWTexture2D(format=R32_SINT, size=4, content=one, mipMaps = 1, arrayLength=2, sampleCount = two)
+//TEST_INPUT: set image_2dMultiSampleArray = RWTexture2D(format=R32Sint, size=4, content=one, mipMaps = 1, arrayLength=2, sampleCount = two)
 uniform layout(binding=10,r32i) iimage2DMSArray image_2dMultiSampleArray;
 
 bool checkAllImageSize()

--- a/tests/glsl-intrinsic/image/iimageDimTiny.slang
+++ b/tests/glsl-intrinsic/image/iimageDimTiny.slang
@@ -11,7 +11,7 @@ buffer MyBlockName2
 
 layout(local_size_x = 1) in;
 
-//TEST_INPUT: set image_1d = RWTexture1D(format=R32_SINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_1d = RWTexture1D(format=R32Sint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=0,r32i) iimage1D image_1d;
 
 bool checkAllImageAtomicAdd()

--- a/tests/glsl-intrinsic/image/imageAsParamWithMemoryQualifiers.slang
+++ b/tests/glsl-intrinsic/image/imageAsParamWithMemoryQualifiers.slang
@@ -20,12 +20,12 @@ layout(local_size_x = 4) in;
 //CHECK_SPV: OpDecorate %{{.*}} {{(Restrict|NonWritable|NonReadable)}}
 //CHECK_SPV: OpDecorate %{{.*}} {{(Restrict|NonWritable|NonReadable)}}
 //CHECK_SPV: OpDecorate %{{.*}} {{(Restrict|NonWritable|NonReadable)}}
-//TEST_INPUT: set someImage = RWTexture2D(format=R16G16B16A16_FLOAT, size=1, content=one, mipMaps = 1)
+//TEST_INPUT: set someImage = RWTexture2D(format=RGBA16Float, size=1, content=one, mipMaps = 1)
 uniform layout(binding=0,rgba16f) restrict writeonly readonly image2D someImage;
 
 //CHECK_GLSL: writeonly
 //CHECK_SPV: OpDecorate {{.*}} {{(Restrict|NonWritable|NonReadable)}}
-//TEST_INPUT: set someImage2 = RWTexture2D(format=R16G16B16A16_FLOAT, size=1, content=one, mipMaps = 1)
+//TEST_INPUT: set someImage2 = RWTexture2D(format=RGBA16Float, size=1, content=one, mipMaps = 1)
 uniform layout(binding=1,rgba16f) writeonly image2D someImage2;
 
 bool checkAllImageSizesParamSameQualifiers(writeonly readonly image2D val)

--- a/tests/glsl-intrinsic/image/imageAsParamWithMemoryQualifiersError.slang
+++ b/tests/glsl-intrinsic/image/imageAsParamWithMemoryQualifiersError.slang
@@ -8,7 +8,7 @@ buffer MyBlockName2
 
 layout(local_size_x = 4) in;
 
-//TEST_INPUT: set someImage = RWTexture2D(format=R16G16B16A16_FLOAT, size=1, content=one, mipMaps = 1)
+//TEST_INPUT: set someImage = RWTexture2D(format=RGBA16Float, size=1, content=one, mipMaps = 1)
 uniform layout(binding=0,rgba16f) readonly image2D someImage;
 
 // CHECK: error 30048

--- a/tests/glsl-intrinsic/image/imageDim.slang
+++ b/tests/glsl-intrinsic/image/imageDim.slang
@@ -16,27 +16,27 @@ buffer MyBlockName2
 
 layout(local_size_x = 1) in;
 
-//TEST_INPUT: set image_1d = RWTexture1D(format=R32_FLOAT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_1d = RWTexture1D(format=R32Float, size=4, content=one, mipMaps = 1)
 uniform layout(binding=0,r32f) image1D image_1d;
-//TEST_INPUT: set image_buffer = RWTextureBuffer(format=R32_FLOAT, stride=4, data=[1.0f 1.0f 1.0f 1.0f])
+//TEST_INPUT: set image_buffer = RWTextureBuffer(format=R32Float, stride=4, data=[1.0f 1.0f 1.0f 1.0f])
 uniform layout(binding=1,r32f) imageBuffer image_buffer;
-//TEST_INPUT: set image_1dArray = RWTexture1D(format=R32_FLOAT, size=4, content=one, mipMaps = 1, arrayLength=2)
+//TEST_INPUT: set image_1dArray = RWTexture1D(format=R32Float, size=4, content=one, mipMaps = 1, arrayLength=2)
 uniform layout(binding=2,r32f) image1DArray image_1dArray;
-//TEST_INPUT: set image_2d = RWTexture2D(format=R32_FLOAT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_2d = RWTexture2D(format=R32Float, size=4, content=one, mipMaps = 1)
 uniform layout(binding=3,r32f) image2D image_2d;
-//TEST_INPUT: set image_2dRect = RWTexture2D(format=R32_FLOAT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_2dRect = RWTexture2D(format=R32Float, size=4, content=one, mipMaps = 1)
 uniform layout(binding=4,r32f) image2DRect image_2dRect;
-//TEST_INPUT: set image_2dMultiSample = RWTexture2D(format=R32_FLOAT, size=4, content=one, mipMaps = 1, sampleCount = two)
+//TEST_INPUT: set image_2dMultiSample = RWTexture2D(format=R32Float, size=4, content=one, mipMaps = 1, sampleCount = two)
 uniform layout(binding=5,r32f) image2DMS image_2dMultiSample;
-//TEST_INPUT: set image_2dArray = RWTexture2D(format=R32_FLOAT, size=4, content=one, mipMaps = 1, arrayLength=2)
+//TEST_INPUT: set image_2dArray = RWTexture2D(format=R32Float, size=4, content=one, mipMaps = 1, arrayLength=2)
 uniform layout(binding=6,r32f) image2DArray image_2dArray;
-//TEST_INPUT: set image_3d = RWTexture3D(format=R32_FLOAT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_3d = RWTexture3D(format=R32Float, size=4, content=one, mipMaps = 1)
 uniform layout(binding=7,r32f) image3D image_3d;
-//TEST_INPUT: set image_cube = RWTextureCube(format=R32_FLOAT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_cube = RWTextureCube(format=R32Float, size=4, content=one, mipMaps = 1)
 uniform layout(binding=8,r32f) imageCube image_cube;
-//TEST_INPUT: set image_cubeArray = RWTextureCube(format=R32_FLOAT, size=4, content=one, mipMaps = 1, arrayLength=2)
+//TEST_INPUT: set image_cubeArray = RWTextureCube(format=R32Float, size=4, content=one, mipMaps = 1, arrayLength=2)
 uniform layout(binding=9,r32f) imageCubeArray image_cubeArray;
-//TEST_INPUT: set image_2dMultiSampleArray = RWTexture2D(format=R32_FLOAT, size=4, content=one, mipMaps = 1, arrayLength=2, sampleCount = two)
+//TEST_INPUT: set image_2dMultiSampleArray = RWTexture2D(format=R32Float, size=4, content=one, mipMaps = 1, arrayLength=2, sampleCount = two)
 uniform layout(binding=10,r32f) image2DMSArray image_2dMultiSampleArray;
 
 bool checkAllImageSize()

--- a/tests/glsl-intrinsic/image/u64imageDim.slang
+++ b/tests/glsl-intrinsic/image/u64imageDim.slang
@@ -17,30 +17,30 @@ buffer MyBlockName2
 
 layout(local_size_x = 1) in;
 
-//TEST_INPUT: set image_1d = RWTexture1D(format=R64_UINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_1d = RWTexture1D(format=R64Uint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=0,r64ui) u64image1D image_1d;
 #ifdef TEST_when_hardware_supports_i64_and_u64_buffers
-//COM:TEST_INPUT: set image_buffer = RWTextureBuffer(format=R64_UINT, stride=8, data=[0 1 0 1 0 1 0 1])
+//COM:TEST_INPUT: set image_buffer = RWTextureBuffer(format=R64Uint, stride=8, data=[0 1 0 1 0 1 0 1])
 uniform layout(binding=1,r64ui) u64imageBuffer image_buffer;
 #endif // #ifdef TEST_when_hardware_supports_i64_and_u64_buffers
-//TEST_INPUT: set image_1dArray = RWTexture1D(format=R64_UINT, size=4, content=one, mipMaps = 1, arrayLength=2)
+//TEST_INPUT: set image_1dArray = RWTexture1D(format=R64Uint, size=4, content=one, mipMaps = 1, arrayLength=2)
 uniform layout(binding=2,r64ui) u64image1DArray image_1dArray;
-//TEST_INPUT: set image_2d = RWTexture2D(format=R64_UINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_2d = RWTexture2D(format=R64Uint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=3,r64ui) u64image2D image_2d;
-//TEST_INPUT: set image_2dRect = RWTexture2D(format=R64_UINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_2dRect = RWTexture2D(format=R64Uint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=4,r64ui) u64image2DRect image_2dRect;
-//TEST_INPUT: set image_2dArray = RWTexture2D(format=R64_UINT, size=4, content=one, mipMaps = 1, arrayLength=2)
+//TEST_INPUT: set image_2dArray = RWTexture2D(format=R64Uint, size=4, content=one, mipMaps = 1, arrayLength=2)
 uniform layout(binding=6,r64ui) u64image2DArray image_2dArray;
-//TEST_INPUT: set image_3d = RWTexture3D(format=R64_UINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_3d = RWTexture3D(format=R64Uint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=7,r64ui) u64image3D image_3d;
-//TEST_INPUT: set image_cube = RWTextureCube(format=R64_UINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_cube = RWTextureCube(format=R64Uint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=8,r64ui) u64imageCube image_cube;
-//TEST_INPUT: set image_cubeArray = RWTextureCube(format=R64_UINT, size=4, content=one, mipMaps = 1, arrayLength=2)
+//TEST_INPUT: set image_cubeArray = RWTextureCube(format=R64Uint, size=4, content=one, mipMaps = 1, arrayLength=2)
 uniform layout(binding=9,r64ui) u64imageCubeArray image_cubeArray;
 #ifdef test_when_hardware_supports_i64_and_u64_sampled_textures
-//COM:TEST_INPUT: set image_2dMultiSample = RWTexture2D(format=R64_UINT, size=4, content=one, mipMaps = 1, sampleCount = two)
+//COM:TEST_INPUT: set image_2dMultiSample = RWTexture2D(format=R64Uint, size=4, content=one, mipMaps = 1, sampleCount = two)
 uniform layout(binding=5,r64ui) u64image2DMS image_2dMultiSample;
-//COM:TEST_INPUT: set image_2dMultiSampleArray = RWTexture2D(format=R64_UINT, size=4, content=one, mipMaps = 1, arrayLength=2, sampleCount = two)
+//COM:TEST_INPUT: set image_2dMultiSampleArray = RWTexture2D(format=R64Uint, size=4, content=one, mipMaps = 1, arrayLength=2, sampleCount = two)
 uniform layout(binding=10,r64ui) u64image2DMSArray image_2dMultiSampleArray;
 #endif // #ifdef test_when_hardware_supports_i64_and_u64_sampled_textures
 

--- a/tests/glsl-intrinsic/image/uimageDim.slang
+++ b/tests/glsl-intrinsic/image/uimageDim.slang
@@ -11,27 +11,27 @@ buffer MyBlockName2
 
 layout(local_size_x = 1) in;
 
-//TEST_INPUT: set image_1d = RWTexture1D(format=R32_UINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_1d = RWTexture1D(format=R32Uint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=0,r32ui) uimage1D image_1d;
-//TEST_INPUT: set image_buffer = RWTextureBuffer(format=R32_UINT, stride=8, data=[1 1 1 1])
+//TEST_INPUT: set image_buffer = RWTextureBuffer(format=R32Uint, stride=8, data=[1 1 1 1])
 uniform layout(binding=1,r32ui) uimageBuffer image_buffer;
-//TEST_INPUT: set image_1dArray = RWTexture1D(format=R32_UINT, size=4, content=one, mipMaps = 1, arrayLength=2)
+//TEST_INPUT: set image_1dArray = RWTexture1D(format=R32Uint, size=4, content=one, mipMaps = 1, arrayLength=2)
 uniform layout(binding=2,r32ui) uimage1DArray image_1dArray;
-//TEST_INPUT: set image_2d = RWTexture2D(format=R32_UINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_2d = RWTexture2D(format=R32Uint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=3,r32ui) uimage2D image_2d;
-//TEST_INPUT: set image_2dRect = RWTexture2D(format=R32_UINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_2dRect = RWTexture2D(format=R32Uint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=4,r32ui) uimage2DRect image_2dRect;
-//TEST_INPUT: set image_2dMultiSample = RWTexture2D(format=R32_UINT, size=4, content=one, mipMaps = 1, sampleCount = two)
+//TEST_INPUT: set image_2dMultiSample = RWTexture2D(format=R32Uint, size=4, content=one, mipMaps = 1, sampleCount = two)
 uniform layout(binding=5,r32ui) uimage2DMS image_2dMultiSample;
-//TEST_INPUT: set image_2dArray = RWTexture2D(format=R32_UINT, size=4, content=one, mipMaps = 1, arrayLength=2)
+//TEST_INPUT: set image_2dArray = RWTexture2D(format=R32Uint, size=4, content=one, mipMaps = 1, arrayLength=2)
 uniform layout(binding=6,r32ui) uimage2DArray image_2dArray;
-//TEST_INPUT: set image_3d = RWTexture3D(format=R32_UINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_3d = RWTexture3D(format=R32Uint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=7,r32ui) uimage3D image_3d;
-//TEST_INPUT: set image_cube = RWTextureCube(format=R32_UINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set image_cube = RWTextureCube(format=R32Uint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=8,r32ui) uimageCube image_cube;
-//TEST_INPUT: set image_cubeArray = RWTextureCube(format=R32_UINT, size=4, content=one, mipMaps = 1, arrayLength=2)
+//TEST_INPUT: set image_cubeArray = RWTextureCube(format=R32Uint, size=4, content=one, mipMaps = 1, arrayLength=2)
 uniform layout(binding=9,r32ui) uimageCubeArray image_cubeArray;
-//TEST_INPUT: set image_2dMultiSampleArray = RWTexture2D(format=R32_UINT, size=4, content=one, mipMaps = 1, arrayLength=2, sampleCount = two)
+//TEST_INPUT: set image_2dMultiSampleArray = RWTexture2D(format=R32Uint, size=4, content=one, mipMaps = 1, arrayLength=2, sampleCount = two)
 uniform layout(binding=10,r32ui) uimage2DMSArray image_2dMultiSampleArray;
 
 bool checkAllImageSize()

--- a/tests/glsl-intrinsic/shader-memory-control/shader-memory-control.slang
+++ b/tests/glsl-intrinsic/shader-memory-control/shader-memory-control.slang
@@ -15,7 +15,7 @@ buffer MyBlockName1
 
 groupshared uint raceConditionShared;
 
-//TEST_INPUT: set raceConditionImage = RWTexture1D(format=R32_SINT, size=4, content=one, mipMaps = 1)
+//TEST_INPUT: set raceConditionImage = RWTexture1D(format=R32Sint, size=4, content=one, mipMaps = 1)
 uniform layout(binding=0,r32i) iimage1D raceConditionImage;
 
 //TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer

--- a/tests/glsl-intrinsic/shader-subgroup/shader-subgroup-arithmetic_Exclusive.slang
+++ b/tests/glsl-intrinsic/shader-subgroup/shader-subgroup-arithmetic_Exclusive.slang
@@ -8,7 +8,7 @@
 
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl -emit-spirv-directly
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain -allow-glsl -xslang -DWGPU
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain -allow-glsl -xslang -DWGPU -render-feature half
 
 // Not testing because CI runners may not support Metal's intrinsics.
 //DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-metal -compute -entry computeMain -allow-glsl -xslang -DMETAL

--- a/tests/glsl-intrinsic/shader-subgroup/shader-subgroup-arithmetic_None.slang
+++ b/tests/glsl-intrinsic/shader-subgroup/shader-subgroup-arithmetic_None.slang
@@ -8,7 +8,7 @@
 
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl -emit-spirv-directly
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain -allow-glsl -xslang -DWGPU
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain -allow-glsl -xslang -DWGPU -render-feature half
 
 // Not testing because CI runners may not support Metal's intrinsics.
 //DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-metal -compute -entry computeMain -allow-glsl -xslang -DMETAL

--- a/tests/glsl-intrinsic/shader-subgroup/shader-subgroup-ballot.slang
+++ b/tests/glsl-intrinsic/shader-subgroup/shader-subgroup-ballot.slang
@@ -9,7 +9,7 @@
 
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl -emit-spirv-directly
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain -allow-glsl -xslang -DWGPU
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain -allow-glsl -xslang -DWGPU -render-feature half
 
 // Not testing because CI runners may not support Metal's intrinsics.
 //DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-metal -compute -entry computeMain -allow-glsl -xslang -DMETAL

--- a/tests/glsl-intrinsic/shader-subgroup/shader-subgroup-quad.slang
+++ b/tests/glsl-intrinsic/shader-subgroup/shader-subgroup-quad.slang
@@ -9,7 +9,7 @@
 
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl -emit-spirv-directly
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain -allow-glsl -xslang -DWGPU
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain -allow-glsl -xslang -DWGPU -render-feature half
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-metal -compute -entry computeMain -allow-glsl -xslang -DMETAL
 
 #version 430

--- a/tests/glsl-intrinsic/shader-subgroup/shader-subgroup-shuffle-relative.slang
+++ b/tests/glsl-intrinsic/shader-subgroup/shader-subgroup-shuffle-relative.slang
@@ -10,7 +10,7 @@
 
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl -emit-spirv-directly
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain -allow-glsl -xslang -DWGPU
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain -allow-glsl -xslang -DWGPU -render-feature half
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-metal -compute -entry computeMain -allow-glsl -xslang -DMETAL
 
 #version 430

--- a/tests/glsl-intrinsic/shader-subgroup/shader-subgroup-shuffle.slang
+++ b/tests/glsl-intrinsic/shader-subgroup/shader-subgroup-shuffle.slang
@@ -10,7 +10,7 @@
 
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl -emit-spirv-directly
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain -allow-glsl -xslang -DWGPU
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-wgpu -compute -entry computeMain -allow-glsl -xslang -DWGPU -render-feature half
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-metal -compute -entry computeMain -allow-glsl -xslang -DMETAL
 
 #version 430

--- a/tests/glsl-intrinsic/unpack-float.slang
+++ b/tests/glsl-intrinsic/unpack-float.slang
@@ -1,6 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute -shaderobj -emit-spirv-via-glsl -allow-glsl
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute -shaderobj -emit-spirv-directly -allow-glsl
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -shaderobj -render-feature hardware-device -allow-glsl
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -profile cs_6_6 -dx12 -use-dxil -shaderobj -render-feature hardware-device -allow-glsl
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-metal -compute -shaderobj -allow-glsl
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cpu -compute -shaderobj -allow-glsl

--- a/tests/hlsl-intrinsic/dot-accumulate.slang
+++ b/tests/hlsl-intrinsic/dot-accumulate.slang
@@ -3,7 +3,7 @@
 //DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx11
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -profile cs_6_4 -use-dxil -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX:-metal -compute -shaderobj -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX:-wgsl -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX:-wgsl -compute -shaderobj -render-feature half -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj -g0 -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj -output-using-type
 

--- a/tests/hlsl-intrinsic/packed/pack-unpack-float.slang
+++ b/tests/hlsl-intrinsic/packed/pack-unpack-float.slang
@@ -5,13 +5,12 @@
 
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute -shaderobj -emit-spirv-via-glsl -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute -shaderobj -emit-spirv-directly -output-using-type -allow-glsl
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -shaderobj -render-feature hardware-device -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -profile cs_6_6 -dx12 -use-dxil -shaderobj -render-feature hardware-device -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-metal -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cpu -compute -shaderobj -output-using-type -allow-glsl
 
 // 16 bit variants are not supported by WGSL.
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-wgpu -compute -shaderobj -xslang -DWGSL -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-wgpu -compute -shaderobj -xslang -DWGSL -render-feature half -output-using-type
 // Debug info for inlining errors can be given out, so disable them for this test.
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cuda -compute -g0 -output-using-type
 

--- a/tests/hlsl-intrinsic/packed/pack-unpack.slang
+++ b/tests/hlsl-intrinsic/packed/pack-unpack.slang
@@ -1,5 +1,4 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj -render-feature hardware-device
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -profile cs_6_6 -dx12 -use-dxil -shaderobj -render-feature hardware-device
 //TEST(compute):COMPARE_COMPUTE_EX:-metal -compute -shaderobj 
 //TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
@@ -10,7 +9,6 @@
 //TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -g0
 
 //TEST(compute):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -xslang -DUSE_SLANG_SYNTAX
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj -render-feature hardware-device -xslang -DUSE_SLANG_SYNTAX
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -profile cs_6_6 -dx12 -use-dxil -shaderobj -render-feature hardware-device -xslang -DUSE_SLANG_SYNTAX
 //TEST(compute):COMPARE_COMPUTE_EX:-metal -compute -shaderobj -xslang -DUSE_SLANG_SYNTAX
 //TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj -xslang -DUSE_SLANG_SYNTAX

--- a/tests/hlsl-intrinsic/packed/unpack-float.slang
+++ b/tests/hlsl-intrinsic/packed/unpack-float.slang
@@ -1,6 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute -shaderobj -emit-spirv-via-glsl -allow-glsl
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute -shaderobj -emit-spirv-directly -allow-glsl
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -shaderobj -render-feature hardware-device -allow-glsl
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -profile cs_6_6 -dx12 -use-dxil -shaderobj -render-feature hardware-device -allow-glsl
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-metal -compute -shaderobj -allow-glsl
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cpu -compute -shaderobj -allow-glsl

--- a/tests/hlsl-intrinsic/texture/float-atomics.slang
+++ b/tests/hlsl-intrinsic/texture/float-atomics.slang
@@ -5,7 +5,7 @@
 
 // Test atomics on a RWTexture2D<float>.
 
-//TEST_INPUT: set t = RWTexture2D(format=R32_FLOAT, size=4, content = zero, mipMaps = 1)
+//TEST_INPUT: set t = RWTexture2D(format=R32Float, size=4, content = zero, mipMaps = 1)
 [format("r32f")]
 globallycoherent RWTexture2D<float> t;
 

--- a/tests/hlsl-intrinsic/texture/texture-intrinsics.slang
+++ b/tests/hlsl-intrinsic/texture/texture-intrinsics.slang
@@ -360,10 +360,10 @@ void computeMain(int3 dispatchThreadID: SV_DispatchThreadID)
     outputBuffer[idx] = val;
 }
 
-// DX11: 327
-// DX11: 327
-// DX11: 327
-// DX11: 327
+// DX11: 354
+// DX11: 354
+// DX11: 354
+// DX11: 354
 // DX12: 354
 // DX12: 354
 // DX12: 354

--- a/tests/hlsl-intrinsic/texture/texture-intrinsics.slang
+++ b/tests/hlsl-intrinsic/texture/texture-intrinsics.slang
@@ -1,5 +1,5 @@
 //DISABLE_TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=DX11):-slang -compute -shaderobj -output-using-type -render-feature hardware-device
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=DX11):-slang -compute -dx11 -shaderobj -output-using-type -render-feature hardware-device
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=DX12):-slang -compute -dx12 -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=DX12CS6):-slang -compute -dx12 -profile cs_6_0 -use-dxil -shaderobj -output-using-type -xslang -DCS60
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=VK):-vk -emit-spirv-directly -compute -shaderobj -output-using-type -render-feature hardware-device -xslang -DVK

--- a/tests/spirv/atomic-image-access.slang
+++ b/tests/spirv/atomic-image-access.slang
@@ -9,7 +9,7 @@
 //TEST_INPUT:set resultBuffer = out ubuffer(data=[0 0 0 0], stride=4)
 RWStructuredBuffer<uint> resultBuffer;
 
-// TEST_INPUT: set tex = RWTexture2D(format=R32_UINT, size=4, content=zero, mipMaps = 1)
+// TEST_INPUT: set tex = RWTexture2D(format=R32Uint, size=4, content=zero, mipMaps = 1)
 [vk::image_format("r32ui")]
 RWTexture2D<uint> tex;
 

--- a/tests/spirv/small-int-texture.slang
+++ b/tests/spirv/small-int-texture.slang
@@ -2,7 +2,7 @@
 
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
 
-//TEST_INPUT: RWTexture2D(format=R8_UINT, size=4, content = one, mipMaps = 1):name g_Image
+//TEST_INPUT: RWTexture2D(format=R8Uint, size=4, content = one, mipMaps = 1):name g_Image
 RWTexture2D<uint8_t> g_Image;
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer

--- a/tests/wgsl/texture-storage.slang
+++ b/tests/wgsl/texture-storage.slang
@@ -8,30 +8,30 @@ RWStructuredBuffer<int> outputBuffer;
 
 // f32 types
 
-//TEST_INPUT: RWTexture1D(format=R32G32_FLOAT, size=4, content = zero):name w1D_f32v2
-//TEST_INPUT: RWTexture2D(format=R32G32_FLOAT, size=4, content = zero):name w2D_f32v2
-//TEST_INPUT: RWTexture3D(format=R32G32_FLOAT, size=4, content = zero):name w3D_f32v2
-//TEST_INPUT: RWTexture2D(format=R32G32_FLOAT, size=4, content = zero, arrayLength=2):name w2DArray_f32v2
+//TEST_INPUT: RWTexture1D(format=RG32Float, size=4, content = zero):name w1D_f32v2
+//TEST_INPUT: RWTexture2D(format=RG32Float, size=4, content = zero):name w2D_f32v2
+//TEST_INPUT: RWTexture3D(format=RG32Float, size=4, content = zero):name w3D_f32v2
+//TEST_INPUT: RWTexture2D(format=RG32Float, size=4, content = zero, arrayLength=2):name w2DArray_f32v2
 // WGSL: var w1D_f32v2{{[^:]*}}: texture_storage_1d<rg32float, read_write>
 [format("rg32f")] RWTexture1D<float2>      w1D_f32v2;
 [format("rg32f")] RWTexture2D<float2>      w2D_f32v2;
 [format("rg32f")] RWTexture3D<float2>      w3D_f32v2;
 [format("rg32f")] RWTexture2DArray<float2> w2DArray_f32v2;
 
-//TEST_INPUT: RWTexture1D(format=R8G8B8A8_UNORM, size=4, content = zero):name w1D_f32v4
-//TEST_INPUT: RWTexture2D(format=R8G8B8A8_UNORM, size=4, content = zero):name w2D_f32v4
-//TEST_INPUT: RWTexture3D(format=R8G8B8A8_UNORM, size=4, content = zero):name w3D_f32v4
-//TEST_INPUT: RWTexture2D(format=R8G8B8A8_UNORM, size=4, content = zero, arrayLength=2):name w2DArray_f32v4
+//TEST_INPUT: RWTexture1D(format=RGBA8Unorm, size=4, content = zero):name w1D_f32v4
+//TEST_INPUT: RWTexture2D(format=RGBA8Unorm, size=4, content = zero):name w2D_f32v4
+//TEST_INPUT: RWTexture3D(format=RGBA8Unorm, size=4, content = zero):name w3D_f32v4
+//TEST_INPUT: RWTexture2D(format=RGBA8Unorm, size=4, content = zero, arrayLength=2):name w2DArray_f32v4
 // WGSL: var w1D_f32v4{{[^:]*}}: texture_storage_1d<rgba8unorm, read_write>
 [format("rgba8")] RWTexture1D<float4>      w1D_f32v4;
 [format("rgba8")] RWTexture2D<float4>      w2D_f32v4;
 [format("rgba8")] RWTexture3D<float4>      w3D_f32v4;
 [format("rgba8")] RWTexture2DArray<float4> w2DArray_f32v4;
 
-//TEST_INPUT: RWTexture1D(format=B8G8R8A8_UNORM, size=4, content = zero):name w1D_f32_bgra_v4
-//TEST_INPUT: RWTexture2D(format=B8G8R8A8_UNORM, size=4, content = zero):name w2D_f32_bgra_v4
-//TEST_INPUT: RWTexture3D(format=B8G8R8A8_UNORM, size=4, content = zero):name w3D_f32_bgra_v4
-//TEST_INPUT: RWTexture2D(format=B8G8R8A8_UNORM, size=4, content = zero, arrayLength=2):name w2DArray_f32_bgra_v4
+//TEST_INPUT: RWTexture1D(format=BGRA8Unorm, size=4, content = zero):name w1D_f32_bgra_v4
+//TEST_INPUT: RWTexture2D(format=BGRA8Unorm, size=4, content = zero):name w2D_f32_bgra_v4
+//TEST_INPUT: RWTexture3D(format=BGRA8Unorm, size=4, content = zero):name w3D_f32_bgra_v4
+//TEST_INPUT: RWTexture2D(format=BGRA8Unorm, size=4, content = zero, arrayLength=2):name w2DArray_f32_bgra_v4
 // WGSL: var w1D_f32_bgra_v4{{[^:]*}}: texture_storage_1d<bgra8unorm, read_write>
 [format("bgra8")] RWTexture1D<float4>      w1D_f32_bgra_v4;
 [format("bgra8")] RWTexture2D<float4>      w2D_f32_bgra_v4;
@@ -40,20 +40,20 @@ RWStructuredBuffer<int> outputBuffer;
 
 // i32 types
 
-//TEST_INPUT: RWTexture1D(format=R32G32_SINT, size=4, content = zero):name w1D_i32v2
-//TEST_INPUT: RWTexture2D(format=R32G32_SINT, size=4, content = zero):name w2D_i32v2
-//TEST_INPUT: RWTexture3D(format=R32G32_SINT, size=4, content = zero):name w3D_i32v2
-//TEST_INPUT: RWTexture2D(format=R32G32_SINT, size=4, content = zero, arrayLength=2):name w2DArray_i32v2
+//TEST_INPUT: RWTexture1D(format=RG32Sint, size=4, content = zero):name w1D_i32v2
+//TEST_INPUT: RWTexture2D(format=RG32Sint, size=4, content = zero):name w2D_i32v2
+//TEST_INPUT: RWTexture3D(format=RG32Sint, size=4, content = zero):name w3D_i32v2
+//TEST_INPUT: RWTexture2D(format=RG32Sint, size=4, content = zero, arrayLength=2):name w2DArray_i32v2
 // WGSL: var w1D_i32v2{{[^:]*}}: texture_storage_1d<rg32sint, read_write>
 [format("rg32i")] RWTexture1D<int2>      w1D_i32v2;
 [format("rg32i")] RWTexture2D<int2>      w2D_i32v2;
 [format("rg32i")] RWTexture3D<int2>      w3D_i32v2;
 [format("rg32i")] RWTexture2DArray<int2> w2DArray_i32v2;
 
-//TEST_INPUT: RWTexture1D(format=R32G32B32A32_SINT, size=4, content = zero):name w1D_i32v4
-//TEST_INPUT: RWTexture2D(format=R32G32B32A32_SINT, size=4, content = zero):name w2D_i32v4
-//TEST_INPUT: RWTexture3D(format=R32G32B32A32_SINT, size=4, content = zero):name w3D_i32v4
-//TEST_INPUT: RWTexture2D(format=R32G32B32A32_SINT, size=4, content = zero, arrayLength=2):name w2DArray_i32v4
+//TEST_INPUT: RWTexture1D(format=RGBA32Sint, size=4, content = zero):name w1D_i32v4
+//TEST_INPUT: RWTexture2D(format=RGBA32Sint, size=4, content = zero):name w2D_i32v4
+//TEST_INPUT: RWTexture3D(format=RGBA32Sint, size=4, content = zero):name w3D_i32v4
+//TEST_INPUT: RWTexture2D(format=RGBA32Sint, size=4, content = zero, arrayLength=2):name w2DArray_i32v4
 // WGSL: var w1D_i32v4{{[^:]*}}: texture_storage_1d<rgba32sint, read_write>
 [format("rgba32i")] RWTexture1D<int4>      w1D_i32v4;
 [format("rgba32i")] RWTexture2D<int4>      w2D_i32v4;
@@ -62,20 +62,20 @@ RWStructuredBuffer<int> outputBuffer;
 
 // u32 types
 
-//TEST_INPUT: RWTexture1D(format=R32G32_UINT, size=4, content = zero):name w1D_u32v2
-//TEST_INPUT: RWTexture2D(format=R32G32_UINT, size=4, content = zero):name w2D_u32v2
-//TEST_INPUT: RWTexture3D(format=R32G32_UINT, size=4, content = zero):name w3D_u32v2
-//TEST_INPUT: RWTexture2D(format=R32G32_UINT, size=4, content = zero, arrayLength=2):name w2DArray_u32v2
+//TEST_INPUT: RWTexture1D(format=RG32Uint, size=4, content = zero):name w1D_u32v2
+//TEST_INPUT: RWTexture2D(format=RG32Uint, size=4, content = zero):name w2D_u32v2
+//TEST_INPUT: RWTexture3D(format=RG32Uint, size=4, content = zero):name w3D_u32v2
+//TEST_INPUT: RWTexture2D(format=RG32Uint, size=4, content = zero, arrayLength=2):name w2DArray_u32v2
 // WGSL: var w1D_u32v2{{[^:]*}}: texture_storage_1d<rg32uint, read_write>
 [format("rg32ui")] RWTexture1D<uint2>      w1D_u32v2;
 [format("rg32ui")] RWTexture2D<uint2>      w2D_u32v2;
 [format("rg32ui")] RWTexture3D<uint2>      w3D_u32v2;
 [format("rg32ui")] RWTexture2DArray<uint2> w2DArray_u32v2;
 
-//TEST_INPUT: RWTexture1D(format=R16G16B16A16_UINT, size=4, content = zero):name w1D_u32v4
-//TEST_INPUT: RWTexture2D(format=R16G16B16A16_UINT, size=4, content = zero):name w2D_u32v4
-//TEST_INPUT: RWTexture3D(format=R16G16B16A16_UINT, size=4, content = zero):name w3D_u32v4
-//TEST_INPUT: RWTexture2D(format=R16G16B16A16_UINT, size=4, content = zero, arrayLength=2):name w2DArray_u32v4
+//TEST_INPUT: RWTexture1D(format=RGBA16Uint, size=4, content = zero):name w1D_u32v4
+//TEST_INPUT: RWTexture2D(format=RGBA16Uint, size=4, content = zero):name w2D_u32v4
+//TEST_INPUT: RWTexture3D(format=RGBA16Uint, size=4, content = zero):name w3D_u32v4
+//TEST_INPUT: RWTexture2D(format=RGBA16Uint, size=4, content = zero, arrayLength=2):name w2DArray_u32v4
 // WGSL: var w1D_u32v4{{[^:]*}}: texture_storage_1d<rgba16uint, read_write>
 [format("rgba16ui")] RWTexture1D<uint4>      w1D_u32v4;
 [format("rgba16ui")] RWTexture2D<uint4>      w2D_u32v4;

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -721,7 +721,7 @@ void RenderTestApp::_initializeRenderPass()
     depthBufferDesc.size.width = gWindowWidth;
     depthBufferDesc.size.height = gWindowHeight;
     depthBufferDesc.size.depth = 1;
-    depthBufferDesc.mipLevelCount = 1;
+    depthBufferDesc.mipCount = 1;
     depthBufferDesc.format = Format::D32Float;
     depthBufferDesc.usage = TextureUsage::DepthStencil;
     depthBufferDesc.defaultState = ResourceState::DepthWrite;
@@ -735,7 +735,7 @@ void RenderTestApp::_initializeRenderPass()
     colorBufferDesc.size.width = gWindowWidth;
     colorBufferDesc.size.height = gWindowHeight;
     colorBufferDesc.size.depth = 1;
-    colorBufferDesc.mipLevelCount = 1;
+    colorBufferDesc.mipCount = 1;
     colorBufferDesc.format = Format::RGBA8Unorm;
     colorBufferDesc.usage = TextureUsage::RenderTarget | TextureUsage::CopySource;
     colorBufferDesc.defaultState = ResourceState::RenderTarget;

--- a/tools/render-test/shader-input-layout.cpp
+++ b/tools/render-test/shader-input-layout.cpp
@@ -30,7 +30,7 @@ Format _getFormatFromName(const UnownedStringSlice& slice)
             return Format(i);
         }
     }
-    return Format::Unknown;
+    return Format::Undefined;
 }
 
 struct TypeInfo
@@ -150,7 +150,7 @@ struct ShaderInputLayoutParser
         {
             val->textureDesc.format = parseFormatOption(parser);
 
-            if (val->textureDesc.format == Format::Unknown)
+            if (val->textureDesc.format == Format::Undefined)
             {
                 return SLANG_FAIL;
             }
@@ -1294,14 +1294,14 @@ void generateTextureData(TextureData& output, const InputTextureDesc& desc)
 
     switch (desc.format)
     {
-    case Format::R8G8B8A8_UNORM:
+    case Format::RGBA8Unorm:
         {
             generateTextureDataRGB8(output, desc);
             break;
         }
-    case Format::R16_FLOAT:
-    case Format::R16G16_FLOAT:
-    case Format::R16G16B16A16_FLOAT:
+    case Format::R16Float:
+    case Format::RG16Float:
+    case Format::RGBA16Float:
         {
             generateTextureDataWithTargetTStorage<uint16_t>(
                 output,
@@ -1310,7 +1310,7 @@ void generateTextureData(TextureData& output, const InputTextureDesc& desc)
                 loadDataIntoHalf);
             break;
         }
-    case Format::R64_UINT:
+    case Format::R64Uint:
         {
             generateTextureDataWithTargetTStorage<uint64_t>(
                 output,
@@ -1319,11 +1319,11 @@ void generateTextureData(TextureData& output, const InputTextureDesc& desc)
                 loadDataIntoUint<uint64_t>);
             break;
         }
-    case Format::R32_FLOAT:
-    case Format::R32G32_FLOAT:
-    case Format::R32G32B32_FLOAT:
-    case Format::R32G32B32A32_FLOAT:
-    case Format::D32_FLOAT:
+    case Format::R32Float:
+    case Format::RG32Float:
+    case Format::RGB32Float:
+    case Format::RGBA32Float:
+    case Format::D32Float:
         {
             generateTextureDataWithTargetTStorage<float>(
                 output,
@@ -1332,10 +1332,10 @@ void generateTextureData(TextureData& output, const InputTextureDesc& desc)
                 loadDataIntoFloat);
             break;
         }
-    case Format::R32_UINT:
-    case Format::R32G32_UINT:
-    case Format::R32G32B32_UINT:
-    case Format::R32G32B32A32_UINT:
+    case Format::R32Uint:
+    case Format::RG32Uint:
+    case Format::RGB32Uint:
+    case Format::RGBA32Uint:
         {
             generateTextureDataWithTargetTStorage<uint32_t>(
                 output,
@@ -1344,9 +1344,9 @@ void generateTextureData(TextureData& output, const InputTextureDesc& desc)
                 loadDataIntoUint<uint32_t>);
             break;
         }
-    case Format::R16_UINT:
-    case Format::R16G16_UINT:
-    case Format::R16G16B16A16_UINT:
+    case Format::R16Uint:
+    case Format::RG16Uint:
+    case Format::RGBA16Uint:
         {
             generateTextureDataWithTargetTStorage<uint16_t>(
                 output,
@@ -1355,9 +1355,9 @@ void generateTextureData(TextureData& output, const InputTextureDesc& desc)
                 loadDataIntoUint<uint16_t>);
             break;
         }
-    case Format::R8_UINT:
-    case Format::R8G8_UINT:
-    case Format::R8G8B8A8_UINT:
+    case Format::R8Uint:
+    case Format::RG8Uint:
+    case Format::RGBA8Uint:
         {
             generateTextureDataWithTargetTStorage<uint8_t>(
                 output,
@@ -1366,7 +1366,7 @@ void generateTextureData(TextureData& output, const InputTextureDesc& desc)
                 loadDataIntoUint<uint8_t>);
             break;
         }
-    case Format::R64_SINT:
+    case Format::R64Sint:
         {
             generateTextureDataWithTargetTStorage<int64_t>(
                 output,
@@ -1375,10 +1375,10 @@ void generateTextureData(TextureData& output, const InputTextureDesc& desc)
                 loadDataIntoInt<int64_t>);
             break;
         }
-    case Format::R32_SINT:
-    case Format::R32G32_SINT:
-    case Format::R32G32B32_SINT:
-    case Format::R32G32B32A32_SINT:
+    case Format::R32Sint:
+    case Format::RG32Sint:
+    case Format::RGB32Sint:
+    case Format::RGBA32Sint:
         {
             generateTextureDataWithTargetTStorage<int32_t>(
                 output,
@@ -1387,9 +1387,9 @@ void generateTextureData(TextureData& output, const InputTextureDesc& desc)
                 loadDataIntoInt<int32_t>);
             break;
         }
-    case Format::R16_SINT:
-    case Format::R16G16_SINT:
-    case Format::R16G16B16A16_SINT:
+    case Format::R16Sint:
+    case Format::RG16Sint:
+    case Format::RGBA16Sint:
         {
             generateTextureDataWithTargetTStorage<int16_t>(
                 output,
@@ -1398,9 +1398,9 @@ void generateTextureData(TextureData& output, const InputTextureDesc& desc)
                 loadDataIntoInt<int16_t>);
             break;
         }
-    case Format::R8_SINT:
-    case Format::R8G8_SINT:
-    case Format::R8G8B8A8_SINT:
+    case Format::R8Sint:
+    case Format::RG8Sint:
+    case Format::RGBA8Sint:
         {
             generateTextureDataWithTargetTStorage<int8_t>(
                 output,
@@ -1440,7 +1440,7 @@ void generateTextureDataRGB8(TextureData& output, const InputTextureDesc& inputD
     if (arrLen == 0)
         arrLen = 1;
 
-    output.init(Format::R8G8B8A8_UNORM);
+    output.init(Format::RGBA8Unorm);
 
     enum class SimpleScalarType
     {

--- a/tools/render-test/shader-input-layout.h
+++ b/tools/render-test/shader-input-layout.h
@@ -55,7 +55,7 @@ struct InputTextureDesc
     int mipMapCount = 0; ///< 0 means the maximum number of mips will be bound
 
     InputTextureSampleCount sampleCount = InputTextureSampleCount::One;
-    Format format = Format::R8G8B8A8_UNORM;
+    Format format = Format::RGBA8Unorm;
 
     InputTextureContent content = InputTextureContent::One;
 };
@@ -72,7 +72,7 @@ struct InputBufferDesc
     InputBufferType type = InputBufferType::StorageBuffer;
     int stride = 0; // stride == 0 indicates an unstructured buffer.
     int elementCount = 1;
-    Format format = Format::Unknown;
+    Format format = Format::Undefined;
     // For RWStructuredBuffer, AppendStructuredBuffer, ConsumeStructuredBuffer
     // the default value of 0xffffffff indicates that a counter buffer should
     // not be assigned
@@ -149,7 +149,7 @@ struct TextureData
         m_slices.clear();
     }
 
-    rhi::Format m_format = rhi::Format::Unknown;
+    rhi::Format m_format = rhi::Format::Undefined;
     uint8_t m_formatSize = 0;
 
     Slang::List<Slice> m_slices;

--- a/tools/render-test/shader-renderer-util.cpp
+++ b/tools/render-test/shader-renderer-util.cpp
@@ -79,7 +79,7 @@ inline int calcNumMipLevels(TextureType type, Extent3D size)
 
     textureDesc.sampleCount = inputDesc.sampleCount;
     textureDesc.format = format;
-    textureDesc.mipLevelCount = texData.m_mipLevels;
+    textureDesc.mipCount = texData.m_mipLevels;
     if (isArray)
     {
         textureDesc.arrayLength = inputDesc.arrayLength;
@@ -131,9 +131,9 @@ inline int calcNumMipLevels(TextureType type, Extent3D size)
         }
     }
 
-    if (textureDesc.mipLevelCount == 0)
+    if (textureDesc.mipCount == 0)
     {
-        textureDesc.mipLevelCount = calcNumMipLevels(textureDesc.type, textureDesc.size);
+        textureDesc.mipCount = calcNumMipLevels(textureDesc.type, textureDesc.size);
     }
 
     // Metal doesn't support mip maps for 1D textures.
@@ -141,7 +141,7 @@ inline int calcNumMipLevels(TextureType type, Extent3D size)
         (textureDesc.type == TextureType::Texture1D ||
          textureDesc.type == TextureType::Texture1DArray))
     {
-        textureDesc.mipLevelCount = 1;
+        textureDesc.mipCount = 1;
     }
 
     List<SubresourceData> initSubresources;
@@ -149,7 +149,7 @@ inline int calcNumMipLevels(TextureType type, Extent3D size)
     int subResourceCounter = 0;
     for (int a = 0; a < layerCount; ++a)
     {
-        for (int m = 0; m < textureDesc.mipLevelCount; ++m)
+        for (int m = 0; m < textureDesc.mipCount; ++m)
         {
             int subResourceIndex = subResourceCounter++;
             const int mipWidth = calcMipSize(textureDesc.size.width, m);

--- a/tools/render-test/shader-renderer-util.cpp
+++ b/tools/render-test/shader-renderer-util.cpp
@@ -69,9 +69,9 @@ inline int calcNumMipLevels(TextureType type, Extents size)
 {
     TextureDesc textureDesc = {};
 
-    // Default to R8G8B8A8_UNORM
+    // Default to RGBA8Unorm
     const Format format =
-        (inputDesc.format == Format::Unknown) ? Format::R8G8B8A8_UNORM : inputDesc.format;
+        (inputDesc.format == Format::Undefined) ? Format::RGBA8Unorm : inputDesc.format;
 
     textureDesc.sampleCount = inputDesc.sampleCount;
     textureDesc.format = format;

--- a/tools/render-test/shader-renderer-util.cpp
+++ b/tools/render-test/shader-renderer-util.cpp
@@ -73,6 +73,8 @@ inline int calcNumMipLevels(TextureType type, Extent3D size)
     const Format format =
         (inputDesc.format == Format::Undefined) ? Format::RGBA8Unorm : inputDesc.format;
 
+    const FormatInfo& formatInfo = getFormatInfo(format);
+
     bool isArray = inputDesc.arrayLength > 1;
 
     textureDesc.sampleCount = inputDesc.sampleCount;
@@ -153,7 +155,7 @@ inline int calcNumMipLevels(TextureType type, Extent3D size)
             const int mipWidth = calcMipSize(textureDesc.size.width, m);
             const int mipHeight = calcMipSize(textureDesc.size.height, m);
 
-            size_t rowPitch = mipWidth * sizeof(uint32_t);
+            size_t rowPitch = mipWidth * formatInfo.blockSizeInBytes;
             size_t slicePitch = mipHeight * rowPitch;
 
             SubresourceData subresourceData;

--- a/tools/render-test/shader-renderer-util.cpp
+++ b/tools/render-test/shader-renderer-util.cpp
@@ -14,9 +14,9 @@ inline int calcMipSize(int size, int level)
     return size > 0 ? size : 1;
 }
 
-inline Extents calcMipSize(Extents size, int mipLevel)
+inline Extent3D calcMipSize(Extent3D size, int mipLevel)
 {
-    Extents rs;
+    Extent3D rs;
     rs.width = calcMipSize(size.width, mipLevel);
     rs.height = calcMipSize(size.height, mipLevel);
     rs.depth = calcMipSize(size.depth, mipLevel);
@@ -24,7 +24,7 @@ inline Extents calcMipSize(Extents size, int mipLevel)
 }
 
 /// Given the type works out the maximum dimension size
-inline int calcMaxDimension(Extents size, TextureType type)
+inline int calcMaxDimension(Extent3D size, TextureType type)
 {
     switch (type)
     {
@@ -43,7 +43,7 @@ inline int calcMaxDimension(Extents size, TextureType type)
 }
 
 /// Given the type, calculates the number of mip maps. 0 on error
-inline int calcNumMipLevels(TextureType type, Extents size)
+inline int calcNumMipLevels(TextureType type, Extent3D size)
 {
     const int maxDimensionSize = calcMaxDimension(size, type);
     return (maxDimensionSize > 0) ? (Math::Log2Floor(maxDimensionSize) + 1) : 0;
@@ -145,13 +145,13 @@ inline int calcNumMipLevels(TextureType type, Extents size)
             const int mipWidth = calcMipSize(textureDesc.size.width, m);
             const int mipHeight = calcMipSize(textureDesc.size.height, m);
 
-            auto strideY = mipWidth * sizeof(uint32_t);
-            auto strideZ = mipHeight * strideY;
+            size_t rowPitch = mipWidth * sizeof(uint32_t);
+            size_t slicePitch = mipHeight * rowPitch;
 
             SubresourceData subresourceData;
             subresourceData.data = texData.m_slices[subResourceIndex].values;
-            subresourceData.strideY = strideY;
-            subresourceData.strideZ = strideZ;
+            subresourceData.rowPitch = rowPitch;
+            subresourceData.slicePitch = slicePitch;
 
             initSubresources.add(subresourceData);
         }

--- a/tools/render-test/shader-renderer-util.cpp
+++ b/tools/render-test/shader-renderer-util.cpp
@@ -134,6 +134,14 @@ inline int calcNumMipLevels(TextureType type, Extent3D size)
         textureDesc.mipLevelCount = calcNumMipLevels(textureDesc.type, textureDesc.size);
     }
 
+    // Metal doesn't support mip maps for 1D textures.
+    if (device->getDeviceType() == DeviceType::Metal &&
+        (textureDesc.type == TextureType::Texture1D ||
+         textureDesc.type == TextureType::Texture1DArray))
+    {
+        textureDesc.mipLevelCount = 1;
+    }
+
     List<SubresourceData> initSubresources;
     int layerCount = textureDesc.getLayerCount();
     int subResourceCounter = 0;


### PR DESCRIPTION
Update to latest `slang-rhi` version.

- Update render test application due to slang-rhi API changes
- Update texture format strings used in tests, they now use a `CamelCase` style

I had to disable two tests (adding them `to expected-failure-github.txt`):
- `tests/compute/cbuffer-legalize.slang.2 syn (mtl)` (@kaizhangNV maybe this is related to the metal parameter block change?!)
- `tests/hlsl-intrinsic/classify-float.slang.5 syn (wgpu)` (`isnan` bug reported here #6881)

In addition the following tests require the `half` render feature now for WGPU, because slang-rhi switched WGPU backend to Vulkan which doesn't support the `f16` extension. Once we can switch back to D3D12 backend again those tests will automatically be re-enabled as the `half` render feature will be reported again:
- `tests/glsl-intrinsic/shader-subgroup/shader-subgroup-arithmetic_Exclusive.slang`
- `tests/glsl-intrinsic/shader-subgroup/shader-subgroup-arithmetic_None.slang`
- `tests/glsl-intrinsic/shader-subgroup/shader-subgroup-ballot.slang`
- `tests/glsl-intrinsic/shader-subgroup/shader-subgroup-quad.slang`
- `tests/glsl-intrinsic/shader-subgroup/shader-subgroup-shuffle-relative.slang`
- `tests/glsl-intrinsic/shader-subgroup/shader-subgroup-shuffle.slang`
- `tests/hlsl-intrinsic/dot-accumulate.slang`
- `tests/hlsl-intrinsic/packed/pack-unpack-float.slang`

Explicitly removed testing on D3D11 for the following tests. Before, they were ignored because D3D11 didn't report the `hardware-device` render feature:
- `tests/glsl-intrinsic/unpack-float.slang`
- `tests/hlsl-intrinsic/packed/pack-unpack-float.slang`
- `tests/hlsl-intrinsic/packed/pack-unpack.slang`
- `tests/hlsl-intrinsic/packed/unpack-float.slang`
- `tests/hlsl-intrinsic/texture/texture-intrinsics.slang` (also fixed expected result, which now matches D3D12)
