### PR TITLE
Use coopvec supporting dxcompiler.dll and dxil.dll

### DIFF
--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-ahit.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-ahit.slang
@@ -47,15 +47,13 @@
 // DXIL: call i32 @dx.op.instanceID.i32
 // DXIL: call i32 @dx.op.geometryIndex.i32
 // DXIL: call i32 @dx.op.primitiveIndex.i32
+
 // DXIL: call float @dx.op.objectRayOrigin.f32
 // DXIL: call float @dx.op.objectRayDirection.f32
 // DXIL: call float @dx.op.objectToWorld.f32
 // DXIL: call float @dx.op.worldToObject.f32
 // DXIL: call i32 @dx.op.hitKind.i32
 
-// DXIL: call float @dx.op.objectRayOrigin.f32
-// DXIL: call float @dx.op.objectRayDirection.f32
-// DXIL: call float @dx.op.rayTCurrent.f32
 // DXIL: call void @dx.op.acceptHitAndEndSearch
 // DXIL: call void @dx.op.ignoreHit
 

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-int.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-int.slang
@@ -32,11 +32,12 @@
 
 // DXIL: main
 
+// DXIL: call float @dx.op.worldRayOrigin.f32
+// DXIL: call float @dx.op.worldRayDirection.f32
+
 // DXIL: call i32 @dx.op.dispatchRaysIndex.i32
 // DXIL: call i32 @dx.op.dispatchRaysDimensions.i32
 
-// DXIL: call float @dx.op.worldRayOrigin.f32
-// DXIL: call float @dx.op.worldRayDirection.f32
 // DXIL: call float @dx.op.rayTMin.f32
 // DXIL: call float @dx.op.rayTCurrent.f32
 // DXIL: call i32 @dx.op.rayFlags.i32
@@ -50,8 +51,6 @@
 // DXIL: call float @dx.op.objectToWorld.f32
 // DXIL: call float @dx.op.worldToObject.f32
 
-// DXIL: call float @dx.op.rayTMin.f32
-// DXIL: call float @dx.op.rayTCurrent.f32
 // DXIL: call i1 @dx.op.reportHit.struct.MyAttributes_0
 
 float CheckRayDispatchValues() // all

--- a/tests/metal/texture.slang
+++ b/tests/metal/texture.slang
@@ -741,7 +741,7 @@ bool TEST_texture<T>(
     return result;
 }
 
-[numthreads(1, 1, 1)]
+[numthreads(2, 2, 1)]
 void computeMain()
 {
     // SPIR: OpEntryPoint


### PR DESCRIPTION
Closes #4919
Related to #6250 

This commit upgrades DXC version from 1.7 to 1.9 that supports CoopVector.

The DXC is compiled from a [public repo](https://github.com/NVIDIA-RTX/DirectXShaderCompiler/tree/CooperativeVector), and it uses `MinSizeRel` build config.

The version information from a command "dxc.exe --help":

Version: dxcompiler.dll: 1.9 - 1.8.0.4817 (CooperativeVector, 018d767f9); dxil.dll: 1.9(1.8.0.4817)