### PR TITLE
Fix pointer field/member access for GLSL

### DIFF
--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -2139,7 +2139,15 @@ bool GLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
                 EmitOpInfo outerPrec = inOuterPrec;
                 bool needClose = maybeEmitParens(outerPrec, prec);
                 emitOperand(inst->getOperand(0), prec);
-                m_writer->emit("._data");
+
+                // `_data` member extraction is not required for `FieldAddress` instructions because
+                // it is already emitted alongside the user requested field during `FieldAddress`
+                // emit. See `kIROp_FieldAddress` case below.
+                if (!as<IRFieldAddress>(addr))
+                {
+                    m_writer->emit("._data");
+                }
+
                 maybeCloseParens(needClose);
                 return true;
             }
@@ -2158,7 +2166,7 @@ bool GLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
                 bool needClose = maybeEmitParens(outerPrec, prec);
                 emitOperand(inst->getOperand(0), prec);
                 m_writer->emit("._data.");
-                emitOperand(inst->getOperand(1), getInfo(EmitOp::General));
+                m_writer->emit(getName(as<IRFieldAddress>(inst)->getField()));
                 maybeCloseParens(needClose);
                 return true;
             }

--- a/tests/spirv/pointer-2.slang
+++ b/tests/spirv/pointer-2.slang
@@ -33,7 +33,6 @@ struct PushConstants
 PushConstants pushConstants;
 
 ConstantBuffer<PushConstants> constantBuffer;
-StructuredBuffer<PushConstants> structuredBuffer;
 
 // CHECK_SPV: OpEntryPoint
 // CHECK_SPV: OpPtrAccessChain
@@ -51,9 +50,8 @@ VSOutput vertexMain(int vertexIndex: SV_VertexID)
     // CHECK_GLSL: (((((constantBuffer_0.verts_0 + 7)._data.inner_1) + 3)._data.inner_0) + 4)._data.position_0
     let position2 = constantBuffer.verts[7].inner[3].inner[4].position;
 
-    // CHECK_GLSL: (((structuredBuffer_0._data[uint(2)].verts_0 + gl_VertexIndex)._data.inner_1) + 12)._data.position_1
-    let position3 = structuredBuffer[2].verts[vertexIndex].inner[12].position;
-
+    // CHECK_GLSL: (((constantBuffer_0.verts_0 + gl_VertexIndex)._data.inner_1) + 12)._data.position_1
+    let position3 = constantBuffer.verts[vertexIndex].inner[12].position;
 
     //
     // Test accesing from a variable.

--- a/tests/spirv/pointer-2.slang
+++ b/tests/spirv/pointer-2.slang
@@ -1,0 +1,72 @@
+//TEST:SIMPLE(filecheck=CHECK_SPV): -entry vertexMain -stage vertex -emit-spirv-directly -target spirv
+//TEST:SIMPLE(filecheck=CHECK_GLSL): -entry vertexMain -stage vertex -target glsl
+
+struct Inner1
+{
+    float4 position;
+    Inner2* inner;
+}
+
+struct Inner2
+{
+    float4 position;
+}
+
+struct Vertex
+{
+    float4 position;
+    Inner1* inner;
+}
+
+struct VSOutput
+{
+    float4 position : SV_Position;
+}
+
+struct PushConstants
+{
+    float a;
+    Vertex* verts;
+};
+
+[[vk::push_constant]]
+PushConstants pushConstants;
+
+ConstantBuffer<PushConstants> constantBuffer;
+StructuredBuffer<PushConstants> structuredBuffer;
+
+// CHECK_SPV: OpEntryPoint
+// CHECK_SPV: OpPtrAccessChain
+
+[shader("vertex")]
+VSOutput vertexMain(int vertexIndex: SV_VertexID)
+{
+    //
+    // Test field access chains.
+    //
+
+    // CHECK_GLSL: (((((pushConstants_0.verts_0 + gl_VertexIndex)._data.inner_1) + 1)._data.inner_0) + 5)._data.position_0
+    let position1 = pushConstants.verts[vertexIndex].inner[1].inner[5].position;
+
+    // CHECK_GLSL: (((((constantBuffer_0.verts_0 + 7)._data.inner_1) + 3)._data.inner_0) + 4)._data.position_0
+    let position2 = constantBuffer.verts[7].inner[3].inner[4].position;
+
+    // CHECK_GLSL: (((structuredBuffer_0._data[uint(2)].verts_0 + gl_VertexIndex)._data.inner_1) + 12)._data.position_1
+    let position3 = structuredBuffer[2].verts[vertexIndex].inner[12].position;
+
+
+    //
+    // Test accesing from a variable.
+    //
+
+    // CHECK_GLSL: ((((pushConstants_0.verts_0 + 8)._data.inner_1 + 6)._data.inner_0))._data.position_0
+    let vertex = pushConstants.verts[8];
+    let position4 = vertex.inner[6].inner.position;
+
+    VSOutput output;
+    output.position = position1 + position2 + position3 + position4;
+    output.position *= pushConstants.a;
+
+    return output;
+}
+

--- a/tests/spirv/pointer-2.slang
+++ b/tests/spirv/pointer-2.slang
@@ -1,4 +1,5 @@
 //TEST:SIMPLE(filecheck=CHECK_SPV): -entry vertexMain -stage vertex -emit-spirv-directly -target spirv
+//TEST:SIMPLE(filecheck=CHECK_SPV_VIA_GLSL): -entry vertexMain -stage vertex -emit-spirv-via-glsl -target spirv
 //TEST:SIMPLE(filecheck=CHECK_GLSL): -entry vertexMain -stage vertex -target glsl
 
 struct Inner1
@@ -35,7 +36,12 @@ PushConstants pushConstants;
 ConstantBuffer<PushConstants> constantBuffer;
 
 // CHECK_SPV: OpEntryPoint
+// CHECK_SPV: OpTypePointer PhysicalStorageBuffer
 // CHECK_SPV: OpPtrAccessChain
+
+// CHECK_SPV_VIA_GLSL: Glslang
+// CHECK_SPV_VIA_GLSL: OpEntryPoint
+// CHECK_SPV_VIA_GLSL: OpTypePointer PhysicalStorageBuffer
 
 [shader("vertex")]
 VSOutput vertexMain(int vertexIndex: SV_VertexID)


### PR DESCRIPTION
Closes #6710.

Fixes field/member acceses for pointer(`*`) syntax when targeting GLSL. The current behavior returns internal error 9999/unexpected IR during code emit.