### PR TITLE
Report an error if a module imports itself

### DIFF
--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -1927,6 +1927,8 @@ DIAGNOSTIC(
     vectorWithDisallowedElementTypeEncountered,
     "vector with disallowed element type '$0' encountered")
 
+DIAGNOSTIC(38204, Warning, moduleSelfImport, "module '$0' imported more than once")
+
 // 39xxx - Type layout and parameter binding.
 
 DIAGNOSTIC(

--- a/tests/diagnostics/self-import-extra.slang
+++ b/tests/diagnostics/self-import-extra.slang
@@ -1,0 +1,8 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): tests/diagnostics/self-import.slang -stage compute
+
+// This test compiles two Slang shaders via the command line, where the second
+// shader imports this one. This should produce a warning.
+
+interface I { }
+
+// CHECK: warning 38204: module 'self-import-extra' imported more than once

--- a/tests/diagnostics/self-import.slang
+++ b/tests/diagnostics/self-import.slang
@@ -1,0 +1,15 @@
+//TEST_IGNORE_FILE:
+
+// A file that imports a module which spans two files, including itself.
+// This file is intended to be compiled as part of the self-import-extra
+// test and does nothing by itself.
+
+import "self-import-extra";
+
+struct S { }
+
+extension S : I { }
+
+void main()
+{
+}


### PR DESCRIPTION
Fixes issue #5660

Undefined behavior was reported when files in a given module attempted to import that module. Now when a module imports itself we report error 38200 for a recursive import.