### PR TITLE
Add SV_PointCoord to match gl_PointCoord

### DIFF
--- a/docs/user-guide/a2-01-spirv-target-specific.md
+++ b/docs/user-guide/a2-01-spirv-target-specific.md
@@ -62,6 +62,7 @@ The system-value semantics are translated to the following SPIR-V code.
 | `SV_IsFrontFace`              | `BuiltIn FrontFacing`             |
 | `SV_OutputControlPointID`     | `BuiltIn InvocationId`            |
 | `SV_PointSize`<sup>*</sup>    | `BuiltIn PointSize`               |
+| `SV_PointCoord`<sup>*</sup>   | `BuiltIn PointCoord`              |
 | `SV_Position`                 | `BuiltIn Position/FragCoord`      |
 | `SV_PrimitiveID`              | `BuiltIn PrimitiveId`             |
 | `SV_RenderTargetArrayIndex`   | `BuiltIn Layer`                   |
@@ -76,7 +77,7 @@ The system-value semantics are translated to the following SPIR-V code.
 | `SV_ViewID`                   | `BuiltIn ViewIndex`               |
 | `SV_ViewportArrayIndex`       | `BuiltIn ViewportIndex`           |
 
-*Note* that `SV_DrawIndex` and `SV_PointSize` are Slang-specific semantics that are not defined in HLSL.
+*Note* that `SV_DrawIndex`, `SV_PointSize` and `SV_PointCoord` are Slang-specific semantics that are not defined in HLSL.
 
 
 Behavior of `discard` after SPIR-V 1.6

--- a/docs/user-guide/a2-02-metal-target-specific.md
+++ b/docs/user-guide/a2-02-metal-target-specific.md
@@ -34,6 +34,8 @@ The system-value semantics are translated to the following Metal attributes:
 | `SV_GroupIndex`             | Calculated from `SV_GroupThreadID` and group extents |
 | `SV_InstanceID`             | `[[instance_id]]`                                    |
 | `SV_IsFrontFace`            | `[[front_facing]]`                                   |
+| `SV_PointSize`              | `[[point_size]]`                                     |
+| `SV_PointCoord`             | `[[point_coord]]`                                    |
 | `SV_PrimitiveID`            | `[[primitive_id]]`                                   |
 | `SV_RenderTargetArrayIndex` | `[[render_target_array_index]]`                      |
 | `SV_SampleIndex`            | `[[sample_id]]`                                      |

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -96,21 +96,7 @@ public typealias dmat4x4 = matrix<double, 4, 4>;
 
 public out float4 gl_Position : SV_Position;
 public out float gl_PointSize : SV_PointSize;
-public property float2 gl_PointCoord {
-    [require(glsl_spirv, fragment)]
-    get
-    {
-        __target_switch
-        {
-        case glsl:
-            __intrinsic_asm "(gl_PointCoord)";
-        case spirv:
-            return spirv_asm {
-                result:$$float2 = OpLoad builtin(PointCoord:float2);
-            };
-        }
-    }
-}
+public in float2 gl_PointCoord : SV_PointCoord;
 
 public in vec4 gl_FragCoord : SV_Position;
 public out float gl_FragDepth : SV_Depth;

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -96,6 +96,22 @@ public typealias dmat4x4 = matrix<double, 4, 4>;
 
 public out float4 gl_Position : SV_Position;
 public out float gl_PointSize : SV_PointSize;
+public property float2 gl_PointCoord {
+    [require(glsl_spirv, fragment)]
+    get
+    {
+        __target_switch
+        {
+        case glsl:
+            __intrinsic_asm "(gl_PointCoord)";
+        case spirv:
+            return spirv_asm {
+                result:$$float2 = OpLoad builtin(PointCoord:float2);
+            };
+        }
+    }
+}
+
 public in vec4 gl_FragCoord : SV_Position;
 public out float gl_FragDepth : SV_Depth;
 public out int gl_FragStencilRef : SV_StencilRef;

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -5438,6 +5438,10 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     // float in hlsl & glsl
                     return getBuiltinGlobalVar(inst->getFullType(), SpvBuiltInPointSize, inst);
                 }
