### PR TITLE
Metal remove void field

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -1278,6 +1278,15 @@ Result linkAndOptimizeIR(
         //
         legalizeResourceTypes(targetProgram, irModule, sink);
 
+        // We also need to legalize empty types for Metal targets.
+        switch (target)
+        {
+        case CodeGenTarget::Metal:
+        case CodeGenTarget::MetalLib:
+        case CodeGenTarget::MetalLibAssembly:
+            legalizeEmptyTypes(targetProgram, irModule, sink);
+            break;
+        }
         //  Debugging output of legalization
 #if 0
         dumpIRIfEnabled(codeGenContext, irModule, "LEGALIZED");

--- a/source/slang/slang-ir-cleanup-void.cpp
+++ b/source/slang/slang-ir-cleanup-void.cpp
@@ -122,6 +122,8 @@ struct CleanUpVoidContext
         case kIROp_StructType:
             {
                 List<IRInst*> toRemove;
+                UInt fieldIndex = 0;
+                ShortList<UInt> voidFieldIndex;
                 for (auto child : inst->getChildren())
                 {
                     if (auto field = as<IRStructField>(child))
@@ -129,11 +131,29 @@ struct CleanUpVoidContext
                         if (field->getFieldType()->getOp() == kIROp_VoidType)
                         {
                             toRemove.add(field);
+                            voidFieldIndex.add(fieldIndex);
                         }
                     }
+                    fieldIndex++;
                 }
                 for (auto ii : toRemove)
                     ii->removeAndDeallocate();
+
+                // Once we remove the void fields in the struct, we also need update the make_struct
+                // call sites to remove the arguments corresponding to the void fields.
+                if (inst->hasUses() && voidFieldIndex.getCount())
+                {
+                    for (auto use = inst->firstUse; use; use = use->nextUse)
+                    {
+                        if (auto makeStructInst = as<IRMakeStruct>(use->user))
+                        {
+                            for (Int i = 0; i < voidFieldIndex.getCount(); i++)
+                            {
+                                makeStructInst->removeOperand(voidFieldIndex[i]);
+                            }
+                        }
+                    }
+                }
             }
             break;
         default:

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -4123,6 +4123,11 @@ struct IREmptyTypeLegalizationContext : IRTypeLegalizationContext
 
     bool isSimpleType(IRType* type) override
     {
+        if (isMetalTarget(targetProgram->getTargetReq()))
+        {
+            return false;
+        }
+
         // If type is used as public interface, then treat it as simple.
         for (auto decor : type->getDecorations())
         {
@@ -4144,6 +4149,11 @@ struct IREmptyTypeLegalizationContext : IRTypeLegalizationContext
     LegalType createLegalUniformBufferType(IROp, LegalType, IRInst*) override
     {
         return LegalType();
+    }
+
+    virtual bool shouldLegalizeParameterBlockElementType() override
+    {
+        return isMetalTarget(targetProgram->getTargetReq());
     }
 };
 

--- a/source/slang/slang-legalize-types.cpp
+++ b/source/slang/slang-legalize-types.cpp
@@ -1211,11 +1211,15 @@ LegalType legalizeTypeImpl(TypeLegalizationContext* context, IRType* type)
         LegalType legalElementType;
 
         if (isMetalTarget(context->targetProgram->getTargetReq()) &&
-            as<IRParameterBlockType>(uniformBufferType))
+            as<IRParameterBlockType>(uniformBufferType) &&
+            !context->shouldLegalizeParameterBlockElementType())
         {
             // On Metal, we do not need to legalize the element type of
             // a parameter block because we can translate it directly into
             // an argument buffer.
+            //
+            // But we do need empty type legalized for Metal, because Metal doesn't
+            // allow empty struct in argument buffer.
             legalElementType = LegalType::simple(originalElementType);
         }
         else

--- a/source/slang/slang-legalize-types.h
+++ b/source/slang/slang-legalize-types.h
@@ -660,6 +660,10 @@ struct IRTypeLegalizationContext
         LegalType legalElementType,
         IRInst* layoutOperand) = 0;
 
+    /// Customization point to decide whether a parameter block type should be legalized.
+    ///
+    /// This function is called in `legalizeTypeImpl` to decide whether a parameter block
+    /// type should be legalized. Not all legalization passes need to legalize parameter block.
     virtual bool shouldLegalizeParameterBlockElementType() { return false; }
 };
 

--- a/source/slang/slang-legalize-types.h
+++ b/source/slang/slang-legalize-types.h
@@ -659,6 +659,8 @@ struct IRTypeLegalizationContext
         IROp op,
         LegalType legalElementType,
         IRInst* layoutOperand) = 0;
+
+    virtual bool shouldLegalizeParameterBlockElementType() { return false; }
 };
 
 // This typedef exists to support pre-existing code from when

--- a/tests/metal/empty-struct-remove.slang
+++ b/tests/metal/empty-struct-remove.slang
@@ -1,6 +1,6 @@
 
-//TEST:SIMPLE(filecheck=LIB):-target metallib -entry computeMain -stage compute -DMETAL
-//TEST:SIMPLE(filecheck=METAL):-target metal -entry computeMain -stage compute -DMETAL
+//TEST:SIMPLE(filecheck=LIB):-target metallib -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=METAL):-target metal -entry computeMain -stage compute
 
 // METAL-NOT: struct emptyStruct
 struct emptyStruct

--- a/tests/metal/empty-struct-remove.slang
+++ b/tests/metal/empty-struct-remove.slang
@@ -1,0 +1,33 @@
+
+//TEST:SIMPLE(filecheck=LIB):-target metallib -entry computeMain -stage compute -DMETAL
+//TEST:SIMPLE(filecheck=METAL):-target metal -entry computeMain -stage compute -DMETAL
+
+// METAL-NOT: struct emptyStruct
+struct emptyStruct
+{
+    void set(RWStructuredBuffer<int> buffer, int value) {buffer[0] = value;}
+}
+
+
+struct MyStruct
+{
+    RWStructuredBuffer<int> buffer;
+    int value;
+    void set()
+    {
+        e.set(buffer, value);
+    }
+    emptyStruct e;
+}
+
+ParameterBlock<MyStruct> param;
+
+// LIB: @computeMain
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(
+    uint tid: SV_DispatchThreadID,
+)
+{
+    param.set();
+}


### PR DESCRIPTION
Remove argument in make_struct call corresponding to void field

    
- This is a follow-up of #6543, where we leave the VoidType field as it in
  make_struct call during legalization pass.
    
  So during cleaning_void IR pass, when we remove "VoidType" from struct,
  we will have to also clean up the argument corresponding to the
  "VoidType" field.

- Reapply "Eliminate empty struct on metal target (#6603)" which is reverted in (#6711)
  Because #6603 is not the root casuse. #6543 is.