### PR TITLE
Improve embed tool to search all include directories as determined by CMake

### DIFF
--- a/prelude/CMakeLists.txt
+++ b/prelude/CMakeLists.txt
@@ -12,8 +12,8 @@ foreach(input ${prelude_headers})
     add_custom_command(
         OUTPUT ${output}
         COMMAND
-            slang-embed "${input}" "${CMAKE_CURRENT_LIST_DIR}/../include"
-            ${output}
+            slang-embed "${input}" ${output} "-I$<JOIN:$<TARGET_PROPERTY:core,INCLUDE_DIRECTORIES>, -I>"
+             
         DEPENDS ${input} slang-embed
         VERBATIM
     )

--- a/prelude/CMakeLists.txt
+++ b/prelude/CMakeLists.txt
@@ -12,8 +12,8 @@ foreach(input ${prelude_headers})
     add_custom_command(
         OUTPUT ${output}
         COMMAND
-            slang-embed "${input}" ${output} "-I$<JOIN:$<TARGET_PROPERTY:core,INCLUDE_DIRECTORIES>, -I>"
-             
+            slang-embed "${input}" ${output} 
+            "-I$<JOIN:$<TARGET_PROPERTY:core,INCLUDE_DIRECTORIES>, -I>" 
         DEPENDS ${input} slang-embed
         VERBATIM
     )

--- a/prelude/CMakeLists.txt
+++ b/prelude/CMakeLists.txt
@@ -12,8 +12,8 @@ foreach(input ${prelude_headers})
     add_custom_command(
         OUTPUT ${output}
         COMMAND
-            slang-embed "${input}" ${output} 
-            "-I$<JOIN:$<TARGET_PROPERTY:core,INCLUDE_DIRECTORIES>, -I>" 
+            slang-embed "${input}" ${output}
+            "-I$<JOIN:$<TARGET_PROPERTY:core,INCLUDE_DIRECTORIES>, -I>"
         DEPENDS ${input} slang-embed
         VERBATIM
     )

--- a/tools/slang-embed/slang-embed.cpp
+++ b/tools/slang-embed/slang-embed.cpp
@@ -127,28 +127,19 @@ struct App
                     {
                         // Create a null-terminated copy
                         size_t dirLen = dirEnd - dirStart;
-                        char* tempDir = (char*)malloc(dirLen + 1);
-                        strncpy(tempDir, dirStart, dirLen);
-                        tempDir[dirLen] = '\0';
+                        Slang::String tempDir(Slang::UnownedStringSlice(dirStart, dirLen));
 
                         // Remove any quotes
-                        char* dir = tempDir;
-                        if (*dir == '"')
-                            dir++;
-                        if (dir[strlen(dir) - 1] == '"')
-                            dir[strlen(dir) - 1] = '\0';
+                        if (tempDir[0] == '"')
+                            tempDir = tempDir.subString(1, tempDir.getLength() - 1);
+                        if (tempDir.endsWith("\"") && tempDir.getLength() > 0)
+                            tempDir = tempDir.subString(0, tempDir.getLength() - 1);
 
                         // Remove trailing whitespace
-                        size_t len = strlen(dir);
-                        while (len > 0 && isspace((unsigned char)dir[len - 1]))
-                        {
-                            dir[len - 1] = '\0';
-                            len--;
-                        }
+                        tempDir = tempDir.trimEnd();
 
                         // Add to include dirs
-                        includeDirs.add(Slang::String(dir));
-                        free(tempDir);
+                        includeDirs.add(tempDir);
                     }
 
                     // Move to next position (if any)


### PR DESCRIPTION
Fixes: #6674 

This change makes it so that we emit the full set of include directories from CMake as a command line argument to slang-embed. 

Hopefully this puts an end to prelude generation issues, and makes it so that we don't have to do elaborate workarounds to our include paths to keep `slang-embed` happy.