### PR TITLE
Fix compilation of global builtin variables inside generics

### DIFF
--- a/source/slang/slang-ir-call-graph.cpp
+++ b/source/slang/slang-ir-call-graph.cpp
@@ -88,6 +88,7 @@ void buildEntryPointReferenceGraph(
             case kIROp_GlobalParam:
             case kIROp_GlobalVar:
             case kIROp_SPIRVAsmOperandBuiltinVar:
+            case kIROp_Generic:
                 addToWorkList({entryPoint, operand});
                 break;
             }

--- a/tests/glsl/builtin-inside-generics.slang
+++ b/tests/glsl/builtin-inside-generics.slang
@@ -1,0 +1,41 @@
+//TEST:SIMPLE(filecheck=CHECK_SPIRV): -entry main -stage compute -target spirv -allow-glsl
+//TEST:SIMPLE(filecheck=CHECK_GLSL): -entry main -stage compute -target glsl -allow-glsl
+//TEST:SIMPLE(filecheck=CHECK_HLSL): -entry main -stage compute -target hlsl -allow-glsl
+//TEST:SIMPLE(filecheck=CHECK_METAL): -entry main -stage compute -target metal -allow-glsl
+//TEST:SIMPLE(filecheck=CHECK_WGSL): -entry main -stage compute -target wgsl -allow-glsl
+
+RWStructuredBuffer<uint> outputBuffer;
+
+T getGlobalInvocationID<T: IInteger>(T value)
+{
+    return T(gl_GlobalInvocationID.x) + value;
+}
+
+T getWaveLaneIndex<T: IInteger>(T value)
+{
+    return T(WaveGetLaneIndex()) + value;
+}
+
+// CHECK_SPIRV: GlobalInvocationId
+// CHECK_SPIRV: SubgroupLocalInvocationId
+
+// CHECK_GLSL: gl_GlobalInvocationID
+// CHECK_GLSL: gl_SubgroupInvocationID
+
+// CHECK_HLSL: WaveGetLaneIndex()
+// CHECK_HLSL: SV_DispatchThreadID
+
+// CHECK_METAL: thread_position_in_grid
+// CHECK_METAL: thread_index_in_simdgroup
+
+// CHECK_WGSL: global_invocation_id
+// CHECK_WGSL: subgroup_invocation_id
+
+[shader("compute")]
+void main()
+{
+    outputBuffer[0U] = getGlobalInvocationID(0U);
+    outputBuffer[1U] = getWaveLaneIndex(0U);
+}
+
+


### PR DESCRIPTION
Closes #6501.

Global builtin variables inside generic functions currently fail to compile properly - they are not added as entry point parameter list for targets that require it (HLSL, Metal and WGSL).

The logic that handles adding global builtin variables to the entry point parameter list  is done inside `translateGlobalVaryingVar`.  A call graph is constructed to obtain the referencing entry points for each global variable. This constructed call graph however does not include generic functions, hence builtin global variables inside generics  return no referenced entry points inside `translateGlobalVaryingVar` and are not added to entry point parameter list. The fix here is to include generics when constructing the call graph, inside `buildEntryPointReferenceGraph`.