### PR TITLE
Add GLSL debugPrintfEXT syntax support

### DIFF
--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -9401,4 +9401,9 @@ __intrinsic_op($(kIROp_NonUniformResourceIndex))
 [require(cpp_cuda_glsl_hlsl_spirv, nonuniformqualifier)]
 public T nonuniformEXT(T index);
 
-
+/// Debug output printing
+[ForceInline]
+public void debugPrintfEXT<each T>(NativeString format, expand each T args)
+{
+    printf(format, args);
+}

--- a/tests/glsl-intrinsic/debug-printf.slang
+++ b/tests/glsl-intrinsic/debug-printf.slang
@@ -1,0 +1,15 @@
+//TEST:SIMPLE(filecheck=CHECK_SPIRV): -target spirv -stage compute -entry main -allow-glsl
+//TEST:SIMPLE(filecheck=CHECK_GLSL): -target glsl -stage compute -entry main -allow-glsl
+
+void main()
+{
+    debugPrintfEXT("test");
+    debugPrintfEXT(R"(test1 "%d %d")", 5, 6);
+
+    // CHECK_SPIRV: %[[SET:[0-9]+]] = OpExtInstImport "NonSemantic.DebugPrintf"
+    // CHECK_SPIRV: {{.*}} = OpExtInst %{{[a-zA-Z0-9_]+}} %[[SET]] 1 %{{[a-zA-Z0-9_]+}}
+    // CHECK_SPIRV: {{.*}} = OpExtInst %{{[a-zA-Z0-9_]+}} %[[SET]] 1 %{{[a-zA-Z0-9_]+}} %int_5 %int_6
+
+    // CHECK_GLSL: debugPrintfEXT("test")
+    // CHECK_GLSL: debugPrintfEXT("test1 \"%d %d\"", 5, 6);
+}


### PR DESCRIPTION
Related to #6652.

Implements GLSL `debugPrintfEXT` syntax, which just calls the already implemented Slang `printf` function.