### PR TITLE
Fixed name mangling of generic extensions

### DIFF
--- a/source/slang/slang-mangle.cpp
+++ b/source/slang/slang-mangle.cpp
@@ -391,6 +391,7 @@ void emitVal(ManglingContext* context, Val* val)
 
 void emitQualifiedName(ManglingContext* context, DeclRef<Decl> declRef, bool includeModuleName)
 {
+    bool ignoreName = false;
     if (!includeModuleName)
     {
         if (as<ModuleDecl>(declRef))
@@ -445,19 +446,6 @@ void emitQualifiedName(ManglingContext* context, DeclRef<Decl> declRef, bool inc
         return;
     }
 
-    // Inheritance declarations don't have meaningful names,
-    // and so we should emit them based on the type
-    // that is doing the inheriting.
-    if (auto inheritanceDeclRef = declRef.as<TypeConstraintDecl>())
-    {
-        emit(context, "I");
-        emitType(context, getSup(context->astBuilder, inheritanceDeclRef));
-        return;
-    }
-
-    // Similarly, an extension doesn't have a name worth
-    // emitting, and we should base things on its target
-    // type instead.
     if (auto extensionDeclRef = declRef.as<ExtensionDecl>())
     {
         // TODO: as a special case, an "unconditional" extension
@@ -471,7 +459,25 @@ void emitQualifiedName(ManglingContext* context, DeclRef<Decl> declRef, bool inc
             emit(context, "I");
             emitType(context, getSup(context->astBuilder, inheritanceDecl));
         }
-        return;
+        // A non generic extension doesn't have a name worth
+        // emitting, and we should base things on its target
+        // type instead.
+        if (parentGenericDeclRef)
+        {
+            ignoreName = true;
+        }
+    }
+    // Inheritance declarations don't have meaningful names,
+    // and so we should emit them based on the type
+    // that is doing the inheriting.
+    else if (auto inheritanceDeclRef = declRef.as<TypeConstraintDecl>())
+    {
+        emit(context, "I");
+        emitType(context, getSup(context->astBuilder, inheritanceDeclRef));
+        if (parentGenericDeclRef)
+        {
+            ignoreName = true;
+        }
     }
 
     // TODO: we should special case GenericTypeParamDecl and GenericValueParamDecl nodes
@@ -480,7 +486,10 @@ void emitQualifiedName(ManglingContext* context, DeclRef<Decl> declRef, bool inc
     // For each generic parameter, we should assign it a unique ID (i, j), where i is the
     // nesting level of the generic, and j is the sequential order of the parameter within
     // its generic parent, and use this 2D ID to refer to such a parameter.
-    emitName(context, declRef.getName());
+    if (!ignoreName)
+    {
+        emitName(context, declRef.getName());
+    }
 
     // Special case: accessors need some way to distinguish themselves
     // so that a getter/setter/ref-er don't all compile to the same name.

--- a/tests/disabled-tests.txt
+++ b/tests/disabled-tests.txt
@@ -33,7 +33,6 @@ They should either be ported to use existentials directly (at which point we pot
 * compute/global-type-param-in-entrypoint.slang
 * compute/global-type-param.slang
 * compute/int-generic.slang
-* bugs/gh-6331.slang
 
 ### Static Specialization
 

--- a/tests/disabled-tests.txt
+++ b/tests/disabled-tests.txt
@@ -33,6 +33,7 @@ They should either be ported to use existentials directly (at which point we pot
 * compute/global-type-param-in-entrypoint.slang
 * compute/global-type-param.slang
 * compute/int-generic.slang
+* bugs/gh-6331.slang
 
 ### Static Specialization
 

--- a/tests/language-feature/extensions/generic-extension-3.slang
+++ b/tests/language-feature/extensions/generic-extension-3.slang
@@ -1,0 +1,42 @@
+// Test that multiple functions from different extensions are properly linked.
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj
+interface IValuable
+{
+	int getValue();
+};
+
+__generic <Int : __BuiltinIntegerType>
+extension Int : IValuable
+{
+	int getValue()
+	{
+		return 0;
+	}
+};
+
+__generic <Float : __BuiltinFloatingPointType>
+extension Float : IValuable
+{
+	int getValue()
+	{
+		return 1;
+	}
+};
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+	uint i = 0;
+	float f = float(i) / float(10);	
+
+	// CHECK: 0
+	outputBuffer[0] = i.getValue();
+
+	// CHECK: 1
+	outputBuffer[1] = f.getValue();
+}

--- a/tests/language-feature/extensions/generic-extension-4.slang
+++ b/tests/language-feature/extensions/generic-extension-4.slang
@@ -1,0 +1,58 @@
+// Test that multiple functions from different extensions are properly linked through their respective witness table.
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj
+interface IValuableImpl
+{
+	int getValue();
+}
+
+interface IValuable
+{
+	associatedtype Impl : IValuableImpl;
+	Impl getImpl();
+};
+
+__generic <Int : __BuiltinIntegerType>
+extension Int : IValuableImpl
+{
+	int getValue()
+	{
+		return 0;
+	}
+};
+
+__generic <Float : __BuiltinFloatingPointType>
+extension Float : IValuableImpl
+{
+	int getValue()
+	{
+		return 1;
+	}
+};
+
+__generic <ValuableImpl : IValuableImpl>
+extension ValuableImpl : IValuable
+{
+	typealias Impl = ValuableImpl;
+	ValuableImpl getImpl()
+	{
+		return this;
+	}
+};
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+	uint i = 0;
+	float f = float(i) / float(10);	
+
+	// CHECK: 0
+	outputBuffer[0] = i.getImpl().getValue();
+
+	// CHECK: 1
+	outputBuffer[1] = f.getImpl().getValue();
+}


### PR DESCRIPTION

I have had some problems recently with genereics lately, mostly generic extensions. 
I made simple shaders to expose the problem.

example1.slang
```
interface IValuable
{
	uint getValue();
};

__generic <Int : __BuiltinIntegerType>
extension Int : IValuable
{
	uint getValue()
	{
		return 0;
	}
};

__generic <Float : __BuiltinFloatingPointType>
extension Float : IValuable
{
	uint getValue()
	{
		return 1;
	}
};


RWByteAddressBuffer buffer;


[shader("compute")]
[numthreads(1, 1, 1)]
void main(uint3 gl_GlobalInvocationID : SV_DispatchThreadID)
{
	uint i = gl_GlobalInvocationID.x;
	float f = float(i) / float(10);	

	buffer.StoreAligned<uint>(i, i.getValue()); // (a)
	buffer.StoreAligned<uint>(i + 1000, f.getValue()); // (b)
}
```

When compiling this shader (I did it in SPIR-V and GLSL), there is no error, but the result is incorrect.
Lines (a) and (b) should get compiled to:
```
buffer.StoreAligned<uint>(i, 0); // (a)
buffer.StoreAligned<uint>(i + 1000, 1); // (b)
```
But instead, they are compiled to:
```
buffer.StoreAligned<uint>(i, 0); // (a)
buffer.StoreAligned<uint>(i + 1000, 0); // (b)
```
Moreover, If we swap line (b) and (a) (store the `float` before the `uint`), we get:
```
buffer.StoreAligned<uint>(i + 1000, 1); // (b)
buffer.StoreAligned<uint>(i, 1); // (a)
```
It looks like it keeps only the first implementation of `getValue()`. 

But if we wrote non generic extensions like:
```
extension uint : IValuable
{
	uint getValue()
	{
		return 0;
	}
};

extension float : IValuable
{
	uint getValue()
	{
		return 1;
	}
};
```
We get a correct result. So the issue appears to come from generic extensions.
I looked at the IR dumps to try to find the issue. 
In the LOWER-TO-IR dump, both `getValue()` implementations are present, but in the next dump (POST IR VALIDATION) only one of the two is present (the first one being called).
Importantly, both functions were decorated with the same export tag: `[export("_S5test3XGP0I5test39IValuable8getValuep0pu")]`, which appears to be the source of the issue. (When using non generic extensions, both funtions get a different export tag.)

example2.slang
```
interface IValuableImpl
{
	uint getValue();
}

interface IValuable
{
	IValuableImpl getImpl();
};

__generic <Int : __BuiltinIntegerType>
extension Int : IValuableImpl
{
	uint getValue()
	{
		return 0;
	}
};

__generic <Float : __BuiltinFloatingPointType>
extension Float : IValuableImpl
{
	uint getValue()
	{
		return 1;
	}
};

__generic <ValuableImpl : IValuableImpl>
extension ValuableImpl : IValuable
{
	ValuableImpl getImpl()
	{
		return this;
	}
};


RWByteAddressBuffer buffer;


[shader("compute")]
[numthreads(1, 1, 1)]
void main(uint3 gl_GlobalInvocationID : SV_DispatchThreadID)
{
	uint i = gl_GlobalInvocationID.x;
	float f = float(i) / float(10);	

	buffer.StoreAligned<uint>(i, i.getImpl().getValue());
	buffer.StoreAligned<uint>(i + 1000, f.getImpl().getValue());
}
```

The same problem arises with the second example, but this time it is less forward. 
This time, the problemn comes from the witness tables that are not exported properly. 
The witness table for `IValuableImpl` for both `__BuiltinIntegerType` and `__BuiltinFloatingPointType` get exported with: `[export("_SWGP05test413IValuableImpl")]`, and only one of the two remains during later stages of the compilation (the first one being called). 



Solution: 
I looked into the name mangler which generates these export names. 
Generic extensions don't appear to be properly handled by the mangler.
I removed some early returns in `emitQualifiedName(...)` that were preventing the emition of the generic declaration when existing.
Also when lowring an inheritance declaration (in `visitInheritanceDecl(...)`), I explicitely handled the case of a generic extension, so that the witness table gets a mangled name with the generic included.

For the first example, `__BuiltinIntegerType::getValue` is now decorated with `[export("_S5test3XGP0I5test39IValuableg2TCGP04core20__BuiltinIntegerType8getValuep0pu")]`, and `__BuiltinFloatingPointType::getValue` is now decorated with `[export("_S5test3XGP0I5test39IValuableg2TCGP04core26__BuiltinFloatingPointType8getValuep0pu")]`.

For the second example, the witness table of `IValuableImpl` for `__BuiltinIntegerType` is now decorated with `[export("_SW5test4XGP0I5test413IValuableImplg2TCGP04core20__BuiltinIntegerType5test413IValuableImpl")]`, and for `__BuiltinFloatingPointType`, it is now decorated with `[export("_SW5test4XGP0I5test413IValuableImplg2TCGP04core26__BuiltinFloatingPointType5test413IValuableImpl")]`.

(This is first time I look into Slang's implementation, so my solution might not be correct.)
