### PR TITLE
Add `vk::offset` to specify member offsets for push constants

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -3710,6 +3710,10 @@ attribute_syntax [vk_location(location : int)] : GLSLLocationAttribute;
 __attributeTarget(VarDeclBase)
 attribute_syntax [vk_index(index : int)] : GLSLIndexAttribute;
 
+/// Declare struct member offset.
+__attributeTarget(DeclBase)
+attribute_syntax [vk_offset(index: int)] : GLSLStructOffsetAttribute;
+
 /// @deprecated
 /// Use `spirv_asm` instead for inline SPIR-V assembly.
 __attributeTarget(FuncDecl)

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -3710,8 +3710,8 @@ attribute_syntax [vk_location(location : int)] : GLSLLocationAttribute;
 __attributeTarget(VarDeclBase)
 attribute_syntax [vk_index(index : int)] : GLSLIndexAttribute;
 
-/// Declare struct member offset.
-__attributeTarget(DeclBase)
+/// Declare offset for a struct member. Only applies to Vulkan and GLSL targets.
+__attributeTarget(VarDeclBase)
 attribute_syntax [vk_offset(index: int)] : GLSLStructOffsetAttribute;
 
 /// @deprecated

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -3715,7 +3715,7 @@ attribute_syntax [vk_index(index : int)] : GLSLIndexAttribute;
 /// when targeting GLSL, as GLSL does not support the `offset` qualifier on regular structs.
 /// This attribute has no effect on other targets.
 __attributeTarget(VarDeclBase)
-attribute_syntax [vk_offset(index: int)] : GLSLStructOffsetAttribute;
+attribute_syntax [vk_offset(index: int)] : VkStructOffsetAttribute;
 
 /// @deprecated
 /// Use `spirv_asm` instead for inline SPIR-V assembly.

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -3710,7 +3710,10 @@ attribute_syntax [vk_location(location : int)] : GLSLLocationAttribute;
 __attributeTarget(VarDeclBase)
 attribute_syntax [vk_index(index : int)] : GLSLIndexAttribute;
 
-/// Declare offset for a struct member. Only applies to Vulkan and GLSL targets.
+/// Declare offset for a struct field. Applies to all kinds of structs when targetting Vulkan.
+/// Applies only to structs that are directly used as interface blocks (such as push constants and uniforms)
+/// when targetting GLSL, as GLSL does not support the `offset` qualifier on regular structs.
+/// This attribute has no effect on other targets.
 __attributeTarget(VarDeclBase)
 attribute_syntax [vk_offset(index: int)] : GLSLStructOffsetAttribute;
 

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -3710,9 +3710,9 @@ attribute_syntax [vk_location(location : int)] : GLSLLocationAttribute;
 __attributeTarget(VarDeclBase)
 attribute_syntax [vk_index(index : int)] : GLSLIndexAttribute;
 
-/// Declare offset for a struct field. Applies to all kinds of structs when targetting Vulkan.
+/// Declare offset for a struct field. Applies to all kinds of structs when targeting Vulkan.
 /// Applies only to structs that are directly used as interface blocks (such as push constants and uniforms)
-/// when targetting GLSL, as GLSL does not support the `offset` qualifier on regular structs.
+/// when targeting GLSL, as GLSL does not support the `offset` qualifier on regular structs.
 /// This attribute has no effect on other targets.
 __attributeTarget(VarDeclBase)
 attribute_syntax [vk_offset(index: int)] : GLSLStructOffsetAttribute;

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -956,9 +956,9 @@ class GLSLIndexAttribute : public GLSLSimpleIntegerLayoutAttribute
 };
 
 // [[vk_offset]]
-class GLSLStructOffsetAttribute : public GLSLSimpleIntegerLayoutAttribute
+class VkStructOffsetAttribute : public GLSLSimpleIntegerLayoutAttribute
 {
-    SLANG_AST_CLASS(GLSLStructOffsetAttribute)
+    SLANG_AST_CLASS(VkStructOffsetAttribute)
 };
 
 // [[vk_spirv_instruction]]

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -955,6 +955,12 @@ class GLSLIndexAttribute : public GLSLSimpleIntegerLayoutAttribute
     SLANG_AST_CLASS(GLSLIndexAttribute)
 };
 
