### PR TITLE
Add unordered_dense as an include path for gcc and msvc

### DIFF
--- a/source/compiler-core/slang-gcc-compiler-util.cpp
+++ b/source/compiler-core/slang-gcc-compiler-util.cpp
@@ -647,6 +647,11 @@ static SlangResult _parseGCCFamilyLine(
         cmdLine.addArg("-I");
         cmdLine.addArg(asString(include));
     }
+    // As a convenience, add our dependencies as system include paths, if the
+    // user is compiling without these available here they will have to provide
+    // this themselves.
+    cmdLine.addArg("-isystem");
+    cmdLine.addArg("external/unordered_dense/include");
 
     // Link options
     if (0) // && options.targetType != TargetType::Object)

--- a/source/compiler-core/slang-visual-studio-compiler-util.cpp
+++ b/source/compiler-core/slang-visual-studio-compiler-util.cpp
@@ -282,6 +282,12 @@ static void _addFile(
         cmdLine.addArg("/I");
         cmdLine.addArg(asString(include));
     }
+    // As a convenience, add our dependencies as system include paths, if the
+    // user is compiling without these available here they will have to provide
+    // this themselves.
+    cmdLine.addArg("/external:I");
+    cmdLine.addArg("external/unordered_dense/include");
+
 
     // https://docs.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=vs-2019
     // /Eha - Specifies the model of exception handling. (a, s, c, r are options)


### PR DESCRIPTION
Closes https://github.com/shader-slang/slang/issues/6618

This PR restores the old behavior, however we should probably modify slang-embed to also embed `#include`d files or install the unordered_dense headers 