### PR TITLE
Apply pixel interlock execution mode to entry-point functions only

### DIFF
--- a/tests/pipeline/rasterization/fragment-shader-interlock-child-function.slang
+++ b/tests/pipeline/rasterization/fragment-shader-interlock-child-function.slang
@@ -1,0 +1,31 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage fragment
+
+RasterizerOrderedTexture2D<float4> texture;
+
+//
+// Tests that an interlock region place at a non-entry point function will properly apply the SPIRV execution mode
+// to the entry point function and not the child function.
+//
+
+// CHECK: OpEntryPoint
+// CHECK: OpExecutionMode %main PixelInterlockOrderedEXT
+
+float4 foo(float4 coords)
+{
+    float4 result;
+
+    beginInvocationInterlock();
+    {
+        result = texture[uint2(coords.xy)];
+        texture[uint2(coords.xy)] = result + coords;
+    }
+    endInvocationInterlock();
+
+    return result;
+}
+
+[shader("fragment")]
+float4 main(float4 coords : COORDS) : SV_Target
+{
+    return foo(coords);
+}


### PR DESCRIPTION
Closes #6658.

Fixes an issue where having pixel interlock regions outside of the entry point function, i.e. in another child function that gets called/referenced by the entry point function, incorrectly applies the execution mode to that child function instead of to the entry point function.