### PR TITLE
Fix MSVC warning D9025 when building external dependencies.

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -20,9 +20,7 @@ endif()
 
 # Similarly, disable warnings for external projects
 if(NOT SLANG_ENABLE_EXTERNAL_COMPILER_WARNINGS)
-    if(MSVC)
-        add_compile_options(/W0)
-    else()
+    if(NOT MSVC)
         add_compile_options(-w)
     endif()
 endif()

--- a/tests/bugs/gh-6482-interface-method-existential-specialize.slang
+++ b/tests/bugs/gh-6482-interface-method-existential-specialize.slang
@@ -51,7 +51,7 @@ namespace integrator {
 
         float4 sample(IScene scene, RayDesc _ray, IRandom rng, int pixel_aabb_uv, uint3 id) {
             float4 grad = { 0.0f, 0.0f, 0.0f, 1.0f };
-
+                
             RayDesc ray = _ray; uint32_t depth = 0;
             RayQuery<0> rayQuery;
             while (rayQuery.Proceed()) {

--- a/tests/bugs/gh-6482-interface-method-existential-specialize.slang
+++ b/tests/bugs/gh-6482-interface-method-existential-specialize.slang
@@ -51,7 +51,7 @@ namespace integrator {
 
         float4 sample(IScene scene, RayDesc _ray, IRandom rng, int pixel_aabb_uv, uint3 id) {
             float4 grad = { 0.0f, 0.0f, 0.0f, 1.0f };
-                
+
             RayDesc ray = _ray; uint32_t depth = 0;
             RayQuery<0> rayQuery;
             while (rayQuery.Proceed()) {


### PR DESCRIPTION
Closes #6631.