### PR TITLE
Update the access tokens used for auto labeling CI

### DIFF
--- a/.github/workflows/add-issue-labels.yml
+++ b/.github/workflows/add-issue-labels.yml
@@ -21,7 +21,7 @@ jobs:
         id: check_team
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.SLANGBOT_PAT }}
+          github-token: ${{ secrets.SLANGBOT_MEMBERS_READONLY }}
           script: |
             const response = await github.rest.teams.listMembersInOrg({
               org: 'shader-slang',
@@ -46,7 +46,7 @@ jobs:
         if: steps.check_team.outputs.is_team_member == 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.SLANGBOT_PAT }}
+          github-token: ${{ secrets.SLANGBOT_ISSUES_WRITE }}
           script: |
             // Only add label if this is a real issue and not a test run
             if (context.eventName === 'issues') {


### PR DESCRIPTION
The auto labeling CI has been failing as a result of the SLANGBOT_PAT token not having all of the necessary permissions. Change updates the tokens used for requests to use new tokens that were created with the specific permissions needed for the operations in this CI workflow.