+                else if (semanticName == "sv_pointcoord")
+                {
+                    return getBuiltinGlobalVar(inst->getFullType(), SpvBuiltInPointCoord, inst);
+                }
                 else if (semanticName == "sv_drawindex")
                 {
                     requireSPIRVCapability(SpvCapabilityDrawParameters);

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -651,6 +651,13 @@ GLSLSystemValueInfo* getGLSLSystemValueInfo(
         name = "gl_PointSize";
         requiredType = builder->getBasicType(BaseType::Float);
     }
+    else if (semanticName == "sv_pointcoord")
+    {
+        name = "gl_PointCoord";
+        requiredType = builder->getVectorType(
+            builder->getBasicType(BaseType::Float),
+            builder->getIntValue(builder->getIntType(), 2));
+    }
     else if (semanticName == "sv_drawindex")
     {
         name = "gl_DrawID";

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -3154,6 +3154,14 @@ protected:
                 result.permittedTypes.add(builder.getBasicType(BaseType::Float));
                 break;
             }
+        case SystemValueSemanticName::PointCoord:
+            {
+                result.systemValueName = toSlice("point_coord");
+                result.permittedTypes.add(builder.getVectorType(
+                    builder.getBasicType(BaseType::Float),
+                    builder.getIntValue(builder.getIntType(), 2)));
+                break;
+            }
         case SystemValueSemanticName::PrimitiveID:
             {
                 result.systemValueName = toSlice("primitive_id");
@@ -3804,6 +3812,7 @@ protected:
 
         case SystemValueSemanticName::OutputControlPointID:
         case SystemValueSemanticName::PointSize:
+        case SystemValueSemanticName::PointCoord:
             {
                 result.isUnsupported = true;
             }

--- a/source/slang/slang-ir-legalize-varying-params.h
+++ b/source/slang/slang-ir-legalize-varying-params.h
@@ -56,6 +56,7 @@ void depointerizeInputParams(IRFunc* entryPoint);
     M(IsFrontFace, SV_IsFrontFace)                       \
     M(OutputControlPointID, SV_OutputControlPointID)     \
     M(PointSize, SV_PointSize)                           \
+    M(PointCoord, SV_PointCoord)                         \
     M(PrimitiveID, SV_PrimitiveID)                       \
     M(DrawIndex, SV_DrawIndex)                           \
     M(RenderTargetArrayIndex, SV_RenderTargetArrayIndex) \

--- a/source/slang/slang-language-server-completion.cpp
+++ b/source/slang/slang-language-server-completion.cpp
@@ -115,6 +115,7 @@ static const char* hlslSemanticNames[] = {
     "SV_OutputControlPointID",
     "SV_Position",
     "SV_PointSize",
+    "SV_PointCoord",
     "SV_PrimitiveID",
     "SV_DrawIndex",
     "SV_RenderTargetArrayIndex",

--- a/tests/glsl-intrinsic/point-coord.slang
+++ b/tests/glsl-intrinsic/point-coord.slang
@@ -1,5 +1,6 @@
 //TEST:SIMPLE(filecheck=CHECK_SPIRV): -entry main -stage fragment -target spirv
 //TEST:SIMPLE(filecheck=CHECK_GLSL): -entry main -stage fragment -target glsl
+//TEST:SIMPLE(filecheck=CHECK_METAL): -entry main -stage fragment -target metal
 
 #version 460
 
@@ -11,5 +12,6 @@ void main()
 
     // CHECK_SPIRV: BuiltIn PointCoord
     // CHECK_GLSL: gl_PointCoord
+    // CHECK_METAL: point_coord
 }
 

--- a/tests/glsl-intrinsic/point-coord.slang
+++ b/tests/glsl-intrinsic/point-coord.slang
@@ -1,0 +1,15 @@
+//TEST:SIMPLE(filecheck=CHECK_SPIRV): -entry main -stage fragment -target spirv
+//TEST:SIMPLE(filecheck=CHECK_GLSL): -entry main -stage fragment -target glsl
+
+#version 460
+
+out vec4 fragColor;
+
+void main()
+{
+    fragColor = vec4(gl_PointCoord.xy, 0, 0);
+
+    // CHECK_SPIRV: BuiltIn PointCoord
+    // CHECK_GLSL: gl_PointCoord
+}
+


### PR DESCRIPTION
Adds support for [`gl_PointCoord`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/gl_PointCoord.xhtml) in the GLSL compatibility mode and a simple test for it.

It'd probably be nice to have this functionality available even without the GLSL compatibility mode, but that requires some kind of API decisions since HLSL doesn't have any equivalent value, and it would only work with the GLSL and SPIRV targets.