+// [[vk_offset]]
+class GLSLStructOffsetAttribute : public GLSLSimpleIntegerLayoutAttribute
+{
+    SLANG_AST_CLASS(GLSLStructOffsetAttribute)
+};
+
 // [[vk_spirv_instruction]]
 class SPIRVInstructionOpAttribute : public Attribute
 {

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -1282,7 +1282,7 @@ AttributeBase* SemanticsVisitor::checkAttribute(
     switch (attr->astNodeType)
     {
     // Allowed only on struct fields.
-    case ASTNodeType::GLSLStructOffsetAttribute:
+    case ASTNodeType::VkStructOffsetAttribute:
         auto targetDecl = as<Decl>(attrTarget);
         validTarget = validTarget && targetDecl && as<StructDecl>(getParentDecl(targetDecl));
         break;
@@ -1338,7 +1338,7 @@ ASTNodeType getModifierConflictGroupKind(ASTNodeType modifierType)
     case ASTNodeType::GLSLLayoutModifierGroupBegin:
     case ASTNodeType::GLSLLayoutModifierGroupEnd:
     case ASTNodeType::GLSLBufferModifier:
-    case ASTNodeType::GLSLStructOffsetAttribute:
+    case ASTNodeType::VkStructOffsetAttribute:
     case ASTNodeType::MemoryQualifierSetModifier:
     case ASTNodeType::GLSLWriteOnlyModifier:
     case ASTNodeType::GLSLReadOnlyModifier:

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -1,6 +1,5 @@
 // slang-check-modifier.cpp
 #include "../core/slang-char-util.h"
-#include "slang-ast-decl.h"
 #include "slang-check-impl.h"
 
 // This file implements semantic checking behavior for
@@ -9,9 +8,7 @@
 // At present, the semantic checking we do on modifiers is primarily
 // focused on `[attributes]`.
 
-#include "slang-generated-ast.h"
 #include "slang-lookup.h"
-#include "slang-syntax.h"
 
 namespace Slang
 {
@@ -1280,7 +1277,7 @@ AttributeBase* SemanticsVisitor::checkAttribute(
         }
     }
 
-    // Some attributes impose contrains on where they can be placed that cannot be captured by the
+    // Some attributes impose constraints on where they can be placed that cannot be captured by the
     // only checking the syntax class. Perform more checks here.
     switch (attr->astNodeType)
     {
@@ -1678,8 +1675,7 @@ Modifier* SemanticsVisitor::checkModifier(
         bool isGLSLInput = getOptionSet().getBoolOption(CompilerOptionName::AllowGLSL);
         if (!isGLSLInput && moduleDecl && moduleDecl->findModifier<GLSLModuleModifier>())
             isGLSLInput = true;
-        auto modAllowed = isModifierAllowedOnDecl(isGLSLInput, m->astNodeType, decl);
-        if (!modAllowed)
+        if (!isModifierAllowedOnDecl(isGLSLInput, m->astNodeType, decl))
         {
             if (!ignoreUnallowedModifier)
             {

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -4413,7 +4413,7 @@ void CLikeSourceEmitter::emitStructDeclarationsBlock(
             }
         }
         emitSemanticsPrefix(fieldKey);
-        emitStructFieldAttributes(structType, ff);
+        emitStructFieldAttributes(structType, ff, allowOffsetLayout);
         emitMemoryQualifiers(fieldKey);
         emitType(fieldType, getName(fieldKey));
         emitSemantics(fieldKey, allowOffsetLayout);

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -417,7 +417,7 @@ public:
     virtual void emitStructFieldAttributes(
         IRStructType* /* structType */,
         IRStructField* /* field */,
-        bool /* allowOffsetLayout */) {};
+        bool /* allowOffsetLayout */){};
     void emitInterpolationModifiers(IRInst* varInst, IRType* valueType, IRVarLayout* layout);
     void emitMeshShaderModifiers(IRInst* varInst);
     virtual void emitPackOffsetModifier(

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -413,18 +413,18 @@ public:
     /// Emit type attributes that should appear after, e.g., a `struct` keyword
     void emitPostKeywordTypeAttributes(IRInst* inst) { emitPostKeywordTypeAttributesImpl(inst); }
 
-    virtual void emitMemoryQualifiers(IRInst* /*varInst*/){};
+    virtual void emitMemoryQualifiers(IRInst* /*varInst*/) {};
     virtual void emitStructFieldAttributes(
         IRStructType* /* structType */,
-        IRStructField* /* field */
-    ){};
+        IRStructField* /* field */,
+        bool /* allowOffsetLayout */) {};
     void emitInterpolationModifiers(IRInst* varInst, IRType* valueType, IRVarLayout* layout);
     void emitMeshShaderModifiers(IRInst* varInst);
     virtual void emitPackOffsetModifier(
         IRInst* /*varInst*/,
         IRType* /*valueType*/,
         IRPackOffsetDecoration* /*decoration*/
-    ){};
+    ) {};
 
 
     /// Emit modifiers that should apply even for a declaration of an SSA temporary.

--- a/source/slang/slang-emit-c-like.h
+++ b/source/slang/slang-emit-c-like.h
@@ -413,7 +413,7 @@ public:
     /// Emit type attributes that should appear after, e.g., a `struct` keyword
     void emitPostKeywordTypeAttributes(IRInst* inst) { emitPostKeywordTypeAttributesImpl(inst); }
 
-    virtual void emitMemoryQualifiers(IRInst* /*varInst*/) {};
+    virtual void emitMemoryQualifiers(IRInst* /*varInst*/){};
     virtual void emitStructFieldAttributes(
         IRStructType* /* structType */,
         IRStructField* /* field */,
@@ -424,7 +424,7 @@ public:
         IRInst* /*varInst*/,
         IRType* /*valueType*/,
         IRPackOffsetDecoration* /*decoration*/
-    ) {};
+    ){};
 
 
     /// Emit modifiers that should apply even for a declaration of an SSA temporary.

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -5,7 +5,6 @@
 #include "slang-emit-source-writer.h"
 #include "slang-ir-call-graph.h"
 #include "slang-ir-entry-point-decorations.h"
-#include "slang-ir-insts.h"
 #include "slang-ir-layout.h"
 #include "slang-ir-util.h"
 #include "slang-legalize-types.h"

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -245,7 +245,7 @@ void GLSLSourceEmitter::emitStructFieldAttributes(
 
     if (allowOffsetLayout)
     {
-        if (auto offsetDecoration = structKey->findDecoration<IRGLSLStructOffsetDecoration>())
+        if (auto offsetDecoration = structKey->findDecoration<IRVkStructOffsetDecoration>())
         {
             m_writer->emit("layout(offset = ");
             m_writer->emit(offsetDecoration->getOffset()->getValue());

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -5,6 +5,7 @@
 #include "slang-emit-source-writer.h"
 #include "slang-ir-call-graph.h"
 #include "slang-ir-entry-point-decorations.h"
+#include "slang-ir-insts.h"
 #include "slang-ir-layout.h"
 #include "slang-ir-util.h"
 #include "slang-legalize-types.h"
@@ -232,6 +233,26 @@ void GLSLSourceEmitter::_emitMemoryQualifierDecorations(IRInst* varDecl)
 void GLSLSourceEmitter::emitMemoryQualifiers(IRInst* varDecl)
 {
     _emitMemoryQualifierDecorations(varDecl);
+}
+
+
+void GLSLSourceEmitter::emitStructFieldAttributes(
+    IRStructType* structType,
+    IRStructField* field,
+    bool allowOffsetLayout)
+{
+    SLANG_UNUSED(structType);
+    auto structKey = field->getKey();
+
+    if (allowOffsetLayout)
+    {
+        if (auto offsetDecoration = structKey->findDecoration<IRGLSLStructOffsetDecoration>())
+        {
+            m_writer->emit("layout(offset = ");
+            m_writer->emit(offsetDecoration->getOffset()->getValue());
+            m_writer->emit(") ");
+        }
+    }
 }
 
 void GLSLSourceEmitter::_emitGLSLStructuredBuffer(

--- a/source/slang/slang-emit-glsl.h
+++ b/source/slang/slang-emit-glsl.h
@@ -53,6 +53,10 @@ protected:
         IRPackOffsetDecoration* decoration) SLANG_OVERRIDE;
 
     virtual void emitMemoryQualifiers(IRInst* varInst) SLANG_OVERRIDE;
+    virtual void emitStructFieldAttributes(
+        IRStructType* structType,
+        IRStructField* field,
+        bool allowOffsetLayout) SLANG_OVERRIDE;
     virtual void emitMeshShaderModifiersImpl(IRInst* varInst) SLANG_OVERRIDE;
     virtual void emitSimpleTypeImpl(IRType* type) SLANG_OVERRIDE;
     virtual void emitVectorTypeNameImpl(IRType* elementType, IRIntegerValue elementCount)

--- a/source/slang/slang-emit-wgsl.cpp
+++ b/source/slang/slang-emit-wgsl.cpp
@@ -280,8 +280,13 @@ void WGSLSourceEmitter::emitSemanticsPrefixImpl(IRInst* inst)
     }
 }
 
-void WGSLSourceEmitter::emitStructFieldAttributes(IRStructType* structType, IRStructField* field)
+void WGSLSourceEmitter::emitStructFieldAttributes(
+    IRStructType* structType,
+    IRStructField* field,
+    bool allowOffsetLayout)
 {
+    SLANG_UNUSED(allowOffsetLayout);
+
     // Tint emits errors unless we explicitly spell out the layout in some cases, so emit
     // offset and align attribtues for all fields.
     IRSizeAndAlignmentDecoration* const sizeAndAlignmentDecoration =

--- a/source/slang/slang-emit-wgsl.h
+++ b/source/slang/slang-emit-wgsl.h
@@ -42,8 +42,10 @@ public:
     virtual void _emitType(IRType* type, DeclaratorInfo* declarator) SLANG_OVERRIDE;
     virtual void emitFrontMatterImpl(TargetRequest* targetReq) SLANG_OVERRIDE;
     virtual void emitSemanticsPrefixImpl(IRInst* inst) SLANG_OVERRIDE;
-    virtual void emitStructFieldAttributes(IRStructType* structType, IRStructField* field)
-        SLANG_OVERRIDE;
+    virtual void emitStructFieldAttributes(
+        IRStructType* structType,
+        IRStructField* field,
+        bool allowOffsetLayout) SLANG_OVERRIDE;
     virtual void emitCallArg(IRInst* inst) SLANG_OVERRIDE;
     virtual void emitInterpolationModifiersImpl(
         IRInst* varInst,

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -1008,6 +1008,7 @@ INST_RANGE(BindingQuery, GetRegisterIndex, GetRegisterSpace)
     INST(GlobalInputDecoration, input, 0, 0)
     INST(GLSLLocationDecoration, glslLocation, 1, 0)
     INST(GLSLOffsetDecoration, glslOffset, 1, 0)
+    INST(GLSLStructOffsetDecoration, glslStructOffset, 1, 0)
     INST(PayloadDecoration, payload, 0, 0)
     INST(RayPayloadDecoration, raypayload, 0, 0)
 

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -1008,7 +1008,7 @@ INST_RANGE(BindingQuery, GetRegisterIndex, GetRegisterSpace)
     INST(GlobalInputDecoration, input, 0, 0)
     INST(GLSLLocationDecoration, glslLocation, 1, 0)
     INST(GLSLOffsetDecoration, glslOffset, 1, 0)
-    INST(GLSLStructOffsetDecoration, glslStructOffset, 1, 0)
+    INST(VkStructOffsetDecoration, vkStructOffset, 1, 0)
     INST(PayloadDecoration, payload, 0, 0)
     INST(RayPayloadDecoration, raypayload, 0, 0)
 

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -502,6 +502,12 @@ struct IRGLSLOffsetDecoration : IRDecoration
     IRIntLit* getOffset() { return cast<IRIntLit>(getOperand(0)); }
 };
 
+struct IRGLSLStructOffsetDecoration : IRDecoration
+{
+    IR_LEAF_ISA(GLSLStructOffsetDecoration)
+    IRIntLit* getOffset() { return cast<IRIntLit>(getOperand(0)); }
+};
+
 struct IRNVAPIMagicDecoration : IRDecoration
 {
     enum

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -502,9 +502,9 @@ struct IRGLSLOffsetDecoration : IRDecoration
     IRIntLit* getOffset() { return cast<IRIntLit>(getOperand(0)); }
 };
 
-struct IRGLSLStructOffsetDecoration : IRDecoration
+struct IRVkStructOffsetDecoration : IRDecoration
 {
-    IR_LEAF_ISA(GLSLStructOffsetDecoration)
+    IR_LEAF_ISA(VkStructOffsetDecoration)
     IRIntLit* getOffset() { return cast<IRIntLit>(getOperand(0)); }
 };
 

--- a/source/slang/slang-ir-layout.cpp
+++ b/source/slang/slang-ir-layout.cpp
@@ -160,7 +160,7 @@ static Result _calcSizeAndAlignment(
                 SLANG_ASSERT(!seenFinalUnsizedArrayField);
 
                 if (auto offsetDecor =
-                        field->getKey()->findDecoration<IRGLSLStructOffsetDecoration>())
+                        field->getKey()->findDecoration<IRVkStructOffsetDecoration>())
                 {
                     offset = offsetDecor->getOffset()->getValue();
                 }

--- a/source/slang/slang-ir-layout.cpp
+++ b/source/slang/slang-ir-layout.cpp
@@ -159,6 +159,12 @@ static Result _calcSizeAndAlignment(
                 // subsequent offsets
                 SLANG_ASSERT(!seenFinalUnsizedArrayField);
 
+                if (auto offsetDecor =
+                        field->getKey()->findDecoration<IRGLSLStructOffsetDecoration>())
+                {
+                    offset = offsetDecor->getOffset()->getValue();
+                }
+
                 IRSizeAndAlignment fieldTypeLayout;
                 SLANG_RETURN_ON_FAIL(
                     getSizeAndAlignment(optionSet, rules, field->getFieldType(), &fieldTypeLayout));

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -2360,6 +2360,13 @@ void addVarDecorations(IRGenContext* context, IRInst* inst, Decl* decl)
                 kIROp_GLSLOffsetDecoration,
                 builder->getIntValue(builder->getIntType(), glslOffsetMod->offset));
         }
+        else if (auto glslStructOffsetMod = as<GLSLStructOffsetAttribute>(mod))
+        {
+            builder->addDecoration(
+                inst,
+                kIROp_GLSLStructOffsetDecoration,
+                builder->getIntValue(builder->getIntType(), glslStructOffsetMod->value));
+        }
         else if (auto hlslSemantic = as<HLSLSimpleSemantic>(mod))
         {
             builder->addSemanticDecoration(inst, hlslSemantic->name.getContent());

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -2360,11 +2360,11 @@ void addVarDecorations(IRGenContext* context, IRInst* inst, Decl* decl)
                 kIROp_GLSLOffsetDecoration,
                 builder->getIntValue(builder->getIntType(), glslOffsetMod->offset));
         }
-        else if (auto glslStructOffsetMod = as<GLSLStructOffsetAttribute>(mod))
+        else if (auto glslStructOffsetMod = as<VkStructOffsetAttribute>(mod))
         {
             builder->addDecoration(
                 inst,
-                kIROp_GLSLStructOffsetDecoration,
+                kIROp_VkStructOffsetDecoration,
                 builder->getIntValue(builder->getIntType(), glslStructOffsetMod->value));
         }
         else if (auto hlslSemantic = as<HLSLSimpleSemantic>(mod))

--- a/tests/diagnostics/vk-offset.slang
+++ b/tests/diagnostics/vk-offset.slang
@@ -1,0 +1,34 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-directly -entry vertexMain -stage vertex
+
+// CHECK: error 31002: attribute 'vk_offset' is not valid here
+// CHECK-NEXT: [vk::offset(16)]] struct S1
+// CHECK: error 31002: attribute 'vk_offset' is not valid here
+// CHECK-NEXT: [vk::offset(8)]] VertexOutput output;
+
+[[vk::offset(16)]] struct S1
+{
+    [[vk::offset(32)]]
+    float2 a;
+
+    float3 b;
+
+    [[vk::offset(16)]]
+    float4 c;
+  }
+
+[[vk::push_constant]]
+S1 pc;
+
+struct VertexOutput
+{
+    float3 position : SV_Position;
+}
+
+[shader("vertex")]
+VertexOutput vertexMain()
+{
+    [[vk::offset(8)]] VertexOutput output;
+    output.position = float3(pc.a.x, pc.b.y, pc.c.z);
+    return output;
+}
+

--- a/tests/spirv/vk-offset.slang
+++ b/tests/spirv/vk-offset.slang
@@ -1,0 +1,41 @@
+//TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv -emit-spirv-directly -entry vertexMain -stage vertex
+//TEST:SIMPLE(filecheck=CHECK_GLSL): -target glsl -entry vertexMain -stage vertex
+
+struct S1
+{
+    [[vk::offset(32)]]
+    float2 a;
+
+    float3 b;
+
+    [[vk::offset(16)]]
+    float4 c;
+  }
+
+[[vk::push_constant]]
+S1 pc;
+
+struct VertexOutput
+{
+    float3 position : SV_Position;
+}
+
+// CHECK_SPV: OpDecorate %S1_std430 Block
+// CHECK_SPV-NEXT: OpMemberDecorate %S1_std430 0 Offset 32
+// CHECK_SPV-NEXT: OpMemberDecorate %S1_std430 1 Offset 48
+// CHECK_SPV-NEXT: OpMemberDecorate %S1_std430 2 Offset 16
+
+// CHECK_GLSL: layout(std430) uniform
+// CHECK_GLSL-NEXT: {
+// CHECK_GLSL-NEXT: layout(offset = 32) vec2 a
+// CHECK_GLSL-NEXT: vec3 b
+// CHECK_GLSL-NEXT: layout(offset = 16) vec4 c
+
+[shader("vertex")]
+VertexOutput vertexMain()
+{
+    VertexOutput output;
+    output.position = float3(pc.a.x, pc.b.y, pc.c.z);
+    return output;
+}
+

--- a/tests/spirv/vk-offset.slang
+++ b/tests/spirv/vk-offset.slang
@@ -1,4 +1,5 @@
 //TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv -emit-spirv-directly -entry vertexMain -stage vertex
+//TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv -emit-spirv-via-glsl -entry vertexMain -stage vertex
 //TEST:SIMPLE(filecheck=CHECK_GLSL): -target glsl -entry vertexMain -stage vertex
 
 struct S1
@@ -20,10 +21,10 @@ struct VertexOutput
     float3 position : SV_Position;
 }
 
-// CHECK_SPV: OpDecorate %S1_std430 Block
-// CHECK_SPV-NEXT: OpMemberDecorate %S1_std430 0 Offset 32
-// CHECK_SPV-NEXT: OpMemberDecorate %S1_std430 1 Offset 48
-// CHECK_SPV-NEXT: OpMemberDecorate %S1_std430 2 Offset 16
+// CHECK_SPV: OpDecorate [[STRUCT:%[a-zA-Z0-9_]+]] Block
+// CHECK_SPV-NEXT: OpMemberDecorate [[STRUCT]] 0 Offset 32
+// CHECK_SPV-NEXT: OpMemberDecorate [[STRUCT]] 1 Offset 48
+// CHECK_SPV-NEXT: OpMemberDecorate [[STRUCT]] 2 Offset 16
 
 // CHECK_GLSL: layout(std430) uniform
 // CHECK_GLSL-NEXT: {


### PR DESCRIPTION
Closes #6660.

Adds a `vk::offset` modifier to specify offsets for struct fields. The main use-case for this is for push constants to specify member variables for different shader stages. The `vk::offset` is derived from DXC, this has already been implemented there.