### PR TITLE
Do no fail on missing no_diff annotation on non-differentiable function outputs

### DIFF
--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -147,6 +147,20 @@ bool isNoDiffType(IRType* paramType)
     return false;
 }
 
+// Return true if the result type and all the parameter types are no_diff
+bool isNeverDiffFuncType(IRFuncType* const funcType)
+{
+    const auto resultType = funcType->getResultType();
+    if (!isNoDiffType(resultType))
+        return false;
+    for (const auto p : funcType->getParamTypes())
+    {
+        if (!isNoDiffType(p))
+            return false;
+    }
+    return true;
+}
+
 IRInst* lookupForwardDerivativeReference(IRInst* primalFunction)
 {
     if (auto jvpDefinition = primalFunction->findDecoration<IRForwardDerivativeDecoration>())

--- a/source/slang/slang-ir-autodiff.h
+++ b/source/slang/slang-ir-autodiff.h
@@ -563,6 +563,7 @@ void stripAutoDiffDecorations(IRModule* module);
 void stripTempDecorations(IRInst* inst);
 
 bool isNoDiffType(IRType* paramType);
+bool isNeverDiffFuncType(IRFuncType* funcType);
 
 IRInst* lookupForwardDerivativeReference(IRInst* primalFunction);
 

--- a/tests/bugs/gh-6632.slang
+++ b/tests/bugs/gh-6632.slang
@@ -1,0 +1,29 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu
+
+// CHECK: 40000000
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
+
+// Non-differentiable function with no_diff parameters and return type
+no_diff float targetFunc(no_diff float x)
+{
+    return x * 2.0f;
+}
+
+[Differentiable]
+float errorForward(no_diff float x)
+{
+    float result = targetFunc(x);
+    return result;
+}
+
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    float input = 1.0f;
+
+    outputBuffer[0] = errorForward(input);
+}
+


### PR DESCRIPTION

Closes https://github.com/shader-slang/slang/issues/6632