### PR TITLE
void field rework

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -1716,6 +1716,8 @@ Result linkAndOptimizeIR(
     //
     eliminateDeadCode(irModule, deadCodeEliminationOptions);
 
+    cleanUpVoidType(irModule);
+
     if (isKhronosTarget(targetRequest))
     {
         // As a fallback, if the above specialization steps failed to remove resource type
@@ -1728,7 +1730,6 @@ Result linkAndOptimizeIR(
 #endif
     validateIRModuleIfEnabled(codeGenContext, irModule);
 
-    cleanUpVoidType(irModule);
 
     // Lower the `getRegisterIndex` and `getRegisterSpace` intrinsics.
     //

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -1962,6 +1962,8 @@ static LegalVal coerceToLegalType(IRTypeLegalizationContext* context, LegalType 
             ShortList<IRInst*> fields;
             for (auto field : structType->getFields())
             {
+                if (as<IRVoidType>(field->getFieldType()))
+                    continue;
                 auto fieldVal = coerceToLegalType(
                     context,
                     LegalType::simple(field->getFieldType()),

--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -402,6 +402,12 @@ struct PeepholeContext : InstPassBase
                     Index i = 0;
                     for (auto sfield : structType->getFields())
                     {
+                        // skip the void field
+                        if (as<IRVoidType>(sfield->getFieldType()))
+                        {
+                            continue;
+                        }
+
                         if (sfield->getKey() == field)
                         {
                             fieldIndex = i;


### PR DESCRIPTION
This change is a rework on previous PR #6725.

The background of this issue is that we have inconsistent IR instructions cross our code base for make_struct and get_field regarding the `void` field.

Think about the struct:
```
struct
{
void a;
int b;
}
```
this is generated during the resource type legalization pass which will finally be eliminated. However, during IR passes we still need to access such intermediate struct.

So if we call `make_struct(a, b)`, we will have to call `get_field(0)` for a and `get_field(1)` for b, while if we call `make_struct(b)`, we will need to call `get_field(0)` for b.

Both ways are the correct fix, we just need to see which way take us less effort.

Previously in #6725, we choose the 1st way that when constructing construct, we just keep the `void` field in `make_struct` call. However, this causes lots more trouble because we could dynamically emit new `get_field` instruct during legalization, and we will have to do all the cleanup in the same pass and later pass to remove that `void`.

This change change to the 2nd way. where we keep original method to always skip the `void` field, and we just need to calculate the correct index for the field in very few locations.
