### PR TITLE
findAndValidateEntryPoint should return null on failing

### DIFF
--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -691,6 +691,12 @@ RefPtr<EntryPoint> findAndValidateEntryPoint(FrontEndEntryPointRequest* entryPoi
     //
     validateEntryPoint(entryPoint, sink);
 
+    // We should return nullptr if entry point fails to validate
+    if (sink->getErrorCount())
+    {
+        return nullptr;
+    }
+
     return entryPoint;
 }
 


### PR DESCRIPTION
close #6694

We should return nullptr when findAndValidateEntryPoint fails to valid the entrypoint.