### PR TITLE
Add auto-diff support for `GetOffsetPtr`

### DIFF
--- a/source/slang/slang-ir-addr-inst-elimination.cpp
+++ b/source/slang/slang-ir-addr-inst-elimination.cpp
@@ -174,6 +174,7 @@ struct AddressInstEliminationContext
                 case kIROp_FieldAddress:
                 case kIROp_Unmodified:
                 case kIROp_DebugValue:
+                case kIROp_GetOffsetPtr:
                     break;
                 default:
                     sink->diagnose(

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -2187,6 +2187,7 @@ InstPair ForwardDiffTranscriber::transcribeInstImpl(IRBuilder* builder, IRInst* 
     case kIROp_MakeCoopVector:
     case kIROp_MakeCoopVectorFromValuePack:
     case kIROp_GetCurrentStage:
+    case kIROp_GetOffsetPtr:
         return transcribeNonDiffInst(builder, origInst);
 
         // A call to createDynamicObject<T>(arbitraryData) cannot provide a diff value,

--- a/tests/autodiff/get-offset-ptr.slang
+++ b/tests/autodiff/get-offset-ptr.slang
@@ -1,0 +1,40 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -line-directive-mode none
+
+//CHECK: struct s_bwd_prop_function_Intermediates{{[_0-9]+}}
+//CHECK: {
+//CHECK:     MyDiffPtr{{[_0-9]+}} {{[_A-Za-z0-9]+}};
+//CHECK:     MyDiffPtr{{[_0-9]+}} {{[_A-Za-z0-9]+}};
+//CHECK: };
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out, name outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+struct MyDiffPtr
+{
+    uint offset;
+    uint d_offset;
+
+    [BackwardDerivative(__bwd_foo)]
+    float foo() 
+    { 
+        return outputBuffer[offset] * outputBuffer[offset];
+    }
+
+    void __bwd_foo(float grad) 
+    {
+        outputBuffer[d_offset] = 2.f * outputBuffer[offset] * grad;
+    }
+};
+
+[Differentiable]
+float function(MyDiffPtr *i)
+{
+    return i[0].foo() + i[1].foo();
+}
+
+[numthreads(1, 1, 1), shader("compute")]
+void main(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    MyDiffPtr s[2] = {{0, 2}, {1, 3}};
+    __bwd_diff(function)(&s[0], 1.0f);
+}


### PR DESCRIPTION
Allows non-differentiable ptr types to be used within differentiable function bodies. They will be treated as primal values, but if represented in "pairs", they are a very useful way to perform derivative aggregation.

Fixes: https://github.com/shader-slang/slang/issues/6562