### PR TITLE
Fix SPV_KHR_maximal_reconvergence extension name spelling

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -4650,7 +4650,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             }
             break;
         case kIROp_MaximallyReconvergesDecoration:
-            ensureExtensionDeclaration(UnownedStringSlice("SPV_khr_maximal_reconvergence"));
+            ensureExtensionDeclaration(UnownedStringSlice("SPV_KHR_maximal_reconvergence"));
             requireSPIRVExecutionMode(nullptr, dstID, SpvExecutionModeMaximallyReconvergesKHR);
             break;
         case kIROp_QuadDerivativesDecoration:

--- a/tests/hlsl-intrinsic/quad-control/quad-control-frag-many-entry-points.slang
+++ b/tests/hlsl-intrinsic/quad-control/quad-control-frag-many-entry-points.slang
@@ -27,6 +27,7 @@ float4 getFragColor(float2 uv) {
     return fragColor;
 }
 
+// CHECK_SPIRV: OpExtension "SPV_KHR_maximal_reconvergence"
 // CHECK_SPIRV: OpExecutionMode %fragmentMain1 MaximallyReconvergesKHR
 // CHECK_SPIRV: OpExecutionMode %fragmentMain1 QuadDerivativesKHR
 // CHECK_GLSL: layout(quad_derivatives) in
@@ -49,7 +50,6 @@ float4 fragmentMain1(FragmentInput input) : SV_Target
 }
 
 // CHECK_SPIRV-NOT: OpExecutionMode %fragmentMain2 QuadDerivativesKHR
-// CHECK_SPIRV: OpExtension "SPV_KHR_maximal_reconvergence"
 // CHECK_SPIRV: OpExecutionMode %fragmentMain2 MaximallyReconvergesKHR
 // CHECK_GLSL-NOT: layout(quad_derivatives) in
 // CHECK_GLSL: [maximally_reconverges]

--- a/tests/hlsl-intrinsic/quad-control/quad-control-frag-many-entry-points.slang
+++ b/tests/hlsl-intrinsic/quad-control/quad-control-frag-many-entry-points.slang
@@ -49,6 +49,7 @@ float4 fragmentMain1(FragmentInput input) : SV_Target
 }
 
 // CHECK_SPIRV-NOT: OpExecutionMode %fragmentMain2 QuadDerivativesKHR
+// CHECK_SPIRV: OpExtension "SPV_KHR_maximal_reconvergence"
 // CHECK_SPIRV: OpExecutionMode %fragmentMain2 MaximallyReconvergesKHR
 // CHECK_GLSL-NOT: layout(quad_derivatives) in
 // CHECK_GLSL: [maximally_reconverges]


### PR DESCRIPTION
Vulkan validation layers emit warnings on lowercase khr.