### PR TITLE
Eliminate empty struct on metal target

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -1278,6 +1278,15 @@ Result linkAndOptimizeIR(
         //
         legalizeResourceTypes(targetProgram, irModule, sink);
 
+        // We also need to legalize empty types for Metal targets.
+        switch (target)
+        {
+        case CodeGenTarget::Metal:
+        case CodeGenTarget::MetalLib:
+        case CodeGenTarget::MetalLibAssembly:
+            legalizeEmptyTypes(targetProgram, irModule, sink);
+            break;
+        }
         //  Debugging output of legalization
 #if 0
         dumpIRIfEnabled(codeGenContext, irModule, "LEGALIZED");

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -4125,6 +4125,11 @@ struct IREmptyTypeLegalizationContext : IRTypeLegalizationContext
 
     bool isSimpleType(IRType* type) override
     {
+        if (isMetalTarget(targetProgram->getTargetReq()))
+        {
+            return false;
+        }
+
         // If type is used as public interface, then treat it as simple.
         for (auto decor : type->getDecorations())
         {

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -4147,6 +4147,8 @@ struct IREmptyTypeLegalizationContext : IRTypeLegalizationContext
     {
         return LegalType();
     }
+
+    virtual bool isEmptyTypeLegalize() override { return true; }
 };
 
 // The main entry points that are used when transforming IR code

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -4153,7 +4153,10 @@ struct IREmptyTypeLegalizationContext : IRTypeLegalizationContext
         return LegalType();
     }
 
-    virtual bool isEmptyTypeLegalize() override { return true; }
+    virtual bool shouldLegalizeParameterBlockElementType() override
+    {
+        return isMetalTarget(targetProgram->getTargetReq());
+    }
 };
 
 // The main entry points that are used when transforming IR code

--- a/source/slang/slang-legalize-types.cpp
+++ b/source/slang/slang-legalize-types.cpp
@@ -1211,7 +1211,8 @@ LegalType legalizeTypeImpl(TypeLegalizationContext* context, IRType* type)
         LegalType legalElementType;
 
         if (isMetalTarget(context->targetProgram->getTargetReq()) &&
-            as<IRParameterBlockType>(uniformBufferType) && !context->isEmptyTypeLegalize())
+            as<IRParameterBlockType>(uniformBufferType) &&
+            !context->shouldLegalizeParameterBlockElementType())
         {
             // On Metal, we do not need to legalize the element type of
             // a parameter block because we can translate it directly into

--- a/source/slang/slang-legalize-types.cpp
+++ b/source/slang/slang-legalize-types.cpp
@@ -1211,11 +1211,14 @@ LegalType legalizeTypeImpl(TypeLegalizationContext* context, IRType* type)
         LegalType legalElementType;
 
         if (isMetalTarget(context->targetProgram->getTargetReq()) &&
-            as<IRParameterBlockType>(uniformBufferType))
+            as<IRParameterBlockType>(uniformBufferType) && !context->isEmptyTypeLegalize())
         {
             // On Metal, we do not need to legalize the element type of
             // a parameter block because we can translate it directly into
             // an argument buffer.
+            //
+            // But we do need empty type legalized for Metal, because Metal doesn't
+            // allow empty struct in argument buffer.
             legalElementType = LegalType::simple(originalElementType);
         }
         else

--- a/source/slang/slang-legalize-types.h
+++ b/source/slang/slang-legalize-types.h
@@ -660,7 +660,7 @@ struct IRTypeLegalizationContext
         LegalType legalElementType,
         IRInst* layoutOperand) = 0;
 
-    virtual bool isEmptyTypeLegalize() { return false; }
+    virtual bool shouldLegalizeParameterBlockElementType() { return false; }
 };
 
 // This typedef exists to support pre-existing code from when

--- a/source/slang/slang-legalize-types.h
+++ b/source/slang/slang-legalize-types.h
@@ -659,6 +659,8 @@ struct IRTypeLegalizationContext
         IROp op,
         LegalType legalElementType,
         IRInst* layoutOperand) = 0;
+
+    virtual bool isEmptyTypeLegalize() { return false; }
 };
 
 // This typedef exists to support pre-existing code from when

--- a/tests/metal/empty-struct-remove.slang
+++ b/tests/metal/empty-struct-remove.slang
@@ -22,6 +22,7 @@ struct MyStruct
 
 ParameterBlock<MyStruct> param;
 
+// LIB: @computeMain
 [shader("compute")]
 [numthreads(1, 1, 1)]
 void computeMain(

--- a/tests/metal/empty-struct-remove.slang
+++ b/tests/metal/empty-struct-remove.slang
@@ -1,0 +1,32 @@
+
+//TEST:SIMPLE(filecheck=LIB):-target metallib -entry computeMain -stage compute -DMETAL
+//TEST:SIMPLE(filecheck=METAL):-target metal -entry computeMain -stage compute -DMETAL
+
+// METAL-NOT: struct emptyStruct
+struct emptyStruct
+{
+    void set(RWStructuredBuffer<int> buffer, int value) {buffer[0] = value;}
+}
+
+
+struct MyStruct
+{
+    RWStructuredBuffer<int> buffer;
+    int value;
+    void set()
+    {
+        e.set(buffer, value);
+    }
+    emptyStruct e;
+}
+
+ParameterBlock<MyStruct> param;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(
+    uint tid: SV_DispatchThreadID,
+)
+{
+    param.set();
+}


### PR DESCRIPTION
Close #6573.

We previously disabled the type legalization for ParameterBlock on Metal, but Metal doesn't allow empty struct in the argument buffer which is mapped from ParameterBlock, so we will need legalizeEmptyTypes on Metal target.