### PR TITLE
Add GLSL array length syntax support

### DIFF
--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -321,6 +321,17 @@ ${{{{
 }
 }}}}
 
+/// Array length
+__generic<T, let N : int>
+public extension Array<T, N>
+{
+    [ForceInline]
+    public int length()
+    {
+        return this.getCount();
+    }
+}
+
 //
 // Section 8.1. Angle and Trigonometry Functions
 //

--- a/tests/glsl-intrinsic/array-length.slang
+++ b/tests/glsl-intrinsic/array-length.slang
@@ -1,0 +1,34 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute -shaderobj  -allow-glsl
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -shaderobj -render-feature hardware-device -allow-glsl
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-metal -compute -shaderobj -allow-glsl
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cpu -compute -shaderobj -allow-glsl
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-wgpu -compute -shaderobj -allow-glsl
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cuda -compute -g0 -allow-glsl
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+//
+// Tests GLSL array.length() syntax.
+//
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    int myArray[4] = {4, 3, 2, 1};
+    outputBuffer[0] = myArray[0];
+    outputBuffer[1] = myArray[1];
+    outputBuffer[2] = myArray[2];
+    outputBuffer[3] = myArray[3];
+    outputBuffer[4] = myArray.length();
+
+    // BUF: 4
+    // BUF-NEXT: 3
+    // BUF-NEXT: 2
+    // BUF-NEXT: 1
+    // BUF-NEXT: 4
+}
+
+
+


### PR DESCRIPTION
 Implement array.length() function for GLSL syntax.
 Closes #6652 