### PR TITLE
Add SPIRV atomic debug type

### DIFF
--- a/source/slang/slang-emit-spirv-ops-debug-info-ext.h
+++ b/source/slang/slang-emit-spirv-ops-debug-info-ext.h
@@ -401,6 +401,28 @@ SpvInst* emitOpDebugTypePointer(
 }
 
 template<typename T>
+SpvInst* emitOpDebugTypeQualifier(
+    SpvInstParent* parent,
+    IRInst* inst,
+    const T& idResultType,
+    SpvInst* set,
+    SpvInst* baseType,
+    IRInst* typeQualifier)
+{
+    static_assert(isSingular<T>);
+    return emitInst(
+        parent,
+        inst,
+        SpvOpExtInst,
+        idResultType,
+        kResultID,
+        set,
+        SpvWord(4),
+        baseType,
+        typeQualifier);
+}
+
+template<typename T>
 SpvInst* emitOpDebugScope(
     SpvInstParent* parent,
     IRInst* inst,

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -7440,6 +7440,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
     HashSet<IRType*> m_emittingTypes; // Types that are being emitted.
     Dictionary<IRType*, SpvInst*> m_mapForwardRefsToDebugType;
     static constexpr const int kUnknownPhysicalLayout = 1 << 17;
+    static constexpr const int kDebugTypeAtomicQualifier = 3;
 
     SpvInst* emitDebugTypeImpl(IRType* type)
     {
@@ -7691,6 +7692,19 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 debugBaseType,
                 builder.getIntValue(builder.getUIntType(), storageClass),
                 builder.getIntValue(builder.getUIntType(), kUnknownPhysicalLayout));
+        }
+        else if (auto atomicType = as<IRAtomicType>(type))
+        {
+            auto baseType = atomicType->getElementType();
+            auto debugBaseType = emitDebugType(baseType);
+
+            return emitOpDebugTypeQualifier(
+                getSection(SpvLogicalSectionID::ConstantsAndTypes),
+                nullptr,
+                m_voidType,
+                getNonSemanticDebugInfoExtInst(),
+                debugBaseType,
+                builder.getIntValue(builder.getUIntType(), kDebugTypeAtomicQualifier));
         }
         return ensureInst(m_voidType);
     }

--- a/tests/spirv/debug-type-atomic-pointer.slang
+++ b/tests/spirv/debug-type-atomic-pointer.slang
@@ -1,0 +1,31 @@
+//TEST(compute, vulkan):SIMPLE(filecheck=CHECK_SPV): -stage compute -entry computeMain -target spirv -emit-spirv-directly -g2
+
+
+// CHECK_SPV: [[STRING_uint:%[1-9][0-9]*]] = OpString "uint"
+// CHECK_SPV: [[TYPE_uint:%[1-9][0-9]*]] = OpExtInst %void %{{[0-9]*}} DebugTypeBasic [[STRING_uint]]
+
+// Debug type qualifier for atomic is 3
+// CHECK_SPV: [[TYPE_atomic_uint:%[1-9][0-9]*]] = OpExtInst %void %{{[0-9]*}} DebugTypeQualifier [[TYPE_uint]] %uint_3
+// CHECK_SPV: OpExtInst %void %{{[0-9]*}} DebugTypePointer [[TYPE_atomic_uint]]
+
+struct Test {
+    Atomic<uint32_t> atomicMember;
+};
+
+struct PC {
+    Atomic<uint>* atomicMember;
+    Test* test;
+}
+
+[[vk::push_constant]]
+PC pc;
+
+[shader("compute")]
+[numthreads(1,1,1)]
+public void computeMain() {
+    Atomic<uint32_t>* atomicMember = pc.atomicMember;
+    atomicMember.store(10);
+
+    Test* test = pc.test;
+    test.atomicMember.store(10);
+}


### PR DESCRIPTION
Closes #6597.

Adds SPIRV debug type info for atomic types. This is implemented through the [debug type qualifier](https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc#DebugTypeQualifier) instruction and the [type qualifier constants](https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc#TypeQualifiers).