### PR TITLE
Get real value for typeAdapter

### DIFF
--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -3541,6 +3541,13 @@ void legalizeEntryPointParameterForGLSL(
                         if (elem.key == key)
                         {
                             realGlobalVar = elem.val.irValue;
+                            if (!realGlobalVar &&
+                                ScalarizedVal::Flavor::typeAdapter == elem.val.flavor)
+                            {
+                                auto typeAdapterVal =
+                                    as<ScalarizedTypeAdapterValImpl>(elem.val.impl);
+                                realGlobalVar = typeAdapterVal->val.irValue;
+                            }
                             break;
                         }
                     }


### PR DESCRIPTION
When the type is mismatch and typeAdapter is used, 
get the real value from typeAdapter so that we don't get nullptr for irValue.

This fixes the assert if uint is used for SV_VertexID, which is an int in the system binding semantic.

Fixes: #6525