### PR TITLE
fix trimming of "v" from version string

### DIFF
--- a/.github/workflows/release-linux-glibc-2-17.yml
+++ b/.github/workflows/release-linux-glibc-2-17.yml
@@ -35,7 +35,11 @@ jobs:
         id: package
         run: |
           triggering_ref=${{ github.ref_name }}
-          version=${triggering_ref#v}
+          if [[ $triggering_ref =~ ^v[0-9] ]]; then
+            version=${triggering_ref#v}
+          else
+            version=$triggering_ref
+          fi
           base=$(pwd)/slang-${version}-linux-x86_64-glibc-2.17
 
           sudo mv "$(pwd)/build/dist-release/slang.zip" "${base}.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,12 @@ jobs:
           cpack --preset "$config-debug-info" -G TGZ
 
           triggering_ref=${{ github.ref_name }}
-          base=slang-${triggering_ref#v}-${{matrix.os}}-${{matrix.platform}}
+          if [[ $triggering_ref =~ ^v[0-9] ]]; then
+            version=${triggering_ref#v}
+          else
+            version=$triggering_ref
+          fi
+          base=slang-${version}-${{matrix.os}}-${{matrix.platform}}
 
           # Move main packages
           mv "$(pwd)/build/dist-${config}/slang.zip" "${base}.zip"


### PR DESCRIPTION
Current releases are removing "v" from "vulkan-sdk-1.4.309.0" when they were supposed to remove it from something like "v1.2.4" https://github.com/shader-slang/slang/releases/tag/vulkan-sdk-1.4.309.0

Fixed it so it only removes "v", if next character is a number