### PR TITLE
Fix mul operator followed by global scope

### DIFF
--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -7738,7 +7738,6 @@ static Expr* parsePostfixExpr(Parser* parser)
                 case TokenType::LBracket:
                 case TokenType::OpMul:
                 case TokenType::Dot:
-                case TokenType::Scope:
                     expr = parsePostfixTypeSuffix(parser, expr);
                     break;
                 default:

--- a/tests/language-feature/namespaces/simple-namespace.slang
+++ b/tests/language-feature/namespaces/simple-namespace.slang
@@ -3,9 +3,11 @@
 //TEST(compute):COMPARE_COMPUTE: -shaderobj
 
 // Test that simple `namespace` declarations work as expected
+// Test that the global scope operator `::` works as expected
 
 namespace A
 {
+    static int num = 16;
     struct X
     {
         int val;
@@ -47,7 +49,10 @@ namespace A
 int test(int val)
 {
     A.X a = A::makeX(val);
-    B::X b = B.makeX(val*16, val*256);
+    // Use the global scope operator "::A::num" to access the static member of namespace A
+    // Test it with mul operator
+    int num = 16*::A::num;
+    B::X b = B.makeX(val*16, val*num);
 
     return a.getVal() + b.getHead() + b.getTail();
 }


### PR DESCRIPTION
This should fix expr like `2.0f * ::a::b::c`

But it will no longer parse something like
```
extension<T> Ptr<T> { static void foo(); }
int*::foo() // won't work, but this is a less common case
```

Fixes #6684